### PR TITLE
Use pm2 runtime for api

### DIFF
--- a/change/@memberjunction-codegen-lib-756981b0-5331-4c7e-ba1e-ce1064726720.json
+++ b/change/@memberjunction-codegen-lib-756981b0-5331-4c7e-ba1e-ce1064726720.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Applying package updates [skip ci]",
+  "packageName": "@memberjunction/codegen-lib",
+  "email": "craig@memberjunction.com",
+  "dependentChangeType": "patch"
+}

--- a/docker/MJAPI/Dockerfile
+++ b/docker/MJAPI/Dockerfile
@@ -19,6 +19,8 @@ WORKDIR /app
 RUN curl -fsSL https://deb.nodesource.com/setup_20.x | bash - \
     && apt-get install -y nodejs
 
+# Install pm2 globally
+RUN npm install -g pm2
 
 # Copy package.json and package-lock.json from the root directory
 COPY package.json turbo.json ./
@@ -38,7 +40,7 @@ COPY packages/MJAPI ./packages/MJAPI/
 # Build the MJAPI application
 RUN npm run build:api
 
-COPY docker/MJAPI/docker.config.cjs ./mj.config.js
+COPY docker/MJAPI/docker.config.cjs ./mj.config.cjs
 COPY migrations ./migrations
 COPY ["[SQL Scripts]", "./[SQL Scripts]"]
 

--- a/docker/MJAPI/docker.config.cjs
+++ b/docker/MJAPI/docker.config.cjs
@@ -119,25 +119,25 @@ const codegenConfig = {
     ],
   },
   output: [
-    { type: 'GraphQLServer', directory: './MJAPI/src/generated' },
-    { type: 'ActionSubclasses', directory: './GeneratedActions/src/generated' },
-    { type: 'EntitySubclasses', directory: './GeneratedEntities/src/generated' },
+    { type: 'GraphQLServer', directory: './packages/MJAPI/src/generated' },
+    { type: 'ActionSubclasses', directory: './packages/GeneratedActions/src/generated' },
+    { type: 'EntitySubclasses', directory: './packages/GeneratedEntities/src/generated' },
   ],
   commands: [
     {
-      workingDirectory: './GeneratedEntities',
+      workingDirectory: './packages/GeneratedEntities',
       command: 'npm',
       args: ['run', 'build'],
       when: 'after',
     },
     {
-      workingDirectory: './GeneratedActions',
+      workingDirectory: './packages/GeneratedActions',
       command: 'npm',
       args: ['run', 'build'],
       when: 'after',
     },
     {
-      workingDirectory: './MJAPI',
+      workingDirectory: './packages/MJAPI',
       command: 'npm',
       args: ['run', 'build'],
       when: 'after',

--- a/docker/MJAPI/entrypoint.sh
+++ b/docker/MJAPI/entrypoint.sh
@@ -12,4 +12,4 @@ mj migrate
 mj codegen
 
 # Start the MJAPI application
-node packages/MJAPI/dist/index.js
+pm2-runtime packages/MJAPI/dist/index.js

--- a/packages/CodeGenLib/src/Database/sql.ts
+++ b/packages/CodeGenLib/src/Database/sql.ts
@@ -262,7 +262,7 @@ public async recompileAllBaseViews(ds: DataSource, excludeSchemas: string[], app
  }
 
  private maskPassword(input: string, password: string, replaceWith: string = 'XXXXX'): string {
-  return input.replace(new RegExp(password, 'g'), replaceWith);
+  return input.replace(password, replaceWith);
 }
 
  public async executeBatchSQLScript(scriptText: string): Promise<boolean> {


### PR DESCRIPTION
This pull request includes several updates and improvements to the `MJAPI` Docker setup and code generation configurations. The most important changes include installing `pm2` globally, updating file paths in the `docker.config.cjs`, and modifying the `entrypoint.sh` script to use `pm2-runtime`.

Docker setup improvements:

* [`docker/MJAPI/Dockerfile`](diffhunk://#diff-bec87a0dbc18640168bee34a9db580d4bb176eda15d8a3b535d046821eb5ff2dR22-R23): Installed `pm2` globally to manage the application process.
* [`docker/MJAPI/entrypoint.sh`](diffhunk://#diff-dc9174979058ca92f0b65060d012f0c3a5cbfc3fe45420b832a8a32bbc1b8411L15-R15): Modified the script to start the MJAPI application using `pm2-runtime` instead of `node`.

Code generation configuration updates:

* [`docker/MJAPI/docker.config.cjs`](diffhunk://#diff-373c257fb964d855d30a13a261cfa145c0debf1bd20994ab885101014664378bL122-R140): Updated the output directories and working directories to use the `packages` folder structure.

Other changes:

* [`docker/MJAPI/Dockerfile`](diffhunk://#diff-bec87a0dbc18640168bee34a9db580d4bb176eda15d8a3b535d046821eb5ff2dL41-R43): Corrected the filename from `mj.config.js` to `mj.config.cjs`.
* [`packages/CodeGenLib/src/Database/sql.ts`](diffhunk://#diff-d3bb5fa8ca1809c0a1906517400bde05bdb15d40b65621fa0222d90887171208L265-R265): Simplified the `maskPassword` method by removing the use of `RegExp`.