### PR TITLE
feat: variable-count batch separation for SQL logging 

### DIFF
--- a/metadata/.mj-sync.json
+++ b/metadata/.mj-sync.json
@@ -49,7 +49,8 @@
     "outputDirectory": "./sql_logging",
     "filterPatterns": ["*spCreateAIPromptRun*", "*spUpdateAIPromptRun*"],
     "filterType": "exclude",
-    "formatAsMigration": true
+    "formatAsMigration": true,
+    "variableBatchThreshold": 200
   },
   "emitSyncNotes": false
 }

--- a/packages/GenericDatabaseProvider/src/GenericDatabaseProvider.ts
+++ b/packages/GenericDatabaseProvider/src/GenericDatabaseProvider.ts
@@ -67,6 +67,7 @@ import { QueryParameterProcessor } from '@memberjunction/query-processor';
 import { v4 as uuidv4 } from 'uuid';
 import { SqlLoggingSessionImpl } from './SqlLogger.js';
 import { SqlLoggingOptions, SqlLoggingSession } from './types.js';
+import { SQLDialect } from '@memberjunction/sql-dialect';
 import { QueryCompositionEngine } from './queryCompositionEngine.js';
 
 import {
@@ -217,8 +218,10 @@ export abstract class GenericDatabaseProvider extends DatabaseProviderBase {
         const session = new SqlLoggingSessionImpl(sessionId, filePath,
             {
                 defaultSchemaName: mjCoreSchema,
-                ...options // if defaultSchemaName is not provided, it will use the MJCoreSchemaName, otherwise
-                // the caller's defaultSchemaName will be used
+                // Inject the platform's batch separator as the default so callers don't need to
+                // hardcode 'GO'. Callers can still override by passing batchSeparator explicitly.
+                batchSeparator: this.PlatformBatchSeparator || undefined,
+                ...options
             });
 
         // Initialize the session (create file, write header)
@@ -678,6 +681,26 @@ export abstract class GenericDatabaseProvider extends DatabaseProviderBase {
     /**************************************************************************/
     // InternalRunView — Shared View Execution Engine
     /**************************************************************************/
+
+    /**
+     * Returns the SQLDialect instance for this provider's platform.
+     * Subclasses override to return the appropriate dialect (e.g. SQLServerDialect, PostgreSQLDialect).
+     * Used by `PlatformBatchSeparator` to retrieve the correct batch separator token via
+     * `@memberjunction/sql-dialect` rather than hardcoding platform strings.
+     */
+    protected getDialect(): SQLDialect | null {
+        return null;
+    }
+
+    /**
+     * Returns the batch separator token for the underlying database platform by delegating to
+     * the SQLDialect instance returned by `getDialect()`.
+     * SQL Server → `'GO'`, PostgreSQL → `''` (no separator needed).
+     * Auto-injected as the default `batchSeparator` in `CreateSqlLogger`.
+     */
+    protected get PlatformBatchSeparator(): string {
+        return this.getDialect()?.BatchSeparator() ?? '';
+    }
 
     /**
      * Builds a platform-specific pagination clause.

--- a/packages/GenericDatabaseProvider/src/SqlLogger.ts
+++ b/packages/GenericDatabaseProvider/src/SqlLogger.ts
@@ -27,6 +27,7 @@ export class SqlLoggingSessionImpl implements SqlLoggingSession {
   public readonly options: SqlLoggingOptions;
   private _statementCount: number = 0;
   private _emittedStatementCount: number = 0; // Track actually emitted statements
+  private _currentBatchVariableCount: number = 0; // Running count of DECLARE @var declarations in current batch
   private _fileHandle: fs.promises.FileHandle | null = null;
   private _disposed: boolean = false;
   private _compiledPatterns: RegExp[] | undefined;
@@ -210,8 +211,24 @@ export class SqlLoggingSessionImpl implements SqlLoggingSession {
       }
     }
 
-    // Add batch separator if specified
-    if (this.options.batchSeparator) {
+    // Batch separator logic:
+    // - Threshold mode: emit separator when accumulated variable declarations reach the threshold.
+    //   The separator is prepended BEFORE the current statement (ending the previous batch).
+    // - Legacy mode (no threshold): emit separator after every statement.
+    const threshold = this.options.variableBatchThreshold;
+    if (this.options.batchSeparator && threshold && threshold > 0) {
+      const newVarCount = this._countVariableDeclarations(processedQuery);
+      if (newVarCount > 0) {
+        if (this._currentBatchVariableCount > 0 &&
+            this._currentBatchVariableCount + newVarCount >= threshold) {
+          // End the previous batch before this statement
+          logEntry = `${this.options.batchSeparator}\n\n` + logEntry;
+          this._currentBatchVariableCount = newVarCount;
+        } else {
+          this._currentBatchVariableCount += newVarCount;
+        }
+      }
+    } else if (this.options.batchSeparator) {
       logEntry += `\n${this.options.batchSeparator}\n`;
     }
 
@@ -421,6 +438,24 @@ export class SqlLoggingSessionImpl implements SqlLoggingSession {
     }
 
     return segments;
+  }
+
+  /**
+   * Counts the number of SQL variable declarations in a statement.
+   * Matches `@varName SQLTYPE` patterns that appear in DECLARE blocks (both the leading
+   * `DECLARE @var TYPE` and continuation `@var TYPE` lines in multi-variable DECLAREs).
+   * SET/EXEC parameter references are excluded because they have `=` or `,` after the var name,
+   * not a type keyword.
+   *
+   * Used by the `variableBatchThreshold` logic to decide when to emit a batch separator.
+   */
+  private _countVariableDeclarations(sql: string): number {
+    // Matches @varName followed by a SQL Server type keyword.
+    // This covers both DECLARE @v TYPE and continuation @v TYPE (comma-separated multi-var DECLAREs).
+    // It does NOT match SET @v = ... or EXEC sp @p = @v because those don't have a type keyword.
+    const varDeclRegex = /@\w+\s+(?:UNIQUEIDENTIFIER|N?VARCHAR|N?CHAR|INT|BIGINT|SMALLINT|TINYINT|BIT|FLOAT|REAL|DECIMAL|NUMERIC|DATETIME(?:2|OFFSET)?|DATE(?!TIME)\b|TIME\b|MONEY|SMALLMONEY|VARBINARY|XML|TABLE|N?TEXT|IMAGE|ROWVERSION|TIMESTAMP|GEOGRAPHY|GEOMETRY)\b/gi;
+    const matches = sql.match(varDeclRegex);
+    return matches ? matches.length : 0;
   }
 
   /**

--- a/packages/GenericDatabaseProvider/src/__tests__/GenericDatabaseProvider.test.ts
+++ b/packages/GenericDatabaseProvider/src/__tests__/GenericDatabaseProvider.test.ts
@@ -720,4 +720,75 @@ describe('SqlLoggingSessionImpl', () => {
             expect(result).toContain("''Complete'' END as Col");
         });
     });
+
+    describe('_countVariableDeclarations', () => {
+        const countVars = (sql: string) => {
+            const session = new SqlLoggingSessionImpl('t', '/tmp/t.sql');
+            return (session as Record<string, CallableFunction>)._countVariableDeclarations(sql);
+        };
+
+        it('should count a single DECLARE @var TYPE', () => {
+            expect(countVars('DECLARE @MyVar NVARCHAR(255)')).toBe(1);
+        });
+
+        it('should count multiple variables in a comma-separated DECLARE block', () => {
+            const sql = 'DECLARE @ID UNIQUEIDENTIFIER,\n@Name NVARCHAR(255),\n@Status NVARCHAR(50)';
+            expect(countVars(sql)).toBe(3);
+        });
+
+        it('should count variables across multiple DECLARE statements', () => {
+            const sql = 'DECLARE @A INT\nDECLARE @B BIT\nDECLARE @C DATETIME';
+            expect(countVars(sql)).toBe(3);
+        });
+
+        it('should NOT count SET assignments (no type keyword after var name)', () => {
+            const sql = "SET @MyVar = 'value'\nSET @Count = 0";
+            expect(countVars(sql)).toBe(0);
+        });
+
+        it('should NOT count EXEC parameter references', () => {
+            const sql = 'EXEC spUpdate @ID = @ID_abc, @Name = @Name_abc';
+            expect(countVars(sql)).toBe(0);
+        });
+
+        it('should return 0 for empty string', () => {
+            expect(countVars('')).toBe(0);
+        });
+
+        it('should return 0 for SQL with no variable declarations', () => {
+            expect(countVars('SELECT * FROM Users WHERE Status = N\'Active\'')).toBe(0);
+        });
+    });
+
+    describe('variableBatchThreshold', () => {
+        /**
+         * Minimal helper: invoke the threshold logic without hitting the file system.
+         * We test the _countVariableDeclarations helper and the threshold branching logic
+         * independently since logSqlStatement requires an open file handle.
+         */
+        it('should use threshold logic when variableBatchThreshold > 0 and batchSeparator is set', () => {
+            // Verify the option is accepted without error
+            const session = new SqlLoggingSessionImpl('t', '/tmp/t.sql', {
+                batchSeparator: 'GO',
+                variableBatchThreshold: 200,
+            });
+            expect(session.options.variableBatchThreshold).toBe(200);
+            expect(session.options.batchSeparator).toBe('GO');
+        });
+
+        it('should fall back to legacy mode when variableBatchThreshold is 0', () => {
+            const session = new SqlLoggingSessionImpl('t', '/tmp/t.sql', {
+                batchSeparator: 'GO',
+                variableBatchThreshold: 0,
+            });
+            expect(session.options.variableBatchThreshold).toBe(0);
+        });
+
+        it('should default to no threshold when variableBatchThreshold is undefined', () => {
+            const session = new SqlLoggingSessionImpl('t', '/tmp/t.sql', {
+                batchSeparator: 'GO',
+            });
+            expect(session.options.variableBatchThreshold).toBeUndefined();
+        });
+    });
 });

--- a/packages/GenericDatabaseProvider/src/types.ts
+++ b/packages/GenericDatabaseProvider/src/types.ts
@@ -39,6 +39,19 @@ export interface SqlLoggingOptions {
   /** Whether to output verbose debug information to console (default: false) */
   verboseOutput?: boolean;
   /**
+   * When set, enables variable-count-based batch separation instead of emitting the batch separator
+   * after every statement. The logger tracks how many SQL variable declarations (DECLARE @...) have
+   * accumulated in the current batch. When the running count reaches this threshold, a batch separator
+   * is emitted before the next statement and the counter resets.
+   *
+   * This prevents SQL Server's 10,000-variable-per-batch limit from being hit on large migration files
+   * while avoiding the verbosity of one GO per statement.
+   *
+   * Requires `batchSeparator` to also be set. Recommended value: 200.
+   * Set to 0 or leave undefined to use the legacy per-statement behavior.
+   */
+  variableBatchThreshold?: number;
+  /**
    * Array of patterns to filter SQL statements.
    * Supports both regex (RegExp objects) and simple wildcard patterns (strings).
    * How these patterns are applied depends on filterType.

--- a/packages/MJServer/src/config.ts
+++ b/packages/MJServer/src/config.ts
@@ -90,6 +90,14 @@ const sqlLoggingOptionsSchema = z.object({
   formatAsMigration: z.boolean().optional().default(false),
   statementTypes: z.enum(['queries', 'mutations', 'both']).optional().default('both'),
   batchSeparator: z.string().optional().default('GO'),
+  /**
+   * When set, enables variable-count-based batch separation.
+   * A batch separator is emitted only when the accumulated DECLARE @ count reaches this threshold,
+   * instead of after every statement. Prevents hitting SQL Server's 10,000-variable-per-batch limit
+   * on large migration files while avoiding one GO per statement. Recommended: 200.
+   * Set to 0 to use the legacy per-statement behavior.
+   */
+  variableBatchThreshold: z.coerce.number().optional().default(200),
   prettyPrint: z.boolean().optional().default(true),
   logRecordChangeMetadata: z.boolean().optional().default(false),
   retainEmptyLogFiles: z.boolean().optional().default(false),

--- a/packages/MetadataSync/src/config.ts
+++ b/packages/MetadataSync/src/config.ts
@@ -111,6 +111,12 @@ export interface SyncConfig {
     filterType?: 'exclude' | 'include';
     /** Whether to output verbose debug information to console (default: false) */
     verboseOutput?: boolean;
+    /**
+     * Number of SQL variable declarations (DECLARE @...) to accumulate before emitting a batch
+     * separator. Prevents hitting SQL Server's 10,000-variable-per-batch limit on large migrations
+     * while avoiding one GO per statement. Defaults to 200. Set to 0 for legacy per-statement behavior.
+     */
+    variableBatchThreshold?: number;
   };
   /** Watch command configuration */
   watch?: {

--- a/packages/MetadataSync/src/services/PushService.ts
+++ b/packages/MetadataSync/src/services/PushService.ts
@@ -189,7 +189,9 @@ export class PushService {
             description: 'MetadataSync push operation',
             statementTypes: "mutations",
             prettyPrint: true,
-            batchSeparator: 'GO',
+            // batchSeparator is intentionally omitted — CreateSqlLogger injects the platform-appropriate
+            // separator automatically (GO for SQL Server, nothing for PostgreSQL) via PlatformBatchSeparator.
+            variableBatchThreshold: this.syncConfig?.sqlLogging?.variableBatchThreshold ?? 200,
             filterPatterns: this.syncConfig?.sqlLogging?.filterPatterns,
             filterType: this.syncConfig?.sqlLogging?.filterType,
             verboseOutput: this.syncConfig?.sqlLogging?.verboseOutput || false,

--- a/packages/MetadataSync/src/services/WatchService.ts
+++ b/packages/MetadataSync/src/services/WatchService.ts
@@ -369,7 +369,9 @@ export class WatchService {
             formatAsMigration: syncConfig.sqlLogging?.formatAsMigration || false,
             description: 'MetadataSync watch operation',
             logRecordChangeMetadata: true,
-            batchSeparator: 'GO',
+            // batchSeparator is intentionally omitted — CreateSqlLogger injects the platform-appropriate
+            // separator automatically (GO for SQL Server, nothing for PostgreSQL) via PlatformBatchSeparator.
+            variableBatchThreshold: syncConfig.sqlLogging?.variableBatchThreshold ?? 200,
           });
           
           callbacks?.onLog?.(`📝 SQL logging enabled: ${filepath}`);

--- a/packages/PostgreSQLDataProvider/src/PostgreSQLDataProvider.ts
+++ b/packages/PostgreSQLDataProvider/src/PostgreSQLDataProvider.ts
@@ -149,6 +149,10 @@ export class PostgreSQLDataProvider extends GenericDatabaseProvider {
         return pgDialect;
     }
 
+    protected getDialect(): PostgreSQLDialect {
+        return pgDialect;
+    }
+
     // ─── Configuration & Lifecycle ───────────────────────────────────
 
     get ConfigData(): PostgreSQLProviderConfigData {

--- a/packages/SQLServerDataProvider/package.json
+++ b/packages/SQLServerDataProvider/package.json
@@ -34,6 +34,7 @@
     "@memberjunction/core-entities": "5.14.0",
     "@memberjunction/encryption": "5.14.0",
     "@memberjunction/generic-database-provider": "5.14.0",
+    "@memberjunction/sql-dialect": "5.14.0",
     "@memberjunction/global": "5.14.0",
     "@memberjunction/query-processor": "5.14.0",
     "@memberjunction/queue": "5.14.0",

--- a/packages/SQLServerDataProvider/src/SQLServerDataProvider.ts
+++ b/packages/SQLServerDataProvider/src/SQLServerDataProvider.ts
@@ -73,6 +73,7 @@ import { DuplicateRecordDetector } from '@memberjunction/ai-vector-dupe';
 import { EncryptionEngine } from '@memberjunction/encryption';
 import { v4 as uuidv4 } from 'uuid';
 import { UUIDsEqual } from '@memberjunction/global';
+import { SQLServerDialect, SQLDialect } from '@memberjunction/sql-dialect';
 /**
  * Checks whether an error indicates a stale/dead database connection that
  * could be resolved by retrying with a fresh connection from the pool.
@@ -248,6 +249,15 @@ export class SQLServerDataProvider
   /**************************************************************************/
   // SQL Dialect Implementations (override abstract methods from DatabaseProviderBase)
   /**************************************************************************/
+
+  /**
+   * Returns the SQL Server dialect instance so that platform-specific tokens
+   * (batch separator, quoted identifiers, etc.) are sourced from
+   * `@memberjunction/sql-dialect` rather than hardcoded strings.
+   */
+  protected getDialect(): SQLDialect {
+    return new SQLServerDialect();
+  }
 
   public override QuoteIdentifier(name: string): string {
     return `[${name}]`;


### PR DESCRIPTION
## Problem

The 5.14.0 metadata migration had 13,921 `DECLARE @` variables in a single batch, hitting SQL Server's 10,000-variable limit. The emergency fix emitted `GO` after every record block — producing 1,272 batch separators for 1,272 records, which is far more than necessary.

## Solution

Track the number of `DECLARE @` variable declarations on a running basis across SQL statements. When the accumulated count would hit a configurable threshold, emit a batch separator **before** that statement (ending the previous batch) and reset the counter. This produces ~70 separators instead of 1,272 for the same dataset, while staying well under SQL Server's 10,000-variable limit.

## Changes

### `@memberjunction/generic-database-provider`
- **`types.ts`**: Added `variableBatchThreshold?: number` to `SqlLoggingOptions`
- **`SqlLogger.ts`**: Added `_currentBatchVariableCount` running tally, `_countVariableDeclarations()` regex helper, and threshold-aware batch separator logic. Legacy mode (separator after every statement) is preserved when threshold is not set.
- **`GenericDatabaseProvider.ts`**: Added `getDialect()` virtual method and `PlatformBatchSeparator` getter — batch separator token is now sourced from `@memberjunction/sql-dialect` rather than hardcoded strings. `CreateSqlLogger` auto-injects the platform separator as the default.

### `@memberjunction/sqlserver-dataprovider`
- Added `getDialect()` returning `new SQLServerDialect()` so `BatchSeparator()` returns `'GO'` via the dialect package
- Added `@memberjunction/sql-dialect` as an explicit dependency

### `@memberjunction/postgresql-dataprovider`
- Added `getDialect()` returning `PostgreSQLDialect` — `BatchSeparator()` returns `''`, so no separator is emitted for PostgreSQL

### `@memberjunction/server`
- Added `variableBatchThreshold` to `sqlLoggingOptionsSchema` with default of `200`

### `@memberjunction/metadata-sync`
- `config.ts`: Added `variableBatchThreshold?: number` to the `sqlLogging` config type
- `PushService.ts` / `WatchService.ts`: Removed hardcoded `batchSeparator: 'GO'`, added `variableBatchThreshold` (defaults to `200`)

### `metadata/.mj-sync.json`
- Added `"variableBatchThreshold": 200` to the `sqlLogging` block so users can see and adjust it

## Configuration

In `.mj-sync.json`:
```json
"sqlLogging": {
  "enabled": true,
  "variableBatchThreshold": 200
}
