### PR TITLE
Simplify Open App spec: migrations-only metadata, lean data model

### DIFF
--- a/.changeset/eleven-things-follow.md
+++ b/.changeset/eleven-things-follow.md
@@ -1,0 +1,5 @@
+---
+"@memberjunction/core": patch
+---
+
+just a plan


### PR DESCRIPTION
Remove mj-sync as an install-time step — all metadata (entity registrations, actions, prompts, dashboards) is now delivered as DML within migration files. mj-sync remains as optional dev-time tooling for app authors.

Slim data model from 5 tables to 3: remove AppRegistry (config-driven) and OpenAppPackage (manifest + package.json are source of truth).