### PR TITLE
Component registry cache fix

### DIFF
--- a/.changeset/dry-colts-mix.md
+++ b/.changeset/dry-colts-mix.md
@@ -1,0 +1,5 @@
+---
+"@memberjunction/server": patch
+---
+
+Component Registry Cache Fix. Pass Registry ID, not Name to cache method

--- a/packages/MJServer/src/resolvers/ComponentRegistryResolver.ts
+++ b/packages/MJServer/src/resolvers/ComponentRegistryResolver.ts
@@ -175,7 +175,7 @@ export class ComponentRegistryExtendedResolver {
             
             // Optional: Cache in database if configured
             if (this.shouldCache(registry)) {
-                await this.cacheComponent(component, registryName, user);
+                await this.cacheComponent(component, registry.ID, user);
             }
             
             // Return the ComponentSpec as a JSON string


### PR DESCRIPTION
This pull request addresses a bug in the component registry caching logic by ensuring the correct registry identifier is used when caching components. The main change is to pass the registry's unique ID rather than its name to the cache method, which improves reliability and prevents potential cache conflicts.

Component Registry Caching Fixes:

* Updated the call to `cacheComponent` in `ComponentRegistryExtendedResolver` to use `registry.ID` instead of `registryName`, ensuring the correct identifier is passed for caching.
* Documented the fix in `.changeset/dry-colts-mix.md` as a patch for `@memberjunction/server`.

### Symptom
While working with Skip, after Skip created the Component, there is a call to cache to Component on the Skip Client. The MJAPI app on the Skip Client attempts to store the information in the client DB's Components Entity and logs a failure to convert a string value into a uniqueidentifier: RequestError: Conversion failed when converting from a character string to uniqueidentifier. 

The SourceRegistryID property was set to 'Skip' which is the Name of the Registry but it's expecting the ID of the Registry. 

### Testing
After making the change, the SourceRegistryID property is set to the uniqueidentifier for the Skip Registry, a new Component record has been created in the Skip Client's DB and there's no error in the Skip Client's log.