### PR TITLE
Update Groq SDK to version 0.21.0

### DIFF
--- a/.changeset/honest-maps-cross.md
+++ b/.changeset/honest-maps-cross.md
@@ -1,0 +1,5 @@
+---
+"@memberjunction/ai-groq": patch
+---
+
+updated to latest Groq SDK

--- a/package-lock.json
+++ b/package-lock.json
@@ -17645,21 +17645,6 @@
         "graphql": ">=0.11 <=16"
       }
     },
-    "node_modules/groq-sdk": {
-      "version": "0.15.0",
-      "resolved": "https://registry.npmjs.org/groq-sdk/-/groq-sdk-0.15.0.tgz",
-      "integrity": "sha512-aYDEdr4qczx3cLCRRe+Beb37I7g/9bD5kHF+EEDxcrREWw1vKoRcfP3vHEkJB7Ud/8oOuF0scRwDpwWostTWuQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@types/node": "^18.11.18",
-        "@types/node-fetch": "^2.6.4",
-        "abort-controller": "^3.0.0",
-        "agentkeepalive": "^4.2.1",
-        "form-data-encoder": "1.7.2",
-        "formdata-node": "^4.3.2",
-        "node-fetch": "^2.6.7"
-      }
-    },
     "node_modules/gtoken": {
       "version": "7.1.0",
       "license": "MIT",
@@ -29658,11 +29643,35 @@
       "dependencies": {
         "@memberjunction/ai": "2.37.1",
         "@memberjunction/global": "2.37.1",
-        "groq-sdk": "0.15.0"
+        "groq-sdk": "0.21.0"
       },
       "devDependencies": {
         "ts-node-dev": "^2.0.0",
         "typescript": "^5.4.5"
+      }
+    },
+    "packages/AI/Providers/Groq/node_modules/@types/node": {
+      "version": "18.19.100",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.100.tgz",
+      "integrity": "sha512-ojmMP8SZBKprc3qGrGk8Ujpo80AXkrP7G2tOT4VWr5jlr5DHjsJF+emXJz+Wm0glmy4Js62oKMdZZ6B9Y+tEcA==",
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~5.26.4"
+      }
+    },
+    "packages/AI/Providers/Groq/node_modules/groq-sdk": {
+      "version": "0.21.0",
+      "resolved": "https://registry.npmjs.org/groq-sdk/-/groq-sdk-0.21.0.tgz",
+      "integrity": "sha512-SZg7oH/DsFvJllmdujNGZbfKUr2ATaU6urq0ZcnyObnmj6+nYM7WCGkyI2JMK+aWDzNiW6MwBNlSH722sHvtEQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@types/node": "^18.11.18",
+        "@types/node-fetch": "^2.6.4",
+        "abort-controller": "^3.0.0",
+        "agentkeepalive": "^4.2.1",
+        "form-data-encoder": "1.7.2",
+        "formdata-node": "^4.3.2",
+        "node-fetch": "^2.6.7"
       }
     },
     "packages/AI/Providers/HeyGen": {

--- a/packages/AI/Providers/Groq/package.json
+++ b/packages/AI/Providers/Groq/package.json
@@ -21,6 +21,6 @@
   "dependencies": {
     "@memberjunction/ai": "2.37.1",
     "@memberjunction/global": "2.37.1",
-    "groq-sdk": "0.15.0"
+    "groq-sdk": "0.21.0"
   }
 }


### PR DESCRIPTION
## Summary
- Upgraded groq-sdk from version 0.15.0 to 0.21.0
- Successfully built package with the updated dependency

## Test plan
- Successfully built the Groq provider package with the updated dependency