### PR TITLE
Correct JSDoc @param names to match actual parameter names

### DIFF
--- a/packages/Angular/Generic/skip-chat/src/lib/skip-chat/skip-chat.component.ts
+++ b/packages/Angular/Generic/skip-chat/src/lib/skip-chat/skip-chat.component.ts
@@ -604,7 +604,7 @@ export class SkipChatComponent extends BaseManagedComponent implements OnInit, A
   
   /**
    * Starts polling for conversation status updates
-   * @param conversationId The ID of the conversation to poll for
+   * @param convoID The ID of the conversation to poll for
    */
   protected startRequestStatusPolling(convoID: string) {
     // Clear any existing polling for this conversation
@@ -727,7 +727,7 @@ export class SkipChatComponent extends BaseManagedComponent implements OnInit, A
   
   /**
    * Checks the status of a conversation request
-   * @param conversationId The ID of the conversation to check
+   * @param convoID The ID of the conversation to check
    */
   protected async checkRequestStatus(convoID: string) {
     try {


### PR DESCRIPTION
Fix TypeDoc warnings causing docs workflow to fail with exit code 4. The @param tags referenced "conversationId" but the actual parameters were named "convoID".