### PR TITLE
Revamp new user process

### DIFF
--- a/change/@memberjunction-core-13b11079-dd37-4ee2-a96d-75929c8c878c.json
+++ b/change/@memberjunction-core-13b11079-dd37-4ee2-a96d-75929c8c878c.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Applying package updates [skip ci]",
+  "packageName": "@memberjunction/core",
+  "email": "155523863+JS-BC@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@memberjunction-server-31dbc591-6e0b-4b1b-b014-95e9788a5071.json
+++ b/change/@memberjunction-server-31dbc591-6e0b-4b1b-b014-95e9788a5071.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Applying package updates [skip ci]",
+  "packageName": "@memberjunction/server",
+  "email": "155523863+JS-BC@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@memberjunction-sqlserver-dataprovider-e1494f77-8eb1-4377-9213-ac2861c3b6bf.json
+++ b/change/@memberjunction-sqlserver-dataprovider-e1494f77-8eb1-4377-9213-ac2861c3b6bf.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Applying package updates [skip ci]",
+  "packageName": "@memberjunction/sqlserver-dataprovider",
+  "email": "155523863+JS-BC@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/MJAPI/config.json
+++ b/packages/MJAPI/config.json
@@ -3,10 +3,10 @@
     "autoCreateNewUsers": true,
     "newUserLimitedToAuthorizedDomains": false,
     "newUserAuthorizedDomains": [],
-    "newUserRoles": ["developer"],
+    "newUserRoles": ["UI"],
     "updateCacheWhenNotFound": true,
     "updateCacheWhenNotFoundDelay": 5000,
-    "contextUserForNewUserCreation": "fill.in.user.email.here@whatever.com"
+    "contextUserForNewUserCreation": "not.set@nowhere.com"
   },
   "databaseSettings": {
     "connectionTimeout": 45000,

--- a/packages/MJCore/src/generic/securityInfo.ts
+++ b/packages/MJCore/src/generic/securityInfo.ts
@@ -1,5 +1,6 @@
 import { BaseInfo } from "./baseInfo";
 import { IMetadataProvider } from "./interfaces";
+import { LogError } from "./logging";
 import { Metadata } from "./metadata";
 
 /**
@@ -31,31 +32,35 @@ export class UserInfo extends BaseInfo {
     EmployeeSupervisor: string = null
     EmployeeSupervisorEmail: string = null
 
-
     private _UserRoles: UserRoleInfo[] = []
     public get UserRoles(): UserRoleInfo[] {
         return this._UserRoles;
     } 
 
     constructor (md: IMetadataProvider, initData: any = null) {
-        super()
-        this.copyInitData(initData)
-        if (initData) 
-            this.SetupUserRoles(md, initData.UserRoles || initData._UserRoles)
+        super();
+        this.copyInitData(initData);
+        if (initData){
+            const userRoles: UserRoleInfo[] = initData.UserRoles || initData._UserRoles;
+            this.SetupUserRoles(md, userRoles);
+        }
     }
 
     public SetupUserRoles(md: IMetadataProvider, userRoles: UserRoleInfo[]) {
         if (userRoles) {
             const mdRoles = md.Roles;
             this._UserRoles=  [];
-            for (let i = 0; i < userRoles.length; i++) {
-                // 
-                const uri = new UserRoleInfo(userRoles[i])
-                this._UserRoles.push(uri)
-    
-                const match = mdRoles.find(r => r.ID == uri.RoleID) 
-                if (match)
-                    uri._setRole(match)
+            for(const userRole of userRoles){
+                const roleInfo: UserRoleInfo = new UserRoleInfo(userRole);
+                this._UserRoles.push(roleInfo);
+
+                const match: RoleInfo | undefined = mdRoles.find(r => r.ID == roleInfo.RoleID) 
+                if (match){
+                    roleInfo._setRole(match);
+                }
+                else{
+                    LogError(`User ${this.Email} has a role that does not exist in the system: ${roleInfo.Role} ID: ${roleInfo.RoleID}`)
+                }
             }
         }
     }

--- a/packages/SQLServerDataProvider/src/UserCache.ts
+++ b/packages/SQLServerDataProvider/src/UserCache.ts
@@ -52,17 +52,24 @@ export class UserCache {
         LogError(err); 
       }
     }
+
     static get Instance(): UserCache {
       if (!UserCache._instance) {
         UserCache._instance = new UserCache();
       }
       return UserCache._instance;
     }
+
     public get Users(): UserInfo[] {
       return this._users;
     }
+
     static get Users(): UserInfo[] {
       return UserCache.Instance.Users; 
+    }
+
+    public UserByName(name: string): UserInfo | undefined {
+      return UserCache.Users.find(u => u.Name === name);
     }
   }
   


### PR DESCRIPTION
Notable changes:
- When creating a new user, if the contextUser specified in the config file is not found, we default to using the first user in the user cache with the `Owner` Role
- New users are given the UI role by default, rather than the Developer Role 
- When creating a UserInfo object to insert into the user cache, we now also pass in the RoleID
  - This fixes a bug where we fail to read the UserRoles view due to searching for user permissions by ID, not by name. 