### PR TITLE
Jf skip

### DIFF
--- a/.changeset/many-bags-tease.md
+++ b/.changeset/many-bags-tease.md
@@ -1,0 +1,10 @@
+---
+"@memberjunction/metadata-sync": patch
+"@memberjunction/cli": patch
+---
+
+feat(metadata-sync): add deleteRecord feature for removing records via sync
+
+- Added deleteRecord directive to mark records for deletion in JSON files
+- Records with deleteRecord.delete=true are deleted during push operations
+- After successful deletion, adds deletedAt timestamp to track when deleted

--- a/package-lock.json
+++ b/package-lock.json
@@ -36655,6 +36655,7 @@
       "version": "2.95.0",
       "license": "ISC",
       "dependencies": {
+        "@memberjunction/actions-base": "2.95.0",
         "@memberjunction/ai-core-plus": "2.95.0",
         "@memberjunction/ai-engine-base": "2.95.0",
         "@memberjunction/core": "2.95.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -35375,6 +35375,23 @@
         "typescript": "^5.4.5"
       }
     },
+    "packages/Actions/node_modules/@types/node": {
+      "version": "20.8.7",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.8.7.tgz",
+      "integrity": "sha512-21TKHHh3eUHIi2MloeptJWALuCu5H7HQTdTrWIFReA8ad+aggoX+lRes3ex7/FtpC+sVUpFMQ+QTfYr74mruiQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~5.25.1"
+      }
+    },
+    "packages/Actions/node_modules/@types/node/node_modules/undici-types": {
+      "version": "5.25.3",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.25.3.tgz",
+      "integrity": "sha512-Ga1jfYwRn7+cP9v8auvEXN1rX3sWqlayd4HP7OKk4mZWylEmu3KzXDUGrQUN6Ol7qo1gPvB2e5gX6udnyEPgdA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "packages/Actions/node_modules/archiver": {
       "version": "6.0.2",
       "license": "MIT",

--- a/packages/Angular/Generic/skip-chat/src/lib/skip-chat/skip-chat.component.ts
+++ b/packages/Angular/Generic/skip-chat/src/lib/skip-chat/skip-chat.component.ts
@@ -768,6 +768,11 @@ export class SkipChatComponent extends BaseManagedComponent implements OnInit, A
             
             // Automatically show artifact if the new AI message has one
             this.autoShowArtifactIfPresent(aiDetail);
+            
+            // Check if the conversation name was updated on the server (especially when artifacts are created)
+            if (aiDetail.ArtifactID) {
+              await this.syncConversationNameFromServer(conversation.ID);
+            }
           }
           // NOTE: we don't create a user notification at this point, that is done on the server and via GraphQL subscriptions it tells us and we update the UI automatically...
         }
@@ -1603,6 +1608,11 @@ export class SkipChatComponent extends BaseManagedComponent implements OnInit, A
           
           // Automatically show artifact if the new AI message has one
           this.autoShowArtifactIfPresent(aiDetail);
+          
+          // Check if the conversation name was updated on the server (especially when artifacts are created)
+          if (aiDetail.ArtifactID) {
+            await this.syncConversationNameFromServer(this.SelectedConversation.ID);
+          }
           // NOTE: we don't create a user notification at this point, that is done on the server and via GraphQL subscriptions it tells us and we update the UI automatically...
         }
       }
@@ -2506,6 +2516,30 @@ export class SkipChatComponent extends BaseManagedComponent implements OnInit, A
     } catch (error) {
       LogError(`Error stopping processing: ${error}`);
       this.notificationService.CreateSimpleNotification('Failed to stop processing', 'error', 3000);
+    }
+  }
+
+  /**
+   * Checks if the conversation name was updated on the server and syncs it to the UI
+   * This typically happens when artifacts are created and Skip renames the conversation
+   * @param conversationId The ID of the conversation to check
+   */
+  private async syncConversationNameFromServer(conversationId: string): Promise<void> {
+    const p = this.ProviderToUse;
+    const updatedConvo = <ConversationEntity>await p.GetEntityObject('Conversations', p.CurrentUser);
+    await updatedConvo.Load(conversationId);
+    
+    if (this.SelectedConversation && updatedConvo.Name !== this.SelectedConversation.Name) {
+      // Update the conversation name in memory
+      this.SelectedConversation.Name = updatedConvo.Name;
+      
+      // Update the conversation in the list
+      const idx = this.Conversations.findIndex((c) => c.ID === conversationId);
+      if (idx >= 0) {
+        this.Conversations[idx].Name = updatedConvo.Name;
+        // Trigger change detection for the list
+        this.Conversations = [...this.Conversations];
+      }
     }
   }
 

--- a/packages/MJCLI/src/commands/sync/push.ts
+++ b/packages/MJCLI/src/commands/sync/push.ts
@@ -175,8 +175,8 @@ export default class Push extends Command {
         created: result.created,
         updated: result.updated,
         unchanged: result.unchanged,
-        deleted: 0,
-        skipped: 0,
+        deleted: result.deleted || 0,
+        skipped: result.skipped || 0,
         errors: result.errors,
         duration: endTime - startTime,
       });

--- a/packages/MetadataSync/CHANGELOG.md
+++ b/packages/MetadataSync/CHANGELOG.md
@@ -1,5 +1,29 @@
 # @memberjunction/metadata-sync
 
+## Unreleased
+
+### Minor Changes
+
+- **deleteRecord Feature**: Added support for deleting records from the database through the metadata sync tool
+  - New `deleteRecord` directive allows marking records for deletion in JSON files
+  - Records are deleted when `deleteRecord.delete` is set to `true`
+  - After successful deletion, the tool updates the JSON with a `deletedAt` timestamp
+  - Delete operations are included in SQL logs when SQL logging is enabled
+  - Supports dry-run mode to preview deletions without executing them
+  - Handles foreign key constraint errors gracefully with helpful error messages
+  - Primary key is required to identify which record to delete
+  - Once deleted (indicated by `deletedAt`), subsequent push operations skip the deletion
+  - Takes precedence over normal create/update operations when present
+
+### Implementation Details
+
+- Modified `PushService.ts` to detect and process deleteRecord directives
+- Added new `processDeleteRecord` method to handle deletion logic
+- Updated `RecordData` interface to include optional `deleteRecord` field
+- Modified `JsonWriteHelper` to properly serialize the deleteRecord field
+- Delete operations generate appropriate SQL DELETE statements in migration logs
+- Error handling provides detailed context for troubleshooting failed deletions
+
 ## 2.95.0
 
 ### Patch Changes

--- a/packages/MetadataSync/README.md
+++ b/packages/MetadataSync/README.md
@@ -64,7 +64,7 @@ The Metadata Sync tool bridges the gap between database-stored metadata and file
 - **External files**: Store large text fields (prompts, templates, etc.) in appropriate formats (.md, .html, .sql)
 - **File references**: Use `@file:filename.ext` to link external files from JSON
 
-### Embedded Collections (NEW)
+### Embedded Collections
 - **Related Entities**: Store related records as arrays within parent JSON files
 - **Hierarchical References**: Use `@parent:` and `@root:` to reference parent/root entity fields
 - **Automatic Metadata**: Related entities maintain their own primaryKey and sync metadata
@@ -526,7 +526,7 @@ Each JSON file contains one record:
 }
 ```
 
-#### Multiple Records per File (NEW)
+#### Multiple Records per File
 JSON files can contain arrays of records:
 ```json
 [
@@ -604,7 +604,7 @@ metadata/
 }
 ```
 
-### Record with Embedded Collections (NEW)
+### Record with Embedded Collections
 ```json
 {
   "fields": {
@@ -706,7 +706,7 @@ The tool automatically detects primary key fields from entity metadata:
 - **Auto-detection**: Tool reads entity metadata to determine primary key structure
 - **No hardcoding**: Works with any primary key field name(s)
 
-### deleteRecord Directive (NEW)
+### deleteRecord Directive
 The tool now supports deleting records from the database using a special `deleteRecord` directive in JSON files. This allows you to remove obsolete records as part of your metadata sync workflow:
 
 #### How to Delete a Record
@@ -800,7 +800,7 @@ Examples:
 - `@lookup:AI Prompt Categories.Name=Examples?create` - Creates if missing
 - `@lookup:AI Prompt Categories.Name=Examples?create&Description=Example prompts` - Creates with description
 
-#### Multi-Field Lookups (NEW)
+#### Multi-Field Lookups
 When you need to match records based on multiple criteria, use the multi-field syntax:
 ```json
 {
@@ -811,13 +811,13 @@ When you need to match records based on multiple criteria, use the multi-field s
 
 This ensures you get the exact record you want when multiple records might have the same value in a single field.
 
-### @parent: References (NEW)
+### @parent: References 
 Reference fields from the immediate parent entity in embedded collections:
 - `@parent:ID` - Get the parent's ID field
 - `@parent:Name` - Get the parent's Name field
 - Works with any field from the parent entity
 
-### @root: References (NEW)
+### @root: References
 Reference fields from the root entity in nested structures:
 - `@root:ID` - Get the root entity's ID
 - `@root:CategoryID` - Get the root's CategoryID
@@ -1179,7 +1179,7 @@ This ensures that included content can contain other special references that wil
 - Those @file references are resolved to their actual content
 - If the @file points to a JSON file with @include directives, those are also processed
 
-### @template: References (NEW)
+### @template: References
 Enable JSON template composition for reusable configurations:
 
 #### String Template Reference
@@ -1268,7 +1268,7 @@ mj sync pull --entity="AI Prompts"
 # Pull specific records by filter
 mj sync pull --entity="AI Prompts" --filter="CategoryID='customer-service-id'"
 
-# Pull multiple records into a single file (NEW)
+# Pull multiple records into a single file
 mj sync pull --entity="AI Prompts" --multi-file="all-prompts"
 mj sync pull --entity="AI Prompts" --filter="Status='Active'" --multi-file="active-prompts.json"
 
@@ -1278,14 +1278,14 @@ mj sync push
 # Push only specific entity directory
 mj sync push --dir="ai-prompts"
 
-# Push with verbose output (NEW)
+# Push with verbose output
 mj sync push -v
 mj sync push --verbose
 
 # Dry run to see what would change
 mj sync push --dry-run
 
-# Push with parallel processing (NEW)
+# Push with parallel processing
 mj sync push --parallel-batch-size=20  # Process 20 records in parallel (default: 10, max: 50)
 
 # Show status of local vs database
@@ -1314,7 +1314,7 @@ Configuration follows a hierarchical structure:
 - **Entity configs**: Each entity directory has its own config defining the entity type
 - **Inheritance**: All files within an entity directory are treated as records of that entity type
 
-### Parallel Processing (NEW)
+### Parallel Processing
 
 MetadataSync now supports parallel processing of records during push operations, significantly improving performance for large datasets.
 
@@ -1364,7 +1364,7 @@ mj sync push --parallel-batch-size=1
 - Working with complex dependencies
 - Limited database connection pools
 
-### Directory Processing Order (NEW)
+### Directory Processing Order
 
 The MetadataSync tool now supports custom directory processing order to handle dependencies between entity types. This feature ensures that dependent entities are processed in the correct order.
 
@@ -1442,7 +1442,7 @@ In this example:
 - Production subdirectory further adds "drafts"
 - All patterns are cumulative, so production inherits all parent ignores
 
-### SQL Logging (NEW)
+### SQL Logging 
 
 The MetadataSync tool now supports SQL logging for capturing all database operations during push commands. This feature is useful for:
 - Creating migration files from MetadataSync operations
@@ -1565,7 +1565,7 @@ The `filterPatterns` option allows you to include or exclude specific SQL statem
 - `*pattern` - Ends with pattern
 - `pattern` - Exact match
 
-### User Role Validation (NEW)
+### User Role Validation 
 
 MetadataSync now supports validating UserID fields against specific roles in the MemberJunction system. This ensures that only users with appropriate roles can be referenced in metadata files.
 
@@ -1719,7 +1719,7 @@ The validation will:
 }
 ```
 
-## Embedded Collections (NEW)
+## Embedded Collections 
 
 The tool now supports managing related entities as embedded collections within parent JSON files. This is ideal for entities that have a strong parent-child relationship.
 
@@ -1729,7 +1729,7 @@ The tool now supports managing related entities as embedded collections within p
 - **Cleaner Organization**: Fewer files to manage
 - **Relationship Clarity**: Visual representation of data relationships
 
-## Recursive Patterns (NEW)
+## Recursive Patterns 
 
 The tool now supports automatic recursive patterns for self-referencing entities, eliminating the need to manually define each nesting level for hierarchical data structures.
 

--- a/packages/MetadataSync/README.md
+++ b/packages/MetadataSync/README.md
@@ -706,6 +706,63 @@ The tool automatically detects primary key fields from entity metadata:
 - **Auto-detection**: Tool reads entity metadata to determine primary key structure
 - **No hardcoding**: Works with any primary key field name(s)
 
+### deleteRecord Directive (NEW)
+The tool now supports deleting records from the database using a special `deleteRecord` directive in JSON files. This allows you to remove obsolete records as part of your metadata sync workflow:
+
+#### How to Delete a Record
+1. Add a `deleteRecord` section to any record JSON file
+2. Set `delete: true` to mark the record for deletion
+3. Run `mj sync push` to execute the deletion
+4. The tool will update the JSON with a deletion timestamp
+
+#### Syntax
+```json
+{
+  "fields": {
+    "Name": "Obsolete Prompt",
+    "Description": "This prompt is no longer needed"
+  },
+  "primaryKey": {
+    "ID": "550e8400-e29b-41d4-a716-446655440000"
+  },
+  "deleteRecord": {
+    "delete": true
+  }
+}
+```
+
+#### After Deletion
+After successfully deleting the record, the tool updates the JSON file:
+```json
+{
+  "fields": {
+    "Name": "Obsolete Prompt",
+    "Description": "This prompt is no longer needed"
+  },
+  "primaryKey": {
+    "ID": "550e8400-e29b-41d4-a716-446655440000"
+  },
+  "deleteRecord": {
+    "delete": true,
+    "deletedAt": "2024-01-15T14:30:00.000Z"
+  }
+}
+```
+
+#### Important Notes
+- **Primary key required**: You must specify the `primaryKey` to identify which record to delete
+- **One-time operation**: Once `deletedAt` is set, the deletion won't be attempted again
+- **SQL logging**: Delete operations are included in SQL logs when enabled
+- **Foreign key constraints**: Deletions may fail if other records reference this record
+- **Dry-run support**: Use `--dry-run` to preview what would be deleted
+- **Takes precedence**: If `deleteRecord` is present, normal create/update operations are skipped
+
+#### Use Cases
+- Removing deprecated prompts, templates, or configurations
+- Cleaning up test data
+- Synchronizing deletions across environments
+- Maintaining clean metadata through version control
+
 ### @file: References
 When a field value starts with `@file:`, the tool will:
 1. Read content from the specified file for push operations

--- a/packages/MetadataSync/demo/delete-example/.mj-sync.json
+++ b/packages/MetadataSync/demo/delete-example/.mj-sync.json
@@ -1,0 +1,11 @@
+{
+  "entity": "AI Prompts",
+  "pull": {
+    "externalizeFields": ["Prompt"],
+    "ignoreNullFields": true
+  },
+  "push": {
+    "autoCreateMissingRecords": false
+  },
+  "description": "Example demonstrating the deleteRecord feature for removing obsolete prompts"
+}

--- a/packages/MetadataSync/demo/delete-example/README.md
+++ b/packages/MetadataSync/demo/delete-example/README.md
@@ -1,0 +1,58 @@
+# deleteRecord Feature Example
+
+This directory demonstrates the new `deleteRecord` feature for removing records from the database through the metadata sync tool.
+
+## How to Test
+
+1. **Review the test file**: Look at `test-delete.json` to see how a record is marked for deletion
+
+2. **Dry run first** (recommended):
+   ```bash
+   mj sync push --dir ./demo/delete-example --dry-run
+   ```
+   This will show you what would be deleted without actually performing the deletion.
+
+3. **Execute the deletion**:
+   ```bash
+   mj sync push --dir ./demo/delete-example
+   ```
+   This will delete the record from the database and update the JSON file with a `deletedAt` timestamp.
+
+## What Happens
+
+When you run the push command:
+
+1. The tool detects the `deleteRecord` directive with `delete: true`
+2. It verifies the record exists using the `primaryKey`
+3. Deletes the record from the database
+4. Updates the JSON file to add `deletedAt` timestamp
+5. Logs the deletion in SQL logs (if enabled)
+
+## After Deletion
+
+The JSON file will be updated to look like:
+```json
+{
+  "fields": { ... },
+  "primaryKey": { ... },
+  "deleteRecord": {
+    "delete": true,
+    "deletedAt": "2024-01-15T14:30:00.000Z"
+  },
+  "sync": { ... }
+}
+```
+
+## Important Notes
+
+- The `primaryKey` must exist and be valid
+- If the record doesn't exist, the tool will warn you but still mark it as deleted
+- If there are foreign key constraints, the deletion will fail with an error
+- Once `deletedAt` is set, subsequent push operations won't attempt deletion again
+
+## Use Cases
+
+- Removing deprecated prompts
+- Cleaning up test data
+- Synchronizing deletions across environments
+- Maintaining clean metadata through version control

--- a/packages/MetadataSync/demo/delete-example/test-delete.json
+++ b/packages/MetadataSync/demo/delete-example/test-delete.json
@@ -1,0 +1,19 @@
+{
+  "fields": {
+    "Name": "Test Prompt for Deletion",
+    "Description": "This is a test prompt that will be deleted",
+    "TypeID": "@lookup:AI Prompt Types.Name=Chat",
+    "Status": "Active",
+    "Prompt": "This is a test prompt that we will delete to demonstrate the deleteRecord feature."
+  },
+  "primaryKey": {
+    "ID": "TEST-DELETE-550e8400-e29b-41d4-a716-446655440000"
+  },
+  "deleteRecord": {
+    "delete": true
+  },
+  "sync": {
+    "lastModified": "2024-01-15T10:30:00Z",
+    "checksum": "sha256:test1234"
+  }
+}

--- a/packages/MetadataSync/src/lib/json-write-helper.ts
+++ b/packages/MetadataSync/src/lib/json-write-helper.ts
@@ -37,7 +37,7 @@ export class JsonWriteHelper {
         // This is a RecordData object - rebuild with correct order
         const ordered: any = {};
         
-        // Add properties in desired order: fields, relatedEntities, primaryKey, sync
+        // Add properties in desired order: fields, relatedEntities, primaryKey, sync, deleteRecord
         if (data.fields !== undefined) {
           ordered.fields = this.normalizeRecordDataOrder(data.fields);
         }
@@ -49,6 +49,9 @@ export class JsonWriteHelper {
         }
         if (data.sync !== undefined) {
           ordered.sync = this.normalizeRecordDataOrder(data.sync);
+        }
+        if (data.deleteRecord !== undefined) {
+          ordered.deleteRecord = this.normalizeRecordDataOrder(data.deleteRecord);
         }
         
         return ordered;

--- a/packages/MetadataSync/src/lib/sync-engine.ts
+++ b/packages/MetadataSync/src/lib/sync-engine.ts
@@ -33,6 +33,15 @@ export interface RecordData {
     /** SHA256 checksum of the fields object */
     checksum: string;
   };
+  /** Delete record directive for removing records from the database */
+  deleteRecord?: {
+    /** Flag to indicate this record should be deleted */
+    delete: boolean;
+    /** ISO timestamp of when the deletion was performed */
+    deletedAt?: string;
+    /** Flag to indicate the record was not found when attempting deletion */
+    notFound?: boolean;
+  };
 }
 
 /**

--- a/packages/MetadataSync/src/services/PushService.ts
+++ b/packages/MetadataSync/src/services/PushService.ts
@@ -38,6 +38,8 @@ export interface PushResult {
   created: number;
   updated: number;
   unchanged: number;
+  deleted: number;
+  skipped: number;
   errors: number;
   warnings: string[];
   sqlLogPath?: string;
@@ -47,6 +49,8 @@ export interface EntityPushResult {
   created: number;
   updated: number;
   unchanged: number;
+  deleted: number;
+  skipped: number;
   errors: number;
 }
 
@@ -159,6 +163,8 @@ export class PushService {
       let totalCreated = 0;
       let totalUpdated = 0;
       let totalUnchanged = 0;
+      let totalDeleted = 0;
+      let totalSkipped = 0;
       let totalErrors = 0;
       
       // Begin transaction if not in dry-run mode
@@ -173,6 +179,7 @@ export class PushService {
             const warning = `Skipping ${entityDir} - no valid entity configuration`;
             this.warnings.push(warning);
             callbacks?.onWarn?.(warning);
+            totalSkipped++; // Count skipped directories
             continue;
           }
           
@@ -205,7 +212,7 @@ export class PushService {
           }
           
           // Show per-directory summary
-          const dirTotal = result.created + result.updated + result.unchanged;
+          const dirTotal = result.created + result.updated + result.unchanged + result.deleted;
           if (dirTotal > 0 || result.errors > 0) {
             callbacks?.onLog?.(`   Total processed: ${dirTotal} unique records`);
             if (result.created > 0) {
@@ -213,6 +220,9 @@ export class PushService {
             }
             if (result.updated > 0) {
               callbacks?.onLog?.(`   ✓ Updated: ${result.updated}`);
+            }
+            if (result.deleted > 0) {
+              callbacks?.onLog?.(`   ✓ Deleted: ${result.deleted}`);
             }
             if (result.unchanged > 0) {
               callbacks?.onLog?.(`   - Unchanged: ${result.unchanged}`);
@@ -225,6 +235,8 @@ export class PushService {
           totalCreated += result.created;
           totalUpdated += result.updated;
           totalUnchanged += result.unchanged;
+          totalDeleted += result.deleted;
+          totalSkipped += result.skipped;
           totalErrors += result.errors;
         }
         
@@ -264,6 +276,8 @@ export class PushService {
         created: totalCreated,
         updated: totalUpdated,
         unchanged: totalUnchanged,
+        deleted: totalDeleted,
+        skipped: totalSkipped,
         errors: totalErrors,
         warnings: this.warnings,
         sqlLogPath
@@ -303,6 +317,8 @@ export class PushService {
     let created = 0;
     let updated = 0;
     let unchanged = 0;
+    let deleted = 0;
+    let skipped = 0;
     let errors = 0;
     
     // Find all JSON files in the directory
@@ -421,10 +437,14 @@ export class PushService {
                 
                 // Update stats for successful results
                 const result = batchResult.result!;
-                if (!result.isDuplicate) {
+                if (result.isDuplicate) {
+                  skipped++; // Count duplicates as skipped
+                } else {
                   if (result.status === 'created') created++;
                   else if (result.status === 'updated') updated++;
                   else if (result.status === 'unchanged') unchanged++;
+                  else if (result.status === 'deleted') deleted++;
+                  else if (result.status === 'error') errors++;
                 }
               }
             }
@@ -442,10 +462,14 @@ export class PushService {
               );
               
               // Update stats
-              if (!result.isDuplicate) {
+              if (result.isDuplicate) {
+                skipped++; // Count duplicates as skipped
+              } else {
                 if (result.status === 'created') created++;
                 else if (result.status === 'updated') updated++;
                 else if (result.status === 'unchanged') unchanged++;
+                else if (result.status === 'deleted') deleted++;
+                else if (result.status === 'error') errors++;
               }
             } catch (recordError) {
               const errorMsg = `Error processing ${flattenedRecord.entityName} record at ${flattenedRecord.path}: ${recordError}`;
@@ -471,7 +495,7 @@ export class PushService {
       }
     }
     
-    return { created, updated, unchanged, errors };
+    return { created, updated, unchanged, deleted, skipped, errors };
   }
   
   private async processFlattenedRecord(
@@ -480,9 +504,14 @@ export class PushService {
     options: PushOptions,
     batchContext: Map<string, BaseEntity>,
     callbacks?: PushCallbacks
-  ): Promise<{ status: 'created' | 'updated' | 'unchanged' | 'error'; isDuplicate?: boolean }> {
+  ): Promise<{ status: 'created' | 'updated' | 'unchanged' | 'error' | 'deleted'; isDuplicate?: boolean }> {
     const metadata = new Metadata();
     const { record, entityName, parentContext, id: recordId } = flattenedRecord;
+    
+    // Check if this record has a deleteRecord directive
+    if (record.deleteRecord && record.deleteRecord.delete === true) {
+      return await this.processDeleteRecord(flattenedRecord, entityDir, options, callbacks);
+    }
     
     // Use the unique record ID from the flattened record for batch context
     // This ensures we can properly find parent entities even when they're new
@@ -526,7 +555,7 @@ export class PushService {
           const warning = `Record not found: ${entityName} with primaryKey {${pkDisplay}}. To auto-create missing records, set push.autoCreateMissingRecords=true in .mj-sync.json`;
           this.warnings.push(warning);
           callbacks?.onWarn?.(warning);
-          return { status: 'error' };
+          return { status: 'error', isDuplicate: false }; // This will be counted as error, not skipped
         } else {
           // Log that we're creating the missing record
           if (options.verbose) {
@@ -857,7 +886,125 @@ export class PushService {
     return String(value);
   }
   
-  private buildBatchContextKey(entityName: string, record: RecordData): string {
+  private async processDeleteRecord(
+    flattenedRecord: FlattenedRecord,
+    _entityDir: string,
+    options: PushOptions,
+    callbacks?: PushCallbacks
+  ): Promise<{ status: 'deleted'; isDuplicate?: boolean }> {
+    const { record, entityName } = flattenedRecord;
+    
+    // Validate that we have a primary key for deletion
+    if (!record.primaryKey || Object.keys(record.primaryKey).length === 0) {
+      throw new Error(`Cannot delete ${entityName} record without primaryKey. Please specify primaryKey fields.`);
+    }
+    
+    // Check if the deletion has already been processed
+    if (record.deleteRecord?.deletedAt) {
+      if (options.verbose) {
+        callbacks?.onLog?.(`   ℹ️  Record already deleted on ${record.deleteRecord.deletedAt}`);
+      }
+      return { status: 'deleted', isDuplicate: true };
+    }
+    
+    // Load the entity to verify it exists
+    const existingEntity = await this.syncEngine.loadEntity(entityName, record.primaryKey);
+    
+    if (!existingEntity) {
+      const pkDisplay = Object.entries(record.primaryKey)
+        .map(([key, value]) => `${key}=${value}`)
+        .join(', ');
+      
+      const warning = `Record not found for deletion: ${entityName} with primaryKey {${pkDisplay}}`;
+      this.warnings.push(warning);
+      callbacks?.onWarn?.(warning);
+      
+      // Mark as deleted anyway since it doesn't exist
+      if (!record.deleteRecord) {
+        record.deleteRecord = { delete: true };
+      }
+      record.deleteRecord.deletedAt = new Date().toISOString();
+      record.deleteRecord.notFound = true;
+      
+      return { status: 'deleted', isDuplicate: false };
+    }
+    
+    // Log the deletion
+    const entityInfo = this.syncEngine.getEntityInfo(entityName);
+    const primaryKeyDisplay: string[] = [];
+    if (entityInfo) {
+      for (const pk of entityInfo.PrimaryKeys) {
+        primaryKeyDisplay.push(`${pk.Name}: ${existingEntity.Get(pk.Name)}`);
+      }
+    }
+    
+    callbacks?.onLog?.(`🗑️  Deleting ${entityName} record:`);
+    if (primaryKeyDisplay.length > 0) {
+      callbacks?.onLog?.(`   Primary Key: ${primaryKeyDisplay.join(', ')}`);
+    }
+    
+    // Additional info if available
+    const recordName = existingEntity.Get('Name');
+    if (recordName) {
+      callbacks?.onLog?.(`   Name: ${recordName}`);
+    }
+    
+    if (options.dryRun) {
+      callbacks?.onLog?.(`[DRY RUN] Would delete ${entityName} record`);
+      return { status: 'deleted', isDuplicate: false };
+    }
+    
+    // Delete the record
+    try {
+      const deleteResult = await existingEntity.Delete();
+      
+      if (!deleteResult) {
+        // Check the LatestResult for error details
+        const errorMessage = existingEntity.LatestResult?.Message || 'Unknown error';
+        const errorDetails = existingEntity.LatestResult?.Errors?.map(err => 
+          typeof err === 'string' ? err : (err?.message || JSON.stringify(err))
+        )?.join(', ') || '';
+        
+        callbacks?.onError?.(`\n❌ Failed to delete ${entityName} record`);
+        callbacks?.onError?.(`   Primary Key: {${primaryKeyDisplay.join(', ')}}`);
+        callbacks?.onError?.(`   Error: ${errorMessage}`);
+        if (errorDetails) {
+          callbacks?.onError?.(`   Details: ${errorDetails}`);
+        }
+        
+        throw new Error(`Failed to delete ${entityName} record: ${errorMessage}`);
+      }
+      
+      // Update the deleteRecord section with deletedAt timestamp
+      if (!record.deleteRecord) {
+        record.deleteRecord = { delete: true };
+      }
+      record.deleteRecord.deletedAt = new Date().toISOString();
+      
+      if (options.verbose) {
+        callbacks?.onLog?.(`   ✓ Successfully deleted ${entityName} record`);
+      }
+      
+      return { status: 'deleted', isDuplicate: false };
+      
+    } catch (deleteError: any) {
+      console.error(`\n❌ DELETE EXCEPTION for ${entityName}`);
+      console.error(`   Primary Key: {${primaryKeyDisplay.join(', ')}}`);
+      console.error(`   Error: ${deleteError.message || deleteError}`);
+      
+      // Check for specific error patterns
+      if (deleteError.message?.includes('FOREIGN KEY constraint')) {
+        console.error(`   Tip: This record is referenced by other records and cannot be deleted.`);
+        console.error(`   Consider deleting dependent records first.`);
+      } else if (deleteError.message?.includes('permission')) {
+        console.error(`   Tip: You may not have permission to delete this record.`);
+      }
+      
+      throw deleteError;
+    }
+  }
+  
+  private _buildBatchContextKey(entityName: string, record: RecordData): string {
     // Build a unique key for the batch context based on entity name and identifying fields
     const keyParts = [entityName];
     


### PR DESCRIPTION
## Summary

This PR improves the MetadataSync package's handling of record deletion tracking and reporting. 

## Changes

### Deletion Status Tracking
- Added proper distinction between successful deletions, skipped deletions (record not found), and unchanged (already deleted)
- Records not found for deletion now return `'skipped'` status instead of `'deleted'`
- Already-deleted records (with `deletedAt` timestamp) now return `'unchanged'` status

### Metadata Management
- When a record is successfully deleted, any existing `notFound` flag is removed from the metadata
- This ensures the metadata accurately reflects the outcome of deletion attempts

### Reporting Improvements
- Updated per-directory summaries to show skipped records separately
- Fixed total record count calculation to include skipped records
- Improved console output clarity for deletion scenarios

## Testing Performed

1. **Single Record Deletion**: Successfully deleted an individual record and verified it was counted as "deleted"

2. **Cascading Deletes**: Tested deletion of parent records with related child entities, confirming cascading deletes worked correctly

3. **SQL Logging**: Verified that SQL logging captured the DELETE statements executed during deletion operations

4. **Non-existent Record Deletion**: Attempted to delete a record that didn't exist in the database:
   - Confirmed it showed warning: "Record not found for deletion"
   - Verified it was counted as "skipped" in statistics
   - Confirmed `notFound: true` was set in metadata

5. **Re-deletion of Missing Record**: When a record previously marked `notFound: true` was found and deleted:
   - Verified successful deletion
   - Confirmed `notFound` flag was removed from metadata
   - Verified `deletedAt` timestamp was added

6. **Already-Deleted Records**: Records with existing `deletedAt` timestamps:
   - Confirmed they were counted as "unchanged" (not skipped)
   - Verified no deletion attempt was made

## Example Output

### Before (incorrect):
```
📁 metadata/queries:
✔ Processed metadata/queries
   Total processed: 2 unique records
   ✓ Deleted: 1
   - Unchanged: 1
```

### After (correct):
```
📁 metadata/queries:
›   Warning: Record not found for deletion: Queries with primaryKey {ID=1ED5F822-5B12-45DB-A376-324CF65B0CAF}
✔ Processed metadata/queries
   Total processed: 2 records
   - Unchanged: 1
   - Skipped: 1
```

## Impact
- More accurate reporting of sync operations
- Better visibility into failed deletion attempts
- Cleaner metadata files with accurate deletion status