### PR TITLE
Add missing repository.url to Integration package.json files

### DIFF
--- a/packages/Integration/actions/package.json
+++ b/packages/Integration/actions/package.json
@@ -25,6 +25,10 @@
     "tsc-alias": "^1.8.16",
     "vitest": "^4.0.18"
   },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/MemberJunction/MJ"
+  },
   "author": "MemberJunction.com",
   "license": "ISC"
 }

--- a/packages/Integration/connectors/package.json
+++ b/packages/Integration/connectors/package.json
@@ -25,6 +25,10 @@
     "tsc-alias": "^1.8.16",
     "vitest": "^4.0.18"
   },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/MemberJunction/MJ"
+  },
   "author": "MemberJunction.com",
   "license": "ISC"
 }

--- a/packages/Integration/engine/package.json
+++ b/packages/Integration/engine/package.json
@@ -23,6 +23,10 @@
     "tsc-alias": "^1.8.16",
     "vitest": "^4.0.18"
   },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/MemberJunction/MJ"
+  },
   "author": "MemberJunction.com",
   "license": "ISC"
 }

--- a/packages/Integration/schema-builder/package.json
+++ b/packages/Integration/schema-builder/package.json
@@ -19,5 +19,11 @@
     "typescript": "^5.9.3",
     "tsc-alias": "^1.8.16",
     "vitest": "^4.0.18"
-  }
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/MemberJunction/MJ"
+  },
+  "author": "MemberJunction.com",
+  "license": "ISC"
 }

--- a/packages/Integration/ui-types/package.json
+++ b/packages/Integration/ui-types/package.json
@@ -14,6 +14,10 @@
   "devDependencies": {
     "typescript": "^5.9.3"
   },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/MemberJunction/MJ"
+  },
   "author": "MemberJunction.com",
   "license": "ISC"
 }


### PR DESCRIPTION
The CI workflow runs a validation script that checks every @memberjunction/* package has a repository.url pointing to https://github.com/MemberJunction/MJ.   

This is required for npm sigstore provenance verification — when packages are published to npm, provenance attestation links each published package back to its source repo and CI build. Without the repository field, npm can't generate that provenance chain, and the CI validation gate fails the build.