### PR TITLE
fix: fixed ordering of entity field creation/updates in CodeGen in or…

### DIFF
--- a/.changeset/shiny-zebras-melt.md
+++ b/.changeset/shiny-zebras-melt.md
@@ -1,0 +1,5 @@
+---
+"@memberjunction/codegen-lib": minor
+---
+
+Fix code gen field sequencing issues re: migrations, see commit


### PR DESCRIPTION
…der to ensure that migration scripts run in same way and updated logic to temporarily add a large integer (100,000) to each newly created sequence in a new entity field so that we never have conflicts - we use the calculated sequence + 100k which ensures no collisions of new fields being created. Then, spUpdateExistingEntityFieldsFromSchema runs after the new creation process resulting in the correct sequences.

The unique key constraint remains in place at all times this way and we ensure consistency between source/developer system and target systems via migration.