### PR TITLE
fix(core): deduplicate RunView params within coalesced mega-batches

### DIFF
--- a/packages/MJCore/src/generic/providerBase.ts
+++ b/packages/MJCore/src/generic/providerBase.ts
@@ -677,7 +677,13 @@ export abstract class ProviderBase implements IMetadataProvider, IRunViewProvide
 
     /**
      * Flushes the coalesce queue: merges all pending RunViews params into one
-     * mega-batch, executes it, then splits results back to each original caller.
+     * mega-batch with intra-batch deduplication, executes it, then splits
+     * results back to each original caller.
+     *
+     * Deduplication works by fingerprinting each individual RunViewParams.
+     * When multiple callers request the same entity with the same filters,
+     * that query is sent to the server only once. The shared result is then
+     * distributed to every caller that requested it.
      */
     private async flushCoalesceQueue(): Promise<void> {
         this._coalesceTimer = null;
@@ -698,31 +704,51 @@ export abstract class ProviderBase implements IMetadataProvider, IRunViewProvide
             return;
         }
 
-        // Merge all params into one mega-batch, tracking boundaries
-        const allParams: RunViewParams[] = [];
-        const boundaries: Array<{ start: number; count: number }> = [];
         // Use the first caller's contextUser (all should be the same on client-side)
         const contextUser = queue[0].contextUser;
 
+        // ── Deduplicate params across all callers ──
+        // Build a map from fingerprint -> unique index, and for each caller's
+        // param record which unique index it maps to.
+        const uniqueParams: RunViewParams[] = [];
+        const fingerprintToUniqueIndex = new Map<string, number>();
+        // For each queue entry, store the unique-index for each of its params
+        const callerParamMappings: number[][] = [];
+
         for (const entry of queue) {
-            boundaries.push({ start: allParams.length, count: entry.params.length });
-            allParams.push(...entry.params);
+            const mapping: number[] = [];
+            for (const param of entry.params) {
+                const fp = this.GenerateParamFingerprint(param, contextUser);
+                let idx = fingerprintToUniqueIndex.get(fp);
+                if (idx === undefined) {
+                    idx = uniqueParams.length;
+                    fingerprintToUniqueIndex.set(fp, idx);
+                    uniqueParams.push(param);
+                }
+                mapping.push(idx);
+            }
+            callerParamMappings.push(mapping);
         }
 
-        const entityNames = allParams.map(p => p.EntityName || p.ViewName || '?').join(', ');
+        const totalRequested = queue.reduce((sum, e) => sum + e.params.length, 0);
+        const dedupSaved = totalRequested - uniqueParams.length;
+        const uniqueEntityNames = uniqueParams.map(p => p.EntityName || p.ViewName || '?').join(', ');
+
         LogStatusEx({
-            message: `⚡ [Coalesce] Merged ${queue.length} RunViews calls (${allParams.length} total entities) into 1 mega-batch: [${entityNames}]`,
+            message: dedupSaved > 0
+                ? `⚡ [Coalesce] Merged ${queue.length} RunViews calls (${totalRequested} total requests, ${dedupSaved} duplicates eliminated) into 1 batch of ${uniqueParams.length} unique queries: [${uniqueEntityNames}]`
+                : `⚡ [Coalesce] Merged ${queue.length} RunViews calls (${uniqueParams.length} unique queries) into 1 batch: [${uniqueEntityNames}]`,
             verboseOnly: false
         });
 
         try {
-            // Execute the mega-batch as a single pipeline call
-            const allResults = await this.RunViewsUncoalesced(allParams, contextUser);
+            // Execute only the deduplicated params
+            const uniqueResults = await this.RunViewsUncoalesced(uniqueParams, contextUser);
 
-            // Split results back to each original caller
+            // Distribute results back to each caller by mapping unique indices
             for (let i = 0; i < queue.length; i++) {
-                const { start, count } = boundaries[i];
-                const callerResults = allResults.slice(start, start + count);
+                const mapping = callerParamMappings[i];
+                const callerResults = mapping.map(idx => this.ShallowCopyResult(uniqueResults[idx]));
                 queue[i].resolve(callerResults);
             }
         } catch (err) {
@@ -787,23 +813,29 @@ export abstract class ProviderBase implements IMetadataProvider, IRunViewProvide
     }
 
     /**
+     * Generates a deterministic fingerprint for a single RunViewParams entry.
+     * Used both for batch dedup keys and for intra-batch deduplication during coalescing.
+     */
+    private GenerateParamFingerprint(p: RunViewParams, contextUser?: UserInfo): string {
+        const base = LocalCacheManager.Instance.GenerateRunViewFingerprint(p, this.InstanceConnectionString);
+        const extras = [
+            p.Fields?.join(',') ?? '',
+            p.UserSearchString ?? '',
+            p.ViewID ?? '',
+            p.ViewName ?? '',
+            contextUser?.ID ?? ''
+        ].join('|');
+        return `${base}|${extras}`;
+    }
+
+    /**
      * Generates a deterministic dedup key for a batch of RunViewParams.
      * Extends the local-cache fingerprint with additional fields that
      * affect result identity (Fields, UserSearchString, ViewID, ViewName,
      * contextUser).
      */
     private GenerateDedupKey(params: RunViewParams[], contextUser?: UserInfo): string {
-        const parts = params.map(p => {
-            const base = LocalCacheManager.Instance.GenerateRunViewFingerprint(p, this.InstanceConnectionString);
-            const extras = [
-                p.Fields?.join(',') ?? '',
-                p.UserSearchString ?? '',
-                p.ViewID ?? '',
-                p.ViewName ?? '',
-                contextUser?.ID ?? ''
-            ].join('|');
-            return `${base}|${extras}`;
-        });
+        const parts = params.map(p => this.GenerateParamFingerprint(p, contextUser));
         return parts.join('||');
     }
 


### PR DESCRIPTION
## Summary

- **Adds intra-batch deduplication to the RunViews coalesce feature** — when multiple concurrent callers request the same entity data, the query is now sent to the server only once instead of N times
- **Extracts `GenerateParamFingerprint()` method** from `GenerateDedupKey()` for reuse in both batch-level and param-level deduplication
- **Improves coalesce log messages** to report dedup savings (e.g., "91 total requests, 84 duplicates eliminated")

## Problem

The coalesce feature merges concurrent `RunViews` calls within a 10ms window into a single GraphQL request. However, it concatenated all params without deduplication. When multiple engine instances requested the same entity data simultaneously, every duplicate was executed as a separate SQL query on the server.

**Observed in production**: 85 RunViews calls coalesced into 1 mega-batch of 467 entity requests — ~80% were duplicates (same entity, same filter). This caused extremely slow startup on provisioned instances, especially with serverless Azure SQL cold starts.

**Root cause**: npm installing multiple copies of MJ packages in the dependency tree → esbuild bundling each as a separate class → BaseSingleton creating 74 singleton instances instead of 14 → each firing independent RunView calls. The npm duplication is being fixed separately in the template repo via `overrides`.

## Fix

`flushCoalesceQueue()` now:
1. Fingerprints each individual `RunViewParams` using `GenerateParamFingerprint()`
2. Builds a `Map<fingerprint, uniqueIndex>` to identify duplicates across all callers
3. Sends only the unique params to the server
4. Distributes results back to each caller via `ShallowCopyResult()` indexed by their param mapping

## Impact

For a deployment with 13 duplicate engine instances each loading 7 entities:
- **Before**: 91 SQL queries executed (13 × 7)
- **After**: 7 unique SQL queries executed
- **Reduction**: ~83% fewer queries during startup

## Test plan

- [ ] Verify coalesce log now shows dedup savings
- [ ] Verify no redundant data loading warnings on startup
- [ ] Verify all engines still receive correct data after dedup
- [ ] Test with `CoalesceWindowMs = 0` (disabled) — should bypass dedup path

🤖 Generated with [Claude Code](https://claude.com/claude-code)