### PR TITLE
fix(migrations): RLS filter for AI runs/steps/prompts uses base view

### DIFF
--- a/.changeset/swift-otters-patch.md
+++ b/.changeset/swift-otters-patch.md
@@ -1,0 +1,5 @@
+---
+"@memberjunction/core": minor
+---
+
+Fix RLS filter target for Unified Permissions Phase 2: rewrite the two `RowLevelSecurityFilter` rows seeded by V202604241700 to reference `__mj.vwAIAgentRuns` instead of the unschema-qualified base table `AIAgentRun`. The original values failed at runtime for UI-role users reading `MJ: AI Agent Run Steps` and `MJ: AI Prompt Runs` because the bare table name didn't resolve and, even schema-qualified, the role lacks SELECT on the base table — only the view.

--- a/migrations/v5/V202605011830__v5.31.x__Fix_Unified_Permissions_RLS_Filter_Schema_Prefix.sql
+++ b/migrations/v5/V202605011830__v5.31.x__Fix_Unified_Permissions_RLS_Filter_Schema_Prefix.sql
@@ -1,0 +1,42 @@
+-- =============================================================================
+-- v5.31.x — Fix RLS filter target for Unified Permissions Phase 2
+--
+-- V202604241700__v5.30.x__Unified_Permissions_Phase_2.sql inserted two
+-- RowLevelSecurityFilter rows whose FilterText subqueries referenced
+-- the base table AIAgentRun without a schema prefix:
+--
+--     'AgentRunID IN (SELECT ID FROM AIAgentRun WHERE UserID = ''{{UserID}}'')'
+--
+-- Two problems:
+--
+--   1. No schema prefix. The RLS engine inlines FilterText into the
+--      entity's resolver query at runtime. SQL Server resolves a bare
+--      AIAgentRun against the caller's default schema (typically dbo),
+--      which doesn't contain the table — Msg 208, "Invalid object name".
+--
+--   2. References the base table, not the base view. MJAPI executes
+--      resolver SQL under the caller's user context (not the CodeGen /
+--      dbowner user). UI users are granted SELECT on vwAIAgentRuns by
+--      CodeGen, but NOT on the base table AIAgentRun — so even with the
+--      schema fixed, the subquery would fail with Msg 229, "SELECT
+--      permission was denied on the object 'AIAgentRun'".
+--
+-- The fix is to reference ${flyway:defaultSchema}.vwAIAgentRuns. Flyway
+-- resolves the placeholder at execute time so the stored value contains
+-- the actual schema (e.g. __mj.vwAIAgentRuns), and the base view is what
+-- end-user roles have permission to read.
+--
+-- vwAIAgentRuns exposes both ID and UserID, so the predicate stays
+-- structurally identical.
+--
+-- The third filter (E1AF0001..., UserID = '{{UserID}}') does not
+-- reference a table and is left unchanged.
+-- =============================================================================
+
+UPDATE ${flyway:defaultSchema}.RowLevelSecurityFilter
+SET FilterText = N'AgentRunID IN (SELECT ID FROM ${flyway:defaultSchema}.vwAIAgentRuns WHERE UserID = ''{{UserID}}'')'
+WHERE ID = 'E1AF0002-0000-4000-B000-000000000002';  -- UI: Own AI Agent Run Steps
+
+UPDATE ${flyway:defaultSchema}.RowLevelSecurityFilter
+SET FilterText = N'AgentRunID IN (SELECT ID FROM ${flyway:defaultSchema}.vwAIAgentRuns WHERE UserID = ''{{UserID}}'')'
+WHERE ID = 'E1AF0003-0000-4000-B000-000000000003';  -- UI: Own AI Prompt Runs


### PR DESCRIPTION
## Summary

- Patches two `RowLevelSecurityFilter` rows seeded by `V202604241700` (shipped in v5.30.0/v5.30.1) whose `FilterText` referenced `AIAgentRun` as a bare base table — at runtime this fails with `Msg 208 (Invalid object name)` and, even schema-qualified, `Msg 229 (SELECT permission was denied)` because UI users only have GRANTs on the base view.
- Affected reads: `MJ: AI Agent Run Steps` (filter `E1AF0002`) and `MJ: AI Prompt Runs` (filter `E1AF0003`). Both grids/queries error for any user constrained by these filters.
- Fix is a follow-up migration (`V202605011830`) that `UPDATE`s both rows to reference `${flyway:defaultSchema}.vwAIAgentRuns`, the CodeGen-managed base view that has SELECT granted to roles with Read on the entity.

## Test plan

- [x] Apply migration; verify `__mj.RowLevelSecurityFilter` rows `E1AF0002` and `E1AF0003` now contain `__mj.vwAIAgentRuns`
- [x] **Restart MJAPI** (RLS filter text is loaded into in-memory metadata at boot)
- [x] Log in as a user whose only relevant role is `UI` (Developer/Integration/Owner roles bypass the filter via role union)
- [x] Open the `MJ: AI Agent Run Steps` entity grid — confirm it loads without GraphQL errors and only shows steps for the user's own agent runs
- [x] Open the `MJ: AI Prompt Runs` entity grid — same expectation; standalone prompt runs (`AgentRunID IS NULL`) remain hidden by design
- [x] Inspect DevTools → Network → graphql response for both queries; confirm no `errors` array