### PR TITLE
fix: Add missing quotes around GUID in V2.47 migration script

### DIFF
--- a/migrations/v2/V202506081500__v2.47.x__Fix_DateTime_Timezone_Handling.sql
+++ b/migrations/v2/V202506081500__v2.47.x__Fix_DateTime_Timezone_Handling.sql
@@ -984,7 +984,7 @@ BEGIN
             @ContextCompressionMessageThreshold,
             @ContextCompressionPromptID,
             @ContextCompressionMessageRetentionCount,
-            CASE @TypeID WHEN '00000000-0000-0000-0000-000000000000' THEN A7B8C9D0-E1F2-3456-7890-123456789ABC ELSE @TypeID END
+            CASE @TypeID WHEN '00000000-0000-0000-0000-000000000000' THEN 'A7B8C9D0-E1F2-3456-7890-123456789ABC' ELSE @TypeID END
         )
     -- return the new record from the base view, which might have some calculated fields
     SELECT * FROM [${flyway:defaultSchema}].[vwAIAgents] WHERE [ID] = (SELECT [ID] FROM @InsertedRow)


### PR DESCRIPTION
## Description

This PR fixes a SQL syntax error in the V2.47 migration script where a GUID constant was missing quotes in the spCreateAIAgent stored procedure.

## What Changed

In the CASE statement for the TypeID parameter:
- **Before**: `THEN A7B8C9D0-E1F2-3456-7890-123456789ABC`
- **After**: `THEN 'A7B8C9D0-E1F2-3456-7890-123456789ABC'`

## Impact

Without this fix, the migration would fail with a SQL syntax error when trying to create the stored procedure.

## Testing

- Verified the migration script now has valid SQL syntax
- The GUID is properly quoted as a string literal