### PR TITLE
feat: add hierarchical CategoryName support for query lookup

### DIFF
--- a/.changeset/quick-trainers-give.md
+++ b/.changeset/quick-trainers-give.md
@@ -1,0 +1,22 @@
+---
+"@memberjunction/ng-core-entity-forms": patch
+"@memberjunction/core": patch
+"@memberjunction/sqlserver-dataprovider": patch
+---
+
+feat: add hierarchical CategoryName support for query lookup
+
+Adds support for hierarchical category paths in query lookup operations.
+The CategoryName parameter now accepts filesystem-like paths (e.g.,
+"/MJ/AI/Agents/") that walk through the QueryCategory parent-child
+relationships.
+
+### New Features
+
+- **Hierarchical Path Resolution**: CategoryName now supports paths like
+  "/MJ/AI/Agents/" that are parsed by splitting on "/" and walking down the
+  category hierarchy using ParentID relationships
+- **CategoryPath Property**: Added CategoryPath getter to QueryInfo class
+  that returns the full hierarchical path for any query
+- **Backward Compatibility**: Existing simple CategoryName usage (e.g.,
+  "Agents") continues to work unchanged

--- a/packages/Angular/Explorer/core-entity-forms/src/lib/custom/ai-agent-run/ai-agent-run-cost.service.ts
+++ b/packages/Angular/Explorer/core-entity-forms/src/lib/custom/ai-agent-run/ai-agent-run-cost.service.ts
@@ -55,7 +55,7 @@ export class AIAgentRunCostService {
       const rq = new RunQuery();
       const queryResult = await rq.RunQuery({
         QueryName: 'CalculateRunCost',
-        CategoryName: 'Agents',
+        CategoryName: 'MJ/AI/Agents',
         Parameters: {
           AIAgentRunID: agentRunId,
           MJCoreSchemaName: mjCoreSchemaName

--- a/packages/MJCore/src/generic/queryInfo.ts
+++ b/packages/MJCore/src/generic/queryInfo.ts
@@ -64,6 +64,20 @@ export class QueryInfo extends BaseInfo {
      */
     Category: string = null
 
+    private _categoryPath: string | null = null;
+    /**
+     * Gets the full hierarchical path of this query's category (e.g., "/MJ/AI/Agents/").
+     * This provides a unique filepath-like identifier for the category hierarchy.
+     * Returns empty string if the query is not categorized.
+     * @returns {string} The category path with leading and trailing slashes
+     */
+    get CategoryPath(): string {
+        if (this._categoryPath === null) {
+            this._categoryPath = this.buildCategoryPath();
+        }
+        return this._categoryPath;
+    }
+
     private _fields: QueryFieldInfo[] = null
     /**
      * Gets the field metadata for this query, including display names, data types, and formatting rules.
@@ -132,6 +146,25 @@ export class QueryInfo extends BaseInfo {
      */
     get CategoryInfo(): QueryCategoryInfo {
         return Metadata.Provider.QueryCategories.find(c => c.ID === this.CategoryID);
+    }
+
+    /**
+     * Builds the hierarchical category path by walking up the parent chain.
+     * @returns {string} The category path (e.g., "/MJ/AI/Agents/") or empty string if uncategorized
+     */
+    private buildCategoryPath(): string {
+        if (!this.CategoryID) return '';
+        
+        const pathSegments: string[] = [];
+        let currentCategory = this.CategoryInfo;
+        
+        // Walk up the hierarchy to build the path
+        while (currentCategory) {
+            pathSegments.unshift(currentCategory.Name);
+            currentCategory = currentCategory.ParentCategoryInfo;
+        }
+        
+        return pathSegments.length > 0 ? `/${pathSegments.join('/')}/` : '';
     }
 
     /**

--- a/packages/SQLServerDataProvider/README.md
+++ b/packages/SQLServerDataProvider/README.md
@@ -275,9 +275,11 @@ console.log('User permissions:', spResult);
 
 // Using RunQuery for pre-defined queries
 const queryParams: RunQueryParams = {
-  QueryID: 'query-id-here', // or use QueryName
-  // CategoryID: 'optional-category-id',
-  // CategoryName: 'optional-category-name'
+  QueryID: 'query-id-here', // or use QueryName + Category identification
+  // Alternative: use QueryName with hierarchical CategoryName path
+  // QueryName: 'CalculateCost',
+  // CategoryName: '/MJ/AI/Agents/'  // Hierarchical path notation
+  // CategoryID: 'optional-direct-category-id',
 };
 
 const queryResult = await dataProvider.RunQuery(queryParams);
@@ -286,6 +288,19 @@ if (queryResult.Success) {
   console.log('Query results:', queryResult.Results);
   console.log('Execution time:', queryResult.ExecutionTime, 'ms');
 }
+
+// Query lookup supports hierarchical category paths
+// Example: Query with name "CalculateCost" in category hierarchy "MJ" -> "AI" -> "Agents"
+const hierarchicalQueryParams: RunQueryParams = {
+  QueryName: 'CalculateCost',
+  CategoryName: '/MJ/AI/Agents/'  // Full hierarchical path with leading/trailing slashes
+};
+
+// The CategoryName is parsed as a path where:
+// - "/" separates category levels
+// - Each segment is matched case-insensitively against category names
+// - The path walks from root to leaf through the ParentID relationships
+// - Falls back to simple category name matching for backward compatibility
 ```
 
 ### User Management and Caching

--- a/packages/SQLServerDataProvider/src/SQLServerDataProvider.ts
+++ b/packages/SQLServerDataProvider/src/SQLServerDataProvider.ts
@@ -74,6 +74,7 @@ import {
   DatasetItemResultType,
   DatabaseProviderBase,
   QueryInfo,
+  QueryCategoryInfo,
 } from '@memberjunction/core';
 import { QueryParameterProcessor } from './queryParameterProcessor';
 
@@ -675,6 +676,53 @@ export class SQLServerDataProvider
   // END ---- IRunReportProvider
   /**************************************************************************/
 
+  /**
+   * Resolves a hierarchical category path (e.g., "/MJ/AI/Agents/") to a CategoryID.
+   * The path is split by "/" and each segment is matched case-insensitively against
+   * category names, walking down the hierarchy from root to leaf.
+   * 
+   * @param categoryPath The hierarchical category path (e.g., "/MJ/AI/Agents/")
+   * @returns The CategoryID if the path exists, null otherwise
+   */
+  private resolveCategoryPath(categoryPath: string): string | null {
+    if (!categoryPath) return null;
+    
+    // Split path and clean segments - remove empty strings from leading/trailing slashes
+    const segments = categoryPath.split('/')
+      .map(s => s.trim())
+      .filter(s => s.length > 0);
+    
+    if (segments.length === 0) return null;
+    
+    // Walk down the hierarchy to find the target category
+    let currentCategory: QueryCategoryInfo | null = null;
+    
+    for (const segment of segments) {
+      const parentId = currentCategory?.ID || null;
+      currentCategory = this.QueryCategories.find(cat => 
+        cat.Name.trim().toLowerCase() === segment.toLowerCase() && 
+        cat.ParentID === parentId
+      );
+      
+      if (!currentCategory) {
+        return null; // Path not found
+      }
+    }
+    
+    return currentCategory.ID;
+  }
+
+  /**
+   * Finds a query by ID or by Name+Category combination.
+   * Supports both direct CategoryID lookup and hierarchical CategoryName path resolution.
+   * 
+   * @param QueryID Unique identifier for the query
+   * @param QueryName Name of the query to find
+   * @param CategoryID Direct category ID for the query
+   * @param CategoryName Hierarchical category path (e.g., "/MJ/AI/Agents/") or simple category name
+   * @param refreshMetadataIfNotFound Whether to refresh metadata if query is not found
+   * @returns The found QueryInfo or null if not found
+   */
   protected async findQuery(QueryID: string, QueryName: string, CategoryID: string, CategoryName: string, refreshMetadataIfNotFound: boolean = false): Promise<QueryInfo | null> {
       // First, get the query metadata
       const queries = this.Queries.filter(q => {
@@ -684,9 +732,16 @@ export class SQLServerDataProvider
           let matches = q.Name.trim().toLowerCase() === QueryName.trim().toLowerCase();
           if (CategoryID) {
             matches = matches && q.CategoryID.trim().toLowerCase() === CategoryID.trim().toLowerCase();
-          }
-          if (CategoryName) {
-            matches = matches && q.Category.trim().toLowerCase() === CategoryName.trim().toLowerCase();
+          } else if (CategoryName) {
+            // New hierarchical path logic - try path resolution first, fall back to simple name match
+            const resolvedCategoryId = this.resolveCategoryPath(CategoryName);
+            if (resolvedCategoryId) {
+              // Hierarchical path matched - use the resolved CategoryID
+              matches = matches && q.CategoryID === resolvedCategoryId;
+            } else {
+              // Fall back to simple category name comparison for backward compatibility
+              matches = matches && q.Category.trim().toLowerCase() === CategoryName.trim().toLowerCase();
+            }
           }
           return matches;
         }


### PR DESCRIPTION
## Summary

Adds support for hierarchical category paths in query lookup operations. The `CategoryName` parameter now accepts filesystem-like paths (e.g., `/MJ/AI/Agents/`) that walk through the QueryCategory parent-child relationships.

## Key Features

- **Hierarchical Path Resolution**: CategoryName now supports paths like `/MJ/AI/Agents/` that are parsed by splitting on "/" and walking down the category hierarchy using ParentID relationships
- **CategoryPath Property**: Added CategoryPath getter to QueryInfo class that returns the full hierarchical path for any query  
- **Backward Compatibility**: Existing simple CategoryName usage (e.g., "Agents") continues to work unchanged
- **Case-Insensitive Matching**: Path segments are matched case-insensitively with automatic trimming

## Technical Changes

- Added `resolveCategoryPath()` method to SQLServerDataProvider for parsing hierarchical paths
- Updated `findQuery()` method to try hierarchical path resolution first, then fall back to simple name matching
- Added `buildCategoryPath()` method to QueryInfo class for constructing paths from category hierarchy
- Enhanced SQLServerDataProvider README with examples of hierarchical CategoryName usage
- Updated existing usage in ai-agent-run-cost.service.ts to demonstrate new format

## Examples

### Before (still works)
```typescript
const queryParams = {
  QueryName: 'CalculateCost',
  CategoryName: 'Agents'  // Simple name
};
```

### After (new capability)
```typescript
const queryParams = {
  QueryName: 'CalculateCost', 
  CategoryName: '/MJ/AI/Agents/'  // Hierarchical path
};
```

## Migration

No breaking changes. Existing code using CategoryName with simple names continues to work. New code can optionally use hierarchical paths for more precise query identification.

## Test plan

- [x] Compiled both MJCore and SQLServerDataProvider packages successfully
- [x] Verified no new TypeScript compilation errors
- [x] Updated existing usage to demonstrate new hierarchical format
- [x] Added comprehensive documentation and examples
- [x] Maintained full backward compatibility

🤖 Generated with [Claude Code](https://claude.ai/code)