### PR TITLE
feat(ai-llamacpp): add llama.cpp provider for local inference

### DIFF
--- a/.changeset/llamacpp-provider.md
+++ b/.changeset/llamacpp-provider.md
@@ -1,0 +1,6 @@
+---
+"@memberjunction/ai-llamacpp": patch
+"@memberjunction/ai-provider-bundle": patch
+---
+
+Add `@memberjunction/ai-llamacpp` — a new AI provider that targets a local `llama-server` (llama.cpp) process via its OpenAI-compatible `/v1/chat/completions` endpoint. Implemented as a thin subclass of `OpenAILLM` following the same pattern as `xAILLM` and `OpenRouterLLM`. Defaults the base URL to `http://localhost:8080/v1` and supplies a placeholder API key since `llama-server` runs unauthenticated by default (callers can still pass a real key if `llama-server --api-key` is configured). Added to the provider bundle.

--- a/package-lock.json
+++ b/package-lock.json
@@ -11298,6 +11298,10 @@
       "resolved": "packages/AI/Knowledge/Pipeline",
       "link": true
     },
+    "node_modules/@memberjunction/ai-llamacpp": {
+      "resolved": "packages/AI/Providers/LlamaCpp",
+      "link": true
+    },
     "node_modules/@memberjunction/ai-lmstudio": {
       "resolved": "packages/AI/Providers/LMStudio",
       "link": true
@@ -14523,6 +14527,7 @@
       "os": [
         "android"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 10.0.0"
       },
@@ -14544,6 +14549,7 @@
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 10.0.0"
       },
@@ -14565,6 +14571,7 @@
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 10.0.0"
       },
@@ -14586,6 +14593,7 @@
       "os": [
         "freebsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 10.0.0"
       },
@@ -14607,6 +14615,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 10.0.0"
       },
@@ -14628,6 +14637,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 10.0.0"
       },
@@ -14649,6 +14659,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 10.0.0"
       },
@@ -14670,6 +14681,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 10.0.0"
       },
@@ -14691,6 +14703,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 10.0.0"
       },
@@ -14712,6 +14725,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 10.0.0"
       },
@@ -14733,6 +14747,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 10.0.0"
       },
@@ -14754,6 +14769,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 10.0.0"
       },
@@ -14775,6 +14791,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 10.0.0"
       },
@@ -23689,6 +23706,7 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "prr": "~1.0.1"
       },
@@ -27032,6 +27050,7 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "bin": {
         "image-size": "bin/image-size.js"
       },
@@ -28787,6 +28806,7 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "pify": "^4.0.1",
         "semver": "^5.6.0"
@@ -28802,6 +28822,7 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "bin": {
         "mime": "cli.js"
       },
@@ -28816,6 +28837,7 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "engines": {
         "node": ">=6"
       }
@@ -28827,6 +28849,7 @@
       "dev": true,
       "license": "ISC",
       "optional": true,
+      "peer": true,
       "bin": {
         "semver": "bin/semver"
       }
@@ -30813,6 +30836,7 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "iconv-lite": "^0.6.3",
         "sax": "^1.2.4"
@@ -30831,6 +30855,7 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "safer-buffer": ">= 2.1.2 < 3.0.0"
       },
@@ -30933,6 +30958,7 @@
       "os": [
         "aix"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -30950,6 +30976,7 @@
       "os": [
         "android"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -30967,6 +30994,7 @@
       "os": [
         "android"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -30984,6 +31012,7 @@
       "os": [
         "android"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -31001,6 +31030,7 @@
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -31018,6 +31048,7 @@
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -31035,6 +31066,7 @@
       "os": [
         "freebsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -31052,6 +31084,7 @@
       "os": [
         "freebsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -31069,6 +31102,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -31086,6 +31120,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -31103,6 +31138,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -31120,6 +31156,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -31137,6 +31174,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -31154,6 +31192,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -31171,6 +31210,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -31188,6 +31228,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -31205,6 +31246,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -31222,6 +31264,7 @@
       "os": [
         "netbsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -31239,6 +31282,7 @@
       "os": [
         "netbsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -31256,6 +31300,7 @@
       "os": [
         "openbsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -31273,6 +31318,7 @@
       "os": [
         "openbsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -31290,6 +31336,7 @@
       "os": [
         "openharmony"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -31307,6 +31354,7 @@
       "os": [
         "sunos"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -31324,6 +31372,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -31341,6 +31390,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -31358,6 +31408,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -34419,7 +34470,8 @@
       "integrity": "sha512-yPw4Sng1gWghHQWj0B3ZggWUm4qVbPwPFcRG8KyxiU7J2OHFSoEHKS+EZ3fv5l1t9CyCiop6l/ZYeWbrgoQejw==",
       "dev": true,
       "license": "MIT",
-      "optional": true
+      "optional": true,
+      "peer": true
     },
     "node_modules/psl": {
       "version": "1.15.0",
@@ -38454,6 +38506,7 @@
       "os": [
         "aix"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -38471,6 +38524,7 @@
       "os": [
         "android"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -38488,6 +38542,7 @@
       "os": [
         "android"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -38505,6 +38560,7 @@
       "os": [
         "android"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -38522,6 +38578,7 @@
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -38539,6 +38596,7 @@
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -38556,6 +38614,7 @@
       "os": [
         "freebsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -38573,6 +38632,7 @@
       "os": [
         "freebsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -38590,6 +38650,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -38607,6 +38668,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -38624,6 +38686,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -38641,6 +38704,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -38658,6 +38722,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -38675,6 +38740,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -38692,6 +38758,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -38709,6 +38776,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -38726,6 +38794,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -38743,6 +38812,7 @@
       "os": [
         "netbsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -38760,6 +38830,7 @@
       "os": [
         "netbsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -38777,6 +38848,7 @@
       "os": [
         "openbsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -38794,6 +38866,7 @@
       "os": [
         "openbsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -38811,6 +38884,7 @@
       "os": [
         "openharmony"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -38828,6 +38902,7 @@
       "os": [
         "sunos"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -38845,6 +38920,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -38862,6 +38938,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -38879,6 +38956,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -41935,6 +42013,137 @@
         "node": ">=16"
       }
     },
+    "packages/Actions/BizApps/Accounting/node_modules/@types/node": {
+      "version": "24.10.11",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.10.11.tgz",
+      "integrity": "sha512-/Af7O8r1frCVgOz0I62jWUtMohJ0/ZQU/ZoketltOJPZpnb17yoNc9BSoVuV9qlaIXJiPNOpsfq4ByFajSArNQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~7.16.0"
+      }
+    },
+    "packages/Actions/BizApps/Accounting/node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "packages/Actions/BizApps/Accounting/node_modules/brace-expansion": {
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
+      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "packages/Actions/BizApps/Accounting/node_modules/glob": {
+      "version": "13.0.6",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-13.0.6.tgz",
+      "integrity": "sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "minimatch": "^10.2.2",
+        "minipass": "^7.1.3",
+        "path-scurry": "^2.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "packages/Actions/BizApps/Accounting/node_modules/lru-cache": {
+      "version": "11.3.5",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.3.5.tgz",
+      "integrity": "sha512-NxVFwLAnrd9i7KUBxC4DrUhmgjzOs+1Qm50D3oF1/oL+r1NpZ4gA7xvG0/zJ8evR7zIKn4vLf7qTNduWFtCrRw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "packages/Actions/BizApps/Accounting/node_modules/minimatch": {
+      "version": "10.2.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "brace-expansion": "^5.0.5"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "packages/Actions/BizApps/Accounting/node_modules/minipass": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
+      "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      }
+    },
+    "packages/Actions/BizApps/Accounting/node_modules/path-scurry": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-2.0.2.tgz",
+      "integrity": "sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "lru-cache": "^11.0.0",
+        "minipass": "^7.1.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "packages/Actions/BizApps/Accounting/node_modules/rimraf": {
+      "version": "6.1.3",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-6.1.3.tgz",
+      "integrity": "sha512-LKg+Cr2ZF61fkcaK1UdkH2yEBBKnYjTyWzTJT6KNPcSPaiT7HSdhtMXQuN5wkTX0Xu72KQ1l8S42rlmexS2hSA==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "glob": "^13.0.3",
+        "package-json-from-dist": "^1.0.1"
+      },
+      "bin": {
+        "rimraf": "dist/esm/bin.mjs"
+      },
+      "engines": {
+        "node": "20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "packages/Actions/BizApps/Accounting/node_modules/undici-types": {
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
+      "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "packages/Actions/BizApps/CRM": {
       "name": "@memberjunction/actions-bizapps-crm",
       "version": "5.29.0",
@@ -41954,6 +42163,137 @@
       "engines": {
         "node": ">=16"
       }
+    },
+    "packages/Actions/BizApps/CRM/node_modules/@types/node": {
+      "version": "24.10.11",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.10.11.tgz",
+      "integrity": "sha512-/Af7O8r1frCVgOz0I62jWUtMohJ0/ZQU/ZoketltOJPZpnb17yoNc9BSoVuV9qlaIXJiPNOpsfq4ByFajSArNQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~7.16.0"
+      }
+    },
+    "packages/Actions/BizApps/CRM/node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "packages/Actions/BizApps/CRM/node_modules/brace-expansion": {
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
+      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "packages/Actions/BizApps/CRM/node_modules/glob": {
+      "version": "13.0.6",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-13.0.6.tgz",
+      "integrity": "sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "minimatch": "^10.2.2",
+        "minipass": "^7.1.3",
+        "path-scurry": "^2.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "packages/Actions/BizApps/CRM/node_modules/lru-cache": {
+      "version": "11.3.5",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.3.5.tgz",
+      "integrity": "sha512-NxVFwLAnrd9i7KUBxC4DrUhmgjzOs+1Qm50D3oF1/oL+r1NpZ4gA7xvG0/zJ8evR7zIKn4vLf7qTNduWFtCrRw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "packages/Actions/BizApps/CRM/node_modules/minimatch": {
+      "version": "10.2.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "brace-expansion": "^5.0.5"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "packages/Actions/BizApps/CRM/node_modules/minipass": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
+      "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      }
+    },
+    "packages/Actions/BizApps/CRM/node_modules/path-scurry": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-2.0.2.tgz",
+      "integrity": "sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "lru-cache": "^11.0.0",
+        "minipass": "^7.1.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "packages/Actions/BizApps/CRM/node_modules/rimraf": {
+      "version": "6.1.3",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-6.1.3.tgz",
+      "integrity": "sha512-LKg+Cr2ZF61fkcaK1UdkH2yEBBKnYjTyWzTJT6KNPcSPaiT7HSdhtMXQuN5wkTX0Xu72KQ1l8S42rlmexS2hSA==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "glob": "^13.0.3",
+        "package-json-from-dist": "^1.0.1"
+      },
+      "bin": {
+        "rimraf": "dist/esm/bin.mjs"
+      },
+      "engines": {
+        "node": "20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "packages/Actions/BizApps/CRM/node_modules/undici-types": {
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
+      "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
+      "dev": true,
+      "license": "MIT"
     },
     "packages/Actions/BizApps/FormBuilders": {
       "name": "@memberjunction/actions-bizapps-formbuilders",
@@ -41979,6 +42319,110 @@
         "node": ">=16"
       }
     },
+    "packages/Actions/BizApps/FormBuilders/node_modules/@types/node": {
+      "version": "24.10.11",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.10.11.tgz",
+      "integrity": "sha512-/Af7O8r1frCVgOz0I62jWUtMohJ0/ZQU/ZoketltOJPZpnb17yoNc9BSoVuV9qlaIXJiPNOpsfq4ByFajSArNQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~7.16.0"
+      }
+    },
+    "packages/Actions/BizApps/FormBuilders/node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "packages/Actions/BizApps/FormBuilders/node_modules/brace-expansion": {
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
+      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "packages/Actions/BizApps/FormBuilders/node_modules/glob": {
+      "version": "13.0.6",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-13.0.6.tgz",
+      "integrity": "sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "minimatch": "^10.2.2",
+        "minipass": "^7.1.3",
+        "path-scurry": "^2.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "packages/Actions/BizApps/FormBuilders/node_modules/lru-cache": {
+      "version": "11.3.5",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.3.5.tgz",
+      "integrity": "sha512-NxVFwLAnrd9i7KUBxC4DrUhmgjzOs+1Qm50D3oF1/oL+r1NpZ4gA7xvG0/zJ8evR7zIKn4vLf7qTNduWFtCrRw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "packages/Actions/BizApps/FormBuilders/node_modules/minimatch": {
+      "version": "10.2.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "brace-expansion": "^5.0.5"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "packages/Actions/BizApps/FormBuilders/node_modules/minipass": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
+      "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      }
+    },
+    "packages/Actions/BizApps/FormBuilders/node_modules/path-scurry": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-2.0.2.tgz",
+      "integrity": "sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "lru-cache": "^11.0.0",
+        "minipass": "^7.1.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "packages/Actions/BizApps/FormBuilders/node_modules/pdf-parse": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/pdf-parse/-/pdf-parse-1.1.4.tgz",
@@ -41994,6 +42438,33 @@
         "type": "github",
         "url": "https://github.com/sponsors/mehmet-kozan"
       }
+    },
+    "packages/Actions/BizApps/FormBuilders/node_modules/rimraf": {
+      "version": "6.1.3",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-6.1.3.tgz",
+      "integrity": "sha512-LKg+Cr2ZF61fkcaK1UdkH2yEBBKnYjTyWzTJT6KNPcSPaiT7HSdhtMXQuN5wkTX0Xu72KQ1l8S42rlmexS2hSA==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "glob": "^13.0.3",
+        "package-json-from-dist": "^1.0.1"
+      },
+      "bin": {
+        "rimraf": "dist/esm/bin.mjs"
+      },
+      "engines": {
+        "node": "20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "packages/Actions/BizApps/FormBuilders/node_modules/undici-types": {
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
+      "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
+      "dev": true,
+      "license": "MIT"
     },
     "packages/Actions/BizApps/LMS": {
       "name": "@memberjunction/actions-bizapps-lms",
@@ -42016,6 +42487,39 @@
         "node": ">=16"
       }
     },
+    "packages/Actions/BizApps/LMS/node_modules/@types/node": {
+      "version": "24.10.11",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.10.11.tgz",
+      "integrity": "sha512-/Af7O8r1frCVgOz0I62jWUtMohJ0/ZQU/ZoketltOJPZpnb17yoNc9BSoVuV9qlaIXJiPNOpsfq4ByFajSArNQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~7.16.0"
+      }
+    },
+    "packages/Actions/BizApps/LMS/node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "packages/Actions/BizApps/LMS/node_modules/brace-expansion": {
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
+      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
     "packages/Actions/BizApps/LMS/node_modules/dotenv": {
       "version": "16.6.1",
       "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.6.1.tgz",
@@ -42028,6 +42532,104 @@
       "funding": {
         "url": "https://dotenvx.com"
       }
+    },
+    "packages/Actions/BizApps/LMS/node_modules/glob": {
+      "version": "13.0.6",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-13.0.6.tgz",
+      "integrity": "sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "minimatch": "^10.2.2",
+        "minipass": "^7.1.3",
+        "path-scurry": "^2.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "packages/Actions/BizApps/LMS/node_modules/lru-cache": {
+      "version": "11.3.5",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.3.5.tgz",
+      "integrity": "sha512-NxVFwLAnrd9i7KUBxC4DrUhmgjzOs+1Qm50D3oF1/oL+r1NpZ4gA7xvG0/zJ8evR7zIKn4vLf7qTNduWFtCrRw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "packages/Actions/BizApps/LMS/node_modules/minimatch": {
+      "version": "10.2.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "brace-expansion": "^5.0.5"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "packages/Actions/BizApps/LMS/node_modules/minipass": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
+      "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      }
+    },
+    "packages/Actions/BizApps/LMS/node_modules/path-scurry": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-2.0.2.tgz",
+      "integrity": "sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "lru-cache": "^11.0.0",
+        "minipass": "^7.1.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "packages/Actions/BizApps/LMS/node_modules/rimraf": {
+      "version": "6.1.3",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-6.1.3.tgz",
+      "integrity": "sha512-LKg+Cr2ZF61fkcaK1UdkH2yEBBKnYjTyWzTJT6KNPcSPaiT7HSdhtMXQuN5wkTX0Xu72KQ1l8S42rlmexS2hSA==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "glob": "^13.0.3",
+        "package-json-from-dist": "^1.0.1"
+      },
+      "bin": {
+        "rimraf": "dist/esm/bin.mjs"
+      },
+      "engines": {
+        "node": "20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "packages/Actions/BizApps/LMS/node_modules/undici-types": {
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
+      "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
+      "dev": true,
+      "license": "MIT"
     },
     "packages/Actions/BizApps/Social": {
       "name": "@memberjunction/actions-bizapps-social",
@@ -42047,6 +42649,137 @@
         "rimraf": "^6.1.2",
         "typescript": "^5.9.3"
       }
+    },
+    "packages/Actions/BizApps/Social/node_modules/@types/node": {
+      "version": "24.12.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.12.2.tgz",
+      "integrity": "sha512-A1sre26ke7HDIuY/M23nd9gfB+nrmhtYyMINbjI1zHJxYteKR6qSMX56FsmjMcDb3SMcjJg5BiRRgOCC/yBD0g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~7.16.0"
+      }
+    },
+    "packages/Actions/BizApps/Social/node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "packages/Actions/BizApps/Social/node_modules/brace-expansion": {
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
+      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "packages/Actions/BizApps/Social/node_modules/glob": {
+      "version": "13.0.6",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-13.0.6.tgz",
+      "integrity": "sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "minimatch": "^10.2.2",
+        "minipass": "^7.1.3",
+        "path-scurry": "^2.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "packages/Actions/BizApps/Social/node_modules/lru-cache": {
+      "version": "11.3.5",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.3.5.tgz",
+      "integrity": "sha512-NxVFwLAnrd9i7KUBxC4DrUhmgjzOs+1Qm50D3oF1/oL+r1NpZ4gA7xvG0/zJ8evR7zIKn4vLf7qTNduWFtCrRw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "packages/Actions/BizApps/Social/node_modules/minimatch": {
+      "version": "10.2.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "brace-expansion": "^5.0.5"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "packages/Actions/BizApps/Social/node_modules/minipass": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
+      "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      }
+    },
+    "packages/Actions/BizApps/Social/node_modules/path-scurry": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-2.0.2.tgz",
+      "integrity": "sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "lru-cache": "^11.0.0",
+        "minipass": "^7.1.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "packages/Actions/BizApps/Social/node_modules/rimraf": {
+      "version": "6.1.3",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-6.1.3.tgz",
+      "integrity": "sha512-LKg+Cr2ZF61fkcaK1UdkH2yEBBKnYjTyWzTJT6KNPcSPaiT7HSdhtMXQuN5wkTX0Xu72KQ1l8S42rlmexS2hSA==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "glob": "^13.0.3",
+        "package-json-from-dist": "^1.0.1"
+      },
+      "bin": {
+        "rimraf": "dist/esm/bin.mjs"
+      },
+      "engines": {
+        "node": "20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "packages/Actions/BizApps/Social/node_modules/undici-types": {
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
+      "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
+      "dev": true,
+      "license": "MIT"
     },
     "packages/Actions/CodeExecution": {
       "name": "@memberjunction/code-execution",
@@ -42072,6 +42805,23 @@
         "typescript": "^5.9.3",
         "vitest": "^4.0.18"
       }
+    },
+    "packages/Actions/CodeExecution/node_modules/@types/node": {
+      "version": "24.12.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.12.2.tgz",
+      "integrity": "sha512-A1sre26ke7HDIuY/M23nd9gfB+nrmhtYyMINbjI1zHJxYteKR6qSMX56FsmjMcDb3SMcjJg5BiRRgOCC/yBD0g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~7.16.0"
+      }
+    },
+    "packages/Actions/CodeExecution/node_modules/undici-types": {
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
+      "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
+      "dev": true,
+      "license": "MIT"
     },
     "packages/Actions/ContentAutotag": {
       "name": "@memberjunction/actions-content-autotag",
@@ -42463,6 +43213,120 @@
         "@types/node": "*"
       }
     },
+    "packages/Actions/ScheduledActionsServer/node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "packages/Actions/ScheduledActionsServer/node_modules/brace-expansion": {
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
+      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "packages/Actions/ScheduledActionsServer/node_modules/glob": {
+      "version": "13.0.6",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-13.0.6.tgz",
+      "integrity": "sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "minimatch": "^10.2.2",
+        "minipass": "^7.1.3",
+        "path-scurry": "^2.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "packages/Actions/ScheduledActionsServer/node_modules/lru-cache": {
+      "version": "11.3.5",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.3.5.tgz",
+      "integrity": "sha512-NxVFwLAnrd9i7KUBxC4DrUhmgjzOs+1Qm50D3oF1/oL+r1NpZ4gA7xvG0/zJ8evR7zIKn4vLf7qTNduWFtCrRw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "packages/Actions/ScheduledActionsServer/node_modules/minimatch": {
+      "version": "10.2.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "brace-expansion": "^5.0.5"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "packages/Actions/ScheduledActionsServer/node_modules/minipass": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
+      "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      }
+    },
+    "packages/Actions/ScheduledActionsServer/node_modules/path-scurry": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-2.0.2.tgz",
+      "integrity": "sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "lru-cache": "^11.0.0",
+        "minipass": "^7.1.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "packages/Actions/ScheduledActionsServer/node_modules/rimraf": {
+      "version": "6.1.3",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-6.1.3.tgz",
+      "integrity": "sha512-LKg+Cr2ZF61fkcaK1UdkH2yEBBKnYjTyWzTJT6KNPcSPaiT7HSdhtMXQuN5wkTX0Xu72KQ1l8S42rlmexS2hSA==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "glob": "^13.0.3",
+        "package-json-from-dist": "^1.0.1"
+      },
+      "bin": {
+        "rimraf": "dist/esm/bin.mjs"
+      },
+      "engines": {
+        "node": "20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "packages/Actions/ScheduledActionsServer/node_modules/undici-types": {
       "version": "7.16.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
@@ -42547,6 +43411,29 @@
         "@types/node": "*"
       }
     },
+    "packages/AI/A2AServer/node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "packages/AI/A2AServer/node_modules/brace-expansion": {
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
+      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
     "packages/AI/A2AServer/node_modules/cosmiconfig": {
       "version": "8.3.6",
       "license": "MIT",
@@ -42569,6 +43456,97 @@
         "typescript": {
           "optional": true
         }
+      }
+    },
+    "packages/AI/A2AServer/node_modules/glob": {
+      "version": "13.0.6",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-13.0.6.tgz",
+      "integrity": "sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "minimatch": "^10.2.2",
+        "minipass": "^7.1.3",
+        "path-scurry": "^2.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "packages/AI/A2AServer/node_modules/lru-cache": {
+      "version": "11.3.5",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.3.5.tgz",
+      "integrity": "sha512-NxVFwLAnrd9i7KUBxC4DrUhmgjzOs+1Qm50D3oF1/oL+r1NpZ4gA7xvG0/zJ8evR7zIKn4vLf7qTNduWFtCrRw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "packages/AI/A2AServer/node_modules/minimatch": {
+      "version": "10.2.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "brace-expansion": "^5.0.5"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "packages/AI/A2AServer/node_modules/minipass": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
+      "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      }
+    },
+    "packages/AI/A2AServer/node_modules/path-scurry": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-2.0.2.tgz",
+      "integrity": "sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "lru-cache": "^11.0.0",
+        "minipass": "^7.1.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "packages/AI/A2AServer/node_modules/rimraf": {
+      "version": "6.1.3",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-6.1.3.tgz",
+      "integrity": "sha512-LKg+Cr2ZF61fkcaK1UdkH2yEBBKnYjTyWzTJT6KNPcSPaiT7HSdhtMXQuN5wkTX0Xu72KQ1l8S42rlmexS2hSA==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "glob": "^13.0.3",
+        "package-json-from-dist": "^1.0.1"
+      },
+      "bin": {
+        "rimraf": "dist/esm/bin.mjs"
+      },
+      "engines": {
+        "node": "20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "packages/AI/A2AServer/node_modules/undici-types": {
@@ -42607,6 +43585,137 @@
         "typescript": "^5.9.3"
       }
     },
+    "packages/AI/AgentManager/actions/node_modules/@types/node": {
+      "version": "24.12.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.12.2.tgz",
+      "integrity": "sha512-A1sre26ke7HDIuY/M23nd9gfB+nrmhtYyMINbjI1zHJxYteKR6qSMX56FsmjMcDb3SMcjJg5BiRRgOCC/yBD0g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~7.16.0"
+      }
+    },
+    "packages/AI/AgentManager/actions/node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "packages/AI/AgentManager/actions/node_modules/brace-expansion": {
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
+      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "packages/AI/AgentManager/actions/node_modules/glob": {
+      "version": "13.0.6",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-13.0.6.tgz",
+      "integrity": "sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "minimatch": "^10.2.2",
+        "minipass": "^7.1.3",
+        "path-scurry": "^2.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "packages/AI/AgentManager/actions/node_modules/lru-cache": {
+      "version": "11.3.5",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.3.5.tgz",
+      "integrity": "sha512-NxVFwLAnrd9i7KUBxC4DrUhmgjzOs+1Qm50D3oF1/oL+r1NpZ4gA7xvG0/zJ8evR7zIKn4vLf7qTNduWFtCrRw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "packages/AI/AgentManager/actions/node_modules/minimatch": {
+      "version": "10.2.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "brace-expansion": "^5.0.5"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "packages/AI/AgentManager/actions/node_modules/minipass": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
+      "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      }
+    },
+    "packages/AI/AgentManager/actions/node_modules/path-scurry": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-2.0.2.tgz",
+      "integrity": "sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "lru-cache": "^11.0.0",
+        "minipass": "^7.1.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "packages/AI/AgentManager/actions/node_modules/rimraf": {
+      "version": "6.1.3",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-6.1.3.tgz",
+      "integrity": "sha512-LKg+Cr2ZF61fkcaK1UdkH2yEBBKnYjTyWzTJT6KNPcSPaiT7HSdhtMXQuN5wkTX0Xu72KQ1l8S42rlmexS2hSA==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "glob": "^13.0.3",
+        "package-json-from-dist": "^1.0.1"
+      },
+      "bin": {
+        "rimraf": "dist/esm/bin.mjs"
+      },
+      "engines": {
+        "node": "20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "packages/AI/AgentManager/actions/node_modules/undici-types": {
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
+      "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "packages/AI/AgentManager/core": {
       "name": "@memberjunction/ai-agent-manager",
       "version": "5.29.0",
@@ -42626,6 +43735,137 @@
         "rimraf": "^6.1.2",
         "typescript": "^5.9.3"
       }
+    },
+    "packages/AI/AgentManager/core/node_modules/@types/node": {
+      "version": "24.12.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.12.2.tgz",
+      "integrity": "sha512-A1sre26ke7HDIuY/M23nd9gfB+nrmhtYyMINbjI1zHJxYteKR6qSMX56FsmjMcDb3SMcjJg5BiRRgOCC/yBD0g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~7.16.0"
+      }
+    },
+    "packages/AI/AgentManager/core/node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "packages/AI/AgentManager/core/node_modules/brace-expansion": {
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
+      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "packages/AI/AgentManager/core/node_modules/glob": {
+      "version": "13.0.6",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-13.0.6.tgz",
+      "integrity": "sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "minimatch": "^10.2.2",
+        "minipass": "^7.1.3",
+        "path-scurry": "^2.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "packages/AI/AgentManager/core/node_modules/lru-cache": {
+      "version": "11.3.5",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.3.5.tgz",
+      "integrity": "sha512-NxVFwLAnrd9i7KUBxC4DrUhmgjzOs+1Qm50D3oF1/oL+r1NpZ4gA7xvG0/zJ8evR7zIKn4vLf7qTNduWFtCrRw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "packages/AI/AgentManager/core/node_modules/minimatch": {
+      "version": "10.2.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "brace-expansion": "^5.0.5"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "packages/AI/AgentManager/core/node_modules/minipass": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
+      "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      }
+    },
+    "packages/AI/AgentManager/core/node_modules/path-scurry": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-2.0.2.tgz",
+      "integrity": "sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "lru-cache": "^11.0.0",
+        "minipass": "^7.1.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "packages/AI/AgentManager/core/node_modules/rimraf": {
+      "version": "6.1.3",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-6.1.3.tgz",
+      "integrity": "sha512-LKg+Cr2ZF61fkcaK1UdkH2yEBBKnYjTyWzTJT6KNPcSPaiT7HSdhtMXQuN5wkTX0Xu72KQ1l8S42rlmexS2hSA==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "glob": "^13.0.3",
+        "package-json-from-dist": "^1.0.1"
+      },
+      "bin": {
+        "rimraf": "dist/esm/bin.mjs"
+      },
+      "engines": {
+        "node": "20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "packages/AI/AgentManager/core/node_modules/undici-types": {
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
+      "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
+      "dev": true,
+      "license": "MIT"
     },
     "packages/AI/Agents": {
       "name": "@memberjunction/ai-agents",
@@ -42662,6 +43902,16 @@
         "vitest": "^4.0.18"
       }
     },
+    "packages/AI/Agents/node_modules/@types/node": {
+      "version": "24.10.11",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.10.11.tgz",
+      "integrity": "sha512-/Af7O8r1frCVgOz0I62jWUtMohJ0/ZQU/ZoketltOJPZpnb17yoNc9BSoVuV9qlaIXJiPNOpsfq4ByFajSArNQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~7.16.0"
+      }
+    },
     "packages/AI/Agents/node_modules/pdfjs-dist": {
       "version": "4.10.38",
       "resolved": "https://registry.npmjs.org/pdfjs-dist/-/pdfjs-dist-4.10.38.tgz",
@@ -42673,6 +43923,13 @@
       "optionalDependencies": {
         "@napi-rs/canvas": "^0.1.65"
       }
+    },
+    "packages/AI/Agents/node_modules/undici-types": {
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
+      "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
+      "dev": true,
+      "license": "MIT"
     },
     "packages/AI/AgentsClient": {
       "name": "@memberjunction/ai-agent-client",
@@ -42688,6 +43945,23 @@
         "@types/node": "24.10.11",
         "typescript": "^5.9.3"
       }
+    },
+    "packages/AI/AgentsClient/node_modules/@types/node": {
+      "version": "24.10.11",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.10.11.tgz",
+      "integrity": "sha512-/Af7O8r1frCVgOz0I62jWUtMohJ0/ZQU/ZoketltOJPZpnb17yoNc9BSoVuV9qlaIXJiPNOpsfq4ByFajSArNQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~7.16.0"
+      }
+    },
+    "packages/AI/AgentsClient/node_modules/undici-types": {
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
+      "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
+      "dev": true,
+      "license": "MIT"
     },
     "packages/AI/AICLI": {
       "name": "@memberjunction/ai-cli",
@@ -42814,6 +44088,29 @@
         "sprintf-js": "~1.0.2"
       }
     },
+    "packages/AI/AICLI/node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "packages/AI/AICLI/node_modules/brace-expansion": {
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
+      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
     "packages/AI/AICLI/node_modules/chalk": {
       "version": "5.6.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
@@ -42824,6 +44121,40 @@
       },
       "funding": {
         "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "packages/AI/AICLI/node_modules/glob": {
+      "version": "13.0.6",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-13.0.6.tgz",
+      "integrity": "sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "minimatch": "^10.2.2",
+        "minipass": "^7.1.3",
+        "path-scurry": "^2.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "packages/AI/AICLI/node_modules/glob/node_modules/minimatch": {
+      "version": "10.2.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "brace-expansion": "^5.0.5"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "packages/AI/AICLI/node_modules/js-yaml": {
@@ -42837,6 +44168,63 @@
       },
       "bin": {
         "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "packages/AI/AICLI/node_modules/lru-cache": {
+      "version": "11.3.5",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.3.5.tgz",
+      "integrity": "sha512-NxVFwLAnrd9i7KUBxC4DrUhmgjzOs+1Qm50D3oF1/oL+r1NpZ4gA7xvG0/zJ8evR7zIKn4vLf7qTNduWFtCrRw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "packages/AI/AICLI/node_modules/minipass": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
+      "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      }
+    },
+    "packages/AI/AICLI/node_modules/path-scurry": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-2.0.2.tgz",
+      "integrity": "sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "lru-cache": "^11.0.0",
+        "minipass": "^7.1.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "packages/AI/AICLI/node_modules/rimraf": {
+      "version": "6.1.2",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-6.1.2.tgz",
+      "integrity": "sha512-cFCkPslJv7BAXJsYlK1dZsbP8/ZNLkCAQ0bi1hf5EKX2QHegmDFEFA6QhuYJlk7UDdc+02JjO80YSOrWPpw06g==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "glob": "^13.0.0",
+        "package-json-from-dist": "^1.0.1"
+      },
+      "bin": {
+        "rimraf": "dist/esm/bin.mjs"
+      },
+      "engines": {
+        "node": "20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "packages/AI/AICLI/node_modules/sprintf-js": {
@@ -42883,6 +44271,23 @@
         "vitest": "^4.0.18"
       }
     },
+    "packages/AI/BaseAIEngine/node_modules/@types/node": {
+      "version": "24.10.11",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.10.11.tgz",
+      "integrity": "sha512-/Af7O8r1frCVgOz0I62jWUtMohJ0/ZQU/ZoketltOJPZpnb17yoNc9BSoVuV9qlaIXJiPNOpsfq4ByFajSArNQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~7.16.0"
+      }
+    },
+    "packages/AI/BaseAIEngine/node_modules/undici-types": {
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
+      "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "packages/AI/ComputerUse": {
       "name": "@memberjunction/computer-use",
       "version": "5.29.0",
@@ -42907,6 +44312,23 @@
         }
       }
     },
+    "packages/AI/ComputerUse/node_modules/@types/node": {
+      "version": "24.10.11",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.10.11.tgz",
+      "integrity": "sha512-/Af7O8r1frCVgOz0I62jWUtMohJ0/ZQU/ZoketltOJPZpnb17yoNc9BSoVuV9qlaIXJiPNOpsfq4ByFajSArNQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~7.16.0"
+      }
+    },
+    "packages/AI/ComputerUse/node_modules/undici-types": {
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
+      "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "packages/AI/Core": {
       "name": "@memberjunction/ai",
       "version": "5.29.0",
@@ -42922,6 +44344,23 @@
         "typescript": "^5.9.3",
         "vitest": "^4.0.18"
       }
+    },
+    "packages/AI/Core/node_modules/@types/node": {
+      "version": "24.10.11",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.10.11.tgz",
+      "integrity": "sha512-/Af7O8r1frCVgOz0I62jWUtMohJ0/ZQU/ZoketltOJPZpnb17yoNc9BSoVuV9qlaIXJiPNOpsfq4ByFajSArNQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~7.16.0"
+      }
+    },
+    "packages/AI/Core/node_modules/undici-types": {
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
+      "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
+      "dev": true,
+      "license": "MIT"
     },
     "packages/AI/CorePlus": {
       "name": "@memberjunction/ai-core-plus",
@@ -42946,6 +44385,16 @@
         "vitest": "^4.0.18"
       }
     },
+    "packages/AI/CorePlus/node_modules/@types/node": {
+      "version": "24.10.11",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.10.11.tgz",
+      "integrity": "sha512-/Af7O8r1frCVgOz0I62jWUtMohJ0/ZQU/ZoketltOJPZpnb17yoNc9BSoVuV9qlaIXJiPNOpsfq4ByFajSArNQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~7.16.0"
+      }
+    },
     "packages/AI/CorePlus/node_modules/date-fns": {
       "version": "4.1.0",
       "license": "MIT",
@@ -42953,6 +44402,13 @@
         "type": "github",
         "url": "https://github.com/sponsors/kossnocorp"
       }
+    },
+    "packages/AI/CorePlus/node_modules/undici-types": {
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
+      "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
+      "dev": true,
+      "license": "MIT"
     },
     "packages/AI/Engine": {
       "name": "@memberjunction/aiengine",
@@ -42978,6 +44434,23 @@
         "vitest": "^4.0.18"
       }
     },
+    "packages/AI/Engine/node_modules/@types/node": {
+      "version": "24.10.11",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.10.11.tgz",
+      "integrity": "sha512-/Af7O8r1frCVgOz0I62jWUtMohJ0/ZQU/ZoketltOJPZpnb17yoNc9BSoVuV9qlaIXJiPNOpsfq4ByFajSArNQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~7.16.0"
+      }
+    },
+    "packages/AI/Engine/node_modules/undici-types": {
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
+      "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "packages/AI/Knowledge/Pipeline": {
       "name": "@memberjunction/ai-knowledge-pipeline",
       "version": "5.29.0",
@@ -42996,6 +44469,23 @@
         "@types/node": "24.10.11",
         "typescript": "^5.9.3"
       }
+    },
+    "packages/AI/Knowledge/Pipeline/node_modules/@types/node": {
+      "version": "24.10.11",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.10.11.tgz",
+      "integrity": "sha512-/Af7O8r1frCVgOz0I62jWUtMohJ0/ZQU/ZoketltOJPZpnb17yoNc9BSoVuV9qlaIXJiPNOpsfq4ByFajSArNQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~7.16.0"
+      }
+    },
+    "packages/AI/Knowledge/Pipeline/node_modules/undici-types": {
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
+      "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
+      "dev": true,
+      "license": "MIT"
     },
     "packages/AI/Knowledge/SearchEngine": {
       "name": "@memberjunction/search-engine",
@@ -43035,6 +44525,23 @@
         "vitest": "^4.0.18"
       }
     },
+    "packages/AI/Knowledge/TagEngine/node_modules/@types/node": {
+      "version": "24.10.11",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.10.11.tgz",
+      "integrity": "sha512-/Af7O8r1frCVgOz0I62jWUtMohJ0/ZQU/ZoketltOJPZpnb17yoNc9BSoVuV9qlaIXJiPNOpsfq4ByFajSArNQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~7.16.0"
+      }
+    },
+    "packages/AI/Knowledge/TagEngine/node_modules/undici-types": {
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
+      "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "packages/AI/Knowledge/TagEngineBase": {
       "name": "@memberjunction/tag-engine-base",
       "version": "5.29.0",
@@ -43049,6 +44556,23 @@
         "typescript": "^5.9.3",
         "vitest": "^4.0.18"
       }
+    },
+    "packages/AI/Knowledge/TagEngineBase/node_modules/@types/node": {
+      "version": "24.10.11",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.10.11.tgz",
+      "integrity": "sha512-/Af7O8r1frCVgOz0I62jWUtMohJ0/ZQU/ZoketltOJPZpnb17yoNc9BSoVuV9qlaIXJiPNOpsfq4ByFajSArNQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~7.16.0"
+      }
+    },
+    "packages/AI/Knowledge/TagEngineBase/node_modules/undici-types": {
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
+      "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
+      "dev": true,
+      "license": "MIT"
     },
     "packages/AI/MCPClient": {
       "name": "@memberjunction/ai-mcp-client",
@@ -43067,6 +44591,23 @@
         "typescript": "^5.9.3",
         "vitest": "^4.0.18"
       }
+    },
+    "packages/AI/MCPClient/node_modules/@types/node": {
+      "version": "24.10.11",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.10.11.tgz",
+      "integrity": "sha512-/Af7O8r1frCVgOz0I62jWUtMohJ0/ZQU/ZoketltOJPZpnb17yoNc9BSoVuV9qlaIXJiPNOpsfq4ByFajSArNQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~7.16.0"
+      }
+    },
+    "packages/AI/MCPClient/node_modules/undici-types": {
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
+      "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
+      "dev": true,
+      "license": "MIT"
     },
     "packages/AI/MCPClient/node_modules/zod": {
       "version": "3.24.4",
@@ -43337,6 +44878,23 @@
         }
       }
     },
+    "packages/AI/MJComputerUse/node_modules/@types/node": {
+      "version": "24.10.11",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.10.11.tgz",
+      "integrity": "sha512-/Af7O8r1frCVgOz0I62jWUtMohJ0/ZQU/ZoketltOJPZpnb17yoNc9BSoVuV9qlaIXJiPNOpsfq4ByFajSArNQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~7.16.0"
+      }
+    },
+    "packages/AI/MJComputerUse/node_modules/undici-types": {
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
+      "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "packages/AI/Prompts": {
       "name": "@memberjunction/ai-prompts",
       "version": "5.29.0",
@@ -43366,6 +44924,16 @@
         "vitest": "^4.0.18"
       }
     },
+    "packages/AI/Prompts/node_modules/@types/node": {
+      "version": "24.10.11",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.10.11.tgz",
+      "integrity": "sha512-/Af7O8r1frCVgOz0I62jWUtMohJ0/ZQU/ZoketltOJPZpnb17yoNc9BSoVuV9qlaIXJiPNOpsfq4ByFajSArNQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~7.16.0"
+      }
+    },
     "packages/AI/Prompts/node_modules/date-fns": {
       "version": "2.30.0",
       "license": "MIT",
@@ -43386,6 +44954,13 @@
       "peerDependencies": {
         "date-fns": "2.x"
       }
+    },
+    "packages/AI/Prompts/node_modules/undici-types": {
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
+      "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
+      "dev": true,
+      "license": "MIT"
     },
     "packages/AI/Providers/Anthropic": {
       "name": "@memberjunction/ai-anthropic",
@@ -43415,6 +44990,120 @@
       "devDependencies": {
         "rimraf": "^6.1.2",
         "typescript": "^5.9.3"
+      }
+    },
+    "packages/AI/Providers/Azure/node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "packages/AI/Providers/Azure/node_modules/brace-expansion": {
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
+      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "packages/AI/Providers/Azure/node_modules/glob": {
+      "version": "13.0.6",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-13.0.6.tgz",
+      "integrity": "sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "minimatch": "^10.2.2",
+        "minipass": "^7.1.3",
+        "path-scurry": "^2.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "packages/AI/Providers/Azure/node_modules/lru-cache": {
+      "version": "11.3.5",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.3.5.tgz",
+      "integrity": "sha512-NxVFwLAnrd9i7KUBxC4DrUhmgjzOs+1Qm50D3oF1/oL+r1NpZ4gA7xvG0/zJ8evR7zIKn4vLf7qTNduWFtCrRw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "packages/AI/Providers/Azure/node_modules/minimatch": {
+      "version": "10.2.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "brace-expansion": "^5.0.5"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "packages/AI/Providers/Azure/node_modules/minipass": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
+      "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      }
+    },
+    "packages/AI/Providers/Azure/node_modules/path-scurry": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-2.0.2.tgz",
+      "integrity": "sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "lru-cache": "^11.0.0",
+        "minipass": "^7.1.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "packages/AI/Providers/Azure/node_modules/rimraf": {
+      "version": "6.1.3",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-6.1.3.tgz",
+      "integrity": "sha512-LKg+Cr2ZF61fkcaK1UdkH2yEBBKnYjTyWzTJT6KNPcSPaiT7HSdhtMXQuN5wkTX0Xu72KQ1l8S42rlmexS2hSA==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "glob": "^13.0.3",
+        "package-json-from-dist": "^1.0.1"
+      },
+      "bin": {
+        "rimraf": "dist/esm/bin.mjs"
+      },
+      "engines": {
+        "node": "20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "packages/AI/Providers/Bedrock": {
@@ -43477,6 +45166,7 @@
         "@memberjunction/ai-gemini": "5.29.0",
         "@memberjunction/ai-groq": "5.29.0",
         "@memberjunction/ai-heygen": "5.29.0",
+        "@memberjunction/ai-llamacpp": "5.29.0",
         "@memberjunction/ai-lmstudio": "5.29.0",
         "@memberjunction/ai-local-embeddings": "5.29.0",
         "@memberjunction/ai-minimax": "5.29.0",
@@ -43522,6 +45212,23 @@
         "ts-node-dev": "^2.0.0",
         "typescript": "^5.9.3"
       }
+    },
+    "packages/AI/Providers/Cohere/node_modules/@types/node": {
+      "version": "24.10.11",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.10.11.tgz",
+      "integrity": "sha512-/Af7O8r1frCVgOz0I62jWUtMohJ0/ZQU/ZoketltOJPZpnb17yoNc9BSoVuV9qlaIXJiPNOpsfq4ByFajSArNQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~7.16.0"
+      }
+    },
+    "packages/AI/Providers/Cohere/node_modules/undici-types": {
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
+      "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
+      "dev": true,
+      "license": "MIT"
     },
     "packages/AI/Providers/ElevenLabs": {
       "name": "@memberjunction/ai-elevenlabs",
@@ -43589,6 +45296,20 @@
         "@memberjunction/ai": "5.29.0",
         "@memberjunction/global": "5.29.0",
         "axios": "^1.13.4"
+      },
+      "devDependencies": {
+        "ts-node-dev": "^2.0.0",
+        "typescript": "^5.9.3"
+      }
+    },
+    "packages/AI/Providers/LlamaCpp": {
+      "name": "@memberjunction/ai-llamacpp",
+      "version": "5.29.0",
+      "license": "ISC",
+      "dependencies": {
+        "@memberjunction/ai": "5.29.0",
+        "@memberjunction/ai-openai": "5.29.0",
+        "@memberjunction/global": "5.29.0"
       },
       "devDependencies": {
         "ts-node-dev": "^2.0.0",
@@ -43793,6 +45514,23 @@
         "vitest": "^4.0.18"
       }
     },
+    "packages/AI/Reranker/node_modules/@types/node": {
+      "version": "24.10.11",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.10.11.tgz",
+      "integrity": "sha512-/Af7O8r1frCVgOz0I62jWUtMohJ0/ZQU/ZoketltOJPZpnb17yoNc9BSoVuV9qlaIXJiPNOpsfq4ByFajSArNQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~7.16.0"
+      }
+    },
+    "packages/AI/Reranker/node_modules/undici-types": {
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
+      "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "packages/AI/Vectors/Core": {
       "name": "@memberjunction/ai-vectors",
       "version": "5.29.0",
@@ -43814,6 +45552,23 @@
         "typescript": "^5.9.3"
       }
     },
+    "packages/AI/Vectors/Core/node_modules/@types/node": {
+      "version": "24.10.11",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.10.11.tgz",
+      "integrity": "sha512-/Af7O8r1frCVgOz0I62jWUtMohJ0/ZQU/ZoketltOJPZpnb17yoNc9BSoVuV9qlaIXJiPNOpsfq4ByFajSArNQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~7.16.0"
+      }
+    },
+    "packages/AI/Vectors/Core/node_modules/undici-types": {
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
+      "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "packages/AI/Vectors/Database": {
       "name": "@memberjunction/ai-vectordb",
       "version": "5.29.0",
@@ -43828,6 +45583,23 @@
         "ts-node-dev": "^2.0.0",
         "typescript": "^5.9.3"
       }
+    },
+    "packages/AI/Vectors/Database/node_modules/@types/node": {
+      "version": "24.10.11",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.10.11.tgz",
+      "integrity": "sha512-/Af7O8r1frCVgOz0I62jWUtMohJ0/ZQU/ZoketltOJPZpnb17yoNc9BSoVuV9qlaIXJiPNOpsfq4ByFajSArNQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~7.16.0"
+      }
+    },
+    "packages/AI/Vectors/Database/node_modules/undici-types": {
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
+      "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
+      "dev": true,
+      "license": "MIT"
     },
     "packages/AI/Vectors/Dupe": {
       "name": "@memberjunction/ai-vector-dupe",
@@ -43852,6 +45624,23 @@
         "typescript": "^5.9.3"
       }
     },
+    "packages/AI/Vectors/Dupe/node_modules/@types/node": {
+      "version": "24.10.11",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.10.11.tgz",
+      "integrity": "sha512-/Af7O8r1frCVgOz0I62jWUtMohJ0/ZQU/ZoketltOJPZpnb17yoNc9BSoVuV9qlaIXJiPNOpsfq4ByFajSArNQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~7.16.0"
+      }
+    },
+    "packages/AI/Vectors/Dupe/node_modules/undici-types": {
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
+      "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "packages/AI/Vectors/Memory": {
       "name": "@memberjunction/ai-vectors-memory",
       "version": "5.29.0",
@@ -43865,6 +45654,23 @@
         "ts-node-dev": "^2.0.0",
         "typescript": "^5.9.3"
       }
+    },
+    "packages/AI/Vectors/Memory/node_modules/@types/node": {
+      "version": "24.10.11",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.10.11.tgz",
+      "integrity": "sha512-/Af7O8r1frCVgOz0I62jWUtMohJ0/ZQU/ZoketltOJPZpnb17yoNc9BSoVuV9qlaIXJiPNOpsfq4ByFajSArNQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~7.16.0"
+      }
+    },
+    "packages/AI/Vectors/Memory/node_modules/undici-types": {
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
+      "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
+      "dev": true,
+      "license": "MIT"
     },
     "packages/AI/Vectors/Providers/pgvector": {
       "name": "@memberjunction/ai-vectors-pgvector",
@@ -43883,6 +45689,23 @@
         "ts-node-dev": "^2.0.0",
         "typescript": "^5.9.3"
       }
+    },
+    "packages/AI/Vectors/Providers/pgvector/node_modules/@types/node": {
+      "version": "24.10.11",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.10.11.tgz",
+      "integrity": "sha512-/Af7O8r1frCVgOz0I62jWUtMohJ0/ZQU/ZoketltOJPZpnb17yoNc9BSoVuV9qlaIXJiPNOpsfq4ByFajSArNQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~7.16.0"
+      }
+    },
+    "packages/AI/Vectors/Providers/pgvector/node_modules/undici-types": {
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
+      "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
+      "dev": true,
+      "license": "MIT"
     },
     "packages/AI/Vectors/Providers/Pinecone": {
       "name": "@memberjunction/ai-vectors-pinecone",
@@ -43905,6 +45728,23 @@
         "typescript": "^5.9.3"
       }
     },
+    "packages/AI/Vectors/Providers/Pinecone/node_modules/@types/node": {
+      "version": "24.10.11",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.10.11.tgz",
+      "integrity": "sha512-/Af7O8r1frCVgOz0I62jWUtMohJ0/ZQU/ZoketltOJPZpnb17yoNc9BSoVuV9qlaIXJiPNOpsfq4ByFajSArNQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~7.16.0"
+      }
+    },
+    "packages/AI/Vectors/Providers/Pinecone/node_modules/undici-types": {
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
+      "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "packages/AI/Vectors/Providers/Qdrant": {
       "name": "@memberjunction/ai-vectors-qdrant",
       "version": "5.29.0",
@@ -43921,6 +45761,23 @@
         "ts-node-dev": "^2.0.0",
         "typescript": "^5.9.3"
       }
+    },
+    "packages/AI/Vectors/Providers/Qdrant/node_modules/@types/node": {
+      "version": "24.10.11",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.10.11.tgz",
+      "integrity": "sha512-/Af7O8r1frCVgOz0I62jWUtMohJ0/ZQU/ZoketltOJPZpnb17yoNc9BSoVuV9qlaIXJiPNOpsfq4ByFajSArNQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~7.16.0"
+      }
+    },
+    "packages/AI/Vectors/Providers/Qdrant/node_modules/undici-types": {
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
+      "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
+      "dev": true,
+      "license": "MIT"
     },
     "packages/AI/Vectors/Sync": {
       "name": "@memberjunction/ai-vector-sync",
@@ -43949,6 +45806,23 @@
         "pkgroll": "2.23.0",
         "typescript": "^5.9.3"
       }
+    },
+    "packages/AI/Vectors/Sync/node_modules/@types/node": {
+      "version": "24.10.11",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.10.11.tgz",
+      "integrity": "sha512-/Af7O8r1frCVgOz0I62jWUtMohJ0/ZQU/ZoketltOJPZpnb17yoNc9BSoVuV9qlaIXJiPNOpsfq4ByFajSArNQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~7.16.0"
+      }
+    },
+    "packages/AI/Vectors/Sync/node_modules/undici-types": {
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
+      "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
+      "dev": true,
+      "license": "MIT"
     },
     "packages/Angular/Bootstrap": {
       "name": "@memberjunction/ng-bootstrap",
@@ -44015,6 +45889,23 @@
         "@types/node": "^24.10.11",
         "typescript": "^5.9.3"
       }
+    },
+    "packages/Angular/BootstrapLite/node_modules/@types/node": {
+      "version": "24.12.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.12.2.tgz",
+      "integrity": "sha512-A1sre26ke7HDIuY/M23nd9gfB+nrmhtYyMINbjI1zHJxYteKR6qSMX56FsmjMcDb3SMcjJg5BiRRgOCC/yBD0g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~7.16.0"
+      }
+    },
+    "packages/Angular/BootstrapLite/node_modules/undici-types": {
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
+      "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
+      "dev": true,
+      "license": "MIT"
     },
     "packages/Angular/Explorer/auth-services": {
       "name": "@memberjunction/ng-auth-services",
@@ -47991,6 +49882,23 @@
         "typescript": "^5.9.3"
       }
     },
+    "packages/APIKeys/Base/node_modules/@types/node": {
+      "version": "24.12.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.12.2.tgz",
+      "integrity": "sha512-A1sre26ke7HDIuY/M23nd9gfB+nrmhtYyMINbjI1zHJxYteKR6qSMX56FsmjMcDb3SMcjJg5BiRRgOCC/yBD0g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~7.16.0"
+      }
+    },
+    "packages/APIKeys/Base/node_modules/undici-types": {
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
+      "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "packages/APIKeys/Engine": {
       "name": "@memberjunction/api-keys",
       "version": "5.29.0",
@@ -48011,6 +49919,23 @@
       "engines": {
         "node": ">=18.0.0"
       }
+    },
+    "packages/APIKeys/Engine/node_modules/@types/node": {
+      "version": "24.12.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.12.2.tgz",
+      "integrity": "sha512-A1sre26ke7HDIuY/M23nd9gfB+nrmhtYyMINbjI1zHJxYteKR6qSMX56FsmjMcDb3SMcjJg5BiRRgOCC/yBD0g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~7.16.0"
+      }
+    },
+    "packages/APIKeys/Engine/node_modules/undici-types": {
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
+      "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
+      "dev": true,
+      "license": "MIT"
     },
     "packages/Archiving/Action": {
       "name": "@memberjunction/archiving-action",
@@ -48289,6 +50214,23 @@
         "vitest": "^4.0.18"
       }
     },
+    "packages/AuthProviders/node_modules/@types/node": {
+      "version": "24.10.11",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.10.11.tgz",
+      "integrity": "sha512-/Af7O8r1frCVgOz0I62jWUtMohJ0/ZQU/ZoketltOJPZpnb17yoNc9BSoVuV9qlaIXJiPNOpsfq4ByFajSArNQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~7.16.0"
+      }
+    },
+    "packages/AuthProviders/node_modules/undici-types": {
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
+      "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "packages/CodeGenLib": {
       "name": "@memberjunction/codegen-lib",
       "version": "5.29.0",
@@ -48443,6 +50385,27 @@
         "url": "https://opencollective.com/vitest"
       }
     },
+    "packages/CodeGenLib/node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "packages/CodeGenLib/node_modules/brace-expansion": {
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
+      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
     "packages/CodeGenLib/node_modules/chai": {
       "version": "5.3.3",
       "resolved": "https://registry.npmjs.org/chai/-/chai-5.3.3.tgz",
@@ -48482,6 +50445,23 @@
         "node": ">=14.14"
       }
     },
+    "packages/CodeGenLib/node_modules/glob": {
+      "version": "13.0.6",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-13.0.6.tgz",
+      "integrity": "sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==",
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "minimatch": "^10.2.2",
+        "minipass": "^7.1.3",
+        "path-scurry": "^2.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "packages/CodeGenLib/node_modules/jsonfile": {
       "version": "6.2.0",
       "license": "MIT",
@@ -48490,6 +50470,55 @@
       },
       "optionalDependencies": {
         "graceful-fs": "^4.1.6"
+      }
+    },
+    "packages/CodeGenLib/node_modules/lru-cache": {
+      "version": "11.3.5",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.3.5.tgz",
+      "integrity": "sha512-NxVFwLAnrd9i7KUBxC4DrUhmgjzOs+1Qm50D3oF1/oL+r1NpZ4gA7xvG0/zJ8evR7zIKn4vLf7qTNduWFtCrRw==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "packages/CodeGenLib/node_modules/minimatch": {
+      "version": "10.2.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "brace-expansion": "^5.0.5"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "packages/CodeGenLib/node_modules/minipass": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
+      "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      }
+    },
+    "packages/CodeGenLib/node_modules/path-scurry": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-2.0.2.tgz",
+      "integrity": "sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==",
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "lru-cache": "^11.0.0",
+        "minipass": "^7.1.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "packages/CodeGenLib/node_modules/tinyexec": {
@@ -48714,6 +50743,120 @@
         "typescript": "^5.9.3"
       }
     },
+    "packages/Communication/providers/gmail/node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "packages/Communication/providers/gmail/node_modules/brace-expansion": {
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
+      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "packages/Communication/providers/gmail/node_modules/glob": {
+      "version": "13.0.6",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-13.0.6.tgz",
+      "integrity": "sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "minimatch": "^10.2.2",
+        "minipass": "^7.1.3",
+        "path-scurry": "^2.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "packages/Communication/providers/gmail/node_modules/lru-cache": {
+      "version": "11.3.5",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.3.5.tgz",
+      "integrity": "sha512-NxVFwLAnrd9i7KUBxC4DrUhmgjzOs+1Qm50D3oF1/oL+r1NpZ4gA7xvG0/zJ8evR7zIKn4vLf7qTNduWFtCrRw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "packages/Communication/providers/gmail/node_modules/minimatch": {
+      "version": "10.2.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "brace-expansion": "^5.0.5"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "packages/Communication/providers/gmail/node_modules/minipass": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
+      "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      }
+    },
+    "packages/Communication/providers/gmail/node_modules/path-scurry": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-2.0.2.tgz",
+      "integrity": "sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "lru-cache": "^11.0.0",
+        "minipass": "^7.1.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "packages/Communication/providers/gmail/node_modules/rimraf": {
+      "version": "6.1.3",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-6.1.3.tgz",
+      "integrity": "sha512-LKg+Cr2ZF61fkcaK1UdkH2yEBBKnYjTyWzTJT6KNPcSPaiT7HSdhtMXQuN5wkTX0Xu72KQ1l8S42rlmexS2hSA==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "glob": "^13.0.3",
+        "package-json-from-dist": "^1.0.1"
+      },
+      "bin": {
+        "rimraf": "dist/esm/bin.mjs"
+      },
+      "engines": {
+        "node": "20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "packages/Communication/providers/MSGraph": {
       "name": "@memberjunction/communication-ms-graph",
       "version": "5.29.0",
@@ -48757,6 +50900,23 @@
         "node": ">=20"
       }
     },
+    "packages/Communication/providers/MSGraph/node_modules/@types/node": {
+      "version": "24.12.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.12.2.tgz",
+      "integrity": "sha512-A1sre26ke7HDIuY/M23nd9gfB+nrmhtYyMINbjI1zHJxYteKR6qSMX56FsmjMcDb3SMcjJg5BiRRgOCC/yBD0g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~7.16.0"
+      }
+    },
+    "packages/Communication/providers/MSGraph/node_modules/undici-types": {
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
+      "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "packages/Communication/providers/MSGraph/node_modules/uuid": {
       "version": "8.3.2",
       "license": "MIT",
@@ -48795,6 +50955,120 @@
       "devDependencies": {
         "rimraf": "^6.1.2",
         "typescript": "^5.9.3"
+      }
+    },
+    "packages/Communication/providers/twilio/node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "packages/Communication/providers/twilio/node_modules/brace-expansion": {
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
+      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "packages/Communication/providers/twilio/node_modules/glob": {
+      "version": "13.0.6",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-13.0.6.tgz",
+      "integrity": "sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "minimatch": "^10.2.2",
+        "minipass": "^7.1.3",
+        "path-scurry": "^2.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "packages/Communication/providers/twilio/node_modules/lru-cache": {
+      "version": "11.3.5",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.3.5.tgz",
+      "integrity": "sha512-NxVFwLAnrd9i7KUBxC4DrUhmgjzOs+1Qm50D3oF1/oL+r1NpZ4gA7xvG0/zJ8evR7zIKn4vLf7qTNduWFtCrRw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "packages/Communication/providers/twilio/node_modules/minimatch": {
+      "version": "10.2.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "brace-expansion": "^5.0.5"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "packages/Communication/providers/twilio/node_modules/minipass": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
+      "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      }
+    },
+    "packages/Communication/providers/twilio/node_modules/path-scurry": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-2.0.2.tgz",
+      "integrity": "sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "lru-cache": "^11.0.0",
+        "minipass": "^7.1.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "packages/Communication/providers/twilio/node_modules/rimraf": {
+      "version": "6.1.3",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-6.1.3.tgz",
+      "integrity": "sha512-LKg+Cr2ZF61fkcaK1UdkH2yEBBKnYjTyWzTJT6KNPcSPaiT7HSdhtMXQuN5wkTX0Xu72KQ1l8S42rlmexS2hSA==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "glob": "^13.0.3",
+        "package-json-from-dist": "^1.0.1"
+      },
+      "bin": {
+        "rimraf": "dist/esm/bin.mjs"
+      },
+      "engines": {
+        "node": "20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "packages/ComponentRegistry": {
@@ -48910,6 +51184,23 @@
         "typescript": "^5.9.3",
         "vitest": "^4.0.18"
       }
+    },
+    "packages/Config/node_modules/@types/node": {
+      "version": "24.12.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.12.2.tgz",
+      "integrity": "sha512-A1sre26ke7HDIuY/M23nd9gfB+nrmhtYyMINbjI1zHJxYteKR6qSMX56FsmjMcDb3SMcjJg5BiRRgOCC/yBD0g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~7.16.0"
+      }
+    },
+    "packages/Config/node_modules/undici-types": {
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
+      "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
+      "dev": true,
+      "license": "MIT"
     },
     "packages/Config/node_modules/zod": {
       "version": "3.24.4",
@@ -49050,6 +51341,16 @@
         "tsc-alias": "^1.8.16",
         "typescript": "^5.9.3",
         "vitest": "^3.1.1"
+      }
+    },
+    "packages/Credentials/Engine/node_modules/@types/node": {
+      "version": "24.10.11",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.10.11.tgz",
+      "integrity": "sha512-/Af7O8r1frCVgOz0I62jWUtMohJ0/ZQU/ZoketltOJPZpnb17yoNc9BSoVuV9qlaIXJiPNOpsfq4ByFajSArNQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~7.16.0"
       }
     },
     "packages/Credentials/Engine/node_modules/@vitest/expect": {
@@ -49249,6 +51550,13 @@
       "engines": {
         "node": ">=14.0.0"
       }
+    },
+    "packages/Credentials/Engine/node_modules/undici-types": {
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
+      "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
+      "dev": true,
+      "license": "MIT"
     },
     "packages/Credentials/Engine/node_modules/vitest": {
       "version": "3.2.4",
@@ -49478,6 +51786,16 @@
       },
       "funding": {
         "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "packages/DBAutoDoc/node_modules/@types/node": {
+      "version": "24.12.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.12.2.tgz",
+      "integrity": "sha512-A1sre26ke7HDIuY/M23nd9gfB+nrmhtYyMINbjI1zHJxYteKR6qSMX56FsmjMcDb3SMcjJg5BiRRgOCC/yBD0g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~7.16.0"
       }
     },
     "packages/DBAutoDoc/node_modules/ansi-regex": {
@@ -49932,6 +52250,13 @@
         "url": "https://github.com/chalk/strip-ansi?sponsor=1"
       }
     },
+    "packages/DBAutoDoc/node_modules/undici-types": {
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
+      "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "packages/DBAutoDoc/node_modules/zod": {
       "version": "3.24.4",
       "resolved": "https://registry.npmjs.org/zod/-/zod-3.24.4.tgz",
@@ -50056,6 +52381,23 @@
           "optional": true
         }
       }
+    },
+    "packages/Encryption/node_modules/@types/node": {
+      "version": "24.12.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.12.2.tgz",
+      "integrity": "sha512-A1sre26ke7HDIuY/M23nd9gfB+nrmhtYyMINbjI1zHJxYteKR6qSMX56FsmjMcDb3SMcjJg5BiRRgOCC/yBD0g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~7.16.0"
+      }
+    },
+    "packages/Encryption/node_modules/undici-types": {
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
+      "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
+      "dev": true,
+      "license": "MIT"
     },
     "packages/ExternalChangeDetection": {
       "name": "@memberjunction/external-change-detection",
@@ -50398,6 +52740,23 @@
         "typescript": "^5.9.3",
         "vitest": "^4.0.18"
       }
+    },
+    "packages/geo-core/node_modules/@types/node": {
+      "version": "24.12.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.12.2.tgz",
+      "integrity": "sha512-A1sre26ke7HDIuY/M23nd9gfB+nrmhtYyMINbjI1zHJxYteKR6qSMX56FsmjMcDb3SMcjJg5BiRRgOCC/yBD0g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~7.16.0"
+      }
+    },
+    "packages/geo-core/node_modules/undici-types": {
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
+      "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
+      "dev": true,
+      "license": "MIT"
     },
     "packages/GraphQLDataProvider": {
       "name": "@memberjunction/graphql-dataprovider",
@@ -50887,6 +53246,24 @@
         "node": ">=14.14"
       }
     },
+    "packages/MetadataSync/node_modules/glob": {
+      "version": "13.0.6",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-13.0.6.tgz",
+      "integrity": "sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "minimatch": "^10.2.2",
+        "minipass": "^7.1.3",
+        "path-scurry": "^2.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "packages/MetadataSync/node_modules/jsonfile": {
       "version": "6.2.0",
       "license": "MIT",
@@ -50895,6 +53272,16 @@
       },
       "optionalDependencies": {
         "graceful-fs": "^4.1.6"
+      }
+    },
+    "packages/MetadataSync/node_modules/lru-cache": {
+      "version": "11.3.5",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.3.5.tgz",
+      "integrity": "sha512-NxVFwLAnrd9i7KUBxC4DrUhmgjzOs+1Qm50D3oF1/oL+r1NpZ4gA7xvG0/zJ8evR7zIKn4vLf7qTNduWFtCrRw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
       }
     },
     "packages/MetadataSync/node_modules/minimatch": {
@@ -50907,6 +53294,53 @@
       },
       "engines": {
         "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "packages/MetadataSync/node_modules/minipass": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
+      "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      }
+    },
+    "packages/MetadataSync/node_modules/path-scurry": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-2.0.2.tgz",
+      "integrity": "sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "lru-cache": "^11.0.0",
+        "minipass": "^7.1.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "packages/MetadataSync/node_modules/rimraf": {
+      "version": "6.1.2",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-6.1.2.tgz",
+      "integrity": "sha512-cFCkPslJv7BAXJsYlK1dZsbP8/ZNLkCAQ0bi1hf5EKX2QHegmDFEFA6QhuYJlk7UDdc+02JjO80YSOrWPpw06g==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "glob": "^13.0.0",
+        "package-json-from-dist": "^1.0.1"
+      },
+      "bin": {
+        "rimraf": "dist/esm/bin.mjs"
+      },
+      "engines": {
+        "node": "20 || >=22"
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
@@ -51117,6 +53551,29 @@
         "sprintf-js": "~1.0.2"
       }
     },
+    "packages/MJCLI/node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "packages/MJCLI/node_modules/brace-expansion": {
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
+      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
     "packages/MJCLI/node_modules/chalk": {
       "version": "5.6.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
@@ -51139,6 +53596,40 @@
       },
       "engines": {
         "node": ">=14.14"
+      }
+    },
+    "packages/MJCLI/node_modules/glob": {
+      "version": "13.0.6",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-13.0.6.tgz",
+      "integrity": "sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "minimatch": "^10.2.2",
+        "minipass": "^7.1.3",
+        "path-scurry": "^2.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "packages/MJCLI/node_modules/glob/node_modules/minimatch": {
+      "version": "10.2.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "brace-expansion": "^5.0.5"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "packages/MJCLI/node_modules/js-yaml": {
@@ -51168,6 +53659,63 @@
       },
       "optionalDependencies": {
         "graceful-fs": "^4.1.6"
+      }
+    },
+    "packages/MJCLI/node_modules/lru-cache": {
+      "version": "11.3.5",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.3.5.tgz",
+      "integrity": "sha512-NxVFwLAnrd9i7KUBxC4DrUhmgjzOs+1Qm50D3oF1/oL+r1NpZ4gA7xvG0/zJ8evR7zIKn4vLf7qTNduWFtCrRw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "packages/MJCLI/node_modules/minipass": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
+      "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      }
+    },
+    "packages/MJCLI/node_modules/path-scurry": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-2.0.2.tgz",
+      "integrity": "sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "lru-cache": "^11.0.0",
+        "minipass": "^7.1.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "packages/MJCLI/node_modules/rimraf": {
+      "version": "6.1.2",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-6.1.2.tgz",
+      "integrity": "sha512-cFCkPslJv7BAXJsYlK1dZsbP8/ZNLkCAQ0bi1hf5EKX2QHegmDFEFA6QhuYJlk7UDdc+02JjO80YSOrWPpw06g==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "glob": "^13.0.0",
+        "package-json-from-dist": "^1.0.1"
+      },
+      "bin": {
+        "rimraf": "dist/esm/bin.mjs"
+      },
+      "engines": {
+        "node": "20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "packages/MJCLI/node_modules/sprintf-js": {
@@ -51286,6 +53834,29 @@
         "@types/node": "*"
       }
     },
+    "packages/MJCodeGenAPI/node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "packages/MJCodeGenAPI/node_modules/brace-expansion": {
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
+      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
     "packages/MJCodeGenAPI/node_modules/fs-extra": {
       "version": "11.3.3",
       "license": "MIT",
@@ -51298,6 +53869,24 @@
         "node": ">=14.14"
       }
     },
+    "packages/MJCodeGenAPI/node_modules/glob": {
+      "version": "13.0.6",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-13.0.6.tgz",
+      "integrity": "sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "minimatch": "^10.2.2",
+        "minipass": "^7.1.3",
+        "path-scurry": "^2.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "packages/MJCodeGenAPI/node_modules/jsonfile": {
       "version": "6.2.0",
       "license": "MIT",
@@ -51306,6 +53895,79 @@
       },
       "optionalDependencies": {
         "graceful-fs": "^4.1.6"
+      }
+    },
+    "packages/MJCodeGenAPI/node_modules/lru-cache": {
+      "version": "11.3.5",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.3.5.tgz",
+      "integrity": "sha512-NxVFwLAnrd9i7KUBxC4DrUhmgjzOs+1Qm50D3oF1/oL+r1NpZ4gA7xvG0/zJ8evR7zIKn4vLf7qTNduWFtCrRw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "packages/MJCodeGenAPI/node_modules/minimatch": {
+      "version": "10.2.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "brace-expansion": "^5.0.5"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "packages/MJCodeGenAPI/node_modules/minipass": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
+      "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      }
+    },
+    "packages/MJCodeGenAPI/node_modules/path-scurry": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-2.0.2.tgz",
+      "integrity": "sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "lru-cache": "^11.0.0",
+        "minipass": "^7.1.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "packages/MJCodeGenAPI/node_modules/rimraf": {
+      "version": "6.1.2",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-6.1.2.tgz",
+      "integrity": "sha512-cFCkPslJv7BAXJsYlK1dZsbP8/ZNLkCAQ0bi1hf5EKX2QHegmDFEFA6QhuYJlk7UDdc+02JjO80YSOrWPpw06g==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "glob": "^13.0.0",
+        "package-json-from-dist": "^1.0.1"
+      },
+      "bin": {
+        "rimraf": "dist/esm/bin.mjs"
+      },
+      "engines": {
+        "node": "20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "packages/MJCodeGenAPI/node_modules/undici-types": {
@@ -54117,6 +56779,16 @@
         "vitest": "^3.1.1"
       }
     },
+    "packages/OpenApp/Engine/node_modules/@types/node": {
+      "version": "24.10.11",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.10.11.tgz",
+      "integrity": "sha512-/Af7O8r1frCVgOz0I62jWUtMohJ0/ZQU/ZoketltOJPZpnb17yoNc9BSoVuV9qlaIXJiPNOpsfq4ByFajSArNQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~7.16.0"
+      }
+    },
     "packages/OpenApp/Engine/node_modules/@vitest/expect": {
       "version": "3.2.4",
       "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-3.2.4.tgz",
@@ -54276,6 +56948,13 @@
         "node": ">=14.0.0"
       }
     },
+    "packages/OpenApp/Engine/node_modules/undici-types": {
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
+      "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "packages/OpenApp/Engine/node_modules/vitest": {
       "version": "3.2.4",
       "resolved": "https://registry.npmjs.org/vitest/-/vitest-3.2.4.tgz",
@@ -54395,6 +57074,16 @@
         "ts-node-dev": "^2.0.0",
         "typescript": "^5.9.3",
         "vitest": "^3.1.1"
+      }
+    },
+    "packages/QueryGen/node_modules/@types/node": {
+      "version": "24.10.11",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.10.11.tgz",
+      "integrity": "sha512-/Af7O8r1frCVgOz0I62jWUtMohJ0/ZQU/ZoketltOJPZpnb17yoNc9BSoVuV9qlaIXJiPNOpsfq4ByFajSArNQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~7.16.0"
       }
     },
     "packages/QueryGen/node_modules/@vitest/expect": {
@@ -54742,6 +57431,13 @@
       "engines": {
         "node": ">=14.0.0"
       }
+    },
+    "packages/QueryGen/node_modules/undici-types": {
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
+      "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
+      "dev": true,
+      "license": "MIT"
     },
     "packages/QueryGen/node_modules/vitest": {
       "version": "3.2.4",
@@ -55210,6 +57906,16 @@
         "@babel/core": "^7.0.0-0"
       }
     },
+    "packages/React/runtime/node_modules/@types/node": {
+      "version": "24.10.11",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.10.11.tgz",
+      "integrity": "sha512-/Af7O8r1frCVgOz0I62jWUtMohJ0/ZQU/ZoketltOJPZpnb17yoNc9BSoVuV9qlaIXJiPNOpsfq4ByFajSArNQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~7.16.0"
+      }
+    },
     "packages/React/runtime/node_modules/babel-plugin-polyfill-corejs3": {
       "version": "0.14.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-polyfill-corejs3/-/babel-plugin-polyfill-corejs3-0.14.0.tgz",
@@ -55224,6 +57930,120 @@
         "@babel/core": "^7.4.0 || ^8.0.0-0 <8.0.0"
       }
     },
+    "packages/React/runtime/node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "packages/React/runtime/node_modules/brace-expansion": {
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
+      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "packages/React/runtime/node_modules/glob": {
+      "version": "13.0.6",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-13.0.6.tgz",
+      "integrity": "sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "minimatch": "^10.2.2",
+        "minipass": "^7.1.3",
+        "path-scurry": "^2.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "packages/React/runtime/node_modules/lru-cache": {
+      "version": "11.3.5",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.3.5.tgz",
+      "integrity": "sha512-NxVFwLAnrd9i7KUBxC4DrUhmgjzOs+1Qm50D3oF1/oL+r1NpZ4gA7xvG0/zJ8evR7zIKn4vLf7qTNduWFtCrRw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "packages/React/runtime/node_modules/minimatch": {
+      "version": "10.2.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "brace-expansion": "^5.0.5"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "packages/React/runtime/node_modules/minipass": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
+      "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      }
+    },
+    "packages/React/runtime/node_modules/path-scurry": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-2.0.2.tgz",
+      "integrity": "sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "lru-cache": "^11.0.0",
+        "minipass": "^7.1.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "packages/React/runtime/node_modules/rimraf": {
+      "version": "6.1.3",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-6.1.3.tgz",
+      "integrity": "sha512-LKg+Cr2ZF61fkcaK1UdkH2yEBBKnYjTyWzTJT6KNPcSPaiT7HSdhtMXQuN5wkTX0Xu72KQ1l8S42rlmexS2hSA==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "glob": "^13.0.3",
+        "package-json-from-dist": "^1.0.1"
+      },
+      "bin": {
+        "rimraf": "dist/esm/bin.mjs"
+      },
+      "engines": {
+        "node": "20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "packages/React/runtime/node_modules/semver": {
       "version": "6.3.1",
       "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
@@ -55233,6 +58053,13 @@
       "bin": {
         "semver": "bin/semver.js"
       }
+    },
+    "packages/React/runtime/node_modules/undici-types": {
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
+      "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
+      "dev": true,
+      "license": "MIT"
     },
     "packages/React/test-harness": {
       "name": "@memberjunction/react-test-harness",
@@ -55469,6 +58296,16 @@
         "vitest": "^3.1.1"
       }
     },
+    "packages/RedisProvider/node_modules/@types/node": {
+      "version": "24.12.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.12.2.tgz",
+      "integrity": "sha512-A1sre26ke7HDIuY/M23nd9gfB+nrmhtYyMINbjI1zHJxYteKR6qSMX56FsmjMcDb3SMcjJg5BiRRgOCC/yBD0g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~7.16.0"
+      }
+    },
     "packages/RedisProvider/node_modules/@vitest/expect": {
       "version": "3.2.4",
       "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-3.2.4.tgz",
@@ -55628,6 +58465,13 @@
         "node": ">=14.0.0"
       }
     },
+    "packages/RedisProvider/node_modules/undici-types": {
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
+      "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "packages/RedisProvider/node_modules/vitest": {
       "version": "3.2.4",
       "resolved": "https://registry.npmjs.org/vitest/-/vitest-3.2.4.tgz",
@@ -55720,6 +58564,16 @@
         "typescript": "^5.9.3"
       }
     },
+    "packages/Scheduling/actions/node_modules/@types/node": {
+      "version": "24.10.11",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.10.11.tgz",
+      "integrity": "sha512-/Af7O8r1frCVgOz0I62jWUtMohJ0/ZQU/ZoketltOJPZpnb17yoNc9BSoVuV9qlaIXJiPNOpsfq4ByFajSArNQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~7.16.0"
+      }
+    },
     "packages/Scheduling/actions/node_modules/cron-parser": {
       "version": "4.9.0",
       "resolved": "https://registry.npmjs.org/cron-parser/-/cron-parser-4.9.0.tgz",
@@ -55731,6 +58585,13 @@
       "engines": {
         "node": ">=12.0.0"
       }
+    },
+    "packages/Scheduling/actions/node_modules/undici-types": {
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
+      "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
+      "dev": true,
+      "license": "MIT"
     },
     "packages/Scheduling/base-engine": {
       "name": "@memberjunction/scheduling-engine-base",
@@ -55747,6 +58608,23 @@
         "typescript": "^5.9.3"
       }
     },
+    "packages/Scheduling/base-engine/node_modules/@types/node": {
+      "version": "24.10.11",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.10.11.tgz",
+      "integrity": "sha512-/Af7O8r1frCVgOz0I62jWUtMohJ0/ZQU/ZoketltOJPZpnb17yoNc9BSoVuV9qlaIXJiPNOpsfq4ByFajSArNQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~7.16.0"
+      }
+    },
+    "packages/Scheduling/base-engine/node_modules/undici-types": {
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
+      "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "packages/Scheduling/base-types": {
       "name": "@memberjunction/scheduling-base-types",
       "version": "5.29.0",
@@ -55758,6 +58636,23 @@
         "@types/node": "24.10.11",
         "typescript": "^5.9.3"
       }
+    },
+    "packages/Scheduling/base-types/node_modules/@types/node": {
+      "version": "24.10.11",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.10.11.tgz",
+      "integrity": "sha512-/Af7O8r1frCVgOz0I62jWUtMohJ0/ZQU/ZoketltOJPZpnb17yoNc9BSoVuV9qlaIXJiPNOpsfq4ByFajSArNQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~7.16.0"
+      }
+    },
+    "packages/Scheduling/base-types/node_modules/undici-types": {
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
+      "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
+      "dev": true,
+      "license": "MIT"
     },
     "packages/Scheduling/engine": {
       "name": "@memberjunction/scheduling-engine",
@@ -55781,6 +58676,16 @@
         "@types/node": "24.10.11",
         "typescript": "^5.9.3",
         "vitest": "^3.1.1"
+      }
+    },
+    "packages/Scheduling/engine/node_modules/@types/node": {
+      "version": "24.10.11",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.10.11.tgz",
+      "integrity": "sha512-/Af7O8r1frCVgOz0I62jWUtMohJ0/ZQU/ZoketltOJPZpnb17yoNc9BSoVuV9qlaIXJiPNOpsfq4ByFajSArNQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~7.16.0"
       }
     },
     "packages/Scheduling/engine/node_modules/@vitest/expect": {
@@ -55954,6 +58859,13 @@
         "node": ">=14.0.0"
       }
     },
+    "packages/Scheduling/engine/node_modules/undici-types": {
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
+      "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "packages/Scheduling/engine/node_modules/vitest": {
       "version": "3.2.4",
       "resolved": "https://registry.npmjs.org/vitest/-/vitest-3.2.4.tgz",
@@ -56062,6 +58974,23 @@
         "typescript": "^5.9.3"
       }
     },
+    "packages/SearchEngine/node_modules/@types/node": {
+      "version": "24.10.11",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.10.11.tgz",
+      "integrity": "sha512-/Af7O8r1frCVgOz0I62jWUtMohJ0/ZQU/ZoketltOJPZpnb17yoNc9BSoVuV9qlaIXJiPNOpsfq4ByFajSArNQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~7.16.0"
+      }
+    },
+    "packages/SearchEngine/node_modules/undici-types": {
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
+      "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "packages/ServerBootstrap": {
       "name": "@memberjunction/server-bootstrap",
       "version": "5.29.0",
@@ -56147,6 +59076,23 @@
         "typescript": "^5.9.3"
       }
     },
+    "packages/ServerBootstrap/node_modules/@types/node": {
+      "version": "24.12.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.12.2.tgz",
+      "integrity": "sha512-A1sre26ke7HDIuY/M23nd9gfB+nrmhtYyMINbjI1zHJxYteKR6qSMX56FsmjMcDb3SMcjJg5BiRRgOCC/yBD0g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~7.16.0"
+      }
+    },
+    "packages/ServerBootstrap/node_modules/undici-types": {
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
+      "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "packages/ServerBootstrapLite": {
       "name": "@memberjunction/server-bootstrap-lite",
       "version": "5.29.0",
@@ -56215,6 +59161,23 @@
         "@types/node": "^24.10.11",
         "typescript": "^5.9.3"
       }
+    },
+    "packages/ServerBootstrapLite/node_modules/@types/node": {
+      "version": "24.12.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.12.2.tgz",
+      "integrity": "sha512-A1sre26ke7HDIuY/M23nd9gfB+nrmhtYyMINbjI1zHJxYteKR6qSMX56FsmjMcDb3SMcjJg5BiRRgOCC/yBD0g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~7.16.0"
+      }
+    },
+    "packages/ServerBootstrapLite/node_modules/undici-types": {
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
+      "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
+      "dev": true,
+      "license": "MIT"
     },
     "packages/ServerExtensionsCore": {
       "name": "@memberjunction/server-extensions-core",

--- a/packages/AI/Providers/Bundle/package.json
+++ b/packages/AI/Providers/Bundle/package.json
@@ -30,6 +30,7 @@
     "@memberjunction/ai-gemini": "5.29.0",
     "@memberjunction/ai-groq": "5.29.0",
     "@memberjunction/ai-heygen": "5.29.0",
+    "@memberjunction/ai-llamacpp": "5.29.0",
     "@memberjunction/ai-lmstudio": "5.29.0",
     "@memberjunction/ai-local-embeddings": "5.29.0",
     "@memberjunction/ai-minimax": "5.29.0",

--- a/packages/AI/Providers/LlamaCpp/README.md
+++ b/packages/AI/Providers/LlamaCpp/README.md
@@ -26,7 +26,35 @@ graph TD
 - **OpenAI-compatible** — inherits chat, streaming, JSON mode, and parameter handling from `OpenAILLM`
 - **Any GGUF model** — run whatever you loaded into `llama-server` (Qwen3, Llama 3.x, DeepSeek-R1, Phi, Gemma, etc.)
 - **No API key required by default** — a placeholder is supplied; pass a real key if you started `llama-server --api-key <key>`
-- **Configurable endpoint** — defaults to `http://localhost:8080/v1` but accepts any host/port
+- **Configurable endpoint** — defaults to `http://localhost:8080/v1` but accepts any host/port via constructor args or env vars
+
+## Environment variables
+
+The endpoint and API key can be overridden without changing code. Precedence is **constructor argument → env var → hardcoded default**.
+
+| Variable | Purpose | Default |
+|---|---|---|
+| `LLAMACPP_BASE_URL` | Full endpoint URL. Wins over host/port if set. | — |
+| `LLAMACPP_HOST` | Host component. Combined with port to build the URL. | `localhost` |
+| `LLAMACPP_PORT` | Port component. | `8080` |
+| `LLAMACPP_API_KEY` | API key for `llama-server --api-key` setups. | placeholder |
+
+Examples:
+
+```bash
+# Point every LlamaCppLLM instance at a different port
+export LLAMACPP_PORT=9090
+
+# Point at a box elsewhere on the LAN
+export LLAMACPP_HOST=10.0.0.5
+export LLAMACPP_PORT=8080
+
+# Full URL override (e.g. a reverse-proxied endpoint)
+export LLAMACPP_BASE_URL=https://llama.internal.example.com/v1
+
+# Authenticated llama-server
+export LLAMACPP_API_KEY=my-secret
+```
 
 ## Installation
 

--- a/packages/AI/Providers/LlamaCpp/README.md
+++ b/packages/AI/Providers/LlamaCpp/README.md
@@ -34,17 +34,146 @@ graph TD
 npm install @memberjunction/ai-llamacpp
 ```
 
-## Prerequisites
+## Setting up `llama-server`
 
-1. Build or install llama.cpp — see the [upstream README](https://github.com/ggml-org/llama.cpp).
-2. Download a GGUF model. Hugging Face has thousands of quantized GGUFs ready to use.
-3. Start the server:
-   ```bash
-   llama-server -m ./models/qwen2.5-coder-32b-instruct-q4_k_m.gguf \
-                --host 0.0.0.0 --port 8080 \
-                -ngl 99
-   ```
-   The `-ngl` flag offloads layers to GPU (use `99` to offload as many as possible).
+This package is a client. Before it can do anything you need a running `llama-server` process with a model loaded. The four steps below get you from zero to a working endpoint.
+
+### 1. Install llama.cpp
+
+Pick the path that matches your platform:
+
+**macOS (Apple Silicon or Intel)**
+```bash
+brew install llama.cpp
+```
+This gives you `llama-server`, `llama-cli`, and friends on your `PATH`, with Metal GPU support built in.
+
+**Linux**
+```bash
+# Homebrew on Linux (simplest, CPU-only by default)
+brew install llama.cpp
+
+# Or prebuilt releases (pick the one matching your CUDA / ROCm / Vulkan stack):
+#   https://github.com/ggml-org/llama.cpp/releases
+```
+
+**Windows**
+Download a prebuilt zip from the [releases page](https://github.com/ggml-org/llama.cpp/releases) (pick `win-cuda` for NVIDIA, `win-vulkan` for AMD/Intel, or the plain `win-avx2` CPU build).
+
+**Build from source (any platform, latest features, custom GPU backend)**
+```bash
+git clone https://github.com/ggml-org/llama.cpp
+cd llama.cpp
+# Pick ONE backend:
+cmake -B build -DGGML_CUDA=ON        # NVIDIA
+cmake -B build -DGGML_METAL=ON       # Apple Silicon (default on macOS)
+cmake -B build -DGGML_VULKAN=ON      # AMD / Intel GPUs, cross-platform
+cmake -B build -DGGML_HIPBLAS=ON     # AMD ROCm
+cmake -B build                        # CPU only
+cmake --build build --config Release -j
+# Binaries land in ./build/bin/
+```
+
+Verify the install:
+```bash
+llama-server --version
+```
+
+### 2. Get a GGUF model
+
+llama.cpp only loads models in the GGUF format. [Hugging Face](https://huggingface.co/models?library=gguf&sort=trending) has thousands. Some sensible starting points:
+
+| Use case | Model | Approx. VRAM at Q4_K_M |
+|---|---|---|
+| Coding agent (laptop) | [Qwen2.5-Coder-7B-Instruct-GGUF](https://huggingface.co/bartowski/Qwen2.5-Coder-7B-Instruct-GGUF) | ~5 GB |
+| Coding agent (workstation) | [Qwen2.5-Coder-32B-Instruct-GGUF](https://huggingface.co/bartowski/Qwen2.5-Coder-32B-Instruct-GGUF) | ~20 GB |
+| General reasoning | [Llama-3.3-70B-Instruct-GGUF](https://huggingface.co/bartowski/Llama-3.3-70B-Instruct-GGUF) | ~42 GB |
+| Small / fast | [Phi-4-mini-instruct-GGUF](https://huggingface.co/bartowski/Phi-4-mini-instruct-GGUF) | ~3 GB |
+
+**Quantization cheat sheet.** The suffix on the filename (e.g. `Q4_K_M`) is the quantization. Rules of thumb:
+
+- `Q4_K_M` — best size/quality tradeoff for most users. Start here.
+- `Q5_K_M` / `Q6_K` — higher quality, ~25–50% more VRAM.
+- `Q8_0` — near-lossless, about half the size of full precision.
+- `IQ3_XXS` / `IQ2_M` — squeeze a bigger model into less VRAM at real quality cost.
+
+Download with `curl` or the `huggingface-cli`:
+
+```bash
+# Raw download
+curl -L -o qwen2.5-coder-7b-q4.gguf \
+  https://huggingface.co/bartowski/Qwen2.5-Coder-7B-Instruct-GGUF/resolve/main/Qwen2.5-Coder-7B-Instruct-Q4_K_M.gguf
+
+# Or with the HF CLI
+huggingface-cli download bartowski/Qwen2.5-Coder-7B-Instruct-GGUF \
+  Qwen2.5-Coder-7B-Instruct-Q4_K_M.gguf --local-dir ./models
+```
+
+### 3. Start the server
+
+Minimal command:
+
+```bash
+llama-server -m ./models/qwen2.5-coder-7b-q4.gguf --port 8080
+```
+
+Realistic command with the flags that actually matter for agent workloads:
+
+```bash
+llama-server \
+  -m ./models/qwen2.5-coder-7b-q4.gguf \
+  --host 0.0.0.0 --port 8080 \
+  -c 32768 \
+  -ngl 99 \
+  -np 4 \
+  --flash-attn
+```
+
+| Flag | What it does | When to change it |
+|---|---|---|
+| `-m <path>` | GGUF model file to load | Required |
+| `--host` | Bind address (default `127.0.0.1`) | Use `0.0.0.0` to allow LAN access |
+| `--port` | HTTP port (default `8080`) | Change if 8080 is taken |
+| `-c <N>` | Context window in tokens | Raise for long agent histories. 32k is a good default; cap at the model's max |
+| `-ngl <N>` | Layers to offload to GPU | `99` = everything. Lower it if you OOM on VRAM |
+| `-np <N>` | Parallel request slots | `4–8` lets multiple MJ agents hit the server concurrently |
+| `--flash-attn` | Flash attention kernel | Big speedup on CUDA / Metal |
+| `--api-key <key>` | Require `Authorization: Bearer <key>` | Enable when exposing to a network |
+| `-t <N>` | CPU threads | Auto-detected; override only if needed |
+
+### 4. Verify it's running
+
+```bash
+# Health check
+curl http://localhost:8080/health
+
+# Sanity chat request
+curl http://localhost:8080/v1/chat/completions \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "local",
+    "messages": [{"role": "user", "content": "Say hi in one word."}]
+  }'
+```
+
+`llama-server` also exposes a web UI at `http://localhost:8080` for interactive testing.
+
+### Running as a long-lived service
+
+For anything beyond a dev session, don't run `llama-server` in a terminal window. Options:
+
+- **systemd** (Linux) — write a unit file pointing at `llama-server` with the flags above and `Restart=on-failure`.
+- **launchd** (macOS) — same idea with a `.plist`.
+- **Docker** — `ghcr.io/ggml-org/llama.cpp:server` (CUDA variant: `:server-cuda`). Mount your models directory and map port 8080.
+- **tmux / screen** — fine for a dev box.
+
+### Common gotchas
+
+- **"Context length exceeded" errors** — raise `-c` or shrink your prompts. The default is whatever's baked into the model, often much smaller than you want.
+- **Slow / CPU-only inference despite having a GPU** — `-ngl` was 0 (the default) or the llama.cpp build doesn't have your GPU backend compiled in. Check startup logs for `CUDA` / `Metal` / `Vulkan` detection.
+- **Model won't load / "failed to open"** — wrong path, or the file is a `.safetensors` / `.bin` instead of `.gguf`. Only GGUF loads.
+- **429 / queued requests under load** — raise `-np` (parallel slots). Each slot needs its own KV cache, so VRAM usage scales with it.
+- **First request is very slow** — the model is being loaded into VRAM. Subsequent requests are fast. Keep the process running.
 
 ## Usage
 

--- a/packages/AI/Providers/LlamaCpp/README.md
+++ b/packages/AI/Providers/LlamaCpp/README.md
@@ -1,0 +1,138 @@
+# @memberjunction/ai-llamacpp
+
+MemberJunction AI provider for [llama.cpp](https://github.com/ggml-org/llama.cpp), enabling MJ agents and prompts to run against a local `llama-server` process. Because `llama-server` exposes an OpenAI-compatible `/v1/chat/completions` API, this package is a thin subclass of `@memberjunction/ai-openai` that simply points the client at your local endpoint.
+
+## Architecture
+
+```mermaid
+graph TD
+    A["LlamaCppLLM<br/>(Provider)"] -->|extends| B["OpenAILLM<br/>(@memberjunction/ai-openai)"]
+    B -->|extends| C["BaseLLM<br/>(@memberjunction/ai)"]
+    A -->|HTTP| D["llama-server<br/>(localhost:8080/v1)"]
+    D -->|runs| E["GGUF models<br/>(Qwen, Llama, DeepSeek, ...)"]
+    C -->|registered via| F["@RegisterClass"]
+
+    style A fill:#7c5295,stroke:#563a6b,color:#fff
+    style B fill:#2d6a9f,stroke:#1a4971,color:#fff
+    style C fill:#2d6a9f,stroke:#1a4971,color:#fff
+    style D fill:#2d8659,stroke:#1a5c3a,color:#fff
+    style E fill:#b8762f,stroke:#8a5722,color:#fff
+    style F fill:#b8762f,stroke:#8a5722,color:#fff
+```
+
+## Features
+
+- **Fully local inference** — no cloud dependencies, works offline / in airplane mode
+- **OpenAI-compatible** — inherits chat, streaming, JSON mode, and parameter handling from `OpenAILLM`
+- **Any GGUF model** — run whatever you loaded into `llama-server` (Qwen3, Llama 3.x, DeepSeek-R1, Phi, Gemma, etc.)
+- **No API key required by default** — a placeholder is supplied; pass a real key if you started `llama-server --api-key <key>`
+- **Configurable endpoint** — defaults to `http://localhost:8080/v1` but accepts any host/port
+
+## Installation
+
+```bash
+npm install @memberjunction/ai-llamacpp
+```
+
+## Prerequisites
+
+1. Build or install llama.cpp — see the [upstream README](https://github.com/ggml-org/llama.cpp).
+2. Download a GGUF model. Hugging Face has thousands of quantized GGUFs ready to use.
+3. Start the server:
+   ```bash
+   llama-server -m ./models/qwen2.5-coder-32b-instruct-q4_k_m.gguf \
+                --host 0.0.0.0 --port 8080 \
+                -ngl 99
+   ```
+   The `-ngl` flag offloads layers to GPU (use `99` to offload as many as possible).
+
+## Usage
+
+```typescript
+import { LlamaCppLLM } from '@memberjunction/ai-llamacpp';
+
+// API key is ignored unless llama-server was started with --api-key
+const llm = new LlamaCppLLM();
+
+const result = await llm.ChatCompletion({
+    model: 'qwen2.5-coder-32b', // the name reported by llama-server (any value works for most builds)
+    messages: [
+        { role: 'system', content: 'You are a helpful assistant.' },
+        { role: 'user', content: 'Write a TypeScript function that reverses a linked list.' }
+    ],
+    temperature: 0.2,
+});
+
+if (result.success) {
+    console.log(result.data.choices[0].message.content);
+}
+```
+
+### Connecting to a remote or non-default endpoint
+
+```typescript
+// Custom host/port (e.g. another box on your LAN, or a container)
+const llm = new LlamaCppLLM('', 'http://192.168.1.42:9090/v1');
+```
+
+### Using an authenticated endpoint
+
+If you started `llama-server --api-key my-secret`:
+
+```typescript
+const llm = new LlamaCppLLM('my-secret');
+```
+
+## Streaming
+
+Streaming is inherited from `OpenAILLM`:
+
+```typescript
+await llm.StreamingChatCompletion({
+    model: 'qwen2.5-coder-32b',
+    messages: [{ role: 'user', content: 'Explain quicksort.' }],
+}, {
+    OnContent: (chunk) => process.stdout.write(chunk),
+    OnComplete: (final) => console.log('\n\nDone:', final.data.usage),
+});
+```
+
+## Configuration via MJ Metadata
+
+Register llama.cpp as a vendor and add a model record pointing at it:
+
+| Field | Value |
+|---|---|
+| `AI Vendor.Name` | `llama.cpp` |
+| `AI Model.DriverClass` | `LlamaCppLLM` |
+| `AI Model.APIName` | model name your llama-server exposes (e.g. `qwen2.5-coder-32b`) |
+| Additional settings (on vendor or model) | `{ "baseUrl": "http://localhost:8080/v1" }` if non-default |
+
+## How It Works
+
+`LlamaCppLLM` is a ~15-line subclass of `OpenAILLM` that:
+
+1. Defaults `baseURL` to `http://localhost:8080/v1`.
+2. Substitutes a placeholder API key when none is provided, since the OpenAI SDK requires a non-empty string but `llama-server` runs unauthenticated by default.
+
+All chat, streaming, tool-call, and parameter-handling logic is inherited — there's no duplicated code. This mirrors how `xAILLM` and `OpenRouterLLM` wrap their respective OpenAI-compatible endpoints.
+
+## Class Registration
+
+Registered as `LlamaCppLLM` via `@RegisterClass(BaseLLM, 'LlamaCppLLM')`, which is how the MJ `ClassFactory` discovers it at runtime.
+
+## llama.cpp vs. Ollama / LM Studio
+
+MJ ships providers for all three. Quick comparison:
+
+- **llama.cpp (this package)** — direct access to `llama-server`. Best performance ceiling, fine-grained sampler control, latest features. You manage GGUF files yourself.
+- **Ollama** (`@memberjunction/ai-ollama`) — friendlier model management (`ollama pull ...`), automatic load/unload, better default concurrency. Uses llama.cpp internally.
+- **LM Studio** (`@memberjunction/ai-lmstudio`) — GUI model management on macOS/Windows, also uses llama.cpp internally.
+
+Use this package when you want to talk to `llama-server` directly — no daemon, no extra process, no model manager in between.
+
+## Dependencies
+
+- `@memberjunction/ai` — core AI abstractions
+- `@memberjunction/ai-openai` — parent class providing OpenAI-compatible behaviour
+- `@memberjunction/global` — class registration system

--- a/packages/AI/Providers/LlamaCpp/package.json
+++ b/packages/AI/Providers/LlamaCpp/package.json
@@ -1,0 +1,31 @@
+{
+  "name": "@memberjunction/ai-llamacpp",
+  "type": "module",
+  "version": "5.29.0",
+  "description": "MemberJunction Wrapper for llama.cpp - Local Inference via llama-server",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "files": [
+    "/dist"
+  ],
+  "scripts": {
+    "start": "ts-node-dev src/index.ts",
+    "build": "tsc && tsc-alias -f",
+    "test": "vitest run"
+  },
+  "author": "MemberJunction.com",
+  "license": "ISC",
+  "devDependencies": {
+    "ts-node-dev": "^2.0.0",
+    "typescript": "^5.9.3"
+  },
+  "dependencies": {
+    "@memberjunction/ai": "5.29.0",
+    "@memberjunction/ai-openai": "5.29.0",
+    "@memberjunction/global": "5.29.0"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/MemberJunction/MJ"
+  }
+}

--- a/packages/AI/Providers/LlamaCpp/src/__tests__/LlamaCppLLM.test.ts
+++ b/packages/AI/Providers/LlamaCpp/src/__tests__/LlamaCppLLM.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 
 /* ------------------------------------------------------------------ */
 /*  Hoisted mocks                                                     */
@@ -38,15 +38,30 @@ vi.mock('@memberjunction/ai-openai', () => {
 
 import { LlamaCppLLM, DEFAULT_LLAMA_CPP_URL } from '../models/llama-cpp';
 
+const readField = (instance: LlamaCppLLM, key: string): unknown =>
+  (instance as unknown as Record<string, unknown>)[key];
+
 /* ------------------------------------------------------------------ */
 /*  Tests                                                              */
 /* ------------------------------------------------------------------ */
 describe('LlamaCppLLM', () => {
-  let llm: LlamaCppLLM;
+  const envKeys = ['LLAMACPP_BASE_URL', 'LLAMACPP_HOST', 'LLAMACPP_PORT', 'LLAMACPP_API_KEY'] as const;
+  const originalEnv: Record<string, string | undefined> = {};
 
   beforeEach(() => {
     vi.clearAllMocks();
-    llm = new LlamaCppLLM();
+    // Snapshot and clear the env vars so each test starts clean.
+    for (const key of envKeys) {
+      originalEnv[key] = process.env[key];
+      delete process.env[key];
+    }
+  });
+
+  afterEach(() => {
+    for (const key of envKeys) {
+      if (originalEnv[key] === undefined) delete process.env[key];
+      else process.env[key] = originalEnv[key];
+    }
   });
 
   /* ---- Constants ---- */
@@ -56,51 +71,111 @@ describe('LlamaCppLLM', () => {
     });
   });
 
-  /* ---- Constructor ---- */
-  describe('constructor', () => {
-    it('should create an instance without arguments', () => {
-      expect(llm).toBeInstanceOf(LlamaCppLLM);
+  /* ---- Constructor (no env, no args) ---- */
+  describe('constructor with no args and no env', () => {
+    it('should create an instance', () => {
+      expect(new LlamaCppLLM()).toBeInstanceOf(LlamaCppLLM);
     });
 
     it('should default base URL to the local llama-server endpoint', () => {
-      expect((llm as unknown as Record<string, unknown>)['_baseUrl']).toBe(DEFAULT_LLAMA_CPP_URL);
+      expect(readField(new LlamaCppLLM(), '_baseUrl')).toBe(DEFAULT_LLAMA_CPP_URL);
     });
 
-    it('should use a placeholder API key when none is provided', () => {
-      expect((llm as unknown as Record<string, unknown>)['_apiKey']).toBe('llama-cpp-no-auth');
+    it('should use a placeholder API key', () => {
+      expect(readField(new LlamaCppLLM(), '_apiKey')).toBe('llama-cpp-no-auth');
     });
 
     it('should use a placeholder API key when an empty string is provided', () => {
-      const instance = new LlamaCppLLM('');
-      expect((instance as unknown as Record<string, unknown>)['_apiKey']).toBe('llama-cpp-no-auth');
+      expect(readField(new LlamaCppLLM(''), '_apiKey')).toBe('llama-cpp-no-auth');
     });
+  });
 
-    it('should forward a caller-supplied API key (for --api-key llama-server mode)', () => {
-      const instance = new LlamaCppLLM('secret-token');
-      expect((instance as unknown as Record<string, unknown>)['_apiKey']).toBe('secret-token');
+  /* ---- Explicit constructor arguments ---- */
+  describe('explicit constructor arguments', () => {
+    it('should forward a caller-supplied API key', () => {
+      expect(readField(new LlamaCppLLM('secret-token'), '_apiKey')).toBe('secret-token');
     });
 
     it('should accept a custom base URL', () => {
-      const instance = new LlamaCppLLM(undefined, 'http://192.168.1.10:8000/v1');
-      expect((instance as unknown as Record<string, unknown>)['_baseUrl']).toBe('http://192.168.1.10:8000/v1');
+      const inst = new LlamaCppLLM(undefined, 'http://192.168.1.10:8000/v1');
+      expect(readField(inst, '_baseUrl')).toBe('http://192.168.1.10:8000/v1');
     });
 
     it('should fall back to the default base URL when an empty string is provided', () => {
-      const instance = new LlamaCppLLM('key', '');
-      expect((instance as unknown as Record<string, unknown>)['_baseUrl']).toBe(DEFAULT_LLAMA_CPP_URL);
+      const inst = new LlamaCppLLM('key', '');
+      expect(readField(inst, '_baseUrl')).toBe(DEFAULT_LLAMA_CPP_URL);
     });
 
     it('should accept both a custom key and custom URL together', () => {
-      const instance = new LlamaCppLLM('my-key', 'http://remote-host:9090/v1');
-      expect((instance as unknown as Record<string, unknown>)['_apiKey']).toBe('my-key');
-      expect((instance as unknown as Record<string, unknown>)['_baseUrl']).toBe('http://remote-host:9090/v1');
+      const inst = new LlamaCppLLM('my-key', 'http://remote-host:9090/v1');
+      expect(readField(inst, '_apiKey')).toBe('my-key');
+      expect(readField(inst, '_baseUrl')).toBe('http://remote-host:9090/v1');
+    });
+  });
+
+  /* ---- Environment variable overrides ---- */
+  describe('env var overrides', () => {
+    it('LLAMACPP_BASE_URL should override the default when no constructor arg is given', () => {
+      process.env.LLAMACPP_BASE_URL = 'http://my-box:7000/v1';
+      expect(readField(new LlamaCppLLM(), '_baseUrl')).toBe('http://my-box:7000/v1');
+    });
+
+    it('LLAMACPP_HOST alone should produce the expected URL', () => {
+      process.env.LLAMACPP_HOST = 'inference.lan';
+      expect(readField(new LlamaCppLLM(), '_baseUrl')).toBe('http://inference.lan:8080/v1');
+    });
+
+    it('LLAMACPP_PORT alone should produce the expected URL', () => {
+      process.env.LLAMACPP_PORT = '9999';
+      expect(readField(new LlamaCppLLM(), '_baseUrl')).toBe('http://localhost:9999/v1');
+    });
+
+    it('LLAMACPP_HOST and LLAMACPP_PORT together should produce the expected URL', () => {
+      process.env.LLAMACPP_HOST = '10.0.0.5';
+      process.env.LLAMACPP_PORT = '8000';
+      expect(readField(new LlamaCppLLM(), '_baseUrl')).toBe('http://10.0.0.5:8000/v1');
+    });
+
+    it('LLAMACPP_BASE_URL should take precedence over LLAMACPP_HOST/LLAMACPP_PORT', () => {
+      process.env.LLAMACPP_BASE_URL = 'http://override:1234/v1';
+      process.env.LLAMACPP_HOST = 'ignored';
+      process.env.LLAMACPP_PORT = '9999';
+      expect(readField(new LlamaCppLLM(), '_baseUrl')).toBe('http://override:1234/v1');
+    });
+
+    it('constructor baseUrl argument should take precedence over env vars', () => {
+      process.env.LLAMACPP_BASE_URL = 'http://env-url:7000/v1';
+      const inst = new LlamaCppLLM(undefined, 'http://explicit:5555/v1');
+      expect(readField(inst, '_baseUrl')).toBe('http://explicit:5555/v1');
+    });
+
+    it('empty env vars should be treated as unset and fall back to defaults', () => {
+      process.env.LLAMACPP_BASE_URL = '';
+      process.env.LLAMACPP_HOST = '';
+      process.env.LLAMACPP_PORT = '';
+      expect(readField(new LlamaCppLLM(), '_baseUrl')).toBe(DEFAULT_LLAMA_CPP_URL);
+    });
+
+    it('LLAMACPP_API_KEY should supply the key when no constructor arg is given', () => {
+      process.env.LLAMACPP_API_KEY = 'env-secret';
+      expect(readField(new LlamaCppLLM(), '_apiKey')).toBe('env-secret');
+    });
+
+    it('constructor apiKey argument should take precedence over LLAMACPP_API_KEY', () => {
+      process.env.LLAMACPP_API_KEY = 'env-secret';
+      expect(readField(new LlamaCppLLM('explicit-key'), '_apiKey')).toBe('explicit-key');
+    });
+
+    it('empty LLAMACPP_API_KEY should fall back to the placeholder', () => {
+      process.env.LLAMACPP_API_KEY = '';
+      expect(readField(new LlamaCppLLM(), '_apiKey')).toBe('llama-cpp-no-auth');
     });
   });
 
   /* ---- Inheritance ---- */
   describe('inheritance', () => {
     it('should inherit SupportsStreaming from OpenAILLM', () => {
-      expect(llm.SupportsStreaming).toBe(true);
+      expect(new LlamaCppLLM().SupportsStreaming).toBe(true);
     });
   });
 });

--- a/packages/AI/Providers/LlamaCpp/src/__tests__/LlamaCppLLM.test.ts
+++ b/packages/AI/Providers/LlamaCpp/src/__tests__/LlamaCppLLM.test.ts
@@ -1,0 +1,106 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+/* ------------------------------------------------------------------ */
+/*  Hoisted mocks                                                     */
+/* ------------------------------------------------------------------ */
+vi.mock('@memberjunction/global', () => ({
+  RegisterClass: () => (_target: unknown) => {},
+}));
+
+vi.mock('@memberjunction/ai', () => {
+  class MockBaseLLM {
+    protected _additionalSettings: Record<string, unknown> = {};
+    constructor(_apiKey: string) {}
+    get SupportsStreaming() { return true; }
+  }
+  return {
+    BaseLLM: MockBaseLLM,
+    ChatParams: class {},
+    ChatResult: class {},
+    ChatMessageRole: { user: 'user', assistant: 'assistant', system: 'system' },
+    ModelUsage: class {},
+    ErrorAnalyzer: { analyzeError: vi.fn() },
+  };
+});
+
+vi.mock('@memberjunction/ai-openai', () => {
+  class MockOpenAILLM {
+    protected _baseUrl: string;
+    protected _apiKey: string;
+    constructor(apiKey: string, baseUrl?: string) {
+      this._apiKey = apiKey;
+      this._baseUrl = baseUrl || 'https://api.openai.com/v1';
+    }
+    get SupportsStreaming() { return true; }
+  }
+  return { OpenAILLM: MockOpenAILLM };
+});
+
+import { LlamaCppLLM, DEFAULT_LLAMA_CPP_URL } from '../models/llama-cpp';
+
+/* ------------------------------------------------------------------ */
+/*  Tests                                                              */
+/* ------------------------------------------------------------------ */
+describe('LlamaCppLLM', () => {
+  let llm: LlamaCppLLM;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    llm = new LlamaCppLLM();
+  });
+
+  /* ---- Constants ---- */
+  describe('DEFAULT_LLAMA_CPP_URL', () => {
+    it('should point at the stock llama-server port and /v1 path', () => {
+      expect(DEFAULT_LLAMA_CPP_URL).toBe('http://localhost:8080/v1');
+    });
+  });
+
+  /* ---- Constructor ---- */
+  describe('constructor', () => {
+    it('should create an instance without arguments', () => {
+      expect(llm).toBeInstanceOf(LlamaCppLLM);
+    });
+
+    it('should default base URL to the local llama-server endpoint', () => {
+      expect((llm as unknown as Record<string, unknown>)['_baseUrl']).toBe(DEFAULT_LLAMA_CPP_URL);
+    });
+
+    it('should use a placeholder API key when none is provided', () => {
+      expect((llm as unknown as Record<string, unknown>)['_apiKey']).toBe('llama-cpp-no-auth');
+    });
+
+    it('should use a placeholder API key when an empty string is provided', () => {
+      const instance = new LlamaCppLLM('');
+      expect((instance as unknown as Record<string, unknown>)['_apiKey']).toBe('llama-cpp-no-auth');
+    });
+
+    it('should forward a caller-supplied API key (for --api-key llama-server mode)', () => {
+      const instance = new LlamaCppLLM('secret-token');
+      expect((instance as unknown as Record<string, unknown>)['_apiKey']).toBe('secret-token');
+    });
+
+    it('should accept a custom base URL', () => {
+      const instance = new LlamaCppLLM(undefined, 'http://192.168.1.10:8000/v1');
+      expect((instance as unknown as Record<string, unknown>)['_baseUrl']).toBe('http://192.168.1.10:8000/v1');
+    });
+
+    it('should fall back to the default base URL when an empty string is provided', () => {
+      const instance = new LlamaCppLLM('key', '');
+      expect((instance as unknown as Record<string, unknown>)['_baseUrl']).toBe(DEFAULT_LLAMA_CPP_URL);
+    });
+
+    it('should accept both a custom key and custom URL together', () => {
+      const instance = new LlamaCppLLM('my-key', 'http://remote-host:9090/v1');
+      expect((instance as unknown as Record<string, unknown>)['_apiKey']).toBe('my-key');
+      expect((instance as unknown as Record<string, unknown>)['_baseUrl']).toBe('http://remote-host:9090/v1');
+    });
+  });
+
+  /* ---- Inheritance ---- */
+  describe('inheritance', () => {
+    it('should inherit SupportsStreaming from OpenAILLM', () => {
+      expect(llm.SupportsStreaming).toBe(true);
+    });
+  });
+});

--- a/packages/AI/Providers/LlamaCpp/src/index.ts
+++ b/packages/AI/Providers/LlamaCpp/src/index.ts
@@ -1,0 +1,1 @@
+export * from './models/llama-cpp';

--- a/packages/AI/Providers/LlamaCpp/src/models/llama-cpp.ts
+++ b/packages/AI/Providers/LlamaCpp/src/models/llama-cpp.ts
@@ -1,0 +1,32 @@
+import { BaseLLM } from "@memberjunction/ai";
+import { RegisterClass } from '@memberjunction/global';
+import { OpenAILLM } from "@memberjunction/ai-openai";
+
+/**
+ * Default base URL for a stock `llama-server` process. llama.cpp's HTTP server
+ * listens on port 8080 and exposes an OpenAI-compatible API under `/v1`.
+ */
+export const DEFAULT_LLAMA_CPP_URL: string = 'http://localhost:8080/v1';
+
+/**
+ * Placeholder API key used when the caller doesn't provide one.
+ * llama.cpp's server typically runs unauthenticated, but the OpenAI SDK requires
+ * a non-empty string. If `llama-server` is started with `--api-key`, the caller
+ * should pass the real key to the constructor.
+ */
+const PLACEHOLDER_API_KEY = 'llama-cpp-no-auth';
+
+/**
+ * llama.cpp implementation is just a sub-class of OpenAILLM that points at a
+ * locally running `llama-server` instance. llama.cpp's HTTP server exposes an
+ * OpenAI-compatible `/v1/chat/completions` endpoint, so all request/streaming
+ * behaviour is inherited.
+ */
+@RegisterClass(BaseLLM, 'LlamaCppLLM')
+export class LlamaCppLLM extends OpenAILLM {
+    constructor(apiKey?: string, baseUrl?: string) {
+        const effectiveKey = apiKey && apiKey.length > 0 ? apiKey : PLACEHOLDER_API_KEY;
+        const effectiveUrl = baseUrl && baseUrl.length > 0 ? baseUrl : DEFAULT_LLAMA_CPP_URL;
+        super(effectiveKey, effectiveUrl);
+    }
+}

--- a/packages/AI/Providers/LlamaCpp/src/models/llama-cpp.ts
+++ b/packages/AI/Providers/LlamaCpp/src/models/llama-cpp.ts
@@ -3,30 +3,79 @@ import { RegisterClass } from '@memberjunction/global';
 import { OpenAILLM } from "@memberjunction/ai-openai";
 
 /**
+ * Default host for a stock `llama-server` process.
+ */
+export const DEFAULT_LLAMA_CPP_HOST = 'localhost';
+
+/**
+ * Default port for a stock `llama-server` process.
+ */
+export const DEFAULT_LLAMA_CPP_PORT = '8080';
+
+/**
  * Default base URL for a stock `llama-server` process. llama.cpp's HTTP server
  * listens on port 8080 and exposes an OpenAI-compatible API under `/v1`.
  */
-export const DEFAULT_LLAMA_CPP_URL: string = 'http://localhost:8080/v1';
+export const DEFAULT_LLAMA_CPP_URL: string = `http://${DEFAULT_LLAMA_CPP_HOST}:${DEFAULT_LLAMA_CPP_PORT}/v1`;
 
 /**
- * Placeholder API key used when the caller doesn't provide one.
+ * Placeholder API key used when neither the caller nor the environment provides one.
  * llama.cpp's server typically runs unauthenticated, but the OpenAI SDK requires
- * a non-empty string. If `llama-server` is started with `--api-key`, the caller
- * should pass the real key to the constructor.
+ * a non-empty string. If `llama-server` is started with `--api-key`, set
+ * `LLAMACPP_API_KEY` or pass the key to the constructor.
  */
 const PLACEHOLDER_API_KEY = 'llama-cpp-no-auth';
+
+/**
+ * Resolve the base URL at construction time. Precedence:
+ *   1. `LLAMACPP_BASE_URL` (full URL, wins if set)
+ *   2. `LLAMACPP_HOST` + `LLAMACPP_PORT` (either can be overridden independently)
+ *   3. hardcoded defaults (localhost:8080)
+ */
+function resolveBaseUrlFromEnv(): string {
+    const explicit = process.env.LLAMACPP_BASE_URL;
+    if (explicit && explicit.length > 0) {
+        return explicit;
+    }
+    const host = process.env.LLAMACPP_HOST && process.env.LLAMACPP_HOST.length > 0
+        ? process.env.LLAMACPP_HOST
+        : DEFAULT_LLAMA_CPP_HOST;
+    const port = process.env.LLAMACPP_PORT && process.env.LLAMACPP_PORT.length > 0
+        ? process.env.LLAMACPP_PORT
+        : DEFAULT_LLAMA_CPP_PORT;
+    return `http://${host}:${port}/v1`;
+}
+
+/**
+ * Resolve the API key at construction time. Precedence:
+ *   1. explicit constructor argument
+ *   2. `LLAMACPP_API_KEY` env var (for `llama-server --api-key` setups)
+ *   3. placeholder (unauthenticated local server)
+ */
+function resolveApiKey(explicit?: string): string {
+    if (explicit && explicit.length > 0) return explicit;
+    const fromEnv = process.env.LLAMACPP_API_KEY;
+    if (fromEnv && fromEnv.length > 0) return fromEnv;
+    return PLACEHOLDER_API_KEY;
+}
 
 /**
  * llama.cpp implementation is just a sub-class of OpenAILLM that points at a
  * locally running `llama-server` instance. llama.cpp's HTTP server exposes an
  * OpenAI-compatible `/v1/chat/completions` endpoint, so all request/streaming
  * behaviour is inherited.
+ *
+ * The endpoint defaults to `http://localhost:8080/v1` but can be overridden
+ * (in order of precedence):
+ *   - constructor argument
+ *   - `LLAMACPP_BASE_URL` env var (full URL)
+ *   - `LLAMACPP_HOST` / `LLAMACPP_PORT` env vars (components)
  */
 @RegisterClass(BaseLLM, 'LlamaCppLLM')
 export class LlamaCppLLM extends OpenAILLM {
     constructor(apiKey?: string, baseUrl?: string) {
-        const effectiveKey = apiKey && apiKey.length > 0 ? apiKey : PLACEHOLDER_API_KEY;
-        const effectiveUrl = baseUrl && baseUrl.length > 0 ? baseUrl : DEFAULT_LLAMA_CPP_URL;
+        const effectiveKey = resolveApiKey(apiKey);
+        const effectiveUrl = baseUrl && baseUrl.length > 0 ? baseUrl : resolveBaseUrlFromEnv();
         super(effectiveKey, effectiveUrl);
     }
 }

--- a/packages/AI/Providers/LlamaCpp/tsconfig.json
+++ b/packages/AI/Providers/LlamaCpp/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "extends": "../../../../tsconfig.server.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": [
+    "src/**/*"
+  ],
+  "exclude": [
+    "node_modules",
+    "src/__tests__"
+  ]
+}

--- a/packages/AI/Providers/LlamaCpp/typedoc.json
+++ b/packages/AI/Providers/LlamaCpp/typedoc.json
@@ -1,0 +1,8 @@
+{
+  "extends": [
+    "../../../../typedoc.base.json"
+  ],
+  "entryPoints": [
+    "src/index.ts"
+  ]
+}

--- a/packages/AI/Providers/LlamaCpp/vitest.config.ts
+++ b/packages/AI/Providers/LlamaCpp/vitest.config.ts
@@ -1,0 +1,11 @@
+import { defineProject, mergeConfig } from 'vitest/config';
+import sharedConfig from '../../../../vitest.shared';
+
+export default mergeConfig(
+  sharedConfig,
+  defineProject({
+    test: {
+      environment: 'node',
+    },
+  })
+);

--- a/packages/AI/Providers/README.md
+++ b/packages/AI/Providers/README.md
@@ -2,7 +2,7 @@
 
 This directory contains all provider-specific implementations of the MemberJunction AI framework interfaces. Each provider package implements the abstract base classes defined in `@memberjunction/ai` to integrate with a specific AI service, translating MJ's common interfaces into provider-specific API calls.
 
-There are 23 packages in total, grouped by category below.
+There are 24 packages in total, grouped by category below.
 
 ## Packages
 
@@ -44,6 +44,7 @@ Run models locally without external API calls.
 
 | Package | npm | Description |
 |---------|-----|-------------|
+| [LlamaCpp](./LlamaCpp/README.md) | `@memberjunction/ai-llamacpp` | Wrapper for llama.cpp - Local Inference via `llama-server` |
 | [LMStudio](./LMStudio/README.md) | `@memberjunction/ai-lmstudio` | Wrapper for LM Studio AI - Local Inference Engine |
 | [Ollama](./Ollama/README.md) | `@memberjunction/ai-ollama` | Wrapper for Ollama - Local Inference |
 


### PR DESCRIPTION
Thin subclass of OpenAILLM that points at a local llama-server process,
following the same pattern as xAILLM and OpenRouterLLM. Defaults baseURL
to http://localhost:8080/v1 and substitutes a placeholder API key when
none is provided (llama-server runs unauthenticated by default).

- New package @memberjunction/ai-llamacpp at packages/AI/Providers/LlamaCpp
- Vitest unit tests covering default URL, placeholder key, custom key/URL,
  empty-string fallbacks, and inherited streaming support (10/10 passing)
- Registered in Bundle package.json and Providers README Local Inference table