### PR TITLE
fix: critical query management and dialog issues

### DIFF
--- a/packages/Angular/Explorer/core-entity-forms/src/lib/custom/AIAgents/ai-agent-form.component.html
+++ b/packages/Angular/Explorer/core-entity-forms/src/lib/custom/AIAgents/ai-agent-form.component.html
@@ -1,6 +1,8 @@
 <div class="record-form-container">
     <!-- Dialog container for Kendo dialogs -->
     <div kendoDialogContainer></div>
+    <!-- Window container for Kendo windows -->
+    <div kendoWindowContainer></div>
     <form *ngIf="record" class="record-form" #form="ngForm">
         <mj-form-toolbar [form]="this"></mj-form-toolbar>
 

--- a/packages/Angular/Explorer/core-entity-forms/src/lib/custom/AIAgents/create-sub-agent-dialog.component.ts
+++ b/packages/Angular/Explorer/core-entity-forms/src/lib/custom/AIAgents/create-sub-agent-dialog.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit, OnDestroy, ChangeDetectorRef, ViewChild } from '@angular/core';
+import { Component, OnInit, OnDestroy, ChangeDetectorRef, ViewChild, ViewContainerRef } from '@angular/core';
 import { FormControl, FormGroup, Validators } from '@angular/forms';
 import { DialogRef, WindowRef } from '@progress/kendo-angular-dialog';
 import { Subject, BehaviorSubject, takeUntil } from 'rxjs';
@@ -81,7 +81,8 @@ export class CreateSubAgentDialogComponent implements OnInit, OnDestroy {
   constructor(
     private dialogRef: WindowRef,
     private cdr: ChangeDetectorRef,
-    private agentManagementService: AIAgentManagementService
+    private agentManagementService: AIAgentManagementService,
+    private viewContainerRef: ViewContainerRef
   ) {
     this.subAgentForm = this.createForm();
   }
@@ -244,7 +245,7 @@ export class CreateSubAgentDialogComponent implements OnInit, OnDestroy {
         selectedPromptIds: [],
         showCreateNew: true,
         linkedPromptIds: linkedPromptIds,
-        viewContainerRef: undefined // Will be top-level modal
+        viewContainerRef: this.viewContainerRef
       }).subscribe({
         next: async (result) => {
           if (result && result.selectedPrompts.length > 0) {
@@ -308,7 +309,7 @@ export class CreateSubAgentDialogComponent implements OnInit, OnDestroy {
       this.agentManagementService.openCreatePromptDialog({
         title: `Create New Prompt for ${this.subAgentEntity?.Name || 'Sub-Agent'}`,
         initialName: '',
-        viewContainerRef: undefined // Will be top-level modal
+        viewContainerRef: this.viewContainerRef
       }).subscribe({
         next: async (result) => {
           if (result && result.prompt) {
@@ -384,7 +385,7 @@ export class CreateSubAgentDialogComponent implements OnInit, OnDestroy {
         agentId: this.subAgentEntity?.ID || '',
         agentName: this.subAgentEntity?.Name || 'Sub-Agent',
         existingActionIds: linkedActionIds,
-        viewContainerRef: undefined // Will be top-level modal
+        viewContainerRef: this.viewContainerRef
       }).subscribe({
         next: async (selectedActions) => {
           if (selectedActions && selectedActions.length > 0) {

--- a/packages/Angular/Explorer/core-entity-forms/src/lib/custom/AIAgents/prompt-selector-dialog.component.ts
+++ b/packages/Angular/Explorer/core-entity-forms/src/lib/custom/AIAgents/prompt-selector-dialog.component.ts
@@ -1,5 +1,5 @@
 import { Component, OnInit, OnDestroy, ChangeDetectorRef } from '@angular/core';
-import { DialogRef } from '@progress/kendo-angular-dialog';
+import { WindowRef } from '@progress/kendo-angular-dialog';
 import { Subject, BehaviorSubject, debounceTime, distinctUntilChanged, takeUntil } from 'rxjs';
 import { FormControl } from '@angular/forms';
 import { RunView } from '@memberjunction/core';
@@ -62,7 +62,7 @@ export class PromptSelectorDialogComponent implements OnInit, OnDestroy {
   viewMode: 'grid' | 'list' = 'list';
 
   constructor(
-    private dialogRef: DialogRef,
+    private dialogRef: WindowRef,
     private cdr: ChangeDetectorRef
   ) {}
 

--- a/packages/Angular/Explorer/core-entity-forms/src/lib/custom/Queries/query-form.component.ts
+++ b/packages/Angular/Explorer/core-entity-forms/src/lib/custom/Queries/query-form.component.ts
@@ -4,7 +4,6 @@ import { RegisterClass } from '@memberjunction/global';
 import { BaseFormComponent } from '@memberjunction/ng-base-forms';
 import { QueryFormComponent } from '../../generated/Entities/Query/query.form.component';
 import { Metadata, RunView, RUN_QUERY_SQL_FILTERS } from '@memberjunction/core';
-import { GraphQLDataProvider } from '@memberjunction/graphql-dataprovider';
 import { MJNotificationService } from '@memberjunction/ng-notifications';
 import { CodeEditorComponent } from '@memberjunction/ng-code-editor';
 import { Subject } from 'rxjs';
@@ -51,7 +50,6 @@ export class QueryFormExtendedComponent extends QueryFormComponent implements On
     ];
     public categories: QueryCategoryEntity[] = [];
     public categoryTreeData: CategoryTreeNode[] = [];
-    private isCategoriesLoaded = false;
     
     // Status options
     public statusOptions = [
@@ -239,7 +237,7 @@ export class QueryFormExtendedComponent extends QueryFormComponent implements On
                 const results = await rv.RunView<QueryPermissionEntity>({
                     EntityName: 'Query Permissions',
                     ExtraFilter: `QueryID='${this.record.ID}'`,
-                    OrderBy: 'Type ASC',
+                    OrderBy: 'Role ASC',
                     ResultType: 'entity_object'
                 });
                 

--- a/packages/Angular/Explorer/form-toolbar/src/lib/form-toolbar.ts
+++ b/packages/Angular/Explorer/form-toolbar/src/lib/form-toolbar.ts
@@ -170,10 +170,18 @@ export class FormToolbarComponent implements OnInit {
     
     public async deleteRecord(): Promise<void> {
         this.toggleDeleteDialog(false);
-        let dependencies: RecordDependency[] = await this.form.GetRecordDependencies();
-        if(dependencies.length > 0){
-            SharedService.Instance.CreateSimpleNotification(`This record cannot be deleted because it is being used by ${dependencies.length} other records.`, 'error', 2000);
-            return;
+        
+        // Check if the entity has cascade deletes enabled
+        const entityInfo = this.form.record?.EntityInfo;
+        const hasCascadeDeletes = entityInfo?.CascadeDeletes === true;
+        
+        // Only check dependencies if cascade deletes are NOT enabled
+        if (!hasCascadeDeletes) {
+            let dependencies: RecordDependency[] = await this.form.GetRecordDependencies();
+            if(dependencies.length > 0){
+                SharedService.Instance.CreateSimpleNotification(`This record cannot be deleted because it is being used by ${dependencies.length} other records.`, 'error', 2000);
+                return;
+            }
         }
 
         const deleteResult: boolean = await this.form.record.Delete();

--- a/packages/MJCoreEntitiesServer/src/custom/QueryEntity.server.ts
+++ b/packages/MJCoreEntitiesServer/src/custom/QueryEntity.server.ts
@@ -219,7 +219,7 @@ export class QueryEntityExtended extends QueryEntity {
         
         try {
             // Get existing query parameters
-            const rv = this.ProviderToUse as any as IRunViewProvider;
+            const rv = new RunView();
             const existingParams: QueryParameterEntity[] = [];
             if (this.IsSaved) {
                 const existingParamsResult = await rv.RunView<QueryParameterEntity>({
@@ -331,7 +331,7 @@ export class QueryEntityExtended extends QueryEntity {
         try {
             if (this.IsSaved) {
                 // Get all existing query parameters
-                const rv = this.ProviderToUse as any as IRunViewProvider;
+                const rv = new RunView();
                 const existingParamsResult = await rv.RunView<QueryParameterEntity>({
                     EntityName: 'MJ: Query Parameters',
                     ExtraFilter: `QueryID='${this.ID}'`,
@@ -364,7 +364,7 @@ export class QueryEntityExtended extends QueryEntity {
             const existingFields: QueryFieldEntity[] = [];
             if (this.IsSaved) {
                 // Get existing query fields
-                const rv = this.ProviderToUse as any as IRunViewProvider;
+                const rv = new RunView();
                 const existingFieldsResult = await rv.RunView<QueryFieldEntity>({
                     EntityName: 'Query Fields',
                     ExtraFilter: `QueryID='${this.ID}'`,
@@ -484,7 +484,7 @@ export class QueryEntityExtended extends QueryEntity {
             // Get existing query entities
             const existingEntities: QueryEntityEntity[] = [];
             if (this.IsSaved) {
-                const rv = this.ProviderToUse as any as IRunViewProvider;
+                const rv = new RunView();
                 const existingEntitiesResult = await rv.RunView<QueryEntityEntity>({
                     EntityName: 'Query Entities',
                     ExtraFilter: `QueryID='${this.ID}'`,
@@ -564,7 +564,7 @@ export class QueryEntityExtended extends QueryEntity {
         try {
             if (!this.IsSaved) return; // Nothing to remove if not saved
 
-            const rv = this.ProviderToUse as any as IRunViewProvider;
+            const rv = new RunView();
             const existingFieldsResult = await rv.RunView<QueryFieldEntity>({
                 EntityName: 'Query Fields',
                 ExtraFilter: `QueryID='${this.ID}'`,
@@ -592,7 +592,7 @@ export class QueryEntityExtended extends QueryEntity {
         try {
             if (!this.IsSaved) return; // Nothing to remove if not saved
             
-            const rv = this.ProviderToUse as any as IRunViewProvider;
+            const rv = new RunView();
             const existingEntitiesResult = await rv.RunView<QueryEntityEntity>({
                 EntityName: 'Query Entities',
                 ExtraFilter: `QueryID='${this.ID}'`,

--- a/packages/MJServer/src/resolvers/MergeRecordsResolver.ts
+++ b/packages/MJServer/src/resolvers/MergeRecordsResolver.ts
@@ -64,7 +64,14 @@ export class RecordDependencyResolver {
       const md = new Metadata();
       const ck = new CompositeKey(ckInput.KeyValuePairs);
       const result = await md.GetRecordDependencies(entityName, ck);
-      return result;
+      
+      // Map PrimaryKey to CompositeKey for GraphQL response
+      return result.map(dep => ({
+        EntityName: dep.EntityName,
+        RelatedEntityName: dep.RelatedEntityName,
+        FieldName: dep.FieldName,
+        CompositeKey: dep.PrimaryKey // Map PrimaryKey to CompositeKey
+      }));
     } catch (e) {
       LogError(e);
       throw e;

--- a/packages/SQLServerDataProvider/src/SQLServerDataProvider.ts
+++ b/packages/SQLServerDataProvider/src/SQLServerDataProvider.ts
@@ -1734,7 +1734,7 @@ export class SQLServerDataProvider
           const parts = kv.split(CompositeKey.DefaultValueDelimiter);
           pkeys[parts[0]] = parts[1];
         });
-        compositeKey.LoadFromEntityInfoAndRecord(entityInfo, keyValues);
+        compositeKey.LoadFromEntityInfoAndRecord(entityInfo, pkeys);
 
         const recordDependency: RecordDependency = {
           EntityName: r.EntityName,


### PR DESCRIPTION
## Summary
- Fixed multiple critical issues affecting query record management and UI dialogs
- Resolved dependency checking errors that prevented record deletion
- Corrected entity instantiation issues in AI-powered extraction

## Issues Fixed

### 1. Query Record Deletion Blocked
**Problem**: Unable to delete Query records even with cascade deletes configured  
**Solution**: Modified delete logic to respect `CascadeDeletes` entity configuration

### 2. GraphQL GetRecordDependencies Error  
**Problem**: "Cannot return null for non-nullable field RecordDependencyResult.CompositeKey"  
**Solution**: Fixed composite key parsing and proper field mapping in resolver

### 3. Query Permissions ORDER BY Error
**Problem**: SQL error "Invalid column name 'Type'" when loading Query Permissions  
**Solution**: Changed ORDER BY from non-existent 'Type' to 'Role' column

### 4. Query Entity AI Extraction Failures
**Problem**: "TypeError: Delete/Save is not a function" during AI extraction  
**Solution**: Use RunView directly instead of incorrect provider casting to ensure proper entity instantiation

### 5. Kendo Dialog/Window Container Errors
**Problem**: NullInjectorError and "Cannot attach window" errors in AI Agent dialogs  
**Solution**: Fixed DialogRef/WindowRef usage and added proper container directives

## Impact
These framework-level fixes benefit:
- All entities with dependencies (proper dependency checking)
- All entities with CascadeDeletes enabled (can be deleted via UI)
- Query management (full CRUD operations including AI extraction)
- AI Agent dialog operations (proper window management)

## Test Plan
- [x] Verify Query records can be deleted when they have dependencies
- [x] Confirm GetRecordDependencies returns proper CompositeKey values
- [x] Test Query Permissions load without ORDER BY errors
- [x] Validate AI extraction properly syncs QueryFields, QueryParameters, and QueryEntities
- [x] Check AI Agent dialogs open without container errors

🤖 Generated with [Claude Code](https://claude.ai/code)