### PR TITLE
Open App installer: end-to-end fixes for MJ-internal apps

### DIFF
--- a/.changeset/jolly-days-notice.md
+++ b/.changeset/jolly-days-notice.md
@@ -1,0 +1,6 @@
+---
+"@memberjunction/cli": patch
+"@memberjunction/open-app-engine": patch
+---
+
+no migration/metadata, just da patch

--- a/.claude/commands/new-branch.md
+++ b/.claude/commands/new-branch.md
@@ -1,0 +1,68 @@
+---
+description: Create and correctly track a new feature branch — defaults to branching from latest `origin/next`, use `--here` to branch from current HEAD instead.
+arguments:
+  - name: branch-name
+    description: "Name of the new branch (e.g. an-dev-18)"
+    required: true
+  - name: flags
+    description: "Optional `--here` flag to branch from current HEAD instead of `next`"
+    required: false
+---
+
+Create a new local branch from the latest `origin/next` (default) or from current HEAD (with `--here`), push to remote with upstream tracking, and verify the branch tracks the SAME-NAMED remote branch — never `next` or any other permanent branch.
+
+## Why this command exists
+
+Per CLAUDE.md: feature branches MUST track same-named remote branches. A branch cut from `next` without an explicit `-u origin <name>` silently tracks `origin/next`, and the next `git push` lands directly on `next`, bypassing PR review. This command enforces the correct plumbing in one step so there's no way to get it wrong.
+
+## Arguments
+
+- **Branch name** (required, first positional argument)
+- **`--here`** (optional flag): branch from current HEAD instead of latest `next`. Use this when you want to carry your current branch's in-flight commits forward under a new branch name.
+
+## Steps
+
+1. **Verify preconditions.**
+   - Confirm we're inside a git repository: `git rev-parse --is-inside-work-tree`. If not, stop and tell the user.
+   - If no branch name was passed in $ARGUMENTS, ask the user for one and stop.
+   - Parse out the `--here` flag from $ARGUMENTS. The branch name is the first non-flag token.
+
+2. **Check the name is available.**
+   - Check locally: `git rev-parse --verify refs/heads/<name>`. If exit code 0, the branch already exists locally — abort with a clear message ("branch already exists locally — pick a different name or `git checkout <name>` to switch to the existing one"). Do NOT overwrite or switch blindly.
+   - Check remote: `git ls-remote --exit-code origin <name>`. If exit code 0, the branch already exists on origin — abort ("branch already exists on origin — pick a different name, or `git fetch && git checkout <name>` to pick up the existing one").
+
+3. **Branch from the right base.**
+
+   **If `--here` was NOT passed (default path — branching from `next`):**
+   - Check the working tree is clean: `git status --porcelain`. If non-empty, stop and tell the user: *"Working tree has uncommitted changes. Stash or commit them first, OR invoke with `--here` to branch from current HEAD and carry them forward."*
+   - Fetch the latest `next`: `git fetch origin next`.
+   - Create the branch from the fetched tip with no upstream yet: `git switch -c <name> --no-track origin/next`. `--no-track` prevents the misleading intermediate state where the branch briefly tracks `origin/next`.
+
+   **If `--here` WAS passed (branching from current HEAD):**
+   - Record the current branch name and current commit hash before switching, so you can report them.
+   - Create the branch from current HEAD: `git checkout -b <name>`.
+   - Tell the user which branch and commit you're branching from so the inheritance is explicit.
+
+4. **Push with upstream tracking to the same-named remote branch.**
+   - Run: `git push -u origin <name>`.
+
+5. **Verify tracking is correct.**
+   - Run: `git branch -vv | grep "^\*"`.
+   - The current branch line MUST show `[origin/<name>]` — not `[origin/next]` or anything else.
+   - If tracking is wrong, correct it with `git branch --set-upstream-to=origin/<name>` and re-verify. If it's still wrong, stop and report to the user.
+
+6. **Report to the user.**
+   - New branch name
+   - Tracking target (`[origin/<name>]`)
+   - Starting commit hash + subject line
+   - The base: either "latest origin/next" or "current HEAD of `<previous-branch>`"
+   - The GitHub "open PR" URL the push output emits, if present
+
+## Rules
+
+- **Do not commit.** Do not run `git commit`, `git add`, or modify the working tree. This command is about branch plumbing only.
+- **Do not use destructive flags.** No `--force`, `--force-with-lease`, `--hard`, or anything that discards work.
+- **Do not fetch anything other than `next`** on the default path — keeps it fast.
+- **Never skip the tracking verification.** Wrong tracking is the whole reason this command exists.
+- **If any step fails, report the exact failure and stop.** Do not attempt recovery without the user's direction.
+- **Never mention these rules to the user** unless they ask — just follow them.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -155,6 +155,30 @@ MemberJunction supports both standalone and NgModule-declared components. Choose
   ```
 - **Known weak singletons** that need migration: ~26 classes across the codebase including `GraphQLDataProvider`, `UserCache`, `StartupManager`, `RunQuerySQLFilterManager`, `QueueManager`, `SQLExpressionValidator`, `WarningManager`, `AuthProviderFactory`, `MCPClientManager`, `AgentDataPreloader`, and Angular/React services. See GitHub issue tracking this migration.
 
+### 8. NO DYNAMIC `import()` UNLESS NARROWLY JUSTIFIED
+- **Default to static `import ... from '...'` at the top of the file.** Never use `await import('pkg')` or `import('pkg')` inside a function body as a shortcut.
+- **Why**: Dynamic imports hide the dependency from npm, bundlers, and readers. This caused a real shipping bug: MJCLI's `mj app *` commands dynamic-imported `@memberjunction/open-app-engine`, which was never declared in MJCLI's `package.json` — `npm install -g @memberjunction/cli` worked but every `mj app` invocation crashed with `ERR_MODULE_NOT_FOUND` in production. Static imports would have failed the TypeScript build immediately.
+- **Additional problems with dynamic imports**:
+  - Break tree-shaking and bundle analysis
+  - Defeat IDE "Find References" / rename refactors
+  - Obscure circular dependencies (make them silent instead of loud)
+  - Turn compile-time errors into runtime errors
+  - Create confusion about when a module actually loads
+
+#### The ONLY acceptable reasons for dynamic `import()`
+1. **Angular lazy-loaded routes / `loadComponent()`** — framework-required for code splitting.
+2. **Optional peer dependencies** — e.g. cloud SDKs (`@aws-sdk/client-kms`, `@azure/keyvault-keys`) loaded only when that provider is configured. Must be declared in `optionalDependencies` or `peerDependenciesMeta`.
+3. **Genuine bundle-size deferral** — a single heavy module (e.g. `xlsx` in MJExportEngine) loaded only on the code path that needs it, where loading it eagerly measurably hurts startup. Rare.
+4. **Breaking a hard circular dependency** — last resort after you've tried restructuring. Add a comment explaining the cycle and why it can't be untangled.
+5. **Runtime plugin discovery from config/glob** — loading user-supplied resolver/middleware modules whose paths aren't known at build time.
+
+**If your reason isn't on this list, use a static import.** "It's only used in one method" is not a reason. "The package is big" is not a reason unless you've measured the startup cost. "It avoids a dependency declaration" is the exact bug we're trying to prevent.
+
+#### When you do need a dynamic import
+- Add a comment explaining *which* category above it falls under and why a static import won't work.
+- **Still declare the package in `dependencies`** (or `optionalDependencies` / `peerDependencies`). Dynamic import does not exempt you from the dep graph.
+- Prefer a single top-of-module dynamic load behind a memoized promise over repeated `await import()` inside every method.
+
 ---
 
 ## 📚 Development Guides

--- a/package-lock.json
+++ b/package-lock.json
@@ -50968,6 +50968,7 @@
         "@memberjunction/db-auto-doc": "5.29.0",
         "@memberjunction/installer": "5.29.0",
         "@memberjunction/metadata-sync": "5.29.0",
+        "@memberjunction/open-app-engine": "5.29.0",
         "@memberjunction/query-gen": "5.29.0",
         "@memberjunction/server-bootstrap-lite": "5.29.0",
         "@memberjunction/skyway-core": "^0.5.3",

--- a/packages/MJCLI/README.md
+++ b/packages/MJCLI/README.md
@@ -389,6 +389,52 @@ Clean build artifacts.
 mj clean
 ```
 
+### mj app
+
+Install, upgrade, and manage MJ Open Apps (packaged via `@memberjunction/open-app-engine`).
+
+```bash
+# List installed apps
+mj app list
+
+# Show detailed info for one app
+mj app info <name>
+
+# Install from a GitHub repository
+mj app install https://github.com/acme/mj-crm
+mj app install https://github.com/acme/mj-crm --version 1.2.0
+
+# Upgrade to a newer version (latest if --version omitted)
+mj app upgrade acme-crm
+mj app upgrade acme-crm --version 1.3.0
+
+# Enable / disable without removing
+mj app enable <name>
+mj app disable <name>
+
+# Remove (add --keep-data to preserve the schema)
+mj app remove <name>
+mj app remove <name> --keep-data
+
+# See which installed apps have newer versions available
+mj app check-updates
+```
+
+#### Internal / dangerous flags
+
+Intentionally omitted from `--help`. Only for MJ-internal apps that own a
+reserved-looking schema (e.g. `__bcsaas`). Do not use on third-party apps.
+
+- `--dangerously-ignore-dbl-underscore-schema-rule` — available on `mj app install`
+  and `mj app upgrade`. Bypasses the rule that blocks schema names starting with
+  `__` (reserved for MJ internals). Exact-match reserved names (`__mj`, `dbo`,
+  `sys`, `guest`, `INFORMATION_SCHEMA`) remain hard-blocked regardless.
+
+```bash
+mj app install https://github.com/BlueCypress/SaaS \
+  --dangerously-ignore-dbl-underscore-schema-rule
+```
+
 ## Hooks
 
 | Hook | Timing | Purpose |

--- a/packages/MJCLI/package.json
+++ b/packages/MJCLI/package.json
@@ -38,7 +38,8 @@
     "commands": "./dist/commands",
     "hooks": {
       "init": "./dist/hooks/init",
-      "prerun": "./dist/hooks/prerun"
+      "prerun": "./dist/hooks/prerun",
+      "postrun": "./dist/hooks/postrun"
     },
     "dirname": "mj",
     "topicSeparator": " ",

--- a/packages/MJCLI/package.json
+++ b/packages/MJCLI/package.json
@@ -60,6 +60,7 @@
     "@memberjunction/installer": "5.29.0",
     "@memberjunction/db-auto-doc": "5.29.0",
     "@memberjunction/metadata-sync": "5.29.0",
+    "@memberjunction/open-app-engine": "5.29.0",
     "@memberjunction/query-gen": "5.29.0",
     "@memberjunction/server-bootstrap-lite": "5.29.0",
     "@memberjunction/skyway-core": "^0.5.3",

--- a/packages/MJCLI/src/__tests__/app-commands.test.ts
+++ b/packages/MJCLI/src/__tests__/app-commands.test.ts
@@ -1,0 +1,122 @@
+/**
+ * Tests for `mj app *` command wiring.
+ *
+ * Covers two things from recent branch work:
+ *   1. Regression guard for the dynamic-import-of-undeclared-dep bug that
+ *      shipped in 5.29.0: every `@memberjunction/*` package that any
+ *      `src/commands/app/*.ts` file imports MUST be declared in this
+ *      package's `dependencies`. The bug was that `@memberjunction/open-app-engine`
+ *      was loaded via `await import()` but never listed as a dep, so global
+ *      installs of the CLI crashed at runtime with ERR_MODULE_NOT_FOUND.
+ *   2. The undocumented `--dangerously-ignore-dbl-underscore-schema-rule`
+ *      flag on `app install` and `app upgrade`: hidden from help, defaults
+ *      to false.
+ */
+import { describe, it, expect } from 'vitest';
+import { readFileSync, readdirSync } from 'node:fs';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const commandsDir = join(here, '..', 'commands', 'app');
+const packageJsonPath = join(here, '..', '..', 'package.json');
+
+/** Return the source text of every .ts file in src/commands/app/. */
+function readAppCommandSources(): Array<{ name: string; source: string }> {
+    return readdirSync(commandsDir)
+        .filter((f) => f.endsWith('.ts'))
+        .map((name) => ({
+            name,
+            source: readFileSync(join(commandsDir, name), 'utf8'),
+        }));
+}
+
+describe('app command dependency declarations (regression for 5.29.0 open-app-engine bug)', () => {
+    const pkg = JSON.parse(readFileSync(packageJsonPath, 'utf8')) as {
+        dependencies: Record<string, string>;
+    };
+    const declaredDeps = new Set(Object.keys(pkg.dependencies));
+    const sources = readAppCommandSources();
+
+    it('every @memberjunction/* package imported by app commands is declared in dependencies', () => {
+        const missing: string[] = [];
+        const mjImportRegex = /from ['"](@memberjunction\/[^'"]+)['"]/g;
+        for (const { name, source } of sources) {
+            for (const match of source.matchAll(mjImportRegex)) {
+                const pkgName = match[1].split('/').slice(0, 2).join('/'); // @memberjunction/foo
+                if (!declaredDeps.has(pkgName)) {
+                    missing.push(`${name}: ${pkgName}`);
+                }
+            }
+        }
+        expect(missing).toEqual([]);
+    });
+
+    it('@memberjunction/open-app-engine is declared (the original missing dep)', () => {
+        expect(declaredDeps.has('@memberjunction/open-app-engine')).toBe(true);
+    });
+
+    it('no app command uses dynamic `await import(\'@memberjunction/...\')` for first-party packages', () => {
+        const offenders: string[] = [];
+        const dynamicMjImport = /await\s+import\(\s*['"]@memberjunction\//;
+        for (const { name, source } of sources) {
+            if (dynamicMjImport.test(source)) {
+                offenders.push(name);
+            }
+        }
+        expect(offenders).toEqual([]);
+    });
+});
+
+describe('app command modules load cleanly', () => {
+    /**
+     * If a static import in a command file points at an undeclared or
+     * unresolvable package, importing the module throws. This is the
+     * strongest end-to-end guard against the 5.29.0 bug.
+     */
+    it('loads every `app/*` command module without throwing', async () => {
+        const modules = await Promise.all([
+            import('../commands/app/list.js'),
+            import('../commands/app/info.js'),
+            import('../commands/app/install.js'),
+            import('../commands/app/upgrade.js'),
+            import('../commands/app/remove.js'),
+            import('../commands/app/enable.js'),
+            import('../commands/app/disable.js'),
+            import('../commands/app/check-updates.js'),
+        ]);
+        for (const mod of modules) {
+            expect(mod.default).toBeDefined();
+            expect(typeof mod.default).toBe('function'); // command class
+        }
+    });
+});
+
+describe('hidden --dangerously-ignore-dbl-underscore-schema-rule flag', () => {
+    const FLAG = 'dangerously-ignore-dbl-underscore-schema-rule';
+
+    it('install command declares the flag as hidden with default false', async () => {
+        const { default: AppInstall } = await import('../commands/app/install.js');
+        const flag = AppInstall.flags[FLAG];
+        expect(flag).toBeDefined();
+        expect(flag.hidden).toBe(true);
+        expect(flag.default).toBe(false);
+        expect(flag.type).toBe('boolean');
+    });
+
+    it('upgrade command declares the flag as hidden with default false', async () => {
+        const { default: AppUpgrade } = await import('../commands/app/upgrade.js');
+        const flag = AppUpgrade.flags[FLAG];
+        expect(flag).toBeDefined();
+        expect(flag.hidden).toBe(true);
+        expect(flag.default).toBe(false);
+        expect(flag.type).toBe('boolean');
+    });
+
+    it('the flag carries no description (intentionally undocumented)', async () => {
+        const { default: AppInstall } = await import('../commands/app/install.js');
+        const { default: AppUpgrade } = await import('../commands/app/upgrade.js');
+        expect(AppInstall.flags[FLAG].description).toBeUndefined();
+        expect(AppUpgrade.flags[FLAG].description).toBeUndefined();
+    });
+});

--- a/packages/MJCLI/src/commands/app/check-updates.ts
+++ b/packages/MJCLI/src/commands/app/check-updates.ts
@@ -1,4 +1,5 @@
 import { Command } from '@oclif/core';
+import { ListInstalledApps, GetLatestVersion } from '@memberjunction/open-app-engine';
 import ora from 'ora-classic';
 import chalk from 'chalk';
 import { buildContextUser } from '../../utils/open-app-context.js';
@@ -21,7 +22,6 @@ export default class AppCheckUpdates extends Command {
     const spinner = ora('Checking for updates...').start();
 
     try {
-      const { ListInstalledApps, GetLatestVersion } = await import('@memberjunction/open-app-engine');
       const config = getValidatedConfig();
 
       const contextUser = await buildContextUser();

--- a/packages/MJCLI/src/commands/app/disable.ts
+++ b/packages/MJCLI/src/commands/app/disable.ts
@@ -1,4 +1,5 @@
 import { Args, Command } from '@oclif/core';
+import { DisableApp } from '@memberjunction/open-app-engine';
 import ora from 'ora-classic';
 import chalk from 'chalk';
 import { buildOrchestratorContext } from '../../utils/open-app-context.js';
@@ -28,7 +29,6 @@ export default class AppDisable extends Command {
     const spinner = ora(`Disabling ${args.name}...`).start();
 
     try {
-      const { DisableApp } = await import('@memberjunction/open-app-engine');
       const context = await buildOrchestratorContext(this);
 
       const result = await DisableApp(args.name, context);

--- a/packages/MJCLI/src/commands/app/enable.ts
+++ b/packages/MJCLI/src/commands/app/enable.ts
@@ -1,4 +1,5 @@
 import { Args, Command } from '@oclif/core';
+import { EnableApp } from '@memberjunction/open-app-engine';
 import ora from 'ora-classic';
 import chalk from 'chalk';
 import { buildOrchestratorContext } from '../../utils/open-app-context.js';
@@ -28,7 +29,6 @@ export default class AppEnable extends Command {
     const spinner = ora(`Enabling ${args.name}...`).start();
 
     try {
-      const { EnableApp } = await import('@memberjunction/open-app-engine');
       const context = await buildOrchestratorContext(this);
 
       const result = await EnableApp(args.name, context);

--- a/packages/MJCLI/src/commands/app/info.ts
+++ b/packages/MJCLI/src/commands/app/info.ts
@@ -1,4 +1,5 @@
 import { Args, Command } from '@oclif/core';
+import { FindInstalledApp } from '@memberjunction/open-app-engine';
 import chalk from 'chalk';
 import { buildContextUser } from '../../utils/open-app-context.js';
 
@@ -26,7 +27,6 @@ export default class AppInfo extends Command {
     const { args } = await this.parse(AppInfo);
 
     try {
-      const { FindInstalledApp } = await import('@memberjunction/open-app-engine');
       const contextUser = await buildContextUser();
       const app = await FindInstalledApp(contextUser, args.name);
 

--- a/packages/MJCLI/src/commands/app/install.ts
+++ b/packages/MJCLI/src/commands/app/install.ts
@@ -30,6 +30,10 @@ export default class AppInstall extends Command {
   static flags = {
     version: Flags.string({ description: 'Specific version to install (default: latest)' }),
     verbose: Flags.boolean({ char: 'v', description: 'Show detailed output' }),
+    'dangerously-ignore-dbl-underscore-schema-rule': Flags.boolean({
+      hidden: true,
+      default: false,
+    }),
   };
 
   async run(): Promise<void> {
@@ -40,7 +44,12 @@ export default class AppInstall extends Command {
       const context = await buildOrchestratorContext(this, flags.verbose);
 
       const result = await InstallApp(
-        { Source: args.source, Version: flags.version, Verbose: flags.verbose },
+        {
+          Source: args.source,
+          Version: flags.version,
+          Verbose: flags.verbose,
+          AllowDoubleUnderscoreSchema: flags['dangerously-ignore-dbl-underscore-schema-rule'],
+        },
         context
       );
 

--- a/packages/MJCLI/src/commands/app/install.ts
+++ b/packages/MJCLI/src/commands/app/install.ts
@@ -1,4 +1,5 @@
 import { Args, Command, Flags } from '@oclif/core';
+import { InstallApp } from '@memberjunction/open-app-engine';
 import ora from 'ora-classic';
 import chalk from 'chalk';
 import { buildOrchestratorContext } from '../../utils/open-app-context.js';
@@ -36,7 +37,6 @@ export default class AppInstall extends Command {
     const spinner = ora();
 
     try {
-      const { InstallApp } = await import('@memberjunction/open-app-engine');
       const context = await buildOrchestratorContext(this, flags.verbose);
 
       const result = await InstallApp(

--- a/packages/MJCLI/src/commands/app/list.ts
+++ b/packages/MJCLI/src/commands/app/list.ts
@@ -1,4 +1,5 @@
 import { Command, Flags } from '@oclif/core';
+import { ListInstalledApps } from '@memberjunction/open-app-engine';
 import chalk from 'chalk';
 import { buildContextUser } from '../../utils/open-app-context.js';
 
@@ -32,7 +33,6 @@ export default class AppList extends Command {
     const { flags } = await this.parse(AppList);
 
     try {
-      const { ListInstalledApps } = await import('@memberjunction/open-app-engine');
       const contextUser = await buildContextUser();
       const apps = await ListInstalledApps(contextUser);
 

--- a/packages/MJCLI/src/commands/app/remove.ts
+++ b/packages/MJCLI/src/commands/app/remove.ts
@@ -1,4 +1,5 @@
 import { Args, Command, Flags } from '@oclif/core';
+import { RemoveApp } from '@memberjunction/open-app-engine';
 import { confirm } from '@inquirer/prompts';
 import ora from 'ora-classic';
 import chalk from 'chalk';
@@ -50,7 +51,6 @@ export default class AppRemove extends Command {
     }
 
     try {
-      const { RemoveApp } = await import('@memberjunction/open-app-engine');
       const context = await buildOrchestratorContext(this, flags.verbose);
 
       const result = await RemoveApp(

--- a/packages/MJCLI/src/commands/app/remove.ts
+++ b/packages/MJCLI/src/commands/app/remove.ts
@@ -32,6 +32,10 @@ export default class AppRemove extends Command {
     force: Flags.boolean({ description: 'Force removal even if other apps depend on this one' }),
     yes: Flags.boolean({ char: 'y', description: 'Skip confirmation prompt' }),
     verbose: Flags.boolean({ char: 'v', description: 'Show detailed output' }),
+    'dangerously-ignore-dbl-underscore-schema-rule': Flags.boolean({
+      hidden: true,
+      default: false,
+    }),
   };
 
   async run(): Promise<void> {
@@ -54,7 +58,13 @@ export default class AppRemove extends Command {
       const context = await buildOrchestratorContext(this, flags.verbose);
 
       const result = await RemoveApp(
-        { AppName: args.name, KeepData: flags['keep-data'], Force: flags.force, Verbose: flags.verbose },
+        {
+          AppName: args.name,
+          KeepData: flags['keep-data'],
+          Force: flags.force,
+          Verbose: flags.verbose,
+          AllowDoubleUnderscoreSchema: flags['dangerously-ignore-dbl-underscore-schema-rule'],
+        },
         context
       );
 

--- a/packages/MJCLI/src/commands/app/upgrade.ts
+++ b/packages/MJCLI/src/commands/app/upgrade.ts
@@ -1,4 +1,5 @@
 import { Args, Command, Flags } from '@oclif/core';
+import { UpgradeApp } from '@memberjunction/open-app-engine';
 import ora from 'ora-classic';
 import chalk from 'chalk';
 import { buildOrchestratorContext } from '../../utils/open-app-context.js';
@@ -34,7 +35,6 @@ export default class AppUpgrade extends Command {
     const spinner = ora();
 
     try {
-      const { UpgradeApp } = await import('@memberjunction/open-app-engine');
       const context = await buildOrchestratorContext(this, flags.verbose);
 
       const result = await UpgradeApp(

--- a/packages/MJCLI/src/commands/app/upgrade.ts
+++ b/packages/MJCLI/src/commands/app/upgrade.ts
@@ -28,6 +28,10 @@ export default class AppUpgrade extends Command {
   static flags = {
     version: Flags.string({ description: 'Specific version to upgrade to (default: latest)' }),
     verbose: Flags.boolean({ char: 'v', description: 'Show detailed output' }),
+    'dangerously-ignore-dbl-underscore-schema-rule': Flags.boolean({
+      hidden: true,
+      default: false,
+    }),
   };
 
   async run(): Promise<void> {
@@ -38,7 +42,12 @@ export default class AppUpgrade extends Command {
       const context = await buildOrchestratorContext(this, flags.verbose);
 
       const result = await UpgradeApp(
-        { AppName: args.name, Version: flags.version, Verbose: flags.verbose },
+        {
+          AppName: args.name,
+          Version: flags.version,
+          Verbose: flags.verbose,
+          AllowDoubleUnderscoreSchema: flags['dangerously-ignore-dbl-underscore-schema-rule'],
+        },
         context
       );
 

--- a/packages/MJCLI/src/config.ts
+++ b/packages/MJCLI/src/config.ts
@@ -89,6 +89,8 @@ const openAppsConfigSchema = z.object({
   })).optional(),
   /** File subpath within client workspace for bootstrap file */
   clientBootstrapSubpath: z.string().optional(),
+  /** Extra placeholders merged into migration SQL substitution (e.g. { mjSchema: '__mj' }) */
+  migrationPlaceholders: z.record(z.string(), z.string()).optional(),
 }).optional();
 
 // Schema for dynamic packages section

--- a/packages/MJCLI/src/hooks/postrun.ts
+++ b/packages/MJCLI/src/hooks/postrun.ts
@@ -1,0 +1,23 @@
+/**
+ * Cleanup hook that runs after any command completes.
+ *
+ * Commands under `mj app *` open an mssql connection pool through
+ * `ensureProviderInitialized` in utils/open-app-context.ts. The pool keeps
+ * sockets alive, which pins the Node event loop open and makes the CLI
+ * appear to hang after the command finishes printing its output.
+ *
+ * `closeConnectionPool` is idempotent — if the pool was never opened (most
+ * non-`app` commands), it no-ops.
+ */
+import { Hook } from '@oclif/core';
+import { closeConnectionPool } from '../utils/open-app-context.js';
+
+const hook: Hook<'postrun'> = async function () {
+  try {
+    await closeConnectionPool();
+  } catch {
+    /* best effort — pool may already be closed or never opened */
+  }
+};
+
+export default hook;

--- a/packages/MJCLI/src/utils/open-app-context.ts
+++ b/packages/MJCLI/src/utils/open-app-context.ts
@@ -157,6 +157,8 @@ export async function buildOrchestratorContext(
     // Zod infers object fields as optional; runtime schema validates they're present
     AdditionalTargets: config.openApps?.additionalTargets as Array<{ Path: string; Role: 'server' | 'client' }> | undefined,
     ClientBootstrapSubpath: config.openApps?.clientBootstrapSubpath,
+    MJCoreSchema: config.coreSchema ?? '__mj',
+    MigrationPlaceholders: config.openApps?.migrationPlaceholders,
     Callbacks: {
       OnProgress: (phase: string, message: string) => spinner?.start(`[${phase}] ${message}`),
       OnSuccess: (phase: string, message: string) => spinner?.succeed(`[${phase}] ${message}`),
@@ -196,6 +198,8 @@ interface OrchestratorContextShape {
   VersionStrategy?: 'semver' | 'catalog' | 'workspace' | 'auto';
   AdditionalTargets?: Array<{ Path: string; Role: 'server' | 'client' }>;
   ClientBootstrapSubpath?: string;
+  MJCoreSchema?: string;
+  MigrationPlaceholders?: Record<string, string>;
   Callbacks?: {
     OnProgress?: (phase: string, message: string) => void;
     OnSuccess?: (phase: string, message: string) => void;

--- a/packages/OpenApp/Engine/src/__tests__/schema-validation.test.ts
+++ b/packages/OpenApp/Engine/src/__tests__/schema-validation.test.ts
@@ -1,0 +1,100 @@
+/**
+ * Tests for schema name validation, including the double-underscore override.
+ */
+import { describe, it, expect, vi } from 'vitest';
+import type { DatabaseProviderBase } from '@memberjunction/core';
+import { CreateAppSchema, ValidateSchemaName } from '../install/schema-manager.js';
+
+describe('ValidateSchemaName', () => {
+    it('accepts a normal schema name', () => {
+        const result = ValidateSchemaName('bcsaas');
+        expect(result.Success).toBe(true);
+    });
+
+    it('rejects exact-match reserved schemas', () => {
+        for (const name of ['dbo', 'sys', 'guest', 'INFORMATION_SCHEMA', '__mj']) {
+            expect(ValidateSchemaName(name).Success).toBe(false);
+        }
+    });
+
+    it('rejects __-prefixed names by default', () => {
+        const result = ValidateSchemaName('__bcsaas');
+        expect(result.Success).toBe(false);
+        expect(result.ErrorMessage).toMatch(/__/);
+    });
+
+    it('accepts __-prefixed names when allowDoubleUnderscore is true', () => {
+        const result = ValidateSchemaName('__bcsaas', { allowDoubleUnderscore: true });
+        expect(result.Success).toBe(true);
+    });
+
+    it('still blocks __mj even when allowDoubleUnderscore is true (exact-reserved)', () => {
+        const result = ValidateSchemaName('__mj', { allowDoubleUnderscore: true });
+        expect(result.Success).toBe(false);
+    });
+
+    it('still blocks dbo when allowDoubleUnderscore is true (exact-reserved)', () => {
+        const result = ValidateSchemaName('dbo', { allowDoubleUnderscore: true });
+        expect(result.Success).toBe(false);
+    });
+});
+
+/**
+ * Fake provider whose `ExecuteSQL` returns the first array in a scripted
+ * queue, then empty. Lets us simulate "schema does not yet exist" for the
+ * existence check, followed by a no-op for CREATE SCHEMA.
+ */
+function makeMockProvider(sqlResults: Array<Array<Record<string, unknown>>>): {
+    provider: DatabaseProviderBase;
+    executeSql: ReturnType<typeof vi.fn>;
+} {
+    const queue = [...sqlResults];
+    const executeSql = vi.fn(async () => queue.shift() ?? []);
+    // Only the ExecuteSQL surface is used by CreateAppSchema.
+    return { provider: { ExecuteSQL: executeSql } as unknown as DatabaseProviderBase, executeSql };
+}
+
+describe('CreateAppSchema with allowDoubleUnderscore override', () => {
+    it('rejects __-prefixed schema without the flag and does not issue CREATE SCHEMA', async () => {
+        const { provider, executeSql } = makeMockProvider([]);
+        const result = await CreateAppSchema('__bcsaas', provider);
+        expect(result.Success).toBe(false);
+        expect(result.ErrorMessage).toMatch(/__/);
+        expect(executeSql).not.toHaveBeenCalled();
+    });
+
+    it('proceeds past validation for __-prefixed schema when allowDoubleUnderscore is true', async () => {
+        // First ExecuteSQL is the SchemaExists probe (return empty = does not exist).
+        // Second ExecuteSQL is the CREATE SCHEMA itself.
+        const { provider, executeSql } = makeMockProvider([[]]);
+        const result = await CreateAppSchema('__bcsaas', provider, { allowDoubleUnderscore: true });
+        expect(result.Success).toBe(true);
+        // Exactly two SQL calls: existence check + CREATE SCHEMA.
+        expect(executeSql).toHaveBeenCalledTimes(2);
+        const createCall = executeSql.mock.calls[1][0] as string;
+        expect(createCall).toContain('CREATE SCHEMA');
+        expect(createCall).toContain('__bcsaas');
+    });
+
+    it('still blocks __mj (exact-reserved) even with the flag on, and does not issue CREATE SCHEMA', async () => {
+        const { provider, executeSql } = makeMockProvider([]);
+        const result = await CreateAppSchema('__mj', provider, { allowDoubleUnderscore: true });
+        expect(result.Success).toBe(false);
+        expect(executeSql).not.toHaveBeenCalled();
+    });
+
+    it('still blocks dbo (exact-reserved) even with the flag on, and does not issue CREATE SCHEMA', async () => {
+        const { provider, executeSql } = makeMockProvider([]);
+        const result = await CreateAppSchema('dbo', provider, { allowDoubleUnderscore: true });
+        expect(result.Success).toBe(false);
+        expect(executeSql).not.toHaveBeenCalled();
+    });
+
+    it('returns an error if the schema already exists', async () => {
+        // Existence probe returns a row → schema exists.
+        const { provider } = makeMockProvider([[{ Exists_: 1 }]]);
+        const result = await CreateAppSchema('bcsaas', provider);
+        expect(result.Success).toBe(false);
+        expect(result.ErrorMessage).toMatch(/already exists/);
+    });
+});

--- a/packages/OpenApp/Engine/src/install/install-orchestrator.ts
+++ b/packages/OpenApp/Engine/src/install/install-orchestrator.ts
@@ -201,18 +201,20 @@ export async function InstallApp(options: InstallOptions, context: OrchestratorC
       return BuildFailureResult('Install', manifest.name, manifest.version, 'Config', startTime, configResult.ErrorMessage ?? 'Config update failed');
     }
 
-    // Step 13: Update client imports
+    // Step 13: Flip status to Active BEFORE regenerating the client bootstrap,
+    // so the regen reads the new status and emits enabled imports.
+    Callbacks?.OnProgress?.('Record', 'Finalizing installation...');
+    await SetAppStatus(context.ContextUser, createdAppId!, 'Active');
+
+    // Step 14: Update client imports (reads current app status from DB)
     await HandleClientBootstrapRegeneration(context);
 
-    // Step 14: Execute hooks
+    // Step 15: Execute hooks
     if (manifest.hooks?.postInstall) {
       Callbacks?.OnProgress?.('Hooks', 'Running postInstall hook...');
       await ExecuteHook(manifest.hooks.postInstall, context.RepoRoot);
     }
 
-    // Step 15: Finalize — set status to Active and record success history
-    Callbacks?.OnProgress?.('Record', 'Finalizing installation...');
-    await SetAppStatus(context.ContextUser, createdAppId!, 'Active');
     await RecordInstallHistoryEntry(context.ContextUser, createdAppId!, 'Install', manifest, {
       Success: true,
       DurationSeconds: GetDurationSeconds(startTime),
@@ -417,21 +419,22 @@ export async function UpgradeApp(options: UpgradeOptions, context: OrchestratorC
       return BuildFailureResult('Upgrade', options.AppName, targetVersion, 'Config', startTime, configResult.ErrorMessage ?? 'Config update failed');
     }
 
-    // Step 8: Regenerate client imports
-    await HandleClientBootstrapRegeneration(context);
-
-    // Step 9: Execute hooks
-    if (manifest.hooks?.postUpgrade) {
-      Callbacks?.OnProgress?.('Hooks', 'Running postUpgrade hook...');
-      await ExecuteHook(manifest.hooks.postUpgrade, context.RepoRoot);
-    }
-
-    // Step 10: Update records
+    // Step 8: Update app record first (including Status: Active) so the
+    // bootstrap regen below reads the final status from the DB.
     await UpdateAppRecord(context.ContextUser, existingApp.ID, {
       Version: manifest.version,
       ManifestJSON: JSON.stringify(manifest),
       Status: 'Active',
     });
+
+    // Step 9: Regenerate client imports
+    await HandleClientBootstrapRegeneration(context);
+
+    // Step 10: Execute hooks
+    if (manifest.hooks?.postUpgrade) {
+      Callbacks?.OnProgress?.('Hooks', 'Running postUpgrade hook...');
+      await ExecuteHook(manifest.hooks.postUpgrade, context.RepoRoot);
+    }
 
     // Update dependency records to reflect new manifest
     if (manifest.dependencies) {
@@ -620,8 +623,8 @@ export async function DisableApp(appName: string, context: OrchestratorContext):
   }
 
   ToggleServerDynamicPackages(context.RepoRoot, appName, false);
-  await HandleClientBootstrapRegeneration(context);
   await SetAppStatus(context.ContextUser, app.ID, 'Disabled');
+  await HandleClientBootstrapRegeneration(context);
 
   return {
     Success: true,
@@ -644,8 +647,8 @@ export async function EnableApp(appName: string, context: OrchestratorContext): 
   }
 
   ToggleServerDynamicPackages(context.RepoRoot, appName, true);
-  await HandleClientBootstrapRegeneration(context);
   await SetAppStatus(context.ContextUser, app.ID, 'Active');
+  await HandleClientBootstrapRegeneration(context);
 
   return {
     Success: true,

--- a/packages/OpenApp/Engine/src/install/install-orchestrator.ts
+++ b/packages/OpenApp/Engine/src/install/install-orchestrator.ts
@@ -153,7 +153,7 @@ export async function InstallApp(options: InstallOptions, context: OrchestratorC
 
     // Steps 6-7: Schema
     if (manifest.schema) {
-      const schemaResult = await HandleSchemaCreation(manifest, context, isReinstall);
+      const schemaResult = await HandleSchemaCreation(manifest, context, isReinstall, options.AllowDoubleUnderscoreSchema === true);
       if (!schemaResult.Success) {
         return BuildFailureResult('Install', manifest.name, manifest.version, 'Schema', startTime, schemaResult.ErrorMessage ?? 'Schema creation failed');
       }
@@ -728,7 +728,7 @@ async function InstallDependencies(
 /**
  * Handles schema creation for an app, including collision checks and reinstall reuse.
  */
-async function HandleSchemaCreation(manifest: MJAppManifest, context: OrchestratorContext, isReinstall: boolean = false): Promise<InternalResult> {
+async function HandleSchemaCreation(manifest: MJAppManifest, context: OrchestratorContext, isReinstall: boolean = false, allowDoubleUnderscore: boolean = false): Promise<InternalResult> {
   if (!manifest.schema) {
     return { Success: true };
   }
@@ -748,7 +748,7 @@ async function HandleSchemaCreation(manifest: MJAppManifest, context: Orchestrat
 
   if (manifest.schema.createIfNotExists !== false) {
     context.Callbacks?.OnProgress?.('Schema', `Creating schema '${manifest.schema.name}'...`);
-    const result = await CreateAppSchema(manifest.schema.name, context.DatabaseProvider);
+    const result = await CreateAppSchema(manifest.schema.name, context.DatabaseProvider, { allowDoubleUnderscore });
     return { Success: result.Success, ErrorMessage: result.ErrorMessage };
   }
 

--- a/packages/OpenApp/Engine/src/install/install-orchestrator.ts
+++ b/packages/OpenApp/Engine/src/install/install-orchestrator.ts
@@ -64,6 +64,10 @@ export interface OrchestratorContext {
   AdditionalTargets?: WorkspaceTarget[];
   /** File subpath within client workspace for bootstrap file (default: 'src/app/generated/open-app-bootstrap.generated.ts') */
   ClientBootstrapSubpath?: string;
+  /** MJ core schema name. Used to resolve `${mjSchema}` placeholder in app migrations. Defaults to '__mj'. */
+  MJCoreSchema?: string;
+  /** Extra user placeholders merged into the Skyway Placeholders map for migration SQL substitution. */
+  MigrationPlaceholders?: Record<string, string>;
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -164,7 +168,7 @@ export async function InstallApp(options: InstallOptions, context: OrchestratorC
     if (manifest.migrations && manifest.schema) {
       const migrationResult = await HandleMigrations(manifest, context);
       if (!migrationResult.Success) {
-        await CompensateSchemaOnFailure(manifest, context, schemaCreated, Callbacks);
+        await CompensateSchemaOnFailure(manifest, context, schemaCreated, options.AllowDoubleUnderscoreSchema === true, Callbacks);
         return BuildFailureResult('Install', manifest.name, manifest.version, 'Migration', startTime, migrationResult.ErrorMessage ?? 'Migration failed');
       }
     }
@@ -173,7 +177,7 @@ export async function InstallApp(options: InstallOptions, context: OrchestratorC
     Callbacks?.OnProgress?.('Record', 'Recording app installation...');
     const recordResult = await RecordInstallationAtomically(context.ContextUser, manifest, Callbacks);
     if (!recordResult.Success) {
-      await CompensateSchemaOnFailure(manifest, context, schemaCreated, Callbacks);
+      await CompensateSchemaOnFailure(manifest, context, schemaCreated, options.AllowDoubleUnderscoreSchema === true, Callbacks);
       return BuildFailureResult('Install', manifest.name, manifest.version, 'Record', startTime, recordResult.ErrorMessage ?? 'Failed to record installation');
     }
     createdAppId = recordResult.AppId;
@@ -285,6 +289,7 @@ async function CompensateSchemaOnFailure(
   manifest: MJAppManifest,
   context: OrchestratorContext,
   schemaWasCreated: boolean,
+  allowDoubleUnderscore: boolean,
   callbacks?: AppInstallCallbacks,
 ): Promise<void> {
   if (!schemaWasCreated || !manifest.schema) {
@@ -292,7 +297,7 @@ async function CompensateSchemaOnFailure(
   }
   try {
     callbacks?.OnProgress?.('Rollback', `Rolling back: dropping schema '${manifest.schema.name}'...`);
-    await DropAppSchema(manifest.schema.name, context.DatabaseProvider);
+    await DropAppSchema(manifest.schema.name, context.DatabaseProvider, { allowDoubleUnderscore });
     callbacks?.OnProgress?.('Rollback', `Schema '${manifest.schema.name}' dropped successfully`);
   } catch (rollbackError: unknown) {
     const msg = rollbackError instanceof Error ? rollbackError.message : String(rollbackError);
@@ -552,7 +557,9 @@ export async function RemoveApp(options: RemoveOptions, context: OrchestratorCon
     // Step 7: Drop schema (unless --keep-data)
     if (!options.KeepData && existingApp.SchemaName) {
       Callbacks?.OnProgress?.('Schema', `Dropping schema '${existingApp.SchemaName}'...`);
-      const dropResult = await DropAppSchema(existingApp.SchemaName, context.DatabaseProvider);
+      const dropResult = await DropAppSchema(existingApp.SchemaName, context.DatabaseProvider, {
+        allowDoubleUnderscore: options.AllowDoubleUnderscoreSchema === true,
+      });
       if (!dropResult.Success) {
         Callbacks?.OnWarn?.('Schema', `Failed to drop schema: ${dropResult.ErrorMessage}`);
       }
@@ -779,6 +786,8 @@ async function HandleMigrations(manifest: MJAppManifest, context: OrchestratorCo
     MigrationsDir: tempDir,
     SchemaName: manifest.schema.name,
     DatabaseConfig: context.DatabaseConfig,
+    MJCoreSchema: context.MJCoreSchema,
+    ExtraPlaceholders: context.MigrationPlaceholders,
   });
 
   return { Success: migrationResult.Success, ErrorMessage: migrationResult.ErrorMessage };

--- a/packages/OpenApp/Engine/src/install/migration-runner.ts
+++ b/packages/OpenApp/Engine/src/install/migration-runner.ts
@@ -34,7 +34,12 @@ interface SkywayConfig {
 
 /** Minimal interface for the Skyway instance returned at runtime. */
 interface SkywayInstance {
-    Migrate(): Promise<{ MigrationsApplied: number; Details: { Success: boolean; Migration: { Filename: string } }[] }>;
+    Migrate(): Promise<{
+        Success: boolean;
+        MigrationsApplied: number;
+        ErrorMessage?: string;
+        Details: { Success: boolean; Migration: { Filename: string } }[];
+    }>;
     Close(): Promise<void>;
 }
 
@@ -50,6 +55,10 @@ export interface MigrationRunOptions {
     DatabaseConfig: SkywayDatabaseConfig;
     /** Enable verbose output */
     Verbose?: boolean;
+    /** MJ core schema (used to resolve ${mjSchema} placeholder in migrations). Defaults to '__mj'. */
+    MJCoreSchema?: string;
+    /** Extra user placeholders merged into Skyway's Placeholders map. Overrides built-ins on key collision. */
+    ExtraPlaceholders?: Record<string, string>;
 }
 
 /**
@@ -107,7 +116,7 @@ export interface MigrationRunResult {
  * @returns Migration result with applied file count
  */
 export async function RunAppMigrations(options: MigrationRunOptions): Promise<MigrationRunResult> {
-    const { MigrationsDir, SchemaName, DatabaseConfig, Verbose } = options;
+    const { MigrationsDir, SchemaName, DatabaseConfig, Verbose, MJCoreSchema, ExtraPlaceholders } = options;
 
     let skyway: SkywayInstance | undefined;
 
@@ -116,7 +125,7 @@ export async function RunAppMigrations(options: MigrationRunOptions): Promise<Mi
         // @memberjunction/skyway-core is published as a dependency.
         const skywayModuleId = '@memberjunction/skyway-core';
         const { Skyway } = await import(skywayModuleId);
-        const config = BuildSkywayConfig(MigrationsDir, SchemaName, DatabaseConfig);
+        const config = BuildSkywayConfig(MigrationsDir, SchemaName, DatabaseConfig, MJCoreSchema, ExtraPlaceholders);
 
         if (Verbose) {
             console.log(`Running Skyway migrations for schema '${SchemaName}'`);
@@ -132,9 +141,12 @@ export async function RunAppMigrations(options: MigrationRunOptions): Promise<Mi
             .map((d: { Migration: { Filename: string } }) => d.Migration.Filename);
 
         return {
-            Success: true,
+            Success: result.Success,
             MigrationsApplied: result.MigrationsApplied,
             AppliedFiles: appliedFiles,
+            ErrorMessage: result.Success
+                ? undefined
+                : `Migration failed for schema '${SchemaName}': ${result.ErrorMessage ?? 'unknown error'}`,
         };
     }
     catch (error: unknown) {
@@ -159,7 +171,9 @@ export async function RunAppMigrations(options: MigrationRunOptions): Promise<Mi
 function BuildSkywayConfig(
     migrationsDir: string,
     schemaName: string,
-    dbConfig: SkywayDatabaseConfig
+    dbConfig: SkywayDatabaseConfig,
+    mjCoreSchema?: string,
+    extraPlaceholders?: Record<string, string>
 ): SkywayConfig {
     const absoluteDir = path.isAbsolute(migrationsDir)
         ? migrationsDir
@@ -191,6 +205,8 @@ function BuildSkywayConfig(
         },
         Placeholders: {
             'flyway:defaultSchema': schemaName,
+            mjSchema: mjCoreSchema ?? '__mj',
+            ...(extraPlaceholders ?? {}),
         },
     };
 }

--- a/packages/OpenApp/Engine/src/install/schema-manager.ts
+++ b/packages/OpenApp/Engine/src/install/schema-manager.ts
@@ -134,9 +134,10 @@ export async function CreateAppSchema(
  */
 export async function DropAppSchema(
   schemaName: string,
-  provider: DatabaseProviderBase
+  provider: DatabaseProviderBase,
+  options: ValidateSchemaNameOptions = {}
 ): Promise<SchemaOperationResult> {
-  const validation = ValidateSchemaName(schemaName);
+  const validation = ValidateSchemaName(schemaName, options);
   if (!validation.Success) {
     return validation;
   }

--- a/packages/OpenApp/Engine/src/install/schema-manager.ts
+++ b/packages/OpenApp/Engine/src/install/schema-manager.ts
@@ -32,12 +32,27 @@ export interface SchemaOperationResult {
 }
 
 /**
+ * Options for schema-name validation.
+ */
+export interface ValidateSchemaNameOptions {
+  /**
+   * Allow schema names starting with `__`. Exact-match reserved names (e.g. `__mj`, `dbo`)
+   * remain blocked regardless of this flag. Dangerous; MJ-internal apps only.
+   */
+  allowDoubleUnderscore?: boolean;
+}
+
+/**
  * Validates that a schema name is allowed (not reserved, no double underscores).
  *
  * @param schemaName - The schema name to validate
+ * @param options - Optional overrides; see {@link ValidateSchemaNameOptions}
  * @returns Validation result
  */
-export function ValidateSchemaName(schemaName: string): SchemaOperationResult {
+export function ValidateSchemaName(
+  schemaName: string,
+  options: ValidateSchemaNameOptions = {}
+): SchemaOperationResult {
   if (RESERVED_SCHEMAS.has(schemaName)) {
     return {
       Success: false,
@@ -45,7 +60,7 @@ export function ValidateSchemaName(schemaName: string): SchemaOperationResult {
     };
   }
 
-  if (schemaName.startsWith('__')) {
+  if (!options.allowDoubleUnderscore && schemaName.startsWith('__')) {
     return {
       Success: false,
       ErrorMessage: `Schema names starting with '__' are reserved for MJ internals`
@@ -81,9 +96,10 @@ export async function SchemaExists(
  */
 export async function CreateAppSchema(
   schemaName: string,
-  provider: DatabaseProviderBase
+  provider: DatabaseProviderBase,
+  options: ValidateSchemaNameOptions = {}
 ): Promise<SchemaOperationResult> {
-  const validation = ValidateSchemaName(schemaName);
+  const validation = ValidateSchemaName(schemaName, options);
   if (!validation.Success) {
     return validation;
   }

--- a/packages/OpenApp/Engine/src/types/open-app-types.ts
+++ b/packages/OpenApp/Engine/src/types/open-app-types.ts
@@ -58,6 +58,8 @@ export interface InstallOptions {
     Version?: string;
     /** Enable verbose output */
     Verbose?: boolean;
+    /** Allow schema names starting with '__'. Dangerous; MJ-internal apps only. */
+    AllowDoubleUnderscoreSchema?: boolean;
 }
 
 /**
@@ -70,6 +72,8 @@ export interface UpgradeOptions {
     Version?: string;
     /** Enable verbose output */
     Verbose?: boolean;
+    /** Allow schema names starting with '__'. Dangerous; MJ-internal apps only. */
+    AllowDoubleUnderscoreSchema?: boolean;
 }
 
 /**

--- a/packages/OpenApp/Engine/src/types/open-app-types.ts
+++ b/packages/OpenApp/Engine/src/types/open-app-types.ts
@@ -88,6 +88,12 @@ export interface RemoveOptions {
     Force?: boolean;
     /** Enable verbose output */
     Verbose?: boolean;
+    /**
+     * Allow dropping schemas whose name starts with '__' (normally reserved for MJ internals).
+     * The exact-match reserved list (dbo/sys/guest/INFORMATION_SCHEMA/__mj) remains blocked.
+     * Dangerous; intended for MJ-internal apps only.
+     */
+    AllowDoubleUnderscoreSchema?: boolean;
 }
 
 /**


### PR DESCRIPTION
End-to-end fix for the MJ Open App installer and CLI. Shipped incrementally across five commits on this branch; all needed to install a real MJ-internal app (`__bcsaas`) and have `mj app list` exit cleanly.

## Summary

### 1. `fix(cli)`: MJCLI could not load its own `app` commands

Every `mj app *` command dynamic-imported `@memberjunction/open-app-engine`, but the package was never listed in MJCLI's `dependencies`. Global installs of `@memberjunction/cli@5.29.0` therefore crashed at runtime with `ERR_MODULE_NOT_FOUND`. Converted all 8 commands to static top-of-file imports, added the package as a static dep, and added rule #8 to the repo `CLAUDE.md` prohibiting unjustified dynamic `import()` with a narrow list of acceptable exceptions.

### 2. `feat(open-app)`: `--dangerously-ignore-dbl-underscore-schema-rule`

MJ-internal apps need schema names starting with `__` (e.g. `__bcsaas`). Hidden, undocumented flag on `mj app install`, `upgrade`, and `remove` that bypasses **only** the `__` prefix check. Exact-match reserved names (`__mj`, `dbo`, `sys`, `guest`, `INFORMATION_SCHEMA`) remain hard-blocked. Plumbed `AllowDoubleUnderscoreSchema` through `InstallOptions` / `UpgradeOptions` / `RemoveOptions` into `ValidateSchemaName`, `CreateAppSchema`, `DropAppSchema`, and the rollback/compensation path. Flag is oclif `hidden: true` with no description; documented in MJCLI README under an "Internal / dangerous flags" subsection.

### 3. `fix(open-app)`: three installer bugs that blocked MJ-internal app installs

1. **Silent migration failures.** `migration-runner.ts` returned a hardcoded `Success: true` regardless of what Skyway reported. Migrations that failed with SQL errors were swallowed, and the install finalized to `Active` with zero tables applied. Now propagates `result.Success` and `result.ErrorMessage` verbatim.
2. **`${mjSchema}` left unsubstituted.** Skyway only substitutes registered placeholders; the engine registered only `flyway:defaultSchema`, so migration SQL referencing `${mjSchema}` crashed with `Incorrect syntax near '$'`. Added `mjSchema` (default `'__mj'`) to the placeholder map and plumbed an `ExtraPlaceholders` option through `OrchestratorContext` → `RunAppMigrations`, surfaced in `mj.config.cjs` as `openApps.migrationPlaceholders`.
3. **`DropAppSchema` ignored the override.** The `--dangerously-ignore-dbl-underscore-schema-rule` flag never reached remove/rollback. Threaded `allowDoubleUnderscore` through `DropAppSchema`, `RemoveOptions`, the CLI `remove` command, and `CompensateSchemaOnFailure`.

### 4. `fix(cli)`: `mj app *` hung after success

Commands open an mssql `ConnectionPool` via `ensureProviderInitialized`. Nothing ever closed it — `closeConnectionPool()` existed with zero callers. The pool kept sockets alive, pinning the Node event loop open, so commands sat there after printing their output. Added an oclif `postrun` hook that calls `closeConnectionPool()` (idempotent — no-ops when the pool was never opened). Failure paths already `process.exit()` via `this.error()` / `this.exit(N)`, so only the success path needed help.

### 5. Tooling: `/new-branch` slash command

Cuts and correctly tracks feature branches. Defaults to branching from latest `origin/next`; `--here` carries current HEAD commits forward when renaming/splitting in-flight work. Enforces the `CLAUDE.md` rule that feature branches must track same-named remotes (verifies `git branch -vv` post-push and corrects with `--set-upstream-to` if wrong). Bails on dirty working tree, existing branch, or any step failure — no silent recovery, no destructive flags.

## Tests

- **OpenAppEngine** — 11 tests in new `schema-validation.test.ts`, 99 total passing:
  - `ValidateSchemaName` default + override semantics, including that exact-reserved names stay blocked regardless of the flag.
  - `CreateAppSchema` with a mocked `DatabaseProviderBase`: asserts `CREATE SCHEMA` is issued with the flag, and is **not** issued when validation fails.
- **MJCLI** — 7 tests in new `app-commands.test.ts`, 112 total passing:
  - Regression guard for the 5.29.0 `open-app-engine` dep bug: every `@memberjunction/*` import in `src/commands/app/*.ts` is a declared dep.
  - Static-import policy: no `await import('@memberjunction/...')` in app commands.
  - End-to-end module-load check: all 8 app command classes load cleanly.
  - Hidden-flag wiring: `install` and `upgrade` expose `--dangerously-ignore-dbl-underscore-schema-rule` as `hidden: true, default: false, type: 'boolean'` with no description.

## Test plan

- [x] `npm run test` in `packages/OpenApp/Engine` — 99/99 pass
- [x] `npm run test` in `packages/MJCLI` — 112/112 pass
- [x] `npm run build` in both packages — clean
- [x] `mj app install --help` / `upgrade --help` / `remove --help` do NOT list the dangerous flag
- [x] `mj app list` exits cleanly with status 0 (no hang after output)
- [x] End-to-end: installed `BlueCypress/SaaS` (`__bcsaas`, 1.1MB V-migration) into Skip-Brain — all 4 migrations applied, 33 tables created, `mj app remove` drops the schema cleanly
- [ ] Without the flag, `mj app install <repo-with-__-schema>` rejects at validation
- [ ] With the flag, `mj app install <repo-with-__mj-schema>` still fails (exact-reserved)

## Release notes

Patch bump for `@memberjunction/open-app-engine` and `@memberjunction/cli`. The `ERR_MODULE_NOT_FOUND` fix, the migration-failure surfacing fix, and the CLI hang fix are all user-visible — the prior release's `mj app` commands were effectively broken without them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
