### PR TITLE
fix: Remove prefill+stop sequences from Loop and Flow Agent Type system prompts

### DIFF
--- a/metadata/prompts/.prompts.json
+++ b/metadata/prompts/.prompts.json
@@ -206,9 +206,9 @@
       "TemplateText": "@file:templates/system/flow-agent-type-system-prompt.template.md",
       "Status": "Active",
       "ResponseFormat": "Any",
-      "AssistantPrefill": "```json",
-      "StopSequences": "\n```",
-      "PrefillFallbackMode": "SystemInstruction",
+      "AssistantPrefill": null,
+      "StopSequences": null,
+      "PrefillFallbackMode": "Ignore",
       "SelectionStrategy": "Specific",
       "PowerPreference": "Highest",
       "ParallelizationMode": "None",
@@ -305,8 +305,8 @@
       "ID": "43A6D122-4A76-453F-97D6-82CACC619227"
     },
     "sync": {
-      "lastModified": "2026-03-26T22:04:40.317Z",
-      "checksum": "46dd9b3726e7a2b0fcfc4ffea7c1a88e6485dee1523584f07b3730ef7556f60f"
+      "lastModified": "2026-04-20T13:29:15.027Z",
+      "checksum": "9691932b72cd4e41ebb8a535e67ecd202e88925c940eaff0df6b146fb225c6ba"
     }
   },
   {

--- a/metadata/prompts/.prompts.json
+++ b/metadata/prompts/.prompts.json
@@ -95,9 +95,9 @@
       "TemplateText": "@file:templates/system/loop-agent-type-system-prompt.template.md",
       "Status": "Active",
       "ResponseFormat": "Any",
-      "AssistantPrefill": "```json",
-      "StopSequences": "\n```",
-      "PrefillFallbackMode": "SystemInstruction",
+      "AssistantPrefill": null,
+      "StopSequences": null,
+      "PrefillFallbackMode": "Ignore",
       "SelectionStrategy": "Specific",
       "PowerPreference": "Highest",
       "ParallelizationMode": "None",
@@ -194,8 +194,8 @@
       "ID": "FF7D441F-36E1-458A-B548-0FC2208923BE"
     },
     "sync": {
-      "lastModified": "2026-04-09T17:24:48.302Z",
-      "checksum": "f38b1865649997b9471f17e07549f4aa36ebf5d3d709df1902fbf96e01c6eb03"
+      "lastModified": "2026-04-20T04:31:30.175Z",
+      "checksum": "0596b6fb813344600038466ab00939c871018a47d7508cda228e930507c52b35"
     }
   },
   {

--- a/metadata/prompts/templates/system/loop-agent-type-system-prompt.template.md
+++ b/metadata/prompts/templates/system/loop-agent-type-system-prompt.template.md
@@ -433,6 +433,7 @@ After completing work, use `actionableCommands` for navigation buttons and `auto
 {% endif %}
 
 # **CRITICAL**
+- Your **entire** response must be only JSON with no leading or trailing characters!
 - Must adhere to [LoopAgentResponse](#response-format)
 {% if __agentTypePromptParams.includeResponseFormDocs != false %}- Use `responseForm` when you need user input (replaces old suggestedResponses pattern){% endif %}
 {% if __agentTypePromptParams.includeCommandDocs != false %}- Use `actionableCommands` to provide navigation buttons after completing work


### PR DESCRIPTION
## Summary
- Clears `AssistantPrefill` and `StopSequences` from the **Loop Agent Type** and **Flow Agent Type** system prompt records — the `\n```​` stop sequence fires on closing code fences inside embedded markdown (TDDs, Mermaid diagrams, data strategy docs) within JSON responses, truncating output mid-JSON
- Sets `PrefillFallbackMode` to `Ignore` (the column default) on both prompts since prefill is no longer used
- Restores the explicit "entire response must be only JSON" instruction in the Loop Agent Type template's CRITICAL section (Flow already had this)
- Standalone prompts with simple JSON output (agent-manager, query-gen, sage-intent-check, codegen, etc.) retain their own prefill/stop settings — this change is scoped to agent type system prompts that can chain child prompts with embedded content

## Background
Two MJ commits combined to create a failure mode for agents running on Gemini/Vertex:
1. **Mar 26 (ef882a6)** — Added `AssistantPrefill`/`StopSequences` to the Loop Agent Type system prompt
2. **Apr 9 (97020fd)** — Fixed Gemini driver's stop sequence casing, making stop sequences actually take effect

Since April 9, every loop/flow agent on Gemini has an active `\n```​` stop sequence. Agents that produce JSON with embedded markdown hit closing code fences that trigger the stop sequence prematurely, truncating responses mid-JSON.

## Test plan
- [ ] Run `mj sync push --dir=metadata --include="prompts"` — verify the field changes apply cleanly to both prompts
- [ ] Test a loop agent to confirm it still produces valid JSON without the prefill mechanism
- [ ] Test an agent that embeds markdown in JSON to confirm responses are no longer truncated

🤖 Generated with [Claude Code](https://claude.com/claude-code)