### PR TITLE
Open App: exact version pins, per-repo tokens, prefix bumps

### DIFF
--- a/.changeset/open-app-version-pins.md
+++ b/.changeset/open-app-version-pins.md
@@ -1,0 +1,15 @@
+---
+"@memberjunction/open-app-engine": patch
+"@memberjunction/cli": patch
+---
+
+Open App: exact version pins, per-repo tokens, and workspace-wide prefix bumps
+
+- `--version` flag now pins packages to exact versions (no ^ prefix) and validates the GitHub tag exists before proceeding
+- Per-repo GitHub token map (`openApps.github.tokens`) for multi-private-repo dependency chains
+- `GetLatestVersion` falls back to tags when no GitHub Releases exist
+- Schema reuse when `createIfNotExists: true` and schema already exists (adopts sidestep installs)
+- Don't pass `--registry` for default npm registry (fixes private scoped package auth)
+- Prevent duplicate `dynamicPackages.server` entries on re-install
+- npm install failures demoted to warnings when package.json was updated (auth issues don't abort install)
+- `packages.prefix` manifest field for workspace-wide dependency bumps during install/upgrade

--- a/packages/MJCLI/src/config.ts
+++ b/packages/MJCLI/src/config.ts
@@ -63,6 +63,8 @@ const dynamicPackageEntrySchema = z.object({
 const openAppsConfigSchema = z.object({
   github: z.object({
     token: z.string().optional(),
+    /** Per-repository token overrides keyed by GitHub repo URL */
+    tokens: z.record(z.string(), z.string().optional()).optional(),
   }).optional(),
   registries: z.array(z.object({
     name: z.string(),

--- a/packages/MJCLI/src/utils/open-app-context.ts
+++ b/packages/MJCLI/src/utils/open-app-context.ts
@@ -147,6 +147,7 @@ export async function buildOrchestratorContext(
     },
     GitHubOptions: {
       Token: config.openApps?.github?.token ?? process.env.GITHUB_TOKEN,
+      TokenMap: filterDefinedTokens(config.openApps?.github?.tokens),
     },
     RepoRoot: process.cwd(),
     MJVersion: getMJVersion(),
@@ -189,13 +190,14 @@ interface OrchestratorContextShape {
   };
   GitHubOptions: {
     Token?: string;
+    TokenMap?: Record<string, string>;
   };
   RepoRoot: string;
   MJVersion: string;
   ServerPackagePath?: string;
   ClientPackagePath?: string;
   PackageManager?: 'npm' | 'pnpm' | 'yarn';
-  VersionStrategy?: 'semver' | 'catalog' | 'workspace' | 'auto';
+  VersionStrategy?: 'semver' | 'exact' | 'catalog' | 'workspace' | 'auto';
   AdditionalTargets?: Array<{ Path: string; Role: 'server' | 'client' }>;
   ClientBootstrapSubpath?: string;
   MJCoreSchema?: string;
@@ -207,6 +209,21 @@ interface OrchestratorContextShape {
     OnWarn?: (phase: string, message: string) => void;
     OnLog?: (message: string) => void;
   };
+}
+
+/**
+ * Filters a token map from config, removing entries where the env var resolved to undefined.
+ * This happens when mj.config.cjs references process.env.SOME_TOKEN but the var isn't set.
+ */
+function filterDefinedTokens(tokens: Record<string, string | undefined> | undefined): Record<string, string> | undefined {
+  if (!tokens) return undefined;
+  const filtered: Record<string, string> = {};
+  for (const [url, token] of Object.entries(tokens)) {
+    if (token) {
+      filtered[url] = token;
+    }
+  }
+  return Object.keys(filtered).length > 0 ? filtered : undefined;
 }
 
 // createRequire is needed because getMJVersion uses require.resolve() to locate

--- a/packages/OpenApp/Engine/src/__tests__/github-client.test.ts
+++ b/packages/OpenApp/Engine/src/__tests__/github-client.test.ts
@@ -3,7 +3,8 @@
  * and GetLatestVersion fallback to tags.
  */
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { ValidateGitHubTag, ListGitHubTags, GetLatestVersion, ParseGitHubUrl } from '../github/github-client.js';
+import { ValidateGitHubTag, ListGitHubTags, GetLatestVersion, ParseGitHubUrl, FetchManifestFromGitHub } from '../github/github-client.js';
+import type { GitHubClientOptions } from '../github/github-client.js';
 
 // Mock global fetch
 const mockFetch = vi.fn();
@@ -167,5 +168,100 @@ describe('GetLatestVersion', () => {
 
         const result = await GetLatestVersion('https://github.com/Acme/App', {});
         expect(result).toBeNull();
+    });
+});
+
+describe('TokenMap resolution', () => {
+    beforeEach(() => {
+        mockFetch.mockReset();
+    });
+
+    it('uses per-repo token from TokenMap when available', async () => {
+        mockFetch.mockResolvedValueOnce({
+            ok: true,
+            json: async () => ({ content: btoa('{}'), encoding: 'base64' }),
+        });
+
+        const options: GitHubClientOptions = {
+            Token: 'default-token',
+            TokenMap: {
+                'https://github.com/Acme/SpecialRepo': 'special-token',
+            },
+        };
+
+        await FetchManifestFromGitHub('https://github.com/Acme/SpecialRepo', undefined, options);
+        const headers = mockFetch.mock.calls[0][1].headers;
+        expect(headers['Authorization']).toBe('Bearer special-token');
+    });
+
+    it('falls back to default Token when repo not in TokenMap', async () => {
+        mockFetch.mockResolvedValueOnce({
+            ok: true,
+            json: async () => ({ content: btoa('{}'), encoding: 'base64' }),
+        });
+
+        const options: GitHubClientOptions = {
+            Token: 'default-token',
+            TokenMap: {
+                'https://github.com/Acme/OtherRepo': 'other-token',
+            },
+        };
+
+        await FetchManifestFromGitHub('https://github.com/Acme/UnmatchedRepo', undefined, options);
+        const headers = mockFetch.mock.calls[0][1].headers;
+        expect(headers['Authorization']).toBe('Bearer default-token');
+    });
+
+    it('matches TokenMap keys case-insensitively', async () => {
+        mockFetch.mockResolvedValueOnce({
+            ok: true,
+            json: async () => ({ content: btoa('{}'), encoding: 'base64' }),
+        });
+
+        const options: GitHubClientOptions = {
+            Token: 'default-token',
+            TokenMap: {
+                'https://github.com/BlueCypress/SaaS': 'saas-token',
+            },
+        };
+
+        await FetchManifestFromGitHub('https://github.com/bluecypress/saas', undefined, options);
+        const headers = mockFetch.mock.calls[0][1].headers;
+        expect(headers['Authorization']).toBe('Bearer saas-token');
+    });
+
+    it('strips .git suffix when matching TokenMap keys', async () => {
+        mockFetch.mockResolvedValueOnce({
+            ok: true,
+            json: async () => ({ content: btoa('{}'), encoding: 'base64' }),
+        });
+
+        const options: GitHubClientOptions = {
+            Token: 'default-token',
+            TokenMap: {
+                'https://github.com/Acme/App': 'app-token',
+            },
+        };
+
+        await FetchManifestFromGitHub('https://github.com/Acme/App.git', undefined, options);
+        const headers = mockFetch.mock.calls[0][1].headers;
+        expect(headers['Authorization']).toBe('Bearer app-token');
+    });
+
+    it('sends no auth header when no token matches and no default', async () => {
+        mockFetch.mockResolvedValueOnce({
+            ok: true,
+            json: async () => ({ content: btoa('{}'), encoding: 'base64' }),
+        });
+
+        const options: GitHubClientOptions = {
+            TokenMap: {
+                'https://github.com/Acme/OtherRepo': 'other-token',
+            },
+        };
+
+        await FetchManifestFromGitHub('https://github.com/Acme/UnmatchedRepo', undefined, options);
+        const headers = mockFetch.mock.calls[0][1].headers;
+        expect(headers['Authorization']).toBeUndefined();
     });
 });

--- a/packages/OpenApp/Engine/src/__tests__/github-client.test.ts
+++ b/packages/OpenApp/Engine/src/__tests__/github-client.test.ts
@@ -1,0 +1,171 @@
+/**
+ * Tests for GitHub client functions: tag validation, tag listing,
+ * and GetLatestVersion fallback to tags.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { ValidateGitHubTag, ListGitHubTags, GetLatestVersion, ParseGitHubUrl } from '../github/github-client.js';
+
+// Mock global fetch
+const mockFetch = vi.fn();
+vi.stubGlobal('fetch', mockFetch);
+
+afterEach(() => {
+    vi.restoreAllMocks();
+});
+
+describe('ParseGitHubUrl', () => {
+    it('parses a standard GitHub URL', () => {
+        const result = ParseGitHubUrl('https://github.com/BlueCypress/SaaS');
+        expect(result).toEqual({ Owner: 'BlueCypress', Repo: 'SaaS' });
+    });
+
+    it('parses a .git URL', () => {
+        const result = ParseGitHubUrl('https://github.com/BlueCypress/SaaS.git');
+        expect(result).toEqual({ Owner: 'BlueCypress', Repo: 'SaaS' });
+    });
+
+    it('returns null for invalid URL', () => {
+        expect(ParseGitHubUrl('https://gitlab.com/foo/bar')).toBeNull();
+    });
+});
+
+describe('ValidateGitHubTag', () => {
+    beforeEach(() => {
+        mockFetch.mockReset();
+    });
+
+    it('returns Exists: true when tag is found', async () => {
+        mockFetch.mockResolvedValueOnce({ ok: true, status: 200 });
+
+        const result = await ValidateGitHubTag('https://github.com/Acme/App', '1.0.7', {});
+        expect(result.Exists).toBe(true);
+        expect(mockFetch).toHaveBeenCalledWith(
+            expect.stringContaining('/git/ref/tags/v1.0.7'),
+            expect.objectContaining({ headers: expect.any(Object) }),
+        );
+    });
+
+    it('normalizes version with existing v prefix', async () => {
+        mockFetch.mockResolvedValueOnce({ ok: true, status: 200 });
+
+        await ValidateGitHubTag('https://github.com/Acme/App', 'v1.0.7', {});
+        expect(mockFetch).toHaveBeenCalledWith(
+            expect.stringContaining('/git/ref/tags/v1.0.7'),
+            expect.anything(),
+        );
+    });
+
+    it('returns Exists: false with helpful message when tag not found', async () => {
+        mockFetch.mockResolvedValueOnce({ ok: false, status: 404 });
+
+        const result = await ValidateGitHubTag('https://github.com/Acme/App', '9.9.9', {});
+        expect(result.Exists).toBe(false);
+        expect(result.ErrorMessage).toContain("Tag 'v9.9.9' not found");
+        expect(result.ErrorMessage).toContain('Acme/App');
+    });
+
+    it('returns error for invalid GitHub URL', async () => {
+        const result = await ValidateGitHubTag('https://gitlab.com/foo/bar', '1.0.0', {});
+        expect(result.Exists).toBe(false);
+        expect(result.ErrorMessage).toContain('Invalid GitHub URL');
+    });
+
+    it('includes auth token in request when provided', async () => {
+        mockFetch.mockResolvedValueOnce({ ok: true, status: 200 });
+
+        await ValidateGitHubTag('https://github.com/Acme/App', '1.0.0', { Token: 'ghp_test123' });
+        const headers = mockFetch.mock.calls[0][1].headers;
+        expect(headers['Authorization']).toBe('Bearer ghp_test123');
+    });
+});
+
+describe('ListGitHubTags', () => {
+    beforeEach(() => {
+        mockFetch.mockReset();
+    });
+
+    it('returns semver tags sorted by version descending', async () => {
+        mockFetch.mockResolvedValueOnce({
+            ok: true,
+            json: async () => [
+                { name: 'v1.0.0' },
+                { name: 'v1.0.7' },
+                { name: 'v1.0.3' },
+                { name: 'v1.0.6' },
+                { name: 'not-semver' },
+            ],
+        });
+
+        const result = await ListGitHubTags('https://github.com/Acme/App', {});
+        expect(result).toEqual(['v1.0.7', 'v1.0.6', 'v1.0.3', 'v1.0.0']);
+    });
+
+    it('filters out non-semver tags', async () => {
+        mockFetch.mockResolvedValueOnce({
+            ok: true,
+            json: async () => [
+                { name: 'latest' },
+                { name: 'release-candidate' },
+                { name: 'v1.0.0' },
+            ],
+        });
+
+        const result = await ListGitHubTags('https://github.com/Acme/App', {});
+        expect(result).toEqual(['v1.0.0']);
+    });
+
+    it('returns empty array on API failure', async () => {
+        mockFetch.mockResolvedValueOnce({ ok: false, status: 404 });
+        const result = await ListGitHubTags('https://github.com/Acme/App', {});
+        expect(result).toEqual([]);
+    });
+});
+
+describe('GetLatestVersion', () => {
+    beforeEach(() => {
+        mockFetch.mockReset();
+    });
+
+    it('returns latest version from GitHub Releases when available', async () => {
+        // Releases endpoint returns results
+        mockFetch.mockResolvedValueOnce({
+            ok: true,
+            json: async () => [
+                { tag_name: 'v1.0.7', prerelease: false, draft: false, created_at: '2026-04-20T00:00:00Z' },
+                { tag_name: 'v1.0.6', prerelease: false, draft: false, created_at: '2026-04-10T00:00:00Z' },
+            ],
+        });
+
+        const result = await GetLatestVersion('https://github.com/Acme/App', {});
+        expect(result).toBe('1.0.7');
+    });
+
+    it('falls back to tags when no GitHub Releases exist', async () => {
+        // Releases endpoint returns empty
+        mockFetch.mockResolvedValueOnce({
+            ok: true,
+            json: async () => [],
+        });
+
+        // Tags endpoint returns results
+        mockFetch.mockResolvedValueOnce({
+            ok: true,
+            json: async () => [
+                { name: 'v1.0.7' },
+                { name: 'v1.0.6' },
+                { name: 'v1.0.0' },
+            ],
+        });
+
+        const result = await GetLatestVersion('https://github.com/Acme/App', {});
+        expect(result).toBe('1.0.7');
+    });
+
+    it('returns null when neither releases nor tags exist', async () => {
+        mockFetch.mockResolvedValueOnce({ ok: true, json: async () => [] }); // releases
+        mockFetch.mockResolvedValueOnce({ ok: true, json: async () => [] }); // tags
+
+        const result = await GetLatestVersion('https://github.com/Acme/App', {});
+        expect(result).toBeNull();
+    });
+});

--- a/packages/OpenApp/Engine/src/__tests__/package-manager-version.test.ts
+++ b/packages/OpenApp/Engine/src/__tests__/package-manager-version.test.ts
@@ -1,0 +1,120 @@
+/**
+ * Tests for version strategy resolution in the package manager,
+ * including the new 'exact' strategy for explicit version pins.
+ */
+import { describe, it, expect, vi } from 'vitest';
+import { readFileSync, writeFileSync, existsSync } from 'node:fs';
+import { AddAppPackages, type PackageManagerOptions, type VersionStrategy } from '../install/package-manager.js';
+import type { ManifestPackageEntry } from '../manifest/manifest-schema.js';
+
+// Mock fs so we can test package.json writes without hitting the filesystem
+vi.mock('node:fs', () => ({
+    readFileSync: vi.fn(),
+    writeFileSync: vi.fn(),
+    existsSync: vi.fn(),
+}));
+
+const mockReadFileSync = vi.mocked(readFileSync);
+const mockWriteFileSync = vi.mocked(writeFileSync);
+const mockExistsSync = vi.mocked(existsSync);
+
+function buildOptions(overrides: Partial<PackageManagerOptions> = {}): PackageManagerOptions {
+    return {
+        RepoRoot: '/fake/root',
+        ServerPackages: [{ name: '@acme/server-pkg', role: 'bootstrap', startupExport: 'LoadAcme' }],
+        ClientPackages: [],
+        SharedPackages: [],
+        Version: '1.0.7',
+        ServerPackagePath: 'apps/Server',
+        ClientPackagePath: 'apps/Client',
+        ...overrides,
+    };
+}
+
+function setupMockPackageJson(): void {
+    // Return a minimal package.json when read
+    mockReadFileSync.mockReturnValue(JSON.stringify({ dependencies: {} }));
+    // Pretend the path exists
+    mockExistsSync.mockReturnValue(true);
+}
+
+describe('Version strategy resolution', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        setupMockPackageJson();
+    });
+
+    it('writes ^version for semver strategy', () => {
+        const result = AddAppPackages(buildOptions({ VersionStrategy: 'semver' }));
+        expect(result.Success).toBe(true);
+
+        const writtenJson = JSON.parse(mockWriteFileSync.mock.calls[0][1] as string);
+        expect(writtenJson.dependencies['@acme/server-pkg']).toBe('^1.0.7');
+    });
+
+    it('writes exact version (no prefix) for exact strategy', () => {
+        const result = AddAppPackages(buildOptions({ VersionStrategy: 'exact' }));
+        expect(result.Success).toBe(true);
+
+        const writtenJson = JSON.parse(mockWriteFileSync.mock.calls[0][1] as string);
+        expect(writtenJson.dependencies['@acme/server-pkg']).toBe('1.0.7');
+    });
+
+    it('writes ^version for auto strategy when not using pnpm catalog', () => {
+        // No pnpm-lock.yaml exists, so auto falls back to semver
+        mockExistsSync.mockImplementation((path) => {
+            if (typeof path === 'string' && path.includes('pnpm-lock')) return false;
+            if (typeof path === 'string' && path.includes('pnpm-workspace')) return false;
+            return true;
+        });
+
+        const result = AddAppPackages(buildOptions({ VersionStrategy: 'auto' }));
+        expect(result.Success).toBe(true);
+
+        const writtenJson = JSON.parse(mockWriteFileSync.mock.calls[0][1] as string);
+        expect(writtenJson.dependencies['@acme/server-pkg']).toBe('^1.0.7');
+    });
+
+    it('writes catalog: for catalog strategy', () => {
+        const result = AddAppPackages(buildOptions({ VersionStrategy: 'catalog' }));
+        expect(result.Success).toBe(true);
+
+        const writtenJson = JSON.parse(mockWriteFileSync.mock.calls[0][1] as string);
+        expect(writtenJson.dependencies['@acme/server-pkg']).toBe('catalog:');
+    });
+
+    it('writes workspace:* for workspace strategy', () => {
+        const result = AddAppPackages(buildOptions({ VersionStrategy: 'workspace' }));
+        expect(result.Success).toBe(true);
+
+        const writtenJson = JSON.parse(mockWriteFileSync.mock.calls[0][1] as string);
+        expect(writtenJson.dependencies['@acme/server-pkg']).toBe('workspace:*');
+    });
+});
+
+describe('Exact version pin integration', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        setupMockPackageJson();
+    });
+
+    it('pins shared packages to exact version when strategy is exact', () => {
+        const opts = buildOptions({
+            VersionStrategy: 'exact',
+            ServerPackages: [],
+            SharedPackages: [
+                { name: '@acme/core', role: 'library' },
+                { name: '@acme/entities', role: 'library' },
+            ],
+        });
+
+        const result = AddAppPackages(opts);
+        expect(result.Success).toBe(true);
+
+        // Shared packages go to both server and client workspaces
+        // Check the first write (server workspace)
+        const writtenJson = JSON.parse(mockWriteFileSync.mock.calls[0][1] as string);
+        expect(writtenJson.dependencies['@acme/core']).toBe('1.0.7');
+        expect(writtenJson.dependencies['@acme/entities']).toBe('1.0.7');
+    });
+});

--- a/packages/OpenApp/Engine/src/github/github-client.ts
+++ b/packages/OpenApp/Engine/src/github/github-client.ts
@@ -255,6 +255,8 @@ export async function DownloadMigrations(
 
 /**
  * Fetches the latest release version for a repository.
+ * Falls back to listing tags if no GitHub Releases exist (common for repos
+ * that only push semver tags without creating formal releases).
  *
  * @param repoUrl - GitHub repository URL
  * @param options - GitHub client options
@@ -264,10 +266,116 @@ export async function GetLatestVersion(
     repoUrl: string,
     options: GitHubClientOptions
 ): Promise<string | null> {
+    // Try GitHub Releases first
     const releases = await ListGitHubReleases(repoUrl, options);
     const stable = releases.find(r => !r.PreRelease && !r.Draft);
-    if (!stable) {
-        return null;
+    if (stable) {
+        return stable.TagName.replace(/^v/, '');
     }
-    return stable.TagName.replace(/^v/, '');
+
+    // Fall back to tags (sorted by semver descending)
+    const tags = await ListGitHubTags(repoUrl, options);
+    if (tags.length > 0) {
+        return tags[0].replace(/^v/, '');
+    }
+
+    return null;
+}
+
+/**
+ * Lists semver tags for a GitHub repository, sorted by version descending.
+ * Only returns tags matching the `v{major}.{minor}.{patch}` pattern.
+ *
+ * @param repoUrl - GitHub repository URL
+ * @param options - GitHub client options
+ * @returns Sorted tag names (e.g., ['v1.0.7', 'v1.0.6', ...])
+ */
+export async function ListGitHubTags(
+    repoUrl: string,
+    options: GitHubClientOptions
+): Promise<string[]> {
+    const parsed = ParseGitHubUrl(repoUrl);
+    if (!parsed) {
+        return [];
+    }
+
+    const apiUrl = `https://api.github.com/repos/${parsed.Owner}/${parsed.Repo}/tags?per_page=100`;
+
+    try {
+        const response = await fetch(apiUrl, {
+            headers: BuildHeaders(options.Token)
+        });
+
+        if (!response.ok) {
+            return [];
+        }
+
+        const tags = await response.json() as Array<{ name: string }>;
+        const semverPattern = /^v?\d+\.\d+\.\d+(-[a-zA-Z0-9]+(\.[a-zA-Z0-9]+)*)?$/;
+
+        return tags
+            .map(t => t.name)
+            .filter(name => semverPattern.test(name))
+            .sort((a, b) => compareSemver(b, a));
+    }
+    catch {
+        return [];
+    }
+}
+
+/**
+ * Validates that a specific version tag exists in a GitHub repository.
+ *
+ * @param repoUrl - GitHub repository URL
+ * @param version - Version to check (e.g., '1.0.7' — will be normalized to 'v1.0.7')
+ * @param options - GitHub client options
+ * @returns Whether the tag exists, with an error message if not
+ */
+export async function ValidateGitHubTag(
+    repoUrl: string,
+    version: string,
+    options: GitHubClientOptions
+): Promise<{ Exists: boolean; ErrorMessage?: string }> {
+    const parsed = ParseGitHubUrl(repoUrl);
+    if (!parsed) {
+        return { Exists: false, ErrorMessage: `Invalid GitHub URL: ${repoUrl}` };
+    }
+
+    const tag = `v${version.replace(/^v/, '')}`;
+    const apiUrl = `https://api.github.com/repos/${parsed.Owner}/${parsed.Repo}/git/ref/tags/${tag}`;
+
+    try {
+        const response = await fetch(apiUrl, {
+            headers: BuildHeaders(options.Token)
+        });
+
+        if (response.ok) {
+            return { Exists: true };
+        }
+
+        if (response.status === 404) {
+            return { Exists: false, ErrorMessage: `Tag '${tag}' not found in ${parsed.Owner}/${parsed.Repo}. Available versions can be checked at ${repoUrl}/tags` };
+        }
+
+        return { Exists: false, ErrorMessage: `GitHub API error checking tag '${tag}': ${response.status} ${response.statusText}` };
+    }
+    catch (error: unknown) {
+        const message = error instanceof Error ? error.message : String(error);
+        return { Exists: false, ErrorMessage: `Failed to validate tag '${tag}': ${message}` };
+    }
+}
+
+/**
+ * Compares two semver version strings (with optional 'v' prefix).
+ * Returns negative if a < b, positive if a > b, zero if equal.
+ */
+function compareSemver(a: string, b: string): number {
+    const parse = (v: string) => v.replace(/^v/, '').split('.').map(Number);
+    const pa = parse(a);
+    const pb = parse(b);
+    for (let i = 0; i < 3; i++) {
+        const diff = (pa[i] ?? 0) - (pb[i] ?? 0);
+        if (diff !== 0) return diff;
+    }
+    return 0;
 }

--- a/packages/OpenApp/Engine/src/github/github-client.ts
+++ b/packages/OpenApp/Engine/src/github/github-client.ts
@@ -11,8 +11,15 @@ import { join } from 'node:path';
  * Options for configuring the GitHub client.
  */
 export interface GitHubClientOptions {
-    /** Personal access token for private repos */
+    /** Default personal access token for private repos */
     Token?: string;
+    /**
+     * Per-repository token overrides. Keys are GitHub repository URLs
+     * (e.g., 'https://github.com/BlueCypress/SaaS'). When a function
+     * receives a repo URL, it checks this map first before falling back
+     * to the default Token.
+     */
+    TokenMap?: Record<string, string>;
 }
 
 /**
@@ -70,6 +77,30 @@ export function ParseGitHubUrl(repoUrl: string): { Owner: string; Repo: string }
 }
 
 /**
+ * Resolves the appropriate token for a given repository URL.
+ * Checks the TokenMap first (matching by normalized URL), then falls back to the default Token.
+ */
+function ResolveToken(repoUrl: string, options: GitHubClientOptions): string | undefined {
+    if (options.TokenMap) {
+        const normalized = normalizeRepoUrl(repoUrl);
+        for (const [mapUrl, mapToken] of Object.entries(options.TokenMap)) {
+            if (normalizeRepoUrl(mapUrl) === normalized) {
+                return mapToken;
+            }
+        }
+    }
+    return options.Token;
+}
+
+/**
+ * Normalizes a GitHub repo URL for comparison: strips trailing .git, trailing slash,
+ * and lowercases for case-insensitive matching.
+ */
+function normalizeRepoUrl(url: string): string {
+    return url.replace(/\.git$/, '').replace(/\/$/, '').toLowerCase();
+}
+
+/**
  * Builds the authorization headers for GitHub API requests.
  */
 function BuildHeaders(token?: string): Record<string, string> {
@@ -106,7 +137,7 @@ export async function FetchManifestFromGitHub(
 
     try {
         const response = await fetch(apiUrl, {
-            headers: BuildHeaders(options.Token)
+            headers: BuildHeaders(ResolveToken(repoUrl, options))
         });
 
         if (!response.ok) {
@@ -150,7 +181,7 @@ export async function ListGitHubReleases(
 
     try {
         const response = await fetch(apiUrl, {
-            headers: BuildHeaders(options.Token)
+            headers: BuildHeaders(ResolveToken(repoUrl, options))
         });
 
         if (!response.ok) {
@@ -204,7 +235,7 @@ export async function DownloadMigrations(
 
     try {
         const response = await fetch(apiUrl, {
-            headers: BuildHeaders(options.Token)
+            headers: BuildHeaders(ResolveToken(repoUrl, options))
         });
 
         if (!response.ok) {
@@ -234,7 +265,7 @@ export async function DownloadMigrations(
             }
 
             const fileResponse = await fetch(file.download_url, {
-                headers: BuildHeaders(options.Token)
+                headers: BuildHeaders(ResolveToken(repoUrl, options))
             });
 
             if (fileResponse.ok) {
@@ -303,7 +334,7 @@ export async function ListGitHubTags(
 
     try {
         const response = await fetch(apiUrl, {
-            headers: BuildHeaders(options.Token)
+            headers: BuildHeaders(ResolveToken(repoUrl, options))
         });
 
         if (!response.ok) {
@@ -346,7 +377,7 @@ export async function ValidateGitHubTag(
 
     try {
         const response = await fetch(apiUrl, {
-            headers: BuildHeaders(options.Token)
+            headers: BuildHeaders(ResolveToken(repoUrl, options))
         });
 
         if (response.ok) {

--- a/packages/OpenApp/Engine/src/index.ts
+++ b/packages/OpenApp/Engine/src/index.ts
@@ -66,7 +66,7 @@ export type { SchemaOperationResult } from './install/schema-manager.js';
 export { RunAppMigrations } from './install/migration-runner.js';
 export type { MigrationRunOptions, MigrationRunResult, FlywayDatabaseConfig, SkywayDatabaseConfig } from './install/migration-runner.js';
 
-export { AddAppPackages, RemoveAppPackages, RunNpmInstall, RunPackageInstall, detectPackageManager, hasPnpmCatalog } from './install/package-manager.js';
+export { AddAppPackages, RemoveAppPackages, RunNpmInstall, RunPackageInstall, BumpPrefixedDependencies, detectPackageManager, hasPnpmCatalog } from './install/package-manager.js';
 export type { PackageManagerOptions, PackageOperationResult, PackageManagerType, VersionStrategy, WorkspaceTarget } from './install/package-manager.js';
 
 export {

--- a/packages/OpenApp/Engine/src/index.ts
+++ b/packages/OpenApp/Engine/src/index.ts
@@ -46,6 +46,8 @@ export type { VersionCheckResult } from './dependency/version-checker.js';
 export {
     FetchManifestFromGitHub,
     ListGitHubReleases,
+    ListGitHubTags,
+    ValidateGitHubTag,
     DownloadMigrations,
     GetLatestVersion,
     ParseGitHubUrl

--- a/packages/OpenApp/Engine/src/install/config-manager.ts
+++ b/packages/OpenApp/Engine/src/install/config-manager.ts
@@ -188,6 +188,14 @@ function EnsureDynamicPackagesSection(content: string): string {
  * Adds a single entry to the dynamicPackages.server array in the config string.
  */
 function AddEntryToServerArray(content: string, entry: DynamicPackageEntry): string {
+    // Skip if an entry with the same PackageName and AppName already exists
+    const existsPattern = new RegExp(
+        `PackageName:\\s*'${EscapeRegex(entry.PackageName)}'[^{}]*AppName:\\s*'${EscapeRegex(entry.AppName)}'`
+    );
+    if (existsPattern.test(content)) {
+        return content;
+    }
+
     // Find the server array
     const serverArrayMatch = content.match(/server:\s*\[/);
     if (!serverArrayMatch || serverArrayMatch.index === undefined) {

--- a/packages/OpenApp/Engine/src/install/install-orchestrator.ts
+++ b/packages/OpenApp/Engine/src/install/install-orchestrator.ts
@@ -775,9 +775,10 @@ async function HandleSchemaCreation(manifest: MJAppManifest, context: Orchestrat
   const exists = await SchemaExists(manifest.schema.name, context.DatabaseProvider);
 
   if (exists) {
-    if (isReinstall) {
-      // Schema left over from a previous install (e.g. --keep-data removal).
-      // Reuse it rather than failing.
+    if (isReinstall || manifest.schema.createIfNotExists !== false) {
+      // Schema already exists — either a reinstall (previously removed app),
+      // or createIfNotExists is set (the app expects to adopt an existing schema).
+      // Reuse it and let Skyway apply only new migrations.
       context.Callbacks?.OnProgress?.('Schema', `Reusing existing schema '${manifest.schema.name}'`);
       return { Success: true };
     }

--- a/packages/OpenApp/Engine/src/install/install-orchestrator.ts
+++ b/packages/OpenApp/Engine/src/install/install-orchestrator.ts
@@ -16,7 +16,7 @@ import type { InstalledAppMap, DependencyNode, DependencyValue } from '../depend
 import { FetchManifestFromGitHub, DownloadMigrations, GetLatestVersion, ValidateGitHubTag, type GitHubClientOptions } from '../github/github-client.js';
 import { CreateAppSchema, DropAppSchema, SchemaExists, EscapeSqlString } from './schema-manager.js';
 import { RunAppMigrations, type SkywayDatabaseConfig } from './migration-runner.js';
-import { AddAppPackages, RemoveAppPackages, RunPackageInstall, type PackageManagerType, type VersionStrategy, type WorkspaceTarget } from './package-manager.js';
+import { AddAppPackages, RemoveAppPackages, RunPackageInstall, BumpPrefixedDependencies, type PackageManagerType, type VersionStrategy, type WorkspaceTarget } from './package-manager.js';
 import { AddServerDynamicPackages, RemoveServerDynamicPackages, ToggleServerDynamicPackages, AddEntityPackageMapping, RemoveEntityPackageMapping } from './config-manager.js';
 import { RegenerateClientBootstrap, type ClientBootstrapEntry } from './client-bootstrap-gen.js';
 import { BaseEntity, DatabaseProviderBase, Metadata, RunView } from '@memberjunction/core';
@@ -447,10 +447,16 @@ export async function UpgradeApp(options: UpgradeOptions, context: OrchestratorC
     const effectiveUpgradeVersion = explicitUpgradeVersion ? targetVersion.replace(/^v/, '') : manifest.version;
     const effectiveUpgradeStrategy: VersionStrategy | undefined = explicitUpgradeVersion ? 'exact' : context.VersionStrategy;
     const pkgResult = await HandlePackageInstallation(manifest, context, effectiveUpgradeVersion, effectiveUpgradeStrategy);
+    let npmInstallWarning: string | undefined;
     if (!pkgResult.Success) {
-      await RecordFailureHistory(context.ContextUser, existingApp.ID, 'Upgrade', manifest, 'Packages', pkgResult.ErrorMessage ?? 'Package update failed', startTime, previousVersion);
-      await SetAppStatus(context.ContextUser, existingApp.ID, 'Error');
-      return BuildFailureResult('Upgrade', options.AppName, targetVersion, 'Packages', startTime, pkgResult.ErrorMessage ?? 'Package update failed');
+      if (pkgResult.PackageJsonUpdated) {
+        npmInstallWarning = pkgResult.ErrorMessage;
+        Callbacks?.OnWarn?.('Packages', `npm install failed — package.json entries were updated but dependencies were not resolved. Run 'npm install' manually after fixing npm auth.\n  Detail: ${pkgResult.ErrorMessage}`);
+      } else {
+        await RecordFailureHistory(context.ContextUser, existingApp.ID, 'Upgrade', manifest, 'Packages', pkgResult.ErrorMessage ?? 'Package update failed', startTime, previousVersion);
+        await SetAppStatus(context.ContextUser, existingApp.ID, 'Error');
+        return BuildFailureResult('Upgrade', options.AppName, targetVersion, 'Packages', startTime, pkgResult.ErrorMessage ?? 'Package update failed');
+      }
     }
 
     // Step 7: Update server config if changed
@@ -495,13 +501,18 @@ export async function UpgradeApp(options: UpgradeOptions, context: OrchestratorC
 
     Callbacks?.OnSuccess?.('Upgrade', `Successfully upgraded ${options.AppName} to v${manifest.version}`);
 
+    const baseSummary = `Upgraded from ${previousVersion} to ${manifest.version}. Restart MJAPI and rebuild MJExplorer.`;
+    const summary = npmInstallWarning
+      ? `${baseSummary}\n\n⚠ npm install failed — package.json and config files were updated but dependencies were not installed. Log in to npm ('npm login') or configure your .npmrc, then run 'npm install' to complete the setup.`
+      : baseSummary;
+
     return {
       Success: true,
       Action: 'Upgrade',
       AppName: options.AppName,
       Version: manifest.version,
       DurationSeconds: GetDurationSeconds(startTime),
-      Summary: `Upgraded from ${previousVersion} to ${manifest.version}. Restart MJAPI and rebuild MJExplorer.`,
+      Summary: summary,
     };
   } catch (error: unknown) {
     const message = error instanceof Error ? error.message : String(error);
@@ -873,6 +884,18 @@ async function HandlePackageInstallation(
 
   if (!addResult.Success) {
     return { Success: false, ErrorMessage: addResult.ErrorMessage };
+  }
+
+  // If the manifest declares a package prefix, bump ALL matching dependencies
+  // across the workspace (not just the manifest-declared ones). This handles
+  // consumer-added packages like bcsaas-settings, bcsaas-credentials, etc.
+  const prefix = manifest.packages.prefix;
+  if (prefix) {
+    const bareVersion = packageVersion ?? manifest.version;
+    const updatedCount = BumpPrefixedDependencies(context.RepoRoot, prefix, bareVersion);
+    if (updatedCount > 0) {
+      context.Callbacks?.OnProgress?.('Packages', `Bumped ${updatedCount} workspace package.json file(s) with prefix '${prefix}' to ${bareVersion}`);
+    }
   }
 
   context.Callbacks?.OnProgress?.('Packages', 'Running package install...');

--- a/packages/OpenApp/Engine/src/install/install-orchestrator.ts
+++ b/packages/OpenApp/Engine/src/install/install-orchestrator.ts
@@ -203,10 +203,19 @@ export async function InstallApp(options: InstallOptions, context: OrchestratorC
 
     // Steps 10-11: Packages
     const pkgResult = await HandlePackageInstallation(manifest, context, effectivePackageVersion, effectiveVersionStrategy);
+    let npmInstallWarning: string | undefined;
     if (!pkgResult.Success) {
-      await SetAppStatus(context.ContextUser, createdAppId!, 'Error');
-      await RecordFailureHistory(context.ContextUser, createdAppId!, 'Install', manifest, 'Packages', pkgResult.ErrorMessage ?? 'Package installation failed', startTime);
-      return BuildFailureResult('Install', manifest.name, manifest.version, 'Packages', startTime, pkgResult.ErrorMessage ?? 'Package installation failed');
+      if (pkgResult.PackageJsonUpdated) {
+        // package.json was updated successfully but `npm install` failed (e.g., missing npm auth).
+        // Continue with the rest of the install — the user can run `npm install` manually once
+        // they fix their npm credentials.
+        npmInstallWarning = pkgResult.ErrorMessage;
+        Callbacks?.OnWarn?.('Packages', `npm install failed — package.json entries were added but dependencies were not resolved. Run 'npm install' manually after fixing npm auth.\n  Detail: ${pkgResult.ErrorMessage}`);
+      } else {
+        await SetAppStatus(context.ContextUser, createdAppId!, 'Error');
+        await RecordFailureHistory(context.ContextUser, createdAppId!, 'Install', manifest, 'Packages', pkgResult.ErrorMessage ?? 'Package installation failed', startTime);
+        return BuildFailureResult('Install', manifest.name, manifest.version, 'Packages', startTime, pkgResult.ErrorMessage ?? 'Package installation failed');
+      }
     }
 
     // Step 12: Update server config
@@ -241,13 +250,18 @@ export async function InstallApp(options: InstallOptions, context: OrchestratorC
 
     Callbacks?.OnSuccess?.('Install', `Successfully installed ${manifest.name} v${manifest.version}`);
 
+    const baseSummary = 'App installed successfully. Restart MJAPI and rebuild MJExplorer to activate.';
+    const summary = npmInstallWarning
+      ? `${baseSummary}\n\n⚠ npm install failed — package.json and config files were updated but dependencies were not installed. Log in to npm ('npm login') or configure your .npmrc, then run 'npm install' to complete the setup.`
+      : baseSummary;
+
     return {
       Success: true,
       Action: 'Install',
       AppName: manifest.name,
       Version: manifest.version,
       DurationSeconds: GetDurationSeconds(startTime),
-      Summary: 'App installed successfully. Restart MJAPI and rebuild MJExplorer to activate.',
+      Summary: summary,
     };
   } catch (error: unknown) {
     const message = error instanceof Error ? error.message : String(error);
@@ -700,6 +714,8 @@ interface InternalResult {
   ErrorMessage?: string;
   AppId?: string;
   DepsToInstall?: Array<{ AppName: string; Repository: string; VersionRange: string }>;
+  /** True when package.json was updated but npm install failed (e.g., auth issue) */
+  PackageJsonUpdated?: boolean;
 }
 
 /**
@@ -861,7 +877,10 @@ async function HandlePackageInstallation(
 
   context.Callbacks?.OnProgress?.('Packages', 'Running package install...');
   const installResult = RunPackageInstall(context.RepoRoot, undefined, manifest.packages.registry, context.PackageManager);
-  return { Success: installResult.Success, ErrorMessage: installResult.ErrorMessage };
+  if (!installResult.Success) {
+    return { Success: false, PackageJsonUpdated: true, ErrorMessage: installResult.ErrorMessage };
+  }
+  return { Success: true };
 }
 
 /**

--- a/packages/OpenApp/Engine/src/install/install-orchestrator.ts
+++ b/packages/OpenApp/Engine/src/install/install-orchestrator.ts
@@ -13,7 +13,7 @@ import { ParseAndValidateManifest } from '../manifest/manifest-loader.js';
 import { CheckMJVersionCompatibility, IsValidUpgrade } from '../dependency/version-checker.js';
 import { ResolveDependencies } from '../dependency/dependency-resolver.js';
 import type { InstalledAppMap, DependencyNode, DependencyValue } from '../dependency/dependency-resolver.js';
-import { FetchManifestFromGitHub, DownloadMigrations, GetLatestVersion, type GitHubClientOptions } from '../github/github-client.js';
+import { FetchManifestFromGitHub, DownloadMigrations, GetLatestVersion, ValidateGitHubTag, type GitHubClientOptions } from '../github/github-client.js';
 import { CreateAppSchema, DropAppSchema, SchemaExists, EscapeSqlString } from './schema-manager.js';
 import { RunAppMigrations, type SkywayDatabaseConfig } from './migration-runner.js';
 import { AddAppPackages, RemoveAppPackages, RunPackageInstall, type PackageManagerType, type VersionStrategy, type WorkspaceTarget } from './package-manager.js';
@@ -101,9 +101,19 @@ export async function InstallApp(options: InstallOptions, context: OrchestratorC
   let manifest: MJAppManifest | undefined;
 
   try {
-    // Step 1: Fetch manifest
+    // Step 1a: If an explicit version was requested, validate the tag exists on GitHub
+    const explicitVersion = options.Version;
+    if (explicitVersion) {
+      Callbacks?.OnProgress?.('Fetch', `Validating version tag v${explicitVersion.replace(/^v/, '')} exists...`);
+      const tagResult = await ValidateGitHubTag(options.Source, explicitVersion, context.GitHubOptions);
+      if (!tagResult.Exists) {
+        return BuildFailureResult('Install', options.Source, '', 'Schema', startTime, tagResult.ErrorMessage ?? `Version ${explicitVersion} not found`);
+      }
+    }
+
+    // Step 1b: Fetch manifest
     Callbacks?.OnProgress?.('Fetch', `Fetching manifest from ${options.Source}...`);
-    const fetchResult = await FetchManifestFromGitHub(options.Source, options.Version, context.GitHubOptions);
+    const fetchResult = await FetchManifestFromGitHub(options.Source, explicitVersion, context.GitHubOptions);
     if (!fetchResult.Success || !fetchResult.ManifestJSON) {
       return BuildFailureResult('Install', options.Source, '', 'Schema', startTime, fetchResult.ErrorMessage ?? 'Failed to fetch manifest');
     }
@@ -115,6 +125,12 @@ export async function InstallApp(options: InstallOptions, context: OrchestratorC
       return BuildFailureResult('Install', options.Source, '', 'Schema', startTime, `Invalid manifest: ${parseResult.Errors?.join(', ')}`);
     }
     manifest = parseResult.Manifest;
+
+    // When an explicit version is requested, use that version for package pins
+    // (not the manifest's version field, which may be a base version like "1.0.0").
+    // Also switch to 'exact' version strategy so packages are pinned without ^ prefix.
+    const effectivePackageVersion = explicitVersion ? explicitVersion.replace(/^v/, '') : manifest.version;
+    const effectiveVersionStrategy: VersionStrategy | undefined = explicitVersion ? 'exact' : context.VersionStrategy;
 
     // Steps 3-4: Validate MJ compatibility and resolve dependencies (parallel)
     Callbacks?.OnProgress?.('Validate', 'Checking MJ version compatibility and resolving dependencies...');
@@ -186,7 +202,7 @@ export async function InstallApp(options: InstallOptions, context: OrchestratorC
     Callbacks?.OnProgress?.('Config', 'Updating configuration files...');
 
     // Steps 10-11: Packages
-    const pkgResult = await HandlePackageInstallation(manifest, context);
+    const pkgResult = await HandlePackageInstallation(manifest, context, effectivePackageVersion, effectiveVersionStrategy);
     if (!pkgResult.Success) {
       await SetAppStatus(context.ContextUser, createdAppId!, 'Error');
       await RecordFailureHistory(context.ContextUser, createdAppId!, 'Install', manifest, 'Packages', pkgResult.ErrorMessage ?? 'Package installation failed', startTime);
@@ -332,9 +348,18 @@ export async function UpgradeApp(options: UpgradeOptions, context: OrchestratorC
     previousVersion = existingApp.Version;
 
     // Step 1: Fetch new manifest
-    const targetVersion = options.Version ?? (await GetLatestVersion(existingApp.RepositoryURL, context.GitHubOptions));
+    const explicitUpgradeVersion = options.Version;
+    const targetVersion = explicitUpgradeVersion ?? (await GetLatestVersion(existingApp.RepositoryURL, context.GitHubOptions));
     if (!targetVersion) {
       return BuildFailureResult('Upgrade', options.AppName, '', 'Schema', startTime, 'Could not determine target version');
+    }
+
+    // If an explicit version was requested, validate the tag exists on GitHub
+    if (explicitUpgradeVersion) {
+      const tagResult = await ValidateGitHubTag(existingApp.RepositoryURL, targetVersion, context.GitHubOptions);
+      if (!tagResult.Exists) {
+        return BuildFailureResult('Upgrade', options.AppName, targetVersion, 'Schema', startTime, tagResult.ErrorMessage ?? `Version ${targetVersion} not found`);
+      }
     }
 
     // Verify target is actually newer than installed version
@@ -404,7 +429,10 @@ export async function UpgradeApp(options: UpgradeOptions, context: OrchestratorC
     }
 
     // Steps 5-6: Update packages
-    const pkgResult = await HandlePackageInstallation(manifest, context);
+    // When upgrading to an explicit version, pin packages exactly; otherwise use default strategy
+    const effectiveUpgradeVersion = explicitUpgradeVersion ? targetVersion.replace(/^v/, '') : manifest.version;
+    const effectiveUpgradeStrategy: VersionStrategy | undefined = explicitUpgradeVersion ? 'exact' : context.VersionStrategy;
+    const pkgResult = await HandlePackageInstallation(manifest, context, effectiveUpgradeVersion, effectiveUpgradeStrategy);
     if (!pkgResult.Success) {
       await RecordFailureHistory(context.ContextUser, existingApp.ID, 'Upgrade', manifest, 'Packages', pkgResult.ErrorMessage ?? 'Package update failed', startTime, previousVersion);
       await SetAppStatus(context.ContextUser, existingApp.ID, 'Error');
@@ -798,8 +826,16 @@ async function HandleMigrations(manifest: MJAppManifest, context: OrchestratorCo
 
 /**
  * Adds app npm packages to the appropriate workspace package.json files and runs npm install.
+ *
+ * @param packageVersion - The version string to write (may differ from manifest.version when an explicit version is requested)
+ * @param versionStrategy - Override for version strategy (e.g., 'exact' when explicit version is requested)
  */
-async function HandlePackageInstallation(manifest: MJAppManifest, context: OrchestratorContext): Promise<InternalResult> {
+async function HandlePackageInstallation(
+  manifest: MJAppManifest,
+  context: OrchestratorContext,
+  packageVersion?: string,
+  versionStrategy?: VersionStrategy,
+): Promise<InternalResult> {
   if (!manifest.packages) {
     return { Success: true };
   }
@@ -810,11 +846,11 @@ async function HandlePackageInstallation(manifest: MJAppManifest, context: Orche
     ServerPackages: manifest.packages.server ?? [],
     ClientPackages: manifest.packages.client ?? [],
     SharedPackages: manifest.packages.shared ?? [],
-    Version: manifest.version,
+    Version: packageVersion ?? manifest.version,
     ServerPackagePath: context.ServerPackagePath,
     ClientPackagePath: context.ClientPackagePath,
     PackageManager: context.PackageManager,
-    VersionStrategy: context.VersionStrategy,
+    VersionStrategy: versionStrategy ?? context.VersionStrategy,
     AdditionalTargets: context.AdditionalTargets,
   });
 

--- a/packages/OpenApp/Engine/src/install/package-manager.ts
+++ b/packages/OpenApp/Engine/src/install/package-manager.ts
@@ -19,11 +19,12 @@ export type PackageManagerType = 'npm' | 'pnpm' | 'yarn';
 /**
  * Strategy for writing dependency versions into package.json.
  * - 'semver': Standard `^version` range (works everywhere)
+ * - 'exact': Exact version pin with no range prefix (e.g., '1.0.7')
  * - 'catalog': pnpm `catalog:` protocol (requires pnpm-workspace.yaml catalog)
  * - 'workspace': pnpm/yarn `workspace:*` protocol (for local packages)
  * - 'auto': Detects from environment — uses 'catalog' if pnpm + catalog exists, else 'semver'
  */
-export type VersionStrategy = 'semver' | 'catalog' | 'workspace' | 'auto';
+export type VersionStrategy = 'semver' | 'exact' | 'catalog' | 'workspace' | 'auto';
 
 const DEFAULT_SERVER_PATH = 'packages/MJAPI';
 const DEFAULT_CLIENT_PATH = 'packages/MJExplorer';
@@ -266,6 +267,8 @@ function resolveVersionString(options: PackageManagerOptions): string {
   const strategy = options.VersionStrategy ?? 'auto';
 
   switch (strategy) {
+    case 'exact':
+      return options.Version;
     case 'catalog':
       return 'catalog:';
     case 'workspace':

--- a/packages/OpenApp/Engine/src/install/package-manager.ts
+++ b/packages/OpenApp/Engine/src/install/package-manager.ts
@@ -195,22 +195,27 @@ export function hasPnpmCatalog(repoRoot: string): boolean {
 export function RunPackageInstall(repoRoot: string, verbose?: boolean, registryUrl?: string, packageManager?: PackageManagerType): PackageOperationResult {
   const pm = packageManager ?? detectPackageManager(repoRoot);
 
+  // Only pass --registry for non-default registries. The standard npm registry
+  // (https://registry.npmjs.org) is already the default, and passing it explicitly
+  // overrides scoped registry + auth token settings in .npmrc, breaking private packages.
+  const isCustomRegistry = registryUrl && !registryUrl.includes('registry.npmjs.org');
+
   try {
     let cmd: string;
     switch (pm) {
       case 'pnpm': {
         cmd = 'pnpm install';
-        if (registryUrl) cmd += ` --registry=${registryUrl}`;
+        if (isCustomRegistry) cmd += ` --registry=${registryUrl}`;
         break;
       }
       case 'yarn': {
         cmd = 'yarn install';
-        if (registryUrl) cmd += ` --registry=${registryUrl}`;
+        if (isCustomRegistry) cmd += ` --registry=${registryUrl}`;
         break;
       }
       default: {
         let flags = verbose ? '' : '--loglevel=warn';
-        if (registryUrl) flags += ` --registry=${registryUrl}`;
+        if (isCustomRegistry) flags += ` --registry=${registryUrl}`;
         cmd = `npm install ${flags}`;
         break;
       }

--- a/packages/OpenApp/Engine/src/install/package-manager.ts
+++ b/packages/OpenApp/Engine/src/install/package-manager.ts
@@ -8,7 +8,7 @@
  * Layout-agnostic: supports configurable workspace paths and multiple targets.
  * Version-agnostic: supports semver ranges, pnpm catalog:, and workspace:*.
  */
-import { readFileSync, writeFileSync, existsSync } from 'node:fs';
+import { readFileSync, writeFileSync, existsSync, readdirSync } from 'node:fs';
 import { execSync } from 'node:child_process';
 import { resolve, dirname } from 'node:path';
 import type { ManifestPackageEntry } from '../manifest/manifest-schema.js';
@@ -325,4 +325,94 @@ function RemoveDependenciesFromPackageJson(pkgJsonPath: string, packages: Manife
   }
 
   writeFileSync(pkgJsonPath, JSON.stringify(pkgJson, null, 2) + '\n', 'utf-8');
+}
+
+/**
+ * Bumps all dependencies matching a package prefix across every package.json in the workspace.
+ * This ensures that consumer-added packages (not declared in the manifest) are also updated
+ * during install/upgrade when an explicit version is requested.
+ *
+ * Preserves existing range prefixes: if a dependency is currently "^1.0.6", it becomes
+ * "^1.0.7" (not "1.0.7"). Same for ~ and other semver range prefixes.
+ *
+ * @param repoRoot - Absolute path to the monorepo root
+ * @param prefix - npm package prefix to match (e.g., '@bluecypress/bcsaas-')
+ * @param bareVersion - The bare version number without range prefix (e.g., '1.0.7')
+ * @returns Number of package.json files that were updated
+ */
+export function BumpPrefixedDependencies(repoRoot: string, prefix: string, bareVersion: string): number {
+  const packageJsonFiles = findWorkspacePackageJsonFiles(repoRoot);
+  let updatedCount = 0;
+
+  for (const pkgJsonPath of packageJsonFiles) {
+    const content = readFileSync(pkgJsonPath, 'utf-8');
+    const pkgJson: {
+      dependencies?: Record<string, string>;
+      devDependencies?: Record<string, string>;
+    } = JSON.parse(content);
+
+    let fileChanged = false;
+
+    for (const section of [pkgJson.dependencies, pkgJson.devDependencies]) {
+      if (!section) continue;
+      for (const depName of Object.keys(section)) {
+        if (!depName.startsWith(prefix)) continue;
+
+        const currentValue = section[depName];
+        // Extract existing range prefix (^, ~, >=, etc.) and preserve it
+        const rangePrefix = currentValue.match(/^([^\d]*)/)?.[1] ?? '';
+        const newValue = `${rangePrefix}${bareVersion}`;
+
+        if (currentValue !== newValue) {
+          section[depName] = newValue;
+          fileChanged = true;
+        }
+      }
+    }
+
+    if (fileChanged) {
+      writeFileSync(pkgJsonPath, JSON.stringify(pkgJson, null, 2) + '\n', 'utf-8');
+      updatedCount++;
+    }
+  }
+
+  return updatedCount;
+}
+
+/**
+ * Finds all package.json files in a monorepo workspace, excluding node_modules and dist.
+ */
+function findWorkspacePackageJsonFiles(repoRoot: string): string[] {
+  const results: string[] = [];
+  const rootPkg = resolve(repoRoot, 'package.json');
+  if (existsSync(rootPkg)) {
+    results.push(rootPkg);
+  }
+
+  // Read workspace globs from root package.json
+  try {
+    const rootContent: { workspaces?: string[] | { packages?: string[] } } =
+      JSON.parse(readFileSync(rootPkg, 'utf-8'));
+    const globs = Array.isArray(rootContent.workspaces)
+      ? rootContent.workspaces
+      : rootContent.workspaces?.packages ?? [];
+
+    for (const glob of globs) {
+      // Support simple globs like "packages/*" and "apps/*"
+      const baseDir = resolve(repoRoot, glob.replace(/\/?\*.*$/, ''));
+      if (!existsSync(baseDir)) continue;
+
+      const entries: string[] = readdirSync(baseDir);
+      for (const entry of entries) {
+        const pkgPath = resolve(baseDir, entry, 'package.json');
+        if (existsSync(pkgPath)) {
+          results.push(pkgPath);
+        }
+      }
+    }
+  } catch {
+    // If we can't read workspaces, just return the root
+  }
+
+  return results;
 }

--- a/packages/OpenApp/Engine/src/manifest/manifest-schema.ts
+++ b/packages/OpenApp/Engine/src/manifest/manifest-schema.ts
@@ -52,6 +52,13 @@ const packageEntrySchema = z.object({
 
 const packagesSchema = z.object({
     registry: z.string().url().optional(),
+    /**
+     * npm package prefix for this app (e.g., '@bluecypress/bcsaas-').
+     * When set, `mj app install --version` and `mj app upgrade --version` will
+     * bump ALL dependencies matching this prefix across the workspace, not just
+     * the packages declared in server/client/shared.
+     */
+    prefix: z.string().min(1).optional(),
     server: z.array(packageEntrySchema).optional(),
     client: z.array(packageEntrySchema).optional(),
     shared: z.array(packageEntrySchema).optional(),


### PR DESCRIPTION
## Summary

End-to-end improvements to the MJ Open App install/upgrade engine, driven by real-world testing installing BCSaaS into Skip-Brain.

- **Exact version pins**: `--version` flag writes exact versions (no `^`) and validates the GitHub tag exists before proceeding
- **Per-repo token map**: `openApps.github.tokens` in `mj.config.cjs` supports different PATs per private repository for multi-app dependency chains
- **Tag fallback**: `GetLatestVersion` falls back to tags when no GitHub Releases exist (fixes repos that only push tags)
- **Schema reuse**: When schema exists and `createIfNotExists: true`, reuse it instead of failing (adopts sidestep installs)
- **Registry fix**: Don't pass `--registry` for default npm registry — was overriding scoped auth in `.npmrc`
- **Duplicate prevention**: `AddEntryToServerArray` checks for existing entries before inserting
- **npm auth warning**: npm install failures demoted to warnings when `package.json` was successfully updated
- **Workspace prefix bumps**: New `packages.prefix` manifest field bumps all matching deps across the workspace during install/upgrade, preserving existing range prefixes (`^`, `~`)

## Test plan

- [x] `mj app install https://github.com/BlueCypress/SaaS --version 1.0.7` — exact pins, tag validation, schema reuse, registry fix all verified
- [x] `mj app upgrade bcsaas --version 1.0.8-test` — prefix bump hit all `@bluecypress/bcsaas-*` deps across 4 workspace packages, npm warning displayed correctly
- [x] OpenApp Engine: 124 tests passing (20 new)
- [x] MJCLI: 112 tests passing
- [ ] Verify `mj app install` without `--version` resolves latest from tags (no releases)
- [ ] Verify per-repo token map with two private repos in a dependency chain

🤖 Generated with [Claude Code](https://claude.com/claude-code)