### PR TITLE
v2.23.1

### DIFF
--- a/.changeset/cool-points-smile.md
+++ b/.changeset/cool-points-smile.md
@@ -1,0 +1,5 @@
+---
+"@memberjunction/server": patch
+---
+
+Auto detect changes to data via SyncData/SyncUsersAndRoles and auto refresh the respective cache

--- a/docker/MJAPI/docker.config.cjs
+++ b/docker/MJAPI/docker.config.cjs
@@ -169,7 +169,9 @@ const mjServerConfig = {
   databaseSettings: {
     connectionTimeout: 45000,
     requestTimeout: 30000,
-    metadataCacheRefreshInterval: Number(process.env.METADATA_CACHE_REFRESH_INTERVAL) ?? 180000,
+    metadataCacheRefreshInterval: isFinite(Number(process.env.METADATA_CACHE_REFRESH_INTERVAL))
+      ? Number(process.env.METADATA_CACHE_REFRESH_INTERVAL)
+      : 180000,
   },
   viewingSystem: {
     enableSmartFilters: true,

--- a/mj.config.cjs
+++ b/mj.config.cjs
@@ -212,7 +212,9 @@ const mjServerConfig = {
   databaseSettings: {
     connectionTimeout: 45000,
     requestTimeout: 30000,
-    metadataCacheRefreshInterval: Number(process.env.METADATA_CACHE_REFRESH_INTERVAL) ?? 180000,
+    metadataCacheRefreshInterval: isFinite(Number(process.env.METADATA_CACHE_REFRESH_INTERVAL))
+      ? Number(process.env.METADATA_CACHE_REFRESH_INTERVAL)
+      : 180000,
   },
   viewingSystem: {
     enableSmartFilters: true,


### PR DESCRIPTION
- **Auto detect changes to users/roles and update UserCache and auto-detect changes to Metadata object via SyncData and refresh Metadata().**
- **docs(changeset): Auto detect changes to data via SyncData/SyncUsersAndRoles and auto refresh the respective cache**
- **Ensure metadataCacheRefreshInterval defaults to 180000 if not a finite number**
