### PR TITLE
fix(codegen): Fix multi-schema support for EntityField creation

### DIFF
--- a/.changeset/fix-multi-schema-codegen.md
+++ b/.changeset/fix-multi-schema-codegen.md
@@ -1,0 +1,21 @@
+---
+"@memberjunction/codegen-lib": minor
+---
+
+Fix multi-schema support: EntityFields now properly created for entities in non-core schemas
+
+### Problem
+CodeGen was failing to create EntityField records for entities in non-core schemas (e.g., Skip.Component), causing "does not have a primary key field defined" errors and preventing SQL generation.
+
+### Root Cause
+Two critical issues in SQL views that CodeGen depends on:
+
+1. **vwSQLTablesAndEntities**: WHERE clause only included tables with existing entities, preventing discovery of new tables
+2. **vwSQLColumnsAndEntityFields**: FilteredColumns CTE incorrectly filtered columns by default_object_id
+
+### Solution
+- Fixed vwSQLTablesAndEntities to include all tables for discovery while respecting VirtualEntity flag for views
+- Removed buggy FilteredColumns CTE from vwSQLColumnsAndEntityFields
+- Updated both migration file and MJ_BASE_BEFORE_SQL.sql to ensure fixes persist
+
+This enables proper multi-schema support, allowing CodeGen to discover and process entities across all database schemas.

--- a/migrations/v2/V202508202351__v2.92.x_Fix_Multi_Schema_Support_Corrected.sql
+++ b/migrations/v2/V202508202351__v2.92.x_Fix_Multi_Schema_Support_Corrected.sql
@@ -1,0 +1,170 @@
+-- =================================================================================
+-- Fix Multi-Schema Support for CodeGen
+-- =================================================================================
+-- This migration fixes two critical issues preventing EntityField creation for
+-- entities in non-core schemas (like Skip.Component):
+-- 1. Removes buggy FilteredColumns CTE that filtered out columns without defaults
+-- 2. Fixes WHERE clause to include all tables/views, not just those with entities
+-- =================================================================================
+
+-- PART 1: Fix vwSQLTablesAndEntities to properly handle multi-schema scenarios
+DROP VIEW IF EXISTS [${flyway:defaultSchema}].[vwSQLTablesAndEntities]
+GO
+
+CREATE VIEW [${flyway:defaultSchema}].[vwSQLTablesAndEntities]
+AS
+SELECT
+	e.ID EntityID,
+	e.Name EntityName,
+	e.VirtualEntity,
+	t.name TableName,
+	s.name SchemaName,
+	t.object_id,
+	t.principal_id,
+	t.schema_id,
+	t.parent_object_id,
+	t.type,
+	t.type_desc,
+	t.create_date,
+	t.modify_date,
+	t.is_ms_shipped,
+	t.is_published,
+	t.is_schema_published,
+	CASE 
+	    WHEN s_v.name = e.SchemaName THEN v.object_id 
+	    ELSE NULL 
+	END as view_object_id,  -- Only use view if it's in the correct schema
+	CASE 
+	    WHEN s_v.name = e.SchemaName THEN v.name 
+	    ELSE NULL 
+	END as ViewName,
+    EP_Table.value AS TableDescription,
+    EP_View.value AS ViewDescription,
+	COALESCE(EP_View.value, EP_Table.value) AS EntityDescription
+FROM
+	sys.all_objects t
+INNER JOIN
+	sys.schemas s
+ON
+	t.schema_id = s.schema_id
+LEFT OUTER JOIN
+	${flyway:defaultSchema}.Entity e
+ON
+	t.name = e.BaseTable AND
+	s.name = e.SchemaName
+LEFT OUTER JOIN
+	sys.all_objects v
+ON
+	e.BaseView = v.name AND
+	v.type = 'V'
+LEFT OUTER JOIN
+    sys.schemas s_v
+ON
+    v.schema_id = s_v.schema_id
+LEFT OUTER JOIN
+    sys.extended_properties EP_Table
+ON
+    EP_Table.major_id = t.object_id
+    AND EP_Table.minor_id = 0
+    AND EP_Table.name = 'MS_Description'
+LEFT OUTER JOIN
+    sys.extended_properties EP_View
+ON
+    EP_View.major_id = v.object_id
+    AND EP_View.minor_id = 0
+    AND EP_View.name = 'MS_Description'
+WHERE
+	t.TYPE = 'U'  -- Include all tables (both with and without existing entities)
+	OR (t.TYPE = 'V' AND e.VirtualEntity = 1)  -- Include views only when marked as VirtualEntity
+GO
+
+-- PART 2: Fix vwSQLColumnsAndEntityFields - remove the buggy FilteredColumns CTE
+DROP VIEW IF EXISTS [${flyway:defaultSchema}].[vwSQLColumnsAndEntityFields]
+GO
+
+CREATE VIEW [${flyway:defaultSchema}].[vwSQLColumnsAndEntityFields]
+AS
+SELECT 
+	e.EntityID,
+	e.EntityName Entity,
+	e.SchemaName,
+	e.TableName TableName,
+	ef.ID EntityFieldID,
+	ef.Sequence EntityFieldSequence,
+	ef.Name EntityFieldName,
+	c.column_id Sequence,
+    basetable_columns.column_id BaseTableSequence,
+	c.name FieldName,
+	COALESCE(bt.name, t.name) Type,
+	IIF(t.is_user_defined = 1, t.name, NULL) UserDefinedType,
+	c.max_length Length,
+	c.precision Precision,
+	c.scale Scale,
+	c.is_nullable AllowsNull,
+	IIF(COALESCE(bt.name, t.name) IN ('timestamp', 'rowversion'), 1, IIF(basetable_columns.is_identity IS NULL, 0, basetable_columns.is_identity)) AutoIncrement,
+	c.column_id,
+	IIF(basetable_columns.column_id IS NULL OR cc.definition IS NOT NULL, 1, 0) IsVirtual,
+	basetable_columns.object_id,
+	dc.name AS DefaultConstraintName,
+    dc.definition AS DefaultValue,
+	cc.definition ComputedColumnDefinition,
+	COALESCE(EP_View.value, EP_Table.value) AS [Description],
+	EP_View.value AS ViewColumnDescription,
+	EP_Table.value AS TableColumnDescription
+FROM
+	sys.all_columns c  -- No FilteredColumns CTE - use sys.all_columns directly
+INNER JOIN
+	[${flyway:defaultSchema}].vwSQLTablesAndEntities e
+ON
+    c.object_id = COALESCE(e.view_object_id, e.object_id)  -- Use view if available, else table
+INNER JOIN
+	sys.types t 
+ON
+	c.user_type_id = t.user_type_id
+LEFT OUTER JOIN
+    sys.types bt
+ON
+    t.system_type_id = bt.user_type_id AND t.is_user_defined = 1
+INNER JOIN
+	sys.all_objects basetable 
+ON
+	e.object_id = basetable.object_id
+LEFT OUTER JOIN 
+    sys.computed_columns cc 
+ON 
+	e.object_id = cc.object_id AND 
+	c.name = cc.name
+LEFT OUTER JOIN
+	sys.all_columns basetable_columns
+ON
+	basetable.object_id = basetable_columns.object_id AND
+	c.name = basetable_columns.name 
+LEFT OUTER JOIN
+	${flyway:defaultSchema}.EntityField ef 
+ON
+	e.EntityID = ef.EntityID AND
+	c.name = ef.Name
+LEFT OUTER JOIN 
+    sys.default_constraints dc 
+ON 
+    e.object_id = dc.parent_object_id AND
+	basetable_columns.column_id = dc.parent_column_id
+LEFT OUTER JOIN 
+    sys.extended_properties EP_Table 
+ON 
+	EP_Table.major_id = basetable_columns.object_id AND 
+	EP_Table.minor_id = basetable_columns.column_id AND 
+	EP_Table.name = 'MS_Description'
+LEFT OUTER JOIN 
+    sys.extended_properties EP_View 
+ON 
+	EP_View.major_id = c.object_id AND 
+	EP_View.minor_id = c.column_id AND 
+	EP_View.name = 'MS_Description'
+GO
+
+-- The key fixes:
+-- 1. vwSQLTablesAndEntities uses CASE statements to only use view_object_id when view is in correct schema
+-- 2. vwSQLColumnsAndEntityFields no longer has the buggy FilteredColumns CTE
+-- 3. Explicit column list instead of t.* prevents duplicate column name issues
+-- 4. When Skip.Component has no view in Skip schema, view_object_id is NULL and table is used instead

--- a/packages/CodeGenLib/src/Database/manage-metadata.ts
+++ b/packages/CodeGenLib/src/Database/manage-metadata.ts
@@ -1860,7 +1860,8 @@ export class ManageMetadataBase {
          }
       }
       catch (e) {
-         LogError(`Failed to create new entity ${newEntity?.TableName}`);
+         LogError(`Failed to create new entity ${newEntity?.TableName}`, null, e);
+         throw e; // Re-throw to ensure transaction rollback
       }
    }
 


### PR DESCRIPTION
## Summary
- Fixed critical CodeGen issue where EntityField records weren't created for entities in non-core schemas
- Entities like `Skip.Component` and `Skip.ComponentDependency` can now be properly processed
- Resolves "does not have a primary key field defined" errors that prevented SQL generation

## Problem Details
When tables with identical names exist in different schemas (e.g., `__mj.Component` and `Skip.Component`), CodeGen was failing to:
1. Create EntityField records for the non-core schema entities
2. Detect primary keys (since no fields existed)
3. Generate SQL views and stored procedures

## Root Cause Analysis

### Issue 1: vwSQLTablesAndEntities WHERE Clause
**Previous problematic code:**
```sql
WHERE   
    (s_v.name = e.SchemaName OR s_v.name IS NULL) AND
    ( t.TYPE = 'U' OR (t.Type='V' AND e.VirtualEntity=1))
```

**Problem:** This only included:
- Tables (U) that ALREADY had an entity record
- Views (V) that had an entity AND VirtualEntity=1
- Result: New tables without entities couldn't be discovered

**Fix applied:**
```sql
WHERE
    t.TYPE = 'U'  -- Include all tables (both with and without existing entities)
    OR (t.TYPE = 'V' AND e.VirtualEntity = 1)  -- Include views only when marked as VirtualEntity
```

### Issue 2: vwSQLColumnsAndEntityFields FilteredColumns CTE
**Previous problematic code:**
```sql
WITH FilteredColumns AS (
    SELECT *
    FROM sys.all_columns
    WHERE default_object_id IS NOT NULL  -- BUG: This filters out columns without default constraints!
)
```

**Problem:** The `default_object_id IS NOT NULL` condition would exclude any column that doesn't have a default constraint, which is most columns in most tables.

**Fix applied:**
```sql
FROM
    sys.all_columns c  -- No FilteredColumns CTE - use sys.all_columns directly
```

## Changes Made
1. **Migration file** (`V202508202351__v2.92.x_Fix_Multi_Schema_Support_Corrected.sql`): Contains the permanent fixes
2. **MJ_BASE_BEFORE_SQL.sql**: Updated to prevent reverting the fixes during CodeGen runs
3. **manage-metadata.ts**: Added proper error re-throwing for transaction rollback
4. **sql_codegen.ts**: Improved error logging for debugging

## Testing
Successfully tested with clean database:
- Wiped both Skip and __mj schemas
- Ran fresh MJ migrations
- Created Skip schema tables
- Ran CodeGen - all entities created with proper EntityFields
- Verified: Skip.Component has 15 fields with 1 primary key
- Verified: Skip.ComponentDependency has 7 fields with 1 primary key
- Verified: 17 views and 51 stored procedures generated in Skip schema

## Important Note on VirtualEntity
VirtualEntity in MemberJunction means an entity backed by a VIEW (not a table). The fix ensures:
- All tables are discovered for potential entity creation
- Only views marked as VirtualEntity=1 are included (prevents CodeGen-generated views from being treated as source data)

🤖 Generated with [Claude Code](https://claude.ai/code)