### PR TITLE
Disable view self-join for virtual NameField across all providers

### DIFF
--- a/.changeset/quiet-otters-pivot.md
+++ b/.changeset/quiet-otters-pivot.md
@@ -1,0 +1,5 @@
+---
+"@memberjunction/codegen-lib": patch
+---
+
+Disable view self-join for virtual NameField across all CodeGen providers. Flip `canSelfJoinViewForVirtualNameField()` default to `false` and drop the now-redundant PostgreSQL override; SQL Server already cannot support the self-reference because the base view emitter uses `DROP VIEW` then `CREATE VIEW` and SQL Server resolves view-body references at parse time. Behavior is unchanged for all currently emitted views.

--- a/packages/CodeGenLib/src/Database/codeGenDatabaseProvider.ts
+++ b/packages/CodeGenLib/src/Database/codeGenDatabaseProvider.ts
@@ -237,23 +237,34 @@ export abstract class CodeGenDatabaseProvider {
      * a virtual computed column (e.g. `vwRecordChanges` joining to itself for the
      * `RestoredFromID` virtual NameField lookup).
      *
-     * Default: `true`. In practice, both shipped providers override to `false`:
-     * - PostgreSQL: `CREATE OR REPLACE VIEW` resolves names against catalog state
-     *   at parse time, so a self-reference fails with `42P01 undefined_table`.
-     * - SQL Server: the emitter uses `DROP VIEW` then `CREATE VIEW`, and SQL
-     *   Server resolves view-body references at parse/bind time (no deferred
-     *   name resolution for views), so the post-DROP self-reference fails with
-     *   error 208 "Invalid object name".
+     * Default: `false`. No shipped provider currently supports this pattern:
+     * - PostgreSQL: `CREATE OR REPLACE VIEW` resolves view names against catalog
+     *   state at parse time, so a self-reference fails with `42P01
+     *   undefined_table`. A `CREATE OR REPLACE` retry against a NULL-typed stub
+     *   then fails with `cannot change data type of view column ... from text
+     *   to character varying(N)` because PG enforces strict column-type compat.
+     * - SQL Server: the base view emitter uses `DROP VIEW` then `CREATE VIEW`,
+     *   and SQL Server resolves view-body references at parse/bind time — there
+     *   is no deferred name resolution for view bodies the way there is for
+     *   stored procedures. After the DROP, the post-DROP self-reference fails
+     *   with error 208 "Invalid object name".
      *
-     * When `false`, `sql_codegen.ts` skips the self-virtual-NameField join
-     * entirely. The trade-off: the corresponding virtual lookup column is not
-     * emitted on the base view. The fix for the underlying conflation
-     * (computed columns marked `IsVirtual = 1` alongside view-only columns)
-     * would let the join target the base table instead, removing the need
-     * for this skip. Until then, returning `false` is the safe choice.
+     * With the default of `false`, `sql_codegen.ts` skips the self-virtual-
+     * NameField join entirely for self-FK + virtual-NameField cases. The trade-
+     * off: the corresponding virtual lookup column (e.g. `RestoredFrom` on
+     * `vwRecordChanges`, or `Parent` on a `vwTags`-style view if the Name Field
+     * were computed) is not emitted on the base view. Matches the baseline-
+     * shipped view shapes.
+     *
+     * Subclasses can override to return `true` if a future dialect (or a
+     * provider that switches to a different emit pattern, e.g. stub-then-alter)
+     * can support the self-reference. The fix for the underlying conflation
+     * between SQL Server computed columns and view-only columns under
+     * `IsVirtual = 1` would let the join target the base table instead,
+     * removing the need for this capability flag entirely.
      */
     canSelfJoinViewForVirtualNameField(): boolean {
-        return true;
+        return false;
     }
 
     // ─── DROP GUARDS ─────────────────────────────────────────────────────

--- a/packages/CodeGenLib/src/Database/codeGenDatabaseProvider.ts
+++ b/packages/CodeGenLib/src/Database/codeGenDatabaseProvider.ts
@@ -237,12 +237,20 @@ export abstract class CodeGenDatabaseProvider {
      * a virtual computed column (e.g. `vwRecordChanges` joining to itself for the
      * `RestoredFromID` virtual NameField lookup).
      *
-     * Default: `true` — SQL Server's `CREATE VIEW` parser tolerates the self-
-     * reference because the view has already been declared by name when the body
-     * is checked. PostgreSQL's strict parser rejects with `42P01 undefined_table`
-     * because the view doesn't yet exist. PG override returns `false`, telling
-     * `sql_codegen.ts` to skip the self-virtual-NameField join entirely (matches
-     * the baseline-shipped view's shape — no `RestoredFrom` virtual column).
+     * Default: `true`. In practice, both shipped providers override to `false`:
+     * - PostgreSQL: `CREATE OR REPLACE VIEW` resolves names against catalog state
+     *   at parse time, so a self-reference fails with `42P01 undefined_table`.
+     * - SQL Server: the emitter uses `DROP VIEW` then `CREATE VIEW`, and SQL
+     *   Server resolves view-body references at parse/bind time (no deferred
+     *   name resolution for views), so the post-DROP self-reference fails with
+     *   error 208 "Invalid object name".
+     *
+     * When `false`, `sql_codegen.ts` skips the self-virtual-NameField join
+     * entirely. The trade-off: the corresponding virtual lookup column is not
+     * emitted on the base view. The fix for the underlying conflation
+     * (computed columns marked `IsVirtual = 1` alongside view-only columns)
+     * would let the join target the base table instead, removing the need
+     * for this skip. Until then, returning `false` is the safe choice.
      */
     canSelfJoinViewForVirtualNameField(): boolean {
         return true;

--- a/packages/CodeGenLib/src/Database/providers/postgresql/PostgreSQLCodeGenProvider.ts
+++ b/packages/CodeGenLib/src/Database/providers/postgresql/PostgreSQLCodeGenProvider.ts
@@ -38,28 +38,6 @@ export class PostgreSQLCodeGenProvider extends CodeGenDatabaseProvider {
         return 'postgresql';
     }
 
-    /**
-     * @inheritdoc
-     *
-     * PostgreSQL: NOT supported. PG's strict `CREATE OR REPLACE VIEW` parser
-     * resolves view names against the existing catalog state at parse time, so
-     * a body that LEFT-JOINs the view-being-created to itself (e.g. for a
-     * self-FK's virtual NameField) raises `42P01 undefined_table` on first
-     * creation. A `CREATE OR REPLACE` retry against a NULL-typed stub then
-     * fails with `cannot change data type of view column ... from text to
-     * character varying(N)` because PG enforces strict column-type compat in
-     * `CREATE OR REPLACE`.
-     *
-     * Returning `false` tells `sql_codegen.ts` to skip the self-join entirely
-     * for self-FK + virtual-NameField cases. The trade-off: the corresponding
-     * virtual column (e.g. `RestoredFrom` on `vwRecordChanges`) is not emitted.
-     * Matches the baseline-shipped vwRecordChanges shape, which never had this
-     * column either.
-     */
-    override canSelfJoinViewForVirtualNameField(): boolean {
-        return false;
-    }
-
     // ─── DROP GUARDS ─────────────────────────────────────────────────────
 
     /**

--- a/packages/CodeGenLib/src/Database/providers/sqlserver/SQLServerCodeGenProvider.ts
+++ b/packages/CodeGenLib/src/Database/providers/sqlserver/SQLServerCodeGenProvider.ts
@@ -40,6 +40,28 @@ export class SQLServerCodeGenProvider extends CodeGenDatabaseProvider {
         return 'sqlserver';
     }
 
+    /**
+     * @inheritdoc
+     *
+     * SQL Server: NOT supported. The base view emitter uses a `DROP VIEW` /
+     * `CREATE VIEW` pattern (see `generateBaseView` below), and SQL Server
+     * resolves view-body object references at parse/bind time — there is no
+     * deferred name resolution for view bodies the way there is for stored
+     * procedures. After the DROP, the view no longer exists, so a body that
+     * LEFT-JOINs the view-being-created to itself (for a self-FK's virtual
+     * NameField, e.g. `Tag.ParentID` if `Tag.Name` were a computed column)
+     * fails with error 208 "Invalid object name".
+     *
+     * No emitted view in the migrations tree currently exercises this path —
+     * the only existing self-FK base view (`vwTags`) joins to the base table
+     * because `Tag.Name` is a regular column (`IsVirtual = 0`). Returning
+     * `false` matches reality: skip the self-join entirely if the related
+     * NameField is virtual on a self-FK, same as PostgreSQL.
+     */
+    override canSelfJoinViewForVirtualNameField(): boolean {
+        return false;
+    }
+
     // ─── DROP GUARDS ─────────────────────────────────────────────────────
 
     /**

--- a/packages/CodeGenLib/src/Database/providers/sqlserver/SQLServerCodeGenProvider.ts
+++ b/packages/CodeGenLib/src/Database/providers/sqlserver/SQLServerCodeGenProvider.ts
@@ -40,28 +40,6 @@ export class SQLServerCodeGenProvider extends CodeGenDatabaseProvider {
         return 'sqlserver';
     }
 
-    /**
-     * @inheritdoc
-     *
-     * SQL Server: NOT supported. The base view emitter uses a `DROP VIEW` /
-     * `CREATE VIEW` pattern (see `generateBaseView` below), and SQL Server
-     * resolves view-body object references at parse/bind time — there is no
-     * deferred name resolution for view bodies the way there is for stored
-     * procedures. After the DROP, the view no longer exists, so a body that
-     * LEFT-JOINs the view-being-created to itself (for a self-FK's virtual
-     * NameField, e.g. `Tag.ParentID` if `Tag.Name` were a computed column)
-     * fails with error 208 "Invalid object name".
-     *
-     * No emitted view in the migrations tree currently exercises this path —
-     * the only existing self-FK base view (`vwTags`) joins to the base table
-     * because `Tag.Name` is a regular column (`IsVirtual = 0`). Returning
-     * `false` matches reality: skip the self-join entirely if the related
-     * NameField is virtual on a self-FK, same as PostgreSQL.
-     */
-    override canSelfJoinViewForVirtualNameField(): boolean {
-        return false;
-    }
-
     // ─── DROP GUARDS ─────────────────────────────────────────────────────
 
     /**


### PR DESCRIPTION
## Summary

No shipped CodeGen provider supports a base view that LEFT-JOINs itself to read a virtual NameField column. Both shipped providers were overriding the base class default of `true` to return `false`. Flip the default to `false` and drop both overrides — identical behavior, single source of truth, less code.

## Background

`canSelfJoinViewForVirtualNameField()` on `CodeGenDatabaseProvider` controls whether `sql_codegen.ts` emits a self-join inside an entity's base view when (a) the entity has a self-referencing FK (e.g. `ParentID`) and (b) the entity's Name Field is virtual (a SQL Server computed column or a view-only column). When the flag is `true`, the emitter produces something like:

```sql
CREATE VIEW vwFoo AS
SELECT f.*, parent.Name AS Parent
FROM Foo f
LEFT JOIN vwFoo AS parent ON f.ParentID = parent.ID;  -- self-reference
```

When the flag is `false`, the emitter skips the self-join entirely and the corresponding virtual lookup column is omitted from the base view.

## Why neither provider supports this

- **PostgreSQL**: `CREATE OR REPLACE VIEW` resolves view names against catalog state at parse time, so a self-reference fails with `42P01 undefined_table`. A retry against a NULL-typed stub then fails with `cannot change data type of view column ... from text to character varying(N)` because PG enforces strict column-type compat in `CREATE OR REPLACE`. PG already overrode to `false`.

- **SQL Server**: the base view emitter (`SQLServerCodeGenProvider.generateBaseView`) uses `DROP VIEW` then `CREATE VIEW`, and SQL Server resolves view-body object references at parse/bind time — there is no deferred name resolution for view bodies the way there is for stored procedures. After the DROP, a body that LEFT-JOINs the view-being-created to itself fails with error 208 "Invalid object name". The base class doc comment claimed otherwise; the claim was wrong.

## Why this has never shipped a broken view

No view in the migrations tree currently exercises the broken path. The only existing self-FK base view today is `vwTags` (`Tag.ParentID → Tag.ID`), and it joins to the **base table** because `Tag.Name` is a regular column (`IsVirtual = 0`):

```sql
LEFT OUTER JOIN [${flyway:defaultSchema}].[Tag] AS Tag_ParentID
   ON [t].[ParentID] = Tag_ParentID.[ID]
```

The combination of **(self-FK)** + **(Name Field as computed/virtual column)** has never coincided in the schema, so the broken codepath was latent. Adding such an entity in the future would have triggered it on first migration on SQL Server.

## What changes

- `codeGenDatabaseProvider.ts` — default flipped from `true` to `false`. Doc comment rewritten to explain why no shipped provider supports the self-reference pattern (covering both PG's `42P01` and SQL Server's error 208), the trade-off (virtual lookup column not emitted), and the path for a future opt-in.
- `PostgreSQLCodeGenProvider.ts` — `override canSelfJoinViewForVirtualNameField()` removed (now redundant).
- `SQLServerCodeGenProvider.ts` — no net change vs `next` (the override added in the first commit was removed in the revision).

Net diff vs `next`: 2 files, +26 / −29.

## Behavior

`sql_codegen.ts:1782` already calls `!this._dbProvider.canSelfJoinViewForVirtualNameField()` to decide whether to skip the self-join. Both providers reach the same skip path they reached before, just via the default rather than an override. No emitted SQL changes for any current entity. Any future provider can override to `true` to opt in.

## Test plan

- [x] `npx turbo build --filter=\"@memberjunction/codegen-lib\"` — 98 tasks successful
- [x] `npm run test` in `packages/CodeGenLib` — 435 passed, 59 skipped (DB integration tests), 0 failed
- [ ] Regenerate views against the workbench SQL Server DB and confirm baseline view set (especially `vwTags`) is byte-identical after regeneration

## Follow-up

The deeper fix is to stop conflating SQL Server **computed columns** with **view-only columns** under the `IsVirtual` flag (`vwSQLColumnsAndEntityFields` sets `IsVirtual = 1` for both). Adding a separate `IsComputed` flag would let `sql_codegen.ts:1645` target the base table for FK joins where the related Name Field is a computed column — eliminating the unnecessary view join, the self-FK skip, and this capability flag entirely. Tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)