### PR TITLE
Update actionengine

### DIFF
--- a/.changeset/khaki-penguins-relate.md
+++ b/.changeset/khaki-penguins-relate.md
@@ -1,0 +1,5 @@
+---
+"@memberjunction/actions": patch
+---
+
+Ensure ActionEngineServer instance returns correct instance

--- a/packages/Actions/Engine/src/generic/ActionEngine.ts
+++ b/packages/Actions/Engine/src/generic/ActionEngine.ts
@@ -14,7 +14,7 @@ import { ActionEngineBase, ActionResult, RunActionParams } from "@memberjunction
 export class ActionEngineServer extends ActionEngineBase {
 
    public static get Instance(): ActionEngineServer {
-      return <ActionEngineServer>super.Instance;
+      return super.getInstance<ActionEngineServer>("ActionEngineServer");
    }
 
     public async RunAction(params: RunActionParams): Promise<ActionResult> {


### PR DESCRIPTION
This PR addresses an edge case where invoking `ActionEngineBase.Instance` before invoking `ActionEngineServer.Instance` causes the latter to always return a class of the former's type, losing the ability to run actions. 
Couple screenshots that showcases the issue:

![image](https://github.com/user-attachments/assets/bf3c027b-fc3f-46ed-a9ce-7b2868641077)
![image](https://github.com/user-attachments/assets/75520169-cb3c-4e2b-9367-ba26dc473a0e)
![image](https://github.com/user-attachments/assets/35d50617-7170-4cdf-bca8-b59758421de1)
