### PR TITLE
v2.20.2

### DIFF
--- a/change/@memberjunction-cli-800beadd-f5e0-4314-96cc-43e1ff7fbaa0.json
+++ b/change/@memberjunction-cli-800beadd-f5e0-4314-96cc-43e1ff7fbaa0.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Applying package updates [skip ci]",
+  "packageName": "@memberjunction/cli",
+  "email": "craig@memberjunction.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@memberjunction-core-31aa685f-9232-4f87-b70a-5d5d67b58ca3.json
+++ b/change/@memberjunction-core-31aa685f-9232-4f87-b70a-5d5d67b58ca3.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Applying package updates [skip ci]",
+  "packageName": "@memberjunction/core",
+  "email": "97354817+AN-BC@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@memberjunction-graphql-dataprovider-2b3dab87-7e70-4147-85a8-068efebdd985.json
+++ b/change/@memberjunction-graphql-dataprovider-2b3dab87-7e70-4147-85a8-068efebdd985.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Applying package updates [skip ci]",
+  "packageName": "@memberjunction/graphql-dataprovider",
+  "email": "97354817+AN-BC@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@memberjunction-ng-resource-permissions-604d9059-5edf-4247-b9eb-af1ed8b98dad.json
+++ b/change/@memberjunction-ng-resource-permissions-604d9059-5edf-4247-b9eb-af1ed8b98dad.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Applying package updates [skip ci]",
+  "packageName": "@memberjunction/ng-resource-permissions",
+  "email": "97354817+AN-BC@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@memberjunction-server-22c95016-abde-4a20-92e4-f683a17cceb8.json
+++ b/change/@memberjunction-server-22c95016-abde-4a20-92e4-f683a17cceb8.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Applying package updates [skip ci]",
+  "packageName": "@memberjunction/server",
+  "email": "97354817+AN-BC@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@memberjunction-server-92c169a8-cd06-400e-b2c1-2ea3fbce31e6.json
+++ b/change/@memberjunction-server-92c169a8-cd06-400e-b2c1-2ea3fbce31e6.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Applying package updates [skip ci]",
+  "packageName": "@memberjunction/server",
+  "email": "craig@memberjunction.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@memberjunction-server-a4ce02fc-5203-4dab-9bb4-294548253abe.json
+++ b/change/@memberjunction-server-a4ce02fc-5203-4dab-9bb4-294548253abe.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Applying package updates [skip ci]",
+  "packageName": "@memberjunction/server",
+  "email": "97354817+AN-BC@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/Angular/Generic/resource-permissions/src/lib/resource-permissions.component.html
+++ b/packages/Angular/Generic/resource-permissions/src/lib/resource-permissions.component.html
@@ -1,4 +1,7 @@
 <div class="container">
+  @if(_Loading) {
+    <kendo-loader></kendo-loader>
+  }
   @if(ShowSaveButton) {
     <button kendoButton (click)="SavePermissions()">Save</button>
   }

--- a/packages/GraphQLDataProvider/src/index.ts
+++ b/packages/GraphQLDataProvider/src/index.ts
@@ -2,3 +2,4 @@ export { gql } from 'graphql-request';
 export { setupGraphQLClient } from './config';
 export { GraphQLDataProvider, GraphQLProviderConfigData } from './graphQLDataProvider';
 export { FieldMapper } from './FieldMapper';
+export * from './rolesAndUsersType';

--- a/packages/GraphQLDataProvider/src/rolesAndUsersType.ts
+++ b/packages/GraphQLDataProvider/src/rolesAndUsersType.ts
@@ -1,0 +1,35 @@
+
+export class RoleInput {
+    ID: string;
+
+    Name: string;
+    
+    Description: string;
+}
+
+
+export class UserInput {
+    ID!: string;
+
+    Name!: string;
+
+    Email!: string;
+
+    Type!: 'Owner' | 'User';
+
+    FirstName: string;
+
+    LastName: string;
+    
+    Title: string;
+
+    Roles?: RoleInput[];
+}
+
+export class RolesAndUsersInput {
+    public Users: UserInput[];
+  
+    public Roles: RoleInput[];
+}
+
+

--- a/packages/MJCLI/src/commands/install/index.ts
+++ b/packages/MJCLI/src/commands/install/index.ts
@@ -11,7 +11,6 @@ import { ZodError, z } from 'zod';
 
 // Directories are relative to execution cwd
 const GENERATED_ENTITIES_DIR = 'GeneratedEntities';
-const CODEGEN_DIR = 'CodeGen';
 const SQL_SCRIPTS_DIR = 'SQL Scripts';
 const GENERATED_DIR = 'generated';
 const MJ_BASE_DIR = 'MJ_BASE';
@@ -136,13 +135,6 @@ ASK_SKIP_API_URL = 'http://localhost:8000'
 ASK_SKIP_ORGANIZATION_ID = 1
 `;
     fs.writeFileSync('.env', dotenvContent);
-
-    //*******************************************************************
-    // Process CodeGen
-    //*******************************************************************
-    this.log('\nProcessing CodeGen...');
-    this.log('   Running npm link for GeneratedEntities...');
-    execSync('npm link ../GeneratedEntities', { stdio: 'inherit', cwd: CODEGEN_DIR });
 
     //*******************************************************************
     // Process MJAPI

--- a/packages/MJServer/src/index.ts
+++ b/packages/MJServer/src/index.ts
@@ -60,6 +60,7 @@ export * from './resolvers/DatasetResolver.js';
 export * from './resolvers/EntityRecordNameResolver.js';
 export * from './resolvers/MergeRecordsResolver.js';
 export * from './resolvers/ReportResolver.js';
+export * from './resolvers/SyncRolesUsersResolver.js';
 
 export * from './generated/generated.js';
 

--- a/packages/MJServer/src/index.ts
+++ b/packages/MJServer/src/index.ts
@@ -66,6 +66,10 @@ export * from './generated/generated.js';
 
 import { resolve } from 'node:path';
 
+export type MJServerOptions = {
+  onBeforeServe?: () => void | Promise<void>;
+};
+
 const localPath = (p: string) => {
   // Convert import.meta.url to a local directory path
   const dirname = fileURLToPath(new URL('.', import.meta.url));
@@ -76,7 +80,7 @@ const localPath = (p: string) => {
 
 export const createApp = () => express();
 
-export const serve = async (resolverPaths: Array<string>, app = createApp()) => {
+export const serve = async (resolverPaths: Array<string>, app = createApp(), options?: MJServerOptions) => {
   const localResolverPaths = ['resolvers/**/*Resolver.{js,ts}', 'generic/*Resolver.{js,ts}', 'generated/generated.{js,ts}'].map(localPath);
 
   const combinedResolverPaths = [...resolverPaths, ...localResolverPaths];
@@ -168,6 +172,10 @@ export const serve = async (resolverPaths: Array<string>, app = createApp()) => 
       context: contextFunction({ setupComplete$, dataSource }),
     })
   );
+
+  if (options?.onBeforeServe) {
+    await Promise.resolve(options.onBeforeServe());
+  }
 
   await new Promise<void>((resolve) => httpServer.listen({ port: graphqlPort }, resolve));
   console.log(`🚀 Server ready at http://localhost:${graphqlPort}/`);

--- a/packages/MJServer/src/resolvers/SyncRolesUsersResolver.ts
+++ b/packages/MJServer/src/resolvers/SyncRolesUsersResolver.ts
@@ -1,0 +1,401 @@
+import { Arg, Ctx, Field, InputType, Int, Mutation, ObjectType, Query, Resolver, registerEnumType } from 'type-graphql';
+import { AppContext } from '../types.js';
+import { LogError, Metadata, RunView, TransactionGroupBase, UserInfo } from '@memberjunction/core';
+import { RequireSystemUser } from '../directives/RequireSystemUser.js';
+import { RoleEntity, UserEntity, UserRoleEntity } from '@memberjunction/core-entities';
+
+@ObjectType()
+export class SyncRolesAndUsersResultType {
+  @Field(() => Boolean)
+  Success: boolean;
+}
+
+
+@InputType()
+export class RoleInputType {
+    @Field(() => String)
+    ID: string;
+
+    @Field(() => String)
+    Name: string;
+    
+    @Field(() => String, {nullable: true})
+    Description: string;
+}
+
+
+export enum UserType {
+  Owner = "Owner",
+  User = "User",
+}
+
+registerEnumType(UserType, {
+  name: "UserType", // GraphQL Enum Name
+  description: "Defines whether a user is an Owner or a User",
+});
+
+@InputType()
+export class UserInputType {
+    @Field(() => String)
+    ID!: string;
+
+    @Field(() => String)
+    Name!: string;
+
+    @Field(() => String)
+    Email!: string;
+
+    // the next field needs to have GraphQL enum with only Owner or User being allowed
+    @Field(() => UserType) 
+    Type!: UserType;
+
+    @Field(() => String, {nullable: true})
+    FirstName: string;
+
+    @Field(() => String, {nullable: true})
+    LastName: string;
+    
+    @Field(() => String, {nullable: true})
+    Title: string;
+
+    @Field(() => [RoleInputType], {nullable: true})
+    Roles?: RoleInputType[];
+}
+
+
+@InputType()
+export class RolesAndUsersInputType {
+    @Field(() => [UserInputType])
+    public Users: UserInputType[];
+  
+    @Field(() => [RoleInputType])
+    public Roles: RoleInputType[];
+}
+
+
+export class SyncRolesAndUsersResolver {
+    /**
+     * This mutation will sync both the roles and the users, and the user/role relationships in the system with the data provided in the input.
+     * Roles are matched by the name (case insensitive) and users are matched by email
+     * @param data 
+     */
+    @RequireSystemUser()
+    @Mutation(() => SyncRolesAndUsersResultType)
+    async SyncRolesAndUsers(
+    @Arg('data', () => RolesAndUsersInputType ) data: RolesAndUsersInputType,
+    @Ctx() context: AppContext
+    ) {
+        try {
+            // first we sync the roles, then the users 
+            const roleResult = await this.SyncRoles(data.Roles, context);
+            if (roleResult.Success) {
+                return await this.SyncUsers(data.Users, context);
+            }
+            else {
+                return roleResult;
+            }
+        } 
+        catch (err) {
+            LogError(err);
+            throw new Error('Error syncing roles and users\n\n' + err);
+        }
+    }
+
+    /**
+     * This mutation will sync the roles in the system with the data provided in the input, using the role name for matching (case insensitive)
+     * @param data 
+     */
+    @RequireSystemUser()
+    @Mutation(() => SyncRolesAndUsersResultType)
+    async SyncRoles(
+    @Arg('roles', () => [RoleInputType]) roles: RoleInputType[],
+    @Ctx() context: AppContext
+    ) : Promise<SyncRolesAndUsersResultType> {
+        try {
+            // we iterate through the provided roles and we remove roles that are not in the input and add roles that are new
+            // and update roles that already exist
+            const rv = new RunView();
+            const result = await rv.RunView<RoleEntity>({
+                EntityName: "Roles",
+                ResultType: 'entity_object'
+            }, context.userPayload.userRecord);
+    
+            if (result && result.Success) {
+                const currentRoles = result.Results;
+                if (await this.DeleteRemovedRoles(currentRoles, roles, context.userPayload.userRecord)) {
+                    if ( await this.AddNewRoles(currentRoles, roles, context.userPayload.userRecord)) {
+                        return await this.UpdateExistingRoles(currentRoles, roles, context.userPayload.userRecord);
+                    }
+                }
+            }
+
+            return { Success: false }; // if we get here, something went wrong
+        } catch (err) {
+            LogError(err);
+            throw new Error('Error syncing roles and users\n\n' + err);
+        }
+    }
+
+    protected async UpdateExistingRoles(currentRoles: RoleEntity[], futureRoles: RoleInputType[], user: UserInfo): Promise<SyncRolesAndUsersResultType> {
+        // go through the future roles and update any that are in the current roles
+        const md = new Metadata();
+        let ok: boolean = true;
+
+        for (const update of futureRoles) {
+            const currentRole = currentRoles.find(r => r.Name.trim().toLowerCase() === update.Name.trim().toLowerCase());
+            if (currentRole) {
+                currentRole.Description = update.Description;
+                ok = ok && await currentRole.Save(); // no await, we do that with submit below
+            }
+        }
+        return { Success: ok };
+    }
+
+    protected async AddNewRoles(currentRoles: RoleEntity[], futureRoles: RoleInputType[], user: UserInfo): Promise<boolean> {
+        // go through the future roles and add any that are not in the current roles
+        const md = new Metadata();
+        let ok: boolean = true;
+
+        for (const add of futureRoles) {
+            if (!currentRoles.find(r => r.Name.trim().toLowerCase() === add.Name.trim().toLowerCase())) {
+                const role = await md.GetEntityObject<RoleEntity>("Roles", user);
+                role.Name = add.Name;
+                role.Description = add.Description;
+                ok = ok && await role.Save(); // no await, we do that with submit below
+            }
+        }
+        return ok;
+    }
+
+
+    protected async DeleteRemovedRoles(currentRoles: RoleEntity[], futureRoles: RoleInputType[], user: UserInfo): Promise<boolean> {
+        const rv = new RunView();
+        let ok: boolean = true;
+
+        // iterate through the existing roles and remove any that are not in the input
+        for (const remove of currentRoles) {
+            if (!this.IsStandardRole(remove.Name)) {
+                if (!futureRoles.find(r => r.Name.trim().toLowerCase() === remove.Name.trim().toLowerCase())) {
+                    ok = ok && await this.DeleteSingleRole(remove, rv, user);
+                }    
+            }
+        }
+        return ok;
+    }
+
+    public get StandardRoles(): string[] {
+        return ['Developer', 'Integration', 'UI']
+    }
+    public IsStandardRole(roleName: string): boolean {
+        return this.StandardRoles.find(r => r.toLowerCase() === roleName.toLowerCase()) !== undefined;
+    }
+
+    protected async DeleteSingleRole(role: RoleEntity, rv: RunView, user: UserInfo): Promise<boolean> {
+        // first, remove all the UserRole records that match this role
+        let ok: boolean = true;
+        const r2 = await rv.RunView<UserRoleEntity>({
+            EntityName: "User Roles",
+            ExtraFilter: "RoleID = '" + role.ID + "'",
+            ResultType: 'entity_object'
+        }, user);
+        if (r2.Success) {
+            for (const ur of r2.Results) {
+                ok = ok && await ur.Delete(); // remove the user role
+            }
+        }
+
+        return ok && role.Delete(); // remove the role
+    }
+
+    /**
+     * This mutation will sync the just the users in the system with the data provided in the input, matches existing users by email
+     * @important This method will NOT work if the roles are not already in sync, meaning if User/Role relationships exist in the input data where the Role doesn't already exist in this system the sync will fail
+     * @param data 
+     */
+    @RequireSystemUser()
+    @Mutation(() => SyncRolesAndUsersResultType)
+    async SyncUsers(
+    @Arg('users', () => [UserInputType]) users: UserInputType[],
+    @Ctx() context: AppContext
+    ) : Promise<SyncRolesAndUsersResultType> {
+        try {
+            // first, we sync up the users and then the user roles. 
+            // for syncing users we first remove users that are no longer in the input, then we add new users and update existing users
+            const rv = new RunView();
+            const result = await rv.RunView<UserEntity>({
+                EntityName: "Users",
+                ResultType: 'entity_object'
+            }, context.userPayload.userRecord);
+            if (result && result.Success) {
+                // go through current users and remove those that are not in the input
+                const currentUsers = result.Results;
+                if (await this.DeleteRemovedUsers(currentUsers, users, context.userPayload.userRecord)) {
+                    if (await this.AddNewUsers(currentUsers, users, context.userPayload.userRecord)) {
+                        if (await this.UpdateExistingUsers(currentUsers, users, context.userPayload.userRecord)) {
+                            if (await this.SyncUserRoles(users, context.userPayload.userRecord)) {
+                                return { Success: true };
+                            }    
+                        }
+                    }
+                }
+            }
+
+            return { Success: false }; // if we get here, something went wrong
+        } catch (err) {
+            LogError(err);
+            throw new Error('Error syncing roles and users\n\n' + err);
+        }
+    }
+
+    protected async UpdateExistingUsers(currentUsers: UserEntity[], futureUsers: UserInputType[], u: UserInfo): Promise<boolean> {  
+        // go through the future users and update any that are in the current users
+        let ok: boolean = true;
+        for (const update of futureUsers) {
+            const current = currentUsers.find(c => c.Email.trim().toLowerCase() === update.Email.trim().toLowerCase());
+            if (current) {
+                current.Name = update.Name;
+                current.Type = update.Type;
+                current.FirstName = update.FirstName;
+                current.LastName = update.LastName;
+                current.Title = update.Title;
+                ok = ok && await current.Save();  
+            }
+        }
+        return ok;
+    }
+    protected async AddNewUsers(currentUsers: UserEntity[], futureUsers: UserInputType[], u: UserInfo): Promise<boolean> {
+        // add users that are not in the current users
+        const md = new Metadata();
+        let ok: boolean = true;
+
+        for (const add of futureUsers) {
+            const match = currentUsers.find(currentUser => currentUser.Email?.trim().toLowerCase() === add.Email?.trim().toLowerCase());
+            if (match) {
+                // make sure the IsActive bit is set to true
+                match.IsActive = true;
+                ok = ok && await match.Save();  
+            }  
+            else {
+                const user = await md.GetEntityObject<UserEntity>("Users", u);
+                user.Name = add.Name;
+                user.Type = add.Type;
+                user.Email = add.Email;
+                user.FirstName = add.FirstName;
+                user.LastName = add.LastName;
+                user.Title = add.Title;
+                user.IsActive = true;
+
+                ok = ok && await user.Save();  
+            }
+        }
+        return ok;
+    }
+
+    protected async DeleteRemovedUsers(currentUsers: UserEntity[], futureUsers: UserInputType[], u: UserInfo): Promise<boolean> {
+        // remove users that are not in the future users
+        const rv = new RunView();
+        const md = new Metadata();
+
+        let ok: boolean = true;
+        //const tg = await md.CreateTransactionGroup(); HAVING PROBLEMS with this, so skipping for now, I think the entire thing is wrapped in a transaction and that's causing issues with two styles of trans wrappers
+        for (const remove of currentUsers) {
+            if (remove.Type.trim().toLowerCase() !== 'owner') {
+                if (!futureUsers.find(r => r.Email.trim().toLowerCase() === remove.Email.trim().toLowerCase())) {
+                    ok = ok && await this.DeleteSingleUser(remove, rv, u);
+                }
+            }
+        }
+        return ok;
+    }
+
+    protected async DeleteSingleUser(user: UserEntity, rv: RunView, u: UserInfo): Promise<boolean> {
+        // first, remove all the UserRole records that match this user
+        let ok: boolean = true;
+        const r2 = await rv.RunView<UserRoleEntity>({
+            EntityName: "User Roles",
+            ExtraFilter: "UserID = '" + user.ID + "'",
+            ResultType: 'entity_object'
+        }, u);
+        if (r2.Success) {
+            for (const ur of r2.Results) {
+                //ur.TransactionGroup = tg;
+                ok = ok && await ur.Delete(); // remove the user role
+            }
+        }
+        if (await user.Delete()) {
+            return ok;
+        }
+        else {
+            // in some cases there are a lot of fkey constraints that prevent the user from being deleted, so we mark the user as inactive instead
+            user.IsActive = false;
+            return await user.Save() && ok;
+        }
+    }
+
+    protected async SyncUserRoles(users: UserInputType[], u: UserInfo): Promise<boolean> {
+        // for each user in the users array, make sure there is a User Role that matches. First, get a list of all DATABASE user and roels so we have that for fast lookup in memory
+        const rv = new RunView();
+        const md = new Metadata();
+
+        const p1 = rv.RunView<UserEntity>({
+            EntityName: "Users",
+            ResultType: 'entity_object'
+        }, u);
+        const p2 = rv.RunView<RoleEntity>({
+            EntityName: "Roles",
+            ResultType: 'entity_object'
+        }, u);
+        const p3 = rv.RunView<UserRoleEntity>({
+            EntityName: "User Roles",
+            ResultType: 'entity_object'
+        }, u);
+
+        // await both 
+        const [uResult,rResult, urResult] = await Promise.all([p1, p2, p3]);
+
+        if (uResult.Success && rResult.Success && urResult.Success) {
+            // we have the DB users and roles, and user roles
+            const dbUsers = uResult.Results;
+            const dbRoles = rResult.Results;    
+            const dbUserRoles = urResult.Results;
+            let ok: boolean = true;
+
+            // now, we can do lookups in memory from those DB roles and Users for their ID values
+            // now we will iterate through the users input type and for each role, make sure it is in there     
+            //const tg = await md.CreateTransactionGroup();
+            for (const user of users) {
+                const dbUser = dbUsers.find(u => u.Email.trim().toLowerCase() === user.Email.trim().toLowerCase());
+                if (dbUser) {
+                    for (const role of user.Roles) {
+                        const dbRole = dbRoles.find(r => r.Name.trim().toLowerCase() === role.Name.trim().toLowerCase());
+                        if (dbRole) {
+                            // now we need to make sure there is a user role that matches this user and role
+                            if (!dbUserRoles.find(ur => ur.UserID === dbUser.ID && ur.RoleID === dbRole.ID)) {
+                                // we need to add a user role
+                                const ur = await md.GetEntityObject<UserRoleEntity>("User Roles", u);
+                                ur.UserID = dbUser.ID;
+                                ur.RoleID = dbRole.ID;
+                                ok = ok && await ur.Save(); // no await, we do that with submit below
+                            }
+                        }
+                    }
+                    // now, we check for DB user roles that are NOT in the user.Roles property as they are no longer part of the user's roles
+                    const thisUserDBRoles = dbUserRoles.filter(ur => ur.UserID === dbUser.ID);
+                    for (const dbUserRole of thisUserDBRoles) {
+                        const role = user.Roles.find(r => r.Name.trim().toLowerCase() === dbRoles.find(rr => rr.ID === dbUserRole.RoleID)?.Name.trim().toLowerCase());
+                        if (!role) {
+                            // this user role is no longer in the user's roles, we need to remove it
+                            //dbUserRole.TransactionGroup = tg;
+                            ok = ok && await dbUserRole.Delete(); // remove the user role - we use await for the DELETE, not the save
+                        }
+                    }
+                }
+            }
+            return ok;
+        }
+        else {
+            return false;
+        }
+    }
+}
+ 

--- a/packages/MJServer/src/resolvers/SyncRolesUsersResolver.ts
+++ b/packages/MJServer/src/resolvers/SyncRolesUsersResolver.ts
@@ -251,7 +251,7 @@ export class SyncRolesAndUsersResolver {
         // go through the future users and update any that are in the current users
         let ok: boolean = true;
         for (const update of futureUsers) {
-            const current = currentUsers.find(c => c.Email.trim().toLowerCase() === update.Email.trim().toLowerCase());
+            const current = currentUsers.find(c => c.Email?.trim().toLowerCase() === update.Email?.trim().toLowerCase());
             if (current) {
                 current.Name = update.Name;
                 current.Type = update.Type;
@@ -383,7 +383,7 @@ export class SyncRolesAndUsersResolver {
                     const thisUserDBRoles = dbUserRoles.filter(ur => ur.UserID === dbUser.ID);
                     for (const dbUserRole of thisUserDBRoles) {
                         const role = user.Roles.find(r => r.Name.trim().toLowerCase() === dbRoles.find(rr => rr.ID === dbUserRole.RoleID)?.Name.trim().toLowerCase());
-                        if (!role) {
+                        if (!role && !this.IsStandardRole(dbUserRole.Role)) {
                             // this user role is no longer in the user's roles, we need to remove it
                             //dbUserRole.TransactionGroup = tg;
                             ok = ok && await dbUserRole.Delete(); // remove the user role - we use await for the DELETE, not the save


### PR DESCRIPTION
- **fix minor bugs in resource permissions component for 2.20.2**
- **Change files**
- **Remove unused CodeGen processing from install command**
- **Change files**
- **Added Sync Roles/Users resolver to MJ Server - first pass**
- **GraphQL call to SyncRolesAndUsers mutation**
- **Added support to GraphQLDataProvider for MJAPIKey (shared secret) - only to be used when GraphQLDataProvider is used on a secure environment like a back-end API**
- **Change files**
- **Added OldValues to eventing architecture for BaseEntity on Delete to let event listeners have access to old values prior to save**
- **bug fixes for raising events - payload wasn't being passed along**
- **Change files**
- **bug fix for emails that aren't provided correctly**
- **Change files**
- **Add MJServerOptions type and onBeforeServe option to serve function**
- **Change files**
