### PR TITLE
fix npm install not working

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4189,10 +4189,6 @@
       "resolved": "packages/MJAI",
       "link": true
     },
-    "node_modules/@memberjunction/aiengine": {
-      "resolved": "packages/MJAIEngine",
-      "link": true
-    },
     "node_modules/@memberjunction/api": {
       "resolved": "packages/MJAPI",
       "link": true


### PR DESCRIPTION
the root package.json was updated to reference @memberjunction/mjaiengine, but since this package doesnt exist yet npm install would fail 