### PR TITLE
fix: repair query composition regressions and conversation/tag-engine UX issues

### DIFF
--- a/.changeset/quiet-foxes-mend.md
+++ b/.changeset/quiet-foxes-mend.md
@@ -1,0 +1,9 @@
+---
+"@memberjunction/ng-conversations": patch
+"@memberjunction/content-autotagging": patch
+"@memberjunction/generic-database-provider": patch
+"@memberjunction/core-entities-server": patch
+"@memberjunction/sql-parser": patch
+---
+
+Repair three query composition pipeline regressions surfaced by Skip-Brain, clear test feedback dialog state when switching conversations, strip tag IDs from taxonomy context injected into LLM prompts, and exclude in-progress runs from last-run-date lookups.

--- a/.changeset/quiet-foxes-mend.md
+++ b/.changeset/quiet-foxes-mend.md
@@ -1,9 +1,10 @@
 ---
 "@memberjunction/ng-conversations": patch
+"@memberjunction/ng-dashboards": patch
 "@memberjunction/content-autotagging": patch
 "@memberjunction/generic-database-provider": patch
 "@memberjunction/core-entities-server": patch
 "@memberjunction/sql-parser": patch
 ---
 
-Repair three query composition pipeline regressions surfaced by Skip-Brain, clear test feedback dialog state when switching conversations, strip tag IDs from taxonomy context injected into LLM prompts, and exclude in-progress runs from last-run-date lookups.
+Repair three query composition pipeline regressions surfaced by Skip-Brain, clear test feedback dialog state when switching conversations, strip tag IDs from taxonomy context injected into LLM prompts, exclude in-progress runs from last-run-date lookups, and replace direct UUID equality checks with `UUIDsEqual()` in the AI analytics dashboards to comply with the cross-platform UUID compliance test.

--- a/packages/Angular/Explorer/dashboards/src/AI/components/analytics/agent-runs/agent-run-analysis.component.ts
+++ b/packages/Angular/Explorer/dashboards/src/AI/components/analytics/agent-runs/agent-run-analysis.component.ts
@@ -12,6 +12,7 @@ import {
 } from '@angular/core';
 import { Subject } from 'rxjs';
 import { RunView } from '@memberjunction/core';
+import { UUIDsEqual } from '@memberjunction/global';
 import { GlobalFilterState } from '../../../interfaces/analytics-preferences.interface';
 
 // ── Interfaces ──
@@ -734,7 +735,7 @@ export class AnalyticsAgentRunsComponent implements OnInit, OnDestroy {
         // Group prompt runs by agent run, then by vendor
         for (const pr of this.promptRuns) {
             if (!pr.AgentRunID) continue;
-            const agentRun = this.agentRuns.find(ar => ar.ID === pr.AgentRunID);
+            const agentRun = this.agentRuns.find(ar => UUIDsEqual(ar.ID, pr.AgentRunID));
             if (!agentRun) continue;
 
             const agentKey = agentRun.AgentID;

--- a/packages/Angular/Explorer/dashboards/src/AI/components/analytics/model-performance/model-performance.component.ts
+++ b/packages/Angular/Explorer/dashboards/src/AI/components/analytics/model-performance/model-performance.component.ts
@@ -11,6 +11,7 @@ import {
 } from '@angular/core';
 import { Subject } from 'rxjs';
 import { RunView } from '@memberjunction/core';
+import { UUIDsEqual } from '@memberjunction/global';
 import { AIEngineBase } from '@memberjunction/ai-engine-base';
 
 // ── Interfaces ──
@@ -590,7 +591,7 @@ export class AnalyticsModelPerformanceComponent implements OnInit, OnDestroy {
         // Look up model API name from engine
         let apiId = '';
         try {
-            const model = AIEngineBase.Instance.Models.find(m => m.ID === modelId);
+            const model = AIEngineBase.Instance.Models.find(m => UUIDsEqual(m.ID, modelId));
             apiId = model?.APIName ?? '';
         } catch {
             // engine might not be ready

--- a/packages/Angular/Generic/conversations/src/lib/components/conversation/conversation-chat-area.component.html
+++ b/packages/Angular/Generic/conversations/src/lib/components/conversation/conversation-chat-area.component.html
@@ -423,8 +423,8 @@
 <!-- Test Feedback Dialog -->
 @if (testFeedbackDialogData) {
   <mj-test-feedback-dialog
-    [visible]="showTestFeedbackDialog"
     [data]="testFeedbackDialogData"
+    [visible]="showTestFeedbackDialog"
     (closed)="onTestFeedbackDialogClosed($event)">
   </mj-test-feedback-dialog>
 }

--- a/packages/Angular/Generic/conversations/src/lib/components/conversation/conversation-chat-area.component.ts
+++ b/packages/Angular/Generic/conversations/src/lib/components/conversation/conversation-chat-area.component.ts
@@ -2060,6 +2060,7 @@ export class ConversationChatAreaComponent implements OnInit, OnDestroy, AfterVi
 
   onTestFeedbackDialogClosed(result: TestFeedbackDialogResult): void {
     this.showTestFeedbackDialog = false;
+    this.testFeedbackDialogData = null;
     if (result.success) {
       console.log('Test feedback saved successfully:', result.feedbackId);
     }

--- a/packages/ContentAutotagging/src/Engine/generic/AutotagBaseEngine.ts
+++ b/packages/ContentAutotagging/src/Engine/generic/AutotagBaseEngine.ts
@@ -963,9 +963,11 @@ export class AutotagBaseEngine extends BaseEngine<AutotagBaseEngine> {
      */
     public async getContentSourceLastRunDate(contentSourceID: string, contextUser: UserInfo): Promise<Date> {
         const rv = new RunView();
+        // Exclude 'Running' status to avoid using the current in-progress run's
+        // start time as the cutoff — that would cause the provider to skip all records.
         const results = await rv.RunView<MJContentProcessRunEntity>({
             EntityName: 'MJ: Content Process Runs',
-            ExtraFilter: `SourceID='${contentSourceID}'`,
+            ExtraFilter: `SourceID='${contentSourceID}' AND Status <> 'Running'`,
             ResultType: 'entity_object',
             OrderBy: 'EndTime DESC'
         }, contextUser);

--- a/packages/ContentAutotagging/src/Entity/generic/AutotagEntity.ts
+++ b/packages/ContentAutotagging/src/Entity/generic/AutotagEntity.ts
@@ -122,7 +122,9 @@ export class AutotagEntity extends AutotagBase {
                 .filter((id): id is string => id != null);
             const taxonomyRoot = rootIDs.length === 1 ? rootIDs[0] : undefined;
             const tree = TagEngine.Instance.GetTaxonomyTree(taxonomyRoot);
-            this.engine.TaxonomyContext = JSON.stringify(tree, null, 2);
+            // Strip IDs from the tree before injecting into the LLM prompt.
+            // The LLM occasionally returns UUIDs as tag names when it sees them.
+            this.engine.TaxonomyContext = JSON.stringify(tree, (key, value) => key === 'ID' ? undefined : value, 2);
         }
 
         // Set up the bridge callback for tag taxonomy linking

--- a/packages/GenericDatabaseProvider/src/__tests__/skip-failure-regressions.test.ts
+++ b/packages/GenericDatabaseProvider/src/__tests__/skip-failure-regressions.test.ts
@@ -1,0 +1,500 @@
+/**
+ * Regression tests for Skip-Brain query rendering failures.
+ *
+ * Each test pulls the EXACT SQL Skip generated for a failed run, so that
+ * any regression that re-introduces these classes of failure trips the test.
+ *
+ * See SKIP-QUERY-RENDERING-BUGS.md at the MJ repo root for the full
+ * triage write-up. Bug → test mapping:
+ *
+ *   Bug A — `stripOrderByViaRegex` (Tier 3 fallback inside
+ *           `stripTrailingOrderBy`) does NOT skip SQL comments before
+ *           matching `ORDER BY`. When a dependency's leading block comment
+ *           contains the literal text "ORDER BY" — e.g.
+ *           "/* No ORDER BY / TOP — composable. *⁠/" — the regex catches
+ *           that text, computes paren-depth = 0 at the comment, and strips
+ *           everything from the match to the end of the SQL. The hoisted
+ *           CTE body is then truncated mid-comment, producing the cryptic
+ *           SQL Server error "Incorrect syntax near '('".
+ *
+ *           Note: the related fix in commit 92f897fb2c made the *paging*
+ *           engine's regex scanner comment-aware, but the equivalent
+ *           function in the composition engine (`stripOrderByViaRegex`)
+ *           was not updated. Tests 1, 2, 3 cover this.
+ *
+ *   Bug C — `assembleCTEs` / `hoistInnerCTEs` do not rename inner CTEs
+ *           across multiple compositions, so two deps that both define an
+ *           inner CTE named `PoolNameBridge` collide.
+ *           Tests 4, 5.
+ */
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { QueryCompositionEngine } from '../queryCompositionEngine';
+import { Metadata, UserInfo, QueryDependencySpec } from '@memberjunction/core';
+
+const mockUser = { UserRoles: [{ Role: 'Admin' }] } as unknown as UserInfo;
+
+afterEach(() => {
+    vi.restoreAllMocks();
+});
+
+// ============================================================================
+// Helpers
+// ============================================================================
+
+function countOccurrences(haystack: string, needle: string): number {
+    if (needle.length === 0) return 0;
+    let count = 0;
+    let pos = 0;
+    while ((pos = haystack.indexOf(needle, pos)) !== -1) {
+        count++;
+        pos += needle.length;
+    }
+    return count;
+}
+
+function setupNoMetadata(): QueryCompositionEngine {
+    vi.spyOn(Metadata, 'Provider', 'get').mockReturnValue({
+        Queries: [],
+        QueryDependencies: [],
+    } as ReturnType<typeof Metadata.Provider>);
+    return new QueryCompositionEngine();
+}
+
+// ============================================================================
+// Bug A — `stripOrderByViaRegex` truncates dep body at comment-embedded
+// "ORDER BY" text
+// ============================================================================
+
+describe('Skip Regression — Bug A: comment-embedded ORDER BY truncates dep body', () => {
+    /**
+     * Test 1 — Skip run 3B5B2DC1 (QEI Patron Engagement Details).
+     *
+     * Dep starts with:
+     *   /*
+     *     ...
+     *     No ORDER BY / TOP -- composable.
+     *   *⁠/
+     *
+     * The comment contains the literal text "ORDER BY" and "TOP".
+     * `stripOrderByViaRegex` must skip comments; otherwise the dep body
+     * gets truncated and the hoisted CTE becomes
+     *   `[__cte_X] AS (\n/* … No\n)` → SQL syntax error.
+     */
+    it('Skip run 3B5B2DC1 — preserves full CTE body when leading comment mentions "ORDER BY"', () => {
+        const engine = setupNoMetadata();
+
+        // VERBATIM from Skip run 3B5B2DC1 (CE38EC39 step 1003) InputData.
+        const inlineDeps: QueryDependencySpec[] = [
+            {
+                Name: 'QEIPatronEngagementActivitySummary',
+                CategoryPath: '/Golden-Queries/Engagement and Outreach/',
+                UsesTemplate: true,
+                SQL: `/*
+  Per-QEI-Patron summary that totals engagement activity across five
+  channels: MEL contacts, event registrations, HL discussion posts, HL
+  logins, and Rasa newsletter actions.
+
+  No ORDER BY / TOP -- composable.
+*/
+
+WITH [TargetOrgs] AS (
+    SELECT
+        [m].[ID] AS [OrganizationID],
+        [m].[EmployerName] AS [OrganizationName],
+        [m].[MemberTypeCode] AS [MemberType]
+    FROM [ym].[vwMembers] AS [m]
+    WHERE [m].[MemberTypeCode] IN {{ MemberTypes | sqlIn }}
+),
+[MEL_Eng] AS (
+    SELECT
+        [m_mel].[EmployerName],
+        COUNT(*) AS [MELCount]
+    FROM [document].[vwMemberEngagementLogs] AS [mel]
+    INNER JOIN [ym].[vwMembers] AS [m_mel]
+        ON [mel].[FirstName] = [m_mel].[FirstName]
+    WHERE [mel].[Date] >= DATEADD(DAY, -{{ DaysBack | sqlNumber }}, GETDATE())
+    GROUP BY [m_mel].[EmployerName]
+)
+SELECT
+    [t].[OrganizationID],
+    [t].[OrganizationName],
+    [t].[MemberType],
+    ISNULL([mel].[MELCount], 0) AS [TotalEngagementCount]
+FROM [TargetOrgs] AS [t]
+LEFT JOIN [MEL_Eng] AS [mel] ON [t].[OrganizationName] = [mel].[EmployerName]
+`,
+            },
+        ];
+
+        const outerSQL = `SELECT [qei].[OrganizationID]
+FROM {{query:"Golden-Queries/Engagement and Outreach/QEIPatronEngagementActivitySummary(MemberTypes=MemberTypes, DaysBack=DaysBack)"}} AS [qei]`;
+
+        const result = engine.ResolveComposition(
+            outerSQL,
+            'sqlserver',
+            mockUser,
+            {},
+            inlineDeps
+        );
+
+        expect(result.HasCompositions).toBe(true);
+
+        // Concrete proof of truncation: these tokens are AFTER the
+        // comment-embedded "ORDER BY" text in the dep body and must
+        // appear in the resolved SQL.
+        expect(result.ResolvedSQL).toContain('[TargetOrgs]');
+        expect(result.ResolvedSQL).toContain('[MEL_Eng]');
+        expect(result.ResolvedSQL).toContain('[TotalEngagementCount]');
+        expect(result.ResolvedSQL).toContain('GROUP BY [m_mel].[EmployerName]');
+    });
+
+    /**
+     * Test 2 — Skip run 7A962472 / 0269B6CA (Executive Compensation w/ Bonus and Context).
+     *
+     * Same comment-embedded "ORDER BY" pattern, but the dep also has a
+     * `ROW_NUMBER() OVER (PARTITION BY ... ORDER BY ...)` window function.
+     * The bug must not cause Tier 3 to mistake either the comment text
+     * OR the window-function ORDER BY for a strip-able trailing ORDER BY.
+     */
+    it('Skip run 7A962472 — preserves full CTE body for ExecComp dep with window function and "No ORDER BY" comment', () => {
+        const engine = setupNoMetadata();
+
+        const inlineDeps: QueryDependencySpec[] = [
+            {
+                Name: 'ExecCompWithMemberContext',
+                CategoryPath: '/Golden-Queries/Financial Analysis/',
+                UsesTemplate: true,
+                SQL: `/*
+  One row per executive compensation respondent with full pool/member
+  context attached (no grouping, no service-area bucketing) so callers
+  can correlate salary against any dimension they like.
+
+  No ORDER BY / TOP -- composable.
+*/
+
+WITH ExecComp AS (
+    SELECT
+        e.[ID]    AS [ExecCompID],
+        e.[Email] AS [Email],
+        TRY_CAST(REPLACE(e.[salary], '$', '') AS DECIMAL(18,2)) AS [BaseSalary]
+    FROM [document].[vwExecutiveCompDatas] AS e
+    WHERE e.[Email] IS NOT NULL
+),
+MemberByEmail AS (
+    SELECT
+        LOWER([m].[EmailAddress]) AS [EmailKey],
+        [m].[ID],
+        [m].[EmployerName],
+        ROW_NUMBER() OVER (
+            PARTITION BY LOWER([m].[EmailAddress])
+            ORDER BY
+                CASE WHEN [m].[Membership] IS NOT NULL THEN 0 ELSE 1 END,
+                [m].[ID]
+        ) AS [rn]
+    FROM [ym].[vwMembers] AS [m]
+)
+SELECT
+    [ec].[ExecCompID],
+    [m].[ID]              AS [MemberID],
+    [m].[EmployerName]    AS [PoolName]
+FROM ExecComp AS [ec]
+LEFT JOIN MemberByEmail AS [m]
+    ON [m].[EmailKey] = LOWER([ec].[Email])
+   AND [m].[rn] = 1
+WHERE 1 = 1
+{% if Region %}
+    AND [ei].[Region] = {{ Region | sqlString }}
+{% endif %}
+`,
+            },
+        ];
+
+        const outerSQL = `SELECT ctx.[ExecCompID]
+FROM {{query:"Golden-Queries/Financial Analysis/ExecCompWithMemberContext(Region=Region)"}} ctx`;
+
+        const result = engine.ResolveComposition(
+            outerSQL,
+            'sqlserver',
+            mockUser,
+            {},
+            inlineDeps
+        );
+
+        expect(result.HasCompositions).toBe(true);
+
+        // The dep body contains the trigger text "No ORDER BY / TOP" inside
+        // a leading block comment. Tier-3 regex stripping must skip
+        // comments — otherwise these tokens (which appear AFTER the
+        // comment-embedded "ORDER BY") will be missing from the resolved SQL.
+        expect(result.ResolvedSQL).toContain('WITH ExecComp');
+        expect(result.ResolvedSQL).toContain('MemberByEmail');
+        expect(result.ResolvedSQL).toContain('ROW_NUMBER()');
+        expect(result.ResolvedSQL).toContain('PoolName');
+
+        // The window-function ORDER BY is legal in CTEs; no Tier-4 fix is needed.
+        expect(result.ResolvedSQL).not.toMatch(/OFFSET\s+0\s+ROWS/i);
+    });
+
+    /**
+     * Test 3 — Skip run 0269B6CA (full ExecComp Drivers Analysis).
+     *
+     * Even when the comment marker is just "ORDER BY" mentioned in passing
+     * (no "No" qualifier), the dep body must be preserved.
+     */
+    it('preserves dep body when block comment mentions "ORDER BY" in any form', () => {
+        const engine = setupNoMetadata();
+
+        const inlineDeps: QueryDependencySpec[] = [
+            {
+                Name: 'TopMembers',
+                CategoryPath: '/Test/',
+                SQL: `/* This is the canonical members source. Callers should add their own ORDER BY downstream. */
+SELECT [ID], [Name]
+FROM [Members]
+WHERE [Active] = 1`,
+            },
+        ];
+
+        const outerSQL = `SELECT * FROM {{query:"Test/TopMembers"}} m`;
+
+        const result = engine.ResolveComposition(
+            outerSQL,
+            'sqlserver',
+            mockUser,
+            {},
+            inlineDeps
+        );
+
+        expect(result.HasCompositions).toBe(true);
+        expect(result.ResolvedSQL).toContain('SELECT [ID], [Name]');
+        expect(result.ResolvedSQL).toContain('FROM [Members]');
+        expect(result.ResolvedSQL).toContain('WHERE [Active] = 1');
+    });
+
+    /**
+     * Sanity check — when the dep ACTUALLY has an illegal trailing ORDER BY,
+     * the engine SHOULD strip it (or, as a last resort, inject OFFSET 0 ROWS
+     * to make it legal). This guards against an over-broad Bug A fix that
+     * disables ORDER BY stripping entirely.
+     */
+    it('still handles a real top-level ORDER BY in a dep with no TOP/OFFSET', () => {
+        const engine = setupNoMetadata();
+
+        const inlineDeps: QueryDependencySpec[] = [
+            {
+                Name: 'TopCustomers',
+                CategoryPath: '/Sales/',
+                SQL: `SELECT [ID], [Name], [TotalRevenue]
+FROM [Customers]
+WHERE [Active] = 1
+ORDER BY [TotalRevenue] DESC`,
+            },
+        ];
+
+        const outerSQL = `SELECT * FROM {{query:"Sales/TopCustomers"}} t`;
+        const result = engine.ResolveComposition(
+            outerSQL,
+            'sqlserver',
+            mockUser,
+            {},
+            inlineDeps
+        );
+
+        expect(result.HasCompositions).toBe(true);
+
+        // The CTE body must be valid in SQL Server. Either the ORDER BY is
+        // stripped, OR it's preserved with OFFSET to make it legal. Both
+        // outcomes are acceptable; the SELECT/FROM body must be intact
+        // either way.
+        expect(result.ResolvedSQL).toContain('SELECT [ID], [Name], [TotalRevenue]');
+        expect(result.ResolvedSQL).toContain('FROM [Customers]');
+
+        const hasOrderBy = /ORDER\s+BY\s+\[TotalRevenue\]/i.test(result.ResolvedSQL);
+        const hasOffset = /OFFSET\s+0\s+ROWS/i.test(result.ResolvedSQL);
+        expect(hasOrderBy === false || hasOffset === true).toBe(true);
+    });
+});
+
+// ============================================================================
+// Bug C — Inner CTE name collisions across multiple deps
+// ============================================================================
+
+describe('Skip Regression — Bug C: duplicate inner CTE names', () => {
+    /**
+     * Test 4 — Skip run 9359F3F2 (Pool Engagement Leaderboard With Top Topic).
+     *
+     * Outer composes BOTH `PoolMELActivitySummary` and `MELResolvedToMember`,
+     * each of which declares its own `AcronymBridge` and `PoolNameBridge`
+     * inner CTEs. SQL Server rejects duplicate CTE names within a single WITH
+     * with "Duplicate common table expression name 'PoolNameBridge' was specified."
+     * The composition engine must rename inner CTEs to unique identifiers.
+     */
+    it('Skip run 9359F3F2 — renames inner CTEs to avoid collisions across deps', () => {
+        const engine = setupNoMetadata();
+
+        const inlineDeps: QueryDependencySpec[] = [
+            {
+                Name: 'PoolMELActivitySummary',
+                CategoryPath: '/Golden-Queries/Engagement and Outreach/',
+                UsesTemplate: true,
+                SQL: `WITH AcronymBridge AS (
+    SELECT
+        LOWER(LTRIM(RTRIM([atm].[Acronym]))) AS [AcronymKey],
+        [atm].[MemberID]
+    FROM [ym].[vwAcronymToMember] AS [atm]
+    INNER JOIN [ym].[vwMembers] AS [m]
+        ON [m].[ID] = [atm].[MemberID]
+),
+PoolNameBridge AS (
+    SELECT
+        LOWER(LTRIM(RTRIM([m].[EmployerName]))) AS [NameKey],
+        [m].[ID] AS [MemberID]
+    FROM [ym].[vwMembers] AS [m]
+    WHERE [m].[EmployerName] IS NOT NULL
+)
+SELECT
+    [m].[ID] AS [MemberID],
+    [m].[EmployerName] AS [PoolName],
+    COUNT(*) AS [TotalMELCount]
+FROM [document].[vwMemberEngagementLogs] AS [mel]
+LEFT JOIN AcronymBridge AS [ab]
+    ON LOWER(LTRIM(RTRIM([mel].[MemberOrganization]))) = [ab].[AcronymKey]
+LEFT JOIN PoolNameBridge AS [pnb]
+    ON LOWER(LTRIM(RTRIM([mel].[MemberOrganization]))) = [pnb].[NameKey]
+INNER JOIN [ym].[vwMembers] AS [m]
+    ON [m].[ID] = COALESCE([ab].[MemberID], [pnb].[MemberID])
+WHERE 1 = 1
+{% if MemberTypes %}
+    AND [m].[MemberTypeCode] IN {{ MemberTypes | sqlIn }}
+{% endif %}
+GROUP BY [m].[ID], [m].[EmployerName]`,
+            },
+            {
+                Name: 'MELResolvedToMember',
+                CategoryPath: '/Golden-Queries/Engagement and Outreach/',
+                UsesTemplate: true,
+                SQL: `WITH AcronymBridge AS (
+    SELECT
+        LOWER(LTRIM(RTRIM([atm].[Acronym]))) AS [AcronymKey],
+        [atm].[MemberID]
+    FROM [ym].[vwAcronymToMember] AS [atm]
+    INNER JOIN [ym].[vwMembers] AS [m]
+        ON [m].[ID] = [atm].[MemberID]
+),
+PoolNameBridge AS (
+    SELECT
+        LOWER(LTRIM(RTRIM([m].[EmployerName]))) AS [NameKey],
+        [m].[ID] AS [MemberID]
+    FROM [ym].[vwMembers] AS [m]
+    WHERE [m].[EmployerName] IS NOT NULL
+)
+SELECT
+    [mel].[ID] AS [MELID],
+    [mel].[Date] AS [LogDate],
+    [mel].[Reason],
+    COALESCE([ab].[MemberID], [pnb].[MemberID]) AS [ResolvedMemberID]
+FROM [document].[vwMemberEngagementLogs] AS [mel]
+LEFT JOIN AcronymBridge AS [ab]
+    ON LOWER(LTRIM(RTRIM([mel].[MemberOrganization]))) = [ab].[AcronymKey]
+LEFT JOIN PoolNameBridge AS [pnb]
+    ON LOWER(LTRIM(RTRIM([mel].[MemberOrganization]))) = [pnb].[NameKey]
+WHERE 1 = 1
+{% if StartDate %}
+    AND [mel].[Date] >= {{ StartDate | sqlDate }}
+{% endif %}`,
+            },
+        ];
+
+        const outerSQL = `SELECT
+    [pmas].[MemberID],
+    [pmas].[PoolName],
+    [pmas].[TotalMELCount],
+    [pr].[Reason] AS [TopReason]
+FROM {{query:"Golden-Queries/Engagement and Outreach/PoolMELActivitySummary(MemberTypes=MemberTypes)"}} AS [pmas]
+LEFT JOIN (
+    SELECT
+        [mel].[ResolvedMemberID],
+        [mel].[Reason]
+    FROM {{query:"Golden-Queries/Engagement and Outreach/MELResolvedToMember(StartDate=StartDate)"}} AS [mel]
+    WHERE [mel].[Reason] IS NOT NULL
+) AS [pr]
+    ON [pr].[ResolvedMemberID] = [pmas].[MemberID]`;
+
+        const result = engine.ResolveComposition(
+            outerSQL,
+            'sqlserver',
+            mockUser,
+            {},
+            inlineDeps
+        );
+
+        expect(result.HasCompositions).toBe(true);
+
+        // BOTH deps were composed.
+        expect(result.CTEs.length).toBeGreaterThanOrEqual(2);
+
+        // The resolved SQL must NOT contain duplicate inner CTE definitions.
+        // The verbatim "PoolNameBridge AS (" / "AcronymBridge AS (" pattern
+        // must appear at most once. Renamed copies will look like
+        // "__cte_PoolNameBridge_<hash> AS (" or similar.
+        const verbatimPoolNameBridgeCount = countOccurrences(
+            result.ResolvedSQL,
+            'PoolNameBridge AS ('
+        );
+        const verbatimAcronymBridgeCount = countOccurrences(
+            result.ResolvedSQL,
+            'AcronymBridge AS ('
+        );
+
+        expect(verbatimPoolNameBridgeCount).toBeLessThanOrEqual(1);
+        expect(verbatimAcronymBridgeCount).toBeLessThanOrEqual(1);
+    });
+
+    /**
+     * Test 5 — A single dep referenced multiple times with different params.
+     * The dedupe key uses params, so we get TWO outer CTEs. Each must own a
+     * distinct copy of the dep's inner CTEs (or a shared single copy if the
+     * engine deduplicates them — but never duplicate names).
+     */
+    it('renames inner CTEs across multiple references to the same dep with different params', () => {
+        const engine = setupNoMetadata();
+
+        const inlineDeps: QueryDependencySpec[] = [
+            {
+                Name: 'MemberByRegion',
+                CategoryPath: '/Test/',
+                UsesTemplate: true,
+                SQL: `WITH AcronymBridge AS (
+    SELECT [atm].[MemberID]
+    FROM [ym].[vwAcronymToMember] AS [atm]
+)
+SELECT [m].[ID]
+FROM [ym].[vwMembers] AS [m]
+INNER JOIN AcronymBridge AS [ab] ON [ab].[MemberID] = [m].[ID]
+WHERE [m].[Region] = {{ Region | sqlString }}`,
+            },
+        ];
+
+        // Same dep, two calls with different Region values → two distinct outer CTEs
+        const outerSQL = `SELECT a.[ID], b.[ID]
+FROM {{query:"Test/MemberByRegion(Region='East')"}} a
+JOIN {{query:"Test/MemberByRegion(Region='West')"}} b ON a.[ID] = b.[ID]`;
+
+        const result = engine.ResolveComposition(
+            outerSQL,
+            'sqlserver',
+            mockUser,
+            {},
+            inlineDeps
+        );
+
+        expect(result.HasCompositions).toBe(true);
+        expect(result.CTEs).toHaveLength(2);
+
+        // Either the inner CTE is hoisted under unique names per outer CTE,
+        // or it's hoisted exactly once and shared. Either way, the verbatim
+        // "AcronymBridge AS (" must appear at most once.
+        const verbatim = countOccurrences(result.ResolvedSQL, 'AcronymBridge AS (');
+        expect(verbatim).toBeLessThanOrEqual(1);
+    });
+});

--- a/packages/GenericDatabaseProvider/src/queryCompositionEngine.ts
+++ b/packages/GenericDatabaseProvider/src/queryCompositionEngine.ts
@@ -615,6 +615,14 @@ export class QueryCompositionEngine {
      * Handles the case where a dependency query's SQL itself contains a WITH clause
      * (inner CTEs). SQL does not allow nested WITH clauses, so inner CTEs are "hoisted"
      * out as sibling CTE definitions preceding the dependency's own CTE.
+     *
+     * Cross-dep CTE name collisions: when two different dependencies each declare
+     * an inner CTE with the same name (e.g. both declare `PoolNameBridge`), the
+     * naive concatenation produces a duplicate CTE error from SQL Server. We
+     * track allocated names across the entire WITH and rename colliding inner
+     * CTEs (and rewrite intra-dep references to the renamed CTE) so the assembled
+     * SQL is valid. See Skip-Brain Bug C in
+     * `__tests__/skip-failure-regressions.test.ts` and `SKIP-QUERY-RENDERING-BUGS.md`.
      */
     private assembleCTEs(cteEntries: CTEEntry[], mainSQL: string, platform: DatabasePlatform): string {
         if (cteEntries.length === 0) return mainSQL;
@@ -624,6 +632,14 @@ export class QueryCompositionEngine {
         const startsWithWith = /^WITH\s/i.test(trimmedMain);
 
         const dialect = this.getDialect(platform);
+
+        // Track every CTE name allocated to the assembled WITH (case-insensitive).
+        // We seed with the outer-CTE names from the entries themselves so that an
+        // inner CTE happening to share a name with another entry's outer CTE
+        // also gets renamed.
+        const allocatedNames = new Set<string>(
+            cteEntries.map(e => this.canonicalCTEName(e.CTEName).toLowerCase())
+        );
 
         // Build CTE definitions, hoisting any inner WITH clauses from dependency SQL
         const cteDefinitions: string[] = [];
@@ -637,8 +653,15 @@ export class QueryCompositionEngine {
                 // Dependency SQL has its own WITH clause — hoist inner CTEs as siblings.
                 // Pass the comment-stripped version so ExtractCTEs can detect the WITH prefix.
                 const { innerCTEDefinitions, mainSelect } = this.hoistInnerCTEs(commentStrippedSQL, platform);
-                cteDefinitions.push(...innerCTEDefinitions);
-                cteDefinitions.push(`${entry.CTEName} AS (\n${mainSelect}\n)`);
+
+                // Rename any inner CTE whose name collides with an already-
+                // allocated name. Rewrites references in (a) other inner CTEs of
+                // this same dep (siblings), and (b) the dep's mainSelect.
+                const { definitions, rewrittenMainSelect } =
+                    this.deconflictInnerCTEs(innerCTEDefinitions, mainSelect, allocatedNames);
+
+                cteDefinitions.push(...definitions);
+                cteDefinitions.push(`${entry.CTEName} AS (\n${rewrittenMainSelect}\n)`);
             } else {
                 cteDefinitions.push(`${entry.CTEName} AS (\n${strippedSQL}\n)`);
             }
@@ -652,6 +675,114 @@ export class QueryCompositionEngine {
         }
 
         return `WITH ${cteDefinitions.join(',\n')}\n${mainSQL}`;
+    }
+
+    /**
+     * Strips the surrounding bracket / quote characters from a CTE name so we
+     * can compare names case-insensitively across quoting styles. `[Foo]`,
+     * `"Foo"`, and bare `Foo` all canonicalize to `Foo`.
+     */
+    private canonicalCTEName(rawName: string): string {
+        return rawName.replace(/^[\["]|[\]"]$/g, '');
+    }
+
+    /**
+     * Walks `innerCTEDefinitions` (each formatted as `Name AS (\nbody\n)` by
+     * `extractCTEsViaRegex`/`extractCTEsViaAST`) and ensures every CTE name is
+     * unique across the assembled WITH. When a collision is detected, the inner
+     * CTE is renamed (`Name` → `Name__2`, `__3`, …) and the new name is
+     * substituted everywhere the original was referenced — both in subsequent
+     * inner CTE bodies (siblings can reference each other) and in the dep's
+     * main SELECT.
+     *
+     * NOTE (Phase 0 trade-off): reference rewriting is a word-boundary regex
+     * over raw SQL. It does NOT skip string literals or comments. Real
+     * dependencies' inner-CTE names are unlikely to appear as quoted text or
+     * column aliases, so this is acceptable for the immediate fix; the
+     * IR-based redesign (see plans/query-rendering-pipeline-redesign.md)
+     * replaces this with a structured walk.
+     */
+    private deconflictInnerCTEs(
+        innerCTEDefinitions: string[],
+        mainSelect: string,
+        allocatedNames: Set<string>
+    ): { definitions: string[]; rewrittenMainSelect: string } {
+        // Pre-compute renames first, so all sibling/main-select rewrites use
+        // the final names regardless of definition order.
+        const renames = new Map<string, string>();   // canonical-old → new bare name
+        const finalDefinitionHeaders: { original: string; rewritten: string }[] = [];
+
+        for (const def of innerCTEDefinitions) {
+            const headerMatch = def.match(/^(\[[^\]]+\]|"[^"]+"|[A-Za-z_]\w*)(\s+AS\s*\()/i);
+            if (!headerMatch) {
+                // Couldn't parse — leave untouched. Future allocations may
+                // still collide, but this preserves existing behavior.
+                finalDefinitionHeaders.push({ original: def, rewritten: def });
+                continue;
+            }
+
+            const rawName = headerMatch[1];
+            const canonical = this.canonicalCTEName(rawName);
+            const lower = canonical.toLowerCase();
+
+            if (!allocatedNames.has(lower)) {
+                allocatedNames.add(lower);
+                finalDefinitionHeaders.push({ original: def, rewritten: def });
+                continue;
+            }
+
+            // Collision — find a fresh name.
+            let suffix = 2;
+            let candidate = `${canonical}__${suffix}`;
+            while (allocatedNames.has(candidate.toLowerCase())) {
+                suffix++;
+                candidate = `${canonical}__${suffix}`;
+            }
+            allocatedNames.add(candidate.toLowerCase());
+            renames.set(canonical, candidate);
+
+            // Replace just the header on the definition; the body will be
+            // rewritten in the next pass alongside other deps' references.
+            const rewrittenDef =
+                candidate + headerMatch[2] + def.substring(headerMatch[0].length);
+            finalDefinitionHeaders.push({ original: def, rewritten: rewrittenDef });
+        }
+
+        if (renames.size === 0) {
+            return { definitions: finalDefinitionHeaders.map(d => d.rewritten), rewrittenMainSelect: mainSelect };
+        }
+
+        // Apply all renames to every inner CTE body and the main SELECT, so
+        // sibling CTEs that reference the renamed CTE point at the new name.
+        const rewriteAll = (sql: string): string => {
+            let result = sql;
+            for (const [oldName, newName] of renames) {
+                result = this.renameSQLIdentifier(result, oldName, newName);
+            }
+            return result;
+        };
+
+        const definitions = finalDefinitionHeaders.map(d => rewriteAll(d.rewritten));
+        const rewrittenMainSelect = rewriteAll(mainSelect);
+        return { definitions, rewrittenMainSelect };
+    }
+
+    /**
+     * Replaces every reference to `oldName` (bare, [bracketed], or "quoted")
+     * with bare `newName`. Case-insensitive. Word-boundary matched so
+     * `MyAcronymBridge` is not affected by renaming `AcronymBridge`.
+     *
+     * Does not attempt to skip string literals or comments — see the note on
+     * `deconflictInnerCTEs` for the trade-off rationale.
+     */
+    private renameSQLIdentifier(sql: string, oldName: string, newName: string): string {
+        const escaped = oldName.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+        // Three forms: [Name], "Name", or bare Name (with word boundaries).
+        const pattern = new RegExp(
+            `\\[${escaped}\\]|"${escaped}"|\\b${escaped}\\b`,
+            'gi'
+        );
+        return sql.replace(pattern, newName);
     }
 
     /**
@@ -709,16 +840,17 @@ export class QueryCompositionEngine {
         const astResult = this.stripOrderByViaAST(trimmed, dialect.ParserDialect);
         if (astResult !== null) return astResult;
 
-        // Tier 3: Regex fallback
+        // Tier 3: Position-aware fallback (skips comments, strings, MJ tokens via MJLexer)
         const regexResult = this.stripOrderByViaRegex(trimmed);
         if (regexResult !== trimmed) return regexResult;
 
-        // Tier 4: OFFSET 0 ROWS injection — last resort.
-        // If we reach here, the SQL has an ORDER BY that neither AST nor regex could strip
-        // (e.g. STRING_AGG WITHIN GROUP with a trailing ORDER BY). Rather than returning
-        // the SQL unchanged (which would cause a SQL Server CTE error), inject OFFSET 0 ROWS
-        // after the ORDER BY to make it legal. This is semantically neutral but may affect
-        // query plan shape on large result sets.
+        // Tier 4: OFFSET 0 ROWS injection — last resort, but ONLY when a real
+        // top-level ORDER BY exists. If there is none, returning SQL unchanged is
+        // correct; injecting OFFSET 0 ROWS would itself be an error
+        // (OFFSET requires ORDER BY in the same query level).
+        if (this.findTopLevelOrderByPositions(trimmed).length === 0) {
+            return sql;
+        }
         return this.injectOffset0Rows(trimmed);
     }
 
@@ -914,23 +1046,22 @@ export class QueryCompositionEngine {
     }
 
     /**
-     * Regex-based fallback for stripping trailing ORDER BY.
-     * Uses parenthesis depth counting to avoid stripping ORDER BY inside subqueries.
+     * Position-aware fallback for stripping the last top-level ORDER BY clause.
+     * Delegates to `stripLastTopLevelOrderBy`, which uses MJLexer to skip MJ
+     * template tokens, then scans only SQL_TEXT segments while respecting paren
+     * depth, single-quoted string literals, line comments (--), and block
+     * comments (/* … *​/).
+     *
+     * The previous regex-only implementation matched any literal "ORDER BY" in
+     * the SQL — including text inside leading block comments like
+     * `/* No ORDER BY / TOP — composable. *​/` — and truncated the dep body
+     * mid-comment, producing illegal SQL ("Incorrect syntax near '('").
+     * Skip-Brain hit this against multiple AGRiP composition deps. See
+     * `__tests__/skip-failure-regressions.test.ts` and
+     * `SKIP-QUERY-RENDERING-BUGS.md` (Bug A) at the repo root.
      */
     private stripOrderByViaRegex(sql: string): string {
-        const orderByMatch = sql.match(/\bORDER\s+BY\s+[\s\S]+$/i);
-        if (!orderByMatch) return sql;
-
-        const beforeOrderBy = sql.substring(0, orderByMatch.index);
-        let parenDepth = 0;
-        for (const ch of beforeOrderBy) {
-            if (ch === '(') parenDepth++;
-            else if (ch === ')') parenDepth--;
-        }
-
-        if (parenDepth !== 0) return sql;
-
-        return sql.substring(0, orderByMatch.index).trimEnd();
+        return this.stripLastTopLevelOrderBy(sql);
     }
 
     /**

--- a/packages/MJCoreEntitiesServer/src/__tests__/MJQueryEntityServer.test.ts
+++ b/packages/MJCoreEntitiesServer/src/__tests__/MJQueryEntityServer.test.ts
@@ -136,6 +136,49 @@ WHERE Limit = {{ Limit | default(25) | sqlNumber }}
             expect(region.defaultValue).toBe('US');
             expect(region.type).toBe('string');
         });
+
+        // Regression test for Skip-Brain Bug B (run 0FEF1C47).
+        // Verifies the integration: when a query SQL contains a `{% for X in Y %}`
+        // loop, the deterministic extractor (consumed by parse.ts → enrich.ts →
+        // sync.ts) registers the iterable Y as a parameter and skips the loop
+        // local X. Without this, Save() would create a stale `kw` parameter
+        // record and reject every actual save attempt with
+        // "Required parameter 'kw' is missing; Unknown parameter: 'OrgKeywords'".
+        it('should register the iterable as an array parameter and skip the loop local (Skip Bug B)', () => {
+            const sql = `SELECT *
+FROM [Sessions]
+WHERE EXISTS (
+    SELECT 1 FROM [Speakers] s
+    WHERE (
+        {% for kw in OrgKeywords %}
+        s.[Org] LIKE {{ kw | sqlLikeContains }}
+        {% if not loop.last %}OR {% endif %}
+        {% endfor %}
+    )
+)
+AND YEAR(s.[Date]) >= {{ StartYear | sqlNumber }}`;
+
+            const params = SQLParser.ExtractParameterInfo(sql);
+
+            // OrgKeywords (iterable) is registered as array, required.
+            const orgKeywords = params.find(p => p.name === 'OrgKeywords');
+            expect(orgKeywords).toBeDefined();
+            expect(orgKeywords!.type).toBe('array');
+            expect(orgKeywords!.isRequired).toBe(true);
+
+            // Plain (non-loop) parameter still works.
+            const startYear = params.find(p => p.name === 'StartYear');
+            expect(startYear).toBeDefined();
+            expect(startYear!.type).toBe('number');
+
+            // Loop local must NOT leak as a parameter — the validator would
+            // otherwise reject every save with "Required parameter 'kw' is missing".
+            expect(params.find(p => p.name === 'kw')).toBeUndefined();
+
+            // Nunjucks built-ins must NOT leak either (loop.last → loop, last).
+            expect(params.find(p => p.name === 'loop')).toBeUndefined();
+            expect(params.find(p => p.name === 'last')).toBeUndefined();
+        });
     });
 
     describe('Table extraction from real-world queries', () => {

--- a/packages/SQLParser/src/__tests__/extract-parameter-info-loops.test.ts
+++ b/packages/SQLParser/src/__tests__/extract-parameter-info-loops.test.ts
@@ -1,0 +1,155 @@
+/**
+ * Regression tests for ExtractParameterInfo handling of `{% for ... in ... %}`
+ * Nunjucks loops.
+ *
+ * Bug B from Skip-Brain query rendering triage:
+ *   `ExtractParameterInfo` walks every `{{ var | filters }}` template
+ *   expression and registers `var` as a query parameter. When `var` is
+ *   actually a loop-local variable bound by a surrounding `{% for var in
+ *   iterable %}` block, this is wrong:
+ *     - The loop variable (`kw`) is NOT a parameter the caller can supply.
+ *     - The iterable (`OrgKeywords`) IS a parameter, but currently goes
+ *       unregistered because it appears only inside a `{% for %}` block tag.
+ *
+ *   The downstream effect: when the validator runs against caller-provided
+ *   parameters, it reports both "Required parameter 'kw' is missing" and
+ *   "Unknown parameter: 'OrgKeywords'" — even though Skip's SQL is valid.
+ *
+ * Source: Skip-Brain run 0FEF1C47-92DD-411C-8107-511E9CE42362, step
+ *   "Create Client Query: Session Speaker Participation By Organization".
+ *
+ * See SKIP-QUERY-RENDERING-BUGS.md at the MJ repo root for the full
+ * triage write-up.
+ */
+import { describe, it, expect } from 'vitest';
+import { SQLParser } from '../sql-parser.js';
+
+const extractParameterInfo = SQLParser.ExtractParameterInfo.bind(SQLParser);
+
+// ============================================================================
+// Edge case SQL strings (verbatim from Skip-Brain failures where applicable)
+// ============================================================================
+
+/**
+ * Skip run 0FEF1C47 — "Session Speaker Participation By Organization".
+ * Skip's Query Designer wrote this SQL; the validator rejected it.
+ */
+const SKIP_FOR_LOOP_OVER_ARRAY = `WITH [Target_Employees] AS (
+    SELECT DISTINCT [FullName]
+    FROM (
+        SELECT LTRIM(RTRIM(ISNULL([FirstName], '') + ' ' + ISNULL([LastName], ''))) AS [FullName]
+        FROM [ym].[vwMembers]
+        WHERE (
+            {% for kw in OrgKeywords %}
+            [EmployerName] LIKE {{ kw | sqlLikeContains }} {% if not loop.last %}OR {% endif %}
+            {% endfor %}
+        )
+    ) [e]
+    WHERE [e].[FullName] IS NOT NULL AND [e].[FullName] <> ''
+)
+SELECT *
+FROM [document].[vwSessions] s
+WHERE YEAR(s.[Date]) >= {{ StartYear | sqlNumber }}
+  AND YEAR(s.[Date]) <= {{ EndYear | sqlNumber }}`;
+
+/** Loop variable referenced via dotted property access (loop.last). */
+const FOR_LOOP_WITH_LOOP_LAST = `{% for kw in tags %}
+    [Tag] = {{ kw | sqlString }} {% if not loop.last %}OR {% endif %}
+{% endfor %}`;
+
+/** Loop iterable used elsewhere too — should be registered exactly once. */
+const FOR_LOOP_ITERABLE_USED_OUTSIDE = `WHERE 1 = 1
+{% if MemberTypes %}
+    AND [MemberTypeCode] IN (
+        {% for mt in MemberTypes %}
+            {{ mt | sqlString }}{% if not loop.last %}, {% endif %}
+        {% endfor %}
+    )
+{% endif %}`;
+
+/**
+ * Mixed: loop-driven IN clause AND a separate parameter outside the loop.
+ * Both `OrgKeywords` (loop iterable) and `StartYear` (outside) must be
+ * registered; loop-local `kw` must NOT.
+ */
+const FOR_LOOP_AND_PLAIN_PARAMS = `SELECT *
+FROM [Sessions] s
+WHERE (
+    {% for kw in OrgKeywords %}
+        [EmployerName] LIKE {{ kw | sqlLikeContains }} {% if not loop.last %}OR {% endif %}
+    {% endfor %}
+)
+AND YEAR(s.[Date]) >= {{ StartYear | sqlNumber }}`;
+
+// ============================================================================
+// Tests
+// ============================================================================
+
+describe('ExtractParameterInfo — Nunjucks {% for %} loops (Skip Bug B)', () => {
+    it('registers the loop iterable as a parameter (Skip 0FEF1C47)', () => {
+        const params = extractParameterInfo(SKIP_FOR_LOOP_OVER_ARRAY);
+        const orgKeywords = params.find(p => p.name === 'OrgKeywords');
+
+        expect(orgKeywords).toBeDefined();
+        // Caller must provide it — the SQL has no `{% if OrgKeywords %}` guard.
+        expect(orgKeywords!.isRequired).toBe(true);
+        // The iterable feeds a `{% for %}` block, so it should be inferred as array.
+        expect(orgKeywords!.type).toBe('array');
+    });
+
+    it('does NOT register the loop variable as a parameter (Skip 0FEF1C47)', () => {
+        const params = extractParameterInfo(SKIP_FOR_LOOP_OVER_ARRAY);
+        const kw = params.find(p => p.name === 'kw');
+        expect(kw).toBeUndefined();
+    });
+
+    it('does NOT register loop.last / loop.* as a parameter', () => {
+        const params = extractParameterInfo(FOR_LOOP_WITH_LOOP_LAST);
+
+        // Loop-local `kw` must not leak.
+        expect(params.find(p => p.name === 'kw')).toBeUndefined();
+
+        // `loop`, `loop.last`, etc. are Nunjucks-internal — not user parameters.
+        expect(params.find(p => p.name === 'loop')).toBeUndefined();
+        expect(params.find(p => p.name === 'loop.last')).toBeUndefined();
+        expect(params.find(p => p.name === 'loop.first')).toBeUndefined();
+    });
+
+    it('still registers the iterable when it appears only inside the {% for %} tag', () => {
+        const params = extractParameterInfo(FOR_LOOP_WITH_LOOP_LAST);
+        const tags = params.find(p => p.name === 'tags');
+        expect(tags).toBeDefined();
+        expect(tags!.type).toBe('array');
+    });
+
+    it('keeps non-loop parameters working alongside a loop iterable', () => {
+        const params = extractParameterInfo(FOR_LOOP_AND_PLAIN_PARAMS);
+
+        expect(params.find(p => p.name === 'OrgKeywords')).toBeDefined();
+        expect(params.find(p => p.name === 'StartYear')).toBeDefined();
+
+        // Loop-local must not leak.
+        expect(params.find(p => p.name === 'kw')).toBeUndefined();
+    });
+
+    it('marks iterable as optional when guarded by {% if iterable %}', () => {
+        const params = extractParameterInfo(FOR_LOOP_ITERABLE_USED_OUTSIDE);
+        const memberTypes = params.find(p => p.name === 'MemberTypes');
+
+        expect(memberTypes).toBeDefined();
+        // `{% if MemberTypes %}` makes it optional (same convention as
+        // existing condition-guarded parameters).
+        expect(memberTypes!.isRequired).toBe(false);
+
+        // Loop-local must not leak.
+        expect(params.find(p => p.name === 'mt')).toBeUndefined();
+    });
+
+    it('does not double-register the iterable when used in both the for tag and elsewhere', () => {
+        // FOR_LOOP_ITERABLE_USED_OUTSIDE references MemberTypes only once
+        // (in the for tag and the if condition). Should appear exactly once.
+        const params = extractParameterInfo(FOR_LOOP_ITERABLE_USED_OUTSIDE);
+        const memberTypesCount = params.filter(p => p.name === 'MemberTypes').length;
+        expect(memberTypesCount).toBe(1);
+    });
+});

--- a/packages/SQLParser/src/sql-parser.ts
+++ b/packages/SQLParser/src/sql-parser.ts
@@ -729,31 +729,124 @@ export class SQLParser {
 
     /**
      * Extract parameter metadata from template expressions.
+     *
+     * Walks tokens with a lexical-scope stack so that loop-local variables
+     * introduced by `{% for X in Y %}` blocks are NOT registered as query
+     * parameters (they're rebound on each iteration; callers can't supply
+     * them). The iterable side of `{% for %}` (`Y`) IS registered as a
+     * parameter — typically `array` and required, unless wrapped in
+     * `{% if Y %}` which makes it optional.
+     *
+     * Skip-Brain Bug B: previously this function treated `{{ kw }}` inside
+     * `{% for kw in OrgKeywords %}` as a required parameter and failed to
+     * register `OrgKeywords` at all. See `__tests__/extract-parameter-info-loops.test.ts`
+     * and `SKIP-QUERY-RENDERING-BUGS.md` (Bug B) at the repo root.
+     *
      * Infers type from filters, isRequired from conditional block context.
      */
     static ExtractParameterInfo(sql: string): MJParameterInfo[] {
         const tokens = MJLexer.Tokenize(sql);
         const paramMap = new Map<string, MJParameterInfo>();
 
+        // Lexical scope stack: each entry is the set of loop-local variable
+        // names introduced by an enclosing {% for %} block.
+        const loopScopes: Set<string>[] = [];
+        // Set of every loop-local identifier ever introduced during the walk
+        // (across all scopes). Used to filter out names that
+        // `findConditionalVariables` may have picked up from {% if %} guards
+        // surrounding a {{ loopLocal }} expression.
+        const everSeenLoopLocals = new Set<string>();
+        const isLoopLocal = (variable: string): boolean => {
+            // Match the root identifier (e.g. `kw` in `kw.foo`, `kw` in `kw|filter`).
+            const root = variable.split(/[.\s|]/, 1)[0];
+            for (const scope of loopScopes) {
+                if (scope.has(root)) return true;
+            }
+            return false;
+        };
+
+        // Track which iterables appear in {% for X in Y %} so we can register
+        // them as array parameters even if Y is never used in a {{ }} expression.
+        // Maps iterable name → whether it appears outside a containing {% if %}
+        // block (used only to differentiate required vs optional later).
+        const loopIterables = new Map<string, { isRequired: boolean }>();
+        let conditionalDepth = 0;
+
         for (const token of tokens) {
-            if (token.type === 'MJ_TEMPLATE_EXPR') {
-                const parsed = token.parsed as MJTemplateExprContent;
-                const varName = parsed.variable;
-
-                if (!paramMap.has(varName)) {
-                    paramMap.set(varName, {
-                        name: varName,
-                        type: SQLParser.inferTypeFromFilters(parsed.filters),
-                        isRequired: true,
-                        defaultValue: SQLParser.extractDefaultValue(parsed.filters),
-                        filters: parsed.filters,
-                        usageLocations: [],
-                    });
+            switch (token.type) {
+                case 'MJ_FOR_OPEN': {
+                    const parsed = token.parsed as MJBlockTagContent;
+                    loopScopes.push(new Set(parsed.loopVariable ? [parsed.loopVariable] : []));
+                    if (parsed.loopVariable) {
+                        everSeenLoopLocals.add(parsed.loopVariable);
+                    }
+                    if (parsed.loopIterable) {
+                        // Iterable identifier — strip filters/whitespace so
+                        // `tags | sort` becomes `tags`.
+                        const iterableName = parsed.loopIterable.split(/[.\s|]/, 1)[0];
+                        if (iterableName && !SQLParser.JINJA_KEYWORDS.has(iterableName.toLowerCase())) {
+                            const existing = loopIterables.get(iterableName);
+                            // Required only when the for tag is at the top level
+                            // (not wrapped in any {% if %}). If wrapped, the iterable
+                            // becomes optional — same convention as condition-only vars.
+                            const isRequired = existing
+                                ? existing.isRequired || conditionalDepth === 0
+                                : conditionalDepth === 0;
+                            loopIterables.set(iterableName, { isRequired });
+                        }
+                    }
+                    break;
                 }
+                case 'MJ_ENDFOR':
+                    loopScopes.pop();
+                    break;
+                case 'MJ_IF_OPEN':
+                    conditionalDepth++;
+                    break;
+                case 'MJ_ENDIF':
+                    conditionalDepth = Math.max(0, conditionalDepth - 1);
+                    break;
+                case 'MJ_TEMPLATE_EXPR': {
+                    const parsed = token.parsed as MJTemplateExprContent;
+                    const varName = parsed.variable;
 
-                paramMap.get(varName)!.usageLocations.push(token.raw);
+                    // Skip if the variable's root is a loop local, or if the
+                    // variable is a Nunjucks built-in (loop, loop.last, etc.).
+                    if (isLoopLocal(varName)) break;
+                    const root = varName.split(/[.\s]/, 1)[0];
+                    if (root.toLowerCase() === 'loop') break;
+
+                    if (!paramMap.has(varName)) {
+                        paramMap.set(varName, {
+                            name: varName,
+                            type: SQLParser.inferTypeFromFilters(parsed.filters),
+                            isRequired: true,
+                            defaultValue: SQLParser.extractDefaultValue(parsed.filters),
+                            filters: parsed.filters,
+                            usageLocations: [],
+                        });
+                    }
+
+                    paramMap.get(varName)!.usageLocations.push(token.raw);
+                    break;
+                }
             }
         }
+
+        // Predicates used to filter out names that look like parameters but
+        // are actually loop locals or Nunjucks built-ins.
+        const isLoopBuiltin = (varName: string): boolean => {
+            const root = varName.split(/[.\s]/, 1)[0].toLowerCase();
+            // `loop` is the Nunjucks-provided namespace inside {% for %} blocks
+            // (`loop.last`, `loop.first`, `loop.index`, etc.). Members of the
+            // namespace get extracted as bare identifiers (`last`, `first`,
+            // `index`) by addConditionVariables's regex split.
+            return root === 'loop'
+                || root === 'last' || root === 'first'
+                || root === 'index' || root === 'index0'
+                || root === 'revindex' || root === 'revindex0'
+                || root === 'length' || root === 'cycle';
+        };
 
         const conditionalVars = SQLParser.findConditionalVariables(tokens);
         for (const [varName, param] of paramMap) {
@@ -765,12 +858,43 @@ export class SQLParser {
         // Variables that appear only in {% if %}/{% elif %} condition expressions
         // (never in a {{ }} template expression) still need to be surfaced as
         // optional parameters so callers can supply them at runtime.
+        // EXCEPT: loop locals (introduced by {% for %}), Nunjucks loop built-ins
+        // (loop, loop.last, etc.), and identifiers we've already classified as
+        // loop iterables.
         for (const varName of conditionalVars.onlyInConditional) {
-            if (!paramMap.has(varName)) {
-                paramMap.set(varName, {
-                    name: varName,
-                    type: 'string',
-                    isRequired: false,
+            if (paramMap.has(varName)) continue;
+            const root = varName.split(/[.\s]/, 1)[0];
+            if (everSeenLoopLocals.has(root)) continue;
+            if (isLoopBuiltin(varName)) continue;
+            if (loopIterables.has(varName)) continue;
+            paramMap.set(varName, {
+                name: varName,
+                type: 'string',
+                isRequired: false,
+                defaultValue: null,
+                filters: [],
+                usageLocations: [],
+            });
+        }
+
+        // Register loop iterables that aren't already in the param map.
+        // If the iterable is also referenced as a {{ }} expression elsewhere
+        // (already in paramMap), keep its existing entry but ensure it's marked
+        // as array type — the {% for %} usage is a stronger type signal.
+        for (const [iterableName, { isRequired }] of loopIterables) {
+            const existing = paramMap.get(iterableName);
+            if (existing) {
+                existing.type = 'array';
+                // If the iterable also appears inside an {% if %} guard, keep
+                // it optional; if it's at top level somewhere, mark required.
+                if (!conditionalVars.onlyInConditional.has(iterableName)) {
+                    existing.isRequired = existing.isRequired && isRequired;
+                }
+            } else {
+                paramMap.set(iterableName, {
+                    name: iterableName,
+                    type: 'array',
+                    isRequired,
                     defaultValue: null,
                     filters: [],
                     usageLocations: [],


### PR DESCRIPTION
## Summary
- **Query composition pipeline**: Repair three regressions surfaced by Skip-Brain in `queryCompositionEngine` and `SQLParser`, with a new `skip-failure-regressions.test.ts` suite plus added `MJQueryEntityServer` and `extract-parameter-info-loops` tests
- **Conversations UI**: Clear stale test-feedback dialog state when switching conversations in the `ng-conversations` chat area
- **Tag engine**: Strip tag IDs from the taxonomy context injected into LLM prompts (AutotagBaseEngine / AutotagEntity)
- **Last-run-date lookup**: Exclude in-progress runs so the result reflects only completed runs

## Test plan
- [ ] `cd packages/GenericDatabaseProvider && npm run test` — confirm new `skip-failure-regressions` suite and existing query-composition tests pass
- [ ] `cd packages/SQLParser && npm run test` — confirm `extract-parameter-info-loops` tests pass
- [ ] `cd packages/MJCoreEntitiesServer && npm run test` — confirm `MJQueryEntityServer` tests pass
- [ ] In MJExplorer, switch between conversations with an open test-feedback dialog and verify it resets cleanly
- [ ] Run an autotag with a taxonomy attached and verify the prompt no longer includes tag IDs
- [ ] Trigger a last-run-date lookup while a run is in-progress and verify only completed runs are considered

🤖 Generated with [Claude Code](https://claude.com/claude-code)