### PR TITLE
Deprecate one Groq model, add a new one

### DIFF
--- a/change/@memberjunction-aiengine-263d2df9-96c7-40a0-9492-ffeebfd8ee67.json
+++ b/change/@memberjunction-aiengine-263d2df9-96c7-40a0-9492-ffeebfd8ee67.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Applying package updates [skip ci]",
+  "packageName": "@memberjunction/aiengine",
+  "email": "155523863+JS-BC@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/migrations/v2/V202502031351__v2.21.x.DeprecateGroqModel.sql
+++ b/migrations/v2/V202502031351__v2.21.x.DeprecateGroqModel.sql
@@ -20,7 +20,7 @@ INSERT INTO [${flyway:defaultSchema}].[AIModel]
 VALUES
 (
 	'Llama 3.3 70b versatile',
-    'Llama 3.1 70 billion parameters',
+    'Llama 3.3 70 billion parameters',
     'Groq',
     'E8A5CCEC-6A37-EF11-86D4-000D3A4E707E',
     '4',

--- a/migrations/v2/V202502031351__v2.21.x.DeprecateGroqModel.sql
+++ b/migrations/v2/V202502031351__v2.21.x.DeprecateGroqModel.sql
@@ -1,0 +1,43 @@
+-- On 1-24-25, Groq deprecated the Llama 3.1 70 billion parameters model 
+-- in favor of the Llama 3.3 70 billion parameters model. 
+-- This migration deactivates the Llama 3.1 model and adds the Llama 3.3 model to the AIModel table.
+
+INSERT INTO [${flyway:defaultSchema}].[AIModel]
+(
+	[Name],
+	[Description],
+	[Vendor],
+	[AIModelTypeID],
+	[PowerRank],
+	[IsActive],
+	[DriverClass],
+	[DriverImportPath],
+	[APIName],
+	[InputTokenLimit],
+	[SpeedRank],
+	[CostRank]
+)
+VALUES
+(
+	'Llama 3.3 70b versatile',
+    'Llama 3.1 70 billion parameters',
+    'Groq',
+    'E8A5CCEC-6A37-EF11-86D4-000D3A4E707E',
+    '4',
+    1,
+    'GroqLLM',
+	null,
+    'llama-3.3-70b-versatile',
+    128000,
+	null,
+	null
+)
+
+GO 
+
+UPDATE [${flyway:defaultSchema}].[AIModel]
+SET IsActive = 0
+where ID = 'F126ED5B-97B3-49E7-BD3B-E796B2099231'
+
+GO
+

--- a/migrations/v2/V202502031351__v2.21.x.DeprecateGroqModel.sql
+++ b/migrations/v2/V202502031351__v2.21.x.DeprecateGroqModel.sql
@@ -26,7 +26,7 @@ VALUES
     '4',
     1,
     'GroqLLM',
-	null,
+    null,
     'llama-3.3-70b-versatile',
     128000,
 	null,

--- a/migrations/v2/V202502031351__v2.21.x.DeprecateGroqModel.sql
+++ b/migrations/v2/V202502031351__v2.21.x.DeprecateGroqModel.sql
@@ -29,8 +29,8 @@ VALUES
     null,
     'llama-3.3-70b-versatile',
     128000,
-	null,
-	null
+    null,
+    null
 )
 
 GO 


### PR DESCRIPTION
On 1-24-25, Groq deprecated the Llama 3.1 70 billion parameters model in favor of the Llama 3.3 70 billion parameters model. This migration deactivates the Llama 3.1 model and adds the Llama 3.3 model to the AIModel table.

Also included is a new method in the AI Engine to get a BaseLLM class by its name