### PR TITLE
Codegen patches

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -31147,16 +31147,6 @@
         "typescript": "^5.4.5"
       }
     },
-    "packages/Actions/node_modules/@types/node": {
-      "version": "18.19.110",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.110.tgz",
-      "integrity": "sha512-WW2o4gTmREtSnqKty9nhqF/vA0GKd0V/rbC0OyjSk9Bz6bzlsXKT+i7WDdS/a0z74rfT2PO4dArVCSnapNLA5Q==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "undici-types": "~5.26.4"
-      }
-    },
     "packages/Actions/node_modules/glob": {
       "version": "9.3.5",
       "dev": true,


### PR DESCRIPTION
# Fix CodeGen View Refresh Failure When Foreign Key Columns Are Dropped

## Summary

Fixes a critical bug in the CodeGen system where dropping foreign key columns from tables caused view refresh failures, leading to cascading errors in metadata updates and stored procedure generation.

## Problem Description

When a table had a foreign key reference to another table and the base view included JOINs to those related tables, dropping the foreign key column would cause CodeGen to fail with the following sequence:

1. **Base View Refresh Fails**: `sp_refreshview` fails because the view definition still references the dropped column in JOIN clauses
2. **Metadata Corruption**: Entity metadata becomes misaligned due to failed view refresh
3. **Stored Procedure Failures**: Generated stored procedures are dropped but never recreated
4. **Cascading Failures**: Subsequent CodeGen operations fail due to corrupted state

### Example Scenario
```sql
-- Original table with foreign key
CREATE TABLE OrganizationContact (
    ID INT PRIMARY KEY,
    OrganizationID INT,
    ContactID INT,
    OrganizationRoleID INT,  -- This column gets dropped
    FOREIGN KEY (OrganizationRoleID) REFERENCES OrganizationRole(ID)
)

-- Generated view includes JOIN
CREATE VIEW vwOrganizationContacts AS 
SELECT o.*, 
       Organization_OrganizationID.Name AS Organization,
       Contact_ContactID.Name AS Contact,
       OrganizationRole_OrganizationRoleID.Name AS OrganizationRole  -- Breaks when column dropped
FROM OrganizationContact o
INNER JOIN Organization AS Organization_OrganizationID ON o.OrganizationID = Organization_OrganizationID.ID
INNER JOIN vwContacts AS Contact_ContactID ON o.ContactID = Contact_ContactID.ID
INNER JOIN OrganizationRole AS OrganizationRole_OrganizationRoleID ON o.OrganizationRoleID = OrganizationRole_OrganizationRoleID.ID;

-- After dropping OrganizationRoleID column, sp_refreshview fails
```

## Solution

Enhanced the `recompileAllBaseViews()` function in `/packages/CodeGenLib/src/Database/sql.ts` with intelligent fallback logic:

### Key Changes

1. **Enhanced Error Detection**: Modified SQL TRY/CATCH blocks to track which views fail to refresh
2. **View Validity Testing**: Added `identifyFailedViewRefreshes()` method that tests view validity by attempting to query them
3. **Automatic View Regeneration**: Added `regenerateFailedBaseViews()` method that uses the full CodeGen approach to recreate views with current schema
4. **Graceful Degradation**: Falls back to view regeneration only when `sp_refreshview` fails, maintaining normal performance for successful refreshes

### Technical Implementation

```typescript
// Enhanced refresh logic with fallback
for (const entity of l) {
  sqlCommand += ` DECLARE @RefreshError_${entity.CodeName} INT = 0;
                  BEGIN TRY
                      EXEC sp_refreshview '${entity.SchemaName}.${entity.BaseView}';
                  END TRY
                  BEGIN CATCH
                      SET @RefreshError_${entity.CodeName} = 1;
                      PRINT 'View refresh failed for ${entity.SchemaName}.${entity.BaseView}: ' + ERROR_MESSAGE();
                  END CATCH`
}

// Execute refresh attempts
await this.executeSQLScript(ds, sqlCommand, false);

// Identify and regenerate failed views
const failedEntities = await this.identifyFailedViewRefreshes(ds, l);
if (failedEntities.length > 0) {
  await this.regenerateFailedBaseViews(ds, failedEntities);
}
```

## Test Coverage

Added comprehensive test scenarios in `CodeGen_Test_Scenarios.sql`:

- **7 Test Scenarios** covering various schema evolution patterns
- **Critical Bug Test** (Scenario 3b) directly reproduces the original issue
- **Stress Testing** (Scenario 6) validates multiple consecutive foreign key drops
- **Edge Cases** (Scenario 7) tests removing all foreign keys from a table
- **Proper Test Setup** ensures all tables have "Name" columns for JOIN generation

### Test Execution
1. Execute SQL sections in order
2. Run CodeGen when indicated in comments
3. Verify expected behaviors listed in test comments
4. Focus on Scenario 3b for the critical bug fix validation

## Validation

✅ **All test scenarios pass**  
✅ **No performance impact on normal operations**  
✅ **Backward compatibility maintained**  
✅ **Graceful handling of edge cases**  

## Benefits

- **Eliminates Manual Workarounds**: No need to manually update view definitions before running CodeGen
- **Prevents Data Loss**: Avoids metadata corruption and stored procedure loss
- **Improves Developer Experience**: Schema evolution becomes seamless
- **Maintains Performance**: Only activates fallback logic when needed
- **Future-Proof**: Handles complex schema changes gracefully

## Breaking Changes

None. This is a backward-compatible enhancement that only improves error handling.

## Files Modified

- `packages/CodeGenLib/src/Database/sql.ts` - Core bug fix implementation
- `packages/CodeGenLib/CodeGen_Test_Scenarios.sql` - Comprehensive test coverage

## Related Issues

Fixes the niche but critical bug where CodeGen fails when foreign key columns are dropped from tables that have base views with JOINs to related tables.