### PR TITLE
feat: Docker workbench — configurable ports, Auth0 auto-setup, standalone Flyway, ARM64 support

### DIFF
--- a/.claude/commands/docker-workbench.md
+++ b/.claude/commands/docker-workbench.md
@@ -66,7 +66,10 @@ docker compose -f docker/workbench/docker-compose.yml logs --tail=50
 ## Important Notes
 
 - The `.env` file in `docker/workbench/` must exist before starting. If it doesn't, copy from `.env.example`.
+- Pre-fill `TEST_AUTH0_DOMAIN`, `TEST_AUTH0_CLIENT_ID`, `TEST_AUTH0_CLIENT_SECRET`, `TEST_UID`, `TEST_PWD` in `.env` for fully automated Auth0 setup (no interactive prompts).
+- Host ports default to 4000 (MJAPI) and 4200 (Explorer). Override with `MJAPI_HOST_PORT` and `EXPLORER_HOST_PORT` in `.env`.
 - SQL Server data persists in the `sql-claude-data` Docker volume across restarts.
 - Claude settings persist in the `claude-settings` Docker volume.
 - The workbench auto-updates Claude Code and MJ CLI on every container start.
 - SA password is `Claude2Sql99` (docker-internal only, disposable environment).
+- Inside the container: `db-bootstrap` to create DB + run migrations, `mjapi` / `mjui` to start the MJ stack, `pwopen` to launch headless browser.

--- a/docker/workbench/.env.example
+++ b/docker/workbench/.env.example
@@ -7,9 +7,17 @@ ANTHROPIC_API_KEY=
 # SQL Server SA password (also used in .env.database and docker-compose.yml)
 SA_PASSWORD=Claude2Sql99
 
+# ─── Host Port Overrides ──────────────────────────────────────────────────────
+# Default ports match the container ports so Auth0 callbacks and GraphQL URIs
+# work without extra configuration.  Override if you already have a local
+# MJAPI (4000) or MJExplorer (4200) running.
+#
+# MJAPI_HOST_PORT=4100
+# EXPLORER_HOST_PORT=4300
+
 # ─── Auth0 Test Credentials ─────────────────────────────────────────────────
-# These are configured interactively by auth-setup on first boot.
-# You can also pre-fill them here to skip the interactive prompts.
+# Pre-fill these to auto-configure Auth0 on container start (no interactive prompts).
+# Or leave blank and run `auth-setup` manually inside the container.
 #
 # TEST_AUTH0_DOMAIN=your-tenant.us.auth0.com
 # TEST_AUTH0_CLIENT_ID=your-client-id

--- a/docker/workbench/.zshrc
+++ b/docker/workbench/.zshrc
@@ -23,7 +23,7 @@ alias mjba='npm run build'                # build all from root
 alias mjapi='cd /workspace/MJ && npm run start:api'
 alias mjui='cd /workspace/MJ && npm run start:explorer'
 alias mjcg='cd /workspace/MJ && mj codegen'
-alias mjmig='cd /workspace/MJ && mj migrate'
+alias mjmig='cd /workspace/MJ && flyway migrate -url="jdbc:sqlserver://${DB_HOST:-sql-claude}:1433;databaseName=${DB_DATABASE:-MJ_Workbench};trustServerCertificate=true" -user="${CODEGEN_DB_USERNAME:-sa}" -password="${CODEGEN_DB_PASSWORD:-Claude2Sql99}" -schemas=__mj -createSchemas=true -baselineVersion=202602061600 -baselineOnMigrate=true -locations="filesystem:/workspace/MJ/migrations"'
 alias mjcd='cd /workspace/MJ'
 
 # ─── Build shortcuts ─────────────────────────────────────────────────────────
@@ -41,7 +41,7 @@ alias gps='git push'
 
 # ─── Browser automation shortcuts ────────────────────────────────────────────
 alias pwc='playwright-cli'                                         # short alias
-alias pwopen='playwright-cli open http://localhost:4200'           # open Explorer headless
+alias pwopen='playwright-cli open --browser chromium http://localhost:4200'  # open Explorer headless
 alias pwsnap='playwright-cli snapshot'                             # take accessibility snapshot
 alias pwclose='playwright-cli close'                               # close browser session
 alias pwlist='playwright-cli list'                                 # list active sessions
@@ -65,8 +65,8 @@ echo "  sqldbs      → list all databases"
 echo "  sqlq        → run inline query"
 echo "  db-bootstrap→ create MJ database + run migrations"
 echo "  auth-setup  → configure Auth0 credentials"
-echo "  mjapi       → start MJAPI (host :4100)"
-echo "  mjui        → start Explorer (host :4300)"
+echo "  mjapi       → start MJAPI (default host :4000)"
+echo "  mjui        → start Explorer (default host :4200)"
 echo "  mjcd        → cd to /workspace/MJ"
 echo "  tb / tbf    → turbo build / turbo build --filter"
 echo "  ─────────── Browser Automation ─────────"

--- a/docker/workbench/Dockerfile
+++ b/docker/workbench/Dockerfile
@@ -33,11 +33,10 @@ ENV PATH="$PATH:/opt/mssql-tools18/bin"
 # Install Angular CLI and Turbo globally
 RUN npm install -g @angular/cli turbo
 
-# Install Playwright with Chromium and all system dependencies
-RUN npx playwright install --with-deps chromium
-
-# Install Playwright CLI (Microsoft's token-efficient browser automation for AI agents)
+# Install Playwright CLI first, then install Chromium using the CLI's bundled
+# Playwright version so the browser revision matches what playwright-cli expects.
 RUN npm install -g @playwright/cli@latest
+RUN cd /usr/local/lib/node_modules/@playwright/cli && npx playwright install --with-deps chromium
 
 # Install Claude Code globally (latest for Opus 4.6+ support)
 RUN npm install -g @anthropic-ai/claude-code@latest
@@ -45,9 +44,16 @@ RUN npm install -g @anthropic-ai/claude-code@latest
 # Install MemberJunction CLI globally
 RUN npm install -g @memberjunction/cli
 
-# Install Flyway CLI (with bundled JRE for linux-x64)
+# Install Flyway CLI (architecture-aware: bundled JRE on x64, platform-independent + system JRE on ARM64)
 ARG FLYWAY_VERSION=10.20.1
-RUN curl -fsSL "https://repo1.maven.org/maven2/org/flywaydb/flyway-commandline/${FLYWAY_VERSION}/flyway-commandline-${FLYWAY_VERSION}-linux-x64.tar.gz" -o /tmp/flyway.tar.gz \
+RUN ARCH=$(dpkg --print-architecture) \
+    && if [ "$ARCH" = "arm64" ] || [ "$ARCH" = "aarch64" ]; then \
+         apt-get update && apt-get install -y --no-install-recommends default-jre-headless && rm -rf /var/lib/apt/lists/* \
+         && FLYWAY_SUFFIX="" ; \
+       else \
+         FLYWAY_SUFFIX="-linux-x64" ; \
+       fi \
+    && curl -fsSL "https://repo1.maven.org/maven2/org/flywaydb/flyway-commandline/${FLYWAY_VERSION}/flyway-commandline-${FLYWAY_VERSION}${FLYWAY_SUFFIX}.tar.gz" -o /tmp/flyway.tar.gz \
     && tar -xzf /tmp/flyway.tar.gz -C /opt \
     && ln -s "/opt/flyway-${FLYWAY_VERSION}/flyway" /usr/local/bin/flyway \
     && rm /tmp/flyway.tar.gz

--- a/docker/workbench/README.md
+++ b/docker/workbench/README.md
@@ -11,8 +11,8 @@ graph TB
     end
 
     HOST_SQL["Host :1444<br/>Azure Data Studio / DBeaver"] -.->|"port forward"| SQL
-    HOST_API["Host :4100<br/>API clients"] -.->|"port forward"| DEV
-    HOST_UI["Host :4300<br/>Browser"] -.->|"port forward"| DEV
+    HOST_API["Host :4000 (configurable)<br/>API clients"] -.->|"port forward"| DEV
+    HOST_UI["Host :4200 (configurable)<br/>Browser"] -.->|"port forward"| DEV
 
     style SQL fill:#1e3a5f,color:#fff
     style DEV fill:#4a9eff,color:#fff
@@ -60,12 +60,21 @@ cd docker/workbench
 cp .env.example .env
 ```
 
-Open `.env` in a text editor. The only setting you might want to change:
+Open `.env` in a text editor and configure:
 
 | Variable | What it does | Default |
 |----------|-------------|---------|
 | `ANTHROPIC_API_KEY` | Your Anthropic API key for Claude Code. **Leave blank** if you use Claude Max (OAuth login). | _(empty)_ |
 | `SA_PASSWORD` | SQL Server admin password. Fine to leave as-is for local dev. | `Claude2Sql99` |
+| `MJAPI_HOST_PORT` | Host port mapped to MJAPI (container :4000). Override if you already run a local MJAPI. | `4000` |
+| `EXPLORER_HOST_PORT` | Host port mapped to MJExplorer (container :4200). Override if you already run a local Explorer. | `4200` |
+| `TEST_AUTH0_DOMAIN` | Auth0 tenant domain. Pre-fill to skip interactive `auth-setup` on first boot. | _(empty)_ |
+| `TEST_AUTH0_CLIENT_ID` | Auth0 SPA application client ID. | _(empty)_ |
+| `TEST_AUTH0_CLIENT_SECRET` | Auth0 application secret. | _(empty)_ |
+| `TEST_UID` | Test user email for browser automation login. | _(empty)_ |
+| `TEST_PWD` | Test user password for browser automation login. | _(empty)_ |
+
+> **Tip**: If you pre-fill the `TEST_AUTH0_*` / `TEST_UID` / `TEST_PWD` variables, the container will auto-configure Auth0 on first boot without any interactive prompts.
 
 ### Step 4: Start the Workbench
 
@@ -145,9 +154,11 @@ Your Auth0 tenant needs a **Single Page Application** (SPA) configured with:
 
 | Setting | Values |
 |---------|--------|
-| Allowed Callback URLs | `http://localhost:4200`, `http://localhost:4300` |
-| Allowed Logout URLs | `http://localhost:4200`, `http://localhost:4300` |
-| Allowed Web Origins | `http://localhost:4200`, `http://localhost:4300` |
+| Allowed Callback URLs | `http://localhost:4200` through `http://localhost:4205` |
+| Allowed Logout URLs | `http://localhost:4200` through `http://localhost:4205` |
+| Allowed Web Origins | `http://localhost:4200` through `http://localhost:4205` |
+
+The port range (4200–4205) supports running multiple workbench instances simultaneously by setting different `EXPLORER_HOST_PORT` values in each instance's `.env` file.
 
 And a **test user account** with email/password for browser automation.
 
@@ -174,11 +185,11 @@ db-bootstrap                # Creates MJ_Workbench + runs Flyway migrations
 Then start the MJ stack:
 
 ```bash
-mjapi                       # Start MJAPI (container :4000 → host :4100)
-mjui                        # Start Explorer (container :4200 → host :4300)
+mjapi                       # Start MJAPI (container :4000 → host :4000 by default)
+mjui                        # Start Explorer (container :4200 → host :4200 by default)
 ```
 
-Open `http://localhost:4300` in your browser to see MJ Explorer.
+Open `http://localhost:4200` in your browser to see MJ Explorer (or the port you set in `EXPLORER_HOST_PORT`).
 
 ---
 
@@ -293,7 +304,7 @@ playwright-cli click e7                     # Submit
 |--------|---------|-----------------|
 | Display mode | `--headed` (visible window) | Headless (no display) |
 | Interaction style | Visual + snapshot | Snapshot-driven |
-| Ports | MJAPI :4001, Explorer :4201 | MJAPI :4000, Explorer :4200 |
+| Ports | MJAPI :4001, Explorer :4201 | MJAPI :4000, Explorer :4200 (configurable) |
 | Auth caching | `.playwright-cli/profile` dir | Fresh per session (or use `--persistent`) |
 | Screenshots | Open in OS viewer | Read with `Read` tool or copy to host |
 
@@ -305,13 +316,15 @@ Chromium uses `/dev/shm` (shared memory) for inter-process communication. The Do
 
 ## Port Mapping
 
-All ports are offset from their defaults so they don't conflict with anything you're running locally.
+By default, host ports match container ports so Auth0 callbacks work without extra configuration. Override via `.env` if you have local services on those ports.
 
-| Service | Inside Container | Your Machine | What to use it for |
-|---------|-----------------|-------------|-------------------|
-| SQL Server | 1433 | **localhost:1444** | Azure Data Studio, DBeaver |
-| MJAPI | 4000 | **localhost:4100** | API testing, GraphQL Playground |
-| MJ Explorer | 4200 | **localhost:4300** | Browser UI |
+| Service | Inside Container | Your Machine (Default) | Env Var Override |
+|---------|-----------------|----------------------|-----------------|
+| SQL Server | 1433 | **localhost:1444** | _(hardcoded)_ |
+| MJAPI | 4000 | **localhost:4000** | `MJAPI_HOST_PORT` |
+| MJ Explorer | 4200 | **localhost:4200** | `EXPLORER_HOST_PORT` |
+
+Example: To avoid conflicts with a local MJAPI on port 4000, add `MJAPI_HOST_PORT=4100` to your `.env`.
 
 ---
 
@@ -343,8 +356,8 @@ When you enter the container (`docker exec -it claude-dev zsh`), these shortcuts
 | Type this | What it does |
 |-----------|-------------|
 | `mjcd` | `cd` to the MJ repo (`/workspace/MJ`) |
-| `mjapi` | Start MJAPI server (accessible at host :4100) |
-| `mjui` | Start MJ Explorer (accessible at host :4300) |
+| `mjapi` | Start MJAPI server (host port configurable via `MJAPI_HOST_PORT`, default :4000) |
+| `mjui` | Start MJ Explorer (host port configurable via `EXPLORER_HOST_PORT`, default :4200) |
 | `mjcg` | Run CodeGen (`mj codegen`) |
 | `mjmig` | Run database migrations (`mj migrate`) |
 | `mjb` | Build all packages (`npm run build`) |
@@ -388,9 +401,11 @@ When you enter the container (`docker exec -it claude-dev zsh`), these shortcuts
 
 A test Auth0 tenant with:
 1. A **Single Page Application** (SPA) configured with:
-   - **Allowed Callback URLs**: `http://localhost:4200`, `http://localhost:4300`
-   - **Allowed Logout URLs**: `http://localhost:4200`, `http://localhost:4300`
-   - **Allowed Web Origins**: `http://localhost:4200`, `http://localhost:4300`
+   - **Allowed Callback URLs**: `http://localhost:4200` through `http://localhost:4205`
+   - **Allowed Logout URLs**: `http://localhost:4200` through `http://localhost:4205`
+   - **Allowed Web Origins**: `http://localhost:4200` through `http://localhost:4205`
+
+   The port range supports multiple simultaneous workbench instances with different `EXPLORER_HOST_PORT` values.
 2. A **test user account** for browser automation
 
 ### How Setup Works
@@ -590,8 +605,9 @@ ports:
 ### Auth0 login fails
 
 1. Run `auth-setup` to verify your credentials
-2. Check that your Auth0 SPA application has `http://localhost:4200` in its Allowed Callback URLs
+2. Check that your Auth0 SPA application has `http://localhost:4200` through `http://localhost:4205` in its Allowed Callback URLs (the port must match your `EXPLORER_HOST_PORT` setting, default 4200)
 3. Verify the test user exists and has a password set in Auth0
+4. Make sure MJAPI is started with the proper start command (via `npm run start` or the `mjapi` alias) so that `-r dotenv/config` loads the Auth0 environment variables
 
 ### Angular environment files missing
 

--- a/docker/workbench/docker-compose.yml
+++ b/docker/workbench/docker-compose.yml
@@ -8,7 +8,7 @@ services:
       SA_PASSWORD: "${SA_PASSWORD:-Claude2Sql99}"
       ACCEPT_EULA: "Y"
       MSSQL_PID: "Developer"
-      MSSQL_MEMORY_LIMIT_MB: "2048"
+      MSSQL_MEMORY_LIMIT_MB: "3072"
     ports:
       - "1444:1433"
     volumes:
@@ -16,9 +16,9 @@ services:
     deploy:
       resources:
         limits:
-          memory: 2560m
+          memory: 4g            # Baseline migration needs headroom (~96K line SQL)
         reservations:
-          memory: 512m
+          memory: 1g
     healthcheck:
       test: /opt/mssql-tools18/bin/sqlcmd -S localhost -U sa -P "$${SA_PASSWORD}" -C -Q "SELECT 1" || exit 1
       interval: 15s
@@ -37,9 +37,15 @@ services:
     environment:
       ANTHROPIC_API_KEY: "${ANTHROPIC_API_KEY}"
       IS_SANDBOX: "1"
+      # Auth0 test credentials (from host .env, used by entrypoint for auto-setup)
+      TEST_AUTH0_DOMAIN: "${TEST_AUTH0_DOMAIN}"
+      TEST_AUTH0_CLIENT_ID: "${TEST_AUTH0_CLIENT_ID}"
+      TEST_AUTH0_CLIENT_SECRET: "${TEST_AUTH0_CLIENT_SECRET}"
+      TEST_UID: "${TEST_UID}"
+      TEST_PWD: "${TEST_PWD}"
     ports:
-      - "4100:4000"    # MJAPI (offset from local :4000)
-      - "4300:4200"    # Explorer (offset from local :4200)
+      - "${MJAPI_HOST_PORT:-4000}:4000"       # MJAPI  (default 4000; set MJAPI_HOST_PORT=4100 to avoid conflicts)
+      - "${EXPLORER_HOST_PORT:-4200}:4200"     # Explorer (default 4200; set EXPLORER_HOST_PORT=4300 to avoid conflicts)
     depends_on:
       sql-claude:
         condition: service_healthy
@@ -51,9 +57,9 @@ services:
     deploy:
       resources:
         limits:
-          memory: 4g          # Increased: browser + MJAPI + Explorer need headroom
+          memory: 8g          # Build + browser + MJAPI + Explorer need headroom
         reservations:
-          memory: 1g
+          memory: 2g
     stdin_open: true
     tty: true
     working_dir: /workspace

--- a/docker/workbench/workspace/.gitignore
+++ b/docker/workbench/workspace/.gitignore
@@ -1,0 +1,4 @@
+# Ignore everything in this directory — it's a Docker bind mount
+# Only this .gitignore file is committed
+*
+!.gitignore


### PR DESCRIPTION
## Summary

Comprehensive overhaul of the Docker workbench to make it **fully turnkey** for new users and enable **end-to-end headless browser automation** with Auth0 authentication inside the container.

- **Configurable host ports** — MJAPI and Explorer ports now default to standard values (4000/4200) with env var overrides, so Auth0 callbacks work out of the box
- **Auth0 auto-configuration** — pre-fill credentials in `.env` for zero-prompt setup; entrypoint writes MJAPI config, Angular environment files, and symlinks automatically
- **Standalone Flyway migrations** — `db-bootstrap` and `mjmig` alias now call Flyway CLI directly, fixing 404 errors from `mj migrate` trying to download Flyway at runtime
- **Dockerfile fixes** — Playwright/Chromium version alignment, ARM64 Flyway support, increased memory limits for SQL Server (4g) and claude-dev (8g)
- **Browser automation fix** — `pwopen` alias includes `--browser chromium` flag (Chrome isn't installed, only Chromium)
- **Documentation overhaul** — updated port mapping tables, Auth0 port range (4200–4205), `.env` variable reference, troubleshooting tips across CLAUDE.md, README.md, and slash command

## Changed Files

| File | Change |
|------|--------|
| `docker-compose.yml` | Configurable host ports via `MJAPI_HOST_PORT`/`EXPLORER_HOST_PORT` env vars (default 4000/4200); Auth0 credential passthrough; increased memory limits |
| `entrypoint.sh` | Auto-configure Auth0 from env vars (writes `.env`, generates Angular environment files, creates symlinks) with fallback to interactive `auth-setup` |
| `db-bootstrap.sh` | Replaced `mj migrate` with standalone `flyway` CLI using identical parameters (`-schemas=__mj`, `-baselineVersion=202602061600`, etc.) |
| `Dockerfile` | Fixed Playwright/Chromium version mismatch; added ARM64/aarch64 Flyway support with architecture detection; SQL memory bump |
| `.zshrc` | `pwopen` adds `--browser chromium`; `mjmig` uses standalone flyway; welcome banner shows correct default ports |
| `.env.example` | Added `MJAPI_HOST_PORT`, `EXPLORER_HOST_PORT` overrides; improved Auth0 credential docs |
| `docker/CLAUDE.md` | Auth0 Option A (pre-fill) vs Option B (interactive); port range 4200–4205; configurable port docs |
| `docker/workbench/README.md` | Rewrote port mapping table, expanded `.env` variable reference, updated Auth0 prerequisites, fixed stale port references, added dotenv troubleshooting |
| `.claude/commands/docker-workbench.md` | Added Auth0 auto-setup notes, configurable port info, in-container workflow shortcuts |
| `docker/workbench/workspace/.gitignore` | Ignore all bind mount contents (MJ clone, screenshots, node_modules) |

## Test Plan

- [x] Verified full end-to-end flow inside Docker container:
  - Container starts with Auth0 credentials auto-configured from env vars
  - `db-bootstrap` creates database and runs Flyway migrations successfully
  - MJAPI starts with Auth0 provider registered (`-r dotenv/config` loads env)
  - MJExplorer loads at localhost:4200
  - Headless Chromium logs in via Auth0 (`da-robot-tester@bluecypress.io`)
  - Navigated Data Explorer, opened Action record, edited description, saved, viewed Record Changes, reverted
  - 11 screenshots captured confirming full CRUD automation works

🤖 Generated with [Claude Code](https://claude.com/claude-code)