### PR TITLE
Fix event message listening logic to prevent duplicates

### DIFF
--- a/change/@memberjunction-server-221a5060-f2d3-4748-afbc-ac595ac325b1.json
+++ b/change/@memberjunction-server-221a5060-f2d3-4748-afbc-ac595ac325b1.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Applying package updates [skip ci]",
+  "packageName": "@memberjunction/server",
+  "email": "craig@memberjunction.com",
+  "dependentChangeType": "patch"
+}

--- a/docker/MJAPI/docker.config.cjs
+++ b/docker/MJAPI/docker.config.cjs
@@ -158,7 +158,7 @@ const mjServerConfig = {
    */
 
   userHandling: {
-    autoCreateNewUsers: false,
+    autoCreateNewUsers: process.env.AUTO_CREATE_NEW_USERS ? process.env.AUTO_CREATE_NEW_USERS === 1 : false,
     newUserLimitedToAuthorizedDomains: false,
     newUserAuthorizedDomains: [],
     newUserRoles: ['UI'],


### PR DESCRIPTION
This pull request includes several changes to the `docker.config.cjs` and `ResolverBase.ts` files to enhance user handling and event subscription management. The most important changes include modifying user creation settings, adding a new subscription import, and ensuring event subscriptions are managed properly.

### User Handling Improvements:

* [`docker/MJAPI/docker.config.cjs`](diffhunk://#diff-373c257fb964d855d30a13a261cfa145c0debf1bd20994ab885101014664378bL161-R161): Modified the `autoCreateNewUsers` setting to be configurable via an environment variable.

### Event Subscription Management:

* [`packages/MJServer/src/generic/ResolverBase.ts`](diffhunk://#diff-70e78e44e007f3cb0df55ddfdc680fbb5ce6e253a6faedca1d9fde4923cedab0R27-R32): Added a new import for `Subscription` from `rxjs`.
* [`packages/MJServer/src/generic/ResolverBase.ts`](diffhunk://#diff-70e78e44e007f3cb0df55ddfdc680fbb5ce6e253a6faedca1d9fde4923cedab0R27-R32): Introduced a private `_eventSubscription` property to manage event subscriptions.
* [`packages/MJServer/src/generic/ResolverBase.ts`](diffhunk://#diff-70e78e44e007f3cb0df55ddfdc680fbb5ce6e253a6faedca1d9fde4923cedab0R542-R544): Updated the `ListenForEntityMessages` method to check for an existing subscription before creating a new one, preventing duplicate subscriptions. [[1]](diffhunk://#diff-70e78e44e007f3cb0df55ddfdc680fbb5ce6e253a6faedca1d9fde4923cedab0R542-R544) [[2]](diffhunk://#diff-70e78e44e007f3cb0df55ddfdc680fbb5ce6e253a6faedca1d9fde4923cedab0R564)
* [`packages/MJServer/src/generic/ResolverBase.ts`](diffhunk://#diff-70e78e44e007f3cb0df55ddfdc680fbb5ce6e253a6faedca1d9fde4923cedab0R783-R785): Added a call to `ListenForEntityMessages` in the `DeleteRecord` method to ensure messages are listened for during entity deletion.