### PR TITLE
feat(codegen-lib): configurable SQL request timeout

### DIFF
--- a/.changeset/swift-pools-stretch.md
+++ b/.changeset/swift-pools-stretch.md
@@ -1,0 +1,5 @@
+---
+"@memberjunction/codegen-lib": patch
+---
+
+Make the CodeGen SQL request timeout configurable via `dbRequestTimeout` in `mj.config.cjs` or the `MJ_CODEGEN_REQUEST_TIMEOUT` environment variable. Default behavior is unchanged (120000ms); the config-file field name matches MJCLI's existing `dbRequestTimeout` so a single value covers both `mj migrate` and `mj codegen`.

--- a/packages/CodeGenLib/src/Config/config.ts
+++ b/packages/CodeGenLib/src/Config/config.ts
@@ -543,6 +543,13 @@ const configInfoSchema = z.object({
     .boolean()
     .default(false)
     .transform((v) => (v ? 'Y' : 'N')),
+  /**
+   * Optional SQL Server request timeout in milliseconds applied to the CodeGen
+   * connection pool. Defaults to 120000 (2 minutes). Set in `mj.config.cjs` or
+   * via the `MJ_CODEGEN_REQUEST_TIMEOUT` environment variable when long-running
+   * CodeGen steps (e.g. spUpdateExistingEntityFieldsFromSchema) exceed the default.
+   */
+  dbRequestTimeout: z.coerce.number().int().positive().optional(),
   outputCode: z.string().nullish(),
   mjCoreSchema: z.string().default('__mj'),
   graphqlPort: z.coerce.number().int().positive().default(4000),
@@ -570,6 +577,9 @@ export const DEFAULT_CODEGEN_CONFIG: Partial<ConfigInfo> = {
   codeGenPassword: process.env.CODEGEN_DB_PASSWORD ?? '',
   dbInstanceName: process.env.DB_INSTANCE_NAME,
   dbTrustServerCertificate: parseBooleanEnv(process.env.DB_TRUST_SERVER_CERTIFICATE) ? 'Y' : 'N',
+  dbRequestTimeout: process.env.MJ_CODEGEN_REQUEST_TIMEOUT
+    ? parseInt(process.env.MJ_CODEGEN_REQUEST_TIMEOUT, 10)
+    : undefined,
   mjCoreSchema: '__mj',
   graphqlPort: 4000,
   verboseOutput: false,

--- a/packages/CodeGenLib/src/Config/db-connection.ts
+++ b/packages/CodeGenLib/src/Config/db-connection.ts
@@ -8,7 +8,7 @@ import mssql from 'mssql';
 import { configInfo } from './config';
 
 /** Extract database connection parameters from configuration */
-const { dbDatabase, dbHost, codeGenPassword, dbPort, codeGenLogin, dbInstanceName, dbTrustServerCertificate } = configInfo;
+const { dbDatabase, dbHost, codeGenPassword, dbPort, codeGenLogin, dbInstanceName, dbTrustServerCertificate, dbRequestTimeout } = configInfo;
 
 /**
  * SQL Server configuration object for mssql package.
@@ -27,8 +27,13 @@ export const sqlConfig: mssql.config = {
   /** Database server port (typically 1433) */
   port: dbPort,
   options: {
-    /** Extended timeout for long-running code generation queries */
-    requestTimeout: 120000,
+    /**
+     * Request timeout for long-running CodeGen queries. Defaults to 120000ms
+     * (2 min); override via `dbRequestTimeout` in mj.config.cjs or the
+     * MJ_CODEGEN_REQUEST_TIMEOUT environment variable when steps like
+     * spUpdateExistingEntityFieldsFromSchema run beyond the default.
+     */
+    requestTimeout: dbRequestTimeout ?? 120000,
     /** Enable encrypted connections */
     encrypt: true,
     /** SQL Server instance name if using named instances */


### PR DESCRIPTION
## Summary
- The mssql pool used by CodeGen hardcoded `requestTimeout` to 120000ms in [db-connection.ts](packages/CodeGenLib/src/Config/db-connection.ts), so long-running steps — notably `spUpdateExistingEntityFieldsFromSchema` on schemas with many entities (post-5.32 surfaces this more often because more fields get flagged "modified" on the first run) — could abort the run with no escape hatch.
- Adds optional `dbRequestTimeout` to the CodeGenLib config schema and a `MJ_CODEGEN_REQUEST_TIMEOUT` env-var fallback in `DEFAULT_CODEGEN_CONFIG`. `db-connection.ts` consumes `configInfo.dbRequestTimeout ?? 120000`.
- Field name matches MJCLI's existing `dbRequestTimeout` (used by `mj migrate` via `MJ_MIGRATION_REQUEST_TIMEOUT`), so a single value set in `mj.config.cjs` now covers both `mj migrate` and `mj codegen` automatically.

## Behavior
- **Default unchanged.** Without `dbRequestTimeout` or `MJ_CODEGEN_REQUEST_TIMEOUT` set, the pool still uses 120000ms.
- **Env override:** `MJ_CODEGEN_REQUEST_TIMEOUT=600000` raises codegen's request timeout to 10 minutes.
- **Config-file override (preferred for cross-flow):** setting `dbRequestTimeout: 600000` in `mj.config.cjs` is honored by both migrate (already) and codegen (new).
- Config-file value wins over env var via the existing `mergeConfigs(DEFAULT_CODEGEN_CONFIG, userConfig)` order.

## Files Changed
- [packages/CodeGenLib/src/Config/config.ts](packages/CodeGenLib/src/Config/config.ts) — add `dbRequestTimeout` to the Zod schema and `MJ_CODEGEN_REQUEST_TIMEOUT` to `DEFAULT_CODEGEN_CONFIG`.
- [packages/CodeGenLib/src/Config/db-connection.ts](packages/CodeGenLib/src/Config/db-connection.ts) — destructure `dbRequestTimeout` from `configInfo` and use it with the 120000 fallback.

## Test plan
- [x] `cd packages/CodeGenLib && npm run build` — clean
- [x] `cd packages/CodeGenLib && npm run test` — 435 passed, 59 skipped (PG integration, expected without PG DB), 0 failures
- [ ] Manual: run `mj codegen` with no env var / no config field — confirm 120000ms default is still applied
- [ ] Manual: set `MJ_CODEGEN_REQUEST_TIMEOUT=600000`, run `mj codegen` against a schema where the entity-fields step previously timed out at 120s — confirm it completes
- [ ] Manual: set `dbRequestTimeout: 600000` in `mj.config.cjs`, run both `mj migrate` and `mj codegen` — confirm both honor the same value

🤖 Generated with [Claude Code](https://claude.com/claude-code)