### PR TITLE
Add Node 24 setup to migrations workflows

### DIFF
--- a/.github/workflows/migrations.yml
+++ b/.github/workflows/migrations.yml
@@ -30,6 +30,11 @@ jobs:
       - name: Create SQL database
         run: docker run --rm --network local-net mcr.microsoft.com/mssql-tools /opt/mssql-tools/bin/sqlcmd -S sql -U SA -P 'VeryStr0ngP@ssw0rd' -Q "CREATE DATABASE [test];"
 
+      - name: Set up node
+        uses: actions/setup-node@v6
+        with:
+          node-version: 24
+
       - name: Install MJ CLI globally
         run: npm install --global @memberjunction/cli
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -42,6 +42,11 @@ jobs:
       - name: Create SQL database
         run: docker run --rm --network local-net mcr.microsoft.com/mssql-tools /opt/mssql-tools/bin/sqlcmd -S sql -U SA -P 'VeryStr0ngP@ssw0rd' -Q "CREATE DATABASE [test];"
 
+      - name: Set up node
+        uses: actions/setup-node@v6
+        with:
+          node-version: 24
+
       - name: Install MJ CLI globally
         run: npm install --global @memberjunction/cli
 


### PR DESCRIPTION
The @memberjunction/cli depends on isolated-vm@6.0.2 which requires Node.js >= 22.0.0. The migrations.yml and publish.yml test-migrations job were missing the setup-node step, causing them to use the default Node 20.x on ubuntu-latest and fail during npm install.