### PR TITLE
Add GPT-5 models and Claude Opus 4.1 to AI Models

### DIFF
--- a/migrations/v2/V202508080930__v2.83.x__Add_GPT5_Models.sql
+++ b/migrations/v2/V202508080930__v2.83.x__Add_GPT5_Models.sql
@@ -2,19 +2,23 @@
 -- This migration adds:
 -- 1. Azure as a new AI Vendor (if not exists)
 -- 2. Azure vendor types for inference provider
--- 3. GPT-5 as a new AI Model
--- 4. GPT-5 Mini as a new AI Model  
--- 5. GPT-5 Nano as a new AI Model
--- 6. Claude Opus 4.1 as a new AI Model
--- 7. AIModelVendor associations for OpenAI as the model developer for GPT-5 models
--- 8. AIModelVendor associations for Anthropic as the model developer and inference provider for Opus 4.1
--- 9. AIModelVendor associations for OpenAI and Azure as inference providers
--- 10. Cost tracking records for OpenAI, Azure, and Anthropic pricing
+-- 3. Amazon Bedrock as a new AI Vendor (if not exists)
+-- 4. Amazon Bedrock vendor types for inference provider
+-- 5. GPT-5 as a new AI Model
+-- 6. GPT-5 Mini as a new AI Model  
+-- 7. GPT-5 Nano as a new AI Model
+-- 8. Claude Opus 4.1 as a new AI Model
+-- 9. AIModelVendor associations for OpenAI as the model developer for GPT-5 models
+-- 10. AIModelVendor associations for Anthropic as the model developer and inference provider for Opus 4.1
+-- 11. AIModelVendor associations for Amazon Bedrock as inference provider for Opus 4.1
+-- 12. AIModelVendor associations for OpenAI and Azure as inference providers for GPT-5 models
+-- 13. Cost tracking records for OpenAI, Azure, Anthropic, and Amazon Bedrock pricing
 
 -- Variable placeholders for vendor IDs 
 DECLARE @OpenAIVendorID UNIQUEIDENTIFIER = 'D8A5CCEC-6A37-EF11-86D4-000D3A4E707E'; -- OpenAI Vendor ID 
 DECLARE @AzureVendorID UNIQUEIDENTIFIER = 'D75ABC84-6BDB-41B9-94C7-2FE748482193'; -- Azure Vendor ID
 DECLARE @AnthropicVendorID UNIQUEIDENTIFIER = 'DAA5CCEC-6A37-EF11-86D4-000D3A4E707E'; -- Anthropic Vendor ID
+DECLARE @BedrockVendorID UNIQUEIDENTIFIER = '59FA8F6E-F14C-4874-A69C-BAD794DDC3AA'; -- Amazon Bedrock Vendor ID
 
 -- Model IDs for the new models
 DECLARE @GPT5ModelID UNIQUEIDENTIFIER = '87C351DF-5039-4E1D-A2E9-CF5B91927E5E';
@@ -55,7 +59,35 @@ BEGIN
         );
 END
 
--- 3. Create GPT-5 model record
+-- 3. Create Amazon Bedrock vendor record (if not exists)
+IF NOT EXISTS (SELECT 1 FROM ${flyway:defaultSchema}.AIVendor WHERE ID = @BedrockVendorID)
+BEGIN
+    INSERT INTO ${flyway:defaultSchema}.AIVendor 
+        (ID, Name, Description)
+    VALUES 
+        (
+            @BedrockVendorID,
+            'Amazon Bedrock',
+            'AWS fully managed service providing access to foundation models from leading AI companies including Anthropic Claude models'
+        );
+END
+
+-- 4. Create Amazon Bedrock vendor type for inference provider
+IF NOT EXISTS (SELECT 1 FROM ${flyway:defaultSchema}.AIVendorType WHERE VendorID = @BedrockVendorID AND TypeID = @InferenceProviderTypeID)
+BEGIN
+    INSERT INTO ${flyway:defaultSchema}.AIVendorType 
+        (ID, VendorID, TypeID, Rank, Status)
+    VALUES 
+        (
+            'F183DF98-ABAA-4414-AEE0-EAF12760675C',
+            @BedrockVendorID,
+            @InferenceProviderTypeID,
+            5, -- Rank
+            'Active'
+        );
+END
+
+-- 5. Create GPT-5 model record
 INSERT INTO ${flyway:defaultSchema}.AIModel 
     (ID, Name, Description, AIModelTypeID, IsActive, PowerRank, SpeedRank, CostRank)
 VALUES 
@@ -70,7 +102,7 @@ VALUES
         5  -- CostRank (moderate - $1.25/$10 per M tokens)
     );
 
--- 4. Create GPT-5 Mini model record
+-- 6. Create GPT-5 Mini model record
 INSERT INTO ${flyway:defaultSchema}.AIModel 
     (ID, Name, Description, AIModelTypeID, IsActive, PowerRank, SpeedRank, CostRank)
 VALUES 
@@ -85,7 +117,7 @@ VALUES
         8  -- CostRank (low cost - $0.25/$2 per M tokens)
     );
 
--- 5. Create GPT-5 Nano model record
+-- 7. Create GPT-5 Nano model record
 INSERT INTO ${flyway:defaultSchema}.AIModel 
     (ID, Name, Description, AIModelTypeID, IsActive, PowerRank, SpeedRank, CostRank)
 VALUES 
@@ -100,7 +132,7 @@ VALUES
         10  -- CostRank (cheapest - $0.05/$0.40 per M tokens)
     );
 
--- 6. Create Claude Opus 4.1 model record
+-- 8. Create Claude Opus 4.1 model record
 INSERT INTO ${flyway:defaultSchema}.AIModel 
     (ID, Name, Description, AIModelTypeID, IsActive, PowerRank, SpeedRank, CostRank)
 VALUES 
@@ -115,7 +147,7 @@ VALUES
         3  -- CostRank (expensive - $15/$75 per M tokens)
     );
 
--- 7. Create AI Model Vendor associations for OpenAI as model developer (all 3 GPT-5 models)
+-- 9. Create AI Model Vendor associations for OpenAI as model developer (all 3 GPT-5 models)
 INSERT INTO ${flyway:defaultSchema}.AIModelVendor 
     (ID, ModelID, VendorID, TypeID, Priority, Status, SupportedResponseFormats, SupportsEffortLevel, SupportsStreaming)
 VALUES 
@@ -156,7 +188,7 @@ VALUES
         0  -- SupportsStreaming
     );
 
--- 8. Create AI Model Vendor associations for Anthropic as model developer and inference provider for Opus 4.1
+-- 10. Create AI Model Vendor associations for Anthropic as model developer and inference provider for Opus 4.1
 INSERT INTO ${flyway:defaultSchema}.AIModelVendor 
     (ID, ModelID, VendorID, TypeID, Priority, Status, SupportedResponseFormats, SupportsEffortLevel, SupportsStreaming)
 VALUES 
@@ -173,7 +205,7 @@ VALUES
         0  -- SupportsStreaming
     );
 
--- 9. Create AI Model Vendor association for Anthropic as inference provider for Opus 4.1
+-- 11. Create AI Model Vendor association for Anthropic as inference provider for Opus 4.1
 INSERT INTO ${flyway:defaultSchema}.AIModelVendor 
     (ID, ModelID, VendorID, TypeID, APIName, Priority, Status, SupportedResponseFormats, SupportsEffortLevel, SupportsStreaming, DriverClass, MaxInputTokens, MaxOutputTokens)
 VALUES 
@@ -194,7 +226,28 @@ VALUES
         4096  -- MaxOutputTokens (4k output limit)
     );
 
--- 10. Create AI Model Vendor associations for OpenAI as inference provider (all 3 GPT-5 models)
+-- 12. Create AI Model Vendor association for Amazon Bedrock as inference provider for Opus 4.1
+INSERT INTO ${flyway:defaultSchema}.AIModelVendor 
+    (ID, ModelID, VendorID, TypeID, APIName, Priority, Status, SupportedResponseFormats, SupportsEffortLevel, SupportsStreaming, DriverClass, MaxInputTokens, MaxOutputTokens)
+VALUES 
+    -- Opus 4.1 on Amazon Bedrock
+    (
+        '3363B831-66DC-4E62-8AAC-9F2A2B12D59E',
+        @Opus41ModelID,
+        @BedrockVendorID,
+        @InferenceProviderTypeID,
+        'anthropic.claude-3-opus-20240229', -- Bedrock model ID for Claude models
+        5, -- Priority (lower than direct Anthropic)
+        'Active',
+        'Any, JSON',
+        0, -- SupportsEffortLevel
+        1, -- SupportsStreaming
+        'BedrockLLM',
+        200000, -- MaxInputTokens (200k context window)
+        4096  -- MaxOutputTokens (4k output limit)
+    );
+
+-- 13. Create AI Model Vendor associations for OpenAI as inference provider (all 3 GPT-5 models)
 INSERT INTO ${flyway:defaultSchema}.AIModelVendor 
     (ID, ModelID, VendorID, TypeID, APIName, Priority, Status, SupportedResponseFormats, SupportsEffortLevel, SupportsStreaming, DriverClass, MaxInputTokens, MaxOutputTokens)
 VALUES 
@@ -247,7 +300,7 @@ VALUES
         128000  -- MaxOutputTokens (128k output limit)
     );
 
--- 11. Create AI Model Vendor associations for Azure as inference provider (all 3 GPT-5 models)
+-- 14. Create AI Model Vendor associations for Azure as inference provider (all 3 GPT-5 models)
 INSERT INTO ${flyway:defaultSchema}.AIModelVendor 
     (ID, ModelID, VendorID, TypeID, APIName, Priority, Status, SupportedResponseFormats, SupportsEffortLevel, SupportsStreaming, DriverClass, MaxInputTokens, MaxOutputTokens)
 VALUES 
@@ -300,7 +353,7 @@ VALUES
         128000  -- MaxOutputTokens (128k output limit)
     );
 
--- 12. Add cost tracking records for OpenAI pricing
+-- 15. Add cost tracking records for OpenAI pricing
 INSERT INTO ${flyway:defaultSchema}.AIModelCost 
     (ID, ModelID, VendorID, StartedAt, EndedAt, Status, Currency, PriceTypeID, InputPricePerUnit, OutputPricePerUnit, UnitTypeID, ProcessingType, Comments)
 VALUES 
@@ -353,7 +406,7 @@ VALUES
         'GPT-5 Nano pricing on OpenAI as of August 2025'
     );
 
--- 13. Add cost tracking record for Anthropic Opus 4.1 pricing
+-- 16. Add cost tracking record for Anthropic Opus 4.1 pricing
 INSERT INTO ${flyway:defaultSchema}.AIModelCost 
     (ID, ModelID, VendorID, StartedAt, EndedAt, Status, Currency, PriceTypeID, InputPricePerUnit, OutputPricePerUnit, UnitTypeID, ProcessingType, Comments)
 VALUES 
@@ -374,7 +427,28 @@ VALUES
         'Claude Opus 4.1 pricing on Anthropic as of August 2025'
     );
 
--- 14. Add cost tracking records for Azure pricing
+-- 17. Add cost tracking record for Amazon Bedrock Opus 4.1 pricing
+INSERT INTO ${flyway:defaultSchema}.AIModelCost 
+    (ID, ModelID, VendorID, StartedAt, EndedAt, Status, Currency, PriceTypeID, InputPricePerUnit, OutputPricePerUnit, UnitTypeID, ProcessingType, Comments)
+VALUES 
+    -- Opus 4.1 on Amazon Bedrock
+    (
+        '64186C02-8782-41C1-B347-415D149133FC',
+        @Opus41ModelID,
+        @BedrockVendorID,
+        GETDATE(),
+        NULL,
+        'Active',
+        'USD',
+        'ece2bcb7-c854-4bf7-a517-d72793a40652', -- Standard token pricing type
+        15.00, -- $15.00 per M input tokens (same as Anthropic)
+        75.00, -- $75.00 per M output tokens (same as Anthropic)
+        '54208f7d-331c-40ab-84e8-163338ee9ea1', -- Per 1M tokens unit type
+        'Realtime',
+        'Claude Opus 4.1 pricing on Amazon Bedrock as of August 2025'
+    );
+
+-- 18. Add cost tracking records for Azure pricing
 INSERT INTO ${flyway:defaultSchema}.AIModelCost 
     (ID, ModelID, VendorID, StartedAt, EndedAt, Status, Currency, PriceTypeID, InputPricePerUnit, OutputPricePerUnit, UnitTypeID, ProcessingType, Comments)
 VALUES 
@@ -435,6 +509,7 @@ PRINT 'GPT-5 Nano Model ID: ' + CAST(@GPT5NanoModelID AS NVARCHAR(50));
 PRINT 'Claude Opus 4.1 Model ID: ' + CAST(@Opus41ModelID AS NVARCHAR(50));
 PRINT '';
 PRINT 'Azure Vendor ID: ' + CAST(@AzureVendorID AS NVARCHAR(50));
+PRINT 'Amazon Bedrock Vendor ID: ' + CAST(@BedrockVendorID AS NVARCHAR(50));
 PRINT '';
 PRINT 'Model Developer Associations:';
 PRINT 'OpenAI Developer (GPT-5): B3D650CE-978D-4E03-8CCB-BA4ABBACB3A0';
@@ -447,6 +522,7 @@ PRINT 'OpenAI Inference (GPT-5): FC307EF5-EA02-4EBF-8553-8A81A436702B';
 PRINT 'OpenAI Inference (GPT-5 Mini): 945C1236-B7C2-4F6B-A535-0915BF861CC0';
 PRINT 'OpenAI Inference (GPT-5 Nano): 6F6210A5-72F2-4D76-AD19-B2E49A9E2FA8';
 PRINT 'Anthropic Inference (Opus 4.1): 61369B16-0F95-4F4B-87EF-F64FD2F728E1';
+PRINT 'Amazon Bedrock Inference (Opus 4.1): 3363B831-66DC-4E62-8AAC-9F2A2B12D59E';
 PRINT 'Azure Inference (GPT-5): C00086B7-E296-40BE-95D4-1FDEDFAAC79D';
 PRINT 'Azure Inference (GPT-5 Mini): B964EDCF-625C-4D0B-B0FC-C1D5E8CF24B1';
 PRINT 'Azure Inference (GPT-5 Nano): 3E7D9C36-3C18-42F5-AE09-562E2C2436BC';
@@ -456,6 +532,7 @@ PRINT 'OpenAI Cost (GPT-5): 5F8BC862-CFAF-4DD9-BEB0-C723C8447597';
 PRINT 'OpenAI Cost (GPT-5 Mini): 4D4CB947-AA09-48E6-9FF3-43C6AA75D58E';
 PRINT 'OpenAI Cost (GPT-5 Nano): 060C9269-CCA4-41A0-99DC-55A95D17A3E0';
 PRINT 'Anthropic Cost (Opus 4.1): 28C400E6-4DAC-4DE2-915C-8525D77FE92C';
+PRINT 'Amazon Bedrock Cost (Opus 4.1): 64186C02-8782-41C1-B347-415D149133FC';
 PRINT 'Azure Cost (GPT-5): 32256481-17B2-4D99-BA39-99C969462459';
 PRINT 'Azure Cost (GPT-5 Mini): 866EF5E1-67BF-4090-840F-0C51C88228BA';
 PRINT 'Azure Cost (GPT-5 Nano): 1A383960-A7D7-457F-81CC-A40DB36F0098';

--- a/migrations/v2/V202508080930__v2.83.x__Add_GPT5_Models.sql
+++ b/migrations/v2/V202508080930__v2.83.x__Add_GPT5_Models.sql
@@ -1,0 +1,461 @@
+-- Add GPT-5 models and Claude Opus 4.1 with model developer and inference provider associations
+-- This migration adds:
+-- 1. Azure as a new AI Vendor (if not exists)
+-- 2. Azure vendor types for inference provider
+-- 3. GPT-5 as a new AI Model
+-- 4. GPT-5 Mini as a new AI Model  
+-- 5. GPT-5 Nano as a new AI Model
+-- 6. Claude Opus 4.1 as a new AI Model
+-- 7. AIModelVendor associations for OpenAI as the model developer for GPT-5 models
+-- 8. AIModelVendor associations for Anthropic as the model developer and inference provider for Opus 4.1
+-- 9. AIModelVendor associations for OpenAI and Azure as inference providers
+-- 10. Cost tracking records for OpenAI, Azure, and Anthropic pricing
+
+-- Variable placeholders for vendor IDs 
+DECLARE @OpenAIVendorID UNIQUEIDENTIFIER = 'D8A5CCEC-6A37-EF11-86D4-000D3A4E707E'; -- OpenAI Vendor ID 
+DECLARE @AzureVendorID UNIQUEIDENTIFIER = 'D75ABC84-6BDB-41B9-94C7-2FE748482193'; -- Azure Vendor ID
+DECLARE @AnthropicVendorID UNIQUEIDENTIFIER = 'DAA5CCEC-6A37-EF11-86D4-000D3A4E707E'; -- Anthropic Vendor ID
+
+-- Model IDs for the new models
+DECLARE @GPT5ModelID UNIQUEIDENTIFIER = '87C351DF-5039-4E1D-A2E9-CF5B91927E5E';
+DECLARE @GPT5MiniModelID UNIQUEIDENTIFIER = '028491AF-48A3-4235-93A7-44A4E91F14C0';
+DECLARE @GPT5NanoModelID UNIQUEIDENTIFIER = '0221217D-2037-48F8-AED0-286F53A165DF';
+DECLARE @Opus41ModelID UNIQUEIDENTIFIER = '2C5EA224-85A1-4D09-ABA6-0D52F2E6AFBB';
+
+-- Type IDs
+DECLARE @LLMTypeID UNIQUEIDENTIFIER = 'E8A5CCEC-6A37-EF11-86D4-000D3A4E707E';
+DECLARE @ModelDeveloperTypeID UNIQUEIDENTIFIER = '10DB468E-F2CE-475D-9F39-2DF2DE75D257';
+DECLARE @InferenceProviderTypeID UNIQUEIDENTIFIER = '5B043EC3-1FF2-4730-B5D2-7CFDA50979B3';
+
+-- 1. Create Azure vendor record (if not exists)
+IF NOT EXISTS (SELECT 1 FROM ${flyway:defaultSchema}.AIVendor WHERE ID = @AzureVendorID)
+BEGIN
+    INSERT INTO ${flyway:defaultSchema}.AIVendor 
+        (ID, Name, Description)
+    VALUES 
+        (
+            @AzureVendorID,
+            'Azure',
+            'Microsoft Azure cloud platform providing AI inference services for OpenAI models'
+        );
+END
+
+-- 2. Create Azure vendor type for inference provider
+IF NOT EXISTS (SELECT 1 FROM ${flyway:defaultSchema}.AIVendorType WHERE VendorID = @AzureVendorID AND TypeID = @InferenceProviderTypeID)
+BEGIN
+    INSERT INTO ${flyway:defaultSchema}.AIVendorType 
+        (ID, VendorID, TypeID, Rank, Status)
+    VALUES 
+        (
+            'B0A79AC2-74F7-4FDE-AAE0-B201550D5CDB',
+            @AzureVendorID,
+            @InferenceProviderTypeID,
+            5, -- Rank
+            'Active'
+        );
+END
+
+-- 3. Create GPT-5 model record
+INSERT INTO ${flyway:defaultSchema}.AIModel 
+    (ID, Name, Description, AIModelTypeID, IsActive, PowerRank, SpeedRank, CostRank)
+VALUES 
+    (
+        @GPT5ModelID,
+        'GPT-5',
+        'OpenAI''s flagship model combining reasoning abilities with fast responses. Smartest, fastest, most useful model with 272k input and 128k output token limits. 45% less likely to hallucinate than GPT-4o.',
+        @LLMTypeID, -- LLM type
+        1, -- IsActive
+        20, -- PowerRank (highest power)
+        9, -- SpeedRank (fast)
+        5  -- CostRank (moderate - $1.25/$10 per M tokens)
+    );
+
+-- 4. Create GPT-5 Mini model record
+INSERT INTO ${flyway:defaultSchema}.AIModel 
+    (ID, Name, Description, AIModelTypeID, IsActive, PowerRank, SpeedRank, CostRank)
+VALUES 
+    (
+        @GPT5MiniModelID,
+        'GPT-5 Mini',
+        'Smaller, cost-efficient version of GPT-5 with excellent performance for most tasks. Supports 272k input and 128k output tokens with fast response times.',
+        @LLMTypeID, -- LLM type
+        1, -- IsActive
+        15, -- PowerRank (powerful)
+        10, -- SpeedRank (fastest)
+        8  -- CostRank (low cost - $0.25/$2 per M tokens)
+    );
+
+-- 5. Create GPT-5 Nano model record
+INSERT INTO ${flyway:defaultSchema}.AIModel 
+    (ID, Name, Description, AIModelTypeID, IsActive, PowerRank, SpeedRank, CostRank)
+VALUES 
+    (
+        @GPT5NanoModelID,
+        'GPT-5 Nano',
+        'Ultra-efficient smallest version of GPT-5 optimized for high-volume, low-latency applications. Supports 272k input and 128k output tokens.',
+        @LLMTypeID, -- LLM type
+        1, -- IsActive
+        12, -- PowerRank (good for its size)
+        10, -- SpeedRank (ultra fast)
+        10  -- CostRank (cheapest - $0.05/$0.40 per M tokens)
+    );
+
+-- 6. Create Claude Opus 4.1 model record
+INSERT INTO ${flyway:defaultSchema}.AIModel 
+    (ID, Name, Description, AIModelTypeID, IsActive, PowerRank, SpeedRank, CostRank)
+VALUES 
+    (
+        @Opus41ModelID,
+        'Claude Opus 4.1',
+        'Anthropic''s most advanced model with 74.5% on SWE-bench Verified. Released August 5, 2025, with improved agentic tasks, real-world coding, and reasoning capabilities. Supports 200k token context window.',
+        @LLMTypeID, -- LLM type
+        1, -- IsActive
+        19, -- PowerRank (very powerful, comparable to GPT-5)
+        7, -- SpeedRank (good speed)
+        3  -- CostRank (expensive - $15/$75 per M tokens)
+    );
+
+-- 7. Create AI Model Vendor associations for OpenAI as model developer (all 3 GPT-5 models)
+INSERT INTO ${flyway:defaultSchema}.AIModelVendor 
+    (ID, ModelID, VendorID, TypeID, Priority, Status, SupportedResponseFormats, SupportsEffortLevel, SupportsStreaming)
+VALUES 
+    -- GPT-5 Model Developer
+    (
+        'B3D650CE-978D-4E03-8CCB-BA4ABBACB3A0',
+        @GPT5ModelID,
+        @OpenAIVendorID,
+        @ModelDeveloperTypeID,
+        0, -- Priority
+        'Active',
+        'Any',
+        0, -- SupportsEffortLevel
+        0  -- SupportsStreaming
+    ),
+    -- GPT-5 Mini Model Developer
+    (
+        '3AD0029B-B02A-4D79-B3D9-2B69097AE3B9',
+        @GPT5MiniModelID,
+        @OpenAIVendorID,
+        @ModelDeveloperTypeID,
+        0, -- Priority
+        'Active',
+        'Any',
+        0, -- SupportsEffortLevel
+        0  -- SupportsStreaming
+    ),
+    -- GPT-5 Nano Model Developer
+    (
+        'A39697E3-9AE3-457F-B921-7D173CC22310',
+        @GPT5NanoModelID,
+        @OpenAIVendorID,
+        @ModelDeveloperTypeID,
+        0, -- Priority
+        'Active',
+        'Any',
+        0, -- SupportsEffortLevel
+        0  -- SupportsStreaming
+    );
+
+-- 8. Create AI Model Vendor associations for Anthropic as model developer and inference provider for Opus 4.1
+INSERT INTO ${flyway:defaultSchema}.AIModelVendor 
+    (ID, ModelID, VendorID, TypeID, Priority, Status, SupportedResponseFormats, SupportsEffortLevel, SupportsStreaming)
+VALUES 
+    -- Opus 4.1 Model Developer
+    (
+        'FDA4F858-F4B1-4256-A180-94C730F362CC',
+        @Opus41ModelID,
+        @AnthropicVendorID,
+        @ModelDeveloperTypeID,
+        0, -- Priority
+        'Active',
+        'Any',
+        0, -- SupportsEffortLevel
+        0  -- SupportsStreaming
+    );
+
+-- 9. Create AI Model Vendor association for Anthropic as inference provider for Opus 4.1
+INSERT INTO ${flyway:defaultSchema}.AIModelVendor 
+    (ID, ModelID, VendorID, TypeID, APIName, Priority, Status, SupportedResponseFormats, SupportsEffortLevel, SupportsStreaming, DriverClass, MaxInputTokens, MaxOutputTokens)
+VALUES 
+    -- Opus 4.1 on Anthropic
+    (
+        '61369B16-0F95-4F4B-87EF-F64FD2F728E1',
+        @Opus41ModelID,
+        @AnthropicVendorID,
+        @InferenceProviderTypeID,
+        'claude-opus-4-1-20250805', -- Anthropic API name
+        0, -- Priority (highest)
+        'Active',
+        'Any, JSON',
+        0, -- SupportsEffortLevel
+        1, -- SupportsStreaming
+        'AnthropicLLM',
+        200000, -- MaxInputTokens (200k context window)
+        4096  -- MaxOutputTokens (4k output limit)
+    );
+
+-- 10. Create AI Model Vendor associations for OpenAI as inference provider (all 3 GPT-5 models)
+INSERT INTO ${flyway:defaultSchema}.AIModelVendor 
+    (ID, ModelID, VendorID, TypeID, APIName, Priority, Status, SupportedResponseFormats, SupportsEffortLevel, SupportsStreaming, DriverClass, MaxInputTokens, MaxOutputTokens)
+VALUES 
+    -- GPT-5 on OpenAI
+    (
+        'FC307EF5-EA02-4EBF-8553-8A81A436702B',
+        @GPT5ModelID,
+        @OpenAIVendorID,
+        @InferenceProviderTypeID,
+        'gpt-5', -- OpenAI API name
+        0, -- Priority (highest - OpenAI preferred over Azure)
+        'Active',
+        'Any, JSON',
+        1, -- SupportsEffortLevel
+        1, -- SupportsStreaming
+        'OpenAILLM',
+        272000, -- MaxInputTokens (272k context window)
+        128000  -- MaxOutputTokens (128k output limit)
+    ),
+    -- GPT-5 Mini on OpenAI
+    (
+        '945C1236-B7C2-4F6B-A535-0915BF861CC0',
+        @GPT5MiniModelID,
+        @OpenAIVendorID,
+        @InferenceProviderTypeID,
+        'gpt-5-mini', -- OpenAI API name
+        0, -- Priority (highest - OpenAI preferred over Azure)
+        'Active',
+        'Any, JSON',
+        1, -- SupportsEffortLevel
+        1, -- SupportsStreaming
+        'OpenAILLM',
+        128000, -- MaxInputTokens (128k context window)
+        32000  -- MaxOutputTokens (32k output limit)
+    ),
+    -- GPT-5 Nano on OpenAI
+    (
+        '6F6210A5-72F2-4D76-AD19-B2E49A9E2FA8',
+        @GPT5NanoModelID,
+        @OpenAIVendorID,
+        @InferenceProviderTypeID,
+        'gpt-5-nano', -- OpenAI API name
+        0, -- Priority (highest - OpenAI preferred over Azure)
+        'Active',
+        'Any, JSON',
+        1, -- SupportsEffortLevel
+        1, -- SupportsStreaming
+        'OpenAILLM',
+        512000, -- MaxInputTokens (512k context window)
+        128000  -- MaxOutputTokens (128k output limit)
+    );
+
+-- 11. Create AI Model Vendor associations for Azure as inference provider (all 3 GPT-5 models)
+INSERT INTO ${flyway:defaultSchema}.AIModelVendor 
+    (ID, ModelID, VendorID, TypeID, APIName, Priority, Status, SupportedResponseFormats, SupportsEffortLevel, SupportsStreaming, DriverClass, MaxInputTokens, MaxOutputTokens)
+VALUES 
+    -- GPT-5 on Azure
+    (
+        'C00086B7-E296-40BE-95D4-1FDEDFAAC79D',
+        @GPT5ModelID,
+        @AzureVendorID,
+        @InferenceProviderTypeID,
+        'gpt-5', -- Azure API name (same as OpenAI)
+        10, -- Priority (lower than OpenAI)
+        'Active',
+        'Any, JSON',
+        1, -- SupportsEffortLevel
+        1, -- SupportsStreaming
+        'AzureOpenAILLM',
+        272000, -- MaxInputTokens (272k context window)
+        128000  -- MaxOutputTokens (128k output limit)
+    ),
+    -- GPT-5 Mini on Azure
+    (
+        'B964EDCF-625C-4D0B-B0FC-C1D5E8CF24B1',
+        @GPT5MiniModelID,
+        @AzureVendorID,
+        @InferenceProviderTypeID,
+        'gpt-5-mini', -- Azure API name (same as OpenAI)
+        10, -- Priority (lower than OpenAI)
+        'Active',
+        'Any, JSON',
+        1, -- SupportsEffortLevel
+        1, -- SupportsStreaming
+        'AzureOpenAILLM',
+        128000, -- MaxInputTokens (128k context window)
+        32000  -- MaxOutputTokens (32k output limit)
+    ),
+    -- GPT-5 Nano on Azure
+    (
+        '3E7D9C36-3C18-42F5-AE09-562E2C2436BC',
+        @GPT5NanoModelID,
+        @AzureVendorID,
+        @InferenceProviderTypeID,
+        'gpt-5-nano', -- Azure API name (same as OpenAI)
+        10, -- Priority (lower than OpenAI)
+        'Active',
+        'Any, JSON',
+        1, -- SupportsEffortLevel
+        1, -- SupportsStreaming
+        'AzureOpenAILLM',
+        272000, -- MaxInputTokens (272k context window)
+        128000  -- MaxOutputTokens (128k output limit)
+    );
+
+-- 12. Add cost tracking records for OpenAI pricing
+INSERT INTO ${flyway:defaultSchema}.AIModelCost 
+    (ID, ModelID, VendorID, StartedAt, EndedAt, Status, Currency, PriceTypeID, InputPricePerUnit, OutputPricePerUnit, UnitTypeID, ProcessingType, Comments)
+VALUES 
+    -- GPT-5 on OpenAI
+    (
+        '5F8BC862-CFAF-4DD9-BEB0-C723C8447597',
+        @GPT5ModelID,
+        @OpenAIVendorID,
+        GETDATE(),
+        NULL,
+        'Active',
+        'USD',
+        'ece2bcb7-c854-4bf7-a517-d72793a40652', -- Standard token pricing type
+        1.25, -- $1.25 per M input tokens
+        10.00, -- $10.00 per M output tokens
+        '54208f7d-331c-40ab-84e8-163338ee9ea1', -- Per 1M tokens unit type
+        'Realtime',
+        'GPT-5 pricing on OpenAI as of August 2025'
+    ),
+    -- GPT-5 Mini on OpenAI
+    (
+        '4D4CB947-AA09-48E6-9FF3-43C6AA75D58E',
+        @GPT5MiniModelID,
+        @OpenAIVendorID,
+        GETDATE(),
+        NULL,
+        'Active',
+        'USD',
+        'ece2bcb7-c854-4bf7-a517-d72793a40652', -- Standard token pricing type
+        0.25, -- $0.25 per M input tokens
+        2.00, -- $2.00 per M output tokens
+        '54208f7d-331c-40ab-84e8-163338ee9ea1', -- Per 1M tokens unit type
+        'Realtime',
+        'GPT-5 Mini pricing on OpenAI as of August 2025'
+    ),
+    -- GPT-5 Nano on OpenAI
+    (
+        '060C9269-CCA4-41A0-99DC-55A95D17A3E0',
+        @GPT5NanoModelID,
+        @OpenAIVendorID,
+        GETDATE(),
+        NULL,
+        'Active',
+        'USD',
+        'ece2bcb7-c854-4bf7-a517-d72793a40652', -- Standard token pricing type
+        0.05, -- $0.05 per M input tokens
+        0.40, -- $0.40 per M output tokens
+        '54208f7d-331c-40ab-84e8-163338ee9ea1', -- Per 1M tokens unit type
+        'Realtime',
+        'GPT-5 Nano pricing on OpenAI as of August 2025'
+    );
+
+-- 13. Add cost tracking record for Anthropic Opus 4.1 pricing
+INSERT INTO ${flyway:defaultSchema}.AIModelCost 
+    (ID, ModelID, VendorID, StartedAt, EndedAt, Status, Currency, PriceTypeID, InputPricePerUnit, OutputPricePerUnit, UnitTypeID, ProcessingType, Comments)
+VALUES 
+    -- Opus 4.1 on Anthropic
+    (
+        '28C400E6-4DAC-4DE2-915C-8525D77FE92C',
+        @Opus41ModelID,
+        @AnthropicVendorID,
+        GETDATE(),
+        NULL,
+        'Active',
+        'USD',
+        'ece2bcb7-c854-4bf7-a517-d72793a40652', -- Standard token pricing type
+        15.00, -- $15.00 per M input tokens
+        75.00, -- $75.00 per M output tokens
+        '54208f7d-331c-40ab-84e8-163338ee9ea1', -- Per 1M tokens unit type
+        'Realtime',
+        'Claude Opus 4.1 pricing on Anthropic as of August 2025'
+    );
+
+-- 14. Add cost tracking records for Azure pricing
+INSERT INTO ${flyway:defaultSchema}.AIModelCost 
+    (ID, ModelID, VendorID, StartedAt, EndedAt, Status, Currency, PriceTypeID, InputPricePerUnit, OutputPricePerUnit, UnitTypeID, ProcessingType, Comments)
+VALUES 
+    -- GPT-5 on Azure
+    (
+        '32256481-17B2-4D99-BA39-99C969462459',
+        @GPT5ModelID,
+        @AzureVendorID,
+        GETDATE(),
+        NULL,
+        'Active',
+        'USD',
+        'ece2bcb7-c854-4bf7-a517-d72793a40652', -- Standard token pricing type
+        1.25, -- $1.25 per M input tokens (same as OpenAI)
+        10.00, -- $10.00 per M output tokens (same as OpenAI)
+        '54208f7d-331c-40ab-84e8-163338ee9ea1', -- Per 1M tokens unit type
+        'Realtime',
+        'GPT-5 pricing on Azure as of August 2025'
+    ),
+    -- GPT-5 Mini on Azure
+    (
+        '866EF5E1-67BF-4090-840F-0C51C88228BA',
+        @GPT5MiniModelID,
+        @AzureVendorID,
+        GETDATE(),
+        NULL,
+        'Active',
+        'USD',
+        'ece2bcb7-c854-4bf7-a517-d72793a40652', -- Standard token pricing type
+        0.25, -- $0.25 per M input tokens (same as OpenAI)
+        2.00, -- $2.00 per M output tokens (same as OpenAI)
+        '54208f7d-331c-40ab-84e8-163338ee9ea1', -- Per 1M tokens unit type
+        'Realtime',
+        'GPT-5 Mini pricing on Azure as of August 2025'
+    ),
+    -- GPT-5 Nano on Azure
+    (
+        '1A383960-A7D7-457F-81CC-A40DB36F0098',
+        @GPT5NanoModelID,
+        @AzureVendorID,
+        GETDATE(),
+        NULL,
+        'Active',
+        'USD',
+        'ece2bcb7-c854-4bf7-a517-d72793a40652', -- Standard token pricing type
+        0.05, -- $0.05 per M input tokens (same as OpenAI)
+        0.40, -- $0.40 per M output tokens (same as OpenAI)
+        '54208f7d-331c-40ab-84e8-163338ee9ea1', -- Per 1M tokens unit type
+        'Realtime',
+        'GPT-5 Nano pricing on Azure as of August 2025'
+    );
+
+-- Log the operation
+PRINT 'Successfully added GPT-5 models and Claude Opus 4.1:';
+PRINT 'GPT-5 Model ID: ' + CAST(@GPT5ModelID AS NVARCHAR(50));
+PRINT 'GPT-5 Mini Model ID: ' + CAST(@GPT5MiniModelID AS NVARCHAR(50));
+PRINT 'GPT-5 Nano Model ID: ' + CAST(@GPT5NanoModelID AS NVARCHAR(50));
+PRINT 'Claude Opus 4.1 Model ID: ' + CAST(@Opus41ModelID AS NVARCHAR(50));
+PRINT '';
+PRINT 'Azure Vendor ID: ' + CAST(@AzureVendorID AS NVARCHAR(50));
+PRINT '';
+PRINT 'Model Developer Associations:';
+PRINT 'OpenAI Developer (GPT-5): B3D650CE-978D-4E03-8CCB-BA4ABBACB3A0';
+PRINT 'OpenAI Developer (GPT-5 Mini): 3AD0029B-B02A-4D79-B3D9-2B69097AE3B9';
+PRINT 'OpenAI Developer (GPT-5 Nano): A39697E3-9AE3-457F-B921-7D173CC22310';
+PRINT 'Anthropic Developer (Opus 4.1): FDA4F858-F4B1-4256-A180-94C730F362CC';
+PRINT '';
+PRINT 'Inference Provider Associations:';
+PRINT 'OpenAI Inference (GPT-5): FC307EF5-EA02-4EBF-8553-8A81A436702B';
+PRINT 'OpenAI Inference (GPT-5 Mini): 945C1236-B7C2-4F6B-A535-0915BF861CC0';
+PRINT 'OpenAI Inference (GPT-5 Nano): 6F6210A5-72F2-4D76-AD19-B2E49A9E2FA8';
+PRINT 'Anthropic Inference (Opus 4.1): 61369B16-0F95-4F4B-87EF-F64FD2F728E1';
+PRINT 'Azure Inference (GPT-5): C00086B7-E296-40BE-95D4-1FDEDFAAC79D';
+PRINT 'Azure Inference (GPT-5 Mini): B964EDCF-625C-4D0B-B0FC-C1D5E8CF24B1';
+PRINT 'Azure Inference (GPT-5 Nano): 3E7D9C36-3C18-42F5-AE09-562E2C2436BC';
+PRINT '';
+PRINT 'Cost Tracking Records:';
+PRINT 'OpenAI Cost (GPT-5): 5F8BC862-CFAF-4DD9-BEB0-C723C8447597';
+PRINT 'OpenAI Cost (GPT-5 Mini): 4D4CB947-AA09-48E6-9FF3-43C6AA75D58E';
+PRINT 'OpenAI Cost (GPT-5 Nano): 060C9269-CCA4-41A0-99DC-55A95D17A3E0';
+PRINT 'Anthropic Cost (Opus 4.1): 28C400E6-4DAC-4DE2-915C-8525D77FE92C';
+PRINT 'Azure Cost (GPT-5): 32256481-17B2-4D99-BA39-99C969462459';
+PRINT 'Azure Cost (GPT-5 Mini): 866EF5E1-67BF-4090-840F-0C51C88228BA';
+PRINT 'Azure Cost (GPT-5 Nano): 1A383960-A7D7-457F-81CC-A40DB36F0098';

--- a/package-lock.json
+++ b/package-lock.json
@@ -35117,6 +35117,23 @@
         "typescript": "^5.4.5"
       }
     },
+    "packages/Actions/node_modules/@types/node": {
+      "version": "20.8.7",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.8.7.tgz",
+      "integrity": "sha512-21TKHHh3eUHIi2MloeptJWALuCu5H7HQTdTrWIFReA8ad+aggoX+lRes3ex7/FtpC+sVUpFMQ+QTfYr74mruiQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~5.25.1"
+      }
+    },
+    "packages/Actions/node_modules/@types/node/node_modules/undici-types": {
+      "version": "5.25.3",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.25.3.tgz",
+      "integrity": "sha512-Ga1jfYwRn7+cP9v8auvEXN1rX3sWqlayd4HP7OKk4mZWylEmu3KzXDUGrQUN6Ol7qo1gPvB2e5gX6udnyEPgdA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "packages/Actions/node_modules/archiver": {
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/archiver/-/archiver-6.0.2.tgz",
@@ -35362,6 +35379,16 @@
         "rimraf": "^4.4.0"
       }
     },
+    "packages/Actions/ScheduledActionsServer/node_modules/@types/node": {
+      "version": "18.19.122",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.122.tgz",
+      "integrity": "sha512-yzegtT82dwTNEe/9y+CM8cgb42WrUfMMCg2QqSddzO1J6uPmBD7qKCZ7dOHZP2Yrpm/kb0eqdNMn2MUyEiqBmA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~5.26.4"
+      }
+    },
     "packages/Actions/ScheduledActionsServer/node_modules/typescript": {
       "version": "4.9.5",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
@@ -35397,6 +35424,16 @@
         "@types/node": "^18.11.9",
         "rimraf": "^3.0.2",
         "typescript": "^5.0.2"
+      }
+    },
+    "packages/AI/A2AServer/node_modules/@types/node": {
+      "version": "18.19.122",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.122.tgz",
+      "integrity": "sha512-yzegtT82dwTNEe/9y+CM8cgb42WrUfMMCg2QqSddzO1J6uPmBD7qKCZ7dOHZP2Yrpm/kb0eqdNMn2MUyEiqBmA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~5.26.4"
       }
     },
     "packages/AI/A2AServer/node_modules/cosmiconfig": {
@@ -35471,6 +35508,16 @@
         "typescript": "^5.0.0"
       }
     },
+    "packages/AI/AgentManager/actions/node_modules/@types/node": {
+      "version": "18.19.122",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.122.tgz",
+      "integrity": "sha512-yzegtT82dwTNEe/9y+CM8cgb42WrUfMMCg2QqSddzO1J6uPmBD7qKCZ7dOHZP2Yrpm/kb0eqdNMn2MUyEiqBmA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~5.26.4"
+      }
+    },
     "packages/AI/AgentManager/core": {
       "name": "@memberjunction/ai-agent-manager",
       "version": "2.82.0",
@@ -35479,6 +35526,16 @@
         "@types/node": "^18.11.0",
         "rimraf": "^3.0.2",
         "typescript": "^5.0.0"
+      }
+    },
+    "packages/AI/AgentManager/core/node_modules/@types/node": {
+      "version": "18.19.122",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.122.tgz",
+      "integrity": "sha512-yzegtT82dwTNEe/9y+CM8cgb42WrUfMMCg2QqSddzO1J6uPmBD7qKCZ7dOHZP2Yrpm/kb0eqdNMn2MUyEiqBmA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~5.26.4"
       }
     },
     "packages/AI/Agents": {
@@ -35894,7 +35951,7 @@
       "dependencies": {
         "@memberjunction/ai": "2.82.0",
         "@memberjunction/global": "2.82.0",
-        "groq-sdk": "0.30.0"
+        "groq-sdk": "^0.30.0"
       },
       "devDependencies": {
         "ts-node-dev": "^2.0.0",
@@ -37851,6 +37908,23 @@
         "typescript": "^5.4.5"
       }
     },
+    "packages/Communication/providers/MSGraph/node_modules/@types/node": {
+      "version": "20.19.10",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.10.tgz",
+      "integrity": "sha512-iAFpG6DokED3roLSP0K+ybeDdIX6Bc0Vd3mLW5uDqThPWtNos3E+EqOM11mPQHKzfWHqEBuLjIlsBQQ8CsISmQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "packages/Communication/providers/MSGraph/node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "packages/Communication/providers/sendgrid": {
       "name": "@memberjunction/communication-sendgrid",
       "version": "2.82.0",
@@ -37927,6 +38001,16 @@
         "@types/pdf-parse": "^1.1.4",
         "ts-node-dev": "^2.0.0",
         "typescript": "^5.4.5"
+      }
+    },
+    "packages/ContentAutotagging/node_modules/@types/node": {
+      "version": "18.19.122",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.122.tgz",
+      "integrity": "sha512-yzegtT82dwTNEe/9y+CM8cgb42WrUfMMCg2QqSddzO1J6uPmBD7qKCZ7dOHZP2Yrpm/kb0eqdNMn2MUyEiqBmA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~5.26.4"
       }
     },
     "packages/DocUtils": {


### PR DESCRIPTION
## Summary
- Adds migration for version 2.83.0 to include new AI models
- Includes 3 GPT-5 model variants and Claude Opus 4.1
- Adds Azure as an inference provider for OpenAI models

## Models Added

### GPT-5 Models
- **GPT-5**: Base model with 272k input / 128k output tokens
- **GPT-5 Mini**: Smaller, cost-efficient version ($0.25/$2 per M tokens)
- **GPT-5 Nano**: Ultra-efficient version ($0.05/$0.40 per M tokens)

### Claude Opus 4.1
- Released August 5, 2025
- 74.5% on SWE-bench Verified
- 200k input / 4k output tokens
- $15/$75 per M tokens

## Vendors
- **OpenAI**: Model developer and inference provider for GPT-5 models
- **Azure**: Added as inference provider for GPT-5 models (with registration requirements)
- **Anthropic**: Model developer and inference provider for Opus 4.1

## Test Plan
- [ ] Run migration in test environment
- [ ] Verify all records are created correctly
- [ ] Test model selection with new models
- [ ] Verify Azure vendor is properly configured
- [ ] Confirm cost calculations work with new pricing

## Notes
- All UUIDs generated using command line `uuidgen`
- Azure requires registration for base GPT-5 model access
- GPT-5 Mini and Nano don't require Azure registration

🤖 Generated with [Claude Code](https://claude.ai/code)