### PR TITLE
Fix transitive UsesTemplate evaluation in query composition engine

### DIFF
--- a/packages/GenericDatabaseProvider/src/GenericDatabaseProvider.ts
+++ b/packages/GenericDatabaseProvider/src/GenericDatabaseProvider.ts
@@ -2181,11 +2181,21 @@ export abstract class GenericDatabaseProvider extends DatabaseProviderBase {
         let appliedParameters: Record<string, string> = {};
 
         // Step 1: Resolve {{query:"..."}} composition tokens BEFORE Nunjucks processing
-        finalSQL = this.ResolveQueryComposition(finalSQL, contextUser, parameters);
+        const compositionResult = this.ResolveQueryComposition(finalSQL, contextUser, parameters);
+        finalSQL = compositionResult.ResolvedSQL;
 
-        // Step 2: Process Nunjucks template parameters
-        if (query.UsesTemplate) {
-            const processingResult = QueryParameterProcessor.processQueryTemplate(query, parameters, finalSQL);
+        // Step 2: Process Nunjucks template parameters.
+        // UsesTemplate is transitive: if ANY dependency uses templates, we must run Nunjucks
+        // even if the outer query itself has UsesTemplate = false.
+        const needsTemplateProcessing = query.UsesTemplate || compositionResult.AnyDependencyUsesTemplates;
+
+        if (needsTemplateProcessing) {
+            const processingResult = QueryParameterProcessor.processQueryTemplate(
+                query,
+                parameters,
+                finalSQL,
+                compositionResult.AnyDependencyUsesTemplates
+            );
 
             if (!processingResult.success) {
                 throw new Error(processingResult.error);

--- a/packages/GenericDatabaseProvider/src/__tests__/query-pipeline.test.ts
+++ b/packages/GenericDatabaseProvider/src/__tests__/query-pipeline.test.ts
@@ -353,6 +353,102 @@ describe('GenericDatabaseProvider Query Pipeline', () => {
             expect(finalSQL).toContain('SELECT ID FROM Users WHERE Active = 1');
             expect(finalSQL).not.toContain('{{query:');
         });
+
+        it('should resolve dependency Nunjucks templates when outer query has UsesTemplate=false', () => {
+            // Dependency uses Nunjucks templates
+            const depQuery = makeQueryInfo({
+                ID: 'dep-1',
+                Name: 'Membership Growth By Period',
+                CategoryPath: '/Reports/',
+                SQL: `SELECT YEAR(m.JoinDate) AS JoinYear, COUNT(*) AS MemberCount
+FROM Members m
+{% if StartDate %}
+WHERE m.JoinDate >= '{{ StartDate }}'
+{% endif %}
+GROUP BY YEAR(m.JoinDate)
+ORDER BY JoinYear`,
+                Reusable: true,
+                UsesTemplate: true,
+            });
+
+            // Outer query does NOT use templates itself, only references the dependency
+            const outerQuery = makeQueryInfo({
+                ID: 'outer-1',
+                Name: 'Growth Report',
+                SQL: 'WITH mg AS (SELECT * FROM {{query:"Reports/Membership Growth By Period"}}) SELECT * FROM mg',
+                UsesTemplate: false,
+            });
+            outerQuery.GetPlatformSQL = vi.fn().mockReturnValue(outerQuery.SQL);
+
+            vi.spyOn(Metadata, 'Provider', 'get').mockReturnValue({
+                Queries: [depQuery],
+                QueryDependencies: [],
+                QueryCategories: [],
+                QueryFields: [],
+                QueryParameters: [],
+                QueryPermissions: [],
+                SQLDialects: [],
+                QuerySQLs: [],
+            } as ReturnType<typeof Metadata.Provider>);
+
+            // Pass StartDate parameter — should be resolved in the dependency's Nunjucks templates
+            const { finalSQL } = provider.testProcessQueryParameters(
+                outerQuery,
+                { StartDate: '2024-01-01' },
+                mockUser
+            );
+
+            // Nunjucks {% if StartDate %} block should be resolved (not raw template syntax)
+            expect(finalSQL).not.toContain('{%');
+            expect(finalSQL).not.toContain('{{');
+            expect(finalSQL).toContain("'2024-01-01'");
+            // ORDER BY should be stripped from the CTE body
+            expect(finalSQL).toContain('WITH');
+            expect(finalSQL).toContain('MemberCount');
+        });
+
+        it('should handle dependency templates with no parameters provided (falsy branch)', () => {
+            const depQuery = makeQueryInfo({
+                ID: 'dep-2',
+                Name: 'All Members',
+                CategoryPath: '/Reports/',
+                SQL: `SELECT m.ID, m.Name
+FROM Members m
+{% if Region %}
+WHERE m.Region = '{{ Region }}'
+{% endif %}`,
+                Reusable: true,
+                UsesTemplate: true,
+            });
+
+            const outerQuery = makeQueryInfo({
+                ID: 'outer-2',
+                Name: 'Member List',
+                SQL: 'SELECT * FROM {{query:"Reports/All Members"}}',
+                UsesTemplate: false,
+            });
+            outerQuery.GetPlatformSQL = vi.fn().mockReturnValue(outerQuery.SQL);
+
+            vi.spyOn(Metadata, 'Provider', 'get').mockReturnValue({
+                Queries: [depQuery],
+                QueryDependencies: [],
+                QueryCategories: [],
+                QueryFields: [],
+                QueryParameters: [],
+                QueryPermissions: [],
+                SQLDialects: [],
+                QuerySQLs: [],
+            } as ReturnType<typeof Metadata.Provider>);
+
+            // No parameters provided — {% if Region %} should evaluate to false
+            const { finalSQL } = provider.testProcessQueryParameters(outerQuery, undefined, mockUser);
+
+            expect(finalSQL).not.toContain('{%');
+            expect(finalSQL).not.toContain('{{ Region }}');
+            // The WHERE clause should NOT be present since Region is not provided
+            expect(finalSQL).not.toContain('WHERE');
+            expect(finalSQL).toContain('SELECT m.ID, m.Name');
+        });
     });
 
     // ================================================================

--- a/packages/MJCore/src/generic/providerBase.ts
+++ b/packages/MJCore/src/generic/providerBase.ts
@@ -10,7 +10,7 @@ import { MJGlobal, SafeJSONParse, UUIDsEqual } from "@memberjunction/global";
 import { TelemetryManager } from "./telemetryManager";
 import { LogError, LogStatus, LogStatusEx } from "./logging";
 import { QueryCategoryInfo, QueryFieldInfo, QueryInfo, QueryPermissionInfo, QueryEntityInfo, QueryParameterInfo, QueryDependencyInfo, SQLDialectInfo, QuerySQLInfo } from "./queryInfo";
-import { QueryCompositionEngine } from "./queryCompositionEngine";
+import { QueryCompositionEngine, CompositionResult } from "./queryCompositionEngine";
 import { LibraryInfo } from "./libraryInfo";
 import { CompositeKey } from "./compositeKey";
 import { ExplorerNavigationItem } from "./explorerNavigationItem";
@@ -1328,26 +1328,30 @@ export abstract class ProviderBase implements IMetadataProvider, IRunViewProvide
      * Resolves {{query:"..."}} composition tokens in SQL, converting referenced
      * queries into CTEs. Call this BEFORE Nunjucks template processing.
      *
-     * If the SQL contains no composition tokens, returns it unchanged.
+     * If the SQL contains no composition tokens, returns a no-op CompositionResult.
      *
      * @param sql - The SQL that may contain composition tokens
      * @param contextUser - User context for permission checks on referenced queries
      * @param parameters - Optional parameter values from the outer query (for pass-through resolution)
-     * @returns The SQL with composition tokens resolved to CTEs
+     * @returns Full CompositionResult including transitive UsesTemplate flag
      */
-    protected ResolveQueryComposition(sql: string, contextUser?: UserInfo, parameters?: Record<string, string>): string {
+    protected ResolveQueryComposition(sql: string, contextUser?: UserInfo, parameters?: Record<string, string>): CompositionResult {
         if (!this._compositionEngine.HasCompositionTokens(sql)) {
-            return sql;
+            return {
+                ResolvedSQL: sql,
+                CTEs: [],
+                DependencyGraph: new Map(),
+                HasCompositions: false,
+                AnyDependencyUsesTemplates: false
+            };
         }
 
-        const result = this._compositionEngine.ResolveComposition(
+        return this._compositionEngine.ResolveComposition(
             sql,
             this.PlatformKey,
             contextUser,
             parameters
         );
-
-        return result.ResolvedSQL;
     }
 
     protected async PreRunQuery(params: RunQueryParams, contextUser?: UserInfo): Promise<typeof this._preRunQueryResultType> {

--- a/packages/MJCore/src/generic/queryCompositionEngine.ts
+++ b/packages/MJCore/src/generic/queryCompositionEngine.ts
@@ -60,6 +60,8 @@ export interface CompositionResult {
     DependencyGraph: Map<string, string[]>;
     /** Whether any composition tokens were found and resolved */
     HasCompositions: boolean;
+    /** True if any resolved dependency query has UsesTemplate = true (depth-first, transitive) */
+    AnyDependencyUsesTemplates: boolean;
 }
 
 /**
@@ -174,6 +176,8 @@ export class QueryCompositionEngine {
         const cteEntries: CTEEntry[] = [];
         const dependencyGraph = new Map<string, string[]>();
         const inProgressSet = new Set<string>();
+        // Mutable flag passed by reference through recursion — short-circuits once true
+        const templateFlag = { value: false };
 
         const resolvedSQL = this.resolveTokensRecursive(
             sql,
@@ -183,6 +187,7 @@ export class QueryCompositionEngine {
             cteEntries,
             dependencyGraph,
             inProgressSet,
+            templateFlag,
             0
         );
 
@@ -197,7 +202,8 @@ export class QueryCompositionEngine {
             ResolvedSQL: finalSQL,
             CTEs: cteEntries.map(e => e.Info),
             DependencyGraph: dependencyGraph,
-            HasCompositions: hasCompositions
+            HasCompositions: hasCompositions,
+            AnyDependencyUsesTemplates: templateFlag.value
         };
     }
 
@@ -212,6 +218,7 @@ export class QueryCompositionEngine {
         cteEntries: CTEEntry[],
         dependencyGraph: Map<string, string[]>,
         inProgressSet: Set<string>,
+        templateFlag: { value: boolean },
         depth: number
     ): string {
         if (depth > MAX_COMPOSITION_DEPTH) {
@@ -229,6 +236,11 @@ export class QueryCompositionEngine {
         for (const token of tokens) {
             const referencedQuery = this.lookupQuery(token);
             this.validateQueryComposable(referencedQuery, token, contextUser);
+
+            // Depth-first transitive UsesTemplate check — short-circuit once true
+            if (!templateFlag.value && referencedQuery.UsesTemplate) {
+                templateFlag.value = true;
+            }
 
             // Cycle detection
             if (inProgressSet.has(referencedQuery.ID)) {
@@ -270,6 +282,7 @@ export class QueryCompositionEngine {
                 cteEntries,
                 dependencyGraph,
                 inProgressSet,
+                templateFlag,
                 depth + 1
             );
 

--- a/packages/QueryProcessor/src/queryParameterProcessor.ts
+++ b/packages/QueryProcessor/src/queryParameterProcessor.ts
@@ -91,7 +91,8 @@ export class QueryParameterProcessor {
      */
     public static validateParameters(
         parameters: Record<string, unknown> | undefined,
-        parameterDefinitions: QueryParameterInfo[]
+        parameterDefinitions: QueryParameterInfo[],
+        skipUnknownParameterCheck?: boolean
     ): ParameterValidationResult {
         const errors: string[] = [];
         const validatedParams: Record<string, unknown> = {};
@@ -208,8 +209,9 @@ export class QueryParameterProcessor {
             }
         }
 
-        // Check for unknown parameters
-        if (parameters) {
+        // Check for unknown parameters (skipped for transitive template processing
+        // where the outer query doesn't define the dependency's parameters)
+        if (parameters && !skipUnknownParameterCheck) {
             const definedParamNames = new Set(parameterDefinitions.map(p => p.Name));
             for (const key of Object.keys(parameters)) {
                 if (!definedParamNames.has(key)) {
@@ -230,17 +232,21 @@ export class QueryParameterProcessor {
      * @param query The query info containing template SQL and parameter definitions
      * @param parameters User-provided parameter values
      * @param sqlOverride Optional SQL to use instead of query.SQL (e.g., platform-resolved SQL)
+     * @param forceTemplateProcessing When true, processes Nunjucks templates even if the query's
+     *        own UsesTemplate is false. Used for transitive template resolution when a composed
+     *        dependency uses templates but the outer query does not.
      */
     public static processQueryTemplate(
         query: QueryInfo,
         parameters: Record<string, unknown> | undefined,
-        sqlOverride?: string
+        sqlOverride?: string,
+        forceTemplateProcessing?: boolean
     ): QueryProcessingResult {
         try {
             const sql = sqlOverride ?? query.SQL;
 
-            // If query doesn't use templates, return the SQL as-is
-            if (!query.UsesTemplate) {
+            // If query doesn't use templates (and no dependency does either), return the SQL as-is
+            if (!query.UsesTemplate && !forceTemplateProcessing) {
                 return {
                     success: true,
                     processedSQL: sql,
@@ -248,8 +254,10 @@ export class QueryParameterProcessor {
                 };
             }
 
-            // Validate parameters
-            const validation = this.validateParameters(parameters, query.Parameters);
+            // Validate parameters against known definitions.
+            // When force-processing for transitive templates, the outer query may not define
+            // all parameters used by dependencies, so we skip the "unknown parameter" check.
+            const validation = this.validateParameters(parameters, query.Parameters, forceTemplateProcessing);
             if (!validation.success) {
                 return {
                     success: false,
@@ -259,17 +267,28 @@ export class QueryParameterProcessor {
                 };
             }
 
+            // When force-processing, merge any provided parameters that weren't in query.Parameters
+            // so Nunjucks can resolve dependency template tokens
+            const renderParams = { ...validation.validatedParameters };
+            if (forceTemplateProcessing && parameters) {
+                for (const [key, value] of Object.entries(parameters)) {
+                    if (!(key in renderParams)) {
+                        renderParams[key] = value;
+                    }
+                }
+            }
+
             // Process the template
             try {
                 const processedSQL = this.nunjucksEnv.renderString(
                     sql,
-                    validation.validatedParameters
+                    renderParams
                 );
 
                 return {
                     success: true,
                     processedSQL,
-                    appliedParameters: validation.validatedParameters
+                    appliedParameters: renderParams
                 };
             } catch (e: unknown) {
                 const msg = e instanceof Error ? e.message : String(e);
@@ -277,7 +296,7 @@ export class QueryParameterProcessor {
                     success: false,
                     processedSQL: '',
                     error: `Template processing failed: ${msg}`,
-                    appliedParameters: validation.validatedParameters
+                    appliedParameters: renderParams
                 };
             }
         } catch (e: unknown) {


### PR DESCRIPTION
## Summary
When an outer query composes a dependency via {{query:"..."}} and the dependency uses Nunjucks templates ({% if %}, {{ param }}) but the outer query does not (UsesTemplate = false), the Nunjucks processing step was skipped entirely — causing raw template syntax to reach SQL Server as a syntax error
Added AnyDependencyUsesTemplates flag to CompositionResult, propagated depth-first through recursive composition resolution, so the Nunjucks gate now checks query.UsesTemplate || compositionResult.AnyDependencyUsesTemplates
Added forceTemplateProcessing and skipUnknownParameterCheck parameters to QueryParameterProcessor to handle transitive template rendering where the outer query doesn't define the dependency's parameters
## Test plan
 - [x] Two new unit tests covering transitive template resolution (with and without parameters)
 - [x]  All 116 existing tests pass across 5 test files
 - [x] MJCore, QueryProcessor, and GenericDatabaseProvider all compile cleanly
 - [x] Manual verification: create an outer query composing a reusable dependency with Nunjucks templates and confirm clean SQL execution