### PR TITLE
feat: Add comprehensive effort level support to AI framework

### DIFF
--- a/.changeset/smart-eagles-sneeze.md
+++ b/.changeset/smart-eagles-sneeze.md
@@ -1,0 +1,6 @@
+---
+"@memberjunction/ng-core-entity-forms": minor
+"@memberjunction/core-entities": minor
+---
+
+migration file for effort level stuff

--- a/.changeset/twelve-doors-decide.md
+++ b/.changeset/twelve-doors-decide.md
@@ -1,0 +1,10 @@
+---
+"@memberjunction/ai-agents": minor
+"@memberjunction/ai-core-plus": minor
+"@memberjunction/ai-prompts": minor
+"@memberjunction/ng-core-entity-forms": minor
+"@memberjunction/core-entities": minor
+"@memberjunction/core-entities-server": minor
+---
+
+migration

--- a/migrations/v2/V202508062035__v2.82.x__Add_EffortLevel_To_AIPrompt.sql
+++ b/migrations/v2/V202508062035__v2.82.x__Add_EffortLevel_To_AIPrompt.sql
@@ -12,21 +12,21 @@
 -- Add EffortLevel column to AIPrompt table
 ALTER TABLE ${flyway:defaultSchema}.AIPrompt 
 ADD EffortLevel INT NULL;
-GO;
+GO
 
 -- Add DefaultPromptEffortLevel column to AIAgent table
 ALTER TABLE ${flyway:defaultSchema}.AIAgent 
 ADD DefaultPromptEffortLevel INT NULL;
-GO;
+GO
 
 -- Add CHECK constraints to enforce valid effort level range (1-100)
 ALTER TABLE ${flyway:defaultSchema}.AIPrompt 
 ADD CONSTRAINT CK_AIPrompt_EffortLevel CHECK (EffortLevel BETWEEN 1 AND 100);
-GO;
+GO
 
 ALTER TABLE ${flyway:defaultSchema}.AIAgent 
 ADD CONSTRAINT CK_AIAgent_DefaultPromptEffortLevel CHECK (DefaultPromptEffortLevel BETWEEN 1 AND 100);
-GO;
+GO
 
 -- Add extended property for AIPrompt.EffortLevel column
 EXEC sp_addextendedproperty 

--- a/migrations/v2/V202508062035__v2.82.x__Add_EffortLevel_To_AIPrompt.sql
+++ b/migrations/v2/V202508062035__v2.82.x__Add_EffortLevel_To_AIPrompt.sql
@@ -1,0 +1,1691 @@
+-- Add EffortLevel support to AIPrompt and AIAgent tables
+-- This migration adds support for effort level configuration (1-100 scale)
+-- Higher values request more thorough reasoning/analysis from AI models
+-- Each provider maps the 1-100 scale to their specific effort level parameters
+--
+-- Precedence hierarchy:
+-- 1. ExecuteAgentParams.effortLevel (Runtime override - highest priority)
+-- 2. AIAgent.DefaultPromptEffortLevel (Agent default - medium priority)  
+-- 3. AIPrompt.EffortLevel (Prompt default - lower priority)
+-- 4. No effort level (Provider default - lowest priority)
+
+-- Add EffortLevel column to AIPrompt table
+ALTER TABLE ${flyway:defaultSchema}.AIPrompt 
+ADD EffortLevel INT NULL;
+GO;
+
+-- Add DefaultPromptEffortLevel column to AIAgent table
+ALTER TABLE ${flyway:defaultSchema}.AIAgent 
+ADD DefaultPromptEffortLevel INT NULL;
+GO;
+
+-- Add CHECK constraints to enforce valid effort level range (1-100)
+ALTER TABLE ${flyway:defaultSchema}.AIPrompt 
+ADD CONSTRAINT CK_AIPrompt_EffortLevel CHECK (EffortLevel BETWEEN 1 AND 100);
+GO;
+
+ALTER TABLE ${flyway:defaultSchema}.AIAgent 
+ADD CONSTRAINT CK_AIAgent_DefaultPromptEffortLevel CHECK (DefaultPromptEffortLevel BETWEEN 1 AND 100);
+GO;
+
+-- Add extended property for AIPrompt.EffortLevel column
+EXEC sp_addextendedproperty 
+    @name = N'MS_Description', 
+    @value = N'Effort level for this specific prompt (1-100, where 1=minimal effort, 100=maximum effort). Higher values request more thorough reasoning and analysis. Can be overridden by agent DefaultPromptEffortLevel or runtime parameters.',
+    @level0type = N'SCHEMA', @level0name = N'${flyway:defaultSchema}',
+    @level1type = N'TABLE', @level1name = N'AIPrompt',
+    @level2type = N'COLUMN', @level2name = N'EffortLevel';
+
+-- Add extended property for AIAgent.DefaultPromptEffortLevel column
+EXEC sp_addextendedproperty 
+    @name = N'MS_Description', 
+    @value = N'Default effort level for all prompts executed by this agent (1-100, where 1=minimal effort, 100=maximum effort). Takes precedence over individual prompt EffortLevel settings but can be overridden by runtime parameters. Inherited by sub-agents unless explicitly overridden.',
+    @level0type = N'SCHEMA', @level0name = N'${flyway:defaultSchema}',
+    @level1type = N'TABLE', @level1name = N'AIAgent',
+    @level2type = N'COLUMN', @level2name = N'DefaultPromptEffortLevel';
+
+
+/*** CODE GEN RUN ***/
+
+
+/* SQL text to insert new entity field */
+
+      IF NOT EXISTS (
+         SELECT 1 FROM [${flyway:defaultSchema}].EntityField 
+         WHERE ID = 'dcbaeefd-c5a2-449d-a4b9-eab1290c2f89'  OR 
+               (EntityID = 'CDB135CC-6D3C-480B-90AE-25B7805F82C1' AND Name = 'DefaultPromptEffortLevel')
+         -- check to make sure we're not inserting a duplicate entity field metadata record
+      )
+      BEGIN
+         INSERT INTO [${flyway:defaultSchema}].EntityField
+         (
+            ID,
+            EntityID,
+            Sequence,
+            Name,
+            DisplayName,
+            Description,
+            Type,
+            Length,
+            Precision,
+            Scale,
+            AllowsNull,
+            DefaultValue,
+            AutoIncrement,
+            AllowUpdateAPI,
+            IsVirtual,
+            RelatedEntityID,
+            RelatedEntityFieldName,
+            IsNameField,
+            IncludeInUserSearchAPI,
+            IncludeRelatedEntityNameFieldInBaseView,
+            DefaultInView,
+            IsPrimaryKey,
+            IsUnique,
+            RelatedEntityDisplayType
+         )
+         VALUES
+         (
+            'dcbaeefd-c5a2-449d-a4b9-eab1290c2f89',
+            'CDB135CC-6D3C-480B-90AE-25B7805F82C1', -- Entity: AI Agents
+            100036,
+            'DefaultPromptEffortLevel',
+            'Default Prompt Effort Level',
+            'Default effort level for all prompts executed by this agent (1-100, where 1=minimal effort, 100=maximum effort). Takes precedence over individual prompt EffortLevel settings but can be overridden by runtime parameters. Inherited by sub-agents unless explicitly overridden.',
+            'int',
+            4,
+            10,
+            0,
+            1,
+            'null',
+            0,
+            1,
+            0,
+            NULL,
+            NULL,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            'Search'
+         )
+      END
+
+/* SQL text to insert new entity field */
+
+      IF NOT EXISTS (
+         SELECT 1 FROM [${flyway:defaultSchema}].EntityField 
+         WHERE ID = 'dafa54d5-f48a-499f-8f4e-e329af0b5b6b'  OR 
+               (EntityID = '73AD0238-8B56-EF11-991A-6045BDEBA539' AND Name = 'EffortLevel')
+         -- check to make sure we're not inserting a duplicate entity field metadata record
+      )
+      BEGIN
+         INSERT INTO [${flyway:defaultSchema}].EntityField
+         (
+            ID,
+            EntityID,
+            Sequence,
+            Name,
+            DisplayName,
+            Description,
+            Type,
+            Length,
+            Precision,
+            Scale,
+            AllowsNull,
+            DefaultValue,
+            AutoIncrement,
+            AllowUpdateAPI,
+            IsVirtual,
+            RelatedEntityID,
+            RelatedEntityFieldName,
+            IsNameField,
+            IncludeInUserSearchAPI,
+            IncludeRelatedEntityNameFieldInBaseView,
+            DefaultInView,
+            IsPrimaryKey,
+            IsUnique,
+            RelatedEntityDisplayType
+         )
+         VALUES
+         (
+            'dafa54d5-f48a-499f-8f4e-e329af0b5b6b',
+            '73AD0238-8B56-EF11-991A-6045BDEBA539', -- Entity: AI Prompts
+            100051,
+            'EffortLevel',
+            'Effort Level',
+            'Effort level for this specific prompt (1-100, where 1=minimal effort, 100=maximum effort). Higher values request more thorough reasoning and analysis. Can be overridden by agent DefaultPromptEffortLevel or runtime parameters.',
+            'int',
+            4,
+            10,
+            0,
+            1,
+            'null',
+            0,
+            1,
+            0,
+            NULL,
+            NULL,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            'Search'
+         )
+      END
+
+/* SQL text to delete entity field value ID 2716443E-F36B-1410-8DBB-00021F8B792E */
+DELETE FROM [${flyway:defaultSchema}].EntityFieldValue WHERE ID='2716443E-F36B-1410-8DBB-00021F8B792E'
+
+/* SQL text to update entity field value sequence */
+UPDATE [${flyway:defaultSchema}].EntityFieldValue SET Sequence=7 WHERE ID='2517443E-F36B-1410-8DBB-00021F8B792E'
+
+/* SQL text to delete entity field value ID 3B16443E-F36B-1410-8DBB-00021F8B792E */
+DELETE FROM [${flyway:defaultSchema}].EntityFieldValue WHERE ID='3B16443E-F36B-1410-8DBB-00021F8B792E'
+
+/* Index for Foreign Keys for AIAgent */
+-----------------------------------------------------------------
+-- SQL Code Generation
+-- Entity: AI Agents
+-- Item: Index for Foreign Keys
+--
+-- This was generated by the MemberJunction CodeGen tool.
+-- This file should NOT be edited by hand.
+-----------------------------------------------------------------
+-- Index for foreign key ParentID in table AIAgent
+IF NOT EXISTS (
+    SELECT 1
+    FROM sys.indexes
+    WHERE name = 'IDX_AUTO_MJ_FKEY_AIAgent_ParentID' 
+    AND object_id = OBJECT_ID('[${flyway:defaultSchema}].[AIAgent]')
+)
+CREATE INDEX IDX_AUTO_MJ_FKEY_AIAgent_ParentID ON [${flyway:defaultSchema}].[AIAgent] ([ParentID]);
+
+-- Index for foreign key ContextCompressionPromptID in table AIAgent
+IF NOT EXISTS (
+    SELECT 1
+    FROM sys.indexes
+    WHERE name = 'IDX_AUTO_MJ_FKEY_AIAgent_ContextCompressionPromptID' 
+    AND object_id = OBJECT_ID('[${flyway:defaultSchema}].[AIAgent]')
+)
+CREATE INDEX IDX_AUTO_MJ_FKEY_AIAgent_ContextCompressionPromptID ON [${flyway:defaultSchema}].[AIAgent] ([ContextCompressionPromptID]);
+
+-- Index for foreign key TypeID in table AIAgent
+IF NOT EXISTS (
+    SELECT 1
+    FROM sys.indexes
+    WHERE name = 'IDX_AUTO_MJ_FKEY_AIAgent_TypeID' 
+    AND object_id = OBJECT_ID('[${flyway:defaultSchema}].[AIAgent]')
+)
+CREATE INDEX IDX_AUTO_MJ_FKEY_AIAgent_TypeID ON [${flyway:defaultSchema}].[AIAgent] ([TypeID]);
+
+/* Base View SQL for AI Agents */
+-----------------------------------------------------------------
+-- SQL Code Generation
+-- Entity: AI Agents
+-- Item: vwAIAgents
+--
+-- This was generated by the MemberJunction CodeGen tool.
+-- This file should NOT be edited by hand.
+-----------------------------------------------------------------
+
+------------------------------------------------------------
+----- BASE VIEW FOR ENTITY:      AI Agents
+-----               SCHEMA:      ${flyway:defaultSchema}
+-----               BASE TABLE:  AIAgent
+-----               PRIMARY KEY: ID
+------------------------------------------------------------
+DROP VIEW IF EXISTS [${flyway:defaultSchema}].[vwAIAgents]
+GO
+
+CREATE VIEW [${flyway:defaultSchema}].[vwAIAgents]
+AS
+SELECT
+    a.*,
+    AIAgent_ParentID.[Name] AS [Parent],
+    AIPrompt_ContextCompressionPromptID.[Name] AS [ContextCompressionPrompt],
+    AIAgentType_TypeID.[Name] AS [Type]
+FROM
+    [${flyway:defaultSchema}].[AIAgent] AS a
+LEFT OUTER JOIN
+    [${flyway:defaultSchema}].[AIAgent] AS AIAgent_ParentID
+  ON
+    [a].[ParentID] = AIAgent_ParentID.[ID]
+LEFT OUTER JOIN
+    [${flyway:defaultSchema}].[AIPrompt] AS AIPrompt_ContextCompressionPromptID
+  ON
+    [a].[ContextCompressionPromptID] = AIPrompt_ContextCompressionPromptID.[ID]
+LEFT OUTER JOIN
+    [${flyway:defaultSchema}].[AIAgentType] AS AIAgentType_TypeID
+  ON
+    [a].[TypeID] = AIAgentType_TypeID.[ID]
+GO
+GRANT SELECT ON [${flyway:defaultSchema}].[vwAIAgents] TO [cdp_UI], [cdp_Developer], [cdp_Integration]
+    
+
+/* Base View Permissions SQL for AI Agents */
+-----------------------------------------------------------------
+-- SQL Code Generation
+-- Entity: AI Agents
+-- Item: Permissions for vwAIAgents
+--
+-- This was generated by the MemberJunction CodeGen tool.
+-- This file should NOT be edited by hand.
+-----------------------------------------------------------------
+
+GRANT SELECT ON [${flyway:defaultSchema}].[vwAIAgents] TO [cdp_UI], [cdp_Developer], [cdp_Integration]
+
+/* spCreate SQL for AI Agents */
+-----------------------------------------------------------------
+-- SQL Code Generation
+-- Entity: AI Agents
+-- Item: spCreateAIAgent
+--
+-- This was generated by the MemberJunction CodeGen tool.
+-- This file should NOT be edited by hand.
+-----------------------------------------------------------------
+
+------------------------------------------------------------
+----- CREATE PROCEDURE FOR AIAgent
+------------------------------------------------------------
+DROP PROCEDURE IF EXISTS [${flyway:defaultSchema}].[spCreateAIAgent]
+GO
+
+CREATE PROCEDURE [${flyway:defaultSchema}].[spCreateAIAgent]
+    @ID uniqueidentifier = NULL,
+    @Name nvarchar(255),
+    @Description nvarchar(MAX),
+    @LogoURL nvarchar(255),
+    @ParentID uniqueidentifier,
+    @ExposeAsAction bit,
+    @ExecutionOrder int,
+    @ExecutionMode nvarchar(20),
+    @EnableContextCompression bit,
+    @ContextCompressionMessageThreshold int,
+    @ContextCompressionPromptID uniqueidentifier,
+    @ContextCompressionMessageRetentionCount int,
+    @TypeID uniqueidentifier,
+    @Status nvarchar(20),
+    @DriverClass nvarchar(255),
+    @IconClass nvarchar(100),
+    @ModelSelectionMode nvarchar(50),
+    @PayloadDownstreamPaths nvarchar(MAX),
+    @PayloadUpstreamPaths nvarchar(MAX),
+    @PayloadSelfReadPaths nvarchar(MAX),
+    @PayloadSelfWritePaths nvarchar(MAX),
+    @PayloadScope nvarchar(MAX),
+    @FinalPayloadValidation nvarchar(MAX),
+    @FinalPayloadValidationMode nvarchar(25),
+    @FinalPayloadValidationMaxRetries int,
+    @MaxCostPerRun decimal(10, 4),
+    @MaxTokensPerRun int,
+    @MaxIterationsPerRun int,
+    @MaxTimePerRun int,
+    @MinExecutionsPerRun int,
+    @MaxExecutionsPerRun int,
+    @StartingPayloadValidation nvarchar(MAX),
+    @StartingPayloadValidationMode nvarchar(25),
+    @DefaultPromptEffortLevel int
+AS
+BEGIN
+    SET NOCOUNT ON;
+    DECLARE @InsertedRow TABLE ([ID] UNIQUEIDENTIFIER)
+    
+    IF @ID IS NOT NULL
+    BEGIN
+        -- User provided a value, use it
+        INSERT INTO [${flyway:defaultSchema}].[AIAgent]
+            (
+                [ID],
+                [Name],
+                [Description],
+                [LogoURL],
+                [ParentID],
+                [ExposeAsAction],
+                [ExecutionOrder],
+                [ExecutionMode],
+                [EnableContextCompression],
+                [ContextCompressionMessageThreshold],
+                [ContextCompressionPromptID],
+                [ContextCompressionMessageRetentionCount],
+                [TypeID],
+                [Status],
+                [DriverClass],
+                [IconClass],
+                [ModelSelectionMode],
+                [PayloadDownstreamPaths],
+                [PayloadUpstreamPaths],
+                [PayloadSelfReadPaths],
+                [PayloadSelfWritePaths],
+                [PayloadScope],
+                [FinalPayloadValidation],
+                [FinalPayloadValidationMode],
+                [FinalPayloadValidationMaxRetries],
+                [MaxCostPerRun],
+                [MaxTokensPerRun],
+                [MaxIterationsPerRun],
+                [MaxTimePerRun],
+                [MinExecutionsPerRun],
+                [MaxExecutionsPerRun],
+                [StartingPayloadValidation],
+                [StartingPayloadValidationMode],
+                [DefaultPromptEffortLevel]
+            )
+        OUTPUT INSERTED.[ID] INTO @InsertedRow
+        VALUES
+            (
+                @ID,
+                @Name,
+                @Description,
+                @LogoURL,
+                @ParentID,
+                @ExposeAsAction,
+                @ExecutionOrder,
+                @ExecutionMode,
+                @EnableContextCompression,
+                @ContextCompressionMessageThreshold,
+                @ContextCompressionPromptID,
+                @ContextCompressionMessageRetentionCount,
+                @TypeID,
+                @Status,
+                @DriverClass,
+                @IconClass,
+                @ModelSelectionMode,
+                @PayloadDownstreamPaths,
+                @PayloadUpstreamPaths,
+                @PayloadSelfReadPaths,
+                @PayloadSelfWritePaths,
+                @PayloadScope,
+                @FinalPayloadValidation,
+                @FinalPayloadValidationMode,
+                @FinalPayloadValidationMaxRetries,
+                @MaxCostPerRun,
+                @MaxTokensPerRun,
+                @MaxIterationsPerRun,
+                @MaxTimePerRun,
+                @MinExecutionsPerRun,
+                @MaxExecutionsPerRun,
+                @StartingPayloadValidation,
+                @StartingPayloadValidationMode,
+                @DefaultPromptEffortLevel
+            )
+    END
+    ELSE
+    BEGIN
+        -- No value provided, let database use its default (e.g., NEWSEQUENTIALID())
+        INSERT INTO [${flyway:defaultSchema}].[AIAgent]
+            (
+                [Name],
+                [Description],
+                [LogoURL],
+                [ParentID],
+                [ExposeAsAction],
+                [ExecutionOrder],
+                [ExecutionMode],
+                [EnableContextCompression],
+                [ContextCompressionMessageThreshold],
+                [ContextCompressionPromptID],
+                [ContextCompressionMessageRetentionCount],
+                [TypeID],
+                [Status],
+                [DriverClass],
+                [IconClass],
+                [ModelSelectionMode],
+                [PayloadDownstreamPaths],
+                [PayloadUpstreamPaths],
+                [PayloadSelfReadPaths],
+                [PayloadSelfWritePaths],
+                [PayloadScope],
+                [FinalPayloadValidation],
+                [FinalPayloadValidationMode],
+                [FinalPayloadValidationMaxRetries],
+                [MaxCostPerRun],
+                [MaxTokensPerRun],
+                [MaxIterationsPerRun],
+                [MaxTimePerRun],
+                [MinExecutionsPerRun],
+                [MaxExecutionsPerRun],
+                [StartingPayloadValidation],
+                [StartingPayloadValidationMode],
+                [DefaultPromptEffortLevel]
+            )
+        OUTPUT INSERTED.[ID] INTO @InsertedRow
+        VALUES
+            (
+                @Name,
+                @Description,
+                @LogoURL,
+                @ParentID,
+                @ExposeAsAction,
+                @ExecutionOrder,
+                @ExecutionMode,
+                @EnableContextCompression,
+                @ContextCompressionMessageThreshold,
+                @ContextCompressionPromptID,
+                @ContextCompressionMessageRetentionCount,
+                @TypeID,
+                @Status,
+                @DriverClass,
+                @IconClass,
+                @ModelSelectionMode,
+                @PayloadDownstreamPaths,
+                @PayloadUpstreamPaths,
+                @PayloadSelfReadPaths,
+                @PayloadSelfWritePaths,
+                @PayloadScope,
+                @FinalPayloadValidation,
+                @FinalPayloadValidationMode,
+                @FinalPayloadValidationMaxRetries,
+                @MaxCostPerRun,
+                @MaxTokensPerRun,
+                @MaxIterationsPerRun,
+                @MaxTimePerRun,
+                @MinExecutionsPerRun,
+                @MaxExecutionsPerRun,
+                @StartingPayloadValidation,
+                @StartingPayloadValidationMode,
+                @DefaultPromptEffortLevel
+            )
+    END
+    -- return the new record from the base view, which might have some calculated fields
+    SELECT * FROM [${flyway:defaultSchema}].[vwAIAgents] WHERE [ID] = (SELECT [ID] FROM @InsertedRow)
+END
+GO
+GRANT EXECUTE ON [${flyway:defaultSchema}].[spCreateAIAgent] TO [cdp_Developer], [cdp_Integration]
+    
+
+/* spCreate Permissions for AI Agents */
+
+GRANT EXECUTE ON [${flyway:defaultSchema}].[spCreateAIAgent] TO [cdp_Developer], [cdp_Integration]
+
+
+
+/* spUpdate SQL for AI Agents */
+-----------------------------------------------------------------
+-- SQL Code Generation
+-- Entity: AI Agents
+-- Item: spUpdateAIAgent
+--
+-- This was generated by the MemberJunction CodeGen tool.
+-- This file should NOT be edited by hand.
+-----------------------------------------------------------------
+
+------------------------------------------------------------
+----- UPDATE PROCEDURE FOR AIAgent
+------------------------------------------------------------
+DROP PROCEDURE IF EXISTS [${flyway:defaultSchema}].[spUpdateAIAgent]
+GO
+
+CREATE PROCEDURE [${flyway:defaultSchema}].[spUpdateAIAgent]
+    @ID uniqueidentifier,
+    @Name nvarchar(255),
+    @Description nvarchar(MAX),
+    @LogoURL nvarchar(255),
+    @ParentID uniqueidentifier,
+    @ExposeAsAction bit,
+    @ExecutionOrder int,
+    @ExecutionMode nvarchar(20),
+    @EnableContextCompression bit,
+    @ContextCompressionMessageThreshold int,
+    @ContextCompressionPromptID uniqueidentifier,
+    @ContextCompressionMessageRetentionCount int,
+    @TypeID uniqueidentifier,
+    @Status nvarchar(20),
+    @DriverClass nvarchar(255),
+    @IconClass nvarchar(100),
+    @ModelSelectionMode nvarchar(50),
+    @PayloadDownstreamPaths nvarchar(MAX),
+    @PayloadUpstreamPaths nvarchar(MAX),
+    @PayloadSelfReadPaths nvarchar(MAX),
+    @PayloadSelfWritePaths nvarchar(MAX),
+    @PayloadScope nvarchar(MAX),
+    @FinalPayloadValidation nvarchar(MAX),
+    @FinalPayloadValidationMode nvarchar(25),
+    @FinalPayloadValidationMaxRetries int,
+    @MaxCostPerRun decimal(10, 4),
+    @MaxTokensPerRun int,
+    @MaxIterationsPerRun int,
+    @MaxTimePerRun int,
+    @MinExecutionsPerRun int,
+    @MaxExecutionsPerRun int,
+    @StartingPayloadValidation nvarchar(MAX),
+    @StartingPayloadValidationMode nvarchar(25),
+    @DefaultPromptEffortLevel int
+AS
+BEGIN
+    SET NOCOUNT ON;
+    UPDATE
+        [${flyway:defaultSchema}].[AIAgent]
+    SET
+        [Name] = @Name,
+        [Description] = @Description,
+        [LogoURL] = @LogoURL,
+        [ParentID] = @ParentID,
+        [ExposeAsAction] = @ExposeAsAction,
+        [ExecutionOrder] = @ExecutionOrder,
+        [ExecutionMode] = @ExecutionMode,
+        [EnableContextCompression] = @EnableContextCompression,
+        [ContextCompressionMessageThreshold] = @ContextCompressionMessageThreshold,
+        [ContextCompressionPromptID] = @ContextCompressionPromptID,
+        [ContextCompressionMessageRetentionCount] = @ContextCompressionMessageRetentionCount,
+        [TypeID] = @TypeID,
+        [Status] = @Status,
+        [DriverClass] = @DriverClass,
+        [IconClass] = @IconClass,
+        [ModelSelectionMode] = @ModelSelectionMode,
+        [PayloadDownstreamPaths] = @PayloadDownstreamPaths,
+        [PayloadUpstreamPaths] = @PayloadUpstreamPaths,
+        [PayloadSelfReadPaths] = @PayloadSelfReadPaths,
+        [PayloadSelfWritePaths] = @PayloadSelfWritePaths,
+        [PayloadScope] = @PayloadScope,
+        [FinalPayloadValidation] = @FinalPayloadValidation,
+        [FinalPayloadValidationMode] = @FinalPayloadValidationMode,
+        [FinalPayloadValidationMaxRetries] = @FinalPayloadValidationMaxRetries,
+        [MaxCostPerRun] = @MaxCostPerRun,
+        [MaxTokensPerRun] = @MaxTokensPerRun,
+        [MaxIterationsPerRun] = @MaxIterationsPerRun,
+        [MaxTimePerRun] = @MaxTimePerRun,
+        [MinExecutionsPerRun] = @MinExecutionsPerRun,
+        [MaxExecutionsPerRun] = @MaxExecutionsPerRun,
+        [StartingPayloadValidation] = @StartingPayloadValidation,
+        [StartingPayloadValidationMode] = @StartingPayloadValidationMode,
+        [DefaultPromptEffortLevel] = @DefaultPromptEffortLevel
+    WHERE
+        [ID] = @ID
+
+    -- Check if the update was successful
+    IF @@ROWCOUNT = 0
+        -- Nothing was updated, return no rows, but column structure from base view intact, semantically correct this way.
+        SELECT TOP 0 * FROM [${flyway:defaultSchema}].[vwAIAgents] WHERE 1=0
+    ELSE
+        -- Return the updated record so the caller can see the updated values and any calculated fields
+        SELECT
+                                        *
+                                    FROM
+                                        [${flyway:defaultSchema}].[vwAIAgents]
+                                    WHERE
+                                        [ID] = @ID
+                                    
+END
+GO
+
+GRANT EXECUTE ON [${flyway:defaultSchema}].[spUpdateAIAgent] TO [cdp_Developer], [cdp_Integration]
+GO
+
+------------------------------------------------------------
+----- TRIGGER FOR __mj_UpdatedAt field for the AIAgent table
+------------------------------------------------------------
+DROP TRIGGER IF EXISTS [${flyway:defaultSchema}].trgUpdateAIAgent
+GO
+CREATE TRIGGER [${flyway:defaultSchema}].trgUpdateAIAgent
+ON [${flyway:defaultSchema}].[AIAgent]
+AFTER UPDATE
+AS
+BEGIN
+    SET NOCOUNT ON;
+    UPDATE
+        [${flyway:defaultSchema}].[AIAgent]
+    SET
+        __mj_UpdatedAt = GETUTCDATE()
+    FROM
+        [${flyway:defaultSchema}].[AIAgent] AS _organicTable
+    INNER JOIN
+        INSERTED AS I ON
+        _organicTable.[ID] = I.[ID];
+END;
+GO
+        
+
+/* spUpdate Permissions for AI Agents */
+
+GRANT EXECUTE ON [${flyway:defaultSchema}].[spUpdateAIAgent] TO [cdp_Developer], [cdp_Integration]
+
+
+
+/* spDelete Permissions for AI Agents */
+
+GRANT EXECUTE ON [${flyway:defaultSchema}].[spDeleteAIAgent] TO [cdp_Integration]
+
+
+
+/* Index for Foreign Keys for AIPrompt */
+-----------------------------------------------------------------
+-- SQL Code Generation
+-- Entity: AI Prompts
+-- Item: Index for Foreign Keys
+--
+-- This was generated by the MemberJunction CodeGen tool.
+-- This file should NOT be edited by hand.
+-----------------------------------------------------------------
+-- Index for foreign key TemplateID in table AIPrompt
+IF NOT EXISTS (
+    SELECT 1
+    FROM sys.indexes
+    WHERE name = 'IDX_AUTO_MJ_FKEY_AIPrompt_TemplateID' 
+    AND object_id = OBJECT_ID('[${flyway:defaultSchema}].[AIPrompt]')
+)
+CREATE INDEX IDX_AUTO_MJ_FKEY_AIPrompt_TemplateID ON [${flyway:defaultSchema}].[AIPrompt] ([TemplateID]);
+
+-- Index for foreign key CategoryID in table AIPrompt
+IF NOT EXISTS (
+    SELECT 1
+    FROM sys.indexes
+    WHERE name = 'IDX_AUTO_MJ_FKEY_AIPrompt_CategoryID' 
+    AND object_id = OBJECT_ID('[${flyway:defaultSchema}].[AIPrompt]')
+)
+CREATE INDEX IDX_AUTO_MJ_FKEY_AIPrompt_CategoryID ON [${flyway:defaultSchema}].[AIPrompt] ([CategoryID]);
+
+-- Index for foreign key TypeID in table AIPrompt
+IF NOT EXISTS (
+    SELECT 1
+    FROM sys.indexes
+    WHERE name = 'IDX_AUTO_MJ_FKEY_AIPrompt_TypeID' 
+    AND object_id = OBJECT_ID('[${flyway:defaultSchema}].[AIPrompt]')
+)
+CREATE INDEX IDX_AUTO_MJ_FKEY_AIPrompt_TypeID ON [${flyway:defaultSchema}].[AIPrompt] ([TypeID]);
+
+-- Index for foreign key AIModelTypeID in table AIPrompt
+IF NOT EXISTS (
+    SELECT 1
+    FROM sys.indexes
+    WHERE name = 'IDX_AUTO_MJ_FKEY_AIPrompt_AIModelTypeID' 
+    AND object_id = OBJECT_ID('[${flyway:defaultSchema}].[AIPrompt]')
+)
+CREATE INDEX IDX_AUTO_MJ_FKEY_AIPrompt_AIModelTypeID ON [${flyway:defaultSchema}].[AIPrompt] ([AIModelTypeID]);
+
+-- Index for foreign key ResultSelectorPromptID in table AIPrompt
+IF NOT EXISTS (
+    SELECT 1
+    FROM sys.indexes
+    WHERE name = 'IDX_AUTO_MJ_FKEY_AIPrompt_ResultSelectorPromptID' 
+    AND object_id = OBJECT_ID('[${flyway:defaultSchema}].[AIPrompt]')
+)
+CREATE INDEX IDX_AUTO_MJ_FKEY_AIPrompt_ResultSelectorPromptID ON [${flyway:defaultSchema}].[AIPrompt] ([ResultSelectorPromptID]);
+
+/* Base View SQL for AI Prompts */
+-----------------------------------------------------------------
+-- SQL Code Generation
+-- Entity: AI Prompts
+-- Item: vwAIPrompts
+--
+-- This was generated by the MemberJunction CodeGen tool.
+-- This file should NOT be edited by hand.
+-----------------------------------------------------------------
+
+------------------------------------------------------------
+----- BASE VIEW FOR ENTITY:      AI Prompts
+-----               SCHEMA:      ${flyway:defaultSchema}
+-----               BASE TABLE:  AIPrompt
+-----               PRIMARY KEY: ID
+------------------------------------------------------------
+DROP VIEW IF EXISTS [${flyway:defaultSchema}].[vwAIPrompts]
+GO
+
+CREATE VIEW [${flyway:defaultSchema}].[vwAIPrompts]
+AS
+SELECT
+    a.*,
+    Template_TemplateID.[Name] AS [Template],
+    AIPromptCategory_CategoryID.[Name] AS [Category],
+    AIPromptType_TypeID.[Name] AS [Type],
+    AIModelType_AIModelTypeID.[Name] AS [AIModelType],
+    AIPrompt_ResultSelectorPromptID.[Name] AS [ResultSelectorPrompt]
+FROM
+    [${flyway:defaultSchema}].[AIPrompt] AS a
+INNER JOIN
+    [${flyway:defaultSchema}].[Template] AS Template_TemplateID
+  ON
+    [a].[TemplateID] = Template_TemplateID.[ID]
+LEFT OUTER JOIN
+    [${flyway:defaultSchema}].[AIPromptCategory] AS AIPromptCategory_CategoryID
+  ON
+    [a].[CategoryID] = AIPromptCategory_CategoryID.[ID]
+INNER JOIN
+    [${flyway:defaultSchema}].[AIPromptType] AS AIPromptType_TypeID
+  ON
+    [a].[TypeID] = AIPromptType_TypeID.[ID]
+LEFT OUTER JOIN
+    [${flyway:defaultSchema}].[AIModelType] AS AIModelType_AIModelTypeID
+  ON
+    [a].[AIModelTypeID] = AIModelType_AIModelTypeID.[ID]
+LEFT OUTER JOIN
+    [${flyway:defaultSchema}].[AIPrompt] AS AIPrompt_ResultSelectorPromptID
+  ON
+    [a].[ResultSelectorPromptID] = AIPrompt_ResultSelectorPromptID.[ID]
+GO
+GRANT SELECT ON [${flyway:defaultSchema}].[vwAIPrompts] TO [cdp_UI], [cdp_Integration], [cdp_UI], [cdp_Developer]
+    
+
+/* Base View Permissions SQL for AI Prompts */
+-----------------------------------------------------------------
+-- SQL Code Generation
+-- Entity: AI Prompts
+-- Item: Permissions for vwAIPrompts
+--
+-- This was generated by the MemberJunction CodeGen tool.
+-- This file should NOT be edited by hand.
+-----------------------------------------------------------------
+
+GRANT SELECT ON [${flyway:defaultSchema}].[vwAIPrompts] TO [cdp_UI], [cdp_Integration], [cdp_UI], [cdp_Developer]
+
+/* spCreate SQL for AI Prompts */
+-----------------------------------------------------------------
+-- SQL Code Generation
+-- Entity: AI Prompts
+-- Item: spCreateAIPrompt
+--
+-- This was generated by the MemberJunction CodeGen tool.
+-- This file should NOT be edited by hand.
+-----------------------------------------------------------------
+
+------------------------------------------------------------
+----- CREATE PROCEDURE FOR AIPrompt
+------------------------------------------------------------
+DROP PROCEDURE IF EXISTS [${flyway:defaultSchema}].[spCreateAIPrompt]
+GO
+
+CREATE PROCEDURE [${flyway:defaultSchema}].[spCreateAIPrompt]
+    @ID uniqueidentifier = NULL,
+    @Name nvarchar(255),
+    @Description nvarchar(MAX),
+    @TemplateID uniqueidentifier,
+    @CategoryID uniqueidentifier,
+    @TypeID uniqueidentifier,
+    @Status nvarchar(50),
+    @ResponseFormat nvarchar(20),
+    @ModelSpecificResponseFormat nvarchar(MAX),
+    @AIModelTypeID uniqueidentifier,
+    @MinPowerRank int,
+    @SelectionStrategy nvarchar(20),
+    @PowerPreference nvarchar(20),
+    @ParallelizationMode nvarchar(20),
+    @ParallelCount int,
+    @ParallelConfigParam nvarchar(100),
+    @OutputType nvarchar(50),
+    @OutputExample nvarchar(MAX),
+    @ValidationBehavior nvarchar(50),
+    @MaxRetries int,
+    @RetryDelayMS int,
+    @RetryStrategy nvarchar(20),
+    @ResultSelectorPromptID uniqueidentifier,
+    @EnableCaching bit,
+    @CacheTTLSeconds int,
+    @CacheMatchType nvarchar(20),
+    @CacheSimilarityThreshold float(53),
+    @CacheMustMatchModel bit,
+    @CacheMustMatchVendor bit,
+    @CacheMustMatchAgent bit,
+    @CacheMustMatchConfig bit,
+    @PromptRole nvarchar(20),
+    @PromptPosition nvarchar(20),
+    @Temperature decimal(3, 2),
+    @TopP decimal(3, 2),
+    @TopK int,
+    @MinP decimal(3, 2),
+    @FrequencyPenalty decimal(3, 2),
+    @PresencePenalty decimal(3, 2),
+    @Seed int,
+    @StopSequences nvarchar(1000),
+    @IncludeLogProbs bit,
+    @TopLogProbs int,
+    @FailoverStrategy nvarchar(50),
+    @FailoverMaxAttempts int,
+    @FailoverDelaySeconds int,
+    @FailoverModelStrategy nvarchar(50),
+    @FailoverErrorScope nvarchar(50),
+    @EffortLevel int
+AS
+BEGIN
+    SET NOCOUNT ON;
+    DECLARE @InsertedRow TABLE ([ID] UNIQUEIDENTIFIER)
+    
+    IF @ID IS NOT NULL
+    BEGIN
+        -- User provided a value, use it
+        INSERT INTO [${flyway:defaultSchema}].[AIPrompt]
+            (
+                [ID],
+                [Name],
+                [Description],
+                [TemplateID],
+                [CategoryID],
+                [TypeID],
+                [Status],
+                [ResponseFormat],
+                [ModelSpecificResponseFormat],
+                [AIModelTypeID],
+                [MinPowerRank],
+                [SelectionStrategy],
+                [PowerPreference],
+                [ParallelizationMode],
+                [ParallelCount],
+                [ParallelConfigParam],
+                [OutputType],
+                [OutputExample],
+                [ValidationBehavior],
+                [MaxRetries],
+                [RetryDelayMS],
+                [RetryStrategy],
+                [ResultSelectorPromptID],
+                [EnableCaching],
+                [CacheTTLSeconds],
+                [CacheMatchType],
+                [CacheSimilarityThreshold],
+                [CacheMustMatchModel],
+                [CacheMustMatchVendor],
+                [CacheMustMatchAgent],
+                [CacheMustMatchConfig],
+                [PromptRole],
+                [PromptPosition],
+                [Temperature],
+                [TopP],
+                [TopK],
+                [MinP],
+                [FrequencyPenalty],
+                [PresencePenalty],
+                [Seed],
+                [StopSequences],
+                [IncludeLogProbs],
+                [TopLogProbs],
+                [FailoverStrategy],
+                [FailoverMaxAttempts],
+                [FailoverDelaySeconds],
+                [FailoverModelStrategy],
+                [FailoverErrorScope],
+                [EffortLevel]
+            )
+        OUTPUT INSERTED.[ID] INTO @InsertedRow
+        VALUES
+            (
+                @ID,
+                @Name,
+                @Description,
+                @TemplateID,
+                @CategoryID,
+                @TypeID,
+                @Status,
+                @ResponseFormat,
+                @ModelSpecificResponseFormat,
+                @AIModelTypeID,
+                @MinPowerRank,
+                @SelectionStrategy,
+                @PowerPreference,
+                @ParallelizationMode,
+                @ParallelCount,
+                @ParallelConfigParam,
+                @OutputType,
+                @OutputExample,
+                @ValidationBehavior,
+                @MaxRetries,
+                @RetryDelayMS,
+                @RetryStrategy,
+                @ResultSelectorPromptID,
+                @EnableCaching,
+                @CacheTTLSeconds,
+                @CacheMatchType,
+                @CacheSimilarityThreshold,
+                @CacheMustMatchModel,
+                @CacheMustMatchVendor,
+                @CacheMustMatchAgent,
+                @CacheMustMatchConfig,
+                @PromptRole,
+                @PromptPosition,
+                @Temperature,
+                @TopP,
+                @TopK,
+                @MinP,
+                @FrequencyPenalty,
+                @PresencePenalty,
+                @Seed,
+                @StopSequences,
+                @IncludeLogProbs,
+                @TopLogProbs,
+                @FailoverStrategy,
+                @FailoverMaxAttempts,
+                @FailoverDelaySeconds,
+                @FailoverModelStrategy,
+                @FailoverErrorScope,
+                @EffortLevel
+            )
+    END
+    ELSE
+    BEGIN
+        -- No value provided, let database use its default (e.g., NEWSEQUENTIALID())
+        INSERT INTO [${flyway:defaultSchema}].[AIPrompt]
+            (
+                [Name],
+                [Description],
+                [TemplateID],
+                [CategoryID],
+                [TypeID],
+                [Status],
+                [ResponseFormat],
+                [ModelSpecificResponseFormat],
+                [AIModelTypeID],
+                [MinPowerRank],
+                [SelectionStrategy],
+                [PowerPreference],
+                [ParallelizationMode],
+                [ParallelCount],
+                [ParallelConfigParam],
+                [OutputType],
+                [OutputExample],
+                [ValidationBehavior],
+                [MaxRetries],
+                [RetryDelayMS],
+                [RetryStrategy],
+                [ResultSelectorPromptID],
+                [EnableCaching],
+                [CacheTTLSeconds],
+                [CacheMatchType],
+                [CacheSimilarityThreshold],
+                [CacheMustMatchModel],
+                [CacheMustMatchVendor],
+                [CacheMustMatchAgent],
+                [CacheMustMatchConfig],
+                [PromptRole],
+                [PromptPosition],
+                [Temperature],
+                [TopP],
+                [TopK],
+                [MinP],
+                [FrequencyPenalty],
+                [PresencePenalty],
+                [Seed],
+                [StopSequences],
+                [IncludeLogProbs],
+                [TopLogProbs],
+                [FailoverStrategy],
+                [FailoverMaxAttempts],
+                [FailoverDelaySeconds],
+                [FailoverModelStrategy],
+                [FailoverErrorScope],
+                [EffortLevel]
+            )
+        OUTPUT INSERTED.[ID] INTO @InsertedRow
+        VALUES
+            (
+                @Name,
+                @Description,
+                @TemplateID,
+                @CategoryID,
+                @TypeID,
+                @Status,
+                @ResponseFormat,
+                @ModelSpecificResponseFormat,
+                @AIModelTypeID,
+                @MinPowerRank,
+                @SelectionStrategy,
+                @PowerPreference,
+                @ParallelizationMode,
+                @ParallelCount,
+                @ParallelConfigParam,
+                @OutputType,
+                @OutputExample,
+                @ValidationBehavior,
+                @MaxRetries,
+                @RetryDelayMS,
+                @RetryStrategy,
+                @ResultSelectorPromptID,
+                @EnableCaching,
+                @CacheTTLSeconds,
+                @CacheMatchType,
+                @CacheSimilarityThreshold,
+                @CacheMustMatchModel,
+                @CacheMustMatchVendor,
+                @CacheMustMatchAgent,
+                @CacheMustMatchConfig,
+                @PromptRole,
+                @PromptPosition,
+                @Temperature,
+                @TopP,
+                @TopK,
+                @MinP,
+                @FrequencyPenalty,
+                @PresencePenalty,
+                @Seed,
+                @StopSequences,
+                @IncludeLogProbs,
+                @TopLogProbs,
+                @FailoverStrategy,
+                @FailoverMaxAttempts,
+                @FailoverDelaySeconds,
+                @FailoverModelStrategy,
+                @FailoverErrorScope,
+                @EffortLevel
+            )
+    END
+    -- return the new record from the base view, which might have some calculated fields
+    SELECT * FROM [${flyway:defaultSchema}].[vwAIPrompts] WHERE [ID] = (SELECT [ID] FROM @InsertedRow)
+END
+GO
+GRANT EXECUTE ON [${flyway:defaultSchema}].[spCreateAIPrompt] TO [cdp_Developer]
+    
+
+/* spCreate Permissions for AI Prompts */
+
+GRANT EXECUTE ON [${flyway:defaultSchema}].[spCreateAIPrompt] TO [cdp_Developer]
+
+
+
+/* spUpdate SQL for AI Prompts */
+-----------------------------------------------------------------
+-- SQL Code Generation
+-- Entity: AI Prompts
+-- Item: spUpdateAIPrompt
+--
+-- This was generated by the MemberJunction CodeGen tool.
+-- This file should NOT be edited by hand.
+-----------------------------------------------------------------
+
+------------------------------------------------------------
+----- UPDATE PROCEDURE FOR AIPrompt
+------------------------------------------------------------
+DROP PROCEDURE IF EXISTS [${flyway:defaultSchema}].[spUpdateAIPrompt]
+GO
+
+CREATE PROCEDURE [${flyway:defaultSchema}].[spUpdateAIPrompt]
+    @ID uniqueidentifier,
+    @Name nvarchar(255),
+    @Description nvarchar(MAX),
+    @TemplateID uniqueidentifier,
+    @CategoryID uniqueidentifier,
+    @TypeID uniqueidentifier,
+    @Status nvarchar(50),
+    @ResponseFormat nvarchar(20),
+    @ModelSpecificResponseFormat nvarchar(MAX),
+    @AIModelTypeID uniqueidentifier,
+    @MinPowerRank int,
+    @SelectionStrategy nvarchar(20),
+    @PowerPreference nvarchar(20),
+    @ParallelizationMode nvarchar(20),
+    @ParallelCount int,
+    @ParallelConfigParam nvarchar(100),
+    @OutputType nvarchar(50),
+    @OutputExample nvarchar(MAX),
+    @ValidationBehavior nvarchar(50),
+    @MaxRetries int,
+    @RetryDelayMS int,
+    @RetryStrategy nvarchar(20),
+    @ResultSelectorPromptID uniqueidentifier,
+    @EnableCaching bit,
+    @CacheTTLSeconds int,
+    @CacheMatchType nvarchar(20),
+    @CacheSimilarityThreshold float(53),
+    @CacheMustMatchModel bit,
+    @CacheMustMatchVendor bit,
+    @CacheMustMatchAgent bit,
+    @CacheMustMatchConfig bit,
+    @PromptRole nvarchar(20),
+    @PromptPosition nvarchar(20),
+    @Temperature decimal(3, 2),
+    @TopP decimal(3, 2),
+    @TopK int,
+    @MinP decimal(3, 2),
+    @FrequencyPenalty decimal(3, 2),
+    @PresencePenalty decimal(3, 2),
+    @Seed int,
+    @StopSequences nvarchar(1000),
+    @IncludeLogProbs bit,
+    @TopLogProbs int,
+    @FailoverStrategy nvarchar(50),
+    @FailoverMaxAttempts int,
+    @FailoverDelaySeconds int,
+    @FailoverModelStrategy nvarchar(50),
+    @FailoverErrorScope nvarchar(50),
+    @EffortLevel int
+AS
+BEGIN
+    SET NOCOUNT ON;
+    UPDATE
+        [${flyway:defaultSchema}].[AIPrompt]
+    SET
+        [Name] = @Name,
+        [Description] = @Description,
+        [TemplateID] = @TemplateID,
+        [CategoryID] = @CategoryID,
+        [TypeID] = @TypeID,
+        [Status] = @Status,
+        [ResponseFormat] = @ResponseFormat,
+        [ModelSpecificResponseFormat] = @ModelSpecificResponseFormat,
+        [AIModelTypeID] = @AIModelTypeID,
+        [MinPowerRank] = @MinPowerRank,
+        [SelectionStrategy] = @SelectionStrategy,
+        [PowerPreference] = @PowerPreference,
+        [ParallelizationMode] = @ParallelizationMode,
+        [ParallelCount] = @ParallelCount,
+        [ParallelConfigParam] = @ParallelConfigParam,
+        [OutputType] = @OutputType,
+        [OutputExample] = @OutputExample,
+        [ValidationBehavior] = @ValidationBehavior,
+        [MaxRetries] = @MaxRetries,
+        [RetryDelayMS] = @RetryDelayMS,
+        [RetryStrategy] = @RetryStrategy,
+        [ResultSelectorPromptID] = @ResultSelectorPromptID,
+        [EnableCaching] = @EnableCaching,
+        [CacheTTLSeconds] = @CacheTTLSeconds,
+        [CacheMatchType] = @CacheMatchType,
+        [CacheSimilarityThreshold] = @CacheSimilarityThreshold,
+        [CacheMustMatchModel] = @CacheMustMatchModel,
+        [CacheMustMatchVendor] = @CacheMustMatchVendor,
+        [CacheMustMatchAgent] = @CacheMustMatchAgent,
+        [CacheMustMatchConfig] = @CacheMustMatchConfig,
+        [PromptRole] = @PromptRole,
+        [PromptPosition] = @PromptPosition,
+        [Temperature] = @Temperature,
+        [TopP] = @TopP,
+        [TopK] = @TopK,
+        [MinP] = @MinP,
+        [FrequencyPenalty] = @FrequencyPenalty,
+        [PresencePenalty] = @PresencePenalty,
+        [Seed] = @Seed,
+        [StopSequences] = @StopSequences,
+        [IncludeLogProbs] = @IncludeLogProbs,
+        [TopLogProbs] = @TopLogProbs,
+        [FailoverStrategy] = @FailoverStrategy,
+        [FailoverMaxAttempts] = @FailoverMaxAttempts,
+        [FailoverDelaySeconds] = @FailoverDelaySeconds,
+        [FailoverModelStrategy] = @FailoverModelStrategy,
+        [FailoverErrorScope] = @FailoverErrorScope,
+        [EffortLevel] = @EffortLevel
+    WHERE
+        [ID] = @ID
+
+    -- Check if the update was successful
+    IF @@ROWCOUNT = 0
+        -- Nothing was updated, return no rows, but column structure from base view intact, semantically correct this way.
+        SELECT TOP 0 * FROM [${flyway:defaultSchema}].[vwAIPrompts] WHERE 1=0
+    ELSE
+        -- Return the updated record so the caller can see the updated values and any calculated fields
+        SELECT
+                                        *
+                                    FROM
+                                        [${flyway:defaultSchema}].[vwAIPrompts]
+                                    WHERE
+                                        [ID] = @ID
+                                    
+END
+GO
+
+GRANT EXECUTE ON [${flyway:defaultSchema}].[spUpdateAIPrompt] TO [cdp_Developer]
+GO
+
+------------------------------------------------------------
+----- TRIGGER FOR __mj_UpdatedAt field for the AIPrompt table
+------------------------------------------------------------
+DROP TRIGGER IF EXISTS [${flyway:defaultSchema}].trgUpdateAIPrompt
+GO
+CREATE TRIGGER [${flyway:defaultSchema}].trgUpdateAIPrompt
+ON [${flyway:defaultSchema}].[AIPrompt]
+AFTER UPDATE
+AS
+BEGIN
+    SET NOCOUNT ON;
+    UPDATE
+        [${flyway:defaultSchema}].[AIPrompt]
+    SET
+        __mj_UpdatedAt = GETUTCDATE()
+    FROM
+        [${flyway:defaultSchema}].[AIPrompt] AS _organicTable
+    INNER JOIN
+        INSERTED AS I ON
+        _organicTable.[ID] = I.[ID];
+END;
+GO
+        
+
+/* spUpdate Permissions for AI Prompts */
+
+GRANT EXECUTE ON [${flyway:defaultSchema}].[spUpdateAIPrompt] TO [cdp_Developer]
+
+
+
+/* spDelete Permissions for AI Prompts */
+
+GRANT EXECUTE ON [${flyway:defaultSchema}].[spDeleteAIPrompt] TO [cdp_Developer]
+
+
+
+/* Index for Foreign Keys for EntityRelationship */
+-----------------------------------------------------------------
+-- SQL Code Generation
+-- Entity: Entity Relationships
+-- Item: Index for Foreign Keys
+--
+-- This was generated by the MemberJunction CodeGen tool.
+-- This file should NOT be edited by hand.
+-----------------------------------------------------------------
+-- Index for foreign key EntityID in table EntityRelationship
+IF NOT EXISTS (
+    SELECT 1
+    FROM sys.indexes
+    WHERE name = 'IDX_AUTO_MJ_FKEY_EntityRelationship_EntityID' 
+    AND object_id = OBJECT_ID('[${flyway:defaultSchema}].[EntityRelationship]')
+)
+CREATE INDEX IDX_AUTO_MJ_FKEY_EntityRelationship_EntityID ON [${flyway:defaultSchema}].[EntityRelationship] ([EntityID]);
+
+-- Index for foreign key RelatedEntityID in table EntityRelationship
+IF NOT EXISTS (
+    SELECT 1
+    FROM sys.indexes
+    WHERE name = 'IDX_AUTO_MJ_FKEY_EntityRelationship_RelatedEntityID' 
+    AND object_id = OBJECT_ID('[${flyway:defaultSchema}].[EntityRelationship]')
+)
+CREATE INDEX IDX_AUTO_MJ_FKEY_EntityRelationship_RelatedEntityID ON [${flyway:defaultSchema}].[EntityRelationship] ([RelatedEntityID]);
+
+-- Index for foreign key DisplayUserViewID in table EntityRelationship
+IF NOT EXISTS (
+    SELECT 1
+    FROM sys.indexes
+    WHERE name = 'IDX_AUTO_MJ_FKEY_EntityRelationship_DisplayUserViewID' 
+    AND object_id = OBJECT_ID('[${flyway:defaultSchema}].[EntityRelationship]')
+)
+CREATE INDEX IDX_AUTO_MJ_FKEY_EntityRelationship_DisplayUserViewID ON [${flyway:defaultSchema}].[EntityRelationship] ([DisplayUserViewID]);
+
+-- Index for foreign key DisplayComponentID in table EntityRelationship
+IF NOT EXISTS (
+    SELECT 1
+    FROM sys.indexes
+    WHERE name = 'IDX_AUTO_MJ_FKEY_EntityRelationship_DisplayComponentID' 
+    AND object_id = OBJECT_ID('[${flyway:defaultSchema}].[EntityRelationship]')
+)
+CREATE INDEX IDX_AUTO_MJ_FKEY_EntityRelationship_DisplayComponentID ON [${flyway:defaultSchema}].[EntityRelationship] ([DisplayComponentID]);
+
+/* Base View Permissions SQL for Entity Relationships */
+-----------------------------------------------------------------
+-- SQL Code Generation
+-- Entity: Entity Relationships
+-- Item: Permissions for vwEntityRelationships
+--
+-- This was generated by the MemberJunction CodeGen tool.
+-- This file should NOT be edited by hand.
+-----------------------------------------------------------------
+
+GRANT SELECT ON [${flyway:defaultSchema}].[vwEntityRelationships] TO [cdp_Integration], [cdp_Developer], [cdp_UI]
+
+/* spCreate SQL for Entity Relationships */
+-----------------------------------------------------------------
+-- SQL Code Generation
+-- Entity: Entity Relationships
+-- Item: spCreateEntityRelationship
+--
+-- This was generated by the MemberJunction CodeGen tool.
+-- This file should NOT be edited by hand.
+-----------------------------------------------------------------
+
+------------------------------------------------------------
+----- CREATE PROCEDURE FOR EntityRelationship
+------------------------------------------------------------
+DROP PROCEDURE IF EXISTS [${flyway:defaultSchema}].[spCreateEntityRelationship]
+GO
+
+CREATE PROCEDURE [${flyway:defaultSchema}].[spCreateEntityRelationship]
+    @ID uniqueidentifier = NULL,
+    @EntityID uniqueidentifier,
+    @Sequence int,
+    @RelatedEntityID uniqueidentifier,
+    @BundleInAPI bit,
+    @IncludeInParentAllQuery bit,
+    @Type nchar(20),
+    @EntityKeyField nvarchar(255),
+    @RelatedEntityJoinField nvarchar(255),
+    @JoinView nvarchar(255),
+    @JoinEntityJoinField nvarchar(255),
+    @JoinEntityInverseJoinField nvarchar(255),
+    @DisplayInForm bit,
+    @DisplayLocation nvarchar(50),
+    @DisplayName nvarchar(255),
+    @DisplayIconType nvarchar(50),
+    @DisplayIcon nvarchar(255),
+    @DisplayComponentID uniqueidentifier,
+    @DisplayComponentConfiguration nvarchar(MAX),
+    @AutoUpdateFromSchema bit
+AS
+BEGIN
+    SET NOCOUNT ON;
+    DECLARE @InsertedRow TABLE ([ID] UNIQUEIDENTIFIER)
+    
+    IF @ID IS NOT NULL
+    BEGIN
+        -- User provided a value, use it
+        INSERT INTO [${flyway:defaultSchema}].[EntityRelationship]
+            (
+                [ID],
+                [EntityID],
+                [Sequence],
+                [RelatedEntityID],
+                [BundleInAPI],
+                [IncludeInParentAllQuery],
+                [Type],
+                [EntityKeyField],
+                [RelatedEntityJoinField],
+                [JoinView],
+                [JoinEntityJoinField],
+                [JoinEntityInverseJoinField],
+                [DisplayInForm],
+                [DisplayLocation],
+                [DisplayName],
+                [DisplayIconType],
+                [DisplayIcon],
+                [DisplayComponentID],
+                [DisplayComponentConfiguration],
+                [AutoUpdateFromSchema]
+            )
+        OUTPUT INSERTED.[ID] INTO @InsertedRow
+        VALUES
+            (
+                @ID,
+                @EntityID,
+                @Sequence,
+                @RelatedEntityID,
+                @BundleInAPI,
+                @IncludeInParentAllQuery,
+                @Type,
+                @EntityKeyField,
+                @RelatedEntityJoinField,
+                @JoinView,
+                @JoinEntityJoinField,
+                @JoinEntityInverseJoinField,
+                @DisplayInForm,
+                @DisplayLocation,
+                @DisplayName,
+                @DisplayIconType,
+                @DisplayIcon,
+                @DisplayComponentID,
+                @DisplayComponentConfiguration,
+                @AutoUpdateFromSchema
+            )
+    END
+    ELSE
+    BEGIN
+        -- No value provided, let database use its default (e.g., NEWSEQUENTIALID())
+        INSERT INTO [${flyway:defaultSchema}].[EntityRelationship]
+            (
+                [EntityID],
+                [Sequence],
+                [RelatedEntityID],
+                [BundleInAPI],
+                [IncludeInParentAllQuery],
+                [Type],
+                [EntityKeyField],
+                [RelatedEntityJoinField],
+                [JoinView],
+                [JoinEntityJoinField],
+                [JoinEntityInverseJoinField],
+                [DisplayInForm],
+                [DisplayLocation],
+                [DisplayName],
+                [DisplayIconType],
+                [DisplayIcon],
+                [DisplayComponentID],
+                [DisplayComponentConfiguration],
+                [AutoUpdateFromSchema]
+            )
+        OUTPUT INSERTED.[ID] INTO @InsertedRow
+        VALUES
+            (
+                @EntityID,
+                @Sequence,
+                @RelatedEntityID,
+                @BundleInAPI,
+                @IncludeInParentAllQuery,
+                @Type,
+                @EntityKeyField,
+                @RelatedEntityJoinField,
+                @JoinView,
+                @JoinEntityJoinField,
+                @JoinEntityInverseJoinField,
+                @DisplayInForm,
+                @DisplayLocation,
+                @DisplayName,
+                @DisplayIconType,
+                @DisplayIcon,
+                @DisplayComponentID,
+                @DisplayComponentConfiguration,
+                @AutoUpdateFromSchema
+            )
+    END
+    -- return the new record from the base view, which might have some calculated fields
+    SELECT * FROM [${flyway:defaultSchema}].[vwEntityRelationships] WHERE [ID] = (SELECT [ID] FROM @InsertedRow)
+END
+GO
+GRANT EXECUTE ON [${flyway:defaultSchema}].[spCreateEntityRelationship] TO [cdp_Integration], [cdp_Developer]
+    
+
+/* spCreate Permissions for Entity Relationships */
+
+GRANT EXECUTE ON [${flyway:defaultSchema}].[spCreateEntityRelationship] TO [cdp_Integration], [cdp_Developer]
+
+
+
+/* spUpdate SQL for Entity Relationships */
+-----------------------------------------------------------------
+-- SQL Code Generation
+-- Entity: Entity Relationships
+-- Item: spUpdateEntityRelationship
+--
+-- This was generated by the MemberJunction CodeGen tool.
+-- This file should NOT be edited by hand.
+-----------------------------------------------------------------
+
+------------------------------------------------------------
+----- UPDATE PROCEDURE FOR EntityRelationship
+------------------------------------------------------------
+DROP PROCEDURE IF EXISTS [${flyway:defaultSchema}].[spUpdateEntityRelationship]
+GO
+
+CREATE PROCEDURE [${flyway:defaultSchema}].[spUpdateEntityRelationship]
+    @ID uniqueidentifier,
+    @EntityID uniqueidentifier,
+    @Sequence int,
+    @RelatedEntityID uniqueidentifier,
+    @BundleInAPI bit,
+    @IncludeInParentAllQuery bit,
+    @Type nchar(20),
+    @EntityKeyField nvarchar(255),
+    @RelatedEntityJoinField nvarchar(255),
+    @JoinView nvarchar(255),
+    @JoinEntityJoinField nvarchar(255),
+    @JoinEntityInverseJoinField nvarchar(255),
+    @DisplayInForm bit,
+    @DisplayLocation nvarchar(50),
+    @DisplayName nvarchar(255),
+    @DisplayIconType nvarchar(50),
+    @DisplayIcon nvarchar(255),
+    @DisplayComponentID uniqueidentifier,
+    @DisplayComponentConfiguration nvarchar(MAX),
+    @AutoUpdateFromSchema bit
+AS
+BEGIN
+    SET NOCOUNT ON;
+    UPDATE
+        [${flyway:defaultSchema}].[EntityRelationship]
+    SET
+        [EntityID] = @EntityID,
+        [Sequence] = @Sequence,
+        [RelatedEntityID] = @RelatedEntityID,
+        [BundleInAPI] = @BundleInAPI,
+        [IncludeInParentAllQuery] = @IncludeInParentAllQuery,
+        [Type] = @Type,
+        [EntityKeyField] = @EntityKeyField,
+        [RelatedEntityJoinField] = @RelatedEntityJoinField,
+        [JoinView] = @JoinView,
+        [JoinEntityJoinField] = @JoinEntityJoinField,
+        [JoinEntityInverseJoinField] = @JoinEntityInverseJoinField,
+        [DisplayInForm] = @DisplayInForm,
+        [DisplayLocation] = @DisplayLocation,
+        [DisplayName] = @DisplayName,
+        [DisplayIconType] = @DisplayIconType,
+        [DisplayIcon] = @DisplayIcon,
+        [DisplayComponentID] = @DisplayComponentID,
+        [DisplayComponentConfiguration] = @DisplayComponentConfiguration,
+        [AutoUpdateFromSchema] = @AutoUpdateFromSchema
+    WHERE
+        [ID] = @ID
+
+    -- Check if the update was successful
+    IF @@ROWCOUNT = 0
+        -- Nothing was updated, return no rows, but column structure from base view intact, semantically correct this way.
+        SELECT TOP 0 * FROM [${flyway:defaultSchema}].[vwEntityRelationships] WHERE 1=0
+    ELSE
+        -- Return the updated record so the caller can see the updated values and any calculated fields
+        SELECT
+                                        *
+                                    FROM
+                                        [${flyway:defaultSchema}].[vwEntityRelationships]
+                                    WHERE
+                                        [ID] = @ID
+                                    
+END
+GO
+
+GRANT EXECUTE ON [${flyway:defaultSchema}].[spUpdateEntityRelationship] TO [cdp_Integration], [cdp_Developer]
+GO
+
+------------------------------------------------------------
+----- TRIGGER FOR __mj_UpdatedAt field for the EntityRelationship table
+------------------------------------------------------------
+DROP TRIGGER IF EXISTS [${flyway:defaultSchema}].trgUpdateEntityRelationship
+GO
+CREATE TRIGGER [${flyway:defaultSchema}].trgUpdateEntityRelationship
+ON [${flyway:defaultSchema}].[EntityRelationship]
+AFTER UPDATE
+AS
+BEGIN
+    SET NOCOUNT ON;
+    UPDATE
+        [${flyway:defaultSchema}].[EntityRelationship]
+    SET
+        __mj_UpdatedAt = GETUTCDATE()
+    FROM
+        [${flyway:defaultSchema}].[EntityRelationship] AS _organicTable
+    INNER JOIN
+        INSERTED AS I ON
+        _organicTable.[ID] = I.[ID];
+END;
+GO
+        
+
+/* spUpdate Permissions for Entity Relationships */
+
+GRANT EXECUTE ON [${flyway:defaultSchema}].[spUpdateEntityRelationship] TO [cdp_Integration], [cdp_Developer]
+
+
+
+/* spDelete Permissions for Entity Relationships */
+
+GRANT EXECUTE ON [${flyway:defaultSchema}].[spDeleteEntityRelationship] TO [cdp_Integration], [cdp_Developer]
+
+
+
+/* SQL text to update entity field related entity name field map for entity field ID AC10443E-F36B-1410-8DBB-00021F8B792E */
+EXEC [${flyway:defaultSchema}].spUpdateEntityFieldRelatedEntityNameFieldMap
+         @EntityFieldID='AC10443E-F36B-1410-8DBB-00021F8B792E',
+         @RelatedEntityNameFieldMap='ResourceType'
+
+/* SQL text to update entity field related entity name field map for entity field ID 2A11443E-F36B-1410-8DBB-00021F8B792E */
+EXEC [${flyway:defaultSchema}].spUpdateEntityFieldRelatedEntityNameFieldMap
+         @EntityFieldID='2A11443E-F36B-1410-8DBB-00021F8B792E',
+         @RelatedEntityNameFieldMap='User'
+
+/* SQL text to update entity field related entity name field map for entity field ID 2E11443E-F36B-1410-8DBB-00021F8B792E */
+EXEC [${flyway:defaultSchema}].spUpdateEntityFieldRelatedEntityNameFieldMap
+         @EntityFieldID='2E11443E-F36B-1410-8DBB-00021F8B792E',
+         @RelatedEntityNameFieldMap='ResourceType'
+
+/* SQL text to update entity field related entity name field map for entity field ID C410443E-F36B-1410-8DBB-00021F8B792E */
+EXEC [${flyway:defaultSchema}].spUpdateEntityFieldRelatedEntityNameFieldMap
+         @EntityFieldID='C410443E-F36B-1410-8DBB-00021F8B792E',
+         @RelatedEntityNameFieldMap='Role'
+
+/* SQL text to update entity field related entity name field map for entity field ID CA10443E-F36B-1410-8DBB-00021F8B792E */
+EXEC [${flyway:defaultSchema}].spUpdateEntityFieldRelatedEntityNameFieldMap
+         @EntityFieldID='CA10443E-F36B-1410-8DBB-00021F8B792E',
+         @RelatedEntityNameFieldMap='User'
+
+/* SQL text to update entity field related entity name field map for entity field ID E80F443E-F36B-1410-8DBB-00021F8B792E */
+EXEC [${flyway:defaultSchema}].spUpdateEntityFieldRelatedEntityNameFieldMap
+         @EntityFieldID='E80F443E-F36B-1410-8DBB-00021F8B792E',
+         @RelatedEntityNameFieldMap='Source'
+
+/* SQL text to update entity field related entity name field map for entity field ID FA0F443E-F36B-1410-8DBB-00021F8B792E */
+EXEC [${flyway:defaultSchema}].spUpdateEntityFieldRelatedEntityNameFieldMap
+         @EntityFieldID='FA0F443E-F36B-1410-8DBB-00021F8B792E',
+         @RelatedEntityNameFieldMap='ContentType'
+
+/* SQL text to update entity field related entity name field map for entity field ID 0810443E-F36B-1410-8DBB-00021F8B792E */
+EXEC [${flyway:defaultSchema}].spUpdateEntityFieldRelatedEntityNameFieldMap
+         @EntityFieldID='0810443E-F36B-1410-8DBB-00021F8B792E',
+         @RelatedEntityNameFieldMap='ContentSource'
+
+/* SQL text to update entity field related entity name field map for entity field ID FC0F443E-F36B-1410-8DBB-00021F8B792E */
+EXEC [${flyway:defaultSchema}].spUpdateEntityFieldRelatedEntityNameFieldMap
+         @EntityFieldID='FC0F443E-F36B-1410-8DBB-00021F8B792E',
+         @RelatedEntityNameFieldMap='ContentSourceType'
+
+/* SQL text to update entity field related entity name field map for entity field ID FE0F443E-F36B-1410-8DBB-00021F8B792E */
+EXEC [${flyway:defaultSchema}].spUpdateEntityFieldRelatedEntityNameFieldMap
+         @EntityFieldID='FE0F443E-F36B-1410-8DBB-00021F8B792E',
+         @RelatedEntityNameFieldMap='ContentFileType'
+
+/* SQL text to update entity field related entity name field map for entity field ID 3210443E-F36B-1410-8DBB-00021F8B792E */
+EXEC [${flyway:defaultSchema}].spUpdateEntityFieldRelatedEntityNameFieldMap
+         @EntityFieldID='3210443E-F36B-1410-8DBB-00021F8B792E',
+         @RelatedEntityNameFieldMap='AIModel'
+
+/* SQL text to update entity field related entity name field map for entity field ID 5610443E-F36B-1410-8DBB-00021F8B792E */
+EXEC [${flyway:defaultSchema}].spUpdateEntityFieldRelatedEntityNameFieldMap
+         @EntityFieldID='5610443E-F36B-1410-8DBB-00021F8B792E',
+         @RelatedEntityNameFieldMap='ContentSource'
+
+/* SQL text to update entity field related entity name field map for entity field ID 6E10443E-F36B-1410-8DBB-00021F8B792E */
+EXEC [${flyway:defaultSchema}].spUpdateEntityFieldRelatedEntityNameFieldMap
+         @EntityFieldID='6E10443E-F36B-1410-8DBB-00021F8B792E',
+         @RelatedEntityNameFieldMap='ContentItem'
+
+/* SQL text to update entity field related entity name field map for entity field ID 7A10443E-F36B-1410-8DBB-00021F8B792E */
+EXEC [${flyway:defaultSchema}].spUpdateEntityFieldRelatedEntityNameFieldMap
+         @EntityFieldID='7A10443E-F36B-1410-8DBB-00021F8B792E',
+         @RelatedEntityNameFieldMap='Item'
+
+/* SQL text to update entity field related entity name field map for entity field ID 5C10443E-F36B-1410-8DBB-00021F8B792E */
+EXEC [${flyway:defaultSchema}].spUpdateEntityFieldRelatedEntityNameFieldMap
+         @EntityFieldID='5C10443E-F36B-1410-8DBB-00021F8B792E',
+         @RelatedEntityNameFieldMap='ContentType'
+
+/* SQL text to update entity field related entity name field map for entity field ID 5E10443E-F36B-1410-8DBB-00021F8B792E */
+EXEC [${flyway:defaultSchema}].spUpdateEntityFieldRelatedEntityNameFieldMap
+         @EntityFieldID='5E10443E-F36B-1410-8DBB-00021F8B792E',
+         @RelatedEntityNameFieldMap='ContentSourceType'
+
+/* SQL text to update entity field related entity name field map for entity field ID 6010443E-F36B-1410-8DBB-00021F8B792E */
+EXEC [${flyway:defaultSchema}].spUpdateEntityFieldRelatedEntityNameFieldMap
+         @EntityFieldID='6010443E-F36B-1410-8DBB-00021F8B792E',
+         @RelatedEntityNameFieldMap='ContentFileType'
+
+/* Generated Validation Functions for AI Agents */
+-- CHECK constraint for AI Agents: Field: DefaultPromptEffortLevel was newly set or modified since the last generation of the validation function, the code was regenerated and updating the GeneratedCode table with the new generated validation function
+INSERT INTO [${flyway:defaultSchema}].[GeneratedCode] (CategoryID, GeneratedByModelID, GeneratedAt, Language, Status, Source, Code, Description, Name, LinkedEntityID, LinkedRecordPrimaryKey)
+                      VALUES ((SELECT ID FROM ${flyway:defaultSchema}.vwGeneratedCodeCategories WHERE Name='CodeGen: Validators'), '287E317F-BF26-F011-A770-AC1A3D21423D', GETUTCDATE(), 'TypeScript','Approved', '([DefaultPromptEffortLevel]>=(1) AND [DefaultPromptEffortLevel]<=(100))', 'public ValidateDefaultPromptEffortLevelWithinRange(result: ValidationResult) {
+	if (this.DefaultPromptEffortLevel < 1 || this.DefaultPromptEffortLevel > 100) {
+		result.Errors.push(new ValidationErrorInfo("DefaultPromptEffortLevel", "DefaultPromptEffortLevel must be between 1 and 100.", this.DefaultPromptEffortLevel, ValidationErrorType.Failure));
+	}
+}', 'This rule ensures that the DefaultPromptEffortLevel must always be a value between 1 and 100, inclusive.', 'ValidateDefaultPromptEffortLevelWithinRange', 'DF238F34-2837-EF11-86D4-6045BDEE16E6', 'DCBAEEFD-C5A2-449D-A4B9-EAB1290C2F89');
+  
+            
+
+/* Generated Validation Functions for AI Prompts */
+-- CHECK constraint for AI Prompts: Field: EffortLevel was newly set or modified since the last generation of the validation function, the code was regenerated and updating the GeneratedCode table with the new generated validation function
+INSERT INTO [${flyway:defaultSchema}].[GeneratedCode] (CategoryID, GeneratedByModelID, GeneratedAt, Language, Status, Source, Code, Description, Name, LinkedEntityID, LinkedRecordPrimaryKey)
+                      VALUES ((SELECT ID FROM ${flyway:defaultSchema}.vwGeneratedCodeCategories WHERE Name='CodeGen: Validators'), '287E317F-BF26-F011-A770-AC1A3D21423D', GETUTCDATE(), 'TypeScript','Approved', '([EffortLevel]>=(1) AND [EffortLevel]<=(100))', 'public ValidateEffortLevelIsWithinRange(result: ValidationResult) {
+	if (this.EffortLevel < 1 || this.EffortLevel > 100) {
+		result.Errors.push(new ValidationErrorInfo("EffortLevel", "EffortLevel must be between 1 and 100.", this.EffortLevel, ValidationErrorType.Failure));
+	}
+}', 'This rule ensures that the EffortLevel must be a value between 1 and 100, inclusive.', 'ValidateEffortLevelIsWithinRange', 'DF238F34-2837-EF11-86D4-6045BDEE16E6', 'DAFA54D5-F48A-499F-8F4E-E329AF0B5B6B');
+  
+            
+

--- a/migrations/v2/V202508062114__v2.82.x__Add_EffortLevel_To_Run_Tables.sql
+++ b/migrations/v2/V202508062114__v2.82.x__Add_EffortLevel_To_Run_Tables.sql
@@ -1,0 +1,1938 @@
+-- Add EffortLevel fields to AIAgentRun and AIPromptRun tables
+-- This migration adds support for tracking the actual effort level used during execution
+-- Higher values request more thorough reasoning/analysis from AI models
+-- Each provider maps the 1-100 scale to their specific effort level parameters
+
+-- Add EffortLevel column to AIAgentRun table
+ALTER TABLE ${flyway:defaultSchema}.AIAgentRun 
+ADD EffortLevel INT NULL;
+GO
+
+-- Add EffortLevel column to AIPromptRun table  
+ALTER TABLE ${flyway:defaultSchema}.AIPromptRun
+ADD EffortLevel INT NULL;
+GO
+
+-- Add CHECK constraints to enforce valid effort level range (1-100)
+ALTER TABLE ${flyway:defaultSchema}.AIAgentRun 
+ADD CONSTRAINT CK_AIAgentRun_EffortLevel CHECK (EffortLevel BETWEEN 1 AND 100);
+GO
+
+ALTER TABLE ${flyway:defaultSchema}.AIPromptRun 
+ADD CONSTRAINT CK_AIPromptRun_EffortLevel CHECK (EffortLevel BETWEEN 1 AND 100);
+GO
+
+-- Add extended property for AIAgentRun.EffortLevel column
+EXEC sp_addextendedproperty 
+    @name = N'MS_Description', 
+    @value = N'Effort level that was actually used during this agent run execution (1-100, where 1=minimal effort, 100=maximum effort). This is the resolved effort level after applying the precedence hierarchy: runtime override > agent default > prompt defaults.',
+    @level0type = N'SCHEMA', @level0name = N'${flyway:defaultSchema}',
+    @level1type = N'TABLE', @level1name = N'AIAgentRun',
+    @level2type = N'COLUMN', @level2name = N'EffortLevel';
+
+-- Add extended property for AIPromptRun.EffortLevel column
+EXEC sp_addextendedproperty 
+    @name = N'MS_Description', 
+    @value = N'Effort level that was actually used during this prompt run execution (1-100, where 1=minimal effort, 100=maximum effort). This is the resolved effort level after applying the precedence hierarchy: runtime override > agent default > prompt default > provider default.',
+    @level0type = N'SCHEMA', @level0name = N'${flyway:defaultSchema}',
+    @level1type = N'TABLE', @level1name = N'AIPromptRun',
+    @level2type = N'COLUMN', @level2name = N'EffortLevel';
+
+
+/** CODE GEN RUN **/
+/* SQL text to insert new entity field */
+
+      IF NOT EXISTS (
+         SELECT 1 FROM [${flyway:defaultSchema}].EntityField 
+         WHERE ID = 'b16b5b36-7238-4a90-abad-da64ed8fadca'  OR 
+               (EntityID = '5190AF93-4C39-4429-BDAA-0AEB492A0256' AND Name = 'EffortLevel')
+         -- check to make sure we're not inserting a duplicate entity field metadata record
+      )
+      BEGIN
+         INSERT INTO [${flyway:defaultSchema}].EntityField
+         (
+            ID,
+            EntityID,
+            Sequence,
+            Name,
+            DisplayName,
+            Description,
+            Type,
+            Length,
+            Precision,
+            Scale,
+            AllowsNull,
+            DefaultValue,
+            AutoIncrement,
+            AllowUpdateAPI,
+            IsVirtual,
+            RelatedEntityID,
+            RelatedEntityFieldName,
+            IsNameField,
+            IncludeInUserSearchAPI,
+            IncludeRelatedEntityNameFieldInBaseView,
+            DefaultInView,
+            IsPrimaryKey,
+            IsUnique,
+            RelatedEntityDisplayType
+         )
+         VALUES
+         (
+            'b16b5b36-7238-4a90-abad-da64ed8fadca',
+            '5190AF93-4C39-4429-BDAA-0AEB492A0256', -- Entity: MJ: AI Agent Runs
+            100037,
+            'EffortLevel',
+            'Effort Level',
+            'Effort level that was actually used during this agent run execution (1-100, where 1=minimal effort, 100=maximum effort). This is the resolved effort level after applying the precedence hierarchy: runtime override > agent default > prompt defaults.',
+            'int',
+            4,
+            10,
+            0,
+            1,
+            'null',
+            0,
+            1,
+            0,
+            NULL,
+            NULL,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            'Search'
+         )
+      END
+
+/* SQL text to insert new entity field */
+
+      IF NOT EXISTS (
+         SELECT 1 FROM [${flyway:defaultSchema}].EntityField 
+         WHERE ID = '7b1032db-f8af-4eaf-9f03-7b9049fba39d'  OR 
+               (EntityID = '7C1C98D0-3978-4CE8-8E3F-C90301E59767' AND Name = 'EffortLevel')
+         -- check to make sure we're not inserting a duplicate entity field metadata record
+      )
+      BEGIN
+         INSERT INTO [${flyway:defaultSchema}].EntityField
+         (
+            ID,
+            EntityID,
+            Sequence,
+            Name,
+            DisplayName,
+            Description,
+            Type,
+            Length,
+            Precision,
+            Scale,
+            AllowsNull,
+            DefaultValue,
+            AutoIncrement,
+            AllowUpdateAPI,
+            IsVirtual,
+            RelatedEntityID,
+            RelatedEntityFieldName,
+            IsNameField,
+            IncludeInUserSearchAPI,
+            IncludeRelatedEntityNameFieldInBaseView,
+            DefaultInView,
+            IsPrimaryKey,
+            IsUnique,
+            RelatedEntityDisplayType
+         )
+         VALUES
+         (
+            '7b1032db-f8af-4eaf-9f03-7b9049fba39d',
+            '7C1C98D0-3978-4CE8-8E3F-C90301E59767', -- Entity: MJ: AI Prompt Runs
+            100081,
+            'EffortLevel',
+            'Effort Level',
+            'Effort level that was actually used during this prompt run execution (1-100, where 1=minimal effort, 100=maximum effort). This is the resolved effort level after applying the precedence hierarchy: runtime override > agent default > prompt default > provider default.',
+            'int',
+            4,
+            10,
+            0,
+            1,
+            'null',
+            0,
+            1,
+            0,
+            NULL,
+            NULL,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            'Search'
+         )
+      END
+
+/* Index for Foreign Keys for AIAgentRun */
+-----------------------------------------------------------------
+-- SQL Code Generation
+-- Entity: MJ: AI Agent Runs
+-- Item: Index for Foreign Keys
+--
+-- This was generated by the MemberJunction CodeGen tool.
+-- This file should NOT be edited by hand.
+-----------------------------------------------------------------
+-- Index for foreign key AgentID in table AIAgentRun
+IF NOT EXISTS (
+    SELECT 1
+    FROM sys.indexes
+    WHERE name = 'IDX_AUTO_MJ_FKEY_AIAgentRun_AgentID' 
+    AND object_id = OBJECT_ID('[${flyway:defaultSchema}].[AIAgentRun]')
+)
+CREATE INDEX IDX_AUTO_MJ_FKEY_AIAgentRun_AgentID ON [${flyway:defaultSchema}].[AIAgentRun] ([AgentID]);
+
+-- Index for foreign key ParentRunID in table AIAgentRun
+IF NOT EXISTS (
+    SELECT 1
+    FROM sys.indexes
+    WHERE name = 'IDX_AUTO_MJ_FKEY_AIAgentRun_ParentRunID' 
+    AND object_id = OBJECT_ID('[${flyway:defaultSchema}].[AIAgentRun]')
+)
+CREATE INDEX IDX_AUTO_MJ_FKEY_AIAgentRun_ParentRunID ON [${flyway:defaultSchema}].[AIAgentRun] ([ParentRunID]);
+
+-- Index for foreign key ConversationID in table AIAgentRun
+IF NOT EXISTS (
+    SELECT 1
+    FROM sys.indexes
+    WHERE name = 'IDX_AUTO_MJ_FKEY_AIAgentRun_ConversationID' 
+    AND object_id = OBJECT_ID('[${flyway:defaultSchema}].[AIAgentRun]')
+)
+CREATE INDEX IDX_AUTO_MJ_FKEY_AIAgentRun_ConversationID ON [${flyway:defaultSchema}].[AIAgentRun] ([ConversationID]);
+
+-- Index for foreign key UserID in table AIAgentRun
+IF NOT EXISTS (
+    SELECT 1
+    FROM sys.indexes
+    WHERE name = 'IDX_AUTO_MJ_FKEY_AIAgentRun_UserID' 
+    AND object_id = OBJECT_ID('[${flyway:defaultSchema}].[AIAgentRun]')
+)
+CREATE INDEX IDX_AUTO_MJ_FKEY_AIAgentRun_UserID ON [${flyway:defaultSchema}].[AIAgentRun] ([UserID]);
+
+-- Index for foreign key ConversationDetailID in table AIAgentRun
+IF NOT EXISTS (
+    SELECT 1
+    FROM sys.indexes
+    WHERE name = 'IDX_AUTO_MJ_FKEY_AIAgentRun_ConversationDetailID' 
+    AND object_id = OBJECT_ID('[${flyway:defaultSchema}].[AIAgentRun]')
+)
+CREATE INDEX IDX_AUTO_MJ_FKEY_AIAgentRun_ConversationDetailID ON [${flyway:defaultSchema}].[AIAgentRun] ([ConversationDetailID]);
+
+-- Index for foreign key LastRunID in table AIAgentRun
+IF NOT EXISTS (
+    SELECT 1
+    FROM sys.indexes
+    WHERE name = 'IDX_AUTO_MJ_FKEY_AIAgentRun_LastRunID' 
+    AND object_id = OBJECT_ID('[${flyway:defaultSchema}].[AIAgentRun]')
+)
+CREATE INDEX IDX_AUTO_MJ_FKEY_AIAgentRun_LastRunID ON [${flyway:defaultSchema}].[AIAgentRun] ([LastRunID]);
+
+-- Index for foreign key ConfigurationID in table AIAgentRun
+IF NOT EXISTS (
+    SELECT 1
+    FROM sys.indexes
+    WHERE name = 'IDX_AUTO_MJ_FKEY_AIAgentRun_ConfigurationID' 
+    AND object_id = OBJECT_ID('[${flyway:defaultSchema}].[AIAgentRun]')
+)
+CREATE INDEX IDX_AUTO_MJ_FKEY_AIAgentRun_ConfigurationID ON [${flyway:defaultSchema}].[AIAgentRun] ([ConfigurationID]);
+
+-- Index for foreign key OverrideModelID in table AIAgentRun
+IF NOT EXISTS (
+    SELECT 1
+    FROM sys.indexes
+    WHERE name = 'IDX_AUTO_MJ_FKEY_AIAgentRun_OverrideModelID' 
+    AND object_id = OBJECT_ID('[${flyway:defaultSchema}].[AIAgentRun]')
+)
+CREATE INDEX IDX_AUTO_MJ_FKEY_AIAgentRun_OverrideModelID ON [${flyway:defaultSchema}].[AIAgentRun] ([OverrideModelID]);
+
+-- Index for foreign key OverrideVendorID in table AIAgentRun
+IF NOT EXISTS (
+    SELECT 1
+    FROM sys.indexes
+    WHERE name = 'IDX_AUTO_MJ_FKEY_AIAgentRun_OverrideVendorID' 
+    AND object_id = OBJECT_ID('[${flyway:defaultSchema}].[AIAgentRun]')
+)
+CREATE INDEX IDX_AUTO_MJ_FKEY_AIAgentRun_OverrideVendorID ON [${flyway:defaultSchema}].[AIAgentRun] ([OverrideVendorID]);
+
+/* Base View SQL for MJ: AI Agent Runs */
+-----------------------------------------------------------------
+-- SQL Code Generation
+-- Entity: MJ: AI Agent Runs
+-- Item: vwAIAgentRuns
+--
+-- This was generated by the MemberJunction CodeGen tool.
+-- This file should NOT be edited by hand.
+-----------------------------------------------------------------
+
+------------------------------------------------------------
+----- BASE VIEW FOR ENTITY:      MJ: AI Agent Runs
+-----               SCHEMA:      ${flyway:defaultSchema}
+-----               BASE TABLE:  AIAgentRun
+-----               PRIMARY KEY: ID
+------------------------------------------------------------
+DROP VIEW IF EXISTS [${flyway:defaultSchema}].[vwAIAgentRuns]
+GO
+
+CREATE VIEW [${flyway:defaultSchema}].[vwAIAgentRuns]
+AS
+SELECT
+    a.*,
+    AIAgent_AgentID.[Name] AS [Agent],
+    Conversation_ConversationID.[Name] AS [Conversation],
+    User_UserID.[Name] AS [User],
+    AIConfiguration_ConfigurationID.[Name] AS [Configuration],
+    AIModel_OverrideModelID.[Name] AS [OverrideModel],
+    AIVendor_OverrideVendorID.[Name] AS [OverrideVendor]
+FROM
+    [${flyway:defaultSchema}].[AIAgentRun] AS a
+INNER JOIN
+    [${flyway:defaultSchema}].[AIAgent] AS AIAgent_AgentID
+  ON
+    [a].[AgentID] = AIAgent_AgentID.[ID]
+LEFT OUTER JOIN
+    [${flyway:defaultSchema}].[Conversation] AS Conversation_ConversationID
+  ON
+    [a].[ConversationID] = Conversation_ConversationID.[ID]
+LEFT OUTER JOIN
+    [${flyway:defaultSchema}].[User] AS User_UserID
+  ON
+    [a].[UserID] = User_UserID.[ID]
+LEFT OUTER JOIN
+    [${flyway:defaultSchema}].[AIConfiguration] AS AIConfiguration_ConfigurationID
+  ON
+    [a].[ConfigurationID] = AIConfiguration_ConfigurationID.[ID]
+LEFT OUTER JOIN
+    [${flyway:defaultSchema}].[AIModel] AS AIModel_OverrideModelID
+  ON
+    [a].[OverrideModelID] = AIModel_OverrideModelID.[ID]
+LEFT OUTER JOIN
+    [${flyway:defaultSchema}].[AIVendor] AS AIVendor_OverrideVendorID
+  ON
+    [a].[OverrideVendorID] = AIVendor_OverrideVendorID.[ID]
+GO
+GRANT SELECT ON [${flyway:defaultSchema}].[vwAIAgentRuns] TO [cdp_UI], [cdp_Developer], [cdp_Integration]
+    
+
+/* Base View Permissions SQL for MJ: AI Agent Runs */
+-----------------------------------------------------------------
+-- SQL Code Generation
+-- Entity: MJ: AI Agent Runs
+-- Item: Permissions for vwAIAgentRuns
+--
+-- This was generated by the MemberJunction CodeGen tool.
+-- This file should NOT be edited by hand.
+-----------------------------------------------------------------
+
+GRANT SELECT ON [${flyway:defaultSchema}].[vwAIAgentRuns] TO [cdp_UI], [cdp_Developer], [cdp_Integration]
+
+/* spCreate SQL for MJ: AI Agent Runs */
+-----------------------------------------------------------------
+-- SQL Code Generation
+-- Entity: MJ: AI Agent Runs
+-- Item: spCreateAIAgentRun
+--
+-- This was generated by the MemberJunction CodeGen tool.
+-- This file should NOT be edited by hand.
+-----------------------------------------------------------------
+
+------------------------------------------------------------
+----- CREATE PROCEDURE FOR AIAgentRun
+------------------------------------------------------------
+DROP PROCEDURE IF EXISTS [${flyway:defaultSchema}].[spCreateAIAgentRun]
+GO
+
+CREATE PROCEDURE [${flyway:defaultSchema}].[spCreateAIAgentRun]
+    @ID uniqueidentifier = NULL,
+    @AgentID uniqueidentifier,
+    @ParentRunID uniqueidentifier,
+    @Status nvarchar(50),
+    @StartedAt datetimeoffset,
+    @CompletedAt datetimeoffset,
+    @Success bit,
+    @ErrorMessage nvarchar(MAX),
+    @ConversationID uniqueidentifier,
+    @UserID uniqueidentifier,
+    @Result nvarchar(MAX),
+    @AgentState nvarchar(MAX),
+    @TotalTokensUsed int,
+    @TotalCost decimal(18, 6),
+    @TotalPromptTokensUsed int,
+    @TotalCompletionTokensUsed int,
+    @TotalTokensUsedRollup int,
+    @TotalPromptTokensUsedRollup int,
+    @TotalCompletionTokensUsedRollup int,
+    @TotalCostRollup decimal(19, 8),
+    @ConversationDetailID uniqueidentifier,
+    @ConversationDetailSequence int,
+    @CancellationReason nvarchar(30),
+    @FinalStep nvarchar(30),
+    @FinalPayload nvarchar(MAX),
+    @Message nvarchar(MAX),
+    @LastRunID uniqueidentifier,
+    @StartingPayload nvarchar(MAX),
+    @TotalPromptIterations int,
+    @ConfigurationID uniqueidentifier,
+    @OverrideModelID uniqueidentifier,
+    @OverrideVendorID uniqueidentifier,
+    @Data nvarchar(MAX),
+    @Verbose bit,
+    @EffortLevel int
+AS
+BEGIN
+    SET NOCOUNT ON;
+    DECLARE @InsertedRow TABLE ([ID] UNIQUEIDENTIFIER)
+    
+    IF @ID IS NOT NULL
+    BEGIN
+        -- User provided a value, use it
+        INSERT INTO [${flyway:defaultSchema}].[AIAgentRun]
+            (
+                [ID],
+                [AgentID],
+                [ParentRunID],
+                [Status],
+                [StartedAt],
+                [CompletedAt],
+                [Success],
+                [ErrorMessage],
+                [ConversationID],
+                [UserID],
+                [Result],
+                [AgentState],
+                [TotalTokensUsed],
+                [TotalCost],
+                [TotalPromptTokensUsed],
+                [TotalCompletionTokensUsed],
+                [TotalTokensUsedRollup],
+                [TotalPromptTokensUsedRollup],
+                [TotalCompletionTokensUsedRollup],
+                [TotalCostRollup],
+                [ConversationDetailID],
+                [ConversationDetailSequence],
+                [CancellationReason],
+                [FinalStep],
+                [FinalPayload],
+                [Message],
+                [LastRunID],
+                [StartingPayload],
+                [TotalPromptIterations],
+                [ConfigurationID],
+                [OverrideModelID],
+                [OverrideVendorID],
+                [Data],
+                [Verbose],
+                [EffortLevel]
+            )
+        OUTPUT INSERTED.[ID] INTO @InsertedRow
+        VALUES
+            (
+                @ID,
+                @AgentID,
+                @ParentRunID,
+                @Status,
+                @StartedAt,
+                @CompletedAt,
+                @Success,
+                @ErrorMessage,
+                @ConversationID,
+                @UserID,
+                @Result,
+                @AgentState,
+                @TotalTokensUsed,
+                @TotalCost,
+                @TotalPromptTokensUsed,
+                @TotalCompletionTokensUsed,
+                @TotalTokensUsedRollup,
+                @TotalPromptTokensUsedRollup,
+                @TotalCompletionTokensUsedRollup,
+                @TotalCostRollup,
+                @ConversationDetailID,
+                @ConversationDetailSequence,
+                @CancellationReason,
+                @FinalStep,
+                @FinalPayload,
+                @Message,
+                @LastRunID,
+                @StartingPayload,
+                @TotalPromptIterations,
+                @ConfigurationID,
+                @OverrideModelID,
+                @OverrideVendorID,
+                @Data,
+                @Verbose,
+                @EffortLevel
+            )
+    END
+    ELSE
+    BEGIN
+        -- No value provided, let database use its default (e.g., NEWSEQUENTIALID())
+        INSERT INTO [${flyway:defaultSchema}].[AIAgentRun]
+            (
+                [AgentID],
+                [ParentRunID],
+                [Status],
+                [StartedAt],
+                [CompletedAt],
+                [Success],
+                [ErrorMessage],
+                [ConversationID],
+                [UserID],
+                [Result],
+                [AgentState],
+                [TotalTokensUsed],
+                [TotalCost],
+                [TotalPromptTokensUsed],
+                [TotalCompletionTokensUsed],
+                [TotalTokensUsedRollup],
+                [TotalPromptTokensUsedRollup],
+                [TotalCompletionTokensUsedRollup],
+                [TotalCostRollup],
+                [ConversationDetailID],
+                [ConversationDetailSequence],
+                [CancellationReason],
+                [FinalStep],
+                [FinalPayload],
+                [Message],
+                [LastRunID],
+                [StartingPayload],
+                [TotalPromptIterations],
+                [ConfigurationID],
+                [OverrideModelID],
+                [OverrideVendorID],
+                [Data],
+                [Verbose],
+                [EffortLevel]
+            )
+        OUTPUT INSERTED.[ID] INTO @InsertedRow
+        VALUES
+            (
+                @AgentID,
+                @ParentRunID,
+                @Status,
+                @StartedAt,
+                @CompletedAt,
+                @Success,
+                @ErrorMessage,
+                @ConversationID,
+                @UserID,
+                @Result,
+                @AgentState,
+                @TotalTokensUsed,
+                @TotalCost,
+                @TotalPromptTokensUsed,
+                @TotalCompletionTokensUsed,
+                @TotalTokensUsedRollup,
+                @TotalPromptTokensUsedRollup,
+                @TotalCompletionTokensUsedRollup,
+                @TotalCostRollup,
+                @ConversationDetailID,
+                @ConversationDetailSequence,
+                @CancellationReason,
+                @FinalStep,
+                @FinalPayload,
+                @Message,
+                @LastRunID,
+                @StartingPayload,
+                @TotalPromptIterations,
+                @ConfigurationID,
+                @OverrideModelID,
+                @OverrideVendorID,
+                @Data,
+                @Verbose,
+                @EffortLevel
+            )
+    END
+    -- return the new record from the base view, which might have some calculated fields
+    SELECT * FROM [${flyway:defaultSchema}].[vwAIAgentRuns] WHERE [ID] = (SELECT [ID] FROM @InsertedRow)
+END
+GO
+GRANT EXECUTE ON [${flyway:defaultSchema}].[spCreateAIAgentRun] TO [cdp_Developer], [cdp_Integration]
+    
+
+/* spCreate Permissions for MJ: AI Agent Runs */
+
+GRANT EXECUTE ON [${flyway:defaultSchema}].[spCreateAIAgentRun] TO [cdp_Developer], [cdp_Integration]
+
+
+
+/* spUpdate SQL for MJ: AI Agent Runs */
+-----------------------------------------------------------------
+-- SQL Code Generation
+-- Entity: MJ: AI Agent Runs
+-- Item: spUpdateAIAgentRun
+--
+-- This was generated by the MemberJunction CodeGen tool.
+-- This file should NOT be edited by hand.
+-----------------------------------------------------------------
+
+------------------------------------------------------------
+----- UPDATE PROCEDURE FOR AIAgentRun
+------------------------------------------------------------
+DROP PROCEDURE IF EXISTS [${flyway:defaultSchema}].[spUpdateAIAgentRun]
+GO
+
+CREATE PROCEDURE [${flyway:defaultSchema}].[spUpdateAIAgentRun]
+    @ID uniqueidentifier,
+    @AgentID uniqueidentifier,
+    @ParentRunID uniqueidentifier,
+    @Status nvarchar(50),
+    @StartedAt datetimeoffset,
+    @CompletedAt datetimeoffset,
+    @Success bit,
+    @ErrorMessage nvarchar(MAX),
+    @ConversationID uniqueidentifier,
+    @UserID uniqueidentifier,
+    @Result nvarchar(MAX),
+    @AgentState nvarchar(MAX),
+    @TotalTokensUsed int,
+    @TotalCost decimal(18, 6),
+    @TotalPromptTokensUsed int,
+    @TotalCompletionTokensUsed int,
+    @TotalTokensUsedRollup int,
+    @TotalPromptTokensUsedRollup int,
+    @TotalCompletionTokensUsedRollup int,
+    @TotalCostRollup decimal(19, 8),
+    @ConversationDetailID uniqueidentifier,
+    @ConversationDetailSequence int,
+    @CancellationReason nvarchar(30),
+    @FinalStep nvarchar(30),
+    @FinalPayload nvarchar(MAX),
+    @Message nvarchar(MAX),
+    @LastRunID uniqueidentifier,
+    @StartingPayload nvarchar(MAX),
+    @TotalPromptIterations int,
+    @ConfigurationID uniqueidentifier,
+    @OverrideModelID uniqueidentifier,
+    @OverrideVendorID uniqueidentifier,
+    @Data nvarchar(MAX),
+    @Verbose bit,
+    @EffortLevel int
+AS
+BEGIN
+    SET NOCOUNT ON;
+    UPDATE
+        [${flyway:defaultSchema}].[AIAgentRun]
+    SET
+        [AgentID] = @AgentID,
+        [ParentRunID] = @ParentRunID,
+        [Status] = @Status,
+        [StartedAt] = @StartedAt,
+        [CompletedAt] = @CompletedAt,
+        [Success] = @Success,
+        [ErrorMessage] = @ErrorMessage,
+        [ConversationID] = @ConversationID,
+        [UserID] = @UserID,
+        [Result] = @Result,
+        [AgentState] = @AgentState,
+        [TotalTokensUsed] = @TotalTokensUsed,
+        [TotalCost] = @TotalCost,
+        [TotalPromptTokensUsed] = @TotalPromptTokensUsed,
+        [TotalCompletionTokensUsed] = @TotalCompletionTokensUsed,
+        [TotalTokensUsedRollup] = @TotalTokensUsedRollup,
+        [TotalPromptTokensUsedRollup] = @TotalPromptTokensUsedRollup,
+        [TotalCompletionTokensUsedRollup] = @TotalCompletionTokensUsedRollup,
+        [TotalCostRollup] = @TotalCostRollup,
+        [ConversationDetailID] = @ConversationDetailID,
+        [ConversationDetailSequence] = @ConversationDetailSequence,
+        [CancellationReason] = @CancellationReason,
+        [FinalStep] = @FinalStep,
+        [FinalPayload] = @FinalPayload,
+        [Message] = @Message,
+        [LastRunID] = @LastRunID,
+        [StartingPayload] = @StartingPayload,
+        [TotalPromptIterations] = @TotalPromptIterations,
+        [ConfigurationID] = @ConfigurationID,
+        [OverrideModelID] = @OverrideModelID,
+        [OverrideVendorID] = @OverrideVendorID,
+        [Data] = @Data,
+        [Verbose] = @Verbose,
+        [EffortLevel] = @EffortLevel
+    WHERE
+        [ID] = @ID
+
+    -- Check if the update was successful
+    IF @@ROWCOUNT = 0
+        -- Nothing was updated, return no rows, but column structure from base view intact, semantically correct this way.
+        SELECT TOP 0 * FROM [${flyway:defaultSchema}].[vwAIAgentRuns] WHERE 1=0
+    ELSE
+        -- Return the updated record so the caller can see the updated values and any calculated fields
+        SELECT
+                                        *
+                                    FROM
+                                        [${flyway:defaultSchema}].[vwAIAgentRuns]
+                                    WHERE
+                                        [ID] = @ID
+                                    
+END
+GO
+
+GRANT EXECUTE ON [${flyway:defaultSchema}].[spUpdateAIAgentRun] TO [cdp_Developer], [cdp_Integration]
+GO
+
+------------------------------------------------------------
+----- TRIGGER FOR __mj_UpdatedAt field for the AIAgentRun table
+------------------------------------------------------------
+DROP TRIGGER IF EXISTS [${flyway:defaultSchema}].trgUpdateAIAgentRun
+GO
+CREATE TRIGGER [${flyway:defaultSchema}].trgUpdateAIAgentRun
+ON [${flyway:defaultSchema}].[AIAgentRun]
+AFTER UPDATE
+AS
+BEGIN
+    SET NOCOUNT ON;
+    UPDATE
+        [${flyway:defaultSchema}].[AIAgentRun]
+    SET
+        __mj_UpdatedAt = GETUTCDATE()
+    FROM
+        [${flyway:defaultSchema}].[AIAgentRun] AS _organicTable
+    INNER JOIN
+        INSERTED AS I ON
+        _organicTable.[ID] = I.[ID];
+END;
+GO
+        
+
+/* spUpdate Permissions for MJ: AI Agent Runs */
+
+GRANT EXECUTE ON [${flyway:defaultSchema}].[spUpdateAIAgentRun] TO [cdp_Developer], [cdp_Integration]
+
+
+
+/* spDelete Permissions for MJ: AI Agent Runs */
+
+GRANT EXECUTE ON [${flyway:defaultSchema}].[spDeleteAIAgentRun] TO [cdp_Integration]
+
+
+
+/* Index for Foreign Keys for AIPromptRun */
+-----------------------------------------------------------------
+-- SQL Code Generation
+-- Entity: MJ: AI Prompt Runs
+-- Item: Index for Foreign Keys
+--
+-- This was generated by the MemberJunction CodeGen tool.
+-- This file should NOT be edited by hand.
+-----------------------------------------------------------------
+-- Index for foreign key PromptID in table AIPromptRun
+IF NOT EXISTS (
+    SELECT 1
+    FROM sys.indexes
+    WHERE name = 'IDX_AUTO_MJ_FKEY_AIPromptRun_PromptID' 
+    AND object_id = OBJECT_ID('[${flyway:defaultSchema}].[AIPromptRun]')
+)
+CREATE INDEX IDX_AUTO_MJ_FKEY_AIPromptRun_PromptID ON [${flyway:defaultSchema}].[AIPromptRun] ([PromptID]);
+
+-- Index for foreign key ModelID in table AIPromptRun
+IF NOT EXISTS (
+    SELECT 1
+    FROM sys.indexes
+    WHERE name = 'IDX_AUTO_MJ_FKEY_AIPromptRun_ModelID' 
+    AND object_id = OBJECT_ID('[${flyway:defaultSchema}].[AIPromptRun]')
+)
+CREATE INDEX IDX_AUTO_MJ_FKEY_AIPromptRun_ModelID ON [${flyway:defaultSchema}].[AIPromptRun] ([ModelID]);
+
+-- Index for foreign key VendorID in table AIPromptRun
+IF NOT EXISTS (
+    SELECT 1
+    FROM sys.indexes
+    WHERE name = 'IDX_AUTO_MJ_FKEY_AIPromptRun_VendorID' 
+    AND object_id = OBJECT_ID('[${flyway:defaultSchema}].[AIPromptRun]')
+)
+CREATE INDEX IDX_AUTO_MJ_FKEY_AIPromptRun_VendorID ON [${flyway:defaultSchema}].[AIPromptRun] ([VendorID]);
+
+-- Index for foreign key AgentID in table AIPromptRun
+IF NOT EXISTS (
+    SELECT 1
+    FROM sys.indexes
+    WHERE name = 'IDX_AUTO_MJ_FKEY_AIPromptRun_AgentID' 
+    AND object_id = OBJECT_ID('[${flyway:defaultSchema}].[AIPromptRun]')
+)
+CREATE INDEX IDX_AUTO_MJ_FKEY_AIPromptRun_AgentID ON [${flyway:defaultSchema}].[AIPromptRun] ([AgentID]);
+
+-- Index for foreign key ConfigurationID in table AIPromptRun
+IF NOT EXISTS (
+    SELECT 1
+    FROM sys.indexes
+    WHERE name = 'IDX_AUTO_MJ_FKEY_AIPromptRun_ConfigurationID' 
+    AND object_id = OBJECT_ID('[${flyway:defaultSchema}].[AIPromptRun]')
+)
+CREATE INDEX IDX_AUTO_MJ_FKEY_AIPromptRun_ConfigurationID ON [${flyway:defaultSchema}].[AIPromptRun] ([ConfigurationID]);
+
+-- Index for foreign key ParentID in table AIPromptRun
+IF NOT EXISTS (
+    SELECT 1
+    FROM sys.indexes
+    WHERE name = 'IDX_AUTO_MJ_FKEY_AIPromptRun_ParentID' 
+    AND object_id = OBJECT_ID('[${flyway:defaultSchema}].[AIPromptRun]')
+)
+CREATE INDEX IDX_AUTO_MJ_FKEY_AIPromptRun_ParentID ON [${flyway:defaultSchema}].[AIPromptRun] ([ParentID]);
+
+-- Index for foreign key AgentRunID in table AIPromptRun
+IF NOT EXISTS (
+    SELECT 1
+    FROM sys.indexes
+    WHERE name = 'IDX_AUTO_MJ_FKEY_AIPromptRun_AgentRunID' 
+    AND object_id = OBJECT_ID('[${flyway:defaultSchema}].[AIPromptRun]')
+)
+CREATE INDEX IDX_AUTO_MJ_FKEY_AIPromptRun_AgentRunID ON [${flyway:defaultSchema}].[AIPromptRun] ([AgentRunID]);
+
+-- Index for foreign key OriginalModelID in table AIPromptRun
+IF NOT EXISTS (
+    SELECT 1
+    FROM sys.indexes
+    WHERE name = 'IDX_AUTO_MJ_FKEY_AIPromptRun_OriginalModelID' 
+    AND object_id = OBJECT_ID('[${flyway:defaultSchema}].[AIPromptRun]')
+)
+CREATE INDEX IDX_AUTO_MJ_FKEY_AIPromptRun_OriginalModelID ON [${flyway:defaultSchema}].[AIPromptRun] ([OriginalModelID]);
+
+-- Index for foreign key RerunFromPromptRunID in table AIPromptRun
+IF NOT EXISTS (
+    SELECT 1
+    FROM sys.indexes
+    WHERE name = 'IDX_AUTO_MJ_FKEY_AIPromptRun_RerunFromPromptRunID' 
+    AND object_id = OBJECT_ID('[${flyway:defaultSchema}].[AIPromptRun]')
+)
+CREATE INDEX IDX_AUTO_MJ_FKEY_AIPromptRun_RerunFromPromptRunID ON [${flyway:defaultSchema}].[AIPromptRun] ([RerunFromPromptRunID]);
+
+-- Index for foreign key JudgeID in table AIPromptRun
+IF NOT EXISTS (
+    SELECT 1
+    FROM sys.indexes
+    WHERE name = 'IDX_AUTO_MJ_FKEY_AIPromptRun_JudgeID' 
+    AND object_id = OBJECT_ID('[${flyway:defaultSchema}].[AIPromptRun]')
+)
+CREATE INDEX IDX_AUTO_MJ_FKEY_AIPromptRun_JudgeID ON [${flyway:defaultSchema}].[AIPromptRun] ([JudgeID]);
+
+-- Index for foreign key ChildPromptID in table AIPromptRun
+IF NOT EXISTS (
+    SELECT 1
+    FROM sys.indexes
+    WHERE name = 'IDX_AUTO_MJ_FKEY_AIPromptRun_ChildPromptID' 
+    AND object_id = OBJECT_ID('[${flyway:defaultSchema}].[AIPromptRun]')
+)
+CREATE INDEX IDX_AUTO_MJ_FKEY_AIPromptRun_ChildPromptID ON [${flyway:defaultSchema}].[AIPromptRun] ([ChildPromptID]);
+
+/* Base View SQL for MJ: AI Prompt Runs */
+-----------------------------------------------------------------
+-- SQL Code Generation
+-- Entity: MJ: AI Prompt Runs
+-- Item: vwAIPromptRuns
+--
+-- This was generated by the MemberJunction CodeGen tool.
+-- This file should NOT be edited by hand.
+-----------------------------------------------------------------
+
+------------------------------------------------------------
+----- BASE VIEW FOR ENTITY:      MJ: AI Prompt Runs
+-----               SCHEMA:      ${flyway:defaultSchema}
+-----               BASE TABLE:  AIPromptRun
+-----               PRIMARY KEY: ID
+------------------------------------------------------------
+DROP VIEW IF EXISTS [${flyway:defaultSchema}].[vwAIPromptRuns]
+GO
+
+CREATE VIEW [${flyway:defaultSchema}].[vwAIPromptRuns]
+AS
+SELECT
+    a.*,
+    AIPrompt_PromptID.[Name] AS [Prompt],
+    AIModel_ModelID.[Name] AS [Model],
+    AIVendor_VendorID.[Name] AS [Vendor],
+    AIAgent_AgentID.[Name] AS [Agent],
+    AIConfiguration_ConfigurationID.[Name] AS [Configuration],
+    AIModel_OriginalModelID.[Name] AS [OriginalModel],
+    AIPrompt_JudgeID.[Name] AS [Judge],
+    AIPrompt_ChildPromptID.[Name] AS [ChildPrompt]
+FROM
+    [${flyway:defaultSchema}].[AIPromptRun] AS a
+INNER JOIN
+    [${flyway:defaultSchema}].[AIPrompt] AS AIPrompt_PromptID
+  ON
+    [a].[PromptID] = AIPrompt_PromptID.[ID]
+INNER JOIN
+    [${flyway:defaultSchema}].[AIModel] AS AIModel_ModelID
+  ON
+    [a].[ModelID] = AIModel_ModelID.[ID]
+INNER JOIN
+    [${flyway:defaultSchema}].[AIVendor] AS AIVendor_VendorID
+  ON
+    [a].[VendorID] = AIVendor_VendorID.[ID]
+LEFT OUTER JOIN
+    [${flyway:defaultSchema}].[AIAgent] AS AIAgent_AgentID
+  ON
+    [a].[AgentID] = AIAgent_AgentID.[ID]
+LEFT OUTER JOIN
+    [${flyway:defaultSchema}].[AIConfiguration] AS AIConfiguration_ConfigurationID
+  ON
+    [a].[ConfigurationID] = AIConfiguration_ConfigurationID.[ID]
+LEFT OUTER JOIN
+    [${flyway:defaultSchema}].[AIModel] AS AIModel_OriginalModelID
+  ON
+    [a].[OriginalModelID] = AIModel_OriginalModelID.[ID]
+LEFT OUTER JOIN
+    [${flyway:defaultSchema}].[AIPrompt] AS AIPrompt_JudgeID
+  ON
+    [a].[JudgeID] = AIPrompt_JudgeID.[ID]
+LEFT OUTER JOIN
+    [${flyway:defaultSchema}].[AIPrompt] AS AIPrompt_ChildPromptID
+  ON
+    [a].[ChildPromptID] = AIPrompt_ChildPromptID.[ID]
+GO
+GRANT SELECT ON [${flyway:defaultSchema}].[vwAIPromptRuns] TO [cdp_UI], [cdp_Developer], [cdp_Integration]
+    
+
+/* Base View Permissions SQL for MJ: AI Prompt Runs */
+-----------------------------------------------------------------
+-- SQL Code Generation
+-- Entity: MJ: AI Prompt Runs
+-- Item: Permissions for vwAIPromptRuns
+--
+-- This was generated by the MemberJunction CodeGen tool.
+-- This file should NOT be edited by hand.
+-----------------------------------------------------------------
+
+GRANT SELECT ON [${flyway:defaultSchema}].[vwAIPromptRuns] TO [cdp_UI], [cdp_Developer], [cdp_Integration]
+
+/* spCreate SQL for MJ: AI Prompt Runs */
+-----------------------------------------------------------------
+-- SQL Code Generation
+-- Entity: MJ: AI Prompt Runs
+-- Item: spCreateAIPromptRun
+--
+-- This was generated by the MemberJunction CodeGen tool.
+-- This file should NOT be edited by hand.
+-----------------------------------------------------------------
+
+------------------------------------------------------------
+----- CREATE PROCEDURE FOR AIPromptRun
+------------------------------------------------------------
+DROP PROCEDURE IF EXISTS [${flyway:defaultSchema}].[spCreateAIPromptRun]
+GO
+
+CREATE PROCEDURE [${flyway:defaultSchema}].[spCreateAIPromptRun]
+    @ID uniqueidentifier = NULL,
+    @PromptID uniqueidentifier,
+    @ModelID uniqueidentifier,
+    @VendorID uniqueidentifier,
+    @AgentID uniqueidentifier,
+    @ConfigurationID uniqueidentifier,
+    @RunAt datetimeoffset,
+    @CompletedAt datetimeoffset,
+    @ExecutionTimeMS int,
+    @Messages nvarchar(MAX),
+    @Result nvarchar(MAX),
+    @TokensUsed int,
+    @TokensPrompt int,
+    @TokensCompletion int,
+    @TotalCost decimal(18, 6),
+    @Success bit,
+    @ErrorMessage nvarchar(MAX),
+    @ParentID uniqueidentifier,
+    @RunType nvarchar(20),
+    @ExecutionOrder int,
+    @AgentRunID uniqueidentifier,
+    @Cost decimal(19, 8),
+    @CostCurrency nvarchar(10),
+    @TokensUsedRollup int,
+    @TokensPromptRollup int,
+    @TokensCompletionRollup int,
+    @Temperature decimal(3, 2),
+    @TopP decimal(3, 2),
+    @TopK int,
+    @MinP decimal(3, 2),
+    @FrequencyPenalty decimal(3, 2),
+    @PresencePenalty decimal(3, 2),
+    @Seed int,
+    @StopSequences nvarchar(MAX),
+    @ResponseFormat nvarchar(50),
+    @LogProbs bit,
+    @TopLogProbs int,
+    @DescendantCost decimal(18, 6),
+    @ValidationAttemptCount int,
+    @SuccessfulValidationCount int,
+    @FinalValidationPassed bit,
+    @ValidationBehavior nvarchar(50),
+    @RetryStrategy nvarchar(50),
+    @MaxRetriesConfigured int,
+    @FinalValidationError nvarchar(500),
+    @ValidationErrorCount int,
+    @CommonValidationError nvarchar(255),
+    @FirstAttemptAt datetime,
+    @LastAttemptAt datetime,
+    @TotalRetryDurationMS int,
+    @ValidationAttempts nvarchar(MAX),
+    @ValidationSummary nvarchar(MAX),
+    @FailoverAttempts int,
+    @FailoverErrors nvarchar(MAX),
+    @FailoverDurations nvarchar(MAX),
+    @OriginalModelID uniqueidentifier,
+    @OriginalRequestStartTime datetime,
+    @TotalFailoverDuration int,
+    @RerunFromPromptRunID uniqueidentifier,
+    @ModelSelection nvarchar(MAX),
+    @Status nvarchar(50),
+    @Cancelled bit,
+    @CancellationReason nvarchar(MAX),
+    @ModelPowerRank int,
+    @SelectionStrategy nvarchar(50),
+    @CacheHit bit,
+    @CacheKey nvarchar(500),
+    @JudgeID uniqueidentifier,
+    @JudgeScore float(53),
+    @WasSelectedResult bit,
+    @StreamingEnabled bit,
+    @FirstTokenTime int,
+    @ErrorDetails nvarchar(MAX),
+    @ChildPromptID uniqueidentifier,
+    @QueueTime int,
+    @PromptTime int,
+    @CompletionTime int,
+    @ModelSpecificResponseDetails nvarchar(MAX),
+    @EffortLevel int
+AS
+BEGIN
+    SET NOCOUNT ON;
+    DECLARE @InsertedRow TABLE ([ID] UNIQUEIDENTIFIER)
+    
+    IF @ID IS NOT NULL
+    BEGIN
+        -- User provided a value, use it
+        INSERT INTO [${flyway:defaultSchema}].[AIPromptRun]
+            (
+                [ID],
+                [PromptID],
+                [ModelID],
+                [VendorID],
+                [AgentID],
+                [ConfigurationID],
+                [RunAt],
+                [CompletedAt],
+                [ExecutionTimeMS],
+                [Messages],
+                [Result],
+                [TokensUsed],
+                [TokensPrompt],
+                [TokensCompletion],
+                [TotalCost],
+                [Success],
+                [ErrorMessage],
+                [ParentID],
+                [RunType],
+                [ExecutionOrder],
+                [AgentRunID],
+                [Cost],
+                [CostCurrency],
+                [TokensUsedRollup],
+                [TokensPromptRollup],
+                [TokensCompletionRollup],
+                [Temperature],
+                [TopP],
+                [TopK],
+                [MinP],
+                [FrequencyPenalty],
+                [PresencePenalty],
+                [Seed],
+                [StopSequences],
+                [ResponseFormat],
+                [LogProbs],
+                [TopLogProbs],
+                [DescendantCost],
+                [ValidationAttemptCount],
+                [SuccessfulValidationCount],
+                [FinalValidationPassed],
+                [ValidationBehavior],
+                [RetryStrategy],
+                [MaxRetriesConfigured],
+                [FinalValidationError],
+                [ValidationErrorCount],
+                [CommonValidationError],
+                [FirstAttemptAt],
+                [LastAttemptAt],
+                [TotalRetryDurationMS],
+                [ValidationAttempts],
+                [ValidationSummary],
+                [FailoverAttempts],
+                [FailoverErrors],
+                [FailoverDurations],
+                [OriginalModelID],
+                [OriginalRequestStartTime],
+                [TotalFailoverDuration],
+                [RerunFromPromptRunID],
+                [ModelSelection],
+                [Status],
+                [Cancelled],
+                [CancellationReason],
+                [ModelPowerRank],
+                [SelectionStrategy],
+                [CacheHit],
+                [CacheKey],
+                [JudgeID],
+                [JudgeScore],
+                [WasSelectedResult],
+                [StreamingEnabled],
+                [FirstTokenTime],
+                [ErrorDetails],
+                [ChildPromptID],
+                [QueueTime],
+                [PromptTime],
+                [CompletionTime],
+                [ModelSpecificResponseDetails],
+                [EffortLevel]
+            )
+        OUTPUT INSERTED.[ID] INTO @InsertedRow
+        VALUES
+            (
+                @ID,
+                @PromptID,
+                @ModelID,
+                @VendorID,
+                @AgentID,
+                @ConfigurationID,
+                @RunAt,
+                @CompletedAt,
+                @ExecutionTimeMS,
+                @Messages,
+                @Result,
+                @TokensUsed,
+                @TokensPrompt,
+                @TokensCompletion,
+                @TotalCost,
+                @Success,
+                @ErrorMessage,
+                @ParentID,
+                @RunType,
+                @ExecutionOrder,
+                @AgentRunID,
+                @Cost,
+                @CostCurrency,
+                @TokensUsedRollup,
+                @TokensPromptRollup,
+                @TokensCompletionRollup,
+                @Temperature,
+                @TopP,
+                @TopK,
+                @MinP,
+                @FrequencyPenalty,
+                @PresencePenalty,
+                @Seed,
+                @StopSequences,
+                @ResponseFormat,
+                @LogProbs,
+                @TopLogProbs,
+                @DescendantCost,
+                @ValidationAttemptCount,
+                @SuccessfulValidationCount,
+                @FinalValidationPassed,
+                @ValidationBehavior,
+                @RetryStrategy,
+                @MaxRetriesConfigured,
+                @FinalValidationError,
+                @ValidationErrorCount,
+                @CommonValidationError,
+                @FirstAttemptAt,
+                @LastAttemptAt,
+                @TotalRetryDurationMS,
+                @ValidationAttempts,
+                @ValidationSummary,
+                @FailoverAttempts,
+                @FailoverErrors,
+                @FailoverDurations,
+                @OriginalModelID,
+                @OriginalRequestStartTime,
+                @TotalFailoverDuration,
+                @RerunFromPromptRunID,
+                @ModelSelection,
+                @Status,
+                @Cancelled,
+                @CancellationReason,
+                @ModelPowerRank,
+                @SelectionStrategy,
+                @CacheHit,
+                @CacheKey,
+                @JudgeID,
+                @JudgeScore,
+                @WasSelectedResult,
+                @StreamingEnabled,
+                @FirstTokenTime,
+                @ErrorDetails,
+                @ChildPromptID,
+                @QueueTime,
+                @PromptTime,
+                @CompletionTime,
+                @ModelSpecificResponseDetails,
+                @EffortLevel
+            )
+    END
+    ELSE
+    BEGIN
+        -- No value provided, let database use its default (e.g., NEWSEQUENTIALID())
+        INSERT INTO [${flyway:defaultSchema}].[AIPromptRun]
+            (
+                [PromptID],
+                [ModelID],
+                [VendorID],
+                [AgentID],
+                [ConfigurationID],
+                [RunAt],
+                [CompletedAt],
+                [ExecutionTimeMS],
+                [Messages],
+                [Result],
+                [TokensUsed],
+                [TokensPrompt],
+                [TokensCompletion],
+                [TotalCost],
+                [Success],
+                [ErrorMessage],
+                [ParentID],
+                [RunType],
+                [ExecutionOrder],
+                [AgentRunID],
+                [Cost],
+                [CostCurrency],
+                [TokensUsedRollup],
+                [TokensPromptRollup],
+                [TokensCompletionRollup],
+                [Temperature],
+                [TopP],
+                [TopK],
+                [MinP],
+                [FrequencyPenalty],
+                [PresencePenalty],
+                [Seed],
+                [StopSequences],
+                [ResponseFormat],
+                [LogProbs],
+                [TopLogProbs],
+                [DescendantCost],
+                [ValidationAttemptCount],
+                [SuccessfulValidationCount],
+                [FinalValidationPassed],
+                [ValidationBehavior],
+                [RetryStrategy],
+                [MaxRetriesConfigured],
+                [FinalValidationError],
+                [ValidationErrorCount],
+                [CommonValidationError],
+                [FirstAttemptAt],
+                [LastAttemptAt],
+                [TotalRetryDurationMS],
+                [ValidationAttempts],
+                [ValidationSummary],
+                [FailoverAttempts],
+                [FailoverErrors],
+                [FailoverDurations],
+                [OriginalModelID],
+                [OriginalRequestStartTime],
+                [TotalFailoverDuration],
+                [RerunFromPromptRunID],
+                [ModelSelection],
+                [Status],
+                [Cancelled],
+                [CancellationReason],
+                [ModelPowerRank],
+                [SelectionStrategy],
+                [CacheHit],
+                [CacheKey],
+                [JudgeID],
+                [JudgeScore],
+                [WasSelectedResult],
+                [StreamingEnabled],
+                [FirstTokenTime],
+                [ErrorDetails],
+                [ChildPromptID],
+                [QueueTime],
+                [PromptTime],
+                [CompletionTime],
+                [ModelSpecificResponseDetails],
+                [EffortLevel]
+            )
+        OUTPUT INSERTED.[ID] INTO @InsertedRow
+        VALUES
+            (
+                @PromptID,
+                @ModelID,
+                @VendorID,
+                @AgentID,
+                @ConfigurationID,
+                @RunAt,
+                @CompletedAt,
+                @ExecutionTimeMS,
+                @Messages,
+                @Result,
+                @TokensUsed,
+                @TokensPrompt,
+                @TokensCompletion,
+                @TotalCost,
+                @Success,
+                @ErrorMessage,
+                @ParentID,
+                @RunType,
+                @ExecutionOrder,
+                @AgentRunID,
+                @Cost,
+                @CostCurrency,
+                @TokensUsedRollup,
+                @TokensPromptRollup,
+                @TokensCompletionRollup,
+                @Temperature,
+                @TopP,
+                @TopK,
+                @MinP,
+                @FrequencyPenalty,
+                @PresencePenalty,
+                @Seed,
+                @StopSequences,
+                @ResponseFormat,
+                @LogProbs,
+                @TopLogProbs,
+                @DescendantCost,
+                @ValidationAttemptCount,
+                @SuccessfulValidationCount,
+                @FinalValidationPassed,
+                @ValidationBehavior,
+                @RetryStrategy,
+                @MaxRetriesConfigured,
+                @FinalValidationError,
+                @ValidationErrorCount,
+                @CommonValidationError,
+                @FirstAttemptAt,
+                @LastAttemptAt,
+                @TotalRetryDurationMS,
+                @ValidationAttempts,
+                @ValidationSummary,
+                @FailoverAttempts,
+                @FailoverErrors,
+                @FailoverDurations,
+                @OriginalModelID,
+                @OriginalRequestStartTime,
+                @TotalFailoverDuration,
+                @RerunFromPromptRunID,
+                @ModelSelection,
+                @Status,
+                @Cancelled,
+                @CancellationReason,
+                @ModelPowerRank,
+                @SelectionStrategy,
+                @CacheHit,
+                @CacheKey,
+                @JudgeID,
+                @JudgeScore,
+                @WasSelectedResult,
+                @StreamingEnabled,
+                @FirstTokenTime,
+                @ErrorDetails,
+                @ChildPromptID,
+                @QueueTime,
+                @PromptTime,
+                @CompletionTime,
+                @ModelSpecificResponseDetails,
+                @EffortLevel
+            )
+    END
+    -- return the new record from the base view, which might have some calculated fields
+    SELECT * FROM [${flyway:defaultSchema}].[vwAIPromptRuns] WHERE [ID] = (SELECT [ID] FROM @InsertedRow)
+END
+GO
+GRANT EXECUTE ON [${flyway:defaultSchema}].[spCreateAIPromptRun] TO [cdp_Developer], [cdp_Integration]
+    
+
+/* spCreate Permissions for MJ: AI Prompt Runs */
+
+GRANT EXECUTE ON [${flyway:defaultSchema}].[spCreateAIPromptRun] TO [cdp_Developer], [cdp_Integration]
+
+
+
+/* spUpdate SQL for MJ: AI Prompt Runs */
+-----------------------------------------------------------------
+-- SQL Code Generation
+-- Entity: MJ: AI Prompt Runs
+-- Item: spUpdateAIPromptRun
+--
+-- This was generated by the MemberJunction CodeGen tool.
+-- This file should NOT be edited by hand.
+-----------------------------------------------------------------
+
+------------------------------------------------------------
+----- UPDATE PROCEDURE FOR AIPromptRun
+------------------------------------------------------------
+DROP PROCEDURE IF EXISTS [${flyway:defaultSchema}].[spUpdateAIPromptRun]
+GO
+
+CREATE PROCEDURE [${flyway:defaultSchema}].[spUpdateAIPromptRun]
+    @ID uniqueidentifier,
+    @PromptID uniqueidentifier,
+    @ModelID uniqueidentifier,
+    @VendorID uniqueidentifier,
+    @AgentID uniqueidentifier,
+    @ConfigurationID uniqueidentifier,
+    @RunAt datetimeoffset,
+    @CompletedAt datetimeoffset,
+    @ExecutionTimeMS int,
+    @Messages nvarchar(MAX),
+    @Result nvarchar(MAX),
+    @TokensUsed int,
+    @TokensPrompt int,
+    @TokensCompletion int,
+    @TotalCost decimal(18, 6),
+    @Success bit,
+    @ErrorMessage nvarchar(MAX),
+    @ParentID uniqueidentifier,
+    @RunType nvarchar(20),
+    @ExecutionOrder int,
+    @AgentRunID uniqueidentifier,
+    @Cost decimal(19, 8),
+    @CostCurrency nvarchar(10),
+    @TokensUsedRollup int,
+    @TokensPromptRollup int,
+    @TokensCompletionRollup int,
+    @Temperature decimal(3, 2),
+    @TopP decimal(3, 2),
+    @TopK int,
+    @MinP decimal(3, 2),
+    @FrequencyPenalty decimal(3, 2),
+    @PresencePenalty decimal(3, 2),
+    @Seed int,
+    @StopSequences nvarchar(MAX),
+    @ResponseFormat nvarchar(50),
+    @LogProbs bit,
+    @TopLogProbs int,
+    @DescendantCost decimal(18, 6),
+    @ValidationAttemptCount int,
+    @SuccessfulValidationCount int,
+    @FinalValidationPassed bit,
+    @ValidationBehavior nvarchar(50),
+    @RetryStrategy nvarchar(50),
+    @MaxRetriesConfigured int,
+    @FinalValidationError nvarchar(500),
+    @ValidationErrorCount int,
+    @CommonValidationError nvarchar(255),
+    @FirstAttemptAt datetime,
+    @LastAttemptAt datetime,
+    @TotalRetryDurationMS int,
+    @ValidationAttempts nvarchar(MAX),
+    @ValidationSummary nvarchar(MAX),
+    @FailoverAttempts int,
+    @FailoverErrors nvarchar(MAX),
+    @FailoverDurations nvarchar(MAX),
+    @OriginalModelID uniqueidentifier,
+    @OriginalRequestStartTime datetime,
+    @TotalFailoverDuration int,
+    @RerunFromPromptRunID uniqueidentifier,
+    @ModelSelection nvarchar(MAX),
+    @Status nvarchar(50),
+    @Cancelled bit,
+    @CancellationReason nvarchar(MAX),
+    @ModelPowerRank int,
+    @SelectionStrategy nvarchar(50),
+    @CacheHit bit,
+    @CacheKey nvarchar(500),
+    @JudgeID uniqueidentifier,
+    @JudgeScore float(53),
+    @WasSelectedResult bit,
+    @StreamingEnabled bit,
+    @FirstTokenTime int,
+    @ErrorDetails nvarchar(MAX),
+    @ChildPromptID uniqueidentifier,
+    @QueueTime int,
+    @PromptTime int,
+    @CompletionTime int,
+    @ModelSpecificResponseDetails nvarchar(MAX),
+    @EffortLevel int
+AS
+BEGIN
+    SET NOCOUNT ON;
+    UPDATE
+        [${flyway:defaultSchema}].[AIPromptRun]
+    SET
+        [PromptID] = @PromptID,
+        [ModelID] = @ModelID,
+        [VendorID] = @VendorID,
+        [AgentID] = @AgentID,
+        [ConfigurationID] = @ConfigurationID,
+        [RunAt] = @RunAt,
+        [CompletedAt] = @CompletedAt,
+        [ExecutionTimeMS] = @ExecutionTimeMS,
+        [Messages] = @Messages,
+        [Result] = @Result,
+        [TokensUsed] = @TokensUsed,
+        [TokensPrompt] = @TokensPrompt,
+        [TokensCompletion] = @TokensCompletion,
+        [TotalCost] = @TotalCost,
+        [Success] = @Success,
+        [ErrorMessage] = @ErrorMessage,
+        [ParentID] = @ParentID,
+        [RunType] = @RunType,
+        [ExecutionOrder] = @ExecutionOrder,
+        [AgentRunID] = @AgentRunID,
+        [Cost] = @Cost,
+        [CostCurrency] = @CostCurrency,
+        [TokensUsedRollup] = @TokensUsedRollup,
+        [TokensPromptRollup] = @TokensPromptRollup,
+        [TokensCompletionRollup] = @TokensCompletionRollup,
+        [Temperature] = @Temperature,
+        [TopP] = @TopP,
+        [TopK] = @TopK,
+        [MinP] = @MinP,
+        [FrequencyPenalty] = @FrequencyPenalty,
+        [PresencePenalty] = @PresencePenalty,
+        [Seed] = @Seed,
+        [StopSequences] = @StopSequences,
+        [ResponseFormat] = @ResponseFormat,
+        [LogProbs] = @LogProbs,
+        [TopLogProbs] = @TopLogProbs,
+        [DescendantCost] = @DescendantCost,
+        [ValidationAttemptCount] = @ValidationAttemptCount,
+        [SuccessfulValidationCount] = @SuccessfulValidationCount,
+        [FinalValidationPassed] = @FinalValidationPassed,
+        [ValidationBehavior] = @ValidationBehavior,
+        [RetryStrategy] = @RetryStrategy,
+        [MaxRetriesConfigured] = @MaxRetriesConfigured,
+        [FinalValidationError] = @FinalValidationError,
+        [ValidationErrorCount] = @ValidationErrorCount,
+        [CommonValidationError] = @CommonValidationError,
+        [FirstAttemptAt] = @FirstAttemptAt,
+        [LastAttemptAt] = @LastAttemptAt,
+        [TotalRetryDurationMS] = @TotalRetryDurationMS,
+        [ValidationAttempts] = @ValidationAttempts,
+        [ValidationSummary] = @ValidationSummary,
+        [FailoverAttempts] = @FailoverAttempts,
+        [FailoverErrors] = @FailoverErrors,
+        [FailoverDurations] = @FailoverDurations,
+        [OriginalModelID] = @OriginalModelID,
+        [OriginalRequestStartTime] = @OriginalRequestStartTime,
+        [TotalFailoverDuration] = @TotalFailoverDuration,
+        [RerunFromPromptRunID] = @RerunFromPromptRunID,
+        [ModelSelection] = @ModelSelection,
+        [Status] = @Status,
+        [Cancelled] = @Cancelled,
+        [CancellationReason] = @CancellationReason,
+        [ModelPowerRank] = @ModelPowerRank,
+        [SelectionStrategy] = @SelectionStrategy,
+        [CacheHit] = @CacheHit,
+        [CacheKey] = @CacheKey,
+        [JudgeID] = @JudgeID,
+        [JudgeScore] = @JudgeScore,
+        [WasSelectedResult] = @WasSelectedResult,
+        [StreamingEnabled] = @StreamingEnabled,
+        [FirstTokenTime] = @FirstTokenTime,
+        [ErrorDetails] = @ErrorDetails,
+        [ChildPromptID] = @ChildPromptID,
+        [QueueTime] = @QueueTime,
+        [PromptTime] = @PromptTime,
+        [CompletionTime] = @CompletionTime,
+        [ModelSpecificResponseDetails] = @ModelSpecificResponseDetails,
+        [EffortLevel] = @EffortLevel
+    WHERE
+        [ID] = @ID
+
+    -- Check if the update was successful
+    IF @@ROWCOUNT = 0
+        -- Nothing was updated, return no rows, but column structure from base view intact, semantically correct this way.
+        SELECT TOP 0 * FROM [${flyway:defaultSchema}].[vwAIPromptRuns] WHERE 1=0
+    ELSE
+        -- Return the updated record so the caller can see the updated values and any calculated fields
+        SELECT
+                                        *
+                                    FROM
+                                        [${flyway:defaultSchema}].[vwAIPromptRuns]
+                                    WHERE
+                                        [ID] = @ID
+                                    
+END
+GO
+
+GRANT EXECUTE ON [${flyway:defaultSchema}].[spUpdateAIPromptRun] TO [cdp_Developer], [cdp_Integration]
+GO
+
+------------------------------------------------------------
+----- TRIGGER FOR __mj_UpdatedAt field for the AIPromptRun table
+------------------------------------------------------------
+DROP TRIGGER IF EXISTS [${flyway:defaultSchema}].trgUpdateAIPromptRun
+GO
+CREATE TRIGGER [${flyway:defaultSchema}].trgUpdateAIPromptRun
+ON [${flyway:defaultSchema}].[AIPromptRun]
+AFTER UPDATE
+AS
+BEGIN
+    SET NOCOUNT ON;
+    UPDATE
+        [${flyway:defaultSchema}].[AIPromptRun]
+    SET
+        __mj_UpdatedAt = GETUTCDATE()
+    FROM
+        [${flyway:defaultSchema}].[AIPromptRun] AS _organicTable
+    INNER JOIN
+        INSERTED AS I ON
+        _organicTable.[ID] = I.[ID];
+END;
+GO
+        
+
+/* spUpdate Permissions for MJ: AI Prompt Runs */
+
+GRANT EXECUTE ON [${flyway:defaultSchema}].[spUpdateAIPromptRun] TO [cdp_Developer], [cdp_Integration]
+
+
+
+/* spDelete Permissions for MJ: AI Prompt Runs */
+
+GRANT EXECUTE ON [${flyway:defaultSchema}].[spDeleteAIPromptRun] TO [cdp_Developer], [cdp_Integration]
+
+
+
+/* spDelete SQL for Conversation Details */
+-----------------------------------------------------------------
+-- SQL Code Generation
+-- Entity: Conversation Details
+-- Item: spDeleteConversationDetail
+--
+-- This was generated by the MemberJunction CodeGen tool.
+-- This file should NOT be edited by hand.
+-----------------------------------------------------------------
+
+------------------------------------------------------------
+----- DELETE PROCEDURE FOR ConversationDetail
+------------------------------------------------------------
+DROP PROCEDURE IF EXISTS [${flyway:defaultSchema}].[spDeleteConversationDetail]
+GO
+
+CREATE PROCEDURE [${flyway:defaultSchema}].[spDeleteConversationDetail]
+    @ID uniqueidentifier
+AS
+BEGIN
+    SET NOCOUNT ON;
+    -- Cascade update on AIAgentRun using cursor to call spUpdateAIAgentRun
+    DECLARE @MJ_AIAgentRunsID uniqueidentifier
+    DECLARE @MJ_AIAgentRuns_AgentID uniqueidentifier
+    DECLARE @MJ_AIAgentRuns_ParentRunID uniqueidentifier
+    DECLARE @MJ_AIAgentRuns_Status nvarchar(50)
+    DECLARE @MJ_AIAgentRuns_StartedAt datetimeoffset
+    DECLARE @MJ_AIAgentRuns_CompletedAt datetimeoffset
+    DECLARE @MJ_AIAgentRuns_Success bit
+    DECLARE @MJ_AIAgentRuns_ErrorMessage nvarchar(MAX)
+    DECLARE @MJ_AIAgentRuns_ConversationID uniqueidentifier
+    DECLARE @MJ_AIAgentRuns_UserID uniqueidentifier
+    DECLARE @MJ_AIAgentRuns_Result nvarchar(MAX)
+    DECLARE @MJ_AIAgentRuns_AgentState nvarchar(MAX)
+    DECLARE @MJ_AIAgentRuns_TotalTokensUsed int
+    DECLARE @MJ_AIAgentRuns_TotalCost decimal(18, 6)
+    DECLARE @MJ_AIAgentRuns_TotalPromptTokensUsed int
+    DECLARE @MJ_AIAgentRuns_TotalCompletionTokensUsed int
+    DECLARE @MJ_AIAgentRuns_TotalTokensUsedRollup int
+    DECLARE @MJ_AIAgentRuns_TotalPromptTokensUsedRollup int
+    DECLARE @MJ_AIAgentRuns_TotalCompletionTokensUsedRollup int
+    DECLARE @MJ_AIAgentRuns_TotalCostRollup decimal(19, 8)
+    DECLARE @MJ_AIAgentRuns_ConversationDetailID uniqueidentifier
+    DECLARE @MJ_AIAgentRuns_ConversationDetailSequence int
+    DECLARE @MJ_AIAgentRuns_CancellationReason nvarchar(30)
+    DECLARE @MJ_AIAgentRuns_FinalStep nvarchar(30)
+    DECLARE @MJ_AIAgentRuns_FinalPayload nvarchar(MAX)
+    DECLARE @MJ_AIAgentRuns_Message nvarchar(MAX)
+    DECLARE @MJ_AIAgentRuns_LastRunID uniqueidentifier
+    DECLARE @MJ_AIAgentRuns_StartingPayload nvarchar(MAX)
+    DECLARE @MJ_AIAgentRuns_TotalPromptIterations int
+    DECLARE @MJ_AIAgentRuns_ConfigurationID uniqueidentifier
+    DECLARE @MJ_AIAgentRuns_OverrideModelID uniqueidentifier
+    DECLARE @MJ_AIAgentRuns_OverrideVendorID uniqueidentifier
+    DECLARE @MJ_AIAgentRuns_Data nvarchar(MAX)
+    DECLARE @MJ_AIAgentRuns_Verbose bit
+    DECLARE @MJ_AIAgentRuns_EffortLevel int
+    DECLARE cascade_update_MJ_AIAgentRuns_cursor CURSOR FOR 
+        SELECT [ID], [AgentID], [ParentRunID], [Status], [StartedAt], [CompletedAt], [Success], [ErrorMessage], [ConversationID], [UserID], [Result], [AgentState], [TotalTokensUsed], [TotalCost], [TotalPromptTokensUsed], [TotalCompletionTokensUsed], [TotalTokensUsedRollup], [TotalPromptTokensUsedRollup], [TotalCompletionTokensUsedRollup], [TotalCostRollup], [ConversationDetailID], [ConversationDetailSequence], [CancellationReason], [FinalStep], [FinalPayload], [Message], [LastRunID], [StartingPayload], [TotalPromptIterations], [ConfigurationID], [OverrideModelID], [OverrideVendorID], [Data], [Verbose], [EffortLevel]
+        FROM [${flyway:defaultSchema}].[AIAgentRun]
+        WHERE [ConversationDetailID] = @ID
+    
+    OPEN cascade_update_MJ_AIAgentRuns_cursor
+    FETCH NEXT FROM cascade_update_MJ_AIAgentRuns_cursor INTO @MJ_AIAgentRunsID, @MJ_AIAgentRuns_AgentID, @MJ_AIAgentRuns_ParentRunID, @MJ_AIAgentRuns_Status, @MJ_AIAgentRuns_StartedAt, @MJ_AIAgentRuns_CompletedAt, @MJ_AIAgentRuns_Success, @MJ_AIAgentRuns_ErrorMessage, @MJ_AIAgentRuns_ConversationID, @MJ_AIAgentRuns_UserID, @MJ_AIAgentRuns_Result, @MJ_AIAgentRuns_AgentState, @MJ_AIAgentRuns_TotalTokensUsed, @MJ_AIAgentRuns_TotalCost, @MJ_AIAgentRuns_TotalPromptTokensUsed, @MJ_AIAgentRuns_TotalCompletionTokensUsed, @MJ_AIAgentRuns_TotalTokensUsedRollup, @MJ_AIAgentRuns_TotalPromptTokensUsedRollup, @MJ_AIAgentRuns_TotalCompletionTokensUsedRollup, @MJ_AIAgentRuns_TotalCostRollup, @MJ_AIAgentRuns_ConversationDetailID, @MJ_AIAgentRuns_ConversationDetailSequence, @MJ_AIAgentRuns_CancellationReason, @MJ_AIAgentRuns_FinalStep, @MJ_AIAgentRuns_FinalPayload, @MJ_AIAgentRuns_Message, @MJ_AIAgentRuns_LastRunID, @MJ_AIAgentRuns_StartingPayload, @MJ_AIAgentRuns_TotalPromptIterations, @MJ_AIAgentRuns_ConfigurationID, @MJ_AIAgentRuns_OverrideModelID, @MJ_AIAgentRuns_OverrideVendorID, @MJ_AIAgentRuns_Data, @MJ_AIAgentRuns_Verbose, @MJ_AIAgentRuns_EffortLevel
+    
+    WHILE @@FETCH_STATUS = 0
+    BEGIN
+        -- Set the FK field to NULL
+        SET @MJ_AIAgentRuns_ConversationDetailID = NULL
+        
+        -- Call the update SP for the related entity
+        EXEC [${flyway:defaultSchema}].[spUpdateAIAgentRun] @ID = @MJ_AIAgentRunsID, @AgentID = @MJ_AIAgentRuns_AgentID, @ParentRunID = @MJ_AIAgentRuns_ParentRunID, @Status = @MJ_AIAgentRuns_Status, @StartedAt = @MJ_AIAgentRuns_StartedAt, @CompletedAt = @MJ_AIAgentRuns_CompletedAt, @Success = @MJ_AIAgentRuns_Success, @ErrorMessage = @MJ_AIAgentRuns_ErrorMessage, @ConversationID = @MJ_AIAgentRuns_ConversationID, @UserID = @MJ_AIAgentRuns_UserID, @Result = @MJ_AIAgentRuns_Result, @AgentState = @MJ_AIAgentRuns_AgentState, @TotalTokensUsed = @MJ_AIAgentRuns_TotalTokensUsed, @TotalCost = @MJ_AIAgentRuns_TotalCost, @TotalPromptTokensUsed = @MJ_AIAgentRuns_TotalPromptTokensUsed, @TotalCompletionTokensUsed = @MJ_AIAgentRuns_TotalCompletionTokensUsed, @TotalTokensUsedRollup = @MJ_AIAgentRuns_TotalTokensUsedRollup, @TotalPromptTokensUsedRollup = @MJ_AIAgentRuns_TotalPromptTokensUsedRollup, @TotalCompletionTokensUsedRollup = @MJ_AIAgentRuns_TotalCompletionTokensUsedRollup, @TotalCostRollup = @MJ_AIAgentRuns_TotalCostRollup, @ConversationDetailID = @MJ_AIAgentRuns_ConversationDetailID, @ConversationDetailSequence = @MJ_AIAgentRuns_ConversationDetailSequence, @CancellationReason = @MJ_AIAgentRuns_CancellationReason, @FinalStep = @MJ_AIAgentRuns_FinalStep, @FinalPayload = @MJ_AIAgentRuns_FinalPayload, @Message = @MJ_AIAgentRuns_Message, @LastRunID = @MJ_AIAgentRuns_LastRunID, @StartingPayload = @MJ_AIAgentRuns_StartingPayload, @TotalPromptIterations = @MJ_AIAgentRuns_TotalPromptIterations, @ConfigurationID = @MJ_AIAgentRuns_ConfigurationID, @OverrideModelID = @MJ_AIAgentRuns_OverrideModelID, @OverrideVendorID = @MJ_AIAgentRuns_OverrideVendorID, @Data = @MJ_AIAgentRuns_Data, @Verbose = @MJ_AIAgentRuns_Verbose, @EffortLevel = @MJ_AIAgentRuns_EffortLevel
+        
+        FETCH NEXT FROM cascade_update_MJ_AIAgentRuns_cursor INTO @MJ_AIAgentRunsID, @MJ_AIAgentRuns_AgentID, @MJ_AIAgentRuns_ParentRunID, @MJ_AIAgentRuns_Status, @MJ_AIAgentRuns_StartedAt, @MJ_AIAgentRuns_CompletedAt, @MJ_AIAgentRuns_Success, @MJ_AIAgentRuns_ErrorMessage, @MJ_AIAgentRuns_ConversationID, @MJ_AIAgentRuns_UserID, @MJ_AIAgentRuns_Result, @MJ_AIAgentRuns_AgentState, @MJ_AIAgentRuns_TotalTokensUsed, @MJ_AIAgentRuns_TotalCost, @MJ_AIAgentRuns_TotalPromptTokensUsed, @MJ_AIAgentRuns_TotalCompletionTokensUsed, @MJ_AIAgentRuns_TotalTokensUsedRollup, @MJ_AIAgentRuns_TotalPromptTokensUsedRollup, @MJ_AIAgentRuns_TotalCompletionTokensUsedRollup, @MJ_AIAgentRuns_TotalCostRollup, @MJ_AIAgentRuns_ConversationDetailID, @MJ_AIAgentRuns_ConversationDetailSequence, @MJ_AIAgentRuns_CancellationReason, @MJ_AIAgentRuns_FinalStep, @MJ_AIAgentRuns_FinalPayload, @MJ_AIAgentRuns_Message, @MJ_AIAgentRuns_LastRunID, @MJ_AIAgentRuns_StartingPayload, @MJ_AIAgentRuns_TotalPromptIterations, @MJ_AIAgentRuns_ConfigurationID, @MJ_AIAgentRuns_OverrideModelID, @MJ_AIAgentRuns_OverrideVendorID, @MJ_AIAgentRuns_Data, @MJ_AIAgentRuns_Verbose, @MJ_AIAgentRuns_EffortLevel
+    END
+    
+    CLOSE cascade_update_MJ_AIAgentRuns_cursor
+    DEALLOCATE cascade_update_MJ_AIAgentRuns_cursor
+    
+    -- Cascade update on Report using cursor to call spUpdateReport
+    DECLARE @ReportsID uniqueidentifier
+    DECLARE @Reports_Name nvarchar(255)
+    DECLARE @Reports_Description nvarchar(MAX)
+    DECLARE @Reports_CategoryID uniqueidentifier
+    DECLARE @Reports_UserID uniqueidentifier
+    DECLARE @Reports_SharingScope nvarchar(20)
+    DECLARE @Reports_ConversationID uniqueidentifier
+    DECLARE @Reports_ConversationDetailID uniqueidentifier
+    DECLARE @Reports_DataContextID uniqueidentifier
+    DECLARE @Reports_Configuration nvarchar(MAX)
+    DECLARE @Reports_OutputTriggerTypeID uniqueidentifier
+    DECLARE @Reports_OutputFormatTypeID uniqueidentifier
+    DECLARE @Reports_OutputDeliveryTypeID uniqueidentifier
+    DECLARE @Reports_OutputFrequency nvarchar(50)
+    DECLARE @Reports_OutputTargetEmail nvarchar(255)
+    DECLARE @Reports_OutputWorkflowID uniqueidentifier
+    DECLARE @Reports_Thumbnail nvarchar(MAX)
+    DECLARE cascade_update_Reports_cursor CURSOR FOR 
+        SELECT [ID], [Name], [Description], [CategoryID], [UserID], [SharingScope], [ConversationID], [ConversationDetailID], [DataContextID], [Configuration], [OutputTriggerTypeID], [OutputFormatTypeID], [OutputDeliveryTypeID], [OutputFrequency], [OutputTargetEmail], [OutputWorkflowID], [Thumbnail]
+        FROM [${flyway:defaultSchema}].[Report]
+        WHERE [ConversationDetailID] = @ID
+    
+    OPEN cascade_update_Reports_cursor
+    FETCH NEXT FROM cascade_update_Reports_cursor INTO @ReportsID, @Reports_Name, @Reports_Description, @Reports_CategoryID, @Reports_UserID, @Reports_SharingScope, @Reports_ConversationID, @Reports_ConversationDetailID, @Reports_DataContextID, @Reports_Configuration, @Reports_OutputTriggerTypeID, @Reports_OutputFormatTypeID, @Reports_OutputDeliveryTypeID, @Reports_OutputFrequency, @Reports_OutputTargetEmail, @Reports_OutputWorkflowID, @Reports_Thumbnail
+    
+    WHILE @@FETCH_STATUS = 0
+    BEGIN
+        -- Set the FK field to NULL
+        SET @Reports_ConversationDetailID = NULL
+        
+        -- Call the update SP for the related entity
+        EXEC [${flyway:defaultSchema}].[spUpdateReport] @ID = @ReportsID, @Name = @Reports_Name, @Description = @Reports_Description, @CategoryID = @Reports_CategoryID, @UserID = @Reports_UserID, @SharingScope = @Reports_SharingScope, @ConversationID = @Reports_ConversationID, @ConversationDetailID = @Reports_ConversationDetailID, @DataContextID = @Reports_DataContextID, @Configuration = @Reports_Configuration, @OutputTriggerTypeID = @Reports_OutputTriggerTypeID, @OutputFormatTypeID = @Reports_OutputFormatTypeID, @OutputDeliveryTypeID = @Reports_OutputDeliveryTypeID, @OutputFrequency = @Reports_OutputFrequency, @OutputTargetEmail = @Reports_OutputTargetEmail, @OutputWorkflowID = @Reports_OutputWorkflowID, @Thumbnail = @Reports_Thumbnail
+        
+        FETCH NEXT FROM cascade_update_Reports_cursor INTO @ReportsID, @Reports_Name, @Reports_Description, @Reports_CategoryID, @Reports_UserID, @Reports_SharingScope, @Reports_ConversationID, @Reports_ConversationDetailID, @Reports_DataContextID, @Reports_Configuration, @Reports_OutputTriggerTypeID, @Reports_OutputFormatTypeID, @Reports_OutputDeliveryTypeID, @Reports_OutputFrequency, @Reports_OutputTargetEmail, @Reports_OutputWorkflowID, @Reports_Thumbnail
+    END
+    
+    CLOSE cascade_update_Reports_cursor
+    DEALLOCATE cascade_update_Reports_cursor
+    
+
+    DELETE FROM
+        [${flyway:defaultSchema}].[ConversationDetail]
+    WHERE
+        [ID] = @ID
+
+
+    -- Check if the delete was successful
+    IF @@ROWCOUNT = 0
+        SELECT NULL AS [ID] -- Return NULL for all primary key fields to indicate no record was deleted
+    ELSE
+        SELECT @ID AS [ID] -- Return the primary key values to indicate we successfully deleted the record
+END
+GO
+GRANT EXECUTE ON [${flyway:defaultSchema}].[spDeleteConversationDetail] TO [cdp_Developer], [cdp_UI], [cdp_Integration]
+    
+
+/* spDelete Permissions for Conversation Details */
+
+GRANT EXECUTE ON [${flyway:defaultSchema}].[spDeleteConversationDetail] TO [cdp_Developer], [cdp_UI], [cdp_Integration]
+
+
+
+/* spDelete SQL for Conversations */
+-----------------------------------------------------------------
+-- SQL Code Generation
+-- Entity: Conversations
+-- Item: spDeleteConversation
+--
+-- This was generated by the MemberJunction CodeGen tool.
+-- This file should NOT be edited by hand.
+-----------------------------------------------------------------
+
+------------------------------------------------------------
+----- DELETE PROCEDURE FOR Conversation
+------------------------------------------------------------
+DROP PROCEDURE IF EXISTS [${flyway:defaultSchema}].[spDeleteConversation]
+GO
+
+CREATE PROCEDURE [${flyway:defaultSchema}].[spDeleteConversation]
+    @ID uniqueidentifier
+AS
+BEGIN
+    SET NOCOUNT ON;
+    -- Cascade update on AIAgentRun using cursor to call spUpdateAIAgentRun
+    DECLARE @MJ_AIAgentRunsID uniqueidentifier
+    DECLARE @MJ_AIAgentRuns_AgentID uniqueidentifier
+    DECLARE @MJ_AIAgentRuns_ParentRunID uniqueidentifier
+    DECLARE @MJ_AIAgentRuns_Status nvarchar(50)
+    DECLARE @MJ_AIAgentRuns_StartedAt datetimeoffset
+    DECLARE @MJ_AIAgentRuns_CompletedAt datetimeoffset
+    DECLARE @MJ_AIAgentRuns_Success bit
+    DECLARE @MJ_AIAgentRuns_ErrorMessage nvarchar(MAX)
+    DECLARE @MJ_AIAgentRuns_ConversationID uniqueidentifier
+    DECLARE @MJ_AIAgentRuns_UserID uniqueidentifier
+    DECLARE @MJ_AIAgentRuns_Result nvarchar(MAX)
+    DECLARE @MJ_AIAgentRuns_AgentState nvarchar(MAX)
+    DECLARE @MJ_AIAgentRuns_TotalTokensUsed int
+    DECLARE @MJ_AIAgentRuns_TotalCost decimal(18, 6)
+    DECLARE @MJ_AIAgentRuns_TotalPromptTokensUsed int
+    DECLARE @MJ_AIAgentRuns_TotalCompletionTokensUsed int
+    DECLARE @MJ_AIAgentRuns_TotalTokensUsedRollup int
+    DECLARE @MJ_AIAgentRuns_TotalPromptTokensUsedRollup int
+    DECLARE @MJ_AIAgentRuns_TotalCompletionTokensUsedRollup int
+    DECLARE @MJ_AIAgentRuns_TotalCostRollup decimal(19, 8)
+    DECLARE @MJ_AIAgentRuns_ConversationDetailID uniqueidentifier
+    DECLARE @MJ_AIAgentRuns_ConversationDetailSequence int
+    DECLARE @MJ_AIAgentRuns_CancellationReason nvarchar(30)
+    DECLARE @MJ_AIAgentRuns_FinalStep nvarchar(30)
+    DECLARE @MJ_AIAgentRuns_FinalPayload nvarchar(MAX)
+    DECLARE @MJ_AIAgentRuns_Message nvarchar(MAX)
+    DECLARE @MJ_AIAgentRuns_LastRunID uniqueidentifier
+    DECLARE @MJ_AIAgentRuns_StartingPayload nvarchar(MAX)
+    DECLARE @MJ_AIAgentRuns_TotalPromptIterations int
+    DECLARE @MJ_AIAgentRuns_ConfigurationID uniqueidentifier
+    DECLARE @MJ_AIAgentRuns_OverrideModelID uniqueidentifier
+    DECLARE @MJ_AIAgentRuns_OverrideVendorID uniqueidentifier
+    DECLARE @MJ_AIAgentRuns_Data nvarchar(MAX)
+    DECLARE @MJ_AIAgentRuns_Verbose bit
+    DECLARE @MJ_AIAgentRuns_EffortLevel int
+    DECLARE cascade_update_MJ_AIAgentRuns_cursor CURSOR FOR 
+        SELECT [ID], [AgentID], [ParentRunID], [Status], [StartedAt], [CompletedAt], [Success], [ErrorMessage], [ConversationID], [UserID], [Result], [AgentState], [TotalTokensUsed], [TotalCost], [TotalPromptTokensUsed], [TotalCompletionTokensUsed], [TotalTokensUsedRollup], [TotalPromptTokensUsedRollup], [TotalCompletionTokensUsedRollup], [TotalCostRollup], [ConversationDetailID], [ConversationDetailSequence], [CancellationReason], [FinalStep], [FinalPayload], [Message], [LastRunID], [StartingPayload], [TotalPromptIterations], [ConfigurationID], [OverrideModelID], [OverrideVendorID], [Data], [Verbose], [EffortLevel]
+        FROM [${flyway:defaultSchema}].[AIAgentRun]
+        WHERE [ConversationID] = @ID
+    
+    OPEN cascade_update_MJ_AIAgentRuns_cursor
+    FETCH NEXT FROM cascade_update_MJ_AIAgentRuns_cursor INTO @MJ_AIAgentRunsID, @MJ_AIAgentRuns_AgentID, @MJ_AIAgentRuns_ParentRunID, @MJ_AIAgentRuns_Status, @MJ_AIAgentRuns_StartedAt, @MJ_AIAgentRuns_CompletedAt, @MJ_AIAgentRuns_Success, @MJ_AIAgentRuns_ErrorMessage, @MJ_AIAgentRuns_ConversationID, @MJ_AIAgentRuns_UserID, @MJ_AIAgentRuns_Result, @MJ_AIAgentRuns_AgentState, @MJ_AIAgentRuns_TotalTokensUsed, @MJ_AIAgentRuns_TotalCost, @MJ_AIAgentRuns_TotalPromptTokensUsed, @MJ_AIAgentRuns_TotalCompletionTokensUsed, @MJ_AIAgentRuns_TotalTokensUsedRollup, @MJ_AIAgentRuns_TotalPromptTokensUsedRollup, @MJ_AIAgentRuns_TotalCompletionTokensUsedRollup, @MJ_AIAgentRuns_TotalCostRollup, @MJ_AIAgentRuns_ConversationDetailID, @MJ_AIAgentRuns_ConversationDetailSequence, @MJ_AIAgentRuns_CancellationReason, @MJ_AIAgentRuns_FinalStep, @MJ_AIAgentRuns_FinalPayload, @MJ_AIAgentRuns_Message, @MJ_AIAgentRuns_LastRunID, @MJ_AIAgentRuns_StartingPayload, @MJ_AIAgentRuns_TotalPromptIterations, @MJ_AIAgentRuns_ConfigurationID, @MJ_AIAgentRuns_OverrideModelID, @MJ_AIAgentRuns_OverrideVendorID, @MJ_AIAgentRuns_Data, @MJ_AIAgentRuns_Verbose, @MJ_AIAgentRuns_EffortLevel
+    
+    WHILE @@FETCH_STATUS = 0
+    BEGIN
+        -- Set the FK field to NULL
+        SET @MJ_AIAgentRuns_ConversationID = NULL
+        
+        -- Call the update SP for the related entity
+        EXEC [${flyway:defaultSchema}].[spUpdateAIAgentRun] @ID = @MJ_AIAgentRunsID, @AgentID = @MJ_AIAgentRuns_AgentID, @ParentRunID = @MJ_AIAgentRuns_ParentRunID, @Status = @MJ_AIAgentRuns_Status, @StartedAt = @MJ_AIAgentRuns_StartedAt, @CompletedAt = @MJ_AIAgentRuns_CompletedAt, @Success = @MJ_AIAgentRuns_Success, @ErrorMessage = @MJ_AIAgentRuns_ErrorMessage, @ConversationID = @MJ_AIAgentRuns_ConversationID, @UserID = @MJ_AIAgentRuns_UserID, @Result = @MJ_AIAgentRuns_Result, @AgentState = @MJ_AIAgentRuns_AgentState, @TotalTokensUsed = @MJ_AIAgentRuns_TotalTokensUsed, @TotalCost = @MJ_AIAgentRuns_TotalCost, @TotalPromptTokensUsed = @MJ_AIAgentRuns_TotalPromptTokensUsed, @TotalCompletionTokensUsed = @MJ_AIAgentRuns_TotalCompletionTokensUsed, @TotalTokensUsedRollup = @MJ_AIAgentRuns_TotalTokensUsedRollup, @TotalPromptTokensUsedRollup = @MJ_AIAgentRuns_TotalPromptTokensUsedRollup, @TotalCompletionTokensUsedRollup = @MJ_AIAgentRuns_TotalCompletionTokensUsedRollup, @TotalCostRollup = @MJ_AIAgentRuns_TotalCostRollup, @ConversationDetailID = @MJ_AIAgentRuns_ConversationDetailID, @ConversationDetailSequence = @MJ_AIAgentRuns_ConversationDetailSequence, @CancellationReason = @MJ_AIAgentRuns_CancellationReason, @FinalStep = @MJ_AIAgentRuns_FinalStep, @FinalPayload = @MJ_AIAgentRuns_FinalPayload, @Message = @MJ_AIAgentRuns_Message, @LastRunID = @MJ_AIAgentRuns_LastRunID, @StartingPayload = @MJ_AIAgentRuns_StartingPayload, @TotalPromptIterations = @MJ_AIAgentRuns_TotalPromptIterations, @ConfigurationID = @MJ_AIAgentRuns_ConfigurationID, @OverrideModelID = @MJ_AIAgentRuns_OverrideModelID, @OverrideVendorID = @MJ_AIAgentRuns_OverrideVendorID, @Data = @MJ_AIAgentRuns_Data, @Verbose = @MJ_AIAgentRuns_Verbose, @EffortLevel = @MJ_AIAgentRuns_EffortLevel
+        
+        FETCH NEXT FROM cascade_update_MJ_AIAgentRuns_cursor INTO @MJ_AIAgentRunsID, @MJ_AIAgentRuns_AgentID, @MJ_AIAgentRuns_ParentRunID, @MJ_AIAgentRuns_Status, @MJ_AIAgentRuns_StartedAt, @MJ_AIAgentRuns_CompletedAt, @MJ_AIAgentRuns_Success, @MJ_AIAgentRuns_ErrorMessage, @MJ_AIAgentRuns_ConversationID, @MJ_AIAgentRuns_UserID, @MJ_AIAgentRuns_Result, @MJ_AIAgentRuns_AgentState, @MJ_AIAgentRuns_TotalTokensUsed, @MJ_AIAgentRuns_TotalCost, @MJ_AIAgentRuns_TotalPromptTokensUsed, @MJ_AIAgentRuns_TotalCompletionTokensUsed, @MJ_AIAgentRuns_TotalTokensUsedRollup, @MJ_AIAgentRuns_TotalPromptTokensUsedRollup, @MJ_AIAgentRuns_TotalCompletionTokensUsedRollup, @MJ_AIAgentRuns_TotalCostRollup, @MJ_AIAgentRuns_ConversationDetailID, @MJ_AIAgentRuns_ConversationDetailSequence, @MJ_AIAgentRuns_CancellationReason, @MJ_AIAgentRuns_FinalStep, @MJ_AIAgentRuns_FinalPayload, @MJ_AIAgentRuns_Message, @MJ_AIAgentRuns_LastRunID, @MJ_AIAgentRuns_StartingPayload, @MJ_AIAgentRuns_TotalPromptIterations, @MJ_AIAgentRuns_ConfigurationID, @MJ_AIAgentRuns_OverrideModelID, @MJ_AIAgentRuns_OverrideVendorID, @MJ_AIAgentRuns_Data, @MJ_AIAgentRuns_Verbose, @MJ_AIAgentRuns_EffortLevel
+    END
+    
+    CLOSE cascade_update_MJ_AIAgentRuns_cursor
+    DEALLOCATE cascade_update_MJ_AIAgentRuns_cursor
+    
+    -- Cascade update on Report using cursor to call spUpdateReport
+    DECLARE @ReportsID uniqueidentifier
+    DECLARE @Reports_Name nvarchar(255)
+    DECLARE @Reports_Description nvarchar(MAX)
+    DECLARE @Reports_CategoryID uniqueidentifier
+    DECLARE @Reports_UserID uniqueidentifier
+    DECLARE @Reports_SharingScope nvarchar(20)
+    DECLARE @Reports_ConversationID uniqueidentifier
+    DECLARE @Reports_ConversationDetailID uniqueidentifier
+    DECLARE @Reports_DataContextID uniqueidentifier
+    DECLARE @Reports_Configuration nvarchar(MAX)
+    DECLARE @Reports_OutputTriggerTypeID uniqueidentifier
+    DECLARE @Reports_OutputFormatTypeID uniqueidentifier
+    DECLARE @Reports_OutputDeliveryTypeID uniqueidentifier
+    DECLARE @Reports_OutputFrequency nvarchar(50)
+    DECLARE @Reports_OutputTargetEmail nvarchar(255)
+    DECLARE @Reports_OutputWorkflowID uniqueidentifier
+    DECLARE @Reports_Thumbnail nvarchar(MAX)
+    DECLARE cascade_update_Reports_cursor CURSOR FOR 
+        SELECT [ID], [Name], [Description], [CategoryID], [UserID], [SharingScope], [ConversationID], [ConversationDetailID], [DataContextID], [Configuration], [OutputTriggerTypeID], [OutputFormatTypeID], [OutputDeliveryTypeID], [OutputFrequency], [OutputTargetEmail], [OutputWorkflowID], [Thumbnail]
+        FROM [${flyway:defaultSchema}].[Report]
+        WHERE [ConversationID] = @ID
+    
+    OPEN cascade_update_Reports_cursor
+    FETCH NEXT FROM cascade_update_Reports_cursor INTO @ReportsID, @Reports_Name, @Reports_Description, @Reports_CategoryID, @Reports_UserID, @Reports_SharingScope, @Reports_ConversationID, @Reports_ConversationDetailID, @Reports_DataContextID, @Reports_Configuration, @Reports_OutputTriggerTypeID, @Reports_OutputFormatTypeID, @Reports_OutputDeliveryTypeID, @Reports_OutputFrequency, @Reports_OutputTargetEmail, @Reports_OutputWorkflowID, @Reports_Thumbnail
+    
+    WHILE @@FETCH_STATUS = 0
+    BEGIN
+        -- Set the FK field to NULL
+        SET @Reports_ConversationID = NULL
+        
+        -- Call the update SP for the related entity
+        EXEC [${flyway:defaultSchema}].[spUpdateReport] @ID = @ReportsID, @Name = @Reports_Name, @Description = @Reports_Description, @CategoryID = @Reports_CategoryID, @UserID = @Reports_UserID, @SharingScope = @Reports_SharingScope, @ConversationID = @Reports_ConversationID, @ConversationDetailID = @Reports_ConversationDetailID, @DataContextID = @Reports_DataContextID, @Configuration = @Reports_Configuration, @OutputTriggerTypeID = @Reports_OutputTriggerTypeID, @OutputFormatTypeID = @Reports_OutputFormatTypeID, @OutputDeliveryTypeID = @Reports_OutputDeliveryTypeID, @OutputFrequency = @Reports_OutputFrequency, @OutputTargetEmail = @Reports_OutputTargetEmail, @OutputWorkflowID = @Reports_OutputWorkflowID, @Thumbnail = @Reports_Thumbnail
+        
+        FETCH NEXT FROM cascade_update_Reports_cursor INTO @ReportsID, @Reports_Name, @Reports_Description, @Reports_CategoryID, @Reports_UserID, @Reports_SharingScope, @Reports_ConversationID, @Reports_ConversationDetailID, @Reports_DataContextID, @Reports_Configuration, @Reports_OutputTriggerTypeID, @Reports_OutputFormatTypeID, @Reports_OutputDeliveryTypeID, @Reports_OutputFrequency, @Reports_OutputTargetEmail, @Reports_OutputWorkflowID, @Reports_Thumbnail
+    END
+    
+    CLOSE cascade_update_Reports_cursor
+    DEALLOCATE cascade_update_Reports_cursor
+    
+    -- Cascade delete from ConversationDetail using cursor to call spDeleteConversationDetail
+    DECLARE @ConversationDetailsID uniqueidentifier
+    DECLARE cascade_delete_ConversationDetails_cursor CURSOR FOR 
+        SELECT [ID]
+        FROM [${flyway:defaultSchema}].[ConversationDetail]
+        WHERE [ConversationID] = @ID
+    
+    OPEN cascade_delete_ConversationDetails_cursor
+    FETCH NEXT FROM cascade_delete_ConversationDetails_cursor INTO @ConversationDetailsID
+    
+    WHILE @@FETCH_STATUS = 0
+    BEGIN
+        -- Call the delete SP for the related entity, which handles its own cascades
+        EXEC [${flyway:defaultSchema}].[spDeleteConversationDetail] @ID = @ConversationDetailsID
+        
+        FETCH NEXT FROM cascade_delete_ConversationDetails_cursor INTO @ConversationDetailsID
+    END
+    
+    CLOSE cascade_delete_ConversationDetails_cursor
+    DEALLOCATE cascade_delete_ConversationDetails_cursor
+    
+    -- Cascade delete from ConversationArtifact using cursor to call spDeleteConversationArtifact
+    DECLARE @MJ_ConversationArtifactsID uniqueidentifier
+    DECLARE cascade_delete_MJ_ConversationArtifacts_cursor CURSOR FOR 
+        SELECT [ID]
+        FROM [${flyway:defaultSchema}].[ConversationArtifact]
+        WHERE [ConversationID] = @ID
+    
+    OPEN cascade_delete_MJ_ConversationArtifacts_cursor
+    FETCH NEXT FROM cascade_delete_MJ_ConversationArtifacts_cursor INTO @MJ_ConversationArtifactsID
+    
+    WHILE @@FETCH_STATUS = 0
+    BEGIN
+        -- Call the delete SP for the related entity, which handles its own cascades
+        EXEC [${flyway:defaultSchema}].[spDeleteConversationArtifact] @ID = @MJ_ConversationArtifactsID
+        
+        FETCH NEXT FROM cascade_delete_MJ_ConversationArtifacts_cursor INTO @MJ_ConversationArtifactsID
+    END
+    
+    CLOSE cascade_delete_MJ_ConversationArtifacts_cursor
+    DEALLOCATE cascade_delete_MJ_ConversationArtifacts_cursor
+    
+
+    DELETE FROM
+        [${flyway:defaultSchema}].[Conversation]
+    WHERE
+        [ID] = @ID
+
+
+    -- Check if the delete was successful
+    IF @@ROWCOUNT = 0
+        SELECT NULL AS [ID] -- Return NULL for all primary key fields to indicate no record was deleted
+    ELSE
+        SELECT @ID AS [ID] -- Return the primary key values to indicate we successfully deleted the record
+END
+GO
+GRANT EXECUTE ON [${flyway:defaultSchema}].[spDeleteConversation] TO [cdp_Developer], [cdp_UI], [cdp_Integration]
+    
+
+/* spDelete Permissions for Conversations */
+
+GRANT EXECUTE ON [${flyway:defaultSchema}].[spDeleteConversation] TO [cdp_Developer], [cdp_UI], [cdp_Integration]
+
+
+
+/* Generated Validation Functions for MJ: AI Agent Runs */
+-- CHECK constraint for MJ: AI Agent Runs: Field: EffortLevel was newly set or modified since the last generation of the validation function, the code was regenerated and updating the GeneratedCode table with the new generated validation function
+INSERT INTO [${flyway:defaultSchema}].[GeneratedCode] (CategoryID, GeneratedByModelID, GeneratedAt, Language, Status, Source, Code, Description, Name, LinkedEntityID, LinkedRecordPrimaryKey)
+                      VALUES ((SELECT ID FROM ${flyway:defaultSchema}.vwGeneratedCodeCategories WHERE Name='CodeGen: Validators'), '287E317F-BF26-F011-A770-AC1A3D21423D', GETUTCDATE(), 'TypeScript','Approved', '([EffortLevel]>=(1) AND [EffortLevel]<=(100))', 'public ValidateEffortLevelWithinAllowedRange(result: ValidationResult) {
+	if (this.EffortLevel < 1 || this.EffortLevel > 100) {
+		result.Errors.push(new ValidationErrorInfo("EffortLevel", "EffortLevel must be between 1 and 100.", this.EffortLevel, ValidationErrorType.Failure));
+	}
+}', 'This rule ensures that the EffortLevel must be a value between 1 and 100, inclusive.', 'ValidateEffortLevelWithinAllowedRange', 'DF238F34-2837-EF11-86D4-6045BDEE16E6', 'B16B5B36-7238-4A90-ABAD-DA64ED8FADCA');
+  
+            
+
+/* Generated Validation Functions for MJ: AI Prompt Runs */
+-- CHECK constraint for MJ: AI Prompt Runs: Field: EffortLevel was newly set or modified since the last generation of the validation function, the code was regenerated and updating the GeneratedCode table with the new generated validation function
+INSERT INTO [${flyway:defaultSchema}].[GeneratedCode] (CategoryID, GeneratedByModelID, GeneratedAt, Language, Status, Source, Code, Description, Name, LinkedEntityID, LinkedRecordPrimaryKey)
+                      VALUES ((SELECT ID FROM ${flyway:defaultSchema}.vwGeneratedCodeCategories WHERE Name='CodeGen: Validators'), '287E317F-BF26-F011-A770-AC1A3D21423D', GETUTCDATE(), 'TypeScript','Approved', '([EffortLevel]>=(1) AND [EffortLevel]<=(100))', 'public ValidateEffortLevelWithinRange(result: ValidationResult) {
+	if (this.EffortLevel < 1 || this.EffortLevel > 100) {
+		result.Errors.push(new ValidationErrorInfo("EffortLevel", "EffortLevel must be between 1 and 100.", this.EffortLevel, ValidationErrorType.Failure));
+	}
+}', 'This rule ensures that the effort level must be a number between 1 and 100, inclusive.', 'ValidateEffortLevelWithinRange', 'DF238F34-2837-EF11-86D4-6045BDEE16E6', '7B1032DB-F8AF-4EAF-9F03-7B9049FBA39D');
+  
+            
+

--- a/packages/AI/CorePlus/README.md
+++ b/packages/AI/CorePlus/README.md
@@ -62,6 +62,7 @@ Parameters for executing AI agents with support for:
 - Conversation context
 - Progress and streaming callbacks
 - Cancellation support
+- **Effort level control** - Override agent and prompt effort levels
 
 ### ExecuteAgentResult
 
@@ -70,6 +71,45 @@ Result of agent execution including:
 - Agent run tracking entity
 - Execution metadata
 - Error information
+
+## Effort Level Control
+
+MemberJunction supports granular control over AI model reasoning effort through a 1-100 integer scale. Higher values request more thorough reasoning and analysis from AI models that support effort levels.
+
+### Effort Level Hierarchy
+
+The effort level is resolved using the following precedence (highest to lowest priority):
+
+1. **`ExecuteAgentParams.effortLevel`** - Runtime override (highest priority)
+2. **`AIAgent.DefaultPromptEffortLevel`** - Agent default setting
+3. **`AIPrompt.EffortLevel`** - Individual prompt setting
+4. **Provider default** - Model's natural behavior (lowest priority)
+
+### Provider Support
+
+Different AI providers map the 1-100 scale to their specific parameters:
+
+- **OpenAI**: Maps to `reasoning_effort` (1-33=low, 34-66=medium, 67-100=high)
+- **Anthropic**: Maps to thinking mode with token budgets (1-100 → 25K-2M tokens)
+- **Groq**: Maps to experimental `reasoning_effort` parameter
+- **Gemini**: Controls reasoning mode intensity
+
+### Usage Examples
+
+```typescript
+// Agent execution with effort level override
+const params: ExecuteAgentParams = {
+  agent: myAgent,
+  conversationMessages: messages,
+  effortLevel: 85, // High effort for thorough analysis
+  contextUser: user
+};
+
+// Prompt execution with effort level
+const promptParams = new AIPromptParams();
+promptParams.prompt = myPrompt;
+promptParams.effortLevel = 50; // Medium effort level
+```
 
 ## System Placeholders
 

--- a/packages/AI/CorePlus/src/agent-types.ts
+++ b/packages/AI/CorePlus/src/agent-types.ts
@@ -385,6 +385,42 @@ export type ExecuteAgentParams<TContext = any, P = any> = {
      * ```
      */
     onAgentRunCreated?: (agentRunId: string) => void | Promise<void>;
+
+    /**
+     * Optional effort level for all prompt executions in this agent run (1-100).
+     * 
+     * Higher values request more thorough reasoning and analysis from AI models.
+     * This effort level takes precedence over the agent's DefaultPromptEffortLevel
+     * and individual prompt EffortLevel settings for all prompts executed during
+     * this agent run.
+     * 
+     * Each provider maps the 1-100 scale to their specific effort parameters:
+     * - OpenAI: Maps to reasoning_effort (1-33=low, 34-66=medium, 67-100=high)
+     * - Anthropic: Maps to thinking mode with token budgets
+     * - Groq: Maps to reasoning_effort parameter (experimental)
+     * - Gemini: Controls reasoning mode intensity
+     * 
+     * This setting is inherited by all sub-agents unless they explicitly override it.
+     * 
+     * Precedence hierarchy (highest to lowest priority):
+     * 1. This effortLevel parameter (runtime override - highest priority)
+     * 2. Agent's DefaultPromptEffortLevel (agent default)
+     * 3. Prompt's EffortLevel property (prompt default)
+     * 4. No effort level (provider default behavior - lowest priority)
+     * 
+     * @example
+     * ```typescript
+     * const params: ExecuteAgentParams = {
+     *   agent: myAgent,
+     *   conversationMessages: messages,
+     *   effortLevel: 85, // High effort for thorough analysis across all prompts
+     *   contextUser: user
+     * };
+     * 
+     * const result = await agent.Execute(params);
+     * ```
+     */
+    effortLevel?: number;
 }
 
 /**

--- a/packages/AI/CorePlus/src/prompt.types.ts
+++ b/packages/AI/CorePlus/src/prompt.types.ts
@@ -536,6 +536,33 @@ export class AIPromptParams {
    * ```
    */
   onPromptRunCreated?: (promptRunId: string) => void | Promise<void>;
+
+  /**
+   * Optional effort level override for this prompt execution (1-100).
+   * 
+   * Higher values request more thorough reasoning and analysis from AI models.
+   * Each provider maps the 1-100 scale to their specific effort parameters:
+   * - OpenAI: Maps to reasoning_effort (1-33=low, 34-66=medium, 67-100=high)
+   * - Anthropic: Maps to thinking mode with token budgets
+   * - Groq: Maps to reasoning_effort parameter (experimental)
+   * - Gemini: Controls reasoning mode intensity
+   * 
+   * Precedence hierarchy (highest to lowest priority):
+   * 1. This effortLevel parameter (runtime override)
+   * 2. Agent's DefaultPromptEffortLevel (if executed via agent)
+   * 3. Prompt's EffortLevel property (prompt default)
+   * 4. No effort level (provider default behavior)
+   * 
+   * @example
+   * ```typescript
+   * const params = new AIPromptParams();
+   * params.prompt = myPrompt;
+   * params.effortLevel = 85; // High effort for thorough analysis
+   * 
+   * const result = await AIPromptRunner.RunPrompt(params);
+   * ```
+   */
+  effortLevel?: number;
 }
 
 

--- a/packages/AI/Prompts/README.md
+++ b/packages/AI/Prompts/README.md
@@ -9,6 +9,31 @@ Advanced AI prompt execution engine with hierarchical template composition, inte
 
 ## Key Features
 
+### 🎯 Effort Level Control
+Granular control over AI model reasoning effort through a 1-100 integer scale. Higher values request more thorough reasoning and analysis from AI models that support effort levels.
+
+#### Effort Level Hierarchy
+The effort level is resolved using the following precedence (highest to lowest priority):
+
+1. **`AIPromptParams.effortLevel`** - Runtime override (highest priority)
+2. **`AIPrompt.EffortLevel`** - Individual prompt setting (lower priority)
+3. **Provider default** - Model's natural behavior (lowest priority)
+
+#### Provider Support
+Different AI providers map the 1-100 scale to their specific parameters:
+- **OpenAI**: Maps to `reasoning_effort` (1-33=low, 34-66=medium, 67-100=high)
+- **Anthropic**: Maps to thinking mode with token budgets (1-100 → 25K-2M tokens)
+- **Groq**: Maps to experimental `reasoning_effort` parameter
+- **Gemini**: Controls reasoning mode intensity
+
+```typescript
+const params = new AIPromptParams();
+params.prompt = myPrompt;
+params.effortLevel = 85; // High effort for thorough analysis
+
+const result = await AIPromptRunner.RunPrompt(params);
+```
+
 ### 🛡️ Intelligent Failover Support
 Automatic failover when AI providers experience outages, rate limits, or service degradation. The system intelligently switches between models and vendors to ensure reliable prompt execution.
 

--- a/packages/AI/Prompts/src/AIPromptRunner.ts
+++ b/packages/AI/Prompts/src/AIPromptRunner.ts
@@ -1770,6 +1770,14 @@ export class AIPromptRunner {
         promptRun.AgentRunID = params.agentRunId;
       }
 
+      // Resolve and save the effort level used (same precedence as ChatParams resolution)
+      if (params.effortLevel !== undefined && params.effortLevel !== null) {
+        promptRun.EffortLevel = params.effortLevel;
+      } else if (prompt.EffortLevel !== undefined && prompt.EffortLevel !== null) {
+        promptRun.EffortLevel = prompt.EffortLevel;
+      }
+      // If neither is set, EffortLevel remains null (provider default was used)
+
       // Set ParentID for hierarchical prompt execution tracking
       if (params.parentPromptRunId) {
         promptRun.ParentID = params.parentPromptRunId;
@@ -2382,6 +2390,18 @@ export class AIPromptRunner {
           chatParams.topLogProbs = params.additionalParameters.topLogProbs;
         }
       }
+
+      // Apply effortLevel with precedence hierarchy
+      // 1. params.effortLevel (runtime override - highest priority)
+      // 2. prompt.EffortLevel (prompt default - lower priority)
+      // 3. No effort level (provider default - lowest priority)
+      // Note: Agent DefaultPromptEffortLevel will be passed via params.effortLevel by BaseAgent
+      if (params.effortLevel !== undefined && params.effortLevel !== null) {
+        chatParams.effortLevel = params.effortLevel.toString();
+      } else if (prompt.EffortLevel !== undefined && prompt.EffortLevel !== null) {
+        chatParams.effortLevel = prompt.EffortLevel.toString();
+      }
+      // If neither is set, effortLevel remains undefined and providers use their defaults
 
       // Apply response format from prompt settings
       if (prompt.ResponseFormat && prompt.ResponseFormat !== 'Any') {

--- a/packages/Angular/Explorer/core-entity-forms/src/lib/custom/AIAgents/ai-agent-form.component.html
+++ b/packages/Angular/Explorer/core-entity-forms/src/lib/custom/AIAgents/ai-agent-form.component.html
@@ -1154,6 +1154,31 @@
                                     <div class="config-card">
                                         <div class="config-card-header">
                                             <div class="config-card-icon">
+                                                <i class="fa-solid fa-tachometer-alt"></i>
+                                            </div>
+                                            <div class="config-card-info">
+                                                <h4>Default Effort Level</h4>
+                                                <p>Default effort level for all prompts (1-100)</p>
+                                            </div>
+                                        </div>
+                                        <div class="config-card-content">
+                                            <mj-form-field 
+                                                FieldName="DefaultPromptEffortLevel" 
+                                                Type="numerictextbox"
+                                                Caption=""
+                                                [EditMode]="EditMode"
+                                                [record]="record">
+                                            </mj-form-field>
+                                            <div class="config-card-hint">
+                                                <i class="fa-solid fa-info-circle"></i>
+                                                Higher values request more thorough reasoning (1=minimal, 100=maximum)
+                                            </div>
+                                        </div>
+                                    </div>
+
+                                    <div class="config-card">
+                                        <div class="config-card-header">
+                                            <div class="config-card-icon">
                                                 <i class="fa-solid fa-code"></i>
                                             </div>
                                             <div class="config-card-info">

--- a/packages/Angular/Explorer/core-entity-forms/src/lib/custom/AIPromptRuns/ai-prompt-run-form.component.html
+++ b/packages/Angular/Explorer/core-entity-forms/src/lib/custom/AIPromptRuns/ai-prompt-run-form.component.html
@@ -110,6 +110,15 @@
                                 </div>
                             </div>
                         }
+                        @if (record.EffortLevel !== null && record.EffortLevel !== undefined) {
+                            <div class="metric-item">
+                                <i class="fa-solid fa-tachometer-alt"></i>
+                                <div class="metric-content">
+                                    <div class="metric-label">Effort Level</div>
+                                    <div class="metric-value">{{ record.EffortLevel }}</div>
+                                </div>
+                            </div>
+                        }
                         @if (record.ResponseFormat) {
                             <div class="metric-item">
                                 <i class="fa-solid fa-code"></i>

--- a/packages/Angular/Explorer/core-entity-forms/src/lib/custom/AIPrompts/ai-prompt-form.component.html
+++ b/packages/Angular/Explorer/core-entity-forms/src/lib/custom/AIPrompts/ai-prompt-form.component.html
@@ -107,6 +107,14 @@
                                     <span style="color: #28a745; font-weight: 500;">Caching Enabled</span>
                                 </div>
                             }
+                            
+                            @if (record.EffortLevel) {
+                                <div class="config-item" style="display: flex; align-items: center; gap: 6px; font-size: 0.85em;">
+                                    <i class="fa-solid fa-tachometer-alt" style="color: #6c757d;"></i>
+                                    <span style="color: #6c757d;">Effort Level:</span>
+                                    <span style="color: #495057; font-weight: 500;">{{ record.EffortLevel }}</span>
+                                </div>
+                            }
                         </div>
                     </div>
                     
@@ -615,6 +623,16 @@
                                     [ShowLabel]="true"
                                     FieldName="OutputType"
                                     Type="dropdownlist"
+                                    [EditMode]="EditMode">
+                                </mj-form-field>
+                                
+                                <mj-form-field 
+                                    [record]="record"
+                                    [ShowLabel]="true"
+                                    FieldName="EffortLevel"
+                                    Type="numerictextbox"
+                                    Caption="Effort Level (1-100)"
+                                    Description="Higher values request more thorough reasoning"
                                     [EditMode]="EditMode">
                                 </mj-form-field>
                                 

--- a/packages/Angular/Explorer/core-entity-forms/src/lib/custom/ai-agent-run/ai-agent-run.component.html
+++ b/packages/Angular/Explorer/core-entity-forms/src/lib/custom/ai-agent-run/ai-agent-run.component.html
@@ -60,6 +60,10 @@
           <span class="value" *ngIf="!costMetrics.isLoading">${{ costMetrics.totalCost | number:'1.2-4' }}</span>
           <span class="value loading" *ngIf="costMetrics.isLoading"><i class="fas fa-spinner fa-spin"></i></span>
         </div>
+        <div class="stat" *ngIf="record.EffortLevel">
+          <span class="label">Effort Level</span>
+          <span class="value">{{ record.EffortLevel }}</span>
+        </div>
       </div>
       
       <!-- Configuration Bar (shown below header stats when ConfigurationID exists) -->

--- a/packages/Angular/Explorer/core-entity-forms/src/lib/generated/Entities/AIAgent/sections/details.component.ts
+++ b/packages/Angular/Explorer/core-entity-forms/src/lib/generated/Entities/AIAgent/sections/details.component.ts
@@ -256,6 +256,13 @@ import { AIAgentEntity } from '@memberjunction/core-entities';
         <mj-form-field 
             [record]="record"
             [ShowLabel]="true"
+            FieldName="DefaultPromptEffortLevel"
+            Type="numerictextbox"
+            [EditMode]="EditMode"
+        ></mj-form-field>
+        <mj-form-field 
+            [record]="record"
+            [ShowLabel]="true"
             FieldName="Parent"
             Type="textbox"
             [EditMode]="EditMode"

--- a/packages/Angular/Explorer/core-entity-forms/src/lib/generated/Entities/AIAgentRun/sections/details.component.ts
+++ b/packages/Angular/Explorer/core-entity-forms/src/lib/generated/Entities/AIAgentRun/sections/details.component.ts
@@ -275,6 +275,13 @@ import { AIAgentRunEntity } from '@memberjunction/core-entities';
         <mj-form-field 
             [record]="record"
             [ShowLabel]="true"
+            FieldName="EffortLevel"
+            Type="numerictextbox"
+            [EditMode]="EditMode"
+        ></mj-form-field>
+        <mj-form-field 
+            [record]="record"
+            [ShowLabel]="true"
             FieldName="Agent"
             Type="textbox"
             [EditMode]="EditMode"

--- a/packages/Angular/Explorer/core-entity-forms/src/lib/generated/Entities/AIPrompt/sections/details.component.ts
+++ b/packages/Angular/Explorer/core-entity-forms/src/lib/generated/Entities/AIPrompt/sections/details.component.ts
@@ -365,6 +365,13 @@ import { AIPromptEntity } from '@memberjunction/core-entities';
         <mj-form-field 
             [record]="record"
             [ShowLabel]="true"
+            FieldName="EffortLevel"
+            Type="numerictextbox"
+            [EditMode]="EditMode"
+        ></mj-form-field>
+        <mj-form-field 
+            [record]="record"
+            [ShowLabel]="true"
             FieldName="Template"
             Type="textbox"
             [EditMode]="EditMode"

--- a/packages/Angular/Explorer/core-entity-forms/src/lib/generated/Entities/AIPromptRun/sections/details.component.ts
+++ b/packages/Angular/Explorer/core-entity-forms/src/lib/generated/Entities/AIPromptRun/sections/details.component.ts
@@ -587,6 +587,13 @@ import { AIPromptRunEntity } from '@memberjunction/core-entities';
         <mj-form-field 
             [record]="record"
             [ShowLabel]="true"
+            FieldName="EffortLevel"
+            Type="numerictextbox"
+            [EditMode]="EditMode"
+        ></mj-form-field>
+        <mj-form-field 
+            [record]="record"
+            [ShowLabel]="true"
             FieldName="Prompt"
             Type="textbox"
             [EditMode]="EditMode"

--- a/packages/Angular/Explorer/core-entity-forms/src/lib/generated/Entities/ConversationArtifact/conversationartifact.form.component.html
+++ b/packages/Angular/Explorer/core-entity-forms/src/lib/generated/Entities/ConversationArtifact/conversationartifact.form.component.html
@@ -16,19 +16,6 @@
                         </mj-form-section>
                     </mj-tab-body>
                     
-                    <mj-tab Name="MJ: Conversation Artifact Versions" [Visible]="record.IsSaved"> 
-                        MJ: Conversation Artifact Versions
-                    </mj-tab>
-                    <mj-tab-body>
-                        <mj-user-view-grid 
-                            [Params]="BuildRelationshipViewParamsByEntityName('MJ: Conversation Artifact Versions','ConversationArtifactID')"  
-                            [NewRecordValues]="NewRecordValues('MJ: Conversation Artifact Versions')"
-                            [AllowLoad]="IsCurrentTab('MJ: Conversation Artifact Versions')"  
-                            [EditMode]="GridEditMode()"  
-                            >
-                        </mj-user-view-grid>                    
-                    </mj-tab-body>
-
                     <mj-tab Name="MJ: Conversation Artifact Permissions" [Visible]="record.IsSaved"> 
                         MJ: Conversation Artifact Permissions
                     </mj-tab>
@@ -37,6 +24,19 @@
                             [Params]="BuildRelationshipViewParamsByEntityName('MJ: Conversation Artifact Permissions','ConversationArtifactID')"  
                             [NewRecordValues]="NewRecordValues('MJ: Conversation Artifact Permissions')"
                             [AllowLoad]="IsCurrentTab('MJ: Conversation Artifact Permissions')"  
+                            [EditMode]="GridEditMode()"  
+                            >
+                        </mj-user-view-grid>                    
+                    </mj-tab-body>
+
+                    <mj-tab Name="MJ: Conversation Artifact Versions" [Visible]="record.IsSaved"> 
+                        MJ: Conversation Artifact Versions
+                    </mj-tab>
+                    <mj-tab-body>
+                        <mj-user-view-grid 
+                            [Params]="BuildRelationshipViewParamsByEntityName('MJ: Conversation Artifact Versions','ConversationArtifactID')"  
+                            [NewRecordValues]="NewRecordValues('MJ: Conversation Artifact Versions')"
+                            [AllowLoad]="IsCurrentTab('MJ: Conversation Artifact Versions')"  
                             [EditMode]="GridEditMode()"  
                             >
                         </mj-user-view-grid>                    

--- a/packages/Angular/Explorer/core-entity-forms/src/lib/generated/Entities/User/user.form.component.html
+++ b/packages/Angular/Explorer/core-entity-forms/src/lib/generated/Entities/User/user.form.component.html
@@ -484,19 +484,6 @@
                         </mj-user-view-grid>                    
                     </mj-tab-body>
 
-                    <mj-tab Name="MJ: Dashboard User States" [Visible]="record.IsSaved"> 
-                        MJ: Dashboard User States
-                    </mj-tab>
-                    <mj-tab-body>
-                        <mj-user-view-grid 
-                            [Params]="BuildRelationshipViewParamsByEntityName('MJ: Dashboard User States','UserID')"  
-                            [NewRecordValues]="NewRecordValues('MJ: Dashboard User States')"
-                            [AllowLoad]="IsCurrentTab('MJ: Dashboard User States')"  
-                            [EditMode]="GridEditMode()"  
-                            >
-                        </mj-user-view-grid>                    
-                    </mj-tab-body>
-
                     <mj-tab Name="MJ: Dashboard User Preferences" [Visible]="record.IsSaved"> 
                         MJ: Dashboard User Preferences
                     </mj-tab>
@@ -505,6 +492,19 @@
                             [Params]="BuildRelationshipViewParamsByEntityName('MJ: Dashboard User Preferences','UserID')"  
                             [NewRecordValues]="NewRecordValues('MJ: Dashboard User Preferences')"
                             [AllowLoad]="IsCurrentTab('MJ: Dashboard User Preferences')"  
+                            [EditMode]="GridEditMode()"  
+                            >
+                        </mj-user-view-grid>                    
+                    </mj-tab-body>
+
+                    <mj-tab Name="MJ: Dashboard User States" [Visible]="record.IsSaved"> 
+                        MJ: Dashboard User States
+                    </mj-tab>
+                    <mj-tab-body>
+                        <mj-user-view-grid 
+                            [Params]="BuildRelationshipViewParamsByEntityName('MJ: Dashboard User States','UserID')"  
+                            [NewRecordValues]="NewRecordValues('MJ: Dashboard User States')"
+                            [AllowLoad]="IsCurrentTab('MJ: Dashboard User States')"  
                             [EditMode]="GridEditMode()"  
                             >
                         </mj-user-view-grid>                    

--- a/packages/MJCoreEntities/src/generated/entity_subclasses.ts
+++ b/packages/MJCoreEntities/src/generated/entity_subclasses.ts
@@ -7908,6 +7908,11 @@ each time the agent processes a prompt step.`),
         * * SQL Data Type: bit
         * * Default Value: 0
         * * Description: Indicates whether verbose logging was enabled during this agent execution. When true, detailed decision-making and execution flow was logged.`),
+    EffortLevel: z.number().nullable().describe(`
+        * * Field Name: EffortLevel
+        * * Display Name: Effort Level
+        * * SQL Data Type: int
+        * * Description: Effort level that was actually used during this agent run execution (1-100, where 1=minimal effort, 100=maximum effort). This is the resolved effort level after applying the precedence hierarchy: runtime override > agent default > prompt defaults.`),
     Agent: z.string().nullable().describe(`
         * * Field Name: Agent
         * * Display Name: Agent
@@ -9196,6 +9201,11 @@ export const AIPromptRunSchema = z.object({
         * * Display Name: Model Specific Response Details
         * * SQL Data Type: nvarchar(MAX)
         * * Description: JSON field containing provider-specific response metadata and details not captured in standard fields. Structure varies by AI provider.`),
+    EffortLevel: z.number().nullable().describe(`
+        * * Field Name: EffortLevel
+        * * Display Name: Effort Level
+        * * SQL Data Type: int
+        * * Description: Effort level that was actually used during this prompt run execution (1-100, where 1=minimal effort, 100=maximum effort). This is the resolved effort level after applying the precedence hierarchy: runtime override > agent default > prompt default > provider default.`),
     Prompt: z.string().describe(`
         * * Field Name: Prompt
         * * Display Name: Prompt
@@ -33524,6 +33534,32 @@ export class AIAgentRunEntity extends BaseEntity<AIAgentRunEntityType> {
     }
 
     /**
+    * Validate() method override for MJ: AI Agent Runs entity. This is an auto-generated method that invokes the generated validators for this entity for the following fields: 
+    * * EffortLevel: This rule ensures that the EffortLevel must be a value between 1 and 100, inclusive.  
+    * @public
+    * @method
+    * @override
+    */
+    public override Validate(): ValidationResult {
+        const result = super.Validate();
+        this.ValidateEffortLevelWithinAllowedRange(result);
+
+        return result;
+    }
+
+    /**
+    * This rule ensures that the EffortLevel must be a value between 1 and 100, inclusive.
+    * @param result - the ValidationResult object to add any errors or warnings to
+    * @public
+    * @method
+    */
+    public ValidateEffortLevelWithinAllowedRange(result: ValidationResult) {
+    	if (this.EffortLevel < 1 || this.EffortLevel > 100) {
+    		result.Errors.push(new ValidationErrorInfo("EffortLevel", "EffortLevel must be between 1 and 100.", this.EffortLevel, ValidationErrorType.Failure));
+    	}
+    }
+
+    /**
     * * Field Name: ID
     * * Display Name: ID
     * * SQL Data Type: uniqueidentifier
@@ -34021,6 +34057,19 @@ each time the agent processes a prompt step.
     }
     set Verbose(value: boolean | null) {
         this.Set('Verbose', value);
+    }
+
+    /**
+    * * Field Name: EffortLevel
+    * * Display Name: Effort Level
+    * * SQL Data Type: int
+    * * Description: Effort level that was actually used during this agent run execution (1-100, where 1=minimal effort, 100=maximum effort). This is the resolved effort level after applying the precedence hierarchy: runtime override > agent default > prompt defaults.
+    */
+    get EffortLevel(): number | null {
+        return this.Get('EffortLevel');
+    }
+    set EffortLevel(value: number | null) {
+        this.Set('EffortLevel', value);
     }
 
     /**
@@ -36476,6 +36525,7 @@ export class AIPromptRunEntity extends BaseEntity<AIPromptRunEntityType> {
 
     /**
     * Validate() method override for MJ: AI Prompt Runs entity. This is an auto-generated method that invokes the generated validators for this entity for the following fields: 
+    * * EffortLevel: This rule ensures that the effort level must be a number between 1 and 100, inclusive.
     * * Table-Level: This rule ensures that if the 'CompletedAt' field has a value, it must be on or after the 'RunAt' field. Otherwise, if 'CompletedAt' is empty, there is no restriction.
     * * Table-Level: This rule ensures that either both TokensPrompt and TokensCompletion are missing, or TokensUsed is missing, or, if all values are present, the value of TokensUsed equals the sum of TokensPrompt and TokensCompletion.  
     * @public
@@ -36484,10 +36534,23 @@ export class AIPromptRunEntity extends BaseEntity<AIPromptRunEntityType> {
     */
     public override Validate(): ValidationResult {
         const result = super.Validate();
+        this.ValidateEffortLevelWithinRange(result);
         this.ValidateCompletedAtIsNullOrAfterRunAt(result);
         this.ValidateTokensUsedSumMatchesPromptAndCompletion(result);
 
         return result;
+    }
+
+    /**
+    * This rule ensures that the effort level must be a number between 1 and 100, inclusive.
+    * @param result - the ValidationResult object to add any errors or warnings to
+    * @public
+    * @method
+    */
+    public ValidateEffortLevelWithinRange(result: ValidationResult) {
+    	if (this.EffortLevel < 1 || this.EffortLevel > 100) {
+    		result.Errors.push(new ValidationErrorInfo("EffortLevel", "EffortLevel must be between 1 and 100.", this.EffortLevel, ValidationErrorType.Failure));
+    	}
     }
 
     /**
@@ -37589,6 +37652,19 @@ export class AIPromptRunEntity extends BaseEntity<AIPromptRunEntityType> {
     }
     set ModelSpecificResponseDetails(value: string | null) {
         this.Set('ModelSpecificResponseDetails', value);
+    }
+
+    /**
+    * * Field Name: EffortLevel
+    * * Display Name: Effort Level
+    * * SQL Data Type: int
+    * * Description: Effort level that was actually used during this prompt run execution (1-100, where 1=minimal effort, 100=maximum effort). This is the resolved effort level after applying the precedence hierarchy: runtime override > agent default > prompt default > provider default.
+    */
+    get EffortLevel(): number | null {
+        return this.Get('EffortLevel');
+    }
+    set EffortLevel(value: number | null) {
+        this.Set('EffortLevel', value);
     }
 
     /**

--- a/packages/MJServer/src/generated/generated.ts
+++ b/packages/MJServer/src/generated/generated.ts
@@ -1350,6 +1350,9 @@ each time the agent processes a prompt step.`})
     @Field(() => Boolean, {nullable: true, description: `Indicates whether verbose logging was enabled during this agent execution. When true, detailed decision-making and execution flow was logged.`}) 
     Verbose?: boolean;
         
+    @Field(() => Int, {nullable: true, description: `Effort level that was actually used during this agent run execution (1-100, where 1=minimal effort, 100=maximum effort). This is the resolved effort level after applying the precedence hierarchy: runtime override > agent default > prompt defaults.`}) 
+    EffortLevel?: number;
+        
     @Field({nullable: true}) 
     @MaxLength(510)
     Agent?: string;
@@ -1491,6 +1494,9 @@ export class CreateAIAgentRunInput {
 
     @Field(() => Boolean, { nullable: true })
     Verbose?: boolean | null;
+
+    @Field(() => Int, { nullable: true })
+    EffortLevel: number | null;
 }
     
 
@@ -1600,6 +1606,9 @@ export class UpdateAIAgentRunInput {
 
     @Field(() => Boolean, { nullable: true })
     Verbose?: boolean | null;
+
+    @Field(() => Int, { nullable: true })
+    EffortLevel?: number | null;
 
     @Field(() => [KeyValuePairInput], { nullable: true })
     OldValues___?: KeyValuePairInput[];
@@ -41219,6 +41228,9 @@ export class AIPromptRun_ {
     @Field({nullable: true, description: `JSON field containing provider-specific response metadata and details not captured in standard fields. Structure varies by AI provider.`}) 
     ModelSpecificResponseDetails?: string;
         
+    @Field(() => Int, {nullable: true, description: `Effort level that was actually used during this prompt run execution (1-100, where 1=minimal effort, 100=maximum effort). This is the resolved effort level after applying the precedence hierarchy: runtime override > agent default > prompt default > provider default.`}) 
+    EffortLevel?: number;
+        
     @Field() 
     @MaxLength(510)
     Prompt: string;
@@ -41497,6 +41509,9 @@ export class CreateAIPromptRunInput {
 
     @Field({ nullable: true })
     ModelSpecificResponseDetails: string | null;
+
+    @Field(() => Int, { nullable: true })
+    EffortLevel: number | null;
 }
     
 
@@ -41738,6 +41753,9 @@ export class UpdateAIPromptRunInput {
 
     @Field({ nullable: true })
     ModelSpecificResponseDetails?: string | null;
+
+    @Field(() => Int, { nullable: true })
+    EffortLevel?: number | null;
 
     @Field(() => [KeyValuePairInput], { nullable: true })
     OldValues___?: KeyValuePairInput[];


### PR DESCRIPTION
## Summary

Implements comprehensive effort level system across the MJ AI framework with a hierarchical precedence system that controls how much reasoning effort AI models apply to each prompt execution.

- **Effort Level Scale**: Uses 1-100 integer scale where higher values request more thorough reasoning
- **Hierarchical Precedence**: 4-level system with runtime overrides, agent defaults, prompt settings, and provider defaults
- **Sub-Agent Inheritance**: Effort levels propagate through entire agent hierarchy
- **Provider Compatibility**: Maps to provider-specific parameters (OpenAI reasoning_effort, Anthropic thinking mode, etc.)

## Key Changes

### Database Schema & Entities
- **V202508062035__v2.82.x__Add_EffortLevel_To_AIPrompt.sql**: Added EffortLevel to AIPrompt and DefaultPromptEffortLevel to AIAgent tables with CHECK constraints (1-100 validation)
- **V202508062114__v2.83.x__Add_EffortLevel_To_Run_Tables.sql**: Added EffortLevel tracking to AIAgentRun and AIPromptRun tables
- Auto-generated entity classes, stored procedures, and views via CodeGen

### Core Implementation
- **AIPromptParams**: Added `effortLevel?: number` override parameter
- **ExecuteAgentParams**: Added `effortLevel?: number` runtime parameter  
- **AIPromptRunner**: Implemented 4-level precedence hierarchy in ChatParams construction
- **BaseAgent**: Added effort level propagation to prompts and sub-agents
- **Run Tracking**: Captures resolved effort level used in execution records

### Angular UI Forms
- **AI Agent Form**: Added DefaultPromptEffortLevel field with validation and description
- **AI Prompt Form**: Added EffortLevel field with comprehensive documentation
- **AI Agent Run Form**: Added readonly EffortLevel display in header stats
- **AI Prompt Run Form**: Added readonly EffortLevel metric display

### Documentation
- Updated README files in AI/CorePlus, AI/Agents, and AI/Prompts packages
- Comprehensive documentation of precedence hierarchy and provider mappings
- Usage examples for agents, prompts, and sub-agent inheritance

## Effort Level Precedence Hierarchy

The system resolves effort levels using strict precedence (highest to lowest priority):

1. **Runtime Override** (`ExecuteAgentParams.effortLevel` / `AIPromptParams.effortLevel`) - Highest priority
2. **Agent Default** (`AIAgent.DefaultPromptEffortLevel`) - Medium priority  
3. **Prompt Setting** (`AIPrompt.EffortLevel`) - Lower priority
4. **Provider Default** - Natural model behavior (lowest priority)

## Provider Support

Different AI providers map the 1-100 scale to their specific parameters:

- **OpenAI**: Maps to `reasoning_effort` (1-33=low, 34-66=medium, 67-100=high)
- **Anthropic**: Maps to thinking mode with token budgets (1-100 → 25K-2M tokens)
- **Groq**: Maps to experimental `reasoning_effort` parameter
- **Gemini**: Controls reasoning mode intensity

## Usage Examples

```typescript
// Agent execution with effort level override
const result = await runner.RunAgent({
  agent: analysisAgent,
  conversationMessages: messages,
  effortLevel: 85, // High effort for thorough analysis
  contextUser: user
});

// Prompt execution with effort level
const params = new AIPromptParams();
params.effortLevel = 50; // Medium effort level
const result = await AIPromptRunner.RunPrompt(params);
```

## Testing

All packages compile successfully:
- ✅ packages/AI/CorePlus
- ✅ packages/AI/Prompts  
- ✅ packages/AI/Agents
- ✅ packages/Angular/Explorer/core-entity-forms

The implementation supports the complete workflow:
1. Configure default effort levels on agents/prompts in UI
2. Override effort levels at runtime via API parameters
3. Propagate effort levels through agent hierarchy including sub-agents
4. Track actual effort levels used in execution run records
5. View effort level metrics in run detail forms

🤖 Generated with [Claude Code](https://claude.ai/code)