### PR TITLE
Fix metadata provider transaction context and subscription leak issues

### DIFF
--- a/.changeset/proud-lobsters-fly.md
+++ b/.changeset/proud-lobsters-fly.md
@@ -1,0 +1,9 @@
+---
+"@memberjunction/graphql-dataprovider": patch
+"@memberjunction/core": patch
+"@memberjunction/core-entities": patch
+"@memberjunction/core-entities-server": patch
+"@memberjunction/sqlserver-dataprovider": patch
+---
+
+Bug fixes for SQLServerDataProvider and fix ability to use other providers for MD refreshes up and down the stack

--- a/metadata/queries/.queries.json
+++ b/metadata/queries/.queries.json
@@ -17,8 +17,8 @@
       "ID": "1ED5F808-5B12-45DB-A376-324CF65B0CAF"
     },
     "sync": {
-      "lastModified": "2025-07-29T21:20:10.748Z",
-      "checksum": "d2d1377076d38e85c6f46ad28cf7cda14efc977ffec00e97db8a6b790d5258f6"
+      "lastModified": "2025-08-04T00:01:05.461Z",
+      "checksum": "a50586414c8651965f7f2c5e9d5f569e05e71fbf22bda36ca04a2a3809a7d9eb"
     }
   }
 ]

--- a/packages/GraphQLDataProvider/src/graphQLDataProvider.ts
+++ b/packages/GraphQLDataProvider/src/graphQLDataProvider.ts
@@ -219,7 +219,7 @@ export class GraphQLDataProvider extends ProviderBase implements IEntityDataProv
      * @param separateConnection 
      * @returns 
      */
-    public async Config(configData: GraphQLProviderConfigData, separateConnection?: boolean, forceRefreshSessionId?: boolean): Promise<boolean> {
+    public async Config(configData: GraphQLProviderConfigData, providerToUse?: IMetadataProvider, separateConnection?: boolean, forceRefreshSessionId?: boolean): Promise<boolean> {
         try {
             if (separateConnection) {
                 this._configData = configData;

--- a/packages/MJCore/src/generic/interfaces.ts
+++ b/packages/MJCore/src/generic/interfaces.ts
@@ -283,7 +283,7 @@ export interface IMetadataProvider {
 
     get DatabaseConnection(): any
 
-    Config(configData: ProviderConfigDataBase): Promise<boolean>
+    Config(configData: ProviderConfigDataBase, providerToUse?: IMetadataProvider): Promise<boolean>
 
     get Entities(): EntityInfo[]
 
@@ -406,15 +406,15 @@ export interface IMetadataProvider {
 
     CreateTransactionGroup(): Promise<TransactionGroupBase>
 
-    Refresh(): Promise<boolean>
+    Refresh(providerToUse?: IMetadataProvider): Promise<boolean>
 
-    RefreshIfNeeded(): Promise<boolean>
+    RefreshIfNeeded(providerToUse?: IMetadataProvider): Promise<boolean>
 
-    CheckToSeeIfRefreshNeeded(): Promise<boolean>
+    CheckToSeeIfRefreshNeeded(providerToUse?: IMetadataProvider): Promise<boolean>
 
     get LocalStorageProvider(): ILocalStorageProvider
 
-    RefreshRemoteMetadataTimestamps(): Promise<boolean>
+    RefreshRemoteMetadataTimestamps(providerToUse?: IMetadataProvider): Promise<boolean>
 
     SaveLocalMetadataToStorage(): Promise<void>
     
@@ -425,13 +425,13 @@ export interface IMetadataProvider {
      * @param datasetName 
      * @param itemFilters 
      */
-    GetDatasetByName(datasetName: string, itemFilters?: DatasetItemFilterType[], contextUser?: UserInfo): Promise<DatasetResultType>;
+    GetDatasetByName(datasetName: string, itemFilters?: DatasetItemFilterType[], contextUser?: UserInfo, providerToUse?: IMetadataProvider): Promise<DatasetResultType>;
     /**
      * Retrieves the date status information for a dataset and all its items from the server. This method will match the datasetName and itemFilters to the server's dataset and item filters to determine a match
      * @param datasetName 
      * @param itemFilters 
      */
-    GetDatasetStatusByName(datasetName: string, itemFilters?: DatasetItemFilterType[], contextUser?: UserInfo): Promise<DatasetStatusResultType>;
+    GetDatasetStatusByName(datasetName: string, itemFilters?: DatasetItemFilterType[], contextUser?: UserInfo, providerToUse?: IMetadataProvider): Promise<DatasetStatusResultType>;
 
     /**
      * Gets a database by name, if required, and caches it in a format available to the client (e.g. IndexedDB, LocalStorage, File, etc). The cache method is Provider specific

--- a/packages/MJCore/src/generic/metadata.ts
+++ b/packages/MJCore/src/generic/metadata.ts
@@ -40,8 +40,8 @@ export class Metadata {
      * Forces a refresh of all cached metadata.
      * @returns 
      */
-    public async Refresh(): Promise<boolean> {
-        return await Metadata.Provider.Refresh();
+    public async Refresh(providerToUse?: IMetadataProvider): Promise<boolean> {
+        return await Metadata.Provider.Refresh(providerToUse);
     }
 
     public get ProviderType(): ProviderType {
@@ -472,16 +472,16 @@ export class Metadata {
      * @param datasetName 
      * @param itemFilters 
      */
-    public async GetDatasetStatusByName(datasetName: string, itemFilters?: DatasetItemFilterType[], contextUser?: UserInfo): Promise<DatasetStatusResultType> {
-        return Metadata.Provider.GetDatasetStatusByName(datasetName, itemFilters, contextUser);
+    public async GetDatasetStatusByName(datasetName: string, itemFilters?: DatasetItemFilterType[], contextUser?: UserInfo, providerToUse?: IMetadataProvider): Promise<DatasetStatusResultType> {
+        return Metadata.Provider.GetDatasetStatusByName(datasetName, itemFilters, contextUser, providerToUse);
     }
     /**
      * Always retrieves data from the server - this method does NOT check cache. To use cached local values if available, call GetAndCacheDatasetByName() instead
      * @param datasetName 
      * @param itemFilters 
      */
-    public async GetDatasetByName(datasetName: string, itemFilters?: DatasetItemFilterType[], contextUser?: UserInfo): Promise<DatasetResultType> {
-        return Metadata.Provider.GetDatasetByName(datasetName, itemFilters, contextUser);
+    public async GetDatasetByName(datasetName: string, itemFilters?: DatasetItemFilterType[], contextUser?: UserInfo, providerToUse?: IMetadataProvider): Promise<DatasetResultType> {
+        return Metadata.Provider.GetDatasetByName(datasetName, itemFilters, contextUser, providerToUse);
     }
 
     /**


### PR DESCRIPTION
## Summary

This PR addresses critical transaction context and connection management issues in the metadata provider system, resolving connection pool exhaustion and duplicate execution problems during transactional operations like MetadataSync.

## Key Changes

### 🔧 **Transaction Context Support**
- **Add `providerToUse` parameter** to IMetadataProvider interface methods (`Refresh`, `GetDatasetByName`, etc.)
- **Enable transaction context propagation** throughout the metadata provider stack
- **Support metadata refreshes within transaction scope** when using different connections than the global provider

### 🐛 **SQLServerDataProvider Bug Fixes**
- **Fix subscription leak** in `initializeQueueProcessor()` that caused duplicate SQL execution
- **Fix transaction context consistency** in `GetDatasetByName` and `GetDatasetStatusByName`
- **Use consistent provider instance** for all SQL operations within the same method
- **Prevent connection pool conflicts** during concurrent transactional operations

### 📡 **Cross-Stack Integration**
- **Update GraphQLDataProvider** to support new `providerToUse` parameter
- **Modify ProviderBase** to propagate transaction context through metadata operations
- **Fix QueryEntity.server** to use transaction-scoped providers for RunView operations
- **Update Metadata class** to pass provider context through the call chain

## Problem Solved

**Before**: During MetadataSync operations, metadata refreshes would fail because:
1. Transaction was active on one provider instance
2. Metadata operations used a different provider instance without transaction context
3. Multiple queue processors caused duplicate SQL execution
4. Connection pool exhaustion from mixed connection contexts

**After**: All metadata operations now respect transaction context and use consistent provider instances throughout the operation chain.

## Impact

- ✅ **Resolves MetadataSync transaction failures**
- ✅ **Prevents connection pool exhaustion**
- ✅ **Eliminates duplicate SQL execution**
- ✅ **Maintains data consistency during transactions**
- ✅ **Supports proper transaction scoping across the entire metadata stack**

## Files Changed

- `IMetadataProvider` interface and implementations
- `SQLServerDataProvider` transaction and queue management
- `GraphQLDataProvider` method signatures
- `ProviderBase` metadata refresh chain  
- `QueryEntity.server` RunView provider usage
- `Metadata` class method propagation

## Testing

This fix addresses the specific error occurring in `GetDatasetByName` during MetadataSync push operations and ensures consistent transaction context throughout the metadata provider ecosystem.