### PR TITLE
v2.26.0

### DIFF
--- a/.changeset/big-worms-cheer.md
+++ b/.changeset/big-worms-cheer.md
@@ -1,0 +1,10 @@
+---
+"@memberjunction/codegen-lib": minor
+"@memberjunction/core": minor
+"@memberjunction/data-context": minor
+"@memberjunction/data-context-server": minor
+"@memberjunction/server": minor
+"@memberjunction/sqlserver-dataprovider": minor
+---
+
+Changes to use of TransactionGroup to use await at all times.Fixed up some metadata bugs in the \_\_mj schema that somehow existed from prior builds.Cleaned up SQL Server Data Provider handling of virtual fields in track record changesFixed CodeGen to not emit null wrapped as a string that was happening in some casesHardened MJCore.BaseEntity to treat a string with the word null in it as same as a true null value (in case someone throws that into the DB)

--- a/.changeset/few-dryers-prove.md
+++ b/.changeset/few-dryers-prove.md
@@ -1,0 +1,5 @@
+---
+"@memberjunction/server": patch
+---
+
+logging for cloud events

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -20,28 +20,31 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
-  # test-migrations:
-  #   runs-on: ubuntu-latest
-  #   steps:
-  #     - name: Checkout repo
-  #       uses: actions/checkout@v4
+  test-migrations:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v4
 
-  #     - name: Create SQL Server container
-  #       run: docker run --rm -d -e "ACCEPT_EULA=Y" -e "MSSQL_SA_PASSWORD=VeryStr0ngP@ssw0rd" -p 1433:1433 mcr.microsoft.com/mssql/server:2022-latest
+      - name: Create SQL Server container
+        run: docker run --rm -d -e "ACCEPT_EULA=Y" -e "MSSQL_SA_PASSWORD=VeryStr0ngP@ssw0rd" -p 1433:1433 mcr.microsoft.com/mssql/server:2022-latest
 
-  #     - name: Install MJ CLI globally
-  #       run: npm install --global @memberjunction/cli
+      - name: Create SQL database
+        run: docker run -it --rm --network host mcr.microsoft.com/mssql-tools /opt/mssql-tools/bin/sqlcmd -S localhost -U SA -P 'VeryStr0ngP@ssw0rd' -Q "CREATE DATABASE [test];"
 
-  #     - name: Run mj migrate locally
-  #       run: mj migrate
-  #       env:
-  #         DB_HOST: localhost
-  #         DB_DATABASE: master
-  #         DB_USERNAME: sa
-  #         DB_PASSWORD: VeryStr0ngP@ssw0rd
-  #         CODEGEN_DB_USERNAME: sa
-  #         CODEGEN_DB_PASSWORD: VeryStr0ngP@ssw0rd
-  #         DB_TRUST_SERVER_CERTIFICATE: Y
+      - name: Install MJ CLI globally
+        run: npm install --global @memberjunction/cli
+
+      - name: Run mj migrate locally
+        run: mj migrate
+        env:
+          DB_HOST: localhost
+          DB_DATABASE: test
+          DB_USERNAME: sa
+          DB_PASSWORD: VeryStr0ngP@ssw0rd
+          CODEGEN_DB_USERNAME: sa
+          CODEGEN_DB_PASSWORD: VeryStr0ngP@ssw0rd
+          DB_TRUST_SERVER_CERTIFICATE: Y
 
   build-and-publish:
     name: Build and publish new versions of NPM packages

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -31,7 +31,8 @@
       "sourceMaps": true,
       "webRoot": "${workspaceFolder}/packages",
       "sourceMapPathOverrides": {
-        "webpack:///./src/*": "${workspaceFolder}/packages/MJExplorer/src/*"
+        "webpack:///./src/*": "${workspaceFolder}/packages/MJExplorer/src/*",
+        "../src/*": "${workspaceFolder}/packages/GraphQLDataProvider/src/*"
       }
     },
     {

--- a/migrations/v2/V202502171733__v2.26.x_FIX_NULL_DEFAULTS.sql
+++ b/migrations/v2/V202502171733__v2.26.x_FIX_NULL_DEFAULTS.sql
@@ -1,0 +1,19 @@
+--prior versions of CodeGen emitted nulls wrapped in quotes instead of as a literal null. This migration corrects that. and the code has also been
+--updated to not emit the quotes around nulls. This migration will remove the quotes from the DefaultValue column in the EntityField table.
+UPDATE ${flyway:defaultSchema}.EntityField SET DefaultValue=NULL WHERE DefaultValue='NULL';
+
+-- add Skip to the AIAgent table
+INSERT INTO ${flyway:defaultSchema}.AIAgent (ID, Name, Description, LogoURL) 
+VALUES ('CC7A433E-F36B-1410-8D98-00021F8B792E', 'Skip','Skip AI Data Analyst by MemberJunction','https://askskip.ai/hubfs/SkipFavicon.png')
+
+-- FIX UP SOME ERRONEOUS SEQUENCES IN THE ENTITYFIELD TABLE FOR THE USER NOTIFICATIONS TABLE
+UPDATE ${flyway:defaultSchema}.EntityField 
+  SET 
+    Sequence=12,
+    Type='uniqueidentifier', Length=16, Precision=0 -- these fields were still INT/4/10 for some reason, OLD metadata that never got refreshed... 
+  WHERE 
+    ID='594F17F0-6F36-EF11-86D4-6045BDEE16E6' -- User Notifications.ResourceRecordID
+
+UPDATE ${flyway:defaultSchema}.EntityField SET Sequence=13 WHERE ID='6F4317F0-6F36-EF11-86D4-6045BDEE16E6' -- User Notifications.User
+UPDATE ${flyway:defaultSchema}.EntityField SET Sequence=14 WHERE ID='F1A8FEEC-7840-EF11-86C3-00224821D189' -- User Notifications.ResourceType
+UPDATE ${flyway:defaultSchema}.EntityField SET Sequence=Sequence-1 WHERE Sequence>=7 AND EntityID='14248F34-2837-EF11-86D4-6045BDEE16E6' -- now, downshift all of the User Notificaiton Sequences for the empty spot for having moved ResourceRecordID

--- a/packages/Actions/Engine/src/generic/ActionEntity.server.ts
+++ b/packages/Actions/Engine/src/generic/ActionEntity.server.ts
@@ -106,7 +106,7 @@ export class ActionEntityServerEntity extends ActionEntityExtended {
                 newLib.LibraryID = libMetadata.ID;
                 newLib.ItemsUsed = lib.ItemsUsed.join(',');
                 newLib.TransactionGroup = tg;
-                newLib.Save(); // no await, within a TG
+                await newLib.Save(); 
             }
         }
 
@@ -115,14 +115,14 @@ export class ActionEntityServerEntity extends ActionEntityExtended {
             const newCode = codeLibraries.find(l => l.LibraryName.trim().toLowerCase() === lib.Library.trim().toLowerCase());
             lib.ItemsUsed = newCode.ItemsUsed.join(',');
             lib.TransactionGroup = tg;
-            lib.Save(); // no await, within a TG
+            await lib.Save();  
         }
 
         // now remove the libraries that are no longer used
         for (const lib of librariesToRemove) {
             // each lib in this array iteration is already a BaseEntity derived object
             lib.TransactionGroup = tg;
-            lib.Delete(); // no await, within a TG
+            await lib.Delete();  
         }
 
         // now commit the transaction

--- a/packages/Angular/Explorer/ask-skip/src/lib/skip-chat-with-record/skip-chat-with-record.component.ts
+++ b/packages/Angular/Explorer/ask-skip/src/lib/skip-chat-with-record/skip-chat-with-record.component.ts
@@ -157,7 +157,7 @@ export class SkipChatWithRecordComponent implements AfterViewInit {
             for (const cd of result.Results) {
                 const cdE = <ConversationDetailEntity>cd;
                 cdE.TransactionGroup = tg;
-                cdE.Delete();  // dont await because inside a TG
+                await cdE.Delete();  
             }
             const convoEntity = await md.GetEntityObject<ConversationEntity>("Conversations");
             await convoEntity.Load(this._conversationId);
@@ -171,19 +171,19 @@ export class SkipChatWithRecordComponent implements AfterViewInit {
                 for (const dciEntity of resultDCI.Results) {
                     const dci = <DataContextItemEntity>dciEntity;
                     dci.TransactionGroup = tg;
-                    dci.Delete(); // dont await because inside a TG
+                    await dci.Delete();  
                 }
 
                 // now delete the data context itself
                 const dcEntity = await md.GetEntityObject<DataContextEntity>("Data Contexts");
                 await dcEntity.Load(convoEntity.DataContextID);
                 dcEntity.TransactionGroup = tg;
-                dcEntity.Delete(); // dont await because inside a TG
+                await dcEntity.Delete();  
             }
 
             // now delete the conversation itself
             convoEntity.TransactionGroup = tg;
-            convoEntity.Delete(); // dont await because inside a TG
+            await convoEntity.Delete();  
 
             await tg.Submit();
 

--- a/packages/Angular/Explorer/base-forms/src/lib/base-form-component.ts
+++ b/packages/Angular/Explorer/base-forms/src/lib/base-form-component.ts
@@ -461,7 +461,7 @@ export abstract class BaseFormComponent extends BaseRecordComponent implements A
             const md = new Metadata();
             const tg = await md.CreateTransactionGroup();
             this.record.TransactionGroup = tg;
-            this.record.Save(); // DO NOT USE await - trans group.submit() is where we await
+            await this.record.Save();  
 
             // now add to the rest of the pending records
             for (const x of this._pendingRecords) {

--- a/packages/Angular/Explorer/entity-permissions/src/lib/grid/entity-permissions-grid.component.ts
+++ b/packages/Angular/Explorer/entity-permissions/src/lib/grid/entity-permissions-grid.component.ts
@@ -151,13 +151,13 @@ export class EntityPermissionsGridComponent implements OnInit, OnChanges {
       const md = new Metadata();
       const tg = await md.CreateTransactionGroup();
       let itemCount: number = 0;
-      this.permissions.forEach(p => {
+      for (const p of this.permissions) {
         if (this.IsPermissionReallyDirty(p)) {
           p.TransactionGroup = tg;
           itemCount++;
-          p.Save(); // don't await since we are using a tg
+          await p.Save();  
         }
-      })
+      }
       if (itemCount > 0)
         await tg.Submit();
     }

--- a/packages/Angular/Explorer/explorer-core/src/lib/app-view/application-view.component.ts
+++ b/packages/Angular/Explorer/explorer-core/src/lib/app-view/application-view.component.ts
@@ -216,14 +216,14 @@ export class ApplicationViewComponent extends BaseBrowserComponent implements On
           }
           // finally, we need to submit a single transaction so we have one server round trip to commit all this good stuff
           const tg = await md.CreateTransactionGroup();
-          userAppEntitiesToSave.forEach(toSave => {
+          for (const toSave of userAppEntitiesToSave) {
             toSave.TransactionGroup = tg;
-            toSave.Save(); // no await since we are in a transaction group
-          })
-          userAppEntitiesToDelete.forEach(d => {
+            await toSave.Save();  
+          }
+          for (const d of userAppEntitiesToDelete) {
             d.TransactionGroup = tg;
-            d.Delete(); // no await 
-          })
+            await d.Delete();   
+          }
 
           if (!await tg.Submit()) {
             // the data doesn't need to be updated when we are succesful because we're all bound to the same data which is cool

--- a/packages/Angular/Explorer/explorer-core/src/lib/data-browser-component/data-browser.component.ts
+++ b/packages/Angular/Explorer/explorer-core/src/lib/data-browser-component/data-browser.component.ts
@@ -120,7 +120,7 @@ export class DataBrowserComponent extends BaseNavigationComponent {
       for (let index = 0; index < userAppsToSave.length; index++) {
         const ua = userAppsToSave[index];
         ua.TransactionGroup = tg;
-        ua.Save(); // no await since we are in a transaction group
+        await ua.Save();  
       }
       if (!await tg.Submit()) {
         // the data doesn't need to be updated when we are succesful because we're all bound to the same data which is cool

--- a/packages/Angular/Explorer/explorer-core/src/lib/navigation/navigation.component.ts
+++ b/packages/Angular/Explorer/explorer-core/src/lib/navigation/navigation.component.ts
@@ -930,7 +930,7 @@ export class NavigationComponent implements OnInit, OnDestroy, AfterViewInit {
       }
       else {
         entity.TransactionGroup = transGroup;
-        entity.Delete(); // no await here, we're in a transaction group so we don't want to block
+        await entity.Delete();  
       }
     }
   }

--- a/packages/Angular/Explorer/explorer-core/src/lib/user-notifications/user-notifications.component.ts
+++ b/packages/Angular/Explorer/explorer-core/src/lib/user-notifications/user-notifications.component.ts
@@ -183,7 +183,7 @@ export class UserNotificationsComponent implements AfterViewInit {
       // part of a transaction group, if so, add it as that will defer the actual network traffic/save
       if (transGroup) {
         notificationEntity.TransactionGroup = transGroup;
-        notificationEntity.Save() // no await when using a transaction group
+        await notificationEntity.Save()  
         return true;
       }
       else {
@@ -227,8 +227,7 @@ export class UserNotificationsComponent implements AfterViewInit {
     const conversationDetail = await md.GetEntityObject<ConversationDetailEntity>('Conversation Details');
     conversationDetail.Message = 'Test Message';
     conversationDetail.Role = 'User';
-    const fakeUUID = '00000000-0000-0000-0000-000000000000';
-    conversationDetail.ConversationID = 'x'; // fakeUUID; // must be non-null to pass validation, this will be replaced by the variable, since we're part of a TG, not a real save, so doesn't validate it as a true fkey
+    conversationDetail.ConversationID = 'x'; // fake UUID must be non-null to pass validation, this will be replaced by the variable, since we're part of a TG, not a real save, so doesn't validate it as a true fkey
     conversationDetail.TransactionGroup = transGroup;
     if (!await conversationDetail.Save()) {
       this.sharedService.CreateSimpleNotification('Unable to create conversation detail', 'error', 500);

--- a/packages/Angular/Explorer/explorer-settings/src/lib/application-entities-grid/application-entities-grid.component.ts
+++ b/packages/Angular/Explorer/explorer-settings/src/lib/application-entities-grid/application-entities-grid.component.ts
@@ -157,7 +157,7 @@ export class ApplicationEntitiesGridComponent implements OnInit, OnChanges {
     const md = new Metadata();
     const tg = await md.CreateTransactionGroup();
     let itemCount: number = 0;
-    this.rows.forEach(r => {
+    for (const r of this.rows) {
       if (this.IsReallyDirty(r)) {
         r.TransactionGroup = tg;
         itemCount++;
@@ -166,11 +166,12 @@ export class ApplicationEntitiesGridComponent implements OnInit, OnChanges {
         // if ur.Selected === false and we are in the database, we need to delete
         // otherwise, we need to save
         if (r.Selected)
-          r.Save(); 
+          await r.Save(); 
         else
-          r.Delete();  
+          await r.Delete();  
       }
-    })
+    }
+
     if (itemCount > 0) {
       if (await tg.Submit()) {
         // for any items in the above that were deleted, we would have had the ApplicationName/Application and Entity property wiped out so we need to go check to see if we have a null ID and if so, copy the values back in

--- a/packages/Angular/Explorer/explorer-settings/src/lib/user-roles-grid/user-roles-grid.component.ts
+++ b/packages/Angular/Explorer/explorer-settings/src/lib/user-roles-grid/user-roles-grid.component.ts
@@ -144,7 +144,7 @@ export class UserRolesGridComponent implements OnInit, OnChanges {
     const md = new Metadata();
     const tg = await md.CreateTransactionGroup();
     let itemCount: number = 0;
-    this.userRoles.forEach(ur => {
+    for (const ur of this.userRoles) {
       if (this.IsReallyDirty(ur)) {
         ur.TransactionGroup = tg;
         itemCount++;
@@ -153,11 +153,12 @@ export class UserRolesGridComponent implements OnInit, OnChanges {
         // if ur.Selected === false and we are in the database, we need to delete
         // otherwise, we need to save
         if (ur.Selected)
-          ur.Save(); 
+          await ur.Save(); 
         else
-          ur.Delete();  
+          await ur.Delete();  
       }
-    })
+    }
+
     if (itemCount > 0) {
       if (await tg.Submit()) {
         // for any items in the above that were deleted, we would have had the User property wiped out so we need to go check to see if we have a null ID and if so, copy the UserName back into the User property

--- a/packages/Angular/Generic/join-grid/src/lib/join-grid/join-grid.component.ts
+++ b/packages/Angular/Generic/join-grid/src/lib/join-grid/join-grid.component.ts
@@ -221,17 +221,18 @@ export class JoinGridComponent implements AfterViewInit {
     if (this.ColumnsMode === 'Entity') {
       let validated = true;
       const valErrors: ValidationErrorInfo[][] = [];
-      this._pendingDeletes.forEach(obj => {
+      for (const obj of this._pendingDeletes) {
         obj.TransactionGroup = tg;
-        obj.Delete();
-      });
-      this._pendingInserts.forEach(obj => {
+        await obj.Delete();
+      }
+      for (const obj of this._pendingInserts) {
         obj.TransactionGroup = tg;
         const valResult = obj.Validate()
         validated = validated && valResult.Success;
         valErrors.push(valResult.Errors);
-        obj.Save();
-      });
+        await obj.Save();
+      }
+
       if (validated) {
         if (!await tg.Submit()) {
           alert ('Error saving changes');
@@ -252,15 +253,18 @@ export class JoinGridComponent implements AfterViewInit {
       // in fields mode we use the _joinEntityData array to save the changes
       let validated = true;
       const valErrors: ValidationErrorInfo[][] = [];
-      this._joinEntityData?.forEach(obj => {
-        if (obj.Dirty) {
-          obj.TransactionGroup = tg;
-          const valResult = obj.Validate()
-          validated = validated && valResult.Success;
-          valErrors.push(valResult.Errors);
-          obj.Save();
+      if (this._joinEntityData) {
+        for (const obj of this._joinEntityData) {
+          if (obj.Dirty) {
+            obj.TransactionGroup = tg;
+            const valResult = obj.Validate()
+            validated = validated && valResult.Success;
+            valErrors.push(valResult.Errors);
+            await obj.Save();
+          }
         }
-      });
+      }
+
       if (validated) {
         if (!await tg.Submit()) {
           alert ('Error saving changes');

--- a/packages/Angular/Generic/resource-permissions/src/lib/resource-permissions.component.ts
+++ b/packages/Angular/Generic/resource-permissions/src/lib/resource-permissions.component.ts
@@ -199,7 +199,7 @@ export class ResourcePermissionsComponent extends BaseAngularComponent implement
       if (this._pendingDeletes.includes(permission)) {
         // don't save a permission record that is new, if it was also marked for deletion
         permission.TransactionGroup = tg;
-        if (!permission.Save()) { // no await on saves, use tg.Submit() below
+        if (!await permission.Save()) { 
           // validation errors come back here
           if (this.ShowUserErrorMessages)
             MJNotificationService.Instance.CreateSimpleNotification('Error saving permissions', 'error', 2500);
@@ -215,7 +215,7 @@ export class ResourcePermissionsComponent extends BaseAngularComponent implement
       // make sure not in the delete array
       if (!this._pendingDeletes.includes(permission)) {
         permission.TransactionGroup = tg;
-        if (!permission.Save()) { // no await on saves, use tg.Submit() below
+        if (!await permission.Save()) {  
           // validation errors come back here
           if (this.ShowUserErrorMessages)
             MJNotificationService.Instance.CreateSimpleNotification('Error saving permissions', 'error', 2500);

--- a/packages/Angular/Generic/skip-chat/src/lib/skip-chat/skip-chat.component.ts
+++ b/packages/Angular/Generic/skip-chat/src/lib/skip-chat/skip-chat.component.ts
@@ -1524,7 +1524,7 @@ export class SkipChatComponent extends BaseAngularComponent implements OnInit, A
           // check to see if it loaded succesfully or not, sometimes it is already deleted
           if (actualEntityObject.ConversationID === this.SelectedConversation.ID) {
             actualEntityObject.TransactionGroup = tg;
-            actualEntityObject.Delete(); // no await as we'll await the transaciton group below    
+            await actualEntityObject.Delete();  
           }
           else {
             // didn't load successfully, drop to console, possibly the record was already deleted, non-fatal

--- a/packages/MJAPI/No transactions to submit, switching status back to Pending
+++ b/packages/MJAPI/No transactions to submit, switching status back to Pending
@@ -1,0 +1,8 @@
+STATUS (Mon Feb 17 2025 17:42:54 GMT-0600 (Central Standard Time): TransactionGroupBase.Submit
+STATUS (Mon Feb 17 2025 18:09:36 GMT-0600 (Central Standard Time): TransactionGroupBase.Submit
+STATUS (Mon Feb 17 2025 18:10:48 GMT-0600 (Central Standard Time): TransactionGroupBase.Submit
+STATUS (Mon Feb 17 2025 18:12:06 GMT-0600 (Central Standard Time): TransactionGroupBase.Submit
+STATUS (Mon Feb 17 2025 18:27:46 GMT-0600 (Central Standard Time): TransactionGroupBase.Submit
+STATUS (Mon Feb 17 2025 18:36:17 GMT-0600 (Central Standard Time): TransactionGroupBase.Submit
+STATUS (Mon Feb 17 2025 18:36:47 GMT-0600 (Central Standard Time): TransactionGroupBase.Submit
+STATUS (Mon Feb 17 2025 18:37:21 GMT-0600 (Central Standard Time): TransactionGroupBase.Submit

--- a/packages/MJCore/src/generic/baseEntity.ts
+++ b/packages/MJCore/src/generic/baseEntity.ts
@@ -197,7 +197,12 @@ export class EntityField {
             }
             else if (fieldInfo.TSType === EntityFieldTSType.Number) {
                 // special handling for numbers as we don't want a string passed into a value for a numeric field
-                this.Value = Number(fieldInfo.DefaultValue);
+                if (!isNaN(Number(fieldInfo.DefaultValue))) {
+                    this.Value = Number(fieldInfo.DefaultValue);
+                }
+                else if (fieldInfo.DefaultValue.trim().toLowerCase() === "null") {
+                    this.Value = null;
+                }
             }
             else if (fieldInfo.Type.trim().toLowerCase() === "uniqueidentifier") {
                 // special handling for GUIDs, we don't want to populate anything here because the server always sets the value, leave blank

--- a/packages/MJDataContext/src/types.ts
+++ b/packages/MJDataContext/src/types.ts
@@ -664,7 +664,7 @@ export class DataContext {
                     dciEntity.DataJSON = null; //JSON.stringify(item.Data); 
 
                 dciEntity.TransactionGroup = tg;
-                dciEntity.Save() // no await because we are part of a transaction group
+                await dciEntity.Save()  
             }          
             const result = await tg.Submit();
             if (result) {
@@ -796,7 +796,7 @@ export class DataContext {
                         newItem.DataJSON = null; // if we aren't including the data, we need to clear it out
 
                     newItem.TransactionGroup = tg;
-                    newItem.Save(); // no await because we are part of a transaction group
+                    await newItem.Save();  
                 }
                 const result = await tg.Submit();
                 if (!result)

--- a/packages/MJServer/src/resolvers/SyncRolesUsersResolver.ts
+++ b/packages/MJServer/src/resolvers/SyncRolesUsersResolver.ts
@@ -154,7 +154,7 @@ export class SyncRolesAndUsersResolver {
             const currentRole = currentRoles.find(r => r.Name.trim().toLowerCase() === update.Name.trim().toLowerCase());
             if (currentRole) {
                 currentRole.Description = update.Description;
-                ok = ok && await currentRole.Save(); // no await, we do that with submit below
+                ok = ok && await currentRole.Save();  
             }
         }
         return { Success: ok };
@@ -170,7 +170,7 @@ export class SyncRolesAndUsersResolver {
                 const role = await md.GetEntityObject<RoleEntity>("Roles", user);
                 role.Name = add.Name;
                 role.Description = add.Description;
-                ok = ok && await role.Save(); // no await, we do that with submit below
+                ok = ok && await role.Save();  
             }
         }
         return ok;
@@ -384,7 +384,7 @@ export class SyncRolesAndUsersResolver {
                                 const ur = await md.GetEntityObject<UserRoleEntity>("User Roles", u);
                                 ur.UserID = dbUser.ID;
                                 ur.RoleID = dbRole.ID;
-                                ok = ok && await ur.Save(); // no await, we do that with submit below
+                                ok = ok && await ur.Save();  
                             }
                         }
                     }

--- a/packages/SQLServerDataProvider/src/SQLServerDataProvider.ts
+++ b/packages/SQLServerDataProvider/src/SQLServerDataProvider.ts
@@ -1528,7 +1528,7 @@ export class SQLServerDataProvider
     for (let i = 0; i < entityInfo.Fields.length; i++) {
       const f = entityInfo.Fields[i];
       if (outputCount !== 0) sRet += ',\n';
-      sRet += '[' + f.Name + '] ' + f.SQLFullType + ' ' + (f.AllowsNull ? 'NULL' : 'NOT NULL');
+      sRet += '[' + f.Name + '] ' + f.SQLFullType + ' ' + (f.AllowsNull || f.IsVirtual? 'NULL' : 'NOT NULL');
       outputCount++;
     }
     return sRet;


### PR DESCRIPTION
- **Update GitHub Actions workflow for SQL migrations and enhance VSCode launch configuration**
- **additional logging for debugging cloud events problem**
- **docs(changeset): logging for cloud events**
- **Changes to use of TransactionGroup to use await at all times.**
- **docs(changeset): Changes to use of TransactionGroup to use await at all times.Fixed up some metadata bugs in the __mj schema that somehow existed from prior builds.Cleaned up SQL Server Data Provider handling of virtual fields in track record changesFixed CodeGen to not emit null wrapped as a string that was happening in some casesHardened MJCore.BaseEntity to treat a string with the word null in it as same as a true null value (in case someone throws that into the DB)**
