### PR TITLE
fix MJAPI

### DIFF
--- a/change/@memberjunction-ai-vector-sync-e2cfd23e-af8e-44ea-8020-4266f2c2cba2.json
+++ b/change/@memberjunction-ai-vector-sync-e2cfd23e-af8e-44ea-8020-4266f2c2cba2.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Applying package updates [skip ci]",
+  "packageName": "@memberjunction/ai-vector-sync",
+  "email": "155523863+JS-BC@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/AI/Vectors/Sync/src/index.ts
+++ b/packages/AI/Vectors/Sync/src/index.ts
@@ -2,6 +2,3 @@ export * from './generic/vectorSync.types';
 export * from './generic/entitySyncConfig.types';
 export * from './models/entityVectorSync';
 export * from './generic/EntityDocumentTemplateParser';
-export * from './models/workers/UpsertVectors';
-export * from './models/workers/VectorizeTemplates';
-export * from './models/workers/upserter';

--- a/packages/MJAPI/src/index.ts
+++ b/packages/MJAPI/src/index.ts
@@ -23,4 +23,8 @@ const resolverPaths = [
   'generated/generated.{js,ts}',
 ];
 
-serve(resolverPaths.map(localPath));
+serve(resolverPaths.map(localPath)).then(() => {}).catch((e: unknown) => {
+  const errorString: string = JSON.stringify(e, null, 4);
+  console.error('Error starting MJAPI server:');
+  console.error(errorString);
+});


### PR DESCRIPTION
Also added a .catch block to MJAPI's call to MJServer's `serve` method as any exception thrown there prints an [object Object] error message