### PR TITLE
Eliminate ad-hoc RunView calls for cached storage metadata

### DIFF
--- a/packages/AI/Agents/src/base-agent.ts
+++ b/packages/AI/Agents/src/base-agent.ts
@@ -7747,8 +7747,7 @@ The context is now within limits. Please retry your request with the recovered c
             }
         }
 
-        // 5. System fallback
-        await FileStorageEngineBase.Instance.Config(false, params.contextUser);
+        // 5. System fallback — use cached metadata (already loaded during engine Config)
         const activeAccounts = FileStorageEngineBase.Instance.AccountsWithProviders
             .filter(a => a.provider.IsActive);
 

--- a/packages/AI/Engine/src/services/ConversationAttachmentService.ts
+++ b/packages/AI/Engine/src/services/ConversationAttachmentService.ts
@@ -15,7 +15,6 @@
 import { Metadata, RunView, UserInfo, IMetadataProvider } from '@memberjunction/core';
 import {
     MJFileStorageProviderEntity,
-    MJFileStorageAccountEntity,
     MJFileEntity,
     MJAIAgentEntity,
     MJAIModelEntity,
@@ -335,19 +334,13 @@ export class ConversationAttachmentService {
                 return null;
             }
 
-            // Find the FileStorageAccount that links to this provider
-            const rv = RunView.FromMetadataProvider(provider ?? this._defaultProvider);
-            const accountResult = await rv.RunView<MJFileStorageAccountEntity>({
-                EntityName: 'MJ: File Storage Accounts',
-                ExtraFilter: `ProviderID = '${file.ProviderID}'`,
-                MaxRows: 1,
-                ResultType: 'entity_object'
-            }, contextUser);
+            // Find the FileStorageAccount that links to this provider using cached metadata
+            const matchingAccounts = FileStorageEngine.Instance.GetAccountsByProviderID(file.ProviderID);
 
             let driver: FileStorageBase;
-            if (accountResult.Success && accountResult.Results.length > 0) {
+            if (matchingAccounts.length > 0) {
                 // Initialize driver with account credentials via FileStorageEngine
-                driver = await FileStorageEngine.Instance.GetDriver(accountResult.Results[0].ID, contextUser);
+                driver = await FileStorageEngine.Instance.GetDriver(matchingAccounts[0].ID, contextUser);
             } else {
                 // Fallback: create driver without account credentials (env vars only)
                 driver = MJGlobal.Instance.ClassFactory.CreateInstance<FileStorageBase>(

--- a/packages/Actions/CoreActions/src/custom/files/base-file-storage.action.ts
+++ b/packages/Actions/CoreActions/src/custom/files/base-file-storage.action.ts
@@ -1,6 +1,6 @@
 import { ActionResultSimple, RunActionParams } from "@memberjunction/actions-base";
 import { BaseAction } from "@memberjunction/actions";
-import { RunView, UserInfo } from "@memberjunction/core";
+import { UserInfo } from "@memberjunction/core";
 import { MJFileStorageAccountEntity, MJFileStorageProviderEntity } from "@memberjunction/core-entities";
 import { FileStorageBase, FileStorageEngine } from "@memberjunction/storage";
 
@@ -15,45 +15,21 @@ import { FileStorageBase, FileStorageEngine } from "@memberjunction/storage";
 export abstract class BaseFileStorageAction extends BaseAction {
 
     /**
-     * Get storage account entity by name
+     * Get storage account entity by name using cached metadata.
      * @param accountName - Name of the storage account
-     * @param contextUser - User context for the operation
      * @returns MJFileStorageAccountEntity or null if not found
      */
-    protected async getStorageAccount(accountName: string, contextUser: UserInfo): Promise<MJFileStorageAccountEntity | null> {
-        const rv = new RunView();
-        const result = await rv.RunView<MJFileStorageAccountEntity>({
-            EntityName: 'MJ: File Storage Accounts',
-            ExtraFilter: `Name='${accountName.replace(/'/g, "''")}'`,
-            ResultType: 'entity_object'
-        }, contextUser);
-
-        if (result.Success && result.Results && result.Results.length > 0) {
-            return result.Results[0];
-        }
-
-        return null;
+    protected getStorageAccount(accountName: string): MJFileStorageAccountEntity | null {
+        return FileStorageEngine.Instance.GetAccountByName(accountName) ?? null;
     }
 
     /**
-     * Get storage provider entity by ID
+     * Get storage provider entity by ID using cached metadata.
      * @param providerId - ID of the storage provider
-     * @param contextUser - User context for the operation
      * @returns MJFileStorageProviderEntity or null if not found
      */
-    protected async getStorageProviderById(providerId: string, contextUser: UserInfo): Promise<MJFileStorageProviderEntity | null> {
-        const rv = new RunView();
-        const result = await rv.RunView<MJFileStorageProviderEntity>({
-            EntityName: 'MJ: File Storage Providers',
-            ExtraFilter: `ID='${providerId}'`,
-            ResultType: 'entity_object'
-        }, contextUser);
-
-        if (result.Success && result.Results && result.Results.length > 0) {
-            return result.Results[0];
-        }
-
-        return null;
+    protected getStorageProviderById(providerId: string): MJFileStorageProviderEntity | null {
+        return FileStorageEngine.Instance.GetProviderById(providerId) ?? null;
     }
 
     /**
@@ -84,14 +60,14 @@ export abstract class BaseFileStorageAction extends BaseAction {
             };
         }
 
-        const account = await this.getStorageAccount(accountName, params.ContextUser);
+        const account = this.getStorageAccount(accountName);
         if (!account) {
             return {
                 error: this.createErrorResult(`Storage account '${accountName}' not found`, "ACCOUNT_NOT_FOUND")
             };
         }
 
-        const provider = await this.getStorageProviderById(account.ProviderID, params.ContextUser);
+        const provider = this.getStorageProviderById(account.ProviderID);
         if (!provider) {
             return {
                 error: this.createErrorResult(`Storage provider not found for account '${accountName}'`, "PROVIDER_NOT_FOUND")

--- a/packages/Actions/CoreActions/src/custom/files/list-storage-providers.action.ts
+++ b/packages/Actions/CoreActions/src/custom/files/list-storage-providers.action.ts
@@ -1,10 +1,8 @@
 import { ActionResultSimple, RunActionParams, ActionParam } from "@memberjunction/actions-base";
 import { RegisterClass } from "@memberjunction/global";
-import { MJGlobal } from "@memberjunction/global";
-import { RunView } from "@memberjunction/core";
-import { MJFileStorageAccountEntity, MJFileStorageProviderEntity } from "@memberjunction/core-entities";
 import { BaseFileStorageAction } from "./base-file-storage.action";
 import { BaseAction } from "@memberjunction/actions";
+import { FileStorageEngine } from "@memberjunction/storage";
 
 /**
  * Action that retrieves a list of configured file storage accounts.
@@ -42,44 +40,11 @@ export class ListStorageAccountsAction extends BaseFileStorageAction {
         const searchSupportedOnly = this.getBooleanParam(params, "searchsupportedonly", false);
 
         try {
-            const rv = new RunView();
+            await FileStorageEngine.Instance.Config(false, params.ContextUser);
 
-            // Load accounts and providers in parallel
-            const [accountsResult, providersResult] = await rv.RunViews([
-                {
-                    EntityName: 'MJ: File Storage Accounts',
-                    ExtraFilter: '',
-                    OrderBy: 'Name',
-                    ResultType: 'entity_object'
-                },
-                {
-                    EntityName: 'MJ: File Storage Providers',
-                    ExtraFilter: 'IsActive=1',
-                    OrderBy: 'Name',
-                    ResultType: 'entity_object'
-                }
-            ], params.ContextUser);
-
-            if (!accountsResult.Success) {
-                return this.createErrorResult(
-                    `Failed to retrieve storage accounts: ${accountsResult.ErrorMessage}`,
-                    "QUERY_FAILED"
-                );
-            }
-
-            if (!providersResult.Success) {
-                return this.createErrorResult(
-                    `Failed to retrieve storage providers: ${providersResult.ErrorMessage}`,
-                    "QUERY_FAILED"
-                );
-            }
-
-            const accounts = accountsResult.Results as MJFileStorageAccountEntity[] || [];
-            const providers = providersResult.Results as MJFileStorageProviderEntity[] || [];
-
-            // Create provider lookup map
-            const providerMap = new Map<string, MJFileStorageProviderEntity>();
-            providers.forEach(p => providerMap.set(p.ID, p));
+            // Use cached metadata from the engine — no RunView needed
+            const accountsWithProviders = FileStorageEngine.Instance.AccountsWithProviders
+                .filter(a => a.provider.IsActive !== false);
 
             const availableAccounts: Array<{
                 Name: string;
@@ -90,12 +55,7 @@ export class ListStorageAccountsAction extends BaseFileStorageAction {
                 HasCredential: boolean;
             }> = [];
 
-            for (const account of accounts) {
-                const provider = providerMap.get(account.ProviderID);
-                if (!provider) {
-                    continue; // Skip accounts with inactive/missing providers
-                }
-
+            for (const { account, provider } of accountsWithProviders) {
                 const supportsSearch = provider.Get('SupportsSearch') ?? false;
 
                 // Skip if filtering for search-only and this provider doesn't support it

--- a/packages/Actions/CoreActions/src/custom/utilities/base-file-handler.ts
+++ b/packages/Actions/CoreActions/src/custom/utilities/base-file-handler.ts
@@ -1,7 +1,7 @@
 import { BaseAction } from "@memberjunction/actions";
 import { RunActionParams } from "@memberjunction/actions-base";
-import { Metadata, RunView } from "@memberjunction/core";
-import { MJFileEntity, MJFileStorageAccountEntity, MJFileStorageProviderEntity } from "@memberjunction/core-entities";
+import { RunView } from "@memberjunction/core";
+import { MJFileEntity, MJFileStorageAccountEntity } from "@memberjunction/core-entities";
 import { FileStorageEngine } from "@memberjunction/storage";
 
 /**
@@ -171,8 +171,8 @@ export abstract class BaseFileHandlerAction extends BaseAction {
             // Resolve storage account ID
             let storageAccountId: string | undefined;
             if (storageAccountName) {
-                const { accountEntity } = await this.loadStorageAccountByName(storageAccountName, params);
-                storageAccountId = accountEntity.ID;
+                const account = this.loadStorageAccountByName(storageAccountName);
+                storageAccountId = account.ID;
             } else {
                 storageAccountId = await this.resolveStorageAccountId(params);
             }
@@ -198,35 +198,14 @@ export abstract class BaseFileHandlerAction extends BaseAction {
     }
 
     /**
-     * Loads a FileStorageAccount by name along with its provider entity.
+     * Finds a FileStorageAccount by name using the engine's cached metadata.
      */
-    private async loadStorageAccountByName(accountName: string, params: RunActionParams): Promise<{
-        accountEntity: MJFileStorageAccountEntity;
-        providerEntity: MJFileStorageProviderEntity;
-    }> {
-        const rv = new RunView();
-        const accountResult = await rv.RunView<MJFileStorageAccountEntity>({
-            EntityName: 'MJ: File Storage Accounts',
-            ExtraFilter: `Name = '${accountName.replace(/'/g, "''")}'`,
-            MaxRows: 1,
-            ResultType: 'entity_object'
-        }, params.ContextUser);
-
-        if (!accountResult.Success || accountResult.Results.length === 0) {
+    private loadStorageAccountByName(accountName: string): MJFileStorageAccountEntity {
+        const account = FileStorageEngine.Instance.GetAccountByName(accountName);
+        if (!account) {
             throw new Error(`FileStorageAccount "${accountName}" not found. Check account name or use default.`);
         }
-
-        const accountEntity = accountResult.Results[0];
-        const md = new Metadata();
-        const providerEntity = await md.GetEntityObject<MJFileStorageProviderEntity>(
-            'MJ: File Storage Providers', params.ContextUser
-        );
-        const providerLoaded = await providerEntity.Load(accountEntity.ProviderID);
-        if (!providerLoaded) {
-            throw new Error(`FileStorageProvider ${accountEntity.ProviderID} not found for account "${accountName}"`);
-        }
-
-        return { accountEntity, providerEntity };
+        return account;
     }
 
     /**
@@ -247,22 +226,15 @@ export abstract class BaseFileHandlerAction extends BaseAction {
     }
 
     /**
-     * Initializes a storage driver for the given file by looking up its storage account.
+     * Initializes a storage driver for the given file using the engine's cached metadata.
      */
     private async initializeDriverForFile(file: MJFileEntity, params: RunActionParams) {
-        const rv = new RunView();
-        const accountResult = await rv.RunView<MJFileStorageAccountEntity>({
-            EntityName: 'MJ: File Storage Accounts',
-            ExtraFilter: `ProviderID = '${file.ProviderID}'`,
-            MaxRows: 1,
-            ResultType: 'entity_object'
-        }, params.ContextUser);
-
-        if (!accountResult.Success || accountResult.Results.length === 0) {
+        const accounts = FileStorageEngine.Instance.GetAccountsByProviderID(file.ProviderID);
+        if (accounts.length === 0) {
             throw new Error(`No FileStorageAccount found for ProviderID ${file.ProviderID}`);
         }
 
-        return FileStorageEngine.Instance.GetDriver(accountResult.Results[0].ID, params.ContextUser);
+        return FileStorageEngine.Instance.GetDriver(accounts[0].ID, params.ContextUser);
     }
 
     /**

--- a/packages/Angular/Generic/file-storage/src/lib/file-upload/file-upload.ts
+++ b/packages/Angular/Generic/file-storage/src/lib/file-upload/file-upload.ts
@@ -1,6 +1,6 @@
 import { Component, EventEmitter, Input, OnInit, Output } from '@angular/core';
-import { Metadata, RunView } from '@memberjunction/core';
-import { MJFileEntity, MJFileSchema, MJFileStorageProviderEntity } from '@memberjunction/core-entities';
+import { Metadata } from '@memberjunction/core';
+import { MJFileEntity, MJFileSchema, MJFileStorageProviderEntity, FileStorageEngineBase } from '@memberjunction/core-entities';
 import { GraphQLDataProvider, gql } from '@memberjunction/graphql-dataprovider';
 
 import { z } from 'zod';
@@ -85,9 +85,11 @@ export class FileUploadComponent implements OnInit {
   }
 
   async Refresh() {
-    const rv = new RunView();
-    const viewResults = await rv.RunView({ EntityName: 'MJ: File Storage Providers', ExtraFilter: 'IsActive = 1', OrderBy: 'Priority DESC' });
-    const provider: MJFileStorageProviderEntity | undefined = viewResults.Results[0];
+    await FileStorageEngineBase.Instance.Config(false);
+    const activeProviders = FileStorageEngineBase.Instance.Providers
+      .filter(p => p.IsActive)
+      .sort((a, b) => (b.Priority ?? 0) - (a.Priority ?? 0));
+    const provider: MJFileStorageProviderEntity | undefined = activeProviders[0];
     if (typeof provider?.ID === 'string') {
       this.defaultProviderID = provider.ID;
     }

--- a/packages/MJCoreEntities/src/engines/FileStorageEngine.ts
+++ b/packages/MJCoreEntities/src/engines/FileStorageEngine.ts
@@ -122,6 +122,24 @@ export class FileStorageEngineBase extends BaseEngine<FileStorageEngineBase> {
     }
 
     /**
+     * Gets a file storage account by its name (case-insensitive).
+     * @param name - The name of the account to find
+     * @returns The account entity or undefined if not found
+     */
+    public GetAccountByName(name: string): MJFileStorageAccountEntity | undefined {
+        return this.Accounts.find(a => a.Name?.trim().toLowerCase() === name.trim().toLowerCase());
+    }
+
+    /**
+     * Gets file storage accounts linked to a given provider ID.
+     * @param providerId - The provider ID to match against account.ProviderID
+     * @returns Array of matching accounts (may be empty)
+     */
+    public GetAccountsByProviderID(providerId: string): MJFileStorageAccountEntity[] {
+        return this.Accounts.filter(a => UUIDsEqual(a.ProviderID, providerId));
+    }
+
+    /**
      * Gets a storage account with its provider details by account ID
      * @param accountId - The ID of the account to find
      * @returns The account with provider or null if not found or provider is inactive

--- a/packages/MJServer/src/resolvers/ArtifactFileResolver.ts
+++ b/packages/MJServer/src/resolvers/ArtifactFileResolver.ts
@@ -1,6 +1,6 @@
 import { Resolver, Query, Arg, Ctx } from 'type-graphql';
-import { Metadata, RunView, IMetadataProvider } from '@memberjunction/core';
-import { MJArtifactVersionEntity, MJFileEntity, MJFileStorageAccountEntity } from '@memberjunction/core-entities';
+import { Metadata, IMetadataProvider } from '@memberjunction/core';
+import { MJArtifactVersionEntity, MJFileEntity } from '@memberjunction/core-entities';
 import { FileStorageEngine } from '@memberjunction/storage';
 import { ResolverBase } from '../generic/ResolverBase.js';
 import { AppContext } from '../types.js';
@@ -58,21 +58,14 @@ export class ArtifactFileResolver extends ResolverBase {
             throw new Error(`File record ${fileId} not found`);
         }
 
-        // Find the storage account for this file's provider
-        const rv = RunView.FromMetadataProvider(provider);
-        const accountResult = await rv.RunView<MJFileStorageAccountEntity>({
-            EntityName: 'MJ: File Storage Accounts',
-            ExtraFilter: `ProviderID = '${fileEntity.ProviderID}'`,
-            MaxRows: 1,
-            ResultType: 'entity_object',
-        }, user);
-
-        if (!accountResult.Success || accountResult.Results.length === 0) {
+        // Find the storage account for this file's provider using cached metadata
+        await FileStorageEngine.Instance.Config(false, user!);
+        const matchingAccounts = FileStorageEngine.Instance.GetAccountsByProviderID(fileEntity.ProviderID);
+        if (matchingAccounts.length === 0) {
             throw new Error(`No FileStorageAccount found for ProviderID ${fileEntity.ProviderID}. Cannot generate download URL.`);
         }
 
-        await FileStorageEngine.Instance.Config(false, user!);
-        const driver = await FileStorageEngine.Instance.GetDriver(accountResult.Results[0].ID, user!);
+        const driver = await FileStorageEngine.Instance.GetDriver(matchingAccounts[0].ID, user!);
         return driver.CreatePreAuthDownloadUrl(fileEntity.ProviderKey ?? fileEntity.Name);
     }
 }

--- a/packages/MJServer/src/resolvers/FileResolver.ts
+++ b/packages/MJServer/src/resolvers/FileResolver.ts
@@ -1,4 +1,4 @@
-import { EntityPermissionType, Metadata, FieldValueCollection, EntitySaveOptions, RunView } from '@memberjunction/core';
+import { EntityPermissionType, Metadata, FieldValueCollection, EntitySaveOptions } from '@memberjunction/core';
 import { NormalizeUUID } from '@memberjunction/global';
 import { MJFileEntity, MJFileStorageProviderEntity, MJFileStorageAccountEntity } from '@memberjunction/core-entities';
 import {
@@ -723,23 +723,12 @@ export class FileResolver extends FileResolverBase {
     const fileEntity = await md.GetEntityObject<MJFileEntity>('MJ: Files', user);
     fileEntity.CheckPermissions(EntityPermissionType.Read, true);
 
-    // Load all requested account entities in a single query
-    const rv = new RunView();
-    const quotedIDs = input.AccountIDs.map((id) => `'${id}'`).join(', ');
-    const accountResult = await rv.RunView<MJFileStorageAccountEntity>(
-      {
-        EntityName: 'MJ: File Storage Accounts',
-        ExtraFilter: `ID IN (${quotedIDs})`,
-        ResultType: 'entity_object',
-      },
-      user,
-    );
+    // Use cached accounts from the engine — no RunView needed
+    await FileStorageEngine.Instance.Config(false, user);
+    const normalizedIDs = new Set(input.AccountIDs.map((id: string) => NormalizeUUID(id)));
+    const accountEntities = FileStorageEngine.Instance.Accounts
+      .filter(a => normalizedIDs.has(NormalizeUUID(a.ID)));
 
-    if (!accountResult.Success) {
-      throw new Error(`Failed to load storage accounts: ${accountResult.ErrorMessage}`);
-    }
-
-    const accountEntities = accountResult.Results;
     if (accountEntities.length === 0) {
       throw new Error('No valid storage accounts found for the provided IDs');
     }
@@ -751,24 +740,9 @@ export class FileResolver extends FileResolverBase {
       console.warn(`[FileResolver] Accounts not found: ${missingIDs.join(', ')}`);
     }
 
-    // Load providers for all accounts
-    const providerIDs = [...new Set(accountEntities.map((a) => a.ProviderID))];
-    const quotedProviderIDs = providerIDs.map((id) => `'${id}'`).join(', ');
-    const providerResult = await rv.RunView<MJFileStorageProviderEntity>(
-      {
-        EntityName: 'MJ: File Storage Providers',
-        ExtraFilter: `ID IN (${quotedProviderIDs})`,
-        ResultType: 'entity_object',
-      },
-      user,
-    );
-
-    if (!providerResult.Success) {
-      throw new Error(`Failed to load storage providers: ${providerResult.ErrorMessage}`);
-    }
-
+    // Load providers from cached metadata
     const providerMap = new Map<string, MJFileStorageProviderEntity>();
-    for (const provider of providerResult.Results) {
+    for (const provider of FileStorageEngine.Instance.Providers) {
       providerMap.set(provider.ID, provider);
     }
 

--- a/packages/MJStorage/src/FileStorageEngine.ts
+++ b/packages/MJStorage/src/FileStorageEngine.ts
@@ -158,6 +158,16 @@ export class FileStorageEngine extends BaseSingleton<FileStorageEngine> {
         return this.Base.GetProviderById(providerId);
     }
 
+    /** Gets a file storage account by its name (case-insensitive). */
+    public GetAccountByName(name: string): MJFileStorageAccountEntity | undefined {
+        return this.Base.GetAccountByName(name);
+    }
+
+    /** Gets file storage accounts linked to a given provider ID. */
+    public GetAccountsByProviderID(providerId: string): MJFileStorageAccountEntity[] {
+        return this.Base.GetAccountsByProviderID(providerId);
+    }
+
     /** Gets a storage account with its provider details by account ID. */
     public GetAccountWithProvider(accountId: string): StorageAccountWithProvider | null {
         return this.Base.GetAccountWithProvider(accountId);

--- a/packages/SearchEngine/src/generic/StorageSearchProvider.ts
+++ b/packages/SearchEngine/src/generic/StorageSearchProvider.ts
@@ -65,33 +65,22 @@ export class StorageSearchProvider implements ISearchProvider {
      */
     public async CheckAvailability(contextUser: UserInfo): Promise<void> {
         try {
+            // Use cached accounts and providers from the engine — no RunView needed for these
+            await FileStorageEngine.Instance.Config(false, contextUser);
+            const allAccounts = FileStorageEngine.Instance.Accounts;
+            const allProviders = FileStorageEngine.Instance.Providers;
+
+            // Filter to accounts with IncludeInGlobalSearch and active providers that support search
+            const accounts = allAccounts.filter(a => a.Get('IncludeInGlobalSearch') === true);
+            const providers = allProviders.filter(p => p.IsActive && p.Get('SupportsSearch') === true);
+
+            // Permissions are user-context-dependent, so we still need a RunView for these
             const rv = new RunView();
-            const [accountsResult, providersResult, permissionsResult] = await rv.RunViews([
-                {
-                    EntityName: 'MJ: File Storage Accounts',
-                    ExtraFilter: 'IncludeInGlobalSearch = 1',
-                    ResultType: 'entity_object'
-                },
-                {
-                    EntityName: 'MJ: File Storage Providers',
-                    ExtraFilter: 'IsActive = 1 AND SupportsSearch = 1',
-                    ResultType: 'entity_object'
-                },
-                {
-                    EntityName: 'MJ: File Storage Account Permissions',
-                    ExtraFilter: '',
-                    ResultType: 'entity_object'
-                }
-            ], contextUser);
+            const permissionsResult = await rv.RunView<MJFileStorageAccountPermissionEntity>({
+                EntityName: 'MJ: File Storage Account Permissions',
+                ResultType: 'entity_object'
+            }, contextUser);
 
-            if (!accountsResult.Success || !providersResult.Success) {
-                LogError('StorageSearchProvider: Failed to load storage accounts or providers');
-                this._available = false;
-                return;
-            }
-
-            const accounts = accountsResult.Results as MJFileStorageAccountEntity[];
-            const providers = providersResult.Results as MJFileStorageProviderEntity[];
             this._permissions = permissionsResult.Success
                 ? permissionsResult.Results as MJFileStorageAccountPermissionEntity[]
                 : [];


### PR DESCRIPTION
## Summary

Follow-up to PR #2351. Addresses additional review feedback: all hand-written RunView calls for `MJ: File Storage Accounts` and `MJ: File Storage Providers` have been replaced with cached metadata lookups from `FileStorageEngine` / `FileStorageEngineBase`.

This is the "papercut" pattern — ad-hoc database queries for metadata that rarely changes and is already cached in the engine. Every instance across the codebase has been eliminated.

## Changes

### New Lookup Methods on FileStorageEngineBase
- `GetAccountByName(name)` — case-insensitive account lookup by name
- `GetAccountsByProviderID(providerId)` — find accounts linked to a provider

Both delegated through `FileStorageEngine` following the containment pattern.

### Migrated Files (7 consumer files)

| File | Before | After |
|------|--------|-------|
| `base-file-handler.ts` | `loadStorageAccountByName()` — RunView by name + provider entity load | `GetAccountByName()` from engine cache |
| `base-file-handler.ts` | `initializeDriverForFile()` — RunView by ProviderID | `GetAccountsByProviderID()` from engine cache |
| `ConversationAttachmentService.ts` | RunView for accounts by ProviderID | `GetAccountsByProviderID()` from engine cache |
| `ArtifactFileResolver.ts` | RunView for accounts by ProviderID | `GetAccountsByProviderID()` from engine cache |
| `base-file-storage.action.ts` | `getStorageAccount()` + `getStorageProviderById()` — RunView calls | Direct cache lookups via engine |
| `list-storage-providers.action.ts` | RunViews for accounts + providers | `FileStorageEngine.Instance.AccountsWithProviders` |
| `FileResolver.ts` | RunView for accounts by ID list + RunView for providers | Filtered engine cache (`Accounts`, `Providers`) |
| `file-upload.ts` (Angular) | RunView for active providers | `FileStorageEngineBase.Instance.Providers` |

### Additional Cleanup
- Removed redundant `FileStorageEngineBase.Instance.Config()` call in `base-agent.ts` `getStorageAccountID()` — metadata already loaded during engine startup
- Cleaned up unused `RunView`, `Metadata`, `MJFileStorageProviderEntity` imports

### Result
Zero hand-written RunView calls for `MJ: File Storage Accounts` or `MJ: File Storage Providers` remain outside of auto-generated code and the engine's own `Config()`.

## Testing

- **Build**: 188/188 packages pass
- **Live E2E**: Tested agent-level Dropbox vs category-level Box.com — Dropbox correctly selected (agent wins), file uploaded to Dropbox, download URL generated from Dropbox via `ArtifactFileResolver` using cached `GetAccountsByProviderID()`. Full upload + download path verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)