### PR TITLE
v2.31.0

### DIFF
--- a/.changeset/big-peas-develop.md
+++ b/.changeset/big-peas-develop.md
@@ -1,0 +1,6 @@
+---
+"@memberjunction/ng-skip-chat": patch
+"@memberjunction/skip-types": patch
+---
+
+Added UpdateUserState to event raising options for HTML Components we host for Skip generated HTML components.

--- a/.changeset/chilly-dancers-act.md
+++ b/.changeset/chilly-dancers-act.md
@@ -1,0 +1,6 @@
+---
+"@memberjunction/aiengine": patch
+"@memberjunction/ai-mcp-server": patch
+---
+
+First version of MCP server for MJ and removed unneeded file from AIEngine project

--- a/.changeset/forty-scissors-roll.md
+++ b/.changeset/forty-scissors-roll.md
@@ -1,0 +1,6 @@
+---
+"@memberjunction/ng-skip-chat": patch
+"@memberjunction/skip-types": patch
+---
+
+Prepare for HTML Report Type

--- a/.changeset/kind-poets-poke.md
+++ b/.changeset/kind-poets-poke.md
@@ -1,0 +1,5 @@
+---
+"@memberjunction/ai-mcp-server": patch
+---
+
+Clean up tool naming to support Claude Desktop stricter naming requriements - no spaces

--- a/.changeset/large-tomatoes-doubt.md
+++ b/.changeset/large-tomatoes-doubt.md
@@ -1,0 +1,7 @@
+---
+"@memberjunction/communication-types": patch
+"@memberjunction/communication-ms-graph": patch
+"@memberjunction/communication-sendgrid": patch
+---
+
+Add CC and BCC fields to Message class

--- a/.changeset/late-apricots-rhyme.md
+++ b/.changeset/late-apricots-rhyme.md
@@ -1,0 +1,5 @@
+---
+"@memberjunction/ai-mcp-server": patch
+---
+
+Stubbed out Action Tools code

--- a/.changeset/rude-wombats-retire.md
+++ b/.changeset/rude-wombats-retire.md
@@ -1,0 +1,7 @@
+---
+"@memberjunction/ng-skip-chat": minor
+"@memberjunction/codegen-lib": minor
+"@memberjunction/server": minor
+---
+
+Added new metadata for Report Versions and Report User States, added plumbing for them and various bug fixes

--- a/.changeset/ten-snails-pump.md
+++ b/.changeset/ten-snails-pump.md
@@ -1,0 +1,5 @@
+---
+"@memberjunction/codegen-lib": patch
+---
+
+Update Entity Types to output correct nullable types

--- a/.changeset/tender-ants-pay.md
+++ b/.changeset/tender-ants-pay.md
@@ -1,0 +1,5 @@
+---
+"@memberjunction/templates": patch
+---
+
+Support for simple template rendering where templates are not stored in the database.

--- a/.changeset/young-chicken-trade.md
+++ b/.changeset/young-chicken-trade.md
@@ -1,0 +1,10 @@
+---
+"@memberjunction/ng-skip-chat": patch
+"@memberjunction/graphql-dataprovider": patch
+"@memberjunction/data-context": patch
+"@memberjunction/data-context-server": patch
+"@memberjunction/server": patch
+"@memberjunction/skip-types": patch
+---
+
+SkipTypes - further cleanup to normalize for HTML Report that won't use a sub process

--- a/.gitignore
+++ b/.gitignore
@@ -116,3 +116,4 @@ packages/MJAPI/.env-remote
 mj.config.js
 mj.config.ts
 *.local
+packages/AI/MCPServer/build/Server.js

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -4,6 +4,19 @@
     {
       "type": "node",
       "request": "launch",
+      "name": "MCPServer",
+      "cwd": "${workspaceFolder}/packages/AI/MCPServer",
+      "preLaunchTask": "build-mcp-server",
+      "program": "${workspaceFolder}/packages/AI/MCPServer/dist/index.js",
+      "outFiles": ["${workspaceFolder}/packages/AI/MCPServer/dist/**/*.js"],
+      "sourceMaps": true,
+      "smartStep": true,
+      "console": "integratedTerminal",
+      "skipFiles": ["${workspaceFolder}/node_modules/**/*.js", "<node_internals>/**"]
+    },
+    {
+      "type": "node",
+      "request": "launch",
       "name": "Scheduled Actions Server",
       "envFile": "${workspaceFolder}/packages/Actions/ScheduledActionsServer/.env",
       "cwd": "${workspaceFolder}/packages/Actions/ScheduledActionsServer",

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -31,6 +31,18 @@
           }
         }
       }
+    },
+    {
+      "label": "build-mcp-server",
+      "type": "npm",
+      "script": "build",
+      "path": "packages/AI/MCPServer",
+      "group": "build",
+      "problemMatcher": ["$tsc"],
+      "presentation": {
+        "reveal": "silent",
+        "panel": "shared"
+      }
     }
   ]
 }

--- a/migrations/v2/V202503180119__v2.31.x_Unique_Action_Names.sql
+++ b/migrations/v2/V202503180119__v2.31.x_Unique_Action_Names.sql
@@ -1,0 +1,29 @@
+/*
+Prevent Actions from having the same name
+If you have two distinct actions with the same name, 
+there's nothing to ensure the intended action gets executed at runtime. 
+Because we pass in the action entity's name into the class factory function 
+to instantiate the action class.  
+*/
+ALTER TABLE [${flyway:defaultSchema}].[Action]
+ADD UNIQUE(Name);
+
+/*
+prevent Action Params from having the same name for a given Action
+Similarly with action params, whenever we attempt to look for a parameter, 
+we usually tend to look for them by name. Its possible for two params with different 
+value types to share the same name, resulting in different, outcomes of the action
+the user may not intended
+*/
+ALTER TABLE [${flyway:defaultSchema}].[ActionParam]
+ADD UNIQUE(Name, ActionID);
+
+/*
+Prevent an action param from having multiple scheduled action params tied to it 
+If multiple scheduled action params are defined for a single action param, it may not be 
+clear which scheduled aciton param gets selected at run time to execute a scheduled action.
+The scheduled action params may have different values which could affect the outcome of the
+scheduled action. 
+*/
+ALTER TABLE [${flyway:defaultSchema}].[ScheduledActionParam]
+ADD UNIQUE(ScheduledActionID, ActionParamID);

--- a/migrations/v2/V202504011929__v2.31.x_Report_User_State_and_Versions.sql
+++ b/migrations/v2/V202504011929__v2.31.x_Report_User_State_and_Versions.sql
@@ -1,0 +1,2441 @@
+CREATE TABLE [${flyway:defaultSchema}].[ReportVersion](
+    [ID] [uniqueidentifier] NOT NULL DEFAULT (newsequentialid()),
+    [ReportID] [uniqueidentifier] NOT NULL,
+    [VersionNumber] [int] NOT NULL,
+    [Name] [nvarchar](255) NOT NULL,
+    [Description] [nvarchar](max) NULL,
+    [Configuration] [nvarchar](max) NULL,
+    [DataContextUpdated] [bit] NOT NULL DEFAULT (0),
+    CONSTRAINT [PK_ReportVersion_ID] PRIMARY KEY CLUSTERED 
+    (
+        [ID] ASC
+    ),
+    CONSTRAINT [FK_ReportVersion_Report] FOREIGN KEY([ReportID]) REFERENCES [${flyway:defaultSchema}].[Report] ([ID]),
+    CONSTRAINT [UQ_ReportVersion_ReportID_VersionNumber] UNIQUE ([ReportID], [VersionNumber]),
+    CONSTRAINT [CK_ReportVersion_VersionNumber] CHECK ([VersionNumber] > 0)
+) 
+GO
+
+
+-- Table level extended property
+EXEC sp_addextendedproperty @name = N'MS_Description', 
+    @value = N'Stores iterations of report logic, structure, and layout changes', 
+    @level0type = N'SCHEMA', @level0name = N'${flyway:defaultSchema}', 
+    @level1type = N'TABLE', @level1name = N'ReportVersion'
+GO
+
+-- Column level extended properties
+EXEC sp_addextendedproperty @name = N'MS_Description', 
+    @value = N'Report version number, sequential per report starting at 1', 
+    @level0type = N'SCHEMA', @level0name = N'${flyway:defaultSchema}', 
+    @level1type = N'TABLE', @level1name = N'ReportVersion',
+    @level2type = N'COLUMN', @level2name = N'VersionNumber'
+GO
+
+EXEC sp_addextendedproperty @name = N'MS_Description', 
+    @value = N'Name of this report version', 
+    @level0type = N'SCHEMA', @level0name = N'${flyway:defaultSchema}', 
+    @level1type = N'TABLE', @level1name = N'ReportVersion',
+    @level2type = N'COLUMN', @level2name = N'Name'
+GO
+
+EXEC sp_addextendedproperty @name = N'MS_Description', 
+    @value = N'Description of this report version', 
+    @level0type = N'SCHEMA', @level0name = N'${flyway:defaultSchema}', 
+    @level1type = N'TABLE', @level1name = N'ReportVersion',
+    @level2type = N'COLUMN', @level2name = N'Description'
+GO
+
+EXEC sp_addextendedproperty @name = N'MS_Description', 
+    @value = N'JSON configuration of report structure, layout and logic', 
+    @level0type = N'SCHEMA', @level0name = N'${flyway:defaultSchema}', 
+    @level1type = N'TABLE', @level1name = N'ReportVersion',
+    @level2type = N'COLUMN', @level2name = N'Configuration'
+GO
+
+EXEC sp_addextendedproperty @name = N'MS_Description', 
+    @value = N'Indicates if the data context was updated in this version', 
+    @level0type = N'SCHEMA', @level0name = N'${flyway:defaultSchema}', 
+    @level1type = N'TABLE', @level1name = N'ReportVersion',
+    @level2type = N'COLUMN', @level2name = N'DataContextUpdated'
+GO
+
+
+CREATE TABLE [${flyway:defaultSchema}].[ReportUserState](
+    [ID] [uniqueidentifier] NOT NULL DEFAULT (newsequentialid()),
+    [ReportID] [uniqueidentifier] NOT NULL,
+    [UserID] [uniqueidentifier] NOT NULL,
+    [ReportState] [nvarchar](max) NULL,
+    CONSTRAINT [PK_ReportUserState_ID] PRIMARY KEY CLUSTERED 
+    (
+        [ID] ASC
+    ),
+    CONSTRAINT [FK_ReportUserState_Report] FOREIGN KEY([ReportID]) REFERENCES [${flyway:defaultSchema}].[Report] ([ID]),
+    CONSTRAINT [FK_ReportUserState_User] FOREIGN KEY([UserID]) REFERENCES [${flyway:defaultSchema}].[User] ([ID]),
+    CONSTRAINT [UQ_ReportUserState_ReportID_UserID] UNIQUE ([ReportID], [UserID])
+)  
+GO
+
+-- Table level extended property
+EXEC sp_addextendedproperty @name = N'MS_Description', 
+    @value = N'Tracks individual user state within interactive reports', 
+    @level0type = N'SCHEMA', @level0name = N'${flyway:defaultSchema}', 
+    @level1type = N'TABLE', @level1name = N'ReportUserState'
+GO
+
+-- Column level extended property
+EXEC sp_addextendedproperty @name = N'MS_Description', 
+    @value = N'JSON serialized state of user interaction with the report', 
+    @level0type = N'SCHEMA', @level0name = N'${flyway:defaultSchema}', 
+    @level1type = N'TABLE', @level1name = N'ReportUserState',
+    @level2type = N'COLUMN', @level2name = N'ReportState'
+GO
+
+
+----- CODE GENERATION -----
+/* SQL generated to create new entity MJ: Report Versions */
+
+      INSERT INTO [${flyway:defaultSchema}].Entity (
+         ID,
+         Name,
+         Description,
+         NameSuffix,
+         BaseTable,
+         BaseView,
+         SchemaName,
+         IncludeInAPI,
+         AllowUserSearchAPI
+         , TrackRecordChanges
+         , AuditRecordAccess
+         , AuditViewRuns
+         , AllowAllRowsAPI
+         , AllowCreateAPI
+         , AllowUpdateAPI
+         , AllowDeleteAPI
+         , UserViewMaxRows
+      )
+      VALUES (
+         '9516058d-9729-48ec-b0b8-e91a8221fc8f',
+         'MJ: Report Versions',
+         NULL,
+         NULL,
+         'ReportVersion',
+         'vwReportVersions',
+         '${flyway:defaultSchema}',
+         1,
+         0
+         , 1
+         , 0
+         , 0
+         , 0
+         , 1
+         , 1
+         , 1
+         , 1000
+      )
+   
+
+/* SQL generated to add new permission for entity MJ: Report Versions for role UI */
+INSERT INTO ${flyway:defaultSchema}.EntityPermission
+                                                   (EntityID, RoleID, CanRead, CanCreate, CanUpdate, CanDelete) VALUES
+                                                   ('9516058d-9729-48ec-b0b8-e91a8221fc8f', 'E0AFCCEC-6A37-EF11-86D4-000D3A4E707E', 1, 0, 0, 0)
+
+/* SQL generated to add new permission for entity MJ: Report Versions for role Developer */
+INSERT INTO ${flyway:defaultSchema}.EntityPermission
+                                                   (EntityID, RoleID, CanRead, CanCreate, CanUpdate, CanDelete) VALUES
+                                                   ('9516058d-9729-48ec-b0b8-e91a8221fc8f', 'DEAFCCEC-6A37-EF11-86D4-000D3A4E707E', 1, 1, 1, 0)
+
+/* SQL generated to add new permission for entity MJ: Report Versions for role Integration */
+INSERT INTO ${flyway:defaultSchema}.EntityPermission
+                                                   (EntityID, RoleID, CanRead, CanCreate, CanUpdate, CanDelete) VALUES
+                                                   ('9516058d-9729-48ec-b0b8-e91a8221fc8f', 'DFAFCCEC-6A37-EF11-86D4-000D3A4E707E', 1, 1, 1, 1)
+
+/* SQL generated to create new entity MJ: Report User States */
+
+      INSERT INTO [${flyway:defaultSchema}].Entity (
+         ID,
+         Name,
+         Description,
+         NameSuffix,
+         BaseTable,
+         BaseView,
+         SchemaName,
+         IncludeInAPI,
+         AllowUserSearchAPI
+         , TrackRecordChanges
+         , AuditRecordAccess
+         , AuditViewRuns
+         , AllowAllRowsAPI
+         , AllowCreateAPI
+         , AllowUpdateAPI
+         , AllowDeleteAPI
+         , UserViewMaxRows
+      )
+      VALUES (
+         '4a4c2ee1-bfdd-434e-9a03-6f6c2384d01f',
+         'MJ: Report User States',
+         NULL,
+         NULL,
+         'ReportUserState',
+         'vwReportUserStates',
+         '${flyway:defaultSchema}',
+         1,
+         0
+         , 1
+         , 0
+         , 0
+         , 0
+         , 1
+         , 1
+         , 1
+         , 1000
+      )
+   
+
+/* SQL generated to add new permission for entity MJ: Report User States for role UI */
+INSERT INTO ${flyway:defaultSchema}.EntityPermission
+                                                   (EntityID, RoleID, CanRead, CanCreate, CanUpdate, CanDelete) VALUES
+                                                   ('4a4c2ee1-bfdd-434e-9a03-6f6c2384d01f', 'E0AFCCEC-6A37-EF11-86D4-000D3A4E707E', 1, 0, 0, 0)
+
+/* SQL generated to add new permission for entity MJ: Report User States for role Developer */
+INSERT INTO ${flyway:defaultSchema}.EntityPermission
+                                                   (EntityID, RoleID, CanRead, CanCreate, CanUpdate, CanDelete) VALUES
+                                                   ('4a4c2ee1-bfdd-434e-9a03-6f6c2384d01f', 'DEAFCCEC-6A37-EF11-86D4-000D3A4E707E', 1, 1, 1, 0)
+
+/* SQL generated to add new permission for entity MJ: Report User States for role Integration */
+INSERT INTO ${flyway:defaultSchema}.EntityPermission
+                                                   (EntityID, RoleID, CanRead, CanCreate, CanUpdate, CanDelete) VALUES
+                                                   ('4a4c2ee1-bfdd-434e-9a03-6f6c2384d01f', 'DFAFCCEC-6A37-EF11-86D4-000D3A4E707E', 1, 1, 1, 1)
+
+/* SQL text to add special date field ${flyway:defaultSchema}_CreatedAt to entity ${flyway:defaultSchema}.ReportUserState */
+ALTER TABLE [${flyway:defaultSchema}].[ReportUserState] ADD ${flyway:defaultSchema}_CreatedAt DATETIMEOFFSET NOT NULL DEFAULT GETUTCDATE()
+
+/* SQL text to add special date field ${flyway:defaultSchema}_UpdatedAt to entity ${flyway:defaultSchema}.ReportUserState */
+ALTER TABLE [${flyway:defaultSchema}].[ReportUserState] ADD ${flyway:defaultSchema}_UpdatedAt DATETIMEOFFSET NOT NULL DEFAULT GETUTCDATE()
+
+/* SQL text to add special date field ${flyway:defaultSchema}_CreatedAt to entity ${flyway:defaultSchema}.ReportVersion */
+ALTER TABLE [${flyway:defaultSchema}].[ReportVersion] ADD ${flyway:defaultSchema}_CreatedAt DATETIMEOFFSET NOT NULL DEFAULT GETUTCDATE()
+
+/* SQL text to add special date field ${flyway:defaultSchema}_UpdatedAt to entity ${flyway:defaultSchema}.ReportVersion */
+ALTER TABLE [${flyway:defaultSchema}].[ReportVersion] ADD ${flyway:defaultSchema}_UpdatedAt DATETIMEOFFSET NOT NULL DEFAULT GETUTCDATE()
+
+/* SQL text to insert new entity field */
+
+      IF NOT EXISTS (
+         SELECT 1 FROM [${flyway:defaultSchema}].EntityField 
+         WHERE ID = '91bcfb05-1d1b-467b-8a17-a06e0606c7fb'  OR 
+               (EntityID = '4A4C2EE1-BFDD-434E-9A03-6F6C2384D01F' AND Name = 'ID')
+         -- check to make sure we're not inserting a duplicate entity field metadata record
+      )
+      BEGIN
+         INSERT INTO [${flyway:defaultSchema}].EntityField
+         (
+            ID,
+            EntityID,
+            Sequence,
+            Name,
+            DisplayName,
+            Description,
+            Type,
+            Length,
+            Precision,
+            Scale,
+            AllowsNull,
+            DefaultValue,
+            AutoIncrement,
+            AllowUpdateAPI,
+            IsVirtual,
+            RelatedEntityID,
+            RelatedEntityFieldName,
+            IsNameField,
+            IncludeInUserSearchAPI,
+            IncludeRelatedEntityNameFieldInBaseView,
+            DefaultInView,
+            IsPrimaryKey,
+            IsUnique,
+            RelatedEntityDisplayType
+         )
+         VALUES
+         (
+            '91bcfb05-1d1b-467b-8a17-a06e0606c7fb',
+            '4A4C2EE1-BFDD-434E-9A03-6F6C2384D01F', -- Entity: MJ: Report User States
+            1,
+            'ID',
+            'ID',
+            NULL,
+            'uniqueidentifier',
+            16,
+            0,
+            0,
+            0,
+            'newsequentialid()',
+            0,
+            0,
+            0,
+            NULL,
+            NULL,
+            0,
+            1,
+            0,
+            1,
+            1,
+            1,
+            'Search'
+         )
+      END
+
+/* SQL text to insert new entity field */
+
+      IF NOT EXISTS (
+         SELECT 1 FROM [${flyway:defaultSchema}].EntityField 
+         WHERE ID = 'f7bddafd-e2b7-4bb8-a888-dee07d33d580'  OR 
+               (EntityID = '4A4C2EE1-BFDD-434E-9A03-6F6C2384D01F' AND Name = 'ReportID')
+         -- check to make sure we're not inserting a duplicate entity field metadata record
+      )
+      BEGIN
+         INSERT INTO [${flyway:defaultSchema}].EntityField
+         (
+            ID,
+            EntityID,
+            Sequence,
+            Name,
+            DisplayName,
+            Description,
+            Type,
+            Length,
+            Precision,
+            Scale,
+            AllowsNull,
+            DefaultValue,
+            AutoIncrement,
+            AllowUpdateAPI,
+            IsVirtual,
+            RelatedEntityID,
+            RelatedEntityFieldName,
+            IsNameField,
+            IncludeInUserSearchAPI,
+            IncludeRelatedEntityNameFieldInBaseView,
+            DefaultInView,
+            IsPrimaryKey,
+            IsUnique,
+            RelatedEntityDisplayType
+         )
+         VALUES
+         (
+            'f7bddafd-e2b7-4bb8-a888-dee07d33d580',
+            '4A4C2EE1-BFDD-434E-9A03-6F6C2384D01F', -- Entity: MJ: Report User States
+            2,
+            'ReportID',
+            'Report ID',
+            NULL,
+            'uniqueidentifier',
+            16,
+            0,
+            0,
+            0,
+            'null',
+            0,
+            1,
+            0,
+            '09248F34-2837-EF11-86D4-6045BDEE16E6',
+            'ID',
+            0,
+            0,
+            1,
+            1,
+            0,
+            1,
+            'Search'
+         )
+      END
+
+/* SQL text to insert new entity field */
+
+      IF NOT EXISTS (
+         SELECT 1 FROM [${flyway:defaultSchema}].EntityField 
+         WHERE ID = '1382c49f-a90a-4dcd-9d3c-9b0c58a1752e'  OR 
+               (EntityID = '4A4C2EE1-BFDD-434E-9A03-6F6C2384D01F' AND Name = 'UserID')
+         -- check to make sure we're not inserting a duplicate entity field metadata record
+      )
+      BEGIN
+         INSERT INTO [${flyway:defaultSchema}].EntityField
+         (
+            ID,
+            EntityID,
+            Sequence,
+            Name,
+            DisplayName,
+            Description,
+            Type,
+            Length,
+            Precision,
+            Scale,
+            AllowsNull,
+            DefaultValue,
+            AutoIncrement,
+            AllowUpdateAPI,
+            IsVirtual,
+            RelatedEntityID,
+            RelatedEntityFieldName,
+            IsNameField,
+            IncludeInUserSearchAPI,
+            IncludeRelatedEntityNameFieldInBaseView,
+            DefaultInView,
+            IsPrimaryKey,
+            IsUnique,
+            RelatedEntityDisplayType
+         )
+         VALUES
+         (
+            '1382c49f-a90a-4dcd-9d3c-9b0c58a1752e',
+            '4A4C2EE1-BFDD-434E-9A03-6F6C2384D01F', -- Entity: MJ: Report User States
+            3,
+            'UserID',
+            'User ID',
+            NULL,
+            'uniqueidentifier',
+            16,
+            0,
+            0,
+            0,
+            'null',
+            0,
+            1,
+            0,
+            'E1238F34-2837-EF11-86D4-6045BDEE16E6',
+            'ID',
+            0,
+            0,
+            1,
+            1,
+            0,
+            1,
+            'Search'
+         )
+      END
+
+/* SQL text to insert new entity field */
+
+      IF NOT EXISTS (
+         SELECT 1 FROM [${flyway:defaultSchema}].EntityField 
+         WHERE ID = '6591a693-50a6-43fe-b4df-61c91b5bca83'  OR 
+               (EntityID = '4A4C2EE1-BFDD-434E-9A03-6F6C2384D01F' AND Name = 'ReportState')
+         -- check to make sure we're not inserting a duplicate entity field metadata record
+      )
+      BEGIN
+         INSERT INTO [${flyway:defaultSchema}].EntityField
+         (
+            ID,
+            EntityID,
+            Sequence,
+            Name,
+            DisplayName,
+            Description,
+            Type,
+            Length,
+            Precision,
+            Scale,
+            AllowsNull,
+            DefaultValue,
+            AutoIncrement,
+            AllowUpdateAPI,
+            IsVirtual,
+            RelatedEntityID,
+            RelatedEntityFieldName,
+            IsNameField,
+            IncludeInUserSearchAPI,
+            IncludeRelatedEntityNameFieldInBaseView,
+            DefaultInView,
+            IsPrimaryKey,
+            IsUnique,
+            RelatedEntityDisplayType
+         )
+         VALUES
+         (
+            '6591a693-50a6-43fe-b4df-61c91b5bca83',
+            '4A4C2EE1-BFDD-434E-9A03-6F6C2384D01F', -- Entity: MJ: Report User States
+            4,
+            'ReportState',
+            'Report State',
+            'JSON serialized state of user interaction with the report',
+            'nvarchar',
+            -1,
+            0,
+            0,
+            1,
+            'null',
+            0,
+            1,
+            0,
+            NULL,
+            NULL,
+            0,
+            0,
+            0,
+            1,
+            0,
+            0,
+            'Search'
+         )
+      END
+
+/* SQL text to insert new entity field */
+
+      IF NOT EXISTS (
+         SELECT 1 FROM [${flyway:defaultSchema}].EntityField 
+         WHERE ID = 'cf4aa583-1f56-4228-b59f-998b6506d7fe'  OR 
+               (EntityID = '4A4C2EE1-BFDD-434E-9A03-6F6C2384D01F' AND Name = '${flyway:defaultSchema}_CreatedAt')
+         -- check to make sure we're not inserting a duplicate entity field metadata record
+      )
+      BEGIN
+         INSERT INTO [${flyway:defaultSchema}].EntityField
+         (
+            ID,
+            EntityID,
+            Sequence,
+            Name,
+            DisplayName,
+            Description,
+            Type,
+            Length,
+            Precision,
+            Scale,
+            AllowsNull,
+            DefaultValue,
+            AutoIncrement,
+            AllowUpdateAPI,
+            IsVirtual,
+            RelatedEntityID,
+            RelatedEntityFieldName,
+            IsNameField,
+            IncludeInUserSearchAPI,
+            IncludeRelatedEntityNameFieldInBaseView,
+            DefaultInView,
+            IsPrimaryKey,
+            IsUnique,
+            RelatedEntityDisplayType
+         )
+         VALUES
+         (
+            'cf4aa583-1f56-4228-b59f-998b6506d7fe',
+            '4A4C2EE1-BFDD-434E-9A03-6F6C2384D01F', -- Entity: MJ: Report User States
+            5,
+            '${flyway:defaultSchema}_CreatedAt',
+            'Created At',
+            NULL,
+            'datetimeoffset',
+            10,
+            34,
+            7,
+            0,
+            'getutcdate()',
+            0,
+            0,
+            0,
+            NULL,
+            NULL,
+            0,
+            0,
+            0,
+            1,
+            0,
+            0,
+            'Search'
+         )
+      END
+
+/* SQL text to insert new entity field */
+
+      IF NOT EXISTS (
+         SELECT 1 FROM [${flyway:defaultSchema}].EntityField 
+         WHERE ID = 'fbc96d80-d0bd-451c-98a5-eb29efba6f03'  OR 
+               (EntityID = '4A4C2EE1-BFDD-434E-9A03-6F6C2384D01F' AND Name = '${flyway:defaultSchema}_UpdatedAt')
+         -- check to make sure we're not inserting a duplicate entity field metadata record
+      )
+      BEGIN
+         INSERT INTO [${flyway:defaultSchema}].EntityField
+         (
+            ID,
+            EntityID,
+            Sequence,
+            Name,
+            DisplayName,
+            Description,
+            Type,
+            Length,
+            Precision,
+            Scale,
+            AllowsNull,
+            DefaultValue,
+            AutoIncrement,
+            AllowUpdateAPI,
+            IsVirtual,
+            RelatedEntityID,
+            RelatedEntityFieldName,
+            IsNameField,
+            IncludeInUserSearchAPI,
+            IncludeRelatedEntityNameFieldInBaseView,
+            DefaultInView,
+            IsPrimaryKey,
+            IsUnique,
+            RelatedEntityDisplayType
+         )
+         VALUES
+         (
+            'fbc96d80-d0bd-451c-98a5-eb29efba6f03',
+            '4A4C2EE1-BFDD-434E-9A03-6F6C2384D01F', -- Entity: MJ: Report User States
+            6,
+            '${flyway:defaultSchema}_UpdatedAt',
+            'Updated At',
+            NULL,
+            'datetimeoffset',
+            10,
+            34,
+            7,
+            0,
+            'getutcdate()',
+            0,
+            0,
+            0,
+            NULL,
+            NULL,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            'Search'
+         )
+      END
+
+/* SQL text to insert new entity field */
+
+      IF NOT EXISTS (
+         SELECT 1 FROM [${flyway:defaultSchema}].EntityField 
+         WHERE ID = 'db4981fb-88d1-4fe3-aa65-20c4720a8503'  OR 
+               (EntityID = '9516058D-9729-48EC-B0B8-E91A8221FC8F' AND Name = 'ID')
+         -- check to make sure we're not inserting a duplicate entity field metadata record
+      )
+      BEGIN
+         INSERT INTO [${flyway:defaultSchema}].EntityField
+         (
+            ID,
+            EntityID,
+            Sequence,
+            Name,
+            DisplayName,
+            Description,
+            Type,
+            Length,
+            Precision,
+            Scale,
+            AllowsNull,
+            DefaultValue,
+            AutoIncrement,
+            AllowUpdateAPI,
+            IsVirtual,
+            RelatedEntityID,
+            RelatedEntityFieldName,
+            IsNameField,
+            IncludeInUserSearchAPI,
+            IncludeRelatedEntityNameFieldInBaseView,
+            DefaultInView,
+            IsPrimaryKey,
+            IsUnique,
+            RelatedEntityDisplayType
+         )
+         VALUES
+         (
+            'db4981fb-88d1-4fe3-aa65-20c4720a8503',
+            '9516058D-9729-48EC-B0B8-E91A8221FC8F', -- Entity: MJ: Report Versions
+            1,
+            'ID',
+            'ID',
+            NULL,
+            'uniqueidentifier',
+            16,
+            0,
+            0,
+            0,
+            'newsequentialid()',
+            0,
+            0,
+            0,
+            NULL,
+            NULL,
+            0,
+            1,
+            0,
+            1,
+            1,
+            1,
+            'Search'
+         )
+      END
+
+/* SQL text to insert new entity field */
+
+      IF NOT EXISTS (
+         SELECT 1 FROM [${flyway:defaultSchema}].EntityField 
+         WHERE ID = '9e8ed87c-b436-4b67-b2b2-09b126ed0a82'  OR 
+               (EntityID = '9516058D-9729-48EC-B0B8-E91A8221FC8F' AND Name = 'ReportID')
+         -- check to make sure we're not inserting a duplicate entity field metadata record
+      )
+      BEGIN
+         INSERT INTO [${flyway:defaultSchema}].EntityField
+         (
+            ID,
+            EntityID,
+            Sequence,
+            Name,
+            DisplayName,
+            Description,
+            Type,
+            Length,
+            Precision,
+            Scale,
+            AllowsNull,
+            DefaultValue,
+            AutoIncrement,
+            AllowUpdateAPI,
+            IsVirtual,
+            RelatedEntityID,
+            RelatedEntityFieldName,
+            IsNameField,
+            IncludeInUserSearchAPI,
+            IncludeRelatedEntityNameFieldInBaseView,
+            DefaultInView,
+            IsPrimaryKey,
+            IsUnique,
+            RelatedEntityDisplayType
+         )
+         VALUES
+         (
+            '9e8ed87c-b436-4b67-b2b2-09b126ed0a82',
+            '9516058D-9729-48EC-B0B8-E91A8221FC8F', -- Entity: MJ: Report Versions
+            2,
+            'ReportID',
+            'Report ID',
+            NULL,
+            'uniqueidentifier',
+            16,
+            0,
+            0,
+            0,
+            'null',
+            0,
+            1,
+            0,
+            '09248F34-2837-EF11-86D4-6045BDEE16E6',
+            'ID',
+            0,
+            0,
+            1,
+            1,
+            0,
+            1,
+            'Search'
+         )
+      END
+
+/* SQL text to insert new entity field */
+
+      IF NOT EXISTS (
+         SELECT 1 FROM [${flyway:defaultSchema}].EntityField 
+         WHERE ID = '79bf06a4-d891-478d-8621-c0ff430b541a'  OR 
+               (EntityID = '9516058D-9729-48EC-B0B8-E91A8221FC8F' AND Name = 'VersionNumber')
+         -- check to make sure we're not inserting a duplicate entity field metadata record
+      )
+      BEGIN
+         INSERT INTO [${flyway:defaultSchema}].EntityField
+         (
+            ID,
+            EntityID,
+            Sequence,
+            Name,
+            DisplayName,
+            Description,
+            Type,
+            Length,
+            Precision,
+            Scale,
+            AllowsNull,
+            DefaultValue,
+            AutoIncrement,
+            AllowUpdateAPI,
+            IsVirtual,
+            RelatedEntityID,
+            RelatedEntityFieldName,
+            IsNameField,
+            IncludeInUserSearchAPI,
+            IncludeRelatedEntityNameFieldInBaseView,
+            DefaultInView,
+            IsPrimaryKey,
+            IsUnique,
+            RelatedEntityDisplayType
+         )
+         VALUES
+         (
+            '79bf06a4-d891-478d-8621-c0ff430b541a',
+            '9516058D-9729-48EC-B0B8-E91A8221FC8F', -- Entity: MJ: Report Versions
+            3,
+            'VersionNumber',
+            'Version Number',
+            'Report version number, sequential per report starting at 1',
+            'int',
+            4,
+            10,
+            0,
+            0,
+            'null',
+            0,
+            1,
+            0,
+            NULL,
+            NULL,
+            0,
+            0,
+            0,
+            1,
+            0,
+            1,
+            'Search'
+         )
+      END
+
+/* SQL text to insert new entity field */
+
+      IF NOT EXISTS (
+         SELECT 1 FROM [${flyway:defaultSchema}].EntityField 
+         WHERE ID = '4f3368e4-9732-47ef-a615-eec00087897f'  OR 
+               (EntityID = '9516058D-9729-48EC-B0B8-E91A8221FC8F' AND Name = 'Name')
+         -- check to make sure we're not inserting a duplicate entity field metadata record
+      )
+      BEGIN
+         INSERT INTO [${flyway:defaultSchema}].EntityField
+         (
+            ID,
+            EntityID,
+            Sequence,
+            Name,
+            DisplayName,
+            Description,
+            Type,
+            Length,
+            Precision,
+            Scale,
+            AllowsNull,
+            DefaultValue,
+            AutoIncrement,
+            AllowUpdateAPI,
+            IsVirtual,
+            RelatedEntityID,
+            RelatedEntityFieldName,
+            IsNameField,
+            IncludeInUserSearchAPI,
+            IncludeRelatedEntityNameFieldInBaseView,
+            DefaultInView,
+            IsPrimaryKey,
+            IsUnique,
+            RelatedEntityDisplayType
+         )
+         VALUES
+         (
+            '4f3368e4-9732-47ef-a615-eec00087897f',
+            '9516058D-9729-48EC-B0B8-E91A8221FC8F', -- Entity: MJ: Report Versions
+            4,
+            'Name',
+            'Name',
+            'Name of this report version',
+            'nvarchar',
+            510,
+            0,
+            0,
+            0,
+            'null',
+            0,
+            1,
+            0,
+            NULL,
+            NULL,
+            1,
+            1,
+            0,
+            1,
+            0,
+            0,
+            'Search'
+         )
+      END
+
+/* SQL text to insert new entity field */
+
+      IF NOT EXISTS (
+         SELECT 1 FROM [${flyway:defaultSchema}].EntityField 
+         WHERE ID = '8a4b53c6-0558-489a-8922-dd5ea9b7df29'  OR 
+               (EntityID = '9516058D-9729-48EC-B0B8-E91A8221FC8F' AND Name = 'Description')
+         -- check to make sure we're not inserting a duplicate entity field metadata record
+      )
+      BEGIN
+         INSERT INTO [${flyway:defaultSchema}].EntityField
+         (
+            ID,
+            EntityID,
+            Sequence,
+            Name,
+            DisplayName,
+            Description,
+            Type,
+            Length,
+            Precision,
+            Scale,
+            AllowsNull,
+            DefaultValue,
+            AutoIncrement,
+            AllowUpdateAPI,
+            IsVirtual,
+            RelatedEntityID,
+            RelatedEntityFieldName,
+            IsNameField,
+            IncludeInUserSearchAPI,
+            IncludeRelatedEntityNameFieldInBaseView,
+            DefaultInView,
+            IsPrimaryKey,
+            IsUnique,
+            RelatedEntityDisplayType
+         )
+         VALUES
+         (
+            '8a4b53c6-0558-489a-8922-dd5ea9b7df29',
+            '9516058D-9729-48EC-B0B8-E91A8221FC8F', -- Entity: MJ: Report Versions
+            5,
+            'Description',
+            'Description',
+            'Description of this report version',
+            'nvarchar',
+            -1,
+            0,
+            0,
+            1,
+            'null',
+            0,
+            1,
+            0,
+            NULL,
+            NULL,
+            0,
+            0,
+            0,
+            1,
+            0,
+            0,
+            'Search'
+         )
+      END
+
+/* SQL text to insert new entity field */
+
+      IF NOT EXISTS (
+         SELECT 1 FROM [${flyway:defaultSchema}].EntityField 
+         WHERE ID = 'c479d62c-4f0d-4001-8db4-f2c73034098f'  OR 
+               (EntityID = '9516058D-9729-48EC-B0B8-E91A8221FC8F' AND Name = 'Configuration')
+         -- check to make sure we're not inserting a duplicate entity field metadata record
+      )
+      BEGIN
+         INSERT INTO [${flyway:defaultSchema}].EntityField
+         (
+            ID,
+            EntityID,
+            Sequence,
+            Name,
+            DisplayName,
+            Description,
+            Type,
+            Length,
+            Precision,
+            Scale,
+            AllowsNull,
+            DefaultValue,
+            AutoIncrement,
+            AllowUpdateAPI,
+            IsVirtual,
+            RelatedEntityID,
+            RelatedEntityFieldName,
+            IsNameField,
+            IncludeInUserSearchAPI,
+            IncludeRelatedEntityNameFieldInBaseView,
+            DefaultInView,
+            IsPrimaryKey,
+            IsUnique,
+            RelatedEntityDisplayType
+         )
+         VALUES
+         (
+            'c479d62c-4f0d-4001-8db4-f2c73034098f',
+            '9516058D-9729-48EC-B0B8-E91A8221FC8F', -- Entity: MJ: Report Versions
+            6,
+            'Configuration',
+            'Configuration',
+            'JSON configuration of report structure, layout and logic',
+            'nvarchar',
+            -1,
+            0,
+            0,
+            1,
+            'null',
+            0,
+            1,
+            0,
+            NULL,
+            NULL,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            'Search'
+         )
+      END
+
+/* SQL text to insert new entity field */
+
+      IF NOT EXISTS (
+         SELECT 1 FROM [${flyway:defaultSchema}].EntityField 
+         WHERE ID = '07e0d463-716a-4bac-aa3b-f5e61e7c70ae'  OR 
+               (EntityID = '9516058D-9729-48EC-B0B8-E91A8221FC8F' AND Name = 'DataContextUpdated')
+         -- check to make sure we're not inserting a duplicate entity field metadata record
+      )
+      BEGIN
+         INSERT INTO [${flyway:defaultSchema}].EntityField
+         (
+            ID,
+            EntityID,
+            Sequence,
+            Name,
+            DisplayName,
+            Description,
+            Type,
+            Length,
+            Precision,
+            Scale,
+            AllowsNull,
+            DefaultValue,
+            AutoIncrement,
+            AllowUpdateAPI,
+            IsVirtual,
+            RelatedEntityID,
+            RelatedEntityFieldName,
+            IsNameField,
+            IncludeInUserSearchAPI,
+            IncludeRelatedEntityNameFieldInBaseView,
+            DefaultInView,
+            IsPrimaryKey,
+            IsUnique,
+            RelatedEntityDisplayType
+         )
+         VALUES
+         (
+            '07e0d463-716a-4bac-aa3b-f5e61e7c70ae',
+            '9516058D-9729-48EC-B0B8-E91A8221FC8F', -- Entity: MJ: Report Versions
+            7,
+            'DataContextUpdated',
+            'Data Context Updated',
+            'Indicates if the data context was updated in this version',
+            'bit',
+            1,
+            1,
+            0,
+            0,
+            '(0)',
+            0,
+            1,
+            0,
+            NULL,
+            NULL,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            'Search'
+         )
+      END
+
+/* SQL text to insert new entity field */
+
+      IF NOT EXISTS (
+         SELECT 1 FROM [${flyway:defaultSchema}].EntityField 
+         WHERE ID = '8bda1551-ecde-43a2-97fd-c526133325b5'  OR 
+               (EntityID = '9516058D-9729-48EC-B0B8-E91A8221FC8F' AND Name = '${flyway:defaultSchema}_CreatedAt')
+         -- check to make sure we're not inserting a duplicate entity field metadata record
+      )
+      BEGIN
+         INSERT INTO [${flyway:defaultSchema}].EntityField
+         (
+            ID,
+            EntityID,
+            Sequence,
+            Name,
+            DisplayName,
+            Description,
+            Type,
+            Length,
+            Precision,
+            Scale,
+            AllowsNull,
+            DefaultValue,
+            AutoIncrement,
+            AllowUpdateAPI,
+            IsVirtual,
+            RelatedEntityID,
+            RelatedEntityFieldName,
+            IsNameField,
+            IncludeInUserSearchAPI,
+            IncludeRelatedEntityNameFieldInBaseView,
+            DefaultInView,
+            IsPrimaryKey,
+            IsUnique,
+            RelatedEntityDisplayType
+         )
+         VALUES
+         (
+            '8bda1551-ecde-43a2-97fd-c526133325b5',
+            '9516058D-9729-48EC-B0B8-E91A8221FC8F', -- Entity: MJ: Report Versions
+            8,
+            '${flyway:defaultSchema}_CreatedAt',
+            'Created At',
+            NULL,
+            'datetimeoffset',
+            10,
+            34,
+            7,
+            0,
+            'getutcdate()',
+            0,
+            0,
+            0,
+            NULL,
+            NULL,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            'Search'
+         )
+      END
+
+/* SQL text to insert new entity field */
+
+      IF NOT EXISTS (
+         SELECT 1 FROM [${flyway:defaultSchema}].EntityField 
+         WHERE ID = '769327f1-77c2-4682-bc63-f043a39045ff'  OR 
+               (EntityID = '9516058D-9729-48EC-B0B8-E91A8221FC8F' AND Name = '${flyway:defaultSchema}_UpdatedAt')
+         -- check to make sure we're not inserting a duplicate entity field metadata record
+      )
+      BEGIN
+         INSERT INTO [${flyway:defaultSchema}].EntityField
+         (
+            ID,
+            EntityID,
+            Sequence,
+            Name,
+            DisplayName,
+            Description,
+            Type,
+            Length,
+            Precision,
+            Scale,
+            AllowsNull,
+            DefaultValue,
+            AutoIncrement,
+            AllowUpdateAPI,
+            IsVirtual,
+            RelatedEntityID,
+            RelatedEntityFieldName,
+            IsNameField,
+            IncludeInUserSearchAPI,
+            IncludeRelatedEntityNameFieldInBaseView,
+            DefaultInView,
+            IsPrimaryKey,
+            IsUnique,
+            RelatedEntityDisplayType
+         )
+         VALUES
+         (
+            '769327f1-77c2-4682-bc63-f043a39045ff',
+            '9516058D-9729-48EC-B0B8-E91A8221FC8F', -- Entity: MJ: Report Versions
+            9,
+            '${flyway:defaultSchema}_UpdatedAt',
+            'Updated At',
+            NULL,
+            'datetimeoffset',
+            10,
+            34,
+            7,
+            0,
+            'getutcdate()',
+            0,
+            0,
+            0,
+            NULL,
+            NULL,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            'Search'
+         )
+      END
+
+/* SQL text to create Entitiy Relationships */
+
+   IF NOT EXISTS (
+      SELECT 1
+      FROM [${flyway:defaultSchema}].EntityRelationship
+      WHERE ID = 'c989997d-85b4-4755-b08a-c60b77353ae1'
+   )
+   BEGIN
+      INSERT INTO ${flyway:defaultSchema}.EntityRelationship (ID, EntityID, RelatedEntityID, RelatedEntityJoinField, Type, BundleInAPI, DisplayInForm, DisplayName, Sequence)
+                              VALUES ('c989997d-85b4-4755-b08a-c60b77353ae1', 'E1238F34-2837-EF11-86D4-6045BDEE16E6', '4A4C2EE1-BFDD-434E-9A03-6F6C2384D01F', 'UserID', 'One To Many', 1, 1, 'MJ: Report User States', 1);
+   END
+                              
+
+/* SQL text to create Entitiy Relationships */
+
+   IF NOT EXISTS (
+      SELECT 1
+      FROM [${flyway:defaultSchema}].EntityRelationship
+      WHERE ID = '0f6be221-508c-4949-b73e-d76088f007e4'
+   )
+   BEGIN
+      INSERT INTO ${flyway:defaultSchema}.EntityRelationship (ID, EntityID, RelatedEntityID, RelatedEntityJoinField, Type, BundleInAPI, DisplayInForm, DisplayName, Sequence)
+                              VALUES ('0f6be221-508c-4949-b73e-d76088f007e4', '09248F34-2837-EF11-86D4-6045BDEE16E6', '4A4C2EE1-BFDD-434E-9A03-6F6C2384D01F', 'ReportID', 'One To Many', 1, 1, 'MJ: Report User States', 2);
+   END
+                              
+   IF NOT EXISTS (
+      SELECT 1
+      FROM [${flyway:defaultSchema}].EntityRelationship
+      WHERE ID = 'f0e18355-6ab2-49d3-a65d-574e9408ad35'
+   )
+   BEGIN
+      INSERT INTO ${flyway:defaultSchema}.EntityRelationship (ID, EntityID, RelatedEntityID, RelatedEntityJoinField, Type, BundleInAPI, DisplayInForm, DisplayName, Sequence)
+                              VALUES ('f0e18355-6ab2-49d3-a65d-574e9408ad35', '09248F34-2837-EF11-86D4-6045BDEE16E6', '9516058D-9729-48EC-B0B8-E91A8221FC8F', 'ReportID', 'One To Many', 1, 1, 'MJ: Report Versions', 1);
+   END
+                              
+
+/* Index for Foreign Keys for ReportUserState */
+-----------------------------------------------------------------
+-- SQL Code Generation
+-- Entity: MJ: Report User States
+-- Item: Index for Foreign Keys
+--
+-- This was generated by the MemberJunction CodeGen tool.
+-- This file should NOT be edited by hand.
+-----------------------------------------------------------------
+-- Index for foreign key ReportID in table ReportUserState
+IF NOT EXISTS (
+    SELECT 1
+    FROM sys.indexes
+    WHERE name = 'IDX_AUTO_MJ_FKEY_ReportUserState_ReportID' 
+    AND object_id = OBJECT_ID('[${flyway:defaultSchema}].[ReportUserState]')
+)
+CREATE INDEX IDX_AUTO_MJ_FKEY_ReportUserState_ReportID ON [${flyway:defaultSchema}].[ReportUserState] ([ReportID]);
+
+-- Index for foreign key UserID in table ReportUserState
+IF NOT EXISTS (
+    SELECT 1
+    FROM sys.indexes
+    WHERE name = 'IDX_AUTO_MJ_FKEY_ReportUserState_UserID' 
+    AND object_id = OBJECT_ID('[${flyway:defaultSchema}].[ReportUserState]')
+)
+CREATE INDEX IDX_AUTO_MJ_FKEY_ReportUserState_UserID ON [${flyway:defaultSchema}].[ReportUserState] ([UserID]);
+
+/* SQL text to update entity field related entity name field map for entity field ID F7BDDAFD-E2B7-4BB8-A888-DEE07D33D580 */
+EXEC [${flyway:defaultSchema}].spUpdateEntityFieldRelatedEntityNameFieldMap
+         @EntityFieldID='F7BDDAFD-E2B7-4BB8-A888-DEE07D33D580',
+         @RelatedEntityNameFieldMap='Report'
+
+/* SQL text to update entity field related entity name field map for entity field ID 1382C49F-A90A-4DCD-9D3C-9B0C58A1752E */
+EXEC [${flyway:defaultSchema}].spUpdateEntityFieldRelatedEntityNameFieldMap
+         @EntityFieldID='1382C49F-A90A-4DCD-9D3C-9B0C58A1752E',
+         @RelatedEntityNameFieldMap='User'
+
+/* Base View SQL for MJ: Report User States */
+-----------------------------------------------------------------
+-- SQL Code Generation
+-- Entity: MJ: Report User States
+-- Item: vwReportUserStates
+--
+-- This was generated by the MemberJunction CodeGen tool.
+-- This file should NOT be edited by hand.
+-----------------------------------------------------------------
+
+------------------------------------------------------------
+----- BASE VIEW FOR ENTITY:      MJ: Report User States
+-----               SCHEMA:      ${flyway:defaultSchema}
+-----               BASE TABLE:  ReportUserState
+-----               PRIMARY KEY: ID
+------------------------------------------------------------
+DROP VIEW IF EXISTS [${flyway:defaultSchema}].[vwReportUserStates]
+GO
+
+CREATE VIEW [${flyway:defaultSchema}].[vwReportUserStates]
+AS
+SELECT
+    r.*,
+    Report_ReportID.[Name] AS [Report],
+    User_UserID.[Name] AS [User]
+FROM
+    [${flyway:defaultSchema}].[ReportUserState] AS r
+INNER JOIN
+    [${flyway:defaultSchema}].[Report] AS Report_ReportID
+  ON
+    [r].[ReportID] = Report_ReportID.[ID]
+INNER JOIN
+    [${flyway:defaultSchema}].[User] AS User_UserID
+  ON
+    [r].[UserID] = User_UserID.[ID]
+GO
+GRANT SELECT ON [${flyway:defaultSchema}].[vwReportUserStates] TO [cdp_UI], [cdp_Developer], [cdp_Integration]
+    
+
+/* Base View Permissions SQL for MJ: Report User States */
+-----------------------------------------------------------------
+-- SQL Code Generation
+-- Entity: MJ: Report User States
+-- Item: Permissions for vwReportUserStates
+--
+-- This was generated by the MemberJunction CodeGen tool.
+-- This file should NOT be edited by hand.
+-----------------------------------------------------------------
+
+GRANT SELECT ON [${flyway:defaultSchema}].[vwReportUserStates] TO [cdp_UI], [cdp_Developer], [cdp_Integration]
+
+/* spCreate SQL for MJ: Report User States */
+-----------------------------------------------------------------
+-- SQL Code Generation
+-- Entity: MJ: Report User States
+-- Item: spCreateReportUserState
+--
+-- This was generated by the MemberJunction CodeGen tool.
+-- This file should NOT be edited by hand.
+-----------------------------------------------------------------
+
+------------------------------------------------------------
+----- CREATE PROCEDURE FOR ReportUserState
+------------------------------------------------------------
+DROP PROCEDURE IF EXISTS [${flyway:defaultSchema}].[spCreateReportUserState]
+GO
+
+CREATE PROCEDURE [${flyway:defaultSchema}].[spCreateReportUserState]
+    @ReportID uniqueidentifier = '00000000-0000-0000-0000-000000000000',
+    @UserID uniqueidentifier = '00000000-0000-0000-0000-000000000000',
+    @ReportState nvarchar(MAX)
+AS
+BEGIN
+    SET NOCOUNT ON;
+    DECLARE @InsertedRow TABLE ([ID] UNIQUEIDENTIFIER)
+    INSERT INTO
+    [${flyway:defaultSchema}].[ReportUserState]
+        (
+            [ReportID],
+            [UserID],
+            [ReportState]
+        )
+    OUTPUT INSERTED.[ID] INTO @InsertedRow
+    VALUES
+        (
+            CASE @ReportID WHEN '00000000-0000-0000-0000-000000000000' THEN null ELSE @ReportID END,
+            CASE @UserID WHEN '00000000-0000-0000-0000-000000000000' THEN null ELSE @UserID END,
+            @ReportState
+        )
+    -- return the new record from the base view, which might have some calculated fields
+    SELECT * FROM [${flyway:defaultSchema}].[vwReportUserStates] WHERE [ID] = (SELECT [ID] FROM @InsertedRow)
+END
+GO
+GRANT EXECUTE ON [${flyway:defaultSchema}].[spCreateReportUserState] TO [cdp_Developer], [cdp_Integration]
+    
+
+/* spCreate Permissions for MJ: Report User States */
+
+GRANT EXECUTE ON [${flyway:defaultSchema}].[spCreateReportUserState] TO [cdp_Developer], [cdp_Integration]
+
+
+
+/* spUpdate SQL for MJ: Report User States */
+-----------------------------------------------------------------
+-- SQL Code Generation
+-- Entity: MJ: Report User States
+-- Item: spUpdateReportUserState
+--
+-- This was generated by the MemberJunction CodeGen tool.
+-- This file should NOT be edited by hand.
+-----------------------------------------------------------------
+
+------------------------------------------------------------
+----- UPDATE PROCEDURE FOR ReportUserState
+------------------------------------------------------------
+DROP PROCEDURE IF EXISTS [${flyway:defaultSchema}].[spUpdateReportUserState]
+GO
+
+CREATE PROCEDURE [${flyway:defaultSchema}].[spUpdateReportUserState]
+    @ID uniqueidentifier,
+    @ReportID uniqueidentifier,
+    @UserID uniqueidentifier,
+    @ReportState nvarchar(MAX)
+AS
+BEGIN
+    SET NOCOUNT ON;
+    UPDATE
+        [${flyway:defaultSchema}].[ReportUserState]
+    SET
+        [ReportID] = @ReportID,
+        [UserID] = @UserID,
+        [ReportState] = @ReportState
+    WHERE
+        [ID] = @ID
+
+    -- return the updated record so the caller can see the updated values and any calculated fields
+    SELECT
+                                        *
+                                    FROM
+                                        [${flyway:defaultSchema}].[vwReportUserStates]
+                                    WHERE
+                                        [ID] = @ID
+                                    
+END
+GO
+
+GRANT EXECUTE ON [${flyway:defaultSchema}].[spUpdateReportUserState] TO [cdp_Developer], [cdp_Integration]
+GO
+
+------------------------------------------------------------
+----- TRIGGER FOR ${flyway:defaultSchema}_UpdatedAt field for the ReportUserState table
+------------------------------------------------------------
+DROP TRIGGER IF EXISTS [${flyway:defaultSchema}].trgUpdateReportUserState
+GO
+CREATE TRIGGER [${flyway:defaultSchema}].trgUpdateReportUserState
+ON [${flyway:defaultSchema}].[ReportUserState]
+AFTER UPDATE
+AS
+BEGIN
+    SET NOCOUNT ON;
+    UPDATE
+        [${flyway:defaultSchema}].[ReportUserState]
+    SET
+        ${flyway:defaultSchema}_UpdatedAt = GETUTCDATE()
+    FROM
+        [${flyway:defaultSchema}].[ReportUserState] AS _organicTable
+    INNER JOIN
+        INSERTED AS I ON
+        _organicTable.[ID] = I.[ID];
+END;
+GO
+        
+
+/* spUpdate Permissions for MJ: Report User States */
+
+GRANT EXECUTE ON [${flyway:defaultSchema}].[spUpdateReportUserState] TO [cdp_Developer], [cdp_Integration]
+
+
+
+/* spDelete SQL for MJ: Report User States */
+-----------------------------------------------------------------
+-- SQL Code Generation
+-- Entity: MJ: Report User States
+-- Item: spDeleteReportUserState
+--
+-- This was generated by the MemberJunction CodeGen tool.
+-- This file should NOT be edited by hand.
+-----------------------------------------------------------------
+
+------------------------------------------------------------
+----- DELETE PROCEDURE FOR ReportUserState
+------------------------------------------------------------
+DROP PROCEDURE IF EXISTS [${flyway:defaultSchema}].[spDeleteReportUserState]
+GO
+
+CREATE PROCEDURE [${flyway:defaultSchema}].[spDeleteReportUserState]
+    @ID uniqueidentifier
+AS
+BEGIN
+    SET NOCOUNT ON;
+
+    DELETE FROM
+        [${flyway:defaultSchema}].[ReportUserState]
+    WHERE
+        [ID] = @ID
+
+
+    SELECT @ID AS [ID] -- Return the primary key to indicate we successfully deleted the record
+END
+GO
+GRANT EXECUTE ON [${flyway:defaultSchema}].[spDeleteReportUserState] TO [cdp_Integration]
+    
+
+/* spDelete Permissions for MJ: Report User States */
+
+GRANT EXECUTE ON [${flyway:defaultSchema}].[spDeleteReportUserState] TO [cdp_Integration]
+
+
+
+/* Index for Foreign Keys for ReportVersion */
+-----------------------------------------------------------------
+-- SQL Code Generation
+-- Entity: MJ: Report Versions
+-- Item: Index for Foreign Keys
+--
+-- This was generated by the MemberJunction CodeGen tool.
+-- This file should NOT be edited by hand.
+-----------------------------------------------------------------
+-- Index for foreign key ReportID in table ReportVersion
+IF NOT EXISTS (
+    SELECT 1
+    FROM sys.indexes
+    WHERE name = 'IDX_AUTO_MJ_FKEY_ReportVersion_ReportID' 
+    AND object_id = OBJECT_ID('[${flyway:defaultSchema}].[ReportVersion]')
+)
+CREATE INDEX IDX_AUTO_MJ_FKEY_ReportVersion_ReportID ON [${flyway:defaultSchema}].[ReportVersion] ([ReportID]);
+
+/* SQL text to update entity field related entity name field map for entity field ID 9E8ED87C-B436-4B67-B2B2-09B126ED0A82 */
+EXEC [${flyway:defaultSchema}].spUpdateEntityFieldRelatedEntityNameFieldMap
+         @EntityFieldID='9E8ED87C-B436-4B67-B2B2-09B126ED0A82',
+         @RelatedEntityNameFieldMap='Report'
+
+/* Base View SQL for MJ: Report Versions */
+-----------------------------------------------------------------
+-- SQL Code Generation
+-- Entity: MJ: Report Versions
+-- Item: vwReportVersions
+--
+-- This was generated by the MemberJunction CodeGen tool.
+-- This file should NOT be edited by hand.
+-----------------------------------------------------------------
+
+------------------------------------------------------------
+----- BASE VIEW FOR ENTITY:      MJ: Report Versions
+-----               SCHEMA:      ${flyway:defaultSchema}
+-----               BASE TABLE:  ReportVersion
+-----               PRIMARY KEY: ID
+------------------------------------------------------------
+DROP VIEW IF EXISTS [${flyway:defaultSchema}].[vwReportVersions]
+GO
+
+CREATE VIEW [${flyway:defaultSchema}].[vwReportVersions]
+AS
+SELECT
+    r.*,
+    Report_ReportID.[Name] AS [Report]
+FROM
+    [${flyway:defaultSchema}].[ReportVersion] AS r
+INNER JOIN
+    [${flyway:defaultSchema}].[Report] AS Report_ReportID
+  ON
+    [r].[ReportID] = Report_ReportID.[ID]
+GO
+GRANT SELECT ON [${flyway:defaultSchema}].[vwReportVersions] TO [cdp_UI], [cdp_Developer], [cdp_Integration]
+    
+
+/* Base View Permissions SQL for MJ: Report Versions */
+-----------------------------------------------------------------
+-- SQL Code Generation
+-- Entity: MJ: Report Versions
+-- Item: Permissions for vwReportVersions
+--
+-- This was generated by the MemberJunction CodeGen tool.
+-- This file should NOT be edited by hand.
+-----------------------------------------------------------------
+
+GRANT SELECT ON [${flyway:defaultSchema}].[vwReportVersions] TO [cdp_UI], [cdp_Developer], [cdp_Integration]
+
+/* spCreate SQL for MJ: Report Versions */
+-----------------------------------------------------------------
+-- SQL Code Generation
+-- Entity: MJ: Report Versions
+-- Item: spCreateReportVersion
+--
+-- This was generated by the MemberJunction CodeGen tool.
+-- This file should NOT be edited by hand.
+-----------------------------------------------------------------
+
+------------------------------------------------------------
+----- CREATE PROCEDURE FOR ReportVersion
+------------------------------------------------------------
+DROP PROCEDURE IF EXISTS [${flyway:defaultSchema}].[spCreateReportVersion]
+GO
+
+CREATE PROCEDURE [${flyway:defaultSchema}].[spCreateReportVersion]
+    @ReportID uniqueidentifier = '00000000-0000-0000-0000-000000000000',
+    @VersionNumber int,
+    @Name nvarchar(255),
+    @Description nvarchar(MAX),
+    @Configuration nvarchar(MAX),
+    @DataContextUpdated bit
+AS
+BEGIN
+    SET NOCOUNT ON;
+    DECLARE @InsertedRow TABLE ([ID] UNIQUEIDENTIFIER)
+    INSERT INTO
+    [${flyway:defaultSchema}].[ReportVersion]
+        (
+            [ReportID],
+            [VersionNumber],
+            [Name],
+            [Description],
+            [Configuration],
+            [DataContextUpdated]
+        )
+    OUTPUT INSERTED.[ID] INTO @InsertedRow
+    VALUES
+        (
+            CASE @ReportID WHEN '00000000-0000-0000-0000-000000000000' THEN null ELSE @ReportID END,
+            @VersionNumber,
+            @Name,
+            @Description,
+            @Configuration,
+            @DataContextUpdated
+        )
+    -- return the new record from the base view, which might have some calculated fields
+    SELECT * FROM [${flyway:defaultSchema}].[vwReportVersions] WHERE [ID] = (SELECT [ID] FROM @InsertedRow)
+END
+GO
+GRANT EXECUTE ON [${flyway:defaultSchema}].[spCreateReportVersion] TO [cdp_Developer], [cdp_Integration]
+    
+
+/* spCreate Permissions for MJ: Report Versions */
+
+GRANT EXECUTE ON [${flyway:defaultSchema}].[spCreateReportVersion] TO [cdp_Developer], [cdp_Integration]
+
+
+
+/* spUpdate SQL for MJ: Report Versions */
+-----------------------------------------------------------------
+-- SQL Code Generation
+-- Entity: MJ: Report Versions
+-- Item: spUpdateReportVersion
+--
+-- This was generated by the MemberJunction CodeGen tool.
+-- This file should NOT be edited by hand.
+-----------------------------------------------------------------
+
+------------------------------------------------------------
+----- UPDATE PROCEDURE FOR ReportVersion
+------------------------------------------------------------
+DROP PROCEDURE IF EXISTS [${flyway:defaultSchema}].[spUpdateReportVersion]
+GO
+
+CREATE PROCEDURE [${flyway:defaultSchema}].[spUpdateReportVersion]
+    @ID uniqueidentifier,
+    @ReportID uniqueidentifier,
+    @VersionNumber int,
+    @Name nvarchar(255),
+    @Description nvarchar(MAX),
+    @Configuration nvarchar(MAX),
+    @DataContextUpdated bit
+AS
+BEGIN
+    SET NOCOUNT ON;
+    UPDATE
+        [${flyway:defaultSchema}].[ReportVersion]
+    SET
+        [ReportID] = @ReportID,
+        [VersionNumber] = @VersionNumber,
+        [Name] = @Name,
+        [Description] = @Description,
+        [Configuration] = @Configuration,
+        [DataContextUpdated] = @DataContextUpdated
+    WHERE
+        [ID] = @ID
+
+    -- return the updated record so the caller can see the updated values and any calculated fields
+    SELECT
+                                        *
+                                    FROM
+                                        [${flyway:defaultSchema}].[vwReportVersions]
+                                    WHERE
+                                        [ID] = @ID
+                                    
+END
+GO
+
+GRANT EXECUTE ON [${flyway:defaultSchema}].[spUpdateReportVersion] TO [cdp_Developer], [cdp_Integration]
+GO
+
+------------------------------------------------------------
+----- TRIGGER FOR ${flyway:defaultSchema}_UpdatedAt field for the ReportVersion table
+------------------------------------------------------------
+DROP TRIGGER IF EXISTS [${flyway:defaultSchema}].trgUpdateReportVersion
+GO
+CREATE TRIGGER [${flyway:defaultSchema}].trgUpdateReportVersion
+ON [${flyway:defaultSchema}].[ReportVersion]
+AFTER UPDATE
+AS
+BEGIN
+    SET NOCOUNT ON;
+    UPDATE
+        [${flyway:defaultSchema}].[ReportVersion]
+    SET
+        ${flyway:defaultSchema}_UpdatedAt = GETUTCDATE()
+    FROM
+        [${flyway:defaultSchema}].[ReportVersion] AS _organicTable
+    INNER JOIN
+        INSERTED AS I ON
+        _organicTable.[ID] = I.[ID];
+END;
+GO
+        
+
+/* spUpdate Permissions for MJ: Report Versions */
+
+GRANT EXECUTE ON [${flyway:defaultSchema}].[spUpdateReportVersion] TO [cdp_Developer], [cdp_Integration]
+
+
+
+/* spDelete SQL for MJ: Report Versions */
+-----------------------------------------------------------------
+-- SQL Code Generation
+-- Entity: MJ: Report Versions
+-- Item: spDeleteReportVersion
+--
+-- This was generated by the MemberJunction CodeGen tool.
+-- This file should NOT be edited by hand.
+-----------------------------------------------------------------
+
+------------------------------------------------------------
+----- DELETE PROCEDURE FOR ReportVersion
+------------------------------------------------------------
+DROP PROCEDURE IF EXISTS [${flyway:defaultSchema}].[spDeleteReportVersion]
+GO
+
+CREATE PROCEDURE [${flyway:defaultSchema}].[spDeleteReportVersion]
+    @ID uniqueidentifier
+AS
+BEGIN
+    SET NOCOUNT ON;
+
+    DELETE FROM
+        [${flyway:defaultSchema}].[ReportVersion]
+    WHERE
+        [ID] = @ID
+
+
+    SELECT @ID AS [ID] -- Return the primary key to indicate we successfully deleted the record
+END
+GO
+GRANT EXECUTE ON [${flyway:defaultSchema}].[spDeleteReportVersion] TO [cdp_Integration]
+    
+
+/* spDelete Permissions for MJ: Report Versions */
+
+GRANT EXECUTE ON [${flyway:defaultSchema}].[spDeleteReportVersion] TO [cdp_Integration]
+
+
+
+-- CHECK constraint for MJ: Report Versions: Field: VersionNumber was newly set or modified since the last generation of the validation function, the code was regenerated and updating the GeneratedCode table with the new generated validation function
+INSERT INTO [${flyway:defaultSchema}].[GeneratedCode] (CategoryID, GeneratedByModelID, GeneratedAt, Language, Status, Source, Code, Description, Name, LinkedEntityID, LinkedRecordPrimaryKey)
+                      VALUES ((SELECT ID FROM ${flyway:defaultSchema}.vwGeneratedCodeCategories WHERE Name='CodeGen: Validators'), '0AE8548E-30A6-4FBC-8F69-6344D0CBAF2D', GETUTCDATE(), 'TypeScript','Approved', '([VersionNumber]>(0))', 'public ValidateVersionNumberGreaterThanZero(result: ValidationResult) {
+	if (this.VersionNumber <= 0) {
+		result.Errors.push(new ValidationErrorInfo("VersionNumber", "The version number must be greater than zero.", this.VersionNumber, ValidationErrorType.Failure));
+	}
+}', 'This rule ensures that the version number must be greater than zero, meaning there should be at least one version created.', 'ValidateVersionNumberGreaterThanZero', 'DF238F34-2837-EF11-86D4-6045BDEE16E6', '79BF06A4-D891-478D-8621-C0FF430B541A');
+  
+            
+
+---- MORE CODE GEN ----- 
+
+
+/* SQL text to insert new entity field */
+
+      IF NOT EXISTS (
+         SELECT 1 FROM [${flyway:defaultSchema}].EntityField 
+         WHERE ID = '037b2e85-2834-4052-aa6f-f6870dde0b53'  OR 
+               (EntityID = '4A4C2EE1-BFDD-434E-9A03-6F6C2384D01F' AND Name = 'Report')
+         -- check to make sure we're not inserting a duplicate entity field metadata record
+      )
+      BEGIN
+         INSERT INTO [${flyway:defaultSchema}].EntityField
+         (
+            ID,
+            EntityID,
+            Sequence,
+            Name,
+            DisplayName,
+            Description,
+            Type,
+            Length,
+            Precision,
+            Scale,
+            AllowsNull,
+            DefaultValue,
+            AutoIncrement,
+            AllowUpdateAPI,
+            IsVirtual,
+            RelatedEntityID,
+            RelatedEntityFieldName,
+            IsNameField,
+            IncludeInUserSearchAPI,
+            IncludeRelatedEntityNameFieldInBaseView,
+            DefaultInView,
+            IsPrimaryKey,
+            IsUnique,
+            RelatedEntityDisplayType
+         )
+         VALUES
+         (
+            '037b2e85-2834-4052-aa6f-f6870dde0b53',
+            '4A4C2EE1-BFDD-434E-9A03-6F6C2384D01F', -- Entity: MJ: Report User States
+            7,
+            'Report',
+            'Report',
+            NULL,
+            'nvarchar',
+            510,
+            0,
+            0,
+            0,
+            'null',
+            0,
+            0,
+            1,
+            NULL,
+            NULL,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            'Search'
+         )
+      END
+
+/* SQL text to insert new entity field */
+
+      IF NOT EXISTS (
+         SELECT 1 FROM [${flyway:defaultSchema}].EntityField 
+         WHERE ID = '1c327adb-fe15-4662-87db-74aced132059'  OR 
+               (EntityID = '4A4C2EE1-BFDD-434E-9A03-6F6C2384D01F' AND Name = 'User')
+         -- check to make sure we're not inserting a duplicate entity field metadata record
+      )
+      BEGIN
+         INSERT INTO [${flyway:defaultSchema}].EntityField
+         (
+            ID,
+            EntityID,
+            Sequence,
+            Name,
+            DisplayName,
+            Description,
+            Type,
+            Length,
+            Precision,
+            Scale,
+            AllowsNull,
+            DefaultValue,
+            AutoIncrement,
+            AllowUpdateAPI,
+            IsVirtual,
+            RelatedEntityID,
+            RelatedEntityFieldName,
+            IsNameField,
+            IncludeInUserSearchAPI,
+            IncludeRelatedEntityNameFieldInBaseView,
+            DefaultInView,
+            IsPrimaryKey,
+            IsUnique,
+            RelatedEntityDisplayType
+         )
+         VALUES
+         (
+            '1c327adb-fe15-4662-87db-74aced132059',
+            '4A4C2EE1-BFDD-434E-9A03-6F6C2384D01F', -- Entity: MJ: Report User States
+            8,
+            'User',
+            'User',
+            NULL,
+            'nvarchar',
+            200,
+            0,
+            0,
+            0,
+            'null',
+            0,
+            0,
+            1,
+            NULL,
+            NULL,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            'Search'
+         )
+      END
+
+/* SQL text to insert new entity field */
+
+      IF NOT EXISTS (
+         SELECT 1 FROM [${flyway:defaultSchema}].EntityField 
+         WHERE ID = '168eb427-6eec-4b92-98d4-aa669f6275a4'  OR 
+               (EntityID = '9516058D-9729-48EC-B0B8-E91A8221FC8F' AND Name = 'Report')
+         -- check to make sure we're not inserting a duplicate entity field metadata record
+      )
+      BEGIN
+         INSERT INTO [${flyway:defaultSchema}].EntityField
+         (
+            ID,
+            EntityID,
+            Sequence,
+            Name,
+            DisplayName,
+            Description,
+            Type,
+            Length,
+            Precision,
+            Scale,
+            AllowsNull,
+            DefaultValue,
+            AutoIncrement,
+            AllowUpdateAPI,
+            IsVirtual,
+            RelatedEntityID,
+            RelatedEntityFieldName,
+            IsNameField,
+            IncludeInUserSearchAPI,
+            IncludeRelatedEntityNameFieldInBaseView,
+            DefaultInView,
+            IsPrimaryKey,
+            IsUnique,
+            RelatedEntityDisplayType
+         )
+         VALUES
+         (
+            '168eb427-6eec-4b92-98d4-aa669f6275a4',
+            '9516058D-9729-48EC-B0B8-E91A8221FC8F', -- Entity: MJ: Report Versions
+            10,
+            'Report',
+            'Report',
+            NULL,
+            'nvarchar',
+            510,
+            0,
+            0,
+            0,
+            'null',
+            0,
+            0,
+            1,
+            NULL,
+            NULL,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            'Search'
+         )
+      END
+
+/* Index for Foreign Keys for ReportUserState */
+-----------------------------------------------------------------
+-- SQL Code Generation
+-- Entity: MJ: Report User States
+-- Item: Index for Foreign Keys
+--
+-- This was generated by the MemberJunction CodeGen tool.
+-- This file should NOT be edited by hand.
+-----------------------------------------------------------------
+-- Index for foreign key ReportID in table ReportUserState
+IF NOT EXISTS (
+    SELECT 1
+    FROM sys.indexes
+    WHERE name = 'IDX_AUTO_MJ_FKEY_ReportUserState_ReportID' 
+    AND object_id = OBJECT_ID('[${flyway:defaultSchema}].[ReportUserState]')
+)
+CREATE INDEX IDX_AUTO_MJ_FKEY_ReportUserState_ReportID ON [${flyway:defaultSchema}].[ReportUserState] ([ReportID]);
+
+-- Index for foreign key UserID in table ReportUserState
+IF NOT EXISTS (
+    SELECT 1
+    FROM sys.indexes
+    WHERE name = 'IDX_AUTO_MJ_FKEY_ReportUserState_UserID' 
+    AND object_id = OBJECT_ID('[${flyway:defaultSchema}].[ReportUserState]')
+)
+CREATE INDEX IDX_AUTO_MJ_FKEY_ReportUserState_UserID ON [${flyway:defaultSchema}].[ReportUserState] ([UserID]);
+
+/* Base View SQL for MJ: Report User States */
+-----------------------------------------------------------------
+-- SQL Code Generation
+-- Entity: MJ: Report User States
+-- Item: vwReportUserStates
+--
+-- This was generated by the MemberJunction CodeGen tool.
+-- This file should NOT be edited by hand.
+-----------------------------------------------------------------
+
+------------------------------------------------------------
+----- BASE VIEW FOR ENTITY:      MJ: Report User States
+-----               SCHEMA:      ${flyway:defaultSchema}
+-----               BASE TABLE:  ReportUserState
+-----               PRIMARY KEY: ID
+------------------------------------------------------------
+DROP VIEW IF EXISTS [${flyway:defaultSchema}].[vwReportUserStates]
+GO
+
+CREATE VIEW [${flyway:defaultSchema}].[vwReportUserStates]
+AS
+SELECT
+    r.*,
+    Report_ReportID.[Name] AS [Report],
+    User_UserID.[Name] AS [User]
+FROM
+    [${flyway:defaultSchema}].[ReportUserState] AS r
+INNER JOIN
+    [${flyway:defaultSchema}].[Report] AS Report_ReportID
+  ON
+    [r].[ReportID] = Report_ReportID.[ID]
+INNER JOIN
+    [${flyway:defaultSchema}].[User] AS User_UserID
+  ON
+    [r].[UserID] = User_UserID.[ID]
+GO
+GRANT SELECT ON [${flyway:defaultSchema}].[vwReportUserStates] TO [cdp_UI], [cdp_Developer], [cdp_Integration]
+    
+
+/* Base View Permissions SQL for MJ: Report User States */
+-----------------------------------------------------------------
+-- SQL Code Generation
+-- Entity: MJ: Report User States
+-- Item: Permissions for vwReportUserStates
+--
+-- This was generated by the MemberJunction CodeGen tool.
+-- This file should NOT be edited by hand.
+-----------------------------------------------------------------
+
+GRANT SELECT ON [${flyway:defaultSchema}].[vwReportUserStates] TO [cdp_UI], [cdp_Developer], [cdp_Integration]
+
+/* spCreate SQL for MJ: Report User States */
+-----------------------------------------------------------------
+-- SQL Code Generation
+-- Entity: MJ: Report User States
+-- Item: spCreateReportUserState
+--
+-- This was generated by the MemberJunction CodeGen tool.
+-- This file should NOT be edited by hand.
+-----------------------------------------------------------------
+
+------------------------------------------------------------
+----- CREATE PROCEDURE FOR ReportUserState
+------------------------------------------------------------
+DROP PROCEDURE IF EXISTS [${flyway:defaultSchema}].[spCreateReportUserState]
+GO
+
+CREATE PROCEDURE [${flyway:defaultSchema}].[spCreateReportUserState]
+    @ReportID uniqueidentifier,
+    @UserID uniqueidentifier,
+    @ReportState nvarchar(MAX)
+AS
+BEGIN
+    SET NOCOUNT ON;
+    DECLARE @InsertedRow TABLE ([ID] UNIQUEIDENTIFIER)
+    INSERT INTO
+    [${flyway:defaultSchema}].[ReportUserState]
+        (
+            [ReportID],
+            [UserID],
+            [ReportState]
+        )
+    OUTPUT INSERTED.[ID] INTO @InsertedRow
+    VALUES
+        (
+            @ReportID,
+            @UserID,
+            @ReportState
+        )
+    -- return the new record from the base view, which might have some calculated fields
+    SELECT * FROM [${flyway:defaultSchema}].[vwReportUserStates] WHERE [ID] = (SELECT [ID] FROM @InsertedRow)
+END
+GO
+GRANT EXECUTE ON [${flyway:defaultSchema}].[spCreateReportUserState] TO [cdp_Developer], [cdp_Integration]
+    
+
+/* spCreate Permissions for MJ: Report User States */
+
+GRANT EXECUTE ON [${flyway:defaultSchema}].[spCreateReportUserState] TO [cdp_Developer], [cdp_Integration]
+
+
+
+/* spUpdate SQL for MJ: Report User States */
+-----------------------------------------------------------------
+-- SQL Code Generation
+-- Entity: MJ: Report User States
+-- Item: spUpdateReportUserState
+--
+-- This was generated by the MemberJunction CodeGen tool.
+-- This file should NOT be edited by hand.
+-----------------------------------------------------------------
+
+------------------------------------------------------------
+----- UPDATE PROCEDURE FOR ReportUserState
+------------------------------------------------------------
+DROP PROCEDURE IF EXISTS [${flyway:defaultSchema}].[spUpdateReportUserState]
+GO
+
+CREATE PROCEDURE [${flyway:defaultSchema}].[spUpdateReportUserState]
+    @ID uniqueidentifier,
+    @ReportID uniqueidentifier,
+    @UserID uniqueidentifier,
+    @ReportState nvarchar(MAX)
+AS
+BEGIN
+    SET NOCOUNT ON;
+    UPDATE
+        [${flyway:defaultSchema}].[ReportUserState]
+    SET
+        [ReportID] = @ReportID,
+        [UserID] = @UserID,
+        [ReportState] = @ReportState
+    WHERE
+        [ID] = @ID
+
+    -- return the updated record so the caller can see the updated values and any calculated fields
+    SELECT
+                                        *
+                                    FROM
+                                        [${flyway:defaultSchema}].[vwReportUserStates]
+                                    WHERE
+                                        [ID] = @ID
+                                    
+END
+GO
+
+GRANT EXECUTE ON [${flyway:defaultSchema}].[spUpdateReportUserState] TO [cdp_Developer], [cdp_Integration]
+GO
+
+------------------------------------------------------------
+----- TRIGGER FOR ${flyway:defaultSchema}_UpdatedAt field for the ReportUserState table
+------------------------------------------------------------
+DROP TRIGGER IF EXISTS [${flyway:defaultSchema}].trgUpdateReportUserState
+GO
+CREATE TRIGGER [${flyway:defaultSchema}].trgUpdateReportUserState
+ON [${flyway:defaultSchema}].[ReportUserState]
+AFTER UPDATE
+AS
+BEGIN
+    SET NOCOUNT ON;
+    UPDATE
+        [${flyway:defaultSchema}].[ReportUserState]
+    SET
+        ${flyway:defaultSchema}_UpdatedAt = GETUTCDATE()
+    FROM
+        [${flyway:defaultSchema}].[ReportUserState] AS _organicTable
+    INNER JOIN
+        INSERTED AS I ON
+        _organicTable.[ID] = I.[ID];
+END;
+GO
+        
+
+/* spUpdate Permissions for MJ: Report User States */
+
+GRANT EXECUTE ON [${flyway:defaultSchema}].[spUpdateReportUserState] TO [cdp_Developer], [cdp_Integration]
+
+
+
+/* spDelete SQL for MJ: Report User States */
+-----------------------------------------------------------------
+-- SQL Code Generation
+-- Entity: MJ: Report User States
+-- Item: spDeleteReportUserState
+--
+-- This was generated by the MemberJunction CodeGen tool.
+-- This file should NOT be edited by hand.
+-----------------------------------------------------------------
+
+------------------------------------------------------------
+----- DELETE PROCEDURE FOR ReportUserState
+------------------------------------------------------------
+DROP PROCEDURE IF EXISTS [${flyway:defaultSchema}].[spDeleteReportUserState]
+GO
+
+CREATE PROCEDURE [${flyway:defaultSchema}].[spDeleteReportUserState]
+    @ID uniqueidentifier
+AS
+BEGIN
+    SET NOCOUNT ON;
+
+    DELETE FROM
+        [${flyway:defaultSchema}].[ReportUserState]
+    WHERE
+        [ID] = @ID
+
+
+    SELECT @ID AS [ID] -- Return the primary key to indicate we successfully deleted the record
+END
+GO
+GRANT EXECUTE ON [${flyway:defaultSchema}].[spDeleteReportUserState] TO [cdp_Integration]
+    
+
+/* spDelete Permissions for MJ: Report User States */
+
+GRANT EXECUTE ON [${flyway:defaultSchema}].[spDeleteReportUserState] TO [cdp_Integration]
+
+
+
+/* Index for Foreign Keys for ReportVersion */
+-----------------------------------------------------------------
+-- SQL Code Generation
+-- Entity: MJ: Report Versions
+-- Item: Index for Foreign Keys
+--
+-- This was generated by the MemberJunction CodeGen tool.
+-- This file should NOT be edited by hand.
+-----------------------------------------------------------------
+-- Index for foreign key ReportID in table ReportVersion
+IF NOT EXISTS (
+    SELECT 1
+    FROM sys.indexes
+    WHERE name = 'IDX_AUTO_MJ_FKEY_ReportVersion_ReportID' 
+    AND object_id = OBJECT_ID('[${flyway:defaultSchema}].[ReportVersion]')
+)
+CREATE INDEX IDX_AUTO_MJ_FKEY_ReportVersion_ReportID ON [${flyway:defaultSchema}].[ReportVersion] ([ReportID]);
+
+/* Base View SQL for MJ: Report Versions */
+-----------------------------------------------------------------
+-- SQL Code Generation
+-- Entity: MJ: Report Versions
+-- Item: vwReportVersions
+--
+-- This was generated by the MemberJunction CodeGen tool.
+-- This file should NOT be edited by hand.
+-----------------------------------------------------------------
+
+------------------------------------------------------------
+----- BASE VIEW FOR ENTITY:      MJ: Report Versions
+-----               SCHEMA:      ${flyway:defaultSchema}
+-----               BASE TABLE:  ReportVersion
+-----               PRIMARY KEY: ID
+------------------------------------------------------------
+DROP VIEW IF EXISTS [${flyway:defaultSchema}].[vwReportVersions]
+GO
+
+CREATE VIEW [${flyway:defaultSchema}].[vwReportVersions]
+AS
+SELECT
+    r.*,
+    Report_ReportID.[Name] AS [Report]
+FROM
+    [${flyway:defaultSchema}].[ReportVersion] AS r
+INNER JOIN
+    [${flyway:defaultSchema}].[Report] AS Report_ReportID
+  ON
+    [r].[ReportID] = Report_ReportID.[ID]
+GO
+GRANT SELECT ON [${flyway:defaultSchema}].[vwReportVersions] TO [cdp_UI], [cdp_Developer], [cdp_Integration]
+    
+
+/* Base View Permissions SQL for MJ: Report Versions */
+-----------------------------------------------------------------
+-- SQL Code Generation
+-- Entity: MJ: Report Versions
+-- Item: Permissions for vwReportVersions
+--
+-- This was generated by the MemberJunction CodeGen tool.
+-- This file should NOT be edited by hand.
+-----------------------------------------------------------------
+
+GRANT SELECT ON [${flyway:defaultSchema}].[vwReportVersions] TO [cdp_UI], [cdp_Developer], [cdp_Integration]
+
+/* spCreate SQL for MJ: Report Versions */
+-----------------------------------------------------------------
+-- SQL Code Generation
+-- Entity: MJ: Report Versions
+-- Item: spCreateReportVersion
+--
+-- This was generated by the MemberJunction CodeGen tool.
+-- This file should NOT be edited by hand.
+-----------------------------------------------------------------
+
+------------------------------------------------------------
+----- CREATE PROCEDURE FOR ReportVersion
+------------------------------------------------------------
+DROP PROCEDURE IF EXISTS [${flyway:defaultSchema}].[spCreateReportVersion]
+GO
+
+CREATE PROCEDURE [${flyway:defaultSchema}].[spCreateReportVersion]
+    @ReportID uniqueidentifier,
+    @VersionNumber int,
+    @Name nvarchar(255),
+    @Description nvarchar(MAX),
+    @Configuration nvarchar(MAX),
+    @DataContextUpdated bit
+AS
+BEGIN
+    SET NOCOUNT ON;
+    DECLARE @InsertedRow TABLE ([ID] UNIQUEIDENTIFIER)
+    INSERT INTO
+    [${flyway:defaultSchema}].[ReportVersion]
+        (
+            [ReportID],
+            [VersionNumber],
+            [Name],
+            [Description],
+            [Configuration],
+            [DataContextUpdated]
+        )
+    OUTPUT INSERTED.[ID] INTO @InsertedRow
+    VALUES
+        (
+            @ReportID,
+            @VersionNumber,
+            @Name,
+            @Description,
+            @Configuration,
+            @DataContextUpdated
+        )
+    -- return the new record from the base view, which might have some calculated fields
+    SELECT * FROM [${flyway:defaultSchema}].[vwReportVersions] WHERE [ID] = (SELECT [ID] FROM @InsertedRow)
+END
+GO
+GRANT EXECUTE ON [${flyway:defaultSchema}].[spCreateReportVersion] TO [cdp_Developer], [cdp_Integration]
+    
+
+/* spCreate Permissions for MJ: Report Versions */
+
+GRANT EXECUTE ON [${flyway:defaultSchema}].[spCreateReportVersion] TO [cdp_Developer], [cdp_Integration]
+
+
+
+/* spUpdate SQL for MJ: Report Versions */
+-----------------------------------------------------------------
+-- SQL Code Generation
+-- Entity: MJ: Report Versions
+-- Item: spUpdateReportVersion
+--
+-- This was generated by the MemberJunction CodeGen tool.
+-- This file should NOT be edited by hand.
+-----------------------------------------------------------------
+
+------------------------------------------------------------
+----- UPDATE PROCEDURE FOR ReportVersion
+------------------------------------------------------------
+DROP PROCEDURE IF EXISTS [${flyway:defaultSchema}].[spUpdateReportVersion]
+GO
+
+CREATE PROCEDURE [${flyway:defaultSchema}].[spUpdateReportVersion]
+    @ID uniqueidentifier,
+    @ReportID uniqueidentifier,
+    @VersionNumber int,
+    @Name nvarchar(255),
+    @Description nvarchar(MAX),
+    @Configuration nvarchar(MAX),
+    @DataContextUpdated bit
+AS
+BEGIN
+    SET NOCOUNT ON;
+    UPDATE
+        [${flyway:defaultSchema}].[ReportVersion]
+    SET
+        [ReportID] = @ReportID,
+        [VersionNumber] = @VersionNumber,
+        [Name] = @Name,
+        [Description] = @Description,
+        [Configuration] = @Configuration,
+        [DataContextUpdated] = @DataContextUpdated
+    WHERE
+        [ID] = @ID
+
+    -- return the updated record so the caller can see the updated values and any calculated fields
+    SELECT
+                                        *
+                                    FROM
+                                        [${flyway:defaultSchema}].[vwReportVersions]
+                                    WHERE
+                                        [ID] = @ID
+                                    
+END
+GO
+
+GRANT EXECUTE ON [${flyway:defaultSchema}].[spUpdateReportVersion] TO [cdp_Developer], [cdp_Integration]
+GO
+
+------------------------------------------------------------
+----- TRIGGER FOR ${flyway:defaultSchema}_UpdatedAt field for the ReportVersion table
+------------------------------------------------------------
+DROP TRIGGER IF EXISTS [${flyway:defaultSchema}].trgUpdateReportVersion
+GO
+CREATE TRIGGER [${flyway:defaultSchema}].trgUpdateReportVersion
+ON [${flyway:defaultSchema}].[ReportVersion]
+AFTER UPDATE
+AS
+BEGIN
+    SET NOCOUNT ON;
+    UPDATE
+        [${flyway:defaultSchema}].[ReportVersion]
+    SET
+        ${flyway:defaultSchema}_UpdatedAt = GETUTCDATE()
+    FROM
+        [${flyway:defaultSchema}].[ReportVersion] AS _organicTable
+    INNER JOIN
+        INSERTED AS I ON
+        _organicTable.[ID] = I.[ID];
+END;
+GO
+        
+
+/* spUpdate Permissions for MJ: Report Versions */
+
+GRANT EXECUTE ON [${flyway:defaultSchema}].[spUpdateReportVersion] TO [cdp_Developer], [cdp_Integration]
+
+
+
+/* spDelete SQL for MJ: Report Versions */
+-----------------------------------------------------------------
+-- SQL Code Generation
+-- Entity: MJ: Report Versions
+-- Item: spDeleteReportVersion
+--
+-- This was generated by the MemberJunction CodeGen tool.
+-- This file should NOT be edited by hand.
+-----------------------------------------------------------------
+
+------------------------------------------------------------
+----- DELETE PROCEDURE FOR ReportVersion
+------------------------------------------------------------
+DROP PROCEDURE IF EXISTS [${flyway:defaultSchema}].[spDeleteReportVersion]
+GO
+
+CREATE PROCEDURE [${flyway:defaultSchema}].[spDeleteReportVersion]
+    @ID uniqueidentifier
+AS
+BEGIN
+    SET NOCOUNT ON;
+
+    DELETE FROM
+        [${flyway:defaultSchema}].[ReportVersion]
+    WHERE
+        [ID] = @ID
+
+
+    SELECT @ID AS [ID] -- Return the primary key to indicate we successfully deleted the record
+END
+GO
+GRANT EXECUTE ON [${flyway:defaultSchema}].[spDeleteReportVersion] TO [cdp_Integration]
+    
+
+/* spDelete Permissions for MJ: Report Versions */
+
+GRANT EXECUTE ON [${flyway:defaultSchema}].[spDeleteReportVersion] TO [cdp_Integration]
+
+
+

--- a/mj.config.cjs
+++ b/mj.config.cjs
@@ -1,5 +1,6 @@
 /** @import { ConfigInfo as CodeGenConfig } from "./packages/CodeGenLib/src/Config/config" */
 /** @import { ConfigInfo as MJServerConfig } from "./packages/MJServer/src/config" */
+/** @import { ConfigInfo as MCPServerConfig } from "./packages/AI/MCPServer/src/config" */
 /** @import { MJConfig } from "./packages/MJCLI/src/config" */
 
 /** @type {CodeGenConfig} */
@@ -264,10 +265,36 @@ const mjServerConfig = {
   },
 };
 
+/** @type {MCPServerConfig} */
+const mcpServerConfig = {
+  mcpServerSettings: {
+    port: 3100,
+    enableMCPServer: true,
+    actionTools: [
+      {
+        actionName: 'NOT YET SUPPORTED',
+        actionCategory: '*',
+      }
+    ],
+    entityTools: [
+      {
+        schemaName: 'CRM',
+        entityName: '*',
+        get: true,
+        create: true,
+        update: true,
+        delete: true,
+        runView: true,
+      },
+    ]
+  }
+}
+
 /** @type {CodeGenConfig & MJConfig & MJServerConfig} */
 const config = {
   ...codegenConfig,
   ...mjServerConfig,
+  ...mcpServerConfig,
 
   /**
    * Shared Configuration and Environment Variables

--- a/package-lock.json
+++ b/package-lock.json
@@ -6964,6 +6964,10 @@
       "resolved": "packages/AI/Providers/HeyGen",
       "link": true
     },
+    "node_modules/@memberjunction/ai-mcp-server": {
+      "resolved": "packages/AI/MCPServer",
+      "link": true
+    },
     "node_modules/@memberjunction/ai-mistral": {
       "resolved": "packages/AI/Providers/Mistral",
       "link": true
@@ -7294,6 +7298,396 @@
       },
       "peerDependencies": {
         "zod": ">= 3"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.8.0.tgz",
+      "integrity": "sha512-e06W7SwrontJDHwCawNO5SGxG+nU9AAx+jpHHZqGl/WrDBdWOpvirC+s58VpJTB5QemI4jTRcjWT4Pt3Q1NPQQ==",
+      "license": "MIT",
+      "dependencies": {
+        "content-type": "^1.0.5",
+        "cors": "^2.8.5",
+        "cross-spawn": "^7.0.3",
+        "eventsource": "^3.0.2",
+        "express": "^5.0.1",
+        "express-rate-limit": "^7.5.0",
+        "pkce-challenge": "^4.1.0",
+        "raw-body": "^3.0.0",
+        "zod": "^3.23.8",
+        "zod-to-json-schema": "^3.24.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/accepts": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
+      "integrity": "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-types": "^3.0.0",
+        "negotiator": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/body-parser": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.2.0.tgz",
+      "integrity": "sha512-02qvAaxv8tp7fBa/mw1ga98OGm+eCbqzJOKoRt70sLmfEEi+jyBYVTDGfCL/k06/4EMk/z01gCe7HoCH/f2LTg==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "^3.1.2",
+        "content-type": "^1.0.5",
+        "debug": "^4.4.0",
+        "http-errors": "^2.0.0",
+        "iconv-lite": "^0.6.3",
+        "on-finished": "^2.4.1",
+        "qs": "^6.14.0",
+        "raw-body": "^3.0.0",
+        "type-is": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/body-parser/node_modules/debug": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.0.tgz",
+      "integrity": "sha512-6WTZ/IxCY/T6BALoZHaE4ctp9xm+Z5kY/pzYaCHRFeyVhojxlrm+46y68HA6hr0TcwEssoxNiDEUJQjfPZ/RYA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/body-parser/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/body-parser/node_modules/qs": {
+      "version": "6.14.0",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.0.tgz",
+      "integrity": "sha512-YWWTjgABSKcvs/nWBi9PycY/JiPJqOD4JA6o9Sej2AtvSGarXxKC3OQSk4pAarbdQlKAh5D4FCQkJNkW+GAn3w==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "side-channel": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/content-disposition": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.0.0.tgz",
+      "integrity": "sha512-Au9nRL8VNUut/XSzbQA38+M78dzP4D+eqg3gfJHMIHHYa3bg067xj1KxMUWj+VULbiZMowKngFFbKczUrNJ1mg==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "5.2.1"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/cookie": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.1.tgz",
+      "integrity": "sha512-6DnInpx7SJ2AK3+CTUE/ZM0vWTUboZCegxhC2xiIydHR9jNuTAASBrfEpHhiGOZw/nX51bHt6YQl8jsGo4y/0w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/cookie-signature": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.2.tgz",
+      "integrity": "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.6.0"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/debug": {
+      "version": "4.3.6",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.6.tgz",
+      "integrity": "sha512-O/09Bd4Z1fBrU4VzkhFqVgpPzaGbw6Sm9FEkBT1A/YBXQFGuuSxa1dN2nxgxS34JmKXqYx8CZAwEVoJFImUXIg==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "2.1.2"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/encodeurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
+      "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/express": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/express/-/express-5.0.1.tgz",
+      "integrity": "sha512-ORF7g6qGnD+YtUG9yx4DFoqCShNMmUKiXuT5oWMHiOvt/4WFbHC6yCwQMTSBMno7AqntNCAzzcnnjowRkTL9eQ==",
+      "license": "MIT",
+      "dependencies": {
+        "accepts": "^2.0.0",
+        "body-parser": "^2.0.1",
+        "content-disposition": "^1.0.0",
+        "content-type": "~1.0.4",
+        "cookie": "0.7.1",
+        "cookie-signature": "^1.2.1",
+        "debug": "4.3.6",
+        "depd": "2.0.0",
+        "encodeurl": "~2.0.0",
+        "escape-html": "~1.0.3",
+        "etag": "~1.8.1",
+        "finalhandler": "^2.0.0",
+        "fresh": "2.0.0",
+        "http-errors": "2.0.0",
+        "merge-descriptors": "^2.0.0",
+        "methods": "~1.1.2",
+        "mime-types": "^3.0.0",
+        "on-finished": "2.4.1",
+        "once": "1.4.0",
+        "parseurl": "~1.3.3",
+        "proxy-addr": "~2.0.7",
+        "qs": "6.13.0",
+        "range-parser": "~1.2.1",
+        "router": "^2.0.0",
+        "safe-buffer": "5.2.1",
+        "send": "^1.1.0",
+        "serve-static": "^2.1.0",
+        "setprototypeof": "1.2.0",
+        "statuses": "2.0.1",
+        "type-is": "^2.0.0",
+        "utils-merge": "1.0.1",
+        "vary": "~1.1.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/finalhandler": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.0.tgz",
+      "integrity": "sha512-/t88Ty3d5JWQbWYgaOGCCYfXRwV1+be02WqYYlL6h0lEiUAMPM8o8qKGO01YIkOHzka2up08wvgYD0mDiI+q3Q==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "on-finished": "^2.4.1",
+        "parseurl": "^1.3.3",
+        "statuses": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/finalhandler/node_modules/debug": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.0.tgz",
+      "integrity": "sha512-6WTZ/IxCY/T6BALoZHaE4ctp9xm+Z5kY/pzYaCHRFeyVhojxlrm+46y68HA6hr0TcwEssoxNiDEUJQjfPZ/RYA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/finalhandler/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/fresh": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-2.0.0.tgz",
+      "integrity": "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/media-typer": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.0.tgz",
+      "integrity": "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/merge-descriptors": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-2.0.0.tgz",
+      "integrity": "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/mime-db": {
+      "version": "1.54.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/mime-types": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.1.tgz",
+      "integrity": "sha512-xRc4oEhT6eaBpU1XF7AjpOFD+xQmXNB5OVKwp4tqCuBpHLS/ZbBDrc07mYTDqVMg6PfxUjjNp85O6Cd2Z/5HWA==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "^1.54.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/negotiator": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
+      "integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/qs": {
+      "version": "6.13.0",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.13.0.tgz",
+      "integrity": "sha512-+38qI9SOr8tfZ4QmJNplMUxqjbe7LKvvZgWdExBOmd+egZTtjLB67Gu0HRX3u/XOq7UU2Nx6nsjvS16Z9uwfpg==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "side-channel": "^1.0.6"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/raw-body": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.0.tgz",
+      "integrity": "sha512-RmkhL8CAyCRPXCE28MMH0z2PNWQBNk2Q09ZdxM9IOOXwxwZbN+qbWaatPkdkWIKL2ZVDImrN/pK5HTRz2PcS4g==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "3.1.2",
+        "http-errors": "2.0.0",
+        "iconv-lite": "0.6.3",
+        "unpipe": "1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/send": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/send/-/send-1.2.0.tgz",
+      "integrity": "sha512-uaW0WwXKpL9blXE2o0bRhoL2EGXIrZxQ2ZQ4mgcfoBxdFmQold+qWsD2jLrfZ0trjKL6vOw0j//eAwcALFjKSw==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.3.5",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.0",
+        "mime-types": "^3.0.1",
+        "ms": "^2.1.3",
+        "on-finished": "^2.4.1",
+        "range-parser": "^1.2.1",
+        "statuses": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/send/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/serve-static": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-2.2.0.tgz",
+      "integrity": "sha512-61g9pCh0Vnh7IutZjtLGGpTA355+OPn2TyDv/6ivP2h/AdAVX9azsoxmg2/M6nZeQZNYBEwIcsne1mJd9oQItQ==",
+      "license": "MIT",
+      "dependencies": {
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "parseurl": "^1.3.3",
+        "send": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/type-is": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.0.1.tgz",
+      "integrity": "sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==",
+      "license": "MIT",
+      "dependencies": {
+        "content-type": "^1.0.5",
+        "media-typer": "^1.1.0",
+        "mime-types": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
       }
     },
     "node_modules/@msgpackr-extract/msgpackr-extract-darwin-arm64": {
@@ -9372,6 +9766,12 @@
       "version": "3.2.1",
       "license": "MIT"
     },
+    "node_modules/@sec-ant/readable-stream": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@sec-ant/readable-stream/-/readable-stream-0.4.1.tgz",
+      "integrity": "sha512-831qok9r2t8AlxLko40y2ebgSDhenenCatLVeW/uBtnHPyhHOvG0C7TvfgecV+wHzIm5KUICgzmVpWS+IMEAeg==",
+      "license": "MIT"
+    },
     "node_modules/@selderee/plugin-htmlparser2": {
       "version": "0.11.0",
       "license": "MIT",
@@ -10195,6 +10595,64 @@
     "node_modules/@tempfix/idb": {
       "version": "8.0.3",
       "license": "ISC"
+    },
+    "node_modules/@tokenizer/inflate": {
+      "version": "0.2.7",
+      "resolved": "https://registry.npmjs.org/@tokenizer/inflate/-/inflate-0.2.7.tgz",
+      "integrity": "sha512-MADQgmZT1eKjp06jpI2yozxaU9uVs4GzzgSL+uEq7bVcJ9V1ZXQkeGNql1fsSI0gMy1vhvNTNbUqrx+pZfJVmg==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "fflate": "^0.8.2",
+        "token-types": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Borewit"
+      }
+    },
+    "node_modules/@tokenizer/inflate/node_modules/debug": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.0.tgz",
+      "integrity": "sha512-6WTZ/IxCY/T6BALoZHaE4ctp9xm+Z5kY/pzYaCHRFeyVhojxlrm+46y68HA6hr0TcwEssoxNiDEUJQjfPZ/RYA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@tokenizer/inflate/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/@tokenizer/inflate/node_modules/token-types": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/token-types/-/token-types-6.0.0.tgz",
+      "integrity": "sha512-lbDrTLVsHhOMljPscd0yitpozq7Ga2M5Cvez5AjGg8GASBjtt6iERCAJ93yommPmz62fb45oFIXHEZ3u9bfJEA==",
+      "license": "MIT",
+      "dependencies": {
+        "@tokenizer/token": "^0.3.0",
+        "ieee754": "^1.2.1"
+      },
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Borewit"
+      }
     },
     "node_modules/@tokenizer/token": {
       "version": "0.3.0",
@@ -13072,6 +13530,32 @@
         "layout-base": "^1.0.0"
       }
     },
+    "node_modules/cosmiconfig": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-9.0.0.tgz",
+      "integrity": "sha512-itvL5h8RETACmOTFc4UfIyB2RfEHi71Ax6E/PivVxq9NseKbOWpeyHEOIbmAw1rs8Ak0VursQNww7lf7YtUwzg==",
+      "license": "MIT",
+      "dependencies": {
+        "env-paths": "^2.2.1",
+        "import-fresh": "^3.3.0",
+        "js-yaml": "^4.1.0",
+        "parse-json": "^5.2.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/d-fischer"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.9.5"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/crc-32": {
       "version": "1.2.2",
       "license": "Apache-2.0",
@@ -15475,6 +15959,27 @@
         "node": ">=0.8.x"
       }
     },
+    "node_modules/eventsource": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-3.0.6.tgz",
+      "integrity": "sha512-l19WpE2m9hSuyP06+FbuUUf1G+R0SFLrtQfbRb9PRr+oimOfxQhgGCbVaXg5IvZyyTThJsxh6L/srkMiCeBPDA==",
+      "license": "MIT",
+      "dependencies": {
+        "eventsource-parser": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/eventsource-parser": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.0.1.tgz",
+      "integrity": "sha512-VARTJ9CYeuQYb0pZEPbzi740OWFgpHe7AYJ2WFZVnUDUQp5Dk2yJUgF36YsZ81cOyxT0QxmXD2EQpapAouzWVA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
     "node_modules/execa": {
       "version": "5.1.1",
       "license": "MIT",
@@ -15539,6 +16044,21 @@
       },
       "engines": {
         "node": ">= 0.10.0"
+      }
+    },
+    "node_modules/express-rate-limit": {
+      "version": "7.5.0",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-7.5.0.tgz",
+      "integrity": "sha512-eB5zbQh5h+VenMPM3fh+nw1YExi5nMr6HUCR62ELSP11huvxm/Uir1H1QEyTkk5QX6A58pX6NmaTMceKZ0Eodg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/express-rate-limit"
+      },
+      "peerDependencies": {
+        "express": "^4.11 || 5 || ^5.0.0-beta.1"
       }
     },
     "node_modules/express/node_modules/debug": {
@@ -15739,6 +16259,253 @@
         "node": ">= 4.9.1"
       }
     },
+    "node_modules/fastmcp": {
+      "version": "1.20.5",
+      "resolved": "https://registry.npmjs.org/fastmcp/-/fastmcp-1.20.5.tgz",
+      "integrity": "sha512-jwcPgMF9bcE9qsEG82YMlAG26/n5CSYsr95e60ntqWWd+3kgTBbUIasB3HfpqHLTNaQuoX6/jl18fpDcybBjcQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@modelcontextprotocol/sdk": "^1.6.0",
+        "execa": "^9.5.2",
+        "file-type": "^20.3.0",
+        "fuse.js": "^7.1.0",
+        "mcp-proxy": "^2.10.4",
+        "strict-event-emitter-types": "^2.0.0",
+        "undici": "^7.4.0",
+        "uri-templates": "^0.2.0",
+        "yargs": "^17.7.2",
+        "zod": "^3.24.2",
+        "zod-to-json-schema": "^3.24.3"
+      },
+      "bin": {
+        "fastmcp": "dist/bin/fastmcp.js"
+      }
+    },
+    "node_modules/fastmcp/node_modules/@sindresorhus/merge-streams": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@sindresorhus/merge-streams/-/merge-streams-4.0.0.tgz",
+      "integrity": "sha512-tlqY9xq5ukxTUZBmoOp+m61cqwQD5pHJtFY3Mn8CA8ps6yghLH/Hw8UPdqg4OLmFW3IFlcXnQNmo/dh8HzXYIQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/fastmcp/node_modules/execa": {
+      "version": "9.5.2",
+      "resolved": "https://registry.npmjs.org/execa/-/execa-9.5.2.tgz",
+      "integrity": "sha512-EHlpxMCpHWSAh1dgS6bVeoLAXGnJNdR93aabr4QCGbzOM73o5XmRfM/e5FUqsw3aagP8S8XEWUWFAxnRBnAF0Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@sindresorhus/merge-streams": "^4.0.0",
+        "cross-spawn": "^7.0.3",
+        "figures": "^6.1.0",
+        "get-stream": "^9.0.0",
+        "human-signals": "^8.0.0",
+        "is-plain-obj": "^4.1.0",
+        "is-stream": "^4.0.1",
+        "npm-run-path": "^6.0.0",
+        "pretty-ms": "^9.0.0",
+        "signal-exit": "^4.1.0",
+        "strip-final-newline": "^4.0.0",
+        "yoctocolors": "^2.0.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.5.0"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/execa?sponsor=1"
+      }
+    },
+    "node_modules/fastmcp/node_modules/file-type": {
+      "version": "20.4.1",
+      "resolved": "https://registry.npmjs.org/file-type/-/file-type-20.4.1.tgz",
+      "integrity": "sha512-hw9gNZXUfZ02Jo0uafWLaFVPter5/k2rfcrjFJJHX/77xtSDOfJuEFb6oKlFV86FLP1SuyHMW1PSk0U9M5tKkQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@tokenizer/inflate": "^0.2.6",
+        "strtok3": "^10.2.0",
+        "token-types": "^6.0.0",
+        "uint8array-extras": "^1.4.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/file-type?sponsor=1"
+      }
+    },
+    "node_modules/fastmcp/node_modules/get-stream": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-9.0.1.tgz",
+      "integrity": "sha512-kVCxPF3vQM/N0B1PmoqVUqgHP+EeVjmZSQn+1oCRPxd2P21P2F19lIgbR3HBosbB1PUhOAoctJnfEn2GbN2eZA==",
+      "license": "MIT",
+      "dependencies": {
+        "@sec-ant/readable-stream": "^0.4.1",
+        "is-stream": "^4.0.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/fastmcp/node_modules/human-signals": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-8.0.1.tgz",
+      "integrity": "sha512-eKCa6bwnJhvxj14kZk5NCPc6Hb6BdsU9DZcOnmQKSnO1VKrfV0zCvtttPZUsBvjmNDn8rpcJfpwSYnHBjc95MQ==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/fastmcp/node_modules/is-plain-obj": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-4.1.0.tgz",
+      "integrity": "sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/fastmcp/node_modules/is-stream": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-4.0.1.tgz",
+      "integrity": "sha512-Dnz92NInDqYckGEUJv689RbRiTSEHCQ7wOVeALbkOz999YpqT46yMRIGtSNl2iCL1waAZSx40+h59NV/EwzV/A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/fastmcp/node_modules/npm-run-path": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-6.0.0.tgz",
+      "integrity": "sha512-9qny7Z9DsQU8Ou39ERsPU4OZQlSTP47ShQzuKZ6PRXpYLtIFgl/DEBYEXKlvcEa+9tHVcK8CF81Y2V72qaZhWA==",
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^4.0.0",
+        "unicorn-magic": "^0.3.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/fastmcp/node_modules/path-key": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-4.0.0.tgz",
+      "integrity": "sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/fastmcp/node_modules/peek-readable": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/peek-readable/-/peek-readable-7.0.0.tgz",
+      "integrity": "sha512-nri2TO5JE3/mRryik9LlHFT53cgHfRK0Lt0BAZQXku/AW3E6XLt2GaY8siWi7dvW/m1z0ecn+J+bpDa9ZN3IsQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Borewit"
+      }
+    },
+    "node_modules/fastmcp/node_modules/signal-exit": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/fastmcp/node_modules/strip-final-newline": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-4.0.0.tgz",
+      "integrity": "sha512-aulFJcD6YK8V1G7iRB5tigAP4TsHBZZrOV8pjV++zdUwmeV8uzbY7yn6h9MswN62adStNZFuCIx4haBnRuMDaw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/fastmcp/node_modules/strtok3": {
+      "version": "10.2.2",
+      "resolved": "https://registry.npmjs.org/strtok3/-/strtok3-10.2.2.tgz",
+      "integrity": "sha512-Xt18+h4s7Z8xyZ0tmBoRmzxcop97R4BAh+dXouUDCYn+Em+1P3qpkUfI5ueWLT8ynC5hZ+q4iPEmGG1urvQGBg==",
+      "license": "MIT",
+      "dependencies": {
+        "@tokenizer/token": "^0.3.0",
+        "peek-readable": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Borewit"
+      }
+    },
+    "node_modules/fastmcp/node_modules/token-types": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/token-types/-/token-types-6.0.0.tgz",
+      "integrity": "sha512-lbDrTLVsHhOMljPscd0yitpozq7Ga2M5Cvez5AjGg8GASBjtt6iERCAJ93yommPmz62fb45oFIXHEZ3u9bfJEA==",
+      "license": "MIT",
+      "dependencies": {
+        "@tokenizer/token": "^0.3.0",
+        "ieee754": "^1.2.1"
+      },
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Borewit"
+      }
+    },
+    "node_modules/fastmcp/node_modules/undici": {
+      "version": "7.6.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.6.0.tgz",
+      "integrity": "sha512-gaFsbThjrDGvAaD670r81RZro/s6H2PVZF640Qn0p5kZK+/rim7/mmyfp2W7VB5vOMaFM8vuFBJUaMlaZTYHlA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.1"
+      }
+    },
+    "node_modules/fastmcp/node_modules/unicorn-magic": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/unicorn-magic/-/unicorn-magic-0.3.0.tgz",
+      "integrity": "sha512-+QBBXBCvifc56fsbuxZQ6Sic3wqqc3WWaqxs58gvJrcOuN83HGTCwz3oS5phzU9LthRNE9VrJCFCLUgHeeFnfA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/fastq": {
       "version": "1.17.1",
       "license": "ISC",
@@ -15764,6 +16531,12 @@
         "pend": "~1.2.0"
       }
     },
+    "node_modules/fflate": {
+      "version": "0.8.2",
+      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.8.2.tgz",
+      "integrity": "sha512-cPJU47OaAoCbg0pBvzsgpTPhmhqI5eJjh/JIu8tPj5q+T7iLvW/JAYUqmE7KOB4R1ZyEhzBaIQpQpardBF5z8A==",
+      "license": "MIT"
+    },
     "node_modules/figlet": {
       "version": "1.7.0",
       "license": "MIT",
@@ -15772,6 +16545,21 @@
       },
       "engines": {
         "node": ">= 0.4.0"
+      }
+    },
+    "node_modules/figures": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/figures/-/figures-6.1.0.tgz",
+      "integrity": "sha512-d+l3qxjSesT4V7v2fh+QnmFnUWv9lSpjarhShNTgBOfA0ttejbQUAlHLitbjkoRiDulW0OPoQPYIGhIC8ohejg==",
+      "license": "MIT",
+      "dependencies": {
+        "is-unicode-supported": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/file-entry-cache": {
@@ -16091,6 +16879,15 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/fuse.js": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/fuse.js/-/fuse.js-7.1.0.tgz",
+      "integrity": "sha512-trLf4SzuuUxfusZADLINj+dE8clK1frKdmqiJNb1Es75fmI5oY6X2mxLVUciLLjxqw/xr72Dhy+lER6dGd02FQ==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/gaxios": {
@@ -17583,6 +18380,12 @@
       "version": "1.0.1",
       "license": "MIT"
     },
+    "node_modules/is-promise": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
+      "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
+      "license": "MIT"
+    },
     "node_modules/is-reference": {
       "version": "1.2.1",
       "dev": true,
@@ -17697,7 +18500,6 @@
     },
     "node_modules/is-unicode-supported": {
       "version": "2.0.0",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=18"
@@ -19036,6 +19838,20 @@
       "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/mcp-proxy": {
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/mcp-proxy/-/mcp-proxy-2.12.0.tgz",
+      "integrity": "sha512-hL2Y6EtK7vkgAOZxOQe9M4Z9g5xEnvR4ZYBKqFi/5tjhz/1jyNEz5NL87Uzv46k8iZQPVNEof/T6arEooBU5bQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@modelcontextprotocol/sdk": "^1.6.0",
+        "eventsource": "^3.0.5",
+        "yargs": "^17.7.2"
+      },
+      "bin": {
+        "mcp-proxy": "dist/bin/mcp-proxy.js"
       }
     },
     "node_modules/md5": {
@@ -21317,6 +22133,18 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/parse-ms": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/parse-ms/-/parse-ms-4.0.0.tgz",
+      "integrity": "sha512-TXfryirbmq34y8QBwgqCVLi+8oA3oWx2eAnSn62ITyEhEYaWRlVZ2DvMM9eZbMs/RfxPu/PK/aBLyGj4IrqMHw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/parse-node-version": {
       "version": "1.0.1",
       "dev": true,
@@ -21595,6 +22423,15 @@
       "license": "MIT",
       "optionalDependencies": {
         "nice-napi": "^1.0.2"
+      }
+    },
+    "node_modules/pkce-challenge": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/pkce-challenge/-/pkce-challenge-4.1.0.tgz",
+      "integrity": "sha512-ZBmhE1C9LcPoH9XZSdwiPtbPHZROwAnMy+kIFQVrnMCxY4Cudlz3gBOpzilgc0jOgRaiT3sIWfpMomW2ar2orQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.20.0"
       }
     },
     "node_modules/pkg-dir": {
@@ -22193,31 +23030,6 @@
         }
       }
     },
-    "node_modules/postcss-loader/node_modules/cosmiconfig": {
-      "version": "9.0.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "env-paths": "^2.2.1",
-        "import-fresh": "^3.3.0",
-        "js-yaml": "^4.1.0",
-        "parse-json": "^5.2.0"
-      },
-      "engines": {
-        "node": ">=14"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/d-fischer"
-      },
-      "peerDependencies": {
-        "typescript": ">=4.9.5"
-      },
-      "peerDependenciesMeta": {
-        "typescript": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/postcss-media-query-parser": {
       "version": "0.2.3",
       "dev": true,
@@ -22361,6 +23173,21 @@
       },
       "engines": {
         "node": ">=6.0.0"
+      }
+    },
+    "node_modules/pretty-ms": {
+      "version": "9.2.0",
+      "resolved": "https://registry.npmjs.org/pretty-ms/-/pretty-ms-9.2.0.tgz",
+      "integrity": "sha512-4yf0QO/sllf/1zbZWYnvWw3NxCQwLXKzIj0G849LSufP15BXKM0rbD2Z3wVnkMfjdn/CB0Dpp444gYAACdsplg==",
+      "license": "MIT",
+      "dependencies": {
+        "parse-ms": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/prismjs": {
@@ -23045,6 +23872,54 @@
       "os": [
         "linux"
       ]
+    },
+    "node_modules/router": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/router/-/router-2.2.0.tgz",
+      "integrity": "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "is-promise": "^4.0.0",
+        "parseurl": "^1.3.3",
+        "path-to-regexp": "^8.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/router/node_modules/debug": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.0.tgz",
+      "integrity": "sha512-6WTZ/IxCY/T6BALoZHaE4ctp9xm+Z5kY/pzYaCHRFeyVhojxlrm+46y68HA6hr0TcwEssoxNiDEUJQjfPZ/RYA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/router/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/router/node_modules/path-to-regexp": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.2.0.tgz",
+      "integrity": "sha512-TdrF7fW9Rphjq4RjrW0Kp2AW0Ahwu9sRGTkS6bvDi0SCwZlEZYmcfDbEsTz8RVk0EHIS/Vd1bv3JhG+1xZuAyQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16"
+      }
     },
     "node_modules/rrweb-cssom": {
       "version": "0.7.1",
@@ -24250,6 +25125,12 @@
         "bare-events": "^2.2.0"
       }
     },
+    "node_modules/strict-event-emitter-types": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/strict-event-emitter-types/-/strict-event-emitter-types-2.0.0.tgz",
+      "integrity": "sha512-Nk/brWYpD85WlOgzw5h173aci0Teyv8YdIAEtV+N88nDB0dLlazZyJMIsN6eo1/AR61l+p6CJTG1JIyFaoNEEA==",
+      "license": "ISC"
+    },
     "node_modules/string_decoder": {
       "version": "1.3.0",
       "license": "MIT",
@@ -24552,31 +25433,6 @@
       },
       "funding": {
         "url": "https://github.com/chalk/chalk?sponsor=1"
-      }
-    },
-    "node_modules/syncpack/node_modules/cosmiconfig": {
-      "version": "9.0.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "env-paths": "^2.2.1",
-        "import-fresh": "^3.3.0",
-        "js-yaml": "^4.1.0",
-        "parse-json": "^5.2.0"
-      },
-      "engines": {
-        "node": ">=14"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/d-fischer"
-      },
-      "peerDependencies": {
-        "typescript": ">=4.9.5"
-      },
-      "peerDependenciesMeta": {
-        "typescript": {
-          "optional": true
-        }
       }
     },
     "node_modules/syncpack/node_modules/globby": {
@@ -25807,6 +26663,18 @@
         "node": "*"
       }
     },
+    "node_modules/uint8array-extras": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/uint8array-extras/-/uint8array-extras-1.4.0.tgz",
+      "integrity": "sha512-ZPtzy0hu4cZjv3z5NW9gfKnNLjoz4y6uv4HlelAjDK7sY/xOkKZv9xK/WQpcsBB3jEybChz9DPC2U/+cusjJVQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/unbox-primitive": {
       "version": "1.0.2",
       "devOptional": true,
@@ -26015,6 +26883,12 @@
       "dependencies": {
         "punycode": "^2.1.0"
       }
+    },
+    "node_modules/uri-templates": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/uri-templates/-/uri-templates-0.2.0.tgz",
+      "integrity": "sha512-EWkjYEN0L6KOfEoOH6Wj4ghQqU7eBZMJqRHQnxQAq+dSEzRPClkWjf8557HkWQXF6BrAUoLSAyy9i3RVTliaNg==",
+      "license": "http://geraintluff.github.io/tv4/LICENSE.txt"
     },
     "node_modules/url-join": {
       "version": "4.0.1",
@@ -27364,6 +28238,18 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/yoctocolors": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/yoctocolors/-/yoctocolors-2.1.1.tgz",
+      "integrity": "sha512-GQHQqAopRhwU8Kt1DDM8NjibDXHC8eoh1erhGAJPEyveY9qqVeXvVikNKrDz69sHowPMorbPUrH/mx8c50eiBQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/zip-stream": {
       "version": "6.0.1",
       "license": "MIT",
@@ -27377,18 +28263,18 @@
       }
     },
     "node_modules/zod": {
-      "version": "3.24.1",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-3.24.1.tgz",
-      "integrity": "sha512-muH7gBL9sI1nciMZV67X5fTKKBLtwpZ5VBp1vsOQzj1MhrBZ4wlVCm3gedKZWLp0Oyel8sIGfeiz54Su+OVT+A==",
+      "version": "3.24.2",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.24.2.tgz",
+      "integrity": "sha512-lY7CDW43ECgW9u1TcT3IoXHflywfVqDYze4waEz812jR/bZ8FHDsl7pFQoSZTz5N+2NqRXs8GBwnAwo3ZNxqhQ==",
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }
     },
     "node_modules/zod-to-json-schema": {
-      "version": "3.24.1",
-      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.24.1.tgz",
-      "integrity": "sha512-3h08nf3Vw3Wl3PK+q3ow/lIil81IT2Oa7YpQyUUDsEWbXveMesdfK1xBd2RhCkynwZndAxixji/7SYJJowr62w==",
+      "version": "3.24.5",
+      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.24.5.tgz",
+      "integrity": "sha512-/AuWwMP+YqiPbsJx5D6TfgRTc4kTLjsh5SOcd4bLsfUg2RcEXrFMJl1DGgdHy2aCfsIA/cr/1JM0xcB2GZji8g==",
       "license": "ISC",
       "peerDependencies": {
         "zod": "^3.24.1"
@@ -27403,13 +28289,13 @@
     "packages/Actions": {},
     "packages/Actions/ApolloEnrichment": {
       "name": "@memberjunction/actions-apollo",
-      "version": "2.29.2",
+      "version": "2.30.0",
       "license": "ISC",
       "dependencies": {
-        "@memberjunction/actions": "2.29.2",
-        "@memberjunction/core": "2.29.2",
-        "@memberjunction/core-entities": "2.29.2",
-        "@memberjunction/global": "2.29.2",
+        "@memberjunction/actions": "2.30.0",
+        "@memberjunction/core": "2.30.0",
+        "@memberjunction/core-entities": "2.30.0",
+        "@memberjunction/global": "2.30.0",
         "axios": "^1.7.2"
       },
       "devDependencies": {
@@ -27419,12 +28305,12 @@
     },
     "packages/Actions/Base": {
       "name": "@memberjunction/actions-base",
-      "version": "2.29.2",
+      "version": "2.30.0",
       "license": "ISC",
       "dependencies": {
-        "@memberjunction/core": "2.29.2",
-        "@memberjunction/core-entities": "2.29.2",
-        "@memberjunction/global": "2.29.2"
+        "@memberjunction/core": "2.30.0",
+        "@memberjunction/core-entities": "2.30.0",
+        "@memberjunction/global": "2.30.0"
       },
       "devDependencies": {
         "ts-node-dev": "^2.0.0",
@@ -27433,15 +28319,15 @@
     },
     "packages/Actions/ContentAutotag": {
       "name": "@memberjunction/actions-content-autotag",
-      "version": "2.29.2",
+      "version": "2.30.0",
       "license": "ISC",
       "dependencies": {
-        "@memberjunction/actions": "2.29.2",
-        "@memberjunction/content-autotagging": "2.29.2",
-        "@memberjunction/core": "2.29.2",
-        "@memberjunction/core-actions": "2.29.2",
-        "@memberjunction/core-entities": "2.29.2",
-        "@memberjunction/global": "2.29.2",
+        "@memberjunction/actions": "2.30.0",
+        "@memberjunction/content-autotagging": "2.30.0",
+        "@memberjunction/core": "2.30.0",
+        "@memberjunction/core-actions": "2.30.0",
+        "@memberjunction/core-entities": "2.30.0",
+        "@memberjunction/global": "2.30.0",
         "axios": "^1.7.2"
       },
       "devDependencies": {
@@ -27451,17 +28337,17 @@
     },
     "packages/Actions/CoreActions": {
       "name": "@memberjunction/core-actions",
-      "version": "2.29.2",
+      "version": "2.30.0",
       "license": "ISC",
       "dependencies": {
-        "@memberjunction/actions": "2.29.2",
-        "@memberjunction/ai-vector-sync": "2.29.2",
-        "@memberjunction/communication-engine": "2.29.2",
-        "@memberjunction/content-autotagging": "2.29.2",
-        "@memberjunction/core": "2.29.2",
-        "@memberjunction/core-entities": "2.29.2",
-        "@memberjunction/external-change-detection": "2.29.2",
-        "@memberjunction/global": "2.29.2"
+        "@memberjunction/actions": "2.30.0",
+        "@memberjunction/ai-vector-sync": "2.30.0",
+        "@memberjunction/communication-engine": "2.30.0",
+        "@memberjunction/content-autotagging": "2.30.0",
+        "@memberjunction/core": "2.30.0",
+        "@memberjunction/core-entities": "2.30.0",
+        "@memberjunction/external-change-detection": "2.30.0",
+        "@memberjunction/global": "2.30.0"
       },
       "devDependencies": {
         "ts-node-dev": "^2.0.0",
@@ -27470,16 +28356,16 @@
     },
     "packages/Actions/Engine": {
       "name": "@memberjunction/actions",
-      "version": "2.29.2",
+      "version": "2.30.0",
       "license": "ISC",
       "dependencies": {
-        "@memberjunction/actions-base": "2.29.2",
-        "@memberjunction/ai": "2.29.2",
-        "@memberjunction/aiengine": "2.29.2",
-        "@memberjunction/core": "2.29.2",
-        "@memberjunction/core-entities": "2.29.2",
-        "@memberjunction/doc-utils": "2.29.2",
-        "@memberjunction/global": "2.29.2"
+        "@memberjunction/actions-base": "2.30.0",
+        "@memberjunction/ai": "2.30.0",
+        "@memberjunction/aiengine": "2.30.0",
+        "@memberjunction/core": "2.30.0",
+        "@memberjunction/core-entities": "2.30.0",
+        "@memberjunction/doc-utils": "2.30.0",
+        "@memberjunction/global": "2.30.0"
       },
       "devDependencies": {
         "ts-node-dev": "^2.0.0",
@@ -27552,15 +28438,15 @@
     },
     "packages/Actions/ScheduledActions": {
       "name": "@memberjunction/scheduled-actions",
-      "version": "2.29.2",
+      "version": "2.30.0",
       "license": "ISC",
       "dependencies": {
-        "@memberjunction/actions": "2.29.2",
-        "@memberjunction/core": "2.29.2",
-        "@memberjunction/core-actions": "2.29.2",
-        "@memberjunction/core-entities": "2.29.2",
-        "@memberjunction/global": "2.29.2",
-        "@memberjunction/sqlserver-dataprovider": "2.29.2",
+        "@memberjunction/actions": "2.30.0",
+        "@memberjunction/core": "2.30.0",
+        "@memberjunction/core-actions": "2.30.0",
+        "@memberjunction/core-entities": "2.30.0",
+        "@memberjunction/global": "2.30.0",
+        "@memberjunction/sqlserver-dataprovider": "2.30.0",
         "cron-parser": "^4.9.0"
       },
       "devDependencies": {
@@ -27570,19 +28456,19 @@
     },
     "packages/Actions/ScheduledActionsServer": {
       "name": "@memberjunction/scheduled-actions-server",
-      "version": "2.29.2",
+      "version": "2.30.0",
       "license": "ISC",
       "dependencies": {
-        "@memberjunction/actions": "2.29.2",
-        "@memberjunction/actions-content-autotag": "2.29.2",
-        "@memberjunction/ai": "2.29.2",
-        "@memberjunction/ai-mistral": "2.29.2",
-        "@memberjunction/ai-openai": "2.29.2",
-        "@memberjunction/ai-vector-sync": "2.29.2",
-        "@memberjunction/ai-vectors-pinecone": "2.29.2",
-        "@memberjunction/core": "2.29.2",
-        "@memberjunction/core-entities": "2.29.2",
-        "@memberjunction/scheduled-actions": "2.29.2",
+        "@memberjunction/actions": "2.30.0",
+        "@memberjunction/actions-content-autotag": "2.30.0",
+        "@memberjunction/ai": "2.30.0",
+        "@memberjunction/ai-mistral": "2.30.0",
+        "@memberjunction/ai-openai": "2.30.0",
+        "@memberjunction/ai-vector-sync": "2.30.0",
+        "@memberjunction/ai-vectors-pinecone": "2.30.0",
+        "@memberjunction/core": "2.30.0",
+        "@memberjunction/core-entities": "2.30.0",
+        "@memberjunction/scheduled-actions": "2.30.0",
         "@types/axios": "^0.14.0",
         "env-var": "^7.3.0",
         "express": "^4.18.2",
@@ -27608,10 +28494,10 @@
     },
     "packages/AI/Core": {
       "name": "@memberjunction/ai",
-      "version": "2.29.2",
+      "version": "2.30.0",
       "license": "ISC",
       "dependencies": {
-        "@memberjunction/global": "2.29.2",
+        "@memberjunction/global": "2.30.0",
         "dotenv": "^16.4.1",
         "rxjs": "^7.8.1",
         "typeorm": "^0.3.20"
@@ -27624,13 +28510,13 @@
     },
     "packages/AI/Engine": {
       "name": "@memberjunction/aiengine",
-      "version": "2.29.2",
+      "version": "2.30.0",
       "license": "ISC",
       "dependencies": {
-        "@memberjunction/ai": "2.29.2",
-        "@memberjunction/core": "2.29.2",
-        "@memberjunction/core-entities": "2.29.2",
-        "@memberjunction/global": "2.29.2",
+        "@memberjunction/ai": "2.30.0",
+        "@memberjunction/core": "2.30.0",
+        "@memberjunction/core-entities": "2.30.0",
+        "@memberjunction/global": "2.30.0",
         "dotenv": "^16.4.1",
         "rxjs": "^7.8.1"
       },
@@ -27640,14 +28526,39 @@
         "typescript": "^5.4.5"
       }
     },
+    "packages/AI/MCPServer": {
+      "name": "@memberjunction/ai-mcp-server",
+      "version": "2.30.0",
+      "license": "ISC",
+      "dependencies": {
+        "@memberjunction/core": "2.30.0",
+        "@memberjunction/core-entities": "2.30.0",
+        "@memberjunction/global": "2.30.0",
+        "@memberjunction/sqlserver-dataprovider": "2.30.0",
+        "@modelcontextprotocol/sdk": "^1.8.0",
+        "cosmiconfig": "9.0.0",
+        "dotenv": "^16.4.1",
+        "fastmcp": "^1.20.5",
+        "typeorm": "^0.3.20",
+        "zod": "^3.23.8"
+      },
+      "bin": {
+        "MemberJunction": "build/index.js"
+      },
+      "devDependencies": {
+        "@types/node": "20.14.2",
+        "ts-node-dev": "^2.0.0",
+        "typescript": "^5.4.5"
+      }
+    },
     "packages/AI/Providers/Anthropic": {
       "name": "@memberjunction/ai-anthropic",
-      "version": "2.29.2",
+      "version": "2.30.0",
       "license": "ISC",
       "dependencies": {
         "@anthropic-ai/sdk": "0.36.3",
-        "@memberjunction/ai": "2.29.2",
-        "@memberjunction/global": "2.29.2"
+        "@memberjunction/ai": "2.30.0",
+        "@memberjunction/global": "2.30.0"
       },
       "devDependencies": {
         "ts-node-dev": "^2.0.0",
@@ -27656,11 +28567,11 @@
     },
     "packages/AI/Providers/BettyBot": {
       "name": "@memberjunction/ai-betty-bot",
-      "version": "2.29.2",
+      "version": "2.30.0",
       "license": "ISC",
       "dependencies": {
-        "@memberjunction/ai": "2.29.2",
-        "@memberjunction/global": "2.29.2",
+        "@memberjunction/ai": "2.30.0",
+        "@memberjunction/global": "2.30.0",
         "axios": "^1.7.7",
         "axios-retry": "^4.3.0",
         "env-var": "^7.5.0"
@@ -27672,11 +28583,11 @@
     },
     "packages/AI/Providers/ElevenLabs": {
       "name": "@memberjunction/ai-elevenlabs",
-      "version": "2.29.2",
+      "version": "2.30.0",
       "license": "ISC",
       "dependencies": {
-        "@memberjunction/ai": "2.29.2",
-        "@memberjunction/global": "2.29.2",
+        "@memberjunction/ai": "2.30.0",
+        "@memberjunction/global": "2.30.0",
         "elevenlabs": "^1.51.0"
       },
       "devDependencies": {
@@ -27686,12 +28597,12 @@
     },
     "packages/AI/Providers/Gemini": {
       "name": "@memberjunction/ai-gemini",
-      "version": "2.29.2",
+      "version": "2.30.0",
       "license": "ISC",
       "dependencies": {
         "@google/generative-ai": "0.21.0",
-        "@memberjunction/ai": "2.29.2",
-        "@memberjunction/global": "2.29.2"
+        "@memberjunction/ai": "2.30.0",
+        "@memberjunction/global": "2.30.0"
       },
       "devDependencies": {
         "ts-node-dev": "^2.0.0",
@@ -27700,11 +28611,11 @@
     },
     "packages/AI/Providers/Groq": {
       "name": "@memberjunction/ai-groq",
-      "version": "2.29.2",
+      "version": "2.30.0",
       "license": "ISC",
       "dependencies": {
-        "@memberjunction/ai": "2.29.2",
-        "@memberjunction/global": "2.29.2",
+        "@memberjunction/ai": "2.30.0",
+        "@memberjunction/global": "2.30.0",
         "groq-sdk": "0.15.0"
       },
       "devDependencies": {
@@ -27714,11 +28625,11 @@
     },
     "packages/AI/Providers/HeyGen": {
       "name": "@memberjunction/ai-heygen",
-      "version": "2.29.2",
+      "version": "2.30.0",
       "license": "ISC",
       "dependencies": {
-        "@memberjunction/ai": "2.29.2",
-        "@memberjunction/global": "2.29.2",
+        "@memberjunction/ai": "2.30.0",
+        "@memberjunction/global": "2.30.0",
         "elevenlabs": "^1.51.0"
       },
       "devDependencies": {
@@ -27728,11 +28639,11 @@
     },
     "packages/AI/Providers/Mistral": {
       "name": "@memberjunction/ai-mistral",
-      "version": "2.29.2",
+      "version": "2.30.0",
       "license": "ISC",
       "dependencies": {
-        "@memberjunction/ai": "2.29.2",
-        "@memberjunction/global": "2.29.2",
+        "@memberjunction/ai": "2.30.0",
+        "@memberjunction/global": "2.30.0",
         "@mistralai/mistralai": "^1.5.0",
         "axios-retry": "4.3.0"
       },
@@ -27755,11 +28666,11 @@
     },
     "packages/AI/Providers/OpenAI": {
       "name": "@memberjunction/ai-openai",
-      "version": "2.29.2",
+      "version": "2.30.0",
       "license": "ISC",
       "dependencies": {
-        "@memberjunction/ai": "2.29.2",
-        "@memberjunction/global": "2.29.2",
+        "@memberjunction/ai": "2.30.0",
+        "@memberjunction/global": "2.30.0",
         "openai": "4.83.0"
       },
       "devDependencies": {
@@ -27831,12 +28742,12 @@
     },
     "packages/AI/Providers/Recommendations-Rex": {
       "name": "@memberjunction/ai-recommendations-rex",
-      "version": "2.29.2",
+      "version": "2.30.0",
       "license": "ISC",
       "dependencies": {
-        "@memberjunction/ai": "2.29.2",
-        "@memberjunction/ai-recommendations": "2.29.2",
-        "@memberjunction/global": "2.29.2",
+        "@memberjunction/ai": "2.30.0",
+        "@memberjunction/ai-recommendations": "2.30.0",
+        "@memberjunction/global": "2.30.0",
         "axios": "^1.7.2",
         "dotenv": "^16.4.1",
         "openai": "^4.28.4"
@@ -27848,13 +28759,13 @@
     },
     "packages/AI/Providers/Vectors-Pinecone": {
       "name": "@memberjunction/ai-vectors-pinecone",
-      "version": "2.29.2",
+      "version": "2.30.0",
       "license": "ISC",
       "dependencies": {
-        "@memberjunction/ai-vectors": "2.29.2",
-        "@memberjunction/aiengine": "2.29.2",
-        "@memberjunction/core": "2.29.2",
-        "@memberjunction/global": "2.29.2",
+        "@memberjunction/ai-vectors": "2.30.0",
+        "@memberjunction/aiengine": "2.30.0",
+        "@memberjunction/core": "2.30.0",
+        "@memberjunction/global": "2.30.0",
         "@pinecone-database/pinecone": "2.2.2",
         "dotenv": "^16.4.1",
         "openai": "^4.28.4",
@@ -27869,13 +28780,13 @@
     },
     "packages/AI/Recommendations/Engine": {
       "name": "@memberjunction/ai-recommendations",
-      "version": "2.29.2",
+      "version": "2.30.0",
       "license": "ISC",
       "dependencies": {
-        "@memberjunction/ai": "2.29.2",
-        "@memberjunction/core": "2.29.2",
-        "@memberjunction/core-entities": "2.29.2",
-        "@memberjunction/global": "2.29.2"
+        "@memberjunction/ai": "2.30.0",
+        "@memberjunction/core": "2.30.0",
+        "@memberjunction/core-entities": "2.30.0",
+        "@memberjunction/global": "2.30.0"
       },
       "devDependencies": {
         "ts-node-dev": "^2.0.0",
@@ -27884,15 +28795,15 @@
     },
     "packages/AI/Vectors/Core": {
       "name": "@memberjunction/ai-vectors",
-      "version": "2.29.2",
+      "version": "2.30.0",
       "license": "ISC",
       "dependencies": {
-        "@memberjunction/ai": "2.29.2",
-        "@memberjunction/ai-vectordb": "2.29.2",
-        "@memberjunction/aiengine": "2.29.2",
-        "@memberjunction/core": "2.29.2",
-        "@memberjunction/core-entities": "2.29.2",
-        "@memberjunction/global": "2.29.2",
+        "@memberjunction/ai": "2.30.0",
+        "@memberjunction/ai-vectordb": "2.30.0",
+        "@memberjunction/aiengine": "2.30.0",
+        "@memberjunction/core": "2.30.0",
+        "@memberjunction/core-entities": "2.30.0",
+        "@memberjunction/global": "2.30.0",
         "dotenv": "^16.4.1",
         "openai": "^4.28.4"
       },
@@ -27904,11 +28815,11 @@
     },
     "packages/AI/Vectors/Database": {
       "name": "@memberjunction/ai-vectordb",
-      "version": "2.29.2",
+      "version": "2.30.0",
       "license": "ISC",
       "dependencies": {
-        "@memberjunction/core": "2.29.2",
-        "@memberjunction/global": "2.29.2",
+        "@memberjunction/core": "2.30.0",
+        "@memberjunction/global": "2.30.0",
         "dotenv": "^16.4.1"
       },
       "devDependencies": {
@@ -27919,18 +28830,18 @@
     },
     "packages/AI/Vectors/Dupe": {
       "name": "@memberjunction/ai-vector-dupe",
-      "version": "2.29.2",
+      "version": "2.30.0",
       "license": "ISC",
       "dependencies": {
-        "@memberjunction/ai": "2.29.2",
-        "@memberjunction/ai-vector-sync": "2.29.2",
-        "@memberjunction/ai-vectordb": "2.29.2",
-        "@memberjunction/ai-vectors": "2.29.2",
-        "@memberjunction/ai-vectors-pinecone": "2.29.2",
-        "@memberjunction/aiengine": "2.29.2",
-        "@memberjunction/core": "2.29.2",
-        "@memberjunction/core-entities": "2.29.2",
-        "@memberjunction/global": "2.29.2",
+        "@memberjunction/ai": "2.30.0",
+        "@memberjunction/ai-vector-sync": "2.30.0",
+        "@memberjunction/ai-vectordb": "2.30.0",
+        "@memberjunction/ai-vectors": "2.30.0",
+        "@memberjunction/ai-vectors-pinecone": "2.30.0",
+        "@memberjunction/aiengine": "2.30.0",
+        "@memberjunction/core": "2.30.0",
+        "@memberjunction/core-entities": "2.30.0",
+        "@memberjunction/global": "2.30.0",
         "dotenv": "^16.4.1",
         "typeorm": "^0.3.20"
       },
@@ -27943,20 +28854,20 @@
     },
     "packages/AI/Vectors/Sync": {
       "name": "@memberjunction/ai-vector-sync",
-      "version": "2.29.2",
+      "version": "2.30.0",
       "license": "ISC",
       "dependencies": {
-        "@memberjunction/ai": "2.29.2",
-        "@memberjunction/ai-mistral": "2.29.2",
-        "@memberjunction/ai-openai": "2.29.2",
-        "@memberjunction/ai-vectordb": "2.29.2",
-        "@memberjunction/ai-vectors": "2.29.2",
-        "@memberjunction/ai-vectors-pinecone": "2.29.2",
-        "@memberjunction/aiengine": "2.29.2",
-        "@memberjunction/core": "2.29.2",
-        "@memberjunction/global": "2.29.2",
-        "@memberjunction/templates": "2.29.2",
-        "@memberjunction/templates-base-types": "2.29.2",
+        "@memberjunction/ai": "2.30.0",
+        "@memberjunction/ai-mistral": "2.30.0",
+        "@memberjunction/ai-openai": "2.30.0",
+        "@memberjunction/ai-vectordb": "2.30.0",
+        "@memberjunction/ai-vectors": "2.30.0",
+        "@memberjunction/ai-vectors-pinecone": "2.30.0",
+        "@memberjunction/aiengine": "2.30.0",
+        "@memberjunction/core": "2.30.0",
+        "@memberjunction/global": "2.30.0",
+        "@memberjunction/templates": "2.30.0",
+        "@memberjunction/templates-base-types": "2.30.0",
         "dotenv": "^16.4.1",
         "typeorm": "^0.3.20"
       },
@@ -27969,22 +28880,22 @@
     },
     "packages/Angular/Explorer/ask-skip": {
       "name": "@memberjunction/ng-ask-skip",
-      "version": "2.29.2",
+      "version": "2.30.0",
       "license": "ISC",
       "dependencies": {
         "@angular/cdk": "18.0.2",
-        "@memberjunction/core": "2.29.2",
-        "@memberjunction/core-entities": "2.29.2",
-        "@memberjunction/global": "2.29.2",
-        "@memberjunction/graphql-dataprovider": "2.29.2",
-        "@memberjunction/ng-chat": "2.29.2",
-        "@memberjunction/ng-container-directives": "2.29.2",
-        "@memberjunction/ng-data-context": "2.29.2",
-        "@memberjunction/ng-shared": "2.29.2",
-        "@memberjunction/ng-skip-chat": "2.29.2",
-        "@memberjunction/ng-tabstrip": "2.29.2",
-        "@memberjunction/ng-user-view-grid": "2.29.2",
-        "@memberjunction/skip-types": "2.29.2",
+        "@memberjunction/core": "2.30.0",
+        "@memberjunction/core-entities": "2.30.0",
+        "@memberjunction/global": "2.30.0",
+        "@memberjunction/graphql-dataprovider": "2.30.0",
+        "@memberjunction/ng-chat": "2.30.0",
+        "@memberjunction/ng-container-directives": "2.30.0",
+        "@memberjunction/ng-data-context": "2.30.0",
+        "@memberjunction/ng-shared": "2.30.0",
+        "@memberjunction/ng-skip-chat": "2.30.0",
+        "@memberjunction/ng-tabstrip": "2.30.0",
+        "@memberjunction/ng-user-view-grid": "2.30.0",
+        "@memberjunction/skip-types": "2.30.0",
         "@progress/kendo-angular-dialog": "16.2.0",
         "@progress/kendo-angular-filter": "16.2.0",
         "@progress/kendo-angular-grid": "16.2.0",
@@ -28045,10 +28956,10 @@
     },
     "packages/Angular/Explorer/auth-services": {
       "name": "@memberjunction/ng-auth-services",
-      "version": "2.29.2",
+      "version": "2.30.0",
       "license": "ISC",
       "dependencies": {
-        "@memberjunction/core": "2.29.2",
+        "@memberjunction/core": "2.30.0",
         "tslib": "^2.3.0"
       },
       "devDependencies": {
@@ -28066,18 +28977,18 @@
     },
     "packages/Angular/Explorer/base-forms": {
       "name": "@memberjunction/ng-base-forms",
-      "version": "2.29.2",
+      "version": "2.30.0",
       "license": "ISC",
       "dependencies": {
-        "@memberjunction/core": "2.29.2",
-        "@memberjunction/global": "2.29.2",
-        "@memberjunction/ng-base-types": "2.29.2",
-        "@memberjunction/ng-code-editor": "2.29.2",
-        "@memberjunction/ng-container-directives": "2.29.2",
-        "@memberjunction/ng-link-directives": "2.29.2",
-        "@memberjunction/ng-record-changes": "2.29.2",
-        "@memberjunction/ng-shared": "2.29.2",
-        "@memberjunction/ng-tabstrip": "2.29.2",
+        "@memberjunction/core": "2.30.0",
+        "@memberjunction/global": "2.30.0",
+        "@memberjunction/ng-base-types": "2.30.0",
+        "@memberjunction/ng-code-editor": "2.30.0",
+        "@memberjunction/ng-container-directives": "2.30.0",
+        "@memberjunction/ng-link-directives": "2.30.0",
+        "@memberjunction/ng-record-changes": "2.30.0",
+        "@memberjunction/ng-shared": "2.30.0",
+        "@memberjunction/ng-tabstrip": "2.30.0",
         "@progress/kendo-angular-buttons": "16.2.0",
         "@progress/kendo-angular-dateinputs": "16.2.0",
         "@progress/kendo-angular-dialog": "16.2.0",
@@ -28133,11 +29044,11 @@
     },
     "packages/Angular/Explorer/compare-records": {
       "name": "@memberjunction/ng-compare-records",
-      "version": "2.29.2",
+      "version": "2.30.0",
       "license": "ISC",
       "dependencies": {
-        "@memberjunction/core": "2.29.2",
-        "@memberjunction/core-entities": "2.29.2",
+        "@memberjunction/core": "2.30.0",
+        "@memberjunction/core-entities": "2.30.0",
         "@progress/kendo-angular-grid": "16.2.0",
         "tslib": "^2.3.0"
       },
@@ -28156,19 +29067,19 @@
     },
     "packages/Angular/Explorer/core-entity-forms": {
       "name": "@memberjunction/ng-core-entity-forms",
-      "version": "2.29.2",
+      "version": "2.30.0",
       "license": "ISC",
       "dependencies": {
-        "@memberjunction/core": "2.29.2",
-        "@memberjunction/core-entities": "2.29.2",
-        "@memberjunction/ng-base-forms": "2.29.2",
-        "@memberjunction/ng-code-editor": "2.29.2",
-        "@memberjunction/ng-container-directives": "2.29.2",
-        "@memberjunction/ng-explorer-core": "2.29.2",
-        "@memberjunction/ng-form-toolbar": "2.29.2",
-        "@memberjunction/ng-join-grid": "2.29.2",
-        "@memberjunction/ng-tabstrip": "2.29.2",
-        "@memberjunction/ng-timeline": "2.29.2",
+        "@memberjunction/core": "2.30.0",
+        "@memberjunction/core-entities": "2.30.0",
+        "@memberjunction/ng-base-forms": "2.30.0",
+        "@memberjunction/ng-code-editor": "2.30.0",
+        "@memberjunction/ng-container-directives": "2.30.0",
+        "@memberjunction/ng-explorer-core": "2.30.0",
+        "@memberjunction/ng-form-toolbar": "2.30.0",
+        "@memberjunction/ng-join-grid": "2.30.0",
+        "@memberjunction/ng-tabstrip": "2.30.0",
+        "@memberjunction/ng-timeline": "2.30.0",
         "@progress/kendo-angular-dropdowns": "16.2.0",
         "@progress/kendo-angular-grid": "16.2.0",
         "tslib": "^2.3.0"
@@ -28209,15 +29120,15 @@
     },
     "packages/Angular/Explorer/entity-form-dialog": {
       "name": "@memberjunction/ng-entity-form-dialog",
-      "version": "2.29.2",
+      "version": "2.30.0",
       "license": "ISC",
       "dependencies": {
-        "@memberjunction/core": "2.29.2",
-        "@memberjunction/core-entities": "2.29.2",
-        "@memberjunction/global": "2.29.2",
-        "@memberjunction/ng-base-forms": "2.29.2",
-        "@memberjunction/ng-container-directives": "2.29.2",
-        "@memberjunction/ng-shared": "2.29.2",
+        "@memberjunction/core": "2.30.0",
+        "@memberjunction/core-entities": "2.30.0",
+        "@memberjunction/global": "2.30.0",
+        "@memberjunction/ng-base-forms": "2.30.0",
+        "@memberjunction/ng-container-directives": "2.30.0",
+        "@memberjunction/ng-shared": "2.30.0",
         "@progress/kendo-angular-buttons": "16.2.0",
         "@progress/kendo-angular-dialog": "16.2.0",
         "tslib": "^2.3.0"
@@ -28235,14 +29146,14 @@
     },
     "packages/Angular/Explorer/entity-permissions": {
       "name": "@memberjunction/ng-entity-permissions",
-      "version": "2.29.2",
+      "version": "2.30.0",
       "license": "ISC",
       "dependencies": {
-        "@memberjunction/core": "2.29.2",
-        "@memberjunction/core-entities": "2.29.2",
-        "@memberjunction/global": "2.29.2",
-        "@memberjunction/ng-container-directives": "2.29.2",
-        "@memberjunction/ng-shared": "2.29.2",
+        "@memberjunction/core": "2.30.0",
+        "@memberjunction/core-entities": "2.30.0",
+        "@memberjunction/global": "2.30.0",
+        "@memberjunction/ng-container-directives": "2.30.0",
+        "@memberjunction/ng-shared": "2.30.0",
         "@progress/kendo-angular-buttons": "16.2.0",
         "@progress/kendo-angular-dialog": "16.2.0",
         "@progress/kendo-angular-dropdowns": "16.2.0",
@@ -28263,32 +29174,32 @@
     },
     "packages/Angular/Explorer/explorer-core": {
       "name": "@memberjunction/ng-explorer-core",
-      "version": "2.29.2",
+      "version": "2.30.0",
       "license": "ISC",
       "dependencies": {
-        "@memberjunction/communication-types": "2.29.2",
-        "@memberjunction/core": "2.29.2",
-        "@memberjunction/core-entities": "2.29.2",
-        "@memberjunction/entity-communications-client": "2.29.2",
-        "@memberjunction/global": "2.29.2",
-        "@memberjunction/ng-ask-skip": "2.29.2",
-        "@memberjunction/ng-auth-services": "2.29.2",
-        "@memberjunction/ng-base-forms": "2.29.2",
-        "@memberjunction/ng-compare-records": "2.29.2",
-        "@memberjunction/ng-container-directives": "2.29.2",
-        "@memberjunction/ng-entity-form-dialog": "2.29.2",
-        "@memberjunction/ng-explorer-settings": "2.29.2",
-        "@memberjunction/ng-file-storage": "2.29.2",
-        "@memberjunction/ng-query-grid": "2.29.2",
-        "@memberjunction/ng-record-changes": "2.29.2",
-        "@memberjunction/ng-record-selector": "2.29.2",
-        "@memberjunction/ng-resource-permissions": "2.29.2",
-        "@memberjunction/ng-shared": "2.29.2",
-        "@memberjunction/ng-skip-chat": "2.29.2",
-        "@memberjunction/ng-tabstrip": "2.29.2",
-        "@memberjunction/ng-user-view-grid": "2.29.2",
-        "@memberjunction/ng-user-view-properties": "2.29.2",
-        "@memberjunction/templates-base-types": "2.29.2",
+        "@memberjunction/communication-types": "2.30.0",
+        "@memberjunction/core": "2.30.0",
+        "@memberjunction/core-entities": "2.30.0",
+        "@memberjunction/entity-communications-client": "2.30.0",
+        "@memberjunction/global": "2.30.0",
+        "@memberjunction/ng-ask-skip": "2.30.0",
+        "@memberjunction/ng-auth-services": "2.30.0",
+        "@memberjunction/ng-base-forms": "2.30.0",
+        "@memberjunction/ng-compare-records": "2.30.0",
+        "@memberjunction/ng-container-directives": "2.30.0",
+        "@memberjunction/ng-entity-form-dialog": "2.30.0",
+        "@memberjunction/ng-explorer-settings": "2.30.0",
+        "@memberjunction/ng-file-storage": "2.30.0",
+        "@memberjunction/ng-query-grid": "2.30.0",
+        "@memberjunction/ng-record-changes": "2.30.0",
+        "@memberjunction/ng-record-selector": "2.30.0",
+        "@memberjunction/ng-resource-permissions": "2.30.0",
+        "@memberjunction/ng-shared": "2.30.0",
+        "@memberjunction/ng-skip-chat": "2.30.0",
+        "@memberjunction/ng-tabstrip": "2.30.0",
+        "@memberjunction/ng-user-view-grid": "2.30.0",
+        "@memberjunction/ng-user-view-properties": "2.30.0",
+        "@memberjunction/templates-base-types": "2.30.0",
         "@progress/kendo-angular-buttons": "16.2.0",
         "@progress/kendo-angular-charts": "16.2.0",
         "@progress/kendo-angular-dialog": "16.2.0",
@@ -28316,20 +29227,20 @@
     },
     "packages/Angular/Explorer/explorer-settings": {
       "name": "@memberjunction/ng-explorer-settings",
-      "version": "2.29.2",
+      "version": "2.30.0",
       "license": "ISC",
       "dependencies": {
-        "@memberjunction/core": "2.29.2",
-        "@memberjunction/core-entities": "2.29.2",
-        "@memberjunction/global": "2.29.2",
-        "@memberjunction/ng-base-forms": "2.29.2",
-        "@memberjunction/ng-container-directives": "2.29.2",
-        "@memberjunction/ng-entity-form-dialog": "2.29.2",
-        "@memberjunction/ng-entity-permissions": "2.29.2",
-        "@memberjunction/ng-shared": "2.29.2",
-        "@memberjunction/ng-simple-record-list": "2.29.2",
-        "@memberjunction/ng-tabstrip": "2.29.2",
-        "@memberjunction/ng-user-view-grid": "2.29.2",
+        "@memberjunction/core": "2.30.0",
+        "@memberjunction/core-entities": "2.30.0",
+        "@memberjunction/global": "2.30.0",
+        "@memberjunction/ng-base-forms": "2.30.0",
+        "@memberjunction/ng-container-directives": "2.30.0",
+        "@memberjunction/ng-entity-form-dialog": "2.30.0",
+        "@memberjunction/ng-entity-permissions": "2.30.0",
+        "@memberjunction/ng-shared": "2.30.0",
+        "@memberjunction/ng-simple-record-list": "2.30.0",
+        "@memberjunction/ng-tabstrip": "2.30.0",
+        "@memberjunction/ng-user-view-grid": "2.30.0",
         "@progress/kendo-angular-buttons": "16.2.0",
         "@progress/kendo-angular-dialog": "16.2.0",
         "@progress/kendo-angular-dropdowns": "16.2.0",
@@ -28351,16 +29262,16 @@
     },
     "packages/Angular/Explorer/form-toolbar": {
       "name": "@memberjunction/ng-form-toolbar",
-      "version": "2.29.2",
+      "version": "2.30.0",
       "license": "ISC",
       "dependencies": {
-        "@memberjunction/core": "2.29.2",
-        "@memberjunction/global": "2.29.2",
-        "@memberjunction/ng-ask-skip": "2.29.2",
-        "@memberjunction/ng-base-forms": "2.29.2",
-        "@memberjunction/ng-container-directives": "2.29.2",
-        "@memberjunction/ng-record-changes": "2.29.2",
-        "@memberjunction/ng-shared": "2.29.2",
+        "@memberjunction/core": "2.30.0",
+        "@memberjunction/global": "2.30.0",
+        "@memberjunction/ng-ask-skip": "2.30.0",
+        "@memberjunction/ng-base-forms": "2.30.0",
+        "@memberjunction/ng-container-directives": "2.30.0",
+        "@memberjunction/ng-record-changes": "2.30.0",
+        "@memberjunction/ng-shared": "2.30.0",
         "@progress/kendo-angular-buttons": "16.2.0",
         "@progress/kendo-angular-dialog": "16.2.0",
         "ngx-markdown": "^18.0.0",
@@ -28412,10 +29323,10 @@
     },
     "packages/Angular/Explorer/link-directives": {
       "name": "@memberjunction/ng-link-directives",
-      "version": "2.29.2",
+      "version": "2.30.0",
       "license": "ISC",
       "dependencies": {
-        "@memberjunction/core": "2.29.2",
+        "@memberjunction/core": "2.30.0",
         "tslib": "^2.3.0"
       },
       "devDependencies": {
@@ -28430,15 +29341,15 @@
     },
     "packages/Angular/Explorer/list-detail-grid": {
       "name": "@memberjunction/ng-list-detail-grid",
-      "version": "2.29.2",
+      "version": "2.30.0",
       "license": "ISC",
       "dependencies": {
-        "@memberjunction/core": "2.29.2",
-        "@memberjunction/core-entities": "2.29.2",
-        "@memberjunction/global": "2.29.2",
-        "@memberjunction/ng-compare-records": "2.29.2",
-        "@memberjunction/ng-container-directives": "2.29.2",
-        "@memberjunction/ng-shared": "2.29.2",
+        "@memberjunction/core": "2.30.0",
+        "@memberjunction/core-entities": "2.30.0",
+        "@memberjunction/global": "2.30.0",
+        "@memberjunction/ng-compare-records": "2.30.0",
+        "@memberjunction/ng-container-directives": "2.30.0",
+        "@memberjunction/ng-shared": "2.30.0",
         "@progress/kendo-angular-buttons": "16.2.0",
         "@progress/kendo-angular-grid": "16.2.0",
         "@progress/kendo-angular-inputs": "16.2.0",
@@ -28458,13 +29369,13 @@
     },
     "packages/Angular/Explorer/record-changes": {
       "name": "@memberjunction/ng-record-changes",
-      "version": "2.29.2",
+      "version": "2.30.0",
       "license": "ISC",
       "dependencies": {
-        "@memberjunction/core": "2.29.2",
-        "@memberjunction/global": "2.29.2",
-        "@memberjunction/ng-compare-records": "2.29.2",
-        "@memberjunction/ng-container-directives": "2.29.2",
+        "@memberjunction/core": "2.30.0",
+        "@memberjunction/global": "2.30.0",
+        "@memberjunction/ng-compare-records": "2.30.0",
+        "@memberjunction/ng-container-directives": "2.30.0",
         "tslib": "^2.3.0"
       },
       "devDependencies": {
@@ -28512,14 +29423,14 @@
     },
     "packages/Angular/Explorer/shared": {
       "name": "@memberjunction/ng-shared",
-      "version": "2.29.2",
+      "version": "2.30.0",
       "license": "ISC",
       "dependencies": {
-        "@memberjunction/core": "2.29.2",
-        "@memberjunction/core-entities": "2.29.2",
-        "@memberjunction/graphql-dataprovider": "2.29.2",
-        "@memberjunction/ng-base-types": "2.29.2",
-        "@memberjunction/ng-notifications": "2.29.2",
+        "@memberjunction/core": "2.30.0",
+        "@memberjunction/core-entities": "2.30.0",
+        "@memberjunction/graphql-dataprovider": "2.30.0",
+        "@memberjunction/ng-base-types": "2.30.0",
+        "@memberjunction/ng-notifications": "2.30.0",
         "@progress/kendo-angular-notification": "16.2.0",
         "tslib": "^2.3.0"
       },
@@ -28535,22 +29446,22 @@
     },
     "packages/Angular/Explorer/user-view-grid": {
       "name": "@memberjunction/ng-user-view-grid",
-      "version": "2.29.2",
+      "version": "2.30.0",
       "license": "ISC",
       "dependencies": {
-        "@memberjunction/actions-base": "2.29.2",
-        "@memberjunction/communication-types": "2.29.2",
-        "@memberjunction/core": "2.29.2",
-        "@memberjunction/core-entities": "2.29.2",
-        "@memberjunction/entity-communications-client": "2.29.2",
-        "@memberjunction/global": "2.29.2",
-        "@memberjunction/ng-base-types": "2.29.2",
-        "@memberjunction/ng-compare-records": "2.29.2",
-        "@memberjunction/ng-container-directives": "2.29.2",
-        "@memberjunction/ng-entity-communications": "2.29.2",
-        "@memberjunction/ng-entity-form-dialog": "2.29.2",
-        "@memberjunction/ng-shared": "2.29.2",
-        "@memberjunction/templates-base-types": "2.29.2",
+        "@memberjunction/actions-base": "2.30.0",
+        "@memberjunction/communication-types": "2.30.0",
+        "@memberjunction/core": "2.30.0",
+        "@memberjunction/core-entities": "2.30.0",
+        "@memberjunction/entity-communications-client": "2.30.0",
+        "@memberjunction/global": "2.30.0",
+        "@memberjunction/ng-base-types": "2.30.0",
+        "@memberjunction/ng-compare-records": "2.30.0",
+        "@memberjunction/ng-container-directives": "2.30.0",
+        "@memberjunction/ng-entity-communications": "2.30.0",
+        "@memberjunction/ng-entity-form-dialog": "2.30.0",
+        "@memberjunction/ng-shared": "2.30.0",
+        "@memberjunction/templates-base-types": "2.30.0",
         "@progress/kendo-angular-buttons": "16.2.0",
         "@progress/kendo-angular-grid": "16.2.0",
         "@progress/kendo-angular-inputs": "16.2.0",
@@ -28570,16 +29481,16 @@
     },
     "packages/Angular/Explorer/user-view-properties": {
       "name": "@memberjunction/ng-user-view-properties",
-      "version": "2.29.2",
+      "version": "2.30.0",
       "license": "ISC",
       "dependencies": {
-        "@memberjunction/core": "2.29.2",
-        "@memberjunction/core-entities": "2.29.2",
-        "@memberjunction/global": "2.29.2",
-        "@memberjunction/ng-base-forms": "2.29.2",
-        "@memberjunction/ng-find-record": "2.29.2",
-        "@memberjunction/ng-resource-permissions": "2.29.2",
-        "@memberjunction/ng-shared": "2.29.2",
+        "@memberjunction/core": "2.30.0",
+        "@memberjunction/core-entities": "2.30.0",
+        "@memberjunction/global": "2.30.0",
+        "@memberjunction/ng-base-forms": "2.30.0",
+        "@memberjunction/ng-find-record": "2.30.0",
+        "@memberjunction/ng-resource-permissions": "2.30.0",
+        "@memberjunction/ng-shared": "2.30.0",
         "@progress/kendo-angular-buttons": "16.2.0",
         "@progress/kendo-angular-dialog": "16.2.0",
         "@progress/kendo-angular-filter": "16.2.0",
@@ -28601,12 +29512,12 @@
     },
     "packages/Angular/Generic/base-types": {
       "name": "@memberjunction/ng-base-types",
-      "version": "2.29.2",
+      "version": "2.30.0",
       "license": "ISC",
       "dependencies": {
-        "@memberjunction/core": "2.29.2",
-        "@memberjunction/core-entities": "2.29.2",
-        "@memberjunction/global": "2.29.2",
+        "@memberjunction/core": "2.30.0",
+        "@memberjunction/core-entities": "2.30.0",
+        "@memberjunction/global": "2.30.0",
         "tslib": "^2.3.0"
       },
       "devDependencies": {
@@ -28620,11 +29531,11 @@
     },
     "packages/Angular/Generic/chat": {
       "name": "@memberjunction/ng-chat",
-      "version": "2.29.2",
+      "version": "2.30.0",
       "license": "ISC",
       "dependencies": {
-        "@memberjunction/core": "2.29.2",
-        "@memberjunction/ng-container-directives": "2.29.2",
+        "@memberjunction/core": "2.30.0",
+        "@memberjunction/ng-container-directives": "2.30.0",
         "@progress/kendo-angular-buttons": "16.2.0",
         "@progress/kendo-angular-dialog": "16.2.0",
         "@progress/kendo-angular-indicators": "16.2.0",
@@ -28676,15 +29587,15 @@
     },
     "packages/Angular/Generic/code-editor": {
       "name": "@memberjunction/ng-code-editor",
-      "version": "2.29.2",
+      "version": "2.30.0",
       "license": "ISC",
       "dependencies": {
         "@codemirror/language-data": "^6.5.1",
         "@codemirror/merge": "^6.6.3",
-        "@memberjunction/core": "2.29.2",
-        "@memberjunction/core-entities": "2.29.2",
-        "@memberjunction/global": "2.29.2",
-        "@memberjunction/ng-container-directives": "2.29.2",
+        "@memberjunction/core": "2.30.0",
+        "@memberjunction/core-entities": "2.30.0",
+        "@memberjunction/global": "2.30.0",
+        "@memberjunction/ng-container-directives": "2.30.0",
         "codemirror": "^6.0.1",
         "tslib": "^2.3.0"
       },
@@ -28699,11 +29610,11 @@
     },
     "packages/Angular/Generic/container-directives": {
       "name": "@memberjunction/ng-container-directives",
-      "version": "2.29.2",
+      "version": "2.30.0",
       "license": "ISC",
       "dependencies": {
-        "@memberjunction/core": "2.29.2",
-        "@memberjunction/global": "2.29.2",
+        "@memberjunction/core": "2.30.0",
+        "@memberjunction/global": "2.30.0",
         "tslib": "^2.3.0"
       },
       "devDependencies": {
@@ -28718,12 +29629,12 @@
     },
     "packages/Angular/Generic/data-context": {
       "name": "@memberjunction/ng-data-context",
-      "version": "2.29.2",
+      "version": "2.30.0",
       "license": "ISC",
       "dependencies": {
-        "@memberjunction/core": "2.29.2",
-        "@memberjunction/core-entities": "2.29.2",
-        "@memberjunction/global": "2.29.2",
+        "@memberjunction/core": "2.30.0",
+        "@memberjunction/core-entities": "2.30.0",
+        "@memberjunction/global": "2.30.0",
         "tslib": "^2.3.0"
       },
       "devDependencies": {
@@ -28739,17 +29650,17 @@
     },
     "packages/Angular/Generic/entity-communication": {
       "name": "@memberjunction/ng-entity-communications",
-      "version": "2.29.2",
+      "version": "2.30.0",
       "license": "ISC",
       "dependencies": {
-        "@memberjunction/communication-types": "2.29.2",
-        "@memberjunction/core": "2.29.2",
-        "@memberjunction/core-entities": "2.29.2",
-        "@memberjunction/entity-communications-base": "2.29.2",
-        "@memberjunction/entity-communications-client": "2.29.2",
-        "@memberjunction/global": "2.29.2",
-        "@memberjunction/ng-container-directives": "2.29.2",
-        "@memberjunction/ng-shared": "2.29.2",
+        "@memberjunction/communication-types": "2.30.0",
+        "@memberjunction/core": "2.30.0",
+        "@memberjunction/core-entities": "2.30.0",
+        "@memberjunction/entity-communications-base": "2.30.0",
+        "@memberjunction/entity-communications-client": "2.30.0",
+        "@memberjunction/global": "2.30.0",
+        "@memberjunction/ng-container-directives": "2.30.0",
+        "@memberjunction/ng-shared": "2.30.0",
         "tslib": "^2.3.0"
       },
       "devDependencies": {
@@ -28769,15 +29680,15 @@
     },
     "packages/Angular/Generic/file-storage": {
       "name": "@memberjunction/ng-file-storage",
-      "version": "2.29.2",
+      "version": "2.30.0",
       "license": "ISC",
       "dependencies": {
-        "@memberjunction/core": "2.29.2",
-        "@memberjunction/core-entities": "2.29.2",
-        "@memberjunction/global": "2.29.2",
-        "@memberjunction/graphql-dataprovider": "2.29.2",
-        "@memberjunction/ng-container-directives": "2.29.2",
-        "@memberjunction/ng-shared": "2.29.2",
+        "@memberjunction/core": "2.30.0",
+        "@memberjunction/core-entities": "2.30.0",
+        "@memberjunction/global": "2.30.0",
+        "@memberjunction/graphql-dataprovider": "2.30.0",
+        "@memberjunction/ng-container-directives": "2.30.0",
+        "@memberjunction/ng-shared": "2.30.0",
         "@progress/kendo-angular-buttons": "16.2.0",
         "@progress/kendo-angular-dialog": "16.2.0",
         "@progress/kendo-angular-dropdowns": "16.2.0",
@@ -28802,14 +29713,14 @@
     },
     "packages/Angular/Generic/find-record": {
       "name": "@memberjunction/ng-find-record",
-      "version": "2.29.2",
+      "version": "2.30.0",
       "license": "ISC",
       "dependencies": {
-        "@memberjunction/core": "2.29.2",
-        "@memberjunction/core-entities": "2.29.2",
-        "@memberjunction/global": "2.29.2",
-        "@memberjunction/ng-container-directives": "2.29.2",
-        "@memberjunction/ng-shared": "2.29.2",
+        "@memberjunction/core": "2.30.0",
+        "@memberjunction/core-entities": "2.30.0",
+        "@memberjunction/global": "2.30.0",
+        "@memberjunction/ng-container-directives": "2.30.0",
+        "@memberjunction/ng-shared": "2.30.0",
         "rxjs": "^7.8.1",
         "tslib": "^2.3.0"
       },
@@ -28831,7 +29742,7 @@
     },
     "packages/Angular/Generic/generic-dialog": {
       "name": "@memberjunction/ng-generic-dialog",
-      "version": "2.29.2",
+      "version": "2.30.0",
       "license": "ISC",
       "dependencies": {
         "tslib": "^2.3.0"
@@ -28849,15 +29760,15 @@
     },
     "packages/Angular/Generic/join-grid": {
       "name": "@memberjunction/ng-join-grid",
-      "version": "2.29.2",
+      "version": "2.30.0",
       "license": "ISC",
       "dependencies": {
-        "@memberjunction/core": "2.29.2",
-        "@memberjunction/core-entities": "2.29.2",
-        "@memberjunction/global": "2.29.2",
-        "@memberjunction/ng-base-types": "2.29.2",
-        "@memberjunction/ng-container-directives": "2.29.2",
-        "@memberjunction/ng-shared": "2.29.2",
+        "@memberjunction/core": "2.30.0",
+        "@memberjunction/core-entities": "2.30.0",
+        "@memberjunction/global": "2.30.0",
+        "@memberjunction/ng-base-types": "2.30.0",
+        "@memberjunction/ng-container-directives": "2.30.0",
+        "@memberjunction/ng-shared": "2.30.0",
         "@progress/kendo-angular-buttons": "16.2.0",
         "@progress/kendo-angular-dialog": "16.2.0",
         "@progress/kendo-angular-grid": "16.2.0",
@@ -28879,13 +29790,13 @@
     },
     "packages/Angular/Generic/notifications": {
       "name": "@memberjunction/ng-notifications",
-      "version": "2.29.2",
+      "version": "2.30.0",
       "license": "ISC",
       "dependencies": {
-        "@memberjunction/core": "2.29.2",
-        "@memberjunction/core-entities": "2.29.2",
-        "@memberjunction/global": "2.29.2",
-        "@memberjunction/graphql-dataprovider": "2.29.2",
+        "@memberjunction/core": "2.30.0",
+        "@memberjunction/core-entities": "2.30.0",
+        "@memberjunction/global": "2.30.0",
+        "@memberjunction/graphql-dataprovider": "2.30.0",
         "rxjs": "^7.8.1",
         "tslib": "^2.3.0"
       },
@@ -28901,15 +29812,15 @@
     },
     "packages/Angular/Generic/query-grid": {
       "name": "@memberjunction/ng-query-grid",
-      "version": "2.29.2",
+      "version": "2.30.0",
       "license": "ISC",
       "dependencies": {
-        "@memberjunction/core": "2.29.2",
-        "@memberjunction/core-entities": "2.29.2",
-        "@memberjunction/global": "2.29.2",
-        "@memberjunction/ng-compare-records": "2.29.2",
-        "@memberjunction/ng-container-directives": "2.29.2",
-        "@memberjunction/ng-shared": "2.29.2",
+        "@memberjunction/core": "2.30.0",
+        "@memberjunction/core-entities": "2.30.0",
+        "@memberjunction/global": "2.30.0",
+        "@memberjunction/ng-compare-records": "2.30.0",
+        "@memberjunction/ng-container-directives": "2.30.0",
+        "@memberjunction/ng-shared": "2.30.0",
         "tslib": "^2.3.0"
       },
       "devDependencies": {
@@ -28928,14 +29839,14 @@
     },
     "packages/Angular/Generic/record-selector": {
       "name": "@memberjunction/ng-record-selector",
-      "version": "2.29.2",
+      "version": "2.30.0",
       "license": "ISC",
       "dependencies": {
-        "@memberjunction/core": "2.29.2",
-        "@memberjunction/core-entities": "2.29.2",
-        "@memberjunction/global": "2.29.2",
-        "@memberjunction/ng-container-directives": "2.29.2",
-        "@memberjunction/ng-shared": "2.29.2",
+        "@memberjunction/core": "2.30.0",
+        "@memberjunction/core-entities": "2.30.0",
+        "@memberjunction/global": "2.30.0",
+        "@memberjunction/ng-container-directives": "2.30.0",
+        "@memberjunction/ng-shared": "2.30.0",
         "tslib": "^2.3.0"
       },
       "devDependencies": {
@@ -28954,16 +29865,16 @@
     },
     "packages/Angular/Generic/resource-permissions": {
       "name": "@memberjunction/ng-resource-permissions",
-      "version": "2.29.2",
+      "version": "2.30.0",
       "license": "ISC",
       "dependencies": {
-        "@memberjunction/core": "2.29.2",
-        "@memberjunction/core-entities": "2.29.2",
-        "@memberjunction/global": "2.29.2",
-        "@memberjunction/ng-base-types": "2.29.2",
-        "@memberjunction/ng-container-directives": "2.29.2",
-        "@memberjunction/ng-generic-dialog": "2.29.2",
-        "@memberjunction/ng-notifications": "2.29.2",
+        "@memberjunction/core": "2.30.0",
+        "@memberjunction/core-entities": "2.30.0",
+        "@memberjunction/global": "2.30.0",
+        "@memberjunction/ng-base-types": "2.30.0",
+        "@memberjunction/ng-container-directives": "2.30.0",
+        "@memberjunction/ng-generic-dialog": "2.30.0",
+        "@memberjunction/ng-notifications": "2.30.0",
         "@progress/kendo-angular-buttons": "16.2.0",
         "@progress/kendo-angular-dialog": "16.2.0",
         "@progress/kendo-angular-dropdowns": "16.2.0",
@@ -28984,15 +29895,15 @@
     },
     "packages/Angular/Generic/simple-record-list": {
       "name": "@memberjunction/ng-simple-record-list",
-      "version": "2.29.2",
+      "version": "2.30.0",
       "license": "ISC",
       "dependencies": {
-        "@memberjunction/core": "2.29.2",
-        "@memberjunction/core-entities": "2.29.2",
-        "@memberjunction/global": "2.29.2",
-        "@memberjunction/ng-container-directives": "2.29.2",
-        "@memberjunction/ng-entity-form-dialog": "2.29.2",
-        "@memberjunction/ng-shared": "2.29.2",
+        "@memberjunction/core": "2.30.0",
+        "@memberjunction/core-entities": "2.30.0",
+        "@memberjunction/global": "2.30.0",
+        "@memberjunction/ng-container-directives": "2.30.0",
+        "@memberjunction/ng-entity-form-dialog": "2.30.0",
+        "@memberjunction/ng-shared": "2.30.0",
         "@progress/kendo-angular-buttons": "16.2.0",
         "@progress/kendo-angular-dialog": "16.2.0",
         "@progress/kendo-angular-indicators": "16.2.0",
@@ -29012,21 +29923,21 @@
     },
     "packages/Angular/Generic/skip-chat": {
       "name": "@memberjunction/ng-skip-chat",
-      "version": "2.29.2",
+      "version": "2.30.0",
       "license": "ISC",
       "dependencies": {
         "@angular/cdk": "18.0.2",
-        "@memberjunction/core": "2.29.2",
-        "@memberjunction/core-entities": "2.29.2",
-        "@memberjunction/data-context": "2.29.2",
-        "@memberjunction/global": "2.29.2",
-        "@memberjunction/graphql-dataprovider": "2.29.2",
-        "@memberjunction/ng-base-types": "2.29.2",
-        "@memberjunction/ng-container-directives": "2.29.2",
-        "@memberjunction/ng-data-context": "2.29.2",
-        "@memberjunction/ng-notifications": "2.29.2",
-        "@memberjunction/ng-resource-permissions": "2.29.2",
-        "@memberjunction/skip-types": "2.29.2",
+        "@memberjunction/core": "2.30.0",
+        "@memberjunction/core-entities": "2.30.0",
+        "@memberjunction/data-context": "2.30.0",
+        "@memberjunction/global": "2.30.0",
+        "@memberjunction/graphql-dataprovider": "2.30.0",
+        "@memberjunction/ng-base-types": "2.30.0",
+        "@memberjunction/ng-container-directives": "2.30.0",
+        "@memberjunction/ng-data-context": "2.30.0",
+        "@memberjunction/ng-notifications": "2.30.0",
+        "@memberjunction/ng-resource-permissions": "2.30.0",
+        "@memberjunction/skip-types": "2.30.0",
         "@progress/kendo-angular-dialog": "16.2.0",
         "@progress/kendo-angular-grid": "16.2.0",
         "@progress/kendo-angular-indicators": "16.2.0",
@@ -29091,10 +30002,10 @@
     },
     "packages/Angular/Generic/tab-strip": {
       "name": "@memberjunction/ng-tabstrip",
-      "version": "2.29.2",
+      "version": "2.30.0",
       "license": "ISC",
       "dependencies": {
-        "@memberjunction/ng-container-directives": "2.29.2",
+        "@memberjunction/ng-container-directives": "2.30.0",
         "tslib": "^2.3.0"
       },
       "devDependencies": {
@@ -29108,15 +30019,15 @@
     },
     "packages/Angular/Generic/timeline": {
       "name": "@memberjunction/ng-timeline",
-      "version": "2.29.2",
+      "version": "2.30.0",
       "license": "ISC",
       "dependencies": {
-        "@memberjunction/core": "2.29.2",
-        "@memberjunction/core-entities": "2.29.2",
-        "@memberjunction/global": "2.29.2",
-        "@memberjunction/ng-container-directives": "2.29.2",
-        "@memberjunction/ng-entity-form-dialog": "2.29.2",
-        "@memberjunction/ng-shared": "2.29.2",
+        "@memberjunction/core": "2.30.0",
+        "@memberjunction/core-entities": "2.30.0",
+        "@memberjunction/global": "2.30.0",
+        "@memberjunction/ng-container-directives": "2.30.0",
+        "@memberjunction/ng-entity-form-dialog": "2.30.0",
+        "@memberjunction/ng-shared": "2.30.0",
         "@progress/kendo-angular-buttons": "16.2.0",
         "@progress/kendo-angular-indicators": "16.2.0",
         "@progress/kendo-angular-layout": "16.2.0",
@@ -29136,15 +30047,15 @@
     },
     "packages/Angular/Generic/tree-list": {
       "name": "@memberjunction/ng-treelist",
-      "version": "2.29.2",
+      "version": "2.30.0",
       "license": "ISC",
       "dependencies": {
-        "@memberjunction/core": "2.29.2",
-        "@memberjunction/core-entities": "2.29.2",
-        "@memberjunction/global": "2.29.2",
-        "@memberjunction/ng-container-directives": "2.29.2",
-        "@memberjunction/ng-entity-form-dialog": "2.29.2",
-        "@memberjunction/ng-shared": "2.29.2",
+        "@memberjunction/core": "2.30.0",
+        "@memberjunction/core-entities": "2.30.0",
+        "@memberjunction/global": "2.30.0",
+        "@memberjunction/ng-container-directives": "2.30.0",
+        "@memberjunction/ng-entity-form-dialog": "2.30.0",
+        "@memberjunction/ng-shared": "2.30.0",
         "@progress/kendo-angular-buttons": "16.2.0",
         "@progress/kendo-angular-indicators": "16.2.0",
         "@progress/kendo-angular-layout": "16.2.0",
@@ -29175,10 +30086,10 @@
         "@angular/platform-browser": "18.0.2",
         "@angular/platform-browser-dynamic": "18.0.2",
         "@angular/router": "18.0.2",
-        "@memberjunction/core": "2.29.2",
-        "@memberjunction/global": "2.29.2",
-        "@memberjunction/graphql-dataprovider": "2.29.2",
-        "@memberjunction/ng-user-view-grid": "2.29.2",
+        "@memberjunction/core": "2.30.0",
+        "@memberjunction/global": "2.30.0",
+        "@memberjunction/graphql-dataprovider": "2.30.0",
+        "@memberjunction/ng-user-view-grid": "2.30.0",
         "rxjs": "^7.8.1",
         "tslib": "^2.3.0",
         "zone.js": "^0.14.0"
@@ -29199,20 +30110,20 @@
     },
     "packages/CodeGenLib": {
       "name": "@memberjunction/codegen-lib",
-      "version": "2.29.2",
+      "version": "2.30.0",
       "license": "ISC",
       "dependencies": {
-        "@memberjunction/actions": "2.29.2",
-        "@memberjunction/ai": "2.29.2",
-        "@memberjunction/ai-anthropic": "2.29.2",
-        "@memberjunction/ai-groq": "2.29.2",
-        "@memberjunction/ai-mistral": "2.29.2",
-        "@memberjunction/ai-openai": "2.29.2",
-        "@memberjunction/aiengine": "2.29.2",
-        "@memberjunction/core": "2.29.2",
-        "@memberjunction/core-entities": "2.29.2",
-        "@memberjunction/global": "2.29.2",
-        "@memberjunction/sqlserver-dataprovider": "2.29.2",
+        "@memberjunction/actions": "2.30.0",
+        "@memberjunction/ai": "2.30.0",
+        "@memberjunction/ai-anthropic": "2.30.0",
+        "@memberjunction/ai-groq": "2.30.0",
+        "@memberjunction/ai-mistral": "2.30.0",
+        "@memberjunction/ai-openai": "2.30.0",
+        "@memberjunction/aiengine": "2.30.0",
+        "@memberjunction/core": "2.30.0",
+        "@memberjunction/core-entities": "2.30.0",
+        "@memberjunction/global": "2.30.0",
+        "@memberjunction/sqlserver-dataprovider": "2.30.0",
         "cosmiconfig": "9.0.0",
         "fs-extra": "^11.2.0",
         "glob": "^10.3.10",
@@ -29255,30 +30166,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=16"
-      }
-    },
-    "packages/CodeGenLib/node_modules/cosmiconfig": {
-      "version": "9.0.0",
-      "license": "MIT",
-      "dependencies": {
-        "env-paths": "^2.2.1",
-        "import-fresh": "^3.3.0",
-        "js-yaml": "^4.1.0",
-        "parse-json": "^5.2.0"
-      },
-      "engines": {
-        "node": ">=14"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/d-fischer"
-      },
-      "peerDependencies": {
-        "typescript": ">=4.9.5"
-      },
-      "peerDependenciesMeta": {
-        "typescript": {
-          "optional": true
-        }
       }
     },
     "packages/CodeGenLib/node_modules/iconv-lite": {
@@ -29341,13 +30228,13 @@
     },
     "packages/Communication/base-types": {
       "name": "@memberjunction/communication-types",
-      "version": "2.29.2",
+      "version": "2.30.0",
       "license": "ISC",
       "dependencies": {
-        "@memberjunction/core": "2.29.2",
-        "@memberjunction/core-entities": "2.29.2",
-        "@memberjunction/global": "2.29.2",
-        "@memberjunction/templates-base-types": "2.29.2",
+        "@memberjunction/core": "2.30.0",
+        "@memberjunction/core-entities": "2.30.0",
+        "@memberjunction/global": "2.30.0",
+        "@memberjunction/templates-base-types": "2.30.0",
         "rxjs": "^7.8.1"
       },
       "devDependencies": {
@@ -29357,14 +30244,14 @@
     },
     "packages/Communication/engine": {
       "name": "@memberjunction/communication-engine",
-      "version": "2.29.2",
+      "version": "2.30.0",
       "license": "ISC",
       "dependencies": {
-        "@memberjunction/communication-types": "2.29.2",
-        "@memberjunction/core": "2.29.2",
-        "@memberjunction/core-entities": "2.29.2",
-        "@memberjunction/global": "2.29.2",
-        "@memberjunction/templates": "2.29.2",
+        "@memberjunction/communication-types": "2.30.0",
+        "@memberjunction/core": "2.30.0",
+        "@memberjunction/core-entities": "2.30.0",
+        "@memberjunction/global": "2.30.0",
+        "@memberjunction/templates": "2.30.0",
         "rxjs": "^7.8.1"
       },
       "devDependencies": {
@@ -29374,13 +30261,13 @@
     },
     "packages/Communication/entity-comm-base": {
       "name": "@memberjunction/entity-communications-base",
-      "version": "2.29.2",
+      "version": "2.30.0",
       "license": "ISC",
       "dependencies": {
-        "@memberjunction/communication-types": "2.29.2",
-        "@memberjunction/core": "2.29.2",
-        "@memberjunction/core-entities": "2.29.2",
-        "@memberjunction/global": "2.29.2"
+        "@memberjunction/communication-types": "2.30.0",
+        "@memberjunction/core": "2.30.0",
+        "@memberjunction/core-entities": "2.30.0",
+        "@memberjunction/global": "2.30.0"
       },
       "devDependencies": {
         "ts-node-dev": "^2.0.0",
@@ -29389,14 +30276,14 @@
     },
     "packages/Communication/entity-comm-client": {
       "name": "@memberjunction/entity-communications-client",
-      "version": "2.29.2",
+      "version": "2.30.0",
       "license": "ISC",
       "dependencies": {
-        "@memberjunction/core": "2.29.2",
-        "@memberjunction/core-entities": "2.29.2",
-        "@memberjunction/entity-communications-base": "2.29.2",
-        "@memberjunction/global": "2.29.2",
-        "@memberjunction/graphql-dataprovider": "2.29.2"
+        "@memberjunction/core": "2.30.0",
+        "@memberjunction/core-entities": "2.30.0",
+        "@memberjunction/entity-communications-base": "2.30.0",
+        "@memberjunction/global": "2.30.0",
+        "@memberjunction/graphql-dataprovider": "2.30.0"
       },
       "devDependencies": {
         "ts-node-dev": "^2.0.0",
@@ -29405,14 +30292,14 @@
     },
     "packages/Communication/entity-comm-server": {
       "name": "@memberjunction/entity-communications-server",
-      "version": "2.29.2",
+      "version": "2.30.0",
       "license": "ISC",
       "dependencies": {
-        "@memberjunction/communication-engine": "2.29.2",
-        "@memberjunction/core": "2.29.2",
-        "@memberjunction/core-entities": "2.29.2",
-        "@memberjunction/entity-communications-base": "2.29.2",
-        "@memberjunction/global": "2.29.2"
+        "@memberjunction/communication-engine": "2.30.0",
+        "@memberjunction/core": "2.30.0",
+        "@memberjunction/core-entities": "2.30.0",
+        "@memberjunction/entity-communications-base": "2.30.0",
+        "@memberjunction/global": "2.30.0"
       },
       "devDependencies": {
         "ts-node-dev": "^2.0.0",
@@ -29421,19 +30308,19 @@
     },
     "packages/Communication/providers/MSGraph": {
       "name": "@memberjunction/communication-ms-graph",
-      "version": "2.29.2",
+      "version": "2.30.0",
       "license": "ISC",
       "dependencies": {
         "@azure/identity": "^4.4.1",
         "@azure/msal-node": "^2.14.0",
-        "@memberjunction/ai": "2.29.2",
-        "@memberjunction/ai-openai": "2.29.2",
-        "@memberjunction/aiengine": "2.29.2",
-        "@memberjunction/communication-types": "2.29.2",
-        "@memberjunction/core": "2.29.2",
-        "@memberjunction/core-entities": "2.29.2",
-        "@memberjunction/global": "2.29.2",
-        "@memberjunction/sqlserver-dataprovider": "2.29.2",
+        "@memberjunction/ai": "2.30.0",
+        "@memberjunction/ai-openai": "2.30.0",
+        "@memberjunction/aiengine": "2.30.0",
+        "@memberjunction/communication-types": "2.30.0",
+        "@memberjunction/core": "2.30.0",
+        "@memberjunction/core-entities": "2.30.0",
+        "@memberjunction/global": "2.30.0",
+        "@memberjunction/sqlserver-dataprovider": "2.30.0",
         "@microsoft/microsoft-graph-client": "^3.0.7",
         "@microsoft/microsoft-graph-types": "^2.40.0",
         "@types/html-to-text": "^9.0.4",
@@ -29626,13 +30513,13 @@
     },
     "packages/Communication/providers/sendgrid": {
       "name": "@memberjunction/communication-sendgrid",
-      "version": "2.29.2",
+      "version": "2.30.0",
       "license": "ISC",
       "dependencies": {
-        "@memberjunction/communication-types": "2.29.2",
-        "@memberjunction/core": "2.29.2",
-        "@memberjunction/core-entities": "2.29.2",
-        "@memberjunction/global": "2.29.2",
+        "@memberjunction/communication-types": "2.30.0",
+        "@memberjunction/core": "2.30.0",
+        "@memberjunction/core-entities": "2.30.0",
+        "@memberjunction/global": "2.30.0",
         "@sendgrid/mail": "^8.1.3"
       },
       "devDependencies": {
@@ -29642,13 +30529,13 @@
     },
     "packages/ContentAutotagging": {
       "name": "@memberjunction/content-autotagging",
-      "version": "2.29.2",
+      "version": "2.30.0",
       "license": "ISC",
       "dependencies": {
-        "@memberjunction/ai": "2.29.2",
-        "@memberjunction/core": "2.29.2",
-        "@memberjunction/core-entities": "2.29.2",
-        "@memberjunction/global": "2.29.2",
+        "@memberjunction/ai": "2.30.0",
+        "@memberjunction/core": "2.30.0",
+        "@memberjunction/core-entities": "2.30.0",
+        "@memberjunction/global": "2.30.0",
         "axios": "^1.7.2",
         "cheerio": "^1.0.0-rc.12",
         "crypto": "^1.0.1",
@@ -29682,12 +30569,12 @@
     },
     "packages/DocUtils": {
       "name": "@memberjunction/doc-utils",
-      "version": "2.29.2",
+      "version": "2.30.0",
       "license": "ISC",
       "dependencies": {
-        "@memberjunction/core": "2.29.2",
-        "@memberjunction/core-entities": "2.29.2",
-        "@memberjunction/global": "2.29.2",
+        "@memberjunction/core": "2.30.0",
+        "@memberjunction/core-entities": "2.30.0",
+        "@memberjunction/global": "2.30.0",
         "axios": "^1.6.7",
         "jsdom": "^24.1.0"
       },
@@ -29698,13 +30585,13 @@
     },
     "packages/ExternalChangeDetection": {
       "name": "@memberjunction/external-change-detection",
-      "version": "2.29.2",
+      "version": "2.30.0",
       "license": "ISC",
       "dependencies": {
-        "@memberjunction/core": "2.29.2",
-        "@memberjunction/core-entities": "2.29.2",
-        "@memberjunction/global": "2.29.2",
-        "@memberjunction/sqlserver-dataprovider": "2.29.2"
+        "@memberjunction/core": "2.30.0",
+        "@memberjunction/core-entities": "2.30.0",
+        "@memberjunction/global": "2.30.0",
+        "@memberjunction/sqlserver-dataprovider": "2.30.0"
       },
       "devDependencies": {
         "ts-node-dev": "^2.0.0",
@@ -29716,12 +30603,12 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
-        "@memberjunction/actions": "2.29.2",
-        "@memberjunction/ai": "2.29.2",
-        "@memberjunction/aiengine": "2.29.2",
-        "@memberjunction/core": "2.29.2",
-        "@memberjunction/core-entities": "2.29.2",
-        "@memberjunction/global": "2.29.2",
+        "@memberjunction/actions": "2.30.0",
+        "@memberjunction/ai": "2.30.0",
+        "@memberjunction/aiengine": "2.30.0",
+        "@memberjunction/core": "2.30.0",
+        "@memberjunction/core-entities": "2.30.0",
+        "@memberjunction/global": "2.30.0",
         "zod": "^3.23.8"
       },
       "devDependencies": {
@@ -29734,8 +30621,8 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
-        "@memberjunction/core": "2.29.2",
-        "@memberjunction/global": "2.29.2",
+        "@memberjunction/core": "2.30.0",
+        "@memberjunction/global": "2.30.0",
         "zod": "^3.23.8"
       },
       "devDependencies": {
@@ -29745,12 +30632,12 @@
     },
     "packages/GraphQLDataProvider": {
       "name": "@memberjunction/graphql-dataprovider",
-      "version": "2.29.2",
+      "version": "2.30.0",
       "license": "ISC",
       "dependencies": {
-        "@memberjunction/core": "2.29.2",
-        "@memberjunction/core-entities": "2.29.2",
-        "@memberjunction/global": "2.29.2",
+        "@memberjunction/core": "2.30.0",
+        "@memberjunction/core-entities": "2.30.0",
+        "@memberjunction/global": "2.30.0",
         "@tempfix/idb": "^8.0.3",
         "graphql": "^16.8.0",
         "graphql-request": "^5.2.0",
@@ -29819,13 +30706,13 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
-        "@memberjunction/ai": "2.29.2",
-        "@memberjunction/communication-sendgrid": "2.29.2",
-        "@memberjunction/core": "2.29.2",
-        "@memberjunction/global": "2.29.2",
-        "@memberjunction/server": "2.29.2",
-        "@memberjunction/sqlserver-dataprovider": "2.29.2",
-        "@memberjunction/templates": "2.29.2",
+        "@memberjunction/ai": "2.30.0",
+        "@memberjunction/communication-sendgrid": "2.30.0",
+        "@memberjunction/core": "2.30.0",
+        "@memberjunction/global": "2.30.0",
+        "@memberjunction/server": "2.30.0",
+        "@memberjunction/sqlserver-dataprovider": "2.30.0",
+        "@memberjunction/templates": "2.30.0",
         "axios": "^1.6.7",
         "class-validator": "^0.14.0",
         "mj_generatedactions": "1.0.0",
@@ -29841,11 +30728,11 @@
     },
     "packages/MJCLI": {
       "name": "@memberjunction/cli",
-      "version": "2.29.2",
+      "version": "2.30.0",
       "license": "ISC",
       "dependencies": {
         "@inquirer/prompts": "^5.0.1",
-        "@memberjunction/codegen-lib": "2.29.2",
+        "@memberjunction/codegen-lib": "2.30.0",
         "@oclif/core": "^3",
         "@oclif/plugin-help": "^6",
         "@oclif/plugin-version": "^2.0.17",
@@ -29877,30 +30764,6 @@
         "node": ">=20.0.0"
       }
     },
-    "packages/MJCLI/node_modules/cosmiconfig": {
-      "version": "9.0.0",
-      "license": "MIT",
-      "dependencies": {
-        "env-paths": "^2.2.1",
-        "import-fresh": "^3.3.0",
-        "js-yaml": "^4.1.0",
-        "parse-json": "^5.2.0"
-      },
-      "engines": {
-        "node": ">=14"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/d-fischer"
-      },
-      "peerDependencies": {
-        "typescript": ">=4.9.5"
-      },
-      "peerDependenciesMeta": {
-        "typescript": {
-          "optional": true
-        }
-      }
-    },
     "packages/MJCLI/node_modules/rimraf": {
       "version": "5.0.7",
       "dev": true,
@@ -29923,11 +30786,11 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
-        "@memberjunction/codegen-lib": "2.29.2",
-        "@memberjunction/core": "2.29.2",
-        "@memberjunction/core-entities": "2.29.2",
-        "@memberjunction/global": "2.29.2",
-        "@memberjunction/sqlserver-dataprovider": "2.29.2",
+        "@memberjunction/codegen-lib": "2.30.0",
+        "@memberjunction/core": "2.30.0",
+        "@memberjunction/core-entities": "2.30.0",
+        "@memberjunction/global": "2.30.0",
+        "@memberjunction/sqlserver-dataprovider": "2.30.0",
         "@types/axios": "^0.14.0",
         "@types/mssql": "^9.1.5",
         "axios": "^1.6.7",
@@ -29968,10 +30831,10 @@
     },
     "packages/MJCore": {
       "name": "@memberjunction/core",
-      "version": "2.29.2",
+      "version": "2.30.0",
       "license": "ISC",
       "dependencies": {
-        "@memberjunction/global": "2.29.2",
+        "@memberjunction/global": "2.30.0",
         "debug": "^4.4.0",
         "rxjs": "^7.8.1",
         "zod": "^3.23.8"
@@ -30007,11 +30870,11 @@
     },
     "packages/MJCoreEntities": {
       "name": "@memberjunction/core-entities",
-      "version": "2.29.2",
+      "version": "2.30.0",
       "license": "ISC",
       "dependencies": {
-        "@memberjunction/core": "2.29.2",
-        "@memberjunction/global": "2.29.2",
+        "@memberjunction/core": "2.30.0",
+        "@memberjunction/global": "2.30.0",
         "zod": "^3.23.8"
       },
       "devDependencies": {
@@ -30021,12 +30884,12 @@
     },
     "packages/MJDataContext": {
       "name": "@memberjunction/data-context",
-      "version": "2.29.2",
+      "version": "2.30.0",
       "license": "ISC",
       "dependencies": {
-        "@memberjunction/core": "2.29.2",
-        "@memberjunction/core-entities": "2.29.2",
-        "@memberjunction/global": "2.29.2"
+        "@memberjunction/core": "2.30.0",
+        "@memberjunction/core-entities": "2.30.0",
+        "@memberjunction/global": "2.30.0"
       },
       "devDependencies": {
         "ts-node-dev": "^2.0.0",
@@ -30035,11 +30898,11 @@
     },
     "packages/MJDataContextServer": {
       "name": "@memberjunction/data-context-server",
-      "version": "2.29.2",
+      "version": "2.30.0",
       "license": "ISC",
       "dependencies": {
-        "@memberjunction/data-context": "2.29.2",
-        "@memberjunction/global": "2.29.2",
+        "@memberjunction/data-context": "2.30.0",
+        "@memberjunction/global": "2.30.0",
         "typeorm": "^0.3.20"
       },
       "devDependencies": {
@@ -30060,23 +30923,23 @@
         "@angular/platform-browser-dynamic": "18.0.2",
         "@angular/router": "18.0.2",
         "@azure/msal-angular": "^3.0.11",
-        "@memberjunction/core": "2.29.2",
-        "@memberjunction/core-entities": "2.29.2",
-        "@memberjunction/global": "2.29.2",
-        "@memberjunction/graphql-dataprovider": "2.29.2",
-        "@memberjunction/ng-ask-skip": "2.29.2",
-        "@memberjunction/ng-auth-services": "2.29.2",
-        "@memberjunction/ng-compare-records": "2.29.2",
-        "@memberjunction/ng-container-directives": "2.29.2",
-        "@memberjunction/ng-core-entity-forms": "2.29.2",
-        "@memberjunction/ng-explorer-core": "2.29.2",
-        "@memberjunction/ng-explorer-settings": "2.29.2",
-        "@memberjunction/ng-join-grid": "2.29.2",
-        "@memberjunction/ng-link-directives": "2.29.2",
-        "@memberjunction/ng-record-changes": "2.29.2",
-        "@memberjunction/ng-tabstrip": "2.29.2",
-        "@memberjunction/ng-timeline": "2.29.2",
-        "@memberjunction/ng-user-view-grid": "2.29.2",
+        "@memberjunction/core": "2.30.0",
+        "@memberjunction/core-entities": "2.30.0",
+        "@memberjunction/global": "2.30.0",
+        "@memberjunction/graphql-dataprovider": "2.30.0",
+        "@memberjunction/ng-ask-skip": "2.30.0",
+        "@memberjunction/ng-auth-services": "2.30.0",
+        "@memberjunction/ng-compare-records": "2.30.0",
+        "@memberjunction/ng-container-directives": "2.30.0",
+        "@memberjunction/ng-core-entity-forms": "2.30.0",
+        "@memberjunction/ng-explorer-core": "2.30.0",
+        "@memberjunction/ng-explorer-settings": "2.30.0",
+        "@memberjunction/ng-join-grid": "2.30.0",
+        "@memberjunction/ng-link-directives": "2.30.0",
+        "@memberjunction/ng-record-changes": "2.30.0",
+        "@memberjunction/ng-tabstrip": "2.30.0",
+        "@memberjunction/ng-timeline": "2.30.0",
+        "@memberjunction/ng-user-view-grid": "2.30.0",
         "@progress/kendo-angular-notification": "16.2.0",
         "@progress/kendo-angular-scheduler": "16.2.0",
         "@progress/kendo-licensing": "^1.3.5",
@@ -30105,7 +30968,7 @@
     },
     "packages/MJGlobal": {
       "name": "@memberjunction/global",
-      "version": "2.29.2",
+      "version": "2.30.0",
       "license": "ISC",
       "dependencies": {
         "rxjs": "^7.8.1"
@@ -30117,14 +30980,14 @@
     },
     "packages/MJQueue": {
       "name": "@memberjunction/queue",
-      "version": "2.29.2",
+      "version": "2.30.0",
       "license": "ISC",
       "dependencies": {
-        "@memberjunction/ai": "2.29.2",
-        "@memberjunction/aiengine": "2.29.2",
-        "@memberjunction/core": "2.29.2",
-        "@memberjunction/core-entities": "2.29.2",
-        "@memberjunction/global": "2.29.2",
+        "@memberjunction/ai": "2.30.0",
+        "@memberjunction/aiengine": "2.30.0",
+        "@memberjunction/core": "2.30.0",
+        "@memberjunction/core-entities": "2.30.0",
+        "@memberjunction/global": "2.30.0",
         "@types/uuid": "^9.0.1",
         "uuid": "^9.0.0"
       },
@@ -30135,32 +30998,32 @@
     },
     "packages/MJServer": {
       "name": "@memberjunction/server",
-      "version": "2.29.2",
+      "version": "2.30.0",
       "license": "ISC",
       "dependencies": {
         "@apollo/server": "^4.9.1",
         "@graphql-tools/utils": "^10.0.1",
-        "@memberjunction/actions": "2.29.2",
-        "@memberjunction/ai": "2.29.2",
-        "@memberjunction/ai-mistral": "2.29.2",
-        "@memberjunction/ai-openai": "2.29.2",
-        "@memberjunction/ai-vectors-pinecone": "2.29.2",
-        "@memberjunction/aiengine": "2.29.2",
-        "@memberjunction/core": "2.29.2",
-        "@memberjunction/core-actions": "2.29.2",
-        "@memberjunction/core-entities": "2.29.2",
-        "@memberjunction/data-context": "2.29.2",
-        "@memberjunction/data-context-server": "2.29.2",
-        "@memberjunction/doc-utils": "2.29.2",
-        "@memberjunction/entity-communications-server": "2.29.2",
-        "@memberjunction/external-change-detection": "2.29.2",
-        "@memberjunction/global": "2.29.2",
-        "@memberjunction/graphql-dataprovider": "2.29.2",
-        "@memberjunction/queue": "2.29.2",
-        "@memberjunction/skip-types": "2.29.2",
-        "@memberjunction/sqlserver-dataprovider": "2.29.2",
-        "@memberjunction/storage": "2.29.2",
-        "@memberjunction/templates": "2.29.2",
+        "@memberjunction/actions": "2.30.0",
+        "@memberjunction/ai": "2.30.0",
+        "@memberjunction/ai-mistral": "2.30.0",
+        "@memberjunction/ai-openai": "2.30.0",
+        "@memberjunction/ai-vectors-pinecone": "2.30.0",
+        "@memberjunction/aiengine": "2.30.0",
+        "@memberjunction/core": "2.30.0",
+        "@memberjunction/core-actions": "2.30.0",
+        "@memberjunction/core-entities": "2.30.0",
+        "@memberjunction/data-context": "2.30.0",
+        "@memberjunction/data-context-server": "2.30.0",
+        "@memberjunction/doc-utils": "2.30.0",
+        "@memberjunction/entity-communications-server": "2.30.0",
+        "@memberjunction/external-change-detection": "2.30.0",
+        "@memberjunction/global": "2.30.0",
+        "@memberjunction/graphql-dataprovider": "2.30.0",
+        "@memberjunction/queue": "2.30.0",
+        "@memberjunction/skip-types": "2.30.0",
+        "@memberjunction/sqlserver-dataprovider": "2.30.0",
+        "@memberjunction/storage": "2.30.0",
+        "@memberjunction/templates": "2.30.0",
         "@types/cors": "^2.8.13",
         "@types/jsonwebtoken": "9.0.6",
         "@types/node": "20.14.2",
@@ -30233,30 +31096,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=16"
-      }
-    },
-    "packages/MJServer/node_modules/cosmiconfig": {
-      "version": "9.0.0",
-      "license": "MIT",
-      "dependencies": {
-        "env-paths": "^2.2.1",
-        "import-fresh": "^3.3.0",
-        "js-yaml": "^4.1.0",
-        "parse-json": "^5.2.0"
-      },
-      "engines": {
-        "node": ">=14"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/d-fischer"
-      },
-      "peerDependencies": {
-        "typescript": ">=4.9.5"
-      },
-      "peerDependenciesMeta": {
-        "typescript": {
-          "optional": true
-        }
       }
     },
     "packages/MJServer/node_modules/iconv-lite": {
@@ -30355,7 +31194,7 @@
     },
     "packages/MJStorage": {
       "name": "@memberjunction/storage",
-      "version": "2.29.2",
+      "version": "2.30.0",
       "license": "ISC",
       "dependencies": {
         "@aws-sdk/client-s3": "^3.537.0",
@@ -30363,9 +31202,9 @@
         "@azure/identity": "^4.0.1",
         "@azure/storage-blob": "^12.17.0",
         "@google-cloud/storage": "^7.9.0",
-        "@memberjunction/core": "2.29.2",
-        "@memberjunction/core-entities": "2.29.2",
-        "@memberjunction/global": "2.29.2",
+        "@memberjunction/core": "2.30.0",
+        "@memberjunction/core-entities": "2.30.0",
+        "@memberjunction/global": "2.30.0",
         "env-var": "^7.4.1",
         "mime-types": "^2.1.35"
       },
@@ -30457,11 +31296,11 @@
     },
     "packages/SkipTypes": {
       "name": "@memberjunction/skip-types",
-      "version": "2.29.2",
+      "version": "2.30.0",
       "license": "ISC",
       "dependencies": {
-        "@memberjunction/core-entities": "2.29.2",
-        "@memberjunction/data-context": "2.29.2"
+        "@memberjunction/core-entities": "2.30.0",
+        "@memberjunction/data-context": "2.30.0"
       },
       "devDependencies": {
         "ts-node-dev": "^2.0.0",
@@ -30470,17 +31309,17 @@
     },
     "packages/SQLServerDataProvider": {
       "name": "@memberjunction/sqlserver-dataprovider",
-      "version": "2.29.2",
+      "version": "2.30.0",
       "license": "ISC",
       "dependencies": {
-        "@memberjunction/actions": "2.29.2",
-        "@memberjunction/ai": "2.29.2",
-        "@memberjunction/ai-vector-dupe": "2.29.2",
-        "@memberjunction/aiengine": "2.29.2",
-        "@memberjunction/core": "2.29.2",
-        "@memberjunction/core-entities": "2.29.2",
-        "@memberjunction/global": "2.29.2",
-        "@memberjunction/queue": "2.29.2",
+        "@memberjunction/actions": "2.30.0",
+        "@memberjunction/ai": "2.30.0",
+        "@memberjunction/ai-vector-dupe": "2.30.0",
+        "@memberjunction/aiengine": "2.30.0",
+        "@memberjunction/core": "2.30.0",
+        "@memberjunction/core-entities": "2.30.0",
+        "@memberjunction/global": "2.30.0",
+        "@memberjunction/queue": "2.30.0",
         "mssql": "^11.0.1",
         "typeorm": "^0.3.20"
       },
@@ -30568,12 +31407,12 @@
     },
     "packages/Templates/base-types": {
       "name": "@memberjunction/templates-base-types",
-      "version": "2.29.2",
+      "version": "2.30.0",
       "license": "ISC",
       "dependencies": {
-        "@memberjunction/core": "2.29.2",
-        "@memberjunction/core-entities": "2.29.2",
-        "@memberjunction/global": "2.29.2"
+        "@memberjunction/core": "2.30.0",
+        "@memberjunction/core-entities": "2.30.0",
+        "@memberjunction/global": "2.30.0"
       },
       "devDependencies": {
         "typescript": "^5.4.5"
@@ -30581,16 +31420,16 @@
     },
     "packages/Templates/engine": {
       "name": "@memberjunction/templates",
-      "version": "2.29.2",
+      "version": "2.30.0",
       "license": "ISC",
       "dependencies": {
-        "@memberjunction/ai": "2.29.2",
-        "@memberjunction/ai-groq": "2.29.2",
-        "@memberjunction/aiengine": "2.29.2",
-        "@memberjunction/core": "2.29.2",
-        "@memberjunction/core-entities": "2.29.2",
-        "@memberjunction/global": "2.29.2",
-        "@memberjunction/templates-base-types": "2.29.2",
+        "@memberjunction/ai": "2.30.0",
+        "@memberjunction/ai-groq": "2.30.0",
+        "@memberjunction/aiengine": "2.30.0",
+        "@memberjunction/core": "2.30.0",
+        "@memberjunction/core-entities": "2.30.0",
+        "@memberjunction/global": "2.30.0",
+        "@memberjunction/templates-base-types": "2.30.0",
         "nunjucks": "3.2.4"
       },
       "devDependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -28543,7 +28543,7 @@
         "zod": "^3.23.8"
       },
       "bin": {
-        "MemberJunction": "build/index.js"
+        "MemberJunction": "dist/index.js"
       },
       "devDependencies": {
         "@types/node": "20.14.2",

--- a/packages/AI/Engine/index.ts
+++ b/packages/AI/Engine/index.ts
@@ -1,1 +1,0 @@
-export * from './src/AIEngine';

--- a/packages/AI/MCPServer/package.json
+++ b/packages/AI/MCPServer/package.json
@@ -1,0 +1,35 @@
+{
+  "name": "@memberjunction/ai-mcp-server",
+  "version": "2.30.0",
+  "description": "MemberJunction: Model Context Protocol (MCP) - Server Implementation",
+  "type": "module",
+  "bin": {
+    "MemberJunction": "./dist/index.js"
+  },
+  "scripts": {
+    "build": "tsc && chmod 755 dist/index.js",
+    "start": "node dist/index.js"
+  },
+  "files": [
+    "dist"
+  ],
+  "author": "MemberJunction.com",
+  "license": "ISC",
+  "dependencies": {
+    "@memberjunction/core": "2.30.0",
+    "@memberjunction/global": "2.30.0",
+    "@memberjunction/core-entities": "2.30.0",
+    "@memberjunction/sqlserver-dataprovider": "2.30.0",
+    "@modelcontextprotocol/sdk": "^1.8.0",
+    "cosmiconfig": "9.0.0",
+    "dotenv": "^16.4.1",
+    "fastmcp": "^1.20.5",
+    "typeorm": "^0.3.20",
+    "zod": "^3.23.8"
+  },
+  "devDependencies": {
+    "@types/node": "20.14.2",
+    "ts-node-dev": "^2.0.0",  
+    "typescript": "^5.4.5"
+  }
+}

--- a/packages/AI/MCPServer/src/Server.ts
+++ b/packages/AI/MCPServer/src/Server.ts
@@ -1,0 +1,107 @@
+import { LogError, LogStatus, Metadata } from "@memberjunction/core";
+import { setupSQLServerClient, SQLServerProviderConfigData } from "@memberjunction/sqlserver-dataprovider";
+import { FastMCP } from "fastmcp";
+import { DataSource } from "typeorm";
+import { z } from "zod";
+import { DataSourceOptions } from 'typeorm';
+import { configInfo, dbDatabase, dbHost, dbPassword, dbPort, dbUsername, dbInstanceName, dbTrustServerCertificate, mcpServerPort } from './config.js';
+
+// Prepare ORM configuration
+const ormConfig = {
+    type: 'mssql' as const,
+    entities: [],
+    logging: false,
+    host: dbHost,
+    port: dbPort,
+    username: dbUsername,
+    password: dbPassword,
+    database: dbDatabase,
+    synchronize: false,
+    requestTimeout: configInfo.databaseSettings.requestTimeout,
+    connectionTimeout: configInfo.databaseSettings.connectionTimeout,
+    options: {},
+};
+
+if (dbInstanceName !== null && dbInstanceName !== undefined && dbInstanceName.trim().length > 0) {
+    ormConfig.options = {
+        ...ormConfig.options,
+        instanceName: dbInstanceName,
+    };
+}
+
+if (dbTrustServerCertificate !== null && dbTrustServerCertificate !== undefined) {
+    ormConfig.options = {
+        ...ormConfig.options,
+        trustServerCertificate: dbTrustServerCertificate === 'Y',
+    };
+}
+
+// Create FastMCP server instance
+const server = new FastMCP({
+    name: "MemberJunction",
+    version: "1.0.0"
+});
+
+// Initialize database and setup tools
+async function initializeServer() {
+    try {
+        // Initialize database connection
+        const dataSource = new DataSource(ormConfig);
+        await dataSource.initialize();
+        console.log(`Connected to database: ${ormConfig.database}`);
+        
+        // Setup SQL Server client
+        const config = new SQLServerProviderConfigData(dataSource, '', '__mj');
+        await setupSQLServerClient(config);
+        
+        // Define tools
+        server.addTool({
+            name: "add",
+            description: "Add two numbers together",
+            parameters: z.object({
+                a: z.number(),
+                b: z.number()
+            }),
+            execute: async ({ a, b }) => {
+                return String(a + b);
+            }
+        });
+
+        server.addTool({
+            name: "get-all-entities",
+            description: "Get all entities from the metadata",
+            parameters: z.object({}),
+            execute: async () => {
+                const md = new Metadata();
+                const output = JSON.stringify(md.Entities, null, 2);
+                return output;
+            }
+        });
+
+        // Configure server options
+        const serverOptions = {
+            transportType: "sse" as const,
+            sse: {
+                endpoint: "/mcp" as `/${string}`,
+                port: mcpServerPort
+            },
+            // Optional: Add auth configuration if needed
+            // auth: {
+            //   type: "basic",
+            //   username: "user",
+            //   password: "pass"
+            // }
+        };
+
+        // Start server with SSE transport
+        server.start(serverOptions);
+
+        console.log(`MemberJunction MCP Server running on port ${mcpServerPort}`);
+        console.log(`Server endpoint available at: http://localhost:${mcpServerPort}/mcp`);
+    } catch (error) {
+        console.error("Failed to initialize MCP server:", error);
+    }
+}
+
+// Run the server
+initializeServer();

--- a/packages/AI/MCPServer/src/Server.ts
+++ b/packages/AI/MCPServer/src/Server.ts
@@ -1,10 +1,14 @@
-import { LogError, LogStatus, Metadata } from "@memberjunction/core";
-import { setupSQLServerClient, SQLServerProviderConfigData } from "@memberjunction/sqlserver-dataprovider";
-import { FastMCP } from "fastmcp";
+import { BaseEntity, CompositeKey, EntityFieldInfo, EntityInfo, LogError, LogStatus, Metadata, RunView, UserInfo } from "@memberjunction/core";
+import { setupSQLServerClient, SQLServerProviderConfigData, UserCache } from "@memberjunction/sqlserver-dataprovider";
+import { FastMCP, Resource, ResourceResult } from "fastmcp";
 import { DataSource } from "typeorm";
 import { z } from "zod";
 import { DataSourceOptions } from 'typeorm';
-import { configInfo, dbDatabase, dbHost, dbPassword, dbPort, dbUsername, dbInstanceName, dbTrustServerCertificate, mcpServerPort } from './config.js';
+import { configInfo, dbDatabase, dbHost, dbPassword, dbPort, dbUsername, dbInstanceName, dbTrustServerCertificate, mcpServerSettings } from './config.js';
+import { match } from "assert";
+
+
+const mcpServerPort = mcpServerSettings?.port || 3100;
 
 // Prepare ORM configuration
 const ormConfig = {
@@ -45,39 +49,35 @@ const server = new FastMCP({
 // Initialize database and setup tools
 async function initializeServer() {
     try {
+        if (!mcpServerSettings?.enableMCPServer) {
+            console.log("MCP Server is disabled in the configuration.");
+            throw new Error("MCP Server is disabled in the configuration.");
+       }
         // Initialize database connection
         const dataSource = new DataSource(ormConfig);
         await dataSource.initialize();
-        console.log(`Connected to database: ${ormConfig.database}`);
         
         // Setup SQL Server client
-        const config = new SQLServerProviderConfigData(dataSource, '', '__mj');
+        const config = new SQLServerProviderConfigData(dataSource, '', configInfo.mjCoreSchema);
         await setupSQLServerClient(config);
-        
-        // Define tools
-        server.addTool({
-            name: "add",
-            description: "Add two numbers together",
-            parameters: z.object({
-                a: z.number(),
-                b: z.number()
-            }),
-            execute: async ({ a, b }) => {
-                return String(a + b);
-            }
-        });
+        console.log("Database connection setup completed.");
 
         server.addTool({
-            name: "get-all-entities",
-            description: "Get all entities from the metadata",
+            name: "Get All Entities",
+            description: "Retrieves all Entities including entity fields and relationships, from the MemberJunction Metadata",
             parameters: z.object({}),
-            execute: async () => {
+            async execute() {
                 const md = new Metadata();
                 const output = JSON.stringify(md.Entities, null, 2);
                 return output;
-            }
+            }        
         });
 
+        const contextUser = UserCache.Instance.Users[0];
+        await loadEntityTools(contextUser);
+        await loadActionTools(contextUser);
+        console.log("Tools loaded successfully.");
+        
         // Configure server options
         const serverOptions = {
             transportType: "sse" as const,
@@ -101,6 +101,327 @@ async function initializeServer() {
     } catch (error) {
         console.error("Failed to initialize MCP server:", error);
     }
+}
+
+async function loadActionTools(contextUser: UserInfo) {
+    // not yet supported but don't throw log error unless the config has action tools in it
+    const actionTools = mcpServerSettings?.actionTools;
+    if (actionTools && actionTools.length > 0) {
+        console.warn("Action tools are not yet supported");
+    }
+}
+
+async function loadEntityTools(contextUser: UserInfo) {
+    // use the config metadata to load up the tools requested
+    const entityTools = mcpServerSettings?.entityTools;
+
+    if (entityTools && entityTools.length > 0) {
+        const md = new Metadata();
+
+        // iterate through the tools and add them to the server
+        entityTools.forEach((tool) => {
+            const matchingEntities = getMatchingEntitiesForTool(md.Entities, tool);
+            matchingEntities.forEach((entity) => {
+                if (tool.get) {
+                    addEntityGetTool(entity, contextUser);
+                }
+                if (tool.create) {
+                    addEntityCreateTool(entity, contextUser);
+                }
+                if (tool.update) {
+                    addEntityUpdateTool(entity, contextUser);
+                }
+                if (tool.delete) {
+                    addEntityDeleteTool(entity, contextUser);
+                }
+                if (tool.runView) {
+                    addEntityRunViewTool(entity, contextUser);
+                }
+            });
+        });
+    }
+}
+
+function addEntityRunViewTool(entity: EntityInfo, contextUser: UserInfo) {
+    const paramObject = z.object({
+        extraFilter: z.string().optional(),
+        orderBy: z.string().optional(),
+        fields: z.array(z.string()).optional(),
+    })
+    const toolConfig = {
+        name: `Run ${entity.Name} View`,
+        description: `Returns data from the ${entity.Name} entity, optionally filtered by extraFilter and ordered by orderBy`,
+        parameters: paramObject,
+        async execute (props: any) {
+            const rv = new RunView();
+            const result = await rv.RunView({
+                EntityName: entity.Name,
+                ExtraFilter: props.extraFilter ? props.extraFilter : undefined,
+                OrderBy: props.orderBy ? props.orderBy : undefined,
+                Fields: props.fields ? props.fields : undefined,
+            }, contextUser);
+            return JSON.stringify(result);
+        }
+    };
+    server.addTool(toolConfig);
+}
+
+function addEntityCreateTool(entity: EntityInfo, contextUser: UserInfo) {
+    // add a tool for getting records from the specified entity or wildcard
+    const paramObject = getEntityParamObject(entity, true, false, false);
+
+    const toolConfig = {
+        name: `Create ${entity.Name} Record`,
+        description: `Creates a new record in the ${entity.Name} entity`,
+        parameters: z.object(paramObject),
+        async execute (props: any) {
+            const md = new Metadata();
+            const record = await md.GetEntityObject(entity.Name, contextUser);
+            record.SetMany(props, true);
+            const success = await record.Save();
+            if (!success) {
+                return JSON.stringify({success, record: undefined, errorMessage: record.LatestResult.Message });
+            }
+            else {
+                return JSON.stringify({success, record: await convertEntityObjectToJSON(record), errorMessage: undefined });
+            }
+        }
+    };
+    server.addTool(toolConfig);    
+}
+
+function addEntityUpdateTool(entity: EntityInfo, contextUser: UserInfo) {
+    const paramObject = getEntityParamObject(entity, true, true, true);
+
+    const toolConfig = {
+        name: `Update ${entity.Name} Record`,
+        description: `Updates the specified record in the ${entity.Name} entity`,
+        parameters: z.object(paramObject),
+        async execute (props: any) {
+            const md = new Metadata();
+            const record = await md.GetEntityObject(entity.Name, contextUser);
+            const loaded = await record.InnerLoad(new CompositeKey(
+                // use the primary keys to load the record
+                entity.PrimaryKeys.map((pk) => {
+                    return {
+                        FieldName: pk.Name,
+                        Value: props[pk.Name]
+                    };
+                })
+            ));
+            if (loaded) {
+                // remove the primary keys from the props so we don't try to update them
+                const newProps = { ...props };
+                entity.PrimaryKeys.forEach((pk) => {
+                    delete newProps[pk.Name];
+                });
+                record.SetMany(newProps, true);
+                const success = await record.Save();
+                return JSON.stringify({success, record: await convertEntityObjectToJSON(record), errorMessage: !success ? record.LatestResult.Message : undefined });
+            }
+            else {
+                return JSON.stringify({success: false, record: undefined, errorMessage: "Record not found"});
+            }
+        }
+    };
+    server.addTool(toolConfig);    
+}
+
+function addEntityDeleteTool(entity: EntityInfo, contextUser: UserInfo) {
+    const pkeyParams = getEntityPrimaryKeyParamsObject(entity);
+    const toolConfig = {
+        name: `Delete ${entity.Name} Record`,
+        description: `Deletes the specified record from the ${entity.Name} entity`,
+        parameters: z.object(pkeyParams),
+        async execute (props: any) {
+            const md = new Metadata();
+            const record = await md.GetEntityObject(entity.Name, contextUser);
+            const loaded = await record.InnerLoad(new CompositeKey(
+                // use the primary keys to load the record
+                entity.PrimaryKeys.map((pk) => {
+                    return {
+                        FieldName: pk.Name,
+                        Value: props[pk.Name]
+                    };
+                })
+            ));
+            if (loaded) {
+                const savedRecordJSON = await convertEntityObjectToJSON(record);
+                const success = await record.Delete();
+                return JSON.stringify({success, record: savedRecordJSON, errorMessage: !success ? record.LatestResult.Message : undefined });    
+            }
+            else {
+                return JSON.stringify({success: false, record: undefined, errorMessage: "Record not found"});
+            }
+        }
+    };
+    server.addTool(toolConfig);
+}
+
+
+async function convertEntityObjectToJSON(record: BaseEntity) {
+    const output = await record.GetDataObjectJSON({
+        includeRelatedEntityData: false,
+        oldValues: false,
+        omitEmptyStrings: false,
+        omitNullValues: false,
+        excludeFields: [],
+        relatedEntityList: [],
+    });
+    return output;
+}
+
+function getEntityParamObject(entity: EntityInfo, excludeReadOnlyFields: boolean, includePrimaryKeys: boolean, nonPKeysOptional: boolean) {
+    const paramObject: { [key: string]: any } = {};
+    // add the updateable fields as arguments
+
+    entity.Fields.filter(f => {
+        if (f.IsPrimaryKey && includePrimaryKeys) {
+            return true;
+        }
+        else if (f.ReadOnly && excludeReadOnlyFields) {
+            return false;
+        }
+        else {
+            return true;
+        } 
+
+    }).forEach((f) => {
+        addSingleParamToObject(paramObject, f, f.IsPrimaryKey ? false : nonPKeysOptional);
+    })
+    return paramObject;
+}
+
+function addSingleParamToObject(theObject: any, field: EntityFieldInfo, optional: boolean){
+    let newParam: any;
+    switch (field.TSType) {
+        case 'Date':
+            newParam = z.date();
+            break;
+        case 'boolean':
+            newParam = z.boolean();
+            break;
+        case 'number':
+            newParam = z.number();
+            break;
+        case 'string':
+            // for strings, check to see if we have a list of entity field values and if so, create an enum otherwise just a regular string
+            if (field.ValueListTypeEnum === 'None' || field.EntityFieldValues.length === 0) {
+                newParam = z.string();
+            }
+            else {
+                // we have either a list only, or list + user input scenario so set that up for zod
+                const enumList = field.EntityFieldValues.map((v) => {
+                    return v.Value;
+                });
+                if (field.ValueListTypeEnum === 'List') {
+                    newParam = z.enum(enumList as [string, ...string[]]);
+                }
+                else {
+                    newParam = z.union([z.enum(enumList as [string, ...string[]]), z.string()]);
+                }    
+            }
+            break;
+    }
+    if (optional) {
+        theObject[field.Name] = newParam.optional();
+    }
+    else {
+        theObject[field.Name] = newParam;
+    }
+}
+
+function getEntityPrimaryKeyParamsObject(entity: EntityInfo) {
+    // add a tool for getting records from the specified entity or wildcard
+    const paramObject: { [key: string]: any } = {};
+    // add the primary keys as arguments
+    entity.PrimaryKeys.forEach((pk) => {
+        addSingleParamToObject(paramObject, pk, false); 
+    })
+    return paramObject;
+}
+
+function addEntityGetTool(entity: EntityInfo, contextUser: UserInfo) {
+    const pkeyParams = getEntityPrimaryKeyParamsObject(entity);
+
+    const toolConfig = {
+        name: `Get ${entity.Name} Record`,
+        description: `Retrieves the specified record from the ${entity.Name} entity`,
+        parameters: z.object(pkeyParams),
+        async execute (props: any) {
+            const md = new Metadata();
+            const record = await md.GetEntityObject(entity.Name, contextUser);
+            await record.InnerLoad(new CompositeKey(
+                // use the primary keys to load the record
+                entity.PrimaryKeys.map((pk) => {
+                    return {
+                        FieldName: pk.Name,
+                        Value: props[pk.Name]
+                    };
+                })
+            ));
+            return await convertEntityObjectToJSON(record);
+        }
+    };
+    server.addTool(toolConfig);
+}
+function getMatchingEntitiesForTool(allEntities: EntityInfo[], tool: {
+    get: boolean;
+    create: boolean;
+    update: boolean;
+    delete: boolean;
+    runView: boolean;
+    entityName?: string | undefined;
+    schemaName?: string | undefined;
+}) {
+    const matchingEntities = allEntities.filter((entity) => {
+        const entityName = entity.Name;
+        const schemaName = entity.SchemaName;
+        const toolEntityName = tool.entityName?.trim().toLowerCase() || "*";
+        const toolSchemaName = tool.schemaName?.trim().toLowerCase() || "*";
+
+        // we support wildcards such as * which is all entities/schemas, *Partial which would be Partial is the ending of the string, or Partial* where Partial is the start of the string
+        // so we need to check for the conditions as follows: exact match, wildcard at the start, wildcard at the end, and wildcard only means always match and assign to two variables, schemaMatch
+        // first to scope the schema and then entityMatch if the schemaMatch is true
+        let schemaMatch = false;
+        let entityMatch = false;
+        if (toolSchemaName === "*") {
+            schemaMatch = true;
+        }
+        else if (toolSchemaName.startsWith("*") && toolSchemaName.endsWith("*")) {
+            schemaMatch = schemaName.toLowerCase().includes(toolSchemaName.slice(1, -1));
+        }
+        else if (toolSchemaName.endsWith("*")) {
+            schemaMatch = schemaName.toLowerCase().startsWith(toolSchemaName.slice(0, -1));
+        }
+        else if (toolSchemaName.startsWith("*")) {
+            schemaMatch = schemaName.toLowerCase().endsWith(toolSchemaName.slice(1));
+        }
+        else {
+            schemaMatch = schemaName.toLowerCase() === toolSchemaName;
+        }
+
+        if (schemaMatch) {
+            // if the schema matches, we can check the entity name, otherwise we don't bother since we don't care about the entity name
+            if (toolEntityName === "*") {
+                entityMatch = true;
+            }
+            else if (toolEntityName.startsWith("*") && toolEntityName.endsWith("*")) {
+                entityMatch = entityName.toLowerCase().includes(toolEntityName.slice(1, -1));
+            }
+            else if (toolEntityName.endsWith("*")) {
+                entityMatch = entityName.toLowerCase().startsWith(toolEntityName.slice(0, -1));
+            }
+            else if (toolEntityName.startsWith("*")) {
+                entityMatch = entityName.toLowerCase().endsWith(toolEntityName.slice(1));
+            }
+            else {
+                entityMatch = entityName.toLowerCase() === toolEntityName;
+            }
+        }
+        return schemaMatch && entityMatch;
+    });
+    return matchingEntities;
 }
 
 // Run the server

--- a/packages/AI/MCPServer/src/Server.ts
+++ b/packages/AI/MCPServer/src/Server.ts
@@ -63,7 +63,7 @@ async function initializeServer() {
         console.log("Database connection setup completed.");
 
         server.addTool({
-            name: "Get All Entities",
+            name: "Get_All_Entities",
             description: "Retrieves all Entities including entity fields and relationships, from the MemberJunction Metadata",
             parameters: z.object({}),
             async execute() {
@@ -149,7 +149,7 @@ function addEntityRunViewTool(entity: EntityInfo, contextUser: UserInfo) {
         fields: z.array(z.string()).optional(),
     })
     const toolConfig = {
-        name: `Run ${entity.Name} View`,
+        name: `Run_${entity.ClassName}_View`,
         description: `Returns data from the ${entity.Name} entity, optionally filtered by extraFilter and ordered by orderBy`,
         parameters: paramObject,
         async execute (props: any) {
@@ -171,7 +171,7 @@ function addEntityCreateTool(entity: EntityInfo, contextUser: UserInfo) {
     const paramObject = getEntityParamObject(entity, true, false, false);
 
     const toolConfig = {
-        name: `Create ${entity.Name} Record`,
+        name: `Create_${entity.ClassName}_Record`,
         description: `Creates a new record in the ${entity.Name} entity`,
         parameters: z.object(paramObject),
         async execute (props: any) {
@@ -194,7 +194,7 @@ function addEntityUpdateTool(entity: EntityInfo, contextUser: UserInfo) {
     const paramObject = getEntityParamObject(entity, true, true, true);
 
     const toolConfig = {
-        name: `Update ${entity.Name} Record`,
+        name: `Update_${entity.ClassName}_Record`,
         description: `Updates the specified record in the ${entity.Name} entity`,
         parameters: z.object(paramObject),
         async execute (props: any) {
@@ -230,7 +230,7 @@ function addEntityUpdateTool(entity: EntityInfo, contextUser: UserInfo) {
 function addEntityDeleteTool(entity: EntityInfo, contextUser: UserInfo) {
     const pkeyParams = getEntityPrimaryKeyParamsObject(entity);
     const toolConfig = {
-        name: `Delete ${entity.Name} Record`,
+        name: `Delete_${entity.ClassName}_Record`,
         description: `Deletes the specified record from the ${entity.Name} entity`,
         parameters: z.object(pkeyParams),
         async execute (props: any) {
@@ -345,7 +345,7 @@ function addEntityGetTool(entity: EntityInfo, contextUser: UserInfo) {
     const pkeyParams = getEntityPrimaryKeyParamsObject(entity);
 
     const toolConfig = {
-        name: `Get ${entity.Name} Record`,
+        name: `Get_${entity.ClassName}_Record`,
         description: `Retrieves the specified record from the ${entity.Name} entity`,
         parameters: z.object(pkeyParams),
         async execute (props: any) {

--- a/packages/AI/MCPServer/src/config.ts
+++ b/packages/AI/MCPServer/src/config.ts
@@ -1,0 +1,144 @@
+import dotenv from 'dotenv';
+
+dotenv.config();
+
+import { z } from 'zod';
+import { cosmiconfigSync } from 'cosmiconfig';
+import { LogError } from '@memberjunction/core';
+
+const explorer = cosmiconfigSync('mj', { searchStrategy: 'global' });
+
+const userHandlingInfoSchema = z.object({
+  autoCreateNewUsers: z.boolean().optional().default(false),
+  newUserLimitedToAuthorizedDomains: z.boolean().optional().default(false),
+  newUserAuthorizedDomains: z.array(z.string()).optional().default([]),
+  newUserRoles: z.array(z.string()).optional().default([]),
+  updateCacheWhenNotFound: z.boolean().optional().default(false),
+  updateCacheWhenNotFoundDelay: z.number().optional().default(30000),
+  contextUserForNewUserCreation: z.string().optional().default(''),
+  CreateUserApplicationRecords: z.boolean().optional().default(false),
+  UserApplications: z.array(z.string()).optional().default([]),
+});
+
+const databaseSettingsInfoSchema = z.object({
+  connectionTimeout: z.number(),
+  requestTimeout: z.number(),
+  metadataCacheRefreshInterval: z.number(),
+  dbReadOnlyUsername: z.string().optional(),
+  dbReadOnlyPassword: z.string().optional(),
+});
+
+const viewingSystemInfoSchema = z.object({
+  enableSmartFilters: z.boolean().optional(),
+});
+
+const askSkipInfoSchema = z.object({
+  organizationInfo: z.string().optional(),
+  entitiesToSendSkip: z
+    .object({
+      excludeSchemas: z.array(z.string()).optional(),
+      includeEntitiesFromExcludedSchemas: z.array(z.string()).optional(),
+    })
+    .optional(),
+});
+
+const configInfoSchema = z.object({
+  userHandling: userHandlingInfoSchema,
+  databaseSettings: databaseSettingsInfoSchema,
+  viewingSystem: viewingSystemInfoSchema.optional(),
+  askSkip: askSkipInfoSchema.optional(),
+
+  apiKey: z.string().optional(),
+  baseUrl: z.string().optional(),
+
+  dbHost: z.string().default('localhost'),
+  dbDatabase: z.string(),
+  dbPort: z.number({ coerce: true }).default(1433),
+  dbUsername: z.string(),
+  dbPassword: z.string(),
+  dbReadOnlyUsername: z.string().optional(),
+  dbReadOnlyPassword: z.string().optional(),
+  dbTrustServerCertificate: z.coerce
+    .boolean()
+    .default(false)
+    .transform((v) => (v ? 'Y' : 'N')),
+  dbInstanceName: z.string().optional(),
+  graphqlPort: z.coerce.number().default(4000),
+  
+  // MCP Server settings
+  mcpServerPort: z.coerce.number().optional().default(3100),
+
+  ___codeGenAPIURL: z.string().optional(),
+  ___codeGenAPIPort: z.coerce.number().optional().default(3999),
+  ___codeGenAPISubmissionDelay: z.coerce.number().optional().default(5000),
+  graphqlRootPath: z.string().optional().default('/'),
+  webClientID: z.string().optional(),
+  tenantID: z.string().optional(),
+  enableIntrospection: z.coerce.boolean().optional().default(false),
+  websiteRunFromPackage: z.coerce.number().optional(),
+  userEmailMap: z
+    .string()
+    .transform((val) => z.record(z.string()).parse(JSON.parse(val)))
+    .optional(),
+  ___skipAPIurl: z.string().optional(),
+  ___skipAPIOrgId: z.string().optional(),
+  auth0Domain: z.string().optional(),
+  auth0WebClientID: z.string().optional(),
+  auth0ClientSecret: z.string().optional(),
+  mjCoreSchema: z.string(),
+});
+
+export type UserHandlingInfo = z.infer<typeof userHandlingInfoSchema>;
+export type DatabaseSettingsInfo = z.infer<typeof databaseSettingsInfoSchema>;
+export type ViewingSystemSettingsInfo = z.infer<typeof viewingSystemInfoSchema>;
+export type ConfigInfo = z.infer<typeof configInfoSchema>;
+
+export const configInfo: ConfigInfo = loadConfig();
+
+export const {
+  dbUsername,
+  dbPassword,
+  dbHost,
+  dbDatabase,
+  dbPort,
+  dbTrustServerCertificate,
+  dbInstanceName,
+  graphqlPort,
+  mcpServerPort,
+  ___codeGenAPIURL,
+  ___codeGenAPIPort,
+  ___codeGenAPISubmissionDelay,
+  graphqlRootPath,
+  webClientID,
+  tenantID,
+  enableIntrospection,
+  websiteRunFromPackage,
+  userEmailMap,
+  ___skipAPIurl,
+  ___skipAPIOrgId,
+  auth0Domain,
+  auth0WebClientID,
+  auth0ClientSecret,
+  apiKey,
+  baseUrl,
+  mjCoreSchema: mj_core_schema,
+  dbReadOnlyUsername,
+  dbReadOnlyPassword,
+} = configInfo;
+
+export function loadConfig(): ConfigInfo {
+  const configSearchResult = explorer.search(process.cwd());
+  if (!configSearchResult) {
+    throw new Error('Config file not found.');
+  }
+
+  if (configSearchResult.isEmpty) {
+    throw new Error(`Config file ${configSearchResult.filepath} is empty or does not exist.`);
+  }
+
+  const configParsing = configInfoSchema.safeParse(configSearchResult.config);
+  if (!configParsing.success) {
+    LogError('Error parsing config file', null, JSON.stringify(configParsing.error.issues, null, 2));
+  }
+  return <ConfigInfo>configParsing.data;
+}

--- a/packages/AI/MCPServer/src/config.ts
+++ b/packages/AI/MCPServer/src/config.ts
@@ -8,48 +8,37 @@ import { LogError } from '@memberjunction/core';
 
 const explorer = cosmiconfigSync('mj', { searchStrategy: 'global' });
 
-const userHandlingInfoSchema = z.object({
-  autoCreateNewUsers: z.boolean().optional().default(false),
-  newUserLimitedToAuthorizedDomains: z.boolean().optional().default(false),
-  newUserAuthorizedDomains: z.array(z.string()).optional().default([]),
-  newUserRoles: z.array(z.string()).optional().default([]),
-  updateCacheWhenNotFound: z.boolean().optional().default(false),
-  updateCacheWhenNotFoundDelay: z.number().optional().default(30000),
-  contextUserForNewUserCreation: z.string().optional().default(''),
-  CreateUserApplicationRecords: z.boolean().optional().default(false),
-  UserApplications: z.array(z.string()).optional().default([]),
-});
-
 const databaseSettingsInfoSchema = z.object({
   connectionTimeout: z.number(),
   requestTimeout: z.number(),
-  metadataCacheRefreshInterval: z.number(),
   dbReadOnlyUsername: z.string().optional(),
   dbReadOnlyPassword: z.string().optional(),
 });
 
-const viewingSystemInfoSchema = z.object({
-  enableSmartFilters: z.boolean().optional(),
+const mcpServerEntityToolInfoSchema = z.object({
+  entityName: z.string().optional(),
+  schemaName: z.string().optional(),
+  get: z.boolean().optional().default(false),
+  create: z.boolean().optional().default(false),
+  update: z.boolean().optional().default(false),
+  delete: z.boolean().optional().default(false),
+  runView: z.boolean().optional().default(false),
 });
 
-const askSkipInfoSchema = z.object({
-  organizationInfo: z.string().optional(),
-  entitiesToSendSkip: z
-    .object({
-      excludeSchemas: z.array(z.string()).optional(),
-      includeEntitiesFromExcludedSchemas: z.array(z.string()).optional(),
-    })
-    .optional(),
+const mcpServerActionToolInfoSchema = z.object({
+  actionName: z.string().optional(),
+  actionCategory: z.string().optional(),
+});
+
+const mcpServerInfoSchema = z.object({
+  port: z.coerce.number().optional().default(3100),
+  entityTools: z.array(mcpServerEntityToolInfoSchema).optional(),
+  actionTools: z.array(mcpServerActionToolInfoSchema).optional(),
+  enableMCPServer: z.boolean().optional().default(false),
 });
 
 const configInfoSchema = z.object({
-  userHandling: userHandlingInfoSchema,
   databaseSettings: databaseSettingsInfoSchema,
-  viewingSystem: viewingSystemInfoSchema.optional(),
-  askSkip: askSkipInfoSchema.optional(),
-
-  apiKey: z.string().optional(),
-  baseUrl: z.string().optional(),
 
   dbHost: z.string().default('localhost'),
   dbDatabase: z.string(),
@@ -63,34 +52,14 @@ const configInfoSchema = z.object({
     .default(false)
     .transform((v) => (v ? 'Y' : 'N')),
   dbInstanceName: z.string().optional(),
-  graphqlPort: z.coerce.number().default(4000),
-  
-  // MCP Server settings
-  mcpServerPort: z.coerce.number().optional().default(3100),
 
-  ___codeGenAPIURL: z.string().optional(),
-  ___codeGenAPIPort: z.coerce.number().optional().default(3999),
-  ___codeGenAPISubmissionDelay: z.coerce.number().optional().default(5000),
-  graphqlRootPath: z.string().optional().default('/'),
-  webClientID: z.string().optional(),
-  tenantID: z.string().optional(),
-  enableIntrospection: z.coerce.boolean().optional().default(false),
-  websiteRunFromPackage: z.coerce.number().optional(),
-  userEmailMap: z
-    .string()
-    .transform((val) => z.record(z.string()).parse(JSON.parse(val)))
-    .optional(),
-  ___skipAPIurl: z.string().optional(),
-  ___skipAPIOrgId: z.string().optional(),
-  auth0Domain: z.string().optional(),
-  auth0WebClientID: z.string().optional(),
-  auth0ClientSecret: z.string().optional(),
+  // MCP Server settings
+  mcpServerSettings: mcpServerInfoSchema.optional(),
+
   mjCoreSchema: z.string(),
 });
 
-export type UserHandlingInfo = z.infer<typeof userHandlingInfoSchema>;
 export type DatabaseSettingsInfo = z.infer<typeof databaseSettingsInfoSchema>;
-export type ViewingSystemSettingsInfo = z.infer<typeof viewingSystemInfoSchema>;
 export type ConfigInfo = z.infer<typeof configInfoSchema>;
 
 export const configInfo: ConfigInfo = loadConfig();
@@ -103,24 +72,7 @@ export const {
   dbPort,
   dbTrustServerCertificate,
   dbInstanceName,
-  graphqlPort,
-  mcpServerPort,
-  ___codeGenAPIURL,
-  ___codeGenAPIPort,
-  ___codeGenAPISubmissionDelay,
-  graphqlRootPath,
-  webClientID,
-  tenantID,
-  enableIntrospection,
-  websiteRunFromPackage,
-  userEmailMap,
-  ___skipAPIurl,
-  ___skipAPIOrgId,
-  auth0Domain,
-  auth0WebClientID,
-  auth0ClientSecret,
-  apiKey,
-  baseUrl,
+  mcpServerSettings,
   mjCoreSchema: mj_core_schema,
   dbReadOnlyUsername,
   dbReadOnlyPassword,

--- a/packages/AI/MCPServer/src/index.ts
+++ b/packages/AI/MCPServer/src/index.ts
@@ -1,0 +1,1 @@
+export * from './Server.js';

--- a/packages/AI/MCPServer/tsconfig.json
+++ b/packages/AI/MCPServer/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "Node16",
+    "moduleResolution": "Node16",
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "sourceMap": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules"]
+}

--- a/packages/AI/MCPServer/typedoc.json
+++ b/packages/AI/MCPServer/typedoc.json
@@ -1,0 +1,4 @@
+{
+  "extends": ["../../../typedoc.base.json"],
+  "entryPoints": ["src/index.ts"]
+}

--- a/packages/Angular/Explorer/core-entity-forms/src/lib/generated/Entities/Report/report.form.component.html
+++ b/packages/Angular/Explorer/core-entity-forms/src/lib/generated/Entities/Report/report.form.component.html
@@ -28,6 +28,32 @@
                             [BottomMargin]="GridBottomMargin">
                         </mj-user-view-grid>                    
                     </mj-tab-body>
+
+                    <mj-tab Name="MJ: Report Versions" [Visible]="record.IsSaved"> 
+                        MJ: Report Versions
+                    </mj-tab>
+                    <mj-tab-body>
+                        <mj-user-view-grid 
+                            [Params]="BuildRelationshipViewParamsByEntityName('MJ: Report Versions','ReportID')"  
+                            [NewRecordValues]="NewRecordValues('MJ: Report Versions')"
+                            [AllowLoad]="IsCurrentTab('MJ: Report Versions')"  
+                            [EditMode]="GridEditMode()"  
+                            [BottomMargin]="GridBottomMargin">
+                        </mj-user-view-grid>                    
+                    </mj-tab-body>
+
+                    <mj-tab Name="MJ: Report User States" [Visible]="record.IsSaved"> 
+                        MJ: Report User States
+                    </mj-tab>
+                    <mj-tab-body>
+                        <mj-user-view-grid 
+                            [Params]="BuildRelationshipViewParamsByEntityName('MJ: Report User States','ReportID')"  
+                            [NewRecordValues]="NewRecordValues('MJ: Report User States')"
+                            [AllowLoad]="IsCurrentTab('MJ: Report User States')"  
+                            [EditMode]="GridEditMode()"  
+                            [BottomMargin]="GridBottomMargin">
+                        </mj-user-view-grid>                    
+                    </mj-tab-body>
                 </mj-tabstrip>
     </form>
 </div>

--- a/packages/Angular/Explorer/core-entity-forms/src/lib/generated/Entities/ReportUserState/reportuserstate.form.component.html
+++ b/packages/Angular/Explorer/core-entity-forms/src/lib/generated/Entities/ReportUserState/reportuserstate.form.component.html
@@ -1,0 +1,22 @@
+<div class="record-form-container" mjFillContainer [bottomMargin]="20" [rightMargin]="5">
+    <form *ngIf="record" class="record-form"  #form="ngForm" mjFillContainer>
+        <mj-form-toolbar [form]="this"></mj-form-toolbar>
+
+                <mj-tabstrip (TabSelected)="onTabSelect($event)" mjFillContainer (ResizeContainer)="InvokeManualResize()">
+                    
+                    <mj-tab Name="Details">
+                        Details
+                    </mj-tab>
+                    <mj-tab-body>
+                        <mj-form-section 
+                            Entity="MJ: Report User States" 
+                            Section="details" 
+                            [record]="record" 
+                            [EditMode]="this.EditMode">
+                        </mj-form-section>
+                    </mj-tab-body>
+                    
+                </mj-tabstrip>
+    </form>
+</div>
+        

--- a/packages/Angular/Explorer/core-entity-forms/src/lib/generated/Entities/ReportUserState/reportuserstate.form.component.ts
+++ b/packages/Angular/Explorer/core-entity-forms/src/lib/generated/Entities/ReportUserState/reportuserstate.form.component.ts
@@ -1,0 +1,19 @@
+import { Component } from '@angular/core';
+import { ReportUserStateEntity } from '@memberjunction/core-entities';
+import { RegisterClass } from '@memberjunction/global';
+import { BaseFormComponent } from '@memberjunction/ng-base-forms';
+import { LoadReportUserStateDetailsComponent } from "./sections/details.component"
+
+@RegisterClass(BaseFormComponent, 'MJ: Report User States') // Tell MemberJunction about this class
+@Component({
+    selector: 'gen-reportuserstate-form',
+    templateUrl: './reportuserstate.form.component.html',
+    styleUrls: ['../../../../shared/form-styles.css']
+})
+export class ReportUserStateFormComponent extends BaseFormComponent {
+    public record!: ReportUserStateEntity;
+} 
+
+export function LoadReportUserStateFormComponent() {
+    LoadReportUserStateDetailsComponent();
+}

--- a/packages/Angular/Explorer/core-entity-forms/src/lib/generated/Entities/ReportUserState/sections/details.component.ts
+++ b/packages/Angular/Explorer/core-entity-forms/src/lib/generated/Entities/ReportUserState/sections/details.component.ts
@@ -1,0 +1,78 @@
+import { Component, Input } from '@angular/core';
+import { RegisterClass } from '@memberjunction/global';
+import { BaseFormSectionComponent } from '@memberjunction/ng-base-forms';
+import { ReportUserStateEntity } from '@memberjunction/core-entities';
+
+@RegisterClass(BaseFormSectionComponent, 'MJ: Report User States.details') // Tell MemberJunction about this class 
+@Component({
+    selector: 'gen-reportuserstate-form-details',
+    styleUrls: ['../../../../../shared/form-styles.css'],
+    template: `<div *ngIf="this.record">
+    <div class="record-form">
+        <mj-form-field 
+            [record]="record"
+            [ShowLabel]="true"
+            FieldName="ReportID"
+            Type="textbox"
+            [EditMode]="EditMode"
+            LinkType="Record"
+            LinkComponentType="Search"
+        ></mj-form-field>
+        <mj-form-field 
+            [record]="record"
+            [ShowLabel]="true"
+            FieldName="UserID"
+            Type="textbox"
+            [EditMode]="EditMode"
+            LinkType="Record"
+            LinkComponentType="Search"
+        ></mj-form-field>
+        <mj-form-field 
+            [record]="record"
+            [ShowLabel]="true"
+            FieldName="ReportState"
+            Type="textarea"
+            [EditMode]="EditMode"
+        ></mj-form-field>
+        <mj-form-field 
+            [record]="record"
+            [ShowLabel]="true"
+            FieldName="__mj_CreatedAt"
+            Type="textbox"
+            [EditMode]="EditMode"
+        ></mj-form-field>
+        <mj-form-field 
+            [record]="record"
+            [ShowLabel]="true"
+            FieldName="__mj_UpdatedAt"
+            Type="textbox"
+            [EditMode]="EditMode"
+        ></mj-form-field>
+        <mj-form-field 
+            [record]="record"
+            [ShowLabel]="true"
+            FieldName="Report"
+            Type="textbox"
+            [EditMode]="EditMode"
+        ></mj-form-field>
+        <mj-form-field 
+            [record]="record"
+            [ShowLabel]="true"
+            FieldName="User"
+            Type="textbox"
+            [EditMode]="EditMode"
+        ></mj-form-field>
+
+    </div>
+</div>
+    `
+})
+export class ReportUserStateDetailsComponent extends BaseFormSectionComponent {
+    @Input() override record!: ReportUserStateEntity;
+    @Input() override EditMode: boolean = false;
+}
+
+export function LoadReportUserStateDetailsComponent() {
+    // does nothing, but called in order to prevent tree-shaking from eliminating this component from the build
+}
+      

--- a/packages/Angular/Explorer/core-entity-forms/src/lib/generated/Entities/ReportVersion/reportversion.form.component.html
+++ b/packages/Angular/Explorer/core-entity-forms/src/lib/generated/Entities/ReportVersion/reportversion.form.component.html
@@ -1,0 +1,22 @@
+<div class="record-form-container" mjFillContainer [bottomMargin]="20" [rightMargin]="5">
+    <form *ngIf="record" class="record-form"  #form="ngForm" mjFillContainer>
+        <mj-form-toolbar [form]="this"></mj-form-toolbar>
+
+                <mj-tabstrip (TabSelected)="onTabSelect($event)" mjFillContainer (ResizeContainer)="InvokeManualResize()">
+                    
+                    <mj-tab Name="Details">
+                        Details
+                    </mj-tab>
+                    <mj-tab-body>
+                        <mj-form-section 
+                            Entity="MJ: Report Versions" 
+                            Section="details" 
+                            [record]="record" 
+                            [EditMode]="this.EditMode">
+                        </mj-form-section>
+                    </mj-tab-body>
+                    
+                </mj-tabstrip>
+    </form>
+</div>
+        

--- a/packages/Angular/Explorer/core-entity-forms/src/lib/generated/Entities/ReportVersion/reportversion.form.component.ts
+++ b/packages/Angular/Explorer/core-entity-forms/src/lib/generated/Entities/ReportVersion/reportversion.form.component.ts
@@ -1,0 +1,19 @@
+import { Component } from '@angular/core';
+import { ReportVersionEntity } from '@memberjunction/core-entities';
+import { RegisterClass } from '@memberjunction/global';
+import { BaseFormComponent } from '@memberjunction/ng-base-forms';
+import { LoadReportVersionDetailsComponent } from "./sections/details.component"
+
+@RegisterClass(BaseFormComponent, 'MJ: Report Versions') // Tell MemberJunction about this class
+@Component({
+    selector: 'gen-reportversion-form',
+    templateUrl: './reportversion.form.component.html',
+    styleUrls: ['../../../../shared/form-styles.css']
+})
+export class ReportVersionFormComponent extends BaseFormComponent {
+    public record!: ReportVersionEntity;
+} 
+
+export function LoadReportVersionFormComponent() {
+    LoadReportVersionDetailsComponent();
+}

--- a/packages/Angular/Explorer/core-entity-forms/src/lib/generated/Entities/ReportVersion/sections/details.component.ts
+++ b/packages/Angular/Explorer/core-entity-forms/src/lib/generated/Entities/ReportVersion/sections/details.component.ts
@@ -1,0 +1,90 @@
+import { Component, Input } from '@angular/core';
+import { RegisterClass } from '@memberjunction/global';
+import { BaseFormSectionComponent } from '@memberjunction/ng-base-forms';
+import { ReportVersionEntity } from '@memberjunction/core-entities';
+
+@RegisterClass(BaseFormSectionComponent, 'MJ: Report Versions.details') // Tell MemberJunction about this class 
+@Component({
+    selector: 'gen-reportversion-form-details',
+    styleUrls: ['../../../../../shared/form-styles.css'],
+    template: `<div *ngIf="this.record">
+    <div class="record-form">
+        <mj-form-field 
+            [record]="record"
+            [ShowLabel]="true"
+            FieldName="ReportID"
+            Type="textbox"
+            [EditMode]="EditMode"
+            LinkType="Record"
+            LinkComponentType="Search"
+        ></mj-form-field>
+        <mj-form-field 
+            [record]="record"
+            [ShowLabel]="true"
+            FieldName="VersionNumber"
+            Type="numerictextbox"
+            [EditMode]="EditMode"
+        ></mj-form-field>
+        <mj-form-field 
+            [record]="record"
+            [ShowLabel]="true"
+            FieldName="Name"
+            Type="textarea"
+            [EditMode]="EditMode"
+        ></mj-form-field>
+        <mj-form-field 
+            [record]="record"
+            [ShowLabel]="true"
+            FieldName="Description"
+            Type="textarea"
+            [EditMode]="EditMode"
+        ></mj-form-field>
+        <mj-form-field 
+            [record]="record"
+            [ShowLabel]="true"
+            FieldName="Configuration"
+            Type="textarea"
+            [EditMode]="EditMode"
+        ></mj-form-field>
+        <mj-form-field 
+            [record]="record"
+            [ShowLabel]="true"
+            FieldName="DataContextUpdated"
+            Type="checkbox"
+            [EditMode]="EditMode"
+        ></mj-form-field>
+        <mj-form-field 
+            [record]="record"
+            [ShowLabel]="true"
+            FieldName="__mj_CreatedAt"
+            Type="textbox"
+            [EditMode]="EditMode"
+        ></mj-form-field>
+        <mj-form-field 
+            [record]="record"
+            [ShowLabel]="true"
+            FieldName="__mj_UpdatedAt"
+            Type="textbox"
+            [EditMode]="EditMode"
+        ></mj-form-field>
+        <mj-form-field 
+            [record]="record"
+            [ShowLabel]="true"
+            FieldName="Report"
+            Type="textbox"
+            [EditMode]="EditMode"
+        ></mj-form-field>
+
+    </div>
+</div>
+    `
+})
+export class ReportVersionDetailsComponent extends BaseFormSectionComponent {
+    @Input() override record!: ReportVersionEntity;
+    @Input() override EditMode: boolean = false;
+}
+
+export function LoadReportVersionDetailsComponent() {
+    // does nothing, but called in order to prevent tree-shaking from eliminating this component from the build
+}
+      

--- a/packages/Angular/Explorer/core-entity-forms/src/lib/generated/Entities/User/user.form.component.html
+++ b/packages/Angular/Explorer/core-entity-forms/src/lib/generated/Entities/User/user.form.component.html
@@ -458,6 +458,19 @@
                         </mj-user-view-grid>                    
                     </mj-tab-body>
 
+                    <mj-tab Name="MJ: Report User States" [Visible]="record.IsSaved"> 
+                        MJ: Report User States
+                    </mj-tab>
+                    <mj-tab-body>
+                        <mj-user-view-grid 
+                            [Params]="BuildRelationshipViewParamsByEntityName('MJ: Report User States','UserID')"  
+                            [NewRecordValues]="NewRecordValues('MJ: Report User States')"
+                            [AllowLoad]="IsCurrentTab('MJ: Report User States')"  
+                            [EditMode]="GridEditMode()"  
+                            [BottomMargin]="GridBottomMargin">
+                        </mj-user-view-grid>                    
+                    </mj-tab-body>
+
                     <mj-tab Name="AI Agent Notes" [Visible]="record.IsSaved"> 
                         AI Agent Notes
                     </mj-tab>

--- a/packages/Angular/Explorer/core-entity-forms/src/lib/generated/generated-forms.module.ts
+++ b/packages/Angular/Explorer/core-entity-forms/src/lib/generated/generated-forms.module.ts
@@ -130,6 +130,8 @@ import { LibraryItemFormComponent, LoadLibraryItemFormComponent } from "./Entiti
 import { ListCategoryFormComponent, LoadListCategoryFormComponent } from "./Entities/ListCategory/listcategory.form.component";
 import { ListDetailFormComponent, LoadListDetailFormComponent } from "./Entities/ListDetail/listdetail.form.component";
 import { ListFormComponent, LoadListFormComponent } from "./Entities/List/list.form.component";
+import { ReportUserStateFormComponent, LoadReportUserStateFormComponent } from "./Entities/ReportUserState/reportuserstate.form.component";
+import { ReportVersionFormComponent, LoadReportVersionFormComponent } from "./Entities/ReportVersion/reportversion.form.component";
 import { OutputDeliveryTypeFormComponent, LoadOutputDeliveryTypeFormComponent } from "./Entities/OutputDeliveryType/outputdeliverytype.form.component";
 import { OutputFormatTypeFormComponent, LoadOutputFormatTypeFormComponent } from "./Entities/OutputFormatType/outputformattype.form.component";
 import { OutputTriggerTypeFormComponent, LoadOutputTriggerTypeFormComponent } from "./Entities/OutputTriggerType/outputtriggertype.form.component";
@@ -298,6 +300,8 @@ import { LibraryItemDetailsComponent, LoadLibraryItemDetailsComponent } from "./
 import { ListCategoryDetailsComponent, LoadListCategoryDetailsComponent } from "./Entities/ListCategory/sections/details.component"
 import { ListDetailDetailsComponent, LoadListDetailDetailsComponent } from "./Entities/ListDetail/sections/details.component"
 import { ListDetailsComponent, LoadListDetailsComponent } from "./Entities/List/sections/details.component"
+import { ReportUserStateDetailsComponent, LoadReportUserStateDetailsComponent } from "./Entities/ReportUserState/sections/details.component"
+import { ReportVersionDetailsComponent, LoadReportVersionDetailsComponent } from "./Entities/ReportVersion/sections/details.component"
 import { OutputDeliveryTypeDetailsComponent, LoadOutputDeliveryTypeDetailsComponent } from "./Entities/OutputDeliveryType/sections/details.component"
 import { OutputFormatTypeDetailsComponent, LoadOutputFormatTypeDetailsComponent } from "./Entities/OutputFormatType/sections/details.component"
 import { OutputTriggerTypeDetailsComponent, LoadOutputTriggerTypeDetailsComponent } from "./Entities/OutputTriggerType/sections/details.component"
@@ -594,6 +598,8 @@ declarations: [
     ListCategoryFormComponent,
     ListDetailFormComponent,
     ListFormComponent,
+    ReportUserStateFormComponent,
+    ReportVersionFormComponent,
     OutputDeliveryTypeFormComponent,
     OutputFormatTypeFormComponent,
     OutputTriggerTypeFormComponent,
@@ -607,9 +613,7 @@ declarations: [
     QueueFormComponent,
     RecommendationItemFormComponent,
     RecommendationProviderFormComponent,
-    RecommendationRunFormComponent,
-    RecommendationFormComponent,
-    RecordChangeReplayRunFormComponent],
+    RecommendationRunFormComponent],
 imports: [
     CommonModule,
     FormsModule,
@@ -636,6 +640,8 @@ export class GeneratedForms_SubModule_5 { }
 
 @NgModule({
 declarations: [
+    RecommendationFormComponent,
+    RecordChangeReplayRunFormComponent,
     RecordChangeFormComponent,
     RecordMergeDeletionLogFormComponent,
     RecordMergeLogFormComponent,
@@ -653,9 +659,7 @@ declarations: [
     SkillFormComponent,
     TaggedItemFormComponent,
     TagFormComponent,
-    TemplateCategoryFormComponent,
-    TemplateContentTypeFormComponent,
-    TemplateContentFormComponent],
+    TemplateCategoryFormComponent],
 imports: [
     CommonModule,
     FormsModule,
@@ -682,6 +686,8 @@ export class GeneratedForms_SubModule_6 { }
 
 @NgModule({
 declarations: [
+    TemplateContentTypeFormComponent,
+    TemplateContentFormComponent,
     TemplateParamFormComponent,
     TemplateFormComponent,
     UserApplicationEntityFormComponent,
@@ -699,9 +705,7 @@ declarations: [
     VectorIndexFormComponent,
     VersionInstallationFormComponent,
     WorkflowEngineFormComponent,
-    WorkflowRunFormComponent,
-    WorkflowFormComponent,
-    WorkspaceItemFormComponent],
+    WorkflowRunFormComponent],
 imports: [
     CommonModule,
     FormsModule,
@@ -728,6 +732,8 @@ export class GeneratedForms_SubModule_7 { }
 
 @NgModule({
 declarations: [
+    WorkflowFormComponent,
+    WorkspaceItemFormComponent,
     WorkspaceFormComponent,
     ActionAuthorizationDetailsComponent,
     ActionCategoryDetailsComponent,
@@ -745,9 +751,7 @@ declarations: [
     AIAgentActionDetailsComponent,
     AIAgentLearningCycleDetailsComponent,
     AIAgentModelDetailsComponent,
-    AIAgentNoteTypeDetailsComponent,
-    AIAgentNoteDetailsComponent,
-    AIAgentRequestDetailsComponent],
+    AIAgentNoteTypeDetailsComponent],
 imports: [
     CommonModule,
     FormsModule,
@@ -774,6 +778,8 @@ export class GeneratedForms_SubModule_8 { }
 
 @NgModule({
 declarations: [
+    AIAgentNoteDetailsComponent,
+    AIAgentRequestDetailsComponent,
     AIAgentDetailsComponent,
     AIModelActionDetailsComponent,
     AIModelTypeDetailsComponent,
@@ -791,9 +797,7 @@ declarations: [
     AuthorizationDetailsComponent,
     CommunicationBaseMessageTypeDetailsComponent,
     CommunicationLogDetailsComponent,
-    CommunicationProviderMessageTypeDetailsComponent,
-    CommunicationProviderDetailsComponent,
-    CommunicationRunDetailsComponent],
+    CommunicationProviderMessageTypeDetailsComponent],
 imports: [
     CommonModule,
     FormsModule,
@@ -819,6 +823,8 @@ export class GeneratedForms_SubModule_9 { }
 
 @NgModule({
 declarations: [
+    CommunicationProviderDetailsComponent,
+    CommunicationRunDetailsComponent,
     CompanyDetailsComponent,
     CompanyIntegrationRecordMapDetailsComponent,
     CompanyIntegrationRunAPILogDetailsComponent,
@@ -836,9 +842,7 @@ declarations: [
     ContentSourceDetailsComponent,
     ContentTypeAttributeDetailsComponent,
     ContentTypeDetailsComponent,
-    ConversationDetailDetailsComponent,
-    ConversationDetailsComponent,
-    DashboardCategoryDetailsComponent],
+    ConversationDetailDetailsComponent],
 imports: [
     CommonModule,
     FormsModule,
@@ -864,6 +868,8 @@ export class GeneratedForms_SubModule_10 { }
 
 @NgModule({
 declarations: [
+    ConversationDetailsComponent,
+    DashboardCategoryDetailsComponent,
     DashboardDetailsComponent,
     DataContextItemDetailsComponent,
     DataContextDetailsComponent,
@@ -881,9 +887,7 @@ declarations: [
     EntityAuditComponent,
     EntityAPIComponent,
     EntityDBComponent,
-    EntityUIComponent,
-    EntityActionFilterDetailsComponent,
-    EntityActionInvocationTypeDetailsComponent],
+    EntityUIComponent],
 imports: [
     CommonModule,
     FormsModule,
@@ -909,6 +913,8 @@ export class GeneratedForms_SubModule_11 { }
 
 @NgModule({
 declarations: [
+    EntityActionFilterDetailsComponent,
+    EntityActionInvocationTypeDetailsComponent,
     EntityActionInvocationDetailsComponent,
     EntityActionParamDetailsComponent,
     EntityActionDetailsComponent,
@@ -926,9 +932,7 @@ declarations: [
     EntityRelationshipDisplayComponentDetailsComponent,
     EntityRelationshipDetailsComponent,
     EntitySettingDetailsComponent,
-    ErrorLogDetailsComponent,
-    ExplorerNavigationItemDetailsComponent,
-    FileCategoryDetailsComponent],
+    ErrorLogDetailsComponent],
 imports: [
     CommonModule,
     FormsModule,
@@ -954,6 +958,8 @@ export class GeneratedForms_SubModule_12 { }
 
 @NgModule({
 declarations: [
+    ExplorerNavigationItemDetailsComponent,
+    FileCategoryDetailsComponent,
     FileEntityRecordLinkDetailsComponent,
     FileStorageProviderDetailsComponent,
     FileDetailsComponent,
@@ -966,14 +972,12 @@ declarations: [
     ListCategoryDetailsComponent,
     ListDetailDetailsComponent,
     ListDetailsComponent,
+    ReportUserStateDetailsComponent,
+    ReportVersionDetailsComponent,
     OutputDeliveryTypeDetailsComponent,
     OutputFormatTypeDetailsComponent,
     OutputTriggerTypeDetailsComponent,
-    QueryDetailsComponent,
-    QueryCategoryDetailsComponent,
-    QueryEntityDetailsComponent,
-    QueryFieldDetailsComponent,
-    QueryPermissionDetailsComponent],
+    QueryDetailsComponent],
 imports: [
     CommonModule,
     FormsModule,
@@ -999,6 +1003,10 @@ export class GeneratedForms_SubModule_13 { }
 
 @NgModule({
 declarations: [
+    QueryCategoryDetailsComponent,
+    QueryEntityDetailsComponent,
+    QueryFieldDetailsComponent,
+    QueryPermissionDetailsComponent,
     QueueTaskDetailsComponent,
     QueueTypeDetailsComponent,
     QueueDetailsComponent,
@@ -1014,11 +1022,7 @@ declarations: [
     ReportSnapshotDetailsComponent,
     ReportDetailsComponent,
     ResourceLinkDetailsComponent,
-    ResourcePermissionDetailsComponent,
-    ResourceTypeDetailsComponent,
-    RoleDetailsComponent,
-    RowLevelSecurityFilterDetailsComponent,
-    ScheduledActionParamDetailsComponent],
+    ResourcePermissionDetailsComponent],
 imports: [
     CommonModule,
     FormsModule,
@@ -1044,6 +1048,10 @@ export class GeneratedForms_SubModule_14 { }
 
 @NgModule({
 declarations: [
+    ResourceTypeDetailsComponent,
+    RoleDetailsComponent,
+    RowLevelSecurityFilterDetailsComponent,
+    ScheduledActionParamDetailsComponent,
     ScheduledActionDetailsComponent,
     SchemaInfoDetailsComponent,
     SkillDetailsComponent,
@@ -1059,11 +1067,7 @@ declarations: [
     UserFavoriteDetailsComponent,
     UserNotificationDetailsComponent,
     UserRecordLogDetailsComponent,
-    UserRoleDetailsComponent,
-    UserViewCategoryDetailsComponent,
-    UserViewRunDetailDetailsComponent,
-    UserViewRunDetailsComponent,
-    UserViewDetailsComponent],
+    UserRoleDetailsComponent],
 imports: [
     CommonModule,
     FormsModule,
@@ -1089,6 +1093,10 @@ export class GeneratedForms_SubModule_15 { }
 
 @NgModule({
 declarations: [
+    UserViewCategoryDetailsComponent,
+    UserViewRunDetailDetailsComponent,
+    UserViewRunDetailsComponent,
+    UserViewDetailsComponent,
     UserDetailsComponent,
     VectorDatabaseDetailsComponent,
     VectorIndexDetailsComponent,
@@ -1256,6 +1264,8 @@ export function LoadCoreGeneratedForms() {
     LoadListCategoryFormComponent();
     LoadListDetailFormComponent();
     LoadListFormComponent();
+    LoadReportUserStateFormComponent();
+    LoadReportVersionFormComponent();
     LoadOutputDeliveryTypeFormComponent();
     LoadOutputFormatTypeFormComponent();
     LoadOutputTriggerTypeFormComponent();
@@ -1424,6 +1434,8 @@ export function LoadCoreGeneratedForms() {
     LoadListCategoryDetailsComponent();
     LoadListDetailDetailsComponent();
     LoadListDetailsComponent();
+    LoadReportUserStateDetailsComponent();
+    LoadReportVersionDetailsComponent();
     LoadOutputDeliveryTypeDetailsComponent();
     LoadOutputFormatTypeDetailsComponent();
     LoadOutputTriggerTypeDetailsComponent();

--- a/packages/Angular/Generic/skip-chat/src/lib/dynamic-report/base-report.ts
+++ b/packages/Angular/Generic/skip-chat/src/lib/dynamic-report/base-report.ts
@@ -84,20 +84,26 @@ export abstract class SkipDynamicReportBase  extends BaseAngularComponent implem
       return this.SkipData?.tableDataColumns || [];
   }
 
+  protected get ResultType(): string {
+    // support for legacy format where the resultType was within executionResults and for the new location at the root of SkipData
+    let rt = this.SkipData?.resultType?.trim().toLowerCase();
+    if (!rt) {
+      // we don't have the new format, so check for legacy location
+      const executionResults = this.SkipData?.executionResults as any; // becuase new type does NOT have resultType on executionResults as it was moved
+      if (executionResults) {
+        rt = executionResults.resultType?.trim().toLowerCase();
+      }
+    }
+    return rt || '';
+  }
   public get IsChart(): boolean {
-      if (!this.SkipData) 
-          return false;
-      return this.SkipData.executionResults?.resultType?.trim().toLowerCase() === 'plot';
+    return this.ResultType === 'plot';
   }
   public get IsTable(): boolean {
-      if (!this.SkipData) 
-          return false;
-      return this.SkipData.executionResults?.resultType?.trim().toLowerCase() === 'table';
+    return this.ResultType === 'table';
   }
   public get IsHTML(): boolean {
-      if (!this.SkipData) 
-          return false;
-      return this.SkipData.executionResults?.resultType?.trim().toLowerCase() === 'html';
+    return this.ResultType === 'html';
   }
 
   /**
@@ -162,10 +168,10 @@ export abstract class SkipDynamicReportBase  extends BaseAngularComponent implem
       // do this via a single gql call to make it faster than doing operation via standard objects since it is a multi-step operation
       const mutation = `mutation CreateReportFromConversationDetailIDMutation ($ConversationDetailID: String!) {
           CreateReportFromConversationDetailID(ConversationDetailID: $ConversationDetailID) {
-          ReportID
-          ReportName
-          Success
-          ErrorMessage
+            ReportID
+            ReportName
+            Success
+            ErrorMessage
           }
       }`;
       const p = <GraphQLDataProvider>this.ProviderToUse;
@@ -230,6 +236,17 @@ export abstract class SkipDynamicReportBase  extends BaseAngularComponent implem
       const newSkipData: SkipAPIAnalysisCompleteResponse = JSON.parse(resultObj.Result);
       this.SkipData.analysis = newSkipData.analysis; // update the analysis
       this.SkipData.executionResults = newSkipData.executionResults; // drives the chart/table bindings
+      this.SkipData.dataContext = newSkipData.dataContext; // drives the HTML report bindings
+
+      // make sure to push the techExplanation and userExplanation to the newSkipData object as that WILL NOT come back with that info from the original report
+      newSkipData.userExplanation = this.SkipData.userExplanation;
+      newSkipData.techExplanation = this.SkipData.techExplanation;
+      newSkipData.resultType = this.SkipData.resultType;  
+      newSkipData.responsePhase = this.SkipData.responsePhase; 
+      newSkipData.messages = this.SkipData.messages; // this is the array of messages that are used to create the report from the original message, we don't want message from the refresh, it is simple message
+      newSkipData.reportTitle = this.SkipData.reportTitle; // this is the title of the report, we don't want to change it
+      newSkipData.drillDown = this.SkipData.drillDown; // this is the drill down data, we don't want to change it
+      
       this.ReportEntity.Configuration = JSON.stringify(newSkipData);
 
       const saveResult: boolean = await this.ReportEntity.Save();

--- a/packages/Angular/Generic/skip-chat/src/lib/dynamic-report/dynamic-html-report.ts
+++ b/packages/Angular/Generic/skip-chat/src/lib/dynamic-report/dynamic-html-report.ts
@@ -1,0 +1,97 @@
+import { AfterViewInit, Component, ElementRef, EventEmitter, Input, OnDestroy, OnInit, Output, ViewChild } from '@angular/core';
+import { CompositeKey, GetEntityNameFromSchemaAndViewString, Metadata, RunView } from '@memberjunction/core';
+import { SkipAPIAnalysisCompleteResponse, SkipHTMLReportInitFunction } from '@memberjunction/skip-types';
+import { DrillDownInfo } from '../drill-down-info';
+import { InvokeManualResize } from '@memberjunction/global';
+
+@Component({
+  selector: 'skip-dynamic-html-report',
+  template: `
+    <button kendoButton *ngIf="ShowPrintReport" (click)="PrintReport()">
+      <span class="fa-regular fa-image"></span>
+      Print 
+    </button>
+    <div #htmlContainer mjFillContainer>
+        <!-- this is where we'll dynamically inject the HTML that was AI generated -->
+    </div>
+  `,
+  styles: [`button { margin-top: 5px; margin-bottom: 5px;}`] 
+})
+export class SkipDynamicHTMLReportComponent implements AfterViewInit {
+    @Input() HTMLReport: string | null = null;
+    @Input() HTMLReportInitFunctionName: string | null = null;
+    @Input() ShowPrintReport: boolean = true;
+    @Output() DrillDownEvent = new EventEmitter<DrillDownInfo>();
+
+    constructor(private el: ElementRef) { }
+  
+    public async PrintReport() {
+        // Implement printing of the HTML element only here
+    }
+
+    ngAfterViewInit() {
+        // here we want to dynamically inject the HTML that was AI generated
+        if (this.HTMLReport) {
+            const container = this.el.nativeElement.querySelector('#htmlContainer');
+            if (container) {
+                container.innerHTML = this.HTMLReport;
+                // call the function for the embedded generated HTML report to pass it updated data
+                if (this.HTMLReportInitFunctionName && this.SkipData) {
+                    this.invokeHTMLInitFunction();
+                }
+            }
+        }
+    }
+  
+    private _skipData: SkipAPIAnalysisCompleteResponse | undefined;
+    @Input() get SkipData(): SkipAPIAnalysisCompleteResponse | undefined {
+        return this._skipData ? this._skipData : undefined;   
+    }
+    set SkipData(d: SkipAPIAnalysisCompleteResponse | undefined){
+        const hadData = this._skipData ? true : false;
+        this._skipData = d;
+        if (d) {
+            this.HTMLReport = d.htmlReport;
+            this.HTMLReportInitFunctionName = d.htmlReportInitFunctionName;
+        }
+        if (d && hadData) {
+            // normally the initFunction is called in ngAfterViewInit, but here the data changed so we need to call it again
+            this.invokeHTMLInitFunction();
+        }
+    }
+
+    private invokeHTMLInitFunction() {
+        const container = this.el.nativeElement.querySelector('#htmlContainer');
+        if (container && this.HTMLReportInitFunctionName) {
+            const initFunction = (window as any)[this.HTMLReportInitFunctionName];
+            if (initFunction && this.SkipData?.dataContext) {
+                const castedFunction = initFunction as SkipHTMLReportInitFunction;
+                castedFunction(this.SkipData.dataContext, {
+                    RefreshData: () => {
+                        // this is a callback function that can be called from the HTML report to refresh data
+                        console.log('HTML Report requested data refresh');
+                        // need to implement this
+                    },
+                    OpenEntityRecord: (entityName: string, key: CompositeKey) => {
+                        // this is a callback function that can be called from the HTML report to open an entity record
+                        const entityId = GetEntityNameFromSchemaAndViewString(entityName);
+                        if (entityId) {
+                            // bubble this up to our parent component as we don't directly open records in this component
+                            this.DrillDownEvent.emit(new DrillDownInfo(entityId, key.ToURLSegment()));
+                        }
+                    },
+                    NotifyEvent: (eventName: string, eventData: any) => {
+                        // this is a callback function that can be called from the HTML report to notify an event
+                        console.log(`HTML Report raised event: ${eventName} notified with data:`, eventData);
+                    }
+                });
+            }
+            else {
+                console.warn(`HTML Report init function ${this.HTMLReportInitFunctionName} not found or invalid data context`);
+            }
+        }
+        else {
+            console.warn('HTML Report container not found or init function name not provided');
+        }
+    }
+}

--- a/packages/Angular/Generic/skip-chat/src/lib/dynamic-report/dynamic-html-report.ts
+++ b/packages/Angular/Generic/skip-chat/src/lib/dynamic-report/dynamic-html-report.ts
@@ -66,7 +66,8 @@ export class SkipDynamicHTMLReportComponent implements AfterViewInit {
             const initFunction = (window as any)[this.HTMLReportInitFunctionName];
             if (initFunction && this.SkipData?.dataContext) {
                 const castedFunction = initFunction as SkipHTMLReportInitFunction;
-                castedFunction(this.SkipData.dataContext, {
+                const userState = {};
+                castedFunction(this.SkipData.dataContext, userState, {
                     RefreshData: () => {
                         // this is a callback function that can be called from the HTML report to refresh data
                         console.log('HTML Report requested data refresh');
@@ -79,6 +80,11 @@ export class SkipDynamicHTMLReportComponent implements AfterViewInit {
                             // bubble this up to our parent component as we don't directly open records in this component
                             this.DrillDownEvent.emit(new DrillDownInfo(entityId, key.ToURLSegment()));
                         }
+                    },
+                    UpdateUserState: (userState: any) => {
+                        // this is a callback function that can be called from the HTML report to update user state
+                        console.log('HTML Report updated user state:', userState);
+                        // need to implement this
                     },
                     NotifyEvent: (eventName: string, eventData: any) => {
                         // this is a callback function that can be called from the HTML report to notify an event

--- a/packages/Angular/Generic/skip-chat/src/lib/dynamic-report/linear-report.html
+++ b/packages/Angular/Generic/skip-chat/src/lib/dynamic-report/linear-report.html
@@ -10,56 +10,71 @@
             {{SkipData.userExplanation || 'No Explanation Provided'}}
         </div>
     </div>
-    <kendo-expansionpanel
-        *ngIf="IsChart"
+
+    <!-- Report Type is next -->
+    @if(IsChart) {
+      <kendo-expansionpanel
         [title]="'Chart'"
         [expanded]="ExpandAll"
         >
         <skip-dynamic-chart 
-            *ngIf="IsChart" 
             #theChart 
             [AutoResizeChart]="false"
             [SkipData]="SkipData" 
             style="display:block;">
         </skip-dynamic-chart>
-    </kendo-expansionpanel>                     
-    <kendo-expansionpanel
-        *ngIf="!IsChart"
-        [title]="'Table'"
-        [expanded]="ExpandAll"
-        mjSkipResize="true"
-    >
-        <skip-dynamic-grid *ngIf="!IsChart" 
-                        [GridHeight]="300"
-                        #theGrid [SkipData]="SkipData"
-                        ></skip-dynamic-grid>  
-    </kendo-expansionpanel>
-    <kendo-expansionpanel
-        *ngIf="SkipData?.analysis" 
-        [title]="'Analysis'"
-        [expanded]="ExpandAll"
-        >
-        <!-- <div class="analysis" *ngIf="SkipData.analysis">
-            {{SkipData.analysis}}
-        </div> -->
-        <markdown [data]="SkipData.analysis"></markdown>
-    </kendo-expansionpanel>                     
+      </kendo-expansionpanel>                     
+    }
+    @else if(IsTable) {
+      <kendo-expansionpanel
+          [title]="'Table'"
+          [expanded]="ExpandAll"
+          mjSkipResize="true"
+      >
+          <skip-dynamic-grid  
+                          [GridHeight]="300"
+                          #theGrid [SkipData]="SkipData"
+                          ></skip-dynamic-grid>  
+      </kendo-expansionpanel>
+    }
+    @else if (IsHTML) {
+      <kendo-expansionpanel
+          [title]="'Report'"
+          [expanded]="ExpandAll"
+          mjSkipResize="true"
+      >
+          <skip-dynamic-html-report
+                          #theHtmlReport 
+                          [SkipData]="SkipData"
+                          ></skip-dynamic-html-report>  
+      </kendo-expansionpanel>
+    }
 
-  <kendo-dialog
-    title="Please confirm"
-    *ngIf="confirmCreateReportDialogOpen"
-    (close)="closeCreateReport('no')"
-    [minWidth]="250"
-    [width]="450"
-  >
-    <p style="margin: 30px; text-align: center;">
-      Would you like to create a new report from this conversation element? If you choose to continue you'll be notified when the report has been created.
-    </p>
-    <kendo-dialog-actions>
-      <button kendoButton (click)="closeCreateReport('yes')" themeColor="primary">
-        Yes
-      </button>
-      <button kendoButton (click)="closeCreateReport('no')">No</button>
-    </kendo-dialog-actions>
-  </kendo-dialog>
+    @if (SkipData.analysis) {
+      <kendo-expansionpanel
+          [title]="'Analysis'"
+          [expanded]="ExpandAll"
+          >
+          <markdown [data]="SkipData.analysis"></markdown>
+      </kendo-expansionpanel>                     
+    }
+    
+  @if (confirmCreateReportDialogOpen) {
+    <kendo-dialog
+      title="Please confirm"
+      (close)="closeCreateReport('no')"
+      [minWidth]="250"
+      [width]="450"
+    >
+      <p style="margin: 30px; text-align: center;">
+        Would you like to create a new report from this conversation element? If you choose to continue you'll be notified when the report has been created.
+      </p>
+      <kendo-dialog-actions>
+        <button kendoButton (click)="closeCreateReport('yes')" themeColor="primary">
+          Yes
+        </button>
+        <button kendoButton (click)="closeCreateReport('no')">No</button>
+      </kendo-dialog-actions>
+    </kendo-dialog>
+  }
 } 

--- a/packages/Angular/Generic/skip-chat/src/lib/module.ts
+++ b/packages/Angular/Generic/skip-chat/src/lib/module.ts
@@ -40,6 +40,7 @@ import { SkipDynamicLinearReportComponent } from './dynamic-report/linear-report
 import { SkipDynamicChartComponent } from './dynamic-report/dynamic-chart';
 import { SkipDynamicGridComponent } from './dynamic-report/dynamic-grid';
 import { MJNotificationsModule } from '@memberjunction/ng-notifications';
+import { SkipDynamicHTMLReportComponent } from './dynamic-report/dynamic-html-report';
 
 
 @NgModule({
@@ -50,6 +51,7 @@ import { MJNotificationsModule } from '@memberjunction/ng-notifications';
     SkipDynamicReportWrapperComponent,
     SkipDynamicChartComponent,
     SkipDynamicGridComponent,
+    SkipDynamicHTMLReportComponent
   ],
   imports: [
     CommonModule,

--- a/packages/Angular/Generic/skip-chat/src/lib/skip-chat/skip-chat.component.ts
+++ b/packages/Angular/Generic/skip-chat/src/lib/skip-chat/skip-chat.component.ts
@@ -904,6 +904,14 @@ export class SkipChatComponent extends BaseAngularComponent implements OnInit, A
         LogStatus('Skip Chat: Time to load data context: ' + (new Date().getTime() - start) + 'ms');
         // cache it for later
         convoAny._DataContext = this.DataContext;
+
+        // // client side we call the graphql data provider directly for efficiency to load entire context in one network call
+        // const gqlProvider = <GraphQLDataProvider>this.ProviderToUse;
+        // const dataContextData = await gqlProvider.GetDataContextData(this.DataContextID);
+        // if (dataContextData) {
+        //   this.DataContext.LoadDataFromObject(dataContextData);
+        // }
+        // console.log(this.DataContext.ConvertToSimpleObject())
       }
 
       const convoShouldReload = this._conversationsToReload[conversation.ID];

--- a/packages/Angular/Generic/skip-chat/src/public-api.ts
+++ b/packages/Angular/Generic/skip-chat/src/public-api.ts
@@ -8,5 +8,6 @@ export * from './lib/dynamic-report/skip-dynamic-report-wrapper';
 export * from './lib/dynamic-report/linear-report';
 export * from './lib/dynamic-report/dynamic-chart';
 export * from './lib/dynamic-report/dynamic-grid';
+export * from './lib/dynamic-report/dynamic-html-report';
 export * from './lib/report-cache';
 export * from './lib/drill-down-info';

--- a/packages/CodeGenLib/src/Misc/entity_subclasses_codegen.ts
+++ b/packages/CodeGenLib/src/Misc/entity_subclasses_codegen.ts
@@ -295,7 +295,7 @@ ${validationFunctions}`
           ).join('');
           valueList = `\n    * * Value List Type: ${e.ValueListType}\n    * * Possible Values ` + values;
         }
-        let typeString: string = `${TypeScriptTypeFromSQLType(e.Type).toLowerCase()}()` + (e.AllowsNull ? '.nullish()' : '');
+        let typeString: string = `${TypeScriptTypeFromSQLType(e.Type).toLowerCase()}()` + (e.AllowsNull ? '.nullable()' : '');
         if (e.ValueListTypeEnum !== EntityFieldValueListType.None && e.EntityFieldValues && e.EntityFieldValues.length > 0) {
           // construct a typeString that is a union of the possible values
           const quotes = e.NeedsQuotes ? "'" : '';
@@ -307,7 +307,7 @@ ${validationFunctions}`
 
           // finally, add the null type if it allows null
           if (e.AllowsNull) {
-            typeString += '.nullish()';
+            typeString += '.nullable()';
           }
         }
         let sRet: string = `    ${e.CodeName}: z.${typeString}.describe(\`\n${this.GenetateZodDescription(e)}\`),`;

--- a/packages/Communication/base-types/src/BaseProvider.ts
+++ b/packages/Communication/base-types/src/BaseProvider.ts
@@ -51,6 +51,16 @@ export class Message {
     public To: string;
 
     /**
+     * Recipients to send a copy of the message to, typically an email address
+     */
+    public CCRecipients?: string[];
+
+    /**
+     * Recipients to send a copy of the message to without revealing their email addresses to the other recipients, typically an email address
+     */
+    public BCCRecipients?: string[];
+
+    /**
      * The date and time to send the message, if not provided the message will be sent immediately
      */
     public SendAt?: Date;
@@ -193,10 +203,17 @@ export type ForwardMessageParams = {
     /*
     * The recipients to forward the message to
     */
-    ToRecipients: {
-        Name: string,
-        Address: string;
-    }[];
+    ToRecipients: string[];
+
+    /*
+    * The recipients to send a copy of the forwarded message to
+    */
+    CCRecipients?: string[];
+
+    /*
+    * The recipients to send a blind copy of the forwarded message to
+    */
+    BCCRecipients?: string[];
 };
 
 export type ForwardMessageResult<T = Record<string, any>> = BaseMessageResult & {

--- a/packages/Communication/providers/MSGraph/src/MSGraphProvider.ts
+++ b/packages/Communication/providers/MSGraph/src/MSGraphProvider.ts
@@ -43,7 +43,7 @@ export class MSGraphProvider extends BaseCommunicationProvider{
                 };
             }
     
-            const sendMail = {
+            const sendMail: Record<string, any> = {
                 message: {
                     subject: message.Subject,
                     body: {
@@ -56,7 +56,21 @@ export class MSGraphProvider extends BaseCommunicationProvider{
                             address: message.To
                             }
                         }
-                    ]
+                    ],
+                    ccRecipients: message.CCRecipients?.map((recipient) => {
+                        return {
+                            emailAddress: {
+                                address: recipient
+                            }
+                        };
+                    }),
+                    bccRecipients: message.BCCRecipients?.map((recipient) => {
+                        return {
+                            emailAddress: {
+                                address: recipient
+                            }
+                        };
+                    })
                 },
                 saveToSentItems: 'false'
             };
@@ -90,7 +104,7 @@ export class MSGraphProvider extends BaseCommunicationProvider{
                 };
             }
 
-            const reply = {
+            let reply: Record<string, any> = {
                 message: {
                     toRecipients: [
                         {
@@ -98,7 +112,21 @@ export class MSGraphProvider extends BaseCommunicationProvider{
                                 address: params.Message.To
                             }
                         }
-                    ]
+                    ],
+                    ccRecipients: params.Message.CCRecipients?.map((recipient) => {
+                        return {
+                            emailAddress: {
+                                address: recipient
+                            }
+                        };
+                    }),
+                    bccRecipients: params.Message.BCCRecipients?.map((recipient) => {
+                        return {
+                            emailAddress: {
+                                address: recipient
+                            }
+                        };
+                    })
                 },
                 comment: params.Message.ProcessedBody || params.Message.ProcessedHTMLBody
             };
@@ -204,13 +232,26 @@ export class MSGraphProvider extends BaseCommunicationProvider{
                 }
             }
 
-            const forward = {
+            const forward: Record<string, any> = {
                 comment: params.Message,
                 toRecipients: params.ToRecipients.map((recipient) => {
                     return {
                         emailAddress: {
-                            name: recipient.Name,
-                            address: recipient.Address
+                            address: recipient
+                        }
+                    };
+                }),
+                ccRecipients: params.CCRecipients?.map((recipient) => {
+                    return {
+                        emailAddress: {
+                            address: recipient
+                        }
+                    };
+                }),
+                bccRecipients: params.BCCRecipients?.map((recipient) => {
+                    return {
+                        emailAddress: {
+                            address: recipient
                         }
                     };
                 })

--- a/packages/Communication/providers/sendgrid/src/SendGridProvider.ts
+++ b/packages/Communication/providers/sendgrid/src/SendGridProvider.ts
@@ -23,6 +23,8 @@ export class SendGridProvider extends BaseCommunicationProvider {
                 email: from,
                 name: message.FromName
             },
+            cc: message.CCRecipients,
+            bcc: message.BCCRecipients,
             subject: message.ProcessedSubject,
             text: message.ProcessedBody,
             html: message.ProcessedHTMLBody,

--- a/packages/GraphQLDataProvider/src/graphQLDataProvider.ts
+++ b/packages/GraphQLDataProvider/src/graphQLDataProvider.ts
@@ -1381,6 +1381,75 @@ export class GraphQLDataProvider extends ProviderBase implements IEntityDataProv
             return data.GetEntityRecordNames;
     }
 
+    /**
+     * Retrieves all of the data context data for the specified data context ID.
+     * @param dataContextID 
+     * @returns 
+     */
+    public async GetDataContextData(dataContextID: string) {
+        try {
+            const query = gql`query GetDataContextData ($DataContextID: String!) {
+                GetDataContextData(DataContextID: $DataContextID) {
+                    Success
+                    ErrorMessages
+                    Results
+                }
+            }`
+    
+            const data = await this.ExecuteGQL(query,  {DataContextID: dataContextID});
+            if (data && data.GetDataContextData) {
+                if (data.GetDataContextData.Success) {
+                    return data.GetDataContextData.Results.map((item: any) => {
+                        return JSON.parse(item);
+                    });
+                }
+                else {
+                    throw new Error(data.GetDataContextData.ErrorMessages.join(', '));
+                }
+            }
+            else {
+                throw new Error('GraphQL query failed');
+            }    
+        }
+        catch (e) {
+            LogError(e);
+            throw e;
+        }
+    }
+
+    /**
+     * Retrieves the data context item data for the specified data context item ID.
+     * @param dataContextItemID 
+     * @returns 
+     */
+    public async GetDataContextItemData(dataContextItemID: string) {
+        try {
+            const query = gql`query GetDataContextItemData ($DataContextItemID: String!) {
+                GetDataContextItemData(DataContextItemID: $DataContextItemID) {
+                    Success
+                    ErrorMessage
+                    Result
+                }
+            }`
+    
+            const data = await this.ExecuteGQL(query,  {DataContextItemID: dataContextItemID});
+            if (data && data.GetDataContextItemData) {
+                if (data.GetDataContextItemData.Success) {
+                    return JSON.parse(data.GetDataContextItemData.Result);
+                }
+                else {
+                    throw new Error(data.GetDataContextItemData.ErrorMessage);
+                }
+            }
+            else {
+                throw new Error('GraphQL query failed');
+            }    
+        }
+        catch (e) {
+            LogError(e);
+            throw e;
+        }
+    }
 
     /**
      * Static version of the ExecuteGQL method that will use the global instance of the GraphQLDataProvider and execute the specified query with the provided variables. 

--- a/packages/MJCoreEntities/src/generated/entity_subclasses.ts
+++ b/packages/MJCoreEntities/src/generated/entity_subclasses.ts
@@ -27,7 +27,7 @@ export const ActionAuthorizationSchema = z.object({
         * * Display Name: Authorization ID
         * * SQL Data Type: uniqueidentifier
         * * Related Entity/Foreign Key: Authorizations (vwAuthorizations.ID)`),
-    Comments: z.string().nullish().describe(`
+    Comments: z.string().nullable().describe(`
         * * Field Name: Comments
         * * Display Name: Comments
         * * SQL Data Type: nvarchar(MAX)`),
@@ -67,12 +67,12 @@ export const ActionCategorySchema = z.object({
         * * Display Name: Name
         * * SQL Data Type: nvarchar(255)
     * * Description: Name of the action category.`),
-    Description: z.string().nullish().describe(`
+    Description: z.string().nullable().describe(`
         * * Field Name: Description
         * * Display Name: Description
         * * SQL Data Type: nvarchar(MAX)
     * * Description: Description of the action category.`),
-    ParentID: z.string().nullish().describe(`
+    ParentID: z.string().nullable().describe(`
         * * Field Name: ParentID
         * * Display Name: Parent ID
         * * SQL Data Type: uniqueidentifier
@@ -98,7 +98,7 @@ export const ActionCategorySchema = z.object({
         * * Display Name: __mj _Updated At
         * * SQL Data Type: datetimeoffset
         * * Default Value: getutcdate()`),
-    Parent: z.string().nullish().describe(`
+    Parent: z.string().nullable().describe(`
         * * Field Name: Parent
         * * Display Name: Parent
         * * SQL Data Type: nvarchar(255)`),
@@ -120,7 +120,7 @@ export const ActionContextTypeSchema = z.object({
         * * Display Name: Name
         * * SQL Data Type: nvarchar(255)
     * * Description: Name of the context type.`),
-    Description: z.string().nullish().describe(`
+    Description: z.string().nullable().describe(`
         * * Field Name: Description
         * * Display Name: Description
         * * SQL Data Type: nvarchar(MAX)
@@ -153,7 +153,7 @@ export const ActionContextSchema = z.object({
         * * Display Name: Action ID
         * * SQL Data Type: uniqueidentifier
         * * Related Entity/Foreign Key: Actions (vwActions.ID)`),
-    ContextTypeID: z.string().nullish().describe(`
+    ContextTypeID: z.string().nullable().describe(`
         * * Field Name: ContextTypeID
         * * Display Name: Context Type ID
         * * SQL Data Type: uniqueidentifier
@@ -183,7 +183,7 @@ export const ActionContextSchema = z.object({
         * * Field Name: Action
         * * Display Name: Action
         * * SQL Data Type: nvarchar(425)`),
-    ContextType: z.string().nullish().describe(`
+    ContextType: z.string().nullable().describe(`
         * * Field Name: ContextType
         * * Display Name: Context Type
         * * SQL Data Type: nvarchar(255)`),
@@ -211,16 +211,16 @@ export const ActionExecutionLogSchema = z.object({
         * * SQL Data Type: datetime
         * * Default Value: getdate()
     * * Description: Timestamp of when the action started execution.`),
-    EndedAt: z.date().nullish().describe(`
+    EndedAt: z.date().nullable().describe(`
         * * Field Name: EndedAt
         * * Display Name: Ended At
         * * SQL Data Type: datetime
     * * Description: Timestamp of when the action ended execution.`),
-    Params: z.string().nullish().describe(`
+    Params: z.string().nullable().describe(`
         * * Field Name: Params
         * * Display Name: Params
         * * SQL Data Type: nvarchar(MAX)`),
-    ResultCode: z.string().nullish().describe(`
+    ResultCode: z.string().nullable().describe(`
         * * Field Name: ResultCode
         * * Display Name: Result Code
         * * SQL Data Type: nvarchar(255)`),
@@ -229,7 +229,7 @@ export const ActionExecutionLogSchema = z.object({
         * * Display Name: User ID
         * * SQL Data Type: uniqueidentifier
         * * Related Entity/Foreign Key: Users (vwUsers.ID)`),
-    RetentionPeriod: z.number().nullish().describe(`
+    RetentionPeriod: z.number().nullable().describe(`
         * * Field Name: RetentionPeriod
         * * Display Name: Retention Period
         * * SQL Data Type: int
@@ -269,7 +269,7 @@ export const ActionFilterSchema = z.object({
         * * Field Name: UserDescription
         * * Display Name: User Description
         * * SQL Data Type: nvarchar(MAX)`),
-    UserComments: z.string().nullish().describe(`
+    UserComments: z.string().nullable().describe(`
         * * Field Name: UserComments
         * * Display Name: User Comments
         * * SQL Data Type: nvarchar(MAX)`),
@@ -277,7 +277,7 @@ export const ActionFilterSchema = z.object({
         * * Field Name: Code
         * * Display Name: Code
         * * SQL Data Type: nvarchar(MAX)`),
-    CodeExplanation: z.string().nullish().describe(`
+    CodeExplanation: z.string().nullable().describe(`
         * * Field Name: CodeExplanation
         * * Display Name: Code Explanation
         * * SQL Data Type: nvarchar(MAX)`),
@@ -314,7 +314,7 @@ export const ActionLibrarySchema = z.object({
         * * Display Name: Library ID
         * * SQL Data Type: uniqueidentifier
         * * Related Entity/Foreign Key: Libraries (vwLibraries.ID)`),
-    ItemsUsed: z.string().nullish().describe(`
+    ItemsUsed: z.string().nullable().describe(`
         * * Field Name: ItemsUsed
         * * Display Name: Items Used
         * * SQL Data Type: nvarchar(MAX)
@@ -359,7 +359,7 @@ export const ActionParamSchema = z.object({
         * * Field Name: Name
         * * Display Name: Name
         * * SQL Data Type: nvarchar(255)`),
-    DefaultValue: z.string().nullish().describe(`
+    DefaultValue: z.string().nullable().describe(`
         * * Field Name: DefaultValue
         * * Display Name: Default Value
         * * SQL Data Type: nvarchar(MAX)`),
@@ -388,7 +388,7 @@ export const ActionParamSchema = z.object({
         * * Display Name: Is Array
         * * SQL Data Type: bit
         * * Default Value: 0`),
-    Description: z.string().nullish().describe(`
+    Description: z.string().nullable().describe(`
         * * Field Name: Description
         * * Display Name: Description
         * * SQL Data Type: nvarchar(MAX)`),
@@ -439,7 +439,7 @@ export const ActionResultCodeSchema = z.object({
         * * SQL Data Type: bit
         * * Default Value: 0
     * * Description: Indicates if the result code is a success or not. It is possible an action might have more than one failure condition/result code and same for success conditions.`),
-    Description: z.string().nullish().describe(`
+    Description: z.string().nullable().describe(`
         * * Field Name: Description
         * * Display Name: Description
         * * SQL Data Type: nvarchar(MAX)
@@ -471,7 +471,7 @@ export const ActionSchema = z.object({
         * * Display Name: ID
         * * SQL Data Type: uniqueidentifier
         * * Default Value: newsequentialid()`),
-    CategoryID: z.string().nullish().describe(`
+    CategoryID: z.string().nullable().describe(`
         * * Field Name: CategoryID
         * * Display Name: Category ID
         * * SQL Data Type: uniqueidentifier
@@ -480,7 +480,7 @@ export const ActionSchema = z.object({
         * * Field Name: Name
         * * Display Name: Name
         * * SQL Data Type: nvarchar(425)`),
-    Description: z.string().nullish().describe(`
+    Description: z.string().nullable().describe(`
         * * Field Name: Description
         * * Display Name: Description
         * * SQL Data Type: nvarchar(MAX)`),
@@ -494,20 +494,20 @@ export const ActionSchema = z.object({
     *   * Generated
     *   * Custom
     * * Description: Generated or Custom. Generated means the UserPrompt is used to prompt an AI model to automatically create the code for the Action. Custom means that a custom class has been implemented that subclasses the BaseAction class. The custom class needs to use the @RegisterClass decorator and be included in the MJAPI (or other runtime environment) to be available for execution.`),
-    UserPrompt: z.string().nullish().describe(`
+    UserPrompt: z.string().nullable().describe(`
         * * Field Name: UserPrompt
         * * Display Name: User Prompt
         * * SQL Data Type: nvarchar(MAX)`),
-    UserComments: z.string().nullish().describe(`
+    UserComments: z.string().nullable().describe(`
         * * Field Name: UserComments
         * * Display Name: User Comments
         * * SQL Data Type: nvarchar(MAX)
     * * Description: User's comments not shared with the LLM.`),
-    Code: z.string().nullish().describe(`
+    Code: z.string().nullable().describe(`
         * * Field Name: Code
         * * Display Name: Code
         * * SQL Data Type: nvarchar(MAX)`),
-    CodeComments: z.string().nullish().describe(`
+    CodeComments: z.string().nullable().describe(`
         * * Field Name: CodeComments
         * * Display Name: Code Comments
         * * SQL Data Type: nvarchar(MAX)
@@ -523,17 +523,17 @@ export const ActionSchema = z.object({
     *   * Approved
     *   * Pending
     * * Description: An action won't be usable until the code is approved.`),
-    CodeApprovalComments: z.string().nullish().describe(`
+    CodeApprovalComments: z.string().nullable().describe(`
         * * Field Name: CodeApprovalComments
         * * Display Name: Code Approval Comments
         * * SQL Data Type: nvarchar(MAX)
     * * Description: Optional comments when an individual (or an AI) reviews and approves the code.`),
-    CodeApprovedByUserID: z.string().nullish().describe(`
+    CodeApprovedByUserID: z.string().nullable().describe(`
         * * Field Name: CodeApprovedByUserID
         * * Display Name: Code Approved By User ID
         * * SQL Data Type: uniqueidentifier
         * * Related Entity/Foreign Key: Users (vwUsers.ID)`),
-    CodeApprovedAt: z.date().nullish().describe(`
+    CodeApprovedAt: z.date().nullable().describe(`
         * * Field Name: CodeApprovedAt
         * * Display Name: Code Approved At
         * * SQL Data Type: datetime
@@ -550,7 +550,7 @@ export const ActionSchema = z.object({
         * * SQL Data Type: bit
         * * Default Value: 0
     * * Description: If set to 1, the Action will generate code for the provided UserPrompt on the next Save even if the UserPrompt hasn't changed. This is useful to force regeneration when other candidates (such as a change in Action Inputs/Outputs) occurs or on demand by a user.`),
-    RetentionPeriod: z.number().nullish().describe(`
+    RetentionPeriod: z.number().nullable().describe(`
         * * Field Name: RetentionPeriod
         * * Display Name: Retention Period
         * * SQL Data Type: int
@@ -576,11 +576,11 @@ export const ActionSchema = z.object({
         * * Display Name: __mj _Updated At
         * * SQL Data Type: datetimeoffset
         * * Default Value: getutcdate()`),
-    Category: z.string().nullish().describe(`
+    Category: z.string().nullable().describe(`
         * * Field Name: Category
         * * Display Name: Category
         * * SQL Data Type: nvarchar(255)`),
-    CodeApprovedByUser: z.string().nullish().describe(`
+    CodeApprovedByUser: z.string().nullable().describe(`
         * * Field Name: CodeApprovedByUser
         * * Display Name: Code Approved By User
         * * SQL Data Type: nvarchar(100)`),
@@ -601,15 +601,15 @@ export const AIActionSchema = z.object({
         * * Field Name: Name
         * * Display Name: Name
         * * SQL Data Type: nvarchar(50)`),
-    Description: z.string().nullish().describe(`
+    Description: z.string().nullable().describe(`
         * * Field Name: Description
         * * Display Name: Description
         * * SQL Data Type: nvarchar(MAX)`),
-    DefaultPrompt: z.string().nullish().describe(`
+    DefaultPrompt: z.string().nullable().describe(`
         * * Field Name: DefaultPrompt
         * * Display Name: Default Prompt
         * * SQL Data Type: nvarchar(MAX)`),
-    DefaultModelID: z.string().nullish().describe(`
+    DefaultModelID: z.string().nullable().describe(`
         * * Field Name: DefaultModelID
         * * Display Name: Default Model ID
         * * SQL Data Type: uniqueidentifier
@@ -629,7 +629,7 @@ export const AIActionSchema = z.object({
         * * Display Name: Updated At
         * * SQL Data Type: datetimeoffset
         * * Default Value: getutcdate()`),
-    DefaultModel: z.string().nullish().describe(`
+    DefaultModel: z.string().nullable().describe(`
         * * Field Name: DefaultModel
         * * Display Name: Default Model
         * * SQL Data Type: nvarchar(50)`),
@@ -647,13 +647,13 @@ export const AIAgentActionSchema = z.object({
         * * SQL Data Type: uniqueidentifier
         * * Default Value: newsequentialid()
     * * Description: The unique identifier for each AI agent-action mapping. Serves as the primary key.`),
-    AgentID: z.string().nullish().describe(`
+    AgentID: z.string().nullable().describe(`
         * * Field Name: AgentID
         * * Display Name: Agent ID
         * * SQL Data Type: uniqueidentifier
         * * Related Entity/Foreign Key: AI Agents (vwAIAgents.ID)
     * * Description: References the unique identifier of the associated AI agent from the AIAgent table.`),
-    ActionID: z.string().nullish().describe(`
+    ActionID: z.string().nullable().describe(`
         * * Field Name: ActionID
         * * Display Name: Action ID
         * * SQL Data Type: uniqueidentifier
@@ -679,11 +679,11 @@ export const AIAgentActionSchema = z.object({
         * * Display Name: Updated At
         * * SQL Data Type: datetimeoffset
         * * Default Value: getutcdate()`),
-    Agent: z.string().nullish().describe(`
+    Agent: z.string().nullable().describe(`
         * * Field Name: Agent
         * * Display Name: Agent
         * * SQL Data Type: nvarchar(255)`),
-    Action: z.string().nullish().describe(`
+    Action: z.string().nullable().describe(`
         * * Field Name: Action
         * * Display Name: Action
         * * SQL Data Type: nvarchar(425)`),
@@ -713,7 +713,7 @@ export const AIAgentLearningCycleSchema = z.object({
         * * SQL Data Type: datetimeoffset
         * * Default Value: getutcdate()
     * * Description: Timestamp indicating when the learning cycle started.`),
-    EndedAt: z.date().nullish().describe(`
+    EndedAt: z.date().nullable().describe(`
         * * Field Name: EndedAt
         * * Display Name: Ended At
         * * SQL Data Type: datetimeoffset
@@ -728,7 +728,7 @@ export const AIAgentLearningCycleSchema = z.object({
     *   * Complete
     *   * Failed
     * * Description: Status of the learning cycle (In-Progress, Complete, or Failed).`),
-    AgentSummary: z.string().nullish().describe(`
+    AgentSummary: z.string().nullable().describe(`
         * * Field Name: AgentSummary
         * * Display Name: Agent Summary
         * * SQL Data Type: nvarchar(MAX)
@@ -743,7 +743,7 @@ export const AIAgentLearningCycleSchema = z.object({
         * * Display Name: Updated At
         * * SQL Data Type: datetimeoffset
         * * Default Value: getutcdate()`),
-    Agent: z.string().nullish().describe(`
+    Agent: z.string().nullable().describe(`
         * * Field Name: Agent
         * * Display Name: Agent
         * * SQL Data Type: nvarchar(255)`),
@@ -761,23 +761,23 @@ export const AIAgentModelSchema = z.object({
         * * SQL Data Type: uniqueidentifier
         * * Default Value: newsequentialid()
     * * Description: The unique identifier for each AI agent-model mapping. Serves as the primary key.`),
-    AgentID: z.string().nullish().describe(`
+    AgentID: z.string().nullable().describe(`
         * * Field Name: AgentID
         * * Display Name: Agent ID
         * * SQL Data Type: uniqueidentifier
         * * Related Entity/Foreign Key: AI Agents (vwAIAgents.ID)
     * * Description: References the unique identifier of the associated AI agent from AIAgent table.`),
-    ModelID: z.string().nullish().describe(`
+    ModelID: z.string().nullable().describe(`
         * * Field Name: ModelID
         * * Display Name: Model ID
         * * SQL Data Type: uniqueidentifier
         * * Related Entity/Foreign Key: AI Models (vwAIModels.ID)
     * * Description: The unique identifier of the associated AI model.`),
-    Active: z.boolean().nullish().describe(`
+    Active: z.boolean().nullable().describe(`
         * * Field Name: Active
         * * Display Name: Active
         * * SQL Data Type: bit`),
-    Priority: z.number().nullish().describe(`
+    Priority: z.number().nullable().describe(`
         * * Field Name: Priority
         * * Display Name: Priority
         * * SQL Data Type: int
@@ -792,11 +792,11 @@ export const AIAgentModelSchema = z.object({
         * * Display Name: Updated At
         * * SQL Data Type: datetimeoffset
         * * Default Value: getutcdate()`),
-    Agent: z.string().nullish().describe(`
+    Agent: z.string().nullable().describe(`
         * * Field Name: Agent
         * * Display Name: Agent
         * * SQL Data Type: nvarchar(255)`),
-    Model: z.string().nullish().describe(`
+    Model: z.string().nullable().describe(`
         * * Field Name: Model
         * * Display Name: Model
         * * SQL Data Type: nvarchar(50)`),
@@ -813,11 +813,11 @@ export const AIAgentNoteTypeSchema = z.object({
         * * Display Name: ID
         * * SQL Data Type: uniqueidentifier
         * * Default Value: newsequentialid()`),
-    Name: z.string().nullish().describe(`
+    Name: z.string().nullable().describe(`
         * * Field Name: Name
         * * Display Name: Name
         * * SQL Data Type: nvarchar(255)`),
-    Description: z.string().nullish().describe(`
+    Description: z.string().nullable().describe(`
         * * Field Name: Description
         * * Display Name: Description
         * * SQL Data Type: nvarchar(MAX)`),
@@ -844,17 +844,17 @@ export const AIAgentNoteSchema = z.object({
         * * Display Name: ID
         * * SQL Data Type: uniqueidentifier
         * * Default Value: newsequentialid()`),
-    AgentID: z.string().nullish().describe(`
+    AgentID: z.string().nullable().describe(`
         * * Field Name: AgentID
         * * Display Name: Agent ID
         * * SQL Data Type: uniqueidentifier
         * * Related Entity/Foreign Key: AI Agents (vwAIAgents.ID)`),
-    AgentNoteTypeID: z.string().nullish().describe(`
+    AgentNoteTypeID: z.string().nullable().describe(`
         * * Field Name: AgentNoteTypeID
         * * Display Name: Agent Note Type ID
         * * SQL Data Type: uniqueidentifier
         * * Related Entity/Foreign Key: AI Agent Note Types (vwAIAgentNoteTypes.ID)`),
-    Note: z.string().nullish().describe(`
+    Note: z.string().nullable().describe(`
         * * Field Name: Note
         * * Display Name: Note
         * * SQL Data Type: nvarchar(MAX)`),
@@ -877,21 +877,21 @@ export const AIAgentNoteSchema = z.object({
     *   * User
     *   * Global
     * * Description: Indicates the type of note, either User-specific or Global.`),
-    UserID: z.string().nullish().describe(`
+    UserID: z.string().nullable().describe(`
         * * Field Name: UserID
         * * Display Name: User ID
         * * SQL Data Type: uniqueidentifier
         * * Related Entity/Foreign Key: Users (vwUsers.ID)
     * * Description: Foreign key referencing the ID column in the User table, indicating the user associated with the note. Used when Type=User`),
-    Agent: z.string().nullish().describe(`
+    Agent: z.string().nullable().describe(`
         * * Field Name: Agent
         * * Display Name: Agent
         * * SQL Data Type: nvarchar(255)`),
-    AgentNoteType: z.string().nullish().describe(`
+    AgentNoteType: z.string().nullable().describe(`
         * * Field Name: AgentNoteType
         * * Display Name: Agent Note Type
         * * SQL Data Type: nvarchar(255)`),
-    User: z.string().nullish().describe(`
+    User: z.string().nullable().describe(`
         * * Field Name: User
         * * Display Name: User
         * * SQL Data Type: nvarchar(100)`),
@@ -920,7 +920,7 @@ export const AIAgentRequestSchema = z.object({
         * * Display Name: Requested At
         * * SQL Data Type: datetime
     * * Description: Timestamp when the request was made by the agent.`),
-    RequestForUserID: z.string().nullish().describe(`
+    RequestForUserID: z.string().nullable().describe(`
         * * Field Name: RequestForUserID
         * * Display Name: Request For User ID
         * * SQL Data Type: uniqueidentifier
@@ -942,23 +942,23 @@ export const AIAgentRequestSchema = z.object({
         * * Display Name: Request
         * * SQL Data Type: nvarchar(MAX)
     * * Description: Details of what the AI Agent is requesting.`),
-    Response: z.string().nullish().describe(`
+    Response: z.string().nullable().describe(`
         * * Field Name: Response
         * * Display Name: Response
         * * SQL Data Type: nvarchar(MAX)
     * * Description: Response provided by the human to the agent request.`),
-    ResponseByUserID: z.string().nullish().describe(`
+    ResponseByUserID: z.string().nullable().describe(`
         * * Field Name: ResponseByUserID
         * * Display Name: Response By User ID
         * * SQL Data Type: uniqueidentifier
         * * Related Entity/Foreign Key: Users (vwUsers.ID)
     * * Description: Populated when a user responds indicating which user responded to the request.`),
-    RespondedAt: z.date().nullish().describe(`
+    RespondedAt: z.date().nullable().describe(`
         * * Field Name: RespondedAt
         * * Display Name: Responded At
         * * SQL Data Type: datetime
     * * Description: Timestamp when the response was provided by the human.`),
-    Comments: z.string().nullish().describe(`
+    Comments: z.string().nullable().describe(`
         * * Field Name: Comments
         * * Display Name: Comments
         * * SQL Data Type: nvarchar(MAX)
@@ -973,15 +973,15 @@ export const AIAgentRequestSchema = z.object({
         * * Display Name: Updated At
         * * SQL Data Type: datetimeoffset
         * * Default Value: getutcdate()`),
-    Agent: z.string().nullish().describe(`
+    Agent: z.string().nullable().describe(`
         * * Field Name: Agent
         * * Display Name: Agent
         * * SQL Data Type: nvarchar(255)`),
-    RequestForUser: z.string().nullish().describe(`
+    RequestForUser: z.string().nullable().describe(`
         * * Field Name: RequestForUser
         * * Display Name: Request For User
         * * SQL Data Type: nvarchar(100)`),
-    ResponseByUser: z.string().nullish().describe(`
+    ResponseByUser: z.string().nullable().describe(`
         * * Field Name: ResponseByUser
         * * Display Name: Response By User
         * * SQL Data Type: nvarchar(100)`),
@@ -999,17 +999,17 @@ export const AIAgentSchema = z.object({
         * * SQL Data Type: uniqueidentifier
         * * Default Value: newsequentialid()
     * * Description: The unique identifier for each AI agent. Serves as the primary key.`),
-    Name: z.string().nullish().describe(`
+    Name: z.string().nullable().describe(`
         * * Field Name: Name
         * * Display Name: Name
         * * SQL Data Type: nvarchar(255)
     * * Description: The name of the AI agent.`),
-    Description: z.string().nullish().describe(`
+    Description: z.string().nullable().describe(`
         * * Field Name: Description
         * * Display Name: Description
         * * SQL Data Type: nvarchar(MAX)
     * * Description: A detailed description of the AI agent.`),
-    LogoURL: z.string().nullish().describe(`
+    LogoURL: z.string().nullable().describe(`
         * * Field Name: LogoURL
         * * Display Name: Logo URL
         * * SQL Data Type: nvarchar(255)`),
@@ -1086,7 +1086,7 @@ export const AIModelTypeSchema = z.object({
         * * Field Name: Name
         * * Display Name: Name
         * * SQL Data Type: nvarchar(50)`),
-    Description: z.string().nullish().describe(`
+    Description: z.string().nullable().describe(`
         * * Field Name: Description
         * * Display Name: Description
         * * SQL Data Type: nvarchar(MAX)`),
@@ -1117,11 +1117,11 @@ export const AIModelSchema = z.object({
         * * Field Name: Name
         * * Display Name: Name
         * * SQL Data Type: nvarchar(50)`),
-    Description: z.string().nullish().describe(`
+    Description: z.string().nullable().describe(`
         * * Field Name: Description
         * * Display Name: Description
         * * SQL Data Type: nvarchar(MAX)`),
-    Vendor: z.string().nullish().describe(`
+    Vendor: z.string().nullable().describe(`
         * * Field Name: Vendor
         * * Display Name: Vendor
         * * SQL Data Type: nvarchar(50)`),
@@ -1130,7 +1130,7 @@ export const AIModelSchema = z.object({
         * * Display Name: AI Model Type ID
         * * SQL Data Type: uniqueidentifier
         * * Related Entity/Foreign Key: AI Model Types (vwAIModelTypes.ID)`),
-    PowerRank: z.number().nullish().describe(`
+    PowerRank: z.number().nullable().describe(`
         * * Field Name: PowerRank
         * * Display Name: Power Rank
         * * SQL Data Type: int
@@ -1141,15 +1141,15 @@ export const AIModelSchema = z.object({
         * * Display Name: Is Active
         * * SQL Data Type: bit
         * * Default Value: 1`),
-    DriverClass: z.string().nullish().describe(`
+    DriverClass: z.string().nullable().describe(`
         * * Field Name: DriverClass
         * * Display Name: Driver Class
         * * SQL Data Type: nvarchar(100)`),
-    DriverImportPath: z.string().nullish().describe(`
+    DriverImportPath: z.string().nullable().describe(`
         * * Field Name: DriverImportPath
         * * Display Name: Driver Import Path
         * * SQL Data Type: nvarchar(255)`),
-    APIName: z.string().nullish().describe(`
+    APIName: z.string().nullable().describe(`
         * * Field Name: APIName
         * * Display Name: APIName
         * * SQL Data Type: nvarchar(100)
@@ -1164,24 +1164,24 @@ export const AIModelSchema = z.object({
         * * Display Name: Updated At
         * * SQL Data Type: datetimeoffset
         * * Default Value: getutcdate()`),
-    SpeedRank: z.number().nullish().describe(`
+    SpeedRank: z.number().nullable().describe(`
         * * Field Name: SpeedRank
         * * Display Name: Speed Rank
         * * SQL Data Type: int
         * * Default Value: 0
     * * Description: Optional column that ranks the speed of the AI model. Default is 0 and should be non-negative.`),
-    CostRank: z.number().nullish().describe(`
+    CostRank: z.number().nullable().describe(`
         * * Field Name: CostRank
         * * Display Name: Cost Rank
         * * SQL Data Type: int
         * * Default Value: 0
     * * Description: Optional column that ranks the cost of the AI model. Default is 0 and should be non-negative.`),
-    ModelSelectionInsights: z.string().nullish().describe(`
+    ModelSelectionInsights: z.string().nullable().describe(`
         * * Field Name: ModelSelectionInsights
         * * Display Name: Model Selection Insights
         * * SQL Data Type: nvarchar(MAX)
     * * Description: This column stores unstructured text notes that provide insights into what the model is particularly good at and areas where it may not perform as well. These notes can be used by a human or an AI to determine if the model is a good fit for various purposes.`),
-    InputTokenLimit: z.number().nullish().describe(`
+    InputTokenLimit: z.number().nullable().describe(`
         * * Field Name: InputTokenLimit
         * * Display Name: Input Token Limit
         * * SQL Data Type: int
@@ -1213,13 +1213,13 @@ export const AIPromptCategorySchema = z.object({
         * * Field Name: Name
         * * Display Name: Name
         * * SQL Data Type: nvarchar(255)`),
-    ParentID: z.string().nullish().describe(`
+    ParentID: z.string().nullable().describe(`
         * * Field Name: ParentID
         * * Display Name: Parent ID
         * * SQL Data Type: uniqueidentifier
         * * Related Entity/Foreign Key: AI Prompt Categories (vwAIPromptCategories.ID)
     * * Description: Parent category ID for hierarchical organization.`),
-    Description: z.string().nullish().describe(`
+    Description: z.string().nullable().describe(`
         * * Field Name: Description
         * * Display Name: Description
         * * SQL Data Type: nvarchar(MAX)`),
@@ -1233,7 +1233,7 @@ export const AIPromptCategorySchema = z.object({
         * * Display Name: Updated At
         * * SQL Data Type: datetimeoffset
         * * Default Value: getutcdate()`),
-    Parent: z.string().nullish().describe(`
+    Parent: z.string().nullable().describe(`
         * * Field Name: Parent
         * * Display Name: Parent
         * * SQL Data Type: nvarchar(255)`),
@@ -1254,7 +1254,7 @@ export const AIPromptTypeSchema = z.object({
         * * Field Name: Name
         * * Display Name: Name
         * * SQL Data Type: nvarchar(255)`),
-    Description: z.string().nullish().describe(`
+    Description: z.string().nullable().describe(`
         * * Field Name: Description
         * * Display Name: Description
         * * SQL Data Type: nvarchar(MAX)`),
@@ -1285,7 +1285,7 @@ export const AIPromptSchema = z.object({
         * * Field Name: Name
         * * Display Name: Name
         * * SQL Data Type: nvarchar(255)`),
-    Description: z.string().nullish().describe(`
+    Description: z.string().nullable().describe(`
         * * Field Name: Description
         * * Display Name: Description
         * * SQL Data Type: nvarchar(MAX)`),
@@ -1295,7 +1295,7 @@ export const AIPromptSchema = z.object({
         * * SQL Data Type: uniqueidentifier
         * * Related Entity/Foreign Key: Templates (vwTemplates.ID)
     * * Description: Reference to the template used for the prompt.`),
-    CategoryID: z.string().nullish().describe(`
+    CategoryID: z.string().nullable().describe(`
         * * Field Name: CategoryID
         * * Display Name: Category ID
         * * SQL Data Type: uniqueidentifier
@@ -1351,7 +1351,7 @@ export const AIPromptSchema = z.object({
     *   * JSON
     *   * ModelSpecific
     * * Description: Specifies the expected response format for the AI model. Options include Any, Text, Markdown, JSON, and ModelSpecific. Defaults to Any if not specified.`),
-    ModelSpecificResponseFormat: z.string().nullish().describe(`
+    ModelSpecificResponseFormat: z.string().nullable().describe(`
         * * Field Name: ModelSpecificResponseFormat
         * * Display Name: Model Specific Response Format
         * * SQL Data Type: nvarchar(MAX)
@@ -1360,7 +1360,7 @@ export const AIPromptSchema = z.object({
         * * Field Name: Template
         * * Display Name: Template
         * * SQL Data Type: nvarchar(255)`),
-    Category: z.string().nullish().describe(`
+    Category: z.string().nullable().describe(`
         * * Field Name: Category
         * * Display Name: Category
         * * SQL Data Type: nvarchar(255)`),
@@ -1403,7 +1403,7 @@ export const AIResultCacheSchema = z.object({
         * * Display Name: Prompt Text
         * * SQL Data Type: nvarchar(MAX)
     * * Description: The prompt text used to generate this result.`),
-    ResultText: z.string().nullish().describe(`
+    ResultText: z.string().nullable().describe(`
         * * Field Name: ResultText
         * * Display Name: Result Text
         * * SQL Data Type: nvarchar(MAX)
@@ -1417,7 +1417,7 @@ export const AIResultCacheSchema = z.object({
     *   * Active
     *   * Expired
     * * Description: The status of this result, indicating whether it is currently active or expired.`),
-    ExpiredOn: z.date().nullish().describe(`
+    ExpiredOn: z.date().nullable().describe(`
         * * Field Name: ExpiredOn
         * * Display Name: Expired On
         * * SQL Data Type: datetimeoffset
@@ -1491,15 +1491,15 @@ export const ApplicationEntitySchema = z.object({
         * * Field Name: EntityBaseTable
         * * Display Name: Entity Base Table
         * * SQL Data Type: nvarchar(255)`),
-    EntityCodeName: z.string().nullish().describe(`
+    EntityCodeName: z.string().nullable().describe(`
         * * Field Name: EntityCodeName
         * * Display Name: Entity Code Name
         * * SQL Data Type: nvarchar(MAX)`),
-    EntityClassName: z.string().nullish().describe(`
+    EntityClassName: z.string().nullable().describe(`
         * * Field Name: EntityClassName
         * * Display Name: Entity Class Name
         * * SQL Data Type: nvarchar(MAX)`),
-    EntityBaseTableCodeName: z.string().nullish().describe(`
+    EntityBaseTableCodeName: z.string().nullable().describe(`
         * * Field Name: EntityBaseTableCodeName
         * * Display Name: Entity Base Table Code Name
         * * SQL Data Type: nvarchar(MAX)`),
@@ -1529,7 +1529,7 @@ export const ApplicationSettingSchema = z.object({
         * * Field Name: Value
         * * Display Name: Value
         * * SQL Data Type: nvarchar(MAX)`),
-    Comments: z.string().nullish().describe(`
+    Comments: z.string().nullable().describe(`
         * * Field Name: Comments
         * * Display Name: Comments
         * * SQL Data Type: nvarchar(MAX)`),
@@ -1562,10 +1562,10 @@ export const ApplicationSchema = z.object({
     Name: z.string().describe(`
         * * Field Name: Name
         * * SQL Data Type: nvarchar(100)`),
-    Description: z.string().nullish().describe(`
+    Description: z.string().nullable().describe(`
         * * Field Name: Description
         * * SQL Data Type: nvarchar(MAX)`),
-    Icon: z.string().nullish().describe(`
+    Icon: z.string().nullable().describe(`
         * * Field Name: Icon
         * * Display Name: Icon
         * * SQL Data Type: nvarchar(500)
@@ -1603,16 +1603,16 @@ export const AuditLogTypeSchema = z.object({
         * * Field Name: Name
         * * Display Name: Name
         * * SQL Data Type: nvarchar(50)`),
-    Description: z.string().nullish().describe(`
+    Description: z.string().nullable().describe(`
         * * Field Name: Description
         * * Display Name: Description
         * * SQL Data Type: nvarchar(MAX)`),
-    ParentID: z.string().nullish().describe(`
+    ParentID: z.string().nullable().describe(`
         * * Field Name: ParentID
         * * Display Name: Parent ID
         * * SQL Data Type: uniqueidentifier
         * * Related Entity/Foreign Key: Audit Log Types (vwAuditLogTypes.ID)`),
-    AuthorizationID: z.string().nullish().describe(`
+    AuthorizationID: z.string().nullable().describe(`
         * * Field Name: AuthorizationID
         * * Display Name: Authorization ID
         * * SQL Data Type: uniqueidentifier
@@ -1627,11 +1627,11 @@ export const AuditLogTypeSchema = z.object({
         * * Display Name: __mj _Updated At
         * * SQL Data Type: datetimeoffset
         * * Default Value: getutcdate()`),
-    Parent: z.string().nullish().describe(`
+    Parent: z.string().nullable().describe(`
         * * Field Name: Parent
         * * Display Name: Parent
         * * SQL Data Type: nvarchar(50)`),
-    Authorization: z.string().nullish().describe(`
+    Authorization: z.string().nullable().describe(`
         * * Field Name: Authorization
         * * Display Name: Authorization
         * * SQL Data Type: nvarchar(100)`),
@@ -1658,7 +1658,7 @@ export const AuditLogSchema = z.object({
         * * Display Name: Audit Log Type ID
         * * SQL Data Type: uniqueidentifier
         * * Related Entity/Foreign Key: Audit Log Types (vwAuditLogTypes.ID)`),
-    AuthorizationID: z.string().nullish().describe(`
+    AuthorizationID: z.string().nullable().describe(`
         * * Field Name: AuthorizationID
         * * Display Name: Authorization ID
         * * SQL Data Type: uniqueidentifier
@@ -1672,20 +1672,20 @@ export const AuditLogSchema = z.object({
     * * Possible Values 
     *   * Success
     *   * Failed`),
-    Description: z.string().nullish().describe(`
+    Description: z.string().nullable().describe(`
         * * Field Name: Description
         * * Display Name: Description
         * * SQL Data Type: nvarchar(MAX)`),
-    Details: z.string().nullish().describe(`
+    Details: z.string().nullable().describe(`
         * * Field Name: Details
         * * Display Name: Details
         * * SQL Data Type: nvarchar(MAX)`),
-    EntityID: z.string().nullish().describe(`
+    EntityID: z.string().nullable().describe(`
         * * Field Name: EntityID
         * * Display Name: Entity ID
         * * SQL Data Type: uniqueidentifier
         * * Related Entity/Foreign Key: Entities (vwEntities.ID)`),
-    RecordID: z.string().nullish().describe(`
+    RecordID: z.string().nullable().describe(`
         * * Field Name: RecordID
         * * Display Name: Record
         * * SQL Data Type: nvarchar(450)`),
@@ -1707,11 +1707,11 @@ export const AuditLogSchema = z.object({
         * * Field Name: AuditLogType
         * * Display Name: Audit Log Type
         * * SQL Data Type: nvarchar(50)`),
-    Authorization: z.string().nullish().describe(`
+    Authorization: z.string().nullable().describe(`
         * * Field Name: Authorization
         * * Display Name: Authorization
         * * SQL Data Type: nvarchar(100)`),
-    Entity: z.string().nullish().describe(`
+    Entity: z.string().nullable().describe(`
         * * Field Name: Entity
         * * Display Name: Entity
         * * SQL Data Type: nvarchar(255)`),
@@ -1778,7 +1778,7 @@ export const AuthorizationSchema = z.object({
         * * Display Name: ID
         * * SQL Data Type: uniqueidentifier
         * * Default Value: newsequentialid()`),
-    ParentID: z.string().nullish().describe(`
+    ParentID: z.string().nullable().describe(`
         * * Field Name: ParentID
         * * Display Name: Parent ID
         * * SQL Data Type: uniqueidentifier
@@ -1798,7 +1798,7 @@ export const AuthorizationSchema = z.object({
         * * SQL Data Type: bit
         * * Default Value: 1
     * * Description: When set to 1, Audit Log records are created whenever this authorization is invoked for a user`),
-    Description: z.string().nullish().describe(`
+    Description: z.string().nullable().describe(`
         * * Field Name: Description
         * * Display Name: Description
         * * SQL Data Type: nvarchar(MAX)`),
@@ -1812,7 +1812,7 @@ export const AuthorizationSchema = z.object({
         * * Display Name: __mj _Updated At
         * * SQL Data Type: datetimeoffset
         * * Default Value: getutcdate()`),
-    Parent: z.string().nullish().describe(`
+    Parent: z.string().nullable().describe(`
         * * Field Name: Parent
         * * Display Name: Parent
         * * SQL Data Type: nvarchar(100)`),
@@ -1851,7 +1851,7 @@ export const CommunicationBaseMessageTypeSchema = z.object({
         * * SQL Data Type: bit
         * * Default Value: 0
     * * Description: Indicates if HTML content is supported.`),
-    MaxBytes: z.number().nullish().describe(`
+    MaxBytes: z.number().nullable().describe(`
         * * Field Name: MaxBytes
         * * Display Name: Max Bytes
         * * SQL Data Type: int
@@ -1889,7 +1889,7 @@ export const CommunicationLogSchema = z.object({
         * * Display Name: Communication Provider Message Type ID
         * * SQL Data Type: uniqueidentifier
         * * Related Entity/Foreign Key: Communication Provider Message Types (vwCommunicationProviderMessageTypes.ID)`),
-    CommunicationRunID: z.string().nullish().describe(`
+    CommunicationRunID: z.string().nullable().describe(`
         * * Field Name: CommunicationRunID
         * * Display Name: Communication Run ID
         * * SQL Data Type: uniqueidentifier
@@ -1920,12 +1920,12 @@ export const CommunicationLogSchema = z.object({
     *   * Complete
     *   * Failed
     * * Description: The status of the logged message (Pending, In-Progress, Complete, Failed).`),
-    MessageContent: z.string().nullish().describe(`
+    MessageContent: z.string().nullable().describe(`
         * * Field Name: MessageContent
         * * Display Name: Message Content
         * * SQL Data Type: nvarchar(MAX)
     * * Description: The content of the logged message.`),
-    ErrorMessage: z.string().nullish().describe(`
+    ErrorMessage: z.string().nullable().describe(`
         * * Field Name: ErrorMessage
         * * Display Name: Error Message
         * * SQL Data Type: nvarchar(MAX)
@@ -1985,7 +1985,7 @@ export const CommunicationProviderMessageTypeSchema = z.object({
     *   * Disabled
     *   * Active
     * * Description: The status of the provider message type (Disabled or Active).`),
-    AdditionalAttributes: z.string().nullish().describe(`
+    AdditionalAttributes: z.string().nullable().describe(`
         * * Field Name: AdditionalAttributes
         * * Display Name: Additional Attributes
         * * SQL Data Type: nvarchar(MAX)
@@ -2025,7 +2025,7 @@ export const CommunicationProviderSchema = z.object({
         * * Field Name: Name
         * * Display Name: Name
         * * SQL Data Type: nvarchar(255)`),
-    Description: z.string().nullish().describe(`
+    Description: z.string().nullable().describe(`
         * * Field Name: Description
         * * Display Name: Description
         * * SQL Data Type: nvarchar(MAX)`),
@@ -2117,19 +2117,19 @@ export const CommunicationRunSchema = z.object({
     *   * Complete
     *   * Failed
     * * Description: The status of the communication run (Pending, In-Progress, Complete, Failed).`),
-    StartedAt: z.date().nullish().describe(`
+    StartedAt: z.date().nullable().describe(`
         * * Field Name: StartedAt
         * * Display Name: Started At
         * * SQL Data Type: datetime`),
-    EndedAt: z.date().nullish().describe(`
+    EndedAt: z.date().nullable().describe(`
         * * Field Name: EndedAt
         * * Display Name: Ended At
         * * SQL Data Type: datetime`),
-    Comments: z.string().nullish().describe(`
+    Comments: z.string().nullable().describe(`
         * * Field Name: Comments
         * * Display Name: Comments
         * * SQL Data Type: nvarchar(MAX)`),
-    ErrorMessage: z.string().nullish().describe(`
+    ErrorMessage: z.string().nullable().describe(`
         * * Field Name: ErrorMessage
         * * Display Name: Error Message
         * * SQL Data Type: nvarchar(MAX)
@@ -2166,14 +2166,14 @@ export const CompanySchema = z.object({
     Description: z.string().describe(`
         * * Field Name: Description
         * * SQL Data Type: nvarchar(200)`),
-    Website: z.string().nullish().describe(`
+    Website: z.string().nullable().describe(`
         * * Field Name: Website
         * * SQL Data Type: nvarchar(100)`),
-    LogoURL: z.string().nullish().describe(`
+    LogoURL: z.string().nullable().describe(`
         * * Field Name: LogoURL
         * * Display Name: Logo URL
         * * SQL Data Type: nvarchar(500)`),
-    Domain: z.string().nullish().describe(`
+    Domain: z.string().nullable().describe(`
         * * Field Name: Domain
         * * Display Name: Domain
         * * SQL Data Type: nvarchar(255)`),
@@ -2259,7 +2259,7 @@ export const CompanyIntegrationRunAPILogSchema = z.object({
         * * Display Name: Is Success
         * * SQL Data Type: bit
         * * Default Value: 0`),
-    RequestMethod: z.union([z.literal('GET'), z.literal('POST'), z.literal('PUT'), z.literal('DELETE'), z.literal('PATCH'), z.literal('HEAD'), z.literal('OPTIONS')]).nullish().describe(`
+    RequestMethod: z.union([z.literal('GET'), z.literal('POST'), z.literal('PUT'), z.literal('DELETE'), z.literal('PATCH'), z.literal('HEAD'), z.literal('OPTIONS')]).nullable().describe(`
         * * Field Name: RequestMethod
         * * Display Name: Request Method
         * * SQL Data Type: nvarchar(12)
@@ -2272,10 +2272,10 @@ export const CompanyIntegrationRunAPILogSchema = z.object({
     *   * PATCH
     *   * HEAD
     *   * OPTIONS`),
-    URL: z.string().nullish().describe(`
+    URL: z.string().nullable().describe(`
         * * Field Name: URL
         * * SQL Data Type: nvarchar(MAX)`),
-    Parameters: z.string().nullish().describe(`
+    Parameters: z.string().nullable().describe(`
         * * Field Name: Parameters
         * * SQL Data Type: nvarchar(MAX)`),
     __mj_CreatedAt: z.date().describe(`
@@ -2340,11 +2340,11 @@ export const CompanyIntegrationRunDetailSchema = z.object({
     Entity: z.string().describe(`
         * * Field Name: Entity
         * * SQL Data Type: nvarchar(255)`),
-    RunStartedAt: z.date().nullish().describe(`
+    RunStartedAt: z.date().nullable().describe(`
         * * Field Name: RunStartedAt
         * * Display Name: Run Started At
         * * SQL Data Type: datetime`),
-    RunEndedAt: z.date().nullish().describe(`
+    RunEndedAt: z.date().nullable().describe(`
         * * Field Name: RunEndedAt
         * * Display Name: Run Ended At
         * * SQL Data Type: datetime`),
@@ -2370,11 +2370,11 @@ export const CompanyIntegrationRunSchema = z.object({
         * * Display Name: RunByUser ID
         * * SQL Data Type: uniqueidentifier
         * * Related Entity/Foreign Key: Users (vwUsers.ID)`),
-    StartedAt: z.date().nullish().describe(`
+    StartedAt: z.date().nullable().describe(`
         * * Field Name: StartedAt
         * * Display Name: Started At
         * * SQL Data Type: datetime`),
-    EndedAt: z.date().nullish().describe(`
+    EndedAt: z.date().nullable().describe(`
         * * Field Name: EndedAt
         * * Display Name: Ended At
         * * SQL Data Type: datetime`),
@@ -2382,7 +2382,7 @@ export const CompanyIntegrationRunSchema = z.object({
         * * Field Name: TotalRecords
         * * Display Name: Total Records
         * * SQL Data Type: int`),
-    Comments: z.string().nullish().describe(`
+    Comments: z.string().nullable().describe(`
         * * Field Name: Comments
         * * SQL Data Type: nvarchar(MAX)`),
     __mj_CreatedAt: z.date().describe(`
@@ -2407,12 +2407,12 @@ export const CompanyIntegrationRunSchema = z.object({
     *   * Success
     *   * Failed
     * * Description: Status of the integration run. Possible values: Pending, In Progress, Success, Failed.`),
-    ErrorLog: z.string().nullish().describe(`
+    ErrorLog: z.string().nullable().describe(`
         * * Field Name: ErrorLog
         * * Display Name: Error Log
         * * SQL Data Type: nvarchar(MAX)
     * * Description: Optional error log information for the integration run.`),
-    ConfigData: z.string().nullish().describe(`
+    ConfigData: z.string().nullable().describe(`
         * * Field Name: ConfigData
         * * Display Name: Config Data
         * * SQL Data Type: nvarchar(MAX)
@@ -2451,26 +2451,26 @@ export const CompanyIntegrationSchema = z.object({
         * * Display Name: Integration ID
         * * SQL Data Type: uniqueidentifier
         * * Related Entity/Foreign Key: Integrations (vwIntegrations.ID)`),
-    IsActive: z.boolean().nullish().describe(`
+    IsActive: z.boolean().nullable().describe(`
         * * Field Name: IsActive
         * * Display Name: Is Active
         * * SQL Data Type: bit`),
-    AccessToken: z.string().nullish().describe(`
+    AccessToken: z.string().nullable().describe(`
         * * Field Name: AccessToken
         * * Display Name: Access Token
         * * SQL Data Type: nvarchar(255)`),
-    RefreshToken: z.string().nullish().describe(`
+    RefreshToken: z.string().nullable().describe(`
         * * Field Name: RefreshToken
         * * Display Name: Refresh Token
         * * SQL Data Type: nvarchar(255)`),
-    TokenExpirationDate: z.date().nullish().describe(`
+    TokenExpirationDate: z.date().nullable().describe(`
         * * Field Name: TokenExpirationDate
         * * Display Name: Token Expiration Date
         * * SQL Data Type: datetime`),
-    APIKey: z.string().nullish().describe(`
+    APIKey: z.string().nullable().describe(`
         * * Field Name: APIKey
         * * SQL Data Type: nvarchar(255)`),
-    ExternalSystemID: z.string().nullish().describe(`
+    ExternalSystemID: z.string().nullable().describe(`
         * * Field Name: ExternalSystemID
         * * Display Name: ExternalSystem
         * * SQL Data Type: nvarchar(100)`),
@@ -2479,15 +2479,15 @@ export const CompanyIntegrationSchema = z.object({
         * * Display Name: Is External System Read Only
         * * SQL Data Type: bit
         * * Default Value: 0`),
-    ClientID: z.string().nullish().describe(`
+    ClientID: z.string().nullable().describe(`
         * * Field Name: ClientID
         * * Display Name: Client
         * * SQL Data Type: nvarchar(255)`),
-    ClientSecret: z.string().nullish().describe(`
+    ClientSecret: z.string().nullable().describe(`
         * * Field Name: ClientSecret
         * * Display Name: Client Secret
         * * SQL Data Type: nvarchar(255)`),
-    CustomAttribute1: z.string().nullish().describe(`
+    CustomAttribute1: z.string().nullable().describe(`
         * * Field Name: CustomAttribute1
         * * Display Name: Custom Attribute 1
         * * SQL Data Type: nvarchar(255)`),
@@ -2507,23 +2507,23 @@ export const CompanyIntegrationSchema = z.object({
     Integration: z.string().describe(`
         * * Field Name: Integration
         * * SQL Data Type: nvarchar(100)`),
-    DriverClassName: z.string().nullish().describe(`
+    DriverClassName: z.string().nullable().describe(`
         * * Field Name: DriverClassName
         * * Display Name: Driver Class Name
         * * SQL Data Type: nvarchar(100)`),
-    DriverImportPath: z.string().nullish().describe(`
+    DriverImportPath: z.string().nullable().describe(`
         * * Field Name: DriverImportPath
         * * Display Name: Driver Import Path
         * * SQL Data Type: nvarchar(100)`),
-    LastRunID: z.string().nullish().describe(`
+    LastRunID: z.string().nullable().describe(`
         * * Field Name: LastRunID
         * * Display Name: LastRun
         * * SQL Data Type: uniqueidentifier`),
-    LastRunStartedAt: z.date().nullish().describe(`
+    LastRunStartedAt: z.date().nullable().describe(`
         * * Field Name: LastRunStartedAt
         * * Display Name: Last Run Started At
         * * SQL Data Type: datetime`),
-    LastRunEndedAt: z.date().nullish().describe(`
+    LastRunEndedAt: z.date().nullable().describe(`
         * * Field Name: LastRunEndedAt
         * * Display Name: Last Run Ended At
         * * SQL Data Type: datetime`),
@@ -2544,7 +2544,7 @@ export const ContentFileTypeSchema = z.object({
         * * Field Name: Name
         * * Display Name: Name
         * * SQL Data Type: nvarchar(255)`),
-    FileExtension: z.string().nullish().describe(`
+    FileExtension: z.string().nullable().describe(`
         * * Field Name: FileExtension
         * * Display Name: File Extension
         * * SQL Data Type: nvarchar(255)`),
@@ -2594,7 +2594,7 @@ export const ContentItemAttributeSchema = z.object({
         * * Display Name: Updated At
         * * SQL Data Type: datetimeoffset
         * * Default Value: getutcdate()`),
-    ContentItem: z.string().nullish().describe(`
+    ContentItem: z.string().nullable().describe(`
         * * Field Name: ContentItem
         * * Display Name: Content Item
         * * SQL Data Type: nvarchar(250)`),
@@ -2630,7 +2630,7 @@ export const ContentItemTagSchema = z.object({
         * * Display Name: Updated At
         * * SQL Data Type: datetimeoffset
         * * Default Value: getutcdate()`),
-    Item: z.string().nullish().describe(`
+    Item: z.string().nullable().describe(`
         * * Field Name: Item
         * * Display Name: Item
         * * SQL Data Type: nvarchar(250)`),
@@ -2652,11 +2652,11 @@ export const ContentItemSchema = z.object({
         * * Display Name: Content Source ID
         * * SQL Data Type: uniqueidentifier
         * * Related Entity/Foreign Key: Content Sources (vwContentSources.ID)`),
-    Name: z.string().nullish().describe(`
+    Name: z.string().nullable().describe(`
         * * Field Name: Name
         * * Display Name: Name
         * * SQL Data Type: nvarchar(250)`),
-    Description: z.string().nullish().describe(`
+    Description: z.string().nullable().describe(`
         * * Field Name: Description
         * * Display Name: Description
         * * SQL Data Type: nvarchar(MAX)`),
@@ -2675,7 +2675,7 @@ export const ContentItemSchema = z.object({
         * * Display Name: Content File Type ID
         * * SQL Data Type: uniqueidentifier
         * * Related Entity/Foreign Key: Content File Types (vwContentFileTypes.ID)`),
-    Checksum: z.string().nullish().describe(`
+    Checksum: z.string().nullable().describe(`
         * * Field Name: Checksum
         * * Display Name: Checksum
         * * SQL Data Type: nvarchar(100)`),
@@ -2683,7 +2683,7 @@ export const ContentItemSchema = z.object({
         * * Field Name: URL
         * * Display Name: URL
         * * SQL Data Type: nvarchar(2000)`),
-    Text: z.string().nullish().describe(`
+    Text: z.string().nullable().describe(`
         * * Field Name: Text
         * * Display Name: Text
         * * SQL Data Type: nvarchar(MAX)`),
@@ -2697,7 +2697,7 @@ export const ContentItemSchema = z.object({
         * * Display Name: Updated At
         * * SQL Data Type: datetimeoffset
         * * Default Value: getutcdate()`),
-    ContentSource: z.string().nullish().describe(`
+    ContentSource: z.string().nullable().describe(`
         * * Field Name: ContentSource
         * * Display Name: Content Source
         * * SQL Data Type: nvarchar(255)`),
@@ -2731,19 +2731,19 @@ export const ContentProcessRunSchema = z.object({
         * * Display Name: Source ID
         * * SQL Data Type: uniqueidentifier
         * * Related Entity/Foreign Key: Content Sources (vwContentSources.ID)`),
-    StartTime: z.date().nullish().describe(`
+    StartTime: z.date().nullable().describe(`
         * * Field Name: StartTime
         * * Display Name: Start Time
         * * SQL Data Type: datetime`),
-    EndTime: z.date().nullish().describe(`
+    EndTime: z.date().nullable().describe(`
         * * Field Name: EndTime
         * * Display Name: End Time
         * * SQL Data Type: datetime`),
-    Status: z.string().nullish().describe(`
+    Status: z.string().nullable().describe(`
         * * Field Name: Status
         * * Display Name: Status
         * * SQL Data Type: nvarchar(100)`),
-    ProcessedItems: z.number().nullish().describe(`
+    ProcessedItems: z.number().nullable().describe(`
         * * Field Name: ProcessedItems
         * * Display Name: Processed Items
         * * SQL Data Type: int`),
@@ -2757,7 +2757,7 @@ export const ContentProcessRunSchema = z.object({
         * * Display Name: Updated At
         * * SQL Data Type: datetimeoffset
         * * Default Value: getutcdate()`),
-    Source: z.string().nullish().describe(`
+    Source: z.string().nullable().describe(`
         * * Field Name: Source
         * * Display Name: Source
         * * SQL Data Type: nvarchar(255)`),
@@ -2797,7 +2797,7 @@ export const ContentSourceParamSchema = z.object({
         * * Display Name: Updated At
         * * SQL Data Type: datetimeoffset
         * * Default Value: getutcdate()`),
-    ContentSource: z.string().nullish().describe(`
+    ContentSource: z.string().nullable().describe(`
         * * Field Name: ContentSource
         * * Display Name: Content Source
         * * SQL Data Type: nvarchar(255)`),
@@ -2818,15 +2818,15 @@ export const ContentSourceTypeParamSchema = z.object({
         * * Field Name: Name
         * * Display Name: Name
         * * SQL Data Type: nvarchar(100)`),
-    Description: z.string().nullish().describe(`
+    Description: z.string().nullable().describe(`
         * * Field Name: Description
         * * Display Name: Description
         * * SQL Data Type: nvarchar(MAX)`),
-    Type: z.string().nullish().describe(`
+    Type: z.string().nullable().describe(`
         * * Field Name: Type
         * * Display Name: Type
         * * SQL Data Type: nvarchar(50)`),
-    DefaultValue: z.string().nullish().describe(`
+    DefaultValue: z.string().nullable().describe(`
         * * Field Name: DefaultValue
         * * Display Name: Default Value
         * * SQL Data Type: nvarchar(MAX)`),
@@ -2861,7 +2861,7 @@ export const ContentSourceTypeSchema = z.object({
         * * Field Name: Name
         * * Display Name: Name
         * * SQL Data Type: nvarchar(255)`),
-    Description: z.string().nullish().describe(`
+    Description: z.string().nullable().describe(`
         * * Field Name: Description
         * * Display Name: Description
         * * SQL Data Type: nvarchar(1000)`),
@@ -2888,7 +2888,7 @@ export const ContentSourceSchema = z.object({
         * * Display Name: ID
         * * SQL Data Type: uniqueidentifier
         * * Default Value: newsequentialid()`),
-    Name: z.string().nullish().describe(`
+    Name: z.string().nullable().describe(`
         * * Field Name: Name
         * * Display Name: Name
         * * SQL Data Type: nvarchar(255)`),
@@ -2958,7 +2958,7 @@ export const ContentTypeAttributeSchema = z.object({
         * * Field Name: Prompt
         * * Display Name: Prompt
         * * SQL Data Type: nvarchar(MAX)`),
-    Description: z.string().nullish().describe(`
+    Description: z.string().nullable().describe(`
         * * Field Name: Description
         * * Display Name: Description
         * * SQL Data Type: nvarchar(MAX)`),
@@ -2989,7 +2989,7 @@ export const ContentTypeSchema = z.object({
         * * Field Name: Name
         * * Display Name: Name
         * * SQL Data Type: nvarchar(255)`),
-    Description: z.string().nullish().describe(`
+    Description: z.string().nullable().describe(`
         * * Field Name: Description
         * * Display Name: Description
         * * SQL Data Type: nvarchar(MAX)`),
@@ -3038,7 +3038,7 @@ export const ConversationDetailSchema = z.object({
         * * Display Name: Conversation ID
         * * SQL Data Type: uniqueidentifier
         * * Related Entity/Foreign Key: Conversations (vwConversations.ID)`),
-    ExternalID: z.string().nullish().describe(`
+    ExternalID: z.string().nullable().describe(`
         * * Field Name: ExternalID
         * * Display Name: External ID
         * * SQL Data Type: nvarchar(100)`),
@@ -3056,7 +3056,7 @@ export const ConversationDetailSchema = z.object({
         * * Field Name: Message
         * * Display Name: Message
         * * SQL Data Type: nvarchar(MAX)`),
-    Error: z.string().nullish().describe(`
+    Error: z.string().nullable().describe(`
         * * Field Name: Error
         * * Display Name: Error
         * * SQL Data Type: nvarchar(MAX)`),
@@ -3075,37 +3075,37 @@ export const ConversationDetailSchema = z.object({
         * * Display Name: Updated At
         * * SQL Data Type: datetimeoffset
         * * Default Value: getutcdate()`),
-    UserRating: z.number().nullish().describe(`
+    UserRating: z.number().nullable().describe(`
         * * Field Name: UserRating
         * * Display Name: User Rating
         * * SQL Data Type: int
     * * Description: This column is used to capture user feedback as a rating scale. The scale ranges from 1 to 10, where 1 might represent thumbs down, and 10 might represent thumbs up or the highest rating in a star-based scale.`),
-    UserFeedback: z.string().nullish().describe(`
+    UserFeedback: z.string().nullable().describe(`
         * * Field Name: UserFeedback
         * * Display Name: User Feedback
         * * SQL Data Type: nvarchar(MAX)
     * * Description: This column is used to store user text feedback about a given AI response, describing what they liked or disliked.`),
-    ReflectionInsights: z.string().nullish().describe(`
+    ReflectionInsights: z.string().nullable().describe(`
         * * Field Name: ReflectionInsights
         * * Display Name: Reflection Insights
         * * SQL Data Type: nvarchar(MAX)
     * * Description: This column stores human or AI-generated reflections on how to improve future responses based on the user feedback and the AI output generated for prior messages in the conversation.`),
-    SummaryOfEarlierConversation: z.string().nullish().describe(`
+    SummaryOfEarlierConversation: z.string().nullable().describe(`
         * * Field Name: SummaryOfEarlierConversation
         * * Display Name: Summary Of Earlier Conversation
         * * SQL Data Type: nvarchar(MAX)
     * * Description: This column optionally stores a summary of the entire conversation leading up to this particular conversation detail record. It is used in long-running conversations to optimize performance by summarizing earlier parts.`),
-    UserID: z.string().nullish().describe(`
+    UserID: z.string().nullable().describe(`
         * * Field Name: UserID
         * * Display Name: User ID
         * * SQL Data Type: uniqueidentifier
         * * Related Entity/Foreign Key: Users (vwUsers.ID)
     * * Description: This field, when populated, overrides the UserID at the Conversation level to specify a different user created the message.`),
-    Conversation: z.string().nullish().describe(`
+    Conversation: z.string().nullable().describe(`
         * * Field Name: Conversation
         * * Display Name: Conversation
         * * SQL Data Type: nvarchar(255)`),
-    User: z.string().nullish().describe(`
+    User: z.string().nullable().describe(`
         * * Field Name: User
         * * Display Name: User
         * * SQL Data Type: nvarchar(100)`),
@@ -3127,15 +3127,15 @@ export const ConversationSchema = z.object({
         * * Display Name: User ID
         * * SQL Data Type: uniqueidentifier
         * * Related Entity/Foreign Key: Users (vwUsers.ID)`),
-    ExternalID: z.string().nullish().describe(`
+    ExternalID: z.string().nullable().describe(`
         * * Field Name: ExternalID
         * * Display Name: External ID
         * * SQL Data Type: nvarchar(500)`),
-    Name: z.string().nullish().describe(`
+    Name: z.string().nullable().describe(`
         * * Field Name: Name
         * * Display Name: Name
         * * SQL Data Type: nvarchar(255)`),
-    Description: z.string().nullish().describe(`
+    Description: z.string().nullable().describe(`
         * * Field Name: Description
         * * Display Name: Description
         * * SQL Data Type: nvarchar(MAX)`),
@@ -3149,16 +3149,16 @@ export const ConversationSchema = z.object({
         * * Display Name: Is Archived
         * * SQL Data Type: bit
         * * Default Value: 0`),
-    LinkedEntityID: z.string().nullish().describe(`
+    LinkedEntityID: z.string().nullable().describe(`
         * * Field Name: LinkedEntityID
         * * Display Name: Linked Entity ID
         * * SQL Data Type: uniqueidentifier
         * * Related Entity/Foreign Key: Entities (vwEntities.ID)`),
-    LinkedRecordID: z.string().nullish().describe(`
+    LinkedRecordID: z.string().nullable().describe(`
         * * Field Name: LinkedRecordID
         * * Display Name: Linked Record ID
         * * SQL Data Type: nvarchar(500)`),
-    DataContextID: z.string().nullish().describe(`
+    DataContextID: z.string().nullable().describe(`
         * * Field Name: DataContextID
         * * Display Name: Data Context ID
         * * SQL Data Type: uniqueidentifier
@@ -3177,11 +3177,11 @@ export const ConversationSchema = z.object({
         * * Field Name: User
         * * Display Name: User
         * * SQL Data Type: nvarchar(100)`),
-    LinkedEntity: z.string().nullish().describe(`
+    LinkedEntity: z.string().nullable().describe(`
         * * Field Name: LinkedEntity
         * * Display Name: Linked Entity
         * * SQL Data Type: nvarchar(255)`),
-    DataContext: z.string().nullish().describe(`
+    DataContext: z.string().nullable().describe(`
         * * Field Name: DataContext
         * * Display Name: Data Context
         * * SQL Data Type: nvarchar(255)`),
@@ -3202,11 +3202,11 @@ export const DashboardCategorySchema = z.object({
         * * Field Name: Name
         * * Display Name: Name
         * * SQL Data Type: nvarchar(100)`),
-    Description: z.string().nullish().describe(`
+    Description: z.string().nullable().describe(`
         * * Field Name: Description
         * * Display Name: Description
         * * SQL Data Type: nvarchar(MAX)`),
-    ParentID: z.string().nullish().describe(`
+    ParentID: z.string().nullable().describe(`
         * * Field Name: ParentID
         * * Display Name: Parent ID
         * * SQL Data Type: uniqueidentifier
@@ -3226,7 +3226,7 @@ export const DashboardCategorySchema = z.object({
         * * Display Name: Updated At
         * * SQL Data Type: datetimeoffset
         * * Default Value: getutcdate()`),
-    Parent: z.string().nullish().describe(`
+    Parent: z.string().nullable().describe(`
         * * Field Name: Parent
         * * Display Name: Parent
         * * SQL Data Type: nvarchar(100)`),
@@ -3251,7 +3251,7 @@ export const DashboardSchema = z.object({
         * * Field Name: Name
         * * Display Name: Name
         * * SQL Data Type: nvarchar(255)`),
-    Description: z.string().nullish().describe(`
+    Description: z.string().nullable().describe(`
         * * Field Name: Description
         * * Display Name: Description
         * * SQL Data Type: nvarchar(MAX)`),
@@ -3260,7 +3260,7 @@ export const DashboardSchema = z.object({
         * * Display Name: User ID
         * * SQL Data Type: uniqueidentifier
         * * Related Entity/Foreign Key: Users (vwUsers.ID)`),
-    CategoryID: z.string().nullish().describe(`
+    CategoryID: z.string().nullable().describe(`
         * * Field Name: CategoryID
         * * Display Name: Category ID
         * * SQL Data Type: uniqueidentifier
@@ -3283,7 +3283,7 @@ export const DashboardSchema = z.object({
         * * Field Name: User
         * * Display Name: User
         * * SQL Data Type: nvarchar(100)`),
-    Category: z.string().nullish().describe(`
+    Category: z.string().nullable().describe(`
         * * Field Name: Category
         * * Display Name: Category
         * * SQL Data Type: nvarchar(100)`),
@@ -3317,37 +3317,37 @@ export const DataContextItemSchema = z.object({
     *   * single_record
     *   * full_entity
     * * Description: The type of the item, either "view", "query", "full_entity", "single_record", or "sql"`),
-    ViewID: z.string().nullish().describe(`
+    ViewID: z.string().nullable().describe(`
         * * Field Name: ViewID
         * * Display Name: View ID
         * * SQL Data Type: uniqueidentifier
         * * Related Entity/Foreign Key: User Views (vwUserViews.ID)`),
-    QueryID: z.string().nullish().describe(`
+    QueryID: z.string().nullable().describe(`
         * * Field Name: QueryID
         * * Display Name: Query ID
         * * SQL Data Type: uniqueidentifier
         * * Related Entity/Foreign Key: Queries (vwQueries.ID)`),
-    EntityID: z.string().nullish().describe(`
+    EntityID: z.string().nullable().describe(`
         * * Field Name: EntityID
         * * Display Name: Entity ID
         * * SQL Data Type: uniqueidentifier
         * * Related Entity/Foreign Key: Entities (vwEntities.ID)`),
-    RecordID: z.string().nullish().describe(`
+    RecordID: z.string().nullable().describe(`
         * * Field Name: RecordID
         * * Display Name: Record ID
         * * SQL Data Type: nvarchar(450)
     * * Description: The Primary Key value for the record, only used when Type='single_record'`),
-    SQL: z.string().nullish().describe(`
+    SQL: z.string().nullable().describe(`
         * * Field Name: SQL
         * * Display Name: SQL
         * * SQL Data Type: nvarchar(MAX)
     * * Description: Only used when Type=sql`),
-    DataJSON: z.string().nullish().describe(`
+    DataJSON: z.string().nullable().describe(`
         * * Field Name: DataJSON
         * * Display Name: Data JSON
         * * SQL Data Type: nvarchar(MAX)
     * * Description: Optionally used to cache results of an item. This can be used for performance optimization, and also for having snapshots of data for historical comparisons.`),
-    LastRefreshedAt: z.date().nullish().describe(`
+    LastRefreshedAt: z.date().nullable().describe(`
         * * Field Name: LastRefreshedAt
         * * Display Name: Last Refreshed At
         * * SQL Data Type: datetime
@@ -3362,7 +3362,7 @@ export const DataContextItemSchema = z.object({
         * * Display Name: Updated At
         * * SQL Data Type: datetimeoffset
         * * Default Value: getutcdate()`),
-    Description: z.string().nullish().describe(`
+    Description: z.string().nullable().describe(`
         * * Field Name: Description
         * * Display Name: Description
         * * SQL Data Type: nvarchar(MAX)`),
@@ -3370,15 +3370,15 @@ export const DataContextItemSchema = z.object({
         * * Field Name: DataContext
         * * Display Name: Data Context
         * * SQL Data Type: nvarchar(255)`),
-    View: z.string().nullish().describe(`
+    View: z.string().nullable().describe(`
         * * Field Name: View
         * * Display Name: View
         * * SQL Data Type: nvarchar(100)`),
-    Query: z.string().nullish().describe(`
+    Query: z.string().nullable().describe(`
         * * Field Name: Query
         * * Display Name: Query
         * * SQL Data Type: nvarchar(255)`),
-    Entity: z.string().nullish().describe(`
+    Entity: z.string().nullable().describe(`
         * * Field Name: Entity
         * * Display Name: Entity
         * * SQL Data Type: nvarchar(255)`),
@@ -3399,7 +3399,7 @@ export const DataContextSchema = z.object({
         * * Field Name: Name
         * * Display Name: Name
         * * SQL Data Type: nvarchar(255)`),
-    Description: z.string().nullish().describe(`
+    Description: z.string().nullable().describe(`
         * * Field Name: Description
         * * Display Name: Description
         * * SQL Data Type: nvarchar(MAX)`),
@@ -3408,7 +3408,7 @@ export const DataContextSchema = z.object({
         * * Display Name: User ID
         * * SQL Data Type: uniqueidentifier
         * * Related Entity/Foreign Key: Users (vwUsers.ID)`),
-    LastRefreshedAt: z.date().nullish().describe(`
+    LastRefreshedAt: z.date().nullable().describe(`
         * * Field Name: LastRefreshedAt
         * * Display Name: Last Refreshed At
         * * SQL Data Type: datetime`),
@@ -3458,7 +3458,7 @@ export const DatasetItemSchema = z.object({
         * * Display Name: Entity ID
         * * SQL Data Type: uniqueidentifier
         * * Related Entity/Foreign Key: Entities (vwEntities.ID)`),
-    WhereClause: z.string().nullish().describe(`
+    WhereClause: z.string().nullable().describe(`
         * * Field Name: WhereClause
         * * Display Name: Where Clause
         * * SQL Data Type: nvarchar(MAX)`),
@@ -3466,7 +3466,7 @@ export const DatasetItemSchema = z.object({
         * * Field Name: DateFieldToCheck
         * * Display Name: Date Field To Check
         * * SQL Data Type: nvarchar(100)`),
-    Description: z.string().nullish().describe(`
+    Description: z.string().nullable().describe(`
         * * Field Name: Description
         * * Display Name: Description
         * * SQL Data Type: nvarchar(MAX)`),
@@ -3480,7 +3480,7 @@ export const DatasetItemSchema = z.object({
         * * Display Name: Updated At
         * * SQL Data Type: datetimeoffset
         * * Default Value: getutcdate()`),
-    Columns: z.string().nullish().describe(`
+    Columns: z.string().nullable().describe(`
         * * Field Name: Columns
         * * Display Name: Columns
         * * SQL Data Type: nvarchar(MAX)
@@ -3510,7 +3510,7 @@ export const DatasetSchema = z.object({
         * * Field Name: Name
         * * Display Name: Name
         * * SQL Data Type: nvarchar(100)`),
-    Description: z.string().nullish().describe(`
+    Description: z.string().nullable().describe(`
         * * Field Name: Description
         * * Display Name: Description
         * * SQL Data Type: nvarchar(MAX)`),
@@ -3582,7 +3582,7 @@ export const DuplicateRunDetailMatchSchema = z.object({
     *   * Rejected
     *   * Approved
     *   * Pending`),
-    RecordMergeLogID: z.string().nullish().describe(`
+    RecordMergeLogID: z.string().nullable().describe(`
         * * Field Name: RecordMergeLogID
         * * Display Name: Record Merge Log ID
         * * SQL Data Type: uniqueidentifier
@@ -3645,12 +3645,12 @@ export const DuplicateRunDetailSchema = z.object({
     *   * Skipped
     *   * Complete
     *   * Pending`),
-    SkippedReason: z.string().nullish().describe(`
+    SkippedReason: z.string().nullable().describe(`
         * * Field Name: SkippedReason
         * * Display Name: Skipped Reason
         * * SQL Data Type: nvarchar(MAX)
     * * Description: If MatchStatus=Skipped, this field can be used to store the reason why the record was skipped`),
-    MatchErrorMessage: z.string().nullish().describe(`
+    MatchErrorMessage: z.string().nullable().describe(`
         * * Field Name: MatchErrorMessage
         * * Display Name: Match Error Message
         * * SQL Data Type: nvarchar(MAX)
@@ -3666,7 +3666,7 @@ export const DuplicateRunDetailSchema = z.object({
     *   * Complete
     *   * Pending
     *   * Not Applicable`),
-    MergeErrorMessage: z.string().nullish().describe(`
+    MergeErrorMessage: z.string().nullable().describe(`
         * * Field Name: MergeErrorMessage
         * * Display Name: Merge Error Message
         * * SQL Data Type: nvarchar(MAX)`),
@@ -3713,7 +3713,7 @@ export const DuplicateRunSchema = z.object({
         * * Display Name: Started At
         * * SQL Data Type: datetime
         * * Default Value: getdate()`),
-    EndedAt: z.date().nullish().describe(`
+    EndedAt: z.date().nullable().describe(`
         * * Field Name: EndedAt
         * * Display Name: Ended At
         * * SQL Data Type: datetime`),
@@ -3727,11 +3727,11 @@ export const DuplicateRunSchema = z.object({
     *   * Rejected
     *   * Approved
     *   * Pending`),
-    ApprovalComments: z.string().nullish().describe(`
+    ApprovalComments: z.string().nullable().describe(`
         * * Field Name: ApprovalComments
         * * Display Name: Approval Comments
         * * SQL Data Type: nvarchar(MAX)`),
-    ApprovedByUserID: z.string().nullish().describe(`
+    ApprovedByUserID: z.string().nullable().describe(`
         * * Field Name: ApprovedByUserID
         * * Display Name: Approved By User ID
         * * SQL Data Type: uniqueidentifier
@@ -3747,7 +3747,7 @@ export const DuplicateRunSchema = z.object({
     *   * Complete
     *   * In Progress
     *   * Pending`),
-    ProcessingErrorMessage: z.string().nullish().describe(`
+    ProcessingErrorMessage: z.string().nullable().describe(`
         * * Field Name: ProcessingErrorMessage
         * * Display Name: Processing Error Message
         * * SQL Data Type: nvarchar(MAX)`),
@@ -3773,7 +3773,7 @@ export const DuplicateRunSchema = z.object({
         * * Field Name: SourceList
         * * Display Name: Source List
         * * SQL Data Type: nvarchar(100)`),
-    ApprovedByUser: z.string().nullish().describe(`
+    ApprovedByUser: z.string().nullable().describe(`
         * * Field Name: ApprovedByUser
         * * Display Name: Approved By User
         * * SQL Data Type: nvarchar(100)`),
@@ -3922,18 +3922,18 @@ export const EmployeeSchema = z.object({
         * * Display Name: Company ID
         * * SQL Data Type: uniqueidentifier
         * * Related Entity/Foreign Key: Companies (vwCompanies.ID)`),
-    SupervisorID: z.string().nullish().describe(`
+    SupervisorID: z.string().nullable().describe(`
         * * Field Name: SupervisorID
         * * Display Name: Supervisor ID
         * * SQL Data Type: uniqueidentifier
         * * Related Entity/Foreign Key: Employees (vwEmployees.ID)`),
-    Title: z.string().nullish().describe(`
+    Title: z.string().nullable().describe(`
         * * Field Name: Title
         * * SQL Data Type: nvarchar(50)`),
     Email: z.string().describe(`
         * * Field Name: Email
         * * SQL Data Type: nvarchar(100)`),
-    Phone: z.string().nullish().describe(`
+    Phone: z.string().nullable().describe(`
         * * Field Name: Phone
         * * SQL Data Type: nvarchar(20)`),
     Active: z.boolean().describe(`
@@ -3950,23 +3950,23 @@ export const EmployeeSchema = z.object({
         * * Display Name: __mj _Updated At
         * * SQL Data Type: datetimeoffset
         * * Default Value: getutcdate()`),
-    FirstLast: z.string().nullish().describe(`
+    FirstLast: z.string().nullable().describe(`
         * * Field Name: FirstLast
         * * Display Name: First Last
         * * SQL Data Type: nvarchar(81)`),
-    Supervisor: z.string().nullish().describe(`
+    Supervisor: z.string().nullable().describe(`
         * * Field Name: Supervisor
         * * Display Name: Supervisor
         * * SQL Data Type: nvarchar(81)`),
-    SupervisorFirstName: z.string().nullish().describe(`
+    SupervisorFirstName: z.string().nullable().describe(`
         * * Field Name: SupervisorFirstName
         * * Display Name: Supervisor First Name
         * * SQL Data Type: nvarchar(30)`),
-    SupervisorLastName: z.string().nullish().describe(`
+    SupervisorLastName: z.string().nullable().describe(`
         * * Field Name: SupervisorLastName
         * * Display Name: Supervisor Last Name
         * * SQL Data Type: nvarchar(50)`),
-    SupervisorEmail: z.string().nullish().describe(`
+    SupervisorEmail: z.string().nullable().describe(`
         * * Field Name: SupervisorEmail
         * * Display Name: Supervisor Email
         * * SQL Data Type: nvarchar(100)`),
@@ -3982,7 +3982,7 @@ export const EntitySchema = z.object({
         * * Field Name: ID
         * * SQL Data Type: uniqueidentifier
         * * Default Value: newsequentialid()`),
-    ParentID: z.string().nullish().describe(`
+    ParentID: z.string().nullable().describe(`
         * * Field Name: ParentID
         * * Display Name: Parent ID
         * * SQL Data Type: uniqueidentifier
@@ -3990,11 +3990,11 @@ export const EntitySchema = z.object({
     Name: z.string().describe(`
         * * Field Name: Name
         * * SQL Data Type: nvarchar(255)`),
-    NameSuffix: z.string().nullish().describe(`
+    NameSuffix: z.string().nullable().describe(`
         * * Field Name: NameSuffix
         * * Display Name: Name Suffix
         * * SQL Data Type: nvarchar(255)`),
-    Description: z.string().nullish().describe(`
+    Description: z.string().nullable().describe(`
         * * Field Name: Description
         * * SQL Data Type: nvarchar(MAX)`),
     AutoUpdateDescription: z.boolean().describe(`
@@ -4092,7 +4092,7 @@ export const EntitySchema = z.object({
         * * Display Name: Full Text Search Enabled
         * * SQL Data Type: bit
         * * Default Value: 0`),
-    FullTextCatalog: z.string().nullish().describe(`
+    FullTextCatalog: z.string().nullable().describe(`
         * * Field Name: FullTextCatalog
         * * Display Name: Full Text Catalog
         * * SQL Data Type: nvarchar(255)`),
@@ -4101,7 +4101,7 @@ export const EntitySchema = z.object({
         * * Display Name: Full Text Catalog Generated
         * * SQL Data Type: bit
         * * Default Value: 1`),
-    FullTextIndex: z.string().nullish().describe(`
+    FullTextIndex: z.string().nullable().describe(`
         * * Field Name: FullTextIndex
         * * Display Name: Full Text Index
         * * SQL Data Type: nvarchar(255)`),
@@ -4110,7 +4110,7 @@ export const EntitySchema = z.object({
         * * Display Name: Full Text Index Generated
         * * SQL Data Type: bit
         * * Default Value: 1`),
-    FullTextSearchFunction: z.string().nullish().describe(`
+    FullTextSearchFunction: z.string().nullable().describe(`
         * * Field Name: FullTextSearchFunction
         * * Display Name: Full Text Search Function
         * * SQL Data Type: nvarchar(255)`),
@@ -4119,20 +4119,20 @@ export const EntitySchema = z.object({
         * * Display Name: Full Text Search Function Generated
         * * SQL Data Type: bit
         * * Default Value: 1`),
-    UserViewMaxRows: z.number().nullish().describe(`
+    UserViewMaxRows: z.number().nullable().describe(`
         * * Field Name: UserViewMaxRows
         * * Display Name: User View Max Rows
         * * SQL Data Type: int
         * * Default Value: 1000`),
-    spCreate: z.string().nullish().describe(`
+    spCreate: z.string().nullable().describe(`
         * * Field Name: spCreate
         * * Display Name: spCreate
         * * SQL Data Type: nvarchar(255)`),
-    spUpdate: z.string().nullish().describe(`
+    spUpdate: z.string().nullable().describe(`
         * * Field Name: spUpdate
         * * Display Name: spUpdate
         * * SQL Data Type: nvarchar(255)`),
-    spDelete: z.string().nullish().describe(`
+    spDelete: z.string().nullable().describe(`
         * * Field Name: spDelete
         * * Display Name: spDelete
         * * SQL Data Type: nvarchar(255)`),
@@ -4173,7 +4173,7 @@ export const EntitySchema = z.object({
         * * SQL Data Type: bit
         * * Default Value: 0
     * * Description: This field must be turned on in order to enable merging of records for the entity. For AllowRecordMerge to be turned on, AllowDeleteAPI must be set to 1, and DeleteType must be set to Soft`),
-    spMatch: z.string().nullish().describe(`
+    spMatch: z.string().nullable().describe(`
         * * Field Name: spMatch
         * * Display Name: sp Match
         * * SQL Data Type: nvarchar(255)
@@ -4193,20 +4193,20 @@ export const EntitySchema = z.object({
         * * Display Name: User Form Generated
         * * SQL Data Type: bit
         * * Default Value: 1`),
-    EntityObjectSubclassName: z.string().nullish().describe(`
+    EntityObjectSubclassName: z.string().nullable().describe(`
         * * Field Name: EntityObjectSubclassName
         * * Display Name: Entity Object Subclass Name
         * * SQL Data Type: nvarchar(255)`),
-    EntityObjectSubclassImport: z.string().nullish().describe(`
+    EntityObjectSubclassImport: z.string().nullable().describe(`
         * * Field Name: EntityObjectSubclassImport
         * * Display Name: Entity Object Subclass Import
         * * SQL Data Type: nvarchar(255)`),
-    PreferredCommunicationField: z.string().nullish().describe(`
+    PreferredCommunicationField: z.string().nullable().describe(`
         * * Field Name: PreferredCommunicationField
         * * Display Name: Preferred Communication Field
         * * SQL Data Type: nvarchar(255)
     * * Description: Used to specify a field within the entity that in turn contains the field name that will be used for record-level communication preferences. For example in a hypothetical entity called Contacts, say there is a field called PreferredComm and that field had possible values of Email1, SMS, and Phone, and those value in turn corresponded to field names in the entity. Each record in the Contacts entity could have a specific preference for which field would be used for communication. The MJ Communication Framework will use this information when available, as a priority ahead of the data in the Entity Communication Fields entity which is entity-level and not record-level.`),
-    Icon: z.string().nullish().describe(`
+    Icon: z.string().nullable().describe(`
         * * Field Name: Icon
         * * Display Name: Icon
         * * SQL Data Type: nvarchar(500)
@@ -4221,7 +4221,7 @@ export const EntitySchema = z.object({
         * * Display Name: __mj _Updated At
         * * SQL Data Type: datetimeoffset
         * * Default Value: getutcdate()`),
-    ScopeDefault: z.string().nullish().describe(`
+    ScopeDefault: z.string().nullable().describe(`
         * * Field Name: ScopeDefault
         * * Display Name: Scope Default
         * * SQL Data Type: nvarchar(100)
@@ -4254,32 +4254,32 @@ export const EntitySchema = z.object({
         * * SQL Data Type: int
         * * Default Value: 0
     * * Description: The number of rows to pack when RowsToPackWithSchema is set to Sample, based on the designated sampling method. Defaults to 0.`),
-    RowsToPackSampleOrder: z.string().nullish().describe(`
+    RowsToPackSampleOrder: z.string().nullable().describe(`
         * * Field Name: RowsToPackSampleOrder
         * * Display Name: Rows To Pack Sample Order
         * * SQL Data Type: nvarchar(MAX)
     * * Description: An optional ORDER BY clause for row packing when RowsToPackWithSchema is set to Sample. Allows custom ordering for selected entity data when using top n and bottom n.`),
-    CodeName: z.string().nullish().describe(`
+    CodeName: z.string().nullable().describe(`
         * * Field Name: CodeName
         * * Display Name: Code Name
         * * SQL Data Type: nvarchar(MAX)`),
-    ClassName: z.string().nullish().describe(`
+    ClassName: z.string().nullable().describe(`
         * * Field Name: ClassName
         * * Display Name: Class Name
         * * SQL Data Type: nvarchar(MAX)`),
-    BaseTableCodeName: z.string().nullish().describe(`
+    BaseTableCodeName: z.string().nullable().describe(`
         * * Field Name: BaseTableCodeName
         * * Display Name: Base Table Code Name
         * * SQL Data Type: nvarchar(MAX)`),
-    ParentEntity: z.string().nullish().describe(`
+    ParentEntity: z.string().nullable().describe(`
         * * Field Name: ParentEntity
         * * Display Name: Parent Entity
         * * SQL Data Type: nvarchar(255)`),
-    ParentBaseTable: z.string().nullish().describe(`
+    ParentBaseTable: z.string().nullable().describe(`
         * * Field Name: ParentBaseTable
         * * Display Name: Parent Base Table
         * * SQL Data Type: nvarchar(255)`),
-    ParentBaseView: z.string().nullish().describe(`
+    ParentBaseView: z.string().nullable().describe(`
         * * Field Name: ParentBaseView
         * * Display Name: Parent Base View
         * * SQL Data Type: nvarchar(255)`),
@@ -4350,7 +4350,7 @@ export const EntityActionInvocationTypeSchema = z.object({
         * * Display Name: Name
         * * SQL Data Type: nvarchar(255)
     * * Description: Name of the invocation type such as Record Created/Updated/etc.`),
-    Description: z.string().nullish().describe(`
+    Description: z.string().nullable().describe(`
         * * Field Name: Description
         * * Display Name: Description
         * * SQL Data Type: nvarchar(MAX)
@@ -4452,12 +4452,12 @@ export const EntityActionParamSchema = z.object({
     *   * Script
     *   * Entity Field
     * * Description: Type of the value, which can be Static, Entity Object, or Script.`),
-    Value: z.string().nullish().describe(`
+    Value: z.string().nullable().describe(`
         * * Field Name: Value
         * * Display Name: Value
         * * SQL Data Type: nvarchar(MAX)
     * * Description: Value of the parameter, used only when ValueType is Static or Script. When value is Script, any valid JavaScript code can be provided. The script will have access to an object called EntityActionContext. This object will have a property called EntityObject on it that will contain the BaseEntity derived sub-class with the current data for the entity object this action is operating against. The script must provide the parameter value to the EntityActionContext.result property. This scripting capabilty is designed for very small and simple code, for anything of meaningful complexity, create a sub-class instead.`),
-    Comments: z.string().nullish().describe(`
+    Comments: z.string().nullable().describe(`
         * * Field Name: Comments
         * * Display Name: Comments
         * * SQL Data Type: nvarchar(MAX)
@@ -4560,7 +4560,7 @@ export const EntityAIActionSchema = z.object({
         * * Field Name: Name
         * * Display Name: Name
         * * SQL Data Type: nvarchar(255)`),
-    Prompt: z.string().nullish().describe(`
+    Prompt: z.string().nullable().describe(`
         * * Field Name: Prompt
         * * Display Name: Prompt
         * * SQL Data Type: nvarchar(MAX)`),
@@ -4586,7 +4586,7 @@ export const EntityAIActionSchema = z.object({
     * * Possible Values 
     *   * entity
     *   * field`),
-    OutputField: z.string().nullish().describe(`
+    OutputField: z.string().nullable().describe(`
         * * Field Name: OutputField
         * * Display Name: Output Field
         * * SQL Data Type: nvarchar(50)`),
@@ -4595,12 +4595,12 @@ export const EntityAIActionSchema = z.object({
         * * Display Name: Skip If Output Field Not Empty
         * * SQL Data Type: bit
         * * Default Value: 1`),
-    OutputEntityID: z.string().nullish().describe(`
+    OutputEntityID: z.string().nullable().describe(`
         * * Field Name: OutputEntityID
         * * Display Name: Output Entity ID
         * * SQL Data Type: uniqueidentifier
         * * Related Entity/Foreign Key: Entities (vwEntities.ID)`),
-    Comments: z.string().nullish().describe(`
+    Comments: z.string().nullable().describe(`
         * * Field Name: Comments
         * * Display Name: Comments
         * * SQL Data Type: nvarchar(MAX)`),
@@ -4626,7 +4626,7 @@ export const EntityAIActionSchema = z.object({
         * * Field Name: AIAction
         * * Display Name: AIAction
         * * SQL Data Type: nvarchar(50)`),
-    OutputEntity: z.string().nullish().describe(`
+    OutputEntity: z.string().nullable().describe(`
         * * Field Name: OutputEntity
         * * Display Name: Output Entity
         * * SQL Data Type: nvarchar(255)`),
@@ -4733,11 +4733,11 @@ export const EntityDocumentRunSchema = z.object({
         * * Display Name: Entity Document ID
         * * SQL Data Type: uniqueidentifier
         * * Related Entity/Foreign Key: Entity Documents (vwEntityDocuments.ID)`),
-    StartedAt: z.date().nullish().describe(`
+    StartedAt: z.date().nullable().describe(`
         * * Field Name: StartedAt
         * * Display Name: Started At
         * * SQL Data Type: datetime`),
-    EndedAt: z.date().nullish().describe(`
+    EndedAt: z.date().nullable().describe(`
         * * Field Name: EndedAt
         * * Display Name: Ended At
         * * SQL Data Type: datetime`),
@@ -4792,7 +4792,7 @@ export const EntityDocumentSettingSchema = z.object({
         * * Field Name: Value
         * * Display Name: Value
         * * SQL Data Type: nvarchar(MAX)`),
-    Comments: z.string().nullish().describe(`
+    Comments: z.string().nullable().describe(`
         * * Field Name: Comments
         * * Display Name: Comments
         * * SQL Data Type: nvarchar(MAX)`),
@@ -4827,7 +4827,7 @@ export const EntityDocumentTypeSchema = z.object({
         * * Field Name: Name
         * * Display Name: Name
         * * SQL Data Type: nvarchar(100)`),
-    Description: z.string().nullish().describe(`
+    Description: z.string().nullable().describe(`
         * * Field Name: Description
         * * Display Name: Description
         * * SQL Data Type: nvarchar(MAX)`),
@@ -4960,11 +4960,11 @@ export const EntityFieldValueSchema = z.object({
         * * Field Name: Value
         * * Display Name: Value
         * * SQL Data Type: nvarchar(255)`),
-    Code: z.string().nullish().describe(`
+    Code: z.string().nullable().describe(`
         * * Field Name: Code
         * * Display Name: Code
         * * SQL Data Type: nvarchar(50)`),
-    Description: z.string().nullish().describe(`
+    Description: z.string().nullable().describe(`
         * * Field Name: Description
         * * Display Name: Description
         * * SQL Data Type: nvarchar(MAX)`),
@@ -5016,12 +5016,12 @@ export const EntityFieldSchema = z.object({
         * * Field Name: Name
         * * SQL Data Type: nvarchar(255)
     * * Description: Name of the field within the database table`),
-    DisplayName: z.string().nullish().describe(`
+    DisplayName: z.string().nullable().describe(`
         * * Field Name: DisplayName
         * * Display Name: Display Name
         * * SQL Data Type: nvarchar(255)
     * * Description: A user friendly alternative to the field name`),
-    Description: z.string().nullish().describe(`
+    Description: z.string().nullable().describe(`
         * * Field Name: Description
         * * SQL Data Type: nvarchar(MAX)
     * * Description: Descriptive text explaining the purpose of the field`),
@@ -5043,7 +5043,7 @@ export const EntityFieldSchema = z.object({
         * * SQL Data Type: bit
         * * Default Value: 0
     * * Description: Indicates if the field must have unique values within the entity.`),
-    Category: z.string().nullish().describe(`
+    Category: z.string().nullable().describe(`
         * * Field Name: Category
         * * Display Name: Category
         * * SQL Data Type: nvarchar(255)
@@ -5052,15 +5052,15 @@ export const EntityFieldSchema = z.object({
         * * Field Name: Type
         * * SQL Data Type: nvarchar(100)
     * * Description: SQL Data type (auto maintained by CodeGen)`),
-    Length: z.number().nullish().describe(`
+    Length: z.number().nullable().describe(`
         * * Field Name: Length
         * * SQL Data Type: int
     * * Description: SQL data length (auto maintained by CodeGen)`),
-    Precision: z.number().nullish().describe(`
+    Precision: z.number().nullable().describe(`
         * * Field Name: Precision
         * * SQL Data Type: int
     * * Description: SQL precision (auto maintained by CodeGen)`),
-    Scale: z.number().nullish().describe(`
+    Scale: z.number().nullable().describe(`
         * * Field Name: Scale
         * * SQL Data Type: int
     * * Description: SQL scale (auto maintained by CodeGen)`),
@@ -5070,7 +5070,7 @@ export const EntityFieldSchema = z.object({
         * * SQL Data Type: bit
         * * Default Value: 1
     * * Description: Does the column allow null or not (auto maintained by CodeGen)`),
-    DefaultValue: z.string().nullish().describe(`
+    DefaultValue: z.string().nullable().describe(`
         * * Field Name: DefaultValue
         * * Display Name: Default Value
         * * SQL Data Type: nvarchar(255)
@@ -5092,7 +5092,7 @@ export const EntityFieldSchema = z.object({
     *   * List
     *   * ListOrUserEntry
     * * Description: Possible Values of None, List, ListOrUserEntry - the last option meaning that the list of possible values are options, but a user can enter anything else desired too.`),
-    ExtendedType: z.union([z.literal('Email'), z.literal('URL'), z.literal('Tel'), z.literal('SMS'), z.literal('Geo'), z.literal('WhatsApp'), z.literal('FaceTime'), z.literal('Skype'), z.literal('SIP'), z.literal('MSTeams'), z.literal('ZoomMtg'), z.literal('Other'), z.literal('Code')]).nullish().describe(`
+    ExtendedType: z.union([z.literal('Email'), z.literal('URL'), z.literal('Tel'), z.literal('SMS'), z.literal('Geo'), z.literal('WhatsApp'), z.literal('FaceTime'), z.literal('Skype'), z.literal('SIP'), z.literal('MSTeams'), z.literal('ZoomMtg'), z.literal('Other'), z.literal('Code')]).nullable().describe(`
         * * Field Name: ExtendedType
         * * Display Name: Extended Type
         * * SQL Data Type: nvarchar(50)
@@ -5112,7 +5112,7 @@ export const EntityFieldSchema = z.object({
     *   * Other
     *   * Code
     * * Description: Defines extended behaviors for a field such as for Email, Web URLs, Code, etc.`),
-    CodeType: z.union([z.literal('TypeScript'), z.literal('SQL'), z.literal('HTML'), z.literal('CSS'), z.literal('JavaScript'), z.literal('Other')]).nullish().describe(`
+    CodeType: z.union([z.literal('TypeScript'), z.literal('SQL'), z.literal('HTML'), z.literal('CSS'), z.literal('JavaScript'), z.literal('Other')]).nullable().describe(`
         * * Field Name: CodeType
         * * Display Name: Code Type
         * * SQL Data Type: nvarchar(50)
@@ -5131,12 +5131,12 @@ export const EntityFieldSchema = z.object({
         * * SQL Data Type: bit
         * * Default Value: 0
     * * Description: If set to 1, this field will be included by default in any new view created by a user.`),
-    ViewCellTemplate: z.string().nullish().describe(`
+    ViewCellTemplate: z.string().nullable().describe(`
         * * Field Name: ViewCellTemplate
         * * Display Name: View Cell Template
         * * SQL Data Type: nvarchar(MAX)
     * * Description: NULL`),
-    DefaultColumnWidth: z.number().nullish().describe(`
+    DefaultColumnWidth: z.number().nullable().describe(`
         * * Field Name: DefaultColumnWidth
         * * Display Name: Default Column Width
         * * SQL Data Type: int
@@ -5165,7 +5165,7 @@ export const EntityFieldSchema = z.object({
         * * SQL Data Type: bit
         * * Default Value: 0
     * * Description: If set to 1, CodeGen will automatically generate a Full Text Catalog/Index in the database and include this field in the search index.`),
-    UserSearchParamFormatAPI: z.string().nullish().describe(`
+    UserSearchParamFormatAPI: z.string().nullable().describe(`
         * * Field Name: UserSearchParamFormatAPI
         * * Display Name: User Search Param Format API
         * * SQL Data Type: nvarchar(500)
@@ -5199,12 +5199,12 @@ export const EntityFieldSchema = z.object({
         * * SQL Data Type: bit
         * * Default Value: 0
     * * Description: If set to 1, this column will be used as the "Name" field for the entity and will be used to display the name of the record in various places in the UI.`),
-    RelatedEntityID: z.string().nullish().describe(`
+    RelatedEntityID: z.string().nullable().describe(`
         * * Field Name: RelatedEntityID
         * * Display Name: RelatedEntity ID
         * * SQL Data Type: uniqueidentifier
         * * Related Entity/Foreign Key: Entities (vwEntities.ID)`),
-    RelatedEntityFieldName: z.string().nullish().describe(`
+    RelatedEntityFieldName: z.string().nullable().describe(`
         * * Field Name: RelatedEntityFieldName
         * * Display Name: Related Entity Field Name
         * * SQL Data Type: nvarchar(255)
@@ -5215,7 +5215,7 @@ export const EntityFieldSchema = z.object({
         * * SQL Data Type: bit
         * * Default Value: 1
     * * Description: If set to 1, the "Name" field of the Related Entity will be included in this entity as a virtual field`),
-    RelatedEntityNameFieldMap: z.string().nullish().describe(`
+    RelatedEntityNameFieldMap: z.string().nullable().describe(`
         * * Field Name: RelatedEntityNameFieldMap
         * * Display Name: Related Entity Name Field Map
         * * SQL Data Type: nvarchar(255)`),
@@ -5225,7 +5225,7 @@ export const EntityFieldSchema = z.object({
         * * SQL Data Type: nvarchar(20)
         * * Default Value: Search
     * * Description: Controls the generated form in the MJ Explorer UI - defaults to a search box, other option is a drop down. Possible values are Search and Dropdown`),
-    EntityIDFieldName: z.string().nullish().describe(`
+    EntityIDFieldName: z.string().nullable().describe(`
         * * Field Name: EntityIDFieldName
         * * Display Name: Entity IDField Name
         * * SQL Data Type: nvarchar(100)
@@ -5240,7 +5240,7 @@ export const EntityFieldSchema = z.object({
         * * Display Name: __mj _Updated At
         * * SQL Data Type: datetimeoffset
         * * Default Value: getutcdate()`),
-    ScopeDefault: z.string().nullish().describe(`
+    ScopeDefault: z.string().nullable().describe(`
         * * Field Name: ScopeDefault
         * * Display Name: Scope Default
         * * SQL Data Type: nvarchar(100)
@@ -5262,27 +5262,27 @@ export const EntityFieldSchema = z.object({
     *   * None
     *   * All
     * * Description: Determines whether values for the field should be included when the schema is packed. Options: Auto (include manually set or auto-derived values), None (exclude all values), All (include all distinct values from the table). Defaults to Auto.`),
-    GeneratedValidationFunctionName: z.string().nullish().describe(`
+    GeneratedValidationFunctionName: z.string().nullable().describe(`
         * * Field Name: GeneratedValidationFunctionName
         * * Display Name: Generated Validation Function Name
         * * SQL Data Type: nvarchar(255)
     * * Description: Contains the name of the generated field validation function, if it exists, null otherwise`),
-    GeneratedValidationFunctionDescription: z.string().nullish().describe(`
+    GeneratedValidationFunctionDescription: z.string().nullable().describe(`
         * * Field Name: GeneratedValidationFunctionDescription
         * * Display Name: Generated Validation Function Description
         * * SQL Data Type: nvarchar(MAX)
     * * Description: Contains a description for business users of what the validation function for this field does, if it exists`),
-    GeneratedValidationFunctionCode: z.string().nullish().describe(`
+    GeneratedValidationFunctionCode: z.string().nullable().describe(`
         * * Field Name: GeneratedValidationFunctionCode
         * * Display Name: Generated Validation Function Code
         * * SQL Data Type: nvarchar(MAX)
     * * Description: Contains the generated code for the field validation function, if it exists, null otherwise.`),
-    GeneratedValidationFunctionCheckConstraint: z.string().nullish().describe(`
+    GeneratedValidationFunctionCheckConstraint: z.string().nullable().describe(`
         * * Field Name: GeneratedValidationFunctionCheckConstraint
         * * Display Name: Generated Validation Function Check Constraint
         * * SQL Data Type: nvarchar(MAX)
     * * Description: If a generated validation function was generated previously, this stores the text from the source CHECK constraint in the database. This is stored so that regeneration of the validation function will only occur when the source CHECK constraint changes.`),
-    FieldCodeName: z.string().nullish().describe(`
+    FieldCodeName: z.string().nullable().describe(`
         * * Field Name: FieldCodeName
         * * Display Name: Field Code Name
         * * SQL Data Type: nvarchar(MAX)`),
@@ -5301,35 +5301,35 @@ export const EntityFieldSchema = z.object({
         * * Field Name: BaseView
         * * Display Name: Base View
         * * SQL Data Type: nvarchar(255)`),
-    EntityCodeName: z.string().nullish().describe(`
+    EntityCodeName: z.string().nullable().describe(`
         * * Field Name: EntityCodeName
         * * Display Name: Entity Code Name
         * * SQL Data Type: nvarchar(MAX)`),
-    EntityClassName: z.string().nullish().describe(`
+    EntityClassName: z.string().nullable().describe(`
         * * Field Name: EntityClassName
         * * Display Name: Entity Class Name
         * * SQL Data Type: nvarchar(MAX)`),
-    RelatedEntity: z.string().nullish().describe(`
+    RelatedEntity: z.string().nullable().describe(`
         * * Field Name: RelatedEntity
         * * Display Name: Related Entity
         * * SQL Data Type: nvarchar(255)`),
-    RelatedEntitySchemaName: z.string().nullish().describe(`
+    RelatedEntitySchemaName: z.string().nullable().describe(`
         * * Field Name: RelatedEntitySchemaName
         * * Display Name: Related Entity Schema Name
         * * SQL Data Type: nvarchar(255)`),
-    RelatedEntityBaseTable: z.string().nullish().describe(`
+    RelatedEntityBaseTable: z.string().nullable().describe(`
         * * Field Name: RelatedEntityBaseTable
         * * Display Name: Related Entity Base Table
         * * SQL Data Type: nvarchar(255)`),
-    RelatedEntityBaseView: z.string().nullish().describe(`
+    RelatedEntityBaseView: z.string().nullable().describe(`
         * * Field Name: RelatedEntityBaseView
         * * Display Name: Related Entity Base View
         * * SQL Data Type: nvarchar(255)`),
-    RelatedEntityCodeName: z.string().nullish().describe(`
+    RelatedEntityCodeName: z.string().nullable().describe(`
         * * Field Name: RelatedEntityCodeName
         * * Display Name: Related Entity Code Name
         * * SQL Data Type: nvarchar(MAX)`),
-    RelatedEntityClassName: z.string().nullish().describe(`
+    RelatedEntityClassName: z.string().nullable().describe(`
         * * Field Name: RelatedEntityClassName
         * * Display Name: Related Entity Class Name
         * * SQL Data Type: nvarchar(MAX)`),
@@ -5375,22 +5375,22 @@ export const EntityPermissionSchema = z.object({
         * * Display Name: Can Delete
         * * SQL Data Type: bit
         * * Default Value: 0`),
-    ReadRLSFilterID: z.string().nullish().describe(`
+    ReadRLSFilterID: z.string().nullable().describe(`
         * * Field Name: ReadRLSFilterID
         * * Display Name: Read RLSFilter ID
         * * SQL Data Type: uniqueidentifier
         * * Related Entity/Foreign Key: Row Level Security Filters (vwRowLevelSecurityFilters.ID)`),
-    CreateRLSFilterID: z.string().nullish().describe(`
+    CreateRLSFilterID: z.string().nullable().describe(`
         * * Field Name: CreateRLSFilterID
         * * Display Name: Create RLSFilter ID
         * * SQL Data Type: uniqueidentifier
         * * Related Entity/Foreign Key: Row Level Security Filters (vwRowLevelSecurityFilters.ID)`),
-    UpdateRLSFilterID: z.string().nullish().describe(`
+    UpdateRLSFilterID: z.string().nullable().describe(`
         * * Field Name: UpdateRLSFilterID
         * * Display Name: Update RLSFilter ID
         * * SQL Data Type: uniqueidentifier
         * * Related Entity/Foreign Key: Row Level Security Filters (vwRowLevelSecurityFilters.ID)`),
-    DeleteRLSFilterID: z.string().nullish().describe(`
+    DeleteRLSFilterID: z.string().nullable().describe(`
         * * Field Name: DeleteRLSFilterID
         * * Display Name: Delete RLSFilter ID
         * * SQL Data Type: uniqueidentifier
@@ -5413,23 +5413,23 @@ export const EntityPermissionSchema = z.object({
         * * Field Name: RoleName
         * * Display Name: Role Name
         * * SQL Data Type: nvarchar(50)`),
-    RoleSQLName: z.string().nullish().describe(`
+    RoleSQLName: z.string().nullable().describe(`
         * * Field Name: RoleSQLName
         * * Display Name: Role SQLName
         * * SQL Data Type: nvarchar(250)`),
-    CreateRLSFilter: z.string().nullish().describe(`
+    CreateRLSFilter: z.string().nullable().describe(`
         * * Field Name: CreateRLSFilter
         * * Display Name: Create RLSFilter
         * * SQL Data Type: nvarchar(100)`),
-    ReadRLSFilter: z.string().nullish().describe(`
+    ReadRLSFilter: z.string().nullable().describe(`
         * * Field Name: ReadRLSFilter
         * * Display Name: Read RLSFilter
         * * SQL Data Type: nvarchar(100)`),
-    UpdateRLSFilter: z.string().nullish().describe(`
+    UpdateRLSFilter: z.string().nullable().describe(`
         * * Field Name: UpdateRLSFilter
         * * Display Name: Update RLSFilter
         * * SQL Data Type: nvarchar(100)`),
-    DeleteRLSFilter: z.string().nullish().describe(`
+    DeleteRLSFilter: z.string().nullable().describe(`
         * * Field Name: DeleteRLSFilter
         * * Display Name: Delete RLSFilter
         * * SQL Data Type: nvarchar(100)`),
@@ -5460,7 +5460,7 @@ export const EntityRecordDocumentSchema = z.object({
         * * Display Name: Entity Document ID
         * * SQL Data Type: uniqueidentifier
         * * Related Entity/Foreign Key: Entity Documents (vwEntityDocuments.ID)`),
-    DocumentText: z.string().nullish().describe(`
+    DocumentText: z.string().nullable().describe(`
         * * Field Name: DocumentText
         * * Display Name: Document Text
         * * SQL Data Type: nvarchar(MAX)`),
@@ -5469,11 +5469,11 @@ export const EntityRecordDocumentSchema = z.object({
         * * Display Name: Vector Index ID
         * * SQL Data Type: uniqueidentifier
         * * Related Entity/Foreign Key: Vector Indexes (vwVectorIndexes.ID)`),
-    VectorID: z.string().nullish().describe(`
+    VectorID: z.string().nullable().describe(`
         * * Field Name: VectorID
         * * Display Name: Vector ID
         * * SQL Data Type: nvarchar(50)`),
-    VectorJSON: z.string().nullish().describe(`
+    VectorJSON: z.string().nullable().describe(`
         * * Field Name: VectorJSON
         * * Display Name: Vector JSON
         * * SQL Data Type: nvarchar(MAX)`),
@@ -5520,7 +5520,7 @@ export const EntityRelationshipDisplayComponentSchema = z.object({
         * * Field Name: Name
         * * Display Name: Name
         * * SQL Data Type: nvarchar(255)`),
-    Description: z.string().nullish().describe(`
+    Description: z.string().nullable().describe(`
         * * Field Name: Description
         * * Display Name: Description
         * * SQL Data Type: nvarchar(MAX)`),
@@ -5590,7 +5590,7 @@ export const EntityRelationshipSchema = z.object({
     * * Possible Values 
     *   * One To Many
     *   * Many To Many`),
-    EntityKeyField: z.string().nullish().describe(`
+    EntityKeyField: z.string().nullable().describe(`
         * * Field Name: EntityKeyField
         * * Display Name: Entity Key Field
         * * SQL Data Type: nvarchar(255)`),
@@ -5598,15 +5598,15 @@ export const EntityRelationshipSchema = z.object({
         * * Field Name: RelatedEntityJoinField
         * * Display Name: Related Entity Join Field
         * * SQL Data Type: nvarchar(255)`),
-    JoinView: z.string().nullish().describe(`
+    JoinView: z.string().nullable().describe(`
         * * Field Name: JoinView
         * * Display Name: Join View
         * * SQL Data Type: nvarchar(255)`),
-    JoinEntityJoinField: z.string().nullish().describe(`
+    JoinEntityJoinField: z.string().nullable().describe(`
         * * Field Name: JoinEntityJoinField
         * * Display Name: Join Entity Join Field
         * * SQL Data Type: nvarchar(255)`),
-    JoinEntityInverseJoinField: z.string().nullish().describe(`
+    JoinEntityInverseJoinField: z.string().nullable().describe(`
         * * Field Name: JoinEntityInverseJoinField
         * * Display Name: Join Entity Inverse Join Field
         * * SQL Data Type: nvarchar(255)`),
@@ -5625,7 +5625,7 @@ export const EntityRelationshipSchema = z.object({
     * * Possible Values 
     *   * After Field Tabs
     *   * Before Field Tabs`),
-    DisplayName: z.string().nullish().describe(`
+    DisplayName: z.string().nullable().describe(`
         * * Field Name: DisplayName
         * * Display Name: Display Name
         * * SQL Data Type: nvarchar(255)
@@ -5641,22 +5641,22 @@ export const EntityRelationshipSchema = z.object({
     *   * Custom
     *   * None
     * * Description: When Related Entity Icon - uses the icon from the related entity, if one exists. When Custom, uses the value in the DisplayIcon field in this record, and when None, no icon is displayed`),
-    DisplayIcon: z.string().nullish().describe(`
+    DisplayIcon: z.string().nullable().describe(`
         * * Field Name: DisplayIcon
         * * Display Name: Display Icon
         * * SQL Data Type: nvarchar(255)
     * * Description: If specified, the icon `),
-    DisplayUserViewID: z.string().nullish().describe(`
+    DisplayUserViewID: z.string().nullable().describe(`
         * * Field Name: DisplayUserViewID
         * * Display Name: Display User View ID
         * * SQL Data Type: uniqueidentifier
         * * Related Entity/Foreign Key: User Views (vwUserViews.ID)`),
-    DisplayComponentID: z.string().nullish().describe(`
+    DisplayComponentID: z.string().nullable().describe(`
         * * Field Name: DisplayComponentID
         * * Display Name: Display Component ID
         * * SQL Data Type: uniqueidentifier
         * * Related Entity/Foreign Key: Entity Relationship Display Components (vwEntityRelationshipDisplayComponents.ID)`),
-    DisplayComponentConfiguration: z.string().nullish().describe(`
+    DisplayComponentConfiguration: z.string().nullable().describe(`
         * * Field Name: DisplayComponentConfiguration
         * * Display Name: Display Component Configuration
         * * SQL Data Type: nvarchar(MAX)
@@ -5700,19 +5700,19 @@ export const EntityRelationshipSchema = z.object({
         * * Field Name: RelatedEntityBaseView
         * * Display Name: Related Entity Base View
         * * SQL Data Type: nvarchar(255)`),
-    RelatedEntityClassName: z.string().nullish().describe(`
+    RelatedEntityClassName: z.string().nullable().describe(`
         * * Field Name: RelatedEntityClassName
         * * Display Name: Related Entity Class Name
         * * SQL Data Type: nvarchar(MAX)`),
-    RelatedEntityCodeName: z.string().nullish().describe(`
+    RelatedEntityCodeName: z.string().nullable().describe(`
         * * Field Name: RelatedEntityCodeName
         * * Display Name: Related Entity Code Name
         * * SQL Data Type: nvarchar(MAX)`),
-    RelatedEntityBaseTableCodeName: z.string().nullish().describe(`
+    RelatedEntityBaseTableCodeName: z.string().nullable().describe(`
         * * Field Name: RelatedEntityBaseTableCodeName
         * * Display Name: Related Entity Base Table Code Name
         * * SQL Data Type: nvarchar(MAX)`),
-    DisplayUserViewName: z.string().nullish().describe(`
+    DisplayUserViewName: z.string().nullable().describe(`
         * * Field Name: DisplayUserViewName
         * * Display Name: Display User View Name
         * * SQL Data Type: nvarchar(100)`),
@@ -5742,7 +5742,7 @@ export const EntitySettingSchema = z.object({
         * * Field Name: Value
         * * Display Name: Value
         * * SQL Data Type: nvarchar(MAX)`),
-    Comments: z.string().nullish().describe(`
+    Comments: z.string().nullable().describe(`
         * * Field Name: Comments
         * * Display Name: Comments
         * * SQL Data Type: nvarchar(MAX)`),
@@ -5772,34 +5772,34 @@ export const ErrorLogSchema = z.object({
         * * Field Name: ID
         * * SQL Data Type: uniqueidentifier
         * * Default Value: newsequentialid()`),
-    CompanyIntegrationRunID: z.string().nullish().describe(`
+    CompanyIntegrationRunID: z.string().nullable().describe(`
         * * Field Name: CompanyIntegrationRunID
         * * Display Name: CompanyIntegrationRun ID
         * * SQL Data Type: uniqueidentifier
         * * Related Entity/Foreign Key: Company Integration Runs (vwCompanyIntegrationRuns.ID)`),
-    CompanyIntegrationRunDetailID: z.string().nullish().describe(`
+    CompanyIntegrationRunDetailID: z.string().nullable().describe(`
         * * Field Name: CompanyIntegrationRunDetailID
         * * Display Name: CompanyIntegrationRunDetail ID
         * * SQL Data Type: uniqueidentifier
         * * Related Entity/Foreign Key: Company Integration Run Details (vwCompanyIntegrationRunDetails.ID)`),
-    Code: z.string().nullish().describe(`
+    Code: z.string().nullable().describe(`
         * * Field Name: Code
         * * SQL Data Type: nchar(20)`),
-    Message: z.string().nullish().describe(`
+    Message: z.string().nullable().describe(`
         * * Field Name: Message
         * * SQL Data Type: nvarchar(MAX)`),
-    CreatedBy: z.string().nullish().describe(`
+    CreatedBy: z.string().nullable().describe(`
         * * Field Name: CreatedBy
         * * Display Name: Created By
         * * SQL Data Type: nvarchar(50)
         * * Default Value: suser_name()`),
-    Status: z.string().nullish().describe(`
+    Status: z.string().nullable().describe(`
         * * Field Name: Status
         * * SQL Data Type: nvarchar(10)`),
-    Category: z.string().nullish().describe(`
+    Category: z.string().nullable().describe(`
         * * Field Name: Category
         * * SQL Data Type: nvarchar(20)`),
-    Details: z.string().nullish().describe(`
+    Details: z.string().nullable().describe(`
         * * Field Name: Details
         * * SQL Data Type: nvarchar(MAX)`),
     __mj_CreatedAt: z.date().describe(`
@@ -5859,17 +5859,17 @@ export const ExplorerNavigationItemSchema = z.object({
         * * SQL Data Type: bit
         * * Default Value: 0
     * * Description: Controls if the item is shown in the left navigation drawer in the MJ Explorer app or not.`),
-    IconCSSClass: z.string().nullish().describe(`
+    IconCSSClass: z.string().nullable().describe(`
         * * Field Name: IconCSSClass
         * * Display Name: Icon CSSClass
         * * SQL Data Type: nvarchar(100)
     * * Description: Optional, CSS class for an icon to be displayed with the navigation item`),
-    Description: z.string().nullish().describe(`
+    Description: z.string().nullable().describe(`
         * * Field Name: Description
         * * Display Name: Description
         * * SQL Data Type: nvarchar(MAX)
     * * Description: Description of the navigation item, shown to the user on hover or in larger displays`),
-    Comments: z.string().nullish().describe(`
+    Comments: z.string().nullable().describe(`
         * * Field Name: Comments
         * * Display Name: Comments
         * * SQL Data Type: nvarchar(MAX)
@@ -5901,12 +5901,12 @@ export const FileCategorySchema = z.object({
         * * Field Name: Name
         * * Display Name: Name
         * * SQL Data Type: nvarchar(255)`),
-    ParentID: z.string().nullish().describe(`
+    ParentID: z.string().nullable().describe(`
         * * Field Name: ParentID
         * * Display Name: Parent ID
         * * SQL Data Type: uniqueidentifier
         * * Related Entity/Foreign Key: File Categories (vwFileCategories.ID)`),
-    Description: z.string().nullish().describe(`
+    Description: z.string().nullable().describe(`
         * * Field Name: Description
         * * Display Name: Description
         * * SQL Data Type: nvarchar(MAX)`),
@@ -5920,7 +5920,7 @@ export const FileCategorySchema = z.object({
         * * Display Name: Updated At
         * * SQL Data Type: datetimeoffset
         * * Default Value: getutcdate()`),
-    Parent: z.string().nullish().describe(`
+    Parent: z.string().nullable().describe(`
         * * Field Name: Parent
         * * Display Name: Parent
         * * SQL Data Type: nvarchar(255)`),
@@ -5986,7 +5986,7 @@ export const FileStorageProviderSchema = z.object({
         * * Field Name: Name
         * * Display Name: Name
         * * SQL Data Type: nvarchar(50)`),
-    Description: z.string().nullish().describe(`
+    Description: z.string().nullable().describe(`
         * * Field Name: Description
         * * Display Name: Description
         * * SQL Data Type: nvarchar(MAX)`),
@@ -6035,11 +6035,11 @@ export const FileSchema = z.object({
         * * Field Name: Name
         * * Display Name: Name
         * * SQL Data Type: nvarchar(500)`),
-    Description: z.string().nullish().describe(`
+    Description: z.string().nullable().describe(`
         * * Field Name: Description
         * * Display Name: Description
         * * SQL Data Type: nvarchar(MAX)`),
-    CategoryID: z.string().nullish().describe(`
+    CategoryID: z.string().nullable().describe(`
         * * Field Name: CategoryID
         * * Display Name: Category ID
         * * SQL Data Type: uniqueidentifier
@@ -6049,11 +6049,11 @@ export const FileSchema = z.object({
         * * Display Name: Provider ID
         * * SQL Data Type: uniqueidentifier
         * * Related Entity/Foreign Key: File Storage Providers (vwFileStorageProviders.ID)`),
-    ContentType: z.string().nullish().describe(`
+    ContentType: z.string().nullable().describe(`
         * * Field Name: ContentType
         * * Display Name: Content Type
         * * SQL Data Type: nvarchar(50)`),
-    ProviderKey: z.string().nullish().describe(`
+    ProviderKey: z.string().nullable().describe(`
         * * Field Name: ProviderKey
         * * Display Name: Provider Key
         * * SQL Data Type: nvarchar(500)`),
@@ -6073,7 +6073,7 @@ export const FileSchema = z.object({
         * * Display Name: Updated At
         * * SQL Data Type: datetimeoffset
         * * Default Value: getutcdate()`),
-    Category: z.string().nullish().describe(`
+    Category: z.string().nullable().describe(`
         * * Field Name: Category
         * * Display Name: Category
         * * SQL Data Type: nvarchar(255)`),
@@ -6098,11 +6098,11 @@ export const GeneratedCodeCategorySchema = z.object({
         * * Field Name: Name
         * * Display Name: Name
         * * SQL Data Type: nvarchar(255)`),
-    Description: z.string().nullish().describe(`
+    Description: z.string().nullable().describe(`
         * * Field Name: Description
         * * Display Name: Description
         * * SQL Data Type: nvarchar(MAX)`),
-    ParentID: z.string().nullish().describe(`
+    ParentID: z.string().nullable().describe(`
         * * Field Name: ParentID
         * * Display Name: Parent ID
         * * SQL Data Type: uniqueidentifier
@@ -6118,7 +6118,7 @@ export const GeneratedCodeCategorySchema = z.object({
         * * Display Name: Updated At
         * * SQL Data Type: datetimeoffset
         * * Default Value: getutcdate()`),
-    Parent: z.string().nullish().describe(`
+    Parent: z.string().nullable().describe(`
         * * Field Name: Parent
         * * Display Name: Parent
         * * SQL Data Type: nvarchar(255)`),
@@ -6158,7 +6158,7 @@ export const GeneratedCodeSchema = z.object({
         * * Display Name: Name
         * * SQL Data Type: nvarchar(255)
     * * Description: Descriptive name of the generated code.`),
-    Description: z.string().nullish().describe(`
+    Description: z.string().nullable().describe(`
         * * Field Name: Description
         * * Display Name: Description
         * * SQL Data Type: nvarchar(MAX)
@@ -6173,12 +6173,12 @@ export const GeneratedCodeSchema = z.object({
         * * Display Name: Source
         * * SQL Data Type: nvarchar(MAX)
     * * Description: Source material used to generate the code, e.g., a SQL CHECK constraint.`),
-    LinkedEntityID: z.string().nullish().describe(`
+    LinkedEntityID: z.string().nullable().describe(`
         * * Field Name: LinkedEntityID
         * * Display Name: Linked Entity ID
         * * SQL Data Type: uniqueidentifier
         * * Related Entity/Foreign Key: Entities (vwEntities.ID)`),
-    LinkedRecordPrimaryKey: z.string().nullish().describe(`
+    LinkedRecordPrimaryKey: z.string().nullable().describe(`
         * * Field Name: LinkedRecordPrimaryKey
         * * Display Name: Linked Record Primary Key
         * * SQL Data Type: nvarchar(MAX)`),
@@ -6226,7 +6226,7 @@ export const GeneratedCodeSchema = z.object({
         * * Field Name: GeneratedByModel
         * * Display Name: Generated By Model
         * * SQL Data Type: nvarchar(50)`),
-    LinkedEntity: z.string().nullish().describe(`
+    LinkedEntity: z.string().nullable().describe(`
         * * Field Name: LinkedEntity
         * * Display Name: Linked Entity
         * * SQL Data Type: nvarchar(255)`),
@@ -6256,7 +6256,7 @@ export const IntegrationURLFormatSchema = z.object({
         * * Field Name: URLFormat
         * * SQL Data Type: nvarchar(500)
     * * Description: The URL Format for the given integration including the ability to include markup with fields from the integration`),
-    Comments: z.string().nullish().describe(`
+    Comments: z.string().nullable().describe(`
         * * Field Name: Comments
         * * Display Name: Comments
         * * SQL Data Type: nvarchar(MAX)`),
@@ -6274,11 +6274,11 @@ export const IntegrationURLFormatSchema = z.object({
         * * Field Name: Integration
         * * Display Name: Integration
         * * SQL Data Type: nvarchar(100)`),
-    NavigationBaseURL: z.string().nullish().describe(`
+    NavigationBaseURL: z.string().nullable().describe(`
         * * Field Name: NavigationBaseURL
         * * Display Name: Navigation Base URL
         * * SQL Data Type: nvarchar(500)`),
-    FullURLFormat: z.string().nullish().describe(`
+    FullURLFormat: z.string().nullable().describe(`
         * * Field Name: FullURLFormat
         * * Display Name: Full URLFormat
         * * SQL Data Type: nvarchar(1000)`),
@@ -6293,18 +6293,18 @@ export const IntegrationSchema = z.object({
     Name: z.string().describe(`
         * * Field Name: Name
         * * SQL Data Type: nvarchar(100)`),
-    Description: z.string().nullish().describe(`
+    Description: z.string().nullable().describe(`
         * * Field Name: Description
         * * SQL Data Type: nvarchar(255)`),
-    NavigationBaseURL: z.string().nullish().describe(`
+    NavigationBaseURL: z.string().nullable().describe(`
         * * Field Name: NavigationBaseURL
         * * Display Name: Navigation Base URL
         * * SQL Data Type: nvarchar(500)`),
-    ClassName: z.string().nullish().describe(`
+    ClassName: z.string().nullable().describe(`
         * * Field Name: ClassName
         * * Display Name: Class Name
         * * SQL Data Type: nvarchar(100)`),
-    ImportPath: z.string().nullish().describe(`
+    ImportPath: z.string().nullable().describe(`
         * * Field Name: ImportPath
         * * Display Name: Import Path
         * * SQL Data Type: nvarchar(100)`),
@@ -6349,7 +6349,7 @@ export const LibrarySchema = z.object({
         * * Field Name: Name
         * * Display Name: Name
         * * SQL Data Type: nvarchar(255)`),
-    Description: z.string().nullish().describe(`
+    Description: z.string().nullable().describe(`
         * * Field Name: Description
         * * Display Name: Description
         * * SQL Data Type: nvarchar(MAX)`),
@@ -6364,12 +6364,12 @@ export const LibrarySchema = z.object({
     *   * Active
     *   * Disabled
     * * Description: Status of the library, only libraries marked as Active will be available for use by generated code. If a library was once active but no longer is, existing code that used the library will not be affected.`),
-    TypeDefinitions: z.string().nullish().describe(`
+    TypeDefinitions: z.string().nullable().describe(`
         * * Field Name: TypeDefinitions
         * * Display Name: Type Definitions
         * * SQL Data Type: nvarchar(MAX)
     * * Description: Code showing the types and functions defined in the library to be used for reference by humans and AI`),
-    SampleCode: z.string().nullish().describe(`
+    SampleCode: z.string().nullable().describe(`
         * * Field Name: SampleCode
         * * Display Name: Sample Code
         * * SQL Data Type: nvarchar(MAX)
@@ -6450,11 +6450,11 @@ export const ListCategorySchema = z.object({
         * * Field Name: Name
         * * Display Name: Name
         * * SQL Data Type: nvarchar(100)`),
-    Description: z.string().nullish().describe(`
+    Description: z.string().nullable().describe(`
         * * Field Name: Description
         * * Display Name: Description
         * * SQL Data Type: nvarchar(MAX)`),
-    ParentID: z.string().nullish().describe(`
+    ParentID: z.string().nullable().describe(`
         * * Field Name: ParentID
         * * Display Name: Parent ID
         * * SQL Data Type: uniqueidentifier
@@ -6474,7 +6474,7 @@ export const ListCategorySchema = z.object({
         * * Display Name: Updated At
         * * SQL Data Type: datetimeoffset
         * * Default Value: getutcdate()`),
-    Parent: z.string().nullish().describe(`
+    Parent: z.string().nullable().describe(`
         * * Field Name: Parent
         * * Display Name: Parent
         * * SQL Data Type: nvarchar(100)`),
@@ -6532,7 +6532,7 @@ export const ListDetailSchema = z.object({
     *   * Error
     *   * Other
     * * Description: Tracks the status of each individual list detail row to enable processing of various types and the use of the status column for filtering list detail rows within a list that are in a particular state.`),
-    AdditionalData: z.string().nullish().describe(`
+    AdditionalData: z.string().nullable().describe(`
         * * Field Name: AdditionalData
         * * Display Name: Additional Data
         * * SQL Data Type: nvarchar(MAX)
@@ -6556,7 +6556,7 @@ export const ListSchema = z.object({
     Name: z.string().describe(`
         * * Field Name: Name
         * * SQL Data Type: nvarchar(100)`),
-    Description: z.string().nullish().describe(`
+    Description: z.string().nullable().describe(`
         * * Field Name: Description
         * * SQL Data Type: nvarchar(MAX)`),
     EntityID: z.string().describe(`
@@ -6569,16 +6569,16 @@ export const ListSchema = z.object({
         * * Display Name: User ID
         * * SQL Data Type: uniqueidentifier
         * * Related Entity/Foreign Key: Users (vwUsers.ID)`),
-    CategoryID: z.string().nullish().describe(`
+    CategoryID: z.string().nullable().describe(`
         * * Field Name: CategoryID
         * * Display Name: Category ID
         * * SQL Data Type: uniqueidentifier
         * * Related Entity/Foreign Key: List Categories (vwListCategories.ID)`),
-    ExternalSystemRecordID: z.string().nullish().describe(`
+    ExternalSystemRecordID: z.string().nullable().describe(`
         * * Field Name: ExternalSystemRecordID
         * * Display Name: External System Record ID
         * * SQL Data Type: nvarchar(100)`),
-    CompanyIntegrationID: z.string().nullish().describe(`
+    CompanyIntegrationID: z.string().nullable().describe(`
         * * Field Name: CompanyIntegrationID
         * * Display Name: Company Integration ID
         * * SQL Data Type: uniqueidentifier
@@ -6601,13 +6601,120 @@ export const ListSchema = z.object({
         * * Field Name: User
         * * Display Name: User
         * * SQL Data Type: nvarchar(100)`),
-    Category: z.string().nullish().describe(`
+    Category: z.string().nullable().describe(`
         * * Field Name: Category
         * * Display Name: Category
         * * SQL Data Type: nvarchar(100)`),
 });
 
 export type ListEntityType = z.infer<typeof ListSchema>;
+
+/**
+ * zod schema definition for the entity MJ: Report User States
+ */
+export const ReportUserStateSchema = z.object({
+    ID: z.string().describe(`
+        * * Field Name: ID
+        * * Display Name: ID
+        * * SQL Data Type: uniqueidentifier
+        * * Default Value: newsequentialid()`),
+    ReportID: z.string().describe(`
+        * * Field Name: ReportID
+        * * Display Name: Report ID
+        * * SQL Data Type: uniqueidentifier
+        * * Related Entity/Foreign Key: Reports (vwReports.ID)`),
+    UserID: z.string().describe(`
+        * * Field Name: UserID
+        * * Display Name: User ID
+        * * SQL Data Type: uniqueidentifier
+        * * Related Entity/Foreign Key: Users (vwUsers.ID)`),
+    ReportState: z.string().nullable().describe(`
+        * * Field Name: ReportState
+        * * Display Name: Report State
+        * * SQL Data Type: nvarchar(MAX)
+    * * Description: JSON serialized state of user interaction with the report`),
+    __mj_CreatedAt: z.date().describe(`
+        * * Field Name: __mj_CreatedAt
+        * * Display Name: Created At
+        * * SQL Data Type: datetimeoffset
+        * * Default Value: getutcdate()`),
+    __mj_UpdatedAt: z.date().describe(`
+        * * Field Name: __mj_UpdatedAt
+        * * Display Name: Updated At
+        * * SQL Data Type: datetimeoffset
+        * * Default Value: getutcdate()`),
+    Report: z.string().describe(`
+        * * Field Name: Report
+        * * Display Name: Report
+        * * SQL Data Type: nvarchar(255)
+        * * Default Value: null`),
+    User: z.string().describe(`
+        * * Field Name: User
+        * * Display Name: User
+        * * SQL Data Type: nvarchar(100)
+        * * Default Value: null`),
+});
+
+export type ReportUserStateEntityType = z.infer<typeof ReportUserStateSchema>;
+
+/**
+ * zod schema definition for the entity MJ: Report Versions
+ */
+export const ReportVersionSchema = z.object({
+    ID: z.string().describe(`
+        * * Field Name: ID
+        * * Display Name: ID
+        * * SQL Data Type: uniqueidentifier
+        * * Default Value: newsequentialid()`),
+    ReportID: z.string().describe(`
+        * * Field Name: ReportID
+        * * Display Name: Report ID
+        * * SQL Data Type: uniqueidentifier
+        * * Related Entity/Foreign Key: Reports (vwReports.ID)`),
+    VersionNumber: z.number().describe(`
+        * * Field Name: VersionNumber
+        * * Display Name: Version Number
+        * * SQL Data Type: int
+    * * Description: Report version number, sequential per report starting at 1`),
+    Name: z.string().describe(`
+        * * Field Name: Name
+        * * Display Name: Name
+        * * SQL Data Type: nvarchar(255)
+    * * Description: Name of this report version`),
+    Description: z.string().nullable().describe(`
+        * * Field Name: Description
+        * * Display Name: Description
+        * * SQL Data Type: nvarchar(MAX)
+    * * Description: Description of this report version`),
+    Configuration: z.string().nullable().describe(`
+        * * Field Name: Configuration
+        * * Display Name: Configuration
+        * * SQL Data Type: nvarchar(MAX)
+    * * Description: JSON configuration of report structure, layout and logic`),
+    DataContextUpdated: z.boolean().describe(`
+        * * Field Name: DataContextUpdated
+        * * Display Name: Data Context Updated
+        * * SQL Data Type: bit
+        * * Default Value: 0
+    * * Description: Indicates if the data context was updated in this version`),
+    __mj_CreatedAt: z.date().describe(`
+        * * Field Name: __mj_CreatedAt
+        * * Display Name: Created At
+        * * SQL Data Type: datetimeoffset
+        * * Default Value: getutcdate()`),
+    __mj_UpdatedAt: z.date().describe(`
+        * * Field Name: __mj_UpdatedAt
+        * * Display Name: Updated At
+        * * SQL Data Type: datetimeoffset
+        * * Default Value: getutcdate()`),
+    Report: z.string().describe(`
+        * * Field Name: Report
+        * * Display Name: Report
+        * * SQL Data Type: nvarchar(255)
+        * * Default Value: null`),
+});
+
+export type ReportVersionEntityType = z.infer<typeof ReportVersionSchema>;
 
 /**
  * zod schema definition for the entity Output Delivery Types
@@ -6622,7 +6729,7 @@ export const OutputDeliveryTypeSchema = z.object({
         * * Field Name: Name
         * * Display Name: Name
         * * SQL Data Type: nvarchar(255)`),
-    Description: z.string().nullish().describe(`
+    Description: z.string().nullable().describe(`
         * * Field Name: Description
         * * Display Name: Description
         * * SQL Data Type: nvarchar(MAX)`),
@@ -6653,11 +6760,11 @@ export const OutputFormatTypeSchema = z.object({
         * * Field Name: Name
         * * Display Name: Name
         * * SQL Data Type: nvarchar(255)`),
-    Description: z.string().nullish().describe(`
+    Description: z.string().nullable().describe(`
         * * Field Name: Description
         * * Display Name: Description
         * * SQL Data Type: nvarchar(MAX)`),
-    DisplayFormat: z.string().nullish().describe(`
+    DisplayFormat: z.string().nullable().describe(`
         * * Field Name: DisplayFormat
         * * Display Name: Display Format
         * * SQL Data Type: nvarchar(MAX)`),
@@ -6688,7 +6795,7 @@ export const OutputTriggerTypeSchema = z.object({
         * * Field Name: Name
         * * Display Name: Name
         * * SQL Data Type: nvarchar(255)`),
-    Description: z.string().nullish().describe(`
+    Description: z.string().nullable().describe(`
         * * Field Name: Description
         * * Display Name: Description
         * * SQL Data Type: nvarchar(MAX)`),
@@ -6719,32 +6826,32 @@ export const QuerySchema = z.object({
         * * Field Name: Name
         * * Display Name: Name
         * * SQL Data Type: nvarchar(255)`),
-    CategoryID: z.string().nullish().describe(`
+    CategoryID: z.string().nullable().describe(`
         * * Field Name: CategoryID
         * * Display Name: Category ID
         * * SQL Data Type: uniqueidentifier
         * * Related Entity/Foreign Key: Query Categories (vwQueryCategories.ID)`),
-    UserQuestion: z.string().nullish().describe(`
+    UserQuestion: z.string().nullable().describe(`
         * * Field Name: UserQuestion
         * * Display Name: User Question
         * * SQL Data Type: nvarchar(MAX)`),
-    Description: z.string().nullish().describe(`
+    Description: z.string().nullable().describe(`
         * * Field Name: Description
         * * Display Name: Description
         * * SQL Data Type: nvarchar(MAX)`),
-    SQL: z.string().nullish().describe(`
+    SQL: z.string().nullable().describe(`
         * * Field Name: SQL
         * * Display Name: SQL
         * * SQL Data Type: nvarchar(MAX)`),
-    TechnicalDescription: z.string().nullish().describe(`
+    TechnicalDescription: z.string().nullable().describe(`
         * * Field Name: TechnicalDescription
         * * Display Name: Technical Description
         * * SQL Data Type: nvarchar(MAX)`),
-    OriginalSQL: z.string().nullish().describe(`
+    OriginalSQL: z.string().nullable().describe(`
         * * Field Name: OriginalSQL
         * * Display Name: Original SQL
         * * SQL Data Type: nvarchar(MAX)`),
-    Feedback: z.string().nullish().describe(`
+    Feedback: z.string().nullable().describe(`
         * * Field Name: Feedback
         * * Display Name: Feedback
         * * SQL Data Type: nvarchar(MAX)`),
@@ -6759,13 +6866,13 @@ export const QuerySchema = z.object({
     *   * Approved
     *   * Rejected
     *   * Expired`),
-    QualityRank: z.number().nullish().describe(`
+    QualityRank: z.number().nullable().describe(`
         * * Field Name: QualityRank
         * * Display Name: Quality Rank
         * * SQL Data Type: int
         * * Default Value: 0
     * * Description: Value indicating the quality of the query, higher values mean a better quality`),
-    ExecutionCostRank: z.number().nullish().describe(`
+    ExecutionCostRank: z.number().nullable().describe(`
         * * Field Name: ExecutionCostRank
         * * Display Name: Execution Cost Rank
         * * SQL Data Type: int
@@ -6780,7 +6887,7 @@ export const QuerySchema = z.object({
         * * Display Name: __mj _Updated At
         * * SQL Data Type: datetimeoffset
         * * Default Value: getutcdate()`),
-    Category: z.string().nullish().describe(`
+    Category: z.string().nullable().describe(`
         * * Field Name: Category
         * * Display Name: Category
         * * SQL Data Type: nvarchar(50)`),
@@ -6801,12 +6908,12 @@ export const QueryCategorySchema = z.object({
         * * Field Name: Name
         * * Display Name: Name
         * * SQL Data Type: nvarchar(50)`),
-    ParentID: z.string().nullish().describe(`
+    ParentID: z.string().nullable().describe(`
         * * Field Name: ParentID
         * * Display Name: Parent ID
         * * SQL Data Type: uniqueidentifier
         * * Related Entity/Foreign Key: Query Categories (vwQueryCategories.ID)`),
-    Description: z.string().nullish().describe(`
+    Description: z.string().nullable().describe(`
         * * Field Name: Description
         * * Display Name: Description
         * * SQL Data Type: nvarchar(MAX)`),
@@ -6825,7 +6932,7 @@ export const QueryCategorySchema = z.object({
         * * Display Name: __mj _Updated At
         * * SQL Data Type: datetimeoffset
         * * Default Value: getutcdate()`),
-    Parent: z.string().nullish().describe(`
+    Parent: z.string().nullable().describe(`
         * * Field Name: Parent
         * * Display Name: Parent
         * * SQL Data Type: nvarchar(50)`),
@@ -6899,7 +7006,7 @@ export const QueryFieldSchema = z.object({
         * * Field Name: Name
         * * Display Name: Name
         * * SQL Data Type: nvarchar(255)`),
-    Description: z.string().nullish().describe(`
+    Description: z.string().nullable().describe(`
         * * Field Name: Description
         * * Display Name: Description
         * * SQL Data Type: nvarchar(MAX)`),
@@ -6917,12 +7024,12 @@ export const QueryFieldSchema = z.object({
         * * Display Name: SQLFull Type
         * * SQL Data Type: nvarchar(100)
     * * Description: The full SQL type for the field, for example datetime or nvarchar(10) etc.`),
-    SourceEntityID: z.string().nullish().describe(`
+    SourceEntityID: z.string().nullable().describe(`
         * * Field Name: SourceEntityID
         * * Display Name: Source Entity ID
         * * SQL Data Type: uniqueidentifier
         * * Related Entity/Foreign Key: Entities (vwEntities.ID)`),
-    SourceFieldName: z.string().nullish().describe(`
+    SourceFieldName: z.string().nullable().describe(`
         * * Field Name: SourceFieldName
         * * Display Name: Source Field Name
         * * SQL Data Type: nvarchar(255)`),
@@ -6931,7 +7038,7 @@ export const QueryFieldSchema = z.object({
         * * Display Name: Is Computed
         * * SQL Data Type: bit
         * * Default Value: 0`),
-    ComputationDescription: z.string().nullish().describe(`
+    ComputationDescription: z.string().nullable().describe(`
         * * Field Name: ComputationDescription
         * * Display Name: Computation Description
         * * SQL Data Type: nvarchar(MAX)`),
@@ -6940,7 +7047,7 @@ export const QueryFieldSchema = z.object({
         * * Display Name: Is Summary
         * * SQL Data Type: bit
         * * Default Value: 0`),
-    SummaryDescription: z.string().nullish().describe(`
+    SummaryDescription: z.string().nullable().describe(`
         * * Field Name: SummaryDescription
         * * Display Name: Summary Description
         * * SQL Data Type: nvarchar(MAX)`),
@@ -6958,7 +7065,7 @@ export const QueryFieldSchema = z.object({
         * * Field Name: Query
         * * Display Name: Query
         * * SQL Data Type: nvarchar(255)`),
-    SourceEntity: z.string().nullish().describe(`
+    SourceEntity: z.string().nullable().describe(`
         * * Field Name: SourceEntity
         * * Display Name: Source Entity
         * * SQL Data Type: nvarchar(255)`),
@@ -7031,31 +7138,31 @@ export const QueueTaskSchema = z.object({
     *   * In Progress
     *   * Completed
     *   * Failed`),
-    StartedAt: z.date().nullish().describe(`
+    StartedAt: z.date().nullable().describe(`
         * * Field Name: StartedAt
         * * Display Name: Started At
         * * SQL Data Type: datetime`),
-    EndedAt: z.date().nullish().describe(`
+    EndedAt: z.date().nullable().describe(`
         * * Field Name: EndedAt
         * * Display Name: Ended At
         * * SQL Data Type: datetime`),
-    Data: z.string().nullish().describe(`
+    Data: z.string().nullable().describe(`
         * * Field Name: Data
         * * Display Name: Data
         * * SQL Data Type: nvarchar(MAX)`),
-    Options: z.string().nullish().describe(`
+    Options: z.string().nullable().describe(`
         * * Field Name: Options
         * * Display Name: Options
         * * SQL Data Type: nvarchar(MAX)`),
-    Output: z.string().nullish().describe(`
+    Output: z.string().nullable().describe(`
         * * Field Name: Output
         * * Display Name: Output
         * * SQL Data Type: nvarchar(MAX)`),
-    ErrorMessage: z.string().nullish().describe(`
+    ErrorMessage: z.string().nullable().describe(`
         * * Field Name: ErrorMessage
         * * Display Name: Error Message
         * * SQL Data Type: nvarchar(MAX)`),
-    Comments: z.string().nullish().describe(`
+    Comments: z.string().nullable().describe(`
         * * Field Name: Comments
         * * Display Name: Comments
         * * SQL Data Type: nvarchar(MAX)`),
@@ -7090,7 +7197,7 @@ export const QueueTypeSchema = z.object({
         * * Field Name: Name
         * * Display Name: Name
         * * SQL Data Type: nvarchar(50)`),
-    Description: z.string().nullish().describe(`
+    Description: z.string().nullable().describe(`
         * * Field Name: Description
         * * Display Name: Description
         * * SQL Data Type: nvarchar(MAX)`),
@@ -7098,7 +7205,7 @@ export const QueueTypeSchema = z.object({
         * * Field Name: DriverClass
         * * Display Name: Driver Class
         * * SQL Data Type: nvarchar(100)`),
-    DriverImportPath: z.string().nullish().describe(`
+    DriverImportPath: z.string().nullable().describe(`
         * * Field Name: DriverImportPath
         * * Display Name: Driver Import Path
         * * SQL Data Type: nvarchar(200)`),
@@ -7134,7 +7241,7 @@ export const QueueSchema = z.object({
         * * Field Name: Name
         * * Display Name: Name
         * * SQL Data Type: nvarchar(50)`),
-    Description: z.string().nullish().describe(`
+    Description: z.string().nullable().describe(`
         * * Field Name: Description
         * * Display Name: Description
         * * SQL Data Type: nvarchar(MAX)`),
@@ -7148,47 +7255,47 @@ export const QueueSchema = z.object({
         * * Display Name: Is Active
         * * SQL Data Type: bit
         * * Default Value: 0`),
-    ProcessPID: z.number().nullish().describe(`
+    ProcessPID: z.number().nullable().describe(`
         * * Field Name: ProcessPID
         * * Display Name: Process PID
         * * SQL Data Type: int`),
-    ProcessPlatform: z.string().nullish().describe(`
+    ProcessPlatform: z.string().nullable().describe(`
         * * Field Name: ProcessPlatform
         * * Display Name: Process Platform
         * * SQL Data Type: nvarchar(30)`),
-    ProcessVersion: z.string().nullish().describe(`
+    ProcessVersion: z.string().nullable().describe(`
         * * Field Name: ProcessVersion
         * * Display Name: Process Version
         * * SQL Data Type: nvarchar(15)`),
-    ProcessCwd: z.string().nullish().describe(`
+    ProcessCwd: z.string().nullable().describe(`
         * * Field Name: ProcessCwd
         * * Display Name: Process Cwd
         * * SQL Data Type: nvarchar(100)`),
-    ProcessIPAddress: z.string().nullish().describe(`
+    ProcessIPAddress: z.string().nullable().describe(`
         * * Field Name: ProcessIPAddress
         * * Display Name: Process IPAddress
         * * SQL Data Type: nvarchar(50)`),
-    ProcessMacAddress: z.string().nullish().describe(`
+    ProcessMacAddress: z.string().nullable().describe(`
         * * Field Name: ProcessMacAddress
         * * Display Name: Process Mac Address
         * * SQL Data Type: nvarchar(50)`),
-    ProcessOSName: z.string().nullish().describe(`
+    ProcessOSName: z.string().nullable().describe(`
         * * Field Name: ProcessOSName
         * * Display Name: Process OSName
         * * SQL Data Type: nvarchar(25)`),
-    ProcessOSVersion: z.string().nullish().describe(`
+    ProcessOSVersion: z.string().nullable().describe(`
         * * Field Name: ProcessOSVersion
         * * Display Name: Process OSVersion
         * * SQL Data Type: nvarchar(10)`),
-    ProcessHostName: z.string().nullish().describe(`
+    ProcessHostName: z.string().nullable().describe(`
         * * Field Name: ProcessHostName
         * * Display Name: Process Host Name
         * * SQL Data Type: nvarchar(50)`),
-    ProcessUserID: z.string().nullish().describe(`
+    ProcessUserID: z.string().nullable().describe(`
         * * Field Name: ProcessUserID
         * * Display Name: Process User ID
         * * SQL Data Type: nvarchar(25)`),
-    ProcessUserName: z.string().nullish().describe(`
+    ProcessUserName: z.string().nullable().describe(`
         * * Field Name: ProcessUserName
         * * Display Name: Process User Name
         * * SQL Data Type: nvarchar(50)`),
@@ -7239,7 +7346,7 @@ export const RecommendationItemSchema = z.object({
         * * Display Name: Destination Entity Record ID
         * * SQL Data Type: nvarchar(450)
     * * Description: The record ID of the destination entity`),
-    MatchProbability: z.number().nullish().describe(`
+    MatchProbability: z.number().nullable().describe(`
         * * Field Name: MatchProbability
         * * Display Name: Match Probability
         * * SQL Data Type: decimal(18, 15)
@@ -7275,7 +7382,7 @@ export const RecommendationProviderSchema = z.object({
         * * Field Name: Name
         * * Display Name: Name
         * * SQL Data Type: nvarchar(255)`),
-    Description: z.string().nullish().describe(`
+    Description: z.string().nullable().describe(`
         * * Field Name: Description
         * * Display Name: Description
         * * SQL Data Type: nvarchar(MAX)`),
@@ -7312,7 +7419,7 @@ export const RecommendationRunSchema = z.object({
         * * Display Name: Start Date
         * * SQL Data Type: datetime
     * * Description: The start date of the recommendation run`),
-    EndDate: z.date().nullish().describe(`
+    EndDate: z.date().nullable().describe(`
         * * Field Name: EndDate
         * * Display Name: End Date
         * * SQL Data Type: datetime
@@ -7329,7 +7436,7 @@ export const RecommendationRunSchema = z.object({
     *   * Canceled
     *   * Error
     * * Description: The status of the recommendation run`),
-    Description: z.string().nullish().describe(`
+    Description: z.string().nullable().describe(`
         * * Field Name: Description
         * * Display Name: Description
         * * SQL Data Type: nvarchar(MAX)`),
@@ -7416,7 +7523,7 @@ export const RecordChangeReplayRunSchema = z.object({
         * * Display Name: Started At
         * * SQL Data Type: datetime
     * * Description: Timestamp when the replay run started`),
-    EndedAt: z.date().nullish().describe(`
+    EndedAt: z.date().nullable().describe(`
         * * Field Name: EndedAt
         * * Display Name: Ended At
         * * SQL Data Type: datetime
@@ -7529,21 +7636,21 @@ export const RecordChangeSchema = z.object({
     *   * Complete
     *   * Error
     * * Description: For internal record changes generated within MJ, the status is immediately Complete. For external changes that are detected, the workflow starts off as Pending, then In Progress and finally either Complete or Error`),
-    ErrorLog: z.string().nullish().describe(`
+    ErrorLog: z.string().nullable().describe(`
         * * Field Name: ErrorLog
         * * Display Name: Error Log
         * * SQL Data Type: nvarchar(MAX)`),
-    ReplayRunID: z.string().nullish().describe(`
+    ReplayRunID: z.string().nullable().describe(`
         * * Field Name: ReplayRunID
         * * Display Name: Replay Run ID
         * * SQL Data Type: uniqueidentifier
         * * Related Entity/Foreign Key: Record Change Replay Runs (vwRecordChangeReplayRuns.ID)`),
-    IntegrationID: z.string().nullish().describe(`
+    IntegrationID: z.string().nullable().describe(`
         * * Field Name: IntegrationID
         * * Display Name: Integration ID
         * * SQL Data Type: uniqueidentifier
         * * Related Entity/Foreign Key: Integrations (vwIntegrations.ID)`),
-    Comments: z.string().nullish().describe(`
+    Comments: z.string().nullable().describe(`
         * * Field Name: Comments
         * * SQL Data Type: nvarchar(MAX)`),
     CreatedAt: z.date().describe(`
@@ -7564,7 +7671,7 @@ export const RecordChangeSchema = z.object({
         * * Field Name: User
         * * Display Name: User
         * * SQL Data Type: nvarchar(100)`),
-    Integration: z.string().nullish().describe(`
+    Integration: z.string().nullable().describe(`
         * * Field Name: Integration
         * * Display Name: Integration
         * * SQL Data Type: nvarchar(100)`),
@@ -7600,7 +7707,7 @@ export const RecordMergeDeletionLogSchema = z.object({
     *   * Pending
     *   * Complete
     *   * Error`),
-    ProcessingLog: z.string().nullish().describe(`
+    ProcessingLog: z.string().nullable().describe(`
         * * Field Name: ProcessingLog
         * * Display Name: Processing Log
         * * SQL Data Type: nvarchar(MAX)`),
@@ -7651,7 +7758,7 @@ export const RecordMergeLogSchema = z.object({
     *   * Pending
     *   * Approved
     *   * Rejected`),
-    ApprovedByUserID: z.string().nullish().describe(`
+    ApprovedByUserID: z.string().nullable().describe(`
         * * Field Name: ApprovedByUserID
         * * Display Name: Approved By User ID
         * * SQL Data Type: uniqueidentifier
@@ -7671,15 +7778,15 @@ export const RecordMergeLogSchema = z.object({
         * * Display Name: Processing Started At
         * * SQL Data Type: datetime
         * * Default Value: getdate()`),
-    ProcessingEndedAt: z.date().nullish().describe(`
+    ProcessingEndedAt: z.date().nullable().describe(`
         * * Field Name: ProcessingEndedAt
         * * Display Name: Processing Ended At
         * * SQL Data Type: datetime`),
-    ProcessingLog: z.string().nullish().describe(`
+    ProcessingLog: z.string().nullable().describe(`
         * * Field Name: ProcessingLog
         * * Display Name: Processing Log
         * * SQL Data Type: nvarchar(MAX)`),
-    Comments: z.string().nullish().describe(`
+    Comments: z.string().nullable().describe(`
         * * Field Name: Comments
         * * Display Name: Comments
         * * SQL Data Type: nvarchar(MAX)`),
@@ -7701,7 +7808,7 @@ export const RecordMergeLogSchema = z.object({
         * * Field Name: InitiatedByUser
         * * Display Name: Initiated By User
         * * SQL Data Type: nvarchar(100)`),
-    ApprovedByUser: z.string().nullish().describe(`
+    ApprovedByUser: z.string().nullable().describe(`
         * * Field Name: ApprovedByUser
         * * Display Name: Approved By User
         * * SQL Data Type: nvarchar(100)`),
@@ -7722,11 +7829,11 @@ export const ReportCategorySchema = z.object({
         * * Field Name: Name
         * * Display Name: Name
         * * SQL Data Type: nvarchar(100)`),
-    Description: z.string().nullish().describe(`
+    Description: z.string().nullable().describe(`
         * * Field Name: Description
         * * Display Name: Description
         * * SQL Data Type: nvarchar(MAX)`),
-    ParentID: z.string().nullish().describe(`
+    ParentID: z.string().nullable().describe(`
         * * Field Name: ParentID
         * * Display Name: Parent ID
         * * SQL Data Type: uniqueidentifier
@@ -7746,7 +7853,7 @@ export const ReportCategorySchema = z.object({
         * * Display Name: Updated At
         * * SQL Data Type: datetimeoffset
         * * Default Value: getutcdate()`),
-    Parent: z.string().nullish().describe(`
+    Parent: z.string().nullable().describe(`
         * * Field Name: Parent
         * * Display Name: Parent
         * * SQL Data Type: nvarchar(100)`),
@@ -7816,11 +7923,11 @@ export const ReportSchema = z.object({
         * * Field Name: Name
         * * Display Name: Name
         * * SQL Data Type: nvarchar(255)`),
-    Description: z.string().nullish().describe(`
+    Description: z.string().nullable().describe(`
         * * Field Name: Description
         * * Display Name: Description
         * * SQL Data Type: nvarchar(MAX)`),
-    CategoryID: z.string().nullish().describe(`
+    CategoryID: z.string().nullable().describe(`
         * * Field Name: CategoryID
         * * Display Name: Category ID
         * * SQL Data Type: uniqueidentifier
@@ -7840,49 +7947,49 @@ export const ReportSchema = z.object({
     *   * None
     *   * Specific
     *   * Everyone`),
-    ConversationID: z.string().nullish().describe(`
+    ConversationID: z.string().nullable().describe(`
         * * Field Name: ConversationID
         * * Display Name: Conversation ID
         * * SQL Data Type: uniqueidentifier
         * * Related Entity/Foreign Key: Conversations (vwConversations.ID)`),
-    ConversationDetailID: z.string().nullish().describe(`
+    ConversationDetailID: z.string().nullable().describe(`
         * * Field Name: ConversationDetailID
         * * Display Name: Conversation Detail ID
         * * SQL Data Type: uniqueidentifier
         * * Related Entity/Foreign Key: Conversation Details (vwConversationDetails.ID)`),
-    DataContextID: z.string().nullish().describe(`
+    DataContextID: z.string().nullable().describe(`
         * * Field Name: DataContextID
         * * Display Name: Data Context ID
         * * SQL Data Type: uniqueidentifier
         * * Related Entity/Foreign Key: Data Contexts (vwDataContexts.ID)`),
-    Configuration: z.string().nullish().describe(`
+    Configuration: z.string().nullable().describe(`
         * * Field Name: Configuration
         * * Display Name: Configuration
         * * SQL Data Type: nvarchar(MAX)`),
-    OutputTriggerTypeID: z.string().nullish().describe(`
+    OutputTriggerTypeID: z.string().nullable().describe(`
         * * Field Name: OutputTriggerTypeID
         * * Display Name: Output Trigger Type ID
         * * SQL Data Type: uniqueidentifier
         * * Related Entity/Foreign Key: Output Trigger Types (vwOutputTriggerTypes.ID)`),
-    OutputFormatTypeID: z.string().nullish().describe(`
+    OutputFormatTypeID: z.string().nullable().describe(`
         * * Field Name: OutputFormatTypeID
         * * Display Name: Output Format Type ID
         * * SQL Data Type: uniqueidentifier
         * * Related Entity/Foreign Key: Output Format Types (vwOutputFormatTypes.ID)`),
-    OutputDeliveryTypeID: z.string().nullish().describe(`
+    OutputDeliveryTypeID: z.string().nullable().describe(`
         * * Field Name: OutputDeliveryTypeID
         * * Display Name: Output Delivery Type ID
         * * SQL Data Type: uniqueidentifier
         * * Related Entity/Foreign Key: Output Delivery Types (vwOutputDeliveryTypes.ID)`),
-    OutputFrequency: z.string().nullish().describe(`
+    OutputFrequency: z.string().nullable().describe(`
         * * Field Name: OutputFrequency
         * * Display Name: Output Frequency
         * * SQL Data Type: nvarchar(50)`),
-    OutputTargetEmail: z.string().nullish().describe(`
+    OutputTargetEmail: z.string().nullable().describe(`
         * * Field Name: OutputTargetEmail
         * * Display Name: Output Target Email
         * * SQL Data Type: nvarchar(255)`),
-    OutputWorkflowID: z.string().nullish().describe(`
+    OutputWorkflowID: z.string().nullable().describe(`
         * * Field Name: OutputWorkflowID
         * * Display Name: Output Workflow ID
         * * SQL Data Type: uniqueidentifier
@@ -7897,7 +8004,7 @@ export const ReportSchema = z.object({
         * * Display Name: Updated At
         * * SQL Data Type: datetimeoffset
         * * Default Value: getutcdate()`),
-    Category: z.string().nullish().describe(`
+    Category: z.string().nullable().describe(`
         * * Field Name: Category
         * * Display Name: Category
         * * SQL Data Type: nvarchar(100)`),
@@ -7905,27 +8012,27 @@ export const ReportSchema = z.object({
         * * Field Name: User
         * * Display Name: User
         * * SQL Data Type: nvarchar(100)`),
-    Conversation: z.string().nullish().describe(`
+    Conversation: z.string().nullable().describe(`
         * * Field Name: Conversation
         * * Display Name: Conversation
         * * SQL Data Type: nvarchar(255)`),
-    DataContext: z.string().nullish().describe(`
+    DataContext: z.string().nullable().describe(`
         * * Field Name: DataContext
         * * Display Name: Data Context
         * * SQL Data Type: nvarchar(255)`),
-    OutputTriggerType: z.string().nullish().describe(`
+    OutputTriggerType: z.string().nullable().describe(`
         * * Field Name: OutputTriggerType
         * * Display Name: Output Trigger Type
         * * SQL Data Type: nvarchar(255)`),
-    OutputFormatType: z.string().nullish().describe(`
+    OutputFormatType: z.string().nullable().describe(`
         * * Field Name: OutputFormatType
         * * Display Name: Output Format Type
         * * SQL Data Type: nvarchar(255)`),
-    OutputDeliveryType: z.string().nullish().describe(`
+    OutputDeliveryType: z.string().nullable().describe(`
         * * Field Name: OutputDeliveryType
         * * Display Name: Output Delivery Type
         * * SQL Data Type: nvarchar(255)`),
-    OutputWorkflow: z.string().nullish().describe(`
+    OutputWorkflow: z.string().nullable().describe(`
         * * Field Name: OutputWorkflow
         * * Display Name: Output Workflow
         * * SQL Data Type: nvarchar(100)`),
@@ -7960,7 +8067,7 @@ export const ResourceLinkSchema = z.object({
         * * Display Name: Resource Record ID
         * * SQL Data Type: nvarchar(255)
     * * Description: ID of the specific resource being linked`),
-    FolderID: z.string().nullish().describe(`
+    FolderID: z.string().nullable().describe(`
         * * Field Name: FolderID
         * * Display Name: Folder ID
         * * SQL Data Type: nvarchar(255)
@@ -8016,27 +8123,27 @@ export const ResourcePermissionSchema = z.object({
     *   * Role
     *   * User
     * * Description: The level of sharing either Role or User`),
-    StartSharingAt: z.date().nullish().describe(`
+    StartSharingAt: z.date().nullable().describe(`
         * * Field Name: StartSharingAt
         * * Display Name: Start Sharing At
         * * SQL Data Type: datetimeoffset
     * * Description: Optional: Date when sharing starts`),
-    EndSharingAt: z.date().nullish().describe(`
+    EndSharingAt: z.date().nullable().describe(`
         * * Field Name: EndSharingAt
         * * Display Name: End Sharing At
         * * SQL Data Type: datetimeoffset
     * * Description: Optional: Date when sharing ends`),
-    RoleID: z.string().nullish().describe(`
+    RoleID: z.string().nullable().describe(`
         * * Field Name: RoleID
         * * Display Name: Role ID
         * * SQL Data Type: uniqueidentifier
         * * Related Entity/Foreign Key: Roles (vwRoles.ID)`),
-    UserID: z.string().nullish().describe(`
+    UserID: z.string().nullable().describe(`
         * * Field Name: UserID
         * * Display Name: User ID
         * * SQL Data Type: uniqueidentifier
         * * Related Entity/Foreign Key: Users (vwUsers.ID)`),
-    PermissionLevel: z.union([z.literal('View'), z.literal('Edit'), z.literal('Owner')]).nullish().describe(`
+    PermissionLevel: z.union([z.literal('View'), z.literal('Edit'), z.literal('Owner')]).nullable().describe(`
         * * Field Name: PermissionLevel
         * * Display Name: Permission Level
         * * SQL Data Type: nvarchar(20)
@@ -8072,11 +8179,11 @@ export const ResourcePermissionSchema = z.object({
         * * Field Name: ResourceType
         * * Display Name: Resource Type
         * * SQL Data Type: nvarchar(255)`),
-    Role: z.string().nullish().describe(`
+    Role: z.string().nullable().describe(`
         * * Field Name: Role
         * * Display Name: Role
         * * SQL Data Type: nvarchar(50)`),
-    User: z.string().nullish().describe(`
+    User: z.string().nullable().describe(`
         * * Field Name: User
         * * Display Name: User
         * * SQL Data Type: nvarchar(100)`),
@@ -8101,15 +8208,15 @@ export const ResourceTypeSchema = z.object({
         * * Field Name: DisplayName
         * * Display Name: Display Name
         * * SQL Data Type: nvarchar(255)`),
-    Description: z.string().nullish().describe(`
+    Description: z.string().nullable().describe(`
         * * Field Name: Description
         * * Display Name: Description
         * * SQL Data Type: nvarchar(MAX)`),
-    Icon: z.string().nullish().describe(`
+    Icon: z.string().nullable().describe(`
         * * Field Name: Icon
         * * Display Name: Icon
         * * SQL Data Type: nvarchar(100)`),
-    EntityID: z.string().nullish().describe(`
+    EntityID: z.string().nullable().describe(`
         * * Field Name: EntityID
         * * Display Name: Entity ID
         * * SQL Data Type: uniqueidentifier
@@ -8124,17 +8231,17 @@ export const ResourceTypeSchema = z.object({
         * * Display Name: __mj _Updated At
         * * SQL Data Type: datetimeoffset
         * * Default Value: getutcdate()`),
-    CategoryEntityID: z.string().nullish().describe(`
+    CategoryEntityID: z.string().nullable().describe(`
         * * Field Name: CategoryEntityID
         * * Display Name: Category Entity ID
         * * SQL Data Type: uniqueidentifier
         * * Related Entity/Foreign Key: Entities (vwEntities.ID)
     * * Description: Nullable foreign key to the ID column in Entities entity, representing the category entity. ASSUMPTION: If provided, the assumption is there is a self-referencing/recursive foreign key establishing a hierarchy within the Category Entity, commonly called ParentID, but it can be named anything.`),
-    Entity: z.string().nullish().describe(`
+    Entity: z.string().nullable().describe(`
         * * Field Name: Entity
         * * Display Name: Entity
         * * SQL Data Type: nvarchar(255)`),
-    CategoryEntity: z.string().nullish().describe(`
+    CategoryEntity: z.string().nullable().describe(`
         * * Field Name: CategoryEntity
         * * Display Name: Category Entity
         * * SQL Data Type: nvarchar(255)`),
@@ -8153,16 +8260,16 @@ export const RoleSchema = z.object({
     Name: z.string().describe(`
         * * Field Name: Name
         * * SQL Data Type: nvarchar(50)`),
-    Description: z.string().nullish().describe(`
+    Description: z.string().nullable().describe(`
         * * Field Name: Description
         * * SQL Data Type: nvarchar(MAX)
     * * Description: Description of the role`),
-    DirectoryID: z.string().nullish().describe(`
+    DirectoryID: z.string().nullable().describe(`
         * * Field Name: DirectoryID
         * * Display Name: Directory ID
         * * SQL Data Type: nvarchar(250)
     * * Description: The unique ID of the role in the directory being used for authentication, for example an ID in Azure.`),
-    SQLName: z.string().nullish().describe(`
+    SQLName: z.string().nullable().describe(`
         * * Field Name: SQLName
         * * SQL Data Type: nvarchar(250)
     * * Description: The name of the role in the database, this is used for auto-generating permission statements by CodeGen`),
@@ -8193,11 +8300,11 @@ export const RowLevelSecurityFilterSchema = z.object({
         * * Field Name: Name
         * * Display Name: Name
         * * SQL Data Type: nvarchar(100)`),
-    Description: z.string().nullish().describe(`
+    Description: z.string().nullable().describe(`
         * * Field Name: Description
         * * Display Name: Description
         * * SQL Data Type: nvarchar(MAX)`),
-    FilterText: z.string().nullish().describe(`
+    FilterText: z.string().nullable().describe(`
         * * Field Name: FilterText
         * * Display Name: Filter Text
         * * SQL Data Type: nvarchar(MAX)`),
@@ -8242,11 +8349,11 @@ export const ScheduledActionParamSchema = z.object({
     * * Possible Values 
     *   * Static
     *   * SQL Statement`),
-    Value: z.string().nullish().describe(`
+    Value: z.string().nullable().describe(`
         * * Field Name: Value
         * * Display Name: Value
         * * SQL Data Type: nvarchar(MAX)`),
-    Comments: z.string().nullish().describe(`
+    Comments: z.string().nullable().describe(`
         * * Field Name: Comments
         * * Display Name: Comments
         * * SQL Data Type: nvarchar(MAX)`),
@@ -8285,7 +8392,7 @@ export const ScheduledActionSchema = z.object({
         * * Field Name: Name
         * * Display Name: Name
         * * SQL Data Type: nvarchar(255)`),
-    Description: z.string().nullish().describe(`
+    Description: z.string().nullable().describe(`
         * * Field Name: Description
         * * Display Name: Description
         * * SQL Data Type: nvarchar(MAX)`),
@@ -8311,7 +8418,7 @@ export const ScheduledActionSchema = z.object({
     *   * Yearly
     *   * Custom
     * * Description: Type of the scheduled action (Daily, Weekly, Monthly, Yearly, Custom)`),
-    CronExpression: z.string().nullish().describe(`
+    CronExpression: z.string().nullable().describe(`
         * * Field Name: CronExpression
         * * Display Name: Cron Expression
         * * SQL Data Type: nvarchar(100)
@@ -8333,27 +8440,27 @@ export const ScheduledActionSchema = z.object({
     *   * Disabled
     *   * Expired
     * * Description: Status of the scheduled action (Pending, Active, Disabled, Expired)`),
-    IntervalDays: z.number().nullish().describe(`
+    IntervalDays: z.number().nullable().describe(`
         * * Field Name: IntervalDays
         * * Display Name: Interval Days
         * * SQL Data Type: int
     * * Description: Interval in days for the scheduled action`),
-    DayOfWeek: z.string().nullish().describe(`
+    DayOfWeek: z.string().nullable().describe(`
         * * Field Name: DayOfWeek
         * * Display Name: Day Of Week
         * * SQL Data Type: nvarchar(20)
     * * Description: Day of the week for the scheduled action`),
-    DayOfMonth: z.number().nullish().describe(`
+    DayOfMonth: z.number().nullable().describe(`
         * * Field Name: DayOfMonth
         * * Display Name: Day Of Month
         * * SQL Data Type: int
     * * Description: Day of the month for the scheduled action`),
-    Month: z.string().nullish().describe(`
+    Month: z.string().nullable().describe(`
         * * Field Name: Month
         * * Display Name: Month
         * * SQL Data Type: nvarchar(20)
     * * Description: Month for the scheduled action`),
-    CustomCronExpression: z.string().nullish().describe(`
+    CustomCronExpression: z.string().nullable().describe(`
         * * Field Name: CustomCronExpression
         * * Display Name: Custom Cron Expression
         * * SQL Data Type: nvarchar(255)`),
@@ -8400,7 +8507,7 @@ export const SchemaInfoSchema = z.object({
         * * Field Name: EntityIDMax
         * * Display Name: Entity IDMax
         * * SQL Data Type: int`),
-    Comments: z.string().nullish().describe(`
+    Comments: z.string().nullable().describe(`
         * * Field Name: Comments
         * * Display Name: Comments
         * * SQL Data Type: nvarchar(MAX)`),
@@ -8429,7 +8536,7 @@ export const SkillSchema = z.object({
     Name: z.string().describe(`
         * * Field Name: Name
         * * SQL Data Type: nvarchar(50)`),
-    ParentID: z.string().nullish().describe(`
+    ParentID: z.string().nullable().describe(`
         * * Field Name: ParentID
         * * Display Name: Parent
         * * SQL Data Type: uniqueidentifier
@@ -8444,7 +8551,7 @@ export const SkillSchema = z.object({
         * * Display Name: Updated At
         * * SQL Data Type: datetimeoffset
         * * Default Value: getutcdate()`),
-    Parent: z.string().nullish().describe(`
+    Parent: z.string().nullable().describe(`
         * * Field Name: Parent
         * * Display Name: Parent
         * * SQL Data Type: nvarchar(50)`),
@@ -8510,7 +8617,7 @@ export const TagSchema = z.object({
         * * Field Name: Name
         * * Display Name: Name
         * * SQL Data Type: nvarchar(255)`),
-    ParentID: z.string().nullish().describe(`
+    ParentID: z.string().nullable().describe(`
         * * Field Name: ParentID
         * * Display Name: Parent ID
         * * SQL Data Type: uniqueidentifier
@@ -8519,7 +8626,7 @@ export const TagSchema = z.object({
         * * Field Name: DisplayName
         * * Display Name: Display Name
         * * SQL Data Type: nvarchar(255)`),
-    Description: z.string().nullish().describe(`
+    Description: z.string().nullable().describe(`
         * * Field Name: Description
         * * Display Name: Description
         * * SQL Data Type: nvarchar(MAX)`),
@@ -8533,7 +8640,7 @@ export const TagSchema = z.object({
         * * Display Name: Updated At
         * * SQL Data Type: datetimeoffset
         * * Default Value: getutcdate()`),
-    Parent: z.string().nullish().describe(`
+    Parent: z.string().nullable().describe(`
         * * Field Name: Parent
         * * Display Name: Parent
         * * SQL Data Type: nvarchar(255)`),
@@ -8555,12 +8662,12 @@ export const TemplateCategorySchema = z.object({
         * * Display Name: Name
         * * SQL Data Type: nvarchar(255)
     * * Description: Name of the template category`),
-    Description: z.string().nullish().describe(`
+    Description: z.string().nullable().describe(`
         * * Field Name: Description
         * * Display Name: Description
         * * SQL Data Type: nvarchar(MAX)
     * * Description: Description of the template category`),
-    ParentID: z.string().nullish().describe(`
+    ParentID: z.string().nullable().describe(`
         * * Field Name: ParentID
         * * Display Name: Parent ID
         * * SQL Data Type: uniqueidentifier
@@ -8580,7 +8687,7 @@ export const TemplateCategorySchema = z.object({
         * * Display Name: Updated At
         * * SQL Data Type: datetimeoffset
         * * Default Value: getutcdate()`),
-    Parent: z.string().nullish().describe(`
+    Parent: z.string().nullable().describe(`
         * * Field Name: Parent
         * * Display Name: Parent
         * * SQL Data Type: nvarchar(255)`),
@@ -8606,7 +8713,7 @@ export const TemplateContentTypeSchema = z.object({
         * * Display Name: Name
         * * SQL Data Type: nvarchar(255)
     * * Description: Name of the template content type`),
-    Description: z.string().nullish().describe(`
+    Description: z.string().nullable().describe(`
         * * Field Name: Description
         * * Display Name: Description
         * * SQL Data Type: nvarchar(MAX)
@@ -8659,7 +8766,7 @@ export const TemplateContentSchema = z.object({
         * * Display Name: Type ID
         * * SQL Data Type: uniqueidentifier
         * * Related Entity/Foreign Key: Template Content Types (vwTemplateContentTypes.ID)`),
-    TemplateText: z.string().nullish().describe(`
+    TemplateText: z.string().nullable().describe(`
         * * Field Name: TemplateText
         * * Display Name: Template Text
         * * SQL Data Type: nvarchar(MAX)
@@ -8716,7 +8823,7 @@ export const TemplateParamSchema = z.object({
         * * Display Name: Name
         * * SQL Data Type: nvarchar(255)
     * * Description: Name of the parameter`),
-    Description: z.string().nullish().describe(`
+    Description: z.string().nullable().describe(`
         * * Field Name: Description
         * * Display Name: Description
         * * SQL Data Type: nvarchar(MAX)
@@ -8734,7 +8841,7 @@ export const TemplateParamSchema = z.object({
     *   * Record
     *   * Entity
     * * Description: Type of the parameter - Record is an individual record within the entity specified by EntityID. Entity means an entire Entity or an entity filtered by the LinkedParameterName/Field attributes and/or ExtraFilter. Object is any valid JSON object. Array and Scalar have their common meanings.`),
-    DefaultValue: z.string().nullish().describe(`
+    DefaultValue: z.string().nullable().describe(`
         * * Field Name: DefaultValue
         * * Display Name: Default Value
         * * SQL Data Type: nvarchar(MAX)
@@ -8744,27 +8851,27 @@ export const TemplateParamSchema = z.object({
         * * Display Name: Is Required
         * * SQL Data Type: bit
         * * Default Value: 0`),
-    LinkedParameterName: z.string().nullish().describe(`
+    LinkedParameterName: z.string().nullable().describe(`
         * * Field Name: LinkedParameterName
         * * Display Name: Linked Parameter Name
         * * SQL Data Type: nvarchar(255)
     * * Description: Only used when Type=Entity, this is used to link an Entity parameter with another parameter so that the rows in the Entity parameter can be filtered automatically based on the FKEY relationship between the Record and this Entity parameter. For example, if the Entity-based parameter is for an entity like Activities and there is another parameter of type Record for an entity like Contacts, in that situation the Activities Parameter would point to the Contacts parameter as the LinkedParameterName because we would filter down the Activities in each template render to only those linked to the Contact.`),
-    LinkedParameterField: z.string().nullish().describe(`
+    LinkedParameterField: z.string().nullable().describe(`
         * * Field Name: LinkedParameterField
         * * Display Name: Linked Parameter Field
         * * SQL Data Type: nvarchar(500)
     * * Description: If the LinkedParameterName is specified, this is an optional setting to specify the field within the LinkedParameter that will be used for filtering. This is only needed if there is more than one foreign key relationship between the Entity parameter and the Linked parameter, or if there is no defined foreign key in the database between the two entities.`),
-    ExtraFilter: z.string().nullish().describe(`
+    ExtraFilter: z.string().nullable().describe(`
         * * Field Name: ExtraFilter
         * * Display Name: Extra Filter
         * * SQL Data Type: nvarchar(MAX)
     * * Description: Only used when Type = Entity, used to specify an optional filter to reduce the set of rows that are returned for each of the templates being rendered.`),
-    EntityID: z.string().nullish().describe(`
+    EntityID: z.string().nullable().describe(`
         * * Field Name: EntityID
         * * Display Name: Entity ID
         * * SQL Data Type: uniqueidentifier
         * * Related Entity/Foreign Key: Entities (vwEntities.ID)`),
-    RecordID: z.string().nullish().describe(`
+    RecordID: z.string().nullable().describe(`
         * * Field Name: RecordID
         * * Display Name: Record ID
         * * SQL Data Type: nvarchar(2000)
@@ -8779,7 +8886,7 @@ export const TemplateParamSchema = z.object({
         * * Display Name: Updated At
         * * SQL Data Type: datetimeoffset
         * * Default Value: getutcdate()`),
-    OrderBy: z.string().nullish().describe(`
+    OrderBy: z.string().nullable().describe(`
         * * Field Name: OrderBy
         * * Display Name: Order By
         * * SQL Data Type: nvarchar(MAX)
@@ -8788,7 +8895,7 @@ export const TemplateParamSchema = z.object({
         * * Field Name: Template
         * * Display Name: Template
         * * SQL Data Type: nvarchar(255)`),
-    Entity: z.string().nullish().describe(`
+    Entity: z.string().nullable().describe(`
         * * Field Name: Entity
         * * Display Name: Entity
         * * SQL Data Type: nvarchar(255)`),
@@ -8810,17 +8917,17 @@ export const TemplateSchema = z.object({
         * * Display Name: Name
         * * SQL Data Type: nvarchar(255)
     * * Description: Name of the template`),
-    Description: z.string().nullish().describe(`
+    Description: z.string().nullable().describe(`
         * * Field Name: Description
         * * Display Name: Description
         * * SQL Data Type: nvarchar(MAX)
     * * Description: Description of the template`),
-    CategoryID: z.string().nullish().describe(`
+    CategoryID: z.string().nullable().describe(`
         * * Field Name: CategoryID
         * * Display Name: Category ID
         * * SQL Data Type: uniqueidentifier
         * * Related Entity/Foreign Key: Template Categories (vwTemplateCategories.ID)`),
-    UserPrompt: z.string().nullish().describe(`
+    UserPrompt: z.string().nullable().describe(`
         * * Field Name: UserPrompt
         * * Display Name: User Prompt
         * * SQL Data Type: nvarchar(MAX)
@@ -8830,12 +8937,12 @@ export const TemplateSchema = z.object({
         * * Display Name: User ID
         * * SQL Data Type: uniqueidentifier
         * * Related Entity/Foreign Key: Users (vwUsers.ID)`),
-    ActiveAt: z.date().nullish().describe(`
+    ActiveAt: z.date().nullable().describe(`
         * * Field Name: ActiveAt
         * * Display Name: Active At
         * * SQL Data Type: datetime
     * * Description: Optional, if provided, this template will not be available for use until the specified date. Requires IsActive to be set to 1`),
-    DisabledAt: z.date().nullish().describe(`
+    DisabledAt: z.date().nullable().describe(`
         * * Field Name: DisabledAt
         * * Display Name: Disabled At
         * * SQL Data Type: datetime
@@ -8856,7 +8963,7 @@ export const TemplateSchema = z.object({
         * * Display Name: Updated At
         * * SQL Data Type: datetimeoffset
         * * Default Value: getutcdate()`),
-    Category: z.string().nullish().describe(`
+    Category: z.string().nullable().describe(`
         * * Field Name: Category
         * * Display Name: Category
         * * SQL Data Type: nvarchar(255)`),
@@ -9026,20 +9133,20 @@ export const UserNotificationSchema = z.object({
         * * Display Name: User ID
         * * SQL Data Type: uniqueidentifier
         * * Related Entity/Foreign Key: Users (vwUsers.ID)`),
-    Title: z.string().nullish().describe(`
+    Title: z.string().nullable().describe(`
         * * Field Name: Title
         * * Display Name: Title
         * * SQL Data Type: nvarchar(255)`),
-    Message: z.string().nullish().describe(`
+    Message: z.string().nullable().describe(`
         * * Field Name: Message
         * * Display Name: Message
         * * SQL Data Type: nvarchar(MAX)`),
-    ResourceTypeID: z.string().nullish().describe(`
+    ResourceTypeID: z.string().nullable().describe(`
         * * Field Name: ResourceTypeID
         * * Display Name: Resource Type ID
         * * SQL Data Type: uniqueidentifier
         * * Related Entity/Foreign Key: Resource Types (vwResourceTypes.ID)`),
-    ResourceConfiguration: z.string().nullish().describe(`
+    ResourceConfiguration: z.string().nullable().describe(`
         * * Field Name: ResourceConfiguration
         * * Display Name: Resource Configuration
         * * SQL Data Type: nvarchar(MAX)`),
@@ -9048,7 +9155,7 @@ export const UserNotificationSchema = z.object({
         * * Display Name: Unread
         * * SQL Data Type: bit
         * * Default Value: 1`),
-    ReadAt: z.date().nullish().describe(`
+    ReadAt: z.date().nullable().describe(`
         * * Field Name: ReadAt
         * * Display Name: Read At
         * * SQL Data Type: datetime`),
@@ -9062,7 +9169,7 @@ export const UserNotificationSchema = z.object({
         * * Display Name: Updated At
         * * SQL Data Type: datetimeoffset
         * * Default Value: getutcdate()`),
-    ResourceRecordID: z.string().nullish().describe(`
+    ResourceRecordID: z.string().nullable().describe(`
         * * Field Name: ResourceRecordID
         * * Display Name: Resource Record ID
         * * SQL Data Type: uniqueidentifier`),
@@ -9070,7 +9177,7 @@ export const UserNotificationSchema = z.object({
         * * Field Name: User
         * * Display Name: User
         * * SQL Data Type: nvarchar(100)`),
-    ResourceType: z.string().nullish().describe(`
+    ResourceType: z.string().nullable().describe(`
         * * Field Name: ResourceType
         * * Display Name: Resource Type
         * * SQL Data Type: nvarchar(255)`),
@@ -9133,7 +9240,7 @@ export const UserRecordLogSchema = z.object({
         * * Field Name: UserName
         * * Display Name: User Name
         * * SQL Data Type: nvarchar(100)`),
-    UserFirstLast: z.string().nullish().describe(`
+    UserFirstLast: z.string().nullable().describe(`
         * * Field Name: UserFirstLast
         * * Display Name: User First Last
         * * SQL Data Type: nvarchar(101)`),
@@ -9141,11 +9248,11 @@ export const UserRecordLogSchema = z.object({
         * * Field Name: UserEmail
         * * Display Name: User Email
         * * SQL Data Type: nvarchar(100)`),
-    UserSupervisor: z.string().nullish().describe(`
+    UserSupervisor: z.string().nullable().describe(`
         * * Field Name: UserSupervisor
         * * Display Name: User Supervisor
         * * SQL Data Type: nvarchar(81)`),
-    UserSupervisorEmail: z.string().nullish().describe(`
+    UserSupervisorEmail: z.string().nullable().describe(`
         * * Field Name: UserSupervisorEmail
         * * Display Name: User Supervisor Email
         * * SQL Data Type: nvarchar(100)`),
@@ -9207,11 +9314,11 @@ export const UserViewCategorySchema = z.object({
         * * Field Name: Name
         * * Display Name: Name
         * * SQL Data Type: nvarchar(100)`),
-    Description: z.string().nullish().describe(`
+    Description: z.string().nullable().describe(`
         * * Field Name: Description
         * * Display Name: Description
         * * SQL Data Type: nvarchar(MAX)`),
-    ParentID: z.string().nullish().describe(`
+    ParentID: z.string().nullable().describe(`
         * * Field Name: ParentID
         * * Display Name: Parent ID
         * * SQL Data Type: uniqueidentifier
@@ -9236,7 +9343,7 @@ export const UserViewCategorySchema = z.object({
         * * Display Name: Updated At
         * * SQL Data Type: datetimeoffset
         * * Default Value: getutcdate()`),
-    Parent: z.string().nullish().describe(`
+    Parent: z.string().nullable().describe(`
         * * Field Name: Parent
         * * Display Name: Parent
         * * SQL Data Type: nvarchar(100)`),
@@ -9356,10 +9463,10 @@ export const UserViewSchema = z.object({
     Name: z.string().describe(`
         * * Field Name: Name
         * * SQL Data Type: nvarchar(100)`),
-    Description: z.string().nullish().describe(`
+    Description: z.string().nullable().describe(`
         * * Field Name: Description
         * * SQL Data Type: nvarchar(MAX)`),
-    CategoryID: z.string().nullish().describe(`
+    CategoryID: z.string().nullable().describe(`
         * * Field Name: CategoryID
         * * Display Name: Category ID
         * * SQL Data Type: uniqueidentifier
@@ -9374,11 +9481,11 @@ export const UserViewSchema = z.object({
         * * Display Name: Is Default
         * * SQL Data Type: bit
         * * Default Value: 0`),
-    GridState: z.string().nullish().describe(`
+    GridState: z.string().nullable().describe(`
         * * Field Name: GridState
         * * Display Name: Grid State
         * * SQL Data Type: nvarchar(MAX)`),
-    FilterState: z.string().nullish().describe(`
+    FilterState: z.string().nullable().describe(`
         * * Field Name: FilterState
         * * Display Name: Filter State
         * * SQL Data Type: nvarchar(MAX)`),
@@ -9392,19 +9499,19 @@ export const UserViewSchema = z.object({
         * * Display Name: Smart Filter Enabled
         * * SQL Data Type: bit
         * * Default Value: 0`),
-    SmartFilterPrompt: z.string().nullish().describe(`
+    SmartFilterPrompt: z.string().nullable().describe(`
         * * Field Name: SmartFilterPrompt
         * * Display Name: Smart Filter Prompt
         * * SQL Data Type: nvarchar(MAX)`),
-    SmartFilterWhereClause: z.string().nullish().describe(`
+    SmartFilterWhereClause: z.string().nullable().describe(`
         * * Field Name: SmartFilterWhereClause
         * * Display Name: Smart Filter Where Clause
         * * SQL Data Type: nvarchar(MAX)`),
-    SmartFilterExplanation: z.string().nullish().describe(`
+    SmartFilterExplanation: z.string().nullable().describe(`
         * * Field Name: SmartFilterExplanation
         * * Display Name: Smart Filter Explanation
         * * SQL Data Type: nvarchar(MAX)`),
-    WhereClause: z.string().nullish().describe(`
+    WhereClause: z.string().nullable().describe(`
         * * Field Name: WhereClause
         * * Display Name: Where Clause
         * * SQL Data Type: nvarchar(MAX)`),
@@ -9413,7 +9520,7 @@ export const UserViewSchema = z.object({
         * * Display Name: Custom Where Clause
         * * SQL Data Type: bit
         * * Default Value: 0`),
-    SortState: z.string().nullish().describe(`
+    SortState: z.string().nullable().describe(`
         * * Field Name: SortState
         * * Display Name: Sort State
         * * SQL Data Type: nvarchar(MAX)`),
@@ -9431,7 +9538,7 @@ export const UserViewSchema = z.object({
         * * Field Name: UserName
         * * Display Name: User Name
         * * SQL Data Type: nvarchar(100)`),
-    UserFirstLast: z.string().nullish().describe(`
+    UserFirstLast: z.string().nullable().describe(`
         * * Field Name: UserFirstLast
         * * Display Name: User First Last
         * * SQL Data Type: nvarchar(101)`),
@@ -9466,15 +9573,15 @@ export const UserSchema = z.object({
     Name: z.string().describe(`
         * * Field Name: Name
         * * SQL Data Type: nvarchar(100)`),
-    FirstName: z.string().nullish().describe(`
+    FirstName: z.string().nullable().describe(`
         * * Field Name: FirstName
         * * Display Name: First Name
         * * SQL Data Type: nvarchar(50)`),
-    LastName: z.string().nullish().describe(`
+    LastName: z.string().nullable().describe(`
         * * Field Name: LastName
         * * Display Name: Last Name
         * * SQL Data Type: nvarchar(50)`),
-    Title: z.string().nullish().describe(`
+    Title: z.string().nullable().describe(`
         * * Field Name: Title
         * * Display Name: Title
         * * SQL Data Type: nvarchar(50)`),
@@ -9498,16 +9605,16 @@ export const UserSchema = z.object({
         * * Display Name: Linked Record Type
         * * SQL Data Type: nchar(10)
         * * Default Value: None`),
-    LinkedEntityID: z.string().nullish().describe(`
+    LinkedEntityID: z.string().nullable().describe(`
         * * Field Name: LinkedEntityID
         * * Display Name: Linked Entity ID
         * * SQL Data Type: uniqueidentifier
         * * Related Entity/Foreign Key: Entities (vwEntities.ID)`),
-    LinkedEntityRecordID: z.string().nullish().describe(`
+    LinkedEntityRecordID: z.string().nullable().describe(`
         * * Field Name: LinkedEntityRecordID
         * * Display Name: Linked Entity Record ID
         * * SQL Data Type: nvarchar(450)`),
-    EmployeeID: z.string().nullish().describe(`
+    EmployeeID: z.string().nullable().describe(`
         * * Field Name: EmployeeID
         * * Display Name: Employee
         * * SQL Data Type: uniqueidentifier
@@ -9522,27 +9629,27 @@ export const UserSchema = z.object({
         * * Display Name: __mj _Updated At
         * * SQL Data Type: datetimeoffset
         * * Default Value: getutcdate()`),
-    FirstLast: z.string().nullish().describe(`
+    FirstLast: z.string().nullable().describe(`
         * * Field Name: FirstLast
         * * Display Name: First Last
         * * SQL Data Type: nvarchar(101)`),
-    EmployeeFirstLast: z.string().nullish().describe(`
+    EmployeeFirstLast: z.string().nullable().describe(`
         * * Field Name: EmployeeFirstLast
         * * Display Name: Employee First Last
         * * SQL Data Type: nvarchar(81)`),
-    EmployeeEmail: z.string().nullish().describe(`
+    EmployeeEmail: z.string().nullable().describe(`
         * * Field Name: EmployeeEmail
         * * Display Name: Employee Email
         * * SQL Data Type: nvarchar(100)`),
-    EmployeeTitle: z.string().nullish().describe(`
+    EmployeeTitle: z.string().nullable().describe(`
         * * Field Name: EmployeeTitle
         * * Display Name: Employee Title
         * * SQL Data Type: nvarchar(50)`),
-    EmployeeSupervisor: z.string().nullish().describe(`
+    EmployeeSupervisor: z.string().nullable().describe(`
         * * Field Name: EmployeeSupervisor
         * * Display Name: Employee Supervisor
         * * SQL Data Type: nvarchar(81)`),
-    EmployeeSupervisorEmail: z.string().nullish().describe(`
+    EmployeeSupervisorEmail: z.string().nullable().describe(`
         * * Field Name: EmployeeSupervisorEmail
         * * Display Name: Employee Supervisor Email
         * * SQL Data Type: nvarchar(100)`),
@@ -9563,15 +9670,15 @@ export const VectorDatabaseSchema = z.object({
         * * Field Name: Name
         * * Display Name: Name
         * * SQL Data Type: nvarchar(100)`),
-    Description: z.string().nullish().describe(`
+    Description: z.string().nullable().describe(`
         * * Field Name: Description
         * * Display Name: Description
         * * SQL Data Type: nvarchar(MAX)`),
-    DefaultURL: z.string().nullish().describe(`
+    DefaultURL: z.string().nullable().describe(`
         * * Field Name: DefaultURL
         * * Display Name: Default URL
         * * SQL Data Type: nvarchar(255)`),
-    ClassKey: z.string().nullish().describe(`
+    ClassKey: z.string().nullable().describe(`
         * * Field Name: ClassKey
         * * Display Name: Class Key
         * * SQL Data Type: nvarchar(100)`),
@@ -9602,7 +9709,7 @@ export const VectorIndexSchema = z.object({
         * * Field Name: Name
         * * Display Name: Name
         * * SQL Data Type: nvarchar(255)`),
-    Description: z.string().nullish().describe(`
+    Description: z.string().nullable().describe(`
         * * Field Name: Description
         * * Display Name: Description
         * * SQL Data Type: nvarchar(MAX)`),
@@ -9659,7 +9766,7 @@ export const VersionInstallationSchema = z.object({
         * * Field Name: PatchVersion
         * * Display Name: Patch Version
         * * SQL Data Type: int`),
-    Type: z.union([z.literal('New'), z.literal('Upgrade')]).nullish().describe(`
+    Type: z.union([z.literal('New'), z.literal('Upgrade')]).nullable().describe(`
         * * Field Name: Type
         * * Display Name: Type
         * * SQL Data Type: nvarchar(20)
@@ -9685,12 +9792,12 @@ export const VersionInstallationSchema = z.object({
     *   * Complete
     *   * Failed
     * * Description: Pending, Complete, Failed`),
-    InstallLog: z.string().nullish().describe(`
+    InstallLog: z.string().nullable().describe(`
         * * Field Name: InstallLog
         * * Display Name: Install Log
         * * SQL Data Type: nvarchar(MAX)
     * * Description: Any logging that was saved from the installation process`),
-    Comments: z.string().nullish().describe(`
+    Comments: z.string().nullable().describe(`
         * * Field Name: Comments
         * * Display Name: Comments
         * * SQL Data Type: nvarchar(MAX)
@@ -9705,7 +9812,7 @@ export const VersionInstallationSchema = z.object({
         * * Display Name: Updated At
         * * SQL Data Type: datetimeoffset
         * * Default Value: getutcdate()`),
-    CompleteVersion: z.string().nullish().describe(`
+    CompleteVersion: z.string().nullable().describe(`
         * * Field Name: CompleteVersion
         * * Display Name: Complete Version
         * * SQL Data Type: nvarchar(302)`),
@@ -9724,7 +9831,7 @@ export const WorkflowEngineSchema = z.object({
     Name: z.string().describe(`
         * * Field Name: Name
         * * SQL Data Type: nvarchar(100)`),
-    Description: z.string().nullish().describe(`
+    Description: z.string().nullable().describe(`
         * * Field Name: Description
         * * SQL Data Type: nvarchar(MAX)`),
     DriverPath: z.string().describe(`
@@ -9770,7 +9877,7 @@ export const WorkflowRunSchema = z.object({
         * * Field Name: StartedAt
         * * Display Name: Started At
         * * SQL Data Type: datetime`),
-    EndedAt: z.date().nullish().describe(`
+    EndedAt: z.date().nullable().describe(`
         * * Field Name: EndedAt
         * * Display Name: Ended At
         * * SQL Data Type: datetime`),
@@ -9784,7 +9891,7 @@ export const WorkflowRunSchema = z.object({
     *   * In Progress
     *   * Complete
     *   * Failed`),
-    Results: z.string().nullish().describe(`
+    Results: z.string().nullable().describe(`
         * * Field Name: Results
         * * SQL Data Type: nvarchar(MAX)`),
     __mj_CreatedAt: z.date().describe(`
@@ -9820,7 +9927,7 @@ export const WorkflowSchema = z.object({
     Name: z.string().describe(`
         * * Field Name: Name
         * * SQL Data Type: nvarchar(100)`),
-    Description: z.string().nullish().describe(`
+    Description: z.string().nullable().describe(`
         * * Field Name: Description
         * * SQL Data Type: nvarchar(MAX)`),
     WorkflowEngineID: z.string().describe(`
@@ -9838,7 +9945,7 @@ export const WorkflowSchema = z.object({
         * * SQL Data Type: bit
         * * Default Value: 0
     * * Description: If set to 1, the workflow will be run automatically on the interval specified by the AutoRunIntervalType and AutoRunInterval fields`),
-    AutoRunIntervalUnits: z.union([z.literal('Years'), z.literal('Months'), z.literal('Weeks'), z.literal('Days'), z.literal('Hours'), z.literal('Minutes')]).nullish().describe(`
+    AutoRunIntervalUnits: z.union([z.literal('Years'), z.literal('Months'), z.literal('Weeks'), z.literal('Days'), z.literal('Hours'), z.literal('Minutes')]).nullable().describe(`
         * * Field Name: AutoRunIntervalUnits
         * * Display Name: Auto Run Interval Units
         * * SQL Data Type: nvarchar(20)
@@ -9851,12 +9958,12 @@ export const WorkflowSchema = z.object({
     *   * Hours
     *   * Minutes
     * * Description: Minutes, Hours, Days, Weeks, Months, Years`),
-    AutoRunInterval: z.number().nullish().describe(`
+    AutoRunInterval: z.number().nullable().describe(`
         * * Field Name: AutoRunInterval
         * * Display Name: Auto Run Interval
         * * SQL Data Type: int
     * * Description: The interval, denominated in the units specified in the AutoRunIntervalUnits column, between auto runs of this workflow.`),
-    SubclassName: z.string().nullish().describe(`
+    SubclassName: z.string().nullable().describe(`
         * * Field Name: SubclassName
         * * Display Name: Subclass Name
         * * SQL Data Type: nvarchar(200)
@@ -9871,7 +9978,7 @@ export const WorkflowSchema = z.object({
         * * Display Name: Updated At
         * * SQL Data Type: datetimeoffset
         * * Default Value: getutcdate()`),
-    AutoRunIntervalMinutes: z.number().nullish().describe(`
+    AutoRunIntervalMinutes: z.number().nullable().describe(`
         * * Field Name: AutoRunIntervalMinutes
         * * Display Name: Auto Run Interval Minutes
         * * SQL Data Type: int`),
@@ -9892,7 +9999,7 @@ export const WorkspaceItemSchema = z.object({
         * * Field Name: Name
         * * Display Name: Name
         * * SQL Data Type: nvarchar(255)`),
-    Description: z.string().nullish().describe(`
+    Description: z.string().nullable().describe(`
         * * Field Name: Description
         * * Display Name: Description
         * * SQL Data Type: nvarchar(MAX)`),
@@ -9906,7 +10013,7 @@ export const WorkspaceItemSchema = z.object({
         * * Display Name: Resource Type ID
         * * SQL Data Type: uniqueidentifier
         * * Related Entity/Foreign Key: Resource Types (vwResourceTypes.ID)`),
-    ResourceRecordID: z.string().nullish().describe(`
+    ResourceRecordID: z.string().nullable().describe(`
         * * Field Name: ResourceRecordID
         * * Display Name: Resource Record ID
         * * SQL Data Type: nvarchar(2000)`),
@@ -9914,7 +10021,7 @@ export const WorkspaceItemSchema = z.object({
         * * Field Name: Sequence
         * * Display Name: Sequence
         * * SQL Data Type: int`),
-    Configuration: z.string().nullish().describe(`
+    Configuration: z.string().nullable().describe(`
         * * Field Name: Configuration
         * * Display Name: Configuration
         * * SQL Data Type: nvarchar(MAX)`),
@@ -9953,7 +10060,7 @@ export const WorkspaceSchema = z.object({
         * * Field Name: Name
         * * Display Name: Name
         * * SQL Data Type: nvarchar(255)`),
-    Description: z.string().nullish().describe(`
+    Description: z.string().nullable().describe(`
         * * Field Name: Description
         * * Display Name: Description
         * * SQL Data Type: nvarchar(MAX)`),
@@ -27272,6 +27379,302 @@ export class ListEntity extends BaseEntity<ListEntityType> {
     */
     get Category(): string | null {
         return this.Get('Category');
+    }
+}
+
+
+/**
+ * MJ: Report User States - strongly typed entity sub-class
+ * * Schema: __mj
+ * * Base Table: ReportUserState
+ * * Base View: vwReportUserStates
+ * * Primary Key: ID
+ * @extends {BaseEntity}
+ * @class
+ * @public
+ */
+@RegisterClass(BaseEntity, 'MJ: Report User States')
+export class ReportUserStateEntity extends BaseEntity<ReportUserStateEntityType> {
+    /**
+    * Loads the MJ: Report User States record from the database
+    * @param ID: string - primary key value to load the MJ: Report User States record.
+    * @param EntityRelationshipsToLoad - (optional) the relationships to load
+    * @returns {Promise<boolean>} - true if successful, false otherwise
+    * @public
+    * @async
+    * @memberof ReportUserStateEntity
+    * @method
+    * @override
+    */
+    public async Load(ID: string, EntityRelationshipsToLoad?: string[]) : Promise<boolean> {
+        const compositeKey: CompositeKey = new CompositeKey();
+        compositeKey.KeyValuePairs.push({ FieldName: 'ID', Value: ID });
+        return await super.InnerLoad(compositeKey, EntityRelationshipsToLoad);
+    }
+
+    /**
+    * * Field Name: ID
+    * * Display Name: ID
+    * * SQL Data Type: uniqueidentifier
+    * * Default Value: newsequentialid()
+    */
+    get ID(): string {
+        return this.Get('ID');
+    }
+
+    /**
+    * * Field Name: ReportID
+    * * Display Name: Report ID
+    * * SQL Data Type: uniqueidentifier
+    * * Related Entity/Foreign Key: Reports (vwReports.ID)
+    */
+    get ReportID(): string {
+        return this.Get('ReportID');
+    }
+    set ReportID(value: string) {
+        this.Set('ReportID', value);
+    }
+
+    /**
+    * * Field Name: UserID
+    * * Display Name: User ID
+    * * SQL Data Type: uniqueidentifier
+    * * Related Entity/Foreign Key: Users (vwUsers.ID)
+    */
+    get UserID(): string {
+        return this.Get('UserID');
+    }
+    set UserID(value: string) {
+        this.Set('UserID', value);
+    }
+
+    /**
+    * * Field Name: ReportState
+    * * Display Name: Report State
+    * * SQL Data Type: nvarchar(MAX)
+    * * Description: JSON serialized state of user interaction with the report
+    */
+    get ReportState(): string | null {
+        return this.Get('ReportState');
+    }
+    set ReportState(value: string | null) {
+        this.Set('ReportState', value);
+    }
+
+    /**
+    * * Field Name: __mj_CreatedAt
+    * * Display Name: Created At
+    * * SQL Data Type: datetimeoffset
+    * * Default Value: getutcdate()
+    */
+    get __mj_CreatedAt(): Date {
+        return this.Get('__mj_CreatedAt');
+    }
+
+    /**
+    * * Field Name: __mj_UpdatedAt
+    * * Display Name: Updated At
+    * * SQL Data Type: datetimeoffset
+    * * Default Value: getutcdate()
+    */
+    get __mj_UpdatedAt(): Date {
+        return this.Get('__mj_UpdatedAt');
+    }
+
+    /**
+    * * Field Name: Report
+    * * Display Name: Report
+    * * SQL Data Type: nvarchar(255)
+    * * Default Value: null
+    */
+    get Report(): string {
+        return this.Get('Report');
+    }
+
+    /**
+    * * Field Name: User
+    * * Display Name: User
+    * * SQL Data Type: nvarchar(100)
+    * * Default Value: null
+    */
+    get User(): string {
+        return this.Get('User');
+    }
+}
+
+
+/**
+ * MJ: Report Versions - strongly typed entity sub-class
+ * * Schema: __mj
+ * * Base Table: ReportVersion
+ * * Base View: vwReportVersions
+ * * Primary Key: ID
+ * @extends {BaseEntity}
+ * @class
+ * @public
+ */
+@RegisterClass(BaseEntity, 'MJ: Report Versions')
+export class ReportVersionEntity extends BaseEntity<ReportVersionEntityType> {
+    /**
+    * Loads the MJ: Report Versions record from the database
+    * @param ID: string - primary key value to load the MJ: Report Versions record.
+    * @param EntityRelationshipsToLoad - (optional) the relationships to load
+    * @returns {Promise<boolean>} - true if successful, false otherwise
+    * @public
+    * @async
+    * @memberof ReportVersionEntity
+    * @method
+    * @override
+    */
+    public async Load(ID: string, EntityRelationshipsToLoad?: string[]) : Promise<boolean> {
+        const compositeKey: CompositeKey = new CompositeKey();
+        compositeKey.KeyValuePairs.push({ FieldName: 'ID', Value: ID });
+        return await super.InnerLoad(compositeKey, EntityRelationshipsToLoad);
+    }
+
+    /**
+    * Validate() method override for MJ: Report Versions entity. This is an auto-generated method that invokes the generated validators for this entity for the following fields: 
+    * * VersionNumber: This rule ensures that the version number must be greater than zero, meaning there should be at least one version created.  
+    * @public
+    * @method
+    * @override
+    */
+    public override Validate(): ValidationResult {
+        const result = super.Validate();
+        this.ValidateVersionNumberGreaterThanZero(result);
+
+        return result;
+    }
+
+    /**
+    * This rule ensures that the version number must be greater than zero, meaning there should be at least one version created.
+    * @param result - the ValidationResult object to add any errors or warnings to
+    * @public
+    * @method
+    */
+    public ValidateVersionNumberGreaterThanZero(result: ValidationResult) {
+    	if (this.VersionNumber <= 0) {
+    		result.Errors.push(new ValidationErrorInfo("VersionNumber", "The version number must be greater than zero.", this.VersionNumber, ValidationErrorType.Failure));
+    	}
+    }
+
+    /**
+    * * Field Name: ID
+    * * Display Name: ID
+    * * SQL Data Type: uniqueidentifier
+    * * Default Value: newsequentialid()
+    */
+    get ID(): string {
+        return this.Get('ID');
+    }
+
+    /**
+    * * Field Name: ReportID
+    * * Display Name: Report ID
+    * * SQL Data Type: uniqueidentifier
+    * * Related Entity/Foreign Key: Reports (vwReports.ID)
+    */
+    get ReportID(): string {
+        return this.Get('ReportID');
+    }
+    set ReportID(value: string) {
+        this.Set('ReportID', value);
+    }
+
+    /**
+    * * Field Name: VersionNumber
+    * * Display Name: Version Number
+    * * SQL Data Type: int
+    * * Description: Report version number, sequential per report starting at 1
+    */
+    get VersionNumber(): number {
+        return this.Get('VersionNumber');
+    }
+    set VersionNumber(value: number) {
+        this.Set('VersionNumber', value);
+    }
+
+    /**
+    * * Field Name: Name
+    * * Display Name: Name
+    * * SQL Data Type: nvarchar(255)
+    * * Description: Name of this report version
+    */
+    get Name(): string {
+        return this.Get('Name');
+    }
+    set Name(value: string) {
+        this.Set('Name', value);
+    }
+
+    /**
+    * * Field Name: Description
+    * * Display Name: Description
+    * * SQL Data Type: nvarchar(MAX)
+    * * Description: Description of this report version
+    */
+    get Description(): string | null {
+        return this.Get('Description');
+    }
+    set Description(value: string | null) {
+        this.Set('Description', value);
+    }
+
+    /**
+    * * Field Name: Configuration
+    * * Display Name: Configuration
+    * * SQL Data Type: nvarchar(MAX)
+    * * Description: JSON configuration of report structure, layout and logic
+    */
+    get Configuration(): string | null {
+        return this.Get('Configuration');
+    }
+    set Configuration(value: string | null) {
+        this.Set('Configuration', value);
+    }
+
+    /**
+    * * Field Name: DataContextUpdated
+    * * Display Name: Data Context Updated
+    * * SQL Data Type: bit
+    * * Default Value: 0
+    * * Description: Indicates if the data context was updated in this version
+    */
+    get DataContextUpdated(): boolean {
+        return this.Get('DataContextUpdated');
+    }
+    set DataContextUpdated(value: boolean) {
+        this.Set('DataContextUpdated', value);
+    }
+
+    /**
+    * * Field Name: __mj_CreatedAt
+    * * Display Name: Created At
+    * * SQL Data Type: datetimeoffset
+    * * Default Value: getutcdate()
+    */
+    get __mj_CreatedAt(): Date {
+        return this.Get('__mj_CreatedAt');
+    }
+
+    /**
+    * * Field Name: __mj_UpdatedAt
+    * * Display Name: Updated At
+    * * SQL Data Type: datetimeoffset
+    * * Default Value: getutcdate()
+    */
+    get __mj_UpdatedAt(): Date {
+        return this.Get('__mj_UpdatedAt');
+    }
+
+    /**
+    * * Field Name: Report
+    * * Display Name: Report
+    * * SQL Data Type: nvarchar(255)
+    * * Default Value: null
+    */
+    get Report(): string {
+        return this.Get('Report');
     }
 }
 

--- a/packages/MJServer/src/entitySubclasses/reportEntity.server.ts
+++ b/packages/MJServer/src/entitySubclasses/reportEntity.server.ts
@@ -1,6 +1,7 @@
-import { BaseEntity, Metadata } from "@memberjunction/core";
-import { RegisterClass } from "@memberjunction/global";
-import { ReportEntity, ReportSnapshotEntity } from "@memberjunction/core-entities";
+import { BaseEntity, Metadata, RunView } from "@memberjunction/core";
+import { RegisterClass, SafeJSONParse } from "@memberjunction/global";
+import { ReportEntity, ReportSnapshotEntity, ReportVersionEntity } from "@memberjunction/core-entities";
+import { SkipAPIAnalysisCompleteResponse } from "@memberjunction/skip-types";
 
 @RegisterClass(BaseEntity, 'Reports')
 export class ReportEntity_Server extends ReportEntity  {
@@ -10,20 +11,119 @@ export class ReportEntity_Server extends ReportEntity  {
      * @returns 
      */
     public async Save(): Promise<boolean> {
-        const createSnapshot: boolean = !this.IsSaved || this.GetFieldByName('Configuration')?.Dirty; // do this only if we have a new record or the configuration has changed
-        const saveResult: boolean = await super.Save();
-        if (saveResult && createSnapshot) {
-            // here we either have a new record or the configuration has changed, so we need to create a snapshot of the report
-            const md = new Metadata();
-            const snapshot = await md.GetEntityObject<ReportSnapshotEntity>('Report Snapshots', this.ContextCurrentUser);
-            snapshot.ReportID = this.ID;
-            snapshot.UserID = this.ContextCurrentUser.ID;
-            // in the snapshot entity the ResultSet column is the Configuration column from the Report entity
-            snapshot.ResultSet = JSON.stringify(this.Configuration);
-            return await snapshot.Save();
-        }        
-        else
-            return saveResult;
+        try {
+            // first let's get the actual parsed object for the Configuration field
+            const config = this.Configuration && this.Configuration.length > 0 ? SafeJSONParse(this.Configuration) : null;
+            const oldTextConfig = this.GetFieldByName('Configuration')?.OldValue;
+            const oldConfig = oldTextConfig && oldTextConfig.length > 0 ? SafeJSONParse(oldTextConfig) : null;
+ 
+            if ( (config && oldConfig) || (config && !this.IsSaved) ) {
+                let createSnapshot = false;
+                let createReportVersion = false;
+                if (this.IsSaved) {
+                    // existing record
+                    // we nave a configuration and an old configuration, so we can compare them, cast them to their strong types first
+                    const castedConfig = config as SkipAPIAnalysisCompleteResponse;
+                    const castedOldConfig = oldConfig as SkipAPIAnalysisCompleteResponse;
+
+                    // Next, we need to see if the data context has changed at all. We do this by comparing the # of items in the data context. a Data context's items are immutable and we only add new Data Context Items
+                    // so we can simply check to see if we have new data context items or not
+                    const dataContextChanged = Object.keys(castedConfig.dataContext || {})?.length !== Object.keys(castedOldConfig.dataContext || {})?.length;
+
+                    // next up, we check to see if anything in the execution results changed. The simple way to do that is convert the execution results back to a string and compare those strings
+                    const executionResultsChanged = JSON.stringify(castedConfig.executionResults) !== JSON.stringify(castedOldConfig.executionResults);
+
+                    // next up we check to see if the analysis changed, which would also represent a "data" change
+                    const analysisChanged = castedConfig.analysis !== castedOldConfig.analysis;
+
+                    // finally, we check to see if the configuration itself has OUTSIDE of the data elements we just checked. We do that by deleting those properties from those objects, converting to strings
+                    // and comparing them
+                    delete castedConfig.dataContext;
+                    delete castedConfig.analysis;
+                    delete castedConfig.executionResults;
+
+                    delete castedOldConfig.dataContext;
+                    delete castedOldConfig.executionResults;
+                    delete castedOldConfig.analysis;
+
+                    // we can now compare the two objects
+                    const configChanged = JSON.stringify(castedConfig) !== JSON.stringify(castedOldConfig);
+
+                    // now our logic is this - if the DATA changed, but the configuration did NOT change, that means we want to create a new SNAPSHOT of the report - which is the data changing side
+                    // if the configuration changed at all we wnat to create a new Report Version. Sometimes both changd and we do both
+                    createSnapshot = dataContextChanged || executionResultsChanged || analysisChanged;
+                    createReportVersion = configChanged;
+                }
+                else {
+                    // we have a new record set createSnapshot to true and createReportVersion to true
+                    createSnapshot = true;
+                    createReportVersion = true;
+                }
+
+                const wasNewRecord: boolean = !this.IsSaved;
+                const saveResult: boolean = await super.Save();
+                if (saveResult && (createSnapshot || createReportVersion)) {
+                    // here we either have a new record or the configuration has changed, so we need to create a snapshot of the report
+                    let success: boolean = true;
+                    const md = new Metadata();
+
+                    if (createReportVersion) {
+                        const reportVersion = await md.GetEntityObject<ReportVersionEntity>('MJ: Report Versions', this.ContextCurrentUser);
+                        reportVersion.ReportID = this.ID;
+                        // const get highest new version number already in DB
+                        let newVersionNumber: number = 1;
+                        if (!wasNewRecord) {
+                            const rv = new RunView();
+                            const rvResult = await rv.RunView({
+                                Fields: ['VersionNumber'],
+                                EntityName: 'MJ: Report Versions',
+                                ExtraFilter: `ReportID = '${this.ID}'`,
+                                MaxRows: 1,
+                                OrderBy: 'VersionNumber DESC',
+                            }, this.ContextCurrentUser);
+                            if (rvResult.Success && rvResult.Results.length > 0) {
+                                newVersionNumber = parseInt(rvResult.Results[0].VersionNumber) + 1;
+                            }
+                            else {
+                                newVersionNumber = 1; // this is an error state as we previously had a saved report, BUT there were no saved versions for the report, so we are going to use 1 here, but let's log a warning
+                                console.warn('ReportEntity_Server.Save(): No report versions found for report ID:', this.ID);
+                                console.warn('ReportEntity_Server.Save(): Using version number 1 for new report version');
+                            }
+                        }
+                        reportVersion.Name = this.Name; // copy current name to the new version
+                        reportVersion.Description = this.Description; // copy current description to the new version
+                        reportVersion.VersionNumber = newVersionNumber;
+                        reportVersion.Configuration = JSON.stringify(this.Configuration);
+                        success = success && await reportVersion.Save();
+                        if (!success) {
+                            console.error('ReportEntity_Server.Save(): Error saving report version\n' + reportVersion.LatestResult.Message);
+                        }
+                    }
+
+                    if (createSnapshot) {
+                        const snapshot = await md.GetEntityObject<ReportSnapshotEntity>('Report Snapshots', this.ContextCurrentUser);
+                        snapshot.ReportID = this.ID;
+                        snapshot.UserID = this.ContextCurrentUser.ID;
+                        // in the snapshot entity the ResultSet column is the Configuration column from the Report entity
+                        snapshot.ResultSet = JSON.stringify(this.Configuration);
+                        success = success && await snapshot.Save();
+                    }
+
+                    return success;
+                }        
+                else {
+                    return saveResult;    
+                }    
+            }
+            else {
+                // no configuration or no parseable configuration, so we just call super.Save();
+                return super.Save();
+            }
+        }
+        catch (e) {
+            console.error('Error in ReportEntity_Server.Save():', e);
+            return false;
+        }
     }
 }
 

--- a/packages/MJServer/src/generated/generated.ts
+++ b/packages/MJServer/src/generated/generated.ts
@@ -19,7 +19,7 @@ import { mj_core_schema } from '../config.js';
 
 
 
-import { ScheduledActionEntity, ScheduledActionParamEntity, ExplorerNavigationItemEntity, GeneratedCodeCategoryEntity, AIAgentModelEntity, AIAgentNoteTypeEntity, AIAgentEntity, AIAgentNoteEntity, AIAgentActionEntity, AIPromptEntity, AIResultCacheEntity, AIPromptCategoryEntity, AIPromptTypeEntity, CompanyEntity, EmployeeEntity, UserFavoriteEntity, EmployeeCompanyIntegrationEntity, EmployeeRoleEntity, EmployeeSkillEntity, RoleEntity, SkillEntity, IntegrationURLFormatEntity, IntegrationEntity, CompanyIntegrationEntity, EntityFieldEntity, EntityEntity, UserEntity, EntityRelationshipEntity, UserRecordLogEntity, UserViewEntity, CompanyIntegrationRunEntity, CompanyIntegrationRunDetailEntity, ErrorLogEntity, ApplicationEntity, ApplicationEntityEntity, EntityPermissionEntity, UserApplicationEntityEntity, UserApplicationEntity, CompanyIntegrationRunAPILogEntity, ListEntity, ListDetailEntity, UserViewRunEntity, UserViewRunDetailEntity, WorkflowRunEntity, WorkflowEntity, WorkflowEngineEntity, RecordChangeEntity, UserRoleEntity, RowLevelSecurityFilterEntity, AuditLogEntity, AuthorizationEntity, AuthorizationRoleEntity, AuditLogTypeEntity, EntityFieldValueEntity, AIModelEntity, AIActionEntity, AIModelActionEntity, EntityAIActionEntity, AIModelTypeEntity, QueueTypeEntity, QueueEntity, QueueTaskEntity, DashboardEntity, OutputTriggerTypeEntity, OutputFormatTypeEntity, OutputDeliveryTypeEntity, ReportEntity, ReportSnapshotEntity, ResourceTypeEntity, TagEntity, TaggedItemEntity, WorkspaceEntity, WorkspaceItemEntity, DatasetEntity, DatasetItemEntity, ConversationDetailEntity, ConversationEntity, UserNotificationEntity, SchemaInfoEntity, CompanyIntegrationRecordMapEntity, RecordMergeLogEntity, RecordMergeDeletionLogEntity, QueryFieldEntity, QueryCategoryEntity, QueryEntity, QueryPermissionEntity, VectorIndexEntity, EntityDocumentTypeEntity, EntityDocumentRunEntity, VectorDatabaseEntity, EntityRecordDocumentEntity, EntityDocumentEntity, DataContextItemEntity, DataContextEntity, UserViewCategoryEntity, DashboardCategoryEntity, ReportCategoryEntity, FileStorageProviderEntity, FileEntity, FileCategoryEntity, FileEntityRecordLinkEntity, VersionInstallationEntity, DuplicateRunDetailMatchEntity, EntityDocumentSettingEntity, EntitySettingEntity, DuplicateRunEntity, DuplicateRunDetailEntity, ApplicationSettingEntity, ActionCategoryEntity, EntityActionEntity, EntityActionInvocationEntity, ActionAuthorizationEntity, EntityActionInvocationTypeEntity, ActionEntity, EntityActionFilterEntity, ActionFilterEntity, ActionContextTypeEntity, ActionResultCodeEntity, ActionContextEntity, ActionExecutionLogEntity, ActionParamEntity, ActionLibraryEntity, LibraryEntity, ListCategoryEntity, CommunicationProviderEntity, CommunicationRunEntity, CommunicationProviderMessageTypeEntity, CommunicationLogEntity, CommunicationBaseMessageTypeEntity, TemplateEntity, TemplateCategoryEntity, TemplateContentEntity, TemplateParamEntity, TemplateContentTypeEntity, RecommendationEntity, RecommendationProviderEntity, RecommendationRunEntity, RecommendationItemEntity, EntityCommunicationMessageTypeEntity, EntityCommunicationFieldEntity, RecordChangeReplayRunEntity, LibraryItemEntity, EntityRelationshipDisplayComponentEntity, EntityActionParamEntity, ResourcePermissionEntity, ResourceLinkEntity, AIAgentRequestEntity, QueryEntityEntity, ContentProcessRunEntity, ContentSourceEntity, ContentSourceParamEntity, ContentSourceTypeEntity, ContentSourceTypeParamEntity, ContentTypeEntity, ContentTypeAttributeEntity, ContentFileTypeEntity, ContentItemEntity, ContentItemAttributeEntity, ContentItemTagEntity, GeneratedCodeEntity, AIAgentLearningCycleEntity } from '@memberjunction/core-entities';
+import { ScheduledActionEntity, ScheduledActionParamEntity, ExplorerNavigationItemEntity, GeneratedCodeCategoryEntity, AIAgentModelEntity, AIAgentNoteTypeEntity, AIAgentEntity, AIAgentNoteEntity, AIAgentActionEntity, AIPromptEntity, AIResultCacheEntity, AIPromptCategoryEntity, AIPromptTypeEntity, CompanyEntity, EmployeeEntity, UserFavoriteEntity, EmployeeCompanyIntegrationEntity, EmployeeRoleEntity, EmployeeSkillEntity, RoleEntity, SkillEntity, IntegrationURLFormatEntity, IntegrationEntity, CompanyIntegrationEntity, EntityFieldEntity, EntityEntity, UserEntity, EntityRelationshipEntity, UserRecordLogEntity, UserViewEntity, CompanyIntegrationRunEntity, CompanyIntegrationRunDetailEntity, ErrorLogEntity, ApplicationEntity, ApplicationEntityEntity, EntityPermissionEntity, UserApplicationEntityEntity, UserApplicationEntity, CompanyIntegrationRunAPILogEntity, ListEntity, ListDetailEntity, UserViewRunEntity, UserViewRunDetailEntity, WorkflowRunEntity, WorkflowEntity, WorkflowEngineEntity, RecordChangeEntity, UserRoleEntity, RowLevelSecurityFilterEntity, AuditLogEntity, AuthorizationEntity, AuthorizationRoleEntity, AuditLogTypeEntity, EntityFieldValueEntity, AIModelEntity, AIActionEntity, AIModelActionEntity, EntityAIActionEntity, AIModelTypeEntity, QueueTypeEntity, QueueEntity, QueueTaskEntity, DashboardEntity, OutputTriggerTypeEntity, OutputFormatTypeEntity, OutputDeliveryTypeEntity, ReportEntity, ReportSnapshotEntity, ResourceTypeEntity, TagEntity, TaggedItemEntity, WorkspaceEntity, WorkspaceItemEntity, DatasetEntity, DatasetItemEntity, ConversationDetailEntity, ConversationEntity, UserNotificationEntity, SchemaInfoEntity, CompanyIntegrationRecordMapEntity, RecordMergeLogEntity, RecordMergeDeletionLogEntity, QueryFieldEntity, QueryCategoryEntity, QueryEntity, QueryPermissionEntity, VectorIndexEntity, EntityDocumentTypeEntity, EntityDocumentRunEntity, VectorDatabaseEntity, EntityRecordDocumentEntity, EntityDocumentEntity, DataContextItemEntity, DataContextEntity, UserViewCategoryEntity, DashboardCategoryEntity, ReportCategoryEntity, FileStorageProviderEntity, FileEntity, FileCategoryEntity, FileEntityRecordLinkEntity, VersionInstallationEntity, DuplicateRunDetailMatchEntity, EntityDocumentSettingEntity, EntitySettingEntity, DuplicateRunEntity, DuplicateRunDetailEntity, ApplicationSettingEntity, ActionCategoryEntity, EntityActionEntity, EntityActionInvocationEntity, ActionAuthorizationEntity, EntityActionInvocationTypeEntity, ActionEntity, EntityActionFilterEntity, ActionFilterEntity, ActionContextTypeEntity, ActionResultCodeEntity, ActionContextEntity, ActionExecutionLogEntity, ActionParamEntity, ActionLibraryEntity, LibraryEntity, ListCategoryEntity, CommunicationProviderEntity, CommunicationRunEntity, CommunicationProviderMessageTypeEntity, CommunicationLogEntity, CommunicationBaseMessageTypeEntity, TemplateEntity, TemplateCategoryEntity, TemplateContentEntity, TemplateParamEntity, TemplateContentTypeEntity, RecommendationEntity, RecommendationProviderEntity, RecommendationRunEntity, RecommendationItemEntity, EntityCommunicationMessageTypeEntity, EntityCommunicationFieldEntity, RecordChangeReplayRunEntity, LibraryItemEntity, EntityRelationshipDisplayComponentEntity, EntityActionParamEntity, ResourcePermissionEntity, ResourceLinkEntity, AIAgentRequestEntity, ReportUserStateEntity, QueryEntityEntity, ContentProcessRunEntity, ContentSourceEntity, ContentSourceParamEntity, ContentSourceTypeEntity, ContentSourceTypeParamEntity, ContentTypeEntity, ContentTypeAttributeEntity, ContentFileTypeEntity, ContentItemEntity, ContentItemAttributeEntity, ContentItemTagEntity, GeneratedCodeEntity, AIAgentLearningCycleEntity, ReportVersionEntity } from '@memberjunction/core-entities';
     
 
 //****************************************************************************
@@ -6320,6 +6320,9 @@ export class User_ {
     @Field(() => [AIAgentRequest_])
     AIAgentRequests_ResponseByUserIDArray: AIAgentRequest_[]; // Link to AIAgentRequests
     
+    @Field(() => [ReportUserState_])
+    MJ_ReportUserStates_UserIDArray: ReportUserState_[]; // Link to MJ_ReportUserStates
+    
     @Field(() => [AIAgentNote_])
     AIAgentNotes_UserIDArray: AIAgentNote_[]; // Link to AIAgentNotes
     
@@ -6787,6 +6790,15 @@ export class UserResolverBase extends ResolverBase {
         const dataSource = GetReadOnlyDataSource(dataSources, { allowFallbackToReadWrite: true });
         const sSQL = `SELECT * FROM [${Metadata.Provider.ConfigData.MJCoreSchemaName}].[vwAIAgentRequests] WHERE [ResponseByUserID]='${user_.ID}' ` + this.getRowLevelSecurityWhereClause('AI Agent Requests', userPayload, EntityPermissionType.Read, 'AND');
         const result = this.ArrayMapFieldNamesToCodeNames('AI Agent Requests', await dataSource.query(sSQL));
+        return result;
+    }
+        
+    @FieldResolver(() => [ReportUserState_])
+    async MJ_ReportUserStates_UserIDArray(@Root() user_: User_, @Ctx() { dataSources, userPayload }: AppContext, @PubSub() pubSub: PubSubEngine) {
+        this.CheckUserReadPermissions('MJ: Report User States', userPayload);
+        const dataSource = GetReadOnlyDataSource(dataSources, { allowFallbackToReadWrite: true });
+        const sSQL = `SELECT * FROM [${Metadata.Provider.ConfigData.MJCoreSchemaName}].[vwReportUserStates] WHERE [UserID]='${user_.ID}' ` + this.getRowLevelSecurityWhereClause('MJ: Report User States', userPayload, EntityPermissionType.Read, 'AND');
+        const result = this.ArrayMapFieldNamesToCodeNames('MJ: Report User States', await dataSource.query(sSQL));
         return result;
     }
         
@@ -14339,6 +14351,12 @@ export class Report_ {
     @Field(() => [ReportSnapshot_])
     ReportSnapshots_ReportIDArray: ReportSnapshot_[]; // Link to ReportSnapshots
     
+    @Field(() => [ReportVersion_])
+    MJ_ReportVersions_ReportIDArray: ReportVersion_[]; // Link to MJ_ReportVersions
+    
+    @Field(() => [ReportUserState_])
+    MJ_ReportUserStates_ReportIDArray: ReportUserState_[]; // Link to MJ_ReportUserStates
+    
 }
 
 //****************************************************************************
@@ -14512,6 +14530,24 @@ export class ReportResolver extends ResolverBase {
         const dataSource = GetReadOnlyDataSource(dataSources, { allowFallbackToReadWrite: true });
         const sSQL = `SELECT * FROM [${Metadata.Provider.ConfigData.MJCoreSchemaName}].[vwReportSnapshots] WHERE [ReportID]='${report_.ID}' ` + this.getRowLevelSecurityWhereClause('Report Snapshots', userPayload, EntityPermissionType.Read, 'AND');
         const result = this.ArrayMapFieldNamesToCodeNames('Report Snapshots', await dataSource.query(sSQL));
+        return result;
+    }
+        
+    @FieldResolver(() => [ReportVersion_])
+    async MJ_ReportVersions_ReportIDArray(@Root() report_: Report_, @Ctx() { dataSources, userPayload }: AppContext, @PubSub() pubSub: PubSubEngine) {
+        this.CheckUserReadPermissions('MJ: Report Versions', userPayload);
+        const dataSource = GetReadOnlyDataSource(dataSources, { allowFallbackToReadWrite: true });
+        const sSQL = `SELECT * FROM [${Metadata.Provider.ConfigData.MJCoreSchemaName}].[vwReportVersions] WHERE [ReportID]='${report_.ID}' ` + this.getRowLevelSecurityWhereClause('MJ: Report Versions', userPayload, EntityPermissionType.Read, 'AND');
+        const result = this.ArrayMapFieldNamesToCodeNames('MJ: Report Versions', await dataSource.query(sSQL));
+        return result;
+    }
+        
+    @FieldResolver(() => [ReportUserState_])
+    async MJ_ReportUserStates_ReportIDArray(@Root() report_: Report_, @Ctx() { dataSources, userPayload }: AppContext, @PubSub() pubSub: PubSubEngine) {
+        this.CheckUserReadPermissions('MJ: Report User States', userPayload);
+        const dataSource = GetReadOnlyDataSource(dataSources, { allowFallbackToReadWrite: true });
+        const sSQL = `SELECT * FROM [${Metadata.Provider.ConfigData.MJCoreSchemaName}].[vwReportUserStates] WHERE [ReportID]='${report_.ID}' ` + this.getRowLevelSecurityWhereClause('MJ: Report User States', userPayload, EntityPermissionType.Read, 'AND');
+        const result = this.ArrayMapFieldNamesToCodeNames('MJ: Report User States', await dataSource.query(sSQL));
         return result;
     }
         
@@ -29565,6 +29601,166 @@ export class AIAgentRequestResolver extends ResolverBase {
 }
 
 //****************************************************************************
+// ENTITY CLASS for MJ: Report User States
+//****************************************************************************
+@ObjectType()
+export class ReportUserState_ {
+    @Field() 
+    @MaxLength(16)
+    ID: string;
+        
+    @Field() 
+    @MaxLength(16)
+    ReportID: string;
+        
+    @Field() 
+    @MaxLength(16)
+    UserID: string;
+        
+    @Field({nullable: true, description: `JSON serialized state of user interaction with the report`}) 
+    ReportState?: string;
+        
+    @Field() 
+    @MaxLength(10)
+    _mj__CreatedAt: Date;
+        
+    @Field() 
+    @MaxLength(10)
+    _mj__UpdatedAt: Date;
+        
+    @Field() 
+    @MaxLength(510)
+    Report: string;
+        
+    @Field() 
+    @MaxLength(200)
+    User: string;
+        
+}
+
+//****************************************************************************
+// INPUT TYPE for MJ: Report User States
+//****************************************************************************
+@InputType()
+export class CreateReportUserStateInput {
+    @Field({ nullable: true })
+    ReportID?: string;
+
+    @Field({ nullable: true })
+    UserID?: string;
+
+    @Field({ nullable: true })
+    ReportState: string | null;
+}
+    
+
+//****************************************************************************
+// INPUT TYPE for MJ: Report User States
+//****************************************************************************
+@InputType()
+export class UpdateReportUserStateInput {
+    @Field()
+    ID: string;
+
+    @Field({ nullable: true })
+    ReportID?: string;
+
+    @Field({ nullable: true })
+    UserID?: string;
+
+    @Field({ nullable: true })
+    ReportState?: string | null;
+
+    @Field(() => [KeyValuePairInput], { nullable: true })
+    OldValues___?: KeyValuePairInput[];
+}
+    
+//****************************************************************************
+// RESOLVER for MJ: Report User States
+//****************************************************************************
+@ObjectType()
+export class RunReportUserStateViewResult {
+    @Field(() => [ReportUserState_])
+    Results: ReportUserState_[];
+
+    @Field(() => String, {nullable: true})
+    UserViewRunID?: string;
+
+    @Field(() => Int, {nullable: true})
+    RowCount: number;
+
+    @Field(() => Int, {nullable: true})
+    TotalRowCount: number;
+
+    @Field(() => Int, {nullable: true})
+    ExecutionTime: number;
+
+    @Field({nullable: true})
+    ErrorMessage?: string;
+
+    @Field(() => Boolean, {nullable: false})
+    Success: boolean;
+}
+
+@Resolver(ReportUserState_)
+export class ReportUserStateResolver extends ResolverBase {
+    @Query(() => RunReportUserStateViewResult)
+    async RunReportUserStateViewByID(@Arg('input', () => RunViewByIDInput) input: RunViewByIDInput, @Ctx() { dataSources, userPayload }: AppContext, @PubSub() pubSub: PubSubEngine) {
+        const dataSource = GetReadOnlyDataSource(dataSources, { allowFallbackToReadWrite: true });
+        return super.RunViewByIDGeneric(input, dataSource, userPayload, pubSub);
+    }
+
+    @Query(() => RunReportUserStateViewResult)
+    async RunReportUserStateViewByName(@Arg('input', () => RunViewByNameInput) input: RunViewByNameInput, @Ctx() { dataSources, userPayload }: AppContext, @PubSub() pubSub: PubSubEngine) {
+        const dataSource = GetReadOnlyDataSource(dataSources, { allowFallbackToReadWrite: true });
+        return super.RunViewByNameGeneric(input, dataSource, userPayload, pubSub);
+    }
+
+    @Query(() => RunReportUserStateViewResult)
+    async RunReportUserStateDynamicView(@Arg('input', () => RunDynamicViewInput) input: RunDynamicViewInput, @Ctx() { dataSources, userPayload }: AppContext, @PubSub() pubSub: PubSubEngine) {
+        const dataSource = GetReadOnlyDataSource(dataSources, { allowFallbackToReadWrite: true });
+        input.EntityName = 'MJ: Report User States';
+        return super.RunDynamicViewGeneric(input, dataSource, userPayload, pubSub);
+    }
+    @Query(() => ReportUserState_, { nullable: true })
+    async ReportUserState(@Arg('ID', () => String) ID: string, @Ctx() { dataSources, userPayload }: AppContext, @PubSub() pubSub: PubSubEngine): Promise<ReportUserState_ | null> {
+        this.CheckUserReadPermissions('MJ: Report User States', userPayload);
+        const dataSource = GetReadOnlyDataSource(dataSources, { allowFallbackToReadWrite: true });
+        const sSQL = `SELECT * FROM [${Metadata.Provider.ConfigData.MJCoreSchemaName}].[vwReportUserStates] WHERE [ID]='${ID}' ` + this.getRowLevelSecurityWhereClause('MJ: Report User States', userPayload, EntityPermissionType.Read, 'AND');
+        const result = this.MapFieldNamesToCodeNames('MJ: Report User States', await dataSource.query(sSQL).then((r) => r && r.length > 0 ? r[0] : {}))
+        return result;
+    }
+    
+    @Mutation(() => ReportUserState_)
+    async CreateReportUserState(
+        @Arg('input', () => CreateReportUserStateInput) input: CreateReportUserStateInput,
+        @Ctx() { dataSources, userPayload }: AppContext,
+        @PubSub() pubSub: PubSubEngine
+    ) {
+        const dataSource = GetReadWriteDataSource(dataSources);
+        return this.CreateRecord('MJ: Report User States', input, dataSource, userPayload, pubSub)
+    }
+        
+    @Mutation(() => ReportUserState_)
+    async UpdateReportUserState(
+        @Arg('input', () => UpdateReportUserStateInput) input: UpdateReportUserStateInput,
+        @Ctx() { dataSources, userPayload }: AppContext,
+        @PubSub() pubSub: PubSubEngine
+    ) {
+        const dataSource = GetReadWriteDataSource(dataSources);
+        return this.UpdateRecord('MJ: Report User States', input, dataSource, userPayload, pubSub);
+    }
+    
+    @Mutation(() => ReportUserState_)
+    async DeleteReportUserState(@Arg('ID', () => String) ID: string, @Arg('options___', () => DeleteOptionsInput) options: DeleteOptionsInput, @Ctx() { dataSources, userPayload }: AppContext, @PubSub() pubSub: PubSubEngine) {
+        const dataSource = GetReadWriteDataSource(dataSources);
+        const key = new CompositeKey([{FieldName: 'ID', Value: ID}]);
+        return this.DeleteRecord('MJ: Report User States', key, options, dataSource, userPayload, pubSub);
+    }
+    
+}
+
+//****************************************************************************
 // ENTITY CLASS for Query Entities
 //****************************************************************************
 @ObjectType({ description: `Tracks which entities are involved in a given query. The Queries table stores SQL and descriptions for stored queries that can be executed and serve as examples for AI.` })
@@ -32098,6 +32294,189 @@ export class AIAgentLearningCycleResolver extends ResolverBase {
         const dataSource = GetReadWriteDataSource(dataSources);
         const key = new CompositeKey([{FieldName: 'ID', Value: ID}]);
         return this.DeleteRecord('AI Agent Learning Cycles', key, options, dataSource, userPayload, pubSub);
+    }
+    
+}
+
+//****************************************************************************
+// ENTITY CLASS for MJ: Report Versions
+//****************************************************************************
+@ObjectType()
+export class ReportVersion_ {
+    @Field() 
+    @MaxLength(16)
+    ID: string;
+        
+    @Field() 
+    @MaxLength(16)
+    ReportID: string;
+        
+    @Field(() => Int, {description: `Report version number, sequential per report starting at 1`}) 
+    VersionNumber: number;
+        
+    @Field({description: `Name of this report version`}) 
+    @MaxLength(510)
+    Name: string;
+        
+    @Field({nullable: true, description: `Description of this report version`}) 
+    Description?: string;
+        
+    @Field({nullable: true, description: `JSON configuration of report structure, layout and logic`}) 
+    Configuration?: string;
+        
+    @Field(() => Boolean, {description: `Indicates if the data context was updated in this version`}) 
+    DataContextUpdated: boolean;
+        
+    @Field() 
+    @MaxLength(10)
+    _mj__CreatedAt: Date;
+        
+    @Field() 
+    @MaxLength(10)
+    _mj__UpdatedAt: Date;
+        
+    @Field() 
+    @MaxLength(510)
+    Report: string;
+        
+}
+
+//****************************************************************************
+// INPUT TYPE for MJ: Report Versions
+//****************************************************************************
+@InputType()
+export class CreateReportVersionInput {
+    @Field({ nullable: true })
+    ReportID?: string;
+
+    @Field(() => Int, { nullable: true })
+    VersionNumber?: number;
+
+    @Field({ nullable: true })
+    Name?: string;
+
+    @Field({ nullable: true })
+    Description: string | null;
+
+    @Field({ nullable: true })
+    Configuration: string | null;
+
+    @Field(() => Boolean, { nullable: true })
+    DataContextUpdated?: boolean;
+}
+    
+
+//****************************************************************************
+// INPUT TYPE for MJ: Report Versions
+//****************************************************************************
+@InputType()
+export class UpdateReportVersionInput {
+    @Field()
+    ID: string;
+
+    @Field({ nullable: true })
+    ReportID?: string;
+
+    @Field(() => Int, { nullable: true })
+    VersionNumber?: number;
+
+    @Field({ nullable: true })
+    Name?: string;
+
+    @Field({ nullable: true })
+    Description?: string | null;
+
+    @Field({ nullable: true })
+    Configuration?: string | null;
+
+    @Field(() => Boolean, { nullable: true })
+    DataContextUpdated?: boolean;
+
+    @Field(() => [KeyValuePairInput], { nullable: true })
+    OldValues___?: KeyValuePairInput[];
+}
+    
+//****************************************************************************
+// RESOLVER for MJ: Report Versions
+//****************************************************************************
+@ObjectType()
+export class RunReportVersionViewResult {
+    @Field(() => [ReportVersion_])
+    Results: ReportVersion_[];
+
+    @Field(() => String, {nullable: true})
+    UserViewRunID?: string;
+
+    @Field(() => Int, {nullable: true})
+    RowCount: number;
+
+    @Field(() => Int, {nullable: true})
+    TotalRowCount: number;
+
+    @Field(() => Int, {nullable: true})
+    ExecutionTime: number;
+
+    @Field({nullable: true})
+    ErrorMessage?: string;
+
+    @Field(() => Boolean, {nullable: false})
+    Success: boolean;
+}
+
+@Resolver(ReportVersion_)
+export class ReportVersionResolver extends ResolverBase {
+    @Query(() => RunReportVersionViewResult)
+    async RunReportVersionViewByID(@Arg('input', () => RunViewByIDInput) input: RunViewByIDInput, @Ctx() { dataSources, userPayload }: AppContext, @PubSub() pubSub: PubSubEngine) {
+        const dataSource = GetReadOnlyDataSource(dataSources, { allowFallbackToReadWrite: true });
+        return super.RunViewByIDGeneric(input, dataSource, userPayload, pubSub);
+    }
+
+    @Query(() => RunReportVersionViewResult)
+    async RunReportVersionViewByName(@Arg('input', () => RunViewByNameInput) input: RunViewByNameInput, @Ctx() { dataSources, userPayload }: AppContext, @PubSub() pubSub: PubSubEngine) {
+        const dataSource = GetReadOnlyDataSource(dataSources, { allowFallbackToReadWrite: true });
+        return super.RunViewByNameGeneric(input, dataSource, userPayload, pubSub);
+    }
+
+    @Query(() => RunReportVersionViewResult)
+    async RunReportVersionDynamicView(@Arg('input', () => RunDynamicViewInput) input: RunDynamicViewInput, @Ctx() { dataSources, userPayload }: AppContext, @PubSub() pubSub: PubSubEngine) {
+        const dataSource = GetReadOnlyDataSource(dataSources, { allowFallbackToReadWrite: true });
+        input.EntityName = 'MJ: Report Versions';
+        return super.RunDynamicViewGeneric(input, dataSource, userPayload, pubSub);
+    }
+    @Query(() => ReportVersion_, { nullable: true })
+    async ReportVersion(@Arg('ID', () => String) ID: string, @Ctx() { dataSources, userPayload }: AppContext, @PubSub() pubSub: PubSubEngine): Promise<ReportVersion_ | null> {
+        this.CheckUserReadPermissions('MJ: Report Versions', userPayload);
+        const dataSource = GetReadOnlyDataSource(dataSources, { allowFallbackToReadWrite: true });
+        const sSQL = `SELECT * FROM [${Metadata.Provider.ConfigData.MJCoreSchemaName}].[vwReportVersions] WHERE [ID]='${ID}' ` + this.getRowLevelSecurityWhereClause('MJ: Report Versions', userPayload, EntityPermissionType.Read, 'AND');
+        const result = this.MapFieldNamesToCodeNames('MJ: Report Versions', await dataSource.query(sSQL).then((r) => r && r.length > 0 ? r[0] : {}))
+        return result;
+    }
+    
+    @Mutation(() => ReportVersion_)
+    async CreateReportVersion(
+        @Arg('input', () => CreateReportVersionInput) input: CreateReportVersionInput,
+        @Ctx() { dataSources, userPayload }: AppContext,
+        @PubSub() pubSub: PubSubEngine
+    ) {
+        const dataSource = GetReadWriteDataSource(dataSources);
+        return this.CreateRecord('MJ: Report Versions', input, dataSource, userPayload, pubSub)
+    }
+        
+    @Mutation(() => ReportVersion_)
+    async UpdateReportVersion(
+        @Arg('input', () => UpdateReportVersionInput) input: UpdateReportVersionInput,
+        @Ctx() { dataSources, userPayload }: AppContext,
+        @PubSub() pubSub: PubSubEngine
+    ) {
+        const dataSource = GetReadWriteDataSource(dataSources);
+        return this.UpdateRecord('MJ: Report Versions', input, dataSource, userPayload, pubSub);
+    }
+    
+    @Mutation(() => ReportVersion_)
+    async DeleteReportVersion(@Arg('ID', () => String) ID: string, @Arg('options___', () => DeleteOptionsInput) options: DeleteOptionsInput, @Ctx() { dataSources, userPayload }: AppContext, @PubSub() pubSub: PubSubEngine) {
+        const dataSource = GetReadWriteDataSource(dataSources);
+        const key = new CompositeKey([{FieldName: 'ID', Value: ID}]);
+        return this.DeleteRecord('MJ: Report Versions', key, options, dataSource, userPayload, pubSub);
     }
     
 }

--- a/packages/MJServer/src/index.ts
+++ b/packages/MJServer/src/index.ts
@@ -63,6 +63,7 @@ export * from './resolvers/ReportResolver.js';
 export * from './resolvers/SyncRolesUsersResolver.js';
 export * from './resolvers/SyncDataResolver.js';
 export * from './resolvers/GetDataResolver.js';
+export * from './resolvers/GetDataContextDataResolver.js';
 export * from './resolvers/TransactionGroupResolver.js';
 
 export { GetReadOnlyDataSource, GetReadWriteDataSource } from './util.js';

--- a/packages/MJServer/src/resolvers/GetDataContextDataResolver.ts
+++ b/packages/MJServer/src/resolvers/GetDataContextDataResolver.ts
@@ -1,0 +1,136 @@
+import { Arg, Ctx, Field, ObjectType, Query } from "type-graphql";
+import { AppContext } from "../types";
+import { DataContext } from "@memberjunction/data-context";
+import { GetReadOnlyDataSource } from "../util";
+import { Metadata } from "@memberjunction/core";
+import { DataContextItemEntity } from "@memberjunction/core-entities";
+
+@ObjectType()
+export class GetDataContextItemDataOutputType {
+    @Field(() => Boolean)
+    Success: boolean;
+
+    /**
+     * If not successful, this will be the error message.
+     */
+    @Field(() => String, { nullable: true })
+    ErrorMessage: string | null;
+
+    /**
+     * If successful, this will be the JSON for the data context item's data.
+     */
+    @Field(() => String, { nullable: true })  
+    Result: string | null;
+}
+
+@ObjectType()
+export class GetDataContextDataOutputType {
+    @Field(() => Boolean)
+    Success: boolean;
+
+    @Field(() => [String], { nullable: 'itemsAndList' }) // Allow nulls inside array & entire field nullable
+    ErrorMessages: (string | null)[];
+
+    /**
+     * Each data context item's results will be converted to JSON and returned as a string
+     */
+    @Field(() => [String], { nullable: 'itemsAndList' }) // Allow nulls inside array & entire field nullable
+    Results: (string | null)[];
+}
+
+
+export class GetDataContextDataResolver {
+    /**
+     * Returns data for a given data context item. 
+     * @param DataContextItemID 
+     */
+    @Query(() => GetDataContextItemDataOutputType)
+    async GetDataContextItemData(
+        @Arg('DataContextItemID', () => String) DataContextItemID: string,
+        @Ctx() appCtx: AppContext
+    ) {
+        try {
+            const ds = GetReadOnlyDataSource(appCtx.dataSources, {
+                allowFallbackToReadWrite: true,
+            })
+            const md = new Metadata();
+            const dciData = await md.GetEntityObject<DataContextItemEntity>("Data Context Items", appCtx.userPayload.userRecord);
+            if (await dciData.Load(DataContextItemID)) {
+                const dci = DataContext.CreateDataContextItem(); // use class factory to get whatever lowest level sub-class is registered
+                await dci.LoadMetadataFromEntityRecord(dciData, Metadata.Provider, appCtx.userPayload.userRecord);
+                // now the metadata is loaded so we can call the regular load function
+                if (await dci.LoadData(ds)) {
+                    return {
+                        Success: true,
+                        ErrorMessage: null,
+                        Result: JSON.stringify(dci.Data),
+                    }
+                }
+                else {
+                    return {
+                        Success: false,
+                        ErrorMessage: 'Error loading data context item data',
+                        Result: null,
+                    }
+                }
+            }
+            else {
+                return {
+                    Success: false,
+                    ErrorMessage: 'Error loading data context item metadata',
+                    Result: null,
+                }
+            }    
+        }
+        catch (e) {
+            return {
+                Success: false,
+                ErrorMessage: e,
+                Result: null,
+            }
+        }
+    }
+
+    /**
+     * Returns data for a given data context. 
+     * @param DataContextID 
+     */
+    @Query(() => GetDataContextDataOutputType)
+    async GetDataContextData(
+        @Arg('DataContextID', () => String) DataContextID: string,
+        @Ctx() appCtx: AppContext
+    ) {
+        try {
+            // our job here is to load the entire data context, so we do that with the Data Context object
+            const dc = new DataContext();
+            const ds = GetReadOnlyDataSource(appCtx.dataSources, {
+                allowFallbackToReadWrite: true,
+            })
+            const success = await dc.Load(DataContextID, ds, true, false, 0, appCtx.userPayload.userRecord);
+            if (success) {
+                const retVal =   {
+                    Success: true,
+                    ErrorMessages: null,
+                    Results: dc.Items.map((item) => {
+                        return JSON.stringify(item.Data);
+                    }),
+                }
+                return retVal;
+            }
+            else {
+                return {
+                    Success: false,
+                    ErrorMessages: ['Error loading data context'],
+                    Results: null,    
+                }
+            }
+        }
+        catch (e) {
+            return {
+                Success: false,
+                ErrorMessages: [e],
+                Results: null,
+            }
+        }
+    }
+}

--- a/packages/MJServer/src/resolvers/GetDataResolver.ts
+++ b/packages/MJServer/src/resolvers/GetDataResolver.ts
@@ -96,7 +96,9 @@ export class SimpleEntityFieldOutputType {
     MaxLength: number;
 }
 
-
+/**
+ * General purpose resolver for fetching different kinds of data payloads for SYSTEM users only.
+ */
 export class GetDataResolver {
     /**
      * This query will sync the specified items with the existing system. Items will be processed in order and the results of each operation will be returned in the Results array within the return value.

--- a/packages/SkipTypes/src/types.ts
+++ b/packages/SkipTypes/src/types.ts
@@ -900,6 +900,16 @@ export interface SkipHTMLReportCallbacks {
     OpenEntityRecord: (entityName: string, key: CompositeKey) => void;
 
     /**
+     * This event should be raised by the HTML component whenever something changes within the component that should be tracked as a change in state
+     * that will persist. userState is any valid, simple JavaScript object, meaning it can have scalars, arrays, objects, etc, it must be an object that 
+     * can be serialized to JSON, but otherwise has no special requirements. The parent component will be responsible for tracking the user-specific states
+     * and passing them back to the HTML component each time it is loaded or if the user changes via the init function.
+     * @param userState 
+     * @returns 
+     */
+    UpdateUserState: (userState: any) => void;
+
+    /**
      * Used for any other type of event notification that an HTML Report might want to send to the parent component.
      * @param eventName 
      * @param eventData 
@@ -909,9 +919,12 @@ export interface SkipHTMLReportCallbacks {
 }
 
 /**
- * This is the function signature for the InitFunctionName that is passed into the HTML report. This function is called when the HTML report is loaded and is passed the data context and a set of callbacks that can be used to interact with the parent component.
+ * This is the function signature for the InitFunctionName that is passed into the HTML report. 
+ * This function is called when the HTML report is loaded and is passed the data context and a set of callbacks that can be used to interact with the parent component.
+ * userState is an optional parameter that can be used to pass in any state information that the parent component wants to provide to the HTML report that is specific
+ * to the CURRENT user. If the component modifies the userState, it should notify the parent component via the UserStateChanged event in the callbacks object so that the parent component can handle storage.
  */
-export type SkipHTMLReportInitFunction = (data: SimpleDataContext, callbacks?: SkipHTMLReportCallbacks) => void;
+export type SkipHTMLReportInitFunction = (data: SimpleDataContext, userState?: any, callbacks?: SkipHTMLReportCallbacks) => void;
 
 /**
  * This is a simple data context object that is passed into the SkipHTMLReportInitFunction, it contains a property for each of the data context items and typically are named


### PR DESCRIPTION
- **Create V202503180119__v2.30.x_Unique_Action_Names.sql**
- **docs(changeset): Update Entity Types to output correct nullable types**
- **Update entity_subclasses_codegen.ts**
- **docs(changeset): Support for simple template rendering where templates are not stored in the database.**
- **Support for simple template rendering where templates are not stored in the database.**
- **Update V202503180119__v2.30.x_Unique_Action_Names.sql**
- **bump to 2.31.x**
- **Add CC and BCC fields to message class**
- **docs(changeset): Add CC and BCC fields to Message class**
- **Update MSGraphProvider.ts**
- **First attempt at MCP Server for MemberJunction**
- **WIP**
- **wip**
- **First working version of MCP Server for MJ - basic metadata retrieval only**
- **docs(changeset): First version of MCP server for MJ and removed unneeded file from AIEngine project**
- **Updated MCP Server to emit tools based on configuration file including wildcard support at entity/schema level for admin controls.**
- **added back entity metadata retrieval to tools**
- **Stubbed out code for Action Tools - not implemented yet**
- **docs(changeset): Stubbed out Action Tools code**
- **Clean up tool names to comply with Claude Desktop rules (no spaces)**
- **docs(changeset): Clean up tool naming to support Claude Desktop stricter naming requriements - no spaces**
- **Basic plumbing for HTML reports**
- **docs(changeset): Prepare for HTML Report Type**
- **Updates to Skip Types and use in the HTML Report**
- **SkipTypes - further cleanup to normalize for HTML Report that won't use a sub process**
- **docs(changeset): SkipTypes - further cleanup to normalize for HTML Report that won't use a sub process**
- **Added UpdateUserState to event raising options for HTML Components we host for Skip generated HTML components.**
- **docs(changeset): Added UpdateUserState to event raising options for HTML Components we host for Skip generated HTML components.**
