### PR TITLE
Fix: Remove non-existent ComputationEnabled field from Query operations

### DIFF
--- a/.changeset/fix-computation-enabled-field.md
+++ b/.changeset/fix-computation-enabled-field.md
@@ -1,0 +1,11 @@
+---
+"@memberjunction/graphql-dataprovider": patch
+"@memberjunction/server": patch
+---
+
+Fix: Remove non-existent ComputationEnabled field from Query operations
+
+- Removed ComputationEnabled field from GraphQL mutations (CreateQuerySystemUser and UpdateQuerySystemUser) in GraphQLSystemUserClient
+- Removed ComputationEnabled from QueryField TypeScript interface
+- Fixed CreateQueryResolver to not set ComputationEnabled when mapping query fields
+- This fixes GraphQL validation errors when creating or updating queries

--- a/packages/GraphQLDataProvider/src/graphQLSystemUserClient.ts
+++ b/packages/GraphQLDataProvider/src/graphQLSystemUserClient.ts
@@ -580,7 +580,6 @@ export class GraphQLSystemUserClient {
                         SQLBaseType
                         SQLFullType
                         IsComputed
-                        ComputationEnabled
                         ComputationDescription
                     }
                     Parameters {
@@ -656,7 +655,6 @@ export class GraphQLSystemUserClient {
                         SQLBaseType
                         SQLFullType
                         IsComputed
-                        ComputationEnabled
                         ComputationDescription
                     }
                     Parameters {
@@ -1361,7 +1359,6 @@ export interface QueryField {
     SQLBaseType?: string;
     SQLFullType?: string;
     IsComputed: boolean;
-    ComputationEnabled: boolean;
     ComputationDescription?: string;
 }
 

--- a/packages/MJServer/src/resolvers/CreateQueryResolver.ts
+++ b/packages/MJServer/src/resolvers/CreateQueryResolver.ts
@@ -501,7 +501,6 @@ export class QueryResolverExtended extends QueryResolver {
                 SQLBaseType: f.SQLBaseType || undefined,
                 SQLFullType: f.SQLFullType || undefined,
                 IsComputed: f.IsComputed,
-                ComputationEnabled: true, // Default to true as it's not in QueryFieldInfo
                 ComputationDescription: f.ComputationDescription || undefined
             }));
             


### PR DESCRIPTION
## Summary
- Removes the non-existent `ComputationEnabled` field from GraphQL Query operations
- Fixes GraphQL validation errors when creating or updating queries
- Ensures compatibility with the database schema where only `IsComputed` and `ComputationDescription` exist

## Problem
The `ComputationEnabled` field was being requested in GraphQL mutations and set in the resolver, but this field doesn't exist in:
- The GraphQL schema (`QueryFieldType`)
- The database entity (`QueryFieldEntity`)
- The MemberJunction metadata

This caused GraphQL validation errors: `Cannot query field "ComputationEnabled" on type "QueryFieldType"`

## Solution
Removed `ComputationEnabled` from:
1. **GraphQLSystemUserClient** (`packages/GraphQLDataProvider/src/graphQLSystemUserClient.ts`)
   - Removed from `CreateQuerySystemUser` mutation
   - Removed from `UpdateQuerySystemUser` mutation
   - Removed from `QueryField` TypeScript interface

2. **CreateQueryResolver** (`packages/MJServer/src/resolvers/CreateQueryResolver.ts`)
   - Removed the incorrect `ComputationEnabled: true` assignment when mapping query fields

## Testing
✅ **Source code verification**: Confirmed 0 occurrences of `ComputationEnabled` in the codebase
✅ **Compilation**: Both packages compile successfully without TypeScript errors
✅ **GraphQL mutation testing**: Verified the mutations work correctly without requesting the non-existent field
✅ **Database integration**: Successfully created and updated Query records in the database

## Test Results
```
🎉 SUCCESS: All tests passed\!
✅ GraphQL mutations execute without ComputationEnabled field
✅ Query records created successfully in database
✅ Query records updated successfully in database
```

## Changeset
Includes changeset marking both packages as patch releases.

🤖 Generated with [Claude Code](https://claude.ai/code)