### PR TITLE
chore: bump version to 2.83.0

### DIFF
--- a/.changeset/bump-minor-version.md
+++ b/.changeset/bump-minor-version.md
@@ -1,0 +1,5 @@
+---
+"@memberjunction/core": minor
+---
+
+Bump to version 2.83.0 to align with migration file versioning


### PR DESCRIPTION
## Summary
- Adds changeset to bump @memberjunction/core to minor version 2.83.0
- Fixes version mismatch between expected version (2.83.0) and changeset version (2.82.1)
- Aligns package version with existing migration file v2.83

## Context
The GitHub Action "Build and Publish new Package Version" was failing because changesets only had patch bumps, resulting in version 2.82.1 instead of the expected 2.83.0 to match the migration file.

## Test plan
- [ ] Changesets will properly bump to v2.83.0
- [ ] GitHub Action will pass with matching versions