### PR TITLE
fix: sqlLike filter wildcards, QueryProcessor defaults, react-test-harness lint rules

### DIFF
--- a/.changeset/gentle-foxes-dance.md
+++ b/.changeset/gentle-foxes-dance.md
@@ -1,0 +1,10 @@
+---
+"@memberjunction/core": patch
+"@memberjunction/core-entities-server": patch
+"@memberjunction/query-processor": patch
+"@memberjunction/react-test-harness": patch
+"@memberjunction/sql-parser": patch
+"@memberjunction/sqlserver-dataprovider": patch
+---
+
+Fix boundary wildcard stripping in sqlLike filters, fix QueryProcessor default value handling for array-typed parameters, add Chart.js canvas container and no-unwrap-utility-libs lint rules to react-test-harness, and fix SimpleChart label leak through onDataPointClick

--- a/metadata/component-libraries/.component-libraries.json
+++ b/metadata/component-libraries/.component-libraries.json
@@ -77,8 +77,8 @@
       "ID": "754D12D4-B182-45E8-B4BB-98FB8A366B02"
     },
     "sync": {
-      "lastModified": "2026-01-08T14:57:20.913Z",
-      "checksum": "762a3ac51b17157c684b7ce77c35d87cb9e249747c0ab525c49698398a430366"
+      "lastModified": "2026-04-30T22:22:37.674Z",
+      "checksum": "0863e33a75a18240c6547219ef693220aa699ef7116462ba7ebb0a265630478f"
     }
   },
   {

--- a/metadata/component-libraries/lint-rules/chart-js/check-canvas-container.js
+++ b/metadata/component-libraries/lint-rules/chart-js/check-canvas-container.js
@@ -1,0 +1,99 @@
+/**
+ * Validate that the Chart.js canvas parent container has position: 'relative'
+ * and an explicit height. Without these, Chart.js renders into a 0-height or
+ * collapsed container, producing a blank canvas.
+ *
+ * @param {Object} ast - The full AST
+ * @param {Object} path - Current node path being validated
+ * @param {Object} t - Babel types
+ * @param {Object} context - Additional context with libraryName, globalVariable, instanceVariables
+ * @returns {Object|null} Violation object or null if valid
+ */
+(ast, path, t, context) => {
+  // Only trigger on <canvas> JSXOpeningElements that have a ref attribute
+  if (!t.isJSXOpeningElement(path.node) ||
+      !t.isJSXIdentifier(path.node.name) ||
+      path.node.name.name !== 'canvas') {
+    return null;
+  }
+
+  const hasRef = path.node.attributes.some(attr =>
+    t.isJSXAttribute(attr) &&
+    t.isJSXIdentifier(attr.name) &&
+    attr.name.name === 'ref'
+  );
+
+  if (!hasRef) return null;
+
+  // Walk up from the canvas JSXElement to find the nearest parent JSXElement
+  // path is JSXOpeningElement -> parentPath is the canvas JSXElement
+  let walker = path.parentPath?.parentPath;
+  let parentJSX = null;
+  while (walker) {
+    if (t.isJSXElement(walker.node)) {
+      parentJSX = walker;
+      break;
+    }
+    walker = walker.parentPath;
+  }
+
+  if (!parentJSX) return null;
+
+  const openingEl = parentJSX.node.openingElement;
+
+  // Extract the ObjectExpression from an inline style={{ ... }} attribute
+  const styleAttr = openingEl.attributes.find(attr =>
+    t.isJSXAttribute(attr) &&
+    t.isJSXIdentifier(attr.name) &&
+    attr.name.name === 'style'
+  );
+
+  if (!styleAttr ||
+      !t.isJSXExpressionContainer(styleAttr.value) ||
+      !t.isObjectExpression(styleAttr.value.expression)) {
+    // No inline style object at all
+    return {
+      rule: 'chart-canvas-container',
+      severity: 'high',
+      message: "Chart.js canvas container must have an inline style with position: 'relative' and explicit height",
+      line: openingEl.loc?.start.line || 0,
+      column: openingEl.loc?.start.column || 0,
+      fix: "<div style={{ position: 'relative', width: '100%', height: '300px' }}>"
+    };
+  }
+
+  const styleObj = styleAttr.value.expression;
+
+  // Check for position: 'relative'
+  const hasPosition = styleObj.properties.some(prop =>
+    t.isObjectProperty(prop) &&
+    t.isIdentifier(prop.key) &&
+    prop.key.name === 'position' &&
+    t.isStringLiteral(prop.value) &&
+    prop.value.value === 'relative'
+  );
+
+  // Check for explicit height (any value type is fine — string, number, expression)
+  const hasHeight = styleObj.properties.some(prop =>
+    t.isObjectProperty(prop) &&
+    t.isIdentifier(prop.key) &&
+    prop.key.name === 'height'
+  );
+
+  const missing = [];
+  if (!hasPosition) missing.push("position: 'relative'");
+  if (!hasHeight) missing.push("explicit height (e.g. height: '300px')");
+
+  if (missing.length > 0) {
+    return {
+      rule: 'chart-canvas-container',
+      severity: 'high',
+      message: `Chart.js canvas container is missing ${missing.join(' and ')}. Without these the chart renders as a blank/collapsed canvas.`,
+      line: openingEl.loc?.start.line || 0,
+      column: openingEl.loc?.start.column || 0,
+      fix: "<div style={{ position: 'relative', width: '100%', height: '300px' }}>"
+    };
+  }
+
+  return null;
+}

--- a/metadata/component-libraries/lint-rules/chart-js/lint.json
+++ b/metadata/component-libraries/lint-rules/chart-js/lint.json
@@ -25,6 +25,11 @@
       "description": "Check for Chart.register() when using tree-shaking",
       "severity": "medium",
       "validate": "@file:check-chart-registration.js"
+    },
+    "checkCanvasContainer": {
+      "description": "Validate canvas parent has position: relative and explicit height for Chart.js rendering",
+      "severity": "high",
+      "validate": "@file:check-canvas-container.js"
     }
   }
 }

--- a/metadata/components/.components.json
+++ b/metadata/components/.components.json
@@ -1781,8 +1781,8 @@
       "ID": "21A95BC1-2CCD-4949-A90F-4262F1DBDB62"
     },
     "sync": {
-      "lastModified": "2026-04-27T18:51:33.619Z",
-      "checksum": "686a19cff9feee9379a1a8b02cb33e7f9d780db893d6e9403795b21ea8d2debb"
+      "lastModified": "2026-04-28T18:26:37.543Z",
+      "checksum": "a18e83a5c7764fbe91f8b8fa178556ddcec8c7e88acc5ef0d4db95766c554c66"
     }
   },
   {

--- a/metadata/components/code/generic/simple-chart.js
+++ b/metadata/components/code/generic/simple-chart.js
@@ -105,7 +105,7 @@ function SimpleChart({
   // Process and aggregate data
   const processData = React.useMemo(() => {
     if (!data || !Array.isArray(data) || data.length === 0) {
-      return { chartData: [], categories: [], values: [], datasets: [], isEmpty: true };
+      return { chartData: [], categories: [], values: [], datasets: [], isEmpty: true, isDateField: false };
     }
 
     try {
@@ -117,21 +117,21 @@ function SimpleChart({
           const error = `Field "${groupBy}" not found in data. Available fields: ${Object.keys(data[0]).join(', ')}`;
           console.error(error);
           setError(error);
-          return { chartData: [], categories: [], values: [], datasets: [], isEmpty: true };
+          return { chartData: [], categories: [], values: [], datasets: [], isEmpty: true, isDateField: false };
         }
 
         if (stackBy && !(stackBy in data[0])) {
           const error = `Stack field "${stackBy}" not found in data. Available fields: ${Object.keys(data[0]).join(', ')}`;
           console.error(error);
           setError(error);
-          return { chartData: [], categories: [], values: [], datasets: [], isEmpty: true };
+          return { chartData: [], categories: [], values: [], datasets: [], isEmpty: true, isDateField: false };
         }
 
         if (valueField && !(valueField in data[0])) {
           const error = `Value field "${valueField}" not found in data. Available fields: ${Object.keys(data[0]).join(', ')}`;
           console.error(error);
           setError(error);
-          return { chartData: [], categories: [], values: [], datasets: [], isEmpty: true };
+          return { chartData: [], categories: [], values: [], datasets: [], isEmpty: true, isDateField: false };
         }
       }
 
@@ -147,7 +147,7 @@ function SimpleChart({
         const sampleValue = data[0][groupBy];
         isDateField = sampleValue && (
           sampleValue instanceof Date ||
-          (typeof sampleValue === 'string' && !isNaN(Date.parse(sampleValue)))
+          (typeof sampleValue === 'string' && sampleValue.length >= 8 && !isNaN(Date.parse(sampleValue)))
         );
       }
 
@@ -156,13 +156,7 @@ function SimpleChart({
         // Collect all unique primary categories (X-axis)
         const categoriesSet = new Set();
         data.forEach(record => {
-          let key = record[groupBy] || 'Unknown';
-          if (isDateField && key !== 'Unknown') {
-            const date = new Date(key);
-            if (!isNaN(date.getTime())) {
-              key = date.toISOString().split('T')[0];
-            }
-          }
+          const key = record[groupBy] || 'Unknown';
           categoriesSet.add(key);
         });
 
@@ -192,13 +186,7 @@ function SimpleChart({
         // Group data by both primary category AND stack value
         const grouped = {};
         data.forEach(record => {
-          let categoryKey = record[groupBy] || 'Unknown';
-          if (isDateField && categoryKey !== 'Unknown') {
-            const date = new Date(categoryKey);
-            if (!isNaN(date.getTime())) {
-              categoryKey = date.toISOString().split('T')[0];
-            }
-          }
+          const categoryKey = record[groupBy] || 'Unknown';
 
           // Skip if category was filtered out by limit
           if (!categories.includes(categoryKey)) return;
@@ -270,7 +258,8 @@ function SimpleChart({
           categories: categories.map(c => String(c)),
           values: [], // Not used in stacked mode
           datasets: datasets,
-          isEmpty: false
+          isEmpty: false,
+          isDateField
         };
       }
 
@@ -278,17 +267,8 @@ function SimpleChart({
       const grouped = {};
 
       data.forEach(record => {
-        let key = record[groupBy] || 'Unknown';
-        
-        // Format date values for display
-        if (isDateField && key !== 'Unknown') {
-          const date = new Date(key);
-          if (!isNaN(date.getTime())) {
-            // Format as YYYY-MM-DD for grouping
-            key = date.toISOString().split('T')[0];
-          }
-        }
-        
+        const key = record[groupBy] || 'Unknown';
+
         if (!grouped[key]) {
           grouped[key] = {
             label: key,
@@ -361,12 +341,13 @@ function SimpleChart({
         categories,
         values,
         datasets: [], // Empty in non-stacked mode
-        isEmpty: false
+        isEmpty: false,
+        isDateField
       };
     } catch (err) {
       console.error('Error processing chart data:', err);
       setError(err.message);
-      return { chartData: [], categories: [], values: [], datasets: [], isEmpty: true };
+      return { chartData: [], categories: [], values: [], datasets: [], isEmpty: true, isDateField: false };
     }
   }, [data, groupBy, stackBy, valueField, aggregateMethod, sortBy, sortOrder, limit, entityInfo]);
 
@@ -392,7 +373,7 @@ function SimpleChart({
       const sampleValue = data[0][groupBy];
       isDateField = sampleValue && (
         sampleValue instanceof Date ||
-        (typeof sampleValue === 'string' && !isNaN(Date.parse(sampleValue)))
+        (typeof sampleValue === 'string' && sampleValue.length >= 8 && !isNaN(Date.parse(sampleValue)))
       );
     }
     
@@ -604,6 +585,16 @@ function SimpleChart({
             usePointStyle: true,
             boxPadding: 6,
             callbacks: {
+              title: (tooltipItems) => {
+                const raw = tooltipItems[0]?.label || '';
+                if (processData.isDateField && raw !== 'Unknown') {
+                  const date = new Date(raw);
+                  if (!isNaN(date.getTime())) {
+                    return date.toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' });
+                  }
+                }
+                return raw;
+              },
               label: (context) => {
                 const label = context.dataset.label || '';
                 const value = formatValue(context.parsed.y !== undefined ? context.parsed.y : context.parsed);
@@ -646,6 +637,13 @@ function SimpleChart({
             },
             callback: function(value) {
               const label = this.getLabelForValue(value);
+              // Format date values for display on the axis
+              if (processData.isDateField && typeof label === 'string' && label !== 'Unknown') {
+                const date = new Date(label);
+                if (!isNaN(date.getTime())) {
+                  return date.toISOString().split('T')[0];
+                }
+              }
               if (typeof label === 'string' && label.length > 18) {
                 return label.substring(0, 16) + '…';
               }

--- a/packages/MJCore/src/__tests__/sqlLikeFilters.test.ts
+++ b/packages/MJCore/src/__tests__/sqlLikeFilters.test.ts
@@ -27,12 +27,24 @@ describe('sqlLike filters', () => {
                 expect(manager.executeFilter('sqlLikeContains', "O'Brien")).toBe("'%O''Brien%'");
             });
 
-            it('should escape literal % with bracket syntax', () => {
-                expect(manager.executeFilter('sqlLikeContains', '100%')).toBe("'%100[%]%'");
+            it('should strip and not escape boundary % wildcards', () => {
+                expect(manager.executeFilter('sqlLikeContains', '100%')).toBe("'%100%'");
             });
 
             it('should escape literal _ with bracket syntax', () => {
                 expect(manager.executeFilter('sqlLikeContains', 'first_name')).toBe("'%first[_]name%'");
+            });
+
+            it('should escape interior % with bracket syntax', () => {
+                expect(manager.executeFilter('sqlLikeContains', '50% off 100% items')).toBe("'%50[%] off 100[%] items%'");
+            });
+
+            it('should strip leading and trailing % wildcards from value', () => {
+                expect(manager.executeFilter('sqlLikeContains', '%Leadership%')).toBe("'%Leadership%'");
+            });
+
+            it('should strip multiple leading and trailing % wildcards', () => {
+                expect(manager.executeFilter('sqlLikeContains', '%%Leadership%%')).toBe("'%Leadership%'");
             });
 
             it('should handle empty string', () => {
@@ -61,8 +73,12 @@ describe('sqlLike filters', () => {
                 expect(manager.executeFilter('sqlLikeBegins', "O'Brien")).toBe("'O''Brien%'");
             });
 
-            it('should escape literal % with bracket syntax', () => {
-                expect(manager.executeFilter('sqlLikeBegins', '100%')).toBe("'100[%]%'");
+            it('should strip trailing % wildcard from value', () => {
+                expect(manager.executeFilter('sqlLikeBegins', 'Leadership%')).toBe("'Leadership%'");
+            });
+
+            it('should preserve leading % as literal and escape it', () => {
+                expect(manager.executeFilter('sqlLikeBegins', '%Leadership')).toBe("'[%]Leadership%'");
             });
 
             it('should escape literal _ with bracket syntax', () => {
@@ -87,7 +103,11 @@ describe('sqlLike filters', () => {
                 expect(manager.executeFilter('sqlLikeEnds', "O'Brien")).toBe("'%O''Brien'");
             });
 
-            it('should escape literal % with bracket syntax', () => {
+            it('should strip leading % wildcard from value', () => {
+                expect(manager.executeFilter('sqlLikeEnds', '%Conference')).toBe("'%Conference'");
+            });
+
+            it('should preserve trailing % as literal and escape it', () => {
                 expect(manager.executeFilter('sqlLikeEnds', '100%')).toBe("'%100[%]'");
             });
 
@@ -115,8 +135,16 @@ describe('sqlLike filters', () => {
                 expect(manager.executeFilter('sqlLikeContains', "O'Brien")).toBe("'%O''Brien%'");
             });
 
-            it('should escape literal % with backslash syntax', () => {
-                expect(manager.executeFilter('sqlLikeContains', '100%')).toBe("'%100\\%%'");
+            it('should strip and not escape boundary % wildcards', () => {
+                expect(manager.executeFilter('sqlLikeContains', '100%')).toBe("'%100%'");
+            });
+
+            it('should escape interior % with backslash syntax', () => {
+                expect(manager.executeFilter('sqlLikeContains', '50% off 100% items')).toBe("'%50\\% off 100\\% items%'");
+            });
+
+            it('should strip leading and trailing % wildcards from value', () => {
+                expect(manager.executeFilter('sqlLikeContains', '%Leadership%')).toBe("'%Leadership%'");
             });
 
             it('should escape literal _ with backslash syntax', () => {
@@ -129,8 +157,12 @@ describe('sqlLike filters', () => {
                 expect(manager.executeFilter('sqlLikeBegins', 'Leadership')).toBe("'Leadership%'");
             });
 
-            it('should escape literal % with backslash syntax', () => {
-                expect(manager.executeFilter('sqlLikeBegins', '100%')).toBe("'100\\%%'");
+            it('should strip trailing % wildcard from value', () => {
+                expect(manager.executeFilter('sqlLikeBegins', 'Leadership%')).toBe("'Leadership%'");
+            });
+
+            it('should preserve leading % as literal and escape it', () => {
+                expect(manager.executeFilter('sqlLikeBegins', '%Leadership')).toBe("'\\%Leadership%'");
             });
 
             it('should escape literal _ with backslash syntax', () => {
@@ -143,7 +175,11 @@ describe('sqlLike filters', () => {
                 expect(manager.executeFilter('sqlLikeEnds', 'Conference')).toBe("'%Conference'");
             });
 
-            it('should escape literal % with backslash syntax', () => {
+            it('should strip leading % wildcard from value', () => {
+                expect(manager.executeFilter('sqlLikeEnds', '%Conference')).toBe("'%Conference'");
+            });
+
+            it('should preserve trailing % as literal and escape it', () => {
                 expect(manager.executeFilter('sqlLikeEnds', '100%')).toBe("'%100\\%'");
             });
 

--- a/packages/MJCore/src/generic/runQuerySQLFilterImplementations.ts
+++ b/packages/MJCore/src/generic/runQuerySQLFilterImplementations.ts
@@ -148,20 +148,20 @@ const FILTER_IMPLEMENTATIONS: Record<string, (value: any) => any> = {
     
     sqlLikeContains: (value: any) => {
         if (value === null || value === undefined) return 'NULL';
-        const escaped = String(value).replace(/'/g, "''").replace(/%/g, '[%]').replace(/_/g, '[_]');
-        return `'%${escaped}%'`;
+        const stripped = stripBoundaryWildcards(String(value), 'both');
+        return `'%${escapeLikeValue(stripped, 'sqlserver')}%'`;
     },
 
     sqlLikeBegins: (value: any) => {
         if (value === null || value === undefined) return 'NULL';
-        const escaped = String(value).replace(/'/g, "''").replace(/%/g, '[%]').replace(/_/g, '[_]');
-        return `'${escaped}%'`;
+        const stripped = stripBoundaryWildcards(String(value), 'trailing');
+        return `'${escapeLikeValue(stripped, 'sqlserver')}%'`;
     },
 
     sqlLikeEnds: (value: any) => {
         if (value === null || value === undefined) return 'NULL';
-        const escaped = String(value).replace(/'/g, "''").replace(/%/g, '[%]').replace(/_/g, '[_]');
-        return `'%${escaped}'`;
+        const stripped = stripBoundaryWildcards(String(value), 'leading');
+        return `'%${escapeLikeValue(stripped, 'sqlserver')}'`;
     },
 
     sqlNoKeywordsExpression: (value: any) => {
@@ -263,6 +263,25 @@ function createPlatformSqlIdentifier(platform: DatabasePlatform): (value: unknow
 }
 
 /**
+ * Strips leading and/or trailing SQL LIKE wildcard characters (%) from a value.
+ * The sqlLike* filters add their own wildcards, so any user-supplied wildcards at
+ * the boundaries are redundant and cause double-wrapping bugs (e.g. '%[%]value[%]%').
+ *
+ * @param value  The raw parameter value
+ * @param side   Which boundary to strip: 'leading', 'trailing', or 'both'
+ */
+function stripBoundaryWildcards(value: string, side: 'leading' | 'trailing' | 'both'): string {
+    switch (side) {
+        case 'leading':
+            return value.replace(/^%+/, '');
+        case 'trailing':
+            return value.replace(/%+$/, '');
+        case 'both':
+            return value.replace(/^%+/, '').replace(/%+$/, '');
+    }
+}
+
+/**
  * Escapes literal % and _ characters inside a LIKE value in a platform-aware way.
  * SQL Server uses bracket escaping [%] [_]; PostgreSQL uses backslash escaping \% \_.
  */
@@ -281,21 +300,24 @@ function escapeLikeValue(value: string, platform: DatabasePlatform): string {
 function createPlatformSqlLikeContains(platform: DatabasePlatform): (value: any) => string {
     return (value: any) => {
         if (value === null || value === undefined) return 'NULL';
-        return `'%${escapeLikeValue(String(value), platform)}%'`;
+        const stripped = stripBoundaryWildcards(String(value), 'both');
+        return `'%${escapeLikeValue(stripped, platform)}%'`;
     };
 }
 
 function createPlatformSqlLikeBegins(platform: DatabasePlatform): (value: any) => string {
     return (value: any) => {
         if (value === null || value === undefined) return 'NULL';
-        return `'${escapeLikeValue(String(value), platform)}%'`;
+        const stripped = stripBoundaryWildcards(String(value), 'trailing');
+        return `'${escapeLikeValue(stripped, platform)}%'`;
     };
 }
 
 function createPlatformSqlLikeEnds(platform: DatabasePlatform): (value: any) => string {
     return (value: any) => {
         if (value === null || value === undefined) return 'NULL';
-        return `'%${escapeLikeValue(String(value), platform)}'`;
+        const stripped = stripBoundaryWildcards(String(value), 'leading');
+        return `'%${escapeLikeValue(stripped, platform)}'`;
     };
 }
 

--- a/packages/MJCoreEntitiesServer/src/__tests__/MJQueryEntityServer.test.ts
+++ b/packages/MJCoreEntitiesServer/src/__tests__/MJQueryEntityServer.test.ts
@@ -1686,3 +1686,39 @@ WHERE a.IsPersonAccount = 1
         expect(params[0].isRequired).toBe(true);
     });
 });
+
+// ═══════════════════════════════════════════════════
+// NormalizeDefaultForType (enrich.ts)
+// Ensures array-typed parameter defaults are valid JSON arrays.
+// ═══════════════════════════════════════════════════
+
+import { NormalizeDefaultForType } from '../custom/query-extraction/enrich';
+
+describe('NormalizeDefaultForType', () => {
+    it('should pass through non-array types unchanged', () => {
+        expect(NormalizeDefaultForType('hello', 'string')).toBe('hello');
+        expect(NormalizeDefaultForType('42', 'number')).toBe('42');
+        expect(NormalizeDefaultForType('true', 'boolean')).toBe('true');
+    });
+
+    it('should pass through valid JSON array strings for array type', () => {
+        expect(NormalizeDefaultForType('["a","b"]', 'array')).toBe('["a","b"]');
+        expect(NormalizeDefaultForType('[1,2,3]', 'array')).toBe('[1,2,3]');
+    });
+
+    it('should wrap plain string in JSON array for array type', () => {
+        expect(NormalizeDefaultForType('Attended', 'array')).toBe('["Attended"]');
+        expect(NormalizeDefaultForType('Active', 'array')).toBe('["Active"]');
+    });
+
+    it('should wrap non-array JSON value in array for array type', () => {
+        expect(NormalizeDefaultForType('42', 'array')).toBe('[42]');
+        expect(NormalizeDefaultForType('"hello"', 'array')).toBe('["hello"]');
+    });
+
+    it('should handle JSON object default by wrapping in array', () => {
+        const obj = '{"key":"value"}';
+        const result = NormalizeDefaultForType(obj, 'array');
+        expect(JSON.parse(result)).toEqual([{ key: 'value' }]);
+    });
+});

--- a/packages/MJCoreEntitiesServer/src/custom/query-extraction/enrich.ts
+++ b/packages/MJCoreEntitiesServer/src/custom/query-extraction/enrich.ts
@@ -178,15 +178,44 @@ function ResolveParameterType(
 
 /**
  * Resolves the default value, preferring the deterministic value over LLM.
+ * For array-typed parameters, ensures the default is a valid JSON array string
+ * so downstream consumers (e.g., queryParameterProcessor) can parse it safely.
  */
 function ResolveDefaultValue(
     dp: MJParameterInfo,
     llmMatch: ExtractedParameter | undefined,
 ): string | null {
-    if (dp.defaultValue !== null) {
-        return String(dp.defaultValue);
+    const raw = dp.defaultValue !== null
+        ? String(dp.defaultValue)
+        : (llmMatch?.defaultValue ?? null);
+
+    if (raw === null) return null;
+
+    return NormalizeDefaultForType(raw, dp.type === 'unknown' ? (llmMatch?.type ?? 'string') : dp.type);
+}
+
+/**
+ * Normalizes a raw default value string based on the parameter type.
+ * For array types, ensures the value is a valid JSON array string.
+ * Plain strings like "Attended" become '["Attended"]'; already-valid
+ * JSON arrays like '["a","b"]' pass through unchanged.
+ */
+export function NormalizeDefaultForType(
+    rawDefault: string,
+    paramType: string,
+): string {
+    if (paramType !== 'array') return rawDefault;
+
+    // Already a valid JSON array? Pass through.
+    try {
+        const parsed = JSON.parse(rawDefault);
+        if (Array.isArray(parsed)) return rawDefault;
+        // Parsed to a non-array (e.g., a number or string) — wrap it
+        return JSON.stringify([parsed]);
+    } catch {
+        // Not valid JSON (e.g., "Attended") — wrap as single-element array
+        return JSON.stringify([rawDefault]);
     }
-    return llmMatch?.defaultValue ?? null;
 }
 
 /**

--- a/packages/QueryProcessor/src/__tests__/queryParameterProcessor.test.ts
+++ b/packages/QueryProcessor/src/__tests__/queryParameterProcessor.test.ts
@@ -203,62 +203,38 @@ describe('QueryParameterProcessor.validateParameters', () => {
     });
   });
 
-  describe('default value handling', () => {
-    it('should apply default value when parameter is not provided', () => {
+  describe('default value handling (metadata only — not injected)', () => {
+    // DefaultValue is informational metadata. The SQL template handles defaults
+    // via {% else %} blocks or | default() filters. The processor does NOT inject
+    // DefaultValue into the template context.
+
+    it('should NOT inject default values — they are metadata only', () => {
       const defs = [makeParamDef({ Name: 'limit', Type: 'number', DefaultValue: '100' })];
       const result = QueryParameterProcessor.validateParameters({}, defs as never[]);
       expect(result.success).toBe(true);
-      expect(result.validatedParameters.limit).toBe(100);
+      expect(result.validatedParameters.limit).toBeUndefined();
     });
 
-    it('should apply string default value', () => {
-      const defs = [makeParamDef({ Name: 'status', Type: 'string', DefaultValue: 'active' })];
+    it('should succeed when optional param with SQL expression default is absent', () => {
+      // GETDATE() is a SQL function — the template handles it via {% else %}
+      const defs = [makeParamDef({ Name: 'RefDate', Type: 'date', DefaultValue: 'GETDATE()' })];
       const result = QueryParameterProcessor.validateParameters({}, defs as never[]);
       expect(result.success).toBe(true);
-      expect(result.validatedParameters.status).toBe('active');
+      expect(result.validatedParameters.RefDate).toBeUndefined();
     });
 
-    it('should apply boolean default value (SQL Server)', () => {
-      const defs = [makeParamDef({ Name: 'flag', Type: 'boolean', DefaultValue: 'true' })];
+    it('should succeed when optional param with SQL IN-list default is absent', () => {
+      const defs = [makeParamDef({ Name: 'statuses', Type: 'array', DefaultValue: "('Cancelled', 'Refunded')" })];
       const result = QueryParameterProcessor.validateParameters({}, defs as never[]);
       expect(result.success).toBe(true);
-      expect(result.validatedParameters.flag).toBe(1);
+      expect(result.validatedParameters.statuses).toBeUndefined();
     });
 
-    it('should apply boolean default value (PostgreSQL)', () => {
-      RunQuerySQLFilterManager.Instance.SetPlatform('postgresql');
-      const defs = [makeParamDef({ Name: 'flag', Type: 'boolean', DefaultValue: 'true' })];
-      const result = QueryParameterProcessor.validateParameters({}, defs as never[]);
-      expect(result.success).toBe(true);
-      expect(result.validatedParameters.flag).toBe(true);
-    });
-
-    it('should prefer provided value over default', () => {
+    it('should still validate and use explicitly provided values', () => {
       const defs = [makeParamDef({ Name: 'limit', Type: 'number', DefaultValue: '100' })];
       const result = QueryParameterProcessor.validateParameters({ limit: 50 }, defs as never[]);
       expect(result.success).toBe(true);
       expect(result.validatedParameters.limit).toBe(50);
-    });
-
-    it('should parse valid JSON array default for array type', () => {
-      const defs = [makeParamDef({ Name: 'tags', Type: 'array', DefaultValue: '["a","b"]' })];
-      const result = QueryParameterProcessor.validateParameters({}, defs as never[]);
-      expect(result.success).toBe(true);
-      expect(result.validatedParameters.tags).toEqual(['a', 'b']);
-    });
-
-    it('should wrap plain string default in array for array type', () => {
-      const defs = [makeParamDef({ Name: 'status', Type: 'array', DefaultValue: 'Attended' })];
-      const result = QueryParameterProcessor.validateParameters({}, defs as never[]);
-      expect(result.success).toBe(true);
-      expect(result.validatedParameters.status).toEqual(['Attended']);
-    });
-
-    it('should wrap non-array JSON default in array for array type', () => {
-      const defs = [makeParamDef({ Name: 'code', Type: 'array', DefaultValue: '42' })];
-      const result = QueryParameterProcessor.validateParameters({}, defs as never[]);
-      expect(result.success).toBe(true);
-      expect(result.validatedParameters.code).toEqual([42]);
     });
   });
 

--- a/packages/QueryProcessor/src/__tests__/queryParameterProcessor.test.ts
+++ b/packages/QueryProcessor/src/__tests__/queryParameterProcessor.test.ts
@@ -239,6 +239,27 @@ describe('QueryParameterProcessor.validateParameters', () => {
       expect(result.success).toBe(true);
       expect(result.validatedParameters.limit).toBe(50);
     });
+
+    it('should parse valid JSON array default for array type', () => {
+      const defs = [makeParamDef({ Name: 'tags', Type: 'array', DefaultValue: '["a","b"]' })];
+      const result = QueryParameterProcessor.validateParameters({}, defs as never[]);
+      expect(result.success).toBe(true);
+      expect(result.validatedParameters.tags).toEqual(['a', 'b']);
+    });
+
+    it('should wrap plain string default in array for array type', () => {
+      const defs = [makeParamDef({ Name: 'status', Type: 'array', DefaultValue: 'Attended' })];
+      const result = QueryParameterProcessor.validateParameters({}, defs as never[]);
+      expect(result.success).toBe(true);
+      expect(result.validatedParameters.status).toEqual(['Attended']);
+    });
+
+    it('should wrap non-array JSON default in array for array type', () => {
+      const defs = [makeParamDef({ Name: 'code', Type: 'array', DefaultValue: '42' })];
+      const result = QueryParameterProcessor.validateParameters({}, defs as never[]);
+      expect(result.success).toBe(true);
+      expect(result.validatedParameters.code).toEqual([42]);
+    });
   });
 
   describe('unknown parameters', () => {

--- a/packages/QueryProcessor/src/queryParameterProcessor.ts
+++ b/packages/QueryProcessor/src/queryParameterProcessor.ts
@@ -122,39 +122,13 @@ export class QueryParameterProcessor {
                 continue;
             }
 
-            // Use default value if not provided
-            let finalValue = value;
-            if ((finalValue === undefined || finalValue === null) && paramDef.DefaultValue !== null) {
-                try {
-                    // Parse default value based on type
-                    switch (paramDef.Type) {
-                        case 'number':
-                            finalValue = Number(paramDef.DefaultValue);
-                            break;
-                        case 'boolean':
-                            finalValue = paramDef.DefaultValue.toLowerCase() === 'true';
-                            break;
-                        case 'date':
-                            finalValue = new Date(paramDef.DefaultValue);
-                            break;
-                        case 'array':
-                            try {
-                                const parsed = JSON.parse(paramDef.DefaultValue);
-                                finalValue = Array.isArray(parsed) ? parsed : [parsed];
-                            } catch {
-                                // Plain string default (e.g., "Attended") — wrap in array
-                                finalValue = [paramDef.DefaultValue];
-                            }
-                            break;
-                        default:
-                            finalValue = paramDef.DefaultValue;
-                    }
-                } catch (e: unknown) {
-                    const msg = e instanceof Error ? e.message : String(e);
-                    errors.push(`Failed to parse default value for parameter '${paramDef.Name}': ${msg}`);
-                    continue;
-                }
-            }
+            // DefaultValue is informational metadata only — it is NOT injected into
+            // the template context. The SQL template is the single source of truth for
+            // default behavior via {% else %} blocks or Nunjucks | default() filters.
+            // Attempting to parse DefaultValue as JavaScript caused a class of bugs
+            // where SQL expressions (GETDATE(), ('Cancelled','Refunded'), etc.) were
+            // rejected by the JS type parser.
+            const finalValue = value;
 
             // Type conversion and validation
             if (finalValue !== undefined && finalValue !== null) {

--- a/packages/QueryProcessor/src/queryParameterProcessor.ts
+++ b/packages/QueryProcessor/src/queryParameterProcessor.ts
@@ -138,7 +138,13 @@ export class QueryParameterProcessor {
                             finalValue = new Date(paramDef.DefaultValue);
                             break;
                         case 'array':
-                            finalValue = JSON.parse(paramDef.DefaultValue);
+                            try {
+                                const parsed = JSON.parse(paramDef.DefaultValue);
+                                finalValue = Array.isArray(parsed) ? parsed : [parsed];
+                            } catch {
+                                // Plain string default (e.g., "Attended") — wrap in array
+                                finalValue = [paramDef.DefaultValue];
+                            }
                             break;
                         default:
                             finalValue = paramDef.DefaultValue;

--- a/packages/React/test-harness/src/__tests__/component-linter/chart-canvas-container.test.ts
+++ b/packages/React/test-harness/src/__tests__/component-linter/chart-canvas-container.test.ts
@@ -1,0 +1,297 @@
+/**
+ * Chart.js Canvas Container Lint Rule Tests
+ *
+ * Tests the `check-canvas-container.js` library validator which ensures that
+ * the parent element of a Chart.js <canvas> has `position: 'relative'` and
+ * an explicit height — both required for Chart.js to render correctly.
+ *
+ * Requires a database connection (for contextUser when linting with libraries).
+ */
+
+import { describe, it, expect, beforeAll } from 'vitest';
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+import { ComponentLinter } from '../../lib/component-linter';
+import { LibraryLintCache } from '../../lib/library-lint-cache';
+import { ComponentSpec } from '@memberjunction/interactive-component-types';
+import { UserInfo } from '@memberjunction/core';
+import { UserCache } from '@memberjunction/sqlserver-dataprovider';
+
+// ═══════════════════════════════════════════════════════════════════════════
+// Setup
+// ═══════════════════════════════════════════════════════════════════════════
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const DB_AVAILABLE = process.env.__MJ_DB_AVAILABLE === 'true';
+
+/** Resolve the validator source from the metadata directory */
+function loadValidatorSource(filename: string): string {
+  const filePath = path.resolve(
+    __dirname,
+    '../../../../../../metadata/component-libraries/lint-rules/chart-js',
+    filename,
+  );
+  return fs.readFileSync(filePath, 'utf-8');
+}
+
+function getContextUser(): UserInfo | undefined {
+  if (!DB_AVAILABLE) return undefined;
+  try {
+    const user = UserCache.Instance.UserByName('System', false);
+    return user || UserCache.Instance.Users?.[0] || undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+/** Base component spec with Chart.js as a library dependency */
+const chartSpec: ComponentSpec = {
+  name: 'ChartComponent',
+  type: 'chart' as const,
+  title: 'Test Chart',
+  description: 'Test component for Chart.js canvas container validation',
+  code: '',
+  location: 'embedded' as const,
+  functionalRequirements: 'Render a chart',
+  technicalDesign: 'Uses Chart.js directly',
+  exampleUsage: '<ChartComponent />',
+  dataRequirements: {
+    mode: 'queries' as const,
+    queries: [
+      {
+        name: 'ChartData',
+        categoryPath: 'Test',
+        fields: [],
+        entityNames: [],
+      },
+    ],
+    entities: [],
+  },
+  libraries: [{ name: 'Chart.js', globalVariable: 'Chart' }],
+} as ComponentSpec;
+
+// The rule name that the linter assigns to library validator violations
+const VIOLATION_RULE = 'chart.js-validator';
+
+/** Common Chart.js useEffect boilerplate shared across test cases */
+const CHART_EFFECT = `
+  React.useEffect(() => {
+    if (canvasRef.current) {
+      const chart = new Chart(canvasRef.current, {
+        type: 'bar',
+        data: { labels: ['A'], datasets: [{ data: [1] }] },
+      });
+      return () => { chart.destroy(); };
+    }
+  }, []);`;
+
+/** Build a complete component with the given JSX return block */
+function makeComponent(jsxReturn: string): string {
+  return `
+    function ChartComponent({ utilities }) {
+      const canvasRef = React.useRef(null);
+      ${CHART_EFFECT}
+      return (
+        ${jsxReturn}
+      );
+    }
+  `;
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// Tests
+// ═══════════════════════════════════════════════════════════════════════════
+
+describe('Chart.js Canvas Container Lint Rule', () => {
+  beforeAll(() => {
+    // Load the validator JS from the file system and inject into the cache
+    const validatorSource = loadValidatorSource('check-canvas-container.js');
+
+    const cache = LibraryLintCache.getInstance();
+    cache.clearCache();
+    cache.addTestLibraryRules('Chart.js', {
+      initialization: {
+        constructorName: 'Chart',
+        requiresNew: true,
+        elementType: 'canvas',
+        requiredConfig: ['type', 'data'],
+      },
+      lifecycle: {
+        cleanupMethods: ['destroy'],
+        updateMethods: ['update'],
+        requiredMethods: [],
+      },
+      validators: {
+        checkCanvasContainer: {
+          description:
+            'Validate canvas parent has position: relative and explicit height for Chart.js rendering',
+          severity: 'high',
+          validate: validatorSource,
+        },
+      },
+    });
+  });
+
+  // ─────────────────────────────────────────────────────────────────────────
+  // Violation cases
+  // ─────────────────────────────────────────────────────────────────────────
+
+  it('should flag canvas container with NO style attribute', async () => {
+    if (!DB_AVAILABLE) return;
+    const contextUser = getContextUser();
+
+    const code = makeComponent(`
+      <div>
+        <canvas ref={canvasRef} />
+      </div>
+    `);
+
+    const result = await ComponentLinter.lintComponent(
+      code, 'ChartComponent', chartSpec, true, contextUser,
+    );
+
+    const violations = result.violations.filter(
+      v => v.rule === VIOLATION_RULE && v.message.includes('canvas container'),
+    );
+    expect(violations.length).toBeGreaterThanOrEqual(1);
+    expect(violations[0].severity).toBe('high');
+    expect(violations[0].message).toContain("position: 'relative'");
+  });
+
+  it('should flag canvas container missing position: relative (has height only)', async () => {
+    if (!DB_AVAILABLE) return;
+    const contextUser = getContextUser();
+
+    const code = makeComponent(`
+      <div style={{ width: '100%', height: '300px' }}>
+        <canvas ref={canvasRef} />
+      </div>
+    `);
+
+    const result = await ComponentLinter.lintComponent(
+      code, 'ChartComponent', chartSpec, true, contextUser,
+    );
+
+    const violations = result.violations.filter(
+      v => v.rule === VIOLATION_RULE && v.message.includes('canvas container'),
+    );
+    expect(violations.length).toBeGreaterThanOrEqual(1);
+    expect(violations[0].message).toContain("position: 'relative'");
+    expect(violations[0].message).not.toContain('height');
+  });
+
+  it('should flag canvas container missing explicit height (has position only)', async () => {
+    if (!DB_AVAILABLE) return;
+    const contextUser = getContextUser();
+
+    const code = makeComponent(`
+      <div style={{ width: '100%', position: 'relative' }}>
+        <canvas ref={canvasRef} />
+      </div>
+    `);
+
+    const result = await ComponentLinter.lintComponent(
+      code, 'ChartComponent', chartSpec, true, contextUser,
+    );
+
+    const violations = result.violations.filter(
+      v => v.rule === VIOLATION_RULE && v.message.includes('canvas container'),
+    );
+    expect(violations.length).toBeGreaterThanOrEqual(1);
+    expect(violations[0].message).toContain('height');
+    expect(violations[0].message).not.toContain("position: 'relative'");
+  });
+
+  it('should flag canvas container missing BOTH position and height', async () => {
+    if (!DB_AVAILABLE) return;
+    const contextUser = getContextUser();
+
+    const code = makeComponent(`
+      <div style={{ width: '100%', backgroundColor: '#fff' }}>
+        <canvas ref={canvasRef} />
+      </div>
+    `);
+
+    const result = await ComponentLinter.lintComponent(
+      code, 'ChartComponent', chartSpec, true, contextUser,
+    );
+
+    const violations = result.violations.filter(
+      v => v.rule === VIOLATION_RULE && v.message.includes('canvas container'),
+    );
+    expect(violations.length).toBeGreaterThanOrEqual(1);
+    expect(violations[0].message).toContain("position: 'relative'");
+    expect(violations[0].message).toContain('height');
+  });
+
+  // ─────────────────────────────────────────────────────────────────────────
+  // Valid / no-violation cases
+  // ─────────────────────────────────────────────────────────────────────────
+
+  it('should NOT flag canvas container with correct position and height', async () => {
+    if (!DB_AVAILABLE) return;
+    const contextUser = getContextUser();
+
+    const code = makeComponent(`
+      <div style={{ width: '100%', height: '300px', position: 'relative' }}>
+        <canvas ref={canvasRef} />
+      </div>
+    `);
+
+    const result = await ComponentLinter.lintComponent(
+      code, 'ChartComponent', chartSpec, true, contextUser,
+    );
+
+    const violations = result.violations.filter(
+      v => v.rule === VIOLATION_RULE && v.message.includes('canvas container'),
+    );
+    expect(violations).toHaveLength(0);
+  });
+
+  it('should NOT flag canvas without a ref attribute', async () => {
+    if (!DB_AVAILABLE) return;
+    const contextUser = getContextUser();
+
+    const code = makeComponent(`
+      <div>
+        <canvas id="myCanvas" />
+      </div>
+    `);
+
+    const result = await ComponentLinter.lintComponent(
+      code, 'ChartComponent', chartSpec, true, contextUser,
+    );
+
+    const violations = result.violations.filter(
+      v => v.rule === VIOLATION_RULE && v.message.includes('canvas container'),
+    );
+    expect(violations).toHaveLength(0);
+  });
+
+  it('should accept dynamic height expression', async () => {
+    if (!DB_AVAILABLE) return;
+    const contextUser = getContextUser();
+
+    const code = `
+      function ChartComponent({ utilities, height = 300 }) {
+        const canvasRef = React.useRef(null);
+        ${CHART_EFFECT}
+        return (
+          <div style={{ width: '100%', height: height + 'px', position: 'relative' }}>
+            <canvas ref={canvasRef} />
+          </div>
+        );
+      }
+    `;
+
+    const result = await ComponentLinter.lintComponent(
+      code, 'ChartComponent', chartSpec, true, contextUser,
+    );
+
+    const violations = result.violations.filter(
+      v => v.rule === VIOLATION_RULE && v.message.includes('canvas container'),
+    );
+    expect(violations).toHaveLength(0);
+  });
+});

--- a/packages/React/test-harness/src/__tests__/component-linter/no-unwrap-utility-libs.test.ts
+++ b/packages/React/test-harness/src/__tests__/component-linter/no-unwrap-utility-libs.test.ts
@@ -1,0 +1,229 @@
+/**
+ * Tests for the no-unwrap-utility-libs lint rule.
+ *
+ * Ensures unwrapLibraryComponents() is not used with utility libraries
+ * (lodash, dayjs, d3, moment) whose functions become non-callable when wrapped.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { ComponentLinter } from '../../lib/component-linter';
+import { ComponentSpec } from '@memberjunction/interactive-component-types';
+
+const baseSpec = {
+  name: 'TestComponent',
+  type: 'chart' as const,
+  title: 'Test',
+  description: 'Test component',
+  code: '',
+  location: 'embedded' as const,
+  functionalRequirements: '',
+  technicalDesign: '',
+  exampleUsage: '<TestComponent />',
+  dataRequirements: {
+    mode: 'queries' as const,
+    queries: [],
+    entities: [],
+  },
+} as ComponentSpec;
+
+const RULE = 'no-unwrap-utility-libs';
+
+function findViolations(result: Awaited<ReturnType<typeof ComponentLinter.lintComponent>>) {
+  return result.violations.filter(v => v.rule === RULE);
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// Cases that SHOULD produce violations
+// ═══════════════════════════════════════════════════════════════════════════
+
+describe('ComponentLinter - no-unwrap-utility-libs (violations)', () => {
+  it('should flag lodash debounce via unwrap (the production failure case)', async () => {
+    const code = `function TestComponent({ utilities }) {
+      const { debounce } = unwrapLibraryComponents(_, 'debounce');
+      return React.createElement('div', null, 'hello');
+    }`;
+
+    const result = await ComponentLinter.lintComponent(code, 'TestComponent', baseSpec, true);
+    const violations = findViolations(result);
+
+    expect(violations).toHaveLength(1);
+    expect(violations[0].severity).toBe('critical');
+    expect(violations[0].message).toContain('lodash');
+    expect(violations[0].message).toContain('"_"');
+    expect(violations[0].suggestion).toBeDefined();
+    expect(violations[0].suggestion?.example).toContain('_.debounce');
+  });
+
+  it('should flag multiple lodash functions via unwrap', async () => {
+    const code = `function TestComponent({ utilities }) {
+      const { sortBy, groupBy, uniq } = unwrapLibraryComponents(_, 'sortBy', 'groupBy', 'uniq');
+      return React.createElement('div', null, 'hello');
+    }`;
+
+    const result = await ComponentLinter.lintComponent(code, 'TestComponent', baseSpec, true);
+    const violations = findViolations(result);
+
+    expect(violations).toHaveLength(1);
+    expect(violations[0].severity).toBe('critical');
+    expect(violations[0].message).toContain('lodash');
+  });
+
+  it('should flag single lodash function via unwrap', async () => {
+    const code = `function TestComponent({ utilities }) {
+      const { throttle } = unwrapLibraryComponents(_, 'throttle');
+      return React.createElement('div', null, 'hello');
+    }`;
+
+    const result = await ComponentLinter.lintComponent(code, 'TestComponent', baseSpec, true);
+    const violations = findViolations(result);
+
+    expect(violations).toHaveLength(1);
+    expect(violations[0].severity).toBe('critical');
+  });
+
+  it('should flag dayjs via unwrap', async () => {
+    const code = `function TestComponent({ utilities }) {
+      const { extend } = unwrapLibraryComponents(dayjs, 'extend');
+      return React.createElement('div', null, 'hello');
+    }`;
+
+    const result = await ComponentLinter.lintComponent(code, 'TestComponent', baseSpec, true);
+    const violations = findViolations(result);
+
+    expect(violations).toHaveLength(1);
+    expect(violations[0].severity).toBe('critical');
+    expect(violations[0].message).toContain('Day.js');
+    expect(violations[0].message).toContain('"dayjs"');
+  });
+
+  it('should flag d3 via unwrap', async () => {
+    const code = `function TestComponent({ utilities }) {
+      const { select, scaleLinear } = unwrapLibraryComponents(d3, 'select', 'scaleLinear');
+      return React.createElement('div', null, 'hello');
+    }`;
+
+    const result = await ComponentLinter.lintComponent(code, 'TestComponent', baseSpec, true);
+    const violations = findViolations(result);
+
+    expect(violations).toHaveLength(1);
+    expect(violations[0].severity).toBe('critical');
+    expect(violations[0].message).toContain('D3.js');
+    expect(violations[0].message).toContain('"d3"');
+  });
+
+  it('should flag moment via unwrap', async () => {
+    const code = `function TestComponent({ utilities }) {
+      const { duration } = unwrapLibraryComponents(moment, 'duration');
+      return React.createElement('div', null, 'hello');
+    }`;
+
+    const result = await ComponentLinter.lintComponent(code, 'TestComponent', baseSpec, true);
+    const violations = findViolations(result);
+
+    expect(violations).toHaveLength(1);
+    expect(violations[0].severity).toBe('critical');
+    expect(violations[0].message).toContain('Moment.js');
+    expect(violations[0].message).toContain('"moment"');
+  });
+});
+
+// ═══════════════════════════════════════════════════════════════════════════
+// Cases that should NOT produce violations (false positive prevention)
+// ═══════════════════════════════════════════════════════════════════════════
+
+describe('ComponentLinter - no-unwrap-utility-libs (no false positives)', () => {
+  it('should allow antd via unwrap (correct usage)', async () => {
+    const code = `function TestComponent({ utilities }) {
+      const { Select, Spin, Button } = unwrapLibraryComponents(antd, 'Select', 'Spin', 'Button');
+      return React.createElement('div', null, 'hello');
+    }`;
+
+    const result = await ComponentLinter.lintComponent(code, 'TestComponent', baseSpec, true);
+    const violations = findViolations(result);
+    expect(violations).toHaveLength(0);
+  });
+
+  it('should allow Chart.js via unwrap (UI library)', async () => {
+    const code = `function TestComponent({ utilities }) {
+      const { Chart: ChartJS } = unwrapLibraryComponents(Chart, 'Chart');
+      return React.createElement('div', null, 'hello');
+    }`;
+
+    const result = await ComponentLinter.lintComponent(code, 'TestComponent', baseSpec, true);
+    const violations = findViolations(result);
+    expect(violations).toHaveLength(0);
+  });
+
+  it('should allow XLSX via unwrap (UI library exports)', async () => {
+    const code = `function TestComponent({ utilities }) {
+      const { utils, writeFile } = unwrapLibraryComponents(XLSX, 'utils', 'writeFile');
+      return React.createElement('div', null, 'hello');
+    }`;
+
+    const result = await ComponentLinter.lintComponent(code, 'TestComponent', baseSpec, true);
+    const violations = findViolations(result);
+    expect(violations).toHaveLength(0);
+  });
+
+  it('should not flag lodash used directly (correct pattern)', async () => {
+    const code = `function TestComponent({ utilities }) {
+      const sorted = _.sortBy(items, 'name');
+      const debouncedFn = _.debounce(loadData, 500);
+      const grouped = _.groupBy(data, 'category');
+      return React.createElement('div', null, 'hello');
+    }`;
+
+    const result = await ComponentLinter.lintComponent(code, 'TestComponent', baseSpec, true);
+    const violations = findViolations(result);
+    expect(violations).toHaveLength(0);
+  });
+
+  it('should not flag dayjs used directly (correct pattern)', async () => {
+    const code = `function TestComponent({ utilities }) {
+      const formatted = dayjs(date).format('YYYY-MM-DD');
+      return React.createElement('div', null, 'hello');
+    }`;
+
+    const result = await ComponentLinter.lintComponent(code, 'TestComponent', baseSpec, true);
+    const violations = findViolations(result);
+    expect(violations).toHaveLength(0);
+  });
+
+  it('should not flag d3 used directly (correct pattern)', async () => {
+    const code = `function TestComponent({ utilities }) {
+      const svg = d3.select('#chart');
+      const scale = d3.scaleLinear().domain([0, 100]);
+      return React.createElement('div', null, 'hello');
+    }`;
+
+    const result = await ComponentLinter.lintComponent(code, 'TestComponent', baseSpec, true);
+    const violations = findViolations(result);
+    expect(violations).toHaveLength(0);
+  });
+
+  it('should not flag _ in non-unwrap contexts', async () => {
+    const code = `function TestComponent({ utilities }) {
+      const _ = someOtherThing;
+      const result = _.process(data);
+      return React.createElement('div', null, 'hello');
+    }`;
+
+    const result = await ComponentLinter.lintComponent(code, 'TestComponent', baseSpec, true);
+    const violations = findViolations(result);
+    expect(violations).toHaveLength(0);
+  });
+
+  it('should still flag _ as first arg to unwrapLibraryComponents regardless of shadowing', async () => {
+    const code = `function TestComponent({ utilities }) {
+      const _ = someOtherThing;
+      const { debounce } = unwrapLibraryComponents(_, 'debounce');
+      return React.createElement('div', null, 'hello');
+    }`;
+
+    const result = await ComponentLinter.lintComponent(code, 'TestComponent', baseSpec, true);
+    const violations = findViolations(result);
+
+    expect(violations).toHaveLength(1);
+    expect(violations[0].severity).toBe('critical');
+  });
+});

--- a/packages/React/test-harness/src/lib/runtime-rules/index.ts
+++ b/packages/React/test-harness/src/lib/runtime-rules/index.ts
@@ -22,6 +22,7 @@ import './no-react-destructuring';
 import './no-require-statements';
 import './no-return-component';
 import './no-use-reducer';
+import './no-unwrap-utility-libs';
 import './no-window-access';
 import './noisy-settings-updates';
 import './pass-standard-props';

--- a/packages/React/test-harness/src/lib/runtime-rules/no-unwrap-utility-libs.ts
+++ b/packages/React/test-harness/src/lib/runtime-rules/no-unwrap-utility-libs.ts
@@ -1,0 +1,86 @@
+import { traverse, NodePath, createViolation, truncateCode } from '../lint-utils';
+import * as t from '@babel/types';
+import { RegisterClass } from '@memberjunction/global';
+import { BaseLintRule } from '../lint-rule';
+import { Violation } from '../component-linter';
+
+/**
+ * Known utility libraries whose globals must NOT be passed to unwrapLibraryComponents().
+ * These libraries expose their API as methods on the global variable and should be
+ * called directly (e.g., `_.debounce(fn, 500)`, `dayjs(date).format('YYYY-MM-DD')`).
+ *
+ * unwrapLibraryComponents() wraps the value in a way that makes utility functions
+ * non-callable, causing runtime crashes like:
+ *   Uncaught TypeError: D is not a function
+ */
+const UTILITY_LIBS: ReadonlyMap<string, { library: string; example: string }> = new Map([
+  ['_',      { library: 'lodash',    example: '_.debounce(myFunction, 500)' }],
+  ['dayjs',  { library: 'Day.js',    example: "dayjs(date).format('YYYY-MM-DD')" }],
+  ['d3',     { library: 'D3.js',     example: "d3.select('#chart')" }],
+  ['moment', { library: 'Moment.js', example: "moment().format('YYYY-MM-DD')" }],
+]);
+
+/**
+ * Rule: no-unwrap-utility-libs
+ *
+ * Flags unwrapLibraryComponents() calls where the first argument is a known utility
+ * library global (`_`, `dayjs`, `d3`, `moment`). These libraries expose their API as
+ * methods on the global variable — wrapping them with unwrapLibraryComponents() makes
+ * the extracted functions non-callable, causing runtime crashes.
+ *
+ * Severity: critical
+ * Applies to: all components
+ */
+@RegisterClass(BaseLintRule, 'no-unwrap-utility-libs')
+export class NoUnwrapUtilityLibsRule extends BaseLintRule {
+  get Name() { return 'no-unwrap-utility-libs'; }
+  get AppliesTo(): 'all' | 'child' | 'root' { return 'all'; }
+
+  Test(ast: t.File, componentName: string): Violation[] {
+    const violations: Violation[] = [];
+
+    traverse(ast, {
+      CallExpression(path: NodePath<t.CallExpression>) {
+        if (!t.isIdentifier(path.node.callee) || path.node.callee.name !== 'unwrapLibraryComponents') {
+          return;
+        }
+
+        const firstArg = path.node.arguments[0];
+        if (!firstArg || !t.isIdentifier(firstArg)) {
+          return;
+        }
+
+        const globalName = firstArg.name;
+        const libInfo = UTILITY_LIBS.get(globalName);
+        if (!libInfo) {
+          return;
+        }
+
+        const message =
+          `Do not use unwrapLibraryComponents() with utility library "${globalName}" (${libInfo.library}). ` +
+          `Utility libraries expose their API as methods on the global variable — call them directly ` +
+          `(e.g., ${libInfo.example}). unwrapLibraryComponents() is only for UI component libraries like antd.`;
+
+        violations.push(
+          createViolation(
+            'no-unwrap-utility-libs',
+            'critical',
+            path.node,
+            message,
+            truncateCode(path.toString()),
+            {
+              text: 'Remove the unwrapLibraryComponents() call and use the library global directly.',
+              example:
+                '// Instead of:\n' +
+                `const { debounce } = unwrapLibraryComponents(${globalName}, 'debounce');\n` +
+                '// Use:\n' +
+                `const debouncedFn = ${libInfo.example};`,
+            },
+          ),
+        );
+      },
+    });
+
+    return violations;
+  }
+}

--- a/packages/SQLParser/src/__tests__/mj-sql-parser.test.ts
+++ b/packages/SQLParser/src/__tests__/mj-sql-parser.test.ts
@@ -382,6 +382,121 @@ describe('extractParameterInfo', () => {
         expect(typeMap['g']).toBe('string');
         expect(typeMap['h']).toBe('unknown');
     });
+
+    describe('default values from {% else %} branches', () => {
+        it('should extract string default from else branch', () => {
+            const sql = `SELECT * FROM t WHERE 1=1
+{% if Status and Status.length > 0 %}
+  AND t.Status IN {{ Status | sqlIn }}
+{% else %}
+  AND t.Status = 'Attended'
+{% endif %}`;
+            const params = extractParameterInfo(sql);
+            const status = params.find(p => p.name === 'Status');
+            expect(status).toBeDefined();
+            expect(status!.type).toBe('array');
+            expect(status!.defaultValue).toBe('Attended');
+        });
+
+        it('should extract numeric default from else branch', () => {
+            const sql = `SELECT * FROM t WHERE 1=1
+{% if Limit %}
+  AND t.Limit = {{ Limit | sqlNumber }}
+{% else %}
+  AND t.Limit = 100
+{% endif %}`;
+            const params = extractParameterInfo(sql);
+            const limit = params.find(p => p.name === 'Limit');
+            expect(limit).toBeDefined();
+            expect(limit!.defaultValue).toBe(100);
+        });
+
+        it('should not override default from | default() filter', () => {
+            const sql = `SELECT * FROM t
+{% if Limit %}
+  WHERE t.Limit = {{ Limit | default(50) | sqlNumber }}
+{% else %}
+  WHERE t.Limit = 100
+{% endif %}`;
+            const params = extractParameterInfo(sql);
+            const limit = params.find(p => p.name === 'Limit');
+            expect(limit).toBeDefined();
+            expect(limit!.defaultValue).toBe(50); // filter default takes precedence
+        });
+
+        it('should skip else branch with multiple literals (ambiguous)', () => {
+            const sql = `SELECT * FROM t WHERE 1=1
+{% if Region %}
+  AND t.Region = {{ Region | sqlString }}
+{% else %}
+  AND t.Region = 'US' AND t.SubRegion = 'West'
+{% endif %}`;
+            const params = extractParameterInfo(sql);
+            const region = params.find(p => p.name === 'Region');
+            expect(region).toBeDefined();
+            expect(region!.defaultValue).toBeNull(); // ambiguous — two literals
+        });
+
+        it('should handle if/elif/else with default on else', () => {
+            const sql = `SELECT * FROM t WHERE 1=1
+{% if Priority %}
+  AND t.Priority = {{ Priority | sqlNumber }}
+{% elif Category %}
+  AND t.Category = {{ Category | sqlString }}
+{% else %}
+  AND t.Priority = 1
+{% endif %}`;
+            const params = extractParameterInfo(sql);
+            const priority = params.find(p => p.name === 'Priority');
+            expect(priority).toBeDefined();
+            expect(priority!.defaultValue).toBe(1);
+        });
+
+        it('should not set default when there is no else branch', () => {
+            const sql = `SELECT * FROM t WHERE 1=1
+{% if Region %}
+  AND t.Region = {{ Region | sqlString }}
+{% endif %}`;
+            const params = extractParameterInfo(sql);
+            const region = params.find(p => p.name === 'Region');
+            expect(region).toBeDefined();
+            expect(region!.defaultValue).toBeNull();
+        });
+
+        it('should handle the Member Event Attendance History pattern', () => {
+            const sql = `SELECT er.ID, er.MemberID, e.Name
+FROM vwEventRegistrations er
+INNER JOIN vwEvents e ON er.EventID = e.ID
+WHERE 1=1
+{% if MemberID and MemberID.length > 0 %}
+  AND CAST(er.MemberID AS NVARCHAR(36)) IN {{ MemberID | sqlIn }}
+{% endif %}
+{% if Status and Status.length > 0 %}
+  AND er.Status IN {{ Status | sqlIn }}
+{% else %}
+  AND er.Status = 'Attended'
+{% endif %}
+{% if StartDate and StartDate.length > 0 %}
+  AND e.StartDate >= {{ StartDate | sqlDate }}
+{% endif %}
+ORDER BY e.StartDate DESC`;
+            const params = extractParameterInfo(sql);
+
+            const memberID = params.find(p => p.name === 'MemberID');
+            expect(memberID).toBeDefined();
+            expect(memberID!.type).toBe('array');
+            expect(memberID!.defaultValue).toBeNull(); // no else branch
+
+            const status = params.find(p => p.name === 'Status');
+            expect(status).toBeDefined();
+            expect(status!.type).toBe('array');
+            expect(status!.defaultValue).toBe('Attended');
+
+            const startDate = params.find(p => p.name === 'StartDate');
+            expect(startDate).toBeDefined();
+            expect(startDate!.defaultValue).toBeNull(); // no else branch
+        });
+    });
 });
 
 // ═══════════════════════════════════════════════════

--- a/packages/SQLParser/src/sql-parser.ts
+++ b/packages/SQLParser/src/sql-parser.ts
@@ -900,6 +900,11 @@ export class SQLParser {
             }
         }
 
+        // Enrich parameters with default values extracted from {% else %} blocks.
+        // Pattern: {% if Var %} ... {{ Var | sqlFilter }} ... {% else %} ... = 'literal' ... {% endif %}
+        // The literal in the else branch is the semantic default for the parameter.
+        SQLParser.enrichDefaultsFromElseBranches(sql, paramMap);
+
         return Array.from(paramMap.values());
     }
 
@@ -1628,6 +1633,83 @@ export class SQLParser {
             }
         }
         return null;
+    }
+
+    /**
+     * Extracts the primary variable name from an {% if %} condition expression.
+     * Handles patterns like:
+     *   "Status"                         → "Status"
+     *   "Status and Status.length > 0"   → "Status"
+     *   "StartDate and StartDate.length" → "StartDate"
+     */
+    private static extractConditionVariable(condition: string): string | null {
+        const match = condition.match(/^\s*([A-Za-z_]\w*)/);
+        return match ? match[1] : null;
+    }
+
+    /**
+     * Extracts a SQL literal value from an {% else %} branch body.
+     * Looks for patterns like:
+     *   `= 'Attended'`    → "Attended"
+     *   `= 42`            → 42
+     *   `= 3.14`          → 3.14
+     *
+     * Only returns a value when exactly one literal is found, to avoid
+     * ambiguity from complex else bodies with multiple conditions.
+     */
+    private static extractLiteralFromElseBody(body: string): string | number | null {
+        // Match string literals: = 'value' (SQL single-quoted strings)
+        const stringMatches = [...body.matchAll(/=\s*'([^']+)'/g)];
+        if (stringMatches.length === 1) {
+            return stringMatches[0][1];
+        }
+
+        // Match numeric literals: = 42 or = 3.14 (but not parts of column names)
+        const numericMatches = [...body.matchAll(/=\s*(-?\d+(?:\.\d+)?)\b/g)];
+        if (numericMatches.length === 1 && stringMatches.length === 0) {
+            const num = Number(numericMatches[0][1]);
+            return isNaN(num) ? null : num;
+        }
+
+        return null;
+    }
+
+    /**
+     * Enriches parameters that lack default values by inspecting {% else %} branches
+     * of conditional blocks. When a block guards a parameter with {% if Var %} and
+     * the else branch contains a single literal value (e.g., `= 'Attended'`), that
+     * literal is assigned as the parameter's default.
+     *
+     * Only sets defaults on parameters that don't already have one (from a `| default()` filter).
+     */
+    private static enrichDefaultsFromElseBranches(
+        sql: string,
+        paramMap: Map<string, MJParameterInfo>
+    ): void {
+        const blocks = SQLParser.ExtractConditionalBlocks(sql);
+
+        for (const block of blocks) {
+            // Need at least 2 branches (if + else) and last branch must be else (condition === null)
+            if (block.branches.length < 2) continue;
+            const elseBranch = block.branches[block.branches.length - 1];
+            if (elseBranch.condition !== null) continue;
+
+            // Extract the variable from the if-condition
+            const ifCondition = block.branches[0].condition;
+            if (!ifCondition) continue;
+
+            const varName = SQLParser.extractConditionVariable(ifCondition);
+            if (!varName) continue;
+
+            // Only enrich parameters that exist and don't already have a default
+            const param = paramMap.get(varName);
+            if (!param || param.defaultValue !== null) continue;
+
+            const literal = SQLParser.extractLiteralFromElseBody(elseBranch.body.raw);
+            if (literal !== null) {
+                param.defaultValue = literal;
+            }
+        }
     }
 
     private static findConditionalVariables(tokens: MJToken[]): {

--- a/packages/SQLServerDataProvider/src/__tests__/sql-utils.test.ts
+++ b/packages/SQLServerDataProvider/src/__tests__/sql-utils.test.ts
@@ -263,29 +263,25 @@ describe('QueryParameterProcessor.validateParameters', () => {
     });
   });
 
-  describe('default value handling', () => {
-    it('should apply default value when parameter is not provided', () => {
+  describe('default value handling (metadata only — not injected)', () => {
+    // DefaultValue is informational metadata. The SQL template handles defaults
+    // via {% else %} blocks or | default() filters.
+
+    it('should NOT inject default values — they are metadata only', () => {
       const defs = [makeParamDef({ Name: 'limit', Type: 'number', DefaultValue: '100' })];
       const result = QueryParameterProcessor.validateParameters({}, defs as never[]);
       expect(result.success).toBe(true);
-      expect(result.validatedParameters.limit).toBe(100);
+      expect(result.validatedParameters.limit).toBeUndefined();
     });
 
-    it('should apply string default value', () => {
-      const defs = [makeParamDef({ Name: 'status', Type: 'string', DefaultValue: 'active' })];
+    it('should succeed when optional param with SQL expression default is absent', () => {
+      const defs = [makeParamDef({ Name: 'RefDate', Type: 'date', DefaultValue: 'GETDATE()' })];
       const result = QueryParameterProcessor.validateParameters({}, defs as never[]);
       expect(result.success).toBe(true);
-      expect(result.validatedParameters.status).toBe('active');
+      expect(result.validatedParameters.RefDate).toBeUndefined();
     });
 
-    it('should apply boolean default value', () => {
-      const defs = [makeParamDef({ Name: 'flag', Type: 'boolean', DefaultValue: 'true' })];
-      const result = QueryParameterProcessor.validateParameters({}, defs as never[]);
-      expect(result.success).toBe(true);
-      expect(result.validatedParameters.flag).toBe(1);
-    });
-
-    it('should prefer provided value over default', () => {
+    it('should still validate and use explicitly provided values', () => {
       const defs = [makeParamDef({ Name: 'limit', Type: 'number', DefaultValue: '100' })];
       const result = QueryParameterProcessor.validateParameters({ limit: 50 }, defs as never[]);
       expect(result.success).toBe(true);


### PR DESCRIPTION
## Summary
- **Fix sqlLike* filters**: Strip boundary wildcards (`%`/`_`) that were causing zero-row results when combined with SQL Server's LIKE semantics
- **Fix QueryProcessor**: Stop injecting `DefaultValue` into Nunjucks template context and handle non-JSON default values for array-typed parameters
- **React test-harness lint rules**: Add `chart-canvas-container` rule (Chart.js must render inside a sized container) and `no-unwrap-utility-libs` rule (prevent importing internal modules of utility libraries)
- **Fix SimpleChart**: Stop leaking transformed labels back through `onDataPointClick` callback
- **SQL Parser**: Add support for extracting `{% else %}` block defaults for array parameters

## Test plan
- [x] Verify `sqlLike*` filters no longer strip meaningful wildcards while correctly handling boundary wildcards
- [x] Test QueryProcessor with array-typed parameters that have non-JSON default values
- [x] Run react-test-harness tests: `cd packages/React/test-harness && npm test`
- [x] Run MJCore tests: `cd packages/MJCore && npm test`
- [x] Run SQLParser tests: `cd packages/SQLParser && npm test`
- [x] Confirm SimpleChart `onDataPointClick` returns original (untransformed) labels

🤖 Generated with [Claude Code](https://claude.com/claude-code)