### PR TITLE
3.0 Proposed MJAPI and MJExplorer Refactoring

### DIFF
--- a/plans/3.0-minimal-app-shell-architecture.md
+++ b/plans/3.0-minimal-app-shell-architecture.md
@@ -1,0 +1,1003 @@
+# MemberJunction 3.0: Minimal App Shell Architecture
+
+## Executive Summary
+
+This document defines the architecture for MemberJunction 3.0's **Minimal App Shell Pattern** - a fundamental restructuring that makes MJAPI and MJExplorer nearly empty bootstrapping applications that import all functionality from NPM packages, including customer-generated code.
+
+**Key Decision**: Generated code (entities, actions, forms, resolvers) will be output as **separate publishable packages** rather than files inside the app folders. Apps become pure configuration with ~10-25 lines of code.
+
+**Breaking Change**: This is a 3.0 breaking change. Existing 2.x projects will need migration.
+
+**Customer Environment**: All customer installations will be **monorepo setups by default**.
+
+---
+
+## Problem Statement
+
+### Current State (2.x)
+
+```
+customer-project/
+├── MJAPI/
+│   ├── src/
+│   │   ├── index.ts              # ~34 lines of bootstrap code
+│   │   └── generated/
+│   │       └── generated.ts      # CodeGen writes here
+│   └── package.json
+├── MJExplorer/
+│   ├── src/
+│   │   ├── app/
+│   │   │   ├── app.component.ts  # ~245 lines of auth/bootstrap
+│   │   │   ├── app.module.ts     # ~107 lines of imports
+│   │   │   └── generated/
+│   │   │       └── generated-forms.module.ts  # CodeGen writes here
+│   └── package.json
+├── GeneratedEntities/            # Local package, not published
+└── GeneratedActions/             # Local package, not published
+```
+
+**Problems:**
+1. **Code inside apps gets stale** - When MJ updates, bootstrap logic in apps doesn't update
+2. **Generated code is trapped** - Can't be versioned/published independently
+3. **Duplicate bootstrap logic** - Every customer has same auth setup copied
+4. **Mixed concerns** - Demo components, styling, config all in app folders
+5. **Manual updates required** - Changes to bootstrap patterns require manual intervention
+
+### Desired State (3.0)
+
+```
+customer-project/
+├── packages/
+│   ├── api/                      # ~6 lines
+│   ├── explorer/                 # ~20 lines
+│   ├── generated-entities/       # Publishable package
+│   ├── generated-actions/        # Publishable package
+│   ├── generated-forms/          # Publishable package
+│   └── generated-resolvers/      # Publishable package
+├── mj.config.cjs
+├── package.json                  # Workspace root
+└── turbo.json
+```
+
+**Benefits:**
+- Zero-copy NPM updates for all MJ functionality
+- Generated code as proper packages (versionable, publishable)
+- Apps are pure configuration - nothing to get stale
+- Standard monorepo tooling (Turbo, npm workspaces)
+- CI/CD friendly with standard npm workflows
+
+---
+
+## Architecture Overview
+
+### Core Principle
+
+**Apps import everything, contain nothing.**
+
+```
+┌─────────────────────────────────────────────────────────────────┐
+│                        Customer Monorepo                         │
+├─────────────────────────────────────────────────────────────────┤
+│                                                                  │
+│  ┌──────────────┐     ┌──────────────┐     ┌──────────────┐    │
+│  │  packages/   │     │  packages/   │     │  packages/   │    │
+│  │    api/      │     │  explorer/   │     │  generated-  │    │
+│  │  (~6 lines)  │     │  (~20 lines) │     │   entities/  │    │
+│  └──────┬───────┘     └──────┬───────┘     └──────────────┘    │
+│         │                    │                                   │
+│         │ imports            │ imports                           │
+│         ▼                    ▼                                   │
+│  ┌─────────────────────────────────────────────────────────┐   │
+│  │                   NPM Packages                           │   │
+│  │  @memberjunction/server-bootstrap                        │   │
+│  │  @memberjunction/ng-explorer-core                        │   │
+│  │  @memberjunction/ng-bootstrap                            │   │
+│  │  @memberjunction/core, etc.                              │   │
+│  └─────────────────────────────────────────────────────────┘   │
+│                                                                  │
+└─────────────────────────────────────────────────────────────────┘
+```
+
+### New NPM Packages Required
+
+| Package | Purpose | Extracted From |
+|---------|---------|----------------|
+| `@memberjunction/server-bootstrap` | Server initialization, config loading | MJAPI/src/index.ts |
+| `@memberjunction/ng-bootstrap` | Auth flow, GraphQL setup, metadata loading | MJExplorer/src/app/app.component.ts |
+| `@memberjunction/scaffold-lib` | Templates and generators for MJCLI | New |
+
+---
+
+## Detailed Design
+
+### 1. New Package: `@memberjunction/server-bootstrap`
+
+**Location**: `packages/ServerBootstrap/`
+
+**Purpose**: Encapsulate all server initialization logic so MJAPI becomes a one-liner.
+
+```typescript
+// packages/ServerBootstrap/src/index.ts
+import { serve } from '@memberjunction/server';
+import { cosmiconfigSync } from 'cosmiconfig';
+
+export interface MJServerConfig {
+  configPath?: string;
+  resolverPaths?: string[];
+  beforeStart?: () => Promise<void>;
+  afterStart?: () => Promise<void>;
+}
+
+export async function createMJServer(options: MJServerConfig = {}): Promise<void> {
+  // Load configuration
+  const explorer = cosmiconfigSync('mj');
+  const config = explorer.search(process.cwd());
+
+  // Discover and load generated packages automatically
+  // Uses package.json "mj" field or mj.config.cjs settings
+  await discoverAndLoadGeneratedPackages(config);
+
+  // Build resolver paths
+  const resolverPaths = options.resolverPaths || [];
+
+  // Optional pre-start hook
+  if (options.beforeStart) {
+    await options.beforeStart();
+  }
+
+  // Start server
+  await serve(resolverPaths);
+
+  // Optional post-start hook
+  if (options.afterStart) {
+    await options.afterStart();
+  }
+}
+
+async function discoverAndLoadGeneratedPackages(config: any): Promise<void> {
+  // Auto-import generated packages based on config
+  // This triggers their registration via side effects
+}
+```
+
+**Resulting MJAPI 3.0** (`packages/api/src/index.ts`):
+
+```typescript
+import { createMJServer } from '@memberjunction/server-bootstrap';
+
+// Import generated packages to trigger registration
+import '@mycompany/generated-entities';
+import '@mycompany/generated-actions';
+import '@mycompany/generated-resolvers';
+
+createMJServer().catch(console.error);
+```
+
+**That's it. 6 lines.**
+
+---
+
+### 2. New Package: `@memberjunction/ng-bootstrap`
+
+**Location**: `packages/Angular/Bootstrap/`
+
+**Purpose**: Encapsulate all Angular authentication and initialization logic.
+
+```typescript
+// packages/Angular/Bootstrap/src/lib/bootstrap.module.ts
+import { NgModule, ModuleWithProviders } from '@angular/core';
+import { MJBootstrapComponent } from './bootstrap.component';
+import { MJBootstrapService } from './bootstrap.service';
+
+export interface MJEnvironmentConfig {
+  production: boolean;
+  GRAPHQL_URI: string;
+  GRAPHQL_WS_URI: string;
+  AUTH_TYPE: 'msal' | 'auth0';
+  MJ_CORE_SCHEMA_NAME: string;
+  // Auth provider specific
+  CLIENT_ID?: string;
+  TENANT_ID?: string;
+  AUTH0_DOMAIN?: string;
+  AUTH0_CLIENTID?: string;
+}
+
+@NgModule({
+  declarations: [MJBootstrapComponent],
+  exports: [MJBootstrapComponent]
+})
+export class MJBootstrapModule {
+  static forRoot(environment: MJEnvironmentConfig): ModuleWithProviders<MJBootstrapModule> {
+    return {
+      ngModule: MJBootstrapModule,
+      providers: [
+        { provide: 'MJ_ENVIRONMENT', useValue: environment },
+        MJBootstrapService
+      ]
+    };
+  }
+}
+```
+
+```typescript
+// packages/Angular/Bootstrap/src/lib/bootstrap.component.ts
+@Component({
+  selector: 'mj-bootstrap',
+  template: `
+    <ng-container *ngIf="!hasError && isAuthenticated">
+      <mj-shell></mj-shell>
+    </ng-container>
+    <mj-login *ngIf="!isAuthenticated" (onLogin)="handleLogin($event)"></mj-login>
+    <mj-error *ngIf="hasError" [message]="errorMessage"></mj-error>
+    <mj-validation-banner *ngIf="showValidation"></mj-validation-banner>
+  `
+})
+export class MJBootstrapComponent implements OnInit {
+  // All the auth logic currently in app.component.ts moves here
+}
+```
+
+**Resulting MJExplorer 3.0** (`packages/explorer/src/app/app.module.ts`):
+
+```typescript
+import { NgModule } from '@angular/core';
+import { MJBootstrapModule, MJBootstrapComponent } from '@memberjunction/ng-bootstrap';
+import { MJExplorerModule } from '@memberjunction/ng-explorer-core';
+import { GeneratedFormsModule } from '@mycompany/generated-forms';
+import { environment } from '../environments/environment';
+
+@NgModule({
+  imports: [
+    MJBootstrapModule.forRoot(environment),
+    MJExplorerModule,
+    GeneratedFormsModule
+  ],
+  bootstrap: [MJBootstrapComponent]
+})
+export class AppModule {}
+```
+
+**That's it. ~15 lines.**
+
+---
+
+### 3. New Package: `@memberjunction/scaffold-lib`
+
+**Location**: `packages/Scaffold/`
+
+**Purpose**: Templates and generators used by MJCLI for scaffolding projects.
+
+```
+packages/Scaffold/
+├── src/
+│   ├── index.ts
+│   ├── generators/
+│   │   ├── ProjectGenerator.ts      # Full project scaffolding
+│   │   ├── ApiGenerator.ts          # API-only scaffolding
+│   │   ├── ExplorerGenerator.ts     # Explorer-only scaffolding
+│   │   ├── PackageGenerator.ts      # Generated package scaffolding
+│   │   ├── ActionGenerator.ts       # Action class scaffolding
+│   │   ├── AgentGenerator.ts        # AI Agent scaffolding
+│   │   └── ComponentGenerator.ts    # Angular component scaffolding
+│   ├── templates/
+│   │   ├── project/
+│   │   │   ├── root/
+│   │   │   │   ├── package.json.hbs
+│   │   │   │   ├── turbo.json.hbs
+│   │   │   │   ├── mj.config.cjs.hbs
+│   │   │   │   └── .env.example.hbs
+│   │   │   ├── api/
+│   │   │   │   ├── src/
+│   │   │   │   │   └── index.ts.hbs
+│   │   │   │   ├── package.json.hbs
+│   │   │   │   └── tsconfig.json.hbs
+│   │   │   ├── explorer/
+│   │   │   │   ├── src/
+│   │   │   │   │   ├── app/
+│   │   │   │   │   │   └── app.module.ts.hbs
+│   │   │   │   │   ├── environments/
+│   │   │   │   │   │   ├── environment.ts.hbs
+│   │   │   │   │   │   └── environment.prod.ts.hbs
+│   │   │   │   │   └── main.ts.hbs
+│   │   │   │   ├── angular.json.hbs
+│   │   │   │   └── package.json.hbs
+│   │   │   └── generated/
+│   │   │       ├── entities/
+│   │   │       │   ├── src/
+│   │   │       │   │   └── index.ts.hbs
+│   │   │       │   └── package.json.hbs
+│   │   │       ├── actions/
+│   │   │       ├── forms/
+│   │   │       └── resolvers/
+│   │   ├── action/
+│   │   │   └── action.ts.hbs
+│   │   ├── agent/
+│   │   │   └── agent.ts.hbs
+│   │   └── component/
+│   │       ├── component.ts.hbs
+│   │       ├── component.html.hbs
+│   │       └── component.scss.hbs
+│   └── utils/
+│       ├── TemplateEngine.ts        # Handlebars wrapper
+│       ├── FileWriter.ts            # Safe file writing with rollback
+│       └── PackageManager.ts        # npm/pnpm detection and operations
+└── package.json
+```
+
+---
+
+### 4. MJCLI New Commands
+
+Add to `packages/MJCLI/src/commands/`:
+
+#### `mj new project`
+
+```typescript
+// packages/MJCLI/src/commands/new/project.ts
+import { Command, Flags } from '@oclif/core';
+import { input, select, confirm } from '@inquirer/prompts';
+import { ProjectGenerator } from '@memberjunction/scaffold-lib';
+import ora from 'ora-classic';
+
+export default class NewProject extends Command {
+  static description = 'Create a new MemberJunction 3.0 project';
+
+  static examples = [
+    '<%= config.bin %> new project',
+    '<%= config.bin %> new project --name my-project --auth msal',
+  ];
+
+  static flags = {
+    name: Flags.string({ char: 'n', description: 'Project name' }),
+    path: Flags.string({ char: 'p', description: 'Output path', default: '.' }),
+    auth: Flags.string({
+      description: 'Auth provider',
+      options: ['msal', 'auth0', 'both']
+    }),
+    'skip-api': Flags.boolean({ description: 'Skip API generation' }),
+    'skip-explorer': Flags.boolean({ description: 'Skip Explorer generation' }),
+    'skip-install': Flags.boolean({ description: 'Skip npm install' }),
+  };
+
+  async run(): Promise<void> {
+    const { flags } = await this.parse(NewProject);
+
+    this.log('\n🚀 MemberJunction 3.0 Project Generator\n');
+
+    const config = {
+      name: flags.name || await input({
+        message: 'Project name:',
+        validate: (v) => /^[a-z][a-z0-9-]*$/.test(v) ||
+          'Use lowercase letters, numbers, and hyphens only'
+      }),
+
+      path: flags.path,
+
+      includeApi: flags['skip-api'] ? false : await confirm({
+        message: 'Include API server?',
+        default: true
+      }),
+
+      includeExplorer: flags['skip-explorer'] ? false : await confirm({
+        message: 'Include Explorer UI?',
+        default: true
+      }),
+
+      authProvider: flags.auth as 'msal' | 'auth0' | 'both' || await select({
+        message: 'Authentication provider:',
+        choices: [
+          { name: 'Microsoft Entra (MSAL)', value: 'msal' },
+          { name: 'Auth0', value: 'auth0' },
+          { name: 'Both', value: 'both' }
+        ]
+      }),
+
+      database: await this.getDatabaseConfig(),
+
+      packageScope: await input({
+        message: 'NPM package scope (e.g., @mycompany):',
+        default: '@' + (flags.name || 'myproject').replace(/-/g, ''),
+        validate: (v) => /^@[a-z][a-z0-9-]*$/.test(v) ||
+          'Scope must start with @ followed by lowercase letters'
+      })
+    };
+
+    const spinner = ora();
+    const generator = new ProjectGenerator(config);
+
+    try {
+      spinner.start('Creating project structure...');
+      await generator.createDirectoryStructure();
+      spinner.succeed('Project structure created');
+
+      spinner.start('Generating packages...');
+      await generator.generateAllPackages();
+      spinner.succeed('Packages generated');
+
+      spinner.start('Writing configuration files...');
+      await generator.writeConfigFiles();
+      spinner.succeed('Configuration complete');
+
+      if (!flags['skip-install']) {
+        spinner.start('Installing dependencies (this may take a few minutes)...');
+        await generator.installDependencies();
+        spinner.succeed('Dependencies installed');
+      }
+
+      this.log('\n✅ Project created successfully!\n');
+      this.logNextSteps(config);
+
+    } catch (error) {
+      spinner.fail('Project creation failed');
+      throw error;
+    }
+  }
+
+  private async getDatabaseConfig() {
+    const configureDb = await confirm({
+      message: 'Configure database connection now?',
+      default: true
+    });
+
+    if (!configureDb) {
+      return null;
+    }
+
+    return {
+      host: await input({ message: 'Database host:', default: 'localhost' }),
+      port: await input({ message: 'Database port:', default: '1433' }),
+      database: await input({ message: 'Database name:' }),
+      trustCert: await confirm({
+        message: 'Trust server certificate (for local dev)?',
+        default: true
+      })
+    };
+  }
+
+  private logNextSteps(config: any) {
+    this.log('Next steps:\n');
+    this.log(`  cd ${config.name}`);
+    this.log('  # Edit .env with your database credentials');
+    this.log('  mj codegen        # Generate entity/action code from database');
+    if (config.includeApi) {
+      this.log('  mj start api      # Start the API server');
+    }
+    if (config.includeExplorer) {
+      this.log('  mj start explorer # Start the Explorer UI');
+    }
+    this.log('');
+  }
+}
+```
+
+#### `mj new api` / `mj new explorer`
+
+Simpler variants that create just one component.
+
+#### `mj scaffold action`
+
+```typescript
+// packages/MJCLI/src/commands/scaffold/action.ts
+export default class ScaffoldAction extends Command {
+  static description = 'Scaffold a new MemberJunction Action';
+
+  static flags = {
+    name: Flags.string({ char: 'n', description: 'Action name (PascalCase)' }),
+    category: Flags.string({ char: 'c', description: 'Action category' }),
+    output: Flags.string({ char: 'o', description: 'Output directory' }),
+  };
+
+  async run(): Promise<void> {
+    const { flags } = await this.parse(ScaffoldAction);
+
+    const config = {
+      name: flags.name || await input({
+        message: 'Action name (PascalCase):',
+        validate: (v) => /^[A-Z][a-zA-Z0-9]*$/.test(v) ||
+          'Use PascalCase (e.g., SendEmail, ProcessPayment)'
+      }),
+      category: flags.category || await input({
+        message: 'Category:',
+        default: 'Custom'
+      }),
+      description: await input({ message: 'Description:' }),
+      hasInputParams: await confirm({
+        message: 'Does this action have input parameters?',
+        default: true
+      }),
+      hasOutputParams: await confirm({
+        message: 'Does this action have output parameters?',
+        default: false
+      }),
+    };
+
+    const generator = new ActionGenerator(config);
+    const outputPath = await generator.generate(flags.output);
+
+    this.log(`\n✅ Action "${config.name}" created at ${outputPath}`);
+    this.log('\nNext steps:');
+    this.log('  1. Implement the Run() method in the generated file');
+    this.log('  2. Run: mj codegen --skipdb');
+    this.log('  3. The action will be registered in metadata\n');
+  }
+}
+```
+
+#### `mj scaffold agent`
+
+Similar pattern for AI Agent scaffolding.
+
+#### `mj start api` / `mj start explorer`
+
+```typescript
+// packages/MJCLI/src/commands/start/api.ts
+export default class StartApi extends Command {
+  static description = 'Start the MemberJunction API server';
+
+  static flags = {
+    watch: Flags.boolean({ char: 'w', description: 'Watch mode' }),
+  };
+
+  async run(): Promise<void> {
+    const { flags } = await this.parse(StartApi);
+    const cmd = flags.watch ? 'npm run watch' : 'npm run start';
+
+    execSync(cmd, {
+      stdio: 'inherit',
+      cwd: this.findPackageDir('api')
+    });
+  }
+
+  private findPackageDir(name: string): string {
+    // Look for packages/api, packages/my-api, etc.
+    const candidates = [
+      `packages/${name}`,
+      `packages/my-${name}`,
+      name
+    ];
+    for (const dir of candidates) {
+      if (fs.existsSync(dir)) return dir;
+    }
+    throw new Error(`Cannot find ${name} package`);
+  }
+}
+```
+
+---
+
+### 5. CodeGen Updates
+
+Update `@memberjunction/codegen-lib` to support package-based output.
+
+#### New Configuration Schema
+
+```javascript
+// mj.config.cjs
+module.exports = {
+  // Database settings (unchanged)
+  dbHost: process.env.DB_HOST,
+  dbDatabase: process.env.DB_DATABASE,
+  dbPort: process.env.DB_PORT || 1433,
+  codeGenLogin: process.env.CODEGEN_DB_USERNAME,
+  codeGenPassword: process.env.CODEGEN_DB_PASSWORD,
+
+  // 3.0 CodeGen Output Configuration
+  codeGeneration: {
+    // Output mode: 'packages' (3.0) or 'legacy' (2.x compatibility)
+    outputMode: 'packages',
+
+    // Package scope for generated packages
+    packageScope: '@mycompany',
+
+    // Package configurations
+    packages: {
+      entities: {
+        path: './packages/generated-entities',
+        name: '${packageScope}/generated-entities',
+        // Include demo subclasses
+        includeDemos: false
+      },
+      actions: {
+        path: './packages/generated-actions',
+        name: '${packageScope}/generated-actions'
+      },
+      angularForms: {
+        path: './packages/generated-forms',
+        name: '${packageScope}/generated-forms'
+      },
+      graphqlResolvers: {
+        path: './packages/generated-resolvers',
+        name: '${packageScope}/generated-resolvers'
+      }
+    }
+  },
+
+  // ... rest of config
+};
+```
+
+#### CodeGen Package Output
+
+When `outputMode: 'packages'`, CodeGen will:
+
+1. **Generate package.json** for each generated package:
+   ```json
+   {
+     "name": "@mycompany/generated-entities",
+     "version": "1.0.0",
+     "main": "dist/index.js",
+     "types": "dist/index.d.ts",
+     "scripts": {
+       "build": "tsc"
+     },
+     "dependencies": {
+       "@memberjunction/core": "^3.0.0",
+       "@memberjunction/global": "^3.0.0"
+     }
+   }
+   ```
+
+2. **Generate proper exports**:
+   ```typescript
+   // packages/generated-entities/src/index.ts
+   export * from './generated/entity_subclasses';
+
+   // Side-effect import to register classes
+   import './generated/entity_subclasses';
+
+   export function LoadGeneratedEntities() {
+     // No-op, but prevents tree-shaking
+   }
+   ```
+
+3. **Update workspace package.json** to include generated packages:
+   ```json
+   {
+     "workspaces": [
+       "packages/*"
+     ]
+   }
+   ```
+
+---
+
+### 6. Generated Project Structure
+
+When running `mj new project my-app`, the following is created:
+
+```
+my-app/
+├── packages/
+│   ├── api/
+│   │   ├── src/
+│   │   │   └── index.ts
+│   │   ├── package.json
+│   │   └── tsconfig.json
+│   │
+│   ├── explorer/
+│   │   ├── src/
+│   │   │   ├── app/
+│   │   │   │   └── app.module.ts
+│   │   │   ├── environments/
+│   │   │   │   ├── environment.ts
+│   │   │   │   └── environment.prod.ts
+│   │   │   ├── index.html
+│   │   │   ├── main.ts
+│   │   │   └── styles.scss
+│   │   ├── angular.json
+│   │   ├── package.json
+│   │   └── tsconfig.json
+│   │
+│   ├── generated-entities/
+│   │   ├── src/
+│   │   │   ├── index.ts
+│   │   │   └── generated/
+│   │   │       └── .gitkeep          # CodeGen fills this
+│   │   ├── package.json
+│   │   └── tsconfig.json
+│   │
+│   ├── generated-actions/
+│   │   ├── src/
+│   │   │   ├── index.ts
+│   │   │   └── generated/
+│   │   │       └── .gitkeep
+│   │   ├── package.json
+│   │   └── tsconfig.json
+│   │
+│   ├── generated-forms/
+│   │   ├── src/
+│   │   │   ├── index.ts
+│   │   │   └── generated/
+│   │   │       └── .gitkeep
+│   │   ├── package.json
+│   │   └── tsconfig.json
+│   │
+│   └── generated-resolvers/
+│       ├── src/
+│       │   ├── index.ts
+│       │   └── generated/
+│       │       └── .gitkeep
+│       ├── package.json
+│       └── tsconfig.json
+│
+├── .env.example                      # Template for .env
+├── .env                              # Created with user input (gitignored)
+├── .gitignore
+├── mj.config.cjs                     # MJ configuration
+├── package.json                      # Workspace root
+├── turbo.json                        # Turbo build configuration
+└── README.md
+```
+
+---
+
+## Implementation Tasks
+
+### Package Development
+
+| Task | Package | Description |
+|------|---------|-------------|
+| 1.1 | `@memberjunction/server-bootstrap` | Extract server init from MJAPI |
+| 1.2 | `@memberjunction/ng-bootstrap` | Extract auth/init from MJExplorer |
+| 1.3 | `@memberjunction/scaffold-lib` | Create template engine and generators |
+
+### MJCLI Commands
+
+| Task | Command | Description |
+|------|---------|-------------|
+| 2.1 | `mj new project` | Full project scaffolding wizard |
+| 2.2 | `mj new api` | API-only scaffolding |
+| 2.3 | `mj new explorer` | Explorer-only scaffolding |
+| 2.4 | `mj scaffold action` | Action class scaffolding |
+| 2.5 | `mj scaffold agent` | AI Agent scaffolding |
+| 2.6 | `mj scaffold component` | Angular component scaffolding |
+| 2.7 | `mj start api` | Start API server |
+| 2.8 | `mj start explorer` | Start Explorer UI |
+| 2.9 | `mj start` | Start both (with Turbo) |
+
+### CodeGen Updates
+
+| Task | Description |
+|------|-------------|
+| 3.1 | Add `outputMode: 'packages'` configuration support |
+| 3.2 | Generate package.json for each generated package |
+| 3.3 | Update entity generation to output to package structure |
+| 3.4 | Update action generation to output to package structure |
+| 3.5 | Update Angular forms generation to output to package structure |
+| 3.6 | Update GraphQL resolver generation to output to package structure |
+| 3.7 | Add workspace package.json updates |
+
+### Migration Tooling
+
+| Task | Description |
+|------|-------------|
+| 4.1 | Create `mj migrate to-3.0` command |
+| 4.2 | Analyze existing 2.x project structure |
+| 4.3 | Create migration plan and execute |
+| 4.4 | Update imports in custom code |
+| 4.5 | Verify build and functionality |
+
+### Documentation
+
+| Task | Description |
+|------|-------------|
+| 5.1 | Update getting started guide for 3.0 |
+| 5.2 | Create migration guide from 2.x |
+| 5.3 | Update CLAUDE.md with 3.0 patterns |
+| 5.4 | Update architecture documentation |
+
+---
+
+## Template Examples
+
+### API index.ts Template
+
+```handlebars
+/**
+ * {{projectName}} API Server
+ * Generated by MemberJunction CLI v3.0
+ */
+import { createMJServer } from '@memberjunction/server-bootstrap';
+
+// Import generated packages to trigger class registration
+import '{{packageScope}}/generated-entities';
+import '{{packageScope}}/generated-actions';
+import '{{packageScope}}/generated-resolvers';
+
+{{#if customResolvers}}
+// Import custom resolvers
+import './resolvers';
+{{/if}}
+
+createMJServer({
+  configPath: '../../mj.config.cjs'
+}).catch((error) => {
+  console.error('Failed to start server:', error);
+  process.exit(1);
+});
+```
+
+### Explorer app.module.ts Template
+
+```handlebars
+/**
+ * {{projectName}} Explorer
+ * Generated by MemberJunction CLI v3.0
+ */
+import { NgModule } from '@angular/core';
+import { BrowserModule } from '@angular/platform-browser';
+import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
+
+import { MJBootstrapModule, MJBootstrapComponent } from '@memberjunction/ng-bootstrap';
+import { MJExplorerModule } from '@memberjunction/ng-explorer-core';
+import { CoreGeneratedFormsModule } from '@memberjunction/ng-core-entity-forms';
+import { GeneratedFormsModule } from '{{packageScope}}/generated-forms';
+
+import { environment } from '../environments/environment';
+
+@NgModule({
+  imports: [
+    BrowserModule,
+    BrowserAnimationsModule,
+    MJBootstrapModule.forRoot(environment),
+    MJExplorerModule,
+    CoreGeneratedFormsModule,
+    GeneratedFormsModule
+  ],
+  bootstrap: [MJBootstrapComponent]
+})
+export class AppModule {}
+```
+
+### mj.config.cjs Template
+
+```handlebars
+/**
+ * MemberJunction Configuration
+ * Generated by MemberJunction CLI v3.0
+ */
+module.exports = {
+  // Database Configuration
+  dbHost: process.env.DB_HOST || '{{database.host}}',
+  dbPort: process.env.DB_PORT || {{database.port}},
+  dbDatabase: process.env.DB_DATABASE || '{{database.database}}',
+  dbTrustServerCertificate: {{database.trustCert}},
+
+  // CodeGen Credentials
+  codeGenLogin: process.env.CODEGEN_DB_USERNAME,
+  codeGenPassword: process.env.CODEGEN_DB_PASSWORD,
+
+  // API Credentials
+  dbUsername: process.env.DB_USERNAME,
+  dbPassword: process.env.DB_PASSWORD,
+
+  // MJ Core Schema
+  coreSchema: process.env.MJ_CORE_SCHEMA || '__mj',
+
+  // 3.0 Code Generation Configuration
+  codeGeneration: {
+    outputMode: 'packages',
+    packageScope: '{{packageScope}}',
+
+    packages: {
+      entities: {
+        path: './packages/generated-entities',
+        name: '{{packageScope}}/generated-entities'
+      },
+      actions: {
+        path: './packages/generated-actions',
+        name: '{{packageScope}}/generated-actions'
+      },
+      angularForms: {
+        path: './packages/generated-forms',
+        name: '{{packageScope}}/generated-forms'
+      },
+      graphqlResolvers: {
+        path: './packages/generated-resolvers',
+        name: '{{packageScope}}/generated-resolvers'
+      }
+    }
+  },
+
+  // Server Configuration
+  graphqlPort: process.env.PORT || 4000,
+
+  // Authentication
+  authentication: {
+{{#if (eq authProvider 'msal')}}
+    providers: ['msal'],
+    msal: {
+      clientId: process.env.WEB_CLIENT_ID,
+      tenantId: process.env.TENANT_ID
+    }
+{{else if (eq authProvider 'auth0')}}
+    providers: ['auth0'],
+    auth0: {
+      clientId: process.env.AUTH0_CLIENT_ID,
+      clientSecret: process.env.AUTH0_CLIENT_SECRET,
+      domain: process.env.AUTH0_DOMAIN
+    }
+{{else}}
+    providers: ['msal', 'auth0'],
+    msal: {
+      clientId: process.env.WEB_CLIENT_ID,
+      tenantId: process.env.TENANT_ID
+    },
+    auth0: {
+      clientId: process.env.AUTH0_CLIENT_ID,
+      clientSecret: process.env.AUTH0_CLIENT_SECRET,
+      domain: process.env.AUTH0_DOMAIN
+    }
+{{/if}}
+  }
+};
+```
+
+---
+
+## Migration Guide (2.x to 3.0)
+
+### Automatic Migration
+
+```bash
+cd my-existing-project
+mj migrate to-3.0
+```
+
+The migration command will:
+
+1. **Analyze** current project structure
+2. **Create** new package structure alongside existing
+3. **Move** generated code to new packages
+4. **Update** imports in custom code
+5. **Generate** new minimal app files
+6. **Update** mj.config.cjs with new settings
+7. **Verify** build succeeds
+8. **Clean up** old structure (with confirmation)
+
+### Manual Migration Steps
+
+If automatic migration isn't suitable:
+
+1. Create new project with `mj new project`
+2. Copy custom code to appropriate locations
+3. Update imports to use new package names
+4. Run `mj codegen` to populate generated packages
+5. Test thoroughly
+
+---
+
+## Success Criteria
+
+- [ ] `mj new project` creates fully functional monorepo
+- [ ] Generated project has < 50 lines of custom code total
+- [ ] All MJ updates come via `npm update`
+- [ ] CodeGen outputs to package structure
+- [ ] Existing 2.x projects can migrate
+- [ ] All tests pass
+- [ ] Documentation complete
+
+---
+
+## Open Questions
+
+1. **Package Registry**: Should we recommend customers use a private NPM registry for their generated packages, or is local workspace sufficient?
+   - **Recommendation**: Local workspace by default, document private registry as optional for multi-repo scenarios.
+
+2. **Versioning**: Should generated packages have independent versions or track MJ version?
+   - **Recommendation**: Start at 1.0.0, increment on schema changes. Independent of MJ version.
+
+3. **Custom Code Location**: Where should customers put custom Actions, Agents, etc. that aren't generated?
+   - **Recommendation**: Create `packages/custom-actions/`, `packages/custom-agents/` with similar structure.
+
+---
+
+## Timeline
+
+This is a **3.0 breaking change** to be implemented as a single cohesive release. All components must be completed together - no phasing.
+
+---
+
+*Document Created: 2025-12-01*
+*Status: Planning*
+*Version: 3.0*


### PR DESCRIPTION
Comprehensive architecture document for 3.0 that restructures how customer projects are organized:

- Apps become minimal bootstrapping shells (~10-25 lines of code)
- Generated code outputs to separate publishable packages
- Customer environments are monorepos by default
- All functionality imported from NPM packages
- New bootstrap packages extract auth/init from apps
- MJCLI gains scaffolding commands (mj new project, mj scaffold action)
- CodeGen updated to output to package structure
- Migration tooling for existing 2.x projects