### PR TITLE
Add user email tracking to Component Registry

### DIFF
--- a/.changeset/soft-bugs-sniff.md
+++ b/.changeset/soft-bugs-sniff.md
@@ -1,0 +1,6 @@
+---
+"@memberjunction/component-registry-client-sdk": patch
+"@memberjunction/server": patch
+---
+
+Add user email support to Component Registry Client SDK for usage tracking. The SDK now sends authenticated user email to component registry servers via query parameters (GET requests) or request body (POST requests), enabling per-user analytics and contact tracking.

--- a/packages/ComponentRegistryClientSDK/src/ComponentRegistryClient.ts
+++ b/packages/ComponentRegistryClientSDK/src/ComponentRegistryClient.ts
@@ -63,8 +63,8 @@ export class ComponentRegistryClient {
    * Returns ComponentResponse which includes hash and notModified flag
    */
   async getComponentWithHash(params: GetComponentParams): Promise<ComponentResponse> {
-    const { namespace, name, version = 'latest', hash } = params;
-    
+    const { namespace, name, version = 'latest', hash, userEmail } = params;
+
     // Build query parameters
     const queryParams = new URLSearchParams();
     if (version !== 'latest') {
@@ -73,13 +73,16 @@ export class ComponentRegistryClient {
     if (hash) {
       queryParams.append('hash', hash);
     }
-    
+    if (userEmail) {
+      queryParams.append('userEmail', userEmail);
+    }
+
     const queryString = queryParams.toString();
     const path = `/api/v1/components/${encodeURIComponent(namespace)}/${encodeURIComponent(name)}${queryString ? `?${queryString}` : ''}`;
-    
+
     try {
       const response = await this.makeRequest('GET', path);
-      
+
       // Handle 304 Not Modified response
       if (response && typeof response === 'object' && 'message' in response && response.message === 'Not modified') {
         return {
@@ -87,7 +90,7 @@ export class ComponentRegistryClient {
           notModified: true
         } as ComponentResponse;
       }
-      
+
       return response as ComponentResponse;
     } catch (error) {
       if (error instanceof RegistryError) {

--- a/packages/ComponentRegistryClientSDK/src/types.ts
+++ b/packages/ComponentRegistryClientSDK/src/types.ts
@@ -63,26 +63,31 @@ export interface GetComponentParams {
    * Registry identifier
    */
   registry: string;
-  
+
   /**
    * Component namespace
    */
   namespace: string;
-  
+
   /**
    * Component name
    */
   name: string;
-  
+
   /**
    * Component version (defaults to 'latest')
    */
   version?: string;
-  
+
   /**
    * Optional hash for caching - if provided and matches current spec, returns 304
    */
   hash?: string;
+
+  /**
+   * User email for tracking and analytics (optional)
+   */
+  userEmail?: string;
 }
 
 /**

--- a/packages/MJServer/src/resolvers/ComponentRegistryResolver.ts
+++ b/packages/MJServer/src/resolvers/ComponentRegistryResolver.ts
@@ -210,7 +210,8 @@ export class ComponentRegistryExtendedResolver {
                 namespace,
                 name,
                 version: version || 'latest',
-                hash: hash
+                hash: hash,
+                userEmail: user.Email
             });
             
             // If not modified (304), return response with notModified flag


### PR DESCRIPTION
Adds user email support to Component Registry for usage tracking and analytics.

## Changes
- Component Registry Client SDK now sends user email in requests
- GraphQL resolver passes authenticated user's email to registry servers
- Supports both GET (query params) and POST (body) requests

## Packages
- `@memberjunction/component-registry-client-sdk` - minor
- `@memberjunction/server` - patch