### PR TITLE
Add docs config and generation workflow

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+docs/** linguist-generated=true

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,52 @@
+name: Update package documentation
+
+on:
+  push:
+    branches: ["main"]
+
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
+
+jobs:
+  docs:
+    name: Generate and deploy package documentation
+    timeout-minutes: 10
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0          
+
+      - name: Set up node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: 'npm'
+          cache-dependency-path: 'package-lock.json'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Generate doumentation
+        run: npm run docs
+
+      - name: Setup Pages
+        uses: actions/configure-pages@v5
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: 'docs'
+
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/.gitignore
+++ b/.gitignore
@@ -67,6 +67,7 @@ packages/MJExplorer/src/environments/environment.development.ts
 packages/MJExplorer/src/environments/environment.staging.ts
 packages/MJExplorer/src/environments/environment.ts
 Schema Files/
+docs/
 SQL Scripts/generated/
 *.old
 SQL Scripts/internal_only/BC CDP - FULL TEXT Index Setup.sql

--- a/index.html
+++ b/index.html
@@ -1,1 +1,0 @@
-Hello World!

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,9 @@
         "archiver": "^7.0.0"
       },
       "devDependencies": {
-        "turbo": "^1.12.5"
+        "turbo": "^1.12.5",
+        "typedoc": "^0.25.12",
+        "typedoc-plugin-missing-exports": "^2.2.0"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {
@@ -33,6 +35,7 @@
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.2.1.tgz",
       "integrity": "sha512-lFMjJTrFL3j7L9yBxwYfCq2k6qqwHyzuUl/XBnif78PWTJYyL/dfowQHWE3sp6U6ZzqWiiIZnpTMO96zhkjwtg==",
+      "dev": true,
       "dependencies": {
         "@jridgewell/gen-mapping": "^0.3.0",
         "@jridgewell/trace-mapping": "^0.3.9"
@@ -451,6 +454,7 @@
       "version": "17.2.4",
       "resolved": "https://registry.npmjs.org/@angular/compiler-cli/-/compiler-cli-17.2.4.tgz",
       "integrity": "sha512-VGQx1YoYuifQZNj2/nGMEyYVYvXSWrt1ZXK43dgxPDH3jCWNncOBUYtmyCmYvxKvDz0aDO3KL8cro8c4+N0pPw==",
+      "dev": true,
       "dependencies": {
         "@babel/core": "7.23.9",
         "@jridgewell/sourcemap-codec": "^1.4.14",
@@ -477,7 +481,8 @@
     "node_modules/@angular/compiler-cli/node_modules/reflect-metadata": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/reflect-metadata/-/reflect-metadata-0.2.1.tgz",
-      "integrity": "sha512-i5lLI6iw9AU3Uu4szRNPPEkomnkjRTaVt9hy/bn5g/oSzekBSMeLZblcjP74AW0vBabqERLLIrz+gR8QYR54Tw=="
+      "integrity": "sha512-i5lLI6iw9AU3Uu4szRNPPEkomnkjRTaVt9hy/bn5g/oSzekBSMeLZblcjP74AW0vBabqERLLIrz+gR8QYR54Tw==",
+      "dev": true
     },
     "node_modules/@angular/core": {
       "version": "17.2.4",
@@ -530,6 +535,9 @@
       "version": "17.2.4",
       "resolved": "https://registry.npmjs.org/@angular/localize/-/localize-17.2.4.tgz",
       "integrity": "sha512-l6qZzP7f0fH6bCufyrhlUD6n7ggfTEaerIZW/jw0mnXFqVsHVfXX2jWHKljaZJWT3vhDp312i8xAukoAPM0uSQ==",
+      "dev": true,
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "@babel/core": "7.23.9",
         "@types/babel__core": "7.20.5",
@@ -2156,6 +2164,7 @@
       "version": "7.23.5",
       "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.23.5.tgz",
       "integrity": "sha512-CgH3s1a96LipHCmSUmYFPwY7MNx8C3avkq7i4Wl3cfa662ldtUe4VM1TPXX70pfmrlWTb6jLqTYrZyT2ZTJBgA==",
+      "dev": true,
       "dependencies": {
         "@babel/highlight": "^7.23.4",
         "chalk": "^2.4.2"
@@ -2168,6 +2177,7 @@
       "version": "7.23.5",
       "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.23.5.tgz",
       "integrity": "sha512-uU27kfDRlhfKl+w1U6vp16IuvSLtjAxdArVXPa9BvLkrr7CYIsxH5adpHObeAGY/41+syctUWOZ140a2Rvkgjw==",
+      "dev": true,
       "engines": {
         "node": ">=6.9.0"
       }
@@ -2176,6 +2186,7 @@
       "version": "7.23.9",
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.23.9.tgz",
       "integrity": "sha512-5q0175NOjddqpvvzU+kDiSOAk4PfdO6FvwCWoQ6RO7rTzEe8vlo+4HVfcnAREhD4npMs0e9uZypjTwzZPCf/cw==",
+      "dev": true,
       "dependencies": {
         "@ampproject/remapping": "^2.2.0",
         "@babel/code-frame": "^7.23.5",
@@ -2204,12 +2215,14 @@
     "node_modules/@babel/core/node_modules/convert-source-map": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
-      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg=="
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+      "dev": true
     },
     "node_modules/@babel/core/node_modules/semver": {
       "version": "6.3.1",
       "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
       "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
       "bin": {
         "semver": "bin/semver.js"
       }
@@ -2218,6 +2231,7 @@
       "version": "7.23.6",
       "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.23.6.tgz",
       "integrity": "sha512-qrSfCYxYQB5owCmGLbl8XRpX1ytXlpueOb0N0UmQwA073KZxejgQTzAmJezxvpwQD9uGtK2shHdi55QT+MbjIw==",
+      "dev": true,
       "dependencies": {
         "@babel/types": "^7.23.6",
         "@jridgewell/gen-mapping": "^0.3.2",
@@ -2256,6 +2270,7 @@
       "version": "7.23.6",
       "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.23.6.tgz",
       "integrity": "sha512-9JB548GZoQVmzrFgp8o7KxdgkTGm6xs9DW0o/Pim72UDjzr5ObUQ6ZzYPqA+g9OTS2bBQoctLJrky0RDCAWRgQ==",
+      "dev": true,
       "dependencies": {
         "@babel/compat-data": "^7.23.5",
         "@babel/helper-validator-option": "^7.23.5",
@@ -2271,6 +2286,7 @@
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
       "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
+      "dev": true,
       "dependencies": {
         "yallist": "^3.0.2"
       }
@@ -2279,6 +2295,7 @@
       "version": "6.3.1",
       "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
       "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
       "bin": {
         "semver": "bin/semver.js"
       }
@@ -2286,7 +2303,8 @@
     "node_modules/@babel/helper-compilation-targets/node_modules/yallist": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
-      "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g=="
+      "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
+      "dev": true
     },
     "node_modules/@babel/helper-create-class-features-plugin": {
       "version": "7.24.0",
@@ -2366,6 +2384,7 @@
       "version": "7.22.20",
       "resolved": "https://registry.npmjs.org/@babel/helper-environment-visitor/-/helper-environment-visitor-7.22.20.tgz",
       "integrity": "sha512-zfedSIzFhat/gFhWfHtgWvlec0nqB9YEIVrpuwjruLlXfUSnA8cJB0miHKwqDnQ7d32aKo2xt88/xZptwxbfhA==",
+      "dev": true,
       "engines": {
         "node": ">=6.9.0"
       }
@@ -2374,6 +2393,7 @@
       "version": "7.23.0",
       "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.23.0.tgz",
       "integrity": "sha512-OErEqsrxjZTJciZ4Oo+eoZqeW9UIiOcuYKRJA4ZAgV9myA+pOXhhmpfNCKjEH/auVfEYVFJ6y1Tc4r0eIApqiw==",
+      "dev": true,
       "dependencies": {
         "@babel/template": "^7.22.15",
         "@babel/types": "^7.23.0"
@@ -2386,6 +2406,7 @@
       "version": "7.22.5",
       "resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.22.5.tgz",
       "integrity": "sha512-wGjk9QZVzvknA6yKIUURb8zY3grXCcOZt+/7Wcy8O2uctxhplmUPkOdlgoNhmdVee2c92JXbf1xpMtVNbfoxRw==",
+      "dev": true,
       "dependencies": {
         "@babel/types": "^7.22.5"
       },
@@ -2409,6 +2430,7 @@
       "version": "7.22.15",
       "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.22.15.tgz",
       "integrity": "sha512-0pYVBnDKZO2fnSPCrgM/6WMc7eS20Fbok+0r88fp+YtWVLZrp4CkafFGIp+W0VKw4a22sgebPT99y+FDNMdP4w==",
+      "dev": true,
       "dependencies": {
         "@babel/types": "^7.22.15"
       },
@@ -2420,6 +2442,7 @@
       "version": "7.23.3",
       "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.23.3.tgz",
       "integrity": "sha512-7bBs4ED9OmswdfDzpz4MpWgSrV7FXlc3zIagvLFjS5H+Mk7Snr21vQ6QwrsoCGMfNC4e4LQPdoULEt4ykz0SRQ==",
+      "dev": true,
       "dependencies": {
         "@babel/helper-environment-visitor": "^7.22.20",
         "@babel/helper-module-imports": "^7.22.15",
@@ -2493,6 +2516,7 @@
       "version": "7.22.5",
       "resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.22.5.tgz",
       "integrity": "sha512-n0H99E/K+Bika3++WNL17POvo4rKWZ7lZEp1Q+fStVbUi8nxPQEBOlTmCOxW/0JsS56SKKQ+ojAe2pHKJHN35w==",
+      "dev": true,
       "dependencies": {
         "@babel/types": "^7.22.5"
       },
@@ -2516,6 +2540,7 @@
       "version": "7.22.6",
       "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.22.6.tgz",
       "integrity": "sha512-AsUnxuLhRYsisFiaJwvp1QF+I3KjD5FOxut14q/GzovUe6orHLesW2C7d754kRm53h5gqrz6sFl6sxc4BVtE/g==",
+      "dev": true,
       "dependencies": {
         "@babel/types": "^7.22.5"
       },
@@ -2527,6 +2552,7 @@
       "version": "7.23.4",
       "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.23.4.tgz",
       "integrity": "sha512-803gmbQdqwdf4olxrX4AJyFBV/RTr3rSmOj0rKwesmzlfhYNDEs+/iOcznzpNWlJlIlTJC2QfPFcHB6DlzdVLQ==",
+      "dev": true,
       "engines": {
         "node": ">=6.9.0"
       }
@@ -2535,6 +2561,7 @@
       "version": "7.22.20",
       "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.22.20.tgz",
       "integrity": "sha512-Y4OZ+ytlatR8AI+8KZfKuL5urKp7qey08ha31L8b3BwewJAoJamTzyvxPR/5D+KkdJCGPq/+8TukHBlY10FX9A==",
+      "dev": true,
       "engines": {
         "node": ">=6.9.0"
       }
@@ -2543,6 +2570,7 @@
       "version": "7.23.5",
       "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.23.5.tgz",
       "integrity": "sha512-85ttAOMLsr53VgXkTbkx8oA6YTfT4q7/HzXSLEYmjcSTJPMPQtvq1BD79Byep5xMUYbGRzEpDsjUf3dyp54IKw==",
+      "dev": true,
       "engines": {
         "node": ">=6.9.0"
       }
@@ -2565,6 +2593,7 @@
       "version": "7.24.0",
       "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.24.0.tgz",
       "integrity": "sha512-ulDZdc0Aj5uLc5nETsa7EPx2L7rM0YJM8r7ck7U73AXi7qOV44IHHRAYZHY6iU1rr3C5N4NtTmMRUJP6kwCWeA==",
+      "dev": true,
       "dependencies": {
         "@babel/template": "^7.24.0",
         "@babel/traverse": "^7.24.0",
@@ -2578,6 +2607,7 @@
       "version": "7.23.4",
       "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.23.4.tgz",
       "integrity": "sha512-acGdbYSfp2WheJoJm/EBBBLh/ID8KDc64ISZ9DYtBmC8/Q204PZJLHyzeB5qMzJ5trcOkybd78M4x2KWsUq++A==",
+      "dev": true,
       "dependencies": {
         "@babel/helper-validator-identifier": "^7.22.20",
         "chalk": "^2.4.2",
@@ -2591,6 +2621,7 @@
       "version": "7.24.0",
       "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.24.0.tgz",
       "integrity": "sha512-QuP/FxEAzMSjXygs8v4N9dvdXzEHN4W1oF3PxuWAtPo08UdM17u89RDMgjLn/mlc56iM0HlLmVkO/wgR+rDgHg==",
+      "dev": true,
       "bin": {
         "parser": "bin/babel-parser.js"
       },
@@ -3833,6 +3864,7 @@
       "version": "7.24.0",
       "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.24.0.tgz",
       "integrity": "sha512-Bkf2q8lMB0AFpX0NFEqSbx1OkTHf0f+0j82mkw+ZpzBnkk7e9Ql0891vlfgi+kHwOk8tQjiQHpqh4LaSa0fKEA==",
+      "dev": true,
       "dependencies": {
         "@babel/code-frame": "^7.23.5",
         "@babel/parser": "^7.24.0",
@@ -3846,6 +3878,7 @@
       "version": "7.24.0",
       "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.24.0.tgz",
       "integrity": "sha512-HfuJlI8qq3dEDmNU5ChzzpZRWq+oxCZQyMzIMEqLho+AQnhMnKQUzH6ydo3RBl/YjPCuk68Y6s0Gx0AeyULiWw==",
+      "dev": true,
       "dependencies": {
         "@babel/code-frame": "^7.23.5",
         "@babel/generator": "^7.23.6",
@@ -3866,6 +3899,7 @@
       "version": "7.24.0",
       "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.24.0.tgz",
       "integrity": "sha512-+j7a5c253RfKh8iABBhywc8NSfP5LURe7Uh4qpsh6jc+aLJguvmIUBdjSdEMQv2bENrCR5MfRdjGo7vzS/ob7w==",
+      "dev": true,
       "dependencies": {
         "@babel/helper-string-parser": "^7.23.4",
         "@babel/helper-validator-identifier": "^7.22.20",
@@ -4755,6 +4789,7 @@
       "version": "0.3.5",
       "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.5.tgz",
       "integrity": "sha512-IzL8ZoEDIBRWEzlCcRhOaCupYyN5gdIK+Q6fbFdPDg6HqX6jpkItn7DFIpW9LQzXG6Df9sA7+OKnq0qlz/GaQg==",
+      "dev": true,
       "dependencies": {
         "@jridgewell/set-array": "^1.2.1",
         "@jridgewell/sourcemap-codec": "^1.4.10",
@@ -4776,6 +4811,7 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/@jridgewell/set-array/-/set-array-1.2.1.tgz",
       "integrity": "sha512-R8gLRTZeyp03ymzP/6Lil/28tGeGEzhx1q2k703KGWRAI1VdvPIXdG70VJc2pAMw3NA6JKL5hhFu1sJX0Mnn/A==",
+      "dev": true,
       "engines": {
         "node": ">=6.0.0"
       }
@@ -4799,6 +4835,7 @@
       "version": "0.3.25",
       "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.25.tgz",
       "integrity": "sha512-vNk6aEwybGtawWmy/PzwnGDOjCkLWSD2wqvjGGAgOAwCGWySYXfYoxt00IJkTF+8Lb57DwOb3Aa0o9CApepiYQ==",
+      "dev": true,
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
@@ -4917,10 +4954,6 @@
     },
     "node_modules/@memberjunction/aiengine": {
       "resolved": "packages/AI/Engine",
-      "link": true
-    },
-    "node_modules/@memberjunction/api": {
-      "resolved": "packages/MJAPI",
       "link": true
     },
     "node_modules/@memberjunction/codegen-lib": {
@@ -7291,6 +7324,9 @@
       "version": "7.20.5",
       "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
       "integrity": "sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==",
+      "dev": true,
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "@babel/parser": "^7.20.7",
         "@babel/types": "^7.20.7",
@@ -7303,6 +7339,9 @@
       "version": "7.6.8",
       "resolved": "https://registry.npmjs.org/@types/babel__generator/-/babel__generator-7.6.8.tgz",
       "integrity": "sha512-ASsj+tpEDsEiFr1arWrlN6V3mdfjRMZt6LtK/Vp/kreFLnr5QH5+DhvD5nINYZXzwJvXeGq+05iUXcAzVrqWtw==",
+      "dev": true,
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "@babel/types": "^7.0.0"
       }
@@ -7311,6 +7350,9 @@
       "version": "7.4.4",
       "resolved": "https://registry.npmjs.org/@types/babel__template/-/babel__template-7.4.4.tgz",
       "integrity": "sha512-h/NUaSyG5EyxBIp8YRxo4RMe2/qQgvyowRwVMzhYhBCONbW8PUsg4lkFMrhgZhUe5z3L3MiLDuvyJ/CaPa2A8A==",
+      "dev": true,
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "@babel/parser": "^7.1.0",
         "@babel/types": "^7.0.0"
@@ -7320,6 +7362,9 @@
       "version": "7.20.5",
       "resolved": "https://registry.npmjs.org/@types/babel__traverse/-/babel__traverse-7.20.5.tgz",
       "integrity": "sha512-WXCyOcRtH37HAUkpXhUduaxdm82b4GSlyTqajXviN4EfiuPgNYR109xMCKvpl6zPIpua0DGlMEDCq+g8EdoheQ==",
+      "dev": true,
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "@babel/types": "^7.20.7"
       }
@@ -8390,6 +8435,12 @@
         "url": "https://github.com/chalk/ansi-regex?sponsor=1"
       }
     },
+    "node_modules/ansi-sequence-parser": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ansi-sequence-parser/-/ansi-sequence-parser-1.1.1.tgz",
+      "integrity": "sha512-vJXt3yiaUL4UU546s3rPXlsry/RnM730G1+HkpKE012AN0sx1eOrxSu95oKDIonskeLTijMgqWZ3uDEe3NFvyg==",
+      "dev": true
+    },
     "node_modules/ansi-styles": {
       "version": "6.2.1",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.1.tgz",
@@ -9143,6 +9194,7 @@
       "version": "4.23.0",
       "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.23.0.tgz",
       "integrity": "sha512-QW8HiM1shhT2GuzkvklfjcKDiWFXHOeFCIA/huJPwHsslwcydgk7X+z2zXpEijP98UCY7HbubZt5J2Zgvf0CaQ==",
+      "dev": true,
       "funding": [
         {
           "type": "opencollective",
@@ -9369,6 +9421,7 @@
       "version": "1.0.30001597",
       "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001597.tgz",
       "integrity": "sha512-7LjJvmQU6Sj7bL0j5b5WY/3n7utXUJvAe1lxhsHDbLmwX9mdL86Yjtr+5SRCyf8qME4M7pU2hswj0FpyBVCv9w==",
+      "dev": true,
       "funding": [
         {
           "type": "opencollective",
@@ -9388,6 +9441,7 @@
       "version": "2.4.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
       "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+      "dev": true,
       "dependencies": {
         "ansi-styles": "^3.2.1",
         "escape-string-regexp": "^1.0.5",
@@ -9401,6 +9455,7 @@
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
       "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+      "dev": true,
       "dependencies": {
         "color-convert": "^1.9.0"
       },
@@ -9412,6 +9467,7 @@
       "version": "1.9.3",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
       "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+      "dev": true,
       "dependencies": {
         "color-name": "1.1.3"
       }
@@ -9419,7 +9475,8 @@
     "node_modules/chalk/node_modules/color-name": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-      "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw=="
+      "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==",
+      "dev": true
     },
     "node_modules/character-entities": {
       "version": "2.0.2",
@@ -10158,7 +10215,8 @@
     "node_modules/convert-source-map": {
       "version": "1.9.0",
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.9.0.tgz",
-      "integrity": "sha512-ASFBup0Mz1uyiIjANan1jzLQami9z1PoYSZCiiYW2FczPbenXc45FZdBZLzOT+r6+iciuEModtmCti+hjaAk0A=="
+      "integrity": "sha512-ASFBup0Mz1uyiIjANan1jzLQami9z1PoYSZCiiYW2FczPbenXc45FZdBZLzOT+r6+iciuEModtmCti+hjaAk0A==",
+      "dev": true
     },
     "node_modules/cookie": {
       "version": "0.5.0",
@@ -11563,7 +11621,8 @@
     "node_modules/electron-to-chromium": {
       "version": "1.4.703",
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.703.tgz",
-      "integrity": "sha512-094ZZC4nHXPKl/OwPinSMtLN9+hoFkdfQGKnvXbY+3WEAYtVDpz9UhJIViiY6Zb8agvqxiaJzNG9M+pRZWvSZw=="
+      "integrity": "sha512-094ZZC4nHXPKl/OwPinSMtLN9+hoFkdfQGKnvXbY+3WEAYtVDpz9UhJIViiY6Zb8agvqxiaJzNG9M+pRZWvSZw==",
+      "dev": true
     },
     "node_modules/elkjs": {
       "version": "0.9.2",
@@ -12011,6 +12070,7 @@
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
       "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
+      "dev": true,
       "engines": {
         "node": ">=0.8.0"
       }
@@ -13483,6 +13543,7 @@
       "version": "1.0.0-beta.2",
       "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
       "integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==",
+      "dev": true,
       "engines": {
         "node": ">=6.9.0"
       }
@@ -13604,6 +13665,7 @@
       "version": "11.12.0",
       "resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
       "integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==",
+      "dev": true,
       "engines": {
         "node": ">=4"
       }
@@ -13881,6 +13943,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
       "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
+      "dev": true,
       "engines": {
         "node": ">=4"
       }
@@ -15217,7 +15280,8 @@
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
-      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "dev": true
     },
     "node_modules/js-yaml": {
       "version": "3.14.1",
@@ -15247,6 +15311,7 @@
       "version": "2.5.2",
       "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz",
       "integrity": "sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==",
+      "dev": true,
       "bin": {
         "jsesc": "bin/jsesc"
       },
@@ -15292,6 +15357,7 @@
       "version": "2.2.3",
       "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
       "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
+      "dev": true,
       "bin": {
         "json5": "lib/cli.js"
       },
@@ -16275,6 +16341,12 @@
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
       "integrity": "sha512-ncTzHV7NvsQZkYe1DW7cbDLm0YpzHmZF5r/iyP3ZnQtMiJ+pjzisCiMNI+Sj+xQF5pXhSHxSB3uDbsBTzY/c2A=="
     },
+    "node_modules/lunr": {
+      "version": "2.3.9",
+      "resolved": "https://registry.npmjs.org/lunr/-/lunr-2.3.9.tgz",
+      "integrity": "sha512-zTU3DaZaF3Rt9rhN3uBMGQD3dD2/vFQqnvZCDv4dl5iOzq2IZQqTxu90r4E5J+nP70J3ilqVCrbho2eWaeW8Ow==",
+      "dev": true
+    },
     "node_modules/magic-string": {
       "version": "0.30.7",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.7.tgz",
@@ -17235,6 +17307,10 @@
         "node": ">=8"
       }
     },
+    "node_modules/mj_api": {
+      "resolved": "packages/MJAPI",
+      "link": true
+    },
     "node_modules/mj_explorer": {
       "resolved": "packages/MJExplorer",
       "link": true
@@ -17625,7 +17701,8 @@
     "node_modules/node-releases": {
       "version": "2.0.14",
       "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.14.tgz",
-      "integrity": "sha512-y10wOWt8yZpqXmOgRo77WaHEmhYQYGNA6y421PKsKYWEK8aW+cqAphborZDhqfyKrbZEN92CN1X2KbafY2s7Yw=="
+      "integrity": "sha512-y10wOWt8yZpqXmOgRo77WaHEmhYQYGNA6y421PKsKYWEK8aW+cqAphborZDhqfyKrbZEN92CN1X2KbafY2s7Yw==",
+      "dev": true
     },
     "node_modules/non-layered-tidy-tree-layout": {
       "version": "2.0.2",
@@ -18469,7 +18546,8 @@
     "node_modules/picocolors": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.0.tgz",
-      "integrity": "sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ=="
+      "integrity": "sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ==",
+      "dev": true
     },
     "node_modules/picomatch": {
       "version": "4.0.1",
@@ -20139,6 +20217,18 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/shiki": {
+      "version": "0.14.7",
+      "resolved": "https://registry.npmjs.org/shiki/-/shiki-0.14.7.tgz",
+      "integrity": "sha512-dNPAPrxSc87ua2sKJ3H5dQ/6ZaY8RNnaAqK+t0eG7p0Soi2ydiqbGOTaZCqaYvA/uZYfS1LJnemt3Q+mSfcPCg==",
+      "dev": true,
+      "dependencies": {
+        "ansi-sequence-parser": "^1.1.0",
+        "jsonc-parser": "^3.2.0",
+        "vscode-oniguruma": "^1.7.0",
+        "vscode-textmate": "^8.0.0"
+      }
+    },
     "node_modules/side-channel": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.0.6.tgz",
@@ -20790,6 +20880,7 @@
       "version": "5.5.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
       "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+      "dev": true,
       "dependencies": {
         "has-flag": "^3.0.0"
       },
@@ -21221,6 +21312,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
       "integrity": "sha512-/OaKK0xYrs3DmxRYqL/yDc+FxFUVYhDlXMhRmv3z915w2HF1tnN1omB354j8VUGO/hbRzyD6Y3sA7v7GS/ceog==",
+      "dev": true,
       "engines": {
         "node": ">=4"
       }
@@ -21824,6 +21916,48 @@
       "resolved": "https://registry.npmjs.org/typedi/-/typedi-0.10.0.tgz",
       "integrity": "sha512-v3UJF8xm68BBj6AF4oQML3ikrfK2c9EmZUyLOfShpJuItAqVBHWP/KtpGinkSsIiP6EZyyb6Z3NXyW9dgS9X1w=="
     },
+    "node_modules/typedoc": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.25.12.tgz",
+      "integrity": "sha512-F+qhkK2VoTweDXd1c42GS/By2DvI2uDF4/EpG424dTexSHdtCH52C6IcAvMA6jR3DzAWZjHpUOW+E02kyPNUNw==",
+      "dev": true,
+      "dependencies": {
+        "lunr": "^2.3.9",
+        "marked": "^4.3.0",
+        "minimatch": "^9.0.3",
+        "shiki": "^0.14.7"
+      },
+      "bin": {
+        "typedoc": "bin/typedoc"
+      },
+      "engines": {
+        "node": ">= 16"
+      },
+      "peerDependencies": {
+        "typescript": "4.6.x || 4.7.x || 4.8.x || 4.9.x || 5.0.x || 5.1.x || 5.2.x || 5.3.x || 5.4.x"
+      }
+    },
+    "node_modules/typedoc-plugin-missing-exports": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/typedoc-plugin-missing-exports/-/typedoc-plugin-missing-exports-2.2.0.tgz",
+      "integrity": "sha512-2+XR1IcyQ5UwXZVJe9NE6HrLmNufT9i5OwoIuuj79VxuA3eYq+Y6itS9rnNV1D7UeQnUSH8kISYD73gHE5zw+w==",
+      "dev": true,
+      "peerDependencies": {
+        "typedoc": "0.24.x || 0.25.x"
+      }
+    },
+    "node_modules/typedoc/node_modules/marked": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-4.3.0.tgz",
+      "integrity": "sha512-PRsaiG84bK+AMvxziE/lCFss8juXjNaWzVbN5tXAm4XjeaS9NAHhop+PjQxz2A9h8Q4M/xGmzP8vqNwy6JeK0A==",
+      "dev": true,
+      "bin": {
+        "marked": "bin/marked.js"
+      },
+      "engines": {
+        "node": ">= 12"
+      }
+    },
     "node_modules/typeorm": {
       "version": "0.3.20",
       "resolved": "https://registry.npmjs.org/typeorm/-/typeorm-0.3.20.tgz",
@@ -22159,6 +22293,7 @@
       "version": "1.0.13",
       "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.0.13.tgz",
       "integrity": "sha512-xebP81SNcPuNpPP3uzeW1NYXxI3rxyJzF3pD6sH4jE7o/IX+WtSpwnVU+qIsDPyk0d3hmFQ7mjqc6AtV604hbg==",
+      "dev": true,
       "funding": [
         {
           "type": "opencollective",
@@ -22764,6 +22899,18 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/vscode-oniguruma": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/vscode-oniguruma/-/vscode-oniguruma-1.7.0.tgz",
+      "integrity": "sha512-L9WMGRfrjOhgHSdOYgCt/yRMsXzLDJSL7BPrOZt73gU0iWO4mpqzqQzOz5srxqTvMBaR0XZTSrVWo4j55Rc6cA==",
+      "dev": true
+    },
+    "node_modules/vscode-textmate": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/vscode-textmate/-/vscode-textmate-8.0.0.tgz",
+      "integrity": "sha512-AFbieoL7a5LMqcnOF04ji+rpXadgOXnZsxQr//r83kLPr7biP7am3g9zbaZIaBGwBRWeSvoMD4mgPdX3e4NWBg==",
+      "dev": true
     },
     "node_modules/watchpack": {
       "version": "2.4.0",
@@ -23594,12 +23741,12 @@
     },
     "packages/AI/Anthropic": {
       "name": "@memberjunction/ai-anthropic",
-      "version": "0.9.32",
+      "version": "0.9.34",
       "license": "ISC",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.17.1",
-        "@memberjunction/ai": "^0.9.169",
-        "@memberjunction/global": "^0.9.166"
+        "@memberjunction/ai": "^0.9.171",
+        "@memberjunction/global": "^0.9.168"
       },
       "devDependencies": {
         "ts-node-dev": "^2.0.0",
@@ -23608,10 +23755,10 @@
     },
     "packages/AI/Core": {
       "name": "@memberjunction/ai",
-      "version": "0.9.169",
+      "version": "0.9.171",
       "license": "ISC",
       "dependencies": {
-        "@memberjunction/global": "^0.9.166",
+        "@memberjunction/global": "^0.9.168",
         "dotenv": "^16.0.3",
         "rxjs": "^7.8.1",
         "typeorm": "^0.3.20"
@@ -23624,13 +23771,13 @@
     },
     "packages/AI/Engine": {
       "name": "@memberjunction/aiengine",
-      "version": "0.9.80",
+      "version": "0.9.86",
       "license": "ISC",
       "dependencies": {
-        "@memberjunction/ai": "^0.9.169",
-        "@memberjunction/core": "^0.9.184",
-        "@memberjunction/core-entities": "^0.9.179",
-        "@memberjunction/global": "^0.9.166",
+        "@memberjunction/ai": "^0.9.171",
+        "@memberjunction/core": "^0.9.188",
+        "@memberjunction/core-entities": "^0.9.185",
+        "@memberjunction/global": "^0.9.168",
         "dotenv": "^16.0.3",
         "openai": "^3.2.1",
         "rxjs": "^7.8.1",
@@ -23644,12 +23791,12 @@
     },
     "packages/AI/gemini": {
       "name": "@memberjunction/ai-gemini",
-      "version": "0.9.33",
+      "version": "0.9.35",
       "license": "ISC",
       "dependencies": {
         "@google/generative-ai": "~0.3.1",
-        "@memberjunction/ai": "^0.9.169",
-        "@memberjunction/global": "^0.9.166"
+        "@memberjunction/ai": "^0.9.171",
+        "@memberjunction/global": "^0.9.168"
       },
       "devDependencies": {
         "ts-node-dev": "^2.0.0",
@@ -23658,11 +23805,11 @@
     },
     "packages/AI/Groq": {
       "name": "@memberjunction/ai-groq",
-      "version": "0.9.15",
+      "version": "0.9.17",
       "license": "ISC",
       "dependencies": {
-        "@memberjunction/ai": "^0.9.169",
-        "@memberjunction/global": "^0.9.166",
+        "@memberjunction/ai": "^0.9.171",
+        "@memberjunction/global": "^0.9.168",
         "groq-sdk": "^0.3.2"
       },
       "devDependencies": {
@@ -23672,11 +23819,11 @@
     },
     "packages/AI/Mistral": {
       "name": "@memberjunction/ai-mistral",
-      "version": "0.9.30",
+      "version": "0.9.32",
       "license": "ISC",
       "dependencies": {
-        "@memberjunction/ai": "^0.9.169",
-        "@memberjunction/global": "^0.9.166"
+        "@memberjunction/ai": "^0.9.171",
+        "@memberjunction/global": "^0.9.168"
       },
       "devDependencies": {
         "ts-node-dev": "^2.0.0",
@@ -23685,11 +23832,11 @@
     },
     "packages/AI/OpenAI": {
       "name": "@memberjunction/ai-openai",
-      "version": "0.9.28",
+      "version": "0.9.30",
       "license": "ISC",
       "dependencies": {
-        "@memberjunction/ai": "^0.9.169",
-        "@memberjunction/global": "^0.9.166",
+        "@memberjunction/ai": "^0.9.171",
+        "@memberjunction/global": "^0.9.168",
         "openai": "^4.28.4"
       },
       "devDependencies": {
@@ -23726,11 +23873,11 @@
     },
     "packages/AI/VectorDB": {
       "name": "@memberjunction/ai-vectordb",
-      "version": "0.9.15",
+      "version": "0.9.19",
       "license": "ISC",
       "dependencies": {
-        "@memberjunction/core": "^0.9.184",
-        "@memberjunction/global": "^0.9.166",
+        "@memberjunction/core": "^0.9.188",
+        "@memberjunction/global": "^0.9.168",
         "dotenv": "^16.0.3"
       },
       "devDependencies": {
@@ -23741,17 +23888,17 @@
     },
     "packages/AI/VectorDupe": {
       "name": "@memberjunction/ai-vector-dupe",
-      "version": "0.9.32",
+      "version": "0.9.38",
       "license": "ISC",
       "dependencies": {
-        "@memberjunction/ai": "^0.9.169",
-        "@memberjunction/ai-vectordb": "^0.9.15",
-        "@memberjunction/ai-vectors": "^0.9.16",
-        "@memberjunction/ai-vectors-pinecone": "^0.9.31",
-        "@memberjunction/aiengine": "^0.9.80",
-        "@memberjunction/core": "^0.9.184",
-        "@memberjunction/core-entities": "^0.9.179",
-        "@memberjunction/global": "^0.9.166",
+        "@memberjunction/ai": "^0.9.171",
+        "@memberjunction/ai-vectordb": "^0.9.19",
+        "@memberjunction/ai-vectors": "^0.9.20",
+        "@memberjunction/ai-vectors-pinecone": "^0.9.37",
+        "@memberjunction/aiengine": "^0.9.86",
+        "@memberjunction/core": "^0.9.188",
+        "@memberjunction/core-entities": "^0.9.185",
+        "@memberjunction/global": "^0.9.168",
         "dotenv": "^16.0.3",
         "typeorm": "^0.3.20"
       },
@@ -23764,12 +23911,12 @@
     },
     "packages/AI/Vectors": {
       "name": "@memberjunction/ai-vectors",
-      "version": "0.9.16",
+      "version": "0.9.20",
       "license": "ISC",
       "dependencies": {
         "@langchain/mistralai": "^0.0.7",
-        "@memberjunction/core": "^0.9.184",
-        "@memberjunction/global": "^0.9.166",
+        "@memberjunction/core": "^0.9.188",
+        "@memberjunction/global": "^0.9.168",
         "dotenv": "^16.0.3",
         "openai": "^3.2.1"
       },
@@ -23806,13 +23953,13 @@
     },
     "packages/AI/VectorsPinecone": {
       "name": "@memberjunction/ai-vectors-pinecone",
-      "version": "0.9.31",
+      "version": "0.9.37",
       "license": "ISC",
       "dependencies": {
-        "@memberjunction/ai-vectors": "^0.9.16",
-        "@memberjunction/aiengine": "^0.9.80",
-        "@memberjunction/core": "^0.9.184",
-        "@memberjunction/global": "^0.9.166",
+        "@memberjunction/ai-vectors": "^0.9.20",
+        "@memberjunction/aiengine": "^0.9.86",
+        "@memberjunction/core": "^0.9.188",
+        "@memberjunction/global": "^0.9.168",
         "@pinecone-database/pinecone": "^2.0.1",
         "dotenv": "^16.0.3",
         "openai": "^3.2.1",
@@ -23827,16 +23974,16 @@
     },
     "packages/AI/VectorSync": {
       "name": "@memberjunction/ai-vector-sync",
-      "version": "0.9.29",
+      "version": "0.9.35",
       "license": "ISC",
       "dependencies": {
-        "@memberjunction/ai": "^0.9.169",
-        "@memberjunction/ai-vectordb": "^0.9.15",
-        "@memberjunction/ai-vectors": "^0.9.16",
-        "@memberjunction/aiengine": "^0.9.80",
-        "@memberjunction/core": "^0.9.184",
-        "@memberjunction/global": "^0.9.166",
-        "@memberjunction/sqlserver-dataprovider": "^0.9.216",
+        "@memberjunction/ai": "^0.9.171",
+        "@memberjunction/ai-vectordb": "^0.9.19",
+        "@memberjunction/ai-vectors": "^0.9.20",
+        "@memberjunction/aiengine": "^0.9.86",
+        "@memberjunction/core": "^0.9.188",
+        "@memberjunction/global": "^0.9.168",
+        "@memberjunction/sqlserver-dataprovider": "^0.9.222",
         "dotenv": "^16.0.3",
         "typeorm": "^0.3.20"
       },
@@ -23849,17 +23996,27 @@
     },
     "packages/Angular/ask-skip": {
       "name": "@memberjunction/ng-ask-skip",
-      "version": "0.9.118",
+      "version": "0.9.127",
       "license": "ISC",
       "dependencies": {
         "@angular/cdk": "~17.2.1",
-        "@memberjunction/core": "^0.9.184",
-        "@memberjunction/global": "^0.9.166",
-        "@memberjunction/ng-container-directives": "^0.9.147",
-        "@memberjunction/ng-data-context": "^0.9.49",
-        "@memberjunction/ng-shared": "^0.9.47",
-        "@memberjunction/ng-user-view-grid": "^0.9.230",
-        "@memberjunction/skip-types": "^0.9.91",
+        "@memberjunction/core": "^0.9.188",
+        "@memberjunction/global": "^0.9.168",
+        "@memberjunction/ng-container-directives": "^0.9.151",
+        "@memberjunction/ng-data-context": "^0.9.55",
+        "@memberjunction/ng-shared": "^0.9.53",
+        "@memberjunction/ng-tabstrip": "^0.9.13",
+        "@memberjunction/ng-user-view-grid": "^0.9.237",
+        "@memberjunction/skip-types": "^0.9.97",
+        "@progress/kendo-angular-dialog": "~15.1.0",
+        "@progress/kendo-angular-filter": "~15.1.0",
+        "@progress/kendo-angular-grid": "~15.1.0",
+        "@progress/kendo-angular-indicators": "~15.1.0",
+        "@progress/kendo-angular-label": "~15.1.0",
+        "@progress/kendo-angular-layout": "~15.1.0",
+        "@progress/kendo-angular-listview": "~15.1.0",
+        "@progress/kendo-angular-notification": "~15.1.0",
+        "@progress/kendo-svg-icons": "^2.1.0",
         "@types/plotly.js-dist-min": "^2.3.4",
         "angular-plotly.js": "^5.2.2",
         "ngx-markdown": "^17.1.1",
@@ -23874,24 +24031,15 @@
         "@angular/common": "~17.2.2",
         "@angular/core": "~17.2.2",
         "@angular/forms": "~17.2.2",
-        "@angular/router": "~17.2.2",
-        "@progress/kendo-angular-dialog": "~15.1.0",
-        "@progress/kendo-angular-filter": "~15.1.0",
-        "@progress/kendo-angular-grid": "~15.1.0",
-        "@progress/kendo-angular-indicators": "~15.1.0",
-        "@progress/kendo-angular-label": "~15.1.0",
-        "@progress/kendo-angular-layout": "~15.1.0",
-        "@progress/kendo-angular-listview": "~15.1.0",
-        "@progress/kendo-angular-notification": "~15.1.0",
-        "@progress/kendo-svg-icons": "^2.1.0"
+        "@angular/router": "~17.2.2"
       }
     },
     "packages/Angular/auth-services": {
       "name": "@memberjunction/ng-auth-services",
-      "version": "0.9.106",
+      "version": "0.9.110",
       "license": "ISC",
       "dependencies": {
-        "@memberjunction/core": "^0.9.184",
+        "@memberjunction/core": "^0.9.188",
         "tslib": "^2.3.0"
       },
       "devDependencies": {
@@ -23909,16 +24057,14 @@
     },
     "packages/Angular/base-forms": {
       "name": "@memberjunction/ng-base-forms",
-      "version": "0.9.15",
+      "version": "0.9.26",
       "license": "ISC",
       "dependencies": {
-        "@memberjunction/core": "^0.9.184",
-        "@memberjunction/global": "^0.9.166",
-        "@memberjunction/ng-record-changes": "^0.9.129",
-        "@memberjunction/ng-shared": "^0.9.47",
-        "@memberjunction/ng-user-view-grid": "^0.9.230",
+        "@memberjunction/core": "^0.9.188",
+        "@memberjunction/global": "^0.9.168",
+        "@memberjunction/ng-record-changes": "^0.9.135",
+        "@memberjunction/ng-tabstrip": "^0.9.13",
         "@progress/kendo-angular-buttons": "~15.1.0",
-        "@progress/kendo-angular-layout": "~15.1.0",
         "tslib": "^2.3.0"
       },
       "devDependencies": {
@@ -23934,11 +24080,11 @@
     },
     "packages/Angular/compare-records": {
       "name": "@memberjunction/ng-compare-records",
-      "version": "0.9.195",
+      "version": "0.9.201",
       "license": "ISC",
       "dependencies": {
-        "@memberjunction/core": "^0.9.184",
-        "@memberjunction/core-entities": "^0.9.179",
+        "@memberjunction/core": "^0.9.188",
+        "@memberjunction/core-entities": "^0.9.185",
         "tslib": "^2.3.0"
       },
       "devDependencies": {
@@ -23954,11 +24100,11 @@
     },
     "packages/Angular/container-directives": {
       "name": "@memberjunction/ng-container-directives",
-      "version": "0.9.147",
+      "version": "0.9.151",
       "license": "ISC",
       "dependencies": {
-        "@memberjunction/core": "^0.9.184",
-        "@memberjunction/global": "^0.9.166",
+        "@memberjunction/core": "^0.9.188",
+        "@memberjunction/global": "^0.9.168",
         "tslib": "^2.3.0"
       },
       "devDependencies": {
@@ -23973,13 +24119,15 @@
     },
     "packages/Angular/core-entity-forms": {
       "name": "@memberjunction/ng-core-entity-forms",
-      "version": "0.9.162",
+      "version": "0.9.175",
       "license": "ISC",
       "dependencies": {
-        "@memberjunction/core": "^0.9.184",
-        "@memberjunction/core-entities": "^0.9.179",
-        "@memberjunction/ng-base-forms": "^0.9.15",
-        "@memberjunction/ng-explorer-core": "^0.9.223",
+        "@memberjunction/core": "^0.9.188",
+        "@memberjunction/core-entities": "^0.9.185",
+        "@memberjunction/ng-base-forms": "^0.9.26",
+        "@memberjunction/ng-container-directives": "^0.9.151",
+        "@memberjunction/ng-explorer-core": "^0.9.236",
+        "@memberjunction/ng-tabstrip": "^0.9.13",
         "@progress/kendo-angular-dropdowns": "~15.1.0",
         "@progress/kendo-angular-grid": "~15.1.0",
         "tslib": "^2.3.0"
@@ -23996,12 +24144,12 @@
     },
     "packages/Angular/data-context": {
       "name": "@memberjunction/ng-data-context",
-      "version": "0.9.49",
+      "version": "0.9.55",
       "license": "ISC",
       "dependencies": {
-        "@memberjunction/core": "^0.9.184",
-        "@memberjunction/global": "^0.9.166",
-        "@memberjunction/ng-compare-records": "^0.9.195",
+        "@memberjunction/core": "^0.9.188",
+        "@memberjunction/global": "^0.9.168",
+        "@memberjunction/ng-compare-records": "^0.9.201",
         "tslib": "^2.3.0"
       },
       "devDependencies": {
@@ -24019,15 +24167,15 @@
     },
     "packages/Angular/entity-form-dialog": {
       "name": "@memberjunction/ng-entity-form-dialog",
-      "version": "0.9.15",
+      "version": "0.9.25",
       "license": "ISC",
       "dependencies": {
-        "@memberjunction/core": "^0.9.184",
-        "@memberjunction/core-entities": "^0.9.179",
-        "@memberjunction/global": "^0.9.166",
-        "@memberjunction/ng-base-forms": "^0.9.15",
-        "@memberjunction/ng-container-directives": "^0.9.147",
-        "@memberjunction/ng-shared": "^0.9.47",
+        "@memberjunction/core": "^0.9.188",
+        "@memberjunction/core-entities": "^0.9.185",
+        "@memberjunction/global": "^0.9.168",
+        "@memberjunction/ng-base-forms": "^0.9.26",
+        "@memberjunction/ng-container-directives": "^0.9.151",
+        "@memberjunction/ng-shared": "^0.9.53",
         "@progress/kendo-angular-buttons": "~15.1.0",
         "@progress/kendo-angular-dialog": "~15.1.0",
         "tslib": "^2.3.0"
@@ -24045,14 +24193,14 @@
     },
     "packages/Angular/entity-permissions": {
       "name": "@memberjunction/ng-entity-permissions",
-      "version": "0.9.23",
+      "version": "0.9.30",
       "license": "ISC",
       "dependencies": {
-        "@memberjunction/core": "^0.9.184",
-        "@memberjunction/core-entities": "^0.9.179",
-        "@memberjunction/global": "^0.9.166",
-        "@memberjunction/ng-container-directives": "^0.9.147",
-        "@memberjunction/ng-shared": "^0.9.47",
+        "@memberjunction/core": "^0.9.188",
+        "@memberjunction/core-entities": "^0.9.185",
+        "@memberjunction/global": "^0.9.168",
+        "@memberjunction/ng-container-directives": "^0.9.151",
+        "@memberjunction/ng-shared": "^0.9.53",
         "@progress/kendo-angular-buttons": "~15.1.0",
         "@progress/kendo-angular-dialog": "~15.1.0",
         "@progress/kendo-angular-dropdowns": "~15.1.0",
@@ -24073,24 +24221,24 @@
     },
     "packages/Angular/explorer-core": {
       "name": "@memberjunction/ng-explorer-core",
-      "version": "0.9.223",
+      "version": "0.9.236",
       "license": "ISC",
       "dependencies": {
-        "@memberjunction/core": "^0.9.184",
-        "@memberjunction/global": "^0.9.166",
-        "@memberjunction/ng-ask-skip": "^0.9.118",
-        "@memberjunction/ng-auth-services": "^0.9.106",
-        "@memberjunction/ng-base-forms": "^0.9.15",
-        "@memberjunction/ng-compare-records": "^0.9.195",
-        "@memberjunction/ng-container-directives": "^0.9.147",
-        "@memberjunction/ng-explorer-settings": "^0.9.25",
-        "@memberjunction/ng-file-storage": "^0.9.20",
-        "@memberjunction/ng-query-grid": "^0.9.77",
-        "@memberjunction/ng-record-changes": "^0.9.129",
-        "@memberjunction/ng-shared": "^0.9.47",
-        "@memberjunction/ng-tabstrip": "^0.9.1",
-        "@memberjunction/ng-user-view-grid": "^0.9.230",
-        "@memberjunction/ng-user-view-properties": "^0.9.3",
+        "@memberjunction/core": "^0.9.188",
+        "@memberjunction/global": "^0.9.168",
+        "@memberjunction/ng-ask-skip": "^0.9.127",
+        "@memberjunction/ng-auth-services": "^0.9.110",
+        "@memberjunction/ng-base-forms": "^0.9.26",
+        "@memberjunction/ng-compare-records": "^0.9.201",
+        "@memberjunction/ng-container-directives": "^0.9.151",
+        "@memberjunction/ng-explorer-settings": "^0.9.35",
+        "@memberjunction/ng-file-storage": "^0.9.26",
+        "@memberjunction/ng-query-grid": "^0.9.83",
+        "@memberjunction/ng-record-changes": "^0.9.135",
+        "@memberjunction/ng-shared": "^0.9.53",
+        "@memberjunction/ng-tabstrip": "^0.9.13",
+        "@memberjunction/ng-user-view-grid": "^0.9.237",
+        "@memberjunction/ng-user-view-properties": "^0.9.14",
         "@progress/kendo-angular-buttons": "~15.1.0",
         "@progress/kendo-angular-charts": "~15.1.0",
         "@progress/kendo-angular-dialog": "~15.1.0",
@@ -24118,19 +24266,20 @@
     },
     "packages/Angular/explorer-settings": {
       "name": "@memberjunction/ng-explorer-settings",
-      "version": "0.9.25",
+      "version": "0.9.35",
       "license": "ISC",
       "dependencies": {
-        "@memberjunction/core": "^0.9.184",
-        "@memberjunction/core-entities": "^0.9.179",
-        "@memberjunction/global": "^0.9.166",
-        "@memberjunction/ng-base-forms": "^0.9.15",
-        "@memberjunction/ng-container-directives": "^0.9.147",
-        "@memberjunction/ng-entity-form-dialog": "^0.9.15",
-        "@memberjunction/ng-entity-permissions": "^0.9.23",
-        "@memberjunction/ng-shared": "^0.9.47",
-        "@memberjunction/ng-simple-record-list": "^0.9.15",
-        "@memberjunction/ng-user-view-grid": "^0.9.230",
+        "@memberjunction/core": "^0.9.188",
+        "@memberjunction/core-entities": "^0.9.185",
+        "@memberjunction/global": "^0.9.168",
+        "@memberjunction/ng-base-forms": "^0.9.26",
+        "@memberjunction/ng-container-directives": "^0.9.151",
+        "@memberjunction/ng-entity-form-dialog": "^0.9.25",
+        "@memberjunction/ng-entity-permissions": "^0.9.30",
+        "@memberjunction/ng-shared": "^0.9.53",
+        "@memberjunction/ng-simple-record-list": "^0.9.25",
+        "@memberjunction/ng-tabstrip": "^0.9.13",
+        "@memberjunction/ng-user-view-grid": "^0.9.237",
         "@progress/kendo-angular-buttons": "~15.1.0",
         "@progress/kendo-angular-dialog": "~15.1.0",
         "@progress/kendo-angular-dropdowns": "~15.1.0",
@@ -24152,14 +24301,14 @@
     },
     "packages/Angular/file-storage": {
       "name": "@memberjunction/ng-file-storage",
-      "version": "0.9.20",
+      "version": "0.9.26",
       "license": "ISC",
       "dependencies": {
-        "@memberjunction/core": "^0.9.184",
-        "@memberjunction/core-entities": "^0.9.179",
-        "@memberjunction/global": "^0.9.166",
-        "@memberjunction/ng-container-directives": "^0.9.147",
-        "@memberjunction/ng-shared": "^0.9.47",
+        "@memberjunction/core": "^0.9.188",
+        "@memberjunction/core-entities": "^0.9.185",
+        "@memberjunction/global": "^0.9.168",
+        "@memberjunction/ng-container-directives": "^0.9.151",
+        "@memberjunction/ng-shared": "^0.9.53",
         "@progress/kendo-angular-buttons": "~15.1.0",
         "@progress/kendo-angular-dialog": "~15.1.0",
         "@progress/kendo-angular-dropdowns": "~15.1.0",
@@ -24184,10 +24333,10 @@
     },
     "packages/Angular/link-directives": {
       "name": "@memberjunction/ng-link-directives",
-      "version": "0.9.139",
+      "version": "0.9.143",
       "license": "ISC",
       "dependencies": {
-        "@memberjunction/core": "^0.9.184",
+        "@memberjunction/core": "^0.9.188",
         "tslib": "^2.3.0"
       },
       "devDependencies": {
@@ -24202,14 +24351,14 @@
     },
     "packages/Angular/query-grid": {
       "name": "@memberjunction/ng-query-grid",
-      "version": "0.9.77",
+      "version": "0.9.83",
       "license": "ISC",
       "dependencies": {
-        "@memberjunction/core": "^0.9.184",
-        "@memberjunction/core-entities": "^0.9.179",
-        "@memberjunction/global": "^0.9.166",
-        "@memberjunction/ng-container-directives": "^0.9.147",
-        "@memberjunction/ng-shared": "^0.9.47",
+        "@memberjunction/core": "^0.9.188",
+        "@memberjunction/core-entities": "^0.9.185",
+        "@memberjunction/global": "^0.9.168",
+        "@memberjunction/ng-container-directives": "^0.9.151",
+        "@memberjunction/ng-shared": "^0.9.53",
         "tslib": "^2.3.0"
       },
       "devDependencies": {
@@ -24228,13 +24377,13 @@
     },
     "packages/Angular/record-changes": {
       "name": "@memberjunction/ng-record-changes",
-      "version": "0.9.129",
+      "version": "0.9.135",
       "license": "ISC",
       "dependencies": {
-        "@memberjunction/core": "^0.9.184",
-        "@memberjunction/global": "^0.9.166",
-        "@memberjunction/ng-compare-records": "^0.9.195",
-        "@memberjunction/ng-container-directives": "^0.9.147",
+        "@memberjunction/core": "^0.9.188",
+        "@memberjunction/global": "^0.9.168",
+        "@memberjunction/ng-compare-records": "^0.9.201",
+        "@memberjunction/ng-container-directives": "^0.9.151",
         "tslib": "^2.3.0"
       },
       "devDependencies": {
@@ -24252,11 +24401,11 @@
     },
     "packages/Angular/shared": {
       "name": "@memberjunction/ng-shared",
-      "version": "0.9.47",
+      "version": "0.9.53",
       "license": "ISC",
       "dependencies": {
-        "@memberjunction/core": "^0.9.184",
-        "@memberjunction/graphql-dataprovider": "^0.9.200",
+        "@memberjunction/core": "^0.9.188",
+        "@memberjunction/graphql-dataprovider": "^0.9.206",
         "@progress/kendo-angular-notification": "~15.1.0",
         "tslib": "^2.3.0"
       },
@@ -24272,15 +24421,15 @@
     },
     "packages/Angular/simple-record-list": {
       "name": "@memberjunction/ng-simple-record-list",
-      "version": "0.9.15",
+      "version": "0.9.25",
       "license": "ISC",
       "dependencies": {
-        "@memberjunction/core": "^0.9.184",
-        "@memberjunction/core-entities": "^0.9.179",
-        "@memberjunction/global": "^0.9.166",
-        "@memberjunction/ng-container-directives": "^0.9.147",
-        "@memberjunction/ng-entity-form-dialog": "^0.9.15",
-        "@memberjunction/ng-shared": "^0.9.47",
+        "@memberjunction/core": "^0.9.188",
+        "@memberjunction/core-entities": "^0.9.185",
+        "@memberjunction/global": "^0.9.168",
+        "@memberjunction/ng-container-directives": "^0.9.151",
+        "@memberjunction/ng-entity-form-dialog": "^0.9.25",
+        "@memberjunction/ng-shared": "^0.9.53",
         "@progress/kendo-angular-buttons": "~15.1.0",
         "@progress/kendo-angular-dialog": "~15.1.0",
         "@progress/kendo-angular-indicators": "~15.1.0",
@@ -24299,9 +24448,12 @@
       }
     },
     "packages/Angular/tab-strip": {
-      "version": "0.9.1",
+      "name": "@memberjunction/ng-tabstrip",
+      "version": "0.9.13",
       "license": "ISC",
       "dependencies": {
+        "@memberjunction/ng-container-directives": "^0.9.151",
+        "@memberjunction/ng-shared": "^0.9.53",
         "tslib": "^2.3.0"
       },
       "devDependencies": {
@@ -24315,16 +24467,15 @@
     },
     "packages/Angular/user-view-grid": {
       "name": "@memberjunction/ng-user-view-grid",
-      "version": "0.9.230",
+      "version": "0.9.237",
       "license": "ISC",
       "dependencies": {
-        "@memberjunction/core": "^0.9.184",
-        "@memberjunction/core-entities": "^0.9.179",
-        "@memberjunction/global": "^0.9.166",
-        "@memberjunction/graphql-dataprovider": "^0.9.200",
-        "@memberjunction/ng-compare-records": "^0.9.195",
-        "@memberjunction/ng-container-directives": "^0.9.147",
-        "@memberjunction/ng-shared": "^0.9.47",
+        "@memberjunction/core": "^0.9.188",
+        "@memberjunction/core-entities": "^0.9.185",
+        "@memberjunction/global": "^0.9.168",
+        "@memberjunction/ng-compare-records": "^0.9.201",
+        "@memberjunction/ng-container-directives": "^0.9.151",
+        "@memberjunction/ng-shared": "^0.9.53",
         "@progress/kendo-angular-buttons": "~15.1.0",
         "@progress/kendo-angular-grid": "~15.1.0",
         "@progress/kendo-angular-inputs": "~15.1.0",
@@ -24344,14 +24495,14 @@
     },
     "packages/Angular/user-view-properties": {
       "name": "@memberjunction/ng-user-view-properties",
-      "version": "0.9.3",
+      "version": "0.9.14",
       "license": "ISC",
       "dependencies": {
-        "@memberjunction/core": "^0.9.184",
-        "@memberjunction/core-entities": "^0.9.179",
-        "@memberjunction/global": "^0.9.166",
-        "@memberjunction/ng-base-forms": "^0.9.15",
-        "@memberjunction/ng-shared": "^0.9.47",
+        "@memberjunction/core": "^0.9.188",
+        "@memberjunction/core-entities": "^0.9.185",
+        "@memberjunction/global": "^0.9.168",
+        "@memberjunction/ng-base-forms": "^0.9.26",
+        "@memberjunction/ng-shared": "^0.9.53",
         "@progress/kendo-angular-buttons": "~15.1.0",
         "@progress/kendo-angular-dialog": "~15.1.0",
         "@progress/kendo-angular-filter": "~15.1.0",
@@ -24410,7 +24561,7 @@
       "version": "1.0.1",
       "license": "ISC",
       "dependencies": {
-        "@memberjunction/codegen-lib": "^0.9.202",
+        "@memberjunction/codegen-lib": "^0.9.208",
         "dotenv": "^16.3.1",
         "ts-node-dev": "^2.0.0",
         "typescript": "^5.3.3"
@@ -24431,14 +24582,14 @@
     },
     "packages/CodeGenLib": {
       "name": "@memberjunction/codegen-lib",
-      "version": "0.9.202",
+      "version": "0.9.208",
       "license": "ISC",
       "dependencies": {
-        "@memberjunction/ai": "^0.9.169",
-        "@memberjunction/core": "^0.9.184",
-        "@memberjunction/core-entities": "^0.9.179",
-        "@memberjunction/global": "^0.9.166",
-        "@memberjunction/sqlserver-dataprovider": "^0.9.216",
+        "@memberjunction/ai": "^0.9.171",
+        "@memberjunction/core": "^0.9.188",
+        "@memberjunction/core-entities": "^0.9.185",
+        "@memberjunction/global": "^0.9.168",
+        "@memberjunction/sqlserver-dataprovider": "^0.9.222",
         "env-var": "^7.4.1",
         "fs-extra": "^11.1.1",
         "glob": "^10.3.10",
@@ -24454,8 +24605,8 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
-        "@memberjunction/core": "^0.9.184",
-        "@memberjunction/global": "^0.9.166"
+        "@memberjunction/core": "^0.9.188",
+        "@memberjunction/global": "^0.9.168"
       },
       "devDependencies": {
         "ts-node-dev": "^2.0.0",
@@ -24464,12 +24615,12 @@
     },
     "packages/GraphQLDataProvider": {
       "name": "@memberjunction/graphql-dataprovider",
-      "version": "0.9.200",
+      "version": "0.9.206",
       "license": "ISC",
       "dependencies": {
-        "@memberjunction/core": "^0.9.184",
-        "@memberjunction/core-entities": "^0.9.179",
-        "@memberjunction/global": "^0.9.166",
+        "@memberjunction/core": "^0.9.188",
+        "@memberjunction/core-entities": "^0.9.185",
+        "@memberjunction/global": "^0.9.168",
         "graphql": "^16.6.0",
         "graphql-request": "^5.2.0",
         "graphql-ws": "^5.14.0",
@@ -24485,15 +24636,15 @@
       }
     },
     "packages/MJAPI": {
-      "name": "@memberjunction/api",
+      "name": "mj_api",
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
-        "@memberjunction/ai": "^0.9.169",
-        "@memberjunction/core": "^0.9.184",
-        "@memberjunction/global": "^0.9.166",
-        "@memberjunction/server": "^0.9.259",
-        "@memberjunction/sqlserver-dataprovider": "^0.9.216",
+        "@memberjunction/ai": "^0.9.171",
+        "@memberjunction/core": "^0.9.188",
+        "@memberjunction/global": "^0.9.168",
+        "@memberjunction/server": "^0.9.265",
+        "@memberjunction/sqlserver-dataprovider": "^0.9.222",
         "axios": "^1.5.1",
         "class-validator": "^0.14.0",
         "mj_generatedentities": "file:../GeneratedEntities",
@@ -24509,10 +24660,10 @@
     },
     "packages/MJCore": {
       "name": "@memberjunction/core",
-      "version": "0.9.184",
+      "version": "0.9.188",
       "license": "ISC",
       "dependencies": {
-        "@memberjunction/global": "^0.9.166"
+        "@memberjunction/global": "^0.9.168"
       },
       "devDependencies": {
         "ts-node-dev": "^2.0.0",
@@ -24521,11 +24672,11 @@
     },
     "packages/MJCoreEntities": {
       "name": "@memberjunction/core-entities",
-      "version": "0.9.179",
+      "version": "0.9.185",
       "license": "ISC",
       "dependencies": {
-        "@memberjunction/core": "^0.9.184",
-        "@memberjunction/global": "^0.9.166"
+        "@memberjunction/core": "^0.9.188",
+        "@memberjunction/global": "^0.9.168"
       },
       "devDependencies": {
         "ts-node-dev": "^2.0.0",
@@ -24534,11 +24685,11 @@
     },
     "packages/MJDataContext": {
       "name": "@memberjunction/data-context",
-      "version": "0.9.66",
+      "version": "0.9.72",
       "license": "ISC",
       "dependencies": {
-        "@memberjunction/core-entities": "^0.9.179",
-        "@memberjunction/global": "^0.9.166"
+        "@memberjunction/core-entities": "^0.9.185",
+        "@memberjunction/global": "^0.9.168"
       },
       "devDependencies": {
         "ts-node-dev": "^2.0.0",
@@ -24547,11 +24698,11 @@
     },
     "packages/MJDataContextServer": {
       "name": "@memberjunction/data-context-server",
-      "version": "0.9.62",
+      "version": "0.9.68",
       "license": "ISC",
       "dependencies": {
-        "@memberjunction/data-context": "^0.9.66",
-        "@memberjunction/global": "^0.9.166",
+        "@memberjunction/data-context": "^0.9.72",
+        "@memberjunction/global": "^0.9.168",
         "typeorm": "^0.3.20"
       },
       "devDependencies": {
@@ -24563,34 +24714,31 @@
       "name": "mj_explorer",
       "version": "1.0.0",
       "dependencies": {
-        "@angular/animations": "~17.2.2",
         "@angular/common": "~17.2.2",
-        "@angular/compiler": "~17.2.2",
         "@angular/core": "~17.2.2",
         "@angular/forms": "~17.2.2",
-        "@angular/localize": "~17.2.2",
         "@angular/platform-browser": "~17.2.2",
         "@angular/platform-browser-dynamic": "~17.2.2",
         "@angular/router": "~17.2.2",
         "@auth0/auth0-angular": "^2.2.3",
         "@azure/msal-angular": "^3.0.11",
-        "@memberjunction/core": "^0.9.184",
-        "@memberjunction/core-entities": "^0.9.179",
-        "@memberjunction/global": "^0.9.166",
-        "@memberjunction/graphql-dataprovider": "^0.9.200",
-        "@memberjunction/ng-ask-skip": "^0.9.118",
-        "@memberjunction/ng-auth-services": "^0.9.106",
-        "@memberjunction/ng-compare-records": "^0.9.195",
-        "@memberjunction/ng-container-directives": "^0.9.147",
-        "@memberjunction/ng-core-entity-forms": "^0.9.162",
-        "@memberjunction/ng-explorer-core": "^0.9.223",
-        "@memberjunction/ng-explorer-settings": "^0.9.25",
-        "@memberjunction/ng-link-directives": "^0.9.139",
-        "@memberjunction/ng-record-changes": "^0.9.129",
-        "@memberjunction/ng-user-view-grid": "^0.9.230",
+        "@memberjunction/core": "^0.9.188",
+        "@memberjunction/core-entities": "^0.9.185",
+        "@memberjunction/global": "^0.9.168",
+        "@memberjunction/graphql-dataprovider": "^0.9.206",
+        "@memberjunction/ng-ask-skip": "^0.9.127",
+        "@memberjunction/ng-auth-services": "^0.9.110",
+        "@memberjunction/ng-compare-records": "^0.9.201",
+        "@memberjunction/ng-container-directives": "^0.9.151",
+        "@memberjunction/ng-core-entity-forms": "^0.9.175",
+        "@memberjunction/ng-explorer-core": "^0.9.236",
+        "@memberjunction/ng-explorer-settings": "^0.9.35",
+        "@memberjunction/ng-link-directives": "^0.9.143",
+        "@memberjunction/ng-record-changes": "^0.9.135",
+        "@memberjunction/ng-tabstrip": "^0.9.13",
+        "@memberjunction/ng-user-view-grid": "^0.9.237",
         "@progress/kendo-angular-notification": "~15.1.0",
         "@progress/kendo-theme-default": "~7.2.0",
-        "body-parser": "^1.20.2",
         "hammerjs": "^2.0.0",
         "mj_generatedentities": "file:../GeneratedEntities",
         "rxjs": "~7.8.1",
@@ -24607,7 +24755,7 @@
     },
     "packages/MJGlobal": {
       "name": "@memberjunction/global",
-      "version": "0.9.166",
+      "version": "0.9.168",
       "license": "ISC",
       "dependencies": {
         "rxjs": "^7.8.1"
@@ -24619,13 +24767,13 @@
     },
     "packages/MJQueue": {
       "name": "@memberjunction/queue",
-      "version": "0.9.202",
+      "version": "0.9.208",
       "license": "ISC",
       "dependencies": {
-        "@memberjunction/ai": "^0.9.169",
-        "@memberjunction/core": "^0.9.184",
-        "@memberjunction/core-entities": "^0.9.179",
-        "@memberjunction/global": "^0.9.166",
+        "@memberjunction/ai": "^0.9.171",
+        "@memberjunction/core": "^0.9.188",
+        "@memberjunction/core-entities": "^0.9.185",
+        "@memberjunction/global": "^0.9.168",
         "@types/uuid": "^9.0.1",
         "uuid": "^9.0.0"
       },
@@ -24636,22 +24784,22 @@
     },
     "packages/MJServer": {
       "name": "@memberjunction/server",
-      "version": "0.9.259",
+      "version": "0.9.265",
       "license": "ISC",
       "dependencies": {
         "@apollo/server": "^4.9.1",
         "@graphql-tools/utils": "^10.0.1",
-        "@memberjunction/ai": "^0.9.169",
-        "@memberjunction/aiengine": "^0.9.80",
-        "@memberjunction/core": "^0.9.184",
-        "@memberjunction/core-entities": "^0.9.179",
-        "@memberjunction/data-context": "^0.9.66",
-        "@memberjunction/data-context-server": "^0.9.62",
-        "@memberjunction/global": "^0.9.166",
-        "@memberjunction/queue": "^0.9.202",
-        "@memberjunction/skip-types": "^0.9.91",
-        "@memberjunction/sqlserver-dataprovider": "^0.9.216",
-        "@memberjunction/storage": "^0.9.24",
+        "@memberjunction/ai": "^0.9.171",
+        "@memberjunction/aiengine": "^0.9.86",
+        "@memberjunction/core": "^0.9.188",
+        "@memberjunction/core-entities": "^0.9.185",
+        "@memberjunction/data-context": "^0.9.72",
+        "@memberjunction/data-context-server": "^0.9.68",
+        "@memberjunction/global": "^0.9.168",
+        "@memberjunction/queue": "^0.9.208",
+        "@memberjunction/skip-types": "^0.9.97",
+        "@memberjunction/sqlserver-dataprovider": "^0.9.222",
+        "@memberjunction/storage": "^0.9.30",
         "@types/cors": "^2.8.13",
         "@types/jsonwebtoken": "^8.5.9",
         "@types/node": "^18.11.14",
@@ -24988,7 +25136,7 @@
     },
     "packages/MJStorage": {
       "name": "@memberjunction/storage",
-      "version": "0.9.24",
+      "version": "0.9.30",
       "license": "ISC",
       "dependencies": {
         "@aws-sdk/client-s3": "^3.537.0",
@@ -24996,9 +25144,9 @@
         "@azure/identity": "^4.0.1",
         "@azure/storage-blob": "^12.17.0",
         "@google-cloud/storage": "^7.9.0",
-        "@memberjunction/core": "^0.9.184",
-        "@memberjunction/core-entities": "^0.9.179",
-        "@memberjunction/global": "^0.9.166",
+        "@memberjunction/core": "^0.9.188",
+        "@memberjunction/core-entities": "^0.9.185",
+        "@memberjunction/global": "^0.9.168",
         "env-var": "^7.3.0",
         "mime-types": "^2.1.35"
       },
@@ -25052,11 +25200,11 @@
     },
     "packages/SkipTypes": {
       "name": "@memberjunction/skip-types",
-      "version": "0.9.91",
+      "version": "0.9.97",
       "license": "ISC",
       "dependencies": {
-        "@memberjunction/core-entities": "^0.9.179",
-        "@memberjunction/data-context": "^0.9.66"
+        "@memberjunction/core-entities": "^0.9.185",
+        "@memberjunction/data-context": "^0.9.72"
       },
       "devDependencies": {
         "ts-node-dev": "^2.0.0",
@@ -25065,16 +25213,16 @@
     },
     "packages/SQLServerDataProvider": {
       "name": "@memberjunction/sqlserver-dataprovider",
-      "version": "0.9.216",
+      "version": "0.9.222",
       "license": "ISC",
       "dependencies": {
-        "@memberjunction/ai": "^0.9.169",
-        "@memberjunction/ai-vector-dupe": "^0.9.32",
-        "@memberjunction/aiengine": "^0.9.80",
-        "@memberjunction/core": "^0.9.184",
-        "@memberjunction/core-entities": "^0.9.179",
-        "@memberjunction/global": "^0.9.166",
-        "@memberjunction/queue": "^0.9.202",
+        "@memberjunction/ai": "^0.9.171",
+        "@memberjunction/ai-vector-dupe": "^0.9.38",
+        "@memberjunction/aiengine": "^0.9.86",
+        "@memberjunction/core": "^0.9.188",
+        "@memberjunction/core-entities": "^0.9.185",
+        "@memberjunction/global": "^0.9.168",
+        "@memberjunction/queue": "^0.9.208",
         "mssql": "^10.0.2",
         "typeorm": "^0.3.20"
       },

--- a/package.json
+++ b/package.json
@@ -9,12 +9,15 @@
   ],
   "scripts": {
     "build": "turbo build --filter=!mj_explorer",
-    "start": "turbo start --filter=mj_explorer --filter=mj_api"
+    "start": "turbo start --filter=mj_explorer --filter=mj_api",
+    "docs": "typedoc"
   },
   "dependencies": {
     "archiver": "^7.0.0"
   },
   "devDependencies": {
-    "turbo": "^1.12.5"
+    "turbo": "^1.12.5",
+    "typedoc": "^0.25.12",
+    "typedoc-plugin-missing-exports": "^2.2.0"
   }
 }

--- a/packages/AI/Anthropic/typedoc.json
+++ b/packages/AI/Anthropic/typedoc.json
@@ -1,0 +1,4 @@
+{
+  "extends": ["../../../typedoc.base.json"],
+  "entryPoints": ["src/index.ts"]
+}

--- a/packages/AI/Core/typedoc.json
+++ b/packages/AI/Core/typedoc.json
@@ -1,0 +1,4 @@
+{
+  "extends": ["../../../typedoc.base.json"],
+  "entryPoints": ["src/index.ts"]
+}

--- a/packages/AI/Engine/typedoc.json
+++ b/packages/AI/Engine/typedoc.json
@@ -1,0 +1,4 @@
+{
+  "extends": ["../../../typedoc.base.json"],
+  "entryPoints": ["src/index.ts"]
+}

--- a/packages/AI/Groq/typedoc.json
+++ b/packages/AI/Groq/typedoc.json
@@ -1,0 +1,4 @@
+{
+  "extends": ["../../../typedoc.base.json"],
+  "entryPoints": ["src/index.ts"]
+}

--- a/packages/AI/Mistral/typedoc.json
+++ b/packages/AI/Mistral/typedoc.json
@@ -1,0 +1,4 @@
+{
+  "extends": ["../../../typedoc.base.json"],
+  "entryPoints": ["src/index.ts"]
+}

--- a/packages/AI/OpenAI/typedoc.json
+++ b/packages/AI/OpenAI/typedoc.json
@@ -1,0 +1,4 @@
+{
+  "extends": ["../../../typedoc.base.json"],
+  "entryPoints": ["src/index.ts"]
+}

--- a/packages/AI/VectorDB/typedoc.json
+++ b/packages/AI/VectorDB/typedoc.json
@@ -1,0 +1,4 @@
+{
+  "extends": ["../../../typedoc.base.json"],
+  "entryPoints": ["src/index.ts"]
+}

--- a/packages/AI/VectorDupe/typedoc.json
+++ b/packages/AI/VectorDupe/typedoc.json
@@ -1,0 +1,4 @@
+{
+  "extends": ["../../../typedoc.base.json"],
+  "entryPoints": ["src/index.ts"]
+}

--- a/packages/AI/VectorSync/typedoc.json
+++ b/packages/AI/VectorSync/typedoc.json
@@ -1,0 +1,4 @@
+{
+  "extends": ["../../../typedoc.base.json"],
+  "entryPoints": ["src/index.ts"]
+}

--- a/packages/AI/Vectors/typedoc.json
+++ b/packages/AI/Vectors/typedoc.json
@@ -1,0 +1,4 @@
+{
+  "extends": ["../../../typedoc.base.json"],
+  "entryPoints": ["src/index.ts"]
+}

--- a/packages/AI/VectorsPinecone/typedoc.json
+++ b/packages/AI/VectorsPinecone/typedoc.json
@@ -1,0 +1,4 @@
+{
+  "extends": ["../../../typedoc.base.json"],
+  "entryPoints": ["src/index.ts"]
+}

--- a/packages/AI/gemini/typedoc.json
+++ b/packages/AI/gemini/typedoc.json
@@ -1,0 +1,4 @@
+{
+  "extends": ["../../../typedoc.base.json"],
+  "entryPoints": ["src/index.ts"]
+}

--- a/packages/Angular/ask-skip/typedoc.json
+++ b/packages/Angular/ask-skip/typedoc.json
@@ -1,0 +1,4 @@
+{
+  "extends": ["../../../typedoc.base.json"],
+  "entryPoints": ["src/public-api.ts"]
+}

--- a/packages/Angular/auth-services/typedoc.json
+++ b/packages/Angular/auth-services/typedoc.json
@@ -1,0 +1,4 @@
+{
+  "extends": ["../../../typedoc.base.json"],
+  "entryPoints": ["src/public-api.ts"]
+}

--- a/packages/Angular/base-forms/typedoc.json
+++ b/packages/Angular/base-forms/typedoc.json
@@ -1,0 +1,4 @@
+{
+  "extends": ["../../../typedoc.base.json"],
+  "entryPoints": ["src/public-api.ts"]
+}

--- a/packages/Angular/compare-records/typedoc.json
+++ b/packages/Angular/compare-records/typedoc.json
@@ -1,0 +1,4 @@
+{
+  "extends": ["../../../typedoc.base.json"],
+  "entryPoints": ["src/public-api.ts"]
+}

--- a/packages/Angular/container-directives/typedoc.json
+++ b/packages/Angular/container-directives/typedoc.json
@@ -1,0 +1,4 @@
+{
+  "extends": ["../../../typedoc.base.json"],
+  "entryPoints": ["src/public-api.ts"]
+}

--- a/packages/Angular/core-entity-forms/typedoc.json
+++ b/packages/Angular/core-entity-forms/typedoc.json
@@ -1,0 +1,4 @@
+{
+  "extends": ["../../../typedoc.base.json"],
+  "entryPoints": ["src/public-api.ts"]
+}

--- a/packages/Angular/data-context/typedoc.json
+++ b/packages/Angular/data-context/typedoc.json
@@ -1,0 +1,4 @@
+{
+  "extends": ["../../../typedoc.base.json"],
+  "entryPoints": ["src/public-api.ts"]
+}

--- a/packages/Angular/entity-form-dialog/typedoc.json
+++ b/packages/Angular/entity-form-dialog/typedoc.json
@@ -1,0 +1,4 @@
+{
+  "extends": ["../../../typedoc.base.json"],
+  "entryPoints": ["src/public-api.ts"]
+}

--- a/packages/Angular/entity-permissions/typedoc copy.json
+++ b/packages/Angular/entity-permissions/typedoc copy.json
@@ -1,0 +1,4 @@
+{
+  "extends": ["../../../typedoc.base.json"],
+  "entryPoints": ["src/index.ts"]
+}

--- a/packages/Angular/entity-permissions/typedoc.json
+++ b/packages/Angular/entity-permissions/typedoc.json
@@ -1,0 +1,4 @@
+{
+  "extends": ["../../../typedoc.base.json"],
+  "entryPoints": ["src/public-api.ts"]
+}

--- a/packages/Angular/explorer-core/typedoc.json
+++ b/packages/Angular/explorer-core/typedoc.json
@@ -1,0 +1,4 @@
+{
+  "extends": ["../../../typedoc.base.json"],
+  "entryPoints": ["src/public-api.ts"]
+}

--- a/packages/Angular/explorer-settings/typedoc.json
+++ b/packages/Angular/explorer-settings/typedoc.json
@@ -1,0 +1,4 @@
+{
+  "extends": ["../../../typedoc.base.json"],
+  "entryPoints": ["src/public-api.ts"]
+}

--- a/packages/Angular/file-storage/typedoc.json
+++ b/packages/Angular/file-storage/typedoc.json
@@ -1,0 +1,4 @@
+{
+  "extends": ["../../../typedoc.base.json"],
+  "entryPoints": ["src/public-api.ts"]
+}

--- a/packages/Angular/link-directives/typedoc copy.json
+++ b/packages/Angular/link-directives/typedoc copy.json
@@ -1,0 +1,4 @@
+{
+  "extends": ["../../../typedoc.base.json"],
+  "entryPoints": ["src/index.ts"]
+}

--- a/packages/Angular/link-directives/typedoc.json
+++ b/packages/Angular/link-directives/typedoc.json
@@ -1,0 +1,4 @@
+{
+  "extends": ["../../../typedoc.base.json"],
+  "entryPoints": ["src/public-api.ts"]
+}

--- a/packages/Angular/query-grid/typedoc.json
+++ b/packages/Angular/query-grid/typedoc.json
@@ -1,0 +1,4 @@
+{
+  "extends": ["../../../typedoc.base.json"],
+  "entryPoints": ["src/public-api.ts"]
+}

--- a/packages/Angular/record-changes/typedoc.json
+++ b/packages/Angular/record-changes/typedoc.json
@@ -1,0 +1,4 @@
+{
+  "extends": ["../../../typedoc.base.json"],
+  "entryPoints": ["src/public-api.ts"]
+}

--- a/packages/Angular/shared/typedoc.json
+++ b/packages/Angular/shared/typedoc.json
@@ -1,0 +1,4 @@
+{
+  "extends": ["../../../typedoc.base.json"],
+  "entryPoints": ["src/public-api.ts"]
+}

--- a/packages/Angular/simple-record-list/typedoc.json
+++ b/packages/Angular/simple-record-list/typedoc.json
@@ -1,0 +1,4 @@
+{
+  "extends": ["../../../typedoc.base.json"],
+  "entryPoints": ["src/public-api.ts"]
+}

--- a/packages/Angular/tab-strip/typedoc.json
+++ b/packages/Angular/tab-strip/typedoc.json
@@ -1,0 +1,4 @@
+{
+  "extends": ["../../../typedoc.base.json"],
+  "entryPoints": ["src/public-api.ts"]
+}

--- a/packages/Angular/user-view-grid/typedoc.json
+++ b/packages/Angular/user-view-grid/typedoc.json
@@ -1,0 +1,4 @@
+{
+  "extends": ["../../../typedoc.base.json"],
+  "entryPoints": ["src/public-api.ts"]
+}

--- a/packages/Angular/user-view-properties/typedoc.json
+++ b/packages/Angular/user-view-properties/typedoc.json
@@ -1,0 +1,4 @@
+{
+  "extends": ["../../../typedoc.base.json"],
+  "entryPoints": ["src/public-api.ts"]
+}

--- a/packages/CodeGen/package.json
+++ b/packages/CodeGen/package.json
@@ -1,8 +1,9 @@
 {
-  "name": "codegen",
+  "name": "mj_codegen",
   "version": "1.0.1",
   "description": "MemberJunction Code Generator Utility",
   "main": "src/index.ts",
+  "private": true,
   "scripts": {
     "dev:debug": "ts-node-dev --transpile-only --respawn --inspect=4321 --project tsconfig.dev.json src/index.ts",
     "dev": "ts-node-dev --transpile-only --respawn --project tsconfig.dev.json src/index.ts",

--- a/packages/CodeGen/typedoc.json
+++ b/packages/CodeGen/typedoc.json
@@ -1,0 +1,5 @@
+{
+  "name": "CodeGen",
+  "extends": ["../../typedoc.base.json"],
+  "entryPoints": ["src/index.ts"]
+}

--- a/packages/CodeGenLib/typedoc.json
+++ b/packages/CodeGenLib/typedoc.json
@@ -1,0 +1,4 @@
+{
+  "extends": ["../../typedoc.base.json"],
+  "entryPoints": ["src/index.ts"]
+}

--- a/packages/GraphQLDataProvider/typedoc.json
+++ b/packages/GraphQLDataProvider/typedoc.json
@@ -1,0 +1,4 @@
+{
+  "extends": ["../../typedoc.base.json"],
+  "entryPoints": ["src/index.ts"]
+}

--- a/packages/MJCore/typedoc.json
+++ b/packages/MJCore/typedoc.json
@@ -1,0 +1,4 @@
+{
+  "extends": ["../../typedoc.base.json"],
+  "entryPoints": ["src/index.ts"]
+}

--- a/packages/MJCoreEntities/typedoc.json
+++ b/packages/MJCoreEntities/typedoc.json
@@ -1,0 +1,4 @@
+{
+  "extends": ["../../typedoc.base.json"],
+  "entryPoints": ["src/index.ts"]
+}

--- a/packages/MJDataContext/typedoc.json
+++ b/packages/MJDataContext/typedoc.json
@@ -1,0 +1,4 @@
+{
+  "extends": ["../../typedoc.base.json"],
+  "entryPoints": ["src/index.ts"]
+}

--- a/packages/MJDataContextServer/typedoc.json
+++ b/packages/MJDataContextServer/typedoc.json
@@ -1,0 +1,4 @@
+{
+  "extends": ["../../typedoc.base.json"],
+  "entryPoints": ["src/index.ts"]
+}

--- a/packages/MJGlobal/typedoc.json
+++ b/packages/MJGlobal/typedoc.json
@@ -1,0 +1,4 @@
+{
+  "extends": ["../../typedoc.base.json"],
+  "entryPoints": ["src/index.ts"]
+}

--- a/packages/MJQueue/typedoc.json
+++ b/packages/MJQueue/typedoc.json
@@ -1,0 +1,4 @@
+{
+  "extends": ["../../typedoc.base.json"],
+  "entryPoints": ["src/index.ts"]
+}

--- a/packages/MJServer/typedoc.json
+++ b/packages/MJServer/typedoc.json
@@ -1,0 +1,4 @@
+{
+  "extends": ["../../typedoc.base.json"],
+  "entryPoints": ["src/index.ts"]
+}

--- a/packages/MJStorage/typedoc.json
+++ b/packages/MJStorage/typedoc.json
@@ -1,0 +1,4 @@
+{
+  "extends": ["../../typedoc.base.json"],
+  "entryPoints": ["src/index.ts"]
+}

--- a/packages/SQLServerDataProvider/typedoc.json
+++ b/packages/SQLServerDataProvider/typedoc.json
@@ -1,0 +1,4 @@
+{
+  "extends": ["../../typedoc.base.json"],
+  "entryPoints": ["src/index.ts"]
+}

--- a/packages/SkipTypes/typedoc.json
+++ b/packages/SkipTypes/typedoc.json
@@ -1,0 +1,4 @@
+{
+  "extends": ["../../typedoc.base.json"],
+  "entryPoints": ["src/index.ts"]
+}

--- a/typedoc.base.json
+++ b/typedoc.base.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "https://typedoc.org/schema.json",
+  "includeVersion": true
+}

--- a/typedoc.json
+++ b/typedoc.json
@@ -1,0 +1,16 @@
+{
+  // Comments are supported
+  "name": "Member Junction",
+  "entryPoints": ["packages/*", "packages/Angular/*", "packages/AI/*"],
+  "entryPointStrategy": "packages",
+  "out": "docs",
+  "exclude": [
+    "packages/CodeGen/",
+    "packages/GeneratedEntities/",
+    "packages/MJAPI/",
+    "packages/MJExplorer/",
+    "**/*.spec.ts",
+    "**/*.d.ts",
+    "node_modules"
+  ]
+}


### PR DESCRIPTION
This adds documentation support for the repo

- Typedoc configuration for monorepo packages
- A manually-triggerable workflow to generate docs

It also renames the CodeGen package to `mj_codgen` and adds the `private: true` flag since it isn't a published package.