### PR TITLE
Fix npm ci failures: Regenerate package-lock.json with npm 11

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15485,6 +15485,21 @@
       "version": "1.0.2",
       "license": "MIT"
     },
+    "node_modules/bare-events": {
+      "version": "2.8.2",
+      "resolved": "https://registry.npmjs.org/bare-events/-/bare-events-2.8.2.tgz",
+      "integrity": "sha512-riJjyv1/mHLIPX4RwiK+oW9/4c3TEUeORHKefKAKnZ5kyslbN+HXowtbaVEqt4IMUB7OXlfixcs6gsFeo/jhiQ==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "peerDependencies": {
+        "bare-abort-controller": "*"
+      },
+      "peerDependenciesMeta": {
+        "bare-abort-controller": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/bare-fs": {
       "version": "4.1.6",
       "license": "Apache-2.0",
@@ -34630,6 +34645,20 @@
         "turbo-windows-arm64": "2.3.3"
       }
     },
+    "node_modules/turbo-darwin-64": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/turbo-darwin-64/-/turbo-darwin-64-2.3.3.tgz",
+      "integrity": "sha512-bxX82xe6du/3rPmm4aCC5RdEilIN99VUld4HkFQuw+mvFg6darNBuQxyWSHZTtc25XgYjQrjsV05888w1grpaA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
     "node_modules/turbo-darwin-arm64": {
       "version": "2.3.3",
       "cpu": [
@@ -34640,6 +34669,62 @@
       "optional": true,
       "os": [
         "darwin"
+      ]
+    },
+    "node_modules/turbo-linux-64": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/turbo-linux-64/-/turbo-linux-64-2.3.3.tgz",
+      "integrity": "sha512-eHj9OIB0dFaP6BxB88jSuaCLsOQSYWBgmhy2ErCu6D2GG6xW3b6e2UWHl/1Ho9FsTg4uVgo4DB9wGsKa5erjUA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/turbo-linux-arm64": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/turbo-linux-arm64/-/turbo-linux-arm64-2.3.3.tgz",
+      "integrity": "sha512-NmDE/NjZoDj1UWBhMtOPmqFLEBKhzGS61KObfrDEbXvU3lekwHeoPvAMfcovzswzch+kN2DrtbNIlz+/rp8OCg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/turbo-windows-64": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/turbo-windows-64/-/turbo-windows-64-2.3.3.tgz",
+      "integrity": "sha512-O2+BS4QqjK3dOERscXqv7N2GXNcqHr9hXumkMxDj/oGx9oCatIwnnwx34UmzodloSnJpgSqjl8iRWiY65SmYoQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/turbo-windows-arm64": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/turbo-windows-arm64/-/turbo-windows-arm64-2.3.3.tgz",
+      "integrity": "sha512-dW4ZK1r6XLPNYLIKjC4o87HxYidtRRcBeo/hZ9Wng2XM/MqqYkAyzJXJGgRMsc0MMEN9z4+ZIfnSNBrA0b08ag==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
       ]
     },
     "node_modules/turndown": {
@@ -36958,7 +37043,11 @@
       "version": "4.4.2",
       "license": "MIT"
     },
-    "packages/Actions": {},
+    "packages/Actions": {
+      "dev": true,
+      "optional": true,
+      "peer": true
+    },
     "packages/Actions/ApolloEnrichment": {
       "name": "@memberjunction/actions-apollo",
       "version": "2.121.0",
@@ -38199,15 +38288,6 @@
         "rimraf": "^4.4.0"
       }
     },
-    "packages/Actions/ScheduledActionsServer/node_modules/@types/node": {
-      "version": "18.19.130",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.130.tgz",
-      "integrity": "sha512-GRaXQx6jGfL8sKfaIDD6OupbIHBr9jv7Jnaml9tB7l4v068PAOXqfcujMMo5PhbIs6ggR1XODELqahT2R8v0fg==",
-      "dev": true,
-      "dependencies": {
-        "undici-types": "~5.26.4"
-      }
-    },
     "packages/Actions/ScheduledActionsServer/node_modules/typescript": {
       "version": "4.9.5",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
@@ -38592,14 +38672,6 @@
         "typescript": "^5.0.0"
       }
     },
-    "packages/AI/AgentManager/actions/node_modules/@types/node": {
-      "version": "18.19.130",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "undici-types": "~5.26.4"
-      }
-    },
     "packages/AI/AgentManager/core": {
       "name": "@memberjunction/ai-agent-manager",
       "version": "2.121.0",
@@ -38615,14 +38687,6 @@
         "@types/node": "^18.11.0",
         "rimraf": "^3.0.2",
         "typescript": "^5.0.0"
-      }
-    },
-    "packages/AI/AgentManager/core/node_modules/@types/node": {
-      "version": "18.19.130",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "undici-types": "~5.26.4"
       }
     },
     "packages/AI/Agents": {
@@ -39046,230 +39110,11 @@
         }
       }
     },
-    "packages/AI/Providers/Gemini/node_modules/@modelcontextprotocol/sdk": {
-      "version": "1.23.0",
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "ajv": "^8.17.1",
-        "ajv-formats": "^3.0.1",
-        "content-type": "^1.0.5",
-        "cors": "^2.8.5",
-        "cross-spawn": "^7.0.5",
-        "eventsource": "^3.0.2",
-        "eventsource-parser": "^3.0.0",
-        "express": "^5.0.1",
-        "express-rate-limit": "^7.5.0",
-        "pkce-challenge": "^5.0.0",
-        "raw-body": "^3.0.0",
-        "zod": "^3.25 || ^4.0",
-        "zod-to-json-schema": "^3.25.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "peerDependencies": {
-        "@cfworker/json-schema": "^4.1.1",
-        "zod": "^3.25 || ^4.0"
-      },
-      "peerDependenciesMeta": {
-        "@cfworker/json-schema": {
-          "optional": true
-        },
-        "zod": {
-          "optional": false
-        }
-      }
-    },
-    "packages/AI/Providers/Gemini/node_modules/accepts": {
-      "version": "2.0.0",
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "mime-types": "^3.0.0",
-        "negotiator": "^1.0.0"
-      },
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "packages/AI/Providers/Gemini/node_modules/ajv": {
-      "version": "8.17.1",
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "fast-deep-equal": "^3.1.3",
-        "fast-uri": "^3.0.1",
-        "json-schema-traverse": "^1.0.0",
-        "require-from-string": "^2.0.2"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/epoberezkin"
-      }
-    },
-    "packages/AI/Providers/Gemini/node_modules/body-parser": {
-      "version": "2.2.1",
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "bytes": "^3.1.2",
-        "content-type": "^1.0.5",
-        "debug": "^4.4.3",
-        "http-errors": "^2.0.0",
-        "iconv-lite": "^0.7.0",
-        "on-finished": "^2.4.1",
-        "qs": "^6.14.0",
-        "raw-body": "^3.0.1",
-        "type-is": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/express"
-      }
-    },
-    "packages/AI/Providers/Gemini/node_modules/content-disposition": {
-      "version": "1.0.1",
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/express"
-      }
-    },
-    "packages/AI/Providers/Gemini/node_modules/cookie": {
-      "version": "0.7.2",
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "packages/AI/Providers/Gemini/node_modules/cookie-signature": {
-      "version": "1.2.2",
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "engines": {
-        "node": ">=6.6.0"
-      }
-    },
     "packages/AI/Providers/Gemini/node_modules/data-uri-to-buffer": {
       "version": "4.0.1",
       "license": "MIT",
       "engines": {
         "node": ">= 12"
-      }
-    },
-    "packages/AI/Providers/Gemini/node_modules/debug": {
-      "version": "4.4.3",
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "ms": "^2.1.3"
-      },
-      "engines": {
-        "node": ">=6.0"
-      },
-      "peerDependenciesMeta": {
-        "supports-color": {
-          "optional": true
-        }
-      }
-    },
-    "packages/AI/Providers/Gemini/node_modules/encodeurl": {
-      "version": "2.0.0",
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "engines": {
-        "node": ">= 0.8"
-      }
-    },
-    "packages/AI/Providers/Gemini/node_modules/express": {
-      "version": "5.2.0",
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "accepts": "^2.0.0",
-        "body-parser": "^2.2.1",
-        "content-disposition": "^1.0.0",
-        "content-type": "^1.0.5",
-        "cookie": "^0.7.1",
-        "cookie-signature": "^1.2.1",
-        "debug": "^4.4.0",
-        "depd": "^2.0.0",
-        "encodeurl": "^2.0.0",
-        "escape-html": "^1.0.3",
-        "etag": "^1.8.1",
-        "finalhandler": "^2.1.0",
-        "fresh": "^2.0.0",
-        "http-errors": "^2.0.0",
-        "merge-descriptors": "^2.0.0",
-        "mime-types": "^3.0.0",
-        "on-finished": "^2.4.1",
-        "once": "^1.4.0",
-        "parseurl": "^1.3.3",
-        "proxy-addr": "^2.0.7",
-        "qs": "^6.14.0",
-        "range-parser": "^1.2.1",
-        "router": "^2.2.0",
-        "send": "^1.1.0",
-        "serve-static": "^2.2.0",
-        "statuses": "^2.0.1",
-        "type-is": "^2.0.1",
-        "vary": "^1.1.2"
-      },
-      "engines": {
-        "node": ">= 18"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/express"
-      }
-    },
-    "packages/AI/Providers/Gemini/node_modules/finalhandler": {
-      "version": "2.1.1",
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "debug": "^4.4.0",
-        "encodeurl": "^2.0.0",
-        "escape-html": "^1.0.3",
-        "on-finished": "^2.4.1",
-        "parseurl": "^1.3.3",
-        "statuses": "^2.0.1"
-      },
-      "engines": {
-        "node": ">= 18.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/express"
-      }
-    },
-    "packages/AI/Providers/Gemini/node_modules/fresh": {
-      "version": "2.0.0",
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "engines": {
-        "node": ">= 0.8"
       }
     },
     "packages/AI/Providers/Gemini/node_modules/gaxios": {
@@ -39324,109 +39169,6 @@
         "node": ">=18"
       }
     },
-    "packages/AI/Providers/Gemini/node_modules/http-errors": {
-      "version": "2.0.1",
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "depd": "~2.0.0",
-        "inherits": "~2.0.4",
-        "setprototypeof": "~1.2.0",
-        "statuses": "~2.0.2",
-        "toidentifier": "~1.0.1"
-      },
-      "engines": {
-        "node": ">= 0.8"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/express"
-      }
-    },
-    "packages/AI/Providers/Gemini/node_modules/iconv-lite": {
-      "version": "0.7.0",
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "safer-buffer": ">= 2.1.2 < 3.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/express"
-      }
-    },
-    "packages/AI/Providers/Gemini/node_modules/json-schema-traverse": {
-      "version": "1.0.0",
-      "license": "MIT",
-      "optional": true,
-      "peer": true
-    },
-    "packages/AI/Providers/Gemini/node_modules/media-typer": {
-      "version": "1.1.0",
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "engines": {
-        "node": ">= 0.8"
-      }
-    },
-    "packages/AI/Providers/Gemini/node_modules/merge-descriptors": {
-      "version": "2.0.0",
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "packages/AI/Providers/Gemini/node_modules/mime-db": {
-      "version": "1.54.0",
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "packages/AI/Providers/Gemini/node_modules/mime-types": {
-      "version": "3.0.2",
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "mime-db": "^1.54.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/express"
-      }
-    },
-    "packages/AI/Providers/Gemini/node_modules/ms": {
-      "version": "2.1.3",
-      "license": "MIT",
-      "optional": true,
-      "peer": true
-    },
-    "packages/AI/Providers/Gemini/node_modules/negotiator": {
-      "version": "1.0.0",
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
     "packages/AI/Providers/Gemini/node_modules/node-fetch": {
       "version": "3.3.2",
       "license": "MIT",
@@ -39443,36 +39185,6 @@
         "url": "https://opencollective.com/node-fetch"
       }
     },
-    "packages/AI/Providers/Gemini/node_modules/qs": {
-      "version": "6.14.0",
-      "license": "BSD-3-Clause",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "side-channel": "^1.1.0"
-      },
-      "engines": {
-        "node": ">=0.6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "packages/AI/Providers/Gemini/node_modules/raw-body": {
-      "version": "3.0.2",
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "bytes": "~3.1.2",
-        "http-errors": "~2.0.1",
-        "iconv-lite": "~0.7.0",
-        "unpipe": "~1.0.0"
-      },
-      "engines": {
-        "node": ">= 0.10"
-      }
-    },
     "packages/AI/Providers/Gemini/node_modules/rimraf": {
       "version": "5.0.10",
       "license": "ISC",
@@ -39484,66 +39196,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "packages/AI/Providers/Gemini/node_modules/send": {
-      "version": "1.2.0",
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "debug": "^4.3.5",
-        "encodeurl": "^2.0.0",
-        "escape-html": "^1.0.3",
-        "etag": "^1.8.1",
-        "fresh": "^2.0.0",
-        "http-errors": "^2.0.0",
-        "mime-types": "^3.0.1",
-        "ms": "^2.1.3",
-        "on-finished": "^2.4.1",
-        "range-parser": "^1.2.1",
-        "statuses": "^2.0.1"
-      },
-      "engines": {
-        "node": ">= 18"
-      }
-    },
-    "packages/AI/Providers/Gemini/node_modules/serve-static": {
-      "version": "2.2.0",
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "encodeurl": "^2.0.0",
-        "escape-html": "^1.0.3",
-        "parseurl": "^1.3.3",
-        "send": "^1.2.0"
-      },
-      "engines": {
-        "node": ">= 18"
-      }
-    },
-    "packages/AI/Providers/Gemini/node_modules/statuses": {
-      "version": "2.0.2",
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "engines": {
-        "node": ">= 0.8"
-      }
-    },
-    "packages/AI/Providers/Gemini/node_modules/type-is": {
-      "version": "2.0.1",
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "content-type": "^1.0.5",
-        "media-typer": "^1.1.0",
-        "mime-types": "^3.0.0"
-      },
-      "engines": {
-        "node": ">= 0.6"
       }
     },
     "packages/AI/Providers/Gemini/node_modules/ws": {
@@ -39563,24 +39215,6 @@
         "utf-8-validate": {
           "optional": true
         }
-      }
-    },
-    "packages/AI/Providers/Gemini/node_modules/zod": {
-      "version": "4.1.13",
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "funding": {
-        "url": "https://github.com/sponsors/colinhacks"
-      }
-    },
-    "packages/AI/Providers/Gemini/node_modules/zod-to-json-schema": {
-      "version": "3.25.0",
-      "license": "ISC",
-      "optional": true,
-      "peer": true,
-      "peerDependencies": {
-        "zod": "^3.25 || ^4"
       }
     },
     "packages/AI/Providers/Groq": {
@@ -41831,19 +41465,6 @@
         "typescript": "^5.4.5"
       }
     },
-    "packages/Communication/providers/MSGraph/node_modules/@types/node": {
-      "version": "20.19.25",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "undici-types": "~6.21.0"
-      }
-    },
-    "packages/Communication/providers/MSGraph/node_modules/undici-types": {
-      "version": "6.21.0",
-      "dev": true,
-      "license": "MIT"
-    },
     "packages/Communication/providers/sendgrid": {
       "name": "@memberjunction/communication-sendgrid",
       "version": "2.121.0",
@@ -42258,14 +41879,6 @@
         "@types/pdf-parse": "^1.1.4",
         "ts-node-dev": "^2.0.0",
         "typescript": "^5.4.5"
-      }
-    },
-    "packages/ContentAutotagging/node_modules/@types/node": {
-      "version": "18.19.130",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "undici-types": "~5.26.4"
       }
     },
     "packages/DBAutoDoc": {
@@ -45450,76 +45063,6 @@
     "packages/TestingFramework/EngineBase/node_modules/ms": {
       "version": "2.1.3",
       "license": "MIT"
-    },
-    "node_modules/turbo-darwin-64": {
-      "version": "2.3.3",
-      "resolved": "https://registry.npmjs.org/turbo-darwin-64/-/turbo-darwin-64-2.3.3.tgz",
-      "integrity": "sha512-bxX82xe6du/3rPmm4aCC5RdEilIN99VUld4HkFQuw+mvFg6darNBuQxyWSHZTtc25XgYjQrjsV05888w1grpaA==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ]
-    },
-    "node_modules/turbo-linux-64": {
-      "version": "2.3.3",
-      "resolved": "https://registry.npmjs.org/turbo-linux-64/-/turbo-linux-64-2.3.3.tgz",
-      "integrity": "sha512-eHj9OIB0dFaP6BxB88jSuaCLsOQSYWBgmhy2ErCu6D2GG6xW3b6e2UWHl/1Ho9FsTg4uVgo4DB9wGsKa5erjUA==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/turbo-linux-arm64": {
-      "version": "2.3.3",
-      "resolved": "https://registry.npmjs.org/turbo-linux-arm64/-/turbo-linux-arm64-2.3.3.tgz",
-      "integrity": "sha512-NmDE/NjZoDj1UWBhMtOPmqFLEBKhzGS61KObfrDEbXvU3lekwHeoPvAMfcovzswzch+kN2DrtbNIlz+/rp8OCg==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/turbo-windows-64": {
-      "version": "2.3.3",
-      "resolved": "https://registry.npmjs.org/turbo-windows-64/-/turbo-windows-64-2.3.3.tgz",
-      "integrity": "sha512-O2+BS4QqjK3dOERscXqv7N2GXNcqHr9hXumkMxDj/oGx9oCatIwnnwx34UmzodloSnJpgSqjl8iRWiY65SmYoQ==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ]
-    },
-    "node_modules/turbo-windows-arm64": {
-      "version": "2.3.3",
-      "resolved": "https://registry.npmjs.org/turbo-windows-arm64/-/turbo-windows-arm64-2.3.3.tgz",
-      "integrity": "sha512-dW4ZK1r6XLPNYLIKjC4o87HxYidtRRcBeo/hZ9Wng2XM/MqqYkAyzJXJGgRMsc0MMEN9z4+ZIfnSNBrA0b08ag==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ]
     }
   }
 }


### PR DESCRIPTION
## Summary
- Regenerate package-lock.json using npm 11.6.4 (Node 24 default)
- Fixes npm ci failures on GitHub Actions runners

## Problem
The GitHub Actions workflow uses Node 24, which bundles npm 11. The package-lock.json was previously generated with npm 10.5.0, which is incompatible with npm 11's stricter validation in `npm ci`.

This caused the workflow to fail with:
```
Missing: @memberjunction/ng-shared-generic@2.121.0 from lock file
```

## Root Cause
- npm 11 has breaking changes in lock file format and validation
- Lock files generated by npm 10 are not compatible with npm 11's `npm ci`
- Lock files generated by npm 11 are not backward compatible with npm 10

## Solution
Regenerated the lock file using npm 11.6.4, which:
- Matches the npm version in Node 24 (used by GitHub Actions)
- Generates more efficient lock files (457 fewer lines)
- Passes npm ci validation on both local and CI environments

## Important
All developers must use **npm 11+ (Node 24+)** when working on this project to avoid lock file conflicts.