### PR TITLE
[POST 3.0] feat(caching): implement differential caching for RunViews

### DIFF
--- a/packages/MJServer/src/generic/RunViewResolver.ts
+++ b/packages/MJServer/src/generic/RunViewResolver.ts
@@ -410,23 +410,42 @@ export class RunViewWithCacheCheckInput {
 }
 
 @ObjectType()
+export class DifferentialDataOutput {
+  @Field(() => [RunViewGenericResultRow], {
+    description: 'Records that have been created or updated since the client\'s maxUpdatedAt'
+  })
+  updatedRows: RunViewGenericResultRow[];
+
+  @Field(() => [String], {
+    description: 'Primary key values (as concatenated strings) of records that have been deleted'
+  })
+  deletedRecordIDs: string[];
+}
+
+@ObjectType()
 export class RunViewWithCacheCheckResultOutput {
   @Field(() => Int, { description: 'The index of this view in the batch request' })
   viewIndex: number;
 
-  @Field(() => String, { description: "'current', 'stale', or 'error'" })
+  @Field(() => String, { description: "'current', 'differential', 'stale', or 'error'" })
   status: string;
 
   @Field(() => [RunViewGenericResultRow], {
     nullable: true,
-    description: 'Fresh results - only populated when status is stale'
+    description: 'Fresh results - only populated when status is stale (full refresh)'
   })
   Results?: RunViewGenericResultRow[];
 
-  @Field(() => String, { nullable: true, description: 'Max __mj_UpdatedAt from results when stale' })
+  @Field(() => DifferentialDataOutput, {
+    nullable: true,
+    description: 'Differential update data - only populated when status is differential'
+  })
+  differentialData?: DifferentialDataOutput;
+
+  @Field(() => String, { nullable: true, description: 'Max __mj_UpdatedAt from results when stale or differential' })
   maxUpdatedAt?: string;
 
-  @Field(() => Int, { nullable: true, description: 'Row count of results when stale' })
+  @Field(() => Int, { nullable: true, description: 'Row count of results when stale or differential (total after applying delta)' })
   rowCount?: number;
 
   @Field(() => String, { nullable: true, description: 'Error message if status is error' })
@@ -886,13 +905,35 @@ export class RunViewResolver extends ResolverBase {
         const inputItem = input[index];
         const entity = provider.Entities.find(e => e.Name === inputItem.params.EntityName);
 
+        if (result.status === 'differential' && result.differentialData && entity) {
+          // Process differential data into GraphQL-compatible format
+          const processedUpdatedRows = this.processRawData(
+            result.differentialData.updatedRows as Record<string, unknown>[],
+            entity.ID,
+            entity
+          );
+          return {
+            viewIndex: result.viewIndex,
+            status: result.status,
+            Results: undefined,
+            differentialData: {
+              updatedRows: processedUpdatedRows,
+              deletedRecordIDs: result.differentialData.deletedRecordIDs,
+            },
+            maxUpdatedAt: result.maxUpdatedAt,
+            rowCount: result.rowCount,
+            errorMessage: result.errorMessage,
+          };
+        }
+
         if (result.status === 'stale' && result.results && entity) {
-          // Process raw data into GraphQL-compatible format
+          // Process raw data into GraphQL-compatible format (full refresh)
           const processedRows = this.processRawData(result.results as Record<string, unknown>[], entity.ID, entity);
           return {
             viewIndex: result.viewIndex,
             status: result.status,
             Results: processedRows,
+            differentialData: undefined,
             maxUpdatedAt: result.maxUpdatedAt,
             rowCount: result.rowCount,
             errorMessage: result.errorMessage,
@@ -903,6 +944,7 @@ export class RunViewResolver extends ResolverBase {
           viewIndex: result.viewIndex,
           status: result.status,
           Results: undefined,
+          differentialData: undefined,
           maxUpdatedAt: result.maxUpdatedAt,
           rowCount: result.rowCount,
           errorMessage: result.errorMessage,


### PR DESCRIPTION
When a cache is found stale, instead of returning the entire dataset,
the server now returns only the changes (differential update) for entities
that have TrackRecordChanges enabled:

- Added DifferentialData<T> type with updatedRows and deletedRecordIDs
- Added 'differential' status to RunViewWithCacheCheckResult
- SQLServerDataProvider: Added getDeletedRecordIDsSince() to query RecordChange table
- SQLServerDataProvider: Added getUpdatedRowsSince() to get rows since timestamp
- SQLServerDataProvider: Added runDifferentialQueryAndReturn() orchestration method
- Modified RunViewsWithCacheCheck to use differential updates when entity supports it
- LocalCacheManager: Added ApplyDifferentialUpdate() to merge deltas with cache
- providerBase: Updated processSingleSmartCacheResult to handle 'differential' status
- GraphQL: Added DifferentialDataOutput type and updated resolver

Entities without TrackRecordChanges fall back to full refresh ('stale' status).
This dramatically reduces bandwidth for frequently accessed, slowly changing data.