### PR TITLE
fix(runtime SQL): route BaseView orphan/IS-A queries through SQLDialect

### DIFF
--- a/.changeset/quiet-comets-orbit.md
+++ b/.changeset/quiet-comets-orbit.md
@@ -1,0 +1,5 @@
+---
+"@memberjunction/core-actions": patch
+---
+
+Fix scheduled geocoding orphan-cleanup filter to query the entity's `BaseView` (not `BaseTable`) and bracket-quote the schema, view, and primary-key identifiers, so cleanup works for entities backed by views and tolerates spaces/reserved words in identifiers.

--- a/.changeset/quiet-comets-orbit.md
+++ b/.changeset/quiet-comets-orbit.md
@@ -1,5 +1,12 @@
 ---
+"@memberjunction/sql-dialect": patch
+"@memberjunction/sqlserver-dataprovider": patch
+"@memberjunction/postgresql-dataprovider": patch
 "@memberjunction/core-actions": patch
 ---
 
-Fix scheduled geocoding orphan-cleanup filter to query the entity's `BaseView` (not `BaseTable`) and bracket-quote the schema, view, and primary-key identifiers, so cleanup works for entities backed by views and tolerates spaces/reserved words in identifiers.
+Fix two runtime SQL paths that referenced an entity's `BaseTable` directly, which fails under tightened DB grants (the runtime app user has SELECT only on BaseViews and EXECUTE on CRUD sprocs). Both paths now read from `BaseView` and route their identifier, string-literal, and bounded-string-cast generation through `SQLDialect` so the same code produces correct SQL on SQL Server, PostgreSQL, and any future supported platform.
+
+Adds three new helpers to `SQLDialect`: `QuoteStringLiteral` (concrete, both dialects share `''`-doubling escape), `QuoteColumnAlias` (abstract — bare on SQL Server, double-quoted on PG to preserve case), and `CastToBoundedString` (concrete, composed from existing `ResolveAbstractType` so it emits `NVARCHAR(450)` on SQL Server and `VARCHAR(450)` on PG).
+
+Refactored sites: `ScheduledGeocodingAction` orphan-cleanup `NOT EXISTS` filter, and `BuildChildDiscoverySQL` (IS-A subtype probe) on both `SQLServerDataProvider` and `PostgreSQLDataProvider` — the latter two also fix the runtime-failing `FROM [schema].[BaseTable]` shape that fired on every IS-A entity load and on the `FindISAChildEntity` GraphQL resolver.

--- a/package-lock.json
+++ b/package-lock.json
@@ -42208,6 +42208,7 @@
         "@memberjunction/global": "5.32.0",
         "@memberjunction/integration-engine": "5.32.0",
         "@memberjunction/search-engine": "5.32.0",
+        "@memberjunction/sql-dialect": "5.32.0",
         "@memberjunction/sqlserver-dataprovider": "5.32.0",
         "@memberjunction/storage": "5.32.0",
         "@types/d3-cloud": "^1.2.9",

--- a/packages/Actions/CoreActions/package.json
+++ b/packages/Actions/CoreActions/package.json
@@ -51,6 +51,7 @@
     "@memberjunction/global": "5.32.0",
     "@memberjunction/integration-engine": "5.32.0",
     "@memberjunction/search-engine": "5.32.0",
+    "@memberjunction/sql-dialect": "5.32.0",
     "@memberjunction/sqlserver-dataprovider": "5.32.0",
     "@memberjunction/storage": "5.32.0",
     "@types/d3-cloud": "^1.2.9",

--- a/packages/Actions/CoreActions/src/custom/geo/scheduled-geocoding.action.ts
+++ b/packages/Actions/CoreActions/src/custom/geo/scheduled-geocoding.action.ts
@@ -3,10 +3,11 @@ import { BaseAction } from '@memberjunction/actions';
 import { RegisterClass, MJGlobal, MJEventType } from '@memberjunction/global';
 import {
     RunView, Metadata, LogStatus, LogError, UserInfo, EntityInfo,
-    CompositeKey, BaseEntity, BaseEntityEvent, IMetadataProvider
+    CompositeKey, BaseEntity, BaseEntityEvent, IMetadataProvider, DatabaseProviderBase
 } from '@memberjunction/core';
 import { MJRecordGeoCodeEntity } from '@memberjunction/core-entities';
 import { GeoCodeSyncService, ExistingGeoCodeInfo } from '@memberjunction/geo-core';
+import { GetDialect, SQLDialect } from '@memberjunction/sql-dialect';
 
 /**
  * Scheduled geocoding maintenance action that handles three tasks:
@@ -348,6 +349,12 @@ export class ScheduledGeocodingAction extends BaseAction {
     ): Promise<number> {
         const rv = new RunView();
         const md = (provider ?? new Metadata()) as unknown as IMetadataProvider;
+        // Resolve the dialect for the active provider once — the orphan filter
+        // is built per-entity but the dialect (SQL Server vs PostgreSQL) is
+        // bound to the provider, not the entity, so deriving it here keeps
+        // the per-entity loop dialect-agnostic.
+        const platformKey = (md as unknown as DatabaseProviderBase).PlatformKey ?? 'sqlserver';
+        const dialect = GetDialect(platformKey);
         let totalRemoved = 0;
 
         // Get distinct EntityIDs from RecordGeoCode (lightweight — just IDs)
@@ -371,7 +378,7 @@ export class ScheduledGeocodingAction extends BaseAction {
                 if (!pkField) continue;
 
                 const entityRemoved = await this.cleanupOrphansForEntity(
-                    entityId, entityInfo, pkField.Name, contextUser, batchSize, rv
+                    entityId, entityInfo, pkField.Name, contextUser, batchSize, rv, dialect
                 );
                 totalRemoved += entityRemoved;
             } catch (e: unknown) {
@@ -394,10 +401,15 @@ export class ScheduledGeocodingAction extends BaseAction {
         pkFieldName: string,
         contextUser: UserInfo,
         batchSize: number,
-        rv: RunView
+        rv: RunView,
+        dialect: SQLDialect
     ): Promise<number> {
         let entityRemoved = 0;
-        const orphanFilter = `EntityID = '${entityId}' AND NOT EXISTS (SELECT 1 FROM [${entityInfo.SchemaName}].[${entityInfo.BaseView}] src WHERE CAST(src.[${pkFieldName}] AS NVARCHAR(450)) = RecordID)`;
+        const sourceRef = dialect.QuoteSchema(entityInfo.SchemaName, entityInfo.BaseView);
+        const pkRef = `src.${dialect.QuoteIdentifier(pkFieldName)}`;
+        const pkAsString = dialect.CastToBoundedString(pkRef, 450);
+        const entityIdLit = dialect.QuoteStringLiteral(entityId);
+        const orphanFilter = `EntityID = ${entityIdLit} AND NOT EXISTS (SELECT 1 FROM ${sourceRef} src WHERE ${pkAsString} = RecordID)`;
 
         // Paginate: fetch a page, delete it, repeat. Since we're deleting rows,
         // always query from the start — deleted rows won't appear again.

--- a/packages/Actions/CoreActions/src/custom/geo/scheduled-geocoding.action.ts
+++ b/packages/Actions/CoreActions/src/custom/geo/scheduled-geocoding.action.ts
@@ -397,7 +397,7 @@ export class ScheduledGeocodingAction extends BaseAction {
         rv: RunView
     ): Promise<number> {
         let entityRemoved = 0;
-        const orphanFilter = `EntityID = '${entityId}' AND NOT EXISTS (SELECT 1 FROM ${entityInfo.SchemaName}.${entityInfo.BaseTable} src WHERE CAST(src.${pkFieldName} AS NVARCHAR(450)) = RecordID)`;
+        const orphanFilter = `EntityID = '${entityId}' AND NOT EXISTS (SELECT 1 FROM [${entityInfo.SchemaName}].[${entityInfo.BaseView}] src WHERE CAST(src.[${pkFieldName}] AS NVARCHAR(450)) = RecordID)`;
 
         // Paginate: fetch a page, delete it, repeat. Since we're deleting rows,
         // always query from the start — deleted rows won't appear again.

--- a/packages/PostgreSQLDataProvider/src/PostgreSQLDataProvider.ts
+++ b/packages/PostgreSQLDataProvider/src/PostgreSQLDataProvider.ts
@@ -78,18 +78,22 @@ export class PostgreSQLDataProvider extends GenericDatabaseProvider {
         return PostgreSQLDataProvider._pgDefaultPattern;
     }
 
+    /**
+     * Probes each child entity's BaseView (not BaseTable) so the runtime SQL
+     * identity — which has SELECT only on views — can execute the union. All
+     * identifier and string-literal formatting goes through the dialect.
+     */
     protected override BuildChildDiscoverySQL(childEntities: EntityInfo[], recordPKValue: string): string {
-        const safePKValue = recordPKValue.replace(/'/g, "''");
+        const pkValueLit = pgDialect.QuoteStringLiteral(recordPKValue);
+        const aliasName = pgDialect.QuoteColumnAlias('EntityName');
         const unionParts = childEntities
             .filter(child => child.PrimaryKeys.length > 0)
             .map(child => {
                 const schema = child.SchemaName || '__mj';
-                const table = child.BaseTable;
-                const pkName = child.PrimaryKeys[0].Name;
-                const safeName = child.Name.replace(/'/g, "''");
-                const safeSchema = pgDialect.QuoteSchema(schema, table);
-                const safePK = pgDialect.QuoteIdentifier(pkName);
-                return "SELECT '" + safeName + '\' AS "EntityName" FROM ' + safeSchema + ' WHERE ' + safePK + " = '" + safePKValue + "'";
+                const sourceRef = pgDialect.QuoteSchema(schema, child.BaseView);
+                const pkRef = pgDialect.QuoteIdentifier(child.PrimaryKeys[0].Name);
+                const nameLit = pgDialect.QuoteStringLiteral(child.Name);
+                return `SELECT ${nameLit} AS ${aliasName} FROM ${sourceRef} WHERE ${pkRef} = ${pkValueLit}`;
             });
         if (unionParts.length === 0) return '';
         return unionParts.join(' UNION ALL ');

--- a/packages/SQLDialect/src/__tests__/postgresqlDialect.test.ts
+++ b/packages/SQLDialect/src/__tests__/postgresqlDialect.test.ts
@@ -515,4 +515,34 @@ describe('PostgreSQLDialect', () => {
             expect(ddl).toContain('BEFORE INSERT OR UPDATE');
         });
     });
+
+    describe('QuoteStringLiteral', () => {
+        it('wraps a value in single quotes', () => {
+            expect(dialect.QuoteStringLiteral('hello')).toBe("'hello'");
+        });
+
+        it("doubles internal apostrophes (same convention as SQL Server)", () => {
+            expect(dialect.QuoteStringLiteral("O'Brien")).toBe("'O''Brien'");
+        });
+    });
+
+    describe('QuoteColumnAlias', () => {
+        it('double-quotes the alias to preserve case', () => {
+            expect(dialect.QuoteColumnAlias('EntityName')).toBe('"EntityName"');
+        });
+
+        it('preserves mixed casing exactly (PG would lowercase otherwise)', () => {
+            expect(dialect.QuoteColumnAlias('IDValue')).toBe('"IDValue"');
+        });
+    });
+
+    describe('CastToBoundedString', () => {
+        it('emits CAST AS VARCHAR(450) by default', () => {
+            expect(dialect.CastToBoundedString('src."ID"')).toBe('CAST(src."ID" AS VARCHAR(450))');
+        });
+
+        it('honours an explicit maxLength', () => {
+            expect(dialect.CastToBoundedString('x', 100)).toBe('CAST(x AS VARCHAR(100))');
+        });
+    });
 });

--- a/packages/SQLDialect/src/__tests__/sqlServerDialect.test.ts
+++ b/packages/SQLDialect/src/__tests__/sqlServerDialect.test.ts
@@ -346,4 +346,42 @@ describe('SQLServerDialect', () => {
             expect(dialect.IsNull('@MyParam', '[Status]')).toBe('ISNULL(@MyParam, [Status])');
         });
     });
+
+    describe('QuoteStringLiteral', () => {
+        it('wraps a value in single quotes', () => {
+            expect(dialect.QuoteStringLiteral('hello')).toBe("'hello'");
+        });
+
+        it("doubles internal apostrophes for SQL injection safety", () => {
+            expect(dialect.QuoteStringLiteral("O'Brien")).toBe("'O''Brien'");
+        });
+
+        it("handles values with multiple apostrophes", () => {
+            expect(dialect.QuoteStringLiteral("it's a 'test'")).toBe("'it''s a ''test'''");
+        });
+
+        it('returns just the quotes for empty input', () => {
+            expect(dialect.QuoteStringLiteral('')).toBe("''");
+        });
+    });
+
+    describe('QuoteColumnAlias', () => {
+        it('returns a bare identifier (SQL Server is case-insensitive)', () => {
+            expect(dialect.QuoteColumnAlias('EntityName')).toBe('EntityName');
+        });
+    });
+
+    describe('CastToBoundedString', () => {
+        it('emits CAST AS NVARCHAR(450) by default to match indexable RecordID width', () => {
+            expect(dialect.CastToBoundedString('src.[ID]')).toBe('CAST(src.[ID] AS NVARCHAR(450))');
+        });
+
+        it('honours an explicit maxLength', () => {
+            expect(dialect.CastToBoundedString('x', 100)).toBe('CAST(x AS NVARCHAR(100))');
+        });
+
+        it('falls back to NVARCHAR(MAX) above 4000 chars (matches resolveStringType)', () => {
+            expect(dialect.CastToBoundedString('x', 8000)).toBe('CAST(x AS NVARCHAR(MAX))');
+        });
+    });
 });

--- a/packages/SQLDialect/src/postgresqlDialect.ts
+++ b/packages/SQLDialect/src/postgresqlDialect.ts
@@ -168,6 +168,17 @@ export class PostgreSQLDialect extends SQLDialect {
         return `${schema}."${object}"`;
     }
 
+    /**
+     * PostgreSQL folds unquoted identifiers to lowercase, which would turn
+     * `AS EntityName` into the result column `entityname`. Quoting the
+     * alias preserves the requested casing for callers that key off the
+     * column name (e.g. when consuming results into a TypeScript object
+     * with a PascalCase property).
+     */
+    QuoteColumnAlias(aliasName: string): string {
+        return `"${aliasName}"`;
+    }
+
     // ─── Pagination ──────────────────────────────────────────────────
 
     LimitClause(limit: number, offset?: number): LimitClauseResult {

--- a/packages/SQLDialect/src/sqlDialect.ts
+++ b/packages/SQLDialect/src/sqlDialect.ts
@@ -184,6 +184,26 @@ export abstract class SQLDialect implements SQLParserDialect {
      */
     abstract QuoteSchema(schema: string, object: string): string;
 
+    /**
+     * Quotes a column alias used in `SELECT ... AS <alias>`. SQL Server is
+     * case-insensitive and accepts a bare identifier; PostgreSQL folds
+     * unquoted identifiers to lowercase, so we must quote the alias when the
+     * caller cares about preserving case (e.g. matching a TypeScript property
+     * name in the result row).
+     */
+    abstract QuoteColumnAlias(aliasName: string): string;
+
+    /**
+     * Quotes a value as a SQL string literal. Both SQL Server and PostgreSQL
+     * use single quotes with `''` doubling to escape internal apostrophes —
+     * this is concrete in the base class so callers don't reinvent the
+     * `value.replace(/'/g, "''")` pattern. Subclasses may override if a
+     * future dialect needs a different escape rule.
+     */
+    QuoteStringLiteral(value: string): string {
+        return `'${value.replace(/'/g, "''")}'`;
+    }
+
     // ─── Pagination ──────────────────────────────────────────────────
 
     /**
@@ -264,6 +284,22 @@ export abstract class SQLDialect implements SQLParserDialect {
      * SQL Server: CAST(expr AS NVARCHAR(MAX)), PostgreSQL: CAST(expr AS TEXT)
      */
     abstract CastToText(expr: string): string;
+
+    /**
+     * Returns a CAST to a bounded-width string type. Used when the result
+     * needs to be comparable against an indexed column (SQL Server cannot
+     * compare/index `NVARCHAR(MAX)`) or against a fixed-width text column
+     * such as MJ's `RecordID` (NVARCHAR(450) on SQL Server).
+     *
+     * Implemented by composing `ResolveAbstractType({ type: 'string', maxLength })`,
+     * which dialects already supply — SQL Server emits `NVARCHAR(N)` and
+     * PostgreSQL emits `VARCHAR(N)`. Defaults to MJ's standard 450-char
+     * width to match the cap on indexable string columns in SQL Server.
+     */
+    CastToBoundedString(expr: string, maxLength: number = 450): string {
+        const sqlType = this.ResolveAbstractType({ type: 'string', maxLength });
+        return `CAST(${expr} AS ${sqlType})`;
+    }
 
     /**
      * Returns a CAST-to-UUID expression.

--- a/packages/SQLDialect/src/sqlServerDialect.ts
+++ b/packages/SQLDialect/src/sqlServerDialect.ts
@@ -141,6 +141,15 @@ export class SQLServerDialect extends SQLDialect {
         return `[${schema}].[${object}]`;
     }
 
+    /**
+     * SQL Server identifiers are case-insensitive by default, so a bare
+     * alias preserves the requested casing when echoed in result-set
+     * column metadata. Bracketed quoting would also work but is unnecessary.
+     */
+    QuoteColumnAlias(aliasName: string): string {
+        return aliasName;
+    }
+
     // ─── Pagination ──────────────────────────────────────────────────
 
     LimitClause(limit: number, offset?: number): LimitClauseResult {

--- a/packages/SQLServerDataProvider/src/SQLServerDataProvider.ts
+++ b/packages/SQLServerDataProvider/src/SQLServerDataProvider.ts
@@ -1973,24 +1973,32 @@ export class SQLServerDataProvider
 
 
   /**
-   * Builds a UNION ALL query that checks each child entity's base table for a record
-   * with the given primary key. Returns the first match (disjoint subtypes guarantee
-   * at most one result) unless used with overlapping subtypes.
+   * Builds a UNION ALL query that probes each child entity's BaseView for a
+   * record with the given primary key. Returns the first match (disjoint
+   * subtypes guarantee at most one result) unless used with overlapping
+   * subtypes.
+   *
+   * Probes BaseView rather than BaseTable so the runtime SQL identity, which
+   * has SELECT only on views (not on the underlying tables), can execute it.
+   * All identifier and string-literal formatting is delegated to the dialect
+   * so the same generation logic produces correct SQL on any future platform.
    */
   protected override BuildChildDiscoverySQL(
     childEntities: EntityInfo[],
     recordPKValue: string
   ): string {
-    // Sanitize the PK value to prevent SQL injection
-    const safePKValue = recordPKValue.replace(/'/g, "''");
+    const dialect = this.getDialect();
+    const pkValueLit = dialect.QuoteStringLiteral(recordPKValue);
+    const aliasName = dialect.QuoteColumnAlias('EntityName');
 
     const unionParts = childEntities
       .filter(child => child.PrimaryKeys.length > 0)
       .map(child => {
         const schema = child.SchemaName || '__mj';
-        const table = child.BaseTable;
-        const pkName = child.PrimaryKeys[0].Name;
-        return `SELECT '${child.Name.replace(/'/g, "''")}' AS EntityName FROM [${schema}].[${table}] WHERE [${pkName}] = '${safePKValue}'`;
+        const sourceRef = dialect.QuoteSchema(schema, child.BaseView);
+        const pkRef = dialect.QuoteIdentifier(child.PrimaryKeys[0].Name);
+        const nameLit = dialect.QuoteStringLiteral(child.Name);
+        return `SELECT ${nameLit} AS ${aliasName} FROM ${sourceRef} WHERE ${pkRef} = ${pkValueLit}`;
       });
 
     if (unionParts.length === 0) return '';


### PR DESCRIPTION
## Summary

Three runtime SQL paths were hitting an entity's `BaseTable` directly and/or hand-rolling identifier and string-literal formatting that wouldn't translate to PostgreSQL. The runtime DB user (`DB_USERNAME`) only has `SELECT` on BaseViews and `EXECUTE` on CRUD sprocs, so any direct `FROM [Schema].[BaseTable]` shape ships broken under tightened permissions. This PR fixes all three by reading from `BaseView` and routing identifier, literal, and bounded-string-cast generation through `@memberjunction/sql-dialect` so the same code produces correct SQL on SQL Server, PostgreSQL, and any future supported platform.

## What changed

**New helpers in `@memberjunction/sql-dialect`:**

| Method | Where | Why |
|---|---|---|
| `QuoteStringLiteral(value)` | concrete in base | Both dialects share `'`-wrap + `''`-doubling — stops every caller from hand-rolling `value.replace(/'/g, "''")`. |
| `QuoteColumnAlias(aliasName)` | abstract per dialect | SQL Server returns the bare alias (case-insensitive). PostgreSQL double-quotes it so `EntityName` doesn't get folded to `entityname` in result rows. |
| `CastToBoundedString(expr, maxLength=450)` | concrete in base | Composes existing `ResolveAbstractType({type:'string', maxLength})` — emits `NVARCHAR(N)` on SQL Server and `VARCHAR(N)` on PostgreSQL. Default 450 matches MJ's standard indexable-string cap. |

**Refactored sites:**

1. [`ScheduledGeocodingAction.cleanupOrphansForEntity`](packages/Actions/CoreActions/src/custom/geo/scheduled-geocoding.action.ts#L391-L408) — orphan-detection `NOT EXISTS` subquery now goes through `dialect.QuoteSchema` / `QuoteIdentifier` / `CastToBoundedString` / `QuoteStringLiteral`. The dialect is resolved once in `cleanupOrphanedRecords` from the request-scoped provider's `PlatformKey` and threaded down so the per-entity loop stays platform-agnostic.

2. [`SQLServerDataProvider.BuildChildDiscoverySQL`](packages/SQLServerDataProvider/src/SQLServerDataProvider.ts#L1980-L2007) — IS-A subtype probe was reading from `[Schema].[BaseTable]`. Now reads from `BaseView` via `dialect.QuoteSchema` and uses `QuoteIdentifier` / `QuoteStringLiteral` / `QuoteColumnAlias` for the rest.

3. [`PostgreSQLDataProvider.BuildChildDiscoverySQL`](packages/PostgreSQLDataProvider/src/PostgreSQLDataProvider.ts#L81-L101) — same fix on the PG side; switches from `child.BaseTable` to `child.BaseView` and replaces the remaining hand-rolled string concatenation with dialect calls.

## Why the IS-A fix matters

`BuildChildDiscoverySQL` runs on **every IS-A subtype lookup** — both server-internally during `BaseEntity` hydration ([`baseEntity.ts:1066`](packages/MJCore/src/generic/baseEntity.ts#L1066)) and on demand from clients via the [`FindISAChildEntity` GraphQL resolver](packages/MJServer/src/resolvers/ISAEntityResolver.ts#L59-L88). Its old form would silently work in dev (where the dev account often has dbo) but fail in any environment where the runtime account's grants are tightened to the documented baseline. Both bugs were surfaced in a broader audit and bundled into this PR because they share the same shape and the same fix.

## Tests

- 12 new unit tests in `@memberjunction/sql-dialect` covering the three new helpers across both dialects.
- Full suites pass: SQLDialect 212/212, MJCore 1099/1099, CoreActions 68/68, PostgreSQLDataProvider 90/90.
- SQLServerDataProvider has 2 pre-existing failures in `sql-utils.test.ts > QueryParameterProcessor.validateParameters > default value handling` — verified unrelated by re-running with these changes stashed (same 2 failures).

## Test plan

- [ ] Run the Scheduled Geocoding action against an entity whose `BaseTable` and `BaseView` differ; confirm the orphan pass no longer over-deletes geocode records that still resolve via the view.
- [ ] Re-run on a "normal" entity (BaseTable == BaseView's source) and confirm orphan counts match the pre-change behavior.
- [ ] Sanity-check on an entity whose schema or view name contains spaces or a reserved word — verify the generated SQL parses on both SQL Server and PostgreSQL.
- [ ] Load an IS-A subtype record (e.g. via the Explorer) and confirm `FindISAChildEntity` resolves the child entity correctly on both platforms.
- [ ] Run a tightened-permissions smoke pass: connect MJAPI as a user with only `SELECT` on `vw*` and `EXECUTE` on `sp*`, then exercise an IS-A entity load and a Scheduled Geocoding orphan-cleanup run. Both should succeed.
- [ ] Verify pagination still terminates correctly in the geocoding orphan loop after the filter change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)