### PR TITLE
Address PR review feedback: architecture, encapsulation, caching, naming

### DIFF
--- a/packages/AI/Agents/src/AgentRunner.ts
+++ b/packages/AI/Agents/src/AgentRunner.ts
@@ -11,13 +11,13 @@
  */
 
 import { createHash } from 'crypto';
-import { LogError, LogStatusEx, IsVerboseLoggingEnabled, LogStatus, Metadata, RunView, UserInfo, IMetadataProvider, IRunViewProvider, DatabaseProviderBase, ProviderType } from '@memberjunction/core';
+import { LogError, LogStatusEx, IsVerboseLoggingEnabled, LogStatus, Metadata, RunView, UserInfo, IMetadataProvider, DatabaseProviderBase, ProviderType } from '@memberjunction/core';
 import { MJGlobal, UUIDsEqual } from '@memberjunction/global';
 import { AIEngine } from '@memberjunction/aiengine';
-import { ExecuteAgentResult, ExecuteAgentParams, MediaOutput, FileOutputRef, ActionStepOutputData, ActionStepSummary, parseFileOutputRef } from '@memberjunction/ai-core-plus';
+import { ExecuteAgentResult, ExecuteAgentParams, MediaOutput, FileOutputRef, ActionStepOutputData, ActionStepSummary, ParseFileOutputRef } from '@memberjunction/ai-core-plus';
 import { BaseAgent } from './base-agent';
-import { MJConversationEntity, MJConversationDetailEntity, MJArtifactEntity, MJArtifactVersionEntity, MJConversationDetailArtifactEntity, MJAIAgentRunMediaEntity, MJConversationDetailAttachmentEntity, MJFileEntity, ArtifactMetadataEngine, FileStorageEngine, StorageAccountWithProvider } from '@memberjunction/core-entities';
-import { initializeDriverWithAccountCredentials } from '@memberjunction/storage';
+import { MJConversationEntity, MJConversationDetailEntity, MJArtifactEntity, MJArtifactVersionEntity, MJConversationDetailArtifactEntity, MJAIAgentRunMediaEntity, MJConversationDetailAttachmentEntity, ArtifactMetadataEngine } from '@memberjunction/core-entities';
+import { FileStorageEngine } from '@memberjunction/storage';
 
 
 /**
@@ -46,11 +46,6 @@ export class AgentRunner {
         this._provider = provider || Metadata.Provider;
     }
 
-    /** Casts the resolved IMetadataProvider to IRunViewProvider for RunView construction.
-     *  Safe because the runtime object is always a ProviderBase which implements both interfaces. */
-    private asRunViewProvider(provider?: IMetadataProvider): IRunViewProvider {
-        return <IRunViewProvider><any>(provider || this._provider); // eslint-disable-line @typescript-eslint/no-explicit-any
-    }
 
     /**
      * Runs an AI agent with the specified parameters.
@@ -537,7 +532,7 @@ export class AgentRunner {
      */
     public async GetMaxVersionForArtifact(artifactId: string, contextUser: UserInfo, provider?: IMetadataProvider): Promise<number> {
         try {
-            const rv = new RunView(this.asRunViewProvider(provider));
+            const rv = RunView.FromMetadataProvider(provider || this._provider);
             const result = await rv.RunView<MJArtifactVersionEntity>({
                 EntityName: 'MJ: Artifact Versions',
                 ExtraFilter: `ArtifactID='${artifactId}'`,
@@ -581,7 +576,7 @@ export class AgentRunner {
     ): Promise<string | null> {
         const candidateHash = createHash('sha256').update(candidateContent, 'utf8').digest('hex');
 
-        const rv = new RunView(this.asRunViewProvider(provider));
+        const rv = RunView.FromMetadataProvider(provider || this._provider);
         const result = await rv.RunView<{ ID: string; ContentHash: string }>({
             EntityName: 'MJ: Artifact Versions',
             ExtraFilter: `ArtifactID='${artifactId}' AND VersionNumber=${latestVersionNumber}`,
@@ -660,7 +655,7 @@ export class AgentRunner {
         provider?: IMetadataProvider
     ): Promise<{ artifactId: string; versionNumber: number } | null> {
         try {
-            const rv = new RunView(this.asRunViewProvider(provider));
+            const rv = RunView.FromMetadataProvider(provider || this._provider);
             const result = await rv.RunView<MJConversationDetailArtifactEntity>({
                 EntityName: 'MJ: Conversation Detail Artifacts',
                 ExtraFilter: `ConversationDetailID='${conversationDetailId}' AND Direction='Output'`,
@@ -1260,7 +1255,7 @@ export class AgentRunner {
 
     /** Loads all completed action steps for a given agent run (read-only, narrow fields). */
     private async loadActionStepsForRun(agentRunId: string, contextUser: UserInfo, provider?: IMetadataProvider): Promise<ActionStepSummary[]> {
-        const rv = new RunView(this.asRunViewProvider(provider));
+        const rv = RunView.FromMetadataProvider(provider || this._provider);
         const result = await rv.RunView<ActionStepSummary>({
             EntityName: 'MJ: AI Agent Run Steps',
             ExtraFilter: `AgentRunID='${agentRunId}' AND StepType='Actions' AND Status='Completed'`,
@@ -1293,7 +1288,7 @@ export class AgentRunner {
         const results: FileOutputRef[] = [];
         for (const param of params) {
             if (param.Value == null) continue;
-            const ref = parseFileOutputRef(param.Value);
+            const ref = ParseFileOutputRef(param.Value);
             if (ref) results.push(ref);
         }
         return results;
@@ -1316,7 +1311,7 @@ export class AgentRunner {
             }
 
             // Check if any storage accounts are configured
-            const hasStorage = FileStorageEngine.Instance.AccountsWithProviders.length > 0;
+            const hasStorage = FileStorageEngine.Instance.HasStorageAccounts;
 
             if (!hasStorage) {
                 // No storage configured — go straight to inline artifact
@@ -1361,42 +1356,15 @@ export class AgentRunner {
         resolvedStorageAccountId: string | undefined,
         provider: IMetadataProvider
     ): Promise<string> {
-        const accounts = FileStorageEngine.Instance.AccountsWithProviders;
-        if (accounts.length === 0) {
-            throw new Error('No file storage accounts configured. Cannot upload file artifact.');
-        }
-
-        // Use the resolved account if provided, otherwise fall back to first active
-        let resolved: StorageAccountWithProvider | undefined;
-        if (resolvedStorageAccountId) {
-            resolved = FileStorageEngine.Instance.GetAccountWithProvider(resolvedStorageAccountId) ?? undefined;
-        }
-        const { account, provider: storageProvider } = resolved ?? accounts.find(a => a.provider.IsActive !== false) ?? accounts[0];
-        const driver = await initializeDriverWithAccountCredentials({
-            accountEntity: account,
-            providerEntity: storageProvider,
-            contextUser
+        const result = await FileStorageEngine.Instance.UploadFile({
+            content: Buffer.from(base64Data, 'base64'),
+            fileName,
+            mimeType,
+            contextUser,
+            storageAccountId: resolvedStorageAccountId,
+            provider
         });
-
-        const buffer = Buffer.from(base64Data, 'base64');
-        const storagePath = `artifacts/${new Date().toISOString().slice(0, 10)}/${crypto.randomUUID()}/${fileName}`;
-        const uploaded = await driver.PutObject(storagePath, buffer, mimeType);
-        if (!uploaded) {
-            throw new Error(`PutObject returned false for path: ${storagePath}`);
-        }
-
-        const fileEntity = await provider.GetEntityObject<MJFileEntity>('MJ: Files', contextUser);
-        fileEntity.Name = fileName;
-        fileEntity.ContentType = mimeType;
-        fileEntity.ProviderID = storageProvider.ID;
-        fileEntity.ProviderKey = storagePath;
-        fileEntity.Status = 'Uploaded';
-
-        if (!(await fileEntity.Save())) {
-            throw new Error('Failed to save MJ: Files record after upload');
-        }
-
-        return fileEntity.ID;
+        return result.FileID;
     }
 
     /**

--- a/packages/AI/Agents/src/base-agent.ts
+++ b/packages/AI/Agents/src/base-agent.ts
@@ -11,9 +11,9 @@
  * @since 2.49.0
  */
 
-import { MJAIAgentTypeEntity,  MJTemplateParamEntity, MJActionParamEntity, MJAIAgentRelationshipEntity, MJAIAgentNoteEntity, MJAIAgentExampleEntity, MJConversationDetailEntity, MJAIAgentRequestEntity, MJAIAgentRequestTypeEntity, FileStorageEngine } from '@memberjunction/core-entities';
+import { MJAIAgentTypeEntity,  MJTemplateParamEntity, MJActionParamEntity, MJAIAgentRelationshipEntity, MJAIAgentNoteEntity, MJAIAgentExampleEntity, MJConversationDetailEntity, MJAIAgentRequestEntity, MJAIAgentRequestTypeEntity, FileStorageEngineBase } from '@memberjunction/core-entities';
 import { MJAIAgentRunEntityExtended, MJAIAgentRunStepEntityExtended, MJAIPromptEntityExtended, MJAIAgentEntityExtended } from "@memberjunction/ai-core-plus";
-import { UserInfo, Metadata, RunView, LogStatus, LogStatusEx, LogError, LogErrorEx, IsVerboseLoggingEnabled, IMetadataProvider, IRunViewProvider } from '@memberjunction/core';
+import { UserInfo, Metadata, RunView, LogStatus, LogStatusEx, LogError, LogErrorEx, IsVerboseLoggingEnabled, IMetadataProvider } from '@memberjunction/core';
 import { AIPromptRunner } from '@memberjunction/ai-prompts';
 import { ChatMessage, ChatMessageContent, ChatMessageContentBlock, AIErrorType } from '@memberjunction/ai';
 import { BaseAgentType } from './agent-types/base-agent-type';
@@ -45,7 +45,7 @@ import {
     ActionChangeScope,
     MediaOutput,
     FileOutputRef,
-    parseFileOutputRef,
+    ParseFileOutputRef,
     SecondaryScopeConfig,
     SecondaryScopeValue,
     AgentResponseForm,
@@ -265,13 +265,18 @@ export class BaseAgent {
      */
     private _feedbackRequestId: string | null = null;
 
-    /**
-     * Resolved FileStorageAccount ID for this agent run. Set during Execute()
-     * via the hierarchical resolution chain and included in the ExecuteAgentResult
-     * so AgentRunner can route file artifact uploads.
-     * @private
-     */
     private _resolvedStorageAccountId: string | null = null;
+
+    /**
+     * The resolved FileStorageAccount ID for this agent run. Set during Execute()
+     * via the hierarchical resolution chain (Runtime → Agent → Category → Type → fallback).
+     * Included in the ExecuteAgentResult so AgentRunner can route file artifact uploads.
+     *
+     * Subclasses can read this to customize storage behavior based on the resolved account.
+     */
+    protected get ResolvedStorageAccountId(): string | null {
+        return this._resolvedStorageAccountId;
+    }
 
     /**
      * Access the current run for the agent
@@ -386,7 +391,7 @@ export class BaseAgent {
         const results: FileOutputRef[] = [];
         for (const param of outputParams) {
             if (param.Value == null) continue;
-            const ref = parseFileOutputRef(param.Value);
+            const ref = ParseFileOutputRef(param.Value);
             if (ref) results.push(ref);
         }
         return results;
@@ -7652,11 +7657,8 @@ The context is now within limits. Please retry your request with the recovered c
 
     /**
      * Walks up the agent's category hierarchy looking for an AssignmentStrategy.
-     * Loads categories via RunView and caches them for the duration of this run.
-     * @private
+     * Uses AIEngine.Instance.AgentCategories (cached during engine Config).
      */
-    private _categoryCache: Array<{ ID: string; Name: string; ParentID: string | null; AssignmentStrategy: string | null; DefaultStorageAccountID: string | null }> | null = null;
-
     private async resolveCategoryAssignmentStrategy(
         params: ExecuteAgentParams
     ): Promise<AgentRequestAssignmentStrategy | null> {
@@ -7664,14 +7666,14 @@ The context is now within limits. Please retry your request with the recovered c
         if (!categoryId) return null;
 
         try {
-            await this.ensureCategoryCacheLoaded(params);
+            const categories = AIEngine.Instance.AgentCategories;
 
             // Walk up the tree from the agent's category to the root
             let currentId: string | null = categoryId;
             const visited = new Set<string>(); // prevent infinite loops
             while (currentId && !visited.has(currentId)) {
                 visited.add(currentId);
-                const cat = this._categoryCache!.find(c => UUIDsEqual(c.ID, currentId));
+                const cat = categories.find(c => UUIDsEqual(c.ID, currentId));
                 if (!cat) break;
 
                 const strategy = parseAssignmentStrategy(cat.AssignmentStrategy);
@@ -7686,21 +7688,6 @@ The context is now within limits. Please retry your request with the recovered c
         return null;
     }
 
-    /**
-     * Loads all agent categories into the cache if not already loaded.
-     * Shared by both assignment strategy and storage account resolution.
-     */
-    private async ensureCategoryCacheLoaded(params: ExecuteAgentParams): Promise<void> {
-        if (!this._categoryCache) {
-            const rv = new RunView(<IRunViewProvider><any>(params.provider || this._activeProvider));
-            const result = await rv.RunView<{ ID: string; Name: string; ParentID: string | null; AssignmentStrategy: string | null; DefaultStorageAccountID: string | null }>({
-                EntityName: 'MJ: AI Agent Categories',
-                Fields: ['ID', 'Name', 'ParentID', 'AssignmentStrategy', 'DefaultStorageAccountID'],
-                ResultType: 'simple'
-            }, params.contextUser);
-            this._categoryCache = result.Success ? result.Results : [];
-        }
-    }
 
     /**
      * Resolves the file storage account ID for this agent's file artifacts.
@@ -7733,13 +7720,13 @@ The context is now within limits. Please retry your request with the recovered c
         const categoryId = params.agent.CategoryID;
         if (categoryId) {
             try {
-                await this.ensureCategoryCacheLoaded(params);
+                const categories = AIEngine.Instance.AgentCategories;
 
                 let currentId: string | null = categoryId;
                 const visited = new Set<string>();
                 while (currentId && !visited.has(currentId)) {
                     visited.add(currentId);
-                    const cat = this._categoryCache!.find(c => UUIDsEqual(c.ID, currentId));
+                    const cat = categories.find(c => UUIDsEqual(c.ID, currentId));
                     if (!cat) break;
                     if (cat.DefaultStorageAccountID) return cat.DefaultStorageAccountID;
                     currentId = cat.ParentID;
@@ -7761,8 +7748,8 @@ The context is now within limits. Please retry your request with the recovered c
         }
 
         // 5. System fallback
-        await FileStorageEngine.Instance.Config(false, params.contextUser);
-        const activeAccounts = FileStorageEngine.Instance.AccountsWithProviders
+        await FileStorageEngineBase.Instance.Config(false, params.contextUser);
+        const activeAccounts = FileStorageEngineBase.Instance.AccountsWithProviders
             .filter(a => a.provider.IsActive);
 
         if (activeAccounts.length === 0) {
@@ -7780,7 +7767,7 @@ The context is now within limits. Please retry your request with the recovered c
             ? AIEngine.Instance.AgentTypes.find(at => UUIDsEqual(at.ID, params.agent.TypeID))?.Name || params.agent.TypeID
             : 'unknown';
         const categoryName = params.agent.CategoryID
-            ? this._categoryCache?.find(c => UUIDsEqual(c.ID, params.agent.CategoryID))?.Name || params.agent.CategoryID
+            ? AIEngine.Instance.AgentCategories.find(c => UUIDsEqual(c.ID, params.agent.CategoryID))?.Name || params.agent.CategoryID
             : 'none';
         const accountNames = activeAccounts.map(a => `'${a.account.Name}' (${a.provider.Name})`).join(', ');
 

--- a/packages/AI/BaseAIEngine/src/BaseAIEngine.ts
+++ b/packages/AI/BaseAIEngine/src/BaseAIEngine.ts
@@ -27,6 +27,7 @@ import { MJAIActionEntity, MJAIAgentActionEntity, MJAIAgentNoteEntity, MJAIAgent
          MJAIModelModalityEntity,
          MJAIClientToolDefinitionEntity,
          MJAIAgentClientToolEntity,
+         MJAIAgentCategoryEntity,
          ArtifactMetadataEngine} from "@memberjunction/core-entities";
 import { AIAgentPermissionHelper, EffectiveAgentPermissions } from "./AIAgentPermissionHelper";
 import { TemplateEngineBase } from "@memberjunction/templates-base-types";
@@ -110,6 +111,7 @@ export class AIEngineBase extends BaseEngine<AIEngineBase> {
     private _modelModalities: MJAIModelModalityEntity[] = [];
     private _clientToolDefinitions: MJAIClientToolDefinitionEntity[] = [];
     private _agentClientTools: MJAIAgentClientToolEntity[] = [];
+    private _agentCategories: MJAIAgentCategoryEntity[] = [];
 
     /**
      * Cache for configuration inheritance chains.
@@ -288,6 +290,11 @@ export class AIEngineBase extends BaseEngine<AIEngineBase> {
             {
                 PropertyName: '_agentClientTools',
                 EntityName: 'MJ: AI Agent Client Tools',
+                CacheLocal: true
+            },
+            {
+                PropertyName: '_agentCategories',
+                EntityName: 'MJ: AI Agent Categories',
                 CacheLocal: true
             }
         ];
@@ -478,6 +485,12 @@ export class AIEngineBase extends BaseEngine<AIEngineBase> {
 
     public get AgentTypes(): MJAIAgentTypeEntity[] {
         return this._agentTypes;
+    }
+
+    /** All agent categories, cached during Config(). Used for hierarchical resolution of
+     *  assignment strategies and default storage accounts (category → parent → root). */
+    public get AgentCategories(): MJAIAgentCategoryEntity[] {
+        return this._agentCategories;
     }
 
     public GetAgentByName(agentName: string): MJAIAgentEntityExtended {

--- a/packages/AI/CorePlus/src/agent-types.ts
+++ b/packages/AI/CorePlus/src/agent-types.ts
@@ -253,7 +253,7 @@ export interface FileOutputRef {
  *
  * @since 5.22.0
  */
-export function parseFileOutputRef(raw: unknown): FileOutputRef | null {
+export function ParseFileOutputRef(raw: unknown): FileOutputRef | null {
     let fo: Record<string, unknown> | null = null;
     if (typeof raw === 'string') {
         try { fo = JSON.parse(raw) as Record<string, unknown>; } catch { return null; }

--- a/packages/AI/Engine/src/AIEngine.ts
+++ b/packages/AI/Engine/src/AIEngine.ts
@@ -20,7 +20,7 @@ import { MJAIActionEntity, MJActionEntity,
          MJAIAgentDataSourceEntity, MJAIAgentConfigurationEntity, MJAIAgentExampleEntity,
          MJAICredentialBindingEntity, MJAIModalityEntity, MJAIAgentModalityEntity,
          MJAIModelModalityEntity, MJAIClientToolDefinitionEntity,
-         MJAIAgentClientToolEntity } from "@memberjunction/core-entities";
+         MJAIAgentClientToolEntity, MJAIAgentCategoryEntity } from "@memberjunction/core-entities";
 import { AIEngineBase } from "@memberjunction/ai-engine-base";
 import { SimpleVectorService } from "@memberjunction/ai-vectors-memory";
 import { AgentEmbeddingService } from "./services/AgentEmbeddingService";
@@ -115,6 +115,7 @@ export class AIEngine extends BaseSingleton<AIEngine> {
     public get Agents(): MJAIAgentEntityExtended[] { return this.Base.Agents; }
     public get AgentRelationships(): MJAIAgentRelationshipEntity[] { return this.Base.AgentRelationships; }
     public get AgentTypes(): MJAIAgentTypeEntity[] { return this.Base.AgentTypes; }
+    public get AgentCategories(): MJAIAgentCategoryEntity[] { return this.Base.AgentCategories; }
     public get AgentActions(): MJAIAgentActionEntity[] { return this.Base.AgentActions; }
     public get AgentPrompts(): MJAIAgentPromptEntity[] { return this.Base.AgentPrompts; }
     public get AgentConfigurations(): MJAIAgentConfigurationEntity[] { return this.Base.AgentConfigurations; }

--- a/packages/AI/Engine/src/services/ConversationAttachmentService.ts
+++ b/packages/AI/Engine/src/services/ConversationAttachmentService.ts
@@ -12,7 +12,7 @@
  * @since 2.130.0
  */
 
-import { Metadata, RunView, UserInfo, IMetadataProvider, IRunViewProvider } from '@memberjunction/core';
+import { Metadata, RunView, UserInfo, IMetadataProvider } from '@memberjunction/core';
 import {
     MJFileStorageProviderEntity,
     MJFileStorageAccountEntity,
@@ -20,11 +20,10 @@ import {
     MJAIAgentEntity,
     MJAIModelEntity,
     MJConversationDetailAttachmentEntity,
-    MJAIModalityEntity,
-    FileStorageEngine
+    MJAIModalityEntity
 } from '@memberjunction/core-entities';
 import { MJGlobal } from '@memberjunction/global';
-import { FileStorageBase, initializeDriverWithAccountCredentials } from '@memberjunction/storage';
+import { FileStorageBase, FileStorageEngine } from '@memberjunction/storage';
 import {
     ConversationUtility,
     AttachmentType,
@@ -99,11 +98,6 @@ export class ConversationAttachmentService {
         return provider ?? this._defaultProvider;
     }
 
-    /** Casts the resolved IMetadataProvider to IRunViewProvider for RunView construction.
-     *  Safe because the runtime object is always a ProviderBase which implements both interfaces. */
-    private asRunViewProvider(provider?: IMetadataProvider): IRunViewProvider {
-        return <IRunViewProvider><any>(provider ?? this._defaultProvider); // eslint-disable-line @typescript-eslint/no-explicit-any
-    }
 
     /**
      * Load and cache modalities for efficient lookup
@@ -113,7 +107,7 @@ export class ConversationAttachmentService {
             return;
         }
 
-        const rv = new RunView(this.asRunViewProvider(provider));
+        const rv = RunView.FromMetadataProvider(provider ?? this._defaultProvider);
         const result = await rv.RunView<MJAIModalityEntity>({
             EntityName: 'MJ: AI Modalities',
             ResultType: 'entity_object'
@@ -342,7 +336,7 @@ export class ConversationAttachmentService {
             }
 
             // Find the FileStorageAccount that links to this provider
-            const rv = new RunView(this.asRunViewProvider(provider));
+            const rv = RunView.FromMetadataProvider(provider ?? this._defaultProvider);
             const accountResult = await rv.RunView<MJFileStorageAccountEntity>({
                 EntityName: 'MJ: File Storage Accounts',
                 ExtraFilter: `ProviderID = '${file.ProviderID}'`,
@@ -352,12 +346,8 @@ export class ConversationAttachmentService {
 
             let driver: FileStorageBase;
             if (accountResult.Success && accountResult.Results.length > 0) {
-                // Initialize driver with account credentials (handles OAuth token refresh)
-                driver = await initializeDriverWithAccountCredentials({
-                    accountEntity: accountResult.Results[0],
-                    providerEntity: storageProvider,
-                    contextUser
-                });
+                // Initialize driver with account credentials via FileStorageEngine
+                driver = await FileStorageEngine.Instance.GetDriver(accountResult.Results[0].ID, contextUser);
             } else {
                 // Fallback: create driver without account credentials (env vars only)
                 driver = MJGlobal.Instance.ClassFactory.CreateInstance<FileStorageBase>(
@@ -419,7 +409,7 @@ export class ConversationAttachmentService {
         contextUser: UserInfo,
         provider?: IMetadataProvider
     ): Promise<MJConversationDetailAttachmentEntity[]> {
-        const rv = new RunView(this.asRunViewProvider(provider));
+        const rv = RunView.FromMetadataProvider(provider ?? this._defaultProvider);
         const result = await rv.RunView<MJConversationDetailAttachmentEntity>({
             EntityName: 'MJ: Conversation Detail Attachments',
             ExtraFilter: `ConversationDetailID='${conversationDetailId}'`,
@@ -452,7 +442,7 @@ export class ConversationAttachmentService {
 
         const idList = conversationDetailIds.map(id => `'${id}'`).join(',');
 
-        const rv = new RunView(this.asRunViewProvider(provider));
+        const rv = RunView.FromMetadataProvider(provider ?? this._defaultProvider);
         const result = await rv.RunView<MJConversationDetailAttachmentEntity>({
             EntityName: 'MJ: Conversation Detail Attachments',
             ExtraFilter: `ConversationDetailID IN (${idList})`,
@@ -554,7 +544,7 @@ export class ConversationAttachmentService {
      * 1. Agent's `DefaultStorageAccountID` (account-based, with credentials)
      * 2. Fallback: Agent's `AttachmentStorageProviderID` (legacy provider-based)
      *
-     * When an account is resolved, uses `initializeDriverWithAccountCredentials()`
+     * When an account is resolved, uses `FileStorageEngine.Instance.UploadFile()`
      * for proper OAuth credential handling.
      */
     private async uploadToStorage(
@@ -566,44 +556,43 @@ export class ConversationAttachmentService {
         provider?: IMetadataProvider
     ): Promise<{ success: boolean; fileId?: string; error?: string }> {
         const md = this.resolveProvider(provider);
-        let driver: FileStorageBase;
-        let providerId: string;
 
-        // Prefer account-based resolution (new path with proper credentials)
+        // Prefer account-based resolution (new path via FileStorageEngine)
         const storageAccountId = agent?.DefaultStorageAccountID ?? null;
         if (storageAccountId) {
             await FileStorageEngine.Instance.Config(false, contextUser);
-            const resolved = FileStorageEngine.Instance.GetAccountWithProvider(storageAccountId);
-            if (!resolved) {
-                return { success: false, error: `Storage account ${storageAccountId} not found` };
+            try {
+                const result = await FileStorageEngine.Instance.UploadFile({
+                    content: Buffer.from(base64Data, 'base64'),
+                    fileName,
+                    mimeType,
+                    contextUser,
+                    storageAccountId,
+                    provider: md,
+                    pathPrefix: `conversation-attachments/${Date.now()}`
+                });
+                return { success: true, fileId: result.FileID };
+            } catch (err) {
+                return { success: false, error: (err as Error).message };
             }
-            driver = await initializeDriverWithAccountCredentials({
-                accountEntity: resolved.account,
-                providerEntity: resolved.provider,
-                contextUser
-            });
-            providerId = resolved.provider.ID;
-        } else {
-            // Legacy fallback: provider-based resolution (no account credentials)
-            const legacyProviderId = agent?.AttachmentStorageProviderID ?? null;
-            if (!legacyProviderId) {
-                return { success: false, error: 'No storage provider configured for attachments' };
-            }
-            const storageProviderEntity = await md.GetEntityObject<MJFileStorageProviderEntity>('MJ: File Storage Providers', contextUser);
-            if (!await storageProviderEntity.Load(legacyProviderId)) {
-                return { success: false, error: 'Failed to load storage provider' };
-            }
-            driver = MJGlobal.Instance.ClassFactory.CreateInstance<FileStorageBase>(
-                FileStorageBase,
-                storageProviderEntity.ServerDriverKey
-            );
-            providerId = legacyProviderId;
         }
 
+        // Legacy fallback: provider-based resolution (no account credentials)
+        const legacyProviderId = agent?.AttachmentStorageProviderID ?? null;
+        if (!legacyProviderId) {
+            return { success: false, error: 'No storage provider configured for attachments' };
+        }
+        const storageProviderEntity = await md.GetEntityObject<MJFileStorageProviderEntity>('MJ: File Storage Providers', contextUser);
+        if (!await storageProviderEntity.Load(legacyProviderId)) {
+            return { success: false, error: 'Failed to load storage provider' };
+        }
+        const driver = MJGlobal.Instance.ClassFactory.CreateInstance<FileStorageBase>(
+            FileStorageBase,
+            storageProviderEntity.ServerDriverKey
+        );
+
         // Determine storage path
-        const basePath = 'conversation-attachments';
-        const timestamp = Date.now();
-        const objectName = `${basePath}/${timestamp}_${fileName}`;
+        const objectName = `conversation-attachments/${Date.now()}_${fileName}`;
 
         // Convert base64 to buffer and upload
         const buffer = Buffer.from(base64Data, 'base64');
@@ -615,7 +604,7 @@ export class ConversationAttachmentService {
         // Create File entity record
         const file = await md.GetEntityObject<MJFileEntity>('MJ: Files', contextUser);
         file.Name = fileName;
-        file.ProviderID = providerId;
+        file.ProviderID = legacyProviderId;
         file.ContentType = mimeType;
         file.ProviderKey = objectName;
         file.Status = 'Uploaded';

--- a/packages/Actions/CoreActions/src/custom/files/base-file-storage.action.ts
+++ b/packages/Actions/CoreActions/src/custom/files/base-file-storage.action.ts
@@ -2,7 +2,7 @@ import { ActionResultSimple, RunActionParams } from "@memberjunction/actions-bas
 import { BaseAction } from "@memberjunction/actions";
 import { RunView, UserInfo } from "@memberjunction/core";
 import { MJFileStorageAccountEntity, MJFileStorageProviderEntity } from "@memberjunction/core-entities";
-import { FileStorageBase, initializeDriverWithAccountCredentials } from "@memberjunction/storage";
+import { FileStorageBase, FileStorageEngine } from "@memberjunction/storage";
 
 /**
  * Abstract base class for file storage operations.
@@ -57,22 +57,17 @@ export abstract class BaseFileStorageAction extends BaseAction {
     }
 
     /**
-     * Initialize storage driver using the enterprise credential model
+     * Initialize storage driver using the enterprise credential model via FileStorageEngine.
      * @param accountEntity - MJFileStorageAccountEntity to initialize
-     * @param providerEntity - MJFileStorageProviderEntity for the account
      * @param contextUser - User context for credential access
      * @returns Initialized FileStorageBase driver
      */
     protected async initializeDriver(
         accountEntity: MJFileStorageAccountEntity,
-        providerEntity: MJFileStorageProviderEntity,
         contextUser: UserInfo
     ): Promise<FileStorageBase> {
-        return initializeDriverWithAccountCredentials({
-            accountEntity,
-            providerEntity,
-            contextUser
-        });
+        await FileStorageEngine.Instance.Config(false, contextUser);
+        return FileStorageEngine.Instance.GetDriver(accountEntity.ID, contextUser);
     }
 
     /**
@@ -103,7 +98,7 @@ export abstract class BaseFileStorageAction extends BaseAction {
             };
         }
 
-        const driver = await this.initializeDriver(account, provider, params.ContextUser);
+        const driver = await this.initializeDriver(account, params.ContextUser);
         return { driver };
     }
 

--- a/packages/Actions/CoreActions/src/custom/utilities/base-file-handler.ts
+++ b/packages/Actions/CoreActions/src/custom/utilities/base-file-handler.ts
@@ -1,8 +1,8 @@
 import { BaseAction } from "@memberjunction/actions";
 import { RunActionParams } from "@memberjunction/actions-base";
 import { Metadata, RunView } from "@memberjunction/core";
-import { MJFileEntity, MJFileStorageAccountEntity, MJFileStorageProviderEntity, FileStorageEngine } from "@memberjunction/core-entities";
-import { initializeDriverWithAccountCredentials } from "@memberjunction/storage";
+import { MJFileEntity, MJFileStorageAccountEntity, MJFileStorageProviderEntity } from "@memberjunction/core-entities";
+import { FileStorageEngine } from "@memberjunction/storage";
 
 /**
  * Base class for actions that handle file inputs from multiple sources
@@ -166,38 +166,32 @@ export abstract class BaseFileHandlerAction extends BaseAction {
         storagePath?: string
     ): Promise<string> {
         try {
-            const { accountEntity, providerEntity } = storageAccountName
-                ? await this.loadStorageAccountByName(storageAccountName, params)
-                : await this.loadResolvedOrDefaultStorageAccount(params);
-            const driver = await initializeDriverWithAccountCredentials({
-                accountEntity,
-                providerEntity,
-                contextUser: params.ContextUser
-            });
+            await FileStorageEngine.Instance.Config(false, params.ContextUser);
+
+            // Resolve storage account ID
+            let storageAccountId: string | undefined;
+            if (storageAccountName) {
+                const { accountEntity } = await this.loadStorageAccountByName(storageAccountName, params);
+                storageAccountId = accountEntity.ID;
+            } else {
+                storageAccountId = await this.resolveStorageAccountId(params);
+            }
 
             const buffer = Buffer.isBuffer(content) ? content : Buffer.from(content);
-            const resolvedPath = storagePath
-                ? `${storagePath.replace(/\/+$/, '')}/${fileName}`
-                : `artifacts/${new Date().toISOString().slice(0, 10)}/${crypto.randomUUID()}/${fileName}`;
-            const uploaded = await driver.PutObject(resolvedPath, buffer, mimeType);
-            if (!uploaded) {
-                throw new Error(`PutObject returned false for path: ${resolvedPath}`);
-            }
+            const pathPrefix = storagePath
+                ? storagePath.replace(/\/+$/, '')
+                : undefined;
 
-            const md = new Metadata();
-            const fileEntity = await md.GetEntityObject<MJFileEntity>('MJ: Files', params.ContextUser);
-            fileEntity.Name = fileName;
-            fileEntity.ContentType = mimeType;
-            fileEntity.ProviderID = providerEntity.ID;
-            fileEntity.ProviderKey = resolvedPath;
-            fileEntity.Status = 'Uploaded';
+            const result = await FileStorageEngine.Instance.UploadFile({
+                content: buffer,
+                fileName,
+                mimeType,
+                contextUser: params.ContextUser,
+                storageAccountId,
+                pathPrefix
+            });
 
-            const saved = await fileEntity.Save();
-            if (!saved) {
-                throw new Error('Failed to save MJ: Files record after upload');
-            }
-
-            return fileEntity.ID;
+            return result.FileID;
         } catch (error) {
             throw new Error(`Failed to save file to storage: ${error instanceof Error ? error.message : String(error)}`);
         }
@@ -236,35 +230,20 @@ export abstract class BaseFileHandlerAction extends BaseAction {
     }
 
     /**
-     * Resolves the storage account from the agent's resolution chain (via Context)
-     * or falls back to priority-based selection.
+     * Resolves a storage account ID from the agent's resolution chain (via Context)
+     * or falls back to the first active account via FileStorageEngine.
      */
-    private async loadResolvedOrDefaultStorageAccount(params: RunActionParams): Promise<{
-        accountEntity: MJFileStorageAccountEntity;
-        providerEntity: MJFileStorageProviderEntity;
-    }> {
-        await FileStorageEngine.Instance.Config(false, params.ContextUser);
-
+    private async resolveStorageAccountId(params: RunActionParams): Promise<string | undefined> {
         // Check for agent-resolved storage account ID (passed via Context by BaseAgent)
         const context = params.Context as Record<string, unknown> | undefined;
         const resolvedId = context?.__resolvedStorageAccountId;
         if (resolvedId) {
-            const resolved = FileStorageEngine.Instance.GetAccountWithProvider(resolvedId.toString());
-            if (resolved) {
-                return { accountEntity: resolved.account, providerEntity: resolved.provider };
-            }
+            return resolvedId.toString();
         }
 
-        // Fallback: pick by provider priority
-        const activeAccounts = FileStorageEngine.Instance.AccountsWithProviders
-            .filter(a => a.provider.IsActive);
-
-        if (activeAccounts.length === 0) {
-            throw new Error('No active FileStorageAccount found. Configure at least one storage account.');
-        }
-
-        const sorted = [...activeAccounts].sort((a, b) => a.provider.Priority - b.provider.Priority);
-        return { accountEntity: sorted[0].account, providerEntity: sorted[0].provider };
+        // Fallback: pick first active via engine
+        const resolved = FileStorageEngine.Instance.ResolveStorageAccount();
+        return resolved?.account.ID;
     }
 
     /**
@@ -283,17 +262,7 @@ export abstract class BaseFileHandlerAction extends BaseAction {
             throw new Error(`No FileStorageAccount found for ProviderID ${file.ProviderID}`);
         }
 
-        const accountEntity = accountResult.Results[0];
-        const md = new Metadata();
-        const providerEntity = await md.GetEntityObject<MJFileStorageProviderEntity>(
-            'MJ: File Storage Providers', params.ContextUser
-        );
-        const providerLoaded = await providerEntity.Load(file.ProviderID);
-        if (!providerLoaded) {
-            throw new Error(`FileStorageProvider ${file.ProviderID} not found`);
-        }
-
-        return initializeDriverWithAccountCredentials({ accountEntity, providerEntity, contextUser: params.ContextUser });
+        return FileStorageEngine.Instance.GetDriver(accountResult.Results[0].ID, params.ContextUser);
     }
 
     /**

--- a/packages/Angular/Generic/data-context/src/lib/ng-data-context.component.ts
+++ b/packages/Angular/Generic/data-context/src/lib/ng-data-context.component.ts
@@ -1,5 +1,5 @@
 import { Component, Input, OnInit } from '@angular/core';
-import { IMetadataProvider, IRunViewProvider, LogError, Metadata, RunView } from '@memberjunction/core';
+import { IMetadataProvider, LogError, Metadata, RunView } from '@memberjunction/core';
 import { UUIDsEqual } from '@memberjunction/global';
 import { MJDataContextEntity, MJDataContextItemEntity } from '@memberjunction/core-entities';
 
@@ -61,7 +61,7 @@ export class DataContextComponent implements OnInit {
         this.dataContextRecord = await p.GetEntityObject<MJDataContextEntity>("MJ: Data Contexts", p.CurrentUser);
         await this.dataContextRecord.Load(dataContextId);
 
-        const rv = new RunView(<IRunViewProvider><any>p);
+        const rv = RunView.FromMetadataProvider(p);
         const response = await rv.RunView<MJDataContextItemEntity>(
           { 
             EntityName: "MJ: Data Context Items", 

--- a/packages/Angular/Generic/file-storage/src/lib/file-browser/file-grid.component.ts
+++ b/packages/Angular/Generic/file-storage/src/lib/file-browser/file-grid.component.ts
@@ -1,6 +1,6 @@
 import { Component, Input, Output, EventEmitter, OnInit, OnChanges, SimpleChanges, ChangeDetectorRef, inject } from '@angular/core';
 import { GraphQLDataProvider, GraphQLFileStorageClient } from '@memberjunction/graphql-dataprovider';
-import { FileStorageEngine, StorageAccountWithProvider } from '@memberjunction/core-entities';
+import { FileStorageEngineBase, StorageAccountWithProvider } from '@memberjunction/core-entities';
 import { UUIDsEqual } from '@memberjunction/global';
 
 /**
@@ -1390,7 +1390,7 @@ export class FileGridComponent implements OnInit, OnChanges {
     }
 
     try {
-      const engine = FileStorageEngine.Instance;
+      const engine = FileStorageEngineBase.Instance;
       await engine.Config(false);  // Use cached data if available
 
       // Build available accounts (excluding current account)
@@ -1571,7 +1571,7 @@ export class FileGridComponent implements OnInit, OnChanges {
    */
   private async loadAvailableAccountsForSearch(): Promise<void> {
     try {
-      const engine = FileStorageEngine.Instance;
+      const engine = FileStorageEngineBase.Instance;
       await engine.Config(false);  // Use cached data if available
       this.availableAccounts = engine.AccountsWithProviders;
     } catch (error) {

--- a/packages/Angular/Generic/file-storage/src/lib/file-browser/storage-providers-list.component.ts
+++ b/packages/Angular/Generic/file-storage/src/lib/file-browser/storage-providers-list.component.ts
@@ -1,5 +1,5 @@
 import { Component, EventEmitter, OnInit, Output, ChangeDetectorRef } from '@angular/core';
-import { FileStorageEngine, StorageAccountWithProvider } from '@memberjunction/core-entities';
+import { FileStorageEngineBase, StorageAccountWithProvider } from '@memberjunction/core-entities';
 import { UUIDsEqual } from '@memberjunction/global';
 
 /**
@@ -49,14 +49,14 @@ export class StorageProvidersListComponent implements OnInit {
 
   /**
    * Loads all available file storage accounts with their provider details.
-   * Uses FileStorageEngine for centralized, cached access.
+   * Uses FileStorageEngineBase for centralized, cached access.
    */
   private async loadAccounts(): Promise<void> {
     this.isLoading = true;
     this.errorMessage = null;
 
     try {
-      const engine = FileStorageEngine.Instance;
+      const engine = FileStorageEngineBase.Instance;
       await engine.Config(false);  // Use cached data if available
 
       // Only show accounts whose provider is active
@@ -128,6 +128,6 @@ export class StorageProvidersListComponent implements OnInit {
    * Refreshes the accounts list by forcing a reload from the database.
    */
   public refresh(): void {
-    FileStorageEngine.Instance.Config(true).then(() => this.loadAccounts());
+    FileStorageEngineBase.Instance.Config(true).then(() => this.loadAccounts());
   }
 }

--- a/packages/Angular/Generic/resource-permissions/src/lib/resource-permissions.component.ts
+++ b/packages/Angular/Generic/resource-permissions/src/lib/resource-permissions.component.ts
@@ -1,5 +1,5 @@
 import { AfterViewInit, Component, Input } from '@angular/core';
-import { IMetadataProvider, IRunViewProvider, LogError, Metadata, RoleInfo, RunView } from '@memberjunction/core';
+import { LogError, RoleInfo, RunView } from '@memberjunction/core';
 import { ResourcePermissionEngine, MJResourcePermissionEntity, MJUserEntity } from '@memberjunction/core-entities';
 import { UUIDsEqual } from '@memberjunction/global';
 import { BaseAngularComponent } from '@memberjunction/ng-base-types';
@@ -108,7 +108,7 @@ export class ResourcePermissionsComponent extends BaseAngularComponent implement
     this.resourcePermissions = allResourcePermissions.filter((p) => p.Status === 'Approved'); // only include approved permissions in the UI, we don't show requested, rejected, revoked permissions here, just suppress them.
     
     const p = this.ProviderToUse;
-    const rv = new RunView(<IRunViewProvider><any>p)
+    const rv = RunView.FromMetadataProvider(p)
     const result = await rv.RunView<MJUserEntity>({
       EntityName: "MJ: Users",
       ResultType: "entity_object",

--- a/packages/MJCore/src/views/runView.ts
+++ b/packages/MJCore/src/views/runView.ts
@@ -327,6 +327,18 @@ export class RunView  {
     }
 
     /**
+     * Creates a RunView instance from an IMetadataProvider. At runtime the provider object
+     * (ProviderBase) implements both IMetadataProvider and IRunViewProvider, but TypeScript
+     * doesn't know that statically. This factory centralizes the cast so callers don't need
+     * their own helper methods.
+     * @param provider An IMetadataProvider instance (typically from Metadata.Provider or a contextUser's provider)
+     * @returns A new RunView wired to the given provider
+     */
+    public static FromMetadataProvider(provider: IMetadataProvider): RunView {
+        return new RunView(provider as unknown as IRunViewProvider);
+    }
+
+    /**
      * This property is used to get the IRunViewProvider implementation that is used by this instance of the RunView class. If a provider was specified to the constructor, that provider is used, otherwise the static RunView.Provider property is used.
      */
     public get ProviderToUse(): IRunViewProvider {
@@ -396,7 +408,7 @@ export class RunView  {
         }
         else if (params.ViewID || params.ViewName) {
             // we don't have a view entity loaded, so load it up now
-            const rv = new RunView(<IRunViewProvider><any>p);
+            const rv = RunView.FromMetadataProvider(p);
             const result = await rv.RunView({
                 EntityName: "MJ: User Views",
                 ExtraFilter: params.ViewID ? `ID = '${params.ViewID}'` : `Name = '${params.ViewName}'`,

--- a/packages/MJCoreEntities/src/__tests__/UUIDCrossDbCompliance.test.ts
+++ b/packages/MJCoreEntities/src/__tests__/UUIDCrossDbCompliance.test.ts
@@ -152,10 +152,10 @@ describe('UUID Cross-Database Compliance', () => {
         });
     });
 
-    describe('FileStorageEngine', () => {
+    describe('FileStorageEngineBase', () => {
         it('should find account by ID regardless of UUID case', async () => {
-            const { FileStorageEngine } = await import('../engines/FileStorageEngine');
-            const engine = FileStorageEngine.Instance;
+            const { FileStorageEngineBase } = await import('../engines/FileStorageEngine');
+            const engine = FileStorageEngineBase.Instance;
 
             (engine as Record<string, unknown>)['_accounts'] = [
                 { ID: UUID_UPPER, Name: 'S3 Bucket' },
@@ -167,8 +167,8 @@ describe('UUID Cross-Database Compliance', () => {
         });
 
         it('should find provider by ID regardless of UUID case', async () => {
-            const { FileStorageEngine } = await import('../engines/FileStorageEngine');
-            const engine = FileStorageEngine.Instance;
+            const { FileStorageEngineBase } = await import('../engines/FileStorageEngine');
+            const engine = FileStorageEngineBase.Instance;
 
             (engine as Record<string, unknown>)['_providers'] = [
                 { ID: UUID_LOWER, Name: 'AWS S3' },

--- a/packages/MJCoreEntities/src/engines/FileStorageEngine.ts
+++ b/packages/MJCoreEntities/src/engines/FileStorageEngine.ts
@@ -11,25 +11,29 @@ export interface StorageAccountWithProvider {
 }
 
 /**
- * FileStorageEngine provides centralized, cached access to file storage accounts and providers.
+ * FileStorageEngineBase provides centralized, cached access to file storage accounts and providers.
  * This engine eliminates redundant database calls by caching the data and making it available
- * across the application.
+ * across the application. It is safe to use on both client and server — it only deals with
+ * cached metadata, not file I/O.
+ *
+ * For server-side file operations (upload, download, driver initialization), use the
+ * `FileStorageEngine` class from `@memberjunction/storage` which wraps this base via containment.
  *
  * Usage:
  * ```typescript
- * const engine = FileStorageEngine.Instance;
+ * const engine = FileStorageEngineBase.Instance;
  * await engine.Config(false);  // Use cached data if available
  * const accounts = engine.AccountsWithProviders;
  * ```
  */
-export class FileStorageEngine extends BaseEngine<FileStorageEngine> {
+export class FileStorageEngineBase extends BaseEngine<FileStorageEngineBase> {
     /**
      * Returns the global instance of the class. This is a singleton class, so there is only
      * one instance of it in the application. Do not directly create new instances of it,
      * always use this method to get the instance.
      */
-    public static get Instance(): FileStorageEngine {
-        return super.getInstance<FileStorageEngine>();
+    public static get Instance(): FileStorageEngineBase {
+        return super.getInstance<FileStorageEngineBase>();
     }
 
     private _accounts: MJFileStorageAccountEntity[] = [];

--- a/packages/MJDataContext/src/types.ts
+++ b/packages/MJDataContext/src/types.ts
@@ -1,4 +1,4 @@
-import { BaseEntity, DataObjectRelatedEntityParam, EntityInfo, LogError, Metadata, KeyValuePair, QueryInfo, RunQuery, RunView, RunViewParams, UserInfo, CompositeKey, IMetadataProvider, IRunViewProvider } from "@memberjunction/core";
+import { BaseEntity, DataObjectRelatedEntityParam, EntityInfo, LogError, Metadata, KeyValuePair, QueryInfo, RunQuery, RunView, RunViewParams, UserInfo, CompositeKey, IMetadataProvider } from "@memberjunction/core";
 import { MJDataContextEntity, MJDataContextItemEntity, MJDataContextItemEntityType, MJUserViewEntityExtended } from "@memberjunction/core-entities";
 import { MJGlobal, RegisterClass, UUIDsEqual } from "@memberjunction/global";
 
@@ -606,7 +606,7 @@ export class DataContext {
                 throw new Error(`Data Context ID not set or invalid`);
 
             const p = provider ? provider : Metadata.Provider; 
-            const rv = <IRunViewProvider><any>p;
+            const rv = RunView.FromMetadataProvider(p);
             const dciEntityInfo = p.Entities.find((e) => e.Name === 'MJ: Data Context Items');
             if (!dciEntityInfo)
               throw new Error(`Data Context Items entity not found`);

--- a/packages/MJServer/src/resolvers/ArtifactFileResolver.ts
+++ b/packages/MJServer/src/resolvers/ArtifactFileResolver.ts
@@ -1,7 +1,7 @@
 import { Resolver, Query, Arg, Ctx } from 'type-graphql';
-import { Metadata, RunView, IMetadataProvider, IRunViewProvider } from '@memberjunction/core';
-import { MJArtifactVersionEntity, MJFileEntity, MJFileStorageAccountEntity, MJFileStorageProviderEntity } from '@memberjunction/core-entities';
-import { initializeDriverWithAccountCredentials } from '@memberjunction/storage';
+import { Metadata, RunView, IMetadataProvider } from '@memberjunction/core';
+import { MJArtifactVersionEntity, MJFileEntity, MJFileStorageAccountEntity } from '@memberjunction/core-entities';
+import { FileStorageEngine } from '@memberjunction/storage';
 import { ResolverBase } from '../generic/ResolverBase.js';
 import { AppContext } from '../types.js';
 import { GetReadWriteProvider } from '../util.js';
@@ -58,11 +58,8 @@ export class ArtifactFileResolver extends ResolverBase {
             throw new Error(`File record ${fileId} not found`);
         }
 
-        const providerEntity = await provider.GetEntityObject<MJFileStorageProviderEntity>('MJ: File Storage Providers', user);
-        await providerEntity.Load(fileEntity.ProviderID);
-
-        // Load the storage account so we can use the credential engine for OAuth providers (e.g. Box)
-        const rv = new RunView(<IRunViewProvider><any>provider);
+        // Find the storage account for this file's provider
+        const rv = RunView.FromMetadataProvider(provider);
         const accountResult = await rv.RunView<MJFileStorageAccountEntity>({
             EntityName: 'MJ: File Storage Accounts',
             ExtraFilter: `ProviderID = '${fileEntity.ProviderID}'`,
@@ -74,12 +71,8 @@ export class ArtifactFileResolver extends ResolverBase {
             throw new Error(`No FileStorageAccount found for ProviderID ${fileEntity.ProviderID}. Cannot generate download URL.`);
         }
 
-        const accountEntity = accountResult.Results[0];
-        const driver = await initializeDriverWithAccountCredentials({
-            accountEntity,
-            providerEntity,
-            contextUser: user!,
-        });
+        await FileStorageEngine.Instance.Config(false, user!);
+        const driver = await FileStorageEngine.Instance.GetDriver(accountResult.Results[0].ID, user!);
         return driver.CreatePreAuthDownloadUrl(fileEntity.ProviderKey ?? fileEntity.Name);
     }
 }

--- a/packages/MJServer/src/resolvers/FileResolver.ts
+++ b/packages/MJServer/src/resolvers/FileResolver.ts
@@ -32,7 +32,7 @@ import {
   FileSearchResult,
   UserContextOptions,
   ExtendedUserContextOptions,
-  initializeDriverWithAccountCredentials,
+  FileStorageEngine,
 } from '@memberjunction/storage';
 import { CreateMJFileInput, MJFileResolver as FileResolverBase, MJFile_, UpdateMJFileInput } from '../generated/generated.js';
 import { FieldMapper } from '@memberjunction/graphql-dataprovider';
@@ -648,12 +648,9 @@ export class FileResolver extends FileResolverBase {
     const fileEntity = await md.GetEntityObject<MJFileEntity>('MJ: Files', user);
     fileEntity.CheckPermissions(EntityPermissionType.Create, true);
 
-    // Initialize driver with account-based credentials from Credential Engine
-    const driver = await initializeDriverWithAccountCredentials({
-      accountEntity,
-      providerEntity,
-      contextUser: user,
-    });
+    // Initialize driver via FileStorageEngine (handles credential decryption + token refresh)
+    await FileStorageEngine.Instance.Config(false, user);
+    const driver = await FileStorageEngine.Instance.GetDriver(accountEntity.ID, user);
 
     const success = await driver.CreateDirectory(input.Path);
     return success;

--- a/packages/MJServer/src/resolvers/RunAIAgentResolver.ts
+++ b/packages/MJServer/src/resolvers/RunAIAgentResolver.ts
@@ -1,6 +1,6 @@
 import { Resolver, Mutation, Query, Arg, Ctx, ObjectType, Field, PubSub, PubSubEngine, Subscription, Root, ResolverFilterData, ID, Int } from 'type-graphql';
 import { AppContext, UserPayload } from '../types.js';
-import { DatabaseProviderBase, LogError, LogStatus, Metadata, RunView, UserInfo, IMetadataProvider, IRunViewProvider } from '@memberjunction/core';
+import { DatabaseProviderBase, LogError, LogStatus, Metadata, RunView, UserInfo, IMetadataProvider } from '@memberjunction/core';
 import { MJConversationDetailEntity, MJConversationDetailAttachmentEntity, MJConversationDetailArtifactEntity, MJArtifactVersionEntity, MJAIAgentRequestEntity } from '@memberjunction/core-entities';
 import { AgentRunner } from '@memberjunction/ai-agents';
 import { MJAIAgentEntityExtended, MJAIAgentRunEntityExtended, ExecuteAgentResult, ConversationUtility, AttachmentData } from '@memberjunction/ai-core-plus';
@@ -801,7 +801,7 @@ export class RunAIAgentResolver extends ResolverBase {
         provider: IMetadataProvider
     ): Promise<void> {
         try {
-            const rv = new RunView(<IRunViewProvider><any>provider);
+            const rv = RunView.FromMetadataProvider(provider);
             const result = await rv.RunView<MJAIAgentRequestEntity>({
                 EntityName: 'MJ: AI Agent Requests',
                 ExtraFilter: `OriginatingAgentRunID='${lastRunId}' AND Status='Requested'`,
@@ -1266,7 +1266,7 @@ export class RunAIAgentResolver extends ResolverBase {
         maxMessages: number,
         provider: IMetadataProvider
     ): Promise<ChatMessage[]> {
-        const rv = new RunView(<IRunViewProvider><any>provider);
+        const rv = RunView.FromMetadataProvider(provider);
         const attachmentService = GetAttachmentService();
 
         // Load recent conversation details (messages) for this conversation.
@@ -1395,7 +1395,7 @@ export class RunAIAgentResolver extends ResolverBase {
         const map = new Map<string, MJArtifactVersionEntity[]>();
         if (conversationDetailIds.length === 0) return map;
 
-        const rv = new RunView(<IRunViewProvider><any>provider);
+        const rv = RunView.FromMetadataProvider(provider);
         const idList = conversationDetailIds.map(id => `'${id}'`).join(',');
 
         // Load ConversationDetailArtifact links with Direction='Input'

--- a/packages/MJStorage/src/FileStorageEngine.ts
+++ b/packages/MJStorage/src/FileStorageEngine.ts
@@ -1,0 +1,388 @@
+import { IMetadataProvider, LogError, Metadata, UserInfo } from '@memberjunction/core';
+import { BaseSingleton } from '@memberjunction/global';
+import {
+    FileStorageEngineBase,
+    StorageAccountWithProvider,
+    MJFileEntity,
+    MJFileStorageAccountEntity,
+    MJFileStorageProviderEntity
+} from '@memberjunction/core-entities';
+import { FileStorageBase } from './generic/FileStorageBase';
+import { initializeDriverWithAccountCredentials } from './util';
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Types
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * Options for uploading a file to MJ Storage.
+ */
+export interface UploadFileOptions {
+    /** Raw file content as a Buffer */
+    content: Buffer;
+    /** File name (used for the MJ: Files record and the storage path) */
+    fileName: string;
+    /** MIME type of the file (e.g., 'application/pdf') */
+    mimeType: string;
+    /** User context for DB operations and credential access */
+    contextUser: UserInfo;
+    /**
+     * Optional pre-resolved FileStorageAccount ID.
+     * When provided, the file is uploaded to this specific account.
+     * Otherwise, the first active account is used.
+     */
+    storageAccountId?: string;
+    /**
+     * Optional metadata provider. Defaults to `Metadata.Provider`.
+     */
+    provider?: IMetadataProvider;
+    /**
+     * Optional path prefix within the storage bucket.
+     * Defaults to `'artifacts/<date>/<uuid>'`.
+     */
+    pathPrefix?: string;
+}
+
+/**
+ * Result returned by {@link FileStorageEngine.UploadFile}.
+ */
+export interface UploadFileResult {
+    /** The newly created MJ: Files record ID */
+    FileID: string;
+    /** The storage path (ProviderKey) where the file was stored */
+    StoragePath: string;
+    /** The storage account that was used */
+    Account: MJFileStorageAccountEntity;
+    /** The storage provider that was used */
+    Provider: MJFileStorageProviderEntity;
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Engine
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * Server-side file storage engine providing high-level operations for uploading,
+ * downloading, and managing files in MJ Storage.
+ *
+ * Follows the containment pattern (like AIEngine wraps AIEngineBase):
+ * - Delegates all metadata access to {@link FileStorageEngineBase}
+ * - Adds server-side methods: {@link UploadFile}, {@link GetDriver}, {@link ResolveStorageAccount}
+ *
+ * **Client-side code** should use `FileStorageEngineBase` from `@memberjunction/core-entities`
+ * for metadata-only access (accounts, providers, lookups).
+ *
+ * Usage:
+ * ```typescript
+ * import { FileStorageEngine } from '@memberjunction/storage';
+ *
+ * const engine = FileStorageEngine.Instance;
+ * await engine.Config(false, contextUser);
+ *
+ * // Upload a file
+ * const result = await engine.UploadFile({
+ *     content: Buffer.from(base64Data, 'base64'),
+ *     fileName: 'report.pdf',
+ *     mimeType: 'application/pdf',
+ *     contextUser
+ * });
+ *
+ * // Get a driver for direct operations
+ * const driver = await engine.GetDriver(accountId, contextUser);
+ * const objects = await driver.ListObjects('/');
+ * ```
+ */
+export class FileStorageEngine extends BaseSingleton<FileStorageEngine> {
+
+    // Loading state management (mirrors AIEngine pattern)
+    private _loaded: boolean = false;
+    private _loading: boolean = false;
+    private _loadingPromise: Promise<void> | null = null;
+    private _contextUser: UserInfo | undefined;
+
+    // Server-specific state: cached, initialized drivers keyed by account ID
+    private _driverCache: Map<string, FileStorageBase> = new Map();
+
+    /**
+     * Returns the global singleton instance.
+     */
+    public static get Instance(): FileStorageEngine {
+        return super.getInstance<FileStorageEngine>();
+    }
+
+    // ─────────────────────────────────────────────────────────────────────
+    // Containment — delegate to FileStorageEngineBase
+    // ─────────────────────────────────────────────────────────────────────
+
+    /** Access to the underlying metadata-only engine. */
+    protected get Base(): FileStorageEngineBase {
+        return FileStorageEngineBase.Instance;
+    }
+
+    /** Returns true if the engine has been configured. */
+    public get Loaded(): boolean {
+        return this._loaded && this.Base.Loaded;
+    }
+
+    // --- Delegated metadata getters ---
+
+    /** Gets all file storage accounts (cached). */
+    public get Accounts(): MJFileStorageAccountEntity[] {
+        return this.Base.Accounts;
+    }
+
+    /** Gets all file storage providers (cached). */
+    public get Providers(): MJFileStorageProviderEntity[] {
+        return this.Base.Providers;
+    }
+
+    /** Gets all storage accounts combined with their provider details (cached). */
+    public get AccountsWithProviders(): StorageAccountWithProvider[] {
+        return this.Base.AccountsWithProviders;
+    }
+
+    /** Whether any storage accounts are configured. */
+    public get HasStorageAccounts(): boolean {
+        return this.Base.AccountsWithProviders.length > 0;
+    }
+
+    // --- Delegated lookup methods ---
+
+    /** Gets a file storage account by its ID. */
+    public GetAccountById(accountId: string): MJFileStorageAccountEntity | undefined {
+        return this.Base.GetAccountById(accountId);
+    }
+
+    /** Gets a file storage provider by its ID. */
+    public GetProviderById(providerId: string): MJFileStorageProviderEntity | undefined {
+        return this.Base.GetProviderById(providerId);
+    }
+
+    /** Gets a storage account with its provider details by account ID. */
+    public GetAccountWithProvider(accountId: string): StorageAccountWithProvider | null {
+        return this.Base.GetAccountWithProvider(accountId);
+    }
+
+    // ─────────────────────────────────────────────────────────────────────
+    // Configuration
+    // ─────────────────────────────────────────────────────────────────────
+
+    /**
+     * Configures the engine by loading the underlying metadata cache and any
+     * server-specific state. Safe to call multiple times — uses cached data
+     * unless `forceRefresh` is true. Concurrent callers share a single loading
+     * promise to avoid redundant work.
+     */
+    public async Config(forceRefresh?: boolean, contextUser?: UserInfo, provider?: IMetadataProvider): Promise<void> {
+        if (this._loaded && !forceRefresh) {
+            return;
+        }
+
+        // If currently loading, return the existing promise so all callers wait together
+        if (this._loading && this._loadingPromise) {
+            return this._loadingPromise;
+        }
+
+        this._loading = true;
+        this._loadingPromise = this.innerLoad(forceRefresh, contextUser, provider);
+
+        try {
+            await this._loadingPromise;
+        } finally {
+            this._loading = false;
+            this._loadingPromise = null;
+        }
+    }
+
+    /**
+     * Internal loading logic — separated for clean promise management.
+     * First ensures the base metadata cache is loaded, then loads any
+     * server-specific state (extensible for future needs).
+     */
+    private async innerLoad(forceRefresh?: boolean, contextUser?: UserInfo, provider?: IMetadataProvider): Promise<void> {
+        try {
+            this._contextUser = contextUser;
+
+            // Load base metadata (accounts, providers)
+            await this.Base.Config(forceRefresh ?? false, contextUser, provider);
+
+            // Initialize drivers for all active accounts and cache them
+            await this.RefreshDriverCache();
+
+            this._loaded = true;
+        } catch (error) {
+            LogError(error);
+            throw error;
+        }
+    }
+
+    /**
+     * Initializes storage drivers for all active accounts and caches them.
+     * Called automatically during Config(). Can also be called independently to
+     * re-initialize drivers without reloading metadata (e.g., after credential rotation).
+     * Accounts that fail to initialize are logged and skipped — they will fall back to
+     * on-demand initialization when GetDriver() is called.
+     */
+    public async RefreshDriverCache(): Promise<void> {
+        this._driverCache.clear();
+
+        const activeAccounts = this.Base.AccountsWithProviders.filter(a => a.provider.IsActive !== false);
+        if (activeAccounts.length === 0 || !this._contextUser) {
+            return;
+        }
+
+        const contextUser = this._contextUser;
+        const results = await Promise.allSettled(
+            activeAccounts.map(async ({ account, provider: storageProvider }) => {
+                const driver = await initializeDriverWithAccountCredentials({
+                    accountEntity: account,
+                    providerEntity: storageProvider,
+                    contextUser
+                });
+                this._driverCache.set(account.ID, driver);
+            })
+        );
+
+        // Log failures but don't throw — failed accounts fall back to on-demand init
+        for (let i = 0; i < results.length; i++) {
+            if (results[i].status === 'rejected') {
+                const accountName = activeAccounts[i].account.Name;
+                const reason = (results[i] as PromiseRejectedResult).reason;
+                LogError(`FileStorageEngine: failed to pre-initialize driver for account "${accountName}": ${reason}`);
+            }
+        }
+    }
+
+    // ─────────────────────────────────────────────────────────────────────
+    // Server-side operations
+    // ─────────────────────────────────────────────────────────────────────
+
+    /**
+     * Resolves a storage account to use for file operations.
+     *
+     * Resolution logic:
+     * 1. If `accountId` is provided, returns that specific account
+     * 2. Otherwise, returns the first active account
+     * 3. If no active accounts exist, returns the first account regardless of active status
+     *
+     * @param accountId - Optional explicit account ID
+     * @returns The resolved account with provider, or null if no accounts are configured
+     */
+    public ResolveStorageAccount(accountId?: string): StorageAccountWithProvider | null {
+        if (accountId) {
+            return this.Base.GetAccountWithProvider(accountId);
+        }
+
+        const accounts = this.Base.AccountsWithProviders;
+        if (accounts.length === 0) return null;
+
+        return accounts.find(a => a.provider.IsActive !== false) ?? accounts[0];
+    }
+
+    /**
+     * Returns an authenticated storage driver for a given account.
+     *
+     * Checks the pre-initialized driver cache first (populated during Config()).
+     * If the account wasn't cached (e.g., it failed during Config or was added after),
+     * falls back to on-demand initialization.
+     *
+     * This handles:
+     * - Looking up the account and provider from cached metadata
+     * - Decrypting credentials via the Credential Engine
+     * - Setting up OAuth token refresh callbacks for providers like Box
+     *
+     * @param accountId - The FileStorageAccount ID to get a driver for
+     * @param contextUser - User context for credential decryption (used for on-demand init)
+     * @returns An initialized, ready-to-use FileStorageBase driver
+     * @throws Error if the account is not found or driver initialization fails
+     */
+    public async GetDriver(accountId: string, contextUser: UserInfo): Promise<FileStorageBase> {
+        // Check pre-initialized cache first
+        const cached = this._driverCache.get(accountId);
+        if (cached) {
+            return cached;
+        }
+
+        // On-demand fallback: account wasn't in cache (failed init, added late, etc.)
+        const resolved = this.Base.GetAccountWithProvider(accountId);
+        if (!resolved) {
+            throw new Error(`FileStorageEngine.GetDriver: account '${accountId}' not found in cached metadata. Did you call Config() first?`);
+        }
+
+        const driver = await initializeDriverWithAccountCredentials({
+            accountEntity: resolved.account,
+            providerEntity: resolved.provider,
+            contextUser
+        });
+
+        // Cache it for future calls
+        this._driverCache.set(accountId, driver);
+        return driver;
+    }
+
+    /**
+     * Uploads a file to MJ Storage and creates an `MJ: Files` entity record.
+     *
+     * This is the primary high-level method for storing files. It handles:
+     * 1. Resolving which storage account to use
+     * 2. Initializing an authenticated driver
+     * 3. Uploading the file content
+     * 4. Creating the `MJ: Files` database record
+     *
+     * @param options - Upload options (content, fileName, mimeType, contextUser, etc.)
+     * @returns Upload result containing the file ID, storage path, and account/provider used
+     * @throws Error if no storage accounts are configured or the upload/save fails
+     *
+     * @example
+     * ```typescript
+     * const result = await FileStorageEngine.Instance.UploadFile({
+     *     content: Buffer.from(base64Data, 'base64'),
+     *     fileName: 'report.pdf',
+     *     mimeType: 'application/pdf',
+     *     contextUser,
+     *     storageAccountId: resolvedAccountId  // optional
+     * });
+     * console.log('Created file:', result.FileID);
+     * ```
+     */
+    public async UploadFile(options: UploadFileOptions): Promise<UploadFileResult> {
+        const { content, fileName, mimeType, contextUser, storageAccountId, provider } = options;
+        const md = provider ?? Metadata.Provider;
+
+        // 1. Resolve storage account
+        const resolved = this.ResolveStorageAccount(storageAccountId);
+        if (!resolved) {
+            throw new Error('FileStorageEngine.UploadFile: no file storage accounts configured. Cannot upload.');
+        }
+
+        // 2. Initialize driver
+        const driver = await this.GetDriver(resolved.account.ID, contextUser);
+
+        // 3. Upload
+        const pathPrefix = options.pathPrefix ?? `artifacts/${new Date().toISOString().slice(0, 10)}/${crypto.randomUUID()}`;
+        const storagePath = `${pathPrefix}/${fileName}`;
+        const uploaded = await driver.PutObject(storagePath, content, mimeType);
+        if (!uploaded) {
+            throw new Error(`FileStorageEngine.UploadFile: PutObject returned false for path '${storagePath}'`);
+        }
+
+        // 4. Create MJ: Files record
+        const fileEntity = await md.GetEntityObject<MJFileEntity>('MJ: Files', contextUser);
+        fileEntity.Name = fileName;
+        fileEntity.ContentType = mimeType;
+        fileEntity.ProviderID = resolved.provider.ID;
+        fileEntity.ProviderKey = storagePath;
+        fileEntity.Status = 'Uploaded';
+
+        if (!(await fileEntity.Save())) {
+            throw new Error(`FileStorageEngine.UploadFile: failed to save MJ: Files record for '${fileName}'`);
+        }
+
+        return {
+            FileID: fileEntity.ID,
+            StoragePath: storagePath,
+            Account: resolved.account,
+            Provider: resolved.provider
+        };
+    }
+}

--- a/packages/MJStorage/src/index.ts
+++ b/packages/MJStorage/src/index.ts
@@ -8,3 +8,4 @@ export * from './drivers/BoxFileStorage';
 export * from './generic/FileStorageBase';
 export * from './util';
 export * from './config';
+export * from './FileStorageEngine';

--- a/packages/SearchEngine/src/generic/StorageSearchProvider.ts
+++ b/packages/SearchEngine/src/generic/StorageSearchProvider.ts
@@ -19,7 +19,7 @@ import {
 import {
     FileSearchResult,
     FileSearchOptions,
-    initializeDriverWithAccountCredentials
+    FileStorageEngine
 } from '@memberjunction/storage';
 import { ISearchProvider } from './ISearchProvider';
 import { SearchSource, SearchFilters, SearchResultItem, SearchResultType } from './search.types';
@@ -234,11 +234,7 @@ export class StorageSearchProvider implements ISearchProvider {
         contextUser: UserInfo
     ): Promise<SearchResultItem[]> {
         try {
-            const driver = await initializeDriverWithAccountCredentials({
-                accountEntity: entry.Account,
-                providerEntity: entry.Provider,
-                contextUser
-            });
+            const driver = await FileStorageEngine.Instance.GetDriver(entry.Account.ID, contextUser);
 
             if (!driver.IsConfigured) {
                 LogError(


### PR DESCRIPTION
## Summary

Addresses all PR review feedback from AN-BC on the `file-artifact-io-plan` branch. Five distinct items, all verified with full builds (188/188) and live end-to-end testing of the storage resolution chain.

## Changes

### 1. `RunView.FromMetadataProvider()` Factory Method
- Added static factory `RunView.FromMetadataProvider(provider)` in MJCore to centralize the `IMetadataProvider → IRunViewProvider` cast
- Replaced all 15 inline `<IRunViewProvider><any>` casts and 2 private `asRunViewProvider()` helpers across 9 files
- Cleaned up unused `IRunViewProvider` imports

### 2. FileStorageEngine → FileStorageEngineBase + FileStorageEngine (Containment Pattern)
- **Renamed** `FileStorageEngine` → `FileStorageEngineBase` in `@memberjunction/core-entities` (metadata-only, client+server safe)
- **Created** new `FileStorageEngine` in `@memberjunction/storage` following the AIEngine/AIEngineBase containment pattern:
  - `extends BaseSingleton<FileStorageEngine>` with `protected get Base()` returning `FileStorageEngineBase.Instance`
  - Loading state management with concurrent-caller deduplication (`_loaded`, `_loading`, `_loadingPromise`)
  - Server-specific state: `_driverCache` pre-initializes authenticated drivers during `Config()` via `RefreshDriverCache()`
  - High-level methods: `UploadFile()`, `GetDriver()`, `ResolveStorageAccount()`, `HasStorageAccounts`
- **Migrated all 8 external consumers** of `initializeDriverWithAccountCredentials` to use engine methods — zero direct calls remain outside `@memberjunction/storage`

### 3. Protected Getter for `_resolvedStorageAccountId`
- Added `protected get ResolvedStorageAccountId()` on `BaseAgent` so subclasses can read the resolved storage account

### 4. Agent Category Cache → AIEngineBase
- **Eliminated per-agent-run DB query**: Moved `MJ: AI Agent Categories` from ad-hoc `RunView` in `BaseAgent._categoryCache` to `AIEngineBase.Config()` with `BaseEngine` caching
- Added `AgentCategories` getter to `AIEngineBase` and delegation in `AIEngine`
- Removed `_categoryCache` field and `ensureCategoryCacheLoaded()` method from `BaseAgent`

### 5. `ParseFileOutputRef` Naming Convention
- Renamed exported function `parseFileOutputRef` → `ParseFileOutputRef` (MJ PascalCase convention for exported functions)

## Files Changed (22)

| Package | Files | What |
|---------|-------|------|
| `@memberjunction/core` | `runView.ts` | Added `FromMetadataProvider()` factory |
| `@memberjunction/core-entities` | `FileStorageEngine.ts`, test | Renamed class to `FileStorageEngineBase` |
| `@memberjunction/storage` | `FileStorageEngine.ts` (NEW), `index.ts` | New server-side engine with containment pattern |
| `@memberjunction/ai-engine-base` | `BaseAIEngine.ts` | Added `_agentCategories` + `AgentCategories` getter |
| `@memberjunction/aiengine` | `AIEngine.ts` | Added `AgentCategories` delegation |
| `@memberjunction/ai-agents` | `AgentRunner.ts`, `base-agent.ts` | Migrated to engine methods, removed category cache |
| `@memberjunction/ai-core-plus` | `agent-types.ts` | `ParseFileOutputRef` rename |
| `@memberjunction/aiengine` | `ConversationAttachmentService.ts` | Migrated upload/download to engine |
| `@memberjunction/actions` | `base-file-handler.ts`, `base-file-storage.action.ts` | Migrated to engine methods |
| `@memberjunction/server` | `ArtifactFileResolver.ts`, `FileResolver.ts`, `RunAIAgentResolver.ts` | Migrated to engine + RunView factory |
| `@memberjunction/search` | `StorageSearchProvider.ts` | Migrated to `GetDriver()` |
| Angular packages | 4 components | Updated to `FileStorageEngineBase` / `RunView.FromMetadataProvider` |
| `@memberjunction/data-context` | `types.ts` | `RunView.FromMetadataProvider` |

## Testing

- **Build**: 188/188 packages pass
- **Unit Tests**: MJCore (863), MJCoreEntities (294), MJStorage (30), AI CorePlus (150) — all green
- **Live E2E**: Storage resolution chain tested with 2 active accounts (Box.com + Dropbox) configured at different hierarchy levels:
  - ✅ Multi-account error when no defaults configured
  - ✅ Agent-level beats category-level (Box.com on agent, Dropbox on category → Box.com selected)
  - ✅ Category-level beats agent type-level (Dropbox on category, Box.com on type → Dropbox selected)
  - ✅ Agent type-level fallback when no agent/category defaults (Box.com on type → Box.com selected)

🤖 Generated with [Claude Code](https://claude.com/claude-code)