### PR TITLE
Add ability to CC and BCC recipients when sending a message, forwarding and replying to a message

### DIFF
--- a/.changeset/large-tomatoes-doubt.md
+++ b/.changeset/large-tomatoes-doubt.md
@@ -1,0 +1,7 @@
+---
+"@memberjunction/communication-types": patch
+"@memberjunction/communication-ms-graph": patch
+"@memberjunction/communication-sendgrid": patch
+---
+
+Add CC and BCC fields to Message class

--- a/packages/Communication/base-types/src/BaseProvider.ts
+++ b/packages/Communication/base-types/src/BaseProvider.ts
@@ -51,6 +51,16 @@ export class Message {
     public To: string;
 
     /**
+     * Recipients to send a copy of the message to, typically an email address
+     */
+    public CCRecipients?: string[];
+
+    /**
+     * Recipients to send a copy of the message to without revealing their email addresses to the other recipients, typically an email address
+     */
+    public BCCRecipients?: string[];
+
+    /**
      * The date and time to send the message, if not provided the message will be sent immediately
      */
     public SendAt?: Date;
@@ -193,10 +203,17 @@ export type ForwardMessageParams = {
     /*
     * The recipients to forward the message to
     */
-    ToRecipients: {
-        Name: string,
-        Address: string;
-    }[];
+    ToRecipients: string[];
+
+    /*
+    * The recipients to send a copy of the forwarded message to
+    */
+    CCRecipients?: string[];
+
+    /*
+    * The recipients to send a blind copy of the forwarded message to
+    */
+    BCCRecipients?: string[];
 };
 
 export type ForwardMessageResult<T = Record<string, any>> = BaseMessageResult & {

--- a/packages/Communication/providers/MSGraph/src/MSGraphProvider.ts
+++ b/packages/Communication/providers/MSGraph/src/MSGraphProvider.ts
@@ -56,30 +56,24 @@ export class MSGraphProvider extends BaseCommunicationProvider{
                             address: message.To
                             }
                         }
-                    ]
+                    ],
+                    ccRecipients: message.CCRecipients?.map((recipient) => {
+                        return {
+                            emailAddress: {
+                                address: recipient
+                            }
+                        };
+                    }),
+                    bccRecipients: message.BCCRecipients?.map((recipient) => {
+                        return {
+                            emailAddress: {
+                                address: recipient
+                            }
+                        };
+                    })
                 },
                 saveToSentItems: 'false'
             };
-
-            if(message.CCRecipients){
-                sendMail.message.ccRecipients = message.CCRecipients.map((ccRecipient: string) => {
-                    return {
-                            emailAddress: {
-                            address: ccRecipient
-                        }
-                    };
-                });
-            }
-
-            if(message.BCCRecipients){
-                sendMail.message.bccRecipients = message.BCCRecipients.map((bccRecipient: string) => {
-                    return {
-                            emailAddress: {
-                            address: bccRecipient
-                        }
-                    };
-                });
-            }
     
             const sendMessagePath: string = `${Auth.ApiConfig.uri}/${user.id}/sendMail`;
             await Auth.GraphClient.api(sendMessagePath).post(sendMail);

--- a/packages/Communication/providers/MSGraph/src/MSGraphProvider.ts
+++ b/packages/Communication/providers/MSGraph/src/MSGraphProvider.ts
@@ -43,7 +43,7 @@ export class MSGraphProvider extends BaseCommunicationProvider{
                 };
             }
     
-            const sendMail = {
+            const sendMail: Record<string, any> = {
                 message: {
                     subject: message.Subject,
                     body: {
@@ -60,6 +60,26 @@ export class MSGraphProvider extends BaseCommunicationProvider{
                 },
                 saveToSentItems: 'false'
             };
+
+            if(message.CCRecipients){
+                sendMail.message.ccRecipients = message.CCRecipients.map((ccRecipient: string) => {
+                    return {
+                            emailAddress: {
+                            address: ccRecipient
+                        }
+                    };
+                });
+            }
+
+            if(message.BCCRecipients){
+                sendMail.message.bccRecipients = message.BCCRecipients.map((bccRecipient: string) => {
+                    return {
+                            emailAddress: {
+                            address: bccRecipient
+                        }
+                    };
+                });
+            }
     
             const sendMessagePath: string = `${Auth.ApiConfig.uri}/${user.id}/sendMail`;
             await Auth.GraphClient.api(sendMessagePath).post(sendMail);
@@ -90,7 +110,7 @@ export class MSGraphProvider extends BaseCommunicationProvider{
                 };
             }
 
-            const reply = {
+            let reply: Record<string, any> = {
                 message: {
                     toRecipients: [
                         {
@@ -98,7 +118,21 @@ export class MSGraphProvider extends BaseCommunicationProvider{
                                 address: params.Message.To
                             }
                         }
-                    ]
+                    ],
+                    ccRecipients: params.Message.CCRecipients?.map((recipient) => {
+                        return {
+                            emailAddress: {
+                                address: recipient
+                            }
+                        };
+                    }),
+                    bccRecipients: params.Message.BCCRecipients?.map((recipient) => {
+                        return {
+                            emailAddress: {
+                                address: recipient
+                            }
+                        };
+                    })
                 },
                 comment: params.Message.ProcessedBody || params.Message.ProcessedHTMLBody
             };
@@ -204,13 +238,26 @@ export class MSGraphProvider extends BaseCommunicationProvider{
                 }
             }
 
-            const forward = {
+            const forward: Record<string, any> = {
                 comment: params.Message,
                 toRecipients: params.ToRecipients.map((recipient) => {
                     return {
                         emailAddress: {
-                            name: recipient.Name,
-                            address: recipient.Address
+                            address: recipient
+                        }
+                    };
+                }),
+                ccRecipients: params.CCRecipients?.map((recipient) => {
+                    return {
+                        emailAddress: {
+                            address: recipient
+                        }
+                    };
+                }),
+                bccRecipients: params.BCCRecipients?.map((recipient) => {
+                    return {
+                        emailAddress: {
+                            address: recipient
                         }
                     };
                 })

--- a/packages/Communication/providers/sendgrid/src/SendGridProvider.ts
+++ b/packages/Communication/providers/sendgrid/src/SendGridProvider.ts
@@ -23,6 +23,8 @@ export class SendGridProvider extends BaseCommunicationProvider {
                 email: from,
                 name: message.FromName
             },
+            cc: message.CCRecipients,
+            bcc: message.BCCRecipients,
             subject: message.ProcessedSubject,
             text: message.ProcessedBody,
             html: message.ProcessedHTMLBody,


### PR DESCRIPTION
This PR updates the communication providers to support CC'ing and BCC'ing multiple recipients. This came from Izzy requiring this functionality. 

This PR also changes the `ToRecipients` field on the ForwardMessageParams type from an object to a list of strings. The former was too specific to MS Graph. 

Screenshot showcasing CC'ing multiple recipients working: 
![image](https://github.com/user-attachments/assets/36302de0-fbf3-414f-850c-d0c8d00b5e91)
