### PR TITLE
Fix MJExplorer environment file regex updates

### DIFF
--- a/change/@memberjunction-cli-e09794b2-142a-4eb6-a0e4-2978f0daf8bc.json
+++ b/change/@memberjunction-cli-e09794b2-142a-4eb6-a0e4-2978f0daf8bc.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Applying package updates [skip ci]",
+  "packageName": "@memberjunction/cli",
+  "email": "craig.adam@bluecypress.io",
+  "dependentChangeType": "patch"
+}

--- a/packages/MJCLI/src/commands/install/index.ts
+++ b/packages/MJCLI/src/commands/install/index.ts
@@ -191,6 +191,7 @@ CONFIG_FILE='config.json'
       CLIENT_ID: this.userConfig.msalWebClientId,
       TENANT_ID: this.userConfig.msalTenantId,
       CLIENT_AUTHORITY: this.userConfig.msalTenantId ? `https://login.microsoftonline.com/${this.userConfig.msalTenantId}` : '',
+      AUTH_TYPE: this.userConfig.authType,
       AUTH0_DOMAIN: this.userConfig.auth0Domain,
       AUTH0_CLIENTID: this.userConfig.auth0ClientId,
     };
@@ -390,7 +391,7 @@ CONFIG_FILE='config.json'
    * @param {string} dirPath - The path to the directory containing environment files.
    * @param {object} config - The configuration object with values to update.
    */
-  async updateEnvironmentFiles(dirPath: string, config: Record<string, unknown>) {
+  async updateEnvironmentFiles(dirPath: string, config: Record<string, string | undefined>) {
     try {
       // Define the pattern for environment files.
       const envFilePattern = /environment.*\.ts$/;
@@ -411,9 +412,10 @@ CONFIG_FILE='config.json'
 
         // Replace the values in the file.
         let updatedData = data;
-        Object.keys(config).forEach((key) => {
-          const regex = new RegExp(`${key}:\\s*'.*?'`, 'g');
-          updatedData = updatedData.replace(regex, `${key}: '${config[key]}'`);
+        Object.entries(config).forEach(([key, value = '']) => {
+          const regex = new RegExp(`(["\']?${key}["\']?:\\s*["\'])([^"\']*)(["\'])`, 'g');
+          const escapedValue = value.replaceAll('$', () => '$$');
+          updatedData = updatedData.replace(regex, `$1${escapedValue}$3`);
         });
 
         // Write the updated data back to the file.


### PR DESCRIPTION
In testing the 1.6.1 release, I ran into authentication errors with MJExplorer. I noticed that the `environment*.ts` files were not updated with the installer config values due to some incorrect regex matching.

This updates the regex and adds a bit more resiliency against unexpected values when updating environment files in the CLI installer.