### PR TITLE
Fix: Use PascalCase properties in hasSoftPrimaryKeyInConfig()

### DIFF
--- a/packages/CodeGenLib/src/Database/manage-metadata.ts
+++ b/packages/CodeGenLib/src/Database/manage-metadata.ts
@@ -3046,10 +3046,14 @@ DROP TABLE #__mj__CodeGen__vwTableUniqueKeys;
       try {
          const config = ManageMetadataBase.getSoftPKFKConfig();
          if (!config) {
-           logStatus(`         [Soft PK Check] Config file found but no tables array`);
-           return false;
+            logStatus(`         [Soft PK Check] Config file found but could not be parsed`);
+            return false;
          }
          const tables = this.extractTablesFromConfig(config);
+         if (tables.length === 0) {
+            logStatus(`         [Soft PK Check] Config file found but no tables defined`);
+            return false;
+         }
          const tableConfig = tables.find(
             (t) =>
                t.SchemaName.toLowerCase() === schemaName?.toLowerCase() &&


### PR DESCRIPTION
hasSoftPrimaryKeyInConfig() was using camelCase property names (config.tables, t.schemaName, t.tableName, tableConfig.primaryKeys) to search the raw config, but the config file and extractTablesFromConfig() both use PascalCase. This caused the method to always return false, breaking entity creation validation for tables with soft PKs defined in config.

Fixed by reusing extractTablesFromConfig() which already handles both config formats and returns normalized SoftPKFKTableConfig objects with correct PascalCase properties (SchemaName, TableName, PrimaryKey).