### PR TITLE
App view create record

### DIFF
--- a/change/@memberjunction-ng-explorer-core-2e9e75dc-2b04-4443-8586-9d5676b75417.json
+++ b/change/@memberjunction-ng-explorer-core-2e9e75dc-2b04-4443-8586-9d5676b75417.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Applying package updates [skip ci]",
+  "packageName": "@memberjunction/ng-explorer-core",
+  "email": "155523863+JS-BC@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/Angular/Explorer/explorer-core/src/lib/app-view/application-view.component.ts
+++ b/packages/Angular/Explorer/explorer-core/src/lib/app-view/application-view.component.ts
@@ -42,7 +42,16 @@ export class ApplicationViewComponent extends BaseBrowserComponent implements On
             Action: () => {
                 this.createNewView();
             }
-        }];
+        },
+        {
+            Text: 'New Record',
+            Description: `Create a new record for the currently selected entity`,
+            Icon: 'plus',
+            Action: () => {
+                this.createNewRecord();
+            }
+        }
+    ];
 
     public ViewResourceTypeID!: string;
 
@@ -330,11 +339,6 @@ export class ApplicationViewComponent extends BaseBrowserComponent implements On
         this.router.navigate(url, {queryParams: {viewMode: this.viewMode}});
     }
 
-    private isOverflown(element: any) {
-        let e: any = element.nativeElement;
-        return e.scrollHeight > e.clientHeight || e.scrollWidth > e.clientWidth;
-    }
-
     public onViewModeChange(viewMode: string): void {
         this.viewMode = viewMode;
     }
@@ -430,6 +434,38 @@ export class ApplicationViewComponent extends BaseBrowserComponent implements On
         event.preventDefault();
         // tell the router to go to /home
         this.router.navigate(['home']);
+    }
+
+    public createNewRecord(): void {
+        if(!this.currentlySelectedAppEntity){
+            LogError("Unable to create new record: No Entity selected");
+            return;
+        }
+
+        const md: Metadata = new Metadata();
+        const entityInfo = md.EntityByName(this.currentlySelectedAppEntity.Name);
+        if (!entityInfo.AllowCreateAPI) {
+            LogError(`Unable to create new record: ${entityInfo.Name} does not allow creation`);
+            return;
+        }
+
+        const permissions = entityInfo.GetUserPermisions(md.CurrentUser);
+        if(!permissions.CanCreate){
+            LogError(`Unable to create new record: Current User ${md.CurrentUser.Name} does not have permission to create records for ${entityInfo.Name}`);
+            return;
+        }
+
+        // route to a resource/record with a blank string for the 3rd segment which is normally the pkey value
+        // here we don't provide the pkey value so the record component will know to create a new record
+        this.router.navigate(
+            ['resource', 'record',''/*add this 3rd param that's blank so the route validates*/], 
+            { queryParams: 
+              { 
+                Entity: entityInfo.Name,
+                NewRecordValues: null
+              } 
+            }
+          );
     }
 } 
  


### PR DESCRIPTION
Currently if you want to create a new record for an entity, you need to first look at a view of that entity. This PR introduces a new `Create Record` option in the resource browser component dropdown, to make it easier for users to create records. 