### PR TITLE
AI Model Research Report — 2026-04-18

### DIFF
--- a/metadata/ai-models/.ai-models.json
+++ b/metadata/ai-models/.ai-models.json
@@ -11609,5 +11609,470 @@
       "lastModified": "2026-03-17T01:57:33.714Z",
       "checksum": "a41c2b101e9565ea597222242b095036ac8e36e64141b26d711c869cba06b2d4"
     }
+  },
+  {
+    "fields": {
+      "Name": "Claude Opus 4.7",
+      "PowerRank": 23,
+      "Description": "Anthropic's most capable generally available model. Released April 16, 2026. Features a 1M token context window at standard pricing, 128K max output tokens, adaptive thinking (default off; must be explicitly enabled), a new xhigh effort level, task budgets (beta), and high-resolution image support (up to 2576px / 3.75MP with 1:1 pixel coordinate mapping). Uses a new tokenizer that may produce 1.0x-1.35x as many tokens as Opus 4.6 for equivalent text. Improvements over 4.6 on long-horizon agentic work, knowledge work (Office doc redlining, PPTX editing, chart analysis), memory/scratchpad use, and vision.",
+      "AIModelTypeID": "@lookup:MJ: AI Model Types.Name=LLM",
+      "IsActive": true,
+      "SpeedRank": 7,
+      "CostRank": 10,
+      "InheritTypeModalities": true,
+      "PriorVersionID": "@lookup:MJ: AI Models.Name=Claude Opus 4.6"
+    },
+    "relatedEntities": {
+      "MJ: AI Model Vendors": [
+        {
+          "fields": {
+            "ModelID": "@parent:ID",
+            "VendorID": "@lookup:MJ: AI Vendors.Name=Anthropic",
+            "Priority": 0,
+            "Status": "Active",
+            "SupportedResponseFormats": "Any",
+            "SupportsEffortLevel": true,
+            "SupportsStreaming": false,
+            "TypeID": "@lookup:MJ: AI Vendor Type Definitions.Name=Model Developer"
+          }
+        },
+        {
+          "fields": {
+            "ModelID": "@parent:ID",
+            "VendorID": "@lookup:MJ: AI Vendors.Name=Anthropic",
+            "Priority": 1,
+            "Status": "Active",
+            "DriverClass": "AnthropicLLM",
+            "APIName": "claude-opus-4-7",
+            "MaxInputTokens": 1000000,
+            "MaxOutputTokens": 128000,
+            "SupportedResponseFormats": "Any, JSON",
+            "SupportsEffortLevel": true,
+            "SupportsStreaming": true,
+            "TypeID": "@lookup:MJ: AI Vendor Type Definitions.Name=Inference Provider"
+          }
+        },
+        {
+          "fields": {
+            "ModelID": "@parent:ID",
+            "VendorID": "@lookup:MJ: AI Vendors.Name=Amazon Bedrock",
+            "Priority": 5,
+            "Status": "Active",
+            "DriverClass": "BedrockLLM",
+            "APIName": "anthropic.claude-opus-4-7-v1",
+            "MaxInputTokens": 1000000,
+            "MaxOutputTokens": 128000,
+            "SupportedResponseFormats": "Any, JSON",
+            "SupportsEffortLevel": true,
+            "SupportsStreaming": true,
+            "TypeID": "@lookup:MJ: AI Vendor Type Definitions.Name=Inference Provider"
+          }
+        }
+      ],
+      "MJ: AI Model Costs": [
+        {
+          "fields": {
+            "ModelID": "@parent:ID",
+            "VendorID": "@lookup:MJ: AI Vendors.Name=Anthropic",
+            "StartedAt": "2026-04-16T00:00:00.000Z",
+            "Status": "Active",
+            "Currency": "USD",
+            "PriceTypeID": "@lookup:MJ: AI Model Price Types.Name=Tokens",
+            "InputPricePerUnit": 5,
+            "OutputPricePerUnit": 25,
+            "UnitTypeID": "@lookup:MJ: AI Model Price Unit Types.Name=Per 1M Tokens",
+            "ProcessingType": "Realtime",
+            "Comments": "Claude Opus 4.7 pricing on Anthropic as of April 16, 2026 launch. Rates match Opus 4.6 ($5/$25 per 1M tokens) but the new tokenizer may use up to 35% more tokens for equivalent text, increasing effective cost per request. Full 1M context at standard pricing. Prompt caching (up to 90% savings) and batch processing (50% savings) available."
+          }
+        },
+        {
+          "fields": {
+            "ModelID": "@parent:ID",
+            "VendorID": "@lookup:MJ: AI Vendors.Name=Amazon Bedrock",
+            "StartedAt": "2026-04-16T00:00:00.000Z",
+            "Status": "Active",
+            "Currency": "USD",
+            "PriceTypeID": "@lookup:MJ: AI Model Price Types.Name=Tokens",
+            "InputPricePerUnit": 5,
+            "OutputPricePerUnit": 25,
+            "UnitTypeID": "@lookup:MJ: AI Model Price Unit Types.Name=Per 1M Tokens",
+            "ProcessingType": "Realtime",
+            "Comments": "Claude Opus 4.7 pricing on Amazon Bedrock as of April 2026 launch. Matches Anthropic direct pricing."
+          }
+        }
+      ]
+    }
+  },
+  {
+    "fields": {
+      "Name": "GPT 5.4 Mini",
+      "PowerRank": 13,
+      "Description": "OpenAI's mid-tier variant of the GPT 5.4 family, released March 17, 2026. Brings GPT 5.4's core capabilities (reasoning, computer-use, coding) at substantially lower cost with 400K token context window and 128K output. Supports adjustable reasoning via reasoning_effort (none, low, medium, high, xhigh). Knowledge cutoff August 31, 2025. Designed for high-volume workloads where full GPT 5.4 is overkill.",
+      "AIModelTypeID": "@lookup:MJ: AI Model Types.Name=LLM",
+      "IsActive": true,
+      "SpeedRank": 8,
+      "CostRank": 4,
+      "InheritTypeModalities": true,
+      "PriorVersionID": "@lookup:MJ: AI Models.Name=GPT 5-mini"
+    },
+    "relatedEntities": {
+      "MJ: AI Model Vendors": [
+        {
+          "fields": {
+            "ModelID": "@parent:ID",
+            "VendorID": "@lookup:MJ: AI Vendors.Name=OpenAI",
+            "Priority": 0,
+            "Status": "Active",
+            "SupportedResponseFormats": "Any",
+            "SupportsEffortLevel": true,
+            "SupportsStreaming": false,
+            "TypeID": "@lookup:MJ: AI Vendor Type Definitions.Name=Model Developer"
+          }
+        },
+        {
+          "fields": {
+            "ModelID": "@parent:ID",
+            "VendorID": "@lookup:MJ: AI Vendors.Name=OpenAI",
+            "Priority": 1,
+            "Status": "Active",
+            "DriverClass": "OpenAILLM",
+            "APIName": "gpt-5.4-mini",
+            "MaxInputTokens": 400000,
+            "MaxOutputTokens": 128000,
+            "SupportedResponseFormats": "Any, JSON",
+            "SupportsEffortLevel": true,
+            "SupportsStreaming": true,
+            "TypeID": "@lookup:MJ: AI Vendor Type Definitions.Name=Inference Provider"
+          }
+        },
+        {
+          "fields": {
+            "ModelID": "@parent:ID",
+            "VendorID": "@lookup:MJ: AI Vendors.Name=Azure",
+            "Priority": 5,
+            "Status": "Active",
+            "DriverClass": "AzureLLM",
+            "APIName": "gpt-5.4-mini",
+            "MaxInputTokens": 400000,
+            "MaxOutputTokens": 128000,
+            "SupportedResponseFormats": "Any, JSON",
+            "SupportsEffortLevel": false,
+            "SupportsStreaming": true,
+            "TypeID": "@lookup:MJ: AI Vendor Type Definitions.Name=Inference Provider"
+          }
+        }
+      ],
+      "MJ: AI Model Costs": [
+        {
+          "fields": {
+            "ModelID": "@parent:ID",
+            "VendorID": "@lookup:MJ: AI Vendors.Name=OpenAI",
+            "StartedAt": "2026-03-17T00:00:00.000Z",
+            "Status": "Active",
+            "Currency": "USD",
+            "PriceTypeID": "@lookup:MJ: AI Model Price Types.Name=Tokens",
+            "InputPricePerUnit": 0.75,
+            "OutputPricePerUnit": 4.5,
+            "UnitTypeID": "@lookup:MJ: AI Model Price Unit Types.Name=Per 1M Tokens",
+            "ProcessingType": "Realtime",
+            "Comments": "GPT 5.4 Mini pricing on OpenAI as of March 2026. Regional processing (data residency) endpoints are charged a 10% uplift. Batch API offers 50% discount."
+          }
+        },
+        {
+          "fields": {
+            "ModelID": "@parent:ID",
+            "VendorID": "@lookup:MJ: AI Vendors.Name=Azure",
+            "StartedAt": "2026-03-17T00:00:00.000Z",
+            "Status": "Active",
+            "Currency": "USD",
+            "PriceTypeID": "@lookup:MJ: AI Model Price Types.Name=Tokens",
+            "InputPricePerUnit": 0.75,
+            "OutputPricePerUnit": 4.5,
+            "UnitTypeID": "@lookup:MJ: AI Model Price Unit Types.Name=Per 1M Tokens",
+            "ProcessingType": "Realtime",
+            "Comments": "GPT-5.4 Mini pricing on Azure OpenAI (Global Standard) as of March 2026."
+          }
+        }
+      ]
+    }
+  },
+  {
+    "fields": {
+      "Name": "GPT 5.4 Nano",
+      "PowerRank": 11,
+      "Description": "OpenAI's smallest, cheapest member of the GPT 5.4 family, released March 17, 2026. Best suited for classification, data extraction, ranking, and sub-agent workloads where speed and cost matter most. 400K token context window with 128K output. Supports reasoning tokens and adjustable reasoning_effort. Knowledge cutoff August 31, 2025. A significant upgrade over GPT 5 nano.",
+      "AIModelTypeID": "@lookup:MJ: AI Model Types.Name=LLM",
+      "IsActive": true,
+      "SpeedRank": 9,
+      "CostRank": 2,
+      "InheritTypeModalities": true,
+      "PriorVersionID": "@lookup:MJ: AI Models.Name=GPT 5-nano"
+    },
+    "relatedEntities": {
+      "MJ: AI Model Vendors": [
+        {
+          "fields": {
+            "ModelID": "@parent:ID",
+            "VendorID": "@lookup:MJ: AI Vendors.Name=OpenAI",
+            "Priority": 0,
+            "Status": "Active",
+            "SupportedResponseFormats": "Any",
+            "SupportsEffortLevel": true,
+            "SupportsStreaming": false,
+            "TypeID": "@lookup:MJ: AI Vendor Type Definitions.Name=Model Developer"
+          }
+        },
+        {
+          "fields": {
+            "ModelID": "@parent:ID",
+            "VendorID": "@lookup:MJ: AI Vendors.Name=OpenAI",
+            "Priority": 1,
+            "Status": "Active",
+            "DriverClass": "OpenAILLM",
+            "APIName": "gpt-5.4-nano",
+            "MaxInputTokens": 400000,
+            "MaxOutputTokens": 128000,
+            "SupportedResponseFormats": "Any, JSON",
+            "SupportsEffortLevel": true,
+            "SupportsStreaming": true,
+            "TypeID": "@lookup:MJ: AI Vendor Type Definitions.Name=Inference Provider"
+          }
+        },
+        {
+          "fields": {
+            "ModelID": "@parent:ID",
+            "VendorID": "@lookup:MJ: AI Vendors.Name=Azure",
+            "Priority": 5,
+            "Status": "Active",
+            "DriverClass": "AzureLLM",
+            "APIName": "gpt-5.4-nano",
+            "MaxInputTokens": 400000,
+            "MaxOutputTokens": 128000,
+            "SupportedResponseFormats": "Any, JSON",
+            "SupportsEffortLevel": false,
+            "SupportsStreaming": true,
+            "TypeID": "@lookup:MJ: AI Vendor Type Definitions.Name=Inference Provider"
+          }
+        }
+      ],
+      "MJ: AI Model Costs": [
+        {
+          "fields": {
+            "ModelID": "@parent:ID",
+            "VendorID": "@lookup:MJ: AI Vendors.Name=OpenAI",
+            "StartedAt": "2026-03-17T00:00:00.000Z",
+            "Status": "Active",
+            "Currency": "USD",
+            "PriceTypeID": "@lookup:MJ: AI Model Price Types.Name=Tokens",
+            "InputPricePerUnit": 0.2,
+            "OutputPricePerUnit": 1.25,
+            "UnitTypeID": "@lookup:MJ: AI Model Price Unit Types.Name=Per 1M Tokens",
+            "ProcessingType": "Realtime",
+            "Comments": "GPT 5.4 Nano pricing on OpenAI as of March 2026. Regional processing (data residency) endpoints charged 10% uplift. Batch API offers 50% discount."
+          }
+        },
+        {
+          "fields": {
+            "ModelID": "@parent:ID",
+            "VendorID": "@lookup:MJ: AI Vendors.Name=Azure",
+            "StartedAt": "2026-03-17T00:00:00.000Z",
+            "Status": "Active",
+            "Currency": "USD",
+            "PriceTypeID": "@lookup:MJ: AI Model Price Types.Name=Tokens",
+            "InputPricePerUnit": 0.2,
+            "OutputPricePerUnit": 1.25,
+            "UnitTypeID": "@lookup:MJ: AI Model Price Unit Types.Name=Per 1M Tokens",
+            "ProcessingType": "Realtime",
+            "Comments": "GPT-5.4 Nano pricing on Azure OpenAI (Global Standard) as of March 2026."
+          }
+        }
+      ]
+    }
+  },
+  {
+    "fields": {
+      "Name": "Grok 4.20 (Reasoning)",
+      "PowerRank": 22,
+      "Description": "xAI's flagship reasoning model released March 31, 2026. Activates internal chain-of-thought processing before responding for higher scores on complex reasoning benchmarks at the cost of more output tokens. Features a 2M token context window, industry-leading speed, agentic tool calling, the lowest hallucination rate among current frontier models, and strict prompt adherence. Reasoning is automatic — no reasoning_effort parameter required. xAI also offers a non-reasoning variant at identical pricing.",
+      "AIModelTypeID": "@lookup:MJ: AI Model Types.Name=LLM",
+      "IsActive": true,
+      "SpeedRank": 7,
+      "CostRank": 6,
+      "InheritTypeModalities": true,
+      "PriorVersionID": "@lookup:MJ: AI Models.Name=Grok 4"
+    },
+    "relatedEntities": {
+      "MJ: AI Model Vendors": [
+        {
+          "fields": {
+            "ModelID": "@parent:ID",
+            "VendorID": "@lookup:MJ: AI Vendors.Name=x.ai",
+            "Priority": 0,
+            "Status": "Active",
+            "SupportedResponseFormats": "Any",
+            "SupportsEffortLevel": false,
+            "SupportsStreaming": false,
+            "TypeID": "@lookup:MJ: AI Vendor Type Definitions.Name=Model Developer"
+          }
+        },
+        {
+          "fields": {
+            "ModelID": "@parent:ID",
+            "VendorID": "@lookup:MJ: AI Vendors.Name=x.ai",
+            "Priority": 0,
+            "Status": "Active",
+            "DriverClass": "xAILLM",
+            "APIName": "grok-4.20-0309-reasoning",
+            "MaxInputTokens": 2000000,
+            "MaxOutputTokens": 128000,
+            "SupportedResponseFormats": "Any, JSON",
+            "SupportsEffortLevel": false,
+            "SupportsStreaming": true,
+            "TypeID": "@lookup:MJ: AI Vendor Type Definitions.Name=Inference Provider"
+          }
+        }
+      ],
+      "MJ: AI Model Costs": [
+        {
+          "fields": {
+            "ModelID": "@parent:ID",
+            "VendorID": "@lookup:MJ: AI Vendors.Name=x.ai",
+            "StartedAt": "2026-03-31T00:00:00.000Z",
+            "Status": "Active",
+            "Currency": "USD",
+            "PriceTypeID": "@lookup:MJ: AI Model Price Types.Name=Tokens",
+            "InputPricePerUnit": 2,
+            "OutputPricePerUnit": 6,
+            "UnitTypeID": "@lookup:MJ: AI Model Price Unit Types.Name=Per 1M Tokens",
+            "ProcessingType": "Realtime",
+            "Comments": "Grok 4.20 (Reasoning) pricing on x.ai as of March 31, 2026 launch. Reasoning variant consumes more output tokens than non-reasoning. Tool call pricing dropped ~50% to no more than $5 per 1,000 successful calls."
+          }
+        }
+      ]
+    }
+  },
+  {
+    "fields": {
+      "Name": "Grok 4.20 (Non-Reasoning)",
+      "PowerRank": 18,
+      "Description": "xAI's flagship non-reasoning model released March 31, 2026. Same 2M token context window and agentic tool calling as the reasoning variant, but skips internal chain-of-thought for faster, cheaper responses on tasks that don't benefit from explicit reasoning. Industry-leading speed, lowest hallucination rate among current frontier models, strict prompt adherence.",
+      "AIModelTypeID": "@lookup:MJ: AI Model Types.Name=LLM",
+      "IsActive": true,
+      "SpeedRank": 9,
+      "CostRank": 6,
+      "InheritTypeModalities": true,
+      "PriorVersionID": "@lookup:MJ: AI Models.Name=Grok 4"
+    },
+    "relatedEntities": {
+      "MJ: AI Model Vendors": [
+        {
+          "fields": {
+            "ModelID": "@parent:ID",
+            "VendorID": "@lookup:MJ: AI Vendors.Name=x.ai",
+            "Priority": 0,
+            "Status": "Active",
+            "SupportedResponseFormats": "Any",
+            "SupportsEffortLevel": false,
+            "SupportsStreaming": false,
+            "TypeID": "@lookup:MJ: AI Vendor Type Definitions.Name=Model Developer"
+          }
+        },
+        {
+          "fields": {
+            "ModelID": "@parent:ID",
+            "VendorID": "@lookup:MJ: AI Vendors.Name=x.ai",
+            "Priority": 0,
+            "Status": "Active",
+            "DriverClass": "xAILLM",
+            "APIName": "grok-4.20-0309-non-reasoning",
+            "MaxInputTokens": 2000000,
+            "MaxOutputTokens": 128000,
+            "SupportedResponseFormats": "Any, JSON",
+            "SupportsEffortLevel": false,
+            "SupportsStreaming": true,
+            "TypeID": "@lookup:MJ: AI Vendor Type Definitions.Name=Inference Provider"
+          }
+        }
+      ],
+      "MJ: AI Model Costs": [
+        {
+          "fields": {
+            "ModelID": "@parent:ID",
+            "VendorID": "@lookup:MJ: AI Vendors.Name=x.ai",
+            "StartedAt": "2026-03-31T00:00:00.000Z",
+            "Status": "Active",
+            "Currency": "USD",
+            "PriceTypeID": "@lookup:MJ: AI Model Price Types.Name=Tokens",
+            "InputPricePerUnit": 2,
+            "OutputPricePerUnit": 6,
+            "UnitTypeID": "@lookup:MJ: AI Model Price Unit Types.Name=Per 1M Tokens",
+            "ProcessingType": "Realtime",
+            "Comments": "Grok 4.20 (Non-Reasoning) pricing on x.ai as of March 31, 2026 launch. Identical to reasoning variant rates. Tool call pricing dropped ~50% to no more than $5 per 1,000 successful calls."
+          }
+        }
+      ]
+    }
+  },
+  {
+    "fields": {
+      "Name": "Mistral Small 4",
+      "PowerRank": 10,
+      "Description": "Mistral AI's unified multi-capability model released March 16, 2026. Consolidates the former Magistral (reasoning), Pixtral (multimodal vision), and Devstral (agentic coding) product lines into a single 119B-parameter Mixture-of-Experts model with only 6B active parameters per token. 262K token context window. Open-weight under Apache 2.0. Strong multimodal reasoning + coding at very low cost.",
+      "AIModelTypeID": "@lookup:MJ: AI Model Types.Name=LLM",
+      "IsActive": true,
+      "SpeedRank": 8,
+      "CostRank": 2,
+      "InheritTypeModalities": true,
+      "PriorVersionID": "@lookup:MJ: AI Models.Name=Mistral Small 3.2"
+    },
+    "relatedEntities": {
+      "MJ: AI Model Vendors": [
+        {
+          "fields": {
+            "ModelID": "@parent:ID",
+            "VendorID": "@lookup:MJ: AI Vendors.Name=Mistral AI",
+            "Priority": 0,
+            "Status": "Active",
+            "SupportedResponseFormats": "Any",
+            "SupportsEffortLevel": false,
+            "SupportsStreaming": false,
+            "TypeID": "@lookup:MJ: AI Vendor Type Definitions.Name=Model Developer"
+          }
+        },
+        {
+          "fields": {
+            "ModelID": "@parent:ID",
+            "VendorID": "@lookup:MJ: AI Vendors.Name=Mistral AI",
+            "Priority": 1,
+            "Status": "Active",
+            "DriverClass": "MistralLLM",
+            "APIName": "mistral-small-2603",
+            "MaxInputTokens": 262144,
+            "MaxOutputTokens": 128000,
+            "SupportedResponseFormats": "Any, JSON",
+            "SupportsEffortLevel": false,
+            "SupportsStreaming": true,
+            "TypeID": "@lookup:MJ: AI Vendor Type Definitions.Name=Inference Provider"
+          }
+        }
+      ],
+      "MJ: AI Model Costs": [
+        {
+          "fields": {
+            "ModelID": "@parent:ID",
+            "VendorID": "@lookup:MJ: AI Vendors.Name=Mistral AI",
+            "StartedAt": "2026-03-16T00:00:00.000Z",
+            "Status": "Active",
+            "Currency": "USD",
+            "PriceTypeID": "@lookup:MJ: AI Model Price Types.Name=Tokens",
+            "InputPricePerUnit": 0.15,
+            "OutputPricePerUnit": 0.6,
+            "UnitTypeID": "@lookup:MJ: AI Model Price Unit Types.Name=Per 1M Tokens",
+            "ProcessingType": "Realtime",
+            "Comments": "Mistral Small 4 pricing on Mistral AI as of March 16, 2026 launch. 119B MoE (6B active per token). Apache 2.0 open-weight. Unifies former Magistral / Pixtral / Devstral lineups."
+          }
+        }
+      ]
+    }
   }
 ]

--- a/reports/ai-model-research/2026-04-18-weekly-report.md
+++ b/reports/ai-model-research/2026-04-18-weekly-report.md
@@ -1,0 +1,174 @@
+# AI Model & Vendor Weekly Intelligence Report
+**Generated**: 2026-04-18
+**Research Period**: Approximately 2026-03-17 → 2026-04-18 (since last inventory update)
+**Base Branch**: next
+**Branch**: claude/ai-model-research-2026-04-18
+
+## Executive Summary
+Five production-ready new models have shipped since the last MJ inventory update and are being added in this report: **Claude Opus 4.7** (Anthropic, Apr 16), **GPT 5.4 Mini** and **GPT 5.4 Nano** (OpenAI, Mar 17), **Grok 4.20** (xAI, Mar 31), and **Mistral Small 4** (Mistral AI, Mar 16). No pricing changes were detected on the existing inventory (rates held steady). Several other emerging models — DeepSeek V4, Qwen 3.5-Flash / Qwen 3.5 Medium, Kimi K2.6 Code Preview — are flagged for human review but intentionally not added to the JSON due to missing vendor, unclear pricing, or preview-only status.
+
+## Current Inventory Snapshot
+
+| Category | Count |
+|---|---|
+| Total models in `.ai-models.json` | 111 |
+| Cohere reranker models (separate file) | 2 |
+| Active LLMs | ~80 |
+| Vendors registered | 22 |
+
+Primary LLM vendors currently covered: Anthropic, OpenAI, Google, Vertex AI, Amazon Bedrock, Azure, Mistral AI, x.ai, Groq, Cerebras, Fireworks.ai, Alibaba Cloud, Moonshot AI, Z.AI, MiniMax, OpenRouter, Black Forest Labs, LM Studio, Cohere, Eleven Labs, HeyGen, Tasio Labs, LocalEmbeddings.
+
+## New Models Available
+
+### 1. Claude Opus 4.7 (Anthropic) — **ADDING**
+| Attribute | Value |
+|---|---|
+| API name (Anthropic) | `claude-opus-4-7` |
+| API name (Bedrock) | `anthropic.claude-opus-4-7-v1` |
+| Release date | 2026-04-16 |
+| Input price | $5.00 per 1M tokens |
+| Output price | $25.00 per 1M tokens |
+| Context window | 1,000,000 tokens |
+| Max output | 128,000 tokens |
+| Capabilities | Adaptive thinking, `xhigh` effort level, task budgets (beta), high-resolution image support (2576px), 1M context at standard pricing |
+
+**Rationale to add**: Anthropic's new flagship, GA on both Anthropic API and Amazon Bedrock. Same per-token rates as Opus 4.6 but with better agentic coding, memory, and vision performance. Note that the new tokenizer may use up to 1.35x more tokens for the same text, so effective cost per request can increase. PowerRank set to 23 (incrementing from 4.6's 22).
+
+### 2. GPT 5.4 Mini (OpenAI) — **ADDING**
+| Attribute | Value |
+|---|---|
+| API name | `gpt-5.4-mini` |
+| Release date | 2026-03-17 |
+| Input price | $0.75 per 1M tokens |
+| Output price | $4.50 per 1M tokens |
+| Context window | 400,000 tokens |
+| Max output | 128,000 tokens |
+| Available on | OpenAI, Azure |
+| Knowledge cutoff | 2025-08-31 |
+
+**Rationale to add**: Mid-tier variant of the GPT 5.4 family — brings full 5.4 capability at substantially lower cost (70% cheaper input than full GPT 5.4). Strongly competitive mid-tier option. PowerRank 13 (between GPT 5-nano at 12 and GPT 5-mini at 15).
+
+### 3. GPT 5.4 Nano (OpenAI) — **ADDING**
+| Attribute | Value |
+|---|---|
+| API name | `gpt-5.4-nano` |
+| Release date | 2026-03-17 |
+| Input price | $0.20 per 1M tokens |
+| Output price | $1.25 per 1M tokens |
+| Context window | 400,000 tokens |
+| Max output | 128,000 tokens |
+| Available on | OpenAI, Azure |
+| Knowledge cutoff | 2025-08-31 |
+
+**Rationale to add**: Smallest, cheapest member of the 5.4 family. Designed for classification, extraction, ranking, and sub-agent workloads. Undercuts almost every alternative on input price. PowerRank 11.
+
+### 4. Grok 4.20 (x.ai) — **ADDING**
+| Attribute | Value |
+|---|---|
+| API name (reasoning) | `grok-4.20-0309-reasoning` |
+| API name (non-reasoning) | `grok-4.20-0309-non-reasoning` |
+| Release date | 2026-03-31 |
+| Input price | $2.00 per 1M tokens |
+| Output price | $6.00 per 1M tokens |
+| Context window | 2,000,000 tokens |
+| Max output | 128,000 tokens |
+
+**Rationale to add**: xAI's newest flagship. 2M context at $2/$6 is aggressively priced vs Claude/GPT 5.4 flagships. Reasoning and non-reasoning variants ship under the same price. Multi-agent variant (`grok-4.20-multi-agent-0309`) also available at identical pricing but not added to avoid clutter — can be added later if adopted. PowerRank 22 (above Grok 4's 19 since this is xAI's new top model).
+
+### 5. Mistral Small 4 (Mistral AI) — **ADDING**
+| Attribute | Value |
+|---|---|
+| API name | `mistral-small-2603` |
+| Release date | 2026-03-16 |
+| Input price | $0.15 per 1M tokens |
+| Output price | $0.60 per 1M tokens |
+| Context window | 262,144 tokens |
+| Max output | 128,000 tokens |
+| Architecture | 119B-param MoE (6B active), Apache 2.0 |
+
+**Rationale to add**: Unifies Magistral (reasoning) + Pixtral (vision) + Devstral (agentic coding) into one model. Open-weights and cheaper than Mistral Medium 3.1. PowerRank 10 (above Small 3.2's 6, below Medium 3.1's 8 would be odd — bumping to 10 to reflect the multi-capability merge).
+
+## Pricing Changes Detected
+
+**No pricing changes** were detected on models already in the inventory during this research period. Claude Opus 4.7 pricing matches Opus 4.6 ($5/$25). Existing OpenAI, Anthropic, Mistral, Groq, x.ai, and Google models all match their current published rates.
+
+## Model Updates & New Versions
+
+### Grok Model Lineage (Noted, No Edit)
+Grok 4.20 supersedes Grok 4 as xAI's flagship. However, Grok 4 remains available on the API, so we are keeping it `IsActive: true`. The older `grok-4-0709` is still the generally recommended model for some users.
+
+### Gemini Free Tier Changes (Noted, No Edit)
+As of 2026-04-01, Google tightened the Gemini free tier — Pro-series models (Gemini 3 Pro, Gemini 3.1 Pro) are now paid-only; Flash and Flash-Lite remain in the free tier. This does not change API pricing itself and no inventory edit is required.
+
+## Deprecated / Sunset Models
+
+No models in the current inventory have been announced for sunset/deprecation in this research window. (The already-`IsActive: false` models — Claude 3 Haiku, Claude 3 Sonnet, claude-v1, GPT 4, GPT 3.5, Llama 3.1 70b, Gemini 1.0 Ultra — remain marked inactive.)
+
+## New Vendors Worth Considering
+
+### DeepSeek (flagged, not adding)
+DeepSeek V4 was released in early March 2026 at $0.30 input / $0.50 output per 1M tokens with a 1M-token context window and ~81% SWE-bench Verified. DeepSeek is **not currently an MJ vendor**. Adding it would require:
+1. A new entry in `.ai-vendors.json` for the DeepSeek vendor
+2. Confirmation of the exact API model name (search results variously suggest `deepseek-v4` and `deepseek-chat`)
+3. Confirmation whether the existing `OpenAILLM` driver can be reused via base URL override, or whether a new `DeepSeekLLM` driver class is needed
+
+Recommended for human review — not included in this PR's JSON edits.
+
+## Recommended Actions
+
+Ordered by impact:
+
+1. **(High)** Review and merge the Claude Opus 4.7 addition — this is the new production flagship across Anthropic, Bedrock, Vertex AI, and Azure Foundry. Customers running agentic workloads will likely ask for it. **[Done in this PR]**
+2. **(High)** Review and merge the GPT 5.4 Mini/Nano additions. These are now OpenAI's most cost-competitive serious models and likely to be adopted for medium- and low-cost tiers. **[Done in this PR]**
+3. **(Medium)** Review and merge Grok 4.20 — new xAI flagship with attractive pricing at 2M context. **[Done in this PR]**
+4. **(Medium)** Review and merge Mistral Small 4 — significant model lineage consolidation, strong multimodal + coding at very low cost. **[Done in this PR]**
+5. **(Medium)** Consider adding DeepSeek as a new vendor with DeepSeek V4 (manual decision — requires driver class + vendor entry).
+6. **(Low)** Watch for Kimi K3 (announced but no release date) and Qwen3.5 Medium (open-weights available, API pricing pending). Re-evaluate next cycle.
+7. **(Low)** Consider whether the multi-agent Grok 4.20 variant (`grok-4.20-multi-agent-0309`) should be a separate MJ model entry or a future option.
+
+## Research Sources
+
+### Anthropic
+- [What's new in Claude Opus 4.7 — Claude API Docs](https://platform.claude.com/docs/en/about-claude/models/whats-new-claude-4-7)
+- [Introducing Claude Opus 4.7 — Anthropic](https://www.anthropic.com/news/claude-opus-4-7)
+- [Claude Opus 4.7 in Amazon Bedrock — AWS](https://aws.amazon.com/blogs/aws/introducing-anthropics-claude-opus-4-7-model-in-amazon-bedrock/)
+- [Claude Opus 4.7 — Amazon Bedrock model card](https://docs.aws.amazon.com/bedrock/latest/userguide/model-card-anthropic-claude-opus-4-7.html)
+- [Anthropic releases Claude Opus 4.7 — VentureBeat](https://venturebeat.com/technology/anthropic-releases-claude-opus-4-7-narrowly-retaking-lead-for-most-powerful-generally-available-llm)
+
+### OpenAI
+- [Introducing GPT-5.4 mini and nano — OpenAI](https://openai.com/index/introducing-gpt-5-4-mini-and-nano/)
+- [GPT-5.4 mini Model — OpenAI API docs](https://developers.openai.com/api/docs/models/gpt-5.4-mini)
+- [GPT-5.4 nano Model — OpenAI API docs](https://developers.openai.com/api/docs/models/gpt-5.4-nano)
+- [OpenAI API Pricing](https://openai.com/api/pricing/)
+
+### xAI
+- [Models and Pricing — xAI Docs](https://docs.x.ai/developers/models)
+- [Grok 4.20 0309 Reasoning — xAI Docs](https://docs.x.ai/developers/models/grok-4.20-0309-reasoning)
+- [xAI Grok API Pricing 2026 — mem0.ai](https://mem0.ai/blog/xai-grok-api-pricing)
+
+### Mistral AI
+- [Changelog — Mistral Docs](https://docs.mistral.ai/getting-started/changelog)
+- [Mistral Small 4 — Puter Developer](https://developer.puter.com/ai/mistralai/mistral-small-2603/)
+- [Mistral Small 4 on Hugging Face](https://huggingface.co/mistralai/Mistral-Small-4-119B-2603)
+- [Mistral AI Pricing](https://mistral.ai/pricing)
+
+### Google
+- [Gemini API Pricing Guide — aipricing.guru](https://www.aipricing.guru/google-ai-pricing/)
+- [Release notes — Gemini API](https://ai.google.dev/gemini-api/docs/changelog)
+
+### DeepSeek (flagged, not added)
+- [DeepSeek V4 Specs & API Pricing — Morph](https://www.morphllm.com/deepseek-v4)
+- [Models & Pricing — DeepSeek API Docs](https://api-docs.deepseek.com/quick_start/pricing)
+
+### Alibaba / Qwen (flagged, not added)
+- [Alibaba's Qwen3.5-Medium — VentureBeat](https://venturebeat.com/technology/alibabas-new-open-source-qwen3-5-medium-models-offer-sonnet-4-5-performance)
+- [Alibaba Cloud Model Studio pricing](https://www.alibabacloud.com/help/en/model-studio/model-pricing)
+
+### Moonshot AI (flagged, not added)
+- [Kimi Code K2.6 Preview — Buildfast](https://www.buildfastwithai.com/blogs/kimi-code-k26-preview-2026)
+
+### Black Forest Labs (confirmed no changes)
+- [FLUX API Pricing](https://bfl.ai/pricing)
+
+### Cohere (confirmed no changes)
+- [Cohere Pricing](https://cohere.com/pricing)


### PR DESCRIPTION
## Summary

Weekly AI model and vendor intelligence research covering the period 2026-03-17 → 2026-04-18.

**Findings:**
- **5 new models added** (6 entries, with Grok 4.20 split into reasoning + non-reasoning variants)
- **0 pricing changes** detected on existing inventory
- **0 new deprecations** this cycle

## New Models Added to `.ai-models.json`

| Model | Vendor | Context | Input/Output per 1M |
|---|---|---|---|
| Claude Opus 4.7 | Anthropic + Bedrock | 1M / 128k | $5 / $25 |
| GPT 5.4 Mini | OpenAI + Azure | 400k / 128k | $0.75 / $4.50 |
| GPT 5.4 Nano | OpenAI + Azure | 400k / 128k | $0.20 / $1.25 |
| Grok 4.20 (Reasoning) | x.ai | 2M / 128k | $2 / $6 |
| Grok 4.20 (Non-Reasoning) | x.ai | 2M / 128k | $2 / $6 |
| Mistral Small 4 | Mistral AI | 262k / 128k | $0.15 / $0.60 |

## Flagged for Human Review (Not Added)

- **DeepSeek V4** — requires new vendor entry + driver class decision
- **Qwen 3.5 Medium** — pricing unclear, API availability pending
- **Kimi K2.6 Code Preview** — still preview-only status
- **Grok 4.20 multi-agent variant** — can be added later if adopted

## Full Report

See [`reports/ai-model-research/2026-04-18-weekly-report.md`](../blob/claude/ai-model-research-2026-04-18/reports/ai-model-research/2026-04-18-weekly-report.md) for complete research notes, rationales, and source links.

## Test plan

- [ ] Verify `.ai-models.json` parses as valid JSON (117 models total, up from 111)
- [ ] Run `npx mj sync push --dry-run --dir=metadata --include="ai-models"` to validate `@lookup:` / `@parent:` references resolve
- [ ] Spot-check PowerRank / SpeedRank / CostRank values against sibling models
- [ ] Confirm both "Model Developer" and "Inference Provider" vendor entries exist for each new model where applicable
- [ ] Review DriverClass values match existing patterns (`AnthropicLLM`, `OpenAILLM`, `AzureLLM`, `BedrockLLM`, `xAILLM`, `MistralLLM`)

https://claude.ai/code/session_01S1VrmR8Lo4N3evDNF7SdPk