### PR TITLE
Add Gemini 3.1 Flash-Lite as top priority for Sage Multimodal config

### DIFF
--- a/.changeset/whole-meteors-cross.md
+++ b/.changeset/whole-meteors-cross.md
@@ -1,0 +1,5 @@
+---
+"@memberjunction/ai-prompts": minor
+---
+
+metadata

--- a/metadata/prompts/.prompts.json
+++ b/metadata/prompts/.prompts.json
@@ -1411,6 +1411,22 @@
             "lastModified": "2026-04-06T11:01:32.473Z",
             "checksum": "997de1960f15c66147e70257a981fd028cf8084e0ad251931e8a59d87fdc3caf"
           }
+        },
+        {
+          "fields": {
+            "PromptID": "@parent:ID",
+            "ModelID": "@lookup:MJ: AI Models.Name=Gemini 3.1 Flash-Lite",
+            "VendorID": "@lookup:MJ: AI Vendors.Name=Google",
+            "ConfigurationID": "@lookup:MJ: AI Configurations.Name=Sage Multimodal",
+            "Priority": 30
+          },
+          "primaryKey": {
+            "ID": "ED9F8A84-ADD0-4012-B86E-D9C4DE32D7AC"
+          },
+          "sync": {
+            "lastModified": "2026-05-05T16:03:48.429Z",
+            "checksum": "13d12919065497a2846039dd501c8c0a1d6cc7c73cede093abe890c7a3ef803e"
+          }
         }
       ]
     },
@@ -1611,7 +1627,7 @@
       "ID": "F89C5890-D5CD-4824-B431-329799047372"
     },
     "sync": {
-      "lastModified": "2026-04-27T18:51:16.589Z",
+      "lastModified": "2026-05-05T15:49:00.413Z",
       "checksum": "58c5a32b26dbd537e582dbf4e529ecb30e9a1ac298435277fe32df922914eb48"
     }
   }


### PR DESCRIPTION
## Summary

Adds a new AI Prompt Model binding to the **Sage - System Prompt** that scopes **Gemini 3.1 Flash-Lite (Google)** at Priority 30 to the **Sage Multimodal** AI Configuration. This ensures multimodal Sage conversations default to a vision-capable model rather than falling through to text-only fallbacks.

## Changes

- **`metadata/prompts/.prompts.json`** — New `MJ: AI Prompt Models` entry on the Sage system prompt:
  - `ModelID`: Gemini 3.1 Flash-Lite
  - `VendorID`: Google
  - `ConfigurationID`: Sage Multimodal
  - `Priority`: 30
- **`.changeset/whole-meteors-cross.md`** — Metadata-only patch changeset

## Behavior

| Scenario | Selected model |
|---|---|
| Sage invoked with `Sage Multimodal` config (e.g. via @mention preset) | **Gemini 3.1 Flash-Lite / Google** (P30) |
| Sage invoked with `Sage Text` config | Existing GPT-OSS-120B / Cerebras (P22) |
| Ambient Sage runs with no config | Existing no-config bindings unchanged (GPT-OSS-120B P25, Gemini Google P20, Vertex P19, GPT 5-mini P1) |

Note: `AIPromptRunner` filters config-scoped bindings out of runs that don't supply a `configurationId`, so this addition has no effect on the ambient flow — it only activates when a caller explicitly selects the Sage Multimodal configuration.

## Test plan

- [ ] Push metadata: `npx mj sync push --dir=metadata --include="prompts"`
- [ ] Restart MJAPI to refresh the prompt-model cache
- [ ] @mention Sage with the Sage Multimodal configuration preset and confirm the run picks Gemini 3.1 Flash-Lite (check `MJ: AI Prompt Runs` for `ModelID`/`VendorID`)
- [ ] Verify ambient Sage runs (no @mention) still hit GPT-OSS-120B / Cerebras as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)