### PR TITLE
Include non-mj entities for Skip

### DIFF
--- a/change/@memberjunction-server-d14a69a1-0cd4-4dde-b54d-4a0fbee45716.json
+++ b/change/@memberjunction-server-d14a69a1-0cd4-4dde-b54d-4a0fbee45716.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Applying package updates [skip ci]",
+  "packageName": "@memberjunction/server",
+  "email": "nico.ortiz@bluecypress.io",
+  "dependentChangeType": "patch"
+}

--- a/packages/MJAPI/config.json
+++ b/packages/MJAPI/config.json
@@ -20,7 +20,12 @@
     "organizationInfo": "",
     "entitiesToSendSkip": {
       "excludeSchemas": ["__mj"],
-      "includeEntities": ["Content Auto Tagger Stuff Here", "And here", "And here"]
+      "includeEntitiesFromExcludedSchemas": [
+                                              "Content Items", "Content Item Tags", "Content Item Attributes", 
+                                              "Content Types", "Content Type Attributes", "Content File Types",
+                                              "Content Sources", "Content Source Types", "Content Source Params",
+                                              "Content Source Type Params", "Content Process Runs"
+                                            ]
     }
   }
 }

--- a/packages/MJServer/src/config.ts
+++ b/packages/MJServer/src/config.ts
@@ -61,6 +61,10 @@ const viewingSystemInfoSchema = z.object({
 
 const askSkipInfoSchema = z.object({
   organizationInfo: z.string().optional(),
+  entitiesToSendSkip: z.object({
+    excludeSchemas: z.array(z.string()).optional(),
+    includeEntitiesFromExcludedSchemas: z.array(z.string()).optional(),
+  })
 });
 
 const configInfoSchema = z.object({

--- a/packages/MJServer/src/resolvers/AskSkipResolver.ts
+++ b/packages/MJServer/src/resolvers/AskSkipResolver.ts
@@ -380,8 +380,9 @@ export class AskSkipResolver {
     // narrower in scope than our native MJ metadata
     // don't pass the mj_core_schema entities by default, but allow flexibilty 
     // to include specific entities from the MJAPI config.json
+    const includedEntities = configInfo.askSkip.entitiesToSendSkip.includeEntitiesFromExcludedSchemas.map((e) => e.trim().toLowerCase());
     const md = new Metadata();
-    return md.Entities.filter((e) => e.SchemaName !== mj_core_schema || configInfo.askSkip.entitiesToSendSkip.includeEntitiesFromExcludedSchemas.includes(e.Name)).map((e) => {
+    return md.Entities.filter((e) => e.SchemaName !== mj_core_schema || includedEntities.includes(e.Name.trim().toLowerCase())).map((e) => {
       const ret: SkipEntityInfo = {
         id: e.ID,
         name: e.Name,

--- a/packages/MJServer/src/resolvers/AskSkipResolver.ts
+++ b/packages/MJServer/src/resolvers/AskSkipResolver.ts
@@ -381,7 +381,7 @@ export class AskSkipResolver {
     // don't pass the mj_core_schema entities by default, but allow flexibilty 
     // to include specific entities from the MJAPI config.json
     const md = new Metadata();
-    return md.Entities.filter((e) => e.SchemaName !== mj_core_schema).map((e) => {
+    return md.Entities.filter((e) => e.SchemaName !== mj_core_schema || configInfo.askSkip.entitiesToSendSkip.includeEntitiesFromExcludedSchemas.includes(e.Name)).map((e) => {
       const ret: SkipEntityInfo = {
         id: e.ID,
         name: e.Name,

--- a/packages/MJServer/src/resolvers/AskSkipResolver.ts
+++ b/packages/MJServer/src/resolvers/AskSkipResolver.ts
@@ -378,7 +378,8 @@ export class AskSkipResolver {
   protected BuildSkipEntities(): SkipEntityInfo[] {
     // build the entity info for skip in its format which is
     // narrower in scope than our native MJ metadata
-    // don't pass the mj_core_schema entities
+    // don't pass the mj_core_schema entities by default, but allow flexibilty 
+    // to include specific entities from the MJAPI config.json
     const md = new Metadata();
     return md.Entities.filter((e) => e.SchemaName !== mj_core_schema).map((e) => {
       const ret: SkipEntityInfo = {


### PR DESCRIPTION
PR adds as part of the MJAPI config the ability to specify entities outside of the excluded __mj schema to be included when Skip builds its entities. Also adds by default the content autotagging entities in the config.json. 