### PR TITLE
Feature: Populate MJAPI/config.json with sample data

### DIFF
--- a/packages/MJAPI/config.json
+++ b/packages/MJAPI/config.json
@@ -1,8 +1,8 @@
 {
   "userHandling": {
     "autoCreateNewUsers": false,
-    "newUserAuthorizedDomains": ["localhost"],
-    "newUserRoles": ["UI", "Developer", "Integration"],
+    "newUserAuthorizedDomains": [],
+    "newUserRoles": [],
     "updateCacheWhenNotFound": true,
     "updateCacheWhenNotFoundDelay": 5000,
     "contextUserForNewUserCreation": "fill.in.user.email.here@whatever.com"

--- a/packages/MJAPI/config.json
+++ b/packages/MJAPI/config.json
@@ -1,8 +1,8 @@
 {
   "userHandling": {
     "autoCreateNewUsers": false,
-    "newUserAuthorizedDomains": [],
-    "newUserRoles": [],
+    "newUserAuthorizedDomains": ["localhost"],
+    "newUserRoles": ["UI", "Developer", "Integration"],
     "updateCacheWhenNotFound": true,
     "updateCacheWhenNotFoundDelay": 5000,
     "contextUserForNewUserCreation": "fill.in.user.email.here@whatever.com"

--- a/packages/MJAPI/sample.config.json
+++ b/packages/MJAPI/sample.config.json
@@ -1,0 +1,19 @@
+{
+    "userHandling": {
+      "autoCreateNewUsers": false,
+      "newUserAuthorizedDomains": ["localhost"],
+      "newUserRoles": ["UI", "Developer", "Integration"],
+      "updateCacheWhenNotFound": true,
+      "updateCacheWhenNotFoundDelay": 5000,
+      "contextUserForNewUserCreation": "fill.in.user.email.here@whatever.com"
+    },
+    "databaseSettings": {
+      "connectionTimeout": 45000,
+      "requestTimeout": 30000,
+      "metadataCacheRefreshInterval": 180000
+    },
+    "viewingSystem" : {
+      "enableSmartFilters": true
+    }
+  }
+  


### PR DESCRIPTION
Since we cannot add comments to json files, providing sample data should help developers get a better understanding on how to populate certain fields when making changes to the config file. This change comes from a result of some users of MJ having difficulties in automatically adding new users to the DB due to some configuration related errors