### PR TITLE
feat(home-dashboard): pin Actions as quick-launch cards

### DIFF
--- a/.changeset/bolt-pins-launch.md
+++ b/.changeset/bolt-pins-launch.md
@@ -1,0 +1,6 @@
+---
+"@memberjunction/ng-dashboards": patch
+"@memberjunction/ng-shared": patch
+---
+
+Pin Actions as quick-launch cards on the Home dashboard with a configurable title, accent color, FA icon, preset parameter values, and a list of parameters to prompt for at runtime. Adds Configure and Runner dialogs and extends HomeAppPinService with an 'Actions' ResourceType dedup case.

--- a/packages/Angular/Explorer/dashboards/src/Home/action-pin-config-dialog.component.css
+++ b/packages/Angular/Explorer/dashboards/src/Home/action-pin-config-dialog.component.css
@@ -123,20 +123,6 @@
     color: var(--mj-text-inverse, white);
 }
 
-.apc-preview-svg {
-    width: 40px;
-    height: 40px;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    color: var(--mj-text-inverse, white);
-}
-
-.apc-preview-svg svg {
-    width: 100%;
-    height: 100%;
-}
-
 .apc-preview-title {
     font-size: 13px;
     font-weight: 600;
@@ -163,35 +149,6 @@
     font-size: 13px;
     font-weight: 600;
     color: var(--mj-text-secondary);
-}
-
-.apc-field-header {
-    display: flex;
-    align-items: center;
-    justify-content: space-between;
-}
-
-.apc-ai-btn {
-    display: inline-flex;
-    align-items: center;
-    gap: 6px;
-    padding: 6px 12px;
-    background: color-mix(in srgb, var(--mj-brand-primary) 10%, var(--mj-bg-surface));
-    color: var(--mj-brand-primary);
-    border: 1px solid color-mix(in srgb, var(--mj-brand-primary) 30%, transparent);
-    border-radius: 6px;
-    font-size: 12px;
-    font-weight: 500;
-    cursor: pointer;
-}
-
-.apc-ai-btn:hover:not(:disabled) {
-    background: color-mix(in srgb, var(--mj-brand-primary) 15%, var(--mj-bg-surface));
-}
-
-.apc-ai-btn:disabled {
-    opacity: 0.6;
-    cursor: wait;
 }
 
 .apc-color-grid {
@@ -223,10 +180,6 @@
     box-shadow: 0 0 0 2px var(--mj-bg-surface), 0 0 0 4px var(--mj-text-primary);
 }
 
-.apc-hint-input {
-    width: 100%;
-}
-
 .apc-icon-grid {
     display: grid;
     grid-template-columns: repeat(10, 1fr);
@@ -237,10 +190,6 @@
     border: 1px solid var(--mj-border-subtle);
     border-radius: 8px;
     background: var(--mj-bg-surface-sunken);
-}
-
-.apc-icon-grid.dimmed {
-    opacity: 0.5;
 }
 
 .apc-icon-swatch {
@@ -266,61 +215,6 @@
     background: color-mix(in srgb, var(--mj-brand-primary) 15%, var(--mj-bg-surface));
     color: var(--mj-brand-primary);
     border-color: var(--mj-brand-primary);
-}
-
-.apc-ai-result {
-    display: flex;
-    align-items: center;
-    gap: 12px;
-    padding: 12px;
-    background: color-mix(in srgb, var(--mj-brand-primary) 6%, var(--mj-bg-surface));
-    border: 1px solid color-mix(in srgb, var(--mj-brand-primary) 25%, transparent);
-    border-radius: 8px;
-}
-
-.apc-ai-svg-preview {
-    width: 48px;
-    height: 48px;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    background: var(--mj-bg-surface);
-    border-radius: 8px;
-    border: 1px solid var(--mj-border-subtle);
-    flex-shrink: 0;
-}
-
-.apc-ai-svg-preview svg {
-    width: 32px;
-    height: 32px;
-}
-
-.apc-ai-result-info {
-    display: flex;
-    flex-direction: column;
-    gap: 4px;
-}
-
-.apc-ai-result-label {
-    font-size: 13px;
-    font-weight: 600;
-    color: var(--mj-text-primary);
-}
-
-.apc-link-btn {
-    background: transparent;
-    border: none;
-    padding: 0;
-    font-size: 12px;
-    color: var(--mj-text-link);
-    cursor: pointer;
-    display: inline-flex;
-    align-items: center;
-    gap: 4px;
-}
-
-.apc-link-btn:hover {
-    text-decoration: underline;
 }
 
 .apc-params-loading,

--- a/packages/Angular/Explorer/dashboards/src/Home/action-pin-config-dialog.component.css
+++ b/packages/Angular/Explorer/dashboards/src/Home/action-pin-config-dialog.component.css
@@ -1,0 +1,487 @@
+.apc-backdrop {
+    position: fixed;
+    inset: 0;
+    background: var(--mj-bg-overlay);
+    z-index: 9000;
+    animation: apc-fade-in 0.15s ease;
+}
+
+.apc-dialog {
+    position: fixed;
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%);
+    z-index: 9001;
+    width: min(640px, calc(100vw - 32px));
+    max-height: calc(100vh - 48px);
+    background: var(--mj-bg-surface);
+    color: var(--mj-text-primary);
+    border: 1px solid var(--mj-border-default);
+    border-radius: 12px;
+    box-shadow: 0 24px 60px rgba(0, 0, 0, 0.25);
+    display: flex;
+    flex-direction: column;
+    animation: apc-pop-in 0.18s ease;
+}
+
+@keyframes apc-fade-in {
+    from { opacity: 0; }
+    to { opacity: 1; }
+}
+
+@keyframes apc-pop-in {
+    from { opacity: 0; transform: translate(-50%, -48%) scale(0.98); }
+    to { opacity: 1; transform: translate(-50%, -50%) scale(1); }
+}
+
+.apc-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 16px 20px;
+    border-bottom: 1px solid var(--mj-border-subtle);
+}
+
+.apc-header h3 {
+    margin: 0;
+    font-size: 17px;
+    font-weight: 600;
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    color: var(--mj-text-primary);
+}
+
+.apc-header h3 i {
+    color: var(--mj-brand-primary);
+}
+
+.apc-close {
+    background: transparent;
+    border: none;
+    color: var(--mj-text-muted);
+    font-size: 16px;
+    cursor: pointer;
+    padding: 6px 10px;
+    border-radius: 6px;
+}
+
+.apc-close:hover {
+    background: var(--mj-bg-surface-hover);
+    color: var(--mj-text-primary);
+}
+
+.apc-body {
+    padding: 20px;
+    overflow-y: auto;
+    display: flex;
+    flex-direction: column;
+    gap: 20px;
+}
+
+.apc-action-chip {
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
+    padding: 6px 12px;
+    background: var(--mj-bg-surface-sunken);
+    border: 1px solid var(--mj-border-subtle);
+    border-radius: 999px;
+    font-size: 13px;
+    color: var(--mj-text-secondary);
+    align-self: flex-start;
+}
+
+.apc-action-chip i {
+    color: var(--mj-brand-primary);
+}
+
+.apc-preview {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 8px;
+}
+
+.apc-preview-card {
+    width: 180px;
+    height: 120px;
+    border-radius: 10px;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    gap: 8px;
+    color: var(--mj-text-inverse, white);
+    box-shadow: 0 8px 24px rgba(0, 0, 0, 0.15);
+    transition: transform 0.15s ease;
+}
+
+.apc-preview-icon {
+    font-size: 34px;
+    line-height: 1;
+    color: var(--mj-text-inverse, white);
+}
+
+.apc-preview-svg {
+    width: 40px;
+    height: 40px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    color: var(--mj-text-inverse, white);
+}
+
+.apc-preview-svg svg {
+    width: 100%;
+    height: 100%;
+}
+
+.apc-preview-title {
+    font-size: 13px;
+    font-weight: 600;
+    text-align: center;
+    padding: 0 12px;
+    max-width: 100%;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+.apc-preview-hint {
+    font-size: 12px;
+    color: var(--mj-text-muted);
+}
+
+.apc-field {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+}
+
+.apc-field > label {
+    font-size: 13px;
+    font-weight: 600;
+    color: var(--mj-text-secondary);
+}
+
+.apc-field-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+}
+
+.apc-ai-btn {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    padding: 6px 12px;
+    background: color-mix(in srgb, var(--mj-brand-primary) 10%, var(--mj-bg-surface));
+    color: var(--mj-brand-primary);
+    border: 1px solid color-mix(in srgb, var(--mj-brand-primary) 30%, transparent);
+    border-radius: 6px;
+    font-size: 12px;
+    font-weight: 500;
+    cursor: pointer;
+}
+
+.apc-ai-btn:hover:not(:disabled) {
+    background: color-mix(in srgb, var(--mj-brand-primary) 15%, var(--mj-bg-surface));
+}
+
+.apc-ai-btn:disabled {
+    opacity: 0.6;
+    cursor: wait;
+}
+
+.apc-color-grid {
+    display: grid;
+    grid-template-columns: repeat(8, 1fr);
+    gap: 8px;
+}
+
+.apc-color-swatch {
+    width: 100%;
+    aspect-ratio: 1;
+    border-radius: 8px;
+    border: 2px solid transparent;
+    cursor: pointer;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    color: var(--mj-text-inverse, white);
+    font-size: 12px;
+    transition: transform 0.1s ease;
+}
+
+.apc-color-swatch:hover {
+    transform: scale(1.08);
+}
+
+.apc-color-swatch.selected {
+    border-color: var(--mj-text-primary);
+    box-shadow: 0 0 0 2px var(--mj-bg-surface), 0 0 0 4px var(--mj-text-primary);
+}
+
+.apc-hint-input {
+    width: 100%;
+}
+
+.apc-icon-grid {
+    display: grid;
+    grid-template-columns: repeat(10, 1fr);
+    gap: 6px;
+    max-height: 180px;
+    overflow-y: auto;
+    padding: 4px;
+    border: 1px solid var(--mj-border-subtle);
+    border-radius: 8px;
+    background: var(--mj-bg-surface-sunken);
+}
+
+.apc-icon-grid.dimmed {
+    opacity: 0.5;
+}
+
+.apc-icon-swatch {
+    aspect-ratio: 1;
+    background: var(--mj-bg-surface);
+    border: 1px solid transparent;
+    border-radius: 6px;
+    color: var(--mj-text-secondary);
+    cursor: pointer;
+    font-size: 14px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    transition: all 0.1s ease;
+}
+
+.apc-icon-swatch:hover {
+    background: var(--mj-bg-surface-hover);
+    color: var(--mj-text-primary);
+}
+
+.apc-icon-swatch.selected {
+    background: color-mix(in srgb, var(--mj-brand-primary) 15%, var(--mj-bg-surface));
+    color: var(--mj-brand-primary);
+    border-color: var(--mj-brand-primary);
+}
+
+.apc-ai-result {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    padding: 12px;
+    background: color-mix(in srgb, var(--mj-brand-primary) 6%, var(--mj-bg-surface));
+    border: 1px solid color-mix(in srgb, var(--mj-brand-primary) 25%, transparent);
+    border-radius: 8px;
+}
+
+.apc-ai-svg-preview {
+    width: 48px;
+    height: 48px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    background: var(--mj-bg-surface);
+    border-radius: 8px;
+    border: 1px solid var(--mj-border-subtle);
+    flex-shrink: 0;
+}
+
+.apc-ai-svg-preview svg {
+    width: 32px;
+    height: 32px;
+}
+
+.apc-ai-result-info {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+}
+
+.apc-ai-result-label {
+    font-size: 13px;
+    font-weight: 600;
+    color: var(--mj-text-primary);
+}
+
+.apc-link-btn {
+    background: transparent;
+    border: none;
+    padding: 0;
+    font-size: 12px;
+    color: var(--mj-text-link);
+    cursor: pointer;
+    display: inline-flex;
+    align-items: center;
+    gap: 4px;
+}
+
+.apc-link-btn:hover {
+    text-decoration: underline;
+}
+
+.apc-params-loading,
+.apc-params-empty {
+    padding: 16px;
+    text-align: center;
+    font-size: 13px;
+    color: var(--mj-text-muted);
+    background: var(--mj-bg-surface-sunken);
+    border-radius: 8px;
+}
+
+.apc-params-help {
+    font-size: 12px;
+    color: var(--mj-text-muted);
+    margin-bottom: 4px;
+}
+
+.apc-params-help strong {
+    color: var(--mj-text-secondary);
+}
+
+.apc-params-table {
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+    max-height: 260px;
+    overflow-y: auto;
+    padding-right: 4px;
+}
+
+.apc-param-row {
+    display: grid;
+    grid-template-columns: 1fr 160px 1fr;
+    gap: 10px;
+    align-items: center;
+    padding: 10px 12px;
+    background: var(--mj-bg-surface-sunken);
+    border: 1px solid var(--mj-border-subtle);
+    border-radius: 6px;
+}
+
+.apc-param-name {
+    font-size: 13px;
+    font-weight: 600;
+    color: var(--mj-text-primary);
+    display: flex;
+    align-items: center;
+    gap: 6px;
+}
+
+.apc-param-req {
+    font-size: 10px;
+    font-weight: 500;
+    padding: 1px 6px;
+    background: var(--mj-status-warning-bg);
+    color: var(--mj-status-warning-text);
+    border-radius: 3px;
+    text-transform: uppercase;
+    letter-spacing: 0.4px;
+}
+
+.apc-param-desc {
+    font-size: 11px;
+    color: var(--mj-text-muted);
+    margin-top: 2px;
+    line-height: 1.4;
+}
+
+.apc-param-mode {
+    display: flex;
+    gap: 4px;
+    background: var(--mj-bg-surface);
+    border: 1px solid var(--mj-border-subtle);
+    border-radius: 6px;
+    padding: 2px;
+}
+
+.apc-mode-option {
+    flex: 1;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: 4px 8px;
+    border-radius: 4px;
+    font-size: 11px;
+    font-weight: 500;
+    color: var(--mj-text-muted);
+    cursor: pointer;
+    transition: all 0.1s ease;
+}
+
+.apc-mode-option input {
+    display: none;
+}
+
+.apc-mode-option.selected {
+    background: var(--mj-brand-primary);
+    color: var(--mj-text-inverse, white);
+}
+
+.apc-runtime-hint {
+    font-size: 11px;
+    color: var(--mj-text-muted);
+    display: inline-flex;
+    align-items: center;
+    gap: 4px;
+    font-style: italic;
+}
+
+.apc-error {
+    padding: 10px 12px;
+    background: var(--mj-status-error-bg);
+    color: var(--mj-status-error-text);
+    border: 1px solid var(--mj-status-error-border);
+    border-radius: 6px;
+    font-size: 13px;
+    display: flex;
+    align-items: center;
+    gap: 8px;
+}
+
+.apc-footer {
+    display: flex;
+    gap: 8px;
+    padding: 14px 20px;
+    border-top: 1px solid var(--mj-border-subtle);
+    background: var(--mj-bg-surface-card);
+    border-bottom-left-radius: 12px;
+    border-bottom-right-radius: 12px;
+}
+
+.apc-btn {
+    padding: 8px 16px;
+    border-radius: 6px;
+    font-size: 13px;
+    font-weight: 500;
+    cursor: pointer;
+    border: 1px solid var(--mj-border-default);
+    background: var(--mj-bg-surface);
+    color: var(--mj-text-primary);
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+}
+
+.apc-btn:hover:not(:disabled) {
+    background: var(--mj-bg-surface-hover);
+}
+
+.apc-btn.primary {
+    background: var(--mj-brand-primary);
+    color: var(--mj-text-inverse, white);
+    border-color: var(--mj-brand-primary);
+}
+
+.apc-btn.primary:hover:not(:disabled) {
+    background: var(--mj-brand-primary-hover);
+}
+
+.apc-btn:disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
+}

--- a/packages/Angular/Explorer/dashboards/src/Home/action-pin-config-dialog.component.html
+++ b/packages/Angular/Explorer/dashboards/src/Home/action-pin-config-dialog.component.html
@@ -1,0 +1,175 @@
+@if (Visible) {
+  <div class="apc-backdrop" (click)="Cancel()"></div>
+  <div class="apc-dialog" role="dialog" aria-modal="true" aria-labelledby="apc-title">
+    <div class="apc-header">
+      <h3 id="apc-title">
+        <i class="fa-solid fa-thumbtack"></i>
+        Pin Action
+      </h3>
+      <button class="apc-close" (click)="Cancel()" aria-label="Close">
+        <i class="fa-solid fa-xmark"></i>
+      </button>
+    </div>
+
+    <div class="apc-body">
+      <div class="apc-action-chip">
+        <i class="fa-solid fa-bolt"></i>
+        <span>{{ ActionName }}</span>
+      </div>
+
+      <div class="apc-preview">
+        <div class="apc-preview-card" [style.background]="'linear-gradient(135deg, ' + AccentColor + ' 0%, ' + AccentColor + 'cc 100%)'">
+          <div class="apc-preview-icon">
+            @if (SafeSvgIcon) {
+              <div class="apc-preview-svg" [innerHTML]="SafeSvgIcon"></div>
+            } @else {
+              <i [class]="FaIcon"></i>
+            }
+          </div>
+          <div class="apc-preview-title">{{ DisplayName || 'Untitled pin' }}</div>
+        </div>
+        <div class="apc-preview-hint">Live preview of how your pin will look on Home</div>
+      </div>
+
+      <div class="apc-field">
+        <label for="apc-name">Pin title</label>
+        <input id="apc-name" type="text" class="mj-input"
+               [(ngModel)]="DisplayName"
+               placeholder="e.g. Run Weekly Sales Report" />
+      </div>
+
+      <div class="apc-field">
+        <label>Accent color</label>
+        <div class="apc-color-grid">
+          @for (c of ColorPalette; track c.value) {
+            <button type="button"
+                    class="apc-color-swatch"
+                    [class.selected]="AccentColor === c.value"
+                    [style.background]="c.value"
+                    [attr.aria-label]="c.name"
+                    (click)="SelectColor(c.value)">
+              @if (AccentColor === c.value) {
+                <i class="fa-solid fa-check"></i>
+              }
+            </button>
+          }
+        </div>
+      </div>
+
+      <div class="apc-field">
+        <div class="apc-field-header">
+          <label>Icon</label>
+          <button type="button" class="apc-ai-btn"
+                  [disabled]="IsGeneratingIcon"
+                  (click)="GenerateAiIcon()">
+            @if (IsGeneratingIcon) {
+              <i class="fa-solid fa-spinner fa-spin"></i> Generating…
+            } @else {
+              <i class="fa-solid fa-wand-magic-sparkles"></i> Generate with AI
+            }
+          </button>
+        </div>
+        @if (SafeSvgIcon) {
+          <div class="apc-ai-result">
+            <div class="apc-ai-svg-preview" [style.color]="AccentColor" [innerHTML]="SafeSvgIcon"></div>
+            <div class="apc-ai-result-info">
+              <div class="apc-ai-result-label">AI-generated icon</div>
+              <button type="button" class="apc-link-btn" (click)="ClearSvgIcon()">
+                <i class="fa-solid fa-xmark"></i> Clear and use an icon below
+              </button>
+            </div>
+          </div>
+        }
+        <input type="text" class="mj-input apc-hint-input"
+               [(ngModel)]="AiHint"
+               [disabled]="IsGeneratingIcon"
+               placeholder="Optional: describe the icon style (e.g. 'minimalist rocket')" />
+        <div class="apc-icon-grid" [class.dimmed]="SafeSvgIcon">
+          @for (icon of FaIconPalette; track icon) {
+            <button type="button"
+                    class="apc-icon-swatch"
+                    [class.selected]="!SafeSvgIcon && FaIcon === icon"
+                    (click)="SelectFaIcon(icon)">
+              <i [class]="icon"></i>
+            </button>
+          }
+        </div>
+      </div>
+
+      <div class="apc-field">
+        <label>Parameters</label>
+        @if (IsLoadingParams) {
+          <div class="apc-params-loading">
+            <i class="fa-solid fa-spinner fa-spin"></i> Loading parameters…
+          </div>
+        } @else if (Params.length === 0) {
+          <div class="apc-params-empty">This action takes no input parameters.</div>
+        } @else {
+          <div class="apc-params-help">
+            Choose which parameters are <strong>preset</strong> (baked into the pin) vs.
+            <strong>prompted at runtime</strong> each time the pin is clicked.
+          </div>
+          <div class="apc-params-table">
+            @for (p of Params; track p.Name) {
+              <div class="apc-param-row">
+                <div class="apc-param-info">
+                  <div class="apc-param-name">
+                    {{ p.Name }}
+                    @if (p.IsRequired) { <span class="apc-param-req">required</span> }
+                  </div>
+                  @if (p.Description) {
+                    <div class="apc-param-desc">{{ p.Description }}</div>
+                  }
+                </div>
+                <div class="apc-param-mode">
+                  <label class="apc-mode-option" [class.selected]="p.Mode === 'preset'">
+                    <input type="radio"
+                           [name]="'mode-' + p.Name"
+                           [checked]="p.Mode === 'preset'"
+                           (change)="SetParamMode(p, 'preset')" />
+                    <span>Preset</span>
+                  </label>
+                  <label class="apc-mode-option" [class.selected]="p.Mode === 'runtime'">
+                    <input type="radio"
+                           [name]="'mode-' + p.Name"
+                           [checked]="p.Mode === 'runtime'"
+                           (change)="SetParamMode(p, 'runtime')" />
+                    <span>Prompt</span>
+                  </label>
+                </div>
+                <div class="apc-param-value">
+                  @if (p.Mode === 'preset') {
+                    <input type="text" class="mj-input"
+                           [(ngModel)]="p.PresetValue"
+                           [placeholder]="p.DefaultValue || 'Preset value'" />
+                  } @else {
+                    <span class="apc-runtime-hint">
+                      <i class="fa-solid fa-keyboard"></i> Asked at click time
+                    </span>
+                  }
+                </div>
+              </div>
+            }
+          </div>
+        }
+      </div>
+
+      @if (ErrorMessage) {
+        <div class="apc-error">
+          <i class="fa-solid fa-triangle-exclamation"></i> {{ ErrorMessage }}
+        </div>
+      }
+    </div>
+
+    <div class="apc-footer">
+      <button type="button" class="apc-btn primary"
+              [disabled]="!CanSave()"
+              (click)="Save()">
+        <i class="fa-solid fa-thumbtack"></i> Pin to Home
+      </button>
+      <button type="button" class="apc-btn" (click)="Cancel()">
+        Cancel
+      </button>
+    </div>
+  </div>
+}

--- a/packages/Angular/Explorer/dashboards/src/Home/action-pin-config-dialog.component.html
+++ b/packages/Angular/Explorer/dashboards/src/Home/action-pin-config-dialog.component.html
@@ -20,11 +20,7 @@
       <div class="apc-preview">
         <div class="apc-preview-card" [style.background]="'linear-gradient(135deg, ' + AccentColor + ' 0%, ' + AccentColor + 'cc 100%)'">
           <div class="apc-preview-icon">
-            @if (SafeSvgIcon) {
-              <div class="apc-preview-svg" [innerHTML]="SafeSvgIcon"></div>
-            } @else {
-              <i [class]="FaIcon"></i>
-            }
+            <i [class]="FaIcon"></i>
           </div>
           <div class="apc-preview-title">{{ DisplayName || 'Untitled pin' }}</div>
         </div>
@@ -57,38 +53,12 @@
       </div>
 
       <div class="apc-field">
-        <div class="apc-field-header">
-          <label>Icon</label>
-          <button type="button" class="apc-ai-btn"
-                  [disabled]="IsGeneratingIcon"
-                  (click)="GenerateAiIcon()">
-            @if (IsGeneratingIcon) {
-              <i class="fa-solid fa-spinner fa-spin"></i> Generating…
-            } @else {
-              <i class="fa-solid fa-wand-magic-sparkles"></i> Generate with AI
-            }
-          </button>
-        </div>
-        @if (SafeSvgIcon) {
-          <div class="apc-ai-result">
-            <div class="apc-ai-svg-preview" [style.color]="AccentColor" [innerHTML]="SafeSvgIcon"></div>
-            <div class="apc-ai-result-info">
-              <div class="apc-ai-result-label">AI-generated icon</div>
-              <button type="button" class="apc-link-btn" (click)="ClearSvgIcon()">
-                <i class="fa-solid fa-xmark"></i> Clear and use an icon below
-              </button>
-            </div>
-          </div>
-        }
-        <input type="text" class="mj-input apc-hint-input"
-               [(ngModel)]="AiHint"
-               [disabled]="IsGeneratingIcon"
-               placeholder="Optional: describe the icon style (e.g. 'minimalist rocket')" />
-        <div class="apc-icon-grid" [class.dimmed]="SafeSvgIcon">
+        <label>Icon</label>
+        <div class="apc-icon-grid">
           @for (icon of FaIconPalette; track icon) {
             <button type="button"
                     class="apc-icon-swatch"
-                    [class.selected]="!SafeSvgIcon && FaIcon === icon"
+                    [class.selected]="FaIcon === icon"
                     (click)="SelectFaIcon(icon)">
               <i [class]="icon"></i>
             </button>

--- a/packages/Angular/Explorer/dashboards/src/Home/action-pin-config-dialog.component.ts
+++ b/packages/Angular/Explorer/dashboards/src/Home/action-pin-config-dialog.component.ts
@@ -1,8 +1,6 @@
 import { Component, Input, Output, EventEmitter, OnChanges, SimpleChanges, ChangeDetectorRef, ViewEncapsulation } from '@angular/core';
-import { DomSanitizer, SafeHtml } from '@angular/platform-browser';
-import { Metadata, RunView } from '@memberjunction/core';
+import { RunView } from '@memberjunction/core';
 import { MJActionParamEntity } from '@memberjunction/core-entities';
-import { GraphQLAIClient, GraphQLDataProvider } from '@memberjunction/graphql-dataprovider';
 
 /**
  * One row in the param configuration table — either a preset-value or a runtime-prompted param.
@@ -27,7 +25,6 @@ export interface ActionPinConfigResult {
         ActionName: string;
         AccentColor: string;
         FaIcon: string;
-        SvgIcon?: string;
         PresetParams: Record<string, string>;
         RuntimeParamNames: string[];
     };
@@ -57,15 +54,6 @@ const FA_ICON_PALETTE = [
     'fa-solid fa-cloud', 'fa-solid fa-cube', 'fa-solid fa-thumbtack'
 ];
 
-const ICON_SYSTEM_PROMPT = `You are an expert icon designer. Generate a single, minimal, modern SVG icon (viewBox="0 0 24 24") that visually represents the user's action.
-
-Strict rules:
-- Output ONLY the raw SVG markup, no markdown fences, no prose, no commentary
-- Use currentColor for strokes/fills so the icon inherits the pin's accent color
-- Keep it simple: at most 6 shapes, stroke-width 1.5, rounded caps
-- Do NOT include <?xml?>, <!DOCTYPE>, or width/height attributes — only viewBox
-- Must start with <svg and end with </svg>`;
-
 @Component({
     standalone: false,
     selector: 'mj-action-pin-config-dialog',
@@ -86,17 +74,13 @@ export class ActionPinConfigDialogComponent implements OnChanges {
     public DisplayName = '';
     public AccentColor: string = COLOR_PALETTE[0].value;
     public FaIcon = FA_ICON_PALETTE[0];
-    public SvgIcon: string | null = null;
-    public SafeSvgIcon: SafeHtml | null = null;
-    public AiHint = '';
 
     public Params: ActionPinParamConfig[] = [];
 
     public IsLoadingParams = false;
-    public IsGeneratingIcon = false;
     public ErrorMessage: string | null = null;
 
-    constructor(private cdr: ChangeDetectorRef, private sanitizer: DomSanitizer) {}
+    constructor(private cdr: ChangeDetectorRef) {}
 
     ngOnChanges(changes: SimpleChanges): void {
         if (changes['Visible'] && this.Visible && this.ActionID) {
@@ -109,13 +93,9 @@ export class ActionPinConfigDialogComponent implements OnChanges {
         this.DisplayName = this.ActionName ?? '';
         this.AccentColor = COLOR_PALETTE[0].value;
         this.FaIcon = FA_ICON_PALETTE[0];
-        this.SvgIcon = null;
-        this.SafeSvgIcon = null;
-        this.AiHint = '';
         this.Params = [];
         this.ErrorMessage = null;
         this.IsLoadingParams = false;
-        this.IsGeneratingIcon = false;
     }
 
     private async loadParams(): Promise<void> {
@@ -157,70 +137,12 @@ export class ActionPinConfigDialogComponent implements OnChanges {
 
     SelectFaIcon(icon: string): void {
         this.FaIcon = icon;
-        this.SvgIcon = null;
-        this.SafeSvgIcon = null;
-        this.cdr.markForCheck();
-    }
-
-    ClearSvgIcon(): void {
-        this.SvgIcon = null;
-        this.SafeSvgIcon = null;
         this.cdr.markForCheck();
     }
 
     SetParamMode(param: ActionPinParamConfig, mode: 'preset' | 'runtime'): void {
         param.Mode = mode;
         this.cdr.markForCheck();
-    }
-
-    async GenerateAiIcon(): Promise<void> {
-        if (this.IsGeneratingIcon) return;
-        this.IsGeneratingIcon = true;
-        this.ErrorMessage = null;
-        this.cdr.markForCheck();
-        try {
-            const userMessage = this.buildIconPromptMessage();
-            const provider = Metadata.Provider as GraphQLDataProvider;
-            const aiClient = new GraphQLAIClient(provider);
-            const result = await aiClient.ExecuteSimplePrompt({
-                systemPrompt: ICON_SYSTEM_PROMPT,
-                messages: [{ message: userMessage, role: 'user' }],
-                modelPower: 'medium'
-            });
-            if (!result?.success || !result.result) {
-                this.ErrorMessage = result?.error ?? 'AI did not return an icon. Try again or pick one manually.';
-                return;
-            }
-            const svg = this.extractSvg(result.result);
-            if (!svg) {
-                this.ErrorMessage = 'AI response did not contain a valid SVG. Try again.';
-                return;
-            }
-            this.SvgIcon = svg;
-            this.SafeSvgIcon = this.sanitizer.bypassSecurityTrustHtml(svg);
-        } catch (err) {
-            this.ErrorMessage = `Icon generation failed: ${(err as Error).message}`;
-        } finally {
-            this.IsGeneratingIcon = false;
-            this.cdr.markForCheck();
-        }
-    }
-
-    private buildIconPromptMessage(): string {
-        const lines = [`Action name: ${this.ActionName ?? 'Untitled action'}`];
-        if (this.ActionDescription) lines.push(`Action description: ${this.ActionDescription}`);
-        if (this.DisplayName && this.DisplayName !== this.ActionName) {
-            lines.push(`Pin title: ${this.DisplayName}`);
-        }
-        if (this.AiHint.trim()) lines.push(`User hint: ${this.AiHint.trim()}`);
-        lines.push('Return only the SVG markup.');
-        return lines.join('\n');
-    }
-
-    private extractSvg(raw: string): string | null {
-        // Strip common markdown fences and any preamble/trailing text; keep only the <svg>...</svg> block.
-        const match = raw.match(/<svg[\s\S]*?<\/svg>/i);
-        return match ? match[0] : null;
     }
 
     CanSave(): boolean {
@@ -250,7 +172,6 @@ export class ActionPinConfigDialogComponent implements OnChanges {
                 ActionName: this.ActionName,
                 AccentColor: this.AccentColor,
                 FaIcon: this.FaIcon,
-                SvgIcon: this.SvgIcon ?? undefined,
                 PresetParams: presetParams,
                 RuntimeParamNames: runtimeParamNames
             }

--- a/packages/Angular/Explorer/dashboards/src/Home/action-pin-config-dialog.component.ts
+++ b/packages/Angular/Explorer/dashboards/src/Home/action-pin-config-dialog.component.ts
@@ -1,0 +1,263 @@
+import { Component, Input, Output, EventEmitter, OnChanges, SimpleChanges, ChangeDetectorRef, ViewEncapsulation } from '@angular/core';
+import { DomSanitizer, SafeHtml } from '@angular/platform-browser';
+import { Metadata, RunView } from '@memberjunction/core';
+import { MJActionParamEntity } from '@memberjunction/core-entities';
+import { GraphQLAIClient, GraphQLDataProvider } from '@memberjunction/graphql-dataprovider';
+
+/**
+ * One row in the param configuration table — either a preset-value or a runtime-prompted param.
+ */
+export interface ActionPinParamConfig {
+    Name: string;
+    Description: string;
+    IsRequired: boolean;
+    DefaultValue: string;
+    Mode: 'preset' | 'runtime';
+    PresetValue: string;
+}
+
+/**
+ * Payload returned when the user saves the dialog.
+ */
+export interface ActionPinConfigResult {
+    Action: 'save' | 'cancel';
+    Pin?: {
+        DisplayName: string;
+        ActionID: string;
+        ActionName: string;
+        AccentColor: string;
+        FaIcon: string;
+        SvgIcon?: string;
+        PresetParams: Record<string, string>;
+        RuntimeParamNames: string[];
+    };
+}
+
+const COLOR_PALETTE = [
+    { name: 'Indigo', value: '#4F46E5' },
+    { name: 'Emerald', value: '#10B981' },
+    { name: 'Rose', value: '#F43F5E' },
+    { name: 'Amber', value: '#F59E0B' },
+    { name: 'Sky', value: '#0EA5E9' },
+    { name: 'Violet', value: '#8B5CF6' },
+    { name: 'Teal', value: '#14B8A6' },
+    { name: 'Slate', value: '#475569' }
+];
+
+const FA_ICON_PALETTE = [
+    'fa-solid fa-bolt', 'fa-solid fa-rocket', 'fa-solid fa-wand-magic-sparkles',
+    'fa-solid fa-robot', 'fa-solid fa-gears', 'fa-solid fa-play',
+    'fa-solid fa-bullhorn', 'fa-solid fa-envelope', 'fa-solid fa-chart-line',
+    'fa-solid fa-file-export', 'fa-solid fa-file-import', 'fa-solid fa-database',
+    'fa-solid fa-code', 'fa-solid fa-terminal', 'fa-solid fa-paper-plane',
+    'fa-solid fa-camera', 'fa-solid fa-image', 'fa-solid fa-bell',
+    'fa-solid fa-flag', 'fa-solid fa-star', 'fa-solid fa-heart',
+    'fa-solid fa-bookmark', 'fa-solid fa-tag', 'fa-solid fa-lightbulb',
+    'fa-solid fa-brain', 'fa-solid fa-microchip', 'fa-solid fa-server',
+    'fa-solid fa-cloud', 'fa-solid fa-cube', 'fa-solid fa-thumbtack'
+];
+
+const ICON_SYSTEM_PROMPT = `You are an expert icon designer. Generate a single, minimal, modern SVG icon (viewBox="0 0 24 24") that visually represents the user's action.
+
+Strict rules:
+- Output ONLY the raw SVG markup, no markdown fences, no prose, no commentary
+- Use currentColor for strokes/fills so the icon inherits the pin's accent color
+- Keep it simple: at most 6 shapes, stroke-width 1.5, rounded caps
+- Do NOT include <?xml?>, <!DOCTYPE>, or width/height attributes — only viewBox
+- Must start with <svg and end with </svg>`;
+
+@Component({
+    standalone: false,
+    selector: 'mj-action-pin-config-dialog',
+    templateUrl: './action-pin-config-dialog.component.html',
+    styleUrls: ['./action-pin-config-dialog.component.css'],
+    encapsulation: ViewEncapsulation.None
+})
+export class ActionPinConfigDialogComponent implements OnChanges {
+    @Input() Visible = false;
+    @Input() ActionID: string | null = null;
+    @Input() ActionName: string | null = null;
+    @Input() ActionDescription: string | null = null;
+    @Output() Result = new EventEmitter<ActionPinConfigResult>();
+
+    public readonly ColorPalette = COLOR_PALETTE;
+    public readonly FaIconPalette = FA_ICON_PALETTE;
+
+    public DisplayName = '';
+    public AccentColor: string = COLOR_PALETTE[0].value;
+    public FaIcon = FA_ICON_PALETTE[0];
+    public SvgIcon: string | null = null;
+    public SafeSvgIcon: SafeHtml | null = null;
+    public AiHint = '';
+
+    public Params: ActionPinParamConfig[] = [];
+
+    public IsLoadingParams = false;
+    public IsGeneratingIcon = false;
+    public ErrorMessage: string | null = null;
+
+    constructor(private cdr: ChangeDetectorRef, private sanitizer: DomSanitizer) {}
+
+    ngOnChanges(changes: SimpleChanges): void {
+        if (changes['Visible'] && this.Visible && this.ActionID) {
+            this.resetState();
+            this.loadParams();
+        }
+    }
+
+    private resetState(): void {
+        this.DisplayName = this.ActionName ?? '';
+        this.AccentColor = COLOR_PALETTE[0].value;
+        this.FaIcon = FA_ICON_PALETTE[0];
+        this.SvgIcon = null;
+        this.SafeSvgIcon = null;
+        this.AiHint = '';
+        this.Params = [];
+        this.ErrorMessage = null;
+        this.IsLoadingParams = false;
+        this.IsGeneratingIcon = false;
+    }
+
+    private async loadParams(): Promise<void> {
+        if (!this.ActionID) return;
+        this.IsLoadingParams = true;
+        this.cdr.markForCheck();
+        try {
+            const rv = new RunView();
+            const result = await rv.RunView<MJActionParamEntity>({
+                EntityName: 'MJ: Action Params',
+                ExtraFilter: `ActionID='${this.ActionID}' AND (Type='Input' OR Type='Both')`,
+                OrderBy: 'Name',
+                ResultType: 'entity_object'
+            });
+            if (!result.Success) {
+                this.ErrorMessage = `Could not load parameters: ${result.ErrorMessage}`;
+                return;
+            }
+            this.Params = (result.Results ?? []).map(p => ({
+                Name: p.Name,
+                Description: p.Description ?? '',
+                IsRequired: p.IsRequired,
+                DefaultValue: p.DefaultValue ?? '',
+                Mode: p.IsRequired ? 'preset' : 'runtime',
+                PresetValue: p.DefaultValue ?? ''
+            }));
+        } catch (err) {
+            this.ErrorMessage = `Failed to load action parameters: ${(err as Error).message}`;
+        } finally {
+            this.IsLoadingParams = false;
+            this.cdr.markForCheck();
+        }
+    }
+
+    SelectColor(hex: string): void {
+        this.AccentColor = hex;
+        this.cdr.markForCheck();
+    }
+
+    SelectFaIcon(icon: string): void {
+        this.FaIcon = icon;
+        this.SvgIcon = null;
+        this.SafeSvgIcon = null;
+        this.cdr.markForCheck();
+    }
+
+    ClearSvgIcon(): void {
+        this.SvgIcon = null;
+        this.SafeSvgIcon = null;
+        this.cdr.markForCheck();
+    }
+
+    SetParamMode(param: ActionPinParamConfig, mode: 'preset' | 'runtime'): void {
+        param.Mode = mode;
+        this.cdr.markForCheck();
+    }
+
+    async GenerateAiIcon(): Promise<void> {
+        if (this.IsGeneratingIcon) return;
+        this.IsGeneratingIcon = true;
+        this.ErrorMessage = null;
+        this.cdr.markForCheck();
+        try {
+            const userMessage = this.buildIconPromptMessage();
+            const provider = Metadata.Provider as GraphQLDataProvider;
+            const aiClient = new GraphQLAIClient(provider);
+            const result = await aiClient.ExecuteSimplePrompt({
+                systemPrompt: ICON_SYSTEM_PROMPT,
+                messages: [{ message: userMessage, role: 'user' }],
+                modelPower: 'medium'
+            });
+            if (!result?.success || !result.result) {
+                this.ErrorMessage = result?.error ?? 'AI did not return an icon. Try again or pick one manually.';
+                return;
+            }
+            const svg = this.extractSvg(result.result);
+            if (!svg) {
+                this.ErrorMessage = 'AI response did not contain a valid SVG. Try again.';
+                return;
+            }
+            this.SvgIcon = svg;
+            this.SafeSvgIcon = this.sanitizer.bypassSecurityTrustHtml(svg);
+        } catch (err) {
+            this.ErrorMessage = `Icon generation failed: ${(err as Error).message}`;
+        } finally {
+            this.IsGeneratingIcon = false;
+            this.cdr.markForCheck();
+        }
+    }
+
+    private buildIconPromptMessage(): string {
+        const lines = [`Action name: ${this.ActionName ?? 'Untitled action'}`];
+        if (this.ActionDescription) lines.push(`Action description: ${this.ActionDescription}`);
+        if (this.DisplayName && this.DisplayName !== this.ActionName) {
+            lines.push(`Pin title: ${this.DisplayName}`);
+        }
+        if (this.AiHint.trim()) lines.push(`User hint: ${this.AiHint.trim()}`);
+        lines.push('Return only the SVG markup.');
+        return lines.join('\n');
+    }
+
+    private extractSvg(raw: string): string | null {
+        // Strip common markdown fences and any preamble/trailing text; keep only the <svg>...</svg> block.
+        const match = raw.match(/<svg[\s\S]*?<\/svg>/i);
+        return match ? match[0] : null;
+    }
+
+    CanSave(): boolean {
+        if (!this.DisplayName.trim()) return false;
+        for (const p of this.Params) {
+            if (p.Mode === 'preset' && p.IsRequired && !p.PresetValue.trim()) return false;
+        }
+        return true;
+    }
+
+    Save(): void {
+        if (!this.CanSave() || !this.ActionID || !this.ActionName) return;
+        const presetParams: Record<string, string> = {};
+        const runtimeParamNames: string[] = [];
+        for (const p of this.Params) {
+            if (p.Mode === 'preset') {
+                if (p.PresetValue.trim() !== '') presetParams[p.Name] = p.PresetValue;
+            } else {
+                runtimeParamNames.push(p.Name);
+            }
+        }
+        this.Result.emit({
+            Action: 'save',
+            Pin: {
+                DisplayName: this.DisplayName.trim(),
+                ActionID: this.ActionID,
+                ActionName: this.ActionName,
+                AccentColor: this.AccentColor,
+                FaIcon: this.FaIcon,
+                SvgIcon: this.SvgIcon ?? undefined,
+                PresetParams: presetParams,
+                RuntimeParamNames: runtimeParamNames
+            }
+        });
+    }
+
+    Cancel(): void {
+        this.Result.emit({ Action: 'cancel' });
+    }
+}

--- a/packages/Angular/Explorer/dashboards/src/Home/action-pin-runner-dialog.component.css
+++ b/packages/Angular/Explorer/dashboards/src/Home/action-pin-runner-dialog.component.css
@@ -57,20 +57,6 @@
     color: var(--mj-text-inverse, white);
 }
 
-.apr-hero-svg {
-    width: 32px;
-    height: 32px;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    color: var(--mj-text-inverse, white);
-}
-
-.apr-hero-svg svg {
-    width: 100%;
-    height: 100%;
-}
-
 .apr-hero-info {
     flex: 1;
     min-width: 0;

--- a/packages/Angular/Explorer/dashboards/src/Home/action-pin-runner-dialog.component.css
+++ b/packages/Angular/Explorer/dashboards/src/Home/action-pin-runner-dialog.component.css
@@ -1,0 +1,255 @@
+.apr-backdrop {
+    position: fixed;
+    inset: 0;
+    background: var(--mj-bg-overlay);
+    z-index: 9000;
+    animation: apr-fade-in 0.15s ease;
+}
+
+.apr-dialog {
+    position: fixed;
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%);
+    z-index: 9001;
+    width: min(480px, calc(100vw - 32px));
+    max-height: calc(100vh - 48px);
+    background: var(--mj-bg-surface);
+    color: var(--mj-text-primary);
+    border: 1px solid var(--mj-border-default);
+    border-radius: 12px;
+    box-shadow: 0 24px 60px rgba(0, 0, 0, 0.25);
+    display: flex;
+    flex-direction: column;
+    overflow: hidden;
+    animation: apr-pop-in 0.18s ease;
+}
+
+@keyframes apr-fade-in {
+    from { opacity: 0; }
+    to { opacity: 1; }
+}
+
+@keyframes apr-pop-in {
+    from { opacity: 0; transform: translate(-50%, -48%) scale(0.98); }
+    to { opacity: 1; transform: translate(-50%, -50%) scale(1); }
+}
+
+.apr-hero {
+    display: flex;
+    align-items: center;
+    gap: 14px;
+    padding: 18px 20px;
+    color: var(--mj-text-inverse, white);
+    position: relative;
+}
+
+.apr-hero-icon {
+    width: 48px;
+    height: 48px;
+    border-radius: 10px;
+    background: rgba(255, 255, 255, 0.2);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 22px;
+    flex-shrink: 0;
+    color: var(--mj-text-inverse, white);
+}
+
+.apr-hero-svg {
+    width: 32px;
+    height: 32px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    color: var(--mj-text-inverse, white);
+}
+
+.apr-hero-svg svg {
+    width: 100%;
+    height: 100%;
+}
+
+.apr-hero-info {
+    flex: 1;
+    min-width: 0;
+}
+
+.apr-hero-title {
+    font-size: 16px;
+    font-weight: 600;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
+
+.apr-hero-sub {
+    font-size: 12px;
+    opacity: 0.85;
+    margin-top: 2px;
+    display: flex;
+    align-items: center;
+    gap: 6px;
+}
+
+.apr-close {
+    background: rgba(255, 255, 255, 0.15);
+    border: none;
+    color: var(--mj-text-inverse, white);
+    font-size: 14px;
+    width: 32px;
+    height: 32px;
+    border-radius: 8px;
+    cursor: pointer;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    flex-shrink: 0;
+}
+
+.apr-close:hover:not(:disabled) {
+    background: rgba(255, 255, 255, 0.25);
+}
+
+.apr-close:disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
+}
+
+.apr-body {
+    padding: 20px;
+    overflow-y: auto;
+    display: flex;
+    flex-direction: column;
+    gap: 14px;
+}
+
+.apr-no-fields {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    padding: 14px;
+    background: var(--mj-bg-surface-sunken);
+    border: 1px solid var(--mj-border-subtle);
+    border-radius: 8px;
+    font-size: 13px;
+    color: var(--mj-text-secondary);
+}
+
+.apr-no-fields i {
+    color: var(--mj-brand-primary);
+}
+
+.apr-help {
+    font-size: 13px;
+    color: var(--mj-text-muted);
+}
+
+.apr-fields {
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+}
+
+.apr-field {
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+}
+
+.apr-field label {
+    font-size: 12px;
+    font-weight: 600;
+    color: var(--mj-text-secondary);
+}
+
+.apr-result {
+    display: flex;
+    gap: 14px;
+    padding: 16px;
+    border-radius: 8px;
+    align-items: flex-start;
+}
+
+.apr-result.success {
+    background: var(--mj-status-success-bg);
+    border: 1px solid var(--mj-status-success-border);
+    color: var(--mj-status-success-text);
+}
+
+.apr-result.failure {
+    background: var(--mj-status-error-bg);
+    border: 1px solid var(--mj-status-error-border);
+    color: var(--mj-status-error-text);
+}
+
+.apr-result-icon {
+    font-size: 28px;
+    line-height: 1;
+}
+
+.apr-result-title {
+    font-size: 14px;
+    font-weight: 600;
+    margin-bottom: 4px;
+}
+
+.apr-result-msg {
+    font-size: 13px;
+    line-height: 1.5;
+    opacity: 0.9;
+}
+
+.apr-error {
+    padding: 10px 12px;
+    background: var(--mj-status-error-bg);
+    color: var(--mj-status-error-text);
+    border: 1px solid var(--mj-status-error-border);
+    border-radius: 6px;
+    font-size: 13px;
+    display: flex;
+    align-items: center;
+    gap: 8px;
+}
+
+.apr-footer {
+    display: flex;
+    gap: 8px;
+    padding: 14px 20px;
+    border-top: 1px solid var(--mj-border-subtle);
+    background: var(--mj-bg-surface-card);
+}
+
+.apr-btn {
+    padding: 9px 16px;
+    border-radius: 6px;
+    font-size: 13px;
+    font-weight: 500;
+    cursor: pointer;
+    border: 1px solid var(--mj-border-default);
+    background: var(--mj-bg-surface);
+    color: var(--mj-text-primary);
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+}
+
+.apr-btn:hover:not(:disabled) {
+    background: var(--mj-bg-surface-hover);
+}
+
+.apr-btn.primary {
+    background: var(--mj-brand-primary);
+    color: var(--mj-text-inverse, white);
+    border-color: var(--mj-brand-primary);
+}
+
+.apr-btn.primary:hover:not(:disabled) {
+    filter: brightness(0.92);
+}
+
+.apr-btn:disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
+}

--- a/packages/Angular/Explorer/dashboards/src/Home/action-pin-runner-dialog.component.html
+++ b/packages/Angular/Explorer/dashboards/src/Home/action-pin-runner-dialog.component.html
@@ -3,11 +3,7 @@
   <div class="apr-dialog" role="dialog" aria-modal="true">
     <div class="apr-hero" [style.background]="'linear-gradient(135deg, ' + AccentColor + ' 0%, ' + AccentColor + 'cc 100%)'">
       <div class="apr-hero-icon">
-        @if (SafeSvgIcon) {
-          <div class="apr-hero-svg" [innerHTML]="SafeSvgIcon"></div>
-        } @else {
-          <i [class]="FaIcon"></i>
-        }
+        <i [class]="FaIcon"></i>
       </div>
       <div class="apr-hero-info">
         <div class="apr-hero-title">{{ Pin.DisplayName }}</div>

--- a/packages/Angular/Explorer/dashboards/src/Home/action-pin-runner-dialog.component.html
+++ b/packages/Angular/Explorer/dashboards/src/Home/action-pin-runner-dialog.component.html
@@ -1,0 +1,92 @@
+@if (Visible && Pin) {
+  <div class="apr-backdrop" (click)="Close()"></div>
+  <div class="apr-dialog" role="dialog" aria-modal="true">
+    <div class="apr-hero" [style.background]="'linear-gradient(135deg, ' + AccentColor + ' 0%, ' + AccentColor + 'cc 100%)'">
+      <div class="apr-hero-icon">
+        @if (SafeSvgIcon) {
+          <div class="apr-hero-svg" [innerHTML]="SafeSvgIcon"></div>
+        } @else {
+          <i [class]="FaIcon"></i>
+        }
+      </div>
+      <div class="apr-hero-info">
+        <div class="apr-hero-title">{{ Pin.DisplayName }}</div>
+        <div class="apr-hero-sub">{{ ActionName }}</div>
+      </div>
+      <button class="apr-close" (click)="Close()" [disabled]="IsRunning" aria-label="Close">
+        <i class="fa-solid fa-xmark"></i>
+      </button>
+    </div>
+
+    <div class="apr-body">
+      @if (RunSucceeded === null) {
+        @if (RuntimeFields.length === 0) {
+          <div class="apr-no-fields">
+            <i class="fa-solid fa-circle-info"></i>
+            This action runs with all parameters preset — no input needed.
+          </div>
+        } @else {
+          <div class="apr-help">Provide values for the parameters below:</div>
+          <div class="apr-fields">
+            @for (f of RuntimeFields; track f.Name) {
+              <div class="apr-field">
+                <label [for]="'rf-' + f.Name">{{ f.Name }}</label>
+                <input [id]="'rf-' + f.Name"
+                       type="text"
+                       class="mj-input"
+                       [(ngModel)]="f.Value"
+                       [disabled]="IsRunning"
+                       [placeholder]="'Enter ' + f.Name" />
+              </div>
+            }
+          </div>
+        }
+      } @else {
+        <div class="apr-result" [class.success]="RunSucceeded" [class.failure]="!RunSucceeded">
+          <div class="apr-result-icon">
+            @if (RunSucceeded) {
+              <i class="fa-solid fa-circle-check"></i>
+            } @else {
+              <i class="fa-solid fa-circle-xmark"></i>
+            }
+          </div>
+          <div class="apr-result-text">
+            <div class="apr-result-title">{{ RunSucceeded ? 'Action completed' : 'Action failed' }}</div>
+            @if (ResultMessage) {
+              <div class="apr-result-msg">{{ ResultMessage }}</div>
+            }
+          </div>
+        </div>
+      }
+
+      @if (ErrorMessage) {
+        <div class="apr-error">
+          <i class="fa-solid fa-triangle-exclamation"></i> {{ ErrorMessage }}
+        </div>
+      }
+    </div>
+
+    <div class="apr-footer">
+      @if (RunSucceeded === null) {
+        <button type="button" class="apr-btn primary"
+                [disabled]="!CanRun()"
+                [style.background]="AccentColor"
+                [style.border-color]="AccentColor"
+                (click)="Run()">
+          @if (IsRunning) {
+            <i class="fa-solid fa-spinner fa-spin"></i> Running…
+          } @else {
+            <i class="fa-solid fa-play"></i> Run action
+          }
+        </button>
+        <button type="button" class="apr-btn" [disabled]="IsRunning" (click)="Close()">
+          Cancel
+        </button>
+      } @else {
+        <button type="button" class="apr-btn primary" (click)="Close()">
+          Done
+        </button>
+      }
+    </div>
+  </div>
+}

--- a/packages/Angular/Explorer/dashboards/src/Home/action-pin-runner-dialog.component.ts
+++ b/packages/Angular/Explorer/dashboards/src/Home/action-pin-runner-dialog.component.ts
@@ -1,0 +1,129 @@
+import { Component, Input, Output, EventEmitter, OnChanges, SimpleChanges, ChangeDetectorRef, ViewEncapsulation } from '@angular/core';
+import { DomSanitizer, SafeHtml } from '@angular/platform-browser';
+import { Metadata } from '@memberjunction/core';
+import { GraphQLActionClient, GraphQLDataProvider } from '@memberjunction/graphql-dataprovider';
+import { ActionParam } from '@memberjunction/actions-base';
+import { HomeAppPinnedItem, ActionPinConfiguration } from '@memberjunction/ng-shared';
+
+/**
+ * Result emitted after the action finishes (or the dialog is cancelled).
+ */
+export interface ActionPinRunResult {
+    Closed: true;
+}
+
+interface RuntimeField {
+    Name: string;
+    Value: string;
+}
+
+@Component({
+    standalone: false,
+    selector: 'mj-action-pin-runner-dialog',
+    templateUrl: './action-pin-runner-dialog.component.html',
+    styleUrls: ['./action-pin-runner-dialog.component.css'],
+    encapsulation: ViewEncapsulation.None
+})
+export class ActionPinRunnerDialogComponent implements OnChanges {
+    @Input() Visible = false;
+    @Input() Pin: HomeAppPinnedItem | null = null;
+    @Output() Result = new EventEmitter<ActionPinRunResult>();
+
+    public RuntimeFields: RuntimeField[] = [];
+    public IsRunning = false;
+    public RunSucceeded: boolean | null = null;
+    public ResultMessage: string | null = null;
+    public ErrorMessage: string | null = null;
+    public SafeSvgIcon: SafeHtml | null = null;
+
+    constructor(private cdr: ChangeDetectorRef, private sanitizer: DomSanitizer) {}
+
+    ngOnChanges(changes: SimpleChanges): void {
+        if (changes['Visible'] && this.Visible && this.Pin) {
+            this.initFromPin();
+        }
+    }
+
+    private getConfig(): ActionPinConfiguration | null {
+        if (!this.Pin) return null;
+        return this.Pin.Configuration as unknown as ActionPinConfiguration;
+    }
+
+    private initFromPin(): void {
+        const cfg = this.getConfig();
+        this.RuntimeFields = (cfg?.runtimeParamNames ?? []).map(name => ({ Name: name, Value: '' }));
+        this.IsRunning = false;
+        this.RunSucceeded = null;
+        this.ResultMessage = null;
+        this.ErrorMessage = null;
+        this.SafeSvgIcon = cfg?.svgIcon ? this.sanitizer.bypassSecurityTrustHtml(cfg.svgIcon) : null;
+        this.cdr.markForCheck();
+    }
+
+    get AccentColor(): string {
+        return this.getConfig()?.accentColor ?? 'var(--mj-brand-primary)';
+    }
+
+    get FaIcon(): string {
+        return this.Pin?.Icon ?? 'fa-solid fa-bolt';
+    }
+
+    get ActionName(): string {
+        return this.getConfig()?.actionName ?? 'Action';
+    }
+
+    CanRun(): boolean {
+        if (this.IsRunning) return false;
+        // Runtime fields without values are allowed (action may handle missing params).
+        // The action itself reports required-param errors via its result.
+        return true;
+    }
+
+    async Run(): Promise<void> {
+        const cfg = this.getConfig();
+        if (!cfg || !cfg.actionId) {
+            this.ErrorMessage = 'Pin is missing an actionId — cannot execute.';
+            this.cdr.markForCheck();
+            return;
+        }
+
+        this.IsRunning = true;
+        this.RunSucceeded = null;
+        this.ResultMessage = null;
+        this.ErrorMessage = null;
+        this.cdr.markForCheck();
+
+        try {
+            const params = this.buildActionParams(cfg);
+            const provider = Metadata.Provider as GraphQLDataProvider;
+            const actionClient = new GraphQLActionClient(provider);
+            const result = await actionClient.RunAction(cfg.actionId, params);
+            this.RunSucceeded = result.Success;
+            this.ResultMessage = result.Message ?? (result.Success ? 'Action completed.' : 'Action reported a failure.');
+        } catch (err) {
+            this.RunSucceeded = false;
+            this.ErrorMessage = `Execution failed: ${(err as Error).message}`;
+        } finally {
+            this.IsRunning = false;
+            this.cdr.markForCheck();
+        }
+    }
+
+    private buildActionParams(cfg: ActionPinConfiguration): ActionParam[] {
+        const params: ActionParam[] = [];
+        for (const [name, value] of Object.entries(cfg.presetParams ?? {})) {
+            params.push({ Name: name, Value: value, Type: 'Input' });
+        }
+        for (const f of this.RuntimeFields) {
+            if (f.Value !== '') {
+                params.push({ Name: f.Name, Value: f.Value, Type: 'Input' });
+            }
+        }
+        return params;
+    }
+
+    Close(): void {
+        if (this.IsRunning) return;
+        this.Result.emit({ Closed: true });
+    }
+}

--- a/packages/Angular/Explorer/dashboards/src/Home/action-pin-runner-dialog.component.ts
+++ b/packages/Angular/Explorer/dashboards/src/Home/action-pin-runner-dialog.component.ts
@@ -1,5 +1,4 @@
 import { Component, Input, Output, EventEmitter, OnChanges, SimpleChanges, ChangeDetectorRef, ViewEncapsulation } from '@angular/core';
-import { DomSanitizer, SafeHtml } from '@angular/platform-browser';
 import { Metadata } from '@memberjunction/core';
 import { GraphQLActionClient, GraphQLDataProvider } from '@memberjunction/graphql-dataprovider';
 import { ActionParam } from '@memberjunction/actions-base';
@@ -34,9 +33,8 @@ export class ActionPinRunnerDialogComponent implements OnChanges {
     public RunSucceeded: boolean | null = null;
     public ResultMessage: string | null = null;
     public ErrorMessage: string | null = null;
-    public SafeSvgIcon: SafeHtml | null = null;
 
-    constructor(private cdr: ChangeDetectorRef, private sanitizer: DomSanitizer) {}
+    constructor(private cdr: ChangeDetectorRef) {}
 
     ngOnChanges(changes: SimpleChanges): void {
         if (changes['Visible'] && this.Visible && this.Pin) {
@@ -56,7 +54,6 @@ export class ActionPinRunnerDialogComponent implements OnChanges {
         this.RunSucceeded = null;
         this.ResultMessage = null;
         this.ErrorMessage = null;
-        this.SafeSvgIcon = cfg?.svgIcon ? this.sanitizer.bypassSecurityTrustHtml(cfg.svgIcon) : null;
         this.cdr.markForCheck();
     }
 

--- a/packages/Angular/Explorer/dashboards/src/Home/home-dashboard.component.css
+++ b/packages/Angular/Explorer/dashboards/src/Home/home-dashboard.component.css
@@ -907,20 +907,6 @@
   color: var(--mj-text-inverse, white);
 }
 
-.pin-thumbnail.action-mode .pin-action-svg {
-  width: 44px;
-  height: 44px;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  color: var(--mj-text-inverse, white);
-}
-
-.pin-thumbnail.action-mode .pin-action-svg svg {
-  width: 100%;
-  height: 100%;
-}
-
 /* Hover overlay */
 .pin-overlay {
   position: absolute;

--- a/packages/Angular/Explorer/dashboards/src/Home/home-dashboard.component.css
+++ b/packages/Angular/Explorer/dashboards/src/Home/home-dashboard.component.css
@@ -893,6 +893,34 @@
   opacity: 0.7;
 }
 
+/* Action-pin card: colored gradient background with white icon/SVG */
+.pin-thumbnail.action-mode {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--mj-text-inverse, white);
+  background: var(--mj-brand-primary);
+}
+
+.pin-thumbnail.action-mode > i {
+  font-size: 36px;
+  color: var(--mj-text-inverse, white);
+}
+
+.pin-thumbnail.action-mode .pin-action-svg {
+  width: 44px;
+  height: 44px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--mj-text-inverse, white);
+}
+
+.pin-thumbnail.action-mode .pin-action-svg svg {
+  width: 100%;
+  height: 100%;
+}
+
 /* Hover overlay */
 .pin-overlay {
   position: absolute;

--- a/packages/Angular/Explorer/dashboards/src/Home/home-dashboard.component.html
+++ b/packages/Angular/Explorer/dashboards/src/Home/home-dashboard.component.html
@@ -96,11 +96,7 @@
                 } @else if (pin.ResourceType === 'Actions') {
                   <div class="pin-thumbnail action-mode"
                        [style.background]="'linear-gradient(135deg, ' + GetPinAccentColor(pin) + ' 0%, ' + GetPinAccentColor(pin) + 'cc 100%)'">
-                    @if (GetPinSvgIcon(pin); as svg) {
-                      <div class="pin-action-svg" [innerHTML]="svg"></div>
-                    } @else {
-                      <i [class]="GetPinIcon(pin)"></i>
-                    }
+                    <i [class]="GetPinIcon(pin)"></i>
                     @if (!EditMode) {
                       <div class="pin-overlay">
                         <button class="open-btn" (click)="OnPinClick(pin); $event.stopPropagation()">Run</button>
@@ -207,11 +203,7 @@
                   } @else if (pin.ResourceType === 'Actions') {
                     <div class="pin-thumbnail action-mode"
                          [style.background]="'linear-gradient(135deg, ' + GetPinAccentColor(pin) + ' 0%, ' + GetPinAccentColor(pin) + 'cc 100%)'">
-                      @if (GetPinSvgIcon(pin); as svg) {
-                        <div class="pin-action-svg" [innerHTML]="svg"></div>
-                      } @else {
-                        <i [class]="GetPinIcon(pin)"></i>
-                      }
+                      <i [class]="GetPinIcon(pin)"></i>
                       @if (!EditMode) {
                         <div class="pin-overlay">
                           <button class="open-btn" (click)="OnPinClick(pin); $event.stopPropagation()">Run</button>

--- a/packages/Angular/Explorer/dashboards/src/Home/home-dashboard.component.html
+++ b/packages/Angular/Explorer/dashboards/src/Home/home-dashboard.component.html
@@ -93,6 +93,20 @@
                       </div>
                     }
                   </div>
+                } @else if (pin.ResourceType === 'Actions') {
+                  <div class="pin-thumbnail action-mode"
+                       [style.background]="'linear-gradient(135deg, ' + GetPinAccentColor(pin) + ' 0%, ' + GetPinAccentColor(pin) + 'cc 100%)'">
+                    @if (GetPinSvgIcon(pin); as svg) {
+                      <div class="pin-action-svg" [innerHTML]="svg"></div>
+                    } @else {
+                      <i [class]="GetPinIcon(pin)"></i>
+                    }
+                    @if (!EditMode) {
+                      <div class="pin-overlay">
+                        <button class="open-btn" (click)="OnPinClick(pin); $event.stopPropagation()">Run</button>
+                      </div>
+                    }
+                  </div>
                 } @else {
                   <div class="pin-thumbnail icon-mode" [style.--pin-icon-color]="pin.Color || 'var(--mj-text-muted)'">
                     <i [class]="GetPinIcon(pin)"></i>
@@ -187,6 +201,20 @@
                       @if (!EditMode) {
                         <div class="pin-overlay">
                           <button class="open-btn" (click)="OnPinClick(pin); $event.stopPropagation()">Open</button>
+                        </div>
+                      }
+                    </div>
+                  } @else if (pin.ResourceType === 'Actions') {
+                    <div class="pin-thumbnail action-mode"
+                         [style.background]="'linear-gradient(135deg, ' + GetPinAccentColor(pin) + ' 0%, ' + GetPinAccentColor(pin) + 'cc 100%)'">
+                      @if (GetPinSvgIcon(pin); as svg) {
+                        <div class="pin-action-svg" [innerHTML]="svg"></div>
+                      } @else {
+                        <i [class]="GetPinIcon(pin)"></i>
+                      }
+                      @if (!EditMode) {
+                        <div class="pin-overlay">
+                          <button class="open-btn" (click)="OnPinClick(pin); $event.stopPropagation()">Run</button>
                         </div>
                       }
                     </div>
@@ -459,10 +487,56 @@
                 }
               </div>
             }
+
+            <!-- Quick Actions -->
+            @if (FilterPanelItems(AvailableActions).length > 0) {
+              <div class="panel-section">
+                <div class="panel-section-title collapsible" (click)="TogglePanelSection('actions')">
+                  <i class="fa-solid fa-bolt"></i> Quick Actions
+                  <span class="panel-count">{{ FilterPanelItems(AvailableActions).length }}</span>
+                  <i class="section-chevron fa-solid" [class.fa-chevron-down]="!PanelSectionCollapsed['actions']" [class.fa-chevron-right]="PanelSectionCollapsed['actions']"></i>
+                </div>
+                @if (!PanelSectionCollapsed['actions']) {
+                  @for (item of FilterPanelItems(AvailableActions); track item.id) {
+                    <div class="panel-item">
+                      <div class="panel-item-icon" style="background: color-mix(in srgb, var(--mj-brand-primary) 10%, var(--mj-bg-surface-card))">
+                        <i class="fa-solid fa-bolt" style="color: var(--mj-brand-primary)"></i>
+                      </div>
+                      <div class="panel-item-info">
+                        <div class="panel-item-name">{{ item.name }}</div>
+                        @if (item.description) {
+                          <div class="panel-item-sub">{{ item.description }}</div>
+                        }
+                      </div>
+                      <div class="panel-item-action">
+                        <button class="pin-btn" (click)="OpenActionPinConfig(item.id, item.name, item.description)">
+                          <i class="fa-solid fa-sliders"></i> Configure
+                        </button>
+                      </div>
+                    </div>
+                  }
+                }
+              </div>
+            }
           }
         </div>
       </div>
     }
+
+    <!-- Action Pin Dialogs -->
+    <mj-action-pin-config-dialog
+      [Visible]="ActionConfigDialogVisible"
+      [ActionID]="ActionConfigActionId"
+      [ActionName]="ActionConfigActionName"
+      [ActionDescription]="ActionConfigActionDescription"
+      (Result)="OnActionConfigResult($event)">
+    </mj-action-pin-config-dialog>
+
+    <mj-action-pin-runner-dialog
+      [Visible]="ActionRunnerDialogVisible"
+      [Pin]="ActionRunnerPin"
+      (Result)="OnActionRunnerResult($event)">
+    </mj-action-pin-runner-dialog>
 
     <!-- Loading State -->
     @if (isLoading) {

--- a/packages/Angular/Explorer/dashboards/src/Home/home-dashboard.component.ts
+++ b/packages/Angular/Explorer/dashboards/src/Home/home-dashboard.component.ts
@@ -5,6 +5,7 @@ import { BaseResourceComponent, NavigationService, RecentAccessService, RecentAc
 import { RegisterClass } from '@memberjunction/global';
 import { Metadata, CompositeKey, EntityRecordNameInput, RunView } from '@memberjunction/core';
 import { ResourceData, MJUserFavoriteEntity, MJUserNotificationEntity, UserInfoEngine } from '@memberjunction/core-entities';
+import { ActionEngineBase } from '@memberjunction/actions-base';
 import { ApplicationManager, BaseApplication } from '@memberjunction/ng-base-application';
 import { UserAppConfigComponent } from '@memberjunction/ng-explorer-settings';
 import { MJNotificationService } from '@memberjunction/ng-notifications';
@@ -1130,8 +1131,10 @@ export class HomeDashboardComponent extends BaseResourceComponent implements Aft
   private async loadAvailableResources(): Promise<void> {
     const rv = new RunView();
 
-    // Load dashboards, views, queries, actions in parallel
-    const [dashboards, views, queries, actions] = await Promise.all([
+    // Actions come from ActionEngineBase's cache — no RunView needed. Config() is idempotent,
+    // so calling it in parallel with the remaining RunViews is cheap on repeat loads and avoids
+    // a redundant DB round trip when the engine is already primed.
+    const [dashboards, views, queries] = await Promise.all([
       rv.RunView<{ID: string; Name: string}>({
         EntityName: 'MJ: Dashboards',
         Fields: ['ID', 'Name'],
@@ -1152,14 +1155,12 @@ export class HomeDashboardComponent extends BaseResourceComponent implements Aft
         OrderBy: 'Name',
         ResultType: 'simple'
       }),
-      rv.RunView<{ID: string; Name: string; Description: string}>({
-        EntityName: 'MJ: Actions',
-        Fields: ['ID', 'Name', 'Description'],
-        ExtraFilter: `Status='Active'`,
-        OrderBy: 'Name',
-        ResultType: 'simple'
-      })
+      ActionEngineBase.Instance.Config()
     ]);
+
+    const cachedActions = ActionEngineBase.Instance.Actions
+      .filter(a => a.Status === 'Active')
+      .sort((a, b) => a.Name.localeCompare(b.Name));
 
     this.AvailableDashboards = (dashboards.Results || []).map(d => ({
       id: d.ID, name: d.Name,
@@ -1178,7 +1179,7 @@ export class HomeDashboardComponent extends BaseResourceComponent implements Aft
 
     // Actions can be pinned multiple times with different configs, so we treat them
     // as always "not pinned" in the panel — the checkmark would be misleading.
-    this.AvailableActions = (actions.Results || []).map(a => ({
+    this.AvailableActions = cachedActions.map(a => ({
       id: a.ID, name: a.Name, description: a.Description || '',
       pinned: false
     }));

--- a/packages/Angular/Explorer/dashboards/src/Home/home-dashboard.component.ts
+++ b/packages/Angular/Explorer/dashboards/src/Home/home-dashboard.component.ts
@@ -1,13 +1,16 @@
 import { Component, AfterViewInit, OnDestroy, ChangeDetectorRef, ViewChild, ChangeDetectionStrategy, inject } from '@angular/core';
+import { DomSanitizer, SafeHtml } from '@angular/platform-browser';
 import { Subject } from 'rxjs';
 import { takeUntil } from 'rxjs/operators';
-import { BaseResourceComponent, NavigationService, RecentAccessService, RecentAccessItem, HomeAppPinService, HomeAppPinnedItem, HomeAppPinInput } from '@memberjunction/ng-shared';
+import { BaseResourceComponent, NavigationService, RecentAccessService, RecentAccessItem, HomeAppPinService, HomeAppPinnedItem, HomeAppPinInput, ActionPinConfiguration } from '@memberjunction/ng-shared';
 import { RegisterClass } from '@memberjunction/global';
 import { Metadata, CompositeKey, EntityRecordNameInput, RunView } from '@memberjunction/core';
 import { ResourceData, MJUserFavoriteEntity, MJUserNotificationEntity, UserInfoEngine } from '@memberjunction/core-entities';
 import { ApplicationManager, BaseApplication } from '@memberjunction/ng-base-application';
 import { UserAppConfigComponent } from '@memberjunction/ng-explorer-settings';
 import { MJNotificationService } from '@memberjunction/ng-notifications';
+import { ActionPinConfigResult } from './action-pin-config-dialog.component';
+import { ActionPinRunResult } from './action-pin-runner-dialog.component';
 
 /**
  * Cached app data with pre-computed values for optimal rendering performance
@@ -83,8 +86,21 @@ export class HomeDashboardComponent extends BaseResourceComponent implements Aft
   public AvailableDashboards: { id: string; name: string; pinned: boolean }[] = [];
   public AvailableViews: { id: string; name: string; entityName: string; pinned: boolean }[] = [];
   public AvailableQueries: { id: string; name: string; pinned: boolean }[] = [];
+  public AvailableActions: { id: string; name: string; description: string; pinned: boolean }[] = [];
   public AvailableApps: { appId: string; appName: string; icon: string; color: string; navItems: { label: string; icon: string; pinned: boolean }[] }[] = [];
   public AddPanelLoading = false;
+
+  // Action pin dialog state
+  public ActionConfigDialogVisible = false;
+  public ActionConfigActionId: string | null = null;
+  public ActionConfigActionName: string | null = null;
+  public ActionConfigActionDescription: string | null = null;
+
+  public ActionRunnerDialogVisible = false;
+  public ActionRunnerPin: HomeAppPinnedItem | null = null;
+
+  // Cache of sanitized SVG icons, keyed by pin ID. Rebuilt when Pins$ emits.
+  private pinSvgIconCache = new Map<string, SafeHtml>();
 
   // Collapsible section state for Add Pin panel
   public PanelSectionCollapsed: Record<string, boolean> = {};
@@ -137,7 +153,8 @@ export class HomeDashboardComponent extends BaseResourceComponent implements Aft
   constructor(
     private appManager: ApplicationManager,
     private recentAccessService: RecentAccessService,
-    private cdr: ChangeDetectorRef
+    private cdr: ChangeDetectorRef,
+    private sanitizer: DomSanitizer
   ) {
     super();
   }
@@ -747,6 +764,17 @@ export class HomeDashboardComponent extends BaseResourceComponent implements Aft
         }
         break;
       }
+      case 'Actions': {
+        const actionId = config['actionId'] as string;
+        if (!actionId) {
+          console.warn('[Pin Click] Action pin missing actionId', config);
+          break;
+        }
+        this.ActionRunnerPin = pin;
+        this.ActionRunnerDialogVisible = true;
+        this.cdr.markForCheck();
+        break;
+      }
       default:
         console.warn('[Pin Click] Unrecognized resource type', rt, 'for pin', pin.DisplayName, config);
         break;
@@ -763,7 +791,7 @@ export class HomeDashboardComponent extends BaseResourceComponent implements Aft
     const config = pin.Configuration;
 
     // Already a known canonical type
-    const knownTypes = ['Dashboards', 'User Views', 'Queries', 'Reports', 'Records', 'Custom'];
+    const knownTypes = ['Dashboards', 'User Views', 'Queries', 'Reports', 'Records', 'Custom', 'Actions'];
     if (knownTypes.includes(rt)) return rt;
 
     // Check the config's own resourceType field
@@ -776,6 +804,7 @@ export class HomeDashboardComponent extends BaseResourceComponent implements Aft
     if (config['queryId']) return 'Queries';
     if (config['reportId']) return 'Reports';
     if ((config['Entity'] || config['entity']) && config['recordId']) return 'Records';
+    if (config['actionId']) return 'Actions';
     if (config['navItemName']) return 'Custom';
 
     return rt; // Give up and return whatever was stored
@@ -879,6 +908,7 @@ export class HomeDashboardComponent extends BaseResourceComponent implements Aft
       case 'Reports': return 'fa-solid fa-chart-bar';
       case 'Records': return entity ? this.getEntityIconByName(entity) : 'fa-solid fa-file';
       case 'Custom': return this.getNavItemIcon(pin) || this.getAppIcon(pin) || 'fa-solid fa-cube';
+      case 'Actions': return 'fa-solid fa-bolt';
       default: return 'fa-solid fa-thumbtack';
     }
   }
@@ -894,8 +924,29 @@ export class HomeDashboardComponent extends BaseResourceComponent implements Aft
       case 'Reports': return 'Report';
       case 'Records': return (pin.Configuration?.['Entity'] as string) || (pin.Configuration?.['entity'] as string) || 'Record';
       case 'Custom': return pin.ApplicationName || (pin.Configuration['appName'] as string) || 'App';
+      case 'Actions': return 'Quick Action';
       default: return pin.ResourceType;
     }
+  }
+
+  /**
+   * Returns a sanitized SafeHtml for the pin's AI-generated SVG icon, or null
+   * if the pin doesn't have one. Cached per pin ID to avoid re-sanitizing on every render.
+   */
+  GetPinSvgIcon(pin: HomeAppPinnedItem): SafeHtml | null {
+    const svg = (pin.Configuration as unknown as ActionPinConfiguration).svgIcon;
+    if (!svg) return null;
+    const cached = this.pinSvgIconCache.get(pin.Id);
+    if (cached) return cached;
+    const safe = this.sanitizer.bypassSecurityTrustHtml(svg);
+    this.pinSvgIconCache.set(pin.Id, safe);
+    return safe;
+  }
+
+  /** Accent color for a pin — prefers the stored accentColor in Configuration, falls back to Color, then CSS var */
+  GetPinAccentColor(pin: HomeAppPinnedItem): string {
+    const fromConfig = (pin.Configuration as unknown as ActionPinConfiguration).accentColor;
+    return fromConfig || pin.Color || 'var(--mj-text-muted)';
   }
 
   /**
@@ -1098,8 +1149,8 @@ export class HomeDashboardComponent extends BaseResourceComponent implements Aft
   private async loadAvailableResources(): Promise<void> {
     const rv = new RunView();
 
-    // Load dashboards, views, queries in parallel
-    const [dashboards, views, queries] = await Promise.all([
+    // Load dashboards, views, queries, actions in parallel
+    const [dashboards, views, queries, actions] = await Promise.all([
       rv.RunView<{ID: string; Name: string}>({
         EntityName: 'MJ: Dashboards',
         Fields: ['ID', 'Name'],
@@ -1119,6 +1170,13 @@ export class HomeDashboardComponent extends BaseResourceComponent implements Aft
         Fields: ['ID', 'Name'],
         OrderBy: 'Name',
         ResultType: 'simple'
+      }),
+      rv.RunView<{ID: string; Name: string; Description: string}>({
+        EntityName: 'MJ: Actions',
+        Fields: ['ID', 'Name', 'Description'],
+        ExtraFilter: `Status='Active'`,
+        OrderBy: 'Name',
+        ResultType: 'simple'
       })
     ]);
 
@@ -1135,6 +1193,13 @@ export class HomeDashboardComponent extends BaseResourceComponent implements Aft
     this.AvailableQueries = (queries.Results || []).map(q => ({
       id: q.ID, name: q.Name,
       pinned: this.pinService.IsPinned('Queries', { queryId: q.ID })
+    }));
+
+    // Actions can be pinned multiple times with different configs, so we treat them
+    // as always "not pinned" in the panel — the checkmark would be misleading.
+    this.AvailableActions = (actions.Results || []).map(a => ({
+      id: a.ID, name: a.Name, description: a.Description || '',
+      pinned: false
     }));
 
     // Load apps with their nav items
@@ -1253,6 +1318,68 @@ export class HomeDashboardComponent extends BaseResourceComponent implements Aft
         `"${name}" pinned to Home`, 'success', 3000
       );
     }
+  }
+
+  // =============================================
+  // ACTION PIN DIALOGS
+  // =============================================
+
+  /**
+   * Open the Configure Action Pin dialog — triggered when the user clicks an Action
+   * in the Add Pin panel. Actions need extra configuration (preset params, runtime
+   * params, title, theming) before they can be pinned.
+   */
+  OpenActionPinConfig(actionId: string, actionName: string, description: string): void {
+    this.ActionConfigActionId = actionId;
+    this.ActionConfigActionName = actionName;
+    this.ActionConfigActionDescription = description || null;
+    this.ActionConfigDialogVisible = true;
+    this.cdr.markForCheck();
+  }
+
+  /** Callback from the Configure Action Pin dialog */
+  OnActionConfigResult(result: ActionPinConfigResult): void {
+    this.ActionConfigDialogVisible = false;
+    this.cdr.markForCheck();
+    if (result.Action !== 'save' || !result.Pin) return;
+
+    const p = result.Pin;
+    const config: ActionPinConfiguration = {
+      actionId: p.ActionID,
+      actionName: p.ActionName,
+      presetParams: p.PresetParams,
+      runtimeParamNames: p.RuntimeParamNames,
+      accentColor: p.AccentColor,
+      svgIcon: p.SvgIcon,
+      displayName: p.DisplayName
+    };
+
+    const input: HomeAppPinInput = {
+      DisplayName: p.DisplayName,
+      ResourceType: 'Actions',
+      Icon: p.FaIcon,
+      Color: p.AccentColor,
+      Configuration: config as unknown as Record<string, unknown>,
+      Group: this.getSelectedGroup() || undefined
+    };
+
+    const added = this.pinService.AddPin(input);
+    if (added) {
+      MJNotificationService.Instance.CreateSimpleNotification(
+        `"${p.DisplayName}" pinned to Home`, 'success', 3000
+      );
+    } else {
+      MJNotificationService.Instance.CreateSimpleNotification(
+        'A pin with the same title and config already exists.', 'warning', 3000
+      );
+    }
+  }
+
+  /** Callback from the Run Action Pin dialog */
+  OnActionRunnerResult(_result: ActionPinRunResult): void {
+    this.ActionRunnerDialogVisible = false;
+    this.ActionRunnerPin = null;
+    this.cdr.markForCheck();
   }
 
   /**

--- a/packages/Angular/Explorer/dashboards/src/Home/home-dashboard.component.ts
+++ b/packages/Angular/Explorer/dashboards/src/Home/home-dashboard.component.ts
@@ -1,5 +1,4 @@
 import { Component, AfterViewInit, OnDestroy, ChangeDetectorRef, ViewChild, ChangeDetectionStrategy, inject } from '@angular/core';
-import { DomSanitizer, SafeHtml } from '@angular/platform-browser';
 import { Subject } from 'rxjs';
 import { takeUntil } from 'rxjs/operators';
 import { BaseResourceComponent, NavigationService, RecentAccessService, RecentAccessItem, HomeAppPinService, HomeAppPinnedItem, HomeAppPinInput, ActionPinConfiguration } from '@memberjunction/ng-shared';
@@ -99,9 +98,6 @@ export class HomeDashboardComponent extends BaseResourceComponent implements Aft
   public ActionRunnerDialogVisible = false;
   public ActionRunnerPin: HomeAppPinnedItem | null = null;
 
-  // Cache of sanitized SVG icons, keyed by pin ID. Rebuilt when Pins$ emits.
-  private pinSvgIconCache = new Map<string, SafeHtml>();
-
   // Collapsible section state for Add Pin panel
   public PanelSectionCollapsed: Record<string, boolean> = {};
 
@@ -153,8 +149,7 @@ export class HomeDashboardComponent extends BaseResourceComponent implements Aft
   constructor(
     private appManager: ApplicationManager,
     private recentAccessService: RecentAccessService,
-    private cdr: ChangeDetectorRef,
-    private sanitizer: DomSanitizer
+    private cdr: ChangeDetectorRef
   ) {
     super();
   }
@@ -929,20 +924,6 @@ export class HomeDashboardComponent extends BaseResourceComponent implements Aft
     }
   }
 
-  /**
-   * Returns a sanitized SafeHtml for the pin's AI-generated SVG icon, or null
-   * if the pin doesn't have one. Cached per pin ID to avoid re-sanitizing on every render.
-   */
-  GetPinSvgIcon(pin: HomeAppPinnedItem): SafeHtml | null {
-    const svg = (pin.Configuration as unknown as ActionPinConfiguration).svgIcon;
-    if (!svg) return null;
-    const cached = this.pinSvgIconCache.get(pin.Id);
-    if (cached) return cached;
-    const safe = this.sanitizer.bypassSecurityTrustHtml(svg);
-    this.pinSvgIconCache.set(pin.Id, safe);
-    return safe;
-  }
-
   /** Accent color for a pin — prefers the stored accentColor in Configuration, falls back to Color, then CSS var */
   GetPinAccentColor(pin: HomeAppPinnedItem): string {
     const fromConfig = (pin.Configuration as unknown as ActionPinConfiguration).accentColor;
@@ -1350,7 +1331,6 @@ export class HomeDashboardComponent extends BaseResourceComponent implements Aft
       presetParams: p.PresetParams,
       runtimeParamNames: p.RuntimeParamNames,
       accentColor: p.AccentColor,
-      svgIcon: p.SvgIcon,
       displayName: p.DisplayName
     };
 

--- a/packages/Angular/Explorer/dashboards/src/core-dashboards.module.ts
+++ b/packages/Angular/Explorer/dashboards/src/core-dashboards.module.ts
@@ -16,6 +16,8 @@ import { SharedPipesModule } from './shared/shared-pipes.module';
 // Core components — eagerly loaded, most-visited pages
 import { EntityAdminDashboardComponent } from './EntityAdmin/entity-admin-dashboard.component';
 import { HomeDashboardComponent } from './Home/home-dashboard.component';
+import { ActionPinConfigDialogComponent } from './Home/action-pin-config-dialog.component';
+import { ActionPinRunnerDialogComponent } from './Home/action-pin-runner-dialog.component';
 // HomeApplication is a non-Angular class registered via @RegisterClass(BaseApplication, 'HomeApplication').
 // It must be imported here so ESBuild includes it in this chunk, making it discoverable
 // via the lazy loading system when ApplicationManager calls CreateInstanceAsync.
@@ -48,6 +50,8 @@ import { VersionHistoryGraphResourceComponent } from './VersionHistory/component
   declarations: [
     EntityAdminDashboardComponent,
     HomeDashboardComponent,
+    ActionPinConfigDialogComponent,
+    ActionPinRunnerDialogComponent,
     SystemDiagnosticsComponent,
     QueryBrowserResourceComponent,
     DashboardBrowserResourceComponent,

--- a/packages/Angular/Explorer/shared/src/lib/home-pin.service.ts
+++ b/packages/Angular/Explorer/shared/src/lib/home-pin.service.ts
@@ -216,6 +216,20 @@ export class HomeAppPinService {
         const sameQP = pinQP === configQP;
         return sameApp && sameNav && sameRoute && sameQP;
       }
+      case 'Actions': {
+        // A pinned Action is unique per (actionId + preset-params + runtime-params + title).
+        // Two pins targeting the same action with different preset configs are allowed —
+        // e.g. "Weekly Report — Sales" vs. "Weekly Report — Ops" both pin "Run Report".
+        if (pin.Configuration['actionId'] !== config['actionId']) return false;
+        const pinPreset = JSON.stringify(pin.Configuration['presetParams'] ?? {});
+        const configPreset = JSON.stringify(config['presetParams'] ?? {});
+        const pinRuntime = JSON.stringify(pin.Configuration['runtimeParamNames'] ?? []);
+        const configRuntime = JSON.stringify(config['runtimeParamNames'] ?? []);
+        const samePreset = pinPreset === configPreset;
+        const sameRuntime = pinRuntime === configRuntime;
+        const sameTitle = pin.DisplayName === (config['displayName'] ?? pin.DisplayName);
+        return samePreset && sameRuntime && sameTitle;
+      }
       default:
         return false;
     }

--- a/packages/Angular/Explorer/shared/src/lib/home-pin.types.ts
+++ b/packages/Angular/Explorer/shared/src/lib/home-pin.types.ts
@@ -56,8 +56,6 @@ export interface ActionPinConfiguration {
   presetParams: Record<string, string>;
   /** Names of ActionParams to prompt the user for when the pin is clicked */
   runtimeParamNames: string[];
-  /** Optional AI/user-authored SVG markup used as the pin icon instead of a FA icon */
-  svgIcon?: string;
   /** Hex accent color (e.g. '#4F46E5') used for the pin card background gradient */
   accentColor?: string;
   /** User's custom title (also stored on HomeAppPinnedItem.DisplayName for consistency) */

--- a/packages/Angular/Explorer/shared/src/lib/home-pin.types.ts
+++ b/packages/Angular/Explorer/shared/src/lib/home-pin.types.ts
@@ -44,6 +44,27 @@ export interface HomeAppPinnedItem {
 }
 
 /**
+ * Configuration shape for pins with ResourceType === 'Actions'.
+ * Stored inside HomeAppPinnedItem.Configuration as a plain object.
+ */
+export interface ActionPinConfiguration {
+  /** ID of the MJ Action to execute */
+  actionId: string;
+  /** Action name at pin time — kept for display in case the Action is renamed */
+  actionName: string;
+  /** Parameter values baked into the pin — passed every time the pin is invoked */
+  presetParams: Record<string, string>;
+  /** Names of ActionParams to prompt the user for when the pin is clicked */
+  runtimeParamNames: string[];
+  /** Optional AI/user-authored SVG markup used as the pin icon instead of a FA icon */
+  svgIcon?: string;
+  /** Hex accent color (e.g. '#4F46E5') used for the pin card background gradient */
+  accentColor?: string;
+  /** User's custom title (also stored on HomeAppPinnedItem.DisplayName for consistency) */
+  displayName?: string;
+}
+
+/**
  * Input for creating a new pin (ID, Sequence, and PinnedAt are auto-generated)
  */
 export type HomeAppPinInput = Omit<HomeAppPinnedItem, 'Id' | 'Sequence' | 'PinnedAt'>;


### PR DESCRIPTION
## Summary

- Adds a new **Quick Actions** section to the Home "Add Pin" panel that lets users pin any Active Action as a styled quick-launch card. Each pin stores a custom title, preset parameter values, and a list of parameters to prompt for at runtime.
- Adds two dialogs: **Configure Action Pin** (pick accent color + FA icon, set title, choose preset-vs-runtime per parameter) and **Run Action Pin** (prompts for runtime params then executes via `GraphQLActionClient.RunAction`).
- Extends `HomeAppPinService` with an `'Actions'` dedup case and adds an `ActionPinConfiguration` interface on `@memberjunction/ng-shared`. No database migration — all config lives inside the existing `UserSettings.HomeApp.PinnedItems` JSON blob the current pin system already uses.

## Test plan

- [ ] From Home, click **Add Pin** and confirm the new **Quick Actions** section lists all `Status='Active'` Actions
- [ ] Click **Configure** on an Action → dialog opens with the action name, title input, color palette (8), icon palette (30), and a parameter row per `MJ: Action Params` entry for that action
- [ ] Required params default to **Preset** with the Action's DefaultValue pre-filled; optional params default to **Prompt**
- [ ] **Pin to Home** is disabled until a title is set and every required-preset has a value
- [ ] Saving creates a pin with `ResourceType='Actions'` in `UserSettings.HomeApp.PinnedItems`; accent color is visible on the card; drag-drop / rename / group / unpin all work via the existing pin UI
- [ ] Clicking a pinned action opens the **Run Action Pin** dialog showing only the runtime fields (or a "no input needed" panel if all params are preset)
- [ ] **Run** submits `GraphQLActionClient.RunAction(actionId, [...presetParams, ...runtimeParams])` and shows a success/failure card with the action's Message
- [ ] Pin the same Action twice with different presets/titles — both pins should coexist (dedup compares actionId + presetParams + runtimeParamNames + title)
- [ ] Unrelated pin types (Dashboards, Views, Queries, Records, Custom) still render and open correctly
- [ ] Refresh/re-login verifies all Action pins reload from `UserSettings`

🤖 Generated with [Claude Code](https://claude.com/claude-code)