### PR TITLE
v2.38.0

### DIFF
--- a/.changeset/chilly-camels-cough.md
+++ b/.changeset/chilly-camels-cough.md
@@ -1,0 +1,5 @@
+---
+"@memberjunction/ai-cerebras": patch
+---
+
+initial implementation of Cerebras AI provider for MJ

--- a/.changeset/cool-rivers-float.md
+++ b/.changeset/cool-rivers-float.md
@@ -1,0 +1,5 @@
+---
+"@memberjunction/core-entities": minor
+---
+
+flagging this package to trigger a minor version bump. No actual code changes, but we have a new migration file to clean up and add new AI models

--- a/.changeset/giant-moose-explode.md
+++ b/.changeset/giant-moose-explode.md
@@ -1,0 +1,5 @@
+---
+"@memberjunction/a2aserver": patch
+---
+
+Preliminary A2A (AI Agent protocol standard from Google) implementation

--- a/.changeset/honest-maps-cross.md
+++ b/.changeset/honest-maps-cross.md
@@ -1,0 +1,5 @@
+---
+"@memberjunction/ai-groq": patch
+---
+
+updated to latest Groq SDK

--- a/.changeset/nervous-rice-dress.md
+++ b/.changeset/nervous-rice-dress.md
@@ -1,0 +1,5 @@
+---
+"@memberjunction/ai-mistral": patch
+---
+
+update to latest mistral SDK

--- a/.changeset/rotten-windows-shout.md
+++ b/.changeset/rotten-windows-shout.md
@@ -1,0 +1,5 @@
+---
+"@memberjunction/ai-gemini": patch
+---
+
+Update to use new google gen ai library

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,8 @@
 # MemberJunction Development Guide
 
+## IMPORTANT
+- Before starting a new line of work always check the local branch we're on and see if it is (a) separate from the default branch in the remote repo - we always want to work in local feature branches and (b) if we aren't in such a feature branch that is named for the work being requested and empty, cut a new one but ask first and then switch to it
+
 ## Build Commands
 - Build all packages: `npm run build`
 - Build specific packages: `turbo build --filter="@memberjunction/package-name"`

--- a/migrations/v2/V202505131808__v2.38.x_Clean_Up_And_Add_AI_Models.sql
+++ b/migrations/v2/V202505131808__v2.38.x_Clean_Up_And_Add_AI_Models.sql
@@ -1,0 +1,19 @@
+UPDATE ${flyway:defaultSchema}.AIModel SET Name='Llama 3.3 70B Versatile / Groq' WHERE ID='853E890E-F2E3-EF11-B015-286B35C04427'
+UPDATE ${flyway:defaultSchema}.AIModel SET Name='GPT 4.1', APIName='gpt-4.1' WHERE ID='287E317F-BF26-F011-A770-AC1A3D21423D'
+UPDATE ${flyway:defaultSchema}.AIModel SET Name='GPT 4.1-mini' WHERE ID='9604B1A4-3A21-F011-8B3D-7C1E5249773E'
+UPDATE ${flyway:defaultSchema}.AIModel SET Name='GPT 4o-mini' WHERE ID='0AE8548E-30A6-4FBC-8F69-6344D0CBAF2D'
+
+INSERT INTO ${flyway:defaultSchema}.AIModel (ID, Name, Description, Vendor, AIModelTypeID, PowerRank, IsActive, DriverClass, APIName)  VALUES
+                         ('845D433E-F36B-1410-8DA9-00021F8B792E', 'Deepseek R1 Distill Llama 3.3 70B / Groq','Deepseek R1/Llama 3.3 70B Distillation','Groq','E8A5CCEC-6A37-EF11-86D4-000D3A4E707E',9,1,'GroqLLM','deepseek-r1-distill-llama-70b')
+
+INSERT INTO ${flyway:defaultSchema}.AIModel (ID, Name, Description, Vendor, AIModelTypeID, PowerRank, IsActive, DriverClass, APIName)  VALUES
+                         ('875D433E-F36B-1410-8DA9-00021F8B792E', 'Llama 4 Scout / Groq','Smallest Llama 4 Model','Groq','E8A5CCEC-6A37-EF11-86D4-000D3A4E707E',7,1,'GroqLLM','meta-llama/llama-4-scout-17b-16e-instruct')
+
+INSERT INTO ${flyway:defaultSchema}.AIModel (ID, Name, Description, Vendor, AIModelTypeID, PowerRank, IsActive, DriverClass, APIName)  VALUES
+                         ('8A5D433E-F36B-1410-8DA9-00021F8B792E', 'Llama 4 Maverick / Groq','Mid-sized Llama 4 Model','Groq','E8A5CCEC-6A37-EF11-86D4-000D3A4E707E',8,1,'GroqLLM','meta-llama/llama-4-maverick-17b-128e-instruct')
+
+INSERT INTO ${flyway:defaultSchema}.AIModel (ID, Name, Description, Vendor, AIModelTypeID, PowerRank, IsActive, DriverClass, APIName)  VALUES
+                         ('8D5D433E-F36B-1410-8DA9-00021F8B792E', 'Gemini 2.5 Pro Preview','Gemini 2.5 Pro Preview Model','Google','E8A5CCEC-6A37-EF11-86D4-000D3A4E707E',7,1,'GeminiLLM','gemini-2.5-pro-preview-05-06')
+
+INSERT INTO ${flyway:defaultSchema}.AIModel (ID, Name, Description, Vendor, AIModelTypeID, PowerRank, IsActive, DriverClass, APIName)  VALUES
+                         ('905D433E-F36B-1410-8DA9-00021F8B792E', 'Gemini 2.5 Flash Preview','Gemini 2.5 Flash Preview Model','Google','E8A5CCEC-6A37-EF11-86D4-000D3A4E707E',7,1,'GeminiLLM','gemini-2.5-flash-preview-04-17')

--- a/mj.config.cjs
+++ b/mj.config.cjs
@@ -1,6 +1,7 @@
 /** @import { ConfigInfo as CodeGenConfig } from "./packages/CodeGenLib/src/Config/config" */
 /** @import { ConfigInfo as MJServerConfig } from "./packages/MJServer/src/config" */
 /** @import { ConfigInfo as MCPServerConfig } from "./packages/AI/MCPServer/src/config" */
+/** @import { ConfigInfo as A2AServerConfig } from "./packages/AI/A2AServer/src/config" */
 /** @import { MJConfig } from "./packages/MJCLI/src/config" */
 
 /** @type {CodeGenConfig} */
@@ -299,11 +300,34 @@ const mcpServerConfig = {
   }
 }
 
-/** @type {CodeGenConfig & MJConfig & MJServerConfig & MCPServerConfig} */
+/** @type {A2AServerConfig} */
+const a2aServerConfig = {
+  a2aServerSettings: {
+    port: 3200,
+    enableA2AServer: true,
+    agentName: "MemberJunction",
+    agentDescription: "Access MemberJunction data and capabilities via the A2A protocol",
+    streamingEnabled: true,
+    entityCapabilities: [
+      {
+        schemaName: 'CRM',
+        entityName: '*',
+        get: true,
+        create: true,
+        update: true,
+        delete: true,
+        runView: true,
+      },
+    ]
+  }
+}
+
+/** @type {CodeGenConfig & MJConfig & MJServerConfig & MCPServerConfig & A2AServerConfig} */
 const config = {
   ...codegenConfig,
   ...mjServerConfig,
   ...mcpServerConfig,
+  ...a2aServerConfig,
 
   /**
    * Shared Configuration and Environment Variables

--- a/package-lock.json
+++ b/package-lock.json
@@ -2591,8 +2591,6 @@
     "node_modules/@azure/identity": {
       "version": "3.4.2",
       "license": "MIT",
-      "optional": true,
-      "peer": true,
       "dependencies": {
         "@azure/abort-controller": "^1.0.0",
         "@azure/core-auth": "^1.5.0",
@@ -6561,6 +6559,95 @@
       "version": "1.1.1",
       "license": "MIT"
     },
+    "node_modules/@langchain/core": {
+      "version": "0.1.63",
+      "resolved": "https://registry.npmjs.org/@langchain/core/-/core-0.1.63.tgz",
+      "integrity": "sha512-+fjyYi8wy6x1P+Ee1RWfIIEyxd9Ee9jksEwvrggPwwI/p45kIDTdYTblXsM13y4mNWTiACyLSdbwnPaxxdoz+w==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^5.0.0",
+        "camelcase": "6",
+        "decamelize": "1.2.0",
+        "js-tiktoken": "^1.0.12",
+        "langsmith": "~0.1.7",
+        "ml-distance": "^4.0.0",
+        "mustache": "^4.2.0",
+        "p-queue": "^6.6.2",
+        "p-retry": "4",
+        "uuid": "^9.0.0",
+        "zod": "^3.22.4",
+        "zod-to-json-schema": "^3.22.3"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@langchain/core/node_modules/@types/retry": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/@types/retry/-/retry-0.12.0.tgz",
+      "integrity": "sha512-wWKOClTTiizcZhXnPY4wikVAwmdYHp8q6DmC+EJUzAMsycb7HB32Kh9RN4+0gExjmPmZSAQjgURXIGATPegAvA==",
+      "license": "MIT"
+    },
+    "node_modules/@langchain/core/node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/@langchain/core/node_modules/camelcase": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.3.0.tgz",
+      "integrity": "sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@langchain/core/node_modules/p-retry": {
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/p-retry/-/p-retry-4.6.2.tgz",
+      "integrity": "sha512-312Id396EbJdvRONlngUx0NydfrIQ5lsYu0znKVUzVvArzEIt08V1qhtyESbGVd1FGX7UKtiFp5uwKZdM8wIuQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/retry": "0.12.0",
+        "retry": "^0.13.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@langchain/mistralai": {
+      "version": "0.0.7",
+      "resolved": "https://registry.npmjs.org/@langchain/mistralai/-/mistralai-0.0.7.tgz",
+      "integrity": "sha512-i0L463ojB9/LHSYo3MCYBWkCsb+qqNxD6PYRAJQ1fObSqLqpGIhRRIWegipIte8MFzIfREkOTiEQEbwIM1I7Wg==",
+      "license": "MIT",
+      "dependencies": {
+        "@langchain/core": "~0.1.5",
+        "@mistralai/mistralai": "^0.0.7"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@langchain/mistralai/node_modules/@mistralai/mistralai": {
+      "version": "0.0.7",
+      "resolved": "https://registry.npmjs.org/@mistralai/mistralai/-/mistralai-0.0.7.tgz",
+      "integrity": "sha512-47FiV/GBnt6gug99ZfDBcBofYuYvqT5AyhUDdtktUbCN+gq52tmiAbtwc88k7hlyUWHzJ28VpHRDfNTRfaWKxA==",
+      "license": "ISC",
+      "dependencies": {
+        "axios": "^1.6.2",
+        "axios-retry": "^4.0.0"
+      }
+    },
     "node_modules/@leichtgewicht/ip-codec": {
       "version": "2.0.5",
       "dev": true,
@@ -7005,6 +7092,10 @@
       "engines": {
         "node": ">= 4.0.0"
       }
+    },
+    "node_modules/@memberjunction/a2aserver": {
+      "resolved": "packages/AI/A2AServer",
+      "link": true
     },
     "node_modules/@memberjunction/actions": {
       "resolved": "packages/Actions/Engine",
@@ -12121,7 +12212,6 @@
     },
     "node_modules/array-buffer-byte-length": {
       "version": "1.0.1",
-      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "call-bind": "^1.0.5",
@@ -12183,7 +12273,6 @@
     },
     "node_modules/arraybuffer.prototype.slice": {
       "version": "1.0.3",
-      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "array-buffer-byte-length": "^1.0.1",
@@ -12496,6 +12585,12 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/binary-search": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/binary-search/-/binary-search-1.3.6.tgz",
+      "integrity": "sha512-nbE1WxOTTrUWIfsfZ4aHGYu5DOuNkbxGokjV6Z2kxfJK3uaAb8zNK1muzOeipoLHZjInT4Br88BHpzevc681xA==",
+      "license": "CC0-1.0"
     },
     "node_modules/bl": {
       "version": "6.0.13",
@@ -14518,7 +14613,6 @@
     },
     "node_modules/data-view-buffer": {
       "version": "1.0.1",
-      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "call-bind": "^1.0.6",
@@ -14534,7 +14628,6 @@
     },
     "node_modules/data-view-byte-length": {
       "version": "1.0.1",
-      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "call-bind": "^1.0.7",
@@ -14550,7 +14643,6 @@
     },
     "node_modules/data-view-byte-offset": {
       "version": "1.0.0",
-      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "call-bind": "^1.0.6",
@@ -14604,6 +14696,15 @@
         "supports-color": {
           "optional": true
         }
+      }
+    },
+    "node_modules/decamelize": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+      "integrity": "sha512-z2S+W9X73hAUUki+N+9Za2lBlun89zigOyGrsax+KUQ6wKW4ZoWpEYBkGhQjwAjjDCkWxhY0VKEhk8wzY7F5cA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/decimal.js": {
@@ -14935,7 +15036,6 @@
     },
     "node_modules/define-properties": {
       "version": "1.2.1",
-      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "define-data-property": "^1.0.1",
@@ -15509,7 +15609,6 @@
     },
     "node_modules/es-abstract": {
       "version": "1.23.3",
-      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "array-buffer-byte-length": "^1.0.1",
@@ -15569,8 +15668,6 @@
     "node_modules/es-aggregate-error": {
       "version": "1.0.13",
       "license": "MIT",
-      "optional": true,
-      "peer": true,
       "dependencies": {
         "define-data-property": "^1.1.4",
         "define-properties": "^1.2.1",
@@ -15620,7 +15717,6 @@
     },
     "node_modules/es-set-tostringtag": {
       "version": "2.0.3",
-      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "get-intrinsic": "^1.2.4",
@@ -15641,7 +15737,6 @@
     },
     "node_modules/es-to-primitive": {
       "version": "1.2.1",
-      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "is-callable": "^1.1.4",
@@ -16186,7 +16281,6 @@
     },
     "node_modules/eventemitter3": {
       "version": "4.0.7",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/events": {
@@ -17095,7 +17189,6 @@
     },
     "node_modules/function.prototype.name": {
       "version": "1.1.6",
-      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "call-bind": "^1.0.2",
@@ -17112,7 +17205,6 @@
     },
     "node_modules/functions-have-names": {
       "version": "1.2.3",
-      "devOptional": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -17242,7 +17334,6 @@
     },
     "node_modules/get-symbol-description": {
       "version": "1.0.2",
-      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "call-bind": "^1.0.5",
@@ -17333,7 +17424,6 @@
     },
     "node_modules/globalthis": {
       "version": "1.0.4",
-      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "define-properties": "^1.2.1",
@@ -17566,7 +17656,6 @@
     },
     "node_modules/has-bigints": {
       "version": "1.0.2",
-      "devOptional": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -17591,7 +17680,6 @@
     },
     "node_modules/has-proto": {
       "version": "1.0.3",
-      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -18282,7 +18370,6 @@
     },
     "node_modules/internal-slot": {
       "version": "1.0.7",
-      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
@@ -18329,6 +18416,12 @@
         "node": ">= 0.10"
       }
     },
+    "node_modules/is-any-array": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-any-array/-/is-any-array-2.0.1.tgz",
+      "integrity": "sha512-UtilS7hLRu++wb/WBAw9bNuP1Eg04Ivn1vERJck8zJthEvXCBEBpGR/33u/xLKWEQf95803oalHrVDptcAvFdQ==",
+      "license": "MIT"
+    },
     "node_modules/is-arguments": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/is-arguments/-/is-arguments-1.2.0.tgz",
@@ -18346,7 +18439,6 @@
     },
     "node_modules/is-array-buffer": {
       "version": "3.0.4",
-      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "call-bind": "^1.0.2",
@@ -18365,7 +18457,6 @@
     },
     "node_modules/is-bigint": {
       "version": "1.0.4",
-      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "has-bigints": "^1.0.1"
@@ -18386,7 +18477,6 @@
     },
     "node_modules/is-boolean-object": {
       "version": "1.1.2",
-      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "call-bind": "^1.0.2",
@@ -18442,7 +18532,6 @@
     },
     "node_modules/is-data-view": {
       "version": "1.0.1",
-      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "is-typed-array": "^1.1.13"
@@ -18456,7 +18545,6 @@
     },
     "node_modules/is-date-object": {
       "version": "1.0.5",
-      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "has-tostringtag": "^1.0.0"
@@ -18578,7 +18666,6 @@
     },
     "node_modules/is-negative-zero": {
       "version": "2.0.3",
-      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -18607,7 +18694,6 @@
     },
     "node_modules/is-number-object": {
       "version": "1.0.7",
-      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "has-tostringtag": "^1.0.0"
@@ -18696,7 +18782,6 @@
     },
     "node_modules/is-shared-array-buffer": {
       "version": "1.0.3",
-      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "call-bind": "^1.0.7"
@@ -18720,7 +18805,6 @@
     },
     "node_modules/is-string": {
       "version": "1.0.7",
-      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "has-tostringtag": "^1.0.0"
@@ -18746,7 +18830,6 @@
     },
     "node_modules/is-symbol": {
       "version": "1.0.4",
-      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "has-symbols": "^1.0.2"
@@ -18783,7 +18866,6 @@
     },
     "node_modules/is-weakref": {
       "version": "1.0.2",
-      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "call-bind": "^1.0.2"
@@ -18818,7 +18900,6 @@
     },
     "node_modules/isarray": {
       "version": "2.0.5",
-      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/isbinaryfile": {
@@ -19026,6 +19107,15 @@
       "version": "0.3.2",
       "license": "MIT"
     },
+    "node_modules/js-tiktoken": {
+      "version": "1.0.20",
+      "resolved": "https://registry.npmjs.org/js-tiktoken/-/js-tiktoken-1.0.20.tgz",
+      "integrity": "sha512-Xlaqhhs8VfCd6Sh7a1cFkZHQbYTLCwVJJWiHVxBYzLPxW0XsoxBy1hitmjkdIjD3Aon5BXLHFwU5O8WUx6HH+A==",
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.5.1"
+      }
+    },
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "license": "MIT"
@@ -19042,9 +19132,7 @@
     },
     "node_modules/jsbi": {
       "version": "4.3.0",
-      "license": "Apache-2.0",
-      "optional": true,
-      "peer": true
+      "license": "Apache-2.0"
     },
     "node_modules/jsbn": {
       "version": "1.1.0",
@@ -19572,6 +19660,87 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/langsmith": {
+      "version": "0.1.68",
+      "resolved": "https://registry.npmjs.org/langsmith/-/langsmith-0.1.68.tgz",
+      "integrity": "sha512-otmiysWtVAqzMx3CJ4PrtUBhWRG5Co8Z4o7hSZENPjlit9/j3/vm3TSvbaxpDYakZxtMjhkcJTqrdYFipISEiQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/uuid": "^10.0.0",
+        "commander": "^10.0.1",
+        "p-queue": "^6.6.2",
+        "p-retry": "4",
+        "semver": "^7.6.3",
+        "uuid": "^10.0.0"
+      },
+      "peerDependencies": {
+        "openai": "*"
+      },
+      "peerDependenciesMeta": {
+        "openai": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/langsmith/node_modules/@types/retry": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/@types/retry/-/retry-0.12.0.tgz",
+      "integrity": "sha512-wWKOClTTiizcZhXnPY4wikVAwmdYHp8q6DmC+EJUzAMsycb7HB32Kh9RN4+0gExjmPmZSAQjgURXIGATPegAvA==",
+      "license": "MIT"
+    },
+    "node_modules/langsmith/node_modules/@types/uuid": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-10.0.0.tgz",
+      "integrity": "sha512-7gqG38EyHgyP1S+7+xomFtL+ZNHcKv6DwNaCZmJmo1vgMugyF3TCnXVg4t1uk89mLNwnLtnY3TpOpCOyp1/xHQ==",
+      "license": "MIT"
+    },
+    "node_modules/langsmith/node_modules/commander": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-10.0.1.tgz",
+      "integrity": "sha512-y4Mg2tXshplEbSGzx7amzPwKKOCGuoSRP/CjEdwwk0FOGlUbq6lKuoyDZTNZkmxHdJtp54hdfY/JUrdL7Xfdug==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/langsmith/node_modules/p-retry": {
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/p-retry/-/p-retry-4.6.2.tgz",
+      "integrity": "sha512-312Id396EbJdvRONlngUx0NydfrIQ5lsYu0znKVUzVvArzEIt08V1qhtyESbGVd1FGX7UKtiFp5uwKZdM8wIuQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/retry": "0.12.0",
+        "retry": "^0.13.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/langsmith/node_modules/semver": {
+      "version": "7.7.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz",
+      "integrity": "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/langsmith/node_modules/uuid": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-10.0.0.tgz",
+      "integrity": "sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/bin/uuid"
       }
     },
     "node_modules/language-subtag-registry": {
@@ -20994,6 +21163,51 @@
         "mkdirp": "bin/cmd.js"
       }
     },
+    "node_modules/ml-array-mean": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/ml-array-mean/-/ml-array-mean-1.1.6.tgz",
+      "integrity": "sha512-MIdf7Zc8HznwIisyiJGRH9tRigg3Yf4FldW8DxKxpCCv/g5CafTw0RRu51nojVEOXuCQC7DRVVu5c7XXO/5joQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ml-array-sum": "^1.1.6"
+      }
+    },
+    "node_modules/ml-array-sum": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/ml-array-sum/-/ml-array-sum-1.1.6.tgz",
+      "integrity": "sha512-29mAh2GwH7ZmiRnup4UyibQZB9+ZLyMShvt4cH4eTK+cL2oEMIZFnSyB3SS8MlsTh6q/w/yh48KmqLxmovN4Dw==",
+      "license": "MIT",
+      "dependencies": {
+        "is-any-array": "^2.0.0"
+      }
+    },
+    "node_modules/ml-distance": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/ml-distance/-/ml-distance-4.0.1.tgz",
+      "integrity": "sha512-feZ5ziXs01zhyFUUUeZV5hwc0f5JW0Sh0ckU1koZe/wdVkJdGxcP06KNQuF0WBTj8FttQUzcvQcpcrOp/XrlEw==",
+      "license": "MIT",
+      "dependencies": {
+        "ml-array-mean": "^1.1.6",
+        "ml-distance-euclidean": "^2.0.0",
+        "ml-tree-similarity": "^1.0.0"
+      }
+    },
+    "node_modules/ml-distance-euclidean": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ml-distance-euclidean/-/ml-distance-euclidean-2.0.0.tgz",
+      "integrity": "sha512-yC9/2o8QF0A3m/0IXqCTXCzz2pNEzvmcE/9HFKOZGnTjatvBbsn4lWYJkxENkA4Ug2fnYl7PXQxnPi21sgMy/Q==",
+      "license": "MIT"
+    },
+    "node_modules/ml-tree-similarity": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/ml-tree-similarity/-/ml-tree-similarity-1.0.0.tgz",
+      "integrity": "sha512-XJUyYqjSuUQkNQHMscr6tcjldsOoAekxADTplt40QKfwW6nd++1wHWV9AArl0Zvw/TIHgNaZZNvr8QGvE8wLRg==",
+      "license": "MIT",
+      "dependencies": {
+        "binary-search": "^1.3.5",
+        "num-sort": "^2.0.0"
+      }
+    },
     "node_modules/mri": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/mri/-/mri-1.2.0.tgz",
@@ -21062,8 +21276,6 @@
     "node_modules/mssql": {
       "version": "10.0.4",
       "license": "MIT",
-      "optional": true,
-      "peer": true,
       "dependencies": {
         "@tediousjs/connection-string": "^0.5.0",
         "commander": "^11.0.0",
@@ -21082,8 +21294,6 @@
     "node_modules/mssql/node_modules/commander": {
       "version": "11.1.0",
       "license": "MIT",
-      "optional": true,
-      "peer": true,
       "engines": {
         "node": ">=16"
       }
@@ -21098,6 +21308,15 @@
       },
       "bin": {
         "multicast-dns": "cli.js"
+      }
+    },
+    "node_modules/mustache": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/mustache/-/mustache-4.2.0.tgz",
+      "integrity": "sha512-71ippSywq5Yb7/tVYyGbkBggbU8H3u5Rz56fH60jGFgr8uHwxs+aSKeqmluIVzM0m0kB7xQjKS6qPfd0b2ZoqQ==",
+      "license": "MIT",
+      "bin": {
+        "mustache": "bin/mustache"
       }
     },
     "node_modules/mute-stream": {
@@ -21655,6 +21874,18 @@
         "url": "https://github.com/fb55/nth-check?sponsor=1"
       }
     },
+    "node_modules/num-sort": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/num-sort/-/num-sort-2.1.0.tgz",
+      "integrity": "sha512-1MQz1Ed8z2yckoBeSfkQHHO9K1yDRxxtotKSJ9yvcTUUxSvfvzEq5GwBrjjHEpMlq/k5gvXdmJ1SbYxWtpNoVg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/nunjucks": {
       "version": "3.2.4",
       "license": "BSD-2-Clause",
@@ -21709,7 +21940,6 @@
     },
     "node_modules/object-keys": {
       "version": "1.1.1",
-      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -21724,7 +21954,6 @@
     },
     "node_modules/object.assign": {
       "version": "4.1.5",
-      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "call-bind": "^1.0.5",
@@ -22293,6 +22522,15 @@
         "node": ">=8"
       }
     },
+    "node_modules/p-finally": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
+      "integrity": "sha512-LICb2p9CB7FS+0eR1oqWnHhp0FljGLZCWBE9aix0Uye9W8LTQPwMTYVGWQWIw9RdQiDg4+epXQODwIYJtSJaow==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/p-limit": {
       "version": "3.1.0",
       "license": "MIT",
@@ -22329,6 +22567,22 @@
         "node": ">=6"
       }
     },
+    "node_modules/p-queue": {
+      "version": "6.6.2",
+      "resolved": "https://registry.npmjs.org/p-queue/-/p-queue-6.6.2.tgz",
+      "integrity": "sha512-RwFpb72c/BhQLEXIZ5K2e+AhgNVmIejGlTgiB9MzZ0e93GRvqZ7uSi0dvRF7/XIXDeNkra2fNHBxTyPDGySpjQ==",
+      "license": "MIT",
+      "dependencies": {
+        "eventemitter3": "^4.0.4",
+        "p-timeout": "^3.2.0"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/p-retry": {
       "version": "6.2.0",
       "dev": true,
@@ -22343,6 +22597,18 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-timeout": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-3.2.0.tgz",
+      "integrity": "sha512-rhIwUycgwwKcP9yTOOFK/AKsAopjjCakVqLHePO3CC6Mir1Z99xT+R63jZxAT5lFZLa2inS5h+ZS2GvR99/FBg==",
+      "license": "MIT",
+      "dependencies": {
+        "p-finally": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/p-try": {
@@ -23852,7 +24118,6 @@
     },
     "node_modules/regexp.prototype.flags": {
       "version": "1.5.2",
-      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "call-bind": "^1.0.6",
@@ -24314,7 +24579,6 @@
     },
     "node_modules/safe-array-concat": {
       "version": "1.1.2",
-      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "call-bind": "^1.0.7",
@@ -24731,7 +24995,6 @@
     },
     "node_modules/set-function-name": {
       "version": "2.0.2",
-      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "define-data-property": "^1.1.4",
@@ -25498,7 +25761,6 @@
     },
     "node_modules/string.prototype.trim": {
       "version": "1.2.9",
-      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "call-bind": "^1.0.7",
@@ -25515,7 +25777,6 @@
     },
     "node_modules/string.prototype.trimend": {
       "version": "1.0.8",
-      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "call-bind": "^1.0.7",
@@ -25528,7 +25789,6 @@
     },
     "node_modules/string.prototype.trimstart": {
       "version": "1.0.8",
-      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "call-bind": "^1.0.7",
@@ -25902,8 +26162,6 @@
     "node_modules/tedious": {
       "version": "16.7.1",
       "license": "MIT",
-      "optional": true,
-      "peer": true,
       "dependencies": {
         "@azure/identity": "^3.4.1",
         "@azure/keyvault-keys": "^4.4.0",
@@ -25924,8 +26182,6 @@
     "node_modules/tedious/node_modules/iconv-lite": {
       "version": "0.6.3",
       "license": "MIT",
-      "optional": true,
-      "peer": true,
       "dependencies": {
         "safer-buffer": ">= 2.1.2 < 3.0.0"
       },
@@ -26767,7 +27023,6 @@
     },
     "node_modules/typed-array-buffer": {
       "version": "1.0.2",
-      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "call-bind": "^1.0.7",
@@ -26780,7 +27035,6 @@
     },
     "node_modules/typed-array-byte-length": {
       "version": "1.0.1",
-      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "call-bind": "^1.0.7",
@@ -26798,7 +27052,6 @@
     },
     "node_modules/typed-array-byte-offset": {
       "version": "1.0.2",
-      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "available-typed-arrays": "^1.0.7",
@@ -26817,7 +27070,6 @@
     },
     "node_modules/typed-array-length": {
       "version": "1.0.6",
-      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "call-bind": "^1.0.7",
@@ -27035,7 +27287,6 @@
     },
     "node_modules/unbox-primitive": {
       "version": "1.0.2",
-      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "call-bind": "^1.0.2",
@@ -28303,7 +28554,6 @@
     },
     "node_modules/which-boxed-primitive": {
       "version": "1.0.2",
-      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "is-bigint": "^1.0.1",
@@ -28648,13 +28898,13 @@
     "packages/Actions": {},
     "packages/Actions/ApolloEnrichment": {
       "name": "@memberjunction/actions-apollo",
-      "version": "2.37.0",
+      "version": "2.37.1",
       "license": "ISC",
       "dependencies": {
-        "@memberjunction/actions": "2.37.0",
-        "@memberjunction/core": "2.37.0",
-        "@memberjunction/core-entities": "2.37.0",
-        "@memberjunction/global": "2.37.0",
+        "@memberjunction/actions": "2.37.1",
+        "@memberjunction/core": "2.37.1",
+        "@memberjunction/core-entities": "2.37.1",
+        "@memberjunction/global": "2.37.1",
         "axios": "^1.7.2"
       },
       "devDependencies": {
@@ -28664,12 +28914,12 @@
     },
     "packages/Actions/Base": {
       "name": "@memberjunction/actions-base",
-      "version": "2.37.0",
+      "version": "2.37.1",
       "license": "ISC",
       "dependencies": {
-        "@memberjunction/core": "2.37.0",
-        "@memberjunction/core-entities": "2.37.0",
-        "@memberjunction/global": "2.37.0"
+        "@memberjunction/core": "2.37.1",
+        "@memberjunction/core-entities": "2.37.1",
+        "@memberjunction/global": "2.37.1"
       },
       "devDependencies": {
         "ts-node-dev": "^2.0.0",
@@ -28678,15 +28928,15 @@
     },
     "packages/Actions/ContentAutotag": {
       "name": "@memberjunction/actions-content-autotag",
-      "version": "2.37.0",
+      "version": "2.37.1",
       "license": "ISC",
       "dependencies": {
-        "@memberjunction/actions": "2.37.0",
-        "@memberjunction/content-autotagging": "2.37.0",
-        "@memberjunction/core": "2.37.0",
-        "@memberjunction/core-actions": "2.37.0",
-        "@memberjunction/core-entities": "2.37.0",
-        "@memberjunction/global": "2.37.0",
+        "@memberjunction/actions": "2.37.1",
+        "@memberjunction/content-autotagging": "2.37.1",
+        "@memberjunction/core": "2.37.1",
+        "@memberjunction/core-actions": "2.37.1",
+        "@memberjunction/core-entities": "2.37.1",
+        "@memberjunction/global": "2.37.1",
         "axios": "^1.7.2"
       },
       "devDependencies": {
@@ -28696,17 +28946,17 @@
     },
     "packages/Actions/CoreActions": {
       "name": "@memberjunction/core-actions",
-      "version": "2.37.0",
+      "version": "2.37.1",
       "license": "ISC",
       "dependencies": {
-        "@memberjunction/actions": "2.37.0",
-        "@memberjunction/ai-vector-sync": "2.37.0",
-        "@memberjunction/communication-engine": "2.37.0",
-        "@memberjunction/content-autotagging": "2.37.0",
-        "@memberjunction/core": "2.37.0",
-        "@memberjunction/core-entities": "2.37.0",
-        "@memberjunction/external-change-detection": "2.37.0",
-        "@memberjunction/global": "2.37.0"
+        "@memberjunction/actions": "2.37.1",
+        "@memberjunction/ai-vector-sync": "2.37.1",
+        "@memberjunction/communication-engine": "2.37.1",
+        "@memberjunction/content-autotagging": "2.37.1",
+        "@memberjunction/core": "2.37.1",
+        "@memberjunction/core-entities": "2.37.1",
+        "@memberjunction/external-change-detection": "2.37.1",
+        "@memberjunction/global": "2.37.1"
       },
       "devDependencies": {
         "ts-node-dev": "^2.0.0",
@@ -28715,16 +28965,16 @@
     },
     "packages/Actions/Engine": {
       "name": "@memberjunction/actions",
-      "version": "2.37.0",
+      "version": "2.37.1",
       "license": "ISC",
       "dependencies": {
-        "@memberjunction/actions-base": "2.37.0",
-        "@memberjunction/ai": "2.37.0",
-        "@memberjunction/aiengine": "2.37.0",
-        "@memberjunction/core": "2.37.0",
-        "@memberjunction/core-entities": "2.37.0",
-        "@memberjunction/doc-utils": "2.37.0",
-        "@memberjunction/global": "2.37.0"
+        "@memberjunction/actions-base": "2.37.1",
+        "@memberjunction/ai": "2.37.1",
+        "@memberjunction/aiengine": "2.37.1",
+        "@memberjunction/core": "2.37.1",
+        "@memberjunction/core-entities": "2.37.1",
+        "@memberjunction/doc-utils": "2.37.1",
+        "@memberjunction/global": "2.37.1"
       },
       "devDependencies": {
         "ts-node-dev": "^2.0.0",
@@ -28797,15 +29047,15 @@
     },
     "packages/Actions/ScheduledActions": {
       "name": "@memberjunction/scheduled-actions",
-      "version": "2.37.0",
+      "version": "2.37.1",
       "license": "ISC",
       "dependencies": {
-        "@memberjunction/actions": "2.37.0",
-        "@memberjunction/core": "2.37.0",
-        "@memberjunction/core-actions": "2.37.0",
-        "@memberjunction/core-entities": "2.37.0",
-        "@memberjunction/global": "2.37.0",
-        "@memberjunction/sqlserver-dataprovider": "2.37.0",
+        "@memberjunction/actions": "2.37.1",
+        "@memberjunction/core": "2.37.1",
+        "@memberjunction/core-actions": "2.37.1",
+        "@memberjunction/core-entities": "2.37.1",
+        "@memberjunction/global": "2.37.1",
+        "@memberjunction/sqlserver-dataprovider": "2.37.1",
         "cron-parser": "^4.9.0"
       },
       "devDependencies": {
@@ -28815,19 +29065,19 @@
     },
     "packages/Actions/ScheduledActionsServer": {
       "name": "@memberjunction/scheduled-actions-server",
-      "version": "2.37.0",
+      "version": "2.37.1",
       "license": "ISC",
       "dependencies": {
-        "@memberjunction/actions": "2.37.0",
-        "@memberjunction/actions-content-autotag": "2.37.0",
-        "@memberjunction/ai": "2.37.0",
-        "@memberjunction/ai-mistral": "2.37.0",
-        "@memberjunction/ai-openai": "2.37.0",
-        "@memberjunction/ai-vector-sync": "2.37.0",
-        "@memberjunction/ai-vectors-pinecone": "2.37.0",
-        "@memberjunction/core": "2.37.0",
-        "@memberjunction/core-entities": "2.37.0",
-        "@memberjunction/scheduled-actions": "2.37.0",
+        "@memberjunction/actions": "2.37.1",
+        "@memberjunction/actions-content-autotag": "2.37.1",
+        "@memberjunction/ai": "2.37.1",
+        "@memberjunction/ai-mistral": "2.37.1",
+        "@memberjunction/ai-openai": "2.37.1",
+        "@memberjunction/ai-vector-sync": "2.37.1",
+        "@memberjunction/ai-vectors-pinecone": "2.37.1",
+        "@memberjunction/core": "2.37.1",
+        "@memberjunction/core-entities": "2.37.1",
+        "@memberjunction/scheduled-actions": "2.37.1",
         "@types/axios": "^0.14.0",
         "env-var": "^7.3.0",
         "express": "^4.18.2",
@@ -28851,12 +29101,234 @@
         "node": ">=4.2.0"
       }
     },
-    "packages/AI/Core": {
-      "name": "@memberjunction/ai",
-      "version": "2.37.0",
+    "packages/AI/A2AServer": {
+      "name": "@memberjunction/a2aserver",
+      "version": "0.1.0",
+      "license": "MIT",
+      "dependencies": {
+        "@memberjunction/core": "^0.9.127",
+        "@memberjunction/global": "^0.9.125",
+        "@memberjunction/sqlserver-dataprovider": "^0.9.161",
+        "cosmiconfig": "^8.0.0",
+        "dotenv": "^16.0.3",
+        "express": "^4.18.2",
+        "typeorm": "^0.3.10",
+        "zod": "^3.22.4"
+      },
+      "devDependencies": {
+        "@types/express": "^4.17.17",
+        "@types/node": "^18.11.9",
+        "rimraf": "^3.0.2",
+        "typescript": "^5.0.2"
+      }
+    },
+    "packages/AI/A2AServer/node_modules/@memberjunction/ai": {
+      "version": "0.9.171",
+      "resolved": "https://registry.npmjs.org/@memberjunction/ai/-/ai-0.9.171.tgz",
+      "integrity": "sha512-CTn57Ae4SlKh87i724UvNJUkgOyXOUhUwYH776zpZ/vzN6VZEivNG+Qtou+Nu8JPpcJoVu5jiMCwI4fQmzv0LQ==",
       "license": "ISC",
       "dependencies": {
-        "@memberjunction/global": "2.37.0",
+        "@memberjunction/global": "^0.9.168",
+        "dotenv": "^16.0.3",
+        "rxjs": "^7.8.1",
+        "typeorm": "^0.3.20"
+      }
+    },
+    "packages/AI/A2AServer/node_modules/@memberjunction/ai-vector-dupe": {
+      "version": "0.9.38",
+      "resolved": "https://registry.npmjs.org/@memberjunction/ai-vector-dupe/-/ai-vector-dupe-0.9.38.tgz",
+      "integrity": "sha512-LY1/LA/hyjYidDaO3ihU+Mx9KogxPW68YO0/oJF0TRaRoUPaFnyoDNrxA1KvZsUAOm8k+hmaHFxlHuqvlokXSg==",
+      "license": "ISC",
+      "dependencies": {
+        "@memberjunction/ai": "^0.9.171",
+        "@memberjunction/ai-vectordb": "^0.9.19",
+        "@memberjunction/ai-vectors": "^0.9.20",
+        "@memberjunction/ai-vectors-pinecone": "^0.9.37",
+        "@memberjunction/aiengine": "^0.9.86",
+        "@memberjunction/core": "^0.9.188",
+        "@memberjunction/core-entities": "^0.9.185",
+        "@memberjunction/global": "^0.9.168",
+        "dotenv": "^16.0.3",
+        "typeorm": "^0.3.20"
+      }
+    },
+    "packages/AI/A2AServer/node_modules/@memberjunction/ai-vectordb": {
+      "version": "0.9.19",
+      "resolved": "https://registry.npmjs.org/@memberjunction/ai-vectordb/-/ai-vectordb-0.9.19.tgz",
+      "integrity": "sha512-z5WiQOU4v46gMkwP0LEvrSFExQ2VSdY5niZ6XqL1FIc5b8zhHun/QAdxFau+TINT9SEu6zgUStFf4FB4FFGvag==",
+      "license": "ISC",
+      "dependencies": {
+        "@memberjunction/core": "^0.9.188",
+        "@memberjunction/global": "^0.9.168",
+        "dotenv": "^16.0.3"
+      }
+    },
+    "packages/AI/A2AServer/node_modules/@memberjunction/ai-vectors": {
+      "version": "0.9.20",
+      "resolved": "https://registry.npmjs.org/@memberjunction/ai-vectors/-/ai-vectors-0.9.20.tgz",
+      "integrity": "sha512-J6z3e4q/EUPu/QIRbqdKYYruHE3A8doQYDv1f4MySLF6b1hxDh+ylB+lEQsa1PwrUJLOsknzdPL7/6/wYAK6ew==",
+      "license": "ISC",
+      "dependencies": {
+        "@langchain/mistralai": "^0.0.7",
+        "@memberjunction/core": "^0.9.188",
+        "@memberjunction/global": "^0.9.168",
+        "dotenv": "^16.0.3",
+        "openai": "^3.2.1"
+      }
+    },
+    "packages/AI/A2AServer/node_modules/@memberjunction/ai-vectors-pinecone": {
+      "version": "0.9.37",
+      "resolved": "https://registry.npmjs.org/@memberjunction/ai-vectors-pinecone/-/ai-vectors-pinecone-0.9.37.tgz",
+      "integrity": "sha512-Is9L/fpEmH/AdwNLyzG/ZjnaF8Yca9SSAs72A1q1ur/+ScMbeZVxIOuvJYH3RLfGEN2pCyNUSZHspiVAkK5/kA==",
+      "license": "ISC",
+      "dependencies": {
+        "@memberjunction/ai-vectors": "^0.9.20",
+        "@memberjunction/aiengine": "^0.9.86",
+        "@memberjunction/core": "^0.9.188",
+        "@memberjunction/global": "^0.9.168",
+        "@pinecone-database/pinecone": "^2.0.1",
+        "dotenv": "^16.0.3",
+        "openai": "^3.2.1",
+        "rxjs": "^7.8.1",
+        "typeorm": "^0.3.20"
+      }
+    },
+    "packages/AI/A2AServer/node_modules/@memberjunction/aiengine": {
+      "version": "0.9.86",
+      "resolved": "https://registry.npmjs.org/@memberjunction/aiengine/-/aiengine-0.9.86.tgz",
+      "integrity": "sha512-X4EIyi1xzlM/lO3qHUuNEqbATrQfeOSN9oOW4vAT0bUepEyGp5ECkBr+FCvOsblkLxEs87gbKg1yZXtNI1RIzA==",
+      "license": "ISC",
+      "dependencies": {
+        "@memberjunction/ai": "^0.9.171",
+        "@memberjunction/core": "^0.9.188",
+        "@memberjunction/core-entities": "^0.9.185",
+        "@memberjunction/global": "^0.9.168",
+        "dotenv": "^16.0.3",
+        "openai": "^3.2.1",
+        "rxjs": "^7.8.1",
+        "typeorm": "^0.3.16"
+      }
+    },
+    "packages/AI/A2AServer/node_modules/@memberjunction/core": {
+      "version": "0.9.188",
+      "resolved": "https://registry.npmjs.org/@memberjunction/core/-/core-0.9.188.tgz",
+      "integrity": "sha512-HYZfBy3abZTpnG3l3QQFqUo4a3JEzF+R7Fstc4K3LRTw/sAWb1RohyXI3jEmii+VjHC2RCOB9h6qe+vWQa2ZzA==",
+      "license": "ISC",
+      "dependencies": {
+        "@memberjunction/global": "^0.9.168"
+      }
+    },
+    "packages/AI/A2AServer/node_modules/@memberjunction/core-entities": {
+      "version": "0.9.185",
+      "resolved": "https://registry.npmjs.org/@memberjunction/core-entities/-/core-entities-0.9.185.tgz",
+      "integrity": "sha512-gCEMTiSTse+BcCczE3w7qHJxj2CIvhPNMTpJ9bfmGungmE8/2x/52wGXmzgQrg6f8Lik/ATngCDuXTt8yUG4DA==",
+      "license": "ISC",
+      "dependencies": {
+        "@memberjunction/core": "^0.9.188",
+        "@memberjunction/global": "^0.9.168"
+      }
+    },
+    "packages/AI/A2AServer/node_modules/@memberjunction/global": {
+      "version": "0.9.168",
+      "resolved": "https://registry.npmjs.org/@memberjunction/global/-/global-0.9.168.tgz",
+      "integrity": "sha512-P7XDfcIxp5CdQu7FDQxUMqnH44DCdKyWqUGglJM9kCqKZkl396v1hB40A9THhkexmc5hZU+fnhvrr6ORmpmvOA==",
+      "license": "ISC",
+      "dependencies": {
+        "rxjs": "^7.8.1"
+      }
+    },
+    "packages/AI/A2AServer/node_modules/@memberjunction/queue": {
+      "version": "0.9.208",
+      "resolved": "https://registry.npmjs.org/@memberjunction/queue/-/queue-0.9.208.tgz",
+      "integrity": "sha512-nw8VOtqcAB7o5q8mAj2P/VOG18mvdnEfKgFxqiJ5jgdPWZXjur8EVO+MRze/Dt21VVBAXKpHV4uzuKgowRUWSA==",
+      "license": "ISC",
+      "dependencies": {
+        "@memberjunction/ai": "^0.9.171",
+        "@memberjunction/core": "^0.9.188",
+        "@memberjunction/core-entities": "^0.9.185",
+        "@memberjunction/global": "^0.9.168",
+        "@types/uuid": "^9.0.1",
+        "uuid": "^9.0.0"
+      }
+    },
+    "packages/AI/A2AServer/node_modules/@memberjunction/sqlserver-dataprovider": {
+      "version": "0.9.222",
+      "resolved": "https://registry.npmjs.org/@memberjunction/sqlserver-dataprovider/-/sqlserver-dataprovider-0.9.222.tgz",
+      "integrity": "sha512-KP7a4RqSlXyzwkukkXZqKtqnhZ9/PtVORJgo6inFTAJc7KZZzOi7DlXYdSl7Jy+9POVeYHls9ha/ydW9jSbBxQ==",
+      "license": "ISC",
+      "dependencies": {
+        "@memberjunction/ai": "^0.9.171",
+        "@memberjunction/ai-vector-dupe": "^0.9.38",
+        "@memberjunction/aiengine": "^0.9.86",
+        "@memberjunction/core": "^0.9.188",
+        "@memberjunction/core-entities": "^0.9.185",
+        "@memberjunction/global": "^0.9.168",
+        "@memberjunction/queue": "^0.9.208",
+        "mssql": "^10.0.2",
+        "typeorm": "^0.3.20"
+      }
+    },
+    "packages/AI/A2AServer/node_modules/@types/node": {
+      "version": "18.19.100",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.100.tgz",
+      "integrity": "sha512-ojmMP8SZBKprc3qGrGk8Ujpo80AXkrP7G2tOT4VWr5jlr5DHjsJF+emXJz+Wm0glmy4Js62oKMdZZ6B9Y+tEcA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~5.26.4"
+      }
+    },
+    "packages/AI/A2AServer/node_modules/axios": {
+      "version": "0.26.1",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.26.1.tgz",
+      "integrity": "sha512-fPwcX4EvnSHuInCMItEhAGnaSEXRBjtzh9fOtsE6E1G6p7vl7edEeZe11QHf18+6+9gR5PbKV/sGKNaD8YaMeA==",
+      "license": "MIT",
+      "dependencies": {
+        "follow-redirects": "^1.14.8"
+      }
+    },
+    "packages/AI/A2AServer/node_modules/cosmiconfig": {
+      "version": "8.3.6",
+      "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-8.3.6.tgz",
+      "integrity": "sha512-kcZ6+W5QzcJ3P1Mt+83OUv/oHFqZHIx8DuxG6eZ5RGMERoLqp4BuGjhHLYGK+Kf5XVkQvqBSmAy/nGWN3qDgEA==",
+      "license": "MIT",
+      "dependencies": {
+        "import-fresh": "^3.3.0",
+        "js-yaml": "^4.1.0",
+        "parse-json": "^5.2.0",
+        "path-type": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/d-fischer"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.9.5"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "packages/AI/A2AServer/node_modules/openai": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/openai/-/openai-3.3.0.tgz",
+      "integrity": "sha512-uqxI/Au+aPRnsaQRe8CojU0eCR7I0mBiKjD3sNMzY6DaC1ZVrc85u98mtJW6voDug8fgGN+DIZmTDxTthxb7dQ==",
+      "license": "MIT",
+      "dependencies": {
+        "axios": "^0.26.0",
+        "form-data": "^4.0.0"
+      }
+    },
+    "packages/AI/Core": {
+      "name": "@memberjunction/ai",
+      "version": "2.37.1",
+      "license": "ISC",
+      "dependencies": {
+        "@memberjunction/global": "2.37.1",
         "dotenv": "^16.4.1",
         "rxjs": "^7.8.1",
         "typeorm": "^0.3.20"
@@ -28869,13 +29341,13 @@
     },
     "packages/AI/Engine": {
       "name": "@memberjunction/aiengine",
-      "version": "2.37.0",
+      "version": "2.37.1",
       "license": "ISC",
       "dependencies": {
-        "@memberjunction/ai": "2.37.0",
-        "@memberjunction/core": "2.37.0",
-        "@memberjunction/core-entities": "2.37.0",
-        "@memberjunction/global": "2.37.0",
+        "@memberjunction/ai": "2.37.1",
+        "@memberjunction/core": "2.37.1",
+        "@memberjunction/core-entities": "2.37.1",
+        "@memberjunction/global": "2.37.1",
         "dotenv": "^16.4.1",
         "rxjs": "^7.8.1"
       },
@@ -28887,13 +29359,13 @@
     },
     "packages/AI/MCPServer": {
       "name": "@memberjunction/ai-mcp-server",
-      "version": "2.37.0",
+      "version": "2.37.1",
       "license": "ISC",
       "dependencies": {
-        "@memberjunction/core": "2.37.0",
-        "@memberjunction/core-entities": "2.37.0",
-        "@memberjunction/global": "2.37.0",
-        "@memberjunction/sqlserver-dataprovider": "2.37.0",
+        "@memberjunction/core": "2.37.1",
+        "@memberjunction/core-entities": "2.37.1",
+        "@memberjunction/global": "2.37.1",
+        "@memberjunction/sqlserver-dataprovider": "2.37.1",
         "@modelcontextprotocol/sdk": "^1.8.0",
         "cosmiconfig": "9.0.0",
         "dotenv": "^16.4.1",
@@ -28912,12 +29384,12 @@
     },
     "packages/AI/Providers/Anthropic": {
       "name": "@memberjunction/ai-anthropic",
-      "version": "2.37.0",
+      "version": "2.37.1",
       "license": "ISC",
       "dependencies": {
         "@anthropic-ai/sdk": "0.36.3",
-        "@memberjunction/ai": "2.37.0",
-        "@memberjunction/global": "2.37.0"
+        "@memberjunction/ai": "2.37.1",
+        "@memberjunction/global": "2.37.1"
       },
       "devDependencies": {
         "ts-node-dev": "^2.0.0",
@@ -28926,7 +29398,7 @@
     },
     "packages/AI/Providers/Azure": {
       "name": "@memberjunction/ai-azure",
-      "version": "2.37.0",
+      "version": "2.37.1",
       "license": "MIT",
       "dependencies": {
         "@azure-rest/ai-inference": "^1.0.0-beta.6",
@@ -29081,11 +29553,11 @@
     },
     "packages/AI/Providers/BettyBot": {
       "name": "@memberjunction/ai-betty-bot",
-      "version": "2.37.0",
+      "version": "2.37.1",
       "license": "ISC",
       "dependencies": {
-        "@memberjunction/ai": "2.37.0",
-        "@memberjunction/global": "2.37.0",
+        "@memberjunction/ai": "2.37.1",
+        "@memberjunction/global": "2.37.1",
         "axios": "^1.7.7",
         "axios-retry": "^4.3.0",
         "env-var": "^7.5.0"
@@ -29097,11 +29569,11 @@
     },
     "packages/AI/Providers/ElevenLabs": {
       "name": "@memberjunction/ai-elevenlabs",
-      "version": "2.37.0",
+      "version": "2.37.1",
       "license": "ISC",
       "dependencies": {
-        "@memberjunction/ai": "2.37.0",
-        "@memberjunction/global": "2.37.0",
+        "@memberjunction/ai": "2.37.1",
+        "@memberjunction/global": "2.37.1",
         "elevenlabs": "^1.51.0"
       },
       "devDependencies": {
@@ -29111,12 +29583,12 @@
     },
     "packages/AI/Providers/Gemini": {
       "name": "@memberjunction/ai-gemini",
-      "version": "2.37.0",
+      "version": "2.37.1",
       "license": "ISC",
       "dependencies": {
         "@google/generative-ai": "0.21.0",
-        "@memberjunction/ai": "2.37.0",
-        "@memberjunction/global": "2.37.0"
+        "@memberjunction/ai": "2.37.1",
+        "@memberjunction/global": "2.37.1"
       },
       "devDependencies": {
         "ts-node-dev": "^2.0.0",
@@ -29125,11 +29597,11 @@
     },
     "packages/AI/Providers/Groq": {
       "name": "@memberjunction/ai-groq",
-      "version": "2.37.0",
+      "version": "2.37.1",
       "license": "ISC",
       "dependencies": {
-        "@memberjunction/ai": "2.37.0",
-        "@memberjunction/global": "2.37.0",
+        "@memberjunction/ai": "2.37.1",
+        "@memberjunction/global": "2.37.1",
         "groq-sdk": "0.15.0"
       },
       "devDependencies": {
@@ -29139,11 +29611,11 @@
     },
     "packages/AI/Providers/HeyGen": {
       "name": "@memberjunction/ai-heygen",
-      "version": "2.37.0",
+      "version": "2.37.1",
       "license": "ISC",
       "dependencies": {
-        "@memberjunction/ai": "2.37.0",
-        "@memberjunction/global": "2.37.0",
+        "@memberjunction/ai": "2.37.1",
+        "@memberjunction/global": "2.37.1",
         "elevenlabs": "^1.51.0"
       },
       "devDependencies": {
@@ -29153,11 +29625,11 @@
     },
     "packages/AI/Providers/Mistral": {
       "name": "@memberjunction/ai-mistral",
-      "version": "2.37.0",
+      "version": "2.37.1",
       "license": "ISC",
       "dependencies": {
-        "@memberjunction/ai": "2.37.0",
-        "@memberjunction/global": "2.37.0",
+        "@memberjunction/ai": "2.37.1",
+        "@memberjunction/global": "2.37.1",
         "@mistralai/mistralai": "^1.5.0",
         "axios-retry": "4.3.0"
       },
@@ -29180,11 +29652,11 @@
     },
     "packages/AI/Providers/OpenAI": {
       "name": "@memberjunction/ai-openai",
-      "version": "2.37.0",
+      "version": "2.37.1",
       "license": "ISC",
       "dependencies": {
-        "@memberjunction/ai": "2.37.0",
-        "@memberjunction/global": "2.37.0",
+        "@memberjunction/ai": "2.37.1",
+        "@memberjunction/global": "2.37.1",
         "openai": "4.96.0"
       },
       "devDependencies": {
@@ -29256,12 +29728,12 @@
     },
     "packages/AI/Providers/Recommendations-Rex": {
       "name": "@memberjunction/ai-recommendations-rex",
-      "version": "2.37.0",
+      "version": "2.37.1",
       "license": "ISC",
       "dependencies": {
-        "@memberjunction/ai": "2.37.0",
-        "@memberjunction/ai-recommendations": "2.37.0",
-        "@memberjunction/global": "2.37.0",
+        "@memberjunction/ai": "2.37.1",
+        "@memberjunction/ai-recommendations": "2.37.1",
+        "@memberjunction/global": "2.37.1",
         "axios": "^1.7.2",
         "dotenv": "^16.4.1",
         "openai": "^4.28.4"
@@ -29273,13 +29745,13 @@
     },
     "packages/AI/Providers/Vectors-Pinecone": {
       "name": "@memberjunction/ai-vectors-pinecone",
-      "version": "2.37.0",
+      "version": "2.37.1",
       "license": "ISC",
       "dependencies": {
-        "@memberjunction/ai-vectors": "2.37.0",
-        "@memberjunction/aiengine": "2.37.0",
-        "@memberjunction/core": "2.37.0",
-        "@memberjunction/global": "2.37.0",
+        "@memberjunction/ai-vectors": "2.37.1",
+        "@memberjunction/aiengine": "2.37.1",
+        "@memberjunction/core": "2.37.1",
+        "@memberjunction/global": "2.37.1",
         "@pinecone-database/pinecone": "2.2.2",
         "dotenv": "^16.4.1",
         "openai": "^4.28.4",
@@ -29294,13 +29766,13 @@
     },
     "packages/AI/Recommendations/Engine": {
       "name": "@memberjunction/ai-recommendations",
-      "version": "2.37.0",
+      "version": "2.37.1",
       "license": "ISC",
       "dependencies": {
-        "@memberjunction/ai": "2.37.0",
-        "@memberjunction/core": "2.37.0",
-        "@memberjunction/core-entities": "2.37.0",
-        "@memberjunction/global": "2.37.0"
+        "@memberjunction/ai": "2.37.1",
+        "@memberjunction/core": "2.37.1",
+        "@memberjunction/core-entities": "2.37.1",
+        "@memberjunction/global": "2.37.1"
       },
       "devDependencies": {
         "ts-node-dev": "^2.0.0",
@@ -29309,15 +29781,15 @@
     },
     "packages/AI/Vectors/Core": {
       "name": "@memberjunction/ai-vectors",
-      "version": "2.37.0",
+      "version": "2.37.1",
       "license": "ISC",
       "dependencies": {
-        "@memberjunction/ai": "2.37.0",
-        "@memberjunction/ai-vectordb": "2.37.0",
-        "@memberjunction/aiengine": "2.37.0",
-        "@memberjunction/core": "2.37.0",
-        "@memberjunction/core-entities": "2.37.0",
-        "@memberjunction/global": "2.37.0",
+        "@memberjunction/ai": "2.37.1",
+        "@memberjunction/ai-vectordb": "2.37.1",
+        "@memberjunction/aiengine": "2.37.1",
+        "@memberjunction/core": "2.37.1",
+        "@memberjunction/core-entities": "2.37.1",
+        "@memberjunction/global": "2.37.1",
         "dotenv": "^16.4.1",
         "openai": "^4.28.4"
       },
@@ -29329,11 +29801,11 @@
     },
     "packages/AI/Vectors/Database": {
       "name": "@memberjunction/ai-vectordb",
-      "version": "2.37.0",
+      "version": "2.37.1",
       "license": "ISC",
       "dependencies": {
-        "@memberjunction/core": "2.37.0",
-        "@memberjunction/global": "2.37.0",
+        "@memberjunction/core": "2.37.1",
+        "@memberjunction/global": "2.37.1",
         "dotenv": "^16.4.1"
       },
       "devDependencies": {
@@ -29344,18 +29816,18 @@
     },
     "packages/AI/Vectors/Dupe": {
       "name": "@memberjunction/ai-vector-dupe",
-      "version": "2.37.0",
+      "version": "2.37.1",
       "license": "ISC",
       "dependencies": {
-        "@memberjunction/ai": "2.37.0",
-        "@memberjunction/ai-vector-sync": "2.37.0",
-        "@memberjunction/ai-vectordb": "2.37.0",
-        "@memberjunction/ai-vectors": "2.37.0",
-        "@memberjunction/ai-vectors-pinecone": "2.37.0",
-        "@memberjunction/aiengine": "2.37.0",
-        "@memberjunction/core": "2.37.0",
-        "@memberjunction/core-entities": "2.37.0",
-        "@memberjunction/global": "2.37.0",
+        "@memberjunction/ai": "2.37.1",
+        "@memberjunction/ai-vector-sync": "2.37.1",
+        "@memberjunction/ai-vectordb": "2.37.1",
+        "@memberjunction/ai-vectors": "2.37.1",
+        "@memberjunction/ai-vectors-pinecone": "2.37.1",
+        "@memberjunction/aiengine": "2.37.1",
+        "@memberjunction/core": "2.37.1",
+        "@memberjunction/core-entities": "2.37.1",
+        "@memberjunction/global": "2.37.1",
         "dotenv": "^16.4.1",
         "typeorm": "^0.3.20"
       },
@@ -29368,20 +29840,20 @@
     },
     "packages/AI/Vectors/Sync": {
       "name": "@memberjunction/ai-vector-sync",
-      "version": "2.37.0",
+      "version": "2.37.1",
       "license": "ISC",
       "dependencies": {
-        "@memberjunction/ai": "2.37.0",
-        "@memberjunction/ai-mistral": "2.37.0",
-        "@memberjunction/ai-openai": "2.37.0",
-        "@memberjunction/ai-vectordb": "2.37.0",
-        "@memberjunction/ai-vectors": "2.37.0",
-        "@memberjunction/ai-vectors-pinecone": "2.37.0",
-        "@memberjunction/aiengine": "2.37.0",
-        "@memberjunction/core": "2.37.0",
-        "@memberjunction/global": "2.37.0",
-        "@memberjunction/templates": "2.37.0",
-        "@memberjunction/templates-base-types": "2.37.0",
+        "@memberjunction/ai": "2.37.1",
+        "@memberjunction/ai-mistral": "2.37.1",
+        "@memberjunction/ai-openai": "2.37.1",
+        "@memberjunction/ai-vectordb": "2.37.1",
+        "@memberjunction/ai-vectors": "2.37.1",
+        "@memberjunction/ai-vectors-pinecone": "2.37.1",
+        "@memberjunction/aiengine": "2.37.1",
+        "@memberjunction/core": "2.37.1",
+        "@memberjunction/global": "2.37.1",
+        "@memberjunction/templates": "2.37.1",
+        "@memberjunction/templates-base-types": "2.37.1",
         "dotenv": "^16.4.1",
         "typeorm": "^0.3.20"
       },
@@ -29394,22 +29866,22 @@
     },
     "packages/Angular/Explorer/ask-skip": {
       "name": "@memberjunction/ng-ask-skip",
-      "version": "2.37.0",
+      "version": "2.37.1",
       "license": "ISC",
       "dependencies": {
         "@angular/cdk": "18.0.2",
-        "@memberjunction/core": "2.37.0",
-        "@memberjunction/core-entities": "2.37.0",
-        "@memberjunction/global": "2.37.0",
-        "@memberjunction/graphql-dataprovider": "2.37.0",
-        "@memberjunction/ng-chat": "2.37.0",
-        "@memberjunction/ng-container-directives": "2.37.0",
-        "@memberjunction/ng-data-context": "2.37.0",
-        "@memberjunction/ng-shared": "2.37.0",
-        "@memberjunction/ng-skip-chat": "2.37.0",
-        "@memberjunction/ng-tabstrip": "2.37.0",
-        "@memberjunction/ng-user-view-grid": "2.37.0",
-        "@memberjunction/skip-types": "2.37.0",
+        "@memberjunction/core": "2.37.1",
+        "@memberjunction/core-entities": "2.37.1",
+        "@memberjunction/global": "2.37.1",
+        "@memberjunction/graphql-dataprovider": "2.37.1",
+        "@memberjunction/ng-chat": "2.37.1",
+        "@memberjunction/ng-container-directives": "2.37.1",
+        "@memberjunction/ng-data-context": "2.37.1",
+        "@memberjunction/ng-shared": "2.37.1",
+        "@memberjunction/ng-skip-chat": "2.37.1",
+        "@memberjunction/ng-tabstrip": "2.37.1",
+        "@memberjunction/ng-user-view-grid": "2.37.1",
+        "@memberjunction/skip-types": "2.37.1",
         "@progress/kendo-angular-dialog": "16.2.0",
         "@progress/kendo-angular-filter": "16.2.0",
         "@progress/kendo-angular-grid": "16.2.0",
@@ -29470,10 +29942,10 @@
     },
     "packages/Angular/Explorer/auth-services": {
       "name": "@memberjunction/ng-auth-services",
-      "version": "2.37.0",
+      "version": "2.37.1",
       "license": "ISC",
       "dependencies": {
-        "@memberjunction/core": "2.37.0",
+        "@memberjunction/core": "2.37.1",
         "tslib": "^2.3.0"
       },
       "devDependencies": {
@@ -29491,18 +29963,18 @@
     },
     "packages/Angular/Explorer/base-forms": {
       "name": "@memberjunction/ng-base-forms",
-      "version": "2.37.0",
+      "version": "2.37.1",
       "license": "ISC",
       "dependencies": {
-        "@memberjunction/core": "2.37.0",
-        "@memberjunction/global": "2.37.0",
-        "@memberjunction/ng-base-types": "2.37.0",
-        "@memberjunction/ng-code-editor": "2.37.0",
-        "@memberjunction/ng-container-directives": "2.37.0",
-        "@memberjunction/ng-link-directives": "2.37.0",
-        "@memberjunction/ng-record-changes": "2.37.0",
-        "@memberjunction/ng-shared": "2.37.0",
-        "@memberjunction/ng-tabstrip": "2.37.0",
+        "@memberjunction/core": "2.37.1",
+        "@memberjunction/global": "2.37.1",
+        "@memberjunction/ng-base-types": "2.37.1",
+        "@memberjunction/ng-code-editor": "2.37.1",
+        "@memberjunction/ng-container-directives": "2.37.1",
+        "@memberjunction/ng-link-directives": "2.37.1",
+        "@memberjunction/ng-record-changes": "2.37.1",
+        "@memberjunction/ng-shared": "2.37.1",
+        "@memberjunction/ng-tabstrip": "2.37.1",
         "@progress/kendo-angular-buttons": "16.2.0",
         "@progress/kendo-angular-dateinputs": "16.2.0",
         "@progress/kendo-angular-dialog": "16.2.0",
@@ -29558,11 +30030,11 @@
     },
     "packages/Angular/Explorer/compare-records": {
       "name": "@memberjunction/ng-compare-records",
-      "version": "2.37.0",
+      "version": "2.37.1",
       "license": "ISC",
       "dependencies": {
-        "@memberjunction/core": "2.37.0",
-        "@memberjunction/core-entities": "2.37.0",
+        "@memberjunction/core": "2.37.1",
+        "@memberjunction/core-entities": "2.37.1",
         "@progress/kendo-angular-grid": "16.2.0",
         "tslib": "^2.3.0"
       },
@@ -29581,19 +30053,19 @@
     },
     "packages/Angular/Explorer/core-entity-forms": {
       "name": "@memberjunction/ng-core-entity-forms",
-      "version": "2.37.0",
+      "version": "2.37.1",
       "license": "ISC",
       "dependencies": {
-        "@memberjunction/core": "2.37.0",
-        "@memberjunction/core-entities": "2.37.0",
-        "@memberjunction/ng-base-forms": "2.37.0",
-        "@memberjunction/ng-code-editor": "2.37.0",
-        "@memberjunction/ng-container-directives": "2.37.0",
-        "@memberjunction/ng-explorer-core": "2.37.0",
-        "@memberjunction/ng-form-toolbar": "2.37.0",
-        "@memberjunction/ng-join-grid": "2.37.0",
-        "@memberjunction/ng-tabstrip": "2.37.0",
-        "@memberjunction/ng-timeline": "2.37.0",
+        "@memberjunction/core": "2.37.1",
+        "@memberjunction/core-entities": "2.37.1",
+        "@memberjunction/ng-base-forms": "2.37.1",
+        "@memberjunction/ng-code-editor": "2.37.1",
+        "@memberjunction/ng-container-directives": "2.37.1",
+        "@memberjunction/ng-explorer-core": "2.37.1",
+        "@memberjunction/ng-form-toolbar": "2.37.1",
+        "@memberjunction/ng-join-grid": "2.37.1",
+        "@memberjunction/ng-tabstrip": "2.37.1",
+        "@memberjunction/ng-timeline": "2.37.1",
         "@progress/kendo-angular-dropdowns": "16.2.0",
         "@progress/kendo-angular-grid": "16.2.0",
         "tslib": "^2.3.0"
@@ -29634,15 +30106,15 @@
     },
     "packages/Angular/Explorer/entity-form-dialog": {
       "name": "@memberjunction/ng-entity-form-dialog",
-      "version": "2.37.0",
+      "version": "2.37.1",
       "license": "ISC",
       "dependencies": {
-        "@memberjunction/core": "2.37.0",
-        "@memberjunction/core-entities": "2.37.0",
-        "@memberjunction/global": "2.37.0",
-        "@memberjunction/ng-base-forms": "2.37.0",
-        "@memberjunction/ng-container-directives": "2.37.0",
-        "@memberjunction/ng-shared": "2.37.0",
+        "@memberjunction/core": "2.37.1",
+        "@memberjunction/core-entities": "2.37.1",
+        "@memberjunction/global": "2.37.1",
+        "@memberjunction/ng-base-forms": "2.37.1",
+        "@memberjunction/ng-container-directives": "2.37.1",
+        "@memberjunction/ng-shared": "2.37.1",
         "@progress/kendo-angular-buttons": "16.2.0",
         "@progress/kendo-angular-dialog": "16.2.0",
         "tslib": "^2.3.0"
@@ -29660,14 +30132,14 @@
     },
     "packages/Angular/Explorer/entity-permissions": {
       "name": "@memberjunction/ng-entity-permissions",
-      "version": "2.37.0",
+      "version": "2.37.1",
       "license": "ISC",
       "dependencies": {
-        "@memberjunction/core": "2.37.0",
-        "@memberjunction/core-entities": "2.37.0",
-        "@memberjunction/global": "2.37.0",
-        "@memberjunction/ng-container-directives": "2.37.0",
-        "@memberjunction/ng-shared": "2.37.0",
+        "@memberjunction/core": "2.37.1",
+        "@memberjunction/core-entities": "2.37.1",
+        "@memberjunction/global": "2.37.1",
+        "@memberjunction/ng-container-directives": "2.37.1",
+        "@memberjunction/ng-shared": "2.37.1",
         "@progress/kendo-angular-buttons": "16.2.0",
         "@progress/kendo-angular-dialog": "16.2.0",
         "@progress/kendo-angular-dropdowns": "16.2.0",
@@ -29688,32 +30160,32 @@
     },
     "packages/Angular/Explorer/explorer-core": {
       "name": "@memberjunction/ng-explorer-core",
-      "version": "2.37.0",
+      "version": "2.37.1",
       "license": "ISC",
       "dependencies": {
-        "@memberjunction/communication-types": "2.37.0",
-        "@memberjunction/core": "2.37.0",
-        "@memberjunction/core-entities": "2.37.0",
-        "@memberjunction/entity-communications-client": "2.37.0",
-        "@memberjunction/global": "2.37.0",
-        "@memberjunction/ng-ask-skip": "2.37.0",
-        "@memberjunction/ng-auth-services": "2.37.0",
-        "@memberjunction/ng-base-forms": "2.37.0",
-        "@memberjunction/ng-compare-records": "2.37.0",
-        "@memberjunction/ng-container-directives": "2.37.0",
-        "@memberjunction/ng-entity-form-dialog": "2.37.0",
-        "@memberjunction/ng-explorer-settings": "2.37.0",
-        "@memberjunction/ng-file-storage": "2.37.0",
-        "@memberjunction/ng-query-grid": "2.37.0",
-        "@memberjunction/ng-record-changes": "2.37.0",
-        "@memberjunction/ng-record-selector": "2.37.0",
-        "@memberjunction/ng-resource-permissions": "2.37.0",
-        "@memberjunction/ng-shared": "2.37.0",
-        "@memberjunction/ng-skip-chat": "2.37.0",
-        "@memberjunction/ng-tabstrip": "2.37.0",
-        "@memberjunction/ng-user-view-grid": "2.37.0",
-        "@memberjunction/ng-user-view-properties": "2.37.0",
-        "@memberjunction/templates-base-types": "2.37.0",
+        "@memberjunction/communication-types": "2.37.1",
+        "@memberjunction/core": "2.37.1",
+        "@memberjunction/core-entities": "2.37.1",
+        "@memberjunction/entity-communications-client": "2.37.1",
+        "@memberjunction/global": "2.37.1",
+        "@memberjunction/ng-ask-skip": "2.37.1",
+        "@memberjunction/ng-auth-services": "2.37.1",
+        "@memberjunction/ng-base-forms": "2.37.1",
+        "@memberjunction/ng-compare-records": "2.37.1",
+        "@memberjunction/ng-container-directives": "2.37.1",
+        "@memberjunction/ng-entity-form-dialog": "2.37.1",
+        "@memberjunction/ng-explorer-settings": "2.37.1",
+        "@memberjunction/ng-file-storage": "2.37.1",
+        "@memberjunction/ng-query-grid": "2.37.1",
+        "@memberjunction/ng-record-changes": "2.37.1",
+        "@memberjunction/ng-record-selector": "2.37.1",
+        "@memberjunction/ng-resource-permissions": "2.37.1",
+        "@memberjunction/ng-shared": "2.37.1",
+        "@memberjunction/ng-skip-chat": "2.37.1",
+        "@memberjunction/ng-tabstrip": "2.37.1",
+        "@memberjunction/ng-user-view-grid": "2.37.1",
+        "@memberjunction/ng-user-view-properties": "2.37.1",
+        "@memberjunction/templates-base-types": "2.37.1",
         "@progress/kendo-angular-buttons": "16.2.0",
         "@progress/kendo-angular-charts": "16.2.0",
         "@progress/kendo-angular-dialog": "16.2.0",
@@ -29741,21 +30213,21 @@
     },
     "packages/Angular/Explorer/explorer-settings": {
       "name": "@memberjunction/ng-explorer-settings",
-      "version": "2.37.0",
+      "version": "2.37.1",
       "license": "ISC",
       "dependencies": {
-        "@memberjunction/core": "2.37.0",
-        "@memberjunction/core-entities": "2.37.0",
-        "@memberjunction/global": "2.37.0",
-        "@memberjunction/ng-base-forms": "2.37.0",
-        "@memberjunction/ng-container-directives": "2.37.0",
-        "@memberjunction/ng-entity-form-dialog": "2.37.0",
-        "@memberjunction/ng-entity-permissions": "2.37.0",
-        "@memberjunction/ng-notifications": "2.37.0",
-        "@memberjunction/ng-shared": "2.37.0",
-        "@memberjunction/ng-simple-record-list": "2.37.0",
-        "@memberjunction/ng-tabstrip": "2.37.0",
-        "@memberjunction/ng-user-view-grid": "2.37.0",
+        "@memberjunction/core": "2.37.1",
+        "@memberjunction/core-entities": "2.37.1",
+        "@memberjunction/global": "2.37.1",
+        "@memberjunction/ng-base-forms": "2.37.1",
+        "@memberjunction/ng-container-directives": "2.37.1",
+        "@memberjunction/ng-entity-form-dialog": "2.37.1",
+        "@memberjunction/ng-entity-permissions": "2.37.1",
+        "@memberjunction/ng-notifications": "2.37.1",
+        "@memberjunction/ng-shared": "2.37.1",
+        "@memberjunction/ng-simple-record-list": "2.37.1",
+        "@memberjunction/ng-tabstrip": "2.37.1",
+        "@memberjunction/ng-user-view-grid": "2.37.1",
         "@progress/kendo-angular-buttons": "16.2.0",
         "@progress/kendo-angular-dialog": "16.2.0",
         "@progress/kendo-angular-dropdowns": "16.2.0",
@@ -29777,16 +30249,16 @@
     },
     "packages/Angular/Explorer/form-toolbar": {
       "name": "@memberjunction/ng-form-toolbar",
-      "version": "2.37.0",
+      "version": "2.37.1",
       "license": "ISC",
       "dependencies": {
-        "@memberjunction/core": "2.37.0",
-        "@memberjunction/global": "2.37.0",
-        "@memberjunction/ng-ask-skip": "2.37.0",
-        "@memberjunction/ng-base-forms": "2.37.0",
-        "@memberjunction/ng-container-directives": "2.37.0",
-        "@memberjunction/ng-record-changes": "2.37.0",
-        "@memberjunction/ng-shared": "2.37.0",
+        "@memberjunction/core": "2.37.1",
+        "@memberjunction/global": "2.37.1",
+        "@memberjunction/ng-ask-skip": "2.37.1",
+        "@memberjunction/ng-base-forms": "2.37.1",
+        "@memberjunction/ng-container-directives": "2.37.1",
+        "@memberjunction/ng-record-changes": "2.37.1",
+        "@memberjunction/ng-shared": "2.37.1",
         "@progress/kendo-angular-buttons": "16.2.0",
         "@progress/kendo-angular-dialog": "16.2.0",
         "ngx-markdown": "^18.0.0",
@@ -29838,10 +30310,10 @@
     },
     "packages/Angular/Explorer/link-directives": {
       "name": "@memberjunction/ng-link-directives",
-      "version": "2.37.0",
+      "version": "2.37.1",
       "license": "ISC",
       "dependencies": {
-        "@memberjunction/core": "2.37.0",
+        "@memberjunction/core": "2.37.1",
         "tslib": "^2.3.0"
       },
       "devDependencies": {
@@ -29856,15 +30328,15 @@
     },
     "packages/Angular/Explorer/list-detail-grid": {
       "name": "@memberjunction/ng-list-detail-grid",
-      "version": "2.37.0",
+      "version": "2.37.1",
       "license": "ISC",
       "dependencies": {
-        "@memberjunction/core": "2.37.0",
-        "@memberjunction/core-entities": "2.37.0",
-        "@memberjunction/global": "2.37.0",
-        "@memberjunction/ng-compare-records": "2.37.0",
-        "@memberjunction/ng-container-directives": "2.37.0",
-        "@memberjunction/ng-shared": "2.37.0",
+        "@memberjunction/core": "2.37.1",
+        "@memberjunction/core-entities": "2.37.1",
+        "@memberjunction/global": "2.37.1",
+        "@memberjunction/ng-compare-records": "2.37.1",
+        "@memberjunction/ng-container-directives": "2.37.1",
+        "@memberjunction/ng-shared": "2.37.1",
         "@progress/kendo-angular-buttons": "16.2.0",
         "@progress/kendo-angular-grid": "16.2.0",
         "@progress/kendo-angular-inputs": "16.2.0",
@@ -29884,13 +30356,13 @@
     },
     "packages/Angular/Explorer/record-changes": {
       "name": "@memberjunction/ng-record-changes",
-      "version": "2.37.0",
+      "version": "2.37.1",
       "license": "ISC",
       "dependencies": {
-        "@memberjunction/core": "2.37.0",
-        "@memberjunction/global": "2.37.0",
-        "@memberjunction/ng-compare-records": "2.37.0",
-        "@memberjunction/ng-container-directives": "2.37.0",
+        "@memberjunction/core": "2.37.1",
+        "@memberjunction/global": "2.37.1",
+        "@memberjunction/ng-compare-records": "2.37.1",
+        "@memberjunction/ng-container-directives": "2.37.1",
         "tslib": "^2.3.0"
       },
       "devDependencies": {
@@ -29938,14 +30410,14 @@
     },
     "packages/Angular/Explorer/shared": {
       "name": "@memberjunction/ng-shared",
-      "version": "2.37.0",
+      "version": "2.37.1",
       "license": "ISC",
       "dependencies": {
-        "@memberjunction/core": "2.37.0",
-        "@memberjunction/core-entities": "2.37.0",
-        "@memberjunction/graphql-dataprovider": "2.37.0",
-        "@memberjunction/ng-base-types": "2.37.0",
-        "@memberjunction/ng-notifications": "2.37.0",
+        "@memberjunction/core": "2.37.1",
+        "@memberjunction/core-entities": "2.37.1",
+        "@memberjunction/graphql-dataprovider": "2.37.1",
+        "@memberjunction/ng-base-types": "2.37.1",
+        "@memberjunction/ng-notifications": "2.37.1",
         "@progress/kendo-angular-notification": "16.2.0",
         "tslib": "^2.3.0"
       },
@@ -29961,15 +30433,15 @@
     },
     "packages/Angular/Explorer/simple-record-list": {
       "name": "@memberjunction/ng-simple-record-list",
-      "version": "2.37.0",
+      "version": "2.37.1",
       "license": "ISC",
       "dependencies": {
-        "@memberjunction/core": "2.37.0",
-        "@memberjunction/core-entities": "2.37.0",
-        "@memberjunction/global": "2.37.0",
-        "@memberjunction/ng-container-directives": "2.37.0",
-        "@memberjunction/ng-entity-form-dialog": "2.37.0",
-        "@memberjunction/ng-notifications": "2.37.0",
+        "@memberjunction/core": "2.37.1",
+        "@memberjunction/core-entities": "2.37.1",
+        "@memberjunction/global": "2.37.1",
+        "@memberjunction/ng-container-directives": "2.37.1",
+        "@memberjunction/ng-entity-form-dialog": "2.37.1",
+        "@memberjunction/ng-notifications": "2.37.1",
         "@progress/kendo-angular-buttons": "16.2.0",
         "@progress/kendo-angular-dialog": "16.2.0",
         "@progress/kendo-angular-indicators": "16.2.0",
@@ -29989,22 +30461,22 @@
     },
     "packages/Angular/Explorer/user-view-grid": {
       "name": "@memberjunction/ng-user-view-grid",
-      "version": "2.37.0",
+      "version": "2.37.1",
       "license": "ISC",
       "dependencies": {
-        "@memberjunction/actions-base": "2.37.0",
-        "@memberjunction/communication-types": "2.37.0",
-        "@memberjunction/core": "2.37.0",
-        "@memberjunction/core-entities": "2.37.0",
-        "@memberjunction/entity-communications-client": "2.37.0",
-        "@memberjunction/global": "2.37.0",
-        "@memberjunction/ng-base-types": "2.37.0",
-        "@memberjunction/ng-compare-records": "2.37.0",
-        "@memberjunction/ng-container-directives": "2.37.0",
-        "@memberjunction/ng-entity-communications": "2.37.0",
-        "@memberjunction/ng-entity-form-dialog": "2.37.0",
-        "@memberjunction/ng-shared": "2.37.0",
-        "@memberjunction/templates-base-types": "2.37.0",
+        "@memberjunction/actions-base": "2.37.1",
+        "@memberjunction/communication-types": "2.37.1",
+        "@memberjunction/core": "2.37.1",
+        "@memberjunction/core-entities": "2.37.1",
+        "@memberjunction/entity-communications-client": "2.37.1",
+        "@memberjunction/global": "2.37.1",
+        "@memberjunction/ng-base-types": "2.37.1",
+        "@memberjunction/ng-compare-records": "2.37.1",
+        "@memberjunction/ng-container-directives": "2.37.1",
+        "@memberjunction/ng-entity-communications": "2.37.1",
+        "@memberjunction/ng-entity-form-dialog": "2.37.1",
+        "@memberjunction/ng-shared": "2.37.1",
+        "@memberjunction/templates-base-types": "2.37.1",
         "@progress/kendo-angular-buttons": "16.2.0",
         "@progress/kendo-angular-grid": "16.2.0",
         "@progress/kendo-angular-inputs": "16.2.0",
@@ -30024,16 +30496,16 @@
     },
     "packages/Angular/Explorer/user-view-properties": {
       "name": "@memberjunction/ng-user-view-properties",
-      "version": "2.37.0",
+      "version": "2.37.1",
       "license": "ISC",
       "dependencies": {
-        "@memberjunction/core": "2.37.0",
-        "@memberjunction/core-entities": "2.37.0",
-        "@memberjunction/global": "2.37.0",
-        "@memberjunction/ng-base-forms": "2.37.0",
-        "@memberjunction/ng-find-record": "2.37.0",
-        "@memberjunction/ng-resource-permissions": "2.37.0",
-        "@memberjunction/ng-shared": "2.37.0",
+        "@memberjunction/core": "2.37.1",
+        "@memberjunction/core-entities": "2.37.1",
+        "@memberjunction/global": "2.37.1",
+        "@memberjunction/ng-base-forms": "2.37.1",
+        "@memberjunction/ng-find-record": "2.37.1",
+        "@memberjunction/ng-resource-permissions": "2.37.1",
+        "@memberjunction/ng-shared": "2.37.1",
         "@progress/kendo-angular-buttons": "16.2.0",
         "@progress/kendo-angular-dialog": "16.2.0",
         "@progress/kendo-angular-filter": "16.2.0",
@@ -30055,12 +30527,12 @@
     },
     "packages/Angular/Generic/base-types": {
       "name": "@memberjunction/ng-base-types",
-      "version": "2.37.0",
+      "version": "2.37.1",
       "license": "ISC",
       "dependencies": {
-        "@memberjunction/core": "2.37.0",
-        "@memberjunction/core-entities": "2.37.0",
-        "@memberjunction/global": "2.37.0",
+        "@memberjunction/core": "2.37.1",
+        "@memberjunction/core-entities": "2.37.1",
+        "@memberjunction/global": "2.37.1",
         "tslib": "^2.3.0"
       },
       "devDependencies": {
@@ -30074,11 +30546,11 @@
     },
     "packages/Angular/Generic/chat": {
       "name": "@memberjunction/ng-chat",
-      "version": "2.37.0",
+      "version": "2.37.1",
       "license": "ISC",
       "dependencies": {
-        "@memberjunction/core": "2.37.0",
-        "@memberjunction/ng-container-directives": "2.37.0",
+        "@memberjunction/core": "2.37.1",
+        "@memberjunction/ng-container-directives": "2.37.1",
         "@progress/kendo-angular-buttons": "16.2.0",
         "@progress/kendo-angular-dialog": "16.2.0",
         "@progress/kendo-angular-indicators": "16.2.0",
@@ -30130,15 +30602,15 @@
     },
     "packages/Angular/Generic/code-editor": {
       "name": "@memberjunction/ng-code-editor",
-      "version": "2.37.0",
+      "version": "2.37.1",
       "license": "ISC",
       "dependencies": {
         "@codemirror/language-data": "^6.5.1",
         "@codemirror/merge": "^6.6.3",
-        "@memberjunction/core": "2.37.0",
-        "@memberjunction/core-entities": "2.37.0",
-        "@memberjunction/global": "2.37.0",
-        "@memberjunction/ng-container-directives": "2.37.0",
+        "@memberjunction/core": "2.37.1",
+        "@memberjunction/core-entities": "2.37.1",
+        "@memberjunction/global": "2.37.1",
+        "@memberjunction/ng-container-directives": "2.37.1",
         "codemirror": "^6.0.1",
         "tslib": "^2.3.0"
       },
@@ -30153,11 +30625,11 @@
     },
     "packages/Angular/Generic/container-directives": {
       "name": "@memberjunction/ng-container-directives",
-      "version": "2.37.0",
+      "version": "2.37.1",
       "license": "ISC",
       "dependencies": {
-        "@memberjunction/core": "2.37.0",
-        "@memberjunction/global": "2.37.0",
+        "@memberjunction/core": "2.37.1",
+        "@memberjunction/global": "2.37.1",
         "tslib": "^2.3.0"
       },
       "devDependencies": {
@@ -30172,12 +30644,12 @@
     },
     "packages/Angular/Generic/data-context": {
       "name": "@memberjunction/ng-data-context",
-      "version": "2.37.0",
+      "version": "2.37.1",
       "license": "ISC",
       "dependencies": {
-        "@memberjunction/core": "2.37.0",
-        "@memberjunction/core-entities": "2.37.0",
-        "@memberjunction/global": "2.37.0",
+        "@memberjunction/core": "2.37.1",
+        "@memberjunction/core-entities": "2.37.1",
+        "@memberjunction/global": "2.37.1",
         "tslib": "^2.3.0"
       },
       "devDependencies": {
@@ -30193,17 +30665,17 @@
     },
     "packages/Angular/Generic/entity-communication": {
       "name": "@memberjunction/ng-entity-communications",
-      "version": "2.37.0",
+      "version": "2.37.1",
       "license": "ISC",
       "dependencies": {
-        "@memberjunction/communication-types": "2.37.0",
-        "@memberjunction/core": "2.37.0",
-        "@memberjunction/core-entities": "2.37.0",
-        "@memberjunction/entity-communications-base": "2.37.0",
-        "@memberjunction/entity-communications-client": "2.37.0",
-        "@memberjunction/global": "2.37.0",
-        "@memberjunction/ng-container-directives": "2.37.0",
-        "@memberjunction/ng-shared": "2.37.0",
+        "@memberjunction/communication-types": "2.37.1",
+        "@memberjunction/core": "2.37.1",
+        "@memberjunction/core-entities": "2.37.1",
+        "@memberjunction/entity-communications-base": "2.37.1",
+        "@memberjunction/entity-communications-client": "2.37.1",
+        "@memberjunction/global": "2.37.1",
+        "@memberjunction/ng-container-directives": "2.37.1",
+        "@memberjunction/ng-shared": "2.37.1",
         "tslib": "^2.3.0"
       },
       "devDependencies": {
@@ -30223,15 +30695,15 @@
     },
     "packages/Angular/Generic/file-storage": {
       "name": "@memberjunction/ng-file-storage",
-      "version": "2.37.0",
+      "version": "2.37.1",
       "license": "ISC",
       "dependencies": {
-        "@memberjunction/core": "2.37.0",
-        "@memberjunction/core-entities": "2.37.0",
-        "@memberjunction/global": "2.37.0",
-        "@memberjunction/graphql-dataprovider": "2.37.0",
-        "@memberjunction/ng-container-directives": "2.37.0",
-        "@memberjunction/ng-shared": "2.37.0",
+        "@memberjunction/core": "2.37.1",
+        "@memberjunction/core-entities": "2.37.1",
+        "@memberjunction/global": "2.37.1",
+        "@memberjunction/graphql-dataprovider": "2.37.1",
+        "@memberjunction/ng-container-directives": "2.37.1",
+        "@memberjunction/ng-shared": "2.37.1",
         "@progress/kendo-angular-buttons": "16.2.0",
         "@progress/kendo-angular-dialog": "16.2.0",
         "@progress/kendo-angular-dropdowns": "16.2.0",
@@ -30256,14 +30728,14 @@
     },
     "packages/Angular/Generic/find-record": {
       "name": "@memberjunction/ng-find-record",
-      "version": "2.37.0",
+      "version": "2.37.1",
       "license": "ISC",
       "dependencies": {
-        "@memberjunction/core": "2.37.0",
-        "@memberjunction/core-entities": "2.37.0",
-        "@memberjunction/global": "2.37.0",
-        "@memberjunction/ng-container-directives": "2.37.0",
-        "@memberjunction/ng-shared": "2.37.0",
+        "@memberjunction/core": "2.37.1",
+        "@memberjunction/core-entities": "2.37.1",
+        "@memberjunction/global": "2.37.1",
+        "@memberjunction/ng-container-directives": "2.37.1",
+        "@memberjunction/ng-shared": "2.37.1",
         "rxjs": "^7.8.1",
         "tslib": "^2.3.0"
       },
@@ -30285,7 +30757,7 @@
     },
     "packages/Angular/Generic/generic-dialog": {
       "name": "@memberjunction/ng-generic-dialog",
-      "version": "2.37.0",
+      "version": "2.37.1",
       "license": "ISC",
       "dependencies": {
         "tslib": "^2.3.0"
@@ -30303,15 +30775,15 @@
     },
     "packages/Angular/Generic/join-grid": {
       "name": "@memberjunction/ng-join-grid",
-      "version": "2.37.0",
+      "version": "2.37.1",
       "license": "ISC",
       "dependencies": {
-        "@memberjunction/core": "2.37.0",
-        "@memberjunction/core-entities": "2.37.0",
-        "@memberjunction/global": "2.37.0",
-        "@memberjunction/ng-base-types": "2.37.0",
-        "@memberjunction/ng-container-directives": "2.37.0",
-        "@memberjunction/ng-shared": "2.37.0",
+        "@memberjunction/core": "2.37.1",
+        "@memberjunction/core-entities": "2.37.1",
+        "@memberjunction/global": "2.37.1",
+        "@memberjunction/ng-base-types": "2.37.1",
+        "@memberjunction/ng-container-directives": "2.37.1",
+        "@memberjunction/ng-shared": "2.37.1",
         "@progress/kendo-angular-buttons": "16.2.0",
         "@progress/kendo-angular-dialog": "16.2.0",
         "@progress/kendo-angular-grid": "16.2.0",
@@ -30333,13 +30805,13 @@
     },
     "packages/Angular/Generic/notifications": {
       "name": "@memberjunction/ng-notifications",
-      "version": "2.37.0",
+      "version": "2.37.1",
       "license": "ISC",
       "dependencies": {
-        "@memberjunction/core": "2.37.0",
-        "@memberjunction/core-entities": "2.37.0",
-        "@memberjunction/global": "2.37.0",
-        "@memberjunction/graphql-dataprovider": "2.37.0",
+        "@memberjunction/core": "2.37.1",
+        "@memberjunction/core-entities": "2.37.1",
+        "@memberjunction/global": "2.37.1",
+        "@memberjunction/graphql-dataprovider": "2.37.1",
         "rxjs": "^7.8.1",
         "tslib": "^2.3.0"
       },
@@ -30355,15 +30827,15 @@
     },
     "packages/Angular/Generic/query-grid": {
       "name": "@memberjunction/ng-query-grid",
-      "version": "2.37.0",
+      "version": "2.37.1",
       "license": "ISC",
       "dependencies": {
-        "@memberjunction/core": "2.37.0",
-        "@memberjunction/core-entities": "2.37.0",
-        "@memberjunction/global": "2.37.0",
-        "@memberjunction/ng-compare-records": "2.37.0",
-        "@memberjunction/ng-container-directives": "2.37.0",
-        "@memberjunction/ng-shared": "2.37.0",
+        "@memberjunction/core": "2.37.1",
+        "@memberjunction/core-entities": "2.37.1",
+        "@memberjunction/global": "2.37.1",
+        "@memberjunction/ng-compare-records": "2.37.1",
+        "@memberjunction/ng-container-directives": "2.37.1",
+        "@memberjunction/ng-shared": "2.37.1",
         "tslib": "^2.3.0"
       },
       "devDependencies": {
@@ -30382,14 +30854,14 @@
     },
     "packages/Angular/Generic/record-selector": {
       "name": "@memberjunction/ng-record-selector",
-      "version": "2.37.0",
+      "version": "2.37.1",
       "license": "ISC",
       "dependencies": {
-        "@memberjunction/core": "2.37.0",
-        "@memberjunction/core-entities": "2.37.0",
-        "@memberjunction/global": "2.37.0",
-        "@memberjunction/ng-container-directives": "2.37.0",
-        "@memberjunction/ng-shared": "2.37.0",
+        "@memberjunction/core": "2.37.1",
+        "@memberjunction/core-entities": "2.37.1",
+        "@memberjunction/global": "2.37.1",
+        "@memberjunction/ng-container-directives": "2.37.1",
+        "@memberjunction/ng-shared": "2.37.1",
         "tslib": "^2.3.0"
       },
       "devDependencies": {
@@ -30408,16 +30880,16 @@
     },
     "packages/Angular/Generic/resource-permissions": {
       "name": "@memberjunction/ng-resource-permissions",
-      "version": "2.37.0",
+      "version": "2.37.1",
       "license": "ISC",
       "dependencies": {
-        "@memberjunction/core": "2.37.0",
-        "@memberjunction/core-entities": "2.37.0",
-        "@memberjunction/global": "2.37.0",
-        "@memberjunction/ng-base-types": "2.37.0",
-        "@memberjunction/ng-container-directives": "2.37.0",
-        "@memberjunction/ng-generic-dialog": "2.37.0",
-        "@memberjunction/ng-notifications": "2.37.0",
+        "@memberjunction/core": "2.37.1",
+        "@memberjunction/core-entities": "2.37.1",
+        "@memberjunction/global": "2.37.1",
+        "@memberjunction/ng-base-types": "2.37.1",
+        "@memberjunction/ng-container-directives": "2.37.1",
+        "@memberjunction/ng-generic-dialog": "2.37.1",
+        "@memberjunction/ng-notifications": "2.37.1",
         "@progress/kendo-angular-buttons": "16.2.0",
         "@progress/kendo-angular-dialog": "16.2.0",
         "@progress/kendo-angular-dropdowns": "16.2.0",
@@ -30468,21 +30940,21 @@
     },
     "packages/Angular/Generic/skip-chat": {
       "name": "@memberjunction/ng-skip-chat",
-      "version": "2.37.0",
+      "version": "2.37.1",
       "license": "ISC",
       "dependencies": {
         "@angular/cdk": "18.0.2",
-        "@memberjunction/core": "2.37.0",
-        "@memberjunction/core-entities": "2.37.0",
-        "@memberjunction/data-context": "2.37.0",
-        "@memberjunction/global": "2.37.0",
-        "@memberjunction/graphql-dataprovider": "2.37.0",
-        "@memberjunction/ng-base-types": "2.37.0",
-        "@memberjunction/ng-container-directives": "2.37.0",
-        "@memberjunction/ng-data-context": "2.37.0",
-        "@memberjunction/ng-notifications": "2.37.0",
-        "@memberjunction/ng-resource-permissions": "2.37.0",
-        "@memberjunction/skip-types": "2.37.0",
+        "@memberjunction/core": "2.37.1",
+        "@memberjunction/core-entities": "2.37.1",
+        "@memberjunction/data-context": "2.37.1",
+        "@memberjunction/global": "2.37.1",
+        "@memberjunction/graphql-dataprovider": "2.37.1",
+        "@memberjunction/ng-base-types": "2.37.1",
+        "@memberjunction/ng-container-directives": "2.37.1",
+        "@memberjunction/ng-data-context": "2.37.1",
+        "@memberjunction/ng-notifications": "2.37.1",
+        "@memberjunction/ng-resource-permissions": "2.37.1",
+        "@memberjunction/skip-types": "2.37.1",
         "@progress/kendo-angular-dialog": "16.2.0",
         "@progress/kendo-angular-grid": "16.2.0",
         "@progress/kendo-angular-indicators": "16.2.0",
@@ -30566,10 +31038,10 @@
     },
     "packages/Angular/Generic/tab-strip": {
       "name": "@memberjunction/ng-tabstrip",
-      "version": "2.37.0",
+      "version": "2.37.1",
       "license": "ISC",
       "dependencies": {
-        "@memberjunction/ng-container-directives": "2.37.0",
+        "@memberjunction/ng-container-directives": "2.37.1",
         "tslib": "^2.3.0"
       },
       "devDependencies": {
@@ -30583,15 +31055,15 @@
     },
     "packages/Angular/Generic/timeline": {
       "name": "@memberjunction/ng-timeline",
-      "version": "2.37.0",
+      "version": "2.37.1",
       "license": "ISC",
       "dependencies": {
-        "@memberjunction/core": "2.37.0",
-        "@memberjunction/core-entities": "2.37.0",
-        "@memberjunction/global": "2.37.0",
-        "@memberjunction/ng-container-directives": "2.37.0",
-        "@memberjunction/ng-entity-form-dialog": "2.37.0",
-        "@memberjunction/ng-shared": "2.37.0",
+        "@memberjunction/core": "2.37.1",
+        "@memberjunction/core-entities": "2.37.1",
+        "@memberjunction/global": "2.37.1",
+        "@memberjunction/ng-container-directives": "2.37.1",
+        "@memberjunction/ng-entity-form-dialog": "2.37.1",
+        "@memberjunction/ng-shared": "2.37.1",
         "@progress/kendo-angular-buttons": "16.2.0",
         "@progress/kendo-angular-indicators": "16.2.0",
         "@progress/kendo-angular-layout": "16.2.0",
@@ -30611,15 +31083,15 @@
     },
     "packages/Angular/Generic/tree-list": {
       "name": "@memberjunction/ng-treelist",
-      "version": "2.37.0",
+      "version": "2.37.1",
       "license": "ISC",
       "dependencies": {
-        "@memberjunction/core": "2.37.0",
-        "@memberjunction/core-entities": "2.37.0",
-        "@memberjunction/global": "2.37.0",
-        "@memberjunction/ng-container-directives": "2.37.0",
-        "@memberjunction/ng-entity-form-dialog": "2.37.0",
-        "@memberjunction/ng-shared": "2.37.0",
+        "@memberjunction/core": "2.37.1",
+        "@memberjunction/core-entities": "2.37.1",
+        "@memberjunction/global": "2.37.1",
+        "@memberjunction/ng-container-directives": "2.37.1",
+        "@memberjunction/ng-entity-form-dialog": "2.37.1",
+        "@memberjunction/ng-shared": "2.37.1",
         "@progress/kendo-angular-buttons": "16.2.0",
         "@progress/kendo-angular-indicators": "16.2.0",
         "@progress/kendo-angular-layout": "16.2.0",
@@ -30650,10 +31122,10 @@
         "@angular/platform-browser": "18.0.2",
         "@angular/platform-browser-dynamic": "18.0.2",
         "@angular/router": "18.0.2",
-        "@memberjunction/core": "2.37.0",
-        "@memberjunction/global": "2.37.0",
-        "@memberjunction/graphql-dataprovider": "2.37.0",
-        "@memberjunction/ng-user-view-grid": "2.37.0",
+        "@memberjunction/core": "2.37.1",
+        "@memberjunction/global": "2.37.1",
+        "@memberjunction/graphql-dataprovider": "2.37.1",
+        "@memberjunction/ng-user-view-grid": "2.37.1",
         "rxjs": "^7.8.1",
         "tslib": "^2.3.0",
         "zone.js": "^0.14.0"
@@ -30674,20 +31146,20 @@
     },
     "packages/CodeGenLib": {
       "name": "@memberjunction/codegen-lib",
-      "version": "2.37.0",
+      "version": "2.37.1",
       "license": "ISC",
       "dependencies": {
-        "@memberjunction/actions": "2.37.0",
-        "@memberjunction/ai": "2.37.0",
-        "@memberjunction/ai-anthropic": "2.37.0",
-        "@memberjunction/ai-groq": "2.37.0",
-        "@memberjunction/ai-mistral": "2.37.0",
-        "@memberjunction/ai-openai": "2.37.0",
-        "@memberjunction/aiengine": "2.37.0",
-        "@memberjunction/core": "2.37.0",
-        "@memberjunction/core-entities": "2.37.0",
-        "@memberjunction/global": "2.37.0",
-        "@memberjunction/sqlserver-dataprovider": "2.37.0",
+        "@memberjunction/actions": "2.37.1",
+        "@memberjunction/ai": "2.37.1",
+        "@memberjunction/ai-anthropic": "2.37.1",
+        "@memberjunction/ai-groq": "2.37.1",
+        "@memberjunction/ai-mistral": "2.37.1",
+        "@memberjunction/ai-openai": "2.37.1",
+        "@memberjunction/aiengine": "2.37.1",
+        "@memberjunction/core": "2.37.1",
+        "@memberjunction/core-entities": "2.37.1",
+        "@memberjunction/global": "2.37.1",
+        "@memberjunction/sqlserver-dataprovider": "2.37.1",
         "cosmiconfig": "9.0.0",
         "fs-extra": "^11.2.0",
         "glob": "^10.3.10",
@@ -30792,13 +31264,13 @@
     },
     "packages/Communication/base-types": {
       "name": "@memberjunction/communication-types",
-      "version": "2.37.0",
+      "version": "2.37.1",
       "license": "ISC",
       "dependencies": {
-        "@memberjunction/core": "2.37.0",
-        "@memberjunction/core-entities": "2.37.0",
-        "@memberjunction/global": "2.37.0",
-        "@memberjunction/templates-base-types": "2.37.0",
+        "@memberjunction/core": "2.37.1",
+        "@memberjunction/core-entities": "2.37.1",
+        "@memberjunction/global": "2.37.1",
+        "@memberjunction/templates-base-types": "2.37.1",
         "rxjs": "^7.8.1"
       },
       "devDependencies": {
@@ -30808,14 +31280,14 @@
     },
     "packages/Communication/engine": {
       "name": "@memberjunction/communication-engine",
-      "version": "2.37.0",
+      "version": "2.37.1",
       "license": "ISC",
       "dependencies": {
-        "@memberjunction/communication-types": "2.37.0",
-        "@memberjunction/core": "2.37.0",
-        "@memberjunction/core-entities": "2.37.0",
-        "@memberjunction/global": "2.37.0",
-        "@memberjunction/templates": "2.37.0",
+        "@memberjunction/communication-types": "2.37.1",
+        "@memberjunction/core": "2.37.1",
+        "@memberjunction/core-entities": "2.37.1",
+        "@memberjunction/global": "2.37.1",
+        "@memberjunction/templates": "2.37.1",
         "rxjs": "^7.8.1"
       },
       "devDependencies": {
@@ -30825,13 +31297,13 @@
     },
     "packages/Communication/entity-comm-base": {
       "name": "@memberjunction/entity-communications-base",
-      "version": "2.37.0",
+      "version": "2.37.1",
       "license": "ISC",
       "dependencies": {
-        "@memberjunction/communication-types": "2.37.0",
-        "@memberjunction/core": "2.37.0",
-        "@memberjunction/core-entities": "2.37.0",
-        "@memberjunction/global": "2.37.0"
+        "@memberjunction/communication-types": "2.37.1",
+        "@memberjunction/core": "2.37.1",
+        "@memberjunction/core-entities": "2.37.1",
+        "@memberjunction/global": "2.37.1"
       },
       "devDependencies": {
         "ts-node-dev": "^2.0.0",
@@ -30840,14 +31312,14 @@
     },
     "packages/Communication/entity-comm-client": {
       "name": "@memberjunction/entity-communications-client",
-      "version": "2.37.0",
+      "version": "2.37.1",
       "license": "ISC",
       "dependencies": {
-        "@memberjunction/core": "2.37.0",
-        "@memberjunction/core-entities": "2.37.0",
-        "@memberjunction/entity-communications-base": "2.37.0",
-        "@memberjunction/global": "2.37.0",
-        "@memberjunction/graphql-dataprovider": "2.37.0"
+        "@memberjunction/core": "2.37.1",
+        "@memberjunction/core-entities": "2.37.1",
+        "@memberjunction/entity-communications-base": "2.37.1",
+        "@memberjunction/global": "2.37.1",
+        "@memberjunction/graphql-dataprovider": "2.37.1"
       },
       "devDependencies": {
         "ts-node-dev": "^2.0.0",
@@ -30856,14 +31328,14 @@
     },
     "packages/Communication/entity-comm-server": {
       "name": "@memberjunction/entity-communications-server",
-      "version": "2.37.0",
+      "version": "2.37.1",
       "license": "ISC",
       "dependencies": {
-        "@memberjunction/communication-engine": "2.37.0",
-        "@memberjunction/core": "2.37.0",
-        "@memberjunction/core-entities": "2.37.0",
-        "@memberjunction/entity-communications-base": "2.37.0",
-        "@memberjunction/global": "2.37.0"
+        "@memberjunction/communication-engine": "2.37.1",
+        "@memberjunction/core": "2.37.1",
+        "@memberjunction/core-entities": "2.37.1",
+        "@memberjunction/entity-communications-base": "2.37.1",
+        "@memberjunction/global": "2.37.1"
       },
       "devDependencies": {
         "ts-node-dev": "^2.0.0",
@@ -30872,11 +31344,11 @@
     },
     "packages/Communication/providers/gmail": {
       "name": "@memberjunction/communication-gmail",
-      "version": "2.37.0",
+      "version": "2.37.1",
       "dependencies": {
-        "@memberjunction/communication-types": "2.37.0",
-        "@memberjunction/core": "2.37.0",
-        "@memberjunction/global": "2.37.0",
+        "@memberjunction/communication-types": "2.37.1",
+        "@memberjunction/core": "2.37.1",
+        "@memberjunction/global": "2.37.1",
         "dotenv": "^16.3.1",
         "env-var": "^7.4.1",
         "googleapis": "^130.0.0"
@@ -30917,19 +31389,19 @@
     },
     "packages/Communication/providers/MSGraph": {
       "name": "@memberjunction/communication-ms-graph",
-      "version": "2.37.0",
+      "version": "2.37.1",
       "license": "ISC",
       "dependencies": {
         "@azure/identity": "^4.4.1",
         "@azure/msal-node": "^2.14.0",
-        "@memberjunction/ai": "2.37.0",
-        "@memberjunction/ai-openai": "2.37.0",
-        "@memberjunction/aiengine": "2.37.0",
-        "@memberjunction/communication-types": "2.37.0",
-        "@memberjunction/core": "2.37.0",
-        "@memberjunction/core-entities": "2.37.0",
-        "@memberjunction/global": "2.37.0",
-        "@memberjunction/sqlserver-dataprovider": "2.37.0",
+        "@memberjunction/ai": "2.37.1",
+        "@memberjunction/ai-openai": "2.37.1",
+        "@memberjunction/aiengine": "2.37.1",
+        "@memberjunction/communication-types": "2.37.1",
+        "@memberjunction/core": "2.37.1",
+        "@memberjunction/core-entities": "2.37.1",
+        "@memberjunction/global": "2.37.1",
+        "@memberjunction/sqlserver-dataprovider": "2.37.1",
         "@microsoft/microsoft-graph-client": "^3.0.7",
         "@microsoft/microsoft-graph-types": "^2.40.0",
         "@types/html-to-text": "^9.0.4",
@@ -31108,13 +31580,13 @@
     },
     "packages/Communication/providers/sendgrid": {
       "name": "@memberjunction/communication-sendgrid",
-      "version": "2.37.0",
+      "version": "2.37.1",
       "license": "ISC",
       "dependencies": {
-        "@memberjunction/communication-types": "2.37.0",
-        "@memberjunction/core": "2.37.0",
-        "@memberjunction/core-entities": "2.37.0",
-        "@memberjunction/global": "2.37.0",
+        "@memberjunction/communication-types": "2.37.1",
+        "@memberjunction/core": "2.37.1",
+        "@memberjunction/core-entities": "2.37.1",
+        "@memberjunction/global": "2.37.1",
         "@sendgrid/mail": "^8.1.3"
       },
       "devDependencies": {
@@ -31124,11 +31596,11 @@
     },
     "packages/Communication/providers/twilio": {
       "name": "@memberjunction/communication-twilio",
-      "version": "2.37.0",
+      "version": "2.37.1",
       "dependencies": {
-        "@memberjunction/communication-types": "2.37.0",
-        "@memberjunction/core": "2.37.0",
-        "@memberjunction/global": "2.37.0",
+        "@memberjunction/communication-types": "2.37.1",
+        "@memberjunction/core": "2.37.1",
+        "@memberjunction/global": "2.37.1",
         "dotenv": "^16.3.1",
         "env-var": "^7.4.1",
         "twilio": "^4.23.0"
@@ -31156,14 +31628,14 @@
     },
     "packages/ContentAutotagging": {
       "name": "@memberjunction/content-autotagging",
-      "version": "2.37.0",
+      "version": "2.37.1",
       "license": "ISC",
       "dependencies": {
-        "@memberjunction/ai": "2.37.0",
-        "@memberjunction/aiengine": "2.37.0",
-        "@memberjunction/core": "2.37.0",
-        "@memberjunction/core-entities": "2.37.0",
-        "@memberjunction/global": "2.37.0",
+        "@memberjunction/ai": "2.37.1",
+        "@memberjunction/aiengine": "2.37.1",
+        "@memberjunction/core": "2.37.1",
+        "@memberjunction/core-entities": "2.37.1",
+        "@memberjunction/global": "2.37.1",
         "axios": "^1.7.2",
         "cheerio": "^1.0.0-rc.12",
         "crypto": "^1.0.1",
@@ -31197,12 +31669,12 @@
     },
     "packages/DocUtils": {
       "name": "@memberjunction/doc-utils",
-      "version": "2.37.0",
+      "version": "2.37.1",
       "license": "ISC",
       "dependencies": {
-        "@memberjunction/core": "2.37.0",
-        "@memberjunction/core-entities": "2.37.0",
-        "@memberjunction/global": "2.37.0",
+        "@memberjunction/core": "2.37.1",
+        "@memberjunction/core-entities": "2.37.1",
+        "@memberjunction/global": "2.37.1",
         "axios": "^1.6.7",
         "jsdom": "^24.1.0"
       },
@@ -31213,13 +31685,13 @@
     },
     "packages/ExternalChangeDetection": {
       "name": "@memberjunction/external-change-detection",
-      "version": "2.37.0",
+      "version": "2.37.1",
       "license": "ISC",
       "dependencies": {
-        "@memberjunction/core": "2.37.0",
-        "@memberjunction/core-entities": "2.37.0",
-        "@memberjunction/global": "2.37.0",
-        "@memberjunction/sqlserver-dataprovider": "2.37.0"
+        "@memberjunction/core": "2.37.1",
+        "@memberjunction/core-entities": "2.37.1",
+        "@memberjunction/global": "2.37.1",
+        "@memberjunction/sqlserver-dataprovider": "2.37.1"
       },
       "devDependencies": {
         "ts-node-dev": "^2.0.0",
@@ -31231,12 +31703,12 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
-        "@memberjunction/actions": "2.37.0",
-        "@memberjunction/ai": "2.37.0",
-        "@memberjunction/aiengine": "2.37.0",
-        "@memberjunction/core": "2.37.0",
-        "@memberjunction/core-entities": "2.37.0",
-        "@memberjunction/global": "2.37.0",
+        "@memberjunction/actions": "2.37.1",
+        "@memberjunction/ai": "2.37.1",
+        "@memberjunction/aiengine": "2.37.1",
+        "@memberjunction/core": "2.37.1",
+        "@memberjunction/core-entities": "2.37.1",
+        "@memberjunction/global": "2.37.1",
         "zod": "^3.23.8"
       },
       "devDependencies": {
@@ -31249,8 +31721,8 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
-        "@memberjunction/core": "2.37.0",
-        "@memberjunction/global": "2.37.0",
+        "@memberjunction/core": "2.37.1",
+        "@memberjunction/global": "2.37.1",
         "zod": "^3.23.8"
       },
       "devDependencies": {
@@ -31260,13 +31732,13 @@
     },
     "packages/GraphQLDataProvider": {
       "name": "@memberjunction/graphql-dataprovider",
-      "version": "2.37.0",
+      "version": "2.37.1",
       "license": "ISC",
       "dependencies": {
-        "@memberjunction/actions-base": "2.37.0",
-        "@memberjunction/core": "2.37.0",
-        "@memberjunction/core-entities": "2.37.0",
-        "@memberjunction/global": "2.37.0",
+        "@memberjunction/actions-base": "2.37.1",
+        "@memberjunction/core": "2.37.1",
+        "@memberjunction/core-entities": "2.37.1",
+        "@memberjunction/global": "2.37.1",
         "@tempfix/idb": "^8.0.3",
         "graphql": "^16.8.0",
         "graphql-request": "^5.2.0",
@@ -31335,13 +31807,13 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
-        "@memberjunction/ai": "2.37.0",
-        "@memberjunction/communication-sendgrid": "2.37.0",
-        "@memberjunction/core": "2.37.0",
-        "@memberjunction/global": "2.37.0",
-        "@memberjunction/server": "2.37.0",
-        "@memberjunction/sqlserver-dataprovider": "2.37.0",
-        "@memberjunction/templates": "2.37.0",
+        "@memberjunction/ai": "2.37.1",
+        "@memberjunction/communication-sendgrid": "2.37.1",
+        "@memberjunction/core": "2.37.1",
+        "@memberjunction/global": "2.37.1",
+        "@memberjunction/server": "2.37.1",
+        "@memberjunction/sqlserver-dataprovider": "2.37.1",
+        "@memberjunction/templates": "2.37.1",
         "axios": "^1.6.7",
         "class-validator": "^0.14.0",
         "mj_generatedactions": "1.0.0",
@@ -31357,11 +31829,11 @@
     },
     "packages/MJCLI": {
       "name": "@memberjunction/cli",
-      "version": "2.37.0",
+      "version": "2.37.1",
       "license": "ISC",
       "dependencies": {
         "@inquirer/prompts": "^5.0.1",
-        "@memberjunction/codegen-lib": "2.37.0",
+        "@memberjunction/codegen-lib": "2.37.1",
         "@oclif/core": "^3",
         "@oclif/plugin-help": "^6",
         "@oclif/plugin-version": "^2.0.17",
@@ -31415,11 +31887,11 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
-        "@memberjunction/codegen-lib": "2.37.0",
-        "@memberjunction/core": "2.37.0",
-        "@memberjunction/core-entities": "2.37.0",
-        "@memberjunction/global": "2.37.0",
-        "@memberjunction/sqlserver-dataprovider": "2.37.0",
+        "@memberjunction/codegen-lib": "2.37.1",
+        "@memberjunction/core": "2.37.1",
+        "@memberjunction/core-entities": "2.37.1",
+        "@memberjunction/global": "2.37.1",
+        "@memberjunction/sqlserver-dataprovider": "2.37.1",
         "@types/axios": "^0.14.0",
         "@types/mssql": "^9.1.5",
         "axios": "^1.6.7",
@@ -31460,10 +31932,10 @@
     },
     "packages/MJCore": {
       "name": "@memberjunction/core",
-      "version": "2.37.0",
+      "version": "2.37.1",
       "license": "ISC",
       "dependencies": {
-        "@memberjunction/global": "2.37.0",
+        "@memberjunction/global": "2.37.1",
         "debug": "^4.4.0",
         "rxjs": "^7.8.1",
         "zod": "^3.23.8"
@@ -31499,11 +31971,11 @@
     },
     "packages/MJCoreEntities": {
       "name": "@memberjunction/core-entities",
-      "version": "2.37.0",
+      "version": "2.37.1",
       "license": "ISC",
       "dependencies": {
-        "@memberjunction/core": "2.37.0",
-        "@memberjunction/global": "2.37.0",
+        "@memberjunction/core": "2.37.1",
+        "@memberjunction/global": "2.37.1",
         "zod": "^3.23.8"
       },
       "devDependencies": {
@@ -31513,12 +31985,12 @@
     },
     "packages/MJDataContext": {
       "name": "@memberjunction/data-context",
-      "version": "2.37.0",
+      "version": "2.37.1",
       "license": "ISC",
       "dependencies": {
-        "@memberjunction/core": "2.37.0",
-        "@memberjunction/core-entities": "2.37.0",
-        "@memberjunction/global": "2.37.0"
+        "@memberjunction/core": "2.37.1",
+        "@memberjunction/core-entities": "2.37.1",
+        "@memberjunction/global": "2.37.1"
       },
       "devDependencies": {
         "ts-node-dev": "^2.0.0",
@@ -31527,11 +31999,11 @@
     },
     "packages/MJDataContextServer": {
       "name": "@memberjunction/data-context-server",
-      "version": "2.37.0",
+      "version": "2.37.1",
       "license": "ISC",
       "dependencies": {
-        "@memberjunction/data-context": "2.37.0",
-        "@memberjunction/global": "2.37.0",
+        "@memberjunction/data-context": "2.37.1",
+        "@memberjunction/global": "2.37.1",
         "typeorm": "^0.3.20"
       },
       "devDependencies": {
@@ -31552,23 +32024,23 @@
         "@angular/platform-browser-dynamic": "18.0.2",
         "@angular/router": "18.0.2",
         "@azure/msal-angular": "^3.0.11",
-        "@memberjunction/core": "2.37.0",
-        "@memberjunction/core-entities": "2.37.0",
-        "@memberjunction/global": "2.37.0",
-        "@memberjunction/graphql-dataprovider": "2.37.0",
-        "@memberjunction/ng-ask-skip": "2.37.0",
-        "@memberjunction/ng-auth-services": "2.37.0",
-        "@memberjunction/ng-compare-records": "2.37.0",
-        "@memberjunction/ng-container-directives": "2.37.0",
-        "@memberjunction/ng-core-entity-forms": "2.37.0",
-        "@memberjunction/ng-explorer-core": "2.37.0",
-        "@memberjunction/ng-explorer-settings": "2.37.0",
-        "@memberjunction/ng-join-grid": "2.37.0",
-        "@memberjunction/ng-link-directives": "2.37.0",
-        "@memberjunction/ng-record-changes": "2.37.0",
-        "@memberjunction/ng-tabstrip": "2.37.0",
-        "@memberjunction/ng-timeline": "2.37.0",
-        "@memberjunction/ng-user-view-grid": "2.37.0",
+        "@memberjunction/core": "2.37.1",
+        "@memberjunction/core-entities": "2.37.1",
+        "@memberjunction/global": "2.37.1",
+        "@memberjunction/graphql-dataprovider": "2.37.1",
+        "@memberjunction/ng-ask-skip": "2.37.1",
+        "@memberjunction/ng-auth-services": "2.37.1",
+        "@memberjunction/ng-compare-records": "2.37.1",
+        "@memberjunction/ng-container-directives": "2.37.1",
+        "@memberjunction/ng-core-entity-forms": "2.37.1",
+        "@memberjunction/ng-explorer-core": "2.37.1",
+        "@memberjunction/ng-explorer-settings": "2.37.1",
+        "@memberjunction/ng-join-grid": "2.37.1",
+        "@memberjunction/ng-link-directives": "2.37.1",
+        "@memberjunction/ng-record-changes": "2.37.1",
+        "@memberjunction/ng-tabstrip": "2.37.1",
+        "@memberjunction/ng-timeline": "2.37.1",
+        "@memberjunction/ng-user-view-grid": "2.37.1",
         "@progress/kendo-angular-notification": "16.2.0",
         "@progress/kendo-angular-scheduler": "16.2.0",
         "@progress/kendo-licensing": "^1.3.5",
@@ -31597,7 +32069,7 @@
     },
     "packages/MJGlobal": {
       "name": "@memberjunction/global",
-      "version": "2.37.0",
+      "version": "2.37.1",
       "license": "ISC",
       "dependencies": {
         "rxjs": "^7.8.1"
@@ -31609,14 +32081,14 @@
     },
     "packages/MJQueue": {
       "name": "@memberjunction/queue",
-      "version": "2.37.0",
+      "version": "2.37.1",
       "license": "ISC",
       "dependencies": {
-        "@memberjunction/ai": "2.37.0",
-        "@memberjunction/aiengine": "2.37.0",
-        "@memberjunction/core": "2.37.0",
-        "@memberjunction/core-entities": "2.37.0",
-        "@memberjunction/global": "2.37.0",
+        "@memberjunction/ai": "2.37.1",
+        "@memberjunction/aiengine": "2.37.1",
+        "@memberjunction/core": "2.37.1",
+        "@memberjunction/core-entities": "2.37.1",
+        "@memberjunction/global": "2.37.1",
         "@types/uuid": "^9.0.1",
         "uuid": "^9.0.0"
       },
@@ -31627,32 +32099,32 @@
     },
     "packages/MJServer": {
       "name": "@memberjunction/server",
-      "version": "2.37.0",
+      "version": "2.37.1",
       "license": "ISC",
       "dependencies": {
         "@apollo/server": "^4.9.1",
         "@graphql-tools/utils": "^10.0.1",
-        "@memberjunction/actions": "2.37.0",
-        "@memberjunction/ai": "2.37.0",
-        "@memberjunction/ai-mistral": "2.37.0",
-        "@memberjunction/ai-openai": "2.37.0",
-        "@memberjunction/ai-vectors-pinecone": "2.37.0",
-        "@memberjunction/aiengine": "2.37.0",
-        "@memberjunction/core": "2.37.0",
-        "@memberjunction/core-actions": "2.37.0",
-        "@memberjunction/core-entities": "2.37.0",
-        "@memberjunction/data-context": "2.37.0",
-        "@memberjunction/data-context-server": "2.37.0",
-        "@memberjunction/doc-utils": "2.37.0",
-        "@memberjunction/entity-communications-server": "2.37.0",
-        "@memberjunction/external-change-detection": "2.37.0",
-        "@memberjunction/global": "2.37.0",
-        "@memberjunction/graphql-dataprovider": "2.37.0",
-        "@memberjunction/queue": "2.37.0",
-        "@memberjunction/skip-types": "2.37.0",
-        "@memberjunction/sqlserver-dataprovider": "2.37.0",
-        "@memberjunction/storage": "2.37.0",
-        "@memberjunction/templates": "2.37.0",
+        "@memberjunction/actions": "2.37.1",
+        "@memberjunction/ai": "2.37.1",
+        "@memberjunction/ai-mistral": "2.37.1",
+        "@memberjunction/ai-openai": "2.37.1",
+        "@memberjunction/ai-vectors-pinecone": "2.37.1",
+        "@memberjunction/aiengine": "2.37.1",
+        "@memberjunction/core": "2.37.1",
+        "@memberjunction/core-actions": "2.37.1",
+        "@memberjunction/core-entities": "2.37.1",
+        "@memberjunction/data-context": "2.37.1",
+        "@memberjunction/data-context-server": "2.37.1",
+        "@memberjunction/doc-utils": "2.37.1",
+        "@memberjunction/entity-communications-server": "2.37.1",
+        "@memberjunction/external-change-detection": "2.37.1",
+        "@memberjunction/global": "2.37.1",
+        "@memberjunction/graphql-dataprovider": "2.37.1",
+        "@memberjunction/queue": "2.37.1",
+        "@memberjunction/skip-types": "2.37.1",
+        "@memberjunction/sqlserver-dataprovider": "2.37.1",
+        "@memberjunction/storage": "2.37.1",
+        "@memberjunction/templates": "2.37.1",
         "@types/compression": "^1.7.5",
         "@types/cors": "^2.8.13",
         "@types/jsonwebtoken": "9.0.6",
@@ -31825,7 +32297,7 @@
     },
     "packages/MJStorage": {
       "name": "@memberjunction/storage",
-      "version": "2.37.0",
+      "version": "2.37.1",
       "license": "ISC",
       "dependencies": {
         "@aws-sdk/client-s3": "^3.537.0",
@@ -31833,9 +32305,9 @@
         "@azure/identity": "^4.0.1",
         "@azure/storage-blob": "^12.17.0",
         "@google-cloud/storage": "^7.9.0",
-        "@memberjunction/core": "2.37.0",
-        "@memberjunction/core-entities": "2.37.0",
-        "@memberjunction/global": "2.37.0",
+        "@memberjunction/core": "2.37.1",
+        "@memberjunction/core-entities": "2.37.1",
+        "@memberjunction/global": "2.37.1",
         "@microsoft/mgt-element": "^3.1.3",
         "@microsoft/mgt-msal2-provider": "^3.1.3",
         "@microsoft/mgt-sharepoint-provider": "^3.1.3",
@@ -31934,11 +32406,11 @@
     },
     "packages/SkipTypes": {
       "name": "@memberjunction/skip-types",
-      "version": "2.37.0",
+      "version": "2.37.1",
       "license": "ISC",
       "dependencies": {
-        "@memberjunction/core-entities": "2.37.0",
-        "@memberjunction/data-context": "2.37.0"
+        "@memberjunction/core-entities": "2.37.1",
+        "@memberjunction/data-context": "2.37.1"
       },
       "devDependencies": {
         "ts-node-dev": "^2.0.0",
@@ -31947,17 +32419,17 @@
     },
     "packages/SQLServerDataProvider": {
       "name": "@memberjunction/sqlserver-dataprovider",
-      "version": "2.37.0",
+      "version": "2.37.1",
       "license": "ISC",
       "dependencies": {
-        "@memberjunction/actions": "2.37.0",
-        "@memberjunction/ai": "2.37.0",
-        "@memberjunction/ai-vector-dupe": "2.37.0",
-        "@memberjunction/aiengine": "2.37.0",
-        "@memberjunction/core": "2.37.0",
-        "@memberjunction/core-entities": "2.37.0",
-        "@memberjunction/global": "2.37.0",
-        "@memberjunction/queue": "2.37.0",
+        "@memberjunction/actions": "2.37.1",
+        "@memberjunction/ai": "2.37.1",
+        "@memberjunction/ai-vector-dupe": "2.37.1",
+        "@memberjunction/aiengine": "2.37.1",
+        "@memberjunction/core": "2.37.1",
+        "@memberjunction/core-entities": "2.37.1",
+        "@memberjunction/global": "2.37.1",
+        "@memberjunction/queue": "2.37.1",
         "mssql": "^11.0.1",
         "typeorm": "^0.3.20"
       },
@@ -32045,12 +32517,12 @@
     },
     "packages/Templates/base-types": {
       "name": "@memberjunction/templates-base-types",
-      "version": "2.37.0",
+      "version": "2.37.1",
       "license": "ISC",
       "dependencies": {
-        "@memberjunction/core": "2.37.0",
-        "@memberjunction/core-entities": "2.37.0",
-        "@memberjunction/global": "2.37.0"
+        "@memberjunction/core": "2.37.1",
+        "@memberjunction/core-entities": "2.37.1",
+        "@memberjunction/global": "2.37.1"
       },
       "devDependencies": {
         "typescript": "^5.4.5"
@@ -32058,16 +32530,16 @@
     },
     "packages/Templates/engine": {
       "name": "@memberjunction/templates",
-      "version": "2.37.0",
+      "version": "2.37.1",
       "license": "ISC",
       "dependencies": {
-        "@memberjunction/ai": "2.37.0",
-        "@memberjunction/ai-groq": "2.37.0",
-        "@memberjunction/aiengine": "2.37.0",
-        "@memberjunction/core": "2.37.0",
-        "@memberjunction/core-entities": "2.37.0",
-        "@memberjunction/global": "2.37.0",
-        "@memberjunction/templates-base-types": "2.37.0",
+        "@memberjunction/ai": "2.37.1",
+        "@memberjunction/ai-groq": "2.37.1",
+        "@memberjunction/aiengine": "2.37.1",
+        "@memberjunction/core": "2.37.1",
+        "@memberjunction/core-entities": "2.37.1",
+        "@memberjunction/global": "2.37.1",
+        "@memberjunction/templates-base-types": "2.37.1",
         "nunjucks": "3.2.4"
       },
       "devDependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -5991,13 +5991,41 @@
         "uuid": "dist/bin/uuid"
       }
     },
-    "node_modules/@google/generative-ai": {
-      "version": "0.21.0",
-      "resolved": "https://registry.npmjs.org/@google/generative-ai/-/generative-ai-0.21.0.tgz",
-      "integrity": "sha512-7XhUbtnlkSEZK15kN3t+tzIMxsbKm/dSkKBFalj+20NvPKe1kBY7mR2P7vuijEn+f06z5+A8bVGKO0v39cr6Wg==",
+    "node_modules/@google/genai": {
+      "version": "0.14.0",
+      "resolved": "https://registry.npmjs.org/@google/genai/-/genai-0.14.0.tgz",
+      "integrity": "sha512-nxXbRJZjCUBlPlfTXBMCgkSEpojcLzjxT2Ye3CDiqlXaiSscZ046bDEzztq6ONxUT3BfqHcGsQLhpbR5DU1Mcg==",
       "license": "Apache-2.0",
+      "dependencies": {
+        "google-auth-library": "^9.14.2",
+        "test-server-sdk": "^0.2.1",
+        "ws": "^8.18.0",
+        "zod": "^3.22.4",
+        "zod-to-json-schema": "^3.22.4"
+      },
       "engines": {
         "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@google/genai/node_modules/ws": {
+      "version": "8.18.2",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.2.tgz",
+      "integrity": "sha512-DMricUmwGZUVr++AEAe2uiVM7UoO9MAVZMDu05UQOaUII0lp+zOzLLU4Xqh/JvTqklB1T4uELaaPBKyjE1r4fQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
       }
     },
     "node_modules/@graphql-tools/merge": {
@@ -13164,7 +13192,6 @@
     },
     "node_modules/chownr": {
       "version": "2.0.0",
-      "dev": true,
       "license": "ISC",
       "engines": {
         "node": ">=10"
@@ -17484,7 +17511,9 @@
       }
     },
     "node_modules/google-auth-library": {
-      "version": "9.11.0",
+      "version": "9.15.1",
+      "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-9.15.1.tgz",
+      "integrity": "sha512-Jb6Z0+nvECVz+2lzSMt9u98UsoakXxA2HGHMCxh+so3n90XgYWkq5dur19JAJV7ONiJY22yBTyJB1TSkvPq9Ng==",
       "license": "Apache-2.0",
       "dependencies": {
         "base64-js": "^1.3.0",
@@ -21127,7 +21156,6 @@
     },
     "node_modules/minizlib": {
       "version": "2.1.2",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "minipass": "^3.0.0",
@@ -21139,7 +21167,6 @@
     },
     "node_modules/minizlib/node_modules/minipass": {
       "version": "3.3.6",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "yallist": "^4.0.0"
@@ -26107,7 +26134,6 @@
     },
     "node_modules/tar": {
       "version": "6.2.1",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "chownr": "^2.0.0",
@@ -26132,7 +26158,6 @@
     },
     "node_modules/tar/node_modules/fs-minipass": {
       "version": "2.1.0",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "minipass": "^3.0.0"
@@ -26143,7 +26168,6 @@
     },
     "node_modules/tar/node_modules/fs-minipass/node_modules/minipass": {
       "version": "3.3.6",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "yallist": "^4.0.0"
@@ -26154,7 +26178,6 @@
     },
     "node_modules/tar/node_modules/minipass": {
       "version": "5.0.0",
-      "dev": true,
       "license": "ISC",
       "engines": {
         "node": ">=8"
@@ -26162,7 +26185,6 @@
     },
     "node_modules/tar/node_modules/mkdirp": {
       "version": "1.0.4",
-      "dev": true,
       "license": "MIT",
       "bin": {
         "mkdirp": "bin/cmd.js"
@@ -26446,6 +26468,18 @@
       },
       "engines": {
         "node": "*"
+      }
+    },
+    "node_modules/test-server-sdk": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/test-server-sdk/-/test-server-sdk-0.2.1.tgz",
+      "integrity": "sha512-o9F0HEBZbdDMwZ5xwSafkVb0C2nlZ4hq/g/aMgyLniTs69J7zoQJzF5eA3ZN6MPRoYPhy/QsQ/BuRtqaXzawvw==",
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "axios": "^1.6.0",
+        "extract-zip": "^2.0.1",
+        "tar": "^6.2.0"
       }
     },
     "node_modules/text-decoder": {
@@ -29619,7 +29653,7 @@
       "version": "2.37.1",
       "license": "ISC",
       "dependencies": {
-        "@google/generative-ai": "0.21.0",
+        "@google/genai": "0.14.0",
         "@memberjunction/ai": "2.37.1",
         "@memberjunction/global": "2.37.1"
       },

--- a/package-lock.json
+++ b/package-lock.json
@@ -4561,6 +4561,21 @@
       "license": "MIT",
       "optional": true
     },
+    "node_modules/@cerebras/cerebras_cloud_sdk": {
+      "version": "1.29.0",
+      "resolved": "https://registry.npmjs.org/@cerebras/cerebras_cloud_sdk/-/cerebras_cloud_sdk-1.29.0.tgz",
+      "integrity": "sha512-mZBvHO3x0WVX2k6uu7vNiVveka6cx/jeXD2iBzxfR07BrBN8sSCRIBt4jPuf1RI2HRsjHFJDh4ovGZuK1Fcxug==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@types/node": "^18.11.18",
+        "@types/node-fetch": "^2.6.4",
+        "abort-controller": "^3.0.0",
+        "agentkeepalive": "^4.2.1",
+        "form-data-encoder": "1.7.2",
+        "formdata-node": "^4.3.2",
+        "node-fetch": "^2.6.7"
+      }
+    },
     "node_modules/@changesets/apply-release-plan": {
       "version": "7.0.8",
       "resolved": "https://registry.npmjs.org/@changesets/apply-release-plan/-/apply-release-plan-7.0.8.tgz",
@@ -7127,6 +7142,10 @@
     },
     "node_modules/@memberjunction/ai-betty-bot": {
       "resolved": "packages/AI/Providers/BettyBot",
+      "link": true
+    },
+    "node_modules/@memberjunction/ai-cerebras": {
+      "resolved": "packages/AI/Providers/Cerebras",
       "link": true
     },
     "node_modules/@memberjunction/ai-elevenlabs": {
@@ -29561,6 +29580,20 @@
         "axios": "^1.7.7",
         "axios-retry": "^4.3.0",
         "env-var": "^7.5.0"
+      },
+      "devDependencies": {
+        "ts-node-dev": "^2.0.0",
+        "typescript": "^5.4.5"
+      }
+    },
+    "packages/AI/Providers/Cerebras": {
+      "name": "@memberjunction/ai-cerebras",
+      "version": "2.37.1",
+      "license": "ISC",
+      "dependencies": {
+        "@cerebras/cerebras_cloud_sdk": "^1.29.0",
+        "@memberjunction/ai": "2.37.1",
+        "@memberjunction/global": "2.37.1"
       },
       "devDependencies": {
         "ts-node-dev": "^2.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -7631,17 +7631,6 @@
       "version": "2.40.0",
       "license": "MIT"
     },
-    "node_modules/@mistralai/mistralai": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/@mistralai/mistralai/-/mistralai-1.5.0.tgz",
-      "integrity": "sha512-AIn8pwAwA/fDvEUvmkt+40zH1ZmfaG3Q7oUWl17GUEC1tU7ZPwYz8Cv9P59lyS1SisHdDSu81oknO7f1ywkz8Q==",
-      "dependencies": {
-        "zod-to-json-schema": "^3.24.1"
-      },
-      "peerDependencies": {
-        "zod": ">= 3"
-      }
-    },
     "node_modules/@modelcontextprotocol/sdk": {
       "version": "1.8.0",
       "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.8.0.tgz",
@@ -29697,12 +29686,23 @@
       "dependencies": {
         "@memberjunction/ai": "2.37.1",
         "@memberjunction/global": "2.37.1",
-        "@mistralai/mistralai": "^1.5.0",
+        "@mistralai/mistralai": "^1.6.0",
         "axios-retry": "4.3.0"
       },
       "devDependencies": {
         "ts-node-dev": "^2.0.0",
         "typescript": "^5.4.5"
+      }
+    },
+    "packages/AI/Providers/Mistral/node_modules/@mistralai/mistralai": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@mistralai/mistralai/-/mistralai-1.6.0.tgz",
+      "integrity": "sha512-PQwGV3+n7FbE7Dp3Vnd8DAa3ffx6WuVV966Gfmf4QvzwcO3Mvxpz0SnJ/PjaZcsCwApBCZpNyQzvarAKEQLKeQ==",
+      "dependencies": {
+        "zod-to-json-schema": "^3.24.1"
+      },
+      "peerDependencies": {
+        "zod": ">= 3"
       }
     },
     "packages/AI/Providers/Mistral/node_modules/axios-retry": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -17645,21 +17645,6 @@
         "graphql": ">=0.11 <=16"
       }
     },
-    "node_modules/groq-sdk": {
-      "version": "0.15.0",
-      "resolved": "https://registry.npmjs.org/groq-sdk/-/groq-sdk-0.15.0.tgz",
-      "integrity": "sha512-aYDEdr4qczx3cLCRRe+Beb37I7g/9bD5kHF+EEDxcrREWw1vKoRcfP3vHEkJB7Ud/8oOuF0scRwDpwWostTWuQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@types/node": "^18.11.18",
-        "@types/node-fetch": "^2.6.4",
-        "abort-controller": "^3.0.0",
-        "agentkeepalive": "^4.2.1",
-        "form-data-encoder": "1.7.2",
-        "formdata-node": "^4.3.2",
-        "node-fetch": "^2.6.7"
-      }
-    },
     "node_modules/gtoken": {
       "version": "7.1.0",
       "license": "MIT",
@@ -29658,11 +29643,35 @@
       "dependencies": {
         "@memberjunction/ai": "2.37.1",
         "@memberjunction/global": "2.37.1",
-        "groq-sdk": "0.15.0"
+        "groq-sdk": "0.21.0"
       },
       "devDependencies": {
         "ts-node-dev": "^2.0.0",
         "typescript": "^5.4.5"
+      }
+    },
+    "packages/AI/Providers/Groq/node_modules/@types/node": {
+      "version": "18.19.100",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.100.tgz",
+      "integrity": "sha512-ojmMP8SZBKprc3qGrGk8Ujpo80AXkrP7G2tOT4VWr5jlr5DHjsJF+emXJz+Wm0glmy4Js62oKMdZZ6B9Y+tEcA==",
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~5.26.4"
+      }
+    },
+    "packages/AI/Providers/Groq/node_modules/groq-sdk": {
+      "version": "0.21.0",
+      "resolved": "https://registry.npmjs.org/groq-sdk/-/groq-sdk-0.21.0.tgz",
+      "integrity": "sha512-SZg7oH/DsFvJllmdujNGZbfKUr2ATaU6urq0ZcnyObnmj6+nYM7WCGkyI2JMK+aWDzNiW6MwBNlSH722sHvtEQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@types/node": "^18.11.18",
+        "@types/node-fetch": "^2.6.4",
+        "abort-controller": "^3.0.0",
+        "agentkeepalive": "^4.2.1",
+        "form-data-encoder": "1.7.2",
+        "formdata-node": "^4.3.2",
+        "node-fetch": "^2.6.7"
       }
     },
     "packages/AI/Providers/HeyGen": {

--- a/packages/AI/A2AServer/CHANGELOG.md
+++ b/packages/AI/A2AServer/CHANGELOG.md
@@ -1,0 +1,16 @@
+# Change Log - @memberjunction/a2aserver
+
+This log was last generated on Wed, 12 May 2025
+
+## 0.1.0
+
+Wed, 12 May 2025
+
+### Minor changes
+
+- Initial release of the A2A Server implementation
+- Created basic server structure and configuration
+- Implemented A2A protocol endpoints
+- Added Agent Card generation
+- Implemented task and message handling
+- Added support for streaming responses

--- a/packages/AI/A2AServer/README.md
+++ b/packages/AI/A2AServer/README.md
@@ -1,0 +1,76 @@
+# MemberJunction A2A Server
+
+This package provides a Google Agent-to-Agent (A2A) protocol server implementation for MemberJunction. It allows MemberJunction to expose its capabilities as an A2A agent, enabling interoperability with other A2A-compliant agents.
+
+## About Agent-to-Agent (A2A) Protocol
+
+A2A is an open protocol developed by Google that enables communication and interoperability between opaque agentic applications. The protocol is designed to facilitate collaboration between AI agents built on different platforms and frameworks.
+
+- Official A2A Documentation: [https://google.github.io/A2A/](https://google.github.io/A2A/)
+- GitHub Repository: [https://github.com/google/A2A](https://github.com/google/A2A)
+- Protocol Specification: [https://google.github.io/A2A/specification/](https://google.github.io/A2A/specification/)
+
+## Features
+
+- Implements the Google A2A protocol specification
+- Exposes MemberJunction entities as agent capabilities
+- Supports task-based interactions
+- Handles authentication and security
+- Provides streaming responses with Server-Sent Events (SSE)
+
+## Installation
+
+```bash
+npm install @memberjunction/a2aserver
+```
+
+## Configuration
+
+Add A2A server configuration to your MemberJunction config file:
+
+```javascript
+// mj.config.js
+module.exports = {
+  // other MJ configuration...
+  
+  a2aServerSettings: {
+    enableA2AServer: true,
+    port: 3200,
+    entityCapabilities: [
+      {
+        entityName: "*",
+        schemaName: "*", 
+        get: true,
+        create: false,
+        update: false,
+        delete: false
+      }
+      // Add more capabilities as needed
+    ]
+  }
+}
+```
+
+## Usage
+
+```javascript
+import { initializeA2AServer } from '@memberjunction/a2aserver';
+
+// Start the A2A server
+initializeA2AServer();
+```
+
+## Protocol Implementation
+
+This package implements the Google A2A protocol as specified at: https://google.github.io/A2A/
+
+The implementation includes:
+- Agent card publication
+- Task lifecycle management
+- Message and artifact handling
+- Authentication and security
+- Streaming responses via SSE
+
+## License
+
+MIT

--- a/packages/AI/A2AServer/package.json
+++ b/packages/AI/A2AServer/package.json
@@ -1,0 +1,40 @@
+{
+  "name": "@memberjunction/a2aserver",
+  "version": "0.1.0",
+  "description": "MemberJunction Agent-To-Agent (A2A) Server Implementation",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "type": "module",
+  "files": [
+    "dist/**/*"
+  ],
+  "scripts": {
+    "build": "tsc",
+    "clean": "rimraf dist",
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "keywords": [
+    "MemberJunction",
+    "A2A",
+    "Agent-to-Agent",
+    "AI"
+  ],
+  "author": "MemberJunction",
+  "license": "MIT",
+  "dependencies": {
+    "@memberjunction/core": "^0.9.127",
+    "@memberjunction/global": "^0.9.125",
+    "@memberjunction/sqlserver-dataprovider": "^0.9.161",
+    "cosmiconfig": "^8.0.0",
+    "dotenv": "^16.0.3",
+    "express": "^4.18.2",
+    "typeorm": "^0.3.10",
+    "zod": "^3.22.4"
+  },
+  "devDependencies": {
+    "@types/express": "^4.17.17",
+    "@types/node": "^18.11.9",
+    "rimraf": "^3.0.2",
+    "typescript": "^5.0.2"
+  }
+}

--- a/packages/AI/A2AServer/src/EntityOperations.ts
+++ b/packages/AI/A2AServer/src/EntityOperations.ts
@@ -1,0 +1,361 @@
+import { BaseEntity, EntityInfo, LogError, Metadata, RunView, RunQuery, UserInfo } from "@memberjunction/core";
+import { UserCache } from "@memberjunction/sqlserver-dataprovider";
+import { a2aServerSettings } from './config.js';
+
+export interface OperationResult {
+    success: boolean;
+    result?: any;
+    errorMessage?: string;
+}
+
+export interface OperationParameters {
+    [key: string]: any;
+}
+
+export class EntityOperations {
+    private contextUser: UserInfo;
+    private metadata: Metadata;
+
+    constructor() {
+        this.metadata = new Metadata();
+        // Find the user by email if configured, otherwise use the first user in the cache
+        if (a2aServerSettings?.userEmail) {
+            const user = UserCache.Instance.Users.find((u: UserInfo) =>
+                u.Email && u.Email.toLowerCase() === a2aServerSettings?.userEmail?.toLowerCase());
+
+            if (user) {
+                this.contextUser = user;
+            } else {
+                LogError('EntityOperations', 'Constructor', `User with email ${a2aServerSettings?.userEmail} not found. Using first user in cache.`);
+                this.contextUser = UserCache.Instance.Users[0];
+            }
+        } else {
+            this.contextUser = UserCache.Instance.Users[0];
+        }
+    }
+
+    /**
+     * Finds an entity by name
+     * @param entityName The entity name to find
+     * @returns The entity info or null if not found
+     */
+    public findEntity(entityName: string): EntityInfo | null {
+        if (!entityName) return null;
+        
+        return this.metadata.Entities.find(e => 
+            e.Name.toLowerCase() === entityName.toLowerCase() ||
+            e.ClassName.toLowerCase() === entityName.toLowerCase()
+        ) || null;
+    }
+
+    /**
+     * Converts an entity object to JSON
+     * @param record The entity record to convert
+     * @returns JSON representation of the entity
+     */
+    public async convertEntityObjectToJSON(record: BaseEntity): Promise<any> {
+        const output = await record.GetDataObjectJSON({
+            includeRelatedEntityData: false,
+            oldValues: false,
+            omitEmptyStrings: false,
+            omitNullValues: false,
+            excludeFields: [],
+            relatedEntityList: [],
+        });
+        return output;
+    }
+
+    /**
+     * Creates key pairs for loading an entity
+     * @param entity The entity info
+     * @param parameters The parameters containing key values
+     * @returns Array of key pairs for entity loading
+     */
+    private createKeyPairsForLoading(entity: EntityInfo, parameters: OperationParameters) {
+        const keyPairs = [];
+        for (const pk of entity.PrimaryKeys) {
+            if (parameters[pk.Name] !== undefined) {
+                keyPairs.push({
+                    FieldName: pk.Name,
+                    Value: parameters[pk.Name]
+                });
+            } else {
+                throw new Error(`Missing primary key value for ${pk.Name}`);
+            }
+        }
+        return keyPairs;
+    }
+
+    /**
+     * Gets an entity record by its primary key
+     * @param entityName The name of the entity
+     * @param parameters Parameters containing primary key values
+     * @returns The operation result
+     */
+    public async getEntity(entityName: string, parameters: OperationParameters): Promise<OperationResult> {
+        try {
+            const entity = this.findEntity(entityName);
+            if (!entity) {
+                return { 
+                    success: false, 
+                    errorMessage: `Entity not found: ${entityName}` 
+                };
+            }
+
+            const record = await this.metadata.GetEntityObject(entity.Name, this.contextUser);
+            const keyPairs = this.createKeyPairsForLoading(entity, parameters);
+            
+            const loaded = await record.InnerLoad(keyPairs);
+            if (loaded) {
+                const result = await this.convertEntityObjectToJSON(record);
+                return { success: true, result };
+            } else {
+                return { success: false, errorMessage: "Record not found" };
+            }
+        } catch (error) {
+            return { 
+                success: false, 
+                errorMessage: error instanceof Error ? error.message : String(error) 
+            };
+        }
+    }
+
+    /**
+     * Creates a new entity record
+     * @param entityName The name of the entity
+     * @param parameters Field values for the new record
+     * @returns The operation result
+     */
+    public async createEntity(entityName: string, parameters: OperationParameters): Promise<OperationResult> {
+        try {
+            const entity = this.findEntity(entityName);
+            if (!entity) {
+                return { 
+                    success: false, 
+                    errorMessage: `Entity not found: ${entityName}` 
+                };
+            }
+
+            const record = await this.metadata.GetEntityObject(entity.Name, this.contextUser);
+            record.SetMany(parameters, true);
+            
+            const success = await record.Save();
+            if (success) {
+                const result = await this.convertEntityObjectToJSON(record);
+                return { success: true, result };
+            } else {
+                return { success: false, errorMessage: "Failed to create record" };
+            }
+        } catch (error) {
+            return { 
+                success: false, 
+                errorMessage: error instanceof Error ? error.message : String(error) 
+            };
+        }
+    }
+
+    /**
+     * Updates an existing entity record
+     * @param entityName The name of the entity
+     * @param parameters Parameters containing primary key and fields to update
+     * @returns The operation result
+     */
+    public async updateEntity(entityName: string, parameters: OperationParameters): Promise<OperationResult> {
+        try {
+            const entity = this.findEntity(entityName);
+            if (!entity) {
+                return { 
+                    success: false, 
+                    errorMessage: `Entity not found: ${entityName}` 
+                };
+            }
+
+            const record = await this.metadata.GetEntityObject(entity.Name, this.contextUser);
+            const keyPairs = this.createKeyPairsForLoading(entity, parameters);
+            
+            const loaded = await record.InnerLoad(keyPairs);
+            if (loaded) {
+                // Remove primary keys from update parameters
+                const updateParams = { ...parameters };
+                entity.PrimaryKeys.forEach(pk => {
+                    delete updateParams[pk.Name];
+                });
+                
+                record.SetMany(updateParams, true);
+                const success = await record.Save();
+                
+                if (success) {
+                    const result = await this.convertEntityObjectToJSON(record);
+                    return { success: true, result };
+                } else {
+                    return { success: false, errorMessage: "Failed to update record" };
+                }
+            } else {
+                return { success: false, errorMessage: "Record not found" };
+            }
+        } catch (error) {
+            return { 
+                success: false, 
+                errorMessage: error instanceof Error ? error.message : String(error) 
+            };
+        }
+    }
+
+    /**
+     * Deletes an entity record
+     * @param entityName The name of the entity
+     * @param parameters Parameters containing primary key values
+     * @returns The operation result
+     */
+    public async deleteEntity(entityName: string, parameters: OperationParameters): Promise<OperationResult> {
+        try {
+            const entity = this.findEntity(entityName);
+            if (!entity) {
+                return { 
+                    success: false, 
+                    errorMessage: `Entity not found: ${entityName}` 
+                };
+            }
+
+            const record = await this.metadata.GetEntityObject(entity.Name, this.contextUser);
+            const keyPairs = this.createKeyPairsForLoading(entity, parameters);
+            
+            const loaded = await record.InnerLoad(keyPairs);
+            if (loaded) {
+                const success = await record.Delete();
+                
+                if (success) {
+                    return { success: true };
+                } else {
+                    return { success: false, errorMessage: "Failed to delete record" };
+                }
+            } else {
+                return { success: false, errorMessage: "Record not found" };
+            }
+        } catch (error) {
+            return { 
+                success: false, 
+                errorMessage: error instanceof Error ? error.message : String(error) 
+            };
+        }
+    }
+
+    /**
+     * Queries an entity
+     * @param entityName The name of the entity
+     * @param parameters Query parameters (extraFilter, orderBy, fields)
+     * @returns The operation result
+     */
+    public async queryEntity(entityName: string, parameters: OperationParameters): Promise<OperationResult> {
+        try {
+            const entity = this.findEntity(entityName);
+            if (!entity) {
+                return { 
+                    success: false, 
+                    errorMessage: `Entity not found: ${entityName}` 
+                };
+            }
+
+            const rv = new RunView();
+            const queryResult = await rv.RunView({
+                EntityName: entity.Name,
+                ExtraFilter: parameters.extraFilter,
+                OrderBy: parameters.orderBy,
+                Fields: parameters.fields,
+            }, this.contextUser);
+            
+            return { success: true, result: queryResult };
+        } catch (error) {
+            return { 
+                success: false, 
+                errorMessage: error instanceof Error ? error.message : String(error) 
+            };
+        }
+    }
+
+    /**
+     * Parses a command from text content
+     * @param textContent The text content to parse
+     * @returns Parsed operation details
+     */
+    public parseCommandFromText(textContent: string): { operation: string, entityName: string, parameters: OperationParameters } {
+        let operation = 'unknown';
+        let entityName = '';
+        const parameters: OperationParameters = {};
+
+        if (textContent.match(/get|retrieve|find|read/i)) {
+            operation = 'get';
+        } else if (textContent.match(/create|add|insert|new/i)) {
+            operation = 'create';
+        } else if (textContent.match(/update|edit|modify|change/i)) {
+            operation = 'update';
+        } else if (textContent.match(/delete|remove|drop/i)) {
+            operation = 'delete';
+        } else if (textContent.match(/query|list|view|search/i)) {
+            operation = 'query';
+        }
+
+        // Try to extract entity name
+        const entityMatches = textContent.match(/from\s+(\w+)/i) ||
+                            textContent.match(/(get|update|delete|query)\s+(\w+)/i);
+        if (entityMatches) {
+            entityName = entityMatches[1] || entityMatches[2] || '';
+        }
+
+        // For parameters we would need more sophisticated parsing
+        // This is a simplified approach
+        if (operation === 'get' || operation === 'update' || operation === 'delete') {
+            const idMatch = textContent.match(/id\s*[=:]\s*(\w+)/i) ||
+                        textContent.match(/where\s+id\s*[=:]\s*(\w+)/i);
+            if (idMatch && idMatch[1]) {
+                parameters.ID = idMatch[1];
+            }
+        }
+
+        if (operation === 'query') {
+            const filterMatch = textContent.match(/where\s+(.+?)(\s+order\s+by|$)/i);
+            if (filterMatch && filterMatch[1]) {
+                parameters.extraFilter = filterMatch[1];
+            }
+
+            const orderMatch = textContent.match(/order\s+by\s+(.+?)(\s+limit|$)/i);
+            if (orderMatch && orderMatch[1]) {
+                parameters.orderBy = orderMatch[1];
+            }
+        }
+
+        return { operation, entityName, parameters };
+    }
+
+    /**
+     * Processes an operation on an entity
+     * @param operation The operation to perform (get, create, update, delete, query)
+     * @param entityName The name of the entity
+     * @param parameters The operation parameters
+     * @returns The operation result
+     */
+    public async processOperation(operation: string, entityName: string, parameters: OperationParameters): Promise<OperationResult> {
+        switch(operation) {
+            case 'get':
+                return await this.getEntity(entityName, parameters);
+                
+            case 'create':
+                return await this.createEntity(entityName, parameters);
+                
+            case 'update':
+                return await this.updateEntity(entityName, parameters);
+                
+            case 'delete':
+                return await this.deleteEntity(entityName, parameters);
+                
+            case 'query':
+                return await this.queryEntity(entityName, parameters);
+                
+            default:
+                return { 
+                    success: false, 
+                    errorMessage: `Unsupported operation: ${operation}` 
+                };
+        }
+    }
+}

--- a/packages/AI/A2AServer/src/Server.ts
+++ b/packages/AI/A2AServer/src/Server.ts
@@ -1,0 +1,585 @@
+import { EntityInfo, LogError, Metadata, UserInfo } from "@memberjunction/core";
+import { setupSQLServerClient, SQLServerProviderConfigData, UserCache } from "@memberjunction/sqlserver-dataprovider";
+import express from 'express';
+import { DataSource } from "typeorm";
+import { z } from "zod";
+import { DataSourceOptions } from 'typeorm';
+import { configInfo, dbDatabase, dbHost, dbPassword, dbPort, dbUsername, dbInstanceName, dbTrustServerCertificate, a2aServerSettings } from './config.js';
+import { EntityOperations, OperationResult } from './EntityOperations.js';
+
+// A2A Server Configuration
+const a2aServerPort = a2aServerSettings?.port || 3200;
+
+// Database Configuration
+const ormConfig = {
+    type: 'mssql' as const,
+    entities: [],
+    logging: false,
+    host: dbHost,
+    port: dbPort,
+    username: dbUsername,
+    password: dbPassword,
+    database: dbDatabase,
+    synchronize: false,
+    requestTimeout: configInfo.databaseSettings.requestTimeout,
+    connectionTimeout: configInfo.databaseSettings.connectionTimeout,
+    options: {},
+};
+
+if (dbInstanceName !== null && dbInstanceName !== undefined && dbInstanceName.trim().length > 0) {
+    ormConfig.options = {
+        ...ormConfig.options,
+        instanceName: dbInstanceName,
+    };
+}
+
+if (dbTrustServerCertificate !== null && dbTrustServerCertificate !== undefined) {
+    ormConfig.options = {
+        ...ormConfig.options,
+        trustServerCertificate: dbTrustServerCertificate === 'Y',
+    };
+}
+
+// A2A Server Classes and Types
+type TaskStatus = 'pending' | 'in_progress' | 'completed' | 'cancelled' | 'failed';
+
+interface Task {
+    id: string;
+    status: TaskStatus;
+    messages: Message[];
+    artifacts: Artifact[];
+    created: Date;
+    updated: Date;
+}
+
+interface Message {
+    id: string;
+    taskId: string;
+    role: 'user' | 'agent';
+    parts: Part[];
+    created: Date;
+}
+
+interface Part {
+    id: string;
+    type: 'text' | 'file' | 'data';
+    content: string | object;
+    metadata?: object;
+}
+
+interface Artifact {
+    id: string;
+    taskId: string;
+    name: string;
+    parts: Part[];
+    created: Date;
+}
+
+interface AgentCard {
+    name: string;
+    description: string;
+    version: string;
+    endpoints: {
+        tasks: string;
+        agentCard: string;
+    };
+    authentication?: {
+        type: string;
+        scheme: string;
+    };
+    capabilities: {
+        streaming: boolean;
+        asynchronous: boolean;
+        multimedia: boolean;
+        entities: {
+            name: string;
+            schema: string;
+            operations: string[];
+        }[];
+    };
+}
+
+// In-memory storage for tasks (in production, this would use a database)
+const tasks = new Map<string, Task>();
+
+// Express application
+const app = express();
+app.use(express.json());
+
+// Initialize A2A server
+export async function initializeA2AServer() {
+    try {
+        if (!a2aServerSettings?.enableA2AServer) {
+            console.log("A2A Server is disabled in the configuration.");
+            throw new Error("A2A Server is disabled in the configuration.");
+        }
+
+        // Initialize database connection
+        const dataSource = new DataSource(ormConfig);
+        await dataSource.initialize();
+        
+        // Setup SQL Server client
+        const config = new SQLServerProviderConfigData(dataSource, '', configInfo.mjCoreSchema);
+        await setupSQLServerClient(config);
+        console.log("Database connection setup completed.");
+
+        // Set up routes
+        setupRoutes();
+        
+        // Start the server
+        app.listen(a2aServerPort, () => {
+            console.log(`MemberJunction A2A Server running on port ${a2aServerPort}`);
+            console.log(`Agent card available at: http://localhost:${a2aServerPort}/a2a/agent-card`);
+        });
+    } catch (error) {
+        console.error("Failed to initialize A2A server:", error);
+    }
+}
+
+function setupRoutes() {
+    // Agent Card endpoint
+    app.get('/a2a/agent-card', (req, res) => {
+        const agentCard = generateAgentCard();
+        res.json(agentCard);
+    });
+
+    // Send a message to a task
+    app.post('/a2a/tasks/send', (req, res) => {
+        const result = handleTaskSend(req.body);
+        res.json(result);
+    });
+
+    // Send a message to a task with streaming response
+    app.post('/a2a/tasks/sendSubscribe', (req, res) => {
+        if (!a2aServerSettings?.streamingEnabled) {
+            return res.status(400).json({
+                error: {
+                    code: 400,
+                    message: "Streaming is not enabled for this agent"
+                }
+            });
+        }
+
+        // Set up SSE connection
+        res.setHeader('Content-Type', 'text/event-stream');
+        res.setHeader('Cache-Control', 'no-cache');
+        res.setHeader('Connection', 'keep-alive');
+
+        handleTaskSendSubscribe(req.body, res);
+    });
+
+    // Get a task's status
+    app.get('/a2a/tasks/:taskId', (req, res) => {
+        const { taskId } = req.params;
+        const task = tasks.get(taskId);
+        
+        if (!task) {
+            return res.status(404).json({
+                error: {
+                    code: 404,
+                    message: `Task with ID ${taskId} not found`
+                }
+            });
+        }
+        
+        res.json(task);
+    });
+
+    // Cancel a task
+    app.post('/a2a/tasks/:taskId/cancel', (req, res) => {
+        const { taskId } = req.params;
+        const task = tasks.get(taskId);
+        
+        if (!task) {
+            return res.status(404).json({
+                error: {
+                    code: 404,
+                    message: `Task with ID ${taskId} not found`
+                }
+            });
+        }
+        
+        task.status = 'cancelled';
+        task.updated = new Date();
+        
+        res.json({ success: true });
+    });
+}
+
+function generateAgentCard(): AgentCard {
+    const contextUser = UserCache.Instance.Users[0];
+    const md = new Metadata();
+    const entityCapabilities = getEntityCapabilities(md.Entities, contextUser);
+
+    return {
+        name: a2aServerSettings?.agentName || "MemberJunction",
+        description: a2aServerSettings?.agentDescription || "MemberJunction A2A Agent",
+        version: "1.0.0",
+        endpoints: {
+            tasks: `/a2a/tasks`,
+            agentCard: `/a2a/agent-card`
+        },
+        capabilities: {
+            streaming: !!a2aServerSettings?.streamingEnabled,
+            asynchronous: false,
+            multimedia: false,
+            entities: entityCapabilities
+        }
+    };
+}
+
+function getEntityCapabilities(allEntities: EntityInfo[], contextUser: UserInfo) {
+    const capabilities = [];
+    const entityCapabilitiesConfig = a2aServerSettings?.entityCapabilities || [];
+
+    for (const config of entityCapabilitiesConfig) {
+        const matchingEntities = getMatchingEntitiesForConfig(allEntities, config);
+        
+        for (const entity of matchingEntities) {
+            const operations = [];
+            if (config.get) operations.push('get');
+            if (config.create) operations.push('create');
+            if (config.update) operations.push('update');
+            if (config.delete) operations.push('delete');
+            if (config.runView) operations.push('query');
+
+            if (operations.length > 0) {
+                capabilities.push({
+                    name: entity.Name,
+                    schema: entity.SchemaName,
+                    operations: operations
+                });
+            }
+        }
+    }
+
+    return capabilities;
+}
+
+function getMatchingEntitiesForConfig(allEntities: EntityInfo[], config: any) {
+    return allEntities.filter((entity) => {
+        const entityName = entity.Name.toLowerCase();
+        const schemaName = entity.SchemaName.toLowerCase();
+        const configEntityName = config.entityName?.trim().toLowerCase() || "*";
+        const configSchemaName = config.schemaName?.trim().toLowerCase() || "*";
+
+        let schemaMatch = false;
+        let entityMatch = false;
+
+        // Schema matching
+        if (configSchemaName === "*") {
+            schemaMatch = true;
+        } else if (configSchemaName.startsWith("*") && configSchemaName.endsWith("*")) {
+            schemaMatch = schemaName.includes(configSchemaName.slice(1, -1));
+        } else if (configSchemaName.endsWith("*")) {
+            schemaMatch = schemaName.startsWith(configSchemaName.slice(0, -1));
+        } else if (configSchemaName.startsWith("*")) {
+            schemaMatch = schemaName.endsWith(configSchemaName.slice(1));
+        } else {
+            schemaMatch = schemaName === configSchemaName;
+        }
+
+        // Entity matching (only checked if schema matches)
+        if (schemaMatch) {
+            if (configEntityName === "*") {
+                entityMatch = true;
+            } else if (configEntityName.startsWith("*") && configEntityName.endsWith("*")) {
+                entityMatch = entityName.includes(configEntityName.slice(1, -1));
+            } else if (configEntityName.endsWith("*")) {
+                entityMatch = entityName.startsWith(configEntityName.slice(0, -1));
+            } else if (configEntityName.startsWith("*")) {
+                entityMatch = entityName.endsWith(configEntityName.slice(1));
+            } else {
+                entityMatch = entityName === configEntityName;
+            }
+        }
+
+        return schemaMatch && entityMatch;
+    });
+}
+
+function handleTaskSend(requestBody: any) {
+    const { taskId, message } = requestBody;
+    
+    if (!taskId) {
+        // Create a new task
+        const newTaskId = generateId();
+        const task: Task = {
+            id: newTaskId,
+            status: 'pending',
+            messages: [],
+            artifacts: [],
+            created: new Date(),
+            updated: new Date()
+        };
+        
+        if (message) {
+            const newMessage: Message = {
+                id: generateId(),
+                taskId: newTaskId,
+                role: 'user',
+                parts: message.parts || [],
+                created: new Date()
+            };
+            task.messages.push(newMessage);
+        }
+        
+        tasks.set(newTaskId, task);
+        
+        // Process the task asynchronously
+        processTask(task);
+        
+        return {
+            taskId: newTaskId,
+            status: task.status
+        };
+    } else {
+        // Update an existing task
+        const task = tasks.get(taskId);
+        
+        if (!task) {
+            throw {
+                error: {
+                    code: 404,
+                    message: `Task with ID ${taskId} not found`
+                }
+            };
+        }
+        
+        if (task.status === 'completed' || task.status === 'cancelled' || task.status === 'failed') {
+            throw {
+                error: {
+                    code: 400,
+                    message: `Cannot update a task with status: ${task.status}`
+                }
+            };
+        }
+        
+        if (message) {
+            const newMessage: Message = {
+                id: generateId(),
+                taskId,
+                role: 'user',
+                parts: message.parts || [],
+                created: new Date()
+            };
+            task.messages.push(newMessage);
+            task.updated = new Date();
+        }
+        
+        // Process the updated task
+        processTask(task);
+        
+        return {
+            taskId: task.id,
+            status: task.status
+        };
+    }
+}
+
+function handleTaskSendSubscribe(requestBody: any, res: any) {
+    const result = handleTaskSend(requestBody);
+    const task = tasks.get(result.taskId);
+    
+    if (!task) {
+        res.write(`data: ${JSON.stringify({ error: { code: 404, message: "Task not found" } })}\n\n`);
+        res.end();
+        return;
+    }
+    
+    // Send initial task state
+    res.write(`data: ${JSON.stringify({ 
+        taskId: task.id,
+        status: task.status 
+    })}\n\n`);
+    
+    // Set up a listener for task updates
+    const updateInterval = setInterval(() => {
+        const updatedTask = tasks.get(task.id);
+        
+        if (!updatedTask) {
+            clearInterval(updateInterval);
+            res.end();
+            return;
+        }
+        
+        // Send task status updates
+        res.write(`data: ${JSON.stringify({ 
+            taskId: updatedTask.id,
+            status: updatedTask.status 
+        })}\n\n`);
+        
+        // If task is completed, send final message and end the stream
+        if (updatedTask.status === 'completed' || updatedTask.status === 'cancelled' || updatedTask.status === 'failed') {
+            clearInterval(updateInterval);
+            
+            // Send final artifacts
+            if (updatedTask.artifacts.length > 0) {
+                res.write(`data: ${JSON.stringify({
+                    taskId: updatedTask.id,
+                    artifacts: updatedTask.artifacts
+                })}\n\n`);
+            }
+            
+            res.end();
+        }
+    }, 500);
+    
+    // Handle client disconnect
+    res.on('close', () => {
+        clearInterval(updateInterval);
+    });
+}
+
+// Process a task using MemberJunction APIs
+async function processTask(task: Task) {
+    try {
+        task.status = 'in_progress';
+        task.updated = new Date();
+
+        // Get the last user message
+        const lastMessage = task.messages.filter(m => m.role === 'user').pop();
+
+        if (!lastMessage) {
+            throw new Error("No user message found");
+        }
+
+        // Initialize entity operations
+        const entityOps = new EntityOperations();
+
+        // Extract text content and parse operation
+        const textParts = lastMessage.parts.filter(p => p.type === 'text');
+        const textContent = textParts.map(p => typeof p.content === 'string' ? p.content : JSON.stringify(p.content)).join(" ");
+
+        // Extract structured data if any
+        const dataParts = lastMessage.parts.filter(p => p.type === 'data');
+        const dataContent = dataParts.length > 0 ? dataParts[0].content : null;
+
+        // Parse the command and parameters
+        let operation = 'unknown';
+        let entityName = '';
+        let parameters: any = {};
+
+        // Try to extract command and parameters from structured data first
+        if (dataContent && typeof dataContent === 'object') {
+            operation = (dataContent as any).operation || 'unknown';
+            entityName = (dataContent as any).entity || '';
+            parameters = (dataContent as any).parameters || {};
+        }
+        // Otherwise parse from text
+        else if (textContent) {
+            const parsedCommand = entityOps.parseCommandFromText(textContent);
+            operation = parsedCommand.operation;
+            entityName = parsedCommand.entityName;
+            parameters = parsedCommand.parameters;
+        }
+
+        // Perform the operation
+        let operationResult: OperationResult;
+
+        try {
+            if (!entityName) {
+                throw new Error("Entity name not specified");
+            }
+
+            operationResult = await entityOps.processOperation(operation, entityName, parameters);
+        } catch (error) {
+            operationResult = {
+                success: false,
+                errorMessage: error instanceof Error ? error.message : String(error)
+            };
+        }
+        
+        // Create response message
+        const responseMessage: Message = {
+            id: generateId(),
+            taskId: task.id,
+            role: 'agent',
+            parts: [
+                {
+                    id: generateId(),
+                    type: 'text',
+                    content: operationResult.success
+                        ? `Successfully performed ${operation} operation on ${entityName}`
+                        : `Failed to perform ${operation} operation on ${entityName}: ${operationResult.errorMessage}`
+                }
+            ],
+            created: new Date()
+        };
+
+        // Create artifact with result data
+        const artifact: Artifact = {
+            id: generateId(),
+            taskId: task.id,
+            name: `${operation}_result`,
+            parts: [
+                {
+                    id: generateId(),
+                    type: 'data',
+                    content: {
+                        success: operationResult.success,
+                        operation,
+                        entity: entityName,
+                        result: operationResult.result,
+                        error: operationResult.success ? undefined : operationResult.errorMessage,
+                        timestamp: new Date().toISOString()
+                    }
+                }
+            ],
+            created: new Date()
+        };
+
+        // Update the task
+        task.messages.push(responseMessage);
+        task.artifacts.push(artifact);
+        task.status = 'completed';
+        task.updated = new Date();
+
+    } catch (error) {
+        console.error("Error processing task:", error);
+
+        // Create error response
+        const errorMessage: Message = {
+            id: generateId(),
+            taskId: task.id,
+            role: 'agent',
+            parts: [
+                {
+                    id: generateId(),
+                    type: 'text',
+                    content: `An error occurred while processing your request: ${error instanceof Error ? error.message : String(error)}`
+                }
+            ],
+            created: new Date()
+        };
+
+        // Create error artifact
+        const errorArtifact: Artifact = {
+            id: generateId(),
+            taskId: task.id,
+            name: 'error',
+            parts: [
+                {
+                    id: generateId(),
+                    type: 'data',
+                    content: {
+                        success: false,
+                        error: error instanceof Error ? error.message : String(error),
+                        timestamp: new Date().toISOString()
+                    }
+                }
+            ],
+            created: new Date()
+        };
+
+        task.messages.push(errorMessage);
+        task.artifacts.push(errorArtifact);
+        task.status = 'failed';
+        task.updated = new Date();
+    }
+}
+
+// Utility function to generate a random ID
+function generateId() {
+    return Math.random().toString(36).substring(2, 15) + Math.random().toString(36).substring(2, 15);
+}

--- a/packages/AI/A2AServer/src/config.ts
+++ b/packages/AI/A2AServer/src/config.ts
@@ -1,0 +1,95 @@
+import * as dotenv from 'dotenv';
+
+dotenv.config();
+
+import { z } from 'zod';
+import { cosmiconfigSync } from 'cosmiconfig';
+import { LogError } from '@memberjunction/core';
+
+const explorer = cosmiconfigSync('mj');
+
+const databaseSettingsInfoSchema = z.object({
+  connectionTimeout: z.number(),
+  requestTimeout: z.number(),
+  dbReadOnlyUsername: z.string().optional(),
+  dbReadOnlyPassword: z.string().optional(),
+});
+
+const a2aServerEntityCapabilitySchema = z.object({
+  entityName: z.string().optional(),
+  schemaName: z.string().optional(),
+  get: z.boolean().optional().default(false),
+  create: z.boolean().optional().default(false),
+  update: z.boolean().optional().default(false),
+  delete: z.boolean().optional().default(false),
+  runView: z.boolean().optional().default(false),
+});
+
+const a2aServerInfoSchema = z.object({
+  port: z.coerce.number().optional().default(3200),
+  entityCapabilities: z.array(a2aServerEntityCapabilitySchema).optional(),
+  enableA2AServer: z.boolean().optional().default(false),
+  agentName: z.string().optional().default("MemberJunction"),
+  agentDescription: z.string().optional().default("MemberJunction A2A Agent"),
+  streamingEnabled: z.boolean().optional().default(true),
+  userEmail: z.string().optional().describe("Email address of the user to use for entity operations"),
+});
+
+const configInfoSchema = z.object({
+  databaseSettings: databaseSettingsInfoSchema,
+
+  dbHost: z.string().default('localhost'),
+  dbDatabase: z.string(),
+  dbPort: z.number({ coerce: true }).default(1433),
+  dbUsername: z.string(),
+  dbPassword: z.string(),
+  dbReadOnlyUsername: z.string().optional(),
+  dbReadOnlyPassword: z.string().optional(),
+  dbTrustServerCertificate: z.coerce
+    .boolean()
+    .default(false)
+    .transform((v) => (v ? 'Y' : 'N')),
+  dbInstanceName: z.string().optional(),
+
+  // A2A Server settings
+  a2aServerSettings: a2aServerInfoSchema.optional(),
+
+  mjCoreSchema: z.string(),
+});
+
+export type DatabaseSettingsInfo = z.infer<typeof databaseSettingsInfoSchema>;
+export type ConfigInfo = z.infer<typeof configInfoSchema>;
+
+export const configInfo: ConfigInfo = loadConfig();
+
+export const {
+  dbUsername,
+  dbPassword,
+  dbHost,
+  dbDatabase,
+  dbPort,
+  dbTrustServerCertificate,
+  dbInstanceName,
+  a2aServerSettings,
+  mjCoreSchema: mj_core_schema,
+  dbReadOnlyUsername,
+  dbReadOnlyPassword,
+} = configInfo;
+
+export function loadConfig(): ConfigInfo {
+  const configSearchResult = explorer.search(process.cwd());
+  if (!configSearchResult) {
+    throw new Error('Config file not found.');
+  }
+
+  if (configSearchResult.isEmpty) {
+    throw new Error(`Config file ${configSearchResult.filepath} is empty or does not exist.`);
+  }
+
+  const configParsing = configInfoSchema.safeParse(configSearchResult.config);
+  if (!configParsing.success) {
+    LogError('Error parsing config file', '', JSON.stringify(configParsing.error.issues, null, 2));
+    throw new Error('Error parsing config file');
+  }
+  return configParsing.data;
+}

--- a/packages/AI/A2AServer/src/index.ts
+++ b/packages/AI/A2AServer/src/index.ts
@@ -1,0 +1,2 @@
+export * from './Server.js';
+export * from './config.js';

--- a/packages/AI/A2AServer/tsconfig.json
+++ b/packages/AI/A2AServer/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "Node16",
+    "moduleResolution": "Node16",
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "sourceMap": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules"]
+}

--- a/packages/AI/A2AServer/typedoc.json
+++ b/packages/AI/A2AServer/typedoc.json
@@ -1,0 +1,4 @@
+{
+    "extends": "../../../typedoc.base.json",
+    "name": "MemberJunction A2A Server"
+}

--- a/packages/AI/Providers/Cerebras/CHANGELOG.md
+++ b/packages/AI/Providers/Cerebras/CHANGELOG.md
@@ -1,0 +1,11 @@
+# Change Log - @memberjunction/ai-cerebras
+
+## 2.37.1
+
+Mon, 13 May 2025 12:00:00 GMT
+
+### Patches
+
+- Initial implementation of Cerebras provider (amith@memberjunction.com)
+- Bump @memberjunction/ai to v2.36.1
+- Bump @memberjunction/global to v2.36.1

--- a/packages/AI/Providers/Cerebras/README.md
+++ b/packages/AI/Providers/Cerebras/README.md
@@ -1,0 +1,180 @@
+# @memberjunction/ai-cerebras
+
+A comprehensive wrapper for Cerebras Cloud, providing high-performance AI model access within the MemberJunction framework.
+
+## Features
+
+- **High-Performance Integration**: Connect to Cerebras' ultra-fast inference API
+- **Standardized Interface**: Implements MemberJunction's BaseLLM abstract class
+- **Message Formatting**: Handles conversion between MemberJunction and Cerebras message formats
+- **Error Handling**: Robust error handling with detailed reporting
+- **Token Usage Tracking**: Track token consumption for monitoring
+- **Chat Completion**: Interactive chat completions with various LLMs hosted on Cerebras
+- **Streaming Support**: Full support for streaming responses with real-time processing
+- **Model Support**: Compatible with various models including llama3.1-8b and other models hosted on Cerebras
+
+## Installation
+
+```bash
+npm install @memberjunction/ai-cerebras
+```
+
+## Requirements
+
+- Node.js 16+
+- A Cerebras API key
+- MemberJunction Core libraries
+
+## Usage
+
+### Basic Setup
+
+```typescript
+import { CerebrasLLM } from '@memberjunction/ai-cerebras';
+
+// Initialize with your Cerebras API key
+const cerebrasLLM = new CerebrasLLM('your-cerebras-api-key');
+```
+
+### Chat Completion
+
+```typescript
+import { ChatParams } from '@memberjunction/ai';
+
+// Create chat parameters
+const chatParams: ChatParams = {
+  model: 'llama3.1-8b',
+  messages: [
+    { role: 'system', content: 'You are a helpful AI assistant.' },
+    { role: 'user', content: 'Explain the benefits of specialized AI hardware like Cerebras WSE.' }
+  ],
+  temperature: 0.7,
+  maxOutputTokens: 1000
+};
+
+// Get a response
+try {
+  const response = await cerebrasLLM.ChatCompletion(chatParams);
+  if (response.success) {
+    console.log('Response:', response.data.choices[0].message.content);
+    console.log('Token Usage:', response.data.usage);
+    console.log('Time Elapsed (ms):', response.timeElapsed);
+  } else {
+    console.error('Error:', response.errorMessage);
+  }
+} catch (error) {
+  console.error('Exception:', error);
+}
+```
+
+### Streaming Chat Completion
+
+```typescript
+import { ChatParams, StreamingChatCallbacks } from '@memberjunction/ai';
+
+// Define streaming callbacks
+const callbacks: StreamingChatCallbacks = {
+  onStart: () => console.log('Streaming started'),
+  onUpdate: (content, isFinal) => {
+    process.stdout.write(content);
+    if (isFinal) console.log('\nStreaming complete');
+  },
+  onError: (error) => console.error('Streaming error:', error),
+  onEnd: (finalContent) => console.log(`\nFinal content length: ${finalContent.length}`)
+};
+
+// Create chat parameters with streaming
+const chatParams: ChatParams = {
+  model: 'llama3.1-8b',
+  messages: [
+    { role: 'system', content: 'You are a helpful AI assistant.' },
+    { role: 'user', content: 'Write a short poem about artificial intelligence.' }
+  ],
+  temperature: 0.7,
+  maxOutputTokens: 1000,
+  streaming: true,
+  streamingCallbacks: callbacks
+};
+
+// Start streaming response
+await cerebrasLLM.ChatCompletion(chatParams);
+```
+
+### Direct Access to Cerebras Client
+
+```typescript
+// Access the underlying Cerebras client for advanced usage
+const cerebrasClient = cerebrasLLM.CerebrasClient;
+
+// Use the client directly if needed
+const customResponse = await cerebrasClient.chat.completions.create({
+  model: 'llama3.1-8b',
+  messages: [{ role: 'user', content: 'Hello!' }],
+  max_tokens: 500
+});
+```
+
+## Supported Models
+
+Cerebras provides access to various models with optimized inference:
+
+- `llama3.1-8b`
+- Other models (check Cerebras documentation for the latest list)
+
+## API Reference
+
+### CerebrasLLM Class
+
+A class that extends BaseLLM to provide Cerebras-specific functionality.
+
+#### Constructor
+
+```typescript
+new CerebrasLLM(apiKey: string)
+```
+
+#### Properties
+
+- `CerebrasClient`: (read-only) Returns the underlying Cerebras client instance
+- `SupportsStreaming`: (read-only) Returns true as Cerebras supports streaming
+
+#### Methods
+
+- `ChatCompletion(params: ChatParams): Promise<ChatResult>` - Perform a chat completion
+- `SummarizeText(params: SummarizeParams): Promise<SummarizeResult>` - Summarize text (not implemented)
+- `ClassifyText(params: ClassifyParams): Promise<ClassifyResult>` - Classify text (not implemented)
+
+## Performance Considerations
+
+Cerebras hardware is optimized for high-performance AI inference:
+
+- Fast response generation with low latency
+- Efficient resource utilization
+- Consider appropriate model sizes for your specific use case
+
+## Error Handling
+
+The wrapper provides detailed error information:
+
+```typescript
+try {
+  const response = await cerebrasLLM.ChatCompletion(params);
+  if (!response.success) {
+    console.error('Error:', response.errorMessage);
+    console.error('Status:', response.statusText);
+    console.error('Time Elapsed:', response.timeElapsed, 'ms');
+  }
+} catch (error) {
+  console.error('Exception occurred:', error);
+}
+```
+
+## Dependencies
+
+- `@cerebras/cerebras_cloud_sdk`: Official Cerebras Cloud SDK
+- `@memberjunction/ai`: MemberJunction AI core framework
+- `@memberjunction/global`: MemberJunction global utilities
+
+## License
+
+ISC

--- a/packages/AI/Providers/Cerebras/package.json
+++ b/packages/AI/Providers/Cerebras/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "@memberjunction/ai-cerebras",
+  "version": "2.37.1",
+  "description": "MemberJunction Wrapper for Cerebras AI inference engine",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "files": [
+    "/dist"
+  ],
+  "scripts": {
+    "start": "ts-node-dev src/index.ts",
+    "build": "tsc",
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "author": "MemberJunction.com",
+  "license": "ISC",
+  "devDependencies": {
+    "ts-node-dev": "^2.0.0",
+    "typescript": "^5.4.5"
+  },
+  "dependencies": {
+    "@memberjunction/ai": "2.37.1",
+    "@memberjunction/global": "2.37.1",
+    "@cerebras/cerebras_cloud_sdk": "^1.29.0"
+  }
+}

--- a/packages/AI/Providers/Cerebras/src/index.ts
+++ b/packages/AI/Providers/Cerebras/src/index.ts
@@ -1,0 +1,1 @@
+export * from './models/cerebras';

--- a/packages/AI/Providers/Cerebras/src/models/cerebras.ts
+++ b/packages/AI/Providers/Cerebras/src/models/cerebras.ts
@@ -1,0 +1,244 @@
+import { BaseLLM, ChatParams, ChatResult, ChatResultChoice, ClassifyParams, ClassifyResult, SummarizeParams, SummarizeResult, StreamingChatCallbacks } from '@memberjunction/ai';
+import { RegisterClass } from '@memberjunction/global';
+import { Cerebras } from '@cerebras/cerebras_cloud_sdk';
+import { Chat } from '@cerebras/cerebras_cloud_sdk/resources/chat';
+
+/**
+ * Cerebras implementation of the BaseLLM class
+ */
+@RegisterClass(BaseLLM, "CerebrasLLM")
+export class CerebrasLLM extends BaseLLM {
+    private _client: Cerebras;
+    
+    /**
+     * Creates a new instance of the CerebrasLLM class
+     * @param apiKey The Cerebras API key to use for authentication
+     */
+    constructor(apiKey: string) {
+        super(apiKey);
+        this._client = new Cerebras({ apiKey });
+    }
+
+    /**
+     * Read only getter method to get the Cerebras client instance
+     */
+    public get CerebrasClient(): Cerebras {
+        return this._client;
+    }
+
+    /**
+     * Read only getter method to get the Cerebras client instance
+     */
+    public get client(): Cerebras {
+        return this.CerebrasClient;
+    }
+    
+    /**
+     * Cerebras supports streaming
+     */
+    public override get SupportsStreaming(): boolean {
+        return true;
+    }
+
+    /**
+     * Implementation of non-streaming chat completion for Cerebras
+     */
+    protected async nonStreamingChatCompletion(params: ChatParams): Promise<ChatResult> {
+        const startTime = new Date();
+
+        const cerebrasParams: Chat.ChatCompletionCreateParams = {
+            model: params.model,
+            messages: params.messages,
+            max_tokens: params.maxOutputTokens,
+            temperature: params.temperature
+        };
+        
+        // Handle response format if specified
+        switch (params.responseFormat) {
+            case 'Any':
+            case 'Text':
+            case 'Markdown':
+                break;
+            case 'JSON':
+                cerebrasParams.response_format = { type: "json_object" };
+                break;
+            case 'ModelSpecific':
+                cerebrasParams.response_format = params.modelSpecificResponseFormat;
+                break;
+        }
+
+        const chatResponse = await this.client.chat.completions.create(cerebrasParams);
+        const endTime = new Date();
+
+        const choices: ChatResultChoice[] = (chatResponse.choices as any[]).map((choice: any) => {
+            const res: ChatResultChoice = {
+                message: {
+                    role: 'assistant',
+                    content: choice.message.content
+                },
+                finish_reason: choice.finish_reason,
+                index: choice.index
+            };
+            return res;
+        });
+        
+        const usage = chatResponse.usage as any;
+        
+        return {
+            success: true,
+            statusText: "OK",
+            startTime: startTime,
+            endTime: endTime,
+            timeElapsed: endTime.getTime() - startTime.getTime(),
+            data: {
+                choices: choices,
+                usage: {
+                    totalTokens: usage.total_tokens,
+                    promptTokens: usage.prompt_tokens,
+                    completionTokens: usage.completion_tokens
+                }
+            },
+            errorMessage: "",
+            exception: null,
+        };
+    }
+    
+    /**
+     * Create a streaming request for Cerebras
+     */
+    protected async createStreamingRequest(params: ChatParams): Promise<any> {
+        const cerebrasParams: Chat.ChatCompletionCreateParams = {
+            model: params.model,
+            messages: params.messages,
+            max_tokens: params.maxOutputTokens,
+            temperature: params.temperature,
+            stream: true
+        };
+        
+        // Set response format if specified
+        switch (params.responseFormat) {
+            case 'JSON':
+                cerebrasParams.response_format = { type: "json_object" };
+                break;
+            case 'ModelSpecific':
+                cerebrasParams.response_format = params.modelSpecificResponseFormat;
+                break;
+        }
+        
+        return this.client.chat.completions.create(cerebrasParams);
+    }
+    
+    /**
+     * Process a streaming chunk from Cerebras
+     */
+    protected processStreamingChunk(chunk: any): {
+        content: string;
+        finishReason?: string;
+        usage?: any;
+    } {
+        let content = '';
+        let finishReason = undefined;
+        let usage = undefined;
+        
+        if (chunk?.choices && chunk.choices.length > 0) {
+            const choice = chunk.choices[0];
+            
+            if (choice?.delta?.content) {
+                content = choice.delta.content;
+            }
+            
+            if (choice?.finish_reason) {
+                finishReason = choice.finish_reason;
+            }
+        }
+        
+        // Cerebras sends usage metrics in the final chunk 
+        if (chunk?.usage) {
+            usage = {
+                promptTokens: chunk.usage.prompt_tokens,
+                completionTokens: chunk.usage.completion_tokens,
+                totalTokens: chunk.usage.total_tokens
+            };
+        }
+        
+        return {
+            content,
+            finishReason,
+            usage
+        };
+    }
+    
+    /**
+     * Create the final response from streaming results for Cerebras
+     */
+    protected finalizeStreamingResponse(
+        accumulatedContent: string | null | undefined,
+        lastChunk: any | null | undefined,
+        usage: any | null | undefined
+    ): ChatResult {
+        // Extract finish reason from last chunk if available
+        let finishReason = 'stop';
+        if (lastChunk?.choices && lastChunk.choices.length > 0 && lastChunk.choices[0].finish_reason) {
+            finishReason = lastChunk.choices[0].finish_reason;
+        }
+        
+        // For Cerebras, usage metrics come in the final chunk
+        const promptTokens = usage?.promptTokens || 0;
+        const completionTokens = usage?.completionTokens || 0;
+        
+        // Create dates (will be overridden by base class)
+        const now = new Date();
+        
+        // Create a proper ChatResult instance with constructor params
+        const result = new ChatResult(true, now, now);
+        
+        // Set all properties
+        result.data = {
+            choices: [{
+                message: {
+                    role: 'assistant',
+                    content: accumulatedContent ? accumulatedContent : ''
+                },
+                finish_reason: finishReason,
+                index: 0
+            }],
+            usage: {
+                promptTokens,
+                completionTokens,
+                totalTokens: promptTokens + completionTokens
+            }
+        };
+        
+        result.statusText = 'success';
+        result.errorMessage = null;
+        result.exception = null;
+        
+        return result;
+    }
+ 
+    /**
+     * Summarizes text using Cerebras LLM capabilities
+     * @param params Parameters for the summarization
+     * @returns A summary result
+     */
+    public async SummarizeText(params: SummarizeParams): Promise<SummarizeResult> {
+        throw new Error("Method not implemented.");
+    }
+
+    /**
+     * Classifies text into categories using Cerebras LLM capabilities
+     * @param params Parameters for classification
+     * @returns A classification result
+     */
+    public async ClassifyText(params: ClassifyParams): Promise<ClassifyResult> {
+        throw new Error("Method not implemented.");
+    }
+}
+ 
+/**
+ * Helper function that ensures the CerebrasLLM class is registered
+ * Prevents tree-shaking from removing the class
+ */
+export function LoadCerebrasLLM() {
+    // this does nothing but prevents the class from being removed by the tree shaker
+}

--- a/packages/AI/Providers/Cerebras/tsconfig.json
+++ b/packages/AI/Providers/Cerebras/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "experimentalDecorators": true,
+    "module": "commonjs",
+    "esModuleInterop": true,
+    "target": "es2020",
+    "declaration": true,
+    "declarationMap": true,
+    "moduleResolution": "node",
+    "sourceMap": true,
+    "outDir": "dist"
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "**/*.spec.ts"]
+}

--- a/packages/AI/Providers/Cerebras/typedoc.json
+++ b/packages/AI/Providers/Cerebras/typedoc.json
@@ -1,0 +1,4 @@
+{
+  "extends": ["../../../../typedoc.base.json"],
+  "entryPoints": ["src/index.ts"]
+}

--- a/packages/AI/Providers/Gemini/package.json
+++ b/packages/AI/Providers/Gemini/package.json
@@ -21,6 +21,6 @@
   "dependencies": {
     "@memberjunction/ai": "2.37.1",
     "@memberjunction/global": "2.37.1",
-    "@google/generative-ai": "0.21.0"
+    "@google/genai": "0.14.0"
   }
 }

--- a/packages/AI/Providers/Gemini/readme.md
+++ b/packages/AI/Providers/Gemini/readme.md
@@ -4,7 +4,7 @@ A comprehensive wrapper for Google's Gemini AI models that seamlessly integrates
 
 ## Features
 
-- **Google Gemini Integration**: Connect to Google's state-of-the-art Gemini models
+- **Google Gemini Integration**: Connect to Google's state-of-the-art Gemini models using the official @google/genai SDK
 - **Standardized Interface**: Implements MemberJunction's BaseLLM abstract class
 - **Message Formatting**: Handles conversion between MemberJunction and Gemini message formats
 - **Error Handling**: Robust error handling with detailed reporting
@@ -68,13 +68,15 @@ try {
 ### Direct Access to Gemini Client
 
 ```typescript
-// Access the underlying Google Generative AI client for advanced usage
+// Access the underlying GoogleGenAI client for advanced usage
 const geminiClient = geminiLLM.GeminiClient;
 
 // Use the client directly if needed
-const model = geminiClient.getGenerativeModel({ model: 'gemini-pro' });
-const result = await model.generateContent('Tell me a short joke about programming');
-console.log(result.response.text());
+const result = await geminiClient.models.generateContent({
+  model: 'gemini-pro',
+  contents: 'Tell me a short joke about programming'
+});
+console.log(result.candidates[0].content.parts[0].text);
 ```
 
 ## Supported Models
@@ -101,7 +103,7 @@ new GeminiLLM(apiKey: string)
 
 #### Properties
 
-- `GeminiClient`: (read-only) Returns the underlying Google Generative AI client instance
+- `GeminiClient`: (read-only) Returns the underlying GoogleGenAI client instance
 
 #### Methods
 
@@ -169,7 +171,7 @@ Future implementations may include:
 
 ## Dependencies
 
-- `@google/generative-ai`: Official Google Generative AI SDK
+- `@google/genai`: Official Google GenAI SDK (replaces the deprecated @google/generative-ai)
 - `@memberjunction/ai`: MemberJunction AI core framework
 - `@memberjunction/global`: MemberJunction global utilities
 

--- a/packages/AI/Providers/Groq/package.json
+++ b/packages/AI/Providers/Groq/package.json
@@ -21,6 +21,6 @@
   "dependencies": {
     "@memberjunction/ai": "2.37.1",
     "@memberjunction/global": "2.37.1",
-    "groq-sdk": "0.15.0"
+    "groq-sdk": "0.21.0"
   }
 }

--- a/packages/AI/Providers/Mistral/package.json
+++ b/packages/AI/Providers/Mistral/package.json
@@ -21,7 +21,7 @@
   "dependencies": {
     "@memberjunction/ai": "2.37.1",
     "@memberjunction/global": "2.37.1",
-    "@mistralai/mistralai": "^1.5.0",
+    "@mistralai/mistralai": "^1.6.0",
     "axios-retry": "4.3.0"
   }
 }


### PR DESCRIPTION
- **Add initial implementation of Google's Agent-to-Agent (A2A) protocol server**
- **Refactor A2A server with user configuration and EntityOperations class**
- **docs(changeset): Preliminary A2A (AI Agent protocol standard from Google) implementation**
- **updated package description**
- **feat(ai-cerebras): Add Cerebras AI provider implementation**
- **chore: Update Cerebras provider version to 2.37.1**
- **updated package-lock.json**
- **2.38 migration script**
- **docs(changeset): flagging this package to trigger a minor version bump. No actual code changes, but we have a new migration file to clean up and add new AI models**
- **docs(changeset): Update to use new google gen ai library**
- **feat(ai-gemini): Migrate to official @google/genai SDK from @google/generative-ai**
- **Mistral package updates**
- **docs(changeset): update to latest mistral SDK**
- **feat(ai-groq): Update Groq SDK from 0.15.0 to 0.21.0**
- **package lock update**
- **docs(changeset): updated to latest Groq SDK**
