### PR TITLE
Response format param

### DIFF
--- a/change/@memberjunction-ai-4f767527-42b5-47ff-b585-d5fdecb1f4c6.json
+++ b/change/@memberjunction-ai-4f767527-42b5-47ff-b585-d5fdecb1f4c6.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Applying package updates [skip ci]",
+  "packageName": "@memberjunction/ai",
+  "email": "155523863+JS-BC@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@memberjunction-ai-gemini-636b3574-ae53-4014-9913-c65bf40db831.json
+++ b/change/@memberjunction-ai-gemini-636b3574-ae53-4014-9913-c65bf40db831.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Applying package updates [skip ci]",
+  "packageName": "@memberjunction/ai-gemini",
+  "email": "155523863+JS-BC@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@memberjunction-ai-groq-ebcabef9-ee2e-421e-9656-870899fb2113.json
+++ b/change/@memberjunction-ai-groq-ebcabef9-ee2e-421e-9656-870899fb2113.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Applying package updates [skip ci]",
+  "packageName": "@memberjunction/ai-groq",
+  "email": "155523863+JS-BC@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@memberjunction-ai-mistral-5db54528-d0a4-4afa-b3f2-0378a46c7894.json
+++ b/change/@memberjunction-ai-mistral-5db54528-d0a4-4afa-b3f2-0378a46c7894.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Applying package updates [skip ci]",
+  "packageName": "@memberjunction/ai-mistral",
+  "email": "155523863+JS-BC@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@memberjunction-ai-openai-bfa973de-7d03-4432-bcf6-eda89fddb9fe.json
+++ b/change/@memberjunction-ai-openai-bfa973de-7d03-4432-bcf6-eda89fddb9fe.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Applying package updates [skip ci]",
+  "packageName": "@memberjunction/ai-openai",
+  "email": "155523863+JS-BC@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/AI/Core/src/generic/baseModel.ts
+++ b/packages/AI/Core/src/generic/baseModel.ts
@@ -26,6 +26,14 @@ export class BaseParams {
     temperature?: number
 
     /**
+     * Specifies the format that the model must output.
+     * 
+     * **Important:** when using a JSON response, you **must** also instruct the model to
+     * produce JSON yourself via a system or user message.
+     */
+    responseFormat?: any
+
+    /**
      * Model max output response tokens, optional.
      */
     maxOutputTokens?: number

--- a/packages/AI/Providers/Gemini/src/index.ts
+++ b/packages/AI/Providers/Gemini/src/index.ts
@@ -1,7 +1,7 @@
 
 
 // Google Gemini Import
-import { Content, GoogleGenerativeAI, TextPart } from "@google/generative-ai";
+import { Content, GenerationConfig, GoogleGenerativeAI, TextPart } from "@google/generative-ai";
 
 // MJ stuff
 import { BaseLLM, ChatMessage, ChatParams, ChatResult, SummarizeParams, SummarizeResult } from "@memberjunction/ai";
@@ -45,8 +45,9 @@ export class GeminiLLM extends BaseLLM {
         try {
             // For text-only input, use the gemini-pro model
             const startTime = new Date();
-            const config = {
+            const config: GenerationConfig = {
                 temperature: params.temperature || 0.5,
+                responseMimeType: params.responseFormat
             };
             const model = this.GeminiClient.getGenerativeModel({ model: params.model || "gemini-pro", generationConfig: config}, {apiVersion: "v1beta"});
             const allMessagesButLast = params.messages.slice(0, params.messages.length - 1);

--- a/packages/AI/Providers/Groq/src/models/groq.ts
+++ b/packages/AI/Providers/Groq/src/models/groq.ts
@@ -35,7 +35,8 @@ export class GroqLLM extends BaseLLM {
         const chatResponse = await this.client.chat.completions.create({
             model: params.model,
             messages: params.messages, 
-            max_tokens: params.maxOutputTokens
+            max_tokens: params.maxOutputTokens,
+            response_format: params.responseFormat
         });
         const endTime = new Date();
 

--- a/packages/AI/Providers/Mistral/src/generic/mistral.types.ts
+++ b/packages/AI/Providers/Mistral/src/generic/mistral.types.ts
@@ -44,7 +44,8 @@ export type ChatCompletetionRequest = {
     top_p?: number,
     random_seed?: number,
     stream?: boolean,
-    safe_prompt?: boolean
+    safe_prompt?: boolean,
+    response_format?: any
 }
 
 export interface ChatCompletionResponseChoice {

--- a/packages/AI/Providers/Mistral/src/models/mistral.ts
+++ b/packages/AI/Providers/Mistral/src/models/mistral.ts
@@ -18,7 +18,8 @@ export class MistralLLM extends BaseLLM {
         const chatResponse = await this.client.chat({
             model: params.model,
             messages: params.messages, 
-            max_tokens: params.maxOutputTokens
+            max_tokens: params.maxOutputTokens,
+            response_format: params.responseFormat
         });
         const endTime = new Date();
 

--- a/packages/AI/Providers/OpenAI/src/models/openAI.ts
+++ b/packages/AI/Providers/OpenAI/src/models/openAI.ts
@@ -35,7 +35,8 @@ export class OpenAILLM extends BaseLLM {
             model: params.model,
             messages: messages,
             temperature: params.temperature,
-            max_tokens: params.maxOutputTokens
+            max_tokens: params.maxOutputTokens,
+            response_format: params.responseFormat
         });
         const endTime = new Date();
         const timeElapsed = endTime.getTime() - startTime.getTime();


### PR DESCRIPTION
Adds a `responseFormat` param to the BaseParams class in the AI Core package. Also updates all applicable LLM packages to use this param.

Only tested OpenAI, Groq and Mistral as I only have API keys for those