### PR TITLE
Fix: Prevent server crash in CreateQuerySystemUser resolver

### DIFF
--- a/.changeset/soft-peas-rhyme.md
+++ b/.changeset/soft-peas-rhyme.md
@@ -1,0 +1,12 @@
+---
+"@memberjunction/server": patch
+---
+
+fix: Add error handling to CreateQuerySystemUser resolver to prevent
+server crashes
+
+- Wrap Query Categories entity creation in try/catch block
+- Add null check after GetEntityObject call
+- Improve error messages with actual error details
+- Prevents "Entity Query Categories not found" from killing MJAPI
+  process


### PR DESCRIPTION
## Summary
- Added proper error handling to prevent unhandled exceptions from crashing the MJAPI server
- The `CreateQuerySystemUser` resolver was missing try/catch blocks around entity creation

## Test plan
- [x] Verify CreateQuerySystemUser mutation handles missing metadata gracefully
- [x] Confirm server continues running when "Entity Query Categories not found" error occurs
- [x] Check that appropriate error messages are returned to GraphQL clients

🤖 Generated with [Claude Code](https://claude.ai/code)