### PR TITLE
fix(explorer): bind DevTools/About/Profile components to provider via BaseAngularComponent

### DIFF
--- a/packages/Angular/Explorer/dashboards/src/DevTools/app-state-inspector.component.ts
+++ b/packages/Angular/Explorer/dashboards/src/DevTools/app-state-inspector.component.ts
@@ -2,7 +2,6 @@ import { Component, OnInit, OnDestroy, ChangeDetectorRef } from '@angular/core';
 import { BaseResourceComponent } from '@memberjunction/ng-shared';
 import { RegisterClass } from '@memberjunction/global';
 import { DevToolsPrefs } from './dev-tools-prefs';
-import { Metadata } from '@memberjunction/core';
 import { GraphQLDataProvider } from '@memberjunction/graphql-dataprovider';
 import { WorkspaceStateManager } from '@memberjunction/ng-base-application';
 import { DeveloperModeService } from '@memberjunction/ng-shared';
@@ -129,7 +128,7 @@ export class AppStateInspectorComponent extends BaseResourceComponent implements
     }
 
     private userData(): unknown {
-        const user = Metadata.Provider?.CurrentUser;
+        const user = this.ProviderToUse?.CurrentUser;
         if (!user) return { error: 'No current user' };
         return {
             ID: user.ID,
@@ -146,7 +145,7 @@ export class AppStateInspectorComponent extends BaseResourceComponent implements
     }
 
     private providerData(): unknown {
-        const provider = Metadata.Provider;
+        const provider = this.ProviderToUse;
         if (!provider) return { error: 'No provider' };
         const data: Record<string, unknown> = {
             type: provider.constructor.name,

--- a/packages/Angular/Explorer/dashboards/src/DevTools/graphql-console.component.ts
+++ b/packages/Angular/Explorer/dashboards/src/DevTools/graphql-console.component.ts
@@ -1,7 +1,7 @@
 import { Component, OnInit, OnDestroy, ChangeDetectorRef, ElementRef, ViewChild, HostListener, inject } from '@angular/core';
 import { BaseResourceComponent } from '@memberjunction/ng-shared';
 import { RegisterClass } from '@memberjunction/global';
-import { Metadata, EntityInfo, EntityFieldInfo, getGraphQLTypeNameBase } from '@memberjunction/core';
+import { EntityInfo, EntityFieldInfo, getGraphQLTypeNameBase } from '@memberjunction/core';
 import { GraphQLDataProvider, FieldMapper } from '@memberjunction/graphql-dataprovider';
 import { DevToolsPrefs } from './dev-tools-prefs';
 
@@ -152,7 +152,7 @@ export class GraphQLConsoleComponent extends BaseResourceComponent implements On
 
     private loadEntities(): void {
         try {
-            const md = Metadata.Provider;
+            const md = this.ProviderToUse;
             if (!md) return;
             const items: EntityListItem[] = (md.Entities ?? []).map(e => ({
                 info: e,

--- a/packages/Angular/Explorer/explorer-core/src/lib/about/about-dialog.component.ts
+++ b/packages/Angular/Explorer/explorer-core/src/lib/about/about-dialog.component.ts
@@ -9,10 +9,11 @@ import {
     inject
 } from '@angular/core';
 import { CommonModule } from '@angular/common';
-import { Metadata, UserRoleInfo } from '@memberjunction/core';
+import { UserRoleInfo } from '@memberjunction/core';
 import { InstanceConfigEngine } from '@memberjunction/core-entities';
 import { GraphQLDataProvider, PACKAGE_VERSION } from '@memberjunction/graphql-dataprovider';
 import { MJAuthBase } from '@memberjunction/ng-auth-services';
+import { BaseAngularComponent } from '@memberjunction/ng-base-types';
 import { ThemeService } from '@memberjunction/ng-shared';
 import { Subscription } from 'rxjs';
 import { ServerConnectivityService } from '../services/server-connectivity.service';
@@ -526,7 +527,7 @@ img.mj-about__user-avatar { background: var(--mj-bg-surface-card); }
 }
     `]
 })
-export class AboutDialogComponent implements OnInit, OnDestroy {
+export class AboutDialogComponent extends BaseAngularComponent implements OnInit, OnDestroy {
     @Output() CloseRequested = new EventEmitter<void>();
 
     /** Optional avatar image URL — passed in from the shell where it's already resolved. */
@@ -616,7 +617,7 @@ export class AboutDialogComponent implements OnInit, OnDestroy {
     }
 
     private populate(): void {
-        const provider = Metadata.Provider;
+        const provider = this.ProviderToUse;
 
         this.EntityCount = provider?.Entities?.length ?? 0;
         this.ApplicationCount = provider?.Applications?.length ?? 0;

--- a/packages/Angular/Explorer/explorer-core/src/lib/profile/profile-dialog.component.ts
+++ b/packages/Angular/Explorer/explorer-core/src/lib/profile/profile-dialog.component.ts
@@ -9,13 +9,14 @@ import {
     inject
 } from '@angular/core';
 import { CommonModule } from '@angular/common';
-import { Metadata, UserRoleInfo } from '@memberjunction/core';
+import { UserRoleInfo } from '@memberjunction/core';
 import { UUIDsEqual } from '@memberjunction/global';
 import {
     MJUserNotificationPreferenceEntity,
     UserInfoEngine
 } from '@memberjunction/core-entities';
 import { MJAuthBase } from '@memberjunction/ng-auth-services';
+import { BaseAngularComponent } from '@memberjunction/ng-base-types';
 import { ThemeService, SharedService, ThemeDefinition } from '@memberjunction/ng-shared';
 import { ExplorerSettingsModule } from '@memberjunction/ng-explorer-settings';
 import { Subscription } from 'rxjs';
@@ -716,7 +717,7 @@ img.mj-profile__avatar { background: var(--mj-bg-surface-card); }
 }
     `]
 })
-export class ProfileDialogComponent implements OnInit, OnDestroy {
+export class ProfileDialogComponent extends BaseAngularComponent implements OnInit, OnDestroy {
     @Output() CloseRequested = new EventEmitter<void>();
 
     @Input() AvatarUrl: string | null = null;
@@ -829,7 +830,7 @@ export class ProfileDialogComponent implements OnInit, OnDestroy {
         channel.saving = true;
         this.cdr.markForCheck();
 
-        const provider = Metadata.Provider;
+        const provider = this.ProviderToUse;
         const currentUser = provider?.CurrentUser;
         if (!provider || !currentUser) {
             channel.saving = false;
@@ -889,7 +890,7 @@ export class ProfileDialogComponent implements OnInit, OnDestroy {
     // ---------- private helpers ----------
 
     private populateIdentity(): void {
-        const provider = Metadata.Provider;
+        const provider = this.ProviderToUse;
         const user = provider?.CurrentUser;
         if (user) {
             const name = user.Name || `${user.FirstName ?? ''} ${user.LastName ?? ''}`.trim();


### PR DESCRIPTION


Replaces 6 direct Metadata.Provider references with this.ProviderToUse so these components honor the multi-provider contract enforced by MultiProviderCompliance.test.ts.

The two dashboard components (AppStateInspector, GraphQLConsole) already inherited ProviderToUse via BaseResourceComponent → BaseNavigationComponent → BaseAngularComponent. The two dialogs (AboutDialog, ProfileDialog) now extend BaseAngularComponent directly to gain the same accessor — matching the pattern used by 20+ other dialogs in the codebase (e.g. dashboard- preferences-dialog right next door).

Unblocks the unit-tests workflow on next and prepares these components for use under non-default providers — e.g. a future multi-environment dev-tools host where the same components run against multiple MJ servers in parallel.