### PR TITLE
feat: hierarchical storage account resolution for file artifacts + ArtifactBuilderService rename

### DIFF
--- a/metadata/prompts/templates/system/loop-agent-type-system-prompt.template.md
+++ b/metadata/prompts/templates/system/loop-agent-type-system-prompt.template.md
@@ -507,6 +507,16 @@ Actions are **server-side tools** — they run on the server with direct access 
 Execute multiple in parallel if independent. Retry failed actions up to 3x with adjusted parameters.
 {{ actionDetails | safe }}
 {%- endif -%}
+
+{% if actionDetails and 'Create Document' in actionDetails %}
+### Document Creation Workflow
+When creating PDF, Word, or Excel documents, you **MUST** follow this exact 3-step sequence:
+1. **Create Document** — creates a handle for the new document
+2. **Add Document Content** — adds content sections using the handle
+3. **Finalize Document** — renders the document to a file and saves it to storage
+
+**CRITICAL**: You must ALWAYS call **Finalize Document** after adding content. Without finalization, the document is never created. Never return Success after Add Document Content — always continue to Finalize Document as the next step.
+{%- endif %}
 {%- endif %}
 
 {% if clientToolDetails %}

--- a/migrations/v5/V202604071435__v5.24.x__Add_DefaultStorageAccountID_To_Agent_Hierarchy.sql
+++ b/migrations/v5/V202604071435__v5.24.x__Add_DefaultStorageAccountID_To_Agent_Hierarchy.sql
@@ -1,0 +1,4140 @@
+-- ============================================================================
+-- Migration: Add DefaultStorageAccountID to AIAgentType, AIAgentCategory, AIAgent
+--
+-- Introduces a hierarchical storage account resolution chain for file artifacts:
+--   Type → Category (walk up tree) → Agent → Runtime (ExecuteAgentParams)
+--
+-- Each level's DefaultStorageAccountID is a nullable FK to FileStorageAccount.
+-- First non-null value in the chain determines where file artifacts are stored.
+-- ============================================================================
+
+-- ──────────────────────────────────────────────────────────────────────────────
+-- 1. AIAgentType — broadest default (all agents of this execution type)
+-- ──────────────────────────────────────────────────────────────────────────────
+ALTER TABLE ${flyway:defaultSchema}.AIAgentType
+    ADD DefaultStorageAccountID UNIQUEIDENTIFIER NULL;
+GO
+
+ALTER TABLE ${flyway:defaultSchema}.AIAgentType
+    ADD CONSTRAINT FK_AIAgentType_DefaultStorageAccount
+    FOREIGN KEY (DefaultStorageAccountID)
+    REFERENCES ${flyway:defaultSchema}.FileStorageAccount(ID);
+GO
+
+EXEC sp_addextendedproperty
+    @name = N'MS_Description',
+    @value = N'Default file storage account for agents of this type. Lowest priority in the resolution chain (Type → Category tree → Agent → Runtime override). When set, all agents of this type use this storage account unless overridden at a more specific level. FK to FileStorageAccount.',
+    @level0type = N'SCHEMA', @level0name = '${flyway:defaultSchema}',
+    @level1type = N'TABLE',  @level1name = 'AIAgentType',
+    @level2type = N'COLUMN', @level2name = 'DefaultStorageAccountID';
+GO
+
+-- ──────────────────────────────────────────────────────────────────────────────
+-- 2. AIAgentCategory — business-domain default (inherited down the tree)
+-- ──────────────────────────────────────────────────────────────────────────────
+ALTER TABLE ${flyway:defaultSchema}.AIAgentCategory
+    ADD DefaultStorageAccountID UNIQUEIDENTIFIER NULL;
+GO
+
+ALTER TABLE ${flyway:defaultSchema}.AIAgentCategory
+    ADD CONSTRAINT FK_AIAgentCategory_DefaultStorageAccount
+    FOREIGN KEY (DefaultStorageAccountID)
+    REFERENCES ${flyway:defaultSchema}.FileStorageAccount(ID);
+GO
+
+EXEC sp_addextendedproperty
+    @name = N'MS_Description',
+    @value = N'Default file storage account for agents in this category. Inherited by child categories that do not define their own value — resolution walks up the ParentID tree until a non-null value is found. Overrides the Type-level default. FK to FileStorageAccount.',
+    @level0type = N'SCHEMA', @level0name = '${flyway:defaultSchema}',
+    @level1type = N'TABLE',  @level1name = 'AIAgentCategory',
+    @level2type = N'COLUMN', @level2name = 'DefaultStorageAccountID';
+GO
+
+-- ──────────────────────────────────────────────────────────────────────────────
+-- 3. AIAgent — per-agent override
+-- ──────────────────────────────────────────────────────────────────────────────
+ALTER TABLE ${flyway:defaultSchema}.AIAgent
+    ADD DefaultStorageAccountID UNIQUEIDENTIFIER NULL;
+GO
+
+ALTER TABLE ${flyway:defaultSchema}.AIAgent
+    ADD CONSTRAINT FK_AIAgent_DefaultStorageAccount
+    FOREIGN KEY (DefaultStorageAccountID)
+    REFERENCES ${flyway:defaultSchema}.FileStorageAccount(ID);
+GO
+
+EXEC sp_addextendedproperty
+    @name = N'MS_Description',
+    @value = N'Default file storage account for this specific agent. Overrides both Type-level and Category-level defaults. Can be further overridden at runtime via ExecuteAgentParams.override.storageAccountId. FK to FileStorageAccount.',
+    @level0type = N'SCHEMA', @level0name = '${flyway:defaultSchema}',
+    @level1type = N'TABLE',  @level1name = 'AIAgent',
+    @level2type = N'COLUMN', @level2name = 'DefaultStorageAccountID';
+GO
+
+
+
+
+                    
+
+
+                    
+
+
+                    
+
+
+                    
+
+
+                    
+
+
+-- CODE GEN RUN
+/* SQL text to insert new entity field */
+
+      IF NOT EXISTS (SELECT 1 FROM [${flyway:defaultSchema}].[EntityField] WHERE ID = '8c389086-9876-403c-9ab8-2f6f61303e64' OR (EntityID = '6B8A7C62-C13B-4283-9C81-17D9233A4A69' AND Name = 'DefaultStorageAccountID')) BEGIN
+         INSERT INTO [${flyway:defaultSchema}].[EntityField]
+         (
+            [ID],
+            [EntityID],
+            [Sequence],
+            [Name],
+            [DisplayName],
+            [Description],
+            [Type],
+            [Length],
+            [Precision],
+            [Scale],
+            [AllowsNull],
+            [DefaultValue],
+            [AutoIncrement],
+            [AllowUpdateAPI],
+            [IsVirtual],
+            [RelatedEntityID],
+            [RelatedEntityFieldName],
+            [IsNameField],
+            [IncludeInUserSearchAPI],
+            [IncludeRelatedEntityNameFieldInBaseView],
+            [DefaultInView],
+            [IsPrimaryKey],
+            [IsUnique],
+            [RelatedEntityDisplayType],
+            [__mj_CreatedAt],
+            [__mj_UpdatedAt]
+         )
+         VALUES
+         (
+            '8c389086-9876-403c-9ab8-2f6f61303e64',
+            '6B8A7C62-C13B-4283-9C81-17D9233A4A69', -- Entity: MJ: AI Agent Categories
+            100020,
+            'DefaultStorageAccountID',
+            'Default Storage Account ID',
+            'Default file storage account for agents in this category. Inherited by child categories that do not define their own value — resolution walks up the ParentID tree until a non-null value is found. Overrides the Type-level default. FK to FileStorageAccount.',
+            'uniqueidentifier',
+            16,
+            0,
+            0,
+            1,
+            NULL,
+            0,
+            1,
+            0,
+            '18033543-B80D-4BF7-ADAF-DE1AA2CF70D0',
+            'ID',
+            0,
+            0,
+            1,
+            0,
+            0,
+            0,
+            'Search',
+            GETUTCDATE(),
+            GETUTCDATE()
+         )
+      END
+
+/* SQL text to insert new entity field */
+
+      IF NOT EXISTS (SELECT 1 FROM [${flyway:defaultSchema}].[EntityField] WHERE ID = '76af4818-c79e-4db5-8039-6b51c1c3a832' OR (EntityID = 'CDB135CC-6D3C-480B-90AE-25B7805F82C1' AND Name = 'DefaultStorageAccountID')) BEGIN
+         INSERT INTO [${flyway:defaultSchema}].[EntityField]
+         (
+            [ID],
+            [EntityID],
+            [Sequence],
+            [Name],
+            [DisplayName],
+            [Description],
+            [Type],
+            [Length],
+            [Precision],
+            [Scale],
+            [AllowsNull],
+            [DefaultValue],
+            [AutoIncrement],
+            [AllowUpdateAPI],
+            [IsVirtual],
+            [RelatedEntityID],
+            [RelatedEntityFieldName],
+            [IsNameField],
+            [IncludeInUserSearchAPI],
+            [IncludeRelatedEntityNameFieldInBaseView],
+            [DefaultInView],
+            [IsPrimaryKey],
+            [IsUnique],
+            [RelatedEntityDisplayType],
+            [__mj_CreatedAt],
+            [__mj_UpdatedAt]
+         )
+         VALUES
+         (
+            '76af4818-c79e-4db5-8039-6b51c1c3a832',
+            'CDB135CC-6D3C-480B-90AE-25B7805F82C1', -- Entity: MJ: AI Agents
+            100136,
+            'DefaultStorageAccountID',
+            'Default Storage Account ID',
+            'Default file storage account for this specific agent. Overrides both Type-level and Category-level defaults. Can be further overridden at runtime via ExecuteAgentParams.override.storageAccountId. FK to FileStorageAccount.',
+            'uniqueidentifier',
+            16,
+            0,
+            0,
+            1,
+            NULL,
+            0,
+            1,
+            0,
+            '18033543-B80D-4BF7-ADAF-DE1AA2CF70D0',
+            'ID',
+            0,
+            0,
+            1,
+            0,
+            0,
+            0,
+            'Search',
+            GETUTCDATE(),
+            GETUTCDATE()
+         )
+      END
+
+/* SQL text to insert new entity field */
+
+      IF NOT EXISTS (SELECT 1 FROM [${flyway:defaultSchema}].[EntityField] WHERE ID = '6b31a64b-6bd8-446b-b306-0bdd65645694' OR (EntityID = '65CDC348-C4A6-4D00-A57B-2D489C56F128' AND Name = 'DefaultStorageAccountID')) BEGIN
+         INSERT INTO [${flyway:defaultSchema}].[EntityField]
+         (
+            [ID],
+            [EntityID],
+            [Sequence],
+            [Name],
+            [DisplayName],
+            [Description],
+            [Type],
+            [Length],
+            [Precision],
+            [Scale],
+            [AllowsNull],
+            [DefaultValue],
+            [AutoIncrement],
+            [AllowUpdateAPI],
+            [IsVirtual],
+            [RelatedEntityID],
+            [RelatedEntityFieldName],
+            [IsNameField],
+            [IncludeInUserSearchAPI],
+            [IncludeRelatedEntityNameFieldInBaseView],
+            [DefaultInView],
+            [IsPrimaryKey],
+            [IsUnique],
+            [RelatedEntityDisplayType],
+            [__mj_CreatedAt],
+            [__mj_UpdatedAt]
+         )
+         VALUES
+         (
+            '6b31a64b-6bd8-446b-b306-0bdd65645694',
+            '65CDC348-C4A6-4D00-A57B-2D489C56F128', -- Entity: MJ: AI Agent Types
+            100031,
+            'DefaultStorageAccountID',
+            'Default Storage Account ID',
+            'Default file storage account for agents of this type. Lowest priority in the resolution chain (Type → Category tree → Agent → Runtime override). When set, all agents of this type use this storage account unless overridden at a more specific level. FK to FileStorageAccount.',
+            'uniqueidentifier',
+            16,
+            0,
+            0,
+            1,
+            NULL,
+            0,
+            1,
+            0,
+            '18033543-B80D-4BF7-ADAF-DE1AA2CF70D0',
+            'ID',
+            0,
+            0,
+            1,
+            0,
+            0,
+            0,
+            'Search',
+            GETUTCDATE(),
+            GETUTCDATE()
+         )
+      END
+
+
+/* Create Entity Relationship: MJ: File Storage Accounts -> MJ: AI Agent Types (One To Many via DefaultStorageAccountID) */
+   IF NOT EXISTS (
+      SELECT 1 FROM [${flyway:defaultSchema}].[EntityRelationship] WHERE [ID] = 'e0004f31-df16-43f5-bf1b-30208fd190fc'
+   )
+   BEGIN
+      INSERT INTO [${flyway:defaultSchema}].[EntityRelationship] ([ID], [EntityID], [RelatedEntityID], [RelatedEntityJoinField], [Type], [BundleInAPI], [DisplayInForm], [Sequence], [__mj_CreatedAt], [__mj_UpdatedAt])
+                    VALUES ('e0004f31-df16-43f5-bf1b-30208fd190fc', '18033543-B80D-4BF7-ADAF-DE1AA2CF70D0', '65CDC348-C4A6-4D00-A57B-2D489C56F128', 'DefaultStorageAccountID', 'One To Many', 1, 1, 2, GETUTCDATE(), GETUTCDATE())
+   END;
+                    
+/* Create Entity Relationship: MJ: File Storage Accounts -> MJ: AI Agent Categories (One To Many via DefaultStorageAccountID) */
+   IF NOT EXISTS (
+      SELECT 1 FROM [${flyway:defaultSchema}].[EntityRelationship] WHERE [ID] = 'cf73481c-a449-4ad9-a22f-8378c0f98d55'
+   )
+   BEGIN
+      INSERT INTO [${flyway:defaultSchema}].[EntityRelationship] ([ID], [EntityID], [RelatedEntityID], [RelatedEntityJoinField], [Type], [BundleInAPI], [DisplayInForm], [Sequence], [__mj_CreatedAt], [__mj_UpdatedAt])
+                    VALUES ('cf73481c-a449-4ad9-a22f-8378c0f98d55', '18033543-B80D-4BF7-ADAF-DE1AA2CF70D0', '6B8A7C62-C13B-4283-9C81-17D9233A4A69', 'DefaultStorageAccountID', 'One To Many', 1, 1, 3, GETUTCDATE(), GETUTCDATE())
+   END;
+                    
+/* Create Entity Relationship: MJ: File Storage Accounts -> MJ: AI Agents (One To Many via DefaultStorageAccountID) */
+   IF NOT EXISTS (
+      SELECT 1 FROM [${flyway:defaultSchema}].[EntityRelationship] WHERE [ID] = '49f414c7-92d3-4f55-b5ef-b8e9976c7b18'
+   )
+   BEGIN
+      INSERT INTO [${flyway:defaultSchema}].[EntityRelationship] ([ID], [EntityID], [RelatedEntityID], [RelatedEntityJoinField], [Type], [BundleInAPI], [DisplayInForm], [Sequence], [__mj_CreatedAt], [__mj_UpdatedAt])
+                    VALUES ('49f414c7-92d3-4f55-b5ef-b8e9976c7b18', '18033543-B80D-4BF7-ADAF-DE1AA2CF70D0', 'CDB135CC-6D3C-480B-90AE-25B7805F82C1', 'DefaultStorageAccountID', 'One To Many', 1, 1, 24, GETUTCDATE(), GETUTCDATE())
+   END;
+                    
+
+/* Index for Foreign Keys for AIAgentCategory */
+-----------------------------------------------------------------
+-- SQL Code Generation
+-- Entity: MJ: AI Agent Categories
+-- Item: Index for Foreign Keys
+--
+-- This was generated by the MemberJunction CodeGen tool.
+-- This file should NOT be edited by hand.
+-----------------------------------------------------------------
+-- Index for foreign key ParentID in table AIAgentCategory
+IF NOT EXISTS (
+    SELECT 1
+    FROM sys.indexes
+    WHERE name = 'IDX_AUTO_MJ_FKEY_AIAgentCategory_ParentID' 
+    AND object_id = OBJECT_ID('[${flyway:defaultSchema}].[AIAgentCategory]')
+)
+CREATE INDEX IDX_AUTO_MJ_FKEY_AIAgentCategory_ParentID ON [${flyway:defaultSchema}].[AIAgentCategory] ([ParentID]);
+
+-- Index for foreign key DefaultStorageAccountID in table AIAgentCategory
+IF NOT EXISTS (
+    SELECT 1
+    FROM sys.indexes
+    WHERE name = 'IDX_AUTO_MJ_FKEY_AIAgentCategory_DefaultStorageAccountID' 
+    AND object_id = OBJECT_ID('[${flyway:defaultSchema}].[AIAgentCategory]')
+)
+CREATE INDEX IDX_AUTO_MJ_FKEY_AIAgentCategory_DefaultStorageAccountID ON [${flyway:defaultSchema}].[AIAgentCategory] ([DefaultStorageAccountID]);
+
+/* SQL text to update entity field related entity name field map for entity field ID 8C389086-9876-403C-9AB8-2F6F61303E64 */
+EXEC [${flyway:defaultSchema}].[spUpdateEntityFieldRelatedEntityNameFieldMap] @EntityFieldID='8C389086-9876-403C-9AB8-2F6F61303E64', @RelatedEntityNameFieldMap='DefaultStorageAccount'
+
+/* Root ID Function SQL for MJ: AI Agent Categories.ParentID */
+-----------------------------------------------------------------
+-- SQL Code Generation
+-- Entity: MJ: AI Agent Categories
+-- Item: fnAIAgentCategoryParentID_GetRootID
+--
+-- This was generated by the MemberJunction CodeGen tool.
+-- This file should NOT be edited by hand.
+-----------------------------------------------------------------
+------------------------------------------------------------
+----- ROOT ID FUNCTION FOR: [AIAgentCategory].[ParentID]
+------------------------------------------------------------
+IF OBJECT_ID('[${flyway:defaultSchema}].[fnAIAgentCategoryParentID_GetRootID]', 'IF') IS NOT NULL
+    DROP FUNCTION [${flyway:defaultSchema}].[fnAIAgentCategoryParentID_GetRootID];
+GO
+
+CREATE FUNCTION [${flyway:defaultSchema}].[fnAIAgentCategoryParentID_GetRootID]
+(
+    @RecordID uniqueidentifier,
+    @ParentID uniqueidentifier
+)
+RETURNS TABLE
+AS
+RETURN
+(
+    WITH CTE_RootParent AS (
+        SELECT
+            [ID],
+            [ParentID],
+            [ID] AS [RootParentID],
+            0 AS [Depth]
+        FROM
+            [${flyway:defaultSchema}].[AIAgentCategory]
+        WHERE
+            [ID] = COALESCE(@ParentID, @RecordID)
+
+        UNION ALL
+
+        SELECT
+            c.[ID],
+            c.[ParentID],
+            c.[ID] AS [RootParentID],
+            p.[Depth] + 1 AS [Depth]
+        FROM
+            [${flyway:defaultSchema}].[AIAgentCategory] c
+        INNER JOIN
+            CTE_RootParent p ON c.[ID] = p.[ParentID]
+        WHERE
+            p.[Depth] < 100
+    )
+    SELECT TOP 1
+        [RootParentID] AS RootID
+    FROM
+        CTE_RootParent
+    WHERE
+        [ParentID] IS NULL
+    ORDER BY
+        [RootParentID]
+);
+GO
+
+
+/* Base View SQL for MJ: AI Agent Categories */
+-----------------------------------------------------------------
+-- SQL Code Generation
+-- Entity: MJ: AI Agent Categories
+-- Item: vwAIAgentCategories
+--
+-- This was generated by the MemberJunction CodeGen tool.
+-- This file should NOT be edited by hand.
+-----------------------------------------------------------------
+
+------------------------------------------------------------
+----- BASE VIEW FOR ENTITY:      MJ: AI Agent Categories
+-----               SCHEMA:      ${flyway:defaultSchema}
+-----               BASE TABLE:  AIAgentCategory
+-----               PRIMARY KEY: ID
+------------------------------------------------------------
+IF OBJECT_ID('[${flyway:defaultSchema}].[vwAIAgentCategories]', 'V') IS NOT NULL
+    DROP VIEW [${flyway:defaultSchema}].[vwAIAgentCategories];
+GO
+
+CREATE VIEW [${flyway:defaultSchema}].[vwAIAgentCategories]
+AS
+SELECT
+    a.*,
+    MJAIAgentCategory_ParentID.[Name] AS [Parent],
+    MJFileStorageAccount_DefaultStorageAccountID.[Name] AS [DefaultStorageAccount],
+    root_ParentID.RootID AS [RootParentID]
+FROM
+    [${flyway:defaultSchema}].[AIAgentCategory] AS a
+LEFT OUTER JOIN
+    [${flyway:defaultSchema}].[AIAgentCategory] AS MJAIAgentCategory_ParentID
+  ON
+    [a].[ParentID] = MJAIAgentCategory_ParentID.[ID]
+LEFT OUTER JOIN
+    [${flyway:defaultSchema}].[FileStorageAccount] AS MJFileStorageAccount_DefaultStorageAccountID
+  ON
+    [a].[DefaultStorageAccountID] = MJFileStorageAccount_DefaultStorageAccountID.[ID]
+OUTER APPLY
+    [${flyway:defaultSchema}].[fnAIAgentCategoryParentID_GetRootID]([a].[ID], [a].[ParentID]) AS root_ParentID
+GO
+GRANT SELECT ON [${flyway:defaultSchema}].[vwAIAgentCategories] TO [cdp_UI], [cdp_Developer], [cdp_Integration]
+
+/* Base View Permissions SQL for MJ: AI Agent Categories */
+-----------------------------------------------------------------
+-- SQL Code Generation
+-- Entity: MJ: AI Agent Categories
+-- Item: Permissions for vwAIAgentCategories
+--
+-- This was generated by the MemberJunction CodeGen tool.
+-- This file should NOT be edited by hand.
+-----------------------------------------------------------------
+
+GRANT SELECT ON [${flyway:defaultSchema}].[vwAIAgentCategories] TO [cdp_UI], [cdp_Developer], [cdp_Integration]
+
+/* spCreate SQL for MJ: AI Agent Categories */
+-----------------------------------------------------------------
+-- SQL Code Generation
+-- Entity: MJ: AI Agent Categories
+-- Item: spCreateAIAgentCategory
+--
+-- This was generated by the MemberJunction CodeGen tool.
+-- This file should NOT be edited by hand.
+-----------------------------------------------------------------
+
+------------------------------------------------------------
+----- CREATE PROCEDURE FOR AIAgentCategory
+------------------------------------------------------------
+IF OBJECT_ID('[${flyway:defaultSchema}].[spCreateAIAgentCategory]', 'P') IS NOT NULL
+    DROP PROCEDURE [${flyway:defaultSchema}].[spCreateAIAgentCategory];
+GO
+
+CREATE PROCEDURE [${flyway:defaultSchema}].[spCreateAIAgentCategory]
+    @ID uniqueidentifier = NULL,
+    @Name nvarchar(200),
+    @Description nvarchar(MAX),
+    @ParentID uniqueidentifier,
+    @AssignmentStrategy nvarchar(MAX),
+    @Status nvarchar(20) = NULL,
+    @DefaultStorageAccountID uniqueidentifier
+AS
+BEGIN
+    SET NOCOUNT ON;
+    DECLARE @InsertedRow TABLE ([ID] UNIQUEIDENTIFIER)
+    
+    IF @ID IS NOT NULL
+    BEGIN
+        -- User provided a value, use it
+        INSERT INTO [${flyway:defaultSchema}].[AIAgentCategory]
+            (
+                [ID],
+                [Name],
+                [Description],
+                [ParentID],
+                [AssignmentStrategy],
+                [Status],
+                [DefaultStorageAccountID]
+            )
+        OUTPUT INSERTED.[ID] INTO @InsertedRow
+        VALUES
+            (
+                @ID,
+                @Name,
+                @Description,
+                @ParentID,
+                @AssignmentStrategy,
+                ISNULL(@Status, 'Active'),
+                @DefaultStorageAccountID
+            )
+    END
+    ELSE
+    BEGIN
+        -- No value provided, let database use its default (e.g., NEWSEQUENTIALID())
+        INSERT INTO [${flyway:defaultSchema}].[AIAgentCategory]
+            (
+                [Name],
+                [Description],
+                [ParentID],
+                [AssignmentStrategy],
+                [Status],
+                [DefaultStorageAccountID]
+            )
+        OUTPUT INSERTED.[ID] INTO @InsertedRow
+        VALUES
+            (
+                @Name,
+                @Description,
+                @ParentID,
+                @AssignmentStrategy,
+                ISNULL(@Status, 'Active'),
+                @DefaultStorageAccountID
+            )
+    END
+    -- return the new record from the base view, which might have some calculated fields
+    SELECT * FROM [${flyway:defaultSchema}].[vwAIAgentCategories] WHERE [ID] = (SELECT [ID] FROM @InsertedRow)
+END
+GO
+GRANT EXECUTE ON [${flyway:defaultSchema}].[spCreateAIAgentCategory] TO [cdp_Developer], [cdp_Integration]
+    
+
+/* spCreate Permissions for MJ: AI Agent Categories */
+
+GRANT EXECUTE ON [${flyway:defaultSchema}].[spCreateAIAgentCategory] TO [cdp_Developer], [cdp_Integration]
+
+
+
+/* spUpdate SQL for MJ: AI Agent Categories */
+-----------------------------------------------------------------
+-- SQL Code Generation
+-- Entity: MJ: AI Agent Categories
+-- Item: spUpdateAIAgentCategory
+--
+-- This was generated by the MemberJunction CodeGen tool.
+-- This file should NOT be edited by hand.
+-----------------------------------------------------------------
+
+------------------------------------------------------------
+----- UPDATE PROCEDURE FOR AIAgentCategory
+------------------------------------------------------------
+IF OBJECT_ID('[${flyway:defaultSchema}].[spUpdateAIAgentCategory]', 'P') IS NOT NULL
+    DROP PROCEDURE [${flyway:defaultSchema}].[spUpdateAIAgentCategory];
+GO
+
+CREATE PROCEDURE [${flyway:defaultSchema}].[spUpdateAIAgentCategory]
+    @ID uniqueidentifier,
+    @Name nvarchar(200),
+    @Description nvarchar(MAX),
+    @ParentID uniqueidentifier,
+    @AssignmentStrategy nvarchar(MAX),
+    @Status nvarchar(20),
+    @DefaultStorageAccountID uniqueidentifier
+AS
+BEGIN
+    SET NOCOUNT ON;
+    UPDATE
+        [${flyway:defaultSchema}].[AIAgentCategory]
+    SET
+        [Name] = @Name,
+        [Description] = @Description,
+        [ParentID] = @ParentID,
+        [AssignmentStrategy] = @AssignmentStrategy,
+        [Status] = @Status,
+        [DefaultStorageAccountID] = @DefaultStorageAccountID
+    WHERE
+        [ID] = @ID
+
+    -- Check if the update was successful
+    IF @@ROWCOUNT = 0
+        -- Nothing was updated, return no rows, but column structure from base view intact, semantically correct this way.
+        SELECT TOP 0 * FROM [${flyway:defaultSchema}].[vwAIAgentCategories] WHERE 1=0
+    ELSE
+        -- Return the updated record so the caller can see the updated values and any calculated fields
+        SELECT
+                                        *
+                                    FROM
+                                        [${flyway:defaultSchema}].[vwAIAgentCategories]
+                                    WHERE
+                                        [ID] = @ID
+                                    
+END
+GO
+
+GRANT EXECUTE ON [${flyway:defaultSchema}].[spUpdateAIAgentCategory] TO [cdp_Developer], [cdp_Integration]
+GO
+
+------------------------------------------------------------
+----- TRIGGER FOR __mj_UpdatedAt field for the AIAgentCategory table
+------------------------------------------------------------
+IF OBJECT_ID('[${flyway:defaultSchema}].[trgUpdateAIAgentCategory]', 'TR') IS NOT NULL
+    DROP TRIGGER [${flyway:defaultSchema}].[trgUpdateAIAgentCategory];
+GO
+CREATE TRIGGER [${flyway:defaultSchema}].trgUpdateAIAgentCategory
+ON [${flyway:defaultSchema}].[AIAgentCategory]
+AFTER UPDATE
+AS
+BEGIN
+    SET NOCOUNT ON;
+    UPDATE
+        [${flyway:defaultSchema}].[AIAgentCategory]
+    SET
+        __mj_UpdatedAt = GETUTCDATE()
+    FROM
+        [${flyway:defaultSchema}].[AIAgentCategory] AS _organicTable
+    INNER JOIN
+        INSERTED AS I ON
+        _organicTable.[ID] = I.[ID];
+END;
+GO
+        
+
+/* spUpdate Permissions for MJ: AI Agent Categories */
+
+GRANT EXECUTE ON [${flyway:defaultSchema}].[spUpdateAIAgentCategory] TO [cdp_Developer], [cdp_Integration]
+
+
+
+/* spDelete SQL for MJ: AI Agent Categories */
+-----------------------------------------------------------------
+-- SQL Code Generation
+-- Entity: MJ: AI Agent Categories
+-- Item: spDeleteAIAgentCategory
+--
+-- This was generated by the MemberJunction CodeGen tool.
+-- This file should NOT be edited by hand.
+-----------------------------------------------------------------
+
+------------------------------------------------------------
+----- DELETE PROCEDURE FOR AIAgentCategory
+------------------------------------------------------------
+IF OBJECT_ID('[${flyway:defaultSchema}].[spDeleteAIAgentCategory]', 'P') IS NOT NULL
+    DROP PROCEDURE [${flyway:defaultSchema}].[spDeleteAIAgentCategory];
+GO
+
+CREATE PROCEDURE [${flyway:defaultSchema}].[spDeleteAIAgentCategory]
+    @ID uniqueidentifier
+AS
+BEGIN
+    SET NOCOUNT ON;
+
+    DELETE FROM
+        [${flyway:defaultSchema}].[AIAgentCategory]
+    WHERE
+        [ID] = @ID
+
+
+    -- Check if the delete was successful
+    IF @@ROWCOUNT = 0
+        SELECT NULL AS [ID] -- Return NULL for all primary key fields to indicate no record was deleted
+    ELSE
+        SELECT @ID AS [ID] -- Return the primary key values to indicate we successfully deleted the record
+END
+GO
+GRANT EXECUTE ON [${flyway:defaultSchema}].[spDeleteAIAgentCategory] TO [cdp_Integration]
+    
+
+/* spDelete Permissions for MJ: AI Agent Categories */
+
+GRANT EXECUTE ON [${flyway:defaultSchema}].[spDeleteAIAgentCategory] TO [cdp_Integration]
+
+
+
+/* Index for Foreign Keys for AIAgentType */
+-----------------------------------------------------------------
+-- SQL Code Generation
+-- Entity: MJ: AI Agent Types
+-- Item: Index for Foreign Keys
+--
+-- This was generated by the MemberJunction CodeGen tool.
+-- This file should NOT be edited by hand.
+-----------------------------------------------------------------
+-- Index for foreign key SystemPromptID in table AIAgentType
+IF NOT EXISTS (
+    SELECT 1
+    FROM sys.indexes
+    WHERE name = 'IDX_AUTO_MJ_FKEY_AIAgentType_SystemPromptID' 
+    AND object_id = OBJECT_ID('[${flyway:defaultSchema}].[AIAgentType]')
+)
+CREATE INDEX IDX_AUTO_MJ_FKEY_AIAgentType_SystemPromptID ON [${flyway:defaultSchema}].[AIAgentType] ([SystemPromptID]);
+
+-- Index for foreign key DefaultStorageAccountID in table AIAgentType
+IF NOT EXISTS (
+    SELECT 1
+    FROM sys.indexes
+    WHERE name = 'IDX_AUTO_MJ_FKEY_AIAgentType_DefaultStorageAccountID' 
+    AND object_id = OBJECT_ID('[${flyway:defaultSchema}].[AIAgentType]')
+)
+CREATE INDEX IDX_AUTO_MJ_FKEY_AIAgentType_DefaultStorageAccountID ON [${flyway:defaultSchema}].[AIAgentType] ([DefaultStorageAccountID]);
+
+/* SQL text to update entity field related entity name field map for entity field ID 6B31A64B-6BD8-446B-B306-0BDD65645694 */
+EXEC [${flyway:defaultSchema}].[spUpdateEntityFieldRelatedEntityNameFieldMap] @EntityFieldID='6B31A64B-6BD8-446B-B306-0BDD65645694', @RelatedEntityNameFieldMap='DefaultStorageAccount'
+
+/* Base View SQL for MJ: AI Agent Types */
+-----------------------------------------------------------------
+-- SQL Code Generation
+-- Entity: MJ: AI Agent Types
+-- Item: vwAIAgentTypes
+--
+-- This was generated by the MemberJunction CodeGen tool.
+-- This file should NOT be edited by hand.
+-----------------------------------------------------------------
+
+------------------------------------------------------------
+----- BASE VIEW FOR ENTITY:      MJ: AI Agent Types
+-----               SCHEMA:      ${flyway:defaultSchema}
+-----               BASE TABLE:  AIAgentType
+-----               PRIMARY KEY: ID
+------------------------------------------------------------
+IF OBJECT_ID('[${flyway:defaultSchema}].[vwAIAgentTypes]', 'V') IS NOT NULL
+    DROP VIEW [${flyway:defaultSchema}].[vwAIAgentTypes];
+GO
+
+CREATE VIEW [${flyway:defaultSchema}].[vwAIAgentTypes]
+AS
+SELECT
+    a.*,
+    MJAIPrompt_SystemPromptID.[Name] AS [SystemPrompt],
+    MJFileStorageAccount_DefaultStorageAccountID.[Name] AS [DefaultStorageAccount]
+FROM
+    [${flyway:defaultSchema}].[AIAgentType] AS a
+LEFT OUTER JOIN
+    [${flyway:defaultSchema}].[AIPrompt] AS MJAIPrompt_SystemPromptID
+  ON
+    [a].[SystemPromptID] = MJAIPrompt_SystemPromptID.[ID]
+LEFT OUTER JOIN
+    [${flyway:defaultSchema}].[FileStorageAccount] AS MJFileStorageAccount_DefaultStorageAccountID
+  ON
+    [a].[DefaultStorageAccountID] = MJFileStorageAccount_DefaultStorageAccountID.[ID]
+GO
+GRANT SELECT ON [${flyway:defaultSchema}].[vwAIAgentTypes] TO [cdp_UI], [cdp_Developer], [cdp_Integration]
+
+/* Base View Permissions SQL for MJ: AI Agent Types */
+-----------------------------------------------------------------
+-- SQL Code Generation
+-- Entity: MJ: AI Agent Types
+-- Item: Permissions for vwAIAgentTypes
+--
+-- This was generated by the MemberJunction CodeGen tool.
+-- This file should NOT be edited by hand.
+-----------------------------------------------------------------
+
+GRANT SELECT ON [${flyway:defaultSchema}].[vwAIAgentTypes] TO [cdp_UI], [cdp_Developer], [cdp_Integration]
+
+/* spCreate SQL for MJ: AI Agent Types */
+-----------------------------------------------------------------
+-- SQL Code Generation
+-- Entity: MJ: AI Agent Types
+-- Item: spCreateAIAgentType
+--
+-- This was generated by the MemberJunction CodeGen tool.
+-- This file should NOT be edited by hand.
+-----------------------------------------------------------------
+
+------------------------------------------------------------
+----- CREATE PROCEDURE FOR AIAgentType
+------------------------------------------------------------
+IF OBJECT_ID('[${flyway:defaultSchema}].[spCreateAIAgentType]', 'P') IS NOT NULL
+    DROP PROCEDURE [${flyway:defaultSchema}].[spCreateAIAgentType];
+GO
+
+CREATE PROCEDURE [${flyway:defaultSchema}].[spCreateAIAgentType]
+    @ID uniqueidentifier = NULL,
+    @Name nvarchar(100),
+    @Description nvarchar(MAX),
+    @SystemPromptID uniqueidentifier,
+    @IsActive bit = NULL,
+    @AgentPromptPlaceholder nvarchar(255),
+    @DriverClass nvarchar(255),
+    @UIFormSectionKey nvarchar(500),
+    @UIFormKey nvarchar(500),
+    @UIFormSectionExpandedByDefault bit = NULL,
+    @PromptParamsSchema nvarchar(MAX),
+    @AssignmentStrategy nvarchar(MAX),
+    @DefaultStorageAccountID uniqueidentifier
+AS
+BEGIN
+    SET NOCOUNT ON;
+    DECLARE @InsertedRow TABLE ([ID] UNIQUEIDENTIFIER)
+    
+    IF @ID IS NOT NULL
+    BEGIN
+        -- User provided a value, use it
+        INSERT INTO [${flyway:defaultSchema}].[AIAgentType]
+            (
+                [ID],
+                [Name],
+                [Description],
+                [SystemPromptID],
+                [IsActive],
+                [AgentPromptPlaceholder],
+                [DriverClass],
+                [UIFormSectionKey],
+                [UIFormKey],
+                [UIFormSectionExpandedByDefault],
+                [PromptParamsSchema],
+                [AssignmentStrategy],
+                [DefaultStorageAccountID]
+            )
+        OUTPUT INSERTED.[ID] INTO @InsertedRow
+        VALUES
+            (
+                @ID,
+                @Name,
+                @Description,
+                @SystemPromptID,
+                ISNULL(@IsActive, 1),
+                @AgentPromptPlaceholder,
+                @DriverClass,
+                @UIFormSectionKey,
+                @UIFormKey,
+                ISNULL(@UIFormSectionExpandedByDefault, 1),
+                @PromptParamsSchema,
+                @AssignmentStrategy,
+                @DefaultStorageAccountID
+            )
+    END
+    ELSE
+    BEGIN
+        -- No value provided, let database use its default (e.g., NEWSEQUENTIALID())
+        INSERT INTO [${flyway:defaultSchema}].[AIAgentType]
+            (
+                [Name],
+                [Description],
+                [SystemPromptID],
+                [IsActive],
+                [AgentPromptPlaceholder],
+                [DriverClass],
+                [UIFormSectionKey],
+                [UIFormKey],
+                [UIFormSectionExpandedByDefault],
+                [PromptParamsSchema],
+                [AssignmentStrategy],
+                [DefaultStorageAccountID]
+            )
+        OUTPUT INSERTED.[ID] INTO @InsertedRow
+        VALUES
+            (
+                @Name,
+                @Description,
+                @SystemPromptID,
+                ISNULL(@IsActive, 1),
+                @AgentPromptPlaceholder,
+                @DriverClass,
+                @UIFormSectionKey,
+                @UIFormKey,
+                ISNULL(@UIFormSectionExpandedByDefault, 1),
+                @PromptParamsSchema,
+                @AssignmentStrategy,
+                @DefaultStorageAccountID
+            )
+    END
+    -- return the new record from the base view, which might have some calculated fields
+    SELECT * FROM [${flyway:defaultSchema}].[vwAIAgentTypes] WHERE [ID] = (SELECT [ID] FROM @InsertedRow)
+END
+GO
+GRANT EXECUTE ON [${flyway:defaultSchema}].[spCreateAIAgentType] TO [cdp_Developer], [cdp_Integration]
+    
+
+/* spCreate Permissions for MJ: AI Agent Types */
+
+GRANT EXECUTE ON [${flyway:defaultSchema}].[spCreateAIAgentType] TO [cdp_Developer], [cdp_Integration]
+
+
+
+/* spUpdate SQL for MJ: AI Agent Types */
+-----------------------------------------------------------------
+-- SQL Code Generation
+-- Entity: MJ: AI Agent Types
+-- Item: spUpdateAIAgentType
+--
+-- This was generated by the MemberJunction CodeGen tool.
+-- This file should NOT be edited by hand.
+-----------------------------------------------------------------
+
+------------------------------------------------------------
+----- UPDATE PROCEDURE FOR AIAgentType
+------------------------------------------------------------
+IF OBJECT_ID('[${flyway:defaultSchema}].[spUpdateAIAgentType]', 'P') IS NOT NULL
+    DROP PROCEDURE [${flyway:defaultSchema}].[spUpdateAIAgentType];
+GO
+
+CREATE PROCEDURE [${flyway:defaultSchema}].[spUpdateAIAgentType]
+    @ID uniqueidentifier,
+    @Name nvarchar(100),
+    @Description nvarchar(MAX),
+    @SystemPromptID uniqueidentifier,
+    @IsActive bit,
+    @AgentPromptPlaceholder nvarchar(255),
+    @DriverClass nvarchar(255),
+    @UIFormSectionKey nvarchar(500),
+    @UIFormKey nvarchar(500),
+    @UIFormSectionExpandedByDefault bit,
+    @PromptParamsSchema nvarchar(MAX),
+    @AssignmentStrategy nvarchar(MAX),
+    @DefaultStorageAccountID uniqueidentifier
+AS
+BEGIN
+    SET NOCOUNT ON;
+    UPDATE
+        [${flyway:defaultSchema}].[AIAgentType]
+    SET
+        [Name] = @Name,
+        [Description] = @Description,
+        [SystemPromptID] = @SystemPromptID,
+        [IsActive] = @IsActive,
+        [AgentPromptPlaceholder] = @AgentPromptPlaceholder,
+        [DriverClass] = @DriverClass,
+        [UIFormSectionKey] = @UIFormSectionKey,
+        [UIFormKey] = @UIFormKey,
+        [UIFormSectionExpandedByDefault] = @UIFormSectionExpandedByDefault,
+        [PromptParamsSchema] = @PromptParamsSchema,
+        [AssignmentStrategy] = @AssignmentStrategy,
+        [DefaultStorageAccountID] = @DefaultStorageAccountID
+    WHERE
+        [ID] = @ID
+
+    -- Check if the update was successful
+    IF @@ROWCOUNT = 0
+        -- Nothing was updated, return no rows, but column structure from base view intact, semantically correct this way.
+        SELECT TOP 0 * FROM [${flyway:defaultSchema}].[vwAIAgentTypes] WHERE 1=0
+    ELSE
+        -- Return the updated record so the caller can see the updated values and any calculated fields
+        SELECT
+                                        *
+                                    FROM
+                                        [${flyway:defaultSchema}].[vwAIAgentTypes]
+                                    WHERE
+                                        [ID] = @ID
+                                    
+END
+GO
+
+GRANT EXECUTE ON [${flyway:defaultSchema}].[spUpdateAIAgentType] TO [cdp_Developer], [cdp_Integration]
+GO
+
+------------------------------------------------------------
+----- TRIGGER FOR __mj_UpdatedAt field for the AIAgentType table
+------------------------------------------------------------
+IF OBJECT_ID('[${flyway:defaultSchema}].[trgUpdateAIAgentType]', 'TR') IS NOT NULL
+    DROP TRIGGER [${flyway:defaultSchema}].[trgUpdateAIAgentType];
+GO
+CREATE TRIGGER [${flyway:defaultSchema}].trgUpdateAIAgentType
+ON [${flyway:defaultSchema}].[AIAgentType]
+AFTER UPDATE
+AS
+BEGIN
+    SET NOCOUNT ON;
+    UPDATE
+        [${flyway:defaultSchema}].[AIAgentType]
+    SET
+        __mj_UpdatedAt = GETUTCDATE()
+    FROM
+        [${flyway:defaultSchema}].[AIAgentType] AS _organicTable
+    INNER JOIN
+        INSERTED AS I ON
+        _organicTable.[ID] = I.[ID];
+END;
+GO
+        
+
+/* spUpdate Permissions for MJ: AI Agent Types */
+
+GRANT EXECUTE ON [${flyway:defaultSchema}].[spUpdateAIAgentType] TO [cdp_Developer], [cdp_Integration]
+
+
+
+/* spDelete SQL for MJ: AI Agent Types */
+-----------------------------------------------------------------
+-- SQL Code Generation
+-- Entity: MJ: AI Agent Types
+-- Item: spDeleteAIAgentType
+--
+-- This was generated by the MemberJunction CodeGen tool.
+-- This file should NOT be edited by hand.
+-----------------------------------------------------------------
+
+------------------------------------------------------------
+----- DELETE PROCEDURE FOR AIAgentType
+------------------------------------------------------------
+IF OBJECT_ID('[${flyway:defaultSchema}].[spDeleteAIAgentType]', 'P') IS NOT NULL
+    DROP PROCEDURE [${flyway:defaultSchema}].[spDeleteAIAgentType];
+GO
+
+CREATE PROCEDURE [${flyway:defaultSchema}].[spDeleteAIAgentType]
+    @ID uniqueidentifier
+AS
+BEGIN
+    SET NOCOUNT ON;
+
+    DELETE FROM
+        [${flyway:defaultSchema}].[AIAgentType]
+    WHERE
+        [ID] = @ID
+
+
+    -- Check if the delete was successful
+    IF @@ROWCOUNT = 0
+        SELECT NULL AS [ID] -- Return NULL for all primary key fields to indicate no record was deleted
+    ELSE
+        SELECT @ID AS [ID] -- Return the primary key values to indicate we successfully deleted the record
+END
+GO
+GRANT EXECUTE ON [${flyway:defaultSchema}].[spDeleteAIAgentType] TO [cdp_Integration]
+    
+
+/* spDelete Permissions for MJ: AI Agent Types */
+
+GRANT EXECUTE ON [${flyway:defaultSchema}].[spDeleteAIAgentType] TO [cdp_Integration]
+
+
+
+/* Index for Foreign Keys for AIAgent */
+-----------------------------------------------------------------
+-- SQL Code Generation
+-- Entity: MJ: AI Agents
+-- Item: Index for Foreign Keys
+--
+-- This was generated by the MemberJunction CodeGen tool.
+-- This file should NOT be edited by hand.
+-----------------------------------------------------------------
+-- Index for foreign key ParentID in table AIAgent
+IF NOT EXISTS (
+    SELECT 1
+    FROM sys.indexes
+    WHERE name = 'IDX_AUTO_MJ_FKEY_AIAgent_ParentID' 
+    AND object_id = OBJECT_ID('[${flyway:defaultSchema}].[AIAgent]')
+)
+CREATE INDEX IDX_AUTO_MJ_FKEY_AIAgent_ParentID ON [${flyway:defaultSchema}].[AIAgent] ([ParentID]);
+
+-- Index for foreign key ContextCompressionPromptID in table AIAgent
+IF NOT EXISTS (
+    SELECT 1
+    FROM sys.indexes
+    WHERE name = 'IDX_AUTO_MJ_FKEY_AIAgent_ContextCompressionPromptID' 
+    AND object_id = OBJECT_ID('[${flyway:defaultSchema}].[AIAgent]')
+)
+CREATE INDEX IDX_AUTO_MJ_FKEY_AIAgent_ContextCompressionPromptID ON [${flyway:defaultSchema}].[AIAgent] ([ContextCompressionPromptID]);
+
+-- Index for foreign key TypeID in table AIAgent
+IF NOT EXISTS (
+    SELECT 1
+    FROM sys.indexes
+    WHERE name = 'IDX_AUTO_MJ_FKEY_AIAgent_TypeID' 
+    AND object_id = OBJECT_ID('[${flyway:defaultSchema}].[AIAgent]')
+)
+CREATE INDEX IDX_AUTO_MJ_FKEY_AIAgent_TypeID ON [${flyway:defaultSchema}].[AIAgent] ([TypeID]);
+
+-- Index for foreign key DefaultArtifactTypeID in table AIAgent
+IF NOT EXISTS (
+    SELECT 1
+    FROM sys.indexes
+    WHERE name = 'IDX_AUTO_MJ_FKEY_AIAgent_DefaultArtifactTypeID' 
+    AND object_id = OBJECT_ID('[${flyway:defaultSchema}].[AIAgent]')
+)
+CREATE INDEX IDX_AUTO_MJ_FKEY_AIAgent_DefaultArtifactTypeID ON [${flyway:defaultSchema}].[AIAgent] ([DefaultArtifactTypeID]);
+
+-- Index for foreign key OwnerUserID in table AIAgent
+IF NOT EXISTS (
+    SELECT 1
+    FROM sys.indexes
+    WHERE name = 'IDX_AUTO_MJ_FKEY_AIAgent_OwnerUserID' 
+    AND object_id = OBJECT_ID('[${flyway:defaultSchema}].[AIAgent]')
+)
+CREATE INDEX IDX_AUTO_MJ_FKEY_AIAgent_OwnerUserID ON [${flyway:defaultSchema}].[AIAgent] ([OwnerUserID]);
+
+-- Index for foreign key AttachmentStorageProviderID in table AIAgent
+IF NOT EXISTS (
+    SELECT 1
+    FROM sys.indexes
+    WHERE name = 'IDX_AUTO_MJ_FKEY_AIAgent_AttachmentStorageProviderID' 
+    AND object_id = OBJECT_ID('[${flyway:defaultSchema}].[AIAgent]')
+)
+CREATE INDEX IDX_AUTO_MJ_FKEY_AIAgent_AttachmentStorageProviderID ON [${flyway:defaultSchema}].[AIAgent] ([AttachmentStorageProviderID]);
+
+-- Index for foreign key CategoryID in table AIAgent
+IF NOT EXISTS (
+    SELECT 1
+    FROM sys.indexes
+    WHERE name = 'IDX_AUTO_MJ_FKEY_AIAgent_CategoryID' 
+    AND object_id = OBJECT_ID('[${flyway:defaultSchema}].[AIAgent]')
+)
+CREATE INDEX IDX_AUTO_MJ_FKEY_AIAgent_CategoryID ON [${flyway:defaultSchema}].[AIAgent] ([CategoryID]);
+
+-- Index for foreign key DefaultStorageAccountID in table AIAgent
+IF NOT EXISTS (
+    SELECT 1
+    FROM sys.indexes
+    WHERE name = 'IDX_AUTO_MJ_FKEY_AIAgent_DefaultStorageAccountID' 
+    AND object_id = OBJECT_ID('[${flyway:defaultSchema}].[AIAgent]')
+)
+CREATE INDEX IDX_AUTO_MJ_FKEY_AIAgent_DefaultStorageAccountID ON [${flyway:defaultSchema}].[AIAgent] ([DefaultStorageAccountID]);
+
+/* SQL text to update entity field related entity name field map for entity field ID 76AF4818-C79E-4DB5-8039-6B51C1C3A832 */
+EXEC [${flyway:defaultSchema}].[spUpdateEntityFieldRelatedEntityNameFieldMap] @EntityFieldID='76AF4818-C79E-4DB5-8039-6B51C1C3A832', @RelatedEntityNameFieldMap='DefaultStorageAccount'
+
+/* Root ID Function SQL for MJ: AI Agents.ParentID */
+-----------------------------------------------------------------
+-- SQL Code Generation
+-- Entity: MJ: AI Agents
+-- Item: fnAIAgentParentID_GetRootID
+--
+-- This was generated by the MemberJunction CodeGen tool.
+-- This file should NOT be edited by hand.
+-----------------------------------------------------------------
+------------------------------------------------------------
+----- ROOT ID FUNCTION FOR: [AIAgent].[ParentID]
+------------------------------------------------------------
+IF OBJECT_ID('[${flyway:defaultSchema}].[fnAIAgentParentID_GetRootID]', 'IF') IS NOT NULL
+    DROP FUNCTION [${flyway:defaultSchema}].[fnAIAgentParentID_GetRootID];
+GO
+
+CREATE FUNCTION [${flyway:defaultSchema}].[fnAIAgentParentID_GetRootID]
+(
+    @RecordID uniqueidentifier,
+    @ParentID uniqueidentifier
+)
+RETURNS TABLE
+AS
+RETURN
+(
+    WITH CTE_RootParent AS (
+        SELECT
+            [ID],
+            [ParentID],
+            [ID] AS [RootParentID],
+            0 AS [Depth]
+        FROM
+            [${flyway:defaultSchema}].[AIAgent]
+        WHERE
+            [ID] = COALESCE(@ParentID, @RecordID)
+
+        UNION ALL
+
+        SELECT
+            c.[ID],
+            c.[ParentID],
+            c.[ID] AS [RootParentID],
+            p.[Depth] + 1 AS [Depth]
+        FROM
+            [${flyway:defaultSchema}].[AIAgent] c
+        INNER JOIN
+            CTE_RootParent p ON c.[ID] = p.[ParentID]
+        WHERE
+            p.[Depth] < 100
+    )
+    SELECT TOP 1
+        [RootParentID] AS RootID
+    FROM
+        CTE_RootParent
+    WHERE
+        [ParentID] IS NULL
+    ORDER BY
+        [RootParentID]
+);
+GO
+
+
+/* Base View SQL for MJ: AI Agents */
+-----------------------------------------------------------------
+-- SQL Code Generation
+-- Entity: MJ: AI Agents
+-- Item: vwAIAgents
+--
+-- This was generated by the MemberJunction CodeGen tool.
+-- This file should NOT be edited by hand.
+-----------------------------------------------------------------
+
+------------------------------------------------------------
+----- BASE VIEW FOR ENTITY:      MJ: AI Agents
+-----               SCHEMA:      ${flyway:defaultSchema}
+-----               BASE TABLE:  AIAgent
+-----               PRIMARY KEY: ID
+------------------------------------------------------------
+IF OBJECT_ID('[${flyway:defaultSchema}].[vwAIAgents]', 'V') IS NOT NULL
+    DROP VIEW [${flyway:defaultSchema}].[vwAIAgents];
+GO
+
+CREATE VIEW [${flyway:defaultSchema}].[vwAIAgents]
+AS
+SELECT
+    a.*,
+    MJAIAgent_ParentID.[Name] AS [Parent],
+    MJAIPrompt_ContextCompressionPromptID.[Name] AS [ContextCompressionPrompt],
+    MJAIAgentType_TypeID.[Name] AS [Type],
+    MJArtifactType_DefaultArtifactTypeID.[Name] AS [DefaultArtifactType],
+    MJUser_OwnerUserID.[Name] AS [OwnerUser],
+    MJFileStorageProvider_AttachmentStorageProviderID.[Name] AS [AttachmentStorageProvider],
+    MJAIAgentCategory_CategoryID.[Name] AS [Category],
+    MJFileStorageAccount_DefaultStorageAccountID.[Name] AS [DefaultStorageAccount],
+    root_ParentID.RootID AS [RootParentID]
+FROM
+    [${flyway:defaultSchema}].[AIAgent] AS a
+LEFT OUTER JOIN
+    [${flyway:defaultSchema}].[AIAgent] AS MJAIAgent_ParentID
+  ON
+    [a].[ParentID] = MJAIAgent_ParentID.[ID]
+LEFT OUTER JOIN
+    [${flyway:defaultSchema}].[AIPrompt] AS MJAIPrompt_ContextCompressionPromptID
+  ON
+    [a].[ContextCompressionPromptID] = MJAIPrompt_ContextCompressionPromptID.[ID]
+LEFT OUTER JOIN
+    [${flyway:defaultSchema}].[AIAgentType] AS MJAIAgentType_TypeID
+  ON
+    [a].[TypeID] = MJAIAgentType_TypeID.[ID]
+LEFT OUTER JOIN
+    [${flyway:defaultSchema}].[ArtifactType] AS MJArtifactType_DefaultArtifactTypeID
+  ON
+    [a].[DefaultArtifactTypeID] = MJArtifactType_DefaultArtifactTypeID.[ID]
+INNER JOIN
+    [${flyway:defaultSchema}].[User] AS MJUser_OwnerUserID
+  ON
+    [a].[OwnerUserID] = MJUser_OwnerUserID.[ID]
+LEFT OUTER JOIN
+    [${flyway:defaultSchema}].[FileStorageProvider] AS MJFileStorageProvider_AttachmentStorageProviderID
+  ON
+    [a].[AttachmentStorageProviderID] = MJFileStorageProvider_AttachmentStorageProviderID.[ID]
+LEFT OUTER JOIN
+    [${flyway:defaultSchema}].[AIAgentCategory] AS MJAIAgentCategory_CategoryID
+  ON
+    [a].[CategoryID] = MJAIAgentCategory_CategoryID.[ID]
+LEFT OUTER JOIN
+    [${flyway:defaultSchema}].[FileStorageAccount] AS MJFileStorageAccount_DefaultStorageAccountID
+  ON
+    [a].[DefaultStorageAccountID] = MJFileStorageAccount_DefaultStorageAccountID.[ID]
+OUTER APPLY
+    [${flyway:defaultSchema}].[fnAIAgentParentID_GetRootID]([a].[ID], [a].[ParentID]) AS root_ParentID
+GO
+GRANT SELECT ON [${flyway:defaultSchema}].[vwAIAgents] TO [cdp_UI], [cdp_Developer], [cdp_Integration]
+
+/* Base View Permissions SQL for MJ: AI Agents */
+-----------------------------------------------------------------
+-- SQL Code Generation
+-- Entity: MJ: AI Agents
+-- Item: Permissions for vwAIAgents
+--
+-- This was generated by the MemberJunction CodeGen tool.
+-- This file should NOT be edited by hand.
+-----------------------------------------------------------------
+
+GRANT SELECT ON [${flyway:defaultSchema}].[vwAIAgents] TO [cdp_UI], [cdp_Developer], [cdp_Integration]
+
+/* spCreate SQL for MJ: AI Agents */
+-----------------------------------------------------------------
+-- SQL Code Generation
+-- Entity: MJ: AI Agents
+-- Item: spCreateAIAgent
+--
+-- This was generated by the MemberJunction CodeGen tool.
+-- This file should NOT be edited by hand.
+-----------------------------------------------------------------
+
+------------------------------------------------------------
+----- CREATE PROCEDURE FOR AIAgent
+------------------------------------------------------------
+IF OBJECT_ID('[${flyway:defaultSchema}].[spCreateAIAgent]', 'P') IS NOT NULL
+    DROP PROCEDURE [${flyway:defaultSchema}].[spCreateAIAgent];
+GO
+
+CREATE PROCEDURE [${flyway:defaultSchema}].[spCreateAIAgent]
+    @ID uniqueidentifier = NULL,
+    @Name nvarchar(255),
+    @Description nvarchar(MAX),
+    @LogoURL nvarchar(255),
+    @ParentID uniqueidentifier,
+    @ExposeAsAction bit = NULL,
+    @ExecutionOrder int = NULL,
+    @ExecutionMode nvarchar(20) = NULL,
+    @EnableContextCompression bit = NULL,
+    @ContextCompressionMessageThreshold int,
+    @ContextCompressionPromptID uniqueidentifier,
+    @ContextCompressionMessageRetentionCount int,
+    @TypeID uniqueidentifier,
+    @Status nvarchar(20) = NULL,
+    @DriverClass nvarchar(255),
+    @IconClass nvarchar(100),
+    @ModelSelectionMode nvarchar(50) = NULL,
+    @PayloadDownstreamPaths nvarchar(MAX) = NULL,
+    @PayloadUpstreamPaths nvarchar(MAX) = NULL,
+    @PayloadSelfReadPaths nvarchar(MAX),
+    @PayloadSelfWritePaths nvarchar(MAX),
+    @PayloadScope nvarchar(MAX),
+    @FinalPayloadValidation nvarchar(MAX),
+    @FinalPayloadValidationMode nvarchar(25) = NULL,
+    @FinalPayloadValidationMaxRetries int = NULL,
+    @MaxCostPerRun decimal(10, 4),
+    @MaxTokensPerRun int,
+    @MaxIterationsPerRun int,
+    @MaxTimePerRun int,
+    @MinExecutionsPerRun int,
+    @MaxExecutionsPerRun int,
+    @StartingPayloadValidation nvarchar(MAX),
+    @StartingPayloadValidationMode nvarchar(25) = NULL,
+    @DefaultPromptEffortLevel int,
+    @ChatHandlingOption nvarchar(30),
+    @DefaultArtifactTypeID uniqueidentifier,
+    @OwnerUserID uniqueidentifier = NULL,
+    @InvocationMode nvarchar(20) = NULL,
+    @ArtifactCreationMode nvarchar(20) = NULL,
+    @FunctionalRequirements nvarchar(MAX),
+    @TechnicalDesign nvarchar(MAX),
+    @InjectNotes bit = NULL,
+    @MaxNotesToInject int = NULL,
+    @NoteInjectionStrategy nvarchar(20) = NULL,
+    @InjectExamples bit = NULL,
+    @MaxExamplesToInject int = NULL,
+    @ExampleInjectionStrategy nvarchar(20) = NULL,
+    @IsRestricted bit = NULL,
+    @MessageMode nvarchar(50) = NULL,
+    @MaxMessages int,
+    @AttachmentStorageProviderID uniqueidentifier,
+    @AttachmentRootPath nvarchar(500),
+    @InlineStorageThresholdBytes int,
+    @AgentTypePromptParams nvarchar(MAX),
+    @ScopeConfig nvarchar(MAX),
+    @NoteRetentionDays int,
+    @ExampleRetentionDays int,
+    @AutoArchiveEnabled bit = NULL,
+    @RerankerConfiguration nvarchar(MAX),
+    @CategoryID uniqueidentifier,
+    @AllowEphemeralClientTools bit = NULL,
+    @DefaultStorageAccountID uniqueidentifier
+AS
+BEGIN
+    SET NOCOUNT ON;
+    DECLARE @InsertedRow TABLE ([ID] UNIQUEIDENTIFIER)
+    
+    IF @ID IS NOT NULL
+    BEGIN
+        -- User provided a value, use it
+        INSERT INTO [${flyway:defaultSchema}].[AIAgent]
+            (
+                [ID],
+                [Name],
+                [Description],
+                [LogoURL],
+                [ParentID],
+                [ExposeAsAction],
+                [ExecutionOrder],
+                [ExecutionMode],
+                [EnableContextCompression],
+                [ContextCompressionMessageThreshold],
+                [ContextCompressionPromptID],
+                [ContextCompressionMessageRetentionCount],
+                [TypeID],
+                [Status],
+                [DriverClass],
+                [IconClass],
+                [ModelSelectionMode],
+                [PayloadDownstreamPaths],
+                [PayloadUpstreamPaths],
+                [PayloadSelfReadPaths],
+                [PayloadSelfWritePaths],
+                [PayloadScope],
+                [FinalPayloadValidation],
+                [FinalPayloadValidationMode],
+                [FinalPayloadValidationMaxRetries],
+                [MaxCostPerRun],
+                [MaxTokensPerRun],
+                [MaxIterationsPerRun],
+                [MaxTimePerRun],
+                [MinExecutionsPerRun],
+                [MaxExecutionsPerRun],
+                [StartingPayloadValidation],
+                [StartingPayloadValidationMode],
+                [DefaultPromptEffortLevel],
+                [ChatHandlingOption],
+                [DefaultArtifactTypeID],
+                [OwnerUserID],
+                [InvocationMode],
+                [ArtifactCreationMode],
+                [FunctionalRequirements],
+                [TechnicalDesign],
+                [InjectNotes],
+                [MaxNotesToInject],
+                [NoteInjectionStrategy],
+                [InjectExamples],
+                [MaxExamplesToInject],
+                [ExampleInjectionStrategy],
+                [IsRestricted],
+                [MessageMode],
+                [MaxMessages],
+                [AttachmentStorageProviderID],
+                [AttachmentRootPath],
+                [InlineStorageThresholdBytes],
+                [AgentTypePromptParams],
+                [ScopeConfig],
+                [NoteRetentionDays],
+                [ExampleRetentionDays],
+                [AutoArchiveEnabled],
+                [RerankerConfiguration],
+                [CategoryID],
+                [AllowEphemeralClientTools],
+                [DefaultStorageAccountID]
+            )
+        OUTPUT INSERTED.[ID] INTO @InsertedRow
+        VALUES
+            (
+                @ID,
+                @Name,
+                @Description,
+                @LogoURL,
+                @ParentID,
+                ISNULL(@ExposeAsAction, 0),
+                ISNULL(@ExecutionOrder, 0),
+                ISNULL(@ExecutionMode, 'Sequential'),
+                ISNULL(@EnableContextCompression, 0),
+                @ContextCompressionMessageThreshold,
+                @ContextCompressionPromptID,
+                @ContextCompressionMessageRetentionCount,
+                @TypeID,
+                ISNULL(@Status, 'Pending'),
+                @DriverClass,
+                @IconClass,
+                ISNULL(@ModelSelectionMode, 'Agent Type'),
+                ISNULL(@PayloadDownstreamPaths, '["*"]'),
+                ISNULL(@PayloadUpstreamPaths, '["*"]'),
+                @PayloadSelfReadPaths,
+                @PayloadSelfWritePaths,
+                @PayloadScope,
+                @FinalPayloadValidation,
+                ISNULL(@FinalPayloadValidationMode, 'Retry'),
+                ISNULL(@FinalPayloadValidationMaxRetries, 3),
+                @MaxCostPerRun,
+                @MaxTokensPerRun,
+                @MaxIterationsPerRun,
+                @MaxTimePerRun,
+                @MinExecutionsPerRun,
+                @MaxExecutionsPerRun,
+                @StartingPayloadValidation,
+                ISNULL(@StartingPayloadValidationMode, 'Fail'),
+                @DefaultPromptEffortLevel,
+                @ChatHandlingOption,
+                @DefaultArtifactTypeID,
+                CASE @OwnerUserID WHEN '00000000-0000-0000-0000-000000000000' THEN 'ECAFCCEC-6A37-EF11-86D4-000D3A4E707E' ELSE ISNULL(@OwnerUserID, 'ECAFCCEC-6A37-EF11-86D4-000D3A4E707E') END,
+                ISNULL(@InvocationMode, 'Any'),
+                ISNULL(@ArtifactCreationMode, 'Always'),
+                @FunctionalRequirements,
+                @TechnicalDesign,
+                ISNULL(@InjectNotes, 1),
+                ISNULL(@MaxNotesToInject, 5),
+                ISNULL(@NoteInjectionStrategy, 'Relevant'),
+                ISNULL(@InjectExamples, 0),
+                ISNULL(@MaxExamplesToInject, 3),
+                ISNULL(@ExampleInjectionStrategy, 'Semantic'),
+                ISNULL(@IsRestricted, 0),
+                ISNULL(@MessageMode, 'None'),
+                @MaxMessages,
+                @AttachmentStorageProviderID,
+                @AttachmentRootPath,
+                @InlineStorageThresholdBytes,
+                @AgentTypePromptParams,
+                @ScopeConfig,
+                @NoteRetentionDays,
+                @ExampleRetentionDays,
+                ISNULL(@AutoArchiveEnabled, 1),
+                @RerankerConfiguration,
+                @CategoryID,
+                ISNULL(@AllowEphemeralClientTools, 1),
+                @DefaultStorageAccountID
+            )
+    END
+    ELSE
+    BEGIN
+        -- No value provided, let database use its default (e.g., NEWSEQUENTIALID())
+        INSERT INTO [${flyway:defaultSchema}].[AIAgent]
+            (
+                [Name],
+                [Description],
+                [LogoURL],
+                [ParentID],
+                [ExposeAsAction],
+                [ExecutionOrder],
+                [ExecutionMode],
+                [EnableContextCompression],
+                [ContextCompressionMessageThreshold],
+                [ContextCompressionPromptID],
+                [ContextCompressionMessageRetentionCount],
+                [TypeID],
+                [Status],
+                [DriverClass],
+                [IconClass],
+                [ModelSelectionMode],
+                [PayloadDownstreamPaths],
+                [PayloadUpstreamPaths],
+                [PayloadSelfReadPaths],
+                [PayloadSelfWritePaths],
+                [PayloadScope],
+                [FinalPayloadValidation],
+                [FinalPayloadValidationMode],
+                [FinalPayloadValidationMaxRetries],
+                [MaxCostPerRun],
+                [MaxTokensPerRun],
+                [MaxIterationsPerRun],
+                [MaxTimePerRun],
+                [MinExecutionsPerRun],
+                [MaxExecutionsPerRun],
+                [StartingPayloadValidation],
+                [StartingPayloadValidationMode],
+                [DefaultPromptEffortLevel],
+                [ChatHandlingOption],
+                [DefaultArtifactTypeID],
+                [OwnerUserID],
+                [InvocationMode],
+                [ArtifactCreationMode],
+                [FunctionalRequirements],
+                [TechnicalDesign],
+                [InjectNotes],
+                [MaxNotesToInject],
+                [NoteInjectionStrategy],
+                [InjectExamples],
+                [MaxExamplesToInject],
+                [ExampleInjectionStrategy],
+                [IsRestricted],
+                [MessageMode],
+                [MaxMessages],
+                [AttachmentStorageProviderID],
+                [AttachmentRootPath],
+                [InlineStorageThresholdBytes],
+                [AgentTypePromptParams],
+                [ScopeConfig],
+                [NoteRetentionDays],
+                [ExampleRetentionDays],
+                [AutoArchiveEnabled],
+                [RerankerConfiguration],
+                [CategoryID],
+                [AllowEphemeralClientTools],
+                [DefaultStorageAccountID]
+            )
+        OUTPUT INSERTED.[ID] INTO @InsertedRow
+        VALUES
+            (
+                @Name,
+                @Description,
+                @LogoURL,
+                @ParentID,
+                ISNULL(@ExposeAsAction, 0),
+                ISNULL(@ExecutionOrder, 0),
+                ISNULL(@ExecutionMode, 'Sequential'),
+                ISNULL(@EnableContextCompression, 0),
+                @ContextCompressionMessageThreshold,
+                @ContextCompressionPromptID,
+                @ContextCompressionMessageRetentionCount,
+                @TypeID,
+                ISNULL(@Status, 'Pending'),
+                @DriverClass,
+                @IconClass,
+                ISNULL(@ModelSelectionMode, 'Agent Type'),
+                ISNULL(@PayloadDownstreamPaths, '["*"]'),
+                ISNULL(@PayloadUpstreamPaths, '["*"]'),
+                @PayloadSelfReadPaths,
+                @PayloadSelfWritePaths,
+                @PayloadScope,
+                @FinalPayloadValidation,
+                ISNULL(@FinalPayloadValidationMode, 'Retry'),
+                ISNULL(@FinalPayloadValidationMaxRetries, 3),
+                @MaxCostPerRun,
+                @MaxTokensPerRun,
+                @MaxIterationsPerRun,
+                @MaxTimePerRun,
+                @MinExecutionsPerRun,
+                @MaxExecutionsPerRun,
+                @StartingPayloadValidation,
+                ISNULL(@StartingPayloadValidationMode, 'Fail'),
+                @DefaultPromptEffortLevel,
+                @ChatHandlingOption,
+                @DefaultArtifactTypeID,
+                CASE @OwnerUserID WHEN '00000000-0000-0000-0000-000000000000' THEN 'ECAFCCEC-6A37-EF11-86D4-000D3A4E707E' ELSE ISNULL(@OwnerUserID, 'ECAFCCEC-6A37-EF11-86D4-000D3A4E707E') END,
+                ISNULL(@InvocationMode, 'Any'),
+                ISNULL(@ArtifactCreationMode, 'Always'),
+                @FunctionalRequirements,
+                @TechnicalDesign,
+                ISNULL(@InjectNotes, 1),
+                ISNULL(@MaxNotesToInject, 5),
+                ISNULL(@NoteInjectionStrategy, 'Relevant'),
+                ISNULL(@InjectExamples, 0),
+                ISNULL(@MaxExamplesToInject, 3),
+                ISNULL(@ExampleInjectionStrategy, 'Semantic'),
+                ISNULL(@IsRestricted, 0),
+                ISNULL(@MessageMode, 'None'),
+                @MaxMessages,
+                @AttachmentStorageProviderID,
+                @AttachmentRootPath,
+                @InlineStorageThresholdBytes,
+                @AgentTypePromptParams,
+                @ScopeConfig,
+                @NoteRetentionDays,
+                @ExampleRetentionDays,
+                ISNULL(@AutoArchiveEnabled, 1),
+                @RerankerConfiguration,
+                @CategoryID,
+                ISNULL(@AllowEphemeralClientTools, 1),
+                @DefaultStorageAccountID
+            )
+    END
+    -- return the new record from the base view, which might have some calculated fields
+    SELECT * FROM [${flyway:defaultSchema}].[vwAIAgents] WHERE [ID] = (SELECT [ID] FROM @InsertedRow)
+END
+GO
+GRANT EXECUTE ON [${flyway:defaultSchema}].[spCreateAIAgent] TO [cdp_Developer], [cdp_Integration]
+    
+
+/* spCreate Permissions for MJ: AI Agents */
+
+GRANT EXECUTE ON [${flyway:defaultSchema}].[spCreateAIAgent] TO [cdp_Developer], [cdp_Integration]
+
+
+
+/* spUpdate SQL for MJ: AI Agents */
+-----------------------------------------------------------------
+-- SQL Code Generation
+-- Entity: MJ: AI Agents
+-- Item: spUpdateAIAgent
+--
+-- This was generated by the MemberJunction CodeGen tool.
+-- This file should NOT be edited by hand.
+-----------------------------------------------------------------
+
+------------------------------------------------------------
+----- UPDATE PROCEDURE FOR AIAgent
+------------------------------------------------------------
+IF OBJECT_ID('[${flyway:defaultSchema}].[spUpdateAIAgent]', 'P') IS NOT NULL
+    DROP PROCEDURE [${flyway:defaultSchema}].[spUpdateAIAgent];
+GO
+
+CREATE PROCEDURE [${flyway:defaultSchema}].[spUpdateAIAgent]
+    @ID uniqueidentifier,
+    @Name nvarchar(255),
+    @Description nvarchar(MAX),
+    @LogoURL nvarchar(255),
+    @ParentID uniqueidentifier,
+    @ExposeAsAction bit,
+    @ExecutionOrder int,
+    @ExecutionMode nvarchar(20),
+    @EnableContextCompression bit,
+    @ContextCompressionMessageThreshold int,
+    @ContextCompressionPromptID uniqueidentifier,
+    @ContextCompressionMessageRetentionCount int,
+    @TypeID uniqueidentifier,
+    @Status nvarchar(20),
+    @DriverClass nvarchar(255),
+    @IconClass nvarchar(100),
+    @ModelSelectionMode nvarchar(50),
+    @PayloadDownstreamPaths nvarchar(MAX),
+    @PayloadUpstreamPaths nvarchar(MAX),
+    @PayloadSelfReadPaths nvarchar(MAX),
+    @PayloadSelfWritePaths nvarchar(MAX),
+    @PayloadScope nvarchar(MAX),
+    @FinalPayloadValidation nvarchar(MAX),
+    @FinalPayloadValidationMode nvarchar(25),
+    @FinalPayloadValidationMaxRetries int,
+    @MaxCostPerRun decimal(10, 4),
+    @MaxTokensPerRun int,
+    @MaxIterationsPerRun int,
+    @MaxTimePerRun int,
+    @MinExecutionsPerRun int,
+    @MaxExecutionsPerRun int,
+    @StartingPayloadValidation nvarchar(MAX),
+    @StartingPayloadValidationMode nvarchar(25),
+    @DefaultPromptEffortLevel int,
+    @ChatHandlingOption nvarchar(30),
+    @DefaultArtifactTypeID uniqueidentifier,
+    @OwnerUserID uniqueidentifier,
+    @InvocationMode nvarchar(20),
+    @ArtifactCreationMode nvarchar(20),
+    @FunctionalRequirements nvarchar(MAX),
+    @TechnicalDesign nvarchar(MAX),
+    @InjectNotes bit,
+    @MaxNotesToInject int,
+    @NoteInjectionStrategy nvarchar(20),
+    @InjectExamples bit,
+    @MaxExamplesToInject int,
+    @ExampleInjectionStrategy nvarchar(20),
+    @IsRestricted bit,
+    @MessageMode nvarchar(50),
+    @MaxMessages int,
+    @AttachmentStorageProviderID uniqueidentifier,
+    @AttachmentRootPath nvarchar(500),
+    @InlineStorageThresholdBytes int,
+    @AgentTypePromptParams nvarchar(MAX),
+    @ScopeConfig nvarchar(MAX),
+    @NoteRetentionDays int,
+    @ExampleRetentionDays int,
+    @AutoArchiveEnabled bit,
+    @RerankerConfiguration nvarchar(MAX),
+    @CategoryID uniqueidentifier,
+    @AllowEphemeralClientTools bit,
+    @DefaultStorageAccountID uniqueidentifier
+AS
+BEGIN
+    SET NOCOUNT ON;
+    UPDATE
+        [${flyway:defaultSchema}].[AIAgent]
+    SET
+        [Name] = @Name,
+        [Description] = @Description,
+        [LogoURL] = @LogoURL,
+        [ParentID] = @ParentID,
+        [ExposeAsAction] = @ExposeAsAction,
+        [ExecutionOrder] = @ExecutionOrder,
+        [ExecutionMode] = @ExecutionMode,
+        [EnableContextCompression] = @EnableContextCompression,
+        [ContextCompressionMessageThreshold] = @ContextCompressionMessageThreshold,
+        [ContextCompressionPromptID] = @ContextCompressionPromptID,
+        [ContextCompressionMessageRetentionCount] = @ContextCompressionMessageRetentionCount,
+        [TypeID] = @TypeID,
+        [Status] = @Status,
+        [DriverClass] = @DriverClass,
+        [IconClass] = @IconClass,
+        [ModelSelectionMode] = @ModelSelectionMode,
+        [PayloadDownstreamPaths] = @PayloadDownstreamPaths,
+        [PayloadUpstreamPaths] = @PayloadUpstreamPaths,
+        [PayloadSelfReadPaths] = @PayloadSelfReadPaths,
+        [PayloadSelfWritePaths] = @PayloadSelfWritePaths,
+        [PayloadScope] = @PayloadScope,
+        [FinalPayloadValidation] = @FinalPayloadValidation,
+        [FinalPayloadValidationMode] = @FinalPayloadValidationMode,
+        [FinalPayloadValidationMaxRetries] = @FinalPayloadValidationMaxRetries,
+        [MaxCostPerRun] = @MaxCostPerRun,
+        [MaxTokensPerRun] = @MaxTokensPerRun,
+        [MaxIterationsPerRun] = @MaxIterationsPerRun,
+        [MaxTimePerRun] = @MaxTimePerRun,
+        [MinExecutionsPerRun] = @MinExecutionsPerRun,
+        [MaxExecutionsPerRun] = @MaxExecutionsPerRun,
+        [StartingPayloadValidation] = @StartingPayloadValidation,
+        [StartingPayloadValidationMode] = @StartingPayloadValidationMode,
+        [DefaultPromptEffortLevel] = @DefaultPromptEffortLevel,
+        [ChatHandlingOption] = @ChatHandlingOption,
+        [DefaultArtifactTypeID] = @DefaultArtifactTypeID,
+        [OwnerUserID] = @OwnerUserID,
+        [InvocationMode] = @InvocationMode,
+        [ArtifactCreationMode] = @ArtifactCreationMode,
+        [FunctionalRequirements] = @FunctionalRequirements,
+        [TechnicalDesign] = @TechnicalDesign,
+        [InjectNotes] = @InjectNotes,
+        [MaxNotesToInject] = @MaxNotesToInject,
+        [NoteInjectionStrategy] = @NoteInjectionStrategy,
+        [InjectExamples] = @InjectExamples,
+        [MaxExamplesToInject] = @MaxExamplesToInject,
+        [ExampleInjectionStrategy] = @ExampleInjectionStrategy,
+        [IsRestricted] = @IsRestricted,
+        [MessageMode] = @MessageMode,
+        [MaxMessages] = @MaxMessages,
+        [AttachmentStorageProviderID] = @AttachmentStorageProviderID,
+        [AttachmentRootPath] = @AttachmentRootPath,
+        [InlineStorageThresholdBytes] = @InlineStorageThresholdBytes,
+        [AgentTypePromptParams] = @AgentTypePromptParams,
+        [ScopeConfig] = @ScopeConfig,
+        [NoteRetentionDays] = @NoteRetentionDays,
+        [ExampleRetentionDays] = @ExampleRetentionDays,
+        [AutoArchiveEnabled] = @AutoArchiveEnabled,
+        [RerankerConfiguration] = @RerankerConfiguration,
+        [CategoryID] = @CategoryID,
+        [AllowEphemeralClientTools] = @AllowEphemeralClientTools,
+        [DefaultStorageAccountID] = @DefaultStorageAccountID
+    WHERE
+        [ID] = @ID
+
+    -- Check if the update was successful
+    IF @@ROWCOUNT = 0
+        -- Nothing was updated, return no rows, but column structure from base view intact, semantically correct this way.
+        SELECT TOP 0 * FROM [${flyway:defaultSchema}].[vwAIAgents] WHERE 1=0
+    ELSE
+        -- Return the updated record so the caller can see the updated values and any calculated fields
+        SELECT
+                                        *
+                                    FROM
+                                        [${flyway:defaultSchema}].[vwAIAgents]
+                                    WHERE
+                                        [ID] = @ID
+                                    
+END
+GO
+
+GRANT EXECUTE ON [${flyway:defaultSchema}].[spUpdateAIAgent] TO [cdp_Developer], [cdp_Integration]
+GO
+
+------------------------------------------------------------
+----- TRIGGER FOR __mj_UpdatedAt field for the AIAgent table
+------------------------------------------------------------
+IF OBJECT_ID('[${flyway:defaultSchema}].[trgUpdateAIAgent]', 'TR') IS NOT NULL
+    DROP TRIGGER [${flyway:defaultSchema}].[trgUpdateAIAgent];
+GO
+CREATE TRIGGER [${flyway:defaultSchema}].trgUpdateAIAgent
+ON [${flyway:defaultSchema}].[AIAgent]
+AFTER UPDATE
+AS
+BEGIN
+    SET NOCOUNT ON;
+    UPDATE
+        [${flyway:defaultSchema}].[AIAgent]
+    SET
+        __mj_UpdatedAt = GETUTCDATE()
+    FROM
+        [${flyway:defaultSchema}].[AIAgent] AS _organicTable
+    INNER JOIN
+        INSERTED AS I ON
+        _organicTable.[ID] = I.[ID];
+END;
+GO
+        
+
+/* spUpdate Permissions for MJ: AI Agents */
+
+GRANT EXECUTE ON [${flyway:defaultSchema}].[spUpdateAIAgent] TO [cdp_Developer], [cdp_Integration]
+
+
+
+/* spDelete SQL for MJ: AI Agents */
+-----------------------------------------------------------------
+-- SQL Code Generation
+-- Entity: MJ: AI Agents
+-- Item: spDeleteAIAgent
+--
+-- This was generated by the MemberJunction CodeGen tool.
+-- This file should NOT be edited by hand.
+-----------------------------------------------------------------
+
+------------------------------------------------------------
+----- DELETE PROCEDURE FOR AIAgent
+------------------------------------------------------------
+IF OBJECT_ID('[${flyway:defaultSchema}].[spDeleteAIAgent]', 'P') IS NOT NULL
+    DROP PROCEDURE [${flyway:defaultSchema}].[spDeleteAIAgent];
+GO
+
+CREATE PROCEDURE [${flyway:defaultSchema}].[spDeleteAIAgent]
+    @ID uniqueidentifier
+AS
+BEGIN
+    SET NOCOUNT ON;
+    -- Cascade update on AIAgentAction using cursor to call spUpdateAIAgentAction
+    DECLARE @MJAIAgentActions_AgentIDID uniqueidentifier
+    DECLARE @MJAIAgentActions_AgentID_AgentID uniqueidentifier
+    DECLARE @MJAIAgentActions_AgentID_ActionID uniqueidentifier
+    DECLARE @MJAIAgentActions_AgentID_Status nvarchar(15)
+    DECLARE @MJAIAgentActions_AgentID_MinExecutionsPerRun int
+    DECLARE @MJAIAgentActions_AgentID_MaxExecutionsPerRun int
+    DECLARE @MJAIAgentActions_AgentID_ResultExpirationTurns int
+    DECLARE @MJAIAgentActions_AgentID_ResultExpirationMode nvarchar(20)
+    DECLARE @MJAIAgentActions_AgentID_CompactMode nvarchar(20)
+    DECLARE @MJAIAgentActions_AgentID_CompactLength int
+    DECLARE @MJAIAgentActions_AgentID_CompactPromptID uniqueidentifier
+    DECLARE cascade_update_MJAIAgentActions_AgentID_cursor CURSOR FOR
+        SELECT [ID], [AgentID], [ActionID], [Status], [MinExecutionsPerRun], [MaxExecutionsPerRun], [ResultExpirationTurns], [ResultExpirationMode], [CompactMode], [CompactLength], [CompactPromptID]
+        FROM [${flyway:defaultSchema}].[AIAgentAction]
+        WHERE [AgentID] = @ID
+
+    OPEN cascade_update_MJAIAgentActions_AgentID_cursor
+    FETCH NEXT FROM cascade_update_MJAIAgentActions_AgentID_cursor INTO @MJAIAgentActions_AgentIDID, @MJAIAgentActions_AgentID_AgentID, @MJAIAgentActions_AgentID_ActionID, @MJAIAgentActions_AgentID_Status, @MJAIAgentActions_AgentID_MinExecutionsPerRun, @MJAIAgentActions_AgentID_MaxExecutionsPerRun, @MJAIAgentActions_AgentID_ResultExpirationTurns, @MJAIAgentActions_AgentID_ResultExpirationMode, @MJAIAgentActions_AgentID_CompactMode, @MJAIAgentActions_AgentID_CompactLength, @MJAIAgentActions_AgentID_CompactPromptID
+
+    WHILE @@FETCH_STATUS = 0
+    BEGIN
+        -- Set the FK field to NULL
+        SET @MJAIAgentActions_AgentID_AgentID = NULL
+
+        -- Call the update SP for the related entity
+        EXEC [${flyway:defaultSchema}].[spUpdateAIAgentAction] @ID = @MJAIAgentActions_AgentIDID, @AgentID = @MJAIAgentActions_AgentID_AgentID, @ActionID = @MJAIAgentActions_AgentID_ActionID, @Status = @MJAIAgentActions_AgentID_Status, @MinExecutionsPerRun = @MJAIAgentActions_AgentID_MinExecutionsPerRun, @MaxExecutionsPerRun = @MJAIAgentActions_AgentID_MaxExecutionsPerRun, @ResultExpirationTurns = @MJAIAgentActions_AgentID_ResultExpirationTurns, @ResultExpirationMode = @MJAIAgentActions_AgentID_ResultExpirationMode, @CompactMode = @MJAIAgentActions_AgentID_CompactMode, @CompactLength = @MJAIAgentActions_AgentID_CompactLength, @CompactPromptID = @MJAIAgentActions_AgentID_CompactPromptID
+
+        FETCH NEXT FROM cascade_update_MJAIAgentActions_AgentID_cursor INTO @MJAIAgentActions_AgentIDID, @MJAIAgentActions_AgentID_AgentID, @MJAIAgentActions_AgentID_ActionID, @MJAIAgentActions_AgentID_Status, @MJAIAgentActions_AgentID_MinExecutionsPerRun, @MJAIAgentActions_AgentID_MaxExecutionsPerRun, @MJAIAgentActions_AgentID_ResultExpirationTurns, @MJAIAgentActions_AgentID_ResultExpirationMode, @MJAIAgentActions_AgentID_CompactMode, @MJAIAgentActions_AgentID_CompactLength, @MJAIAgentActions_AgentID_CompactPromptID
+    END
+
+    CLOSE cascade_update_MJAIAgentActions_AgentID_cursor
+    DEALLOCATE cascade_update_MJAIAgentActions_AgentID_cursor
+    
+    -- Cascade delete from AIAgentArtifactType using cursor to call spDeleteAIAgentArtifactType
+    DECLARE @MJAIAgentArtifactTypes_AgentIDID uniqueidentifier
+    DECLARE cascade_delete_MJAIAgentArtifactTypes_AgentID_cursor CURSOR FOR 
+        SELECT [ID]
+        FROM [${flyway:defaultSchema}].[AIAgentArtifactType]
+        WHERE [AgentID] = @ID
+    
+    OPEN cascade_delete_MJAIAgentArtifactTypes_AgentID_cursor
+    FETCH NEXT FROM cascade_delete_MJAIAgentArtifactTypes_AgentID_cursor INTO @MJAIAgentArtifactTypes_AgentIDID
+    
+    WHILE @@FETCH_STATUS = 0
+    BEGIN
+        EXEC [${flyway:defaultSchema}].[spDeleteAIAgentArtifactType] @ID = @MJAIAgentArtifactTypes_AgentIDID
+        
+        FETCH NEXT FROM cascade_delete_MJAIAgentArtifactTypes_AgentID_cursor INTO @MJAIAgentArtifactTypes_AgentIDID
+    END
+    
+    CLOSE cascade_delete_MJAIAgentArtifactTypes_AgentID_cursor
+    DEALLOCATE cascade_delete_MJAIAgentArtifactTypes_AgentID_cursor
+    
+    -- Cascade delete from AIAgentClientTool using cursor to call spDeleteAIAgentClientTool
+    DECLARE @MJAIAgentClientTools_AgentIDID uniqueidentifier
+    DECLARE cascade_delete_MJAIAgentClientTools_AgentID_cursor CURSOR FOR 
+        SELECT [ID]
+        FROM [${flyway:defaultSchema}].[AIAgentClientTool]
+        WHERE [AgentID] = @ID
+    
+    OPEN cascade_delete_MJAIAgentClientTools_AgentID_cursor
+    FETCH NEXT FROM cascade_delete_MJAIAgentClientTools_AgentID_cursor INTO @MJAIAgentClientTools_AgentIDID
+    
+    WHILE @@FETCH_STATUS = 0
+    BEGIN
+        EXEC [${flyway:defaultSchema}].[spDeleteAIAgentClientTool] @ID = @MJAIAgentClientTools_AgentIDID
+        
+        FETCH NEXT FROM cascade_delete_MJAIAgentClientTools_AgentID_cursor INTO @MJAIAgentClientTools_AgentIDID
+    END
+    
+    CLOSE cascade_delete_MJAIAgentClientTools_AgentID_cursor
+    DEALLOCATE cascade_delete_MJAIAgentClientTools_AgentID_cursor
+    
+    -- Cascade delete from AIAgentConfiguration using cursor to call spDeleteAIAgentConfiguration
+    DECLARE @MJAIAgentConfigurations_AgentIDID uniqueidentifier
+    DECLARE cascade_delete_MJAIAgentConfigurations_AgentID_cursor CURSOR FOR 
+        SELECT [ID]
+        FROM [${flyway:defaultSchema}].[AIAgentConfiguration]
+        WHERE [AgentID] = @ID
+    
+    OPEN cascade_delete_MJAIAgentConfigurations_AgentID_cursor
+    FETCH NEXT FROM cascade_delete_MJAIAgentConfigurations_AgentID_cursor INTO @MJAIAgentConfigurations_AgentIDID
+    
+    WHILE @@FETCH_STATUS = 0
+    BEGIN
+        EXEC [${flyway:defaultSchema}].[spDeleteAIAgentConfiguration] @ID = @MJAIAgentConfigurations_AgentIDID
+        
+        FETCH NEXT FROM cascade_delete_MJAIAgentConfigurations_AgentID_cursor INTO @MJAIAgentConfigurations_AgentIDID
+    END
+    
+    CLOSE cascade_delete_MJAIAgentConfigurations_AgentID_cursor
+    DEALLOCATE cascade_delete_MJAIAgentConfigurations_AgentID_cursor
+    
+    -- Cascade delete from AIAgentDataSource using cursor to call spDeleteAIAgentDataSource
+    DECLARE @MJAIAgentDataSources_AgentIDID uniqueidentifier
+    DECLARE cascade_delete_MJAIAgentDataSources_AgentID_cursor CURSOR FOR 
+        SELECT [ID]
+        FROM [${flyway:defaultSchema}].[AIAgentDataSource]
+        WHERE [AgentID] = @ID
+    
+    OPEN cascade_delete_MJAIAgentDataSources_AgentID_cursor
+    FETCH NEXT FROM cascade_delete_MJAIAgentDataSources_AgentID_cursor INTO @MJAIAgentDataSources_AgentIDID
+    
+    WHILE @@FETCH_STATUS = 0
+    BEGIN
+        EXEC [${flyway:defaultSchema}].[spDeleteAIAgentDataSource] @ID = @MJAIAgentDataSources_AgentIDID
+        
+        FETCH NEXT FROM cascade_delete_MJAIAgentDataSources_AgentID_cursor INTO @MJAIAgentDataSources_AgentIDID
+    END
+    
+    CLOSE cascade_delete_MJAIAgentDataSources_AgentID_cursor
+    DEALLOCATE cascade_delete_MJAIAgentDataSources_AgentID_cursor
+    
+    -- Cascade delete from AIAgentExample using cursor to call spDeleteAIAgentExample
+    DECLARE @MJAIAgentExamples_AgentIDID uniqueidentifier
+    DECLARE cascade_delete_MJAIAgentExamples_AgentID_cursor CURSOR FOR 
+        SELECT [ID]
+        FROM [${flyway:defaultSchema}].[AIAgentExample]
+        WHERE [AgentID] = @ID
+    
+    OPEN cascade_delete_MJAIAgentExamples_AgentID_cursor
+    FETCH NEXT FROM cascade_delete_MJAIAgentExamples_AgentID_cursor INTO @MJAIAgentExamples_AgentIDID
+    
+    WHILE @@FETCH_STATUS = 0
+    BEGIN
+        EXEC [${flyway:defaultSchema}].[spDeleteAIAgentExample] @ID = @MJAIAgentExamples_AgentIDID
+        
+        FETCH NEXT FROM cascade_delete_MJAIAgentExamples_AgentID_cursor INTO @MJAIAgentExamples_AgentIDID
+    END
+    
+    CLOSE cascade_delete_MJAIAgentExamples_AgentID_cursor
+    DEALLOCATE cascade_delete_MJAIAgentExamples_AgentID_cursor
+    
+    -- Cascade delete from AIAgentLearningCycle using cursor to call spDeleteAIAgentLearningCycle
+    DECLARE @MJAIAgentLearningCycles_AgentIDID uniqueidentifier
+    DECLARE cascade_delete_MJAIAgentLearningCycles_AgentID_cursor CURSOR FOR 
+        SELECT [ID]
+        FROM [${flyway:defaultSchema}].[AIAgentLearningCycle]
+        WHERE [AgentID] = @ID
+    
+    OPEN cascade_delete_MJAIAgentLearningCycles_AgentID_cursor
+    FETCH NEXT FROM cascade_delete_MJAIAgentLearningCycles_AgentID_cursor INTO @MJAIAgentLearningCycles_AgentIDID
+    
+    WHILE @@FETCH_STATUS = 0
+    BEGIN
+        EXEC [${flyway:defaultSchema}].[spDeleteAIAgentLearningCycle] @ID = @MJAIAgentLearningCycles_AgentIDID
+        
+        FETCH NEXT FROM cascade_delete_MJAIAgentLearningCycles_AgentID_cursor INTO @MJAIAgentLearningCycles_AgentIDID
+    END
+    
+    CLOSE cascade_delete_MJAIAgentLearningCycles_AgentID_cursor
+    DEALLOCATE cascade_delete_MJAIAgentLearningCycles_AgentID_cursor
+    
+    -- Cascade delete from AIAgentModality using cursor to call spDeleteAIAgentModality
+    DECLARE @MJAIAgentModalities_AgentIDID uniqueidentifier
+    DECLARE cascade_delete_MJAIAgentModalities_AgentID_cursor CURSOR FOR 
+        SELECT [ID]
+        FROM [${flyway:defaultSchema}].[AIAgentModality]
+        WHERE [AgentID] = @ID
+    
+    OPEN cascade_delete_MJAIAgentModalities_AgentID_cursor
+    FETCH NEXT FROM cascade_delete_MJAIAgentModalities_AgentID_cursor INTO @MJAIAgentModalities_AgentIDID
+    
+    WHILE @@FETCH_STATUS = 0
+    BEGIN
+        EXEC [${flyway:defaultSchema}].[spDeleteAIAgentModality] @ID = @MJAIAgentModalities_AgentIDID
+        
+        FETCH NEXT FROM cascade_delete_MJAIAgentModalities_AgentID_cursor INTO @MJAIAgentModalities_AgentIDID
+    END
+    
+    CLOSE cascade_delete_MJAIAgentModalities_AgentID_cursor
+    DEALLOCATE cascade_delete_MJAIAgentModalities_AgentID_cursor
+    
+    -- Cascade update on AIAgentModel using cursor to call spUpdateAIAgentModel
+    DECLARE @MJAIAgentModels_AgentIDID uniqueidentifier
+    DECLARE @MJAIAgentModels_AgentID_AgentID uniqueidentifier
+    DECLARE @MJAIAgentModels_AgentID_ModelID uniqueidentifier
+    DECLARE @MJAIAgentModels_AgentID_Active bit
+    DECLARE @MJAIAgentModels_AgentID_Priority int
+    DECLARE cascade_update_MJAIAgentModels_AgentID_cursor CURSOR FOR
+        SELECT [ID], [AgentID], [ModelID], [Active], [Priority]
+        FROM [${flyway:defaultSchema}].[AIAgentModel]
+        WHERE [AgentID] = @ID
+
+    OPEN cascade_update_MJAIAgentModels_AgentID_cursor
+    FETCH NEXT FROM cascade_update_MJAIAgentModels_AgentID_cursor INTO @MJAIAgentModels_AgentIDID, @MJAIAgentModels_AgentID_AgentID, @MJAIAgentModels_AgentID_ModelID, @MJAIAgentModels_AgentID_Active, @MJAIAgentModels_AgentID_Priority
+
+    WHILE @@FETCH_STATUS = 0
+    BEGIN
+        -- Set the FK field to NULL
+        SET @MJAIAgentModels_AgentID_AgentID = NULL
+
+        -- Call the update SP for the related entity
+        EXEC [${flyway:defaultSchema}].[spUpdateAIAgentModel] @ID = @MJAIAgentModels_AgentIDID, @AgentID = @MJAIAgentModels_AgentID_AgentID, @ModelID = @MJAIAgentModels_AgentID_ModelID, @Active = @MJAIAgentModels_AgentID_Active, @Priority = @MJAIAgentModels_AgentID_Priority
+
+        FETCH NEXT FROM cascade_update_MJAIAgentModels_AgentID_cursor INTO @MJAIAgentModels_AgentIDID, @MJAIAgentModels_AgentID_AgentID, @MJAIAgentModels_AgentID_ModelID, @MJAIAgentModels_AgentID_Active, @MJAIAgentModels_AgentID_Priority
+    END
+
+    CLOSE cascade_update_MJAIAgentModels_AgentID_cursor
+    DEALLOCATE cascade_update_MJAIAgentModels_AgentID_cursor
+    
+    -- Cascade update on AIAgentNote using cursor to call spUpdateAIAgentNote
+    DECLARE @MJAIAgentNotes_AgentIDID uniqueidentifier
+    DECLARE @MJAIAgentNotes_AgentID_AgentID uniqueidentifier
+    DECLARE @MJAIAgentNotes_AgentID_AgentNoteTypeID uniqueidentifier
+    DECLARE @MJAIAgentNotes_AgentID_Note nvarchar(MAX)
+    DECLARE @MJAIAgentNotes_AgentID_UserID uniqueidentifier
+    DECLARE @MJAIAgentNotes_AgentID_Type nvarchar(20)
+    DECLARE @MJAIAgentNotes_AgentID_IsAutoGenerated bit
+    DECLARE @MJAIAgentNotes_AgentID_Comments nvarchar(MAX)
+    DECLARE @MJAIAgentNotes_AgentID_Status nvarchar(20)
+    DECLARE @MJAIAgentNotes_AgentID_SourceConversationID uniqueidentifier
+    DECLARE @MJAIAgentNotes_AgentID_SourceConversationDetailID uniqueidentifier
+    DECLARE @MJAIAgentNotes_AgentID_SourceAIAgentRunID uniqueidentifier
+    DECLARE @MJAIAgentNotes_AgentID_CompanyID uniqueidentifier
+    DECLARE @MJAIAgentNotes_AgentID_EmbeddingVector nvarchar(MAX)
+    DECLARE @MJAIAgentNotes_AgentID_EmbeddingModelID uniqueidentifier
+    DECLARE @MJAIAgentNotes_AgentID_PrimaryScopeEntityID uniqueidentifier
+    DECLARE @MJAIAgentNotes_AgentID_PrimaryScopeRecordID nvarchar(100)
+    DECLARE @MJAIAgentNotes_AgentID_SecondaryScopes nvarchar(MAX)
+    DECLARE @MJAIAgentNotes_AgentID_LastAccessedAt datetimeoffset
+    DECLARE @MJAIAgentNotes_AgentID_AccessCount int
+    DECLARE @MJAIAgentNotes_AgentID_ExpiresAt datetimeoffset
+    DECLARE cascade_update_MJAIAgentNotes_AgentID_cursor CURSOR FOR
+        SELECT [ID], [AgentID], [AgentNoteTypeID], [Note], [UserID], [Type], [IsAutoGenerated], [Comments], [Status], [SourceConversationID], [SourceConversationDetailID], [SourceAIAgentRunID], [CompanyID], [EmbeddingVector], [EmbeddingModelID], [PrimaryScopeEntityID], [PrimaryScopeRecordID], [SecondaryScopes], [LastAccessedAt], [AccessCount], [ExpiresAt]
+        FROM [${flyway:defaultSchema}].[AIAgentNote]
+        WHERE [AgentID] = @ID
+
+    OPEN cascade_update_MJAIAgentNotes_AgentID_cursor
+    FETCH NEXT FROM cascade_update_MJAIAgentNotes_AgentID_cursor INTO @MJAIAgentNotes_AgentIDID, @MJAIAgentNotes_AgentID_AgentID, @MJAIAgentNotes_AgentID_AgentNoteTypeID, @MJAIAgentNotes_AgentID_Note, @MJAIAgentNotes_AgentID_UserID, @MJAIAgentNotes_AgentID_Type, @MJAIAgentNotes_AgentID_IsAutoGenerated, @MJAIAgentNotes_AgentID_Comments, @MJAIAgentNotes_AgentID_Status, @MJAIAgentNotes_AgentID_SourceConversationID, @MJAIAgentNotes_AgentID_SourceConversationDetailID, @MJAIAgentNotes_AgentID_SourceAIAgentRunID, @MJAIAgentNotes_AgentID_CompanyID, @MJAIAgentNotes_AgentID_EmbeddingVector, @MJAIAgentNotes_AgentID_EmbeddingModelID, @MJAIAgentNotes_AgentID_PrimaryScopeEntityID, @MJAIAgentNotes_AgentID_PrimaryScopeRecordID, @MJAIAgentNotes_AgentID_SecondaryScopes, @MJAIAgentNotes_AgentID_LastAccessedAt, @MJAIAgentNotes_AgentID_AccessCount, @MJAIAgentNotes_AgentID_ExpiresAt
+
+    WHILE @@FETCH_STATUS = 0
+    BEGIN
+        -- Set the FK field to NULL
+        SET @MJAIAgentNotes_AgentID_AgentID = NULL
+
+        -- Call the update SP for the related entity
+        EXEC [${flyway:defaultSchema}].[spUpdateAIAgentNote] @ID = @MJAIAgentNotes_AgentIDID, @AgentID = @MJAIAgentNotes_AgentID_AgentID, @AgentNoteTypeID = @MJAIAgentNotes_AgentID_AgentNoteTypeID, @Note = @MJAIAgentNotes_AgentID_Note, @UserID = @MJAIAgentNotes_AgentID_UserID, @Type = @MJAIAgentNotes_AgentID_Type, @IsAutoGenerated = @MJAIAgentNotes_AgentID_IsAutoGenerated, @Comments = @MJAIAgentNotes_AgentID_Comments, @Status = @MJAIAgentNotes_AgentID_Status, @SourceConversationID = @MJAIAgentNotes_AgentID_SourceConversationID, @SourceConversationDetailID = @MJAIAgentNotes_AgentID_SourceConversationDetailID, @SourceAIAgentRunID = @MJAIAgentNotes_AgentID_SourceAIAgentRunID, @CompanyID = @MJAIAgentNotes_AgentID_CompanyID, @EmbeddingVector = @MJAIAgentNotes_AgentID_EmbeddingVector, @EmbeddingModelID = @MJAIAgentNotes_AgentID_EmbeddingModelID, @PrimaryScopeEntityID = @MJAIAgentNotes_AgentID_PrimaryScopeEntityID, @PrimaryScopeRecordID = @MJAIAgentNotes_AgentID_PrimaryScopeRecordID, @SecondaryScopes = @MJAIAgentNotes_AgentID_SecondaryScopes, @LastAccessedAt = @MJAIAgentNotes_AgentID_LastAccessedAt, @AccessCount = @MJAIAgentNotes_AgentID_AccessCount, @ExpiresAt = @MJAIAgentNotes_AgentID_ExpiresAt
+
+        FETCH NEXT FROM cascade_update_MJAIAgentNotes_AgentID_cursor INTO @MJAIAgentNotes_AgentIDID, @MJAIAgentNotes_AgentID_AgentID, @MJAIAgentNotes_AgentID_AgentNoteTypeID, @MJAIAgentNotes_AgentID_Note, @MJAIAgentNotes_AgentID_UserID, @MJAIAgentNotes_AgentID_Type, @MJAIAgentNotes_AgentID_IsAutoGenerated, @MJAIAgentNotes_AgentID_Comments, @MJAIAgentNotes_AgentID_Status, @MJAIAgentNotes_AgentID_SourceConversationID, @MJAIAgentNotes_AgentID_SourceConversationDetailID, @MJAIAgentNotes_AgentID_SourceAIAgentRunID, @MJAIAgentNotes_AgentID_CompanyID, @MJAIAgentNotes_AgentID_EmbeddingVector, @MJAIAgentNotes_AgentID_EmbeddingModelID, @MJAIAgentNotes_AgentID_PrimaryScopeEntityID, @MJAIAgentNotes_AgentID_PrimaryScopeRecordID, @MJAIAgentNotes_AgentID_SecondaryScopes, @MJAIAgentNotes_AgentID_LastAccessedAt, @MJAIAgentNotes_AgentID_AccessCount, @MJAIAgentNotes_AgentID_ExpiresAt
+    END
+
+    CLOSE cascade_update_MJAIAgentNotes_AgentID_cursor
+    DEALLOCATE cascade_update_MJAIAgentNotes_AgentID_cursor
+    
+    -- Cascade delete from AIAgentPermission using cursor to call spDeleteAIAgentPermission
+    DECLARE @MJAIAgentPermissions_AgentIDID uniqueidentifier
+    DECLARE cascade_delete_MJAIAgentPermissions_AgentID_cursor CURSOR FOR 
+        SELECT [ID]
+        FROM [${flyway:defaultSchema}].[AIAgentPermission]
+        WHERE [AgentID] = @ID
+    
+    OPEN cascade_delete_MJAIAgentPermissions_AgentID_cursor
+    FETCH NEXT FROM cascade_delete_MJAIAgentPermissions_AgentID_cursor INTO @MJAIAgentPermissions_AgentIDID
+    
+    WHILE @@FETCH_STATUS = 0
+    BEGIN
+        EXEC [${flyway:defaultSchema}].[spDeleteAIAgentPermission] @ID = @MJAIAgentPermissions_AgentIDID
+        
+        FETCH NEXT FROM cascade_delete_MJAIAgentPermissions_AgentID_cursor INTO @MJAIAgentPermissions_AgentIDID
+    END
+    
+    CLOSE cascade_delete_MJAIAgentPermissions_AgentID_cursor
+    DEALLOCATE cascade_delete_MJAIAgentPermissions_AgentID_cursor
+    
+    -- Cascade delete from AIAgentPrompt using cursor to call spDeleteAIAgentPrompt
+    DECLARE @MJAIAgentPrompts_AgentIDID uniqueidentifier
+    DECLARE cascade_delete_MJAIAgentPrompts_AgentID_cursor CURSOR FOR 
+        SELECT [ID]
+        FROM [${flyway:defaultSchema}].[AIAgentPrompt]
+        WHERE [AgentID] = @ID
+    
+    OPEN cascade_delete_MJAIAgentPrompts_AgentID_cursor
+    FETCH NEXT FROM cascade_delete_MJAIAgentPrompts_AgentID_cursor INTO @MJAIAgentPrompts_AgentIDID
+    
+    WHILE @@FETCH_STATUS = 0
+    BEGIN
+        EXEC [${flyway:defaultSchema}].[spDeleteAIAgentPrompt] @ID = @MJAIAgentPrompts_AgentIDID
+        
+        FETCH NEXT FROM cascade_delete_MJAIAgentPrompts_AgentID_cursor INTO @MJAIAgentPrompts_AgentIDID
+    END
+    
+    CLOSE cascade_delete_MJAIAgentPrompts_AgentID_cursor
+    DEALLOCATE cascade_delete_MJAIAgentPrompts_AgentID_cursor
+    
+    -- Cascade delete from AIAgentRelationship using cursor to call spDeleteAIAgentRelationship
+    DECLARE @MJAIAgentRelationships_AgentIDID uniqueidentifier
+    DECLARE cascade_delete_MJAIAgentRelationships_AgentID_cursor CURSOR FOR 
+        SELECT [ID]
+        FROM [${flyway:defaultSchema}].[AIAgentRelationship]
+        WHERE [AgentID] = @ID
+    
+    OPEN cascade_delete_MJAIAgentRelationships_AgentID_cursor
+    FETCH NEXT FROM cascade_delete_MJAIAgentRelationships_AgentID_cursor INTO @MJAIAgentRelationships_AgentIDID
+    
+    WHILE @@FETCH_STATUS = 0
+    BEGIN
+        EXEC [${flyway:defaultSchema}].[spDeleteAIAgentRelationship] @ID = @MJAIAgentRelationships_AgentIDID
+        
+        FETCH NEXT FROM cascade_delete_MJAIAgentRelationships_AgentID_cursor INTO @MJAIAgentRelationships_AgentIDID
+    END
+    
+    CLOSE cascade_delete_MJAIAgentRelationships_AgentID_cursor
+    DEALLOCATE cascade_delete_MJAIAgentRelationships_AgentID_cursor
+    
+    -- Cascade delete from AIAgentRelationship using cursor to call spDeleteAIAgentRelationship
+    DECLARE @MJAIAgentRelationships_SubAgentIDID uniqueidentifier
+    DECLARE cascade_delete_MJAIAgentRelationships_SubAgentID_cursor CURSOR FOR 
+        SELECT [ID]
+        FROM [${flyway:defaultSchema}].[AIAgentRelationship]
+        WHERE [SubAgentID] = @ID
+    
+    OPEN cascade_delete_MJAIAgentRelationships_SubAgentID_cursor
+    FETCH NEXT FROM cascade_delete_MJAIAgentRelationships_SubAgentID_cursor INTO @MJAIAgentRelationships_SubAgentIDID
+    
+    WHILE @@FETCH_STATUS = 0
+    BEGIN
+        EXEC [${flyway:defaultSchema}].[spDeleteAIAgentRelationship] @ID = @MJAIAgentRelationships_SubAgentIDID
+        
+        FETCH NEXT FROM cascade_delete_MJAIAgentRelationships_SubAgentID_cursor INTO @MJAIAgentRelationships_SubAgentIDID
+    END
+    
+    CLOSE cascade_delete_MJAIAgentRelationships_SubAgentID_cursor
+    DEALLOCATE cascade_delete_MJAIAgentRelationships_SubAgentID_cursor
+    
+    -- Cascade delete from AIAgentRequest using cursor to call spDeleteAIAgentRequest
+    DECLARE @MJAIAgentRequests_AgentIDID uniqueidentifier
+    DECLARE cascade_delete_MJAIAgentRequests_AgentID_cursor CURSOR FOR 
+        SELECT [ID]
+        FROM [${flyway:defaultSchema}].[AIAgentRequest]
+        WHERE [AgentID] = @ID
+    
+    OPEN cascade_delete_MJAIAgentRequests_AgentID_cursor
+    FETCH NEXT FROM cascade_delete_MJAIAgentRequests_AgentID_cursor INTO @MJAIAgentRequests_AgentIDID
+    
+    WHILE @@FETCH_STATUS = 0
+    BEGIN
+        EXEC [${flyway:defaultSchema}].[spDeleteAIAgentRequest] @ID = @MJAIAgentRequests_AgentIDID
+        
+        FETCH NEXT FROM cascade_delete_MJAIAgentRequests_AgentID_cursor INTO @MJAIAgentRequests_AgentIDID
+    END
+    
+    CLOSE cascade_delete_MJAIAgentRequests_AgentID_cursor
+    DEALLOCATE cascade_delete_MJAIAgentRequests_AgentID_cursor
+    
+    -- Cascade delete from AIAgentRun using cursor to call spDeleteAIAgentRun
+    DECLARE @MJAIAgentRuns_AgentIDID uniqueidentifier
+    DECLARE cascade_delete_MJAIAgentRuns_AgentID_cursor CURSOR FOR 
+        SELECT [ID]
+        FROM [${flyway:defaultSchema}].[AIAgentRun]
+        WHERE [AgentID] = @ID
+    
+    OPEN cascade_delete_MJAIAgentRuns_AgentID_cursor
+    FETCH NEXT FROM cascade_delete_MJAIAgentRuns_AgentID_cursor INTO @MJAIAgentRuns_AgentIDID
+    
+    WHILE @@FETCH_STATUS = 0
+    BEGIN
+        EXEC [${flyway:defaultSchema}].[spDeleteAIAgentRun] @ID = @MJAIAgentRuns_AgentIDID
+        
+        FETCH NEXT FROM cascade_delete_MJAIAgentRuns_AgentID_cursor INTO @MJAIAgentRuns_AgentIDID
+    END
+    
+    CLOSE cascade_delete_MJAIAgentRuns_AgentID_cursor
+    DEALLOCATE cascade_delete_MJAIAgentRuns_AgentID_cursor
+    
+    -- Cascade delete from AIAgentStep using cursor to call spDeleteAIAgentStep
+    DECLARE @MJAIAgentSteps_AgentIDID uniqueidentifier
+    DECLARE cascade_delete_MJAIAgentSteps_AgentID_cursor CURSOR FOR 
+        SELECT [ID]
+        FROM [${flyway:defaultSchema}].[AIAgentStep]
+        WHERE [AgentID] = @ID
+    
+    OPEN cascade_delete_MJAIAgentSteps_AgentID_cursor
+    FETCH NEXT FROM cascade_delete_MJAIAgentSteps_AgentID_cursor INTO @MJAIAgentSteps_AgentIDID
+    
+    WHILE @@FETCH_STATUS = 0
+    BEGIN
+        EXEC [${flyway:defaultSchema}].[spDeleteAIAgentStep] @ID = @MJAIAgentSteps_AgentIDID
+        
+        FETCH NEXT FROM cascade_delete_MJAIAgentSteps_AgentID_cursor INTO @MJAIAgentSteps_AgentIDID
+    END
+    
+    CLOSE cascade_delete_MJAIAgentSteps_AgentID_cursor
+    DEALLOCATE cascade_delete_MJAIAgentSteps_AgentID_cursor
+    
+    -- Cascade update on AIAgentStep using cursor to call spUpdateAIAgentStep
+    DECLARE @MJAIAgentSteps_SubAgentIDID uniqueidentifier
+    DECLARE @MJAIAgentSteps_SubAgentID_AgentID uniqueidentifier
+    DECLARE @MJAIAgentSteps_SubAgentID_Name nvarchar(255)
+    DECLARE @MJAIAgentSteps_SubAgentID_Description nvarchar(MAX)
+    DECLARE @MJAIAgentSteps_SubAgentID_StepType nvarchar(20)
+    DECLARE @MJAIAgentSteps_SubAgentID_StartingStep bit
+    DECLARE @MJAIAgentSteps_SubAgentID_TimeoutSeconds int
+    DECLARE @MJAIAgentSteps_SubAgentID_RetryCount int
+    DECLARE @MJAIAgentSteps_SubAgentID_OnErrorBehavior nvarchar(20)
+    DECLARE @MJAIAgentSteps_SubAgentID_ActionID uniqueidentifier
+    DECLARE @MJAIAgentSteps_SubAgentID_SubAgentID uniqueidentifier
+    DECLARE @MJAIAgentSteps_SubAgentID_PromptID uniqueidentifier
+    DECLARE @MJAIAgentSteps_SubAgentID_ActionOutputMapping nvarchar(MAX)
+    DECLARE @MJAIAgentSteps_SubAgentID_PositionX int
+    DECLARE @MJAIAgentSteps_SubAgentID_PositionY int
+    DECLARE @MJAIAgentSteps_SubAgentID_Width int
+    DECLARE @MJAIAgentSteps_SubAgentID_Height int
+    DECLARE @MJAIAgentSteps_SubAgentID_Status nvarchar(20)
+    DECLARE @MJAIAgentSteps_SubAgentID_ActionInputMapping nvarchar(MAX)
+    DECLARE @MJAIAgentSteps_SubAgentID_LoopBodyType nvarchar(50)
+    DECLARE @MJAIAgentSteps_SubAgentID_Configuration nvarchar(MAX)
+    DECLARE cascade_update_MJAIAgentSteps_SubAgentID_cursor CURSOR FOR
+        SELECT [ID], [AgentID], [Name], [Description], [StepType], [StartingStep], [TimeoutSeconds], [RetryCount], [OnErrorBehavior], [ActionID], [SubAgentID], [PromptID], [ActionOutputMapping], [PositionX], [PositionY], [Width], [Height], [Status], [ActionInputMapping], [LoopBodyType], [Configuration]
+        FROM [${flyway:defaultSchema}].[AIAgentStep]
+        WHERE [SubAgentID] = @ID
+
+    OPEN cascade_update_MJAIAgentSteps_SubAgentID_cursor
+    FETCH NEXT FROM cascade_update_MJAIAgentSteps_SubAgentID_cursor INTO @MJAIAgentSteps_SubAgentIDID, @MJAIAgentSteps_SubAgentID_AgentID, @MJAIAgentSteps_SubAgentID_Name, @MJAIAgentSteps_SubAgentID_Description, @MJAIAgentSteps_SubAgentID_StepType, @MJAIAgentSteps_SubAgentID_StartingStep, @MJAIAgentSteps_SubAgentID_TimeoutSeconds, @MJAIAgentSteps_SubAgentID_RetryCount, @MJAIAgentSteps_SubAgentID_OnErrorBehavior, @MJAIAgentSteps_SubAgentID_ActionID, @MJAIAgentSteps_SubAgentID_SubAgentID, @MJAIAgentSteps_SubAgentID_PromptID, @MJAIAgentSteps_SubAgentID_ActionOutputMapping, @MJAIAgentSteps_SubAgentID_PositionX, @MJAIAgentSteps_SubAgentID_PositionY, @MJAIAgentSteps_SubAgentID_Width, @MJAIAgentSteps_SubAgentID_Height, @MJAIAgentSteps_SubAgentID_Status, @MJAIAgentSteps_SubAgentID_ActionInputMapping, @MJAIAgentSteps_SubAgentID_LoopBodyType, @MJAIAgentSteps_SubAgentID_Configuration
+
+    WHILE @@FETCH_STATUS = 0
+    BEGIN
+        -- Set the FK field to NULL
+        SET @MJAIAgentSteps_SubAgentID_SubAgentID = NULL
+
+        -- Call the update SP for the related entity
+        EXEC [${flyway:defaultSchema}].[spUpdateAIAgentStep] @ID = @MJAIAgentSteps_SubAgentIDID, @AgentID = @MJAIAgentSteps_SubAgentID_AgentID, @Name = @MJAIAgentSteps_SubAgentID_Name, @Description = @MJAIAgentSteps_SubAgentID_Description, @StepType = @MJAIAgentSteps_SubAgentID_StepType, @StartingStep = @MJAIAgentSteps_SubAgentID_StartingStep, @TimeoutSeconds = @MJAIAgentSteps_SubAgentID_TimeoutSeconds, @RetryCount = @MJAIAgentSteps_SubAgentID_RetryCount, @OnErrorBehavior = @MJAIAgentSteps_SubAgentID_OnErrorBehavior, @ActionID = @MJAIAgentSteps_SubAgentID_ActionID, @SubAgentID = @MJAIAgentSteps_SubAgentID_SubAgentID, @PromptID = @MJAIAgentSteps_SubAgentID_PromptID, @ActionOutputMapping = @MJAIAgentSteps_SubAgentID_ActionOutputMapping, @PositionX = @MJAIAgentSteps_SubAgentID_PositionX, @PositionY = @MJAIAgentSteps_SubAgentID_PositionY, @Width = @MJAIAgentSteps_SubAgentID_Width, @Height = @MJAIAgentSteps_SubAgentID_Height, @Status = @MJAIAgentSteps_SubAgentID_Status, @ActionInputMapping = @MJAIAgentSteps_SubAgentID_ActionInputMapping, @LoopBodyType = @MJAIAgentSteps_SubAgentID_LoopBodyType, @Configuration = @MJAIAgentSteps_SubAgentID_Configuration
+
+        FETCH NEXT FROM cascade_update_MJAIAgentSteps_SubAgentID_cursor INTO @MJAIAgentSteps_SubAgentIDID, @MJAIAgentSteps_SubAgentID_AgentID, @MJAIAgentSteps_SubAgentID_Name, @MJAIAgentSteps_SubAgentID_Description, @MJAIAgentSteps_SubAgentID_StepType, @MJAIAgentSteps_SubAgentID_StartingStep, @MJAIAgentSteps_SubAgentID_TimeoutSeconds, @MJAIAgentSteps_SubAgentID_RetryCount, @MJAIAgentSteps_SubAgentID_OnErrorBehavior, @MJAIAgentSteps_SubAgentID_ActionID, @MJAIAgentSteps_SubAgentID_SubAgentID, @MJAIAgentSteps_SubAgentID_PromptID, @MJAIAgentSteps_SubAgentID_ActionOutputMapping, @MJAIAgentSteps_SubAgentID_PositionX, @MJAIAgentSteps_SubAgentID_PositionY, @MJAIAgentSteps_SubAgentID_Width, @MJAIAgentSteps_SubAgentID_Height, @MJAIAgentSteps_SubAgentID_Status, @MJAIAgentSteps_SubAgentID_ActionInputMapping, @MJAIAgentSteps_SubAgentID_LoopBodyType, @MJAIAgentSteps_SubAgentID_Configuration
+    END
+
+    CLOSE cascade_update_MJAIAgentSteps_SubAgentID_cursor
+    DEALLOCATE cascade_update_MJAIAgentSteps_SubAgentID_cursor
+    
+    -- Cascade update on AIAgent using cursor to call spUpdateAIAgent
+    DECLARE @MJAIAgents_ParentIDID uniqueidentifier
+    DECLARE @MJAIAgents_ParentID_Name nvarchar(255)
+    DECLARE @MJAIAgents_ParentID_Description nvarchar(MAX)
+    DECLARE @MJAIAgents_ParentID_LogoURL nvarchar(255)
+    DECLARE @MJAIAgents_ParentID_ParentID uniqueidentifier
+    DECLARE @MJAIAgents_ParentID_ExposeAsAction bit
+    DECLARE @MJAIAgents_ParentID_ExecutionOrder int
+    DECLARE @MJAIAgents_ParentID_ExecutionMode nvarchar(20)
+    DECLARE @MJAIAgents_ParentID_EnableContextCompression bit
+    DECLARE @MJAIAgents_ParentID_ContextCompressionMessageThreshold int
+    DECLARE @MJAIAgents_ParentID_ContextCompressionPromptID uniqueidentifier
+    DECLARE @MJAIAgents_ParentID_ContextCompressionMessageRetentionCount int
+    DECLARE @MJAIAgents_ParentID_TypeID uniqueidentifier
+    DECLARE @MJAIAgents_ParentID_Status nvarchar(20)
+    DECLARE @MJAIAgents_ParentID_DriverClass nvarchar(255)
+    DECLARE @MJAIAgents_ParentID_IconClass nvarchar(100)
+    DECLARE @MJAIAgents_ParentID_ModelSelectionMode nvarchar(50)
+    DECLARE @MJAIAgents_ParentID_PayloadDownstreamPaths nvarchar(MAX)
+    DECLARE @MJAIAgents_ParentID_PayloadUpstreamPaths nvarchar(MAX)
+    DECLARE @MJAIAgents_ParentID_PayloadSelfReadPaths nvarchar(MAX)
+    DECLARE @MJAIAgents_ParentID_PayloadSelfWritePaths nvarchar(MAX)
+    DECLARE @MJAIAgents_ParentID_PayloadScope nvarchar(MAX)
+    DECLARE @MJAIAgents_ParentID_FinalPayloadValidation nvarchar(MAX)
+    DECLARE @MJAIAgents_ParentID_FinalPayloadValidationMode nvarchar(25)
+    DECLARE @MJAIAgents_ParentID_FinalPayloadValidationMaxRetries int
+    DECLARE @MJAIAgents_ParentID_MaxCostPerRun decimal(10, 4)
+    DECLARE @MJAIAgents_ParentID_MaxTokensPerRun int
+    DECLARE @MJAIAgents_ParentID_MaxIterationsPerRun int
+    DECLARE @MJAIAgents_ParentID_MaxTimePerRun int
+    DECLARE @MJAIAgents_ParentID_MinExecutionsPerRun int
+    DECLARE @MJAIAgents_ParentID_MaxExecutionsPerRun int
+    DECLARE @MJAIAgents_ParentID_StartingPayloadValidation nvarchar(MAX)
+    DECLARE @MJAIAgents_ParentID_StartingPayloadValidationMode nvarchar(25)
+    DECLARE @MJAIAgents_ParentID_DefaultPromptEffortLevel int
+    DECLARE @MJAIAgents_ParentID_ChatHandlingOption nvarchar(30)
+    DECLARE @MJAIAgents_ParentID_DefaultArtifactTypeID uniqueidentifier
+    DECLARE @MJAIAgents_ParentID_OwnerUserID uniqueidentifier
+    DECLARE @MJAIAgents_ParentID_InvocationMode nvarchar(20)
+    DECLARE @MJAIAgents_ParentID_ArtifactCreationMode nvarchar(20)
+    DECLARE @MJAIAgents_ParentID_FunctionalRequirements nvarchar(MAX)
+    DECLARE @MJAIAgents_ParentID_TechnicalDesign nvarchar(MAX)
+    DECLARE @MJAIAgents_ParentID_InjectNotes bit
+    DECLARE @MJAIAgents_ParentID_MaxNotesToInject int
+    DECLARE @MJAIAgents_ParentID_NoteInjectionStrategy nvarchar(20)
+    DECLARE @MJAIAgents_ParentID_InjectExamples bit
+    DECLARE @MJAIAgents_ParentID_MaxExamplesToInject int
+    DECLARE @MJAIAgents_ParentID_ExampleInjectionStrategy nvarchar(20)
+    DECLARE @MJAIAgents_ParentID_IsRestricted bit
+    DECLARE @MJAIAgents_ParentID_MessageMode nvarchar(50)
+    DECLARE @MJAIAgents_ParentID_MaxMessages int
+    DECLARE @MJAIAgents_ParentID_AttachmentStorageProviderID uniqueidentifier
+    DECLARE @MJAIAgents_ParentID_AttachmentRootPath nvarchar(500)
+    DECLARE @MJAIAgents_ParentID_InlineStorageThresholdBytes int
+    DECLARE @MJAIAgents_ParentID_AgentTypePromptParams nvarchar(MAX)
+    DECLARE @MJAIAgents_ParentID_ScopeConfig nvarchar(MAX)
+    DECLARE @MJAIAgents_ParentID_NoteRetentionDays int
+    DECLARE @MJAIAgents_ParentID_ExampleRetentionDays int
+    DECLARE @MJAIAgents_ParentID_AutoArchiveEnabled bit
+    DECLARE @MJAIAgents_ParentID_RerankerConfiguration nvarchar(MAX)
+    DECLARE @MJAIAgents_ParentID_CategoryID uniqueidentifier
+    DECLARE @MJAIAgents_ParentID_AllowEphemeralClientTools bit
+    DECLARE @MJAIAgents_ParentID_DefaultStorageAccountID uniqueidentifier
+    DECLARE cascade_update_MJAIAgents_ParentID_cursor CURSOR FOR
+        SELECT [ID], [Name], [Description], [LogoURL], [ParentID], [ExposeAsAction], [ExecutionOrder], [ExecutionMode], [EnableContextCompression], [ContextCompressionMessageThreshold], [ContextCompressionPromptID], [ContextCompressionMessageRetentionCount], [TypeID], [Status], [DriverClass], [IconClass], [ModelSelectionMode], [PayloadDownstreamPaths], [PayloadUpstreamPaths], [PayloadSelfReadPaths], [PayloadSelfWritePaths], [PayloadScope], [FinalPayloadValidation], [FinalPayloadValidationMode], [FinalPayloadValidationMaxRetries], [MaxCostPerRun], [MaxTokensPerRun], [MaxIterationsPerRun], [MaxTimePerRun], [MinExecutionsPerRun], [MaxExecutionsPerRun], [StartingPayloadValidation], [StartingPayloadValidationMode], [DefaultPromptEffortLevel], [ChatHandlingOption], [DefaultArtifactTypeID], [OwnerUserID], [InvocationMode], [ArtifactCreationMode], [FunctionalRequirements], [TechnicalDesign], [InjectNotes], [MaxNotesToInject], [NoteInjectionStrategy], [InjectExamples], [MaxExamplesToInject], [ExampleInjectionStrategy], [IsRestricted], [MessageMode], [MaxMessages], [AttachmentStorageProviderID], [AttachmentRootPath], [InlineStorageThresholdBytes], [AgentTypePromptParams], [ScopeConfig], [NoteRetentionDays], [ExampleRetentionDays], [AutoArchiveEnabled], [RerankerConfiguration], [CategoryID], [AllowEphemeralClientTools], [DefaultStorageAccountID]
+        FROM [${flyway:defaultSchema}].[AIAgent]
+        WHERE [ParentID] = @ID
+
+    OPEN cascade_update_MJAIAgents_ParentID_cursor
+    FETCH NEXT FROM cascade_update_MJAIAgents_ParentID_cursor INTO @MJAIAgents_ParentIDID, @MJAIAgents_ParentID_Name, @MJAIAgents_ParentID_Description, @MJAIAgents_ParentID_LogoURL, @MJAIAgents_ParentID_ParentID, @MJAIAgents_ParentID_ExposeAsAction, @MJAIAgents_ParentID_ExecutionOrder, @MJAIAgents_ParentID_ExecutionMode, @MJAIAgents_ParentID_EnableContextCompression, @MJAIAgents_ParentID_ContextCompressionMessageThreshold, @MJAIAgents_ParentID_ContextCompressionPromptID, @MJAIAgents_ParentID_ContextCompressionMessageRetentionCount, @MJAIAgents_ParentID_TypeID, @MJAIAgents_ParentID_Status, @MJAIAgents_ParentID_DriverClass, @MJAIAgents_ParentID_IconClass, @MJAIAgents_ParentID_ModelSelectionMode, @MJAIAgents_ParentID_PayloadDownstreamPaths, @MJAIAgents_ParentID_PayloadUpstreamPaths, @MJAIAgents_ParentID_PayloadSelfReadPaths, @MJAIAgents_ParentID_PayloadSelfWritePaths, @MJAIAgents_ParentID_PayloadScope, @MJAIAgents_ParentID_FinalPayloadValidation, @MJAIAgents_ParentID_FinalPayloadValidationMode, @MJAIAgents_ParentID_FinalPayloadValidationMaxRetries, @MJAIAgents_ParentID_MaxCostPerRun, @MJAIAgents_ParentID_MaxTokensPerRun, @MJAIAgents_ParentID_MaxIterationsPerRun, @MJAIAgents_ParentID_MaxTimePerRun, @MJAIAgents_ParentID_MinExecutionsPerRun, @MJAIAgents_ParentID_MaxExecutionsPerRun, @MJAIAgents_ParentID_StartingPayloadValidation, @MJAIAgents_ParentID_StartingPayloadValidationMode, @MJAIAgents_ParentID_DefaultPromptEffortLevel, @MJAIAgents_ParentID_ChatHandlingOption, @MJAIAgents_ParentID_DefaultArtifactTypeID, @MJAIAgents_ParentID_OwnerUserID, @MJAIAgents_ParentID_InvocationMode, @MJAIAgents_ParentID_ArtifactCreationMode, @MJAIAgents_ParentID_FunctionalRequirements, @MJAIAgents_ParentID_TechnicalDesign, @MJAIAgents_ParentID_InjectNotes, @MJAIAgents_ParentID_MaxNotesToInject, @MJAIAgents_ParentID_NoteInjectionStrategy, @MJAIAgents_ParentID_InjectExamples, @MJAIAgents_ParentID_MaxExamplesToInject, @MJAIAgents_ParentID_ExampleInjectionStrategy, @MJAIAgents_ParentID_IsRestricted, @MJAIAgents_ParentID_MessageMode, @MJAIAgents_ParentID_MaxMessages, @MJAIAgents_ParentID_AttachmentStorageProviderID, @MJAIAgents_ParentID_AttachmentRootPath, @MJAIAgents_ParentID_InlineStorageThresholdBytes, @MJAIAgents_ParentID_AgentTypePromptParams, @MJAIAgents_ParentID_ScopeConfig, @MJAIAgents_ParentID_NoteRetentionDays, @MJAIAgents_ParentID_ExampleRetentionDays, @MJAIAgents_ParentID_AutoArchiveEnabled, @MJAIAgents_ParentID_RerankerConfiguration, @MJAIAgents_ParentID_CategoryID, @MJAIAgents_ParentID_AllowEphemeralClientTools, @MJAIAgents_ParentID_DefaultStorageAccountID
+
+    WHILE @@FETCH_STATUS = 0
+    BEGIN
+        -- Set the FK field to NULL
+        SET @MJAIAgents_ParentID_ParentID = NULL
+
+        -- Call the update SP for the related entity
+        EXEC [${flyway:defaultSchema}].[spUpdateAIAgent] @ID = @MJAIAgents_ParentIDID, @Name = @MJAIAgents_ParentID_Name, @Description = @MJAIAgents_ParentID_Description, @LogoURL = @MJAIAgents_ParentID_LogoURL, @ParentID = @MJAIAgents_ParentID_ParentID, @ExposeAsAction = @MJAIAgents_ParentID_ExposeAsAction, @ExecutionOrder = @MJAIAgents_ParentID_ExecutionOrder, @ExecutionMode = @MJAIAgents_ParentID_ExecutionMode, @EnableContextCompression = @MJAIAgents_ParentID_EnableContextCompression, @ContextCompressionMessageThreshold = @MJAIAgents_ParentID_ContextCompressionMessageThreshold, @ContextCompressionPromptID = @MJAIAgents_ParentID_ContextCompressionPromptID, @ContextCompressionMessageRetentionCount = @MJAIAgents_ParentID_ContextCompressionMessageRetentionCount, @TypeID = @MJAIAgents_ParentID_TypeID, @Status = @MJAIAgents_ParentID_Status, @DriverClass = @MJAIAgents_ParentID_DriverClass, @IconClass = @MJAIAgents_ParentID_IconClass, @ModelSelectionMode = @MJAIAgents_ParentID_ModelSelectionMode, @PayloadDownstreamPaths = @MJAIAgents_ParentID_PayloadDownstreamPaths, @PayloadUpstreamPaths = @MJAIAgents_ParentID_PayloadUpstreamPaths, @PayloadSelfReadPaths = @MJAIAgents_ParentID_PayloadSelfReadPaths, @PayloadSelfWritePaths = @MJAIAgents_ParentID_PayloadSelfWritePaths, @PayloadScope = @MJAIAgents_ParentID_PayloadScope, @FinalPayloadValidation = @MJAIAgents_ParentID_FinalPayloadValidation, @FinalPayloadValidationMode = @MJAIAgents_ParentID_FinalPayloadValidationMode, @FinalPayloadValidationMaxRetries = @MJAIAgents_ParentID_FinalPayloadValidationMaxRetries, @MaxCostPerRun = @MJAIAgents_ParentID_MaxCostPerRun, @MaxTokensPerRun = @MJAIAgents_ParentID_MaxTokensPerRun, @MaxIterationsPerRun = @MJAIAgents_ParentID_MaxIterationsPerRun, @MaxTimePerRun = @MJAIAgents_ParentID_MaxTimePerRun, @MinExecutionsPerRun = @MJAIAgents_ParentID_MinExecutionsPerRun, @MaxExecutionsPerRun = @MJAIAgents_ParentID_MaxExecutionsPerRun, @StartingPayloadValidation = @MJAIAgents_ParentID_StartingPayloadValidation, @StartingPayloadValidationMode = @MJAIAgents_ParentID_StartingPayloadValidationMode, @DefaultPromptEffortLevel = @MJAIAgents_ParentID_DefaultPromptEffortLevel, @ChatHandlingOption = @MJAIAgents_ParentID_ChatHandlingOption, @DefaultArtifactTypeID = @MJAIAgents_ParentID_DefaultArtifactTypeID, @OwnerUserID = @MJAIAgents_ParentID_OwnerUserID, @InvocationMode = @MJAIAgents_ParentID_InvocationMode, @ArtifactCreationMode = @MJAIAgents_ParentID_ArtifactCreationMode, @FunctionalRequirements = @MJAIAgents_ParentID_FunctionalRequirements, @TechnicalDesign = @MJAIAgents_ParentID_TechnicalDesign, @InjectNotes = @MJAIAgents_ParentID_InjectNotes, @MaxNotesToInject = @MJAIAgents_ParentID_MaxNotesToInject, @NoteInjectionStrategy = @MJAIAgents_ParentID_NoteInjectionStrategy, @InjectExamples = @MJAIAgents_ParentID_InjectExamples, @MaxExamplesToInject = @MJAIAgents_ParentID_MaxExamplesToInject, @ExampleInjectionStrategy = @MJAIAgents_ParentID_ExampleInjectionStrategy, @IsRestricted = @MJAIAgents_ParentID_IsRestricted, @MessageMode = @MJAIAgents_ParentID_MessageMode, @MaxMessages = @MJAIAgents_ParentID_MaxMessages, @AttachmentStorageProviderID = @MJAIAgents_ParentID_AttachmentStorageProviderID, @AttachmentRootPath = @MJAIAgents_ParentID_AttachmentRootPath, @InlineStorageThresholdBytes = @MJAIAgents_ParentID_InlineStorageThresholdBytes, @AgentTypePromptParams = @MJAIAgents_ParentID_AgentTypePromptParams, @ScopeConfig = @MJAIAgents_ParentID_ScopeConfig, @NoteRetentionDays = @MJAIAgents_ParentID_NoteRetentionDays, @ExampleRetentionDays = @MJAIAgents_ParentID_ExampleRetentionDays, @AutoArchiveEnabled = @MJAIAgents_ParentID_AutoArchiveEnabled, @RerankerConfiguration = @MJAIAgents_ParentID_RerankerConfiguration, @CategoryID = @MJAIAgents_ParentID_CategoryID, @AllowEphemeralClientTools = @MJAIAgents_ParentID_AllowEphemeralClientTools, @DefaultStorageAccountID = @MJAIAgents_ParentID_DefaultStorageAccountID
+
+        FETCH NEXT FROM cascade_update_MJAIAgents_ParentID_cursor INTO @MJAIAgents_ParentIDID, @MJAIAgents_ParentID_Name, @MJAIAgents_ParentID_Description, @MJAIAgents_ParentID_LogoURL, @MJAIAgents_ParentID_ParentID, @MJAIAgents_ParentID_ExposeAsAction, @MJAIAgents_ParentID_ExecutionOrder, @MJAIAgents_ParentID_ExecutionMode, @MJAIAgents_ParentID_EnableContextCompression, @MJAIAgents_ParentID_ContextCompressionMessageThreshold, @MJAIAgents_ParentID_ContextCompressionPromptID, @MJAIAgents_ParentID_ContextCompressionMessageRetentionCount, @MJAIAgents_ParentID_TypeID, @MJAIAgents_ParentID_Status, @MJAIAgents_ParentID_DriverClass, @MJAIAgents_ParentID_IconClass, @MJAIAgents_ParentID_ModelSelectionMode, @MJAIAgents_ParentID_PayloadDownstreamPaths, @MJAIAgents_ParentID_PayloadUpstreamPaths, @MJAIAgents_ParentID_PayloadSelfReadPaths, @MJAIAgents_ParentID_PayloadSelfWritePaths, @MJAIAgents_ParentID_PayloadScope, @MJAIAgents_ParentID_FinalPayloadValidation, @MJAIAgents_ParentID_FinalPayloadValidationMode, @MJAIAgents_ParentID_FinalPayloadValidationMaxRetries, @MJAIAgents_ParentID_MaxCostPerRun, @MJAIAgents_ParentID_MaxTokensPerRun, @MJAIAgents_ParentID_MaxIterationsPerRun, @MJAIAgents_ParentID_MaxTimePerRun, @MJAIAgents_ParentID_MinExecutionsPerRun, @MJAIAgents_ParentID_MaxExecutionsPerRun, @MJAIAgents_ParentID_StartingPayloadValidation, @MJAIAgents_ParentID_StartingPayloadValidationMode, @MJAIAgents_ParentID_DefaultPromptEffortLevel, @MJAIAgents_ParentID_ChatHandlingOption, @MJAIAgents_ParentID_DefaultArtifactTypeID, @MJAIAgents_ParentID_OwnerUserID, @MJAIAgents_ParentID_InvocationMode, @MJAIAgents_ParentID_ArtifactCreationMode, @MJAIAgents_ParentID_FunctionalRequirements, @MJAIAgents_ParentID_TechnicalDesign, @MJAIAgents_ParentID_InjectNotes, @MJAIAgents_ParentID_MaxNotesToInject, @MJAIAgents_ParentID_NoteInjectionStrategy, @MJAIAgents_ParentID_InjectExamples, @MJAIAgents_ParentID_MaxExamplesToInject, @MJAIAgents_ParentID_ExampleInjectionStrategy, @MJAIAgents_ParentID_IsRestricted, @MJAIAgents_ParentID_MessageMode, @MJAIAgents_ParentID_MaxMessages, @MJAIAgents_ParentID_AttachmentStorageProviderID, @MJAIAgents_ParentID_AttachmentRootPath, @MJAIAgents_ParentID_InlineStorageThresholdBytes, @MJAIAgents_ParentID_AgentTypePromptParams, @MJAIAgents_ParentID_ScopeConfig, @MJAIAgents_ParentID_NoteRetentionDays, @MJAIAgents_ParentID_ExampleRetentionDays, @MJAIAgents_ParentID_AutoArchiveEnabled, @MJAIAgents_ParentID_RerankerConfiguration, @MJAIAgents_ParentID_CategoryID, @MJAIAgents_ParentID_AllowEphemeralClientTools, @MJAIAgents_ParentID_DefaultStorageAccountID
+    END
+
+    CLOSE cascade_update_MJAIAgents_ParentID_cursor
+    DEALLOCATE cascade_update_MJAIAgents_ParentID_cursor
+    
+    -- Cascade update on AIPromptRun using cursor to call spUpdateAIPromptRun
+    DECLARE @MJAIPromptRuns_AgentIDID uniqueidentifier
+    DECLARE @MJAIPromptRuns_AgentID_PromptID uniqueidentifier
+    DECLARE @MJAIPromptRuns_AgentID_ModelID uniqueidentifier
+    DECLARE @MJAIPromptRuns_AgentID_VendorID uniqueidentifier
+    DECLARE @MJAIPromptRuns_AgentID_AgentID uniqueidentifier
+    DECLARE @MJAIPromptRuns_AgentID_ConfigurationID uniqueidentifier
+    DECLARE @MJAIPromptRuns_AgentID_RunAt datetimeoffset
+    DECLARE @MJAIPromptRuns_AgentID_CompletedAt datetimeoffset
+    DECLARE @MJAIPromptRuns_AgentID_ExecutionTimeMS int
+    DECLARE @MJAIPromptRuns_AgentID_Messages nvarchar(MAX)
+    DECLARE @MJAIPromptRuns_AgentID_Result nvarchar(MAX)
+    DECLARE @MJAIPromptRuns_AgentID_TokensUsed int
+    DECLARE @MJAIPromptRuns_AgentID_TokensPrompt int
+    DECLARE @MJAIPromptRuns_AgentID_TokensCompletion int
+    DECLARE @MJAIPromptRuns_AgentID_TotalCost decimal(18, 6)
+    DECLARE @MJAIPromptRuns_AgentID_Success bit
+    DECLARE @MJAIPromptRuns_AgentID_ErrorMessage nvarchar(MAX)
+    DECLARE @MJAIPromptRuns_AgentID_ParentID uniqueidentifier
+    DECLARE @MJAIPromptRuns_AgentID_RunType nvarchar(20)
+    DECLARE @MJAIPromptRuns_AgentID_ExecutionOrder int
+    DECLARE @MJAIPromptRuns_AgentID_AgentRunID uniqueidentifier
+    DECLARE @MJAIPromptRuns_AgentID_Cost decimal(19, 8)
+    DECLARE @MJAIPromptRuns_AgentID_CostCurrency nvarchar(10)
+    DECLARE @MJAIPromptRuns_AgentID_TokensUsedRollup int
+    DECLARE @MJAIPromptRuns_AgentID_TokensPromptRollup int
+    DECLARE @MJAIPromptRuns_AgentID_TokensCompletionRollup int
+    DECLARE @MJAIPromptRuns_AgentID_Temperature decimal(3, 2)
+    DECLARE @MJAIPromptRuns_AgentID_TopP decimal(3, 2)
+    DECLARE @MJAIPromptRuns_AgentID_TopK int
+    DECLARE @MJAIPromptRuns_AgentID_MinP decimal(3, 2)
+    DECLARE @MJAIPromptRuns_AgentID_FrequencyPenalty decimal(3, 2)
+    DECLARE @MJAIPromptRuns_AgentID_PresencePenalty decimal(3, 2)
+    DECLARE @MJAIPromptRuns_AgentID_Seed int
+    DECLARE @MJAIPromptRuns_AgentID_StopSequences nvarchar(MAX)
+    DECLARE @MJAIPromptRuns_AgentID_ResponseFormat nvarchar(50)
+    DECLARE @MJAIPromptRuns_AgentID_LogProbs bit
+    DECLARE @MJAIPromptRuns_AgentID_TopLogProbs int
+    DECLARE @MJAIPromptRuns_AgentID_DescendantCost decimal(18, 6)
+    DECLARE @MJAIPromptRuns_AgentID_ValidationAttemptCount int
+    DECLARE @MJAIPromptRuns_AgentID_SuccessfulValidationCount int
+    DECLARE @MJAIPromptRuns_AgentID_FinalValidationPassed bit
+    DECLARE @MJAIPromptRuns_AgentID_ValidationBehavior nvarchar(50)
+    DECLARE @MJAIPromptRuns_AgentID_RetryStrategy nvarchar(50)
+    DECLARE @MJAIPromptRuns_AgentID_MaxRetriesConfigured int
+    DECLARE @MJAIPromptRuns_AgentID_FinalValidationError nvarchar(500)
+    DECLARE @MJAIPromptRuns_AgentID_ValidationErrorCount int
+    DECLARE @MJAIPromptRuns_AgentID_CommonValidationError nvarchar(255)
+    DECLARE @MJAIPromptRuns_AgentID_FirstAttemptAt datetimeoffset
+    DECLARE @MJAIPromptRuns_AgentID_LastAttemptAt datetimeoffset
+    DECLARE @MJAIPromptRuns_AgentID_TotalRetryDurationMS int
+    DECLARE @MJAIPromptRuns_AgentID_ValidationAttempts nvarchar(MAX)
+    DECLARE @MJAIPromptRuns_AgentID_ValidationSummary nvarchar(MAX)
+    DECLARE @MJAIPromptRuns_AgentID_FailoverAttempts int
+    DECLARE @MJAIPromptRuns_AgentID_FailoverErrors nvarchar(MAX)
+    DECLARE @MJAIPromptRuns_AgentID_FailoverDurations nvarchar(MAX)
+    DECLARE @MJAIPromptRuns_AgentID_OriginalModelID uniqueidentifier
+    DECLARE @MJAIPromptRuns_AgentID_OriginalRequestStartTime datetimeoffset
+    DECLARE @MJAIPromptRuns_AgentID_TotalFailoverDuration int
+    DECLARE @MJAIPromptRuns_AgentID_RerunFromPromptRunID uniqueidentifier
+    DECLARE @MJAIPromptRuns_AgentID_ModelSelection nvarchar(MAX)
+    DECLARE @MJAIPromptRuns_AgentID_Status nvarchar(50)
+    DECLARE @MJAIPromptRuns_AgentID_Cancelled bit
+    DECLARE @MJAIPromptRuns_AgentID_CancellationReason nvarchar(MAX)
+    DECLARE @MJAIPromptRuns_AgentID_ModelPowerRank int
+    DECLARE @MJAIPromptRuns_AgentID_SelectionStrategy nvarchar(50)
+    DECLARE @MJAIPromptRuns_AgentID_CacheHit bit
+    DECLARE @MJAIPromptRuns_AgentID_CacheKey nvarchar(500)
+    DECLARE @MJAIPromptRuns_AgentID_JudgeID uniqueidentifier
+    DECLARE @MJAIPromptRuns_AgentID_JudgeScore float(53)
+    DECLARE @MJAIPromptRuns_AgentID_WasSelectedResult bit
+    DECLARE @MJAIPromptRuns_AgentID_StreamingEnabled bit
+    DECLARE @MJAIPromptRuns_AgentID_FirstTokenTime int
+    DECLARE @MJAIPromptRuns_AgentID_ErrorDetails nvarchar(MAX)
+    DECLARE @MJAIPromptRuns_AgentID_ChildPromptID uniqueidentifier
+    DECLARE @MJAIPromptRuns_AgentID_QueueTime int
+    DECLARE @MJAIPromptRuns_AgentID_PromptTime int
+    DECLARE @MJAIPromptRuns_AgentID_CompletionTime int
+    DECLARE @MJAIPromptRuns_AgentID_ModelSpecificResponseDetails nvarchar(MAX)
+    DECLARE @MJAIPromptRuns_AgentID_EffortLevel int
+    DECLARE @MJAIPromptRuns_AgentID_RunName nvarchar(255)
+    DECLARE @MJAIPromptRuns_AgentID_Comments nvarchar(MAX)
+    DECLARE @MJAIPromptRuns_AgentID_TestRunID uniqueidentifier
+    DECLARE @MJAIPromptRuns_AgentID_AssistantPrefill nvarchar(MAX)
+    DECLARE cascade_update_MJAIPromptRuns_AgentID_cursor CURSOR FOR
+        SELECT [ID], [PromptID], [ModelID], [VendorID], [AgentID], [ConfigurationID], [RunAt], [CompletedAt], [ExecutionTimeMS], [Messages], [Result], [TokensUsed], [TokensPrompt], [TokensCompletion], [TotalCost], [Success], [ErrorMessage], [ParentID], [RunType], [ExecutionOrder], [AgentRunID], [Cost], [CostCurrency], [TokensUsedRollup], [TokensPromptRollup], [TokensCompletionRollup], [Temperature], [TopP], [TopK], [MinP], [FrequencyPenalty], [PresencePenalty], [Seed], [StopSequences], [ResponseFormat], [LogProbs], [TopLogProbs], [DescendantCost], [ValidationAttemptCount], [SuccessfulValidationCount], [FinalValidationPassed], [ValidationBehavior], [RetryStrategy], [MaxRetriesConfigured], [FinalValidationError], [ValidationErrorCount], [CommonValidationError], [FirstAttemptAt], [LastAttemptAt], [TotalRetryDurationMS], [ValidationAttempts], [ValidationSummary], [FailoverAttempts], [FailoverErrors], [FailoverDurations], [OriginalModelID], [OriginalRequestStartTime], [TotalFailoverDuration], [RerunFromPromptRunID], [ModelSelection], [Status], [Cancelled], [CancellationReason], [ModelPowerRank], [SelectionStrategy], [CacheHit], [CacheKey], [JudgeID], [JudgeScore], [WasSelectedResult], [StreamingEnabled], [FirstTokenTime], [ErrorDetails], [ChildPromptID], [QueueTime], [PromptTime], [CompletionTime], [ModelSpecificResponseDetails], [EffortLevel], [RunName], [Comments], [TestRunID], [AssistantPrefill]
+        FROM [${flyway:defaultSchema}].[AIPromptRun]
+        WHERE [AgentID] = @ID
+
+    OPEN cascade_update_MJAIPromptRuns_AgentID_cursor
+    FETCH NEXT FROM cascade_update_MJAIPromptRuns_AgentID_cursor INTO @MJAIPromptRuns_AgentIDID, @MJAIPromptRuns_AgentID_PromptID, @MJAIPromptRuns_AgentID_ModelID, @MJAIPromptRuns_AgentID_VendorID, @MJAIPromptRuns_AgentID_AgentID, @MJAIPromptRuns_AgentID_ConfigurationID, @MJAIPromptRuns_AgentID_RunAt, @MJAIPromptRuns_AgentID_CompletedAt, @MJAIPromptRuns_AgentID_ExecutionTimeMS, @MJAIPromptRuns_AgentID_Messages, @MJAIPromptRuns_AgentID_Result, @MJAIPromptRuns_AgentID_TokensUsed, @MJAIPromptRuns_AgentID_TokensPrompt, @MJAIPromptRuns_AgentID_TokensCompletion, @MJAIPromptRuns_AgentID_TotalCost, @MJAIPromptRuns_AgentID_Success, @MJAIPromptRuns_AgentID_ErrorMessage, @MJAIPromptRuns_AgentID_ParentID, @MJAIPromptRuns_AgentID_RunType, @MJAIPromptRuns_AgentID_ExecutionOrder, @MJAIPromptRuns_AgentID_AgentRunID, @MJAIPromptRuns_AgentID_Cost, @MJAIPromptRuns_AgentID_CostCurrency, @MJAIPromptRuns_AgentID_TokensUsedRollup, @MJAIPromptRuns_AgentID_TokensPromptRollup, @MJAIPromptRuns_AgentID_TokensCompletionRollup, @MJAIPromptRuns_AgentID_Temperature, @MJAIPromptRuns_AgentID_TopP, @MJAIPromptRuns_AgentID_TopK, @MJAIPromptRuns_AgentID_MinP, @MJAIPromptRuns_AgentID_FrequencyPenalty, @MJAIPromptRuns_AgentID_PresencePenalty, @MJAIPromptRuns_AgentID_Seed, @MJAIPromptRuns_AgentID_StopSequences, @MJAIPromptRuns_AgentID_ResponseFormat, @MJAIPromptRuns_AgentID_LogProbs, @MJAIPromptRuns_AgentID_TopLogProbs, @MJAIPromptRuns_AgentID_DescendantCost, @MJAIPromptRuns_AgentID_ValidationAttemptCount, @MJAIPromptRuns_AgentID_SuccessfulValidationCount, @MJAIPromptRuns_AgentID_FinalValidationPassed, @MJAIPromptRuns_AgentID_ValidationBehavior, @MJAIPromptRuns_AgentID_RetryStrategy, @MJAIPromptRuns_AgentID_MaxRetriesConfigured, @MJAIPromptRuns_AgentID_FinalValidationError, @MJAIPromptRuns_AgentID_ValidationErrorCount, @MJAIPromptRuns_AgentID_CommonValidationError, @MJAIPromptRuns_AgentID_FirstAttemptAt, @MJAIPromptRuns_AgentID_LastAttemptAt, @MJAIPromptRuns_AgentID_TotalRetryDurationMS, @MJAIPromptRuns_AgentID_ValidationAttempts, @MJAIPromptRuns_AgentID_ValidationSummary, @MJAIPromptRuns_AgentID_FailoverAttempts, @MJAIPromptRuns_AgentID_FailoverErrors, @MJAIPromptRuns_AgentID_FailoverDurations, @MJAIPromptRuns_AgentID_OriginalModelID, @MJAIPromptRuns_AgentID_OriginalRequestStartTime, @MJAIPromptRuns_AgentID_TotalFailoverDuration, @MJAIPromptRuns_AgentID_RerunFromPromptRunID, @MJAIPromptRuns_AgentID_ModelSelection, @MJAIPromptRuns_AgentID_Status, @MJAIPromptRuns_AgentID_Cancelled, @MJAIPromptRuns_AgentID_CancellationReason, @MJAIPromptRuns_AgentID_ModelPowerRank, @MJAIPromptRuns_AgentID_SelectionStrategy, @MJAIPromptRuns_AgentID_CacheHit, @MJAIPromptRuns_AgentID_CacheKey, @MJAIPromptRuns_AgentID_JudgeID, @MJAIPromptRuns_AgentID_JudgeScore, @MJAIPromptRuns_AgentID_WasSelectedResult, @MJAIPromptRuns_AgentID_StreamingEnabled, @MJAIPromptRuns_AgentID_FirstTokenTime, @MJAIPromptRuns_AgentID_ErrorDetails, @MJAIPromptRuns_AgentID_ChildPromptID, @MJAIPromptRuns_AgentID_QueueTime, @MJAIPromptRuns_AgentID_PromptTime, @MJAIPromptRuns_AgentID_CompletionTime, @MJAIPromptRuns_AgentID_ModelSpecificResponseDetails, @MJAIPromptRuns_AgentID_EffortLevel, @MJAIPromptRuns_AgentID_RunName, @MJAIPromptRuns_AgentID_Comments, @MJAIPromptRuns_AgentID_TestRunID, @MJAIPromptRuns_AgentID_AssistantPrefill
+
+    WHILE @@FETCH_STATUS = 0
+    BEGIN
+        -- Set the FK field to NULL
+        SET @MJAIPromptRuns_AgentID_AgentID = NULL
+
+        -- Call the update SP for the related entity
+        EXEC [${flyway:defaultSchema}].[spUpdateAIPromptRun] @ID = @MJAIPromptRuns_AgentIDID, @PromptID = @MJAIPromptRuns_AgentID_PromptID, @ModelID = @MJAIPromptRuns_AgentID_ModelID, @VendorID = @MJAIPromptRuns_AgentID_VendorID, @AgentID = @MJAIPromptRuns_AgentID_AgentID, @ConfigurationID = @MJAIPromptRuns_AgentID_ConfigurationID, @RunAt = @MJAIPromptRuns_AgentID_RunAt, @CompletedAt = @MJAIPromptRuns_AgentID_CompletedAt, @ExecutionTimeMS = @MJAIPromptRuns_AgentID_ExecutionTimeMS, @Messages = @MJAIPromptRuns_AgentID_Messages, @Result = @MJAIPromptRuns_AgentID_Result, @TokensUsed = @MJAIPromptRuns_AgentID_TokensUsed, @TokensPrompt = @MJAIPromptRuns_AgentID_TokensPrompt, @TokensCompletion = @MJAIPromptRuns_AgentID_TokensCompletion, @TotalCost = @MJAIPromptRuns_AgentID_TotalCost, @Success = @MJAIPromptRuns_AgentID_Success, @ErrorMessage = @MJAIPromptRuns_AgentID_ErrorMessage, @ParentID = @MJAIPromptRuns_AgentID_ParentID, @RunType = @MJAIPromptRuns_AgentID_RunType, @ExecutionOrder = @MJAIPromptRuns_AgentID_ExecutionOrder, @AgentRunID = @MJAIPromptRuns_AgentID_AgentRunID, @Cost = @MJAIPromptRuns_AgentID_Cost, @CostCurrency = @MJAIPromptRuns_AgentID_CostCurrency, @TokensUsedRollup = @MJAIPromptRuns_AgentID_TokensUsedRollup, @TokensPromptRollup = @MJAIPromptRuns_AgentID_TokensPromptRollup, @TokensCompletionRollup = @MJAIPromptRuns_AgentID_TokensCompletionRollup, @Temperature = @MJAIPromptRuns_AgentID_Temperature, @TopP = @MJAIPromptRuns_AgentID_TopP, @TopK = @MJAIPromptRuns_AgentID_TopK, @MinP = @MJAIPromptRuns_AgentID_MinP, @FrequencyPenalty = @MJAIPromptRuns_AgentID_FrequencyPenalty, @PresencePenalty = @MJAIPromptRuns_AgentID_PresencePenalty, @Seed = @MJAIPromptRuns_AgentID_Seed, @StopSequences = @MJAIPromptRuns_AgentID_StopSequences, @ResponseFormat = @MJAIPromptRuns_AgentID_ResponseFormat, @LogProbs = @MJAIPromptRuns_AgentID_LogProbs, @TopLogProbs = @MJAIPromptRuns_AgentID_TopLogProbs, @DescendantCost = @MJAIPromptRuns_AgentID_DescendantCost, @ValidationAttemptCount = @MJAIPromptRuns_AgentID_ValidationAttemptCount, @SuccessfulValidationCount = @MJAIPromptRuns_AgentID_SuccessfulValidationCount, @FinalValidationPassed = @MJAIPromptRuns_AgentID_FinalValidationPassed, @ValidationBehavior = @MJAIPromptRuns_AgentID_ValidationBehavior, @RetryStrategy = @MJAIPromptRuns_AgentID_RetryStrategy, @MaxRetriesConfigured = @MJAIPromptRuns_AgentID_MaxRetriesConfigured, @FinalValidationError = @MJAIPromptRuns_AgentID_FinalValidationError, @ValidationErrorCount = @MJAIPromptRuns_AgentID_ValidationErrorCount, @CommonValidationError = @MJAIPromptRuns_AgentID_CommonValidationError, @FirstAttemptAt = @MJAIPromptRuns_AgentID_FirstAttemptAt, @LastAttemptAt = @MJAIPromptRuns_AgentID_LastAttemptAt, @TotalRetryDurationMS = @MJAIPromptRuns_AgentID_TotalRetryDurationMS, @ValidationAttempts = @MJAIPromptRuns_AgentID_ValidationAttempts, @ValidationSummary = @MJAIPromptRuns_AgentID_ValidationSummary, @FailoverAttempts = @MJAIPromptRuns_AgentID_FailoverAttempts, @FailoverErrors = @MJAIPromptRuns_AgentID_FailoverErrors, @FailoverDurations = @MJAIPromptRuns_AgentID_FailoverDurations, @OriginalModelID = @MJAIPromptRuns_AgentID_OriginalModelID, @OriginalRequestStartTime = @MJAIPromptRuns_AgentID_OriginalRequestStartTime, @TotalFailoverDuration = @MJAIPromptRuns_AgentID_TotalFailoverDuration, @RerunFromPromptRunID = @MJAIPromptRuns_AgentID_RerunFromPromptRunID, @ModelSelection = @MJAIPromptRuns_AgentID_ModelSelection, @Status = @MJAIPromptRuns_AgentID_Status, @Cancelled = @MJAIPromptRuns_AgentID_Cancelled, @CancellationReason = @MJAIPromptRuns_AgentID_CancellationReason, @ModelPowerRank = @MJAIPromptRuns_AgentID_ModelPowerRank, @SelectionStrategy = @MJAIPromptRuns_AgentID_SelectionStrategy, @CacheHit = @MJAIPromptRuns_AgentID_CacheHit, @CacheKey = @MJAIPromptRuns_AgentID_CacheKey, @JudgeID = @MJAIPromptRuns_AgentID_JudgeID, @JudgeScore = @MJAIPromptRuns_AgentID_JudgeScore, @WasSelectedResult = @MJAIPromptRuns_AgentID_WasSelectedResult, @StreamingEnabled = @MJAIPromptRuns_AgentID_StreamingEnabled, @FirstTokenTime = @MJAIPromptRuns_AgentID_FirstTokenTime, @ErrorDetails = @MJAIPromptRuns_AgentID_ErrorDetails, @ChildPromptID = @MJAIPromptRuns_AgentID_ChildPromptID, @QueueTime = @MJAIPromptRuns_AgentID_QueueTime, @PromptTime = @MJAIPromptRuns_AgentID_PromptTime, @CompletionTime = @MJAIPromptRuns_AgentID_CompletionTime, @ModelSpecificResponseDetails = @MJAIPromptRuns_AgentID_ModelSpecificResponseDetails, @EffortLevel = @MJAIPromptRuns_AgentID_EffortLevel, @RunName = @MJAIPromptRuns_AgentID_RunName, @Comments = @MJAIPromptRuns_AgentID_Comments, @TestRunID = @MJAIPromptRuns_AgentID_TestRunID, @AssistantPrefill = @MJAIPromptRuns_AgentID_AssistantPrefill
+
+        FETCH NEXT FROM cascade_update_MJAIPromptRuns_AgentID_cursor INTO @MJAIPromptRuns_AgentIDID, @MJAIPromptRuns_AgentID_PromptID, @MJAIPromptRuns_AgentID_ModelID, @MJAIPromptRuns_AgentID_VendorID, @MJAIPromptRuns_AgentID_AgentID, @MJAIPromptRuns_AgentID_ConfigurationID, @MJAIPromptRuns_AgentID_RunAt, @MJAIPromptRuns_AgentID_CompletedAt, @MJAIPromptRuns_AgentID_ExecutionTimeMS, @MJAIPromptRuns_AgentID_Messages, @MJAIPromptRuns_AgentID_Result, @MJAIPromptRuns_AgentID_TokensUsed, @MJAIPromptRuns_AgentID_TokensPrompt, @MJAIPromptRuns_AgentID_TokensCompletion, @MJAIPromptRuns_AgentID_TotalCost, @MJAIPromptRuns_AgentID_Success, @MJAIPromptRuns_AgentID_ErrorMessage, @MJAIPromptRuns_AgentID_ParentID, @MJAIPromptRuns_AgentID_RunType, @MJAIPromptRuns_AgentID_ExecutionOrder, @MJAIPromptRuns_AgentID_AgentRunID, @MJAIPromptRuns_AgentID_Cost, @MJAIPromptRuns_AgentID_CostCurrency, @MJAIPromptRuns_AgentID_TokensUsedRollup, @MJAIPromptRuns_AgentID_TokensPromptRollup, @MJAIPromptRuns_AgentID_TokensCompletionRollup, @MJAIPromptRuns_AgentID_Temperature, @MJAIPromptRuns_AgentID_TopP, @MJAIPromptRuns_AgentID_TopK, @MJAIPromptRuns_AgentID_MinP, @MJAIPromptRuns_AgentID_FrequencyPenalty, @MJAIPromptRuns_AgentID_PresencePenalty, @MJAIPromptRuns_AgentID_Seed, @MJAIPromptRuns_AgentID_StopSequences, @MJAIPromptRuns_AgentID_ResponseFormat, @MJAIPromptRuns_AgentID_LogProbs, @MJAIPromptRuns_AgentID_TopLogProbs, @MJAIPromptRuns_AgentID_DescendantCost, @MJAIPromptRuns_AgentID_ValidationAttemptCount, @MJAIPromptRuns_AgentID_SuccessfulValidationCount, @MJAIPromptRuns_AgentID_FinalValidationPassed, @MJAIPromptRuns_AgentID_ValidationBehavior, @MJAIPromptRuns_AgentID_RetryStrategy, @MJAIPromptRuns_AgentID_MaxRetriesConfigured, @MJAIPromptRuns_AgentID_FinalValidationError, @MJAIPromptRuns_AgentID_ValidationErrorCount, @MJAIPromptRuns_AgentID_CommonValidationError, @MJAIPromptRuns_AgentID_FirstAttemptAt, @MJAIPromptRuns_AgentID_LastAttemptAt, @MJAIPromptRuns_AgentID_TotalRetryDurationMS, @MJAIPromptRuns_AgentID_ValidationAttempts, @MJAIPromptRuns_AgentID_ValidationSummary, @MJAIPromptRuns_AgentID_FailoverAttempts, @MJAIPromptRuns_AgentID_FailoverErrors, @MJAIPromptRuns_AgentID_FailoverDurations, @MJAIPromptRuns_AgentID_OriginalModelID, @MJAIPromptRuns_AgentID_OriginalRequestStartTime, @MJAIPromptRuns_AgentID_TotalFailoverDuration, @MJAIPromptRuns_AgentID_RerunFromPromptRunID, @MJAIPromptRuns_AgentID_ModelSelection, @MJAIPromptRuns_AgentID_Status, @MJAIPromptRuns_AgentID_Cancelled, @MJAIPromptRuns_AgentID_CancellationReason, @MJAIPromptRuns_AgentID_ModelPowerRank, @MJAIPromptRuns_AgentID_SelectionStrategy, @MJAIPromptRuns_AgentID_CacheHit, @MJAIPromptRuns_AgentID_CacheKey, @MJAIPromptRuns_AgentID_JudgeID, @MJAIPromptRuns_AgentID_JudgeScore, @MJAIPromptRuns_AgentID_WasSelectedResult, @MJAIPromptRuns_AgentID_StreamingEnabled, @MJAIPromptRuns_AgentID_FirstTokenTime, @MJAIPromptRuns_AgentID_ErrorDetails, @MJAIPromptRuns_AgentID_ChildPromptID, @MJAIPromptRuns_AgentID_QueueTime, @MJAIPromptRuns_AgentID_PromptTime, @MJAIPromptRuns_AgentID_CompletionTime, @MJAIPromptRuns_AgentID_ModelSpecificResponseDetails, @MJAIPromptRuns_AgentID_EffortLevel, @MJAIPromptRuns_AgentID_RunName, @MJAIPromptRuns_AgentID_Comments, @MJAIPromptRuns_AgentID_TestRunID, @MJAIPromptRuns_AgentID_AssistantPrefill
+    END
+
+    CLOSE cascade_update_MJAIPromptRuns_AgentID_cursor
+    DEALLOCATE cascade_update_MJAIPromptRuns_AgentID_cursor
+    
+    -- Cascade update on AIResultCache using cursor to call spUpdateAIResultCache
+    DECLARE @MJAIResultCache_AgentIDID uniqueidentifier
+    DECLARE @MJAIResultCache_AgentID_AIPromptID uniqueidentifier
+    DECLARE @MJAIResultCache_AgentID_AIModelID uniqueidentifier
+    DECLARE @MJAIResultCache_AgentID_RunAt datetimeoffset
+    DECLARE @MJAIResultCache_AgentID_PromptText nvarchar(MAX)
+    DECLARE @MJAIResultCache_AgentID_ResultText nvarchar(MAX)
+    DECLARE @MJAIResultCache_AgentID_Status nvarchar(50)
+    DECLARE @MJAIResultCache_AgentID_ExpiredOn datetimeoffset
+    DECLARE @MJAIResultCache_AgentID_VendorID uniqueidentifier
+    DECLARE @MJAIResultCache_AgentID_AgentID uniqueidentifier
+    DECLARE @MJAIResultCache_AgentID_ConfigurationID uniqueidentifier
+    DECLARE @MJAIResultCache_AgentID_PromptEmbedding varbinary
+    DECLARE @MJAIResultCache_AgentID_PromptRunID uniqueidentifier
+    DECLARE cascade_update_MJAIResultCache_AgentID_cursor CURSOR FOR
+        SELECT [ID], [AIPromptID], [AIModelID], [RunAt], [PromptText], [ResultText], [Status], [ExpiredOn], [VendorID], [AgentID], [ConfigurationID], [PromptEmbedding], [PromptRunID]
+        FROM [${flyway:defaultSchema}].[AIResultCache]
+        WHERE [AgentID] = @ID
+
+    OPEN cascade_update_MJAIResultCache_AgentID_cursor
+    FETCH NEXT FROM cascade_update_MJAIResultCache_AgentID_cursor INTO @MJAIResultCache_AgentIDID, @MJAIResultCache_AgentID_AIPromptID, @MJAIResultCache_AgentID_AIModelID, @MJAIResultCache_AgentID_RunAt, @MJAIResultCache_AgentID_PromptText, @MJAIResultCache_AgentID_ResultText, @MJAIResultCache_AgentID_Status, @MJAIResultCache_AgentID_ExpiredOn, @MJAIResultCache_AgentID_VendorID, @MJAIResultCache_AgentID_AgentID, @MJAIResultCache_AgentID_ConfigurationID, @MJAIResultCache_AgentID_PromptEmbedding, @MJAIResultCache_AgentID_PromptRunID
+
+    WHILE @@FETCH_STATUS = 0
+    BEGIN
+        -- Set the FK field to NULL
+        SET @MJAIResultCache_AgentID_AgentID = NULL
+
+        -- Call the update SP for the related entity
+        EXEC [${flyway:defaultSchema}].[spUpdateAIResultCache] @ID = @MJAIResultCache_AgentIDID, @AIPromptID = @MJAIResultCache_AgentID_AIPromptID, @AIModelID = @MJAIResultCache_AgentID_AIModelID, @RunAt = @MJAIResultCache_AgentID_RunAt, @PromptText = @MJAIResultCache_AgentID_PromptText, @ResultText = @MJAIResultCache_AgentID_ResultText, @Status = @MJAIResultCache_AgentID_Status, @ExpiredOn = @MJAIResultCache_AgentID_ExpiredOn, @VendorID = @MJAIResultCache_AgentID_VendorID, @AgentID = @MJAIResultCache_AgentID_AgentID, @ConfigurationID = @MJAIResultCache_AgentID_ConfigurationID, @PromptEmbedding = @MJAIResultCache_AgentID_PromptEmbedding, @PromptRunID = @MJAIResultCache_AgentID_PromptRunID
+
+        FETCH NEXT FROM cascade_update_MJAIResultCache_AgentID_cursor INTO @MJAIResultCache_AgentIDID, @MJAIResultCache_AgentID_AIPromptID, @MJAIResultCache_AgentID_AIModelID, @MJAIResultCache_AgentID_RunAt, @MJAIResultCache_AgentID_PromptText, @MJAIResultCache_AgentID_ResultText, @MJAIResultCache_AgentID_Status, @MJAIResultCache_AgentID_ExpiredOn, @MJAIResultCache_AgentID_VendorID, @MJAIResultCache_AgentID_AgentID, @MJAIResultCache_AgentID_ConfigurationID, @MJAIResultCache_AgentID_PromptEmbedding, @MJAIResultCache_AgentID_PromptRunID
+    END
+
+    CLOSE cascade_update_MJAIResultCache_AgentID_cursor
+    DEALLOCATE cascade_update_MJAIResultCache_AgentID_cursor
+    
+    -- Cascade update on ConversationDetail using cursor to call spUpdateConversationDetail
+    DECLARE @MJConversationDetails_AgentIDID uniqueidentifier
+    DECLARE @MJConversationDetails_AgentID_ConversationID uniqueidentifier
+    DECLARE @MJConversationDetails_AgentID_ExternalID nvarchar(100)
+    DECLARE @MJConversationDetails_AgentID_Role nvarchar(20)
+    DECLARE @MJConversationDetails_AgentID_Message nvarchar(MAX)
+    DECLARE @MJConversationDetails_AgentID_Error nvarchar(MAX)
+    DECLARE @MJConversationDetails_AgentID_HiddenToUser bit
+    DECLARE @MJConversationDetails_AgentID_UserRating int
+    DECLARE @MJConversationDetails_AgentID_UserFeedback nvarchar(MAX)
+    DECLARE @MJConversationDetails_AgentID_ReflectionInsights nvarchar(MAX)
+    DECLARE @MJConversationDetails_AgentID_SummaryOfEarlierConversation nvarchar(MAX)
+    DECLARE @MJConversationDetails_AgentID_UserID uniqueidentifier
+    DECLARE @MJConversationDetails_AgentID_ArtifactID uniqueidentifier
+    DECLARE @MJConversationDetails_AgentID_ArtifactVersionID uniqueidentifier
+    DECLARE @MJConversationDetails_AgentID_CompletionTime bigint
+    DECLARE @MJConversationDetails_AgentID_IsPinned bit
+    DECLARE @MJConversationDetails_AgentID_ParentID uniqueidentifier
+    DECLARE @MJConversationDetails_AgentID_AgentID uniqueidentifier
+    DECLARE @MJConversationDetails_AgentID_Status nvarchar(20)
+    DECLARE @MJConversationDetails_AgentID_SuggestedResponses nvarchar(MAX)
+    DECLARE @MJConversationDetails_AgentID_TestRunID uniqueidentifier
+    DECLARE @MJConversationDetails_AgentID_ResponseForm nvarchar(MAX)
+    DECLARE @MJConversationDetails_AgentID_ActionableCommands nvarchar(MAX)
+    DECLARE @MJConversationDetails_AgentID_AutomaticCommands nvarchar(MAX)
+    DECLARE @MJConversationDetails_AgentID_OriginalMessageChanged bit
+    DECLARE cascade_update_MJConversationDetails_AgentID_cursor CURSOR FOR
+        SELECT [ID], [ConversationID], [ExternalID], [Role], [Message], [Error], [HiddenToUser], [UserRating], [UserFeedback], [ReflectionInsights], [SummaryOfEarlierConversation], [UserID], [ArtifactID], [ArtifactVersionID], [CompletionTime], [IsPinned], [ParentID], [AgentID], [Status], [SuggestedResponses], [TestRunID], [ResponseForm], [ActionableCommands], [AutomaticCommands], [OriginalMessageChanged]
+        FROM [${flyway:defaultSchema}].[ConversationDetail]
+        WHERE [AgentID] = @ID
+
+    OPEN cascade_update_MJConversationDetails_AgentID_cursor
+    FETCH NEXT FROM cascade_update_MJConversationDetails_AgentID_cursor INTO @MJConversationDetails_AgentIDID, @MJConversationDetails_AgentID_ConversationID, @MJConversationDetails_AgentID_ExternalID, @MJConversationDetails_AgentID_Role, @MJConversationDetails_AgentID_Message, @MJConversationDetails_AgentID_Error, @MJConversationDetails_AgentID_HiddenToUser, @MJConversationDetails_AgentID_UserRating, @MJConversationDetails_AgentID_UserFeedback, @MJConversationDetails_AgentID_ReflectionInsights, @MJConversationDetails_AgentID_SummaryOfEarlierConversation, @MJConversationDetails_AgentID_UserID, @MJConversationDetails_AgentID_ArtifactID, @MJConversationDetails_AgentID_ArtifactVersionID, @MJConversationDetails_AgentID_CompletionTime, @MJConversationDetails_AgentID_IsPinned, @MJConversationDetails_AgentID_ParentID, @MJConversationDetails_AgentID_AgentID, @MJConversationDetails_AgentID_Status, @MJConversationDetails_AgentID_SuggestedResponses, @MJConversationDetails_AgentID_TestRunID, @MJConversationDetails_AgentID_ResponseForm, @MJConversationDetails_AgentID_ActionableCommands, @MJConversationDetails_AgentID_AutomaticCommands, @MJConversationDetails_AgentID_OriginalMessageChanged
+
+    WHILE @@FETCH_STATUS = 0
+    BEGIN
+        -- Set the FK field to NULL
+        SET @MJConversationDetails_AgentID_AgentID = NULL
+
+        -- Call the update SP for the related entity
+        EXEC [${flyway:defaultSchema}].[spUpdateConversationDetail] @ID = @MJConversationDetails_AgentIDID, @ConversationID = @MJConversationDetails_AgentID_ConversationID, @ExternalID = @MJConversationDetails_AgentID_ExternalID, @Role = @MJConversationDetails_AgentID_Role, @Message = @MJConversationDetails_AgentID_Message, @Error = @MJConversationDetails_AgentID_Error, @HiddenToUser = @MJConversationDetails_AgentID_HiddenToUser, @UserRating = @MJConversationDetails_AgentID_UserRating, @UserFeedback = @MJConversationDetails_AgentID_UserFeedback, @ReflectionInsights = @MJConversationDetails_AgentID_ReflectionInsights, @SummaryOfEarlierConversation = @MJConversationDetails_AgentID_SummaryOfEarlierConversation, @UserID = @MJConversationDetails_AgentID_UserID, @ArtifactID = @MJConversationDetails_AgentID_ArtifactID, @ArtifactVersionID = @MJConversationDetails_AgentID_ArtifactVersionID, @CompletionTime = @MJConversationDetails_AgentID_CompletionTime, @IsPinned = @MJConversationDetails_AgentID_IsPinned, @ParentID = @MJConversationDetails_AgentID_ParentID, @AgentID = @MJConversationDetails_AgentID_AgentID, @Status = @MJConversationDetails_AgentID_Status, @SuggestedResponses = @MJConversationDetails_AgentID_SuggestedResponses, @TestRunID = @MJConversationDetails_AgentID_TestRunID, @ResponseForm = @MJConversationDetails_AgentID_ResponseForm, @ActionableCommands = @MJConversationDetails_AgentID_ActionableCommands, @AutomaticCommands = @MJConversationDetails_AgentID_AutomaticCommands, @OriginalMessageChanged = @MJConversationDetails_AgentID_OriginalMessageChanged
+
+        FETCH NEXT FROM cascade_update_MJConversationDetails_AgentID_cursor INTO @MJConversationDetails_AgentIDID, @MJConversationDetails_AgentID_ConversationID, @MJConversationDetails_AgentID_ExternalID, @MJConversationDetails_AgentID_Role, @MJConversationDetails_AgentID_Message, @MJConversationDetails_AgentID_Error, @MJConversationDetails_AgentID_HiddenToUser, @MJConversationDetails_AgentID_UserRating, @MJConversationDetails_AgentID_UserFeedback, @MJConversationDetails_AgentID_ReflectionInsights, @MJConversationDetails_AgentID_SummaryOfEarlierConversation, @MJConversationDetails_AgentID_UserID, @MJConversationDetails_AgentID_ArtifactID, @MJConversationDetails_AgentID_ArtifactVersionID, @MJConversationDetails_AgentID_CompletionTime, @MJConversationDetails_AgentID_IsPinned, @MJConversationDetails_AgentID_ParentID, @MJConversationDetails_AgentID_AgentID, @MJConversationDetails_AgentID_Status, @MJConversationDetails_AgentID_SuggestedResponses, @MJConversationDetails_AgentID_TestRunID, @MJConversationDetails_AgentID_ResponseForm, @MJConversationDetails_AgentID_ActionableCommands, @MJConversationDetails_AgentID_AutomaticCommands, @MJConversationDetails_AgentID_OriginalMessageChanged
+    END
+
+    CLOSE cascade_update_MJConversationDetails_AgentID_cursor
+    DEALLOCATE cascade_update_MJConversationDetails_AgentID_cursor
+    
+    -- Cascade update on Task using cursor to call spUpdateTask
+    DECLARE @MJTasks_AgentIDID uniqueidentifier
+    DECLARE @MJTasks_AgentID_ParentID uniqueidentifier
+    DECLARE @MJTasks_AgentID_Name nvarchar(255)
+    DECLARE @MJTasks_AgentID_Description nvarchar(MAX)
+    DECLARE @MJTasks_AgentID_TypeID uniqueidentifier
+    DECLARE @MJTasks_AgentID_EnvironmentID uniqueidentifier
+    DECLARE @MJTasks_AgentID_ProjectID uniqueidentifier
+    DECLARE @MJTasks_AgentID_ConversationDetailID uniqueidentifier
+    DECLARE @MJTasks_AgentID_UserID uniqueidentifier
+    DECLARE @MJTasks_AgentID_AgentID uniqueidentifier
+    DECLARE @MJTasks_AgentID_Status nvarchar(50)
+    DECLARE @MJTasks_AgentID_PercentComplete int
+    DECLARE @MJTasks_AgentID_DueAt datetimeoffset
+    DECLARE @MJTasks_AgentID_StartedAt datetimeoffset
+    DECLARE @MJTasks_AgentID_CompletedAt datetimeoffset
+    DECLARE cascade_update_MJTasks_AgentID_cursor CURSOR FOR
+        SELECT [ID], [ParentID], [Name], [Description], [TypeID], [EnvironmentID], [ProjectID], [ConversationDetailID], [UserID], [AgentID], [Status], [PercentComplete], [DueAt], [StartedAt], [CompletedAt]
+        FROM [${flyway:defaultSchema}].[Task]
+        WHERE [AgentID] = @ID
+
+    OPEN cascade_update_MJTasks_AgentID_cursor
+    FETCH NEXT FROM cascade_update_MJTasks_AgentID_cursor INTO @MJTasks_AgentIDID, @MJTasks_AgentID_ParentID, @MJTasks_AgentID_Name, @MJTasks_AgentID_Description, @MJTasks_AgentID_TypeID, @MJTasks_AgentID_EnvironmentID, @MJTasks_AgentID_ProjectID, @MJTasks_AgentID_ConversationDetailID, @MJTasks_AgentID_UserID, @MJTasks_AgentID_AgentID, @MJTasks_AgentID_Status, @MJTasks_AgentID_PercentComplete, @MJTasks_AgentID_DueAt, @MJTasks_AgentID_StartedAt, @MJTasks_AgentID_CompletedAt
+
+    WHILE @@FETCH_STATUS = 0
+    BEGIN
+        -- Set the FK field to NULL
+        SET @MJTasks_AgentID_AgentID = NULL
+
+        -- Call the update SP for the related entity
+        EXEC [${flyway:defaultSchema}].[spUpdateTask] @ID = @MJTasks_AgentIDID, @ParentID = @MJTasks_AgentID_ParentID, @Name = @MJTasks_AgentID_Name, @Description = @MJTasks_AgentID_Description, @TypeID = @MJTasks_AgentID_TypeID, @EnvironmentID = @MJTasks_AgentID_EnvironmentID, @ProjectID = @MJTasks_AgentID_ProjectID, @ConversationDetailID = @MJTasks_AgentID_ConversationDetailID, @UserID = @MJTasks_AgentID_UserID, @AgentID = @MJTasks_AgentID_AgentID, @Status = @MJTasks_AgentID_Status, @PercentComplete = @MJTasks_AgentID_PercentComplete, @DueAt = @MJTasks_AgentID_DueAt, @StartedAt = @MJTasks_AgentID_StartedAt, @CompletedAt = @MJTasks_AgentID_CompletedAt
+
+        FETCH NEXT FROM cascade_update_MJTasks_AgentID_cursor INTO @MJTasks_AgentIDID, @MJTasks_AgentID_ParentID, @MJTasks_AgentID_Name, @MJTasks_AgentID_Description, @MJTasks_AgentID_TypeID, @MJTasks_AgentID_EnvironmentID, @MJTasks_AgentID_ProjectID, @MJTasks_AgentID_ConversationDetailID, @MJTasks_AgentID_UserID, @MJTasks_AgentID_AgentID, @MJTasks_AgentID_Status, @MJTasks_AgentID_PercentComplete, @MJTasks_AgentID_DueAt, @MJTasks_AgentID_StartedAt, @MJTasks_AgentID_CompletedAt
+    END
+
+    CLOSE cascade_update_MJTasks_AgentID_cursor
+    DEALLOCATE cascade_update_MJTasks_AgentID_cursor
+    
+
+    DELETE FROM
+        [${flyway:defaultSchema}].[AIAgent]
+    WHERE
+        [ID] = @ID
+
+
+    -- Check if the delete was successful
+    IF @@ROWCOUNT = 0
+        SELECT NULL AS [ID] -- Return NULL for all primary key fields to indicate no record was deleted
+    ELSE
+        SELECT @ID AS [ID] -- Return the primary key values to indicate we successfully deleted the record
+END
+GO
+GRANT EXECUTE ON [${flyway:defaultSchema}].[spDeleteAIAgent] TO [cdp_Integration]
+    
+
+/* spDelete Permissions for MJ: AI Agents */
+
+GRANT EXECUTE ON [${flyway:defaultSchema}].[spDeleteAIAgent] TO [cdp_Integration]
+
+
+
+/* spDelete SQL for MJ: AI Prompts */
+-----------------------------------------------------------------
+-- SQL Code Generation
+-- Entity: MJ: AI Prompts
+-- Item: spDeleteAIPrompt
+--
+-- This was generated by the MemberJunction CodeGen tool.
+-- This file should NOT be edited by hand.
+-----------------------------------------------------------------
+
+------------------------------------------------------------
+----- DELETE PROCEDURE FOR AIPrompt
+------------------------------------------------------------
+IF OBJECT_ID('[${flyway:defaultSchema}].[spDeleteAIPrompt]', 'P') IS NOT NULL
+    DROP PROCEDURE [${flyway:defaultSchema}].[spDeleteAIPrompt];
+GO
+
+CREATE PROCEDURE [${flyway:defaultSchema}].[spDeleteAIPrompt]
+    @ID uniqueidentifier
+AS
+BEGIN
+    SET NOCOUNT ON;
+    -- Cascade update on Action using cursor to call spUpdateAction
+    DECLARE @MJActions_DefaultCompactPromptIDID uniqueidentifier
+    DECLARE @MJActions_DefaultCompactPromptID_CategoryID uniqueidentifier
+    DECLARE @MJActions_DefaultCompactPromptID_Name nvarchar(425)
+    DECLARE @MJActions_DefaultCompactPromptID_Description nvarchar(MAX)
+    DECLARE @MJActions_DefaultCompactPromptID_Type nvarchar(20)
+    DECLARE @MJActions_DefaultCompactPromptID_UserPrompt nvarchar(MAX)
+    DECLARE @MJActions_DefaultCompactPromptID_UserComments nvarchar(MAX)
+    DECLARE @MJActions_DefaultCompactPromptID_Code nvarchar(MAX)
+    DECLARE @MJActions_DefaultCompactPromptID_CodeComments nvarchar(MAX)
+    DECLARE @MJActions_DefaultCompactPromptID_CodeApprovalStatus nvarchar(20)
+    DECLARE @MJActions_DefaultCompactPromptID_CodeApprovalComments nvarchar(MAX)
+    DECLARE @MJActions_DefaultCompactPromptID_CodeApprovedByUserID uniqueidentifier
+    DECLARE @MJActions_DefaultCompactPromptID_CodeApprovedAt datetimeoffset
+    DECLARE @MJActions_DefaultCompactPromptID_CodeLocked bit
+    DECLARE @MJActions_DefaultCompactPromptID_ForceCodeGeneration bit
+    DECLARE @MJActions_DefaultCompactPromptID_RetentionPeriod int
+    DECLARE @MJActions_DefaultCompactPromptID_Status nvarchar(20)
+    DECLARE @MJActions_DefaultCompactPromptID_DriverClass nvarchar(255)
+    DECLARE @MJActions_DefaultCompactPromptID_ParentID uniqueidentifier
+    DECLARE @MJActions_DefaultCompactPromptID_IconClass nvarchar(100)
+    DECLARE @MJActions_DefaultCompactPromptID_DefaultCompactPromptID uniqueidentifier
+    DECLARE @MJActions_DefaultCompactPromptID_Config nvarchar(MAX)
+    DECLARE cascade_update_MJActions_DefaultCompactPromptID_cursor CURSOR FOR
+        SELECT [ID], [CategoryID], [Name], [Description], [Type], [UserPrompt], [UserComments], [Code], [CodeComments], [CodeApprovalStatus], [CodeApprovalComments], [CodeApprovedByUserID], [CodeApprovedAt], [CodeLocked], [ForceCodeGeneration], [RetentionPeriod], [Status], [DriverClass], [ParentID], [IconClass], [DefaultCompactPromptID], [Config]
+        FROM [${flyway:defaultSchema}].[Action]
+        WHERE [DefaultCompactPromptID] = @ID
+
+    OPEN cascade_update_MJActions_DefaultCompactPromptID_cursor
+    FETCH NEXT FROM cascade_update_MJActions_DefaultCompactPromptID_cursor INTO @MJActions_DefaultCompactPromptIDID, @MJActions_DefaultCompactPromptID_CategoryID, @MJActions_DefaultCompactPromptID_Name, @MJActions_DefaultCompactPromptID_Description, @MJActions_DefaultCompactPromptID_Type, @MJActions_DefaultCompactPromptID_UserPrompt, @MJActions_DefaultCompactPromptID_UserComments, @MJActions_DefaultCompactPromptID_Code, @MJActions_DefaultCompactPromptID_CodeComments, @MJActions_DefaultCompactPromptID_CodeApprovalStatus, @MJActions_DefaultCompactPromptID_CodeApprovalComments, @MJActions_DefaultCompactPromptID_CodeApprovedByUserID, @MJActions_DefaultCompactPromptID_CodeApprovedAt, @MJActions_DefaultCompactPromptID_CodeLocked, @MJActions_DefaultCompactPromptID_ForceCodeGeneration, @MJActions_DefaultCompactPromptID_RetentionPeriod, @MJActions_DefaultCompactPromptID_Status, @MJActions_DefaultCompactPromptID_DriverClass, @MJActions_DefaultCompactPromptID_ParentID, @MJActions_DefaultCompactPromptID_IconClass, @MJActions_DefaultCompactPromptID_DefaultCompactPromptID, @MJActions_DefaultCompactPromptID_Config
+
+    WHILE @@FETCH_STATUS = 0
+    BEGIN
+        -- Set the FK field to NULL
+        SET @MJActions_DefaultCompactPromptID_DefaultCompactPromptID = NULL
+
+        -- Call the update SP for the related entity
+        EXEC [${flyway:defaultSchema}].[spUpdateAction] @ID = @MJActions_DefaultCompactPromptIDID, @CategoryID = @MJActions_DefaultCompactPromptID_CategoryID, @Name = @MJActions_DefaultCompactPromptID_Name, @Description = @MJActions_DefaultCompactPromptID_Description, @Type = @MJActions_DefaultCompactPromptID_Type, @UserPrompt = @MJActions_DefaultCompactPromptID_UserPrompt, @UserComments = @MJActions_DefaultCompactPromptID_UserComments, @Code = @MJActions_DefaultCompactPromptID_Code, @CodeComments = @MJActions_DefaultCompactPromptID_CodeComments, @CodeApprovalStatus = @MJActions_DefaultCompactPromptID_CodeApprovalStatus, @CodeApprovalComments = @MJActions_DefaultCompactPromptID_CodeApprovalComments, @CodeApprovedByUserID = @MJActions_DefaultCompactPromptID_CodeApprovedByUserID, @CodeApprovedAt = @MJActions_DefaultCompactPromptID_CodeApprovedAt, @CodeLocked = @MJActions_DefaultCompactPromptID_CodeLocked, @ForceCodeGeneration = @MJActions_DefaultCompactPromptID_ForceCodeGeneration, @RetentionPeriod = @MJActions_DefaultCompactPromptID_RetentionPeriod, @Status = @MJActions_DefaultCompactPromptID_Status, @DriverClass = @MJActions_DefaultCompactPromptID_DriverClass, @ParentID = @MJActions_DefaultCompactPromptID_ParentID, @IconClass = @MJActions_DefaultCompactPromptID_IconClass, @DefaultCompactPromptID = @MJActions_DefaultCompactPromptID_DefaultCompactPromptID, @Config = @MJActions_DefaultCompactPromptID_Config
+
+        FETCH NEXT FROM cascade_update_MJActions_DefaultCompactPromptID_cursor INTO @MJActions_DefaultCompactPromptIDID, @MJActions_DefaultCompactPromptID_CategoryID, @MJActions_DefaultCompactPromptID_Name, @MJActions_DefaultCompactPromptID_Description, @MJActions_DefaultCompactPromptID_Type, @MJActions_DefaultCompactPromptID_UserPrompt, @MJActions_DefaultCompactPromptID_UserComments, @MJActions_DefaultCompactPromptID_Code, @MJActions_DefaultCompactPromptID_CodeComments, @MJActions_DefaultCompactPromptID_CodeApprovalStatus, @MJActions_DefaultCompactPromptID_CodeApprovalComments, @MJActions_DefaultCompactPromptID_CodeApprovedByUserID, @MJActions_DefaultCompactPromptID_CodeApprovedAt, @MJActions_DefaultCompactPromptID_CodeLocked, @MJActions_DefaultCompactPromptID_ForceCodeGeneration, @MJActions_DefaultCompactPromptID_RetentionPeriod, @MJActions_DefaultCompactPromptID_Status, @MJActions_DefaultCompactPromptID_DriverClass, @MJActions_DefaultCompactPromptID_ParentID, @MJActions_DefaultCompactPromptID_IconClass, @MJActions_DefaultCompactPromptID_DefaultCompactPromptID, @MJActions_DefaultCompactPromptID_Config
+    END
+
+    CLOSE cascade_update_MJActions_DefaultCompactPromptID_cursor
+    DEALLOCATE cascade_update_MJActions_DefaultCompactPromptID_cursor
+    
+    -- Cascade update on AIAgentAction using cursor to call spUpdateAIAgentAction
+    DECLARE @MJAIAgentActions_CompactPromptIDID uniqueidentifier
+    DECLARE @MJAIAgentActions_CompactPromptID_AgentID uniqueidentifier
+    DECLARE @MJAIAgentActions_CompactPromptID_ActionID uniqueidentifier
+    DECLARE @MJAIAgentActions_CompactPromptID_Status nvarchar(15)
+    DECLARE @MJAIAgentActions_CompactPromptID_MinExecutionsPerRun int
+    DECLARE @MJAIAgentActions_CompactPromptID_MaxExecutionsPerRun int
+    DECLARE @MJAIAgentActions_CompactPromptID_ResultExpirationTurns int
+    DECLARE @MJAIAgentActions_CompactPromptID_ResultExpirationMode nvarchar(20)
+    DECLARE @MJAIAgentActions_CompactPromptID_CompactMode nvarchar(20)
+    DECLARE @MJAIAgentActions_CompactPromptID_CompactLength int
+    DECLARE @MJAIAgentActions_CompactPromptID_CompactPromptID uniqueidentifier
+    DECLARE cascade_update_MJAIAgentActions_CompactPromptID_cursor CURSOR FOR
+        SELECT [ID], [AgentID], [ActionID], [Status], [MinExecutionsPerRun], [MaxExecutionsPerRun], [ResultExpirationTurns], [ResultExpirationMode], [CompactMode], [CompactLength], [CompactPromptID]
+        FROM [${flyway:defaultSchema}].[AIAgentAction]
+        WHERE [CompactPromptID] = @ID
+
+    OPEN cascade_update_MJAIAgentActions_CompactPromptID_cursor
+    FETCH NEXT FROM cascade_update_MJAIAgentActions_CompactPromptID_cursor INTO @MJAIAgentActions_CompactPromptIDID, @MJAIAgentActions_CompactPromptID_AgentID, @MJAIAgentActions_CompactPromptID_ActionID, @MJAIAgentActions_CompactPromptID_Status, @MJAIAgentActions_CompactPromptID_MinExecutionsPerRun, @MJAIAgentActions_CompactPromptID_MaxExecutionsPerRun, @MJAIAgentActions_CompactPromptID_ResultExpirationTurns, @MJAIAgentActions_CompactPromptID_ResultExpirationMode, @MJAIAgentActions_CompactPromptID_CompactMode, @MJAIAgentActions_CompactPromptID_CompactLength, @MJAIAgentActions_CompactPromptID_CompactPromptID
+
+    WHILE @@FETCH_STATUS = 0
+    BEGIN
+        -- Set the FK field to NULL
+        SET @MJAIAgentActions_CompactPromptID_CompactPromptID = NULL
+
+        -- Call the update SP for the related entity
+        EXEC [${flyway:defaultSchema}].[spUpdateAIAgentAction] @ID = @MJAIAgentActions_CompactPromptIDID, @AgentID = @MJAIAgentActions_CompactPromptID_AgentID, @ActionID = @MJAIAgentActions_CompactPromptID_ActionID, @Status = @MJAIAgentActions_CompactPromptID_Status, @MinExecutionsPerRun = @MJAIAgentActions_CompactPromptID_MinExecutionsPerRun, @MaxExecutionsPerRun = @MJAIAgentActions_CompactPromptID_MaxExecutionsPerRun, @ResultExpirationTurns = @MJAIAgentActions_CompactPromptID_ResultExpirationTurns, @ResultExpirationMode = @MJAIAgentActions_CompactPromptID_ResultExpirationMode, @CompactMode = @MJAIAgentActions_CompactPromptID_CompactMode, @CompactLength = @MJAIAgentActions_CompactPromptID_CompactLength, @CompactPromptID = @MJAIAgentActions_CompactPromptID_CompactPromptID
+
+        FETCH NEXT FROM cascade_update_MJAIAgentActions_CompactPromptID_cursor INTO @MJAIAgentActions_CompactPromptIDID, @MJAIAgentActions_CompactPromptID_AgentID, @MJAIAgentActions_CompactPromptID_ActionID, @MJAIAgentActions_CompactPromptID_Status, @MJAIAgentActions_CompactPromptID_MinExecutionsPerRun, @MJAIAgentActions_CompactPromptID_MaxExecutionsPerRun, @MJAIAgentActions_CompactPromptID_ResultExpirationTurns, @MJAIAgentActions_CompactPromptID_ResultExpirationMode, @MJAIAgentActions_CompactPromptID_CompactMode, @MJAIAgentActions_CompactPromptID_CompactLength, @MJAIAgentActions_CompactPromptID_CompactPromptID
+    END
+
+    CLOSE cascade_update_MJAIAgentActions_CompactPromptID_cursor
+    DEALLOCATE cascade_update_MJAIAgentActions_CompactPromptID_cursor
+    
+    -- Cascade delete from AIAgentPrompt using cursor to call spDeleteAIAgentPrompt
+    DECLARE @MJAIAgentPrompts_PromptIDID uniqueidentifier
+    DECLARE cascade_delete_MJAIAgentPrompts_PromptID_cursor CURSOR FOR 
+        SELECT [ID]
+        FROM [${flyway:defaultSchema}].[AIAgentPrompt]
+        WHERE [PromptID] = @ID
+    
+    OPEN cascade_delete_MJAIAgentPrompts_PromptID_cursor
+    FETCH NEXT FROM cascade_delete_MJAIAgentPrompts_PromptID_cursor INTO @MJAIAgentPrompts_PromptIDID
+    
+    WHILE @@FETCH_STATUS = 0
+    BEGIN
+        EXEC [${flyway:defaultSchema}].[spDeleteAIAgentPrompt] @ID = @MJAIAgentPrompts_PromptIDID
+        
+        FETCH NEXT FROM cascade_delete_MJAIAgentPrompts_PromptID_cursor INTO @MJAIAgentPrompts_PromptIDID
+    END
+    
+    CLOSE cascade_delete_MJAIAgentPrompts_PromptID_cursor
+    DEALLOCATE cascade_delete_MJAIAgentPrompts_PromptID_cursor
+    
+    -- Cascade update on AIAgentStep using cursor to call spUpdateAIAgentStep
+    DECLARE @MJAIAgentSteps_PromptIDID uniqueidentifier
+    DECLARE @MJAIAgentSteps_PromptID_AgentID uniqueidentifier
+    DECLARE @MJAIAgentSteps_PromptID_Name nvarchar(255)
+    DECLARE @MJAIAgentSteps_PromptID_Description nvarchar(MAX)
+    DECLARE @MJAIAgentSteps_PromptID_StepType nvarchar(20)
+    DECLARE @MJAIAgentSteps_PromptID_StartingStep bit
+    DECLARE @MJAIAgentSteps_PromptID_TimeoutSeconds int
+    DECLARE @MJAIAgentSteps_PromptID_RetryCount int
+    DECLARE @MJAIAgentSteps_PromptID_OnErrorBehavior nvarchar(20)
+    DECLARE @MJAIAgentSteps_PromptID_ActionID uniqueidentifier
+    DECLARE @MJAIAgentSteps_PromptID_SubAgentID uniqueidentifier
+    DECLARE @MJAIAgentSteps_PromptID_PromptID uniqueidentifier
+    DECLARE @MJAIAgentSteps_PromptID_ActionOutputMapping nvarchar(MAX)
+    DECLARE @MJAIAgentSteps_PromptID_PositionX int
+    DECLARE @MJAIAgentSteps_PromptID_PositionY int
+    DECLARE @MJAIAgentSteps_PromptID_Width int
+    DECLARE @MJAIAgentSteps_PromptID_Height int
+    DECLARE @MJAIAgentSteps_PromptID_Status nvarchar(20)
+    DECLARE @MJAIAgentSteps_PromptID_ActionInputMapping nvarchar(MAX)
+    DECLARE @MJAIAgentSteps_PromptID_LoopBodyType nvarchar(50)
+    DECLARE @MJAIAgentSteps_PromptID_Configuration nvarchar(MAX)
+    DECLARE cascade_update_MJAIAgentSteps_PromptID_cursor CURSOR FOR
+        SELECT [ID], [AgentID], [Name], [Description], [StepType], [StartingStep], [TimeoutSeconds], [RetryCount], [OnErrorBehavior], [ActionID], [SubAgentID], [PromptID], [ActionOutputMapping], [PositionX], [PositionY], [Width], [Height], [Status], [ActionInputMapping], [LoopBodyType], [Configuration]
+        FROM [${flyway:defaultSchema}].[AIAgentStep]
+        WHERE [PromptID] = @ID
+
+    OPEN cascade_update_MJAIAgentSteps_PromptID_cursor
+    FETCH NEXT FROM cascade_update_MJAIAgentSteps_PromptID_cursor INTO @MJAIAgentSteps_PromptIDID, @MJAIAgentSteps_PromptID_AgentID, @MJAIAgentSteps_PromptID_Name, @MJAIAgentSteps_PromptID_Description, @MJAIAgentSteps_PromptID_StepType, @MJAIAgentSteps_PromptID_StartingStep, @MJAIAgentSteps_PromptID_TimeoutSeconds, @MJAIAgentSteps_PromptID_RetryCount, @MJAIAgentSteps_PromptID_OnErrorBehavior, @MJAIAgentSteps_PromptID_ActionID, @MJAIAgentSteps_PromptID_SubAgentID, @MJAIAgentSteps_PromptID_PromptID, @MJAIAgentSteps_PromptID_ActionOutputMapping, @MJAIAgentSteps_PromptID_PositionX, @MJAIAgentSteps_PromptID_PositionY, @MJAIAgentSteps_PromptID_Width, @MJAIAgentSteps_PromptID_Height, @MJAIAgentSteps_PromptID_Status, @MJAIAgentSteps_PromptID_ActionInputMapping, @MJAIAgentSteps_PromptID_LoopBodyType, @MJAIAgentSteps_PromptID_Configuration
+
+    WHILE @@FETCH_STATUS = 0
+    BEGIN
+        -- Set the FK field to NULL
+        SET @MJAIAgentSteps_PromptID_PromptID = NULL
+
+        -- Call the update SP for the related entity
+        EXEC [${flyway:defaultSchema}].[spUpdateAIAgentStep] @ID = @MJAIAgentSteps_PromptIDID, @AgentID = @MJAIAgentSteps_PromptID_AgentID, @Name = @MJAIAgentSteps_PromptID_Name, @Description = @MJAIAgentSteps_PromptID_Description, @StepType = @MJAIAgentSteps_PromptID_StepType, @StartingStep = @MJAIAgentSteps_PromptID_StartingStep, @TimeoutSeconds = @MJAIAgentSteps_PromptID_TimeoutSeconds, @RetryCount = @MJAIAgentSteps_PromptID_RetryCount, @OnErrorBehavior = @MJAIAgentSteps_PromptID_OnErrorBehavior, @ActionID = @MJAIAgentSteps_PromptID_ActionID, @SubAgentID = @MJAIAgentSteps_PromptID_SubAgentID, @PromptID = @MJAIAgentSteps_PromptID_PromptID, @ActionOutputMapping = @MJAIAgentSteps_PromptID_ActionOutputMapping, @PositionX = @MJAIAgentSteps_PromptID_PositionX, @PositionY = @MJAIAgentSteps_PromptID_PositionY, @Width = @MJAIAgentSteps_PromptID_Width, @Height = @MJAIAgentSteps_PromptID_Height, @Status = @MJAIAgentSteps_PromptID_Status, @ActionInputMapping = @MJAIAgentSteps_PromptID_ActionInputMapping, @LoopBodyType = @MJAIAgentSteps_PromptID_LoopBodyType, @Configuration = @MJAIAgentSteps_PromptID_Configuration
+
+        FETCH NEXT FROM cascade_update_MJAIAgentSteps_PromptID_cursor INTO @MJAIAgentSteps_PromptIDID, @MJAIAgentSteps_PromptID_AgentID, @MJAIAgentSteps_PromptID_Name, @MJAIAgentSteps_PromptID_Description, @MJAIAgentSteps_PromptID_StepType, @MJAIAgentSteps_PromptID_StartingStep, @MJAIAgentSteps_PromptID_TimeoutSeconds, @MJAIAgentSteps_PromptID_RetryCount, @MJAIAgentSteps_PromptID_OnErrorBehavior, @MJAIAgentSteps_PromptID_ActionID, @MJAIAgentSteps_PromptID_SubAgentID, @MJAIAgentSteps_PromptID_PromptID, @MJAIAgentSteps_PromptID_ActionOutputMapping, @MJAIAgentSteps_PromptID_PositionX, @MJAIAgentSteps_PromptID_PositionY, @MJAIAgentSteps_PromptID_Width, @MJAIAgentSteps_PromptID_Height, @MJAIAgentSteps_PromptID_Status, @MJAIAgentSteps_PromptID_ActionInputMapping, @MJAIAgentSteps_PromptID_LoopBodyType, @MJAIAgentSteps_PromptID_Configuration
+    END
+
+    CLOSE cascade_update_MJAIAgentSteps_PromptID_cursor
+    DEALLOCATE cascade_update_MJAIAgentSteps_PromptID_cursor
+    
+    -- Cascade update on AIAgentType using cursor to call spUpdateAIAgentType
+    DECLARE @MJAIAgentTypes_SystemPromptIDID uniqueidentifier
+    DECLARE @MJAIAgentTypes_SystemPromptID_Name nvarchar(100)
+    DECLARE @MJAIAgentTypes_SystemPromptID_Description nvarchar(MAX)
+    DECLARE @MJAIAgentTypes_SystemPromptID_SystemPromptID uniqueidentifier
+    DECLARE @MJAIAgentTypes_SystemPromptID_IsActive bit
+    DECLARE @MJAIAgentTypes_SystemPromptID_AgentPromptPlaceholder nvarchar(255)
+    DECLARE @MJAIAgentTypes_SystemPromptID_DriverClass nvarchar(255)
+    DECLARE @MJAIAgentTypes_SystemPromptID_UIFormSectionKey nvarchar(500)
+    DECLARE @MJAIAgentTypes_SystemPromptID_UIFormKey nvarchar(500)
+    DECLARE @MJAIAgentTypes_SystemPromptID_UIFormSectionExpandedByDefault bit
+    DECLARE @MJAIAgentTypes_SystemPromptID_PromptParamsSchema nvarchar(MAX)
+    DECLARE @MJAIAgentTypes_SystemPromptID_AssignmentStrategy nvarchar(MAX)
+    DECLARE @MJAIAgentTypes_SystemPromptID_DefaultStorageAccountID uniqueidentifier
+    DECLARE cascade_update_MJAIAgentTypes_SystemPromptID_cursor CURSOR FOR
+        SELECT [ID], [Name], [Description], [SystemPromptID], [IsActive], [AgentPromptPlaceholder], [DriverClass], [UIFormSectionKey], [UIFormKey], [UIFormSectionExpandedByDefault], [PromptParamsSchema], [AssignmentStrategy], [DefaultStorageAccountID]
+        FROM [${flyway:defaultSchema}].[AIAgentType]
+        WHERE [SystemPromptID] = @ID
+
+    OPEN cascade_update_MJAIAgentTypes_SystemPromptID_cursor
+    FETCH NEXT FROM cascade_update_MJAIAgentTypes_SystemPromptID_cursor INTO @MJAIAgentTypes_SystemPromptIDID, @MJAIAgentTypes_SystemPromptID_Name, @MJAIAgentTypes_SystemPromptID_Description, @MJAIAgentTypes_SystemPromptID_SystemPromptID, @MJAIAgentTypes_SystemPromptID_IsActive, @MJAIAgentTypes_SystemPromptID_AgentPromptPlaceholder, @MJAIAgentTypes_SystemPromptID_DriverClass, @MJAIAgentTypes_SystemPromptID_UIFormSectionKey, @MJAIAgentTypes_SystemPromptID_UIFormKey, @MJAIAgentTypes_SystemPromptID_UIFormSectionExpandedByDefault, @MJAIAgentTypes_SystemPromptID_PromptParamsSchema, @MJAIAgentTypes_SystemPromptID_AssignmentStrategy, @MJAIAgentTypes_SystemPromptID_DefaultStorageAccountID
+
+    WHILE @@FETCH_STATUS = 0
+    BEGIN
+        -- Set the FK field to NULL
+        SET @MJAIAgentTypes_SystemPromptID_SystemPromptID = NULL
+
+        -- Call the update SP for the related entity
+        EXEC [${flyway:defaultSchema}].[spUpdateAIAgentType] @ID = @MJAIAgentTypes_SystemPromptIDID, @Name = @MJAIAgentTypes_SystemPromptID_Name, @Description = @MJAIAgentTypes_SystemPromptID_Description, @SystemPromptID = @MJAIAgentTypes_SystemPromptID_SystemPromptID, @IsActive = @MJAIAgentTypes_SystemPromptID_IsActive, @AgentPromptPlaceholder = @MJAIAgentTypes_SystemPromptID_AgentPromptPlaceholder, @DriverClass = @MJAIAgentTypes_SystemPromptID_DriverClass, @UIFormSectionKey = @MJAIAgentTypes_SystemPromptID_UIFormSectionKey, @UIFormKey = @MJAIAgentTypes_SystemPromptID_UIFormKey, @UIFormSectionExpandedByDefault = @MJAIAgentTypes_SystemPromptID_UIFormSectionExpandedByDefault, @PromptParamsSchema = @MJAIAgentTypes_SystemPromptID_PromptParamsSchema, @AssignmentStrategy = @MJAIAgentTypes_SystemPromptID_AssignmentStrategy, @DefaultStorageAccountID = @MJAIAgentTypes_SystemPromptID_DefaultStorageAccountID
+
+        FETCH NEXT FROM cascade_update_MJAIAgentTypes_SystemPromptID_cursor INTO @MJAIAgentTypes_SystemPromptIDID, @MJAIAgentTypes_SystemPromptID_Name, @MJAIAgentTypes_SystemPromptID_Description, @MJAIAgentTypes_SystemPromptID_SystemPromptID, @MJAIAgentTypes_SystemPromptID_IsActive, @MJAIAgentTypes_SystemPromptID_AgentPromptPlaceholder, @MJAIAgentTypes_SystemPromptID_DriverClass, @MJAIAgentTypes_SystemPromptID_UIFormSectionKey, @MJAIAgentTypes_SystemPromptID_UIFormKey, @MJAIAgentTypes_SystemPromptID_UIFormSectionExpandedByDefault, @MJAIAgentTypes_SystemPromptID_PromptParamsSchema, @MJAIAgentTypes_SystemPromptID_AssignmentStrategy, @MJAIAgentTypes_SystemPromptID_DefaultStorageAccountID
+    END
+
+    CLOSE cascade_update_MJAIAgentTypes_SystemPromptID_cursor
+    DEALLOCATE cascade_update_MJAIAgentTypes_SystemPromptID_cursor
+    
+    -- Cascade update on AIAgent using cursor to call spUpdateAIAgent
+    DECLARE @MJAIAgents_ContextCompressionPromptIDID uniqueidentifier
+    DECLARE @MJAIAgents_ContextCompressionPromptID_Name nvarchar(255)
+    DECLARE @MJAIAgents_ContextCompressionPromptID_Description nvarchar(MAX)
+    DECLARE @MJAIAgents_ContextCompressionPromptID_LogoURL nvarchar(255)
+    DECLARE @MJAIAgents_ContextCompressionPromptID_ParentID uniqueidentifier
+    DECLARE @MJAIAgents_ContextCompressionPromptID_ExposeAsAction bit
+    DECLARE @MJAIAgents_ContextCompressionPromptID_ExecutionOrder int
+    DECLARE @MJAIAgents_ContextCompressionPromptID_ExecutionMode nvarchar(20)
+    DECLARE @MJAIAgents_ContextCompressionPromptID_EnableContextCompression bit
+    DECLARE @MJAIAgents_ContextCompressionPromptID_ContextCompressionMessageThreshold int
+    DECLARE @MJAIAgents_ContextCompressionPromptID_ContextCompressionPromptID uniqueidentifier
+    DECLARE @MJAIAgents_ContextCompressionPromptID_ContextCompressionMessageRetentionCount int
+    DECLARE @MJAIAgents_ContextCompressionPromptID_TypeID uniqueidentifier
+    DECLARE @MJAIAgents_ContextCompressionPromptID_Status nvarchar(20)
+    DECLARE @MJAIAgents_ContextCompressionPromptID_DriverClass nvarchar(255)
+    DECLARE @MJAIAgents_ContextCompressionPromptID_IconClass nvarchar(100)
+    DECLARE @MJAIAgents_ContextCompressionPromptID_ModelSelectionMode nvarchar(50)
+    DECLARE @MJAIAgents_ContextCompressionPromptID_PayloadDownstreamPaths nvarchar(MAX)
+    DECLARE @MJAIAgents_ContextCompressionPromptID_PayloadUpstreamPaths nvarchar(MAX)
+    DECLARE @MJAIAgents_ContextCompressionPromptID_PayloadSelfReadPaths nvarchar(MAX)
+    DECLARE @MJAIAgents_ContextCompressionPromptID_PayloadSelfWritePaths nvarchar(MAX)
+    DECLARE @MJAIAgents_ContextCompressionPromptID_PayloadScope nvarchar(MAX)
+    DECLARE @MJAIAgents_ContextCompressionPromptID_FinalPayloadValidation nvarchar(MAX)
+    DECLARE @MJAIAgents_ContextCompressionPromptID_FinalPayloadValidationMode nvarchar(25)
+    DECLARE @MJAIAgents_ContextCompressionPromptID_FinalPayloadValidationMaxRetries int
+    DECLARE @MJAIAgents_ContextCompressionPromptID_MaxCostPerRun decimal(10, 4)
+    DECLARE @MJAIAgents_ContextCompressionPromptID_MaxTokensPerRun int
+    DECLARE @MJAIAgents_ContextCompressionPromptID_MaxIterationsPerRun int
+    DECLARE @MJAIAgents_ContextCompressionPromptID_MaxTimePerRun int
+    DECLARE @MJAIAgents_ContextCompressionPromptID_MinExecutionsPerRun int
+    DECLARE @MJAIAgents_ContextCompressionPromptID_MaxExecutionsPerRun int
+    DECLARE @MJAIAgents_ContextCompressionPromptID_StartingPayloadValidation nvarchar(MAX)
+    DECLARE @MJAIAgents_ContextCompressionPromptID_StartingPayloadValidationMode nvarchar(25)
+    DECLARE @MJAIAgents_ContextCompressionPromptID_DefaultPromptEffortLevel int
+    DECLARE @MJAIAgents_ContextCompressionPromptID_ChatHandlingOption nvarchar(30)
+    DECLARE @MJAIAgents_ContextCompressionPromptID_DefaultArtifactTypeID uniqueidentifier
+    DECLARE @MJAIAgents_ContextCompressionPromptID_OwnerUserID uniqueidentifier
+    DECLARE @MJAIAgents_ContextCompressionPromptID_InvocationMode nvarchar(20)
+    DECLARE @MJAIAgents_ContextCompressionPromptID_ArtifactCreationMode nvarchar(20)
+    DECLARE @MJAIAgents_ContextCompressionPromptID_FunctionalRequirements nvarchar(MAX)
+    DECLARE @MJAIAgents_ContextCompressionPromptID_TechnicalDesign nvarchar(MAX)
+    DECLARE @MJAIAgents_ContextCompressionPromptID_InjectNotes bit
+    DECLARE @MJAIAgents_ContextCompressionPromptID_MaxNotesToInject int
+    DECLARE @MJAIAgents_ContextCompressionPromptID_NoteInjectionStrategy nvarchar(20)
+    DECLARE @MJAIAgents_ContextCompressionPromptID_InjectExamples bit
+    DECLARE @MJAIAgents_ContextCompressionPromptID_MaxExamplesToInject int
+    DECLARE @MJAIAgents_ContextCompressionPromptID_ExampleInjectionStrategy nvarchar(20)
+    DECLARE @MJAIAgents_ContextCompressionPromptID_IsRestricted bit
+    DECLARE @MJAIAgents_ContextCompressionPromptID_MessageMode nvarchar(50)
+    DECLARE @MJAIAgents_ContextCompressionPromptID_MaxMessages int
+    DECLARE @MJAIAgents_ContextCompressionPromptID_AttachmentStorageProviderID uniqueidentifier
+    DECLARE @MJAIAgents_ContextCompressionPromptID_AttachmentRootPath nvarchar(500)
+    DECLARE @MJAIAgents_ContextCompressionPromptID_InlineStorageThresholdBytes int
+    DECLARE @MJAIAgents_ContextCompressionPromptID_AgentTypePromptParams nvarchar(MAX)
+    DECLARE @MJAIAgents_ContextCompressionPromptID_ScopeConfig nvarchar(MAX)
+    DECLARE @MJAIAgents_ContextCompressionPromptID_NoteRetentionDays int
+    DECLARE @MJAIAgents_ContextCompressionPromptID_ExampleRetentionDays int
+    DECLARE @MJAIAgents_ContextCompressionPromptID_AutoArchiveEnabled bit
+    DECLARE @MJAIAgents_ContextCompressionPromptID_RerankerConfiguration nvarchar(MAX)
+    DECLARE @MJAIAgents_ContextCompressionPromptID_CategoryID uniqueidentifier
+    DECLARE @MJAIAgents_ContextCompressionPromptID_AllowEphemeralClientTools bit
+    DECLARE @MJAIAgents_ContextCompressionPromptID_DefaultStorageAccountID uniqueidentifier
+    DECLARE cascade_update_MJAIAgents_ContextCompressionPromptID_cursor CURSOR FOR
+        SELECT [ID], [Name], [Description], [LogoURL], [ParentID], [ExposeAsAction], [ExecutionOrder], [ExecutionMode], [EnableContextCompression], [ContextCompressionMessageThreshold], [ContextCompressionPromptID], [ContextCompressionMessageRetentionCount], [TypeID], [Status], [DriverClass], [IconClass], [ModelSelectionMode], [PayloadDownstreamPaths], [PayloadUpstreamPaths], [PayloadSelfReadPaths], [PayloadSelfWritePaths], [PayloadScope], [FinalPayloadValidation], [FinalPayloadValidationMode], [FinalPayloadValidationMaxRetries], [MaxCostPerRun], [MaxTokensPerRun], [MaxIterationsPerRun], [MaxTimePerRun], [MinExecutionsPerRun], [MaxExecutionsPerRun], [StartingPayloadValidation], [StartingPayloadValidationMode], [DefaultPromptEffortLevel], [ChatHandlingOption], [DefaultArtifactTypeID], [OwnerUserID], [InvocationMode], [ArtifactCreationMode], [FunctionalRequirements], [TechnicalDesign], [InjectNotes], [MaxNotesToInject], [NoteInjectionStrategy], [InjectExamples], [MaxExamplesToInject], [ExampleInjectionStrategy], [IsRestricted], [MessageMode], [MaxMessages], [AttachmentStorageProviderID], [AttachmentRootPath], [InlineStorageThresholdBytes], [AgentTypePromptParams], [ScopeConfig], [NoteRetentionDays], [ExampleRetentionDays], [AutoArchiveEnabled], [RerankerConfiguration], [CategoryID], [AllowEphemeralClientTools], [DefaultStorageAccountID]
+        FROM [${flyway:defaultSchema}].[AIAgent]
+        WHERE [ContextCompressionPromptID] = @ID
+
+    OPEN cascade_update_MJAIAgents_ContextCompressionPromptID_cursor
+    FETCH NEXT FROM cascade_update_MJAIAgents_ContextCompressionPromptID_cursor INTO @MJAIAgents_ContextCompressionPromptIDID, @MJAIAgents_ContextCompressionPromptID_Name, @MJAIAgents_ContextCompressionPromptID_Description, @MJAIAgents_ContextCompressionPromptID_LogoURL, @MJAIAgents_ContextCompressionPromptID_ParentID, @MJAIAgents_ContextCompressionPromptID_ExposeAsAction, @MJAIAgents_ContextCompressionPromptID_ExecutionOrder, @MJAIAgents_ContextCompressionPromptID_ExecutionMode, @MJAIAgents_ContextCompressionPromptID_EnableContextCompression, @MJAIAgents_ContextCompressionPromptID_ContextCompressionMessageThreshold, @MJAIAgents_ContextCompressionPromptID_ContextCompressionPromptID, @MJAIAgents_ContextCompressionPromptID_ContextCompressionMessageRetentionCount, @MJAIAgents_ContextCompressionPromptID_TypeID, @MJAIAgents_ContextCompressionPromptID_Status, @MJAIAgents_ContextCompressionPromptID_DriverClass, @MJAIAgents_ContextCompressionPromptID_IconClass, @MJAIAgents_ContextCompressionPromptID_ModelSelectionMode, @MJAIAgents_ContextCompressionPromptID_PayloadDownstreamPaths, @MJAIAgents_ContextCompressionPromptID_PayloadUpstreamPaths, @MJAIAgents_ContextCompressionPromptID_PayloadSelfReadPaths, @MJAIAgents_ContextCompressionPromptID_PayloadSelfWritePaths, @MJAIAgents_ContextCompressionPromptID_PayloadScope, @MJAIAgents_ContextCompressionPromptID_FinalPayloadValidation, @MJAIAgents_ContextCompressionPromptID_FinalPayloadValidationMode, @MJAIAgents_ContextCompressionPromptID_FinalPayloadValidationMaxRetries, @MJAIAgents_ContextCompressionPromptID_MaxCostPerRun, @MJAIAgents_ContextCompressionPromptID_MaxTokensPerRun, @MJAIAgents_ContextCompressionPromptID_MaxIterationsPerRun, @MJAIAgents_ContextCompressionPromptID_MaxTimePerRun, @MJAIAgents_ContextCompressionPromptID_MinExecutionsPerRun, @MJAIAgents_ContextCompressionPromptID_MaxExecutionsPerRun, @MJAIAgents_ContextCompressionPromptID_StartingPayloadValidation, @MJAIAgents_ContextCompressionPromptID_StartingPayloadValidationMode, @MJAIAgents_ContextCompressionPromptID_DefaultPromptEffortLevel, @MJAIAgents_ContextCompressionPromptID_ChatHandlingOption, @MJAIAgents_ContextCompressionPromptID_DefaultArtifactTypeID, @MJAIAgents_ContextCompressionPromptID_OwnerUserID, @MJAIAgents_ContextCompressionPromptID_InvocationMode, @MJAIAgents_ContextCompressionPromptID_ArtifactCreationMode, @MJAIAgents_ContextCompressionPromptID_FunctionalRequirements, @MJAIAgents_ContextCompressionPromptID_TechnicalDesign, @MJAIAgents_ContextCompressionPromptID_InjectNotes, @MJAIAgents_ContextCompressionPromptID_MaxNotesToInject, @MJAIAgents_ContextCompressionPromptID_NoteInjectionStrategy, @MJAIAgents_ContextCompressionPromptID_InjectExamples, @MJAIAgents_ContextCompressionPromptID_MaxExamplesToInject, @MJAIAgents_ContextCompressionPromptID_ExampleInjectionStrategy, @MJAIAgents_ContextCompressionPromptID_IsRestricted, @MJAIAgents_ContextCompressionPromptID_MessageMode, @MJAIAgents_ContextCompressionPromptID_MaxMessages, @MJAIAgents_ContextCompressionPromptID_AttachmentStorageProviderID, @MJAIAgents_ContextCompressionPromptID_AttachmentRootPath, @MJAIAgents_ContextCompressionPromptID_InlineStorageThresholdBytes, @MJAIAgents_ContextCompressionPromptID_AgentTypePromptParams, @MJAIAgents_ContextCompressionPromptID_ScopeConfig, @MJAIAgents_ContextCompressionPromptID_NoteRetentionDays, @MJAIAgents_ContextCompressionPromptID_ExampleRetentionDays, @MJAIAgents_ContextCompressionPromptID_AutoArchiveEnabled, @MJAIAgents_ContextCompressionPromptID_RerankerConfiguration, @MJAIAgents_ContextCompressionPromptID_CategoryID, @MJAIAgents_ContextCompressionPromptID_AllowEphemeralClientTools, @MJAIAgents_ContextCompressionPromptID_DefaultStorageAccountID
+
+    WHILE @@FETCH_STATUS = 0
+    BEGIN
+        -- Set the FK field to NULL
+        SET @MJAIAgents_ContextCompressionPromptID_ContextCompressionPromptID = NULL
+
+        -- Call the update SP for the related entity
+        EXEC [${flyway:defaultSchema}].[spUpdateAIAgent] @ID = @MJAIAgents_ContextCompressionPromptIDID, @Name = @MJAIAgents_ContextCompressionPromptID_Name, @Description = @MJAIAgents_ContextCompressionPromptID_Description, @LogoURL = @MJAIAgents_ContextCompressionPromptID_LogoURL, @ParentID = @MJAIAgents_ContextCompressionPromptID_ParentID, @ExposeAsAction = @MJAIAgents_ContextCompressionPromptID_ExposeAsAction, @ExecutionOrder = @MJAIAgents_ContextCompressionPromptID_ExecutionOrder, @ExecutionMode = @MJAIAgents_ContextCompressionPromptID_ExecutionMode, @EnableContextCompression = @MJAIAgents_ContextCompressionPromptID_EnableContextCompression, @ContextCompressionMessageThreshold = @MJAIAgents_ContextCompressionPromptID_ContextCompressionMessageThreshold, @ContextCompressionPromptID = @MJAIAgents_ContextCompressionPromptID_ContextCompressionPromptID, @ContextCompressionMessageRetentionCount = @MJAIAgents_ContextCompressionPromptID_ContextCompressionMessageRetentionCount, @TypeID = @MJAIAgents_ContextCompressionPromptID_TypeID, @Status = @MJAIAgents_ContextCompressionPromptID_Status, @DriverClass = @MJAIAgents_ContextCompressionPromptID_DriverClass, @IconClass = @MJAIAgents_ContextCompressionPromptID_IconClass, @ModelSelectionMode = @MJAIAgents_ContextCompressionPromptID_ModelSelectionMode, @PayloadDownstreamPaths = @MJAIAgents_ContextCompressionPromptID_PayloadDownstreamPaths, @PayloadUpstreamPaths = @MJAIAgents_ContextCompressionPromptID_PayloadUpstreamPaths, @PayloadSelfReadPaths = @MJAIAgents_ContextCompressionPromptID_PayloadSelfReadPaths, @PayloadSelfWritePaths = @MJAIAgents_ContextCompressionPromptID_PayloadSelfWritePaths, @PayloadScope = @MJAIAgents_ContextCompressionPromptID_PayloadScope, @FinalPayloadValidation = @MJAIAgents_ContextCompressionPromptID_FinalPayloadValidation, @FinalPayloadValidationMode = @MJAIAgents_ContextCompressionPromptID_FinalPayloadValidationMode, @FinalPayloadValidationMaxRetries = @MJAIAgents_ContextCompressionPromptID_FinalPayloadValidationMaxRetries, @MaxCostPerRun = @MJAIAgents_ContextCompressionPromptID_MaxCostPerRun, @MaxTokensPerRun = @MJAIAgents_ContextCompressionPromptID_MaxTokensPerRun, @MaxIterationsPerRun = @MJAIAgents_ContextCompressionPromptID_MaxIterationsPerRun, @MaxTimePerRun = @MJAIAgents_ContextCompressionPromptID_MaxTimePerRun, @MinExecutionsPerRun = @MJAIAgents_ContextCompressionPromptID_MinExecutionsPerRun, @MaxExecutionsPerRun = @MJAIAgents_ContextCompressionPromptID_MaxExecutionsPerRun, @StartingPayloadValidation = @MJAIAgents_ContextCompressionPromptID_StartingPayloadValidation, @StartingPayloadValidationMode = @MJAIAgents_ContextCompressionPromptID_StartingPayloadValidationMode, @DefaultPromptEffortLevel = @MJAIAgents_ContextCompressionPromptID_DefaultPromptEffortLevel, @ChatHandlingOption = @MJAIAgents_ContextCompressionPromptID_ChatHandlingOption, @DefaultArtifactTypeID = @MJAIAgents_ContextCompressionPromptID_DefaultArtifactTypeID, @OwnerUserID = @MJAIAgents_ContextCompressionPromptID_OwnerUserID, @InvocationMode = @MJAIAgents_ContextCompressionPromptID_InvocationMode, @ArtifactCreationMode = @MJAIAgents_ContextCompressionPromptID_ArtifactCreationMode, @FunctionalRequirements = @MJAIAgents_ContextCompressionPromptID_FunctionalRequirements, @TechnicalDesign = @MJAIAgents_ContextCompressionPromptID_TechnicalDesign, @InjectNotes = @MJAIAgents_ContextCompressionPromptID_InjectNotes, @MaxNotesToInject = @MJAIAgents_ContextCompressionPromptID_MaxNotesToInject, @NoteInjectionStrategy = @MJAIAgents_ContextCompressionPromptID_NoteInjectionStrategy, @InjectExamples = @MJAIAgents_ContextCompressionPromptID_InjectExamples, @MaxExamplesToInject = @MJAIAgents_ContextCompressionPromptID_MaxExamplesToInject, @ExampleInjectionStrategy = @MJAIAgents_ContextCompressionPromptID_ExampleInjectionStrategy, @IsRestricted = @MJAIAgents_ContextCompressionPromptID_IsRestricted, @MessageMode = @MJAIAgents_ContextCompressionPromptID_MessageMode, @MaxMessages = @MJAIAgents_ContextCompressionPromptID_MaxMessages, @AttachmentStorageProviderID = @MJAIAgents_ContextCompressionPromptID_AttachmentStorageProviderID, @AttachmentRootPath = @MJAIAgents_ContextCompressionPromptID_AttachmentRootPath, @InlineStorageThresholdBytes = @MJAIAgents_ContextCompressionPromptID_InlineStorageThresholdBytes, @AgentTypePromptParams = @MJAIAgents_ContextCompressionPromptID_AgentTypePromptParams, @ScopeConfig = @MJAIAgents_ContextCompressionPromptID_ScopeConfig, @NoteRetentionDays = @MJAIAgents_ContextCompressionPromptID_NoteRetentionDays, @ExampleRetentionDays = @MJAIAgents_ContextCompressionPromptID_ExampleRetentionDays, @AutoArchiveEnabled = @MJAIAgents_ContextCompressionPromptID_AutoArchiveEnabled, @RerankerConfiguration = @MJAIAgents_ContextCompressionPromptID_RerankerConfiguration, @CategoryID = @MJAIAgents_ContextCompressionPromptID_CategoryID, @AllowEphemeralClientTools = @MJAIAgents_ContextCompressionPromptID_AllowEphemeralClientTools, @DefaultStorageAccountID = @MJAIAgents_ContextCompressionPromptID_DefaultStorageAccountID
+
+        FETCH NEXT FROM cascade_update_MJAIAgents_ContextCompressionPromptID_cursor INTO @MJAIAgents_ContextCompressionPromptIDID, @MJAIAgents_ContextCompressionPromptID_Name, @MJAIAgents_ContextCompressionPromptID_Description, @MJAIAgents_ContextCompressionPromptID_LogoURL, @MJAIAgents_ContextCompressionPromptID_ParentID, @MJAIAgents_ContextCompressionPromptID_ExposeAsAction, @MJAIAgents_ContextCompressionPromptID_ExecutionOrder, @MJAIAgents_ContextCompressionPromptID_ExecutionMode, @MJAIAgents_ContextCompressionPromptID_EnableContextCompression, @MJAIAgents_ContextCompressionPromptID_ContextCompressionMessageThreshold, @MJAIAgents_ContextCompressionPromptID_ContextCompressionPromptID, @MJAIAgents_ContextCompressionPromptID_ContextCompressionMessageRetentionCount, @MJAIAgents_ContextCompressionPromptID_TypeID, @MJAIAgents_ContextCompressionPromptID_Status, @MJAIAgents_ContextCompressionPromptID_DriverClass, @MJAIAgents_ContextCompressionPromptID_IconClass, @MJAIAgents_ContextCompressionPromptID_ModelSelectionMode, @MJAIAgents_ContextCompressionPromptID_PayloadDownstreamPaths, @MJAIAgents_ContextCompressionPromptID_PayloadUpstreamPaths, @MJAIAgents_ContextCompressionPromptID_PayloadSelfReadPaths, @MJAIAgents_ContextCompressionPromptID_PayloadSelfWritePaths, @MJAIAgents_ContextCompressionPromptID_PayloadScope, @MJAIAgents_ContextCompressionPromptID_FinalPayloadValidation, @MJAIAgents_ContextCompressionPromptID_FinalPayloadValidationMode, @MJAIAgents_ContextCompressionPromptID_FinalPayloadValidationMaxRetries, @MJAIAgents_ContextCompressionPromptID_MaxCostPerRun, @MJAIAgents_ContextCompressionPromptID_MaxTokensPerRun, @MJAIAgents_ContextCompressionPromptID_MaxIterationsPerRun, @MJAIAgents_ContextCompressionPromptID_MaxTimePerRun, @MJAIAgents_ContextCompressionPromptID_MinExecutionsPerRun, @MJAIAgents_ContextCompressionPromptID_MaxExecutionsPerRun, @MJAIAgents_ContextCompressionPromptID_StartingPayloadValidation, @MJAIAgents_ContextCompressionPromptID_StartingPayloadValidationMode, @MJAIAgents_ContextCompressionPromptID_DefaultPromptEffortLevel, @MJAIAgents_ContextCompressionPromptID_ChatHandlingOption, @MJAIAgents_ContextCompressionPromptID_DefaultArtifactTypeID, @MJAIAgents_ContextCompressionPromptID_OwnerUserID, @MJAIAgents_ContextCompressionPromptID_InvocationMode, @MJAIAgents_ContextCompressionPromptID_ArtifactCreationMode, @MJAIAgents_ContextCompressionPromptID_FunctionalRequirements, @MJAIAgents_ContextCompressionPromptID_TechnicalDesign, @MJAIAgents_ContextCompressionPromptID_InjectNotes, @MJAIAgents_ContextCompressionPromptID_MaxNotesToInject, @MJAIAgents_ContextCompressionPromptID_NoteInjectionStrategy, @MJAIAgents_ContextCompressionPromptID_InjectExamples, @MJAIAgents_ContextCompressionPromptID_MaxExamplesToInject, @MJAIAgents_ContextCompressionPromptID_ExampleInjectionStrategy, @MJAIAgents_ContextCompressionPromptID_IsRestricted, @MJAIAgents_ContextCompressionPromptID_MessageMode, @MJAIAgents_ContextCompressionPromptID_MaxMessages, @MJAIAgents_ContextCompressionPromptID_AttachmentStorageProviderID, @MJAIAgents_ContextCompressionPromptID_AttachmentRootPath, @MJAIAgents_ContextCompressionPromptID_InlineStorageThresholdBytes, @MJAIAgents_ContextCompressionPromptID_AgentTypePromptParams, @MJAIAgents_ContextCompressionPromptID_ScopeConfig, @MJAIAgents_ContextCompressionPromptID_NoteRetentionDays, @MJAIAgents_ContextCompressionPromptID_ExampleRetentionDays, @MJAIAgents_ContextCompressionPromptID_AutoArchiveEnabled, @MJAIAgents_ContextCompressionPromptID_RerankerConfiguration, @MJAIAgents_ContextCompressionPromptID_CategoryID, @MJAIAgents_ContextCompressionPromptID_AllowEphemeralClientTools, @MJAIAgents_ContextCompressionPromptID_DefaultStorageAccountID
+    END
+
+    CLOSE cascade_update_MJAIAgents_ContextCompressionPromptID_cursor
+    DEALLOCATE cascade_update_MJAIAgents_ContextCompressionPromptID_cursor
+    
+    -- Cascade update on AIConfiguration using cursor to call spUpdateAIConfiguration
+    DECLARE @MJAIConfigurations_DefaultPromptForContextCompressionIDID uniqueidentifier
+    DECLARE @MJAIConfigurations_DefaultPromptForContextCompressionID_Name nvarchar(100)
+    DECLARE @MJAIConfigurations_DefaultPromptForContextCompressionID_Description nvarchar(MAX)
+    DECLARE @MJAIConfigurations_DefaultPromptForContextCompressionID_IsDefault bit
+    DECLARE @MJAIConfigurations_DefaultPromptForContextCompressionID_Status nvarchar(20)
+    DECLARE @MJAIConfigurations_DefaultPromptForContextCompressionID_DefaultPromptForContextCompressionID uniqueidentifier
+    DECLARE @MJAIConfigurations_DefaultPromptForContextCompressionID_DefaultPromptForContextSummarizationID uniqueidentifier
+    DECLARE @MJAIConfigurations_DefaultPromptForContextCompressionID_DefaultStorageProviderID uniqueidentifier
+    DECLARE @MJAIConfigurations_DefaultPromptForContextCompressionID_DefaultStorageRootPath nvarchar(500)
+    DECLARE @MJAIConfigurations_DefaultPromptForContextCompressionID_ParentID uniqueidentifier
+    DECLARE cascade_update_MJAIConfigurations_DefaultPromptForContextCompressionID_cursor CURSOR FOR
+        SELECT [ID], [Name], [Description], [IsDefault], [Status], [DefaultPromptForContextCompressionID], [DefaultPromptForContextSummarizationID], [DefaultStorageProviderID], [DefaultStorageRootPath], [ParentID]
+        FROM [${flyway:defaultSchema}].[AIConfiguration]
+        WHERE [DefaultPromptForContextCompressionID] = @ID
+
+    OPEN cascade_update_MJAIConfigurations_DefaultPromptForContextCompressionID_cursor
+    FETCH NEXT FROM cascade_update_MJAIConfigurations_DefaultPromptForContextCompressionID_cursor INTO @MJAIConfigurations_DefaultPromptForContextCompressionIDID, @MJAIConfigurations_DefaultPromptForContextCompressionID_Name, @MJAIConfigurations_DefaultPromptForContextCompressionID_Description, @MJAIConfigurations_DefaultPromptForContextCompressionID_IsDefault, @MJAIConfigurations_DefaultPromptForContextCompressionID_Status, @MJAIConfigurations_DefaultPromptForContextCompressionID_DefaultPromptForContextCompressionID, @MJAIConfigurations_DefaultPromptForContextCompressionID_DefaultPromptForContextSummarizationID, @MJAIConfigurations_DefaultPromptForContextCompressionID_DefaultStorageProviderID, @MJAIConfigurations_DefaultPromptForContextCompressionID_DefaultStorageRootPath, @MJAIConfigurations_DefaultPromptForContextCompressionID_ParentID
+
+    WHILE @@FETCH_STATUS = 0
+    BEGIN
+        -- Set the FK field to NULL
+        SET @MJAIConfigurations_DefaultPromptForContextCompressionID_DefaultPromptForContextCompressionID = NULL
+
+        -- Call the update SP for the related entity
+        EXEC [${flyway:defaultSchema}].[spUpdateAIConfiguration] @ID = @MJAIConfigurations_DefaultPromptForContextCompressionIDID, @Name = @MJAIConfigurations_DefaultPromptForContextCompressionID_Name, @Description = @MJAIConfigurations_DefaultPromptForContextCompressionID_Description, @IsDefault = @MJAIConfigurations_DefaultPromptForContextCompressionID_IsDefault, @Status = @MJAIConfigurations_DefaultPromptForContextCompressionID_Status, @DefaultPromptForContextCompressionID = @MJAIConfigurations_DefaultPromptForContextCompressionID_DefaultPromptForContextCompressionID, @DefaultPromptForContextSummarizationID = @MJAIConfigurations_DefaultPromptForContextCompressionID_DefaultPromptForContextSummarizationID, @DefaultStorageProviderID = @MJAIConfigurations_DefaultPromptForContextCompressionID_DefaultStorageProviderID, @DefaultStorageRootPath = @MJAIConfigurations_DefaultPromptForContextCompressionID_DefaultStorageRootPath, @ParentID = @MJAIConfigurations_DefaultPromptForContextCompressionID_ParentID
+
+        FETCH NEXT FROM cascade_update_MJAIConfigurations_DefaultPromptForContextCompressionID_cursor INTO @MJAIConfigurations_DefaultPromptForContextCompressionIDID, @MJAIConfigurations_DefaultPromptForContextCompressionID_Name, @MJAIConfigurations_DefaultPromptForContextCompressionID_Description, @MJAIConfigurations_DefaultPromptForContextCompressionID_IsDefault, @MJAIConfigurations_DefaultPromptForContextCompressionID_Status, @MJAIConfigurations_DefaultPromptForContextCompressionID_DefaultPromptForContextCompressionID, @MJAIConfigurations_DefaultPromptForContextCompressionID_DefaultPromptForContextSummarizationID, @MJAIConfigurations_DefaultPromptForContextCompressionID_DefaultStorageProviderID, @MJAIConfigurations_DefaultPromptForContextCompressionID_DefaultStorageRootPath, @MJAIConfigurations_DefaultPromptForContextCompressionID_ParentID
+    END
+
+    CLOSE cascade_update_MJAIConfigurations_DefaultPromptForContextCompressionID_cursor
+    DEALLOCATE cascade_update_MJAIConfigurations_DefaultPromptForContextCompressionID_cursor
+    
+    -- Cascade update on AIConfiguration using cursor to call spUpdateAIConfiguration
+    DECLARE @MJAIConfigurations_DefaultPromptForContextSummarizationIDID uniqueidentifier
+    DECLARE @MJAIConfigurations_DefaultPromptForContextSummarizationID_Name nvarchar(100)
+    DECLARE @MJAIConfigurations_DefaultPromptForContextSummarizationID_Description nvarchar(MAX)
+    DECLARE @MJAIConfigurations_DefaultPromptForContextSummarizationID_IsDefault bit
+    DECLARE @MJAIConfigurations_DefaultPromptForContextSummarizationID_Status nvarchar(20)
+    DECLARE @MJAIConfigurations_DefaultPromptForContextSummarizationID_DefaultPromptForContextCompressionID uniqueidentifier
+    DECLARE @MJAIConfigurations_DefaultPromptForContextSummarizationID_DefaultPromptForContextSummarizationID uniqueidentifier
+    DECLARE @MJAIConfigurations_DefaultPromptForContextSummarizationID_DefaultStorageProviderID uniqueidentifier
+    DECLARE @MJAIConfigurations_DefaultPromptForContextSummarizationID_DefaultStorageRootPath nvarchar(500)
+    DECLARE @MJAIConfigurations_DefaultPromptForContextSummarizationID_ParentID uniqueidentifier
+    DECLARE cascade_update_MJAIConfigurations_DefaultPromptForContextSummarizationID_cursor CURSOR FOR
+        SELECT [ID], [Name], [Description], [IsDefault], [Status], [DefaultPromptForContextCompressionID], [DefaultPromptForContextSummarizationID], [DefaultStorageProviderID], [DefaultStorageRootPath], [ParentID]
+        FROM [${flyway:defaultSchema}].[AIConfiguration]
+        WHERE [DefaultPromptForContextSummarizationID] = @ID
+
+    OPEN cascade_update_MJAIConfigurations_DefaultPromptForContextSummarizationID_cursor
+    FETCH NEXT FROM cascade_update_MJAIConfigurations_DefaultPromptForContextSummarizationID_cursor INTO @MJAIConfigurations_DefaultPromptForContextSummarizationIDID, @MJAIConfigurations_DefaultPromptForContextSummarizationID_Name, @MJAIConfigurations_DefaultPromptForContextSummarizationID_Description, @MJAIConfigurations_DefaultPromptForContextSummarizationID_IsDefault, @MJAIConfigurations_DefaultPromptForContextSummarizationID_Status, @MJAIConfigurations_DefaultPromptForContextSummarizationID_DefaultPromptForContextCompressionID, @MJAIConfigurations_DefaultPromptForContextSummarizationID_DefaultPromptForContextSummarizationID, @MJAIConfigurations_DefaultPromptForContextSummarizationID_DefaultStorageProviderID, @MJAIConfigurations_DefaultPromptForContextSummarizationID_DefaultStorageRootPath, @MJAIConfigurations_DefaultPromptForContextSummarizationID_ParentID
+
+    WHILE @@FETCH_STATUS = 0
+    BEGIN
+        -- Set the FK field to NULL
+        SET @MJAIConfigurations_DefaultPromptForContextSummarizationID_DefaultPromptForContextSummarizationID = NULL
+
+        -- Call the update SP for the related entity
+        EXEC [${flyway:defaultSchema}].[spUpdateAIConfiguration] @ID = @MJAIConfigurations_DefaultPromptForContextSummarizationIDID, @Name = @MJAIConfigurations_DefaultPromptForContextSummarizationID_Name, @Description = @MJAIConfigurations_DefaultPromptForContextSummarizationID_Description, @IsDefault = @MJAIConfigurations_DefaultPromptForContextSummarizationID_IsDefault, @Status = @MJAIConfigurations_DefaultPromptForContextSummarizationID_Status, @DefaultPromptForContextCompressionID = @MJAIConfigurations_DefaultPromptForContextSummarizationID_DefaultPromptForContextCompressionID, @DefaultPromptForContextSummarizationID = @MJAIConfigurations_DefaultPromptForContextSummarizationID_DefaultPromptForContextSummarizationID, @DefaultStorageProviderID = @MJAIConfigurations_DefaultPromptForContextSummarizationID_DefaultStorageProviderID, @DefaultStorageRootPath = @MJAIConfigurations_DefaultPromptForContextSummarizationID_DefaultStorageRootPath, @ParentID = @MJAIConfigurations_DefaultPromptForContextSummarizationID_ParentID
+
+        FETCH NEXT FROM cascade_update_MJAIConfigurations_DefaultPromptForContextSummarizationID_cursor INTO @MJAIConfigurations_DefaultPromptForContextSummarizationIDID, @MJAIConfigurations_DefaultPromptForContextSummarizationID_Name, @MJAIConfigurations_DefaultPromptForContextSummarizationID_Description, @MJAIConfigurations_DefaultPromptForContextSummarizationID_IsDefault, @MJAIConfigurations_DefaultPromptForContextSummarizationID_Status, @MJAIConfigurations_DefaultPromptForContextSummarizationID_DefaultPromptForContextCompressionID, @MJAIConfigurations_DefaultPromptForContextSummarizationID_DefaultPromptForContextSummarizationID, @MJAIConfigurations_DefaultPromptForContextSummarizationID_DefaultStorageProviderID, @MJAIConfigurations_DefaultPromptForContextSummarizationID_DefaultStorageRootPath, @MJAIConfigurations_DefaultPromptForContextSummarizationID_ParentID
+    END
+
+    CLOSE cascade_update_MJAIConfigurations_DefaultPromptForContextSummarizationID_cursor
+    DEALLOCATE cascade_update_MJAIConfigurations_DefaultPromptForContextSummarizationID_cursor
+    
+    -- Cascade delete from AIPromptModel using cursor to call spDeleteAIPromptModel
+    DECLARE @MJAIPromptModels_PromptIDID uniqueidentifier
+    DECLARE cascade_delete_MJAIPromptModels_PromptID_cursor CURSOR FOR 
+        SELECT [ID]
+        FROM [${flyway:defaultSchema}].[AIPromptModel]
+        WHERE [PromptID] = @ID
+    
+    OPEN cascade_delete_MJAIPromptModels_PromptID_cursor
+    FETCH NEXT FROM cascade_delete_MJAIPromptModels_PromptID_cursor INTO @MJAIPromptModels_PromptIDID
+    
+    WHILE @@FETCH_STATUS = 0
+    BEGIN
+        EXEC [${flyway:defaultSchema}].[spDeleteAIPromptModel] @ID = @MJAIPromptModels_PromptIDID
+        
+        FETCH NEXT FROM cascade_delete_MJAIPromptModels_PromptID_cursor INTO @MJAIPromptModels_PromptIDID
+    END
+    
+    CLOSE cascade_delete_MJAIPromptModels_PromptID_cursor
+    DEALLOCATE cascade_delete_MJAIPromptModels_PromptID_cursor
+    
+    -- Cascade delete from AIPromptRun using cursor to call spDeleteAIPromptRun
+    DECLARE @MJAIPromptRuns_PromptIDID uniqueidentifier
+    DECLARE cascade_delete_MJAIPromptRuns_PromptID_cursor CURSOR FOR 
+        SELECT [ID]
+        FROM [${flyway:defaultSchema}].[AIPromptRun]
+        WHERE [PromptID] = @ID
+    
+    OPEN cascade_delete_MJAIPromptRuns_PromptID_cursor
+    FETCH NEXT FROM cascade_delete_MJAIPromptRuns_PromptID_cursor INTO @MJAIPromptRuns_PromptIDID
+    
+    WHILE @@FETCH_STATUS = 0
+    BEGIN
+        EXEC [${flyway:defaultSchema}].[spDeleteAIPromptRun] @ID = @MJAIPromptRuns_PromptIDID
+        
+        FETCH NEXT FROM cascade_delete_MJAIPromptRuns_PromptID_cursor INTO @MJAIPromptRuns_PromptIDID
+    END
+    
+    CLOSE cascade_delete_MJAIPromptRuns_PromptID_cursor
+    DEALLOCATE cascade_delete_MJAIPromptRuns_PromptID_cursor
+    
+    -- Cascade update on AIPromptRun using cursor to call spUpdateAIPromptRun
+    DECLARE @MJAIPromptRuns_JudgeIDID uniqueidentifier
+    DECLARE @MJAIPromptRuns_JudgeID_PromptID uniqueidentifier
+    DECLARE @MJAIPromptRuns_JudgeID_ModelID uniqueidentifier
+    DECLARE @MJAIPromptRuns_JudgeID_VendorID uniqueidentifier
+    DECLARE @MJAIPromptRuns_JudgeID_AgentID uniqueidentifier
+    DECLARE @MJAIPromptRuns_JudgeID_ConfigurationID uniqueidentifier
+    DECLARE @MJAIPromptRuns_JudgeID_RunAt datetimeoffset
+    DECLARE @MJAIPromptRuns_JudgeID_CompletedAt datetimeoffset
+    DECLARE @MJAIPromptRuns_JudgeID_ExecutionTimeMS int
+    DECLARE @MJAIPromptRuns_JudgeID_Messages nvarchar(MAX)
+    DECLARE @MJAIPromptRuns_JudgeID_Result nvarchar(MAX)
+    DECLARE @MJAIPromptRuns_JudgeID_TokensUsed int
+    DECLARE @MJAIPromptRuns_JudgeID_TokensPrompt int
+    DECLARE @MJAIPromptRuns_JudgeID_TokensCompletion int
+    DECLARE @MJAIPromptRuns_JudgeID_TotalCost decimal(18, 6)
+    DECLARE @MJAIPromptRuns_JudgeID_Success bit
+    DECLARE @MJAIPromptRuns_JudgeID_ErrorMessage nvarchar(MAX)
+    DECLARE @MJAIPromptRuns_JudgeID_ParentID uniqueidentifier
+    DECLARE @MJAIPromptRuns_JudgeID_RunType nvarchar(20)
+    DECLARE @MJAIPromptRuns_JudgeID_ExecutionOrder int
+    DECLARE @MJAIPromptRuns_JudgeID_AgentRunID uniqueidentifier
+    DECLARE @MJAIPromptRuns_JudgeID_Cost decimal(19, 8)
+    DECLARE @MJAIPromptRuns_JudgeID_CostCurrency nvarchar(10)
+    DECLARE @MJAIPromptRuns_JudgeID_TokensUsedRollup int
+    DECLARE @MJAIPromptRuns_JudgeID_TokensPromptRollup int
+    DECLARE @MJAIPromptRuns_JudgeID_TokensCompletionRollup int
+    DECLARE @MJAIPromptRuns_JudgeID_Temperature decimal(3, 2)
+    DECLARE @MJAIPromptRuns_JudgeID_TopP decimal(3, 2)
+    DECLARE @MJAIPromptRuns_JudgeID_TopK int
+    DECLARE @MJAIPromptRuns_JudgeID_MinP decimal(3, 2)
+    DECLARE @MJAIPromptRuns_JudgeID_FrequencyPenalty decimal(3, 2)
+    DECLARE @MJAIPromptRuns_JudgeID_PresencePenalty decimal(3, 2)
+    DECLARE @MJAIPromptRuns_JudgeID_Seed int
+    DECLARE @MJAIPromptRuns_JudgeID_StopSequences nvarchar(MAX)
+    DECLARE @MJAIPromptRuns_JudgeID_ResponseFormat nvarchar(50)
+    DECLARE @MJAIPromptRuns_JudgeID_LogProbs bit
+    DECLARE @MJAIPromptRuns_JudgeID_TopLogProbs int
+    DECLARE @MJAIPromptRuns_JudgeID_DescendantCost decimal(18, 6)
+    DECLARE @MJAIPromptRuns_JudgeID_ValidationAttemptCount int
+    DECLARE @MJAIPromptRuns_JudgeID_SuccessfulValidationCount int
+    DECLARE @MJAIPromptRuns_JudgeID_FinalValidationPassed bit
+    DECLARE @MJAIPromptRuns_JudgeID_ValidationBehavior nvarchar(50)
+    DECLARE @MJAIPromptRuns_JudgeID_RetryStrategy nvarchar(50)
+    DECLARE @MJAIPromptRuns_JudgeID_MaxRetriesConfigured int
+    DECLARE @MJAIPromptRuns_JudgeID_FinalValidationError nvarchar(500)
+    DECLARE @MJAIPromptRuns_JudgeID_ValidationErrorCount int
+    DECLARE @MJAIPromptRuns_JudgeID_CommonValidationError nvarchar(255)
+    DECLARE @MJAIPromptRuns_JudgeID_FirstAttemptAt datetimeoffset
+    DECLARE @MJAIPromptRuns_JudgeID_LastAttemptAt datetimeoffset
+    DECLARE @MJAIPromptRuns_JudgeID_TotalRetryDurationMS int
+    DECLARE @MJAIPromptRuns_JudgeID_ValidationAttempts nvarchar(MAX)
+    DECLARE @MJAIPromptRuns_JudgeID_ValidationSummary nvarchar(MAX)
+    DECLARE @MJAIPromptRuns_JudgeID_FailoverAttempts int
+    DECLARE @MJAIPromptRuns_JudgeID_FailoverErrors nvarchar(MAX)
+    DECLARE @MJAIPromptRuns_JudgeID_FailoverDurations nvarchar(MAX)
+    DECLARE @MJAIPromptRuns_JudgeID_OriginalModelID uniqueidentifier
+    DECLARE @MJAIPromptRuns_JudgeID_OriginalRequestStartTime datetimeoffset
+    DECLARE @MJAIPromptRuns_JudgeID_TotalFailoverDuration int
+    DECLARE @MJAIPromptRuns_JudgeID_RerunFromPromptRunID uniqueidentifier
+    DECLARE @MJAIPromptRuns_JudgeID_ModelSelection nvarchar(MAX)
+    DECLARE @MJAIPromptRuns_JudgeID_Status nvarchar(50)
+    DECLARE @MJAIPromptRuns_JudgeID_Cancelled bit
+    DECLARE @MJAIPromptRuns_JudgeID_CancellationReason nvarchar(MAX)
+    DECLARE @MJAIPromptRuns_JudgeID_ModelPowerRank int
+    DECLARE @MJAIPromptRuns_JudgeID_SelectionStrategy nvarchar(50)
+    DECLARE @MJAIPromptRuns_JudgeID_CacheHit bit
+    DECLARE @MJAIPromptRuns_JudgeID_CacheKey nvarchar(500)
+    DECLARE @MJAIPromptRuns_JudgeID_JudgeID uniqueidentifier
+    DECLARE @MJAIPromptRuns_JudgeID_JudgeScore float(53)
+    DECLARE @MJAIPromptRuns_JudgeID_WasSelectedResult bit
+    DECLARE @MJAIPromptRuns_JudgeID_StreamingEnabled bit
+    DECLARE @MJAIPromptRuns_JudgeID_FirstTokenTime int
+    DECLARE @MJAIPromptRuns_JudgeID_ErrorDetails nvarchar(MAX)
+    DECLARE @MJAIPromptRuns_JudgeID_ChildPromptID uniqueidentifier
+    DECLARE @MJAIPromptRuns_JudgeID_QueueTime int
+    DECLARE @MJAIPromptRuns_JudgeID_PromptTime int
+    DECLARE @MJAIPromptRuns_JudgeID_CompletionTime int
+    DECLARE @MJAIPromptRuns_JudgeID_ModelSpecificResponseDetails nvarchar(MAX)
+    DECLARE @MJAIPromptRuns_JudgeID_EffortLevel int
+    DECLARE @MJAIPromptRuns_JudgeID_RunName nvarchar(255)
+    DECLARE @MJAIPromptRuns_JudgeID_Comments nvarchar(MAX)
+    DECLARE @MJAIPromptRuns_JudgeID_TestRunID uniqueidentifier
+    DECLARE @MJAIPromptRuns_JudgeID_AssistantPrefill nvarchar(MAX)
+    DECLARE cascade_update_MJAIPromptRuns_JudgeID_cursor CURSOR FOR
+        SELECT [ID], [PromptID], [ModelID], [VendorID], [AgentID], [ConfigurationID], [RunAt], [CompletedAt], [ExecutionTimeMS], [Messages], [Result], [TokensUsed], [TokensPrompt], [TokensCompletion], [TotalCost], [Success], [ErrorMessage], [ParentID], [RunType], [ExecutionOrder], [AgentRunID], [Cost], [CostCurrency], [TokensUsedRollup], [TokensPromptRollup], [TokensCompletionRollup], [Temperature], [TopP], [TopK], [MinP], [FrequencyPenalty], [PresencePenalty], [Seed], [StopSequences], [ResponseFormat], [LogProbs], [TopLogProbs], [DescendantCost], [ValidationAttemptCount], [SuccessfulValidationCount], [FinalValidationPassed], [ValidationBehavior], [RetryStrategy], [MaxRetriesConfigured], [FinalValidationError], [ValidationErrorCount], [CommonValidationError], [FirstAttemptAt], [LastAttemptAt], [TotalRetryDurationMS], [ValidationAttempts], [ValidationSummary], [FailoverAttempts], [FailoverErrors], [FailoverDurations], [OriginalModelID], [OriginalRequestStartTime], [TotalFailoverDuration], [RerunFromPromptRunID], [ModelSelection], [Status], [Cancelled], [CancellationReason], [ModelPowerRank], [SelectionStrategy], [CacheHit], [CacheKey], [JudgeID], [JudgeScore], [WasSelectedResult], [StreamingEnabled], [FirstTokenTime], [ErrorDetails], [ChildPromptID], [QueueTime], [PromptTime], [CompletionTime], [ModelSpecificResponseDetails], [EffortLevel], [RunName], [Comments], [TestRunID], [AssistantPrefill]
+        FROM [${flyway:defaultSchema}].[AIPromptRun]
+        WHERE [JudgeID] = @ID
+
+    OPEN cascade_update_MJAIPromptRuns_JudgeID_cursor
+    FETCH NEXT FROM cascade_update_MJAIPromptRuns_JudgeID_cursor INTO @MJAIPromptRuns_JudgeIDID, @MJAIPromptRuns_JudgeID_PromptID, @MJAIPromptRuns_JudgeID_ModelID, @MJAIPromptRuns_JudgeID_VendorID, @MJAIPromptRuns_JudgeID_AgentID, @MJAIPromptRuns_JudgeID_ConfigurationID, @MJAIPromptRuns_JudgeID_RunAt, @MJAIPromptRuns_JudgeID_CompletedAt, @MJAIPromptRuns_JudgeID_ExecutionTimeMS, @MJAIPromptRuns_JudgeID_Messages, @MJAIPromptRuns_JudgeID_Result, @MJAIPromptRuns_JudgeID_TokensUsed, @MJAIPromptRuns_JudgeID_TokensPrompt, @MJAIPromptRuns_JudgeID_TokensCompletion, @MJAIPromptRuns_JudgeID_TotalCost, @MJAIPromptRuns_JudgeID_Success, @MJAIPromptRuns_JudgeID_ErrorMessage, @MJAIPromptRuns_JudgeID_ParentID, @MJAIPromptRuns_JudgeID_RunType, @MJAIPromptRuns_JudgeID_ExecutionOrder, @MJAIPromptRuns_JudgeID_AgentRunID, @MJAIPromptRuns_JudgeID_Cost, @MJAIPromptRuns_JudgeID_CostCurrency, @MJAIPromptRuns_JudgeID_TokensUsedRollup, @MJAIPromptRuns_JudgeID_TokensPromptRollup, @MJAIPromptRuns_JudgeID_TokensCompletionRollup, @MJAIPromptRuns_JudgeID_Temperature, @MJAIPromptRuns_JudgeID_TopP, @MJAIPromptRuns_JudgeID_TopK, @MJAIPromptRuns_JudgeID_MinP, @MJAIPromptRuns_JudgeID_FrequencyPenalty, @MJAIPromptRuns_JudgeID_PresencePenalty, @MJAIPromptRuns_JudgeID_Seed, @MJAIPromptRuns_JudgeID_StopSequences, @MJAIPromptRuns_JudgeID_ResponseFormat, @MJAIPromptRuns_JudgeID_LogProbs, @MJAIPromptRuns_JudgeID_TopLogProbs, @MJAIPromptRuns_JudgeID_DescendantCost, @MJAIPromptRuns_JudgeID_ValidationAttemptCount, @MJAIPromptRuns_JudgeID_SuccessfulValidationCount, @MJAIPromptRuns_JudgeID_FinalValidationPassed, @MJAIPromptRuns_JudgeID_ValidationBehavior, @MJAIPromptRuns_JudgeID_RetryStrategy, @MJAIPromptRuns_JudgeID_MaxRetriesConfigured, @MJAIPromptRuns_JudgeID_FinalValidationError, @MJAIPromptRuns_JudgeID_ValidationErrorCount, @MJAIPromptRuns_JudgeID_CommonValidationError, @MJAIPromptRuns_JudgeID_FirstAttemptAt, @MJAIPromptRuns_JudgeID_LastAttemptAt, @MJAIPromptRuns_JudgeID_TotalRetryDurationMS, @MJAIPromptRuns_JudgeID_ValidationAttempts, @MJAIPromptRuns_JudgeID_ValidationSummary, @MJAIPromptRuns_JudgeID_FailoverAttempts, @MJAIPromptRuns_JudgeID_FailoverErrors, @MJAIPromptRuns_JudgeID_FailoverDurations, @MJAIPromptRuns_JudgeID_OriginalModelID, @MJAIPromptRuns_JudgeID_OriginalRequestStartTime, @MJAIPromptRuns_JudgeID_TotalFailoverDuration, @MJAIPromptRuns_JudgeID_RerunFromPromptRunID, @MJAIPromptRuns_JudgeID_ModelSelection, @MJAIPromptRuns_JudgeID_Status, @MJAIPromptRuns_JudgeID_Cancelled, @MJAIPromptRuns_JudgeID_CancellationReason, @MJAIPromptRuns_JudgeID_ModelPowerRank, @MJAIPromptRuns_JudgeID_SelectionStrategy, @MJAIPromptRuns_JudgeID_CacheHit, @MJAIPromptRuns_JudgeID_CacheKey, @MJAIPromptRuns_JudgeID_JudgeID, @MJAIPromptRuns_JudgeID_JudgeScore, @MJAIPromptRuns_JudgeID_WasSelectedResult, @MJAIPromptRuns_JudgeID_StreamingEnabled, @MJAIPromptRuns_JudgeID_FirstTokenTime, @MJAIPromptRuns_JudgeID_ErrorDetails, @MJAIPromptRuns_JudgeID_ChildPromptID, @MJAIPromptRuns_JudgeID_QueueTime, @MJAIPromptRuns_JudgeID_PromptTime, @MJAIPromptRuns_JudgeID_CompletionTime, @MJAIPromptRuns_JudgeID_ModelSpecificResponseDetails, @MJAIPromptRuns_JudgeID_EffortLevel, @MJAIPromptRuns_JudgeID_RunName, @MJAIPromptRuns_JudgeID_Comments, @MJAIPromptRuns_JudgeID_TestRunID, @MJAIPromptRuns_JudgeID_AssistantPrefill
+
+    WHILE @@FETCH_STATUS = 0
+    BEGIN
+        -- Set the FK field to NULL
+        SET @MJAIPromptRuns_JudgeID_JudgeID = NULL
+
+        -- Call the update SP for the related entity
+        EXEC [${flyway:defaultSchema}].[spUpdateAIPromptRun] @ID = @MJAIPromptRuns_JudgeIDID, @PromptID = @MJAIPromptRuns_JudgeID_PromptID, @ModelID = @MJAIPromptRuns_JudgeID_ModelID, @VendorID = @MJAIPromptRuns_JudgeID_VendorID, @AgentID = @MJAIPromptRuns_JudgeID_AgentID, @ConfigurationID = @MJAIPromptRuns_JudgeID_ConfigurationID, @RunAt = @MJAIPromptRuns_JudgeID_RunAt, @CompletedAt = @MJAIPromptRuns_JudgeID_CompletedAt, @ExecutionTimeMS = @MJAIPromptRuns_JudgeID_ExecutionTimeMS, @Messages = @MJAIPromptRuns_JudgeID_Messages, @Result = @MJAIPromptRuns_JudgeID_Result, @TokensUsed = @MJAIPromptRuns_JudgeID_TokensUsed, @TokensPrompt = @MJAIPromptRuns_JudgeID_TokensPrompt, @TokensCompletion = @MJAIPromptRuns_JudgeID_TokensCompletion, @TotalCost = @MJAIPromptRuns_JudgeID_TotalCost, @Success = @MJAIPromptRuns_JudgeID_Success, @ErrorMessage = @MJAIPromptRuns_JudgeID_ErrorMessage, @ParentID = @MJAIPromptRuns_JudgeID_ParentID, @RunType = @MJAIPromptRuns_JudgeID_RunType, @ExecutionOrder = @MJAIPromptRuns_JudgeID_ExecutionOrder, @AgentRunID = @MJAIPromptRuns_JudgeID_AgentRunID, @Cost = @MJAIPromptRuns_JudgeID_Cost, @CostCurrency = @MJAIPromptRuns_JudgeID_CostCurrency, @TokensUsedRollup = @MJAIPromptRuns_JudgeID_TokensUsedRollup, @TokensPromptRollup = @MJAIPromptRuns_JudgeID_TokensPromptRollup, @TokensCompletionRollup = @MJAIPromptRuns_JudgeID_TokensCompletionRollup, @Temperature = @MJAIPromptRuns_JudgeID_Temperature, @TopP = @MJAIPromptRuns_JudgeID_TopP, @TopK = @MJAIPromptRuns_JudgeID_TopK, @MinP = @MJAIPromptRuns_JudgeID_MinP, @FrequencyPenalty = @MJAIPromptRuns_JudgeID_FrequencyPenalty, @PresencePenalty = @MJAIPromptRuns_JudgeID_PresencePenalty, @Seed = @MJAIPromptRuns_JudgeID_Seed, @StopSequences = @MJAIPromptRuns_JudgeID_StopSequences, @ResponseFormat = @MJAIPromptRuns_JudgeID_ResponseFormat, @LogProbs = @MJAIPromptRuns_JudgeID_LogProbs, @TopLogProbs = @MJAIPromptRuns_JudgeID_TopLogProbs, @DescendantCost = @MJAIPromptRuns_JudgeID_DescendantCost, @ValidationAttemptCount = @MJAIPromptRuns_JudgeID_ValidationAttemptCount, @SuccessfulValidationCount = @MJAIPromptRuns_JudgeID_SuccessfulValidationCount, @FinalValidationPassed = @MJAIPromptRuns_JudgeID_FinalValidationPassed, @ValidationBehavior = @MJAIPromptRuns_JudgeID_ValidationBehavior, @RetryStrategy = @MJAIPromptRuns_JudgeID_RetryStrategy, @MaxRetriesConfigured = @MJAIPromptRuns_JudgeID_MaxRetriesConfigured, @FinalValidationError = @MJAIPromptRuns_JudgeID_FinalValidationError, @ValidationErrorCount = @MJAIPromptRuns_JudgeID_ValidationErrorCount, @CommonValidationError = @MJAIPromptRuns_JudgeID_CommonValidationError, @FirstAttemptAt = @MJAIPromptRuns_JudgeID_FirstAttemptAt, @LastAttemptAt = @MJAIPromptRuns_JudgeID_LastAttemptAt, @TotalRetryDurationMS = @MJAIPromptRuns_JudgeID_TotalRetryDurationMS, @ValidationAttempts = @MJAIPromptRuns_JudgeID_ValidationAttempts, @ValidationSummary = @MJAIPromptRuns_JudgeID_ValidationSummary, @FailoverAttempts = @MJAIPromptRuns_JudgeID_FailoverAttempts, @FailoverErrors = @MJAIPromptRuns_JudgeID_FailoverErrors, @FailoverDurations = @MJAIPromptRuns_JudgeID_FailoverDurations, @OriginalModelID = @MJAIPromptRuns_JudgeID_OriginalModelID, @OriginalRequestStartTime = @MJAIPromptRuns_JudgeID_OriginalRequestStartTime, @TotalFailoverDuration = @MJAIPromptRuns_JudgeID_TotalFailoverDuration, @RerunFromPromptRunID = @MJAIPromptRuns_JudgeID_RerunFromPromptRunID, @ModelSelection = @MJAIPromptRuns_JudgeID_ModelSelection, @Status = @MJAIPromptRuns_JudgeID_Status, @Cancelled = @MJAIPromptRuns_JudgeID_Cancelled, @CancellationReason = @MJAIPromptRuns_JudgeID_CancellationReason, @ModelPowerRank = @MJAIPromptRuns_JudgeID_ModelPowerRank, @SelectionStrategy = @MJAIPromptRuns_JudgeID_SelectionStrategy, @CacheHit = @MJAIPromptRuns_JudgeID_CacheHit, @CacheKey = @MJAIPromptRuns_JudgeID_CacheKey, @JudgeID = @MJAIPromptRuns_JudgeID_JudgeID, @JudgeScore = @MJAIPromptRuns_JudgeID_JudgeScore, @WasSelectedResult = @MJAIPromptRuns_JudgeID_WasSelectedResult, @StreamingEnabled = @MJAIPromptRuns_JudgeID_StreamingEnabled, @FirstTokenTime = @MJAIPromptRuns_JudgeID_FirstTokenTime, @ErrorDetails = @MJAIPromptRuns_JudgeID_ErrorDetails, @ChildPromptID = @MJAIPromptRuns_JudgeID_ChildPromptID, @QueueTime = @MJAIPromptRuns_JudgeID_QueueTime, @PromptTime = @MJAIPromptRuns_JudgeID_PromptTime, @CompletionTime = @MJAIPromptRuns_JudgeID_CompletionTime, @ModelSpecificResponseDetails = @MJAIPromptRuns_JudgeID_ModelSpecificResponseDetails, @EffortLevel = @MJAIPromptRuns_JudgeID_EffortLevel, @RunName = @MJAIPromptRuns_JudgeID_RunName, @Comments = @MJAIPromptRuns_JudgeID_Comments, @TestRunID = @MJAIPromptRuns_JudgeID_TestRunID, @AssistantPrefill = @MJAIPromptRuns_JudgeID_AssistantPrefill
+
+        FETCH NEXT FROM cascade_update_MJAIPromptRuns_JudgeID_cursor INTO @MJAIPromptRuns_JudgeIDID, @MJAIPromptRuns_JudgeID_PromptID, @MJAIPromptRuns_JudgeID_ModelID, @MJAIPromptRuns_JudgeID_VendorID, @MJAIPromptRuns_JudgeID_AgentID, @MJAIPromptRuns_JudgeID_ConfigurationID, @MJAIPromptRuns_JudgeID_RunAt, @MJAIPromptRuns_JudgeID_CompletedAt, @MJAIPromptRuns_JudgeID_ExecutionTimeMS, @MJAIPromptRuns_JudgeID_Messages, @MJAIPromptRuns_JudgeID_Result, @MJAIPromptRuns_JudgeID_TokensUsed, @MJAIPromptRuns_JudgeID_TokensPrompt, @MJAIPromptRuns_JudgeID_TokensCompletion, @MJAIPromptRuns_JudgeID_TotalCost, @MJAIPromptRuns_JudgeID_Success, @MJAIPromptRuns_JudgeID_ErrorMessage, @MJAIPromptRuns_JudgeID_ParentID, @MJAIPromptRuns_JudgeID_RunType, @MJAIPromptRuns_JudgeID_ExecutionOrder, @MJAIPromptRuns_JudgeID_AgentRunID, @MJAIPromptRuns_JudgeID_Cost, @MJAIPromptRuns_JudgeID_CostCurrency, @MJAIPromptRuns_JudgeID_TokensUsedRollup, @MJAIPromptRuns_JudgeID_TokensPromptRollup, @MJAIPromptRuns_JudgeID_TokensCompletionRollup, @MJAIPromptRuns_JudgeID_Temperature, @MJAIPromptRuns_JudgeID_TopP, @MJAIPromptRuns_JudgeID_TopK, @MJAIPromptRuns_JudgeID_MinP, @MJAIPromptRuns_JudgeID_FrequencyPenalty, @MJAIPromptRuns_JudgeID_PresencePenalty, @MJAIPromptRuns_JudgeID_Seed, @MJAIPromptRuns_JudgeID_StopSequences, @MJAIPromptRuns_JudgeID_ResponseFormat, @MJAIPromptRuns_JudgeID_LogProbs, @MJAIPromptRuns_JudgeID_TopLogProbs, @MJAIPromptRuns_JudgeID_DescendantCost, @MJAIPromptRuns_JudgeID_ValidationAttemptCount, @MJAIPromptRuns_JudgeID_SuccessfulValidationCount, @MJAIPromptRuns_JudgeID_FinalValidationPassed, @MJAIPromptRuns_JudgeID_ValidationBehavior, @MJAIPromptRuns_JudgeID_RetryStrategy, @MJAIPromptRuns_JudgeID_MaxRetriesConfigured, @MJAIPromptRuns_JudgeID_FinalValidationError, @MJAIPromptRuns_JudgeID_ValidationErrorCount, @MJAIPromptRuns_JudgeID_CommonValidationError, @MJAIPromptRuns_JudgeID_FirstAttemptAt, @MJAIPromptRuns_JudgeID_LastAttemptAt, @MJAIPromptRuns_JudgeID_TotalRetryDurationMS, @MJAIPromptRuns_JudgeID_ValidationAttempts, @MJAIPromptRuns_JudgeID_ValidationSummary, @MJAIPromptRuns_JudgeID_FailoverAttempts, @MJAIPromptRuns_JudgeID_FailoverErrors, @MJAIPromptRuns_JudgeID_FailoverDurations, @MJAIPromptRuns_JudgeID_OriginalModelID, @MJAIPromptRuns_JudgeID_OriginalRequestStartTime, @MJAIPromptRuns_JudgeID_TotalFailoverDuration, @MJAIPromptRuns_JudgeID_RerunFromPromptRunID, @MJAIPromptRuns_JudgeID_ModelSelection, @MJAIPromptRuns_JudgeID_Status, @MJAIPromptRuns_JudgeID_Cancelled, @MJAIPromptRuns_JudgeID_CancellationReason, @MJAIPromptRuns_JudgeID_ModelPowerRank, @MJAIPromptRuns_JudgeID_SelectionStrategy, @MJAIPromptRuns_JudgeID_CacheHit, @MJAIPromptRuns_JudgeID_CacheKey, @MJAIPromptRuns_JudgeID_JudgeID, @MJAIPromptRuns_JudgeID_JudgeScore, @MJAIPromptRuns_JudgeID_WasSelectedResult, @MJAIPromptRuns_JudgeID_StreamingEnabled, @MJAIPromptRuns_JudgeID_FirstTokenTime, @MJAIPromptRuns_JudgeID_ErrorDetails, @MJAIPromptRuns_JudgeID_ChildPromptID, @MJAIPromptRuns_JudgeID_QueueTime, @MJAIPromptRuns_JudgeID_PromptTime, @MJAIPromptRuns_JudgeID_CompletionTime, @MJAIPromptRuns_JudgeID_ModelSpecificResponseDetails, @MJAIPromptRuns_JudgeID_EffortLevel, @MJAIPromptRuns_JudgeID_RunName, @MJAIPromptRuns_JudgeID_Comments, @MJAIPromptRuns_JudgeID_TestRunID, @MJAIPromptRuns_JudgeID_AssistantPrefill
+    END
+
+    CLOSE cascade_update_MJAIPromptRuns_JudgeID_cursor
+    DEALLOCATE cascade_update_MJAIPromptRuns_JudgeID_cursor
+    
+    -- Cascade update on AIPromptRun using cursor to call spUpdateAIPromptRun
+    DECLARE @MJAIPromptRuns_ChildPromptIDID uniqueidentifier
+    DECLARE @MJAIPromptRuns_ChildPromptID_PromptID uniqueidentifier
+    DECLARE @MJAIPromptRuns_ChildPromptID_ModelID uniqueidentifier
+    DECLARE @MJAIPromptRuns_ChildPromptID_VendorID uniqueidentifier
+    DECLARE @MJAIPromptRuns_ChildPromptID_AgentID uniqueidentifier
+    DECLARE @MJAIPromptRuns_ChildPromptID_ConfigurationID uniqueidentifier
+    DECLARE @MJAIPromptRuns_ChildPromptID_RunAt datetimeoffset
+    DECLARE @MJAIPromptRuns_ChildPromptID_CompletedAt datetimeoffset
+    DECLARE @MJAIPromptRuns_ChildPromptID_ExecutionTimeMS int
+    DECLARE @MJAIPromptRuns_ChildPromptID_Messages nvarchar(MAX)
+    DECLARE @MJAIPromptRuns_ChildPromptID_Result nvarchar(MAX)
+    DECLARE @MJAIPromptRuns_ChildPromptID_TokensUsed int
+    DECLARE @MJAIPromptRuns_ChildPromptID_TokensPrompt int
+    DECLARE @MJAIPromptRuns_ChildPromptID_TokensCompletion int
+    DECLARE @MJAIPromptRuns_ChildPromptID_TotalCost decimal(18, 6)
+    DECLARE @MJAIPromptRuns_ChildPromptID_Success bit
+    DECLARE @MJAIPromptRuns_ChildPromptID_ErrorMessage nvarchar(MAX)
+    DECLARE @MJAIPromptRuns_ChildPromptID_ParentID uniqueidentifier
+    DECLARE @MJAIPromptRuns_ChildPromptID_RunType nvarchar(20)
+    DECLARE @MJAIPromptRuns_ChildPromptID_ExecutionOrder int
+    DECLARE @MJAIPromptRuns_ChildPromptID_AgentRunID uniqueidentifier
+    DECLARE @MJAIPromptRuns_ChildPromptID_Cost decimal(19, 8)
+    DECLARE @MJAIPromptRuns_ChildPromptID_CostCurrency nvarchar(10)
+    DECLARE @MJAIPromptRuns_ChildPromptID_TokensUsedRollup int
+    DECLARE @MJAIPromptRuns_ChildPromptID_TokensPromptRollup int
+    DECLARE @MJAIPromptRuns_ChildPromptID_TokensCompletionRollup int
+    DECLARE @MJAIPromptRuns_ChildPromptID_Temperature decimal(3, 2)
+    DECLARE @MJAIPromptRuns_ChildPromptID_TopP decimal(3, 2)
+    DECLARE @MJAIPromptRuns_ChildPromptID_TopK int
+    DECLARE @MJAIPromptRuns_ChildPromptID_MinP decimal(3, 2)
+    DECLARE @MJAIPromptRuns_ChildPromptID_FrequencyPenalty decimal(3, 2)
+    DECLARE @MJAIPromptRuns_ChildPromptID_PresencePenalty decimal(3, 2)
+    DECLARE @MJAIPromptRuns_ChildPromptID_Seed int
+    DECLARE @MJAIPromptRuns_ChildPromptID_StopSequences nvarchar(MAX)
+    DECLARE @MJAIPromptRuns_ChildPromptID_ResponseFormat nvarchar(50)
+    DECLARE @MJAIPromptRuns_ChildPromptID_LogProbs bit
+    DECLARE @MJAIPromptRuns_ChildPromptID_TopLogProbs int
+    DECLARE @MJAIPromptRuns_ChildPromptID_DescendantCost decimal(18, 6)
+    DECLARE @MJAIPromptRuns_ChildPromptID_ValidationAttemptCount int
+    DECLARE @MJAIPromptRuns_ChildPromptID_SuccessfulValidationCount int
+    DECLARE @MJAIPromptRuns_ChildPromptID_FinalValidationPassed bit
+    DECLARE @MJAIPromptRuns_ChildPromptID_ValidationBehavior nvarchar(50)
+    DECLARE @MJAIPromptRuns_ChildPromptID_RetryStrategy nvarchar(50)
+    DECLARE @MJAIPromptRuns_ChildPromptID_MaxRetriesConfigured int
+    DECLARE @MJAIPromptRuns_ChildPromptID_FinalValidationError nvarchar(500)
+    DECLARE @MJAIPromptRuns_ChildPromptID_ValidationErrorCount int
+    DECLARE @MJAIPromptRuns_ChildPromptID_CommonValidationError nvarchar(255)
+    DECLARE @MJAIPromptRuns_ChildPromptID_FirstAttemptAt datetimeoffset
+    DECLARE @MJAIPromptRuns_ChildPromptID_LastAttemptAt datetimeoffset
+    DECLARE @MJAIPromptRuns_ChildPromptID_TotalRetryDurationMS int
+    DECLARE @MJAIPromptRuns_ChildPromptID_ValidationAttempts nvarchar(MAX)
+    DECLARE @MJAIPromptRuns_ChildPromptID_ValidationSummary nvarchar(MAX)
+    DECLARE @MJAIPromptRuns_ChildPromptID_FailoverAttempts int
+    DECLARE @MJAIPromptRuns_ChildPromptID_FailoverErrors nvarchar(MAX)
+    DECLARE @MJAIPromptRuns_ChildPromptID_FailoverDurations nvarchar(MAX)
+    DECLARE @MJAIPromptRuns_ChildPromptID_OriginalModelID uniqueidentifier
+    DECLARE @MJAIPromptRuns_ChildPromptID_OriginalRequestStartTime datetimeoffset
+    DECLARE @MJAIPromptRuns_ChildPromptID_TotalFailoverDuration int
+    DECLARE @MJAIPromptRuns_ChildPromptID_RerunFromPromptRunID uniqueidentifier
+    DECLARE @MJAIPromptRuns_ChildPromptID_ModelSelection nvarchar(MAX)
+    DECLARE @MJAIPromptRuns_ChildPromptID_Status nvarchar(50)
+    DECLARE @MJAIPromptRuns_ChildPromptID_Cancelled bit
+    DECLARE @MJAIPromptRuns_ChildPromptID_CancellationReason nvarchar(MAX)
+    DECLARE @MJAIPromptRuns_ChildPromptID_ModelPowerRank int
+    DECLARE @MJAIPromptRuns_ChildPromptID_SelectionStrategy nvarchar(50)
+    DECLARE @MJAIPromptRuns_ChildPromptID_CacheHit bit
+    DECLARE @MJAIPromptRuns_ChildPromptID_CacheKey nvarchar(500)
+    DECLARE @MJAIPromptRuns_ChildPromptID_JudgeID uniqueidentifier
+    DECLARE @MJAIPromptRuns_ChildPromptID_JudgeScore float(53)
+    DECLARE @MJAIPromptRuns_ChildPromptID_WasSelectedResult bit
+    DECLARE @MJAIPromptRuns_ChildPromptID_StreamingEnabled bit
+    DECLARE @MJAIPromptRuns_ChildPromptID_FirstTokenTime int
+    DECLARE @MJAIPromptRuns_ChildPromptID_ErrorDetails nvarchar(MAX)
+    DECLARE @MJAIPromptRuns_ChildPromptID_ChildPromptID uniqueidentifier
+    DECLARE @MJAIPromptRuns_ChildPromptID_QueueTime int
+    DECLARE @MJAIPromptRuns_ChildPromptID_PromptTime int
+    DECLARE @MJAIPromptRuns_ChildPromptID_CompletionTime int
+    DECLARE @MJAIPromptRuns_ChildPromptID_ModelSpecificResponseDetails nvarchar(MAX)
+    DECLARE @MJAIPromptRuns_ChildPromptID_EffortLevel int
+    DECLARE @MJAIPromptRuns_ChildPromptID_RunName nvarchar(255)
+    DECLARE @MJAIPromptRuns_ChildPromptID_Comments nvarchar(MAX)
+    DECLARE @MJAIPromptRuns_ChildPromptID_TestRunID uniqueidentifier
+    DECLARE @MJAIPromptRuns_ChildPromptID_AssistantPrefill nvarchar(MAX)
+    DECLARE cascade_update_MJAIPromptRuns_ChildPromptID_cursor CURSOR FOR
+        SELECT [ID], [PromptID], [ModelID], [VendorID], [AgentID], [ConfigurationID], [RunAt], [CompletedAt], [ExecutionTimeMS], [Messages], [Result], [TokensUsed], [TokensPrompt], [TokensCompletion], [TotalCost], [Success], [ErrorMessage], [ParentID], [RunType], [ExecutionOrder], [AgentRunID], [Cost], [CostCurrency], [TokensUsedRollup], [TokensPromptRollup], [TokensCompletionRollup], [Temperature], [TopP], [TopK], [MinP], [FrequencyPenalty], [PresencePenalty], [Seed], [StopSequences], [ResponseFormat], [LogProbs], [TopLogProbs], [DescendantCost], [ValidationAttemptCount], [SuccessfulValidationCount], [FinalValidationPassed], [ValidationBehavior], [RetryStrategy], [MaxRetriesConfigured], [FinalValidationError], [ValidationErrorCount], [CommonValidationError], [FirstAttemptAt], [LastAttemptAt], [TotalRetryDurationMS], [ValidationAttempts], [ValidationSummary], [FailoverAttempts], [FailoverErrors], [FailoverDurations], [OriginalModelID], [OriginalRequestStartTime], [TotalFailoverDuration], [RerunFromPromptRunID], [ModelSelection], [Status], [Cancelled], [CancellationReason], [ModelPowerRank], [SelectionStrategy], [CacheHit], [CacheKey], [JudgeID], [JudgeScore], [WasSelectedResult], [StreamingEnabled], [FirstTokenTime], [ErrorDetails], [ChildPromptID], [QueueTime], [PromptTime], [CompletionTime], [ModelSpecificResponseDetails], [EffortLevel], [RunName], [Comments], [TestRunID], [AssistantPrefill]
+        FROM [${flyway:defaultSchema}].[AIPromptRun]
+        WHERE [ChildPromptID] = @ID
+
+    OPEN cascade_update_MJAIPromptRuns_ChildPromptID_cursor
+    FETCH NEXT FROM cascade_update_MJAIPromptRuns_ChildPromptID_cursor INTO @MJAIPromptRuns_ChildPromptIDID, @MJAIPromptRuns_ChildPromptID_PromptID, @MJAIPromptRuns_ChildPromptID_ModelID, @MJAIPromptRuns_ChildPromptID_VendorID, @MJAIPromptRuns_ChildPromptID_AgentID, @MJAIPromptRuns_ChildPromptID_ConfigurationID, @MJAIPromptRuns_ChildPromptID_RunAt, @MJAIPromptRuns_ChildPromptID_CompletedAt, @MJAIPromptRuns_ChildPromptID_ExecutionTimeMS, @MJAIPromptRuns_ChildPromptID_Messages, @MJAIPromptRuns_ChildPromptID_Result, @MJAIPromptRuns_ChildPromptID_TokensUsed, @MJAIPromptRuns_ChildPromptID_TokensPrompt, @MJAIPromptRuns_ChildPromptID_TokensCompletion, @MJAIPromptRuns_ChildPromptID_TotalCost, @MJAIPromptRuns_ChildPromptID_Success, @MJAIPromptRuns_ChildPromptID_ErrorMessage, @MJAIPromptRuns_ChildPromptID_ParentID, @MJAIPromptRuns_ChildPromptID_RunType, @MJAIPromptRuns_ChildPromptID_ExecutionOrder, @MJAIPromptRuns_ChildPromptID_AgentRunID, @MJAIPromptRuns_ChildPromptID_Cost, @MJAIPromptRuns_ChildPromptID_CostCurrency, @MJAIPromptRuns_ChildPromptID_TokensUsedRollup, @MJAIPromptRuns_ChildPromptID_TokensPromptRollup, @MJAIPromptRuns_ChildPromptID_TokensCompletionRollup, @MJAIPromptRuns_ChildPromptID_Temperature, @MJAIPromptRuns_ChildPromptID_TopP, @MJAIPromptRuns_ChildPromptID_TopK, @MJAIPromptRuns_ChildPromptID_MinP, @MJAIPromptRuns_ChildPromptID_FrequencyPenalty, @MJAIPromptRuns_ChildPromptID_PresencePenalty, @MJAIPromptRuns_ChildPromptID_Seed, @MJAIPromptRuns_ChildPromptID_StopSequences, @MJAIPromptRuns_ChildPromptID_ResponseFormat, @MJAIPromptRuns_ChildPromptID_LogProbs, @MJAIPromptRuns_ChildPromptID_TopLogProbs, @MJAIPromptRuns_ChildPromptID_DescendantCost, @MJAIPromptRuns_ChildPromptID_ValidationAttemptCount, @MJAIPromptRuns_ChildPromptID_SuccessfulValidationCount, @MJAIPromptRuns_ChildPromptID_FinalValidationPassed, @MJAIPromptRuns_ChildPromptID_ValidationBehavior, @MJAIPromptRuns_ChildPromptID_RetryStrategy, @MJAIPromptRuns_ChildPromptID_MaxRetriesConfigured, @MJAIPromptRuns_ChildPromptID_FinalValidationError, @MJAIPromptRuns_ChildPromptID_ValidationErrorCount, @MJAIPromptRuns_ChildPromptID_CommonValidationError, @MJAIPromptRuns_ChildPromptID_FirstAttemptAt, @MJAIPromptRuns_ChildPromptID_LastAttemptAt, @MJAIPromptRuns_ChildPromptID_TotalRetryDurationMS, @MJAIPromptRuns_ChildPromptID_ValidationAttempts, @MJAIPromptRuns_ChildPromptID_ValidationSummary, @MJAIPromptRuns_ChildPromptID_FailoverAttempts, @MJAIPromptRuns_ChildPromptID_FailoverErrors, @MJAIPromptRuns_ChildPromptID_FailoverDurations, @MJAIPromptRuns_ChildPromptID_OriginalModelID, @MJAIPromptRuns_ChildPromptID_OriginalRequestStartTime, @MJAIPromptRuns_ChildPromptID_TotalFailoverDuration, @MJAIPromptRuns_ChildPromptID_RerunFromPromptRunID, @MJAIPromptRuns_ChildPromptID_ModelSelection, @MJAIPromptRuns_ChildPromptID_Status, @MJAIPromptRuns_ChildPromptID_Cancelled, @MJAIPromptRuns_ChildPromptID_CancellationReason, @MJAIPromptRuns_ChildPromptID_ModelPowerRank, @MJAIPromptRuns_ChildPromptID_SelectionStrategy, @MJAIPromptRuns_ChildPromptID_CacheHit, @MJAIPromptRuns_ChildPromptID_CacheKey, @MJAIPromptRuns_ChildPromptID_JudgeID, @MJAIPromptRuns_ChildPromptID_JudgeScore, @MJAIPromptRuns_ChildPromptID_WasSelectedResult, @MJAIPromptRuns_ChildPromptID_StreamingEnabled, @MJAIPromptRuns_ChildPromptID_FirstTokenTime, @MJAIPromptRuns_ChildPromptID_ErrorDetails, @MJAIPromptRuns_ChildPromptID_ChildPromptID, @MJAIPromptRuns_ChildPromptID_QueueTime, @MJAIPromptRuns_ChildPromptID_PromptTime, @MJAIPromptRuns_ChildPromptID_CompletionTime, @MJAIPromptRuns_ChildPromptID_ModelSpecificResponseDetails, @MJAIPromptRuns_ChildPromptID_EffortLevel, @MJAIPromptRuns_ChildPromptID_RunName, @MJAIPromptRuns_ChildPromptID_Comments, @MJAIPromptRuns_ChildPromptID_TestRunID, @MJAIPromptRuns_ChildPromptID_AssistantPrefill
+
+    WHILE @@FETCH_STATUS = 0
+    BEGIN
+        -- Set the FK field to NULL
+        SET @MJAIPromptRuns_ChildPromptID_ChildPromptID = NULL
+
+        -- Call the update SP for the related entity
+        EXEC [${flyway:defaultSchema}].[spUpdateAIPromptRun] @ID = @MJAIPromptRuns_ChildPromptIDID, @PromptID = @MJAIPromptRuns_ChildPromptID_PromptID, @ModelID = @MJAIPromptRuns_ChildPromptID_ModelID, @VendorID = @MJAIPromptRuns_ChildPromptID_VendorID, @AgentID = @MJAIPromptRuns_ChildPromptID_AgentID, @ConfigurationID = @MJAIPromptRuns_ChildPromptID_ConfigurationID, @RunAt = @MJAIPromptRuns_ChildPromptID_RunAt, @CompletedAt = @MJAIPromptRuns_ChildPromptID_CompletedAt, @ExecutionTimeMS = @MJAIPromptRuns_ChildPromptID_ExecutionTimeMS, @Messages = @MJAIPromptRuns_ChildPromptID_Messages, @Result = @MJAIPromptRuns_ChildPromptID_Result, @TokensUsed = @MJAIPromptRuns_ChildPromptID_TokensUsed, @TokensPrompt = @MJAIPromptRuns_ChildPromptID_TokensPrompt, @TokensCompletion = @MJAIPromptRuns_ChildPromptID_TokensCompletion, @TotalCost = @MJAIPromptRuns_ChildPromptID_TotalCost, @Success = @MJAIPromptRuns_ChildPromptID_Success, @ErrorMessage = @MJAIPromptRuns_ChildPromptID_ErrorMessage, @ParentID = @MJAIPromptRuns_ChildPromptID_ParentID, @RunType = @MJAIPromptRuns_ChildPromptID_RunType, @ExecutionOrder = @MJAIPromptRuns_ChildPromptID_ExecutionOrder, @AgentRunID = @MJAIPromptRuns_ChildPromptID_AgentRunID, @Cost = @MJAIPromptRuns_ChildPromptID_Cost, @CostCurrency = @MJAIPromptRuns_ChildPromptID_CostCurrency, @TokensUsedRollup = @MJAIPromptRuns_ChildPromptID_TokensUsedRollup, @TokensPromptRollup = @MJAIPromptRuns_ChildPromptID_TokensPromptRollup, @TokensCompletionRollup = @MJAIPromptRuns_ChildPromptID_TokensCompletionRollup, @Temperature = @MJAIPromptRuns_ChildPromptID_Temperature, @TopP = @MJAIPromptRuns_ChildPromptID_TopP, @TopK = @MJAIPromptRuns_ChildPromptID_TopK, @MinP = @MJAIPromptRuns_ChildPromptID_MinP, @FrequencyPenalty = @MJAIPromptRuns_ChildPromptID_FrequencyPenalty, @PresencePenalty = @MJAIPromptRuns_ChildPromptID_PresencePenalty, @Seed = @MJAIPromptRuns_ChildPromptID_Seed, @StopSequences = @MJAIPromptRuns_ChildPromptID_StopSequences, @ResponseFormat = @MJAIPromptRuns_ChildPromptID_ResponseFormat, @LogProbs = @MJAIPromptRuns_ChildPromptID_LogProbs, @TopLogProbs = @MJAIPromptRuns_ChildPromptID_TopLogProbs, @DescendantCost = @MJAIPromptRuns_ChildPromptID_DescendantCost, @ValidationAttemptCount = @MJAIPromptRuns_ChildPromptID_ValidationAttemptCount, @SuccessfulValidationCount = @MJAIPromptRuns_ChildPromptID_SuccessfulValidationCount, @FinalValidationPassed = @MJAIPromptRuns_ChildPromptID_FinalValidationPassed, @ValidationBehavior = @MJAIPromptRuns_ChildPromptID_ValidationBehavior, @RetryStrategy = @MJAIPromptRuns_ChildPromptID_RetryStrategy, @MaxRetriesConfigured = @MJAIPromptRuns_ChildPromptID_MaxRetriesConfigured, @FinalValidationError = @MJAIPromptRuns_ChildPromptID_FinalValidationError, @ValidationErrorCount = @MJAIPromptRuns_ChildPromptID_ValidationErrorCount, @CommonValidationError = @MJAIPromptRuns_ChildPromptID_CommonValidationError, @FirstAttemptAt = @MJAIPromptRuns_ChildPromptID_FirstAttemptAt, @LastAttemptAt = @MJAIPromptRuns_ChildPromptID_LastAttemptAt, @TotalRetryDurationMS = @MJAIPromptRuns_ChildPromptID_TotalRetryDurationMS, @ValidationAttempts = @MJAIPromptRuns_ChildPromptID_ValidationAttempts, @ValidationSummary = @MJAIPromptRuns_ChildPromptID_ValidationSummary, @FailoverAttempts = @MJAIPromptRuns_ChildPromptID_FailoverAttempts, @FailoverErrors = @MJAIPromptRuns_ChildPromptID_FailoverErrors, @FailoverDurations = @MJAIPromptRuns_ChildPromptID_FailoverDurations, @OriginalModelID = @MJAIPromptRuns_ChildPromptID_OriginalModelID, @OriginalRequestStartTime = @MJAIPromptRuns_ChildPromptID_OriginalRequestStartTime, @TotalFailoverDuration = @MJAIPromptRuns_ChildPromptID_TotalFailoverDuration, @RerunFromPromptRunID = @MJAIPromptRuns_ChildPromptID_RerunFromPromptRunID, @ModelSelection = @MJAIPromptRuns_ChildPromptID_ModelSelection, @Status = @MJAIPromptRuns_ChildPromptID_Status, @Cancelled = @MJAIPromptRuns_ChildPromptID_Cancelled, @CancellationReason = @MJAIPromptRuns_ChildPromptID_CancellationReason, @ModelPowerRank = @MJAIPromptRuns_ChildPromptID_ModelPowerRank, @SelectionStrategy = @MJAIPromptRuns_ChildPromptID_SelectionStrategy, @CacheHit = @MJAIPromptRuns_ChildPromptID_CacheHit, @CacheKey = @MJAIPromptRuns_ChildPromptID_CacheKey, @JudgeID = @MJAIPromptRuns_ChildPromptID_JudgeID, @JudgeScore = @MJAIPromptRuns_ChildPromptID_JudgeScore, @WasSelectedResult = @MJAIPromptRuns_ChildPromptID_WasSelectedResult, @StreamingEnabled = @MJAIPromptRuns_ChildPromptID_StreamingEnabled, @FirstTokenTime = @MJAIPromptRuns_ChildPromptID_FirstTokenTime, @ErrorDetails = @MJAIPromptRuns_ChildPromptID_ErrorDetails, @ChildPromptID = @MJAIPromptRuns_ChildPromptID_ChildPromptID, @QueueTime = @MJAIPromptRuns_ChildPromptID_QueueTime, @PromptTime = @MJAIPromptRuns_ChildPromptID_PromptTime, @CompletionTime = @MJAIPromptRuns_ChildPromptID_CompletionTime, @ModelSpecificResponseDetails = @MJAIPromptRuns_ChildPromptID_ModelSpecificResponseDetails, @EffortLevel = @MJAIPromptRuns_ChildPromptID_EffortLevel, @RunName = @MJAIPromptRuns_ChildPromptID_RunName, @Comments = @MJAIPromptRuns_ChildPromptID_Comments, @TestRunID = @MJAIPromptRuns_ChildPromptID_TestRunID, @AssistantPrefill = @MJAIPromptRuns_ChildPromptID_AssistantPrefill
+
+        FETCH NEXT FROM cascade_update_MJAIPromptRuns_ChildPromptID_cursor INTO @MJAIPromptRuns_ChildPromptIDID, @MJAIPromptRuns_ChildPromptID_PromptID, @MJAIPromptRuns_ChildPromptID_ModelID, @MJAIPromptRuns_ChildPromptID_VendorID, @MJAIPromptRuns_ChildPromptID_AgentID, @MJAIPromptRuns_ChildPromptID_ConfigurationID, @MJAIPromptRuns_ChildPromptID_RunAt, @MJAIPromptRuns_ChildPromptID_CompletedAt, @MJAIPromptRuns_ChildPromptID_ExecutionTimeMS, @MJAIPromptRuns_ChildPromptID_Messages, @MJAIPromptRuns_ChildPromptID_Result, @MJAIPromptRuns_ChildPromptID_TokensUsed, @MJAIPromptRuns_ChildPromptID_TokensPrompt, @MJAIPromptRuns_ChildPromptID_TokensCompletion, @MJAIPromptRuns_ChildPromptID_TotalCost, @MJAIPromptRuns_ChildPromptID_Success, @MJAIPromptRuns_ChildPromptID_ErrorMessage, @MJAIPromptRuns_ChildPromptID_ParentID, @MJAIPromptRuns_ChildPromptID_RunType, @MJAIPromptRuns_ChildPromptID_ExecutionOrder, @MJAIPromptRuns_ChildPromptID_AgentRunID, @MJAIPromptRuns_ChildPromptID_Cost, @MJAIPromptRuns_ChildPromptID_CostCurrency, @MJAIPromptRuns_ChildPromptID_TokensUsedRollup, @MJAIPromptRuns_ChildPromptID_TokensPromptRollup, @MJAIPromptRuns_ChildPromptID_TokensCompletionRollup, @MJAIPromptRuns_ChildPromptID_Temperature, @MJAIPromptRuns_ChildPromptID_TopP, @MJAIPromptRuns_ChildPromptID_TopK, @MJAIPromptRuns_ChildPromptID_MinP, @MJAIPromptRuns_ChildPromptID_FrequencyPenalty, @MJAIPromptRuns_ChildPromptID_PresencePenalty, @MJAIPromptRuns_ChildPromptID_Seed, @MJAIPromptRuns_ChildPromptID_StopSequences, @MJAIPromptRuns_ChildPromptID_ResponseFormat, @MJAIPromptRuns_ChildPromptID_LogProbs, @MJAIPromptRuns_ChildPromptID_TopLogProbs, @MJAIPromptRuns_ChildPromptID_DescendantCost, @MJAIPromptRuns_ChildPromptID_ValidationAttemptCount, @MJAIPromptRuns_ChildPromptID_SuccessfulValidationCount, @MJAIPromptRuns_ChildPromptID_FinalValidationPassed, @MJAIPromptRuns_ChildPromptID_ValidationBehavior, @MJAIPromptRuns_ChildPromptID_RetryStrategy, @MJAIPromptRuns_ChildPromptID_MaxRetriesConfigured, @MJAIPromptRuns_ChildPromptID_FinalValidationError, @MJAIPromptRuns_ChildPromptID_ValidationErrorCount, @MJAIPromptRuns_ChildPromptID_CommonValidationError, @MJAIPromptRuns_ChildPromptID_FirstAttemptAt, @MJAIPromptRuns_ChildPromptID_LastAttemptAt, @MJAIPromptRuns_ChildPromptID_TotalRetryDurationMS, @MJAIPromptRuns_ChildPromptID_ValidationAttempts, @MJAIPromptRuns_ChildPromptID_ValidationSummary, @MJAIPromptRuns_ChildPromptID_FailoverAttempts, @MJAIPromptRuns_ChildPromptID_FailoverErrors, @MJAIPromptRuns_ChildPromptID_FailoverDurations, @MJAIPromptRuns_ChildPromptID_OriginalModelID, @MJAIPromptRuns_ChildPromptID_OriginalRequestStartTime, @MJAIPromptRuns_ChildPromptID_TotalFailoverDuration, @MJAIPromptRuns_ChildPromptID_RerunFromPromptRunID, @MJAIPromptRuns_ChildPromptID_ModelSelection, @MJAIPromptRuns_ChildPromptID_Status, @MJAIPromptRuns_ChildPromptID_Cancelled, @MJAIPromptRuns_ChildPromptID_CancellationReason, @MJAIPromptRuns_ChildPromptID_ModelPowerRank, @MJAIPromptRuns_ChildPromptID_SelectionStrategy, @MJAIPromptRuns_ChildPromptID_CacheHit, @MJAIPromptRuns_ChildPromptID_CacheKey, @MJAIPromptRuns_ChildPromptID_JudgeID, @MJAIPromptRuns_ChildPromptID_JudgeScore, @MJAIPromptRuns_ChildPromptID_WasSelectedResult, @MJAIPromptRuns_ChildPromptID_StreamingEnabled, @MJAIPromptRuns_ChildPromptID_FirstTokenTime, @MJAIPromptRuns_ChildPromptID_ErrorDetails, @MJAIPromptRuns_ChildPromptID_ChildPromptID, @MJAIPromptRuns_ChildPromptID_QueueTime, @MJAIPromptRuns_ChildPromptID_PromptTime, @MJAIPromptRuns_ChildPromptID_CompletionTime, @MJAIPromptRuns_ChildPromptID_ModelSpecificResponseDetails, @MJAIPromptRuns_ChildPromptID_EffortLevel, @MJAIPromptRuns_ChildPromptID_RunName, @MJAIPromptRuns_ChildPromptID_Comments, @MJAIPromptRuns_ChildPromptID_TestRunID, @MJAIPromptRuns_ChildPromptID_AssistantPrefill
+    END
+
+    CLOSE cascade_update_MJAIPromptRuns_ChildPromptID_cursor
+    DEALLOCATE cascade_update_MJAIPromptRuns_ChildPromptID_cursor
+    
+    -- Cascade update on AIPrompt using cursor to call spUpdateAIPrompt
+    DECLARE @MJAIPrompts_ResultSelectorPromptIDID uniqueidentifier
+    DECLARE @MJAIPrompts_ResultSelectorPromptID_Name nvarchar(255)
+    DECLARE @MJAIPrompts_ResultSelectorPromptID_Description nvarchar(MAX)
+    DECLARE @MJAIPrompts_ResultSelectorPromptID_TemplateID uniqueidentifier
+    DECLARE @MJAIPrompts_ResultSelectorPromptID_CategoryID uniqueidentifier
+    DECLARE @MJAIPrompts_ResultSelectorPromptID_TypeID uniqueidentifier
+    DECLARE @MJAIPrompts_ResultSelectorPromptID_Status nvarchar(50)
+    DECLARE @MJAIPrompts_ResultSelectorPromptID_ResponseFormat nvarchar(20)
+    DECLARE @MJAIPrompts_ResultSelectorPromptID_ModelSpecificResponseFormat nvarchar(MAX)
+    DECLARE @MJAIPrompts_ResultSelectorPromptID_AIModelTypeID uniqueidentifier
+    DECLARE @MJAIPrompts_ResultSelectorPromptID_MinPowerRank int
+    DECLARE @MJAIPrompts_ResultSelectorPromptID_SelectionStrategy nvarchar(20)
+    DECLARE @MJAIPrompts_ResultSelectorPromptID_PowerPreference nvarchar(20)
+    DECLARE @MJAIPrompts_ResultSelectorPromptID_ParallelizationMode nvarchar(20)
+    DECLARE @MJAIPrompts_ResultSelectorPromptID_ParallelCount int
+    DECLARE @MJAIPrompts_ResultSelectorPromptID_ParallelConfigParam nvarchar(100)
+    DECLARE @MJAIPrompts_ResultSelectorPromptID_OutputType nvarchar(50)
+    DECLARE @MJAIPrompts_ResultSelectorPromptID_OutputExample nvarchar(MAX)
+    DECLARE @MJAIPrompts_ResultSelectorPromptID_ValidationBehavior nvarchar(50)
+    DECLARE @MJAIPrompts_ResultSelectorPromptID_MaxRetries int
+    DECLARE @MJAIPrompts_ResultSelectorPromptID_RetryDelayMS int
+    DECLARE @MJAIPrompts_ResultSelectorPromptID_RetryStrategy nvarchar(20)
+    DECLARE @MJAIPrompts_ResultSelectorPromptID_ResultSelectorPromptID uniqueidentifier
+    DECLARE @MJAIPrompts_ResultSelectorPromptID_EnableCaching bit
+    DECLARE @MJAIPrompts_ResultSelectorPromptID_CacheTTLSeconds int
+    DECLARE @MJAIPrompts_ResultSelectorPromptID_CacheMatchType nvarchar(20)
+    DECLARE @MJAIPrompts_ResultSelectorPromptID_CacheSimilarityThreshold float(53)
+    DECLARE @MJAIPrompts_ResultSelectorPromptID_CacheMustMatchModel bit
+    DECLARE @MJAIPrompts_ResultSelectorPromptID_CacheMustMatchVendor bit
+    DECLARE @MJAIPrompts_ResultSelectorPromptID_CacheMustMatchAgent bit
+    DECLARE @MJAIPrompts_ResultSelectorPromptID_CacheMustMatchConfig bit
+    DECLARE @MJAIPrompts_ResultSelectorPromptID_PromptRole nvarchar(20)
+    DECLARE @MJAIPrompts_ResultSelectorPromptID_PromptPosition nvarchar(20)
+    DECLARE @MJAIPrompts_ResultSelectorPromptID_Temperature decimal(3, 2)
+    DECLARE @MJAIPrompts_ResultSelectorPromptID_TopP decimal(3, 2)
+    DECLARE @MJAIPrompts_ResultSelectorPromptID_TopK int
+    DECLARE @MJAIPrompts_ResultSelectorPromptID_MinP decimal(3, 2)
+    DECLARE @MJAIPrompts_ResultSelectorPromptID_FrequencyPenalty decimal(3, 2)
+    DECLARE @MJAIPrompts_ResultSelectorPromptID_PresencePenalty decimal(3, 2)
+    DECLARE @MJAIPrompts_ResultSelectorPromptID_Seed int
+    DECLARE @MJAIPrompts_ResultSelectorPromptID_StopSequences nvarchar(1000)
+    DECLARE @MJAIPrompts_ResultSelectorPromptID_IncludeLogProbs bit
+    DECLARE @MJAIPrompts_ResultSelectorPromptID_TopLogProbs int
+    DECLARE @MJAIPrompts_ResultSelectorPromptID_FailoverStrategy nvarchar(50)
+    DECLARE @MJAIPrompts_ResultSelectorPromptID_FailoverMaxAttempts int
+    DECLARE @MJAIPrompts_ResultSelectorPromptID_FailoverDelaySeconds int
+    DECLARE @MJAIPrompts_ResultSelectorPromptID_FailoverModelStrategy nvarchar(50)
+    DECLARE @MJAIPrompts_ResultSelectorPromptID_FailoverErrorScope nvarchar(50)
+    DECLARE @MJAIPrompts_ResultSelectorPromptID_EffortLevel int
+    DECLARE @MJAIPrompts_ResultSelectorPromptID_AssistantPrefill nvarchar(MAX)
+    DECLARE @MJAIPrompts_ResultSelectorPromptID_PrefillFallbackMode nvarchar(20)
+    DECLARE @MJAIPrompts_ResultSelectorPromptID_RequireSpecificModels bit
+    DECLARE cascade_update_MJAIPrompts_ResultSelectorPromptID_cursor CURSOR FOR
+        SELECT [ID], [Name], [Description], [TemplateID], [CategoryID], [TypeID], [Status], [ResponseFormat], [ModelSpecificResponseFormat], [AIModelTypeID], [MinPowerRank], [SelectionStrategy], [PowerPreference], [ParallelizationMode], [ParallelCount], [ParallelConfigParam], [OutputType], [OutputExample], [ValidationBehavior], [MaxRetries], [RetryDelayMS], [RetryStrategy], [ResultSelectorPromptID], [EnableCaching], [CacheTTLSeconds], [CacheMatchType], [CacheSimilarityThreshold], [CacheMustMatchModel], [CacheMustMatchVendor], [CacheMustMatchAgent], [CacheMustMatchConfig], [PromptRole], [PromptPosition], [Temperature], [TopP], [TopK], [MinP], [FrequencyPenalty], [PresencePenalty], [Seed], [StopSequences], [IncludeLogProbs], [TopLogProbs], [FailoverStrategy], [FailoverMaxAttempts], [FailoverDelaySeconds], [FailoverModelStrategy], [FailoverErrorScope], [EffortLevel], [AssistantPrefill], [PrefillFallbackMode], [RequireSpecificModels]
+        FROM [${flyway:defaultSchema}].[AIPrompt]
+        WHERE [ResultSelectorPromptID] = @ID
+
+    OPEN cascade_update_MJAIPrompts_ResultSelectorPromptID_cursor
+    FETCH NEXT FROM cascade_update_MJAIPrompts_ResultSelectorPromptID_cursor INTO @MJAIPrompts_ResultSelectorPromptIDID, @MJAIPrompts_ResultSelectorPromptID_Name, @MJAIPrompts_ResultSelectorPromptID_Description, @MJAIPrompts_ResultSelectorPromptID_TemplateID, @MJAIPrompts_ResultSelectorPromptID_CategoryID, @MJAIPrompts_ResultSelectorPromptID_TypeID, @MJAIPrompts_ResultSelectorPromptID_Status, @MJAIPrompts_ResultSelectorPromptID_ResponseFormat, @MJAIPrompts_ResultSelectorPromptID_ModelSpecificResponseFormat, @MJAIPrompts_ResultSelectorPromptID_AIModelTypeID, @MJAIPrompts_ResultSelectorPromptID_MinPowerRank, @MJAIPrompts_ResultSelectorPromptID_SelectionStrategy, @MJAIPrompts_ResultSelectorPromptID_PowerPreference, @MJAIPrompts_ResultSelectorPromptID_ParallelizationMode, @MJAIPrompts_ResultSelectorPromptID_ParallelCount, @MJAIPrompts_ResultSelectorPromptID_ParallelConfigParam, @MJAIPrompts_ResultSelectorPromptID_OutputType, @MJAIPrompts_ResultSelectorPromptID_OutputExample, @MJAIPrompts_ResultSelectorPromptID_ValidationBehavior, @MJAIPrompts_ResultSelectorPromptID_MaxRetries, @MJAIPrompts_ResultSelectorPromptID_RetryDelayMS, @MJAIPrompts_ResultSelectorPromptID_RetryStrategy, @MJAIPrompts_ResultSelectorPromptID_ResultSelectorPromptID, @MJAIPrompts_ResultSelectorPromptID_EnableCaching, @MJAIPrompts_ResultSelectorPromptID_CacheTTLSeconds, @MJAIPrompts_ResultSelectorPromptID_CacheMatchType, @MJAIPrompts_ResultSelectorPromptID_CacheSimilarityThreshold, @MJAIPrompts_ResultSelectorPromptID_CacheMustMatchModel, @MJAIPrompts_ResultSelectorPromptID_CacheMustMatchVendor, @MJAIPrompts_ResultSelectorPromptID_CacheMustMatchAgent, @MJAIPrompts_ResultSelectorPromptID_CacheMustMatchConfig, @MJAIPrompts_ResultSelectorPromptID_PromptRole, @MJAIPrompts_ResultSelectorPromptID_PromptPosition, @MJAIPrompts_ResultSelectorPromptID_Temperature, @MJAIPrompts_ResultSelectorPromptID_TopP, @MJAIPrompts_ResultSelectorPromptID_TopK, @MJAIPrompts_ResultSelectorPromptID_MinP, @MJAIPrompts_ResultSelectorPromptID_FrequencyPenalty, @MJAIPrompts_ResultSelectorPromptID_PresencePenalty, @MJAIPrompts_ResultSelectorPromptID_Seed, @MJAIPrompts_ResultSelectorPromptID_StopSequences, @MJAIPrompts_ResultSelectorPromptID_IncludeLogProbs, @MJAIPrompts_ResultSelectorPromptID_TopLogProbs, @MJAIPrompts_ResultSelectorPromptID_FailoverStrategy, @MJAIPrompts_ResultSelectorPromptID_FailoverMaxAttempts, @MJAIPrompts_ResultSelectorPromptID_FailoverDelaySeconds, @MJAIPrompts_ResultSelectorPromptID_FailoverModelStrategy, @MJAIPrompts_ResultSelectorPromptID_FailoverErrorScope, @MJAIPrompts_ResultSelectorPromptID_EffortLevel, @MJAIPrompts_ResultSelectorPromptID_AssistantPrefill, @MJAIPrompts_ResultSelectorPromptID_PrefillFallbackMode, @MJAIPrompts_ResultSelectorPromptID_RequireSpecificModels
+
+    WHILE @@FETCH_STATUS = 0
+    BEGIN
+        -- Set the FK field to NULL
+        SET @MJAIPrompts_ResultSelectorPromptID_ResultSelectorPromptID = NULL
+
+        -- Call the update SP for the related entity
+        EXEC [${flyway:defaultSchema}].[spUpdateAIPrompt] @ID = @MJAIPrompts_ResultSelectorPromptIDID, @Name = @MJAIPrompts_ResultSelectorPromptID_Name, @Description = @MJAIPrompts_ResultSelectorPromptID_Description, @TemplateID = @MJAIPrompts_ResultSelectorPromptID_TemplateID, @CategoryID = @MJAIPrompts_ResultSelectorPromptID_CategoryID, @TypeID = @MJAIPrompts_ResultSelectorPromptID_TypeID, @Status = @MJAIPrompts_ResultSelectorPromptID_Status, @ResponseFormat = @MJAIPrompts_ResultSelectorPromptID_ResponseFormat, @ModelSpecificResponseFormat = @MJAIPrompts_ResultSelectorPromptID_ModelSpecificResponseFormat, @AIModelTypeID = @MJAIPrompts_ResultSelectorPromptID_AIModelTypeID, @MinPowerRank = @MJAIPrompts_ResultSelectorPromptID_MinPowerRank, @SelectionStrategy = @MJAIPrompts_ResultSelectorPromptID_SelectionStrategy, @PowerPreference = @MJAIPrompts_ResultSelectorPromptID_PowerPreference, @ParallelizationMode = @MJAIPrompts_ResultSelectorPromptID_ParallelizationMode, @ParallelCount = @MJAIPrompts_ResultSelectorPromptID_ParallelCount, @ParallelConfigParam = @MJAIPrompts_ResultSelectorPromptID_ParallelConfigParam, @OutputType = @MJAIPrompts_ResultSelectorPromptID_OutputType, @OutputExample = @MJAIPrompts_ResultSelectorPromptID_OutputExample, @ValidationBehavior = @MJAIPrompts_ResultSelectorPromptID_ValidationBehavior, @MaxRetries = @MJAIPrompts_ResultSelectorPromptID_MaxRetries, @RetryDelayMS = @MJAIPrompts_ResultSelectorPromptID_RetryDelayMS, @RetryStrategy = @MJAIPrompts_ResultSelectorPromptID_RetryStrategy, @ResultSelectorPromptID = @MJAIPrompts_ResultSelectorPromptID_ResultSelectorPromptID, @EnableCaching = @MJAIPrompts_ResultSelectorPromptID_EnableCaching, @CacheTTLSeconds = @MJAIPrompts_ResultSelectorPromptID_CacheTTLSeconds, @CacheMatchType = @MJAIPrompts_ResultSelectorPromptID_CacheMatchType, @CacheSimilarityThreshold = @MJAIPrompts_ResultSelectorPromptID_CacheSimilarityThreshold, @CacheMustMatchModel = @MJAIPrompts_ResultSelectorPromptID_CacheMustMatchModel, @CacheMustMatchVendor = @MJAIPrompts_ResultSelectorPromptID_CacheMustMatchVendor, @CacheMustMatchAgent = @MJAIPrompts_ResultSelectorPromptID_CacheMustMatchAgent, @CacheMustMatchConfig = @MJAIPrompts_ResultSelectorPromptID_CacheMustMatchConfig, @PromptRole = @MJAIPrompts_ResultSelectorPromptID_PromptRole, @PromptPosition = @MJAIPrompts_ResultSelectorPromptID_PromptPosition, @Temperature = @MJAIPrompts_ResultSelectorPromptID_Temperature, @TopP = @MJAIPrompts_ResultSelectorPromptID_TopP, @TopK = @MJAIPrompts_ResultSelectorPromptID_TopK, @MinP = @MJAIPrompts_ResultSelectorPromptID_MinP, @FrequencyPenalty = @MJAIPrompts_ResultSelectorPromptID_FrequencyPenalty, @PresencePenalty = @MJAIPrompts_ResultSelectorPromptID_PresencePenalty, @Seed = @MJAIPrompts_ResultSelectorPromptID_Seed, @StopSequences = @MJAIPrompts_ResultSelectorPromptID_StopSequences, @IncludeLogProbs = @MJAIPrompts_ResultSelectorPromptID_IncludeLogProbs, @TopLogProbs = @MJAIPrompts_ResultSelectorPromptID_TopLogProbs, @FailoverStrategy = @MJAIPrompts_ResultSelectorPromptID_FailoverStrategy, @FailoverMaxAttempts = @MJAIPrompts_ResultSelectorPromptID_FailoverMaxAttempts, @FailoverDelaySeconds = @MJAIPrompts_ResultSelectorPromptID_FailoverDelaySeconds, @FailoverModelStrategy = @MJAIPrompts_ResultSelectorPromptID_FailoverModelStrategy, @FailoverErrorScope = @MJAIPrompts_ResultSelectorPromptID_FailoverErrorScope, @EffortLevel = @MJAIPrompts_ResultSelectorPromptID_EffortLevel, @AssistantPrefill = @MJAIPrompts_ResultSelectorPromptID_AssistantPrefill, @PrefillFallbackMode = @MJAIPrompts_ResultSelectorPromptID_PrefillFallbackMode, @RequireSpecificModels = @MJAIPrompts_ResultSelectorPromptID_RequireSpecificModels
+
+        FETCH NEXT FROM cascade_update_MJAIPrompts_ResultSelectorPromptID_cursor INTO @MJAIPrompts_ResultSelectorPromptIDID, @MJAIPrompts_ResultSelectorPromptID_Name, @MJAIPrompts_ResultSelectorPromptID_Description, @MJAIPrompts_ResultSelectorPromptID_TemplateID, @MJAIPrompts_ResultSelectorPromptID_CategoryID, @MJAIPrompts_ResultSelectorPromptID_TypeID, @MJAIPrompts_ResultSelectorPromptID_Status, @MJAIPrompts_ResultSelectorPromptID_ResponseFormat, @MJAIPrompts_ResultSelectorPromptID_ModelSpecificResponseFormat, @MJAIPrompts_ResultSelectorPromptID_AIModelTypeID, @MJAIPrompts_ResultSelectorPromptID_MinPowerRank, @MJAIPrompts_ResultSelectorPromptID_SelectionStrategy, @MJAIPrompts_ResultSelectorPromptID_PowerPreference, @MJAIPrompts_ResultSelectorPromptID_ParallelizationMode, @MJAIPrompts_ResultSelectorPromptID_ParallelCount, @MJAIPrompts_ResultSelectorPromptID_ParallelConfigParam, @MJAIPrompts_ResultSelectorPromptID_OutputType, @MJAIPrompts_ResultSelectorPromptID_OutputExample, @MJAIPrompts_ResultSelectorPromptID_ValidationBehavior, @MJAIPrompts_ResultSelectorPromptID_MaxRetries, @MJAIPrompts_ResultSelectorPromptID_RetryDelayMS, @MJAIPrompts_ResultSelectorPromptID_RetryStrategy, @MJAIPrompts_ResultSelectorPromptID_ResultSelectorPromptID, @MJAIPrompts_ResultSelectorPromptID_EnableCaching, @MJAIPrompts_ResultSelectorPromptID_CacheTTLSeconds, @MJAIPrompts_ResultSelectorPromptID_CacheMatchType, @MJAIPrompts_ResultSelectorPromptID_CacheSimilarityThreshold, @MJAIPrompts_ResultSelectorPromptID_CacheMustMatchModel, @MJAIPrompts_ResultSelectorPromptID_CacheMustMatchVendor, @MJAIPrompts_ResultSelectorPromptID_CacheMustMatchAgent, @MJAIPrompts_ResultSelectorPromptID_CacheMustMatchConfig, @MJAIPrompts_ResultSelectorPromptID_PromptRole, @MJAIPrompts_ResultSelectorPromptID_PromptPosition, @MJAIPrompts_ResultSelectorPromptID_Temperature, @MJAIPrompts_ResultSelectorPromptID_TopP, @MJAIPrompts_ResultSelectorPromptID_TopK, @MJAIPrompts_ResultSelectorPromptID_MinP, @MJAIPrompts_ResultSelectorPromptID_FrequencyPenalty, @MJAIPrompts_ResultSelectorPromptID_PresencePenalty, @MJAIPrompts_ResultSelectorPromptID_Seed, @MJAIPrompts_ResultSelectorPromptID_StopSequences, @MJAIPrompts_ResultSelectorPromptID_IncludeLogProbs, @MJAIPrompts_ResultSelectorPromptID_TopLogProbs, @MJAIPrompts_ResultSelectorPromptID_FailoverStrategy, @MJAIPrompts_ResultSelectorPromptID_FailoverMaxAttempts, @MJAIPrompts_ResultSelectorPromptID_FailoverDelaySeconds, @MJAIPrompts_ResultSelectorPromptID_FailoverModelStrategy, @MJAIPrompts_ResultSelectorPromptID_FailoverErrorScope, @MJAIPrompts_ResultSelectorPromptID_EffortLevel, @MJAIPrompts_ResultSelectorPromptID_AssistantPrefill, @MJAIPrompts_ResultSelectorPromptID_PrefillFallbackMode, @MJAIPrompts_ResultSelectorPromptID_RequireSpecificModels
+    END
+
+    CLOSE cascade_update_MJAIPrompts_ResultSelectorPromptID_cursor
+    DEALLOCATE cascade_update_MJAIPrompts_ResultSelectorPromptID_cursor
+    
+    -- Cascade delete from AIResultCache using cursor to call spDeleteAIResultCache
+    DECLARE @MJAIResultCache_AIPromptIDID uniqueidentifier
+    DECLARE cascade_delete_MJAIResultCache_AIPromptID_cursor CURSOR FOR 
+        SELECT [ID]
+        FROM [${flyway:defaultSchema}].[AIResultCache]
+        WHERE [AIPromptID] = @ID
+    
+    OPEN cascade_delete_MJAIResultCache_AIPromptID_cursor
+    FETCH NEXT FROM cascade_delete_MJAIResultCache_AIPromptID_cursor INTO @MJAIResultCache_AIPromptIDID
+    
+    WHILE @@FETCH_STATUS = 0
+    BEGIN
+        EXEC [${flyway:defaultSchema}].[spDeleteAIResultCache] @ID = @MJAIResultCache_AIPromptIDID
+        
+        FETCH NEXT FROM cascade_delete_MJAIResultCache_AIPromptID_cursor INTO @MJAIResultCache_AIPromptIDID
+    END
+    
+    CLOSE cascade_delete_MJAIResultCache_AIPromptID_cursor
+    DEALLOCATE cascade_delete_MJAIResultCache_AIPromptID_cursor
+    
+
+    DELETE FROM
+        [${flyway:defaultSchema}].[AIPrompt]
+    WHERE
+        [ID] = @ID
+
+
+    -- Check if the delete was successful
+    IF @@ROWCOUNT = 0
+        SELECT NULL AS [ID] -- Return NULL for all primary key fields to indicate no record was deleted
+    ELSE
+        SELECT @ID AS [ID] -- Return the primary key values to indicate we successfully deleted the record
+END
+GO
+GRANT EXECUTE ON [${flyway:defaultSchema}].[spDeleteAIPrompt] TO [cdp_Developer]
+    
+
+/* spDelete Permissions for MJ: AI Prompts */
+
+GRANT EXECUTE ON [${flyway:defaultSchema}].[spDeleteAIPrompt] TO [cdp_Developer]
+
+
+
+/* SQL text to insert new entity field */
+
+      IF NOT EXISTS (SELECT 1 FROM [${flyway:defaultSchema}].[EntityField] WHERE ID = 'c67cb669-16ea-4741-bf5f-bd735869768e' OR (EntityID = '6B8A7C62-C13B-4283-9C81-17D9233A4A69' AND Name = 'DefaultStorageAccount')) BEGIN
+         INSERT INTO [${flyway:defaultSchema}].[EntityField]
+         (
+            [ID],
+            [EntityID],
+            [Sequence],
+            [Name],
+            [DisplayName],
+            [Description],
+            [Type],
+            [Length],
+            [Precision],
+            [Scale],
+            [AllowsNull],
+            [DefaultValue],
+            [AutoIncrement],
+            [AllowUpdateAPI],
+            [IsVirtual],
+            [RelatedEntityID],
+            [RelatedEntityFieldName],
+            [IsNameField],
+            [IncludeInUserSearchAPI],
+            [IncludeRelatedEntityNameFieldInBaseView],
+            [DefaultInView],
+            [IsPrimaryKey],
+            [IsUnique],
+            [RelatedEntityDisplayType],
+            [__mj_CreatedAt],
+            [__mj_UpdatedAt]
+         )
+         VALUES
+         (
+            'c67cb669-16ea-4741-bf5f-bd735869768e',
+            '6B8A7C62-C13B-4283-9C81-17D9233A4A69', -- Entity: MJ: AI Agent Categories
+            100022,
+            'DefaultStorageAccount',
+            'Default Storage Account',
+            NULL,
+            'nvarchar',
+            400,
+            0,
+            0,
+            1,
+            NULL,
+            0,
+            0,
+            1,
+            NULL,
+            NULL,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            'Search',
+            GETUTCDATE(),
+            GETUTCDATE()
+         )
+      END
+
+/* SQL text to insert new entity field */
+
+      IF NOT EXISTS (SELECT 1 FROM [${flyway:defaultSchema}].[EntityField] WHERE ID = 'd900c3b8-f414-4468-aaa1-3ceb52c80acd' OR (EntityID = 'CDB135CC-6D3C-480B-90AE-25B7805F82C1' AND Name = 'DefaultStorageAccount')) BEGIN
+         INSERT INTO [${flyway:defaultSchema}].[EntityField]
+         (
+            [ID],
+            [EntityID],
+            [Sequence],
+            [Name],
+            [DisplayName],
+            [Description],
+            [Type],
+            [Length],
+            [Precision],
+            [Scale],
+            [AllowsNull],
+            [DefaultValue],
+            [AutoIncrement],
+            [AllowUpdateAPI],
+            [IsVirtual],
+            [RelatedEntityID],
+            [RelatedEntityFieldName],
+            [IsNameField],
+            [IncludeInUserSearchAPI],
+            [IncludeRelatedEntityNameFieldInBaseView],
+            [DefaultInView],
+            [IsPrimaryKey],
+            [IsUnique],
+            [RelatedEntityDisplayType],
+            [__mj_CreatedAt],
+            [__mj_UpdatedAt]
+         )
+         VALUES
+         (
+            'd900c3b8-f414-4468-aaa1-3ceb52c80acd',
+            'CDB135CC-6D3C-480B-90AE-25B7805F82C1', -- Entity: MJ: AI Agents
+            100144,
+            'DefaultStorageAccount',
+            'Default Storage Account',
+            NULL,
+            'nvarchar',
+            400,
+            0,
+            0,
+            1,
+            NULL,
+            0,
+            0,
+            1,
+            NULL,
+            NULL,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            'Search',
+            GETUTCDATE(),
+            GETUTCDATE()
+         )
+      END
+
+/* SQL text to insert new entity field */
+
+      IF NOT EXISTS (SELECT 1 FROM [${flyway:defaultSchema}].[EntityField] WHERE ID = 'bc5fc66f-cded-4316-8e1a-f0b3f0577f3d' OR (EntityID = '65CDC348-C4A6-4D00-A57B-2D489C56F128' AND Name = 'DefaultStorageAccount')) BEGIN
+         INSERT INTO [${flyway:defaultSchema}].[EntityField]
+         (
+            [ID],
+            [EntityID],
+            [Sequence],
+            [Name],
+            [DisplayName],
+            [Description],
+            [Type],
+            [Length],
+            [Precision],
+            [Scale],
+            [AllowsNull],
+            [DefaultValue],
+            [AutoIncrement],
+            [AllowUpdateAPI],
+            [IsVirtual],
+            [RelatedEntityID],
+            [RelatedEntityFieldName],
+            [IsNameField],
+            [IncludeInUserSearchAPI],
+            [IncludeRelatedEntityNameFieldInBaseView],
+            [DefaultInView],
+            [IsPrimaryKey],
+            [IsUnique],
+            [RelatedEntityDisplayType],
+            [__mj_CreatedAt],
+            [__mj_UpdatedAt]
+         )
+         VALUES
+         (
+            'bc5fc66f-cded-4316-8e1a-f0b3f0577f3d',
+            '65CDC348-C4A6-4D00-A57B-2D489C56F128', -- Entity: MJ: AI Agent Types
+            100033,
+            'DefaultStorageAccount',
+            'Default Storage Account',
+            NULL,
+            'nvarchar',
+            400,
+            0,
+            0,
+            1,
+            NULL,
+            0,
+            0,
+            1,
+            NULL,
+            NULL,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            'Search',
+            GETUTCDATE(),
+            GETUTCDATE()
+         )
+      END
+
+/* Set field properties for entity */
+
+               UPDATE [${flyway:defaultSchema}].[EntityField]
+               SET DefaultInView = 1
+               WHERE ID = 'C67CB669-16EA-4741-BF5F-BD735869768E'
+               AND AutoUpdateDefaultInView = 1
+            
+
+                  UPDATE [${flyway:defaultSchema}].[EntityField]
+                  SET IncludeInUserSearchAPI = 1
+                  WHERE ID = 'C67CB669-16EA-4741-BF5F-BD735869768E'
+                  AND AutoUpdateIncludeInUserSearchAPI = 1
+               
+
+/* Set field properties for entity */
+
+                  UPDATE [${flyway:defaultSchema}].[EntityField]
+                  SET IncludeInUserSearchAPI = 1
+                  WHERE ID = '91CA077D-3F59-48E1-A593-AF8686276115'
+                  AND AutoUpdateIncludeInUserSearchAPI = 1
+               
+
+                  UPDATE [${flyway:defaultSchema}].[EntityField]
+                  SET IncludeInUserSearchAPI = 1
+                  WHERE ID = '261B4D18-464B-4AD9-9FFD-EA8B70C576D8'
+                  AND AutoUpdateIncludeInUserSearchAPI = 1
+               
+
+                  UPDATE [${flyway:defaultSchema}].[EntityField]
+                  SET IncludeInUserSearchAPI = 1
+                  WHERE ID = '7DCA7B3C-9A81-4D32-AF2E-5EA32B22D988'
+                  AND AutoUpdateIncludeInUserSearchAPI = 1
+               
+
+/* Set categories for 12 fields */
+
+-- UPDATE Entity Field Category Info MJ: AI Agent Categories.ID 
+UPDATE [${flyway:defaultSchema}].[EntityField]
+SET 
+   GeneratedFormSection = 'Category',
+   ExtendedType = NULL,
+   CodeType = NULL
+WHERE 
+   ID = 'E5868229-B9A2-459E-BFFB-A559F67DC95A' AND AutoUpdateCategory = 1
+
+-- UPDATE Entity Field Category Info MJ: AI Agent Categories.Name 
+UPDATE [${flyway:defaultSchema}].[EntityField]
+SET 
+   GeneratedFormSection = 'Category',
+   ExtendedType = NULL,
+   CodeType = NULL
+WHERE 
+   ID = '52CE977C-7557-4E76-A9C8-FBADA6276C00' AND AutoUpdateCategory = 1
+
+-- UPDATE Entity Field Category Info MJ: AI Agent Categories.Description 
+UPDATE [${flyway:defaultSchema}].[EntityField]
+SET 
+   GeneratedFormSection = 'Category',
+   ExtendedType = NULL,
+   CodeType = NULL
+WHERE 
+   ID = '6D54C233-D33D-47F7-BB7C-3715DDFB3D12' AND AutoUpdateCategory = 1
+
+-- UPDATE Entity Field Category Info MJ: AI Agent Categories.ParentID 
+UPDATE [${flyway:defaultSchema}].[EntityField]
+SET 
+   GeneratedFormSection = 'Category',
+   ExtendedType = NULL,
+   CodeType = NULL
+WHERE 
+   ID = '811D3955-423B-4E3A-9994-276C72900ABD' AND AutoUpdateCategory = 1
+
+-- UPDATE Entity Field Category Info MJ: AI Agent Categories.AssignmentStrategy 
+UPDATE [${flyway:defaultSchema}].[EntityField]
+SET 
+   GeneratedFormSection = 'Category',
+   ExtendedType = NULL,
+   CodeType = NULL
+WHERE 
+   ID = 'D9C33D3D-15F8-4634-9992-0CEA41DE5DD8' AND AutoUpdateCategory = 1
+
+-- UPDATE Entity Field Category Info MJ: AI Agent Categories.Status 
+UPDATE [${flyway:defaultSchema}].[EntityField]
+SET 
+   GeneratedFormSection = 'Category',
+   ExtendedType = NULL,
+   CodeType = NULL
+WHERE 
+   ID = 'AB433CCD-66A7-4A6D-90CF-DB74D151F489' AND AutoUpdateCategory = 1
+
+-- UPDATE Entity Field Category Info MJ: AI Agent Categories.__mj_CreatedAt 
+UPDATE [${flyway:defaultSchema}].[EntityField]
+SET 
+   GeneratedFormSection = 'Category',
+   ExtendedType = NULL,
+   CodeType = NULL
+WHERE 
+   ID = '3C9F482B-2673-4C37-A772-8DCB1E14597F' AND AutoUpdateCategory = 1
+
+-- UPDATE Entity Field Category Info MJ: AI Agent Categories.__mj_UpdatedAt 
+UPDATE [${flyway:defaultSchema}].[EntityField]
+SET 
+   GeneratedFormSection = 'Category',
+   ExtendedType = NULL,
+   CodeType = NULL
+WHERE 
+   ID = '18E36027-17FC-478C-B3B3-C8F9F090459A' AND AutoUpdateCategory = 1
+
+-- UPDATE Entity Field Category Info MJ: AI Agent Categories.DefaultStorageAccountID 
+UPDATE [${flyway:defaultSchema}].[EntityField]
+SET 
+   Category = 'Storage Configuration',
+   GeneratedFormSection = 'Category',
+   DisplayName = 'Default Storage Account',
+   ExtendedType = NULL,
+   CodeType = NULL
+WHERE 
+   ID = '8C389086-9876-403C-9AB8-2F6F61303E64' AND AutoUpdateCategory = 1
+
+-- UPDATE Entity Field Category Info MJ: AI Agent Categories.Parent 
+UPDATE [${flyway:defaultSchema}].[EntityField]
+SET 
+   GeneratedFormSection = 'Category',
+   DisplayName = 'Parent',
+   ExtendedType = NULL,
+   CodeType = NULL
+WHERE 
+   ID = 'E85F7708-91A1-4F8E-8B8E-49E380772E4A' AND AutoUpdateCategory = 1
+
+-- UPDATE Entity Field Category Info MJ: AI Agent Categories.DefaultStorageAccount 
+UPDATE [${flyway:defaultSchema}].[EntityField]
+SET 
+   Category = 'Storage Configuration',
+   GeneratedFormSection = 'Category',
+   DisplayName = 'Default Storage Account Name',
+   ExtendedType = NULL,
+   CodeType = NULL
+WHERE 
+   ID = 'C67CB669-16EA-4741-BF5F-BD735869768E' AND AutoUpdateCategory = 1
+
+-- UPDATE Entity Field Category Info MJ: AI Agent Categories.RootParentID 
+UPDATE [${flyway:defaultSchema}].[EntityField]
+SET 
+   GeneratedFormSection = 'Category',
+   ExtendedType = NULL,
+   CodeType = NULL
+WHERE 
+   ID = '2A0F33D6-4F71-4BBA-8470-28201E36F9B4' AND AutoUpdateCategory = 1
+
+/* Update FieldCategoryInfo setting for entity */
+
+               UPDATE [${flyway:defaultSchema}].[EntitySetting]
+               SET Value = '{"Storage Configuration":{"icon":"fa fa-hdd","description":"Default file storage account settings inherited by agents in this category"}}', __mj_UpdatedAt = GETUTCDATE()
+               WHERE EntityID = '6B8A7C62-C13B-4283-9C81-17D9233A4A69' AND Name = 'FieldCategoryInfo'
+            
+
+/* Update FieldCategoryIcons setting (legacy) */
+
+               UPDATE [${flyway:defaultSchema}].[EntitySetting]
+               SET Value = '{"Storage Configuration":"fa fa-hdd"}', __mj_UpdatedAt = GETUTCDATE()
+               WHERE EntityID = '6B8A7C62-C13B-4283-9C81-17D9233A4A69' AND Name = 'FieldCategoryIcons'
+            
+
+/* Set categories for 17 fields */
+
+-- UPDATE Entity Field Category Info MJ: AI Agent Types.ID 
+UPDATE [${flyway:defaultSchema}].[EntityField]
+SET 
+   GeneratedFormSection = 'Category',
+   ExtendedType = NULL,
+   CodeType = NULL
+WHERE 
+   ID = '5BDF7CC2-8BB6-4B10-A69B-F5C4EF647FAF' AND AutoUpdateCategory = 1
+
+-- UPDATE Entity Field Category Info MJ: AI Agent Types.Name 
+UPDATE [${flyway:defaultSchema}].[EntityField]
+SET 
+   GeneratedFormSection = 'Category',
+   ExtendedType = NULL,
+   CodeType = NULL
+WHERE 
+   ID = '5C0C0D1C-4B14-417E-9280-B4545A8AF1EF' AND AutoUpdateCategory = 1
+
+-- UPDATE Entity Field Category Info MJ: AI Agent Types.Description 
+UPDATE [${flyway:defaultSchema}].[EntityField]
+SET 
+   GeneratedFormSection = 'Category',
+   ExtendedType = NULL,
+   CodeType = NULL
+WHERE 
+   ID = '0C6E768F-C587-4538-BC48-C869854F3A18' AND AutoUpdateCategory = 1
+
+-- UPDATE Entity Field Category Info MJ: AI Agent Types.SystemPromptID 
+UPDATE [${flyway:defaultSchema}].[EntityField]
+SET 
+   GeneratedFormSection = 'Category',
+   ExtendedType = NULL,
+   CodeType = NULL
+WHERE 
+   ID = '24424A6A-C0E3-4DB0-9AF1-551D12AE7E10' AND AutoUpdateCategory = 1
+
+-- UPDATE Entity Field Category Info MJ: AI Agent Types.AgentPromptPlaceholder 
+UPDATE [${flyway:defaultSchema}].[EntityField]
+SET 
+   GeneratedFormSection = 'Category',
+   ExtendedType = NULL,
+   CodeType = NULL
+WHERE 
+   ID = '47FCBE6A-43EA-47FA-912B-ACB82A311471' AND AutoUpdateCategory = 1
+
+-- UPDATE Entity Field Category Info MJ: AI Agent Types.PromptParamsSchema 
+UPDATE [${flyway:defaultSchema}].[EntityField]
+SET 
+   GeneratedFormSection = 'Category',
+   DisplayName = 'Prompt Params Schema',
+   ExtendedType = NULL,
+   CodeType = NULL
+WHERE 
+   ID = '41DA3898-26C0-4AE9-B934-84EA97C726B7' AND AutoUpdateCategory = 1
+
+-- UPDATE Entity Field Category Info MJ: AI Agent Types.SystemPrompt 
+UPDATE [${flyway:defaultSchema}].[EntityField]
+SET 
+   GeneratedFormSection = 'Category',
+   DisplayName = 'System Prompt',
+   ExtendedType = NULL,
+   CodeType = NULL
+WHERE 
+   ID = '200792E6-E7EC-4293-A821-77B42A49DAB5' AND AutoUpdateCategory = 1
+
+-- UPDATE Entity Field Category Info MJ: AI Agent Types.IsActive 
+UPDATE [${flyway:defaultSchema}].[EntityField]
+SET 
+   GeneratedFormSection = 'Category',
+   ExtendedType = NULL,
+   CodeType = NULL
+WHERE 
+   ID = '980B9BE8-5C4E-45A4-BE62-32874A339AF6' AND AutoUpdateCategory = 1
+
+-- UPDATE Entity Field Category Info MJ: AI Agent Types.DriverClass 
+UPDATE [${flyway:defaultSchema}].[EntityField]
+SET 
+   GeneratedFormSection = 'Category',
+   ExtendedType = NULL,
+   CodeType = NULL
+WHERE 
+   ID = 'DB83502E-F00C-4CF8-AD0E-FFE9BF3C8904' AND AutoUpdateCategory = 1
+
+-- UPDATE Entity Field Category Info MJ: AI Agent Types.UIFormSectionKey 
+UPDATE [${flyway:defaultSchema}].[EntityField]
+SET 
+   GeneratedFormSection = 'Category',
+   ExtendedType = NULL,
+   CodeType = NULL
+WHERE 
+   ID = '7763B64B-E410-4247-89DE-5E9E565F15A0' AND AutoUpdateCategory = 1
+
+-- UPDATE Entity Field Category Info MJ: AI Agent Types.UIFormKey 
+UPDATE [${flyway:defaultSchema}].[EntityField]
+SET 
+   GeneratedFormSection = 'Category',
+   ExtendedType = NULL,
+   CodeType = NULL
+WHERE 
+   ID = 'FAC68362-126A-4F7E-B706-8DD7B40897A1' AND AutoUpdateCategory = 1
+
+-- UPDATE Entity Field Category Info MJ: AI Agent Types.UIFormSectionExpandedByDefault 
+UPDATE [${flyway:defaultSchema}].[EntityField]
+SET 
+   GeneratedFormSection = 'Category',
+   ExtendedType = NULL,
+   CodeType = NULL
+WHERE 
+   ID = 'DA3D74E3-D1A2-4932-A1FB-4219F3BE1CC9' AND AutoUpdateCategory = 1
+
+-- UPDATE Entity Field Category Info MJ: AI Agent Types.AssignmentStrategy 
+UPDATE [${flyway:defaultSchema}].[EntityField]
+SET 
+   GeneratedFormSection = 'Category',
+   ExtendedType = NULL,
+   CodeType = NULL
+WHERE 
+   ID = '27C830A6-A889-4A9C-908C-33BB7A6CDB37' AND AutoUpdateCategory = 1
+
+-- UPDATE Entity Field Category Info MJ: AI Agent Types.__mj_CreatedAt 
+UPDATE [${flyway:defaultSchema}].[EntityField]
+SET 
+   GeneratedFormSection = 'Category',
+   ExtendedType = NULL,
+   CodeType = NULL
+WHERE 
+   ID = '7A190481-BB1D-4B6D-8EA1-E554E56B83B9' AND AutoUpdateCategory = 1
+
+-- UPDATE Entity Field Category Info MJ: AI Agent Types.__mj_UpdatedAt 
+UPDATE [${flyway:defaultSchema}].[EntityField]
+SET 
+   GeneratedFormSection = 'Category',
+   ExtendedType = NULL,
+   CodeType = NULL
+WHERE 
+   ID = '4AEB4F4F-664A-409A-AD4E-FD96800BF5FF' AND AutoUpdateCategory = 1
+
+-- UPDATE Entity Field Category Info MJ: AI Agent Types.DefaultStorageAccountID 
+UPDATE [${flyway:defaultSchema}].[EntityField]
+SET 
+   Category = 'Storage Settings',
+   GeneratedFormSection = 'Category',
+   DisplayName = 'Default Storage Account',
+   ExtendedType = NULL,
+   CodeType = NULL
+WHERE 
+   ID = '6B31A64B-6BD8-446B-B306-0BDD65645694' AND AutoUpdateCategory = 1
+
+-- UPDATE Entity Field Category Info MJ: AI Agent Types.DefaultStorageAccount 
+UPDATE [${flyway:defaultSchema}].[EntityField]
+SET 
+   Category = 'Storage Settings',
+   GeneratedFormSection = 'Category',
+   DisplayName = 'Default Storage Account Name',
+   ExtendedType = NULL,
+   CodeType = NULL
+WHERE 
+   ID = 'BC5FC66F-CDED-4316-8E1A-F0B3F0577F3D' AND AutoUpdateCategory = 1
+
+/* Update FieldCategoryInfo setting for entity */
+
+               UPDATE [${flyway:defaultSchema}].[EntitySetting]
+               SET Value = '{"Storage Settings":{"icon":"fa fa-database","description":"Configuration of default file storage accounts used by the agent type"}}', __mj_UpdatedAt = GETUTCDATE()
+               WHERE EntityID = '65CDC348-C4A6-4D00-A57B-2D489C56F128' AND Name = 'FieldCategoryInfo'
+            
+
+/* Update FieldCategoryIcons setting (legacy) */
+
+               UPDATE [${flyway:defaultSchema}].[EntitySetting]
+               SET Value = '{"Storage Settings":"fa fa-database"}', __mj_UpdatedAt = GETUTCDATE()
+               WHERE EntityID = '65CDC348-C4A6-4D00-A57B-2D489C56F128' AND Name = 'FieldCategoryIcons'
+            
+
+/* Set categories for 30 fields */
+
+-- UPDATE Entity Field Category Info MJ: AI Agents.ID 
+UPDATE [${flyway:defaultSchema}].[EntityField]
+SET 
+   GeneratedFormSection = 'Category',
+   ExtendedType = NULL,
+   CodeType = NULL
+WHERE 
+   ID = 'AA64DA98-1DA1-4525-8CC5-BC3E3E4893B6' AND AutoUpdateCategory = 1
+
+-- UPDATE Entity Field Category Info MJ: AI Agents.Name 
+UPDATE [${flyway:defaultSchema}].[EntityField]
+SET 
+   GeneratedFormSection = 'Category',
+   ExtendedType = NULL,
+   CodeType = NULL
+WHERE 
+   ID = '1B312173-DA2A-492C-A8F7-EB92CC0F8BDA' AND AutoUpdateCategory = 1
+
+-- UPDATE Entity Field Category Info MJ: AI Agents.Description 
+UPDATE [${flyway:defaultSchema}].[EntityField]
+SET 
+   GeneratedFormSection = 'Category',
+   ExtendedType = NULL,
+   CodeType = NULL
+WHERE 
+   ID = '6EDC921F-36C4-4739-9F2A-8F9F00E95AE7' AND AutoUpdateCategory = 1
+
+-- UPDATE Entity Field Category Info MJ: AI Agents.LogoURL 
+UPDATE [${flyway:defaultSchema}].[EntityField]
+SET 
+   GeneratedFormSection = 'Category',
+   ExtendedType = 'URL',
+   CodeType = NULL
+WHERE 
+   ID = '77845738-5781-458B-AD3C-5DAE745373C2' AND AutoUpdateCategory = 1
+
+-- UPDATE Entity Field Category Info MJ: AI Agents.__mj_CreatedAt 
+UPDATE [${flyway:defaultSchema}].[EntityField]
+SET 
+   GeneratedFormSection = 'Category',
+   ExtendedType = NULL,
+   CodeType = NULL
+WHERE 
+   ID = '353D4710-73B2-4AF5-8A93-9DC1F47FF6E5' AND AutoUpdateCategory = 1
+
+-- UPDATE Entity Field Category Info MJ: AI Agents.__mj_UpdatedAt 
+UPDATE [${flyway:defaultSchema}].[EntityField]
+SET 
+   GeneratedFormSection = 'Category',
+   ExtendedType = NULL,
+   CodeType = NULL
+WHERE 
+   ID = '3177830D-10A0-4003-B95D-8514974BA846' AND AutoUpdateCategory = 1
+
+-- UPDATE Entity Field Category Info MJ: AI Agents.ParentID 
+UPDATE [${flyway:defaultSchema}].[EntityField]
+SET 
+   GeneratedFormSection = 'Category',
+   ExtendedType = NULL,
+   CodeType = NULL
+WHERE 
+   ID = 'A6F8773F-4021-45DD-B142-9BFE4F67EC87' AND AutoUpdateCategory = 1
+
+-- UPDATE Entity Field Category Info MJ: AI Agents.ExposeAsAction 
+UPDATE [${flyway:defaultSchema}].[EntityField]
+SET 
+   GeneratedFormSection = 'Category',
+   ExtendedType = NULL,
+   CodeType = NULL
+WHERE 
+   ID = 'DF61AC7C-79A7-4058-96A1-85EBA9339D45' AND AutoUpdateCategory = 1
+
+-- UPDATE Entity Field Category Info MJ: AI Agents.ExecutionOrder 
+UPDATE [${flyway:defaultSchema}].[EntityField]
+SET 
+   GeneratedFormSection = 'Category',
+   ExtendedType = NULL,
+   CodeType = NULL
+WHERE 
+   ID = '090830CE-4073-486C-BBF2-E2105BEADD91' AND AutoUpdateCategory = 1
+
+-- UPDATE Entity Field Category Info MJ: AI Agents.ExecutionMode 
+UPDATE [${flyway:defaultSchema}].[EntityField]
+SET 
+   GeneratedFormSection = 'Category',
+   ExtendedType = NULL,
+   CodeType = NULL
+WHERE 
+   ID = '8261D630-2560-4C03-BE14-C8A9682ABBB4' AND AutoUpdateCategory = 1
+
+-- UPDATE Entity Field Category Info MJ: AI Agents.EnableContextCompression 
+UPDATE [${flyway:defaultSchema}].[EntityField]
+SET 
+   GeneratedFormSection = 'Category',
+   ExtendedType = NULL,
+   CodeType = NULL
+WHERE 
+   ID = '09AFE563-63E3-4F2B-B6F1-5945432FF07B' AND AutoUpdateCategory = 1
+
+-- UPDATE Entity Field Category Info MJ: AI Agents.ContextCompressionMessageThreshold 
+UPDATE [${flyway:defaultSchema}].[EntityField]
+SET 
+   GeneratedFormSection = 'Category',
+   DisplayName = 'Context Compression Message Threshold',
+   ExtendedType = NULL,
+   CodeType = NULL
+WHERE 
+   ID = '451D5C8F-6749-4789-A158-658B38A74AE4' AND AutoUpdateCategory = 1
+
+-- UPDATE Entity Field Category Info MJ: AI Agents.ContextCompressionPromptID 
+UPDATE [${flyway:defaultSchema}].[EntityField]
+SET 
+   GeneratedFormSection = 'Category',
+   DisplayName = 'Context Compression Prompt',
+   ExtendedType = NULL,
+   CodeType = NULL
+WHERE 
+   ID = 'FFD209C5-48F3-45D1-9094-E76EC832EA07' AND AutoUpdateCategory = 1
+
+-- UPDATE Entity Field Category Info MJ: AI Agents.ContextCompressionMessageRetentionCount 
+UPDATE [${flyway:defaultSchema}].[EntityField]
+SET 
+   GeneratedFormSection = 'Category',
+   DisplayName = 'Context Compression Message Retention Count',
+   ExtendedType = NULL,
+   CodeType = NULL
+WHERE 
+   ID = '73A50D68-976F-49A7-9737-12D1D26C6011' AND AutoUpdateCategory = 1
+
+-- UPDATE Entity Field Category Info MJ: AI Agents.ContextCompressionPrompt 
+UPDATE [${flyway:defaultSchema}].[EntityField]
+SET 
+   GeneratedFormSection = 'Category',
+   DisplayName = 'Context Compression Prompt',
+   ExtendedType = NULL,
+   CodeType = NULL
+WHERE 
+   ID = 'AD36EF69-1494-409C-A97E-FE73669DD28A' AND AutoUpdateCategory = 1
+
+-- UPDATE Entity Field Category Info MJ: AI Agents.TypeID 
+UPDATE [${flyway:defaultSchema}].[EntityField]
+SET 
+   GeneratedFormSection = 'Category',
+   ExtendedType = NULL,
+   CodeType = NULL
+WHERE 
+   ID = '91CA077D-3F59-48E1-A593-AF8686276115' AND AutoUpdateCategory = 1
+
+-- UPDATE Entity Field Category Info MJ: AI Agents.Status 
+UPDATE [${flyway:defaultSchema}].[EntityField]
+SET 
+   GeneratedFormSection = 'Category',
+   ExtendedType = NULL,
+   CodeType = NULL
+WHERE 
+   ID = 'BC44595E-6FCA-42A9-AAF8-4A730088BE46' AND AutoUpdateCategory = 1
+
+-- UPDATE Entity Field Category Info MJ: AI Agents.DriverClass 
+UPDATE [${flyway:defaultSchema}].[EntityField]
+SET 
+   GeneratedFormSection = 'Category',
+   ExtendedType = NULL,
+   CodeType = NULL
+WHERE 
+   ID = 'BB9AD9CB-40C0-41F1-B54B-750C844FD41B' AND AutoUpdateCategory = 1
+
+-- UPDATE Entity Field Category Info MJ: AI Agents.IconClass 
+UPDATE [${flyway:defaultSchema}].[EntityField]
+SET 
+   GeneratedFormSection = 'Category',
+   ExtendedType = NULL,
+   CodeType = NULL
+WHERE 
+   ID = 'E3E05E29-CDAF-4BFE-9FC8-4450EEBE05E5' AND AutoUpdateCategory = 1
+
+-- UPDATE Entity Field Category Info MJ: AI Agents.ModelSelectionMode 
+UPDATE [${flyway:defaultSchema}].[EntityField]
+SET 
+   GeneratedFormSection = 'Category',
+   ExtendedType = NULL,
+   CodeType = NULL
+WHERE 
+   ID = 'FEEBD49D-5572-45D7-9F1E-08AE762F41D9' AND AutoUpdateCategory = 1
+
+-- UPDATE Entity Field Category Info MJ: AI Agents.PayloadDownstreamPaths 
+UPDATE [${flyway:defaultSchema}].[EntityField]
+SET 
+   GeneratedFormSection = 'Category',
+   ExtendedType = NULL,
+   CodeType = NULL
+WHERE 
+   ID = '85B6AA86-796D-4970-9E35-5A483498B517' AND AutoUpdateCategory = 1
+
+-- UPDATE Entity Field Category Info MJ: AI Agents.PayloadUpstreamPaths 
+UPDATE [${flyway:defaultSchema}].[EntityField]
+SET 
+   GeneratedFormSection = 'Category',
+   ExtendedType = NULL,
+   CodeType = NULL
+WHERE 
+   ID = 'DA784B76-66CD-434B-90BD-DEC808917E68' AND AutoUpdateCategory = 1
+
+-- UPDATE Entity Field Category Info MJ: AI Agents.PayloadSelfReadPaths 
+UPDATE [${flyway:defaultSchema}].[EntityField]
+SET 
+   GeneratedFormSection = 'Category',
+   ExtendedType = NULL,
+   CodeType = NULL
+WHERE 
+   ID = 'EBF3B958-F07C-420B-82BE-2CB1E396A0F5' AND AutoUpdateCategory = 1
+
+-- UPDATE Entity Field Category Info MJ: AI Agents.PayloadSelfWritePaths 
+UPDATE [${flyway:defaultSchema}].[EntityField]
+SET 
+   GeneratedFormSection = 'Category',
+   ExtendedType = NULL,
+   CodeType = NULL
+WHERE 
+   ID = '61E51FC3-8EFA-40D9-9525-F3FAD0A95DCA' AND AutoUpdateCategory = 1
+
+-- UPDATE Entity Field Category Info MJ: AI Agents.PayloadScope 
+UPDATE [${flyway:defaultSchema}].[EntityField]
+SET 
+   GeneratedFormSection = 'Category',
+   ExtendedType = NULL,
+   CodeType = NULL
+WHERE 
+   ID = '2E542986-0164-4B9E-8457-06826A4AB892' AND AutoUpdateCategory = 1
+
+-- UPDATE Entity Field Category Info MJ: AI Agents.FinalPayloadValidation 
+UPDATE [${flyway:defaultSchema}].[EntityField]
+SET 
+   GeneratedFormSection = 'Category',
+   ExtendedType = NULL,
+   CodeType = NULL
+WHERE 
+   ID = '1C7959AE-F48B-4858-8383-28C3F4706314' AND AutoUpdateCategory = 1
+
+-- UPDATE Entity Field Category Info MJ: AI Agents.FinalPayloadValidationMode 
+UPDATE [${flyway:defaultSchema}].[EntityField]
+SET 
+   GeneratedFormSection = 'Category',
+   ExtendedType = NULL,
+   CodeType = NULL
+WHERE 
+   ID = '8931DE12-4048-4DEB-A2A3-E821354CFFB2' AND AutoUpdateCategory = 1
+
+-- UPDATE Entity Field Category Info MJ: AI Agents.FinalPayloadValidationMaxRetries 
+UPDATE [${flyway:defaultSchema}].[EntityField]
+SET 
+   GeneratedFormSection = 'Category',
+   ExtendedType = NULL,
+   CodeType = NULL
+WHERE 
+   ID = 'AF62DAAB-74D4-4539-9B47-58DD4A023E4B' AND AutoUpdateCategory = 1
+
+-- UPDATE Entity Field Category Info MJ: AI Agents.StartingPayloadValidation 
+UPDATE [${flyway:defaultSchema}].[EntityField]
+SET 
+   GeneratedFormSection = 'Category',
+   ExtendedType = NULL,
+   CodeType = NULL
+WHERE 
+   ID = 'B7A2371C-A22C-48EA-827E-824F8A40DA3D' AND AutoUpdateCategory = 1
+
+-- UPDATE Entity Field Category Info MJ: AI Agents.StartingPayloadValidationMode 
+UPDATE [${flyway:defaultSchema}].[EntityField]
+SET 
+   GeneratedFormSection = 'Category',
+   ExtendedType = NULL,
+   CodeType = NULL
+WHERE 
+   ID = '0947203D-A5CA-4ED2-895B-17A8007323FC' AND AutoUpdateCategory = 1
+

--- a/packages/AI/Agents/README.md
+++ b/packages/AI/Agents/README.md
@@ -332,6 +332,38 @@ New code should import these directly from `@memberjunction/ai-reranker`.
 - `@memberjunction/aiengine` -- AIEngine for metadata and vector search
 - `@memberjunction/ai-core-plus` -- Shared types (ExecuteAgentParams, ExecuteAgentResult)
 - `@memberjunction/ai-engine-base` -- Base metadata cache and permissions
+## Storage Account Resolution
+
+When agents create file-based artifacts (PDF, Excel, Word), the system resolves which `FileStorageAccount` to use via a hierarchical chain. The first non-null value wins:
+
+| Priority | Source | Field |
+|----------|--------|-------|
+| 1 (highest) | Runtime | `ExecuteAgentParams.override.storageAccountId` |
+| 2 | Agent | `AIAgent.DefaultStorageAccountID` |
+| 3 | Category tree | `AIAgentCategory.DefaultStorageAccountID` (walks up `ParentID`) |
+| 4 (lowest) | Agent Type | `AIAgentType.DefaultStorageAccountID` |
+| Fallback | System | Single active account (if only one exists) |
+
+### How it works
+
+- `BaseAgent.getStorageAccountID(params)` implements the resolution logic. It is `protected` so subclasses can override it for custom routing.
+- The resolved ID is stored in `ExecuteAgentResult.resolvedStorageAccountId` and passed to `AgentRunner.ProcessFileArtifacts()` for upload routing.
+- `AgentRunner.uploadBase64ToStorage()` uses `FileStorageEngine.Instance.GetAccountWithProvider()` to get the account + provider, then `initializeDriverWithAccountCredentials()` for proper OAuth credential handling.
+
+### Startup validation
+
+`AIEngine.validateStorageAccountDefaults()` runs at server startup. If 2+ active storage accounts exist but agent types lack a `DefaultStorageAccountID`, it auto-assigns the highest-priority account and logs a prominent warning.
+
+### Configuration
+
+Set `DefaultStorageAccountID` at any level via the admin UI or metadata sync:
+- **Agent Type** -- broadest default (e.g., all Loop agents → Dropbox)
+- **Agent Category** -- business-domain default (e.g., Marketing → Box, Finance → SharePoint)
+- **Agent** -- per-agent override
+- **Runtime** -- `ExecuteAgentParams.override.storageAccountId` for programmatic callers
+
+## Dependencies
+
 - `@memberjunction/ai` -- Core AI abstractions
 - `@memberjunction/ai-reranker` -- Two-stage retrieval reranking
 - `@memberjunction/actions` -- Server-side action execution

--- a/packages/AI/Agents/src/AgentRunner.ts
+++ b/packages/AI/Agents/src/AgentRunner.ts
@@ -16,7 +16,7 @@ import { MJGlobal, UUIDsEqual } from '@memberjunction/global';
 import { AIEngine } from '@memberjunction/aiengine';
 import { ExecuteAgentResult, ExecuteAgentParams, MediaOutput, FileOutputRef } from '@memberjunction/ai-core-plus';
 import { BaseAgent } from './base-agent';
-import { MJConversationEntity, MJConversationDetailEntity, MJArtifactEntity, MJArtifactVersionEntity, MJConversationDetailArtifactEntity, MJAIAgentRunMediaEntity, MJConversationDetailAttachmentEntity, MJFileEntity, ArtifactMetadataEngine, FileStorageEngine } from '@memberjunction/core-entities';
+import { MJConversationEntity, MJConversationDetailEntity, MJArtifactEntity, MJArtifactVersionEntity, MJConversationDetailArtifactEntity, MJAIAgentRunMediaEntity, MJConversationDetailAttachmentEntity, MJFileEntity, ArtifactMetadataEngine, FileStorageEngine, StorageAccountWithProvider } from '@memberjunction/core-entities';
 import { initializeDriverWithAccountCredentials } from '@memberjunction/storage';
 
 // ── Types used only by the historical reprocessing path ──────────────────────
@@ -428,7 +428,8 @@ export class AgentRunner {
                 await this.ProcessFileArtifacts(
                     agentResult.fileOutputs,
                     agentResponseDetailId,
-                    contextUser
+                    contextUser,
+                    agentResult.resolvedStorageAccountId
                 );
             }
 
@@ -1161,11 +1162,15 @@ export class AgentRunner {
      * @param fileOutputs - File outputs collected by BaseAgent during action execution
      * @param conversationDetailId - The conversation detail to link artifacts to
      * @param contextUser - User context for DB operations
+     * @param resolvedStorageAccountId - Pre-resolved FileStorageAccount ID from the agent's
+     *   hierarchical resolution chain (Runtime → Agent → Category → Type → fallback).
+     *   When provided, uploads use this specific account instead of picking the first active one.
      */
     public async ProcessFileArtifacts(
         fileOutputs: FileOutputRef[],
         conversationDetailId: string,
-        contextUser: UserInfo
+        contextUser: UserInfo,
+        resolvedStorageAccountId?: string
     ): Promise<void> {
         if (fileOutputs.length === 0) return;
 
@@ -1176,7 +1181,7 @@ export class AgentRunner {
         ]);
 
         await Promise.all(
-            fileOutputs.map(fo => this.processFileOutput(fo, conversationDetailId, contextUser))
+            fileOutputs.map(fo => this.processFileOutput(fo, conversationDetailId, contextUser, resolvedStorageAccountId))
         );
     }
 
@@ -1253,7 +1258,8 @@ export class AgentRunner {
     private async processFileOutput(
         fo: FileOutputRef,
         conversationDetailId: string,
-        contextUser: UserInfo
+        contextUser: UserInfo,
+        resolvedStorageAccountId?: string
     ): Promise<void> {
         try {
             if (fo.fileId) {
@@ -1278,7 +1284,8 @@ export class AgentRunner {
                     fo.fileData!,
                     fo.fileName,
                     fo.mimeType,
-                    contextUser
+                    contextUser,
+                    resolvedStorageAccountId
                 );
                 await this.createFileArtifact(fileId, fo.mimeType, fo.fileName, fo.sizeBytes, conversationDetailId, contextUser);
             } catch (storageError) {
@@ -1294,19 +1301,28 @@ export class AgentRunner {
     /**
      * Uploads base64-encoded file content to MJStorage and creates an MJ: Files record.
      * Returns the new MJ: Files record ID.
+     *
+     * @param resolvedStorageAccountId - Pre-resolved account from the agent's storage resolution chain.
+     *   When provided, uploads to this specific account. Otherwise falls back to the first active account.
      */
     private async uploadBase64ToStorage(
         base64Data: string,
         fileName: string,
         mimeType: string,
-        contextUser: UserInfo
+        contextUser: UserInfo,
+        resolvedStorageAccountId?: string
     ): Promise<string> {
         const accounts = FileStorageEngine.Instance.AccountsWithProviders;
         if (accounts.length === 0) {
             throw new Error('No file storage accounts configured. Cannot upload file artifact.');
         }
 
-        const { account, provider } = accounts.find(a => a.provider.IsActive !== false) ?? accounts[0];
+        // Use the resolved account if provided, otherwise fall back to first active
+        let resolved: StorageAccountWithProvider | undefined;
+        if (resolvedStorageAccountId) {
+            resolved = FileStorageEngine.Instance.GetAccountWithProvider(resolvedStorageAccountId) ?? undefined;
+        }
+        const { account, provider } = resolved ?? accounts.find(a => a.provider.IsActive !== false) ?? accounts[0];
         const driver = await initializeDriverWithAccountCredentials({
             accountEntity: account,
             providerEntity: provider,

--- a/packages/AI/Agents/src/base-agent.ts
+++ b/packages/AI/Agents/src/base-agent.ts
@@ -11,7 +11,7 @@
  * @since 2.49.0
  */
 
-import { MJAIAgentTypeEntity,  MJTemplateParamEntity, MJActionParamEntity, MJAIAgentRelationshipEntity, MJAIAgentNoteEntity, MJAIAgentExampleEntity, MJConversationDetailEntity, MJAIAgentRequestEntity, MJAIAgentRequestTypeEntity } from '@memberjunction/core-entities';
+import { MJAIAgentTypeEntity,  MJTemplateParamEntity, MJActionParamEntity, MJAIAgentRelationshipEntity, MJAIAgentNoteEntity, MJAIAgentExampleEntity, MJConversationDetailEntity, MJAIAgentRequestEntity, MJAIAgentRequestTypeEntity, FileStorageEngine } from '@memberjunction/core-entities';
 import { MJAIAgentRunEntityExtended, MJAIAgentRunStepEntityExtended, MJAIPromptEntityExtended, MJAIAgentEntityExtended } from "@memberjunction/ai-core-plus";
 import { UserInfo, Metadata, RunView, LogStatus, LogStatusEx, LogError, LogErrorEx, IsVerboseLoggingEnabled, IMetadataProvider } from '@memberjunction/core';
 import { AIPromptRunner } from '@memberjunction/ai-prompts';
@@ -263,6 +263,14 @@ export class BaseAgent {
      * @private
      */
     private _feedbackRequestId: string | null = null;
+
+    /**
+     * Resolved FileStorageAccount ID for this agent run. Set during Execute()
+     * via the hierarchical resolution chain and included in the ExecuteAgentResult
+     * so AgentRunner can route file artifact uploads.
+     * @private
+     */
+    private _resolvedStorageAccountId: string | null = null;
 
     /**
      * Access the current run for the agent
@@ -1131,6 +1139,9 @@ export class BaseAgent {
 
             // Initialize engines
             await this.initializeEngines(params.contextUser);
+
+            // Resolve storage account for file artifacts (needs engines loaded)
+            this._resolvedStorageAccountId = await this.getStorageAccountID(wrappedParams);
 
             // Check for cancellation after initialization
             if (params.cancellationToken?.aborted) {
@@ -3960,7 +3971,12 @@ The context is now within limits. Please retry your request with the recovered c
                 Value: value,
                 Type: 'Input' as const
             }));
-            
+
+            // Build action context: preserve the agent's context and inject resolved storage account ID
+            const actionContext = this._resolvedStorageAccountId
+                ? { ...(typeof params.context === 'object' && params.context ? params.context : {}), __resolvedStorageAccountId: this._resolvedStorageAccountId }
+                : params.context;
+
             // Execute the action and return the full ActionResult
             const result = await actionEngine.RunAction({
                 Action: actionEntity,
@@ -3968,7 +3984,7 @@ The context is now within limits. Please retry your request with the recovered c
                 ContextUser: contextUser,
                 Filters: [],
                 SkipActionLog: false,
-                Context: params.context // pass along our context to actions so they can use it however they need
+                Context: actionContext
             });
             
             if (result.Success) {
@@ -7594,7 +7610,7 @@ The context is now within limits. Please retry your request with the recovered c
      * Loads categories via RunView and caches them for the duration of this run.
      * @private
      */
-    private _categoryCache: Array<{ ID: string; ParentID: string | null; AssignmentStrategy: string | null }> | null = null;
+    private _categoryCache: Array<{ ID: string; Name: string; ParentID: string | null; AssignmentStrategy: string | null; DefaultStorageAccountID: string | null }> | null = null;
 
     private async resolveCategoryAssignmentStrategy(
         params: ExecuteAgentParams
@@ -7603,23 +7619,14 @@ The context is now within limits. Please retry your request with the recovered c
         if (!categoryId) return null;
 
         try {
-            // Load all categories if not cached
-            if (!this._categoryCache) {
-                const rv = new RunView();
-                const result = await rv.RunView<{ ID: string; ParentID: string | null; AssignmentStrategy: string | null }>({
-                    EntityName: 'MJ: AI Agent Categories',
-                    Fields: ['ID', 'ParentID', 'AssignmentStrategy'],
-                    ResultType: 'simple'
-                }, params.contextUser);
-                this._categoryCache = result.Success ? result.Results : [];
-            }
+            await this.ensureCategoryCacheLoaded(params);
 
             // Walk up the tree from the agent's category to the root
             let currentId: string | null = categoryId;
             const visited = new Set<string>(); // prevent infinite loops
             while (currentId && !visited.has(currentId)) {
                 visited.add(currentId);
-                const cat = this._categoryCache.find(c => UUIDsEqual(c.ID, currentId));
+                const cat = this._categoryCache!.find(c => UUIDsEqual(c.ID, currentId));
                 if (!cat) break;
 
                 const strategy = parseAssignmentStrategy(cat.AssignmentStrategy);
@@ -7632,6 +7639,114 @@ The context is now within limits. Please retry your request with the recovered c
         }
 
         return null;
+    }
+
+    /**
+     * Loads all agent categories into the cache if not already loaded.
+     * Shared by both assignment strategy and storage account resolution.
+     */
+    private async ensureCategoryCacheLoaded(params: ExecuteAgentParams): Promise<void> {
+        if (!this._categoryCache) {
+            const rv = new RunView();
+            const result = await rv.RunView<{ ID: string; Name: string; ParentID: string | null; AssignmentStrategy: string | null; DefaultStorageAccountID: string | null }>({
+                EntityName: 'MJ: AI Agent Categories',
+                Fields: ['ID', 'Name', 'ParentID', 'AssignmentStrategy', 'DefaultStorageAccountID'],
+                ResultType: 'simple'
+            }, params.contextUser);
+            this._categoryCache = result.Success ? result.Results : [];
+        }
+    }
+
+    /**
+     * Resolves the file storage account ID for this agent's file artifacts.
+     *
+     * Resolution chain (first non-null wins):
+     * 1. Runtime override (`params.override?.storageAccountId`)
+     * 2. Agent-level (`params.agent.DefaultStorageAccountID`)
+     * 3. Category hierarchy — walks up the agent's category tree via `ParentID`
+     * 4. Agent Type-level (`agentType.DefaultStorageAccountID`)
+     * 5. System fallback — single active storage account, if only one exists
+     *
+     * This method is `protected` so subclasses can override the resolution logic
+     * for custom storage routing (e.g., routing by file type or tenant).
+     *
+     * @param params - The current agent execution parameters
+     * @returns The resolved FileStorageAccount ID, or null if none configured
+     */
+    protected async getStorageAccountID(params: ExecuteAgentParams): Promise<string | null> {
+        // 1. Runtime override — highest priority
+        if (params.override?.storageAccountId) {
+            return params.override.storageAccountId;
+        }
+
+        // 2. Agent-level override
+        if (params.agent.DefaultStorageAccountID) {
+            return params.agent.DefaultStorageAccountID;
+        }
+
+        // 3. Category tree walk
+        const categoryId = params.agent.CategoryID;
+        if (categoryId) {
+            try {
+                await this.ensureCategoryCacheLoaded(params);
+
+                let currentId: string | null = categoryId;
+                const visited = new Set<string>();
+                while (currentId && !visited.has(currentId)) {
+                    visited.add(currentId);
+                    const cat = this._categoryCache!.find(c => UUIDsEqual(c.ID, currentId));
+                    if (!cat) break;
+                    if (cat.DefaultStorageAccountID) return cat.DefaultStorageAccountID;
+                    currentId = cat.ParentID;
+                }
+            } catch (error) {
+                LogError(`Error resolving category storage account: ${(error as Error).message}`);
+            }
+        }
+
+        // 4. Agent Type-level default
+        const agentTypeId = params.agent.TypeID;
+        if (agentTypeId) {
+            const agentType = AIEngine.Instance.AgentTypes.find(
+                at => UUIDsEqual(at.ID, agentTypeId)
+            );
+            if (agentType?.DefaultStorageAccountID) {
+                return agentType.DefaultStorageAccountID;
+            }
+        }
+
+        // 5. System fallback
+        await FileStorageEngine.Instance.Config(false, params.contextUser);
+        const activeAccounts = FileStorageEngine.Instance.AccountsWithProviders
+            .filter(a => a.provider.IsActive);
+
+        if (activeAccounts.length === 0) {
+            // No storage configured — return null, inline base64 fallback handles it downstream
+            return null;
+        }
+
+        if (activeAccounts.length === 1) {
+            return activeAccounts[0].account.ID;
+        }
+
+        // 2+ active accounts but nothing configured at any level
+        const agentName = params.agent.Name || params.agent.ID;
+        const typeName = params.agent.TypeID
+            ? AIEngine.Instance.AgentTypes.find(at => UUIDsEqual(at.ID, params.agent.TypeID))?.Name || params.agent.TypeID
+            : 'unknown';
+        const categoryName = params.agent.CategoryID
+            ? this._categoryCache?.find(c => UUIDsEqual(c.ID, params.agent.CategoryID))?.Name || params.agent.CategoryID
+            : 'none';
+        const accountNames = activeAccounts.map(a => `'${a.account.Name}' (${a.provider.Name})`).join(', ');
+
+        throw new Error(
+            `Multiple active file storage accounts detected (${accountNames}) but no DefaultStorageAccountID is configured ` +
+            `for agent '${agentName}', category '${categoryName}', or agent type '${typeName}'.\n` +
+            `To fix: Set DefaultStorageAccountID on one of the following (in order of priority):\n` +
+            `  1. Agent '${agentName}' — for this specific agent\n` +
+            `  2. Agent Category '${categoryName}' — for all agents in this category\n` +
+            `  3. Agent Type '${typeName}' — for all agents of this type`
+        );
     }
 
     /**
@@ -8738,7 +8853,8 @@ The context is now within limits. Please retry your request with the recovered c
                 : undefined,
             mediaOutputs: this._mediaOutputs.length > 0 ? this._mediaOutputs : undefined,
             fileOutputs: this._fileOutputs.length > 0 ? this._fileOutputs : undefined,
-            feedbackRequestId: this._feedbackRequestId || undefined
+            feedbackRequestId: this._feedbackRequestId || undefined,
+            resolvedStorageAccountId: this._resolvedStorageAccountId || undefined
         };
     }
 

--- a/packages/AI/CorePlus/src/agent-types.ts
+++ b/packages/AI/CorePlus/src/agent-types.ts
@@ -586,6 +586,17 @@ export type ExecuteAgentResult<P = any> = {
      * @since 5.12.0
      */
     feedbackRequestId?: string;
+
+    /**
+     * The resolved FileStorageAccount ID for file artifact storage, determined during
+     * agent execution via the hierarchical resolution chain:
+     * Runtime → Agent → Category tree → Type → system fallback.
+     *
+     * Used by AgentRunner to route file artifact uploads to the correct storage account.
+     * Null when no storage account could be resolved (e.g., no accounts configured).
+     * @since 5.24.0
+     */
+    resolvedStorageAccountId?: string;
 }
 
 /**
@@ -794,6 +805,13 @@ export type ExecuteAgentParams<TContext = any, P = any, TAgentTypeParams = unkno
     override?: {
         modelId?: string;
         vendorId?: string;
+        /**
+         * Runtime override for the file storage account used when creating file artifacts.
+         * Highest priority in the resolution chain: Runtime → Agent → Category tree → Type → system fallback.
+         * Resolves to a FileStorageAccount record which carries both the provider driver
+         * (via ProviderID) and credentials (via CredentialID).
+         */
+        storageAccountId?: string;
     };
     /** 
      * Optional flag to enable verbose logging during agent execution.

--- a/packages/AI/Engine/src/services/ConversationAttachmentService.ts
+++ b/packages/AI/Engine/src/services/ConversationAttachmentService.ts
@@ -20,7 +20,8 @@ import {
     MJAIAgentEntity,
     MJAIModelEntity,
     MJConversationDetailAttachmentEntity,
-    MJAIModalityEntity
+    MJAIModalityEntity,
+    FileStorageEngine
 } from '@memberjunction/core-entities';
 import { MJGlobal } from '@memberjunction/global';
 import { FileStorageBase, initializeDriverWithAccountCredentials } from '@memberjunction/storage';
@@ -522,7 +523,14 @@ export class ConversationAttachmentService {
     }
 
     /**
-     * Upload data to MJStorage
+     * Upload data to MJStorage.
+     *
+     * Resolves the storage account using:
+     * 1. Agent's `DefaultStorageAccountID` (account-based, with credentials)
+     * 2. Fallback: Agent's `AttachmentStorageProviderID` (legacy provider-based)
+     *
+     * When an account is resolved, uses `initializeDriverWithAccountCredentials()`
+     * for proper OAuth credential handling.
      */
     private async uploadToStorage(
         base64Data: string,
@@ -531,45 +539,50 @@ export class ConversationAttachmentService {
         agent: MJAIAgentEntity | null,
         contextUser: UserInfo
     ): Promise<{ success: boolean; fileId?: string; error?: string }> {
-        // Get storage provider from agent config or use default
-        const providerId = agent?.AttachmentStorageProviderID ?? null;
-        if (!providerId) {
-            return {
-                success: false,
-                error: 'No storage provider configured for attachments'
-            };
+        let driver: FileStorageBase;
+        let providerId: string;
+
+        // Prefer account-based resolution (new path with proper credentials)
+        const storageAccountId = agent?.DefaultStorageAccountID ?? null;
+        if (storageAccountId) {
+            await FileStorageEngine.Instance.Config(false, contextUser);
+            const resolved = FileStorageEngine.Instance.GetAccountWithProvider(storageAccountId);
+            if (!resolved) {
+                return { success: false, error: `Storage account ${storageAccountId} not found` };
+            }
+            driver = await initializeDriverWithAccountCredentials({
+                accountEntity: resolved.account,
+                providerEntity: resolved.provider,
+                contextUser
+            });
+            providerId = resolved.provider.ID;
+        } else {
+            // Legacy fallback: provider-based resolution (no account credentials)
+            const legacyProviderId = agent?.AttachmentStorageProviderID ?? null;
+            if (!legacyProviderId) {
+                return { success: false, error: 'No storage provider configured for attachments' };
+            }
+            const provider = await this.md.GetEntityObject<MJFileStorageProviderEntity>('MJ: File Storage Providers', contextUser);
+            if (!await provider.Load(legacyProviderId)) {
+                return { success: false, error: 'Failed to load storage provider' };
+            }
+            driver = MJGlobal.Instance.ClassFactory.CreateInstance<FileStorageBase>(
+                FileStorageBase,
+                provider.ServerDriverKey
+            );
+            providerId = legacyProviderId;
         }
 
-        // Load provider
-        const provider = await this.md.GetEntityObject<MJFileStorageProviderEntity>('MJ: File Storage Providers', contextUser);
-        if (!await provider.Load(providerId)) {
-            return {
-                success: false,
-                error: 'Failed to load storage provider'
-            };
-        }
-
-        // Get driver
-        const driver = MJGlobal.Instance.ClassFactory.CreateInstance<FileStorageBase>(
-            FileStorageBase,
-            provider.ServerDriverKey
-        );
-
-        // Determine storage path - use a default if agent doesn't have one
+        // Determine storage path
         const basePath = 'conversation-attachments';
         const timestamp = Date.now();
         const objectName = `${basePath}/${timestamp}_${fileName}`;
 
-        // Convert base64 to buffer
+        // Convert base64 to buffer and upload
         const buffer = Buffer.from(base64Data, 'base64');
-
-        // Upload
         const uploaded = await driver.PutObject(objectName, buffer, mimeType);
         if (!uploaded) {
-            return {
-                success: false,
-                error: 'Failed to upload file to storage'
-            };
+            return { success: false, error: 'Failed to upload file to storage' };
         }
 
         // Create File entity record
@@ -581,18 +594,11 @@ export class ConversationAttachmentService {
         file.Status = 'Uploaded';
 
         if (!await file.Save()) {
-            // Try to clean up uploaded file
             await driver.DeleteObject(objectName);
-            return {
-                success: false,
-                error: 'Failed to create file record'
-            };
+            return { success: false, error: 'Failed to create file record' };
         }
 
-        return {
-            success: true,
-            fileId: file.ID
-        };
+        return { success: true, fileId: file.ID };
     }
 
     /**

--- a/packages/Actions/CoreActions/src/__tests__/document-builder.test.ts
+++ b/packages/Actions/CoreActions/src/__tests__/document-builder.test.ts
@@ -1,11 +1,11 @@
 import { describe, it, expect, beforeEach } from 'vitest';
-import { DocumentBuilderService, DocumentOperation } from '../custom/utilities/document-builder-service';
+import { ArtifactBuilderService, DocumentOperation } from '../custom/utilities/artifact-builder-service';
 
-describe('DocumentBuilderService', () => {
-    let service: DocumentBuilderService;
+describe('ArtifactBuilderService', () => {
+    let service: ArtifactBuilderService;
 
     beforeEach(() => {
-        service = DocumentBuilderService.Instance;
+        service = ArtifactBuilderService.Instance;
     });
 
     describe('CreateDocument', () => {

--- a/packages/Actions/CoreActions/src/custom/files/add-document-content.action.ts
+++ b/packages/Actions/CoreActions/src/custom/files/add-document-content.action.ts
@@ -2,7 +2,7 @@ import { ActionResultSimple, RunActionParams } from "@memberjunction/actions-bas
 import { RegisterClass } from "@memberjunction/global";
 import { BaseAction } from '@memberjunction/actions';
 import { BaseFileHandlerAction } from "../utilities/base-file-handler";
-import { DocumentBuilderService, DocumentOperation } from "../utilities/document-builder-service";
+import { ArtifactBuilderService, DocumentOperation } from "../utilities/artifact-builder-service";
 import { JSONParamHelper } from "../utilities/json-param-helper";
 
 /**
@@ -44,7 +44,7 @@ export class AddDocumentContentAction extends BaseFileHandlerAction {
                 return { Success: false, Message: "Operations must be a non-empty array", ResultCode: "INVALID_OPERATIONS" };
             }
 
-            const service = DocumentBuilderService.Instance;
+            const service = ArtifactBuilderService.Instance;
             const sectionIds = service.AddContent(handle.toString(), operations);
             const preview = service.GetPreview(handle.toString());
 

--- a/packages/Actions/CoreActions/src/custom/files/create-document.action.ts
+++ b/packages/Actions/CoreActions/src/custom/files/create-document.action.ts
@@ -2,7 +2,7 @@ import { ActionResultSimple, RunActionParams } from "@memberjunction/actions-bas
 import { RegisterClass } from "@memberjunction/global";
 import { BaseAction } from '@memberjunction/actions';
 import { BaseFileHandlerAction } from "../utilities/base-file-handler";
-import { DocumentBuilderService, DocumentType, DocumentOptions } from "../utilities/document-builder-service";
+import { ArtifactBuilderService, DocumentType, DocumentOptions } from "../utilities/artifact-builder-service";
 import { JSONParamHelper } from "../utilities/json-param-helper";
 
 /**
@@ -35,7 +35,7 @@ export class CreateDocumentAction extends BaseFileHandlerAction {
             const fileName = this.getParamValue(params, 'filename');
             const options = JSONParamHelper.getJSONParam(params, 'options') as DocumentOptions | null;
 
-            const service = DocumentBuilderService.Instance;
+            const service = ArtifactBuilderService.Instance;
             const handle = service.CreateDocument(documentType, fileName ?? undefined, options ?? undefined);
 
             const defaultFileNames: Record<string, string> = { pdf: 'document.pdf', docx: 'document.docx', xlsx: 'workbook.xlsx' };

--- a/packages/Actions/CoreActions/src/custom/files/finalize-document.action.ts
+++ b/packages/Actions/CoreActions/src/custom/files/finalize-document.action.ts
@@ -2,7 +2,7 @@ import { ActionResultSimple, RunActionParams } from "@memberjunction/actions-bas
 import { RegisterClass } from "@memberjunction/global";
 import { BaseAction } from '@memberjunction/actions';
 import { BaseFileHandlerAction } from "../utilities/base-file-handler";
-import { DocumentBuilderService } from "../utilities/document-builder-service";
+import { ArtifactBuilderService } from "../utilities/artifact-builder-service";
 
 /**
  * Finalizes an in-progress document: renders it to a binary file, saves to MJStorage,
@@ -33,7 +33,7 @@ export class FinalizeDocumentAction extends BaseFileHandlerAction {
             const storageAccountName = this.getParamValue(params, 'storageaccountname');
             const storagePath = this.getParamValue(params, 'storagepath');
 
-            const service = DocumentBuilderService.Instance;
+            const service = ArtifactBuilderService.Instance;
             const result = await service.Finalize(handle.toString());
 
             const fileName = fileNameOverride?.toString() || result.fileName;

--- a/packages/Actions/CoreActions/src/custom/files/modify-document-section.action.ts
+++ b/packages/Actions/CoreActions/src/custom/files/modify-document-section.action.ts
@@ -2,7 +2,7 @@ import { ActionResultSimple, RunActionParams } from "@memberjunction/actions-bas
 import { RegisterClass } from "@memberjunction/global";
 import { BaseAction } from '@memberjunction/actions';
 import { BaseFileHandlerAction } from "../utilities/base-file-handler";
-import { DocumentBuilderService, DocumentOperation } from "../utilities/document-builder-service";
+import { ArtifactBuilderService, DocumentOperation } from "../utilities/artifact-builder-service";
 import { JSONParamHelper } from "../utilities/json-param-helper";
 
 /**
@@ -38,7 +38,7 @@ export class ModifyDocumentSectionAction extends BaseFileHandlerAction {
                 return { Success: false, Message: "Action must be 'replace' or 'remove'", ResultCode: "INVALID_ACTION" };
             }
 
-            const service = DocumentBuilderService.Instance;
+            const service = ArtifactBuilderService.Instance;
 
             if (action === 'remove') {
                 service.RemoveSection(handle.toString(), sectionId.toString());

--- a/packages/Actions/CoreActions/src/custom/files/preview-document.action.ts
+++ b/packages/Actions/CoreActions/src/custom/files/preview-document.action.ts
@@ -2,7 +2,7 @@ import { ActionResultSimple, RunActionParams } from "@memberjunction/actions-bas
 import { RegisterClass } from "@memberjunction/global";
 import { BaseAction } from '@memberjunction/actions';
 import { BaseFileHandlerAction } from "../utilities/base-file-handler";
-import { DocumentBuilderService } from "../utilities/document-builder-service";
+import { ArtifactBuilderService } from "../utilities/artifact-builder-service";
 
 /**
  * Returns a summary of the current state of an in-progress document.
@@ -25,7 +25,7 @@ export class PreviewDocumentAction extends BaseFileHandlerAction {
                 return { Success: false, Message: "Handle parameter is required", ResultCode: "MISSING_HANDLE" };
             }
 
-            const service = DocumentBuilderService.Instance;
+            const service = ArtifactBuilderService.Instance;
             const preview = service.GetPreview(handle.toString());
 
             return {

--- a/packages/Actions/CoreActions/src/custom/utilities/artifact-builder-service.ts
+++ b/packages/Actions/CoreActions/src/custom/utilities/artifact-builder-service.ts
@@ -1,5 +1,5 @@
 /**
- * DocumentBuilderService — manages in-progress document state for incremental building.
+ * ArtifactBuilderService — manages in-progress artifact/document state for incremental building.
  *
  * The LLM creates a document handle, then adds content across multiple agent turns.
  * At finalize, the accumulated content is rendered to a binary file (PDF, DOCX, XLSX)
@@ -81,8 +81,8 @@ const CLEANUP_INTERVAL_MS = 5 * 60 * 1000; // Check every 5 minutes
  * Each document is identified by a UUID handle and persists across agent turns
  * within the same Node.js process.
  */
-export class DocumentBuilderService {
-    private static _instance: DocumentBuilderService | null = null;
+export class ArtifactBuilderService {
+    private static _instance: ArtifactBuilderService | null = null;
     private documents: Map<string, InProgressDocument> = new Map();
     private cleanupTimer: ReturnType<typeof setInterval> | null = null;
 
@@ -90,11 +90,11 @@ export class DocumentBuilderService {
         this.startCleanupTimer();
     }
 
-    public static get Instance(): DocumentBuilderService {
-        if (!DocumentBuilderService._instance) {
-            DocumentBuilderService._instance = new DocumentBuilderService();
+    public static get Instance(): ArtifactBuilderService {
+        if (!ArtifactBuilderService._instance) {
+            ArtifactBuilderService._instance = new ArtifactBuilderService();
         }
-        return DocumentBuilderService._instance;
+        return ArtifactBuilderService._instance;
     }
 
     // ── Lifecycle ─────────────────────────────────────────────────────────────

--- a/packages/Actions/CoreActions/src/custom/utilities/base-file-handler.ts
+++ b/packages/Actions/CoreActions/src/custom/utilities/base-file-handler.ts
@@ -1,7 +1,7 @@
 import { BaseAction } from "@memberjunction/actions";
 import { RunActionParams } from "@memberjunction/actions-base";
 import { Metadata, RunView } from "@memberjunction/core";
-import { MJFileEntity, MJFileStorageAccountEntity, MJFileStorageProviderEntity } from "@memberjunction/core-entities";
+import { MJFileEntity, MJFileStorageAccountEntity, MJFileStorageProviderEntity, FileStorageEngine } from "@memberjunction/core-entities";
 import { initializeDriverWithAccountCredentials } from "@memberjunction/storage";
 
 /**
@@ -168,7 +168,7 @@ export abstract class BaseFileHandlerAction extends BaseAction {
         try {
             const { accountEntity, providerEntity } = storageAccountName
                 ? await this.loadStorageAccountByName(storageAccountName, params)
-                : await this.loadDefaultStorageAccount(params);
+                : await this.loadResolvedOrDefaultStorageAccount(params);
             const driver = await initializeDriverWithAccountCredentials({
                 accountEntity,
                 providerEntity,
@@ -236,36 +236,35 @@ export abstract class BaseFileHandlerAction extends BaseAction {
     }
 
     /**
-     * Loads the first active FileStorageAccount along with its provider entity.
-     * Used by saveToMJStorage to determine where to upload files.
+     * Resolves the storage account from the agent's resolution chain (via Context)
+     * or falls back to priority-based selection.
      */
-    private async loadDefaultStorageAccount(params: RunActionParams): Promise<{
+    private async loadResolvedOrDefaultStorageAccount(params: RunActionParams): Promise<{
         accountEntity: MJFileStorageAccountEntity;
         providerEntity: MJFileStorageProviderEntity;
     }> {
-        const rv = new RunView();
-        const accountResult = await rv.RunView<MJFileStorageAccountEntity>({
-            EntityName: 'MJ: File Storage Accounts',
-            OrderBy: '__mj_CreatedAt ASC',
-            MaxRows: 1,
-            ResultType: 'entity_object'
-        }, params.ContextUser);
+        await FileStorageEngine.Instance.Config(false, params.ContextUser);
 
-        if (!accountResult.Success || accountResult.Results.length === 0) {
+        // Check for agent-resolved storage account ID (passed via Context by BaseAgent)
+        const context = params.Context as Record<string, unknown> | undefined;
+        const resolvedId = context?.__resolvedStorageAccountId;
+        if (resolvedId) {
+            const resolved = FileStorageEngine.Instance.GetAccountWithProvider(resolvedId.toString());
+            if (resolved) {
+                return { accountEntity: resolved.account, providerEntity: resolved.provider };
+            }
+        }
+
+        // Fallback: pick by provider priority
+        const activeAccounts = FileStorageEngine.Instance.AccountsWithProviders
+            .filter(a => a.provider.IsActive);
+
+        if (activeAccounts.length === 0) {
             throw new Error('No active FileStorageAccount found. Configure at least one storage account.');
         }
 
-        const accountEntity = accountResult.Results[0];
-        const md = new Metadata();
-        const providerEntity = await md.GetEntityObject<MJFileStorageProviderEntity>(
-            'MJ: File Storage Providers', params.ContextUser
-        );
-        const providerLoaded = await providerEntity.Load(accountEntity.ProviderID);
-        if (!providerLoaded) {
-            throw new Error(`FileStorageProvider ${accountEntity.ProviderID} not found for account "${accountEntity.Name}"`);
-        }
-
-        return { accountEntity, providerEntity };
+        const sorted = [...activeAccounts].sort((a, b) => a.provider.Priority - b.provider.Priority);
+        return { accountEntity: sorted[0].account, providerEntity: sorted[0].provider };
     }
 
     /**

--- a/packages/Actions/CoreActions/src/custom/utilities/docx-renderer.ts
+++ b/packages/Actions/CoreActions/src/custom/utilities/docx-renderer.ts
@@ -1,6 +1,6 @@
 /**
  * DOCX rendering engine extracted from WordGeneratorAction.
- * Used by both the single-shot Word Generator action and the incremental DocumentBuilderService.
+ * Used by both the single-shot Word Generator action and the incremental ArtifactBuilderService.
  */
 import {
     AlignmentType,

--- a/packages/Actions/CoreActions/src/custom/utilities/pdf-renderer.ts
+++ b/packages/Actions/CoreActions/src/custom/utilities/pdf-renderer.ts
@@ -1,6 +1,6 @@
 /**
  * PDF rendering engine extracted from PDFGeneratorAction.
- * Used by both the single-shot PDF Generator action and the incremental DocumentBuilderService.
+ * Used by both the single-shot PDF Generator action and the incremental ArtifactBuilderService.
  */
 import PDFDocument from "pdfkit";
 import { Parser } from 'htmlparser2';

--- a/packages/GeneratedEntities/src/generated/entity_subclasses.ts
+++ b/packages/GeneratedEntities/src/generated/entity_subclasses.ts
@@ -7,5 +7,7195 @@ export const loadModule = () => {
 }
 
      
-  
  
+/**
+ * zod schema definition for the entity Action Items
+ */
+export const mjCommitteesActionItemSchema = z.object({
+    ID: z.string().describe(`
+        * * Field Name: ID
+        * * Display Name: ID
+        * * SQL Data Type: uniqueidentifier
+        * * Default Value: newsequentialid()`),
+    CommitteeID: z.string().describe(`
+        * * Field Name: CommitteeID
+        * * Display Name: Committee
+        * * SQL Data Type: uniqueidentifier
+        * * Related Entity/Foreign Key: Committees (vwCommittees.ID)`),
+    MeetingID: z.string().nullable().describe(`
+        * * Field Name: MeetingID
+        * * Display Name: Meeting
+        * * SQL Data Type: uniqueidentifier
+        * * Related Entity/Foreign Key: Meetings (vwMeetings.ID)`),
+    AgendaItemID: z.string().nullable().describe(`
+        * * Field Name: AgendaItemID
+        * * Display Name: Agenda Item
+        * * SQL Data Type: uniqueidentifier
+        * * Related Entity/Foreign Key: Agenda Items (vwAgendaItems.ID)`),
+    Title: z.string().describe(`
+        * * Field Name: Title
+        * * Display Name: Title
+        * * SQL Data Type: nvarchar(255)
+        * * Description: Title of the action item`),
+    Description: z.string().nullable().describe(`
+        * * Field Name: Description
+        * * Display Name: Description
+        * * SQL Data Type: nvarchar(MAX)
+        * * Description: Detailed description of what needs to be done`),
+    AssignedToPersonID: z.string().describe(`
+        * * Field Name: AssignedToPersonID
+        * * Display Name: Assigned To
+        * * SQL Data Type: uniqueidentifier
+        * * Related Entity/Foreign Key: People (vwPeople.ID)`),
+    AssignedByPersonID: z.string().nullable().describe(`
+        * * Field Name: AssignedByPersonID
+        * * Display Name: Assigned By
+        * * SQL Data Type: uniqueidentifier
+        * * Related Entity/Foreign Key: People (vwPeople.ID)`),
+    DueDate: z.date().nullable().describe(`
+        * * Field Name: DueDate
+        * * Display Name: Due Date
+        * * SQL Data Type: date
+        * * Description: Due date for completion`),
+    Priority: z.union([z.literal('Critical'), z.literal('High'), z.literal('Low'), z.literal('Medium')]).describe(`
+        * * Field Name: Priority
+        * * Display Name: Priority
+        * * SQL Data Type: nvarchar(20)
+        * * Default Value: Medium
+    * * Value List Type: List
+    * * Possible Values 
+    *   * Critical
+    *   * High
+    *   * Low
+    *   * Medium
+        * * Description: Priority level: Low, Medium, High, Critical`),
+    Status: z.union([z.literal('Blocked'), z.literal('Cancelled'), z.literal('Completed'), z.literal('InProgress'), z.literal('Open')]).describe(`
+        * * Field Name: Status
+        * * Display Name: Status
+        * * SQL Data Type: nvarchar(50)
+        * * Default Value: Open
+    * * Value List Type: List
+    * * Possible Values 
+    *   * Blocked
+    *   * Cancelled
+    *   * Completed
+    *   * InProgress
+    *   * Open
+        * * Description: Current status: Open, InProgress, Blocked, Completed, Cancelled`),
+    CompletedAt: z.date().nullable().describe(`
+        * * Field Name: CompletedAt
+        * * Display Name: Completed At
+        * * SQL Data Type: datetimeoffset
+        * * Description: Timestamp when the action item was completed`),
+    CompletionNotes: z.string().nullable().describe(`
+        * * Field Name: CompletionNotes
+        * * Display Name: Completion Notes
+        * * SQL Data Type: nvarchar(MAX)
+        * * Description: Notes about how the item was completed`),
+    __mj_CreatedAt: z.date().describe(`
+        * * Field Name: __mj_CreatedAt
+        * * Display Name: Created At
+        * * SQL Data Type: datetimeoffset
+        * * Default Value: getutcdate()`),
+    __mj_UpdatedAt: z.date().describe(`
+        * * Field Name: __mj_UpdatedAt
+        * * Display Name: Updated At
+        * * SQL Data Type: datetimeoffset
+        * * Default Value: getutcdate()`),
+    Committee: z.string().describe(`
+        * * Field Name: Committee
+        * * Display Name: Committee
+        * * SQL Data Type: nvarchar(255)`),
+    Meeting: z.string().nullable().describe(`
+        * * Field Name: Meeting
+        * * Display Name: Meeting
+        * * SQL Data Type: nvarchar(255)`),
+    AgendaItem: z.string().nullable().describe(`
+        * * Field Name: AgendaItem
+        * * Display Name: Agenda Item
+        * * SQL Data Type: nvarchar(255)`),
+    AssignedToPerson: z.string().describe(`
+        * * Field Name: AssignedToPerson
+        * * Display Name: Assigned To Person
+        * * SQL Data Type: nvarchar(100)`),
+    AssignedByPerson: z.string().nullable().describe(`
+        * * Field Name: AssignedByPerson
+        * * Display Name: Assigned By Person
+        * * SQL Data Type: nvarchar(100)`),
+});
+
+export type mjCommitteesActionItemEntityType = z.infer<typeof mjCommitteesActionItemSchema>;
+
+/**
+ * zod schema definition for the entity Address Links
+ */
+export const mjBizAppsCommonAddressLinkSchema = z.object({
+    ID: z.string().describe(`
+        * * Field Name: ID
+        * * Display Name: ID
+        * * SQL Data Type: uniqueidentifier
+        * * Default Value: newsequentialid()`),
+    AddressID: z.string().describe(`
+        * * Field Name: AddressID
+        * * Display Name: Address
+        * * SQL Data Type: uniqueidentifier
+        * * Related Entity/Foreign Key: Addresses (vwAddresses.ID)`),
+    EntityID: z.string().describe(`
+        * * Field Name: EntityID
+        * * Display Name: Entity
+        * * SQL Data Type: uniqueidentifier
+        * * Related Entity/Foreign Key: MJ: Entities (vwEntities.ID)`),
+    RecordID: z.string().describe(`
+        * * Field Name: RecordID
+        * * Display Name: Record
+        * * SQL Data Type: nvarchar(700)
+        * * Description: Primary key value(s) of the linked record. NVARCHAR(700) to support concatenated composite keys for entities without single-valued primary keys`),
+    AddressTypeID: z.string().describe(`
+        * * Field Name: AddressTypeID
+        * * Display Name: Address Type
+        * * SQL Data Type: uniqueidentifier
+        * * Related Entity/Foreign Key: Address Types (vwAddressTypes.ID)`),
+    IsPrimary: z.boolean().describe(`
+        * * Field Name: IsPrimary
+        * * Display Name: Primary
+        * * SQL Data Type: bit
+        * * Default Value: 0
+        * * Description: Whether this is the primary address for the linked record. Only one address per entity record should be marked primary`),
+    Rank: z.number().nullable().describe(`
+        * * Field Name: Rank
+        * * Display Name: Rank
+        * * SQL Data Type: int
+        * * Description: Sort order override for this specific link. When NULL, falls back to AddressType.DefaultRank. Lower values appear first`),
+    __mj_CreatedAt: z.date().describe(`
+        * * Field Name: __mj_CreatedAt
+        * * Display Name: Created At
+        * * SQL Data Type: datetimeoffset
+        * * Default Value: getutcdate()`),
+    __mj_UpdatedAt: z.date().describe(`
+        * * Field Name: __mj_UpdatedAt
+        * * Display Name: Updated At
+        * * SQL Data Type: datetimeoffset
+        * * Default Value: getutcdate()`),
+    Address: z.string().describe(`
+        * * Field Name: Address
+        * * Display Name: Address
+        * * SQL Data Type: nvarchar(255)`),
+    Entity: z.string().describe(`
+        * * Field Name: Entity
+        * * Display Name: Entity Name
+        * * SQL Data Type: nvarchar(255)`),
+    AddressType: z.string().describe(`
+        * * Field Name: AddressType
+        * * Display Name: Address Type Name
+        * * SQL Data Type: nvarchar(100)`),
+});
+
+export type mjBizAppsCommonAddressLinkEntityType = z.infer<typeof mjBizAppsCommonAddressLinkSchema>;
+
+/**
+ * zod schema definition for the entity Address Types
+ */
+export const mjBizAppsCommonAddressTypeSchema = z.object({
+    ID: z.string().describe(`
+        * * Field Name: ID
+        * * Display Name: ID
+        * * SQL Data Type: uniqueidentifier
+        * * Default Value: newsequentialid()`),
+    Name: z.string().describe(`
+        * * Field Name: Name
+        * * Display Name: Name
+        * * SQL Data Type: nvarchar(100)
+        * * Description: Display name for the address type`),
+    Description: z.string().nullable().describe(`
+        * * Field Name: Description
+        * * Display Name: Description
+        * * SQL Data Type: nvarchar(MAX)
+        * * Description: Detailed description of this address type`),
+    DefaultRank: z.number().describe(`
+        * * Field Name: DefaultRank
+        * * Display Name: Default Rank
+        * * SQL Data Type: int
+        * * Default Value: 100
+        * * Description: Default sort order for this address type in dropdown lists. Lower values appear first. Can be overridden per-record via AddressLink.Rank`),
+    __mj_CreatedAt: z.date().describe(`
+        * * Field Name: __mj_CreatedAt
+        * * Display Name: Created At
+        * * SQL Data Type: datetimeoffset
+        * * Default Value: getutcdate()`),
+    __mj_UpdatedAt: z.date().describe(`
+        * * Field Name: __mj_UpdatedAt
+        * * Display Name: Updated At
+        * * SQL Data Type: datetimeoffset
+        * * Default Value: getutcdate()`),
+});
+
+export type mjBizAppsCommonAddressTypeEntityType = z.infer<typeof mjBizAppsCommonAddressTypeSchema>;
+
+/**
+ * zod schema definition for the entity Addresses
+ */
+export const mjBizAppsCommonAddressSchema = z.object({
+    ID: z.string().describe(`
+        * * Field Name: ID
+        * * Display Name: ID
+        * * SQL Data Type: uniqueidentifier
+        * * Default Value: newsequentialid()`),
+    Line1: z.string().describe(`
+        * * Field Name: Line1
+        * * Display Name: Address Line 1
+        * * SQL Data Type: nvarchar(255)
+        * * Description: Street address line 1`),
+    Line2: z.string().nullable().describe(`
+        * * Field Name: Line2
+        * * Display Name: Address Line 2
+        * * SQL Data Type: nvarchar(255)
+        * * Description: Street address line 2 (suite, apt, etc.)`),
+    Line3: z.string().nullable().describe(`
+        * * Field Name: Line3
+        * * Display Name: Address Line 3
+        * * SQL Data Type: nvarchar(255)
+        * * Description: Street address line 3 (additional detail)`),
+    City: z.string().describe(`
+        * * Field Name: City
+        * * Display Name: City
+        * * SQL Data Type: nvarchar(100)
+        * * Description: City or locality name`),
+    StateProvince: z.string().nullable().describe(`
+        * * Field Name: StateProvince
+        * * Display Name: State / Province
+        * * SQL Data Type: nvarchar(100)
+        * * Description: State, province, or region`),
+    PostalCode: z.string().nullable().describe(`
+        * * Field Name: PostalCode
+        * * Display Name: Postal Code
+        * * SQL Data Type: nvarchar(20)
+        * * Description: Postal or ZIP code`),
+    Country: z.string().describe(`
+        * * Field Name: Country
+        * * Display Name: Country
+        * * SQL Data Type: nvarchar(100)
+        * * Default Value: US
+        * * Description: Country code or name, defaults to US`),
+    Latitude: z.number().nullable().describe(`
+        * * Field Name: Latitude
+        * * Display Name: Latitude
+        * * SQL Data Type: decimal(9, 6)
+        * * Description: Geographic latitude for mapping`),
+    Longitude: z.number().nullable().describe(`
+        * * Field Name: Longitude
+        * * Display Name: Longitude
+        * * SQL Data Type: decimal(9, 6)
+        * * Description: Geographic longitude for mapping`),
+    __mj_CreatedAt: z.date().describe(`
+        * * Field Name: __mj_CreatedAt
+        * * Display Name: Created At
+        * * SQL Data Type: datetimeoffset
+        * * Default Value: getutcdate()`),
+    __mj_UpdatedAt: z.date().describe(`
+        * * Field Name: __mj_UpdatedAt
+        * * Display Name: Updated At
+        * * SQL Data Type: datetimeoffset
+        * * Default Value: getutcdate()`),
+});
+
+export type mjBizAppsCommonAddressEntityType = z.infer<typeof mjBizAppsCommonAddressSchema>;
+
+/**
+ * zod schema definition for the entity Agenda Items
+ */
+export const mjCommitteesAgendaItemSchema = z.object({
+    ID: z.string().describe(`
+        * * Field Name: ID
+        * * Display Name: ID
+        * * SQL Data Type: uniqueidentifier
+        * * Default Value: newsequentialid()`),
+    MeetingID: z.string().describe(`
+        * * Field Name: MeetingID
+        * * Display Name: Meeting
+        * * SQL Data Type: uniqueidentifier
+        * * Related Entity/Foreign Key: Meetings (vwMeetings.ID)`),
+    ParentAgendaItemID: z.string().nullable().describe(`
+        * * Field Name: ParentAgendaItemID
+        * * Display Name: Parent Agenda Item
+        * * SQL Data Type: uniqueidentifier
+        * * Related Entity/Foreign Key: Agenda Items (vwAgendaItems.ID)`),
+    Sequence: z.number().describe(`
+        * * Field Name: Sequence
+        * * Display Name: Sequence
+        * * SQL Data Type: int
+        * * Description: Display order within the meeting agenda`),
+    Title: z.string().describe(`
+        * * Field Name: Title
+        * * Display Name: Title
+        * * SQL Data Type: nvarchar(255)
+        * * Description: Title of the agenda item`),
+    Description: z.string().nullable().describe(`
+        * * Field Name: Description
+        * * Display Name: Description
+        * * SQL Data Type: nvarchar(MAX)
+        * * Description: Detailed description of the agenda item`),
+    PresenterPersonID: z.string().nullable().describe(`
+        * * Field Name: PresenterPersonID
+        * * Display Name: Presenter Person
+        * * SQL Data Type: uniqueidentifier
+        * * Related Entity/Foreign Key: People (vwPeople.ID)`),
+    DurationMinutes: z.number().nullable().describe(`
+        * * Field Name: DurationMinutes
+        * * Display Name: Duration Minutes
+        * * SQL Data Type: int
+        * * Description: Estimated duration in minutes`),
+    ItemType: z.union([z.literal('Action'), z.literal('Discussion'), z.literal('Information'), z.literal('Other'), z.literal('Report'), z.literal('Vote')]).describe(`
+        * * Field Name: ItemType
+        * * Display Name: Item Type
+        * * SQL Data Type: nvarchar(50)
+        * * Default Value: Discussion
+    * * Value List Type: List
+    * * Possible Values 
+    *   * Action
+    *   * Discussion
+    *   * Information
+    *   * Other
+    *   * Report
+    *   * Vote
+        * * Description: Type of item: Information, Discussion, Action, Vote, Report, Other`),
+    RelatedDocumentURL: z.string().nullable().describe(`
+        * * Field Name: RelatedDocumentURL
+        * * Display Name: Related Document URL
+        * * SQL Data Type: nvarchar(1000)
+        * * Description: URL to related document for this item`),
+    Status: z.union([z.literal('Completed'), z.literal('Discussed'), z.literal('Pending'), z.literal('Skipped'), z.literal('Tabled')]).describe(`
+        * * Field Name: Status
+        * * Display Name: Status
+        * * SQL Data Type: nvarchar(50)
+        * * Default Value: Pending
+    * * Value List Type: List
+    * * Possible Values 
+    *   * Completed
+    *   * Discussed
+    *   * Pending
+    *   * Skipped
+    *   * Tabled
+        * * Description: Current status: Pending, Discussed, Tabled, Completed, Skipped`),
+    Notes: z.string().nullable().describe(`
+        * * Field Name: Notes
+        * * Display Name: Notes
+        * * SQL Data Type: nvarchar(MAX)
+        * * Description: Discussion notes and outcomes captured during the meeting`),
+    __mj_CreatedAt: z.date().describe(`
+        * * Field Name: __mj_CreatedAt
+        * * Display Name: Created At
+        * * SQL Data Type: datetimeoffset
+        * * Default Value: getutcdate()`),
+    __mj_UpdatedAt: z.date().describe(`
+        * * Field Name: __mj_UpdatedAt
+        * * Display Name: Updated At
+        * * SQL Data Type: datetimeoffset
+        * * Default Value: getutcdate()`),
+    Meeting: z.string().describe(`
+        * * Field Name: Meeting
+        * * Display Name: Meeting
+        * * SQL Data Type: nvarchar(255)`),
+    ParentAgendaItem: z.string().nullable().describe(`
+        * * Field Name: ParentAgendaItem
+        * * Display Name: Parent Agenda Item
+        * * SQL Data Type: nvarchar(255)`),
+    PresenterPerson: z.string().nullable().describe(`
+        * * Field Name: PresenterPerson
+        * * Display Name: Presenter Person
+        * * SQL Data Type: nvarchar(100)`),
+    RootParentAgendaItemID: z.string().nullable().describe(`
+        * * Field Name: RootParentAgendaItemID
+        * * Display Name: Root Parent Agenda Item
+        * * SQL Data Type: uniqueidentifier`),
+});
+
+export type mjCommitteesAgendaItemEntityType = z.infer<typeof mjCommitteesAgendaItemSchema>;
+
+/**
+ * zod schema definition for the entity Artifact Types
+ */
+export const mjCommitteesArtifactTypeSchema = z.object({
+    ID: z.string().describe(`
+        * * Field Name: ID
+        * * Display Name: ID
+        * * SQL Data Type: uniqueidentifier
+        * * Default Value: newsequentialid()`),
+    Name: z.string().describe(`
+        * * Field Name: Name
+        * * Display Name: Name
+        * * SQL Data Type: nvarchar(100)
+        * * Description: Display name for the artifact type`),
+    Description: z.string().nullable().describe(`
+        * * Field Name: Description
+        * * Display Name: Description
+        * * SQL Data Type: nvarchar(MAX)
+        * * Description: Detailed description of this artifact type`),
+    ExtendedEntityID: z.string().nullable().describe(`
+        * * Field Name: ExtendedEntityID
+        * * Display Name: Extended Entity
+        * * SQL Data Type: uniqueidentifier
+        * * Related Entity/Foreign Key: MJ: Entities (vwEntities.ID)
+        * * Description: Optional reference to an MJ Entity that provides additional fields for this artifact type via a 1:1 extension table`),
+    IconClass: z.string().nullable().describe(`
+        * * Field Name: IconClass
+        * * Display Name: Icon Class
+        * * SQL Data Type: nvarchar(100)
+        * * Description: Font Awesome icon class for UI display`),
+    __mj_CreatedAt: z.date().describe(`
+        * * Field Name: __mj_CreatedAt
+        * * Display Name: Created At
+        * * SQL Data Type: datetimeoffset
+        * * Default Value: getutcdate()`),
+    __mj_UpdatedAt: z.date().describe(`
+        * * Field Name: __mj_UpdatedAt
+        * * Display Name: Updated At
+        * * SQL Data Type: datetimeoffset
+        * * Default Value: getutcdate()`),
+    ExtendedEntity: z.string().nullable().describe(`
+        * * Field Name: ExtendedEntity
+        * * Display Name: Extension Entity
+        * * SQL Data Type: nvarchar(255)`),
+});
+
+export type mjCommitteesArtifactTypeEntityType = z.infer<typeof mjCommitteesArtifactTypeSchema>;
+
+/**
+ * zod schema definition for the entity Artifacts
+ */
+export const mjCommitteesArtifactSchema = z.object({
+    ID: z.string().describe(`
+        * * Field Name: ID
+        * * Display Name: ID
+        * * SQL Data Type: uniqueidentifier
+        * * Default Value: newsequentialid()`),
+    CommitteeID: z.string().nullable().describe(`
+        * * Field Name: CommitteeID
+        * * Display Name: Committee
+        * * SQL Data Type: uniqueidentifier
+        * * Related Entity/Foreign Key: Committees (vwCommittees.ID)`),
+    MeetingID: z.string().nullable().describe(`
+        * * Field Name: MeetingID
+        * * Display Name: Meeting
+        * * SQL Data Type: uniqueidentifier
+        * * Related Entity/Foreign Key: Meetings (vwMeetings.ID)`),
+    AgendaItemID: z.string().nullable().describe(`
+        * * Field Name: AgendaItemID
+        * * Display Name: Agenda Item
+        * * SQL Data Type: uniqueidentifier
+        * * Related Entity/Foreign Key: Agenda Items (vwAgendaItems.ID)`),
+    ActionItemID: z.string().nullable().describe(`
+        * * Field Name: ActionItemID
+        * * Display Name: Action Item
+        * * SQL Data Type: uniqueidentifier
+        * * Related Entity/Foreign Key: Action Items (vwActionItems.ID)`),
+    Title: z.string().describe(`
+        * * Field Name: Title
+        * * Display Name: Title
+        * * SQL Data Type: nvarchar(255)
+        * * Description: Display title for the artifact`),
+    Description: z.string().nullable().describe(`
+        * * Field Name: Description
+        * * Display Name: Description
+        * * SQL Data Type: nvarchar(MAX)
+        * * Description: Description of the artifact contents`),
+    ArtifactTypeID: z.string().describe(`
+        * * Field Name: ArtifactTypeID
+        * * Display Name: Artifact Type
+        * * SQL Data Type: uniqueidentifier
+        * * Related Entity/Foreign Key: Artifact Types (vwArtifactTypes.ID)`),
+    Provider: z.union([z.literal('Box'), z.literal('Dropbox'), z.literal('GoogleDrive'), z.literal('OneDrive'), z.literal('SharePoint'), z.literal('URL')]).describe(`
+        * * Field Name: Provider
+        * * Display Name: Provider
+        * * SQL Data Type: nvarchar(50)
+    * * Value List Type: List
+    * * Possible Values 
+    *   * Box
+    *   * Dropbox
+    *   * GoogleDrive
+    *   * OneDrive
+    *   * SharePoint
+    *   * URL
+        * * Description: Storage provider: GoogleDrive, SharePoint, Box, OneDrive, Dropbox, URL`),
+    ExternalID: z.string().nullable().describe(`
+        * * Field Name: ExternalID
+        * * Display Name: External ID
+        * * SQL Data Type: nvarchar(500)
+        * * Description: Provider-specific document or file ID`),
+    URL: z.string().describe(`
+        * * Field Name: URL
+        * * Display Name: URL
+        * * SQL Data Type: nvarchar(2000)
+        * * Description: Direct URL to access the artifact`),
+    MimeType: z.string().nullable().describe(`
+        * * Field Name: MimeType
+        * * Display Name: MIME Type
+        * * SQL Data Type: nvarchar(100)
+        * * Description: MIME type of the file`),
+    FileSize: z.number().nullable().describe(`
+        * * Field Name: FileSize
+        * * Display Name: File Size
+        * * SQL Data Type: bigint
+        * * Description: File size in bytes`),
+    UploadedByPersonID: z.string().nullable().describe(`
+        * * Field Name: UploadedByPersonID
+        * * Display Name: Uploaded By Person
+        * * SQL Data Type: uniqueidentifier
+        * * Related Entity/Foreign Key: People (vwPeople.ID)`),
+    __mj_CreatedAt: z.date().describe(`
+        * * Field Name: __mj_CreatedAt
+        * * Display Name: Created At
+        * * SQL Data Type: datetimeoffset
+        * * Default Value: getutcdate()`),
+    __mj_UpdatedAt: z.date().describe(`
+        * * Field Name: __mj_UpdatedAt
+        * * Display Name: Updated At
+        * * SQL Data Type: datetimeoffset
+        * * Default Value: getutcdate()`),
+    Committee: z.string().nullable().describe(`
+        * * Field Name: Committee
+        * * Display Name: Committee
+        * * SQL Data Type: nvarchar(255)`),
+    Meeting: z.string().nullable().describe(`
+        * * Field Name: Meeting
+        * * Display Name: Meeting
+        * * SQL Data Type: nvarchar(255)`),
+    AgendaItem: z.string().nullable().describe(`
+        * * Field Name: AgendaItem
+        * * Display Name: Agenda Item
+        * * SQL Data Type: nvarchar(255)`),
+    ActionItem: z.string().nullable().describe(`
+        * * Field Name: ActionItem
+        * * Display Name: Action Item
+        * * SQL Data Type: nvarchar(255)`),
+    ArtifactType: z.string().describe(`
+        * * Field Name: ArtifactType
+        * * Display Name: Artifact Type
+        * * SQL Data Type: nvarchar(100)`),
+    UploadedByPerson: z.string().nullable().describe(`
+        * * Field Name: UploadedByPerson
+        * * Display Name: Uploaded By Person
+        * * SQL Data Type: nvarchar(100)`),
+});
+
+export type mjCommitteesArtifactEntityType = z.infer<typeof mjCommitteesArtifactSchema>;
+
+/**
+ * zod schema definition for the entity Attendances
+ */
+export const mjCommitteesAttendanceSchema = z.object({
+    ID: z.string().describe(`
+        * * Field Name: ID
+        * * Display Name: ID
+        * * SQL Data Type: uniqueidentifier
+        * * Default Value: newsequentialid()`),
+    MeetingID: z.string().describe(`
+        * * Field Name: MeetingID
+        * * Display Name: Meeting
+        * * SQL Data Type: uniqueidentifier
+        * * Related Entity/Foreign Key: Meetings (vwMeetings.ID)`),
+    PersonID: z.string().describe(`
+        * * Field Name: PersonID
+        * * Display Name: Person
+        * * SQL Data Type: uniqueidentifier
+        * * Related Entity/Foreign Key: People (vwPeople.ID)`),
+    AttendanceStatus: z.union([z.literal('Absent'), z.literal('Excused'), z.literal('Expected'), z.literal('Partial'), z.literal('Present')]).describe(`
+        * * Field Name: AttendanceStatus
+        * * Display Name: Attendance Status
+        * * SQL Data Type: nvarchar(50)
+        * * Default Value: Expected
+    * * Value List Type: List
+    * * Possible Values 
+    *   * Absent
+    *   * Excused
+    *   * Expected
+    *   * Partial
+    *   * Present
+        * * Description: Attendance status: Expected, Present, Absent, Excused, Partial`),
+    JoinedAt: z.date().nullable().describe(`
+        * * Field Name: JoinedAt
+        * * Display Name: Joined At
+        * * SQL Data Type: datetimeoffset
+        * * Description: Timestamp when the attendee joined the meeting`),
+    LeftAt: z.date().nullable().describe(`
+        * * Field Name: LeftAt
+        * * Display Name: Left At
+        * * SQL Data Type: datetimeoffset
+        * * Description: Timestamp when the attendee left the meeting`),
+    Notes: z.string().nullable().describe(`
+        * * Field Name: Notes
+        * * Display Name: Notes
+        * * SQL Data Type: nvarchar(500)
+        * * Description: Additional notes about attendance`),
+    __mj_CreatedAt: z.date().describe(`
+        * * Field Name: __mj_CreatedAt
+        * * Display Name: Created At
+        * * SQL Data Type: datetimeoffset
+        * * Default Value: getutcdate()`),
+    __mj_UpdatedAt: z.date().describe(`
+        * * Field Name: __mj_UpdatedAt
+        * * Display Name: Updated At
+        * * SQL Data Type: datetimeoffset
+        * * Default Value: getutcdate()`),
+    Meeting: z.string().describe(`
+        * * Field Name: Meeting
+        * * Display Name: Meeting
+        * * SQL Data Type: nvarchar(255)`),
+    Person: z.string().describe(`
+        * * Field Name: Person
+        * * Display Name: Person
+        * * SQL Data Type: nvarchar(100)`),
+});
+
+export type mjCommitteesAttendanceEntityType = z.infer<typeof mjCommitteesAttendanceSchema>;
+
+/**
+ * zod schema definition for the entity Comments
+ */
+export const mjCommitteesCommentSchema = z.object({
+    ID: z.string().describe(`
+        * * Field Name: ID
+        * * Display Name: ID
+        * * SQL Data Type: uniqueidentifier
+        * * Default Value: newsequentialid()`),
+    CommitteeID: z.string().describe(`
+        * * Field Name: CommitteeID
+        * * Display Name: Committee
+        * * SQL Data Type: uniqueidentifier
+        * * Related Entity/Foreign Key: Committees (vwCommittees.ID)`),
+    MeetingID: z.string().nullable().describe(`
+        * * Field Name: MeetingID
+        * * Display Name: Meeting
+        * * SQL Data Type: uniqueidentifier
+        * * Related Entity/Foreign Key: Meetings (vwMeetings.ID)`),
+    AgendaItemID: z.string().nullable().describe(`
+        * * Field Name: AgendaItemID
+        * * Display Name: Agenda Item
+        * * SQL Data Type: uniqueidentifier
+        * * Related Entity/Foreign Key: Agenda Items (vwAgendaItems.ID)`),
+    ActionItemID: z.string().nullable().describe(`
+        * * Field Name: ActionItemID
+        * * Display Name: Action Item
+        * * SQL Data Type: uniqueidentifier
+        * * Related Entity/Foreign Key: Action Items (vwActionItems.ID)`),
+    ArtifactID: z.string().nullable().describe(`
+        * * Field Name: ArtifactID
+        * * Display Name: Artifact
+        * * SQL Data Type: uniqueidentifier
+        * * Related Entity/Foreign Key: Artifacts (vwArtifacts.ID)`),
+    ParentCommentID: z.string().nullable().describe(`
+        * * Field Name: ParentCommentID
+        * * Display Name: Parent Comment
+        * * SQL Data Type: uniqueidentifier
+        * * Related Entity/Foreign Key: Comments (vwComments.ID)`),
+    PersonID: z.string().describe(`
+        * * Field Name: PersonID
+        * * Display Name: Person
+        * * SQL Data Type: uniqueidentifier
+        * * Related Entity/Foreign Key: People (vwPeople.ID)`),
+    CommentText: z.string().describe(`
+        * * Field Name: CommentText
+        * * Display Name: Comment Text
+        * * SQL Data Type: nvarchar(MAX)`),
+    MentionedPersonIDs: z.string().nullable().describe(`
+        * * Field Name: MentionedPersonIDs
+        * * Display Name: Mentioned Person IDs
+        * * SQL Data Type: nvarchar(MAX)`),
+    IsResolved: z.boolean().describe(`
+        * * Field Name: IsResolved
+        * * Display Name: Is Resolved
+        * * SQL Data Type: bit
+        * * Default Value: 0`),
+    __mj_CreatedAt: z.date().describe(`
+        * * Field Name: __mj_CreatedAt
+        * * Display Name: Created At
+        * * SQL Data Type: datetimeoffset
+        * * Default Value: getutcdate()`),
+    __mj_UpdatedAt: z.date().describe(`
+        * * Field Name: __mj_UpdatedAt
+        * * Display Name: Updated At
+        * * SQL Data Type: datetimeoffset
+        * * Default Value: getutcdate()`),
+    Committee: z.string().describe(`
+        * * Field Name: Committee
+        * * Display Name: Committee
+        * * SQL Data Type: nvarchar(255)`),
+    Meeting: z.string().nullable().describe(`
+        * * Field Name: Meeting
+        * * Display Name: Meeting
+        * * SQL Data Type: nvarchar(255)`),
+    AgendaItem: z.string().nullable().describe(`
+        * * Field Name: AgendaItem
+        * * Display Name: Agenda Item
+        * * SQL Data Type: nvarchar(255)`),
+    ActionItem: z.string().nullable().describe(`
+        * * Field Name: ActionItem
+        * * Display Name: Action Item
+        * * SQL Data Type: nvarchar(255)`),
+    Artifact: z.string().nullable().describe(`
+        * * Field Name: Artifact
+        * * Display Name: Artifact
+        * * SQL Data Type: nvarchar(255)`),
+    ParentComment: z.string().nullable().describe(`
+        * * Field Name: ParentComment
+        * * Display Name: Parent Comment
+        * * SQL Data Type: nvarchar(MAX)`),
+    Person: z.string().describe(`
+        * * Field Name: Person
+        * * Display Name: Person
+        * * SQL Data Type: nvarchar(100)`),
+    RootParentCommentID: z.string().nullable().describe(`
+        * * Field Name: RootParentCommentID
+        * * Display Name: Root Parent Comment
+        * * SQL Data Type: uniqueidentifier`),
+});
+
+export type mjCommitteesCommentEntityType = z.infer<typeof mjCommitteesCommentSchema>;
+
+/**
+ * zod schema definition for the entity Committees
+ */
+export const mjCommitteesCommitteeSchema = z.object({
+    ID: z.string().describe(`
+        * * Field Name: ID
+        * * Display Name: ID
+        * * SQL Data Type: uniqueidentifier
+        * * Default Value: newsequentialid()`),
+    Name: z.string().describe(`
+        * * Field Name: Name
+        * * Display Name: Committee Name
+        * * SQL Data Type: nvarchar(255)
+        * * Description: Official name of the committee`),
+    Description: z.string().nullable().describe(`
+        * * Field Name: Description
+        * * Display Name: Description
+        * * SQL Data Type: nvarchar(MAX)
+        * * Description: Detailed description of the committee purpose and scope`),
+    TypeID: z.string().describe(`
+        * * Field Name: TypeID
+        * * Display Name: Committee Type ID
+        * * SQL Data Type: uniqueidentifier
+        * * Related Entity/Foreign Key: Types (vwTypes.ID)`),
+    ParentCommitteeID: z.string().nullable().describe(`
+        * * Field Name: ParentCommitteeID
+        * * Display Name: Parent Committee ID
+        * * SQL Data Type: uniqueidentifier
+        * * Related Entity/Foreign Key: Committees (vwCommittees.ID)`),
+    OrganizationID: z.string().nullable().describe(`
+        * * Field Name: OrganizationID
+        * * Display Name: Organization ID
+        * * SQL Data Type: uniqueidentifier
+        * * Related Entity/Foreign Key: Organizations (vwOrganizations.ID)`),
+    CharterDocumentURL: z.string().nullable().describe(`
+        * * Field Name: CharterDocumentURL
+        * * Display Name: Charter Document URL
+        * * SQL Data Type: nvarchar(1000)
+        * * Description: URL to the committee charter document`),
+    MissionStatement: z.string().nullable().describe(`
+        * * Field Name: MissionStatement
+        * * Display Name: Mission Statement
+        * * SQL Data Type: nvarchar(MAX)
+        * * Description: Brief statement of the committee mission`),
+    Status: z.union([z.literal('Active'), z.literal('Dissolved'), z.literal('Inactive'), z.literal('Pending')]).describe(`
+        * * Field Name: Status
+        * * Display Name: Status
+        * * SQL Data Type: nvarchar(50)
+        * * Default Value: Active
+    * * Value List Type: List
+    * * Possible Values 
+    *   * Active
+    *   * Dissolved
+    *   * Inactive
+    *   * Pending
+        * * Description: Current status: Active, Inactive, Pending, or Dissolved`),
+    IsPublic: z.boolean().describe(`
+        * * Field Name: IsPublic
+        * * Display Name: Is Public
+        * * SQL Data Type: bit
+        * * Default Value: 1
+        * * Description: Whether the committee is visible to all users`),
+    FormationDate: z.date().nullable().describe(`
+        * * Field Name: FormationDate
+        * * Display Name: Formation Date
+        * * SQL Data Type: date
+        * * Description: Date the committee was formed`),
+    DissolutionDate: z.date().nullable().describe(`
+        * * Field Name: DissolutionDate
+        * * Display Name: Dissolution Date
+        * * SQL Data Type: date
+        * * Description: Date the committee was dissolved, if applicable`),
+    __mj_CreatedAt: z.date().describe(`
+        * * Field Name: __mj_CreatedAt
+        * * Display Name: Created At
+        * * SQL Data Type: datetimeoffset
+        * * Default Value: getutcdate()`),
+    __mj_UpdatedAt: z.date().describe(`
+        * * Field Name: __mj_UpdatedAt
+        * * Display Name: Updated At
+        * * SQL Data Type: datetimeoffset
+        * * Default Value: getutcdate()`),
+    Type: z.string().describe(`
+        * * Field Name: Type
+        * * Display Name: Type
+        * * SQL Data Type: nvarchar(100)`),
+    ParentCommittee: z.string().nullable().describe(`
+        * * Field Name: ParentCommittee
+        * * Display Name: Parent Committee
+        * * SQL Data Type: nvarchar(255)`),
+    Organization: z.string().nullable().describe(`
+        * * Field Name: Organization
+        * * Display Name: Organization
+        * * SQL Data Type: nvarchar(255)`),
+    RootParentCommitteeID: z.string().nullable().describe(`
+        * * Field Name: RootParentCommitteeID
+        * * Display Name: Root Parent Committee ID
+        * * SQL Data Type: uniqueidentifier`),
+});
+
+export type mjCommitteesCommitteeEntityType = z.infer<typeof mjCommitteesCommitteeSchema>;
+
+/**
+ * zod schema definition for the entity Contact Methods
+ */
+export const mjBizAppsCommonContactMethodSchema = z.object({
+    ID: z.string().describe(`
+        * * Field Name: ID
+        * * Display Name: ID
+        * * SQL Data Type: uniqueidentifier
+        * * Default Value: newsequentialid()`),
+    PersonID: z.string().nullable().describe(`
+        * * Field Name: PersonID
+        * * Display Name: Person
+        * * SQL Data Type: uniqueidentifier
+        * * Related Entity/Foreign Key: People (vwPeople.ID)`),
+    OrganizationID: z.string().nullable().describe(`
+        * * Field Name: OrganizationID
+        * * Display Name: Organization
+        * * SQL Data Type: uniqueidentifier
+        * * Related Entity/Foreign Key: Organizations (vwOrganizations.ID)`),
+    ContactTypeID: z.string().describe(`
+        * * Field Name: ContactTypeID
+        * * Display Name: Contact Type
+        * * SQL Data Type: uniqueidentifier
+        * * Related Entity/Foreign Key: Contact Types (vwContactTypes.ID)`),
+    Value: z.string().describe(`
+        * * Field Name: Value
+        * * Display Name: Value
+        * * SQL Data Type: nvarchar(500)
+        * * Description: The contact value: phone number, email address, URL, social media handle, etc.`),
+    Label: z.string().nullable().describe(`
+        * * Field Name: Label
+        * * Display Name: Label
+        * * SQL Data Type: nvarchar(100)
+        * * Description: Descriptive label such as Work cell, Personal Gmail, Corporate LinkedIn`),
+    IsPrimary: z.boolean().describe(`
+        * * Field Name: IsPrimary
+        * * Display Name: Is Primary
+        * * SQL Data Type: bit
+        * * Default Value: 0
+        * * Description: Whether this is the primary contact method of its type for the linked person or organization`),
+    __mj_CreatedAt: z.date().describe(`
+        * * Field Name: __mj_CreatedAt
+        * * Display Name: Created At
+        * * SQL Data Type: datetimeoffset
+        * * Default Value: getutcdate()`),
+    __mj_UpdatedAt: z.date().describe(`
+        * * Field Name: __mj_UpdatedAt
+        * * Display Name: Updated At
+        * * SQL Data Type: datetimeoffset
+        * * Default Value: getutcdate()`),
+    Person: z.string().nullable().describe(`
+        * * Field Name: Person
+        * * Display Name: Person
+        * * SQL Data Type: nvarchar(100)`),
+    Organization: z.string().nullable().describe(`
+        * * Field Name: Organization
+        * * Display Name: Organization
+        * * SQL Data Type: nvarchar(255)`),
+    ContactType: z.string().describe(`
+        * * Field Name: ContactType
+        * * Display Name: Contact Type
+        * * SQL Data Type: nvarchar(100)`),
+});
+
+export type mjBizAppsCommonContactMethodEntityType = z.infer<typeof mjBizAppsCommonContactMethodSchema>;
+
+/**
+ * zod schema definition for the entity Contact Types
+ */
+export const mjBizAppsCommonContactTypeSchema = z.object({
+    ID: z.string().describe(`
+        * * Field Name: ID
+        * * Display Name: ID
+        * * SQL Data Type: uniqueidentifier
+        * * Default Value: newsequentialid()`),
+    Name: z.string().describe(`
+        * * Field Name: Name
+        * * Display Name: Name
+        * * SQL Data Type: nvarchar(100)
+        * * Description: Display name for the contact type`),
+    Description: z.string().nullable().describe(`
+        * * Field Name: Description
+        * * Display Name: Description
+        * * SQL Data Type: nvarchar(MAX)
+        * * Description: Detailed description of this contact type`),
+    IconClass: z.string().nullable().describe(`
+        * * Field Name: IconClass
+        * * Display Name: Icon Class
+        * * SQL Data Type: nvarchar(100)
+        * * Description: Font Awesome icon class for UI display`),
+    __mj_CreatedAt: z.date().describe(`
+        * * Field Name: __mj_CreatedAt
+        * * Display Name: Created At
+        * * SQL Data Type: datetimeoffset
+        * * Default Value: getutcdate()`),
+    __mj_UpdatedAt: z.date().describe(`
+        * * Field Name: __mj_UpdatedAt
+        * * Display Name: Updated At
+        * * SQL Data Type: datetimeoffset
+        * * Default Value: getutcdate()`),
+});
+
+export type mjBizAppsCommonContactTypeEntityType = z.infer<typeof mjBizAppsCommonContactTypeSchema>;
+
+/**
+ * zod schema definition for the entity Meetings
+ */
+export const mjCommitteesMeetingSchema = z.object({
+    ID: z.string().describe(`
+        * * Field Name: ID
+        * * Display Name: ID
+        * * SQL Data Type: uniqueidentifier
+        * * Default Value: newsequentialid()`),
+    CommitteeID: z.string().describe(`
+        * * Field Name: CommitteeID
+        * * Display Name: Committee
+        * * SQL Data Type: uniqueidentifier
+        * * Related Entity/Foreign Key: Committees (vwCommittees.ID)`),
+    Title: z.string().describe(`
+        * * Field Name: Title
+        * * Display Name: Title
+        * * SQL Data Type: nvarchar(255)
+        * * Description: Title of the meeting`),
+    Description: z.string().nullable().describe(`
+        * * Field Name: Description
+        * * Display Name: Description
+        * * SQL Data Type: nvarchar(MAX)
+        * * Description: Detailed description or purpose of the meeting`),
+    StartDateTime: z.date().describe(`
+        * * Field Name: StartDateTime
+        * * Display Name: Start Date & Time
+        * * SQL Data Type: datetimeoffset
+        * * Description: Scheduled start date and time with timezone offset`),
+    EndDateTime: z.date().nullable().describe(`
+        * * Field Name: EndDateTime
+        * * Display Name: End Date & Time
+        * * SQL Data Type: datetimeoffset
+        * * Description: Scheduled end date and time with timezone offset`),
+    TimeZone: z.string().describe(`
+        * * Field Name: TimeZone
+        * * Display Name: Time Zone
+        * * SQL Data Type: nvarchar(50)
+        * * Default Value: America/New_York
+        * * Description: IANA timezone identifier for the meeting`),
+    LocationType: z.union([z.literal('Hybrid'), z.literal('InPerson'), z.literal('Virtual')]).describe(`
+        * * Field Name: LocationType
+        * * Display Name: Location Type
+        * * SQL Data Type: nvarchar(50)
+        * * Default Value: Virtual
+    * * Value List Type: List
+    * * Possible Values 
+    *   * Hybrid
+    *   * InPerson
+    *   * Virtual
+        * * Description: Meeting format: Virtual, InPerson, or Hybrid`),
+    LocationText: z.string().nullable().describe(`
+        * * Field Name: LocationText
+        * * Display Name: Location
+        * * SQL Data Type: nvarchar(500)
+        * * Description: Physical address or room name for in-person meetings`),
+    VideoProvider: z.string().nullable().describe(`
+        * * Field Name: VideoProvider
+        * * Display Name: Video Provider
+        * * SQL Data Type: nvarchar(50)
+        * * Description: Video conferencing provider: Zoom, Teams, Meet, etc.`),
+    VideoMeetingID: z.string().nullable().describe(`
+        * * Field Name: VideoMeetingID
+        * * Display Name: Video Meeting ID
+        * * SQL Data Type: nvarchar(255)
+        * * Description: External meeting ID from the video provider`),
+    VideoJoinURL: z.string().nullable().describe(`
+        * * Field Name: VideoJoinURL
+        * * Display Name: Join URL
+        * * SQL Data Type: nvarchar(1000)
+        * * Description: URL to join the video meeting`),
+    VideoRecordingURL: z.string().nullable().describe(`
+        * * Field Name: VideoRecordingURL
+        * * Display Name: Recording URL
+        * * SQL Data Type: nvarchar(1000)
+        * * Description: URL to the meeting recording after completion`),
+    TranscriptURL: z.string().nullable().describe(`
+        * * Field Name: TranscriptURL
+        * * Display Name: Transcript URL
+        * * SQL Data Type: nvarchar(1000)
+        * * Description: URL to the meeting transcript`),
+    Status: z.union([z.literal('Cancelled'), z.literal('Completed'), z.literal('Draft'), z.literal('InProgress'), z.literal('Postponed'), z.literal('Scheduled')]).describe(`
+        * * Field Name: Status
+        * * Display Name: Status
+        * * SQL Data Type: nvarchar(50)
+        * * Default Value: Scheduled
+    * * Value List Type: List
+    * * Possible Values 
+    *   * Cancelled
+    *   * Completed
+    *   * Draft
+    *   * InProgress
+    *   * Postponed
+    *   * Scheduled
+        * * Description: Current status: Draft, Scheduled, InProgress, Completed, Cancelled, Postponed`),
+    CalendarEventID: z.string().nullable().describe(`
+        * * Field Name: CalendarEventID
+        * * Display Name: Calendar Event ID
+        * * SQL Data Type: nvarchar(255)
+        * * Description: External calendar event ID for sync purposes`),
+    VideoProviderID: z.string().nullable().describe(`
+        * * Field Name: VideoProviderID
+        * * Display Name: Video Provider
+        * * SQL Data Type: uniqueidentifier
+        * * Related Entity/Foreign Key: Video Providers (vwVideoProviders.ID)
+        * * Description: FK to VideoProvider — when set, video meeting URL is auto-created on save`),
+    __mj_CreatedAt: z.date().describe(`
+        * * Field Name: __mj_CreatedAt
+        * * Display Name: Created At
+        * * SQL Data Type: datetimeoffset
+        * * Default Value: getutcdate()`),
+    __mj_UpdatedAt: z.date().describe(`
+        * * Field Name: __mj_UpdatedAt
+        * * Display Name: Updated At
+        * * SQL Data Type: datetimeoffset
+        * * Default Value: getutcdate()`),
+    Committee: z.string().describe(`
+        * * Field Name: Committee
+        * * Display Name: Committee Name
+        * * SQL Data Type: nvarchar(255)`),
+    VideoProvider_Virtual: z.string().nullable().describe(`
+        * * Field Name: VideoProvider_Virtual
+        * * Display Name: Virtual Video Provider
+        * * SQL Data Type: nvarchar(100)`),
+});
+
+export type mjCommitteesMeetingEntityType = z.infer<typeof mjCommitteesMeetingSchema>;
+
+/**
+ * zod schema definition for the entity Memberships
+ */
+export const mjCommitteesMembershipSchema = z.object({
+    ID: z.string().describe(`
+        * * Field Name: ID
+        * * Display Name: ID
+        * * SQL Data Type: uniqueidentifier
+        * * Default Value: newsequentialid()`),
+    PersonID: z.string().describe(`
+        * * Field Name: PersonID
+        * * Display Name: Person
+        * * SQL Data Type: uniqueidentifier
+        * * Related Entity/Foreign Key: People (vwPeople.ID)`),
+    RoleID: z.string().describe(`
+        * * Field Name: RoleID
+        * * Display Name: Role
+        * * SQL Data Type: uniqueidentifier
+        * * Related Entity/Foreign Key: Roles (vwRoles.ID)`),
+    TermID: z.string().describe(`
+        * * Field Name: TermID
+        * * Display Name: Term
+        * * SQL Data Type: uniqueidentifier
+        * * Related Entity/Foreign Key: Terms (vwTerms.ID)`),
+    StartDate: z.date().describe(`
+        * * Field Name: StartDate
+        * * Display Name: Start Date
+        * * SQL Data Type: date
+        * * Description: Date the membership started`),
+    EndDate: z.date().nullable().describe(`
+        * * Field Name: EndDate
+        * * Display Name: End Date
+        * * SQL Data Type: date
+        * * Description: Date the membership ended, if applicable`),
+    Status: z.union([z.literal('Active'), z.literal('Ended'), z.literal('Pending'), z.literal('Suspended')]).describe(`
+        * * Field Name: Status
+        * * Display Name: Status
+        * * SQL Data Type: nvarchar(50)
+        * * Default Value: Active
+    * * Value List Type: List
+    * * Possible Values 
+    *   * Active
+    *   * Ended
+    *   * Pending
+    *   * Suspended
+        * * Description: Current status: Active, Pending, Ended, or Suspended`),
+    EndReason: z.string().nullable().describe(`
+        * * Field Name: EndReason
+        * * Display Name: End Reason
+        * * SQL Data Type: nvarchar(100)
+        * * Description: Reason the membership ended: Term ended, Resigned, Removed, etc.`),
+    Notes: z.string().nullable().describe(`
+        * * Field Name: Notes
+        * * Display Name: Notes
+        * * SQL Data Type: nvarchar(MAX)
+        * * Description: Additional notes about this membership`),
+    __mj_CreatedAt: z.date().describe(`
+        * * Field Name: __mj_CreatedAt
+        * * Display Name: Created At
+        * * SQL Data Type: datetimeoffset
+        * * Default Value: getutcdate()`),
+    __mj_UpdatedAt: z.date().describe(`
+        * * Field Name: __mj_UpdatedAt
+        * * Display Name: Updated At
+        * * SQL Data Type: datetimeoffset
+        * * Default Value: getutcdate()`),
+    Person: z.string().describe(`
+        * * Field Name: Person
+        * * Display Name: Person
+        * * SQL Data Type: nvarchar(100)`),
+    Role: z.string().describe(`
+        * * Field Name: Role
+        * * Display Name: Role
+        * * SQL Data Type: nvarchar(100)`),
+    Term: z.string().describe(`
+        * * Field Name: Term
+        * * Display Name: Term
+        * * SQL Data Type: nvarchar(100)`),
+});
+
+export type mjCommitteesMembershipEntityType = z.infer<typeof mjCommitteesMembershipSchema>;
+
+/**
+ * zod schema definition for the entity Minutes
+ */
+export const mjCommitteesMinuteSchema = z.object({
+    ID: z.string().describe(`
+        * * Field Name: ID
+        * * Display Name: ID
+        * * SQL Data Type: uniqueidentifier
+        * * Default Value: newsequentialid()`),
+    ArtifactID: z.string().nullable().describe(`
+        * * Field Name: ArtifactID
+        * * Display Name: Artifact
+        * * SQL Data Type: uniqueidentifier`),
+    ApprovalStatus: z.union([z.literal('Approved'), z.literal('Draft'), z.literal('PendingApproval'), z.literal('Rejected')]).describe(`
+        * * Field Name: ApprovalStatus
+        * * Display Name: Approval Status
+        * * SQL Data Type: nvarchar(50)
+        * * Default Value: Draft
+    * * Value List Type: List
+    * * Possible Values 
+    *   * Approved
+    *   * Draft
+    *   * PendingApproval
+    *   * Rejected
+        * * Description: Current approval status: Draft, PendingApproval, Approved, Rejected`),
+    ApprovedAt: z.date().nullable().describe(`
+        * * Field Name: ApprovedAt
+        * * Display Name: Approved At
+        * * SQL Data Type: datetimeoffset
+        * * Description: Timestamp when the minutes were approved`),
+    ApprovedByMeetingID: z.string().nullable().describe(`
+        * * Field Name: ApprovedByMeetingID
+        * * Display Name: Approved By Meeting
+        * * SQL Data Type: uniqueidentifier
+        * * Related Entity/Foreign Key: Meetings (vwMeetings.ID)
+        * * Description: Reference to the meeting at which these minutes were approved (typically the next meeting)`),
+    Notes: z.string().nullable().describe(`
+        * * Field Name: Notes
+        * * Display Name: Notes
+        * * SQL Data Type: nvarchar(MAX)
+        * * Description: Additional notes about the minutes`),
+    MeetingID: z.string().nullable().describe(`
+        * * Field Name: MeetingID
+        * * Display Name: Meeting
+        * * SQL Data Type: uniqueidentifier
+        * * Related Entity/Foreign Key: Meetings (vwMeetings.ID)`),
+    Content: z.string().nullable().describe(`
+        * * Field Name: Content
+        * * Display Name: Content
+        * * SQL Data Type: nvarchar(MAX)`),
+    __mj_CreatedAt: z.date().describe(`
+        * * Field Name: __mj_CreatedAt
+        * * Display Name: Created At
+        * * SQL Data Type: datetimeoffset
+        * * Default Value: getutcdate()`),
+    __mj_UpdatedAt: z.date().describe(`
+        * * Field Name: __mj_UpdatedAt
+        * * Display Name: Updated At
+        * * SQL Data Type: datetimeoffset
+        * * Default Value: getutcdate()`),
+    ApprovedByMeeting: z.string().nullable().describe(`
+        * * Field Name: ApprovedByMeeting
+        * * Display Name: Approved By Meeting Name
+        * * SQL Data Type: nvarchar(255)`),
+    Meeting: z.string().nullable().describe(`
+        * * Field Name: Meeting
+        * * Display Name: Meeting Name
+        * * SQL Data Type: nvarchar(255)`),
+});
+
+export type mjCommitteesMinuteEntityType = z.infer<typeof mjCommitteesMinuteSchema>;
+
+/**
+ * zod schema definition for the entity Motions
+ */
+export const mjCommitteesMotionSchema = z.object({
+    ID: z.string().describe(`
+        * * Field Name: ID
+        * * Display Name: ID
+        * * SQL Data Type: uniqueidentifier
+        * * Default Value: newsequentialid()`),
+    MeetingID: z.string().describe(`
+        * * Field Name: MeetingID
+        * * Display Name: Meeting
+        * * SQL Data Type: uniqueidentifier
+        * * Related Entity/Foreign Key: Meetings (vwMeetings.ID)`),
+    AgendaItemID: z.string().nullable().describe(`
+        * * Field Name: AgendaItemID
+        * * Display Name: Agenda Item
+        * * SQL Data Type: uniqueidentifier
+        * * Related Entity/Foreign Key: Agenda Items (vwAgendaItems.ID)`),
+    Sequence: z.number().describe(`
+        * * Field Name: Sequence
+        * * Display Name: Sequence
+        * * SQL Data Type: int
+        * * Default Value: 1
+        * * Description: Display order when multiple motions exist for the same agenda item`),
+    Title: z.string().describe(`
+        * * Field Name: Title
+        * * Display Name: Title
+        * * SQL Data Type: nvarchar(255)
+        * * Description: Title of the motion`),
+    Description: z.string().nullable().describe(`
+        * * Field Name: Description
+        * * Display Name: Description
+        * * SQL Data Type: nvarchar(MAX)
+        * * Description: Full text or description of the motion`),
+    MovedByMembershipID: z.string().nullable().describe(`
+        * * Field Name: MovedByMembershipID
+        * * Display Name: Moved By Membership
+        * * SQL Data Type: uniqueidentifier
+        * * Related Entity/Foreign Key: Memberships (vwMemberships.ID)
+        * * Description: The committee member who made the motion`),
+    SecondedByMembershipID: z.string().nullable().describe(`
+        * * Field Name: SecondedByMembershipID
+        * * Display Name: Seconded By Membership
+        * * SQL Data Type: uniqueidentifier
+        * * Related Entity/Foreign Key: Memberships (vwMemberships.ID)
+        * * Description: The committee member who seconded the motion`),
+    Result: z.union([z.literal('Failed'), z.literal('Passed'), z.literal('Pending'), z.literal('Tabled'), z.literal('Withdrawn')]).describe(`
+        * * Field Name: Result
+        * * Display Name: Result
+        * * SQL Data Type: nvarchar(50)
+        * * Default Value: Pending
+    * * Value List Type: List
+    * * Possible Values 
+    *   * Failed
+    *   * Passed
+    *   * Pending
+    *   * Tabled
+    *   * Withdrawn
+        * * Description: Outcome of the vote: Pending, Passed, Failed, Tabled, Withdrawn`),
+    ResultSummary: z.string().nullable().describe(`
+        * * Field Name: ResultSummary
+        * * Display Name: Result Summary
+        * * SQL Data Type: nvarchar(255)
+        * * Description: Human-readable vote tally, e.g. 7-2-1 or Passed unanimously`),
+    YesCount: z.number().nullable().describe(`
+        * * Field Name: YesCount
+        * * Display Name: Yes Count
+        * * SQL Data Type: int
+        * * Description: Number of Yes votes`),
+    NoCount: z.number().nullable().describe(`
+        * * Field Name: NoCount
+        * * Display Name: No Count
+        * * SQL Data Type: int
+        * * Description: Number of No votes`),
+    AbstainCount: z.number().nullable().describe(`
+        * * Field Name: AbstainCount
+        * * Display Name: Abstain Count
+        * * SQL Data Type: int
+        * * Description: Number of Abstain votes`),
+    Notes: z.string().nullable().describe(`
+        * * Field Name: Notes
+        * * Display Name: Notes
+        * * SQL Data Type: nvarchar(MAX)
+        * * Description: Additional notes about the motion or vote`),
+    __mj_CreatedAt: z.date().describe(`
+        * * Field Name: __mj_CreatedAt
+        * * Display Name: Created At
+        * * SQL Data Type: datetimeoffset
+        * * Default Value: getutcdate()`),
+    __mj_UpdatedAt: z.date().describe(`
+        * * Field Name: __mj_UpdatedAt
+        * * Display Name: Updated At
+        * * SQL Data Type: datetimeoffset
+        * * Default Value: getutcdate()`),
+    Meeting: z.string().describe(`
+        * * Field Name: Meeting
+        * * Display Name: Meeting
+        * * SQL Data Type: nvarchar(255)`),
+    AgendaItem: z.string().nullable().describe(`
+        * * Field Name: AgendaItem
+        * * Display Name: Agenda Item
+        * * SQL Data Type: nvarchar(255)`),
+    MovedByMembership: z.string().nullable().describe(`
+        * * Field Name: MovedByMembership
+        * * Display Name: Moved By Membership
+        * * SQL Data Type: nvarchar(100)`),
+    SecondedByMembership: z.string().nullable().describe(`
+        * * Field Name: SecondedByMembership
+        * * Display Name: Seconded By Membership
+        * * SQL Data Type: nvarchar(100)`),
+});
+
+export type mjCommitteesMotionEntityType = z.infer<typeof mjCommitteesMotionSchema>;
+
+/**
+ * zod schema definition for the entity Organization Types
+ */
+export const mjBizAppsCommonOrganizationTypeSchema = z.object({
+    ID: z.string().describe(`
+        * * Field Name: ID
+        * * Display Name: ID
+        * * SQL Data Type: uniqueidentifier
+        * * Default Value: newsequentialid()`),
+    Name: z.string().describe(`
+        * * Field Name: Name
+        * * Display Name: Name
+        * * SQL Data Type: nvarchar(100)
+        * * Description: Display name for the organization type`),
+    Description: z.string().nullable().describe(`
+        * * Field Name: Description
+        * * Display Name: Description
+        * * SQL Data Type: nvarchar(MAX)
+        * * Description: Detailed description of this organization type`),
+    IconClass: z.string().nullable().describe(`
+        * * Field Name: IconClass
+        * * Display Name: Icon Class
+        * * SQL Data Type: nvarchar(100)
+        * * Description: Font Awesome icon class for UI display`),
+    __mj_CreatedAt: z.date().describe(`
+        * * Field Name: __mj_CreatedAt
+        * * Display Name: Created At
+        * * SQL Data Type: datetimeoffset
+        * * Default Value: getutcdate()`),
+    __mj_UpdatedAt: z.date().describe(`
+        * * Field Name: __mj_UpdatedAt
+        * * Display Name: Updated At
+        * * SQL Data Type: datetimeoffset
+        * * Default Value: getutcdate()`),
+});
+
+export type mjBizAppsCommonOrganizationTypeEntityType = z.infer<typeof mjBizAppsCommonOrganizationTypeSchema>;
+
+/**
+ * zod schema definition for the entity Organizations
+ */
+export const mjBizAppsCommonOrganizationSchema = z.object({
+    ID: z.string().describe(`
+        * * Field Name: ID
+        * * Display Name: ID
+        * * SQL Data Type: uniqueidentifier
+        * * Default Value: newsequentialid()`),
+    Name: z.string().describe(`
+        * * Field Name: Name
+        * * Display Name: Name
+        * * SQL Data Type: nvarchar(255)
+        * * Description: Common or display name of the organization`),
+    LegalName: z.string().nullable().describe(`
+        * * Field Name: LegalName
+        * * Display Name: Legal Name
+        * * SQL Data Type: nvarchar(255)
+        * * Description: Full legal name if different from display name`),
+    OrganizationTypeID: z.string().nullable().describe(`
+        * * Field Name: OrganizationTypeID
+        * * Display Name: Organization Type
+        * * SQL Data Type: uniqueidentifier
+        * * Related Entity/Foreign Key: Organization Types (vwOrganizationTypes.ID)`),
+    ParentID: z.string().nullable().describe(`
+        * * Field Name: ParentID
+        * * Display Name: Parent
+        * * SQL Data Type: uniqueidentifier
+        * * Related Entity/Foreign Key: Organizations (vwOrganizations.ID)`),
+    Website: z.string().nullable().describe(`
+        * * Field Name: Website
+        * * Display Name: Website
+        * * SQL Data Type: nvarchar(1000)
+        * * Description: Primary website URL`),
+    LogoURL: z.string().nullable().describe(`
+        * * Field Name: LogoURL
+        * * Display Name: Logo URL
+        * * SQL Data Type: nvarchar(1000)
+        * * Description: URL to organization logo image`),
+    Description: z.string().nullable().describe(`
+        * * Field Name: Description
+        * * Display Name: Description
+        * * SQL Data Type: nvarchar(MAX)
+        * * Description: Description of the organization purpose and scope`),
+    Email: z.string().nullable().describe(`
+        * * Field Name: Email
+        * * Display Name: Email
+        * * SQL Data Type: nvarchar(255)
+        * * Description: Primary contact email address`),
+    Phone: z.string().nullable().describe(`
+        * * Field Name: Phone
+        * * Display Name: Phone
+        * * SQL Data Type: nvarchar(50)
+        * * Description: Primary phone number`),
+    FoundedDate: z.date().nullable().describe(`
+        * * Field Name: FoundedDate
+        * * Display Name: Founded Date
+        * * SQL Data Type: date
+        * * Description: Date the organization was founded or incorporated`),
+    TaxID: z.string().nullable().describe(`
+        * * Field Name: TaxID
+        * * Display Name: Tax ID
+        * * SQL Data Type: nvarchar(50)
+        * * Description: Tax identification number such as EIN`),
+    Status: z.union([z.literal('Active'), z.literal('Dissolved'), z.literal('Inactive')]).describe(`
+        * * Field Name: Status
+        * * Display Name: Status
+        * * SQL Data Type: nvarchar(50)
+        * * Default Value: Active
+    * * Value List Type: List
+    * * Possible Values 
+    *   * Active
+    *   * Dissolved
+    *   * Inactive
+        * * Description: Current status: Active, Inactive, or Dissolved`),
+    __mj_CreatedAt: z.date().describe(`
+        * * Field Name: __mj_CreatedAt
+        * * Display Name: Created At
+        * * SQL Data Type: datetimeoffset
+        * * Default Value: getutcdate()`),
+    __mj_UpdatedAt: z.date().describe(`
+        * * Field Name: __mj_UpdatedAt
+        * * Display Name: Updated At
+        * * SQL Data Type: datetimeoffset
+        * * Default Value: getutcdate()`),
+    OrganizationType: z.string().nullable().describe(`
+        * * Field Name: OrganizationType
+        * * Display Name: Organization Type
+        * * SQL Data Type: nvarchar(100)`),
+    Parent: z.string().nullable().describe(`
+        * * Field Name: Parent
+        * * Display Name: Parent (Name)
+        * * SQL Data Type: nvarchar(255)`),
+    RootParentID: z.string().nullable().describe(`
+        * * Field Name: RootParentID
+        * * Display Name: Root Parent
+        * * SQL Data Type: uniqueidentifier`),
+});
+
+export type mjBizAppsCommonOrganizationEntityType = z.infer<typeof mjBizAppsCommonOrganizationSchema>;
+
+/**
+ * zod schema definition for the entity People
+ */
+export const mjBizAppsCommonPersonSchema = z.object({
+    ID: z.string().describe(`
+        * * Field Name: ID
+        * * Display Name: ID
+        * * SQL Data Type: uniqueidentifier
+        * * Default Value: newsequentialid()`),
+    FirstName: z.string().describe(`
+        * * Field Name: FirstName
+        * * Display Name: First Name
+        * * SQL Data Type: nvarchar(100)
+        * * Description: First (given) name`),
+    LastName: z.string().describe(`
+        * * Field Name: LastName
+        * * Display Name: Last Name
+        * * SQL Data Type: nvarchar(100)
+        * * Description: Last (family) name`),
+    MiddleName: z.string().nullable().describe(`
+        * * Field Name: MiddleName
+        * * Display Name: Middle Name
+        * * SQL Data Type: nvarchar(100)
+        * * Description: Middle name or initial`),
+    Prefix: z.string().nullable().describe(`
+        * * Field Name: Prefix
+        * * Display Name: Prefix
+        * * SQL Data Type: nvarchar(20)
+        * * Description: Name prefix such as Dr., Mr., Ms., Rev.`),
+    Suffix: z.string().nullable().describe(`
+        * * Field Name: Suffix
+        * * Display Name: Suffix
+        * * SQL Data Type: nvarchar(20)
+        * * Description: Name suffix such as Jr., III, PhD, Esq.`),
+    PreferredName: z.string().nullable().describe(`
+        * * Field Name: PreferredName
+        * * Display Name: Preferred Name
+        * * SQL Data Type: nvarchar(100)
+        * * Description: Nickname or preferred name the person goes by`),
+    Title: z.string().nullable().describe(`
+        * * Field Name: Title
+        * * Display Name: Title
+        * * SQL Data Type: nvarchar(200)
+        * * Description: Professional or job title, e.g. VP of Engineering, Board Director`),
+    Email: z.string().nullable().describe(`
+        * * Field Name: Email
+        * * Display Name: Email
+        * * SQL Data Type: nvarchar(255)
+        * * Description: Primary email address for this person`),
+    Phone: z.string().nullable().describe(`
+        * * Field Name: Phone
+        * * Display Name: Phone
+        * * SQL Data Type: nvarchar(50)
+        * * Description: Primary phone number for this person`),
+    DateOfBirth: z.date().nullable().describe(`
+        * * Field Name: DateOfBirth
+        * * Display Name: Date of Birth
+        * * SQL Data Type: date
+        * * Description: Date of birth`),
+    Gender: z.string().nullable().describe(`
+        * * Field Name: Gender
+        * * Display Name: Gender
+        * * SQL Data Type: nvarchar(50)
+        * * Description: Gender identity`),
+    PhotoURL: z.string().nullable().describe(`
+        * * Field Name: PhotoURL
+        * * Display Name: Photo URL
+        * * SQL Data Type: nvarchar(1000)
+        * * Description: URL to profile photo or avatar image`),
+    Bio: z.string().nullable().describe(`
+        * * Field Name: Bio
+        * * Display Name: Bio
+        * * SQL Data Type: nvarchar(MAX)
+        * * Description: Biographical text or notes about this person`),
+    LinkedUserID: z.string().nullable().describe(`
+        * * Field Name: LinkedUserID
+        * * Display Name: Linked User
+        * * SQL Data Type: uniqueidentifier
+        * * Related Entity/Foreign Key: MJ: Users (vwUsers.ID)`),
+    Status: z.union([z.literal('Active'), z.literal('Deceased'), z.literal('Inactive')]).describe(`
+        * * Field Name: Status
+        * * Display Name: Status
+        * * SQL Data Type: nvarchar(50)
+        * * Default Value: Active
+    * * Value List Type: List
+    * * Possible Values 
+    *   * Active
+    *   * Deceased
+    *   * Inactive
+        * * Description: Current status: Active, Inactive, or Deceased`),
+    __mj_CreatedAt: z.date().describe(`
+        * * Field Name: __mj_CreatedAt
+        * * Display Name: Created At
+        * * SQL Data Type: datetimeoffset
+        * * Default Value: getutcdate()`),
+    __mj_UpdatedAt: z.date().describe(`
+        * * Field Name: __mj_UpdatedAt
+        * * Display Name: Updated At
+        * * SQL Data Type: datetimeoffset
+        * * Default Value: getutcdate()`),
+    LinkedUser: z.string().nullable().describe(`
+        * * Field Name: LinkedUser
+        * * Display Name: Linked User Name
+        * * SQL Data Type: nvarchar(100)`),
+});
+
+export type mjBizAppsCommonPersonEntityType = z.infer<typeof mjBizAppsCommonPersonSchema>;
+
+/**
+ * zod schema definition for the entity Relationship Types
+ */
+export const mjBizAppsCommonRelationshipTypeSchema = z.object({
+    ID: z.string().describe(`
+        * * Field Name: ID
+        * * Display Name: ID
+        * * SQL Data Type: uniqueidentifier
+        * * Default Value: newsequentialid()`),
+    Name: z.string().describe(`
+        * * Field Name: Name
+        * * Display Name: Name
+        * * SQL Data Type: nvarchar(100)
+        * * Description: Display name for the relationship type, e.g. Employee, Spouse, Partner`),
+    Description: z.string().nullable().describe(`
+        * * Field Name: Description
+        * * Display Name: Description
+        * * SQL Data Type: nvarchar(MAX)
+        * * Description: Detailed description of this relationship type`),
+    Category: z.union([z.literal('OrganizationToOrganization'), z.literal('PersonToOrganization'), z.literal('PersonToPerson')]).describe(`
+        * * Field Name: Category
+        * * Display Name: Category
+        * * SQL Data Type: nvarchar(50)
+    * * Value List Type: List
+    * * Possible Values 
+    *   * OrganizationToOrganization
+    *   * PersonToOrganization
+    *   * PersonToPerson
+        * * Description: Which entity types this relationship connects: PersonToPerson, PersonToOrganization, or OrganizationToOrganization`),
+    IsDirectional: z.boolean().describe(`
+        * * Field Name: IsDirectional
+        * * Display Name: Is Directional
+        * * SQL Data Type: bit
+        * * Default Value: 1
+        * * Description: Whether the relationship has a direction. False for symmetric relationships like Spouse or Partner`),
+    ForwardLabel: z.string().nullable().describe(`
+        * * Field Name: ForwardLabel
+        * * Display Name: Forward Label
+        * * SQL Data Type: nvarchar(100)
+        * * Description: Label describing the From-to-To direction, e.g. is employee of, is parent of`),
+    ReverseLabel: z.string().nullable().describe(`
+        * * Field Name: ReverseLabel
+        * * Display Name: Reverse Label
+        * * SQL Data Type: nvarchar(100)
+        * * Description: Label describing the To-to-From direction, e.g. employs, is child of`),
+    __mj_CreatedAt: z.date().describe(`
+        * * Field Name: __mj_CreatedAt
+        * * Display Name: Created At
+        * * SQL Data Type: datetimeoffset
+        * * Default Value: getutcdate()`),
+    __mj_UpdatedAt: z.date().describe(`
+        * * Field Name: __mj_UpdatedAt
+        * * Display Name: Updated At
+        * * SQL Data Type: datetimeoffset
+        * * Default Value: getutcdate()`),
+});
+
+export type mjBizAppsCommonRelationshipTypeEntityType = z.infer<typeof mjBizAppsCommonRelationshipTypeSchema>;
+
+/**
+ * zod schema definition for the entity Relationships
+ */
+export const mjBizAppsCommonRelationshipSchema = z.object({
+    ID: z.string().describe(`
+        * * Field Name: ID
+        * * Display Name: ID
+        * * SQL Data Type: uniqueidentifier
+        * * Default Value: newsequentialid()`),
+    RelationshipTypeID: z.string().describe(`
+        * * Field Name: RelationshipTypeID
+        * * Display Name: Relationship Type
+        * * SQL Data Type: uniqueidentifier
+        * * Related Entity/Foreign Key: Relationship Types (vwRelationshipTypes.ID)`),
+    FromPersonID: z.string().nullable().describe(`
+        * * Field Name: FromPersonID
+        * * Display Name: From Person
+        * * SQL Data Type: uniqueidentifier
+        * * Related Entity/Foreign Key: People (vwPeople.ID)`),
+    FromOrganizationID: z.string().nullable().describe(`
+        * * Field Name: FromOrganizationID
+        * * Display Name: From Organization
+        * * SQL Data Type: uniqueidentifier
+        * * Related Entity/Foreign Key: Organizations (vwOrganizations.ID)`),
+    ToPersonID: z.string().nullable().describe(`
+        * * Field Name: ToPersonID
+        * * Display Name: To Person
+        * * SQL Data Type: uniqueidentifier
+        * * Related Entity/Foreign Key: People (vwPeople.ID)`),
+    ToOrganizationID: z.string().nullable().describe(`
+        * * Field Name: ToOrganizationID
+        * * Display Name: To Organization
+        * * SQL Data Type: uniqueidentifier
+        * * Related Entity/Foreign Key: Organizations (vwOrganizations.ID)`),
+    Title: z.string().nullable().describe(`
+        * * Field Name: Title
+        * * Display Name: Title
+        * * SQL Data Type: nvarchar(255)
+        * * Description: Contextual title for this specific relationship, e.g. CEO, Primary Contact, Founding Member`),
+    StartDate: z.date().nullable().describe(`
+        * * Field Name: StartDate
+        * * Display Name: Start Date
+        * * SQL Data Type: date
+        * * Description: Date the relationship began`),
+    EndDate: z.date().nullable().describe(`
+        * * Field Name: EndDate
+        * * Display Name: End Date
+        * * SQL Data Type: date
+        * * Description: Date the relationship ended, if applicable`),
+    Status: z.union([z.literal('Active'), z.literal('Ended'), z.literal('Inactive')]).describe(`
+        * * Field Name: Status
+        * * Display Name: Status
+        * * SQL Data Type: nvarchar(50)
+        * * Default Value: Active
+    * * Value List Type: List
+    * * Possible Values 
+    *   * Active
+    *   * Ended
+    *   * Inactive
+        * * Description: Current status: Active, Inactive, or Ended`),
+    Notes: z.string().nullable().describe(`
+        * * Field Name: Notes
+        * * Display Name: Notes
+        * * SQL Data Type: nvarchar(MAX)
+        * * Description: Additional notes about this relationship`),
+    __mj_CreatedAt: z.date().describe(`
+        * * Field Name: __mj_CreatedAt
+        * * Display Name: Created At
+        * * SQL Data Type: datetimeoffset
+        * * Default Value: getutcdate()`),
+    __mj_UpdatedAt: z.date().describe(`
+        * * Field Name: __mj_UpdatedAt
+        * * Display Name: Updated At
+        * * SQL Data Type: datetimeoffset
+        * * Default Value: getutcdate()`),
+    RelationshipType: z.string().describe(`
+        * * Field Name: RelationshipType
+        * * Display Name: Relationship Type Name
+        * * SQL Data Type: nvarchar(100)`),
+    FromPerson: z.string().nullable().describe(`
+        * * Field Name: FromPerson
+        * * Display Name: From Person
+        * * SQL Data Type: nvarchar(100)`),
+    FromOrganization: z.string().nullable().describe(`
+        * * Field Name: FromOrganization
+        * * Display Name: From Organization
+        * * SQL Data Type: nvarchar(255)`),
+    ToPerson: z.string().nullable().describe(`
+        * * Field Name: ToPerson
+        * * Display Name: To Person
+        * * SQL Data Type: nvarchar(100)`),
+    ToOrganization: z.string().nullable().describe(`
+        * * Field Name: ToOrganization
+        * * Display Name: To Organization
+        * * SQL Data Type: nvarchar(255)`),
+});
+
+export type mjBizAppsCommonRelationshipEntityType = z.infer<typeof mjBizAppsCommonRelationshipSchema>;
+
+/**
+ * zod schema definition for the entity Roles
+ */
+export const mjCommitteesRoleSchema = z.object({
+    ID: z.string().describe(`
+        * * Field Name: ID
+        * * Display Name: ID
+        * * SQL Data Type: uniqueidentifier
+        * * Default Value: newsequentialid()`),
+    Name: z.string().describe(`
+        * * Field Name: Name
+        * * Display Name: Name
+        * * SQL Data Type: nvarchar(100)
+        * * Description: Display name for the role`),
+    Description: z.string().nullable().describe(`
+        * * Field Name: Description
+        * * Display Name: Description
+        * * SQL Data Type: nvarchar(MAX)
+        * * Description: Detailed description of role responsibilities`),
+    IsOfficer: z.boolean().describe(`
+        * * Field Name: IsOfficer
+        * * Display Name: Officer Role
+        * * SQL Data Type: bit
+        * * Default Value: 0
+        * * Description: Whether this is an officer role like Chair or Secretary`),
+    IsVotingRole: z.boolean().describe(`
+        * * Field Name: IsVotingRole
+        * * Display Name: Voting Role
+        * * SQL Data Type: bit
+        * * Default Value: 1
+        * * Description: Whether members in this role can vote`),
+    DefaultPermissionsJSON: z.string().nullable().describe(`
+        * * Field Name: DefaultPermissionsJSON
+        * * Display Name: Default Permissions
+        * * SQL Data Type: nvarchar(MAX)
+        * * Description: JSON object defining default permissions for this role`),
+    Sequence: z.number().describe(`
+        * * Field Name: Sequence
+        * * Display Name: Sequence
+        * * SQL Data Type: int
+        * * Default Value: 100
+        * * Description: Display order for sorting roles`),
+    __mj_CreatedAt: z.date().describe(`
+        * * Field Name: __mj_CreatedAt
+        * * Display Name: Created At
+        * * SQL Data Type: datetimeoffset
+        * * Default Value: getutcdate()`),
+    __mj_UpdatedAt: z.date().describe(`
+        * * Field Name: __mj_UpdatedAt
+        * * Display Name: Updated At
+        * * SQL Data Type: datetimeoffset
+        * * Default Value: getutcdate()`),
+});
+
+export type mjCommitteesRoleEntityType = z.infer<typeof mjCommitteesRoleSchema>;
+
+/**
+ * zod schema definition for the entity Terms
+ */
+export const mjCommitteesTermSchema = z.object({
+    ID: z.string().describe(`
+        * * Field Name: ID
+        * * Display Name: ID
+        * * SQL Data Type: uniqueidentifier
+        * * Default Value: newsequentialid()`),
+    CommitteeID: z.string().describe(`
+        * * Field Name: CommitteeID
+        * * Display Name: Committee
+        * * SQL Data Type: uniqueidentifier
+        * * Related Entity/Foreign Key: Committees (vwCommittees.ID)`),
+    Name: z.string().describe(`
+        * * Field Name: Name
+        * * Display Name: Term Name
+        * * SQL Data Type: nvarchar(100)
+        * * Description: Display name for the term, e.g. 2025-2026`),
+    StartDate: z.date().describe(`
+        * * Field Name: StartDate
+        * * Display Name: Start Date
+        * * SQL Data Type: date
+        * * Description: Start date of the term`),
+    EndDate: z.date().nullable().describe(`
+        * * Field Name: EndDate
+        * * Display Name: End Date
+        * * SQL Data Type: date
+        * * Description: End date of the term`),
+    Status: z.union([z.literal('Active'), z.literal('Completed'), z.literal('Upcoming')]).describe(`
+        * * Field Name: Status
+        * * Display Name: Status
+        * * SQL Data Type: nvarchar(50)
+        * * Default Value: Active
+    * * Value List Type: List
+    * * Possible Values 
+    *   * Active
+    *   * Completed
+    *   * Upcoming
+        * * Description: Current status: Active, Upcoming, or Completed`),
+    __mj_CreatedAt: z.date().describe(`
+        * * Field Name: __mj_CreatedAt
+        * * Display Name: Created At
+        * * SQL Data Type: datetimeoffset
+        * * Default Value: getutcdate()`),
+    __mj_UpdatedAt: z.date().describe(`
+        * * Field Name: __mj_UpdatedAt
+        * * Display Name: Updated At
+        * * SQL Data Type: datetimeoffset
+        * * Default Value: getutcdate()`),
+    Committee: z.string().describe(`
+        * * Field Name: Committee
+        * * Display Name: Committee Name
+        * * SQL Data Type: nvarchar(255)`),
+});
+
+export type mjCommitteesTermEntityType = z.infer<typeof mjCommitteesTermSchema>;
+
+/**
+ * zod schema definition for the entity Types
+ */
+export const mjCommitteesTypeSchema = z.object({
+    ID: z.string().describe(`
+        * * Field Name: ID
+        * * Display Name: ID
+        * * SQL Data Type: uniqueidentifier
+        * * Default Value: newsequentialid()`),
+    Name: z.string().describe(`
+        * * Field Name: Name
+        * * Display Name: Name
+        * * SQL Data Type: nvarchar(100)
+        * * Description: Display name for the committee type`),
+    Description: z.string().nullable().describe(`
+        * * Field Name: Description
+        * * Display Name: Description
+        * * SQL Data Type: nvarchar(MAX)
+        * * Description: Detailed description of this committee type`),
+    IsStandards: z.boolean().describe(`
+        * * Field Name: IsStandards
+        * * Display Name: Is Standards
+        * * SQL Data Type: bit
+        * * Default Value: 0
+        * * Description: Whether this type is for standards development committees`),
+    DefaultTermMonths: z.number().nullable().describe(`
+        * * Field Name: DefaultTermMonths
+        * * Display Name: Default Term (Months)
+        * * SQL Data Type: int
+        * * Description: Default term length in months for committees of this type`),
+    IconClass: z.string().nullable().describe(`
+        * * Field Name: IconClass
+        * * Display Name: Icon Class
+        * * SQL Data Type: nvarchar(100)
+        * * Description: Font Awesome icon class for UI display`),
+    __mj_CreatedAt: z.date().describe(`
+        * * Field Name: __mj_CreatedAt
+        * * Display Name: Created At
+        * * SQL Data Type: datetimeoffset
+        * * Default Value: getutcdate()`),
+    __mj_UpdatedAt: z.date().describe(`
+        * * Field Name: __mj_UpdatedAt
+        * * Display Name: Updated At
+        * * SQL Data Type: datetimeoffset
+        * * Default Value: getutcdate()`),
+});
+
+export type mjCommitteesTypeEntityType = z.infer<typeof mjCommitteesTypeSchema>;
+
+/**
+ * zod schema definition for the entity Video Providers
+ */
+export const mjCommitteesVideoProviderSchema = z.object({
+    ID: z.string().describe(`
+        * * Field Name: ID
+        * * Display Name: ID
+        * * SQL Data Type: uniqueidentifier
+        * * Default Value: newsequentialid()`),
+    Name: z.string().describe(`
+        * * Field Name: Name
+        * * Display Name: Name
+        * * SQL Data Type: nvarchar(100)`),
+    ServerDriverKey: z.string().describe(`
+        * * Field Name: ServerDriverKey
+        * * Display Name: Server Driver Key
+        * * SQL Data Type: nvarchar(100)`),
+    IsActive: z.boolean().describe(`
+        * * Field Name: IsActive
+        * * Display Name: Active
+        * * SQL Data Type: bit
+        * * Default Value: 1`),
+    IsDefault: z.boolean().describe(`
+        * * Field Name: IsDefault
+        * * Display Name: Default
+        * * SQL Data Type: bit
+        * * Default Value: 0`),
+    CredentialID: z.string().nullable().describe(`
+        * * Field Name: CredentialID
+        * * Display Name: Credential ID
+        * * SQL Data Type: uniqueidentifier
+        * * Related Entity/Foreign Key: MJ: Credentials (vwCredentials.ID)`),
+    __mj_CreatedAt: z.date().describe(`
+        * * Field Name: __mj_CreatedAt
+        * * Display Name: Created At
+        * * SQL Data Type: datetimeoffset
+        * * Default Value: getutcdate()`),
+    __mj_UpdatedAt: z.date().describe(`
+        * * Field Name: __mj_UpdatedAt
+        * * Display Name: Updated At
+        * * SQL Data Type: datetimeoffset
+        * * Default Value: getutcdate()`),
+    Credential: z.string().nullable().describe(`
+        * * Field Name: Credential
+        * * Display Name: Credential
+        * * SQL Data Type: nvarchar(200)`),
+});
+
+export type mjCommitteesVideoProviderEntityType = z.infer<typeof mjCommitteesVideoProviderSchema>;
+
+/**
+ * zod schema definition for the entity Votes
+ */
+export const mjCommitteesVoteSchema = z.object({
+    ID: z.string().describe(`
+        * * Field Name: ID
+        * * Display Name: ID
+        * * SQL Data Type: uniqueidentifier
+        * * Default Value: newsequentialid()`),
+    MotionID: z.string().describe(`
+        * * Field Name: MotionID
+        * * Display Name: Motion
+        * * SQL Data Type: uniqueidentifier
+        * * Related Entity/Foreign Key: Motions (vwMotions.ID)`),
+    MembershipID: z.string().describe(`
+        * * Field Name: MembershipID
+        * * Display Name: Membership
+        * * SQL Data Type: uniqueidentifier
+        * * Related Entity/Foreign Key: Memberships (vwMemberships.ID)`),
+    VoteValue: z.union([z.literal('Absent'), z.literal('Abstain'), z.literal('No'), z.literal('Yes')]).describe(`
+        * * Field Name: VoteValue
+        * * Display Name: Vote Value
+        * * SQL Data Type: nvarchar(20)
+    * * Value List Type: List
+    * * Possible Values 
+    *   * Absent
+    *   * Abstain
+    *   * No
+    *   * Yes
+        * * Description: The vote cast: Yes, No, Abstain, or Absent`),
+    Notes: z.string().nullable().describe(`
+        * * Field Name: Notes
+        * * Display Name: Notes
+        * * SQL Data Type: nvarchar(500)
+        * * Description: Optional notes explaining the vote`),
+    __mj_CreatedAt: z.date().describe(`
+        * * Field Name: __mj_CreatedAt
+        * * Display Name: Created At
+        * * SQL Data Type: datetimeoffset
+        * * Default Value: getutcdate()`),
+    __mj_UpdatedAt: z.date().describe(`
+        * * Field Name: __mj_UpdatedAt
+        * * Display Name: Updated At
+        * * SQL Data Type: datetimeoffset
+        * * Default Value: getutcdate()`),
+    Motion: z.string().describe(`
+        * * Field Name: Motion
+        * * Display Name: Motion
+        * * SQL Data Type: nvarchar(255)`),
+    Membership: z.string().describe(`
+        * * Field Name: Membership
+        * * Display Name: Membership
+        * * SQL Data Type: nvarchar(100)`),
+});
+
+export type mjCommitteesVoteEntityType = z.infer<typeof mjCommitteesVoteSchema>;
+ 
+ 
+
+/**
+ * Action Items - strongly typed entity sub-class
+ * * Schema: __mj_Committees
+ * * Base Table: ActionItem
+ * * Base View: vwActionItems
+ * * @description Tasks and action items assigned from committees or meetings
+ * * Primary Key: ID
+ * @extends {BaseEntity}
+ * @class
+ * @public
+ */
+@RegisterClass(BaseEntity, 'Action Items')
+export class mjCommitteesActionItemEntity extends BaseEntity<mjCommitteesActionItemEntityType> {
+    /**
+    * Loads the Action Items record from the database
+    * @param ID: string - primary key value to load the Action Items record.
+    * @param EntityRelationshipsToLoad - (optional) the relationships to load
+    * @returns {Promise<boolean>} - true if successful, false otherwise
+    * @public
+    * @async
+    * @memberof mjCommitteesActionItemEntity
+    * @method
+    * @override
+    */
+    public async Load(ID: string, EntityRelationshipsToLoad?: string[]) : Promise<boolean> {
+        const compositeKey: CompositeKey = new CompositeKey();
+        compositeKey.KeyValuePairs.push({ FieldName: 'ID', Value: ID });
+        return await super.InnerLoad(compositeKey, EntityRelationshipsToLoad);
+    }
+
+    /**
+    * * Field Name: ID
+    * * Display Name: ID
+    * * SQL Data Type: uniqueidentifier
+    * * Default Value: newsequentialid()
+    */
+    get ID(): string {
+        return this.Get('ID');
+    }
+    set ID(value: string) {
+        this.Set('ID', value);
+    }
+
+    /**
+    * * Field Name: CommitteeID
+    * * Display Name: Committee
+    * * SQL Data Type: uniqueidentifier
+    * * Related Entity/Foreign Key: Committees (vwCommittees.ID)
+    */
+    get CommitteeID(): string {
+        return this.Get('CommitteeID');
+    }
+    set CommitteeID(value: string) {
+        this.Set('CommitteeID', value);
+    }
+
+    /**
+    * * Field Name: MeetingID
+    * * Display Name: Meeting
+    * * SQL Data Type: uniqueidentifier
+    * * Related Entity/Foreign Key: Meetings (vwMeetings.ID)
+    */
+    get MeetingID(): string | null {
+        return this.Get('MeetingID');
+    }
+    set MeetingID(value: string | null) {
+        this.Set('MeetingID', value);
+    }
+
+    /**
+    * * Field Name: AgendaItemID
+    * * Display Name: Agenda Item
+    * * SQL Data Type: uniqueidentifier
+    * * Related Entity/Foreign Key: Agenda Items (vwAgendaItems.ID)
+    */
+    get AgendaItemID(): string | null {
+        return this.Get('AgendaItemID');
+    }
+    set AgendaItemID(value: string | null) {
+        this.Set('AgendaItemID', value);
+    }
+
+    /**
+    * * Field Name: Title
+    * * Display Name: Title
+    * * SQL Data Type: nvarchar(255)
+    * * Description: Title of the action item
+    */
+    get Title(): string {
+        return this.Get('Title');
+    }
+    set Title(value: string) {
+        this.Set('Title', value);
+    }
+
+    /**
+    * * Field Name: Description
+    * * Display Name: Description
+    * * SQL Data Type: nvarchar(MAX)
+    * * Description: Detailed description of what needs to be done
+    */
+    get Description(): string | null {
+        return this.Get('Description');
+    }
+    set Description(value: string | null) {
+        this.Set('Description', value);
+    }
+
+    /**
+    * * Field Name: AssignedToPersonID
+    * * Display Name: Assigned To
+    * * SQL Data Type: uniqueidentifier
+    * * Related Entity/Foreign Key: People (vwPeople.ID)
+    */
+    get AssignedToPersonID(): string {
+        return this.Get('AssignedToPersonID');
+    }
+    set AssignedToPersonID(value: string) {
+        this.Set('AssignedToPersonID', value);
+    }
+
+    /**
+    * * Field Name: AssignedByPersonID
+    * * Display Name: Assigned By
+    * * SQL Data Type: uniqueidentifier
+    * * Related Entity/Foreign Key: People (vwPeople.ID)
+    */
+    get AssignedByPersonID(): string | null {
+        return this.Get('AssignedByPersonID');
+    }
+    set AssignedByPersonID(value: string | null) {
+        this.Set('AssignedByPersonID', value);
+    }
+
+    /**
+    * * Field Name: DueDate
+    * * Display Name: Due Date
+    * * SQL Data Type: date
+    * * Description: Due date for completion
+    */
+    get DueDate(): Date | null {
+        return this.Get('DueDate');
+    }
+    set DueDate(value: Date | null) {
+        this.Set('DueDate', value);
+    }
+
+    /**
+    * * Field Name: Priority
+    * * Display Name: Priority
+    * * SQL Data Type: nvarchar(20)
+    * * Default Value: Medium
+    * * Value List Type: List
+    * * Possible Values 
+    *   * Critical
+    *   * High
+    *   * Low
+    *   * Medium
+    * * Description: Priority level: Low, Medium, High, Critical
+    */
+    get Priority(): 'Critical' | 'High' | 'Low' | 'Medium' {
+        return this.Get('Priority');
+    }
+    set Priority(value: 'Critical' | 'High' | 'Low' | 'Medium') {
+        this.Set('Priority', value);
+    }
+
+    /**
+    * * Field Name: Status
+    * * Display Name: Status
+    * * SQL Data Type: nvarchar(50)
+    * * Default Value: Open
+    * * Value List Type: List
+    * * Possible Values 
+    *   * Blocked
+    *   * Cancelled
+    *   * Completed
+    *   * InProgress
+    *   * Open
+    * * Description: Current status: Open, InProgress, Blocked, Completed, Cancelled
+    */
+    get Status(): 'Blocked' | 'Cancelled' | 'Completed' | 'InProgress' | 'Open' {
+        return this.Get('Status');
+    }
+    set Status(value: 'Blocked' | 'Cancelled' | 'Completed' | 'InProgress' | 'Open') {
+        this.Set('Status', value);
+    }
+
+    /**
+    * * Field Name: CompletedAt
+    * * Display Name: Completed At
+    * * SQL Data Type: datetimeoffset
+    * * Description: Timestamp when the action item was completed
+    */
+    get CompletedAt(): Date | null {
+        return this.Get('CompletedAt');
+    }
+    set CompletedAt(value: Date | null) {
+        this.Set('CompletedAt', value);
+    }
+
+    /**
+    * * Field Name: CompletionNotes
+    * * Display Name: Completion Notes
+    * * SQL Data Type: nvarchar(MAX)
+    * * Description: Notes about how the item was completed
+    */
+    get CompletionNotes(): string | null {
+        return this.Get('CompletionNotes');
+    }
+    set CompletionNotes(value: string | null) {
+        this.Set('CompletionNotes', value);
+    }
+
+    /**
+    * * Field Name: __mj_CreatedAt
+    * * Display Name: Created At
+    * * SQL Data Type: datetimeoffset
+    * * Default Value: getutcdate()
+    */
+    get __mj_CreatedAt(): Date {
+        return this.Get('__mj_CreatedAt');
+    }
+
+    /**
+    * * Field Name: __mj_UpdatedAt
+    * * Display Name: Updated At
+    * * SQL Data Type: datetimeoffset
+    * * Default Value: getutcdate()
+    */
+    get __mj_UpdatedAt(): Date {
+        return this.Get('__mj_UpdatedAt');
+    }
+
+    /**
+    * * Field Name: Committee
+    * * Display Name: Committee
+    * * SQL Data Type: nvarchar(255)
+    */
+    get Committee(): string {
+        return this.Get('Committee');
+    }
+
+    /**
+    * * Field Name: Meeting
+    * * Display Name: Meeting
+    * * SQL Data Type: nvarchar(255)
+    */
+    get Meeting(): string | null {
+        return this.Get('Meeting');
+    }
+
+    /**
+    * * Field Name: AgendaItem
+    * * Display Name: Agenda Item
+    * * SQL Data Type: nvarchar(255)
+    */
+    get AgendaItem(): string | null {
+        return this.Get('AgendaItem');
+    }
+
+    /**
+    * * Field Name: AssignedToPerson
+    * * Display Name: Assigned To Person
+    * * SQL Data Type: nvarchar(100)
+    */
+    get AssignedToPerson(): string {
+        return this.Get('AssignedToPerson');
+    }
+
+    /**
+    * * Field Name: AssignedByPerson
+    * * Display Name: Assigned By Person
+    * * SQL Data Type: nvarchar(100)
+    */
+    get AssignedByPerson(): string | null {
+        return this.Get('AssignedByPerson');
+    }
+}
+
+
+/**
+ * Address Links - strongly typed entity sub-class
+ * * Schema: __mj_BizAppsCommon
+ * * Base Table: AddressLink
+ * * Base View: vwAddressLinks
+ * * @description Polymorphic link table connecting Address records to any entity record in the system via EntityID and RecordID
+ * * Primary Key: ID
+ * @extends {BaseEntity}
+ * @class
+ * @public
+ */
+@RegisterClass(BaseEntity, 'Address Links')
+export class mjBizAppsCommonAddressLinkEntity extends BaseEntity<mjBizAppsCommonAddressLinkEntityType> {
+    /**
+    * Loads the Address Links record from the database
+    * @param ID: string - primary key value to load the Address Links record.
+    * @param EntityRelationshipsToLoad - (optional) the relationships to load
+    * @returns {Promise<boolean>} - true if successful, false otherwise
+    * @public
+    * @async
+    * @memberof mjBizAppsCommonAddressLinkEntity
+    * @method
+    * @override
+    */
+    public async Load(ID: string, EntityRelationshipsToLoad?: string[]) : Promise<boolean> {
+        const compositeKey: CompositeKey = new CompositeKey();
+        compositeKey.KeyValuePairs.push({ FieldName: 'ID', Value: ID });
+        return await super.InnerLoad(compositeKey, EntityRelationshipsToLoad);
+    }
+
+    /**
+    * * Field Name: ID
+    * * Display Name: ID
+    * * SQL Data Type: uniqueidentifier
+    * * Default Value: newsequentialid()
+    */
+    get ID(): string {
+        return this.Get('ID');
+    }
+    set ID(value: string) {
+        this.Set('ID', value);
+    }
+
+    /**
+    * * Field Name: AddressID
+    * * Display Name: Address
+    * * SQL Data Type: uniqueidentifier
+    * * Related Entity/Foreign Key: Addresses (vwAddresses.ID)
+    */
+    get AddressID(): string {
+        return this.Get('AddressID');
+    }
+    set AddressID(value: string) {
+        this.Set('AddressID', value);
+    }
+
+    /**
+    * * Field Name: EntityID
+    * * Display Name: Entity
+    * * SQL Data Type: uniqueidentifier
+    * * Related Entity/Foreign Key: MJ: Entities (vwEntities.ID)
+    */
+    get EntityID(): string {
+        return this.Get('EntityID');
+    }
+    set EntityID(value: string) {
+        this.Set('EntityID', value);
+    }
+
+    /**
+    * * Field Name: RecordID
+    * * Display Name: Record
+    * * SQL Data Type: nvarchar(700)
+    * * Description: Primary key value(s) of the linked record. NVARCHAR(700) to support concatenated composite keys for entities without single-valued primary keys
+    */
+    get RecordID(): string {
+        return this.Get('RecordID');
+    }
+    set RecordID(value: string) {
+        this.Set('RecordID', value);
+    }
+
+    /**
+    * * Field Name: AddressTypeID
+    * * Display Name: Address Type
+    * * SQL Data Type: uniqueidentifier
+    * * Related Entity/Foreign Key: Address Types (vwAddressTypes.ID)
+    */
+    get AddressTypeID(): string {
+        return this.Get('AddressTypeID');
+    }
+    set AddressTypeID(value: string) {
+        this.Set('AddressTypeID', value);
+    }
+
+    /**
+    * * Field Name: IsPrimary
+    * * Display Name: Primary
+    * * SQL Data Type: bit
+    * * Default Value: 0
+    * * Description: Whether this is the primary address for the linked record. Only one address per entity record should be marked primary
+    */
+    get IsPrimary(): boolean {
+        return this.Get('IsPrimary');
+    }
+    set IsPrimary(value: boolean) {
+        this.Set('IsPrimary', value);
+    }
+
+    /**
+    * * Field Name: Rank
+    * * Display Name: Rank
+    * * SQL Data Type: int
+    * * Description: Sort order override for this specific link. When NULL, falls back to AddressType.DefaultRank. Lower values appear first
+    */
+    get Rank(): number | null {
+        return this.Get('Rank');
+    }
+    set Rank(value: number | null) {
+        this.Set('Rank', value);
+    }
+
+    /**
+    * * Field Name: __mj_CreatedAt
+    * * Display Name: Created At
+    * * SQL Data Type: datetimeoffset
+    * * Default Value: getutcdate()
+    */
+    get __mj_CreatedAt(): Date {
+        return this.Get('__mj_CreatedAt');
+    }
+
+    /**
+    * * Field Name: __mj_UpdatedAt
+    * * Display Name: Updated At
+    * * SQL Data Type: datetimeoffset
+    * * Default Value: getutcdate()
+    */
+    get __mj_UpdatedAt(): Date {
+        return this.Get('__mj_UpdatedAt');
+    }
+
+    /**
+    * * Field Name: Address
+    * * Display Name: Address
+    * * SQL Data Type: nvarchar(255)
+    */
+    get Address(): string {
+        return this.Get('Address');
+    }
+
+    /**
+    * * Field Name: Entity
+    * * Display Name: Entity Name
+    * * SQL Data Type: nvarchar(255)
+    */
+    get Entity(): string {
+        return this.Get('Entity');
+    }
+
+    /**
+    * * Field Name: AddressType
+    * * Display Name: Address Type Name
+    * * SQL Data Type: nvarchar(100)
+    */
+    get AddressType(): string {
+        return this.Get('AddressType');
+    }
+}
+
+
+/**
+ * Address Types - strongly typed entity sub-class
+ * * Schema: __mj_BizAppsCommon
+ * * Base Table: AddressType
+ * * Base View: vwAddressTypes
+ * * @description Categories of addresses such as Home, Work, Mailing, Billing
+ * * Primary Key: ID
+ * @extends {BaseEntity}
+ * @class
+ * @public
+ */
+@RegisterClass(BaseEntity, 'Address Types')
+export class mjBizAppsCommonAddressTypeEntity extends BaseEntity<mjBizAppsCommonAddressTypeEntityType> {
+    /**
+    * Loads the Address Types record from the database
+    * @param ID: string - primary key value to load the Address Types record.
+    * @param EntityRelationshipsToLoad - (optional) the relationships to load
+    * @returns {Promise<boolean>} - true if successful, false otherwise
+    * @public
+    * @async
+    * @memberof mjBizAppsCommonAddressTypeEntity
+    * @method
+    * @override
+    */
+    public async Load(ID: string, EntityRelationshipsToLoad?: string[]) : Promise<boolean> {
+        const compositeKey: CompositeKey = new CompositeKey();
+        compositeKey.KeyValuePairs.push({ FieldName: 'ID', Value: ID });
+        return await super.InnerLoad(compositeKey, EntityRelationshipsToLoad);
+    }
+
+    /**
+    * * Field Name: ID
+    * * Display Name: ID
+    * * SQL Data Type: uniqueidentifier
+    * * Default Value: newsequentialid()
+    */
+    get ID(): string {
+        return this.Get('ID');
+    }
+    set ID(value: string) {
+        this.Set('ID', value);
+    }
+
+    /**
+    * * Field Name: Name
+    * * Display Name: Name
+    * * SQL Data Type: nvarchar(100)
+    * * Description: Display name for the address type
+    */
+    get Name(): string {
+        return this.Get('Name');
+    }
+    set Name(value: string) {
+        this.Set('Name', value);
+    }
+
+    /**
+    * * Field Name: Description
+    * * Display Name: Description
+    * * SQL Data Type: nvarchar(MAX)
+    * * Description: Detailed description of this address type
+    */
+    get Description(): string | null {
+        return this.Get('Description');
+    }
+    set Description(value: string | null) {
+        this.Set('Description', value);
+    }
+
+    /**
+    * * Field Name: DefaultRank
+    * * Display Name: Default Rank
+    * * SQL Data Type: int
+    * * Default Value: 100
+    * * Description: Default sort order for this address type in dropdown lists. Lower values appear first. Can be overridden per-record via AddressLink.Rank
+    */
+    get DefaultRank(): number {
+        return this.Get('DefaultRank');
+    }
+    set DefaultRank(value: number) {
+        this.Set('DefaultRank', value);
+    }
+
+    /**
+    * * Field Name: __mj_CreatedAt
+    * * Display Name: Created At
+    * * SQL Data Type: datetimeoffset
+    * * Default Value: getutcdate()
+    */
+    get __mj_CreatedAt(): Date {
+        return this.Get('__mj_CreatedAt');
+    }
+
+    /**
+    * * Field Name: __mj_UpdatedAt
+    * * Display Name: Updated At
+    * * SQL Data Type: datetimeoffset
+    * * Default Value: getutcdate()
+    */
+    get __mj_UpdatedAt(): Date {
+        return this.Get('__mj_UpdatedAt');
+    }
+}
+
+
+/**
+ * Addresses - strongly typed entity sub-class
+ * * Schema: __mj_BizAppsCommon
+ * * Base Table: Address
+ * * Base View: vwAddresses
+ * * @description Standalone physical address records linked to entities via AddressLink for sharing across people and organizations
+ * * Primary Key: ID
+ * @extends {BaseEntity}
+ * @class
+ * @public
+ */
+@RegisterClass(BaseEntity, 'Addresses')
+export class mjBizAppsCommonAddressEntity extends BaseEntity<mjBizAppsCommonAddressEntityType> {
+    /**
+    * Loads the Addresses record from the database
+    * @param ID: string - primary key value to load the Addresses record.
+    * @param EntityRelationshipsToLoad - (optional) the relationships to load
+    * @returns {Promise<boolean>} - true if successful, false otherwise
+    * @public
+    * @async
+    * @memberof mjBizAppsCommonAddressEntity
+    * @method
+    * @override
+    */
+    public async Load(ID: string, EntityRelationshipsToLoad?: string[]) : Promise<boolean> {
+        const compositeKey: CompositeKey = new CompositeKey();
+        compositeKey.KeyValuePairs.push({ FieldName: 'ID', Value: ID });
+        return await super.InnerLoad(compositeKey, EntityRelationshipsToLoad);
+    }
+
+    /**
+    * * Field Name: ID
+    * * Display Name: ID
+    * * SQL Data Type: uniqueidentifier
+    * * Default Value: newsequentialid()
+    */
+    get ID(): string {
+        return this.Get('ID');
+    }
+    set ID(value: string) {
+        this.Set('ID', value);
+    }
+
+    /**
+    * * Field Name: Line1
+    * * Display Name: Address Line 1
+    * * SQL Data Type: nvarchar(255)
+    * * Description: Street address line 1
+    */
+    get Line1(): string {
+        return this.Get('Line1');
+    }
+    set Line1(value: string) {
+        this.Set('Line1', value);
+    }
+
+    /**
+    * * Field Name: Line2
+    * * Display Name: Address Line 2
+    * * SQL Data Type: nvarchar(255)
+    * * Description: Street address line 2 (suite, apt, etc.)
+    */
+    get Line2(): string | null {
+        return this.Get('Line2');
+    }
+    set Line2(value: string | null) {
+        this.Set('Line2', value);
+    }
+
+    /**
+    * * Field Name: Line3
+    * * Display Name: Address Line 3
+    * * SQL Data Type: nvarchar(255)
+    * * Description: Street address line 3 (additional detail)
+    */
+    get Line3(): string | null {
+        return this.Get('Line3');
+    }
+    set Line3(value: string | null) {
+        this.Set('Line3', value);
+    }
+
+    /**
+    * * Field Name: City
+    * * Display Name: City
+    * * SQL Data Type: nvarchar(100)
+    * * Description: City or locality name
+    */
+    get City(): string {
+        return this.Get('City');
+    }
+    set City(value: string) {
+        this.Set('City', value);
+    }
+
+    /**
+    * * Field Name: StateProvince
+    * * Display Name: State / Province
+    * * SQL Data Type: nvarchar(100)
+    * * Description: State, province, or region
+    */
+    get StateProvince(): string | null {
+        return this.Get('StateProvince');
+    }
+    set StateProvince(value: string | null) {
+        this.Set('StateProvince', value);
+    }
+
+    /**
+    * * Field Name: PostalCode
+    * * Display Name: Postal Code
+    * * SQL Data Type: nvarchar(20)
+    * * Description: Postal or ZIP code
+    */
+    get PostalCode(): string | null {
+        return this.Get('PostalCode');
+    }
+    set PostalCode(value: string | null) {
+        this.Set('PostalCode', value);
+    }
+
+    /**
+    * * Field Name: Country
+    * * Display Name: Country
+    * * SQL Data Type: nvarchar(100)
+    * * Default Value: US
+    * * Description: Country code or name, defaults to US
+    */
+    get Country(): string {
+        return this.Get('Country');
+    }
+    set Country(value: string) {
+        this.Set('Country', value);
+    }
+
+    /**
+    * * Field Name: Latitude
+    * * Display Name: Latitude
+    * * SQL Data Type: decimal(9, 6)
+    * * Description: Geographic latitude for mapping
+    */
+    get Latitude(): number | null {
+        return this.Get('Latitude');
+    }
+    set Latitude(value: number | null) {
+        this.Set('Latitude', value);
+    }
+
+    /**
+    * * Field Name: Longitude
+    * * Display Name: Longitude
+    * * SQL Data Type: decimal(9, 6)
+    * * Description: Geographic longitude for mapping
+    */
+    get Longitude(): number | null {
+        return this.Get('Longitude');
+    }
+    set Longitude(value: number | null) {
+        this.Set('Longitude', value);
+    }
+
+    /**
+    * * Field Name: __mj_CreatedAt
+    * * Display Name: Created At
+    * * SQL Data Type: datetimeoffset
+    * * Default Value: getutcdate()
+    */
+    get __mj_CreatedAt(): Date {
+        return this.Get('__mj_CreatedAt');
+    }
+
+    /**
+    * * Field Name: __mj_UpdatedAt
+    * * Display Name: Updated At
+    * * SQL Data Type: datetimeoffset
+    * * Default Value: getutcdate()
+    */
+    get __mj_UpdatedAt(): Date {
+        return this.Get('__mj_UpdatedAt');
+    }
+}
+
+
+/**
+ * Agenda Items - strongly typed entity sub-class
+ * * Schema: __mj_Committees
+ * * Base Table: AgendaItem
+ * * Base View: vwAgendaItems
+ * * @description Structured agenda items for meetings with hierarchy support
+ * * Primary Key: ID
+ * @extends {BaseEntity}
+ * @class
+ * @public
+ */
+@RegisterClass(BaseEntity, 'Agenda Items')
+export class mjCommitteesAgendaItemEntity extends BaseEntity<mjCommitteesAgendaItemEntityType> {
+    /**
+    * Loads the Agenda Items record from the database
+    * @param ID: string - primary key value to load the Agenda Items record.
+    * @param EntityRelationshipsToLoad - (optional) the relationships to load
+    * @returns {Promise<boolean>} - true if successful, false otherwise
+    * @public
+    * @async
+    * @memberof mjCommitteesAgendaItemEntity
+    * @method
+    * @override
+    */
+    public async Load(ID: string, EntityRelationshipsToLoad?: string[]) : Promise<boolean> {
+        const compositeKey: CompositeKey = new CompositeKey();
+        compositeKey.KeyValuePairs.push({ FieldName: 'ID', Value: ID });
+        return await super.InnerLoad(compositeKey, EntityRelationshipsToLoad);
+    }
+
+    /**
+    * * Field Name: ID
+    * * Display Name: ID
+    * * SQL Data Type: uniqueidentifier
+    * * Default Value: newsequentialid()
+    */
+    get ID(): string {
+        return this.Get('ID');
+    }
+    set ID(value: string) {
+        this.Set('ID', value);
+    }
+
+    /**
+    * * Field Name: MeetingID
+    * * Display Name: Meeting
+    * * SQL Data Type: uniqueidentifier
+    * * Related Entity/Foreign Key: Meetings (vwMeetings.ID)
+    */
+    get MeetingID(): string {
+        return this.Get('MeetingID');
+    }
+    set MeetingID(value: string) {
+        this.Set('MeetingID', value);
+    }
+
+    /**
+    * * Field Name: ParentAgendaItemID
+    * * Display Name: Parent Agenda Item
+    * * SQL Data Type: uniqueidentifier
+    * * Related Entity/Foreign Key: Agenda Items (vwAgendaItems.ID)
+    */
+    get ParentAgendaItemID(): string | null {
+        return this.Get('ParentAgendaItemID');
+    }
+    set ParentAgendaItemID(value: string | null) {
+        this.Set('ParentAgendaItemID', value);
+    }
+
+    /**
+    * * Field Name: Sequence
+    * * Display Name: Sequence
+    * * SQL Data Type: int
+    * * Description: Display order within the meeting agenda
+    */
+    get Sequence(): number {
+        return this.Get('Sequence');
+    }
+    set Sequence(value: number) {
+        this.Set('Sequence', value);
+    }
+
+    /**
+    * * Field Name: Title
+    * * Display Name: Title
+    * * SQL Data Type: nvarchar(255)
+    * * Description: Title of the agenda item
+    */
+    get Title(): string {
+        return this.Get('Title');
+    }
+    set Title(value: string) {
+        this.Set('Title', value);
+    }
+
+    /**
+    * * Field Name: Description
+    * * Display Name: Description
+    * * SQL Data Type: nvarchar(MAX)
+    * * Description: Detailed description of the agenda item
+    */
+    get Description(): string | null {
+        return this.Get('Description');
+    }
+    set Description(value: string | null) {
+        this.Set('Description', value);
+    }
+
+    /**
+    * * Field Name: PresenterPersonID
+    * * Display Name: Presenter Person
+    * * SQL Data Type: uniqueidentifier
+    * * Related Entity/Foreign Key: People (vwPeople.ID)
+    */
+    get PresenterPersonID(): string | null {
+        return this.Get('PresenterPersonID');
+    }
+    set PresenterPersonID(value: string | null) {
+        this.Set('PresenterPersonID', value);
+    }
+
+    /**
+    * * Field Name: DurationMinutes
+    * * Display Name: Duration Minutes
+    * * SQL Data Type: int
+    * * Description: Estimated duration in minutes
+    */
+    get DurationMinutes(): number | null {
+        return this.Get('DurationMinutes');
+    }
+    set DurationMinutes(value: number | null) {
+        this.Set('DurationMinutes', value);
+    }
+
+    /**
+    * * Field Name: ItemType
+    * * Display Name: Item Type
+    * * SQL Data Type: nvarchar(50)
+    * * Default Value: Discussion
+    * * Value List Type: List
+    * * Possible Values 
+    *   * Action
+    *   * Discussion
+    *   * Information
+    *   * Other
+    *   * Report
+    *   * Vote
+    * * Description: Type of item: Information, Discussion, Action, Vote, Report, Other
+    */
+    get ItemType(): 'Action' | 'Discussion' | 'Information' | 'Other' | 'Report' | 'Vote' {
+        return this.Get('ItemType');
+    }
+    set ItemType(value: 'Action' | 'Discussion' | 'Information' | 'Other' | 'Report' | 'Vote') {
+        this.Set('ItemType', value);
+    }
+
+    /**
+    * * Field Name: RelatedDocumentURL
+    * * Display Name: Related Document URL
+    * * SQL Data Type: nvarchar(1000)
+    * * Description: URL to related document for this item
+    */
+    get RelatedDocumentURL(): string | null {
+        return this.Get('RelatedDocumentURL');
+    }
+    set RelatedDocumentURL(value: string | null) {
+        this.Set('RelatedDocumentURL', value);
+    }
+
+    /**
+    * * Field Name: Status
+    * * Display Name: Status
+    * * SQL Data Type: nvarchar(50)
+    * * Default Value: Pending
+    * * Value List Type: List
+    * * Possible Values 
+    *   * Completed
+    *   * Discussed
+    *   * Pending
+    *   * Skipped
+    *   * Tabled
+    * * Description: Current status: Pending, Discussed, Tabled, Completed, Skipped
+    */
+    get Status(): 'Completed' | 'Discussed' | 'Pending' | 'Skipped' | 'Tabled' {
+        return this.Get('Status');
+    }
+    set Status(value: 'Completed' | 'Discussed' | 'Pending' | 'Skipped' | 'Tabled') {
+        this.Set('Status', value);
+    }
+
+    /**
+    * * Field Name: Notes
+    * * Display Name: Notes
+    * * SQL Data Type: nvarchar(MAX)
+    * * Description: Discussion notes and outcomes captured during the meeting
+    */
+    get Notes(): string | null {
+        return this.Get('Notes');
+    }
+    set Notes(value: string | null) {
+        this.Set('Notes', value);
+    }
+
+    /**
+    * * Field Name: __mj_CreatedAt
+    * * Display Name: Created At
+    * * SQL Data Type: datetimeoffset
+    * * Default Value: getutcdate()
+    */
+    get __mj_CreatedAt(): Date {
+        return this.Get('__mj_CreatedAt');
+    }
+
+    /**
+    * * Field Name: __mj_UpdatedAt
+    * * Display Name: Updated At
+    * * SQL Data Type: datetimeoffset
+    * * Default Value: getutcdate()
+    */
+    get __mj_UpdatedAt(): Date {
+        return this.Get('__mj_UpdatedAt');
+    }
+
+    /**
+    * * Field Name: Meeting
+    * * Display Name: Meeting
+    * * SQL Data Type: nvarchar(255)
+    */
+    get Meeting(): string {
+        return this.Get('Meeting');
+    }
+
+    /**
+    * * Field Name: ParentAgendaItem
+    * * Display Name: Parent Agenda Item
+    * * SQL Data Type: nvarchar(255)
+    */
+    get ParentAgendaItem(): string | null {
+        return this.Get('ParentAgendaItem');
+    }
+
+    /**
+    * * Field Name: PresenterPerson
+    * * Display Name: Presenter Person
+    * * SQL Data Type: nvarchar(100)
+    */
+    get PresenterPerson(): string | null {
+        return this.Get('PresenterPerson');
+    }
+
+    /**
+    * * Field Name: RootParentAgendaItemID
+    * * Display Name: Root Parent Agenda Item
+    * * SQL Data Type: uniqueidentifier
+    */
+    get RootParentAgendaItemID(): string | null {
+        return this.Get('RootParentAgendaItemID');
+    }
+}
+
+
+/**
+ * Artifact Types - strongly typed entity sub-class
+ * * Schema: __mj_Committees
+ * * Base Table: ArtifactType
+ * * Base View: vwArtifactTypes
+ * * @description Categories of committee artifacts with optional extension entity for type-specific fields
+ * * Primary Key: ID
+ * @extends {BaseEntity}
+ * @class
+ * @public
+ */
+@RegisterClass(BaseEntity, 'Artifact Types')
+export class mjCommitteesArtifactTypeEntity extends BaseEntity<mjCommitteesArtifactTypeEntityType> {
+    /**
+    * Loads the Artifact Types record from the database
+    * @param ID: string - primary key value to load the Artifact Types record.
+    * @param EntityRelationshipsToLoad - (optional) the relationships to load
+    * @returns {Promise<boolean>} - true if successful, false otherwise
+    * @public
+    * @async
+    * @memberof mjCommitteesArtifactTypeEntity
+    * @method
+    * @override
+    */
+    public async Load(ID: string, EntityRelationshipsToLoad?: string[]) : Promise<boolean> {
+        const compositeKey: CompositeKey = new CompositeKey();
+        compositeKey.KeyValuePairs.push({ FieldName: 'ID', Value: ID });
+        return await super.InnerLoad(compositeKey, EntityRelationshipsToLoad);
+    }
+
+    /**
+    * * Field Name: ID
+    * * Display Name: ID
+    * * SQL Data Type: uniqueidentifier
+    * * Default Value: newsequentialid()
+    */
+    get ID(): string {
+        return this.Get('ID');
+    }
+    set ID(value: string) {
+        this.Set('ID', value);
+    }
+
+    /**
+    * * Field Name: Name
+    * * Display Name: Name
+    * * SQL Data Type: nvarchar(100)
+    * * Description: Display name for the artifact type
+    */
+    get Name(): string {
+        return this.Get('Name');
+    }
+    set Name(value: string) {
+        this.Set('Name', value);
+    }
+
+    /**
+    * * Field Name: Description
+    * * Display Name: Description
+    * * SQL Data Type: nvarchar(MAX)
+    * * Description: Detailed description of this artifact type
+    */
+    get Description(): string | null {
+        return this.Get('Description');
+    }
+    set Description(value: string | null) {
+        this.Set('Description', value);
+    }
+
+    /**
+    * * Field Name: ExtendedEntityID
+    * * Display Name: Extended Entity
+    * * SQL Data Type: uniqueidentifier
+    * * Related Entity/Foreign Key: MJ: Entities (vwEntities.ID)
+    * * Description: Optional reference to an MJ Entity that provides additional fields for this artifact type via a 1:1 extension table
+    */
+    get ExtendedEntityID(): string | null {
+        return this.Get('ExtendedEntityID');
+    }
+    set ExtendedEntityID(value: string | null) {
+        this.Set('ExtendedEntityID', value);
+    }
+
+    /**
+    * * Field Name: IconClass
+    * * Display Name: Icon Class
+    * * SQL Data Type: nvarchar(100)
+    * * Description: Font Awesome icon class for UI display
+    */
+    get IconClass(): string | null {
+        return this.Get('IconClass');
+    }
+    set IconClass(value: string | null) {
+        this.Set('IconClass', value);
+    }
+
+    /**
+    * * Field Name: __mj_CreatedAt
+    * * Display Name: Created At
+    * * SQL Data Type: datetimeoffset
+    * * Default Value: getutcdate()
+    */
+    get __mj_CreatedAt(): Date {
+        return this.Get('__mj_CreatedAt');
+    }
+
+    /**
+    * * Field Name: __mj_UpdatedAt
+    * * Display Name: Updated At
+    * * SQL Data Type: datetimeoffset
+    * * Default Value: getutcdate()
+    */
+    get __mj_UpdatedAt(): Date {
+        return this.Get('__mj_UpdatedAt');
+    }
+
+    /**
+    * * Field Name: ExtendedEntity
+    * * Display Name: Extension Entity
+    * * SQL Data Type: nvarchar(255)
+    */
+    get ExtendedEntity(): string | null {
+        return this.Get('ExtendedEntity');
+    }
+}
+
+
+/**
+ * Artifacts - strongly typed entity sub-class
+ * * Schema: __mj_Committees
+ * * Base Table: Artifact
+ * * Base View: vwArtifacts
+ * * @description Links to external documents and files from various providers
+ * * Primary Key: ID
+ * @extends {BaseEntity}
+ * @class
+ * @public
+ */
+@RegisterClass(BaseEntity, 'Artifacts')
+export class mjCommitteesArtifactEntity extends BaseEntity<mjCommitteesArtifactEntityType> {
+    /**
+    * Loads the Artifacts record from the database
+    * @param ID: string - primary key value to load the Artifacts record.
+    * @param EntityRelationshipsToLoad - (optional) the relationships to load
+    * @returns {Promise<boolean>} - true if successful, false otherwise
+    * @public
+    * @async
+    * @memberof mjCommitteesArtifactEntity
+    * @method
+    * @override
+    */
+    public async Load(ID: string, EntityRelationshipsToLoad?: string[]) : Promise<boolean> {
+        const compositeKey: CompositeKey = new CompositeKey();
+        compositeKey.KeyValuePairs.push({ FieldName: 'ID', Value: ID });
+        return await super.InnerLoad(compositeKey, EntityRelationshipsToLoad);
+    }
+
+    /**
+    * * Field Name: ID
+    * * Display Name: ID
+    * * SQL Data Type: uniqueidentifier
+    * * Default Value: newsequentialid()
+    */
+    get ID(): string {
+        return this.Get('ID');
+    }
+    set ID(value: string) {
+        this.Set('ID', value);
+    }
+
+    /**
+    * * Field Name: CommitteeID
+    * * Display Name: Committee
+    * * SQL Data Type: uniqueidentifier
+    * * Related Entity/Foreign Key: Committees (vwCommittees.ID)
+    */
+    get CommitteeID(): string | null {
+        return this.Get('CommitteeID');
+    }
+    set CommitteeID(value: string | null) {
+        this.Set('CommitteeID', value);
+    }
+
+    /**
+    * * Field Name: MeetingID
+    * * Display Name: Meeting
+    * * SQL Data Type: uniqueidentifier
+    * * Related Entity/Foreign Key: Meetings (vwMeetings.ID)
+    */
+    get MeetingID(): string | null {
+        return this.Get('MeetingID');
+    }
+    set MeetingID(value: string | null) {
+        this.Set('MeetingID', value);
+    }
+
+    /**
+    * * Field Name: AgendaItemID
+    * * Display Name: Agenda Item
+    * * SQL Data Type: uniqueidentifier
+    * * Related Entity/Foreign Key: Agenda Items (vwAgendaItems.ID)
+    */
+    get AgendaItemID(): string | null {
+        return this.Get('AgendaItemID');
+    }
+    set AgendaItemID(value: string | null) {
+        this.Set('AgendaItemID', value);
+    }
+
+    /**
+    * * Field Name: ActionItemID
+    * * Display Name: Action Item
+    * * SQL Data Type: uniqueidentifier
+    * * Related Entity/Foreign Key: Action Items (vwActionItems.ID)
+    */
+    get ActionItemID(): string | null {
+        return this.Get('ActionItemID');
+    }
+    set ActionItemID(value: string | null) {
+        this.Set('ActionItemID', value);
+    }
+
+    /**
+    * * Field Name: Title
+    * * Display Name: Title
+    * * SQL Data Type: nvarchar(255)
+    * * Description: Display title for the artifact
+    */
+    get Title(): string {
+        return this.Get('Title');
+    }
+    set Title(value: string) {
+        this.Set('Title', value);
+    }
+
+    /**
+    * * Field Name: Description
+    * * Display Name: Description
+    * * SQL Data Type: nvarchar(MAX)
+    * * Description: Description of the artifact contents
+    */
+    get Description(): string | null {
+        return this.Get('Description');
+    }
+    set Description(value: string | null) {
+        this.Set('Description', value);
+    }
+
+    /**
+    * * Field Name: ArtifactTypeID
+    * * Display Name: Artifact Type
+    * * SQL Data Type: uniqueidentifier
+    * * Related Entity/Foreign Key: Artifact Types (vwArtifactTypes.ID)
+    */
+    get ArtifactTypeID(): string {
+        return this.Get('ArtifactTypeID');
+    }
+    set ArtifactTypeID(value: string) {
+        this.Set('ArtifactTypeID', value);
+    }
+
+    /**
+    * * Field Name: Provider
+    * * Display Name: Provider
+    * * SQL Data Type: nvarchar(50)
+    * * Value List Type: List
+    * * Possible Values 
+    *   * Box
+    *   * Dropbox
+    *   * GoogleDrive
+    *   * OneDrive
+    *   * SharePoint
+    *   * URL
+    * * Description: Storage provider: GoogleDrive, SharePoint, Box, OneDrive, Dropbox, URL
+    */
+    get Provider(): 'Box' | 'Dropbox' | 'GoogleDrive' | 'OneDrive' | 'SharePoint' | 'URL' {
+        return this.Get('Provider');
+    }
+    set Provider(value: 'Box' | 'Dropbox' | 'GoogleDrive' | 'OneDrive' | 'SharePoint' | 'URL') {
+        this.Set('Provider', value);
+    }
+
+    /**
+    * * Field Name: ExternalID
+    * * Display Name: External ID
+    * * SQL Data Type: nvarchar(500)
+    * * Description: Provider-specific document or file ID
+    */
+    get ExternalID(): string | null {
+        return this.Get('ExternalID');
+    }
+    set ExternalID(value: string | null) {
+        this.Set('ExternalID', value);
+    }
+
+    /**
+    * * Field Name: URL
+    * * Display Name: URL
+    * * SQL Data Type: nvarchar(2000)
+    * * Description: Direct URL to access the artifact
+    */
+    get URL(): string {
+        return this.Get('URL');
+    }
+    set URL(value: string) {
+        this.Set('URL', value);
+    }
+
+    /**
+    * * Field Name: MimeType
+    * * Display Name: MIME Type
+    * * SQL Data Type: nvarchar(100)
+    * * Description: MIME type of the file
+    */
+    get MimeType(): string | null {
+        return this.Get('MimeType');
+    }
+    set MimeType(value: string | null) {
+        this.Set('MimeType', value);
+    }
+
+    /**
+    * * Field Name: FileSize
+    * * Display Name: File Size
+    * * SQL Data Type: bigint
+    * * Description: File size in bytes
+    */
+    get FileSize(): number | null {
+        return this.Get('FileSize');
+    }
+    set FileSize(value: number | null) {
+        this.Set('FileSize', value);
+    }
+
+    /**
+    * * Field Name: UploadedByPersonID
+    * * Display Name: Uploaded By Person
+    * * SQL Data Type: uniqueidentifier
+    * * Related Entity/Foreign Key: People (vwPeople.ID)
+    */
+    get UploadedByPersonID(): string | null {
+        return this.Get('UploadedByPersonID');
+    }
+    set UploadedByPersonID(value: string | null) {
+        this.Set('UploadedByPersonID', value);
+    }
+
+    /**
+    * * Field Name: __mj_CreatedAt
+    * * Display Name: Created At
+    * * SQL Data Type: datetimeoffset
+    * * Default Value: getutcdate()
+    */
+    get __mj_CreatedAt(): Date {
+        return this.Get('__mj_CreatedAt');
+    }
+
+    /**
+    * * Field Name: __mj_UpdatedAt
+    * * Display Name: Updated At
+    * * SQL Data Type: datetimeoffset
+    * * Default Value: getutcdate()
+    */
+    get __mj_UpdatedAt(): Date {
+        return this.Get('__mj_UpdatedAt');
+    }
+
+    /**
+    * * Field Name: Committee
+    * * Display Name: Committee
+    * * SQL Data Type: nvarchar(255)
+    */
+    get Committee(): string | null {
+        return this.Get('Committee');
+    }
+
+    /**
+    * * Field Name: Meeting
+    * * Display Name: Meeting
+    * * SQL Data Type: nvarchar(255)
+    */
+    get Meeting(): string | null {
+        return this.Get('Meeting');
+    }
+
+    /**
+    * * Field Name: AgendaItem
+    * * Display Name: Agenda Item
+    * * SQL Data Type: nvarchar(255)
+    */
+    get AgendaItem(): string | null {
+        return this.Get('AgendaItem');
+    }
+
+    /**
+    * * Field Name: ActionItem
+    * * Display Name: Action Item
+    * * SQL Data Type: nvarchar(255)
+    */
+    get ActionItem(): string | null {
+        return this.Get('ActionItem');
+    }
+
+    /**
+    * * Field Name: ArtifactType
+    * * Display Name: Artifact Type
+    * * SQL Data Type: nvarchar(100)
+    */
+    get ArtifactType(): string {
+        return this.Get('ArtifactType');
+    }
+
+    /**
+    * * Field Name: UploadedByPerson
+    * * Display Name: Uploaded By Person
+    * * SQL Data Type: nvarchar(100)
+    */
+    get UploadedByPerson(): string | null {
+        return this.Get('UploadedByPerson');
+    }
+}
+
+
+/**
+ * Attendances - strongly typed entity sub-class
+ * * Schema: __mj_Committees
+ * * Base Table: Attendance
+ * * Base View: vwAttendances
+ * * @description Meeting attendance records for committee members
+ * * Primary Key: ID
+ * @extends {BaseEntity}
+ * @class
+ * @public
+ */
+@RegisterClass(BaseEntity, 'Attendances')
+export class mjCommitteesAttendanceEntity extends BaseEntity<mjCommitteesAttendanceEntityType> {
+    /**
+    * Loads the Attendances record from the database
+    * @param ID: string - primary key value to load the Attendances record.
+    * @param EntityRelationshipsToLoad - (optional) the relationships to load
+    * @returns {Promise<boolean>} - true if successful, false otherwise
+    * @public
+    * @async
+    * @memberof mjCommitteesAttendanceEntity
+    * @method
+    * @override
+    */
+    public async Load(ID: string, EntityRelationshipsToLoad?: string[]) : Promise<boolean> {
+        const compositeKey: CompositeKey = new CompositeKey();
+        compositeKey.KeyValuePairs.push({ FieldName: 'ID', Value: ID });
+        return await super.InnerLoad(compositeKey, EntityRelationshipsToLoad);
+    }
+
+    /**
+    * * Field Name: ID
+    * * Display Name: ID
+    * * SQL Data Type: uniqueidentifier
+    * * Default Value: newsequentialid()
+    */
+    get ID(): string {
+        return this.Get('ID');
+    }
+    set ID(value: string) {
+        this.Set('ID', value);
+    }
+
+    /**
+    * * Field Name: MeetingID
+    * * Display Name: Meeting
+    * * SQL Data Type: uniqueidentifier
+    * * Related Entity/Foreign Key: Meetings (vwMeetings.ID)
+    */
+    get MeetingID(): string {
+        return this.Get('MeetingID');
+    }
+    set MeetingID(value: string) {
+        this.Set('MeetingID', value);
+    }
+
+    /**
+    * * Field Name: PersonID
+    * * Display Name: Person
+    * * SQL Data Type: uniqueidentifier
+    * * Related Entity/Foreign Key: People (vwPeople.ID)
+    */
+    get PersonID(): string {
+        return this.Get('PersonID');
+    }
+    set PersonID(value: string) {
+        this.Set('PersonID', value);
+    }
+
+    /**
+    * * Field Name: AttendanceStatus
+    * * Display Name: Attendance Status
+    * * SQL Data Type: nvarchar(50)
+    * * Default Value: Expected
+    * * Value List Type: List
+    * * Possible Values 
+    *   * Absent
+    *   * Excused
+    *   * Expected
+    *   * Partial
+    *   * Present
+    * * Description: Attendance status: Expected, Present, Absent, Excused, Partial
+    */
+    get AttendanceStatus(): 'Absent' | 'Excused' | 'Expected' | 'Partial' | 'Present' {
+        return this.Get('AttendanceStatus');
+    }
+    set AttendanceStatus(value: 'Absent' | 'Excused' | 'Expected' | 'Partial' | 'Present') {
+        this.Set('AttendanceStatus', value);
+    }
+
+    /**
+    * * Field Name: JoinedAt
+    * * Display Name: Joined At
+    * * SQL Data Type: datetimeoffset
+    * * Description: Timestamp when the attendee joined the meeting
+    */
+    get JoinedAt(): Date | null {
+        return this.Get('JoinedAt');
+    }
+    set JoinedAt(value: Date | null) {
+        this.Set('JoinedAt', value);
+    }
+
+    /**
+    * * Field Name: LeftAt
+    * * Display Name: Left At
+    * * SQL Data Type: datetimeoffset
+    * * Description: Timestamp when the attendee left the meeting
+    */
+    get LeftAt(): Date | null {
+        return this.Get('LeftAt');
+    }
+    set LeftAt(value: Date | null) {
+        this.Set('LeftAt', value);
+    }
+
+    /**
+    * * Field Name: Notes
+    * * Display Name: Notes
+    * * SQL Data Type: nvarchar(500)
+    * * Description: Additional notes about attendance
+    */
+    get Notes(): string | null {
+        return this.Get('Notes');
+    }
+    set Notes(value: string | null) {
+        this.Set('Notes', value);
+    }
+
+    /**
+    * * Field Name: __mj_CreatedAt
+    * * Display Name: Created At
+    * * SQL Data Type: datetimeoffset
+    * * Default Value: getutcdate()
+    */
+    get __mj_CreatedAt(): Date {
+        return this.Get('__mj_CreatedAt');
+    }
+
+    /**
+    * * Field Name: __mj_UpdatedAt
+    * * Display Name: Updated At
+    * * SQL Data Type: datetimeoffset
+    * * Default Value: getutcdate()
+    */
+    get __mj_UpdatedAt(): Date {
+        return this.Get('__mj_UpdatedAt');
+    }
+
+    /**
+    * * Field Name: Meeting
+    * * Display Name: Meeting
+    * * SQL Data Type: nvarchar(255)
+    */
+    get Meeting(): string {
+        return this.Get('Meeting');
+    }
+
+    /**
+    * * Field Name: Person
+    * * Display Name: Person
+    * * SQL Data Type: nvarchar(100)
+    */
+    get Person(): string {
+        return this.Get('Person');
+    }
+}
+
+
+/**
+ * Comments - strongly typed entity sub-class
+ * * Schema: __mj_Committees
+ * * Base Table: Comment
+ * * Base View: vwComments
+ * * @description Threaded discussion comments on committee meetings, agenda items, action items, and documents
+ * * Primary Key: ID
+ * @extends {BaseEntity}
+ * @class
+ * @public
+ */
+@RegisterClass(BaseEntity, 'Comments')
+export class mjCommitteesCommentEntity extends BaseEntity<mjCommitteesCommentEntityType> {
+    /**
+    * Loads the Comments record from the database
+    * @param ID: string - primary key value to load the Comments record.
+    * @param EntityRelationshipsToLoad - (optional) the relationships to load
+    * @returns {Promise<boolean>} - true if successful, false otherwise
+    * @public
+    * @async
+    * @memberof mjCommitteesCommentEntity
+    * @method
+    * @override
+    */
+    public async Load(ID: string, EntityRelationshipsToLoad?: string[]) : Promise<boolean> {
+        const compositeKey: CompositeKey = new CompositeKey();
+        compositeKey.KeyValuePairs.push({ FieldName: 'ID', Value: ID });
+        return await super.InnerLoad(compositeKey, EntityRelationshipsToLoad);
+    }
+
+    /**
+    * * Field Name: ID
+    * * Display Name: ID
+    * * SQL Data Type: uniqueidentifier
+    * * Default Value: newsequentialid()
+    */
+    get ID(): string {
+        return this.Get('ID');
+    }
+    set ID(value: string) {
+        this.Set('ID', value);
+    }
+
+    /**
+    * * Field Name: CommitteeID
+    * * Display Name: Committee
+    * * SQL Data Type: uniqueidentifier
+    * * Related Entity/Foreign Key: Committees (vwCommittees.ID)
+    */
+    get CommitteeID(): string {
+        return this.Get('CommitteeID');
+    }
+    set CommitteeID(value: string) {
+        this.Set('CommitteeID', value);
+    }
+
+    /**
+    * * Field Name: MeetingID
+    * * Display Name: Meeting
+    * * SQL Data Type: uniqueidentifier
+    * * Related Entity/Foreign Key: Meetings (vwMeetings.ID)
+    */
+    get MeetingID(): string | null {
+        return this.Get('MeetingID');
+    }
+    set MeetingID(value: string | null) {
+        this.Set('MeetingID', value);
+    }
+
+    /**
+    * * Field Name: AgendaItemID
+    * * Display Name: Agenda Item
+    * * SQL Data Type: uniqueidentifier
+    * * Related Entity/Foreign Key: Agenda Items (vwAgendaItems.ID)
+    */
+    get AgendaItemID(): string | null {
+        return this.Get('AgendaItemID');
+    }
+    set AgendaItemID(value: string | null) {
+        this.Set('AgendaItemID', value);
+    }
+
+    /**
+    * * Field Name: ActionItemID
+    * * Display Name: Action Item
+    * * SQL Data Type: uniqueidentifier
+    * * Related Entity/Foreign Key: Action Items (vwActionItems.ID)
+    */
+    get ActionItemID(): string | null {
+        return this.Get('ActionItemID');
+    }
+    set ActionItemID(value: string | null) {
+        this.Set('ActionItemID', value);
+    }
+
+    /**
+    * * Field Name: ArtifactID
+    * * Display Name: Artifact
+    * * SQL Data Type: uniqueidentifier
+    * * Related Entity/Foreign Key: Artifacts (vwArtifacts.ID)
+    */
+    get ArtifactID(): string | null {
+        return this.Get('ArtifactID');
+    }
+    set ArtifactID(value: string | null) {
+        this.Set('ArtifactID', value);
+    }
+
+    /**
+    * * Field Name: ParentCommentID
+    * * Display Name: Parent Comment
+    * * SQL Data Type: uniqueidentifier
+    * * Related Entity/Foreign Key: Comments (vwComments.ID)
+    */
+    get ParentCommentID(): string | null {
+        return this.Get('ParentCommentID');
+    }
+    set ParentCommentID(value: string | null) {
+        this.Set('ParentCommentID', value);
+    }
+
+    /**
+    * * Field Name: PersonID
+    * * Display Name: Person
+    * * SQL Data Type: uniqueidentifier
+    * * Related Entity/Foreign Key: People (vwPeople.ID)
+    */
+    get PersonID(): string {
+        return this.Get('PersonID');
+    }
+    set PersonID(value: string) {
+        this.Set('PersonID', value);
+    }
+
+    /**
+    * * Field Name: CommentText
+    * * Display Name: Comment Text
+    * * SQL Data Type: nvarchar(MAX)
+    */
+    get CommentText(): string {
+        return this.Get('CommentText');
+    }
+    set CommentText(value: string) {
+        this.Set('CommentText', value);
+    }
+
+    /**
+    * * Field Name: MentionedPersonIDs
+    * * Display Name: Mentioned Person IDs
+    * * SQL Data Type: nvarchar(MAX)
+    */
+    get MentionedPersonIDs(): string | null {
+        return this.Get('MentionedPersonIDs');
+    }
+    set MentionedPersonIDs(value: string | null) {
+        this.Set('MentionedPersonIDs', value);
+    }
+
+    /**
+    * * Field Name: IsResolved
+    * * Display Name: Is Resolved
+    * * SQL Data Type: bit
+    * * Default Value: 0
+    */
+    get IsResolved(): boolean {
+        return this.Get('IsResolved');
+    }
+    set IsResolved(value: boolean) {
+        this.Set('IsResolved', value);
+    }
+
+    /**
+    * * Field Name: __mj_CreatedAt
+    * * Display Name: Created At
+    * * SQL Data Type: datetimeoffset
+    * * Default Value: getutcdate()
+    */
+    get __mj_CreatedAt(): Date {
+        return this.Get('__mj_CreatedAt');
+    }
+
+    /**
+    * * Field Name: __mj_UpdatedAt
+    * * Display Name: Updated At
+    * * SQL Data Type: datetimeoffset
+    * * Default Value: getutcdate()
+    */
+    get __mj_UpdatedAt(): Date {
+        return this.Get('__mj_UpdatedAt');
+    }
+
+    /**
+    * * Field Name: Committee
+    * * Display Name: Committee
+    * * SQL Data Type: nvarchar(255)
+    */
+    get Committee(): string {
+        return this.Get('Committee');
+    }
+
+    /**
+    * * Field Name: Meeting
+    * * Display Name: Meeting
+    * * SQL Data Type: nvarchar(255)
+    */
+    get Meeting(): string | null {
+        return this.Get('Meeting');
+    }
+
+    /**
+    * * Field Name: AgendaItem
+    * * Display Name: Agenda Item
+    * * SQL Data Type: nvarchar(255)
+    */
+    get AgendaItem(): string | null {
+        return this.Get('AgendaItem');
+    }
+
+    /**
+    * * Field Name: ActionItem
+    * * Display Name: Action Item
+    * * SQL Data Type: nvarchar(255)
+    */
+    get ActionItem(): string | null {
+        return this.Get('ActionItem');
+    }
+
+    /**
+    * * Field Name: Artifact
+    * * Display Name: Artifact
+    * * SQL Data Type: nvarchar(255)
+    */
+    get Artifact(): string | null {
+        return this.Get('Artifact');
+    }
+
+    /**
+    * * Field Name: ParentComment
+    * * Display Name: Parent Comment
+    * * SQL Data Type: nvarchar(MAX)
+    */
+    get ParentComment(): string | null {
+        return this.Get('ParentComment');
+    }
+
+    /**
+    * * Field Name: Person
+    * * Display Name: Person
+    * * SQL Data Type: nvarchar(100)
+    */
+    get Person(): string {
+        return this.Get('Person');
+    }
+
+    /**
+    * * Field Name: RootParentCommentID
+    * * Display Name: Root Parent Comment
+    * * SQL Data Type: uniqueidentifier
+    */
+    get RootParentCommentID(): string | null {
+        return this.Get('RootParentCommentID');
+    }
+}
+
+
+/**
+ * Committees - strongly typed entity sub-class
+ * * Schema: __mj_Committees
+ * * Base Table: Committee
+ * * Base View: vwCommittees
+ * * @description Core committee records with hierarchy support
+ * * Primary Key: ID
+ * @extends {BaseEntity}
+ * @class
+ * @public
+ */
+@RegisterClass(BaseEntity, 'Committees')
+export class mjCommitteesCommitteeEntity extends BaseEntity<mjCommitteesCommitteeEntityType> {
+    /**
+    * Loads the Committees record from the database
+    * @param ID: string - primary key value to load the Committees record.
+    * @param EntityRelationshipsToLoad - (optional) the relationships to load
+    * @returns {Promise<boolean>} - true if successful, false otherwise
+    * @public
+    * @async
+    * @memberof mjCommitteesCommitteeEntity
+    * @method
+    * @override
+    */
+    public async Load(ID: string, EntityRelationshipsToLoad?: string[]) : Promise<boolean> {
+        const compositeKey: CompositeKey = new CompositeKey();
+        compositeKey.KeyValuePairs.push({ FieldName: 'ID', Value: ID });
+        return await super.InnerLoad(compositeKey, EntityRelationshipsToLoad);
+    }
+
+    /**
+    * * Field Name: ID
+    * * Display Name: ID
+    * * SQL Data Type: uniqueidentifier
+    * * Default Value: newsequentialid()
+    */
+    get ID(): string {
+        return this.Get('ID');
+    }
+    set ID(value: string) {
+        this.Set('ID', value);
+    }
+
+    /**
+    * * Field Name: Name
+    * * Display Name: Committee Name
+    * * SQL Data Type: nvarchar(255)
+    * * Description: Official name of the committee
+    */
+    get Name(): string {
+        return this.Get('Name');
+    }
+    set Name(value: string) {
+        this.Set('Name', value);
+    }
+
+    /**
+    * * Field Name: Description
+    * * Display Name: Description
+    * * SQL Data Type: nvarchar(MAX)
+    * * Description: Detailed description of the committee purpose and scope
+    */
+    get Description(): string | null {
+        return this.Get('Description');
+    }
+    set Description(value: string | null) {
+        this.Set('Description', value);
+    }
+
+    /**
+    * * Field Name: TypeID
+    * * Display Name: Committee Type ID
+    * * SQL Data Type: uniqueidentifier
+    * * Related Entity/Foreign Key: Types (vwTypes.ID)
+    */
+    get TypeID(): string {
+        return this.Get('TypeID');
+    }
+    set TypeID(value: string) {
+        this.Set('TypeID', value);
+    }
+
+    /**
+    * * Field Name: ParentCommitteeID
+    * * Display Name: Parent Committee ID
+    * * SQL Data Type: uniqueidentifier
+    * * Related Entity/Foreign Key: Committees (vwCommittees.ID)
+    */
+    get ParentCommitteeID(): string | null {
+        return this.Get('ParentCommitteeID');
+    }
+    set ParentCommitteeID(value: string | null) {
+        this.Set('ParentCommitteeID', value);
+    }
+
+    /**
+    * * Field Name: OrganizationID
+    * * Display Name: Organization ID
+    * * SQL Data Type: uniqueidentifier
+    * * Related Entity/Foreign Key: Organizations (vwOrganizations.ID)
+    */
+    get OrganizationID(): string | null {
+        return this.Get('OrganizationID');
+    }
+    set OrganizationID(value: string | null) {
+        this.Set('OrganizationID', value);
+    }
+
+    /**
+    * * Field Name: CharterDocumentURL
+    * * Display Name: Charter Document URL
+    * * SQL Data Type: nvarchar(1000)
+    * * Description: URL to the committee charter document
+    */
+    get CharterDocumentURL(): string | null {
+        return this.Get('CharterDocumentURL');
+    }
+    set CharterDocumentURL(value: string | null) {
+        this.Set('CharterDocumentURL', value);
+    }
+
+    /**
+    * * Field Name: MissionStatement
+    * * Display Name: Mission Statement
+    * * SQL Data Type: nvarchar(MAX)
+    * * Description: Brief statement of the committee mission
+    */
+    get MissionStatement(): string | null {
+        return this.Get('MissionStatement');
+    }
+    set MissionStatement(value: string | null) {
+        this.Set('MissionStatement', value);
+    }
+
+    /**
+    * * Field Name: Status
+    * * Display Name: Status
+    * * SQL Data Type: nvarchar(50)
+    * * Default Value: Active
+    * * Value List Type: List
+    * * Possible Values 
+    *   * Active
+    *   * Dissolved
+    *   * Inactive
+    *   * Pending
+    * * Description: Current status: Active, Inactive, Pending, or Dissolved
+    */
+    get Status(): 'Active' | 'Dissolved' | 'Inactive' | 'Pending' {
+        return this.Get('Status');
+    }
+    set Status(value: 'Active' | 'Dissolved' | 'Inactive' | 'Pending') {
+        this.Set('Status', value);
+    }
+
+    /**
+    * * Field Name: IsPublic
+    * * Display Name: Is Public
+    * * SQL Data Type: bit
+    * * Default Value: 1
+    * * Description: Whether the committee is visible to all users
+    */
+    get IsPublic(): boolean {
+        return this.Get('IsPublic');
+    }
+    set IsPublic(value: boolean) {
+        this.Set('IsPublic', value);
+    }
+
+    /**
+    * * Field Name: FormationDate
+    * * Display Name: Formation Date
+    * * SQL Data Type: date
+    * * Description: Date the committee was formed
+    */
+    get FormationDate(): Date | null {
+        return this.Get('FormationDate');
+    }
+    set FormationDate(value: Date | null) {
+        this.Set('FormationDate', value);
+    }
+
+    /**
+    * * Field Name: DissolutionDate
+    * * Display Name: Dissolution Date
+    * * SQL Data Type: date
+    * * Description: Date the committee was dissolved, if applicable
+    */
+    get DissolutionDate(): Date | null {
+        return this.Get('DissolutionDate');
+    }
+    set DissolutionDate(value: Date | null) {
+        this.Set('DissolutionDate', value);
+    }
+
+    /**
+    * * Field Name: __mj_CreatedAt
+    * * Display Name: Created At
+    * * SQL Data Type: datetimeoffset
+    * * Default Value: getutcdate()
+    */
+    get __mj_CreatedAt(): Date {
+        return this.Get('__mj_CreatedAt');
+    }
+
+    /**
+    * * Field Name: __mj_UpdatedAt
+    * * Display Name: Updated At
+    * * SQL Data Type: datetimeoffset
+    * * Default Value: getutcdate()
+    */
+    get __mj_UpdatedAt(): Date {
+        return this.Get('__mj_UpdatedAt');
+    }
+
+    /**
+    * * Field Name: Type
+    * * Display Name: Type
+    * * SQL Data Type: nvarchar(100)
+    */
+    get Type(): string {
+        return this.Get('Type');
+    }
+
+    /**
+    * * Field Name: ParentCommittee
+    * * Display Name: Parent Committee
+    * * SQL Data Type: nvarchar(255)
+    */
+    get ParentCommittee(): string | null {
+        return this.Get('ParentCommittee');
+    }
+
+    /**
+    * * Field Name: Organization
+    * * Display Name: Organization
+    * * SQL Data Type: nvarchar(255)
+    */
+    get Organization(): string | null {
+        return this.Get('Organization');
+    }
+
+    /**
+    * * Field Name: RootParentCommitteeID
+    * * Display Name: Root Parent Committee ID
+    * * SQL Data Type: uniqueidentifier
+    */
+    get RootParentCommitteeID(): string | null {
+        return this.Get('RootParentCommitteeID');
+    }
+}
+
+
+/**
+ * Contact Methods - strongly typed entity sub-class
+ * * Schema: __mj_BizAppsCommon
+ * * Base Table: ContactMethod
+ * * Base View: vwContactMethods
+ * * @description Additional contact methods for people and organizations beyond the primary email and phone fields
+ * * Primary Key: ID
+ * @extends {BaseEntity}
+ * @class
+ * @public
+ */
+@RegisterClass(BaseEntity, 'Contact Methods')
+export class mjBizAppsCommonContactMethodEntity extends BaseEntity<mjBizAppsCommonContactMethodEntityType> {
+    /**
+    * Loads the Contact Methods record from the database
+    * @param ID: string - primary key value to load the Contact Methods record.
+    * @param EntityRelationshipsToLoad - (optional) the relationships to load
+    * @returns {Promise<boolean>} - true if successful, false otherwise
+    * @public
+    * @async
+    * @memberof mjBizAppsCommonContactMethodEntity
+    * @method
+    * @override
+    */
+    public async Load(ID: string, EntityRelationshipsToLoad?: string[]) : Promise<boolean> {
+        const compositeKey: CompositeKey = new CompositeKey();
+        compositeKey.KeyValuePairs.push({ FieldName: 'ID', Value: ID });
+        return await super.InnerLoad(compositeKey, EntityRelationshipsToLoad);
+    }
+
+    /**
+    * Validate() method override for Contact Methods entity. This is an auto-generated method that invokes the generated validators for this entity for the following fields:
+    * * Table-Level: Each record must be linked to either a person or an organization. At least one of PersonID or OrganizationID must have a value so the contact can be identified correctly.
+    * @public
+    * @method
+    * @override
+    */
+    public override Validate(): ValidationResult {
+        const result = super.Validate();
+        this.ValidatePersonOrOrganizationPresence(result);
+        result.Success = result.Success && (result.Errors.length === 0);
+
+        return result;
+    }
+
+    /**
+    * Each record must be linked to either a person or an organization. At least one of PersonID or OrganizationID must have a value so the contact can be identified correctly.
+    * @param result - the ValidationResult object to add any errors or warnings to
+    * @public
+    * @method
+    */
+    public ValidatePersonOrOrganizationPresence(result: ValidationResult) {
+    	// Ensure the contact is associated with a person or an organization
+    	if (this.PersonID == null && this.OrganizationID == null) {
+    		result.Errors.push(new ValidationErrorInfo(
+    			"PersonID",
+    			"Either PersonID or OrganizationID must be provided. The record must be associated with a person or an organization.",
+    			this.PersonID,
+    			ValidationErrorType.Failure
+    		));
+    	}
+    }
+
+    /**
+    * * Field Name: ID
+    * * Display Name: ID
+    * * SQL Data Type: uniqueidentifier
+    * * Default Value: newsequentialid()
+    */
+    get ID(): string {
+        return this.Get('ID');
+    }
+    set ID(value: string) {
+        this.Set('ID', value);
+    }
+
+    /**
+    * * Field Name: PersonID
+    * * Display Name: Person
+    * * SQL Data Type: uniqueidentifier
+    * * Related Entity/Foreign Key: People (vwPeople.ID)
+    */
+    get PersonID(): string | null {
+        return this.Get('PersonID');
+    }
+    set PersonID(value: string | null) {
+        this.Set('PersonID', value);
+    }
+
+    /**
+    * * Field Name: OrganizationID
+    * * Display Name: Organization
+    * * SQL Data Type: uniqueidentifier
+    * * Related Entity/Foreign Key: Organizations (vwOrganizations.ID)
+    */
+    get OrganizationID(): string | null {
+        return this.Get('OrganizationID');
+    }
+    set OrganizationID(value: string | null) {
+        this.Set('OrganizationID', value);
+    }
+
+    /**
+    * * Field Name: ContactTypeID
+    * * Display Name: Contact Type
+    * * SQL Data Type: uniqueidentifier
+    * * Related Entity/Foreign Key: Contact Types (vwContactTypes.ID)
+    */
+    get ContactTypeID(): string {
+        return this.Get('ContactTypeID');
+    }
+    set ContactTypeID(value: string) {
+        this.Set('ContactTypeID', value);
+    }
+
+    /**
+    * * Field Name: Value
+    * * Display Name: Value
+    * * SQL Data Type: nvarchar(500)
+    * * Description: The contact value: phone number, email address, URL, social media handle, etc.
+    */
+    get Value(): string {
+        return this.Get('Value');
+    }
+    set Value(value: string) {
+        this.Set('Value', value);
+    }
+
+    /**
+    * * Field Name: Label
+    * * Display Name: Label
+    * * SQL Data Type: nvarchar(100)
+    * * Description: Descriptive label such as Work cell, Personal Gmail, Corporate LinkedIn
+    */
+    get Label(): string | null {
+        return this.Get('Label');
+    }
+    set Label(value: string | null) {
+        this.Set('Label', value);
+    }
+
+    /**
+    * * Field Name: IsPrimary
+    * * Display Name: Is Primary
+    * * SQL Data Type: bit
+    * * Default Value: 0
+    * * Description: Whether this is the primary contact method of its type for the linked person or organization
+    */
+    get IsPrimary(): boolean {
+        return this.Get('IsPrimary');
+    }
+    set IsPrimary(value: boolean) {
+        this.Set('IsPrimary', value);
+    }
+
+    /**
+    * * Field Name: __mj_CreatedAt
+    * * Display Name: Created At
+    * * SQL Data Type: datetimeoffset
+    * * Default Value: getutcdate()
+    */
+    get __mj_CreatedAt(): Date {
+        return this.Get('__mj_CreatedAt');
+    }
+
+    /**
+    * * Field Name: __mj_UpdatedAt
+    * * Display Name: Updated At
+    * * SQL Data Type: datetimeoffset
+    * * Default Value: getutcdate()
+    */
+    get __mj_UpdatedAt(): Date {
+        return this.Get('__mj_UpdatedAt');
+    }
+
+    /**
+    * * Field Name: Person
+    * * Display Name: Person
+    * * SQL Data Type: nvarchar(100)
+    */
+    get Person(): string | null {
+        return this.Get('Person');
+    }
+
+    /**
+    * * Field Name: Organization
+    * * Display Name: Organization
+    * * SQL Data Type: nvarchar(255)
+    */
+    get Organization(): string | null {
+        return this.Get('Organization');
+    }
+
+    /**
+    * * Field Name: ContactType
+    * * Display Name: Contact Type
+    * * SQL Data Type: nvarchar(100)
+    */
+    get ContactType(): string {
+        return this.Get('ContactType');
+    }
+}
+
+
+/**
+ * Contact Types - strongly typed entity sub-class
+ * * Schema: __mj_BizAppsCommon
+ * * Base Table: ContactType
+ * * Base View: vwContactTypes
+ * * @description Categories of contact methods such as Phone, Mobile, Email, LinkedIn, Website
+ * * Primary Key: ID
+ * @extends {BaseEntity}
+ * @class
+ * @public
+ */
+@RegisterClass(BaseEntity, 'Contact Types')
+export class mjBizAppsCommonContactTypeEntity extends BaseEntity<mjBizAppsCommonContactTypeEntityType> {
+    /**
+    * Loads the Contact Types record from the database
+    * @param ID: string - primary key value to load the Contact Types record.
+    * @param EntityRelationshipsToLoad - (optional) the relationships to load
+    * @returns {Promise<boolean>} - true if successful, false otherwise
+    * @public
+    * @async
+    * @memberof mjBizAppsCommonContactTypeEntity
+    * @method
+    * @override
+    */
+    public async Load(ID: string, EntityRelationshipsToLoad?: string[]) : Promise<boolean> {
+        const compositeKey: CompositeKey = new CompositeKey();
+        compositeKey.KeyValuePairs.push({ FieldName: 'ID', Value: ID });
+        return await super.InnerLoad(compositeKey, EntityRelationshipsToLoad);
+    }
+
+    /**
+    * * Field Name: ID
+    * * Display Name: ID
+    * * SQL Data Type: uniqueidentifier
+    * * Default Value: newsequentialid()
+    */
+    get ID(): string {
+        return this.Get('ID');
+    }
+    set ID(value: string) {
+        this.Set('ID', value);
+    }
+
+    /**
+    * * Field Name: Name
+    * * Display Name: Name
+    * * SQL Data Type: nvarchar(100)
+    * * Description: Display name for the contact type
+    */
+    get Name(): string {
+        return this.Get('Name');
+    }
+    set Name(value: string) {
+        this.Set('Name', value);
+    }
+
+    /**
+    * * Field Name: Description
+    * * Display Name: Description
+    * * SQL Data Type: nvarchar(MAX)
+    * * Description: Detailed description of this contact type
+    */
+    get Description(): string | null {
+        return this.Get('Description');
+    }
+    set Description(value: string | null) {
+        this.Set('Description', value);
+    }
+
+    /**
+    * * Field Name: IconClass
+    * * Display Name: Icon Class
+    * * SQL Data Type: nvarchar(100)
+    * * Description: Font Awesome icon class for UI display
+    */
+    get IconClass(): string | null {
+        return this.Get('IconClass');
+    }
+    set IconClass(value: string | null) {
+        this.Set('IconClass', value);
+    }
+
+    /**
+    * * Field Name: __mj_CreatedAt
+    * * Display Name: Created At
+    * * SQL Data Type: datetimeoffset
+    * * Default Value: getutcdate()
+    */
+    get __mj_CreatedAt(): Date {
+        return this.Get('__mj_CreatedAt');
+    }
+
+    /**
+    * * Field Name: __mj_UpdatedAt
+    * * Display Name: Updated At
+    * * SQL Data Type: datetimeoffset
+    * * Default Value: getutcdate()
+    */
+    get __mj_UpdatedAt(): Date {
+        return this.Get('__mj_UpdatedAt');
+    }
+}
+
+
+/**
+ * Meetings - strongly typed entity sub-class
+ * * Schema: __mj_Committees
+ * * Base Table: Meeting
+ * * Base View: vwMeetings
+ * * @description Committee meeting records with scheduling and video conferencing info
+ * * Primary Key: ID
+ * @extends {BaseEntity}
+ * @class
+ * @public
+ */
+@RegisterClass(BaseEntity, 'Meetings')
+export class mjCommitteesMeetingEntity extends BaseEntity<mjCommitteesMeetingEntityType> {
+    /**
+    * Loads the Meetings record from the database
+    * @param ID: string - primary key value to load the Meetings record.
+    * @param EntityRelationshipsToLoad - (optional) the relationships to load
+    * @returns {Promise<boolean>} - true if successful, false otherwise
+    * @public
+    * @async
+    * @memberof mjCommitteesMeetingEntity
+    * @method
+    * @override
+    */
+    public async Load(ID: string, EntityRelationshipsToLoad?: string[]) : Promise<boolean> {
+        const compositeKey: CompositeKey = new CompositeKey();
+        compositeKey.KeyValuePairs.push({ FieldName: 'ID', Value: ID });
+        return await super.InnerLoad(compositeKey, EntityRelationshipsToLoad);
+    }
+
+    /**
+    * * Field Name: ID
+    * * Display Name: ID
+    * * SQL Data Type: uniqueidentifier
+    * * Default Value: newsequentialid()
+    */
+    get ID(): string {
+        return this.Get('ID');
+    }
+    set ID(value: string) {
+        this.Set('ID', value);
+    }
+
+    /**
+    * * Field Name: CommitteeID
+    * * Display Name: Committee
+    * * SQL Data Type: uniqueidentifier
+    * * Related Entity/Foreign Key: Committees (vwCommittees.ID)
+    */
+    get CommitteeID(): string {
+        return this.Get('CommitteeID');
+    }
+    set CommitteeID(value: string) {
+        this.Set('CommitteeID', value);
+    }
+
+    /**
+    * * Field Name: Title
+    * * Display Name: Title
+    * * SQL Data Type: nvarchar(255)
+    * * Description: Title of the meeting
+    */
+    get Title(): string {
+        return this.Get('Title');
+    }
+    set Title(value: string) {
+        this.Set('Title', value);
+    }
+
+    /**
+    * * Field Name: Description
+    * * Display Name: Description
+    * * SQL Data Type: nvarchar(MAX)
+    * * Description: Detailed description or purpose of the meeting
+    */
+    get Description(): string | null {
+        return this.Get('Description');
+    }
+    set Description(value: string | null) {
+        this.Set('Description', value);
+    }
+
+    /**
+    * * Field Name: StartDateTime
+    * * Display Name: Start Date & Time
+    * * SQL Data Type: datetimeoffset
+    * * Description: Scheduled start date and time with timezone offset
+    */
+    get StartDateTime(): Date {
+        return this.Get('StartDateTime');
+    }
+    set StartDateTime(value: Date) {
+        this.Set('StartDateTime', value);
+    }
+
+    /**
+    * * Field Name: EndDateTime
+    * * Display Name: End Date & Time
+    * * SQL Data Type: datetimeoffset
+    * * Description: Scheduled end date and time with timezone offset
+    */
+    get EndDateTime(): Date | null {
+        return this.Get('EndDateTime');
+    }
+    set EndDateTime(value: Date | null) {
+        this.Set('EndDateTime', value);
+    }
+
+    /**
+    * * Field Name: TimeZone
+    * * Display Name: Time Zone
+    * * SQL Data Type: nvarchar(50)
+    * * Default Value: America/New_York
+    * * Description: IANA timezone identifier for the meeting
+    */
+    get TimeZone(): string {
+        return this.Get('TimeZone');
+    }
+    set TimeZone(value: string) {
+        this.Set('TimeZone', value);
+    }
+
+    /**
+    * * Field Name: LocationType
+    * * Display Name: Location Type
+    * * SQL Data Type: nvarchar(50)
+    * * Default Value: Virtual
+    * * Value List Type: List
+    * * Possible Values 
+    *   * Hybrid
+    *   * InPerson
+    *   * Virtual
+    * * Description: Meeting format: Virtual, InPerson, or Hybrid
+    */
+    get LocationType(): 'Hybrid' | 'InPerson' | 'Virtual' {
+        return this.Get('LocationType');
+    }
+    set LocationType(value: 'Hybrid' | 'InPerson' | 'Virtual') {
+        this.Set('LocationType', value);
+    }
+
+    /**
+    * * Field Name: LocationText
+    * * Display Name: Location
+    * * SQL Data Type: nvarchar(500)
+    * * Description: Physical address or room name for in-person meetings
+    */
+    get LocationText(): string | null {
+        return this.Get('LocationText');
+    }
+    set LocationText(value: string | null) {
+        this.Set('LocationText', value);
+    }
+
+    /**
+    * * Field Name: VideoProvider
+    * * Display Name: Video Provider
+    * * SQL Data Type: nvarchar(50)
+    * * Description: Video conferencing provider: Zoom, Teams, Meet, etc.
+    */
+    get VideoProvider(): string | null {
+        return this.Get('VideoProvider');
+    }
+    set VideoProvider(value: string | null) {
+        this.Set('VideoProvider', value);
+    }
+
+    /**
+    * * Field Name: VideoMeetingID
+    * * Display Name: Video Meeting ID
+    * * SQL Data Type: nvarchar(255)
+    * * Description: External meeting ID from the video provider
+    */
+    get VideoMeetingID(): string | null {
+        return this.Get('VideoMeetingID');
+    }
+    set VideoMeetingID(value: string | null) {
+        this.Set('VideoMeetingID', value);
+    }
+
+    /**
+    * * Field Name: VideoJoinURL
+    * * Display Name: Join URL
+    * * SQL Data Type: nvarchar(1000)
+    * * Description: URL to join the video meeting
+    */
+    get VideoJoinURL(): string | null {
+        return this.Get('VideoJoinURL');
+    }
+    set VideoJoinURL(value: string | null) {
+        this.Set('VideoJoinURL', value);
+    }
+
+    /**
+    * * Field Name: VideoRecordingURL
+    * * Display Name: Recording URL
+    * * SQL Data Type: nvarchar(1000)
+    * * Description: URL to the meeting recording after completion
+    */
+    get VideoRecordingURL(): string | null {
+        return this.Get('VideoRecordingURL');
+    }
+    set VideoRecordingURL(value: string | null) {
+        this.Set('VideoRecordingURL', value);
+    }
+
+    /**
+    * * Field Name: TranscriptURL
+    * * Display Name: Transcript URL
+    * * SQL Data Type: nvarchar(1000)
+    * * Description: URL to the meeting transcript
+    */
+    get TranscriptURL(): string | null {
+        return this.Get('TranscriptURL');
+    }
+    set TranscriptURL(value: string | null) {
+        this.Set('TranscriptURL', value);
+    }
+
+    /**
+    * * Field Name: Status
+    * * Display Name: Status
+    * * SQL Data Type: nvarchar(50)
+    * * Default Value: Scheduled
+    * * Value List Type: List
+    * * Possible Values 
+    *   * Cancelled
+    *   * Completed
+    *   * Draft
+    *   * InProgress
+    *   * Postponed
+    *   * Scheduled
+    * * Description: Current status: Draft, Scheduled, InProgress, Completed, Cancelled, Postponed
+    */
+    get Status(): 'Cancelled' | 'Completed' | 'Draft' | 'InProgress' | 'Postponed' | 'Scheduled' {
+        return this.Get('Status');
+    }
+    set Status(value: 'Cancelled' | 'Completed' | 'Draft' | 'InProgress' | 'Postponed' | 'Scheduled') {
+        this.Set('Status', value);
+    }
+
+    /**
+    * * Field Name: CalendarEventID
+    * * Display Name: Calendar Event ID
+    * * SQL Data Type: nvarchar(255)
+    * * Description: External calendar event ID for sync purposes
+    */
+    get CalendarEventID(): string | null {
+        return this.Get('CalendarEventID');
+    }
+    set CalendarEventID(value: string | null) {
+        this.Set('CalendarEventID', value);
+    }
+
+    /**
+    * * Field Name: VideoProviderID
+    * * Display Name: Video Provider
+    * * SQL Data Type: uniqueidentifier
+    * * Related Entity/Foreign Key: Video Providers (vwVideoProviders.ID)
+    * * Description: FK to VideoProvider — when set, video meeting URL is auto-created on save
+    */
+    get VideoProviderID(): string | null {
+        return this.Get('VideoProviderID');
+    }
+    set VideoProviderID(value: string | null) {
+        this.Set('VideoProviderID', value);
+    }
+
+    /**
+    * * Field Name: __mj_CreatedAt
+    * * Display Name: Created At
+    * * SQL Data Type: datetimeoffset
+    * * Default Value: getutcdate()
+    */
+    get __mj_CreatedAt(): Date {
+        return this.Get('__mj_CreatedAt');
+    }
+
+    /**
+    * * Field Name: __mj_UpdatedAt
+    * * Display Name: Updated At
+    * * SQL Data Type: datetimeoffset
+    * * Default Value: getutcdate()
+    */
+    get __mj_UpdatedAt(): Date {
+        return this.Get('__mj_UpdatedAt');
+    }
+
+    /**
+    * * Field Name: Committee
+    * * Display Name: Committee Name
+    * * SQL Data Type: nvarchar(255)
+    */
+    get Committee(): string {
+        return this.Get('Committee');
+    }
+
+    /**
+    * * Field Name: VideoProvider_Virtual
+    * * Display Name: Virtual Video Provider
+    * * SQL Data Type: nvarchar(100)
+    */
+    get VideoProvider_Virtual(): string | null {
+        return this.Get('VideoProvider_Virtual');
+    }
+}
+
+
+/**
+ * Memberships - strongly typed entity sub-class
+ * * Schema: __mj_Committees
+ * * Base Table: Membership
+ * * Base View: vwMemberships
+ * * @description Person assignments to committees with roles and terms
+ * * Primary Key: ID
+ * @extends {BaseEntity}
+ * @class
+ * @public
+ */
+@RegisterClass(BaseEntity, 'Memberships')
+export class mjCommitteesMembershipEntity extends BaseEntity<mjCommitteesMembershipEntityType> {
+    /**
+    * Loads the Memberships record from the database
+    * @param ID: string - primary key value to load the Memberships record.
+    * @param EntityRelationshipsToLoad - (optional) the relationships to load
+    * @returns {Promise<boolean>} - true if successful, false otherwise
+    * @public
+    * @async
+    * @memberof mjCommitteesMembershipEntity
+    * @method
+    * @override
+    */
+    public async Load(ID: string, EntityRelationshipsToLoad?: string[]) : Promise<boolean> {
+        const compositeKey: CompositeKey = new CompositeKey();
+        compositeKey.KeyValuePairs.push({ FieldName: 'ID', Value: ID });
+        return await super.InnerLoad(compositeKey, EntityRelationshipsToLoad);
+    }
+
+    /**
+    * * Field Name: ID
+    * * Display Name: ID
+    * * SQL Data Type: uniqueidentifier
+    * * Default Value: newsequentialid()
+    */
+    get ID(): string {
+        return this.Get('ID');
+    }
+    set ID(value: string) {
+        this.Set('ID', value);
+    }
+
+    /**
+    * * Field Name: PersonID
+    * * Display Name: Person
+    * * SQL Data Type: uniqueidentifier
+    * * Related Entity/Foreign Key: People (vwPeople.ID)
+    */
+    get PersonID(): string {
+        return this.Get('PersonID');
+    }
+    set PersonID(value: string) {
+        this.Set('PersonID', value);
+    }
+
+    /**
+    * * Field Name: RoleID
+    * * Display Name: Role
+    * * SQL Data Type: uniqueidentifier
+    * * Related Entity/Foreign Key: Roles (vwRoles.ID)
+    */
+    get RoleID(): string {
+        return this.Get('RoleID');
+    }
+    set RoleID(value: string) {
+        this.Set('RoleID', value);
+    }
+
+    /**
+    * * Field Name: TermID
+    * * Display Name: Term
+    * * SQL Data Type: uniqueidentifier
+    * * Related Entity/Foreign Key: Terms (vwTerms.ID)
+    */
+    get TermID(): string {
+        return this.Get('TermID');
+    }
+    set TermID(value: string) {
+        this.Set('TermID', value);
+    }
+
+    /**
+    * * Field Name: StartDate
+    * * Display Name: Start Date
+    * * SQL Data Type: date
+    * * Description: Date the membership started
+    */
+    get StartDate(): Date {
+        return this.Get('StartDate');
+    }
+    set StartDate(value: Date) {
+        this.Set('StartDate', value);
+    }
+
+    /**
+    * * Field Name: EndDate
+    * * Display Name: End Date
+    * * SQL Data Type: date
+    * * Description: Date the membership ended, if applicable
+    */
+    get EndDate(): Date | null {
+        return this.Get('EndDate');
+    }
+    set EndDate(value: Date | null) {
+        this.Set('EndDate', value);
+    }
+
+    /**
+    * * Field Name: Status
+    * * Display Name: Status
+    * * SQL Data Type: nvarchar(50)
+    * * Default Value: Active
+    * * Value List Type: List
+    * * Possible Values 
+    *   * Active
+    *   * Ended
+    *   * Pending
+    *   * Suspended
+    * * Description: Current status: Active, Pending, Ended, or Suspended
+    */
+    get Status(): 'Active' | 'Ended' | 'Pending' | 'Suspended' {
+        return this.Get('Status');
+    }
+    set Status(value: 'Active' | 'Ended' | 'Pending' | 'Suspended') {
+        this.Set('Status', value);
+    }
+
+    /**
+    * * Field Name: EndReason
+    * * Display Name: End Reason
+    * * SQL Data Type: nvarchar(100)
+    * * Description: Reason the membership ended: Term ended, Resigned, Removed, etc.
+    */
+    get EndReason(): string | null {
+        return this.Get('EndReason');
+    }
+    set EndReason(value: string | null) {
+        this.Set('EndReason', value);
+    }
+
+    /**
+    * * Field Name: Notes
+    * * Display Name: Notes
+    * * SQL Data Type: nvarchar(MAX)
+    * * Description: Additional notes about this membership
+    */
+    get Notes(): string | null {
+        return this.Get('Notes');
+    }
+    set Notes(value: string | null) {
+        this.Set('Notes', value);
+    }
+
+    /**
+    * * Field Name: __mj_CreatedAt
+    * * Display Name: Created At
+    * * SQL Data Type: datetimeoffset
+    * * Default Value: getutcdate()
+    */
+    get __mj_CreatedAt(): Date {
+        return this.Get('__mj_CreatedAt');
+    }
+
+    /**
+    * * Field Name: __mj_UpdatedAt
+    * * Display Name: Updated At
+    * * SQL Data Type: datetimeoffset
+    * * Default Value: getutcdate()
+    */
+    get __mj_UpdatedAt(): Date {
+        return this.Get('__mj_UpdatedAt');
+    }
+
+    /**
+    * * Field Name: Person
+    * * Display Name: Person
+    * * SQL Data Type: nvarchar(100)
+    */
+    get Person(): string {
+        return this.Get('Person');
+    }
+
+    /**
+    * * Field Name: Role
+    * * Display Name: Role
+    * * SQL Data Type: nvarchar(100)
+    */
+    get Role(): string {
+        return this.Get('Role');
+    }
+
+    /**
+    * * Field Name: Term
+    * * Display Name: Term
+    * * SQL Data Type: nvarchar(100)
+    */
+    get Term(): string {
+        return this.Get('Term');
+    }
+}
+
+
+/**
+ * Minutes - strongly typed entity sub-class
+ * * Schema: __mj_Committees
+ * * Base Table: Minute
+ * * Base View: vwMinutes
+ * * @description Extension entity for Minutes artifacts with approval tracking
+ * * Primary Key: ID
+ * @extends {BaseEntity}
+ * @class
+ * @public
+ */
+@RegisterClass(BaseEntity, 'Minutes')
+export class mjCommitteesMinuteEntity extends BaseEntity<mjCommitteesMinuteEntityType> {
+    /**
+    * Loads the Minutes record from the database
+    * @param ID: string - primary key value to load the Minutes record.
+    * @param EntityRelationshipsToLoad - (optional) the relationships to load
+    * @returns {Promise<boolean>} - true if successful, false otherwise
+    * @public
+    * @async
+    * @memberof mjCommitteesMinuteEntity
+    * @method
+    * @override
+    */
+    public async Load(ID: string, EntityRelationshipsToLoad?: string[]) : Promise<boolean> {
+        const compositeKey: CompositeKey = new CompositeKey();
+        compositeKey.KeyValuePairs.push({ FieldName: 'ID', Value: ID });
+        return await super.InnerLoad(compositeKey, EntityRelationshipsToLoad);
+    }
+
+    /**
+    * * Field Name: ID
+    * * Display Name: ID
+    * * SQL Data Type: uniqueidentifier
+    * * Default Value: newsequentialid()
+    */
+    get ID(): string {
+        return this.Get('ID');
+    }
+    set ID(value: string) {
+        this.Set('ID', value);
+    }
+
+    /**
+    * * Field Name: ArtifactID
+    * * Display Name: Artifact
+    * * SQL Data Type: uniqueidentifier
+    */
+    get ArtifactID(): string | null {
+        return this.Get('ArtifactID');
+    }
+    set ArtifactID(value: string | null) {
+        this.Set('ArtifactID', value);
+    }
+
+    /**
+    * * Field Name: ApprovalStatus
+    * * Display Name: Approval Status
+    * * SQL Data Type: nvarchar(50)
+    * * Default Value: Draft
+    * * Value List Type: List
+    * * Possible Values 
+    *   * Approved
+    *   * Draft
+    *   * PendingApproval
+    *   * Rejected
+    * * Description: Current approval status: Draft, PendingApproval, Approved, Rejected
+    */
+    get ApprovalStatus(): 'Approved' | 'Draft' | 'PendingApproval' | 'Rejected' {
+        return this.Get('ApprovalStatus');
+    }
+    set ApprovalStatus(value: 'Approved' | 'Draft' | 'PendingApproval' | 'Rejected') {
+        this.Set('ApprovalStatus', value);
+    }
+
+    /**
+    * * Field Name: ApprovedAt
+    * * Display Name: Approved At
+    * * SQL Data Type: datetimeoffset
+    * * Description: Timestamp when the minutes were approved
+    */
+    get ApprovedAt(): Date | null {
+        return this.Get('ApprovedAt');
+    }
+    set ApprovedAt(value: Date | null) {
+        this.Set('ApprovedAt', value);
+    }
+
+    /**
+    * * Field Name: ApprovedByMeetingID
+    * * Display Name: Approved By Meeting
+    * * SQL Data Type: uniqueidentifier
+    * * Related Entity/Foreign Key: Meetings (vwMeetings.ID)
+    * * Description: Reference to the meeting at which these minutes were approved (typically the next meeting)
+    */
+    get ApprovedByMeetingID(): string | null {
+        return this.Get('ApprovedByMeetingID');
+    }
+    set ApprovedByMeetingID(value: string | null) {
+        this.Set('ApprovedByMeetingID', value);
+    }
+
+    /**
+    * * Field Name: Notes
+    * * Display Name: Notes
+    * * SQL Data Type: nvarchar(MAX)
+    * * Description: Additional notes about the minutes
+    */
+    get Notes(): string | null {
+        return this.Get('Notes');
+    }
+    set Notes(value: string | null) {
+        this.Set('Notes', value);
+    }
+
+    /**
+    * * Field Name: MeetingID
+    * * Display Name: Meeting
+    * * SQL Data Type: uniqueidentifier
+    * * Related Entity/Foreign Key: Meetings (vwMeetings.ID)
+    */
+    get MeetingID(): string | null {
+        return this.Get('MeetingID');
+    }
+    set MeetingID(value: string | null) {
+        this.Set('MeetingID', value);
+    }
+
+    /**
+    * * Field Name: Content
+    * * Display Name: Content
+    * * SQL Data Type: nvarchar(MAX)
+    */
+    get Content(): string | null {
+        return this.Get('Content');
+    }
+    set Content(value: string | null) {
+        this.Set('Content', value);
+    }
+
+    /**
+    * * Field Name: __mj_CreatedAt
+    * * Display Name: Created At
+    * * SQL Data Type: datetimeoffset
+    * * Default Value: getutcdate()
+    */
+    get __mj_CreatedAt(): Date {
+        return this.Get('__mj_CreatedAt');
+    }
+
+    /**
+    * * Field Name: __mj_UpdatedAt
+    * * Display Name: Updated At
+    * * SQL Data Type: datetimeoffset
+    * * Default Value: getutcdate()
+    */
+    get __mj_UpdatedAt(): Date {
+        return this.Get('__mj_UpdatedAt');
+    }
+
+    /**
+    * * Field Name: ApprovedByMeeting
+    * * Display Name: Approved By Meeting Name
+    * * SQL Data Type: nvarchar(255)
+    */
+    get ApprovedByMeeting(): string | null {
+        return this.Get('ApprovedByMeeting');
+    }
+
+    /**
+    * * Field Name: Meeting
+    * * Display Name: Meeting Name
+    * * SQL Data Type: nvarchar(255)
+    */
+    get Meeting(): string | null {
+        return this.Get('Meeting');
+    }
+}
+
+
+/**
+ * Motions - strongly typed entity sub-class
+ * * Schema: __mj_Committees
+ * * Base Table: Motion
+ * * Base View: vwMotions
+ * * @description Formal motions put to vote during committee meetings
+ * * Primary Key: ID
+ * @extends {BaseEntity}
+ * @class
+ * @public
+ */
+@RegisterClass(BaseEntity, 'Motions')
+export class mjCommitteesMotionEntity extends BaseEntity<mjCommitteesMotionEntityType> {
+    /**
+    * Loads the Motions record from the database
+    * @param ID: string - primary key value to load the Motions record.
+    * @param EntityRelationshipsToLoad - (optional) the relationships to load
+    * @returns {Promise<boolean>} - true if successful, false otherwise
+    * @public
+    * @async
+    * @memberof mjCommitteesMotionEntity
+    * @method
+    * @override
+    */
+    public async Load(ID: string, EntityRelationshipsToLoad?: string[]) : Promise<boolean> {
+        const compositeKey: CompositeKey = new CompositeKey();
+        compositeKey.KeyValuePairs.push({ FieldName: 'ID', Value: ID });
+        return await super.InnerLoad(compositeKey, EntityRelationshipsToLoad);
+    }
+
+    /**
+    * * Field Name: ID
+    * * Display Name: ID
+    * * SQL Data Type: uniqueidentifier
+    * * Default Value: newsequentialid()
+    */
+    get ID(): string {
+        return this.Get('ID');
+    }
+    set ID(value: string) {
+        this.Set('ID', value);
+    }
+
+    /**
+    * * Field Name: MeetingID
+    * * Display Name: Meeting
+    * * SQL Data Type: uniqueidentifier
+    * * Related Entity/Foreign Key: Meetings (vwMeetings.ID)
+    */
+    get MeetingID(): string {
+        return this.Get('MeetingID');
+    }
+    set MeetingID(value: string) {
+        this.Set('MeetingID', value);
+    }
+
+    /**
+    * * Field Name: AgendaItemID
+    * * Display Name: Agenda Item
+    * * SQL Data Type: uniqueidentifier
+    * * Related Entity/Foreign Key: Agenda Items (vwAgendaItems.ID)
+    */
+    get AgendaItemID(): string | null {
+        return this.Get('AgendaItemID');
+    }
+    set AgendaItemID(value: string | null) {
+        this.Set('AgendaItemID', value);
+    }
+
+    /**
+    * * Field Name: Sequence
+    * * Display Name: Sequence
+    * * SQL Data Type: int
+    * * Default Value: 1
+    * * Description: Display order when multiple motions exist for the same agenda item
+    */
+    get Sequence(): number {
+        return this.Get('Sequence');
+    }
+    set Sequence(value: number) {
+        this.Set('Sequence', value);
+    }
+
+    /**
+    * * Field Name: Title
+    * * Display Name: Title
+    * * SQL Data Type: nvarchar(255)
+    * * Description: Title of the motion
+    */
+    get Title(): string {
+        return this.Get('Title');
+    }
+    set Title(value: string) {
+        this.Set('Title', value);
+    }
+
+    /**
+    * * Field Name: Description
+    * * Display Name: Description
+    * * SQL Data Type: nvarchar(MAX)
+    * * Description: Full text or description of the motion
+    */
+    get Description(): string | null {
+        return this.Get('Description');
+    }
+    set Description(value: string | null) {
+        this.Set('Description', value);
+    }
+
+    /**
+    * * Field Name: MovedByMembershipID
+    * * Display Name: Moved By Membership
+    * * SQL Data Type: uniqueidentifier
+    * * Related Entity/Foreign Key: Memberships (vwMemberships.ID)
+    * * Description: The committee member who made the motion
+    */
+    get MovedByMembershipID(): string | null {
+        return this.Get('MovedByMembershipID');
+    }
+    set MovedByMembershipID(value: string | null) {
+        this.Set('MovedByMembershipID', value);
+    }
+
+    /**
+    * * Field Name: SecondedByMembershipID
+    * * Display Name: Seconded By Membership
+    * * SQL Data Type: uniqueidentifier
+    * * Related Entity/Foreign Key: Memberships (vwMemberships.ID)
+    * * Description: The committee member who seconded the motion
+    */
+    get SecondedByMembershipID(): string | null {
+        return this.Get('SecondedByMembershipID');
+    }
+    set SecondedByMembershipID(value: string | null) {
+        this.Set('SecondedByMembershipID', value);
+    }
+
+    /**
+    * * Field Name: Result
+    * * Display Name: Result
+    * * SQL Data Type: nvarchar(50)
+    * * Default Value: Pending
+    * * Value List Type: List
+    * * Possible Values 
+    *   * Failed
+    *   * Passed
+    *   * Pending
+    *   * Tabled
+    *   * Withdrawn
+    * * Description: Outcome of the vote: Pending, Passed, Failed, Tabled, Withdrawn
+    */
+    get Result(): 'Failed' | 'Passed' | 'Pending' | 'Tabled' | 'Withdrawn' {
+        return this.Get('Result');
+    }
+    set Result(value: 'Failed' | 'Passed' | 'Pending' | 'Tabled' | 'Withdrawn') {
+        this.Set('Result', value);
+    }
+
+    /**
+    * * Field Name: ResultSummary
+    * * Display Name: Result Summary
+    * * SQL Data Type: nvarchar(255)
+    * * Description: Human-readable vote tally, e.g. 7-2-1 or Passed unanimously
+    */
+    get ResultSummary(): string | null {
+        return this.Get('ResultSummary');
+    }
+    set ResultSummary(value: string | null) {
+        this.Set('ResultSummary', value);
+    }
+
+    /**
+    * * Field Name: YesCount
+    * * Display Name: Yes Count
+    * * SQL Data Type: int
+    * * Description: Number of Yes votes
+    */
+    get YesCount(): number | null {
+        return this.Get('YesCount');
+    }
+    set YesCount(value: number | null) {
+        this.Set('YesCount', value);
+    }
+
+    /**
+    * * Field Name: NoCount
+    * * Display Name: No Count
+    * * SQL Data Type: int
+    * * Description: Number of No votes
+    */
+    get NoCount(): number | null {
+        return this.Get('NoCount');
+    }
+    set NoCount(value: number | null) {
+        this.Set('NoCount', value);
+    }
+
+    /**
+    * * Field Name: AbstainCount
+    * * Display Name: Abstain Count
+    * * SQL Data Type: int
+    * * Description: Number of Abstain votes
+    */
+    get AbstainCount(): number | null {
+        return this.Get('AbstainCount');
+    }
+    set AbstainCount(value: number | null) {
+        this.Set('AbstainCount', value);
+    }
+
+    /**
+    * * Field Name: Notes
+    * * Display Name: Notes
+    * * SQL Data Type: nvarchar(MAX)
+    * * Description: Additional notes about the motion or vote
+    */
+    get Notes(): string | null {
+        return this.Get('Notes');
+    }
+    set Notes(value: string | null) {
+        this.Set('Notes', value);
+    }
+
+    /**
+    * * Field Name: __mj_CreatedAt
+    * * Display Name: Created At
+    * * SQL Data Type: datetimeoffset
+    * * Default Value: getutcdate()
+    */
+    get __mj_CreatedAt(): Date {
+        return this.Get('__mj_CreatedAt');
+    }
+
+    /**
+    * * Field Name: __mj_UpdatedAt
+    * * Display Name: Updated At
+    * * SQL Data Type: datetimeoffset
+    * * Default Value: getutcdate()
+    */
+    get __mj_UpdatedAt(): Date {
+        return this.Get('__mj_UpdatedAt');
+    }
+
+    /**
+    * * Field Name: Meeting
+    * * Display Name: Meeting
+    * * SQL Data Type: nvarchar(255)
+    */
+    get Meeting(): string {
+        return this.Get('Meeting');
+    }
+
+    /**
+    * * Field Name: AgendaItem
+    * * Display Name: Agenda Item
+    * * SQL Data Type: nvarchar(255)
+    */
+    get AgendaItem(): string | null {
+        return this.Get('AgendaItem');
+    }
+
+    /**
+    * * Field Name: MovedByMembership
+    * * Display Name: Moved By Membership
+    * * SQL Data Type: nvarchar(100)
+    */
+    get MovedByMembership(): string | null {
+        return this.Get('MovedByMembership');
+    }
+
+    /**
+    * * Field Name: SecondedByMembership
+    * * Display Name: Seconded By Membership
+    * * SQL Data Type: nvarchar(100)
+    */
+    get SecondedByMembership(): string | null {
+        return this.Get('SecondedByMembership');
+    }
+}
+
+
+/**
+ * Organization Types - strongly typed entity sub-class
+ * * Schema: __mj_BizAppsCommon
+ * * Base Table: OrganizationType
+ * * Base View: vwOrganizationTypes
+ * * @description Categories of organizations such as Company, Non-Profit, Association, Government
+ * * Primary Key: ID
+ * @extends {BaseEntity}
+ * @class
+ * @public
+ */
+@RegisterClass(BaseEntity, 'Organization Types')
+export class mjBizAppsCommonOrganizationTypeEntity extends BaseEntity<mjBizAppsCommonOrganizationTypeEntityType> {
+    /**
+    * Loads the Organization Types record from the database
+    * @param ID: string - primary key value to load the Organization Types record.
+    * @param EntityRelationshipsToLoad - (optional) the relationships to load
+    * @returns {Promise<boolean>} - true if successful, false otherwise
+    * @public
+    * @async
+    * @memberof mjBizAppsCommonOrganizationTypeEntity
+    * @method
+    * @override
+    */
+    public async Load(ID: string, EntityRelationshipsToLoad?: string[]) : Promise<boolean> {
+        const compositeKey: CompositeKey = new CompositeKey();
+        compositeKey.KeyValuePairs.push({ FieldName: 'ID', Value: ID });
+        return await super.InnerLoad(compositeKey, EntityRelationshipsToLoad);
+    }
+
+    /**
+    * * Field Name: ID
+    * * Display Name: ID
+    * * SQL Data Type: uniqueidentifier
+    * * Default Value: newsequentialid()
+    */
+    get ID(): string {
+        return this.Get('ID');
+    }
+    set ID(value: string) {
+        this.Set('ID', value);
+    }
+
+    /**
+    * * Field Name: Name
+    * * Display Name: Name
+    * * SQL Data Type: nvarchar(100)
+    * * Description: Display name for the organization type
+    */
+    get Name(): string {
+        return this.Get('Name');
+    }
+    set Name(value: string) {
+        this.Set('Name', value);
+    }
+
+    /**
+    * * Field Name: Description
+    * * Display Name: Description
+    * * SQL Data Type: nvarchar(MAX)
+    * * Description: Detailed description of this organization type
+    */
+    get Description(): string | null {
+        return this.Get('Description');
+    }
+    set Description(value: string | null) {
+        this.Set('Description', value);
+    }
+
+    /**
+    * * Field Name: IconClass
+    * * Display Name: Icon Class
+    * * SQL Data Type: nvarchar(100)
+    * * Description: Font Awesome icon class for UI display
+    */
+    get IconClass(): string | null {
+        return this.Get('IconClass');
+    }
+    set IconClass(value: string | null) {
+        this.Set('IconClass', value);
+    }
+
+    /**
+    * * Field Name: __mj_CreatedAt
+    * * Display Name: Created At
+    * * SQL Data Type: datetimeoffset
+    * * Default Value: getutcdate()
+    */
+    get __mj_CreatedAt(): Date {
+        return this.Get('__mj_CreatedAt');
+    }
+
+    /**
+    * * Field Name: __mj_UpdatedAt
+    * * Display Name: Updated At
+    * * SQL Data Type: datetimeoffset
+    * * Default Value: getutcdate()
+    */
+    get __mj_UpdatedAt(): Date {
+        return this.Get('__mj_UpdatedAt');
+    }
+}
+
+
+/**
+ * Organizations - strongly typed entity sub-class
+ * * Schema: __mj_BizAppsCommon
+ * * Base Table: Organization
+ * * Base View: vwOrganizations
+ * * @description Companies, associations, government bodies, and other organizations with hierarchy support
+ * * Primary Key: ID
+ * @extends {BaseEntity}
+ * @class
+ * @public
+ */
+@RegisterClass(BaseEntity, 'Organizations')
+export class mjBizAppsCommonOrganizationEntity extends BaseEntity<mjBizAppsCommonOrganizationEntityType> {
+    /**
+    * Loads the Organizations record from the database
+    * @param ID: string - primary key value to load the Organizations record.
+    * @param EntityRelationshipsToLoad - (optional) the relationships to load
+    * @returns {Promise<boolean>} - true if successful, false otherwise
+    * @public
+    * @async
+    * @memberof mjBizAppsCommonOrganizationEntity
+    * @method
+    * @override
+    */
+    public async Load(ID: string, EntityRelationshipsToLoad?: string[]) : Promise<boolean> {
+        const compositeKey: CompositeKey = new CompositeKey();
+        compositeKey.KeyValuePairs.push({ FieldName: 'ID', Value: ID });
+        return await super.InnerLoad(compositeKey, EntityRelationshipsToLoad);
+    }
+
+    /**
+    * * Field Name: ID
+    * * Display Name: ID
+    * * SQL Data Type: uniqueidentifier
+    * * Default Value: newsequentialid()
+    */
+    get ID(): string {
+        return this.Get('ID');
+    }
+    set ID(value: string) {
+        this.Set('ID', value);
+    }
+
+    /**
+    * * Field Name: Name
+    * * Display Name: Name
+    * * SQL Data Type: nvarchar(255)
+    * * Description: Common or display name of the organization
+    */
+    get Name(): string {
+        return this.Get('Name');
+    }
+    set Name(value: string) {
+        this.Set('Name', value);
+    }
+
+    /**
+    * * Field Name: LegalName
+    * * Display Name: Legal Name
+    * * SQL Data Type: nvarchar(255)
+    * * Description: Full legal name if different from display name
+    */
+    get LegalName(): string | null {
+        return this.Get('LegalName');
+    }
+    set LegalName(value: string | null) {
+        this.Set('LegalName', value);
+    }
+
+    /**
+    * * Field Name: OrganizationTypeID
+    * * Display Name: Organization Type
+    * * SQL Data Type: uniqueidentifier
+    * * Related Entity/Foreign Key: Organization Types (vwOrganizationTypes.ID)
+    */
+    get OrganizationTypeID(): string | null {
+        return this.Get('OrganizationTypeID');
+    }
+    set OrganizationTypeID(value: string | null) {
+        this.Set('OrganizationTypeID', value);
+    }
+
+    /**
+    * * Field Name: ParentID
+    * * Display Name: Parent
+    * * SQL Data Type: uniqueidentifier
+    * * Related Entity/Foreign Key: Organizations (vwOrganizations.ID)
+    */
+    get ParentID(): string | null {
+        return this.Get('ParentID');
+    }
+    set ParentID(value: string | null) {
+        this.Set('ParentID', value);
+    }
+
+    /**
+    * * Field Name: Website
+    * * Display Name: Website
+    * * SQL Data Type: nvarchar(1000)
+    * * Description: Primary website URL
+    */
+    get Website(): string | null {
+        return this.Get('Website');
+    }
+    set Website(value: string | null) {
+        this.Set('Website', value);
+    }
+
+    /**
+    * * Field Name: LogoURL
+    * * Display Name: Logo URL
+    * * SQL Data Type: nvarchar(1000)
+    * * Description: URL to organization logo image
+    */
+    get LogoURL(): string | null {
+        return this.Get('LogoURL');
+    }
+    set LogoURL(value: string | null) {
+        this.Set('LogoURL', value);
+    }
+
+    /**
+    * * Field Name: Description
+    * * Display Name: Description
+    * * SQL Data Type: nvarchar(MAX)
+    * * Description: Description of the organization purpose and scope
+    */
+    get Description(): string | null {
+        return this.Get('Description');
+    }
+    set Description(value: string | null) {
+        this.Set('Description', value);
+    }
+
+    /**
+    * * Field Name: Email
+    * * Display Name: Email
+    * * SQL Data Type: nvarchar(255)
+    * * Description: Primary contact email address
+    */
+    get Email(): string | null {
+        return this.Get('Email');
+    }
+    set Email(value: string | null) {
+        this.Set('Email', value);
+    }
+
+    /**
+    * * Field Name: Phone
+    * * Display Name: Phone
+    * * SQL Data Type: nvarchar(50)
+    * * Description: Primary phone number
+    */
+    get Phone(): string | null {
+        return this.Get('Phone');
+    }
+    set Phone(value: string | null) {
+        this.Set('Phone', value);
+    }
+
+    /**
+    * * Field Name: FoundedDate
+    * * Display Name: Founded Date
+    * * SQL Data Type: date
+    * * Description: Date the organization was founded or incorporated
+    */
+    get FoundedDate(): Date | null {
+        return this.Get('FoundedDate');
+    }
+    set FoundedDate(value: Date | null) {
+        this.Set('FoundedDate', value);
+    }
+
+    /**
+    * * Field Name: TaxID
+    * * Display Name: Tax ID
+    * * SQL Data Type: nvarchar(50)
+    * * Description: Tax identification number such as EIN
+    */
+    get TaxID(): string | null {
+        return this.Get('TaxID');
+    }
+    set TaxID(value: string | null) {
+        this.Set('TaxID', value);
+    }
+
+    /**
+    * * Field Name: Status
+    * * Display Name: Status
+    * * SQL Data Type: nvarchar(50)
+    * * Default Value: Active
+    * * Value List Type: List
+    * * Possible Values 
+    *   * Active
+    *   * Dissolved
+    *   * Inactive
+    * * Description: Current status: Active, Inactive, or Dissolved
+    */
+    get Status(): 'Active' | 'Dissolved' | 'Inactive' {
+        return this.Get('Status');
+    }
+    set Status(value: 'Active' | 'Dissolved' | 'Inactive') {
+        this.Set('Status', value);
+    }
+
+    /**
+    * * Field Name: __mj_CreatedAt
+    * * Display Name: Created At
+    * * SQL Data Type: datetimeoffset
+    * * Default Value: getutcdate()
+    */
+    get __mj_CreatedAt(): Date {
+        return this.Get('__mj_CreatedAt');
+    }
+
+    /**
+    * * Field Name: __mj_UpdatedAt
+    * * Display Name: Updated At
+    * * SQL Data Type: datetimeoffset
+    * * Default Value: getutcdate()
+    */
+    get __mj_UpdatedAt(): Date {
+        return this.Get('__mj_UpdatedAt');
+    }
+
+    /**
+    * * Field Name: OrganizationType
+    * * Display Name: Organization Type
+    * * SQL Data Type: nvarchar(100)
+    */
+    get OrganizationType(): string | null {
+        return this.Get('OrganizationType');
+    }
+
+    /**
+    * * Field Name: Parent
+    * * Display Name: Parent (Name)
+    * * SQL Data Type: nvarchar(255)
+    */
+    get Parent(): string | null {
+        return this.Get('Parent');
+    }
+
+    /**
+    * * Field Name: RootParentID
+    * * Display Name: Root Parent
+    * * SQL Data Type: uniqueidentifier
+    */
+    get RootParentID(): string | null {
+        return this.Get('RootParentID');
+    }
+}
+
+
+/**
+ * People - strongly typed entity sub-class
+ * * Schema: __mj_BizAppsCommon
+ * * Base Table: Person
+ * * Base View: vwPeople
+ * * @description Individual people, optionally linked to MJ system user accounts
+ * * Primary Key: ID
+ * @extends {BaseEntity}
+ * @class
+ * @public
+ */
+@RegisterClass(BaseEntity, 'People')
+export class mjBizAppsCommonPersonEntity extends BaseEntity<mjBizAppsCommonPersonEntityType> {
+    /**
+    * Loads the People record from the database
+    * @param ID: string - primary key value to load the People record.
+    * @param EntityRelationshipsToLoad - (optional) the relationships to load
+    * @returns {Promise<boolean>} - true if successful, false otherwise
+    * @public
+    * @async
+    * @memberof mjBizAppsCommonPersonEntity
+    * @method
+    * @override
+    */
+    public async Load(ID: string, EntityRelationshipsToLoad?: string[]) : Promise<boolean> {
+        const compositeKey: CompositeKey = new CompositeKey();
+        compositeKey.KeyValuePairs.push({ FieldName: 'ID', Value: ID });
+        return await super.InnerLoad(compositeKey, EntityRelationshipsToLoad);
+    }
+
+    /**
+    * * Field Name: ID
+    * * Display Name: ID
+    * * SQL Data Type: uniqueidentifier
+    * * Default Value: newsequentialid()
+    */
+    get ID(): string {
+        return this.Get('ID');
+    }
+    set ID(value: string) {
+        this.Set('ID', value);
+    }
+
+    /**
+    * * Field Name: FirstName
+    * * Display Name: First Name
+    * * SQL Data Type: nvarchar(100)
+    * * Description: First (given) name
+    */
+    get FirstName(): string {
+        return this.Get('FirstName');
+    }
+    set FirstName(value: string) {
+        this.Set('FirstName', value);
+    }
+
+    /**
+    * * Field Name: LastName
+    * * Display Name: Last Name
+    * * SQL Data Type: nvarchar(100)
+    * * Description: Last (family) name
+    */
+    get LastName(): string {
+        return this.Get('LastName');
+    }
+    set LastName(value: string) {
+        this.Set('LastName', value);
+    }
+
+    /**
+    * * Field Name: MiddleName
+    * * Display Name: Middle Name
+    * * SQL Data Type: nvarchar(100)
+    * * Description: Middle name or initial
+    */
+    get MiddleName(): string | null {
+        return this.Get('MiddleName');
+    }
+    set MiddleName(value: string | null) {
+        this.Set('MiddleName', value);
+    }
+
+    /**
+    * * Field Name: Prefix
+    * * Display Name: Prefix
+    * * SQL Data Type: nvarchar(20)
+    * * Description: Name prefix such as Dr., Mr., Ms., Rev.
+    */
+    get Prefix(): string | null {
+        return this.Get('Prefix');
+    }
+    set Prefix(value: string | null) {
+        this.Set('Prefix', value);
+    }
+
+    /**
+    * * Field Name: Suffix
+    * * Display Name: Suffix
+    * * SQL Data Type: nvarchar(20)
+    * * Description: Name suffix such as Jr., III, PhD, Esq.
+    */
+    get Suffix(): string | null {
+        return this.Get('Suffix');
+    }
+    set Suffix(value: string | null) {
+        this.Set('Suffix', value);
+    }
+
+    /**
+    * * Field Name: PreferredName
+    * * Display Name: Preferred Name
+    * * SQL Data Type: nvarchar(100)
+    * * Description: Nickname or preferred name the person goes by
+    */
+    get PreferredName(): string | null {
+        return this.Get('PreferredName');
+    }
+    set PreferredName(value: string | null) {
+        this.Set('PreferredName', value);
+    }
+
+    /**
+    * * Field Name: Title
+    * * Display Name: Title
+    * * SQL Data Type: nvarchar(200)
+    * * Description: Professional or job title, e.g. VP of Engineering, Board Director
+    */
+    get Title(): string | null {
+        return this.Get('Title');
+    }
+    set Title(value: string | null) {
+        this.Set('Title', value);
+    }
+
+    /**
+    * * Field Name: Email
+    * * Display Name: Email
+    * * SQL Data Type: nvarchar(255)
+    * * Description: Primary email address for this person
+    */
+    get Email(): string | null {
+        return this.Get('Email');
+    }
+    set Email(value: string | null) {
+        this.Set('Email', value);
+    }
+
+    /**
+    * * Field Name: Phone
+    * * Display Name: Phone
+    * * SQL Data Type: nvarchar(50)
+    * * Description: Primary phone number for this person
+    */
+    get Phone(): string | null {
+        return this.Get('Phone');
+    }
+    set Phone(value: string | null) {
+        this.Set('Phone', value);
+    }
+
+    /**
+    * * Field Name: DateOfBirth
+    * * Display Name: Date of Birth
+    * * SQL Data Type: date
+    * * Description: Date of birth
+    */
+    get DateOfBirth(): Date | null {
+        return this.Get('DateOfBirth');
+    }
+    set DateOfBirth(value: Date | null) {
+        this.Set('DateOfBirth', value);
+    }
+
+    /**
+    * * Field Name: Gender
+    * * Display Name: Gender
+    * * SQL Data Type: nvarchar(50)
+    * * Description: Gender identity
+    */
+    get Gender(): string | null {
+        return this.Get('Gender');
+    }
+    set Gender(value: string | null) {
+        this.Set('Gender', value);
+    }
+
+    /**
+    * * Field Name: PhotoURL
+    * * Display Name: Photo URL
+    * * SQL Data Type: nvarchar(1000)
+    * * Description: URL to profile photo or avatar image
+    */
+    get PhotoURL(): string | null {
+        return this.Get('PhotoURL');
+    }
+    set PhotoURL(value: string | null) {
+        this.Set('PhotoURL', value);
+    }
+
+    /**
+    * * Field Name: Bio
+    * * Display Name: Bio
+    * * SQL Data Type: nvarchar(MAX)
+    * * Description: Biographical text or notes about this person
+    */
+    get Bio(): string | null {
+        return this.Get('Bio');
+    }
+    set Bio(value: string | null) {
+        this.Set('Bio', value);
+    }
+
+    /**
+    * * Field Name: LinkedUserID
+    * * Display Name: Linked User
+    * * SQL Data Type: uniqueidentifier
+    * * Related Entity/Foreign Key: MJ: Users (vwUsers.ID)
+    */
+    get LinkedUserID(): string | null {
+        return this.Get('LinkedUserID');
+    }
+    set LinkedUserID(value: string | null) {
+        this.Set('LinkedUserID', value);
+    }
+
+    /**
+    * * Field Name: Status
+    * * Display Name: Status
+    * * SQL Data Type: nvarchar(50)
+    * * Default Value: Active
+    * * Value List Type: List
+    * * Possible Values 
+    *   * Active
+    *   * Deceased
+    *   * Inactive
+    * * Description: Current status: Active, Inactive, or Deceased
+    */
+    get Status(): 'Active' | 'Deceased' | 'Inactive' {
+        return this.Get('Status');
+    }
+    set Status(value: 'Active' | 'Deceased' | 'Inactive') {
+        this.Set('Status', value);
+    }
+
+    /**
+    * * Field Name: __mj_CreatedAt
+    * * Display Name: Created At
+    * * SQL Data Type: datetimeoffset
+    * * Default Value: getutcdate()
+    */
+    get __mj_CreatedAt(): Date {
+        return this.Get('__mj_CreatedAt');
+    }
+
+    /**
+    * * Field Name: __mj_UpdatedAt
+    * * Display Name: Updated At
+    * * SQL Data Type: datetimeoffset
+    * * Default Value: getutcdate()
+    */
+    get __mj_UpdatedAt(): Date {
+        return this.Get('__mj_UpdatedAt');
+    }
+
+    /**
+    * * Field Name: LinkedUser
+    * * Display Name: Linked User Name
+    * * SQL Data Type: nvarchar(100)
+    */
+    get LinkedUser(): string | null {
+        return this.Get('LinkedUser');
+    }
+}
+
+
+/**
+ * Relationship Types - strongly typed entity sub-class
+ * * Schema: __mj_BizAppsCommon
+ * * Base Table: RelationshipType
+ * * Base View: vwRelationshipTypes
+ * * @description Defines types of relationships between people and organizations with directionality and labeling
+ * * Primary Key: ID
+ * @extends {BaseEntity}
+ * @class
+ * @public
+ */
+@RegisterClass(BaseEntity, 'Relationship Types')
+export class mjBizAppsCommonRelationshipTypeEntity extends BaseEntity<mjBizAppsCommonRelationshipTypeEntityType> {
+    /**
+    * Loads the Relationship Types record from the database
+    * @param ID: string - primary key value to load the Relationship Types record.
+    * @param EntityRelationshipsToLoad - (optional) the relationships to load
+    * @returns {Promise<boolean>} - true if successful, false otherwise
+    * @public
+    * @async
+    * @memberof mjBizAppsCommonRelationshipTypeEntity
+    * @method
+    * @override
+    */
+    public async Load(ID: string, EntityRelationshipsToLoad?: string[]) : Promise<boolean> {
+        const compositeKey: CompositeKey = new CompositeKey();
+        compositeKey.KeyValuePairs.push({ FieldName: 'ID', Value: ID });
+        return await super.InnerLoad(compositeKey, EntityRelationshipsToLoad);
+    }
+
+    /**
+    * * Field Name: ID
+    * * Display Name: ID
+    * * SQL Data Type: uniqueidentifier
+    * * Default Value: newsequentialid()
+    */
+    get ID(): string {
+        return this.Get('ID');
+    }
+    set ID(value: string) {
+        this.Set('ID', value);
+    }
+
+    /**
+    * * Field Name: Name
+    * * Display Name: Name
+    * * SQL Data Type: nvarchar(100)
+    * * Description: Display name for the relationship type, e.g. Employee, Spouse, Partner
+    */
+    get Name(): string {
+        return this.Get('Name');
+    }
+    set Name(value: string) {
+        this.Set('Name', value);
+    }
+
+    /**
+    * * Field Name: Description
+    * * Display Name: Description
+    * * SQL Data Type: nvarchar(MAX)
+    * * Description: Detailed description of this relationship type
+    */
+    get Description(): string | null {
+        return this.Get('Description');
+    }
+    set Description(value: string | null) {
+        this.Set('Description', value);
+    }
+
+    /**
+    * * Field Name: Category
+    * * Display Name: Category
+    * * SQL Data Type: nvarchar(50)
+    * * Value List Type: List
+    * * Possible Values 
+    *   * OrganizationToOrganization
+    *   * PersonToOrganization
+    *   * PersonToPerson
+    * * Description: Which entity types this relationship connects: PersonToPerson, PersonToOrganization, or OrganizationToOrganization
+    */
+    get Category(): 'OrganizationToOrganization' | 'PersonToOrganization' | 'PersonToPerson' {
+        return this.Get('Category');
+    }
+    set Category(value: 'OrganizationToOrganization' | 'PersonToOrganization' | 'PersonToPerson') {
+        this.Set('Category', value);
+    }
+
+    /**
+    * * Field Name: IsDirectional
+    * * Display Name: Is Directional
+    * * SQL Data Type: bit
+    * * Default Value: 1
+    * * Description: Whether the relationship has a direction. False for symmetric relationships like Spouse or Partner
+    */
+    get IsDirectional(): boolean {
+        return this.Get('IsDirectional');
+    }
+    set IsDirectional(value: boolean) {
+        this.Set('IsDirectional', value);
+    }
+
+    /**
+    * * Field Name: ForwardLabel
+    * * Display Name: Forward Label
+    * * SQL Data Type: nvarchar(100)
+    * * Description: Label describing the From-to-To direction, e.g. is employee of, is parent of
+    */
+    get ForwardLabel(): string | null {
+        return this.Get('ForwardLabel');
+    }
+    set ForwardLabel(value: string | null) {
+        this.Set('ForwardLabel', value);
+    }
+
+    /**
+    * * Field Name: ReverseLabel
+    * * Display Name: Reverse Label
+    * * SQL Data Type: nvarchar(100)
+    * * Description: Label describing the To-to-From direction, e.g. employs, is child of
+    */
+    get ReverseLabel(): string | null {
+        return this.Get('ReverseLabel');
+    }
+    set ReverseLabel(value: string | null) {
+        this.Set('ReverseLabel', value);
+    }
+
+    /**
+    * * Field Name: __mj_CreatedAt
+    * * Display Name: Created At
+    * * SQL Data Type: datetimeoffset
+    * * Default Value: getutcdate()
+    */
+    get __mj_CreatedAt(): Date {
+        return this.Get('__mj_CreatedAt');
+    }
+
+    /**
+    * * Field Name: __mj_UpdatedAt
+    * * Display Name: Updated At
+    * * SQL Data Type: datetimeoffset
+    * * Default Value: getutcdate()
+    */
+    get __mj_UpdatedAt(): Date {
+        return this.Get('__mj_UpdatedAt');
+    }
+}
+
+
+/**
+ * Relationships - strongly typed entity sub-class
+ * * Schema: __mj_BizAppsCommon
+ * * Base Table: Relationship
+ * * Base View: vwRelationships
+ * * @description Typed, directional links between people and organizations supporting Person-to-Person, Person-to-Organization, and Organization-to-Organization relationships
+ * * Primary Key: ID
+ * @extends {BaseEntity}
+ * @class
+ * @public
+ */
+@RegisterClass(BaseEntity, 'Relationships')
+export class mjBizAppsCommonRelationshipEntity extends BaseEntity<mjBizAppsCommonRelationshipEntityType> {
+    /**
+    * Loads the Relationships record from the database
+    * @param ID: string - primary key value to load the Relationships record.
+    * @param EntityRelationshipsToLoad - (optional) the relationships to load
+    * @returns {Promise<boolean>} - true if successful, false otherwise
+    * @public
+    * @async
+    * @memberof mjBizAppsCommonRelationshipEntity
+    * @method
+    * @override
+    */
+    public async Load(ID: string, EntityRelationshipsToLoad?: string[]) : Promise<boolean> {
+        const compositeKey: CompositeKey = new CompositeKey();
+        compositeKey.KeyValuePairs.push({ FieldName: 'ID', Value: ID });
+        return await super.InnerLoad(compositeKey, EntityRelationshipsToLoad);
+    }
+
+    /**
+    * Validate() method override for Relationships entity. This is an auto-generated method that invokes the generated validators for this entity for the following fields:
+    * * Table-Level: A relationship must start from either a person or an organization, but never both at the same time and never from neither. Exactly one of the FromPersonID or FromOrganizationID fields must contain a value.
+    * * Table-Level: Each relationship must point to either a person or an organization, but not both, and it cannot be missing both. This ensures that the target of the relationship is clearly defined.
+    * @public
+    * @method
+    * @override
+    */
+    public override Validate(): ValidationResult {
+        const result = super.Validate();
+        this.ValidateFromPersonOrOrganizationExclusive(result);
+        this.ValidateToPersonOrOrganizationExclusive(result);
+        result.Success = result.Success && (result.Errors.length === 0);
+
+        return result;
+    }
+
+    /**
+    * A relationship must start from either a person or an organization, but never both at the same time and never from neither. Exactly one of the FromPersonID or FromOrganizationID fields must contain a value.
+    * @param result - the ValidationResult object to add any errors or warnings to
+    * @public
+    * @method
+    */
+    public ValidateFromPersonOrOrganizationExclusive(result: ValidationResult) {
+    	// Ensure exactly one of FromPersonID or FromOrganizationID is provided
+    	if ((this.FromPersonID != null && this.FromOrganizationID != null) ||
+    	    (this.FromPersonID == null && this.FromOrganizationID == null)) {
+    		result.Errors.push(new ValidationErrorInfo(
+    			"FromPersonID/FromOrganizationID",
+    			"Exactly one of From Person or From Organization must be provided.",
+    			this.FromPersonID != null ? this.FromPersonID : this.FromOrganizationID,
+    			ValidationErrorType.Failure
+    		));
+    	}
+    }
+
+    /**
+    * Each relationship must point to either a person or an organization, but not both, and it cannot be missing both. This ensures that the target of the relationship is clearly defined.
+    * @param result - the ValidationResult object to add any errors or warnings to
+    * @public
+    * @method
+    */
+    public ValidateToPersonOrOrganizationExclusive(result: ValidationResult) {
+    	if ((this.ToPersonID == null && this.ToOrganizationID == null) || (this.ToPersonID != null && this.ToOrganizationID != null)) {
+    		result.Errors.push(new ValidationErrorInfo(
+    			"ToPersonID/ToOrganizationID",
+    			"A relationship must reference either a person or an organization, but not both and not neither.",
+    			this.ToPersonID ?? this.ToOrganizationID,
+    			ValidationErrorType.Failure
+    		));
+    	}
+    }
+
+    /**
+    * * Field Name: ID
+    * * Display Name: ID
+    * * SQL Data Type: uniqueidentifier
+    * * Default Value: newsequentialid()
+    */
+    get ID(): string {
+        return this.Get('ID');
+    }
+    set ID(value: string) {
+        this.Set('ID', value);
+    }
+
+    /**
+    * * Field Name: RelationshipTypeID
+    * * Display Name: Relationship Type
+    * * SQL Data Type: uniqueidentifier
+    * * Related Entity/Foreign Key: Relationship Types (vwRelationshipTypes.ID)
+    */
+    get RelationshipTypeID(): string {
+        return this.Get('RelationshipTypeID');
+    }
+    set RelationshipTypeID(value: string) {
+        this.Set('RelationshipTypeID', value);
+    }
+
+    /**
+    * * Field Name: FromPersonID
+    * * Display Name: From Person
+    * * SQL Data Type: uniqueidentifier
+    * * Related Entity/Foreign Key: People (vwPeople.ID)
+    */
+    get FromPersonID(): string | null {
+        return this.Get('FromPersonID');
+    }
+    set FromPersonID(value: string | null) {
+        this.Set('FromPersonID', value);
+    }
+
+    /**
+    * * Field Name: FromOrganizationID
+    * * Display Name: From Organization
+    * * SQL Data Type: uniqueidentifier
+    * * Related Entity/Foreign Key: Organizations (vwOrganizations.ID)
+    */
+    get FromOrganizationID(): string | null {
+        return this.Get('FromOrganizationID');
+    }
+    set FromOrganizationID(value: string | null) {
+        this.Set('FromOrganizationID', value);
+    }
+
+    /**
+    * * Field Name: ToPersonID
+    * * Display Name: To Person
+    * * SQL Data Type: uniqueidentifier
+    * * Related Entity/Foreign Key: People (vwPeople.ID)
+    */
+    get ToPersonID(): string | null {
+        return this.Get('ToPersonID');
+    }
+    set ToPersonID(value: string | null) {
+        this.Set('ToPersonID', value);
+    }
+
+    /**
+    * * Field Name: ToOrganizationID
+    * * Display Name: To Organization
+    * * SQL Data Type: uniqueidentifier
+    * * Related Entity/Foreign Key: Organizations (vwOrganizations.ID)
+    */
+    get ToOrganizationID(): string | null {
+        return this.Get('ToOrganizationID');
+    }
+    set ToOrganizationID(value: string | null) {
+        this.Set('ToOrganizationID', value);
+    }
+
+    /**
+    * * Field Name: Title
+    * * Display Name: Title
+    * * SQL Data Type: nvarchar(255)
+    * * Description: Contextual title for this specific relationship, e.g. CEO, Primary Contact, Founding Member
+    */
+    get Title(): string | null {
+        return this.Get('Title');
+    }
+    set Title(value: string | null) {
+        this.Set('Title', value);
+    }
+
+    /**
+    * * Field Name: StartDate
+    * * Display Name: Start Date
+    * * SQL Data Type: date
+    * * Description: Date the relationship began
+    */
+    get StartDate(): Date | null {
+        return this.Get('StartDate');
+    }
+    set StartDate(value: Date | null) {
+        this.Set('StartDate', value);
+    }
+
+    /**
+    * * Field Name: EndDate
+    * * Display Name: End Date
+    * * SQL Data Type: date
+    * * Description: Date the relationship ended, if applicable
+    */
+    get EndDate(): Date | null {
+        return this.Get('EndDate');
+    }
+    set EndDate(value: Date | null) {
+        this.Set('EndDate', value);
+    }
+
+    /**
+    * * Field Name: Status
+    * * Display Name: Status
+    * * SQL Data Type: nvarchar(50)
+    * * Default Value: Active
+    * * Value List Type: List
+    * * Possible Values 
+    *   * Active
+    *   * Ended
+    *   * Inactive
+    * * Description: Current status: Active, Inactive, or Ended
+    */
+    get Status(): 'Active' | 'Ended' | 'Inactive' {
+        return this.Get('Status');
+    }
+    set Status(value: 'Active' | 'Ended' | 'Inactive') {
+        this.Set('Status', value);
+    }
+
+    /**
+    * * Field Name: Notes
+    * * Display Name: Notes
+    * * SQL Data Type: nvarchar(MAX)
+    * * Description: Additional notes about this relationship
+    */
+    get Notes(): string | null {
+        return this.Get('Notes');
+    }
+    set Notes(value: string | null) {
+        this.Set('Notes', value);
+    }
+
+    /**
+    * * Field Name: __mj_CreatedAt
+    * * Display Name: Created At
+    * * SQL Data Type: datetimeoffset
+    * * Default Value: getutcdate()
+    */
+    get __mj_CreatedAt(): Date {
+        return this.Get('__mj_CreatedAt');
+    }
+
+    /**
+    * * Field Name: __mj_UpdatedAt
+    * * Display Name: Updated At
+    * * SQL Data Type: datetimeoffset
+    * * Default Value: getutcdate()
+    */
+    get __mj_UpdatedAt(): Date {
+        return this.Get('__mj_UpdatedAt');
+    }
+
+    /**
+    * * Field Name: RelationshipType
+    * * Display Name: Relationship Type Name
+    * * SQL Data Type: nvarchar(100)
+    */
+    get RelationshipType(): string {
+        return this.Get('RelationshipType');
+    }
+
+    /**
+    * * Field Name: FromPerson
+    * * Display Name: From Person
+    * * SQL Data Type: nvarchar(100)
+    */
+    get FromPerson(): string | null {
+        return this.Get('FromPerson');
+    }
+
+    /**
+    * * Field Name: FromOrganization
+    * * Display Name: From Organization
+    * * SQL Data Type: nvarchar(255)
+    */
+    get FromOrganization(): string | null {
+        return this.Get('FromOrganization');
+    }
+
+    /**
+    * * Field Name: ToPerson
+    * * Display Name: To Person
+    * * SQL Data Type: nvarchar(100)
+    */
+    get ToPerson(): string | null {
+        return this.Get('ToPerson');
+    }
+
+    /**
+    * * Field Name: ToOrganization
+    * * Display Name: To Organization
+    * * SQL Data Type: nvarchar(255)
+    */
+    get ToOrganization(): string | null {
+        return this.Get('ToOrganization');
+    }
+}
+
+
+/**
+ * Roles - strongly typed entity sub-class
+ * * Schema: __mj_Committees
+ * * Base Table: Role
+ * * Base View: vwRoles
+ * * @description Roles that members can hold on committees
+ * * Primary Key: ID
+ * @extends {BaseEntity}
+ * @class
+ * @public
+ */
+@RegisterClass(BaseEntity, 'Roles')
+export class mjCommitteesRoleEntity extends BaseEntity<mjCommitteesRoleEntityType> {
+    /**
+    * Loads the Roles record from the database
+    * @param ID: string - primary key value to load the Roles record.
+    * @param EntityRelationshipsToLoad - (optional) the relationships to load
+    * @returns {Promise<boolean>} - true if successful, false otherwise
+    * @public
+    * @async
+    * @memberof mjCommitteesRoleEntity
+    * @method
+    * @override
+    */
+    public async Load(ID: string, EntityRelationshipsToLoad?: string[]) : Promise<boolean> {
+        const compositeKey: CompositeKey = new CompositeKey();
+        compositeKey.KeyValuePairs.push({ FieldName: 'ID', Value: ID });
+        return await super.InnerLoad(compositeKey, EntityRelationshipsToLoad);
+    }
+
+    /**
+    * * Field Name: ID
+    * * Display Name: ID
+    * * SQL Data Type: uniqueidentifier
+    * * Default Value: newsequentialid()
+    */
+    get ID(): string {
+        return this.Get('ID');
+    }
+    set ID(value: string) {
+        this.Set('ID', value);
+    }
+
+    /**
+    * * Field Name: Name
+    * * Display Name: Name
+    * * SQL Data Type: nvarchar(100)
+    * * Description: Display name for the role
+    */
+    get Name(): string {
+        return this.Get('Name');
+    }
+    set Name(value: string) {
+        this.Set('Name', value);
+    }
+
+    /**
+    * * Field Name: Description
+    * * Display Name: Description
+    * * SQL Data Type: nvarchar(MAX)
+    * * Description: Detailed description of role responsibilities
+    */
+    get Description(): string | null {
+        return this.Get('Description');
+    }
+    set Description(value: string | null) {
+        this.Set('Description', value);
+    }
+
+    /**
+    * * Field Name: IsOfficer
+    * * Display Name: Officer Role
+    * * SQL Data Type: bit
+    * * Default Value: 0
+    * * Description: Whether this is an officer role like Chair or Secretary
+    */
+    get IsOfficer(): boolean {
+        return this.Get('IsOfficer');
+    }
+    set IsOfficer(value: boolean) {
+        this.Set('IsOfficer', value);
+    }
+
+    /**
+    * * Field Name: IsVotingRole
+    * * Display Name: Voting Role
+    * * SQL Data Type: bit
+    * * Default Value: 1
+    * * Description: Whether members in this role can vote
+    */
+    get IsVotingRole(): boolean {
+        return this.Get('IsVotingRole');
+    }
+    set IsVotingRole(value: boolean) {
+        this.Set('IsVotingRole', value);
+    }
+
+    /**
+    * * Field Name: DefaultPermissionsJSON
+    * * Display Name: Default Permissions
+    * * SQL Data Type: nvarchar(MAX)
+    * * Description: JSON object defining default permissions for this role
+    */
+    get DefaultPermissionsJSON(): string | null {
+        return this.Get('DefaultPermissionsJSON');
+    }
+    set DefaultPermissionsJSON(value: string | null) {
+        this.Set('DefaultPermissionsJSON', value);
+    }
+
+    /**
+    * * Field Name: Sequence
+    * * Display Name: Sequence
+    * * SQL Data Type: int
+    * * Default Value: 100
+    * * Description: Display order for sorting roles
+    */
+    get Sequence(): number {
+        return this.Get('Sequence');
+    }
+    set Sequence(value: number) {
+        this.Set('Sequence', value);
+    }
+
+    /**
+    * * Field Name: __mj_CreatedAt
+    * * Display Name: Created At
+    * * SQL Data Type: datetimeoffset
+    * * Default Value: getutcdate()
+    */
+    get __mj_CreatedAt(): Date {
+        return this.Get('__mj_CreatedAt');
+    }
+
+    /**
+    * * Field Name: __mj_UpdatedAt
+    * * Display Name: Updated At
+    * * SQL Data Type: datetimeoffset
+    * * Default Value: getutcdate()
+    */
+    get __mj_UpdatedAt(): Date {
+        return this.Get('__mj_UpdatedAt');
+    }
+}
+
+
+/**
+ * Terms - strongly typed entity sub-class
+ * * Schema: __mj_Committees
+ * * Base Table: Term
+ * * Base View: vwTerms
+ * * @description Time periods for committee membership cycles
+ * * Primary Key: ID
+ * @extends {BaseEntity}
+ * @class
+ * @public
+ */
+@RegisterClass(BaseEntity, 'Terms')
+export class mjCommitteesTermEntity extends BaseEntity<mjCommitteesTermEntityType> {
+    /**
+    * Loads the Terms record from the database
+    * @param ID: string - primary key value to load the Terms record.
+    * @param EntityRelationshipsToLoad - (optional) the relationships to load
+    * @returns {Promise<boolean>} - true if successful, false otherwise
+    * @public
+    * @async
+    * @memberof mjCommitteesTermEntity
+    * @method
+    * @override
+    */
+    public async Load(ID: string, EntityRelationshipsToLoad?: string[]) : Promise<boolean> {
+        const compositeKey: CompositeKey = new CompositeKey();
+        compositeKey.KeyValuePairs.push({ FieldName: 'ID', Value: ID });
+        return await super.InnerLoad(compositeKey, EntityRelationshipsToLoad);
+    }
+
+    /**
+    * * Field Name: ID
+    * * Display Name: ID
+    * * SQL Data Type: uniqueidentifier
+    * * Default Value: newsequentialid()
+    */
+    get ID(): string {
+        return this.Get('ID');
+    }
+    set ID(value: string) {
+        this.Set('ID', value);
+    }
+
+    /**
+    * * Field Name: CommitteeID
+    * * Display Name: Committee
+    * * SQL Data Type: uniqueidentifier
+    * * Related Entity/Foreign Key: Committees (vwCommittees.ID)
+    */
+    get CommitteeID(): string {
+        return this.Get('CommitteeID');
+    }
+    set CommitteeID(value: string) {
+        this.Set('CommitteeID', value);
+    }
+
+    /**
+    * * Field Name: Name
+    * * Display Name: Term Name
+    * * SQL Data Type: nvarchar(100)
+    * * Description: Display name for the term, e.g. 2025-2026
+    */
+    get Name(): string {
+        return this.Get('Name');
+    }
+    set Name(value: string) {
+        this.Set('Name', value);
+    }
+
+    /**
+    * * Field Name: StartDate
+    * * Display Name: Start Date
+    * * SQL Data Type: date
+    * * Description: Start date of the term
+    */
+    get StartDate(): Date {
+        return this.Get('StartDate');
+    }
+    set StartDate(value: Date) {
+        this.Set('StartDate', value);
+    }
+
+    /**
+    * * Field Name: EndDate
+    * * Display Name: End Date
+    * * SQL Data Type: date
+    * * Description: End date of the term
+    */
+    get EndDate(): Date | null {
+        return this.Get('EndDate');
+    }
+    set EndDate(value: Date | null) {
+        this.Set('EndDate', value);
+    }
+
+    /**
+    * * Field Name: Status
+    * * Display Name: Status
+    * * SQL Data Type: nvarchar(50)
+    * * Default Value: Active
+    * * Value List Type: List
+    * * Possible Values 
+    *   * Active
+    *   * Completed
+    *   * Upcoming
+    * * Description: Current status: Active, Upcoming, or Completed
+    */
+    get Status(): 'Active' | 'Completed' | 'Upcoming' {
+        return this.Get('Status');
+    }
+    set Status(value: 'Active' | 'Completed' | 'Upcoming') {
+        this.Set('Status', value);
+    }
+
+    /**
+    * * Field Name: __mj_CreatedAt
+    * * Display Name: Created At
+    * * SQL Data Type: datetimeoffset
+    * * Default Value: getutcdate()
+    */
+    get __mj_CreatedAt(): Date {
+        return this.Get('__mj_CreatedAt');
+    }
+
+    /**
+    * * Field Name: __mj_UpdatedAt
+    * * Display Name: Updated At
+    * * SQL Data Type: datetimeoffset
+    * * Default Value: getutcdate()
+    */
+    get __mj_UpdatedAt(): Date {
+        return this.Get('__mj_UpdatedAt');
+    }
+
+    /**
+    * * Field Name: Committee
+    * * Display Name: Committee Name
+    * * SQL Data Type: nvarchar(255)
+    */
+    get Committee(): string {
+        return this.Get('Committee');
+    }
+}
+
+
+/**
+ * Types - strongly typed entity sub-class
+ * * Schema: __mj_Committees
+ * * Base Table: Type
+ * * Base View: vwTypes
+ * * @description Categories of committees such as Board, Standing, Ad Hoc, Workgroup
+ * * Primary Key: ID
+ * @extends {BaseEntity}
+ * @class
+ * @public
+ */
+@RegisterClass(BaseEntity, 'Types')
+export class mjCommitteesTypeEntity extends BaseEntity<mjCommitteesTypeEntityType> {
+    /**
+    * Loads the Types record from the database
+    * @param ID: string - primary key value to load the Types record.
+    * @param EntityRelationshipsToLoad - (optional) the relationships to load
+    * @returns {Promise<boolean>} - true if successful, false otherwise
+    * @public
+    * @async
+    * @memberof mjCommitteesTypeEntity
+    * @method
+    * @override
+    */
+    public async Load(ID: string, EntityRelationshipsToLoad?: string[]) : Promise<boolean> {
+        const compositeKey: CompositeKey = new CompositeKey();
+        compositeKey.KeyValuePairs.push({ FieldName: 'ID', Value: ID });
+        return await super.InnerLoad(compositeKey, EntityRelationshipsToLoad);
+    }
+
+    /**
+    * * Field Name: ID
+    * * Display Name: ID
+    * * SQL Data Type: uniqueidentifier
+    * * Default Value: newsequentialid()
+    */
+    get ID(): string {
+        return this.Get('ID');
+    }
+    set ID(value: string) {
+        this.Set('ID', value);
+    }
+
+    /**
+    * * Field Name: Name
+    * * Display Name: Name
+    * * SQL Data Type: nvarchar(100)
+    * * Description: Display name for the committee type
+    */
+    get Name(): string {
+        return this.Get('Name');
+    }
+    set Name(value: string) {
+        this.Set('Name', value);
+    }
+
+    /**
+    * * Field Name: Description
+    * * Display Name: Description
+    * * SQL Data Type: nvarchar(MAX)
+    * * Description: Detailed description of this committee type
+    */
+    get Description(): string | null {
+        return this.Get('Description');
+    }
+    set Description(value: string | null) {
+        this.Set('Description', value);
+    }
+
+    /**
+    * * Field Name: IsStandards
+    * * Display Name: Is Standards
+    * * SQL Data Type: bit
+    * * Default Value: 0
+    * * Description: Whether this type is for standards development committees
+    */
+    get IsStandards(): boolean {
+        return this.Get('IsStandards');
+    }
+    set IsStandards(value: boolean) {
+        this.Set('IsStandards', value);
+    }
+
+    /**
+    * * Field Name: DefaultTermMonths
+    * * Display Name: Default Term (Months)
+    * * SQL Data Type: int
+    * * Description: Default term length in months for committees of this type
+    */
+    get DefaultTermMonths(): number | null {
+        return this.Get('DefaultTermMonths');
+    }
+    set DefaultTermMonths(value: number | null) {
+        this.Set('DefaultTermMonths', value);
+    }
+
+    /**
+    * * Field Name: IconClass
+    * * Display Name: Icon Class
+    * * SQL Data Type: nvarchar(100)
+    * * Description: Font Awesome icon class for UI display
+    */
+    get IconClass(): string | null {
+        return this.Get('IconClass');
+    }
+    set IconClass(value: string | null) {
+        this.Set('IconClass', value);
+    }
+
+    /**
+    * * Field Name: __mj_CreatedAt
+    * * Display Name: Created At
+    * * SQL Data Type: datetimeoffset
+    * * Default Value: getutcdate()
+    */
+    get __mj_CreatedAt(): Date {
+        return this.Get('__mj_CreatedAt');
+    }
+
+    /**
+    * * Field Name: __mj_UpdatedAt
+    * * Display Name: Updated At
+    * * SQL Data Type: datetimeoffset
+    * * Default Value: getutcdate()
+    */
+    get __mj_UpdatedAt(): Date {
+        return this.Get('__mj_UpdatedAt');
+    }
+}
+
+
+/**
+ * Video Providers - strongly typed entity sub-class
+ * * Schema: __mj_Committees
+ * * Base Table: VideoProvider
+ * * Base View: vwVideoProviders
+ * * Primary Key: ID
+ * @extends {BaseEntity}
+ * @class
+ * @public
+ */
+@RegisterClass(BaseEntity, 'Video Providers')
+export class mjCommitteesVideoProviderEntity extends BaseEntity<mjCommitteesVideoProviderEntityType> {
+    /**
+    * Loads the Video Providers record from the database
+    * @param ID: string - primary key value to load the Video Providers record.
+    * @param EntityRelationshipsToLoad - (optional) the relationships to load
+    * @returns {Promise<boolean>} - true if successful, false otherwise
+    * @public
+    * @async
+    * @memberof mjCommitteesVideoProviderEntity
+    * @method
+    * @override
+    */
+    public async Load(ID: string, EntityRelationshipsToLoad?: string[]) : Promise<boolean> {
+        const compositeKey: CompositeKey = new CompositeKey();
+        compositeKey.KeyValuePairs.push({ FieldName: 'ID', Value: ID });
+        return await super.InnerLoad(compositeKey, EntityRelationshipsToLoad);
+    }
+
+    /**
+    * * Field Name: ID
+    * * Display Name: ID
+    * * SQL Data Type: uniqueidentifier
+    * * Default Value: newsequentialid()
+    */
+    get ID(): string {
+        return this.Get('ID');
+    }
+    set ID(value: string) {
+        this.Set('ID', value);
+    }
+
+    /**
+    * * Field Name: Name
+    * * Display Name: Name
+    * * SQL Data Type: nvarchar(100)
+    */
+    get Name(): string {
+        return this.Get('Name');
+    }
+    set Name(value: string) {
+        this.Set('Name', value);
+    }
+
+    /**
+    * * Field Name: ServerDriverKey
+    * * Display Name: Server Driver Key
+    * * SQL Data Type: nvarchar(100)
+    */
+    get ServerDriverKey(): string {
+        return this.Get('ServerDriverKey');
+    }
+    set ServerDriverKey(value: string) {
+        this.Set('ServerDriverKey', value);
+    }
+
+    /**
+    * * Field Name: IsActive
+    * * Display Name: Active
+    * * SQL Data Type: bit
+    * * Default Value: 1
+    */
+    get IsActive(): boolean {
+        return this.Get('IsActive');
+    }
+    set IsActive(value: boolean) {
+        this.Set('IsActive', value);
+    }
+
+    /**
+    * * Field Name: IsDefault
+    * * Display Name: Default
+    * * SQL Data Type: bit
+    * * Default Value: 0
+    */
+    get IsDefault(): boolean {
+        return this.Get('IsDefault');
+    }
+    set IsDefault(value: boolean) {
+        this.Set('IsDefault', value);
+    }
+
+    /**
+    * * Field Name: CredentialID
+    * * Display Name: Credential ID
+    * * SQL Data Type: uniqueidentifier
+    * * Related Entity/Foreign Key: MJ: Credentials (vwCredentials.ID)
+    */
+    get CredentialID(): string | null {
+        return this.Get('CredentialID');
+    }
+    set CredentialID(value: string | null) {
+        this.Set('CredentialID', value);
+    }
+
+    /**
+    * * Field Name: __mj_CreatedAt
+    * * Display Name: Created At
+    * * SQL Data Type: datetimeoffset
+    * * Default Value: getutcdate()
+    */
+    get __mj_CreatedAt(): Date {
+        return this.Get('__mj_CreatedAt');
+    }
+
+    /**
+    * * Field Name: __mj_UpdatedAt
+    * * Display Name: Updated At
+    * * SQL Data Type: datetimeoffset
+    * * Default Value: getutcdate()
+    */
+    get __mj_UpdatedAt(): Date {
+        return this.Get('__mj_UpdatedAt');
+    }
+
+    /**
+    * * Field Name: Credential
+    * * Display Name: Credential
+    * * SQL Data Type: nvarchar(200)
+    */
+    get Credential(): string | null {
+        return this.Get('Credential');
+    }
+}
+
+
+/**
+ * Votes - strongly typed entity sub-class
+ * * Schema: __mj_Committees
+ * * Base Table: Vote
+ * * Base View: vwVotes
+ * * @description Individual vote records for committee motions
+ * * Primary Key: ID
+ * @extends {BaseEntity}
+ * @class
+ * @public
+ */
+@RegisterClass(BaseEntity, 'Votes')
+export class mjCommitteesVoteEntity extends BaseEntity<mjCommitteesVoteEntityType> {
+    /**
+    * Loads the Votes record from the database
+    * @param ID: string - primary key value to load the Votes record.
+    * @param EntityRelationshipsToLoad - (optional) the relationships to load
+    * @returns {Promise<boolean>} - true if successful, false otherwise
+    * @public
+    * @async
+    * @memberof mjCommitteesVoteEntity
+    * @method
+    * @override
+    */
+    public async Load(ID: string, EntityRelationshipsToLoad?: string[]) : Promise<boolean> {
+        const compositeKey: CompositeKey = new CompositeKey();
+        compositeKey.KeyValuePairs.push({ FieldName: 'ID', Value: ID });
+        return await super.InnerLoad(compositeKey, EntityRelationshipsToLoad);
+    }
+
+    /**
+    * * Field Name: ID
+    * * Display Name: ID
+    * * SQL Data Type: uniqueidentifier
+    * * Default Value: newsequentialid()
+    */
+    get ID(): string {
+        return this.Get('ID');
+    }
+    set ID(value: string) {
+        this.Set('ID', value);
+    }
+
+    /**
+    * * Field Name: MotionID
+    * * Display Name: Motion
+    * * SQL Data Type: uniqueidentifier
+    * * Related Entity/Foreign Key: Motions (vwMotions.ID)
+    */
+    get MotionID(): string {
+        return this.Get('MotionID');
+    }
+    set MotionID(value: string) {
+        this.Set('MotionID', value);
+    }
+
+    /**
+    * * Field Name: MembershipID
+    * * Display Name: Membership
+    * * SQL Data Type: uniqueidentifier
+    * * Related Entity/Foreign Key: Memberships (vwMemberships.ID)
+    */
+    get MembershipID(): string {
+        return this.Get('MembershipID');
+    }
+    set MembershipID(value: string) {
+        this.Set('MembershipID', value);
+    }
+
+    /**
+    * * Field Name: VoteValue
+    * * Display Name: Vote Value
+    * * SQL Data Type: nvarchar(20)
+    * * Value List Type: List
+    * * Possible Values 
+    *   * Absent
+    *   * Abstain
+    *   * No
+    *   * Yes
+    * * Description: The vote cast: Yes, No, Abstain, or Absent
+    */
+    get VoteValue(): 'Absent' | 'Abstain' | 'No' | 'Yes' {
+        return this.Get('VoteValue');
+    }
+    set VoteValue(value: 'Absent' | 'Abstain' | 'No' | 'Yes') {
+        this.Set('VoteValue', value);
+    }
+
+    /**
+    * * Field Name: Notes
+    * * Display Name: Notes
+    * * SQL Data Type: nvarchar(500)
+    * * Description: Optional notes explaining the vote
+    */
+    get Notes(): string | null {
+        return this.Get('Notes');
+    }
+    set Notes(value: string | null) {
+        this.Set('Notes', value);
+    }
+
+    /**
+    * * Field Name: __mj_CreatedAt
+    * * Display Name: Created At
+    * * SQL Data Type: datetimeoffset
+    * * Default Value: getutcdate()
+    */
+    get __mj_CreatedAt(): Date {
+        return this.Get('__mj_CreatedAt');
+    }
+
+    /**
+    * * Field Name: __mj_UpdatedAt
+    * * Display Name: Updated At
+    * * SQL Data Type: datetimeoffset
+    * * Default Value: getutcdate()
+    */
+    get __mj_UpdatedAt(): Date {
+        return this.Get('__mj_UpdatedAt');
+    }
+
+    /**
+    * * Field Name: Motion
+    * * Display Name: Motion
+    * * SQL Data Type: nvarchar(255)
+    */
+    get Motion(): string {
+        return this.Get('Motion');
+    }
+
+    /**
+    * * Field Name: Membership
+    * * Display Name: Membership
+    * * SQL Data Type: nvarchar(100)
+    */
+    get Membership(): string {
+        return this.Get('Membership');
+    }
+}

--- a/packages/MJAPI/src/generated/generated.ts
+++ b/packages/MJAPI/src/generated/generated.ts
@@ -17,5 +17,6194 @@ import { MaxLength } from 'class-validator';
 import * as mj_core_schema_server_object_types from '@memberjunction/server'
 
 
-export {}
+import { mjCommitteesActionItemEntity, mjBizAppsCommonAddressLinkEntity, mjBizAppsCommonAddressTypeEntity, mjBizAppsCommonAddressEntity, mjCommitteesAgendaItemEntity, mjCommitteesArtifactTypeEntity, mjCommitteesArtifactEntity, mjCommitteesAttendanceEntity, mjCommitteesCommentEntity, mjCommitteesCommitteeEntity, mjBizAppsCommonContactMethodEntity, mjBizAppsCommonContactTypeEntity, mjCommitteesMeetingEntity, mjCommitteesMembershipEntity, mjCommitteesMinuteEntity, mjCommitteesMotionEntity, mjBizAppsCommonOrganizationTypeEntity, mjBizAppsCommonOrganizationEntity, mjBizAppsCommonPersonEntity, mjBizAppsCommonRelationshipTypeEntity, mjBizAppsCommonRelationshipEntity, mjCommitteesRoleEntity, mjCommitteesTermEntity, mjCommitteesTypeEntity, mjCommitteesVideoProviderEntity, mjCommitteesVoteEntity } from 'mj_generatedentities';
     
+
+//****************************************************************************
+// ENTITY CLASS for Action Items
+//****************************************************************************
+@ObjectType({ description: `Tasks and action items assigned from committees or meetings` })
+export class mjCommitteesActionItem_ {
+    @Field() 
+    @MaxLength(36)
+    ID: string;
+        
+    @Field() 
+    @MaxLength(36)
+    CommitteeID: string;
+        
+    @Field({nullable: true}) 
+    @MaxLength(36)
+    MeetingID?: string;
+        
+    @Field({nullable: true}) 
+    @MaxLength(36)
+    AgendaItemID?: string;
+        
+    @Field({description: `Title of the action item`}) 
+    @MaxLength(255)
+    Title: string;
+        
+    @Field({nullable: true, description: `Detailed description of what needs to be done`}) 
+    Description?: string;
+        
+    @Field() 
+    @MaxLength(36)
+    AssignedToPersonID: string;
+        
+    @Field({nullable: true}) 
+    @MaxLength(36)
+    AssignedByPersonID?: string;
+        
+    @Field({nullable: true, description: `Due date for completion`}) 
+    DueDate?: Date;
+        
+    @Field({description: `Priority level: Low, Medium, High, Critical`}) 
+    @MaxLength(20)
+    Priority: string;
+        
+    @Field({description: `Current status: Open, InProgress, Blocked, Completed, Cancelled`}) 
+    @MaxLength(50)
+    Status: string;
+        
+    @Field({nullable: true, description: `Timestamp when the action item was completed`}) 
+    CompletedAt?: Date;
+        
+    @Field({nullable: true, description: `Notes about how the item was completed`}) 
+    CompletionNotes?: string;
+        
+    @Field() 
+    _mj__CreatedAt: Date;
+        
+    @Field() 
+    _mj__UpdatedAt: Date;
+        
+    @Field() 
+    @MaxLength(255)
+    Committee: string;
+        
+    @Field({nullable: true}) 
+    @MaxLength(255)
+    Meeting?: string;
+        
+    @Field({nullable: true}) 
+    @MaxLength(255)
+    AgendaItem?: string;
+        
+    @Field() 
+    @MaxLength(100)
+    AssignedToPerson: string;
+        
+    @Field({nullable: true}) 
+    @MaxLength(100)
+    AssignedByPerson?: string;
+        
+    @Field(() => [mjCommitteesArtifact_])
+    mjCommitteesArtifacts_ActionItemIDArray: mjCommitteesArtifact_[]; // Link to mjCommitteesArtifacts
+    
+    @Field(() => [mjCommitteesComment_])
+    mjCommitteesComments_ActionItemIDArray: mjCommitteesComment_[]; // Link to mjCommitteesComments
+    
+}
+
+//****************************************************************************
+// INPUT TYPE for Action Items
+//****************************************************************************
+@InputType()
+export class CreatemjCommitteesActionItemInput {
+    @Field({ nullable: true })
+    ID?: string;
+
+    @Field({ nullable: true })
+    CommitteeID?: string;
+
+    @Field({ nullable: true })
+    MeetingID: string | null;
+
+    @Field({ nullable: true })
+    AgendaItemID: string | null;
+
+    @Field({ nullable: true })
+    Title?: string;
+
+    @Field({ nullable: true })
+    Description: string | null;
+
+    @Field({ nullable: true })
+    AssignedToPersonID?: string;
+
+    @Field({ nullable: true })
+    AssignedByPersonID: string | null;
+
+    @Field({ nullable: true })
+    DueDate: Date | null;
+
+    @Field({ nullable: true })
+    Priority?: string;
+
+    @Field({ nullable: true })
+    Status?: string;
+
+    @Field({ nullable: true })
+    CompletedAt: Date | null;
+
+    @Field({ nullable: true })
+    CompletionNotes: string | null;
+}
+    
+
+//****************************************************************************
+// INPUT TYPE for Action Items
+//****************************************************************************
+@InputType()
+export class UpdatemjCommitteesActionItemInput {
+    @Field()
+    ID: string;
+
+    @Field({ nullable: true })
+    CommitteeID?: string;
+
+    @Field({ nullable: true })
+    MeetingID?: string | null;
+
+    @Field({ nullable: true })
+    AgendaItemID?: string | null;
+
+    @Field({ nullable: true })
+    Title?: string;
+
+    @Field({ nullable: true })
+    Description?: string | null;
+
+    @Field({ nullable: true })
+    AssignedToPersonID?: string;
+
+    @Field({ nullable: true })
+    AssignedByPersonID?: string | null;
+
+    @Field({ nullable: true })
+    DueDate?: Date | null;
+
+    @Field({ nullable: true })
+    Priority?: string;
+
+    @Field({ nullable: true })
+    Status?: string;
+
+    @Field({ nullable: true })
+    CompletedAt?: Date | null;
+
+    @Field({ nullable: true })
+    CompletionNotes?: string | null;
+
+    @Field(() => [KeyValuePairInput], { nullable: true })
+    OldValues___?: KeyValuePairInput[];
+}
+    
+//****************************************************************************
+// RESOLVER for Action Items
+//****************************************************************************
+@ObjectType()
+export class RunmjCommitteesActionItemViewResult {
+    @Field(() => [mjCommitteesActionItem_])
+    Results: mjCommitteesActionItem_[];
+
+    @Field(() => String, {nullable: true})
+    UserViewRunID?: string;
+
+    @Field(() => Int, {nullable: true})
+    RowCount: number;
+
+    @Field(() => Int, {nullable: true})
+    TotalRowCount: number;
+
+    @Field(() => Int, {nullable: true})
+    ExecutionTime: number;
+
+    @Field({nullable: true})
+    ErrorMessage?: string;
+
+    @Field(() => Boolean, {nullable: false})
+    Success: boolean;
+}
+
+@Resolver(mjCommitteesActionItem_)
+export class mjCommitteesActionItemResolver extends ResolverBase {
+    @Query(() => RunmjCommitteesActionItemViewResult)
+    async RunmjCommitteesActionItemViewByID(@Arg('input', () => RunViewByIDInput) input: RunViewByIDInput, @Ctx() { providers, userPayload }: AppContext, @PubSub() pubSub: PubSubEngine) {
+        const provider = GetReadOnlyProvider(providers, { allowFallbackToReadWrite: true });
+        return super.RunViewByIDGeneric(input, provider, userPayload, pubSub);
+    }
+
+    @Query(() => RunmjCommitteesActionItemViewResult)
+    async RunmjCommitteesActionItemViewByName(@Arg('input', () => RunViewByNameInput) input: RunViewByNameInput, @Ctx() { providers, userPayload }: AppContext, @PubSub() pubSub: PubSubEngine) {
+        const provider = GetReadOnlyProvider(providers, { allowFallbackToReadWrite: true });
+        return super.RunViewByNameGeneric(input, provider, userPayload, pubSub);
+    }
+
+    @Query(() => RunmjCommitteesActionItemViewResult)
+    async RunmjCommitteesActionItemDynamicView(@Arg('input', () => RunDynamicViewInput) input: RunDynamicViewInput, @Ctx() { providers, userPayload }: AppContext, @PubSub() pubSub: PubSubEngine) {
+        const provider = GetReadOnlyProvider(providers, { allowFallbackToReadWrite: true });
+        input.EntityName = 'Action Items';
+        return super.RunDynamicViewGeneric(input, provider, userPayload, pubSub);
+    }
+    @Query(() => mjCommitteesActionItem_, { nullable: true })
+    async mjCommitteesActionItem(@Arg('ID', () => String) ID: string, @Ctx() { userPayload, providers }: AppContext, @PubSub() pubSub: PubSubEngine): Promise<mjCommitteesActionItem_ | null> {
+        this.CheckUserReadPermissions('Action Items', userPayload);
+        const provider = GetReadOnlyProvider(providers, { allowFallbackToReadWrite: true });
+        const sSQL = `SELECT * FROM ${provider.QuoteSchemaAndView('__mj_Committees', 'vwActionItems')} WHERE ${provider.QuoteIdentifier('ID')}='${ID}' ` + this.getRowLevelSecurityWhereClause(provider, 'Action Items', userPayload, EntityPermissionType.Read, 'AND');
+        const rows = await provider.ExecuteSQL(sSQL, undefined, undefined, this.GetUserFromPayload(userPayload));
+        const result = await this.MapFieldNamesToCodeNames('Action Items', rows && rows.length > 0 ? rows[0] : null, this.GetUserFromPayload(userPayload));
+        return result;
+    }
+    
+    @FieldResolver(() => [mjCommitteesArtifact_])
+    async mjCommitteesArtifacts_ActionItemIDArray(@Root() mjcommitteesactionitem_: mjCommitteesActionItem_, @Ctx() { userPayload, providers }: AppContext, @PubSub() pubSub: PubSubEngine) {
+        this.CheckUserReadPermissions('Artifacts', userPayload);
+        const provider = GetReadOnlyProvider(providers, { allowFallbackToReadWrite: true });
+        const sSQL = `SELECT * FROM ${provider.QuoteSchemaAndView('__mj_Committees', 'vwArtifacts')} WHERE ${provider.QuoteIdentifier('ActionItemID')}='${mjcommitteesactionitem_.ID}' ` + this.getRowLevelSecurityWhereClause(provider, 'Artifacts', userPayload, EntityPermissionType.Read, 'AND');
+        const rows = await provider.ExecuteSQL(sSQL, undefined, undefined, this.GetUserFromPayload(userPayload));
+        const result = await this.ArrayMapFieldNamesToCodeNames('Artifacts', rows, this.GetUserFromPayload(userPayload));
+        return result;
+    }
+        
+    @FieldResolver(() => [mjCommitteesComment_])
+    async mjCommitteesComments_ActionItemIDArray(@Root() mjcommitteesactionitem_: mjCommitteesActionItem_, @Ctx() { userPayload, providers }: AppContext, @PubSub() pubSub: PubSubEngine) {
+        this.CheckUserReadPermissions('Comments', userPayload);
+        const provider = GetReadOnlyProvider(providers, { allowFallbackToReadWrite: true });
+        const sSQL = `SELECT * FROM ${provider.QuoteSchemaAndView('__mj_Committees', 'vwComments')} WHERE ${provider.QuoteIdentifier('ActionItemID')}='${mjcommitteesactionitem_.ID}' ` + this.getRowLevelSecurityWhereClause(provider, 'Comments', userPayload, EntityPermissionType.Read, 'AND');
+        const rows = await provider.ExecuteSQL(sSQL, undefined, undefined, this.GetUserFromPayload(userPayload));
+        const result = await this.ArrayMapFieldNamesToCodeNames('Comments', rows, this.GetUserFromPayload(userPayload));
+        return result;
+    }
+        
+    @Mutation(() => mjCommitteesActionItem_)
+    async CreatemjCommitteesActionItem(
+        @Arg('input', () => CreatemjCommitteesActionItemInput) input: CreatemjCommitteesActionItemInput,
+        @Ctx() { providers, userPayload }: AppContext,
+        @PubSub() pubSub: PubSubEngine
+    ) {
+        const provider = GetReadWriteProvider(providers);
+        return this.CreateRecord('Action Items', input, provider, userPayload, pubSub)
+    }
+        
+    @Mutation(() => mjCommitteesActionItem_)
+    async UpdatemjCommitteesActionItem(
+        @Arg('input', () => UpdatemjCommitteesActionItemInput) input: UpdatemjCommitteesActionItemInput,
+        @Ctx() { providers, userPayload }: AppContext,
+        @PubSub() pubSub: PubSubEngine
+    ) {
+        const provider = GetReadWriteProvider(providers);
+        return this.UpdateRecord('Action Items', input, provider, userPayload, pubSub);
+    }
+    
+    @Mutation(() => mjCommitteesActionItem_)
+    async DeletemjCommitteesActionItem(@Arg('ID', () => String) ID: string, @Arg('options___', () => DeleteOptionsInput) options: DeleteOptionsInput, @Ctx() { providers, userPayload }: AppContext, @PubSub() pubSub: PubSubEngine) {
+        const provider = GetReadWriteProvider(providers);
+        const key = new CompositeKey([{FieldName: 'ID', Value: ID}]);
+        return this.DeleteRecord('Action Items', key, options, provider, userPayload, pubSub);
+    }
+    
+}
+
+//****************************************************************************
+// ENTITY CLASS for Address Links
+//****************************************************************************
+@ObjectType({ description: `Polymorphic link table connecting Address records to any entity record in the system via EntityID and RecordID` })
+export class mjBizAppsCommonAddressLink_ {
+    @Field() 
+    @MaxLength(36)
+    ID: string;
+        
+    @Field() 
+    @MaxLength(36)
+    AddressID: string;
+        
+    @Field() 
+    @MaxLength(36)
+    EntityID: string;
+        
+    @Field({description: `Primary key value(s) of the linked record. NVARCHAR(700) to support concatenated composite keys for entities without single-valued primary keys`}) 
+    @MaxLength(700)
+    RecordID: string;
+        
+    @Field() 
+    @MaxLength(36)
+    AddressTypeID: string;
+        
+    @Field(() => Boolean, {description: `Whether this is the primary address for the linked record. Only one address per entity record should be marked primary`}) 
+    IsPrimary: boolean;
+        
+    @Field(() => Int, {nullable: true, description: `Sort order override for this specific link. When NULL, falls back to AddressType.DefaultRank. Lower values appear first`}) 
+    Rank?: number;
+        
+    @Field() 
+    _mj__CreatedAt: Date;
+        
+    @Field() 
+    _mj__UpdatedAt: Date;
+        
+    @Field() 
+    @MaxLength(255)
+    Address: string;
+        
+    @Field() 
+    @MaxLength(255)
+    Entity: string;
+        
+    @Field() 
+    @MaxLength(100)
+    AddressType: string;
+        
+}
+
+//****************************************************************************
+// INPUT TYPE for Address Links
+//****************************************************************************
+@InputType()
+export class CreatemjBizAppsCommonAddressLinkInput {
+    @Field({ nullable: true })
+    ID?: string;
+
+    @Field({ nullable: true })
+    AddressID?: string;
+
+    @Field({ nullable: true })
+    EntityID?: string;
+
+    @Field({ nullable: true })
+    RecordID?: string;
+
+    @Field({ nullable: true })
+    AddressTypeID?: string;
+
+    @Field(() => Boolean, { nullable: true })
+    IsPrimary?: boolean;
+
+    @Field(() => Int, { nullable: true })
+    Rank: number | null;
+}
+    
+
+//****************************************************************************
+// INPUT TYPE for Address Links
+//****************************************************************************
+@InputType()
+export class UpdatemjBizAppsCommonAddressLinkInput {
+    @Field()
+    ID: string;
+
+    @Field({ nullable: true })
+    AddressID?: string;
+
+    @Field({ nullable: true })
+    EntityID?: string;
+
+    @Field({ nullable: true })
+    RecordID?: string;
+
+    @Field({ nullable: true })
+    AddressTypeID?: string;
+
+    @Field(() => Boolean, { nullable: true })
+    IsPrimary?: boolean;
+
+    @Field(() => Int, { nullable: true })
+    Rank?: number | null;
+
+    @Field(() => [KeyValuePairInput], { nullable: true })
+    OldValues___?: KeyValuePairInput[];
+}
+    
+//****************************************************************************
+// RESOLVER for Address Links
+//****************************************************************************
+@ObjectType()
+export class RunmjBizAppsCommonAddressLinkViewResult {
+    @Field(() => [mjBizAppsCommonAddressLink_])
+    Results: mjBizAppsCommonAddressLink_[];
+
+    @Field(() => String, {nullable: true})
+    UserViewRunID?: string;
+
+    @Field(() => Int, {nullable: true})
+    RowCount: number;
+
+    @Field(() => Int, {nullable: true})
+    TotalRowCount: number;
+
+    @Field(() => Int, {nullable: true})
+    ExecutionTime: number;
+
+    @Field({nullable: true})
+    ErrorMessage?: string;
+
+    @Field(() => Boolean, {nullable: false})
+    Success: boolean;
+}
+
+@Resolver(mjBizAppsCommonAddressLink_)
+export class mjBizAppsCommonAddressLinkResolver extends ResolverBase {
+    @Query(() => RunmjBizAppsCommonAddressLinkViewResult)
+    async RunmjBizAppsCommonAddressLinkViewByID(@Arg('input', () => RunViewByIDInput) input: RunViewByIDInput, @Ctx() { providers, userPayload }: AppContext, @PubSub() pubSub: PubSubEngine) {
+        const provider = GetReadOnlyProvider(providers, { allowFallbackToReadWrite: true });
+        return super.RunViewByIDGeneric(input, provider, userPayload, pubSub);
+    }
+
+    @Query(() => RunmjBizAppsCommonAddressLinkViewResult)
+    async RunmjBizAppsCommonAddressLinkViewByName(@Arg('input', () => RunViewByNameInput) input: RunViewByNameInput, @Ctx() { providers, userPayload }: AppContext, @PubSub() pubSub: PubSubEngine) {
+        const provider = GetReadOnlyProvider(providers, { allowFallbackToReadWrite: true });
+        return super.RunViewByNameGeneric(input, provider, userPayload, pubSub);
+    }
+
+    @Query(() => RunmjBizAppsCommonAddressLinkViewResult)
+    async RunmjBizAppsCommonAddressLinkDynamicView(@Arg('input', () => RunDynamicViewInput) input: RunDynamicViewInput, @Ctx() { providers, userPayload }: AppContext, @PubSub() pubSub: PubSubEngine) {
+        const provider = GetReadOnlyProvider(providers, { allowFallbackToReadWrite: true });
+        input.EntityName = 'Address Links';
+        return super.RunDynamicViewGeneric(input, provider, userPayload, pubSub);
+    }
+    @Query(() => mjBizAppsCommonAddressLink_, { nullable: true })
+    async mjBizAppsCommonAddressLink(@Arg('ID', () => String) ID: string, @Ctx() { userPayload, providers }: AppContext, @PubSub() pubSub: PubSubEngine): Promise<mjBizAppsCommonAddressLink_ | null> {
+        this.CheckUserReadPermissions('Address Links', userPayload);
+        const provider = GetReadOnlyProvider(providers, { allowFallbackToReadWrite: true });
+        const sSQL = `SELECT * FROM ${provider.QuoteSchemaAndView('__mj_BizAppsCommon', 'vwAddressLinks')} WHERE ${provider.QuoteIdentifier('ID')}='${ID}' ` + this.getRowLevelSecurityWhereClause(provider, 'Address Links', userPayload, EntityPermissionType.Read, 'AND');
+        const rows = await provider.ExecuteSQL(sSQL, undefined, undefined, this.GetUserFromPayload(userPayload));
+        const result = await this.MapFieldNamesToCodeNames('Address Links', rows && rows.length > 0 ? rows[0] : null, this.GetUserFromPayload(userPayload));
+        return result;
+    }
+    
+    @Mutation(() => mjBizAppsCommonAddressLink_)
+    async CreatemjBizAppsCommonAddressLink(
+        @Arg('input', () => CreatemjBizAppsCommonAddressLinkInput) input: CreatemjBizAppsCommonAddressLinkInput,
+        @Ctx() { providers, userPayload }: AppContext,
+        @PubSub() pubSub: PubSubEngine
+    ) {
+        const provider = GetReadWriteProvider(providers);
+        return this.CreateRecord('Address Links', input, provider, userPayload, pubSub)
+    }
+        
+    @Mutation(() => mjBizAppsCommonAddressLink_)
+    async UpdatemjBizAppsCommonAddressLink(
+        @Arg('input', () => UpdatemjBizAppsCommonAddressLinkInput) input: UpdatemjBizAppsCommonAddressLinkInput,
+        @Ctx() { providers, userPayload }: AppContext,
+        @PubSub() pubSub: PubSubEngine
+    ) {
+        const provider = GetReadWriteProvider(providers);
+        return this.UpdateRecord('Address Links', input, provider, userPayload, pubSub);
+    }
+    
+    @Mutation(() => mjBizAppsCommonAddressLink_)
+    async DeletemjBizAppsCommonAddressLink(@Arg('ID', () => String) ID: string, @Arg('options___', () => DeleteOptionsInput) options: DeleteOptionsInput, @Ctx() { providers, userPayload }: AppContext, @PubSub() pubSub: PubSubEngine) {
+        const provider = GetReadWriteProvider(providers);
+        const key = new CompositeKey([{FieldName: 'ID', Value: ID}]);
+        return this.DeleteRecord('Address Links', key, options, provider, userPayload, pubSub);
+    }
+    
+}
+
+//****************************************************************************
+// ENTITY CLASS for Address Types
+//****************************************************************************
+@ObjectType({ description: `Categories of addresses such as Home, Work, Mailing, Billing` })
+export class mjBizAppsCommonAddressType_ {
+    @Field() 
+    @MaxLength(36)
+    ID: string;
+        
+    @Field({description: `Display name for the address type`}) 
+    @MaxLength(100)
+    Name: string;
+        
+    @Field({nullable: true, description: `Detailed description of this address type`}) 
+    Description?: string;
+        
+    @Field(() => Int, {description: `Default sort order for this address type in dropdown lists. Lower values appear first. Can be overridden per-record via AddressLink.Rank`}) 
+    DefaultRank: number;
+        
+    @Field() 
+    _mj__CreatedAt: Date;
+        
+    @Field() 
+    _mj__UpdatedAt: Date;
+        
+    @Field(() => [mjBizAppsCommonAddressLink_])
+    mjBizAppsCommonAddressLinks_AddressTypeIDArray: mjBizAppsCommonAddressLink_[]; // Link to mjBizAppsCommonAddressLinks
+    
+}
+
+//****************************************************************************
+// INPUT TYPE for Address Types
+//****************************************************************************
+@InputType()
+export class CreatemjBizAppsCommonAddressTypeInput {
+    @Field({ nullable: true })
+    ID?: string;
+
+    @Field({ nullable: true })
+    Name?: string;
+
+    @Field({ nullable: true })
+    Description: string | null;
+
+    @Field(() => Int, { nullable: true })
+    DefaultRank?: number;
+}
+    
+
+//****************************************************************************
+// INPUT TYPE for Address Types
+//****************************************************************************
+@InputType()
+export class UpdatemjBizAppsCommonAddressTypeInput {
+    @Field()
+    ID: string;
+
+    @Field({ nullable: true })
+    Name?: string;
+
+    @Field({ nullable: true })
+    Description?: string | null;
+
+    @Field(() => Int, { nullable: true })
+    DefaultRank?: number;
+
+    @Field(() => [KeyValuePairInput], { nullable: true })
+    OldValues___?: KeyValuePairInput[];
+}
+    
+//****************************************************************************
+// RESOLVER for Address Types
+//****************************************************************************
+@ObjectType()
+export class RunmjBizAppsCommonAddressTypeViewResult {
+    @Field(() => [mjBizAppsCommonAddressType_])
+    Results: mjBizAppsCommonAddressType_[];
+
+    @Field(() => String, {nullable: true})
+    UserViewRunID?: string;
+
+    @Field(() => Int, {nullable: true})
+    RowCount: number;
+
+    @Field(() => Int, {nullable: true})
+    TotalRowCount: number;
+
+    @Field(() => Int, {nullable: true})
+    ExecutionTime: number;
+
+    @Field({nullable: true})
+    ErrorMessage?: string;
+
+    @Field(() => Boolean, {nullable: false})
+    Success: boolean;
+}
+
+@Resolver(mjBizAppsCommonAddressType_)
+export class mjBizAppsCommonAddressTypeResolver extends ResolverBase {
+    @Query(() => RunmjBizAppsCommonAddressTypeViewResult)
+    async RunmjBizAppsCommonAddressTypeViewByID(@Arg('input', () => RunViewByIDInput) input: RunViewByIDInput, @Ctx() { providers, userPayload }: AppContext, @PubSub() pubSub: PubSubEngine) {
+        const provider = GetReadOnlyProvider(providers, { allowFallbackToReadWrite: true });
+        return super.RunViewByIDGeneric(input, provider, userPayload, pubSub);
+    }
+
+    @Query(() => RunmjBizAppsCommonAddressTypeViewResult)
+    async RunmjBizAppsCommonAddressTypeViewByName(@Arg('input', () => RunViewByNameInput) input: RunViewByNameInput, @Ctx() { providers, userPayload }: AppContext, @PubSub() pubSub: PubSubEngine) {
+        const provider = GetReadOnlyProvider(providers, { allowFallbackToReadWrite: true });
+        return super.RunViewByNameGeneric(input, provider, userPayload, pubSub);
+    }
+
+    @Query(() => RunmjBizAppsCommonAddressTypeViewResult)
+    async RunmjBizAppsCommonAddressTypeDynamicView(@Arg('input', () => RunDynamicViewInput) input: RunDynamicViewInput, @Ctx() { providers, userPayload }: AppContext, @PubSub() pubSub: PubSubEngine) {
+        const provider = GetReadOnlyProvider(providers, { allowFallbackToReadWrite: true });
+        input.EntityName = 'Address Types';
+        return super.RunDynamicViewGeneric(input, provider, userPayload, pubSub);
+    }
+    @Query(() => mjBizAppsCommonAddressType_, { nullable: true })
+    async mjBizAppsCommonAddressType(@Arg('ID', () => String) ID: string, @Ctx() { userPayload, providers }: AppContext, @PubSub() pubSub: PubSubEngine): Promise<mjBizAppsCommonAddressType_ | null> {
+        this.CheckUserReadPermissions('Address Types', userPayload);
+        const provider = GetReadOnlyProvider(providers, { allowFallbackToReadWrite: true });
+        const sSQL = `SELECT * FROM ${provider.QuoteSchemaAndView('__mj_BizAppsCommon', 'vwAddressTypes')} WHERE ${provider.QuoteIdentifier('ID')}='${ID}' ` + this.getRowLevelSecurityWhereClause(provider, 'Address Types', userPayload, EntityPermissionType.Read, 'AND');
+        const rows = await provider.ExecuteSQL(sSQL, undefined, undefined, this.GetUserFromPayload(userPayload));
+        const result = await this.MapFieldNamesToCodeNames('Address Types', rows && rows.length > 0 ? rows[0] : null, this.GetUserFromPayload(userPayload));
+        return result;
+    }
+    
+    @FieldResolver(() => [mjBizAppsCommonAddressLink_])
+    async mjBizAppsCommonAddressLinks_AddressTypeIDArray(@Root() mjbizappscommonaddresstype_: mjBizAppsCommonAddressType_, @Ctx() { userPayload, providers }: AppContext, @PubSub() pubSub: PubSubEngine) {
+        this.CheckUserReadPermissions('Address Links', userPayload);
+        const provider = GetReadOnlyProvider(providers, { allowFallbackToReadWrite: true });
+        const sSQL = `SELECT * FROM ${provider.QuoteSchemaAndView('__mj_BizAppsCommon', 'vwAddressLinks')} WHERE ${provider.QuoteIdentifier('AddressTypeID')}='${mjbizappscommonaddresstype_.ID}' ` + this.getRowLevelSecurityWhereClause(provider, 'Address Links', userPayload, EntityPermissionType.Read, 'AND');
+        const rows = await provider.ExecuteSQL(sSQL, undefined, undefined, this.GetUserFromPayload(userPayload));
+        const result = await this.ArrayMapFieldNamesToCodeNames('Address Links', rows, this.GetUserFromPayload(userPayload));
+        return result;
+    }
+        
+    @Mutation(() => mjBizAppsCommonAddressType_)
+    async CreatemjBizAppsCommonAddressType(
+        @Arg('input', () => CreatemjBizAppsCommonAddressTypeInput) input: CreatemjBizAppsCommonAddressTypeInput,
+        @Ctx() { providers, userPayload }: AppContext,
+        @PubSub() pubSub: PubSubEngine
+    ) {
+        const provider = GetReadWriteProvider(providers);
+        return this.CreateRecord('Address Types', input, provider, userPayload, pubSub)
+    }
+        
+    @Mutation(() => mjBizAppsCommonAddressType_)
+    async UpdatemjBizAppsCommonAddressType(
+        @Arg('input', () => UpdatemjBizAppsCommonAddressTypeInput) input: UpdatemjBizAppsCommonAddressTypeInput,
+        @Ctx() { providers, userPayload }: AppContext,
+        @PubSub() pubSub: PubSubEngine
+    ) {
+        const provider = GetReadWriteProvider(providers);
+        return this.UpdateRecord('Address Types', input, provider, userPayload, pubSub);
+    }
+    
+    @Mutation(() => mjBizAppsCommonAddressType_)
+    async DeletemjBizAppsCommonAddressType(@Arg('ID', () => String) ID: string, @Arg('options___', () => DeleteOptionsInput) options: DeleteOptionsInput, @Ctx() { providers, userPayload }: AppContext, @PubSub() pubSub: PubSubEngine) {
+        const provider = GetReadWriteProvider(providers);
+        const key = new CompositeKey([{FieldName: 'ID', Value: ID}]);
+        return this.DeleteRecord('Address Types', key, options, provider, userPayload, pubSub);
+    }
+    
+}
+
+//****************************************************************************
+// ENTITY CLASS for Addresses
+//****************************************************************************
+@ObjectType({ description: `Standalone physical address records linked to entities via AddressLink for sharing across people and organizations` })
+export class mjBizAppsCommonAddress_ {
+    @Field() 
+    @MaxLength(36)
+    ID: string;
+        
+    @Field({description: `Street address line 1`}) 
+    @MaxLength(255)
+    Line1: string;
+        
+    @Field({nullable: true, description: `Street address line 2 (suite, apt, etc.)`}) 
+    @MaxLength(255)
+    Line2?: string;
+        
+    @Field({nullable: true, description: `Street address line 3 (additional detail)`}) 
+    @MaxLength(255)
+    Line3?: string;
+        
+    @Field({description: `City or locality name`}) 
+    @MaxLength(100)
+    City: string;
+        
+    @Field({nullable: true, description: `State, province, or region`}) 
+    @MaxLength(100)
+    StateProvince?: string;
+        
+    @Field({nullable: true, description: `Postal or ZIP code`}) 
+    @MaxLength(20)
+    PostalCode?: string;
+        
+    @Field({description: `Country code or name, defaults to US`}) 
+    @MaxLength(100)
+    Country: string;
+        
+    @Field(() => Float, {nullable: true, description: `Geographic latitude for mapping`}) 
+    Latitude?: number;
+        
+    @Field(() => Float, {nullable: true, description: `Geographic longitude for mapping`}) 
+    Longitude?: number;
+        
+    @Field() 
+    _mj__CreatedAt: Date;
+        
+    @Field() 
+    _mj__UpdatedAt: Date;
+        
+    @Field(() => [mjBizAppsCommonAddressLink_])
+    mjBizAppsCommonAddressLinks_AddressIDArray: mjBizAppsCommonAddressLink_[]; // Link to mjBizAppsCommonAddressLinks
+    
+}
+
+//****************************************************************************
+// INPUT TYPE for Addresses
+//****************************************************************************
+@InputType()
+export class CreatemjBizAppsCommonAddressInput {
+    @Field({ nullable: true })
+    ID?: string;
+
+    @Field({ nullable: true })
+    Line1?: string;
+
+    @Field({ nullable: true })
+    Line2: string | null;
+
+    @Field({ nullable: true })
+    Line3: string | null;
+
+    @Field({ nullable: true })
+    City?: string;
+
+    @Field({ nullable: true })
+    StateProvince: string | null;
+
+    @Field({ nullable: true })
+    PostalCode: string | null;
+
+    @Field({ nullable: true })
+    Country?: string;
+
+    @Field(() => Float, { nullable: true })
+    Latitude: number | null;
+
+    @Field(() => Float, { nullable: true })
+    Longitude: number | null;
+}
+    
+
+//****************************************************************************
+// INPUT TYPE for Addresses
+//****************************************************************************
+@InputType()
+export class UpdatemjBizAppsCommonAddressInput {
+    @Field()
+    ID: string;
+
+    @Field({ nullable: true })
+    Line1?: string;
+
+    @Field({ nullable: true })
+    Line2?: string | null;
+
+    @Field({ nullable: true })
+    Line3?: string | null;
+
+    @Field({ nullable: true })
+    City?: string;
+
+    @Field({ nullable: true })
+    StateProvince?: string | null;
+
+    @Field({ nullable: true })
+    PostalCode?: string | null;
+
+    @Field({ nullable: true })
+    Country?: string;
+
+    @Field(() => Float, { nullable: true })
+    Latitude?: number | null;
+
+    @Field(() => Float, { nullable: true })
+    Longitude?: number | null;
+
+    @Field(() => [KeyValuePairInput], { nullable: true })
+    OldValues___?: KeyValuePairInput[];
+}
+    
+//****************************************************************************
+// RESOLVER for Addresses
+//****************************************************************************
+@ObjectType()
+export class RunmjBizAppsCommonAddressViewResult {
+    @Field(() => [mjBizAppsCommonAddress_])
+    Results: mjBizAppsCommonAddress_[];
+
+    @Field(() => String, {nullable: true})
+    UserViewRunID?: string;
+
+    @Field(() => Int, {nullable: true})
+    RowCount: number;
+
+    @Field(() => Int, {nullable: true})
+    TotalRowCount: number;
+
+    @Field(() => Int, {nullable: true})
+    ExecutionTime: number;
+
+    @Field({nullable: true})
+    ErrorMessage?: string;
+
+    @Field(() => Boolean, {nullable: false})
+    Success: boolean;
+}
+
+@Resolver(mjBizAppsCommonAddress_)
+export class mjBizAppsCommonAddressResolver extends ResolverBase {
+    @Query(() => RunmjBizAppsCommonAddressViewResult)
+    async RunmjBizAppsCommonAddressViewByID(@Arg('input', () => RunViewByIDInput) input: RunViewByIDInput, @Ctx() { providers, userPayload }: AppContext, @PubSub() pubSub: PubSubEngine) {
+        const provider = GetReadOnlyProvider(providers, { allowFallbackToReadWrite: true });
+        return super.RunViewByIDGeneric(input, provider, userPayload, pubSub);
+    }
+
+    @Query(() => RunmjBizAppsCommonAddressViewResult)
+    async RunmjBizAppsCommonAddressViewByName(@Arg('input', () => RunViewByNameInput) input: RunViewByNameInput, @Ctx() { providers, userPayload }: AppContext, @PubSub() pubSub: PubSubEngine) {
+        const provider = GetReadOnlyProvider(providers, { allowFallbackToReadWrite: true });
+        return super.RunViewByNameGeneric(input, provider, userPayload, pubSub);
+    }
+
+    @Query(() => RunmjBizAppsCommonAddressViewResult)
+    async RunmjBizAppsCommonAddressDynamicView(@Arg('input', () => RunDynamicViewInput) input: RunDynamicViewInput, @Ctx() { providers, userPayload }: AppContext, @PubSub() pubSub: PubSubEngine) {
+        const provider = GetReadOnlyProvider(providers, { allowFallbackToReadWrite: true });
+        input.EntityName = 'Addresses';
+        return super.RunDynamicViewGeneric(input, provider, userPayload, pubSub);
+    }
+    @Query(() => mjBizAppsCommonAddress_, { nullable: true })
+    async mjBizAppsCommonAddress(@Arg('ID', () => String) ID: string, @Ctx() { userPayload, providers }: AppContext, @PubSub() pubSub: PubSubEngine): Promise<mjBizAppsCommonAddress_ | null> {
+        this.CheckUserReadPermissions('Addresses', userPayload);
+        const provider = GetReadOnlyProvider(providers, { allowFallbackToReadWrite: true });
+        const sSQL = `SELECT * FROM ${provider.QuoteSchemaAndView('__mj_BizAppsCommon', 'vwAddresses')} WHERE ${provider.QuoteIdentifier('ID')}='${ID}' ` + this.getRowLevelSecurityWhereClause(provider, 'Addresses', userPayload, EntityPermissionType.Read, 'AND');
+        const rows = await provider.ExecuteSQL(sSQL, undefined, undefined, this.GetUserFromPayload(userPayload));
+        const result = await this.MapFieldNamesToCodeNames('Addresses', rows && rows.length > 0 ? rows[0] : null, this.GetUserFromPayload(userPayload));
+        return result;
+    }
+    
+    @FieldResolver(() => [mjBizAppsCommonAddressLink_])
+    async mjBizAppsCommonAddressLinks_AddressIDArray(@Root() mjbizappscommonaddress_: mjBizAppsCommonAddress_, @Ctx() { userPayload, providers }: AppContext, @PubSub() pubSub: PubSubEngine) {
+        this.CheckUserReadPermissions('Address Links', userPayload);
+        const provider = GetReadOnlyProvider(providers, { allowFallbackToReadWrite: true });
+        const sSQL = `SELECT * FROM ${provider.QuoteSchemaAndView('__mj_BizAppsCommon', 'vwAddressLinks')} WHERE ${provider.QuoteIdentifier('AddressID')}='${mjbizappscommonaddress_.ID}' ` + this.getRowLevelSecurityWhereClause(provider, 'Address Links', userPayload, EntityPermissionType.Read, 'AND');
+        const rows = await provider.ExecuteSQL(sSQL, undefined, undefined, this.GetUserFromPayload(userPayload));
+        const result = await this.ArrayMapFieldNamesToCodeNames('Address Links', rows, this.GetUserFromPayload(userPayload));
+        return result;
+    }
+        
+    @Mutation(() => mjBizAppsCommonAddress_)
+    async CreatemjBizAppsCommonAddress(
+        @Arg('input', () => CreatemjBizAppsCommonAddressInput) input: CreatemjBizAppsCommonAddressInput,
+        @Ctx() { providers, userPayload }: AppContext,
+        @PubSub() pubSub: PubSubEngine
+    ) {
+        const provider = GetReadWriteProvider(providers);
+        return this.CreateRecord('Addresses', input, provider, userPayload, pubSub)
+    }
+        
+    @Mutation(() => mjBizAppsCommonAddress_)
+    async UpdatemjBizAppsCommonAddress(
+        @Arg('input', () => UpdatemjBizAppsCommonAddressInput) input: UpdatemjBizAppsCommonAddressInput,
+        @Ctx() { providers, userPayload }: AppContext,
+        @PubSub() pubSub: PubSubEngine
+    ) {
+        const provider = GetReadWriteProvider(providers);
+        return this.UpdateRecord('Addresses', input, provider, userPayload, pubSub);
+    }
+    
+    @Mutation(() => mjBizAppsCommonAddress_)
+    async DeletemjBizAppsCommonAddress(@Arg('ID', () => String) ID: string, @Arg('options___', () => DeleteOptionsInput) options: DeleteOptionsInput, @Ctx() { providers, userPayload }: AppContext, @PubSub() pubSub: PubSubEngine) {
+        const provider = GetReadWriteProvider(providers);
+        const key = new CompositeKey([{FieldName: 'ID', Value: ID}]);
+        return this.DeleteRecord('Addresses', key, options, provider, userPayload, pubSub);
+    }
+    
+}
+
+//****************************************************************************
+// ENTITY CLASS for Agenda Items
+//****************************************************************************
+@ObjectType({ description: `Structured agenda items for meetings with hierarchy support` })
+export class mjCommitteesAgendaItem_ {
+    @Field() 
+    @MaxLength(36)
+    ID: string;
+        
+    @Field() 
+    @MaxLength(36)
+    MeetingID: string;
+        
+    @Field({nullable: true}) 
+    @MaxLength(36)
+    ParentAgendaItemID?: string;
+        
+    @Field(() => Int, {description: `Display order within the meeting agenda`}) 
+    Sequence: number;
+        
+    @Field({description: `Title of the agenda item`}) 
+    @MaxLength(255)
+    Title: string;
+        
+    @Field({nullable: true, description: `Detailed description of the agenda item`}) 
+    Description?: string;
+        
+    @Field({nullable: true}) 
+    @MaxLength(36)
+    PresenterPersonID?: string;
+        
+    @Field(() => Int, {nullable: true, description: `Estimated duration in minutes`}) 
+    DurationMinutes?: number;
+        
+    @Field({description: `Type of item: Information, Discussion, Action, Vote, Report, Other`}) 
+    @MaxLength(50)
+    ItemType: string;
+        
+    @Field({nullable: true, description: `URL to related document for this item`}) 
+    @MaxLength(1000)
+    RelatedDocumentURL?: string;
+        
+    @Field({description: `Current status: Pending, Discussed, Tabled, Completed, Skipped`}) 
+    @MaxLength(50)
+    Status: string;
+        
+    @Field({nullable: true, description: `Discussion notes and outcomes captured during the meeting`}) 
+    Notes?: string;
+        
+    @Field() 
+    _mj__CreatedAt: Date;
+        
+    @Field() 
+    _mj__UpdatedAt: Date;
+        
+    @Field() 
+    @MaxLength(255)
+    Meeting: string;
+        
+    @Field({nullable: true}) 
+    @MaxLength(255)
+    ParentAgendaItem?: string;
+        
+    @Field({nullable: true}) 
+    @MaxLength(100)
+    PresenterPerson?: string;
+        
+    @Field({nullable: true}) 
+    @MaxLength(36)
+    RootParentAgendaItemID?: string;
+        
+    @Field(() => [mjCommitteesAgendaItem_])
+    mjCommitteesAgendaItems_ParentAgendaItemIDArray: mjCommitteesAgendaItem_[]; // Link to mjCommitteesAgendaItems
+    
+    @Field(() => [mjCommitteesMotion_])
+    mjCommitteesMotions_AgendaItemIDArray: mjCommitteesMotion_[]; // Link to mjCommitteesMotions
+    
+    @Field(() => [mjCommitteesActionItem_])
+    mjCommitteesActionItems_AgendaItemIDArray: mjCommitteesActionItem_[]; // Link to mjCommitteesActionItems
+    
+    @Field(() => [mjCommitteesArtifact_])
+    mjCommitteesArtifacts_AgendaItemIDArray: mjCommitteesArtifact_[]; // Link to mjCommitteesArtifacts
+    
+    @Field(() => [mjCommitteesComment_])
+    mjCommitteesComments_AgendaItemIDArray: mjCommitteesComment_[]; // Link to mjCommitteesComments
+    
+}
+
+//****************************************************************************
+// INPUT TYPE for Agenda Items
+//****************************************************************************
+@InputType()
+export class CreatemjCommitteesAgendaItemInput {
+    @Field({ nullable: true })
+    ID?: string;
+
+    @Field({ nullable: true })
+    MeetingID?: string;
+
+    @Field({ nullable: true })
+    ParentAgendaItemID: string | null;
+
+    @Field(() => Int, { nullable: true })
+    Sequence?: number;
+
+    @Field({ nullable: true })
+    Title?: string;
+
+    @Field({ nullable: true })
+    Description: string | null;
+
+    @Field({ nullable: true })
+    PresenterPersonID: string | null;
+
+    @Field(() => Int, { nullable: true })
+    DurationMinutes: number | null;
+
+    @Field({ nullable: true })
+    ItemType?: string;
+
+    @Field({ nullable: true })
+    RelatedDocumentURL: string | null;
+
+    @Field({ nullable: true })
+    Status?: string;
+
+    @Field({ nullable: true })
+    Notes: string | null;
+}
+    
+
+//****************************************************************************
+// INPUT TYPE for Agenda Items
+//****************************************************************************
+@InputType()
+export class UpdatemjCommitteesAgendaItemInput {
+    @Field()
+    ID: string;
+
+    @Field({ nullable: true })
+    MeetingID?: string;
+
+    @Field({ nullable: true })
+    ParentAgendaItemID?: string | null;
+
+    @Field(() => Int, { nullable: true })
+    Sequence?: number;
+
+    @Field({ nullable: true })
+    Title?: string;
+
+    @Field({ nullable: true })
+    Description?: string | null;
+
+    @Field({ nullable: true })
+    PresenterPersonID?: string | null;
+
+    @Field(() => Int, { nullable: true })
+    DurationMinutes?: number | null;
+
+    @Field({ nullable: true })
+    ItemType?: string;
+
+    @Field({ nullable: true })
+    RelatedDocumentURL?: string | null;
+
+    @Field({ nullable: true })
+    Status?: string;
+
+    @Field({ nullable: true })
+    Notes?: string | null;
+
+    @Field(() => [KeyValuePairInput], { nullable: true })
+    OldValues___?: KeyValuePairInput[];
+}
+    
+//****************************************************************************
+// RESOLVER for Agenda Items
+//****************************************************************************
+@ObjectType()
+export class RunmjCommitteesAgendaItemViewResult {
+    @Field(() => [mjCommitteesAgendaItem_])
+    Results: mjCommitteesAgendaItem_[];
+
+    @Field(() => String, {nullable: true})
+    UserViewRunID?: string;
+
+    @Field(() => Int, {nullable: true})
+    RowCount: number;
+
+    @Field(() => Int, {nullable: true})
+    TotalRowCount: number;
+
+    @Field(() => Int, {nullable: true})
+    ExecutionTime: number;
+
+    @Field({nullable: true})
+    ErrorMessage?: string;
+
+    @Field(() => Boolean, {nullable: false})
+    Success: boolean;
+}
+
+@Resolver(mjCommitteesAgendaItem_)
+export class mjCommitteesAgendaItemResolver extends ResolverBase {
+    @Query(() => RunmjCommitteesAgendaItemViewResult)
+    async RunmjCommitteesAgendaItemViewByID(@Arg('input', () => RunViewByIDInput) input: RunViewByIDInput, @Ctx() { providers, userPayload }: AppContext, @PubSub() pubSub: PubSubEngine) {
+        const provider = GetReadOnlyProvider(providers, { allowFallbackToReadWrite: true });
+        return super.RunViewByIDGeneric(input, provider, userPayload, pubSub);
+    }
+
+    @Query(() => RunmjCommitteesAgendaItemViewResult)
+    async RunmjCommitteesAgendaItemViewByName(@Arg('input', () => RunViewByNameInput) input: RunViewByNameInput, @Ctx() { providers, userPayload }: AppContext, @PubSub() pubSub: PubSubEngine) {
+        const provider = GetReadOnlyProvider(providers, { allowFallbackToReadWrite: true });
+        return super.RunViewByNameGeneric(input, provider, userPayload, pubSub);
+    }
+
+    @Query(() => RunmjCommitteesAgendaItemViewResult)
+    async RunmjCommitteesAgendaItemDynamicView(@Arg('input', () => RunDynamicViewInput) input: RunDynamicViewInput, @Ctx() { providers, userPayload }: AppContext, @PubSub() pubSub: PubSubEngine) {
+        const provider = GetReadOnlyProvider(providers, { allowFallbackToReadWrite: true });
+        input.EntityName = 'Agenda Items';
+        return super.RunDynamicViewGeneric(input, provider, userPayload, pubSub);
+    }
+    @Query(() => mjCommitteesAgendaItem_, { nullable: true })
+    async mjCommitteesAgendaItem(@Arg('ID', () => String) ID: string, @Ctx() { userPayload, providers }: AppContext, @PubSub() pubSub: PubSubEngine): Promise<mjCommitteesAgendaItem_ | null> {
+        this.CheckUserReadPermissions('Agenda Items', userPayload);
+        const provider = GetReadOnlyProvider(providers, { allowFallbackToReadWrite: true });
+        const sSQL = `SELECT * FROM ${provider.QuoteSchemaAndView('__mj_Committees', 'vwAgendaItems')} WHERE ${provider.QuoteIdentifier('ID')}='${ID}' ` + this.getRowLevelSecurityWhereClause(provider, 'Agenda Items', userPayload, EntityPermissionType.Read, 'AND');
+        const rows = await provider.ExecuteSQL(sSQL, undefined, undefined, this.GetUserFromPayload(userPayload));
+        const result = await this.MapFieldNamesToCodeNames('Agenda Items', rows && rows.length > 0 ? rows[0] : null, this.GetUserFromPayload(userPayload));
+        return result;
+    }
+    
+    @FieldResolver(() => [mjCommitteesAgendaItem_])
+    async mjCommitteesAgendaItems_ParentAgendaItemIDArray(@Root() mjcommitteesagendaitem_: mjCommitteesAgendaItem_, @Ctx() { userPayload, providers }: AppContext, @PubSub() pubSub: PubSubEngine) {
+        this.CheckUserReadPermissions('Agenda Items', userPayload);
+        const provider = GetReadOnlyProvider(providers, { allowFallbackToReadWrite: true });
+        const sSQL = `SELECT * FROM ${provider.QuoteSchemaAndView('__mj_Committees', 'vwAgendaItems')} WHERE ${provider.QuoteIdentifier('ParentAgendaItemID')}='${mjcommitteesagendaitem_.ID}' ` + this.getRowLevelSecurityWhereClause(provider, 'Agenda Items', userPayload, EntityPermissionType.Read, 'AND');
+        const rows = await provider.ExecuteSQL(sSQL, undefined, undefined, this.GetUserFromPayload(userPayload));
+        const result = await this.ArrayMapFieldNamesToCodeNames('Agenda Items', rows, this.GetUserFromPayload(userPayload));
+        return result;
+    }
+        
+    @FieldResolver(() => [mjCommitteesMotion_])
+    async mjCommitteesMotions_AgendaItemIDArray(@Root() mjcommitteesagendaitem_: mjCommitteesAgendaItem_, @Ctx() { userPayload, providers }: AppContext, @PubSub() pubSub: PubSubEngine) {
+        this.CheckUserReadPermissions('Motions', userPayload);
+        const provider = GetReadOnlyProvider(providers, { allowFallbackToReadWrite: true });
+        const sSQL = `SELECT * FROM ${provider.QuoteSchemaAndView('__mj_Committees', 'vwMotions')} WHERE ${provider.QuoteIdentifier('AgendaItemID')}='${mjcommitteesagendaitem_.ID}' ` + this.getRowLevelSecurityWhereClause(provider, 'Motions', userPayload, EntityPermissionType.Read, 'AND');
+        const rows = await provider.ExecuteSQL(sSQL, undefined, undefined, this.GetUserFromPayload(userPayload));
+        const result = await this.ArrayMapFieldNamesToCodeNames('Motions', rows, this.GetUserFromPayload(userPayload));
+        return result;
+    }
+        
+    @FieldResolver(() => [mjCommitteesActionItem_])
+    async mjCommitteesActionItems_AgendaItemIDArray(@Root() mjcommitteesagendaitem_: mjCommitteesAgendaItem_, @Ctx() { userPayload, providers }: AppContext, @PubSub() pubSub: PubSubEngine) {
+        this.CheckUserReadPermissions('Action Items', userPayload);
+        const provider = GetReadOnlyProvider(providers, { allowFallbackToReadWrite: true });
+        const sSQL = `SELECT * FROM ${provider.QuoteSchemaAndView('__mj_Committees', 'vwActionItems')} WHERE ${provider.QuoteIdentifier('AgendaItemID')}='${mjcommitteesagendaitem_.ID}' ` + this.getRowLevelSecurityWhereClause(provider, 'Action Items', userPayload, EntityPermissionType.Read, 'AND');
+        const rows = await provider.ExecuteSQL(sSQL, undefined, undefined, this.GetUserFromPayload(userPayload));
+        const result = await this.ArrayMapFieldNamesToCodeNames('Action Items', rows, this.GetUserFromPayload(userPayload));
+        return result;
+    }
+        
+    @FieldResolver(() => [mjCommitteesArtifact_])
+    async mjCommitteesArtifacts_AgendaItemIDArray(@Root() mjcommitteesagendaitem_: mjCommitteesAgendaItem_, @Ctx() { userPayload, providers }: AppContext, @PubSub() pubSub: PubSubEngine) {
+        this.CheckUserReadPermissions('Artifacts', userPayload);
+        const provider = GetReadOnlyProvider(providers, { allowFallbackToReadWrite: true });
+        const sSQL = `SELECT * FROM ${provider.QuoteSchemaAndView('__mj_Committees', 'vwArtifacts')} WHERE ${provider.QuoteIdentifier('AgendaItemID')}='${mjcommitteesagendaitem_.ID}' ` + this.getRowLevelSecurityWhereClause(provider, 'Artifacts', userPayload, EntityPermissionType.Read, 'AND');
+        const rows = await provider.ExecuteSQL(sSQL, undefined, undefined, this.GetUserFromPayload(userPayload));
+        const result = await this.ArrayMapFieldNamesToCodeNames('Artifacts', rows, this.GetUserFromPayload(userPayload));
+        return result;
+    }
+        
+    @FieldResolver(() => [mjCommitteesComment_])
+    async mjCommitteesComments_AgendaItemIDArray(@Root() mjcommitteesagendaitem_: mjCommitteesAgendaItem_, @Ctx() { userPayload, providers }: AppContext, @PubSub() pubSub: PubSubEngine) {
+        this.CheckUserReadPermissions('Comments', userPayload);
+        const provider = GetReadOnlyProvider(providers, { allowFallbackToReadWrite: true });
+        const sSQL = `SELECT * FROM ${provider.QuoteSchemaAndView('__mj_Committees', 'vwComments')} WHERE ${provider.QuoteIdentifier('AgendaItemID')}='${mjcommitteesagendaitem_.ID}' ` + this.getRowLevelSecurityWhereClause(provider, 'Comments', userPayload, EntityPermissionType.Read, 'AND');
+        const rows = await provider.ExecuteSQL(sSQL, undefined, undefined, this.GetUserFromPayload(userPayload));
+        const result = await this.ArrayMapFieldNamesToCodeNames('Comments', rows, this.GetUserFromPayload(userPayload));
+        return result;
+    }
+        
+    @Mutation(() => mjCommitteesAgendaItem_)
+    async CreatemjCommitteesAgendaItem(
+        @Arg('input', () => CreatemjCommitteesAgendaItemInput) input: CreatemjCommitteesAgendaItemInput,
+        @Ctx() { providers, userPayload }: AppContext,
+        @PubSub() pubSub: PubSubEngine
+    ) {
+        const provider = GetReadWriteProvider(providers);
+        return this.CreateRecord('Agenda Items', input, provider, userPayload, pubSub)
+    }
+        
+    @Mutation(() => mjCommitteesAgendaItem_)
+    async UpdatemjCommitteesAgendaItem(
+        @Arg('input', () => UpdatemjCommitteesAgendaItemInput) input: UpdatemjCommitteesAgendaItemInput,
+        @Ctx() { providers, userPayload }: AppContext,
+        @PubSub() pubSub: PubSubEngine
+    ) {
+        const provider = GetReadWriteProvider(providers);
+        return this.UpdateRecord('Agenda Items', input, provider, userPayload, pubSub);
+    }
+    
+    @Mutation(() => mjCommitteesAgendaItem_)
+    async DeletemjCommitteesAgendaItem(@Arg('ID', () => String) ID: string, @Arg('options___', () => DeleteOptionsInput) options: DeleteOptionsInput, @Ctx() { providers, userPayload }: AppContext, @PubSub() pubSub: PubSubEngine) {
+        const provider = GetReadWriteProvider(providers);
+        const key = new CompositeKey([{FieldName: 'ID', Value: ID}]);
+        return this.DeleteRecord('Agenda Items', key, options, provider, userPayload, pubSub);
+    }
+    
+}
+
+//****************************************************************************
+// ENTITY CLASS for Artifact Types
+//****************************************************************************
+@ObjectType({ description: `Categories of committee artifacts with optional extension entity for type-specific fields` })
+export class mjCommitteesArtifactType_ {
+    @Field() 
+    @MaxLength(36)
+    ID: string;
+        
+    @Field({description: `Display name for the artifact type`}) 
+    @MaxLength(100)
+    Name: string;
+        
+    @Field({nullable: true, description: `Detailed description of this artifact type`}) 
+    Description?: string;
+        
+    @Field({nullable: true, description: `Optional reference to an MJ Entity that provides additional fields for this artifact type via a 1:1 extension table`}) 
+    @MaxLength(36)
+    ExtendedEntityID?: string;
+        
+    @Field({nullable: true, description: `Font Awesome icon class for UI display`}) 
+    @MaxLength(100)
+    IconClass?: string;
+        
+    @Field() 
+    _mj__CreatedAt: Date;
+        
+    @Field() 
+    _mj__UpdatedAt: Date;
+        
+    @Field({nullable: true}) 
+    @MaxLength(255)
+    ExtendedEntity?: string;
+        
+    @Field(() => [mjCommitteesArtifact_])
+    mjCommitteesArtifacts_ArtifactTypeIDArray: mjCommitteesArtifact_[]; // Link to mjCommitteesArtifacts
+    
+}
+
+//****************************************************************************
+// INPUT TYPE for Artifact Types
+//****************************************************************************
+@InputType()
+export class CreatemjCommitteesArtifactTypeInput {
+    @Field({ nullable: true })
+    ID?: string;
+
+    @Field({ nullable: true })
+    Name?: string;
+
+    @Field({ nullable: true })
+    Description: string | null;
+
+    @Field({ nullable: true })
+    ExtendedEntityID: string | null;
+
+    @Field({ nullable: true })
+    IconClass: string | null;
+}
+    
+
+//****************************************************************************
+// INPUT TYPE for Artifact Types
+//****************************************************************************
+@InputType()
+export class UpdatemjCommitteesArtifactTypeInput {
+    @Field()
+    ID: string;
+
+    @Field({ nullable: true })
+    Name?: string;
+
+    @Field({ nullable: true })
+    Description?: string | null;
+
+    @Field({ nullable: true })
+    ExtendedEntityID?: string | null;
+
+    @Field({ nullable: true })
+    IconClass?: string | null;
+
+    @Field(() => [KeyValuePairInput], { nullable: true })
+    OldValues___?: KeyValuePairInput[];
+}
+    
+//****************************************************************************
+// RESOLVER for Artifact Types
+//****************************************************************************
+@ObjectType()
+export class RunmjCommitteesArtifactTypeViewResult {
+    @Field(() => [mjCommitteesArtifactType_])
+    Results: mjCommitteesArtifactType_[];
+
+    @Field(() => String, {nullable: true})
+    UserViewRunID?: string;
+
+    @Field(() => Int, {nullable: true})
+    RowCount: number;
+
+    @Field(() => Int, {nullable: true})
+    TotalRowCount: number;
+
+    @Field(() => Int, {nullable: true})
+    ExecutionTime: number;
+
+    @Field({nullable: true})
+    ErrorMessage?: string;
+
+    @Field(() => Boolean, {nullable: false})
+    Success: boolean;
+}
+
+@Resolver(mjCommitteesArtifactType_)
+export class mjCommitteesArtifactTypeResolver extends ResolverBase {
+    @Query(() => RunmjCommitteesArtifactTypeViewResult)
+    async RunmjCommitteesArtifactTypeViewByID(@Arg('input', () => RunViewByIDInput) input: RunViewByIDInput, @Ctx() { providers, userPayload }: AppContext, @PubSub() pubSub: PubSubEngine) {
+        const provider = GetReadOnlyProvider(providers, { allowFallbackToReadWrite: true });
+        return super.RunViewByIDGeneric(input, provider, userPayload, pubSub);
+    }
+
+    @Query(() => RunmjCommitteesArtifactTypeViewResult)
+    async RunmjCommitteesArtifactTypeViewByName(@Arg('input', () => RunViewByNameInput) input: RunViewByNameInput, @Ctx() { providers, userPayload }: AppContext, @PubSub() pubSub: PubSubEngine) {
+        const provider = GetReadOnlyProvider(providers, { allowFallbackToReadWrite: true });
+        return super.RunViewByNameGeneric(input, provider, userPayload, pubSub);
+    }
+
+    @Query(() => RunmjCommitteesArtifactTypeViewResult)
+    async RunmjCommitteesArtifactTypeDynamicView(@Arg('input', () => RunDynamicViewInput) input: RunDynamicViewInput, @Ctx() { providers, userPayload }: AppContext, @PubSub() pubSub: PubSubEngine) {
+        const provider = GetReadOnlyProvider(providers, { allowFallbackToReadWrite: true });
+        input.EntityName = 'Artifact Types';
+        return super.RunDynamicViewGeneric(input, provider, userPayload, pubSub);
+    }
+    @Query(() => mjCommitteesArtifactType_, { nullable: true })
+    async mjCommitteesArtifactType(@Arg('ID', () => String) ID: string, @Ctx() { userPayload, providers }: AppContext, @PubSub() pubSub: PubSubEngine): Promise<mjCommitteesArtifactType_ | null> {
+        this.CheckUserReadPermissions('Artifact Types', userPayload);
+        const provider = GetReadOnlyProvider(providers, { allowFallbackToReadWrite: true });
+        const sSQL = `SELECT * FROM ${provider.QuoteSchemaAndView('__mj_Committees', 'vwArtifactTypes')} WHERE ${provider.QuoteIdentifier('ID')}='${ID}' ` + this.getRowLevelSecurityWhereClause(provider, 'Artifact Types', userPayload, EntityPermissionType.Read, 'AND');
+        const rows = await provider.ExecuteSQL(sSQL, undefined, undefined, this.GetUserFromPayload(userPayload));
+        const result = await this.MapFieldNamesToCodeNames('Artifact Types', rows && rows.length > 0 ? rows[0] : null, this.GetUserFromPayload(userPayload));
+        return result;
+    }
+    
+    @FieldResolver(() => [mjCommitteesArtifact_])
+    async mjCommitteesArtifacts_ArtifactTypeIDArray(@Root() mjcommitteesartifacttype_: mjCommitteesArtifactType_, @Ctx() { userPayload, providers }: AppContext, @PubSub() pubSub: PubSubEngine) {
+        this.CheckUserReadPermissions('Artifacts', userPayload);
+        const provider = GetReadOnlyProvider(providers, { allowFallbackToReadWrite: true });
+        const sSQL = `SELECT * FROM ${provider.QuoteSchemaAndView('__mj_Committees', 'vwArtifacts')} WHERE ${provider.QuoteIdentifier('ArtifactTypeID')}='${mjcommitteesartifacttype_.ID}' ` + this.getRowLevelSecurityWhereClause(provider, 'Artifacts', userPayload, EntityPermissionType.Read, 'AND');
+        const rows = await provider.ExecuteSQL(sSQL, undefined, undefined, this.GetUserFromPayload(userPayload));
+        const result = await this.ArrayMapFieldNamesToCodeNames('Artifacts', rows, this.GetUserFromPayload(userPayload));
+        return result;
+    }
+        
+    @Mutation(() => mjCommitteesArtifactType_)
+    async CreatemjCommitteesArtifactType(
+        @Arg('input', () => CreatemjCommitteesArtifactTypeInput) input: CreatemjCommitteesArtifactTypeInput,
+        @Ctx() { providers, userPayload }: AppContext,
+        @PubSub() pubSub: PubSubEngine
+    ) {
+        const provider = GetReadWriteProvider(providers);
+        return this.CreateRecord('Artifact Types', input, provider, userPayload, pubSub)
+    }
+        
+    @Mutation(() => mjCommitteesArtifactType_)
+    async UpdatemjCommitteesArtifactType(
+        @Arg('input', () => UpdatemjCommitteesArtifactTypeInput) input: UpdatemjCommitteesArtifactTypeInput,
+        @Ctx() { providers, userPayload }: AppContext,
+        @PubSub() pubSub: PubSubEngine
+    ) {
+        const provider = GetReadWriteProvider(providers);
+        return this.UpdateRecord('Artifact Types', input, provider, userPayload, pubSub);
+    }
+    
+    @Mutation(() => mjCommitteesArtifactType_)
+    async DeletemjCommitteesArtifactType(@Arg('ID', () => String) ID: string, @Arg('options___', () => DeleteOptionsInput) options: DeleteOptionsInput, @Ctx() { providers, userPayload }: AppContext, @PubSub() pubSub: PubSubEngine) {
+        const provider = GetReadWriteProvider(providers);
+        const key = new CompositeKey([{FieldName: 'ID', Value: ID}]);
+        return this.DeleteRecord('Artifact Types', key, options, provider, userPayload, pubSub);
+    }
+    
+}
+
+//****************************************************************************
+// ENTITY CLASS for Artifacts
+//****************************************************************************
+@ObjectType({ description: `Links to external documents and files from various providers` })
+export class mjCommitteesArtifact_ {
+    @Field() 
+    @MaxLength(36)
+    ID: string;
+        
+    @Field({nullable: true}) 
+    @MaxLength(36)
+    CommitteeID?: string;
+        
+    @Field({nullable: true}) 
+    @MaxLength(36)
+    MeetingID?: string;
+        
+    @Field({nullable: true}) 
+    @MaxLength(36)
+    AgendaItemID?: string;
+        
+    @Field({nullable: true}) 
+    @MaxLength(36)
+    ActionItemID?: string;
+        
+    @Field({description: `Display title for the artifact`}) 
+    @MaxLength(255)
+    Title: string;
+        
+    @Field({nullable: true, description: `Description of the artifact contents`}) 
+    Description?: string;
+        
+    @Field() 
+    @MaxLength(36)
+    ArtifactTypeID: string;
+        
+    @Field({description: `Storage provider: GoogleDrive, SharePoint, Box, OneDrive, Dropbox, URL`}) 
+    @MaxLength(50)
+    Provider: string;
+        
+    @Field({nullable: true, description: `Provider-specific document or file ID`}) 
+    @MaxLength(500)
+    ExternalID?: string;
+        
+    @Field({description: `Direct URL to access the artifact`}) 
+    @MaxLength(2000)
+    URL: string;
+        
+    @Field({nullable: true, description: `MIME type of the file`}) 
+    @MaxLength(100)
+    MimeType?: string;
+        
+    @Field(() => Int, {nullable: true, description: `File size in bytes`}) 
+    FileSize?: number;
+        
+    @Field({nullable: true}) 
+    @MaxLength(36)
+    UploadedByPersonID?: string;
+        
+    @Field() 
+    _mj__CreatedAt: Date;
+        
+    @Field() 
+    _mj__UpdatedAt: Date;
+        
+    @Field({nullable: true}) 
+    @MaxLength(255)
+    Committee?: string;
+        
+    @Field({nullable: true}) 
+    @MaxLength(255)
+    Meeting?: string;
+        
+    @Field({nullable: true}) 
+    @MaxLength(255)
+    AgendaItem?: string;
+        
+    @Field({nullable: true}) 
+    @MaxLength(255)
+    ActionItem?: string;
+        
+    @Field() 
+    @MaxLength(100)
+    ArtifactType: string;
+        
+    @Field({nullable: true}) 
+    @MaxLength(100)
+    UploadedByPerson?: string;
+        
+    @Field(() => [mjCommitteesComment_])
+    mjCommitteesComments_ArtifactIDArray: mjCommitteesComment_[]; // Link to mjCommitteesComments
+    
+}
+
+//****************************************************************************
+// INPUT TYPE for Artifacts
+//****************************************************************************
+@InputType()
+export class CreatemjCommitteesArtifactInput {
+    @Field({ nullable: true })
+    ID?: string;
+
+    @Field({ nullable: true })
+    CommitteeID: string | null;
+
+    @Field({ nullable: true })
+    MeetingID: string | null;
+
+    @Field({ nullable: true })
+    AgendaItemID: string | null;
+
+    @Field({ nullable: true })
+    ActionItemID: string | null;
+
+    @Field({ nullable: true })
+    Title?: string;
+
+    @Field({ nullable: true })
+    Description: string | null;
+
+    @Field({ nullable: true })
+    ArtifactTypeID?: string;
+
+    @Field({ nullable: true })
+    Provider?: string;
+
+    @Field({ nullable: true })
+    ExternalID: string | null;
+
+    @Field({ nullable: true })
+    URL?: string;
+
+    @Field({ nullable: true })
+    MimeType: string | null;
+
+    @Field(() => Int, { nullable: true })
+    FileSize: number | null;
+
+    @Field({ nullable: true })
+    UploadedByPersonID: string | null;
+}
+    
+
+//****************************************************************************
+// INPUT TYPE for Artifacts
+//****************************************************************************
+@InputType()
+export class UpdatemjCommitteesArtifactInput {
+    @Field()
+    ID: string;
+
+    @Field({ nullable: true })
+    CommitteeID?: string | null;
+
+    @Field({ nullable: true })
+    MeetingID?: string | null;
+
+    @Field({ nullable: true })
+    AgendaItemID?: string | null;
+
+    @Field({ nullable: true })
+    ActionItemID?: string | null;
+
+    @Field({ nullable: true })
+    Title?: string;
+
+    @Field({ nullable: true })
+    Description?: string | null;
+
+    @Field({ nullable: true })
+    ArtifactTypeID?: string;
+
+    @Field({ nullable: true })
+    Provider?: string;
+
+    @Field({ nullable: true })
+    ExternalID?: string | null;
+
+    @Field({ nullable: true })
+    URL?: string;
+
+    @Field({ nullable: true })
+    MimeType?: string | null;
+
+    @Field(() => Int, { nullable: true })
+    FileSize?: number | null;
+
+    @Field({ nullable: true })
+    UploadedByPersonID?: string | null;
+
+    @Field(() => [KeyValuePairInput], { nullable: true })
+    OldValues___?: KeyValuePairInput[];
+}
+    
+//****************************************************************************
+// RESOLVER for Artifacts
+//****************************************************************************
+@ObjectType()
+export class RunmjCommitteesArtifactViewResult {
+    @Field(() => [mjCommitteesArtifact_])
+    Results: mjCommitteesArtifact_[];
+
+    @Field(() => String, {nullable: true})
+    UserViewRunID?: string;
+
+    @Field(() => Int, {nullable: true})
+    RowCount: number;
+
+    @Field(() => Int, {nullable: true})
+    TotalRowCount: number;
+
+    @Field(() => Int, {nullable: true})
+    ExecutionTime: number;
+
+    @Field({nullable: true})
+    ErrorMessage?: string;
+
+    @Field(() => Boolean, {nullable: false})
+    Success: boolean;
+}
+
+@Resolver(mjCommitteesArtifact_)
+export class mjCommitteesArtifactResolver extends ResolverBase {
+    @Query(() => RunmjCommitteesArtifactViewResult)
+    async RunmjCommitteesArtifactViewByID(@Arg('input', () => RunViewByIDInput) input: RunViewByIDInput, @Ctx() { providers, userPayload }: AppContext, @PubSub() pubSub: PubSubEngine) {
+        const provider = GetReadOnlyProvider(providers, { allowFallbackToReadWrite: true });
+        return super.RunViewByIDGeneric(input, provider, userPayload, pubSub);
+    }
+
+    @Query(() => RunmjCommitteesArtifactViewResult)
+    async RunmjCommitteesArtifactViewByName(@Arg('input', () => RunViewByNameInput) input: RunViewByNameInput, @Ctx() { providers, userPayload }: AppContext, @PubSub() pubSub: PubSubEngine) {
+        const provider = GetReadOnlyProvider(providers, { allowFallbackToReadWrite: true });
+        return super.RunViewByNameGeneric(input, provider, userPayload, pubSub);
+    }
+
+    @Query(() => RunmjCommitteesArtifactViewResult)
+    async RunmjCommitteesArtifactDynamicView(@Arg('input', () => RunDynamicViewInput) input: RunDynamicViewInput, @Ctx() { providers, userPayload }: AppContext, @PubSub() pubSub: PubSubEngine) {
+        const provider = GetReadOnlyProvider(providers, { allowFallbackToReadWrite: true });
+        input.EntityName = 'Artifacts';
+        return super.RunDynamicViewGeneric(input, provider, userPayload, pubSub);
+    }
+    @Query(() => mjCommitteesArtifact_, { nullable: true })
+    async mjCommitteesArtifact(@Arg('ID', () => String) ID: string, @Ctx() { userPayload, providers }: AppContext, @PubSub() pubSub: PubSubEngine): Promise<mjCommitteesArtifact_ | null> {
+        this.CheckUserReadPermissions('Artifacts', userPayload);
+        const provider = GetReadOnlyProvider(providers, { allowFallbackToReadWrite: true });
+        const sSQL = `SELECT * FROM ${provider.QuoteSchemaAndView('__mj_Committees', 'vwArtifacts')} WHERE ${provider.QuoteIdentifier('ID')}='${ID}' ` + this.getRowLevelSecurityWhereClause(provider, 'Artifacts', userPayload, EntityPermissionType.Read, 'AND');
+        const rows = await provider.ExecuteSQL(sSQL, undefined, undefined, this.GetUserFromPayload(userPayload));
+        const result = await this.MapFieldNamesToCodeNames('Artifacts', rows && rows.length > 0 ? rows[0] : null, this.GetUserFromPayload(userPayload));
+        return result;
+    }
+    
+    @FieldResolver(() => [mjCommitteesComment_])
+    async mjCommitteesComments_ArtifactIDArray(@Root() mjcommitteesartifact_: mjCommitteesArtifact_, @Ctx() { userPayload, providers }: AppContext, @PubSub() pubSub: PubSubEngine) {
+        this.CheckUserReadPermissions('Comments', userPayload);
+        const provider = GetReadOnlyProvider(providers, { allowFallbackToReadWrite: true });
+        const sSQL = `SELECT * FROM ${provider.QuoteSchemaAndView('__mj_Committees', 'vwComments')} WHERE ${provider.QuoteIdentifier('ArtifactID')}='${mjcommitteesartifact_.ID}' ` + this.getRowLevelSecurityWhereClause(provider, 'Comments', userPayload, EntityPermissionType.Read, 'AND');
+        const rows = await provider.ExecuteSQL(sSQL, undefined, undefined, this.GetUserFromPayload(userPayload));
+        const result = await this.ArrayMapFieldNamesToCodeNames('Comments', rows, this.GetUserFromPayload(userPayload));
+        return result;
+    }
+        
+    @Mutation(() => mjCommitteesArtifact_)
+    async CreatemjCommitteesArtifact(
+        @Arg('input', () => CreatemjCommitteesArtifactInput) input: CreatemjCommitteesArtifactInput,
+        @Ctx() { providers, userPayload }: AppContext,
+        @PubSub() pubSub: PubSubEngine
+    ) {
+        const provider = GetReadWriteProvider(providers);
+        return this.CreateRecord('Artifacts', input, provider, userPayload, pubSub)
+    }
+        
+    @Mutation(() => mjCommitteesArtifact_)
+    async UpdatemjCommitteesArtifact(
+        @Arg('input', () => UpdatemjCommitteesArtifactInput) input: UpdatemjCommitteesArtifactInput,
+        @Ctx() { providers, userPayload }: AppContext,
+        @PubSub() pubSub: PubSubEngine
+    ) {
+        const provider = GetReadWriteProvider(providers);
+        return this.UpdateRecord('Artifacts', input, provider, userPayload, pubSub);
+    }
+    
+    @Mutation(() => mjCommitteesArtifact_)
+    async DeletemjCommitteesArtifact(@Arg('ID', () => String) ID: string, @Arg('options___', () => DeleteOptionsInput) options: DeleteOptionsInput, @Ctx() { providers, userPayload }: AppContext, @PubSub() pubSub: PubSubEngine) {
+        const provider = GetReadWriteProvider(providers);
+        const key = new CompositeKey([{FieldName: 'ID', Value: ID}]);
+        return this.DeleteRecord('Artifacts', key, options, provider, userPayload, pubSub);
+    }
+    
+}
+
+//****************************************************************************
+// ENTITY CLASS for Attendances
+//****************************************************************************
+@ObjectType({ description: `Meeting attendance records for committee members` })
+export class mjCommitteesAttendance_ {
+    @Field() 
+    @MaxLength(36)
+    ID: string;
+        
+    @Field() 
+    @MaxLength(36)
+    MeetingID: string;
+        
+    @Field() 
+    @MaxLength(36)
+    PersonID: string;
+        
+    @Field({description: `Attendance status: Expected, Present, Absent, Excused, Partial`}) 
+    @MaxLength(50)
+    AttendanceStatus: string;
+        
+    @Field({nullable: true, description: `Timestamp when the attendee joined the meeting`}) 
+    JoinedAt?: Date;
+        
+    @Field({nullable: true, description: `Timestamp when the attendee left the meeting`}) 
+    LeftAt?: Date;
+        
+    @Field({nullable: true, description: `Additional notes about attendance`}) 
+    @MaxLength(500)
+    Notes?: string;
+        
+    @Field() 
+    _mj__CreatedAt: Date;
+        
+    @Field() 
+    _mj__UpdatedAt: Date;
+        
+    @Field() 
+    @MaxLength(255)
+    Meeting: string;
+        
+    @Field() 
+    @MaxLength(100)
+    Person: string;
+        
+}
+
+//****************************************************************************
+// INPUT TYPE for Attendances
+//****************************************************************************
+@InputType()
+export class CreatemjCommitteesAttendanceInput {
+    @Field({ nullable: true })
+    ID?: string;
+
+    @Field({ nullable: true })
+    MeetingID?: string;
+
+    @Field({ nullable: true })
+    PersonID?: string;
+
+    @Field({ nullable: true })
+    AttendanceStatus?: string;
+
+    @Field({ nullable: true })
+    JoinedAt: Date | null;
+
+    @Field({ nullable: true })
+    LeftAt: Date | null;
+
+    @Field({ nullable: true })
+    Notes: string | null;
+}
+    
+
+//****************************************************************************
+// INPUT TYPE for Attendances
+//****************************************************************************
+@InputType()
+export class UpdatemjCommitteesAttendanceInput {
+    @Field()
+    ID: string;
+
+    @Field({ nullable: true })
+    MeetingID?: string;
+
+    @Field({ nullable: true })
+    PersonID?: string;
+
+    @Field({ nullable: true })
+    AttendanceStatus?: string;
+
+    @Field({ nullable: true })
+    JoinedAt?: Date | null;
+
+    @Field({ nullable: true })
+    LeftAt?: Date | null;
+
+    @Field({ nullable: true })
+    Notes?: string | null;
+
+    @Field(() => [KeyValuePairInput], { nullable: true })
+    OldValues___?: KeyValuePairInput[];
+}
+    
+//****************************************************************************
+// RESOLVER for Attendances
+//****************************************************************************
+@ObjectType()
+export class RunmjCommitteesAttendanceViewResult {
+    @Field(() => [mjCommitteesAttendance_])
+    Results: mjCommitteesAttendance_[];
+
+    @Field(() => String, {nullable: true})
+    UserViewRunID?: string;
+
+    @Field(() => Int, {nullable: true})
+    RowCount: number;
+
+    @Field(() => Int, {nullable: true})
+    TotalRowCount: number;
+
+    @Field(() => Int, {nullable: true})
+    ExecutionTime: number;
+
+    @Field({nullable: true})
+    ErrorMessage?: string;
+
+    @Field(() => Boolean, {nullable: false})
+    Success: boolean;
+}
+
+@Resolver(mjCommitteesAttendance_)
+export class mjCommitteesAttendanceResolver extends ResolverBase {
+    @Query(() => RunmjCommitteesAttendanceViewResult)
+    async RunmjCommitteesAttendanceViewByID(@Arg('input', () => RunViewByIDInput) input: RunViewByIDInput, @Ctx() { providers, userPayload }: AppContext, @PubSub() pubSub: PubSubEngine) {
+        const provider = GetReadOnlyProvider(providers, { allowFallbackToReadWrite: true });
+        return super.RunViewByIDGeneric(input, provider, userPayload, pubSub);
+    }
+
+    @Query(() => RunmjCommitteesAttendanceViewResult)
+    async RunmjCommitteesAttendanceViewByName(@Arg('input', () => RunViewByNameInput) input: RunViewByNameInput, @Ctx() { providers, userPayload }: AppContext, @PubSub() pubSub: PubSubEngine) {
+        const provider = GetReadOnlyProvider(providers, { allowFallbackToReadWrite: true });
+        return super.RunViewByNameGeneric(input, provider, userPayload, pubSub);
+    }
+
+    @Query(() => RunmjCommitteesAttendanceViewResult)
+    async RunmjCommitteesAttendanceDynamicView(@Arg('input', () => RunDynamicViewInput) input: RunDynamicViewInput, @Ctx() { providers, userPayload }: AppContext, @PubSub() pubSub: PubSubEngine) {
+        const provider = GetReadOnlyProvider(providers, { allowFallbackToReadWrite: true });
+        input.EntityName = 'Attendances';
+        return super.RunDynamicViewGeneric(input, provider, userPayload, pubSub);
+    }
+    @Query(() => mjCommitteesAttendance_, { nullable: true })
+    async mjCommitteesAttendance(@Arg('ID', () => String) ID: string, @Ctx() { userPayload, providers }: AppContext, @PubSub() pubSub: PubSubEngine): Promise<mjCommitteesAttendance_ | null> {
+        this.CheckUserReadPermissions('Attendances', userPayload);
+        const provider = GetReadOnlyProvider(providers, { allowFallbackToReadWrite: true });
+        const sSQL = `SELECT * FROM ${provider.QuoteSchemaAndView('__mj_Committees', 'vwAttendances')} WHERE ${provider.QuoteIdentifier('ID')}='${ID}' ` + this.getRowLevelSecurityWhereClause(provider, 'Attendances', userPayload, EntityPermissionType.Read, 'AND');
+        const rows = await provider.ExecuteSQL(sSQL, undefined, undefined, this.GetUserFromPayload(userPayload));
+        const result = await this.MapFieldNamesToCodeNames('Attendances', rows && rows.length > 0 ? rows[0] : null, this.GetUserFromPayload(userPayload));
+        return result;
+    }
+    
+    @Mutation(() => mjCommitteesAttendance_)
+    async CreatemjCommitteesAttendance(
+        @Arg('input', () => CreatemjCommitteesAttendanceInput) input: CreatemjCommitteesAttendanceInput,
+        @Ctx() { providers, userPayload }: AppContext,
+        @PubSub() pubSub: PubSubEngine
+    ) {
+        const provider = GetReadWriteProvider(providers);
+        return this.CreateRecord('Attendances', input, provider, userPayload, pubSub)
+    }
+        
+    @Mutation(() => mjCommitteesAttendance_)
+    async UpdatemjCommitteesAttendance(
+        @Arg('input', () => UpdatemjCommitteesAttendanceInput) input: UpdatemjCommitteesAttendanceInput,
+        @Ctx() { providers, userPayload }: AppContext,
+        @PubSub() pubSub: PubSubEngine
+    ) {
+        const provider = GetReadWriteProvider(providers);
+        return this.UpdateRecord('Attendances', input, provider, userPayload, pubSub);
+    }
+    
+    @Mutation(() => mjCommitteesAttendance_)
+    async DeletemjCommitteesAttendance(@Arg('ID', () => String) ID: string, @Arg('options___', () => DeleteOptionsInput) options: DeleteOptionsInput, @Ctx() { providers, userPayload }: AppContext, @PubSub() pubSub: PubSubEngine) {
+        const provider = GetReadWriteProvider(providers);
+        const key = new CompositeKey([{FieldName: 'ID', Value: ID}]);
+        return this.DeleteRecord('Attendances', key, options, provider, userPayload, pubSub);
+    }
+    
+}
+
+//****************************************************************************
+// ENTITY CLASS for Comments
+//****************************************************************************
+@ObjectType({ description: `Threaded discussion comments on committee meetings, agenda items, action items, and documents` })
+export class mjCommitteesComment_ {
+    @Field() 
+    @MaxLength(36)
+    ID: string;
+        
+    @Field() 
+    @MaxLength(36)
+    CommitteeID: string;
+        
+    @Field({nullable: true}) 
+    @MaxLength(36)
+    MeetingID?: string;
+        
+    @Field({nullable: true}) 
+    @MaxLength(36)
+    AgendaItemID?: string;
+        
+    @Field({nullable: true}) 
+    @MaxLength(36)
+    ActionItemID?: string;
+        
+    @Field({nullable: true}) 
+    @MaxLength(36)
+    ArtifactID?: string;
+        
+    @Field({nullable: true}) 
+    @MaxLength(36)
+    ParentCommentID?: string;
+        
+    @Field() 
+    @MaxLength(36)
+    PersonID: string;
+        
+    @Field() 
+    CommentText: string;
+        
+    @Field({nullable: true}) 
+    MentionedPersonIDs?: string;
+        
+    @Field(() => Boolean) 
+    IsResolved: boolean;
+        
+    @Field() 
+    _mj__CreatedAt: Date;
+        
+    @Field() 
+    _mj__UpdatedAt: Date;
+        
+    @Field() 
+    @MaxLength(255)
+    Committee: string;
+        
+    @Field({nullable: true}) 
+    @MaxLength(255)
+    Meeting?: string;
+        
+    @Field({nullable: true}) 
+    @MaxLength(255)
+    AgendaItem?: string;
+        
+    @Field({nullable: true}) 
+    @MaxLength(255)
+    ActionItem?: string;
+        
+    @Field({nullable: true}) 
+    @MaxLength(255)
+    Artifact?: string;
+        
+    @Field({nullable: true}) 
+    ParentComment?: string;
+        
+    @Field() 
+    @MaxLength(100)
+    Person: string;
+        
+    @Field({nullable: true}) 
+    @MaxLength(36)
+    RootParentCommentID?: string;
+        
+    @Field(() => [mjCommitteesComment_])
+    mjCommitteesComments_ParentCommentIDArray: mjCommitteesComment_[]; // Link to mjCommitteesComments
+    
+}
+
+//****************************************************************************
+// INPUT TYPE for Comments
+//****************************************************************************
+@InputType()
+export class CreatemjCommitteesCommentInput {
+    @Field({ nullable: true })
+    ID?: string;
+
+    @Field({ nullable: true })
+    CommitteeID?: string;
+
+    @Field({ nullable: true })
+    MeetingID: string | null;
+
+    @Field({ nullable: true })
+    AgendaItemID: string | null;
+
+    @Field({ nullable: true })
+    ActionItemID: string | null;
+
+    @Field({ nullable: true })
+    ArtifactID: string | null;
+
+    @Field({ nullable: true })
+    ParentCommentID: string | null;
+
+    @Field({ nullable: true })
+    PersonID?: string;
+
+    @Field({ nullable: true })
+    CommentText?: string;
+
+    @Field({ nullable: true })
+    MentionedPersonIDs: string | null;
+
+    @Field(() => Boolean, { nullable: true })
+    IsResolved?: boolean;
+}
+    
+
+//****************************************************************************
+// INPUT TYPE for Comments
+//****************************************************************************
+@InputType()
+export class UpdatemjCommitteesCommentInput {
+    @Field()
+    ID: string;
+
+    @Field({ nullable: true })
+    CommitteeID?: string;
+
+    @Field({ nullable: true })
+    MeetingID?: string | null;
+
+    @Field({ nullable: true })
+    AgendaItemID?: string | null;
+
+    @Field({ nullable: true })
+    ActionItemID?: string | null;
+
+    @Field({ nullable: true })
+    ArtifactID?: string | null;
+
+    @Field({ nullable: true })
+    ParentCommentID?: string | null;
+
+    @Field({ nullable: true })
+    PersonID?: string;
+
+    @Field({ nullable: true })
+    CommentText?: string;
+
+    @Field({ nullable: true })
+    MentionedPersonIDs?: string | null;
+
+    @Field(() => Boolean, { nullable: true })
+    IsResolved?: boolean;
+
+    @Field(() => [KeyValuePairInput], { nullable: true })
+    OldValues___?: KeyValuePairInput[];
+}
+    
+//****************************************************************************
+// RESOLVER for Comments
+//****************************************************************************
+@ObjectType()
+export class RunmjCommitteesCommentViewResult {
+    @Field(() => [mjCommitteesComment_])
+    Results: mjCommitteesComment_[];
+
+    @Field(() => String, {nullable: true})
+    UserViewRunID?: string;
+
+    @Field(() => Int, {nullable: true})
+    RowCount: number;
+
+    @Field(() => Int, {nullable: true})
+    TotalRowCount: number;
+
+    @Field(() => Int, {nullable: true})
+    ExecutionTime: number;
+
+    @Field({nullable: true})
+    ErrorMessage?: string;
+
+    @Field(() => Boolean, {nullable: false})
+    Success: boolean;
+}
+
+@Resolver(mjCommitteesComment_)
+export class mjCommitteesCommentResolver extends ResolverBase {
+    @Query(() => RunmjCommitteesCommentViewResult)
+    async RunmjCommitteesCommentViewByID(@Arg('input', () => RunViewByIDInput) input: RunViewByIDInput, @Ctx() { providers, userPayload }: AppContext, @PubSub() pubSub: PubSubEngine) {
+        const provider = GetReadOnlyProvider(providers, { allowFallbackToReadWrite: true });
+        return super.RunViewByIDGeneric(input, provider, userPayload, pubSub);
+    }
+
+    @Query(() => RunmjCommitteesCommentViewResult)
+    async RunmjCommitteesCommentViewByName(@Arg('input', () => RunViewByNameInput) input: RunViewByNameInput, @Ctx() { providers, userPayload }: AppContext, @PubSub() pubSub: PubSubEngine) {
+        const provider = GetReadOnlyProvider(providers, { allowFallbackToReadWrite: true });
+        return super.RunViewByNameGeneric(input, provider, userPayload, pubSub);
+    }
+
+    @Query(() => RunmjCommitteesCommentViewResult)
+    async RunmjCommitteesCommentDynamicView(@Arg('input', () => RunDynamicViewInput) input: RunDynamicViewInput, @Ctx() { providers, userPayload }: AppContext, @PubSub() pubSub: PubSubEngine) {
+        const provider = GetReadOnlyProvider(providers, { allowFallbackToReadWrite: true });
+        input.EntityName = 'Comments';
+        return super.RunDynamicViewGeneric(input, provider, userPayload, pubSub);
+    }
+    @Query(() => mjCommitteesComment_, { nullable: true })
+    async mjCommitteesComment(@Arg('ID', () => String) ID: string, @Ctx() { userPayload, providers }: AppContext, @PubSub() pubSub: PubSubEngine): Promise<mjCommitteesComment_ | null> {
+        this.CheckUserReadPermissions('Comments', userPayload);
+        const provider = GetReadOnlyProvider(providers, { allowFallbackToReadWrite: true });
+        const sSQL = `SELECT * FROM ${provider.QuoteSchemaAndView('__mj_Committees', 'vwComments')} WHERE ${provider.QuoteIdentifier('ID')}='${ID}' ` + this.getRowLevelSecurityWhereClause(provider, 'Comments', userPayload, EntityPermissionType.Read, 'AND');
+        const rows = await provider.ExecuteSQL(sSQL, undefined, undefined, this.GetUserFromPayload(userPayload));
+        const result = await this.MapFieldNamesToCodeNames('Comments', rows && rows.length > 0 ? rows[0] : null, this.GetUserFromPayload(userPayload));
+        return result;
+    }
+    
+    @FieldResolver(() => [mjCommitteesComment_])
+    async mjCommitteesComments_ParentCommentIDArray(@Root() mjcommitteescomment_: mjCommitteesComment_, @Ctx() { userPayload, providers }: AppContext, @PubSub() pubSub: PubSubEngine) {
+        this.CheckUserReadPermissions('Comments', userPayload);
+        const provider = GetReadOnlyProvider(providers, { allowFallbackToReadWrite: true });
+        const sSQL = `SELECT * FROM ${provider.QuoteSchemaAndView('__mj_Committees', 'vwComments')} WHERE ${provider.QuoteIdentifier('ParentCommentID')}='${mjcommitteescomment_.ID}' ` + this.getRowLevelSecurityWhereClause(provider, 'Comments', userPayload, EntityPermissionType.Read, 'AND');
+        const rows = await provider.ExecuteSQL(sSQL, undefined, undefined, this.GetUserFromPayload(userPayload));
+        const result = await this.ArrayMapFieldNamesToCodeNames('Comments', rows, this.GetUserFromPayload(userPayload));
+        return result;
+    }
+        
+    @Mutation(() => mjCommitteesComment_)
+    async CreatemjCommitteesComment(
+        @Arg('input', () => CreatemjCommitteesCommentInput) input: CreatemjCommitteesCommentInput,
+        @Ctx() { providers, userPayload }: AppContext,
+        @PubSub() pubSub: PubSubEngine
+    ) {
+        const provider = GetReadWriteProvider(providers);
+        return this.CreateRecord('Comments', input, provider, userPayload, pubSub)
+    }
+        
+    @Mutation(() => mjCommitteesComment_)
+    async UpdatemjCommitteesComment(
+        @Arg('input', () => UpdatemjCommitteesCommentInput) input: UpdatemjCommitteesCommentInput,
+        @Ctx() { providers, userPayload }: AppContext,
+        @PubSub() pubSub: PubSubEngine
+    ) {
+        const provider = GetReadWriteProvider(providers);
+        return this.UpdateRecord('Comments', input, provider, userPayload, pubSub);
+    }
+    
+    @Mutation(() => mjCommitteesComment_)
+    async DeletemjCommitteesComment(@Arg('ID', () => String) ID: string, @Arg('options___', () => DeleteOptionsInput) options: DeleteOptionsInput, @Ctx() { providers, userPayload }: AppContext, @PubSub() pubSub: PubSubEngine) {
+        const provider = GetReadWriteProvider(providers);
+        const key = new CompositeKey([{FieldName: 'ID', Value: ID}]);
+        return this.DeleteRecord('Comments', key, options, provider, userPayload, pubSub);
+    }
+    
+}
+
+//****************************************************************************
+// ENTITY CLASS for Committees
+//****************************************************************************
+@ObjectType({ description: `Core committee records with hierarchy support` })
+export class mjCommitteesCommittee_ {
+    @Field() 
+    @MaxLength(36)
+    ID: string;
+        
+    @Field({description: `Official name of the committee`}) 
+    @MaxLength(255)
+    Name: string;
+        
+    @Field({nullable: true, description: `Detailed description of the committee purpose and scope`}) 
+    Description?: string;
+        
+    @Field() 
+    @MaxLength(36)
+    TypeID: string;
+        
+    @Field({nullable: true}) 
+    @MaxLength(36)
+    ParentCommitteeID?: string;
+        
+    @Field({nullable: true}) 
+    @MaxLength(36)
+    OrganizationID?: string;
+        
+    @Field({nullable: true, description: `URL to the committee charter document`}) 
+    @MaxLength(1000)
+    CharterDocumentURL?: string;
+        
+    @Field({nullable: true, description: `Brief statement of the committee mission`}) 
+    MissionStatement?: string;
+        
+    @Field({description: `Current status: Active, Inactive, Pending, or Dissolved`}) 
+    @MaxLength(50)
+    Status: string;
+        
+    @Field(() => Boolean, {description: `Whether the committee is visible to all users`}) 
+    IsPublic: boolean;
+        
+    @Field({nullable: true, description: `Date the committee was formed`}) 
+    FormationDate?: Date;
+        
+    @Field({nullable: true, description: `Date the committee was dissolved, if applicable`}) 
+    DissolutionDate?: Date;
+        
+    @Field() 
+    _mj__CreatedAt: Date;
+        
+    @Field() 
+    _mj__UpdatedAt: Date;
+        
+    @Field() 
+    @MaxLength(100)
+    Type: string;
+        
+    @Field({nullable: true}) 
+    @MaxLength(255)
+    ParentCommittee?: string;
+        
+    @Field({nullable: true}) 
+    @MaxLength(255)
+    Organization?: string;
+        
+    @Field({nullable: true}) 
+    @MaxLength(36)
+    RootParentCommitteeID?: string;
+        
+    @Field(() => [mjCommitteesTerm_])
+    mjCommitteesTerms_CommitteeIDArray: mjCommitteesTerm_[]; // Link to mjCommitteesTerms
+    
+    @Field(() => [mjCommitteesMeeting_])
+    mjCommitteesMeetings_CommitteeIDArray: mjCommitteesMeeting_[]; // Link to mjCommitteesMeetings
+    
+    @Field(() => [mjCommitteesArtifact_])
+    mjCommitteesArtifacts_CommitteeIDArray: mjCommitteesArtifact_[]; // Link to mjCommitteesArtifacts
+    
+    @Field(() => [mjCommitteesCommittee_])
+    mjCommitteesCommittees_ParentCommitteeIDArray: mjCommitteesCommittee_[]; // Link to mjCommitteesCommittees
+    
+    @Field(() => [mjCommitteesActionItem_])
+    mjCommitteesActionItems_CommitteeIDArray: mjCommitteesActionItem_[]; // Link to mjCommitteesActionItems
+    
+    @Field(() => [mjCommitteesComment_])
+    mjCommitteesComments_CommitteeIDArray: mjCommitteesComment_[]; // Link to mjCommitteesComments
+    
+}
+
+//****************************************************************************
+// INPUT TYPE for Committees
+//****************************************************************************
+@InputType()
+export class CreatemjCommitteesCommitteeInput {
+    @Field({ nullable: true })
+    ID?: string;
+
+    @Field({ nullable: true })
+    Name?: string;
+
+    @Field({ nullable: true })
+    Description: string | null;
+
+    @Field({ nullable: true })
+    TypeID?: string;
+
+    @Field({ nullable: true })
+    ParentCommitteeID: string | null;
+
+    @Field({ nullable: true })
+    OrganizationID: string | null;
+
+    @Field({ nullable: true })
+    CharterDocumentURL: string | null;
+
+    @Field({ nullable: true })
+    MissionStatement: string | null;
+
+    @Field({ nullable: true })
+    Status?: string;
+
+    @Field(() => Boolean, { nullable: true })
+    IsPublic?: boolean;
+
+    @Field({ nullable: true })
+    FormationDate: Date | null;
+
+    @Field({ nullable: true })
+    DissolutionDate: Date | null;
+}
+    
+
+//****************************************************************************
+// INPUT TYPE for Committees
+//****************************************************************************
+@InputType()
+export class UpdatemjCommitteesCommitteeInput {
+    @Field()
+    ID: string;
+
+    @Field({ nullable: true })
+    Name?: string;
+
+    @Field({ nullable: true })
+    Description?: string | null;
+
+    @Field({ nullable: true })
+    TypeID?: string;
+
+    @Field({ nullable: true })
+    ParentCommitteeID?: string | null;
+
+    @Field({ nullable: true })
+    OrganizationID?: string | null;
+
+    @Field({ nullable: true })
+    CharterDocumentURL?: string | null;
+
+    @Field({ nullable: true })
+    MissionStatement?: string | null;
+
+    @Field({ nullable: true })
+    Status?: string;
+
+    @Field(() => Boolean, { nullable: true })
+    IsPublic?: boolean;
+
+    @Field({ nullable: true })
+    FormationDate?: Date | null;
+
+    @Field({ nullable: true })
+    DissolutionDate?: Date | null;
+
+    @Field(() => [KeyValuePairInput], { nullable: true })
+    OldValues___?: KeyValuePairInput[];
+}
+    
+//****************************************************************************
+// RESOLVER for Committees
+//****************************************************************************
+@ObjectType()
+export class RunmjCommitteesCommitteeViewResult {
+    @Field(() => [mjCommitteesCommittee_])
+    Results: mjCommitteesCommittee_[];
+
+    @Field(() => String, {nullable: true})
+    UserViewRunID?: string;
+
+    @Field(() => Int, {nullable: true})
+    RowCount: number;
+
+    @Field(() => Int, {nullable: true})
+    TotalRowCount: number;
+
+    @Field(() => Int, {nullable: true})
+    ExecutionTime: number;
+
+    @Field({nullable: true})
+    ErrorMessage?: string;
+
+    @Field(() => Boolean, {nullable: false})
+    Success: boolean;
+}
+
+@Resolver(mjCommitteesCommittee_)
+export class mjCommitteesCommitteeResolver extends ResolverBase {
+    @Query(() => RunmjCommitteesCommitteeViewResult)
+    async RunmjCommitteesCommitteeViewByID(@Arg('input', () => RunViewByIDInput) input: RunViewByIDInput, @Ctx() { providers, userPayload }: AppContext, @PubSub() pubSub: PubSubEngine) {
+        const provider = GetReadOnlyProvider(providers, { allowFallbackToReadWrite: true });
+        return super.RunViewByIDGeneric(input, provider, userPayload, pubSub);
+    }
+
+    @Query(() => RunmjCommitteesCommitteeViewResult)
+    async RunmjCommitteesCommitteeViewByName(@Arg('input', () => RunViewByNameInput) input: RunViewByNameInput, @Ctx() { providers, userPayload }: AppContext, @PubSub() pubSub: PubSubEngine) {
+        const provider = GetReadOnlyProvider(providers, { allowFallbackToReadWrite: true });
+        return super.RunViewByNameGeneric(input, provider, userPayload, pubSub);
+    }
+
+    @Query(() => RunmjCommitteesCommitteeViewResult)
+    async RunmjCommitteesCommitteeDynamicView(@Arg('input', () => RunDynamicViewInput) input: RunDynamicViewInput, @Ctx() { providers, userPayload }: AppContext, @PubSub() pubSub: PubSubEngine) {
+        const provider = GetReadOnlyProvider(providers, { allowFallbackToReadWrite: true });
+        input.EntityName = 'Committees';
+        return super.RunDynamicViewGeneric(input, provider, userPayload, pubSub);
+    }
+    @Query(() => mjCommitteesCommittee_, { nullable: true })
+    async mjCommitteesCommittee(@Arg('ID', () => String) ID: string, @Ctx() { userPayload, providers }: AppContext, @PubSub() pubSub: PubSubEngine): Promise<mjCommitteesCommittee_ | null> {
+        this.CheckUserReadPermissions('Committees', userPayload);
+        const provider = GetReadOnlyProvider(providers, { allowFallbackToReadWrite: true });
+        const sSQL = `SELECT * FROM ${provider.QuoteSchemaAndView('__mj_Committees', 'vwCommittees')} WHERE ${provider.QuoteIdentifier('ID')}='${ID}' ` + this.getRowLevelSecurityWhereClause(provider, 'Committees', userPayload, EntityPermissionType.Read, 'AND');
+        const rows = await provider.ExecuteSQL(sSQL, undefined, undefined, this.GetUserFromPayload(userPayload));
+        const result = await this.MapFieldNamesToCodeNames('Committees', rows && rows.length > 0 ? rows[0] : null, this.GetUserFromPayload(userPayload));
+        return result;
+    }
+    
+    @FieldResolver(() => [mjCommitteesTerm_])
+    async mjCommitteesTerms_CommitteeIDArray(@Root() mjcommitteescommittee_: mjCommitteesCommittee_, @Ctx() { userPayload, providers }: AppContext, @PubSub() pubSub: PubSubEngine) {
+        this.CheckUserReadPermissions('Terms', userPayload);
+        const provider = GetReadOnlyProvider(providers, { allowFallbackToReadWrite: true });
+        const sSQL = `SELECT * FROM ${provider.QuoteSchemaAndView('__mj_Committees', 'vwTerms')} WHERE ${provider.QuoteIdentifier('CommitteeID')}='${mjcommitteescommittee_.ID}' ` + this.getRowLevelSecurityWhereClause(provider, 'Terms', userPayload, EntityPermissionType.Read, 'AND');
+        const rows = await provider.ExecuteSQL(sSQL, undefined, undefined, this.GetUserFromPayload(userPayload));
+        const result = await this.ArrayMapFieldNamesToCodeNames('Terms', rows, this.GetUserFromPayload(userPayload));
+        return result;
+    }
+        
+    @FieldResolver(() => [mjCommitteesMeeting_])
+    async mjCommitteesMeetings_CommitteeIDArray(@Root() mjcommitteescommittee_: mjCommitteesCommittee_, @Ctx() { userPayload, providers }: AppContext, @PubSub() pubSub: PubSubEngine) {
+        this.CheckUserReadPermissions('Meetings', userPayload);
+        const provider = GetReadOnlyProvider(providers, { allowFallbackToReadWrite: true });
+        const sSQL = `SELECT * FROM ${provider.QuoteSchemaAndView('__mj_Committees', 'vwMeetings')} WHERE ${provider.QuoteIdentifier('CommitteeID')}='${mjcommitteescommittee_.ID}' ` + this.getRowLevelSecurityWhereClause(provider, 'Meetings', userPayload, EntityPermissionType.Read, 'AND');
+        const rows = await provider.ExecuteSQL(sSQL, undefined, undefined, this.GetUserFromPayload(userPayload));
+        const result = await this.ArrayMapFieldNamesToCodeNames('Meetings', rows, this.GetUserFromPayload(userPayload));
+        return result;
+    }
+        
+    @FieldResolver(() => [mjCommitteesArtifact_])
+    async mjCommitteesArtifacts_CommitteeIDArray(@Root() mjcommitteescommittee_: mjCommitteesCommittee_, @Ctx() { userPayload, providers }: AppContext, @PubSub() pubSub: PubSubEngine) {
+        this.CheckUserReadPermissions('Artifacts', userPayload);
+        const provider = GetReadOnlyProvider(providers, { allowFallbackToReadWrite: true });
+        const sSQL = `SELECT * FROM ${provider.QuoteSchemaAndView('__mj_Committees', 'vwArtifacts')} WHERE ${provider.QuoteIdentifier('CommitteeID')}='${mjcommitteescommittee_.ID}' ` + this.getRowLevelSecurityWhereClause(provider, 'Artifacts', userPayload, EntityPermissionType.Read, 'AND');
+        const rows = await provider.ExecuteSQL(sSQL, undefined, undefined, this.GetUserFromPayload(userPayload));
+        const result = await this.ArrayMapFieldNamesToCodeNames('Artifacts', rows, this.GetUserFromPayload(userPayload));
+        return result;
+    }
+        
+    @FieldResolver(() => [mjCommitteesCommittee_])
+    async mjCommitteesCommittees_ParentCommitteeIDArray(@Root() mjcommitteescommittee_: mjCommitteesCommittee_, @Ctx() { userPayload, providers }: AppContext, @PubSub() pubSub: PubSubEngine) {
+        this.CheckUserReadPermissions('Committees', userPayload);
+        const provider = GetReadOnlyProvider(providers, { allowFallbackToReadWrite: true });
+        const sSQL = `SELECT * FROM ${provider.QuoteSchemaAndView('__mj_Committees', 'vwCommittees')} WHERE ${provider.QuoteIdentifier('ParentCommitteeID')}='${mjcommitteescommittee_.ID}' ` + this.getRowLevelSecurityWhereClause(provider, 'Committees', userPayload, EntityPermissionType.Read, 'AND');
+        const rows = await provider.ExecuteSQL(sSQL, undefined, undefined, this.GetUserFromPayload(userPayload));
+        const result = await this.ArrayMapFieldNamesToCodeNames('Committees', rows, this.GetUserFromPayload(userPayload));
+        return result;
+    }
+        
+    @FieldResolver(() => [mjCommitteesActionItem_])
+    async mjCommitteesActionItems_CommitteeIDArray(@Root() mjcommitteescommittee_: mjCommitteesCommittee_, @Ctx() { userPayload, providers }: AppContext, @PubSub() pubSub: PubSubEngine) {
+        this.CheckUserReadPermissions('Action Items', userPayload);
+        const provider = GetReadOnlyProvider(providers, { allowFallbackToReadWrite: true });
+        const sSQL = `SELECT * FROM ${provider.QuoteSchemaAndView('__mj_Committees', 'vwActionItems')} WHERE ${provider.QuoteIdentifier('CommitteeID')}='${mjcommitteescommittee_.ID}' ` + this.getRowLevelSecurityWhereClause(provider, 'Action Items', userPayload, EntityPermissionType.Read, 'AND');
+        const rows = await provider.ExecuteSQL(sSQL, undefined, undefined, this.GetUserFromPayload(userPayload));
+        const result = await this.ArrayMapFieldNamesToCodeNames('Action Items', rows, this.GetUserFromPayload(userPayload));
+        return result;
+    }
+        
+    @FieldResolver(() => [mjCommitteesComment_])
+    async mjCommitteesComments_CommitteeIDArray(@Root() mjcommitteescommittee_: mjCommitteesCommittee_, @Ctx() { userPayload, providers }: AppContext, @PubSub() pubSub: PubSubEngine) {
+        this.CheckUserReadPermissions('Comments', userPayload);
+        const provider = GetReadOnlyProvider(providers, { allowFallbackToReadWrite: true });
+        const sSQL = `SELECT * FROM ${provider.QuoteSchemaAndView('__mj_Committees', 'vwComments')} WHERE ${provider.QuoteIdentifier('CommitteeID')}='${mjcommitteescommittee_.ID}' ` + this.getRowLevelSecurityWhereClause(provider, 'Comments', userPayload, EntityPermissionType.Read, 'AND');
+        const rows = await provider.ExecuteSQL(sSQL, undefined, undefined, this.GetUserFromPayload(userPayload));
+        const result = await this.ArrayMapFieldNamesToCodeNames('Comments', rows, this.GetUserFromPayload(userPayload));
+        return result;
+    }
+        
+    @Mutation(() => mjCommitteesCommittee_)
+    async CreatemjCommitteesCommittee(
+        @Arg('input', () => CreatemjCommitteesCommitteeInput) input: CreatemjCommitteesCommitteeInput,
+        @Ctx() { providers, userPayload }: AppContext,
+        @PubSub() pubSub: PubSubEngine
+    ) {
+        const provider = GetReadWriteProvider(providers);
+        return this.CreateRecord('Committees', input, provider, userPayload, pubSub)
+    }
+        
+    @Mutation(() => mjCommitteesCommittee_)
+    async UpdatemjCommitteesCommittee(
+        @Arg('input', () => UpdatemjCommitteesCommitteeInput) input: UpdatemjCommitteesCommitteeInput,
+        @Ctx() { providers, userPayload }: AppContext,
+        @PubSub() pubSub: PubSubEngine
+    ) {
+        const provider = GetReadWriteProvider(providers);
+        return this.UpdateRecord('Committees', input, provider, userPayload, pubSub);
+    }
+    
+    @Mutation(() => mjCommitteesCommittee_)
+    async DeletemjCommitteesCommittee(@Arg('ID', () => String) ID: string, @Arg('options___', () => DeleteOptionsInput) options: DeleteOptionsInput, @Ctx() { providers, userPayload }: AppContext, @PubSub() pubSub: PubSubEngine) {
+        const provider = GetReadWriteProvider(providers);
+        const key = new CompositeKey([{FieldName: 'ID', Value: ID}]);
+        return this.DeleteRecord('Committees', key, options, provider, userPayload, pubSub);
+    }
+    
+}
+
+//****************************************************************************
+// ENTITY CLASS for Contact Methods
+//****************************************************************************
+@ObjectType({ description: `Additional contact methods for people and organizations beyond the primary email and phone fields` })
+export class mjBizAppsCommonContactMethod_ {
+    @Field() 
+    @MaxLength(36)
+    ID: string;
+        
+    @Field({nullable: true}) 
+    @MaxLength(36)
+    PersonID?: string;
+        
+    @Field({nullable: true}) 
+    @MaxLength(36)
+    OrganizationID?: string;
+        
+    @Field() 
+    @MaxLength(36)
+    ContactTypeID: string;
+        
+    @Field({description: `The contact value: phone number, email address, URL, social media handle, etc.`}) 
+    @MaxLength(500)
+    Value: string;
+        
+    @Field({nullable: true, description: `Descriptive label such as Work cell, Personal Gmail, Corporate LinkedIn`}) 
+    @MaxLength(100)
+    Label?: string;
+        
+    @Field(() => Boolean, {description: `Whether this is the primary contact method of its type for the linked person or organization`}) 
+    IsPrimary: boolean;
+        
+    @Field() 
+    _mj__CreatedAt: Date;
+        
+    @Field() 
+    _mj__UpdatedAt: Date;
+        
+    @Field({nullable: true}) 
+    @MaxLength(100)
+    Person?: string;
+        
+    @Field({nullable: true}) 
+    @MaxLength(255)
+    Organization?: string;
+        
+    @Field() 
+    @MaxLength(100)
+    ContactType: string;
+        
+}
+
+//****************************************************************************
+// INPUT TYPE for Contact Methods
+//****************************************************************************
+@InputType()
+export class CreatemjBizAppsCommonContactMethodInput {
+    @Field({ nullable: true })
+    ID?: string;
+
+    @Field({ nullable: true })
+    PersonID: string | null;
+
+    @Field({ nullable: true })
+    OrganizationID: string | null;
+
+    @Field({ nullable: true })
+    ContactTypeID?: string;
+
+    @Field({ nullable: true })
+    Value?: string;
+
+    @Field({ nullable: true })
+    Label: string | null;
+
+    @Field(() => Boolean, { nullable: true })
+    IsPrimary?: boolean;
+}
+    
+
+//****************************************************************************
+// INPUT TYPE for Contact Methods
+//****************************************************************************
+@InputType()
+export class UpdatemjBizAppsCommonContactMethodInput {
+    @Field()
+    ID: string;
+
+    @Field({ nullable: true })
+    PersonID?: string | null;
+
+    @Field({ nullable: true })
+    OrganizationID?: string | null;
+
+    @Field({ nullable: true })
+    ContactTypeID?: string;
+
+    @Field({ nullable: true })
+    Value?: string;
+
+    @Field({ nullable: true })
+    Label?: string | null;
+
+    @Field(() => Boolean, { nullable: true })
+    IsPrimary?: boolean;
+
+    @Field(() => [KeyValuePairInput], { nullable: true })
+    OldValues___?: KeyValuePairInput[];
+}
+    
+//****************************************************************************
+// RESOLVER for Contact Methods
+//****************************************************************************
+@ObjectType()
+export class RunmjBizAppsCommonContactMethodViewResult {
+    @Field(() => [mjBizAppsCommonContactMethod_])
+    Results: mjBizAppsCommonContactMethod_[];
+
+    @Field(() => String, {nullable: true})
+    UserViewRunID?: string;
+
+    @Field(() => Int, {nullable: true})
+    RowCount: number;
+
+    @Field(() => Int, {nullable: true})
+    TotalRowCount: number;
+
+    @Field(() => Int, {nullable: true})
+    ExecutionTime: number;
+
+    @Field({nullable: true})
+    ErrorMessage?: string;
+
+    @Field(() => Boolean, {nullable: false})
+    Success: boolean;
+}
+
+@Resolver(mjBizAppsCommonContactMethod_)
+export class mjBizAppsCommonContactMethodResolver extends ResolverBase {
+    @Query(() => RunmjBizAppsCommonContactMethodViewResult)
+    async RunmjBizAppsCommonContactMethodViewByID(@Arg('input', () => RunViewByIDInput) input: RunViewByIDInput, @Ctx() { providers, userPayload }: AppContext, @PubSub() pubSub: PubSubEngine) {
+        const provider = GetReadOnlyProvider(providers, { allowFallbackToReadWrite: true });
+        return super.RunViewByIDGeneric(input, provider, userPayload, pubSub);
+    }
+
+    @Query(() => RunmjBizAppsCommonContactMethodViewResult)
+    async RunmjBizAppsCommonContactMethodViewByName(@Arg('input', () => RunViewByNameInput) input: RunViewByNameInput, @Ctx() { providers, userPayload }: AppContext, @PubSub() pubSub: PubSubEngine) {
+        const provider = GetReadOnlyProvider(providers, { allowFallbackToReadWrite: true });
+        return super.RunViewByNameGeneric(input, provider, userPayload, pubSub);
+    }
+
+    @Query(() => RunmjBizAppsCommonContactMethodViewResult)
+    async RunmjBizAppsCommonContactMethodDynamicView(@Arg('input', () => RunDynamicViewInput) input: RunDynamicViewInput, @Ctx() { providers, userPayload }: AppContext, @PubSub() pubSub: PubSubEngine) {
+        const provider = GetReadOnlyProvider(providers, { allowFallbackToReadWrite: true });
+        input.EntityName = 'Contact Methods';
+        return super.RunDynamicViewGeneric(input, provider, userPayload, pubSub);
+    }
+    @Query(() => mjBizAppsCommonContactMethod_, { nullable: true })
+    async mjBizAppsCommonContactMethod(@Arg('ID', () => String) ID: string, @Ctx() { userPayload, providers }: AppContext, @PubSub() pubSub: PubSubEngine): Promise<mjBizAppsCommonContactMethod_ | null> {
+        this.CheckUserReadPermissions('Contact Methods', userPayload);
+        const provider = GetReadOnlyProvider(providers, { allowFallbackToReadWrite: true });
+        const sSQL = `SELECT * FROM ${provider.QuoteSchemaAndView('__mj_BizAppsCommon', 'vwContactMethods')} WHERE ${provider.QuoteIdentifier('ID')}='${ID}' ` + this.getRowLevelSecurityWhereClause(provider, 'Contact Methods', userPayload, EntityPermissionType.Read, 'AND');
+        const rows = await provider.ExecuteSQL(sSQL, undefined, undefined, this.GetUserFromPayload(userPayload));
+        const result = await this.MapFieldNamesToCodeNames('Contact Methods', rows && rows.length > 0 ? rows[0] : null, this.GetUserFromPayload(userPayload));
+        return result;
+    }
+    
+    @Mutation(() => mjBizAppsCommonContactMethod_)
+    async CreatemjBizAppsCommonContactMethod(
+        @Arg('input', () => CreatemjBizAppsCommonContactMethodInput) input: CreatemjBizAppsCommonContactMethodInput,
+        @Ctx() { providers, userPayload }: AppContext,
+        @PubSub() pubSub: PubSubEngine
+    ) {
+        const provider = GetReadWriteProvider(providers);
+        return this.CreateRecord('Contact Methods', input, provider, userPayload, pubSub)
+    }
+        
+    @Mutation(() => mjBizAppsCommonContactMethod_)
+    async UpdatemjBizAppsCommonContactMethod(
+        @Arg('input', () => UpdatemjBizAppsCommonContactMethodInput) input: UpdatemjBizAppsCommonContactMethodInput,
+        @Ctx() { providers, userPayload }: AppContext,
+        @PubSub() pubSub: PubSubEngine
+    ) {
+        const provider = GetReadWriteProvider(providers);
+        return this.UpdateRecord('Contact Methods', input, provider, userPayload, pubSub);
+    }
+    
+    @Mutation(() => mjBizAppsCommonContactMethod_)
+    async DeletemjBizAppsCommonContactMethod(@Arg('ID', () => String) ID: string, @Arg('options___', () => DeleteOptionsInput) options: DeleteOptionsInput, @Ctx() { providers, userPayload }: AppContext, @PubSub() pubSub: PubSubEngine) {
+        const provider = GetReadWriteProvider(providers);
+        const key = new CompositeKey([{FieldName: 'ID', Value: ID}]);
+        return this.DeleteRecord('Contact Methods', key, options, provider, userPayload, pubSub);
+    }
+    
+}
+
+//****************************************************************************
+// ENTITY CLASS for Contact Types
+//****************************************************************************
+@ObjectType({ description: `Categories of contact methods such as Phone, Mobile, Email, LinkedIn, Website` })
+export class mjBizAppsCommonContactType_ {
+    @Field() 
+    @MaxLength(36)
+    ID: string;
+        
+    @Field({description: `Display name for the contact type`}) 
+    @MaxLength(100)
+    Name: string;
+        
+    @Field({nullable: true, description: `Detailed description of this contact type`}) 
+    Description?: string;
+        
+    @Field({nullable: true, description: `Font Awesome icon class for UI display`}) 
+    @MaxLength(100)
+    IconClass?: string;
+        
+    @Field() 
+    _mj__CreatedAt: Date;
+        
+    @Field() 
+    _mj__UpdatedAt: Date;
+        
+    @Field(() => [mjBizAppsCommonContactMethod_])
+    mjBizAppsCommonContactMethods_ContactTypeIDArray: mjBizAppsCommonContactMethod_[]; // Link to mjBizAppsCommonContactMethods
+    
+}
+
+//****************************************************************************
+// INPUT TYPE for Contact Types
+//****************************************************************************
+@InputType()
+export class CreatemjBizAppsCommonContactTypeInput {
+    @Field({ nullable: true })
+    ID?: string;
+
+    @Field({ nullable: true })
+    Name?: string;
+
+    @Field({ nullable: true })
+    Description: string | null;
+
+    @Field({ nullable: true })
+    IconClass: string | null;
+}
+    
+
+//****************************************************************************
+// INPUT TYPE for Contact Types
+//****************************************************************************
+@InputType()
+export class UpdatemjBizAppsCommonContactTypeInput {
+    @Field()
+    ID: string;
+
+    @Field({ nullable: true })
+    Name?: string;
+
+    @Field({ nullable: true })
+    Description?: string | null;
+
+    @Field({ nullable: true })
+    IconClass?: string | null;
+
+    @Field(() => [KeyValuePairInput], { nullable: true })
+    OldValues___?: KeyValuePairInput[];
+}
+    
+//****************************************************************************
+// RESOLVER for Contact Types
+//****************************************************************************
+@ObjectType()
+export class RunmjBizAppsCommonContactTypeViewResult {
+    @Field(() => [mjBizAppsCommonContactType_])
+    Results: mjBizAppsCommonContactType_[];
+
+    @Field(() => String, {nullable: true})
+    UserViewRunID?: string;
+
+    @Field(() => Int, {nullable: true})
+    RowCount: number;
+
+    @Field(() => Int, {nullable: true})
+    TotalRowCount: number;
+
+    @Field(() => Int, {nullable: true})
+    ExecutionTime: number;
+
+    @Field({nullable: true})
+    ErrorMessage?: string;
+
+    @Field(() => Boolean, {nullable: false})
+    Success: boolean;
+}
+
+@Resolver(mjBizAppsCommonContactType_)
+export class mjBizAppsCommonContactTypeResolver extends ResolverBase {
+    @Query(() => RunmjBizAppsCommonContactTypeViewResult)
+    async RunmjBizAppsCommonContactTypeViewByID(@Arg('input', () => RunViewByIDInput) input: RunViewByIDInput, @Ctx() { providers, userPayload }: AppContext, @PubSub() pubSub: PubSubEngine) {
+        const provider = GetReadOnlyProvider(providers, { allowFallbackToReadWrite: true });
+        return super.RunViewByIDGeneric(input, provider, userPayload, pubSub);
+    }
+
+    @Query(() => RunmjBizAppsCommonContactTypeViewResult)
+    async RunmjBizAppsCommonContactTypeViewByName(@Arg('input', () => RunViewByNameInput) input: RunViewByNameInput, @Ctx() { providers, userPayload }: AppContext, @PubSub() pubSub: PubSubEngine) {
+        const provider = GetReadOnlyProvider(providers, { allowFallbackToReadWrite: true });
+        return super.RunViewByNameGeneric(input, provider, userPayload, pubSub);
+    }
+
+    @Query(() => RunmjBizAppsCommonContactTypeViewResult)
+    async RunmjBizAppsCommonContactTypeDynamicView(@Arg('input', () => RunDynamicViewInput) input: RunDynamicViewInput, @Ctx() { providers, userPayload }: AppContext, @PubSub() pubSub: PubSubEngine) {
+        const provider = GetReadOnlyProvider(providers, { allowFallbackToReadWrite: true });
+        input.EntityName = 'Contact Types';
+        return super.RunDynamicViewGeneric(input, provider, userPayload, pubSub);
+    }
+    @Query(() => mjBizAppsCommonContactType_, { nullable: true })
+    async mjBizAppsCommonContactType(@Arg('ID', () => String) ID: string, @Ctx() { userPayload, providers }: AppContext, @PubSub() pubSub: PubSubEngine): Promise<mjBizAppsCommonContactType_ | null> {
+        this.CheckUserReadPermissions('Contact Types', userPayload);
+        const provider = GetReadOnlyProvider(providers, { allowFallbackToReadWrite: true });
+        const sSQL = `SELECT * FROM ${provider.QuoteSchemaAndView('__mj_BizAppsCommon', 'vwContactTypes')} WHERE ${provider.QuoteIdentifier('ID')}='${ID}' ` + this.getRowLevelSecurityWhereClause(provider, 'Contact Types', userPayload, EntityPermissionType.Read, 'AND');
+        const rows = await provider.ExecuteSQL(sSQL, undefined, undefined, this.GetUserFromPayload(userPayload));
+        const result = await this.MapFieldNamesToCodeNames('Contact Types', rows && rows.length > 0 ? rows[0] : null, this.GetUserFromPayload(userPayload));
+        return result;
+    }
+    
+    @FieldResolver(() => [mjBizAppsCommonContactMethod_])
+    async mjBizAppsCommonContactMethods_ContactTypeIDArray(@Root() mjbizappscommoncontacttype_: mjBizAppsCommonContactType_, @Ctx() { userPayload, providers }: AppContext, @PubSub() pubSub: PubSubEngine) {
+        this.CheckUserReadPermissions('Contact Methods', userPayload);
+        const provider = GetReadOnlyProvider(providers, { allowFallbackToReadWrite: true });
+        const sSQL = `SELECT * FROM ${provider.QuoteSchemaAndView('__mj_BizAppsCommon', 'vwContactMethods')} WHERE ${provider.QuoteIdentifier('ContactTypeID')}='${mjbizappscommoncontacttype_.ID}' ` + this.getRowLevelSecurityWhereClause(provider, 'Contact Methods', userPayload, EntityPermissionType.Read, 'AND');
+        const rows = await provider.ExecuteSQL(sSQL, undefined, undefined, this.GetUserFromPayload(userPayload));
+        const result = await this.ArrayMapFieldNamesToCodeNames('Contact Methods', rows, this.GetUserFromPayload(userPayload));
+        return result;
+    }
+        
+    @Mutation(() => mjBizAppsCommonContactType_)
+    async CreatemjBizAppsCommonContactType(
+        @Arg('input', () => CreatemjBizAppsCommonContactTypeInput) input: CreatemjBizAppsCommonContactTypeInput,
+        @Ctx() { providers, userPayload }: AppContext,
+        @PubSub() pubSub: PubSubEngine
+    ) {
+        const provider = GetReadWriteProvider(providers);
+        return this.CreateRecord('Contact Types', input, provider, userPayload, pubSub)
+    }
+        
+    @Mutation(() => mjBizAppsCommonContactType_)
+    async UpdatemjBizAppsCommonContactType(
+        @Arg('input', () => UpdatemjBizAppsCommonContactTypeInput) input: UpdatemjBizAppsCommonContactTypeInput,
+        @Ctx() { providers, userPayload }: AppContext,
+        @PubSub() pubSub: PubSubEngine
+    ) {
+        const provider = GetReadWriteProvider(providers);
+        return this.UpdateRecord('Contact Types', input, provider, userPayload, pubSub);
+    }
+    
+    @Mutation(() => mjBizAppsCommonContactType_)
+    async DeletemjBizAppsCommonContactType(@Arg('ID', () => String) ID: string, @Arg('options___', () => DeleteOptionsInput) options: DeleteOptionsInput, @Ctx() { providers, userPayload }: AppContext, @PubSub() pubSub: PubSubEngine) {
+        const provider = GetReadWriteProvider(providers);
+        const key = new CompositeKey([{FieldName: 'ID', Value: ID}]);
+        return this.DeleteRecord('Contact Types', key, options, provider, userPayload, pubSub);
+    }
+    
+}
+
+//****************************************************************************
+// ENTITY CLASS for Meetings
+//****************************************************************************
+@ObjectType({ description: `Committee meeting records with scheduling and video conferencing info` })
+export class mjCommitteesMeeting_ {
+    @Field() 
+    @MaxLength(36)
+    ID: string;
+        
+    @Field() 
+    @MaxLength(36)
+    CommitteeID: string;
+        
+    @Field({description: `Title of the meeting`}) 
+    @MaxLength(255)
+    Title: string;
+        
+    @Field({nullable: true, description: `Detailed description or purpose of the meeting`}) 
+    Description?: string;
+        
+    @Field({description: `Scheduled start date and time with timezone offset`}) 
+    StartDateTime: Date;
+        
+    @Field({nullable: true, description: `Scheduled end date and time with timezone offset`}) 
+    EndDateTime?: Date;
+        
+    @Field({description: `IANA timezone identifier for the meeting`}) 
+    @MaxLength(50)
+    TimeZone: string;
+        
+    @Field({description: `Meeting format: Virtual, InPerson, or Hybrid`}) 
+    @MaxLength(50)
+    LocationType: string;
+        
+    @Field({nullable: true, description: `Physical address or room name for in-person meetings`}) 
+    @MaxLength(500)
+    LocationText?: string;
+        
+    @Field({nullable: true, description: `Video conferencing provider: Zoom, Teams, Meet, etc.`}) 
+    @MaxLength(50)
+    VideoProvider?: string;
+        
+    @Field({nullable: true, description: `External meeting ID from the video provider`}) 
+    @MaxLength(255)
+    VideoMeetingID?: string;
+        
+    @Field({nullable: true, description: `URL to join the video meeting`}) 
+    @MaxLength(1000)
+    VideoJoinURL?: string;
+        
+    @Field({nullable: true, description: `URL to the meeting recording after completion`}) 
+    @MaxLength(1000)
+    VideoRecordingURL?: string;
+        
+    @Field({nullable: true, description: `URL to the meeting transcript`}) 
+    @MaxLength(1000)
+    TranscriptURL?: string;
+        
+    @Field({description: `Current status: Draft, Scheduled, InProgress, Completed, Cancelled, Postponed`}) 
+    @MaxLength(50)
+    Status: string;
+        
+    @Field({nullable: true, description: `External calendar event ID for sync purposes`}) 
+    @MaxLength(255)
+    CalendarEventID?: string;
+        
+    @Field({nullable: true, description: `FK to VideoProvider — when set, video meeting URL is auto-created on save`}) 
+    @MaxLength(36)
+    VideoProviderID?: string;
+        
+    @Field() 
+    _mj__CreatedAt: Date;
+        
+    @Field() 
+    _mj__UpdatedAt: Date;
+        
+    @Field() 
+    @MaxLength(255)
+    Committee: string;
+        
+    @Field({nullable: true}) 
+    @MaxLength(100)
+    VideoProvider_Virtual?: string;
+        
+    @Field(() => [mjCommitteesMinute_])
+    mjCommitteesMinutes_ApprovedByMeetingIDArray: mjCommitteesMinute_[]; // Link to mjCommitteesMinutes
+    
+    @Field(() => [mjCommitteesMinute_])
+    mjCommitteesMinutes_MeetingIDArray: mjCommitteesMinute_[]; // Link to mjCommitteesMinutes
+    
+    @Field(() => [mjCommitteesAgendaItem_])
+    mjCommitteesAgendaItems_MeetingIDArray: mjCommitteesAgendaItem_[]; // Link to mjCommitteesAgendaItems
+    
+    @Field(() => [mjCommitteesAttendance_])
+    mjCommitteesAttendances_MeetingIDArray: mjCommitteesAttendance_[]; // Link to mjCommitteesAttendances
+    
+    @Field(() => [mjCommitteesArtifact_])
+    mjCommitteesArtifacts_MeetingIDArray: mjCommitteesArtifact_[]; // Link to mjCommitteesArtifacts
+    
+    @Field(() => [mjCommitteesMotion_])
+    mjCommitteesMotions_MeetingIDArray: mjCommitteesMotion_[]; // Link to mjCommitteesMotions
+    
+    @Field(() => [mjCommitteesActionItem_])
+    mjCommitteesActionItems_MeetingIDArray: mjCommitteesActionItem_[]; // Link to mjCommitteesActionItems
+    
+    @Field(() => [mjCommitteesComment_])
+    mjCommitteesComments_MeetingIDArray: mjCommitteesComment_[]; // Link to mjCommitteesComments
+    
+}
+
+//****************************************************************************
+// INPUT TYPE for Meetings
+//****************************************************************************
+@InputType()
+export class CreatemjCommitteesMeetingInput {
+    @Field({ nullable: true })
+    ID?: string;
+
+    @Field({ nullable: true })
+    CommitteeID?: string;
+
+    @Field({ nullable: true })
+    Title?: string;
+
+    @Field({ nullable: true })
+    Description: string | null;
+
+    @Field({ nullable: true })
+    StartDateTime?: Date;
+
+    @Field({ nullable: true })
+    EndDateTime: Date | null;
+
+    @Field({ nullable: true })
+    TimeZone?: string;
+
+    @Field({ nullable: true })
+    LocationType?: string;
+
+    @Field({ nullable: true })
+    LocationText: string | null;
+
+    @Field({ nullable: true })
+    VideoProvider: string | null;
+
+    @Field({ nullable: true })
+    VideoMeetingID: string | null;
+
+    @Field({ nullable: true })
+    VideoJoinURL: string | null;
+
+    @Field({ nullable: true })
+    VideoRecordingURL: string | null;
+
+    @Field({ nullable: true })
+    TranscriptURL: string | null;
+
+    @Field({ nullable: true })
+    Status?: string;
+
+    @Field({ nullable: true })
+    CalendarEventID: string | null;
+
+    @Field({ nullable: true })
+    VideoProviderID: string | null;
+}
+    
+
+//****************************************************************************
+// INPUT TYPE for Meetings
+//****************************************************************************
+@InputType()
+export class UpdatemjCommitteesMeetingInput {
+    @Field()
+    ID: string;
+
+    @Field({ nullable: true })
+    CommitteeID?: string;
+
+    @Field({ nullable: true })
+    Title?: string;
+
+    @Field({ nullable: true })
+    Description?: string | null;
+
+    @Field({ nullable: true })
+    StartDateTime?: Date;
+
+    @Field({ nullable: true })
+    EndDateTime?: Date | null;
+
+    @Field({ nullable: true })
+    TimeZone?: string;
+
+    @Field({ nullable: true })
+    LocationType?: string;
+
+    @Field({ nullable: true })
+    LocationText?: string | null;
+
+    @Field({ nullable: true })
+    VideoProvider?: string | null;
+
+    @Field({ nullable: true })
+    VideoMeetingID?: string | null;
+
+    @Field({ nullable: true })
+    VideoJoinURL?: string | null;
+
+    @Field({ nullable: true })
+    VideoRecordingURL?: string | null;
+
+    @Field({ nullable: true })
+    TranscriptURL?: string | null;
+
+    @Field({ nullable: true })
+    Status?: string;
+
+    @Field({ nullable: true })
+    CalendarEventID?: string | null;
+
+    @Field({ nullable: true })
+    VideoProviderID?: string | null;
+
+    @Field(() => [KeyValuePairInput], { nullable: true })
+    OldValues___?: KeyValuePairInput[];
+}
+    
+//****************************************************************************
+// RESOLVER for Meetings
+//****************************************************************************
+@ObjectType()
+export class RunmjCommitteesMeetingViewResult {
+    @Field(() => [mjCommitteesMeeting_])
+    Results: mjCommitteesMeeting_[];
+
+    @Field(() => String, {nullable: true})
+    UserViewRunID?: string;
+
+    @Field(() => Int, {nullable: true})
+    RowCount: number;
+
+    @Field(() => Int, {nullable: true})
+    TotalRowCount: number;
+
+    @Field(() => Int, {nullable: true})
+    ExecutionTime: number;
+
+    @Field({nullable: true})
+    ErrorMessage?: string;
+
+    @Field(() => Boolean, {nullable: false})
+    Success: boolean;
+}
+
+@Resolver(mjCommitteesMeeting_)
+export class mjCommitteesMeetingResolver extends ResolverBase {
+    @Query(() => RunmjCommitteesMeetingViewResult)
+    async RunmjCommitteesMeetingViewByID(@Arg('input', () => RunViewByIDInput) input: RunViewByIDInput, @Ctx() { providers, userPayload }: AppContext, @PubSub() pubSub: PubSubEngine) {
+        const provider = GetReadOnlyProvider(providers, { allowFallbackToReadWrite: true });
+        return super.RunViewByIDGeneric(input, provider, userPayload, pubSub);
+    }
+
+    @Query(() => RunmjCommitteesMeetingViewResult)
+    async RunmjCommitteesMeetingViewByName(@Arg('input', () => RunViewByNameInput) input: RunViewByNameInput, @Ctx() { providers, userPayload }: AppContext, @PubSub() pubSub: PubSubEngine) {
+        const provider = GetReadOnlyProvider(providers, { allowFallbackToReadWrite: true });
+        return super.RunViewByNameGeneric(input, provider, userPayload, pubSub);
+    }
+
+    @Query(() => RunmjCommitteesMeetingViewResult)
+    async RunmjCommitteesMeetingDynamicView(@Arg('input', () => RunDynamicViewInput) input: RunDynamicViewInput, @Ctx() { providers, userPayload }: AppContext, @PubSub() pubSub: PubSubEngine) {
+        const provider = GetReadOnlyProvider(providers, { allowFallbackToReadWrite: true });
+        input.EntityName = 'Meetings';
+        return super.RunDynamicViewGeneric(input, provider, userPayload, pubSub);
+    }
+    @Query(() => mjCommitteesMeeting_, { nullable: true })
+    async mjCommitteesMeeting(@Arg('ID', () => String) ID: string, @Ctx() { userPayload, providers }: AppContext, @PubSub() pubSub: PubSubEngine): Promise<mjCommitteesMeeting_ | null> {
+        this.CheckUserReadPermissions('Meetings', userPayload);
+        const provider = GetReadOnlyProvider(providers, { allowFallbackToReadWrite: true });
+        const sSQL = `SELECT * FROM ${provider.QuoteSchemaAndView('__mj_Committees', 'vwMeetings')} WHERE ${provider.QuoteIdentifier('ID')}='${ID}' ` + this.getRowLevelSecurityWhereClause(provider, 'Meetings', userPayload, EntityPermissionType.Read, 'AND');
+        const rows = await provider.ExecuteSQL(sSQL, undefined, undefined, this.GetUserFromPayload(userPayload));
+        const result = await this.MapFieldNamesToCodeNames('Meetings', rows && rows.length > 0 ? rows[0] : null, this.GetUserFromPayload(userPayload));
+        return result;
+    }
+    
+    @FieldResolver(() => [mjCommitteesMinute_])
+    async mjCommitteesMinutes_ApprovedByMeetingIDArray(@Root() mjcommitteesmeeting_: mjCommitteesMeeting_, @Ctx() { userPayload, providers }: AppContext, @PubSub() pubSub: PubSubEngine) {
+        this.CheckUserReadPermissions('Minutes', userPayload);
+        const provider = GetReadOnlyProvider(providers, { allowFallbackToReadWrite: true });
+        const sSQL = `SELECT * FROM ${provider.QuoteSchemaAndView('__mj_Committees', 'vwMinutes')} WHERE ${provider.QuoteIdentifier('ApprovedByMeetingID')}='${mjcommitteesmeeting_.ID}' ` + this.getRowLevelSecurityWhereClause(provider, 'Minutes', userPayload, EntityPermissionType.Read, 'AND');
+        const rows = await provider.ExecuteSQL(sSQL, undefined, undefined, this.GetUserFromPayload(userPayload));
+        const result = await this.ArrayMapFieldNamesToCodeNames('Minutes', rows, this.GetUserFromPayload(userPayload));
+        return result;
+    }
+        
+    @FieldResolver(() => [mjCommitteesMinute_])
+    async mjCommitteesMinutes_MeetingIDArray(@Root() mjcommitteesmeeting_: mjCommitteesMeeting_, @Ctx() { userPayload, providers }: AppContext, @PubSub() pubSub: PubSubEngine) {
+        this.CheckUserReadPermissions('Minutes', userPayload);
+        const provider = GetReadOnlyProvider(providers, { allowFallbackToReadWrite: true });
+        const sSQL = `SELECT * FROM ${provider.QuoteSchemaAndView('__mj_Committees', 'vwMinutes')} WHERE ${provider.QuoteIdentifier('MeetingID')}='${mjcommitteesmeeting_.ID}' ` + this.getRowLevelSecurityWhereClause(provider, 'Minutes', userPayload, EntityPermissionType.Read, 'AND');
+        const rows = await provider.ExecuteSQL(sSQL, undefined, undefined, this.GetUserFromPayload(userPayload));
+        const result = await this.ArrayMapFieldNamesToCodeNames('Minutes', rows, this.GetUserFromPayload(userPayload));
+        return result;
+    }
+        
+    @FieldResolver(() => [mjCommitteesAgendaItem_])
+    async mjCommitteesAgendaItems_MeetingIDArray(@Root() mjcommitteesmeeting_: mjCommitteesMeeting_, @Ctx() { userPayload, providers }: AppContext, @PubSub() pubSub: PubSubEngine) {
+        this.CheckUserReadPermissions('Agenda Items', userPayload);
+        const provider = GetReadOnlyProvider(providers, { allowFallbackToReadWrite: true });
+        const sSQL = `SELECT * FROM ${provider.QuoteSchemaAndView('__mj_Committees', 'vwAgendaItems')} WHERE ${provider.QuoteIdentifier('MeetingID')}='${mjcommitteesmeeting_.ID}' ` + this.getRowLevelSecurityWhereClause(provider, 'Agenda Items', userPayload, EntityPermissionType.Read, 'AND');
+        const rows = await provider.ExecuteSQL(sSQL, undefined, undefined, this.GetUserFromPayload(userPayload));
+        const result = await this.ArrayMapFieldNamesToCodeNames('Agenda Items', rows, this.GetUserFromPayload(userPayload));
+        return result;
+    }
+        
+    @FieldResolver(() => [mjCommitteesAttendance_])
+    async mjCommitteesAttendances_MeetingIDArray(@Root() mjcommitteesmeeting_: mjCommitteesMeeting_, @Ctx() { userPayload, providers }: AppContext, @PubSub() pubSub: PubSubEngine) {
+        this.CheckUserReadPermissions('Attendances', userPayload);
+        const provider = GetReadOnlyProvider(providers, { allowFallbackToReadWrite: true });
+        const sSQL = `SELECT * FROM ${provider.QuoteSchemaAndView('__mj_Committees', 'vwAttendances')} WHERE ${provider.QuoteIdentifier('MeetingID')}='${mjcommitteesmeeting_.ID}' ` + this.getRowLevelSecurityWhereClause(provider, 'Attendances', userPayload, EntityPermissionType.Read, 'AND');
+        const rows = await provider.ExecuteSQL(sSQL, undefined, undefined, this.GetUserFromPayload(userPayload));
+        const result = await this.ArrayMapFieldNamesToCodeNames('Attendances', rows, this.GetUserFromPayload(userPayload));
+        return result;
+    }
+        
+    @FieldResolver(() => [mjCommitteesArtifact_])
+    async mjCommitteesArtifacts_MeetingIDArray(@Root() mjcommitteesmeeting_: mjCommitteesMeeting_, @Ctx() { userPayload, providers }: AppContext, @PubSub() pubSub: PubSubEngine) {
+        this.CheckUserReadPermissions('Artifacts', userPayload);
+        const provider = GetReadOnlyProvider(providers, { allowFallbackToReadWrite: true });
+        const sSQL = `SELECT * FROM ${provider.QuoteSchemaAndView('__mj_Committees', 'vwArtifacts')} WHERE ${provider.QuoteIdentifier('MeetingID')}='${mjcommitteesmeeting_.ID}' ` + this.getRowLevelSecurityWhereClause(provider, 'Artifacts', userPayload, EntityPermissionType.Read, 'AND');
+        const rows = await provider.ExecuteSQL(sSQL, undefined, undefined, this.GetUserFromPayload(userPayload));
+        const result = await this.ArrayMapFieldNamesToCodeNames('Artifacts', rows, this.GetUserFromPayload(userPayload));
+        return result;
+    }
+        
+    @FieldResolver(() => [mjCommitteesMotion_])
+    async mjCommitteesMotions_MeetingIDArray(@Root() mjcommitteesmeeting_: mjCommitteesMeeting_, @Ctx() { userPayload, providers }: AppContext, @PubSub() pubSub: PubSubEngine) {
+        this.CheckUserReadPermissions('Motions', userPayload);
+        const provider = GetReadOnlyProvider(providers, { allowFallbackToReadWrite: true });
+        const sSQL = `SELECT * FROM ${provider.QuoteSchemaAndView('__mj_Committees', 'vwMotions')} WHERE ${provider.QuoteIdentifier('MeetingID')}='${mjcommitteesmeeting_.ID}' ` + this.getRowLevelSecurityWhereClause(provider, 'Motions', userPayload, EntityPermissionType.Read, 'AND');
+        const rows = await provider.ExecuteSQL(sSQL, undefined, undefined, this.GetUserFromPayload(userPayload));
+        const result = await this.ArrayMapFieldNamesToCodeNames('Motions', rows, this.GetUserFromPayload(userPayload));
+        return result;
+    }
+        
+    @FieldResolver(() => [mjCommitteesActionItem_])
+    async mjCommitteesActionItems_MeetingIDArray(@Root() mjcommitteesmeeting_: mjCommitteesMeeting_, @Ctx() { userPayload, providers }: AppContext, @PubSub() pubSub: PubSubEngine) {
+        this.CheckUserReadPermissions('Action Items', userPayload);
+        const provider = GetReadOnlyProvider(providers, { allowFallbackToReadWrite: true });
+        const sSQL = `SELECT * FROM ${provider.QuoteSchemaAndView('__mj_Committees', 'vwActionItems')} WHERE ${provider.QuoteIdentifier('MeetingID')}='${mjcommitteesmeeting_.ID}' ` + this.getRowLevelSecurityWhereClause(provider, 'Action Items', userPayload, EntityPermissionType.Read, 'AND');
+        const rows = await provider.ExecuteSQL(sSQL, undefined, undefined, this.GetUserFromPayload(userPayload));
+        const result = await this.ArrayMapFieldNamesToCodeNames('Action Items', rows, this.GetUserFromPayload(userPayload));
+        return result;
+    }
+        
+    @FieldResolver(() => [mjCommitteesComment_])
+    async mjCommitteesComments_MeetingIDArray(@Root() mjcommitteesmeeting_: mjCommitteesMeeting_, @Ctx() { userPayload, providers }: AppContext, @PubSub() pubSub: PubSubEngine) {
+        this.CheckUserReadPermissions('Comments', userPayload);
+        const provider = GetReadOnlyProvider(providers, { allowFallbackToReadWrite: true });
+        const sSQL = `SELECT * FROM ${provider.QuoteSchemaAndView('__mj_Committees', 'vwComments')} WHERE ${provider.QuoteIdentifier('MeetingID')}='${mjcommitteesmeeting_.ID}' ` + this.getRowLevelSecurityWhereClause(provider, 'Comments', userPayload, EntityPermissionType.Read, 'AND');
+        const rows = await provider.ExecuteSQL(sSQL, undefined, undefined, this.GetUserFromPayload(userPayload));
+        const result = await this.ArrayMapFieldNamesToCodeNames('Comments', rows, this.GetUserFromPayload(userPayload));
+        return result;
+    }
+        
+    @Mutation(() => mjCommitteesMeeting_)
+    async CreatemjCommitteesMeeting(
+        @Arg('input', () => CreatemjCommitteesMeetingInput) input: CreatemjCommitteesMeetingInput,
+        @Ctx() { providers, userPayload }: AppContext,
+        @PubSub() pubSub: PubSubEngine
+    ) {
+        const provider = GetReadWriteProvider(providers);
+        return this.CreateRecord('Meetings', input, provider, userPayload, pubSub)
+    }
+        
+    @Mutation(() => mjCommitteesMeeting_)
+    async UpdatemjCommitteesMeeting(
+        @Arg('input', () => UpdatemjCommitteesMeetingInput) input: UpdatemjCommitteesMeetingInput,
+        @Ctx() { providers, userPayload }: AppContext,
+        @PubSub() pubSub: PubSubEngine
+    ) {
+        const provider = GetReadWriteProvider(providers);
+        return this.UpdateRecord('Meetings', input, provider, userPayload, pubSub);
+    }
+    
+    @Mutation(() => mjCommitteesMeeting_)
+    async DeletemjCommitteesMeeting(@Arg('ID', () => String) ID: string, @Arg('options___', () => DeleteOptionsInput) options: DeleteOptionsInput, @Ctx() { providers, userPayload }: AppContext, @PubSub() pubSub: PubSubEngine) {
+        const provider = GetReadWriteProvider(providers);
+        const key = new CompositeKey([{FieldName: 'ID', Value: ID}]);
+        return this.DeleteRecord('Meetings', key, options, provider, userPayload, pubSub);
+    }
+    
+}
+
+//****************************************************************************
+// ENTITY CLASS for Memberships
+//****************************************************************************
+@ObjectType({ description: `Person assignments to committees with roles and terms` })
+export class mjCommitteesMembership_ {
+    @Field() 
+    @MaxLength(36)
+    ID: string;
+        
+    @Field() 
+    @MaxLength(36)
+    PersonID: string;
+        
+    @Field() 
+    @MaxLength(36)
+    RoleID: string;
+        
+    @Field() 
+    @MaxLength(36)
+    TermID: string;
+        
+    @Field({description: `Date the membership started`}) 
+    StartDate: Date;
+        
+    @Field({nullable: true, description: `Date the membership ended, if applicable`}) 
+    EndDate?: Date;
+        
+    @Field({description: `Current status: Active, Pending, Ended, or Suspended`}) 
+    @MaxLength(50)
+    Status: string;
+        
+    @Field({nullable: true, description: `Reason the membership ended: Term ended, Resigned, Removed, etc.`}) 
+    @MaxLength(100)
+    EndReason?: string;
+        
+    @Field({nullable: true, description: `Additional notes about this membership`}) 
+    Notes?: string;
+        
+    @Field() 
+    _mj__CreatedAt: Date;
+        
+    @Field() 
+    _mj__UpdatedAt: Date;
+        
+    @Field() 
+    @MaxLength(100)
+    Person: string;
+        
+    @Field() 
+    @MaxLength(100)
+    Role: string;
+        
+    @Field() 
+    @MaxLength(100)
+    Term: string;
+        
+    @Field(() => [mjCommitteesMotion_])
+    mjCommitteesMotions_MovedByMembershipIDArray: mjCommitteesMotion_[]; // Link to mjCommitteesMotions
+    
+    @Field(() => [mjCommitteesVote_])
+    mjCommitteesVotes_MembershipIDArray: mjCommitteesVote_[]; // Link to mjCommitteesVotes
+    
+    @Field(() => [mjCommitteesMotion_])
+    mjCommitteesMotions_SecondedByMembershipIDArray: mjCommitteesMotion_[]; // Link to mjCommitteesMotions
+    
+}
+
+//****************************************************************************
+// INPUT TYPE for Memberships
+//****************************************************************************
+@InputType()
+export class CreatemjCommitteesMembershipInput {
+    @Field({ nullable: true })
+    ID?: string;
+
+    @Field({ nullable: true })
+    PersonID?: string;
+
+    @Field({ nullable: true })
+    RoleID?: string;
+
+    @Field({ nullable: true })
+    TermID?: string;
+
+    @Field({ nullable: true })
+    StartDate?: Date;
+
+    @Field({ nullable: true })
+    EndDate: Date | null;
+
+    @Field({ nullable: true })
+    Status?: string;
+
+    @Field({ nullable: true })
+    EndReason: string | null;
+
+    @Field({ nullable: true })
+    Notes: string | null;
+}
+    
+
+//****************************************************************************
+// INPUT TYPE for Memberships
+//****************************************************************************
+@InputType()
+export class UpdatemjCommitteesMembershipInput {
+    @Field()
+    ID: string;
+
+    @Field({ nullable: true })
+    PersonID?: string;
+
+    @Field({ nullable: true })
+    RoleID?: string;
+
+    @Field({ nullable: true })
+    TermID?: string;
+
+    @Field({ nullable: true })
+    StartDate?: Date;
+
+    @Field({ nullable: true })
+    EndDate?: Date | null;
+
+    @Field({ nullable: true })
+    Status?: string;
+
+    @Field({ nullable: true })
+    EndReason?: string | null;
+
+    @Field({ nullable: true })
+    Notes?: string | null;
+
+    @Field(() => [KeyValuePairInput], { nullable: true })
+    OldValues___?: KeyValuePairInput[];
+}
+    
+//****************************************************************************
+// RESOLVER for Memberships
+//****************************************************************************
+@ObjectType()
+export class RunmjCommitteesMembershipViewResult {
+    @Field(() => [mjCommitteesMembership_])
+    Results: mjCommitteesMembership_[];
+
+    @Field(() => String, {nullable: true})
+    UserViewRunID?: string;
+
+    @Field(() => Int, {nullable: true})
+    RowCount: number;
+
+    @Field(() => Int, {nullable: true})
+    TotalRowCount: number;
+
+    @Field(() => Int, {nullable: true})
+    ExecutionTime: number;
+
+    @Field({nullable: true})
+    ErrorMessage?: string;
+
+    @Field(() => Boolean, {nullable: false})
+    Success: boolean;
+}
+
+@Resolver(mjCommitteesMembership_)
+export class mjCommitteesMembershipResolver extends ResolverBase {
+    @Query(() => RunmjCommitteesMembershipViewResult)
+    async RunmjCommitteesMembershipViewByID(@Arg('input', () => RunViewByIDInput) input: RunViewByIDInput, @Ctx() { providers, userPayload }: AppContext, @PubSub() pubSub: PubSubEngine) {
+        const provider = GetReadOnlyProvider(providers, { allowFallbackToReadWrite: true });
+        return super.RunViewByIDGeneric(input, provider, userPayload, pubSub);
+    }
+
+    @Query(() => RunmjCommitteesMembershipViewResult)
+    async RunmjCommitteesMembershipViewByName(@Arg('input', () => RunViewByNameInput) input: RunViewByNameInput, @Ctx() { providers, userPayload }: AppContext, @PubSub() pubSub: PubSubEngine) {
+        const provider = GetReadOnlyProvider(providers, { allowFallbackToReadWrite: true });
+        return super.RunViewByNameGeneric(input, provider, userPayload, pubSub);
+    }
+
+    @Query(() => RunmjCommitteesMembershipViewResult)
+    async RunmjCommitteesMembershipDynamicView(@Arg('input', () => RunDynamicViewInput) input: RunDynamicViewInput, @Ctx() { providers, userPayload }: AppContext, @PubSub() pubSub: PubSubEngine) {
+        const provider = GetReadOnlyProvider(providers, { allowFallbackToReadWrite: true });
+        input.EntityName = 'Memberships';
+        return super.RunDynamicViewGeneric(input, provider, userPayload, pubSub);
+    }
+    @Query(() => mjCommitteesMembership_, { nullable: true })
+    async mjCommitteesMembership(@Arg('ID', () => String) ID: string, @Ctx() { userPayload, providers }: AppContext, @PubSub() pubSub: PubSubEngine): Promise<mjCommitteesMembership_ | null> {
+        this.CheckUserReadPermissions('Memberships', userPayload);
+        const provider = GetReadOnlyProvider(providers, { allowFallbackToReadWrite: true });
+        const sSQL = `SELECT * FROM ${provider.QuoteSchemaAndView('__mj_Committees', 'vwMemberships')} WHERE ${provider.QuoteIdentifier('ID')}='${ID}' ` + this.getRowLevelSecurityWhereClause(provider, 'Memberships', userPayload, EntityPermissionType.Read, 'AND');
+        const rows = await provider.ExecuteSQL(sSQL, undefined, undefined, this.GetUserFromPayload(userPayload));
+        const result = await this.MapFieldNamesToCodeNames('Memberships', rows && rows.length > 0 ? rows[0] : null, this.GetUserFromPayload(userPayload));
+        return result;
+    }
+    
+    @FieldResolver(() => [mjCommitteesMotion_])
+    async mjCommitteesMotions_MovedByMembershipIDArray(@Root() mjcommitteesmembership_: mjCommitteesMembership_, @Ctx() { userPayload, providers }: AppContext, @PubSub() pubSub: PubSubEngine) {
+        this.CheckUserReadPermissions('Motions', userPayload);
+        const provider = GetReadOnlyProvider(providers, { allowFallbackToReadWrite: true });
+        const sSQL = `SELECT * FROM ${provider.QuoteSchemaAndView('__mj_Committees', 'vwMotions')} WHERE ${provider.QuoteIdentifier('MovedByMembershipID')}='${mjcommitteesmembership_.ID}' ` + this.getRowLevelSecurityWhereClause(provider, 'Motions', userPayload, EntityPermissionType.Read, 'AND');
+        const rows = await provider.ExecuteSQL(sSQL, undefined, undefined, this.GetUserFromPayload(userPayload));
+        const result = await this.ArrayMapFieldNamesToCodeNames('Motions', rows, this.GetUserFromPayload(userPayload));
+        return result;
+    }
+        
+    @FieldResolver(() => [mjCommitteesVote_])
+    async mjCommitteesVotes_MembershipIDArray(@Root() mjcommitteesmembership_: mjCommitteesMembership_, @Ctx() { userPayload, providers }: AppContext, @PubSub() pubSub: PubSubEngine) {
+        this.CheckUserReadPermissions('Votes', userPayload);
+        const provider = GetReadOnlyProvider(providers, { allowFallbackToReadWrite: true });
+        const sSQL = `SELECT * FROM ${provider.QuoteSchemaAndView('__mj_Committees', 'vwVotes')} WHERE ${provider.QuoteIdentifier('MembershipID')}='${mjcommitteesmembership_.ID}' ` + this.getRowLevelSecurityWhereClause(provider, 'Votes', userPayload, EntityPermissionType.Read, 'AND');
+        const rows = await provider.ExecuteSQL(sSQL, undefined, undefined, this.GetUserFromPayload(userPayload));
+        const result = await this.ArrayMapFieldNamesToCodeNames('Votes', rows, this.GetUserFromPayload(userPayload));
+        return result;
+    }
+        
+    @FieldResolver(() => [mjCommitteesMotion_])
+    async mjCommitteesMotions_SecondedByMembershipIDArray(@Root() mjcommitteesmembership_: mjCommitteesMembership_, @Ctx() { userPayload, providers }: AppContext, @PubSub() pubSub: PubSubEngine) {
+        this.CheckUserReadPermissions('Motions', userPayload);
+        const provider = GetReadOnlyProvider(providers, { allowFallbackToReadWrite: true });
+        const sSQL = `SELECT * FROM ${provider.QuoteSchemaAndView('__mj_Committees', 'vwMotions')} WHERE ${provider.QuoteIdentifier('SecondedByMembershipID')}='${mjcommitteesmembership_.ID}' ` + this.getRowLevelSecurityWhereClause(provider, 'Motions', userPayload, EntityPermissionType.Read, 'AND');
+        const rows = await provider.ExecuteSQL(sSQL, undefined, undefined, this.GetUserFromPayload(userPayload));
+        const result = await this.ArrayMapFieldNamesToCodeNames('Motions', rows, this.GetUserFromPayload(userPayload));
+        return result;
+    }
+        
+    @Mutation(() => mjCommitteesMembership_)
+    async CreatemjCommitteesMembership(
+        @Arg('input', () => CreatemjCommitteesMembershipInput) input: CreatemjCommitteesMembershipInput,
+        @Ctx() { providers, userPayload }: AppContext,
+        @PubSub() pubSub: PubSubEngine
+    ) {
+        const provider = GetReadWriteProvider(providers);
+        return this.CreateRecord('Memberships', input, provider, userPayload, pubSub)
+    }
+        
+    @Mutation(() => mjCommitteesMembership_)
+    async UpdatemjCommitteesMembership(
+        @Arg('input', () => UpdatemjCommitteesMembershipInput) input: UpdatemjCommitteesMembershipInput,
+        @Ctx() { providers, userPayload }: AppContext,
+        @PubSub() pubSub: PubSubEngine
+    ) {
+        const provider = GetReadWriteProvider(providers);
+        return this.UpdateRecord('Memberships', input, provider, userPayload, pubSub);
+    }
+    
+    @Mutation(() => mjCommitteesMembership_)
+    async DeletemjCommitteesMembership(@Arg('ID', () => String) ID: string, @Arg('options___', () => DeleteOptionsInput) options: DeleteOptionsInput, @Ctx() { providers, userPayload }: AppContext, @PubSub() pubSub: PubSubEngine) {
+        const provider = GetReadWriteProvider(providers);
+        const key = new CompositeKey([{FieldName: 'ID', Value: ID}]);
+        return this.DeleteRecord('Memberships', key, options, provider, userPayload, pubSub);
+    }
+    
+}
+
+//****************************************************************************
+// ENTITY CLASS for Minutes
+//****************************************************************************
+@ObjectType({ description: `Extension entity for Minutes artifacts with approval tracking` })
+export class mjCommitteesMinute_ {
+    @Field() 
+    @MaxLength(36)
+    ID: string;
+        
+    @Field({nullable: true}) 
+    @MaxLength(36)
+    ArtifactID?: string;
+        
+    @Field({description: `Current approval status: Draft, PendingApproval, Approved, Rejected`}) 
+    @MaxLength(50)
+    ApprovalStatus: string;
+        
+    @Field({nullable: true, description: `Timestamp when the minutes were approved`}) 
+    ApprovedAt?: Date;
+        
+    @Field({nullable: true, description: `Reference to the meeting at which these minutes were approved (typically the next meeting)`}) 
+    @MaxLength(36)
+    ApprovedByMeetingID?: string;
+        
+    @Field({nullable: true, description: `Additional notes about the minutes`}) 
+    Notes?: string;
+        
+    @Field({nullable: true}) 
+    @MaxLength(36)
+    MeetingID?: string;
+        
+    @Field({nullable: true}) 
+    Content?: string;
+        
+    @Field() 
+    _mj__CreatedAt: Date;
+        
+    @Field() 
+    _mj__UpdatedAt: Date;
+        
+    @Field({nullable: true}) 
+    @MaxLength(255)
+    ApprovedByMeeting?: string;
+        
+    @Field({nullable: true}) 
+    @MaxLength(255)
+    Meeting?: string;
+        
+}
+
+//****************************************************************************
+// INPUT TYPE for Minutes
+//****************************************************************************
+@InputType()
+export class CreatemjCommitteesMinuteInput {
+    @Field({ nullable: true })
+    ID?: string;
+
+    @Field({ nullable: true })
+    ArtifactID: string | null;
+
+    @Field({ nullable: true })
+    ApprovalStatus?: string;
+
+    @Field({ nullable: true })
+    ApprovedAt: Date | null;
+
+    @Field({ nullable: true })
+    ApprovedByMeetingID: string | null;
+
+    @Field({ nullable: true })
+    Notes: string | null;
+
+    @Field({ nullable: true })
+    MeetingID: string | null;
+
+    @Field({ nullable: true })
+    Content: string | null;
+}
+    
+
+//****************************************************************************
+// INPUT TYPE for Minutes
+//****************************************************************************
+@InputType()
+export class UpdatemjCommitteesMinuteInput {
+    @Field()
+    ID: string;
+
+    @Field({ nullable: true })
+    ArtifactID?: string | null;
+
+    @Field({ nullable: true })
+    ApprovalStatus?: string;
+
+    @Field({ nullable: true })
+    ApprovedAt?: Date | null;
+
+    @Field({ nullable: true })
+    ApprovedByMeetingID?: string | null;
+
+    @Field({ nullable: true })
+    Notes?: string | null;
+
+    @Field({ nullable: true })
+    MeetingID?: string | null;
+
+    @Field({ nullable: true })
+    Content?: string | null;
+
+    @Field(() => [KeyValuePairInput], { nullable: true })
+    OldValues___?: KeyValuePairInput[];
+}
+    
+//****************************************************************************
+// RESOLVER for Minutes
+//****************************************************************************
+@ObjectType()
+export class RunmjCommitteesMinuteViewResult {
+    @Field(() => [mjCommitteesMinute_])
+    Results: mjCommitteesMinute_[];
+
+    @Field(() => String, {nullable: true})
+    UserViewRunID?: string;
+
+    @Field(() => Int, {nullable: true})
+    RowCount: number;
+
+    @Field(() => Int, {nullable: true})
+    TotalRowCount: number;
+
+    @Field(() => Int, {nullable: true})
+    ExecutionTime: number;
+
+    @Field({nullable: true})
+    ErrorMessage?: string;
+
+    @Field(() => Boolean, {nullable: false})
+    Success: boolean;
+}
+
+@Resolver(mjCommitteesMinute_)
+export class mjCommitteesMinuteResolver extends ResolverBase {
+    @Query(() => RunmjCommitteesMinuteViewResult)
+    async RunmjCommitteesMinuteViewByID(@Arg('input', () => RunViewByIDInput) input: RunViewByIDInput, @Ctx() { providers, userPayload }: AppContext, @PubSub() pubSub: PubSubEngine) {
+        const provider = GetReadOnlyProvider(providers, { allowFallbackToReadWrite: true });
+        return super.RunViewByIDGeneric(input, provider, userPayload, pubSub);
+    }
+
+    @Query(() => RunmjCommitteesMinuteViewResult)
+    async RunmjCommitteesMinuteViewByName(@Arg('input', () => RunViewByNameInput) input: RunViewByNameInput, @Ctx() { providers, userPayload }: AppContext, @PubSub() pubSub: PubSubEngine) {
+        const provider = GetReadOnlyProvider(providers, { allowFallbackToReadWrite: true });
+        return super.RunViewByNameGeneric(input, provider, userPayload, pubSub);
+    }
+
+    @Query(() => RunmjCommitteesMinuteViewResult)
+    async RunmjCommitteesMinuteDynamicView(@Arg('input', () => RunDynamicViewInput) input: RunDynamicViewInput, @Ctx() { providers, userPayload }: AppContext, @PubSub() pubSub: PubSubEngine) {
+        const provider = GetReadOnlyProvider(providers, { allowFallbackToReadWrite: true });
+        input.EntityName = 'Minutes';
+        return super.RunDynamicViewGeneric(input, provider, userPayload, pubSub);
+    }
+    @Query(() => mjCommitteesMinute_, { nullable: true })
+    async mjCommitteesMinute(@Arg('ID', () => String) ID: string, @Ctx() { userPayload, providers }: AppContext, @PubSub() pubSub: PubSubEngine): Promise<mjCommitteesMinute_ | null> {
+        this.CheckUserReadPermissions('Minutes', userPayload);
+        const provider = GetReadOnlyProvider(providers, { allowFallbackToReadWrite: true });
+        const sSQL = `SELECT * FROM ${provider.QuoteSchemaAndView('__mj_Committees', 'vwMinutes')} WHERE ${provider.QuoteIdentifier('ID')}='${ID}' ` + this.getRowLevelSecurityWhereClause(provider, 'Minutes', userPayload, EntityPermissionType.Read, 'AND');
+        const rows = await provider.ExecuteSQL(sSQL, undefined, undefined, this.GetUserFromPayload(userPayload));
+        const result = await this.MapFieldNamesToCodeNames('Minutes', rows && rows.length > 0 ? rows[0] : null, this.GetUserFromPayload(userPayload));
+        return result;
+    }
+    
+    @Mutation(() => mjCommitteesMinute_)
+    async CreatemjCommitteesMinute(
+        @Arg('input', () => CreatemjCommitteesMinuteInput) input: CreatemjCommitteesMinuteInput,
+        @Ctx() { providers, userPayload }: AppContext,
+        @PubSub() pubSub: PubSubEngine
+    ) {
+        const provider = GetReadWriteProvider(providers);
+        return this.CreateRecord('Minutes', input, provider, userPayload, pubSub)
+    }
+        
+    @Mutation(() => mjCommitteesMinute_)
+    async UpdatemjCommitteesMinute(
+        @Arg('input', () => UpdatemjCommitteesMinuteInput) input: UpdatemjCommitteesMinuteInput,
+        @Ctx() { providers, userPayload }: AppContext,
+        @PubSub() pubSub: PubSubEngine
+    ) {
+        const provider = GetReadWriteProvider(providers);
+        return this.UpdateRecord('Minutes', input, provider, userPayload, pubSub);
+    }
+    
+    @Mutation(() => mjCommitteesMinute_)
+    async DeletemjCommitteesMinute(@Arg('ID', () => String) ID: string, @Arg('options___', () => DeleteOptionsInput) options: DeleteOptionsInput, @Ctx() { providers, userPayload }: AppContext, @PubSub() pubSub: PubSubEngine) {
+        const provider = GetReadWriteProvider(providers);
+        const key = new CompositeKey([{FieldName: 'ID', Value: ID}]);
+        return this.DeleteRecord('Minutes', key, options, provider, userPayload, pubSub);
+    }
+    
+}
+
+//****************************************************************************
+// ENTITY CLASS for Motions
+//****************************************************************************
+@ObjectType({ description: `Formal motions put to vote during committee meetings` })
+export class mjCommitteesMotion_ {
+    @Field() 
+    @MaxLength(36)
+    ID: string;
+        
+    @Field() 
+    @MaxLength(36)
+    MeetingID: string;
+        
+    @Field({nullable: true}) 
+    @MaxLength(36)
+    AgendaItemID?: string;
+        
+    @Field(() => Int, {description: `Display order when multiple motions exist for the same agenda item`}) 
+    Sequence: number;
+        
+    @Field({description: `Title of the motion`}) 
+    @MaxLength(255)
+    Title: string;
+        
+    @Field({nullable: true, description: `Full text or description of the motion`}) 
+    Description?: string;
+        
+    @Field({nullable: true, description: `The committee member who made the motion`}) 
+    @MaxLength(36)
+    MovedByMembershipID?: string;
+        
+    @Field({nullable: true, description: `The committee member who seconded the motion`}) 
+    @MaxLength(36)
+    SecondedByMembershipID?: string;
+        
+    @Field({description: `Outcome of the vote: Pending, Passed, Failed, Tabled, Withdrawn`}) 
+    @MaxLength(50)
+    Result: string;
+        
+    @Field({nullable: true, description: `Human-readable vote tally, e.g. 7-2-1 or Passed unanimously`}) 
+    @MaxLength(255)
+    ResultSummary?: string;
+        
+    @Field(() => Int, {nullable: true, description: `Number of Yes votes`}) 
+    YesCount?: number;
+        
+    @Field(() => Int, {nullable: true, description: `Number of No votes`}) 
+    NoCount?: number;
+        
+    @Field(() => Int, {nullable: true, description: `Number of Abstain votes`}) 
+    AbstainCount?: number;
+        
+    @Field({nullable: true, description: `Additional notes about the motion or vote`}) 
+    Notes?: string;
+        
+    @Field() 
+    _mj__CreatedAt: Date;
+        
+    @Field() 
+    _mj__UpdatedAt: Date;
+        
+    @Field() 
+    @MaxLength(255)
+    Meeting: string;
+        
+    @Field({nullable: true}) 
+    @MaxLength(255)
+    AgendaItem?: string;
+        
+    @Field({nullable: true}) 
+    @MaxLength(100)
+    MovedByMembership?: string;
+        
+    @Field({nullable: true}) 
+    @MaxLength(100)
+    SecondedByMembership?: string;
+        
+    @Field(() => [mjCommitteesVote_])
+    mjCommitteesVotes_MotionIDArray: mjCommitteesVote_[]; // Link to mjCommitteesVotes
+    
+}
+
+//****************************************************************************
+// INPUT TYPE for Motions
+//****************************************************************************
+@InputType()
+export class CreatemjCommitteesMotionInput {
+    @Field({ nullable: true })
+    ID?: string;
+
+    @Field({ nullable: true })
+    MeetingID?: string;
+
+    @Field({ nullable: true })
+    AgendaItemID: string | null;
+
+    @Field(() => Int, { nullable: true })
+    Sequence?: number;
+
+    @Field({ nullable: true })
+    Title?: string;
+
+    @Field({ nullable: true })
+    Description: string | null;
+
+    @Field({ nullable: true })
+    MovedByMembershipID: string | null;
+
+    @Field({ nullable: true })
+    SecondedByMembershipID: string | null;
+
+    @Field({ nullable: true })
+    Result?: string;
+
+    @Field({ nullable: true })
+    ResultSummary: string | null;
+
+    @Field(() => Int, { nullable: true })
+    YesCount: number | null;
+
+    @Field(() => Int, { nullable: true })
+    NoCount: number | null;
+
+    @Field(() => Int, { nullable: true })
+    AbstainCount: number | null;
+
+    @Field({ nullable: true })
+    Notes: string | null;
+}
+    
+
+//****************************************************************************
+// INPUT TYPE for Motions
+//****************************************************************************
+@InputType()
+export class UpdatemjCommitteesMotionInput {
+    @Field()
+    ID: string;
+
+    @Field({ nullable: true })
+    MeetingID?: string;
+
+    @Field({ nullable: true })
+    AgendaItemID?: string | null;
+
+    @Field(() => Int, { nullable: true })
+    Sequence?: number;
+
+    @Field({ nullable: true })
+    Title?: string;
+
+    @Field({ nullable: true })
+    Description?: string | null;
+
+    @Field({ nullable: true })
+    MovedByMembershipID?: string | null;
+
+    @Field({ nullable: true })
+    SecondedByMembershipID?: string | null;
+
+    @Field({ nullable: true })
+    Result?: string;
+
+    @Field({ nullable: true })
+    ResultSummary?: string | null;
+
+    @Field(() => Int, { nullable: true })
+    YesCount?: number | null;
+
+    @Field(() => Int, { nullable: true })
+    NoCount?: number | null;
+
+    @Field(() => Int, { nullable: true })
+    AbstainCount?: number | null;
+
+    @Field({ nullable: true })
+    Notes?: string | null;
+
+    @Field(() => [KeyValuePairInput], { nullable: true })
+    OldValues___?: KeyValuePairInput[];
+}
+    
+//****************************************************************************
+// RESOLVER for Motions
+//****************************************************************************
+@ObjectType()
+export class RunmjCommitteesMotionViewResult {
+    @Field(() => [mjCommitteesMotion_])
+    Results: mjCommitteesMotion_[];
+
+    @Field(() => String, {nullable: true})
+    UserViewRunID?: string;
+
+    @Field(() => Int, {nullable: true})
+    RowCount: number;
+
+    @Field(() => Int, {nullable: true})
+    TotalRowCount: number;
+
+    @Field(() => Int, {nullable: true})
+    ExecutionTime: number;
+
+    @Field({nullable: true})
+    ErrorMessage?: string;
+
+    @Field(() => Boolean, {nullable: false})
+    Success: boolean;
+}
+
+@Resolver(mjCommitteesMotion_)
+export class mjCommitteesMotionResolver extends ResolverBase {
+    @Query(() => RunmjCommitteesMotionViewResult)
+    async RunmjCommitteesMotionViewByID(@Arg('input', () => RunViewByIDInput) input: RunViewByIDInput, @Ctx() { providers, userPayload }: AppContext, @PubSub() pubSub: PubSubEngine) {
+        const provider = GetReadOnlyProvider(providers, { allowFallbackToReadWrite: true });
+        return super.RunViewByIDGeneric(input, provider, userPayload, pubSub);
+    }
+
+    @Query(() => RunmjCommitteesMotionViewResult)
+    async RunmjCommitteesMotionViewByName(@Arg('input', () => RunViewByNameInput) input: RunViewByNameInput, @Ctx() { providers, userPayload }: AppContext, @PubSub() pubSub: PubSubEngine) {
+        const provider = GetReadOnlyProvider(providers, { allowFallbackToReadWrite: true });
+        return super.RunViewByNameGeneric(input, provider, userPayload, pubSub);
+    }
+
+    @Query(() => RunmjCommitteesMotionViewResult)
+    async RunmjCommitteesMotionDynamicView(@Arg('input', () => RunDynamicViewInput) input: RunDynamicViewInput, @Ctx() { providers, userPayload }: AppContext, @PubSub() pubSub: PubSubEngine) {
+        const provider = GetReadOnlyProvider(providers, { allowFallbackToReadWrite: true });
+        input.EntityName = 'Motions';
+        return super.RunDynamicViewGeneric(input, provider, userPayload, pubSub);
+    }
+    @Query(() => mjCommitteesMotion_, { nullable: true })
+    async mjCommitteesMotion(@Arg('ID', () => String) ID: string, @Ctx() { userPayload, providers }: AppContext, @PubSub() pubSub: PubSubEngine): Promise<mjCommitteesMotion_ | null> {
+        this.CheckUserReadPermissions('Motions', userPayload);
+        const provider = GetReadOnlyProvider(providers, { allowFallbackToReadWrite: true });
+        const sSQL = `SELECT * FROM ${provider.QuoteSchemaAndView('__mj_Committees', 'vwMotions')} WHERE ${provider.QuoteIdentifier('ID')}='${ID}' ` + this.getRowLevelSecurityWhereClause(provider, 'Motions', userPayload, EntityPermissionType.Read, 'AND');
+        const rows = await provider.ExecuteSQL(sSQL, undefined, undefined, this.GetUserFromPayload(userPayload));
+        const result = await this.MapFieldNamesToCodeNames('Motions', rows && rows.length > 0 ? rows[0] : null, this.GetUserFromPayload(userPayload));
+        return result;
+    }
+    
+    @FieldResolver(() => [mjCommitteesVote_])
+    async mjCommitteesVotes_MotionIDArray(@Root() mjcommitteesmotion_: mjCommitteesMotion_, @Ctx() { userPayload, providers }: AppContext, @PubSub() pubSub: PubSubEngine) {
+        this.CheckUserReadPermissions('Votes', userPayload);
+        const provider = GetReadOnlyProvider(providers, { allowFallbackToReadWrite: true });
+        const sSQL = `SELECT * FROM ${provider.QuoteSchemaAndView('__mj_Committees', 'vwVotes')} WHERE ${provider.QuoteIdentifier('MotionID')}='${mjcommitteesmotion_.ID}' ` + this.getRowLevelSecurityWhereClause(provider, 'Votes', userPayload, EntityPermissionType.Read, 'AND');
+        const rows = await provider.ExecuteSQL(sSQL, undefined, undefined, this.GetUserFromPayload(userPayload));
+        const result = await this.ArrayMapFieldNamesToCodeNames('Votes', rows, this.GetUserFromPayload(userPayload));
+        return result;
+    }
+        
+    @Mutation(() => mjCommitteesMotion_)
+    async CreatemjCommitteesMotion(
+        @Arg('input', () => CreatemjCommitteesMotionInput) input: CreatemjCommitteesMotionInput,
+        @Ctx() { providers, userPayload }: AppContext,
+        @PubSub() pubSub: PubSubEngine
+    ) {
+        const provider = GetReadWriteProvider(providers);
+        return this.CreateRecord('Motions', input, provider, userPayload, pubSub)
+    }
+        
+    @Mutation(() => mjCommitteesMotion_)
+    async UpdatemjCommitteesMotion(
+        @Arg('input', () => UpdatemjCommitteesMotionInput) input: UpdatemjCommitteesMotionInput,
+        @Ctx() { providers, userPayload }: AppContext,
+        @PubSub() pubSub: PubSubEngine
+    ) {
+        const provider = GetReadWriteProvider(providers);
+        return this.UpdateRecord('Motions', input, provider, userPayload, pubSub);
+    }
+    
+    @Mutation(() => mjCommitteesMotion_)
+    async DeletemjCommitteesMotion(@Arg('ID', () => String) ID: string, @Arg('options___', () => DeleteOptionsInput) options: DeleteOptionsInput, @Ctx() { providers, userPayload }: AppContext, @PubSub() pubSub: PubSubEngine) {
+        const provider = GetReadWriteProvider(providers);
+        const key = new CompositeKey([{FieldName: 'ID', Value: ID}]);
+        return this.DeleteRecord('Motions', key, options, provider, userPayload, pubSub);
+    }
+    
+}
+
+//****************************************************************************
+// ENTITY CLASS for Organization Types
+//****************************************************************************
+@ObjectType({ description: `Categories of organizations such as Company, Non-Profit, Association, Government` })
+export class mjBizAppsCommonOrganizationType_ {
+    @Field() 
+    @MaxLength(36)
+    ID: string;
+        
+    @Field({description: `Display name for the organization type`}) 
+    @MaxLength(100)
+    Name: string;
+        
+    @Field({nullable: true, description: `Detailed description of this organization type`}) 
+    Description?: string;
+        
+    @Field({nullable: true, description: `Font Awesome icon class for UI display`}) 
+    @MaxLength(100)
+    IconClass?: string;
+        
+    @Field() 
+    _mj__CreatedAt: Date;
+        
+    @Field() 
+    _mj__UpdatedAt: Date;
+        
+    @Field(() => [mjBizAppsCommonOrganization_])
+    mjBizAppsCommonOrganizations_OrganizationTypeIDArray: mjBizAppsCommonOrganization_[]; // Link to mjBizAppsCommonOrganizations
+    
+}
+
+//****************************************************************************
+// INPUT TYPE for Organization Types
+//****************************************************************************
+@InputType()
+export class CreatemjBizAppsCommonOrganizationTypeInput {
+    @Field({ nullable: true })
+    ID?: string;
+
+    @Field({ nullable: true })
+    Name?: string;
+
+    @Field({ nullable: true })
+    Description: string | null;
+
+    @Field({ nullable: true })
+    IconClass: string | null;
+}
+    
+
+//****************************************************************************
+// INPUT TYPE for Organization Types
+//****************************************************************************
+@InputType()
+export class UpdatemjBizAppsCommonOrganizationTypeInput {
+    @Field()
+    ID: string;
+
+    @Field({ nullable: true })
+    Name?: string;
+
+    @Field({ nullable: true })
+    Description?: string | null;
+
+    @Field({ nullable: true })
+    IconClass?: string | null;
+
+    @Field(() => [KeyValuePairInput], { nullable: true })
+    OldValues___?: KeyValuePairInput[];
+}
+    
+//****************************************************************************
+// RESOLVER for Organization Types
+//****************************************************************************
+@ObjectType()
+export class RunmjBizAppsCommonOrganizationTypeViewResult {
+    @Field(() => [mjBizAppsCommonOrganizationType_])
+    Results: mjBizAppsCommonOrganizationType_[];
+
+    @Field(() => String, {nullable: true})
+    UserViewRunID?: string;
+
+    @Field(() => Int, {nullable: true})
+    RowCount: number;
+
+    @Field(() => Int, {nullable: true})
+    TotalRowCount: number;
+
+    @Field(() => Int, {nullable: true})
+    ExecutionTime: number;
+
+    @Field({nullable: true})
+    ErrorMessage?: string;
+
+    @Field(() => Boolean, {nullable: false})
+    Success: boolean;
+}
+
+@Resolver(mjBizAppsCommonOrganizationType_)
+export class mjBizAppsCommonOrganizationTypeResolver extends ResolverBase {
+    @Query(() => RunmjBizAppsCommonOrganizationTypeViewResult)
+    async RunmjBizAppsCommonOrganizationTypeViewByID(@Arg('input', () => RunViewByIDInput) input: RunViewByIDInput, @Ctx() { providers, userPayload }: AppContext, @PubSub() pubSub: PubSubEngine) {
+        const provider = GetReadOnlyProvider(providers, { allowFallbackToReadWrite: true });
+        return super.RunViewByIDGeneric(input, provider, userPayload, pubSub);
+    }
+
+    @Query(() => RunmjBizAppsCommonOrganizationTypeViewResult)
+    async RunmjBizAppsCommonOrganizationTypeViewByName(@Arg('input', () => RunViewByNameInput) input: RunViewByNameInput, @Ctx() { providers, userPayload }: AppContext, @PubSub() pubSub: PubSubEngine) {
+        const provider = GetReadOnlyProvider(providers, { allowFallbackToReadWrite: true });
+        return super.RunViewByNameGeneric(input, provider, userPayload, pubSub);
+    }
+
+    @Query(() => RunmjBizAppsCommonOrganizationTypeViewResult)
+    async RunmjBizAppsCommonOrganizationTypeDynamicView(@Arg('input', () => RunDynamicViewInput) input: RunDynamicViewInput, @Ctx() { providers, userPayload }: AppContext, @PubSub() pubSub: PubSubEngine) {
+        const provider = GetReadOnlyProvider(providers, { allowFallbackToReadWrite: true });
+        input.EntityName = 'Organization Types';
+        return super.RunDynamicViewGeneric(input, provider, userPayload, pubSub);
+    }
+    @Query(() => mjBizAppsCommonOrganizationType_, { nullable: true })
+    async mjBizAppsCommonOrganizationType(@Arg('ID', () => String) ID: string, @Ctx() { userPayload, providers }: AppContext, @PubSub() pubSub: PubSubEngine): Promise<mjBizAppsCommonOrganizationType_ | null> {
+        this.CheckUserReadPermissions('Organization Types', userPayload);
+        const provider = GetReadOnlyProvider(providers, { allowFallbackToReadWrite: true });
+        const sSQL = `SELECT * FROM ${provider.QuoteSchemaAndView('__mj_BizAppsCommon', 'vwOrganizationTypes')} WHERE ${provider.QuoteIdentifier('ID')}='${ID}' ` + this.getRowLevelSecurityWhereClause(provider, 'Organization Types', userPayload, EntityPermissionType.Read, 'AND');
+        const rows = await provider.ExecuteSQL(sSQL, undefined, undefined, this.GetUserFromPayload(userPayload));
+        const result = await this.MapFieldNamesToCodeNames('Organization Types', rows && rows.length > 0 ? rows[0] : null, this.GetUserFromPayload(userPayload));
+        return result;
+    }
+    
+    @FieldResolver(() => [mjBizAppsCommonOrganization_])
+    async mjBizAppsCommonOrganizations_OrganizationTypeIDArray(@Root() mjbizappscommonorganizationtype_: mjBizAppsCommonOrganizationType_, @Ctx() { userPayload, providers }: AppContext, @PubSub() pubSub: PubSubEngine) {
+        this.CheckUserReadPermissions('Organizations', userPayload);
+        const provider = GetReadOnlyProvider(providers, { allowFallbackToReadWrite: true });
+        const sSQL = `SELECT * FROM ${provider.QuoteSchemaAndView('__mj_BizAppsCommon', 'vwOrganizations')} WHERE ${provider.QuoteIdentifier('OrganizationTypeID')}='${mjbizappscommonorganizationtype_.ID}' ` + this.getRowLevelSecurityWhereClause(provider, 'Organizations', userPayload, EntityPermissionType.Read, 'AND');
+        const rows = await provider.ExecuteSQL(sSQL, undefined, undefined, this.GetUserFromPayload(userPayload));
+        const result = await this.ArrayMapFieldNamesToCodeNames('Organizations', rows, this.GetUserFromPayload(userPayload));
+        return result;
+    }
+        
+    @Mutation(() => mjBizAppsCommonOrganizationType_)
+    async CreatemjBizAppsCommonOrganizationType(
+        @Arg('input', () => CreatemjBizAppsCommonOrganizationTypeInput) input: CreatemjBizAppsCommonOrganizationTypeInput,
+        @Ctx() { providers, userPayload }: AppContext,
+        @PubSub() pubSub: PubSubEngine
+    ) {
+        const provider = GetReadWriteProvider(providers);
+        return this.CreateRecord('Organization Types', input, provider, userPayload, pubSub)
+    }
+        
+    @Mutation(() => mjBizAppsCommonOrganizationType_)
+    async UpdatemjBizAppsCommonOrganizationType(
+        @Arg('input', () => UpdatemjBizAppsCommonOrganizationTypeInput) input: UpdatemjBizAppsCommonOrganizationTypeInput,
+        @Ctx() { providers, userPayload }: AppContext,
+        @PubSub() pubSub: PubSubEngine
+    ) {
+        const provider = GetReadWriteProvider(providers);
+        return this.UpdateRecord('Organization Types', input, provider, userPayload, pubSub);
+    }
+    
+    @Mutation(() => mjBizAppsCommonOrganizationType_)
+    async DeletemjBizAppsCommonOrganizationType(@Arg('ID', () => String) ID: string, @Arg('options___', () => DeleteOptionsInput) options: DeleteOptionsInput, @Ctx() { providers, userPayload }: AppContext, @PubSub() pubSub: PubSubEngine) {
+        const provider = GetReadWriteProvider(providers);
+        const key = new CompositeKey([{FieldName: 'ID', Value: ID}]);
+        return this.DeleteRecord('Organization Types', key, options, provider, userPayload, pubSub);
+    }
+    
+}
+
+//****************************************************************************
+// ENTITY CLASS for Organizations
+//****************************************************************************
+@ObjectType({ description: `Companies, associations, government bodies, and other organizations with hierarchy support` })
+export class mjBizAppsCommonOrganization_ {
+    @Field() 
+    @MaxLength(36)
+    ID: string;
+        
+    @Field({description: `Common or display name of the organization`}) 
+    @MaxLength(255)
+    Name: string;
+        
+    @Field({nullable: true, description: `Full legal name if different from display name`}) 
+    @MaxLength(255)
+    LegalName?: string;
+        
+    @Field({nullable: true}) 
+    @MaxLength(36)
+    OrganizationTypeID?: string;
+        
+    @Field({nullable: true}) 
+    @MaxLength(36)
+    ParentID?: string;
+        
+    @Field({nullable: true, description: `Primary website URL`}) 
+    @MaxLength(1000)
+    Website?: string;
+        
+    @Field({nullable: true, description: `URL to organization logo image`}) 
+    @MaxLength(1000)
+    LogoURL?: string;
+        
+    @Field({nullable: true, description: `Description of the organization purpose and scope`}) 
+    Description?: string;
+        
+    @Field({nullable: true, description: `Primary contact email address`}) 
+    @MaxLength(255)
+    Email?: string;
+        
+    @Field({nullable: true, description: `Primary phone number`}) 
+    @MaxLength(50)
+    Phone?: string;
+        
+    @Field({nullable: true, description: `Date the organization was founded or incorporated`}) 
+    FoundedDate?: Date;
+        
+    @Field({nullable: true, description: `Tax identification number such as EIN`}) 
+    @MaxLength(50)
+    TaxID?: string;
+        
+    @Field({description: `Current status: Active, Inactive, or Dissolved`}) 
+    @MaxLength(50)
+    Status: string;
+        
+    @Field() 
+    _mj__CreatedAt: Date;
+        
+    @Field() 
+    _mj__UpdatedAt: Date;
+        
+    @Field({nullable: true}) 
+    @MaxLength(100)
+    OrganizationType?: string;
+        
+    @Field({nullable: true}) 
+    @MaxLength(255)
+    Parent?: string;
+        
+    @Field({nullable: true}) 
+    @MaxLength(36)
+    RootParentID?: string;
+        
+    @Field(() => [mjBizAppsCommonOrganization_])
+    mjBizAppsCommonOrganizations_ParentIDArray: mjBizAppsCommonOrganization_[]; // Link to mjBizAppsCommonOrganizations
+    
+    @Field(() => [mjCommitteesCommittee_])
+    mjCommitteesCommittees_OrganizationIDArray: mjCommitteesCommittee_[]; // Link to mjCommitteesCommittees
+    
+    @Field(() => [mjBizAppsCommonContactMethod_])
+    mjBizAppsCommonContactMethods_OrganizationIDArray: mjBizAppsCommonContactMethod_[]; // Link to mjBizAppsCommonContactMethods
+    
+    @Field(() => [mjBizAppsCommonRelationship_])
+    mjBizAppsCommonRelationships_ToOrganizationIDArray: mjBizAppsCommonRelationship_[]; // Link to mjBizAppsCommonRelationships
+    
+    @Field(() => [mjBizAppsCommonRelationship_])
+    mjBizAppsCommonRelationships_FromOrganizationIDArray: mjBizAppsCommonRelationship_[]; // Link to mjBizAppsCommonRelationships
+    
+}
+
+//****************************************************************************
+// INPUT TYPE for Organizations
+//****************************************************************************
+@InputType()
+export class CreatemjBizAppsCommonOrganizationInput {
+    @Field({ nullable: true })
+    ID?: string;
+
+    @Field({ nullable: true })
+    Name?: string;
+
+    @Field({ nullable: true })
+    LegalName: string | null;
+
+    @Field({ nullable: true })
+    OrganizationTypeID: string | null;
+
+    @Field({ nullable: true })
+    ParentID: string | null;
+
+    @Field({ nullable: true })
+    Website: string | null;
+
+    @Field({ nullable: true })
+    LogoURL: string | null;
+
+    @Field({ nullable: true })
+    Description: string | null;
+
+    @Field({ nullable: true })
+    Email: string | null;
+
+    @Field({ nullable: true })
+    Phone: string | null;
+
+    @Field({ nullable: true })
+    FoundedDate: Date | null;
+
+    @Field({ nullable: true })
+    TaxID: string | null;
+
+    @Field({ nullable: true })
+    Status?: string;
+}
+    
+
+//****************************************************************************
+// INPUT TYPE for Organizations
+//****************************************************************************
+@InputType()
+export class UpdatemjBizAppsCommonOrganizationInput {
+    @Field()
+    ID: string;
+
+    @Field({ nullable: true })
+    Name?: string;
+
+    @Field({ nullable: true })
+    LegalName?: string | null;
+
+    @Field({ nullable: true })
+    OrganizationTypeID?: string | null;
+
+    @Field({ nullable: true })
+    ParentID?: string | null;
+
+    @Field({ nullable: true })
+    Website?: string | null;
+
+    @Field({ nullable: true })
+    LogoURL?: string | null;
+
+    @Field({ nullable: true })
+    Description?: string | null;
+
+    @Field({ nullable: true })
+    Email?: string | null;
+
+    @Field({ nullable: true })
+    Phone?: string | null;
+
+    @Field({ nullable: true })
+    FoundedDate?: Date | null;
+
+    @Field({ nullable: true })
+    TaxID?: string | null;
+
+    @Field({ nullable: true })
+    Status?: string;
+
+    @Field(() => [KeyValuePairInput], { nullable: true })
+    OldValues___?: KeyValuePairInput[];
+}
+    
+//****************************************************************************
+// RESOLVER for Organizations
+//****************************************************************************
+@ObjectType()
+export class RunmjBizAppsCommonOrganizationViewResult {
+    @Field(() => [mjBizAppsCommonOrganization_])
+    Results: mjBizAppsCommonOrganization_[];
+
+    @Field(() => String, {nullable: true})
+    UserViewRunID?: string;
+
+    @Field(() => Int, {nullable: true})
+    RowCount: number;
+
+    @Field(() => Int, {nullable: true})
+    TotalRowCount: number;
+
+    @Field(() => Int, {nullable: true})
+    ExecutionTime: number;
+
+    @Field({nullable: true})
+    ErrorMessage?: string;
+
+    @Field(() => Boolean, {nullable: false})
+    Success: boolean;
+}
+
+@Resolver(mjBizAppsCommonOrganization_)
+export class mjBizAppsCommonOrganizationResolver extends ResolverBase {
+    @Query(() => RunmjBizAppsCommonOrganizationViewResult)
+    async RunmjBizAppsCommonOrganizationViewByID(@Arg('input', () => RunViewByIDInput) input: RunViewByIDInput, @Ctx() { providers, userPayload }: AppContext, @PubSub() pubSub: PubSubEngine) {
+        const provider = GetReadOnlyProvider(providers, { allowFallbackToReadWrite: true });
+        return super.RunViewByIDGeneric(input, provider, userPayload, pubSub);
+    }
+
+    @Query(() => RunmjBizAppsCommonOrganizationViewResult)
+    async RunmjBizAppsCommonOrganizationViewByName(@Arg('input', () => RunViewByNameInput) input: RunViewByNameInput, @Ctx() { providers, userPayload }: AppContext, @PubSub() pubSub: PubSubEngine) {
+        const provider = GetReadOnlyProvider(providers, { allowFallbackToReadWrite: true });
+        return super.RunViewByNameGeneric(input, provider, userPayload, pubSub);
+    }
+
+    @Query(() => RunmjBizAppsCommonOrganizationViewResult)
+    async RunmjBizAppsCommonOrganizationDynamicView(@Arg('input', () => RunDynamicViewInput) input: RunDynamicViewInput, @Ctx() { providers, userPayload }: AppContext, @PubSub() pubSub: PubSubEngine) {
+        const provider = GetReadOnlyProvider(providers, { allowFallbackToReadWrite: true });
+        input.EntityName = 'Organizations';
+        return super.RunDynamicViewGeneric(input, provider, userPayload, pubSub);
+    }
+    @Query(() => mjBizAppsCommonOrganization_, { nullable: true })
+    async mjBizAppsCommonOrganization(@Arg('ID', () => String) ID: string, @Ctx() { userPayload, providers }: AppContext, @PubSub() pubSub: PubSubEngine): Promise<mjBizAppsCommonOrganization_ | null> {
+        this.CheckUserReadPermissions('Organizations', userPayload);
+        const provider = GetReadOnlyProvider(providers, { allowFallbackToReadWrite: true });
+        const sSQL = `SELECT * FROM ${provider.QuoteSchemaAndView('__mj_BizAppsCommon', 'vwOrganizations')} WHERE ${provider.QuoteIdentifier('ID')}='${ID}' ` + this.getRowLevelSecurityWhereClause(provider, 'Organizations', userPayload, EntityPermissionType.Read, 'AND');
+        const rows = await provider.ExecuteSQL(sSQL, undefined, undefined, this.GetUserFromPayload(userPayload));
+        const result = await this.MapFieldNamesToCodeNames('Organizations', rows && rows.length > 0 ? rows[0] : null, this.GetUserFromPayload(userPayload));
+        return result;
+    }
+    
+    @FieldResolver(() => [mjBizAppsCommonOrganization_])
+    async mjBizAppsCommonOrganizations_ParentIDArray(@Root() mjbizappscommonorganization_: mjBizAppsCommonOrganization_, @Ctx() { userPayload, providers }: AppContext, @PubSub() pubSub: PubSubEngine) {
+        this.CheckUserReadPermissions('Organizations', userPayload);
+        const provider = GetReadOnlyProvider(providers, { allowFallbackToReadWrite: true });
+        const sSQL = `SELECT * FROM ${provider.QuoteSchemaAndView('__mj_BizAppsCommon', 'vwOrganizations')} WHERE ${provider.QuoteIdentifier('ParentID')}='${mjbizappscommonorganization_.ID}' ` + this.getRowLevelSecurityWhereClause(provider, 'Organizations', userPayload, EntityPermissionType.Read, 'AND');
+        const rows = await provider.ExecuteSQL(sSQL, undefined, undefined, this.GetUserFromPayload(userPayload));
+        const result = await this.ArrayMapFieldNamesToCodeNames('Organizations', rows, this.GetUserFromPayload(userPayload));
+        return result;
+    }
+        
+    @FieldResolver(() => [mjCommitteesCommittee_])
+    async mjCommitteesCommittees_OrganizationIDArray(@Root() mjbizappscommonorganization_: mjBizAppsCommonOrganization_, @Ctx() { userPayload, providers }: AppContext, @PubSub() pubSub: PubSubEngine) {
+        this.CheckUserReadPermissions('Committees', userPayload);
+        const provider = GetReadOnlyProvider(providers, { allowFallbackToReadWrite: true });
+        const sSQL = `SELECT * FROM ${provider.QuoteSchemaAndView('__mj_Committees', 'vwCommittees')} WHERE ${provider.QuoteIdentifier('OrganizationID')}='${mjbizappscommonorganization_.ID}' ` + this.getRowLevelSecurityWhereClause(provider, 'Committees', userPayload, EntityPermissionType.Read, 'AND');
+        const rows = await provider.ExecuteSQL(sSQL, undefined, undefined, this.GetUserFromPayload(userPayload));
+        const result = await this.ArrayMapFieldNamesToCodeNames('Committees', rows, this.GetUserFromPayload(userPayload));
+        return result;
+    }
+        
+    @FieldResolver(() => [mjBizAppsCommonContactMethod_])
+    async mjBizAppsCommonContactMethods_OrganizationIDArray(@Root() mjbizappscommonorganization_: mjBizAppsCommonOrganization_, @Ctx() { userPayload, providers }: AppContext, @PubSub() pubSub: PubSubEngine) {
+        this.CheckUserReadPermissions('Contact Methods', userPayload);
+        const provider = GetReadOnlyProvider(providers, { allowFallbackToReadWrite: true });
+        const sSQL = `SELECT * FROM ${provider.QuoteSchemaAndView('__mj_BizAppsCommon', 'vwContactMethods')} WHERE ${provider.QuoteIdentifier('OrganizationID')}='${mjbizappscommonorganization_.ID}' ` + this.getRowLevelSecurityWhereClause(provider, 'Contact Methods', userPayload, EntityPermissionType.Read, 'AND');
+        const rows = await provider.ExecuteSQL(sSQL, undefined, undefined, this.GetUserFromPayload(userPayload));
+        const result = await this.ArrayMapFieldNamesToCodeNames('Contact Methods', rows, this.GetUserFromPayload(userPayload));
+        return result;
+    }
+        
+    @FieldResolver(() => [mjBizAppsCommonRelationship_])
+    async mjBizAppsCommonRelationships_ToOrganizationIDArray(@Root() mjbizappscommonorganization_: mjBizAppsCommonOrganization_, @Ctx() { userPayload, providers }: AppContext, @PubSub() pubSub: PubSubEngine) {
+        this.CheckUserReadPermissions('Relationships', userPayload);
+        const provider = GetReadOnlyProvider(providers, { allowFallbackToReadWrite: true });
+        const sSQL = `SELECT * FROM ${provider.QuoteSchemaAndView('__mj_BizAppsCommon', 'vwRelationships')} WHERE ${provider.QuoteIdentifier('ToOrganizationID')}='${mjbizappscommonorganization_.ID}' ` + this.getRowLevelSecurityWhereClause(provider, 'Relationships', userPayload, EntityPermissionType.Read, 'AND');
+        const rows = await provider.ExecuteSQL(sSQL, undefined, undefined, this.GetUserFromPayload(userPayload));
+        const result = await this.ArrayMapFieldNamesToCodeNames('Relationships', rows, this.GetUserFromPayload(userPayload));
+        return result;
+    }
+        
+    @FieldResolver(() => [mjBizAppsCommonRelationship_])
+    async mjBizAppsCommonRelationships_FromOrganizationIDArray(@Root() mjbizappscommonorganization_: mjBizAppsCommonOrganization_, @Ctx() { userPayload, providers }: AppContext, @PubSub() pubSub: PubSubEngine) {
+        this.CheckUserReadPermissions('Relationships', userPayload);
+        const provider = GetReadOnlyProvider(providers, { allowFallbackToReadWrite: true });
+        const sSQL = `SELECT * FROM ${provider.QuoteSchemaAndView('__mj_BizAppsCommon', 'vwRelationships')} WHERE ${provider.QuoteIdentifier('FromOrganizationID')}='${mjbizappscommonorganization_.ID}' ` + this.getRowLevelSecurityWhereClause(provider, 'Relationships', userPayload, EntityPermissionType.Read, 'AND');
+        const rows = await provider.ExecuteSQL(sSQL, undefined, undefined, this.GetUserFromPayload(userPayload));
+        const result = await this.ArrayMapFieldNamesToCodeNames('Relationships', rows, this.GetUserFromPayload(userPayload));
+        return result;
+    }
+        
+    @Mutation(() => mjBizAppsCommonOrganization_)
+    async CreatemjBizAppsCommonOrganization(
+        @Arg('input', () => CreatemjBizAppsCommonOrganizationInput) input: CreatemjBizAppsCommonOrganizationInput,
+        @Ctx() { providers, userPayload }: AppContext,
+        @PubSub() pubSub: PubSubEngine
+    ) {
+        const provider = GetReadWriteProvider(providers);
+        return this.CreateRecord('Organizations', input, provider, userPayload, pubSub)
+    }
+        
+    @Mutation(() => mjBizAppsCommonOrganization_)
+    async UpdatemjBizAppsCommonOrganization(
+        @Arg('input', () => UpdatemjBizAppsCommonOrganizationInput) input: UpdatemjBizAppsCommonOrganizationInput,
+        @Ctx() { providers, userPayload }: AppContext,
+        @PubSub() pubSub: PubSubEngine
+    ) {
+        const provider = GetReadWriteProvider(providers);
+        return this.UpdateRecord('Organizations', input, provider, userPayload, pubSub);
+    }
+    
+    @Mutation(() => mjBizAppsCommonOrganization_)
+    async DeletemjBizAppsCommonOrganization(@Arg('ID', () => String) ID: string, @Arg('options___', () => DeleteOptionsInput) options: DeleteOptionsInput, @Ctx() { providers, userPayload }: AppContext, @PubSub() pubSub: PubSubEngine) {
+        const provider = GetReadWriteProvider(providers);
+        const key = new CompositeKey([{FieldName: 'ID', Value: ID}]);
+        return this.DeleteRecord('Organizations', key, options, provider, userPayload, pubSub);
+    }
+    
+}
+
+//****************************************************************************
+// ENTITY CLASS for People
+//****************************************************************************
+@ObjectType({ description: `Individual people, optionally linked to MJ system user accounts` })
+export class mjBizAppsCommonPerson_ {
+    @Field() 
+    @MaxLength(36)
+    ID: string;
+        
+    @Field({description: `First (given) name`}) 
+    @MaxLength(100)
+    FirstName: string;
+        
+    @Field({description: `Last (family) name`}) 
+    @MaxLength(100)
+    LastName: string;
+        
+    @Field({nullable: true, description: `Middle name or initial`}) 
+    @MaxLength(100)
+    MiddleName?: string;
+        
+    @Field({nullable: true, description: `Name prefix such as Dr., Mr., Ms., Rev.`}) 
+    @MaxLength(20)
+    Prefix?: string;
+        
+    @Field({nullable: true, description: `Name suffix such as Jr., III, PhD, Esq.`}) 
+    @MaxLength(20)
+    Suffix?: string;
+        
+    @Field({nullable: true, description: `Nickname or preferred name the person goes by`}) 
+    @MaxLength(100)
+    PreferredName?: string;
+        
+    @Field({nullable: true, description: `Professional or job title, e.g. VP of Engineering, Board Director`}) 
+    @MaxLength(200)
+    Title?: string;
+        
+    @Field({nullable: true, description: `Primary email address for this person`}) 
+    @MaxLength(255)
+    Email?: string;
+        
+    @Field({nullable: true, description: `Primary phone number for this person`}) 
+    @MaxLength(50)
+    Phone?: string;
+        
+    @Field({nullable: true, description: `Date of birth`}) 
+    DateOfBirth?: Date;
+        
+    @Field({nullable: true, description: `Gender identity`}) 
+    @MaxLength(50)
+    Gender?: string;
+        
+    @Field({nullable: true, description: `URL to profile photo or avatar image`}) 
+    @MaxLength(1000)
+    PhotoURL?: string;
+        
+    @Field({nullable: true, description: `Biographical text or notes about this person`}) 
+    Bio?: string;
+        
+    @Field({nullable: true}) 
+    @MaxLength(36)
+    LinkedUserID?: string;
+        
+    @Field({description: `Current status: Active, Inactive, or Deceased`}) 
+    @MaxLength(50)
+    Status: string;
+        
+    @Field() 
+    _mj__CreatedAt: Date;
+        
+    @Field() 
+    _mj__UpdatedAt: Date;
+        
+    @Field({nullable: true}) 
+    @MaxLength(100)
+    LinkedUser?: string;
+        
+    @Field(() => [mjCommitteesActionItem_])
+    mjCommitteesActionItems_AssignedByPersonIDArray: mjCommitteesActionItem_[]; // Link to mjCommitteesActionItems
+    
+    @Field(() => [mjCommitteesAgendaItem_])
+    mjCommitteesAgendaItems_PresenterPersonIDArray: mjCommitteesAgendaItem_[]; // Link to mjCommitteesAgendaItems
+    
+    @Field(() => [mjCommitteesAttendance_])
+    mjCommitteesAttendances_PersonIDArray: mjCommitteesAttendance_[]; // Link to mjCommitteesAttendances
+    
+    @Field(() => [mjBizAppsCommonRelationship_])
+    mjBizAppsCommonRelationships_FromPersonIDArray: mjBizAppsCommonRelationship_[]; // Link to mjBizAppsCommonRelationships
+    
+    @Field(() => [mjCommitteesMembership_])
+    mjCommitteesMemberships_PersonIDArray: mjCommitteesMembership_[]; // Link to mjCommitteesMemberships
+    
+    @Field(() => [mjCommitteesArtifact_])
+    mjCommitteesArtifacts_UploadedByPersonIDArray: mjCommitteesArtifact_[]; // Link to mjCommitteesArtifacts
+    
+    @Field(() => [mjCommitteesComment_])
+    mjCommitteesComments_PersonIDArray: mjCommitteesComment_[]; // Link to mjCommitteesComments
+    
+    @Field(() => [mjCommitteesActionItem_])
+    mjCommitteesActionItems_AssignedToPersonIDArray: mjCommitteesActionItem_[]; // Link to mjCommitteesActionItems
+    
+    @Field(() => [mjBizAppsCommonContactMethod_])
+    mjBizAppsCommonContactMethods_PersonIDArray: mjBizAppsCommonContactMethod_[]; // Link to mjBizAppsCommonContactMethods
+    
+    @Field(() => [mjBizAppsCommonRelationship_])
+    mjBizAppsCommonRelationships_ToPersonIDArray: mjBizAppsCommonRelationship_[]; // Link to mjBizAppsCommonRelationships
+    
+}
+
+//****************************************************************************
+// INPUT TYPE for People
+//****************************************************************************
+@InputType()
+export class CreatemjBizAppsCommonPersonInput {
+    @Field({ nullable: true })
+    ID?: string;
+
+    @Field({ nullable: true })
+    FirstName?: string;
+
+    @Field({ nullable: true })
+    LastName?: string;
+
+    @Field({ nullable: true })
+    MiddleName: string | null;
+
+    @Field({ nullable: true })
+    Prefix: string | null;
+
+    @Field({ nullable: true })
+    Suffix: string | null;
+
+    @Field({ nullable: true })
+    PreferredName: string | null;
+
+    @Field({ nullable: true })
+    Title: string | null;
+
+    @Field({ nullable: true })
+    Email: string | null;
+
+    @Field({ nullable: true })
+    Phone: string | null;
+
+    @Field({ nullable: true })
+    DateOfBirth: Date | null;
+
+    @Field({ nullable: true })
+    Gender: string | null;
+
+    @Field({ nullable: true })
+    PhotoURL: string | null;
+
+    @Field({ nullable: true })
+    Bio: string | null;
+
+    @Field({ nullable: true })
+    LinkedUserID: string | null;
+
+    @Field({ nullable: true })
+    Status?: string;
+}
+    
+
+//****************************************************************************
+// INPUT TYPE for People
+//****************************************************************************
+@InputType()
+export class UpdatemjBizAppsCommonPersonInput {
+    @Field()
+    ID: string;
+
+    @Field({ nullable: true })
+    FirstName?: string;
+
+    @Field({ nullable: true })
+    LastName?: string;
+
+    @Field({ nullable: true })
+    MiddleName?: string | null;
+
+    @Field({ nullable: true })
+    Prefix?: string | null;
+
+    @Field({ nullable: true })
+    Suffix?: string | null;
+
+    @Field({ nullable: true })
+    PreferredName?: string | null;
+
+    @Field({ nullable: true })
+    Title?: string | null;
+
+    @Field({ nullable: true })
+    Email?: string | null;
+
+    @Field({ nullable: true })
+    Phone?: string | null;
+
+    @Field({ nullable: true })
+    DateOfBirth?: Date | null;
+
+    @Field({ nullable: true })
+    Gender?: string | null;
+
+    @Field({ nullable: true })
+    PhotoURL?: string | null;
+
+    @Field({ nullable: true })
+    Bio?: string | null;
+
+    @Field({ nullable: true })
+    LinkedUserID?: string | null;
+
+    @Field({ nullable: true })
+    Status?: string;
+
+    @Field(() => [KeyValuePairInput], { nullable: true })
+    OldValues___?: KeyValuePairInput[];
+}
+    
+//****************************************************************************
+// RESOLVER for People
+//****************************************************************************
+@ObjectType()
+export class RunmjBizAppsCommonPersonViewResult {
+    @Field(() => [mjBizAppsCommonPerson_])
+    Results: mjBizAppsCommonPerson_[];
+
+    @Field(() => String, {nullable: true})
+    UserViewRunID?: string;
+
+    @Field(() => Int, {nullable: true})
+    RowCount: number;
+
+    @Field(() => Int, {nullable: true})
+    TotalRowCount: number;
+
+    @Field(() => Int, {nullable: true})
+    ExecutionTime: number;
+
+    @Field({nullable: true})
+    ErrorMessage?: string;
+
+    @Field(() => Boolean, {nullable: false})
+    Success: boolean;
+}
+
+@Resolver(mjBizAppsCommonPerson_)
+export class mjBizAppsCommonPersonResolver extends ResolverBase {
+    @Query(() => RunmjBizAppsCommonPersonViewResult)
+    async RunmjBizAppsCommonPersonViewByID(@Arg('input', () => RunViewByIDInput) input: RunViewByIDInput, @Ctx() { providers, userPayload }: AppContext, @PubSub() pubSub: PubSubEngine) {
+        const provider = GetReadOnlyProvider(providers, { allowFallbackToReadWrite: true });
+        return super.RunViewByIDGeneric(input, provider, userPayload, pubSub);
+    }
+
+    @Query(() => RunmjBizAppsCommonPersonViewResult)
+    async RunmjBizAppsCommonPersonViewByName(@Arg('input', () => RunViewByNameInput) input: RunViewByNameInput, @Ctx() { providers, userPayload }: AppContext, @PubSub() pubSub: PubSubEngine) {
+        const provider = GetReadOnlyProvider(providers, { allowFallbackToReadWrite: true });
+        return super.RunViewByNameGeneric(input, provider, userPayload, pubSub);
+    }
+
+    @Query(() => RunmjBizAppsCommonPersonViewResult)
+    async RunmjBizAppsCommonPersonDynamicView(@Arg('input', () => RunDynamicViewInput) input: RunDynamicViewInput, @Ctx() { providers, userPayload }: AppContext, @PubSub() pubSub: PubSubEngine) {
+        const provider = GetReadOnlyProvider(providers, { allowFallbackToReadWrite: true });
+        input.EntityName = 'People';
+        return super.RunDynamicViewGeneric(input, provider, userPayload, pubSub);
+    }
+    @Query(() => mjBizAppsCommonPerson_, { nullable: true })
+    async mjBizAppsCommonPerson(@Arg('ID', () => String) ID: string, @Ctx() { userPayload, providers }: AppContext, @PubSub() pubSub: PubSubEngine): Promise<mjBizAppsCommonPerson_ | null> {
+        this.CheckUserReadPermissions('People', userPayload);
+        const provider = GetReadOnlyProvider(providers, { allowFallbackToReadWrite: true });
+        const sSQL = `SELECT * FROM ${provider.QuoteSchemaAndView('__mj_BizAppsCommon', 'vwPeople')} WHERE ${provider.QuoteIdentifier('ID')}='${ID}' ` + this.getRowLevelSecurityWhereClause(provider, 'People', userPayload, EntityPermissionType.Read, 'AND');
+        const rows = await provider.ExecuteSQL(sSQL, undefined, undefined, this.GetUserFromPayload(userPayload));
+        const result = await this.MapFieldNamesToCodeNames('People', rows && rows.length > 0 ? rows[0] : null, this.GetUserFromPayload(userPayload));
+        return result;
+    }
+    
+    @FieldResolver(() => [mjCommitteesActionItem_])
+    async mjCommitteesActionItems_AssignedByPersonIDArray(@Root() mjbizappscommonperson_: mjBizAppsCommonPerson_, @Ctx() { userPayload, providers }: AppContext, @PubSub() pubSub: PubSubEngine) {
+        this.CheckUserReadPermissions('Action Items', userPayload);
+        const provider = GetReadOnlyProvider(providers, { allowFallbackToReadWrite: true });
+        const sSQL = `SELECT * FROM ${provider.QuoteSchemaAndView('__mj_Committees', 'vwActionItems')} WHERE ${provider.QuoteIdentifier('AssignedByPersonID')}='${mjbizappscommonperson_.ID}' ` + this.getRowLevelSecurityWhereClause(provider, 'Action Items', userPayload, EntityPermissionType.Read, 'AND');
+        const rows = await provider.ExecuteSQL(sSQL, undefined, undefined, this.GetUserFromPayload(userPayload));
+        const result = await this.ArrayMapFieldNamesToCodeNames('Action Items', rows, this.GetUserFromPayload(userPayload));
+        return result;
+    }
+        
+    @FieldResolver(() => [mjCommitteesAgendaItem_])
+    async mjCommitteesAgendaItems_PresenterPersonIDArray(@Root() mjbizappscommonperson_: mjBizAppsCommonPerson_, @Ctx() { userPayload, providers }: AppContext, @PubSub() pubSub: PubSubEngine) {
+        this.CheckUserReadPermissions('Agenda Items', userPayload);
+        const provider = GetReadOnlyProvider(providers, { allowFallbackToReadWrite: true });
+        const sSQL = `SELECT * FROM ${provider.QuoteSchemaAndView('__mj_Committees', 'vwAgendaItems')} WHERE ${provider.QuoteIdentifier('PresenterPersonID')}='${mjbizappscommonperson_.ID}' ` + this.getRowLevelSecurityWhereClause(provider, 'Agenda Items', userPayload, EntityPermissionType.Read, 'AND');
+        const rows = await provider.ExecuteSQL(sSQL, undefined, undefined, this.GetUserFromPayload(userPayload));
+        const result = await this.ArrayMapFieldNamesToCodeNames('Agenda Items', rows, this.GetUserFromPayload(userPayload));
+        return result;
+    }
+        
+    @FieldResolver(() => [mjCommitteesAttendance_])
+    async mjCommitteesAttendances_PersonIDArray(@Root() mjbizappscommonperson_: mjBizAppsCommonPerson_, @Ctx() { userPayload, providers }: AppContext, @PubSub() pubSub: PubSubEngine) {
+        this.CheckUserReadPermissions('Attendances', userPayload);
+        const provider = GetReadOnlyProvider(providers, { allowFallbackToReadWrite: true });
+        const sSQL = `SELECT * FROM ${provider.QuoteSchemaAndView('__mj_Committees', 'vwAttendances')} WHERE ${provider.QuoteIdentifier('PersonID')}='${mjbizappscommonperson_.ID}' ` + this.getRowLevelSecurityWhereClause(provider, 'Attendances', userPayload, EntityPermissionType.Read, 'AND');
+        const rows = await provider.ExecuteSQL(sSQL, undefined, undefined, this.GetUserFromPayload(userPayload));
+        const result = await this.ArrayMapFieldNamesToCodeNames('Attendances', rows, this.GetUserFromPayload(userPayload));
+        return result;
+    }
+        
+    @FieldResolver(() => [mjBizAppsCommonRelationship_])
+    async mjBizAppsCommonRelationships_FromPersonIDArray(@Root() mjbizappscommonperson_: mjBizAppsCommonPerson_, @Ctx() { userPayload, providers }: AppContext, @PubSub() pubSub: PubSubEngine) {
+        this.CheckUserReadPermissions('Relationships', userPayload);
+        const provider = GetReadOnlyProvider(providers, { allowFallbackToReadWrite: true });
+        const sSQL = `SELECT * FROM ${provider.QuoteSchemaAndView('__mj_BizAppsCommon', 'vwRelationships')} WHERE ${provider.QuoteIdentifier('FromPersonID')}='${mjbizappscommonperson_.ID}' ` + this.getRowLevelSecurityWhereClause(provider, 'Relationships', userPayload, EntityPermissionType.Read, 'AND');
+        const rows = await provider.ExecuteSQL(sSQL, undefined, undefined, this.GetUserFromPayload(userPayload));
+        const result = await this.ArrayMapFieldNamesToCodeNames('Relationships', rows, this.GetUserFromPayload(userPayload));
+        return result;
+    }
+        
+    @FieldResolver(() => [mjCommitteesMembership_])
+    async mjCommitteesMemberships_PersonIDArray(@Root() mjbizappscommonperson_: mjBizAppsCommonPerson_, @Ctx() { userPayload, providers }: AppContext, @PubSub() pubSub: PubSubEngine) {
+        this.CheckUserReadPermissions('Memberships', userPayload);
+        const provider = GetReadOnlyProvider(providers, { allowFallbackToReadWrite: true });
+        const sSQL = `SELECT * FROM ${provider.QuoteSchemaAndView('__mj_Committees', 'vwMemberships')} WHERE ${provider.QuoteIdentifier('PersonID')}='${mjbizappscommonperson_.ID}' ` + this.getRowLevelSecurityWhereClause(provider, 'Memberships', userPayload, EntityPermissionType.Read, 'AND');
+        const rows = await provider.ExecuteSQL(sSQL, undefined, undefined, this.GetUserFromPayload(userPayload));
+        const result = await this.ArrayMapFieldNamesToCodeNames('Memberships', rows, this.GetUserFromPayload(userPayload));
+        return result;
+    }
+        
+    @FieldResolver(() => [mjCommitteesArtifact_])
+    async mjCommitteesArtifacts_UploadedByPersonIDArray(@Root() mjbizappscommonperson_: mjBizAppsCommonPerson_, @Ctx() { userPayload, providers }: AppContext, @PubSub() pubSub: PubSubEngine) {
+        this.CheckUserReadPermissions('Artifacts', userPayload);
+        const provider = GetReadOnlyProvider(providers, { allowFallbackToReadWrite: true });
+        const sSQL = `SELECT * FROM ${provider.QuoteSchemaAndView('__mj_Committees', 'vwArtifacts')} WHERE ${provider.QuoteIdentifier('UploadedByPersonID')}='${mjbizappscommonperson_.ID}' ` + this.getRowLevelSecurityWhereClause(provider, 'Artifacts', userPayload, EntityPermissionType.Read, 'AND');
+        const rows = await provider.ExecuteSQL(sSQL, undefined, undefined, this.GetUserFromPayload(userPayload));
+        const result = await this.ArrayMapFieldNamesToCodeNames('Artifacts', rows, this.GetUserFromPayload(userPayload));
+        return result;
+    }
+        
+    @FieldResolver(() => [mjCommitteesComment_])
+    async mjCommitteesComments_PersonIDArray(@Root() mjbizappscommonperson_: mjBizAppsCommonPerson_, @Ctx() { userPayload, providers }: AppContext, @PubSub() pubSub: PubSubEngine) {
+        this.CheckUserReadPermissions('Comments', userPayload);
+        const provider = GetReadOnlyProvider(providers, { allowFallbackToReadWrite: true });
+        const sSQL = `SELECT * FROM ${provider.QuoteSchemaAndView('__mj_Committees', 'vwComments')} WHERE ${provider.QuoteIdentifier('PersonID')}='${mjbizappscommonperson_.ID}' ` + this.getRowLevelSecurityWhereClause(provider, 'Comments', userPayload, EntityPermissionType.Read, 'AND');
+        const rows = await provider.ExecuteSQL(sSQL, undefined, undefined, this.GetUserFromPayload(userPayload));
+        const result = await this.ArrayMapFieldNamesToCodeNames('Comments', rows, this.GetUserFromPayload(userPayload));
+        return result;
+    }
+        
+    @FieldResolver(() => [mjCommitteesActionItem_])
+    async mjCommitteesActionItems_AssignedToPersonIDArray(@Root() mjbizappscommonperson_: mjBizAppsCommonPerson_, @Ctx() { userPayload, providers }: AppContext, @PubSub() pubSub: PubSubEngine) {
+        this.CheckUserReadPermissions('Action Items', userPayload);
+        const provider = GetReadOnlyProvider(providers, { allowFallbackToReadWrite: true });
+        const sSQL = `SELECT * FROM ${provider.QuoteSchemaAndView('__mj_Committees', 'vwActionItems')} WHERE ${provider.QuoteIdentifier('AssignedToPersonID')}='${mjbizappscommonperson_.ID}' ` + this.getRowLevelSecurityWhereClause(provider, 'Action Items', userPayload, EntityPermissionType.Read, 'AND');
+        const rows = await provider.ExecuteSQL(sSQL, undefined, undefined, this.GetUserFromPayload(userPayload));
+        const result = await this.ArrayMapFieldNamesToCodeNames('Action Items', rows, this.GetUserFromPayload(userPayload));
+        return result;
+    }
+        
+    @FieldResolver(() => [mjBizAppsCommonContactMethod_])
+    async mjBizAppsCommonContactMethods_PersonIDArray(@Root() mjbizappscommonperson_: mjBizAppsCommonPerson_, @Ctx() { userPayload, providers }: AppContext, @PubSub() pubSub: PubSubEngine) {
+        this.CheckUserReadPermissions('Contact Methods', userPayload);
+        const provider = GetReadOnlyProvider(providers, { allowFallbackToReadWrite: true });
+        const sSQL = `SELECT * FROM ${provider.QuoteSchemaAndView('__mj_BizAppsCommon', 'vwContactMethods')} WHERE ${provider.QuoteIdentifier('PersonID')}='${mjbizappscommonperson_.ID}' ` + this.getRowLevelSecurityWhereClause(provider, 'Contact Methods', userPayload, EntityPermissionType.Read, 'AND');
+        const rows = await provider.ExecuteSQL(sSQL, undefined, undefined, this.GetUserFromPayload(userPayload));
+        const result = await this.ArrayMapFieldNamesToCodeNames('Contact Methods', rows, this.GetUserFromPayload(userPayload));
+        return result;
+    }
+        
+    @FieldResolver(() => [mjBizAppsCommonRelationship_])
+    async mjBizAppsCommonRelationships_ToPersonIDArray(@Root() mjbizappscommonperson_: mjBizAppsCommonPerson_, @Ctx() { userPayload, providers }: AppContext, @PubSub() pubSub: PubSubEngine) {
+        this.CheckUserReadPermissions('Relationships', userPayload);
+        const provider = GetReadOnlyProvider(providers, { allowFallbackToReadWrite: true });
+        const sSQL = `SELECT * FROM ${provider.QuoteSchemaAndView('__mj_BizAppsCommon', 'vwRelationships')} WHERE ${provider.QuoteIdentifier('ToPersonID')}='${mjbizappscommonperson_.ID}' ` + this.getRowLevelSecurityWhereClause(provider, 'Relationships', userPayload, EntityPermissionType.Read, 'AND');
+        const rows = await provider.ExecuteSQL(sSQL, undefined, undefined, this.GetUserFromPayload(userPayload));
+        const result = await this.ArrayMapFieldNamesToCodeNames('Relationships', rows, this.GetUserFromPayload(userPayload));
+        return result;
+    }
+        
+    @Mutation(() => mjBizAppsCommonPerson_)
+    async CreatemjBizAppsCommonPerson(
+        @Arg('input', () => CreatemjBizAppsCommonPersonInput) input: CreatemjBizAppsCommonPersonInput,
+        @Ctx() { providers, userPayload }: AppContext,
+        @PubSub() pubSub: PubSubEngine
+    ) {
+        const provider = GetReadWriteProvider(providers);
+        return this.CreateRecord('People', input, provider, userPayload, pubSub)
+    }
+        
+    @Mutation(() => mjBizAppsCommonPerson_)
+    async UpdatemjBizAppsCommonPerson(
+        @Arg('input', () => UpdatemjBizAppsCommonPersonInput) input: UpdatemjBizAppsCommonPersonInput,
+        @Ctx() { providers, userPayload }: AppContext,
+        @PubSub() pubSub: PubSubEngine
+    ) {
+        const provider = GetReadWriteProvider(providers);
+        return this.UpdateRecord('People', input, provider, userPayload, pubSub);
+    }
+    
+    @Mutation(() => mjBizAppsCommonPerson_)
+    async DeletemjBizAppsCommonPerson(@Arg('ID', () => String) ID: string, @Arg('options___', () => DeleteOptionsInput) options: DeleteOptionsInput, @Ctx() { providers, userPayload }: AppContext, @PubSub() pubSub: PubSubEngine) {
+        const provider = GetReadWriteProvider(providers);
+        const key = new CompositeKey([{FieldName: 'ID', Value: ID}]);
+        return this.DeleteRecord('People', key, options, provider, userPayload, pubSub);
+    }
+    
+}
+
+//****************************************************************************
+// ENTITY CLASS for Relationship Types
+//****************************************************************************
+@ObjectType({ description: `Defines types of relationships between people and organizations with directionality and labeling` })
+export class mjBizAppsCommonRelationshipType_ {
+    @Field() 
+    @MaxLength(36)
+    ID: string;
+        
+    @Field({description: `Display name for the relationship type, e.g. Employee, Spouse, Partner`}) 
+    @MaxLength(100)
+    Name: string;
+        
+    @Field({nullable: true, description: `Detailed description of this relationship type`}) 
+    Description?: string;
+        
+    @Field({description: `Which entity types this relationship connects: PersonToPerson, PersonToOrganization, or OrganizationToOrganization`}) 
+    @MaxLength(50)
+    Category: string;
+        
+    @Field(() => Boolean, {description: `Whether the relationship has a direction. False for symmetric relationships like Spouse or Partner`}) 
+    IsDirectional: boolean;
+        
+    @Field({nullable: true, description: `Label describing the From-to-To direction, e.g. is employee of, is parent of`}) 
+    @MaxLength(100)
+    ForwardLabel?: string;
+        
+    @Field({nullable: true, description: `Label describing the To-to-From direction, e.g. employs, is child of`}) 
+    @MaxLength(100)
+    ReverseLabel?: string;
+        
+    @Field() 
+    _mj__CreatedAt: Date;
+        
+    @Field() 
+    _mj__UpdatedAt: Date;
+        
+    @Field(() => [mjBizAppsCommonRelationship_])
+    mjBizAppsCommonRelationships_RelationshipTypeIDArray: mjBizAppsCommonRelationship_[]; // Link to mjBizAppsCommonRelationships
+    
+}
+
+//****************************************************************************
+// INPUT TYPE for Relationship Types
+//****************************************************************************
+@InputType()
+export class CreatemjBizAppsCommonRelationshipTypeInput {
+    @Field({ nullable: true })
+    ID?: string;
+
+    @Field({ nullable: true })
+    Name?: string;
+
+    @Field({ nullable: true })
+    Description: string | null;
+
+    @Field({ nullable: true })
+    Category?: string;
+
+    @Field(() => Boolean, { nullable: true })
+    IsDirectional?: boolean;
+
+    @Field({ nullable: true })
+    ForwardLabel: string | null;
+
+    @Field({ nullable: true })
+    ReverseLabel: string | null;
+}
+    
+
+//****************************************************************************
+// INPUT TYPE for Relationship Types
+//****************************************************************************
+@InputType()
+export class UpdatemjBizAppsCommonRelationshipTypeInput {
+    @Field()
+    ID: string;
+
+    @Field({ nullable: true })
+    Name?: string;
+
+    @Field({ nullable: true })
+    Description?: string | null;
+
+    @Field({ nullable: true })
+    Category?: string;
+
+    @Field(() => Boolean, { nullable: true })
+    IsDirectional?: boolean;
+
+    @Field({ nullable: true })
+    ForwardLabel?: string | null;
+
+    @Field({ nullable: true })
+    ReverseLabel?: string | null;
+
+    @Field(() => [KeyValuePairInput], { nullable: true })
+    OldValues___?: KeyValuePairInput[];
+}
+    
+//****************************************************************************
+// RESOLVER for Relationship Types
+//****************************************************************************
+@ObjectType()
+export class RunmjBizAppsCommonRelationshipTypeViewResult {
+    @Field(() => [mjBizAppsCommonRelationshipType_])
+    Results: mjBizAppsCommonRelationshipType_[];
+
+    @Field(() => String, {nullable: true})
+    UserViewRunID?: string;
+
+    @Field(() => Int, {nullable: true})
+    RowCount: number;
+
+    @Field(() => Int, {nullable: true})
+    TotalRowCount: number;
+
+    @Field(() => Int, {nullable: true})
+    ExecutionTime: number;
+
+    @Field({nullable: true})
+    ErrorMessage?: string;
+
+    @Field(() => Boolean, {nullable: false})
+    Success: boolean;
+}
+
+@Resolver(mjBizAppsCommonRelationshipType_)
+export class mjBizAppsCommonRelationshipTypeResolver extends ResolverBase {
+    @Query(() => RunmjBizAppsCommonRelationshipTypeViewResult)
+    async RunmjBizAppsCommonRelationshipTypeViewByID(@Arg('input', () => RunViewByIDInput) input: RunViewByIDInput, @Ctx() { providers, userPayload }: AppContext, @PubSub() pubSub: PubSubEngine) {
+        const provider = GetReadOnlyProvider(providers, { allowFallbackToReadWrite: true });
+        return super.RunViewByIDGeneric(input, provider, userPayload, pubSub);
+    }
+
+    @Query(() => RunmjBizAppsCommonRelationshipTypeViewResult)
+    async RunmjBizAppsCommonRelationshipTypeViewByName(@Arg('input', () => RunViewByNameInput) input: RunViewByNameInput, @Ctx() { providers, userPayload }: AppContext, @PubSub() pubSub: PubSubEngine) {
+        const provider = GetReadOnlyProvider(providers, { allowFallbackToReadWrite: true });
+        return super.RunViewByNameGeneric(input, provider, userPayload, pubSub);
+    }
+
+    @Query(() => RunmjBizAppsCommonRelationshipTypeViewResult)
+    async RunmjBizAppsCommonRelationshipTypeDynamicView(@Arg('input', () => RunDynamicViewInput) input: RunDynamicViewInput, @Ctx() { providers, userPayload }: AppContext, @PubSub() pubSub: PubSubEngine) {
+        const provider = GetReadOnlyProvider(providers, { allowFallbackToReadWrite: true });
+        input.EntityName = 'Relationship Types';
+        return super.RunDynamicViewGeneric(input, provider, userPayload, pubSub);
+    }
+    @Query(() => mjBizAppsCommonRelationshipType_, { nullable: true })
+    async mjBizAppsCommonRelationshipType(@Arg('ID', () => String) ID: string, @Ctx() { userPayload, providers }: AppContext, @PubSub() pubSub: PubSubEngine): Promise<mjBizAppsCommonRelationshipType_ | null> {
+        this.CheckUserReadPermissions('Relationship Types', userPayload);
+        const provider = GetReadOnlyProvider(providers, { allowFallbackToReadWrite: true });
+        const sSQL = `SELECT * FROM ${provider.QuoteSchemaAndView('__mj_BizAppsCommon', 'vwRelationshipTypes')} WHERE ${provider.QuoteIdentifier('ID')}='${ID}' ` + this.getRowLevelSecurityWhereClause(provider, 'Relationship Types', userPayload, EntityPermissionType.Read, 'AND');
+        const rows = await provider.ExecuteSQL(sSQL, undefined, undefined, this.GetUserFromPayload(userPayload));
+        const result = await this.MapFieldNamesToCodeNames('Relationship Types', rows && rows.length > 0 ? rows[0] : null, this.GetUserFromPayload(userPayload));
+        return result;
+    }
+    
+    @FieldResolver(() => [mjBizAppsCommonRelationship_])
+    async mjBizAppsCommonRelationships_RelationshipTypeIDArray(@Root() mjbizappscommonrelationshiptype_: mjBizAppsCommonRelationshipType_, @Ctx() { userPayload, providers }: AppContext, @PubSub() pubSub: PubSubEngine) {
+        this.CheckUserReadPermissions('Relationships', userPayload);
+        const provider = GetReadOnlyProvider(providers, { allowFallbackToReadWrite: true });
+        const sSQL = `SELECT * FROM ${provider.QuoteSchemaAndView('__mj_BizAppsCommon', 'vwRelationships')} WHERE ${provider.QuoteIdentifier('RelationshipTypeID')}='${mjbizappscommonrelationshiptype_.ID}' ` + this.getRowLevelSecurityWhereClause(provider, 'Relationships', userPayload, EntityPermissionType.Read, 'AND');
+        const rows = await provider.ExecuteSQL(sSQL, undefined, undefined, this.GetUserFromPayload(userPayload));
+        const result = await this.ArrayMapFieldNamesToCodeNames('Relationships', rows, this.GetUserFromPayload(userPayload));
+        return result;
+    }
+        
+    @Mutation(() => mjBizAppsCommonRelationshipType_)
+    async CreatemjBizAppsCommonRelationshipType(
+        @Arg('input', () => CreatemjBizAppsCommonRelationshipTypeInput) input: CreatemjBizAppsCommonRelationshipTypeInput,
+        @Ctx() { providers, userPayload }: AppContext,
+        @PubSub() pubSub: PubSubEngine
+    ) {
+        const provider = GetReadWriteProvider(providers);
+        return this.CreateRecord('Relationship Types', input, provider, userPayload, pubSub)
+    }
+        
+    @Mutation(() => mjBizAppsCommonRelationshipType_)
+    async UpdatemjBizAppsCommonRelationshipType(
+        @Arg('input', () => UpdatemjBizAppsCommonRelationshipTypeInput) input: UpdatemjBizAppsCommonRelationshipTypeInput,
+        @Ctx() { providers, userPayload }: AppContext,
+        @PubSub() pubSub: PubSubEngine
+    ) {
+        const provider = GetReadWriteProvider(providers);
+        return this.UpdateRecord('Relationship Types', input, provider, userPayload, pubSub);
+    }
+    
+    @Mutation(() => mjBizAppsCommonRelationshipType_)
+    async DeletemjBizAppsCommonRelationshipType(@Arg('ID', () => String) ID: string, @Arg('options___', () => DeleteOptionsInput) options: DeleteOptionsInput, @Ctx() { providers, userPayload }: AppContext, @PubSub() pubSub: PubSubEngine) {
+        const provider = GetReadWriteProvider(providers);
+        const key = new CompositeKey([{FieldName: 'ID', Value: ID}]);
+        return this.DeleteRecord('Relationship Types', key, options, provider, userPayload, pubSub);
+    }
+    
+}
+
+//****************************************************************************
+// ENTITY CLASS for Relationships
+//****************************************************************************
+@ObjectType({ description: `Typed, directional links between people and organizations supporting Person-to-Person, Person-to-Organization, and Organization-to-Organization relationships` })
+export class mjBizAppsCommonRelationship_ {
+    @Field() 
+    @MaxLength(36)
+    ID: string;
+        
+    @Field() 
+    @MaxLength(36)
+    RelationshipTypeID: string;
+        
+    @Field({nullable: true}) 
+    @MaxLength(36)
+    FromPersonID?: string;
+        
+    @Field({nullable: true}) 
+    @MaxLength(36)
+    FromOrganizationID?: string;
+        
+    @Field({nullable: true}) 
+    @MaxLength(36)
+    ToPersonID?: string;
+        
+    @Field({nullable: true}) 
+    @MaxLength(36)
+    ToOrganizationID?: string;
+        
+    @Field({nullable: true, description: `Contextual title for this specific relationship, e.g. CEO, Primary Contact, Founding Member`}) 
+    @MaxLength(255)
+    Title?: string;
+        
+    @Field({nullable: true, description: `Date the relationship began`}) 
+    StartDate?: Date;
+        
+    @Field({nullable: true, description: `Date the relationship ended, if applicable`}) 
+    EndDate?: Date;
+        
+    @Field({description: `Current status: Active, Inactive, or Ended`}) 
+    @MaxLength(50)
+    Status: string;
+        
+    @Field({nullable: true, description: `Additional notes about this relationship`}) 
+    Notes?: string;
+        
+    @Field() 
+    _mj__CreatedAt: Date;
+        
+    @Field() 
+    _mj__UpdatedAt: Date;
+        
+    @Field() 
+    @MaxLength(100)
+    RelationshipType: string;
+        
+    @Field({nullable: true}) 
+    @MaxLength(100)
+    FromPerson?: string;
+        
+    @Field({nullable: true}) 
+    @MaxLength(255)
+    FromOrganization?: string;
+        
+    @Field({nullable: true}) 
+    @MaxLength(100)
+    ToPerson?: string;
+        
+    @Field({nullable: true}) 
+    @MaxLength(255)
+    ToOrganization?: string;
+        
+}
+
+//****************************************************************************
+// INPUT TYPE for Relationships
+//****************************************************************************
+@InputType()
+export class CreatemjBizAppsCommonRelationshipInput {
+    @Field({ nullable: true })
+    ID?: string;
+
+    @Field({ nullable: true })
+    RelationshipTypeID?: string;
+
+    @Field({ nullable: true })
+    FromPersonID: string | null;
+
+    @Field({ nullable: true })
+    FromOrganizationID: string | null;
+
+    @Field({ nullable: true })
+    ToPersonID: string | null;
+
+    @Field({ nullable: true })
+    ToOrganizationID: string | null;
+
+    @Field({ nullable: true })
+    Title: string | null;
+
+    @Field({ nullable: true })
+    StartDate: Date | null;
+
+    @Field({ nullable: true })
+    EndDate: Date | null;
+
+    @Field({ nullable: true })
+    Status?: string;
+
+    @Field({ nullable: true })
+    Notes: string | null;
+}
+    
+
+//****************************************************************************
+// INPUT TYPE for Relationships
+//****************************************************************************
+@InputType()
+export class UpdatemjBizAppsCommonRelationshipInput {
+    @Field()
+    ID: string;
+
+    @Field({ nullable: true })
+    RelationshipTypeID?: string;
+
+    @Field({ nullable: true })
+    FromPersonID?: string | null;
+
+    @Field({ nullable: true })
+    FromOrganizationID?: string | null;
+
+    @Field({ nullable: true })
+    ToPersonID?: string | null;
+
+    @Field({ nullable: true })
+    ToOrganizationID?: string | null;
+
+    @Field({ nullable: true })
+    Title?: string | null;
+
+    @Field({ nullable: true })
+    StartDate?: Date | null;
+
+    @Field({ nullable: true })
+    EndDate?: Date | null;
+
+    @Field({ nullable: true })
+    Status?: string;
+
+    @Field({ nullable: true })
+    Notes?: string | null;
+
+    @Field(() => [KeyValuePairInput], { nullable: true })
+    OldValues___?: KeyValuePairInput[];
+}
+    
+//****************************************************************************
+// RESOLVER for Relationships
+//****************************************************************************
+@ObjectType()
+export class RunmjBizAppsCommonRelationshipViewResult {
+    @Field(() => [mjBizAppsCommonRelationship_])
+    Results: mjBizAppsCommonRelationship_[];
+
+    @Field(() => String, {nullable: true})
+    UserViewRunID?: string;
+
+    @Field(() => Int, {nullable: true})
+    RowCount: number;
+
+    @Field(() => Int, {nullable: true})
+    TotalRowCount: number;
+
+    @Field(() => Int, {nullable: true})
+    ExecutionTime: number;
+
+    @Field({nullable: true})
+    ErrorMessage?: string;
+
+    @Field(() => Boolean, {nullable: false})
+    Success: boolean;
+}
+
+@Resolver(mjBizAppsCommonRelationship_)
+export class mjBizAppsCommonRelationshipResolver extends ResolverBase {
+    @Query(() => RunmjBizAppsCommonRelationshipViewResult)
+    async RunmjBizAppsCommonRelationshipViewByID(@Arg('input', () => RunViewByIDInput) input: RunViewByIDInput, @Ctx() { providers, userPayload }: AppContext, @PubSub() pubSub: PubSubEngine) {
+        const provider = GetReadOnlyProvider(providers, { allowFallbackToReadWrite: true });
+        return super.RunViewByIDGeneric(input, provider, userPayload, pubSub);
+    }
+
+    @Query(() => RunmjBizAppsCommonRelationshipViewResult)
+    async RunmjBizAppsCommonRelationshipViewByName(@Arg('input', () => RunViewByNameInput) input: RunViewByNameInput, @Ctx() { providers, userPayload }: AppContext, @PubSub() pubSub: PubSubEngine) {
+        const provider = GetReadOnlyProvider(providers, { allowFallbackToReadWrite: true });
+        return super.RunViewByNameGeneric(input, provider, userPayload, pubSub);
+    }
+
+    @Query(() => RunmjBizAppsCommonRelationshipViewResult)
+    async RunmjBizAppsCommonRelationshipDynamicView(@Arg('input', () => RunDynamicViewInput) input: RunDynamicViewInput, @Ctx() { providers, userPayload }: AppContext, @PubSub() pubSub: PubSubEngine) {
+        const provider = GetReadOnlyProvider(providers, { allowFallbackToReadWrite: true });
+        input.EntityName = 'Relationships';
+        return super.RunDynamicViewGeneric(input, provider, userPayload, pubSub);
+    }
+    @Query(() => mjBizAppsCommonRelationship_, { nullable: true })
+    async mjBizAppsCommonRelationship(@Arg('ID', () => String) ID: string, @Ctx() { userPayload, providers }: AppContext, @PubSub() pubSub: PubSubEngine): Promise<mjBizAppsCommonRelationship_ | null> {
+        this.CheckUserReadPermissions('Relationships', userPayload);
+        const provider = GetReadOnlyProvider(providers, { allowFallbackToReadWrite: true });
+        const sSQL = `SELECT * FROM ${provider.QuoteSchemaAndView('__mj_BizAppsCommon', 'vwRelationships')} WHERE ${provider.QuoteIdentifier('ID')}='${ID}' ` + this.getRowLevelSecurityWhereClause(provider, 'Relationships', userPayload, EntityPermissionType.Read, 'AND');
+        const rows = await provider.ExecuteSQL(sSQL, undefined, undefined, this.GetUserFromPayload(userPayload));
+        const result = await this.MapFieldNamesToCodeNames('Relationships', rows && rows.length > 0 ? rows[0] : null, this.GetUserFromPayload(userPayload));
+        return result;
+    }
+    
+    @Mutation(() => mjBizAppsCommonRelationship_)
+    async CreatemjBizAppsCommonRelationship(
+        @Arg('input', () => CreatemjBizAppsCommonRelationshipInput) input: CreatemjBizAppsCommonRelationshipInput,
+        @Ctx() { providers, userPayload }: AppContext,
+        @PubSub() pubSub: PubSubEngine
+    ) {
+        const provider = GetReadWriteProvider(providers);
+        return this.CreateRecord('Relationships', input, provider, userPayload, pubSub)
+    }
+        
+    @Mutation(() => mjBizAppsCommonRelationship_)
+    async UpdatemjBizAppsCommonRelationship(
+        @Arg('input', () => UpdatemjBizAppsCommonRelationshipInput) input: UpdatemjBizAppsCommonRelationshipInput,
+        @Ctx() { providers, userPayload }: AppContext,
+        @PubSub() pubSub: PubSubEngine
+    ) {
+        const provider = GetReadWriteProvider(providers);
+        return this.UpdateRecord('Relationships', input, provider, userPayload, pubSub);
+    }
+    
+    @Mutation(() => mjBizAppsCommonRelationship_)
+    async DeletemjBizAppsCommonRelationship(@Arg('ID', () => String) ID: string, @Arg('options___', () => DeleteOptionsInput) options: DeleteOptionsInput, @Ctx() { providers, userPayload }: AppContext, @PubSub() pubSub: PubSubEngine) {
+        const provider = GetReadWriteProvider(providers);
+        const key = new CompositeKey([{FieldName: 'ID', Value: ID}]);
+        return this.DeleteRecord('Relationships', key, options, provider, userPayload, pubSub);
+    }
+    
+}
+
+//****************************************************************************
+// ENTITY CLASS for Roles
+//****************************************************************************
+@ObjectType({ description: `Roles that members can hold on committees` })
+export class mjCommitteesRole_ {
+    @Field() 
+    @MaxLength(36)
+    ID: string;
+        
+    @Field({description: `Display name for the role`}) 
+    @MaxLength(100)
+    Name: string;
+        
+    @Field({nullable: true, description: `Detailed description of role responsibilities`}) 
+    Description?: string;
+        
+    @Field(() => Boolean, {description: `Whether this is an officer role like Chair or Secretary`}) 
+    IsOfficer: boolean;
+        
+    @Field(() => Boolean, {description: `Whether members in this role can vote`}) 
+    IsVotingRole: boolean;
+        
+    @Field({nullable: true, description: `JSON object defining default permissions for this role`}) 
+    DefaultPermissionsJSON?: string;
+        
+    @Field(() => Int, {description: `Display order for sorting roles`}) 
+    Sequence: number;
+        
+    @Field() 
+    _mj__CreatedAt: Date;
+        
+    @Field() 
+    _mj__UpdatedAt: Date;
+        
+    @Field(() => [mjCommitteesMembership_])
+    mjCommitteesMemberships_RoleIDArray: mjCommitteesMembership_[]; // Link to mjCommitteesMemberships
+    
+}
+
+//****************************************************************************
+// INPUT TYPE for Roles
+//****************************************************************************
+@InputType()
+export class CreatemjCommitteesRoleInput {
+    @Field({ nullable: true })
+    ID?: string;
+
+    @Field({ nullable: true })
+    Name?: string;
+
+    @Field({ nullable: true })
+    Description: string | null;
+
+    @Field(() => Boolean, { nullable: true })
+    IsOfficer?: boolean;
+
+    @Field(() => Boolean, { nullable: true })
+    IsVotingRole?: boolean;
+
+    @Field({ nullable: true })
+    DefaultPermissionsJSON: string | null;
+
+    @Field(() => Int, { nullable: true })
+    Sequence?: number;
+}
+    
+
+//****************************************************************************
+// INPUT TYPE for Roles
+//****************************************************************************
+@InputType()
+export class UpdatemjCommitteesRoleInput {
+    @Field()
+    ID: string;
+
+    @Field({ nullable: true })
+    Name?: string;
+
+    @Field({ nullable: true })
+    Description?: string | null;
+
+    @Field(() => Boolean, { nullable: true })
+    IsOfficer?: boolean;
+
+    @Field(() => Boolean, { nullable: true })
+    IsVotingRole?: boolean;
+
+    @Field({ nullable: true })
+    DefaultPermissionsJSON?: string | null;
+
+    @Field(() => Int, { nullable: true })
+    Sequence?: number;
+
+    @Field(() => [KeyValuePairInput], { nullable: true })
+    OldValues___?: KeyValuePairInput[];
+}
+    
+//****************************************************************************
+// RESOLVER for Roles
+//****************************************************************************
+@ObjectType()
+export class RunmjCommitteesRoleViewResult {
+    @Field(() => [mjCommitteesRole_])
+    Results: mjCommitteesRole_[];
+
+    @Field(() => String, {nullable: true})
+    UserViewRunID?: string;
+
+    @Field(() => Int, {nullable: true})
+    RowCount: number;
+
+    @Field(() => Int, {nullable: true})
+    TotalRowCount: number;
+
+    @Field(() => Int, {nullable: true})
+    ExecutionTime: number;
+
+    @Field({nullable: true})
+    ErrorMessage?: string;
+
+    @Field(() => Boolean, {nullable: false})
+    Success: boolean;
+}
+
+@Resolver(mjCommitteesRole_)
+export class mjCommitteesRoleResolver extends ResolverBase {
+    @Query(() => RunmjCommitteesRoleViewResult)
+    async RunmjCommitteesRoleViewByID(@Arg('input', () => RunViewByIDInput) input: RunViewByIDInput, @Ctx() { providers, userPayload }: AppContext, @PubSub() pubSub: PubSubEngine) {
+        const provider = GetReadOnlyProvider(providers, { allowFallbackToReadWrite: true });
+        return super.RunViewByIDGeneric(input, provider, userPayload, pubSub);
+    }
+
+    @Query(() => RunmjCommitteesRoleViewResult)
+    async RunmjCommitteesRoleViewByName(@Arg('input', () => RunViewByNameInput) input: RunViewByNameInput, @Ctx() { providers, userPayload }: AppContext, @PubSub() pubSub: PubSubEngine) {
+        const provider = GetReadOnlyProvider(providers, { allowFallbackToReadWrite: true });
+        return super.RunViewByNameGeneric(input, provider, userPayload, pubSub);
+    }
+
+    @Query(() => RunmjCommitteesRoleViewResult)
+    async RunmjCommitteesRoleDynamicView(@Arg('input', () => RunDynamicViewInput) input: RunDynamicViewInput, @Ctx() { providers, userPayload }: AppContext, @PubSub() pubSub: PubSubEngine) {
+        const provider = GetReadOnlyProvider(providers, { allowFallbackToReadWrite: true });
+        input.EntityName = 'Roles';
+        return super.RunDynamicViewGeneric(input, provider, userPayload, pubSub);
+    }
+    @Query(() => mjCommitteesRole_, { nullable: true })
+    async mjCommitteesRole(@Arg('ID', () => String) ID: string, @Ctx() { userPayload, providers }: AppContext, @PubSub() pubSub: PubSubEngine): Promise<mjCommitteesRole_ | null> {
+        this.CheckUserReadPermissions('Roles', userPayload);
+        const provider = GetReadOnlyProvider(providers, { allowFallbackToReadWrite: true });
+        const sSQL = `SELECT * FROM ${provider.QuoteSchemaAndView('__mj_Committees', 'vwRoles')} WHERE ${provider.QuoteIdentifier('ID')}='${ID}' ` + this.getRowLevelSecurityWhereClause(provider, 'Roles', userPayload, EntityPermissionType.Read, 'AND');
+        const rows = await provider.ExecuteSQL(sSQL, undefined, undefined, this.GetUserFromPayload(userPayload));
+        const result = await this.MapFieldNamesToCodeNames('Roles', rows && rows.length > 0 ? rows[0] : null, this.GetUserFromPayload(userPayload));
+        return result;
+    }
+    
+    @FieldResolver(() => [mjCommitteesMembership_])
+    async mjCommitteesMemberships_RoleIDArray(@Root() mjcommitteesrole_: mjCommitteesRole_, @Ctx() { userPayload, providers }: AppContext, @PubSub() pubSub: PubSubEngine) {
+        this.CheckUserReadPermissions('Memberships', userPayload);
+        const provider = GetReadOnlyProvider(providers, { allowFallbackToReadWrite: true });
+        const sSQL = `SELECT * FROM ${provider.QuoteSchemaAndView('__mj_Committees', 'vwMemberships')} WHERE ${provider.QuoteIdentifier('RoleID')}='${mjcommitteesrole_.ID}' ` + this.getRowLevelSecurityWhereClause(provider, 'Memberships', userPayload, EntityPermissionType.Read, 'AND');
+        const rows = await provider.ExecuteSQL(sSQL, undefined, undefined, this.GetUserFromPayload(userPayload));
+        const result = await this.ArrayMapFieldNamesToCodeNames('Memberships', rows, this.GetUserFromPayload(userPayload));
+        return result;
+    }
+        
+    @Mutation(() => mjCommitteesRole_)
+    async CreatemjCommitteesRole(
+        @Arg('input', () => CreatemjCommitteesRoleInput) input: CreatemjCommitteesRoleInput,
+        @Ctx() { providers, userPayload }: AppContext,
+        @PubSub() pubSub: PubSubEngine
+    ) {
+        const provider = GetReadWriteProvider(providers);
+        return this.CreateRecord('Roles', input, provider, userPayload, pubSub)
+    }
+        
+    @Mutation(() => mjCommitteesRole_)
+    async UpdatemjCommitteesRole(
+        @Arg('input', () => UpdatemjCommitteesRoleInput) input: UpdatemjCommitteesRoleInput,
+        @Ctx() { providers, userPayload }: AppContext,
+        @PubSub() pubSub: PubSubEngine
+    ) {
+        const provider = GetReadWriteProvider(providers);
+        return this.UpdateRecord('Roles', input, provider, userPayload, pubSub);
+    }
+    
+    @Mutation(() => mjCommitteesRole_)
+    async DeletemjCommitteesRole(@Arg('ID', () => String) ID: string, @Arg('options___', () => DeleteOptionsInput) options: DeleteOptionsInput, @Ctx() { providers, userPayload }: AppContext, @PubSub() pubSub: PubSubEngine) {
+        const provider = GetReadWriteProvider(providers);
+        const key = new CompositeKey([{FieldName: 'ID', Value: ID}]);
+        return this.DeleteRecord('Roles', key, options, provider, userPayload, pubSub);
+    }
+    
+}
+
+//****************************************************************************
+// ENTITY CLASS for Terms
+//****************************************************************************
+@ObjectType({ description: `Time periods for committee membership cycles` })
+export class mjCommitteesTerm_ {
+    @Field() 
+    @MaxLength(36)
+    ID: string;
+        
+    @Field() 
+    @MaxLength(36)
+    CommitteeID: string;
+        
+    @Field({description: `Display name for the term, e.g. 2025-2026`}) 
+    @MaxLength(100)
+    Name: string;
+        
+    @Field({description: `Start date of the term`}) 
+    StartDate: Date;
+        
+    @Field({nullable: true, description: `End date of the term`}) 
+    EndDate?: Date;
+        
+    @Field({description: `Current status: Active, Upcoming, or Completed`}) 
+    @MaxLength(50)
+    Status: string;
+        
+    @Field() 
+    _mj__CreatedAt: Date;
+        
+    @Field() 
+    _mj__UpdatedAt: Date;
+        
+    @Field() 
+    @MaxLength(255)
+    Committee: string;
+        
+    @Field(() => [mjCommitteesMembership_])
+    mjCommitteesMemberships_TermIDArray: mjCommitteesMembership_[]; // Link to mjCommitteesMemberships
+    
+}
+
+//****************************************************************************
+// INPUT TYPE for Terms
+//****************************************************************************
+@InputType()
+export class CreatemjCommitteesTermInput {
+    @Field({ nullable: true })
+    ID?: string;
+
+    @Field({ nullable: true })
+    CommitteeID?: string;
+
+    @Field({ nullable: true })
+    Name?: string;
+
+    @Field({ nullable: true })
+    StartDate?: Date;
+
+    @Field({ nullable: true })
+    EndDate: Date | null;
+
+    @Field({ nullable: true })
+    Status?: string;
+}
+    
+
+//****************************************************************************
+// INPUT TYPE for Terms
+//****************************************************************************
+@InputType()
+export class UpdatemjCommitteesTermInput {
+    @Field()
+    ID: string;
+
+    @Field({ nullable: true })
+    CommitteeID?: string;
+
+    @Field({ nullable: true })
+    Name?: string;
+
+    @Field({ nullable: true })
+    StartDate?: Date;
+
+    @Field({ nullable: true })
+    EndDate?: Date | null;
+
+    @Field({ nullable: true })
+    Status?: string;
+
+    @Field(() => [KeyValuePairInput], { nullable: true })
+    OldValues___?: KeyValuePairInput[];
+}
+    
+//****************************************************************************
+// RESOLVER for Terms
+//****************************************************************************
+@ObjectType()
+export class RunmjCommitteesTermViewResult {
+    @Field(() => [mjCommitteesTerm_])
+    Results: mjCommitteesTerm_[];
+
+    @Field(() => String, {nullable: true})
+    UserViewRunID?: string;
+
+    @Field(() => Int, {nullable: true})
+    RowCount: number;
+
+    @Field(() => Int, {nullable: true})
+    TotalRowCount: number;
+
+    @Field(() => Int, {nullable: true})
+    ExecutionTime: number;
+
+    @Field({nullable: true})
+    ErrorMessage?: string;
+
+    @Field(() => Boolean, {nullable: false})
+    Success: boolean;
+}
+
+@Resolver(mjCommitteesTerm_)
+export class mjCommitteesTermResolver extends ResolverBase {
+    @Query(() => RunmjCommitteesTermViewResult)
+    async RunmjCommitteesTermViewByID(@Arg('input', () => RunViewByIDInput) input: RunViewByIDInput, @Ctx() { providers, userPayload }: AppContext, @PubSub() pubSub: PubSubEngine) {
+        const provider = GetReadOnlyProvider(providers, { allowFallbackToReadWrite: true });
+        return super.RunViewByIDGeneric(input, provider, userPayload, pubSub);
+    }
+
+    @Query(() => RunmjCommitteesTermViewResult)
+    async RunmjCommitteesTermViewByName(@Arg('input', () => RunViewByNameInput) input: RunViewByNameInput, @Ctx() { providers, userPayload }: AppContext, @PubSub() pubSub: PubSubEngine) {
+        const provider = GetReadOnlyProvider(providers, { allowFallbackToReadWrite: true });
+        return super.RunViewByNameGeneric(input, provider, userPayload, pubSub);
+    }
+
+    @Query(() => RunmjCommitteesTermViewResult)
+    async RunmjCommitteesTermDynamicView(@Arg('input', () => RunDynamicViewInput) input: RunDynamicViewInput, @Ctx() { providers, userPayload }: AppContext, @PubSub() pubSub: PubSubEngine) {
+        const provider = GetReadOnlyProvider(providers, { allowFallbackToReadWrite: true });
+        input.EntityName = 'Terms';
+        return super.RunDynamicViewGeneric(input, provider, userPayload, pubSub);
+    }
+    @Query(() => mjCommitteesTerm_, { nullable: true })
+    async mjCommitteesTerm(@Arg('ID', () => String) ID: string, @Ctx() { userPayload, providers }: AppContext, @PubSub() pubSub: PubSubEngine): Promise<mjCommitteesTerm_ | null> {
+        this.CheckUserReadPermissions('Terms', userPayload);
+        const provider = GetReadOnlyProvider(providers, { allowFallbackToReadWrite: true });
+        const sSQL = `SELECT * FROM ${provider.QuoteSchemaAndView('__mj_Committees', 'vwTerms')} WHERE ${provider.QuoteIdentifier('ID')}='${ID}' ` + this.getRowLevelSecurityWhereClause(provider, 'Terms', userPayload, EntityPermissionType.Read, 'AND');
+        const rows = await provider.ExecuteSQL(sSQL, undefined, undefined, this.GetUserFromPayload(userPayload));
+        const result = await this.MapFieldNamesToCodeNames('Terms', rows && rows.length > 0 ? rows[0] : null, this.GetUserFromPayload(userPayload));
+        return result;
+    }
+    
+    @FieldResolver(() => [mjCommitteesMembership_])
+    async mjCommitteesMemberships_TermIDArray(@Root() mjcommitteesterm_: mjCommitteesTerm_, @Ctx() { userPayload, providers }: AppContext, @PubSub() pubSub: PubSubEngine) {
+        this.CheckUserReadPermissions('Memberships', userPayload);
+        const provider = GetReadOnlyProvider(providers, { allowFallbackToReadWrite: true });
+        const sSQL = `SELECT * FROM ${provider.QuoteSchemaAndView('__mj_Committees', 'vwMemberships')} WHERE ${provider.QuoteIdentifier('TermID')}='${mjcommitteesterm_.ID}' ` + this.getRowLevelSecurityWhereClause(provider, 'Memberships', userPayload, EntityPermissionType.Read, 'AND');
+        const rows = await provider.ExecuteSQL(sSQL, undefined, undefined, this.GetUserFromPayload(userPayload));
+        const result = await this.ArrayMapFieldNamesToCodeNames('Memberships', rows, this.GetUserFromPayload(userPayload));
+        return result;
+    }
+        
+    @Mutation(() => mjCommitteesTerm_)
+    async CreatemjCommitteesTerm(
+        @Arg('input', () => CreatemjCommitteesTermInput) input: CreatemjCommitteesTermInput,
+        @Ctx() { providers, userPayload }: AppContext,
+        @PubSub() pubSub: PubSubEngine
+    ) {
+        const provider = GetReadWriteProvider(providers);
+        return this.CreateRecord('Terms', input, provider, userPayload, pubSub)
+    }
+        
+    @Mutation(() => mjCommitteesTerm_)
+    async UpdatemjCommitteesTerm(
+        @Arg('input', () => UpdatemjCommitteesTermInput) input: UpdatemjCommitteesTermInput,
+        @Ctx() { providers, userPayload }: AppContext,
+        @PubSub() pubSub: PubSubEngine
+    ) {
+        const provider = GetReadWriteProvider(providers);
+        return this.UpdateRecord('Terms', input, provider, userPayload, pubSub);
+    }
+    
+    @Mutation(() => mjCommitteesTerm_)
+    async DeletemjCommitteesTerm(@Arg('ID', () => String) ID: string, @Arg('options___', () => DeleteOptionsInput) options: DeleteOptionsInput, @Ctx() { providers, userPayload }: AppContext, @PubSub() pubSub: PubSubEngine) {
+        const provider = GetReadWriteProvider(providers);
+        const key = new CompositeKey([{FieldName: 'ID', Value: ID}]);
+        return this.DeleteRecord('Terms', key, options, provider, userPayload, pubSub);
+    }
+    
+}
+
+//****************************************************************************
+// ENTITY CLASS for Types
+//****************************************************************************
+@ObjectType({ description: `Categories of committees such as Board, Standing, Ad Hoc, Workgroup` })
+export class mjCommitteesType_ {
+    @Field() 
+    @MaxLength(36)
+    ID: string;
+        
+    @Field({description: `Display name for the committee type`}) 
+    @MaxLength(100)
+    Name: string;
+        
+    @Field({nullable: true, description: `Detailed description of this committee type`}) 
+    Description?: string;
+        
+    @Field(() => Boolean, {description: `Whether this type is for standards development committees`}) 
+    IsStandards: boolean;
+        
+    @Field(() => Int, {nullable: true, description: `Default term length in months for committees of this type`}) 
+    DefaultTermMonths?: number;
+        
+    @Field({nullable: true, description: `Font Awesome icon class for UI display`}) 
+    @MaxLength(100)
+    IconClass?: string;
+        
+    @Field() 
+    _mj__CreatedAt: Date;
+        
+    @Field() 
+    _mj__UpdatedAt: Date;
+        
+    @Field(() => [mjCommitteesCommittee_])
+    mjCommitteesCommittees_TypeIDArray: mjCommitteesCommittee_[]; // Link to mjCommitteesCommittees
+    
+}
+
+//****************************************************************************
+// INPUT TYPE for Types
+//****************************************************************************
+@InputType()
+export class CreatemjCommitteesTypeInput {
+    @Field({ nullable: true })
+    ID?: string;
+
+    @Field({ nullable: true })
+    Name?: string;
+
+    @Field({ nullable: true })
+    Description: string | null;
+
+    @Field(() => Boolean, { nullable: true })
+    IsStandards?: boolean;
+
+    @Field(() => Int, { nullable: true })
+    DefaultTermMonths: number | null;
+
+    @Field({ nullable: true })
+    IconClass: string | null;
+}
+    
+
+//****************************************************************************
+// INPUT TYPE for Types
+//****************************************************************************
+@InputType()
+export class UpdatemjCommitteesTypeInput {
+    @Field()
+    ID: string;
+
+    @Field({ nullable: true })
+    Name?: string;
+
+    @Field({ nullable: true })
+    Description?: string | null;
+
+    @Field(() => Boolean, { nullable: true })
+    IsStandards?: boolean;
+
+    @Field(() => Int, { nullable: true })
+    DefaultTermMonths?: number | null;
+
+    @Field({ nullable: true })
+    IconClass?: string | null;
+
+    @Field(() => [KeyValuePairInput], { nullable: true })
+    OldValues___?: KeyValuePairInput[];
+}
+    
+//****************************************************************************
+// RESOLVER for Types
+//****************************************************************************
+@ObjectType()
+export class RunmjCommitteesTypeViewResult {
+    @Field(() => [mjCommitteesType_])
+    Results: mjCommitteesType_[];
+
+    @Field(() => String, {nullable: true})
+    UserViewRunID?: string;
+
+    @Field(() => Int, {nullable: true})
+    RowCount: number;
+
+    @Field(() => Int, {nullable: true})
+    TotalRowCount: number;
+
+    @Field(() => Int, {nullable: true})
+    ExecutionTime: number;
+
+    @Field({nullable: true})
+    ErrorMessage?: string;
+
+    @Field(() => Boolean, {nullable: false})
+    Success: boolean;
+}
+
+@Resolver(mjCommitteesType_)
+export class mjCommitteesTypeResolver extends ResolverBase {
+    @Query(() => RunmjCommitteesTypeViewResult)
+    async RunmjCommitteesTypeViewByID(@Arg('input', () => RunViewByIDInput) input: RunViewByIDInput, @Ctx() { providers, userPayload }: AppContext, @PubSub() pubSub: PubSubEngine) {
+        const provider = GetReadOnlyProvider(providers, { allowFallbackToReadWrite: true });
+        return super.RunViewByIDGeneric(input, provider, userPayload, pubSub);
+    }
+
+    @Query(() => RunmjCommitteesTypeViewResult)
+    async RunmjCommitteesTypeViewByName(@Arg('input', () => RunViewByNameInput) input: RunViewByNameInput, @Ctx() { providers, userPayload }: AppContext, @PubSub() pubSub: PubSubEngine) {
+        const provider = GetReadOnlyProvider(providers, { allowFallbackToReadWrite: true });
+        return super.RunViewByNameGeneric(input, provider, userPayload, pubSub);
+    }
+
+    @Query(() => RunmjCommitteesTypeViewResult)
+    async RunmjCommitteesTypeDynamicView(@Arg('input', () => RunDynamicViewInput) input: RunDynamicViewInput, @Ctx() { providers, userPayload }: AppContext, @PubSub() pubSub: PubSubEngine) {
+        const provider = GetReadOnlyProvider(providers, { allowFallbackToReadWrite: true });
+        input.EntityName = 'Types';
+        return super.RunDynamicViewGeneric(input, provider, userPayload, pubSub);
+    }
+    @Query(() => mjCommitteesType_, { nullable: true })
+    async mjCommitteesType(@Arg('ID', () => String) ID: string, @Ctx() { userPayload, providers }: AppContext, @PubSub() pubSub: PubSubEngine): Promise<mjCommitteesType_ | null> {
+        this.CheckUserReadPermissions('Types', userPayload);
+        const provider = GetReadOnlyProvider(providers, { allowFallbackToReadWrite: true });
+        const sSQL = `SELECT * FROM ${provider.QuoteSchemaAndView('__mj_Committees', 'vwTypes')} WHERE ${provider.QuoteIdentifier('ID')}='${ID}' ` + this.getRowLevelSecurityWhereClause(provider, 'Types', userPayload, EntityPermissionType.Read, 'AND');
+        const rows = await provider.ExecuteSQL(sSQL, undefined, undefined, this.GetUserFromPayload(userPayload));
+        const result = await this.MapFieldNamesToCodeNames('Types', rows && rows.length > 0 ? rows[0] : null, this.GetUserFromPayload(userPayload));
+        return result;
+    }
+    
+    @FieldResolver(() => [mjCommitteesCommittee_])
+    async mjCommitteesCommittees_TypeIDArray(@Root() mjcommitteestype_: mjCommitteesType_, @Ctx() { userPayload, providers }: AppContext, @PubSub() pubSub: PubSubEngine) {
+        this.CheckUserReadPermissions('Committees', userPayload);
+        const provider = GetReadOnlyProvider(providers, { allowFallbackToReadWrite: true });
+        const sSQL = `SELECT * FROM ${provider.QuoteSchemaAndView('__mj_Committees', 'vwCommittees')} WHERE ${provider.QuoteIdentifier('TypeID')}='${mjcommitteestype_.ID}' ` + this.getRowLevelSecurityWhereClause(provider, 'Committees', userPayload, EntityPermissionType.Read, 'AND');
+        const rows = await provider.ExecuteSQL(sSQL, undefined, undefined, this.GetUserFromPayload(userPayload));
+        const result = await this.ArrayMapFieldNamesToCodeNames('Committees', rows, this.GetUserFromPayload(userPayload));
+        return result;
+    }
+        
+    @Mutation(() => mjCommitteesType_)
+    async CreatemjCommitteesType(
+        @Arg('input', () => CreatemjCommitteesTypeInput) input: CreatemjCommitteesTypeInput,
+        @Ctx() { providers, userPayload }: AppContext,
+        @PubSub() pubSub: PubSubEngine
+    ) {
+        const provider = GetReadWriteProvider(providers);
+        return this.CreateRecord('Types', input, provider, userPayload, pubSub)
+    }
+        
+    @Mutation(() => mjCommitteesType_)
+    async UpdatemjCommitteesType(
+        @Arg('input', () => UpdatemjCommitteesTypeInput) input: UpdatemjCommitteesTypeInput,
+        @Ctx() { providers, userPayload }: AppContext,
+        @PubSub() pubSub: PubSubEngine
+    ) {
+        const provider = GetReadWriteProvider(providers);
+        return this.UpdateRecord('Types', input, provider, userPayload, pubSub);
+    }
+    
+    @Mutation(() => mjCommitteesType_)
+    async DeletemjCommitteesType(@Arg('ID', () => String) ID: string, @Arg('options___', () => DeleteOptionsInput) options: DeleteOptionsInput, @Ctx() { providers, userPayload }: AppContext, @PubSub() pubSub: PubSubEngine) {
+        const provider = GetReadWriteProvider(providers);
+        const key = new CompositeKey([{FieldName: 'ID', Value: ID}]);
+        return this.DeleteRecord('Types', key, options, provider, userPayload, pubSub);
+    }
+    
+}
+
+//****************************************************************************
+// ENTITY CLASS for Video Providers
+//****************************************************************************
+@ObjectType()
+export class mjCommitteesVideoProvider_ {
+    @Field() 
+    @MaxLength(36)
+    ID: string;
+        
+    @Field() 
+    @MaxLength(100)
+    Name: string;
+        
+    @Field() 
+    @MaxLength(100)
+    ServerDriverKey: string;
+        
+    @Field(() => Boolean) 
+    IsActive: boolean;
+        
+    @Field(() => Boolean) 
+    IsDefault: boolean;
+        
+    @Field({nullable: true}) 
+    @MaxLength(36)
+    CredentialID?: string;
+        
+    @Field() 
+    _mj__CreatedAt: Date;
+        
+    @Field() 
+    _mj__UpdatedAt: Date;
+        
+    @Field({nullable: true}) 
+    @MaxLength(200)
+    Credential?: string;
+        
+    @Field(() => [mjCommitteesMeeting_])
+    mjCommitteesMeetings_VideoProviderIDArray: mjCommitteesMeeting_[]; // Link to mjCommitteesMeetings
+    
+}
+
+//****************************************************************************
+// INPUT TYPE for Video Providers
+//****************************************************************************
+@InputType()
+export class CreatemjCommitteesVideoProviderInput {
+    @Field({ nullable: true })
+    ID?: string;
+
+    @Field({ nullable: true })
+    Name?: string;
+
+    @Field({ nullable: true })
+    ServerDriverKey?: string;
+
+    @Field(() => Boolean, { nullable: true })
+    IsActive?: boolean;
+
+    @Field(() => Boolean, { nullable: true })
+    IsDefault?: boolean;
+
+    @Field({ nullable: true })
+    CredentialID: string | null;
+}
+    
+
+//****************************************************************************
+// INPUT TYPE for Video Providers
+//****************************************************************************
+@InputType()
+export class UpdatemjCommitteesVideoProviderInput {
+    @Field()
+    ID: string;
+
+    @Field({ nullable: true })
+    Name?: string;
+
+    @Field({ nullable: true })
+    ServerDriverKey?: string;
+
+    @Field(() => Boolean, { nullable: true })
+    IsActive?: boolean;
+
+    @Field(() => Boolean, { nullable: true })
+    IsDefault?: boolean;
+
+    @Field({ nullable: true })
+    CredentialID?: string | null;
+
+    @Field(() => [KeyValuePairInput], { nullable: true })
+    OldValues___?: KeyValuePairInput[];
+}
+    
+//****************************************************************************
+// RESOLVER for Video Providers
+//****************************************************************************
+@ObjectType()
+export class RunmjCommitteesVideoProviderViewResult {
+    @Field(() => [mjCommitteesVideoProvider_])
+    Results: mjCommitteesVideoProvider_[];
+
+    @Field(() => String, {nullable: true})
+    UserViewRunID?: string;
+
+    @Field(() => Int, {nullable: true})
+    RowCount: number;
+
+    @Field(() => Int, {nullable: true})
+    TotalRowCount: number;
+
+    @Field(() => Int, {nullable: true})
+    ExecutionTime: number;
+
+    @Field({nullable: true})
+    ErrorMessage?: string;
+
+    @Field(() => Boolean, {nullable: false})
+    Success: boolean;
+}
+
+@Resolver(mjCommitteesVideoProvider_)
+export class mjCommitteesVideoProviderResolver extends ResolverBase {
+    @Query(() => RunmjCommitteesVideoProviderViewResult)
+    async RunmjCommitteesVideoProviderViewByID(@Arg('input', () => RunViewByIDInput) input: RunViewByIDInput, @Ctx() { providers, userPayload }: AppContext, @PubSub() pubSub: PubSubEngine) {
+        const provider = GetReadOnlyProvider(providers, { allowFallbackToReadWrite: true });
+        return super.RunViewByIDGeneric(input, provider, userPayload, pubSub);
+    }
+
+    @Query(() => RunmjCommitteesVideoProviderViewResult)
+    async RunmjCommitteesVideoProviderViewByName(@Arg('input', () => RunViewByNameInput) input: RunViewByNameInput, @Ctx() { providers, userPayload }: AppContext, @PubSub() pubSub: PubSubEngine) {
+        const provider = GetReadOnlyProvider(providers, { allowFallbackToReadWrite: true });
+        return super.RunViewByNameGeneric(input, provider, userPayload, pubSub);
+    }
+
+    @Query(() => RunmjCommitteesVideoProviderViewResult)
+    async RunmjCommitteesVideoProviderDynamicView(@Arg('input', () => RunDynamicViewInput) input: RunDynamicViewInput, @Ctx() { providers, userPayload }: AppContext, @PubSub() pubSub: PubSubEngine) {
+        const provider = GetReadOnlyProvider(providers, { allowFallbackToReadWrite: true });
+        input.EntityName = 'Video Providers';
+        return super.RunDynamicViewGeneric(input, provider, userPayload, pubSub);
+    }
+    @Query(() => mjCommitteesVideoProvider_, { nullable: true })
+    async mjCommitteesVideoProvider(@Arg('ID', () => String) ID: string, @Ctx() { userPayload, providers }: AppContext, @PubSub() pubSub: PubSubEngine): Promise<mjCommitteesVideoProvider_ | null> {
+        this.CheckUserReadPermissions('Video Providers', userPayload);
+        const provider = GetReadOnlyProvider(providers, { allowFallbackToReadWrite: true });
+        const sSQL = `SELECT * FROM ${provider.QuoteSchemaAndView('__mj_Committees', 'vwVideoProviders')} WHERE ${provider.QuoteIdentifier('ID')}='${ID}' ` + this.getRowLevelSecurityWhereClause(provider, 'Video Providers', userPayload, EntityPermissionType.Read, 'AND');
+        const rows = await provider.ExecuteSQL(sSQL, undefined, undefined, this.GetUserFromPayload(userPayload));
+        const result = await this.MapFieldNamesToCodeNames('Video Providers', rows && rows.length > 0 ? rows[0] : null, this.GetUserFromPayload(userPayload));
+        return result;
+    }
+    
+    @FieldResolver(() => [mjCommitteesMeeting_])
+    async mjCommitteesMeetings_VideoProviderIDArray(@Root() mjcommitteesvideoprovider_: mjCommitteesVideoProvider_, @Ctx() { userPayload, providers }: AppContext, @PubSub() pubSub: PubSubEngine) {
+        this.CheckUserReadPermissions('Meetings', userPayload);
+        const provider = GetReadOnlyProvider(providers, { allowFallbackToReadWrite: true });
+        const sSQL = `SELECT * FROM ${provider.QuoteSchemaAndView('__mj_Committees', 'vwMeetings')} WHERE ${provider.QuoteIdentifier('VideoProviderID')}='${mjcommitteesvideoprovider_.ID}' ` + this.getRowLevelSecurityWhereClause(provider, 'Meetings', userPayload, EntityPermissionType.Read, 'AND');
+        const rows = await provider.ExecuteSQL(sSQL, undefined, undefined, this.GetUserFromPayload(userPayload));
+        const result = await this.ArrayMapFieldNamesToCodeNames('Meetings', rows, this.GetUserFromPayload(userPayload));
+        return result;
+    }
+        
+    @Mutation(() => mjCommitteesVideoProvider_)
+    async CreatemjCommitteesVideoProvider(
+        @Arg('input', () => CreatemjCommitteesVideoProviderInput) input: CreatemjCommitteesVideoProviderInput,
+        @Ctx() { providers, userPayload }: AppContext,
+        @PubSub() pubSub: PubSubEngine
+    ) {
+        const provider = GetReadWriteProvider(providers);
+        return this.CreateRecord('Video Providers', input, provider, userPayload, pubSub)
+    }
+        
+    @Mutation(() => mjCommitteesVideoProvider_)
+    async UpdatemjCommitteesVideoProvider(
+        @Arg('input', () => UpdatemjCommitteesVideoProviderInput) input: UpdatemjCommitteesVideoProviderInput,
+        @Ctx() { providers, userPayload }: AppContext,
+        @PubSub() pubSub: PubSubEngine
+    ) {
+        const provider = GetReadWriteProvider(providers);
+        return this.UpdateRecord('Video Providers', input, provider, userPayload, pubSub);
+    }
+    
+    @Mutation(() => mjCommitteesVideoProvider_)
+    async DeletemjCommitteesVideoProvider(@Arg('ID', () => String) ID: string, @Arg('options___', () => DeleteOptionsInput) options: DeleteOptionsInput, @Ctx() { providers, userPayload }: AppContext, @PubSub() pubSub: PubSubEngine) {
+        const provider = GetReadWriteProvider(providers);
+        const key = new CompositeKey([{FieldName: 'ID', Value: ID}]);
+        return this.DeleteRecord('Video Providers', key, options, provider, userPayload, pubSub);
+    }
+    
+}
+
+//****************************************************************************
+// ENTITY CLASS for Votes
+//****************************************************************************
+@ObjectType({ description: `Individual vote records for committee motions` })
+export class mjCommitteesVote_ {
+    @Field() 
+    @MaxLength(36)
+    ID: string;
+        
+    @Field() 
+    @MaxLength(36)
+    MotionID: string;
+        
+    @Field() 
+    @MaxLength(36)
+    MembershipID: string;
+        
+    @Field({description: `The vote cast: Yes, No, Abstain, or Absent`}) 
+    @MaxLength(20)
+    VoteValue: string;
+        
+    @Field({nullable: true, description: `Optional notes explaining the vote`}) 
+    @MaxLength(500)
+    Notes?: string;
+        
+    @Field() 
+    _mj__CreatedAt: Date;
+        
+    @Field() 
+    _mj__UpdatedAt: Date;
+        
+    @Field() 
+    @MaxLength(255)
+    Motion: string;
+        
+    @Field() 
+    @MaxLength(100)
+    Membership: string;
+        
+}
+
+//****************************************************************************
+// INPUT TYPE for Votes
+//****************************************************************************
+@InputType()
+export class CreatemjCommitteesVoteInput {
+    @Field({ nullable: true })
+    ID?: string;
+
+    @Field({ nullable: true })
+    MotionID?: string;
+
+    @Field({ nullable: true })
+    MembershipID?: string;
+
+    @Field({ nullable: true })
+    VoteValue?: string;
+
+    @Field({ nullable: true })
+    Notes: string | null;
+}
+    
+
+//****************************************************************************
+// INPUT TYPE for Votes
+//****************************************************************************
+@InputType()
+export class UpdatemjCommitteesVoteInput {
+    @Field()
+    ID: string;
+
+    @Field({ nullable: true })
+    MotionID?: string;
+
+    @Field({ nullable: true })
+    MembershipID?: string;
+
+    @Field({ nullable: true })
+    VoteValue?: string;
+
+    @Field({ nullable: true })
+    Notes?: string | null;
+
+    @Field(() => [KeyValuePairInput], { nullable: true })
+    OldValues___?: KeyValuePairInput[];
+}
+    
+//****************************************************************************
+// RESOLVER for Votes
+//****************************************************************************
+@ObjectType()
+export class RunmjCommitteesVoteViewResult {
+    @Field(() => [mjCommitteesVote_])
+    Results: mjCommitteesVote_[];
+
+    @Field(() => String, {nullable: true})
+    UserViewRunID?: string;
+
+    @Field(() => Int, {nullable: true})
+    RowCount: number;
+
+    @Field(() => Int, {nullable: true})
+    TotalRowCount: number;
+
+    @Field(() => Int, {nullable: true})
+    ExecutionTime: number;
+
+    @Field({nullable: true})
+    ErrorMessage?: string;
+
+    @Field(() => Boolean, {nullable: false})
+    Success: boolean;
+}
+
+@Resolver(mjCommitteesVote_)
+export class mjCommitteesVoteResolver extends ResolverBase {
+    @Query(() => RunmjCommitteesVoteViewResult)
+    async RunmjCommitteesVoteViewByID(@Arg('input', () => RunViewByIDInput) input: RunViewByIDInput, @Ctx() { providers, userPayload }: AppContext, @PubSub() pubSub: PubSubEngine) {
+        const provider = GetReadOnlyProvider(providers, { allowFallbackToReadWrite: true });
+        return super.RunViewByIDGeneric(input, provider, userPayload, pubSub);
+    }
+
+    @Query(() => RunmjCommitteesVoteViewResult)
+    async RunmjCommitteesVoteViewByName(@Arg('input', () => RunViewByNameInput) input: RunViewByNameInput, @Ctx() { providers, userPayload }: AppContext, @PubSub() pubSub: PubSubEngine) {
+        const provider = GetReadOnlyProvider(providers, { allowFallbackToReadWrite: true });
+        return super.RunViewByNameGeneric(input, provider, userPayload, pubSub);
+    }
+
+    @Query(() => RunmjCommitteesVoteViewResult)
+    async RunmjCommitteesVoteDynamicView(@Arg('input', () => RunDynamicViewInput) input: RunDynamicViewInput, @Ctx() { providers, userPayload }: AppContext, @PubSub() pubSub: PubSubEngine) {
+        const provider = GetReadOnlyProvider(providers, { allowFallbackToReadWrite: true });
+        input.EntityName = 'Votes';
+        return super.RunDynamicViewGeneric(input, provider, userPayload, pubSub);
+    }
+    @Query(() => mjCommitteesVote_, { nullable: true })
+    async mjCommitteesVote(@Arg('ID', () => String) ID: string, @Ctx() { userPayload, providers }: AppContext, @PubSub() pubSub: PubSubEngine): Promise<mjCommitteesVote_ | null> {
+        this.CheckUserReadPermissions('Votes', userPayload);
+        const provider = GetReadOnlyProvider(providers, { allowFallbackToReadWrite: true });
+        const sSQL = `SELECT * FROM ${provider.QuoteSchemaAndView('__mj_Committees', 'vwVotes')} WHERE ${provider.QuoteIdentifier('ID')}='${ID}' ` + this.getRowLevelSecurityWhereClause(provider, 'Votes', userPayload, EntityPermissionType.Read, 'AND');
+        const rows = await provider.ExecuteSQL(sSQL, undefined, undefined, this.GetUserFromPayload(userPayload));
+        const result = await this.MapFieldNamesToCodeNames('Votes', rows && rows.length > 0 ? rows[0] : null, this.GetUserFromPayload(userPayload));
+        return result;
+    }
+    
+    @Mutation(() => mjCommitteesVote_)
+    async CreatemjCommitteesVote(
+        @Arg('input', () => CreatemjCommitteesVoteInput) input: CreatemjCommitteesVoteInput,
+        @Ctx() { providers, userPayload }: AppContext,
+        @PubSub() pubSub: PubSubEngine
+    ) {
+        const provider = GetReadWriteProvider(providers);
+        return this.CreateRecord('Votes', input, provider, userPayload, pubSub)
+    }
+        
+    @Mutation(() => mjCommitteesVote_)
+    async UpdatemjCommitteesVote(
+        @Arg('input', () => UpdatemjCommitteesVoteInput) input: UpdatemjCommitteesVoteInput,
+        @Ctx() { providers, userPayload }: AppContext,
+        @PubSub() pubSub: PubSubEngine
+    ) {
+        const provider = GetReadWriteProvider(providers);
+        return this.UpdateRecord('Votes', input, provider, userPayload, pubSub);
+    }
+    
+    @Mutation(() => mjCommitteesVote_)
+    async DeletemjCommitteesVote(@Arg('ID', () => String) ID: string, @Arg('options___', () => DeleteOptionsInput) options: DeleteOptionsInput, @Ctx() { providers, userPayload }: AppContext, @PubSub() pubSub: PubSubEngine) {
+        const provider = GetReadWriteProvider(providers);
+        const key = new CompositeKey([{FieldName: 'ID', Value: ID}]);
+        return this.DeleteRecord('Votes', key, options, provider, userPayload, pubSub);
+    }
+    
+}

--- a/packages/MJCoreEntities/src/generated/entity_subclasses.ts
+++ b/packages/MJCoreEntities/src/generated/entity_subclasses.ts
@@ -986,7 +986,7 @@ export const MJAIAgentCategorySchema = z.object({
         * * Description: Optional description explaining the purpose and scope of this category.`),
     ParentID: z.string().nullable().describe(`
         * * Field Name: ParentID
-        * * Display Name: Parent
+        * * Display Name: Parent ID
         * * SQL Data Type: uniqueidentifier
         * * Related Entity/Foreign Key: MJ: AI Agent Categories (vwAIAgentCategories.ID)
         * * Description: Self-referencing foreign key to the parent category, forming a tree hierarchy. NULL for root categories.`),
@@ -1016,13 +1016,23 @@ export const MJAIAgentCategorySchema = z.object({
         * * Display Name: Updated At
         * * SQL Data Type: datetimeoffset
         * * Default Value: getutcdate()`),
+    DefaultStorageAccountID: z.string().nullable().describe(`
+        * * Field Name: DefaultStorageAccountID
+        * * Display Name: Default Storage Account
+        * * SQL Data Type: uniqueidentifier
+        * * Related Entity/Foreign Key: MJ: File Storage Accounts (vwFileStorageAccounts.ID)
+        * * Description: Default file storage account for agents in this category. Inherited by child categories that do not define their own value — resolution walks up the ParentID tree until a non-null value is found. Overrides the Type-level default. FK to FileStorageAccount.`),
     Parent: z.string().nullable().describe(`
         * * Field Name: Parent
         * * Display Name: Parent Name
         * * SQL Data Type: nvarchar(200)`),
+    DefaultStorageAccount: z.string().nullable().describe(`
+        * * Field Name: DefaultStorageAccount
+        * * Display Name: Default Storage Account Name
+        * * SQL Data Type: nvarchar(200)`),
     RootParentID: z.string().nullable().describe(`
         * * Field Name: RootParentID
-        * * Display Name: Root Parent
+        * * Display Name: Root Parent ID
         * * SQL Data Type: uniqueidentifier`),
 });
 
@@ -2618,7 +2628,7 @@ export const MJAIAgentRunStepSchema = z.object({
         * * Description: JSON serialization of the Payload state at the end of this step`),
     FinalPayloadValidationResult: z.union([z.literal('Fail'), z.literal('Fail'), z.literal('Pass'), z.literal('Pass'), z.literal('Retry'), z.literal('Retry'), z.literal('Warn'), z.literal('Warn')]).nullable().describe(`
         * * Field Name: FinalPayloadValidationResult
-        * * Display Name: Validation Result
+        * * Display Name: Final Payload Validation Result
         * * SQL Data Type: nvarchar(25)
     * * Value List Type: List
     * * Possible Values 
@@ -2635,13 +2645,13 @@ validation, Retry means validation failed but will retry, Fail means validation 
 permanently, Warn means validation failed but execution continues.`),
     FinalPayloadValidationMessages: z.string().nullable().describe(`
         * * Field Name: FinalPayloadValidationMessages
-        * * Display Name: Validation Messages
+        * * Display Name: Final Payload Validation Messages
         * * SQL Data Type: nvarchar(MAX)
         * * Description: Validation error messages or warnings from final payload validation. Contains
 detailed information about what validation rules failed.`),
     ParentID: z.string().nullable().describe(`
         * * Field Name: ParentID
-        * * Display Name: Parent Step
+        * * Display Name: Parent
         * * SQL Data Type: uniqueidentifier
         * * Related Entity/Foreign Key: MJ: AI Agent Run Steps (vwAIAgentRunSteps.ID)
         * * Description: Optional reference to parent step for tracking hierarchical relationships like code->test->fix->code cycles`),
@@ -2656,11 +2666,11 @@ detailed information about what validation rules failed.`),
         * * SQL Data Type: nvarchar(255)`),
     Parent: z.string().nullable().describe(`
         * * Field Name: Parent
-        * * Display Name: Parent Step
+        * * Display Name: Parent
         * * SQL Data Type: nvarchar(255)`),
     RootParentID: z.string().nullable().describe(`
         * * Field Name: RootParentID
-        * * Display Name: Root Parent Step
+        * * Display Name: Root Parent
         * * SQL Data Type: uniqueidentifier`),
 });
 
@@ -3289,7 +3299,7 @@ export const MJAIAgentTypeSchema = z.object({
         * * Description: Determines whether the custom form section (specified by UIFormSectionClass) should be expanded by default when the AI Agent form loads. True means the section starts expanded, False means it starts collapsed. Only applies when UIFormSectionClass is specified. Defaults to 1 (expanded).`),
     PromptParamsSchema: z.string().nullable().describe(`
         * * Field Name: PromptParamsSchema
-        * * Display Name: Prompt Parameters Schema
+        * * Display Name: Prompt Params Schema
         * * SQL Data Type: nvarchar(MAX)
         * * Description: JSON Schema defining the available prompt parameters for this agent type. Includes property definitions with types, defaults, and descriptions. Used by agents of this type to customize which prompt sections are included in the system prompt. The schema follows JSON Schema draft-07 format.`),
     AssignmentStrategy: z.string().nullable().describe(`
@@ -3297,10 +3307,20 @@ export const MJAIAgentTypeSchema = z.object({
         * * Display Name: Assignment Strategy
         * * SQL Data Type: nvarchar(MAX)
         * * Description: JSON-serialized AgentRequestAssignmentStrategy defining the default assignment strategy for all agents of this type. Overridden by per-invocation or category-level strategies in the resolution chain.`),
+    DefaultStorageAccountID: z.string().nullable().describe(`
+        * * Field Name: DefaultStorageAccountID
+        * * Display Name: Default Storage Account ID
+        * * SQL Data Type: uniqueidentifier
+        * * Related Entity/Foreign Key: MJ: File Storage Accounts (vwFileStorageAccounts.ID)
+        * * Description: Default file storage account for agents of this type. Lowest priority in the resolution chain (Type → Category tree → Agent → Runtime override). When set, all agents of this type use this storage account unless overridden at a more specific level. FK to FileStorageAccount.`),
     SystemPrompt: z.string().nullable().describe(`
         * * Field Name: SystemPrompt
-        * * Display Name: System Prompt Text
+        * * Display Name: System Prompt
         * * SQL Data Type: nvarchar(255)`),
+    DefaultStorageAccount: z.string().nullable().describe(`
+        * * Field Name: DefaultStorageAccount
+        * * Display Name: Default Storage Account
+        * * SQL Data Type: nvarchar(200)`),
 });
 
 export type MJAIAgentTypeEntityType = z.infer<typeof MJAIAgentTypeSchema>;
@@ -3376,22 +3396,22 @@ export const MJAIAgentSchema = z.object({
         * * Description: When true, enables automatic compression of conversation context when the message threshold is reached.`),
     ContextCompressionMessageThreshold: z.number().nullable().describe(`
         * * Field Name: ContextCompressionMessageThreshold
-        * * Display Name: Compression Message Threshold
+        * * Display Name: Context Compression Message Threshold
         * * SQL Data Type: int
         * * Description: Number of messages that triggers context compression when EnableContextCompression is true.`),
     ContextCompressionPromptID: z.string().nullable().describe(`
         * * Field Name: ContextCompressionPromptID
-        * * Display Name: Compression Prompt
+        * * Display Name: Context Compression Prompt
         * * SQL Data Type: uniqueidentifier
         * * Related Entity/Foreign Key: MJ: AI Prompts (vwAIPrompts.ID)`),
     ContextCompressionMessageRetentionCount: z.number().nullable().describe(`
         * * Field Name: ContextCompressionMessageRetentionCount
-        * * Display Name: Compression Message Retention Count
+        * * Display Name: Context Compression Message Retention Count
         * * SQL Data Type: int
         * * Description: Number of recent messages to keep uncompressed when context compression is applied.`),
     TypeID: z.string().nullable().describe(`
         * * Field Name: TypeID
-        * * Display Name: Type
+        * * Display Name: Agent Type
         * * SQL Data Type: uniqueidentifier
         * * Related Entity/Foreign Key: MJ: AI Agent Types (vwAIAgentTypes.ID)
         * * Description: Reference to the AIAgentType that defines the category and system-level behavior for this agent. Cannot be null.`),
@@ -3717,6 +3737,12 @@ if this limit is exceeded.`),
         * * SQL Data Type: bit
         * * Default Value: 1
         * * Description: When true (default), this agent accepts runtime-registered ephemeral client tools that are not defined in metadata. Set to false for agents that require strict tool governance.`),
+    DefaultStorageAccountID: z.string().nullable().describe(`
+        * * Field Name: DefaultStorageAccountID
+        * * Display Name: Default Storage Account ID
+        * * SQL Data Type: uniqueidentifier
+        * * Related Entity/Foreign Key: MJ: File Storage Accounts (vwFileStorageAccounts.ID)
+        * * Description: Default file storage account for this specific agent. Overrides both Type-level and Category-level defaults. Can be further overridden at runtime via ExecuteAgentParams.override.storageAccountId. FK to FileStorageAccount.`),
     Parent: z.string().nullable().describe(`
         * * Field Name: Parent
         * * Display Name: Parent Name
@@ -3744,6 +3770,10 @@ if this limit is exceeded.`),
     Category: z.string().nullable().describe(`
         * * Field Name: Category
         * * Display Name: Category Name
+        * * SQL Data Type: nvarchar(200)`),
+    DefaultStorageAccount: z.string().nullable().describe(`
+        * * Field Name: DefaultStorageAccount
+        * * Display Name: Default Storage Account
         * * SQL Data Type: nvarchar(200)`),
     RootParentID: z.string().nullable().describe(`
         * * Field Name: RootParentID
@@ -9640,6 +9670,100 @@ export const MJContentItemAttributeSchema = z.object({
 export type MJContentItemAttributeEntityType = z.infer<typeof MJContentItemAttributeSchema>;
 
 /**
+ * zod schema definition for the entity MJ: Content Item Duplicates
+ */
+export const MJContentItemDuplicateSchema = z.object({
+    ID: z.string().describe(`
+        * * Field Name: ID
+        * * Display Name: ID
+        * * SQL Data Type: uniqueidentifier
+        * * Default Value: newsequentialid()`),
+    ContentItemAID: z.string().describe(`
+        * * Field Name: ContentItemAID
+        * * Display Name: Content Item A ID
+        * * SQL Data Type: uniqueidentifier
+        * * Related Entity/Foreign Key: MJ: Content Items (vwContentItems.ID)`),
+    ContentItemBID: z.string().describe(`
+        * * Field Name: ContentItemBID
+        * * Display Name: Content Item B ID
+        * * SQL Data Type: uniqueidentifier
+        * * Related Entity/Foreign Key: MJ: Content Items (vwContentItems.ID)`),
+    SimilarityScore: z.number().describe(`
+        * * Field Name: SimilarityScore
+        * * Display Name: Similarity Score
+        * * SQL Data Type: decimal(5, 4)
+        * * Description: Cosine similarity (for Vector) or exact match score (1.0 for Checksum/URL). Range 0.0-1.0.`),
+    DetectionMethod: z.union([z.literal('Checksum'), z.literal('Title'), z.literal('URL'), z.literal('Vector')]).describe(`
+        * * Field Name: DetectionMethod
+        * * Display Name: Detection Method
+        * * SQL Data Type: nvarchar(30)
+        * * Default Value: Checksum
+    * * Value List Type: List
+    * * Possible Values 
+    *   * Checksum
+    *   * Title
+    *   * URL
+    *   * Vector
+        * * Description: How the duplicate was detected: Checksum (identical text hash), Vector (embedding similarity), Title (same title text), URL (same source URL).`),
+    Status: z.union([z.literal('Confirmed'), z.literal('Dismissed'), z.literal('Merged'), z.literal('Pending')]).describe(`
+        * * Field Name: Status
+        * * Display Name: Status
+        * * SQL Data Type: nvarchar(20)
+        * * Default Value: Pending
+    * * Value List Type: List
+    * * Possible Values 
+    *   * Confirmed
+    *   * Dismissed
+    *   * Merged
+    *   * Pending
+        * * Description: Current status: Pending (awaiting review), Confirmed (verified duplicate), Dismissed (not a duplicate), Merged (one item was removed).`),
+    ResolvedByUserID: z.string().nullable().describe(`
+        * * Field Name: ResolvedByUserID
+        * * Display Name: Resolved By User ID
+        * * SQL Data Type: uniqueidentifier
+        * * Related Entity/Foreign Key: MJ: Users (vwUsers.ID)`),
+    ResolvedAt: z.date().nullable().describe(`
+        * * Field Name: ResolvedAt
+        * * Display Name: Resolved At
+        * * SQL Data Type: datetimeoffset`),
+    Resolution: z.union([z.literal('KeepA'), z.literal('KeepB'), z.literal('MergeBoth'), z.literal('NotDuplicate')]).nullable().describe(`
+        * * Field Name: Resolution
+        * * Display Name: Resolution
+        * * SQL Data Type: nvarchar(20)
+    * * Value List Type: List
+    * * Possible Values 
+    *   * KeepA
+    *   * KeepB
+    *   * MergeBoth
+    *   * NotDuplicate
+        * * Description: How the duplicate was resolved: KeepA (keep first, remove second), KeepB (keep second, remove first), MergeBoth (combine into one), NotDuplicate (false positive).`),
+    __mj_CreatedAt: z.date().describe(`
+        * * Field Name: __mj_CreatedAt
+        * * Display Name: Created At
+        * * SQL Data Type: datetimeoffset
+        * * Default Value: getutcdate()`),
+    __mj_UpdatedAt: z.date().describe(`
+        * * Field Name: __mj_UpdatedAt
+        * * Display Name: Updated At
+        * * SQL Data Type: datetimeoffset
+        * * Default Value: getutcdate()`),
+    ContentItemA: z.string().nullable().describe(`
+        * * Field Name: ContentItemA
+        * * Display Name: Content Item A
+        * * SQL Data Type: nvarchar(250)`),
+    ContentItemB: z.string().nullable().describe(`
+        * * Field Name: ContentItemB
+        * * Display Name: Content Item B
+        * * SQL Data Type: nvarchar(250)`),
+    ResolvedByUser: z.string().nullable().describe(`
+        * * Field Name: ResolvedByUser
+        * * Display Name: Resolved By User
+        * * SQL Data Type: nvarchar(100)`),
+});
+
+export type MJContentItemDuplicateEntityType = z.infer<typeof MJContentItemDuplicateSchema>;
+
+/**
  * zod schema definition for the entity MJ: Content Item Tags
  */
 export const MJContentItemTagSchema = z.object({
@@ -9650,7 +9774,7 @@ export const MJContentItemTagSchema = z.object({
         * * Default Value: newsequentialid()`),
     ItemID: z.string().describe(`
         * * Field Name: ItemID
-        * * Display Name: Item ID
+        * * Display Name: Item
         * * SQL Data Type: uniqueidentifier
         * * Related Entity/Foreign Key: MJ: Content Items (vwContentItems.ID)`),
     Tag: z.string().describe(`
@@ -9674,10 +9798,20 @@ export const MJContentItemTagSchema = z.object({
         * * SQL Data Type: numeric(5, 4)
         * * Default Value: 1.0
         * * Description: Relevance weight for this tag (0.0-1.0). 1.0 = highly relevant central topic, 0.5 = moderately relevant, 0.1 = tangentially related. Assigned by the LLM during autotagging.`),
+    TagID: z.string().nullable().describe(`
+        * * Field Name: TagID
+        * * Display Name: Tag Reference
+        * * SQL Data Type: uniqueidentifier
+        * * Related Entity/Foreign Key: MJ: Tags (vwTags.ID)
+        * * Description: Optional link to the formal MJ Tag taxonomy. When set, this free-text tag has been matched (via semantic similarity or exact match) to a curated Tag record. NULL means the tag is unmatched free text only.`),
     Item: z.string().nullable().describe(`
         * * Field Name: Item
-        * * Display Name: Item
+        * * Display Name: Item Name
         * * SQL Data Type: nvarchar(250)`),
+    Tag_Virtual: z.string().nullable().describe(`
+        * * Field Name: Tag_Virtual
+        * * Display Name: Tag (Virtual)
+        * * SQL Data Type: nvarchar(255)`),
 });
 
 export type MJContentItemTagEntityType = z.infer<typeof MJContentItemTagSchema>;
@@ -9744,6 +9878,54 @@ export const MJContentItemSchema = z.object({
         * * Display Name: Updated At
         * * SQL Data Type: datetimeoffset
         * * Default Value: getutcdate()`),
+    EntityRecordDocumentID: z.string().nullable().describe(`
+        * * Field Name: EntityRecordDocumentID
+        * * Display Name: Entity Record Document ID
+        * * SQL Data Type: uniqueidentifier
+        * * Related Entity/Foreign Key: MJ: Entity Record Documents (vwEntityRecordDocuments.ID)
+        * * Description: For entity-sourced content items, links to the Entity Record Document snapshot that was rendered for this item. Provides traceability back to the source entity record via ERD.EntityID + ERD.RecordID. NULL for non-entity sources.`),
+    EmbeddingStatus: z.union([z.literal('Complete'), z.literal('Failed'), z.literal('Pending'), z.literal('Processing'), z.literal('Skipped')]).describe(`
+        * * Field Name: EmbeddingStatus
+        * * Display Name: Embedding Status
+        * * SQL Data Type: nvarchar(20)
+        * * Default Value: Pending
+    * * Value List Type: List
+    * * Possible Values 
+    *   * Complete
+    *   * Failed
+    *   * Pending
+    *   * Processing
+    *   * Skipped
+        * * Description: Vectorization status: Pending (not yet embedded), Processing (currently being embedded), Complete (vector stored), Failed (embedding error), Skipped (excluded from vectorization).`),
+    LastEmbeddedAt: z.date().nullable().describe(`
+        * * Field Name: LastEmbeddedAt
+        * * Display Name: Last Embedded At
+        * * SQL Data Type: datetimeoffset
+        * * Description: Timestamp of the most recent successful embedding for this content item.`),
+    EmbeddingModelID: z.string().nullable().describe(`
+        * * Field Name: EmbeddingModelID
+        * * Display Name: Embedding Model ID
+        * * SQL Data Type: uniqueidentifier
+        * * Related Entity/Foreign Key: MJ: AI Models (vwAIModels.ID)
+        * * Description: The AI model used to generate the most recent embedding for this content item.`),
+    TaggingStatus: z.union([z.literal('Complete'), z.literal('Failed'), z.literal('Pending'), z.literal('Processing'), z.literal('Skipped')]).describe(`
+        * * Field Name: TaggingStatus
+        * * Display Name: Tagging Status
+        * * SQL Data Type: nvarchar(20)
+        * * Default Value: Pending
+    * * Value List Type: List
+    * * Possible Values 
+    *   * Complete
+    *   * Failed
+    *   * Pending
+    *   * Processing
+    *   * Skipped
+        * * Description: Autotagging status: Pending (not yet tagged), Processing (LLM is generating tags), Complete (tags assigned), Failed (LLM error), Skipped (excluded from tagging).`),
+    LastTaggedAt: z.date().nullable().describe(`
+        * * Field Name: LastTaggedAt
+        * * Display Name: Last Tagged At
+        * * SQL Data Type: datetimeoffset
+        * * Description: Timestamp of the most recent successful autotagging run for this content item.`),
     ContentSource: z.string().nullable().describe(`
         * * Field Name: ContentSource
         * * Display Name: Content Source
@@ -9760,9 +9942,176 @@ export const MJContentItemSchema = z.object({
         * * Field Name: ContentFileType
         * * Display Name: Content File Type
         * * SQL Data Type: nvarchar(255)`),
+    EntityRecordDocument: z.string().nullable().describe(`
+        * * Field Name: EntityRecordDocument
+        * * Display Name: Entity Record Document
+        * * SQL Data Type: nvarchar(450)`),
+    EmbeddingModel: z.string().nullable().describe(`
+        * * Field Name: EmbeddingModel
+        * * Display Name: Embedding Model
+        * * SQL Data Type: nvarchar(50)`),
 });
 
 export type MJContentItemEntityType = z.infer<typeof MJContentItemSchema>;
+
+/**
+ * zod schema definition for the entity MJ: Content Process Run Details
+ */
+export const MJContentProcessRunDetailSchema = z.object({
+    ID: z.string().describe(`
+        * * Field Name: ID
+        * * Display Name: ID
+        * * SQL Data Type: uniqueidentifier
+        * * Default Value: newsequentialid()`),
+    ContentProcessRunID: z.string().describe(`
+        * * Field Name: ContentProcessRunID
+        * * Display Name: Content Process Run
+        * * SQL Data Type: uniqueidentifier
+        * * Related Entity/Foreign Key: MJ: Content Process Runs (vwContentProcessRuns.ID)
+        * * Description: The parent pipeline run this detail belongs to.`),
+    ContentSourceID: z.string().describe(`
+        * * Field Name: ContentSourceID
+        * * Display Name: Content Source
+        * * SQL Data Type: uniqueidentifier
+        * * Related Entity/Foreign Key: MJ: Content Sources (vwContentSources.ID)
+        * * Description: The content source being processed in this detail record.`),
+    ContentSourceTypeID: z.string().describe(`
+        * * Field Name: ContentSourceTypeID
+        * * Display Name: Content Source Type
+        * * SQL Data Type: uniqueidentifier
+        * * Related Entity/Foreign Key: MJ: Content Source Types (vwContentSourceTypes.ID)
+        * * Description: The type of content source (RSS Feed, Entity, Website, Cloud Storage, etc.).`),
+    Status: z.string().describe(`
+        * * Field Name: Status
+        * * Display Name: Status
+        * * SQL Data Type: nvarchar(20)
+        * * Default Value: Pending
+        * * Description: Processing status: Pending, Running, Completed, Failed, or Skipped.`),
+    ItemsProcessed: z.number().describe(`
+        * * Field Name: ItemsProcessed
+        * * Display Name: Items Processed
+        * * SQL Data Type: int
+        * * Default Value: 0
+        * * Description: Total content items processed for this source during the run.`),
+    ItemsTagged: z.number().describe(`
+        * * Field Name: ItemsTagged
+        * * Display Name: Items Tagged
+        * * SQL Data Type: int
+        * * Default Value: 0
+        * * Description: Number of content items successfully tagged by the LLM.`),
+    ItemsVectorized: z.number().describe(`
+        * * Field Name: ItemsVectorized
+        * * Display Name: Items Vectorized
+        * * SQL Data Type: int
+        * * Default Value: 0
+        * * Description: Number of content items successfully embedded and upserted to the vector database.`),
+    TagsCreated: z.number().describe(`
+        * * Field Name: TagsCreated
+        * * Display Name: Tags Created
+        * * SQL Data Type: int
+        * * Default Value: 0
+        * * Description: Number of new ContentItemTag records created during LLM tagging.`),
+    ErrorCount: z.number().describe(`
+        * * Field Name: ErrorCount
+        * * Display Name: Error Count
+        * * SQL Data Type: int
+        * * Default Value: 0
+        * * Description: Number of errors encountered while processing this source.`),
+    StartTime: z.date().nullable().describe(`
+        * * Field Name: StartTime
+        * * Display Name: Start Time
+        * * SQL Data Type: datetimeoffset
+        * * Description: When processing started for this source within the pipeline run.`),
+    EndTime: z.date().nullable().describe(`
+        * * Field Name: EndTime
+        * * Display Name: End Time
+        * * SQL Data Type: datetimeoffset
+        * * Description: When processing completed for this source within the pipeline run.`),
+    TotalTokensUsed: z.number().describe(`
+        * * Field Name: TotalTokensUsed
+        * * Display Name: Total Tokens Used
+        * * SQL Data Type: int
+        * * Default Value: 0
+        * * Description: Rollup of all tokens used across LLM tagging and embedding calls for this source. Computed from linked AIPromptRun records via the ContentProcessRunPromptRun junction table.`),
+    TotalCost: z.number().describe(`
+        * * Field Name: TotalCost
+        * * Display Name: Total Cost
+        * * SQL Data Type: decimal(18, 6)
+        * * Default Value: 0
+        * * Description: Rollup of all costs across LLM tagging and embedding calls for this source. Computed from linked AIPromptRun records via the ContentProcessRunPromptRun junction table.`),
+    __mj_CreatedAt: z.date().describe(`
+        * * Field Name: __mj_CreatedAt
+        * * Display Name: Created At
+        * * SQL Data Type: datetimeoffset
+        * * Default Value: getutcdate()`),
+    __mj_UpdatedAt: z.date().describe(`
+        * * Field Name: __mj_UpdatedAt
+        * * Display Name: Updated At
+        * * SQL Data Type: datetimeoffset
+        * * Default Value: getutcdate()`),
+    ContentProcessRun: z.string().nullable().describe(`
+        * * Field Name: ContentProcessRun
+        * * Display Name: Content Process Run Name
+        * * SQL Data Type: nvarchar(255)`),
+    ContentSource: z.string().nullable().describe(`
+        * * Field Name: ContentSource
+        * * Display Name: Content Source Name
+        * * SQL Data Type: nvarchar(255)`),
+    ContentSourceType: z.string().describe(`
+        * * Field Name: ContentSourceType
+        * * Display Name: Source Type Category
+        * * SQL Data Type: nvarchar(255)`),
+});
+
+export type MJContentProcessRunDetailEntityType = z.infer<typeof MJContentProcessRunDetailSchema>;
+
+/**
+ * zod schema definition for the entity MJ: Content Process Run Prompt Runs
+ */
+export const MJContentProcessRunPromptRunSchema = z.object({
+    ID: z.string().describe(`
+        * * Field Name: ID
+        * * Display Name: ID
+        * * SQL Data Type: uniqueidentifier
+        * * Default Value: newsequentialid()`),
+    ContentProcessRunDetailID: z.string().describe(`
+        * * Field Name: ContentProcessRunDetailID
+        * * Display Name: Content Process Run Detail
+        * * SQL Data Type: uniqueidentifier
+        * * Related Entity/Foreign Key: MJ: Content Process Run Details (vwContentProcessRunDetails.ID)
+        * * Description: The content process run detail record this prompt run is associated with.`),
+    AIPromptRunID: z.string().describe(`
+        * * Field Name: AIPromptRunID
+        * * Display Name: AI Prompt Run
+        * * SQL Data Type: uniqueidentifier
+        * * Related Entity/Foreign Key: MJ: AI Prompt Runs (vwAIPromptRuns.ID)
+        * * Description: The AI prompt run record containing token usage, cost, model, vendor, and execution details for this call.`),
+    RunType: z.union([z.literal('Embed'), z.literal('Tag')]).describe(`
+        * * Field Name: RunType
+        * * Display Name: Run Type
+        * * SQL Data Type: nvarchar(20)
+    * * Value List Type: List
+    * * Possible Values 
+    *   * Embed
+    *   * Tag
+        * * Description: Whether this AIPromptRun was for LLM tagging (Tag) or text embedding (Embed).`),
+    __mj_CreatedAt: z.date().describe(`
+        * * Field Name: __mj_CreatedAt
+        * * Display Name: Created At
+        * * SQL Data Type: datetimeoffset
+        * * Default Value: getutcdate()`),
+    __mj_UpdatedAt: z.date().describe(`
+        * * Field Name: __mj_UpdatedAt
+        * * Display Name: Updated At
+        * * SQL Data Type: datetimeoffset
+        * * Default Value: getutcdate()`),
+    AIPromptRun: z.string().nullable().describe(`
+        * * Field Name: AIPromptRun
+        * * Display Name: Prompt Run Label
+        * * SQL Data Type: nvarchar(255)`),
+});
+
+export type MJContentProcessRunPromptRunEntityType = z.infer<typeof MJContentProcessRunPromptRunSchema>;
 
 /**
  * zod schema definition for the entity MJ: Content Process Runs
@@ -9807,10 +10156,60 @@ export const MJContentProcessRunSchema = z.object({
         * * Display Name: Updated At
         * * SQL Data Type: datetimeoffset
         * * Default Value: getutcdate()`),
+    StartedByUserID: z.string().nullable().describe(`
+        * * Field Name: StartedByUserID
+        * * Display Name: Started By User ID
+        * * SQL Data Type: uniqueidentifier
+        * * Related Entity/Foreign Key: MJ: Users (vwUsers.ID)
+        * * Description: The user who triggered this pipeline run. NULL for system-initiated runs.`),
+    TotalItemCount: z.number().nullable().describe(`
+        * * Field Name: TotalItemCount
+        * * Display Name: Total Item Count
+        * * SQL Data Type: int
+        * * Description: Total number of content items to process in this run. Used for progress percentage calculation.`),
+    LastProcessedOffset: z.number().nullable().describe(`
+        * * Field Name: LastProcessedOffset
+        * * Display Name: Last Processed Offset
+        * * SQL Data Type: int
+        * * Default Value: 0
+        * * Description: StartRow offset of the last successfully completed batch. Used for resume-from-crash: next batch starts at this offset. Reset to 0 on new runs.`),
+    BatchSize: z.number().nullable().describe(`
+        * * Field Name: BatchSize
+        * * Display Name: Batch Size
+        * * SQL Data Type: int
+        * * Default Value: 100
+        * * Description: Number of content items processed per batch. Configurable per run, default 100.`),
+    ErrorCount: z.number().nullable().describe(`
+        * * Field Name: ErrorCount
+        * * Display Name: Error Count
+        * * SQL Data Type: int
+        * * Default Value: 0
+        * * Description: Running count of errors encountered during processing. Used by the circuit breaker to halt the pipeline if error rate exceeds the configured threshold.`),
+    ErrorMessage: z.string().nullable().describe(`
+        * * Field Name: ErrorMessage
+        * * Display Name: Error Message
+        * * SQL Data Type: nvarchar(MAX)
+        * * Description: Error details if the run failed. Includes error messages, stack traces, or circuit breaker trigger reason.`),
+    CancellationRequested: z.boolean().describe(`
+        * * Field Name: CancellationRequested
+        * * Display Name: Cancellation Requested
+        * * SQL Data Type: bit
+        * * Default Value: 0
+        * * Description: When set to 1, the pipeline stops after completing the current batch. Used for pause and cancel operations. The Status column reflects the final state (Paused or Cancelled).`),
+    Configuration: z.any().nullable().describe(`
+        * * Field Name: Configuration
+        * * Display Name: Configuration
+        * * SQL Data Type: nvarchar(MAX)
+        * * JSON Type: MJContentProcessRunEntity_IContentProcessRunConfiguration
+        * * Description: JSON snapshot of the pipeline configuration used for this run. Conforms to the IContentProcessRunConfiguration interface. Includes batch size, rate limits, error thresholds, and duplicate detection settings.`),
     Source: z.string().nullable().describe(`
         * * Field Name: Source
         * * Display Name: Source
         * * SQL Data Type: nvarchar(255)`),
+    StartedByUser: z.string().nullable().describe(`
+        * * Field Name: StartedByUser
+        * * Display Name: Started By User
+        * * SQL Data Type: nvarchar(100)`),
 });
 
 export type MJContentProcessRunEntityType = z.infer<typeof MJContentProcessRunSchema>;
@@ -9930,6 +10329,17 @@ export const MJContentSourceTypeSchema = z.object({
         * * Display Name: Updated At
         * * SQL Data Type: datetimeoffset
         * * Default Value: getutcdate()`),
+    DriverClass: z.string().nullable().describe(`
+        * * Field Name: DriverClass
+        * * Display Name: Driver Class
+        * * SQL Data Type: nvarchar(255)
+        * * Description: The registered class name used by ClassFactory to instantiate the provider for this source type (e.g., AutotagLocalFileSystem, AutotagEntity). Must match a @RegisterClass key on a class extending AutotagBase.`),
+    Configuration: z.any().nullable().describe(`
+        * * Field Name: Configuration
+        * * Display Name: Configuration
+        * * SQL Data Type: nvarchar(MAX)
+        * * JSON Type: MJContentSourceTypeEntity_IContentSourceTypeConfiguration
+        * * Description: JSON configuration blob for type-level settings. Conforms to the IContentSourceTypeConfiguration interface. Reserved for future type-wide settings shared by all sources of this type.`),
 });
 
 export type MJContentSourceTypeEntityType = z.infer<typeof MJContentSourceTypeSchema>;
@@ -9989,6 +10399,30 @@ export const MJContentSourceSchema = z.object({
         * * SQL Data Type: uniqueidentifier
         * * Related Entity/Foreign Key: MJ: Vector Indexes (vwVectorIndexes.ID)
         * * Description: Per-source override for the vector index. When NULL, falls back to the ContentType default.`),
+    Configuration: z.any().nullable().describe(`
+        * * Field Name: Configuration
+        * * Display Name: Configuration
+        * * SQL Data Type: nvarchar(MAX)
+        * * JSON Type: MJContentSourceEntity_IContentSourceConfiguration
+        * * Description: JSON configuration blob for source-instance settings. Conforms to the IContentSourceConfiguration interface. Includes tag taxonomy mode (constrained/auto-grow/free-flow), tag root ID, match threshold, LLM taxonomy sharing, and vectorization toggle.`),
+    EntityID: z.string().nullable().describe(`
+        * * Field Name: EntityID
+        * * Display Name: Entity
+        * * SQL Data Type: uniqueidentifier
+        * * Related Entity/Foreign Key: MJ: Entities (vwEntities.ID)
+        * * Description: For Entity-type content sources, the MJ Entity to pull records from. NULL for non-entity sources (files, RSS, websites, etc.).`),
+    EntityDocumentID: z.string().nullable().describe(`
+        * * Field Name: EntityDocumentID
+        * * Display Name: Entity Document
+        * * SQL Data Type: uniqueidentifier
+        * * Related Entity/Foreign Key: MJ: Entity Documents (vwEntityDocuments.ID)
+        * * Description: For Entity-type content sources, the Entity Document template used to render entity records into text for autotagging. The template defines which fields to include, how to format them, and related record inclusion. NULL for non-entity sources.`),
+    ScheduledActionID: z.string().nullable().describe(`
+        * * Field Name: ScheduledActionID
+        * * Display Name: Scheduled Action
+        * * SQL Data Type: uniqueidentifier
+        * * Related Entity/Foreign Key: MJ: Scheduled Actions (vwScheduledActions.ID)
+        * * Description: Optional link to a MJ Scheduled Action that automatically runs the classification pipeline for this source on a cron schedule.`),
     ContentType: z.string().describe(`
         * * Field Name: ContentType
         * * Display Name: Content Type
@@ -10008,6 +10442,18 @@ export const MJContentSourceSchema = z.object({
     VectorIndex: z.string().nullable().describe(`
         * * Field Name: VectorIndex
         * * Display Name: Vector Index
+        * * SQL Data Type: nvarchar(255)`),
+    Entity: z.string().nullable().describe(`
+        * * Field Name: Entity
+        * * Display Name: Entity
+        * * SQL Data Type: nvarchar(255)`),
+    EntityDocument: z.string().nullable().describe(`
+        * * Field Name: EntityDocument
+        * * Display Name: Entity Document
+        * * SQL Data Type: nvarchar(250)`),
+    ScheduledAction: z.string().nullable().describe(`
+        * * Field Name: ScheduledAction
+        * * Display Name: Scheduled Action
         * * SQL Data Type: nvarchar(255)`),
 });
 
@@ -10108,6 +10554,12 @@ export const MJContentTypeSchema = z.object({
         * * SQL Data Type: uniqueidentifier
         * * Related Entity/Foreign Key: MJ: Vector Indexes (vwVectorIndexes.ID)
         * * Description: Default vector index for storing embeddings of this content type. Sources can override per-source. If NULL, uses the first available vector index.`),
+    Configuration: z.any().nullable().describe(`
+        * * Field Name: Configuration
+        * * Display Name: Configuration
+        * * SQL Data Type: nvarchar(MAX)
+        * * JSON Type: MJContentTypeEntity_IContentTypeConfiguration
+        * * Description: JSON configuration blob for content-type-level settings. Conforms to the IContentTypeConfiguration interface. Reserved for future type-wide settings such as default tag taxonomy rules and processing options.`),
     AIModel: z.string().describe(`
         * * Field Name: AIModel
         * * Display Name: AI Model Name
@@ -10337,11 +10789,11 @@ export const MJConversationDetailArtifactSchema = z.object({
         * * Default Value: getutcdate()`),
     ConversationDetail: z.string().describe(`
         * * Field Name: ConversationDetail
-        * * Display Name: Conversation Detail Summary
+        * * Display Name: Conversation Detail
         * * SQL Data Type: nvarchar(MAX)`),
     ArtifactVersion: z.string().nullable().describe(`
         * * Field Name: ArtifactVersion
-        * * Display Name: Artifact Version Summary
+        * * Display Name: Artifact Version
         * * SQL Data Type: nvarchar(255)`),
 });
 
@@ -10798,7 +11250,7 @@ export const MJConversationSchema = z.object({
         * * Description: Optional Foreign Key - Links this conversation to a test run if this conversation was generated as part of a test. Enables tracking test conversations separately from production conversations.`),
     User: z.string().describe(`
         * * Field Name: User
-        * * Display Name: User Name
+        * * Display Name: User
         * * SQL Data Type: nvarchar(100)`),
     LinkedEntity: z.string().nullable().describe(`
         * * Field Name: LinkedEntity
@@ -10806,19 +11258,19 @@ export const MJConversationSchema = z.object({
         * * SQL Data Type: nvarchar(255)`),
     DataContext: z.string().nullable().describe(`
         * * Field Name: DataContext
-        * * Display Name: Data Context Name
+        * * Display Name: Data Context
         * * SQL Data Type: nvarchar(255)`),
     Environment: z.string().describe(`
         * * Field Name: Environment
-        * * Display Name: Environment Name
+        * * Display Name: Environment
         * * SQL Data Type: nvarchar(255)`),
     Project: z.string().nullable().describe(`
         * * Field Name: Project
-        * * Display Name: Project Name
+        * * Display Name: Project
         * * SQL Data Type: nvarchar(255)`),
     TestRun: z.string().nullable().describe(`
         * * Field Name: TestRun
-        * * Display Name: Test Run Name
+        * * Display Name: Test Run
         * * SQL Data Type: nvarchar(255)`),
 });
 
@@ -11953,7 +12405,7 @@ export const MJDuplicateRunDetailSchema = z.object({
         * * Related Entity/Foreign Key: MJ: Duplicate Runs (vwDuplicateRuns.ID)`),
     RecordID: z.string().describe(`
         * * Field Name: RecordID
-        * * Display Name: Source Record
+        * * Display Name: Record
         * * SQL Data Type: nvarchar(500)
         * * Description: The ID of the record being analyzed for duplicates.`),
     MatchStatus: z.union([z.literal('Complete'), z.literal('Error'), z.literal('Pending'), z.literal('Skipped')]).describe(`
@@ -12010,9 +12462,19 @@ export const MJDuplicateRunDetailSchema = z.object({
         * * Display Name: Record Metadata
         * * SQL Data Type: nvarchar(MAX)
         * * Description: JSON metadata snapshot of the source record from the vector database at detection time. Contains display fields (Name, Description, EntityIcon, etc.) for rich UI rendering without additional lookups.`),
+    StartedAt: z.date().nullable().describe(`
+        * * Field Name: StartedAt
+        * * Display Name: Started At
+        * * SQL Data Type: datetimeoffset
+        * * Description: When processing started for this specific record during duplicate detection.`),
+    EndedAt: z.date().nullable().describe(`
+        * * Field Name: EndedAt
+        * * Display Name: Ended At
+        * * SQL Data Type: datetimeoffset
+        * * Description: When processing completed for this specific record during duplicate detection.`),
     DuplicateRun: z.string().describe(`
         * * Field Name: DuplicateRun
-        * * Display Name: Run Name
+        * * Display Name: Duplicate Run
         * * SQL Data Type: nvarchar(255)`),
 });
 
@@ -12034,7 +12496,7 @@ export const MJDuplicateRunSchema = z.object({
         * * Related Entity/Foreign Key: MJ: Entities (vwEntities.ID)`),
     StartedByUserID: z.string().describe(`
         * * Field Name: StartedByUserID
-        * * Display Name: Started By User
+        * * Display Name: Started By
         * * SQL Data Type: uniqueidentifier
         * * Related Entity/Foreign Key: MJ: Users (vwUsers.ID)`),
     SourceListID: z.string().nullable().describe(`
@@ -12070,7 +12532,7 @@ export const MJDuplicateRunSchema = z.object({
         * * Description: Comments or notes regarding the approval decision for this duplicate run.`),
     ApprovedByUserID: z.string().nullable().describe(`
         * * Field Name: ApprovedByUserID
-        * * Display Name: Approved By User
+        * * Display Name: Approved By
         * * SQL Data Type: uniqueidentifier
         * * Related Entity/Foreign Key: MJ: Users (vwUsers.ID)`),
     ProcessingStatus: z.union([z.literal('Complete'), z.literal('Failed'), z.literal('In Progress'), z.literal('Pending')]).describe(`
@@ -12100,9 +12562,38 @@ export const MJDuplicateRunSchema = z.object({
         * * Display Name: Updated At
         * * SQL Data Type: datetimeoffset
         * * Default Value: getutcdate()`),
+    TotalItemCount: z.number().nullable().describe(`
+        * * Field Name: TotalItemCount
+        * * Display Name: Total Item Count
+        * * SQL Data Type: int
+        * * Description: Total entity records to check for duplicates in this run.`),
+    ProcessedItemCount: z.number().nullable().describe(`
+        * * Field Name: ProcessedItemCount
+        * * Display Name: Processed Item Count
+        * * SQL Data Type: int
+        * * Default Value: 0
+        * * Description: Number of records checked so far. Used for progress percentage.`),
+    LastProcessedOffset: z.number().nullable().describe(`
+        * * Field Name: LastProcessedOffset
+        * * Display Name: Last Processed Offset
+        * * SQL Data Type: int
+        * * Default Value: 0
+        * * Description: Resume cursor for large-scale duplicate detection. Stores the offset of the last completed batch.`),
+    BatchSize: z.number().nullable().describe(`
+        * * Field Name: BatchSize
+        * * Display Name: Batch Size
+        * * SQL Data Type: int
+        * * Default Value: 100
+        * * Description: Number of records processed per batch during duplicate detection.`),
+    CancellationRequested: z.boolean().describe(`
+        * * Field Name: CancellationRequested
+        * * Display Name: Cancellation Requested
+        * * SQL Data Type: bit
+        * * Default Value: 0
+        * * Description: When set to 1, duplicate detection stops after the current batch. Used for pause/cancel.`),
     Entity: z.string().describe(`
         * * Field Name: Entity
-        * * Display Name: Entity
+        * * Display Name: Entity Name
         * * SQL Data Type: nvarchar(255)`),
     StartedByUser: z.string().describe(`
         * * Field Name: StartedByUser
@@ -12110,7 +12601,7 @@ export const MJDuplicateRunSchema = z.object({
         * * SQL Data Type: nvarchar(100)`),
     SourceList: z.string().nullable().describe(`
         * * Field Name: SourceList
-        * * Display Name: Source List
+        * * Display Name: Source List Name
         * * SQL Data Type: nvarchar(100)`),
     ApprovedByUser: z.string().nullable().describe(`
         * * Field Name: ApprovedByUser
@@ -12162,11 +12653,11 @@ export const MJEmployeeCompanyIntegrationSchema = z.object({
         * * Default Value: getutcdate()`),
     Employee: z.string().nullable().describe(`
         * * Field Name: Employee
-        * * Display Name: Employee Name
+        * * Display Name: Employee
         * * SQL Data Type: nvarchar(81)`),
     CompanyIntegration: z.string().describe(`
         * * Field Name: CompanyIntegration
-        * * Display Name: Integration Name
+        * * Display Name: Company Integration
         * * SQL Data Type: nvarchar(255)`),
 });
 
@@ -12203,11 +12694,11 @@ export const MJEmployeeRoleSchema = z.object({
         * * Default Value: getutcdate()`),
     Employee: z.string().nullable().describe(`
         * * Field Name: Employee
-        * * Display Name: Employee Name
+        * * Display Name: Employee
         * * SQL Data Type: nvarchar(81)`),
     Role: z.string().describe(`
         * * Field Name: Role
-        * * Display Name: Role Name
+        * * Display Name: Role
         * * SQL Data Type: nvarchar(50)`),
 });
 
@@ -12244,7 +12735,7 @@ export const MJEmployeeSkillSchema = z.object({
         * * Default Value: getutcdate()`),
     Employee: z.string().nullable().describe(`
         * * Field Name: Employee
-        * * Display Name: Employee Name
+        * * Display Name: Employee
         * * SQL Data Type: nvarchar(81)`),
     Skill: z.string().describe(`
         * * Field Name: Skill
@@ -12990,11 +13481,11 @@ export const MJEntityActionFilterSchema = z.object({
         * * Default Value: getutcdate()`),
     EntityAction: z.string().describe(`
         * * Field Name: EntityAction
-        * * Display Name: Entity Action Name
+        * * Display Name: Entity Action
         * * SQL Data Type: nvarchar(425)`),
     ActionFilter: z.string().describe(`
         * * Field Name: ActionFilter
-        * * Display Name: Action Filter Name
+        * * Display Name: Action Filter
         * * SQL Data Type: nvarchar(MAX)`),
 });
 
@@ -13081,11 +13572,11 @@ export const MJEntityActionInvocationSchema = z.object({
         * * Default Value: getutcdate()`),
     EntityAction: z.string().describe(`
         * * Field Name: EntityAction
-        * * Display Name: Entity Action Name
+        * * Display Name: Entity Action
         * * SQL Data Type: nvarchar(425)`),
     InvocationType: z.string().describe(`
         * * Field Name: InvocationType
-        * * Display Name: Invocation Type Name
+        * * Display Name: Invocation Type
         * * SQL Data Type: nvarchar(255)`),
 });
 
@@ -13102,7 +13593,7 @@ export const MJEntityActionParamSchema = z.object({
         * * Default Value: newsequentialid()`),
     EntityActionID: z.string().describe(`
         * * Field Name: EntityActionID
-        * * Display Name: Entity Action ID
+        * * Display Name: Entity Action
         * * SQL Data Type: uniqueidentifier
         * * Related Entity/Foreign Key: MJ: Entity Actions (vwEntityActions.ID)`),
     ActionParamID: z.string().describe(`
@@ -13349,7 +13840,7 @@ export const MJEntityCommunicationFieldSchema = z.object({
         * * Default Value: getutcdate()`),
     EntityCommunicationMessageType: z.string().describe(`
         * * Field Name: EntityCommunicationMessageType
-        * * Display Name: Message Type Name
+        * * Display Name: Entity Communication Message Type
         * * SQL Data Type: nvarchar(100)`),
 });
 
@@ -14822,22 +15313,22 @@ export const MJErrorLogSchema = z.object({
         * * Default Value: newsequentialid()`),
     CompanyIntegrationRunID: z.string().nullable().describe(`
         * * Field Name: CompanyIntegrationRunID
-        * * Display Name: Company Integration Run ID
+        * * Display Name: Company Integration Run
         * * SQL Data Type: uniqueidentifier
         * * Related Entity/Foreign Key: MJ: Company Integration Runs (vwCompanyIntegrationRuns.ID)`),
     CompanyIntegrationRunDetailID: z.string().nullable().describe(`
         * * Field Name: CompanyIntegrationRunDetailID
-        * * Display Name: Company Integration Run Detail ID
+        * * Display Name: Company Integration Run Detail
         * * SQL Data Type: uniqueidentifier
         * * Related Entity/Foreign Key: MJ: Company Integration Run Details (vwCompanyIntegrationRunDetails.ID)`),
     Code: z.string().nullable().describe(`
         * * Field Name: Code
-        * * Display Name: Error Code
+        * * Display Name: Code
         * * SQL Data Type: nchar(20)
         * * Description: Error code for categorizing and handling specific error types.`),
     Message: z.string().nullable().describe(`
         * * Field Name: Message
-        * * Display Name: Error Message
+        * * Display Name: Message
         * * SQL Data Type: nvarchar(MAX)
         * * Description: The primary error message describing what went wrong.`),
     CreatedBy: z.string().nullable().describe(`
@@ -14857,7 +15348,7 @@ export const MJErrorLogSchema = z.object({
         * * Description: High-level category for grouping related errors (Database, API, Validation, etc.).`),
     Details: z.string().nullable().describe(`
         * * Field Name: Details
-        * * Display Name: Error Details
+        * * Display Name: Details
         * * SQL Data Type: nvarchar(MAX)
         * * Description: Full error details including stack trace, inner exceptions, and context data.`),
     __mj_CreatedAt: z.date().describe(`
@@ -15857,6 +16348,66 @@ export const MJIntegrationSchema = z.object({
 export type MJIntegrationEntityType = z.infer<typeof MJIntegrationSchema>;
 
 /**
+ * zod schema definition for the entity MJ: Knowledge Hub Saved Searches
+ */
+export const MJKnowledgeHubSavedSearchSchema = z.object({
+    ID: z.string().describe(`
+        * * Field Name: ID
+        * * Display Name: ID
+        * * SQL Data Type: uniqueidentifier
+        * * Default Value: newsequentialid()`),
+    UserID: z.string().describe(`
+        * * Field Name: UserID
+        * * Display Name: User
+        * * SQL Data Type: uniqueidentifier
+        * * Related Entity/Foreign Key: MJ: Users (vwUsers.ID)`),
+    Name: z.string().describe(`
+        * * Field Name: Name
+        * * Display Name: Name
+        * * SQL Data Type: nvarchar(255)`),
+    Query: z.string().describe(`
+        * * Field Name: Query
+        * * Display Name: Query
+        * * SQL Data Type: nvarchar(1000)`),
+    Filters: z.string().nullable().describe(`
+        * * Field Name: Filters
+        * * Display Name: Filters
+        * * SQL Data Type: nvarchar(MAX)
+        * * Description: JSON object with active filter selections. Keys are filter categories (Entity, Tags), values are arrays of selected option values.`),
+    MinScore: z.number().nullable().describe(`
+        * * Field Name: MinScore
+        * * Display Name: Minimum Score
+        * * SQL Data Type: decimal(3, 2)`),
+    MaxResults: z.number().nullable().describe(`
+        * * Field Name: MaxResults
+        * * Display Name: Maximum Results
+        * * SQL Data Type: int
+        * * Default Value: 50`),
+    NotifyOnNewResults: z.boolean().describe(`
+        * * Field Name: NotifyOnNewResults
+        * * Display Name: Notify On New Results
+        * * SQL Data Type: bit
+        * * Default Value: 0
+        * * Description: When enabled, the system will notify the user when new results match this saved search (future capability).`),
+    __mj_CreatedAt: z.date().describe(`
+        * * Field Name: __mj_CreatedAt
+        * * Display Name: Created At
+        * * SQL Data Type: datetimeoffset
+        * * Default Value: getutcdate()`),
+    __mj_UpdatedAt: z.date().describe(`
+        * * Field Name: __mj_UpdatedAt
+        * * Display Name: Updated At
+        * * SQL Data Type: datetimeoffset
+        * * Default Value: getutcdate()`),
+    User: z.string().describe(`
+        * * Field Name: User
+        * * Display Name: User Name
+        * * SQL Data Type: nvarchar(100)`),
+});
+
+export type MJKnowledgeHubSavedSearchEntityType = z.infer<typeof MJKnowledgeHubSavedSearchSchema>;
+
+/**
  * zod schema definition for the entity MJ: Libraries
  */
 export const MJLibrarySchema = z.object({
@@ -16364,12 +16915,12 @@ export const MJMCPServerConnectionToolSchema = z.object({
         * * Default Value: newsequentialid()`),
     MCPServerConnectionID: z.string().describe(`
         * * Field Name: MCPServerConnectionID
-        * * Display Name: Connection
+        * * Display Name: MCP Server Connection
         * * SQL Data Type: uniqueidentifier
         * * Related Entity/Foreign Key: MJ: MCP Server Connections (vwMCPServerConnections.ID)`),
     MCPServerToolID: z.string().describe(`
         * * Field Name: MCPServerToolID
-        * * Display Name: Tool
+        * * Display Name: MCP Server Tool
         * * SQL Data Type: uniqueidentifier
         * * Related Entity/Foreign Key: MJ: MCP Server Tools (vwMCPServerTools.ID)`),
     IsEnabled: z.boolean().describe(`
@@ -16400,11 +16951,11 @@ export const MJMCPServerConnectionToolSchema = z.object({
         * * Default Value: getutcdate()`),
     MCPServerConnection: z.string().describe(`
         * * Field Name: MCPServerConnection
-        * * Display Name: Connection Name
+        * * Display Name: MCP Server Connection
         * * SQL Data Type: nvarchar(255)`),
     MCPServerTool: z.string().nullable().describe(`
         * * Field Name: MCPServerTool
-        * * Display Name: Tool Name
+        * * Display Name: MCP Server Tool
         * * SQL Data Type: nvarchar(255)`),
 });
 
@@ -16772,12 +17323,12 @@ export const MJMCPToolExecutionLogSchema = z.object({
         * * Default Value: newsequentialid()`),
     MCPServerConnectionID: z.string().describe(`
         * * Field Name: MCPServerConnectionID
-        * * Display Name: Connection ID
+        * * Display Name: MCP Server Connection
         * * SQL Data Type: uniqueidentifier
         * * Related Entity/Foreign Key: MJ: MCP Server Connections (vwMCPServerConnections.ID)`),
     MCPServerToolID: z.string().nullable().describe(`
         * * Field Name: MCPServerToolID
-        * * Display Name: Tool ID
+        * * Display Name: MCP Server Tool
         * * SQL Data Type: uniqueidentifier
         * * Related Entity/Foreign Key: MJ: MCP Server Tools (vwMCPServerTools.ID)
         * * Description: FK to MCP Server Tool (null if tool not cached)`),
@@ -16788,7 +17339,7 @@ export const MJMCPToolExecutionLogSchema = z.object({
         * * Description: Tool name (stored directly for resilience)`),
     UserID: z.string().describe(`
         * * Field Name: UserID
-        * * Display Name: User ID
+        * * Display Name: User
         * * SQL Data Type: uniqueidentifier
         * * Related Entity/Foreign Key: MJ: Users (vwUsers.ID)
         * * Description: FK to User who initiated the call`),
@@ -16843,11 +17394,11 @@ export const MJMCPToolExecutionLogSchema = z.object({
         * * Default Value: getutcdate()`),
     MCPServerConnection: z.string().describe(`
         * * Field Name: MCPServerConnection
-        * * Display Name: Connection
+        * * Display Name: MCP Server Connection
         * * SQL Data Type: nvarchar(255)`),
     MCPServerTool: z.string().nullable().describe(`
         * * Field Name: MCPServerTool
-        * * Display Name: Tool
+        * * Display Name: MCP Server Tool
         * * SQL Data Type: nvarchar(255)`),
     User: z.string().describe(`
         * * Field Name: User
@@ -18647,7 +19198,7 @@ export const MJRecommendationItemSchema = z.object({
         * * Default Value: newsequentialid()`),
     RecommendationID: z.string().describe(`
         * * Field Name: RecommendationID
-        * * Display Name: Recommendation
+        * * Display Name: Recommendation ID
         * * SQL Data Type: uniqueidentifier
         * * Related Entity/Foreign Key: MJ: Recommendations (vwRecommendations.ID)`),
     DestinationEntityID: z.string().describe(`
@@ -18948,7 +19499,7 @@ export const MJRecordChangeSchema = z.object({
         * * Description: A generated, human-readable description of what was changed.`),
     FullRecordJSON: z.string().describe(`
         * * Field Name: FullRecordJSON
-        * * Display Name: Full Record Snapshot
+        * * Display Name: Full Record JSON
         * * SQL Data Type: nvarchar(MAX)
         * * Description: A complete snapshot of the record AFTER the change was applied in a JSON format that can be parsed.`),
     Status: z.union([z.literal('Complete'), z.literal('Error'), z.literal('Pending')]).describe(`
@@ -19090,12 +19641,12 @@ export const MJRecordMergeDeletionLogSchema = z.object({
         * * Default Value: newsequentialid()`),
     RecordMergeLogID: z.string().describe(`
         * * Field Name: RecordMergeLogID
-        * * Display Name: Record Merge Log
+        * * Display Name: Record Merge Log ID
         * * SQL Data Type: uniqueidentifier
         * * Related Entity/Foreign Key: MJ: Record Merge Logs (vwRecordMergeLogs.ID)`),
     DeletedRecordID: z.string().describe(`
         * * Field Name: DeletedRecordID
-        * * Display Name: Deleted Record
+        * * Display Name: Deleted Record ID
         * * SQL Data Type: nvarchar(750)
         * * Description: Field DeletedRecordID for entity Record Merge Deletion Logs.`),
     Status: z.union([z.literal('Complete'), z.literal('Error'), z.literal('Pending')]).describe(`
@@ -19125,7 +19676,7 @@ export const MJRecordMergeDeletionLogSchema = z.object({
         * * Default Value: getutcdate()`),
     RecordMergeLog: z.string().describe(`
         * * Field Name: RecordMergeLog
-        * * Display Name: Merge Log Summary
+        * * Display Name: Record Merge Log
         * * SQL Data Type: nvarchar(450)`),
 });
 
@@ -19554,7 +20105,7 @@ export const MJReportSchema = z.object({
         * * SQL Data Type: nvarchar(255)`),
     ConversationDetail: z.string().nullable().describe(`
         * * Field Name: ConversationDetail
-        * * Display Name: Conversation Detail Name
+        * * Display Name: Conversation Detail
         * * SQL Data Type: nvarchar(MAX)`),
     DataContext: z.string().nullable().describe(`
         * * Field Name: DataContext
@@ -20525,6 +21076,133 @@ export const MJSQLDialectSchema = z.object({
 export type MJSQLDialectEntityType = z.infer<typeof MJSQLDialectSchema>;
 
 /**
+ * zod schema definition for the entity MJ: Tag Audit Logs
+ */
+export const MJTagAuditLogSchema = z.object({
+    ID: z.string().describe(`
+        * * Field Name: ID
+        * * Display Name: ID
+        * * SQL Data Type: uniqueidentifier
+        * * Default Value: newsequentialid()`),
+    TagID: z.string().describe(`
+        * * Field Name: TagID
+        * * Display Name: Tag
+        * * SQL Data Type: uniqueidentifier
+        * * Related Entity/Foreign Key: MJ: Tags (vwTags.ID)
+        * * Description: The tag that was acted upon.`),
+    Action: z.union([z.literal('Created'), z.literal('Deleted'), z.literal('Deprecated'), z.literal('DescriptionChanged'), z.literal('Merged'), z.literal('Moved'), z.literal('Reactivated'), z.literal('Renamed'), z.literal('Split')]).describe(`
+        * * Field Name: Action
+        * * Display Name: Action
+        * * SQL Data Type: nvarchar(30)
+    * * Value List Type: List
+    * * Possible Values 
+    *   * Created
+    *   * Deleted
+    *   * Deprecated
+    *   * DescriptionChanged
+    *   * Merged
+    *   * Moved
+    *   * Reactivated
+    *   * Renamed
+    *   * Split
+        * * Description: The type of action performed: Created, Renamed, Moved (parent changed), Merged (into RelatedTagID), Split (from RelatedTagID), Deprecated, Reactivated, Deleted, DescriptionChanged.`),
+    Details: z.string().nullable().describe(`
+        * * Field Name: Details
+        * * Display Name: Action Details
+        * * SQL Data Type: nvarchar(MAX)
+        * * Description: JSON object with action-specific details. For Renamed: {"OldName":"...","NewName":"..."}. For Moved: {"OldParentID":"...","NewParentID":"..."}. For Merged: {"ItemsMoved":42}.`),
+    PerformedByUserID: z.string().describe(`
+        * * Field Name: PerformedByUserID
+        * * Display Name: Performed By User
+        * * SQL Data Type: uniqueidentifier
+        * * Related Entity/Foreign Key: MJ: Users (vwUsers.ID)
+        * * Description: User who performed the action.`),
+    RelatedTagID: z.string().nullable().describe(`
+        * * Field Name: RelatedTagID
+        * * Display Name: Related Tag
+        * * SQL Data Type: uniqueidentifier
+        * * Related Entity/Foreign Key: MJ: Tags (vwTags.ID)
+        * * Description: For Merged actions: the surviving tag. For Split actions: the source tag. NULL for other actions.`),
+    __mj_CreatedAt: z.date().describe(`
+        * * Field Name: __mj_CreatedAt
+        * * Display Name: Created At
+        * * SQL Data Type: datetimeoffset
+        * * Default Value: getutcdate()`),
+    __mj_UpdatedAt: z.date().describe(`
+        * * Field Name: __mj_UpdatedAt
+        * * Display Name: Updated At
+        * * SQL Data Type: datetimeoffset
+        * * Default Value: getutcdate()`),
+    Tag: z.string().describe(`
+        * * Field Name: Tag
+        * * Display Name: Tag Name
+        * * SQL Data Type: nvarchar(255)`),
+    PerformedByUser: z.string().describe(`
+        * * Field Name: PerformedByUser
+        * * Display Name: User Name
+        * * SQL Data Type: nvarchar(100)`),
+    RelatedTag: z.string().nullable().describe(`
+        * * Field Name: RelatedTag
+        * * Display Name: Related Tag Name
+        * * SQL Data Type: nvarchar(255)`),
+});
+
+export type MJTagAuditLogEntityType = z.infer<typeof MJTagAuditLogSchema>;
+
+/**
+ * zod schema definition for the entity MJ: Tag Co Occurrences
+ */
+export const MJTagCoOccurrenceSchema = z.object({
+    ID: z.string().describe(`
+        * * Field Name: ID
+        * * Display Name: ID
+        * * SQL Data Type: uniqueidentifier
+        * * Default Value: newsequentialid()`),
+    TagAID: z.string().describe(`
+        * * Field Name: TagAID
+        * * Display Name: Tag A ID
+        * * SQL Data Type: uniqueidentifier
+        * * Related Entity/Foreign Key: MJ: Tags (vwTags.ID)
+        * * Description: First tag in the canonical pair (TagAID < TagBID ensures each pair is stored exactly once).`),
+    TagBID: z.string().describe(`
+        * * Field Name: TagBID
+        * * Display Name: Tag B ID
+        * * SQL Data Type: uniqueidentifier
+        * * Related Entity/Foreign Key: MJ: Tags (vwTags.ID)`),
+    CoOccurrenceCount: z.number().describe(`
+        * * Field Name: CoOccurrenceCount
+        * * Display Name: Co-Occurrence Count
+        * * SQL Data Type: int
+        * * Default Value: 0
+        * * Description: Number of content items (or entity records via TaggedItem) that are tagged with both TagA and TagB.`),
+    LastComputedAt: z.date().describe(`
+        * * Field Name: LastComputedAt
+        * * Display Name: Last Computed At
+        * * SQL Data Type: datetimeoffset
+        * * Default Value: getutcdate()`),
+    __mj_CreatedAt: z.date().describe(`
+        * * Field Name: __mj_CreatedAt
+        * * Display Name: Created At
+        * * SQL Data Type: datetimeoffset
+        * * Default Value: getutcdate()`),
+    __mj_UpdatedAt: z.date().describe(`
+        * * Field Name: __mj_UpdatedAt
+        * * Display Name: Updated At
+        * * SQL Data Type: datetimeoffset
+        * * Default Value: getutcdate()`),
+    TagA: z.string().describe(`
+        * * Field Name: TagA
+        * * Display Name: Tag A
+        * * SQL Data Type: nvarchar(255)`),
+    TagB: z.string().describe(`
+        * * Field Name: TagB
+        * * Display Name: Tag B
+        * * SQL Data Type: nvarchar(255)`),
+});
+
+export type MJTagCoOccurrenceEntityType = z.infer<typeof MJTagCoOccurrenceSchema>;
+
+/**
  * zod schema definition for the entity MJ: Tagged Items
  */
 export const MJTaggedItemSchema = z.object({
@@ -20558,6 +21236,12 @@ export const MJTaggedItemSchema = z.object({
         * * Display Name: Updated At
         * * SQL Data Type: datetimeoffset
         * * Default Value: getutcdate()`),
+    Weight: z.number().describe(`
+        * * Field Name: Weight
+        * * Display Name: Weight
+        * * SQL Data Type: numeric(5, 4)
+        * * Default Value: 1.0
+        * * Description: Relevance weight of this tag association (0.0 to 1.0). 1.0 indicates the tag is highly relevant or was manually applied. Lower values indicate decreasing relevance as determined by LLM autotagging. Default 1.0 for manually applied tags.`),
     Tag: z.string().describe(`
         * * Field Name: Tag
         * * Display Name: Tag
@@ -20585,7 +21269,7 @@ export const MJTagSchema = z.object({
         * * SQL Data Type: nvarchar(255)`),
     ParentID: z.string().nullable().describe(`
         * * Field Name: ParentID
-        * * Display Name: Parent ID
+        * * Display Name: Parent
         * * SQL Data Type: uniqueidentifier
         * * Related Entity/Foreign Key: MJ: Tags (vwTags.ID)`),
     DisplayName: z.string().describe(`
@@ -20607,13 +21291,39 @@ export const MJTagSchema = z.object({
         * * Display Name: Updated At
         * * SQL Data Type: datetimeoffset
         * * Default Value: getutcdate()`),
+    Status: z.union([z.literal('Active'), z.literal('Deleted'), z.literal('Deprecated'), z.literal('Merged')]).describe(`
+        * * Field Name: Status
+        * * Display Name: Status
+        * * SQL Data Type: nvarchar(20)
+        * * Default Value: Active
+    * * Value List Type: List
+    * * Possible Values 
+    *   * Active
+    *   * Deleted
+    *   * Deprecated
+    *   * Merged
+        * * Description: Lifecycle status of the tag: Active (in use), Merged (consolidated into another tag), Deprecated (no longer assigned but preserved), Deleted (soft-deleted).`),
+    MergedIntoTagID: z.string().nullable().describe(`
+        * * Field Name: MergedIntoTagID
+        * * Display Name: Merged Into Tag
+        * * SQL Data Type: uniqueidentifier
+        * * Related Entity/Foreign Key: MJ: Tags (vwTags.ID)
+        * * Description: When Status is Merged, points to the surviving tag this tag was merged into. All TaggedItem and ContentItemTag references are re-pointed during merge.`),
     Parent: z.string().nullable().describe(`
         * * Field Name: Parent
-        * * Display Name: Parent
+        * * Display Name: Parent Name
+        * * SQL Data Type: nvarchar(255)`),
+    MergedIntoTag: z.string().nullable().describe(`
+        * * Field Name: MergedIntoTag
+        * * Display Name: Merged Into Tag Name
         * * SQL Data Type: nvarchar(255)`),
     RootParentID: z.string().nullable().describe(`
         * * Field Name: RootParentID
-        * * Display Name: Root Parent ID
+        * * Display Name: Root Parent
+        * * SQL Data Type: uniqueidentifier`),
+    RootMergedIntoTagID: z.string().nullable().describe(`
+        * * Field Name: RootMergedIntoTagID
+        * * Display Name: Root Merged Into Tag
         * * SQL Data Type: uniqueidentifier`),
 });
 
@@ -20823,7 +21533,7 @@ export const MJTaskSchema = z.object({
         * * SQL Data Type: nvarchar(255)`),
     ConversationDetail: z.string().nullable().describe(`
         * * Field Name: ConversationDetail
-        * * Display Name: Conversation Detail Name
+        * * Display Name: Conversation Detail
         * * SQL Data Type: nvarchar(MAX)`),
     User: z.string().nullable().describe(`
         * * Field Name: User
@@ -21046,7 +21756,7 @@ export const MJTemplateParamSchema = z.object({
         * * Description: Default value of the parameter`),
     IsRequired: z.boolean().describe(`
         * * Field Name: IsRequired
-        * * Display Name: Required
+        * * Display Name: Is Required
         * * SQL Data Type: bit
         * * Default Value: 0
         * * Description: Whether this parameter must be provided when using the template.`),
@@ -21072,7 +21782,7 @@ export const MJTemplateParamSchema = z.object({
         * * Related Entity/Foreign Key: MJ: Entities (vwEntities.ID)`),
     RecordID: z.string().nullable().describe(`
         * * Field Name: RecordID
-        * * Display Name: Record ID
+        * * Display Name: Record
         * * SQL Data Type: nvarchar(2000)
         * * Description: Record ID, used only when Type is Record and a specific hardcoded record ID is desired, this is an uncommon use case, helpful for pulling in static types and metadata in some cases.`),
     __mj_CreatedAt: z.date().describe(`
@@ -21098,15 +21808,15 @@ export const MJTemplateParamSchema = z.object({
         * * Description: Optional reference to a specific template content. When NULL, this parameter applies to all content items within the template. When set, this parameter applies only to the specified template content.`),
     Template: z.string().describe(`
         * * Field Name: Template
-        * * Display Name: Template Name
+        * * Display Name: Template
         * * SQL Data Type: nvarchar(255)`),
     Entity: z.string().nullable().describe(`
         * * Field Name: Entity
-        * * Display Name: Entity Name
+        * * Display Name: Entity
         * * SQL Data Type: nvarchar(255)`),
     TemplateContent: z.string().nullable().describe(`
         * * Field Name: TemplateContent
-        * * Display Name: Template Content Name
+        * * Display Name: Template Content
         * * SQL Data Type: nvarchar(255)`),
 });
 
@@ -22863,15 +23573,17 @@ export const MJUserViewSchema = z.object({
         * * SQL Data Type: bit
         * * Default Value: 0
         * * Description: Whether this is the user's default view for the entity.`),
-    GridState: z.string().nullable().describe(`
+    GridState: z.any().nullable().describe(`
         * * Field Name: GridState
         * * Display Name: Grid State
         * * SQL Data Type: nvarchar(MAX)
+        * * JSON Type: MJUserViewEntity_IGridState
         * * Description: JSON storing complete grid configuration including columns, widths, and formatting.`),
-    FilterState: z.string().nullable().describe(`
+    FilterState: z.any().nullable().describe(`
         * * Field Name: FilterState
         * * Display Name: Filter State
         * * SQL Data Type: nvarchar(MAX)
+        * * JSON Type: MJUserViewEntity_IFilterState
         * * Description: JSON storing the view's filter configuration.`),
     CustomFilterState: z.boolean().describe(`
         * * Field Name: CustomFilterState
@@ -22911,10 +23623,11 @@ export const MJUserViewSchema = z.object({
         * * SQL Data Type: bit
         * * Default Value: 0
         * * Description: Indicates if a custom WHERE clause is used instead of standard filters.`),
-    SortState: z.string().nullable().describe(`
+    SortState: z.any().nullable().describe(`
         * * Field Name: SortState
         * * Display Name: Sort State
         * * SQL Data Type: nvarchar(MAX)
+        * * JSON Type: Array<MJUserViewEntity_ISortStateItem>
         * * Description: JSON storing the view's sort configuration.`),
     __mj_CreatedAt: z.date().describe(`
         * * Field Name: __mj_CreatedAt
@@ -22931,15 +23644,17 @@ export const MJUserViewSchema = z.object({
         * * Display Name: Thumbnail
         * * SQL Data Type: nvarchar(MAX)
         * * Description: Thumbnail image for the user view that can be displayed in gallery views. Can contain either a URL to an image file or a Base64-encoded image string.`),
-    CardState: z.string().nullable().describe(`
+    CardState: z.any().nullable().describe(`
         * * Field Name: CardState
         * * Display Name: Card State
         * * SQL Data Type: nvarchar(MAX)
+        * * JSON Type: MJUserViewEntity_ICardState
         * * Description: JSON configuration for card display mode in Data Explorer. Stores card layout settings including title field, subtitle, display fields, thumbnails, and layout density. When null, defaults are derived from entity metadata. See CardState interface in packages/Angular/Generic/entity-viewer/src/lib/types.ts for the current schema definition.`),
-    DisplayState: z.string().nullable().describe(`
+    DisplayState: z.any().nullable().describe(`
         * * Field Name: DisplayState
         * * Display Name: Display State
         * * SQL Data Type: nvarchar(MAX)
+        * * JSON Type: MJUserViewEntity_IDisplayState
         * * Description: JSON configuration for display mode settings. Stores default display mode (grid/cards/timeline/chart), available modes for sharing, and mode-specific configurations like timeline date field and segmentation. See ViewDisplayState interface in packages/Angular/Generic/entity-viewer/src/lib/types.ts for schema.`),
     UserName: z.string().describe(`
         * * Field Name: UserName
@@ -26475,7 +27190,7 @@ export class MJAIAgentCategoryEntity extends BaseEntity<MJAIAgentCategoryEntityT
 
     /**
     * * Field Name: ParentID
-    * * Display Name: Parent
+    * * Display Name: Parent ID
     * * SQL Data Type: uniqueidentifier
     * * Related Entity/Foreign Key: MJ: AI Agent Categories (vwAIAgentCategories.ID)
     * * Description: Self-referencing foreign key to the parent category, forming a tree hierarchy. NULL for root categories.
@@ -26540,6 +27255,20 @@ export class MJAIAgentCategoryEntity extends BaseEntity<MJAIAgentCategoryEntityT
     }
 
     /**
+    * * Field Name: DefaultStorageAccountID
+    * * Display Name: Default Storage Account
+    * * SQL Data Type: uniqueidentifier
+    * * Related Entity/Foreign Key: MJ: File Storage Accounts (vwFileStorageAccounts.ID)
+    * * Description: Default file storage account for agents in this category. Inherited by child categories that do not define their own value — resolution walks up the ParentID tree until a non-null value is found. Overrides the Type-level default. FK to FileStorageAccount.
+    */
+    get DefaultStorageAccountID(): string | null {
+        return this.Get('DefaultStorageAccountID');
+    }
+    set DefaultStorageAccountID(value: string | null) {
+        this.Set('DefaultStorageAccountID', value);
+    }
+
+    /**
     * * Field Name: Parent
     * * Display Name: Parent Name
     * * SQL Data Type: nvarchar(200)
@@ -26549,8 +27278,17 @@ export class MJAIAgentCategoryEntity extends BaseEntity<MJAIAgentCategoryEntityT
     }
 
     /**
+    * * Field Name: DefaultStorageAccount
+    * * Display Name: Default Storage Account Name
+    * * SQL Data Type: nvarchar(200)
+    */
+    get DefaultStorageAccount(): string | null {
+        return this.Get('DefaultStorageAccount');
+    }
+
+    /**
     * * Field Name: RootParentID
-    * * Display Name: Root Parent
+    * * Display Name: Root Parent ID
     * * SQL Data Type: uniqueidentifier
     */
     get RootParentID(): string | null {
@@ -30700,7 +31438,7 @@ export class MJAIAgentRunStepEntity extends BaseEntity<MJAIAgentRunStepEntityTyp
 
     /**
     * * Field Name: FinalPayloadValidationResult
-    * * Display Name: Validation Result
+    * * Display Name: Final Payload Validation Result
     * * SQL Data Type: nvarchar(25)
     * * Value List Type: List
     * * Possible Values 
@@ -30725,7 +31463,7 @@ permanently, Warn means validation failed but execution continues.
 
     /**
     * * Field Name: FinalPayloadValidationMessages
-    * * Display Name: Validation Messages
+    * * Display Name: Final Payload Validation Messages
     * * SQL Data Type: nvarchar(MAX)
     * * Description: Validation error messages or warnings from final payload validation. Contains
 detailed information about what validation rules failed.
@@ -30739,7 +31477,7 @@ detailed information about what validation rules failed.
 
     /**
     * * Field Name: ParentID
-    * * Display Name: Parent Step
+    * * Display Name: Parent
     * * SQL Data Type: uniqueidentifier
     * * Related Entity/Foreign Key: MJ: AI Agent Run Steps (vwAIAgentRunSteps.ID)
     * * Description: Optional reference to parent step for tracking hierarchical relationships like code->test->fix->code cycles
@@ -30775,7 +31513,7 @@ detailed information about what validation rules failed.
 
     /**
     * * Field Name: Parent
-    * * Display Name: Parent Step
+    * * Display Name: Parent
     * * SQL Data Type: nvarchar(255)
     */
     get Parent(): string | null {
@@ -30784,7 +31522,7 @@ detailed information about what validation rules failed.
 
     /**
     * * Field Name: RootParentID
-    * * Display Name: Root Parent Step
+    * * Display Name: Root Parent
     * * SQL Data Type: uniqueidentifier
     */
     get RootParentID(): string | null {
@@ -32492,7 +33230,7 @@ export class MJAIAgentTypeEntity extends BaseEntity<MJAIAgentTypeEntityType> {
 
     /**
     * * Field Name: PromptParamsSchema
-    * * Display Name: Prompt Parameters Schema
+    * * Display Name: Prompt Params Schema
     * * SQL Data Type: nvarchar(MAX)
     * * Description: JSON Schema defining the available prompt parameters for this agent type. Includes property definitions with types, defaults, and descriptions. Used by agents of this type to customize which prompt sections are included in the system prompt. The schema follows JSON Schema draft-07 format.
     */
@@ -32517,12 +33255,35 @@ export class MJAIAgentTypeEntity extends BaseEntity<MJAIAgentTypeEntityType> {
     }
 
     /**
+    * * Field Name: DefaultStorageAccountID
+    * * Display Name: Default Storage Account ID
+    * * SQL Data Type: uniqueidentifier
+    * * Related Entity/Foreign Key: MJ: File Storage Accounts (vwFileStorageAccounts.ID)
+    * * Description: Default file storage account for agents of this type. Lowest priority in the resolution chain (Type → Category tree → Agent → Runtime override). When set, all agents of this type use this storage account unless overridden at a more specific level. FK to FileStorageAccount.
+    */
+    get DefaultStorageAccountID(): string | null {
+        return this.Get('DefaultStorageAccountID');
+    }
+    set DefaultStorageAccountID(value: string | null) {
+        this.Set('DefaultStorageAccountID', value);
+    }
+
+    /**
     * * Field Name: SystemPrompt
-    * * Display Name: System Prompt Text
+    * * Display Name: System Prompt
     * * SQL Data Type: nvarchar(255)
     */
     get SystemPrompt(): string | null {
         return this.Get('SystemPrompt');
+    }
+
+    /**
+    * * Field Name: DefaultStorageAccount
+    * * Display Name: Default Storage Account
+    * * SQL Data Type: nvarchar(200)
+    */
+    get DefaultStorageAccount(): string | null {
+        return this.Get('DefaultStorageAccount');
     }
 }
 
@@ -32863,7 +33624,7 @@ export class MJAIAgentEntity extends BaseEntity<MJAIAgentEntityType> {
 
     /**
     * * Field Name: ContextCompressionMessageThreshold
-    * * Display Name: Compression Message Threshold
+    * * Display Name: Context Compression Message Threshold
     * * SQL Data Type: int
     * * Description: Number of messages that triggers context compression when EnableContextCompression is true.
     */
@@ -32876,7 +33637,7 @@ export class MJAIAgentEntity extends BaseEntity<MJAIAgentEntityType> {
 
     /**
     * * Field Name: ContextCompressionPromptID
-    * * Display Name: Compression Prompt
+    * * Display Name: Context Compression Prompt
     * * SQL Data Type: uniqueidentifier
     * * Related Entity/Foreign Key: MJ: AI Prompts (vwAIPrompts.ID)
     */
@@ -32889,7 +33650,7 @@ export class MJAIAgentEntity extends BaseEntity<MJAIAgentEntityType> {
 
     /**
     * * Field Name: ContextCompressionMessageRetentionCount
-    * * Display Name: Compression Message Retention Count
+    * * Display Name: Context Compression Message Retention Count
     * * SQL Data Type: int
     * * Description: Number of recent messages to keep uncompressed when context compression is applied.
     */
@@ -32902,7 +33663,7 @@ export class MJAIAgentEntity extends BaseEntity<MJAIAgentEntityType> {
 
     /**
     * * Field Name: TypeID
-    * * Display Name: Type
+    * * Display Name: Agent Type
     * * SQL Data Type: uniqueidentifier
     * * Related Entity/Foreign Key: MJ: AI Agent Types (vwAIAgentTypes.ID)
     * * Description: Reference to the AIAgentType that defines the category and system-level behavior for this agent. Cannot be null.
@@ -33621,6 +34382,20 @@ if this limit is exceeded.
     }
 
     /**
+    * * Field Name: DefaultStorageAccountID
+    * * Display Name: Default Storage Account ID
+    * * SQL Data Type: uniqueidentifier
+    * * Related Entity/Foreign Key: MJ: File Storage Accounts (vwFileStorageAccounts.ID)
+    * * Description: Default file storage account for this specific agent. Overrides both Type-level and Category-level defaults. Can be further overridden at runtime via ExecuteAgentParams.override.storageAccountId. FK to FileStorageAccount.
+    */
+    get DefaultStorageAccountID(): string | null {
+        return this.Get('DefaultStorageAccountID');
+    }
+    set DefaultStorageAccountID(value: string | null) {
+        this.Set('DefaultStorageAccountID', value);
+    }
+
+    /**
     * * Field Name: Parent
     * * Display Name: Parent Name
     * * SQL Data Type: nvarchar(255)
@@ -33681,6 +34456,15 @@ if this limit is exceeded.
     */
     get Category(): string | null {
         return this.Get('Category');
+    }
+
+    /**
+    * * Field Name: DefaultStorageAccount
+    * * Display Name: Default Storage Account
+    * * SQL Data Type: nvarchar(200)
+    */
+    get DefaultStorageAccount(): string | null {
+        return this.Get('DefaultStorageAccount');
     }
 
     /**
@@ -42425,6 +43209,20 @@ export class MJApplicationSettingEntity extends BaseEntity<MJApplicationSettingE
 }
 
 
+/**
+ * Describes a single navigation item in an Application's default tab bar.
+ *
+ * Stored as a JSON array in the `DefaultNavItems` column of the `Applications` entity.
+ * CodeGen emits a strongly-typed `DefaultNavItemsObject` accessor on `ApplicationEntity`
+ * that returns `MJApplicationEntity_IDefaultNavItem[]`.
+ *
+ * When a user opens an application for the first time (or has no saved state),
+ * `BaseApplication.GetNavItems()` parses this array to create the initial set of tabs.
+ * Each item maps to either a persisted Dashboard (via `RecordID`) or a custom component
+ * registered with `@RegisterClass(BaseResourceComponent, DriverClass)`.
+ *
+ * Exactly one item should have `isDefault: true` to indicate which tab is focused on load.
+ */
 export interface MJApplicationEntity_IDefaultNavItem {
     /** Display label for the navigation item */
     Label: string;
@@ -42601,7 +43399,7 @@ export class MJApplicationEntity extends BaseEntity<MJApplicationEntityType> {
     * Uses lazy parsing with cache invalidation when the underlying raw value changes.
     */
     get DefaultNavItemsObject(): Array<MJApplicationEntity_IDefaultNavItem> | null {
-        const raw = this.Get('DefaultNavItems');
+        const raw = this.DefaultNavItems;
         if (raw !== this._DefaultNavItemsObject_lastRaw) {
             this._DefaultNavItemsObject_cached = raw ? JSON.parse(raw) : null;
             this._DefaultNavItemsObject_lastRaw = raw;
@@ -42610,7 +43408,7 @@ export class MJApplicationEntity extends BaseEntity<MJApplicationEntityType> {
     }
     set DefaultNavItemsObject(value: Array<MJApplicationEntity_IDefaultNavItem> | null) {
         const raw = value ? JSON.stringify(value) : null;
-        this.Set('DefaultNavItems', raw);
+        this.DefaultNavItems = raw;
         this._DefaultNavItemsObject_cached = value;
         this._DefaultNavItemsObject_lastRaw = raw;
     }
@@ -49179,6 +49977,221 @@ export class MJContentItemAttributeEntity extends BaseEntity<MJContentItemAttrib
 
 
 /**
+ * MJ: Content Item Duplicates - strongly typed entity sub-class
+ * * Schema: __mj
+ * * Base Table: ContentItemDuplicate
+ * * Base View: vwContentItemDuplicates
+ * * @description Detected duplicate or near-duplicate content items across sources. Each row represents a pair of items with similarity scoring and resolution tracking.
+ * * Primary Key: ID
+ * @extends {BaseEntity}
+ * @class
+ * @public
+ */
+@RegisterClass(BaseEntity, 'MJ: Content Item Duplicates')
+export class MJContentItemDuplicateEntity extends BaseEntity<MJContentItemDuplicateEntityType> {
+    /**
+    * Loads the MJ: Content Item Duplicates record from the database
+    * @param ID: string - primary key value to load the MJ: Content Item Duplicates record.
+    * @param EntityRelationshipsToLoad - (optional) the relationships to load
+    * @returns {Promise<boolean>} - true if successful, false otherwise
+    * @public
+    * @async
+    * @memberof MJContentItemDuplicateEntity
+    * @method
+    * @override
+    */
+    public async Load(ID: string, EntityRelationshipsToLoad?: string[]) : Promise<boolean> {
+        const compositeKey: CompositeKey = new CompositeKey();
+        compositeKey.KeyValuePairs.push({ FieldName: 'ID', Value: ID });
+        return await super.InnerLoad(compositeKey, EntityRelationshipsToLoad);
+    }
+
+    /**
+    * * Field Name: ID
+    * * Display Name: ID
+    * * SQL Data Type: uniqueidentifier
+    * * Default Value: newsequentialid()
+    */
+    get ID(): string {
+        return this.Get('ID');
+    }
+    set ID(value: string) {
+        this.Set('ID', value);
+    }
+
+    /**
+    * * Field Name: ContentItemAID
+    * * Display Name: Content Item A ID
+    * * SQL Data Type: uniqueidentifier
+    * * Related Entity/Foreign Key: MJ: Content Items (vwContentItems.ID)
+    */
+    get ContentItemAID(): string {
+        return this.Get('ContentItemAID');
+    }
+    set ContentItemAID(value: string) {
+        this.Set('ContentItemAID', value);
+    }
+
+    /**
+    * * Field Name: ContentItemBID
+    * * Display Name: Content Item B ID
+    * * SQL Data Type: uniqueidentifier
+    * * Related Entity/Foreign Key: MJ: Content Items (vwContentItems.ID)
+    */
+    get ContentItemBID(): string {
+        return this.Get('ContentItemBID');
+    }
+    set ContentItemBID(value: string) {
+        this.Set('ContentItemBID', value);
+    }
+
+    /**
+    * * Field Name: SimilarityScore
+    * * Display Name: Similarity Score
+    * * SQL Data Type: decimal(5, 4)
+    * * Description: Cosine similarity (for Vector) or exact match score (1.0 for Checksum/URL). Range 0.0-1.0.
+    */
+    get SimilarityScore(): number {
+        return this.Get('SimilarityScore');
+    }
+    set SimilarityScore(value: number) {
+        this.Set('SimilarityScore', value);
+    }
+
+    /**
+    * * Field Name: DetectionMethod
+    * * Display Name: Detection Method
+    * * SQL Data Type: nvarchar(30)
+    * * Default Value: Checksum
+    * * Value List Type: List
+    * * Possible Values 
+    *   * Checksum
+    *   * Title
+    *   * URL
+    *   * Vector
+    * * Description: How the duplicate was detected: Checksum (identical text hash), Vector (embedding similarity), Title (same title text), URL (same source URL).
+    */
+    get DetectionMethod(): 'Checksum' | 'Title' | 'URL' | 'Vector' {
+        return this.Get('DetectionMethod');
+    }
+    set DetectionMethod(value: 'Checksum' | 'Title' | 'URL' | 'Vector') {
+        this.Set('DetectionMethod', value);
+    }
+
+    /**
+    * * Field Name: Status
+    * * Display Name: Status
+    * * SQL Data Type: nvarchar(20)
+    * * Default Value: Pending
+    * * Value List Type: List
+    * * Possible Values 
+    *   * Confirmed
+    *   * Dismissed
+    *   * Merged
+    *   * Pending
+    * * Description: Current status: Pending (awaiting review), Confirmed (verified duplicate), Dismissed (not a duplicate), Merged (one item was removed).
+    */
+    get Status(): 'Confirmed' | 'Dismissed' | 'Merged' | 'Pending' {
+        return this.Get('Status');
+    }
+    set Status(value: 'Confirmed' | 'Dismissed' | 'Merged' | 'Pending') {
+        this.Set('Status', value);
+    }
+
+    /**
+    * * Field Name: ResolvedByUserID
+    * * Display Name: Resolved By User ID
+    * * SQL Data Type: uniqueidentifier
+    * * Related Entity/Foreign Key: MJ: Users (vwUsers.ID)
+    */
+    get ResolvedByUserID(): string | null {
+        return this.Get('ResolvedByUserID');
+    }
+    set ResolvedByUserID(value: string | null) {
+        this.Set('ResolvedByUserID', value);
+    }
+
+    /**
+    * * Field Name: ResolvedAt
+    * * Display Name: Resolved At
+    * * SQL Data Type: datetimeoffset
+    */
+    get ResolvedAt(): Date | null {
+        return this.Get('ResolvedAt');
+    }
+    set ResolvedAt(value: Date | null) {
+        this.Set('ResolvedAt', value);
+    }
+
+    /**
+    * * Field Name: Resolution
+    * * Display Name: Resolution
+    * * SQL Data Type: nvarchar(20)
+    * * Value List Type: List
+    * * Possible Values 
+    *   * KeepA
+    *   * KeepB
+    *   * MergeBoth
+    *   * NotDuplicate
+    * * Description: How the duplicate was resolved: KeepA (keep first, remove second), KeepB (keep second, remove first), MergeBoth (combine into one), NotDuplicate (false positive).
+    */
+    get Resolution(): 'KeepA' | 'KeepB' | 'MergeBoth' | 'NotDuplicate' | null {
+        return this.Get('Resolution');
+    }
+    set Resolution(value: 'KeepA' | 'KeepB' | 'MergeBoth' | 'NotDuplicate' | null) {
+        this.Set('Resolution', value);
+    }
+
+    /**
+    * * Field Name: __mj_CreatedAt
+    * * Display Name: Created At
+    * * SQL Data Type: datetimeoffset
+    * * Default Value: getutcdate()
+    */
+    get __mj_CreatedAt(): Date {
+        return this.Get('__mj_CreatedAt');
+    }
+
+    /**
+    * * Field Name: __mj_UpdatedAt
+    * * Display Name: Updated At
+    * * SQL Data Type: datetimeoffset
+    * * Default Value: getutcdate()
+    */
+    get __mj_UpdatedAt(): Date {
+        return this.Get('__mj_UpdatedAt');
+    }
+
+    /**
+    * * Field Name: ContentItemA
+    * * Display Name: Content Item A
+    * * SQL Data Type: nvarchar(250)
+    */
+    get ContentItemA(): string | null {
+        return this.Get('ContentItemA');
+    }
+
+    /**
+    * * Field Name: ContentItemB
+    * * Display Name: Content Item B
+    * * SQL Data Type: nvarchar(250)
+    */
+    get ContentItemB(): string | null {
+        return this.Get('ContentItemB');
+    }
+
+    /**
+    * * Field Name: ResolvedByUser
+    * * Display Name: Resolved By User
+    * * SQL Data Type: nvarchar(100)
+    */
+    get ResolvedByUser(): string | null {
+        return this.Get('ResolvedByUser');
+    }
+}
+
+
+/**
  * MJ: Content Item Tags - strongly typed entity sub-class
  * * Schema: __mj
  * * Base Table: ContentItemTag
@@ -49223,7 +50236,7 @@ export class MJContentItemTagEntity extends BaseEntity<MJContentItemTagEntityTyp
 
     /**
     * * Field Name: ItemID
-    * * Display Name: Item ID
+    * * Display Name: Item
     * * SQL Data Type: uniqueidentifier
     * * Related Entity/Foreign Key: MJ: Content Items (vwContentItems.ID)
     */
@@ -49282,12 +50295,35 @@ export class MJContentItemTagEntity extends BaseEntity<MJContentItemTagEntityTyp
     }
 
     /**
+    * * Field Name: TagID
+    * * Display Name: Tag Reference
+    * * SQL Data Type: uniqueidentifier
+    * * Related Entity/Foreign Key: MJ: Tags (vwTags.ID)
+    * * Description: Optional link to the formal MJ Tag taxonomy. When set, this free-text tag has been matched (via semantic similarity or exact match) to a curated Tag record. NULL means the tag is unmatched free text only.
+    */
+    get TagID(): string | null {
+        return this.Get('TagID');
+    }
+    set TagID(value: string | null) {
+        this.Set('TagID', value);
+    }
+
+    /**
     * * Field Name: Item
-    * * Display Name: Item
+    * * Display Name: Item Name
     * * SQL Data Type: nvarchar(250)
     */
     get Item(): string | null {
         return this.Get('Item');
+    }
+
+    /**
+    * * Field Name: Tag_Virtual
+    * * Display Name: Tag (Virtual)
+    * * SQL Data Type: nvarchar(255)
+    */
+    get Tag_Virtual(): string | null {
+        return this.Get('Tag_Virtual');
     }
 }
 
@@ -49471,6 +50507,102 @@ export class MJContentItemEntity extends BaseEntity<MJContentItemEntityType> {
     }
 
     /**
+    * * Field Name: EntityRecordDocumentID
+    * * Display Name: Entity Record Document ID
+    * * SQL Data Type: uniqueidentifier
+    * * Related Entity/Foreign Key: MJ: Entity Record Documents (vwEntityRecordDocuments.ID)
+    * * Description: For entity-sourced content items, links to the Entity Record Document snapshot that was rendered for this item. Provides traceability back to the source entity record via ERD.EntityID + ERD.RecordID. NULL for non-entity sources.
+    */
+    get EntityRecordDocumentID(): string | null {
+        return this.Get('EntityRecordDocumentID');
+    }
+    set EntityRecordDocumentID(value: string | null) {
+        this.Set('EntityRecordDocumentID', value);
+    }
+
+    /**
+    * * Field Name: EmbeddingStatus
+    * * Display Name: Embedding Status
+    * * SQL Data Type: nvarchar(20)
+    * * Default Value: Pending
+    * * Value List Type: List
+    * * Possible Values 
+    *   * Complete
+    *   * Failed
+    *   * Pending
+    *   * Processing
+    *   * Skipped
+    * * Description: Vectorization status: Pending (not yet embedded), Processing (currently being embedded), Complete (vector stored), Failed (embedding error), Skipped (excluded from vectorization).
+    */
+    get EmbeddingStatus(): 'Complete' | 'Failed' | 'Pending' | 'Processing' | 'Skipped' {
+        return this.Get('EmbeddingStatus');
+    }
+    set EmbeddingStatus(value: 'Complete' | 'Failed' | 'Pending' | 'Processing' | 'Skipped') {
+        this.Set('EmbeddingStatus', value);
+    }
+
+    /**
+    * * Field Name: LastEmbeddedAt
+    * * Display Name: Last Embedded At
+    * * SQL Data Type: datetimeoffset
+    * * Description: Timestamp of the most recent successful embedding for this content item.
+    */
+    get LastEmbeddedAt(): Date | null {
+        return this.Get('LastEmbeddedAt');
+    }
+    set LastEmbeddedAt(value: Date | null) {
+        this.Set('LastEmbeddedAt', value);
+    }
+
+    /**
+    * * Field Name: EmbeddingModelID
+    * * Display Name: Embedding Model ID
+    * * SQL Data Type: uniqueidentifier
+    * * Related Entity/Foreign Key: MJ: AI Models (vwAIModels.ID)
+    * * Description: The AI model used to generate the most recent embedding for this content item.
+    */
+    get EmbeddingModelID(): string | null {
+        return this.Get('EmbeddingModelID');
+    }
+    set EmbeddingModelID(value: string | null) {
+        this.Set('EmbeddingModelID', value);
+    }
+
+    /**
+    * * Field Name: TaggingStatus
+    * * Display Name: Tagging Status
+    * * SQL Data Type: nvarchar(20)
+    * * Default Value: Pending
+    * * Value List Type: List
+    * * Possible Values 
+    *   * Complete
+    *   * Failed
+    *   * Pending
+    *   * Processing
+    *   * Skipped
+    * * Description: Autotagging status: Pending (not yet tagged), Processing (LLM is generating tags), Complete (tags assigned), Failed (LLM error), Skipped (excluded from tagging).
+    */
+    get TaggingStatus(): 'Complete' | 'Failed' | 'Pending' | 'Processing' | 'Skipped' {
+        return this.Get('TaggingStatus');
+    }
+    set TaggingStatus(value: 'Complete' | 'Failed' | 'Pending' | 'Processing' | 'Skipped') {
+        this.Set('TaggingStatus', value);
+    }
+
+    /**
+    * * Field Name: LastTaggedAt
+    * * Display Name: Last Tagged At
+    * * SQL Data Type: datetimeoffset
+    * * Description: Timestamp of the most recent successful autotagging run for this content item.
+    */
+    get LastTaggedAt(): Date | null {
+        return this.Get('LastTaggedAt');
+    }
+    set LastTaggedAt(value: Date | null) {
+        this.Set('LastTaggedAt', value);
+    }
+
+    /**
     * * Field Name: ContentSource
     * * Display Name: Content Source
     * * SQL Data Type: nvarchar(255)
@@ -49505,8 +50637,457 @@ export class MJContentItemEntity extends BaseEntity<MJContentItemEntityType> {
     get ContentFileType(): string {
         return this.Get('ContentFileType');
     }
+
+    /**
+    * * Field Name: EntityRecordDocument
+    * * Display Name: Entity Record Document
+    * * SQL Data Type: nvarchar(450)
+    */
+    get EntityRecordDocument(): string | null {
+        return this.Get('EntityRecordDocument');
+    }
+
+    /**
+    * * Field Name: EmbeddingModel
+    * * Display Name: Embedding Model
+    * * SQL Data Type: nvarchar(50)
+    */
+    get EmbeddingModel(): string | null {
+        return this.Get('EmbeddingModel');
+    }
 }
 
+
+/**
+ * MJ: Content Process Run Details - strongly typed entity sub-class
+ * * Schema: __mj
+ * * Base Table: ContentProcessRunDetail
+ * * Base View: vwContentProcessRunDetails
+ * * @description Per-content-source tracking within a pipeline run. Each source processed during a ContentProcessRun gets one detail record with item counts, timing, token usage, and cost rollups.
+ * * Primary Key: ID
+ * @extends {BaseEntity}
+ * @class
+ * @public
+ */
+@RegisterClass(BaseEntity, 'MJ: Content Process Run Details')
+export class MJContentProcessRunDetailEntity extends BaseEntity<MJContentProcessRunDetailEntityType> {
+    /**
+    * Loads the MJ: Content Process Run Details record from the database
+    * @param ID: string - primary key value to load the MJ: Content Process Run Details record.
+    * @param EntityRelationshipsToLoad - (optional) the relationships to load
+    * @returns {Promise<boolean>} - true if successful, false otherwise
+    * @public
+    * @async
+    * @memberof MJContentProcessRunDetailEntity
+    * @method
+    * @override
+    */
+    public async Load(ID: string, EntityRelationshipsToLoad?: string[]) : Promise<boolean> {
+        const compositeKey: CompositeKey = new CompositeKey();
+        compositeKey.KeyValuePairs.push({ FieldName: 'ID', Value: ID });
+        return await super.InnerLoad(compositeKey, EntityRelationshipsToLoad);
+    }
+
+    /**
+    * * Field Name: ID
+    * * Display Name: ID
+    * * SQL Data Type: uniqueidentifier
+    * * Default Value: newsequentialid()
+    */
+    get ID(): string {
+        return this.Get('ID');
+    }
+    set ID(value: string) {
+        this.Set('ID', value);
+    }
+
+    /**
+    * * Field Name: ContentProcessRunID
+    * * Display Name: Content Process Run
+    * * SQL Data Type: uniqueidentifier
+    * * Related Entity/Foreign Key: MJ: Content Process Runs (vwContentProcessRuns.ID)
+    * * Description: The parent pipeline run this detail belongs to.
+    */
+    get ContentProcessRunID(): string {
+        return this.Get('ContentProcessRunID');
+    }
+    set ContentProcessRunID(value: string) {
+        this.Set('ContentProcessRunID', value);
+    }
+
+    /**
+    * * Field Name: ContentSourceID
+    * * Display Name: Content Source
+    * * SQL Data Type: uniqueidentifier
+    * * Related Entity/Foreign Key: MJ: Content Sources (vwContentSources.ID)
+    * * Description: The content source being processed in this detail record.
+    */
+    get ContentSourceID(): string {
+        return this.Get('ContentSourceID');
+    }
+    set ContentSourceID(value: string) {
+        this.Set('ContentSourceID', value);
+    }
+
+    /**
+    * * Field Name: ContentSourceTypeID
+    * * Display Name: Content Source Type
+    * * SQL Data Type: uniqueidentifier
+    * * Related Entity/Foreign Key: MJ: Content Source Types (vwContentSourceTypes.ID)
+    * * Description: The type of content source (RSS Feed, Entity, Website, Cloud Storage, etc.).
+    */
+    get ContentSourceTypeID(): string {
+        return this.Get('ContentSourceTypeID');
+    }
+    set ContentSourceTypeID(value: string) {
+        this.Set('ContentSourceTypeID', value);
+    }
+
+    /**
+    * * Field Name: Status
+    * * Display Name: Status
+    * * SQL Data Type: nvarchar(20)
+    * * Default Value: Pending
+    * * Description: Processing status: Pending, Running, Completed, Failed, or Skipped.
+    */
+    get Status(): string {
+        return this.Get('Status');
+    }
+    set Status(value: string) {
+        this.Set('Status', value);
+    }
+
+    /**
+    * * Field Name: ItemsProcessed
+    * * Display Name: Items Processed
+    * * SQL Data Type: int
+    * * Default Value: 0
+    * * Description: Total content items processed for this source during the run.
+    */
+    get ItemsProcessed(): number {
+        return this.Get('ItemsProcessed');
+    }
+    set ItemsProcessed(value: number) {
+        this.Set('ItemsProcessed', value);
+    }
+
+    /**
+    * * Field Name: ItemsTagged
+    * * Display Name: Items Tagged
+    * * SQL Data Type: int
+    * * Default Value: 0
+    * * Description: Number of content items successfully tagged by the LLM.
+    */
+    get ItemsTagged(): number {
+        return this.Get('ItemsTagged');
+    }
+    set ItemsTagged(value: number) {
+        this.Set('ItemsTagged', value);
+    }
+
+    /**
+    * * Field Name: ItemsVectorized
+    * * Display Name: Items Vectorized
+    * * SQL Data Type: int
+    * * Default Value: 0
+    * * Description: Number of content items successfully embedded and upserted to the vector database.
+    */
+    get ItemsVectorized(): number {
+        return this.Get('ItemsVectorized');
+    }
+    set ItemsVectorized(value: number) {
+        this.Set('ItemsVectorized', value);
+    }
+
+    /**
+    * * Field Name: TagsCreated
+    * * Display Name: Tags Created
+    * * SQL Data Type: int
+    * * Default Value: 0
+    * * Description: Number of new ContentItemTag records created during LLM tagging.
+    */
+    get TagsCreated(): number {
+        return this.Get('TagsCreated');
+    }
+    set TagsCreated(value: number) {
+        this.Set('TagsCreated', value);
+    }
+
+    /**
+    * * Field Name: ErrorCount
+    * * Display Name: Error Count
+    * * SQL Data Type: int
+    * * Default Value: 0
+    * * Description: Number of errors encountered while processing this source.
+    */
+    get ErrorCount(): number {
+        return this.Get('ErrorCount');
+    }
+    set ErrorCount(value: number) {
+        this.Set('ErrorCount', value);
+    }
+
+    /**
+    * * Field Name: StartTime
+    * * Display Name: Start Time
+    * * SQL Data Type: datetimeoffset
+    * * Description: When processing started for this source within the pipeline run.
+    */
+    get StartTime(): Date | null {
+        return this.Get('StartTime');
+    }
+    set StartTime(value: Date | null) {
+        this.Set('StartTime', value);
+    }
+
+    /**
+    * * Field Name: EndTime
+    * * Display Name: End Time
+    * * SQL Data Type: datetimeoffset
+    * * Description: When processing completed for this source within the pipeline run.
+    */
+    get EndTime(): Date | null {
+        return this.Get('EndTime');
+    }
+    set EndTime(value: Date | null) {
+        this.Set('EndTime', value);
+    }
+
+    /**
+    * * Field Name: TotalTokensUsed
+    * * Display Name: Total Tokens Used
+    * * SQL Data Type: int
+    * * Default Value: 0
+    * * Description: Rollup of all tokens used across LLM tagging and embedding calls for this source. Computed from linked AIPromptRun records via the ContentProcessRunPromptRun junction table.
+    */
+    get TotalTokensUsed(): number {
+        return this.Get('TotalTokensUsed');
+    }
+    set TotalTokensUsed(value: number) {
+        this.Set('TotalTokensUsed', value);
+    }
+
+    /**
+    * * Field Name: TotalCost
+    * * Display Name: Total Cost
+    * * SQL Data Type: decimal(18, 6)
+    * * Default Value: 0
+    * * Description: Rollup of all costs across LLM tagging and embedding calls for this source. Computed from linked AIPromptRun records via the ContentProcessRunPromptRun junction table.
+    */
+    get TotalCost(): number {
+        return this.Get('TotalCost');
+    }
+    set TotalCost(value: number) {
+        this.Set('TotalCost', value);
+    }
+
+    /**
+    * * Field Name: __mj_CreatedAt
+    * * Display Name: Created At
+    * * SQL Data Type: datetimeoffset
+    * * Default Value: getutcdate()
+    */
+    get __mj_CreatedAt(): Date {
+        return this.Get('__mj_CreatedAt');
+    }
+
+    /**
+    * * Field Name: __mj_UpdatedAt
+    * * Display Name: Updated At
+    * * SQL Data Type: datetimeoffset
+    * * Default Value: getutcdate()
+    */
+    get __mj_UpdatedAt(): Date {
+        return this.Get('__mj_UpdatedAt');
+    }
+
+    /**
+    * * Field Name: ContentProcessRun
+    * * Display Name: Content Process Run Name
+    * * SQL Data Type: nvarchar(255)
+    */
+    get ContentProcessRun(): string | null {
+        return this.Get('ContentProcessRun');
+    }
+
+    /**
+    * * Field Name: ContentSource
+    * * Display Name: Content Source Name
+    * * SQL Data Type: nvarchar(255)
+    */
+    get ContentSource(): string | null {
+        return this.Get('ContentSource');
+    }
+
+    /**
+    * * Field Name: ContentSourceType
+    * * Display Name: Source Type Category
+    * * SQL Data Type: nvarchar(255)
+    */
+    get ContentSourceType(): string {
+        return this.Get('ContentSourceType');
+    }
+}
+
+
+/**
+ * MJ: Content Process Run Prompt Runs - strongly typed entity sub-class
+ * * Schema: __mj
+ * * Base Table: ContentProcessRunPromptRun
+ * * Base View: vwContentProcessRunPromptRuns
+ * * @description Links ContentProcessRunDetail records to their associated AIPromptRun records. Each LLM tagging call and embedding call creates an AIPromptRun, and this junction table provides the FK relationship for cost/token analytics.
+ * * Primary Key: ID
+ * @extends {BaseEntity}
+ * @class
+ * @public
+ */
+@RegisterClass(BaseEntity, 'MJ: Content Process Run Prompt Runs')
+export class MJContentProcessRunPromptRunEntity extends BaseEntity<MJContentProcessRunPromptRunEntityType> {
+    /**
+    * Loads the MJ: Content Process Run Prompt Runs record from the database
+    * @param ID: string - primary key value to load the MJ: Content Process Run Prompt Runs record.
+    * @param EntityRelationshipsToLoad - (optional) the relationships to load
+    * @returns {Promise<boolean>} - true if successful, false otherwise
+    * @public
+    * @async
+    * @memberof MJContentProcessRunPromptRunEntity
+    * @method
+    * @override
+    */
+    public async Load(ID: string, EntityRelationshipsToLoad?: string[]) : Promise<boolean> {
+        const compositeKey: CompositeKey = new CompositeKey();
+        compositeKey.KeyValuePairs.push({ FieldName: 'ID', Value: ID });
+        return await super.InnerLoad(compositeKey, EntityRelationshipsToLoad);
+    }
+
+    /**
+    * * Field Name: ID
+    * * Display Name: ID
+    * * SQL Data Type: uniqueidentifier
+    * * Default Value: newsequentialid()
+    */
+    get ID(): string {
+        return this.Get('ID');
+    }
+    set ID(value: string) {
+        this.Set('ID', value);
+    }
+
+    /**
+    * * Field Name: ContentProcessRunDetailID
+    * * Display Name: Content Process Run Detail
+    * * SQL Data Type: uniqueidentifier
+    * * Related Entity/Foreign Key: MJ: Content Process Run Details (vwContentProcessRunDetails.ID)
+    * * Description: The content process run detail record this prompt run is associated with.
+    */
+    get ContentProcessRunDetailID(): string {
+        return this.Get('ContentProcessRunDetailID');
+    }
+    set ContentProcessRunDetailID(value: string) {
+        this.Set('ContentProcessRunDetailID', value);
+    }
+
+    /**
+    * * Field Name: AIPromptRunID
+    * * Display Name: AI Prompt Run
+    * * SQL Data Type: uniqueidentifier
+    * * Related Entity/Foreign Key: MJ: AI Prompt Runs (vwAIPromptRuns.ID)
+    * * Description: The AI prompt run record containing token usage, cost, model, vendor, and execution details for this call.
+    */
+    get AIPromptRunID(): string {
+        return this.Get('AIPromptRunID');
+    }
+    set AIPromptRunID(value: string) {
+        this.Set('AIPromptRunID', value);
+    }
+
+    /**
+    * * Field Name: RunType
+    * * Display Name: Run Type
+    * * SQL Data Type: nvarchar(20)
+    * * Value List Type: List
+    * * Possible Values 
+    *   * Embed
+    *   * Tag
+    * * Description: Whether this AIPromptRun was for LLM tagging (Tag) or text embedding (Embed).
+    */
+    get RunType(): 'Embed' | 'Tag' {
+        return this.Get('RunType');
+    }
+    set RunType(value: 'Embed' | 'Tag') {
+        this.Set('RunType', value);
+    }
+
+    /**
+    * * Field Name: __mj_CreatedAt
+    * * Display Name: Created At
+    * * SQL Data Type: datetimeoffset
+    * * Default Value: getutcdate()
+    */
+    get __mj_CreatedAt(): Date {
+        return this.Get('__mj_CreatedAt');
+    }
+
+    /**
+    * * Field Name: __mj_UpdatedAt
+    * * Display Name: Updated At
+    * * SQL Data Type: datetimeoffset
+    * * Default Value: getutcdate()
+    */
+    get __mj_UpdatedAt(): Date {
+        return this.Get('__mj_UpdatedAt');
+    }
+
+    /**
+    * * Field Name: AIPromptRun
+    * * Display Name: Prompt Run Label
+    * * SQL Data Type: nvarchar(255)
+    */
+    get AIPromptRun(): string | null {
+        return this.Get('AIPromptRun');
+    }
+}
+
+
+/** Pipeline configuration stored on ContentProcessRun.Configuration.
+ *  Controls batch size, rate limiting, error thresholds, and duplicate detection. */
+export interface MJContentProcessRunEntity_IContentProcessRunConfiguration {
+    /** Batch processing settings */
+    Pipeline?: {
+        /** Number of content items per batch. Default: 100 */
+        BatchSize?: number;
+        /** Maximum concurrent batches. Default: 1 */
+        MaxConcurrentBatches?: number;
+        /** Delay between batches in milliseconds. Default: 200 */
+        DelayBetweenBatchesMs?: number;
+        /** If true, resume from the last completed batch on restart. Default: true */
+        ResumeFromLastBatch?: boolean;
+        /** Error rate percentage that triggers the circuit breaker (0-100). Default: 20 */
+        ErrorThresholdPercent?: number;
+    };
+    /** API rate limiting per provider */
+    RateLimits?: {
+        /** LLM (tagging) rate limits */
+        LLM?: {
+            /** Maximum LLM requests per minute */
+            RequestsPerMinute?: number;
+            /** Maximum LLM tokens per minute */
+            TokensPerMinute?: number;
+        };
+        /** Embedding rate limits */
+        Embedding?: {
+            /** Maximum embedding requests per minute */
+            RequestsPerMinute?: number;
+            /** Maximum embedding tokens per minute */
+            TokensPerMinute?: number;
+        };
+        /** Vector database rate limits */
+        VectorDB?: {
+            /** Maximum vector DB requests per minute */
+            RequestsPerMinute?: number;
+        };
+    };
+}
 
 /**
  * MJ: Content Process Runs - strongly typed entity sub-class
@@ -49636,12 +51217,152 @@ export class MJContentProcessRunEntity extends BaseEntity<MJContentProcessRunEnt
     }
 
     /**
+    * * Field Name: StartedByUserID
+    * * Display Name: Started By User ID
+    * * SQL Data Type: uniqueidentifier
+    * * Related Entity/Foreign Key: MJ: Users (vwUsers.ID)
+    * * Description: The user who triggered this pipeline run. NULL for system-initiated runs.
+    */
+    get StartedByUserID(): string | null {
+        return this.Get('StartedByUserID');
+    }
+    set StartedByUserID(value: string | null) {
+        this.Set('StartedByUserID', value);
+    }
+
+    /**
+    * * Field Name: TotalItemCount
+    * * Display Name: Total Item Count
+    * * SQL Data Type: int
+    * * Description: Total number of content items to process in this run. Used for progress percentage calculation.
+    */
+    get TotalItemCount(): number | null {
+        return this.Get('TotalItemCount');
+    }
+    set TotalItemCount(value: number | null) {
+        this.Set('TotalItemCount', value);
+    }
+
+    /**
+    * * Field Name: LastProcessedOffset
+    * * Display Name: Last Processed Offset
+    * * SQL Data Type: int
+    * * Default Value: 0
+    * * Description: StartRow offset of the last successfully completed batch. Used for resume-from-crash: next batch starts at this offset. Reset to 0 on new runs.
+    */
+    get LastProcessedOffset(): number | null {
+        return this.Get('LastProcessedOffset');
+    }
+    set LastProcessedOffset(value: number | null) {
+        this.Set('LastProcessedOffset', value);
+    }
+
+    /**
+    * * Field Name: BatchSize
+    * * Display Name: Batch Size
+    * * SQL Data Type: int
+    * * Default Value: 100
+    * * Description: Number of content items processed per batch. Configurable per run, default 100.
+    */
+    get BatchSize(): number | null {
+        return this.Get('BatchSize');
+    }
+    set BatchSize(value: number | null) {
+        this.Set('BatchSize', value);
+    }
+
+    /**
+    * * Field Name: ErrorCount
+    * * Display Name: Error Count
+    * * SQL Data Type: int
+    * * Default Value: 0
+    * * Description: Running count of errors encountered during processing. Used by the circuit breaker to halt the pipeline if error rate exceeds the configured threshold.
+    */
+    get ErrorCount(): number | null {
+        return this.Get('ErrorCount');
+    }
+    set ErrorCount(value: number | null) {
+        this.Set('ErrorCount', value);
+    }
+
+    /**
+    * * Field Name: ErrorMessage
+    * * Display Name: Error Message
+    * * SQL Data Type: nvarchar(MAX)
+    * * Description: Error details if the run failed. Includes error messages, stack traces, or circuit breaker trigger reason.
+    */
+    get ErrorMessage(): string | null {
+        return this.Get('ErrorMessage');
+    }
+    set ErrorMessage(value: string | null) {
+        this.Set('ErrorMessage', value);
+    }
+
+    /**
+    * * Field Name: CancellationRequested
+    * * Display Name: Cancellation Requested
+    * * SQL Data Type: bit
+    * * Default Value: 0
+    * * Description: When set to 1, the pipeline stops after completing the current batch. Used for pause and cancel operations. The Status column reflects the final state (Paused or Cancelled).
+    */
+    get CancellationRequested(): boolean {
+        return this.Get('CancellationRequested');
+    }
+    set CancellationRequested(value: boolean) {
+        this.Set('CancellationRequested', value);
+    }
+
+    /**
+    * * Field Name: Configuration
+    * * Display Name: Configuration
+    * * SQL Data Type: nvarchar(MAX)
+    * * JSON Type: MJContentProcessRunEntity_IContentProcessRunConfiguration
+    * * Description: JSON snapshot of the pipeline configuration used for this run. Conforms to the IContentProcessRunConfiguration interface. Includes batch size, rate limits, error thresholds, and duplicate detection settings.
+    */
+    get Configuration(): string | null {
+        return this.Get('Configuration');
+    }
+    set Configuration(value: string | null) {
+        this.Set('Configuration', value);
+    }
+
+    private _ConfigurationObject_cached: MJContentProcessRunEntity_IContentProcessRunConfiguration | null | undefined = undefined;
+    private _ConfigurationObject_lastRaw: string | null = null;
+    /**
+    * Typed accessor for Configuration — returns parsed JSON as MJContentProcessRunEntity_IContentProcessRunConfiguration.
+    * Uses lazy parsing with cache invalidation when the underlying raw value changes.
+    */
+    get ConfigurationObject(): MJContentProcessRunEntity_IContentProcessRunConfiguration | null {
+        const raw = this.Configuration;
+        if (raw !== this._ConfigurationObject_lastRaw) {
+            this._ConfigurationObject_cached = raw ? JSON.parse(raw) : null;
+            this._ConfigurationObject_lastRaw = raw;
+        }
+        return this._ConfigurationObject_cached!;
+    }
+    set ConfigurationObject(value: MJContentProcessRunEntity_IContentProcessRunConfiguration | null) {
+        const raw = value ? JSON.stringify(value) : null;
+        this.Configuration = raw;
+        this._ConfigurationObject_cached = value;
+        this._ConfigurationObject_lastRaw = raw;
+    }
+
+    /**
     * * Field Name: Source
     * * Display Name: Source
     * * SQL Data Type: nvarchar(255)
     */
     get Source(): string | null {
         return this.Get('Source');
+    }
+
+    /**
+    * * Field Name: StartedByUser
+    * * Display Name: Started By User
+    * * SQL Data Type: nvarchar(100)
+    */
+    get StartedByUser(): string | null {
+        return this.Get('StartedByUser');
     }
 }
 
@@ -49888,6 +51609,72 @@ export class MJContentSourceTypeParamEntity extends BaseEntity<MJContentSourceTy
 
 
 /**
+ * Type-level configuration for a Content Source Type.
+ *
+ * Describes what fields/inputs are required when creating a content source
+ * of this type. The UI reads this to dynamically render the appropriate
+ * widgets (URL input, entity picker, storage provider selector, etc.)
+ * without hardcoding source-type-specific logic.
+ *
+ * Each Content Source Type row (Entity, RSS Feed, Website, Cloud Storage,
+ * Local File System) stores its own RequiredFields array describing what
+ * the user needs to provide when configuring a source of that type.
+ */
+export interface MJContentSourceTypeEntity_IContentSourceTypeConfiguration {
+    /** Fields required when creating a content source of this type */
+    RequiredFields?: MJContentSourceTypeEntity_IContentSourceTypeField[];
+    /** Whether this source type requires a Content Type selection. Default true. Entity sources set this to false. */
+    RequiresContentType?: boolean;
+    /** Whether this source type requires a File Type selection. Default true. Entity sources set this to false. */
+    RequiresFileType?: boolean;
+}
+
+/**
+ * Describes a single field/input that a content source of this type requires.
+ * The UI renders the appropriate widget based on the Type property.
+ */
+export interface MJContentSourceTypeEntity_IContentSourceTypeField {
+    /** Internal field key — stored in ContentSource.Configuration.SourceSpecificConfiguration */
+    Key: string;
+    /** Display label for the UI widget */
+    Label: string;
+    /**
+     * Widget type to render:
+     * - 'text': plain text input
+     * - 'url': URL input with validation
+     * - 'path': file/directory path input
+     * - 'entity-picker': dropdown of MJ entities (filtered to those with entity documents)
+     * - 'entity-doc-picker': dropdown of entity documents for the selected entity
+     * - 'storage-provider-picker': dropdown of registered MJ Storage providers
+     * - 'dropdown': generic dropdown with options from the Options array
+     */
+    Type: 'text' | 'url' | 'path' | 'entity-picker' | 'entity-doc-picker' | 'storage-provider-picker' | 'dropdown';
+    /** Help text shown below the widget */
+    Description?: string;
+    /** Whether this field must be filled before saving */
+    Required?: boolean;
+    /** Default value for the field */
+    DefaultValue?: string;
+    /** For 'dropdown' type: available options */
+    Options?: MJContentSourceTypeEntity_IContentSourceTypeFieldOption[];
+    /** For 'entity-doc-picker': only show if the selected entity has > 1 document */
+    ShowOnlyIfMultiple?: boolean;
+    /**
+     * For dependent fields: the Key of the field this depends on.
+     * E.g., entity-doc-picker depends on entity-picker's value.
+     */
+    DependsOnField?: string;
+}
+
+/** A selectable option for dropdown-type fields */
+export interface MJContentSourceTypeEntity_IContentSourceTypeFieldOption {
+    /** Display label */
+    Label: string;
+    /** Value stored in configuration */
+    Value: string;
+}
+
+/**
  * MJ: Content Source Types - strongly typed entity sub-class
  * * Schema: __mj
  * * Base Table: ContentSourceType
@@ -49973,8 +51760,92 @@ export class MJContentSourceTypeEntity extends BaseEntity<MJContentSourceTypeEnt
     get __mj_UpdatedAt(): Date {
         return this.Get('__mj_UpdatedAt');
     }
+
+    /**
+    * * Field Name: DriverClass
+    * * Display Name: Driver Class
+    * * SQL Data Type: nvarchar(255)
+    * * Description: The registered class name used by ClassFactory to instantiate the provider for this source type (e.g., AutotagLocalFileSystem, AutotagEntity). Must match a @RegisterClass key on a class extending AutotagBase.
+    */
+    get DriverClass(): string | null {
+        return this.Get('DriverClass');
+    }
+    set DriverClass(value: string | null) {
+        this.Set('DriverClass', value);
+    }
+
+    /**
+    * * Field Name: Configuration
+    * * Display Name: Configuration
+    * * SQL Data Type: nvarchar(MAX)
+    * * JSON Type: MJContentSourceTypeEntity_IContentSourceTypeConfiguration
+    * * Description: JSON configuration blob for type-level settings. Conforms to the IContentSourceTypeConfiguration interface. Reserved for future type-wide settings shared by all sources of this type.
+    */
+    get Configuration(): string | null {
+        return this.Get('Configuration');
+    }
+    set Configuration(value: string | null) {
+        this.Set('Configuration', value);
+    }
+
+    private _ConfigurationObject_cached: MJContentSourceTypeEntity_IContentSourceTypeConfiguration | null | undefined = undefined;
+    private _ConfigurationObject_lastRaw: string | null = null;
+    /**
+    * Typed accessor for Configuration — returns parsed JSON as MJContentSourceTypeEntity_IContentSourceTypeConfiguration.
+    * Uses lazy parsing with cache invalidation when the underlying raw value changes.
+    */
+    get ConfigurationObject(): MJContentSourceTypeEntity_IContentSourceTypeConfiguration | null {
+        const raw = this.Configuration;
+        if (raw !== this._ConfigurationObject_lastRaw) {
+            this._ConfigurationObject_cached = raw ? JSON.parse(raw) : null;
+            this._ConfigurationObject_lastRaw = raw;
+        }
+        return this._ConfigurationObject_cached!;
+    }
+    set ConfigurationObject(value: MJContentSourceTypeEntity_IContentSourceTypeConfiguration | null) {
+        const raw = value ? JSON.stringify(value) : null;
+        this.Configuration = raw;
+        this._ConfigurationObject_cached = value;
+        this._ConfigurationObject_lastRaw = raw;
+    }
 }
 
+
+/**
+ * Per-source configuration for the Content Classification pipeline.
+ *
+ * Settings here control how a single content source interacts with the tag taxonomy,
+ * the vectorization engine, and source-type-specific parameters. Every property is
+ * optional and falls back to a sensible default, so an empty `{}` configuration is valid.
+ *
+ * The SourceSpecificConfiguration sub-object holds type-specific settings whose shape
+ * depends on the content source type (Entity, RSS, Website, Cloud Storage, etc.).
+ * The keys match the RequiredFields defined on the parent ContentSourceType's Configuration.
+ */
+export interface MJContentSourceEntity_IContentSourceConfiguration {
+    /** Tag taxonomy matching mode: constrained (only match within subtree), auto-grow (match or create within subtree), free-flow (match or create anywhere) */
+    TagTaxonomyMode?: 'constrained' | 'auto-grow' | 'free-flow';
+    /** Root Tag ID for constrained/auto-grow modes — limits taxonomy operations to this subtree */
+    TagRootID?: string | null;
+    /** Similarity threshold (0.0-1.0) for matching ContentItemTags to formal Tags. Default 0.9 */
+    TagMatchThreshold?: number;
+    /** Whether to share existing tag taxonomy with the LLM during autotagging. Default true */
+    ShareTaxonomyWithLLM?: boolean;
+    /** Enable vectorization for this source. Default true */
+    EnableVectorization?: boolean;
+    /**
+     * Source-type-specific configuration values. The keys here correspond to the
+     * RequiredFields[].Key values defined on the parent ContentSourceType's Configuration.
+     *
+     * Examples:
+     * - Entity type: { EntityID: "uuid", EntityDocumentID: "uuid" }
+     * - RSS Feed: { URL: "https://example.com/feed.xml" }
+     * - Cloud Storage: { FileStorageProviderKey: "Azure Blob Storage", PathPrefix: "/documents" }
+     * - Local File System: { Path: "/var/data/documents" }
+     * - Website: { URL: "https://example.com", CrawlDepth: 2 }
+     */
+    SourceSpecificConfiguration?: Record<string, unknown>;
+}
 
 /**
  * MJ: Content Sources - strongly typed entity sub-class
@@ -50132,6 +52003,83 @@ export class MJContentSourceEntity extends BaseEntity<MJContentSourceEntityType>
     }
 
     /**
+    * * Field Name: Configuration
+    * * Display Name: Configuration
+    * * SQL Data Type: nvarchar(MAX)
+    * * JSON Type: MJContentSourceEntity_IContentSourceConfiguration
+    * * Description: JSON configuration blob for source-instance settings. Conforms to the IContentSourceConfiguration interface. Includes tag taxonomy mode (constrained/auto-grow/free-flow), tag root ID, match threshold, LLM taxonomy sharing, and vectorization toggle.
+    */
+    get Configuration(): string | null {
+        return this.Get('Configuration');
+    }
+    set Configuration(value: string | null) {
+        this.Set('Configuration', value);
+    }
+
+    private _ConfigurationObject_cached: MJContentSourceEntity_IContentSourceConfiguration | null | undefined = undefined;
+    private _ConfigurationObject_lastRaw: string | null = null;
+    /**
+    * Typed accessor for Configuration — returns parsed JSON as MJContentSourceEntity_IContentSourceConfiguration.
+    * Uses lazy parsing with cache invalidation when the underlying raw value changes.
+    */
+    get ConfigurationObject(): MJContentSourceEntity_IContentSourceConfiguration | null {
+        const raw = this.Configuration;
+        if (raw !== this._ConfigurationObject_lastRaw) {
+            this._ConfigurationObject_cached = raw ? JSON.parse(raw) : null;
+            this._ConfigurationObject_lastRaw = raw;
+        }
+        return this._ConfigurationObject_cached!;
+    }
+    set ConfigurationObject(value: MJContentSourceEntity_IContentSourceConfiguration | null) {
+        const raw = value ? JSON.stringify(value) : null;
+        this.Configuration = raw;
+        this._ConfigurationObject_cached = value;
+        this._ConfigurationObject_lastRaw = raw;
+    }
+
+    /**
+    * * Field Name: EntityID
+    * * Display Name: Entity
+    * * SQL Data Type: uniqueidentifier
+    * * Related Entity/Foreign Key: MJ: Entities (vwEntities.ID)
+    * * Description: For Entity-type content sources, the MJ Entity to pull records from. NULL for non-entity sources (files, RSS, websites, etc.).
+    */
+    get EntityID(): string | null {
+        return this.Get('EntityID');
+    }
+    set EntityID(value: string | null) {
+        this.Set('EntityID', value);
+    }
+
+    /**
+    * * Field Name: EntityDocumentID
+    * * Display Name: Entity Document
+    * * SQL Data Type: uniqueidentifier
+    * * Related Entity/Foreign Key: MJ: Entity Documents (vwEntityDocuments.ID)
+    * * Description: For Entity-type content sources, the Entity Document template used to render entity records into text for autotagging. The template defines which fields to include, how to format them, and related record inclusion. NULL for non-entity sources.
+    */
+    get EntityDocumentID(): string | null {
+        return this.Get('EntityDocumentID');
+    }
+    set EntityDocumentID(value: string | null) {
+        this.Set('EntityDocumentID', value);
+    }
+
+    /**
+    * * Field Name: ScheduledActionID
+    * * Display Name: Scheduled Action
+    * * SQL Data Type: uniqueidentifier
+    * * Related Entity/Foreign Key: MJ: Scheduled Actions (vwScheduledActions.ID)
+    * * Description: Optional link to a MJ Scheduled Action that automatically runs the classification pipeline for this source on a cron schedule.
+    */
+    get ScheduledActionID(): string | null {
+        return this.Get('ScheduledActionID');
+    }
+    set ScheduledActionID(value: string | null) {
+        this.Set('ScheduledActionID', value);
+    }
+
+    /**
     * * Field Name: ContentType
     * * Display Name: Content Type
     * * SQL Data Type: nvarchar(255)
@@ -50174,6 +52122,33 @@ export class MJContentSourceEntity extends BaseEntity<MJContentSourceEntityType>
     */
     get VectorIndex(): string | null {
         return this.Get('VectorIndex');
+    }
+
+    /**
+    * * Field Name: Entity
+    * * Display Name: Entity
+    * * SQL Data Type: nvarchar(255)
+    */
+    get Entity(): string | null {
+        return this.Get('Entity');
+    }
+
+    /**
+    * * Field Name: EntityDocument
+    * * Display Name: Entity Document
+    * * SQL Data Type: nvarchar(250)
+    */
+    get EntityDocument(): string | null {
+        return this.Get('EntityDocument');
+    }
+
+    /**
+    * * Field Name: ScheduledAction
+    * * Display Name: Scheduled Action
+    * * SQL Data Type: nvarchar(255)
+    */
+    get ScheduledAction(): string | null {
+        return this.Get('ScheduledAction');
     }
 }
 
@@ -50292,6 +52267,21 @@ export class MJContentTypeAttributeEntity extends BaseEntity<MJContentTypeAttrib
     }
 }
 
+
+/**
+ * Content-type-level defaults for the autotagging and vectorization pipeline.
+ *
+ * Content Types classify the kind of content being processed (e.g. "Document", "Email",
+ * "Web Page"). Settings defined here act as defaults for every content source that
+ * produces this type of content. Individual sources can override these defaults via
+ * their own {@link IContentSourceConfiguration}.
+ */
+export interface MJContentTypeEntity_IContentTypeConfiguration {
+    /** Whether to share tag taxonomy with LLM by default for all sources of this type. Can be overridden per source. Default true */
+    ShareTaxonomyWithLLM?: boolean;
+    /** Default tag taxonomy mode for sources of this type. Can be overridden per source */
+    DefaultTagTaxonomyMode?: 'constrained' | 'auto-grow' | 'free-flow';
+}
 
 /**
  * MJ: Content Types - strongly typed entity sub-class
@@ -50445,6 +52435,41 @@ export class MJContentTypeEntity extends BaseEntity<MJContentTypeEntityType> {
     }
     set VectorIndexID(value: string | null) {
         this.Set('VectorIndexID', value);
+    }
+
+    /**
+    * * Field Name: Configuration
+    * * Display Name: Configuration
+    * * SQL Data Type: nvarchar(MAX)
+    * * JSON Type: MJContentTypeEntity_IContentTypeConfiguration
+    * * Description: JSON configuration blob for content-type-level settings. Conforms to the IContentTypeConfiguration interface. Reserved for future type-wide settings such as default tag taxonomy rules and processing options.
+    */
+    get Configuration(): string | null {
+        return this.Get('Configuration');
+    }
+    set Configuration(value: string | null) {
+        this.Set('Configuration', value);
+    }
+
+    private _ConfigurationObject_cached: MJContentTypeEntity_IContentTypeConfiguration | null | undefined = undefined;
+    private _ConfigurationObject_lastRaw: string | null = null;
+    /**
+    * Typed accessor for Configuration — returns parsed JSON as MJContentTypeEntity_IContentTypeConfiguration.
+    * Uses lazy parsing with cache invalidation when the underlying raw value changes.
+    */
+    get ConfigurationObject(): MJContentTypeEntity_IContentTypeConfiguration | null {
+        const raw = this.Configuration;
+        if (raw !== this._ConfigurationObject_lastRaw) {
+            this._ConfigurationObject_cached = raw ? JSON.parse(raw) : null;
+            this._ConfigurationObject_lastRaw = raw;
+        }
+        return this._ConfigurationObject_cached!;
+    }
+    set ConfigurationObject(value: MJContentTypeEntity_IContentTypeConfiguration | null) {
+        const raw = value ? JSON.stringify(value) : null;
+        this.Configuration = raw;
+        this._ConfigurationObject_cached = value;
+        this._ConfigurationObject_lastRaw = raw;
     }
 
     /**
@@ -51115,7 +53140,7 @@ export class MJConversationDetailArtifactEntity extends BaseEntity<MJConversatio
 
     /**
     * * Field Name: ConversationDetail
-    * * Display Name: Conversation Detail Summary
+    * * Display Name: Conversation Detail
     * * SQL Data Type: nvarchar(MAX)
     */
     get ConversationDetail(): string {
@@ -51124,7 +53149,7 @@ export class MJConversationDetailArtifactEntity extends BaseEntity<MJConversatio
 
     /**
     * * Field Name: ArtifactVersion
-    * * Display Name: Artifact Version Summary
+    * * Display Name: Artifact Version
     * * SQL Data Type: nvarchar(255)
     */
     get ArtifactVersion(): string | null {
@@ -52419,7 +54444,7 @@ export class MJConversationEntity extends BaseEntity<MJConversationEntityType> {
 
     /**
     * * Field Name: User
-    * * Display Name: User Name
+    * * Display Name: User
     * * SQL Data Type: nvarchar(100)
     */
     get User(): string {
@@ -52437,7 +54462,7 @@ export class MJConversationEntity extends BaseEntity<MJConversationEntityType> {
 
     /**
     * * Field Name: DataContext
-    * * Display Name: Data Context Name
+    * * Display Name: Data Context
     * * SQL Data Type: nvarchar(255)
     */
     get DataContext(): string | null {
@@ -52446,7 +54471,7 @@ export class MJConversationEntity extends BaseEntity<MJConversationEntityType> {
 
     /**
     * * Field Name: Environment
-    * * Display Name: Environment Name
+    * * Display Name: Environment
     * * SQL Data Type: nvarchar(255)
     */
     get Environment(): string {
@@ -52455,7 +54480,7 @@ export class MJConversationEntity extends BaseEntity<MJConversationEntityType> {
 
     /**
     * * Field Name: Project
-    * * Display Name: Project Name
+    * * Display Name: Project
     * * SQL Data Type: nvarchar(255)
     */
     get Project(): string | null {
@@ -52464,7 +54489,7 @@ export class MJConversationEntity extends BaseEntity<MJConversationEntityType> {
 
     /**
     * * Field Name: TestRun
-    * * Display Name: Test Run Name
+    * * Display Name: Test Run
     * * SQL Data Type: nvarchar(255)
     */
     get TestRun(): string | null {
@@ -55377,7 +57402,7 @@ export class MJDuplicateRunDetailEntity extends BaseEntity<MJDuplicateRunDetailE
 
     /**
     * * Field Name: RecordID
-    * * Display Name: Source Record
+    * * Display Name: Record
     * * SQL Data Type: nvarchar(500)
     * * Description: The ID of the record being analyzed for duplicates.
     */
@@ -55501,8 +57526,34 @@ export class MJDuplicateRunDetailEntity extends BaseEntity<MJDuplicateRunDetailE
     }
 
     /**
+    * * Field Name: StartedAt
+    * * Display Name: Started At
+    * * SQL Data Type: datetimeoffset
+    * * Description: When processing started for this specific record during duplicate detection.
+    */
+    get StartedAt(): Date | null {
+        return this.Get('StartedAt');
+    }
+    set StartedAt(value: Date | null) {
+        this.Set('StartedAt', value);
+    }
+
+    /**
+    * * Field Name: EndedAt
+    * * Display Name: Ended At
+    * * SQL Data Type: datetimeoffset
+    * * Description: When processing completed for this specific record during duplicate detection.
+    */
+    get EndedAt(): Date | null {
+        return this.Get('EndedAt');
+    }
+    set EndedAt(value: Date | null) {
+        this.Set('EndedAt', value);
+    }
+
+    /**
     * * Field Name: DuplicateRun
-    * * Display Name: Run Name
+    * * Display Name: Duplicate Run
     * * SQL Data Type: nvarchar(255)
     */
     get DuplicateRun(): string {
@@ -55569,7 +57620,7 @@ export class MJDuplicateRunEntity extends BaseEntity<MJDuplicateRunEntityType> {
 
     /**
     * * Field Name: StartedByUserID
-    * * Display Name: Started By User
+    * * Display Name: Started By
     * * SQL Data Type: uniqueidentifier
     * * Related Entity/Foreign Key: MJ: Users (vwUsers.ID)
     */
@@ -55653,7 +57704,7 @@ export class MJDuplicateRunEntity extends BaseEntity<MJDuplicateRunEntityType> {
 
     /**
     * * Field Name: ApprovedByUserID
-    * * Display Name: Approved By User
+    * * Display Name: Approved By
     * * SQL Data Type: uniqueidentifier
     * * Related Entity/Foreign Key: MJ: Users (vwUsers.ID)
     */
@@ -55718,8 +57769,77 @@ export class MJDuplicateRunEntity extends BaseEntity<MJDuplicateRunEntityType> {
     }
 
     /**
+    * * Field Name: TotalItemCount
+    * * Display Name: Total Item Count
+    * * SQL Data Type: int
+    * * Description: Total entity records to check for duplicates in this run.
+    */
+    get TotalItemCount(): number | null {
+        return this.Get('TotalItemCount');
+    }
+    set TotalItemCount(value: number | null) {
+        this.Set('TotalItemCount', value);
+    }
+
+    /**
+    * * Field Name: ProcessedItemCount
+    * * Display Name: Processed Item Count
+    * * SQL Data Type: int
+    * * Default Value: 0
+    * * Description: Number of records checked so far. Used for progress percentage.
+    */
+    get ProcessedItemCount(): number | null {
+        return this.Get('ProcessedItemCount');
+    }
+    set ProcessedItemCount(value: number | null) {
+        this.Set('ProcessedItemCount', value);
+    }
+
+    /**
+    * * Field Name: LastProcessedOffset
+    * * Display Name: Last Processed Offset
+    * * SQL Data Type: int
+    * * Default Value: 0
+    * * Description: Resume cursor for large-scale duplicate detection. Stores the offset of the last completed batch.
+    */
+    get LastProcessedOffset(): number | null {
+        return this.Get('LastProcessedOffset');
+    }
+    set LastProcessedOffset(value: number | null) {
+        this.Set('LastProcessedOffset', value);
+    }
+
+    /**
+    * * Field Name: BatchSize
+    * * Display Name: Batch Size
+    * * SQL Data Type: int
+    * * Default Value: 100
+    * * Description: Number of records processed per batch during duplicate detection.
+    */
+    get BatchSize(): number | null {
+        return this.Get('BatchSize');
+    }
+    set BatchSize(value: number | null) {
+        this.Set('BatchSize', value);
+    }
+
+    /**
+    * * Field Name: CancellationRequested
+    * * Display Name: Cancellation Requested
+    * * SQL Data Type: bit
+    * * Default Value: 0
+    * * Description: When set to 1, duplicate detection stops after the current batch. Used for pause/cancel.
+    */
+    get CancellationRequested(): boolean {
+        return this.Get('CancellationRequested');
+    }
+    set CancellationRequested(value: boolean) {
+        this.Set('CancellationRequested', value);
+    }
+
+    /**
     * * Field Name: Entity
-    * * Display Name: Entity
+    * * Display Name: Entity Name
     * * SQL Data Type: nvarchar(255)
     */
     get Entity(): string {
@@ -55737,7 +57857,7 @@ export class MJDuplicateRunEntity extends BaseEntity<MJDuplicateRunEntityType> {
 
     /**
     * * Field Name: SourceList
-    * * Display Name: Source List
+    * * Display Name: Source List Name
     * * SQL Data Type: nvarchar(100)
     */
     get SourceList(): string | null {
@@ -55873,7 +57993,7 @@ export class MJEmployeeCompanyIntegrationEntity extends BaseEntity<MJEmployeeCom
 
     /**
     * * Field Name: Employee
-    * * Display Name: Employee Name
+    * * Display Name: Employee
     * * SQL Data Type: nvarchar(81)
     */
     get Employee(): string | null {
@@ -55882,7 +58002,7 @@ export class MJEmployeeCompanyIntegrationEntity extends BaseEntity<MJEmployeeCom
 
     /**
     * * Field Name: CompanyIntegration
-    * * Display Name: Integration Name
+    * * Display Name: Company Integration
     * * SQL Data Type: nvarchar(255)
     */
     get CompanyIntegration(): string {
@@ -55982,7 +58102,7 @@ export class MJEmployeeRoleEntity extends BaseEntity<MJEmployeeRoleEntityType> {
 
     /**
     * * Field Name: Employee
-    * * Display Name: Employee Name
+    * * Display Name: Employee
     * * SQL Data Type: nvarchar(81)
     */
     get Employee(): string | null {
@@ -55991,7 +58111,7 @@ export class MJEmployeeRoleEntity extends BaseEntity<MJEmployeeRoleEntityType> {
 
     /**
     * * Field Name: Role
-    * * Display Name: Role Name
+    * * Display Name: Role
     * * SQL Data Type: nvarchar(50)
     */
     get Role(): string {
@@ -56091,7 +58211,7 @@ export class MJEmployeeSkillEntity extends BaseEntity<MJEmployeeSkillEntityType>
 
     /**
     * * Field Name: Employee
-    * * Display Name: Employee Name
+    * * Display Name: Employee
     * * SQL Data Type: nvarchar(81)
     */
     get Employee(): string | null {
@@ -57926,7 +60046,7 @@ export class MJEntityActionFilterEntity extends BaseEntity<MJEntityActionFilterE
 
     /**
     * * Field Name: EntityAction
-    * * Display Name: Entity Action Name
+    * * Display Name: Entity Action
     * * SQL Data Type: nvarchar(425)
     */
     get EntityAction(): string {
@@ -57935,7 +60055,7 @@ export class MJEntityActionFilterEntity extends BaseEntity<MJEntityActionFilterE
 
     /**
     * * Field Name: ActionFilter
-    * * Display Name: Action Filter Name
+    * * Display Name: Action Filter
     * * SQL Data Type: nvarchar(MAX)
     */
     get ActionFilter(): string {
@@ -58159,7 +60279,7 @@ export class MJEntityActionInvocationEntity extends BaseEntity<MJEntityActionInv
 
     /**
     * * Field Name: EntityAction
-    * * Display Name: Entity Action Name
+    * * Display Name: Entity Action
     * * SQL Data Type: nvarchar(425)
     */
     get EntityAction(): string {
@@ -58168,7 +60288,7 @@ export class MJEntityActionInvocationEntity extends BaseEntity<MJEntityActionInv
 
     /**
     * * Field Name: InvocationType
-    * * Display Name: Invocation Type Name
+    * * Display Name: Invocation Type
     * * SQL Data Type: nvarchar(255)
     */
     get InvocationType(): string {
@@ -58222,7 +60342,7 @@ export class MJEntityActionParamEntity extends BaseEntity<MJEntityActionParamEnt
 
     /**
     * * Field Name: EntityActionID
-    * * Display Name: Entity Action ID
+    * * Display Name: Entity Action
     * * SQL Data Type: uniqueidentifier
     * * Related Entity/Foreign Key: MJ: Entity Actions (vwEntityActions.ID)
     */
@@ -58830,7 +60950,7 @@ export class MJEntityCommunicationFieldEntity extends BaseEntity<MJEntityCommuni
 
     /**
     * * Field Name: EntityCommunicationMessageType
-    * * Display Name: Message Type Name
+    * * Display Name: Entity Communication Message Type
     * * SQL Data Type: nvarchar(100)
     */
     get EntityCommunicationMessageType(): string {
@@ -62517,7 +64637,7 @@ export class MJErrorLogEntity extends BaseEntity<MJErrorLogEntityType> {
 
     /**
     * * Field Name: CompanyIntegrationRunID
-    * * Display Name: Company Integration Run ID
+    * * Display Name: Company Integration Run
     * * SQL Data Type: uniqueidentifier
     * * Related Entity/Foreign Key: MJ: Company Integration Runs (vwCompanyIntegrationRuns.ID)
     */
@@ -62530,7 +64650,7 @@ export class MJErrorLogEntity extends BaseEntity<MJErrorLogEntityType> {
 
     /**
     * * Field Name: CompanyIntegrationRunDetailID
-    * * Display Name: Company Integration Run Detail ID
+    * * Display Name: Company Integration Run Detail
     * * SQL Data Type: uniqueidentifier
     * * Related Entity/Foreign Key: MJ: Company Integration Run Details (vwCompanyIntegrationRunDetails.ID)
     */
@@ -62543,7 +64663,7 @@ export class MJErrorLogEntity extends BaseEntity<MJErrorLogEntityType> {
 
     /**
     * * Field Name: Code
-    * * Display Name: Error Code
+    * * Display Name: Code
     * * SQL Data Type: nchar(20)
     * * Description: Error code for categorizing and handling specific error types.
     */
@@ -62556,7 +64676,7 @@ export class MJErrorLogEntity extends BaseEntity<MJErrorLogEntityType> {
 
     /**
     * * Field Name: Message
-    * * Display Name: Error Message
+    * * Display Name: Message
     * * SQL Data Type: nvarchar(MAX)
     * * Description: The primary error message describing what went wrong.
     */
@@ -62608,7 +64728,7 @@ export class MJErrorLogEntity extends BaseEntity<MJErrorLogEntityType> {
 
     /**
     * * Field Name: Details
-    * * Display Name: Error Details
+    * * Display Name: Details
     * * SQL Data Type: nvarchar(MAX)
     * * Description: Full error details including stack trace, inner exceptions, and context data.
     */
@@ -65156,6 +67276,169 @@ export class MJIntegrationEntity extends BaseEntity<MJIntegrationEntityType> {
 
 
 /**
+ * MJ: Knowledge Hub Saved Searches - strongly typed entity sub-class
+ * * Schema: __mj
+ * * Base Table: KnowledgeHubSavedSearch
+ * * Base View: vwKnowledgeHubSavedSearches
+ * * @description User-saved search queries for the Knowledge Hub. Stores query text, active filters (JSON), and score thresholds so searches can be recalled or run on a schedule.
+ * * Primary Key: ID
+ * @extends {BaseEntity}
+ * @class
+ * @public
+ */
+@RegisterClass(BaseEntity, 'MJ: Knowledge Hub Saved Searches')
+export class MJKnowledgeHubSavedSearchEntity extends BaseEntity<MJKnowledgeHubSavedSearchEntityType> {
+    /**
+    * Loads the MJ: Knowledge Hub Saved Searches record from the database
+    * @param ID: string - primary key value to load the MJ: Knowledge Hub Saved Searches record.
+    * @param EntityRelationshipsToLoad - (optional) the relationships to load
+    * @returns {Promise<boolean>} - true if successful, false otherwise
+    * @public
+    * @async
+    * @memberof MJKnowledgeHubSavedSearchEntity
+    * @method
+    * @override
+    */
+    public async Load(ID: string, EntityRelationshipsToLoad?: string[]) : Promise<boolean> {
+        const compositeKey: CompositeKey = new CompositeKey();
+        compositeKey.KeyValuePairs.push({ FieldName: 'ID', Value: ID });
+        return await super.InnerLoad(compositeKey, EntityRelationshipsToLoad);
+    }
+
+    /**
+    * * Field Name: ID
+    * * Display Name: ID
+    * * SQL Data Type: uniqueidentifier
+    * * Default Value: newsequentialid()
+    */
+    get ID(): string {
+        return this.Get('ID');
+    }
+    set ID(value: string) {
+        this.Set('ID', value);
+    }
+
+    /**
+    * * Field Name: UserID
+    * * Display Name: User
+    * * SQL Data Type: uniqueidentifier
+    * * Related Entity/Foreign Key: MJ: Users (vwUsers.ID)
+    */
+    get UserID(): string {
+        return this.Get('UserID');
+    }
+    set UserID(value: string) {
+        this.Set('UserID', value);
+    }
+
+    /**
+    * * Field Name: Name
+    * * Display Name: Name
+    * * SQL Data Type: nvarchar(255)
+    */
+    get Name(): string {
+        return this.Get('Name');
+    }
+    set Name(value: string) {
+        this.Set('Name', value);
+    }
+
+    /**
+    * * Field Name: Query
+    * * Display Name: Query
+    * * SQL Data Type: nvarchar(1000)
+    */
+    get Query(): string {
+        return this.Get('Query');
+    }
+    set Query(value: string) {
+        this.Set('Query', value);
+    }
+
+    /**
+    * * Field Name: Filters
+    * * Display Name: Filters
+    * * SQL Data Type: nvarchar(MAX)
+    * * Description: JSON object with active filter selections. Keys are filter categories (Entity, Tags), values are arrays of selected option values.
+    */
+    get Filters(): string | null {
+        return this.Get('Filters');
+    }
+    set Filters(value: string | null) {
+        this.Set('Filters', value);
+    }
+
+    /**
+    * * Field Name: MinScore
+    * * Display Name: Minimum Score
+    * * SQL Data Type: decimal(3, 2)
+    */
+    get MinScore(): number | null {
+        return this.Get('MinScore');
+    }
+    set MinScore(value: number | null) {
+        this.Set('MinScore', value);
+    }
+
+    /**
+    * * Field Name: MaxResults
+    * * Display Name: Maximum Results
+    * * SQL Data Type: int
+    * * Default Value: 50
+    */
+    get MaxResults(): number | null {
+        return this.Get('MaxResults');
+    }
+    set MaxResults(value: number | null) {
+        this.Set('MaxResults', value);
+    }
+
+    /**
+    * * Field Name: NotifyOnNewResults
+    * * Display Name: Notify On New Results
+    * * SQL Data Type: bit
+    * * Default Value: 0
+    * * Description: When enabled, the system will notify the user when new results match this saved search (future capability).
+    */
+    get NotifyOnNewResults(): boolean {
+        return this.Get('NotifyOnNewResults');
+    }
+    set NotifyOnNewResults(value: boolean) {
+        this.Set('NotifyOnNewResults', value);
+    }
+
+    /**
+    * * Field Name: __mj_CreatedAt
+    * * Display Name: Created At
+    * * SQL Data Type: datetimeoffset
+    * * Default Value: getutcdate()
+    */
+    get __mj_CreatedAt(): Date {
+        return this.Get('__mj_CreatedAt');
+    }
+
+    /**
+    * * Field Name: __mj_UpdatedAt
+    * * Display Name: Updated At
+    * * SQL Data Type: datetimeoffset
+    * * Default Value: getutcdate()
+    */
+    get __mj_UpdatedAt(): Date {
+        return this.Get('__mj_UpdatedAt');
+    }
+
+    /**
+    * * Field Name: User
+    * * Display Name: User Name
+    * * SQL Data Type: nvarchar(100)
+    */
+    get User(): string {
+        return this.Get('User');
+    }
+}
+
+
+/**
  * MJ: Libraries - strongly typed entity sub-class
  * * Schema: __mj
  * * Base Table: Library
@@ -66472,7 +68755,7 @@ export class MJMCPServerConnectionToolEntity extends BaseEntity<MJMCPServerConne
 
     /**
     * * Field Name: MCPServerConnectionID
-    * * Display Name: Connection
+    * * Display Name: MCP Server Connection
     * * SQL Data Type: uniqueidentifier
     * * Related Entity/Foreign Key: MJ: MCP Server Connections (vwMCPServerConnections.ID)
     */
@@ -66485,7 +68768,7 @@ export class MJMCPServerConnectionToolEntity extends BaseEntity<MJMCPServerConne
 
     /**
     * * Field Name: MCPServerToolID
-    * * Display Name: Tool
+    * * Display Name: MCP Server Tool
     * * SQL Data Type: uniqueidentifier
     * * Related Entity/Foreign Key: MJ: MCP Server Tools (vwMCPServerTools.ID)
     */
@@ -66558,7 +68841,7 @@ export class MJMCPServerConnectionToolEntity extends BaseEntity<MJMCPServerConne
 
     /**
     * * Field Name: MCPServerConnection
-    * * Display Name: Connection Name
+    * * Display Name: MCP Server Connection
     * * SQL Data Type: nvarchar(255)
     */
     get MCPServerConnection(): string {
@@ -66567,7 +68850,7 @@ export class MJMCPServerConnectionToolEntity extends BaseEntity<MJMCPServerConne
 
     /**
     * * Field Name: MCPServerTool
-    * * Display Name: Tool Name
+    * * Display Name: MCP Server Tool
     * * SQL Data Type: nvarchar(255)
     */
     get MCPServerTool(): string | null {
@@ -67529,7 +69812,7 @@ export class MJMCPToolExecutionLogEntity extends BaseEntity<MJMCPToolExecutionLo
 
     /**
     * * Field Name: MCPServerConnectionID
-    * * Display Name: Connection ID
+    * * Display Name: MCP Server Connection
     * * SQL Data Type: uniqueidentifier
     * * Related Entity/Foreign Key: MJ: MCP Server Connections (vwMCPServerConnections.ID)
     */
@@ -67542,7 +69825,7 @@ export class MJMCPToolExecutionLogEntity extends BaseEntity<MJMCPToolExecutionLo
 
     /**
     * * Field Name: MCPServerToolID
-    * * Display Name: Tool ID
+    * * Display Name: MCP Server Tool
     * * SQL Data Type: uniqueidentifier
     * * Related Entity/Foreign Key: MJ: MCP Server Tools (vwMCPServerTools.ID)
     * * Description: FK to MCP Server Tool (null if tool not cached)
@@ -67569,7 +69852,7 @@ export class MJMCPToolExecutionLogEntity extends BaseEntity<MJMCPToolExecutionLo
 
     /**
     * * Field Name: UserID
-    * * Display Name: User ID
+    * * Display Name: User
     * * SQL Data Type: uniqueidentifier
     * * Related Entity/Foreign Key: MJ: Users (vwUsers.ID)
     * * Description: FK to User who initiated the call
@@ -67706,7 +69989,7 @@ export class MJMCPToolExecutionLogEntity extends BaseEntity<MJMCPToolExecutionLo
 
     /**
     * * Field Name: MCPServerConnection
-    * * Display Name: Connection
+    * * Display Name: MCP Server Connection
     * * SQL Data Type: nvarchar(255)
     */
     get MCPServerConnection(): string {
@@ -67715,7 +69998,7 @@ export class MJMCPToolExecutionLogEntity extends BaseEntity<MJMCPToolExecutionLo
 
     /**
     * * Field Name: MCPServerTool
-    * * Display Name: Tool
+    * * Display Name: MCP Server Tool
     * * SQL Data Type: nvarchar(255)
     */
     get MCPServerTool(): string | null {
@@ -69177,36 +71460,34 @@ export class MJOpenAppEntity extends BaseEntity<MJOpenAppEntityType> {
 
     /**
     * Validate() method override for MJ: Open Apps entity. This is an auto-generated method that invokes the generated validators for this entity for the following fields:
-    * * Name: The name must consist only of lowercase letters, numbers, and hyphens to ensure it is compatible with system naming standards.
+    * * Name: Name can only contain lowercase letters, numbers, and hyphens; any other characters are not allowed.
     * @public
     * @method
     * @override
     */
     public override Validate(): ValidationResult {
         const result = super.Validate();
-        this.ValidateNameAlphanumericHyphenOnly(result);
+        this.ValidateNameAllowedCharacters(result);
         result.Success = result.Success && (result.Errors.length === 0);
 
         return result;
     }
 
     /**
-    * The name must consist only of lowercase letters, numbers, and hyphens to ensure it is compatible with system naming standards.
+    * Name can only contain lowercase letters, numbers, and hyphens; any other characters are not allowed.
     * @param result - the ValidationResult object to add any errors or warnings to
     * @public
     * @method
     */
-    public ValidateNameAlphanumericHyphenOnly(result: ValidationResult) {
-    	// The regex checks that the entire string consists only of lowercase letters, digits, or hyphens
-    	const regex = /^[a-z0-9-]+$/;
-    	if (this.Name != null && !regex.test(this.Name)) {
-    		result.Errors.push(new ValidationErrorInfo(
-    			"Name",
-    			"The name must only contain lowercase letters, numbers, and hyphens.",
-    			this.Name,
-    			ValidationErrorType.Failure
-    		));
-    	}
+    public ValidateNameAllowedCharacters(result: ValidationResult) {
+        if (this.Name != null && /[^a-z0-9-]/.test(this.Name)) {
+            result.Errors.push(new ValidationErrorInfo(
+                "Name",
+                "Name can only contain lowercase letters, numbers, and hyphens.",
+                this.Name,
+                ValidationErrorType.Failure
+            ));
+        }
     }
 
     /**
@@ -72463,7 +74744,7 @@ export class MJRecommendationItemEntity extends BaseEntity<MJRecommendationItemE
 
     /**
     * * Field Name: RecommendationID
-    * * Display Name: Recommendation
+    * * Display Name: Recommendation ID
     * * SQL Data Type: uniqueidentifier
     * * Related Entity/Foreign Key: MJ: Recommendations (vwRecommendations.ID)
     */
@@ -73225,7 +75506,7 @@ export class MJRecordChangeEntity extends BaseEntity<MJRecordChangeEntityType> {
 
     /**
     * * Field Name: FullRecordJSON
-    * * Display Name: Full Record Snapshot
+    * * Display Name: Full Record JSON
     * * SQL Data Type: nvarchar(MAX)
     * * Description: A complete snapshot of the record AFTER the change was applied in a JSON format that can be parsed.
     */
@@ -73585,7 +75866,7 @@ export class MJRecordMergeDeletionLogEntity extends BaseEntity<MJRecordMergeDele
 
     /**
     * * Field Name: RecordMergeLogID
-    * * Display Name: Record Merge Log
+    * * Display Name: Record Merge Log ID
     * * SQL Data Type: uniqueidentifier
     * * Related Entity/Foreign Key: MJ: Record Merge Logs (vwRecordMergeLogs.ID)
     */
@@ -73598,7 +75879,7 @@ export class MJRecordMergeDeletionLogEntity extends BaseEntity<MJRecordMergeDele
 
     /**
     * * Field Name: DeletedRecordID
-    * * Display Name: Deleted Record
+    * * Display Name: Deleted Record ID
     * * SQL Data Type: nvarchar(750)
     * * Description: Field DeletedRecordID for entity Record Merge Deletion Logs.
     */
@@ -73662,7 +75943,7 @@ export class MJRecordMergeDeletionLogEntity extends BaseEntity<MJRecordMergeDele
 
     /**
     * * Field Name: RecordMergeLog
-    * * Display Name: Merge Log Summary
+    * * Display Name: Record Merge Log
     * * SQL Data Type: nvarchar(450)
     */
     get RecordMergeLog(): string {
@@ -74824,7 +77105,7 @@ export class MJReportEntity extends BaseEntity<MJReportEntityType> {
 
     /**
     * * Field Name: ConversationDetail
-    * * Display Name: Conversation Detail Name
+    * * Display Name: Conversation Detail
     * * SQL Data Type: nvarchar(MAX)
     */
     get ConversationDetail(): string | null {
@@ -77424,6 +79705,314 @@ export class MJSQLDialectEntity extends BaseEntity<MJSQLDialectEntityType> {
 
 
 /**
+ * MJ: Tag Audit Logs - strongly typed entity sub-class
+ * * Schema: __mj
+ * * Base Table: TagAuditLog
+ * * Base View: vwTagAuditLogs
+ * * @description Immutable audit trail for all tag taxonomy changes. Each row records a single action with before/after details in JSON.
+ * * Primary Key: ID
+ * @extends {BaseEntity}
+ * @class
+ * @public
+ */
+@RegisterClass(BaseEntity, 'MJ: Tag Audit Logs')
+export class MJTagAuditLogEntity extends BaseEntity<MJTagAuditLogEntityType> {
+    /**
+    * Loads the MJ: Tag Audit Logs record from the database
+    * @param ID: string - primary key value to load the MJ: Tag Audit Logs record.
+    * @param EntityRelationshipsToLoad - (optional) the relationships to load
+    * @returns {Promise<boolean>} - true if successful, false otherwise
+    * @public
+    * @async
+    * @memberof MJTagAuditLogEntity
+    * @method
+    * @override
+    */
+    public async Load(ID: string, EntityRelationshipsToLoad?: string[]) : Promise<boolean> {
+        const compositeKey: CompositeKey = new CompositeKey();
+        compositeKey.KeyValuePairs.push({ FieldName: 'ID', Value: ID });
+        return await super.InnerLoad(compositeKey, EntityRelationshipsToLoad);
+    }
+
+    /**
+    * * Field Name: ID
+    * * Display Name: ID
+    * * SQL Data Type: uniqueidentifier
+    * * Default Value: newsequentialid()
+    */
+    get ID(): string {
+        return this.Get('ID');
+    }
+    set ID(value: string) {
+        this.Set('ID', value);
+    }
+
+    /**
+    * * Field Name: TagID
+    * * Display Name: Tag
+    * * SQL Data Type: uniqueidentifier
+    * * Related Entity/Foreign Key: MJ: Tags (vwTags.ID)
+    * * Description: The tag that was acted upon.
+    */
+    get TagID(): string {
+        return this.Get('TagID');
+    }
+    set TagID(value: string) {
+        this.Set('TagID', value);
+    }
+
+    /**
+    * * Field Name: Action
+    * * Display Name: Action
+    * * SQL Data Type: nvarchar(30)
+    * * Value List Type: List
+    * * Possible Values 
+    *   * Created
+    *   * Deleted
+    *   * Deprecated
+    *   * DescriptionChanged
+    *   * Merged
+    *   * Moved
+    *   * Reactivated
+    *   * Renamed
+    *   * Split
+    * * Description: The type of action performed: Created, Renamed, Moved (parent changed), Merged (into RelatedTagID), Split (from RelatedTagID), Deprecated, Reactivated, Deleted, DescriptionChanged.
+    */
+    get Action(): 'Created' | 'Deleted' | 'Deprecated' | 'DescriptionChanged' | 'Merged' | 'Moved' | 'Reactivated' | 'Renamed' | 'Split' {
+        return this.Get('Action');
+    }
+    set Action(value: 'Created' | 'Deleted' | 'Deprecated' | 'DescriptionChanged' | 'Merged' | 'Moved' | 'Reactivated' | 'Renamed' | 'Split') {
+        this.Set('Action', value);
+    }
+
+    /**
+    * * Field Name: Details
+    * * Display Name: Action Details
+    * * SQL Data Type: nvarchar(MAX)
+    * * Description: JSON object with action-specific details. For Renamed: {"OldName":"...","NewName":"..."}. For Moved: {"OldParentID":"...","NewParentID":"..."}. For Merged: {"ItemsMoved":42}.
+    */
+    get Details(): string | null {
+        return this.Get('Details');
+    }
+    set Details(value: string | null) {
+        this.Set('Details', value);
+    }
+
+    /**
+    * * Field Name: PerformedByUserID
+    * * Display Name: Performed By User
+    * * SQL Data Type: uniqueidentifier
+    * * Related Entity/Foreign Key: MJ: Users (vwUsers.ID)
+    * * Description: User who performed the action.
+    */
+    get PerformedByUserID(): string {
+        return this.Get('PerformedByUserID');
+    }
+    set PerformedByUserID(value: string) {
+        this.Set('PerformedByUserID', value);
+    }
+
+    /**
+    * * Field Name: RelatedTagID
+    * * Display Name: Related Tag
+    * * SQL Data Type: uniqueidentifier
+    * * Related Entity/Foreign Key: MJ: Tags (vwTags.ID)
+    * * Description: For Merged actions: the surviving tag. For Split actions: the source tag. NULL for other actions.
+    */
+    get RelatedTagID(): string | null {
+        return this.Get('RelatedTagID');
+    }
+    set RelatedTagID(value: string | null) {
+        this.Set('RelatedTagID', value);
+    }
+
+    /**
+    * * Field Name: __mj_CreatedAt
+    * * Display Name: Created At
+    * * SQL Data Type: datetimeoffset
+    * * Default Value: getutcdate()
+    */
+    get __mj_CreatedAt(): Date {
+        return this.Get('__mj_CreatedAt');
+    }
+
+    /**
+    * * Field Name: __mj_UpdatedAt
+    * * Display Name: Updated At
+    * * SQL Data Type: datetimeoffset
+    * * Default Value: getutcdate()
+    */
+    get __mj_UpdatedAt(): Date {
+        return this.Get('__mj_UpdatedAt');
+    }
+
+    /**
+    * * Field Name: Tag
+    * * Display Name: Tag Name
+    * * SQL Data Type: nvarchar(255)
+    */
+    get Tag(): string {
+        return this.Get('Tag');
+    }
+
+    /**
+    * * Field Name: PerformedByUser
+    * * Display Name: User Name
+    * * SQL Data Type: nvarchar(100)
+    */
+    get PerformedByUser(): string {
+        return this.Get('PerformedByUser');
+    }
+
+    /**
+    * * Field Name: RelatedTag
+    * * Display Name: Related Tag Name
+    * * SQL Data Type: nvarchar(255)
+    */
+    get RelatedTag(): string | null {
+        return this.Get('RelatedTag');
+    }
+}
+
+
+/**
+ * MJ: Tag Co Occurrences - strongly typed entity sub-class
+ * * Schema: __mj
+ * * Base Table: TagCoOccurrence
+ * * Base View: vwTagCoOccurrences
+ * * @description Materialized co-occurrence counts for tag pairs. Records how many content items share both tags. Used for taxonomy health analysis, merge suggestions, and cross-entity intelligence. Recomputed periodically by the pipeline.
+ * * Primary Key: ID
+ * @extends {BaseEntity}
+ * @class
+ * @public
+ */
+@RegisterClass(BaseEntity, 'MJ: Tag Co Occurrences')
+export class MJTagCoOccurrenceEntity extends BaseEntity<MJTagCoOccurrenceEntityType> {
+    /**
+    * Loads the MJ: Tag Co Occurrences record from the database
+    * @param ID: string - primary key value to load the MJ: Tag Co Occurrences record.
+    * @param EntityRelationshipsToLoad - (optional) the relationships to load
+    * @returns {Promise<boolean>} - true if successful, false otherwise
+    * @public
+    * @async
+    * @memberof MJTagCoOccurrenceEntity
+    * @method
+    * @override
+    */
+    public async Load(ID: string, EntityRelationshipsToLoad?: string[]) : Promise<boolean> {
+        const compositeKey: CompositeKey = new CompositeKey();
+        compositeKey.KeyValuePairs.push({ FieldName: 'ID', Value: ID });
+        return await super.InnerLoad(compositeKey, EntityRelationshipsToLoad);
+    }
+
+    /**
+    * * Field Name: ID
+    * * Display Name: ID
+    * * SQL Data Type: uniqueidentifier
+    * * Default Value: newsequentialid()
+    */
+    get ID(): string {
+        return this.Get('ID');
+    }
+    set ID(value: string) {
+        this.Set('ID', value);
+    }
+
+    /**
+    * * Field Name: TagAID
+    * * Display Name: Tag A ID
+    * * SQL Data Type: uniqueidentifier
+    * * Related Entity/Foreign Key: MJ: Tags (vwTags.ID)
+    * * Description: First tag in the canonical pair (TagAID < TagBID ensures each pair is stored exactly once).
+    */
+    get TagAID(): string {
+        return this.Get('TagAID');
+    }
+    set TagAID(value: string) {
+        this.Set('TagAID', value);
+    }
+
+    /**
+    * * Field Name: TagBID
+    * * Display Name: Tag B ID
+    * * SQL Data Type: uniqueidentifier
+    * * Related Entity/Foreign Key: MJ: Tags (vwTags.ID)
+    */
+    get TagBID(): string {
+        return this.Get('TagBID');
+    }
+    set TagBID(value: string) {
+        this.Set('TagBID', value);
+    }
+
+    /**
+    * * Field Name: CoOccurrenceCount
+    * * Display Name: Co-Occurrence Count
+    * * SQL Data Type: int
+    * * Default Value: 0
+    * * Description: Number of content items (or entity records via TaggedItem) that are tagged with both TagA and TagB.
+    */
+    get CoOccurrenceCount(): number {
+        return this.Get('CoOccurrenceCount');
+    }
+    set CoOccurrenceCount(value: number) {
+        this.Set('CoOccurrenceCount', value);
+    }
+
+    /**
+    * * Field Name: LastComputedAt
+    * * Display Name: Last Computed At
+    * * SQL Data Type: datetimeoffset
+    * * Default Value: getutcdate()
+    */
+    get LastComputedAt(): Date {
+        return this.Get('LastComputedAt');
+    }
+    set LastComputedAt(value: Date) {
+        this.Set('LastComputedAt', value);
+    }
+
+    /**
+    * * Field Name: __mj_CreatedAt
+    * * Display Name: Created At
+    * * SQL Data Type: datetimeoffset
+    * * Default Value: getutcdate()
+    */
+    get __mj_CreatedAt(): Date {
+        return this.Get('__mj_CreatedAt');
+    }
+
+    /**
+    * * Field Name: __mj_UpdatedAt
+    * * Display Name: Updated At
+    * * SQL Data Type: datetimeoffset
+    * * Default Value: getutcdate()
+    */
+    get __mj_UpdatedAt(): Date {
+        return this.Get('__mj_UpdatedAt');
+    }
+
+    /**
+    * * Field Name: TagA
+    * * Display Name: Tag A
+    * * SQL Data Type: nvarchar(255)
+    */
+    get TagA(): string {
+        return this.Get('TagA');
+    }
+
+    /**
+    * * Field Name: TagB
+    * * Display Name: Tag B
+    * * SQL Data Type: nvarchar(255)
+    */
+    get TagB(): string {
+        return this.Get('TagB');
+    }
+}
+
+
+/**
  * MJ: Tagged Items - strongly typed entity sub-class
  * * Schema: __mj
  * * Base Table: TaggedItem
@@ -77526,6 +80115,20 @@ export class MJTaggedItemEntity extends BaseEntity<MJTaggedItemEntityType> {
     }
 
     /**
+    * * Field Name: Weight
+    * * Display Name: Weight
+    * * SQL Data Type: numeric(5, 4)
+    * * Default Value: 1.0
+    * * Description: Relevance weight of this tag association (0.0 to 1.0). 1.0 indicates the tag is highly relevant or was manually applied. Lower values indicate decreasing relevance as determined by LLM autotagging. Default 1.0 for manually applied tags.
+    */
+    get Weight(): number {
+        return this.Get('Weight');
+    }
+    set Weight(value: number) {
+        this.Set('Weight', value);
+    }
+
+    /**
     * * Field Name: Tag
     * * Display Name: Tag
     * * SQL Data Type: nvarchar(255)
@@ -77602,7 +80205,7 @@ export class MJTagEntity extends BaseEntity<MJTagEntityType> {
 
     /**
     * * Field Name: ParentID
-    * * Display Name: Parent ID
+    * * Display Name: Parent
     * * SQL Data Type: uniqueidentifier
     * * Related Entity/Foreign Key: MJ: Tags (vwTags.ID)
     */
@@ -77659,8 +80262,42 @@ export class MJTagEntity extends BaseEntity<MJTagEntityType> {
     }
 
     /**
+    * * Field Name: Status
+    * * Display Name: Status
+    * * SQL Data Type: nvarchar(20)
+    * * Default Value: Active
+    * * Value List Type: List
+    * * Possible Values 
+    *   * Active
+    *   * Deleted
+    *   * Deprecated
+    *   * Merged
+    * * Description: Lifecycle status of the tag: Active (in use), Merged (consolidated into another tag), Deprecated (no longer assigned but preserved), Deleted (soft-deleted).
+    */
+    get Status(): 'Active' | 'Deleted' | 'Deprecated' | 'Merged' {
+        return this.Get('Status');
+    }
+    set Status(value: 'Active' | 'Deleted' | 'Deprecated' | 'Merged') {
+        this.Set('Status', value);
+    }
+
+    /**
+    * * Field Name: MergedIntoTagID
+    * * Display Name: Merged Into Tag
+    * * SQL Data Type: uniqueidentifier
+    * * Related Entity/Foreign Key: MJ: Tags (vwTags.ID)
+    * * Description: When Status is Merged, points to the surviving tag this tag was merged into. All TaggedItem and ContentItemTag references are re-pointed during merge.
+    */
+    get MergedIntoTagID(): string | null {
+        return this.Get('MergedIntoTagID');
+    }
+    set MergedIntoTagID(value: string | null) {
+        this.Set('MergedIntoTagID', value);
+    }
+
+    /**
     * * Field Name: Parent
-    * * Display Name: Parent
+    * * Display Name: Parent Name
     * * SQL Data Type: nvarchar(255)
     */
     get Parent(): string | null {
@@ -77668,12 +80305,30 @@ export class MJTagEntity extends BaseEntity<MJTagEntityType> {
     }
 
     /**
+    * * Field Name: MergedIntoTag
+    * * Display Name: Merged Into Tag Name
+    * * SQL Data Type: nvarchar(255)
+    */
+    get MergedIntoTag(): string | null {
+        return this.Get('MergedIntoTag');
+    }
+
+    /**
     * * Field Name: RootParentID
-    * * Display Name: Root Parent ID
+    * * Display Name: Root Parent
     * * SQL Data Type: uniqueidentifier
     */
     get RootParentID(): string | null {
         return this.Get('RootParentID');
+    }
+
+    /**
+    * * Field Name: RootMergedIntoTagID
+    * * Display Name: Root Merged Into Tag
+    * * SQL Data Type: uniqueidentifier
+    */
+    get RootMergedIntoTagID(): string | null {
+        return this.Get('RootMergedIntoTagID');
     }
 }
 
@@ -78265,7 +80920,7 @@ export class MJTaskEntity extends BaseEntity<MJTaskEntityType> {
 
     /**
     * * Field Name: ConversationDetail
-    * * Display Name: Conversation Detail Name
+    * * Display Name: Conversation Detail
     * * SQL Data Type: nvarchar(MAX)
     */
     get ConversationDetail(): string | null {
@@ -78827,7 +81482,7 @@ export class MJTemplateParamEntity extends BaseEntity<MJTemplateParamEntityType>
 
     /**
     * * Field Name: IsRequired
-    * * Display Name: Required
+    * * Display Name: Is Required
     * * SQL Data Type: bit
     * * Default Value: 0
     * * Description: Whether this parameter must be provided when using the template.
@@ -78893,7 +81548,7 @@ export class MJTemplateParamEntity extends BaseEntity<MJTemplateParamEntityType>
 
     /**
     * * Field Name: RecordID
-    * * Display Name: Record ID
+    * * Display Name: Record
     * * SQL Data Type: nvarchar(2000)
     * * Description: Record ID, used only when Type is Record and a specific hardcoded record ID is desired, this is an uncommon use case, helpful for pulling in static types and metadata in some cases.
     */
@@ -78953,7 +81608,7 @@ export class MJTemplateParamEntity extends BaseEntity<MJTemplateParamEntityType>
 
     /**
     * * Field Name: Template
-    * * Display Name: Template Name
+    * * Display Name: Template
     * * SQL Data Type: nvarchar(255)
     */
     get Template(): string {
@@ -78962,7 +81617,7 @@ export class MJTemplateParamEntity extends BaseEntity<MJTemplateParamEntityType>
 
     /**
     * * Field Name: Entity
-    * * Display Name: Entity Name
+    * * Display Name: Entity
     * * SQL Data Type: nvarchar(255)
     */
     get Entity(): string | null {
@@ -78971,7 +81626,7 @@ export class MJTemplateParamEntity extends BaseEntity<MJTemplateParamEntityType>
 
     /**
     * * Field Name: TemplateContent
-    * * Display Name: Template Content Name
+    * * Display Name: Template Content
     * * SQL Data Type: nvarchar(255)
     */
     get TemplateContent(): string | null {
@@ -83423,6 +86078,437 @@ export class MJUserViewRunEntity extends BaseEntity<MJUserViewRunEntityType> {
 
 
 /**
+ * Persisted grid configuration for a User View.
+ *
+ * Stored in the `GridState` column of the `User Views` entity. Contains column layout,
+ * sort settings, filter state, and aggregate configuration. An empty `{}` is valid and
+ * means "use entity-metadata defaults for all columns."
+ *
+ * The runtime class `ViewGridState` in MJUserViewEntityExtended mirrors this shape but
+ * adds constructor logic. This interface represents the raw serialized form.
+ */
+export interface MJUserViewEntity_IGridState {
+    /** Sort settings — array of field/direction pairs applied left-to-right */
+    sortSettings?: MJUserViewEntity_IGridSortSetting[];
+    /** Column settings — visibility, width, order, pinning, formatting */
+    columnSettings?: MJUserViewEntity_IGridColumnSetting[];
+    /** Filter state (composite filter tree with logic operators) */
+    filter?: MJUserViewEntity_IFilterNode;
+    /** Aggregate calculations and display configuration */
+    aggregates?: MJUserViewEntity_IGridAggregatesConfig;
+}
+
+/**
+ * A single sort-field entry within the grid's persisted sort configuration.
+ *
+ * Used inside {@link MJUserViewEntity_IGridState}.sortSettings to define multi-column sorting
+ * applied left-to-right in the entity data grid.
+ */
+export interface MJUserViewEntity_IGridSortSetting {
+    /** Field name to sort by */
+    field: string;
+    /** Sort direction */
+    dir: 'asc' | 'desc';
+}
+
+/**
+ * Persisted configuration for a single column in the entity data grid.
+ *
+ * Used inside {@link MJUserViewEntity_IGridState}.columnSettings. This is the serializable form
+ * of `ViewColumnInfo` — it omits the non-persisted `EntityField` reference and
+ * stores only user-chosen overrides for visibility, width, ordering, pinning,
+ * and formatting.
+ */
+export interface MJUserViewEntity_IGridColumnSetting {
+    /** Entity field ID */
+    ID?: string;
+    /** Field name */
+    Name: string;
+    /** Display name for column header (from entity metadata) */
+    DisplayName?: string;
+    /** User-defined display name override for column header */
+    userDisplayName?: string;
+    /** Whether column is hidden */
+    hidden?: boolean;
+    /** Column width in pixels */
+    width?: number;
+    /** Column order index */
+    orderIndex?: number;
+    /** Column pinning position ('left', 'right', or null for unpinned) */
+    pinned?: 'left' | 'right' | null;
+    /** Flex grow factor (for auto-sizing columns) */
+    flex?: number;
+    /** Minimum column width */
+    minWidth?: number;
+    /** Maximum column width */
+    maxWidth?: number;
+    /** Column formatting configuration */
+    format?: MJUserViewEntity_IColumnFormat;
+}
+
+/**
+ * Column formatting configuration for the entity data grid.
+ *
+ * Controls value display (number/currency/date/boolean formatting), text alignment,
+ * header and cell styling, and conditional formatting rules. Used inside
+ * {@link MJUserViewEntity_IGridColumnSetting}.format.
+ *
+ * Setting `type: 'auto'` tells the grid to infer formatting from entity field metadata.
+ */
+export interface MJUserViewEntity_IColumnFormat {
+    /** Format type — 'auto' uses smart defaults based on field metadata */
+    type?: 'auto' | 'number' | 'currency' | 'percent' | 'date' | 'datetime' | 'boolean' | 'text';
+    /** Decimal places for number/currency/percent types */
+    decimals?: number;
+    /** Currency code (ISO 4217) for currency type, e.g. 'USD', 'EUR' */
+    currencyCode?: string;
+    /** Show thousands separator for number types */
+    thousandsSeparator?: boolean;
+    /** Date format preset or custom pattern */
+    dateFormat?: 'short' | 'medium' | 'long' | string;
+    /** Label to display for true values (boolean type) */
+    trueLabel?: string;
+    /** Label to display for false values (boolean type) */
+    falseLabel?: string;
+    /** How to display boolean values */
+    booleanDisplay?: 'text' | 'checkbox' | 'icon';
+    /** Text alignment */
+    align?: 'left' | 'center' | 'right';
+    /** Header styling (bold, italic, color, etc.) */
+    headerStyle?: MJUserViewEntity_IColumnTextStyle;
+    /** Cell styling (applies to all cells in the column) */
+    cellStyle?: MJUserViewEntity_IColumnTextStyle;
+    /** Conditional formatting rules (applied in order, first match wins) */
+    conditionalRules?: MJUserViewEntity_IColumnConditionalRule[];
+}
+
+/**
+ * Text styling options for grid column headers and cells.
+ *
+ * Used inside {@link MJUserViewEntity_IColumnFormat}.headerStyle, {@link MJUserViewEntity_IColumnFormat}.cellStyle,
+ * and {@link MJUserViewEntity_IColumnConditionalRule}.style to control font weight, style,
+ * decoration, and color.
+ */
+export interface MJUserViewEntity_IColumnTextStyle {
+    /** Bold text */
+    bold?: boolean;
+    /** Italic text */
+    italic?: boolean;
+    /** Underlined text */
+    underline?: boolean;
+    /** Text color (CSS color value) */
+    color?: string;
+    /** Background color (CSS color value) */
+    backgroundColor?: string;
+}
+
+/**
+ * Conditional formatting rule for dynamic cell styling in the entity data grid.
+ *
+ * Used inside {@link MJUserViewEntity_IColumnFormat}.conditionalRules. Rules are evaluated in order;
+ * the first match wins. Each rule compares the cell value against a condition and
+ * applies the associated {@link MJUserViewEntity_IColumnTextStyle} when the condition is met.
+ */
+export interface MJUserViewEntity_IColumnConditionalRule {
+    /** Condition type */
+    condition: 'equals' | 'notEquals' | 'greaterThan' | 'lessThan' | 'greaterThanOrEqual' | 'lessThanOrEqual' | 'between' | 'contains' | 'startsWith' | 'endsWith' | 'isEmpty' | 'isNotEmpty';
+    /** Value to compare against */
+    value?: string | number | boolean;
+    /** Second value for 'between' condition */
+    value2?: number;
+    /** Style to apply when condition is met */
+    style: MJUserViewEntity_IColumnTextStyle;
+}
+
+/**
+ * A single node in a composite filter tree, used inside {@link MJUserViewEntity_IGridState}.filter.
+ *
+ * Each node is either a **leaf condition** (has `field`, `operator`, `value`) or a
+ * **composite group** (has `logic` and nested `filters`). This recursive structure
+ * supports arbitrarily deep AND/OR filter expressions.
+ */
+export interface MJUserViewEntity_IFilterNode {
+    /** Logic operator for composite groups */
+    logic?: 'and' | 'or';
+    /** Nested filter nodes (for composite groups) */
+    filters?: MJUserViewEntity_IFilterNode[];
+    /** Field name (for leaf conditions) */
+    field?: string;
+    /** Comparison operator (for leaf conditions) */
+    operator?: string;
+    /** Comparison value (for leaf conditions) */
+    value?: string | number | boolean | null;
+}
+
+/**
+ * Complete aggregate configuration for a view's grid, stored inside
+ * {@link MJUserViewEntity_IGridState}.aggregates.
+ *
+ * Contains display settings (where/how to show aggregates) and an array of
+ * aggregate expressions — each of which can be an explicit SQL expression or
+ * an AI-generated expression from a natural-language `smartPrompt`.
+ */
+export interface MJUserViewEntity_IGridAggregatesConfig {
+    /** Display settings for aggregate panel/row */
+    display?: MJUserViewEntity_IGridAggregateDisplay;
+    /** Aggregate expressions and their display configuration */
+    expressions?: MJUserViewEntity_IGridAggregate[];
+}
+
+/**
+ * Display settings for the aggregate panel and pinned summary row.
+ *
+ * Used inside {@link MJUserViewEntity_IGridAggregatesConfig}.display to control where and how
+ * aggregate values are rendered — as pinned rows under columns, as summary
+ * cards in a side/bottom panel, or both.
+ */
+export interface MJUserViewEntity_IGridAggregateDisplay {
+    /** Whether to show column-bound aggregates in pinned row */
+    showColumnAggregates?: boolean;
+    /** Where to show column aggregates: pinned top or bottom row */
+    columnPosition?: 'top' | 'bottom';
+    /** Whether to show card aggregates in a panel */
+    showCardAggregates?: boolean;
+    /** Where to show the card panel */
+    cardPosition?: 'right' | 'bottom';
+    /** Card panel width in pixels (for 'right' position) */
+    cardPanelWidth?: number;
+    /** Card layout style */
+    cardLayout?: 'horizontal' | 'vertical' | 'grid';
+    /** Number of columns for 'grid' layout */
+    cardGridColumns?: number;
+    /** Card panel title */
+    cardPanelTitle?: string;
+    /** Whether card panel is collapsible */
+    cardPanelCollapsible?: boolean;
+    /** Whether card panel starts collapsed */
+    cardPanelStartCollapsed?: boolean;
+}
+
+/**
+ * Configuration for a single aggregate expression in the entity data grid.
+ *
+ * Used inside {@link MJUserViewEntity_IGridAggregatesConfig}.expressions. Each aggregate can be
+ * displayed as a pinned-row value under a column or as a summary card in a panel.
+ * Supports both explicit SQL expressions and AI-generated expressions via
+ * `smartPrompt`.
+ */
+export interface MJUserViewEntity_IGridAggregate {
+    /** Unique ID for this aggregate (auto-generated if not provided) */
+    id?: string;
+    /** SQL expression to calculate (e.g. "SUM(OrderTotal)", "COUNT(*)") */
+    expression: string;
+    /** Natural language prompt for AI-generated expression */
+    smartPrompt?: string;
+    /** Display type: 'column' (pinned row) or 'card' (summary panel) */
+    displayType: 'column' | 'card';
+    /** For 'column' displayType: which column to display under */
+    column?: string;
+    /** Human-readable label */
+    label: string;
+    /** Optional description (shown in tooltip) */
+    description?: string;
+    /** Value formatting */
+    format?: MJUserViewEntity_IAggregateValueFormat;
+    /** Icon for card display (Font Awesome class) */
+    icon?: string;
+    /** Conditional styling rules (applied in order, first match wins) */
+    conditionalStyles?: MJUserViewEntity_IAggregateConditionalStyle[];
+    /** Whether this aggregate is enabled (visible) */
+    enabled?: boolean;
+    /** Sort order for display (lower = earlier) */
+    order?: number;
+}
+
+/**
+ * Value formatting options for aggregate results.
+ *
+ * Used inside {@link MJUserViewEntity_IGridAggregate}.format to control how the computed
+ * aggregate value is displayed — decimal precision, currency symbols,
+ * thousands separators, and prefix/suffix decorations.
+ */
+export interface MJUserViewEntity_IAggregateValueFormat {
+    /** Number of decimal places */
+    decimals?: number;
+    /** Currency code (ISO 4217), e.g. 'USD', 'EUR' */
+    currencyCode?: string;
+    /** Show thousands separator */
+    thousandsSeparator?: boolean;
+    /** Prefix to add before value (e.g. '$') */
+    prefix?: string;
+    /** Suffix to add after value (e.g. '%') */
+    suffix?: string;
+    /** Date format for date aggregates */
+    dateFormat?: string;
+}
+
+/**
+ * Conditional styling rule for aggregate values, providing visual indicators
+ * (green/yellow/red) based on the computed result.
+ *
+ * Used inside {@link MJUserViewEntity_IGridAggregate}.conditionalStyles. Rules are evaluated
+ * in order; the first match wins.
+ */
+export interface MJUserViewEntity_IAggregateConditionalStyle {
+    /** Condition operator */
+    operator: 'eq' | 'neq' | 'gt' | 'gte' | 'lt' | 'lte' | 'between';
+    /** Value to compare against */
+    value: number | string;
+    /** Second value for 'between' operator */
+    value2?: number | string;
+    /** Style class to apply */
+    style: 'success' | 'warning' | 'danger' | 'info' | 'muted';
+}
+
+/**
+ * Persisted filter configuration for a User View.
+ *
+ * Stored in the `FilterState` column of the `User Views` entity. Represents a
+ * composite filter tree where each node is either a leaf condition (field + operator
+ * + value) or a group node (logic + nested filters). The default empty state is
+ * `{ "logic": "and", "filters": [] }`.
+ *
+ * The runtime class `ViewFilterInfo` in MJUserViewEntityExtended transforms `logic`
+ * into a `logicOperator` enum. This interface represents the raw serialized form.
+ */
+export interface MJUserViewEntity_IFilterState {
+    /** Logic operator combining child filters */
+    logic: 'and' | 'or';
+    /** Child filter nodes — either leaf conditions or nested groups */
+    filters: MJUserViewEntity_IFilterItem[];
+}
+
+/**
+ * A single node in the {@link MJUserViewEntity_IFilterState} filter tree — either a leaf condition
+ * or a nested composite group.
+ *
+ * Leaf nodes have `field`, `operator`, and `value`. Group nodes have `logic` and
+ * `filters`. This recursive structure supports arbitrarily deep AND/OR expressions.
+ */
+export interface MJUserViewEntity_IFilterItem {
+    /** Field name (leaf conditions) */
+    field?: string;
+    /** Comparison operator (leaf conditions) — e.g. 'eq', 'contains', 'isnull' */
+    operator?: string;
+    /** Value to compare against (leaf conditions) */
+    value?: string | number | boolean | null;
+    /** Logic operator for nested composite groups */
+    logic?: 'and' | 'or';
+    /** Nested filter nodes (composite groups) */
+    filters?: MJUserViewEntity_IFilterItem[];
+}
+
+/**
+ * A single sort-field entry within a User View's sort configuration.
+ *
+ * The `SortState` column of the `User Views` entity stores a JSON **array** of these
+ * objects, representing a multi-column sort applied left-to-right. For example:
+ * ```json
+ * [{ "field": "LastName", "direction": "asc" }, { "field": "FirstName", "direction": "asc" }]
+ * ```
+ *
+ * The runtime class `ViewSortInfo` in MJUserViewEntityExtended maps the `direction`
+ * string to a `ViewSortDirectionInfo` enum. This interface represents the raw
+ * serialized form. The `JSONTypeIsArray` flag is set so CodeGen emits `MJUserViewEntity_ISortStateItem[]`.
+ */
+export interface MJUserViewEntity_ISortStateItem {
+    /** Field name to sort by */
+    field: string;
+    /** Sort direction (lowercase in JSON) */
+    direction: 'asc' | 'desc';
+}
+
+/**
+ * Persisted card-view configuration for a User View.
+ *
+ * Stored in the `CardState` column of the `User Views` entity. Controls the visual
+ * presentation when the view is displayed in card mode. All properties are optional;
+ * omitting them means "use component defaults."
+ *
+ * The card template itself (title field, subtitle, display fields, thumbnail priority)
+ * is auto-derived from entity metadata at runtime — this interface only stores
+ * user-chosen overrides for display preferences.
+ */
+export interface MJUserViewEntity_ICardState {
+    /** Card size preset — controls card dimensions and content density */
+    cardSize?: 'small' | 'medium' | 'large';
+}
+
+/**
+ * Persisted display-mode configuration for a User View.
+ *
+ * Stored in the `DisplayState` column of the `User Views` entity. Controls which
+ * view modes (grid, cards, timeline) are available and which is shown by default,
+ * along with mode-specific settings like timeline grouping and card sizing.
+ *
+ * The runtime helpers `ParsedDisplayState`, `DefaultViewMode`, and `TimelineConfig`
+ * on `MJUserViewEntityExtended` currently parse this field manually; once CodeGen
+ * emits a typed `DisplayStateObject` accessor, those helpers can delegate to it.
+ */
+export interface MJUserViewEntity_IDisplayState {
+    /** The default view mode to show when loading this view */
+    defaultMode: 'grid' | 'cards' | 'timeline';
+    /** Which view modes are enabled/visible for this view */
+    enabledModes?: {
+        grid?: boolean;
+        cards?: boolean;
+        timeline?: boolean;
+    };
+    /** Timeline-specific configuration */
+    timeline?: MJUserViewEntity_ITimelineState;
+    /** Card-specific configuration */
+    cards?: MJUserViewEntity_IDisplayCardState;
+    /** Grid-specific configuration */
+    grid?: MJUserViewEntity_IGridDisplayState;
+}
+
+/**
+ * Timeline-specific configuration for the entity viewer's timeline display mode.
+ *
+ * Used inside {@link MJUserViewEntity_IDisplayState}.timeline. Controls which date field drives the
+ * timeline, how events are grouped into segments, and segment expand/collapse behavior.
+ */
+export interface MJUserViewEntity_ITimelineState {
+    /** The date field name to use for timeline ordering */
+    dateFieldName: string;
+    /** Time segment grouping */
+    segmentGrouping?: 'none' | 'day' | 'week' | 'month' | 'quarter' | 'year';
+    /** Sort order for timeline events */
+    sortOrder?: 'asc' | 'desc';
+    /** Whether segments are collapsible */
+    segmentsCollapsible?: boolean;
+    /** Whether segments start expanded */
+    segmentsDefaultExpanded?: boolean;
+    /** Timeline orientation */
+    orientation?: 'vertical' | 'horizontal';
+}
+
+/**
+ * Card-specific display configuration within the view display state.
+ *
+ * Used inside {@link MJUserViewEntity_IDisplayState}.cards. Controls card sizing when the view
+ * is in card display mode. The card template itself (title field, subtitle,
+ * display fields) is auto-derived from entity metadata at runtime.
+ */
+export interface MJUserViewEntity_IDisplayCardState {
+    /** Custom card size */
+    cardSize?: 'small' | 'medium' | 'large';
+}
+
+/**
+ * Grid-specific display configuration within the view display state.
+ *
+ * Used inside {@link MJUserViewEntity_IDisplayState}.grid. Controls grid-level display preferences
+ * like row height that are separate from per-column settings in {@link IGridState}.
+ */
+export interface MJUserViewEntity_IGridDisplayState {
+    /** Row height preference */
+    rowHeight?: 'compact' | 'normal' | 'comfortable';
+    /** Enable text wrapping in grid cells — long text wraps and rows auto-size */
+    wrapText?: boolean;
+}
+
+/**
  * MJ: User Views - strongly typed entity sub-class
  * * Schema: __mj
  * * Base Table: UserView
@@ -83560,6 +86646,7 @@ export class MJUserViewEntity extends BaseEntity<MJUserViewEntityType> {
     * * Field Name: GridState
     * * Display Name: Grid State
     * * SQL Data Type: nvarchar(MAX)
+    * * JSON Type: MJUserViewEntity_IGridState
     * * Description: JSON storing complete grid configuration including columns, widths, and formatting.
     */
     get GridState(): string | null {
@@ -83569,10 +86656,32 @@ export class MJUserViewEntity extends BaseEntity<MJUserViewEntityType> {
         this.Set('GridState', value);
     }
 
+    private _GridStateObject_cached: MJUserViewEntity_IGridState | null | undefined = undefined;
+    private _GridStateObject_lastRaw: string | null = null;
+    /**
+    * Typed accessor for GridState — returns parsed JSON as MJUserViewEntity_IGridState.
+    * Uses lazy parsing with cache invalidation when the underlying raw value changes.
+    */
+    get GridStateObject(): MJUserViewEntity_IGridState | null {
+        const raw = this.GridState;
+        if (raw !== this._GridStateObject_lastRaw) {
+            this._GridStateObject_cached = raw ? JSON.parse(raw) : null;
+            this._GridStateObject_lastRaw = raw;
+        }
+        return this._GridStateObject_cached!;
+    }
+    set GridStateObject(value: MJUserViewEntity_IGridState | null) {
+        const raw = value ? JSON.stringify(value) : null;
+        this.GridState = raw;
+        this._GridStateObject_cached = value;
+        this._GridStateObject_lastRaw = raw;
+    }
+
     /**
     * * Field Name: FilterState
     * * Display Name: Filter State
     * * SQL Data Type: nvarchar(MAX)
+    * * JSON Type: MJUserViewEntity_IFilterState
     * * Description: JSON storing the view's filter configuration.
     */
     get FilterState(): string | null {
@@ -83580,6 +86689,27 @@ export class MJUserViewEntity extends BaseEntity<MJUserViewEntityType> {
     }
     set FilterState(value: string | null) {
         this.Set('FilterState', value);
+    }
+
+    private _FilterStateObject_cached: MJUserViewEntity_IFilterState | null | undefined = undefined;
+    private _FilterStateObject_lastRaw: string | null = null;
+    /**
+    * Typed accessor for FilterState — returns parsed JSON as MJUserViewEntity_IFilterState.
+    * Uses lazy parsing with cache invalidation when the underlying raw value changes.
+    */
+    get FilterStateObject(): MJUserViewEntity_IFilterState | null {
+        const raw = this.FilterState;
+        if (raw !== this._FilterStateObject_lastRaw) {
+            this._FilterStateObject_cached = raw ? JSON.parse(raw) : null;
+            this._FilterStateObject_lastRaw = raw;
+        }
+        return this._FilterStateObject_cached!;
+    }
+    set FilterStateObject(value: MJUserViewEntity_IFilterState | null) {
+        const raw = value ? JSON.stringify(value) : null;
+        this.FilterState = raw;
+        this._FilterStateObject_cached = value;
+        this._FilterStateObject_lastRaw = raw;
     }
 
     /**
@@ -83680,6 +86810,7 @@ export class MJUserViewEntity extends BaseEntity<MJUserViewEntityType> {
     * * Field Name: SortState
     * * Display Name: Sort State
     * * SQL Data Type: nvarchar(MAX)
+    * * JSON Type: Array<MJUserViewEntity_ISortStateItem>
     * * Description: JSON storing the view's sort configuration.
     */
     get SortState(): string | null {
@@ -83687,6 +86818,27 @@ export class MJUserViewEntity extends BaseEntity<MJUserViewEntityType> {
     }
     set SortState(value: string | null) {
         this.Set('SortState', value);
+    }
+
+    private _SortStateObject_cached: Array<MJUserViewEntity_ISortStateItem> | null | undefined = undefined;
+    private _SortStateObject_lastRaw: string | null = null;
+    /**
+    * Typed accessor for SortState — returns parsed JSON as Array<MJUserViewEntity_ISortStateItem>.
+    * Uses lazy parsing with cache invalidation when the underlying raw value changes.
+    */
+    get SortStateObject(): Array<MJUserViewEntity_ISortStateItem> | null {
+        const raw = this.SortState;
+        if (raw !== this._SortStateObject_lastRaw) {
+            this._SortStateObject_cached = raw ? JSON.parse(raw) : null;
+            this._SortStateObject_lastRaw = raw;
+        }
+        return this._SortStateObject_cached!;
+    }
+    set SortStateObject(value: Array<MJUserViewEntity_ISortStateItem> | null) {
+        const raw = value ? JSON.stringify(value) : null;
+        this.SortState = raw;
+        this._SortStateObject_cached = value;
+        this._SortStateObject_lastRaw = raw;
     }
 
     /**
@@ -83726,6 +86878,7 @@ export class MJUserViewEntity extends BaseEntity<MJUserViewEntityType> {
     * * Field Name: CardState
     * * Display Name: Card State
     * * SQL Data Type: nvarchar(MAX)
+    * * JSON Type: MJUserViewEntity_ICardState
     * * Description: JSON configuration for card display mode in Data Explorer. Stores card layout settings including title field, subtitle, display fields, thumbnails, and layout density. When null, defaults are derived from entity metadata. See CardState interface in packages/Angular/Generic/entity-viewer/src/lib/types.ts for the current schema definition.
     */
     get CardState(): string | null {
@@ -83735,10 +86888,32 @@ export class MJUserViewEntity extends BaseEntity<MJUserViewEntityType> {
         this.Set('CardState', value);
     }
 
+    private _CardStateObject_cached: MJUserViewEntity_ICardState | null | undefined = undefined;
+    private _CardStateObject_lastRaw: string | null = null;
+    /**
+    * Typed accessor for CardState — returns parsed JSON as MJUserViewEntity_ICardState.
+    * Uses lazy parsing with cache invalidation when the underlying raw value changes.
+    */
+    get CardStateObject(): MJUserViewEntity_ICardState | null {
+        const raw = this.CardState;
+        if (raw !== this._CardStateObject_lastRaw) {
+            this._CardStateObject_cached = raw ? JSON.parse(raw) : null;
+            this._CardStateObject_lastRaw = raw;
+        }
+        return this._CardStateObject_cached!;
+    }
+    set CardStateObject(value: MJUserViewEntity_ICardState | null) {
+        const raw = value ? JSON.stringify(value) : null;
+        this.CardState = raw;
+        this._CardStateObject_cached = value;
+        this._CardStateObject_lastRaw = raw;
+    }
+
     /**
     * * Field Name: DisplayState
     * * Display Name: Display State
     * * SQL Data Type: nvarchar(MAX)
+    * * JSON Type: MJUserViewEntity_IDisplayState
     * * Description: JSON configuration for display mode settings. Stores default display mode (grid/cards/timeline/chart), available modes for sharing, and mode-specific configurations like timeline date field and segmentation. See ViewDisplayState interface in packages/Angular/Generic/entity-viewer/src/lib/types.ts for schema.
     */
     get DisplayState(): string | null {
@@ -83746,6 +86921,27 @@ export class MJUserViewEntity extends BaseEntity<MJUserViewEntityType> {
     }
     set DisplayState(value: string | null) {
         this.Set('DisplayState', value);
+    }
+
+    private _DisplayStateObject_cached: MJUserViewEntity_IDisplayState | null | undefined = undefined;
+    private _DisplayStateObject_lastRaw: string | null = null;
+    /**
+    * Typed accessor for DisplayState — returns parsed JSON as MJUserViewEntity_IDisplayState.
+    * Uses lazy parsing with cache invalidation when the underlying raw value changes.
+    */
+    get DisplayStateObject(): MJUserViewEntity_IDisplayState | null {
+        const raw = this.DisplayState;
+        if (raw !== this._DisplayStateObject_lastRaw) {
+            this._DisplayStateObject_cached = raw ? JSON.parse(raw) : null;
+            this._DisplayStateObject_lastRaw = raw;
+        }
+        return this._DisplayStateObject_cached!;
+    }
+    set DisplayStateObject(value: MJUserViewEntity_IDisplayState | null) {
+        const raw = value ? JSON.stringify(value) : null;
+        this.DisplayState = raw;
+        this._DisplayStateObject_cached = value;
+        this._DisplayStateObject_lastRaw = raw;
     }
 
     /**

--- a/packages/MJServer/src/generated/generated.ts
+++ b/packages/MJServer/src/generated/generated.ts
@@ -18,7 +18,7 @@ import { mj_core_schema } from '../config.js';
 
 
 
-import { MJAccessControlRuleEntity, MJActionAuthorizationEntity, MJActionCategoryEntity, MJActionContextTypeEntity, MJActionContextEntity, MJActionExecutionLogEntity, MJActionFilterEntity, MJActionLibraryEntity, MJActionParamEntity, MJActionResultCodeEntity, MJActionEntity, MJAIActionEntity, MJAIAgentActionEntity, MJAIAgentArtifactTypeEntity, MJAIAgentCategoryEntity, MJAIAgentClientToolEntity, MJAIAgentConfigurationEntity, MJAIAgentDataSourceEntity, MJAIAgentExampleEntity, MJAIAgentLearningCycleEntity, MJAIAgentModalityEntity, MJAIAgentModelEntity, MJAIAgentNoteTypeEntity, MJAIAgentNoteEntity, MJAIAgentPermissionEntity, MJAIAgentPromptEntity, MJAIAgentRelationshipEntity, MJAIAgentRequestTypeEntity, MJAIAgentRequestEntity, MJAIAgentRunMediaEntity, MJAIAgentRunStepEntity, MJAIAgentRunEntity, MJAIAgentStepPathEntity, MJAIAgentStepEntity, MJAIAgentTypeEntity, MJAIAgentEntity, MJAIArchitectureEntity, MJAIClientToolDefinitionEntity, MJAIConfigurationParamEntity, MJAIConfigurationEntity, MJAICredentialBindingEntity, MJAIModalityEntity, MJAIModelActionEntity, MJAIModelArchitectureEntity, MJAIModelCostEntity, MJAIModelModalityEntity, MJAIModelPriceTypeEntity, MJAIModelPriceUnitTypeEntity, MJAIModelTypeEntity, MJAIModelVendorEntity, MJAIModelEntity, MJAIPromptCategoryEntity, MJAIPromptModelEntity, MJAIPromptRunMediaEntity, MJAIPromptRunEntity, MJAIPromptTypeEntity, MJAIPromptEntity, MJAIResultCacheEntity, MJAIVendorTypeDefinitionEntity, MJAIVendorTypeEntity, MJAIVendorEntity, MJAPIApplicationScopeEntity, MJAPIApplicationEntity, MJAPIKeyApplicationEntity, MJAPIKeyScopeEntity, MJAPIKeyUsageLogEntity, MJAPIKeyEntity, MJAPIScopeEntity, MJApplicationEntityEntity, MJApplicationSettingEntity, MJApplicationEntity, MJArtifactPermissionEntity, MJArtifactTypeEntity, MJArtifactUseEntity, MJArtifactVersionAttributeEntity, MJArtifactVersionEntity, MJArtifactEntity, MJAuditLogTypeEntity, MJAuditLogEntity, MJAuthorizationRoleEntity, MJAuthorizationEntity, MJCollectionArtifactEntity, MJCollectionPermissionEntity, MJCollectionEntity, MJCommunicationBaseMessageTypeEntity, MJCommunicationLogEntity, MJCommunicationProviderMessageTypeEntity, MJCommunicationProviderEntity, MJCommunicationRunEntity, MJCompanyEntity, MJCompanyIntegrationEntityMapEntity, MJCompanyIntegrationFieldMapEntity, MJCompanyIntegrationRecordMapEntity, MJCompanyIntegrationRunAPILogEntity, MJCompanyIntegrationRunDetailEntity, MJCompanyIntegrationRunEntity, MJCompanyIntegrationSyncWatermarkEntity, MJCompanyIntegrationEntity, MJComponentDependencyEntity, MJComponentLibraryEntity, MJComponentLibraryLinkEntity, MJComponentRegistryEntity, MJComponentEntity, MJContentFileTypeEntity, MJContentItemAttributeEntity, MJContentItemTagEntity, MJContentItemEntity, MJContentProcessRunEntity, MJContentSourceParamEntity, MJContentSourceTypeParamEntity, MJContentSourceTypeEntity, MJContentSourceEntity, MJContentTypeAttributeEntity, MJContentTypeEntity, MJConversationArtifactPermissionEntity, MJConversationArtifactVersionEntity, MJConversationArtifactEntity, MJConversationDetailArtifactEntity, MJConversationDetailAttachmentEntity, MJConversationDetailRatingEntity, MJConversationDetailEntity, MJConversationEntity, MJCredentialCategoryEntity, MJCredentialTypeEntity, MJCredentialEntity, MJDashboardCategoryEntity, MJDashboardCategoryLinkEntity, MJDashboardCategoryPermissionEntity, MJDashboardPartTypeEntity, MJDashboardPermissionEntity, MJDashboardUserPreferenceEntity, MJDashboardUserStateEntity, MJDashboardEntity, MJDataContextItemEntity, MJDataContextEntity, MJDatasetItemEntity, MJDatasetEntity, MJDuplicateRunDetailMatchEntity, MJDuplicateRunDetailEntity, MJDuplicateRunEntity, MJEmployeeCompanyIntegrationEntity, MJEmployeeRoleEntity, MJEmployeeSkillEntity, MJEmployeeEntity, MJEncryptionAlgorithmEntity, MJEncryptionKeySourceEntity, MJEncryptionKeyEntity, MJEntityEntity, MJEntityActionFilterEntity, MJEntityActionInvocationTypeEntity, MJEntityActionInvocationEntity, MJEntityActionParamEntity, MJEntityActionEntity, MJEntityAIActionEntity, MJEntityCommunicationFieldEntity, MJEntityCommunicationMessageTypeEntity, MJEntityDocumentRunEntity, MJEntityDocumentSettingEntity, MJEntityDocumentTypeEntity, MJEntityDocumentEntity, MJEntityFieldValueEntity, MJEntityFieldEntity, MJEntityOrganicKeyRelatedEntityEntity, MJEntityOrganicKeyEntity, MJEntityPermissionEntity, MJEntityRecordDocumentEntity, MJEntityRelationshipDisplayComponentEntity, MJEntityRelationshipEntity, MJEntitySettingEntity, MJEnvironmentEntity, MJErrorLogEntity, MJExplorerNavigationItemEntity, MJFileCategoryEntity, MJFileEntityRecordLinkEntity, MJFileStorageAccountEntity, MJFileStorageProviderEntity, MJFileEntity, MJGeneratedCodeCategoryEntity, MJGeneratedCodeEntity, MJIntegrationObjectFieldEntity, MJIntegrationObjectEntity, MJIntegrationSourceTypeEntity, MJIntegrationURLFormatEntity, MJIntegrationEntity, MJLibraryEntity, MJLibraryItemEntity, MJListCategoryEntity, MJListDetailEntity, MJListInvitationEntity, MJListShareEntity, MJListEntity, MJMCPServerConnectionPermissionEntity, MJMCPServerConnectionToolEntity, MJMCPServerConnectionEntity, MJMCPServerToolEntity, MJMCPServerEntity, MJMCPToolExecutionLogEntity, MJOAuthAuthServerMetadataCacheEntity, MJOAuthAuthorizationStateEntity, MJOAuthClientRegistrationEntity, MJOAuthTokenEntity, MJOpenAppDependencyEntity, MJOpenAppInstallHistoryEntity, MJOpenAppEntity, MJOutputDeliveryTypeEntity, MJOutputFormatTypeEntity, MJOutputTriggerTypeEntity, MJProjectEntity, MJPublicLinkEntity, MJQueryEntity, MJQueryCategoryEntity, MJQueryDependencyEntity, MJQueryEntityEntity, MJQueryFieldEntity, MJQueryParameterEntity, MJQueryPermissionEntity, MJQuerySQLEntity, MJQueueTaskEntity, MJQueueTypeEntity, MJQueueEntity, MJRecommendationItemEntity, MJRecommendationProviderEntity, MJRecommendationRunEntity, MJRecommendationEntity, MJRecordChangeReplayRunEntity, MJRecordChangeEntity, MJRecordLinkEntity, MJRecordMergeDeletionLogEntity, MJRecordMergeLogEntity, MJReportCategoryEntity, MJReportSnapshotEntity, MJReportUserStateEntity, MJReportVersionEntity, MJReportEntity, MJResourceLinkEntity, MJResourcePermissionEntity, MJResourceTypeEntity, MJRoleEntity, MJRowLevelSecurityFilterEntity, MJScheduledActionParamEntity, MJScheduledActionEntity, MJScheduledJobRunEntity, MJScheduledJobTypeEntity, MJScheduledJobEntity, MJSchemaInfoEntity, MJSkillEntity, MJSQLDialectEntity, MJTaggedItemEntity, MJTagEntity, MJTaskDependencyEntity, MJTaskTypeEntity, MJTaskEntity, MJTemplateCategoryEntity, MJTemplateContentTypeEntity, MJTemplateContentEntity, MJTemplateParamEntity, MJTemplateEntity, MJTestRubricEntity, MJTestRunFeedbackEntity, MJTestRunOutputTypeEntity, MJTestRunOutputEntity, MJTestRunEntity, MJTestSuiteRunEntity, MJTestSuiteTestEntity, MJTestSuiteEntity, MJTestTypeEntity, MJTestEntity, MJUserApplicationEntityEntity, MJUserApplicationEntity, MJUserFavoriteEntity, MJUserNotificationPreferenceEntity, MJUserNotificationTypeEntity, MJUserNotificationEntity, MJUserRecordLogEntity, MJUserRoleEntity, MJUserSettingEntity, MJUserViewCategoryEntity, MJUserViewRunDetailEntity, MJUserViewRunEntity, MJUserViewEntity, MJUserEntity, MJVectorDatabaseEntity, MJVectorIndexEntity, MJVersionInstallationEntity, MJVersionLabelItemEntity, MJVersionLabelRestoreEntity, MJVersionLabelEntity, MJWorkflowEngineEntity, MJWorkflowRunEntity, MJWorkflowEntity, MJWorkspaceItemEntity, MJWorkspaceEntity } from '@memberjunction/core-entities';
+import { MJAccessControlRuleEntity, MJActionAuthorizationEntity, MJActionCategoryEntity, MJActionContextTypeEntity, MJActionContextEntity, MJActionExecutionLogEntity, MJActionFilterEntity, MJActionLibraryEntity, MJActionParamEntity, MJActionResultCodeEntity, MJActionEntity, MJAIActionEntity, MJAIAgentActionEntity, MJAIAgentArtifactTypeEntity, MJAIAgentCategoryEntity, MJAIAgentClientToolEntity, MJAIAgentConfigurationEntity, MJAIAgentDataSourceEntity, MJAIAgentExampleEntity, MJAIAgentLearningCycleEntity, MJAIAgentModalityEntity, MJAIAgentModelEntity, MJAIAgentNoteTypeEntity, MJAIAgentNoteEntity, MJAIAgentPermissionEntity, MJAIAgentPromptEntity, MJAIAgentRelationshipEntity, MJAIAgentRequestTypeEntity, MJAIAgentRequestEntity, MJAIAgentRunMediaEntity, MJAIAgentRunStepEntity, MJAIAgentRunEntity, MJAIAgentStepPathEntity, MJAIAgentStepEntity, MJAIAgentTypeEntity, MJAIAgentEntity, MJAIArchitectureEntity, MJAIClientToolDefinitionEntity, MJAIConfigurationParamEntity, MJAIConfigurationEntity, MJAICredentialBindingEntity, MJAIModalityEntity, MJAIModelActionEntity, MJAIModelArchitectureEntity, MJAIModelCostEntity, MJAIModelModalityEntity, MJAIModelPriceTypeEntity, MJAIModelPriceUnitTypeEntity, MJAIModelTypeEntity, MJAIModelVendorEntity, MJAIModelEntity, MJAIPromptCategoryEntity, MJAIPromptModelEntity, MJAIPromptRunMediaEntity, MJAIPromptRunEntity, MJAIPromptTypeEntity, MJAIPromptEntity, MJAIResultCacheEntity, MJAIVendorTypeDefinitionEntity, MJAIVendorTypeEntity, MJAIVendorEntity, MJAPIApplicationScopeEntity, MJAPIApplicationEntity, MJAPIKeyApplicationEntity, MJAPIKeyScopeEntity, MJAPIKeyUsageLogEntity, MJAPIKeyEntity, MJAPIScopeEntity, MJApplicationEntityEntity, MJApplicationSettingEntity, MJApplicationEntity, MJArtifactPermissionEntity, MJArtifactTypeEntity, MJArtifactUseEntity, MJArtifactVersionAttributeEntity, MJArtifactVersionEntity, MJArtifactEntity, MJAuditLogTypeEntity, MJAuditLogEntity, MJAuthorizationRoleEntity, MJAuthorizationEntity, MJCollectionArtifactEntity, MJCollectionPermissionEntity, MJCollectionEntity, MJCommunicationBaseMessageTypeEntity, MJCommunicationLogEntity, MJCommunicationProviderMessageTypeEntity, MJCommunicationProviderEntity, MJCommunicationRunEntity, MJCompanyEntity, MJCompanyIntegrationEntityMapEntity, MJCompanyIntegrationFieldMapEntity, MJCompanyIntegrationRecordMapEntity, MJCompanyIntegrationRunAPILogEntity, MJCompanyIntegrationRunDetailEntity, MJCompanyIntegrationRunEntity, MJCompanyIntegrationSyncWatermarkEntity, MJCompanyIntegrationEntity, MJComponentDependencyEntity, MJComponentLibraryEntity, MJComponentLibraryLinkEntity, MJComponentRegistryEntity, MJComponentEntity, MJContentFileTypeEntity, MJContentItemAttributeEntity, MJContentItemDuplicateEntity, MJContentItemTagEntity, MJContentItemEntity, MJContentProcessRunDetailEntity, MJContentProcessRunPromptRunEntity, MJContentProcessRunEntity, MJContentSourceParamEntity, MJContentSourceTypeParamEntity, MJContentSourceTypeEntity, MJContentSourceEntity, MJContentTypeAttributeEntity, MJContentTypeEntity, MJConversationArtifactPermissionEntity, MJConversationArtifactVersionEntity, MJConversationArtifactEntity, MJConversationDetailArtifactEntity, MJConversationDetailAttachmentEntity, MJConversationDetailRatingEntity, MJConversationDetailEntity, MJConversationEntity, MJCredentialCategoryEntity, MJCredentialTypeEntity, MJCredentialEntity, MJDashboardCategoryEntity, MJDashboardCategoryLinkEntity, MJDashboardCategoryPermissionEntity, MJDashboardPartTypeEntity, MJDashboardPermissionEntity, MJDashboardUserPreferenceEntity, MJDashboardUserStateEntity, MJDashboardEntity, MJDataContextItemEntity, MJDataContextEntity, MJDatasetItemEntity, MJDatasetEntity, MJDuplicateRunDetailMatchEntity, MJDuplicateRunDetailEntity, MJDuplicateRunEntity, MJEmployeeCompanyIntegrationEntity, MJEmployeeRoleEntity, MJEmployeeSkillEntity, MJEmployeeEntity, MJEncryptionAlgorithmEntity, MJEncryptionKeySourceEntity, MJEncryptionKeyEntity, MJEntityEntity, MJEntityActionFilterEntity, MJEntityActionInvocationTypeEntity, MJEntityActionInvocationEntity, MJEntityActionParamEntity, MJEntityActionEntity, MJEntityAIActionEntity, MJEntityCommunicationFieldEntity, MJEntityCommunicationMessageTypeEntity, MJEntityDocumentRunEntity, MJEntityDocumentSettingEntity, MJEntityDocumentTypeEntity, MJEntityDocumentEntity, MJEntityFieldValueEntity, MJEntityFieldEntity, MJEntityOrganicKeyRelatedEntityEntity, MJEntityOrganicKeyEntity, MJEntityPermissionEntity, MJEntityRecordDocumentEntity, MJEntityRelationshipDisplayComponentEntity, MJEntityRelationshipEntity, MJEntitySettingEntity, MJEnvironmentEntity, MJErrorLogEntity, MJExplorerNavigationItemEntity, MJFileCategoryEntity, MJFileEntityRecordLinkEntity, MJFileStorageAccountEntity, MJFileStorageProviderEntity, MJFileEntity, MJGeneratedCodeCategoryEntity, MJGeneratedCodeEntity, MJIntegrationObjectFieldEntity, MJIntegrationObjectEntity, MJIntegrationSourceTypeEntity, MJIntegrationURLFormatEntity, MJIntegrationEntity, MJKnowledgeHubSavedSearchEntity, MJLibraryEntity, MJLibraryItemEntity, MJListCategoryEntity, MJListDetailEntity, MJListInvitationEntity, MJListShareEntity, MJListEntity, MJMCPServerConnectionPermissionEntity, MJMCPServerConnectionToolEntity, MJMCPServerConnectionEntity, MJMCPServerToolEntity, MJMCPServerEntity, MJMCPToolExecutionLogEntity, MJOAuthAuthServerMetadataCacheEntity, MJOAuthAuthorizationStateEntity, MJOAuthClientRegistrationEntity, MJOAuthTokenEntity, MJOpenAppDependencyEntity, MJOpenAppInstallHistoryEntity, MJOpenAppEntity, MJOutputDeliveryTypeEntity, MJOutputFormatTypeEntity, MJOutputTriggerTypeEntity, MJProjectEntity, MJPublicLinkEntity, MJQueryEntity, MJQueryCategoryEntity, MJQueryDependencyEntity, MJQueryEntityEntity, MJQueryFieldEntity, MJQueryParameterEntity, MJQueryPermissionEntity, MJQuerySQLEntity, MJQueueTaskEntity, MJQueueTypeEntity, MJQueueEntity, MJRecommendationItemEntity, MJRecommendationProviderEntity, MJRecommendationRunEntity, MJRecommendationEntity, MJRecordChangeReplayRunEntity, MJRecordChangeEntity, MJRecordLinkEntity, MJRecordMergeDeletionLogEntity, MJRecordMergeLogEntity, MJReportCategoryEntity, MJReportSnapshotEntity, MJReportUserStateEntity, MJReportVersionEntity, MJReportEntity, MJResourceLinkEntity, MJResourcePermissionEntity, MJResourceTypeEntity, MJRoleEntity, MJRowLevelSecurityFilterEntity, MJScheduledActionParamEntity, MJScheduledActionEntity, MJScheduledJobRunEntity, MJScheduledJobTypeEntity, MJScheduledJobEntity, MJSchemaInfoEntity, MJSkillEntity, MJSQLDialectEntity, MJTagAuditLogEntity, MJTagCoOccurrenceEntity, MJTaggedItemEntity, MJTagEntity, MJTaskDependencyEntity, MJTaskTypeEntity, MJTaskEntity, MJTemplateCategoryEntity, MJTemplateContentTypeEntity, MJTemplateContentEntity, MJTemplateParamEntity, MJTemplateEntity, MJTestRubricEntity, MJTestRunFeedbackEntity, MJTestRunOutputTypeEntity, MJTestRunOutputEntity, MJTestRunEntity, MJTestSuiteRunEntity, MJTestSuiteTestEntity, MJTestSuiteEntity, MJTestTypeEntity, MJTestEntity, MJUserApplicationEntityEntity, MJUserApplicationEntity, MJUserFavoriteEntity, MJUserNotificationPreferenceEntity, MJUserNotificationTypeEntity, MJUserNotificationEntity, MJUserRecordLogEntity, MJUserRoleEntity, MJUserSettingEntity, MJUserViewCategoryEntity, MJUserViewRunDetailEntity, MJUserViewRunEntity, MJUserViewEntity, MJUserEntity, MJVectorDatabaseEntity, MJVectorIndexEntity, MJVersionInstallationEntity, MJVersionLabelItemEntity, MJVersionLabelRestoreEntity, MJVersionLabelEntity, MJWorkflowEngineEntity, MJWorkflowRunEntity, MJWorkflowEntity, MJWorkspaceItemEntity, MJWorkspaceEntity } from '@memberjunction/core-entities';
     
 
 //****************************************************************************
@@ -3043,9 +3043,17 @@ export class MJAIAgentCategory_ {
     @Field() 
     _mj__UpdatedAt: Date;
         
+    @Field({nullable: true, description: `Default file storage account for agents in this category. Inherited by child categories that do not define their own value — resolution walks up the ParentID tree until a non-null value is found. Overrides the Type-level default. FK to FileStorageAccount.`}) 
+    @MaxLength(36)
+    DefaultStorageAccountID?: string;
+        
     @Field({nullable: true}) 
     @MaxLength(200)
     Parent?: string;
+        
+    @Field({nullable: true}) 
+    @MaxLength(200)
+    DefaultStorageAccount?: string;
         
     @Field({nullable: true}) 
     @MaxLength(36)
@@ -3081,6 +3089,9 @@ export class CreateMJAIAgentCategoryInput {
 
     @Field({ nullable: true })
     Status?: string;
+
+    @Field({ nullable: true })
+    DefaultStorageAccountID: string | null;
 }
     
 
@@ -3106,6 +3117,9 @@ export class UpdateMJAIAgentCategoryInput {
 
     @Field({ nullable: true })
     Status?: string;
+
+    @Field({ nullable: true })
+    DefaultStorageAccountID?: string | null;
 
     @Field(() => [KeyValuePairInput], { nullable: true })
     OldValues___?: KeyValuePairInput[];
@@ -8424,9 +8438,17 @@ export class MJAIAgentType_ {
     @Field({nullable: true, description: `JSON-serialized AgentRequestAssignmentStrategy defining the default assignment strategy for all agents of this type. Overridden by per-invocation or category-level strategies in the resolution chain.`}) 
     AssignmentStrategy?: string;
         
+    @Field({nullable: true, description: `Default file storage account for agents of this type. Lowest priority in the resolution chain (Type → Category tree → Agent → Runtime override). When set, all agents of this type use this storage account unless overridden at a more specific level. FK to FileStorageAccount.`}) 
+    @MaxLength(36)
+    DefaultStorageAccountID?: string;
+        
     @Field({nullable: true}) 
     @MaxLength(255)
     SystemPrompt?: string;
+        
+    @Field({nullable: true}) 
+    @MaxLength(200)
+    DefaultStorageAccount?: string;
         
     @Field(() => [MJAIAgent_])
     MJAIAgents_TypeIDArray: MJAIAgent_[]; // Link to MJAIAgents
@@ -8473,6 +8495,9 @@ export class CreateMJAIAgentTypeInput {
 
     @Field({ nullable: true })
     AssignmentStrategy: string | null;
+
+    @Field({ nullable: true })
+    DefaultStorageAccountID: string | null;
 }
     
 
@@ -8516,6 +8541,9 @@ export class UpdateMJAIAgentTypeInput {
 
     @Field({ nullable: true })
     AssignmentStrategy?: string | null;
+
+    @Field({ nullable: true })
+    DefaultStorageAccountID?: string | null;
 
     @Field(() => [KeyValuePairInput], { nullable: true })
     OldValues___?: KeyValuePairInput[];
@@ -8842,6 +8870,10 @@ if this limit is exceeded.`})
     @Field(() => Boolean, {description: `When true (default), this agent accepts runtime-registered ephemeral client tools that are not defined in metadata. Set to false for agents that require strict tool governance.`}) 
     AllowEphemeralClientTools: boolean;
         
+    @Field({nullable: true, description: `Default file storage account for this specific agent. Overrides both Type-level and Category-level defaults. Can be further overridden at runtime via ExecuteAgentParams.override.storageAccountId. FK to FileStorageAccount.`}) 
+    @MaxLength(36)
+    DefaultStorageAccountID?: string;
+        
     @Field({nullable: true}) 
     @MaxLength(255)
     Parent?: string;
@@ -8869,6 +8901,10 @@ if this limit is exceeded.`})
     @Field({nullable: true}) 
     @MaxLength(200)
     Category?: string;
+        
+    @Field({nullable: true}) 
+    @MaxLength(200)
+    DefaultStorageAccount?: string;
         
     @Field({nullable: true}) 
     @MaxLength(36)
@@ -9132,6 +9168,9 @@ export class CreateMJAIAgentInput {
 
     @Field(() => Boolean, { nullable: true })
     AllowEphemeralClientTools?: boolean;
+
+    @Field({ nullable: true })
+    DefaultStorageAccountID: string | null;
 }
     
 
@@ -9322,6 +9361,9 @@ export class UpdateMJAIAgentInput {
 
     @Field(() => Boolean, { nullable: true })
     AllowEphemeralClientTools?: boolean;
+
+    @Field({ nullable: true })
+    DefaultStorageAccountID?: string | null;
 
     @Field(() => [KeyValuePairInput], { nullable: true })
     OldValues___?: KeyValuePairInput[];
@@ -12901,6 +12943,9 @@ export class MJAIModel_ {
     @Field(() => [MJContentType_])
     MJContentTypes_EmbeddingModelIDArray: MJContentType_[]; // Link to MJContentTypes
     
+    @Field(() => [MJContentItem_])
+    MJContentItems_EmbeddingModelIDArray: MJContentItem_[]; // Link to MJContentItems
+    
     @Field(() => [MJAIPromptModel_])
     MJAIPromptModels_ModelIDArray: MJAIPromptModel_[]; // Link to MJAIPromptModels
     
@@ -13284,6 +13329,16 @@ export class MJAIModelResolver extends ResolverBase {
         const sSQL = `SELECT * FROM ${provider.QuoteSchemaAndView(Metadata.Provider.ConfigData.MJCoreSchemaName, 'vwContentTypes')} WHERE ${provider.QuoteIdentifier('EmbeddingModelID')}='${mjaimodel_.ID}' ` + this.getRowLevelSecurityWhereClause(provider, 'MJ: Content Types', userPayload, EntityPermissionType.Read, 'AND');
         const rows = await provider.ExecuteSQL(sSQL, undefined, undefined, this.GetUserFromPayload(userPayload));
         const result = await this.ArrayMapFieldNamesToCodeNames('MJ: Content Types', rows, this.GetUserFromPayload(userPayload));
+        return result;
+    }
+        
+    @FieldResolver(() => [MJContentItem_])
+    async MJContentItems_EmbeddingModelIDArray(@Root() mjaimodel_: MJAIModel_, @Ctx() { userPayload, providers }: AppContext, @PubSub() pubSub: PubSubEngine) {
+        this.CheckUserReadPermissions('MJ: Content Items', userPayload);
+        const provider = GetReadOnlyProvider(providers, { allowFallbackToReadWrite: true });
+        const sSQL = `SELECT * FROM ${provider.QuoteSchemaAndView(Metadata.Provider.ConfigData.MJCoreSchemaName, 'vwContentItems')} WHERE ${provider.QuoteIdentifier('EmbeddingModelID')}='${mjaimodel_.ID}' ` + this.getRowLevelSecurityWhereClause(provider, 'MJ: Content Items', userPayload, EntityPermissionType.Read, 'AND');
+        const rows = await provider.ExecuteSQL(sSQL, undefined, undefined, this.GetUserFromPayload(userPayload));
+        const result = await this.ArrayMapFieldNamesToCodeNames('MJ: Content Items', rows, this.GetUserFromPayload(userPayload));
         return result;
     }
         
@@ -14464,6 +14519,9 @@ export class MJAIPromptRun_ {
     @MaxLength(36)
     RootRerunFromPromptRunID?: string;
         
+    @Field(() => [MJContentProcessRunPromptRun_])
+    MJContentProcessRunPromptRuns_AIPromptRunIDArray: MJContentProcessRunPromptRun_[]; // Link to MJContentProcessRunPromptRuns
+    
     @Field(() => [MJAIPromptRun_])
     MJAIPromptRuns_RerunFromPromptRunIDArray: MJAIPromptRun_[]; // Link to MJAIPromptRuns
     
@@ -15049,6 +15107,16 @@ export class MJAIPromptRunResolver extends ResolverBase {
         return result;
     }
     
+    @FieldResolver(() => [MJContentProcessRunPromptRun_])
+    async MJContentProcessRunPromptRuns_AIPromptRunIDArray(@Root() mjaipromptrun_: MJAIPromptRun_, @Ctx() { userPayload, providers }: AppContext, @PubSub() pubSub: PubSubEngine) {
+        this.CheckUserReadPermissions('MJ: Content Process Run Prompt Runs', userPayload);
+        const provider = GetReadOnlyProvider(providers, { allowFallbackToReadWrite: true });
+        const sSQL = `SELECT * FROM ${provider.QuoteSchemaAndView(Metadata.Provider.ConfigData.MJCoreSchemaName, 'vwContentProcessRunPromptRuns')} WHERE ${provider.QuoteIdentifier('AIPromptRunID')}='${mjaipromptrun_.ID}' ` + this.getRowLevelSecurityWhereClause(provider, 'MJ: Content Process Run Prompt Runs', userPayload, EntityPermissionType.Read, 'AND');
+        const rows = await provider.ExecuteSQL(sSQL, undefined, undefined, this.GetUserFromPayload(userPayload));
+        const result = await this.ArrayMapFieldNamesToCodeNames('MJ: Content Process Run Prompt Runs', rows, this.GetUserFromPayload(userPayload));
+        return result;
+    }
+        
     @FieldResolver(() => [MJAIPromptRun_])
     async MJAIPromptRuns_RerunFromPromptRunIDArray(@Root() mjaipromptrun_: MJAIPromptRun_, @Ctx() { userPayload, providers }: AppContext, @PubSub() pubSub: PubSubEngine) {
         this.CheckUserReadPermissions('MJ: AI Prompt Runs', userPayload);
@@ -26833,6 +26901,221 @@ export class MJContentItemAttributeResolver extends ResolverBase {
 }
 
 //****************************************************************************
+// ENTITY CLASS for MJ: Content Item Duplicates
+//****************************************************************************
+@ObjectType({ description: `Detected duplicate or near-duplicate content items across sources. Each row represents a pair of items with similarity scoring and resolution tracking.` })
+export class MJContentItemDuplicate_ {
+    @Field() 
+    @MaxLength(36)
+    ID: string;
+        
+    @Field() 
+    @MaxLength(36)
+    ContentItemAID: string;
+        
+    @Field() 
+    @MaxLength(36)
+    ContentItemBID: string;
+        
+    @Field(() => Float, {description: `Cosine similarity (for Vector) or exact match score (1.0 for Checksum/URL). Range 0.0-1.0.`}) 
+    SimilarityScore: number;
+        
+    @Field({description: `How the duplicate was detected: Checksum (identical text hash), Vector (embedding similarity), Title (same title text), URL (same source URL).`}) 
+    @MaxLength(30)
+    DetectionMethod: string;
+        
+    @Field({description: `Current status: Pending (awaiting review), Confirmed (verified duplicate), Dismissed (not a duplicate), Merged (one item was removed).`}) 
+    @MaxLength(20)
+    Status: string;
+        
+    @Field({nullable: true}) 
+    @MaxLength(36)
+    ResolvedByUserID?: string;
+        
+    @Field({nullable: true}) 
+    ResolvedAt?: Date;
+        
+    @Field({nullable: true, description: `How the duplicate was resolved: KeepA (keep first, remove second), KeepB (keep second, remove first), MergeBoth (combine into one), NotDuplicate (false positive).`}) 
+    @MaxLength(20)
+    Resolution?: string;
+        
+    @Field() 
+    _mj__CreatedAt: Date;
+        
+    @Field() 
+    _mj__UpdatedAt: Date;
+        
+    @Field({nullable: true}) 
+    @MaxLength(250)
+    ContentItemA?: string;
+        
+    @Field({nullable: true}) 
+    @MaxLength(250)
+    ContentItemB?: string;
+        
+    @Field({nullable: true}) 
+    @MaxLength(100)
+    ResolvedByUser?: string;
+        
+}
+
+//****************************************************************************
+// INPUT TYPE for MJ: Content Item Duplicates
+//****************************************************************************
+@InputType()
+export class CreateMJContentItemDuplicateInput {
+    @Field({ nullable: true })
+    ID?: string;
+
+    @Field({ nullable: true })
+    ContentItemAID?: string;
+
+    @Field({ nullable: true })
+    ContentItemBID?: string;
+
+    @Field(() => Float, { nullable: true })
+    SimilarityScore?: number;
+
+    @Field({ nullable: true })
+    DetectionMethod?: string;
+
+    @Field({ nullable: true })
+    Status?: string;
+
+    @Field({ nullable: true })
+    ResolvedByUserID: string | null;
+
+    @Field({ nullable: true })
+    ResolvedAt: Date | null;
+
+    @Field({ nullable: true })
+    Resolution: string | null;
+}
+    
+
+//****************************************************************************
+// INPUT TYPE for MJ: Content Item Duplicates
+//****************************************************************************
+@InputType()
+export class UpdateMJContentItemDuplicateInput {
+    @Field()
+    ID: string;
+
+    @Field({ nullable: true })
+    ContentItemAID?: string;
+
+    @Field({ nullable: true })
+    ContentItemBID?: string;
+
+    @Field(() => Float, { nullable: true })
+    SimilarityScore?: number;
+
+    @Field({ nullable: true })
+    DetectionMethod?: string;
+
+    @Field({ nullable: true })
+    Status?: string;
+
+    @Field({ nullable: true })
+    ResolvedByUserID?: string | null;
+
+    @Field({ nullable: true })
+    ResolvedAt?: Date | null;
+
+    @Field({ nullable: true })
+    Resolution?: string | null;
+
+    @Field(() => [KeyValuePairInput], { nullable: true })
+    OldValues___?: KeyValuePairInput[];
+}
+    
+//****************************************************************************
+// RESOLVER for MJ: Content Item Duplicates
+//****************************************************************************
+@ObjectType()
+export class RunMJContentItemDuplicateViewResult {
+    @Field(() => [MJContentItemDuplicate_])
+    Results: MJContentItemDuplicate_[];
+
+    @Field(() => String, {nullable: true})
+    UserViewRunID?: string;
+
+    @Field(() => Int, {nullable: true})
+    RowCount: number;
+
+    @Field(() => Int, {nullable: true})
+    TotalRowCount: number;
+
+    @Field(() => Int, {nullable: true})
+    ExecutionTime: number;
+
+    @Field({nullable: true})
+    ErrorMessage?: string;
+
+    @Field(() => Boolean, {nullable: false})
+    Success: boolean;
+}
+
+@Resolver(MJContentItemDuplicate_)
+export class MJContentItemDuplicateResolver extends ResolverBase {
+    @Query(() => RunMJContentItemDuplicateViewResult)
+    async RunMJContentItemDuplicateViewByID(@Arg('input', () => RunViewByIDInput) input: RunViewByIDInput, @Ctx() { providers, userPayload }: AppContext, @PubSub() pubSub: PubSubEngine) {
+        const provider = GetReadOnlyProvider(providers, { allowFallbackToReadWrite: true });
+        return super.RunViewByIDGeneric(input, provider, userPayload, pubSub);
+    }
+
+    @Query(() => RunMJContentItemDuplicateViewResult)
+    async RunMJContentItemDuplicateViewByName(@Arg('input', () => RunViewByNameInput) input: RunViewByNameInput, @Ctx() { providers, userPayload }: AppContext, @PubSub() pubSub: PubSubEngine) {
+        const provider = GetReadOnlyProvider(providers, { allowFallbackToReadWrite: true });
+        return super.RunViewByNameGeneric(input, provider, userPayload, pubSub);
+    }
+
+    @Query(() => RunMJContentItemDuplicateViewResult)
+    async RunMJContentItemDuplicateDynamicView(@Arg('input', () => RunDynamicViewInput) input: RunDynamicViewInput, @Ctx() { providers, userPayload }: AppContext, @PubSub() pubSub: PubSubEngine) {
+        const provider = GetReadOnlyProvider(providers, { allowFallbackToReadWrite: true });
+        input.EntityName = 'MJ: Content Item Duplicates';
+        return super.RunDynamicViewGeneric(input, provider, userPayload, pubSub);
+    }
+    @Query(() => MJContentItemDuplicate_, { nullable: true })
+    async MJContentItemDuplicate(@Arg('ID', () => String) ID: string, @Ctx() { userPayload, providers }: AppContext, @PubSub() pubSub: PubSubEngine): Promise<MJContentItemDuplicate_ | null> {
+        this.CheckUserReadPermissions('MJ: Content Item Duplicates', userPayload);
+        const provider = GetReadOnlyProvider(providers, { allowFallbackToReadWrite: true });
+        const sSQL = `SELECT * FROM ${provider.QuoteSchemaAndView(Metadata.Provider.ConfigData.MJCoreSchemaName, 'vwContentItemDuplicates')} WHERE ${provider.QuoteIdentifier('ID')}='${ID}' ` + this.getRowLevelSecurityWhereClause(provider, 'MJ: Content Item Duplicates', userPayload, EntityPermissionType.Read, 'AND');
+        const rows = await provider.ExecuteSQL(sSQL, undefined, undefined, this.GetUserFromPayload(userPayload));
+        const result = await this.MapFieldNamesToCodeNames('MJ: Content Item Duplicates', rows && rows.length > 0 ? rows[0] : null, this.GetUserFromPayload(userPayload));
+        return result;
+    }
+    
+    @Mutation(() => MJContentItemDuplicate_)
+    async CreateMJContentItemDuplicate(
+        @Arg('input', () => CreateMJContentItemDuplicateInput) input: CreateMJContentItemDuplicateInput,
+        @Ctx() { providers, userPayload }: AppContext,
+        @PubSub() pubSub: PubSubEngine
+    ) {
+        const provider = GetReadWriteProvider(providers);
+        return this.CreateRecord('MJ: Content Item Duplicates', input, provider, userPayload, pubSub)
+    }
+        
+    @Mutation(() => MJContentItemDuplicate_)
+    async UpdateMJContentItemDuplicate(
+        @Arg('input', () => UpdateMJContentItemDuplicateInput) input: UpdateMJContentItemDuplicateInput,
+        @Ctx() { providers, userPayload }: AppContext,
+        @PubSub() pubSub: PubSubEngine
+    ) {
+        const provider = GetReadWriteProvider(providers);
+        return this.UpdateRecord('MJ: Content Item Duplicates', input, provider, userPayload, pubSub);
+    }
+    
+    @Mutation(() => MJContentItemDuplicate_)
+    async DeleteMJContentItemDuplicate(@Arg('ID', () => String) ID: string, @Arg('options___', () => DeleteOptionsInput) options: DeleteOptionsInput, @Ctx() { providers, userPayload }: AppContext, @PubSub() pubSub: PubSubEngine) {
+        const provider = GetReadWriteProvider(providers);
+        const key = new CompositeKey([{FieldName: 'ID', Value: ID}]);
+        return this.DeleteRecord('MJ: Content Item Duplicates', key, options, provider, userPayload, pubSub);
+    }
+    
+}
+
+//****************************************************************************
 // ENTITY CLASS for MJ: Content Item Tags
 //****************************************************************************
 @ObjectType({ description: `Links tags to content items for categorization, searchability, and content discovery across the system.` })
@@ -26858,9 +27141,17 @@ export class MJContentItemTag_ {
     @Field(() => Float, {description: `Relevance weight for this tag (0.0-1.0). 1.0 = highly relevant central topic, 0.5 = moderately relevant, 0.1 = tangentially related. Assigned by the LLM during autotagging.`}) 
     Weight: number;
         
+    @Field({nullable: true, description: `Optional link to the formal MJ Tag taxonomy. When set, this free-text tag has been matched (via semantic similarity or exact match) to a curated Tag record. NULL means the tag is unmatched free text only.`}) 
+    @MaxLength(36)
+    TagID?: string;
+        
     @Field({nullable: true}) 
     @MaxLength(250)
     Item?: string;
+        
+    @Field({nullable: true}) 
+    @MaxLength(255)
+    Tag_Virtual?: string;
         
 }
 
@@ -26880,6 +27171,9 @@ export class CreateMJContentItemTagInput {
 
     @Field(() => Float, { nullable: true })
     Weight?: number;
+
+    @Field({ nullable: true })
+    TagID: string | null;
 }
     
 
@@ -26899,6 +27193,9 @@ export class UpdateMJContentItemTagInput {
 
     @Field(() => Float, { nullable: true })
     Weight?: number;
+
+    @Field({ nullable: true })
+    TagID?: string | null;
 
     @Field(() => [KeyValuePairInput], { nullable: true })
     OldValues___?: KeyValuePairInput[];
@@ -27039,6 +27336,28 @@ export class MJContentItem_ {
     @Field() 
     _mj__UpdatedAt: Date;
         
+    @Field({nullable: true, description: `For entity-sourced content items, links to the Entity Record Document snapshot that was rendered for this item. Provides traceability back to the source entity record via ERD.EntityID + ERD.RecordID. NULL for non-entity sources.`}) 
+    @MaxLength(36)
+    EntityRecordDocumentID?: string;
+        
+    @Field({description: `Vectorization status: Pending (not yet embedded), Processing (currently being embedded), Complete (vector stored), Failed (embedding error), Skipped (excluded from vectorization).`}) 
+    @MaxLength(20)
+    EmbeddingStatus: string;
+        
+    @Field({nullable: true, description: `Timestamp of the most recent successful embedding for this content item.`}) 
+    LastEmbeddedAt?: Date;
+        
+    @Field({nullable: true, description: `The AI model used to generate the most recent embedding for this content item.`}) 
+    @MaxLength(36)
+    EmbeddingModelID?: string;
+        
+    @Field({description: `Autotagging status: Pending (not yet tagged), Processing (LLM is generating tags), Complete (tags assigned), Failed (LLM error), Skipped (excluded from tagging).`}) 
+    @MaxLength(20)
+    TaggingStatus: string;
+        
+    @Field({nullable: true, description: `Timestamp of the most recent successful autotagging run for this content item.`}) 
+    LastTaggedAt?: Date;
+        
     @Field({nullable: true}) 
     @MaxLength(255)
     ContentSource?: string;
@@ -27055,11 +27374,25 @@ export class MJContentItem_ {
     @MaxLength(255)
     ContentFileType: string;
         
+    @Field({nullable: true}) 
+    @MaxLength(450)
+    EntityRecordDocument?: string;
+        
+    @Field({nullable: true}) 
+    @MaxLength(50)
+    EmbeddingModel?: string;
+        
     @Field(() => [MJContentItemAttribute_])
     MJContentItemAttributes_ContentItemIDArray: MJContentItemAttribute_[]; // Link to MJContentItemAttributes
     
     @Field(() => [MJContentItemTag_])
     MJContentItemTags_ItemIDArray: MJContentItemTag_[]; // Link to MJContentItemTags
+    
+    @Field(() => [MJContentItemDuplicate_])
+    MJContentItemDuplicates_ContentItemAIDArray: MJContentItemDuplicate_[]; // Link to MJContentItemDuplicates
+    
+    @Field(() => [MJContentItemDuplicate_])
+    MJContentItemDuplicates_ContentItemBIDArray: MJContentItemDuplicate_[]; // Link to MJContentItemDuplicates
     
 }
 
@@ -27097,6 +27430,24 @@ export class CreateMJContentItemInput {
 
     @Field({ nullable: true })
     Text: string | null;
+
+    @Field({ nullable: true })
+    EntityRecordDocumentID: string | null;
+
+    @Field({ nullable: true })
+    EmbeddingStatus?: string;
+
+    @Field({ nullable: true })
+    LastEmbeddedAt: Date | null;
+
+    @Field({ nullable: true })
+    EmbeddingModelID: string | null;
+
+    @Field({ nullable: true })
+    TaggingStatus?: string;
+
+    @Field({ nullable: true })
+    LastTaggedAt: Date | null;
 }
     
 
@@ -27134,6 +27485,24 @@ export class UpdateMJContentItemInput {
 
     @Field({ nullable: true })
     Text?: string | null;
+
+    @Field({ nullable: true })
+    EntityRecordDocumentID?: string | null;
+
+    @Field({ nullable: true })
+    EmbeddingStatus?: string;
+
+    @Field({ nullable: true })
+    LastEmbeddedAt?: Date | null;
+
+    @Field({ nullable: true })
+    EmbeddingModelID?: string | null;
+
+    @Field({ nullable: true })
+    TaggingStatus?: string;
+
+    @Field({ nullable: true })
+    LastTaggedAt?: Date | null;
 
     @Field(() => [KeyValuePairInput], { nullable: true })
     OldValues___?: KeyValuePairInput[];
@@ -27216,6 +27585,26 @@ export class MJContentItemResolver extends ResolverBase {
         return result;
     }
         
+    @FieldResolver(() => [MJContentItemDuplicate_])
+    async MJContentItemDuplicates_ContentItemAIDArray(@Root() mjcontentitem_: MJContentItem_, @Ctx() { userPayload, providers }: AppContext, @PubSub() pubSub: PubSubEngine) {
+        this.CheckUserReadPermissions('MJ: Content Item Duplicates', userPayload);
+        const provider = GetReadOnlyProvider(providers, { allowFallbackToReadWrite: true });
+        const sSQL = `SELECT * FROM ${provider.QuoteSchemaAndView(Metadata.Provider.ConfigData.MJCoreSchemaName, 'vwContentItemDuplicates')} WHERE ${provider.QuoteIdentifier('ContentItemAID')}='${mjcontentitem_.ID}' ` + this.getRowLevelSecurityWhereClause(provider, 'MJ: Content Item Duplicates', userPayload, EntityPermissionType.Read, 'AND');
+        const rows = await provider.ExecuteSQL(sSQL, undefined, undefined, this.GetUserFromPayload(userPayload));
+        const result = await this.ArrayMapFieldNamesToCodeNames('MJ: Content Item Duplicates', rows, this.GetUserFromPayload(userPayload));
+        return result;
+    }
+        
+    @FieldResolver(() => [MJContentItemDuplicate_])
+    async MJContentItemDuplicates_ContentItemBIDArray(@Root() mjcontentitem_: MJContentItem_, @Ctx() { userPayload, providers }: AppContext, @PubSub() pubSub: PubSubEngine) {
+        this.CheckUserReadPermissions('MJ: Content Item Duplicates', userPayload);
+        const provider = GetReadOnlyProvider(providers, { allowFallbackToReadWrite: true });
+        const sSQL = `SELECT * FROM ${provider.QuoteSchemaAndView(Metadata.Provider.ConfigData.MJCoreSchemaName, 'vwContentItemDuplicates')} WHERE ${provider.QuoteIdentifier('ContentItemBID')}='${mjcontentitem_.ID}' ` + this.getRowLevelSecurityWhereClause(provider, 'MJ: Content Item Duplicates', userPayload, EntityPermissionType.Read, 'AND');
+        const rows = await provider.ExecuteSQL(sSQL, undefined, undefined, this.GetUserFromPayload(userPayload));
+        const result = await this.ArrayMapFieldNamesToCodeNames('MJ: Content Item Duplicates', rows, this.GetUserFromPayload(userPayload));
+        return result;
+    }
+        
     @Mutation(() => MJContentItem_)
     async CreateMJContentItem(
         @Arg('input', () => CreateMJContentItemInput) input: CreateMJContentItemInput,
@@ -27241,6 +27630,436 @@ export class MJContentItemResolver extends ResolverBase {
         const provider = GetReadWriteProvider(providers);
         const key = new CompositeKey([{FieldName: 'ID', Value: ID}]);
         return this.DeleteRecord('MJ: Content Items', key, options, provider, userPayload, pubSub);
+    }
+    
+}
+
+//****************************************************************************
+// ENTITY CLASS for MJ: Content Process Run Details
+//****************************************************************************
+@ObjectType({ description: `Per-content-source tracking within a pipeline run. Each source processed during a ContentProcessRun gets one detail record with item counts, timing, token usage, and cost rollups.` })
+export class MJContentProcessRunDetail_ {
+    @Field() 
+    @MaxLength(36)
+    ID: string;
+        
+    @Field({description: `The parent pipeline run this detail belongs to.`}) 
+    @MaxLength(36)
+    ContentProcessRunID: string;
+        
+    @Field({description: `The content source being processed in this detail record.`}) 
+    @MaxLength(36)
+    ContentSourceID: string;
+        
+    @Field({description: `The type of content source (RSS Feed, Entity, Website, Cloud Storage, etc.).`}) 
+    @MaxLength(36)
+    ContentSourceTypeID: string;
+        
+    @Field({description: `Processing status: Pending, Running, Completed, Failed, or Skipped.`}) 
+    @MaxLength(20)
+    Status: string;
+        
+    @Field(() => Int, {description: `Total content items processed for this source during the run.`}) 
+    ItemsProcessed: number;
+        
+    @Field(() => Int, {description: `Number of content items successfully tagged by the LLM.`}) 
+    ItemsTagged: number;
+        
+    @Field(() => Int, {description: `Number of content items successfully embedded and upserted to the vector database.`}) 
+    ItemsVectorized: number;
+        
+    @Field(() => Int, {description: `Number of new ContentItemTag records created during LLM tagging.`}) 
+    TagsCreated: number;
+        
+    @Field(() => Int, {description: `Number of errors encountered while processing this source.`}) 
+    ErrorCount: number;
+        
+    @Field({nullable: true, description: `When processing started for this source within the pipeline run.`}) 
+    StartTime?: Date;
+        
+    @Field({nullable: true, description: `When processing completed for this source within the pipeline run.`}) 
+    EndTime?: Date;
+        
+    @Field(() => Int, {description: `Rollup of all tokens used across LLM tagging and embedding calls for this source. Computed from linked AIPromptRun records via the ContentProcessRunPromptRun junction table.`}) 
+    TotalTokensUsed: number;
+        
+    @Field(() => Float, {description: `Rollup of all costs across LLM tagging and embedding calls for this source. Computed from linked AIPromptRun records via the ContentProcessRunPromptRun junction table.`}) 
+    TotalCost: number;
+        
+    @Field() 
+    _mj__CreatedAt: Date;
+        
+    @Field() 
+    _mj__UpdatedAt: Date;
+        
+    @Field({nullable: true}) 
+    @MaxLength(255)
+    ContentProcessRun?: string;
+        
+    @Field({nullable: true}) 
+    @MaxLength(255)
+    ContentSource?: string;
+        
+    @Field() 
+    @MaxLength(255)
+    ContentSourceType: string;
+        
+    @Field(() => [MJContentProcessRunPromptRun_])
+    MJContentProcessRunPromptRuns_ContentProcessRunDetailIDArray: MJContentProcessRunPromptRun_[]; // Link to MJContentProcessRunPromptRuns
+    
+}
+
+//****************************************************************************
+// INPUT TYPE for MJ: Content Process Run Details
+//****************************************************************************
+@InputType()
+export class CreateMJContentProcessRunDetailInput {
+    @Field({ nullable: true })
+    ID?: string;
+
+    @Field({ nullable: true })
+    ContentProcessRunID?: string;
+
+    @Field({ nullable: true })
+    ContentSourceID?: string;
+
+    @Field({ nullable: true })
+    ContentSourceTypeID?: string;
+
+    @Field({ nullable: true })
+    Status?: string;
+
+    @Field(() => Int, { nullable: true })
+    ItemsProcessed?: number;
+
+    @Field(() => Int, { nullable: true })
+    ItemsTagged?: number;
+
+    @Field(() => Int, { nullable: true })
+    ItemsVectorized?: number;
+
+    @Field(() => Int, { nullable: true })
+    TagsCreated?: number;
+
+    @Field(() => Int, { nullable: true })
+    ErrorCount?: number;
+
+    @Field({ nullable: true })
+    StartTime: Date | null;
+
+    @Field({ nullable: true })
+    EndTime: Date | null;
+
+    @Field(() => Int, { nullable: true })
+    TotalTokensUsed?: number;
+
+    @Field(() => Float, { nullable: true })
+    TotalCost?: number;
+}
+    
+
+//****************************************************************************
+// INPUT TYPE for MJ: Content Process Run Details
+//****************************************************************************
+@InputType()
+export class UpdateMJContentProcessRunDetailInput {
+    @Field()
+    ID: string;
+
+    @Field({ nullable: true })
+    ContentProcessRunID?: string;
+
+    @Field({ nullable: true })
+    ContentSourceID?: string;
+
+    @Field({ nullable: true })
+    ContentSourceTypeID?: string;
+
+    @Field({ nullable: true })
+    Status?: string;
+
+    @Field(() => Int, { nullable: true })
+    ItemsProcessed?: number;
+
+    @Field(() => Int, { nullable: true })
+    ItemsTagged?: number;
+
+    @Field(() => Int, { nullable: true })
+    ItemsVectorized?: number;
+
+    @Field(() => Int, { nullable: true })
+    TagsCreated?: number;
+
+    @Field(() => Int, { nullable: true })
+    ErrorCount?: number;
+
+    @Field({ nullable: true })
+    StartTime?: Date | null;
+
+    @Field({ nullable: true })
+    EndTime?: Date | null;
+
+    @Field(() => Int, { nullable: true })
+    TotalTokensUsed?: number;
+
+    @Field(() => Float, { nullable: true })
+    TotalCost?: number;
+
+    @Field(() => [KeyValuePairInput], { nullable: true })
+    OldValues___?: KeyValuePairInput[];
+}
+    
+//****************************************************************************
+// RESOLVER for MJ: Content Process Run Details
+//****************************************************************************
+@ObjectType()
+export class RunMJContentProcessRunDetailViewResult {
+    @Field(() => [MJContentProcessRunDetail_])
+    Results: MJContentProcessRunDetail_[];
+
+    @Field(() => String, {nullable: true})
+    UserViewRunID?: string;
+
+    @Field(() => Int, {nullable: true})
+    RowCount: number;
+
+    @Field(() => Int, {nullable: true})
+    TotalRowCount: number;
+
+    @Field(() => Int, {nullable: true})
+    ExecutionTime: number;
+
+    @Field({nullable: true})
+    ErrorMessage?: string;
+
+    @Field(() => Boolean, {nullable: false})
+    Success: boolean;
+}
+
+@Resolver(MJContentProcessRunDetail_)
+export class MJContentProcessRunDetailResolver extends ResolverBase {
+    @Query(() => RunMJContentProcessRunDetailViewResult)
+    async RunMJContentProcessRunDetailViewByID(@Arg('input', () => RunViewByIDInput) input: RunViewByIDInput, @Ctx() { providers, userPayload }: AppContext, @PubSub() pubSub: PubSubEngine) {
+        const provider = GetReadOnlyProvider(providers, { allowFallbackToReadWrite: true });
+        return super.RunViewByIDGeneric(input, provider, userPayload, pubSub);
+    }
+
+    @Query(() => RunMJContentProcessRunDetailViewResult)
+    async RunMJContentProcessRunDetailViewByName(@Arg('input', () => RunViewByNameInput) input: RunViewByNameInput, @Ctx() { providers, userPayload }: AppContext, @PubSub() pubSub: PubSubEngine) {
+        const provider = GetReadOnlyProvider(providers, { allowFallbackToReadWrite: true });
+        return super.RunViewByNameGeneric(input, provider, userPayload, pubSub);
+    }
+
+    @Query(() => RunMJContentProcessRunDetailViewResult)
+    async RunMJContentProcessRunDetailDynamicView(@Arg('input', () => RunDynamicViewInput) input: RunDynamicViewInput, @Ctx() { providers, userPayload }: AppContext, @PubSub() pubSub: PubSubEngine) {
+        const provider = GetReadOnlyProvider(providers, { allowFallbackToReadWrite: true });
+        input.EntityName = 'MJ: Content Process Run Details';
+        return super.RunDynamicViewGeneric(input, provider, userPayload, pubSub);
+    }
+    @Query(() => MJContentProcessRunDetail_, { nullable: true })
+    async MJContentProcessRunDetail(@Arg('ID', () => String) ID: string, @Ctx() { userPayload, providers }: AppContext, @PubSub() pubSub: PubSubEngine): Promise<MJContentProcessRunDetail_ | null> {
+        this.CheckUserReadPermissions('MJ: Content Process Run Details', userPayload);
+        const provider = GetReadOnlyProvider(providers, { allowFallbackToReadWrite: true });
+        const sSQL = `SELECT * FROM ${provider.QuoteSchemaAndView(Metadata.Provider.ConfigData.MJCoreSchemaName, 'vwContentProcessRunDetails')} WHERE ${provider.QuoteIdentifier('ID')}='${ID}' ` + this.getRowLevelSecurityWhereClause(provider, 'MJ: Content Process Run Details', userPayload, EntityPermissionType.Read, 'AND');
+        const rows = await provider.ExecuteSQL(sSQL, undefined, undefined, this.GetUserFromPayload(userPayload));
+        const result = await this.MapFieldNamesToCodeNames('MJ: Content Process Run Details', rows && rows.length > 0 ? rows[0] : null, this.GetUserFromPayload(userPayload));
+        return result;
+    }
+    
+    @FieldResolver(() => [MJContentProcessRunPromptRun_])
+    async MJContentProcessRunPromptRuns_ContentProcessRunDetailIDArray(@Root() mjcontentprocessrundetail_: MJContentProcessRunDetail_, @Ctx() { userPayload, providers }: AppContext, @PubSub() pubSub: PubSubEngine) {
+        this.CheckUserReadPermissions('MJ: Content Process Run Prompt Runs', userPayload);
+        const provider = GetReadOnlyProvider(providers, { allowFallbackToReadWrite: true });
+        const sSQL = `SELECT * FROM ${provider.QuoteSchemaAndView(Metadata.Provider.ConfigData.MJCoreSchemaName, 'vwContentProcessRunPromptRuns')} WHERE ${provider.QuoteIdentifier('ContentProcessRunDetailID')}='${mjcontentprocessrundetail_.ID}' ` + this.getRowLevelSecurityWhereClause(provider, 'MJ: Content Process Run Prompt Runs', userPayload, EntityPermissionType.Read, 'AND');
+        const rows = await provider.ExecuteSQL(sSQL, undefined, undefined, this.GetUserFromPayload(userPayload));
+        const result = await this.ArrayMapFieldNamesToCodeNames('MJ: Content Process Run Prompt Runs', rows, this.GetUserFromPayload(userPayload));
+        return result;
+    }
+        
+    @Mutation(() => MJContentProcessRunDetail_)
+    async CreateMJContentProcessRunDetail(
+        @Arg('input', () => CreateMJContentProcessRunDetailInput) input: CreateMJContentProcessRunDetailInput,
+        @Ctx() { providers, userPayload }: AppContext,
+        @PubSub() pubSub: PubSubEngine
+    ) {
+        const provider = GetReadWriteProvider(providers);
+        return this.CreateRecord('MJ: Content Process Run Details', input, provider, userPayload, pubSub)
+    }
+        
+    @Mutation(() => MJContentProcessRunDetail_)
+    async UpdateMJContentProcessRunDetail(
+        @Arg('input', () => UpdateMJContentProcessRunDetailInput) input: UpdateMJContentProcessRunDetailInput,
+        @Ctx() { providers, userPayload }: AppContext,
+        @PubSub() pubSub: PubSubEngine
+    ) {
+        const provider = GetReadWriteProvider(providers);
+        return this.UpdateRecord('MJ: Content Process Run Details', input, provider, userPayload, pubSub);
+    }
+    
+    @Mutation(() => MJContentProcessRunDetail_)
+    async DeleteMJContentProcessRunDetail(@Arg('ID', () => String) ID: string, @Arg('options___', () => DeleteOptionsInput) options: DeleteOptionsInput, @Ctx() { providers, userPayload }: AppContext, @PubSub() pubSub: PubSubEngine) {
+        const provider = GetReadWriteProvider(providers);
+        const key = new CompositeKey([{FieldName: 'ID', Value: ID}]);
+        return this.DeleteRecord('MJ: Content Process Run Details', key, options, provider, userPayload, pubSub);
+    }
+    
+}
+
+//****************************************************************************
+// ENTITY CLASS for MJ: Content Process Run Prompt Runs
+//****************************************************************************
+@ObjectType({ description: `Links ContentProcessRunDetail records to their associated AIPromptRun records. Each LLM tagging call and embedding call creates an AIPromptRun, and this junction table provides the FK relationship for cost/token analytics.` })
+export class MJContentProcessRunPromptRun_ {
+    @Field() 
+    @MaxLength(36)
+    ID: string;
+        
+    @Field({description: `The content process run detail record this prompt run is associated with.`}) 
+    @MaxLength(36)
+    ContentProcessRunDetailID: string;
+        
+    @Field({description: `The AI prompt run record containing token usage, cost, model, vendor, and execution details for this call.`}) 
+    @MaxLength(36)
+    AIPromptRunID: string;
+        
+    @Field({description: `Whether this AIPromptRun was for LLM tagging (Tag) or text embedding (Embed).`}) 
+    @MaxLength(20)
+    RunType: string;
+        
+    @Field() 
+    _mj__CreatedAt: Date;
+        
+    @Field() 
+    _mj__UpdatedAt: Date;
+        
+    @Field({nullable: true}) 
+    @MaxLength(255)
+    AIPromptRun?: string;
+        
+}
+
+//****************************************************************************
+// INPUT TYPE for MJ: Content Process Run Prompt Runs
+//****************************************************************************
+@InputType()
+export class CreateMJContentProcessRunPromptRunInput {
+    @Field({ nullable: true })
+    ID?: string;
+
+    @Field({ nullable: true })
+    ContentProcessRunDetailID?: string;
+
+    @Field({ nullable: true })
+    AIPromptRunID?: string;
+
+    @Field({ nullable: true })
+    RunType?: string;
+}
+    
+
+//****************************************************************************
+// INPUT TYPE for MJ: Content Process Run Prompt Runs
+//****************************************************************************
+@InputType()
+export class UpdateMJContentProcessRunPromptRunInput {
+    @Field()
+    ID: string;
+
+    @Field({ nullable: true })
+    ContentProcessRunDetailID?: string;
+
+    @Field({ nullable: true })
+    AIPromptRunID?: string;
+
+    @Field({ nullable: true })
+    RunType?: string;
+
+    @Field(() => [KeyValuePairInput], { nullable: true })
+    OldValues___?: KeyValuePairInput[];
+}
+    
+//****************************************************************************
+// RESOLVER for MJ: Content Process Run Prompt Runs
+//****************************************************************************
+@ObjectType()
+export class RunMJContentProcessRunPromptRunViewResult {
+    @Field(() => [MJContentProcessRunPromptRun_])
+    Results: MJContentProcessRunPromptRun_[];
+
+    @Field(() => String, {nullable: true})
+    UserViewRunID?: string;
+
+    @Field(() => Int, {nullable: true})
+    RowCount: number;
+
+    @Field(() => Int, {nullable: true})
+    TotalRowCount: number;
+
+    @Field(() => Int, {nullable: true})
+    ExecutionTime: number;
+
+    @Field({nullable: true})
+    ErrorMessage?: string;
+
+    @Field(() => Boolean, {nullable: false})
+    Success: boolean;
+}
+
+@Resolver(MJContentProcessRunPromptRun_)
+export class MJContentProcessRunPromptRunResolver extends ResolverBase {
+    @Query(() => RunMJContentProcessRunPromptRunViewResult)
+    async RunMJContentProcessRunPromptRunViewByID(@Arg('input', () => RunViewByIDInput) input: RunViewByIDInput, @Ctx() { providers, userPayload }: AppContext, @PubSub() pubSub: PubSubEngine) {
+        const provider = GetReadOnlyProvider(providers, { allowFallbackToReadWrite: true });
+        return super.RunViewByIDGeneric(input, provider, userPayload, pubSub);
+    }
+
+    @Query(() => RunMJContentProcessRunPromptRunViewResult)
+    async RunMJContentProcessRunPromptRunViewByName(@Arg('input', () => RunViewByNameInput) input: RunViewByNameInput, @Ctx() { providers, userPayload }: AppContext, @PubSub() pubSub: PubSubEngine) {
+        const provider = GetReadOnlyProvider(providers, { allowFallbackToReadWrite: true });
+        return super.RunViewByNameGeneric(input, provider, userPayload, pubSub);
+    }
+
+    @Query(() => RunMJContentProcessRunPromptRunViewResult)
+    async RunMJContentProcessRunPromptRunDynamicView(@Arg('input', () => RunDynamicViewInput) input: RunDynamicViewInput, @Ctx() { providers, userPayload }: AppContext, @PubSub() pubSub: PubSubEngine) {
+        const provider = GetReadOnlyProvider(providers, { allowFallbackToReadWrite: true });
+        input.EntityName = 'MJ: Content Process Run Prompt Runs';
+        return super.RunDynamicViewGeneric(input, provider, userPayload, pubSub);
+    }
+    @Query(() => MJContentProcessRunPromptRun_, { nullable: true })
+    async MJContentProcessRunPromptRun(@Arg('ID', () => String) ID: string, @Ctx() { userPayload, providers }: AppContext, @PubSub() pubSub: PubSubEngine): Promise<MJContentProcessRunPromptRun_ | null> {
+        this.CheckUserReadPermissions('MJ: Content Process Run Prompt Runs', userPayload);
+        const provider = GetReadOnlyProvider(providers, { allowFallbackToReadWrite: true });
+        const sSQL = `SELECT * FROM ${provider.QuoteSchemaAndView(Metadata.Provider.ConfigData.MJCoreSchemaName, 'vwContentProcessRunPromptRuns')} WHERE ${provider.QuoteIdentifier('ID')}='${ID}' ` + this.getRowLevelSecurityWhereClause(provider, 'MJ: Content Process Run Prompt Runs', userPayload, EntityPermissionType.Read, 'AND');
+        const rows = await provider.ExecuteSQL(sSQL, undefined, undefined, this.GetUserFromPayload(userPayload));
+        const result = await this.MapFieldNamesToCodeNames('MJ: Content Process Run Prompt Runs', rows && rows.length > 0 ? rows[0] : null, this.GetUserFromPayload(userPayload));
+        return result;
+    }
+    
+    @Mutation(() => MJContentProcessRunPromptRun_)
+    async CreateMJContentProcessRunPromptRun(
+        @Arg('input', () => CreateMJContentProcessRunPromptRunInput) input: CreateMJContentProcessRunPromptRunInput,
+        @Ctx() { providers, userPayload }: AppContext,
+        @PubSub() pubSub: PubSubEngine
+    ) {
+        const provider = GetReadWriteProvider(providers);
+        return this.CreateRecord('MJ: Content Process Run Prompt Runs', input, provider, userPayload, pubSub)
+    }
+        
+    @Mutation(() => MJContentProcessRunPromptRun_)
+    async UpdateMJContentProcessRunPromptRun(
+        @Arg('input', () => UpdateMJContentProcessRunPromptRunInput) input: UpdateMJContentProcessRunPromptRunInput,
+        @Ctx() { providers, userPayload }: AppContext,
+        @PubSub() pubSub: PubSubEngine
+    ) {
+        const provider = GetReadWriteProvider(providers);
+        return this.UpdateRecord('MJ: Content Process Run Prompt Runs', input, provider, userPayload, pubSub);
+    }
+    
+    @Mutation(() => MJContentProcessRunPromptRun_)
+    async DeleteMJContentProcessRunPromptRun(@Arg('ID', () => String) ID: string, @Arg('options___', () => DeleteOptionsInput) options: DeleteOptionsInput, @Ctx() { providers, userPayload }: AppContext, @PubSub() pubSub: PubSubEngine) {
+        const provider = GetReadWriteProvider(providers);
+        const key = new CompositeKey([{FieldName: 'ID', Value: ID}]);
+        return this.DeleteRecord('MJ: Content Process Run Prompt Runs', key, options, provider, userPayload, pubSub);
     }
     
 }
@@ -27277,10 +28096,42 @@ export class MJContentProcessRun_ {
     @Field() 
     _mj__UpdatedAt: Date;
         
+    @Field({nullable: true, description: `The user who triggered this pipeline run. NULL for system-initiated runs.`}) 
+    @MaxLength(36)
+    StartedByUserID?: string;
+        
+    @Field(() => Int, {nullable: true, description: `Total number of content items to process in this run. Used for progress percentage calculation.`}) 
+    TotalItemCount?: number;
+        
+    @Field(() => Int, {nullable: true, description: `StartRow offset of the last successfully completed batch. Used for resume-from-crash: next batch starts at this offset. Reset to 0 on new runs.`}) 
+    LastProcessedOffset?: number;
+        
+    @Field(() => Int, {nullable: true, description: `Number of content items processed per batch. Configurable per run, default 100.`}) 
+    BatchSize?: number;
+        
+    @Field(() => Int, {nullable: true, description: `Running count of errors encountered during processing. Used by the circuit breaker to halt the pipeline if error rate exceeds the configured threshold.`}) 
+    ErrorCount?: number;
+        
+    @Field({nullable: true, description: `Error details if the run failed. Includes error messages, stack traces, or circuit breaker trigger reason.`}) 
+    ErrorMessage?: string;
+        
+    @Field(() => Boolean, {description: `When set to 1, the pipeline stops after completing the current batch. Used for pause and cancel operations. The Status column reflects the final state (Paused or Cancelled).`}) 
+    CancellationRequested: boolean;
+        
+    @Field({nullable: true, description: `JSON snapshot of the pipeline configuration used for this run. Conforms to the IContentProcessRunConfiguration interface. Includes batch size, rate limits, error thresholds, and duplicate detection settings.`}) 
+    Configuration?: string;
+        
     @Field({nullable: true}) 
     @MaxLength(255)
     Source?: string;
         
+    @Field({nullable: true}) 
+    @MaxLength(100)
+    StartedByUser?: string;
+        
+    @Field(() => [MJContentProcessRunDetail_])
+    MJContentProcessRunDetails_ContentProcessRunIDArray: MJContentProcessRunDetail_[]; // Link to MJContentProcessRunDetails
+    
 }
 
 //****************************************************************************
@@ -27305,6 +28156,30 @@ export class CreateMJContentProcessRunInput {
 
     @Field(() => Int, { nullable: true })
     ProcessedItems: number | null;
+
+    @Field({ nullable: true })
+    StartedByUserID: string | null;
+
+    @Field(() => Int, { nullable: true })
+    TotalItemCount: number | null;
+
+    @Field(() => Int, { nullable: true })
+    LastProcessedOffset?: number | null;
+
+    @Field(() => Int, { nullable: true })
+    BatchSize?: number | null;
+
+    @Field(() => Int, { nullable: true })
+    ErrorCount?: number | null;
+
+    @Field({ nullable: true })
+    ErrorMessage: string | null;
+
+    @Field(() => Boolean, { nullable: true })
+    CancellationRequested?: boolean;
+
+    @Field({ nullable: true })
+    Configuration: string | null;
 }
     
 
@@ -27330,6 +28205,30 @@ export class UpdateMJContentProcessRunInput {
 
     @Field(() => Int, { nullable: true })
     ProcessedItems?: number | null;
+
+    @Field({ nullable: true })
+    StartedByUserID?: string | null;
+
+    @Field(() => Int, { nullable: true })
+    TotalItemCount?: number | null;
+
+    @Field(() => Int, { nullable: true })
+    LastProcessedOffset?: number | null;
+
+    @Field(() => Int, { nullable: true })
+    BatchSize?: number | null;
+
+    @Field(() => Int, { nullable: true })
+    ErrorCount?: number | null;
+
+    @Field({ nullable: true })
+    ErrorMessage?: string | null;
+
+    @Field(() => Boolean, { nullable: true })
+    CancellationRequested?: boolean;
+
+    @Field({ nullable: true })
+    Configuration?: string | null;
 
     @Field(() => [KeyValuePairInput], { nullable: true })
     OldValues___?: KeyValuePairInput[];
@@ -27392,6 +28291,16 @@ export class MJContentProcessRunResolver extends ResolverBase {
         return result;
     }
     
+    @FieldResolver(() => [MJContentProcessRunDetail_])
+    async MJContentProcessRunDetails_ContentProcessRunIDArray(@Root() mjcontentprocessrun_: MJContentProcessRun_, @Ctx() { userPayload, providers }: AppContext, @PubSub() pubSub: PubSubEngine) {
+        this.CheckUserReadPermissions('MJ: Content Process Run Details', userPayload);
+        const provider = GetReadOnlyProvider(providers, { allowFallbackToReadWrite: true });
+        const sSQL = `SELECT * FROM ${provider.QuoteSchemaAndView(Metadata.Provider.ConfigData.MJCoreSchemaName, 'vwContentProcessRunDetails')} WHERE ${provider.QuoteIdentifier('ContentProcessRunID')}='${mjcontentprocessrun_.ID}' ` + this.getRowLevelSecurityWhereClause(provider, 'MJ: Content Process Run Details', userPayload, EntityPermissionType.Read, 'AND');
+        const rows = await provider.ExecuteSQL(sSQL, undefined, undefined, this.GetUserFromPayload(userPayload));
+        const result = await this.ArrayMapFieldNamesToCodeNames('MJ: Content Process Run Details', rows, this.GetUserFromPayload(userPayload));
+        return result;
+    }
+        
     @Mutation(() => MJContentProcessRun_)
     async CreateMJContentProcessRun(
         @Arg('input', () => CreateMJContentProcessRunInput) input: CreateMJContentProcessRunInput,
@@ -27774,11 +28683,21 @@ export class MJContentSourceType_ {
     @Field() 
     _mj__UpdatedAt: Date;
         
+    @Field({nullable: true, description: `The registered class name used by ClassFactory to instantiate the provider for this source type (e.g., AutotagLocalFileSystem, AutotagEntity). Must match a @RegisterClass key on a class extending AutotagBase.`}) 
+    @MaxLength(255)
+    DriverClass?: string;
+        
+    @Field({nullable: true, description: `JSON configuration blob for type-level settings. Conforms to the IContentSourceTypeConfiguration interface. Reserved for future type-wide settings shared by all sources of this type.`}) 
+    Configuration?: string;
+        
     @Field(() => [MJContentSource_])
     MJContentSources_ContentSourceTypeIDArray: MJContentSource_[]; // Link to MJContentSources
     
     @Field(() => [MJContentItem_])
     MJContentItems_ContentSourceTypeIDArray: MJContentItem_[]; // Link to MJContentItems
+    
+    @Field(() => [MJContentProcessRunDetail_])
+    MJContentProcessRunDetails_ContentSourceTypeIDArray: MJContentProcessRunDetail_[]; // Link to MJContentProcessRunDetails
     
 }
 
@@ -27795,6 +28714,12 @@ export class CreateMJContentSourceTypeInput {
 
     @Field({ nullable: true })
     Description: string | null;
+
+    @Field({ nullable: true })
+    DriverClass: string | null;
+
+    @Field({ nullable: true })
+    Configuration: string | null;
 }
     
 
@@ -27811,6 +28736,12 @@ export class UpdateMJContentSourceTypeInput {
 
     @Field({ nullable: true })
     Description?: string | null;
+
+    @Field({ nullable: true })
+    DriverClass?: string | null;
+
+    @Field({ nullable: true })
+    Configuration?: string | null;
 
     @Field(() => [KeyValuePairInput], { nullable: true })
     OldValues___?: KeyValuePairInput[];
@@ -27893,6 +28824,16 @@ export class MJContentSourceTypeResolver extends ResolverBase {
         return result;
     }
         
+    @FieldResolver(() => [MJContentProcessRunDetail_])
+    async MJContentProcessRunDetails_ContentSourceTypeIDArray(@Root() mjcontentsourcetype_: MJContentSourceType_, @Ctx() { userPayload, providers }: AppContext, @PubSub() pubSub: PubSubEngine) {
+        this.CheckUserReadPermissions('MJ: Content Process Run Details', userPayload);
+        const provider = GetReadOnlyProvider(providers, { allowFallbackToReadWrite: true });
+        const sSQL = `SELECT * FROM ${provider.QuoteSchemaAndView(Metadata.Provider.ConfigData.MJCoreSchemaName, 'vwContentProcessRunDetails')} WHERE ${provider.QuoteIdentifier('ContentSourceTypeID')}='${mjcontentsourcetype_.ID}' ` + this.getRowLevelSecurityWhereClause(provider, 'MJ: Content Process Run Details', userPayload, EntityPermissionType.Read, 'AND');
+        const rows = await provider.ExecuteSQL(sSQL, undefined, undefined, this.GetUserFromPayload(userPayload));
+        const result = await this.ArrayMapFieldNamesToCodeNames('MJ: Content Process Run Details', rows, this.GetUserFromPayload(userPayload));
+        return result;
+    }
+        
     @Mutation(() => MJContentSourceType_)
     async CreateMJContentSourceType(
         @Arg('input', () => CreateMJContentSourceTypeInput) input: CreateMJContentSourceTypeInput,
@@ -27965,6 +28906,21 @@ export class MJContentSource_ {
     @MaxLength(36)
     VectorIndexID?: string;
         
+    @Field({nullable: true, description: `JSON configuration blob for source-instance settings. Conforms to the IContentSourceConfiguration interface. Includes tag taxonomy mode (constrained/auto-grow/free-flow), tag root ID, match threshold, LLM taxonomy sharing, and vectorization toggle.`}) 
+    Configuration?: string;
+        
+    @Field({nullable: true, description: `For Entity-type content sources, the MJ Entity to pull records from. NULL for non-entity sources (files, RSS, websites, etc.).`}) 
+    @MaxLength(36)
+    EntityID?: string;
+        
+    @Field({nullable: true, description: `For Entity-type content sources, the Entity Document template used to render entity records into text for autotagging. The template defines which fields to include, how to format them, and related record inclusion. NULL for non-entity sources.`}) 
+    @MaxLength(36)
+    EntityDocumentID?: string;
+        
+    @Field({nullable: true, description: `Optional link to a MJ Scheduled Action that automatically runs the classification pipeline for this source on a cron schedule.`}) 
+    @MaxLength(36)
+    ScheduledActionID?: string;
+        
     @Field() 
     @MaxLength(255)
     ContentType: string;
@@ -27985,6 +28941,18 @@ export class MJContentSource_ {
     @MaxLength(255)
     VectorIndex?: string;
         
+    @Field({nullable: true}) 
+    @MaxLength(255)
+    Entity?: string;
+        
+    @Field({nullable: true}) 
+    @MaxLength(250)
+    EntityDocument?: string;
+        
+    @Field({nullable: true}) 
+    @MaxLength(255)
+    ScheduledAction?: string;
+        
     @Field(() => [MJContentItem_])
     MJContentItems_ContentSourceIDArray: MJContentItem_[]; // Link to MJContentItems
     
@@ -27993,6 +28961,9 @@ export class MJContentSource_ {
     
     @Field(() => [MJContentSourceParam_])
     MJContentSourceParams_ContentSourceIDArray: MJContentSourceParam_[]; // Link to MJContentSourceParams
+    
+    @Field(() => [MJContentProcessRunDetail_])
+    MJContentProcessRunDetails_ContentSourceIDArray: MJContentProcessRunDetail_[]; // Link to MJContentProcessRunDetails
     
 }
 
@@ -28024,6 +28995,18 @@ export class CreateMJContentSourceInput {
 
     @Field({ nullable: true })
     VectorIndexID: string | null;
+
+    @Field({ nullable: true })
+    Configuration: string | null;
+
+    @Field({ nullable: true })
+    EntityID: string | null;
+
+    @Field({ nullable: true })
+    EntityDocumentID: string | null;
+
+    @Field({ nullable: true })
+    ScheduledActionID: string | null;
 }
     
 
@@ -28055,6 +29038,18 @@ export class UpdateMJContentSourceInput {
 
     @Field({ nullable: true })
     VectorIndexID?: string | null;
+
+    @Field({ nullable: true })
+    Configuration?: string | null;
+
+    @Field({ nullable: true })
+    EntityID?: string | null;
+
+    @Field({ nullable: true })
+    EntityDocumentID?: string | null;
+
+    @Field({ nullable: true })
+    ScheduledActionID?: string | null;
 
     @Field(() => [KeyValuePairInput], { nullable: true })
     OldValues___?: KeyValuePairInput[];
@@ -28144,6 +29139,16 @@ export class MJContentSourceResolver extends ResolverBase {
         const sSQL = `SELECT * FROM ${provider.QuoteSchemaAndView(Metadata.Provider.ConfigData.MJCoreSchemaName, 'vwContentSourceParams')} WHERE ${provider.QuoteIdentifier('ContentSourceID')}='${mjcontentsource_.ID}' ` + this.getRowLevelSecurityWhereClause(provider, 'MJ: Content Source Params', userPayload, EntityPermissionType.Read, 'AND');
         const rows = await provider.ExecuteSQL(sSQL, undefined, undefined, this.GetUserFromPayload(userPayload));
         const result = await this.ArrayMapFieldNamesToCodeNames('MJ: Content Source Params', rows, this.GetUserFromPayload(userPayload));
+        return result;
+    }
+        
+    @FieldResolver(() => [MJContentProcessRunDetail_])
+    async MJContentProcessRunDetails_ContentSourceIDArray(@Root() mjcontentsource_: MJContentSource_, @Ctx() { userPayload, providers }: AppContext, @PubSub() pubSub: PubSubEngine) {
+        this.CheckUserReadPermissions('MJ: Content Process Run Details', userPayload);
+        const provider = GetReadOnlyProvider(providers, { allowFallbackToReadWrite: true });
+        const sSQL = `SELECT * FROM ${provider.QuoteSchemaAndView(Metadata.Provider.ConfigData.MJCoreSchemaName, 'vwContentProcessRunDetails')} WHERE ${provider.QuoteIdentifier('ContentSourceID')}='${mjcontentsource_.ID}' ` + this.getRowLevelSecurityWhereClause(provider, 'MJ: Content Process Run Details', userPayload, EntityPermissionType.Read, 'AND');
+        const rows = await provider.ExecuteSQL(sSQL, undefined, undefined, this.GetUserFromPayload(userPayload));
+        const result = await this.ArrayMapFieldNamesToCodeNames('MJ: Content Process Run Details', rows, this.GetUserFromPayload(userPayload));
         return result;
     }
         
@@ -28379,6 +29384,9 @@ export class MJContentType_ {
     @MaxLength(36)
     VectorIndexID?: string;
         
+    @Field({nullable: true, description: `JSON configuration blob for content-type-level settings. Conforms to the IContentTypeConfiguration interface. Reserved for future type-wide settings such as default tag taxonomy rules and processing options.`}) 
+    Configuration?: string;
+        
     @Field() 
     @MaxLength(50)
     AIModel: string;
@@ -28427,6 +29435,9 @@ export class CreateMJContentTypeInput {
 
     @Field({ nullable: true })
     VectorIndexID: string | null;
+
+    @Field({ nullable: true })
+    Configuration: string | null;
 }
     
 
@@ -28458,6 +29469,9 @@ export class UpdateMJContentTypeInput {
 
     @Field({ nullable: true })
     VectorIndexID?: string | null;
+
+    @Field({ nullable: true })
+    Configuration?: string | null;
 
     @Field(() => [KeyValuePairInput], { nullable: true })
     OldValues___?: KeyValuePairInput[];
@@ -34113,6 +35127,12 @@ export class MJDuplicateRunDetail_ {
     @Field({nullable: true, description: `JSON metadata snapshot of the source record from the vector database at detection time. Contains display fields (Name, Description, EntityIcon, etc.) for rich UI rendering without additional lookups.`}) 
     RecordMetadata?: string;
         
+    @Field({nullable: true, description: `When processing started for this specific record during duplicate detection.`}) 
+    StartedAt?: Date;
+        
+    @Field({nullable: true, description: `When processing completed for this specific record during duplicate detection.`}) 
+    EndedAt?: Date;
+        
     @Field() 
     @MaxLength(255)
     DuplicateRun: string;
@@ -34153,6 +35173,12 @@ export class CreateMJDuplicateRunDetailInput {
 
     @Field({ nullable: true })
     RecordMetadata: string | null;
+
+    @Field({ nullable: true })
+    StartedAt: Date | null;
+
+    @Field({ nullable: true })
+    EndedAt: Date | null;
 }
     
 
@@ -34187,6 +35213,12 @@ export class UpdateMJDuplicateRunDetailInput {
 
     @Field({ nullable: true })
     RecordMetadata?: string | null;
+
+    @Field({ nullable: true })
+    StartedAt?: Date | null;
+
+    @Field({ nullable: true })
+    EndedAt?: Date | null;
 
     @Field(() => [KeyValuePairInput], { nullable: true })
     OldValues___?: KeyValuePairInput[];
@@ -34339,6 +35371,21 @@ export class MJDuplicateRun_ {
     @Field() 
     _mj__UpdatedAt: Date;
         
+    @Field(() => Int, {nullable: true, description: `Total entity records to check for duplicates in this run.`}) 
+    TotalItemCount?: number;
+        
+    @Field(() => Int, {nullable: true, description: `Number of records checked so far. Used for progress percentage.`}) 
+    ProcessedItemCount?: number;
+        
+    @Field(() => Int, {nullable: true, description: `Resume cursor for large-scale duplicate detection. Stores the offset of the last completed batch.`}) 
+    LastProcessedOffset?: number;
+        
+    @Field(() => Int, {nullable: true, description: `Number of records processed per batch during duplicate detection.`}) 
+    BatchSize?: number;
+        
+    @Field(() => Boolean, {description: `When set to 1, duplicate detection stops after the current batch. Used for pause/cancel.`}) 
+    CancellationRequested: boolean;
+        
     @Field() 
     @MaxLength(255)
     Entity: string;
@@ -34397,6 +35444,21 @@ export class CreateMJDuplicateRunInput {
 
     @Field({ nullable: true })
     ProcessingErrorMessage: string | null;
+
+    @Field(() => Int, { nullable: true })
+    TotalItemCount: number | null;
+
+    @Field(() => Int, { nullable: true })
+    ProcessedItemCount?: number | null;
+
+    @Field(() => Int, { nullable: true })
+    LastProcessedOffset?: number | null;
+
+    @Field(() => Int, { nullable: true })
+    BatchSize?: number | null;
+
+    @Field(() => Boolean, { nullable: true })
+    CancellationRequested?: boolean;
 }
     
 
@@ -34437,6 +35499,21 @@ export class UpdateMJDuplicateRunInput {
 
     @Field({ nullable: true })
     ProcessingErrorMessage?: string | null;
+
+    @Field(() => Int, { nullable: true })
+    TotalItemCount?: number | null;
+
+    @Field(() => Int, { nullable: true })
+    ProcessedItemCount?: number | null;
+
+    @Field(() => Int, { nullable: true })
+    LastProcessedOffset?: number | null;
+
+    @Field(() => Int, { nullable: true })
+    BatchSize?: number | null;
+
+    @Field(() => Boolean, { nullable: true })
+    CancellationRequested?: boolean;
 
     @Field(() => [KeyValuePairInput], { nullable: true })
     OldValues___?: KeyValuePairInput[];
@@ -36357,6 +37434,9 @@ export class MJEntity_ {
     @Field(() => [MJResourceType_])
     MJResourceTypes_CategoryEntityIDArray: MJResourceType_[]; // Link to MJResourceTypes
     
+    @Field(() => [MJContentSource_])
+    MJContentSources_EntityIDArray: MJContentSource_[]; // Link to MJContentSources
+    
     @Field(() => [MJTestRun_])
     MJTestRuns_TargetLogEntityIDArray: MJTestRun_[]; // Link to MJTestRuns
     
@@ -37279,6 +38359,16 @@ export class MJEntityResolverBase extends ResolverBase {
         const sSQL = `SELECT * FROM ${provider.QuoteSchemaAndView(Metadata.Provider.ConfigData.MJCoreSchemaName, 'vwResourceTypes')} WHERE ${provider.QuoteIdentifier('CategoryEntityID')}='${mjentity_.ID}' ` + this.getRowLevelSecurityWhereClause(provider, 'MJ: Resource Types', userPayload, EntityPermissionType.Read, 'AND');
         const rows = await provider.ExecuteSQL(sSQL, undefined, undefined, this.GetUserFromPayload(userPayload));
         const result = await this.ArrayMapFieldNamesToCodeNames('MJ: Resource Types', rows, this.GetUserFromPayload(userPayload));
+        return result;
+    }
+        
+    @FieldResolver(() => [MJContentSource_])
+    async MJContentSources_EntityIDArray(@Root() mjentity_: MJEntity_, @Ctx() { userPayload, providers }: AppContext, @PubSub() pubSub: PubSubEngine) {
+        this.CheckUserReadPermissions('MJ: Content Sources', userPayload);
+        const provider = GetReadOnlyProvider(providers, { allowFallbackToReadWrite: true });
+        const sSQL = `SELECT * FROM ${provider.QuoteSchemaAndView(Metadata.Provider.ConfigData.MJCoreSchemaName, 'vwContentSources')} WHERE ${provider.QuoteIdentifier('EntityID')}='${mjentity_.ID}' ` + this.getRowLevelSecurityWhereClause(provider, 'MJ: Content Sources', userPayload, EntityPermissionType.Read, 'AND');
+        const rows = await provider.ExecuteSQL(sSQL, undefined, undefined, this.GetUserFromPayload(userPayload));
+        const result = await this.ArrayMapFieldNamesToCodeNames('MJ: Content Sources', rows, this.GetUserFromPayload(userPayload));
         return result;
     }
         
@@ -39394,6 +40484,9 @@ export class MJEntityDocument_ {
     @Field(() => [MJEntityRecordDocument_])
     MJEntityRecordDocuments_EntityDocumentIDArray: MJEntityRecordDocument_[]; // Link to MJEntityRecordDocuments
     
+    @Field(() => [MJContentSource_])
+    MJContentSources_EntityDocumentIDArray: MJContentSource_[]; // Link to MJContentSources
+    
 }
 
 //****************************************************************************
@@ -39568,6 +40661,16 @@ export class MJEntityDocumentResolver extends ResolverBase {
         const sSQL = `SELECT * FROM ${provider.QuoteSchemaAndView(Metadata.Provider.ConfigData.MJCoreSchemaName, 'vwEntityRecordDocuments')} WHERE ${provider.QuoteIdentifier('EntityDocumentID')}='${mjentitydocument_.ID}' ` + this.getRowLevelSecurityWhereClause(provider, 'MJ: Entity Record Documents', userPayload, EntityPermissionType.Read, 'AND');
         const rows = await provider.ExecuteSQL(sSQL, undefined, undefined, this.GetUserFromPayload(userPayload));
         const result = await this.ArrayMapFieldNamesToCodeNames('MJ: Entity Record Documents', rows, this.GetUserFromPayload(userPayload));
+        return result;
+    }
+        
+    @FieldResolver(() => [MJContentSource_])
+    async MJContentSources_EntityDocumentIDArray(@Root() mjentitydocument_: MJEntityDocument_, @Ctx() { userPayload, providers }: AppContext, @PubSub() pubSub: PubSubEngine) {
+        this.CheckUserReadPermissions('MJ: Content Sources', userPayload);
+        const provider = GetReadOnlyProvider(providers, { allowFallbackToReadWrite: true });
+        const sSQL = `SELECT * FROM ${provider.QuoteSchemaAndView(Metadata.Provider.ConfigData.MJCoreSchemaName, 'vwContentSources')} WHERE ${provider.QuoteIdentifier('EntityDocumentID')}='${mjentitydocument_.ID}' ` + this.getRowLevelSecurityWhereClause(provider, 'MJ: Content Sources', userPayload, EntityPermissionType.Read, 'AND');
+        const rows = await provider.ExecuteSQL(sSQL, undefined, undefined, this.GetUserFromPayload(userPayload));
+        const result = await this.ArrayMapFieldNamesToCodeNames('MJ: Content Sources', rows, this.GetUserFromPayload(userPayload));
         return result;
     }
         
@@ -41243,6 +42346,9 @@ export class MJEntityRecordDocument_ {
     @MaxLength(255)
     VectorIndex: string;
         
+    @Field(() => [MJContentItem_])
+    MJContentItems_EntityRecordDocumentIDArray: MJContentItem_[]; // Link to MJContentItems
+    
 }
 
 //****************************************************************************
@@ -41372,6 +42478,16 @@ export class MJEntityRecordDocumentResolver extends ResolverBase {
         return result;
     }
     
+    @FieldResolver(() => [MJContentItem_])
+    async MJContentItems_EntityRecordDocumentIDArray(@Root() mjentityrecorddocument_: MJEntityRecordDocument_, @Ctx() { userPayload, providers }: AppContext, @PubSub() pubSub: PubSubEngine) {
+        this.CheckUserReadPermissions('MJ: Content Items', userPayload);
+        const provider = GetReadOnlyProvider(providers, { allowFallbackToReadWrite: true });
+        const sSQL = `SELECT * FROM ${provider.QuoteSchemaAndView(Metadata.Provider.ConfigData.MJCoreSchemaName, 'vwContentItems')} WHERE ${provider.QuoteIdentifier('EntityRecordDocumentID')}='${mjentityrecorddocument_.ID}' ` + this.getRowLevelSecurityWhereClause(provider, 'MJ: Content Items', userPayload, EntityPermissionType.Read, 'AND');
+        const rows = await provider.ExecuteSQL(sSQL, undefined, undefined, this.GetUserFromPayload(userPayload));
+        const result = await this.ArrayMapFieldNamesToCodeNames('MJ: Content Items', rows, this.GetUserFromPayload(userPayload));
+        return result;
+    }
+        
     @Mutation(() => MJEntityRecordDocument_)
     async CreateMJEntityRecordDocument(
         @Arg('input', () => CreateMJEntityRecordDocumentInput) input: CreateMJEntityRecordDocumentInput,
@@ -43175,6 +44291,15 @@ export class MJFileStorageAccount_ {
     @MaxLength(200)
     Credential: string;
         
+    @Field(() => [MJAIAgentType_])
+    MJAIAgentTypes_DefaultStorageAccountIDArray: MJAIAgentType_[]; // Link to MJAIAgentTypes
+    
+    @Field(() => [MJAIAgentCategory_])
+    MJAIAgentCategories_DefaultStorageAccountIDArray: MJAIAgentCategory_[]; // Link to MJAIAgentCategories
+    
+    @Field(() => [MJAIAgent_])
+    MJAIAgents_DefaultStorageAccountIDArray: MJAIAgent_[]; // Link to MJAIAgents
+    
 }
 
 //****************************************************************************
@@ -43280,6 +44405,36 @@ export class MJFileStorageAccountResolver extends ResolverBase {
         return result;
     }
     
+    @FieldResolver(() => [MJAIAgentType_])
+    async MJAIAgentTypes_DefaultStorageAccountIDArray(@Root() mjfilestorageaccount_: MJFileStorageAccount_, @Ctx() { userPayload, providers }: AppContext, @PubSub() pubSub: PubSubEngine) {
+        this.CheckUserReadPermissions('MJ: AI Agent Types', userPayload);
+        const provider = GetReadOnlyProvider(providers, { allowFallbackToReadWrite: true });
+        const sSQL = `SELECT * FROM ${provider.QuoteSchemaAndView(Metadata.Provider.ConfigData.MJCoreSchemaName, 'vwAIAgentTypes')} WHERE ${provider.QuoteIdentifier('DefaultStorageAccountID')}='${mjfilestorageaccount_.ID}' ` + this.getRowLevelSecurityWhereClause(provider, 'MJ: AI Agent Types', userPayload, EntityPermissionType.Read, 'AND');
+        const rows = await provider.ExecuteSQL(sSQL, undefined, undefined, this.GetUserFromPayload(userPayload));
+        const result = await this.ArrayMapFieldNamesToCodeNames('MJ: AI Agent Types', rows, this.GetUserFromPayload(userPayload));
+        return result;
+    }
+        
+    @FieldResolver(() => [MJAIAgentCategory_])
+    async MJAIAgentCategories_DefaultStorageAccountIDArray(@Root() mjfilestorageaccount_: MJFileStorageAccount_, @Ctx() { userPayload, providers }: AppContext, @PubSub() pubSub: PubSubEngine) {
+        this.CheckUserReadPermissions('MJ: AI Agent Categories', userPayload);
+        const provider = GetReadOnlyProvider(providers, { allowFallbackToReadWrite: true });
+        const sSQL = `SELECT * FROM ${provider.QuoteSchemaAndView(Metadata.Provider.ConfigData.MJCoreSchemaName, 'vwAIAgentCategories')} WHERE ${provider.QuoteIdentifier('DefaultStorageAccountID')}='${mjfilestorageaccount_.ID}' ` + this.getRowLevelSecurityWhereClause(provider, 'MJ: AI Agent Categories', userPayload, EntityPermissionType.Read, 'AND');
+        const rows = await provider.ExecuteSQL(sSQL, undefined, undefined, this.GetUserFromPayload(userPayload));
+        const result = await this.ArrayMapFieldNamesToCodeNames('MJ: AI Agent Categories', rows, this.GetUserFromPayload(userPayload));
+        return result;
+    }
+        
+    @FieldResolver(() => [MJAIAgent_])
+    async MJAIAgents_DefaultStorageAccountIDArray(@Root() mjfilestorageaccount_: MJFileStorageAccount_, @Ctx() { userPayload, providers }: AppContext, @PubSub() pubSub: PubSubEngine) {
+        this.CheckUserReadPermissions('MJ: AI Agents', userPayload);
+        const provider = GetReadOnlyProvider(providers, { allowFallbackToReadWrite: true });
+        const sSQL = `SELECT * FROM ${provider.QuoteSchemaAndView(Metadata.Provider.ConfigData.MJCoreSchemaName, 'vwAIAgents')} WHERE ${provider.QuoteIdentifier('DefaultStorageAccountID')}='${mjfilestorageaccount_.ID}' ` + this.getRowLevelSecurityWhereClause(provider, 'MJ: AI Agents', userPayload, EntityPermissionType.Read, 'AND');
+        const rows = await provider.ExecuteSQL(sSQL, undefined, undefined, this.GetUserFromPayload(userPayload));
+        const result = await this.ArrayMapFieldNamesToCodeNames('MJ: AI Agents', rows, this.GetUserFromPayload(userPayload));
+        return result;
+    }
+        
     @Mutation(() => MJFileStorageAccount_)
     async CreateMJFileStorageAccount(
         @Arg('input', () => CreateMJFileStorageAccountInput) input: CreateMJFileStorageAccountInput,
@@ -45573,6 +46728,201 @@ export class MJIntegrationResolver extends ResolverBase {
         const provider = GetReadWriteProvider(providers);
         const key = new CompositeKey([{FieldName: 'ID', Value: ID}]);
         return this.DeleteRecord('MJ: Integrations', key, options, provider, userPayload, pubSub);
+    }
+    
+}
+
+//****************************************************************************
+// ENTITY CLASS for MJ: Knowledge Hub Saved Searches
+//****************************************************************************
+@ObjectType({ description: `User-saved search queries for the Knowledge Hub. Stores query text, active filters (JSON), and score thresholds so searches can be recalled or run on a schedule.` })
+export class MJKnowledgeHubSavedSearch_ {
+    @Field() 
+    @MaxLength(36)
+    ID: string;
+        
+    @Field() 
+    @MaxLength(36)
+    UserID: string;
+        
+    @Field() 
+    @MaxLength(255)
+    Name: string;
+        
+    @Field() 
+    @MaxLength(1000)
+    Query: string;
+        
+    @Field({nullable: true, description: `JSON object with active filter selections. Keys are filter categories (Entity, Tags), values are arrays of selected option values.`}) 
+    Filters?: string;
+        
+    @Field(() => Float, {nullable: true}) 
+    MinScore?: number;
+        
+    @Field(() => Int, {nullable: true}) 
+    MaxResults?: number;
+        
+    @Field(() => Boolean, {description: `When enabled, the system will notify the user when new results match this saved search (future capability).`}) 
+    NotifyOnNewResults: boolean;
+        
+    @Field() 
+    _mj__CreatedAt: Date;
+        
+    @Field() 
+    _mj__UpdatedAt: Date;
+        
+    @Field() 
+    @MaxLength(100)
+    User: string;
+        
+}
+
+//****************************************************************************
+// INPUT TYPE for MJ: Knowledge Hub Saved Searches
+//****************************************************************************
+@InputType()
+export class CreateMJKnowledgeHubSavedSearchInput {
+    @Field({ nullable: true })
+    ID?: string;
+
+    @Field({ nullable: true })
+    UserID?: string;
+
+    @Field({ nullable: true })
+    Name?: string;
+
+    @Field({ nullable: true })
+    Query?: string;
+
+    @Field({ nullable: true })
+    Filters: string | null;
+
+    @Field(() => Float, { nullable: true })
+    MinScore: number | null;
+
+    @Field(() => Int, { nullable: true })
+    MaxResults?: number | null;
+
+    @Field(() => Boolean, { nullable: true })
+    NotifyOnNewResults?: boolean;
+}
+    
+
+//****************************************************************************
+// INPUT TYPE for MJ: Knowledge Hub Saved Searches
+//****************************************************************************
+@InputType()
+export class UpdateMJKnowledgeHubSavedSearchInput {
+    @Field()
+    ID: string;
+
+    @Field({ nullable: true })
+    UserID?: string;
+
+    @Field({ nullable: true })
+    Name?: string;
+
+    @Field({ nullable: true })
+    Query?: string;
+
+    @Field({ nullable: true })
+    Filters?: string | null;
+
+    @Field(() => Float, { nullable: true })
+    MinScore?: number | null;
+
+    @Field(() => Int, { nullable: true })
+    MaxResults?: number | null;
+
+    @Field(() => Boolean, { nullable: true })
+    NotifyOnNewResults?: boolean;
+
+    @Field(() => [KeyValuePairInput], { nullable: true })
+    OldValues___?: KeyValuePairInput[];
+}
+    
+//****************************************************************************
+// RESOLVER for MJ: Knowledge Hub Saved Searches
+//****************************************************************************
+@ObjectType()
+export class RunMJKnowledgeHubSavedSearchViewResult {
+    @Field(() => [MJKnowledgeHubSavedSearch_])
+    Results: MJKnowledgeHubSavedSearch_[];
+
+    @Field(() => String, {nullable: true})
+    UserViewRunID?: string;
+
+    @Field(() => Int, {nullable: true})
+    RowCount: number;
+
+    @Field(() => Int, {nullable: true})
+    TotalRowCount: number;
+
+    @Field(() => Int, {nullable: true})
+    ExecutionTime: number;
+
+    @Field({nullable: true})
+    ErrorMessage?: string;
+
+    @Field(() => Boolean, {nullable: false})
+    Success: boolean;
+}
+
+@Resolver(MJKnowledgeHubSavedSearch_)
+export class MJKnowledgeHubSavedSearchResolver extends ResolverBase {
+    @Query(() => RunMJKnowledgeHubSavedSearchViewResult)
+    async RunMJKnowledgeHubSavedSearchViewByID(@Arg('input', () => RunViewByIDInput) input: RunViewByIDInput, @Ctx() { providers, userPayload }: AppContext, @PubSub() pubSub: PubSubEngine) {
+        const provider = GetReadOnlyProvider(providers, { allowFallbackToReadWrite: true });
+        return super.RunViewByIDGeneric(input, provider, userPayload, pubSub);
+    }
+
+    @Query(() => RunMJKnowledgeHubSavedSearchViewResult)
+    async RunMJKnowledgeHubSavedSearchViewByName(@Arg('input', () => RunViewByNameInput) input: RunViewByNameInput, @Ctx() { providers, userPayload }: AppContext, @PubSub() pubSub: PubSubEngine) {
+        const provider = GetReadOnlyProvider(providers, { allowFallbackToReadWrite: true });
+        return super.RunViewByNameGeneric(input, provider, userPayload, pubSub);
+    }
+
+    @Query(() => RunMJKnowledgeHubSavedSearchViewResult)
+    async RunMJKnowledgeHubSavedSearchDynamicView(@Arg('input', () => RunDynamicViewInput) input: RunDynamicViewInput, @Ctx() { providers, userPayload }: AppContext, @PubSub() pubSub: PubSubEngine) {
+        const provider = GetReadOnlyProvider(providers, { allowFallbackToReadWrite: true });
+        input.EntityName = 'MJ: Knowledge Hub Saved Searches';
+        return super.RunDynamicViewGeneric(input, provider, userPayload, pubSub);
+    }
+    @Query(() => MJKnowledgeHubSavedSearch_, { nullable: true })
+    async MJKnowledgeHubSavedSearch(@Arg('ID', () => String) ID: string, @Ctx() { userPayload, providers }: AppContext, @PubSub() pubSub: PubSubEngine): Promise<MJKnowledgeHubSavedSearch_ | null> {
+        this.CheckUserReadPermissions('MJ: Knowledge Hub Saved Searches', userPayload);
+        const provider = GetReadOnlyProvider(providers, { allowFallbackToReadWrite: true });
+        const sSQL = `SELECT * FROM ${provider.QuoteSchemaAndView(Metadata.Provider.ConfigData.MJCoreSchemaName, 'vwKnowledgeHubSavedSearches')} WHERE ${provider.QuoteIdentifier('ID')}='${ID}' ` + this.getRowLevelSecurityWhereClause(provider, 'MJ: Knowledge Hub Saved Searches', userPayload, EntityPermissionType.Read, 'AND');
+        const rows = await provider.ExecuteSQL(sSQL, undefined, undefined, this.GetUserFromPayload(userPayload));
+        const result = await this.MapFieldNamesToCodeNames('MJ: Knowledge Hub Saved Searches', rows && rows.length > 0 ? rows[0] : null, this.GetUserFromPayload(userPayload));
+        return result;
+    }
+    
+    @Mutation(() => MJKnowledgeHubSavedSearch_)
+    async CreateMJKnowledgeHubSavedSearch(
+        @Arg('input', () => CreateMJKnowledgeHubSavedSearchInput) input: CreateMJKnowledgeHubSavedSearchInput,
+        @Ctx() { providers, userPayload }: AppContext,
+        @PubSub() pubSub: PubSubEngine
+    ) {
+        const provider = GetReadWriteProvider(providers);
+        return this.CreateRecord('MJ: Knowledge Hub Saved Searches', input, provider, userPayload, pubSub)
+    }
+        
+    @Mutation(() => MJKnowledgeHubSavedSearch_)
+    async UpdateMJKnowledgeHubSavedSearch(
+        @Arg('input', () => UpdateMJKnowledgeHubSavedSearchInput) input: UpdateMJKnowledgeHubSavedSearchInput,
+        @Ctx() { providers, userPayload }: AppContext,
+        @PubSub() pubSub: PubSubEngine
+    ) {
+        const provider = GetReadWriteProvider(providers);
+        return this.UpdateRecord('MJ: Knowledge Hub Saved Searches', input, provider, userPayload, pubSub);
+    }
+    
+    @Mutation(() => MJKnowledgeHubSavedSearch_)
+    async DeleteMJKnowledgeHubSavedSearch(@Arg('ID', () => String) ID: string, @Arg('options___', () => DeleteOptionsInput) options: DeleteOptionsInput, @Ctx() { providers, userPayload }: AppContext, @PubSub() pubSub: PubSubEngine) {
+        const provider = GetReadWriteProvider(providers);
+        const key = new CompositeKey([{FieldName: 'ID', Value: ID}]);
+        return this.DeleteRecord('MJ: Knowledge Hub Saved Searches', key, options, provider, userPayload, pubSub);
     }
     
 }
@@ -58157,6 +59507,9 @@ export class MJScheduledAction_ {
     @Field(() => [MJScheduledActionParam_])
     MJScheduledActionParams_ScheduledActionIDArray: MJScheduledActionParam_[]; // Link to MJScheduledActionParams
     
+    @Field(() => [MJContentSource_])
+    MJContentSources_ScheduledActionIDArray: MJContentSource_[]; // Link to MJContentSources
+    
 }
 
 //****************************************************************************
@@ -58323,6 +59676,16 @@ export class MJScheduledActionResolver extends ResolverBase {
         const sSQL = `SELECT * FROM ${provider.QuoteSchemaAndView(Metadata.Provider.ConfigData.MJCoreSchemaName, 'vwScheduledActionParams')} WHERE ${provider.QuoteIdentifier('ScheduledActionID')}='${mjscheduledaction_.ID}' ` + this.getRowLevelSecurityWhereClause(provider, 'MJ: Scheduled Action Params', userPayload, EntityPermissionType.Read, 'AND');
         const rows = await provider.ExecuteSQL(sSQL, undefined, undefined, this.GetUserFromPayload(userPayload));
         const result = await this.ArrayMapFieldNamesToCodeNames('MJ: Scheduled Action Params', rows, this.GetUserFromPayload(userPayload));
+        return result;
+    }
+        
+    @FieldResolver(() => [MJContentSource_])
+    async MJContentSources_ScheduledActionIDArray(@Root() mjscheduledaction_: MJScheduledAction_, @Ctx() { userPayload, providers }: AppContext, @PubSub() pubSub: PubSubEngine) {
+        this.CheckUserReadPermissions('MJ: Content Sources', userPayload);
+        const provider = GetReadOnlyProvider(providers, { allowFallbackToReadWrite: true });
+        const sSQL = `SELECT * FROM ${provider.QuoteSchemaAndView(Metadata.Provider.ConfigData.MJCoreSchemaName, 'vwContentSources')} WHERE ${provider.QuoteIdentifier('ScheduledActionID')}='${mjscheduledaction_.ID}' ` + this.getRowLevelSecurityWhereClause(provider, 'MJ: Content Sources', userPayload, EntityPermissionType.Read, 'AND');
+        const rows = await provider.ExecuteSQL(sSQL, undefined, undefined, this.GetUserFromPayload(userPayload));
+        const result = await this.ArrayMapFieldNamesToCodeNames('MJ: Content Sources', rows, this.GetUserFromPayload(userPayload));
         return result;
     }
         
@@ -59803,6 +61166,363 @@ export class MJSQLDialectResolver extends ResolverBase {
 }
 
 //****************************************************************************
+// ENTITY CLASS for MJ: Tag Audit Logs
+//****************************************************************************
+@ObjectType({ description: `Immutable audit trail for all tag taxonomy changes. Each row records a single action with before/after details in JSON.` })
+export class MJTagAuditLog_ {
+    @Field() 
+    @MaxLength(36)
+    ID: string;
+        
+    @Field({description: `The tag that was acted upon.`}) 
+    @MaxLength(36)
+    TagID: string;
+        
+    @Field({description: `The type of action performed: Created, Renamed, Moved (parent changed), Merged (into RelatedTagID), Split (from RelatedTagID), Deprecated, Reactivated, Deleted, DescriptionChanged.`}) 
+    @MaxLength(30)
+    Action: string;
+        
+    @Field({nullable: true, description: `JSON object with action-specific details. For Renamed: {"OldName":"...","NewName":"..."}. For Moved: {"OldParentID":"...","NewParentID":"..."}. For Merged: {"ItemsMoved":42}.`}) 
+    Details?: string;
+        
+    @Field({description: `User who performed the action.`}) 
+    @MaxLength(36)
+    PerformedByUserID: string;
+        
+    @Field({nullable: true, description: `For Merged actions: the surviving tag. For Split actions: the source tag. NULL for other actions.`}) 
+    @MaxLength(36)
+    RelatedTagID?: string;
+        
+    @Field() 
+    _mj__CreatedAt: Date;
+        
+    @Field() 
+    _mj__UpdatedAt: Date;
+        
+    @Field() 
+    @MaxLength(255)
+    Tag: string;
+        
+    @Field() 
+    @MaxLength(100)
+    PerformedByUser: string;
+        
+    @Field({nullable: true}) 
+    @MaxLength(255)
+    RelatedTag?: string;
+        
+}
+
+//****************************************************************************
+// INPUT TYPE for MJ: Tag Audit Logs
+//****************************************************************************
+@InputType()
+export class CreateMJTagAuditLogInput {
+    @Field({ nullable: true })
+    ID?: string;
+
+    @Field({ nullable: true })
+    TagID?: string;
+
+    @Field({ nullable: true })
+    Action?: string;
+
+    @Field({ nullable: true })
+    Details: string | null;
+
+    @Field({ nullable: true })
+    PerformedByUserID?: string;
+
+    @Field({ nullable: true })
+    RelatedTagID: string | null;
+}
+    
+
+//****************************************************************************
+// INPUT TYPE for MJ: Tag Audit Logs
+//****************************************************************************
+@InputType()
+export class UpdateMJTagAuditLogInput {
+    @Field()
+    ID: string;
+
+    @Field({ nullable: true })
+    TagID?: string;
+
+    @Field({ nullable: true })
+    Action?: string;
+
+    @Field({ nullable: true })
+    Details?: string | null;
+
+    @Field({ nullable: true })
+    PerformedByUserID?: string;
+
+    @Field({ nullable: true })
+    RelatedTagID?: string | null;
+
+    @Field(() => [KeyValuePairInput], { nullable: true })
+    OldValues___?: KeyValuePairInput[];
+}
+    
+//****************************************************************************
+// RESOLVER for MJ: Tag Audit Logs
+//****************************************************************************
+@ObjectType()
+export class RunMJTagAuditLogViewResult {
+    @Field(() => [MJTagAuditLog_])
+    Results: MJTagAuditLog_[];
+
+    @Field(() => String, {nullable: true})
+    UserViewRunID?: string;
+
+    @Field(() => Int, {nullable: true})
+    RowCount: number;
+
+    @Field(() => Int, {nullable: true})
+    TotalRowCount: number;
+
+    @Field(() => Int, {nullable: true})
+    ExecutionTime: number;
+
+    @Field({nullable: true})
+    ErrorMessage?: string;
+
+    @Field(() => Boolean, {nullable: false})
+    Success: boolean;
+}
+
+@Resolver(MJTagAuditLog_)
+export class MJTagAuditLogResolver extends ResolverBase {
+    @Query(() => RunMJTagAuditLogViewResult)
+    async RunMJTagAuditLogViewByID(@Arg('input', () => RunViewByIDInput) input: RunViewByIDInput, @Ctx() { providers, userPayload }: AppContext, @PubSub() pubSub: PubSubEngine) {
+        const provider = GetReadOnlyProvider(providers, { allowFallbackToReadWrite: true });
+        return super.RunViewByIDGeneric(input, provider, userPayload, pubSub);
+    }
+
+    @Query(() => RunMJTagAuditLogViewResult)
+    async RunMJTagAuditLogViewByName(@Arg('input', () => RunViewByNameInput) input: RunViewByNameInput, @Ctx() { providers, userPayload }: AppContext, @PubSub() pubSub: PubSubEngine) {
+        const provider = GetReadOnlyProvider(providers, { allowFallbackToReadWrite: true });
+        return super.RunViewByNameGeneric(input, provider, userPayload, pubSub);
+    }
+
+    @Query(() => RunMJTagAuditLogViewResult)
+    async RunMJTagAuditLogDynamicView(@Arg('input', () => RunDynamicViewInput) input: RunDynamicViewInput, @Ctx() { providers, userPayload }: AppContext, @PubSub() pubSub: PubSubEngine) {
+        const provider = GetReadOnlyProvider(providers, { allowFallbackToReadWrite: true });
+        input.EntityName = 'MJ: Tag Audit Logs';
+        return super.RunDynamicViewGeneric(input, provider, userPayload, pubSub);
+    }
+    @Query(() => MJTagAuditLog_, { nullable: true })
+    async MJTagAuditLog(@Arg('ID', () => String) ID: string, @Ctx() { userPayload, providers }: AppContext, @PubSub() pubSub: PubSubEngine): Promise<MJTagAuditLog_ | null> {
+        this.CheckUserReadPermissions('MJ: Tag Audit Logs', userPayload);
+        const provider = GetReadOnlyProvider(providers, { allowFallbackToReadWrite: true });
+        const sSQL = `SELECT * FROM ${provider.QuoteSchemaAndView(Metadata.Provider.ConfigData.MJCoreSchemaName, 'vwTagAuditLogs')} WHERE ${provider.QuoteIdentifier('ID')}='${ID}' ` + this.getRowLevelSecurityWhereClause(provider, 'MJ: Tag Audit Logs', userPayload, EntityPermissionType.Read, 'AND');
+        const rows = await provider.ExecuteSQL(sSQL, undefined, undefined, this.GetUserFromPayload(userPayload));
+        const result = await this.MapFieldNamesToCodeNames('MJ: Tag Audit Logs', rows && rows.length > 0 ? rows[0] : null, this.GetUserFromPayload(userPayload));
+        return result;
+    }
+    
+    @Mutation(() => MJTagAuditLog_)
+    async CreateMJTagAuditLog(
+        @Arg('input', () => CreateMJTagAuditLogInput) input: CreateMJTagAuditLogInput,
+        @Ctx() { providers, userPayload }: AppContext,
+        @PubSub() pubSub: PubSubEngine
+    ) {
+        const provider = GetReadWriteProvider(providers);
+        return this.CreateRecord('MJ: Tag Audit Logs', input, provider, userPayload, pubSub)
+    }
+        
+    @Mutation(() => MJTagAuditLog_)
+    async UpdateMJTagAuditLog(
+        @Arg('input', () => UpdateMJTagAuditLogInput) input: UpdateMJTagAuditLogInput,
+        @Ctx() { providers, userPayload }: AppContext,
+        @PubSub() pubSub: PubSubEngine
+    ) {
+        const provider = GetReadWriteProvider(providers);
+        return this.UpdateRecord('MJ: Tag Audit Logs', input, provider, userPayload, pubSub);
+    }
+    
+    @Mutation(() => MJTagAuditLog_)
+    async DeleteMJTagAuditLog(@Arg('ID', () => String) ID: string, @Arg('options___', () => DeleteOptionsInput) options: DeleteOptionsInput, @Ctx() { providers, userPayload }: AppContext, @PubSub() pubSub: PubSubEngine) {
+        const provider = GetReadWriteProvider(providers);
+        const key = new CompositeKey([{FieldName: 'ID', Value: ID}]);
+        return this.DeleteRecord('MJ: Tag Audit Logs', key, options, provider, userPayload, pubSub);
+    }
+    
+}
+
+//****************************************************************************
+// ENTITY CLASS for MJ: Tag Co Occurrences
+//****************************************************************************
+@ObjectType({ description: `Materialized co-occurrence counts for tag pairs. Records how many content items share both tags. Used for taxonomy health analysis, merge suggestions, and cross-entity intelligence. Recomputed periodically by the pipeline.` })
+export class MJTagCoOccurrence_ {
+    @Field() 
+    @MaxLength(36)
+    ID: string;
+        
+    @Field({description: `First tag in the canonical pair (TagAID < TagBID ensures each pair is stored exactly once).`}) 
+    @MaxLength(36)
+    TagAID: string;
+        
+    @Field() 
+    @MaxLength(36)
+    TagBID: string;
+        
+    @Field(() => Int, {description: `Number of content items (or entity records via TaggedItem) that are tagged with both TagA and TagB.`}) 
+    CoOccurrenceCount: number;
+        
+    @Field() 
+    LastComputedAt: Date;
+        
+    @Field() 
+    _mj__CreatedAt: Date;
+        
+    @Field() 
+    _mj__UpdatedAt: Date;
+        
+    @Field() 
+    @MaxLength(255)
+    TagA: string;
+        
+    @Field() 
+    @MaxLength(255)
+    TagB: string;
+        
+}
+
+//****************************************************************************
+// INPUT TYPE for MJ: Tag Co Occurrences
+//****************************************************************************
+@InputType()
+export class CreateMJTagCoOccurrenceInput {
+    @Field({ nullable: true })
+    ID?: string;
+
+    @Field({ nullable: true })
+    TagAID?: string;
+
+    @Field({ nullable: true })
+    TagBID?: string;
+
+    @Field(() => Int, { nullable: true })
+    CoOccurrenceCount?: number;
+
+    @Field({ nullable: true })
+    LastComputedAt?: Date;
+}
+    
+
+//****************************************************************************
+// INPUT TYPE for MJ: Tag Co Occurrences
+//****************************************************************************
+@InputType()
+export class UpdateMJTagCoOccurrenceInput {
+    @Field()
+    ID: string;
+
+    @Field({ nullable: true })
+    TagAID?: string;
+
+    @Field({ nullable: true })
+    TagBID?: string;
+
+    @Field(() => Int, { nullable: true })
+    CoOccurrenceCount?: number;
+
+    @Field({ nullable: true })
+    LastComputedAt?: Date;
+
+    @Field(() => [KeyValuePairInput], { nullable: true })
+    OldValues___?: KeyValuePairInput[];
+}
+    
+//****************************************************************************
+// RESOLVER for MJ: Tag Co Occurrences
+//****************************************************************************
+@ObjectType()
+export class RunMJTagCoOccurrenceViewResult {
+    @Field(() => [MJTagCoOccurrence_])
+    Results: MJTagCoOccurrence_[];
+
+    @Field(() => String, {nullable: true})
+    UserViewRunID?: string;
+
+    @Field(() => Int, {nullable: true})
+    RowCount: number;
+
+    @Field(() => Int, {nullable: true})
+    TotalRowCount: number;
+
+    @Field(() => Int, {nullable: true})
+    ExecutionTime: number;
+
+    @Field({nullable: true})
+    ErrorMessage?: string;
+
+    @Field(() => Boolean, {nullable: false})
+    Success: boolean;
+}
+
+@Resolver(MJTagCoOccurrence_)
+export class MJTagCoOccurrenceResolver extends ResolverBase {
+    @Query(() => RunMJTagCoOccurrenceViewResult)
+    async RunMJTagCoOccurrenceViewByID(@Arg('input', () => RunViewByIDInput) input: RunViewByIDInput, @Ctx() { providers, userPayload }: AppContext, @PubSub() pubSub: PubSubEngine) {
+        const provider = GetReadOnlyProvider(providers, { allowFallbackToReadWrite: true });
+        return super.RunViewByIDGeneric(input, provider, userPayload, pubSub);
+    }
+
+    @Query(() => RunMJTagCoOccurrenceViewResult)
+    async RunMJTagCoOccurrenceViewByName(@Arg('input', () => RunViewByNameInput) input: RunViewByNameInput, @Ctx() { providers, userPayload }: AppContext, @PubSub() pubSub: PubSubEngine) {
+        const provider = GetReadOnlyProvider(providers, { allowFallbackToReadWrite: true });
+        return super.RunViewByNameGeneric(input, provider, userPayload, pubSub);
+    }
+
+    @Query(() => RunMJTagCoOccurrenceViewResult)
+    async RunMJTagCoOccurrenceDynamicView(@Arg('input', () => RunDynamicViewInput) input: RunDynamicViewInput, @Ctx() { providers, userPayload }: AppContext, @PubSub() pubSub: PubSubEngine) {
+        const provider = GetReadOnlyProvider(providers, { allowFallbackToReadWrite: true });
+        input.EntityName = 'MJ: Tag Co Occurrences';
+        return super.RunDynamicViewGeneric(input, provider, userPayload, pubSub);
+    }
+    @Query(() => MJTagCoOccurrence_, { nullable: true })
+    async MJTagCoOccurrence(@Arg('ID', () => String) ID: string, @Ctx() { userPayload, providers }: AppContext, @PubSub() pubSub: PubSubEngine): Promise<MJTagCoOccurrence_ | null> {
+        this.CheckUserReadPermissions('MJ: Tag Co Occurrences', userPayload);
+        const provider = GetReadOnlyProvider(providers, { allowFallbackToReadWrite: true });
+        const sSQL = `SELECT * FROM ${provider.QuoteSchemaAndView(Metadata.Provider.ConfigData.MJCoreSchemaName, 'vwTagCoOccurrences')} WHERE ${provider.QuoteIdentifier('ID')}='${ID}' ` + this.getRowLevelSecurityWhereClause(provider, 'MJ: Tag Co Occurrences', userPayload, EntityPermissionType.Read, 'AND');
+        const rows = await provider.ExecuteSQL(sSQL, undefined, undefined, this.GetUserFromPayload(userPayload));
+        const result = await this.MapFieldNamesToCodeNames('MJ: Tag Co Occurrences', rows && rows.length > 0 ? rows[0] : null, this.GetUserFromPayload(userPayload));
+        return result;
+    }
+    
+    @Mutation(() => MJTagCoOccurrence_)
+    async CreateMJTagCoOccurrence(
+        @Arg('input', () => CreateMJTagCoOccurrenceInput) input: CreateMJTagCoOccurrenceInput,
+        @Ctx() { providers, userPayload }: AppContext,
+        @PubSub() pubSub: PubSubEngine
+    ) {
+        const provider = GetReadWriteProvider(providers);
+        return this.CreateRecord('MJ: Tag Co Occurrences', input, provider, userPayload, pubSub)
+    }
+        
+    @Mutation(() => MJTagCoOccurrence_)
+    async UpdateMJTagCoOccurrence(
+        @Arg('input', () => UpdateMJTagCoOccurrenceInput) input: UpdateMJTagCoOccurrenceInput,
+        @Ctx() { providers, userPayload }: AppContext,
+        @PubSub() pubSub: PubSubEngine
+    ) {
+        const provider = GetReadWriteProvider(providers);
+        return this.UpdateRecord('MJ: Tag Co Occurrences', input, provider, userPayload, pubSub);
+    }
+    
+    @Mutation(() => MJTagCoOccurrence_)
+    async DeleteMJTagCoOccurrence(@Arg('ID', () => String) ID: string, @Arg('options___', () => DeleteOptionsInput) options: DeleteOptionsInput, @Ctx() { providers, userPayload }: AppContext, @PubSub() pubSub: PubSubEngine) {
+        const provider = GetReadWriteProvider(providers);
+        const key = new CompositeKey([{FieldName: 'ID', Value: ID}]);
+        return this.DeleteRecord('MJ: Tag Co Occurrences', key, options, provider, userPayload, pubSub);
+    }
+    
+}
+
+//****************************************************************************
 // ENTITY CLASS for MJ: Tagged Items
 //****************************************************************************
 @ObjectType({ description: `Tracks the links between any record in any entity with Tags` })
@@ -59828,6 +61548,9 @@ export class MJTaggedItem_ {
         
     @Field() 
     _mj__UpdatedAt: Date;
+        
+    @Field(() => Float, {description: `Relevance weight of this tag association (0.0 to 1.0). 1.0 indicates the tag is highly relevant or was manually applied. Lower values indicate decreasing relevance as determined by LLM autotagging. Default 1.0 for manually applied tags.`}) 
+    Weight: number;
         
     @Field() 
     @MaxLength(255)
@@ -59855,6 +61578,9 @@ export class CreateMJTaggedItemInput {
 
     @Field({ nullable: true })
     RecordID?: string;
+
+    @Field(() => Float, { nullable: true })
+    Weight?: number;
 }
     
 
@@ -59874,6 +61600,9 @@ export class UpdateMJTaggedItemInput {
 
     @Field({ nullable: true })
     RecordID?: string;
+
+    @Field(() => Float, { nullable: true })
+    Weight?: number;
 
     @Field(() => [KeyValuePairInput], { nullable: true })
     OldValues___?: KeyValuePairInput[];
@@ -59995,19 +61724,53 @@ export class MJTag_ {
     @Field() 
     _mj__UpdatedAt: Date;
         
+    @Field({description: `Lifecycle status of the tag: Active (in use), Merged (consolidated into another tag), Deprecated (no longer assigned but preserved), Deleted (soft-deleted).`}) 
+    @MaxLength(20)
+    Status: string;
+        
+    @Field({nullable: true, description: `When Status is Merged, points to the surviving tag this tag was merged into. All TaggedItem and ContentItemTag references are re-pointed during merge.`}) 
+    @MaxLength(36)
+    MergedIntoTagID?: string;
+        
     @Field({nullable: true}) 
     @MaxLength(255)
     Parent?: string;
         
     @Field({nullable: true}) 
+    @MaxLength(255)
+    MergedIntoTag?: string;
+        
+    @Field({nullable: true}) 
     @MaxLength(36)
     RootParentID?: string;
+        
+    @Field({nullable: true}) 
+    @MaxLength(36)
+    RootMergedIntoTagID?: string;
         
     @Field(() => [MJTag_])
     MJTags_ParentIDArray: MJTag_[]; // Link to MJTags
     
     @Field(() => [MJTaggedItem_])
     MJTaggedItems_TagIDArray: MJTaggedItem_[]; // Link to MJTaggedItems
+    
+    @Field(() => [MJContentItemTag_])
+    MJContentItemTags_TagIDArray: MJContentItemTag_[]; // Link to MJContentItemTags
+    
+    @Field(() => [MJTagCoOccurrence_])
+    MJTagCoOccurrences_TagBIDArray: MJTagCoOccurrence_[]; // Link to MJTagCoOccurrences
+    
+    @Field(() => [MJTagAuditLog_])
+    MJTagAuditLogs_RelatedTagIDArray: MJTagAuditLog_[]; // Link to MJTagAuditLogs
+    
+    @Field(() => [MJTagCoOccurrence_])
+    MJTagCoOccurrences_TagAIDArray: MJTagCoOccurrence_[]; // Link to MJTagCoOccurrences
+    
+    @Field(() => [MJTagAuditLog_])
+    MJTagAuditLogs_TagIDArray: MJTagAuditLog_[]; // Link to MJTagAuditLogs
+    
+    @Field(() => [MJTag_])
+    MJTags_MergedIntoTagIDArray: MJTag_[]; // Link to MJTags
     
 }
 
@@ -60030,6 +61793,12 @@ export class CreateMJTagInput {
 
     @Field({ nullable: true })
     Description: string | null;
+
+    @Field({ nullable: true })
+    Status?: string;
+
+    @Field({ nullable: true })
+    MergedIntoTagID: string | null;
 }
     
 
@@ -60052,6 +61821,12 @@ export class UpdateMJTagInput {
 
     @Field({ nullable: true })
     Description?: string | null;
+
+    @Field({ nullable: true })
+    Status?: string;
+
+    @Field({ nullable: true })
+    MergedIntoTagID?: string | null;
 
     @Field(() => [KeyValuePairInput], { nullable: true })
     OldValues___?: KeyValuePairInput[];
@@ -60131,6 +61906,66 @@ export class MJTagResolver extends ResolverBase {
         const sSQL = `SELECT * FROM ${provider.QuoteSchemaAndView(Metadata.Provider.ConfigData.MJCoreSchemaName, 'vwTaggedItems')} WHERE ${provider.QuoteIdentifier('TagID')}='${mjtag_.ID}' ` + this.getRowLevelSecurityWhereClause(provider, 'MJ: Tagged Items', userPayload, EntityPermissionType.Read, 'AND');
         const rows = await provider.ExecuteSQL(sSQL, undefined, undefined, this.GetUserFromPayload(userPayload));
         const result = await this.ArrayMapFieldNamesToCodeNames('MJ: Tagged Items', rows, this.GetUserFromPayload(userPayload));
+        return result;
+    }
+        
+    @FieldResolver(() => [MJContentItemTag_])
+    async MJContentItemTags_TagIDArray(@Root() mjtag_: MJTag_, @Ctx() { userPayload, providers }: AppContext, @PubSub() pubSub: PubSubEngine) {
+        this.CheckUserReadPermissions('MJ: Content Item Tags', userPayload);
+        const provider = GetReadOnlyProvider(providers, { allowFallbackToReadWrite: true });
+        const sSQL = `SELECT * FROM ${provider.QuoteSchemaAndView(Metadata.Provider.ConfigData.MJCoreSchemaName, 'vwContentItemTags')} WHERE ${provider.QuoteIdentifier('TagID')}='${mjtag_.ID}' ` + this.getRowLevelSecurityWhereClause(provider, 'MJ: Content Item Tags', userPayload, EntityPermissionType.Read, 'AND');
+        const rows = await provider.ExecuteSQL(sSQL, undefined, undefined, this.GetUserFromPayload(userPayload));
+        const result = await this.ArrayMapFieldNamesToCodeNames('MJ: Content Item Tags', rows, this.GetUserFromPayload(userPayload));
+        return result;
+    }
+        
+    @FieldResolver(() => [MJTagCoOccurrence_])
+    async MJTagCoOccurrences_TagBIDArray(@Root() mjtag_: MJTag_, @Ctx() { userPayload, providers }: AppContext, @PubSub() pubSub: PubSubEngine) {
+        this.CheckUserReadPermissions('MJ: Tag Co Occurrences', userPayload);
+        const provider = GetReadOnlyProvider(providers, { allowFallbackToReadWrite: true });
+        const sSQL = `SELECT * FROM ${provider.QuoteSchemaAndView(Metadata.Provider.ConfigData.MJCoreSchemaName, 'vwTagCoOccurrences')} WHERE ${provider.QuoteIdentifier('TagBID')}='${mjtag_.ID}' ` + this.getRowLevelSecurityWhereClause(provider, 'MJ: Tag Co Occurrences', userPayload, EntityPermissionType.Read, 'AND');
+        const rows = await provider.ExecuteSQL(sSQL, undefined, undefined, this.GetUserFromPayload(userPayload));
+        const result = await this.ArrayMapFieldNamesToCodeNames('MJ: Tag Co Occurrences', rows, this.GetUserFromPayload(userPayload));
+        return result;
+    }
+        
+    @FieldResolver(() => [MJTagAuditLog_])
+    async MJTagAuditLogs_RelatedTagIDArray(@Root() mjtag_: MJTag_, @Ctx() { userPayload, providers }: AppContext, @PubSub() pubSub: PubSubEngine) {
+        this.CheckUserReadPermissions('MJ: Tag Audit Logs', userPayload);
+        const provider = GetReadOnlyProvider(providers, { allowFallbackToReadWrite: true });
+        const sSQL = `SELECT * FROM ${provider.QuoteSchemaAndView(Metadata.Provider.ConfigData.MJCoreSchemaName, 'vwTagAuditLogs')} WHERE ${provider.QuoteIdentifier('RelatedTagID')}='${mjtag_.ID}' ` + this.getRowLevelSecurityWhereClause(provider, 'MJ: Tag Audit Logs', userPayload, EntityPermissionType.Read, 'AND');
+        const rows = await provider.ExecuteSQL(sSQL, undefined, undefined, this.GetUserFromPayload(userPayload));
+        const result = await this.ArrayMapFieldNamesToCodeNames('MJ: Tag Audit Logs', rows, this.GetUserFromPayload(userPayload));
+        return result;
+    }
+        
+    @FieldResolver(() => [MJTagCoOccurrence_])
+    async MJTagCoOccurrences_TagAIDArray(@Root() mjtag_: MJTag_, @Ctx() { userPayload, providers }: AppContext, @PubSub() pubSub: PubSubEngine) {
+        this.CheckUserReadPermissions('MJ: Tag Co Occurrences', userPayload);
+        const provider = GetReadOnlyProvider(providers, { allowFallbackToReadWrite: true });
+        const sSQL = `SELECT * FROM ${provider.QuoteSchemaAndView(Metadata.Provider.ConfigData.MJCoreSchemaName, 'vwTagCoOccurrences')} WHERE ${provider.QuoteIdentifier('TagAID')}='${mjtag_.ID}' ` + this.getRowLevelSecurityWhereClause(provider, 'MJ: Tag Co Occurrences', userPayload, EntityPermissionType.Read, 'AND');
+        const rows = await provider.ExecuteSQL(sSQL, undefined, undefined, this.GetUserFromPayload(userPayload));
+        const result = await this.ArrayMapFieldNamesToCodeNames('MJ: Tag Co Occurrences', rows, this.GetUserFromPayload(userPayload));
+        return result;
+    }
+        
+    @FieldResolver(() => [MJTagAuditLog_])
+    async MJTagAuditLogs_TagIDArray(@Root() mjtag_: MJTag_, @Ctx() { userPayload, providers }: AppContext, @PubSub() pubSub: PubSubEngine) {
+        this.CheckUserReadPermissions('MJ: Tag Audit Logs', userPayload);
+        const provider = GetReadOnlyProvider(providers, { allowFallbackToReadWrite: true });
+        const sSQL = `SELECT * FROM ${provider.QuoteSchemaAndView(Metadata.Provider.ConfigData.MJCoreSchemaName, 'vwTagAuditLogs')} WHERE ${provider.QuoteIdentifier('TagID')}='${mjtag_.ID}' ` + this.getRowLevelSecurityWhereClause(provider, 'MJ: Tag Audit Logs', userPayload, EntityPermissionType.Read, 'AND');
+        const rows = await provider.ExecuteSQL(sSQL, undefined, undefined, this.GetUserFromPayload(userPayload));
+        const result = await this.ArrayMapFieldNamesToCodeNames('MJ: Tag Audit Logs', rows, this.GetUserFromPayload(userPayload));
+        return result;
+    }
+        
+    @FieldResolver(() => [MJTag_])
+    async MJTags_MergedIntoTagIDArray(@Root() mjtag_: MJTag_, @Ctx() { userPayload, providers }: AppContext, @PubSub() pubSub: PubSubEngine) {
+        this.CheckUserReadPermissions('MJ: Tags', userPayload);
+        const provider = GetReadOnlyProvider(providers, { allowFallbackToReadWrite: true });
+        const sSQL = `SELECT * FROM ${provider.QuoteSchemaAndView(Metadata.Provider.ConfigData.MJCoreSchemaName, 'vwTags')} WHERE ${provider.QuoteIdentifier('MergedIntoTagID')}='${mjtag_.ID}' ` + this.getRowLevelSecurityWhereClause(provider, 'MJ: Tags', userPayload, EntityPermissionType.Read, 'AND');
+        const rows = await provider.ExecuteSQL(sSQL, undefined, undefined, this.GetUserFromPayload(userPayload));
+        const result = await this.ArrayMapFieldNamesToCodeNames('MJ: Tags', rows, this.GetUserFromPayload(userPayload));
         return result;
     }
         
@@ -67445,6 +69280,18 @@ export class MJUser_ {
     @Field(() => [MJOpenApp_])
     MJOpenApps_InstalledByUserIDArray: MJOpenApp_[]; // Link to MJOpenApps
     
+    @Field(() => [MJContentItemDuplicate_])
+    MJContentItemDuplicates_ResolvedByUserIDArray: MJContentItemDuplicate_[]; // Link to MJContentItemDuplicates
+    
+    @Field(() => [MJContentProcessRun_])
+    MJContentProcessRuns_StartedByUserIDArray: MJContentProcessRun_[]; // Link to MJContentProcessRuns
+    
+    @Field(() => [MJKnowledgeHubSavedSearch_])
+    MJKnowledgeHubSavedSearches_UserIDArray: MJKnowledgeHubSavedSearch_[]; // Link to MJKnowledgeHubSavedSearches
+    
+    @Field(() => [MJTagAuditLog_])
+    MJTagAuditLogs_PerformedByUserIDArray: MJTagAuditLog_[]; // Link to MJTagAuditLogs
+    
     @Field(() => [MJResourcePermission_])
     MJResourcePermissions_UserIDArray: MJResourcePermission_[]; // Link to MJResourcePermissions
     
@@ -68280,6 +70127,46 @@ export class MJUserResolverBase extends ResolverBase {
         const sSQL = `SELECT * FROM ${provider.QuoteSchemaAndView(Metadata.Provider.ConfigData.MJCoreSchemaName, 'vwOpenApps')} WHERE ${provider.QuoteIdentifier('InstalledByUserID')}='${mjuser_.ID}' ` + this.getRowLevelSecurityWhereClause(provider, 'MJ: Open Apps', userPayload, EntityPermissionType.Read, 'AND');
         const rows = await provider.ExecuteSQL(sSQL, undefined, undefined, this.GetUserFromPayload(userPayload));
         const result = await this.ArrayMapFieldNamesToCodeNames('MJ: Open Apps', rows, this.GetUserFromPayload(userPayload));
+        return result;
+    }
+        
+    @FieldResolver(() => [MJContentItemDuplicate_])
+    async MJContentItemDuplicates_ResolvedByUserIDArray(@Root() mjuser_: MJUser_, @Ctx() { userPayload, providers }: AppContext, @PubSub() pubSub: PubSubEngine) {
+        this.CheckUserReadPermissions('MJ: Content Item Duplicates', userPayload);
+        const provider = GetReadOnlyProvider(providers, { allowFallbackToReadWrite: true });
+        const sSQL = `SELECT * FROM ${provider.QuoteSchemaAndView(Metadata.Provider.ConfigData.MJCoreSchemaName, 'vwContentItemDuplicates')} WHERE ${provider.QuoteIdentifier('ResolvedByUserID')}='${mjuser_.ID}' ` + this.getRowLevelSecurityWhereClause(provider, 'MJ: Content Item Duplicates', userPayload, EntityPermissionType.Read, 'AND');
+        const rows = await provider.ExecuteSQL(sSQL, undefined, undefined, this.GetUserFromPayload(userPayload));
+        const result = await this.ArrayMapFieldNamesToCodeNames('MJ: Content Item Duplicates', rows, this.GetUserFromPayload(userPayload));
+        return result;
+    }
+        
+    @FieldResolver(() => [MJContentProcessRun_])
+    async MJContentProcessRuns_StartedByUserIDArray(@Root() mjuser_: MJUser_, @Ctx() { userPayload, providers }: AppContext, @PubSub() pubSub: PubSubEngine) {
+        this.CheckUserReadPermissions('MJ: Content Process Runs', userPayload);
+        const provider = GetReadOnlyProvider(providers, { allowFallbackToReadWrite: true });
+        const sSQL = `SELECT * FROM ${provider.QuoteSchemaAndView(Metadata.Provider.ConfigData.MJCoreSchemaName, 'vwContentProcessRuns')} WHERE ${provider.QuoteIdentifier('StartedByUserID')}='${mjuser_.ID}' ` + this.getRowLevelSecurityWhereClause(provider, 'MJ: Content Process Runs', userPayload, EntityPermissionType.Read, 'AND');
+        const rows = await provider.ExecuteSQL(sSQL, undefined, undefined, this.GetUserFromPayload(userPayload));
+        const result = await this.ArrayMapFieldNamesToCodeNames('MJ: Content Process Runs', rows, this.GetUserFromPayload(userPayload));
+        return result;
+    }
+        
+    @FieldResolver(() => [MJKnowledgeHubSavedSearch_])
+    async MJKnowledgeHubSavedSearches_UserIDArray(@Root() mjuser_: MJUser_, @Ctx() { userPayload, providers }: AppContext, @PubSub() pubSub: PubSubEngine) {
+        this.CheckUserReadPermissions('MJ: Knowledge Hub Saved Searches', userPayload);
+        const provider = GetReadOnlyProvider(providers, { allowFallbackToReadWrite: true });
+        const sSQL = `SELECT * FROM ${provider.QuoteSchemaAndView(Metadata.Provider.ConfigData.MJCoreSchemaName, 'vwKnowledgeHubSavedSearches')} WHERE ${provider.QuoteIdentifier('UserID')}='${mjuser_.ID}' ` + this.getRowLevelSecurityWhereClause(provider, 'MJ: Knowledge Hub Saved Searches', userPayload, EntityPermissionType.Read, 'AND');
+        const rows = await provider.ExecuteSQL(sSQL, undefined, undefined, this.GetUserFromPayload(userPayload));
+        const result = await this.ArrayMapFieldNamesToCodeNames('MJ: Knowledge Hub Saved Searches', rows, this.GetUserFromPayload(userPayload));
+        return result;
+    }
+        
+    @FieldResolver(() => [MJTagAuditLog_])
+    async MJTagAuditLogs_PerformedByUserIDArray(@Root() mjuser_: MJUser_, @Ctx() { userPayload, providers }: AppContext, @PubSub() pubSub: PubSubEngine) {
+        this.CheckUserReadPermissions('MJ: Tag Audit Logs', userPayload);
+        const provider = GetReadOnlyProvider(providers, { allowFallbackToReadWrite: true });
+        const sSQL = `SELECT * FROM ${provider.QuoteSchemaAndView(Metadata.Provider.ConfigData.MJCoreSchemaName, 'vwTagAuditLogs')} WHERE ${provider.QuoteIdentifier('PerformedByUserID')}='${mjuser_.ID}' ` + this.getRowLevelSecurityWhereClause(provider, 'MJ: Tag Audit Logs', userPayload, EntityPermissionType.Read, 'AND');
+        const rows = await provider.ExecuteSQL(sSQL, undefined, undefined, this.GetUserFromPayload(userPayload));
+        const result = await this.ArrayMapFieldNamesToCodeNames('MJ: Tag Audit Logs', rows, this.GetUserFromPayload(userPayload));
         return result;
     }
         


### PR DESCRIPTION
## Summary

Adds a configurable hierarchical resolution chain for determining which `FileStorageAccount` to use when agents create file-based artifacts (PDF, DOCX, XLSX). Replaces the previous "pick first active account" behavior with an explicit configuration hierarchy.

### Storage Account Resolution Chain (first non-null wins)
1. **Runtime** — `ExecuteAgentParams.override.storageAccountId`
2. **Agent** — `AIAgent.DefaultStorageAccountID`
3. **Category tree** — `AIAgentCategory.DefaultStorageAccountID` (walks up `ParentID`)
4. **Type** — `AIAgentType.DefaultStorageAccountID`
5. **Fallback** — sole active account if only one exists; throws descriptive error if 2+ accounts with no config

### Changes

**Database Migration**
- Adds `DefaultStorageAccountID` (nullable FK → `FileStorageAccount`) to `AIAgentType`, `AIAgentCategory`, and `AIAgent`
- Includes `sp_addextendedproperty` documentation on all new columns
- Includes CodeGen output (EntityField inserts, views, stored procedures, FK indexes)

**Core Resolution Logic**
- `BaseAgent.getStorageAccountID()` — protected method implementing the full resolution chain with category tree walk, overridable by subclasses
- `ExecuteAgentParams.override.storageAccountId` — runtime override field
- `ExecuteAgentResult.resolvedStorageAccountId` — resolved ID flows to AgentRunner
- Widened `_categoryCache` to include `DefaultStorageAccountID` alongside `AssignmentStrategy`

**Upload Path Integration**
- `AgentRunner.uploadBase64ToStorage()` — uses resolved account instead of "first active"
- `BaseAgent.ExecuteSingleAction()` — passes resolved ID via action `Context` so `FinalizeDocumentAction` uses the correct account
- `BaseFileHandlerAction.loadResolvedOrDefaultStorageAccount()` — checks Context for resolved ID, falls back to priority-based selection
- `ConversationAttachmentService.uploadToStorage()` — prefers `DefaultStorageAccountID` with `initializeDriverWithAccountCredentials()` for proper OAuth credential handling

**Error Handling**
- 0 active accounts → returns null (inline base64 fallback)
- 1 active account → uses it automatically
- 2+ active accounts with no config → throws descriptive error naming the agent, category, and type with instructions to configure

**Rename**
- `DocumentBuilderService` → `ArtifactBuilderService` (class, file, all imports, tests, JSDoc references)

**Prompt Fix**
- Added document creation workflow instructions to Loop Agent system prompt template (Create → Add Content → Finalize sequence)

**Documentation**
- Added "Storage Account Resolution" section to `packages/AI/Agents/README.md`
- JSDoc on all new methods and types

### Testing

Verified end-to-end with 2 active storage accounts (Box.com + Dropbox):
- ✅ Error with descriptive message when 2+ accounts and no config
- ✅ Type-level default (Dropbox on Loop type)
- ✅ Category override (Box on Assistant category overrides Dropbox on Loop type)
- ✅ Agent override (Dropbox on Sage overrides Box on Assistant category)
- ✅ Inline base64 fallback when storage upload fails
- ✅ File artifact creation + download URL generation on both providers

### Files Changed (21 files)

| Area | Files | Change |
|------|-------|--------|
| Migration | `migrations/v5/V202604071435__*.sql` | DDL + CodeGen output |
| Agent Core | `base-agent.ts`, `AgentRunner.ts`, `agent-types.ts` | Resolution chain + threading |
| Engine | `ConversationAttachmentService.ts` | Account-based upload |
| Actions | `base-file-handler.ts`, `artifact-builder-service.ts`, 5 action files | Rename + Context-based resolution |
| Generated | `entity_subclasses.ts` (×2), `generated.ts` (×2) | CodeGen output |
| Prompt | `loop-agent-type-system-prompt.template.md` | Document workflow instructions |
| Docs | `README.md` | Storage resolution docs |

🤖 Generated with [Claude Code](https://claude.com/claude-code)