### PR TITLE
Fix ORDER BY using invalid table aliases in CTE-paged queries

### DIFF
--- a/packages/MJCore/src/__tests__/queryPagingEngine.test.ts
+++ b/packages/MJCore/src/__tests__/queryPagingEngine.test.ts
@@ -226,11 +226,46 @@ ORDER BY r.TotalRevenue DESC`;
         expect(result.DataSQL).toContain('__cq_1 AS');
         expect(result.DataSQL).toContain('[__paged] AS');
         expect(result.DataSQL).toContain('OFFSET 0 ROWS FETCH NEXT 20 ROWS ONLY');
-        expect(result.DataSQL).toContain('ORDER BY r.TotalRevenue DESC');
+        // After remapping, ORDER BY should use projected column names, not table aliases
+        expect(result.DataSQL).toContain('ORDER BY TotalRevenue DESC');
 
         // Count query should also have all CTEs
         expect(result.CountSQL).toContain('__cq_0 AS');
         expect(result.CountSQL).toContain('[__paged] AS');
         expect(result.CountSQL).toContain('TotalRowCount');
+    });
+
+    it('remaps ORDER BY with COALESCE and aliased columns to projected names', () => {
+        // Include SQL comments like the real composition engine produces
+        const sql = `WITH [__cte_Active_Users_k1gvl3] AS (
+-- Reusable base query: Returns all active users with basic profile info
+SELECT u.ID, u.Name, u.Email, u.Type, u.__mj_CreatedAt AS CreatedAt
+FROM __mj.vwUsers u
+WHERE u.IsActive = 1
+),
+[__cte_Recent_Entity_Changes_sokwc2] AS (
+-- Reusable base query: Returns recent record changes grouped by entity
+SELECT e.Name AS EntityName, COUNT(*) AS ChangeCount, MAX(rc.CreatedAt) AS LatestChange
+FROM __mj.vwRecordChanges rc
+INNER JOIN __mj.vwEntities e ON e.ID = rc.EntityID
+WHERE rc.CreatedAt >= DATEADD(DAY, -30, GETUTCDATE())
+GROUP BY e.Name
+)
+-- Composed query: Joins Active Users with Recent Entity Changes
+-- Demonstrates composition syntax
+SELECT au.Name AS UserName, au.Email, au.Type AS UserType, COALESCE(rc.ChangeCount, 0) AS RecentChanges, rc.LatestChange
+FROM [__cte_Active_Users_k1gvl3] au
+LEFT JOIN [__cte_Recent_Entity_Changes_sokwc2] rc ON rc.EntityName IN (
+    SELECT e.Name FROM __mj.vwEntities e WHERE e.ID IN (
+        SELECT DISTINCT EntityID FROM __mj.vwRecordChanges WHERE UserID = au.ID
+    )
+)
+ORDER BY COALESCE(rc.ChangeCount, 0) DESC, au.Name`;
+
+        const result = QueryPagingEngine.WrapWithPaging(sql, 0, 100, 'sqlserver');
+
+        // ORDER BY should use projected names, not table aliases
+        expect(result.DataSQL).toContain('ORDER BY RecentChanges DESC, UserName');
+        expect(result.DataSQL).not.toContain('ORDER BY COALESCE(rc.ChangeCount');
     });
 });

--- a/packages/MJCore/src/generic/queryPagingEngine.ts
+++ b/packages/MJCore/src/generic/queryPagingEngine.ts
@@ -58,8 +58,13 @@ export class QueryPagingEngine {
         const existingCTEs = ctePrefix ? ctePrefix + ',\n' : 'WITH ';
         const cteChain = `${existingCTEs}${pagingCTEName} AS (\n${cleanSelect}\n)`;
 
-        // Determine ORDER BY for the outer query
-        const outerOrderBy = orderByClause || QueryPagingEngine.defaultOrderBy(platform);
+        // Determine ORDER BY for the outer query, remapping table-qualified
+        // references to projected column names since the outer query is
+        // SELECT * FROM [__paged] where table aliases don't exist.
+        const rawOrderBy = orderByClause || QueryPagingEngine.defaultOrderBy(platform);
+        const outerOrderBy = orderByClause
+            ? QueryPagingEngine.remapOrderByToProjectedNames(rawOrderBy, cleanSelect)
+            : rawOrderBy;
 
         // Build platform-specific data query
         const pagingClause = QueryPagingEngine.buildPagingClause(startRow, maxRows, platform);
@@ -233,6 +238,146 @@ export class QueryPagingEngine {
         }
         // SQL Server
         return `OFFSET ${startRow} ROWS FETCH NEXT ${maxRows} ROWS ONLY`;
+    }
+
+    /**
+     * Remaps ORDER BY expressions so they reference the projected column names
+     * from the SELECT list rather than table-qualified aliases (e.g. `r.Total`
+     * becomes `TotalRevenue` if the SELECT has `r.Total AS TotalRevenue`).
+     *
+     * This is necessary because the outer query is `SELECT * FROM [__paged]`
+     * where the original table aliases no longer exist.
+     */
+    static remapOrderByToProjectedNames(orderByClause: string, selectSQL: string): string {
+        const aliasMap = QueryPagingEngine.buildSelectAliasMap(selectSQL);
+
+        // Split ORDER BY into terms at top-level commas
+        const terms = QueryPagingEngine.splitAtTopLevelCommas(orderByClause);
+
+        const remapped = terms.map(term => {
+            const trimmed = term.trim();
+
+            // Separate direction suffix (ASC, DESC, NULLS FIRST, NULLS LAST)
+            const dirMatch = trimmed.match(/\s+(ASC|DESC)(\s+NULLS\s+(FIRST|LAST))?\s*$/i);
+            const expr = dirMatch ? trimmed.substring(0, dirMatch.index!).trim() : trimmed;
+            const direction = dirMatch ? dirMatch[0] : '';
+
+            // Normalize whitespace for comparison
+            const normalizedExpr = expr.replace(/\s+/g, ' ').trim();
+
+            // 1. Try exact match against SELECT expressions
+            const exactMatch = aliasMap.get(normalizedExpr.toUpperCase());
+            if (exactMatch) {
+                return exactMatch + direction;
+            }
+
+            // 2. Try stripping table alias prefixes from the expression
+            //    e.g., COALESCE(rc.ChangeCount, 0) → COALESCE(ChangeCount, 0)
+            const stripped = normalizedExpr.replace(/\b[a-zA-Z_]\w*\./g, '');
+            const strippedMatch = aliasMap.get(stripped.toUpperCase());
+            if (strippedMatch) {
+                return strippedMatch + direction;
+            }
+
+            // 3. If expr itself is a simple table.column, strip the prefix
+            //    and check if the bare column is a projected name
+            const dotMatch = expr.match(/^[a-zA-Z_]\w*\.([a-zA-Z_]\w*)$/);
+            if (dotMatch) {
+                return dotMatch[1] + direction;
+            }
+
+            // 4. Fallback: strip all table prefixes and hope for the best
+            return stripped + direction;
+        });
+
+        return remapped.join(', ');
+    }
+
+    /**
+     * Parses the SELECT list from a SQL statement and builds a map of
+     * normalized expression → projected column name.
+     *
+     * For `SELECT au.Name AS UserName, COALESCE(rc.Count, 0) AS Total`
+     * returns Map { "AU.NAME" → "UserName", "COALESCE(RC.COUNT, 0)" → "Total" }
+     *
+     * Also indexes the stripped (no table prefix) versions:
+     * { "COALESCE(COUNT, 0)" → "Total", "NAME" → "UserName" }
+     */
+    private static buildSelectAliasMap(selectSQL: string): Map<string, string> {
+        const map = new Map<string, string>();
+
+        // Strip leading SQL comments (-- line comments and /* block comments */)
+        const stripped = selectSQL.replace(/^(\s*(--[^\n]*\n|\/\*[\s\S]*?\*\/))*\s*/i, '');
+
+        // Extract the column list between SELECT [DISTINCT] and the first top-level FROM
+        const selectMatch = stripped.match(/^SELECT\s+(?:DISTINCT\s+)?/i);
+        if (!selectMatch) return map;
+
+        const afterSelect = stripped.substring(selectMatch[0].length);
+
+        // Find top-level FROM
+        const upperAfter = afterSelect.toUpperCase();
+        let depth = 0;
+        let fromPos = -1;
+        for (let i = 0; i < afterSelect.length; i++) {
+            const ch = afterSelect[i];
+            if (ch === '(') depth++;
+            else if (ch === ')') depth--;
+            else if (depth === 0 && i + 5 <= afterSelect.length) {
+                if (upperAfter.substring(i, i + 5) === 'FROM ' || upperAfter.substring(i, i + 5) === 'FROM\n' || upperAfter.substring(i, i + 5) === 'FROM\t') {
+                    if (i === 0 || /\s/.test(afterSelect[i - 1])) {
+                        fromPos = i;
+                        break;
+                    }
+                }
+            }
+        }
+
+        const columnList = fromPos === -1 ? afterSelect : afterSelect.substring(0, fromPos);
+        const items = QueryPagingEngine.splitAtTopLevelCommas(columnList);
+
+        for (const item of items) {
+            const trimmed = item.trim();
+            if (!trimmed) continue;
+
+            // Check for AS alias (case insensitive, must be word-bounded)
+            const asMatch = trimmed.match(/\s+AS\s+(\[?\w+\]?)\s*$/i);
+            if (asMatch) {
+                const expr = trimmed.substring(0, asMatch.index!).trim();
+                const alias = asMatch[1].replace(/[[\]]/g, ''); // strip brackets
+                const normalizedExpr = expr.replace(/\s+/g, ' ').toUpperCase();
+                map.set(normalizedExpr, alias);
+
+                // Also index the stripped version (no table prefixes)
+                const strippedExpr = normalizedExpr.replace(/\b[A-Z_]\w*\./g, '');
+                if (strippedExpr !== normalizedExpr) {
+                    map.set(strippedExpr, alias);
+                }
+            }
+        }
+
+        return map;
+    }
+
+    /**
+     * Splits a SQL fragment by commas that are not inside parentheses.
+     */
+    private static splitAtTopLevelCommas(sql: string): string[] {
+        const parts: string[] = [];
+        let depth = 0;
+        let start = 0;
+
+        for (let i = 0; i < sql.length; i++) {
+            const ch = sql[i];
+            if (ch === '(') depth++;
+            else if (ch === ')') depth--;
+            else if (ch === ',' && depth === 0) {
+                parts.push(sql.substring(start, i));
+                start = i + 1;
+            }
+        }
+        parts.push(sql.substring(start));
+        return parts;
     }
 
     /**


### PR DESCRIPTION
- QueryPagingEngine.WrapWithPaging() wraps composed queries in a [__paged] CTE and adds SELECT * FROM [__paged] ORDER BY ..., but the ORDER BY clause was copied verbatim from the inner query — retaining table aliases (e.g., rc.ChangeCount, au.Name) that don't exist in the outer scope
- Added remapOrderByToProjectedNames() which parses the SELECT list to build an expression-to-alias map and rewrites ORDER BY terms to use projected column names (e.g., RecentChanges, UserName)
- Fixed comment-prefixed SELECT statements (from the composition engine) being unparseable by stripping leading SQL comments before parsing