### PR TITLE
Upgrade npm package manager to 11.7.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "memberjunction-workspace",
   "version": "1.0.10",
   "license": "ISC",
+  "packageManager": "npm@11.7.0",
   "workspaces": [
     "packages/*",
     "packages/Actions/*",


### PR DESCRIPTION
Fix GitHub build issue from the removal of the packageManager attribute. Restore it the attribute and set it to npm 11.7.0