### PR TITLE
docs: improve documentation slash commands with hub-and-spoke model, …

### DIFF
--- a/.claude/commands/analyze-readme-health.md
+++ b/.claude/commands/analyze-readme-health.md
@@ -22,8 +22,9 @@ This command helps maintain documentation quality by:
 1. Finding packages without READMEs
 2. Identifying outdated or incomplete READMEs
 3. Detecting broken cross-links
-4. Scoring documentation quality
+4. Scoring documentation quality (including mermaid diagrams and docs/ folders)
 5. Prioritizing what needs updating
+6. Measuring alignment with the hub-and-spoke documentation model
 
 ## Analysis Process
 
@@ -40,9 +41,16 @@ This command helps maintain documentation quality by:
    Glob: {{directory}}/**/README.md
    ```
 
-3. **Match Packages to READMEs**:
-   - Package has README: ✓
-   - Package missing README: ✗
+3. **Find All docs/ Folders**:
+   ```
+   Glob: {{directory}}/**/docs/*.md
+   ```
+
+4. **Match Packages to READMEs**:
+   - Package has README: check
+   - Package missing README: missing
+   - Package has docs/ folder: check
+   - Complex package missing docs/ folder: flag
 
 ### Phase 2: Quality Analysis
 
@@ -53,18 +61,52 @@ For each README found, analyze:
 Check for required sections:
 | Section | Weight | Check |
 |---------|--------|-------|
-| Title/Package Name | 10 | Has H1 with package name |
-| Description/Overview | 15 | Has overview paragraph |
-| Installation | 10 | Has npm install instructions |
-| Usage/Examples | 20 | Has code examples |
-| API Reference | 15 | Documents main exports |
-| Dependencies | 10 | Lists @memberjunction deps |
-| Related Packages | 10 | Cross-links to related packages |
-| Contributing | 10 | Has contributing section |
+| Title/Package Name | 5 | Has H1 with package name |
+| Description/Overview | 10 | Has overview paragraph |
+| Installation | 5 | Has npm install instructions |
+| Usage/Examples | 15 | Has code examples |
+| Mermaid Diagrams | 15 | Has at least one mermaid diagram |
+| API Reference | 10 | Documents main exports |
+| Dependencies | 5 | Lists @memberjunction deps |
+| Related Packages | 5 | Cross-links to related packages |
+| docs/ Folder | 15 | Has docs/ with topic guides (for complex packages) |
+| Guide Header Blocks | 10 | docs/ guides have standard header format |
+| Contributing | 5 | Has contributing section |
 
 Score = Sum of weights for present sections
 
-#### 2.2 Freshness Analysis
+**Complexity determination** (for docs/ folder scoring):
+- Count source files: `{{packagePath}}/src/**/*.ts`
+- Check for 2+ major subsystems (look for distinct module directories)
+- Check for framework/base class patterns
+- If complex but no docs/ folder, deduct the 15 points
+
+#### 2.2 Mermaid Diagram Quality
+
+For packages that have mermaid diagrams, additionally check:
+- **Diagram variety**: Does it use appropriate diagram types (flowchart, sequence, ER, etc.)?
+- **Styling**: Do diagrams use colors/styling to distinguish groups?
+- **Relevance**: Do diagrams illustrate key architectural concepts?
+
+Flag packages that:
+- Have no mermaid diagrams at all (critical for non-trivial packages)
+- Use ASCII art instead of mermaid (should be migrated)
+- Have only a single basic diagram when the package is complex
+
+#### 2.3 Hub-and-Spoke Alignment
+
+For packages with docs/ folders, check:
+- **Guide header format**: Each guide should have the standard header block:
+  ```
+  > **Package**: [@memberjunction/{name}](../readme.md)
+  > **Related Guides**: [...](...) | [...](...)
+  > **Related Packages**: [...](...) | [...](...)
+  ```
+- **Topic-based naming**: Guides should be named after concepts (e.g., `virtual-entities.md`), not generic categories (e.g., `architecture.md`)
+- **README hub links**: README should link to all docs/ guides in a Documentation section
+- **Cross-references**: Guides should link to each other and to other package docs
+
+#### 2.4 Freshness Analysis
 
 Compare README content against:
 - **package.json changes**: Has package.json been modified more recently?
@@ -76,24 +118,27 @@ Freshness indicators:
 - **Stale**: Source modified 30-90 days after README
 - **Outdated**: Source modified >90 days after README
 
-#### 2.3 Link Validation
+#### 2.5 Link Validation
 
 Check all links in README:
 - **Internal links**: `./path/to/file.md` - verify file exists
 - **Cross-package links**: `../OtherPkg/README.md` - verify path exists
+- **docs/ links**: `./docs/topic.md` - verify guide exists
 - **External links**: URLs - note but don't validate (too slow)
 
 Report:
 - Total links
 - Broken internal links
 - Broken cross-package links
+- Broken docs/ links
 
-#### 2.4 Code Example Validation
+#### 2.6 Code Example Validation
 
 For each code block:
 - Check if imports reference the correct package name
 - Flag examples using deprecated patterns (if detectable)
 - Note if examples use `any` types (violation of codebase standards)
+- Check that examples use real MJ patterns (not pseudocode)
 
 ### Phase 3: Generate Report
 
@@ -113,16 +158,37 @@ For each code block:
 | With README | 145 |
 | Missing README | 32 |
 | Coverage | 82% |
+| With Mermaid Diagrams | 45 |
+| With docs/ Folder | 12 |
+| Hub-and-Spoke Compliant | 8 |
 
 ## Quality Distribution
 
 | Score Range | Count | Packages |
 |-------------|-------|----------|
-| 90-100 (Excellent) | 15 | MetadataSync, Actions, ... |
+| 90-100 (Excellent) | 15 | MJCore, MetadataSync, ... |
 | 70-89 (Good) | 45 | ... |
 | 50-69 (Fair) | 50 | ... |
 | 0-49 (Poor) | 35 | ... |
 | Missing | 32 | ... |
+
+## Diagram Coverage
+
+| Status | Count |
+|--------|-------|
+| Has Mermaid Diagrams | 45 |
+| Has ASCII Art (migrate to mermaid) | 20 |
+| No Diagrams (non-trivial package) | 60 |
+| Simple Package (diagram optional) | 52 |
+
+## Hub-and-Spoke Status
+
+| Status | Count |
+|--------|-------|
+| Full hub-and-spoke (README + docs/) | 8 |
+| Has docs/ but missing standards | 4 |
+| Complex package, should have docs/ | 15 |
+| Simple package (single README fine) | 150 |
 
 ## Freshness
 
@@ -140,6 +206,16 @@ For each code block:
 2. `packages/Angular/Generic/NewComponent` - Recently added
 ...
 
+### Missing Mermaid Diagrams (Priority: High)
+1. `packages/CodeGenLib/README.md` - Complex package, no diagrams
+2. `packages/SQLServerDataProvider/README.md` - Provider pattern, needs class diagram
+...
+
+### Complex Packages Missing docs/ Folder (Priority: Medium)
+1. `packages/AI/Engine` - Multi-subsystem, needs topic guides
+2. `packages/Actions` - Framework with extensions, needs topic guides
+...
+
 ### Broken Links (Priority: Medium)
 1. `packages/MJCore/README.md` line 45: `../OldPackage/README.md` (deleted)
 2. `packages/Actions/README.md` line 120: `./docs/old-guide.md` (moved)
@@ -151,9 +227,10 @@ For each code block:
 
 ## Recommendations
 
-1. **Immediate**: Create READMEs for 5 high-traffic packages
-2. **Short-term**: Update 15 stale READMEs for core packages
-3. **Ongoing**: Fix 23 broken links
+1. **Immediate**: Add mermaid diagrams to top 10 core package READMEs
+2. **Short-term**: Create docs/ folders for 5 most complex packages (AI/Engine, Actions, CodeGenLib, ...)
+3. **Medium-term**: Migrate ASCII art diagrams to mermaid across 20 packages
+4. **Ongoing**: Fix 23 broken links
 ```
 
 #### Detailed Format
@@ -167,19 +244,35 @@ Includes everything in Summary plus:
 
 | Metric | Value |
 |--------|-------|
-| Quality Score | 85/100 |
+| Quality Score | 92/100 |
 | Freshness | Fresh |
 | Links | 12 total, 0 broken |
+| Mermaid Diagrams | 3 (flowchart, sequence, ER) |
+| docs/ Folder | Yes (2 topic guides) |
+| Hub-and-Spoke | Compliant |
 | Last README Update | 2024-01-15 |
 | Last Source Update | 2024-01-10 |
 
-**Sections Present**: ✓ Title, ✓ Overview, ✓ Installation, ✓ Usage, ✗ API Reference, ✓ Dependencies
-**Missing**: API Reference section
-**Recommendations**: Add API reference for Metadata class
+**Sections Present**: Title, Overview, Installation, Usage, API Reference, Dependencies, Documentation (hub links)
+**docs/ Guides**: virtual-entities.md (header: compliant), isa-relationships.md (header: compliant)
+**Recommendations**: None - gold standard
 
 ---
 
 ### @memberjunction/ai-core (packages/AI/Core)
+
+| Metric | Value |
+|--------|-------|
+| Quality Score | 65/100 |
+| Freshness | Stale |
+| Links | 5 total, 1 broken |
+| Mermaid Diagrams | 0 |
+| docs/ Folder | No |
+| Hub-and-Spoke | N/A |
+
+**Sections Present**: Title, Overview, Installation, Usage
+**Missing**: Mermaid diagrams, API Reference, Dependencies, Related Packages
+**Recommendations**: Add mermaid diagram of provider pattern; consider docs/ folder for base class documentation
 ...
 ```
 
@@ -193,22 +286,38 @@ Includes everything in Summary plus:
     "totalPackages": 177,
     "withReadme": 145,
     "missingReadme": 32,
-    "coverage": 0.82
+    "coverage": 0.82,
+    "withMermaidDiagrams": 45,
+    "withDocsFolder": 12,
+    "hubAndSpokeCompliant": 8
   },
   "packages": [
     {
       "name": "@memberjunction/core",
       "path": "packages/MJCore",
       "hasReadme": true,
-      "qualityScore": 85,
+      "qualityScore": 92,
       "freshness": "fresh",
       "sections": {
         "title": true,
         "overview": true,
         "installation": true,
         "usage": true,
-        "apiReference": false,
-        "dependencies": true
+        "apiReference": true,
+        "dependencies": true,
+        "mermaidDiagrams": true,
+        "docsFolder": true,
+        "guideHeaders": true
+      },
+      "mermaid": {
+        "count": 3,
+        "types": ["flowchart", "sequenceDiagram", "erDiagram"]
+      },
+      "docsFolder": {
+        "exists": true,
+        "guides": ["virtual-entities.md", "isa-relationships.md"],
+        "headerCompliant": true,
+        "topicNamed": true
       },
       "links": {
         "total": 12,
@@ -218,10 +327,13 @@ Includes everything in Summary plus:
   ],
   "issues": {
     "missingReadmes": ["packages/AI/Providers/NewProvider"],
+    "missingMermaid": ["packages/CodeGenLib", "packages/SQLServerDataProvider"],
+    "missingDocs": ["packages/AI/Engine", "packages/Actions"],
     "brokenLinks": [
       {"file": "packages/MJCore/README.md", "line": 45, "link": "../OldPackage/README.md"}
     ],
-    "outdated": ["packages/Legacy"]
+    "outdated": ["packages/Legacy"],
+    "asciiArtToMigrate": ["packages/OldPackage/README.md"]
   }
 }
 ```
@@ -232,11 +344,12 @@ Rank packages for update priority:
 
 **Priority Score Calculation**:
 ```
-Priority = (Importance × 3) + (Staleness × 2) + (BrokenLinks × 1)
+Priority = (Importance x 3) + (Staleness x 2) + (MissingDiagrams x 2) + (BrokenLinks x 1)
 
 Where:
 - Importance: 1-10 based on package centrality (how many packages depend on it)
 - Staleness: 1-10 based on how outdated (10 = >1 year, 1 = fresh)
+- MissingDiagrams: 0-5 based on complexity vs diagram coverage
 - BrokenLinks: Count of broken links
 ```
 
@@ -245,11 +358,11 @@ Output top 20 packages to update:
 ```markdown
 ## Update Priority Queue
 
-| Rank | Package | Priority Score | Reason |
-|------|---------|----------------|--------|
-| 1 | @memberjunction/core | 28 | Central package, 45 dependents, stale |
-| 2 | @memberjunction/ai-engine | 25 | High usage, outdated examples |
-| 3 | @memberjunction/actions-base | 22 | 3 broken links, missing sections |
+| Rank | Package | Priority Score | Key Issues |
+|------|---------|----------------|------------|
+| 1 | @memberjunction/core | 28 | Central package, 45 dependents, no mermaid |
+| 2 | @memberjunction/ai-engine | 25 | High usage, outdated, needs docs/ folder |
+| 3 | @memberjunction/actions-base | 22 | 3 broken links, missing sections, no diagrams |
 ...
 ```
 
@@ -264,20 +377,26 @@ Output top 20 packages to update:
 
 # JSON output for CI integration
 /analyze-readme-health packages json
+
+# Check just one area
+/analyze-readme-health packages/MJCore detailed
 ```
 
 ## Integration with Other Commands
 
 Use this command to:
-1. **Plan batch updates**: Identify which packages need work
-2. **Validate after updates**: Confirm improvements
-3. **CI/CD integration**: JSON format for automated checks
-4. **Progress tracking**: Run periodically to track improvement
+1. **Plan batch updates**: Identify which packages need work, then run `/update-readmes-batch`
+2. **Validate after updates**: Confirm improvements post-update
+3. **Find docs/ candidates**: Identify complex packages that should have hub-and-spoke docs
+4. **Track mermaid adoption**: Monitor diagram coverage over time
+5. **CI/CD integration**: JSON format for automated checks
+6. **Progress tracking**: Run periodically to track improvement
 
 ## Output
 
 Provide:
 1. Health report in requested format
 2. Prioritized list of packages needing attention
-3. Specific actionable recommendations
+3. Specific actionable recommendations (organized by: mermaid, docs/ folders, content, links)
 4. Overall documentation coverage percentage
+5. Hub-and-spoke adoption metrics

--- a/.claude/commands/update-folder-readme.md
+++ b/.claude/commands/update-folder-readme.md
@@ -15,15 +15,17 @@ You are creating or updating a folder-level README that serves as an overview an
 Folder-level READMEs provide:
 1. **Overview**: What this family of packages does together
 2. **Navigation**: Quick access to all sub-packages
-3. **Architecture**: How packages relate to each other
+3. **Architecture**: How packages relate to each other (using mermaid diagrams)
 4. **Getting Started**: Entry points for new developers
 
-## Quality Standards
+## Gold Standard
 
-Reference these excellent folder READMEs:
+Reference these folder READMEs:
 - `packages/AI/README.md` - AI framework overview
 - `packages/Actions/README.md` - Actions framework overview
 - `packages/Communication/README.md` - Communication framework overview
+
+Also study the hub-and-spoke model in `packages/MJCore/` where the README points to deep-dive `docs/` guides. Folder-level READMEs should similarly point to individual package READMEs and any docs/ folders within those packages.
 
 ## Process
 
@@ -45,6 +47,7 @@ Reference these excellent folder READMEs:
    - Read its package.json (name, description)
    - Read its README.md (extract key purpose)
    - Note its dependencies on other packages in this folder
+   - Check for docs/ folder with deep-dive guides
 
 4. **Check for CLAUDE.md**:
    ```
@@ -89,9 +92,35 @@ AI Framework Packages:
 - How packages work together
 - When to use this framework}
 
-## Package Structure
+## Architecture
 
-{Visual representation of packages and their relationships}
+{**Use a mermaid diagram** to show how packages relate to each other.
+Choose the diagram type that best fits the architecture.}
+
+\`\`\`mermaid
+flowchart TD
+    subgraph Core["Core Layer"]
+        C[ai-core<br/>Base Abstractions]
+    end
+    subgraph Engine["Orchestration"]
+        E[ai-engine<br/>Model Selection & Routing]
+    end
+    subgraph Providers["Provider Layer"]
+        P1[OpenAI]
+        P2[Anthropic]
+        P3[Google]
+    end
+    E --> C
+    P1 --> C
+    P2 --> C
+    P3 --> C
+    Consumer[Your Application] --> E
+    style Core fill:#d5e8f5,stroke:#2d5f8e
+    style Engine fill:#d5f5e8,stroke:#2d8e5f
+    style Providers fill:#f5e8d5,stroke:#8e5f2d
+\`\`\`
+
+## Package Structure
 
 \`\`\`
 {folderName}/
@@ -111,26 +140,6 @@ AI Framework Packages:
 | [@memberjunction/pkg1](./Pkg1/README.md) | {description} | `Class1`, `Class2` |
 | [@memberjunction/pkg2](./Pkg2/README.md) | {description} | `Class3` |
 
-## Architecture
-
-{Diagram or description of how packages relate}
-
-\`\`\`
-┌─────────────┐
-│  Consumer   │
-└──────┬──────┘
-       │
-       ▼
-┌─────────────┐     ┌─────────────┐
-│   Engine    │────▶│    Core     │
-└──────┬──────┘     └─────────────┘
-       │
-       ▼
-┌─────────────┐
-│  Providers  │
-└─────────────┘
-\`\`\`
-
 ## Getting Started
 
 ### Installation
@@ -148,13 +157,13 @@ npm install @memberjunction/{provider-package}
 \`\`\`typescript
 import { ... } from '@memberjunction/{main-package}';
 
-// Basic usage example
+// Basic usage example — real MJ patterns, no pseudocode
 \`\`\`
 
 ## Key Concepts
 
 ### {Concept 1}
-{Explanation}
+{Explanation with code example or mermaid diagram if helpful}
 
 ### {Concept 2}
 {Explanation}
@@ -163,6 +172,13 @@ import { ... } from '@memberjunction/{main-package}';
 
 1. **{Use Case 1}**: {Brief description and which packages to use}
 2. **{Use Case 2}**: {Brief description and which packages to use}
+
+## Deep-Dive Guides
+
+{If any sub-packages have docs/ folders with topic guides, link to them here:}
+
+- [{Topic from Package A}](./PackageA/docs/topic-guide.md) - Description
+- [{Topic from Package B}](./PackageB/docs/another-guide.md) - Description
 
 ## Development
 
@@ -181,7 +197,7 @@ See the [MemberJunction Contributing Guide](../../CONTRIBUTING.md).
 
 ### Phase 4: Package Table Generation
 
-Create a comprehensive package table:
+Create a comprehensive package table, grouped by function:
 
 ```markdown
 ## Packages
@@ -198,24 +214,47 @@ Create a comprehensive package table:
 | Package | Description | Supported Models |
 |---------|-------------|------------------|
 | [@memberjunction/ai-openai](./Providers/OpenAI/README.md) | OpenAI integration | GPT-4, GPT-3.5 |
-| [@memberjunction/ai-anthropic](./Providers/Anthropic/README.md) | Anthropic integration | Claude 3, Claude 2 |
+| [@memberjunction/ai-anthropic](./Providers/Anthropic/README.md) | Anthropic integration | Claude 4, Claude 3.5 |
 ```
 
-### Phase 5: Cross-Linking
+### Phase 5: Mermaid Diagrams
+
+**Every folder-level README must include at least one mermaid diagram** showing the package architecture. Use mermaid instead of ASCII art for all diagrams.
+
+Recommended diagram types for folder READMEs:
+
+| Purpose | Diagram Type |
+|---------|-------------|
+| Package dependency graph | `flowchart TD` |
+| Data flow through framework | `flowchart LR` |
+| Request lifecycle | `sequenceDiagram` |
+| Class hierarchy (providers) | `classDiagram` |
+
+**Style the diagram** with colors to group related packages:
+- Core/base packages: blue tones (`fill:#d5e8f5,stroke:#2d5f8e`)
+- Engine/orchestration: green tones (`fill:#d5f5e8,stroke:#2d8e5f`)
+- Provider/plugin layer: orange tones (`fill:#f5e8d5,stroke:#8e5f2d`)
+- Consumer/application: neutral (`fill:#f5f5f5,stroke:#666`)
+
+### Phase 6: Cross-Linking
 
 1. **Link to All Sub-Package READMEs**:
    - Use relative paths: `./PackageName/README.md`
    - For nested: `./Providers/OpenAI/README.md`
 
-2. **Link to Related Folders**:
+2. **Link to docs/ Guides in Sub-Packages**:
+   - If a sub-package has docs/ with topic guides, surface those in the folder README
+   - Example: `See the [Virtual Entities Guide](./MJCore/docs/virtual-entities.md)`
+
+3. **Link to Related Folders**:
    - Use relative paths: `../Actions/README.md`
    - Link to parent: `../README.md` (if exists at packages/ level)
 
-3. **Link to Root Documentation**:
+4. **Link to Root Documentation**:
    - `../../CLAUDE.md` for development guide
    - `../../CONTRIBUTING.md` for contribution guide
 
-### Phase 6: Handle Special Folder Structures
+### Phase 7: Handle Special Folder Structures
 
 #### Nested Package Directories
 
@@ -239,11 +278,11 @@ For folders with both packages and non-package directories:
 ## Writing Guidelines
 
 1. **Focus on "Why"**: Explain why packages are organized this way
-2. **Show Relationships**: Make dependencies and data flow clear
+2. **Show Relationships**: Make dependencies and data flow clear with mermaid diagrams
 3. **Provide Entry Points**: Help developers know where to start
 4. **Keep Current**: Only document what exists
-5. **Use ASCII Diagrams**: For architecture visualization
-6. **Link Generously**: Every package should link to its README
+5. **Use Mermaid, Not ASCII**: All architecture diagrams should use mermaid for consistency
+6. **Link Generously**: Every package should link to its README; surface docs/ guides from sub-packages
 7. **No "NEW" Annotations**: Don't use "New" or similar tags for various features/abilities in readme docs as those quickly get out of date. If you see them in packages you're updating, remove New/similar tag.
 
 ## Output
@@ -253,4 +292,5 @@ For folders with both packages and non-package directories:
 3. Report:
    - Packages documented
    - Links created
+   - Deep-dive guides surfaced from sub-packages
    - Any packages missing READMEs (flag for follow-up)

--- a/.claude/commands/update-package-readme.md
+++ b/.claude/commands/update-package-readme.md
@@ -10,12 +10,17 @@ You are a documentation specialist for MemberJunction. Your task is to analyze a
 
 > Note: If `{{packagePath}}` appears literally above, the argument wasn't passed. Check the ARGUMENTS line below and use that path instead.
 
-## Quality Standards
+## Gold Standard
 
-Base your README on the best examples in this repo:
-- **MetadataSync** (`packages/MetadataSync/README.md`) - Most comprehensive
+The documentation model for MemberJunction follows a **hub-and-spoke** pattern:
+- **README.md** is the hub — overview, key concepts, links into deep-dive guides
+- **docs/ folder** contains the spokes — topic-based canonical guides with mermaid diagrams, code examples, and cross-references
+
+**Exemplar packages** (study these before writing):
+- **MJCore** (`packages/MJCore/README.md` + `packages/MJCore/docs/`) - Best example of hub-and-spoke with deep-dive topic guides (`virtual-entities.md`, `isa-relationships.md`)
+- **MetadataSync** (`packages/MetadataSync/README.md`) - Comprehensive single-README package
 - **Actions** (`packages/Actions/README.md`) - Excellent architecture docs
-- **AI Framework** (`packages/AI/README.md`) - Clear package structure
+- **AI Framework** (`packages/AI/README.md`) - Clear package structure overview
 - **Communication** (`packages/Communication/README.md`) - Great capability matrix
 
 ## Process
@@ -45,10 +50,22 @@ Base your README on the best examples in this repo:
    ```
    Incorporate relevant development guidelines if present.
 
-5. **Determine Package Complexity**:
-   - **Simple** (<10 source files): Single README is sufficient
-   - **Medium** (10-30 source files): Consider sections with internal links
-   - **Complex** (>30 source files or sub-packages): Create sub-docs with TOC
+5. **Check for Existing docs/ Folder**:
+   ```
+   Glob: {{packagePath}}/docs/**/*.md
+   ```
+   If guides already exist, review and update them alongside the README.
+
+6. **Determine Documentation Strategy**:
+   Choose one of these based on the package's **conceptual richness** (not just file count):
+
+   - **Single README** — Package has a straightforward, single-purpose API (e.g., a single provider, a thin wrapper). Even with many files, if the concepts are simple, a README alone suffices.
+
+   - **Hub-and-Spoke (README + docs/)** — Package has **multiple distinct concepts** that each deserve deep treatment. Triggers:
+     - Package has 2+ major subsystems or patterns (e.g., virtual entities AND IS-A relationships in MJCore)
+     - Package has complex lifecycle or orchestration (e.g., CodeGen pipeline stages)
+     - Package serves as a framework that others extend (e.g., provider base classes)
+     - Package has concepts that would make the README >300 lines if fully explained inline
 
 ### Phase 2: Generate README Structure
 
@@ -67,17 +84,14 @@ npm install @memberjunction/{package-name}
 
 ## Overview
 
-{2-3 paragraphs explaining the package's purpose, architecture, and key concepts}
+{2-3 paragraphs explaining the package's purpose, architecture, and key concepts.
+Include a mermaid diagram here — see Mermaid Diagrams section below.}
 
 ## Key Features
 
 - **Feature 1**: Description
 - **Feature 2**: Description
 - ...
-
-## Diagram
-
-When appropriate, populate this with a Mermaid sequence or other diagram to illustate the flow of a complex component. This is not required for simple packages but can be very helpful to illustrate how larger more complex systems fit together.
 
 ## Usage
 
@@ -86,7 +100,7 @@ When appropriate, populate this with a Mermaid sequence or other diagram to illu
 \`\`\`typescript
 import { ... } from '@memberjunction/{package-name}';
 
-// Example code
+// Example code showing the most common use case
 \`\`\`
 
 ### {Additional Examples as needed}
@@ -117,30 +131,102 @@ This package depends on:
 See the [MemberJunction Contributing Guide](../../CONTRIBUTING.md) for development setup and guidelines.
 ```
 
-#### Additional Sections for Complex Packages
+#### Hub-and-Spoke: docs/ Folder Guides
 
-For packages with >30 files or sub-packages, create a docs/ folder:
+For packages that warrant deep-dive guides, create a `docs/` folder with **topic-based** guides (NOT generic categories):
 
 ```
 {{packagePath}}/
-├── README.md (overview with TOC)
+├── README.md (hub — overview, links to guides)
 ├── docs/
-│   ├── architecture.md
-│   ├── api-reference.md
-│   ├── examples.md
-│   └── migration-guide.md (if applicable)
+│   ├── {topic-a}.md       (e.g., virtual-entities.md)
+│   ├── {topic-b}.md       (e.g., isa-relationships.md)
+│   └── {topic-c}.md       (e.g., field-sync.md)
 ```
 
-Main README should have:
+**Each guide MUST include this header block:**
+
+```markdown
+# {Topic Title} in MemberJunction
+
+> **Package**: [@memberjunction/{name}](../readme.md)
+> **Related Guides**: [{Other Guide}](./other-guide.md) | [{Another}](./another.md)
+> **Related Packages**: [@memberjunction/{pkg}](../../Pkg/README.md) | ...
+```
+
+The README hub should link to guides:
+
 ```markdown
 ## Documentation
 
-- [Architecture Overview](./docs/architecture.md)
-- [API Reference](./docs/api-reference.md)
-- [Examples](./docs/examples.md)
+For deep-dive guides on specific topics:
+
+- [{Topic A}](./docs/topic-a.md) - One-sentence description
+- [{Topic B}](./docs/topic-b.md) - One-sentence description
 ```
 
-### Phase 3: Cross-Linking
+**Topic naming**: Name guides after the concept, not after generic categories. Use `virtual-entities.md` not `architecture.md`. Use `provider-pattern.md` not `api-reference.md`. Use `pipeline-stages.md` not `examples.md`.
+
+### Phase 3: Mermaid Diagrams
+
+**Mermaid diagrams are essential, not optional.** Every README of a non-trivial package and every docs/ guide should include at least one mermaid diagram. The gold standard (MJCore/docs/) uses multiple diagram types per guide.
+
+Choose the right diagram type for the concept:
+
+| Concept | Diagram Type | Example |
+|---------|-------------|---------|
+| Data flow / architecture layers | `flowchart TD` or `flowchart LR` | How components connect |
+| Request/response lifecycle | `sequenceDiagram` | Save orchestration, API calls |
+| Data model / entity relationships | `erDiagram` | IS-A hierarchies, FK relationships |
+| State transitions | `stateDiagram-v2` | Entity lifecycle states |
+| Class hierarchy | `classDiagram` | Provider pattern, inheritance |
+
+**Example from gold standard:**
+
+```markdown
+\`\`\`mermaid
+flowchart LR
+    subgraph Regular["Regular Entity"]
+        RT[Base Table] --> RV[Base View]
+        RV --> RE[Entity Metadata]
+    end
+    subgraph Virtual["Virtual Entity"]
+        VV[SQL View Only] --> VE[Entity Metadata]
+    end
+    RE --> API[GraphQL API / RunView]
+    VE --> API
+    style Virtual fill:#e8d5f5,stroke:#7b2d8e
+    style Regular fill:#d5e8f5,stroke:#2d5f8e
+\`\`\`
+```
+
+**Rules for mermaid diagrams:**
+- Use colors/styling to distinguish different conceptual groups
+- Keep diagrams focused — one concept per diagram
+- Add labels that explain what's happening, not just box names
+- For complex systems, use multiple smaller diagrams rather than one giant one
+
+### Phase 4: Code Examples
+
+Code examples should be:
+- **Real** — Use actual MemberJunction APIs, not pseudocode
+- **Complete** — Show imports, setup, and the core usage
+- **Typed** — Never use `any` types
+- **Annotated** — Comments explain the WHY, not the WHAT
+
+```typescript
+// GOOD: Real MJ pattern with context
+import { Metadata } from '@memberjunction/core';
+import { ProductEntity } from '@memberjunction/core-entities';
+
+const md = new Metadata();
+// Use GetEntityObject — never instantiate entity classes directly
+const product = await md.GetEntityObject<ProductEntity>('Products');
+product.Name = 'Conference Pass';
+await product.Save();
+```
+
+### Phase 5: Cross-Linking
 
 1. **Link to Dependencies**: Use relative paths to link to dependency READMEs
    ```markdown
@@ -152,12 +238,17 @@ Main README should have:
    - Are in the same functional area (siblings)
    - Provide complementary functionality
 
-3. **Use Relative Paths**: Always use relative paths like:
+3. **Link to docs/ guides** in related packages when relevant:
+   ```markdown
+   See the [Virtual Entities Guide](../MJCore/docs/virtual-entities.md) for details on how virtual entities are defined.
+   ```
+
+4. **Use Relative Paths**: Always use relative paths like:
    - `../PackageName/README.md` for sibling packages
    - `../../OtherDir/PackageName/README.md` for packages in other directories
    - `./docs/file.md` for internal documentation
 
-### Phase 4: Write README
+### Phase 6: Write README
 
 1. **For New README**: Create comprehensive documentation following the template
 
@@ -167,6 +258,8 @@ Main README should have:
    - Add missing sections from the template
    - Fix broken links
    - Update code examples if APIs have changed
+   - Add mermaid diagrams if missing
+   - Create docs/ folder with topic guides if the package warrants it
 
 3. **Validate Links**: Ensure all cross-references point to existing files
 
@@ -174,11 +267,12 @@ Main README should have:
 
 1. **Be Accurate**: Only document what actually exists in the code
 2. **Be Concise**: Avoid redundant explanations
-3. **Use Code Examples**: Show, don't just tell
-4. **Keep It Current**: Reflect the actual current state, not aspirations
-5. **No Emojis**: Unless the existing README uses them
-6. **Consistent Formatting**: Use consistent header levels and code block languages
-7. **No "NEW" Annotations**: Don't use "New" or similar tags for various features/abilities in readme docs as those quickly get out of date. If you see them in packages you're updating, remove New/similar tag.
+3. **Use Code Examples**: Show, don't just tell — real MJ patterns only
+4. **Use Mermaid Diagrams**: Visualize architecture, data flow, and relationships
+5. **Keep It Current**: Reflect the actual current state, not aspirations
+6. **No Emojis**: Unless the existing README uses them
+7. **Consistent Formatting**: Use consistent header levels and code block languages
+8. **No "NEW" Annotations**: Don't use "New" or similar tags for various features/abilities in readme docs as those quickly get out of date. If you see them in packages you're updating, remove New/similar tag.
 
 ## What NOT to Include
 
@@ -191,9 +285,11 @@ Main README should have:
 ## Final Steps
 
 1. Write the README.md file
-2. If complex package, create docs/ folder with sub-documents
-3. Report what was created/updated and key changes made
-4. List any broken links or missing information that couldn't be resolved
+2. If hub-and-spoke, create/update docs/ folder with topic guides
+3. Ensure every guide has the standard header block (Package, Related Guides, Related Packages)
+4. Ensure at least one mermaid diagram per non-trivial doc
+5. Report what was created/updated and key changes made
+6. List any broken links or missing information that couldn't be resolved
 
 ## Example Cross-Link Patterns
 
@@ -205,5 +301,8 @@ See [@memberjunction/ai-engine](../Engine/README.md) for orchestration.
 Built on [@memberjunction/core](../../MJCore/README.md).
 
 <!-- For internal docs -->
-See the [Architecture Guide](./docs/architecture.md) for details.
+See the [Provider Pattern Guide](./docs/provider-pattern.md) for details.
+
+<!-- For cross-package deep-dive links -->
+For details on virtual entity behavior, see the [Virtual Entities Guide](../../MJCore/docs/virtual-entities.md).
 ```

--- a/.claude/commands/update-readmes-batch.md
+++ b/.claude/commands/update-readmes-batch.md
@@ -16,6 +16,16 @@ Parse the arguments from: `{{arguments}}`
 
 Extract these values and use them throughout this command.
 
+## Documentation Model
+
+All package READMEs should follow MemberJunction's **hub-and-spoke** documentation model:
+- **README.md** is the hub — overview, key features, mermaid diagrams, links to deep-dive guides
+- **docs/ folder** (for complex packages) contains topic-based canonical guides
+- **Mermaid diagrams are essential** — every non-trivial package needs at least one
+- **Cross-linking** — packages link to each other's READMEs and docs/ guides
+
+The gold standard is `packages/MJCore/` (README + docs/ with virtual-entities.md, isa-relationships.md). Each sub-agent running `/update-package-readme` has full details on this model.
+
 ## Process
 
 ### Phase 1: Discover Packages
@@ -35,6 +45,7 @@ Extract these values and use them throughout this command.
    - Package name (from `name` field)
    - Package path (directory containing package.json)
    - Dependencies (filter to `@memberjunction/*` only)
+   - Whether docs/ folder exists (flag for reporting)
 
 ### Phase 2: Build Dependency Graph
 
@@ -74,9 +85,11 @@ For each package in wave:
              been updated: {list of dependency paths}.
 
              When creating cross-links, these dependency READMEs are now up-to-date
-             and can be linked to.
+             and can be linked to. Also check if any dependency has a docs/ folder
+             with topic guides — if so, link to relevant guides.
 
-             Return: Summary of what was updated and any issues encountered."
+             Return: Summary of what was updated, whether docs/ folder was created/updated,
+             how many mermaid diagrams were added, and any issues encountered."
 ```
 
 **Important Parallelization Rules**:
@@ -113,15 +126,21 @@ Create a summary report:
 - **Waves**: Y
 - **Duration**: Z minutes
 
+## Documentation Model Adoption
+- **Mermaid diagrams added**: N new diagrams across M packages
+- **docs/ folders created**: N new docs/ folders
+- **Hub-and-spoke packages**: N total (X new in this run)
+- **Cross-links created**: N inter-package links
+
 ## Processing Order
 
 ### Wave 0 (Root Packages)
-- @memberjunction/global ✓
-- @memberjunction/core ✓
+- @memberjunction/global [check] (mermaid: 1, docs/: no)
+- @memberjunction/core [check] (mermaid: 3, docs/: yes - 2 guides)
 
 ### Wave 1
-- @memberjunction/ai-core ✓
-- @memberjunction/actions-base ✓
+- @memberjunction/ai-core [check] (mermaid: 1, docs/: no)
+- @memberjunction/actions-base [check] (mermaid: 2, docs/: yes - 1 guide)
 
 ### Wave 2
 ...
@@ -130,12 +149,12 @@ Create a summary report:
 - Package X: {issue description}
 
 ## Folder READMEs Updated
-- packages/AI/README.md ✓
-- packages/Actions/README.md ✓
+- packages/AI/README.md [check]
+- packages/Actions/README.md [check]
 
-## Cross-Links Created
-- 45 inter-package links added
-- 12 broken links fixed
+## Packages Needing Follow-Up
+- @memberjunction/legacy-pkg: Complex but no docs/ created (time constraint)
+- @memberjunction/xyz: Missing source docs for API reference
 ```
 
 ## Handling Special Cases
@@ -162,7 +181,8 @@ packages/AI/
 ├── README.md (folder-level)
 ├── Core/
 │   ├── package.json
-│   └── README.md (package-level)
+│   ├── README.md (package-level)
+│   └── docs/ (topic guides if complex)
 ├── Engine/
 │   ├── package.json
 │   └── README.md (package-level)
@@ -180,15 +200,16 @@ For `directory: packages/AI`:
    - Wave 2: [Engine, Prompts] (depend on CorePlus)
    - Wave 3: [Agents] (depends on Engine, Prompts)
    - Wave 4: [Providers/*] (depend on Core, Engine)
-4. **Execute**: Process each wave with parallel tasks
-5. **Folder**: Update packages/AI/README.md
-6. **Report**: Generate summary
+4. **Execute**: Process each wave with parallel tasks (each adds mermaid diagrams, creates docs/ if warranted)
+5. **Folder**: Update packages/AI/README.md (with mermaid architecture diagram, surfacing docs/ guides from sub-packages)
+6. **Report**: Generate summary with adoption metrics
 
 ## Dry Run Mode
 
 If user requests dry run (add `--dry-run` or `dryRun: true`):
 - Build the dependency graph
 - Show the processing order
+- Identify which packages need docs/ folders
 - Don't actually update any files
 - Useful for planning and verification
 
@@ -197,6 +218,8 @@ If user requests dry run (add `--dry-run` or `dryRun: true`):
 Report the following when complete:
 1. Total packages processed
 2. Processing order (waves)
-3. Any issues or warnings
-4. List of all files created/modified
-5. Summary of cross-links added
+3. Mermaid diagram adoption (added/total)
+4. docs/ folder adoption (created/total complex packages)
+5. Any issues or warnings
+6. List of all files created/modified
+7. Summary of cross-links added


### PR DESCRIPTION
…mermaid emphasis

Overhaul all 4 documentation slash commands to align with the gold standard established in MJCore/docs/. Key improvements:
- update-package-readme: hub-and-spoke model, mermaid diagrams essential (not optional), topic-based docs/ guides, conceptual richness triggers instead of file count
- update-folder-readme: mermaid instead of ASCII art, surface sub-package docs/ guides
- analyze-readme-health: new scoring for mermaid diagrams (15pts) and docs/ folders (15pts), hub-and-spoke compliance checks, diagram coverage reporting
- update-readmes-batch: docs/ folder tracking, mermaid adoption metrics in reports