### PR TITLE
Add option to run migrations from remote repo

### DIFF
--- a/change/@memberjunction-cli-322d10a4-a791-4b82-babb-af6fd66ffd81.json
+++ b/change/@memberjunction-cli-322d10a4-a791-4b82-babb-af6fd66ffd81.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Applying package updates [skip ci]",
+  "packageName": "@memberjunction/cli",
+  "email": "craig@memberjunction.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/MJCLI/package.json
+++ b/packages/MJCLI/package.json
@@ -63,6 +63,7 @@
     "node-flyway": "0.0.11",
     "ora-classic": "^5.4.2",
     "recast": "^0.23.9",
+    "simple-git": "^3.27.0",
     "zod": "^3.23.4"
   },
   "devDependencies": {

--- a/packages/MJCLI/src/commands/clean/index.ts
+++ b/packages/MJCLI/src/commands/clean/index.ts
@@ -26,7 +26,7 @@ export default class Clean extends Command {
       this.error('No configuration found');
     }
 
-    const flywayConfig = getFlywayConfig(config);
+    const flywayConfig = await getFlywayConfig(config);
     const flyway = new Flyway(flywayConfig);
 
     this.log('Resetting MJ database to pre-installation state');

--- a/packages/MJCLI/src/config.ts
+++ b/packages/MJCLI/src/config.ts
@@ -1,8 +1,13 @@
-import { z } from 'zod';
 import { cosmiconfigSync } from 'cosmiconfig';
 import { FlywayConfig } from 'node-flyway/dist/types/types';
+import { mkdtempSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { simpleGit, SimpleGit } from 'simple-git';
+import { z } from 'zod';
 
 export type MJConfig = z.infer<typeof mjConfigSchema>;
+
+const MJ_REPO_URL = 'https://github.com/MemberJunction/MJ.git';
 
 const explorer = cosmiconfigSync('mj', { searchStrategy: 'global' });
 const result = explorer.search(process.cwd());
@@ -17,6 +22,7 @@ const mjConfigSchema = z.object({
   dbTrustServerCertificate: z.enum(['Y', 'N']).default('Y'),
   coreSchema: z.string().optional().default('__mj'),
   cleanDisabled: z.boolean().optional().default(true),
+  mjRepoUrl: z.string().url().catch(MJ_REPO_URL),
 });
 
 const parsedConfig = mjConfigSchema.safeParse(result?.config);
@@ -33,10 +39,23 @@ export const createFlywayUrl = (mjConfig: MJConfig) => {
   }`;
 };
 
-export const getFlywayConfig = (mjConfig: MJConfig): FlywayConfig => ({
-  url: createFlywayUrl(mjConfig),
-  user: mjConfig.codeGenLogin,
-  password: mjConfig.codeGenPassword,
-  migrationLocations: [mjConfig.migrationsLocation],
-  advanced: { schemas: [mjConfig.coreSchema], cleanDisabled: mjConfig.cleanDisabled === false ? false : undefined },
-});
+export const getFlywayConfig = async (mjConfig: MJConfig, tag?: string): Promise<FlywayConfig> => {
+  let location = mjConfig.migrationsLocation;
+  if (tag) {
+    // when tag is set, we want to fetch migrations from the github repo using the tag specified
+    // we save those to a tmp dir and set that tmp dir as the migration location
+    const tmp = mkdtempSync(tmpdir());
+    const git: SimpleGit = simpleGit(tmp);
+    await git.clone(mjConfig.mjRepoUrl, tmp, ['--sparse', '--depth=1', '--branch', tag]);
+    await git.raw(['sparse-checkout', 'set', 'migrations']);
+
+    location = `filesystem:${tmp}`;
+  }
+  return {
+    url: createFlywayUrl(mjConfig),
+    user: mjConfig.codeGenLogin,
+    password: mjConfig.codeGenPassword,
+    migrationLocations: [location],
+    advanced: { schemas: [mjConfig.coreSchema], cleanDisabled: mjConfig.cleanDisabled === false ? false : undefined },
+  };
+};


### PR DESCRIPTION
This pull request introduces several important changes to the `MJCLI` package, including dependency updates, refactoring for asynchronous operations, and enhancements to the migration command. The key changes are summarized below:

### Dependency Updates:
* Added `simple-git` as a new dependency in `packages/MJCLI/package.json`.

### Refactoring for Asynchronous Operations:
* Updated the `getFlywayConfig` function call to be asynchronous in `packages/MJCLI/src/commands/clean/index.ts`.

### Enhancements to Migration Command:
* Added a new `tag` flag to the `Migrate` command for specifying a version tag for remote migrations in `packages/MJCLI/src/commands/migrate/index.ts`.
* Refactored the `Migrate` command to handle the new `tag` flag and use asynchronous `getFlywayConfig` function calls. [[1]](diffhunk://#diff-637507919a4b6df17c6f0815e7ec408edad0560775e667f1aaf6d09cdbc056d0L2-R4) [[2]](diffhunk://#diff-637507919a4b6df17c6f0815e7ec408edad0560775e667f1aaf6d09cdbc056d0L45-R52)

### Configuration Updates:
* Introduced `mjRepoUrl` with a default value in the `mjConfigSchema` in `packages/MJCLI/src/config.ts`.
* Enhanced the `getFlywayConfig` function to support fetching migrations from a GitHub repository when a tag is specified, using `simple-git`.