### PR TITLE
Improved linter rules for Components with Queries

### DIFF
--- a/.changeset/kind-olives-camp.md
+++ b/.changeset/kind-olives-camp.md
@@ -1,0 +1,5 @@
+---
+"@memberjunction/react-test-harness": patch
+---
+
+Improved linting for RunQuery


### PR DESCRIPTION
This pull request adds new validation logic to the `component-linter.ts` file to improve enforcement of query usage in React components. The main focus is on ensuring that components with defined queries in their `dataRequirements` properly use the `RunQuery` utility, and that all required properties are present when calling `RunQuery`.

**Validation improvements for query usage:**

* Added a new lint rule (`required-queries-not-called`) that checks if components with queries defined in `dataRequirements` (in `queries` or `hybrid` mode) actually call `RunQuery`. If not, a critical violation is reported, including a detailed suggestion and example for correct usage.

* Enhanced the existing validation for `RunQuery` calls to report a critical violation when the required `QueryName` property is missing, providing more precise feedback.