### PR TITLE
Absence of whitespace between end of {% raw %} and next token blew up…

### DIFF
--- a/metadata/prompts/templates/system/loop-agent-type-system-prompt.template.md
+++ b/metadata/prompts/templates/system/loop-agent-type-system-prompt.template.md
@@ -238,7 +238,8 @@ When iterations are **independent** (don't depend on each other), use parallel e
 
 #### Composing Strings from Multiple Fields
 
-{% raw %}When a param needs literal text combined with variables, use `{{variable}}` inline template syntax:
+{% raw %} 
+When a param needs literal text combined with variables, use `{{variable}}` inline template syntax:
 
 ```json
 {


### PR DESCRIPTION
… nunjucks!