### PR TITLE
Add LLM prompt caching support

### DIFF
--- a/packages/AI/Core/src/generic/chat.types.ts
+++ b/packages/AI/Core/src/generic/chat.types.ts
@@ -101,6 +101,17 @@ export class ChatParams extends BaseParams  {
      * If the model supports effort levels, this parameter can be used to specify the effort level.
      */
     effortLevel?: string;
+    
+    /**
+     * Whether to enable caching for this request.
+     * Implementation depends on the specific provider (the below are examples, many other providers exist):
+     * - For Anthropic: Uses Anthropic's ephemeral cache control to cache system prompt and last user message.
+     * - For OpenAI: Uses automatic caching (provider handles it).
+     * - For other providers: May be a no-op if caching isn't supported.
+     * 
+     * @default true - Caching is enabled by default for providers that support it.
+     */
+    enableCaching?: boolean = true;
 }
 /**
  * Returns the first user message from the chat params
@@ -130,9 +141,29 @@ export type ChatResultData = {
     usage: ModelUsage
 }
 
+/**
+ * Cache metadata returned from the provider
+ */
+export interface CacheMetadata {
+    /**
+     * Whether the request had a cache hit
+     */
+    cacheHit?: boolean;
+    
+    /**
+     * The number of tokens retrieved from cache
+     */
+    cachedTokenCount?: number;
+}
+
 export class ChatResult extends BaseResult {
     data: ChatResultData;
     success: boolean;
-    statusText: string
+    statusText: string;
+    
+    /**
+     * Cache-related metadata if available from the provider
+     */
+    cacheInfo?: CacheMetadata;
 }
  


### PR DESCRIPTION
## Summary
- Added a new  parameter to ChatParams (defaulting to true)
- Added CacheMetadata interface and cacheInfo property to ChatResult
- Implemented Anthropic-specific caching using their ephemeral cache control API
- Applied caching to system messages and the last message in conversations
- Extract and expose cache hit information in responses

This feature allows for reduced token costs and improved performance in multi-turn conversations by caching repeated content across requests. The implementation is provider-specific but the API is consistent, allowing applications to enable/disable caching without provider-specific code.

## Test plan
- Successfully built all affected packages
- Manually tested the implementation to ensure it works correctly
- Verified that cache metadata is properly extracted from responses

This is particularly useful for applications with long multi-turn conversations or large system prompts, as it can significantly reduce costs and improve response times.