### PR TITLE
feat (docker:workbench): Add headless browser automation and Auth0 setup

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -5,7 +5,7 @@ MemberJunction ships two Docker configurations for different use cases.
 ```mermaid
 graph LR
     subgraph "docker/"
-        A["workbench/"] -->|Development| B["Claude Code + SQL Server<br/>Autonomous dev & testing"]
+        A["workbench/"] -->|Development| B["Claude Code + SQL Server<br/>Headless Browser + Auth0<br/>Autonomous dev & testing"]
         C["MJAPI/"] -->|Production| D["API Server<br/>Flyway + CodeGen + PM2"]
     end
 
@@ -21,12 +21,16 @@ graph LR
 | Deploy the MJAPI server as a container (CI/CD, staging, production) | [MJAPI/](MJAPI/) |
 | Develop MJ features with a sandboxed SQL Server | [workbench/](workbench/) |
 | Run the full MJ stack (API + Explorer) inside Docker | [workbench/](workbench/) |
+| Do headless browser automation with Playwright CLI | [workbench/](workbench/) |
+| Test Auth0 login flows end-to-end | [workbench/](workbench/) |
 
 ---
 
 ## Workbench (Development)
 
-A two-container Compose stack: **Claude Code** + **SQL Server 2022**. Includes the MJ repo, all build tools, and shell aliases for fast iteration.
+A two-container Compose stack: **Claude Code** + **SQL Server 2022**. Includes the MJ repo, all build tools, headless Chromium browser, Playwright CLI, and shell aliases for fast iteration.
+
+### Quick Start
 
 ```bash
 cd docker/workbench
@@ -38,8 +42,67 @@ Then enter the container and start working:
 
 ```bash
 docker exec -it claude-dev zsh
+# Auth0 setup runs automatically on first boot
 cc                        # launch Claude Code (autonomous mode)
 ```
+
+### What's Inside
+
+| Component | Purpose |
+|-----------|---------|
+| Node.js 24 | JavaScript/TypeScript runtime |
+| Claude Code | AI coding assistant (auto-updated) |
+| @memberjunction/cli | MJ CLI for migrations, codegen, etc. (auto-updated) |
+| Playwright CLI + Chromium | Headless browser automation for AI agents (auto-updated) |
+| Flyway 10.20.1 | Database migration engine (standalone + bundled JRE) |
+| Turbo | Monorepo build orchestration |
+| Angular CLI | Angular development tools |
+| GitHub CLI (`gh`) | GitHub operations from the command line |
+| Oh-My-Zsh | Enhanced shell with plugins and aliases |
+| Xvfb | Virtual framebuffer for browser edge cases |
+| SQL Server tools | `sqlcmd` and ODBC driver |
+
+### Auth0 Setup
+
+On first boot, the workbench prompts for Auth0 test credentials:
+
+```
+  Auth0 Domain (e.g. myapp.us.auth0.com): ____
+  Auth0 Client ID: ____
+  Auth0 Client Secret: ____
+  Test User Email: ____
+  Test User Password: ____
+```
+
+These are saved to the repo `.env` file and used to generate Angular environment files. MJAPI reads Auth0 config from `.env`, and MJExplorer reads it from `environment.development.ts`.
+
+Run `auth-setup` manually at any time to reconfigure.
+
+### Browser Automation
+
+Claude Code can do full-stack headless browser automation inside the container:
+
+```bash
+# Start the MJ stack
+mjapi &                                     # MJAPI on :4000
+mjui &                                      # Explorer on :4200
+
+# Automate with Playwright CLI
+playwright-cli open http://localhost:4200    # headless Chromium
+playwright-cli snapshot                     # get element refs
+playwright-cli click e15                    # interact
+playwright-cli screenshot                   # capture state
+playwright-cli console error                # check for JS errors
+playwright-cli close                        # done
+```
+
+### Port Mapping
+
+| Service | Inside Container | Your Machine | What to use it for |
+|---------|-----------------|-------------|-------------------|
+| SQL Server | 1433 | **localhost:1444** | Azure Data Studio, DBeaver |
+| MJAPI | 4000 | **localhost:4100** | API testing, GraphQL Playground |
+| MJ Explorer | 4200 | **localhost:4300** | Browser UI |
 
 See [workbench/README.md](workbench/) for the full step-by-step guide.
 
@@ -70,3 +133,13 @@ Both configurations require **Docker** installed on your machine. If you've neve
 | Docker Desktop (macOS/Windows) | 4.0+ | `docker --version` |
 | Docker Engine (Linux) | 20.10+ | `docker --version` |
 | Docker Compose | v2 (built into Desktop) | `docker compose version` |
+
+### Memory Requirements
+
+The workbench requires at least **8 GB** allocated to Docker (16 GB recommended):
+
+| Container | Memory Limit | Purpose |
+|-----------|-------------|---------|
+| `sql-claude` | 2.5 GB | SQL Server 2022 |
+| `claude-dev` | 4 GB | Node.js + Claude Code + Chromium + MJAPI + Explorer |
+| `/dev/shm` | 2 GB | Chromium shared memory (prevents tab crashes) |

--- a/docker/workbench/.env.example
+++ b/docker/workbench/.env.example
@@ -6,3 +6,13 @@ ANTHROPIC_API_KEY=
 
 # SQL Server SA password (also used in .env.database and docker-compose.yml)
 SA_PASSWORD=Claude2Sql99
+
+# ─── Auth0 Test Credentials ─────────────────────────────────────────────────
+# These are configured interactively by auth-setup on first boot.
+# You can also pre-fill them here to skip the interactive prompts.
+#
+# TEST_AUTH0_DOMAIN=your-tenant.us.auth0.com
+# TEST_AUTH0_CLIENT_ID=your-client-id
+# TEST_AUTH0_CLIENT_SECRET=your-client-secret
+# TEST_UID=test@example.com
+# TEST_PWD=your-test-password

--- a/docker/workbench/.zshrc
+++ b/docker/workbench/.zshrc
@@ -39,6 +39,15 @@ alias gcb='git checkout -b'
 alias gpl='git pull'
 alias gps='git push'
 
+# ─── Browser automation shortcuts ────────────────────────────────────────────
+alias pwc='playwright-cli'                                         # short alias
+alias pwopen='playwright-cli open http://localhost:4200'           # open Explorer headless
+alias pwsnap='playwright-cli snapshot'                             # take accessibility snapshot
+alias pwclose='playwright-cli close'                               # close browser session
+alias pwlist='playwright-cli list'                                 # list active sessions
+alias pwscreen='playwright-cli screenshot'                         # take screenshot
+alias pwconsole='playwright-cli console'                           # check console output
+
 # ─── General shortcuts ───────────────────────────────────────────────────────
 alias ll='ls -alh'
 alias ..='cd ..'
@@ -55,9 +64,17 @@ echo "  sql / sqlmj → sqlcmd connected to $DB_HOST"
 echo "  sqldbs      → list all databases"
 echo "  sqlq        → run inline query"
 echo "  db-bootstrap→ create MJ database + run migrations"
+echo "  auth-setup  → configure Auth0 credentials"
 echo "  mjapi       → start MJAPI (host :4100)"
 echo "  mjui        → start Explorer (host :4300)"
 echo "  mjcd        → cd to /workspace/MJ"
 echo "  tb / tbf    → turbo build / turbo build --filter"
+echo "  ─────────── Browser Automation ─────────"
+echo "  pwopen      → open headless browser → Explorer"
+echo "  pwsnap      → accessibility snapshot"
+echo "  pwclose     → close browser session"
+echo "  pwscreen    → take screenshot"
+echo "  pwconsole   → check JS console output"
+echo "  pwlist      → list active browser sessions"
 echo "  ─────────────────────────────────────────"
 echo ""

--- a/docker/workbench/Dockerfile
+++ b/docker/workbench/Dockerfile
@@ -1,6 +1,6 @@
 FROM node:24-bookworm
 
-# Install system dependencies
+# Install system dependencies (includes xvfb for headless browser fallback)
 RUN apt-get update && apt-get install -y \
     git \
     ripgrep \
@@ -10,6 +10,7 @@ RUN apt-get update && apt-get install -y \
     jq \
     gnupg2 \
     apt-transport-https \
+    xvfb \
     && rm -rf /var/lib/apt/lists/*
 
 # Install GitHub CLI
@@ -34,6 +35,9 @@ RUN npm install -g @angular/cli turbo
 
 # Install Playwright with Chromium and all system dependencies
 RUN npx playwright install --with-deps chromium
+
+# Install Playwright CLI (Microsoft's token-efficient browser automation for AI agents)
+RUN npm install -g @playwright/cli@latest
 
 # Install Claude Code globally (latest for Opus 4.6+ support)
 RUN npm install -g @anthropic-ai/claude-code@latest
@@ -62,7 +66,8 @@ COPY claude-settings.json /root/.claude/settings.json
 # Copy scripts
 COPY entrypoint.sh /entrypoint.sh
 COPY db-bootstrap.sh /usr/local/bin/db-bootstrap
-RUN chmod +x /entrypoint.sh /usr/local/bin/db-bootstrap
+COPY auth-setup.sh /usr/local/bin/auth-setup
+RUN chmod +x /entrypoint.sh /usr/local/bin/db-bootstrap /usr/local/bin/auth-setup
 
 # Set zsh as default shell
 ENV SHELL=/bin/zsh

--- a/docker/workbench/auth-setup.sh
+++ b/docker/workbench/auth-setup.sh
@@ -1,0 +1,188 @@
+#!/bin/bash
+# ─── Auth0 & Environment Setup for MJ Workbench ────────────────────────────────
+#
+# This script configures Auth0 credentials and Angular environment files
+# needed to run MJAPI and MJExplorer inside the Docker workbench.
+#
+# It is run automatically on first boot (or when Auth0 vars are missing from .env),
+# and can also be invoked manually:
+#
+#   auth-setup              # Interactive prompts
+#   auth-setup --check      # Just check if setup is complete (exit 0 if yes, 1 if no)
+#
+set -e
+
+MJ_DIR="/workspace/MJ"
+ENV_FILE="$MJ_DIR/.env"
+MJAPI_ENV="$MJ_DIR/packages/MJAPI/.env"
+ENVIRONMENTS_DIR="$MJ_DIR/packages/MJExplorer/src/environments"
+
+# ─── Check mode: exit 0 if Auth0 is configured, 1 if not ───────────────────────
+if [ "$1" = "--check" ]; then
+    if [ -f "$ENV_FILE" ] && grep -q "^AUTH0_DOMAIN=." "$ENV_FILE" 2>/dev/null; then
+        exit 0
+    else
+        exit 1
+    fi
+fi
+
+echo ""
+echo "  ┌─────────────────────────────────────────┐"
+echo "  │     MJ Workbench — Auth0 Setup          │"
+echo "  └─────────────────────────────────────────┘"
+echo ""
+echo "  MJAPI and MJExplorer need Auth0 credentials to run."
+echo "  You'll need a test Auth0 tenant with a SPA application configured."
+echo ""
+echo "  These values will be saved to $ENV_FILE"
+echo "  and used to generate Angular environment files."
+echo ""
+
+# ─── Prompt for each variable ──────────────────────────────────────────────────
+read -rp "  Auth0 Domain (e.g. myapp.us.auth0.com): " INPUT_AUTH0_DOMAIN
+read -rp "  Auth0 Client ID: " INPUT_AUTH0_CLIENT_ID
+read -rp "  Auth0 Client Secret: " INPUT_AUTH0_CLIENT_SECRET
+read -rp "  Test User Email (for browser automation login): " INPUT_TEST_UID
+read -rsp "  Test User Password: " INPUT_TEST_PWD
+echo ""  # newline after hidden input
+
+# ─── Validate inputs ──────────────────────────────────────────────────────────
+if [ -z "$INPUT_AUTH0_DOMAIN" ] || [ -z "$INPUT_AUTH0_CLIENT_ID" ] || [ -z "$INPUT_AUTH0_CLIENT_SECRET" ]; then
+    echo ""
+    echo "  ERROR: Auth0 Domain, Client ID, and Client Secret are required."
+    echo "  Run 'auth-setup' again to retry."
+    exit 1
+fi
+
+# ─── Append Auth0 variables to .env ────────────────────────────────────────────
+# Remove any existing Auth0 / test credential lines first
+if [ -f "$ENV_FILE" ]; then
+    # Strip existing Auth0 and test credential lines
+    sed -i '/^# ─── Auth0/d' "$ENV_FILE"
+    sed -i '/^AUTH0_DOMAIN=/d' "$ENV_FILE"
+    sed -i '/^AUTH0_CLIENT_ID=/d' "$ENV_FILE"
+    sed -i '/^AUTH0_CLIENT_SECRET=/d' "$ENV_FILE"
+    sed -i '/^TEST_AUTH0_DOMAIN=/d' "$ENV_FILE"
+    sed -i '/^TEST_AUTH0_CLIENT_ID=/d' "$ENV_FILE"
+    sed -i '/^TEST_AUTH0_CLIENT_SECRET=/d' "$ENV_FILE"
+    sed -i '/^TEST_UID=/d' "$ENV_FILE"
+    sed -i '/^TEST_PWD=/d' "$ENV_FILE"
+    sed -i '/^# Test credentials for browser automation/d' "$ENV_FILE"
+    # Remove trailing blank lines
+    sed -i -e :a -e '/^\n*$/{$d;N;ba' -e '}' "$ENV_FILE"
+fi
+
+cat >> "$ENV_FILE" << EOF
+
+# ─── Auth0 Configuration (used by MJAPI) ───────────────────────────────────────
+AUTH0_DOMAIN=${INPUT_AUTH0_DOMAIN}
+AUTH0_CLIENT_ID=${INPUT_AUTH0_CLIENT_ID}
+AUTH0_CLIENT_SECRET=${INPUT_AUTH0_CLIENT_SECRET}
+
+# Test credentials for browser automation (used by Claude Code for headless login)
+TEST_AUTH0_DOMAIN=${INPUT_AUTH0_DOMAIN}
+TEST_AUTH0_CLIENT_ID=${INPUT_AUTH0_CLIENT_ID}
+TEST_AUTH0_CLIENT_SECRET=${INPUT_AUTH0_CLIENT_SECRET}
+TEST_UID=${INPUT_TEST_UID}
+TEST_PWD=${INPUT_TEST_PWD}
+EOF
+
+echo ""
+echo "  Updated $ENV_FILE with Auth0 credentials."
+
+# ─── Symlink .env into packages/MJAPI/ ─────────────────────────────────────────
+if [ -f "$MJAPI_ENV" ] && [ ! -L "$MJAPI_ENV" ]; then
+    # Back up existing non-symlink .env
+    mv "$MJAPI_ENV" "$MJAPI_ENV.bak"
+    echo "  Backed up existing $MJAPI_ENV to .env.bak"
+fi
+if [ ! -L "$MJAPI_ENV" ]; then
+    ln -sf "$ENV_FILE" "$MJAPI_ENV"
+    echo "  Symlinked $ENV_FILE → $MJAPI_ENV"
+else
+    echo "  Symlink $MJAPI_ENV already exists."
+fi
+
+# ─── Create Angular environment files ──────────────────────────────────────────
+mkdir -p "$ENVIRONMENTS_DIR"
+
+# Base environment (used by production build)
+cat > "$ENVIRONMENTS_DIR/environment.ts" << ENVTS
+export const environment = {
+  GRAPHQL_URI: 'http://localhost:4000/',
+  GRAPHQL_WS_URI: 'ws://localhost:4000/',
+  REDIRECT_URI: 'http://localhost:4200/',
+  AUTH_TYPE: 'auth0',
+  NODE_ENV: 'production',
+  AUTOSAVE_DEBOUNCE_MS: 1200,
+  SEARCH_DEBOUNCE_MS: 800,
+  MIN_SEARCH_LENGTH: 3,
+  MJ_CORE_SCHEMA_NAME: '__mj',
+  production: true,
+  APPLICATION_NAME: 'MemberJunction Explorer',
+  APPLICATION_INSTANCE: 'DOCKER',
+  AUTH0_DOMAIN: '${INPUT_AUTH0_DOMAIN}',
+  AUTH0_CLIENTID: '${INPUT_AUTH0_CLIENT_ID}',
+} as const;
+ENVTS
+
+# Development environment (used by ng serve / npm start)
+cat > "$ENVIRONMENTS_DIR/environment.development.ts" << ENVTS
+export const environment = {
+  GRAPHQL_URI: 'http://localhost:4000/',
+  GRAPHQL_WS_URI: 'ws://localhost:4000/',
+  REDIRECT_URI: 'http://localhost:4200/',
+  AUTH_TYPE: 'auth0',
+  NODE_ENV: 'development',
+  AUTOSAVE_DEBOUNCE_MS: 1200,
+  SEARCH_DEBOUNCE_MS: 800,
+  MIN_SEARCH_LENGTH: 3,
+  MJ_CORE_SCHEMA_NAME: '__mj',
+  production: false,
+  APPLICATION_NAME: 'MemberJunction Explorer',
+  APPLICATION_INSTANCE: 'DEV',
+  AUTH0_DOMAIN: '${INPUT_AUTH0_DOMAIN}',
+  AUTH0_CLIENTID: '${INPUT_AUTH0_CLIENT_ID}',
+} as const;
+ENVTS
+
+# Staging environment (same as dev for workbench purposes)
+cat > "$ENVIRONMENTS_DIR/environment.staging.ts" << ENVTS
+export const environment = {
+  GRAPHQL_URI: 'http://localhost:4000/',
+  GRAPHQL_WS_URI: 'ws://localhost:4000/',
+  REDIRECT_URI: 'http://localhost:4200/',
+  AUTH_TYPE: 'auth0',
+  NODE_ENV: 'staging',
+  AUTOSAVE_DEBOUNCE_MS: 1200,
+  SEARCH_DEBOUNCE_MS: 800,
+  MIN_SEARCH_LENGTH: 3,
+  MJ_CORE_SCHEMA_NAME: '__mj',
+  production: false,
+  APPLICATION_NAME: 'MemberJunction Explorer',
+  APPLICATION_INSTANCE: 'STAGING',
+  AUTH0_DOMAIN: '${INPUT_AUTH0_DOMAIN}',
+  AUTH0_CLIENTID: '${INPUT_AUTH0_CLIENT_ID}',
+} as const;
+ENVTS
+
+echo "  Created Angular environment files in $ENVIRONMENTS_DIR"
+
+echo ""
+echo "  ┌─────────────────────────────────────────┐"
+echo "  │     Setup Complete!                     │"
+echo "  └─────────────────────────────────────────┘"
+echo ""
+echo "  Auth0 domain:    ${INPUT_AUTH0_DOMAIN}"
+echo "  Client ID:       ${INPUT_AUTH0_CLIENT_ID:0:8}..."
+echo "  Test user:       ${INPUT_TEST_UID}"
+echo ""
+echo "  .env:            $ENV_FILE"
+echo "  MJAPI symlink:   $MJAPI_ENV → $ENV_FILE"
+echo "  Environments:    $ENVIRONMENTS_DIR/"
+echo ""
+echo "  Next steps:"
+echo "    db-bootstrap     # Create MJ database + run migrations"
+echo "    mjapi             # Start MJAPI server"
+echo "    mjui              # Start MJ Explorer"
+echo ""

--- a/docker/workbench/claude-settings.json
+++ b/docker/workbench/claude-settings.json
@@ -48,6 +48,7 @@
       "Bash(pkill:*)",
       "Bash(lsof:*)",
       "Bash(rg:*)",
+      "Bash(playwright-cli:*)",
       "Bash(NODE_OPTIONS:*)",
       "Bash(DEBUG:*)"
     ],

--- a/docker/workbench/docker-compose.yml
+++ b/docker/workbench/docker-compose.yml
@@ -31,6 +31,7 @@ services:
       context: .
       dockerfile: Dockerfile
     container_name: claude-dev
+    shm_size: '2gb'     # Chromium needs this (default 64MB causes tab crashes)
     env_file:
       - .env.database
     environment:
@@ -50,9 +51,9 @@ services:
     deploy:
       resources:
         limits:
-          memory: 3g
+          memory: 4g          # Increased: browser + MJAPI + Explorer need headroom
         reservations:
-          memory: 512m
+          memory: 1g
     stdin_open: true
     tty: true
     working_dir: /workspace


### PR DESCRIPTION
## Summary

This PR adds comprehensive headless browser automation capabilities and Auth0 integration to the Docker workbench, enabling Claude Code to perform end-to-end UI testing and authentication flows without manual intervention.

## Key Changes

### Browser Automation
- **Playwright CLI + Chromium**: Added `@playwright/cli` and headless Chromium to the workbench container for token-efficient browser automation
- **Shared Memory Configuration**: Set `shm_size: '2gb'` in docker-compose.yml to prevent Chromium tab crashes (default 64MB is insufficient)
- **Shell Aliases**: Added 7 new aliases (`pwc`, `pwopen`, `pwsnap`, `pwclose`, `pwscreen`, `pwconsole`, `pwlist`) for convenient browser control
- **Auto-update**: Extended entrypoint.sh to auto-update Playwright CLI alongside Claude Code and MJ CLI on every container start
- **Permissions**: Added `playwright-cli` to claude-settings.json pre-approved commands

### Auth0 Integration
- **auth-setup.sh**: New interactive script that:
  - Prompts for Auth0 domain, client ID, client secret, and test user credentials
  - Saves credentials to `/workspace/MJ/.env` with both `AUTH0_*` and `TEST_*` prefixes
  - Generates Angular environment files (`environment.ts`, `environment.development.ts`, `environment.staging.ts`) with Auth0 configuration
  - Creates symlink from repo root `.env` to `packages/MJAPI/.env` for MJAPI to read credentials
  - Supports `--check` flag for non-interactive verification
- **Automatic Prompting**: entrypoint.sh now detects missing Auth0 credentials and prompts for setup on first boot (interactive terminals only)
- **Credential Persistence**: All Auth0 settings persist across container restarts via host-mounted `/workspace` volume

### Documentation
- **README.md**: Comprehensive new sections covering:
  - Browser automation workflow with Playwright CLI examples
  - Auth0 setup process and credential mapping
  - File persistence and volume management
  - Memory requirements increased from 6GB to 8GB (Chromium headroom)
  - Troubleshooting for Chromium crashes and Auth0 login failures
- **CLAUDE.md**: Added Auth0 and headless browser automation sections with workflow examples
- **docker/README.md**: Updated overview to highlight browser automation and Auth0 capabilities

### Configuration Updates
- **Dockerfile**: Added `xvfb` (virtual framebuffer) for edge cases requiring a display
- **.env.example**: Added commented Auth0 credential template for optional pre-configuration
- **.zshrc**: Added browser automation aliases and updated welcome banner
- **entrypoint.sh**: Enhanced to handle .env symlink creation and Auth0 setup prompting

## Implementation Details

- Auth0 credentials are stored in a single `.env` file at the repo root and symlinked to `packages/MJAPI/.env`, ensuring MJAPI reads the same configuration
- Angular environment files are generated with `AUTH0_DOMAIN` and `AUTH0_CLIENTID` (note the different casing for Angular compatibility)
- Test credentials (`TEST_UID`, `TEST_PWD`) are stored separately for Claude Code to use in headless browser login automation
- The `auth-setup --check` command enables non-interactive verification (exit 0 if configured, 1 if not)
- Chromium's 2GB shared memory allocation prevents inter-process communication failures that cause tab crashes
- All changes persist on the host-mounted `/workspace` volume, surviving container restarts

https://claude.ai/code/session_013ZjhEnXeuYBW8FCifabxGQ