### PR TITLE
fix(codegen): include composite-PK columns in spCreate INSERT statements

### DIFF
--- a/.changeset/sturdy-pandas-insert.md
+++ b/.changeset/sturdy-pandas-insert.md
@@ -1,0 +1,5 @@
+---
+"@memberjunction/codegen-lib": minor
+---
+
+Fix CodeGen dropping primary-key columns from `spCreate` INSERT statements for tables with composite (multi-column) primary keys. The existing single-PK uniqueidentifier workaround that re-injects the PK column into the generated INSERT was gated on `entity.PrimaryKeys.length === 1`, so composite-PK tables fell through to the else branch which only built the SELECT-back clause. Combined with metadata sync setting `AllowUpdateAPI=0` on every PK column (and `generateInsertFieldString` filtering on `!ef.AllowUpdateAPI`), every PK column was filtered out of the INSERT, producing broken stored procs that fail at runtime with `NOT NULL` violations on the missing PK columns. Both SQL Server and PostgreSQL providers now re-inject all PK columns and parameters into the INSERT column/value lists when `PrimaryKeys.length > 1`, mirroring what the single-PK branch already does for one key.

--- a/packages/CodeGenLib/src/Database/providers/postgresql/PostgreSQLCodeGenProvider.ts
+++ b/packages/CodeGenLib/src/Database/providers/postgresql/PostgreSQLCodeGenProvider.ts
@@ -1550,12 +1550,28 @@ WHERE p.prokind IN ('f', 'p')
             `${pgDialect.QuoteIdentifier(k.Name)} = p_${this.toSnakeCase(k.CodeName)}`
         ).join(' AND ');
 
+        // Composite-PK tables: every PK column has AllowUpdateAPI=0, so generateInsertFieldString
+        // filters them all out. Prepend them to finalColumns/finalValues so the INSERT is valid.
+        // (The single-PK uniqueidentifier case is already handled above via v_new_id.)
+        let finalColumns = insertColumns;
+        let finalValues = insertValues;
+        if (entity.PrimaryKeys.length > 1) {
+            const pkColumns = entity.PrimaryKeys
+                .map((k: EntityFieldInfo) => pgDialect.QuoteIdentifier(k.Name))
+                .join(',\n            ');
+            const pkValues = entity.PrimaryKeys
+                .map((k: EntityFieldInfo) => `p_${this.toSnakeCase(k.CodeName)}`)
+                .join(',\n            ');
+            finalColumns = `${pkColumns},\n            ${insertColumns}`;
+            finalValues = `${pkValues},\n            ${insertValues}`;
+        }
+
         return {
             preInsert: '',
             returningClause: '',
             selectClause: `SELECT * FROM ${pgDialect.QuoteSchema(entity.SchemaName, viewName)}\n    WHERE ${selectWhere}`,
-            finalColumns: insertColumns,
-            finalValues: insertValues,
+            finalColumns,
+            finalValues,
         };
     }
 

--- a/packages/CodeGenLib/src/Database/providers/sqlserver/SQLServerCodeGenProvider.ts
+++ b/packages/CodeGenLib/src/Database/providers/sqlserver/SQLServerCodeGenProvider.ts
@@ -172,6 +172,15 @@ ${whereClause}GO`;
                 selectInsertedRecord = `SELECT * FROM [${entity.SchemaName}].[${entity.BaseView}] WHERE [${firstKey.Name}] = @ActualID`;
             }
         } else {
+            // Composite-PK tables: every PK column has AllowUpdateAPI=0, so generateInsertFieldString
+            // filters them all out. Add them back manually here so the INSERT is valid. (The
+            // single-PK uniqueidentifier case is already handled by the branch above.)
+            if (entity.PrimaryKeys.length > 1) {
+                for (const k of entity.PrimaryKeys) {
+                    additionalFieldList += ',\n                [' + k.Name + ']';
+                    additionalValueList += ',\n                @' + k.CodeName;
+                }
+            }
             selectInsertedRecord = `SELECT * FROM [${entity.SchemaName}].[${entity.BaseView}] WHERE `;
             let isFirst = true;
             for (const k of entity.PrimaryKeys) {


### PR DESCRIPTION
## Summary

Fixes a real bug in `@memberjunction/codegen-lib` where the generated `spCreate<Entity>` stored procedure for tables with **composite (multi-column) primary keys** omits every PK column from its `INSERT` statement, producing a proc that fails at runtime with `NOT NULL` violations the first time anyone tries to insert.

## Root cause

Two pieces of CodeGen interact:

1. **Metadata sync** ([SQLServerCodeGenProvider.ts:1430-1433](https://github.com/MemberJunction/MJ/blob/next/packages/CodeGenLib/src/Database/providers/sqlserver/SQLServerCodeGenProvider.ts#L1430-L1433)) unconditionally sets `AllowUpdateAPI = 0` on every primary-key column.
2. **`generateInsertFieldString`** ([line 850](https://github.com/MemberJunction/MJ/blob/next/packages/CodeGenLib/src/Database/providers/sqlserver/SQLServerCodeGenProvider.ts#L850)) filters columns out of the generated INSERT via `!ef.AllowUpdateAPI`.

Together that drops every PK column from the INSERT. For **single-PK uniqueidentifier** tables, `generateCRUDCreate` has an explicit workaround that re-injects the PK column back into the INSERT via `additionalFieldList` / `additionalValueList`. That workaround is gated on `entity.PrimaryKeys.length === 1` ([line 128](https://github.com/MemberJunction/MJ/blob/next/packages/CodeGenLib/src/Database/providers/sqlserver/SQLServerCodeGenProvider.ts#L128)).

For **composite-PK** tables the code falls through to the `else` branch ([line 174](https://github.com/MemberJunction/MJ/blob/next/packages/CodeGenLib/src/Database/providers/sqlserver/SQLServerCodeGenProvider.ts#L174)) which only builds the `SELECT`-back clause and never restores the PK columns. PostgreSQL has the identical shape in `buildCreateInsertStrategy`'s composite branch ([line 1548](https://github.com/MemberJunction/MJ/blob/next/packages/CodeGenLib/src/Database/providers/postgresql/PostgreSQLCodeGenProvider.ts#L1548)).

This rarely fires in practice because composite-PK tables are uncommon in MJ-style schemas and the broken proc only blows up when something actually tries to INSERT.

## Fix

In both providers, when `entity.PrimaryKeys.length > 1`:
- **SQL Server**: loop `entity.PrimaryKeys` and append each `[Name]` / `@CodeName` to `additionalFieldList` / `additionalValueList`.
- **PostgreSQL**: prepend each PK column / parameter into `finalColumns` / `finalValues` returned from `buildCreateInsertStrategy`'s composite branch.

This mirrors what the single-PK uniqueidentifier branch already does for one key. Single-PK paths and the auto-increment branch are untouched.

## Versioning

Minor bump on `@memberjunction/codegen-lib` only — no other packages are affected, no migrations.

## Test plan

- [x] `npm run build` in `packages/CodeGenLib` — clean
- [x] `npm run test` in `packages/CodeGenLib` — 418 passed, 0 failed (59 skipped are DB-integration tests that always skip without a live DB)
- [ ] Reviewer: regenerate CodeGen against a schema containing a composite-PK table and confirm the emitted `spCreate*.sql` includes all PK columns in its `INSERT` column list and `VALUES` clause
- [ ] Reviewer: confirm a `spCreate*` for a single-PK uniqueidentifier table is byte-identical before/after this PR (no regression on the workaround path)

🤖 Generated with [Claude Code](https://claude.com/claude-code)