### PR TITLE
v2.39.0

### DIFF
--- a/.changeset/empty-turkeys-look.md
+++ b/.changeset/empty-turkeys-look.md
@@ -1,0 +1,6 @@
+---
+"@memberjunction/ai": minor
+"@memberjunction/ai-anthropic": minor
+---
+
+New Claude Models - bumping to 2.39.0

--- a/.changeset/fresh-camels-cross.md
+++ b/.changeset/fresh-camels-cross.md
@@ -1,0 +1,6 @@
+---
+"@memberjunction/ai-anthropic": patch
+"@memberjunction/ai-openai": patch
+---
+
+updated to include latest SDKs from openai/anthropic

--- a/.changeset/good-mangos-destroy.md
+++ b/.changeset/good-mangos-destroy.md
@@ -1,0 +1,6 @@
+---
+"@memberjunction/aiengine": patch
+"@memberjunction/server": patch
+---
+
+Various minor updates for Skip

--- a/.changeset/lazy-cameras-fly.md
+++ b/.changeset/lazy-cameras-fly.md
@@ -1,0 +1,5 @@
+---
+"@memberjunction/ng-skip-chat": patch
+---
+
+minor bug fixes

--- a/.changeset/lovely-tigers-look.md
+++ b/.changeset/lovely-tigers-look.md
@@ -1,0 +1,6 @@
+---
+"@memberjunction/ng-ask-skip": patch
+"@memberjunction/ng-skip-chat": patch
+---
+
+minor ui bug fix

--- a/.changeset/nervous-fans-clap.md
+++ b/.changeset/nervous-fans-clap.md
@@ -1,0 +1,5 @@
+---
+"@memberjunction/skip-types": patch
+---
+
+clean up types

--- a/.changeset/ninety-steaks-pretend.md
+++ b/.changeset/ninety-steaks-pretend.md
@@ -1,0 +1,5 @@
+---
+"@memberjunction/server": patch
+---
+
+minor bug fixes

--- a/.changeset/shy-files-cross.md
+++ b/.changeset/shy-files-cross.md
@@ -1,0 +1,7 @@
+---
+"@memberjunction/ng-core-entity-forms": patch
+"@memberjunction/core-entities": patch
+"@memberjunction/server": patch
+---
+
+Added SupportsEffortLevel to AIModels entity - generated artifacts to suit...

--- a/migrations/v2/V202505141505__v2.39.x_Claude_AI_Model_Updates.sql
+++ b/migrations/v2/V202505141505__v2.39.x_Claude_AI_Model_Updates.sql
@@ -1,0 +1,5 @@
+UPDATE ${flyway:defaultSchema}.AIModel SET APIName='claude-3-5-sonnet-latest' WHERE ID='5D218BCF-B7F6-439E-97FD-DC3A79432562'
+ 
+DELETE FROM ${flyway:defaultSchema}.AIModel WHERE ID ='5066433E-F36B-1410-8DA9-00021F8B792E'
+INSERT INTO ${flyway:defaultSchema}.AIModel ( ID, Name, Description, Vendor, AIModelTypeID, PowerRank, IsActive, DriverClass, APIName)  VALUES
+                         ( '5066433E-F36B-1410-8DA9-00021F8B792E', 'Claude 3.7 Sonnet','Claude 3.7 Sonnet','Anthropic','E8A5CCEC-6A37-EF11-86D4-000D3A4E707E',9,1,'AnthropicLLM','claude-3-7-sonnet-latest')

--- a/package-lock.json
+++ b/package-lock.json
@@ -15736,12 +15736,15 @@
       }
     },
     "node_modules/es-set-tostringtag": {
-      "version": "2.0.3",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+      "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
       "license": "MIT",
       "dependencies": {
-        "get-intrinsic": "^1.2.4",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6",
         "has-tostringtag": "^1.0.2",
-        "hasown": "^2.0.1"
+        "hasown": "^2.0.2"
       },
       "engines": {
         "node": ">= 0.4"
@@ -17588,6 +17591,48 @@
       "license": "MIT",
       "engines": {
         "node": "^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0"
+      }
+    },
+    "node_modules/graphql-request": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/graphql-request/-/graphql-request-5.2.0.tgz",
+      "integrity": "sha512-pLhKIvnMyBERL0dtFI3medKqWOz/RhHdcgbZ+hMMIb32mEPa5MJSzS4AuXxfI4sRAu6JVVk5tvXuGfCWl9JYWQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@graphql-typed-document-node/core": "^3.1.1",
+        "cross-fetch": "^3.1.5",
+        "extract-files": "^9.0.0",
+        "form-data": "^3.0.0"
+      },
+      "peerDependencies": {
+        "graphql": "14 - 16"
+      }
+    },
+    "node_modules/graphql-request/node_modules/extract-files": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/extract-files/-/extract-files-9.0.0.tgz",
+      "integrity": "sha512-CvdFfHkC95B4bBBk36hcEmvdR2awOdhhVUYH6S/zrVj3477zven/fJMYg7121h4T1xHZC+tetUpubpAhxwI7hQ==",
+      "license": "MIT",
+      "engines": {
+        "node": "^10.17.0 || ^12.0.0 || >= 13.7.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jaydenseric"
+      }
+    },
+    "node_modules/graphql-request/node_modules/form-data": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-3.0.3.tgz",
+      "integrity": "sha512-q5YBMeWy6E2Un0nMGWMgI65MAKtaylxfNJGJxpGh45YDciZB4epbWpaAfImil6CPAPTYB4sh0URQNDRIZG5F2w==",
+      "license": "MIT",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "mime-types": "^2.1.35"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/graphql-scalars": {
@@ -28910,13 +28955,13 @@
     "packages/Actions": {},
     "packages/Actions/ApolloEnrichment": {
       "name": "@memberjunction/actions-apollo",
-      "version": "2.37.1",
+      "version": "2.38.0",
       "license": "ISC",
       "dependencies": {
-        "@memberjunction/actions": "2.37.1",
-        "@memberjunction/core": "2.37.1",
-        "@memberjunction/core-entities": "2.37.1",
-        "@memberjunction/global": "2.37.1",
+        "@memberjunction/actions": "2.38.0",
+        "@memberjunction/core": "2.38.0",
+        "@memberjunction/core-entities": "2.38.0",
+        "@memberjunction/global": "2.38.0",
         "axios": "^1.7.2"
       },
       "devDependencies": {
@@ -28926,12 +28971,12 @@
     },
     "packages/Actions/Base": {
       "name": "@memberjunction/actions-base",
-      "version": "2.37.1",
+      "version": "2.38.0",
       "license": "ISC",
       "dependencies": {
-        "@memberjunction/core": "2.37.1",
-        "@memberjunction/core-entities": "2.37.1",
-        "@memberjunction/global": "2.37.1"
+        "@memberjunction/core": "2.38.0",
+        "@memberjunction/core-entities": "2.38.0",
+        "@memberjunction/global": "2.38.0"
       },
       "devDependencies": {
         "ts-node-dev": "^2.0.0",
@@ -28940,15 +28985,15 @@
     },
     "packages/Actions/ContentAutotag": {
       "name": "@memberjunction/actions-content-autotag",
-      "version": "2.37.1",
+      "version": "2.38.0",
       "license": "ISC",
       "dependencies": {
-        "@memberjunction/actions": "2.37.1",
-        "@memberjunction/content-autotagging": "2.37.1",
-        "@memberjunction/core": "2.37.1",
-        "@memberjunction/core-actions": "2.37.1",
-        "@memberjunction/core-entities": "2.37.1",
-        "@memberjunction/global": "2.37.1",
+        "@memberjunction/actions": "2.38.0",
+        "@memberjunction/content-autotagging": "2.38.0",
+        "@memberjunction/core": "2.38.0",
+        "@memberjunction/core-actions": "2.38.0",
+        "@memberjunction/core-entities": "2.38.0",
+        "@memberjunction/global": "2.38.0",
         "axios": "^1.7.2"
       },
       "devDependencies": {
@@ -28958,17 +29003,17 @@
     },
     "packages/Actions/CoreActions": {
       "name": "@memberjunction/core-actions",
-      "version": "2.37.1",
+      "version": "2.38.0",
       "license": "ISC",
       "dependencies": {
-        "@memberjunction/actions": "2.37.1",
-        "@memberjunction/ai-vector-sync": "2.37.1",
-        "@memberjunction/communication-engine": "2.37.1",
-        "@memberjunction/content-autotagging": "2.37.1",
-        "@memberjunction/core": "2.37.1",
-        "@memberjunction/core-entities": "2.37.1",
-        "@memberjunction/external-change-detection": "2.37.1",
-        "@memberjunction/global": "2.37.1"
+        "@memberjunction/actions": "2.38.0",
+        "@memberjunction/ai-vector-sync": "2.38.0",
+        "@memberjunction/communication-engine": "2.38.0",
+        "@memberjunction/content-autotagging": "2.38.0",
+        "@memberjunction/core": "2.38.0",
+        "@memberjunction/core-entities": "2.38.0",
+        "@memberjunction/external-change-detection": "2.38.0",
+        "@memberjunction/global": "2.38.0"
       },
       "devDependencies": {
         "ts-node-dev": "^2.0.0",
@@ -28977,16 +29022,16 @@
     },
     "packages/Actions/Engine": {
       "name": "@memberjunction/actions",
-      "version": "2.37.1",
+      "version": "2.38.0",
       "license": "ISC",
       "dependencies": {
-        "@memberjunction/actions-base": "2.37.1",
-        "@memberjunction/ai": "2.37.1",
-        "@memberjunction/aiengine": "2.37.1",
-        "@memberjunction/core": "2.37.1",
-        "@memberjunction/core-entities": "2.37.1",
-        "@memberjunction/doc-utils": "2.37.1",
-        "@memberjunction/global": "2.37.1"
+        "@memberjunction/actions-base": "2.38.0",
+        "@memberjunction/ai": "2.38.0",
+        "@memberjunction/aiengine": "2.38.0",
+        "@memberjunction/core": "2.38.0",
+        "@memberjunction/core-entities": "2.38.0",
+        "@memberjunction/doc-utils": "2.38.0",
+        "@memberjunction/global": "2.38.0"
       },
       "devDependencies": {
         "ts-node-dev": "^2.0.0",
@@ -29059,15 +29104,15 @@
     },
     "packages/Actions/ScheduledActions": {
       "name": "@memberjunction/scheduled-actions",
-      "version": "2.37.1",
+      "version": "2.38.0",
       "license": "ISC",
       "dependencies": {
-        "@memberjunction/actions": "2.37.1",
-        "@memberjunction/core": "2.37.1",
-        "@memberjunction/core-actions": "2.37.1",
-        "@memberjunction/core-entities": "2.37.1",
-        "@memberjunction/global": "2.37.1",
-        "@memberjunction/sqlserver-dataprovider": "2.37.1",
+        "@memberjunction/actions": "2.38.0",
+        "@memberjunction/core": "2.38.0",
+        "@memberjunction/core-actions": "2.38.0",
+        "@memberjunction/core-entities": "2.38.0",
+        "@memberjunction/global": "2.38.0",
+        "@memberjunction/sqlserver-dataprovider": "2.38.0",
         "cron-parser": "^4.9.0"
       },
       "devDependencies": {
@@ -29077,19 +29122,19 @@
     },
     "packages/Actions/ScheduledActionsServer": {
       "name": "@memberjunction/scheduled-actions-server",
-      "version": "2.37.1",
+      "version": "2.38.0",
       "license": "ISC",
       "dependencies": {
-        "@memberjunction/actions": "2.37.1",
-        "@memberjunction/actions-content-autotag": "2.37.1",
-        "@memberjunction/ai": "2.37.1",
-        "@memberjunction/ai-mistral": "2.37.1",
-        "@memberjunction/ai-openai": "2.37.1",
-        "@memberjunction/ai-vector-sync": "2.37.1",
-        "@memberjunction/ai-vectors-pinecone": "2.37.1",
-        "@memberjunction/core": "2.37.1",
-        "@memberjunction/core-entities": "2.37.1",
-        "@memberjunction/scheduled-actions": "2.37.1",
+        "@memberjunction/actions": "2.38.0",
+        "@memberjunction/actions-content-autotag": "2.38.0",
+        "@memberjunction/ai": "2.38.0",
+        "@memberjunction/ai-mistral": "2.38.0",
+        "@memberjunction/ai-openai": "2.38.0",
+        "@memberjunction/ai-vector-sync": "2.38.0",
+        "@memberjunction/ai-vectors-pinecone": "2.38.0",
+        "@memberjunction/core": "2.38.0",
+        "@memberjunction/core-entities": "2.38.0",
+        "@memberjunction/scheduled-actions": "2.38.0",
         "@types/axios": "^0.14.0",
         "env-var": "^7.3.0",
         "express": "^4.18.2",
@@ -29115,12 +29160,12 @@
     },
     "packages/AI/A2AServer": {
       "name": "@memberjunction/a2aserver",
-      "version": "0.1.0",
+      "version": "2.38.0",
       "license": "MIT",
       "dependencies": {
-        "@memberjunction/core": "^0.9.127",
-        "@memberjunction/global": "^0.9.125",
-        "@memberjunction/sqlserver-dataprovider": "^0.9.161",
+        "@memberjunction/core": "^2.38.0",
+        "@memberjunction/global": "^2.38.0",
+        "@memberjunction/sqlserver-dataprovider": "^2.38.0",
         "cosmiconfig": "^8.0.0",
         "dotenv": "^16.0.3",
         "express": "^4.18.2",
@@ -29221,15 +29266,6 @@
         "typeorm": "^0.3.16"
       }
     },
-    "packages/AI/A2AServer/node_modules/@memberjunction/core": {
-      "version": "0.9.188",
-      "resolved": "https://registry.npmjs.org/@memberjunction/core/-/core-0.9.188.tgz",
-      "integrity": "sha512-HYZfBy3abZTpnG3l3QQFqUo4a3JEzF+R7Fstc4K3LRTw/sAWb1RohyXI3jEmii+VjHC2RCOB9h6qe+vWQa2ZzA==",
-      "license": "ISC",
-      "dependencies": {
-        "@memberjunction/global": "^0.9.168"
-      }
-    },
     "packages/AI/A2AServer/node_modules/@memberjunction/core-entities": {
       "version": "0.9.185",
       "resolved": "https://registry.npmjs.org/@memberjunction/core-entities/-/core-entities-0.9.185.tgz",
@@ -29238,15 +29274,6 @@
       "dependencies": {
         "@memberjunction/core": "^0.9.188",
         "@memberjunction/global": "^0.9.168"
-      }
-    },
-    "packages/AI/A2AServer/node_modules/@memberjunction/global": {
-      "version": "0.9.168",
-      "resolved": "https://registry.npmjs.org/@memberjunction/global/-/global-0.9.168.tgz",
-      "integrity": "sha512-P7XDfcIxp5CdQu7FDQxUMqnH44DCdKyWqUGglJM9kCqKZkl396v1hB40A9THhkexmc5hZU+fnhvrr6ORmpmvOA==",
-      "license": "ISC",
-      "dependencies": {
-        "rxjs": "^7.8.1"
       }
     },
     "packages/AI/A2AServer/node_modules/@memberjunction/queue": {
@@ -29261,23 +29288,6 @@
         "@memberjunction/global": "^0.9.168",
         "@types/uuid": "^9.0.1",
         "uuid": "^9.0.0"
-      }
-    },
-    "packages/AI/A2AServer/node_modules/@memberjunction/sqlserver-dataprovider": {
-      "version": "0.9.222",
-      "resolved": "https://registry.npmjs.org/@memberjunction/sqlserver-dataprovider/-/sqlserver-dataprovider-0.9.222.tgz",
-      "integrity": "sha512-KP7a4RqSlXyzwkukkXZqKtqnhZ9/PtVORJgo6inFTAJc7KZZzOi7DlXYdSl7Jy+9POVeYHls9ha/ydW9jSbBxQ==",
-      "license": "ISC",
-      "dependencies": {
-        "@memberjunction/ai": "^0.9.171",
-        "@memberjunction/ai-vector-dupe": "^0.9.38",
-        "@memberjunction/aiengine": "^0.9.86",
-        "@memberjunction/core": "^0.9.188",
-        "@memberjunction/core-entities": "^0.9.185",
-        "@memberjunction/global": "^0.9.168",
-        "@memberjunction/queue": "^0.9.208",
-        "mssql": "^10.0.2",
-        "typeorm": "^0.3.20"
       }
     },
     "packages/AI/A2AServer/node_modules/@types/node": {
@@ -29337,10 +29347,10 @@
     },
     "packages/AI/Core": {
       "name": "@memberjunction/ai",
-      "version": "2.37.1",
+      "version": "2.38.0",
       "license": "ISC",
       "dependencies": {
-        "@memberjunction/global": "2.37.1",
+        "@memberjunction/global": "2.38.0",
         "dotenv": "^16.4.1",
         "rxjs": "^7.8.1",
         "typeorm": "^0.3.20"
@@ -29353,13 +29363,13 @@
     },
     "packages/AI/Engine": {
       "name": "@memberjunction/aiengine",
-      "version": "2.37.1",
+      "version": "2.38.0",
       "license": "ISC",
       "dependencies": {
-        "@memberjunction/ai": "2.37.1",
-        "@memberjunction/core": "2.37.1",
-        "@memberjunction/core-entities": "2.37.1",
-        "@memberjunction/global": "2.37.1",
+        "@memberjunction/ai": "2.38.0",
+        "@memberjunction/core": "2.38.0",
+        "@memberjunction/core-entities": "2.38.0",
+        "@memberjunction/global": "2.38.0",
         "dotenv": "^16.4.1",
         "rxjs": "^7.8.1"
       },
@@ -29371,13 +29381,13 @@
     },
     "packages/AI/MCPServer": {
       "name": "@memberjunction/ai-mcp-server",
-      "version": "2.37.1",
+      "version": "2.38.0",
       "license": "ISC",
       "dependencies": {
-        "@memberjunction/core": "2.37.1",
-        "@memberjunction/core-entities": "2.37.1",
-        "@memberjunction/global": "2.37.1",
-        "@memberjunction/sqlserver-dataprovider": "2.37.1",
+        "@memberjunction/core": "2.38.0",
+        "@memberjunction/core-entities": "2.38.0",
+        "@memberjunction/global": "2.38.0",
+        "@memberjunction/sqlserver-dataprovider": "2.38.0",
         "@modelcontextprotocol/sdk": "^1.8.0",
         "cosmiconfig": "9.0.0",
         "dotenv": "^16.4.1",
@@ -29396,12 +29406,12 @@
     },
     "packages/AI/Providers/Anthropic": {
       "name": "@memberjunction/ai-anthropic",
-      "version": "2.37.1",
+      "version": "2.38.0",
       "license": "ISC",
       "dependencies": {
         "@anthropic-ai/sdk": "0.50.4",
-        "@memberjunction/ai": "2.37.1",
-        "@memberjunction/global": "2.37.1"
+        "@memberjunction/ai": "2.38.0",
+        "@memberjunction/global": "2.38.0"
       },
       "devDependencies": {
         "ts-node-dev": "^2.0.0",
@@ -29422,7 +29432,7 @@
     },
     "packages/AI/Providers/Azure": {
       "name": "@memberjunction/ai-azure",
-      "version": "2.37.1",
+      "version": "2.38.0",
       "license": "MIT",
       "dependencies": {
         "@azure-rest/ai-inference": "^1.0.0-beta.6",
@@ -29577,11 +29587,11 @@
     },
     "packages/AI/Providers/BettyBot": {
       "name": "@memberjunction/ai-betty-bot",
-      "version": "2.37.1",
+      "version": "2.38.0",
       "license": "ISC",
       "dependencies": {
-        "@memberjunction/ai": "2.37.1",
-        "@memberjunction/global": "2.37.1",
+        "@memberjunction/ai": "2.38.0",
+        "@memberjunction/global": "2.38.0",
         "axios": "^1.7.7",
         "axios-retry": "^4.3.0",
         "env-var": "^7.5.0"
@@ -29593,12 +29603,12 @@
     },
     "packages/AI/Providers/Cerebras": {
       "name": "@memberjunction/ai-cerebras",
-      "version": "2.37.1",
+      "version": "2.38.0",
       "license": "ISC",
       "dependencies": {
         "@cerebras/cerebras_cloud_sdk": "^1.29.0",
-        "@memberjunction/ai": "2.37.1",
-        "@memberjunction/global": "2.37.1"
+        "@memberjunction/ai": "2.38.0",
+        "@memberjunction/global": "2.38.0"
       },
       "devDependencies": {
         "ts-node-dev": "^2.0.0",
@@ -29607,11 +29617,11 @@
     },
     "packages/AI/Providers/ElevenLabs": {
       "name": "@memberjunction/ai-elevenlabs",
-      "version": "2.37.1",
+      "version": "2.38.0",
       "license": "ISC",
       "dependencies": {
-        "@memberjunction/ai": "2.37.1",
-        "@memberjunction/global": "2.37.1",
+        "@memberjunction/ai": "2.38.0",
+        "@memberjunction/global": "2.38.0",
         "elevenlabs": "^1.51.0"
       },
       "devDependencies": {
@@ -29621,12 +29631,12 @@
     },
     "packages/AI/Providers/Gemini": {
       "name": "@memberjunction/ai-gemini",
-      "version": "2.37.1",
+      "version": "2.38.0",
       "license": "ISC",
       "dependencies": {
         "@google/genai": "0.14.0",
-        "@memberjunction/ai": "2.37.1",
-        "@memberjunction/global": "2.37.1"
+        "@memberjunction/ai": "2.38.0",
+        "@memberjunction/global": "2.38.0"
       },
       "devDependencies": {
         "ts-node-dev": "^2.0.0",
@@ -29635,11 +29645,11 @@
     },
     "packages/AI/Providers/Groq": {
       "name": "@memberjunction/ai-groq",
-      "version": "2.37.1",
+      "version": "2.38.0",
       "license": "ISC",
       "dependencies": {
-        "@memberjunction/ai": "2.37.1",
-        "@memberjunction/global": "2.37.1",
+        "@memberjunction/ai": "2.38.0",
+        "@memberjunction/global": "2.38.0",
         "groq-sdk": "0.21.0"
       },
       "devDependencies": {
@@ -29673,11 +29683,11 @@
     },
     "packages/AI/Providers/HeyGen": {
       "name": "@memberjunction/ai-heygen",
-      "version": "2.37.1",
+      "version": "2.38.0",
       "license": "ISC",
       "dependencies": {
-        "@memberjunction/ai": "2.37.1",
-        "@memberjunction/global": "2.37.1",
+        "@memberjunction/ai": "2.38.0",
+        "@memberjunction/global": "2.38.0",
         "elevenlabs": "^1.51.0"
       },
       "devDependencies": {
@@ -29687,11 +29697,11 @@
     },
     "packages/AI/Providers/Mistral": {
       "name": "@memberjunction/ai-mistral",
-      "version": "2.37.1",
+      "version": "2.38.0",
       "license": "ISC",
       "dependencies": {
-        "@memberjunction/ai": "2.37.1",
-        "@memberjunction/global": "2.37.1",
+        "@memberjunction/ai": "2.38.0",
+        "@memberjunction/global": "2.38.0",
         "@mistralai/mistralai": "^1.6.0",
         "axios-retry": "4.3.0"
       },
@@ -29725,11 +29735,11 @@
     },
     "packages/AI/Providers/OpenAI": {
       "name": "@memberjunction/ai-openai",
-      "version": "2.37.1",
+      "version": "2.38.0",
       "license": "ISC",
       "dependencies": {
-        "@memberjunction/ai": "2.37.1",
-        "@memberjunction/global": "2.37.1",
+        "@memberjunction/ai": "2.38.0",
+        "@memberjunction/global": "2.38.0",
         "openai": "4.98.0"
       },
       "devDependencies": {
@@ -29801,12 +29811,12 @@
     },
     "packages/AI/Providers/Recommendations-Rex": {
       "name": "@memberjunction/ai-recommendations-rex",
-      "version": "2.37.1",
+      "version": "2.38.0",
       "license": "ISC",
       "dependencies": {
-        "@memberjunction/ai": "2.37.1",
-        "@memberjunction/ai-recommendations": "2.37.1",
-        "@memberjunction/global": "2.37.1",
+        "@memberjunction/ai": "2.38.0",
+        "@memberjunction/ai-recommendations": "2.38.0",
+        "@memberjunction/global": "2.38.0",
         "axios": "^1.7.2",
         "dotenv": "^16.4.1",
         "openai": "^4.28.4"
@@ -29818,13 +29828,13 @@
     },
     "packages/AI/Providers/Vectors-Pinecone": {
       "name": "@memberjunction/ai-vectors-pinecone",
-      "version": "2.37.1",
+      "version": "2.38.0",
       "license": "ISC",
       "dependencies": {
-        "@memberjunction/ai-vectors": "2.37.1",
-        "@memberjunction/aiengine": "2.37.1",
-        "@memberjunction/core": "2.37.1",
-        "@memberjunction/global": "2.37.1",
+        "@memberjunction/ai-vectors": "2.38.0",
+        "@memberjunction/aiengine": "2.38.0",
+        "@memberjunction/core": "2.38.0",
+        "@memberjunction/global": "2.38.0",
         "@pinecone-database/pinecone": "2.2.2",
         "dotenv": "^16.4.1",
         "openai": "^4.28.4",
@@ -29839,13 +29849,13 @@
     },
     "packages/AI/Recommendations/Engine": {
       "name": "@memberjunction/ai-recommendations",
-      "version": "2.37.1",
+      "version": "2.38.0",
       "license": "ISC",
       "dependencies": {
-        "@memberjunction/ai": "2.37.1",
-        "@memberjunction/core": "2.37.1",
-        "@memberjunction/core-entities": "2.37.1",
-        "@memberjunction/global": "2.37.1"
+        "@memberjunction/ai": "2.38.0",
+        "@memberjunction/core": "2.38.0",
+        "@memberjunction/core-entities": "2.38.0",
+        "@memberjunction/global": "2.38.0"
       },
       "devDependencies": {
         "ts-node-dev": "^2.0.0",
@@ -29854,15 +29864,15 @@
     },
     "packages/AI/Vectors/Core": {
       "name": "@memberjunction/ai-vectors",
-      "version": "2.37.1",
+      "version": "2.38.0",
       "license": "ISC",
       "dependencies": {
-        "@memberjunction/ai": "2.37.1",
-        "@memberjunction/ai-vectordb": "2.37.1",
-        "@memberjunction/aiengine": "2.37.1",
-        "@memberjunction/core": "2.37.1",
-        "@memberjunction/core-entities": "2.37.1",
-        "@memberjunction/global": "2.37.1",
+        "@memberjunction/ai": "2.38.0",
+        "@memberjunction/ai-vectordb": "2.38.0",
+        "@memberjunction/aiengine": "2.38.0",
+        "@memberjunction/core": "2.38.0",
+        "@memberjunction/core-entities": "2.38.0",
+        "@memberjunction/global": "2.38.0",
         "dotenv": "^16.4.1",
         "openai": "^4.28.4"
       },
@@ -29874,11 +29884,11 @@
     },
     "packages/AI/Vectors/Database": {
       "name": "@memberjunction/ai-vectordb",
-      "version": "2.37.1",
+      "version": "2.38.0",
       "license": "ISC",
       "dependencies": {
-        "@memberjunction/core": "2.37.1",
-        "@memberjunction/global": "2.37.1",
+        "@memberjunction/core": "2.38.0",
+        "@memberjunction/global": "2.38.0",
         "dotenv": "^16.4.1"
       },
       "devDependencies": {
@@ -29889,18 +29899,18 @@
     },
     "packages/AI/Vectors/Dupe": {
       "name": "@memberjunction/ai-vector-dupe",
-      "version": "2.37.1",
+      "version": "2.38.0",
       "license": "ISC",
       "dependencies": {
-        "@memberjunction/ai": "2.37.1",
-        "@memberjunction/ai-vector-sync": "2.37.1",
-        "@memberjunction/ai-vectordb": "2.37.1",
-        "@memberjunction/ai-vectors": "2.37.1",
-        "@memberjunction/ai-vectors-pinecone": "2.37.1",
-        "@memberjunction/aiengine": "2.37.1",
-        "@memberjunction/core": "2.37.1",
-        "@memberjunction/core-entities": "2.37.1",
-        "@memberjunction/global": "2.37.1",
+        "@memberjunction/ai": "2.38.0",
+        "@memberjunction/ai-vector-sync": "2.38.0",
+        "@memberjunction/ai-vectordb": "2.38.0",
+        "@memberjunction/ai-vectors": "2.38.0",
+        "@memberjunction/ai-vectors-pinecone": "2.38.0",
+        "@memberjunction/aiengine": "2.38.0",
+        "@memberjunction/core": "2.38.0",
+        "@memberjunction/core-entities": "2.38.0",
+        "@memberjunction/global": "2.38.0",
         "dotenv": "^16.4.1",
         "typeorm": "^0.3.20"
       },
@@ -29913,20 +29923,20 @@
     },
     "packages/AI/Vectors/Sync": {
       "name": "@memberjunction/ai-vector-sync",
-      "version": "2.37.1",
+      "version": "2.38.0",
       "license": "ISC",
       "dependencies": {
-        "@memberjunction/ai": "2.37.1",
-        "@memberjunction/ai-mistral": "2.37.1",
-        "@memberjunction/ai-openai": "2.37.1",
-        "@memberjunction/ai-vectordb": "2.37.1",
-        "@memberjunction/ai-vectors": "2.37.1",
-        "@memberjunction/ai-vectors-pinecone": "2.37.1",
-        "@memberjunction/aiengine": "2.37.1",
-        "@memberjunction/core": "2.37.1",
-        "@memberjunction/global": "2.37.1",
-        "@memberjunction/templates": "2.37.1",
-        "@memberjunction/templates-base-types": "2.37.1",
+        "@memberjunction/ai": "2.38.0",
+        "@memberjunction/ai-mistral": "2.38.0",
+        "@memberjunction/ai-openai": "2.38.0",
+        "@memberjunction/ai-vectordb": "2.38.0",
+        "@memberjunction/ai-vectors": "2.38.0",
+        "@memberjunction/ai-vectors-pinecone": "2.38.0",
+        "@memberjunction/aiengine": "2.38.0",
+        "@memberjunction/core": "2.38.0",
+        "@memberjunction/global": "2.38.0",
+        "@memberjunction/templates": "2.38.0",
+        "@memberjunction/templates-base-types": "2.38.0",
         "dotenv": "^16.4.1",
         "typeorm": "^0.3.20"
       },
@@ -29939,22 +29949,22 @@
     },
     "packages/Angular/Explorer/ask-skip": {
       "name": "@memberjunction/ng-ask-skip",
-      "version": "2.37.1",
+      "version": "2.38.0",
       "license": "ISC",
       "dependencies": {
         "@angular/cdk": "18.0.2",
-        "@memberjunction/core": "2.37.1",
-        "@memberjunction/core-entities": "2.37.1",
-        "@memberjunction/global": "2.37.1",
-        "@memberjunction/graphql-dataprovider": "2.37.1",
-        "@memberjunction/ng-chat": "2.37.1",
-        "@memberjunction/ng-container-directives": "2.37.1",
-        "@memberjunction/ng-data-context": "2.37.1",
-        "@memberjunction/ng-shared": "2.37.1",
-        "@memberjunction/ng-skip-chat": "2.37.1",
-        "@memberjunction/ng-tabstrip": "2.37.1",
-        "@memberjunction/ng-user-view-grid": "2.37.1",
-        "@memberjunction/skip-types": "2.37.1",
+        "@memberjunction/core": "2.38.0",
+        "@memberjunction/core-entities": "2.38.0",
+        "@memberjunction/global": "2.38.0",
+        "@memberjunction/graphql-dataprovider": "2.38.0",
+        "@memberjunction/ng-chat": "2.38.0",
+        "@memberjunction/ng-container-directives": "2.38.0",
+        "@memberjunction/ng-data-context": "2.38.0",
+        "@memberjunction/ng-shared": "2.38.0",
+        "@memberjunction/ng-skip-chat": "2.38.0",
+        "@memberjunction/ng-tabstrip": "2.38.0",
+        "@memberjunction/ng-user-view-grid": "2.38.0",
+        "@memberjunction/skip-types": "2.38.0",
         "@progress/kendo-angular-dialog": "16.2.0",
         "@progress/kendo-angular-filter": "16.2.0",
         "@progress/kendo-angular-grid": "16.2.0",
@@ -30015,10 +30025,10 @@
     },
     "packages/Angular/Explorer/auth-services": {
       "name": "@memberjunction/ng-auth-services",
-      "version": "2.37.1",
+      "version": "2.38.0",
       "license": "ISC",
       "dependencies": {
-        "@memberjunction/core": "2.37.1",
+        "@memberjunction/core": "2.38.0",
         "tslib": "^2.3.0"
       },
       "devDependencies": {
@@ -30036,18 +30046,18 @@
     },
     "packages/Angular/Explorer/base-forms": {
       "name": "@memberjunction/ng-base-forms",
-      "version": "2.37.1",
+      "version": "2.38.0",
       "license": "ISC",
       "dependencies": {
-        "@memberjunction/core": "2.37.1",
-        "@memberjunction/global": "2.37.1",
-        "@memberjunction/ng-base-types": "2.37.1",
-        "@memberjunction/ng-code-editor": "2.37.1",
-        "@memberjunction/ng-container-directives": "2.37.1",
-        "@memberjunction/ng-link-directives": "2.37.1",
-        "@memberjunction/ng-record-changes": "2.37.1",
-        "@memberjunction/ng-shared": "2.37.1",
-        "@memberjunction/ng-tabstrip": "2.37.1",
+        "@memberjunction/core": "2.38.0",
+        "@memberjunction/global": "2.38.0",
+        "@memberjunction/ng-base-types": "2.38.0",
+        "@memberjunction/ng-code-editor": "2.38.0",
+        "@memberjunction/ng-container-directives": "2.38.0",
+        "@memberjunction/ng-link-directives": "2.38.0",
+        "@memberjunction/ng-record-changes": "2.38.0",
+        "@memberjunction/ng-shared": "2.38.0",
+        "@memberjunction/ng-tabstrip": "2.38.0",
         "@progress/kendo-angular-buttons": "16.2.0",
         "@progress/kendo-angular-dateinputs": "16.2.0",
         "@progress/kendo-angular-dialog": "16.2.0",
@@ -30103,11 +30113,11 @@
     },
     "packages/Angular/Explorer/compare-records": {
       "name": "@memberjunction/ng-compare-records",
-      "version": "2.37.1",
+      "version": "2.38.0",
       "license": "ISC",
       "dependencies": {
-        "@memberjunction/core": "2.37.1",
-        "@memberjunction/core-entities": "2.37.1",
+        "@memberjunction/core": "2.38.0",
+        "@memberjunction/core-entities": "2.38.0",
         "@progress/kendo-angular-grid": "16.2.0",
         "tslib": "^2.3.0"
       },
@@ -30126,19 +30136,19 @@
     },
     "packages/Angular/Explorer/core-entity-forms": {
       "name": "@memberjunction/ng-core-entity-forms",
-      "version": "2.37.1",
+      "version": "2.38.0",
       "license": "ISC",
       "dependencies": {
-        "@memberjunction/core": "2.37.1",
-        "@memberjunction/core-entities": "2.37.1",
-        "@memberjunction/ng-base-forms": "2.37.1",
-        "@memberjunction/ng-code-editor": "2.37.1",
-        "@memberjunction/ng-container-directives": "2.37.1",
-        "@memberjunction/ng-explorer-core": "2.37.1",
-        "@memberjunction/ng-form-toolbar": "2.37.1",
-        "@memberjunction/ng-join-grid": "2.37.1",
-        "@memberjunction/ng-tabstrip": "2.37.1",
-        "@memberjunction/ng-timeline": "2.37.1",
+        "@memberjunction/core": "2.38.0",
+        "@memberjunction/core-entities": "2.38.0",
+        "@memberjunction/ng-base-forms": "2.38.0",
+        "@memberjunction/ng-code-editor": "2.38.0",
+        "@memberjunction/ng-container-directives": "2.38.0",
+        "@memberjunction/ng-explorer-core": "2.38.0",
+        "@memberjunction/ng-form-toolbar": "2.38.0",
+        "@memberjunction/ng-join-grid": "2.38.0",
+        "@memberjunction/ng-tabstrip": "2.38.0",
+        "@memberjunction/ng-timeline": "2.38.0",
         "@progress/kendo-angular-dropdowns": "16.2.0",
         "@progress/kendo-angular-grid": "16.2.0",
         "tslib": "^2.3.0"
@@ -30179,15 +30189,15 @@
     },
     "packages/Angular/Explorer/entity-form-dialog": {
       "name": "@memberjunction/ng-entity-form-dialog",
-      "version": "2.37.1",
+      "version": "2.38.0",
       "license": "ISC",
       "dependencies": {
-        "@memberjunction/core": "2.37.1",
-        "@memberjunction/core-entities": "2.37.1",
-        "@memberjunction/global": "2.37.1",
-        "@memberjunction/ng-base-forms": "2.37.1",
-        "@memberjunction/ng-container-directives": "2.37.1",
-        "@memberjunction/ng-shared": "2.37.1",
+        "@memberjunction/core": "2.38.0",
+        "@memberjunction/core-entities": "2.38.0",
+        "@memberjunction/global": "2.38.0",
+        "@memberjunction/ng-base-forms": "2.38.0",
+        "@memberjunction/ng-container-directives": "2.38.0",
+        "@memberjunction/ng-shared": "2.38.0",
         "@progress/kendo-angular-buttons": "16.2.0",
         "@progress/kendo-angular-dialog": "16.2.0",
         "tslib": "^2.3.0"
@@ -30205,14 +30215,14 @@
     },
     "packages/Angular/Explorer/entity-permissions": {
       "name": "@memberjunction/ng-entity-permissions",
-      "version": "2.37.1",
+      "version": "2.38.0",
       "license": "ISC",
       "dependencies": {
-        "@memberjunction/core": "2.37.1",
-        "@memberjunction/core-entities": "2.37.1",
-        "@memberjunction/global": "2.37.1",
-        "@memberjunction/ng-container-directives": "2.37.1",
-        "@memberjunction/ng-shared": "2.37.1",
+        "@memberjunction/core": "2.38.0",
+        "@memberjunction/core-entities": "2.38.0",
+        "@memberjunction/global": "2.38.0",
+        "@memberjunction/ng-container-directives": "2.38.0",
+        "@memberjunction/ng-shared": "2.38.0",
         "@progress/kendo-angular-buttons": "16.2.0",
         "@progress/kendo-angular-dialog": "16.2.0",
         "@progress/kendo-angular-dropdowns": "16.2.0",
@@ -30233,32 +30243,32 @@
     },
     "packages/Angular/Explorer/explorer-core": {
       "name": "@memberjunction/ng-explorer-core",
-      "version": "2.37.1",
+      "version": "2.38.0",
       "license": "ISC",
       "dependencies": {
-        "@memberjunction/communication-types": "2.37.1",
-        "@memberjunction/core": "2.37.1",
-        "@memberjunction/core-entities": "2.37.1",
-        "@memberjunction/entity-communications-client": "2.37.1",
-        "@memberjunction/global": "2.37.1",
-        "@memberjunction/ng-ask-skip": "2.37.1",
-        "@memberjunction/ng-auth-services": "2.37.1",
-        "@memberjunction/ng-base-forms": "2.37.1",
-        "@memberjunction/ng-compare-records": "2.37.1",
-        "@memberjunction/ng-container-directives": "2.37.1",
-        "@memberjunction/ng-entity-form-dialog": "2.37.1",
-        "@memberjunction/ng-explorer-settings": "2.37.1",
-        "@memberjunction/ng-file-storage": "2.37.1",
-        "@memberjunction/ng-query-grid": "2.37.1",
-        "@memberjunction/ng-record-changes": "2.37.1",
-        "@memberjunction/ng-record-selector": "2.37.1",
-        "@memberjunction/ng-resource-permissions": "2.37.1",
-        "@memberjunction/ng-shared": "2.37.1",
-        "@memberjunction/ng-skip-chat": "2.37.1",
-        "@memberjunction/ng-tabstrip": "2.37.1",
-        "@memberjunction/ng-user-view-grid": "2.37.1",
-        "@memberjunction/ng-user-view-properties": "2.37.1",
-        "@memberjunction/templates-base-types": "2.37.1",
+        "@memberjunction/communication-types": "2.38.0",
+        "@memberjunction/core": "2.38.0",
+        "@memberjunction/core-entities": "2.38.0",
+        "@memberjunction/entity-communications-client": "2.38.0",
+        "@memberjunction/global": "2.38.0",
+        "@memberjunction/ng-ask-skip": "2.38.0",
+        "@memberjunction/ng-auth-services": "2.38.0",
+        "@memberjunction/ng-base-forms": "2.38.0",
+        "@memberjunction/ng-compare-records": "2.38.0",
+        "@memberjunction/ng-container-directives": "2.38.0",
+        "@memberjunction/ng-entity-form-dialog": "2.38.0",
+        "@memberjunction/ng-explorer-settings": "2.38.0",
+        "@memberjunction/ng-file-storage": "2.38.0",
+        "@memberjunction/ng-query-grid": "2.38.0",
+        "@memberjunction/ng-record-changes": "2.38.0",
+        "@memberjunction/ng-record-selector": "2.38.0",
+        "@memberjunction/ng-resource-permissions": "2.38.0",
+        "@memberjunction/ng-shared": "2.38.0",
+        "@memberjunction/ng-skip-chat": "2.38.0",
+        "@memberjunction/ng-tabstrip": "2.38.0",
+        "@memberjunction/ng-user-view-grid": "2.38.0",
+        "@memberjunction/ng-user-view-properties": "2.38.0",
+        "@memberjunction/templates-base-types": "2.38.0",
         "@progress/kendo-angular-buttons": "16.2.0",
         "@progress/kendo-angular-charts": "16.2.0",
         "@progress/kendo-angular-dialog": "16.2.0",
@@ -30286,21 +30296,21 @@
     },
     "packages/Angular/Explorer/explorer-settings": {
       "name": "@memberjunction/ng-explorer-settings",
-      "version": "2.37.1",
+      "version": "2.38.0",
       "license": "ISC",
       "dependencies": {
-        "@memberjunction/core": "2.37.1",
-        "@memberjunction/core-entities": "2.37.1",
-        "@memberjunction/global": "2.37.1",
-        "@memberjunction/ng-base-forms": "2.37.1",
-        "@memberjunction/ng-container-directives": "2.37.1",
-        "@memberjunction/ng-entity-form-dialog": "2.37.1",
-        "@memberjunction/ng-entity-permissions": "2.37.1",
-        "@memberjunction/ng-notifications": "2.37.1",
-        "@memberjunction/ng-shared": "2.37.1",
-        "@memberjunction/ng-simple-record-list": "2.37.1",
-        "@memberjunction/ng-tabstrip": "2.37.1",
-        "@memberjunction/ng-user-view-grid": "2.37.1",
+        "@memberjunction/core": "2.38.0",
+        "@memberjunction/core-entities": "2.38.0",
+        "@memberjunction/global": "2.38.0",
+        "@memberjunction/ng-base-forms": "2.38.0",
+        "@memberjunction/ng-container-directives": "2.38.0",
+        "@memberjunction/ng-entity-form-dialog": "2.38.0",
+        "@memberjunction/ng-entity-permissions": "2.38.0",
+        "@memberjunction/ng-notifications": "2.38.0",
+        "@memberjunction/ng-shared": "2.38.0",
+        "@memberjunction/ng-simple-record-list": "2.38.0",
+        "@memberjunction/ng-tabstrip": "2.38.0",
+        "@memberjunction/ng-user-view-grid": "2.38.0",
         "@progress/kendo-angular-buttons": "16.2.0",
         "@progress/kendo-angular-dialog": "16.2.0",
         "@progress/kendo-angular-dropdowns": "16.2.0",
@@ -30322,16 +30332,16 @@
     },
     "packages/Angular/Explorer/form-toolbar": {
       "name": "@memberjunction/ng-form-toolbar",
-      "version": "2.37.1",
+      "version": "2.38.0",
       "license": "ISC",
       "dependencies": {
-        "@memberjunction/core": "2.37.1",
-        "@memberjunction/global": "2.37.1",
-        "@memberjunction/ng-ask-skip": "2.37.1",
-        "@memberjunction/ng-base-forms": "2.37.1",
-        "@memberjunction/ng-container-directives": "2.37.1",
-        "@memberjunction/ng-record-changes": "2.37.1",
-        "@memberjunction/ng-shared": "2.37.1",
+        "@memberjunction/core": "2.38.0",
+        "@memberjunction/global": "2.38.0",
+        "@memberjunction/ng-ask-skip": "2.38.0",
+        "@memberjunction/ng-base-forms": "2.38.0",
+        "@memberjunction/ng-container-directives": "2.38.0",
+        "@memberjunction/ng-record-changes": "2.38.0",
+        "@memberjunction/ng-shared": "2.38.0",
         "@progress/kendo-angular-buttons": "16.2.0",
         "@progress/kendo-angular-dialog": "16.2.0",
         "ngx-markdown": "^18.0.0",
@@ -30383,10 +30393,10 @@
     },
     "packages/Angular/Explorer/link-directives": {
       "name": "@memberjunction/ng-link-directives",
-      "version": "2.37.1",
+      "version": "2.38.0",
       "license": "ISC",
       "dependencies": {
-        "@memberjunction/core": "2.37.1",
+        "@memberjunction/core": "2.38.0",
         "tslib": "^2.3.0"
       },
       "devDependencies": {
@@ -30401,15 +30411,15 @@
     },
     "packages/Angular/Explorer/list-detail-grid": {
       "name": "@memberjunction/ng-list-detail-grid",
-      "version": "2.37.1",
+      "version": "2.38.0",
       "license": "ISC",
       "dependencies": {
-        "@memberjunction/core": "2.37.1",
-        "@memberjunction/core-entities": "2.37.1",
-        "@memberjunction/global": "2.37.1",
-        "@memberjunction/ng-compare-records": "2.37.1",
-        "@memberjunction/ng-container-directives": "2.37.1",
-        "@memberjunction/ng-shared": "2.37.1",
+        "@memberjunction/core": "2.38.0",
+        "@memberjunction/core-entities": "2.38.0",
+        "@memberjunction/global": "2.38.0",
+        "@memberjunction/ng-compare-records": "2.38.0",
+        "@memberjunction/ng-container-directives": "2.38.0",
+        "@memberjunction/ng-shared": "2.38.0",
         "@progress/kendo-angular-buttons": "16.2.0",
         "@progress/kendo-angular-grid": "16.2.0",
         "@progress/kendo-angular-inputs": "16.2.0",
@@ -30429,13 +30439,13 @@
     },
     "packages/Angular/Explorer/record-changes": {
       "name": "@memberjunction/ng-record-changes",
-      "version": "2.37.1",
+      "version": "2.38.0",
       "license": "ISC",
       "dependencies": {
-        "@memberjunction/core": "2.37.1",
-        "@memberjunction/global": "2.37.1",
-        "@memberjunction/ng-compare-records": "2.37.1",
-        "@memberjunction/ng-container-directives": "2.37.1",
+        "@memberjunction/core": "2.38.0",
+        "@memberjunction/global": "2.38.0",
+        "@memberjunction/ng-compare-records": "2.38.0",
+        "@memberjunction/ng-container-directives": "2.38.0",
         "tslib": "^2.3.0"
       },
       "devDependencies": {
@@ -30483,14 +30493,14 @@
     },
     "packages/Angular/Explorer/shared": {
       "name": "@memberjunction/ng-shared",
-      "version": "2.37.1",
+      "version": "2.38.0",
       "license": "ISC",
       "dependencies": {
-        "@memberjunction/core": "2.37.1",
-        "@memberjunction/core-entities": "2.37.1",
-        "@memberjunction/graphql-dataprovider": "2.37.1",
-        "@memberjunction/ng-base-types": "2.37.1",
-        "@memberjunction/ng-notifications": "2.37.1",
+        "@memberjunction/core": "2.38.0",
+        "@memberjunction/core-entities": "2.38.0",
+        "@memberjunction/graphql-dataprovider": "2.38.0",
+        "@memberjunction/ng-base-types": "2.38.0",
+        "@memberjunction/ng-notifications": "2.38.0",
         "@progress/kendo-angular-notification": "16.2.0",
         "tslib": "^2.3.0"
       },
@@ -30506,15 +30516,15 @@
     },
     "packages/Angular/Explorer/simple-record-list": {
       "name": "@memberjunction/ng-simple-record-list",
-      "version": "2.37.1",
+      "version": "2.38.0",
       "license": "ISC",
       "dependencies": {
-        "@memberjunction/core": "2.37.1",
-        "@memberjunction/core-entities": "2.37.1",
-        "@memberjunction/global": "2.37.1",
-        "@memberjunction/ng-container-directives": "2.37.1",
-        "@memberjunction/ng-entity-form-dialog": "2.37.1",
-        "@memberjunction/ng-notifications": "2.37.1",
+        "@memberjunction/core": "2.38.0",
+        "@memberjunction/core-entities": "2.38.0",
+        "@memberjunction/global": "2.38.0",
+        "@memberjunction/ng-container-directives": "2.38.0",
+        "@memberjunction/ng-entity-form-dialog": "2.38.0",
+        "@memberjunction/ng-notifications": "2.38.0",
         "@progress/kendo-angular-buttons": "16.2.0",
         "@progress/kendo-angular-dialog": "16.2.0",
         "@progress/kendo-angular-indicators": "16.2.0",
@@ -30534,22 +30544,22 @@
     },
     "packages/Angular/Explorer/user-view-grid": {
       "name": "@memberjunction/ng-user-view-grid",
-      "version": "2.37.1",
+      "version": "2.38.0",
       "license": "ISC",
       "dependencies": {
-        "@memberjunction/actions-base": "2.37.1",
-        "@memberjunction/communication-types": "2.37.1",
-        "@memberjunction/core": "2.37.1",
-        "@memberjunction/core-entities": "2.37.1",
-        "@memberjunction/entity-communications-client": "2.37.1",
-        "@memberjunction/global": "2.37.1",
-        "@memberjunction/ng-base-types": "2.37.1",
-        "@memberjunction/ng-compare-records": "2.37.1",
-        "@memberjunction/ng-container-directives": "2.37.1",
-        "@memberjunction/ng-entity-communications": "2.37.1",
-        "@memberjunction/ng-entity-form-dialog": "2.37.1",
-        "@memberjunction/ng-shared": "2.37.1",
-        "@memberjunction/templates-base-types": "2.37.1",
+        "@memberjunction/actions-base": "2.38.0",
+        "@memberjunction/communication-types": "2.38.0",
+        "@memberjunction/core": "2.38.0",
+        "@memberjunction/core-entities": "2.38.0",
+        "@memberjunction/entity-communications-client": "2.38.0",
+        "@memberjunction/global": "2.38.0",
+        "@memberjunction/ng-base-types": "2.38.0",
+        "@memberjunction/ng-compare-records": "2.38.0",
+        "@memberjunction/ng-container-directives": "2.38.0",
+        "@memberjunction/ng-entity-communications": "2.38.0",
+        "@memberjunction/ng-entity-form-dialog": "2.38.0",
+        "@memberjunction/ng-shared": "2.38.0",
+        "@memberjunction/templates-base-types": "2.38.0",
         "@progress/kendo-angular-buttons": "16.2.0",
         "@progress/kendo-angular-grid": "16.2.0",
         "@progress/kendo-angular-inputs": "16.2.0",
@@ -30569,16 +30579,16 @@
     },
     "packages/Angular/Explorer/user-view-properties": {
       "name": "@memberjunction/ng-user-view-properties",
-      "version": "2.37.1",
+      "version": "2.38.0",
       "license": "ISC",
       "dependencies": {
-        "@memberjunction/core": "2.37.1",
-        "@memberjunction/core-entities": "2.37.1",
-        "@memberjunction/global": "2.37.1",
-        "@memberjunction/ng-base-forms": "2.37.1",
-        "@memberjunction/ng-find-record": "2.37.1",
-        "@memberjunction/ng-resource-permissions": "2.37.1",
-        "@memberjunction/ng-shared": "2.37.1",
+        "@memberjunction/core": "2.38.0",
+        "@memberjunction/core-entities": "2.38.0",
+        "@memberjunction/global": "2.38.0",
+        "@memberjunction/ng-base-forms": "2.38.0",
+        "@memberjunction/ng-find-record": "2.38.0",
+        "@memberjunction/ng-resource-permissions": "2.38.0",
+        "@memberjunction/ng-shared": "2.38.0",
         "@progress/kendo-angular-buttons": "16.2.0",
         "@progress/kendo-angular-dialog": "16.2.0",
         "@progress/kendo-angular-filter": "16.2.0",
@@ -30600,12 +30610,12 @@
     },
     "packages/Angular/Generic/base-types": {
       "name": "@memberjunction/ng-base-types",
-      "version": "2.37.1",
+      "version": "2.38.0",
       "license": "ISC",
       "dependencies": {
-        "@memberjunction/core": "2.37.1",
-        "@memberjunction/core-entities": "2.37.1",
-        "@memberjunction/global": "2.37.1",
+        "@memberjunction/core": "2.38.0",
+        "@memberjunction/core-entities": "2.38.0",
+        "@memberjunction/global": "2.38.0",
         "tslib": "^2.3.0"
       },
       "devDependencies": {
@@ -30619,11 +30629,11 @@
     },
     "packages/Angular/Generic/chat": {
       "name": "@memberjunction/ng-chat",
-      "version": "2.37.1",
+      "version": "2.38.0",
       "license": "ISC",
       "dependencies": {
-        "@memberjunction/core": "2.37.1",
-        "@memberjunction/ng-container-directives": "2.37.1",
+        "@memberjunction/core": "2.38.0",
+        "@memberjunction/ng-container-directives": "2.38.0",
         "@progress/kendo-angular-buttons": "16.2.0",
         "@progress/kendo-angular-dialog": "16.2.0",
         "@progress/kendo-angular-indicators": "16.2.0",
@@ -30675,15 +30685,15 @@
     },
     "packages/Angular/Generic/code-editor": {
       "name": "@memberjunction/ng-code-editor",
-      "version": "2.37.1",
+      "version": "2.38.0",
       "license": "ISC",
       "dependencies": {
         "@codemirror/language-data": "^6.5.1",
         "@codemirror/merge": "^6.6.3",
-        "@memberjunction/core": "2.37.1",
-        "@memberjunction/core-entities": "2.37.1",
-        "@memberjunction/global": "2.37.1",
-        "@memberjunction/ng-container-directives": "2.37.1",
+        "@memberjunction/core": "2.38.0",
+        "@memberjunction/core-entities": "2.38.0",
+        "@memberjunction/global": "2.38.0",
+        "@memberjunction/ng-container-directives": "2.38.0",
         "codemirror": "^6.0.1",
         "tslib": "^2.3.0"
       },
@@ -30698,11 +30708,11 @@
     },
     "packages/Angular/Generic/container-directives": {
       "name": "@memberjunction/ng-container-directives",
-      "version": "2.37.1",
+      "version": "2.38.0",
       "license": "ISC",
       "dependencies": {
-        "@memberjunction/core": "2.37.1",
-        "@memberjunction/global": "2.37.1",
+        "@memberjunction/core": "2.38.0",
+        "@memberjunction/global": "2.38.0",
         "tslib": "^2.3.0"
       },
       "devDependencies": {
@@ -30717,12 +30727,12 @@
     },
     "packages/Angular/Generic/data-context": {
       "name": "@memberjunction/ng-data-context",
-      "version": "2.37.1",
+      "version": "2.38.0",
       "license": "ISC",
       "dependencies": {
-        "@memberjunction/core": "2.37.1",
-        "@memberjunction/core-entities": "2.37.1",
-        "@memberjunction/global": "2.37.1",
+        "@memberjunction/core": "2.38.0",
+        "@memberjunction/core-entities": "2.38.0",
+        "@memberjunction/global": "2.38.0",
         "tslib": "^2.3.0"
       },
       "devDependencies": {
@@ -30738,17 +30748,17 @@
     },
     "packages/Angular/Generic/entity-communication": {
       "name": "@memberjunction/ng-entity-communications",
-      "version": "2.37.1",
+      "version": "2.38.0",
       "license": "ISC",
       "dependencies": {
-        "@memberjunction/communication-types": "2.37.1",
-        "@memberjunction/core": "2.37.1",
-        "@memberjunction/core-entities": "2.37.1",
-        "@memberjunction/entity-communications-base": "2.37.1",
-        "@memberjunction/entity-communications-client": "2.37.1",
-        "@memberjunction/global": "2.37.1",
-        "@memberjunction/ng-container-directives": "2.37.1",
-        "@memberjunction/ng-shared": "2.37.1",
+        "@memberjunction/communication-types": "2.38.0",
+        "@memberjunction/core": "2.38.0",
+        "@memberjunction/core-entities": "2.38.0",
+        "@memberjunction/entity-communications-base": "2.38.0",
+        "@memberjunction/entity-communications-client": "2.38.0",
+        "@memberjunction/global": "2.38.0",
+        "@memberjunction/ng-container-directives": "2.38.0",
+        "@memberjunction/ng-shared": "2.38.0",
         "tslib": "^2.3.0"
       },
       "devDependencies": {
@@ -30768,15 +30778,15 @@
     },
     "packages/Angular/Generic/file-storage": {
       "name": "@memberjunction/ng-file-storage",
-      "version": "2.37.1",
+      "version": "2.38.0",
       "license": "ISC",
       "dependencies": {
-        "@memberjunction/core": "2.37.1",
-        "@memberjunction/core-entities": "2.37.1",
-        "@memberjunction/global": "2.37.1",
-        "@memberjunction/graphql-dataprovider": "2.37.1",
-        "@memberjunction/ng-container-directives": "2.37.1",
-        "@memberjunction/ng-shared": "2.37.1",
+        "@memberjunction/core": "2.38.0",
+        "@memberjunction/core-entities": "2.38.0",
+        "@memberjunction/global": "2.38.0",
+        "@memberjunction/graphql-dataprovider": "2.38.0",
+        "@memberjunction/ng-container-directives": "2.38.0",
+        "@memberjunction/ng-shared": "2.38.0",
         "@progress/kendo-angular-buttons": "16.2.0",
         "@progress/kendo-angular-dialog": "16.2.0",
         "@progress/kendo-angular-dropdowns": "16.2.0",
@@ -30801,14 +30811,14 @@
     },
     "packages/Angular/Generic/find-record": {
       "name": "@memberjunction/ng-find-record",
-      "version": "2.37.1",
+      "version": "2.38.0",
       "license": "ISC",
       "dependencies": {
-        "@memberjunction/core": "2.37.1",
-        "@memberjunction/core-entities": "2.37.1",
-        "@memberjunction/global": "2.37.1",
-        "@memberjunction/ng-container-directives": "2.37.1",
-        "@memberjunction/ng-shared": "2.37.1",
+        "@memberjunction/core": "2.38.0",
+        "@memberjunction/core-entities": "2.38.0",
+        "@memberjunction/global": "2.38.0",
+        "@memberjunction/ng-container-directives": "2.38.0",
+        "@memberjunction/ng-shared": "2.38.0",
         "rxjs": "^7.8.1",
         "tslib": "^2.3.0"
       },
@@ -30830,7 +30840,7 @@
     },
     "packages/Angular/Generic/generic-dialog": {
       "name": "@memberjunction/ng-generic-dialog",
-      "version": "2.37.1",
+      "version": "2.38.0",
       "license": "ISC",
       "dependencies": {
         "tslib": "^2.3.0"
@@ -30848,15 +30858,15 @@
     },
     "packages/Angular/Generic/join-grid": {
       "name": "@memberjunction/ng-join-grid",
-      "version": "2.37.1",
+      "version": "2.38.0",
       "license": "ISC",
       "dependencies": {
-        "@memberjunction/core": "2.37.1",
-        "@memberjunction/core-entities": "2.37.1",
-        "@memberjunction/global": "2.37.1",
-        "@memberjunction/ng-base-types": "2.37.1",
-        "@memberjunction/ng-container-directives": "2.37.1",
-        "@memberjunction/ng-shared": "2.37.1",
+        "@memberjunction/core": "2.38.0",
+        "@memberjunction/core-entities": "2.38.0",
+        "@memberjunction/global": "2.38.0",
+        "@memberjunction/ng-base-types": "2.38.0",
+        "@memberjunction/ng-container-directives": "2.38.0",
+        "@memberjunction/ng-shared": "2.38.0",
         "@progress/kendo-angular-buttons": "16.2.0",
         "@progress/kendo-angular-dialog": "16.2.0",
         "@progress/kendo-angular-grid": "16.2.0",
@@ -30878,13 +30888,13 @@
     },
     "packages/Angular/Generic/notifications": {
       "name": "@memberjunction/ng-notifications",
-      "version": "2.37.1",
+      "version": "2.38.0",
       "license": "ISC",
       "dependencies": {
-        "@memberjunction/core": "2.37.1",
-        "@memberjunction/core-entities": "2.37.1",
-        "@memberjunction/global": "2.37.1",
-        "@memberjunction/graphql-dataprovider": "2.37.1",
+        "@memberjunction/core": "2.38.0",
+        "@memberjunction/core-entities": "2.38.0",
+        "@memberjunction/global": "2.38.0",
+        "@memberjunction/graphql-dataprovider": "2.38.0",
         "rxjs": "^7.8.1",
         "tslib": "^2.3.0"
       },
@@ -30900,15 +30910,15 @@
     },
     "packages/Angular/Generic/query-grid": {
       "name": "@memberjunction/ng-query-grid",
-      "version": "2.37.1",
+      "version": "2.38.0",
       "license": "ISC",
       "dependencies": {
-        "@memberjunction/core": "2.37.1",
-        "@memberjunction/core-entities": "2.37.1",
-        "@memberjunction/global": "2.37.1",
-        "@memberjunction/ng-compare-records": "2.37.1",
-        "@memberjunction/ng-container-directives": "2.37.1",
-        "@memberjunction/ng-shared": "2.37.1",
+        "@memberjunction/core": "2.38.0",
+        "@memberjunction/core-entities": "2.38.0",
+        "@memberjunction/global": "2.38.0",
+        "@memberjunction/ng-compare-records": "2.38.0",
+        "@memberjunction/ng-container-directives": "2.38.0",
+        "@memberjunction/ng-shared": "2.38.0",
         "tslib": "^2.3.0"
       },
       "devDependencies": {
@@ -30927,14 +30937,14 @@
     },
     "packages/Angular/Generic/record-selector": {
       "name": "@memberjunction/ng-record-selector",
-      "version": "2.37.1",
+      "version": "2.38.0",
       "license": "ISC",
       "dependencies": {
-        "@memberjunction/core": "2.37.1",
-        "@memberjunction/core-entities": "2.37.1",
-        "@memberjunction/global": "2.37.1",
-        "@memberjunction/ng-container-directives": "2.37.1",
-        "@memberjunction/ng-shared": "2.37.1",
+        "@memberjunction/core": "2.38.0",
+        "@memberjunction/core-entities": "2.38.0",
+        "@memberjunction/global": "2.38.0",
+        "@memberjunction/ng-container-directives": "2.38.0",
+        "@memberjunction/ng-shared": "2.38.0",
         "tslib": "^2.3.0"
       },
       "devDependencies": {
@@ -30953,16 +30963,16 @@
     },
     "packages/Angular/Generic/resource-permissions": {
       "name": "@memberjunction/ng-resource-permissions",
-      "version": "2.37.1",
+      "version": "2.38.0",
       "license": "ISC",
       "dependencies": {
-        "@memberjunction/core": "2.37.1",
-        "@memberjunction/core-entities": "2.37.1",
-        "@memberjunction/global": "2.37.1",
-        "@memberjunction/ng-base-types": "2.37.1",
-        "@memberjunction/ng-container-directives": "2.37.1",
-        "@memberjunction/ng-generic-dialog": "2.37.1",
-        "@memberjunction/ng-notifications": "2.37.1",
+        "@memberjunction/core": "2.38.0",
+        "@memberjunction/core-entities": "2.38.0",
+        "@memberjunction/global": "2.38.0",
+        "@memberjunction/ng-base-types": "2.38.0",
+        "@memberjunction/ng-container-directives": "2.38.0",
+        "@memberjunction/ng-generic-dialog": "2.38.0",
+        "@memberjunction/ng-notifications": "2.38.0",
         "@progress/kendo-angular-buttons": "16.2.0",
         "@progress/kendo-angular-dialog": "16.2.0",
         "@progress/kendo-angular-dropdowns": "16.2.0",
@@ -31013,21 +31023,21 @@
     },
     "packages/Angular/Generic/skip-chat": {
       "name": "@memberjunction/ng-skip-chat",
-      "version": "2.37.1",
+      "version": "2.38.0",
       "license": "ISC",
       "dependencies": {
         "@angular/cdk": "18.0.2",
-        "@memberjunction/core": "2.37.1",
-        "@memberjunction/core-entities": "2.37.1",
-        "@memberjunction/data-context": "2.37.1",
-        "@memberjunction/global": "2.37.1",
-        "@memberjunction/graphql-dataprovider": "2.37.1",
-        "@memberjunction/ng-base-types": "2.37.1",
-        "@memberjunction/ng-container-directives": "2.37.1",
-        "@memberjunction/ng-data-context": "2.37.1",
-        "@memberjunction/ng-notifications": "2.37.1",
-        "@memberjunction/ng-resource-permissions": "2.37.1",
-        "@memberjunction/skip-types": "2.37.1",
+        "@memberjunction/core": "2.38.0",
+        "@memberjunction/core-entities": "2.38.0",
+        "@memberjunction/data-context": "2.38.0",
+        "@memberjunction/global": "2.38.0",
+        "@memberjunction/graphql-dataprovider": "2.38.0",
+        "@memberjunction/ng-base-types": "2.38.0",
+        "@memberjunction/ng-container-directives": "2.38.0",
+        "@memberjunction/ng-data-context": "2.38.0",
+        "@memberjunction/ng-notifications": "2.38.0",
+        "@memberjunction/ng-resource-permissions": "2.38.0",
+        "@memberjunction/skip-types": "2.38.0",
         "@progress/kendo-angular-dialog": "16.2.0",
         "@progress/kendo-angular-grid": "16.2.0",
         "@progress/kendo-angular-indicators": "16.2.0",
@@ -31111,10 +31121,10 @@
     },
     "packages/Angular/Generic/tab-strip": {
       "name": "@memberjunction/ng-tabstrip",
-      "version": "2.37.1",
+      "version": "2.38.0",
       "license": "ISC",
       "dependencies": {
-        "@memberjunction/ng-container-directives": "2.37.1",
+        "@memberjunction/ng-container-directives": "2.38.0",
         "tslib": "^2.3.0"
       },
       "devDependencies": {
@@ -31128,15 +31138,15 @@
     },
     "packages/Angular/Generic/timeline": {
       "name": "@memberjunction/ng-timeline",
-      "version": "2.37.1",
+      "version": "2.38.0",
       "license": "ISC",
       "dependencies": {
-        "@memberjunction/core": "2.37.1",
-        "@memberjunction/core-entities": "2.37.1",
-        "@memberjunction/global": "2.37.1",
-        "@memberjunction/ng-container-directives": "2.37.1",
-        "@memberjunction/ng-entity-form-dialog": "2.37.1",
-        "@memberjunction/ng-shared": "2.37.1",
+        "@memberjunction/core": "2.38.0",
+        "@memberjunction/core-entities": "2.38.0",
+        "@memberjunction/global": "2.38.0",
+        "@memberjunction/ng-container-directives": "2.38.0",
+        "@memberjunction/ng-entity-form-dialog": "2.38.0",
+        "@memberjunction/ng-shared": "2.38.0",
         "@progress/kendo-angular-buttons": "16.2.0",
         "@progress/kendo-angular-indicators": "16.2.0",
         "@progress/kendo-angular-layout": "16.2.0",
@@ -31156,15 +31166,15 @@
     },
     "packages/Angular/Generic/tree-list": {
       "name": "@memberjunction/ng-treelist",
-      "version": "2.37.1",
+      "version": "2.38.0",
       "license": "ISC",
       "dependencies": {
-        "@memberjunction/core": "2.37.1",
-        "@memberjunction/core-entities": "2.37.1",
-        "@memberjunction/global": "2.37.1",
-        "@memberjunction/ng-container-directives": "2.37.1",
-        "@memberjunction/ng-entity-form-dialog": "2.37.1",
-        "@memberjunction/ng-shared": "2.37.1",
+        "@memberjunction/core": "2.38.0",
+        "@memberjunction/core-entities": "2.38.0",
+        "@memberjunction/global": "2.38.0",
+        "@memberjunction/ng-container-directives": "2.38.0",
+        "@memberjunction/ng-entity-form-dialog": "2.38.0",
+        "@memberjunction/ng-shared": "2.38.0",
         "@progress/kendo-angular-buttons": "16.2.0",
         "@progress/kendo-angular-indicators": "16.2.0",
         "@progress/kendo-angular-layout": "16.2.0",
@@ -31195,10 +31205,10 @@
         "@angular/platform-browser": "18.0.2",
         "@angular/platform-browser-dynamic": "18.0.2",
         "@angular/router": "18.0.2",
-        "@memberjunction/core": "2.37.1",
-        "@memberjunction/global": "2.37.1",
-        "@memberjunction/graphql-dataprovider": "2.37.1",
-        "@memberjunction/ng-user-view-grid": "2.37.1",
+        "@memberjunction/core": "2.38.0",
+        "@memberjunction/global": "2.38.0",
+        "@memberjunction/graphql-dataprovider": "2.38.0",
+        "@memberjunction/ng-user-view-grid": "2.38.0",
         "rxjs": "^7.8.1",
         "tslib": "^2.3.0",
         "zone.js": "^0.14.0"
@@ -31219,20 +31229,20 @@
     },
     "packages/CodeGenLib": {
       "name": "@memberjunction/codegen-lib",
-      "version": "2.37.1",
+      "version": "2.38.0",
       "license": "ISC",
       "dependencies": {
-        "@memberjunction/actions": "2.37.1",
-        "@memberjunction/ai": "2.37.1",
-        "@memberjunction/ai-anthropic": "2.37.1",
-        "@memberjunction/ai-groq": "2.37.1",
-        "@memberjunction/ai-mistral": "2.37.1",
-        "@memberjunction/ai-openai": "2.37.1",
-        "@memberjunction/aiengine": "2.37.1",
-        "@memberjunction/core": "2.37.1",
-        "@memberjunction/core-entities": "2.37.1",
-        "@memberjunction/global": "2.37.1",
-        "@memberjunction/sqlserver-dataprovider": "2.37.1",
+        "@memberjunction/actions": "2.38.0",
+        "@memberjunction/ai": "2.38.0",
+        "@memberjunction/ai-anthropic": "2.38.0",
+        "@memberjunction/ai-groq": "2.38.0",
+        "@memberjunction/ai-mistral": "2.38.0",
+        "@memberjunction/ai-openai": "2.38.0",
+        "@memberjunction/aiengine": "2.38.0",
+        "@memberjunction/core": "2.38.0",
+        "@memberjunction/core-entities": "2.38.0",
+        "@memberjunction/global": "2.38.0",
+        "@memberjunction/sqlserver-dataprovider": "2.38.0",
         "cosmiconfig": "9.0.0",
         "fs-extra": "^11.2.0",
         "glob": "^10.3.10",
@@ -31337,13 +31347,13 @@
     },
     "packages/Communication/base-types": {
       "name": "@memberjunction/communication-types",
-      "version": "2.37.1",
+      "version": "2.38.0",
       "license": "ISC",
       "dependencies": {
-        "@memberjunction/core": "2.37.1",
-        "@memberjunction/core-entities": "2.37.1",
-        "@memberjunction/global": "2.37.1",
-        "@memberjunction/templates-base-types": "2.37.1",
+        "@memberjunction/core": "2.38.0",
+        "@memberjunction/core-entities": "2.38.0",
+        "@memberjunction/global": "2.38.0",
+        "@memberjunction/templates-base-types": "2.38.0",
         "rxjs": "^7.8.1"
       },
       "devDependencies": {
@@ -31353,14 +31363,14 @@
     },
     "packages/Communication/engine": {
       "name": "@memberjunction/communication-engine",
-      "version": "2.37.1",
+      "version": "2.38.0",
       "license": "ISC",
       "dependencies": {
-        "@memberjunction/communication-types": "2.37.1",
-        "@memberjunction/core": "2.37.1",
-        "@memberjunction/core-entities": "2.37.1",
-        "@memberjunction/global": "2.37.1",
-        "@memberjunction/templates": "2.37.1",
+        "@memberjunction/communication-types": "2.38.0",
+        "@memberjunction/core": "2.38.0",
+        "@memberjunction/core-entities": "2.38.0",
+        "@memberjunction/global": "2.38.0",
+        "@memberjunction/templates": "2.38.0",
         "rxjs": "^7.8.1"
       },
       "devDependencies": {
@@ -31370,13 +31380,13 @@
     },
     "packages/Communication/entity-comm-base": {
       "name": "@memberjunction/entity-communications-base",
-      "version": "2.37.1",
+      "version": "2.38.0",
       "license": "ISC",
       "dependencies": {
-        "@memberjunction/communication-types": "2.37.1",
-        "@memberjunction/core": "2.37.1",
-        "@memberjunction/core-entities": "2.37.1",
-        "@memberjunction/global": "2.37.1"
+        "@memberjunction/communication-types": "2.38.0",
+        "@memberjunction/core": "2.38.0",
+        "@memberjunction/core-entities": "2.38.0",
+        "@memberjunction/global": "2.38.0"
       },
       "devDependencies": {
         "ts-node-dev": "^2.0.0",
@@ -31385,14 +31395,14 @@
     },
     "packages/Communication/entity-comm-client": {
       "name": "@memberjunction/entity-communications-client",
-      "version": "2.37.1",
+      "version": "2.38.0",
       "license": "ISC",
       "dependencies": {
-        "@memberjunction/core": "2.37.1",
-        "@memberjunction/core-entities": "2.37.1",
-        "@memberjunction/entity-communications-base": "2.37.1",
-        "@memberjunction/global": "2.37.1",
-        "@memberjunction/graphql-dataprovider": "2.37.1"
+        "@memberjunction/core": "2.38.0",
+        "@memberjunction/core-entities": "2.38.0",
+        "@memberjunction/entity-communications-base": "2.38.0",
+        "@memberjunction/global": "2.38.0",
+        "@memberjunction/graphql-dataprovider": "2.38.0"
       },
       "devDependencies": {
         "ts-node-dev": "^2.0.0",
@@ -31401,14 +31411,14 @@
     },
     "packages/Communication/entity-comm-server": {
       "name": "@memberjunction/entity-communications-server",
-      "version": "2.37.1",
+      "version": "2.38.0",
       "license": "ISC",
       "dependencies": {
-        "@memberjunction/communication-engine": "2.37.1",
-        "@memberjunction/core": "2.37.1",
-        "@memberjunction/core-entities": "2.37.1",
-        "@memberjunction/entity-communications-base": "2.37.1",
-        "@memberjunction/global": "2.37.1"
+        "@memberjunction/communication-engine": "2.38.0",
+        "@memberjunction/core": "2.38.0",
+        "@memberjunction/core-entities": "2.38.0",
+        "@memberjunction/entity-communications-base": "2.38.0",
+        "@memberjunction/global": "2.38.0"
       },
       "devDependencies": {
         "ts-node-dev": "^2.0.0",
@@ -31417,11 +31427,11 @@
     },
     "packages/Communication/providers/gmail": {
       "name": "@memberjunction/communication-gmail",
-      "version": "2.37.1",
+      "version": "2.38.0",
       "dependencies": {
-        "@memberjunction/communication-types": "2.37.1",
-        "@memberjunction/core": "2.37.1",
-        "@memberjunction/global": "2.37.1",
+        "@memberjunction/communication-types": "2.38.0",
+        "@memberjunction/core": "2.38.0",
+        "@memberjunction/global": "2.38.0",
         "dotenv": "^16.3.1",
         "env-var": "^7.4.1",
         "googleapis": "^130.0.0"
@@ -31462,19 +31472,19 @@
     },
     "packages/Communication/providers/MSGraph": {
       "name": "@memberjunction/communication-ms-graph",
-      "version": "2.37.1",
+      "version": "2.38.0",
       "license": "ISC",
       "dependencies": {
         "@azure/identity": "^4.4.1",
         "@azure/msal-node": "^2.14.0",
-        "@memberjunction/ai": "2.37.1",
-        "@memberjunction/ai-openai": "2.37.1",
-        "@memberjunction/aiengine": "2.37.1",
-        "@memberjunction/communication-types": "2.37.1",
-        "@memberjunction/core": "2.37.1",
-        "@memberjunction/core-entities": "2.37.1",
-        "@memberjunction/global": "2.37.1",
-        "@memberjunction/sqlserver-dataprovider": "2.37.1",
+        "@memberjunction/ai": "2.38.0",
+        "@memberjunction/ai-openai": "2.38.0",
+        "@memberjunction/aiengine": "2.38.0",
+        "@memberjunction/communication-types": "2.38.0",
+        "@memberjunction/core": "2.38.0",
+        "@memberjunction/core-entities": "2.38.0",
+        "@memberjunction/global": "2.38.0",
+        "@memberjunction/sqlserver-dataprovider": "2.38.0",
         "@microsoft/microsoft-graph-client": "^3.0.7",
         "@microsoft/microsoft-graph-types": "^2.40.0",
         "@types/html-to-text": "^9.0.4",
@@ -31653,13 +31663,13 @@
     },
     "packages/Communication/providers/sendgrid": {
       "name": "@memberjunction/communication-sendgrid",
-      "version": "2.37.1",
+      "version": "2.38.0",
       "license": "ISC",
       "dependencies": {
-        "@memberjunction/communication-types": "2.37.1",
-        "@memberjunction/core": "2.37.1",
-        "@memberjunction/core-entities": "2.37.1",
-        "@memberjunction/global": "2.37.1",
+        "@memberjunction/communication-types": "2.38.0",
+        "@memberjunction/core": "2.38.0",
+        "@memberjunction/core-entities": "2.38.0",
+        "@memberjunction/global": "2.38.0",
         "@sendgrid/mail": "^8.1.3"
       },
       "devDependencies": {
@@ -31669,11 +31679,11 @@
     },
     "packages/Communication/providers/twilio": {
       "name": "@memberjunction/communication-twilio",
-      "version": "2.37.1",
+      "version": "2.38.0",
       "dependencies": {
-        "@memberjunction/communication-types": "2.37.1",
-        "@memberjunction/core": "2.37.1",
-        "@memberjunction/global": "2.37.1",
+        "@memberjunction/communication-types": "2.38.0",
+        "@memberjunction/core": "2.38.0",
+        "@memberjunction/global": "2.38.0",
         "dotenv": "^16.3.1",
         "env-var": "^7.4.1",
         "twilio": "^4.23.0"
@@ -31701,14 +31711,14 @@
     },
     "packages/ContentAutotagging": {
       "name": "@memberjunction/content-autotagging",
-      "version": "2.37.1",
+      "version": "2.38.0",
       "license": "ISC",
       "dependencies": {
-        "@memberjunction/ai": "2.37.1",
-        "@memberjunction/aiengine": "2.37.1",
-        "@memberjunction/core": "2.37.1",
-        "@memberjunction/core-entities": "2.37.1",
-        "@memberjunction/global": "2.37.1",
+        "@memberjunction/ai": "2.38.0",
+        "@memberjunction/aiengine": "2.38.0",
+        "@memberjunction/core": "2.38.0",
+        "@memberjunction/core-entities": "2.38.0",
+        "@memberjunction/global": "2.38.0",
         "axios": "^1.7.2",
         "cheerio": "^1.0.0-rc.12",
         "crypto": "^1.0.1",
@@ -31742,12 +31752,12 @@
     },
     "packages/DocUtils": {
       "name": "@memberjunction/doc-utils",
-      "version": "2.37.1",
+      "version": "2.38.0",
       "license": "ISC",
       "dependencies": {
-        "@memberjunction/core": "2.37.1",
-        "@memberjunction/core-entities": "2.37.1",
-        "@memberjunction/global": "2.37.1",
+        "@memberjunction/core": "2.38.0",
+        "@memberjunction/core-entities": "2.38.0",
+        "@memberjunction/global": "2.38.0",
         "axios": "^1.6.7",
         "jsdom": "^24.1.0"
       },
@@ -31758,13 +31768,13 @@
     },
     "packages/ExternalChangeDetection": {
       "name": "@memberjunction/external-change-detection",
-      "version": "2.37.1",
+      "version": "2.38.0",
       "license": "ISC",
       "dependencies": {
-        "@memberjunction/core": "2.37.1",
-        "@memberjunction/core-entities": "2.37.1",
-        "@memberjunction/global": "2.37.1",
-        "@memberjunction/sqlserver-dataprovider": "2.37.1"
+        "@memberjunction/core": "2.38.0",
+        "@memberjunction/core-entities": "2.38.0",
+        "@memberjunction/global": "2.38.0",
+        "@memberjunction/sqlserver-dataprovider": "2.38.0"
       },
       "devDependencies": {
         "ts-node-dev": "^2.0.0",
@@ -31776,12 +31786,12 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
-        "@memberjunction/actions": "2.37.1",
-        "@memberjunction/ai": "2.37.1",
-        "@memberjunction/aiengine": "2.37.1",
-        "@memberjunction/core": "2.37.1",
-        "@memberjunction/core-entities": "2.37.1",
-        "@memberjunction/global": "2.37.1",
+        "@memberjunction/actions": "2.38.0",
+        "@memberjunction/ai": "2.38.0",
+        "@memberjunction/aiengine": "2.38.0",
+        "@memberjunction/core": "2.38.0",
+        "@memberjunction/core-entities": "2.38.0",
+        "@memberjunction/global": "2.38.0",
         "zod": "^3.23.8"
       },
       "devDependencies": {
@@ -31794,8 +31804,8 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
-        "@memberjunction/core": "2.37.1",
-        "@memberjunction/global": "2.37.1",
+        "@memberjunction/core": "2.38.0",
+        "@memberjunction/global": "2.38.0",
         "zod": "^3.23.8"
       },
       "devDependencies": {
@@ -31805,13 +31815,13 @@
     },
     "packages/GraphQLDataProvider": {
       "name": "@memberjunction/graphql-dataprovider",
-      "version": "2.37.1",
+      "version": "2.38.0",
       "license": "ISC",
       "dependencies": {
-        "@memberjunction/actions-base": "2.37.1",
-        "@memberjunction/core": "2.37.1",
-        "@memberjunction/core-entities": "2.37.1",
-        "@memberjunction/global": "2.37.1",
+        "@memberjunction/actions-base": "2.38.0",
+        "@memberjunction/core": "2.38.0",
+        "@memberjunction/core-entities": "2.38.0",
+        "@memberjunction/global": "2.38.0",
         "@tempfix/idb": "^8.0.3",
         "graphql": "^16.8.0",
         "graphql-request": "^5.2.0",
@@ -31826,41 +31836,6 @@
       "optionalDependencies": {
         "@esbuild/win32-x64": "0.24.0",
         "@rollup/rollup-linux-x64-gnu": "4.17.2"
-      }
-    },
-    "packages/GraphQLDataProvider/node_modules/extract-files": {
-      "version": "9.0.0",
-      "license": "MIT",
-      "engines": {
-        "node": "^10.17.0 || ^12.0.0 || >= 13.7.0"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/jaydenseric"
-      }
-    },
-    "packages/GraphQLDataProvider/node_modules/form-data": {
-      "version": "3.0.1",
-      "license": "MIT",
-      "dependencies": {
-        "asynckit": "^0.4.0",
-        "combined-stream": "^1.0.8",
-        "mime-types": "^2.1.12"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
-    "packages/GraphQLDataProvider/node_modules/graphql-request": {
-      "version": "5.2.0",
-      "license": "MIT",
-      "dependencies": {
-        "@graphql-typed-document-node/core": "^3.1.1",
-        "cross-fetch": "^3.1.5",
-        "extract-files": "^9.0.0",
-        "form-data": "^3.0.0"
-      },
-      "peerDependencies": {
-        "graphql": "14 - 16"
       }
     },
     "packages/GraphQLDataProvider/node_modules/uuid": {
@@ -31880,13 +31855,13 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
-        "@memberjunction/ai": "2.37.1",
-        "@memberjunction/communication-sendgrid": "2.37.1",
-        "@memberjunction/core": "2.37.1",
-        "@memberjunction/global": "2.37.1",
-        "@memberjunction/server": "2.37.1",
-        "@memberjunction/sqlserver-dataprovider": "2.37.1",
-        "@memberjunction/templates": "2.37.1",
+        "@memberjunction/ai": "2.38.0",
+        "@memberjunction/communication-sendgrid": "2.38.0",
+        "@memberjunction/core": "2.38.0",
+        "@memberjunction/global": "2.38.0",
+        "@memberjunction/server": "2.38.0",
+        "@memberjunction/sqlserver-dataprovider": "2.38.0",
+        "@memberjunction/templates": "2.38.0",
         "axios": "^1.6.7",
         "class-validator": "^0.14.0",
         "mj_generatedactions": "1.0.0",
@@ -31902,11 +31877,11 @@
     },
     "packages/MJCLI": {
       "name": "@memberjunction/cli",
-      "version": "2.37.1",
+      "version": "2.38.0",
       "license": "ISC",
       "dependencies": {
         "@inquirer/prompts": "^5.0.1",
-        "@memberjunction/codegen-lib": "2.37.1",
+        "@memberjunction/codegen-lib": "2.38.0",
         "@oclif/core": "^3",
         "@oclif/plugin-help": "^6",
         "@oclif/plugin-version": "^2.0.17",
@@ -31960,11 +31935,11 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
-        "@memberjunction/codegen-lib": "2.37.1",
-        "@memberjunction/core": "2.37.1",
-        "@memberjunction/core-entities": "2.37.1",
-        "@memberjunction/global": "2.37.1",
-        "@memberjunction/sqlserver-dataprovider": "2.37.1",
+        "@memberjunction/codegen-lib": "2.38.0",
+        "@memberjunction/core": "2.38.0",
+        "@memberjunction/core-entities": "2.38.0",
+        "@memberjunction/global": "2.38.0",
+        "@memberjunction/sqlserver-dataprovider": "2.38.0",
         "@types/axios": "^0.14.0",
         "@types/mssql": "^9.1.5",
         "axios": "^1.6.7",
@@ -32005,10 +31980,10 @@
     },
     "packages/MJCore": {
       "name": "@memberjunction/core",
-      "version": "2.37.1",
+      "version": "2.38.0",
       "license": "ISC",
       "dependencies": {
-        "@memberjunction/global": "2.37.1",
+        "@memberjunction/global": "2.38.0",
         "debug": "^4.4.0",
         "rxjs": "^7.8.1",
         "zod": "^3.23.8"
@@ -32044,11 +32019,11 @@
     },
     "packages/MJCoreEntities": {
       "name": "@memberjunction/core-entities",
-      "version": "2.37.1",
+      "version": "2.38.0",
       "license": "ISC",
       "dependencies": {
-        "@memberjunction/core": "2.37.1",
-        "@memberjunction/global": "2.37.1",
+        "@memberjunction/core": "2.38.0",
+        "@memberjunction/global": "2.38.0",
         "zod": "^3.23.8"
       },
       "devDependencies": {
@@ -32058,12 +32033,12 @@
     },
     "packages/MJDataContext": {
       "name": "@memberjunction/data-context",
-      "version": "2.37.1",
+      "version": "2.38.0",
       "license": "ISC",
       "dependencies": {
-        "@memberjunction/core": "2.37.1",
-        "@memberjunction/core-entities": "2.37.1",
-        "@memberjunction/global": "2.37.1"
+        "@memberjunction/core": "2.38.0",
+        "@memberjunction/core-entities": "2.38.0",
+        "@memberjunction/global": "2.38.0"
       },
       "devDependencies": {
         "ts-node-dev": "^2.0.0",
@@ -32072,11 +32047,11 @@
     },
     "packages/MJDataContextServer": {
       "name": "@memberjunction/data-context-server",
-      "version": "2.37.1",
+      "version": "2.38.0",
       "license": "ISC",
       "dependencies": {
-        "@memberjunction/data-context": "2.37.1",
-        "@memberjunction/global": "2.37.1",
+        "@memberjunction/data-context": "2.38.0",
+        "@memberjunction/global": "2.38.0",
         "typeorm": "^0.3.20"
       },
       "devDependencies": {
@@ -32097,23 +32072,23 @@
         "@angular/platform-browser-dynamic": "18.0.2",
         "@angular/router": "18.0.2",
         "@azure/msal-angular": "^3.0.11",
-        "@memberjunction/core": "2.37.1",
-        "@memberjunction/core-entities": "2.37.1",
-        "@memberjunction/global": "2.37.1",
-        "@memberjunction/graphql-dataprovider": "2.37.1",
-        "@memberjunction/ng-ask-skip": "2.37.1",
-        "@memberjunction/ng-auth-services": "2.37.1",
-        "@memberjunction/ng-compare-records": "2.37.1",
-        "@memberjunction/ng-container-directives": "2.37.1",
-        "@memberjunction/ng-core-entity-forms": "2.37.1",
-        "@memberjunction/ng-explorer-core": "2.37.1",
-        "@memberjunction/ng-explorer-settings": "2.37.1",
-        "@memberjunction/ng-join-grid": "2.37.1",
-        "@memberjunction/ng-link-directives": "2.37.1",
-        "@memberjunction/ng-record-changes": "2.37.1",
-        "@memberjunction/ng-tabstrip": "2.37.1",
-        "@memberjunction/ng-timeline": "2.37.1",
-        "@memberjunction/ng-user-view-grid": "2.37.1",
+        "@memberjunction/core": "2.38.0",
+        "@memberjunction/core-entities": "2.38.0",
+        "@memberjunction/global": "2.38.0",
+        "@memberjunction/graphql-dataprovider": "2.38.0",
+        "@memberjunction/ng-ask-skip": "2.38.0",
+        "@memberjunction/ng-auth-services": "2.38.0",
+        "@memberjunction/ng-compare-records": "2.38.0",
+        "@memberjunction/ng-container-directives": "2.38.0",
+        "@memberjunction/ng-core-entity-forms": "2.38.0",
+        "@memberjunction/ng-explorer-core": "2.38.0",
+        "@memberjunction/ng-explorer-settings": "2.38.0",
+        "@memberjunction/ng-join-grid": "2.38.0",
+        "@memberjunction/ng-link-directives": "2.38.0",
+        "@memberjunction/ng-record-changes": "2.38.0",
+        "@memberjunction/ng-tabstrip": "2.38.0",
+        "@memberjunction/ng-timeline": "2.38.0",
+        "@memberjunction/ng-user-view-grid": "2.38.0",
         "@progress/kendo-angular-notification": "16.2.0",
         "@progress/kendo-angular-scheduler": "16.2.0",
         "@progress/kendo-licensing": "^1.3.5",
@@ -32142,7 +32117,7 @@
     },
     "packages/MJGlobal": {
       "name": "@memberjunction/global",
-      "version": "2.37.1",
+      "version": "2.38.0",
       "license": "ISC",
       "dependencies": {
         "rxjs": "^7.8.1"
@@ -32154,14 +32129,14 @@
     },
     "packages/MJQueue": {
       "name": "@memberjunction/queue",
-      "version": "2.37.1",
+      "version": "2.38.0",
       "license": "ISC",
       "dependencies": {
-        "@memberjunction/ai": "2.37.1",
-        "@memberjunction/aiengine": "2.37.1",
-        "@memberjunction/core": "2.37.1",
-        "@memberjunction/core-entities": "2.37.1",
-        "@memberjunction/global": "2.37.1",
+        "@memberjunction/ai": "2.38.0",
+        "@memberjunction/aiengine": "2.38.0",
+        "@memberjunction/core": "2.38.0",
+        "@memberjunction/core-entities": "2.38.0",
+        "@memberjunction/global": "2.38.0",
         "@types/uuid": "^9.0.1",
         "uuid": "^9.0.0"
       },
@@ -32172,32 +32147,32 @@
     },
     "packages/MJServer": {
       "name": "@memberjunction/server",
-      "version": "2.37.1",
+      "version": "2.38.0",
       "license": "ISC",
       "dependencies": {
         "@apollo/server": "^4.9.1",
         "@graphql-tools/utils": "^10.0.1",
-        "@memberjunction/actions": "2.37.1",
-        "@memberjunction/ai": "2.37.1",
-        "@memberjunction/ai-mistral": "2.37.1",
-        "@memberjunction/ai-openai": "2.37.1",
-        "@memberjunction/ai-vectors-pinecone": "2.37.1",
-        "@memberjunction/aiengine": "2.37.1",
-        "@memberjunction/core": "2.37.1",
-        "@memberjunction/core-actions": "2.37.1",
-        "@memberjunction/core-entities": "2.37.1",
-        "@memberjunction/data-context": "2.37.1",
-        "@memberjunction/data-context-server": "2.37.1",
-        "@memberjunction/doc-utils": "2.37.1",
-        "@memberjunction/entity-communications-server": "2.37.1",
-        "@memberjunction/external-change-detection": "2.37.1",
-        "@memberjunction/global": "2.37.1",
-        "@memberjunction/graphql-dataprovider": "2.37.1",
-        "@memberjunction/queue": "2.37.1",
-        "@memberjunction/skip-types": "2.37.1",
-        "@memberjunction/sqlserver-dataprovider": "2.37.1",
-        "@memberjunction/storage": "2.37.1",
-        "@memberjunction/templates": "2.37.1",
+        "@memberjunction/actions": "2.38.0",
+        "@memberjunction/ai": "2.38.0",
+        "@memberjunction/ai-mistral": "2.38.0",
+        "@memberjunction/ai-openai": "2.38.0",
+        "@memberjunction/ai-vectors-pinecone": "2.38.0",
+        "@memberjunction/aiengine": "2.38.0",
+        "@memberjunction/core": "2.38.0",
+        "@memberjunction/core-actions": "2.38.0",
+        "@memberjunction/core-entities": "2.38.0",
+        "@memberjunction/data-context": "2.38.0",
+        "@memberjunction/data-context-server": "2.38.0",
+        "@memberjunction/doc-utils": "2.38.0",
+        "@memberjunction/entity-communications-server": "2.38.0",
+        "@memberjunction/external-change-detection": "2.38.0",
+        "@memberjunction/global": "2.38.0",
+        "@memberjunction/graphql-dataprovider": "2.38.0",
+        "@memberjunction/queue": "2.38.0",
+        "@memberjunction/skip-types": "2.38.0",
+        "@memberjunction/sqlserver-dataprovider": "2.38.0",
+        "@memberjunction/storage": "2.38.0",
+        "@memberjunction/templates": "2.38.0",
         "@types/compression": "^1.7.5",
         "@types/cors": "^2.8.13",
         "@types/jsonwebtoken": "9.0.6",
@@ -32370,7 +32345,7 @@
     },
     "packages/MJStorage": {
       "name": "@memberjunction/storage",
-      "version": "2.37.1",
+      "version": "2.38.0",
       "license": "ISC",
       "dependencies": {
         "@aws-sdk/client-s3": "^3.537.0",
@@ -32378,9 +32353,9 @@
         "@azure/identity": "^4.0.1",
         "@azure/storage-blob": "^12.17.0",
         "@google-cloud/storage": "^7.9.0",
-        "@memberjunction/core": "2.37.1",
-        "@memberjunction/core-entities": "2.37.1",
-        "@memberjunction/global": "2.37.1",
+        "@memberjunction/core": "2.38.0",
+        "@memberjunction/core-entities": "2.38.0",
+        "@memberjunction/global": "2.38.0",
         "@microsoft/mgt-element": "^3.1.3",
         "@microsoft/mgt-msal2-provider": "^3.1.3",
         "@microsoft/mgt-sharepoint-provider": "^3.1.3",
@@ -32479,11 +32454,11 @@
     },
     "packages/SkipTypes": {
       "name": "@memberjunction/skip-types",
-      "version": "2.37.1",
+      "version": "2.38.0",
       "license": "ISC",
       "dependencies": {
-        "@memberjunction/core-entities": "2.37.1",
-        "@memberjunction/data-context": "2.37.1"
+        "@memberjunction/core-entities": "2.38.0",
+        "@memberjunction/data-context": "2.38.0"
       },
       "devDependencies": {
         "ts-node-dev": "^2.0.0",
@@ -32492,17 +32467,17 @@
     },
     "packages/SQLServerDataProvider": {
       "name": "@memberjunction/sqlserver-dataprovider",
-      "version": "2.37.1",
+      "version": "2.38.0",
       "license": "ISC",
       "dependencies": {
-        "@memberjunction/actions": "2.37.1",
-        "@memberjunction/ai": "2.37.1",
-        "@memberjunction/ai-vector-dupe": "2.37.1",
-        "@memberjunction/aiengine": "2.37.1",
-        "@memberjunction/core": "2.37.1",
-        "@memberjunction/core-entities": "2.37.1",
-        "@memberjunction/global": "2.37.1",
-        "@memberjunction/queue": "2.37.1",
+        "@memberjunction/actions": "2.38.0",
+        "@memberjunction/ai": "2.38.0",
+        "@memberjunction/ai-vector-dupe": "2.38.0",
+        "@memberjunction/aiengine": "2.38.0",
+        "@memberjunction/core": "2.38.0",
+        "@memberjunction/core-entities": "2.38.0",
+        "@memberjunction/global": "2.38.0",
+        "@memberjunction/queue": "2.38.0",
         "mssql": "^11.0.1",
         "typeorm": "^0.3.20"
       },
@@ -32590,12 +32565,12 @@
     },
     "packages/Templates/base-types": {
       "name": "@memberjunction/templates-base-types",
-      "version": "2.37.1",
+      "version": "2.38.0",
       "license": "ISC",
       "dependencies": {
-        "@memberjunction/core": "2.37.1",
-        "@memberjunction/core-entities": "2.37.1",
-        "@memberjunction/global": "2.37.1"
+        "@memberjunction/core": "2.38.0",
+        "@memberjunction/core-entities": "2.38.0",
+        "@memberjunction/global": "2.38.0"
       },
       "devDependencies": {
         "typescript": "^5.4.5"
@@ -32603,16 +32578,16 @@
     },
     "packages/Templates/engine": {
       "name": "@memberjunction/templates",
-      "version": "2.37.1",
+      "version": "2.38.0",
       "license": "ISC",
       "dependencies": {
-        "@memberjunction/ai": "2.37.1",
-        "@memberjunction/ai-groq": "2.37.1",
-        "@memberjunction/aiengine": "2.37.1",
-        "@memberjunction/core": "2.37.1",
-        "@memberjunction/core-entities": "2.37.1",
-        "@memberjunction/global": "2.37.1",
-        "@memberjunction/templates-base-types": "2.37.1",
+        "@memberjunction/ai": "2.38.0",
+        "@memberjunction/ai-groq": "2.38.0",
+        "@memberjunction/aiengine": "2.38.0",
+        "@memberjunction/core": "2.38.0",
+        "@memberjunction/core-entities": "2.38.0",
+        "@memberjunction/global": "2.38.0",
+        "@memberjunction/templates-base-types": "2.38.0",
         "nunjucks": "3.2.4"
       },
       "devDependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1170,21 +1170,6 @@
         "rxjs": "^6.5.3 || ^7.4.0"
       }
     },
-    "node_modules/@anthropic-ai/sdk": {
-      "version": "0.36.3",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.36.3.tgz",
-      "integrity": "sha512-+c0mMLxL/17yFZ4P5+U6bTWiCSFZUKJddrv01ud2aFBWnTPLdRncYV76D3q1tqfnL7aCnhRtykFnoCFzvr4U3Q==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/node": "^18.11.18",
-        "@types/node-fetch": "^2.6.4",
-        "abort-controller": "^3.0.0",
-        "agentkeepalive": "^4.2.1",
-        "form-data-encoder": "1.7.2",
-        "formdata-node": "^4.3.2",
-        "node-fetch": "^2.6.7"
-      }
-    },
     "node_modules/@apollo/cache-control-types": {
       "version": "1.0.3",
       "license": "MIT",
@@ -29414,13 +29399,25 @@
       "version": "2.37.1",
       "license": "ISC",
       "dependencies": {
-        "@anthropic-ai/sdk": "0.36.3",
+        "@anthropic-ai/sdk": "0.50.4",
         "@memberjunction/ai": "2.37.1",
         "@memberjunction/global": "2.37.1"
       },
       "devDependencies": {
         "ts-node-dev": "^2.0.0",
         "typescript": "^5.4.5"
+      }
+    },
+    "packages/AI/Providers/Anthropic/node_modules/@anthropic-ai/sdk": {
+      "version": "0.50.4",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.50.4.tgz",
+      "integrity": "sha512-zZOWyIuznx2uqiRcCNuidkAsLC8IBHgS9lTwSVEB29sUCwEcqL95MWpWP1nccHSKfiZga+hbZaI0btR2zjuMmw==",
+      "license": "MIT",
+      "bin": {
+        "anthropic-ai-sdk": "bin/cli"
+      },
+      "engines": {
+        "node": ">= 20"
       }
     },
     "packages/AI/Providers/Azure": {
@@ -29733,7 +29730,7 @@
       "dependencies": {
         "@memberjunction/ai": "2.37.1",
         "@memberjunction/global": "2.37.1",
-        "openai": "4.96.0"
+        "openai": "4.98.0"
       },
       "devDependencies": {
         "ts-node-dev": "^2.0.0",
@@ -29750,9 +29747,9 @@
       }
     },
     "packages/AI/Providers/OpenAI/node_modules/openai": {
-      "version": "4.96.0",
-      "resolved": "https://registry.npmjs.org/openai/-/openai-4.96.0.tgz",
-      "integrity": "sha512-dKoW56i02Prv2XQolJ9Rl9Svqubqkzg3QpwEOBuSVZLk05Shelu7s+ErRTwFc1Bs3JZ2qBqBfVpXQiJhwOGG8A==",
+      "version": "4.98.0",
+      "resolved": "https://registry.npmjs.org/openai/-/openai-4.98.0.tgz",
+      "integrity": "sha512-TmDKur1WjxxMPQAtLG5sgBSCJmX7ynTsGmewKzoDwl1fRxtbLOsiR0FA/AOAAtYUmP6azal+MYQuOENfdU+7yg==",
       "license": "Apache-2.0",
       "dependencies": {
         "@types/node": "^18.11.18",

--- a/packages/AI/Core/src/generic/baseLLM.ts
+++ b/packages/AI/Core/src/generic/baseLLM.ts
@@ -44,6 +44,10 @@ export abstract class BaseLLM extends BaseModel {
      * this will route to the streaming implementation.
      */
     public async ChatCompletion(params: ChatParams): Promise<ChatResult> {
+        if (params.enableCaching === undefined) {
+            params.enableCaching = true; // default to true            
+        }
+
         // Check if streaming is requested and if we support it
         if (params.streaming && params.streamingCallbacks && this.SupportsStreaming) {
             return this.handleStreamingChatCompletion(params);

--- a/packages/AI/Core/src/generic/chat.types.ts
+++ b/packages/AI/Core/src/generic/chat.types.ts
@@ -101,6 +101,17 @@ export class ChatParams extends BaseParams  {
      * If the model supports effort levels, this parameter can be used to specify the effort level.
      */
     effortLevel?: string;
+    
+    /**
+     * Whether to enable caching for this request.
+     * Implementation depends on the specific provider (the below are examples, many other providers exist):
+     * - For Anthropic: Uses Anthropic's ephemeral cache control to cache system prompt and last user message.
+     * - For OpenAI: Uses automatic caching (provider handles it).
+     * - For other providers: May be a no-op if caching isn't supported.
+     * 
+     * @default true - Caching is enabled by default for providers that support it.
+     */
+    enableCaching?: boolean = true;
 }
 /**
  * Returns the first user message from the chat params
@@ -130,9 +141,29 @@ export type ChatResultData = {
     usage: ModelUsage
 }
 
+/**
+ * Cache metadata returned from the provider
+ */
+export interface CacheMetadata {
+    /**
+     * Whether the request had a cache hit
+     */
+    cacheHit?: boolean;
+    
+    /**
+     * The number of tokens retrieved from cache
+     */
+    cachedTokenCount?: number;
+}
+
 export class ChatResult extends BaseResult {
     data: ChatResultData;
     success: boolean;
-    statusText: string
+    statusText: string;
+    
+    /**
+     * Cache-related metadata if available from the provider
+     */
+    cacheInfo?: CacheMetadata;
 }
  

--- a/packages/AI/Engine/src/AIEngine.ts
+++ b/packages/AI/Engine/src/AIEngine.ts
@@ -4,7 +4,7 @@ import { ClassifyResult } from "@memberjunction/ai";
 import { ChatResult } from "@memberjunction/ai";
 import { BaseEngine, BaseEntity, IMetadataProvider, LogError, Metadata, RunView, UserInfo } from "@memberjunction/core";
 import { MJGlobal } from "@memberjunction/global";
-import { AIActionEntity, AIAgentActionEntity, AIAgentModelEntity, AIAgentNoteEntity, AIAgentNoteTypeEntity, AIModelActionEntity, AIModelEntity, AIModelEntityExtended, AIPromptCategoryEntity, AIPromptEntity, AIPromptTypeEntity, AIResultCacheEntity, EntityAIActionEntity, EntityDocumentEntity, EntityDocumentTypeEntity, VectorDatabaseEntity } from "@memberjunction/core-entities";
+import { AIActionEntity, AIAgentActionEntity, AIAgentModelEntity, AIAgentNoteEntity, AIAgentNoteTypeEntity, AIModelActionEntity, AIModelEntity, AIModelEntityExtended, AIPromptCategoryEntity, AIPromptEntity, AIPromptTypeEntity, AIResultCacheEntity, ArtifactTypeEntity, EntityAIActionEntity, EntityDocumentEntity, EntityDocumentTypeEntity, VectorDatabaseEntity } from "@memberjunction/core-entities";
 import { AIPromptCategoryEntityExtended } from "./AIPromptCategoryExtended";
 import { AIAgentEntityExtended } from "./AIAgentExtended";
 
@@ -38,6 +38,7 @@ export class AIEngine extends BaseEngine<AIEngine> {
     private _agentNoteTypes: AIAgentNoteTypeEntity[] = [];
     private _agentNotes: AIAgentNoteEntity[] = [];
     private _agents: AIAgentEntityExtended[] = [];
+    private _artifactTypes: ArtifactTypeEntity[] = [];
 
     public async Config(forceRefresh?: boolean, contextUser?: UserInfo, provider?: IMetadataProvider) {
         const params = [
@@ -92,6 +93,10 @@ export class AIEngine extends BaseEngine<AIEngine> {
             {
                 PropertyName: '_agents',
                 EntityName: 'AI Agents'
+            },
+            {
+                PropertyName: '_artifactTypes',
+                EntityName: 'MJ: Artifact Types'
             }
         ];
         return await this.Load(params, provider, forceRefresh, contextUser);
@@ -372,6 +377,11 @@ export class AIEngine extends BaseEngine<AIEngine> {
     public get Models(): AIModelEntityExtended[] {
         AIEngine.checkMetadataLoaded();
         return AIEngine.Instance._models;
+    }
+
+    public get ArtifactTypes(): ArtifactTypeEntity[] {
+        AIEngine.checkMetadataLoaded();
+        return AIEngine.Instance._artifactTypes;
     }
 
     /**

--- a/packages/AI/Providers/Anthropic/package.json
+++ b/packages/AI/Providers/Anthropic/package.json
@@ -19,7 +19,7 @@
     "typescript": "^5.4.5"
   },
   "dependencies": {
-    "@anthropic-ai/sdk": "0.36.3",
+    "@anthropic-ai/sdk": "0.50.4",
     "@memberjunction/ai": "2.38.0",
     "@memberjunction/global": "2.38.0"
   }

--- a/packages/AI/Providers/OpenAI/package.json
+++ b/packages/AI/Providers/OpenAI/package.json
@@ -21,6 +21,6 @@
   "dependencies": {
     "@memberjunction/ai": "2.38.0",
     "@memberjunction/global": "2.38.0",
-    "openai": "4.96.0"
+    "openai": "4.98.0"
   }
 }

--- a/packages/Angular/Explorer/core-entity-forms/src/lib/generated/Entities/AIModel/sections/details.component.ts
+++ b/packages/Angular/Explorer/core-entity-forms/src/lib/generated/Entities/AIModel/sections/details.component.ts
@@ -126,6 +126,13 @@ import { AIModelEntity } from '@memberjunction/core-entities';
         <mj-form-field 
             [record]="record"
             [ShowLabel]="true"
+            FieldName="SupportsEffortLevel"
+            Type="checkbox"
+            [EditMode]="EditMode"
+        ></mj-form-field>
+        <mj-form-field 
+            [record]="record"
+            [ShowLabel]="true"
             FieldName="AIModelType"
             Type="textbox"
             [EditMode]="EditMode"

--- a/packages/Angular/Generic/skip-chat/src/lib/artifacts/skip-artifact-viewer.component.html
+++ b/packages/Angular/Generic/skip-chat/src/lib/artifacts/skip-artifact-viewer.component.html
@@ -3,9 +3,9 @@
     <div class="artifact-info">
       <h3 class="artifact-title">{{ artifactTitle }}</h3>
       <span class="artifact-type">{{ artifactTypeName }}</span>
-      @if (artifact.Description?.trim().length > 0) {
+      @if (artifact?.Description) {
         <div class="artifact-description">
-          <p>{{ artifact.Description }}</p>
+          <p>{{ artifact!.Description }}</p>
         </div>
       }
     </div>
@@ -49,10 +49,10 @@
 
       @if (artifactVersion) {
         <div class="artifact-metadata">
-          @if (artifactVersion.CreatedAt) {
+          @if (artifactVersion.__mj_CreatedAt) {
             <div class="metadata-item">
               <span class="metadata-label">Created:</span>
-              <span class="metadata-value">{{ artifactVersion.CreatedAt | date:'medium' }}</span>
+              <span class="metadata-value">{{ artifactVersion.__mj_CreatedAt | date:'medium' }}</span>
             </div>
           }
         </div>

--- a/packages/Angular/Generic/skip-chat/src/lib/artifacts/skip-artifact-viewer.component.ts
+++ b/packages/Angular/Generic/skip-chat/src/lib/artifacts/skip-artifact-viewer.component.ts
@@ -37,13 +37,13 @@ export class SkipArtifactViewerComponent extends BaseAngularComponent implements
   @Output() DrillDownEvent = new EventEmitter<DrillDownInfo>();
   
   public isLoading: boolean = false;
-  public artifact: any = null;
-  public artifactVersion: any = null;
+  public artifact: ConversationArtifactEntity | null = null;
+  public artifactVersion: ConversationArtifactVersionEntity | null = null;
   public artifactType: any = null;
   public contentType: string = '';
   public displayContent: any = null;
   public error: string | null = null;
-  public artifactVersions: any[] = [];
+  public artifactVersions: ConversationArtifactVersionEntity[] = [];
   public selectedVersionId: string = '';
   private reportComponentRef: ComponentRef<any> | null = null;
   private conversationDetailRecord: ConversationDetailEntity | null = null;
@@ -256,7 +256,7 @@ export class SkipArtifactViewerComponent extends BaseAngularComponent implements
       this.reportComponentRef = this.reportContainer.createComponent(componentFactory);
 
       if (this.reportComponentRef) {
-        const instance = this.reportComponentRef.instance;
+        const instance = this.reportComponentRef.instance as SkipDynamicReportWrapperComponent
         
         // Initialize from AI message or Configuration
         let configData = null;
@@ -298,7 +298,6 @@ export class SkipArtifactViewerComponent extends BaseAngularComponent implements
         // Set properties on the report component
         instance.SkipData = configData;
         instance.Provider = this.ProviderToUse;
-        instance.RunViewProvider = this.RunViewToUse;
         
         // Set up event handlers
         instance.NavigateToMatchingReport.subscribe((reportID: string) => {
@@ -324,6 +323,7 @@ export class SkipArtifactViewerComponent extends BaseAngularComponent implements
         if (this.conversationDetailRecord) {
           instance.ConversationID = this.conversationDetailRecord.ConversationID;
           instance.ConversationDetailID = this.conversationDetailRecord.ID;
+          instance.ConversationName = this.conversationDetailRecord.Conversation;
         }
       }
     } catch (err) {

--- a/packages/Angular/Generic/skip-chat/src/lib/skip-chat/skip-chat.component.ts
+++ b/packages/Angular/Generic/skip-chat/src/lib/skip-chat/skip-chat.component.ts
@@ -920,6 +920,7 @@ export class SkipChatComponent extends BaseAngularComponent implements OnInit, A
         return;
       }
 
+      this.selectedArtifact = null;
       this.SelectedConversationCurrentUserPermissionLevel = await this.GetUserConversationPermissionLevel(this.ProviderToUse.CurrentUser, conversation);
       this._conversationLoadComplete = false;
       this.ClearMessages();
@@ -1085,6 +1086,7 @@ export class SkipChatComponent extends BaseAngularComponent implements OnInit, A
       convoDetail.Role = 'User';
       // this is NOT saved here because it is saved on the server side. Later on in this code after the save we will update the object with the ID from the server, and below
       this.AddMessageToCurrentConversation(convoDetail, true, true);
+      this.scrollToBottom();
 
       this.SetSkipStatusMessage(this.pickSkipStartMessage(), 850);
 
@@ -1139,6 +1141,7 @@ export class SkipChatComponent extends BaseAngularComponent implements OnInit, A
           const aiDetail = <ConversationDetailEntity>await p.GetEntityObject('Conversation Details', p.CurrentUser);
           await aiDetail.Load(skipResult.AIMessageConversationDetailId); // get record from the database
           this.AddMessageToCurrentConversation(aiDetail, true, true);
+          this.scrollToBottom();
           // NOTE: we don't create a user notification at this point, that is done on the server and via GraphQL subscriptions it tells us and we update the UI automatically...
         }
       }

--- a/packages/Angular/Generic/skip-chat/src/lib/skip-chat/skip-chat.component.ts
+++ b/packages/Angular/Generic/skip-chat/src/lib/skip-chat/skip-chat.component.ts
@@ -99,9 +99,9 @@ export class SkipChatComponent extends BaseAngularComponent implements OnInit, A
   @Input() public EnableArtifactSplitView: boolean = true;
   
   /**
-   * Default ratio for split panels when viewing artifacts (0-1). Default is 0.6 (left panel takes 60% of width).
+   * Default ratio for split panels when viewing artifacts (0-1). Default is 0.5 (left panel takes 50% of width).
    */
-  @Input() public DefaultSplitRatio: number = 0.6;
+  @Input() public DefaultSplitRatio: number = 0.5;
 
   /**
    * This property is used to set the placeholder text for the textbox where the user types their message to Skip.   

--- a/packages/Angular/Generic/skip-chat/src/lib/skip-single-message/skip-single-message.component.ts
+++ b/packages/Angular/Generic/skip-chat/src/lib/skip-single-message/skip-single-message.component.ts
@@ -215,7 +215,13 @@ export class SkipSingleMessageComponent  extends BaseAngularComponent implements
                 this._cachedMessage = clarifyingQuestion.clarifyingQuestion;
                 break;
               case SkipResponsePhase.analysis_complete:
-                this._cachedMessage = '';//"Here's the report I've prepared for you, please let me know if you need anything changed or another report!"
+                // check to see if we have an artifact, if we do, then we want _cachedMessage to be the explanation of the report, otherwise we want it to be empty
+                if (this.ConversationDetailRecord.ArtifactID && this.ConversationDetailRecord.ArtifactID.length > 0) {
+                  this._cachedMessage = (<SkipAPIAnalysisCompleteResponse>resultObject).userExplanation || '';
+                }
+                else {
+                  this._cachedMessage = '';//"Here's the report I've prepared for you, please let me know if you need anything changed or another report!"
+                }
                 break;
               default:
                 this._cachedMessage = "";

--- a/packages/Angular/Generic/skip-chat/src/lib/skip-single-message/skip-single-message.component.ts
+++ b/packages/Angular/Generic/skip-chat/src/lib/skip-single-message/skip-single-message.component.ts
@@ -326,7 +326,7 @@ export class SkipSingleMessageComponent  extends BaseAngularComponent implements
             const analysisResult = <SkipAPIAnalysisCompleteResponse>resultObject;
             const componentRef = this.reportContainerRef.createComponent(SkipDynamicReportWrapperComponent);            
             
-            // Pass the data to the new chart
+            // Pass the data to the new report
             const report = componentRef.instance;
             report.NavigateToMatchingReport.subscribe((reportID: string) => {
               this.NavigateToMatchingReport.emit(reportID); // bubble up

--- a/packages/Angular/Generic/skip-chat/src/lib/split-panel/skip-split-panel.component.html
+++ b/packages/Angular/Generic/skip-chat/src/lib/split-panel/skip-split-panel.component.html
@@ -6,6 +6,7 @@
     
     <!-- Left Panel -->
     <kendo-splitter-pane 
+      #leftSplitterPane
       [size]="Mode === 'LeftOnly' ? '100%' : leftPaneSize"
       [min]="MinLeftPanelWidth"
       [resizable]="true"

--- a/packages/Angular/Generic/skip-chat/src/lib/split-panel/skip-split-panel.component.ts
+++ b/packages/Angular/Generic/skip-chat/src/lib/split-panel/skip-split-panel.component.ts
@@ -1,5 +1,6 @@
-import { Component, Input, Output, EventEmitter, OnInit, AfterViewInit, OnChanges, SimpleChanges } from '@angular/core';
+import { Component, Input, Output, EventEmitter, OnInit, AfterViewInit, OnChanges, SimpleChanges, ViewChild } from '@angular/core';
 import { BaseAngularComponent } from '@memberjunction/ng-base-types';
+import { SplitterPaneComponent } from '@progress/kendo-angular-layout';
 
 export type SplitPanelMode = 'LeftOnly' | 'RightOnly' | 'BothSides';
 
@@ -29,6 +30,9 @@ export class SkipSplitPanelComponent extends BaseAngularComponent implements OnI
   }
   
   @Output() public SplitRatioChanged = new EventEmitter<number>();
+
+  @ViewChild('leftSplitterPane', { static: false }) leftSplitterPane!: SplitterPaneComponent;
+
 
   // Properties for pane sizes
   public leftPaneSize: string = '50%';
@@ -94,6 +98,9 @@ export class SkipSplitPanelComponent extends BaseAngularComponent implements OnI
     // Store the current ratio before closing, so we can restore it later when reopening
     this._lastRatioBeforeClosing = this.SplitRatio;
     
+    if (this.leftSplitterPane) {
+      this.leftSplitterPane.collapsed = false; // make sure we're not collapsed
+    }
     // Close the right panel by switching to LeftOnly mode
     this.Mode = 'LeftOnly';
     this.SplitRatioChanged.emit(this.SplitRatio);

--- a/packages/MJCoreEntities/src/generated/entity_subclasses.ts
+++ b/packages/MJCoreEntities/src/generated/entity_subclasses.ts
@@ -1192,6 +1192,12 @@ export const AIModelSchema = z.object({
         * * SQL Data Type: nvarchar(100)
         * * Default Value: Any
     * * Description: A comma-delimited string indicating the supported response formats for the AI model. Options include Any, Text, Markdown, JSON, and ModelSpecific. Defaults to Any if not specified.`),
+    SupportsEffortLevel: z.boolean().describe(`
+        * * Field Name: SupportsEffortLevel
+        * * Display Name: Supports Effort Level
+        * * SQL Data Type: bit
+        * * Default Value: 0
+    * * Description: Specifies if the model supports the concept of an effort level. For example, for a reasoning model, the options often include low, medium, and high.`),
     AIModelType: z.string().describe(`
         * * Field Name: AIModelType
         * * Display Name: AIModel Type
@@ -13345,6 +13351,20 @@ export class AIModelEntity extends BaseEntity<AIModelEntityType> {
     }
     set SupportedResponseFormats(value: string) {
         this.Set('SupportedResponseFormats', value);
+    }
+
+    /**
+    * * Field Name: SupportsEffortLevel
+    * * Display Name: Supports Effort Level
+    * * SQL Data Type: bit
+    * * Default Value: 0
+    * * Description: Specifies if the model supports the concept of an effort level. For example, for a reasoning model, the options often include low, medium, and high.
+    */
+    get SupportsEffortLevel(): boolean {
+        return this.Get('SupportsEffortLevel');
+    }
+    set SupportsEffortLevel(value: boolean) {
+        this.Set('SupportsEffortLevel', value);
     }
 
     /**

--- a/packages/MJServer/src/generated/generated.ts
+++ b/packages/MJServer/src/generated/generated.ts
@@ -12023,6 +12023,9 @@ export class AIModel_ {
     @MaxLength(200)
     SupportedResponseFormats: string;
         
+    @Field(() => Boolean, {description: `Specifies if the model supports the concept of an effort level. For example, for a reasoning model, the options often include low, medium, and high.`}) 
+    SupportsEffortLevel: boolean;
+        
     @Field() 
     @MaxLength(100)
     AIModelType: string;
@@ -12102,6 +12105,9 @@ export class CreateAIModelInput {
 
     @Field({ nullable: true })
     SupportedResponseFormats?: string;
+
+    @Field(() => Boolean, { nullable: true })
+    SupportsEffortLevel?: boolean;
 }
     
 
@@ -12154,6 +12160,9 @@ export class UpdateAIModelInput {
 
     @Field({ nullable: true })
     SupportedResponseFormats?: string;
+
+    @Field(() => Boolean, { nullable: true })
+    SupportsEffortLevel?: boolean;
 
     @Field(() => [KeyValuePairInput], { nullable: true })
     OldValues___?: KeyValuePairInput[];

--- a/packages/MJServer/src/resolvers/AskSkipResolver.ts
+++ b/packages/MJServer/src/resolvers/AskSkipResolver.ts
@@ -2159,12 +2159,17 @@ cycle.`);
       artifactId = apiResponse.artifactRequest.artifactId; // will only be populated if action == new_artifact_version
       let newVersion: number = 0;
       if (apiResponse.artifactRequest?.action === 'new_artifact') {
-        const artifactEntity = await md.GetEntityObject<ConversationArtifactEntity>('MJ: Convesration Artifacts', user);
+        const artifactEntity = await md.GetEntityObject<ConversationArtifactEntity>('MJ: Conversation Artifacts', user);
         // create the new artifact here
         artifactEntity.NewRecord();
         artifactEntity.ConversationID = convoEntity.ID;
         artifactEntity.Name = apiResponse.artifactRequest.name;
         artifactEntity.Description = apiResponse.artifactRequest.description;
+        // make sure AI Engine is configured.
+        await AIEngine.Instance.Config(false, user)
+        artifactEntity.ArtifactTypeID = AIEngine.Instance.ArtifactTypes.find((t) => t.Name === 'Report')?.ID;
+        artifactEntity.SharingScope = 'None';
+
         if (await artifactEntity.Save()) {
           // saved, grab the new ID
           artifactId = artifactEntity.ID;
@@ -2176,7 +2181,7 @@ cycle.`);
       }
       else {
         // we are updating an existing artifact with a new vesrion so we need to get the old max version and increment it
-        const ei = md.EntityByName("MJ: Convesration Artifacts");        
+        const ei = md.EntityByName("MJ: Conversation Artifacts");        
         const sSQL = `SELECT ISNULL(MAX(Version),0) AS MaxVersion FROM [${ei.SchemaName}].[${ei.BaseView}] WHERE ID = '${artifactId}'`;
         const result = await dataSource.query(sSQL);
         if (result && result.length > 0) {

--- a/packages/MJServer/src/resolvers/AskSkipResolver.ts
+++ b/packages/MJServer/src/resolvers/AskSkipResolver.ts
@@ -2181,13 +2181,19 @@ cycle.`);
       }
       else {
         // we are updating an existing artifact with a new vesrion so we need to get the old max version and increment it
-        const ei = md.EntityByName("MJ: Conversation Artifacts");        
-        const sSQL = `SELECT ISNULL(MAX(Version),0) AS MaxVersion FROM [${ei.SchemaName}].[${ei.BaseView}] WHERE ID = '${artifactId}'`;
-        const result = await dataSource.query(sSQL);
-        if (result && result.length > 0) {
-          newVersion = result[0].MaxVersion + 1;
-        } else {
-          LogError(`Error getting max version for artifact ID: ${artifactId}`, undefined, result);
+        const ei = md.EntityByName("MJ: Conversation Artifact Versions");        
+        const sSQL = `SELECT ISNULL(MAX(Version),0) AS MaxVersion FROM [${ei.SchemaName}].[${ei.BaseView}] WHERE ConversationArtifactID = '${artifactId}'`;
+        try {
+          const result = await dataSource.query(sSQL);
+          if (result && result.length > 0) {
+            newVersion = result[0].MaxVersion + 1;
+          } 
+          else {
+            LogError(`Error getting max version for artifact ID: ${artifactId}`, undefined, result);
+          }
+        }
+        catch (e) {
+          LogError(`Error getting max version for artifact ID: ${artifactId}`, undefined, e);
         }
       }
       if (artifactId && newVersion > 0) {

--- a/packages/SkipTypes/src/types.ts
+++ b/packages/SkipTypes/src/types.ts
@@ -947,8 +947,8 @@ export interface SkipHTMLReportCallbacks {
     /**
      * If an action occurs inside an HTML Report where it would be desirable for the containing UI to open a specific 
      * record, if supported, this event can be listened to and the container UI can then open the record.
-     * @param entityName 
-     * @param key 
+     * @param entityName - this is the Entity NAME from the Entity metadata, not the table name or base view name. Use Entity Metadata to provide the entity name here
+     * @param key - this is an array of key/value pairs representing the primary key. The format of a Composite Key is an array of KeyValuePair objects and KeyValuePair objects simply have FieldName and Value properties. In most cases entities have single-valued primary keys but this structure is here for complex entity types that have composite primary keys
      * @returns 
      */
     OpenEntityRecord: (entityName: string, key: CompositeKey) => void;


### PR DESCRIPTION
- **feat(ai-sdk): Update OpenAI and Anthropic SDKs to latest versions**
- **fix(ai-anthropic): Restore thinking parameter support**
- **Changed budget >= 1 to drive thinking for Anthropic.**
- **docs(changeset): updated to include latest SDKs from openai/anthropic**
- **feat(caching): Add support for prompt caching in LLM providers**
- **feat(artifacts): Add support for conversation artifacts and reporting**
- **docs(changeset): Various minor updates for Skip**
- **bug fix for sql query**
- **docs(changeset): minor bug fixes**
- **bug fixes in Skip UI**
- **docs(changeset): minor bug fixes**
- **change default splitter ratio**
- **Bug fixes for Skip + Claude AI model updates (bump to 2.39)**
- **docs(changeset): New Claude Models - bumping to 2.39.0**
- **docs(changeset): minor ui bug fix**
- **SupportsEffortLevel field for the AIModels entity added via CodeGen to the various generated artifacts**
- **docs(changeset): Added SupportsEffortLevel to AIModels entity - generated artifacts to suit...**
- **clean up skip types a bit**
- **docs(changeset): clean up types**
- **Update lockfile**
