### PR TITLE
feat: add Coalesce telemetry category

### DIFF
--- a/packages/MJCore/src/__tests__/telemetry.coalesce.test.ts
+++ b/packages/MJCore/src/__tests__/telemetry.coalesce.test.ts
@@ -1,0 +1,208 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import {
+    TelemetryManager,
+    TelemetryCoalesceParams,
+    TelemetryEvent
+} from '../generic/telemetryManager';
+
+describe('TelemetryManager — Coalesce category', () => {
+    let tm: TelemetryManager;
+
+    beforeEach(() => {
+        tm = TelemetryManager.Instance;
+        tm.Reset();
+        tm.SetEnabled(true);
+    });
+
+    const sampleParams: TelemetryCoalesceParams = {
+        CallerCount: 3,
+        TotalEntityCount: 7,
+        Entities: ['Users', 'Roles', 'Permissions', 'Actions', 'Entities', 'Apps', 'Settings'],
+        CallerBoundaries: [
+            { start: 0, count: 2 },
+            { start: 2, count: 3 },
+            { start: 5, count: 2 }
+        ]
+    };
+
+    describe('StartEvent', () => {
+        it('should accept Coalesce category and return an event ID', () => {
+            const eventId = tm.StartEvent(
+                'Coalesce',
+                'ProviderBase.flushCoalesceQueue',
+                sampleParams
+            );
+
+            expect(eventId).not.toBeNull();
+            expect(typeof eventId).toBe('string');
+        });
+
+        it('should return null when telemetry is disabled', () => {
+            tm.SetEnabled(false);
+
+            const eventId = tm.StartEvent(
+                'Coalesce',
+                'ProviderBase.flushCoalesceQueue',
+                sampleParams
+            );
+
+            expect(eventId).toBeNull();
+        });
+
+        it('should return null when Coalesce category is disabled', () => {
+            tm.UpdateSettings({
+                categoryOverrides: { Coalesce: { enabled: false } }
+            });
+
+            const eventId = tm.StartEvent(
+                'Coalesce',
+                'ProviderBase.flushCoalesceQueue',
+                sampleParams
+            );
+
+            expect(eventId).toBeNull();
+        });
+    });
+
+    describe('EndEvent', () => {
+        it('should complete a Coalesce event and record elapsed time', () => {
+            const eventId = tm.StartEvent(
+                'Coalesce',
+                'ProviderBase.flushCoalesceQueue',
+                sampleParams
+            );
+
+            const completed = tm.EndEvent(eventId);
+
+            expect(completed).not.toBeNull();
+            expect(completed!.category).toBe('Coalesce');
+            expect(completed!.operation).toBe('ProviderBase.flushCoalesceQueue');
+            expect(typeof completed!.elapsedMs).toBe('number');
+            expect(completed!.elapsedMs!).toBeGreaterThanOrEqual(0);
+        });
+
+        it('should merge additional params on EndEvent', () => {
+            const eventId = tm.StartEvent(
+                'Coalesce',
+                'ProviderBase.flushCoalesceQueue',
+                sampleParams
+            );
+
+            const completed = tm.EndEvent(eventId, { success: false, error: 'timeout' });
+
+            expect(completed).not.toBeNull();
+            const params = completed!.params as TelemetryCoalesceParams & Record<string, unknown>;
+            expect(params.success).toBe(false);
+            expect(params.error).toBe('timeout');
+        });
+    });
+
+    describe('RecordEvent', () => {
+        it('should record a completed Coalesce event directly', () => {
+            tm.RecordEvent(
+                'Coalesce',
+                'ProviderBase.flushCoalesceQueue',
+                sampleParams,
+                42
+            );
+
+            const events = tm.GetEvents({ category: 'Coalesce' });
+            expect(events).toHaveLength(1);
+            expect(events[0].elapsedMs).toBe(42);
+        });
+    });
+
+    describe('GetEvents', () => {
+        it('should filter events by Coalesce category', () => {
+            // Record a Coalesce event and a Cache event
+            tm.RecordEvent(
+                'Coalesce',
+                'ProviderBase.flushCoalesceQueue',
+                sampleParams,
+                10
+            );
+            tm.RecordEvent(
+                'Cache',
+                'CacheManager.get',
+                { cacheType: 'local', operation: 'get', status: 'hit' },
+                2
+            );
+
+            const coalesceEvents = tm.GetEvents({ category: 'Coalesce' });
+            expect(coalesceEvents).toHaveLength(1);
+            expect(coalesceEvents[0].category).toBe('Coalesce');
+        });
+    });
+
+    describe('params preservation', () => {
+        it('should store CallerCount, TotalEntityCount, Entities, and CallerBoundaries', () => {
+            tm.RecordEvent(
+                'Coalesce',
+                'ProviderBase.flushCoalesceQueue',
+                sampleParams,
+                25
+            );
+
+            const events = tm.GetEvents({ category: 'Coalesce' });
+            expect(events).toHaveLength(1);
+
+            const params = events[0].params as TelemetryCoalesceParams;
+            expect(params.CallerCount).toBe(3);
+            expect(params.TotalEntityCount).toBe(7);
+            expect(params.Entities).toEqual([
+                'Users', 'Roles', 'Permissions', 'Actions', 'Entities', 'Apps', 'Settings'
+            ]);
+            expect(params.CallerBoundaries).toEqual([
+                { start: 0, count: 2 },
+                { start: 2, count: 3 },
+                { start: 5, count: 2 }
+            ]);
+        });
+    });
+
+    describe('GetStats', () => {
+        it('should include Coalesce in byCategory stats', () => {
+            tm.RecordEvent(
+                'Coalesce',
+                'ProviderBase.flushCoalesceQueue',
+                sampleParams,
+                50
+            );
+            tm.RecordEvent(
+                'Coalesce',
+                'ProviderBase.flushCoalesceQueue',
+                { ...sampleParams, CallerCount: 2 },
+                30
+            );
+
+            const stats = tm.GetStats();
+            expect(stats.byCategory.Coalesce.events).toBe(2);
+            expect(stats.byCategory.Coalesce.avgMs).toBe(40);
+        });
+    });
+
+    describe('Start/End lifecycle', () => {
+        it('should track the full lifecycle of a coalesce flush', () => {
+            const eventId = tm.StartEvent(
+                'Coalesce',
+                'ProviderBase.flushCoalesceQueue',
+                sampleParams
+            );
+            expect(eventId).not.toBeNull();
+
+            // Before EndEvent, nothing in completed events
+            expect(tm.GetEvents({ category: 'Coalesce' })).toHaveLength(0);
+
+            // Complete the event
+            const completed = tm.EndEvent(eventId);
+            expect(completed).not.toBeNull();
+
+            // Now it should appear in completed events
+            const events = tm.GetEvents({ category: 'Coalesce' });
+            expect(events).toHaveLength(1);
+            expect(events[0].id).toBe(eventId);
+            expect(events[0].endTime).toBeDefined();
+            expect(events[0].startTime).toBeLessThanOrEqual(events[0].endTime!);
+        });
+    });
+});

--- a/packages/MJCore/src/generic/providerBase.ts
+++ b/packages/MJCore/src/generic/providerBase.ts
@@ -710,11 +710,17 @@ export abstract class ProviderBase implements IMetadataProvider, IRunViewProvide
             allParams.push(...entry.params);
         }
 
-        const entityNames = allParams.map(p => p.EntityName || p.ViewName || '?').join(', ');
-        LogStatusEx({
-            message: `⚡ [Coalesce] Merged ${queue.length} RunViews calls (${allParams.length} total entities) into 1 mega-batch: [${entityNames}]`,
-            verboseOnly: false
-        });
+        const entityNames = allParams.map(p => p.EntityName || p.ViewName || '?');
+        const eventId = TelemetryManager.Instance.StartEvent(
+            'Coalesce',
+            'ProviderBase.flushCoalesceQueue',
+            {
+                CallerCount: queue.length,
+                TotalEntityCount: allParams.length,
+                Entities: entityNames,
+                CallerBoundaries: [...boundaries]
+            }
+        );
 
         try {
             // Execute the mega-batch as a single pipeline call
@@ -726,7 +732,11 @@ export abstract class ProviderBase implements IMetadataProvider, IRunViewProvide
                 const callerResults = allResults.slice(start, start + count);
                 queue[i].resolve(callerResults);
             }
+
+            TelemetryManager.Instance.EndEvent(eventId);
         } catch (err) {
+            TelemetryManager.Instance.EndEvent(eventId, { success: false, error: String(err) });
+
             // If the mega-batch fails, reject all callers
             for (const entry of queue) {
                 entry.reject(err);

--- a/packages/MJCore/src/generic/telemetryManager.ts
+++ b/packages/MJCore/src/generic/telemetryManager.ts
@@ -63,6 +63,7 @@ export type TelemetryCategory =
     | 'Network'
     | 'AI'
     | 'Cache'
+    | 'Coalesce'
     | 'Custom';
 
 /**
@@ -230,6 +231,22 @@ export interface TelemetryCacheParams {
 }
 
 /**
+ * Telemetry params for request coalescing operations.
+ * Tracks when concurrent RunViews calls are merged into a single mega-batch,
+ * capturing the merge shape and entity composition for performance analysis.
+ */
+export interface TelemetryCoalesceParams {
+    /** Number of independent RunViews callers that were merged into this batch */
+    CallerCount: number;
+    /** Total number of RunViewParams across all merged callers */
+    TotalEntityCount: number;
+    /** Entity/view names included in the mega-batch */
+    Entities: string[];
+    /** Per-caller boundary info showing how many params each caller contributed */
+    CallerBoundaries: Array<{ start: number; count: number }>;
+}
+
+/**
  * Telemetry params for Network operations.
  * Tracks API calls and network requests.
  */
@@ -269,6 +286,7 @@ export type TelemetryParamsUnion =
     | TelemetryEngineParams
     | TelemetryAIParams
     | TelemetryCacheParams
+    | TelemetryCoalesceParams
     | TelemetryNetworkParams
     | TelemetryCustomParams;
 
@@ -281,6 +299,7 @@ export interface TelemetryCategoryParamsMap {
     Engine: TelemetryEngineParams;
     AI: TelemetryAIParams;
     Cache: TelemetryCacheParams;
+    Coalesce: TelemetryCoalesceParams;
     Network: TelemetryNetworkParams;
     Custom: TelemetryCustomParams;
 }
@@ -868,6 +887,16 @@ export class TelemetryManager extends BaseSingleton<TelemetryManager> {
     ): string | null;
 
     /**
+     * Start tracking a Coalesce event
+     */
+    public StartEvent(
+        category: 'Coalesce',
+        operation: string,
+        params: TelemetryCoalesceParams,
+        userId?: string
+    ): string | null;
+
+    /**
      * Start tracking a Network event
      */
     public StartEvent(
@@ -1004,6 +1033,17 @@ export class TelemetryManager extends BaseSingleton<TelemetryManager> {
         category: 'Cache',
         operation: string,
         params: TelemetryCacheParams,
+        elapsedMs: number,
+        userId?: string
+    ): void;
+
+    /**
+     * Record a completed Coalesce event directly
+     */
+    public RecordEvent(
+        category: 'Coalesce',
+        operation: string,
+        params: TelemetryCoalesceParams,
         elapsedMs: number,
         userId?: string
     ): void;
@@ -1643,6 +1683,7 @@ export class TelemetryManager extends BaseSingleton<TelemetryManager> {
             Network: { events: 0, totalMs: 0 },
             AI: { events: 0, totalMs: 0 },
             Cache: { events: 0, totalMs: 0 },
+            Coalesce: { events: 0, totalMs: 0 },
             Custom: { events: 0, totalMs: 0 }
         };
 


### PR DESCRIPTION
## Summary
- Add `'Coalesce'` to `TelemetryCategory` with a new `TelemetryCoalesceParams` interface tracking `CallerCount`, `TotalEntityCount`, `Entities`, and `CallerBoundaries`
- Replace the `LogStatusEx` fire-and-forget log in `flushCoalesceQueue()` with `StartEvent`/`EndEvent` — coalesce events are now timed, queryable, and participate in pattern detection
- Add 10 unit tests covering the full lifecycle: StartEvent/EndEvent, disabled states, category filtering, params preservation, RecordEvent, and GetStats integration

## Test plan
- [x] 10 new telemetry coalesce tests pass
- [x] 635 existing MJCore tests pass (no regressions)
- [x] MJCore builds clean
- [ ] Verify coalesce events appear in GraphQL telemetry resolver (existing resolver is generic over categories — no code changes needed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)