### PR TITLE
fix(ng-search): reduce excessive search API calls during typing

### DIFF
--- a/.changeset/gentle-waves-rest.md
+++ b/.changeset/gentle-waves-rest.md
@@ -1,0 +1,5 @@
+---
+"@memberjunction/ng-search": patch
+---
+
+Increase search debounce from 200ms to 400ms, add distinctUntilChanged, and add stale-request guards to reduce excessive API calls during typing

--- a/packages/Angular/Generic/search/src/lib/search-composite.component.ts
+++ b/packages/Angular/Generic/search/src/lib/search-composite.component.ts
@@ -50,7 +50,7 @@ export class SearchCompositeComponent implements OnInit, OnDestroy {
     @Input() ShowShortcutHint = true;
 
     /** Debounce time in milliseconds for query changes */
-    @Input() DebounceMs = 200;
+    @Input() DebounceMs = 400;
 
     /** Minimum query length before preview results are fetched */
     @Input() MinQueryLength = 2;
@@ -88,6 +88,7 @@ export class SearchCompositeComponent implements OnInit, OnDestroy {
     public RecentSearches: RecentSearch[] = [];
     public PreviewTotalCount = 0;
     public IsPreviewLoading = false;
+    private previewSearchVersion = 0;
 
     ngOnInit(): void {
         this.subscribeToRecentSearches();
@@ -229,22 +230,27 @@ export class SearchCompositeComponent implements OnInit, OnDestroy {
     }
 
     private async executePreviewSearch(query: string): Promise<void> {
+        const version = ++this.previewSearchVersion;
         this.IsPreviewLoading = true;
         this.cdr.detectChanges();
 
         try {
             const response = await this.searchService.PreviewSearch(query, this.MaxPreviewResults);
-            // Only apply if query hasn't changed since we started
-            if (this.Query === query) {
+            // Only apply if this is still the latest request and query hasn't changed
+            if (version === this.previewSearchVersion && this.Query === query) {
                 this.PreviewResults = response.Results;
                 this.PreviewTotalCount = response.TotalCount;
             }
         } catch {
-            this.PreviewResults = [];
-            this.PreviewTotalCount = 0;
+            if (version === this.previewSearchVersion) {
+                this.PreviewResults = [];
+                this.PreviewTotalCount = 0;
+            }
         } finally {
-            this.IsPreviewLoading = false;
-            this.cdr.detectChanges();
+            if (version === this.previewSearchVersion) {
+                this.IsPreviewLoading = false;
+                this.cdr.detectChanges();
+            }
         }
     }
 

--- a/packages/Angular/Generic/search/src/lib/search-input.component.ts
+++ b/packages/Angular/Generic/search/src/lib/search-input.component.ts
@@ -19,7 +19,7 @@ import {
     inject
 } from '@angular/core';
 import { Subject } from 'rxjs';
-import { debounceTime, takeUntil } from 'rxjs/operators';
+import { debounceTime, distinctUntilChanged, takeUntil } from 'rxjs/operators';
 
 @Component({
     standalone: false,
@@ -60,7 +60,7 @@ export class SearchInputComponent implements OnInit, OnDestroy {
     @Input() ShortcutHint = 'Ctrl+K';
 
     /** Debounce time in milliseconds before QueryChange emits */
-    @Input() DebounceMs = 200;
+    @Input() DebounceMs = 400;
 
     // --- Outputs ---
 
@@ -162,6 +162,7 @@ export class SearchInputComponent implements OnInit, OnDestroy {
         this.queryInput$
             .pipe(
                 debounceTime(this.DebounceMs),
+                distinctUntilChanged(),
                 takeUntil(this.destroy$)
             )
             .subscribe(value => {

--- a/packages/Angular/Generic/search/src/lib/search-overlay.component.ts
+++ b/packages/Angular/Generic/search/src/lib/search-overlay.component.ts
@@ -23,7 +23,7 @@ import {
     inject
 } from '@angular/core';
 import { Subject } from 'rxjs';
-import { debounceTime, takeUntil } from 'rxjs/operators';
+import { debounceTime, distinctUntilChanged, takeUntil } from 'rxjs/operators';
 import { SearchService } from './search.service';
 import {
     SearchResultItem,
@@ -76,7 +76,7 @@ export class SearchOverlayComponent implements OnInit, OnDestroy {
     }
 
     /** Debounce time in ms before search fires */
-    @Input() DebounceMs = 250;
+    @Input() DebounceMs = 400;
 
     /** Which search sources to include */
     @Input() IncludeSources: ('vector' | 'fulltext' | 'entity')[] = ['vector', 'fulltext', 'entity'];
@@ -110,6 +110,7 @@ export class SearchOverlayComponent implements OnInit, OnDestroy {
     public ElapsedMs = 0;
     public HighlightedIndex = -1;
     public HasSearched = false;
+    private searchVersion = 0;
 
     /** All results flattened for keyboard navigation */
     public get FlatResults(): SearchResultItem[] {
@@ -281,6 +282,7 @@ export class SearchOverlayComponent implements OnInit, OnDestroy {
         this.searchInput$
             .pipe(
                 debounceTime(this.DebounceMs),
+                distinctUntilChanged(),
                 takeUntil(this.destroy$)
             )
             .subscribe(() => this.executeSearch());
@@ -302,6 +304,8 @@ export class SearchOverlayComponent implements OnInit, OnDestroy {
             return;
         }
 
+        const version = ++this.searchVersion;
+
         const request: SearchRequest = {
             Query: query,
             MaxResults: this.MaxResults,
@@ -310,6 +314,12 @@ export class SearchOverlayComponent implements OnInit, OnDestroy {
         };
 
         const response = await this.searchService.ExecuteSearch(request);
+
+        // Discard results if a newer search was triggered while this one was in-flight
+        if (version !== this.searchVersion) {
+            return;
+        }
+
         this.AllResults = response.Results;
         this.ResultGroups = response.Groups;
         this.Filters = response.Filters;


### PR DESCRIPTION
## Summary
- Increased debounce from 200ms to 400ms across all search components (input, composite, overlay) to reduce intermediate API calls while typing
- Added `distinctUntilChanged()` to debounce pipelines to prevent duplicate queries from firing
- Added version-counter stale-request guards in both composite (`executePreviewSearch`) and overlay (`executeSearch`) to discard responses from superseded in-flight requests

## Test plan
- [ ] Type a multi-word query (e.g. "Robert Kihm") in the Home Dashboard search box and verify only 1-2 PreviewSearch calls fire (instead of 6+)
- [ ] Verify search results still appear correctly after typing stops
- [ ] Verify Ctrl+K overlay search also debounces properly
- [ ] Verify Enter still submits immediately without waiting for debounce
- [ ] Verify clearing the search input resets results correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)