### PR TITLE
Make EntityRelationshipsToLoad param optional instead of null by default

### DIFF
--- a/packages/CodeGenLib/src/entity_subclasses_codegen.ts
+++ b/packages/CodeGenLib/src/entity_subclasses_codegen.ts
@@ -107,7 +107,7 @@ export const loadModule = () => {
     * @method
     * @override
     */
-    public async Load(${loadFieldString}, EntityRelationshipsToLoad: string[] = null) : Promise<boolean> {
+    public async Load(${loadFieldString}, EntityRelationshipsToLoad?: string[]) : Promise<boolean> {
         const compositeKey: CompositeKey = new CompositeKey();
         ${entity.PrimaryKeys.map((f) => `compositeKey.KeyValuePairs.push({ FieldName: '${f.Name}', Value: ${f.CodeName} });`).join('\n        ')}
         return await super.InnerLoad(compositeKey, EntityRelationshipsToLoad);


### PR DESCRIPTION
In some typescript configs, the line `EntityRelationshipsToLoad: string[] = null` would cause the file to not build because of the error `Type 'null' is not assignable to type 'string[]'.`