### PR TITLE
Only signal initialization complete after auth processes finish. Resolves #58

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,6 @@
+{
+  "editor.codeActionsOnSave": {
+    "source.fixAll": "never",
+    "source.organizeImports": "never"
+  }
+}

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "packages/AngularElements/*"
   ],
   "scripts": {
-    "build": "turbo build --filter=!mj_explorer"
+    "build": "turbo build --filter=!mj_explorer",
+    "start": "turbo start --filter=mj_explorer --filter=mj_api"
   },
   "dependencies": {
     "archiver": "^7.0.0"

--- a/packages/Angular/auth-services/src/lib/mjexplorer-msal-provider.service.ts
+++ b/packages/Angular/auth-services/src/lib/mjexplorer-msal-provider.service.ts
@@ -28,8 +28,8 @@ export class MJMSALProvider extends MJAuthBase {
       .subscribe(() => {
         this.setAuthenticated(this.auth.instance.getAllAccounts().length > 0);
         this.auth.instance.setActiveAccount(this.auth.instance.getAllAccounts()[0] || null);
+        this._initializationCompleted$.next(true); // Signal initialization complete
       });
-    this._initializationCompleted$.next(true); // Signal initialization complete
   }
 
   // Ensure methods wait for initialization

--- a/packages/MJAPI/package.json
+++ b/packages/MJAPI/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@memberjunction/api",
+  "name": "mj_api",
   "version": "1.0.0",
   "description": "",
   "main": "index.js",


### PR DESCRIPTION
Turns out the problem was in the timing– after authenticating and being redirected back to the app URL, the auth library ha to be re-initialized. However, the initialization function signalled completion before the redirect handler could finish, which triggered various errors including `interaction_in_progress`. The solution was to move the completion signal into the subscription that filters for when the auth library is no longer working (i.e. `InteractionStatus.None`).

In this changeset I also renamed the `@memberjunction/api` package to `mj_api` to better reflect that it's a private rather than a published one– aligned with `mj_explorer` which is also customized for a specific deployment rather than published to npm.

I also added some VSCode config to prevent the editor from making cosmetic changes to code that add bulk to commits. In the future, we may want to consider setting up a more consistent linting system so we can take advantage of automatic code formatting.