### PR TITLE
docs(codegen): improve CLI help text and add troubleshooting guide

### DIFF
--- a/packages/MJCLI/src/commands/codegen/index.ts
+++ b/packages/MJCLI/src/commands/codegen/index.ts
@@ -3,15 +3,40 @@ import type { ParserOutput } from '@oclif/core/lib/interfaces/parser';
 import { updatedConfig } from '../../config';
 
 export default class CodeGen extends Command {
-  static description = 'Run CodeGen to generate code and update metadata for MemberJunction';
+  static description = `Run the full MemberJunction code generation pipeline.
+
+Analyzes your SQL Server database schema, updates MemberJunction metadata, and
+generates synchronized code across the entire stack:
+
+  - SQL views, stored procedures, indexes, and permissions
+  - TypeScript entity classes with Zod validation schemas
+  - Angular form components with AI-driven layouts
+  - GraphQL resolvers and type definitions
+  - Action subclasses and DB schema JSON
+
+Configuration is loaded from mj.config.cjs in the current directory (or parent
+directories). Database connection can also be set via environment variables:
+DB_HOST, DB_DATABASE, CODEGEN_DB_USERNAME, CODEGEN_DB_PASSWORD.
+
+Use --skipdb to skip all database operations (metadata sync, SQL object
+generation) and only regenerate TypeScript, Angular, and GraphQL output from
+existing metadata.`;
 
   static examples = [
-    `<%= config.bin %> <%= command.id %>
-`,
+    {
+      command: '<%= config.bin %> <%= command.id %>',
+      description: 'Run the full code generation pipeline',
+    },
+    {
+      command: '<%= config.bin %> <%= command.id %> --skipdb',
+      description: 'Regenerate code files without touching the database',
+    },
   ];
 
   static flags = {
-    skipdb: Flags.boolean({ description: 'Skip database migration' }),
+    skipdb: Flags.boolean({
+      description: 'Skip database operations (metadata sync, SQL generation). Only regenerate TypeScript entities, Angular components, and GraphQL resolvers from existing metadata.',
+    }),
   };
 
   flags: ParserOutput<CodeGen>['flags'];
@@ -25,7 +50,7 @@ export default class CodeGen extends Command {
     const config = updatedConfig();
 
     if (!config) {
-      this.error('No configuration found');
+      this.error('No configuration found. Ensure mj.config.cjs exists in the current directory or a parent directory.');
     }
 
     // Initialize configuration

--- a/packages/MJCLI/src/commands/codegen/manifest.ts
+++ b/packages/MJCLI/src/commands/codegen/manifest.ts
@@ -1,43 +1,66 @@
 import { Command, Flags } from '@oclif/core';
 
 export default class CodeGenManifest extends Command {
-    static description = 'Generate a class registrations manifest to prevent tree-shaking of @RegisterClass decorated classes';
+    static description = `Generate a class registration manifest to prevent tree-shaking.
+
+MemberJunction uses @RegisterClass decorators with a dynamic class factory.
+Modern bundlers (ESBuild, Vite) cannot detect dynamic instantiation and will
+tree-shake these classes out of production builds. This command scans the
+dependency tree for all @RegisterClass-decorated classes and emits a manifest
+file with static imports that the bundler cannot eliminate.
+
+Typically used as a prebuild/prestart script for MJAPI and MJExplorer. For
+MJ distribution users, pre-built manifests ship inside @memberjunction/server-bootstrap
+and @memberjunction/ng-bootstrap -- use --exclude-packages @memberjunction to
+generate a supplemental manifest covering only your own application classes.`;
 
     static examples = [
-        `<%= config.bin %> <%= command.id %> --output ./src/generated/class-registrations-manifest.ts`,
-        `<%= config.bin %> <%= command.id %> --appDir ./packages/MJAPI --output ./packages/MJAPI/src/generated/class-registrations-manifest.ts`,
-        `<%= config.bin %> <%= command.id %> --filter BaseEngine --filter BaseAction`,
-        `<%= config.bin %> <%= command.id %> --verbose`,
+        {
+            command: '<%= config.bin %> <%= command.id %>',
+            description: 'Generate manifest with default output path',
+        },
+        {
+            command: '<%= config.bin %> <%= command.id %> --appDir ./packages/MJAPI --output ./packages/MJAPI/src/generated/class-registrations-manifest.ts',
+            description: 'Generate manifest for a specific application directory',
+        },
+        {
+            command: '<%= config.bin %> <%= command.id %> --exclude-packages @memberjunction',
+            description: 'Exclude MJ packages (use pre-built bootstrap manifests instead)',
+        },
+        {
+            command: '<%= config.bin %> <%= command.id %> --filter BaseEngine --filter BaseAction --verbose',
+            description: 'Only include specific base classes with detailed progress',
+        },
     ];
 
     static flags = {
         output: Flags.string({
             char: 'o',
-            description: 'Output manifest file path',
+            description: 'Output file path for the generated manifest. The file will contain named imports and a CLASS_REGISTRATIONS array.',
             default: './src/generated/class-registrations-manifest.ts',
         }),
         appDir: Flags.string({
             char: 'a',
-            description: 'App directory containing package.json (defaults to current directory)',
+            description: 'Root directory of the application whose package.json dependency tree will be scanned. Defaults to the current working directory.',
         }),
         filter: Flags.string({
             char: 'f',
-            description: 'Only include classes with this base class (can be repeated)',
+            description: 'Only include classes extending this base class. Can be repeated (e.g., --filter BaseEngine --filter BaseAction).',
             multiple: true,
         }),
         'exclude-packages': Flags.string({
             char: 'e',
-            description: 'Exclude packages matching this prefix from scanning (can be repeated). Example: --exclude-packages @memberjunction',
+            description: 'Skip packages whose name starts with this prefix. Useful for excluding @memberjunction packages when using pre-built bootstrap manifests. Can be repeated.',
             multiple: true,
         }),
         quiet: Flags.boolean({
             char: 'q',
-            description: 'Suppress all output',
+            description: 'Suppress all output except errors.',
             default: false,
         }),
         verbose: Flags.boolean({
             char: 'v',
-            description: 'Show detailed progress including skipped classes and per-package info',
+            description: 'Show detailed progress including per-package scanning info and skipped classes.',
             default: false,
         }),
     };


### PR DESCRIPTION
Expand codegen and manifest command descriptions with multi-paragraph explanations, annotated examples, and detailed flag descriptions. Add CLI Usage Guide and Troubleshooting sections to CodeGenLib README covering common workflows and failure scenarios.

The remaining feature requests from #1026 (--dry-run, --entity, --watch flags and richer per-phase summary statistics) are deferred as they represent new feature work rather than documentation improvements.

Closes #1026