### PR TITLE
remove process-env use in mistral client

### DIFF
--- a/packages/AI/Mistral/src/models/mistralClient.ts
+++ b/packages/AI/Mistral/src/models/mistralClient.ts
@@ -23,7 +23,7 @@ export class MistralClient {
 
     constructor(config: {apiKey?: string, endpoint?: string}) {
         this.endpoint = config.endpoint || this.ENDPOINT;
-        this.apiKey = config.apiKey || process.env.MISTRAL_API_KEY;
+        this.apiKey = config.apiKey;
 
         this.textDecoder = new TextDecoder();
 


### PR DESCRIPTION
the api key to use is passed in from the constructor, so there's no need for this