### PR TITLE
fix: vectorization crash and scheduled job lock hardening

### DIFF
--- a/.changeset/bright-locks-clean.md
+++ b/.changeset/bright-locks-clean.md
@@ -1,0 +1,6 @@
+---
+"@memberjunction/actions-content-autotag": patch
+"@memberjunction/scheduling-engine": patch
+---
+
+fix vectorization crash from using non-provider Metadata() fallback, and harden ScheduledJobEngine lock lifecycle with save verification and DB reload after stale lock cleanup

--- a/packages/Actions/ContentAutotag/src/generic/content-autotag-and-vectorize.action.ts
+++ b/packages/Actions/ContentAutotag/src/generic/content-autotag-and-vectorize.action.ts
@@ -198,7 +198,10 @@ export class AutotagAndVectorizeContentAction extends BaseAction {
         // Resolve the per-request provider once and thread it down the call stack so
         // every BaseEntity / RunView operation in this action runs against the caller's
         // connection (multi-tenant correctness; do not fall through to the global default).
-        const provider = (params.Provider ?? new Metadata()) as unknown as IMetadataProvider;
+        // Use Metadata.Provider (the global ProviderBase which implements IRunViewProvider)
+        // as the fallback — NOT `new Metadata()` which is just a wrapper and doesn't
+        // implement RunView.
+        const provider = (params.Provider ?? Metadata.Provider) as unknown as IMetadataProvider;
 
         // Load all content items, then exclude Entity-sourced items.
         // Entity sources get their vectors via EntityVectorSyncer (Phase 2b),

--- a/packages/Scheduling/engine/src/ScheduledJobEngine.ts
+++ b/packages/Scheduling/engine/src/ScheduledJobEngine.ts
@@ -541,7 +541,18 @@ export class SchedulingEngine extends BaseSingleton<SchedulingEngine> {
             if (job.ExpectedCompletionAt && now > job.ExpectedCompletionAt) {
                 console.log(`      → Lock is STALE, cleaning up...`);
                 this.log(`Detected stale lock on job ${job.Name}, cleaning up`);
-                await this.cleanupStaleLock(job);
+                const cleaned = await this.cleanupStaleLock(job);
+                if (!cleaned) {
+                    console.log(`      ❌ Failed to clean up stale lock, skipping`);
+                    return false;
+                }
+                // Reload from DB to verify cleanup succeeded
+                await job.Load(job.ID);
+                if (job.LockToken != null) {
+                    console.log(`      ❌ Lock still present after cleanup (re-acquired by ${job.LockedByInstance}), skipping`);
+                    return false;
+                }
+                console.log(`      ✓ Stale lock cleaned successfully`);
             } else {
                 console.log(`      → Lock is ACTIVE (not stale), returning false`);
                 return false;
@@ -550,11 +561,22 @@ export class SchedulingEngine extends BaseSingleton<SchedulingEngine> {
             console.log(`      → No lock exists, will try to acquire`);
         }
 
+        return this.attemptLockAcquisition(job);
+    }
+
+    /**
+     * Attempt to acquire a fresh lock on a job that is currently unlocked.
+     * Separated from tryAcquireLock to keep the stale-cleanup and acquisition
+     * paths distinct and easier to follow.
+     * @private
+     */
+    private async attemptLockAcquisition(job: MJScheduledJobEntity): Promise<boolean> {
         const lockToken = this.generateGuid();
         const instanceId = this.getInstanceIdentifier();
         const expectedCompletion = new Date(Date.now() + 10 * 60 * 1000);
 
         try {
+            // Reload to get latest DB state right before acquiring
             await job.Load(job.ID);
 
             if (job.LockToken != null) {
@@ -575,46 +597,59 @@ export class SchedulingEngine extends BaseSingleton<SchedulingEngine> {
                 console.log(`      ✅ Lock acquired successfully!`);
                 return true;
             } else {
-                console.log(`      ❌ Save failed - likely race condition with another server`);
-                job.LockToken = null;
-                job.LockedAt = null;
-                job.LockedByInstance = null;
-                job.ExpectedCompletionAt = null;
+                console.log(`      ❌ Save failed: ${job.LatestResult?.CompleteMessage ?? 'unknown'}`);
+                this.clearInMemoryLockFields(job);
                 return false;
             }
         } catch (error) {
             this.logError(`Failed to acquire lock for job ${job.Name}`, error);
-            job.LockToken = null;
-            job.LockedAt = null;
-            job.LockedByInstance = null;
-            job.ExpectedCompletionAt = null;
+            this.clearInMemoryLockFields(job);
             return false;
         }
+    }
+
+    /**
+     * Clear in-memory lock fields without saving — used when a save attempt
+     * fails and we need the in-memory object to reflect "unlocked" so the
+     * next poll cycle doesn't see a phantom lock.
+     * @private
+     */
+    private clearInMemoryLockFields(job: MJScheduledJobEntity): void {
+        job.LockToken = null;
+        job.LockedAt = null;
+        job.LockedByInstance = null;
+        job.ExpectedCompletionAt = null;
     }
 
     /**
      * Release a lock after job execution
      * @private
      */
-    private async releaseLock(job: MJScheduledJobEntity): Promise<void> {
+    private async releaseLock(job: MJScheduledJobEntity): Promise<boolean> {
         try {
             job.LockToken = null;
             job.LockedAt = null;
             job.LockedByInstance = null;
             job.ExpectedCompletionAt = null;
-            await job.Save();
+            const saved = await job.Save();
+            if (!saved) {
+                this.logError(`Failed to release lock for job ${job.Name}: ${job.LatestResult?.CompleteMessage ?? 'Save returned false'}`);
+            }
+            return saved;
         } catch (error) {
             this.logError(`Failed to release lock for job ${job.Name}`, error);
+            return false;
         }
     }
 
     /**
-     * Clean up a stale lock
+     * Clean up a stale lock. Returns true if the lock was successfully
+     * cleared in the database, false if the save failed.
      * @private
      */
-    private async cleanupStaleLock(job: MJScheduledJobEntity): Promise<void> {
+    private async cleanupStaleLock(job: MJScheduledJobEntity): Promise<boolean> {
         this.log(`Cleaning up stale lock on job ${job.Name} (locked by ${job.LockedByInstance})`);
-        await this.releaseLock(job);
+        return this.releaseLock(job);
     }
 
     /**


### PR DESCRIPTION
## Summary
- **Vectorization crash fix**: `RunDirectVectorization` used `new Metadata()` as a fallback provider, but `Metadata` is just a wrapper class that doesn't implement `IRunViewProvider`. Changed to `Metadata.Provider` which is the global `ProviderBase` with both `IMetadataProvider` and `IRunViewProvider`. This caused `"this.ProviderToUse.RunView is not a function"` during the embedding phase of the content tagging pipeline.
- **Scheduled job lock hardening**: `releaseLock` now checks the `Save()` return value instead of silently ignoring failures. After stale lock cleanup, the job is reloaded from DB to verify the lock was actually cleared before attempting re-acquisition. Extracted `attemptLockAcquisition` and `clearInMemoryLockFields` helpers for clarity.

## Test plan
- [ ] Run content tagging pipeline with vectorization enabled — verify Phase 2 no longer crashes with RunView error
- [ ] Trigger a stale lock scenario on a scheduled job — verify lock cleanup is reported accurately and re-acquisition proceeds correctly
- [ ] Verify scheduled jobs that complete normally still release locks without issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)