### PR TITLE
Add documentation automation slash commands

### DIFF
--- a/.claude/commands/analyze-readme-health.md
+++ b/.claude/commands/analyze-readme-health.md
@@ -1,14 +1,20 @@
 ---
-directory: Directory to analyze (default: packages)
-outputFormat: Report format - summary, detailed, or json (default: summary)
+arguments: The directory to analyze and optional format (e.g., "packages/AI summary" or "packages/AI detailed")
 ---
 
 # Analyze README Health
 
 You are auditing the documentation health of the MemberJunction monorepo. Your task is to analyze README coverage, quality, and freshness across all packages.
 
-**Target Directory**: {{directory}}
-**Output Format**: {{outputFormat}}
+## Parse Arguments
+
+First, parse the arguments from: `{{arguments}}`
+
+**Expected format**: `[directory] [outputFormat]`
+- `directory`: Path to analyze (default: `packages`)
+- `outputFormat`: `summary` (default), `detailed`, or `json`
+
+Extract these values and use them throughout this command. If arguments is empty, use defaults.
 
 ## Purpose
 

--- a/.claude/commands/update-folder-readme.md
+++ b/.claude/commands/update-folder-readme.md
@@ -8,6 +8,8 @@ You are creating or updating a folder-level README that serves as an overview an
 
 **Folder Path**: {{folderPath}}
 
+> Note: If `{{folderPath}}` appears literally above, the argument wasn't passed. Check the ARGUMENTS line below and use that path instead.
+
 ## Purpose
 
 Folder-level READMEs provide:

--- a/.claude/commands/update-package-readme.md
+++ b/.claude/commands/update-package-readme.md
@@ -8,6 +8,8 @@ You are a documentation specialist for MemberJunction. Your task is to analyze a
 
 **Package Path**: {{packagePath}}
 
+> Note: If `{{packagePath}}` appears literally above, the argument wasn't passed. Check the ARGUMENTS line below and use that path instead.
+
 ## Quality Standards
 
 Base your README on the best examples in this repo:

--- a/.claude/commands/update-readmes-batch.md
+++ b/.claude/commands/update-readmes-batch.md
@@ -1,14 +1,20 @@
 ---
-directory: Directory to process (e.g., packages/AI, packages/Actions, or packages for all)
-maxParallel: Maximum parallel tasks (default: 5)
+arguments: Directory to process and optional max parallel count (e.g., "packages/AI" or "packages/AI 5")
 ---
 
 # Batch Update Package READMEs
 
 You are orchestrating README updates across multiple packages in the MemberJunction monorepo. Your task is to update READMEs in topological order (dependencies first) while maximizing parallelism.
 
-**Target Directory**: {{directory}}
-**Max Parallel Tasks**: {{maxParallel}}
+## Parse Arguments
+
+Parse the arguments from: `{{arguments}}`
+
+**Expected format**: `[directory] [maxParallel]`
+- `directory`: Directory to process (e.g., `packages/AI`, `packages/Actions`, or `packages` for all)
+- `maxParallel`: Maximum parallel tasks (default: `5`)
+
+Extract these values and use them throughout this command.
 
 ## Process
 


### PR DESCRIPTION
Add four new Claude Code slash commands to help maintain and improve
package README documentation across the monorepo:

- /update-package-readme: Update a single package's README with
  comprehensive analysis of source code, exports, and dependencies
- /update-readmes-batch: Batch update READMEs with topological ordering
  to process dependencies first, with parallel execution support
- /update-folder-readme: Create/update folder-level READMEs for package
  collections like packages/AI/ with navigation and architecture docs
- /analyze-readme-health: Audit README coverage, quality scoring,
  broken link detection, and prioritized update recommendations