### PR TITLE
feat: Add System User GraphQL Resolvers for RunView and Query Operations

### DIFF
--- a/.changeset/real-spies-prove.md
+++ b/.changeset/real-spies-prove.md
@@ -1,0 +1,6 @@
+---
+"@memberjunction/graphql-dataprovider": patch
+"@memberjunction/server": patch
+---
+
+Add system user GraphQL resolvers for RunView and Query operations

--- a/package-lock.json
+++ b/package-lock.json
@@ -27840,14 +27840,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/stoppable": {
-      "version": "1.1.0",
-      "license": "MIT",
-      "engines": {
-        "node": ">=4",
-        "npm": ">=6"
-      }
-    },
     "node_modules/stream-events": {
       "version": "1.0.5",
       "license": "MIT",
@@ -31005,13 +30997,13 @@
     "packages/Actions": {},
     "packages/Actions/ApolloEnrichment": {
       "name": "@memberjunction/actions-apollo",
-      "version": "2.51.0",
+      "version": "2.52.0",
       "license": "ISC",
       "dependencies": {
-        "@memberjunction/actions": "2.51.0",
-        "@memberjunction/core": "2.51.0",
-        "@memberjunction/core-entities": "2.51.0",
-        "@memberjunction/global": "2.51.0",
+        "@memberjunction/actions": "2.52.0",
+        "@memberjunction/core": "2.52.0",
+        "@memberjunction/core-entities": "2.52.0",
+        "@memberjunction/global": "2.52.0",
         "axios": "^1.7.2"
       },
       "devDependencies": {
@@ -31021,12 +31013,12 @@
     },
     "packages/Actions/Base": {
       "name": "@memberjunction/actions-base",
-      "version": "2.51.0",
+      "version": "2.52.0",
       "license": "ISC",
       "dependencies": {
-        "@memberjunction/core": "2.51.0",
-        "@memberjunction/core-entities": "2.51.0",
-        "@memberjunction/global": "2.51.0"
+        "@memberjunction/core": "2.52.0",
+        "@memberjunction/core-entities": "2.52.0",
+        "@memberjunction/global": "2.52.0"
       },
       "devDependencies": {
         "ts-node-dev": "^2.0.0",
@@ -31035,15 +31027,15 @@
     },
     "packages/Actions/ContentAutotag": {
       "name": "@memberjunction/actions-content-autotag",
-      "version": "2.51.0",
+      "version": "2.52.0",
       "license": "ISC",
       "dependencies": {
-        "@memberjunction/actions": "2.51.0",
-        "@memberjunction/content-autotagging": "2.51.0",
-        "@memberjunction/core": "2.51.0",
-        "@memberjunction/core-actions": "2.51.0",
-        "@memberjunction/core-entities": "2.51.0",
-        "@memberjunction/global": "2.51.0",
+        "@memberjunction/actions": "2.52.0",
+        "@memberjunction/content-autotagging": "2.52.0",
+        "@memberjunction/core": "2.52.0",
+        "@memberjunction/core-actions": "2.52.0",
+        "@memberjunction/core-entities": "2.52.0",
+        "@memberjunction/global": "2.52.0",
         "axios": "^1.7.2"
       },
       "devDependencies": {
@@ -31053,17 +31045,17 @@
     },
     "packages/Actions/CoreActions": {
       "name": "@memberjunction/core-actions",
-      "version": "2.51.0",
+      "version": "2.52.0",
       "license": "ISC",
       "dependencies": {
-        "@memberjunction/actions": "2.51.0",
-        "@memberjunction/ai-vector-sync": "2.51.0",
-        "@memberjunction/communication-engine": "2.51.0",
-        "@memberjunction/content-autotagging": "2.51.0",
-        "@memberjunction/core": "2.51.0",
-        "@memberjunction/core-entities": "2.51.0",
-        "@memberjunction/external-change-detection": "2.51.0",
-        "@memberjunction/global": "2.51.0",
+        "@memberjunction/actions": "2.52.0",
+        "@memberjunction/ai-vector-sync": "2.52.0",
+        "@memberjunction/communication-engine": "2.52.0",
+        "@memberjunction/content-autotagging": "2.52.0",
+        "@memberjunction/core": "2.52.0",
+        "@memberjunction/core-entities": "2.52.0",
+        "@memberjunction/external-change-detection": "2.52.0",
+        "@memberjunction/global": "2.52.0",
         "axios": "^1.6.8"
       },
       "devDependencies": {
@@ -31073,30 +31065,20 @@
     },
     "packages/Actions/Engine": {
       "name": "@memberjunction/actions",
-      "version": "2.51.0",
+      "version": "2.52.0",
       "license": "ISC",
       "dependencies": {
-        "@memberjunction/actions-base": "2.51.0",
-        "@memberjunction/ai": "2.51.0",
-        "@memberjunction/aiengine": "2.51.0",
-        "@memberjunction/core": "2.51.0",
-        "@memberjunction/core-entities": "2.51.0",
-        "@memberjunction/doc-utils": "2.51.0",
-        "@memberjunction/global": "2.51.0"
+        "@memberjunction/actions-base": "2.52.0",
+        "@memberjunction/ai": "2.52.0",
+        "@memberjunction/aiengine": "2.52.0",
+        "@memberjunction/core": "2.52.0",
+        "@memberjunction/core-entities": "2.52.0",
+        "@memberjunction/doc-utils": "2.52.0",
+        "@memberjunction/global": "2.52.0"
       },
       "devDependencies": {
         "ts-node-dev": "^2.0.0",
         "typescript": "^5.4.5"
-      }
-    },
-    "packages/Actions/node_modules/@types/node": {
-      "version": "18.19.111",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.111.tgz",
-      "integrity": "sha512-90sGdgA+QLJr1F9X79tQuEut0gEYIfkX9pydI4XGRgvFo9g2JWswefI+WUSUHPYVBHYSEfTEqBxA5hQvAZB3Mw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "undici-types": "~5.26.4"
       }
     },
     "packages/Actions/node_modules/glob": {
@@ -31157,15 +31139,15 @@
     },
     "packages/Actions/ScheduledActions": {
       "name": "@memberjunction/scheduled-actions",
-      "version": "2.51.0",
+      "version": "2.52.0",
       "license": "ISC",
       "dependencies": {
-        "@memberjunction/actions": "2.51.0",
-        "@memberjunction/core": "2.51.0",
-        "@memberjunction/core-actions": "2.51.0",
-        "@memberjunction/core-entities": "2.51.0",
-        "@memberjunction/global": "2.51.0",
-        "@memberjunction/sqlserver-dataprovider": "2.51.0",
+        "@memberjunction/actions": "2.52.0",
+        "@memberjunction/core": "2.52.0",
+        "@memberjunction/core-actions": "2.52.0",
+        "@memberjunction/core-entities": "2.52.0",
+        "@memberjunction/global": "2.52.0",
+        "@memberjunction/sqlserver-dataprovider": "2.52.0",
         "cron-parser": "^4.9.0"
       },
       "devDependencies": {
@@ -31175,19 +31157,19 @@
     },
     "packages/Actions/ScheduledActionsServer": {
       "name": "@memberjunction/scheduled-actions-server",
-      "version": "2.51.0",
+      "version": "2.52.0",
       "license": "ISC",
       "dependencies": {
-        "@memberjunction/actions": "2.51.0",
-        "@memberjunction/actions-content-autotag": "2.51.0",
-        "@memberjunction/ai": "2.51.0",
-        "@memberjunction/ai-mistral": "2.51.0",
-        "@memberjunction/ai-openai": "2.51.0",
-        "@memberjunction/ai-vector-sync": "2.51.0",
-        "@memberjunction/ai-vectors-pinecone": "2.51.0",
-        "@memberjunction/core": "2.51.0",
-        "@memberjunction/core-entities": "2.51.0",
-        "@memberjunction/scheduled-actions": "2.51.0",
+        "@memberjunction/actions": "2.52.0",
+        "@memberjunction/actions-content-autotag": "2.52.0",
+        "@memberjunction/ai": "2.52.0",
+        "@memberjunction/ai-mistral": "2.52.0",
+        "@memberjunction/ai-openai": "2.52.0",
+        "@memberjunction/ai-vector-sync": "2.52.0",
+        "@memberjunction/ai-vectors-pinecone": "2.52.0",
+        "@memberjunction/core": "2.52.0",
+        "@memberjunction/core-entities": "2.52.0",
+        "@memberjunction/scheduled-actions": "2.52.0",
         "@types/axios": "^0.14.0",
         "env-var": "^7.3.0",
         "express": "^4.18.2",
@@ -31213,12 +31195,12 @@
     },
     "packages/AI/A2AServer": {
       "name": "@memberjunction/a2aserver",
-      "version": "2.51.0",
+      "version": "2.52.0",
       "license": "MIT",
       "dependencies": {
-        "@memberjunction/core": "2.51.0",
-        "@memberjunction/global": "2.51.0",
-        "@memberjunction/sqlserver-dataprovider": "2.51.0",
+        "@memberjunction/core": "2.52.0",
+        "@memberjunction/global": "2.52.0",
+        "@memberjunction/sqlserver-dataprovider": "2.52.0",
         "cosmiconfig": "^8.0.0",
         "dotenv": "^16.0.3",
         "express": "^4.18.2",
@@ -31270,17 +31252,17 @@
     },
     "packages/AI/Agents": {
       "name": "@memberjunction/ai-agents",
-      "version": "2.51.0",
+      "version": "2.52.0",
       "license": "ISC",
       "dependencies": {
-        "@memberjunction/actions": "2.51.0",
-        "@memberjunction/actions-base": "2.51.0",
-        "@memberjunction/ai": "2.51.0",
-        "@memberjunction/ai-prompts": "2.51.0",
-        "@memberjunction/aiengine": "2.51.0",
-        "@memberjunction/core": "2.51.0",
-        "@memberjunction/core-entities": "2.51.0",
-        "@memberjunction/global": "2.51.0",
+        "@memberjunction/actions": "2.52.0",
+        "@memberjunction/actions-base": "2.52.0",
+        "@memberjunction/ai": "2.52.0",
+        "@memberjunction/ai-prompts": "2.52.0",
+        "@memberjunction/aiengine": "2.52.0",
+        "@memberjunction/core": "2.52.0",
+        "@memberjunction/core-entities": "2.52.0",
+        "@memberjunction/global": "2.52.0",
         "dotenv": "^16.4.1",
         "rxjs": "^7.8.1"
       },
@@ -31292,13 +31274,13 @@
     },
     "packages/AI/BaseAIEngine": {
       "name": "@memberjunction/ai-engine-base",
-      "version": "2.51.0",
+      "version": "2.52.0",
       "license": "ISC",
       "dependencies": {
-        "@memberjunction/ai": "2.51.0",
-        "@memberjunction/core": "2.51.0",
-        "@memberjunction/core-entities": "2.51.0",
-        "@memberjunction/global": "2.51.0",
+        "@memberjunction/ai": "2.52.0",
+        "@memberjunction/core": "2.52.0",
+        "@memberjunction/core-entities": "2.52.0",
+        "@memberjunction/global": "2.52.0",
         "dotenv": "^16.4.1",
         "rxjs": "^7.8.1"
       },
@@ -31310,10 +31292,10 @@
     },
     "packages/AI/Core": {
       "name": "@memberjunction/ai",
-      "version": "2.51.0",
+      "version": "2.52.0",
       "license": "ISC",
       "dependencies": {
-        "@memberjunction/global": "2.51.0",
+        "@memberjunction/global": "2.52.0",
         "dotenv": "^16.4.1",
         "rxjs": "^7.8.1"
       },
@@ -31325,14 +31307,14 @@
     },
     "packages/AI/Engine": {
       "name": "@memberjunction/aiengine",
-      "version": "2.51.0",
+      "version": "2.52.0",
       "license": "ISC",
       "dependencies": {
-        "@memberjunction/ai": "2.51.0",
-        "@memberjunction/ai-engine-base": "2.51.0",
-        "@memberjunction/core": "2.51.0",
-        "@memberjunction/core-entities": "2.51.0",
-        "@memberjunction/global": "2.51.0",
+        "@memberjunction/ai": "2.52.0",
+        "@memberjunction/ai-engine-base": "2.52.0",
+        "@memberjunction/core": "2.52.0",
+        "@memberjunction/core-entities": "2.52.0",
+        "@memberjunction/global": "2.52.0",
         "dotenv": "^16.4.1",
         "rxjs": "^7.8.1"
       },
@@ -31344,13 +31326,13 @@
     },
     "packages/AI/MCPServer": {
       "name": "@memberjunction/ai-mcp-server",
-      "version": "2.51.0",
+      "version": "2.52.0",
       "license": "ISC",
       "dependencies": {
-        "@memberjunction/core": "2.51.0",
-        "@memberjunction/core-entities": "2.51.0",
-        "@memberjunction/global": "2.51.0",
-        "@memberjunction/sqlserver-dataprovider": "2.51.0",
+        "@memberjunction/core": "2.52.0",
+        "@memberjunction/core-entities": "2.52.0",
+        "@memberjunction/global": "2.52.0",
+        "@memberjunction/sqlserver-dataprovider": "2.52.0",
         "@modelcontextprotocol/sdk": "^1.8.0",
         "cosmiconfig": "9.0.0",
         "dotenv": "^16.4.1",
@@ -31369,16 +31351,16 @@
     },
     "packages/AI/Prompts": {
       "name": "@memberjunction/ai-prompts",
-      "version": "2.51.0",
+      "version": "2.52.0",
       "license": "ISC",
       "dependencies": {
-        "@memberjunction/ai": "2.51.0",
-        "@memberjunction/aiengine": "2.51.0",
-        "@memberjunction/core": "2.51.0",
-        "@memberjunction/core-entities": "2.51.0",
-        "@memberjunction/global": "2.51.0",
-        "@memberjunction/templates": "2.51.0",
-        "@memberjunction/templates-base-types": "2.51.0",
+        "@memberjunction/ai": "2.52.0",
+        "@memberjunction/aiengine": "2.52.0",
+        "@memberjunction/core": "2.52.0",
+        "@memberjunction/core-entities": "2.52.0",
+        "@memberjunction/global": "2.52.0",
+        "@memberjunction/templates": "2.52.0",
+        "@memberjunction/templates-base-types": "2.52.0",
         "ajv": "^8.12.0",
         "date-fns": "^2.30.0",
         "date-fns-tz": "^2.0.0",
@@ -31440,12 +31422,12 @@
     },
     "packages/AI/Providers/Anthropic": {
       "name": "@memberjunction/ai-anthropic",
-      "version": "2.51.0",
+      "version": "2.52.0",
       "license": "ISC",
       "dependencies": {
         "@anthropic-ai/sdk": "0.50.4",
-        "@memberjunction/ai": "2.51.0",
-        "@memberjunction/global": "2.51.0"
+        "@memberjunction/ai": "2.52.0",
+        "@memberjunction/global": "2.52.0"
       },
       "devDependencies": {
         "ts-node-dev": "^2.0.0",
@@ -31466,7 +31448,7 @@
     },
     "packages/AI/Providers/Azure": {
       "name": "@memberjunction/ai-azure",
-      "version": "2.51.0",
+      "version": "2.52.0",
       "license": "MIT",
       "dependencies": {
         "@azure-rest/ai-inference": "^1.0.0-beta.6",
@@ -31478,120 +31460,6 @@
       "devDependencies": {
         "rimraf": "^5.0.0",
         "typescript": "^5.0.2"
-      }
-    },
-    "packages/AI/Providers/Azure/node_modules/@azure/abort-controller": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/@azure/abort-controller/-/abort-controller-2.1.2.tgz",
-      "integrity": "sha512-nBrLsEWm4J2u5LpAPjxADTlq3trDgVZZXHNKabeXZtpq3d3AbN/KGO82R87rdDz5/lYB024rtEf10/q0urNgsA==",
-      "license": "MIT",
-      "dependencies": {
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "packages/AI/Providers/Azure/node_modules/@azure/identity": {
-      "version": "4.9.1",
-      "resolved": "https://registry.npmjs.org/@azure/identity/-/identity-4.9.1.tgz",
-      "integrity": "sha512-986D7Cf1AOwYqSDtO/FnMAyk/Jc8qpftkGsxuehoh4F85MhQ4fICBGX/44+X1y78lN4Sqib3Bsoaoh/FvOGgmg==",
-      "license": "MIT",
-      "dependencies": {
-        "@azure/abort-controller": "^2.0.0",
-        "@azure/core-auth": "^1.9.0",
-        "@azure/core-client": "^1.9.2",
-        "@azure/core-rest-pipeline": "^1.17.0",
-        "@azure/core-tracing": "^1.0.0",
-        "@azure/core-util": "^1.11.0",
-        "@azure/logger": "^1.0.0",
-        "@azure/msal-browser": "^4.2.0",
-        "@azure/msal-node": "^3.5.0",
-        "open": "^10.1.0",
-        "tslib": "^2.2.0"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "packages/AI/Providers/Azure/node_modules/@azure/msal-browser": {
-      "version": "4.11.1",
-      "resolved": "https://registry.npmjs.org/@azure/msal-browser/-/msal-browser-4.11.1.tgz",
-      "integrity": "sha512-jPxASelqmP/0R1jZuYW8cboba95M9jpUi2ZqzgftddlAIRZA9KL/YaESuT55zu9+BIPS5Eo2kuhy3q2jjU3whg==",
-      "license": "MIT",
-      "dependencies": {
-        "@azure/msal-common": "15.5.2"
-      },
-      "engines": {
-        "node": ">=0.8.0"
-      }
-    },
-    "packages/AI/Providers/Azure/node_modules/@azure/msal-common": {
-      "version": "15.5.2",
-      "resolved": "https://registry.npmjs.org/@azure/msal-common/-/msal-common-15.5.2.tgz",
-      "integrity": "sha512-+G85T6oA6i4ubzjOw4BpWd8QCG2FunYN4jaz96gw3SUd8+89vwuiqLg6mtnm/lkPC95bayD+CwuwFn9wvhQGow==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.8.0"
-      }
-    },
-    "packages/AI/Providers/Azure/node_modules/@azure/msal-node": {
-      "version": "3.5.2",
-      "resolved": "https://registry.npmjs.org/@azure/msal-node/-/msal-node-3.5.2.tgz",
-      "integrity": "sha512-mt97ieL+IpD/7Hj7Q6pGTPk3dBgvhkOV1HYyH+PkOakhbOOCEb9flAteDgBfADRXBsYJZT+ZlEbPJa4IDn9HZw==",
-      "license": "MIT",
-      "dependencies": {
-        "@azure/msal-common": "15.5.2",
-        "jsonwebtoken": "^9.0.0",
-        "uuid": "^8.3.0"
-      },
-      "engines": {
-        "node": ">=16"
-      }
-    },
-    "packages/AI/Providers/Azure/node_modules/define-lazy-prop": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/define-lazy-prop/-/define-lazy-prop-3.0.0.tgz",
-      "integrity": "sha512-N+MeXYoqr3pOgn8xfyRPREN7gHakLYjhsHhWGT3fWAiL4IkAt0iDw14QiiEm2bE30c5XX5q0FtAA3CK5f9/BUg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "packages/AI/Providers/Azure/node_modules/is-wsl": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-3.1.0.tgz",
-      "integrity": "sha512-UcVfVfaK4Sc4m7X3dUSoHoozQGBEFeDC+zVo06t98xe8CzHSZZBekNXH+tu0NalHolcJ/QAGqS46Hef7QXBIMw==",
-      "license": "MIT",
-      "dependencies": {
-        "is-inside-container": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=16"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "packages/AI/Providers/Azure/node_modules/open": {
-      "version": "10.1.2",
-      "resolved": "https://registry.npmjs.org/open/-/open-10.1.2.tgz",
-      "integrity": "sha512-cxN6aIDPz6rm8hbebcP7vrQNhvRcveZoJU72Y7vskh4oIm+BZwBECnx5nTmrlres1Qapvx27Qo1Auukpf8PKXw==",
-      "license": "MIT",
-      "dependencies": {
-        "default-browser": "^5.2.1",
-        "define-lazy-prop": "^3.0.0",
-        "is-inside-container": "^1.0.0",
-        "is-wsl": "^3.1.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "packages/AI/Providers/Azure/node_modules/rimraf": {
@@ -31610,23 +31478,14 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
-    "packages/AI/Providers/Azure/node_modules/uuid": {
-      "version": "8.3.2",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
-      "license": "MIT",
-      "bin": {
-        "uuid": "dist/bin/uuid"
-      }
-    },
     "packages/AI/Providers/Bedrock": {
       "name": "@memberjunction/ai-bedrock",
-      "version": "2.51.0",
+      "version": "2.52.0",
       "license": "ISC",
       "dependencies": {
         "@aws-sdk/client-bedrock-runtime": "^3.496.0",
-        "@memberjunction/ai": "2.51.0",
-        "@memberjunction/global": "2.51.0"
+        "@memberjunction/ai": "2.52.0",
+        "@memberjunction/global": "2.52.0"
       },
       "devDependencies": {
         "ts-node-dev": "^2.0.0",
@@ -31635,11 +31494,11 @@
     },
     "packages/AI/Providers/BettyBot": {
       "name": "@memberjunction/ai-betty-bot",
-      "version": "2.51.0",
+      "version": "2.52.0",
       "license": "ISC",
       "dependencies": {
-        "@memberjunction/ai": "2.51.0",
-        "@memberjunction/global": "2.51.0",
+        "@memberjunction/ai": "2.52.0",
+        "@memberjunction/global": "2.52.0",
         "axios": "^1.7.7",
         "axios-retry": "^4.3.0",
         "env-var": "^7.5.0"
@@ -31651,12 +31510,12 @@
     },
     "packages/AI/Providers/Cerebras": {
       "name": "@memberjunction/ai-cerebras",
-      "version": "2.51.0",
+      "version": "2.52.0",
       "license": "ISC",
       "dependencies": {
         "@cerebras/cerebras_cloud_sdk": "^1.29.0",
-        "@memberjunction/ai": "2.51.0",
-        "@memberjunction/global": "2.51.0"
+        "@memberjunction/ai": "2.52.0",
+        "@memberjunction/global": "2.52.0"
       },
       "devDependencies": {
         "ts-node-dev": "^2.0.0",
@@ -31665,11 +31524,11 @@
     },
     "packages/AI/Providers/ElevenLabs": {
       "name": "@memberjunction/ai-elevenlabs",
-      "version": "2.51.0",
+      "version": "2.52.0",
       "license": "ISC",
       "dependencies": {
-        "@memberjunction/ai": "2.51.0",
-        "@memberjunction/global": "2.51.0",
+        "@memberjunction/ai": "2.52.0",
+        "@memberjunction/global": "2.52.0",
         "elevenlabs": "^1.51.0"
       },
       "devDependencies": {
@@ -31679,12 +31538,12 @@
     },
     "packages/AI/Providers/Gemini": {
       "name": "@memberjunction/ai-gemini",
-      "version": "2.51.0",
+      "version": "2.52.0",
       "license": "ISC",
       "dependencies": {
         "@google/genai": "0.14.0",
-        "@memberjunction/ai": "2.51.0",
-        "@memberjunction/global": "2.51.0"
+        "@memberjunction/ai": "2.52.0",
+        "@memberjunction/global": "2.52.0"
       },
       "devDependencies": {
         "ts-node-dev": "^2.0.0",
@@ -31693,11 +31552,11 @@
     },
     "packages/AI/Providers/Groq": {
       "name": "@memberjunction/ai-groq",
-      "version": "2.51.0",
+      "version": "2.52.0",
       "license": "ISC",
       "dependencies": {
-        "@memberjunction/ai": "2.51.0",
-        "@memberjunction/global": "2.51.0",
+        "@memberjunction/ai": "2.52.0",
+        "@memberjunction/global": "2.52.0",
         "groq-sdk": "0.21.0"
       },
       "devDependencies": {
@@ -31731,11 +31590,11 @@
     },
     "packages/AI/Providers/HeyGen": {
       "name": "@memberjunction/ai-heygen",
-      "version": "2.51.0",
+      "version": "2.52.0",
       "license": "ISC",
       "dependencies": {
-        "@memberjunction/ai": "2.51.0",
-        "@memberjunction/global": "2.51.0",
+        "@memberjunction/ai": "2.52.0",
+        "@memberjunction/global": "2.52.0",
         "elevenlabs": "^1.51.0"
       },
       "devDependencies": {
@@ -31745,11 +31604,11 @@
     },
     "packages/AI/Providers/Mistral": {
       "name": "@memberjunction/ai-mistral",
-      "version": "2.51.0",
+      "version": "2.52.0",
       "license": "ISC",
       "dependencies": {
-        "@memberjunction/ai": "2.51.0",
-        "@memberjunction/global": "2.51.0",
+        "@memberjunction/ai": "2.52.0",
+        "@memberjunction/global": "2.52.0",
         "@mistralai/mistralai": "^1.6.0",
         "axios-retry": "4.3.0"
       },
@@ -31783,11 +31642,11 @@
     },
     "packages/AI/Providers/OpenAI": {
       "name": "@memberjunction/ai-openai",
-      "version": "2.51.0",
+      "version": "2.52.0",
       "license": "ISC",
       "dependencies": {
-        "@memberjunction/ai": "2.51.0",
-        "@memberjunction/global": "2.51.0",
+        "@memberjunction/ai": "2.52.0",
+        "@memberjunction/global": "2.52.0",
         "openai": "4.98.0"
       },
       "devDependencies": {
@@ -31859,12 +31718,12 @@
     },
     "packages/AI/Providers/Recommendations-Rex": {
       "name": "@memberjunction/ai-recommendations-rex",
-      "version": "2.51.0",
+      "version": "2.52.0",
       "license": "ISC",
       "dependencies": {
-        "@memberjunction/ai": "2.51.0",
-        "@memberjunction/ai-recommendations": "2.51.0",
-        "@memberjunction/global": "2.51.0",
+        "@memberjunction/ai": "2.52.0",
+        "@memberjunction/ai-recommendations": "2.52.0",
+        "@memberjunction/global": "2.52.0",
         "axios": "^1.7.2",
         "dotenv": "^16.4.1",
         "openai": "^4.28.4"
@@ -31876,13 +31735,13 @@
     },
     "packages/AI/Providers/Vectors-Pinecone": {
       "name": "@memberjunction/ai-vectors-pinecone",
-      "version": "2.51.0",
+      "version": "2.52.0",
       "license": "ISC",
       "dependencies": {
-        "@memberjunction/ai-vectors": "2.51.0",
-        "@memberjunction/aiengine": "2.51.0",
-        "@memberjunction/core": "2.51.0",
-        "@memberjunction/global": "2.51.0",
+        "@memberjunction/ai-vectors": "2.52.0",
+        "@memberjunction/aiengine": "2.52.0",
+        "@memberjunction/core": "2.52.0",
+        "@memberjunction/global": "2.52.0",
         "@pinecone-database/pinecone": "2.2.2",
         "dotenv": "^16.4.1",
         "openai": "^4.28.4",
@@ -31896,12 +31755,12 @@
     },
     "packages/AI/Providers/Vertex": {
       "name": "@memberjunction/ai-vertex",
-      "version": "2.51.0",
+      "version": "2.52.0",
       "license": "ISC",
       "dependencies": {
         "@google-cloud/vertexai": "^1.8.1",
-        "@memberjunction/ai": "2.51.0",
-        "@memberjunction/global": "2.51.0"
+        "@memberjunction/ai": "2.52.0",
+        "@memberjunction/global": "2.52.0"
       },
       "devDependencies": {
         "ts-node-dev": "^2.0.0",
@@ -31910,13 +31769,13 @@
     },
     "packages/AI/Recommendations/Engine": {
       "name": "@memberjunction/ai-recommendations",
-      "version": "2.51.0",
+      "version": "2.52.0",
       "license": "ISC",
       "dependencies": {
-        "@memberjunction/ai": "2.51.0",
-        "@memberjunction/core": "2.51.0",
-        "@memberjunction/core-entities": "2.51.0",
-        "@memberjunction/global": "2.51.0"
+        "@memberjunction/ai": "2.52.0",
+        "@memberjunction/core": "2.52.0",
+        "@memberjunction/core-entities": "2.52.0",
+        "@memberjunction/global": "2.52.0"
       },
       "devDependencies": {
         "ts-node-dev": "^2.0.0",
@@ -31925,15 +31784,15 @@
     },
     "packages/AI/Vectors/Core": {
       "name": "@memberjunction/ai-vectors",
-      "version": "2.51.0",
+      "version": "2.52.0",
       "license": "ISC",
       "dependencies": {
-        "@memberjunction/ai": "2.51.0",
-        "@memberjunction/ai-vectordb": "2.51.0",
-        "@memberjunction/aiengine": "2.51.0",
-        "@memberjunction/core": "2.51.0",
-        "@memberjunction/core-entities": "2.51.0",
-        "@memberjunction/global": "2.51.0",
+        "@memberjunction/ai": "2.52.0",
+        "@memberjunction/ai-vectordb": "2.52.0",
+        "@memberjunction/aiengine": "2.52.0",
+        "@memberjunction/core": "2.52.0",
+        "@memberjunction/core-entities": "2.52.0",
+        "@memberjunction/global": "2.52.0",
         "dotenv": "^16.4.1",
         "openai": "^4.28.4"
       },
@@ -31945,11 +31804,11 @@
     },
     "packages/AI/Vectors/Database": {
       "name": "@memberjunction/ai-vectordb",
-      "version": "2.51.0",
+      "version": "2.52.0",
       "license": "ISC",
       "dependencies": {
-        "@memberjunction/core": "2.51.0",
-        "@memberjunction/global": "2.51.0",
+        "@memberjunction/core": "2.52.0",
+        "@memberjunction/global": "2.52.0",
         "dotenv": "^16.4.1"
       },
       "devDependencies": {
@@ -31960,18 +31819,18 @@
     },
     "packages/AI/Vectors/Dupe": {
       "name": "@memberjunction/ai-vector-dupe",
-      "version": "2.51.0",
+      "version": "2.52.0",
       "license": "ISC",
       "dependencies": {
-        "@memberjunction/ai": "2.51.0",
-        "@memberjunction/ai-vector-sync": "2.51.0",
-        "@memberjunction/ai-vectordb": "2.51.0",
-        "@memberjunction/ai-vectors": "2.51.0",
-        "@memberjunction/ai-vectors-pinecone": "2.51.0",
-        "@memberjunction/aiengine": "2.51.0",
-        "@memberjunction/core": "2.51.0",
-        "@memberjunction/core-entities": "2.51.0",
-        "@memberjunction/global": "2.51.0",
+        "@memberjunction/ai": "2.52.0",
+        "@memberjunction/ai-vector-sync": "2.52.0",
+        "@memberjunction/ai-vectordb": "2.52.0",
+        "@memberjunction/ai-vectors": "2.52.0",
+        "@memberjunction/ai-vectors-pinecone": "2.52.0",
+        "@memberjunction/aiengine": "2.52.0",
+        "@memberjunction/core": "2.52.0",
+        "@memberjunction/core-entities": "2.52.0",
+        "@memberjunction/global": "2.52.0",
         "dotenv": "^16.4.1"
       },
       "devDependencies": {
@@ -31983,20 +31842,20 @@
     },
     "packages/AI/Vectors/Sync": {
       "name": "@memberjunction/ai-vector-sync",
-      "version": "2.51.0",
+      "version": "2.52.0",
       "license": "ISC",
       "dependencies": {
-        "@memberjunction/ai": "2.51.0",
-        "@memberjunction/ai-mistral": "2.51.0",
-        "@memberjunction/ai-openai": "2.51.0",
-        "@memberjunction/ai-vectordb": "2.51.0",
-        "@memberjunction/ai-vectors": "2.51.0",
-        "@memberjunction/ai-vectors-pinecone": "2.51.0",
-        "@memberjunction/aiengine": "2.51.0",
-        "@memberjunction/core": "2.51.0",
-        "@memberjunction/global": "2.51.0",
-        "@memberjunction/templates": "2.51.0",
-        "@memberjunction/templates-base-types": "2.51.0",
+        "@memberjunction/ai": "2.52.0",
+        "@memberjunction/ai-mistral": "2.52.0",
+        "@memberjunction/ai-openai": "2.52.0",
+        "@memberjunction/ai-vectordb": "2.52.0",
+        "@memberjunction/ai-vectors": "2.52.0",
+        "@memberjunction/ai-vectors-pinecone": "2.52.0",
+        "@memberjunction/aiengine": "2.52.0",
+        "@memberjunction/core": "2.52.0",
+        "@memberjunction/global": "2.52.0",
+        "@memberjunction/templates": "2.52.0",
+        "@memberjunction/templates-base-types": "2.52.0",
         "dotenv": "^16.4.1",
         "mssql": "^11.0.1"
       },
@@ -32009,22 +31868,22 @@
     },
     "packages/Angular/Explorer/ask-skip": {
       "name": "@memberjunction/ng-ask-skip",
-      "version": "2.51.0",
+      "version": "2.52.0",
       "license": "ISC",
       "dependencies": {
         "@angular/cdk": "18.0.2",
-        "@memberjunction/core": "2.51.0",
-        "@memberjunction/core-entities": "2.51.0",
-        "@memberjunction/global": "2.51.0",
-        "@memberjunction/graphql-dataprovider": "2.51.0",
-        "@memberjunction/ng-chat": "2.51.0",
-        "@memberjunction/ng-container-directives": "2.51.0",
-        "@memberjunction/ng-data-context": "2.51.0",
-        "@memberjunction/ng-shared": "2.51.0",
-        "@memberjunction/ng-skip-chat": "2.51.0",
-        "@memberjunction/ng-tabstrip": "2.51.0",
-        "@memberjunction/ng-user-view-grid": "2.51.0",
-        "@memberjunction/skip-types": "2.51.0",
+        "@memberjunction/core": "2.52.0",
+        "@memberjunction/core-entities": "2.52.0",
+        "@memberjunction/global": "2.52.0",
+        "@memberjunction/graphql-dataprovider": "2.52.0",
+        "@memberjunction/ng-chat": "2.52.0",
+        "@memberjunction/ng-container-directives": "2.52.0",
+        "@memberjunction/ng-data-context": "2.52.0",
+        "@memberjunction/ng-shared": "2.52.0",
+        "@memberjunction/ng-skip-chat": "2.52.0",
+        "@memberjunction/ng-tabstrip": "2.52.0",
+        "@memberjunction/ng-user-view-grid": "2.52.0",
+        "@memberjunction/skip-types": "2.52.0",
         "@progress/kendo-angular-dialog": "16.2.0",
         "@progress/kendo-angular-filter": "16.2.0",
         "@progress/kendo-angular-grid": "16.2.0",
@@ -32085,10 +31944,10 @@
     },
     "packages/Angular/Explorer/auth-services": {
       "name": "@memberjunction/ng-auth-services",
-      "version": "2.51.0",
+      "version": "2.52.0",
       "license": "ISC",
       "dependencies": {
-        "@memberjunction/core": "2.51.0",
+        "@memberjunction/core": "2.52.0",
         "tslib": "^2.3.0"
       },
       "devDependencies": {
@@ -32106,18 +31965,18 @@
     },
     "packages/Angular/Explorer/base-forms": {
       "name": "@memberjunction/ng-base-forms",
-      "version": "2.51.0",
+      "version": "2.52.0",
       "license": "ISC",
       "dependencies": {
-        "@memberjunction/core": "2.51.0",
-        "@memberjunction/global": "2.51.0",
-        "@memberjunction/ng-base-types": "2.51.0",
-        "@memberjunction/ng-code-editor": "2.51.0",
-        "@memberjunction/ng-container-directives": "2.51.0",
-        "@memberjunction/ng-link-directives": "2.51.0",
-        "@memberjunction/ng-record-changes": "2.51.0",
-        "@memberjunction/ng-shared": "2.51.0",
-        "@memberjunction/ng-tabstrip": "2.51.0",
+        "@memberjunction/core": "2.52.0",
+        "@memberjunction/global": "2.52.0",
+        "@memberjunction/ng-base-types": "2.52.0",
+        "@memberjunction/ng-code-editor": "2.52.0",
+        "@memberjunction/ng-container-directives": "2.52.0",
+        "@memberjunction/ng-link-directives": "2.52.0",
+        "@memberjunction/ng-record-changes": "2.52.0",
+        "@memberjunction/ng-shared": "2.52.0",
+        "@memberjunction/ng-tabstrip": "2.52.0",
         "@progress/kendo-angular-buttons": "16.2.0",
         "@progress/kendo-angular-dateinputs": "16.2.0",
         "@progress/kendo-angular-dialog": "16.2.0",
@@ -32173,11 +32032,11 @@
     },
     "packages/Angular/Explorer/compare-records": {
       "name": "@memberjunction/ng-compare-records",
-      "version": "2.51.0",
+      "version": "2.52.0",
       "license": "ISC",
       "dependencies": {
-        "@memberjunction/core": "2.51.0",
-        "@memberjunction/core-entities": "2.51.0",
+        "@memberjunction/core": "2.52.0",
+        "@memberjunction/core-entities": "2.52.0",
         "@progress/kendo-angular-grid": "16.2.0",
         "tslib": "^2.3.0"
       },
@@ -32227,20 +32086,20 @@
     },
     "packages/Angular/Explorer/core-entity-forms": {
       "name": "@memberjunction/ng-core-entity-forms",
-      "version": "2.51.0",
+      "version": "2.52.0",
       "license": "ISC",
       "dependencies": {
-        "@memberjunction/ai-engine-base": "2.51.0",
-        "@memberjunction/core": "2.51.0",
-        "@memberjunction/core-entities": "2.51.0",
-        "@memberjunction/ng-base-forms": "2.51.0",
-        "@memberjunction/ng-code-editor": "2.51.0",
-        "@memberjunction/ng-container-directives": "2.51.0",
-        "@memberjunction/ng-explorer-core": "2.51.0",
-        "@memberjunction/ng-form-toolbar": "2.51.0",
-        "@memberjunction/ng-join-grid": "2.51.0",
-        "@memberjunction/ng-tabstrip": "2.51.0",
-        "@memberjunction/ng-timeline": "2.51.0",
+        "@memberjunction/ai-engine-base": "2.52.0",
+        "@memberjunction/core": "2.52.0",
+        "@memberjunction/core-entities": "2.52.0",
+        "@memberjunction/ng-base-forms": "2.52.0",
+        "@memberjunction/ng-code-editor": "2.52.0",
+        "@memberjunction/ng-container-directives": "2.52.0",
+        "@memberjunction/ng-explorer-core": "2.52.0",
+        "@memberjunction/ng-form-toolbar": "2.52.0",
+        "@memberjunction/ng-join-grid": "2.52.0",
+        "@memberjunction/ng-tabstrip": "2.52.0",
+        "@memberjunction/ng-timeline": "2.52.0",
         "@progress/kendo-angular-dropdowns": "16.2.0",
         "@progress/kendo-angular-grid": "16.2.0",
         "tslib": "^2.3.0"
@@ -32257,17 +32116,17 @@
     },
     "packages/Angular/Explorer/dashboards": {
       "name": "@memberjunction/ng-dashboards",
-      "version": "2.51.0",
+      "version": "2.52.0",
       "license": "ISC",
       "dependencies": {
         "@codemirror/language-data": "^6.5.1",
         "@codemirror/merge": "^6.6.3",
-        "@memberjunction/core": "2.51.0",
-        "@memberjunction/core-entities": "2.51.0",
-        "@memberjunction/ng-container-directives": "2.51.0",
-        "@memberjunction/ng-notifications": "2.51.0",
-        "@memberjunction/ng-shared": "2.51.0",
-        "@memberjunction/templates-base-types": "2.51.0",
+        "@memberjunction/core": "2.52.0",
+        "@memberjunction/core-entities": "2.52.0",
+        "@memberjunction/ng-container-directives": "2.52.0",
+        "@memberjunction/ng-notifications": "2.52.0",
+        "@memberjunction/ng-shared": "2.52.0",
+        "@memberjunction/templates-base-types": "2.52.0",
         "@progress/kendo-angular-dropdowns": "16.2.0",
         "@progress/kendo-angular-indicators": "16.2.0",
         "@progress/kendo-angular-inputs": "16.2.0",
@@ -32315,15 +32174,15 @@
     },
     "packages/Angular/Explorer/entity-form-dialog": {
       "name": "@memberjunction/ng-entity-form-dialog",
-      "version": "2.51.0",
+      "version": "2.52.0",
       "license": "ISC",
       "dependencies": {
-        "@memberjunction/core": "2.51.0",
-        "@memberjunction/core-entities": "2.51.0",
-        "@memberjunction/global": "2.51.0",
-        "@memberjunction/ng-base-forms": "2.51.0",
-        "@memberjunction/ng-container-directives": "2.51.0",
-        "@memberjunction/ng-shared": "2.51.0",
+        "@memberjunction/core": "2.52.0",
+        "@memberjunction/core-entities": "2.52.0",
+        "@memberjunction/global": "2.52.0",
+        "@memberjunction/ng-base-forms": "2.52.0",
+        "@memberjunction/ng-container-directives": "2.52.0",
+        "@memberjunction/ng-shared": "2.52.0",
         "@progress/kendo-angular-buttons": "16.2.0",
         "@progress/kendo-angular-dialog": "16.2.0",
         "tslib": "^2.3.0"
@@ -32341,14 +32200,14 @@
     },
     "packages/Angular/Explorer/entity-permissions": {
       "name": "@memberjunction/ng-entity-permissions",
-      "version": "2.51.0",
+      "version": "2.52.0",
       "license": "ISC",
       "dependencies": {
-        "@memberjunction/core": "2.51.0",
-        "@memberjunction/core-entities": "2.51.0",
-        "@memberjunction/global": "2.51.0",
-        "@memberjunction/ng-container-directives": "2.51.0",
-        "@memberjunction/ng-shared": "2.51.0",
+        "@memberjunction/core": "2.52.0",
+        "@memberjunction/core-entities": "2.52.0",
+        "@memberjunction/global": "2.52.0",
+        "@memberjunction/ng-container-directives": "2.52.0",
+        "@memberjunction/ng-shared": "2.52.0",
         "@progress/kendo-angular-buttons": "16.2.0",
         "@progress/kendo-angular-dialog": "16.2.0",
         "@progress/kendo-angular-dropdowns": "16.2.0",
@@ -32369,33 +32228,33 @@
     },
     "packages/Angular/Explorer/explorer-core": {
       "name": "@memberjunction/ng-explorer-core",
-      "version": "2.51.0",
+      "version": "2.52.0",
       "license": "ISC",
       "dependencies": {
-        "@memberjunction/communication-types": "2.51.0",
-        "@memberjunction/core": "2.51.0",
-        "@memberjunction/core-entities": "2.51.0",
-        "@memberjunction/entity-communications-client": "2.51.0",
-        "@memberjunction/global": "2.51.0",
-        "@memberjunction/ng-ask-skip": "2.51.0",
-        "@memberjunction/ng-auth-services": "2.51.0",
-        "@memberjunction/ng-base-forms": "2.51.0",
-        "@memberjunction/ng-compare-records": "2.51.0",
-        "@memberjunction/ng-container-directives": "2.51.0",
-        "@memberjunction/ng-dashboards": "2.51.0",
-        "@memberjunction/ng-entity-form-dialog": "2.51.0",
-        "@memberjunction/ng-explorer-settings": "2.51.0",
-        "@memberjunction/ng-file-storage": "2.51.0",
-        "@memberjunction/ng-query-grid": "2.51.0",
-        "@memberjunction/ng-record-changes": "2.51.0",
-        "@memberjunction/ng-record-selector": "2.51.0",
-        "@memberjunction/ng-resource-permissions": "2.51.0",
-        "@memberjunction/ng-shared": "2.51.0",
-        "@memberjunction/ng-skip-chat": "2.51.0",
-        "@memberjunction/ng-tabstrip": "2.51.0",
-        "@memberjunction/ng-user-view-grid": "2.51.0",
-        "@memberjunction/ng-user-view-properties": "2.51.0",
-        "@memberjunction/templates-base-types": "2.51.0",
+        "@memberjunction/communication-types": "2.52.0",
+        "@memberjunction/core": "2.52.0",
+        "@memberjunction/core-entities": "2.52.0",
+        "@memberjunction/entity-communications-client": "2.52.0",
+        "@memberjunction/global": "2.52.0",
+        "@memberjunction/ng-ask-skip": "2.52.0",
+        "@memberjunction/ng-auth-services": "2.52.0",
+        "@memberjunction/ng-base-forms": "2.52.0",
+        "@memberjunction/ng-compare-records": "2.52.0",
+        "@memberjunction/ng-container-directives": "2.52.0",
+        "@memberjunction/ng-dashboards": "2.52.0",
+        "@memberjunction/ng-entity-form-dialog": "2.52.0",
+        "@memberjunction/ng-explorer-settings": "2.52.0",
+        "@memberjunction/ng-file-storage": "2.52.0",
+        "@memberjunction/ng-query-grid": "2.52.0",
+        "@memberjunction/ng-record-changes": "2.52.0",
+        "@memberjunction/ng-record-selector": "2.52.0",
+        "@memberjunction/ng-resource-permissions": "2.52.0",
+        "@memberjunction/ng-shared": "2.52.0",
+        "@memberjunction/ng-skip-chat": "2.52.0",
+        "@memberjunction/ng-tabstrip": "2.52.0",
+        "@memberjunction/ng-user-view-grid": "2.52.0",
+        "@memberjunction/ng-user-view-properties": "2.52.0",
+        "@memberjunction/templates-base-types": "2.52.0",
         "@progress/kendo-angular-buttons": "16.2.0",
         "@progress/kendo-angular-charts": "16.2.0",
         "@progress/kendo-angular-dialog": "16.2.0",
@@ -32423,21 +32282,21 @@
     },
     "packages/Angular/Explorer/explorer-settings": {
       "name": "@memberjunction/ng-explorer-settings",
-      "version": "2.51.0",
+      "version": "2.52.0",
       "license": "ISC",
       "dependencies": {
-        "@memberjunction/core": "2.51.0",
-        "@memberjunction/core-entities": "2.51.0",
-        "@memberjunction/global": "2.51.0",
-        "@memberjunction/ng-base-forms": "2.51.0",
-        "@memberjunction/ng-container-directives": "2.51.0",
-        "@memberjunction/ng-entity-form-dialog": "2.51.0",
-        "@memberjunction/ng-entity-permissions": "2.51.0",
-        "@memberjunction/ng-notifications": "2.51.0",
-        "@memberjunction/ng-shared": "2.51.0",
-        "@memberjunction/ng-simple-record-list": "2.51.0",
-        "@memberjunction/ng-tabstrip": "2.51.0",
-        "@memberjunction/ng-user-view-grid": "2.51.0",
+        "@memberjunction/core": "2.52.0",
+        "@memberjunction/core-entities": "2.52.0",
+        "@memberjunction/global": "2.52.0",
+        "@memberjunction/ng-base-forms": "2.52.0",
+        "@memberjunction/ng-container-directives": "2.52.0",
+        "@memberjunction/ng-entity-form-dialog": "2.52.0",
+        "@memberjunction/ng-entity-permissions": "2.52.0",
+        "@memberjunction/ng-notifications": "2.52.0",
+        "@memberjunction/ng-shared": "2.52.0",
+        "@memberjunction/ng-simple-record-list": "2.52.0",
+        "@memberjunction/ng-tabstrip": "2.52.0",
+        "@memberjunction/ng-user-view-grid": "2.52.0",
         "@progress/kendo-angular-buttons": "16.2.0",
         "@progress/kendo-angular-dialog": "16.2.0",
         "@progress/kendo-angular-dropdowns": "16.2.0",
@@ -32459,16 +32318,16 @@
     },
     "packages/Angular/Explorer/form-toolbar": {
       "name": "@memberjunction/ng-form-toolbar",
-      "version": "2.51.0",
+      "version": "2.52.0",
       "license": "ISC",
       "dependencies": {
-        "@memberjunction/core": "2.51.0",
-        "@memberjunction/global": "2.51.0",
-        "@memberjunction/ng-ask-skip": "2.51.0",
-        "@memberjunction/ng-base-forms": "2.51.0",
-        "@memberjunction/ng-container-directives": "2.51.0",
-        "@memberjunction/ng-record-changes": "2.51.0",
-        "@memberjunction/ng-shared": "2.51.0",
+        "@memberjunction/core": "2.52.0",
+        "@memberjunction/global": "2.52.0",
+        "@memberjunction/ng-ask-skip": "2.52.0",
+        "@memberjunction/ng-base-forms": "2.52.0",
+        "@memberjunction/ng-container-directives": "2.52.0",
+        "@memberjunction/ng-record-changes": "2.52.0",
+        "@memberjunction/ng-shared": "2.52.0",
         "@progress/kendo-angular-buttons": "16.2.0",
         "@progress/kendo-angular-dialog": "16.2.0",
         "ngx-markdown": "^18.0.0",
@@ -32520,10 +32379,10 @@
     },
     "packages/Angular/Explorer/link-directives": {
       "name": "@memberjunction/ng-link-directives",
-      "version": "2.51.0",
+      "version": "2.52.0",
       "license": "ISC",
       "dependencies": {
-        "@memberjunction/core": "2.51.0",
+        "@memberjunction/core": "2.52.0",
         "tslib": "^2.3.0"
       },
       "devDependencies": {
@@ -32538,15 +32397,15 @@
     },
     "packages/Angular/Explorer/list-detail-grid": {
       "name": "@memberjunction/ng-list-detail-grid",
-      "version": "2.51.0",
+      "version": "2.52.0",
       "license": "ISC",
       "dependencies": {
-        "@memberjunction/core": "2.51.0",
-        "@memberjunction/core-entities": "2.51.0",
-        "@memberjunction/global": "2.51.0",
-        "@memberjunction/ng-compare-records": "2.51.0",
-        "@memberjunction/ng-container-directives": "2.51.0",
-        "@memberjunction/ng-shared": "2.51.0",
+        "@memberjunction/core": "2.52.0",
+        "@memberjunction/core-entities": "2.52.0",
+        "@memberjunction/global": "2.52.0",
+        "@memberjunction/ng-compare-records": "2.52.0",
+        "@memberjunction/ng-container-directives": "2.52.0",
+        "@memberjunction/ng-shared": "2.52.0",
         "@progress/kendo-angular-buttons": "16.2.0",
         "@progress/kendo-angular-grid": "16.2.0",
         "@progress/kendo-angular-inputs": "16.2.0",
@@ -32566,14 +32425,14 @@
     },
     "packages/Angular/Explorer/record-changes": {
       "name": "@memberjunction/ng-record-changes",
-      "version": "2.51.0",
+      "version": "2.52.0",
       "license": "ISC",
       "dependencies": {
-        "@memberjunction/core": "2.51.0",
-        "@memberjunction/global": "2.51.0",
-        "@memberjunction/ng-compare-records": "2.51.0",
-        "@memberjunction/ng-container-directives": "2.51.0",
-        "@memberjunction/ng-notifications": "2.51.0",
+        "@memberjunction/core": "2.52.0",
+        "@memberjunction/global": "2.52.0",
+        "@memberjunction/ng-compare-records": "2.52.0",
+        "@memberjunction/ng-container-directives": "2.52.0",
+        "@memberjunction/ng-notifications": "2.52.0",
         "diff": "8.0.2",
         "tslib": "^2.3.0"
       },
@@ -32631,14 +32490,14 @@
     },
     "packages/Angular/Explorer/shared": {
       "name": "@memberjunction/ng-shared",
-      "version": "2.51.0",
+      "version": "2.52.0",
       "license": "ISC",
       "dependencies": {
-        "@memberjunction/core": "2.51.0",
-        "@memberjunction/core-entities": "2.51.0",
-        "@memberjunction/graphql-dataprovider": "2.51.0",
-        "@memberjunction/ng-base-types": "2.51.0",
-        "@memberjunction/ng-notifications": "2.51.0",
+        "@memberjunction/core": "2.52.0",
+        "@memberjunction/core-entities": "2.52.0",
+        "@memberjunction/graphql-dataprovider": "2.52.0",
+        "@memberjunction/ng-base-types": "2.52.0",
+        "@memberjunction/ng-notifications": "2.52.0",
         "@progress/kendo-angular-notification": "16.2.0",
         "tslib": "^2.3.0"
       },
@@ -32655,15 +32514,15 @@
     },
     "packages/Angular/Explorer/simple-record-list": {
       "name": "@memberjunction/ng-simple-record-list",
-      "version": "2.51.0",
+      "version": "2.52.0",
       "license": "ISC",
       "dependencies": {
-        "@memberjunction/core": "2.51.0",
-        "@memberjunction/core-entities": "2.51.0",
-        "@memberjunction/global": "2.51.0",
-        "@memberjunction/ng-container-directives": "2.51.0",
-        "@memberjunction/ng-entity-form-dialog": "2.51.0",
-        "@memberjunction/ng-notifications": "2.51.0",
+        "@memberjunction/core": "2.52.0",
+        "@memberjunction/core-entities": "2.52.0",
+        "@memberjunction/global": "2.52.0",
+        "@memberjunction/ng-container-directives": "2.52.0",
+        "@memberjunction/ng-entity-form-dialog": "2.52.0",
+        "@memberjunction/ng-notifications": "2.52.0",
         "@progress/kendo-angular-buttons": "16.2.0",
         "@progress/kendo-angular-dialog": "16.2.0",
         "@progress/kendo-angular-indicators": "16.2.0",
@@ -32683,22 +32542,22 @@
     },
     "packages/Angular/Explorer/user-view-grid": {
       "name": "@memberjunction/ng-user-view-grid",
-      "version": "2.51.0",
+      "version": "2.52.0",
       "license": "ISC",
       "dependencies": {
-        "@memberjunction/actions-base": "2.51.0",
-        "@memberjunction/communication-types": "2.51.0",
-        "@memberjunction/core": "2.51.0",
-        "@memberjunction/core-entities": "2.51.0",
-        "@memberjunction/entity-communications-client": "2.51.0",
-        "@memberjunction/global": "2.51.0",
-        "@memberjunction/ng-base-types": "2.51.0",
-        "@memberjunction/ng-compare-records": "2.51.0",
-        "@memberjunction/ng-container-directives": "2.51.0",
-        "@memberjunction/ng-entity-communications": "2.51.0",
-        "@memberjunction/ng-entity-form-dialog": "2.51.0",
-        "@memberjunction/ng-shared": "2.51.0",
-        "@memberjunction/templates-base-types": "2.51.0",
+        "@memberjunction/actions-base": "2.52.0",
+        "@memberjunction/communication-types": "2.52.0",
+        "@memberjunction/core": "2.52.0",
+        "@memberjunction/core-entities": "2.52.0",
+        "@memberjunction/entity-communications-client": "2.52.0",
+        "@memberjunction/global": "2.52.0",
+        "@memberjunction/ng-base-types": "2.52.0",
+        "@memberjunction/ng-compare-records": "2.52.0",
+        "@memberjunction/ng-container-directives": "2.52.0",
+        "@memberjunction/ng-entity-communications": "2.52.0",
+        "@memberjunction/ng-entity-form-dialog": "2.52.0",
+        "@memberjunction/ng-shared": "2.52.0",
+        "@memberjunction/templates-base-types": "2.52.0",
         "@progress/kendo-angular-buttons": "16.2.0",
         "@progress/kendo-angular-grid": "16.2.0",
         "@progress/kendo-angular-inputs": "16.2.0",
@@ -32718,16 +32577,16 @@
     },
     "packages/Angular/Explorer/user-view-properties": {
       "name": "@memberjunction/ng-user-view-properties",
-      "version": "2.51.0",
+      "version": "2.52.0",
       "license": "ISC",
       "dependencies": {
-        "@memberjunction/core": "2.51.0",
-        "@memberjunction/core-entities": "2.51.0",
-        "@memberjunction/global": "2.51.0",
-        "@memberjunction/ng-base-forms": "2.51.0",
-        "@memberjunction/ng-find-record": "2.51.0",
-        "@memberjunction/ng-resource-permissions": "2.51.0",
-        "@memberjunction/ng-shared": "2.51.0",
+        "@memberjunction/core": "2.52.0",
+        "@memberjunction/core-entities": "2.52.0",
+        "@memberjunction/global": "2.52.0",
+        "@memberjunction/ng-base-forms": "2.52.0",
+        "@memberjunction/ng-find-record": "2.52.0",
+        "@memberjunction/ng-resource-permissions": "2.52.0",
+        "@memberjunction/ng-shared": "2.52.0",
         "@progress/kendo-angular-buttons": "16.2.0",
         "@progress/kendo-angular-dialog": "16.2.0",
         "@progress/kendo-angular-filter": "16.2.0",
@@ -32749,12 +32608,12 @@
     },
     "packages/Angular/Generic/base-types": {
       "name": "@memberjunction/ng-base-types",
-      "version": "2.51.0",
+      "version": "2.52.0",
       "license": "ISC",
       "dependencies": {
-        "@memberjunction/core": "2.51.0",
-        "@memberjunction/core-entities": "2.51.0",
-        "@memberjunction/global": "2.51.0",
+        "@memberjunction/core": "2.52.0",
+        "@memberjunction/core-entities": "2.52.0",
+        "@memberjunction/global": "2.52.0",
         "tslib": "^2.3.0"
       },
       "devDependencies": {
@@ -32768,11 +32627,11 @@
     },
     "packages/Angular/Generic/chat": {
       "name": "@memberjunction/ng-chat",
-      "version": "2.51.0",
+      "version": "2.52.0",
       "license": "ISC",
       "dependencies": {
-        "@memberjunction/core": "2.51.0",
-        "@memberjunction/ng-container-directives": "2.51.0",
+        "@memberjunction/core": "2.52.0",
+        "@memberjunction/ng-container-directives": "2.52.0",
         "@progress/kendo-angular-buttons": "16.2.0",
         "@progress/kendo-angular-dialog": "16.2.0",
         "@progress/kendo-angular-indicators": "16.2.0",
@@ -32824,7 +32683,7 @@
     },
     "packages/Angular/Generic/code-editor": {
       "name": "@memberjunction/ng-code-editor",
-      "version": "2.51.0",
+      "version": "2.52.0",
       "license": "ISC",
       "dependencies": {
         "@codemirror/lang-javascript": "^6.2.2",
@@ -32833,10 +32692,10 @@
         "@codemirror/lang-sql": "^6.7.1",
         "@codemirror/language-data": "^6.5.1",
         "@codemirror/merge": "^6.6.3",
-        "@memberjunction/core": "2.51.0",
-        "@memberjunction/core-entities": "2.51.0",
-        "@memberjunction/global": "2.51.0",
-        "@memberjunction/ng-container-directives": "2.51.0",
+        "@memberjunction/core": "2.52.0",
+        "@memberjunction/core-entities": "2.52.0",
+        "@memberjunction/global": "2.52.0",
+        "@memberjunction/ng-container-directives": "2.52.0",
         "codemirror": "^6.0.1",
         "tslib": "^2.3.0"
       },
@@ -32865,11 +32724,11 @@
     },
     "packages/Angular/Generic/container-directives": {
       "name": "@memberjunction/ng-container-directives",
-      "version": "2.51.0",
+      "version": "2.52.0",
       "license": "ISC",
       "dependencies": {
-        "@memberjunction/core": "2.51.0",
-        "@memberjunction/global": "2.51.0",
+        "@memberjunction/core": "2.52.0",
+        "@memberjunction/global": "2.52.0",
         "tslib": "^2.3.0"
       },
       "devDependencies": {
@@ -32884,13 +32743,13 @@
     },
     "packages/Angular/Generic/data-context": {
       "name": "@memberjunction/ng-data-context",
-      "version": "2.51.0",
+      "version": "2.52.0",
       "license": "ISC",
       "dependencies": {
-        "@memberjunction/core": "2.51.0",
-        "@memberjunction/core-entities": "2.51.0",
-        "@memberjunction/global": "2.51.0",
-        "@memberjunction/ng-container-directives": "2.51.0",
+        "@memberjunction/core": "2.52.0",
+        "@memberjunction/core-entities": "2.52.0",
+        "@memberjunction/global": "2.52.0",
+        "@memberjunction/ng-container-directives": "2.52.0",
         "tslib": "^2.3.0"
       },
       "devDependencies": {
@@ -32906,17 +32765,17 @@
     },
     "packages/Angular/Generic/entity-communication": {
       "name": "@memberjunction/ng-entity-communications",
-      "version": "2.51.0",
+      "version": "2.52.0",
       "license": "ISC",
       "dependencies": {
-        "@memberjunction/communication-types": "2.51.0",
-        "@memberjunction/core": "2.51.0",
-        "@memberjunction/core-entities": "2.51.0",
-        "@memberjunction/entity-communications-base": "2.51.0",
-        "@memberjunction/entity-communications-client": "2.51.0",
-        "@memberjunction/global": "2.51.0",
-        "@memberjunction/ng-container-directives": "2.51.0",
-        "@memberjunction/ng-shared": "2.51.0",
+        "@memberjunction/communication-types": "2.52.0",
+        "@memberjunction/core": "2.52.0",
+        "@memberjunction/core-entities": "2.52.0",
+        "@memberjunction/entity-communications-base": "2.52.0",
+        "@memberjunction/entity-communications-client": "2.52.0",
+        "@memberjunction/global": "2.52.0",
+        "@memberjunction/ng-container-directives": "2.52.0",
+        "@memberjunction/ng-shared": "2.52.0",
         "tslib": "^2.3.0"
       },
       "devDependencies": {
@@ -32936,15 +32795,15 @@
     },
     "packages/Angular/Generic/file-storage": {
       "name": "@memberjunction/ng-file-storage",
-      "version": "2.51.0",
+      "version": "2.52.0",
       "license": "ISC",
       "dependencies": {
-        "@memberjunction/core": "2.51.0",
-        "@memberjunction/core-entities": "2.51.0",
-        "@memberjunction/global": "2.51.0",
-        "@memberjunction/graphql-dataprovider": "2.51.0",
-        "@memberjunction/ng-container-directives": "2.51.0",
-        "@memberjunction/ng-shared": "2.51.0",
+        "@memberjunction/core": "2.52.0",
+        "@memberjunction/core-entities": "2.52.0",
+        "@memberjunction/global": "2.52.0",
+        "@memberjunction/graphql-dataprovider": "2.52.0",
+        "@memberjunction/ng-container-directives": "2.52.0",
+        "@memberjunction/ng-shared": "2.52.0",
         "@progress/kendo-angular-buttons": "16.2.0",
         "@progress/kendo-angular-dialog": "16.2.0",
         "@progress/kendo-angular-dropdowns": "16.2.0",
@@ -32969,14 +32828,14 @@
     },
     "packages/Angular/Generic/find-record": {
       "name": "@memberjunction/ng-find-record",
-      "version": "2.51.0",
+      "version": "2.52.0",
       "license": "ISC",
       "dependencies": {
-        "@memberjunction/core": "2.51.0",
-        "@memberjunction/core-entities": "2.51.0",
-        "@memberjunction/global": "2.51.0",
-        "@memberjunction/ng-container-directives": "2.51.0",
-        "@memberjunction/ng-shared": "2.51.0",
+        "@memberjunction/core": "2.52.0",
+        "@memberjunction/core-entities": "2.52.0",
+        "@memberjunction/global": "2.52.0",
+        "@memberjunction/ng-container-directives": "2.52.0",
+        "@memberjunction/ng-shared": "2.52.0",
         "rxjs": "^7.8.1",
         "tslib": "^2.3.0"
       },
@@ -32998,7 +32857,7 @@
     },
     "packages/Angular/Generic/generic-dialog": {
       "name": "@memberjunction/ng-generic-dialog",
-      "version": "2.51.0",
+      "version": "2.52.0",
       "license": "ISC",
       "dependencies": {
         "tslib": "^2.3.0"
@@ -33016,15 +32875,15 @@
     },
     "packages/Angular/Generic/join-grid": {
       "name": "@memberjunction/ng-join-grid",
-      "version": "2.51.0",
+      "version": "2.52.0",
       "license": "ISC",
       "dependencies": {
-        "@memberjunction/core": "2.51.0",
-        "@memberjunction/core-entities": "2.51.0",
-        "@memberjunction/global": "2.51.0",
-        "@memberjunction/ng-base-types": "2.51.0",
-        "@memberjunction/ng-container-directives": "2.51.0",
-        "@memberjunction/ng-shared": "2.51.0",
+        "@memberjunction/core": "2.52.0",
+        "@memberjunction/core-entities": "2.52.0",
+        "@memberjunction/global": "2.52.0",
+        "@memberjunction/ng-base-types": "2.52.0",
+        "@memberjunction/ng-container-directives": "2.52.0",
+        "@memberjunction/ng-shared": "2.52.0",
         "@progress/kendo-angular-buttons": "16.2.0",
         "@progress/kendo-angular-dialog": "16.2.0",
         "@progress/kendo-angular-grid": "16.2.0",
@@ -33046,13 +32905,13 @@
     },
     "packages/Angular/Generic/notifications": {
       "name": "@memberjunction/ng-notifications",
-      "version": "2.51.0",
+      "version": "2.52.0",
       "license": "ISC",
       "dependencies": {
-        "@memberjunction/core": "2.51.0",
-        "@memberjunction/core-entities": "2.51.0",
-        "@memberjunction/global": "2.51.0",
-        "@memberjunction/graphql-dataprovider": "2.51.0",
+        "@memberjunction/core": "2.52.0",
+        "@memberjunction/core-entities": "2.52.0",
+        "@memberjunction/global": "2.52.0",
+        "@memberjunction/graphql-dataprovider": "2.52.0",
         "rxjs": "^7.8.1",
         "tslib": "^2.3.0"
       },
@@ -33068,15 +32927,15 @@
     },
     "packages/Angular/Generic/query-grid": {
       "name": "@memberjunction/ng-query-grid",
-      "version": "2.51.0",
+      "version": "2.52.0",
       "license": "ISC",
       "dependencies": {
-        "@memberjunction/core": "2.51.0",
-        "@memberjunction/core-entities": "2.51.0",
-        "@memberjunction/global": "2.51.0",
-        "@memberjunction/ng-compare-records": "2.51.0",
-        "@memberjunction/ng-container-directives": "2.51.0",
-        "@memberjunction/ng-shared": "2.51.0",
+        "@memberjunction/core": "2.52.0",
+        "@memberjunction/core-entities": "2.52.0",
+        "@memberjunction/global": "2.52.0",
+        "@memberjunction/ng-compare-records": "2.52.0",
+        "@memberjunction/ng-container-directives": "2.52.0",
+        "@memberjunction/ng-shared": "2.52.0",
         "tslib": "^2.3.0"
       },
       "devDependencies": {
@@ -33095,14 +32954,14 @@
     },
     "packages/Angular/Generic/record-selector": {
       "name": "@memberjunction/ng-record-selector",
-      "version": "2.51.0",
+      "version": "2.52.0",
       "license": "ISC",
       "dependencies": {
-        "@memberjunction/core": "2.51.0",
-        "@memberjunction/core-entities": "2.51.0",
-        "@memberjunction/global": "2.51.0",
-        "@memberjunction/ng-container-directives": "2.51.0",
-        "@memberjunction/ng-shared": "2.51.0",
+        "@memberjunction/core": "2.52.0",
+        "@memberjunction/core-entities": "2.52.0",
+        "@memberjunction/global": "2.52.0",
+        "@memberjunction/ng-container-directives": "2.52.0",
+        "@memberjunction/ng-shared": "2.52.0",
         "tslib": "^2.3.0"
       },
       "devDependencies": {
@@ -33121,16 +32980,16 @@
     },
     "packages/Angular/Generic/resource-permissions": {
       "name": "@memberjunction/ng-resource-permissions",
-      "version": "2.51.0",
+      "version": "2.52.0",
       "license": "ISC",
       "dependencies": {
-        "@memberjunction/core": "2.51.0",
-        "@memberjunction/core-entities": "2.51.0",
-        "@memberjunction/global": "2.51.0",
-        "@memberjunction/ng-base-types": "2.51.0",
-        "@memberjunction/ng-container-directives": "2.51.0",
-        "@memberjunction/ng-generic-dialog": "2.51.0",
-        "@memberjunction/ng-notifications": "2.51.0",
+        "@memberjunction/core": "2.52.0",
+        "@memberjunction/core-entities": "2.52.0",
+        "@memberjunction/global": "2.52.0",
+        "@memberjunction/ng-base-types": "2.52.0",
+        "@memberjunction/ng-container-directives": "2.52.0",
+        "@memberjunction/ng-generic-dialog": "2.52.0",
+        "@memberjunction/ng-notifications": "2.52.0",
         "@progress/kendo-angular-buttons": "16.2.0",
         "@progress/kendo-angular-dialog": "16.2.0",
         "@progress/kendo-angular-dropdowns": "16.2.0",
@@ -33181,22 +33040,22 @@
     },
     "packages/Angular/Generic/skip-chat": {
       "name": "@memberjunction/ng-skip-chat",
-      "version": "2.51.0",
+      "version": "2.52.0",
       "license": "ISC",
       "dependencies": {
         "@angular/cdk": "18.0.2",
-        "@memberjunction/core": "2.51.0",
-        "@memberjunction/core-entities": "2.51.0",
-        "@memberjunction/data-context": "2.51.0",
-        "@memberjunction/global": "2.51.0",
-        "@memberjunction/graphql-dataprovider": "2.51.0",
-        "@memberjunction/ng-base-types": "2.51.0",
-        "@memberjunction/ng-code-editor": "2.51.0",
-        "@memberjunction/ng-container-directives": "2.51.0",
-        "@memberjunction/ng-data-context": "2.51.0",
-        "@memberjunction/ng-notifications": "2.51.0",
-        "@memberjunction/ng-resource-permissions": "2.51.0",
-        "@memberjunction/skip-types": "2.51.0",
+        "@memberjunction/core": "2.52.0",
+        "@memberjunction/core-entities": "2.52.0",
+        "@memberjunction/data-context": "2.52.0",
+        "@memberjunction/global": "2.52.0",
+        "@memberjunction/graphql-dataprovider": "2.52.0",
+        "@memberjunction/ng-base-types": "2.52.0",
+        "@memberjunction/ng-code-editor": "2.52.0",
+        "@memberjunction/ng-container-directives": "2.52.0",
+        "@memberjunction/ng-data-context": "2.52.0",
+        "@memberjunction/ng-notifications": "2.52.0",
+        "@memberjunction/ng-resource-permissions": "2.52.0",
+        "@memberjunction/skip-types": "2.52.0",
         "@progress/kendo-angular-dialog": "16.2.0",
         "@progress/kendo-angular-grid": "16.2.0",
         "@progress/kendo-angular-indicators": "16.2.0",
@@ -33284,10 +33143,10 @@
     },
     "packages/Angular/Generic/tab-strip": {
       "name": "@memberjunction/ng-tabstrip",
-      "version": "2.51.0",
+      "version": "2.52.0",
       "license": "ISC",
       "dependencies": {
-        "@memberjunction/ng-container-directives": "2.51.0",
+        "@memberjunction/ng-container-directives": "2.52.0",
         "tslib": "^2.3.0"
       },
       "devDependencies": {
@@ -33301,15 +33160,15 @@
     },
     "packages/Angular/Generic/timeline": {
       "name": "@memberjunction/ng-timeline",
-      "version": "2.51.0",
+      "version": "2.52.0",
       "license": "ISC",
       "dependencies": {
-        "@memberjunction/core": "2.51.0",
-        "@memberjunction/core-entities": "2.51.0",
-        "@memberjunction/global": "2.51.0",
-        "@memberjunction/ng-container-directives": "2.51.0",
-        "@memberjunction/ng-entity-form-dialog": "2.51.0",
-        "@memberjunction/ng-shared": "2.51.0",
+        "@memberjunction/core": "2.52.0",
+        "@memberjunction/core-entities": "2.52.0",
+        "@memberjunction/global": "2.52.0",
+        "@memberjunction/ng-container-directives": "2.52.0",
+        "@memberjunction/ng-entity-form-dialog": "2.52.0",
+        "@memberjunction/ng-shared": "2.52.0",
         "@progress/kendo-angular-buttons": "16.2.0",
         "@progress/kendo-angular-indicators": "16.2.0",
         "@progress/kendo-angular-layout": "16.2.0",
@@ -33329,15 +33188,15 @@
     },
     "packages/Angular/Generic/tree-list": {
       "name": "@memberjunction/ng-treelist",
-      "version": "2.51.0",
+      "version": "2.52.0",
       "license": "ISC",
       "dependencies": {
-        "@memberjunction/core": "2.51.0",
-        "@memberjunction/core-entities": "2.51.0",
-        "@memberjunction/global": "2.51.0",
-        "@memberjunction/ng-container-directives": "2.51.0",
-        "@memberjunction/ng-entity-form-dialog": "2.51.0",
-        "@memberjunction/ng-shared": "2.51.0",
+        "@memberjunction/core": "2.52.0",
+        "@memberjunction/core-entities": "2.52.0",
+        "@memberjunction/global": "2.52.0",
+        "@memberjunction/ng-container-directives": "2.52.0",
+        "@memberjunction/ng-entity-form-dialog": "2.52.0",
+        "@memberjunction/ng-shared": "2.52.0",
         "@progress/kendo-angular-buttons": "16.2.0",
         "@progress/kendo-angular-indicators": "16.2.0",
         "@progress/kendo-angular-layout": "16.2.0",
@@ -33368,10 +33227,10 @@
         "@angular/platform-browser": "18.0.2",
         "@angular/platform-browser-dynamic": "18.0.2",
         "@angular/router": "18.0.2",
-        "@memberjunction/core": "2.51.0",
-        "@memberjunction/global": "2.51.0",
-        "@memberjunction/graphql-dataprovider": "2.51.0",
-        "@memberjunction/ng-user-view-grid": "2.51.0",
+        "@memberjunction/core": "2.52.0",
+        "@memberjunction/global": "2.52.0",
+        "@memberjunction/graphql-dataprovider": "2.52.0",
+        "@memberjunction/ng-user-view-grid": "2.52.0",
         "rxjs": "^7.8.1",
         "tslib": "^2.3.0",
         "zone.js": "^0.14.0"
@@ -33392,20 +33251,20 @@
     },
     "packages/CodeGenLib": {
       "name": "@memberjunction/codegen-lib",
-      "version": "2.51.0",
+      "version": "2.52.0",
       "license": "ISC",
       "dependencies": {
-        "@memberjunction/actions": "2.51.0",
-        "@memberjunction/ai": "2.51.0",
-        "@memberjunction/ai-anthropic": "2.51.0",
-        "@memberjunction/ai-groq": "2.51.0",
-        "@memberjunction/ai-mistral": "2.51.0",
-        "@memberjunction/ai-openai": "2.51.0",
-        "@memberjunction/aiengine": "2.51.0",
-        "@memberjunction/core": "2.51.0",
-        "@memberjunction/core-entities": "2.51.0",
-        "@memberjunction/global": "2.51.0",
-        "@memberjunction/sqlserver-dataprovider": "2.51.0",
+        "@memberjunction/actions": "2.52.0",
+        "@memberjunction/ai": "2.52.0",
+        "@memberjunction/ai-anthropic": "2.52.0",
+        "@memberjunction/ai-groq": "2.52.0",
+        "@memberjunction/ai-mistral": "2.52.0",
+        "@memberjunction/ai-openai": "2.52.0",
+        "@memberjunction/aiengine": "2.52.0",
+        "@memberjunction/core": "2.52.0",
+        "@memberjunction/core-entities": "2.52.0",
+        "@memberjunction/global": "2.52.0",
+        "@memberjunction/sqlserver-dataprovider": "2.52.0",
         "cosmiconfig": "9.0.0",
         "fs-extra": "^11.2.0",
         "glob": "^10.3.10",
@@ -33433,13 +33292,13 @@
     },
     "packages/Communication/base-types": {
       "name": "@memberjunction/communication-types",
-      "version": "2.51.0",
+      "version": "2.52.0",
       "license": "ISC",
       "dependencies": {
-        "@memberjunction/core": "2.51.0",
-        "@memberjunction/core-entities": "2.51.0",
-        "@memberjunction/global": "2.51.0",
-        "@memberjunction/templates-base-types": "2.51.0",
+        "@memberjunction/core": "2.52.0",
+        "@memberjunction/core-entities": "2.52.0",
+        "@memberjunction/global": "2.52.0",
+        "@memberjunction/templates-base-types": "2.52.0",
         "rxjs": "^7.8.1"
       },
       "devDependencies": {
@@ -33449,14 +33308,14 @@
     },
     "packages/Communication/engine": {
       "name": "@memberjunction/communication-engine",
-      "version": "2.51.0",
+      "version": "2.52.0",
       "license": "ISC",
       "dependencies": {
-        "@memberjunction/communication-types": "2.51.0",
-        "@memberjunction/core": "2.51.0",
-        "@memberjunction/core-entities": "2.51.0",
-        "@memberjunction/global": "2.51.0",
-        "@memberjunction/templates": "2.51.0",
+        "@memberjunction/communication-types": "2.52.0",
+        "@memberjunction/core": "2.52.0",
+        "@memberjunction/core-entities": "2.52.0",
+        "@memberjunction/global": "2.52.0",
+        "@memberjunction/templates": "2.52.0",
         "rxjs": "^7.8.1"
       },
       "devDependencies": {
@@ -33466,13 +33325,13 @@
     },
     "packages/Communication/entity-comm-base": {
       "name": "@memberjunction/entity-communications-base",
-      "version": "2.51.0",
+      "version": "2.52.0",
       "license": "ISC",
       "dependencies": {
-        "@memberjunction/communication-types": "2.51.0",
-        "@memberjunction/core": "2.51.0",
-        "@memberjunction/core-entities": "2.51.0",
-        "@memberjunction/global": "2.51.0"
+        "@memberjunction/communication-types": "2.52.0",
+        "@memberjunction/core": "2.52.0",
+        "@memberjunction/core-entities": "2.52.0",
+        "@memberjunction/global": "2.52.0"
       },
       "devDependencies": {
         "ts-node-dev": "^2.0.0",
@@ -33481,14 +33340,14 @@
     },
     "packages/Communication/entity-comm-client": {
       "name": "@memberjunction/entity-communications-client",
-      "version": "2.51.0",
+      "version": "2.52.0",
       "license": "ISC",
       "dependencies": {
-        "@memberjunction/core": "2.51.0",
-        "@memberjunction/core-entities": "2.51.0",
-        "@memberjunction/entity-communications-base": "2.51.0",
-        "@memberjunction/global": "2.51.0",
-        "@memberjunction/graphql-dataprovider": "2.51.0"
+        "@memberjunction/core": "2.52.0",
+        "@memberjunction/core-entities": "2.52.0",
+        "@memberjunction/entity-communications-base": "2.52.0",
+        "@memberjunction/global": "2.52.0",
+        "@memberjunction/graphql-dataprovider": "2.52.0"
       },
       "devDependencies": {
         "ts-node-dev": "^2.0.0",
@@ -33497,14 +33356,14 @@
     },
     "packages/Communication/entity-comm-server": {
       "name": "@memberjunction/entity-communications-server",
-      "version": "2.51.0",
+      "version": "2.52.0",
       "license": "ISC",
       "dependencies": {
-        "@memberjunction/communication-engine": "2.51.0",
-        "@memberjunction/core": "2.51.0",
-        "@memberjunction/core-entities": "2.51.0",
-        "@memberjunction/entity-communications-base": "2.51.0",
-        "@memberjunction/global": "2.51.0"
+        "@memberjunction/communication-engine": "2.52.0",
+        "@memberjunction/core": "2.52.0",
+        "@memberjunction/core-entities": "2.52.0",
+        "@memberjunction/entity-communications-base": "2.52.0",
+        "@memberjunction/global": "2.52.0"
       },
       "devDependencies": {
         "ts-node-dev": "^2.0.0",
@@ -33513,11 +33372,11 @@
     },
     "packages/Communication/providers/gmail": {
       "name": "@memberjunction/communication-gmail",
-      "version": "2.51.0",
+      "version": "2.52.0",
       "dependencies": {
-        "@memberjunction/communication-types": "2.51.0",
-        "@memberjunction/core": "2.51.0",
-        "@memberjunction/global": "2.51.0",
+        "@memberjunction/communication-types": "2.52.0",
+        "@memberjunction/core": "2.52.0",
+        "@memberjunction/global": "2.52.0",
         "dotenv": "^16.3.1",
         "env-var": "^7.4.1",
         "googleapis": "^130.0.0"
@@ -33558,19 +33417,19 @@
     },
     "packages/Communication/providers/MSGraph": {
       "name": "@memberjunction/communication-ms-graph",
-      "version": "2.51.0",
+      "version": "2.52.0",
       "license": "ISC",
       "dependencies": {
         "@azure/identity": "^4.4.1",
         "@azure/msal-node": "^2.14.0",
-        "@memberjunction/ai": "2.51.0",
-        "@memberjunction/ai-openai": "2.51.0",
-        "@memberjunction/aiengine": "2.51.0",
-        "@memberjunction/communication-types": "2.51.0",
-        "@memberjunction/core": "2.51.0",
-        "@memberjunction/core-entities": "2.51.0",
-        "@memberjunction/global": "2.51.0",
-        "@memberjunction/sqlserver-dataprovider": "2.51.0",
+        "@memberjunction/ai": "2.52.0",
+        "@memberjunction/ai-openai": "2.52.0",
+        "@memberjunction/aiengine": "2.52.0",
+        "@memberjunction/communication-types": "2.52.0",
+        "@memberjunction/core": "2.52.0",
+        "@memberjunction/core-entities": "2.52.0",
+        "@memberjunction/global": "2.52.0",
+        "@memberjunction/sqlserver-dataprovider": "2.52.0",
         "@microsoft/microsoft-graph-client": "^3.0.7",
         "@microsoft/microsoft-graph-types": "^2.40.0",
         "@types/html-to-text": "^9.0.4",
@@ -33585,73 +33444,6 @@
         "typescript": "^5.4.5"
       }
     },
-    "packages/Communication/providers/MSGraph/node_modules/@azure/abort-controller": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/@azure/abort-controller/-/abort-controller-2.1.2.tgz",
-      "integrity": "sha512-nBrLsEWm4J2u5LpAPjxADTlq3trDgVZZXHNKabeXZtpq3d3AbN/KGO82R87rdDz5/lYB024rtEf10/q0urNgsA==",
-      "dependencies": {
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "packages/Communication/providers/MSGraph/node_modules/@azure/identity": {
-      "version": "4.7.0",
-      "resolved": "https://registry.npmjs.org/@azure/identity/-/identity-4.7.0.tgz",
-      "integrity": "sha512-6z/S2KorkbKaZ0DgZFVRdu7RCuATmMSTjKpuhj7YpjxkJ0vnJ7kTM3cpNgzFgk9OPYfZ31wrBEtC/iwAS4jQDA==",
-      "dependencies": {
-        "@azure/abort-controller": "^2.0.0",
-        "@azure/core-auth": "^1.9.0",
-        "@azure/core-client": "^1.9.2",
-        "@azure/core-rest-pipeline": "^1.17.0",
-        "@azure/core-tracing": "^1.0.0",
-        "@azure/core-util": "^1.11.0",
-        "@azure/logger": "^1.0.0",
-        "@azure/msal-browser": "^4.2.0",
-        "@azure/msal-node": "^3.2.1",
-        "events": "^3.0.0",
-        "jws": "^4.0.0",
-        "open": "^10.1.0",
-        "stoppable": "^1.1.0",
-        "tslib": "^2.2.0"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "packages/Communication/providers/MSGraph/node_modules/@azure/identity/node_modules/@azure/msal-node": {
-      "version": "3.2.3",
-      "resolved": "https://registry.npmjs.org/@azure/msal-node/-/msal-node-3.2.3.tgz",
-      "integrity": "sha512-0eaPqBIWEAizeYiXdeHb09Iq0tvHJ17ztvNEaLdr/KcJJhJxbpkkEQf09DB+vKlFE0tzYi7j4rYLTXtES/InEQ==",
-      "dependencies": {
-        "@azure/msal-common": "15.2.0",
-        "jsonwebtoken": "^9.0.0",
-        "uuid": "^8.3.0"
-      },
-      "engines": {
-        "node": ">=16"
-      }
-    },
-    "packages/Communication/providers/MSGraph/node_modules/@azure/msal-browser": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/@azure/msal-browser/-/msal-browser-4.5.0.tgz",
-      "integrity": "sha512-H7mWmu8yI0n0XxhJobrgncXI6IU5h8DKMiWDHL5y+Dc58cdg26GbmaMUehbUkdKAQV2OTiFa4FUa6Fdu/wIxBg==",
-      "dependencies": {
-        "@azure/msal-common": "15.2.0"
-      },
-      "engines": {
-        "node": ">=0.8.0"
-      }
-    },
-    "packages/Communication/providers/MSGraph/node_modules/@azure/msal-common": {
-      "version": "15.2.0",
-      "resolved": "https://registry.npmjs.org/@azure/msal-common/-/msal-common-15.2.0.tgz",
-      "integrity": "sha512-HiYfGAKthisUYqHG1nImCf/uzcyS31wng3o+CycWLIM9chnYJ9Lk6jZ30Y6YiYYpTQ9+z/FGUpiKKekd3Arc0A==",
-      "engines": {
-        "node": ">=0.8.0"
-      }
-    },
     "packages/Communication/providers/MSGraph/node_modules/@types/node": {
       "version": "20.17.57",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-20.17.57.tgz",
@@ -33662,48 +33454,6 @@
         "undici-types": "~6.19.2"
       }
     },
-    "packages/Communication/providers/MSGraph/node_modules/define-lazy-prop": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/define-lazy-prop/-/define-lazy-prop-3.0.0.tgz",
-      "integrity": "sha512-N+MeXYoqr3pOgn8xfyRPREN7gHakLYjhsHhWGT3fWAiL4IkAt0iDw14QiiEm2bE30c5XX5q0FtAA3CK5f9/BUg==",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "packages/Communication/providers/MSGraph/node_modules/is-wsl": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-3.1.0.tgz",
-      "integrity": "sha512-UcVfVfaK4Sc4m7X3dUSoHoozQGBEFeDC+zVo06t98xe8CzHSZZBekNXH+tu0NalHolcJ/QAGqS46Hef7QXBIMw==",
-      "dependencies": {
-        "is-inside-container": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=16"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "packages/Communication/providers/MSGraph/node_modules/open": {
-      "version": "10.1.0",
-      "resolved": "https://registry.npmjs.org/open/-/open-10.1.0.tgz",
-      "integrity": "sha512-mnkeQ1qP5Ue2wd+aivTD3NHd/lZ96Lu0jgf0pwktLPtx6cTZiH7tyeGRRHs0zX0rbrahXPnXlUnbeXyaBBuIaw==",
-      "dependencies": {
-        "default-browser": "^5.2.1",
-        "define-lazy-prop": "^3.0.0",
-        "is-inside-container": "^1.0.0",
-        "is-wsl": "^3.1.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "packages/Communication/providers/MSGraph/node_modules/undici-types": {
       "version": "6.19.8",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.19.8.tgz",
@@ -33711,23 +33461,15 @@
       "dev": true,
       "license": "MIT"
     },
-    "packages/Communication/providers/MSGraph/node_modules/uuid": {
-      "version": "8.3.2",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
-      "bin": {
-        "uuid": "dist/bin/uuid"
-      }
-    },
     "packages/Communication/providers/sendgrid": {
       "name": "@memberjunction/communication-sendgrid",
-      "version": "2.51.0",
+      "version": "2.52.0",
       "license": "ISC",
       "dependencies": {
-        "@memberjunction/communication-types": "2.51.0",
-        "@memberjunction/core": "2.51.0",
-        "@memberjunction/core-entities": "2.51.0",
-        "@memberjunction/global": "2.51.0",
+        "@memberjunction/communication-types": "2.52.0",
+        "@memberjunction/core": "2.52.0",
+        "@memberjunction/core-entities": "2.52.0",
+        "@memberjunction/global": "2.52.0",
         "@sendgrid/mail": "^8.1.3"
       },
       "devDependencies": {
@@ -33737,11 +33479,11 @@
     },
     "packages/Communication/providers/twilio": {
       "name": "@memberjunction/communication-twilio",
-      "version": "2.51.0",
+      "version": "2.52.0",
       "dependencies": {
-        "@memberjunction/communication-types": "2.51.0",
-        "@memberjunction/core": "2.51.0",
-        "@memberjunction/global": "2.51.0",
+        "@memberjunction/communication-types": "2.52.0",
+        "@memberjunction/core": "2.52.0",
+        "@memberjunction/global": "2.52.0",
         "dotenv": "^16.3.1",
         "env-var": "^7.4.1",
         "twilio": "^4.23.0"
@@ -33769,14 +33511,14 @@
     },
     "packages/ContentAutotagging": {
       "name": "@memberjunction/content-autotagging",
-      "version": "2.51.0",
+      "version": "2.52.0",
       "license": "ISC",
       "dependencies": {
-        "@memberjunction/ai": "2.51.0",
-        "@memberjunction/aiengine": "2.51.0",
-        "@memberjunction/core": "2.51.0",
-        "@memberjunction/core-entities": "2.51.0",
-        "@memberjunction/global": "2.51.0",
+        "@memberjunction/ai": "2.52.0",
+        "@memberjunction/aiengine": "2.52.0",
+        "@memberjunction/core": "2.52.0",
+        "@memberjunction/core-entities": "2.52.0",
+        "@memberjunction/global": "2.52.0",
         "axios": "^1.7.2",
         "cheerio": "^1.0.0-rc.12",
         "crypto": "^1.0.1",
@@ -33812,12 +33554,12 @@
     },
     "packages/DocUtils": {
       "name": "@memberjunction/doc-utils",
-      "version": "2.51.0",
+      "version": "2.52.0",
       "license": "ISC",
       "dependencies": {
-        "@memberjunction/core": "2.51.0",
-        "@memberjunction/core-entities": "2.51.0",
-        "@memberjunction/global": "2.51.0",
+        "@memberjunction/core": "2.52.0",
+        "@memberjunction/core-entities": "2.52.0",
+        "@memberjunction/global": "2.52.0",
         "axios": "^1.6.7",
         "jsdom": "^24.1.0"
       },
@@ -33828,13 +33570,13 @@
     },
     "packages/ExternalChangeDetection": {
       "name": "@memberjunction/external-change-detection",
-      "version": "2.51.0",
+      "version": "2.52.0",
       "license": "ISC",
       "dependencies": {
-        "@memberjunction/core": "2.51.0",
-        "@memberjunction/core-entities": "2.51.0",
-        "@memberjunction/global": "2.51.0",
-        "@memberjunction/sqlserver-dataprovider": "2.51.0"
+        "@memberjunction/core": "2.52.0",
+        "@memberjunction/core-entities": "2.52.0",
+        "@memberjunction/global": "2.52.0",
+        "@memberjunction/sqlserver-dataprovider": "2.52.0"
       },
       "devDependencies": {
         "ts-node-dev": "^2.0.0",
@@ -33846,12 +33588,12 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
-        "@memberjunction/actions": "2.51.0",
-        "@memberjunction/ai": "2.51.0",
-        "@memberjunction/aiengine": "2.51.0",
-        "@memberjunction/core": "2.51.0",
-        "@memberjunction/core-entities": "2.51.0",
-        "@memberjunction/global": "2.51.0",
+        "@memberjunction/actions": "2.52.0",
+        "@memberjunction/ai": "2.52.0",
+        "@memberjunction/aiengine": "2.52.0",
+        "@memberjunction/core": "2.52.0",
+        "@memberjunction/core-entities": "2.52.0",
+        "@memberjunction/global": "2.52.0",
         "zod": "^3.23.8"
       },
       "devDependencies": {
@@ -33864,8 +33606,8 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
-        "@memberjunction/core": "2.51.0",
-        "@memberjunction/global": "2.51.0",
+        "@memberjunction/core": "2.52.0",
+        "@memberjunction/global": "2.52.0",
         "zod": "^3.23.8"
       },
       "devDependencies": {
@@ -33875,13 +33617,13 @@
     },
     "packages/GraphQLDataProvider": {
       "name": "@memberjunction/graphql-dataprovider",
-      "version": "2.51.0",
+      "version": "2.52.0",
       "license": "ISC",
       "dependencies": {
-        "@memberjunction/actions-base": "2.51.0",
-        "@memberjunction/core": "2.51.0",
-        "@memberjunction/core-entities": "2.51.0",
-        "@memberjunction/global": "2.51.0",
+        "@memberjunction/actions-base": "2.52.0",
+        "@memberjunction/core": "2.52.0",
+        "@memberjunction/core-entities": "2.52.0",
+        "@memberjunction/global": "2.52.0",
         "@tempfix/idb": "^8.0.3",
         "graphql": "^16.8.0",
         "graphql-request": "^5.2.0",
@@ -33912,16 +33654,16 @@
     },
     "packages/MetadataSync": {
       "name": "@memberjunction/metadata-sync",
-      "version": "2.51.0",
+      "version": "2.52.0",
       "license": "ISC",
       "dependencies": {
         "@inquirer/prompts": "^5.0.1",
-        "@memberjunction/core": "2.51.0",
-        "@memberjunction/core-entities": "2.51.0",
-        "@memberjunction/core-entities-server": "2.51.0",
-        "@memberjunction/global": "2.51.0",
-        "@memberjunction/graphql-dataprovider": "2.51.0",
-        "@memberjunction/sqlserver-dataprovider": "2.51.0",
+        "@memberjunction/core": "2.52.0",
+        "@memberjunction/core-entities": "2.52.0",
+        "@memberjunction/core-entities-server": "2.52.0",
+        "@memberjunction/global": "2.52.0",
+        "@memberjunction/graphql-dataprovider": "2.52.0",
+        "@memberjunction/sqlserver-dataprovider": "2.52.0",
         "@oclif/core": "^3",
         "@oclif/plugin-help": "^6",
         "@oclif/plugin-version": "^2.0.17",
@@ -33976,13 +33718,13 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
-        "@memberjunction/ai": "2.51.0",
-        "@memberjunction/communication-sendgrid": "2.51.0",
-        "@memberjunction/core": "2.51.0",
-        "@memberjunction/global": "2.51.0",
-        "@memberjunction/server": "2.51.0",
-        "@memberjunction/sqlserver-dataprovider": "2.51.0",
-        "@memberjunction/templates": "2.51.0",
+        "@memberjunction/ai": "2.52.0",
+        "@memberjunction/communication-sendgrid": "2.52.0",
+        "@memberjunction/core": "2.52.0",
+        "@memberjunction/global": "2.52.0",
+        "@memberjunction/server": "2.52.0",
+        "@memberjunction/sqlserver-dataprovider": "2.52.0",
+        "@memberjunction/templates": "2.52.0",
         "axios": "^1.6.7",
         "class-validator": "^0.14.0",
         "mj_generatedactions": "1.0.0",
@@ -33997,11 +33739,11 @@
     },
     "packages/MJCLI": {
       "name": "@memberjunction/cli",
-      "version": "2.51.0",
+      "version": "2.52.0",
       "license": "ISC",
       "dependencies": {
         "@inquirer/prompts": "^5.0.1",
-        "@memberjunction/codegen-lib": "2.51.0",
+        "@memberjunction/codegen-lib": "2.52.0",
         "@oclif/core": "^3",
         "@oclif/plugin-help": "^6",
         "@oclif/plugin-version": "^2.0.17",
@@ -34055,11 +33797,11 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
-        "@memberjunction/codegen-lib": "2.51.0",
-        "@memberjunction/core": "2.51.0",
-        "@memberjunction/core-entities": "2.51.0",
-        "@memberjunction/global": "2.51.0",
-        "@memberjunction/sqlserver-dataprovider": "2.51.0",
+        "@memberjunction/codegen-lib": "2.52.0",
+        "@memberjunction/core": "2.52.0",
+        "@memberjunction/core-entities": "2.52.0",
+        "@memberjunction/global": "2.52.0",
+        "@memberjunction/sqlserver-dataprovider": "2.52.0",
         "@types/axios": "^0.14.0",
         "@types/mssql": "^9.1.5",
         "axios": "^1.6.7",
@@ -34099,10 +33841,10 @@
     },
     "packages/MJCore": {
       "name": "@memberjunction/core",
-      "version": "2.51.0",
+      "version": "2.52.0",
       "license": "ISC",
       "dependencies": {
-        "@memberjunction/global": "2.51.0",
+        "@memberjunction/global": "2.52.0",
         "debug": "^4.4.0",
         "rxjs": "^7.8.1",
         "zod": "^3.23.8"
@@ -34138,11 +33880,11 @@
     },
     "packages/MJCoreEntities": {
       "name": "@memberjunction/core-entities",
-      "version": "2.51.0",
+      "version": "2.52.0",
       "license": "ISC",
       "dependencies": {
-        "@memberjunction/core": "2.51.0",
-        "@memberjunction/global": "2.51.0",
+        "@memberjunction/core": "2.52.0",
+        "@memberjunction/global": "2.52.0",
         "zod": "^3.23.8"
       },
       "devDependencies": {
@@ -34152,15 +33894,15 @@
     },
     "packages/MJCoreEntitiesServer": {
       "name": "@memberjunction/core-entities-server",
-      "version": "2.51.0",
+      "version": "2.52.0",
       "license": "ISC",
       "dependencies": {
-        "@memberjunction/ai-vector-dupe": "2.51.0",
-        "@memberjunction/aiengine": "2.51.0",
-        "@memberjunction/core": "2.51.0",
-        "@memberjunction/core-entities": "2.51.0",
-        "@memberjunction/global": "2.51.0",
-        "@memberjunction/skip-types": "2.51.0",
+        "@memberjunction/ai-vector-dupe": "2.52.0",
+        "@memberjunction/aiengine": "2.52.0",
+        "@memberjunction/core": "2.52.0",
+        "@memberjunction/core-entities": "2.52.0",
+        "@memberjunction/global": "2.52.0",
+        "@memberjunction/skip-types": "2.52.0",
         "zod": "^3.23.8"
       },
       "devDependencies": {
@@ -34170,12 +33912,12 @@
     },
     "packages/MJDataContext": {
       "name": "@memberjunction/data-context",
-      "version": "2.51.0",
+      "version": "2.52.0",
       "license": "ISC",
       "dependencies": {
-        "@memberjunction/core": "2.51.0",
-        "@memberjunction/core-entities": "2.51.0",
-        "@memberjunction/global": "2.51.0"
+        "@memberjunction/core": "2.52.0",
+        "@memberjunction/core-entities": "2.52.0",
+        "@memberjunction/global": "2.52.0"
       },
       "devDependencies": {
         "ts-node-dev": "^2.0.0",
@@ -34184,11 +33926,11 @@
     },
     "packages/MJDataContextServer": {
       "name": "@memberjunction/data-context-server",
-      "version": "2.51.0",
+      "version": "2.52.0",
       "license": "ISC",
       "dependencies": {
-        "@memberjunction/data-context": "2.51.0",
-        "@memberjunction/global": "2.51.0",
+        "@memberjunction/data-context": "2.52.0",
+        "@memberjunction/global": "2.52.0",
         "mssql": "^11.0.1"
       },
       "devDependencies": {
@@ -34209,24 +33951,24 @@
         "@angular/platform-browser-dynamic": "18.0.2",
         "@angular/router": "18.0.2",
         "@azure/msal-angular": "^3.0.11",
-        "@memberjunction/core": "2.51.0",
-        "@memberjunction/core-entities": "2.51.0",
-        "@memberjunction/global": "2.51.0",
-        "@memberjunction/graphql-dataprovider": "2.51.0",
-        "@memberjunction/ng-ask-skip": "2.51.0",
-        "@memberjunction/ng-auth-services": "2.51.0",
-        "@memberjunction/ng-compare-records": "2.51.0",
-        "@memberjunction/ng-container-directives": "2.51.0",
-        "@memberjunction/ng-core-entity-forms": "2.51.0",
-        "@memberjunction/ng-dashboards": "2.51.0",
-        "@memberjunction/ng-explorer-core": "2.51.0",
-        "@memberjunction/ng-explorer-settings": "2.51.0",
-        "@memberjunction/ng-join-grid": "2.51.0",
-        "@memberjunction/ng-link-directives": "2.51.0",
-        "@memberjunction/ng-record-changes": "2.51.0",
-        "@memberjunction/ng-tabstrip": "2.51.0",
-        "@memberjunction/ng-timeline": "2.51.0",
-        "@memberjunction/ng-user-view-grid": "2.51.0",
+        "@memberjunction/core": "2.52.0",
+        "@memberjunction/core-entities": "2.52.0",
+        "@memberjunction/global": "2.52.0",
+        "@memberjunction/graphql-dataprovider": "2.52.0",
+        "@memberjunction/ng-ask-skip": "2.52.0",
+        "@memberjunction/ng-auth-services": "2.52.0",
+        "@memberjunction/ng-compare-records": "2.52.0",
+        "@memberjunction/ng-container-directives": "2.52.0",
+        "@memberjunction/ng-core-entity-forms": "2.52.0",
+        "@memberjunction/ng-dashboards": "2.52.0",
+        "@memberjunction/ng-explorer-core": "2.52.0",
+        "@memberjunction/ng-explorer-settings": "2.52.0",
+        "@memberjunction/ng-join-grid": "2.52.0",
+        "@memberjunction/ng-link-directives": "2.52.0",
+        "@memberjunction/ng-record-changes": "2.52.0",
+        "@memberjunction/ng-tabstrip": "2.52.0",
+        "@memberjunction/ng-timeline": "2.52.0",
+        "@memberjunction/ng-user-view-grid": "2.52.0",
         "@progress/kendo-angular-notification": "16.2.0",
         "@progress/kendo-angular-scheduler": "16.2.0",
         "@progress/kendo-licensing": "^1.3.5",
@@ -34270,7 +34012,7 @@
     },
     "packages/MJGlobal": {
       "name": "@memberjunction/global",
-      "version": "2.51.0",
+      "version": "2.52.0",
       "license": "ISC",
       "dependencies": {
         "rxjs": "^7.8.1",
@@ -34296,14 +34038,14 @@
     },
     "packages/MJQueue": {
       "name": "@memberjunction/queue",
-      "version": "2.51.0",
+      "version": "2.52.0",
       "license": "ISC",
       "dependencies": {
-        "@memberjunction/ai": "2.51.0",
-        "@memberjunction/aiengine": "2.51.0",
-        "@memberjunction/core": "2.51.0",
-        "@memberjunction/core-entities": "2.51.0",
-        "@memberjunction/global": "2.51.0",
+        "@memberjunction/ai": "2.52.0",
+        "@memberjunction/aiengine": "2.52.0",
+        "@memberjunction/core": "2.52.0",
+        "@memberjunction/core-entities": "2.52.0",
+        "@memberjunction/global": "2.52.0",
         "@types/uuid": "^9.0.1",
         "uuid": "^9.0.0"
       },
@@ -34314,35 +34056,35 @@
     },
     "packages/MJServer": {
       "name": "@memberjunction/server",
-      "version": "2.51.0",
+      "version": "2.52.0",
       "license": "ISC",
       "dependencies": {
         "@apollo/server": "^4.9.1",
         "@graphql-tools/utils": "^10.0.1",
-        "@memberjunction/actions": "2.51.0",
-        "@memberjunction/ai": "2.51.0",
-        "@memberjunction/ai-agents": "2.51.0",
-        "@memberjunction/ai-mistral": "2.51.0",
-        "@memberjunction/ai-openai": "2.51.0",
-        "@memberjunction/ai-prompts": "2.51.0",
-        "@memberjunction/ai-vectors-pinecone": "2.51.0",
-        "@memberjunction/aiengine": "2.51.0",
-        "@memberjunction/core": "2.51.0",
-        "@memberjunction/core-actions": "2.51.0",
-        "@memberjunction/core-entities": "2.51.0",
-        "@memberjunction/core-entities-server": "2.51.0",
-        "@memberjunction/data-context": "2.51.0",
-        "@memberjunction/data-context-server": "2.51.0",
-        "@memberjunction/doc-utils": "2.51.0",
-        "@memberjunction/entity-communications-server": "2.51.0",
-        "@memberjunction/external-change-detection": "2.51.0",
-        "@memberjunction/global": "2.51.0",
-        "@memberjunction/graphql-dataprovider": "2.51.0",
-        "@memberjunction/queue": "2.51.0",
-        "@memberjunction/skip-types": "2.51.0",
-        "@memberjunction/sqlserver-dataprovider": "2.51.0",
-        "@memberjunction/storage": "2.51.0",
-        "@memberjunction/templates": "2.51.0",
+        "@memberjunction/actions": "2.52.0",
+        "@memberjunction/ai": "2.52.0",
+        "@memberjunction/ai-agents": "2.52.0",
+        "@memberjunction/ai-mistral": "2.52.0",
+        "@memberjunction/ai-openai": "2.52.0",
+        "@memberjunction/ai-prompts": "2.52.0",
+        "@memberjunction/ai-vectors-pinecone": "2.52.0",
+        "@memberjunction/aiengine": "2.52.0",
+        "@memberjunction/core": "2.52.0",
+        "@memberjunction/core-actions": "2.52.0",
+        "@memberjunction/core-entities": "2.52.0",
+        "@memberjunction/core-entities-server": "2.52.0",
+        "@memberjunction/data-context": "2.52.0",
+        "@memberjunction/data-context-server": "2.52.0",
+        "@memberjunction/doc-utils": "2.52.0",
+        "@memberjunction/entity-communications-server": "2.52.0",
+        "@memberjunction/external-change-detection": "2.52.0",
+        "@memberjunction/global": "2.52.0",
+        "@memberjunction/graphql-dataprovider": "2.52.0",
+        "@memberjunction/queue": "2.52.0",
+        "@memberjunction/skip-types": "2.52.0",
+        "@memberjunction/sqlserver-dataprovider": "2.52.0",
+        "@memberjunction/storage": "2.52.0",
+        "@memberjunction/templates": "2.52.0",
         "@types/compression": "^1.7.5",
         "@types/cors": "^2.8.13",
         "@types/jsonwebtoken": "9.0.6",
@@ -34437,7 +34179,7 @@
     },
     "packages/MJStorage": {
       "name": "@memberjunction/storage",
-      "version": "2.51.0",
+      "version": "2.52.0",
       "license": "ISC",
       "dependencies": {
         "@aws-sdk/client-s3": "^3.537.0",
@@ -34445,9 +34187,9 @@
         "@azure/identity": "^4.0.1",
         "@azure/storage-blob": "^12.17.0",
         "@google-cloud/storage": "^7.9.0",
-        "@memberjunction/core": "2.51.0",
-        "@memberjunction/core-entities": "2.51.0",
-        "@memberjunction/global": "2.51.0",
+        "@memberjunction/core": "2.52.0",
+        "@memberjunction/core-entities": "2.52.0",
+        "@memberjunction/global": "2.52.0",
         "@microsoft/mgt-element": "^3.1.3",
         "@microsoft/mgt-msal2-provider": "^3.1.3",
         "@microsoft/mgt-sharepoint-provider": "^3.1.3",
@@ -34461,29 +34203,6 @@
       "devDependencies": {
         "ts-node-dev": "^2.0.0",
         "typescript": "^5.4.5"
-      }
-    },
-    "packages/MJStorage/node_modules/@azure/identity": {
-      "version": "4.2.0",
-      "license": "MIT",
-      "dependencies": {
-        "@azure/abort-controller": "^1.0.0",
-        "@azure/core-auth": "^1.5.0",
-        "@azure/core-client": "^1.4.0",
-        "@azure/core-rest-pipeline": "^1.1.0",
-        "@azure/core-tracing": "^1.0.0",
-        "@azure/core-util": "^1.3.0",
-        "@azure/logger": "^1.0.0",
-        "@azure/msal-browser": "^3.11.1",
-        "@azure/msal-node": "^2.6.6",
-        "events": "^3.0.0",
-        "jws": "^4.0.0",
-        "open": "^8.0.0",
-        "stoppable": "^1.1.0",
-        "tslib": "^2.2.0"
-      },
-      "engines": {
-        "node": ">=18.0.0"
       }
     },
     "packages/SkipSaaSPortal": {
@@ -34546,11 +34265,11 @@
     },
     "packages/SkipTypes": {
       "name": "@memberjunction/skip-types",
-      "version": "2.51.0",
+      "version": "2.52.0",
       "license": "ISC",
       "dependencies": {
-        "@memberjunction/core-entities": "2.51.0",
-        "@memberjunction/data-context": "2.51.0"
+        "@memberjunction/core-entities": "2.52.0",
+        "@memberjunction/data-context": "2.52.0"
       },
       "devDependencies": {
         "ts-node-dev": "^2.0.0",
@@ -34559,17 +34278,17 @@
     },
     "packages/SQLServerDataProvider": {
       "name": "@memberjunction/sqlserver-dataprovider",
-      "version": "2.51.0",
+      "version": "2.52.0",
       "license": "ISC",
       "dependencies": {
-        "@memberjunction/actions": "2.51.0",
-        "@memberjunction/ai": "2.51.0",
-        "@memberjunction/ai-vector-dupe": "2.51.0",
-        "@memberjunction/aiengine": "2.51.0",
-        "@memberjunction/core": "2.51.0",
-        "@memberjunction/core-entities": "2.51.0",
-        "@memberjunction/global": "2.51.0",
-        "@memberjunction/queue": "2.51.0",
+        "@memberjunction/actions": "2.52.0",
+        "@memberjunction/ai": "2.52.0",
+        "@memberjunction/ai-vector-dupe": "2.52.0",
+        "@memberjunction/aiengine": "2.52.0",
+        "@memberjunction/core": "2.52.0",
+        "@memberjunction/core-entities": "2.52.0",
+        "@memberjunction/global": "2.52.0",
+        "@memberjunction/queue": "2.52.0",
         "mssql": "^11.0.1",
         "rxjs": "^7.8.1",
         "sql-formatter": "^15.3.2",
@@ -34603,12 +34322,12 @@
     },
     "packages/Templates/base-types": {
       "name": "@memberjunction/templates-base-types",
-      "version": "2.51.0",
+      "version": "2.52.0",
       "license": "ISC",
       "dependencies": {
-        "@memberjunction/core": "2.51.0",
-        "@memberjunction/core-entities": "2.51.0",
-        "@memberjunction/global": "2.51.0"
+        "@memberjunction/core": "2.52.0",
+        "@memberjunction/core-entities": "2.52.0",
+        "@memberjunction/global": "2.52.0"
       },
       "devDependencies": {
         "typescript": "^5.4.5"
@@ -34616,16 +34335,16 @@
     },
     "packages/Templates/engine": {
       "name": "@memberjunction/templates",
-      "version": "2.51.0",
+      "version": "2.52.0",
       "license": "ISC",
       "dependencies": {
-        "@memberjunction/ai": "2.51.0",
-        "@memberjunction/ai-groq": "2.51.0",
-        "@memberjunction/aiengine": "2.51.0",
-        "@memberjunction/core": "2.51.0",
-        "@memberjunction/core-entities": "2.51.0",
-        "@memberjunction/global": "2.51.0",
-        "@memberjunction/templates-base-types": "2.51.0",
+        "@memberjunction/ai": "2.52.0",
+        "@memberjunction/ai-groq": "2.52.0",
+        "@memberjunction/aiengine": "2.52.0",
+        "@memberjunction/core": "2.52.0",
+        "@memberjunction/core-entities": "2.52.0",
+        "@memberjunction/global": "2.52.0",
+        "@memberjunction/templates-base-types": "2.52.0",
         "nunjucks": "3.2.4"
       },
       "devDependencies": {

--- a/packages/GraphQLDataProvider/src/graphQLSystemUserClient.ts
+++ b/packages/GraphQLDataProvider/src/graphQLSystemUserClient.ts
@@ -251,6 +251,293 @@ export class GraphQLSystemUserClient {
         }     
     }
 
+    /**
+     * Runs a view by name using the RunViewByNameSystemUser resolver.
+     * @param input - View input parameters for running by name
+     * @returns Promise containing the view execution results
+     */
+    public async RunViewByNameSystemUser(input: RunViewByNameSystemUserInput): Promise<RunViewSystemUserResult> {
+        try {
+            const query = `query RunViewByNameSystemUser($input: RunViewByNameInput!) {
+                RunViewByNameSystemUser(input: $input) {
+                    Results {
+                        ID
+                        EntityID
+                        Data
+                    }
+                    UserViewRunID
+                    RowCount
+                    TotalRowCount
+                    ExecutionTime
+                    ErrorMessage
+                    Success
+                }
+            }`
+
+            const result = await this.Client.request(query, { input }) as { RunViewByNameSystemUser: RunViewSystemUserResult };
+            if (result && result.RunViewByNameSystemUser) {
+                return result.RunViewByNameSystemUser;
+            } else {
+                return {
+                    Results: [],
+                    Success: false,
+                    ErrorMessage: 'Failed to execute view by name'
+                };
+            }
+        }
+        catch (e) {
+            LogError(`GraphQLSystemUserClient::RunViewByNameSystemUser - Error running view by name - ${e}`);
+            return {
+                Results: [],
+                Success: false,
+                ErrorMessage: e.toString()
+            };
+        }
+    }
+
+    /**
+     * Runs a view by ID using the RunViewByIDSystemUser resolver.
+     * @param input - View input parameters for running by ID
+     * @returns Promise containing the view execution results
+     */
+    public async RunViewByIDSystemUser(input: RunViewByIDSystemUserInput): Promise<RunViewSystemUserResult> {
+        try {
+            const query = `query RunViewByIDSystemUser($input: RunViewByIDInput!) {
+                RunViewByIDSystemUser(input: $input) {
+                    Results {
+                        ID
+                        EntityID
+                        Data
+                    }
+                    UserViewRunID
+                    RowCount
+                    TotalRowCount
+                    ExecutionTime
+                    ErrorMessage
+                    Success
+                }
+            }`
+
+            const result = await this.Client.request(query, { input }) as { RunViewByIDSystemUser: RunViewSystemUserResult };
+            if (result && result.RunViewByIDSystemUser) {
+                return result.RunViewByIDSystemUser;
+            } else {
+                return {
+                    Results: [],
+                    Success: false,
+                    ErrorMessage: 'Failed to execute view by ID'
+                };
+            }
+        }
+        catch (e) {
+            LogError(`GraphQLSystemUserClient::RunViewByIDSystemUser - Error running view by ID - ${e}`);
+            return {
+                Results: [],
+                Success: false,
+                ErrorMessage: e.toString()
+            };
+        }
+    }
+
+    /**
+     * Runs a dynamic view using the RunDynamicViewSystemUser resolver.
+     * @param input - View input parameters for dynamic view execution
+     * @returns Promise containing the view execution results
+     */
+    public async RunDynamicViewSystemUser(input: RunDynamicViewSystemUserInput): Promise<RunViewSystemUserResult> {
+        try {
+            const query = `query RunDynamicViewSystemUser($input: RunDynamicViewInput!) {
+                RunDynamicViewSystemUser(input: $input) {
+                    Results {
+                        ID
+                        EntityID
+                        Data
+                    }
+                    UserViewRunID
+                    RowCount
+                    TotalRowCount
+                    ExecutionTime
+                    ErrorMessage
+                    Success
+                }
+            }`
+
+            const result = await this.Client.request(query, { input }) as { RunDynamicViewSystemUser: RunViewSystemUserResult };
+            if (result && result.RunDynamicViewSystemUser) {
+                return result.RunDynamicViewSystemUser;
+            } else {
+                return {
+                    Results: [],
+                    Success: false,
+                    ErrorMessage: 'Failed to execute dynamic view'
+                };
+            }
+        }
+        catch (e) {
+            LogError(`GraphQLSystemUserClient::RunDynamicViewSystemUser - Error running dynamic view - ${e}`);
+            return {
+                Results: [],
+                Success: false,
+                ErrorMessage: e.toString()
+            };
+        }
+    }
+
+    /**
+     * Runs multiple views using the RunViewsSystemUser resolver. This method allows system users
+     * to execute view queries with the same functionality as regular users but with system-level privileges.
+     * @param input - Array of view input parameters
+     * @returns Promise containing the results from all view executions
+     */
+    public async RunViewsSystemUser(input: RunViewSystemUserInput[]): Promise<RunViewSystemUserResult[]> {
+        try {
+            const query = `query RunViewsSystemUser($input: [RunViewGenericInput!]!) {
+                RunViewsSystemUser(input: $input) {
+                    Results {
+                        ID
+                        EntityID
+                        Data
+                    }
+                    UserViewRunID
+                    RowCount
+                    TotalRowCount
+                    ExecutionTime
+                    ErrorMessage
+                    Success
+                }
+            }`
+
+            const result = await this.Client.request(query, { input }) as { RunViewsSystemUser: RunViewSystemUserResult[] };
+            if (result && result.RunViewsSystemUser) {
+                return result.RunViewsSystemUser;
+            } else {
+                return [];
+            }
+        }
+        catch (e) {
+            LogError(`GraphQLSystemUserClient::RunViewsSystemUser - Error running views - ${e}`);
+            return [];
+        }
+    }
+
+    /**
+     * Executes a stored query by ID using the GetQueryDataSystemUser resolver.
+     * @param queryId - The ID of the query to execute
+     * @param categoryId - Optional category ID filter
+     * @param categoryName - Optional category name filter
+     * @returns Promise containing the query execution results
+     */
+    public async GetQueryDataSystemUser(queryId: string, categoryId?: string, categoryName?: string): Promise<RunQuerySystemUserResult> {
+        try {
+            const query = `query GetQueryDataSystemUser($QueryID: String!, $CategoryID: String, $CategoryName: String) {
+                GetQueryDataSystemUser(QueryID: $QueryID, CategoryID: $CategoryID, CategoryName: $CategoryName) {
+                    QueryID
+                    QueryName
+                    Success
+                    Results
+                    RowCount
+                    ExecutionTime
+                    ErrorMessage
+                }
+            }`
+
+            const result = await this.Client.request(query, { 
+                QueryID: queryId, 
+                CategoryID: categoryId, 
+                CategoryName: categoryName 
+            }) as { GetQueryDataSystemUser: RunQuerySystemUserResult };
+            
+            if (result && result.GetQueryDataSystemUser) {
+                // Parse the JSON results for easier consumption
+                return {
+                    ...result.GetQueryDataSystemUser,
+                    Results: result.GetQueryDataSystemUser.Results ? SafeJSONParse(result.GetQueryDataSystemUser.Results) : null
+                };
+            } else {
+                return {
+                    QueryID: queryId,
+                    QueryName: '',
+                    Success: false,
+                    Results: null,
+                    RowCount: 0,
+                    ExecutionTime: 0,
+                    ErrorMessage: 'Query execution failed'
+                };
+            }
+        }
+        catch (e) {
+            LogError(`GraphQLSystemUserClient::GetQueryDataSystemUser - Error executing query - ${e}`);
+            return {
+                QueryID: queryId,
+                QueryName: '',
+                Success: false,
+                Results: null,
+                RowCount: 0,
+                ExecutionTime: 0,
+                ErrorMessage: e.toString()
+            };
+        }
+    }
+
+    /**
+     * Executes a stored query by name using the GetQueryDataByNameSystemUser resolver.
+     * @param queryName - The name of the query to execute
+     * @param categoryId - Optional category ID filter
+     * @param categoryName - Optional category name filter
+     * @returns Promise containing the query execution results
+     */
+    public async GetQueryDataByNameSystemUser(queryName: string, categoryId?: string, categoryName?: string): Promise<RunQuerySystemUserResult> {
+        try {
+            const query = `query GetQueryDataByNameSystemUser($QueryName: String!, $CategoryID: String, $CategoryName: String) {
+                GetQueryDataByNameSystemUser(QueryName: $QueryName, CategoryID: $CategoryID, CategoryName: $CategoryName) {
+                    QueryID
+                    QueryName
+                    Success
+                    Results
+                    RowCount
+                    ExecutionTime
+                    ErrorMessage
+                }
+            }`
+
+            const result = await this.Client.request(query, { 
+                QueryName: queryName, 
+                CategoryID: categoryId, 
+                CategoryName: categoryName 
+            }) as { GetQueryDataByNameSystemUser: RunQuerySystemUserResult };
+            
+            if (result && result.GetQueryDataByNameSystemUser) {
+                // Parse the JSON results for easier consumption
+                return {
+                    ...result.GetQueryDataByNameSystemUser,
+                    Results: result.GetQueryDataByNameSystemUser.Results ? SafeJSONParse(result.GetQueryDataByNameSystemUser.Results) : null
+                };
+            } else {
+                return {
+                    QueryID: '',
+                    QueryName: queryName,
+                    Success: false,
+                    Results: null,
+                    RowCount: 0,
+                    ExecutionTime: 0,
+                    ErrorMessage: 'Query execution failed'
+                };
+            }
+        }
+        catch (e) {
+            LogError(`GraphQLSystemUserClient::GetQueryDataByNameSystemUser - Error executing query - ${e}`);
+            return {
+                QueryID: '',
+                QueryName: queryName,
+                Success: false,
+                Results: null,
+                RowCount: 0,
+                ExecutionTime: 0,
+                ErrorMessage: e.toString()
+            };
+        }
+    }
+
 }
 
 /**
@@ -315,6 +602,121 @@ export class SimpleRemoteEntityField {
     Type: string;
     AllowsNull: boolean;
     MaxLength: number;
+}
+
+/**
+ * Input type for RunViewByNameSystemUser method calls
+ */
+export interface RunViewByNameSystemUserInput {
+    ViewName: string;
+    ExtraFilter?: string;
+    OrderBy?: string;
+    Fields?: string[];
+    UserSearchString?: string;
+    ExcludeUserViewRunID?: string;
+    OverrideExcludeFilter?: string;
+    SaveViewResults?: boolean;
+    ExcludeDataFromAllPriorViewRuns?: boolean;
+    IgnoreMaxRows?: boolean;
+    MaxRows?: number;
+    ForceAuditLog?: boolean;
+    AuditLogDescription?: string;
+    ResultType?: string;
+    StartRow?: number;
+}
+
+/**
+ * Input type for RunViewByIDSystemUser method calls
+ */
+export interface RunViewByIDSystemUserInput {
+    ViewID: string;
+    ExtraFilter?: string;
+    OrderBy?: string;
+    Fields?: string[];
+    UserSearchString?: string;
+    ExcludeUserViewRunID?: string;
+    OverrideExcludeFilter?: string;
+    SaveViewResults?: boolean;
+    ExcludeDataFromAllPriorViewRuns?: boolean;
+    IgnoreMaxRows?: boolean;
+    MaxRows?: number;
+    ForceAuditLog?: boolean;
+    AuditLogDescription?: string;
+    ResultType?: string;
+    StartRow?: number;
+}
+
+/**
+ * Input type for RunDynamicViewSystemUser method calls
+ */
+export interface RunDynamicViewSystemUserInput {
+    EntityName: string;
+    ExtraFilter?: string;
+    OrderBy?: string;
+    Fields?: string[];
+    UserSearchString?: string;
+    ExcludeUserViewRunID?: string;
+    OverrideExcludeFilter?: string;
+    IgnoreMaxRows?: boolean;
+    MaxRows?: number;
+    ForceAuditLog?: boolean;
+    AuditLogDescription?: string;
+    ResultType?: string;
+    StartRow?: number;
+}
+
+/**
+ * Input type for RunViewsSystemUser method calls
+ */
+export interface RunViewSystemUserInput {
+    EntityName: string;
+    ExtraFilter?: string;
+    OrderBy?: string;
+    Fields?: string[];
+    UserSearchString?: string;
+    ExcludeUserViewRunID?: string;
+    OverrideExcludeFilter?: string;
+    IgnoreMaxRows?: boolean;
+    MaxRows?: number;
+    ForceAuditLog?: boolean;
+    AuditLogDescription?: string;
+    ResultType?: string;
+    StartRow?: number;
+}
+
+/**
+ * Result row type for view execution results
+ */
+export interface RunViewSystemUserResultRow {
+    ID: string;
+    EntityID: string;
+    Data: string;
+}
+
+/**
+ * Result type for RunViewsSystemUser method calls
+ */
+export interface RunViewSystemUserResult {
+    Results: RunViewSystemUserResultRow[];
+    UserViewRunID?: string;
+    RowCount?: number;
+    TotalRowCount?: number;
+    ExecutionTime?: number;
+    ErrorMessage?: string;
+    Success: boolean;
+}
+
+/**
+ * Result type for query execution methods
+ */
+export interface RunQuerySystemUserResult {
+    QueryID: string;
+    QueryName: string;
+    Success: boolean;
+    Results: any;
+    RowCount: number;
+    ExecutionTime: number;
+    ErrorMessage: string;
 }
 
  

--- a/packages/MJServer/src/resolvers/QueryResolver.ts
+++ b/packages/MJServer/src/resolvers/QueryResolver.ts
@@ -2,6 +2,7 @@
 import { RunQuery } from '@memberjunction/core';
 import { Arg, Ctx, Field, Int, ObjectType, Query, Resolver } from 'type-graphql';
 import { AppContext } from '../types.js';
+import { RequireSystemUser } from '../directives/RequireSystemUser.js';
 
 @ObjectType()
 export class RunQueryResultType {
@@ -59,6 +60,58 @@ export class ReportResolver {
                            @Ctx() context: AppContext,
                            @Arg('CategoryID', () => String, {nullable: true}) CategoryID?: string,
                            @Arg('CategoryName', () => String, {nullable: true}) CategoryName?: string): Promise<RunQueryResultType> {
+    const runQuery = new RunQuery();
+    const result = await runQuery.RunQuery(
+      { 
+        QueryName: QueryName, 
+        CategoryID: CategoryID,
+        CategoryName: CategoryName
+      },
+      context.userPayload.userRecord);
+      
+    return {
+      QueryID: result.QueryID,
+      QueryName: QueryName,
+      Success: result.Success,
+      Results: JSON.stringify(result.Results),
+      RowCount: result.RowCount,
+      ExecutionTime: result.ExecutionTime,
+      ErrorMessage: result.ErrorMessage,
+    };
+  }
+
+  @RequireSystemUser()
+  @Query(() => RunQueryResultType)
+  async GetQueryDataSystemUser(@Arg('QueryID', () => String) QueryID: string, 
+                               @Ctx() context: AppContext,
+                               @Arg('CategoryID', () => String, {nullable: true}) CategoryID?: string,
+                               @Arg('CategoryName', () => String, {nullable: true}) CategoryName?: string): Promise<RunQueryResultType> {
+    const runQuery = new RunQuery();
+    const result = await runQuery.RunQuery(
+      { 
+        QueryID: QueryID,
+        CategoryID: CategoryID,
+        CategoryName: CategoryName 
+      }, 
+      context.userPayload.userRecord);
+    
+    return {
+      QueryID: QueryID,
+      QueryName: result.QueryName,
+      Success: result.Success,
+      Results: JSON.stringify(result.Results),
+      RowCount: result.RowCount,
+      ExecutionTime: result.ExecutionTime,
+      ErrorMessage: result.ErrorMessage,
+    };
+  }
+
+  @RequireSystemUser()
+  @Query(() => RunQueryResultType)
+  async GetQueryDataByNameSystemUser(@Arg('QueryName', () => String) QueryName: string, 
+                                     @Ctx() context: AppContext,
+                                     @Arg('CategoryID', () => String, {nullable: true}) CategoryID?: string,
+                                     @Arg('CategoryName', () => String, {nullable: true}) CategoryName?: string): Promise<RunQueryResultType> {
     const runQuery = new RunQuery();
     const result = await runQuery.RunQuery(
       { 


### PR DESCRIPTION
## Summary

  - Added RequireSystemUser decorators to new resolver methods in RunViewResolver and QueryResolver
  - Extended GraphQLSystemUserClient with methods to invoke system user resolvers
  - Enables server-to-server communication with system-level privileges for view and query operations

  ## Changes Made

  ### MJServer Package
  - **RunViewResolver.ts**: Added 4 new system user resolvers
    - \`RunViewByNameSystemUser\`
    - \`RunViewByIDSystemUser\`
    - \`RunDynamicViewSystemUser\`
    - \`RunViewsSystemUser\`

  - **QueryResolver.ts**: Added 2 new system user resolvers
    - \`GetQueryDataSystemUser\`
    - \`GetQueryDataByNameSystemUser\`

  ### GraphQLDataProvider Package
  - **GraphQLSystemUserClient.ts**: Added 6 new client methods with TypeScript interfaces
  - Full type safety with comprehensive input/output type definitions

  🤖 Generated with [Claude Code](https://claude.ai/code)" --base next