### PR TITLE
Virtual Entity Support

### DIFF
--- a/change/@memberjunction-codegen-lib-bcdc22eb-5858-47c8-8567-e8624c8a73c7.json
+++ b/change/@memberjunction-codegen-lib-bcdc22eb-5858-47c8-8567-e8624c8a73c7.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Applying package updates [skip ci]",
+  "packageName": "@memberjunction/codegen-lib",
+  "email": "97354817+AN-BC@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/migrations/v2/V202409131653__v2.5.x_FixBaseCodeGenSPs.sql
+++ b/migrations/v2/V202409131653__v2.5.x_FixBaseCodeGenSPs.sql
@@ -1,0 +1,192 @@
+-- Update this procedure to exclude virtual entities
+DROP PROC IF EXISTS [__mj].[spDeleteUnneededEntityFields]
+GO
+CREATE PROC [__mj].[spDeleteUnneededEntityFields]
+    @ExcludedSchemaNames NVARCHAR(MAX)
+
+AS
+-- Get rid of any EntityFields that are NOT virtual and are not part of the underlying VIEW or TABLE - these are orphaned meta-data elements
+-- where a field once existed but no longer does either it was renamed or removed from the table or view
+IF OBJECT_ID('tempdb..#ef_spDeleteUnneededEntityFields') IS NOT NULL
+    DROP TABLE #ef_spDeleteUnneededEntityFields
+IF OBJECT_ID('tempdb..#actual_spDeleteUnneededEntityFields') IS NOT NULL
+    DROP TABLE #actual_spDeleteUnneededEntityFields
+
+-- put these two views into temp tables, for some SQL systems, this makes the join below WAY faster
+SELECT 
+	ef.* 
+INTO 
+	#ef_spDeleteUnneededEntityFields 
+FROM 
+	vwEntityFields ef
+INNER JOIN
+	vwEntities e
+ON 
+	ef.EntityID = e.ID
+-- Use LEFT JOIN with STRING_SPLIT to filter out excluded schemas
+LEFT JOIN
+    STRING_SPLIT(@ExcludedSchemaNames, ',') AS excludedSchemas
+ON
+    e.SchemaName = excludedSchemas.value
+WHERE
+    e.VirtualEntity = 0 AND -- exclude virtual entities from this always
+    excludedSchemas.value IS NULL -- This ensures rows with matching SchemaName are excluded
+
+
+SELECT * INTO #actual_spDeleteUnneededEntityFields FROM vwSQLColumnsAndEntityFields   
+
+-- first update the entity UpdatedAt so that our metadata timestamps are right
+UPDATE __mj.Entity SET __mj_UpdatedAt=GETUTCDATE() WHERE ID IN
+(
+	SELECT 
+	  ef.EntityID 
+	FROM 
+	  #ef_spDeleteUnneededEntityFields ef 
+	LEFT JOIN
+	  #actual_spDeleteUnneededEntityFields actual 
+	  ON
+	  ef.EntityID=actual.EntityID AND
+	  ef.Name = actual.EntityFieldName
+	WHERE 
+	  actual.column_id IS NULL  
+)
+
+-- now delete the entity fields themsevles
+DELETE FROM __mj.EntityField WHERE ID IN
+(
+	SELECT 
+	  ef.ID 
+	FROM 
+	  #ef_spDeleteUnneededEntityFields ef 
+	LEFT JOIN
+	  #actual_spDeleteUnneededEntityFields actual 
+	  ON
+	  ef.EntityID=actual.EntityID AND
+	  ef.Name = actual.EntityFieldName
+	WHERE 
+	  actual.column_id IS NULL  
+)
+
+-- clean up and get rid of our temp tables now
+DROP TABLE #ef_spDeleteUnneededEntityFields
+DROP TABLE #actual_spDeleteUnneededEntityFields
+GO
+
+
+
+---------------------------------------------------
+
+-- update this proc to EXCLUDE virtual entities always
+DROP PROC IF EXISTS [__mj].[spUpdateExistingEntityFieldsFromSchema]
+GO
+CREATE PROC [__mj].[spUpdateExistingEntityFieldsFromSchema]
+    @ExcludedSchemaNames NVARCHAR(MAX)
+AS
+BEGIN
+    -- Update Statement
+    UPDATE [__mj].EntityField
+    SET
+		    Description = IIF(ef.AutoUpdateDescription=1, CONVERT(NVARCHAR(MAX),fromSQL.Description), ef.Description),
+        Type = fromSQL.Type,
+        Length = fromSQL.Length,
+        Precision = fromSQL.Precision,
+        Scale = fromSQL.Scale,
+        AllowsNull = fromSQL.AllowsNull,
+        DefaultValue = fromSQL.DefaultValue,
+        AutoIncrement = fromSQL.AutoIncrement,
+        IsVirtual = fromSQL.IsVirtual,
+        Sequence = fromSQL.Sequence,
+        RelatedEntityID = re.ID,
+        RelatedEntityFieldName = fk.referenced_column,
+        IsPrimaryKey =	CASE 
+							WHEN pk.ColumnName IS NOT NULL THEN 1 
+							ELSE 0 
+						END,
+        IsUnique =		CASE 
+							WHEN pk.ColumnName IS NOT NULL THEN 1 
+							ELSE 
+								CASE 
+									WHEN uk.ColumnName IS NOT NULL THEN 1 
+									ELSE 0 
+								END 
+						END,
+        __mj_UpdatedAt = GETUTCDATE()
+    FROM
+        [__mj].EntityField ef
+    INNER JOIN
+        vwSQLColumnsAndEntityFields fromSQL
+    ON
+        ef.EntityID = fromSQL.EntityID AND
+        ef.Name = fromSQL.FieldName
+    INNER JOIN
+        [__mj].Entity e 
+    ON
+        ef.EntityID = e.ID
+    LEFT OUTER JOIN
+        vwForeignKeys fk
+    ON
+        ef.Name = fk.[column] AND
+        e.BaseTable = fk.[table] AND
+		    e.SchemaName = fk.[schema_name]
+    LEFT OUTER JOIN 
+        [__mj].Entity re -- Related Entity
+    ON
+        re.BaseTable = fk.referenced_table AND
+		    re.SchemaName = fk.[referenced_schema]
+    LEFT OUTER JOIN 
+		    [__mj].vwTablePrimaryKeys pk
+    ON
+        e.BaseTable = pk.TableName AND
+        ef.Name = pk.ColumnName AND
+        e.SchemaName = pk.SchemaName
+    LEFT OUTER JOIN 
+		    [__mj].vwTableUniqueKeys uk
+    ON
+        e.BaseTable = uk.TableName AND
+        ef.Name = uk.ColumnName AND
+        e.SchemaName = uk.SchemaName
+    -- Use LEFT JOIN with STRING_SPLIT to filter out excluded schemas
+    LEFT JOIN
+        STRING_SPLIT(@ExcludedSchemaNames, ',') AS excludedSchemas
+    ON
+        e.SchemaName = excludedSchemas.value
+	WHERE
+    e.VirtualEntity = 0
+    AND
+		    fromSQL.EntityFieldID IS NOT NULL -- only where we HAVE ALREADY CREATED EntityField records
+		AND
+        excludedSchemas.value IS NULL -- This ensures rows with matching SchemaName are excluded
+END
+GO
+
+
+-- update this proc to always exclude virtual entities
+
+DROP PROCEDURE IF EXISTS [__mj].[spUpdateExistingEntitiesFromSchema];
+GO
+
+CREATE PROCEDURE [__mj].spUpdateExistingEntitiesFromSchema
+    @ExcludedSchemaNames NVARCHAR(MAX)
+AS
+BEGIN
+    -- Update statement excluding rows with matching SchemaName
+    UPDATE 
+        [__mj].[Entity]
+    SET
+        Description = IIF(e.AutoUpdateDescription=1, CONVERT(NVARCHAR(MAX),fromSQL.EntityDescription), e.Description)
+    FROM
+        [__mj].[Entity] e
+    INNER JOIN
+        [__mj].[vwSQLTablesAndEntities] fromSQL
+    ON
+        e.ID = fromSQL.EntityID
+    -- Use LEFT JOIN with STRING_SPLIT to filter out excluded schemas
+    LEFT JOIN
+        STRING_SPLIT(@ExcludedSchemaNames, ',') AS excludedSchemas
+    ON
+        fromSQL.SchemaName = excludedSchemas.value
+    WHERE
+        e.VirtualEntity = 0 AND
+        excludedSchemas.value IS NULL; -- This ensures rows with matching SchemaName are excluded
+END;
+GO

--- a/migrations/v2/V202409140738__v2.5.x_spCreateVirtualEntity.sql
+++ b/migrations/v2/V202409140738__v2.5.x_spCreateVirtualEntity.sql
@@ -1,0 +1,69 @@
+DROP PROC IF EXISTS __mj.spCreateVirtualEntity
+GO
+CREATE PROC __mj.spCreateVirtualEntity
+   @Name nvarchar(255),
+   @BaseView nvarchar(255),
+   @SchemaName nvarchar(255),
+   @PrimaryKeyFieldName nvarchar(255),
+   @Description nvarchar(max) = null
+AS
+  DECLARE @NewEntityIDTable TABLE (ID uniqueidentifier);
+
+  INSERT INTO 
+	  __mj.Entity 
+  (
+	  Name, 
+	  BaseView, 
+	  BaseTable, 
+	  VirtualEntity, 
+	  SchemaName, 
+	  IncludeInAPI,
+	  AllowCreateAPI,
+	  AllowUpdateAPI,
+	  AllowDeleteAPI,
+	  AllowRecordMerge,
+	  TrackRecordChanges
+  )
+  OUTPUT INSERTED.ID INTO @NewEntityIDTable
+  VALUES
+  (
+	  @Name, 
+	  @BaseView, 
+	  @BaseView, -- use baseview as basetable, don't leave blank as we use this for the Code/Class virtual fields 
+	  1, 
+	  @SchemaName, 
+	  1,
+	  0,
+	  0,
+	  0,
+	  0,
+	  0
+  )
+
+  -- Declare a variable to hold the actual ID value
+  DECLARE @NewEntityID uniqueidentifier;
+  -- Retrieve the ID from the table variable
+  SELECT @NewEntityID = ID FROM @NewEntityIDTable;
+
+  -- CREATE A SINGLE ROW IN THE EntityField table for the pkey column
+  INSERT INTO __mj.EntityField
+  (
+    EntityID,
+    Sequence,
+    Name,
+    IsPrimaryKey,
+    IsUnique,
+    Type
+  )
+  VALUES
+  (
+    @NewEntityID,
+    1,
+    @PrimaryKeyFieldName,
+    1,
+    1,
+    'int' -- just a placeholder, when CodeGen runs the true type gets dropped in here along with other attributes like length, scale, precision
+  )
+
+  SELECT @NewEntityID -- return the new entity ID
+GO


### PR DESCRIPTION
To create a virtual entity, you setup a base view. The only requirement is that there is a stable, non-repeating primary key in the base view, it can be derived from any source within the view. Here is an example:

```
CREATE VIEW crm.vwDealsWithAccountInfo 
AS
SELECT 
	d.*, 
	a.Name, 
	a.TaxID, 
	a.Acronym, 
	a.Description AccountDescription 
FROM
	crm.vwDeals d 
INNER JOIN 
	crm.vwAccounts a ON d.AccountID=a.ID
```

Once you have a view like this defined, you then insert a row into the `Entity` table with this helper sp like so:

```
EXEC __mj.spCreateVirtualEntity @Name='Deals with Account Info',@BaseView='vwDealsWithAccountInfo',@SchemaName='crm',@PrimaryKeyFieldName='ID'
```  
Then, you run CodeGen and it picks up the new virtual entity and **maintain it for you** automatically as the fields in the virtual entity change over time.