### PR TITLE
perf(theme): unified mj-theme key + flash-free first paint

### DIFF
--- a/.changeset/unified-theme-key.md
+++ b/.changeset/unified-theme-key.md
@@ -1,0 +1,29 @@
+---
+"@memberjunction/ng-shared-generic": patch
+"@memberjunction/ng-auth-services": patch
+"@memberjunction/ng-explorer-app": patch
+"@memberjunction/ng-explorer-service-worker": patch
+---
+
+Unify the theme storage system to a single localStorage key (`mj-theme`) and eliminate the brief light-mode flash dark-mode users saw on every page load.
+
+**Root cause of the original flash:** the inline pre-paint script in `index.html` correctly set `data-theme` on first paint based on the user's preference, but `MJExplorerAppComponent.applyLoginTheme()` then ran during Angular bootstrap and re-read a *different* localStorage key (`'mj-login-theme'`), overriding the script's correct decision before `ThemeService` eventually overrode it back. Result: visible flash on every reload.
+
+**Fix:** all three theme-aware paths now read/write the same `mj-theme` key.
+
+`@memberjunction/ng-shared-generic`:
+- `ThemeService.applyBaseThemeAttribute()` mirrors the resolved base theme (`light` or `dark`) to `localStorage['mj-theme']` on every theme application — including initial load from server preference, manual `SetTheme()` calls, and OS-change responses for `'system'` preference. The mirrored value is the *resolved* base, so the inline pre-paint script can apply the right theme synchronously without needing to read server preference or evaluate `'system'`.
+- `ThemeService.Reset()` deliberately preserves the key (commented why) so the login screen retains the correct theme through logout.
+
+`@memberjunction/ng-auth-services`:
+- `MJExplorerAuthBase.preservedLocalStorageKeys` now contains `'mj-theme'` (was `'mj-login-theme'`) so the unified key survives logout.
+
+`@memberjunction/ng-explorer-app`:
+- `MJExplorerAppComponent.THEME_STORAGE_KEY` changed from `'mj-login-theme'` to `'mj-theme'`. The login-screen toggle (`ToggleTheme()`) now writes the unified key. `applyLoginTheme()` reads the unified key with the same lookup the inline script uses, so Angular bootstrap doesn't override the script's decision.
+
+`@memberjunction/ng-explorer-service-worker`:
+- README backport snippet updated to read only `mj-theme`.
+
+**Migration impact:** Users with `mj-theme` already populated (most logged-in users after the previous Option B work) see zero impact and instant correct theme on every reload. Users with only the legacy `mj-login-theme` from older versions see one flash on their first visit after this lands; `ThemeService` then writes `mj-theme` on next theme application and they're flash-free forever after. The legacy fallback read was deliberately dropped for code simplicity — the one-time migration flash is an acceptable cost.
+
+Verified end-to-end via Playwright in a logged-in browser session against a production build: `data-theme` is correctly set at `DOMContentLoaded` and stays consistent through Angular bootstrap. No flash observed. Logout/preserve unit tests in `@memberjunction/ng-auth-services` updated and all 5 pass.

--- a/packages/Angular/Explorer/auth-services/src/lib/__tests__/auth-services.test.ts
+++ b/packages/Angular/Explorer/auth-services/src/lib/__tests__/auth-services.test.ts
@@ -324,17 +324,17 @@ describe('logout and cache clearing', () => {
     const { removeItem } = stubLocalStorage({
       'mj-session-id': 'abc',
       'auth0.token': 'xyz',
-      'mj-login-theme': 'dark',
+      'mj-theme': 'dark',
     });
     stubIndexedDB();
     await makeProvider().logout();
     expect(removeItem).toHaveBeenCalledWith('mj-session-id');
     expect(removeItem).toHaveBeenCalledWith('auth0.token');
-    expect(removeItem).not.toHaveBeenCalledWith('mj-login-theme');
+    expect(removeItem).not.toHaveBeenCalledWith('mj-theme');
   });
 
-  it('should preserve mj-login-theme by default even when it is the only key', async () => {
-    const { removeItem } = stubLocalStorage({ 'mj-login-theme': 'dark' });
+  it('should preserve mj-theme by default even when it is the only key', async () => {
+    const { removeItem } = stubLocalStorage({ 'mj-theme': 'dark' });
     stubIndexedDB();
     await makeProvider().logout();
     expect(removeItem).not.toHaveBeenCalled();
@@ -383,14 +383,14 @@ describe('logout and cache clearing', () => {
 
   it('should respect overridden preservedLocalStorageKeys in a subclass', async () => {
     const { removeItem } = stubLocalStorage({
-      'mj-login-theme': 'dark',
+      'mj-theme': 'dark',
       'my-app-setting': 'value',
       'session-data': 'to-remove',
     });
     stubIndexedDB();
-    await makeProvider(new Set(['mj-login-theme', 'my-app-setting'])).logout();
+    await makeProvider(new Set(['mj-theme', 'my-app-setting'])).logout();
     expect(removeItem).toHaveBeenCalledWith('session-data');
-    expect(removeItem).not.toHaveBeenCalledWith('mj-login-theme');
+    expect(removeItem).not.toHaveBeenCalledWith('mj-theme');
     expect(removeItem).not.toHaveBeenCalledWith('my-app-setting');
   });
 });

--- a/packages/Angular/Explorer/auth-services/src/lib/mjexplorer-auth-base.service.ts
+++ b/packages/Angular/Explorer/auth-services/src/lib/mjexplorer-auth-base.service.ts
@@ -224,7 +224,11 @@ export abstract class MJAuthBase implements IAngularAuthProvider {
    * to your provider or application.
    */
   protected get preservedLocalStorageKeys(): Set<string> {
-    return new Set(['mj-login-theme']);
+    // 'mj-theme' is the unified theme key used by the inline pre-paint
+    // script in index.html, MJExplorerAppComponent's login screen, and
+    // ThemeService post-login. Preserving across logout means the login
+    // screen continues to show the user's last theme without flashing.
+    return new Set(['mj-theme']);
   }
 
   /**

--- a/packages/Angular/Explorer/explorer-app/src/lib/explorer-app.component.ts
+++ b/packages/Angular/Explorer/explorer-app/src/lib/explorer-app.component.ts
@@ -35,7 +35,13 @@ import { BaseAngularComponent } from '@memberjunction/ng-base-types';
   encapsulation: ViewEncapsulation.None
 })
 export class MJExplorerAppComponent extends BaseAngularComponent implements OnInit, OnDestroy {
-  private static readonly THEME_STORAGE_KEY = 'mj-login-theme';
+  /**
+   * Unified theme storage key. Same value the inline pre-paint script in
+   * index.html and ThemeService both read/write. Single source of truth so
+   * the login-screen toggle, the post-login ThemeService, and the inline
+   * first-paint script all stay in sync.
+   */
+  private static readonly THEME_STORAGE_KEY = 'mj-theme';
 
   public title = 'MJ Explorer';
   public initialPath = '/';
@@ -673,7 +679,11 @@ export class MJExplorerAppComponent extends BaseAngularComponent implements OnIn
   }
 
   /**
-   * Load saved theme preference from localStorage, falling back to OS preference
+   * Load saved theme preference from localStorage, falling back to OS preference.
+   *
+   * Reads the same THEME_STORAGE_KEY ('mj-theme') the inline pre-paint script
+   * reads, so both paths reach the same decision and Angular bootstrap doesn't
+   * override the script's correct first-paint setting.
    */
   private applyLoginTheme(): void {
     const saved = localStorage.getItem(MJExplorerAppComponent.THEME_STORAGE_KEY);

--- a/packages/Angular/Explorer/service-worker/README.md
+++ b/packages/Angular/Explorer/service-worker/README.md
@@ -65,7 +65,7 @@ Without this, dark-mode users see a brief light-mode flash on every load before 
 <script>
   (function () {
     try {
-      var saved = localStorage.getItem('mj-login-theme');
+      var saved = localStorage.getItem('mj-theme');
       var isDark = saved
         ? saved === 'dark'
         : window.matchMedia('(prefers-color-scheme: dark)').matches;
@@ -75,7 +75,16 @@ Without this, dark-mode users see a brief light-mode flash on every load before 
 </script>
 ```
 
-Reads the same `mj-login-theme` localStorage key that `MJExplorerAppComponent` writes when the user toggles theme. Falls back to OS `prefers-color-scheme`. Wrapped in try/catch so localStorage exceptions (Safari private mode, disabled storage) can never block app load.
+Reads `mj-theme`, the unified theme key written by:
+
+- `ThemeService.applyBaseThemeAttribute()` post-login — mirrors the resolved base theme (`light` or `dark`), including the OS-resolved value for `'system'` preference
+- `MJExplorerAppComponent.ToggleTheme()` when the user toggles theme on the login screen
+
+The three readers (this inline script, `MJExplorerAppComponent.applyLoginTheme`, `ThemeService`) all share `mj-theme` as the single source of truth, so they paint in sync with no flash.
+
+`mj-theme` is preserved across logout by `MJExplorerAuthBase.preservedLocalStorageKeys` so the login screen continues to show the user's last theme without flashing back to OS default.
+
+Falls back to OS `prefers-color-scheme` on true first visits with no saved preference. Wrapped in try/catch so localStorage exceptions (Safari private mode, disabled storage) can never block app load.
 
 Combined with the SW app-shell pre-cache, dark-mode users see correct theme paint within ~100ms of navigation start.
 

--- a/packages/Angular/Generic/shared/src/lib/theme.service.ts
+++ b/packages/Angular/Generic/shared/src/lib/theme.service.ts
@@ -30,6 +30,21 @@ export interface ThemeDefinition {
 const THEME_SETTING_KEY = 'Explorer.Theme';
 
 /**
+ * localStorage key the inline theme-preload script reads on first paint
+ * (before Angular boots) to apply the correct theme without flashing.
+ *
+ * The value is the **base theme** ('dark' or 'light'), NOT the full theme
+ * preference (which can be 'system' or a custom theme ID like 'izzy-dark').
+ * The preload script needs an unambiguous answer: should I set
+ * data-theme="dark" or not? Storing the base theme is the simplest
+ * contract: the script does `if (value === 'dark') setAttribute(...)`.
+ *
+ * Mirrored by ThemeService whenever the applied base theme changes,
+ * cleared on logout via Reset().
+ */
+const PRELOAD_BASE_THEME_KEY = 'mj-theme';
+
+/**
  * Built-in light theme definition
  */
 const LIGHT_THEME: ThemeDefinition = {
@@ -215,6 +230,14 @@ export class ThemeService {
         document.documentElement.removeAttribute('data-theme');
         document.documentElement.removeAttribute('data-theme-overlay');
 
+        // NOTE: we deliberately do NOT clear PRELOAD_BASE_THEME_KEY here.
+        // The unified theme key ('mj-theme') is the single source of truth
+        // shared with the login-screen toggle and the inline pre-paint script.
+        // Clearing it on logout would force the login screen back to OS
+        // default and cause a theme flash for the post-logout/pre-login
+        // window. The auth provider's clearClientCaches() preserves it for
+        // exactly this reason (see preservedLocalStorageKeys).
+
         // Disable all custom CSS links
         this.disableAllCustomCss();
     }
@@ -257,12 +280,24 @@ export class ThemeService {
     /**
      * Apply the base theme attribute to <html>.
      * 'dark' sets data-theme="dark"; 'light' removes it (matching existing convention).
+     *
+     * Also mirrors the base theme to localStorage under PRELOAD_BASE_THEME_KEY
+     * so the inline pre-bootstrap theme-preload script in index.html can apply
+     * the correct theme on first paint of the next page load — eliminating
+     * the brief light-mode flash dark-mode users would otherwise see.
      */
     private applyBaseThemeAttribute(baseTheme: 'light' | 'dark'): void {
         if (baseTheme === 'dark') {
             document.documentElement.setAttribute('data-theme', 'dark');
         } else {
             document.documentElement.removeAttribute('data-theme');
+        }
+        try {
+            window.localStorage.setItem(PRELOAD_BASE_THEME_KEY, baseTheme);
+        } catch (e) {
+            // localStorage exceptions (private mode, quota) are non-fatal here —
+            // the app still works, the user just may see a brief theme flash on
+            // their next reload.
         }
     }
 

--- a/packages/MJExplorer/src/index.html
+++ b/packages/MJExplorer/src/index.html
@@ -8,16 +8,17 @@
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <!--
     Theme pre-paint — sets data-theme="dark" on <html> BEFORE Angular
-    boots, so the very first frame paints with the user's chosen theme
-    instead of flashing light first. Reads the same localStorage key
-    MJExplorerAppComponent uses; falls back to OS prefers-color-scheme.
-    Wrapped in try/catch so localStorage exceptions (Safari private mode,
-    disabled storage) can never block the app from loading.
+    boots so the first frame paints with the user's saved theme instead
+    of flashing light first. Reads 'mj-theme', the unified key written by
+    both ThemeService (post-login) and the login-screen toggle. Falls back
+    to OS prefers-color-scheme on true first visits. Wrapped in try/catch
+    so localStorage exceptions (Safari private mode, disabled storage) can
+    never block app load.
   -->
   <script>
     (function () {
       try {
-        var saved = localStorage.getItem('mj-login-theme');
+        var saved = localStorage.getItem('mj-theme');
         var isDark = saved ? saved === 'dark' : window.matchMedia('(prefers-color-scheme: dark)').matches;
         if (isDark) document.documentElement.setAttribute('data-theme', 'dark');
       } catch (e) { /* swallow — theme just falls back to light */ }


### PR DESCRIPTION
## Summary

Fixes the brief light-mode flash dark-mode users saw on every page load by unifying the theme storage system to a single localStorage key (\`mj-theme\`) shared across all three theme-aware paths.

## Root cause of the original flash

The inline pre-paint script in MJExplorer's \`index.html\` correctly set \`data-theme\` on first paint based on the user's preference. But \`MJExplorerAppComponent.applyLoginTheme()\` then ran during Angular bootstrap and re-read a **different** localStorage key (\`'mj-login-theme'\`), overriding the script's correct decision. \`ThemeService\` eventually overrode it back. Result: visible dark↔light flash on every reload.

Three theme-aware code paths, three different storage conventions. The fix is to make them all read/write the same key.

## What's in the PR

### `@memberjunction/ng-shared-generic` (`ThemeService`)
- Adds \`PRELOAD_BASE_THEME_KEY = 'mj-theme'\`.
- \`applyBaseThemeAttribute()\` now mirrors the resolved base theme (\`light\` or \`dark\`) to localStorage on every theme application — including initial load from server preference, manual \`SetTheme()\` calls, and OS-change responses for \`'system'\` preference. Stores the **resolved** base, so the inline pre-paint script can apply the right theme synchronously without server lookup or \`'system'\` evaluation.
- \`Reset()\` deliberately preserves the key (commented why) so the login screen retains correct theme through logout.

### `@memberjunction/ng-auth-services` (`MJExplorerAuthBase`)
- \`preservedLocalStorageKeys\` now contains \`'mj-theme'\` (was \`'mj-login-theme'\`) so the unified key survives logout.

### `@memberjunction/ng-explorer-app` (`MJExplorerAppComponent`)
- \`THEME_STORAGE_KEY\` changed from \`'mj-login-theme'\` to \`'mj-theme'\`. Login-screen toggle (\`ToggleTheme()\`) now writes the unified key.
- \`applyLoginTheme()\` reads the unified key with the same lookup the inline script uses, so Angular bootstrap doesn't override the script's decision.

### `@memberjunction/ng-explorer-service-worker`
- README backport snippet updated to match (read only \`mj-theme\`).

### MJExplorer
- Inline pre-paint script in \`index.html\` reads \`mj-theme\`. Plus comment explaining the unified-key contract for anyone touching it later.

### Tests
- \`@memberjunction/ng-auth-services\` logout/preservation tests updated for the new key. 5/5 pass. (3 pre-existing \`AngularAuthProviderFactory\` test failures unrelated and exist on \`next\`.)

## Migration impact

| Cohort | Behavior |
|---|---|
| Users with \`mj-theme\` already set (most logged-in users after the previous Option B work) | Zero impact, instant correct theme on every reload |
| Users with only legacy \`mj-login-theme\` from older versions | One flash on first visit after this lands. \`ThemeService\` then writes \`mj-theme\` on next theme application. Flash-free forever after. |

The legacy fallback read was deliberately dropped for code simplicity — the one-time migration flash is an acceptable cost. The stale \`mj-login-theme\` localStorage entry remains harmless dead data.

## Verified end-to-end

- ✅ Playwright in a logged-in browser session against a production build of MJExplorer
- ✅ \`data-theme\` correctly set at \`DOMContentLoaded\` and stays consistent through Angular bootstrap (was: flipped during bootstrap)
- ✅ All 4 affected packages build clean
- ✅ MJExplorer postbuild SW cache-shape gate green
- ✅ \`@memberjunction/ng-auth-services\` logout/preserve unit tests: 5/5 pass

## Files touched

| Area | Files |
|---|---|
| Theme service | \`packages/Angular/Generic/shared/src/lib/theme.service.ts\` |
| Auth preservation | \`packages/Angular/Explorer/auth-services/src/lib/mjexplorer-auth-base.service.ts\` (+ tests) |
| Explorer-app component | \`packages/Angular/Explorer/explorer-app/src/lib/explorer-app.component.ts\` |
| MJExplorer index.html | \`packages/MJExplorer/src/index.html\` |
| SW package README | \`packages/Angular/Explorer/service-worker/README.md\` |
| Changeset | \`.changeset/unified-theme-key.md\` |

## Test plan

- [x] All affected packages build clean
- [x] Auth-services logout/preserve unit tests pass
- [x] MJExplorer prod build passes the SW postbuild gate
- [x] In-browser smoke test confirms no flash post-fix
- [ ] Reviewer hard-reloads MJExplorer prod build and confirms no theme flash

🤖 Generated with [Claude Code](https://claude.com/claude-code)