### PR TITLE
Update Mistral SDK to version 1.6.0

### DIFF
--- a/.changeset/nervous-rice-dress.md
+++ b/.changeset/nervous-rice-dress.md
@@ -1,0 +1,5 @@
+---
+"@memberjunction/ai-mistral": patch
+---
+
+update to latest mistral SDK

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,8 @@
 # MemberJunction Development Guide
 
+## IMPORTANT
+- Before starting a new line of work always check the local branch we're on and see if it is (a) separate from the default branch in the remote repo - we always want to work in local feature branches and (b) if we aren't in such a feature branch that is named for the work being requested and empty, cut a new one but ask first and then switch to it
+
 ## Build Commands
 - Build all packages: `npm run build`
 - Build specific packages: `turbo build --filter="@memberjunction/package-name"`

--- a/package-lock.json
+++ b/package-lock.json
@@ -7631,17 +7631,6 @@
       "version": "2.40.0",
       "license": "MIT"
     },
-    "node_modules/@mistralai/mistralai": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/@mistralai/mistralai/-/mistralai-1.5.0.tgz",
-      "integrity": "sha512-AIn8pwAwA/fDvEUvmkt+40zH1ZmfaG3Q7oUWl17GUEC1tU7ZPwYz8Cv9P59lyS1SisHdDSu81oknO7f1ywkz8Q==",
-      "dependencies": {
-        "zod-to-json-schema": "^3.24.1"
-      },
-      "peerDependencies": {
-        "zod": ">= 3"
-      }
-    },
     "node_modules/@modelcontextprotocol/sdk": {
       "version": "1.8.0",
       "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.8.0.tgz",
@@ -29697,12 +29686,23 @@
       "dependencies": {
         "@memberjunction/ai": "2.37.1",
         "@memberjunction/global": "2.37.1",
-        "@mistralai/mistralai": "^1.5.0",
+        "@mistralai/mistralai": "^1.6.0",
         "axios-retry": "4.3.0"
       },
       "devDependencies": {
         "ts-node-dev": "^2.0.0",
         "typescript": "^5.4.5"
+      }
+    },
+    "packages/AI/Providers/Mistral/node_modules/@mistralai/mistralai": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@mistralai/mistralai/-/mistralai-1.6.0.tgz",
+      "integrity": "sha512-PQwGV3+n7FbE7Dp3Vnd8DAa3ffx6WuVV966Gfmf4QvzwcO3Mvxpz0SnJ/PjaZcsCwApBCZpNyQzvarAKEQLKeQ==",
+      "dependencies": {
+        "zod-to-json-schema": "^3.24.1"
+      },
+      "peerDependencies": {
+        "zod": ">= 3"
       }
     },
     "packages/AI/Providers/Mistral/node_modules/axios-retry": {

--- a/packages/AI/Providers/Mistral/package.json
+++ b/packages/AI/Providers/Mistral/package.json
@@ -21,7 +21,7 @@
   "dependencies": {
     "@memberjunction/ai": "2.37.1",
     "@memberjunction/global": "2.37.1",
-    "@mistralai/mistralai": "^1.5.0",
+    "@mistralai/mistralai": "^1.6.0",
     "axios-retry": "4.3.0"
   }
 }


### PR DESCRIPTION
## Summary
- Upgraded @mistralai/mistralai from version 1.5.0 to 1.6.0
- Successfully built package with the new version

## Test plan
- Successfully built the Mistral provider package with the updated dependency