### PR TITLE
MjStorage/AzureFileStorage: Clock Skew Issue Resolved in Pre-Authenticated Upload URL Generation

### DIFF
--- a/.changeset/purple-rats-bake.md
+++ b/.changeset/purple-rats-bake.md
@@ -1,0 +1,5 @@
+---
+"@memberjunction/storage": patch
+---
+
+Fixed AzureFileStorage clock skew issue when creating pre authenticated upload urls.

--- a/packages/MJStorage/src/drivers/AzureFileStorage.ts
+++ b/packages/MJStorage/src/drivers/AzureFileStorage.ts
@@ -64,13 +64,14 @@ export class AzureFileStorage extends FileStorageBase {
   }
 
   public CreatePreAuthUploadUrl(objectName: string): Promise<CreatePreAuthUploadUrlPayload> {
+    const now = new Date();
     const sasOptions: AccountSASSignatureValues = {
       services: AccountSASServices.parse('b').toString(), // blobs
       resourceTypes: AccountSASResourceTypes.parse('o').toString(), // object
       permissions: AccountSASPermissions.parse('w'), // write-only permissions
       protocol: SASProtocol.Https,
-      startsOn: new Date(),
-      expiresOn: new Date(new Date().valueOf() + 10 * 60 * 1000), // 10 minutes
+      startsOn: new Date(now.valueOf() - 60 * 1000), // now minus 1 minute
+      expiresOn: new Date(now.valueOf() + 10 * 60 * 1000), // 10 minutes from now
     };
 
     // Using the SAS url to upload e.g.


### PR DESCRIPTION
Resolved a clock skew issue in MjStorage/AzureFileStorage that affected the availability of pre-authenticated upload URLs.

Previously, a 22-second clock skew between the local system and Azure caused delays in the usability of generated upload URLs.

The timestamp generation logic has been adjusted to eliminate the skew. As a result, upload URLs are now immediately usable upon generation.