### PR TITLE
fix(agents): propagate API keys to sub-agents

### DIFF
--- a/packages/AI/Agents/src/base-agent.ts
+++ b/packages/AI/Agents/src/base-agent.ts
@@ -4047,6 +4047,7 @@ The context is now within limits. Please retry your request with the recovered c
                 payload: payload, // pass the payload if provided
                 configurationId: params.configurationId, // propagate configuration ID to sub-agent
                 effortLevel: params.effortLevel, // propagate effort level to sub-agent
+                apiKeys: params.apiKeys, // propagate API keys to sub-agent
                 data: {
                         ...params.data,
                         ...subAgentRequest.templateParameters,


### PR DESCRIPTION
Pass apiKeys from parent agent params to sub-agent invocations so sub-agents can authenticate with external services.