### PR TITLE
Add --install-links flag to npm ci for workspace compatibility

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,7 +34,7 @@ jobs:
           cache-dependency-path: 'package-lock.json'
 
       - name: Install dependencies
-        run: npm ci
+        run: npm ci --install-links
 
       - name: Build packages
         run: npm run build


### PR DESCRIPTION
## Summary
Add `--install-links` flag to `npm ci` command in build workflow

## Problem
npm ci fails in GitHub Actions (Linux) with:
```
Missing: @memberjunction/ng-shared-generic@2.121.0 from lock file
```

But npm ci works perfectly locally (macOS) on the exact same commit with the exact same package-lock.json file.

## Root Cause
This appears to be a platform-specific issue with how npm handles workspace links on Linux vs macOS.

## Solution
The `--install-links` flag is specifically designed to handle workspace packages and may resolve the validation difference between platforms.

## Testing
- ✅ Verified package-lock.json is identical locally and on GitHub
- ✅ Confirmed npm ci works locally on macOS
- ⏳ Testing if `--install-links` resolves the Linux issue

If this doesn't work, we may need to:
1. Clear GitHub Actions cache
2. Use `npm install --frozen-lockfile` instead of `npm ci`
3. Investigate npm version differences in actions/setup-node