### PR TITLE
fix(conversations): Redesign non-image attachment tiles, fix snapshot "0 B"

### DIFF
--- a/.changeset/ten-rabbits-wish.md
+++ b/.changeset/ten-rabbits-wish.md
@@ -1,0 +1,6 @@
+---
+"@memberjunction/ng-conversations": patch
+"@memberjunction/core-entities-server": patch
+---
+
+Auto-populate ContentSizeBytes on artifact version saves; redesign non-image attachement tiles with type badge and restore click-to-open/download behavior

--- a/package-lock.json
+++ b/package-lock.json
@@ -44822,6 +44822,7 @@
       "dependencies": {
         "@memberjunction/core": "5.28.0",
         "@memberjunction/core-entities": "5.28.0",
+        "@memberjunction/global": "5.28.0",
         "@memberjunction/ng-shared-generic": "5.28.0",
         "tslib": "^2.8.1"
       },

--- a/package-lock.json
+++ b/package-lock.json
@@ -34,7 +34,8 @@
         "packages/Credentials/*",
         "packages/APIKeys/*",
         "packages/OpenApp/*",
-        "packages/Integration/*"
+        "packages/Integration/*",
+        "packages/Archiving/*"
       ],
       "dependencies": {
         "archiver": "~7.0.0",
@@ -11401,6 +11402,14 @@
       "resolved": "packages/APIKeys/Base",
       "link": true
     },
+    "node_modules/@memberjunction/archiving-action": {
+      "resolved": "packages/Archiving/Action",
+      "link": true
+    },
+    "node_modules/@memberjunction/archiving-engine": {
+      "resolved": "packages/Archiving/Engine",
+      "link": true
+    },
     "node_modules/@memberjunction/auth-providers": {
       "resolved": "packages/AuthProviders",
       "link": true
@@ -11603,6 +11612,10 @@
     },
     "node_modules/@memberjunction/ng-ai-test-harness": {
       "resolved": "packages/Angular/Generic/ai-test-harness",
+      "link": true
+    },
+    "node_modules/@memberjunction/ng-archive-manager": {
+      "resolved": "packages/Angular/Generic/archive-manager",
       "link": true
     },
     "node_modules/@memberjunction/ng-artifacts": {
@@ -44013,6 +44026,7 @@
         "@memberjunction/ng-agent-requests": "5.28.0",
         "@memberjunction/ng-agents": "5.28.0",
         "@memberjunction/ng-ai-test-harness": "5.28.0",
+        "@memberjunction/ng-archive-manager": "5.28.0",
         "@memberjunction/ng-base-application": "5.28.0",
         "@memberjunction/ng-clustering": "5.28.0",
         "@memberjunction/ng-code-editor": "5.28.0",
@@ -44799,6 +44813,28 @@
         "@angular/common": "21.1.3",
         "@angular/core": "21.1.3",
         "@angular/forms": "21.1.3"
+      }
+    },
+    "packages/Angular/Generic/archive-manager": {
+      "name": "@memberjunction/ng-archive-manager",
+      "version": "5.28.0",
+      "license": "ISC",
+      "dependencies": {
+        "@memberjunction/core": "5.28.0",
+        "@memberjunction/core-entities": "5.28.0",
+        "@memberjunction/ng-shared-generic": "5.28.0",
+        "tslib": "^2.8.1"
+      },
+      "devDependencies": {
+        "@angular/compiler": "21.1.3",
+        "@angular/compiler-cli": "21.1.3",
+        "vitest": "^4.0.18"
+      },
+      "peerDependencies": {
+        "@angular/common": "21.1.3",
+        "@angular/core": "21.1.3",
+        "@angular/forms": "21.1.3",
+        "rxjs": "^7.8.2"
       }
     },
     "packages/Angular/Generic/artifacts": {
@@ -47781,6 +47817,265 @@
       },
       "engines": {
         "node": ">=18.0.0"
+      }
+    },
+    "packages/Archiving/Action": {
+      "name": "@memberjunction/archiving-action",
+      "version": "5.28.0",
+      "license": "ISC",
+      "dependencies": {
+        "@memberjunction/actions": "5.28.0",
+        "@memberjunction/actions-base": "5.28.0",
+        "@memberjunction/archiving-engine": "5.28.0",
+        "@memberjunction/core": "5.28.0",
+        "@memberjunction/global": "5.28.0"
+      }
+    },
+    "packages/Archiving/Engine": {
+      "name": "@memberjunction/archiving-engine",
+      "version": "5.28.0",
+      "license": "ISC",
+      "dependencies": {
+        "@memberjunction/core": "5.28.0",
+        "@memberjunction/core-entities": "5.28.0",
+        "@memberjunction/global": "5.28.0",
+        "@memberjunction/storage": "5.28.0"
+      },
+      "devDependencies": {
+        "typescript": "^5.9.3",
+        "vitest": "^3.1.1"
+      }
+    },
+    "packages/Archiving/Engine/node_modules/@vitest/expect": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-3.2.4.tgz",
+      "integrity": "sha512-Io0yyORnB6sikFlt8QW5K7slY4OjqNX9jmJQ02QDda8lyM6B5oNgVWoSoKPac8/kgnCUzuHQKrSLtu/uOqqrig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "3.2.4",
+        "@vitest/utils": "3.2.4",
+        "chai": "^5.2.0",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "packages/Archiving/Engine/node_modules/@vitest/pretty-format": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-3.2.4.tgz",
+      "integrity": "sha512-IVNZik8IVRJRTr9fxlitMKeJeXFFFN0JaB9PHPGQ8NKQbGpfjlTx9zO4RefN8gp7eqjNy8nyK3NZmBzOPeIxtA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "packages/Archiving/Engine/node_modules/@vitest/runner": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-3.2.4.tgz",
+      "integrity": "sha512-oukfKT9Mk41LreEW09vt45f8wx7DordoWUZMYdY/cyAk7w5TWkTRCNZYF7sX7n2wB7jyGAl74OxgwhPgKaqDMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "3.2.4",
+        "pathe": "^2.0.3",
+        "strip-literal": "^3.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "packages/Archiving/Engine/node_modules/@vitest/snapshot": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-3.2.4.tgz",
+      "integrity": "sha512-dEYtS7qQP2CjU27QBC5oUOxLE/v5eLkGqPE0ZKEIDGMs4vKWe7IjgLOeauHsR0D5YuuycGRO5oSRXnwnmA78fQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "3.2.4",
+        "magic-string": "^0.30.17",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "packages/Archiving/Engine/node_modules/@vitest/spy": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-3.2.4.tgz",
+      "integrity": "sha512-vAfasCOe6AIK70iP5UD11Ac4siNUNJ9i/9PZ3NKx07sG6sUxeag1LWdNrMWeKKYBLlzuK+Gn65Yd5nyL6ds+nw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyspy": "^4.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "packages/Archiving/Engine/node_modules/@vitest/utils": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-3.2.4.tgz",
+      "integrity": "sha512-fB2V0JFrQSMsCo9HiSq3Ezpdv4iYaXRG1Sx8edX3MwxfyNn83mKiGzOcH+Fkxt4MHxr3y42fQi1oeAInqgX2QA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "3.2.4",
+        "loupe": "^3.1.4",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "packages/Archiving/Engine/node_modules/chai": {
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-5.3.3.tgz",
+      "integrity": "sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "assertion-error": "^2.0.1",
+        "check-error": "^2.1.1",
+        "deep-eql": "^5.0.1",
+        "loupe": "^3.1.0",
+        "pathval": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "packages/Archiving/Engine/node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "packages/Archiving/Engine/node_modules/tinyexec": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.2.tgz",
+      "integrity": "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "packages/Archiving/Engine/node_modules/tinyrainbow": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-2.0.0.tgz",
+      "integrity": "sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "packages/Archiving/Engine/node_modules/vitest": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-3.2.4.tgz",
+      "integrity": "sha512-LUCP5ev3GURDysTWiP47wRRUpLKMOfPh+yKTx3kVIEiu5KOMeqzpnYNsKyOoVrULivR8tLcks4+lga33Whn90A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/chai": "^5.2.2",
+        "@vitest/expect": "3.2.4",
+        "@vitest/mocker": "3.2.4",
+        "@vitest/pretty-format": "^3.2.4",
+        "@vitest/runner": "3.2.4",
+        "@vitest/snapshot": "3.2.4",
+        "@vitest/spy": "3.2.4",
+        "@vitest/utils": "3.2.4",
+        "chai": "^5.2.0",
+        "debug": "^4.4.1",
+        "expect-type": "^1.2.1",
+        "magic-string": "^0.30.17",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.2",
+        "std-env": "^3.9.0",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^0.3.2",
+        "tinyglobby": "^0.2.14",
+        "tinypool": "^1.1.1",
+        "tinyrainbow": "^2.0.0",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0",
+        "vite-node": "3.2.4",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@types/debug": "^4.1.12",
+        "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
+        "@vitest/browser": "3.2.4",
+        "@vitest/ui": "3.2.4",
+        "happy-dom": "*",
+        "jsdom": "*"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@types/debug": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        }
+      }
+    },
+    "packages/Archiving/Engine/node_modules/vitest/node_modules/@vitest/mocker": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-3.2.4.tgz",
+      "integrity": "sha512-46ryTE9RZO/rfDd7pEqFl7etuyzekzEhUbTW3BvmeO/BcCMEgq59BKhek3dXDWgAj4oMK6OZi+vRr1wPW6qjEQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "3.2.4",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.17"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
       }
     },
     "packages/AuthProviders": {
@@ -55617,6 +55912,8 @@
         "@memberjunction/ai-vertex": "5.28.0",
         "@memberjunction/ai-xai": "5.28.0",
         "@memberjunction/ai-zhipu": "5.28.0",
+        "@memberjunction/archiving-action": "5.28.0",
+        "@memberjunction/archiving-engine": "5.28.0",
         "@memberjunction/codegen-lib": "5.28.0",
         "@memberjunction/communication-ms-graph": "5.28.0",
         "@memberjunction/communication-sendgrid": "5.28.0",

--- a/packages/Angular/Generic/archive-manager/package.json
+++ b/packages/Angular/Generic/archive-manager/package.json
@@ -34,6 +34,7 @@
   "dependencies": {
     "@memberjunction/core": "5.28.0",
     "@memberjunction/core-entities": "5.28.0",
+    "@memberjunction/global": "5.28.0",
     "@memberjunction/ng-shared-generic": "5.28.0",
     "tslib": "^2.8.1"
   },

--- a/packages/Angular/Generic/archive-manager/package.json
+++ b/packages/Angular/Generic/archive-manager/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@memberjunction/ng-archive-manager",
-  "version": "5.27.1",
+  "version": "5.28.0",
   "description": "MemberJunction: Angular Archive Manager - UI components for managing entity field archiving, restoration, and configuration.",
   "main": "./dist/public-api.js",
   "typings": "./dist/public-api.d.ts",
@@ -32,9 +32,9 @@
     "rxjs": "^7.8.2"
   },
   "dependencies": {
-    "@memberjunction/core": "5.27.1",
-    "@memberjunction/core-entities": "5.27.1",
-    "@memberjunction/ng-shared-generic": "5.27.1",
+    "@memberjunction/core": "5.28.0",
+    "@memberjunction/core-entities": "5.28.0",
+    "@memberjunction/ng-shared-generic": "5.28.0",
     "tslib": "^2.8.1"
   },
   "sideEffects": false,

--- a/packages/Angular/Generic/archive-manager/src/lib/archive-config/archive-config-admin.component.ts
+++ b/packages/Angular/Generic/archive-manager/src/lib/archive-config/archive-config-admin.component.ts
@@ -7,6 +7,7 @@ import {
   inject,
 } from '@angular/core';
 import { CompositeKey, Metadata, RunView } from '@memberjunction/core';
+import { UUIDsEqual } from '@memberjunction/global';
 import {
   MJArchiveConfigurationEntity,
   MJArchiveConfigurationEntityEntity,
@@ -113,7 +114,7 @@ export class ArchiveConfigAdminComponent implements OnInit, OnDestroy {
 
   /** Check if a config is the currently selected one */
   IsSelectedConfig(config: ArchiveConfig): boolean {
-    return this.SelectedConfig?.ID === config.ID;
+    return UUIDsEqual(this.SelectedConfig?.ID, config.ID);
   }
 
   /** Add a new empty entity row */
@@ -138,7 +139,7 @@ export class ArchiveConfigAdminComponent implements OnInit, OnDestroy {
 
   /** Remove an entity row */
   RemoveEntity(entity: ArchiveConfigEntity): void {
-    this.ConfigEntities = this.ConfigEntities.filter((e) => e.ID !== entity.ID);
+    this.ConfigEntities = this.ConfigEntities.filter((e) => !UUIDsEqual(e.ID, entity.ID));
     this.cdr.markForCheck();
   }
 
@@ -185,7 +186,7 @@ export class ArchiveConfigAdminComponent implements OnInit, OnDestroy {
     const configId = this.SelectedConfig.ID;
     this.clearStatus();
 
-    const original = this.Configs.find((c) => c.ID === configId);
+    const original = this.Configs.find((c) => UUIDsEqual(c.ID, configId));
     if (original) {
       this.SelectedConfig = { ...original };
       await this.loadConfigEntities(configId);

--- a/packages/Angular/Generic/archive-manager/src/lib/archive-restore/archive-restore-dialog.component.ts
+++ b/packages/Angular/Generic/archive-manager/src/lib/archive-restore/archive-restore-dialog.component.ts
@@ -9,6 +9,7 @@ import {
   inject,
 } from '@angular/core';
 import { RunView } from '@memberjunction/core';
+import { UUIDsEqual } from '@memberjunction/global';
 
 /** Represents a single archived version of a record */
 export interface ArchiveVersion {
@@ -118,7 +119,7 @@ export class ArchiveRestoreDialogComponent implements OnDestroy {
 
   /** Check if a version is the currently selected one */
   IsSelected(version: ArchiveVersion): boolean {
-    return this.SelectedVersion?.ID === version.ID;
+    return UUIDsEqual(this.SelectedVersion?.ID, version.ID);
   }
 
   /** Initiate restore of the selected version */

--- a/packages/Angular/Generic/conversations/src/__tests__/attachment-badge.test.ts
+++ b/packages/Angular/Generic/conversations/src/__tests__/attachment-badge.test.ts
@@ -1,0 +1,79 @@
+import { describe, it, expect } from 'vitest';
+import { ShortBadgeText, BadgeTextForAttachment } from '../lib/util/attachment-badge';
+import type { MessageAttachment } from '../lib/components/message/message-item.component';
+
+function makeAttachment(overrides: Partial<MessageAttachment>): MessageAttachment {
+    return {
+        id: 'a1',
+        type: 'Document',
+        mimeType: 'text/plain',
+        fileName: null,
+        sizeBytes: 0,
+        ...overrides
+    } as MessageAttachment;
+}
+
+describe('ShortBadgeText', () => {
+    it('returns "FILE" for empty or whitespace-only input', () => {
+        expect(ShortBadgeText('')).toBe('FILE');
+        expect(ShortBadgeText('   ')).toBe('FILE');
+        expect(ShortBadgeText(null)).toBe('FILE');
+        expect(ShortBadgeText(undefined)).toBe('FILE');
+    });
+
+    it('uppercases names that already fit within 10 characters', () => {
+        expect(ShortBadgeText('Report')).toBe('REPORT');
+        expect(ShortBadgeText('Snapshot')).toBe('SNAPSHOT');
+        expect(ShortBadgeText('json')).toBe('JSON');
+    });
+
+    it('takes the last word when the full name is too long', () => {
+        expect(ShortBadgeText('Data Snapshot')).toBe('SNAPSHOT');
+        expect(ShortBadgeText('Business Intelligence Dashboard')).toBe('DASHBOARD');
+        expect(ShortBadgeText('Skip Report')).toBe('REPORT');
+    });
+
+    it('truncates with ellipsis when the last word is still too long', () => {
+        expect(ShortBadgeText('Monstrouslylongword')).toBe('MONSTROUS…');
+    });
+
+    it('trims surrounding whitespace before measuring length', () => {
+        expect(ShortBadgeText('  Report  ')).toBe('REPORT');
+    });
+});
+
+describe('BadgeTextForAttachment', () => {
+    it('prefers the artifact type name over the file extension', () => {
+        const a = makeAttachment({
+            artifactTypeName: 'Data Snapshot',
+            fileName: 'snapshot.json'
+        });
+        expect(BadgeTextForAttachment(a)).toBe('SNAPSHOT');
+    });
+
+    it('uses the file extension when no artifact type is present', () => {
+        expect(BadgeTextForAttachment(makeAttachment({ fileName: 'Q1_deck.pdf' }))).toBe('PDF');
+        expect(BadgeTextForAttachment(makeAttachment({ fileName: 'data.csv' }))).toBe('CSV');
+    });
+
+    it('uppercases the extension and caps at 10 characters', () => {
+        expect(BadgeTextForAttachment(makeAttachment({ fileName: 'weird.abcdefghijklmnop' }))).toBe('ABCDEFGHIJ');
+    });
+
+    it('falls back to the mime subtype when the filename has no extension', () => {
+        expect(BadgeTextForAttachment(makeAttachment({ fileName: 'noext', mimeType: 'application/pdf' }))).toBe('PDF');
+    });
+
+    it('strips mime parameters (e.g. charset) before using as a fallback', () => {
+        expect(BadgeTextForAttachment(makeAttachment({ fileName: null, mimeType: 'text/plain; charset=utf-8' }))).toBe('PLAIN');
+    });
+
+    it('returns "FILE" when neither extension nor usable mime is available', () => {
+        expect(BadgeTextForAttachment(makeAttachment({ fileName: null, mimeType: '' }))).toBe('FILE');
+    });
+
+    it('ignores a leading dot filename (e.g. ".gitignore") and falls back to mime', () => {
+        // lastIndexOf('.') === 0 → dot is not > 0, so we fall through to mime
+        expect(BadgeTextForAttachment(makeAttachment({ fileName: '.gitignore', mimeType: 'text/plain' }))).toBe('PLAIN');
+    });
+});

--- a/packages/Angular/Generic/conversations/src/lib/components/conversation/conversation-chat-area.component.ts
+++ b/packages/Angular/Generic/conversations/src/lib/components/conversation/conversation-chat-area.component.ts
@@ -1671,9 +1671,26 @@ export class ConversationChatAreaComponent implements OnInit, OnDestroy, AfterVi
       this.selectedImageAlt = attachment.fileName || 'Image attachment';
       this.selectedImageFileName = attachment.fileName || 'image';
       this.showImageViewer = true;
-    } else {
-      // For non-image attachments, could trigger download or other action
-      console.log('Non-image attachment clicked:', attachment);
+      return;
+    }
+
+    // Artifact-backed attachments open in the artifact viewer panel.
+    if (attachment.source === 'artifact' && attachment.artifactId) {
+      this.onArtifactClicked({
+        artifactId: attachment.artifactId,
+        versionId: attachment.artifactVersionId
+      });
+      return;
+    }
+
+    // Plain uploads: trigger a browser download if we have a usable content URL.
+    if (attachment.contentUrl) {
+      const a = document.createElement('a');
+      a.href = attachment.contentUrl;
+      a.download = attachment.fileName || 'download';
+      document.body.appendChild(a);
+      a.click();
+      document.body.removeChild(a);
     }
   }
 

--- a/packages/Angular/Generic/conversations/src/lib/components/message/message-item.component.css
+++ b/packages/Angular/Generic/conversations/src/lib/components/message/message-item.component.css
@@ -1468,33 +1468,73 @@
   font-size: 24px;
 }
 
-.attachment-file {
+/* Non-image attachment tile: horizontal strip with UPPERCASE type badge,
+   filename, and size. Artifact-typed attachments get a brand-primary tinted
+   badge to distinguish them from plain uploads. */
+.attachment-strip {
   display: flex;
-  flex-direction: column;
+  align-items: center;
+  gap: 12px;
+  padding: 8px 12px 8px 8px;
+  width: 320px;
+  max-width: 100%;
+  min-height: 56px;
+  cursor: pointer;
+  border-radius: 8px;
+  background: var(--mj-bg-surface);
+  border: 1px solid var(--mj-border-default);
+  transition: background 0.15s, border-color 0.15s;
+}
+
+.attachment-strip:hover {
+  background: var(--mj-bg-surface-hover);
+  border-color: var(--mj-border-strong);
+}
+
+.attachment-badge {
+  flex: 0 0 auto;
+  min-width: 48px;
+  height: 48px;
+  padding: 0 10px;
+  display: flex;
   align-items: center;
   justify-content: center;
-  padding: 16px 20px;
-  min-width: 120px;
-  gap: 6px;
-}
-
-.attachment-file i {
-  font-size: 28px;
+  border-radius: 6px;
+  font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+  font-size: 11px;
+  font-weight: 700;
+  background: var(--mj-bg-surface-card);
   color: var(--mj-text-secondary);
+  border: 1px solid var(--mj-border-subtle);
+  user-select: none;
+  text-align: center;
+  line-height: 1;
+  white-space: nowrap;
 }
 
-.attachment-file .file-name {
-  font-size: 12px;
+.attachment-strip.is-artifact .attachment-badge {
+  background: color-mix(in srgb, var(--mj-brand-primary) 12%, var(--mj-bg-surface));
+  color: var(--mj-brand-primary);
+  border-color: color-mix(in srgb, var(--mj-brand-primary) 25%, transparent);
+}
+
+.attachment-meta {
+  display: flex;
+  flex-direction: column;
+  min-width: 0; /* allow ellipsis inside flex child */
+  gap: 2px;
+}
+
+.attachment-strip .file-name {
+  font-size: 13px;
   font-weight: 500;
   color: var(--mj-text-primary);
-  max-width: 120px;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
-  text-align: center;
 }
 
-.attachment-file .file-size {
+.attachment-strip .file-size {
   font-size: 11px;
   color: var(--mj-text-muted);
 }
@@ -1506,8 +1546,7 @@
     height: 112px;
   }
 
-  .attachment-file {
-    padding: 12px 16px;
-    min-width: 100px;
+  .attachment-strip {
+    width: 100%;
   }
 }

--- a/packages/Angular/Generic/conversations/src/lib/components/message/message-item.component.html
+++ b/packages/Angular/Generic/conversations/src/lib/components/message/message-item.component.html
@@ -81,10 +81,10 @@
         @if (hasAttachments) {
           <div class="message-attachments">
             @for (attachment of attachments; track attachment.id) {
-              <div class="attachment-item"
-                [class.image-attachment]="attachment.type === 'Image'"
-                (click)="onAttachmentClick(attachment)">
-                @if (attachment.type === 'Image') {
+              @if (attachment.type === 'Image') {
+                <div class="attachment-item image-attachment"
+                  (click)="onAttachmentClick(attachment)"
+                  [title]="attachment.fileName || 'Image attachment'">
                   <img
                     [src]="attachment.thumbnailUrl || attachment.contentUrl"
                     [alt]="attachment.fileName || 'Image attachment'"
@@ -93,19 +93,19 @@
                   <div class="attachment-overlay">
                     <i class="fas fa-expand"></i>
                   </div>
-                } @else {
-                  <div class="attachment-file">
-                    <i class="fas"
-                       [ngClass]="{
-                         'fa-file-video': attachment.type === 'Video',
-                         'fa-file-audio': attachment.type === 'Audio',
-                         'fa-file': attachment.type === 'Document'
-                       }"></i>
+                </div>
+              } @else {
+                <div class="attachment-strip"
+                  [class.is-artifact]="!!attachment.artifactTypeName"
+                  (click)="onAttachmentClick(attachment)"
+                  [title]="attachment.fileName || 'File'">
+                  <div class="attachment-badge">{{ badgeTextFor(attachment) }}</div>
+                  <div class="attachment-meta">
                     <span class="file-name">{{ attachment.fileName || 'File' }}</span>
                     <span class="file-size">{{ formatFileSize(attachment.sizeBytes) }}</span>
                   </div>
-                }
-              </div>
+                </div>
+              }
             }
           </div>
         }

--- a/packages/Angular/Generic/conversations/src/lib/components/message/message-item.component.ts
+++ b/packages/Angular/Generic/conversations/src/lib/components/message/message-item.component.ts
@@ -22,6 +22,7 @@ import { MentionAutocompleteService } from '../../services/mention-autocomplete.
 import { SuggestedResponse } from '../../models/conversation-state.model';
 import { UICommandHandlerService } from '../../services/ui-command-handler.service';
 import { UUIDsEqual } from '@memberjunction/global';
+import { BadgeTextForAttachment } from '../../util/attachment-badge';
 
 /**
  * Represents an attachment on a message for display
@@ -38,6 +39,12 @@ export interface MessageAttachment {
   contentUrl?: string;
   /** Source of the attachment: 'upload' for chat uploads, 'artifact' for artifact picker */
   source?: 'upload' | 'artifact';
+  /** For source='artifact': the underlying MJArtifact.ID so clicks can open the viewer. */
+  artifactId?: string;
+  /** For source='artifact': the underlying MJArtifactVersion.ID. */
+  artifactVersionId?: string;
+  /** For source='artifact': resolved MJArtifactType.Name, e.g. "Data Snapshot". Drives the type badge. */
+  artifactTypeName?: string;
 }
 
 /**
@@ -935,6 +942,11 @@ export class MessageItemComponent extends BaseAngularComponent implements OnInit
     if (bytes < 1024) return bytes + ' B';
     if (bytes < 1024 * 1024) return (bytes / 1024).toFixed(1) + ' KB';
     return (bytes / (1024 * 1024)).toFixed(1) + ' MB';
+  }
+
+  /** Compact UPPERCASE badge label (artifact-type name wins over file extension). */
+  public badgeTextFor(attachment: MessageAttachment): string {
+    return BadgeTextForAttachment(attachment);
   }
 
   /**

--- a/packages/Angular/Generic/conversations/src/lib/services/conversation-attachment.service.ts
+++ b/packages/Angular/Generic/conversations/src/lib/services/conversation-attachment.service.ts
@@ -4,7 +4,9 @@ import {
   MJConversationDetailAttachmentEntity,
   MJConversationDetailArtifactEntity,
   MJArtifactVersionEntity,
-  MJAIModalityEntity
+  MJArtifactEntity,
+  MJAIModalityEntity,
+  ArtifactMetadataEngine
 } from '@memberjunction/core-entities';
 import {
   ConversationUtility,
@@ -72,7 +74,8 @@ export class ConversationAttachmentService {
       }, contextUser);
 
       if (artifactLinksResult.Success && artifactLinksResult.Results && artifactLinksResult.Results.length > 0) {
-        // Load the referenced artifact versions
+        // Load the referenced artifact versions AND their parent artifacts in parallel
+        // so we can resolve the semantic artifact-type name for the tile badge.
         const versionIds = artifactLinksResult.Results.map(l => `'${l.ArtifactVersionID}'`).join(',');
         const versionsResult = await rv.RunView<MJArtifactVersionEntity>({
           EntityName: 'MJ: Artifact Versions',
@@ -86,9 +89,32 @@ export class ConversationAttachmentService {
             versionMap.set(v.ID, v);
           }
 
+          // Bulk-load parent artifacts to get TypeID, then resolve type names via cached engine.
+          const artifactIds = Array.from(new Set(versionsResult.Results.map(v => v.ArtifactID).filter(Boolean)));
+          const artifactMap = new Map<string, MJArtifactEntity>();
+          if (artifactIds.length > 0) {
+            const artifactIdList = artifactIds.map(id => `'${id}'`).join(',');
+            const artifactsResult = await rv.RunView<MJArtifactEntity>({
+              EntityName: 'MJ: Artifacts',
+              ExtraFilter: `ID IN (${artifactIdList})`,
+              ResultType: 'entity_object'
+            }, contextUser);
+            if (artifactsResult.Success && artifactsResult.Results) {
+              for (const a of artifactsResult.Results) {
+                artifactMap.set(a.ID, a);
+              }
+            }
+            // Ensure the artifact-type cache is populated so FindArtifactTypeByID resolves.
+            await ArtifactMetadataEngine.Instance.Config(false, contextUser);
+          }
+
           for (const link of artifactLinksResult.Results) {
             const version = versionMap.get(link.ArtifactVersionID);
             if (version) {
+              const parentArtifact = artifactMap.get(version.ArtifactID);
+              const artifactType = parentArtifact
+                ? ArtifactMetadataEngine.Instance.FindArtifactTypeByID(parentArtifact.TypeID)
+                : undefined;
               const detailId = link.ConversationDetailID;
               if (!result.has(detailId)) {
                 result.set(detailId, []);
@@ -99,7 +125,10 @@ export class ConversationAttachmentService {
                 mimeType: version.MimeType || 'text/plain',
                 fileName: version.FileName || version.Name || 'Artifact',
                 sizeBytes: version.ContentSizeBytes || 0,
-                source: 'artifact'
+                source: 'artifact',
+                artifactId: version.ArtifactID || undefined,
+                artifactVersionId: version.ID,
+                artifactTypeName: artifactType?.Name || undefined
               } as MessageAttachment);
             }
           }

--- a/packages/Angular/Generic/conversations/src/lib/util/attachment-badge.ts
+++ b/packages/Angular/Generic/conversations/src/lib/util/attachment-badge.ts
@@ -1,0 +1,39 @@
+import type { MessageAttachment } from '../components/message/message-item.component';
+
+/**
+ * Reduce a potentially long artifact-type name to a compact UPPERCASE badge
+ * label that fits in ~10 characters. Rules:
+ *   1. If the whole name fits in 10 chars, uppercase it.
+ *   2. Otherwise take the LAST whitespace-delimited word ("Data Snapshot" → "SNAPSHOT",
+ *      "Business Intelligence Dashboard" → "DASHBOARD").
+ *   3. If that last word is still too long, truncate to 9 chars + ellipsis.
+ * Empty/whitespace input returns the generic fallback "FILE".
+ */
+export function ShortBadgeText(typeName: string | null | undefined): string {
+    const trimmed = (typeName ?? '').trim();
+    if (!trimmed) return 'FILE';
+    if (trimmed.length <= 10) return trimmed.toUpperCase();
+    const lastWord = trimmed.split(/\s+/).pop() ?? '';
+    if (lastWord.length <= 10) return lastWord.toUpperCase();
+    return lastWord.slice(0, 9).toUpperCase() + '…';
+}
+
+/**
+ * Pick the text that goes inside an attachment's type badge.
+ * Artifact-typed attachments win over file extension so a "Data Snapshot"
+ * doesn't just display as "JSON". For plain uploads, the file extension
+ * drives the badge; mime type is the final fallback.
+ */
+export function BadgeTextForAttachment(attachment: MessageAttachment): string {
+    if (attachment.artifactTypeName) {
+        return ShortBadgeText(attachment.artifactTypeName);
+    }
+    const name = attachment.fileName ?? '';
+    const dot = name.lastIndexOf('.');
+    if (dot > 0 && dot < name.length - 1) {
+        return name.slice(dot + 1).toUpperCase().slice(0, 10);
+    }
+    const mimeTail = attachment.mimeType?.split('/').pop()?.split(';')[0]?.trim();
+    if (mimeTail) return mimeTail.toUpperCase().slice(0, 10);
+    return 'FILE';
+}

--- a/packages/Archiving/Action/package.json
+++ b/packages/Archiving/Action/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@memberjunction/archiving-action",
   "type": "module",
-  "version": "5.27.1",
+  "version": "5.28.0",
   "description": "Archive and restore actions for MemberJunction Archiving Engine",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -13,10 +13,10 @@
   "author": "MemberJunction.com",
   "license": "ISC",
   "dependencies": {
-    "@memberjunction/core": "5.27.1",
-    "@memberjunction/global": "5.27.1",
-    "@memberjunction/actions-base": "5.27.1",
-    "@memberjunction/actions": "5.27.1",
-    "@memberjunction/archiving-engine": "5.27.1"
+    "@memberjunction/core": "5.28.0",
+    "@memberjunction/global": "5.28.0",
+    "@memberjunction/actions-base": "5.28.0",
+    "@memberjunction/actions": "5.28.0",
+    "@memberjunction/archiving-engine": "5.28.0"
   }
 }

--- a/packages/Archiving/Engine/package.json
+++ b/packages/Archiving/Engine/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@memberjunction/archiving-engine",
   "type": "module",
-  "version": "5.27.1",
+  "version": "5.28.0",
   "description": "Core archiving engine for MemberJunction - handles field-level archiving, storage, and recovery of entity records.",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -22,10 +22,10 @@
     "typescript": "^5.9.3"
   },
   "dependencies": {
-    "@memberjunction/core": "5.27.1",
-    "@memberjunction/core-entities": "5.27.1",
-    "@memberjunction/global": "5.27.1",
-    "@memberjunction/storage": "5.27.1"
+    "@memberjunction/core": "5.28.0",
+    "@memberjunction/core-entities": "5.28.0",
+    "@memberjunction/global": "5.28.0",
+    "@memberjunction/storage": "5.28.0"
   },
   "repository": {
     "type": "git",

--- a/packages/MJCoreEntitiesServer/src/__tests__/MJArtifactVersionEntityServer.test.ts
+++ b/packages/MJCoreEntitiesServer/src/__tests__/MJArtifactVersionEntityServer.test.ts
@@ -1,0 +1,30 @@
+import { describe, it, expect } from 'vitest';
+import { CalculateContentSizeBytes } from '../custom/MJArtifactVersionEntityServer.server';
+
+describe('CalculateContentSizeBytes', () => {
+    it('returns 0 for empty string', () => {
+        expect(CalculateContentSizeBytes('')).toBe(0);
+    });
+
+    it('returns character count for ASCII-only content', () => {
+        expect(CalculateContentSizeBytes('hello')).toBe(5);
+        expect(CalculateContentSizeBytes('{"a":1}')).toBe(7);
+    });
+
+    it('returns UTF-8 byte count (not character count) for multi-byte content', () => {
+        // "é" is 2 bytes in UTF-8, 1 character — total: 6 bytes, 5 chars
+        expect(CalculateContentSizeBytes('héllo')).toBe(6);
+        expect('héllo'.length).toBe(5);
+    });
+
+    it('handles 4-byte UTF-8 sequences (emoji)', () => {
+        // 🎉 is a 4-byte UTF-8 sequence
+        expect(CalculateContentSizeBytes('🎉')).toBe(4);
+    });
+
+    it('matches byte length of a stringified JSON payload', () => {
+        const snapshot = { title: 'Q1 Revenue', rows: [{ id: 1, value: 100 }] };
+        const json = JSON.stringify(snapshot);
+        expect(CalculateContentSizeBytes(json)).toBe(Buffer.byteLength(json, 'utf8'));
+    });
+});

--- a/packages/MJCoreEntitiesServer/src/custom/MJArtifactVersionEntityServer.server.ts
+++ b/packages/MJCoreEntitiesServer/src/custom/MJArtifactVersionEntityServer.server.ts
@@ -3,6 +3,15 @@ import { MJArtifactVersionEntity, MJArtifactEntity, MJArtifactTypeEntity, MJArti
 import { RegisterClass } from "@memberjunction/global";
 import { createHash } from 'crypto';
 
+/**
+ * Returns the UTF-8 byte length of `content`. Used by the Save hook to
+ * populate `ContentSizeBytes` so clients can display file sizes without
+ * reading the full blob. Exported for direct unit-testing.
+ */
+export function CalculateContentSizeBytes(content: string): number {
+    return Buffer.byteLength(content, 'utf8');
+}
+
 @RegisterClass(BaseEntity, "MJ: Artifact Versions")
 export class MJArtifactVersionEntityServer extends MJArtifactVersionEntity {
     private _pendingAttributes: any[] | null = null;
@@ -65,7 +74,11 @@ export class MJArtifactVersionEntityServer extends MJArtifactVersionEntity {
                 // 1. Calculate ContentHash using SHA-256
                 this.ContentHash = this.CalculateContentHash(this.Content);
 
-                // 2. Extract attributes (sets Name/Description and stores pending attributes)
+                // 2. Capture the UTF-8 byte length so the client can render file sizes
+                //    without reading the full Content blob.
+                this.ContentSizeBytes = CalculateContentSizeBytes(this.Content);
+
+                // 3. Extract attributes (sets Name/Description and stores pending attributes)
                 await this.ExtractAndSaveAttributes();
             }
             catch (error) {


### PR DESCRIPTION
## Summary

- **Fix "0 B" on data snapshots.** `AnalyzeArtifactService.CreateSnapshotArtifact` never populated `ContentSizeBytes`, so every data snapshot rendered as "0 B" in the conversation attachment tile. Fixed once at the save layer (`MJArtifactVersionEntityServer.Save()`) alongside the existing `ContentHash` auto-compute — every current and future caller now gets the size populated automatically, no per-call-site audit needed.
- **Redesign non-image attachment tiles.** The old tile was a cramped square with a generic file icon and no differentiation between content types. Replaced with a horizontal strip: UPPERCASE type badge (`SNAPSHOT`, `PDF`, `CSV`, …), filename, size. The badge shows the semantic artifact type for MJ-typed artifacts (tinted with `--mj-brand-primary`) and the file extension for plain uploads (neutral), so at a glance you can tell what came from MJ vs what the user uploaded.
- **Non-image click is no longer a no-op.** Previously `console.log`'d and did nothing. Now dispatches by type: images → image viewer, artifacts → artifact viewer panel, plain uploads → browser download.
- All colors use `--mj-*` design tokens — dark mode works.

### Scope notes (intentionally out)

- No backfill migration for existing `ContentSizeBytes IS NULL` rows — they stay "0 B" forever. Negligible impact; keeping the branch tight.
- No `ShortName` column on `MJArtifactType` — the heuristic (`ShortBadgeText`: if name ≤10 chars use it, else take the last word, else truncate) handles "Data Snapshot" → `SNAPSHOT`, "Business Intelligence Dashboard" → `DASHBOARD`, etc. DB column is the right long-term answer but doesn't belong here.
- No content-type-specific previews (row count, first-line JSON, PDF page) — that's a future enhancement.

## Test plan

- [x] `MJCoreEntitiesServer` builds clean (`tsc && tsc-alias`)
- [x] `MJCoreEntitiesServer` Vitest suite green (169/169, 5 new for `CalculateContentSizeBytes`)
- [x] `ng-conversations` builds clean (`ngc`)
- [x] `ng-conversations` Vitest suite green (115/115, 12 new for `ShortBadgeText` and `BadgeTextForAttachment`)
- [x] Manual browser check: take a data snapshot, confirm the tile shows a `SNAPSHOT` badge with real KB size (not "0 B")
- [x] Manual browser check: upload a PDF/CSV/text file, confirm it shows the extension badge with neutral styling
- [x] Manual browser check: click an image → image viewer opens; click an artifact → artifact viewer opens; click a plain upload → browser downloads
- [x] Manual browser check: dark mode renders correctly (no hardcoded colors)

🤖 Generated with [Claude Code](https://claude.com/claude-code)