### PR TITLE
UX improvements: Data Explorer deep linking, nav panel ng-tree, dashb…

### DIFF
--- a/.changeset/public-cameras-sneeze.md
+++ b/.changeset/public-cameras-sneeze.md
@@ -1,0 +1,6 @@
+---
+"@memberjunction/ng-dashboards": patch
+"@memberjunction/ng-explorer-core": patch
+---
+
+no migration

--- a/metadata/applications/.data-explorer-application.json
+++ b/metadata/applications/.data-explorer-application.json
@@ -8,13 +8,6 @@
     "Color": "#5c6bc0",
     "DefaultNavItems": [
       {
-        "Label": "Dashboards",
-        "Icon": "fa-solid fa-gauge-high",
-        "ResourceType": "Custom",
-        "DriverClass": "DashboardBrowserResource",
-        "isDefault": false
-      },
-      {
         "Label": "Data",
         "Icon": "fa-solid fa-table-cells",
         "ResourceType": "Custom",
@@ -27,6 +20,13 @@
         "ResourceType": "Custom",
         "DriverClass": "QueryBrowserResource",
         "isDefault": false
+      },
+      {
+        "Label": "Dashboards",
+        "Icon": "fa-solid fa-gauge-high",
+        "ResourceType": "Custom",
+        "DriverClass": "DashboardBrowserResource",
+        "isDefault": false
       }
     ]
   },
@@ -37,7 +37,7 @@
     "ID": "867CB743-50F2-4239-AEE1-97F147C77B8F"
   },
   "sync": {
-    "lastModified": "2026-01-21T05:01:18.819Z",
-    "checksum": "ae9520a3c9d875e35873f3758f9f2b53ce26002f0b90e8380755bbf970127ccc"
+    "lastModified": "2026-04-12T22:53:51.800Z",
+    "checksum": "88c113aade5b68f3334f7c90821b60b5e085c0a605dd818680c3e1432d779ea2"
   }
 }

--- a/packages/Angular/Explorer/dashboards/src/AI/components/vectors/vector-management-resource.component.css
+++ b/packages/Angular/Explorer/dashboards/src/AI/components/vectors/vector-management-resource.component.css
@@ -548,7 +548,7 @@
     position: fixed;
     inset: 0;
     background: var(--mj-bg-overlay);
-    z-index: 1000;
+    z-index: 100000;
 }
 
 .slide-panel {
@@ -823,6 +823,12 @@
 
 .entity-picker-item-selected i {
     color: var(--mj-brand-primary);
+}
+
+.entity-picker-item-focused {
+    background: var(--mj-bg-surface-hover);
+    outline: 2px solid var(--mj-brand-primary);
+    outline-offset: -2px;
 }
 
 .entity-picker-empty {

--- a/packages/Angular/Explorer/dashboards/src/AI/components/vectors/vector-management-resource.component.html
+++ b/packages/Angular/Explorer/dashboards/src/AI/components/vectors/vector-management-resource.component.html
@@ -400,12 +400,13 @@
                     <div class="entity-picker-dropdown">
                       <div class="entity-picker-search">
                         <i class="fa-solid fa-search"></i>
-                        <input type="text"
+                        <input #entitySearchInput
+                               type="text"
                                class="entity-picker-search-input"
                                placeholder="Filter entities..."
                                [(ngModel)]="EntitySearchText"
                                (input)="FilterEntities()"
-                               autofocus />
+                               (keydown)="OnEntityPickerKeyDown($event)" />
                       </div>
                       <div class="entity-picker-list">
                         @for (group of FilteredEntityGroups; track group.SchemaName) {
@@ -417,6 +418,7 @@
                             @for (entity of group.Entities; track entity.ID) {
                               <button class="entity-picker-item"
                                       [class.entity-picker-item-selected]="entity.Name === SuggestEntityName"
+                                      [class.entity-picker-item-focused]="FlatFilteredEntities[SelectedEntityIndex]?.ID === entity.ID"
                                       (click)="SelectEntity(entity.Name)">
                                 <i class="fa-solid fa-table"></i>
                                 {{ entity.Name }}

--- a/packages/Angular/Explorer/dashboards/src/AI/components/vectors/vector-management-resource.component.ts
+++ b/packages/Angular/Explorer/dashboards/src/AI/components/vectors/vector-management-resource.component.ts
@@ -7,7 +7,7 @@
  * and storage usage.
  */
 
-import { Component, ChangeDetectorRef, OnDestroy, AfterViewInit, Input, inject } from '@angular/core';
+import { Component, ChangeDetectorRef, OnDestroy, AfterViewInit, Input, ViewChild, ElementRef, inject } from '@angular/core';
 import { Subject } from 'rxjs';
 import { takeUntil } from 'rxjs/operators';
 import { EntityInfo, Metadata, RunView } from '@memberjunction/core';
@@ -475,6 +475,8 @@ export class VectorManagementResourceComponent extends BaseResourceComponent imp
     public EntitySearchText = '';
     /** Whether the entity picker dropdown is open */
     public ShowEntityPicker = false;
+    public SelectedEntityIndex = -1;
+    @ViewChild('entitySearchInput') entitySearchInput?: ElementRef<HTMLInputElement>;
 
     // --- Raw entity data (private) ---
     private entityDocuments: MJEntityDocumentEntity[] = [];
@@ -760,7 +762,62 @@ export class VectorManagementResourceComponent extends BaseResourceComponent imp
                 }))
                 .filter(group => group.Entities.length > 0);
         }
+        // Reset selection to first item when filter changes
+        this.SelectedEntityIndex = this.FlatFilteredEntities.length > 0 ? 0 : -1;
         this.cdr.detectChanges();
+    }
+
+    /**
+     * Get a flat list of all entities across groups (for keyboard navigation indexing)
+     */
+    get FlatFilteredEntities(): { Name: string; ID: string }[] {
+        return this.FilteredEntityGroups.flatMap(g => g.Entities);
+    }
+
+    /**
+     * Handle keyboard events in the entity picker search input
+     */
+    public OnEntityPickerKeyDown(event: KeyboardEvent): void {
+        const entities = this.FlatFilteredEntities;
+        if (entities.length === 0) return;
+
+        switch (event.key) {
+            case 'ArrowDown':
+                event.preventDefault();
+                this.SelectedEntityIndex = Math.min(this.SelectedEntityIndex + 1, entities.length - 1);
+                this.scrollSelectedEntityIntoView();
+                this.cdr.detectChanges();
+                break;
+            case 'ArrowUp':
+                event.preventDefault();
+                this.SelectedEntityIndex = Math.max(this.SelectedEntityIndex - 1, 0);
+                this.scrollSelectedEntityIntoView();
+                this.cdr.detectChanges();
+                break;
+            case 'Enter':
+                event.preventDefault();
+                if (this.SelectedEntityIndex >= 0 && this.SelectedEntityIndex < entities.length) {
+                    this.SelectEntity(entities[this.SelectedEntityIndex].Name);
+                }
+                break;
+            case 'Escape':
+                event.preventDefault();
+                this.ShowEntityPicker = false;
+                this.cdr.detectChanges();
+                break;
+        }
+    }
+
+    /**
+     * Scroll the currently selected entity picker item into view
+     */
+    private scrollSelectedEntityIntoView(): void {
+        setTimeout(() => {
+            const selected = document.querySelector('.entity-picker-item-focused');
+            if (selected) {
+                selected.scrollIntoView({ block: 'nearest', behavior: 'smooth' });
+            }
+        }, 0);
     }
 
     /** Toggle entity picker visibility */
@@ -769,8 +826,16 @@ export class VectorManagementResourceComponent extends BaseResourceComponent imp
         if (this.ShowEntityPicker) {
             this.FilteredEntityGroups = this.EntityGroups;
             this.EntitySearchText = '';
+            this.cdr.detectChanges();
+            // Focus search input after the @if block renders — deferred past the click event
+            setTimeout(() => {
+                if (this.entitySearchInput?.nativeElement) {
+                    this.entitySearchInput.nativeElement.focus();
+                }
+            }, 0);
+        } else {
+            this.cdr.detectChanges();
         }
-        this.cdr.detectChanges();
     }
 
     /** Handle template edits from code editor */

--- a/packages/Angular/Explorer/dashboards/src/DataExplorer/components/navigation-panel/navigation-panel.component.css
+++ b/packages/Angular/Explorer/dashboards/src/DataExplorer/components/navigation-panel/navigation-panel.component.css
@@ -179,6 +179,20 @@
   overflow: hidden;
 }
 
+.entity-tree-container {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
+  overflow: hidden;
+}
+
+.entity-tree-container mj-tree {
+  flex: 1;
+  min-height: 0;
+  overflow-y: auto;
+}
+
 .empty-section {
   padding: 20px 16px;
   text-align: center;

--- a/packages/Angular/Explorer/dashboards/src/DataExplorer/components/navigation-panel/navigation-panel.component.html
+++ b/packages/Angular/Explorer/dashboards/src/DataExplorer/components/navigation-panel/navigation-panel.component.html
@@ -81,7 +81,7 @@
         }
       </div>
 
-      <!-- Entities Section -->
+      <!-- Entities Section (ng-tree) -->
       <div class="section entities-section">
         <div class="section-header" (click)="onSectionToggle('entities')">
           <i class="fa-solid fa-database section-icon"></i>
@@ -91,7 +91,7 @@
         </div>
 
         @if (entitiesSectionExpanded) {
-          <div class="section-content">
+          <div class="section-content entity-tree-container">
             <!-- Entity Search -->
             <div class="entity-search">
               <i class="fa-solid fa-search search-icon"></i>
@@ -100,66 +100,30 @@
                 class="search-input"
                 placeholder="Search entities..."
                 [(ngModel)]="entitySearchTerm"
+                (ngModelChange)="onEntitySearchChanged()"
               />
               @if (entitySearchTerm) {
-                <button class="clear-search" (click)="entitySearchTerm = ''">
+                <button class="clear-search" (click)="clearEntitySearch()">
                   <i class="fa-solid fa-times"></i>
                 </button>
               }
             </div>
 
-            <!-- Entity List (scrollable container) -->
-            <div class="entity-list">
-              <div class="entity-list-inner">
-                @if (hasAppGroups) {
-                  <!-- Grouped by application -->
-                  @for (group of filteredNavGroups; track group.applicationId) {
-                    <div class="nav-app-group">
-                      <div class="nav-app-group-header" (click)="onNavGroupToggle(group.applicationId)">
-                        <i [class]="group.applicationIcon || 'fa-solid fa-folder'" class="nav-app-group-icon"
-                           [style.color]="group.applicationColor || null"></i>
-                        <span class="nav-app-group-name">{{ group.applicationName }}</span>
-                        <span class="nav-app-group-count">{{ group.entities.length }}</span>
-                        <i class="fa-solid fa-chevron-right nav-app-group-chevron"
-                           [class.expanded]="isNavGroupExpanded(group.applicationId)"></i>
-                      </div>
-                      @if (isNavGroupExpanded(group.applicationId)) {
-                        <div class="nav-app-group-entities">
-                          @for (entity of group.entities; track entity.ID) {
-                            <div
-                              class="nav-item entity-item"
-                              [class.selected]="isEntitySelected(entity)"
-                              (click)="onEntityClick(entity)"
-                              [title]="entity.Description || entity.DisplayNameOrName">
-                              <i [class]="getEntityIcon(entity)"></i>
-                              <span class="nav-item-label">{{ entity.DisplayNameOrName }}</span>
-                            </div>
-                          }
-                        </div>
-                      }
-                    </div>
-                  }
-                } @else {
-                  <!-- Flat list (no groups available) -->
-                  @for (entity of filteredEntities; track entity.ID) {
-                    <div
-                      class="nav-item entity-item"
-                      [class.selected]="isEntitySelected(entity)"
-                      (click)="onEntityClick(entity)"
-                      [title]="entity.Description || entity.DisplayNameOrName">
-                      <i [class]="getEntityIcon(entity)"></i>
-                      <span class="nav-item-label">{{ entity.DisplayNameOrName }}</span>
-                    </div>
-                  }
-                }
-
-                @if (filteredEntities.length === 0 && entitySearchTerm) {
-                  <div class="empty-section">
-                    <span>No entities match "{{ entitySearchTerm }}"</span>
-                  </div>
-                }
-              </div>
-            </div>
+            <!-- Entity Tree -->
+            <mj-tree
+              #entityTree
+              [BranchConfig]="treeBranchConfig"
+              [LeafConfig]="treeLeafConfig"
+              [SelectionMode]="'single'"
+              [SelectableTypes]="'leaf'"
+              [SelectedIDs]="selectedEntityIds"
+              [ShowIcons]="true"
+              [ShowExpandCollapseAll]="false"
+              [AnimateExpandCollapse]="true"
+              [EmptyMessage]="entitySearchTerm ? 'No matches for: ' + entitySearchTerm : 'No entities available'"
+              [EmptyIcon]="'fa-solid fa-database'"
+              (SelectionChange)="onTreeEntitySelected($event)">
+            </mj-tree>
           </div>
         }
       </div>

--- a/packages/Angular/Explorer/dashboards/src/DataExplorer/components/navigation-panel/navigation-panel.component.ts
+++ b/packages/Angular/Explorer/dashboards/src/DataExplorer/components/navigation-panel/navigation-panel.component.ts
@@ -1,5 +1,6 @@
-import { Component, Input, Output, EventEmitter } from '@angular/core';
+import { Component, Input, Output, EventEmitter, OnChanges, SimpleChanges, ViewChild } from '@angular/core';
 import { EntityInfo, Metadata, CompositeKey } from '@memberjunction/core';
+import { TreeBranchConfig, TreeLeafConfig, TreeNode, TreeComponent } from '@memberjunction/ng-trees';
 import { RecentItem, FavoriteItem, AppEntityGroup } from '../../models/explorer-state.interface';
 
 /**
@@ -24,7 +25,7 @@ export interface SelectRecordEvent {
   templateUrl: './navigation-panel.component.html',
   styleUrls: ['./navigation-panel.component.css']
 })
-export class NavigationPanelComponent {
+export class NavigationPanelComponent implements OnChanges {
   @Input() entities: EntityInfo[] = [];
   @Input() selectedEntityName: string | null = null;
   @Input() favorites: FavoriteItem[] = [];
@@ -37,6 +38,8 @@ export class NavigationPanelComponent {
   @Input() allowedEntityNames: Set<string> | null = null;
   /** Application-based entity groups from the parent dashboard */
   @Input() appEntityGroups: AppEntityGroup[] = [];
+  /** Optional application ID filter for the tree */
+  @Input() applicationIdFilter: string | null = null;
 
   // Section expansion states
   @Input() favoritesSectionExpanded = true;
@@ -57,71 +60,111 @@ export class NavigationPanelComponent {
 
   private metadata = new Metadata();
 
-  // Entity search/filter
+  // Tree configuration for entity list
+  public treeBranchConfig: TreeBranchConfig = {
+    EntityName: 'MJ: Applications',
+    DisplayField: 'Name',
+    IDField: 'ID',
+    IconField: 'Icon',
+    OrderBy: 'Name'
+  };
+
+  public treeLeafConfig: TreeLeafConfig = {
+    EntityName: 'MJ: Entities',
+    ParentField: '', // Using JunctionConfig for M2M relationship
+    DisplayField: 'Name',
+    IDField: 'ID',
+    IconField: 'Icon',
+    JunctionConfig: {
+      EntityName: 'MJ: Application Entities',
+      BranchForeignKey: 'ApplicationID',
+      LeafForeignKey: 'EntityID'
+    },
+    OrderBy: 'Name'
+  };
+
+  @ViewChild('entityTree') entityTree?: TreeComponent;
+
+  /** Selected entity ID for tree highlighting */
+  public selectedEntityIds: string[] = [];
+
+  /** Search term for filtering the entity tree */
   public entitySearchTerm = '';
-  // Local expand state for nav panel groups (independent of home view state)
-  private navGroupExpanded = new Map<string, boolean>();
 
-  /**
-   * Whether to show grouped entity view (when groups are available)
-   */
-  get hasAppGroups(): boolean {
-    return this.appEntityGroups.length > 0;
-  }
-
-  /**
-   * Get filtered entities based on search term (used in flat/ungrouped mode)
-   */
-  get filteredEntities(): EntityInfo[] {
-    if (!this.entitySearchTerm) {
-      return this.entities;
+  ngOnChanges(changes: SimpleChanges): void {
+    if (changes['selectedEntityName']) {
+      this.updateSelectedEntityKey();
     }
-    const term = this.entitySearchTerm.toLowerCase();
-    return this.entities.filter(e =>
-      e.Name.toLowerCase().includes(term) ||
-      (e.Description && e.Description.toLowerCase().includes(term))
-    );
-  }
-
-  /**
-   * Get app entity groups filtered by search term
-   * Auto-expands groups when searching to show matches
-   */
-  get filteredNavGroups(): AppEntityGroup[] {
-    if (!this.entitySearchTerm) {
-      return this.appEntityGroups.filter(g => g.entities.length > 0);
+    if (changes['applicationIdFilter']) {
+      this.updateTreeBranchFilter();
     }
-    const term = this.entitySearchTerm.toLowerCase();
-    return this.appEntityGroups
-      .map(g => ({
-        ...g,
-        entities: g.entities.filter(e =>
-          e.Name.toLowerCase().includes(term) ||
-          (e.Description && e.Description.toLowerCase().includes(term))
-        ),
-        isExpanded: true // auto-expand when searching
-      }))
-      .filter(g => g.entities.length > 0);
   }
 
   /**
-   * Check if a nav panel group is expanded
+   * Update the selected entity IDs for tree highlighting when selected entity changes
    */
-  isNavGroupExpanded(groupId: string): boolean {
-    if (this.entitySearchTerm) return true; // auto-expand during search
-    const localState = this.navGroupExpanded.get(groupId);
-    if (localState !== undefined) return localState;
-    // Default: first group expanded, others collapsed
-    const idx = this.appEntityGroups.findIndex(g => g.applicationId === groupId);
-    return idx === 0;
+  private updateSelectedEntityKey(): void {
+    if (this.selectedEntityName) {
+      const entity = this.metadata.Entities.find(e => e.Name === this.selectedEntityName);
+      if (entity) {
+        this.selectedEntityIds = [entity.ID];
+        return;
+      }
+    }
+    this.selectedEntityIds = [];
   }
 
   /**
-   * Toggle a nav panel group expand/collapse
+   * Update the tree's branch filter when application filter changes
    */
-  onNavGroupToggle(groupId: string): void {
-    const current = this.isNavGroupExpanded(groupId);
-    this.navGroupExpanded.set(groupId, !current);
+  private updateTreeBranchFilter(): void {
+    if (this.applicationIdFilter) {
+      this.treeBranchConfig = {
+        ...this.treeBranchConfig,
+        ExtraFilter: `ID='${this.applicationIdFilter}'`
+      };
+    } else {
+      this.treeBranchConfig = {
+        ...this.treeBranchConfig,
+        ExtraFilter: undefined
+      };
+    }
+  }
+
+  /**
+   * Filter the entity tree when search term changes
+   */
+  onEntitySearchChanged(): void {
+    if (this.entityTree) {
+      this.entityTree.FilterNodes(this.entitySearchTerm, {
+        searchBranches: true,
+        searchLeaves: true,
+        caseSensitive: false
+      });
+    }
+  }
+
+  /**
+   * Clear the entity search
+   */
+  clearEntitySearch(): void {
+    this.entitySearchTerm = '';
+    this.onEntitySearchChanged();
+  }
+
+  /**
+   * Handle tree selection change - map TreeNode to EntityInfo and emit
+   */
+  onTreeEntitySelected(nodes: TreeNode[]): void {
+    if (!nodes || nodes.length === 0) return;
+    const node = nodes[0];
+    if (node.Type !== 'leaf') return;
+
+    // Find the EntityInfo by ID from the node
+    const entity = this.metadata.Entities.find(e => e.ID === node.ID);
+    if (entity) {
+      this.entitySelected.emit(entity);
+    }
   }
 
   /**

--- a/packages/Angular/Explorer/dashboards/src/DataExplorer/data-explorer-dashboard.component.ts
+++ b/packages/Angular/Explorer/dashboards/src/DataExplorer/data-explorer-dashboard.component.ts
@@ -32,7 +32,7 @@ import {
 } from '@memberjunction/ng-entity-viewer';
 import { ViewSelectedEvent, SaveViewRequestedEvent, ViewSelectorComponent } from './components/view-selector/view-selector.component';
 import { CompositeFilterDescriptor, FilterFieldInfo, createEmptyFilter } from '@memberjunction/ng-filter-builder';
-import { MJUserViewEntityExtended } from '@memberjunction/core-entities';
+import { MJUserViewEntityExtended, UserViewEngine } from '@memberjunction/core-entities';
 import { ExplorerStateService } from './services/explorer-state.service';
 import { DataExplorerState, DataExplorerFilter, BreadcrumbItem, DataExplorerDeepLink, DataExplorerViewMode, RecentRecordAccess, FavoriteRecord, AppEntityGroup } from './models/explorer-state.interface';
 import { MapRenderMode } from '@memberjunction/ng-map-view';
@@ -113,6 +113,13 @@ export class DataExplorerDashboardComponent extends BaseDashboard implements OnI
    * Use this alongside contextName for a fully customized header (e.g., "fa-solid fa-users" for CRM).
    */
   @Input() contextIcon: string | null = null;
+
+  /**
+   * Initial query params forwarded from the resource wrapper.
+   * On hard refresh, the shell delivers params to the wrapper (which has Data.Configuration.queryParams),
+   * not to this inner dashboard component. This input bridges that gap.
+   */
+  @Input() initialQueryParams: Record<string, string> = {};
 
   /**
    * Emitted when the display title should change (entity selected, record opened, etc.)
@@ -580,9 +587,16 @@ export class DataExplorerDashboardComponent extends BaseDashboard implements OnI
     // before the user settings have been loaded from the server
     await UserInfoEngine.Instance.Config(false);
 
-    // Read initial query params from the framework - URL wins over persisted state
-    // This must happen before loading entities to prevent race conditions
-    const rawParams = this.GetQueryParams();
+    // Read initial query params — prefer params forwarded from the resource wrapper
+    // (which has Data.Configuration.queryParams from the shell), then fall back to
+    // this component's own GetQueryParams() for cases where the dashboard is used standalone.
+    const wrapperParams = this.initialQueryParams && Object.keys(this.initialQueryParams).length > 0
+      ? this.initialQueryParams
+      : null;
+    const ownParams = this.GetQueryParams();
+    const rawParams = wrapperParams || (Object.keys(ownParams).length > 0 ? ownParams : {});
+    console.log('[DataExplorer] initDashboard: wrapperParams=', JSON.stringify(wrapperParams), 'ownParams=', JSON.stringify(ownParams), 'using=', JSON.stringify(rawParams));
+
     const urlState = this.buildDeepLinkFromParams(rawParams);
 
     // Set context for state service (enables context-specific settings)
@@ -599,11 +613,14 @@ export class DataExplorerDashboardComponent extends BaseDashboard implements OnI
 
     // Apply URL state after entities are loaded
     if (urlState) {
+      console.log('[DataExplorer] initDashboard: applying URL state (init path)');
       // URL has state - apply it (overrides persisted state)
-      this.applyUrlState(urlState);
+      await this.applyUrlState(urlState);
     } else if (this.deepLink) {
-      // No URL state but @Input deepLink provided - use that
+      console.log('[DataExplorer] initDashboard: no URL state, using @Input deepLink');
       await this.applyDeepLink(this.deepLink);
+    } else {
+      console.log('[DataExplorer] initDashboard: no URL state and no deepLink — using persisted state');
     }
 
     // Subscribe to state changes
@@ -613,6 +630,20 @@ export class DataExplorerDashboardComponent extends BaseDashboard implements OnI
         const entityChanged = state.selectedEntityName !== this.state.selectedEntityName;
 
         this.state = state;
+
+        // Self-correct map mode: if a URL-sourced mode is pending and state
+        // has diverged (e.g., reset to 'point' by some init step), re-apply it.
+        if (this._pendingMapMode && state.mapRenderMode !== this._pendingMapMode) {
+          const mode = this._pendingMapMode;
+          this._pendingMapMode = null; // Clear first to prevent infinite loop
+          console.log('[DataExplorer] state subscription: re-applying pending map mode:', mode, '(state had:', state.mapRenderMode, ')');
+          this.stateService.updateState({ mapRenderMode: mode });
+          return; // Let the next subscription fire handle the rest
+        }
+        // Clear pending once state matches
+        if (this._pendingMapMode && state.mapRenderMode === this._pendingMapMode) {
+          this._pendingMapMode = null;
+        }
 
         // When entity changes, clear user search text and update title
         if (entityChanged) {
@@ -1791,10 +1822,14 @@ export class DataExplorerDashboardComponent extends BaseDashboard implements OnI
    * Get the current map display state for passing to the EntityViewer/MapView.
    */
   get mapDisplayState(): { RenderMode: MapRenderMode; ZoomLevel: number; CenterLat: number; CenterLng: number } | null {
-    if (this.state.mapZoom == null) return null;
+    // Always return state when a non-default render mode is set (even without saved zoom/center),
+    // so the map component respects the URL's mapMode parameter on cold loads.
+    if (this.state.mapZoom == null && (!this.state.mapRenderMode || this.state.mapRenderMode === 'point')) {
+      return null;
+    }
     return {
       RenderMode: this.state.mapRenderMode || 'point',
-      ZoomLevel: this.state.mapZoom,
+      ZoomLevel: this.state.mapZoom ?? 2,
       CenterLat: this.state.mapCenterLat ?? 20,
       CenterLng: this.state.mapCenterLng ?? 0
     };
@@ -1805,8 +1840,18 @@ export class DataExplorerDashboardComponent extends BaseDashboard implements OnI
    * Persists zoom, center, and render mode across page reloads.
    */
   public onMapDisplayStateChange(state: { RenderMode?: MapRenderMode; ZoomLevel?: number; CenterLat?: number; CenterLng?: number }): void {
+    const incomingMode = state.RenderMode || 'point';
+
+    // If a pending URL map mode exists and the map is emitting its default 'point',
+    // use the pending mode instead. Otherwise accept the incoming mode (user-initiated).
+    const newRenderMode = (this._pendingMapMode && incomingMode === 'point' && this._pendingMapMode !== 'point')
+      ? this._pendingMapMode
+      : incomingMode;
+
+    console.log('[DataExplorer] onMapDisplayStateChange: incoming=', incomingMode, 'pending=', this._pendingMapMode, 'final=', newRenderMode);
+
     this.stateService.updateState({
-      mapRenderMode: state.RenderMode || 'point',
+      mapRenderMode: newRenderMode,
       mapZoom: state.ZoomLevel ?? null,
       mapCenterLat: state.CenterLat ?? null,
       mapCenterLng: state.CenterLng ?? null
@@ -2391,6 +2436,13 @@ export class DataExplorerDashboardComponent extends BaseDashboard implements OnI
   /** Record ID to select once data loads (from deep link) */
   private pendingRecordSelection: string | null = null;
 
+  /**
+   * Pending map mode from URL that must survive initialization state resets.
+   * Set during applyUrlState, cleared once state matches or after first successful re-apply.
+   * The state subscription self-corrects: any time state diverges from this value, it re-applies.
+   */
+  private _pendingMapMode: MapRenderMode | null = null;
+
   // ========================================
   // BREADCRUMB NAVIGATION
   // ========================================
@@ -2485,8 +2537,13 @@ export class DataExplorerDashboardComponent extends BaseDashboard implements OnI
     const record = params['record'] || null;
     const filterParam = params['filter'] || null;
     const view = (params['view'] as DataExplorerViewMode) || null;
+    const viewId = params['viewId'] || null;
+    const mapMode = params['mapMode'] || null;
 
-    if (!entity && !record && !filterParam && !view) {
+    console.log('[DataExplorer] buildDeepLinkFromParams:', { entity, record, filter: filterParam, view, viewId, mapMode });
+
+    if (!entity && !record && !filterParam && !view && !viewId && !mapMode) {
+      console.log('[DataExplorer] buildDeepLinkFromParams: all params empty, returning null');
       return null;
     }
 
@@ -2494,7 +2551,9 @@ export class DataExplorerDashboardComponent extends BaseDashboard implements OnI
       entity: entity || undefined,
       record: record || undefined,
       filter: filterParam || undefined,
-      viewMode: view || undefined
+      viewMode: view || undefined,
+      viewId: viewId || undefined,
+      mapMode: mapMode || undefined
     };
   }
 
@@ -2503,16 +2562,26 @@ export class DataExplorerDashboardComponent extends BaseDashboard implements OnI
    * The base class calls this when query params change via popstate or deeplink.
    */
   protected override OnQueryParamsChanged(params: Record<string, string>, _source: 'popstate' | 'deeplink'): void {
+    console.log('[DataExplorer] OnQueryParamsChanged: source=', _source, 'params=', JSON.stringify(params));
+    this.applyParams(params);
+  }
+
+  /**
+   * Public entry point for the resource wrapper to forward query param changes.
+   * The wrapper receives OnQueryParamsChanged from the framework and delegates here.
+   */
+  public HandleQueryParamsChanged(params: Record<string, string>, source: 'popstate' | 'deeplink'): void {
+    console.log('[DataExplorer] HandleQueryParamsChanged (from wrapper): source=', source, 'params=', JSON.stringify(params));
     this.applyParams(params);
   }
 
   /**
    * Apply a params map (from framework query params) to the component state.
    */
-  private applyParams(params: Record<string, string>): void {
+  private async applyParams(params: Record<string, string>): Promise<void> {
     const deepLink = this.buildDeepLinkFromParams(params);
     if (deepLink) {
-      this.applyUrlState(deepLink);
+      await this.applyUrlState(deepLink);
     } else {
       // No params — go to home view
       this.selectedEntity = null;
@@ -2529,12 +2598,19 @@ export class DataExplorerDashboardComponent extends BaseDashboard implements OnI
    * Called whenever state changes so users can bookmark/share URLs.
    */
   private pushCurrentStateToUrl(): void {
+    const hasEntity = !!this.state.selectedEntityName;
+    const hasViewId = !!(this.state.selectedViewId && hasEntity);
+
     const queryParams: Record<string, string | null> = {
       entity: this.state.selectedEntityName || null,
-      record: (this.state.selectedRecordId && this.state.selectedEntityName) ? this.state.selectedRecordId : null,
-      filter: (this.state.smartFilterPrompt && this.state.selectedEntityName) ? this.state.smartFilterPrompt : null,
-      view: (this.state.viewMode && this.state.viewMode !== 'grid') ? this.state.viewMode : null
+      record: (this.state.selectedRecordId && hasEntity) ? this.state.selectedRecordId : null,
+      filter: null, // Never in URL — filters live in saved views (DB), not query strings
+      view: (this.state.viewMode && this.state.viewMode !== 'grid') ? this.state.viewMode : null,
+      viewId: hasViewId ? this.state.selectedViewId : null,
+      mapMode: this.state.viewMode === 'map' ? (this.state.mapRenderMode || 'point') : null
     };
+
+    console.log('[DataExplorer] pushCurrentStateToUrl:', JSON.stringify(queryParams), 'hasViewId=', hasViewId, 'smartFilterPrompt=', this.state.smartFilterPrompt);
 
     this.UpdateQueryParams(queryParams);
   }
@@ -2543,10 +2619,23 @@ export class DataExplorerDashboardComponent extends BaseDashboard implements OnI
    * Apply URL state to the component.
    * Used both during init and for popstate handling.
    */
-  private applyUrlState(urlState: DataExplorerDeepLink): void {
-    // Apply view mode if specified
+  private async applyUrlState(urlState: DataExplorerDeepLink): Promise<void> {
+    console.log('[DataExplorer] applyUrlState:', urlState);
+
+    // Store URL-sourced map mode BEFORE switching to map view — various init steps
+    // can reset mapRenderMode to 'point'. The state subscription self-corrects using this.
+    if (urlState.mapMode && ['point', 'choropleth', 'heatmap'].includes(urlState.mapMode)) {
+      this._pendingMapMode = urlState.mapMode as MapRenderMode;
+    }
+
+    // Apply view mode (may trigger map component creation if switching to 'map')
     if (urlState.viewMode) {
       this.stateService.setViewMode(urlState.viewMode);
+    }
+
+    // Apply map render mode to state
+    if (this._pendingMapMode) {
+      this.stateService.updateState({ mapRenderMode: this._pendingMapMode });
     }
 
     // Navigate to entity if specified
@@ -2565,11 +2654,19 @@ export class DataExplorerDashboardComponent extends BaseDashboard implements OnI
           this.stateService.selectEntity(entity.Name);
         }
 
-        // Apply filter if specified (to smart filter state, not user search)
-        if (urlState.filter) {
-          this.stateService.setSmartFilterPrompt(urlState.filter);
-        } else if (entityChanged) {
-          // Only clear filter if entity changed (selectEntity already handles this)
+        // Restore saved view by ID if specified
+        if (urlState.viewId) {
+          await this.restoreViewFromUrl(urlState.viewId, entity);
+        } else {
+          // No specific view — clear view selection to use default
+          this.selectedViewEntity = null;
+          this.stateService.selectView(null);
+          this.currentGridState = this.loadUserDefaultGridState();
+        }
+
+        // Filters live in saved views (DB), never in URL query strings.
+        // Clear smart filter on entity change when no specific view is selected.
+        if (entityChanged && !urlState.viewId) {
           this.stateService.setSmartFilterPrompt('');
         }
         // User search text is always cleared when applying URL state
@@ -2614,6 +2711,43 @@ export class DataExplorerDashboardComponent extends BaseDashboard implements OnI
       this.detailPanelEntity = null;
       this.stateService.selectEntity(null);
       this.stateService.closeDetailPanel();
+    }
+
+    this.cdr.detectChanges();
+  }
+
+  /**
+   * Restore a saved view from the URL's viewId parameter.
+   * Looks up the view by ID, sets it as selected, and applies its grid state and filters.
+   * Must be async because UserViewEngine's cache may not be populated yet on cold page loads.
+   */
+  private async restoreViewFromUrl(viewId: string, entity: EntityInfo): Promise<void> {
+    console.log('[DataExplorer] restoreViewFromUrl: viewId=', viewId, 'entity=', entity.Name);
+
+    // Ensure the view engine cache is populated before querying —
+    // on hard refresh, the cache may be empty and GetAccessibleViewsForEntity returns []
+    await UserViewEngine.Instance.Config(false);
+
+    const accessibleViews = UserViewEngine.Instance.GetAccessibleViewsForEntity(entity.ID);
+    console.log('[DataExplorer] restoreViewFromUrl: accessible views count=', accessibleViews.length);
+
+    const view = accessibleViews.find(v => v.ID === viewId) || null;
+
+    if (view) {
+      console.log('[DataExplorer] restoreViewFromUrl: found view:', view.Name, 'WhereClause:', view.WhereClause, 'SmartFilter:', view.SmartFilterPrompt);
+      this.selectedViewEntity = view;
+      this.stateService.selectView(viewId);
+      this.currentGridState = this.parseViewGridState(view);
+
+      // Apply the view's smart filter if it has one
+      if (view.SmartFilterEnabled && view.SmartFilterPrompt) {
+        this.stateService.setSmartFilterPrompt(view.SmartFilterPrompt);
+      }
+    } else {
+      console.warn('[DataExplorer] restoreViewFromUrl: view NOT FOUND, falling back to default. viewId=', viewId);
+      this.selectedViewEntity = null;
+      this.stateService.selectView(null);
+      this.currentGridState = this.loadUserDefaultGridState();
     }
 
     this.cdr.detectChanges();

--- a/packages/Angular/Explorer/dashboards/src/DataExplorer/data-explorer-resource.component.ts
+++ b/packages/Angular/Explorer/dashboards/src/DataExplorer/data-explorer-resource.component.ts
@@ -22,6 +22,7 @@ import { DataExplorerFilter } from './models/explorer-state.interface';
                 [entityFilter]="entityFilter"
                 [contextName]="contextName"
                 [contextIcon]="contextIcon"
+                [initialQueryParams]="initialQueryParams"
                 (OpenEntityRecord)="onOpenEntityRecord($event)"
                 (DisplayNameChanged)="onDisplayNameChanged($event)">
             </mj-data-explorer-dashboard>
@@ -48,6 +49,8 @@ export class DataExplorerResourceComponent extends BaseResourceComponent impleme
     public entityFilter: DataExplorerFilter | null = null;
     public contextName: string | null = null;
     public contextIcon: string | null = null;
+    /** Initial query params from the URL, forwarded to the dashboard */
+    public initialQueryParams: Record<string, string> = {};
 
     @ViewChild(DataExplorerDashboardComponent) dataExplorer!: DataExplorerDashboardComponent;
 
@@ -93,6 +96,17 @@ export class DataExplorerResourceComponent extends BaseResourceComponent impleme
         // Configuration loaded via Data setter
     }
 
+    /**
+     * Forward query param changes from the framework to the inner dashboard.
+     * The shell delivers params here (on the resource wrapper), but the dashboard
+     * needs them for deep linking (entity, viewId, filter, view mode, map mode).
+     */
+    protected override OnQueryParamsChanged(params: Record<string, string>, source: 'popstate' | 'deeplink'): void {
+        if (this.dataExplorer) {
+            this.dataExplorer.HandleQueryParamsChanged(params, source);
+        }
+    }
+
     ngOnDestroy(): void {
         super.ngOnDestroy();
         this._destroy$.next();
@@ -128,6 +142,18 @@ export class DataExplorerResourceComponent extends BaseResourceComponent impleme
         this.entityFilter = config['entityFilter'] as DataExplorerFilter || null;
         this.contextName = config['appName'] as string || null;
         this.contextIcon = config['appIcon'] as string || null;
+
+        // Build initial query params: start with workspace-saved params, then let
+        // browser URL params override. The URL is the source of truth for user intent —
+        // if the user navigates to a URL with specific params, those should take priority
+        // over potentially stale workspace state from a prior session.
+        const workspaceParams = (config['queryParams'] as Record<string, string>) || {};
+        const browserParams = new URLSearchParams(window.location.search);
+        const merged = { ...workspaceParams };
+        browserParams.forEach((value, key) => {
+            merged[key] = value;
+        });
+        this.initialQueryParams = merged;
 
         this.cdr.detectChanges();
 

--- a/packages/Angular/Explorer/dashboards/src/DataExplorer/models/explorer-state.interface.ts
+++ b/packages/Angular/Explorer/dashboards/src/DataExplorer/models/explorer-state.interface.ts
@@ -69,10 +69,14 @@ export interface DataExplorerDeepLink {
   entity?: string;
   /** Record ID or composite key string to select */
   record?: string;
-  /** Filter text to apply */
+  /** Filter text to apply (omitted when viewId is present — view carries its own filter) */
   filter?: string;
-  /** View mode to use */
+  /** View mode to use (grid/cards/timeline/map) */
   viewMode?: DataExplorerViewMode;
+  /** Saved view ID to load (uses view's filters/sort/grid state) */
+  viewId?: string;
+  /** Map render mode (point/choropleth/heatmap) — only relevant when viewMode is 'map' */
+  mapMode?: string;
 }
 
 /**
@@ -274,7 +278,7 @@ export interface AutoCardTemplate {
  */
 export const DEFAULT_EXPLORER_STATE: DataExplorerState = {
   navigationPanelWidth: 280,
-  navigationPanelCollapsed: false,
+  navigationPanelCollapsed: true,
   selectedEntityName: null,
   selectedViewId: null,
   viewModified: false,

--- a/packages/Angular/Explorer/dashboards/src/data-explorer-dashboards.module.ts
+++ b/packages/Angular/Explorer/dashboards/src/data-explorer-dashboards.module.ts
@@ -7,6 +7,7 @@ import { SharedGenericModule } from '@memberjunction/ng-shared-generic';
 import { FilterBuilderModule } from '@memberjunction/ng-filter-builder';
 import { ExportServiceModule } from '@memberjunction/ng-export-service';
 import { ListManagementModule } from '@memberjunction/ng-list-management';
+import { NgTreesModule } from '@memberjunction/ng-trees';
 
 // Data Explorer Components
 import { DataExplorerDashboardComponent } from './DataExplorer/data-explorer-dashboard.component';
@@ -37,7 +38,8 @@ import { ExplorerStateService } from './DataExplorer/services/explorer-state.ser
     SharedGenericModule,
     FilterBuilderModule,
     ExportServiceModule,
-    ListManagementModule
+    ListManagementModule,
+    NgTreesModule
   ],
   providers: [
     ExplorerStateService

--- a/packages/Angular/Explorer/explorer-core/src/lib/resource-wrappers/view-resource.component.html
+++ b/packages/Angular/Explorer/explorer-core/src/lib/resource-wrappers/view-resource.component.html
@@ -49,6 +49,7 @@
             [entity]="entityInfo"
             [viewEntity]="viewEntity"
             [gridState]="gridState"
+            [viewMode]="configuredViewMode"
             (recordOpened)="onRecordOpened($any($event))"
             (dataLoaded)="onDataLoaded()">
         </mj-entity-viewer>

--- a/packages/Angular/Explorer/explorer-core/src/lib/resource-wrappers/view-resource.component.ts
+++ b/packages/Angular/Explorer/explorer-core/src/lib/resource-wrappers/view-resource.component.ts
@@ -3,7 +3,7 @@ import { BaseResourceComponent, NavigationService } from '@memberjunction/ng-sha
 import { ResourceData, MJUserViewEntityExtended, ViewInfo } from '@memberjunction/core-entities';
 import { RegisterClass, MJGlobal, MJEventType , UUIDsEqual } from '@memberjunction/global';
 import { CompositeKey, Metadata, EntityInfo, RunView } from '@memberjunction/core';
-import { RecordOpenedEvent, ViewGridState, EntityViewerComponent } from '@memberjunction/ng-entity-viewer';
+import { RecordOpenedEvent, ViewGridState, EntityViewerComponent, EntityViewMode } from '@memberjunction/ng-entity-viewer';
 import { ExportService } from '@memberjunction/ng-export-service';
 import { ExportColumn } from '@memberjunction/export-engine';
 /**
@@ -143,6 +143,9 @@ export class UserViewResource extends BaseResourceComponent {
     public viewEntity: MJUserViewEntityExtended | null = null;
     public gridState: ViewGridState | null = null;
 
+    /** View mode from dashboard configuration (grid/cards/timeline/map) */
+    public configuredViewMode: EntityViewMode | null = null;
+
     // Export state
     public isExporting: boolean = false;
 
@@ -163,6 +166,14 @@ export class UserViewResource extends BaseResourceComponent {
 
         const newRecordId = value?.ResourceRecordID;
         const newEntity = value?.Configuration?.Entity;
+
+        // Read view mode from configuration if provided
+        const viewMode = value?.Configuration?.['viewMode'] as string | undefined;
+        if (viewMode && ['grid', 'cards', 'timeline', 'map'].includes(viewMode)) {
+            this.configuredViewMode = viewMode as EntityViewMode;
+        } else {
+            this.configuredViewMode = null;
+        }
 
         // Load on first set, or when the view/entity has changed
         if (!this.dataLoaded || newRecordId !== previousRecordId || newEntity !== previousEntity) {

--- a/packages/Angular/Explorer/explorer-core/src/lib/single-dashboard/Components/add-item/add-item.component.css
+++ b/packages/Angular/Explorer/explorer-core/src/lib/single-dashboard/Components/add-item/add-item.component.css
@@ -46,6 +46,13 @@
   line-height: 34px;
 }
 
+.optional-hint {
+  font-size: 11px;
+  color: var(--mj-text-muted);
+  font-weight: 400;
+  margin-left: 4px;
+}
+
 .no-items-message, .no-views-message {
   padding: 12px;
   background-color: var(--mj-bg-surface-card);

--- a/packages/Angular/Explorer/explorer-core/src/lib/single-dashboard/Components/add-item/add-item.component.html
+++ b/packages/Angular/Explorer/explorer-core/src/lib/single-dashboard/Components/add-item/add-item.component.html
@@ -17,21 +17,26 @@
               (ValueChange)="onEntityChange($any($event))" [(ngModel)]="selectedEntity">
             </mj-dropdown>
           </label>
-          @if (selectedEntity && Views.length) {
-            <label>Views
+          @if (selectedEntity && !showloader) {
+            @if (Views.length) {
+              <label>View
+                <span class="optional-hint">(optional — leave blank for default)</span>
+                <br />
+                <mj-dropdown [Data]="Views" [TextField]="'Name'" [ValueField]="'ID'"
+                  (ValueChange)="onViewChange($any($event))" [(ngModel)]="selectedView">
+                </mj-dropdown>
+              </label>
+            }
+            <!-- View Mode Selector -->
+            <label>View Mode
               <br />
-              <mj-dropdown [Data]="Views" [TextField]="'Name'" [ValueField]="'ID'"
-                (ValueChange)="onViewChange($any($event))" [(ngModel)]="selectedView">
+              <mj-dropdown [Data]="viewModeOptions" [TextField]="'label'" [ValueField]="'value'"
+                [(ngModel)]="selectedViewMode">
               </mj-dropdown>
             </label>
           }
-          @if (selectedEntity && !Views.length && showloader) {
+          @if (selectedEntity && showloader) {
             <mj-loading [showText]="false" size="medium"></mj-loading>
-          }
-          @if (selectedEntity && !Views.length && !showloader) {
-            <div class="no-views-message">
-              No views available for this entity
-            </div>
           }
         }
         @case ('Reports') {

--- a/packages/Angular/Explorer/explorer-core/src/lib/single-dashboard/Components/add-item/add-item.component.ts
+++ b/packages/Angular/Explorer/explorer-core/src/lib/single-dashboard/Components/add-item/add-item.component.ts
@@ -18,6 +18,13 @@ export class AddItemComponent implements OnInit {
   public selectedEntity: any = null;
   public selectedView: any = null;
   public selectedReport: any = null;
+  public selectedViewMode: string = 'grid';
+  public viewModeOptions = [
+    { label: 'Grid', value: 'grid', icon: 'fa-solid fa-list' },
+    { label: 'Cards', value: 'cards', icon: 'fa-solid fa-grip' },
+    { label: 'Timeline', value: 'timeline', icon: 'fa-solid fa-timeline' },
+    { label: 'Map', value: 'map', icon: 'fa-solid fa-map' }
+  ];
   public Entities: any[] = [];
   public Views: any[] = [];
   public Reports: any[] = [];
@@ -95,36 +102,43 @@ export class AddItemComponent implements OnInit {
   }
 
   public addItem() {
-    if (!this.selectedReport && !this.selectedView) {
+    // For views, allow "Default View" (no specific view selected) when an entity is chosen
+    const isViewResource = this.resourceType?.Name === 'UserViews' || this.resourceType?.Entity === 'MJ: User Views';
+    const isDefaultView = isViewResource && this.selectedEntity && !this.selectedView;
+
+    if (!this.selectedReport && !this.selectedView && !isDefaultView) {
       this.sharedService.CreateSimpleNotification('Please select an item to add', 'warning', 2000);
       return;
     }
-    
-    const name = this.selectedReport?.Name || this.selectedView?.Name;
-    const id = this.selectedReport?.ID || this.selectedView?.ID;
-    
-    if (!id) {
-      this.sharedService.CreateSimpleNotification('Invalid selection', 'error', 2000);
-      return;
+
+    const name = this.selectedReport?.Name || this.selectedView?.Name || (isDefaultView ? `${this.selectedEntity.Name} (Default View)` : null);
+    const id = this.selectedReport?.ID || this.selectedView?.ID || null;
+
+    // Build configuration — include viewMode for view resources
+    const configuration: Record<string, unknown> = {};
+    if (isViewResource && this.selectedViewMode && this.selectedViewMode !== 'grid') {
+      configuration['viewMode'] = this.selectedViewMode;
     }
-    
+    if (isDefaultView && this.selectedEntity) {
+      configuration['Entity'] = this.selectedEntity.Name;
+    }
+
     const dashboardItem = {
-      title: name ? name : 'New Item - ' + id,
+      title: name ? name : 'New Item',
       col: 1,
       rowSpan: 3,
       colSpan: 2,
       ResourceData: new ResourceData({
         Name: name,
-        ResourceType: this.resourceType.Name, // Add ResourceType
+        ResourceType: this.resourceType.Name,
         ResourceTypeID: this.resourceType.ID,
         ResourceRecordID: id,
-        Configuration: {}
+        Configuration: configuration
       }),
     };
-    
+
     this.sharedService.CreateSimpleNotification(`Added "${name}" to dashboard`, 'success', 2000);
     this.onClose.emit(dashboardItem);
-
   }
 
   closeDialog() {

--- a/packages/Angular/Generic/conversations/src/lib/components/mention/mention-dropdown.component.ts
+++ b/packages/Angular/Generic/conversations/src/lib/components/mention/mention-dropdown.component.ts
@@ -22,7 +22,19 @@ import { MentionSuggestion } from '../../services/mention-autocomplete.service';
   ]
 })
 export class MentionDropdownComponent implements OnInit, OnDestroy {
-  @Input() suggestions: MentionSuggestion[] = [];
+  private _suggestions: MentionSuggestion[] = [];
+
+  @Input()
+  set suggestions(value: MentionSuggestion[]) {
+    this._suggestions = value;
+    // Always reset selection to first item when suggestions change
+    // so there's never a state where nothing is selected
+    this.selectedIndex = 0;
+  }
+  get suggestions(): MentionSuggestion[] {
+    return this._suggestions;
+  }
+
   @Input() position: { top: number; left: number } = { top: 0, left: 0 };
   @Input() visible: boolean = false;
   @Input() showAbove: boolean = false; // Controls whether dropdown grows upward

--- a/packages/Angular/Generic/dashboard-viewer/src/lib/config-panels/config-panel.component.css
+++ b/packages/Angular/Generic/dashboard-viewer/src/lib/config-panels/config-panel.component.css
@@ -440,7 +440,7 @@
 .radio-option--compact {
     padding: 10px 14px;
     flex: 1;
-    min-width: 100px;
+    min-width: 120px;
 }
 
 .radio-option--compact .radio-label {

--- a/packages/Angular/Generic/dashboard-viewer/src/lib/config-panels/view-config-panel.component.html
+++ b/packages/Angular/Generic/dashboard-viewer/src/lib/config-panels/view-config-panel.component.html
@@ -132,9 +132,57 @@
                 Timeline
               </span>
             </label>
+            <label class="radio-option radio-option--compact" [class.selected]="displayMode === 'map'">
+              <input
+                type="radio"
+                name="displayMode"
+                value="map"
+                [(ngModel)]="displayMode"
+                (change)="onDisplayModeChange()">
+              <span class="radio-mark"></span>
+              <span class="radio-label">
+                <i class="fa-solid fa-map-location-dot"></i>
+                Map
+              </span>
+            </label>
           </div>
           <span class="form-hint">{{ getDisplayModeDescription() }}</span>
         </div>
+        <!-- Map Render Mode (only shown when map is selected) -->
+        @if (displayMode === 'map') {
+          <div class="form-group">
+            <label>Map Style</label>
+            <div class="radio-group radio-group--horizontal">
+              <label class="radio-option radio-option--compact" [class.selected]="mapRenderMode === 'point'">
+                <input type="radio" name="mapRenderMode" value="point"
+                  [(ngModel)]="mapRenderMode" (change)="onOptionChange()">
+                <span class="radio-mark"></span>
+                <span class="radio-label">
+                  <i class="fa-solid fa-map-pin"></i>
+                  Points
+                </span>
+              </label>
+              <label class="radio-option radio-option--compact" [class.selected]="mapRenderMode === 'choropleth'">
+                <input type="radio" name="mapRenderMode" value="choropleth"
+                  [(ngModel)]="mapRenderMode" (change)="onOptionChange()">
+                <span class="radio-mark"></span>
+                <span class="radio-label">
+                  <i class="fa-solid fa-earth-americas"></i>
+                  Regions
+                </span>
+              </label>
+              <label class="radio-option radio-option--compact" [class.selected]="mapRenderMode === 'heatmap'">
+                <input type="radio" name="mapRenderMode" value="heatmap"
+                  [(ngModel)]="mapRenderMode" (change)="onOptionChange()">
+                <span class="radio-mark"></span>
+                <span class="radio-label">
+                  <i class="fa-solid fa-fire"></i>
+                  Heatmap
+                </span>
+              </label>
+            </div>
+          </div>
+        }
         <!-- Selection Options -->
         <div class="form-group">
           <div class="checkbox-group checkbox-group--compact">

--- a/packages/Angular/Generic/dashboard-viewer/src/lib/config-panels/view-config-panel.component.ts
+++ b/packages/Angular/Generic/dashboard-viewer/src/lib/config-panels/view-config-panel.component.ts
@@ -31,7 +31,8 @@ export class ViewConfigPanelComponent extends BaseConfigPanel {
     public viewId = '';
     public viewName = '';
     public extraFilter = '';
-    public displayMode: 'grid' | 'cards' | 'timeline' = 'grid';
+    public displayMode: 'grid' | 'cards' | 'timeline' | 'map' = 'grid';
+    public mapRenderMode: 'point' | 'choropleth' | 'heatmap' = 'point';
     public allowModeSwitch = true;
     public enableSelection = true;
     public selectionMode: 'none' | 'single' | 'multiple' = 'single';
@@ -83,7 +84,8 @@ export class ViewConfigPanelComponent extends BaseConfigPanel {
             this.entityName = (config['entityName'] as string) || '';
             this.viewId = (config['viewId'] as string) || '';
             this.extraFilter = (config['extraFilter'] as string) || '';
-            this.displayMode = (config['displayMode'] as 'grid' | 'cards' | 'timeline') || 'grid';
+            this.displayMode = (config['displayMode'] as 'grid' | 'cards' | 'timeline' | 'map') || 'grid';
+            this.mapRenderMode = (config['mapRenderMode'] as 'point' | 'choropleth' | 'heatmap') || 'point';
             this.allowModeSwitch = (config['allowModeSwitch'] as boolean) ?? true;
             this.enableSelection = (config['enableSelection'] as boolean) ?? true;
             this.selectionMode = (config['selectionMode'] as 'none' | 'single' | 'multiple') || 'single';
@@ -112,6 +114,7 @@ export class ViewConfigPanelComponent extends BaseConfigPanel {
             viewId: this.viewId.trim() || undefined,
             extraFilter: this.extraFilter.trim() || undefined,
             displayMode: this.displayMode,
+            mapRenderMode: this.displayMode === 'map' ? this.mapRenderMode : undefined,
             allowModeSwitch: this.allowModeSwitch,
             enableSelection: this.enableSelection,
             selectionMode: this.selectionMode
@@ -221,6 +224,8 @@ export class ViewConfigPanelComponent extends BaseConfigPanel {
                 return 'Display records as cards in a responsive grid layout';
             case 'timeline':
                 return 'Display records chronologically along a timeline';
+            case 'map':
+                return 'Display geo-coded records on an interactive map';
             default:
                 return 'Display records in a traditional table/grid format';
         }

--- a/packages/Angular/Generic/entity-viewer/src/lib/entity-viewer/entity-viewer.component.html
+++ b/packages/Angular/Generic/entity-viewer/src/lib/entity-viewer/entity-viewer.component.html
@@ -66,7 +66,6 @@
             title="Map View">
             <i class="fa-solid fa-map-location-dot"></i>
           </button>
-          <span class="geo-debug-marker" style="color:red;font-size:10px;">GEO</span>
         </div>
       }
 

--- a/packages/Angular/Generic/trees/src/lib/tree-dropdown/tree-dropdown.component.ts
+++ b/packages/Angular/Generic/trees/src/lib/tree-dropdown/tree-dropdown.component.ts
@@ -335,20 +335,11 @@ export class TreeDropdownComponent implements OnInit, OnDestroy, AfterViewInit {
         this.calculatePosition();
         this.attachEventListeners();
 
-        // Focus search input after opening — use microtask + fallback to ensure it works
-        // even when Angular change detection hasn't yet rendered the @if block
-        Promise.resolve().then(() => {
-            if (this.EnableSearch && this.searchInput) {
-                this.searchInput.nativeElement.focus();
-            } else {
-                // Fallback: the @if block may not have rendered yet, retry after a frame
-                setTimeout(() => {
-                    if (this.EnableSearch && this.searchInput) {
-                        this.searchInput.nativeElement.focus();
-                    }
-                }, 100);
-            }
-        });
+        // Trigger change detection so the @if (IsOpen) block renders the dropdown panel
+        this.cdr.detectChanges();
+
+        // Focus search input after rendering
+        this.focusSearchInput();
 
         // Fire after event
         const afterEvent = new AfterDropdownOpenEventArgs(
@@ -356,8 +347,6 @@ export class TreeDropdownComponent implements OnInit, OnDestroy, AfterViewInit {
             this.Position?.renderAbove ? 'above' : 'below'
         );
         this.AfterDropdownOpen.emit(afterEvent);
-
-        this.cdr.detectChanges();
     }
 
     /**
@@ -477,7 +466,9 @@ export class TreeDropdownComponent implements OnInit, OnDestroy, AfterViewInit {
     }
 
     /**
-     * Handle search keydown
+     * Handle search keydown — provides full keyboard navigation while search input retains focus.
+     * The tree's own keyboard handler doesn't fire because the search input has DOM focus,
+     * so all navigation is handled here by manipulating the tree's FocusedNode visual state.
      */
     public onSearchKeyDown(event: KeyboardEvent): void {
         switch (event.key) {
@@ -488,14 +479,31 @@ export class TreeDropdownComponent implements OnInit, OnDestroy, AfterViewInit {
                 break;
             case 'ArrowDown':
                 event.preventDefault();
-                // Focus first tree node — guard against null/empty state
-                if (this.treeComponent?.Nodes?.length) {
-                    const visibleNodes = this.getVisibleNodesInOrder(this.treeComponent.Nodes);
-                    if (visibleNodes.length > 0) {
-                        this.treeComponent.FocusedNode = visibleNodes[0];
-                        this.cdr.detectChanges();
-                    }
-                }
+                this.navigateTree('down');
+                break;
+            case 'ArrowUp':
+                event.preventDefault();
+                this.navigateTree('up');
+                break;
+            case 'ArrowRight':
+                event.preventDefault();
+                this.expandOrDescendFocusedNode();
+                break;
+            case 'ArrowLeft':
+                event.preventDefault();
+                this.collapseOrAscendFocusedNode();
+                break;
+            case 'Enter':
+                event.preventDefault();
+                this.selectFocusedNode();
+                break;
+            case 'Home':
+                event.preventDefault();
+                this.navigateTree('first');
+                break;
+            case 'End':
+                event.preventDefault();
+                this.navigateTree('last');
                 break;
         }
     }
@@ -590,6 +598,180 @@ export class TreeDropdownComponent implements OnInit, OnDestroy, AfterViewInit {
 
     public onTreeAfterNodeSelect(event: AfterNodeSelectEventArgs): void {
         this.AfterNodeSelect.emit(event);
+    }
+
+    // ========================================
+    // Keyboard Navigation Helpers
+    // ========================================
+
+    /**
+     * Focus the search input after the dropdown opens.
+     * Deferred to the next macrotask so that:
+     *  1. Angular has fully resolved @ViewChild queries for the @if block
+     *  2. The browser's click event (on the trigger) has completed and won't steal focus back
+     * Falls back to direct DOM querySelector if the ViewChild isn't resolved.
+     */
+    private focusSearchInput(): void {
+        if (!this.EnableSearch) return;
+
+        const tryFocus = (retriesLeft: number): void => {
+            // Try ViewChild first
+            if (this.searchInput?.nativeElement) {
+                this.searchInput.nativeElement.focus();
+                return;
+            }
+            // Fallback: query DOM directly (ViewChild may not resolve for @if blocks)
+            const panel = this.dropdownPanel?.nativeElement;
+            if (panel) {
+                const input = panel.querySelector('.tree-dropdown-search__input') as HTMLInputElement;
+                if (input) {
+                    input.focus();
+                    return;
+                }
+            }
+            // Retry on next frame
+            if (retriesLeft > 0) {
+                requestAnimationFrame(() => tryFocus(retriesLeft - 1));
+            }
+        };
+
+        // Defer to next macrotask so the click event on the trigger completes first
+        // and Angular finishes resolving ViewChild queries for the new @if block
+        setTimeout(() => tryFocus(5), 0);
+    }
+
+    /**
+     * Navigate tree focus up/down/first/last while search input retains DOM focus
+     */
+    private navigateTree(direction: 'up' | 'down' | 'first' | 'last'): void {
+        if (!this.treeComponent?.Nodes?.length) return;
+
+        const visibleNodes = this.getVisibleNodesInOrder(this.treeComponent.Nodes);
+        if (visibleNodes.length === 0) return;
+
+        const currentIndex = this.treeComponent.FocusedNode
+            ? visibleNodes.indexOf(this.treeComponent.FocusedNode)
+            : -1;
+
+        let targetNode: TreeNode | null = null;
+
+        switch (direction) {
+            case 'down':
+                targetNode = currentIndex === -1
+                    ? visibleNodes[0]
+                    : currentIndex < visibleNodes.length - 1
+                        ? visibleNodes[currentIndex + 1]
+                        : null;
+                break;
+            case 'up':
+                targetNode = currentIndex === -1
+                    ? visibleNodes[visibleNodes.length - 1]
+                    : currentIndex > 0
+                        ? visibleNodes[currentIndex - 1]
+                        : null;
+                break;
+            case 'first':
+                targetNode = visibleNodes[0];
+                break;
+            case 'last':
+                targetNode = visibleNodes[visibleNodes.length - 1];
+                break;
+        }
+
+        if (targetNode) {
+            this.treeComponent.FocusedNode = targetNode;
+            this.cdr.detectChanges();
+            this.scrollFocusedNodeIntoView();
+        }
+    }
+
+    /**
+     * Select the currently focused tree node (Enter key)
+     */
+    private selectFocusedNode(): void {
+        const focusedNode = this.treeComponent?.FocusedNode;
+        if (!focusedNode) return;
+
+        // Check if the node type is selectable per config
+        const isSelectable = this.SelectableTypes === 'both'
+            || (this.SelectableTypes === 'leaf' && focusedNode.Type === 'leaf')
+            || (this.SelectableTypes === 'branch' && focusedNode.Type === 'branch');
+
+        if (isSelectable) {
+            this.treeComponent.SelectNodes([focusedNode.ID], true);
+        } else if (focusedNode.Type === 'branch') {
+            // Non-selectable branch: toggle expand/collapse
+            this.toggleBranchExpansion(focusedNode);
+        }
+    }
+
+    /**
+     * ArrowRight: expand focused branch or descend to first child
+     */
+    private expandOrDescendFocusedNode(): void {
+        const node = this.treeComponent?.FocusedNode;
+        if (!node || node.Type !== 'branch') return;
+
+        if (!node.Expanded && node.Children?.length) {
+            this.treeComponent.ExpandToNode(node.Children[0].ID);
+            this.cdr.detectChanges();
+        } else if (node.Expanded && node.Children?.length) {
+            // Already expanded: move focus to first visible child
+            const firstVisible = node.Children.find(c => c.Visible);
+            if (firstVisible) {
+                this.treeComponent.FocusedNode = firstVisible;
+                this.cdr.detectChanges();
+                this.scrollFocusedNodeIntoView();
+            }
+        }
+    }
+
+    /**
+     * ArrowLeft: collapse focused branch or ascend to parent
+     */
+    private collapseOrAscendFocusedNode(): void {
+        const node = this.treeComponent?.FocusedNode;
+        if (!node) return;
+
+        if (node.Type === 'branch' && node.Expanded) {
+            // Collapse the branch
+            this.toggleBranchExpansion(node);
+        } else if (node.ParentID) {
+            // Move to parent
+            const allNodes = this.getVisibleNodesInOrder(this.treeComponent.Nodes);
+            const parent = allNodes.find(n => n.ID === node.ParentID);
+            if (parent) {
+                this.treeComponent.FocusedNode = parent;
+                this.cdr.detectChanges();
+                this.scrollFocusedNodeIntoView();
+            }
+        }
+    }
+
+    /**
+     * Toggle expand/collapse of a branch node
+     */
+    private toggleBranchExpansion(node: TreeNode): void {
+        if (node.Expanded) {
+            node.Expanded = false;
+        } else {
+            this.treeComponent.ExpandToNode(node.ID);
+        }
+        this.cdr.detectChanges();
+    }
+
+    /**
+     * Scroll the currently focused tree node into view within the dropdown panel
+     */
+    private scrollFocusedNodeIntoView(): void {
+        requestAnimationFrame(() => {
+            const panel = this.dropdownPanel?.nativeElement;
+            if (!panel) return;
+            const focused = panel.querySelector('.tree-node-focused, .tree-node--focused, [data-focused="true"]');
+            if (focused) {
+                focused.scrollIntoView({ block: 'nearest', behavior: 'smooth' });
+            }
+        });
     }
 
     // ========================================


### PR DESCRIPTION
…oard view modes, mention selection, tree-dropdown keyboard

Data Explorer:
- Reorder nav items to Data, Queries, Dashboards
- Add viewId and mapMode to URL state for deep linking and bookmarks
- Forward query params from resource wrapper to dashboard via initialQueryParams input
- Merge browser URL params into workspace state to handle stale workspace configs
- Self-correcting map render mode restoration via state subscription guard
- Remove filter from URL (filters live in saved views, not query strings)
- Default left panel to collapsed for cleaner initial UX
- Replace custom entity list with ng-tree (Applications/Entities via junction)

Dashboard config:
- Add view mode selector (grid/cards/timeline/map) to add-item dialog
- Support default view (no specific view ID) when adding to dashboard
- Add Map option to Display Mode in view config panel
- Add Map Style sub-selector (Points/Regions/Heatmap) when Map mode selected
- Pass configured viewMode from dashboard tiles to entity-viewer
- Widen radio button layout for 4 options (min-width 120px)

Tree dropdown:
- Fix auto-focus: defer to next macrotask with requestAnimationFrame retries
- Add full keyboard nav in search input (ArrowUp/Down/Left/Right, Enter, Home/End)
- DOM querySelector fallback when ViewChild isn't resolved for @if blocks

Mention dropdown:
- Fix @mention selection: reset selectedIndex to 0 when suggestions list changes

Entity viewer:
- Remove leftover GEO debug marker from view mode toggle

Vectors dashboard:
- Fix entity picker search focus with ViewChild + deferred focus
- Add keyboard navigation (ArrowUp/Down/Enter/Escape) to entity picker
- Bump slide panel z-index above search overlay