### PR TITLE
fix: MCP Server full_access scope not granting permissions on OAuth tool calls

### DIFF
--- a/.changeset/lemon-vans-build.md
+++ b/.changeset/lemon-vans-build.md
@@ -1,0 +1,5 @@
+---
+"@memberjunction/ai-mcp-server": patch
+---
+
+Support Full Access in MCP Server

--- a/packages/AI/MCPServer/src/Server.ts
+++ b/packages/AI/MCPServer/src/Server.ts
@@ -518,6 +518,11 @@ async function authorizeApiKeyToolCall(
  * @returns true if the granted scope satisfies the requirement
  */
 function scopeMatchesHierarchically(grantedScope: string, requiredScope: string): boolean {
+    // full_access is a wildcard that grants all permissions
+    if (grantedScope === 'full_access') {
+        return true;
+    }
+
     // Exact match
     if (grantedScope === requiredScope) {
         return true;

--- a/packages/AI/MCPServer/src/auth/OAuthProxyRouter.ts
+++ b/packages/AI/MCPServer/src/auth/OAuthProxyRouter.ts
@@ -434,7 +434,7 @@ async function redirectToConsentScreen(
     const requestedScopeNames = authState.scope.split(' ').filter(Boolean);
     if (requestedScopeNames.length > 0) {
       const filteredScopes = availableScopes.filter((s) =>
-        requestedScopeNames.includes(s.Name)
+        requestedScopeNames.includes(s.FullPath)
       );
       // Only use filtered list if at least one valid scope was requested
       // If all requested scopes are unknown, show all scopes (FR-031b)

--- a/packages/AI/MCPServer/src/auth/ScopeService.ts
+++ b/packages/AI/MCPServer/src/auth/ScopeService.ts
@@ -125,7 +125,7 @@ export function clearScopeCache(): void {
  */
 export async function getScopeByName(name: string): Promise<APIScopeInfo | undefined> {
   const scopes = await loadActiveScopes();
-  return scopes.find((s) => s.Name === name);
+  return scopes.find((s) => s.FullPath === name);
 }
 
 /**
@@ -140,7 +140,7 @@ export async function validateScopes(requestedScopes: string[]): Promise<{
   invalidScopes: string[];
 }> {
   const availableScopes = await loadActiveScopes();
-  const availableScopeNames = new Set(availableScopes.map((s) => s.Name));
+  const availableScopeNames = new Set(availableScopes.map((s) => s.FullPath));
 
   const validScopes: string[] = [];
   const invalidScopes: string[] = [];


### PR DESCRIPTION
## Summary
- **Primary fix**: `scopeMatchesHierarchically()` in Server.ts had no awareness of the `full_access` wildcard scope — when a user selected "Full Access" on the consent screen, every tool call was denied because `"full_access"` never matched required scopes like `"entity:read"`
- **Secondary fix**: Scope filtering in `OAuthProxyRouter.redirectToConsentScreen()` compared against `s.Name` (short segment like `"read"`) instead of `s.FullPath` (full identifier like `"entity:read"`), breaking client-requested scope filtering for all hierarchical scopes
- **Preventive fix**: Same `Name` vs `FullPath` mismatch in `ScopeService.validateScopes()` and `getScopeByName()` (exported but not yet called in the active flow)

## Test plan
- [ ] Connect an MCP client, select "Full Access" on the consent screen, verify all tool calls succeed
- [ ] Connect an MCP client, select individual scopes, verify only those tools are accessible
- [ ] Connect an MCP client that requests specific scopes (e.g., `scope=entity:read`), verify the consent screen shows only matching scopes
- [ ] Verify API key authentication continues to work unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)