### PR TITLE
Pass through PORT env var as well

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,41 @@
+name: Build and publish docker images
+
+on:
+  workflow_run:
+    workflows: [Build and publish new package versions]
+    branches: [main]
+    types:
+      - completed
+
+  workflow_dispatch:
+
+jobs:
+  api:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ vars.CRAIG_BC_DOCKER_USERNAME }}
+          password: ${{ secrets.CRAIG_BC_DOCKER_TOKEN }}
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      - name: Get version
+        id: version
+        run: |
+          VERSION=$(jq -r .version packages/MJCore/package.json)
+          "VERSION=$VERSION" >> $GITHUB_OUTPUT
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          push: true
+          tags: |
+            memberjunction/api:latest
+            memberjunction/api:v{{ steps.version.outputs.VERSION }}
+          platforms: |
+            linux/amd64
+            linux/arm64
+          file: docker/MJAPI/Dockerfile
+          context: .

--- a/docker/MJAPI/docker.config.cjs
+++ b/docker/MJAPI/docker.config.cjs
@@ -222,7 +222,7 @@ const config = {
   mjCoreSchema: process.env.MJ_CORE_SCHEMA ?? '__mj',
 
   // Used only for MJAPI
-  graphqlPort: process.env.GRAPHQL_PORT ?? 4000,
+  graphqlPort: process.env.PORT ?? process.env.GRAPHQL_PORT ?? 4000,
   ___codeGenAPIURL: process.env.CODEGEN_API_URL,
   ___codeGenAPIPort: process.env.CODEGEN_API_PORT,
   ___codeGenAPISubmissionDelay: process.env.CODEGEN_API_SUBMISSION_DELAY,


### PR DESCRIPTION
This pull request includes a change to the configuration file for the MJAPI Docker setup. The change modifies the way the `graphqlPort` is determined by prioritizing the `PORT` environment variable over the `GRAPHQL_PORT` environment variable.

Configuration update:

* [`docker/MJAPI/docker.config.cjs`](diffhunk://#diff-373c257fb964d855d30a13a261cfa145c0debf1bd20994ab885101014664378bL225-R225): Updated the `graphqlPort` to use `process.env.PORT` as the primary source, falling back to `process.env.GRAPHQL_PORT` if `PORT` is not set.