### PR TITLE
fix(AIEngine): reset embedding promise on failure to allow retry

### DIFF
--- a/.changeset/calm-engines-retry.md
+++ b/.changeset/calm-engines-retry.md
@@ -1,0 +1,5 @@
+---
+"@memberjunction/aiengine": patch
+---
+
+Fix AIEngine lazy embedding loader poisoning the cache on first-call failure. `ensureEmbeddingsGenerated` now wraps the in-flight load in `try/finally` so a transient failure (e.g., model download flake) clears `_embeddingsPromise` and the next FindSimilar* call retries cleanly. Previously, a single failed load would reject every subsequent FindSimilar* call for the rest of the process lifetime.

--- a/packages/AI/Engine/src/AIEngine.ts
+++ b/packages/AI/Engine/src/AIEngine.ts
@@ -421,14 +421,21 @@ export class AIEngine extends BaseSingleton<AIEngine> {
         if (this._embeddingsGenerated) return;
         if (!this._embeddingsPromise) {
             this._embeddingsPromise = (async () => {
-                await Promise.all([
-                    this.RefreshAgentEmbeddings(),
-                    this.RefreshActionEmbeddings(),
-                    this.RefreshNoteEmbeddings(this._contextUser),
-                    this.RefreshExampleEmbeddings(this._contextUser)
-                ]);
-                this._embeddingsGenerated = true;
-                this._embeddingsPromise = null;
+                try {
+                    await Promise.all([
+                        this.RefreshAgentEmbeddings(),
+                        this.RefreshActionEmbeddings(),
+                        this.RefreshNoteEmbeddings(this._contextUser),
+                        this.RefreshExampleEmbeddings(this._contextUser)
+                    ]);
+                    this._embeddingsGenerated = true;
+                } finally {
+                    // Always clear the in-flight promise so the next caller can retry
+                    // after a transient failure (e.g., model download flake). Without
+                    // this, a single failed load would poison every subsequent
+                    // FindSimilar* call for the lifetime of the process.
+                    this._embeddingsPromise = null;
+                }
             })();
         }
         await this._embeddingsPromise;


### PR DESCRIPTION
## Summary
- Wraps the lazy embedding load in `try/finally` so `_embeddingsPromise` is always cleared
- Without it, a transient failure (e.g., Xenova model download flake) poisons the cache — every subsequent `FindSimilar*` call inherits the rejected promise for the rest of the process

## Why this matters
The lazy embedding loader landed with #2330 (`metadatasync-optimization`). The original implementation only cleared `_embeddingsPromise` on the success path:

```typescript
this._embeddingsPromise = (async () => {
    await Promise.all([...]);
    this._embeddingsGenerated = true;
    this._embeddingsPromise = null;  // never reached on rejection
})();
```

If any of the four `Refresh*Embeddings` calls rejected, the field stayed pointing at a rejected promise. A second `FindSimilar*` call would `await this._embeddingsPromise` and immediately re-throw — no retry possible without restarting the process.

## Fix
Move the success-path mutation inside `try`, move the cleanup into `finally`:

```typescript
this._embeddingsPromise = (async () => {
    try {
        await Promise.all([...]);
        this._embeddingsGenerated = true;
    } finally {
        this._embeddingsPromise = null;
    }
})();
```

Now a failed first call leaves the engine in a clean state and the next caller starts a fresh load.

## Test plan
- [x] AIEngine unit tests pass (66/66)
- [x] TypeScript build clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)