### PR TITLE
Remove prepublishOnly scripts to prevent race condition.

### DIFF
--- a/packages/AI/AgentManager/actions/package.json
+++ b/packages/AI/AgentManager/actions/package.json
@@ -9,7 +9,6 @@
     "build": "tsc && tsc-alias -f",
     "watch": "tsc -w",
     "clean": "rimraf dist",
-    "prepublishOnly": "npm run build",
     "test": "vitest run",
     "test:watch": "vitest"
   },

--- a/packages/AI/AgentManager/core/package.json
+++ b/packages/AI/AgentManager/core/package.json
@@ -9,7 +9,6 @@
     "build": "tsc && tsc-alias -f",
     "watch": "tsc -w",
     "clean": "rimraf dist",
-    "prepublishOnly": "npm run build",
     "test": "vitest run",
     "test:watch": "vitest"
   },

--- a/packages/Actions/BizApps/Social/package.json
+++ b/packages/Actions/BizApps/Social/package.json
@@ -8,8 +8,7 @@
   "scripts": {
     "build": "tsc && tsc-alias -f",
     "watch": "tsc -w",
-    "clean": "rimraf dist",
-    "prepublishOnly": "npm run clean && npm run build"
+    "clean": "rimraf dist"
   },
   "keywords": [
     "memberjunction",


### PR DESCRIPTION
 Remove prepublishOnly from ai-agent-manager, ai-agent-manager-actions, and actions-bizapps-social. These scripts redundantly rebuild during changeset publish, creating a race condition where concurrent packages read partially-rebuilt dist/ directories (tsc strips .js extensions, tsc-alias adds them back, but the window between causes ESM resolution failures). Turbo already builds everything before publish runs.