### PR TITLE
docs(changeset): Remove migration script V202603021400__v5.6.x__Optim…

### DIFF
--- a/.changeset/new-cups-trade.md
+++ b/.changeset/new-cups-trade.md
@@ -1,0 +1,5 @@
+---
+"@memberjunction/core": minor
+---
+
+Remove migration script V202603021400**v5.6.x**Optimize_RecordChange_Detection_Index because it would significantly increase database size and cause migration timeouts for AIDP upgrades (it adds an index on RecordChange that included FullRecordJSON).


### PR DESCRIPTION
…ize_RecordChange_Detection_Index because it would significantly increase database size and cause migration timeouts for AIDP upgrades (it adds an index on RecordChange that included FullRecordJSON).