### PR TITLE
fix(migrations): resolve EntityField sequence conflict between migrations

### DIFF
--- a/migrations/v3/V202601251750__v3.3.x__Add_Multi_Tenant_Scoping_To_Agent_Memory.sql
+++ b/migrations/v3/V202601251750__v3.3.x__Add_Multi_Tenant_Scoping_To_Agent_Memory.sql
@@ -4345,7 +4345,7 @@ GRANT EXECUTE ON [${flyway:defaultSchema}].[spDeleteConversation] TO [cdp_Develo
          (
             '79fad22e-7080-4283-b3dd-ed140949e39a',
             'A24EF5EC-D32C-4A53-85A9-364E322451E6', -- Entity: AI Agent Notes
-            100055,
+            100060,
             'PrimaryScopeEntity',
             'Primary Scope Entity',
             NULL,
@@ -4540,7 +4540,7 @@ GRANT EXECUTE ON [${flyway:defaultSchema}].[spDeleteConversation] TO [cdp_Develo
          (
             '2273625c-67fc-40e6-96f7-ff4cc09bbaa9',
             '3A139346-CC48-479A-A53B-8892664F5DFD', -- Entity: MJ: AI Agent Examples
-            100055,
+            100060,
             'PrimaryScopeEntity',
             'Primary Scope Entity',
             NULL,


### PR DESCRIPTION
## Summary
- Fixed EntityField sequence conflict between migrations V202601251750 and V202601251751
- Changed `PrimaryScopeEntity` sequence from 100055 to 100060 in V202601251750
- Both migrations were using sequence 100055 for different fields, causing unique constraint violation

## Affected Entities
- AI Agent Notes
- MJ: AI Agent Examples

## Root Cause
Migration V202601251750 inserted `PrimaryScopeEntity` at sequence 100055, while V202601251751 tried to insert `ExpiresAt` at the same sequence, violating the `UQ_EntityField_EntityID_Sequence` constraint.

## Test plan
- [x] Verified fix on fresh database with `mj migrate`
- [x] All migrations complete successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)