### PR TITLE
fix(MetadataSync): Add GO batch separator to SQL logging in PushService and WatchService

### DIFF
--- a/packages/MetadataSync/src/services/PushService.ts
+++ b/packages/MetadataSync/src/services/PushService.ts
@@ -189,6 +189,7 @@ export class PushService {
             description: 'MetadataSync push operation',
             statementTypes: "mutations",
             prettyPrint: true,
+            batchSeparator: 'GO',
             filterPatterns: this.syncConfig?.sqlLogging?.filterPatterns,
             filterType: this.syncConfig?.sqlLogging?.filterType,
             verboseOutput: this.syncConfig?.sqlLogging?.verboseOutput || false,

--- a/packages/MetadataSync/src/services/WatchService.ts
+++ b/packages/MetadataSync/src/services/WatchService.ts
@@ -368,7 +368,8 @@ export class WatchService {
           this.sqlLoggingSession = await provider.CreateSqlLogger(filepath, {
             formatAsMigration: syncConfig.sqlLogging?.formatAsMigration || false,
             description: 'MetadataSync watch operation',
-            logRecordChangeMetadata: true
+            logRecordChangeMetadata: true,
+            batchSeparator: 'GO',
           });
           
           callbacks?.onLog?.(`📝 SQL logging enabled: ${filepath}`);


### PR DESCRIPTION

The refactor to GenericDatabaseProvider's SqlLogger introduced a batchSeparator option but it was never passed in CreateSqlLogger calls. Without GO statements, large metadata syncs exceed SQL Server's 10,000 local variable limit per batch.