### PR TITLE
fix: deterministic QueryField extraction for explicit SELECT columns

### DIFF
--- a/.changeset/bright-fields-resolve.md
+++ b/.changeset/bright-fields-resolve.md
@@ -1,0 +1,5 @@
+---
+"@memberjunction/core-entities-server": patch
+---
+
+Fix deterministic QueryField extraction for explicit SELECT columns — previously relied solely on LLM fallback which silently failed, leaving queries with 0 fields. Also prevents destructive deletion of existing fields when extraction returns null.

--- a/packages/MJCoreEntitiesServer/src/__tests__/pipeline-sync-cleanup.test.ts
+++ b/packages/MJCoreEntitiesServer/src/__tests__/pipeline-sync-cleanup.test.ts
@@ -97,28 +97,38 @@ describe('Pipeline sync stage — stale record cleanup', () => {
     });
 
     describe('when extraction produces no fields (finalFields is null)', () => {
-        it('should call RemoveAllRecords for Query Fields', async () => {
-            // LLM returns no selectClause → finalFields will be null
+        it('should preserve existing fields (NOT call RemoveAllRecords) when finalFields is null', async () => {
+            // Use a SQL statement that produces no parseable SELECT columns (e.g., EXEC)
+            // so that both deterministic extraction AND LLM return null.
             mockRunLLMEnrichment.mockResolvedValue(null);
 
-            const ctx = buildCtx('SELECT col1 FROM SomeTable WHERE x = 1');
+            const ctx = buildCtx('EXEC sp_SomeStoredProc @Param1 = 1');
             await RunExtractionPipeline(ctx);
 
-            // Verify RemoveAllRecords was called for fields
+            // With the fix: when finalFields is null, existing fields are preserved
             const fieldCleanupCall = mockRemoveAllRecords.mock.calls.find(
                 (call: unknown[]) => call[1] === 'MJ: Query Fields'
             );
-            expect(fieldCleanupCall).toBeDefined();
-            expect(fieldCleanupCall![0]).toBe(QUERY_ID);
+            expect(fieldCleanupCall).toBeUndefined();
+            expect(mockSyncFields).not.toHaveBeenCalled();
         });
+    });
 
-        it('should NOT call SyncFields when there are no fields to sync', async () => {
+    describe('when deterministic extraction produces fields (even without LLM)', () => {
+        it('should call SyncFields with deterministic fields when LLM is null', async () => {
+            // SELECT col1 produces deterministic fields via BuildFieldsFromSelectColumns
             mockRunLLMEnrichment.mockResolvedValue(null);
 
             const ctx = buildCtx('SELECT col1 FROM SomeTable WHERE x = 1');
             await RunExtractionPipeline(ctx);
 
-            expect(mockSyncFields).not.toHaveBeenCalled();
+            expect(mockSyncFields).toHaveBeenCalled();
+
+            // RemoveAllRecords should NOT be called for fields
+            const fieldCleanupCall = mockRemoveAllRecords.mock.calls.find(
+                (call: unknown[]) => call[1] === 'MJ: Query Fields'
+            );
+            expect(fieldCleanupCall).toBeUndefined();
         });
     });
 

--- a/packages/MJCoreEntitiesServer/src/__tests__/query-field-extraction.test.ts
+++ b/packages/MJCoreEntitiesServer/src/__tests__/query-field-extraction.test.ts
@@ -1,0 +1,450 @@
+/**
+ * Unit tests for deterministic QueryField extraction from SELECT columns.
+ *
+ * Tests the BuildFieldsFromSelectColumns() function and the merge priority
+ * logic that ensures deterministic fields are the PRIMARY source, with
+ * LLM providing enriched descriptions as a FALLBACK.
+ */
+import { describe, it, expect } from 'vitest';
+import { SQLParser } from '@memberjunction/sql-parser';
+import { SQLServerDialect } from '@memberjunction/sql-dialect';
+import { BuildFieldsFromSelectColumns } from '../custom/query-extraction/resolve';
+import type { ExtractedField } from '../custom/query-extraction/types';
+
+const tsqlDialect = new SQLServerDialect();
+
+// ═══════════════════════════════════════════════════
+// BuildFieldsFromSelectColumns — deterministic extraction
+// ═══════════════════════════════════════════════════
+
+describe('BuildFieldsFromSelectColumns', () => {
+    describe('Simple column lists', () => {
+        it('should extract fields from SELECT col1, col2 FROM table', () => {
+            const sql = 'SELECT col1, col2 FROM MyTable';
+            const selectColumns = SQLParser.ExtractSelectColumns(sql, tsqlDialect);
+            const fields = BuildFieldsFromSelectColumns(selectColumns);
+
+            expect(fields).not.toBeNull();
+            expect(fields).toHaveLength(2);
+            expect(fields![0].name).toBe('col1');
+            expect(fields![0].isComputed).toBe(false);
+            expect(fields![0].sourceFieldName).toBe('col1');
+            expect(fields![1].name).toBe('col2');
+        });
+
+        it('should extract fields with table qualifiers', () => {
+            const sql = 'SELECT t.ID, t.Name, t.Email FROM __mj.vwUsers t';
+            const selectColumns = SQLParser.ExtractSelectColumns(sql, tsqlDialect);
+            const fields = BuildFieldsFromSelectColumns(selectColumns);
+
+            expect(fields).not.toBeNull();
+            expect(fields).toHaveLength(3);
+            expect(fields![0].name).toBe('ID');
+            expect(fields![0].sourceFieldName).toBe('ID');
+            expect(fields![1].name).toBe('Name');
+            expect(fields![2].name).toBe('Email');
+        });
+    });
+
+    describe('Aliased columns', () => {
+        it('should extract fields from SELECT col1 AS Alias1, col2 AS Alias2', () => {
+            const sql = 'SELECT col1 AS Alias1, col2 AS Alias2 FROM MyTable';
+            const selectColumns = SQLParser.ExtractSelectColumns(sql, tsqlDialect);
+            const fields = BuildFieldsFromSelectColumns(selectColumns);
+
+            expect(fields).not.toBeNull();
+            expect(fields).toHaveLength(2);
+            expect(fields![0].name).toBe('Alias1');
+            expect(fields![0].sourceFieldName).toBe('col1');
+            expect(fields![0].isComputed).toBe(false);
+            expect(fields![1].name).toBe('Alias2');
+            expect(fields![1].sourceFieldName).toBe('col2');
+        });
+
+        it('should handle mixed aliased and non-aliased columns', () => {
+            const sql = 'SELECT t.ID, t.FirstName AS Name, t.Email FROM __mj.vwUsers t';
+            const selectColumns = SQLParser.ExtractSelectColumns(sql, tsqlDialect);
+            const fields = BuildFieldsFromSelectColumns(selectColumns);
+
+            expect(fields).not.toBeNull();
+            expect(fields).toHaveLength(3);
+            expect(fields![0].name).toBe('ID');
+            expect(fields![0].sourceFieldName).toBe('ID');
+            expect(fields![1].name).toBe('Name');
+            expect(fields![1].sourceFieldName).toBe('FirstName');
+            expect(fields![2].name).toBe('Email');
+        });
+    });
+
+    describe('Aggregate functions and expressions', () => {
+        it('should extract fields from aggregate functions', () => {
+            const sql = 'SELECT COUNT(*) AS Total, SUM(Amount) AS Revenue FROM Orders';
+            const selectColumns = SQLParser.ExtractSelectColumns(sql, tsqlDialect);
+            const fields = BuildFieldsFromSelectColumns(selectColumns);
+
+            expect(fields).not.toBeNull();
+            expect(fields).toHaveLength(2);
+
+            const total = fields!.find(f => f.name === 'Total');
+            expect(total).toBeDefined();
+            expect(total!.isComputed).toBe(true);
+            expect(total!.sourceFieldName).toBeNull(); // expressions don't have a source field
+
+            const revenue = fields!.find(f => f.name === 'Revenue');
+            expect(revenue).toBeDefined();
+            expect(revenue!.isComputed).toBe(true);
+        });
+
+        it('should handle MAX, MIN, AVG aggregates', () => {
+            const sql = 'SELECT MAX(Score) AS HighScore, MIN(Score) AS LowScore, AVG(Score) AS AvgScore FROM Results';
+            const selectColumns = SQLParser.ExtractSelectColumns(sql, tsqlDialect);
+            const fields = BuildFieldsFromSelectColumns(selectColumns);
+
+            expect(fields).not.toBeNull();
+            expect(fields).toHaveLength(3);
+            expect(fields!.every(f => f.isComputed)).toBe(true);
+        });
+    });
+
+    describe('SELECT * handling', () => {
+        it('should return null for SELECT * (defers to BuildFieldsForSelectStar)', () => {
+            const sql = 'SELECT * FROM Users';
+            const selectColumns = SQLParser.ExtractSelectColumns(sql, tsqlDialect);
+            const fields = BuildFieldsFromSelectColumns(selectColumns);
+
+            expect(fields).toBeNull();
+        });
+
+        it('should return null for SELECT t.* FROM table t', () => {
+            const sql = 'SELECT t.* FROM Users t';
+            const selectColumns = SQLParser.ExtractSelectColumns(sql, tsqlDialect);
+            const fields = BuildFieldsFromSelectColumns(selectColumns);
+
+            expect(fields).toBeNull();
+        });
+    });
+
+    describe('Nunjucks template expressions in WHERE', () => {
+        it('should extract fields correctly when SQL contains Nunjucks templates', () => {
+            const sql = `SELECT s.Name AS SpeakerName, s.Rating, COUNT(*) AS SessionCount
+FROM Speakers s
+JOIN Sessions sess ON s.ID = sess.SpeakerID
+WHERE sess.Year = {{ Year | sqlNumber }}
+{% if MinRating %}AND s.Rating >= {{ MinRating | sqlNumber }}{% endif %}
+GROUP BY s.Name, s.Rating`;
+
+            const selectColumns = SQLParser.ExtractSelectColumns(sql, tsqlDialect);
+            const fields = BuildFieldsFromSelectColumns(selectColumns);
+
+            expect(fields).not.toBeNull();
+            expect(fields).toHaveLength(3);
+
+            expect(fields![0].name).toBe('SpeakerName');
+            expect(fields![0].sourceFieldName).toBe('Name');
+            expect(fields![0].isComputed).toBe(false);
+
+            expect(fields![1].name).toBe('Rating');
+            expect(fields![1].isComputed).toBe(false);
+
+            expect(fields![2].name).toBe('SessionCount');
+            expect(fields![2].isComputed).toBe(true);
+        });
+    });
+
+    describe('Complex queries with JOINs', () => {
+        it('should extract fields from multi-JOIN query', () => {
+            const sql = `SELECT
+    m.FirstName,
+    m.LastName,
+    mt.Name AS MembershipType,
+    c.Name AS ChapterName
+FROM [AssociationDemo].[vwMembers] m
+LEFT JOIN [AssociationDemo].[vwMemberships] ms ON ms.MemberID = m.ID
+INNER JOIN [AssociationDemo].[vwMembershipTypes] mt ON ms.MembershipTypeID = mt.ID
+LEFT JOIN [AssociationDemo].[vwChapters] c ON m.ChapterID = c.ID`;
+
+            const selectColumns = SQLParser.ExtractSelectColumns(sql, tsqlDialect);
+            const fields = BuildFieldsFromSelectColumns(selectColumns);
+
+            expect(fields).not.toBeNull();
+            expect(fields).toHaveLength(4);
+            expect(fields![0].name).toBe('FirstName');
+            expect(fields![1].name).toBe('LastName');
+            expect(fields![2].name).toBe('MembershipType');
+            expect(fields![2].sourceFieldName).toBe('Name');
+            expect(fields![3].name).toBe('ChapterName');
+            expect(fields![3].sourceFieldName).toBe('Name');
+        });
+    });
+
+    describe('TOP N and DISTINCT', () => {
+        it('should extract fields from queries with TOP N', () => {
+            const sql = 'SELECT TOP 10 ID, Name, Score FROM Students ORDER BY Score DESC';
+            const selectColumns = SQLParser.ExtractSelectColumns(sql, tsqlDialect);
+            const fields = BuildFieldsFromSelectColumns(selectColumns);
+
+            expect(fields).not.toBeNull();
+            expect(fields).toHaveLength(3);
+            expect(fields![0].name).toBe('ID');
+            expect(fields![1].name).toBe('Name');
+            expect(fields![2].name).toBe('Score');
+        });
+
+        it('should extract fields from queries with DISTINCT', () => {
+            const sql = 'SELECT DISTINCT Region, City FROM Locations';
+            const selectColumns = SQLParser.ExtractSelectColumns(sql, tsqlDialect);
+            const fields = BuildFieldsFromSelectColumns(selectColumns);
+
+            expect(fields).not.toBeNull();
+            expect(fields).toHaveLength(2);
+            expect(fields![0].name).toBe('Region');
+            expect(fields![1].name).toBe('City');
+        });
+    });
+
+    describe('Empty / no columns', () => {
+        it('should return null for empty selectColumns', () => {
+            const fields = BuildFieldsFromSelectColumns([]);
+            expect(fields).toBeNull();
+        });
+    });
+
+    describe('Real-world production queries', () => {
+        it('should extract fields from Speaker Performance query (CASE production bug)', () => {
+            const sql = `SELECT
+    s.Name AS SpeakerName,
+    s.Title AS SpeakerTitle,
+    COUNT(DISTINCT sess.ID) AS TotalSessions,
+    AVG(CAST(r.Rating AS FLOAT)) AS AvgRating,
+    SUM(sess.AttendeeCount) AS TotalAttendees
+FROM [CASE].[vwSpeakers] s
+JOIN [CASE].[vwSessions] sess ON s.ID = sess.SpeakerID
+LEFT JOIN [CASE].[vwRatings] r ON sess.ID = r.SessionID
+GROUP BY s.Name, s.Title
+ORDER BY AvgRating DESC`;
+
+            const selectColumns = SQLParser.ExtractSelectColumns(sql, tsqlDialect);
+            const fields = BuildFieldsFromSelectColumns(selectColumns);
+
+            expect(fields).not.toBeNull();
+            expect(fields).toHaveLength(5);
+
+            const speakerName = fields!.find(f => f.name === 'SpeakerName')!;
+            expect(speakerName.sourceFieldName).toBe('Name');
+            expect(speakerName.isComputed).toBe(false);
+
+            const totalSessions = fields!.find(f => f.name === 'TotalSessions')!;
+            expect(totalSessions.isComputed).toBe(true);
+            expect(totalSessions.sourceFieldName).toBeNull();
+
+            const avgRating = fields!.find(f => f.name === 'AvgRating')!;
+            expect(avgRating.isComputed).toBe(true);
+        });
+    });
+});
+
+// ═══════════════════════════════════════════════════
+// supplementDeterministicWithLLM — merge priority tests
+// Re-implemented as a pure function for testing
+// ═══════════════════════════════════════════════════
+
+function supplementDeterministicWithLLM(
+    deterministicFields: ExtractedField[],
+    llmFields: ExtractedField[] | null
+): ExtractedField[] {
+    if (!llmFields || llmFields.length === 0) return deterministicFields;
+
+    const llmByName = new Map<string, ExtractedField>();
+    for (const lf of llmFields) {
+        llmByName.set(lf.name.toLowerCase(), lf);
+    }
+
+    return deterministicFields.map(df => {
+        const llmMatch = llmByName.get(df.name.toLowerCase());
+        if (!llmMatch) return df;
+
+        return {
+            ...df,
+            description: llmMatch.description || df.description,
+            type: df.isComputed ? (llmMatch.type || df.type) : df.type,
+            isSummary: llmMatch.isSummary ?? df.isSummary,
+            computationDescription: llmMatch.computationDescription ?? df.computationDescription,
+            sourceEntity: df.sourceEntity ?? llmMatch.sourceEntity,
+        };
+    });
+}
+
+describe('Merge Priority: Deterministic vs LLM', () => {
+    it('should use deterministic fields as primary source', () => {
+        const det: ExtractedField[] = [
+            { name: 'ID', description: 'ID', type: 'string', optional: false, isComputed: false },
+            { name: 'Name', description: 'Name', type: 'string', optional: false, isComputed: false },
+        ];
+        const llm: ExtractedField[] = [
+            { name: 'ID', description: 'Unique identifier', type: 'string', optional: false },
+            { name: 'Name', description: 'Full user name', type: 'string', optional: false },
+            { name: 'HallucinatedField', description: 'Does not exist', type: 'string', optional: false },
+        ];
+
+        const result = supplementDeterministicWithLLM(det, llm);
+
+        // Only deterministic fields survive; LLM hallucination is dropped
+        expect(result).toHaveLength(2);
+        expect(result.find(f => f.name === 'HallucinatedField')).toBeUndefined();
+    });
+
+    it('should supplement deterministic descriptions with LLM descriptions', () => {
+        const det: ExtractedField[] = [
+            { name: 'SpeakerName', description: 'Name (aliased as SpeakerName)', type: 'string', optional: false, isComputed: false },
+        ];
+        const llm: ExtractedField[] = [
+            { name: 'SpeakerName', description: 'Full name of the speaker who presented', type: 'string', optional: false },
+        ];
+
+        const result = supplementDeterministicWithLLM(det, llm);
+        expect(result[0].description).toBe('Full name of the speaker who presented');
+    });
+
+    it('should keep deterministic description when LLM has no match', () => {
+        const det: ExtractedField[] = [
+            { name: 'Rating', description: 'Rating', type: 'string', optional: false, isComputed: false },
+        ];
+
+        const result = supplementDeterministicWithLLM(det, []);
+        expect(result[0].description).toBe('Rating');
+    });
+
+    it('should return deterministic fields unchanged when LLM is null', () => {
+        const det: ExtractedField[] = [
+            { name: 'ID', description: 'ID', type: 'string', optional: false, isComputed: false },
+        ];
+
+        const result = supplementDeterministicWithLLM(det, null);
+        expect(result).toBe(det); // Same reference
+    });
+
+    it('should use LLM type for computed fields only', () => {
+        const det: ExtractedField[] = [
+            { name: 'Total', description: 'Computed column: COUNT(*)', type: 'string', optional: false, isComputed: true },
+            { name: 'Name', description: 'Name', type: 'string', optional: false, isComputed: false },
+        ];
+        const llm: ExtractedField[] = [
+            { name: 'Total', description: 'Total count', type: 'number', optional: false },
+            { name: 'Name', description: 'User name', type: 'number', optional: false }, // LLM wrong about non-computed type
+        ];
+
+        const result = supplementDeterministicWithLLM(det, llm);
+        expect(result[0].type).toBe('number'); // Computed: LLM type accepted
+        expect(result[1].type).toBe('string'); // Non-computed: deterministic type preserved
+    });
+
+    it('should use LLM sourceEntity when deterministic has none', () => {
+        const det: ExtractedField[] = [
+            { name: 'SpeakerName', description: 'Name', type: 'string', optional: false, isComputed: false, sourceEntity: null },
+        ];
+        const llm: ExtractedField[] = [
+            { name: 'SpeakerName', description: 'Speaker name', type: 'string', optional: false, sourceEntity: 'Speakers' },
+        ];
+
+        const result = supplementDeterministicWithLLM(det, llm);
+        expect(result[0].sourceEntity).toBe('Speakers');
+    });
+
+    it('should not overwrite existing deterministic sourceEntity with LLM', () => {
+        const det: ExtractedField[] = [
+            { name: 'Name', description: 'Name', type: 'string', optional: false, isComputed: false, sourceEntity: 'Users' },
+        ];
+        const llm: ExtractedField[] = [
+            { name: 'Name', description: 'User name', type: 'string', optional: false, sourceEntity: 'People' },
+        ];
+
+        const result = supplementDeterministicWithLLM(det, llm);
+        expect(result[0].sourceEntity).toBe('Users'); // Deterministic preserved
+    });
+
+    it('should handle case-insensitive name matching between deterministic and LLM', () => {
+        const det: ExtractedField[] = [
+            { name: 'SpeakerName', description: 'Name', type: 'string', optional: false, isComputed: false },
+        ];
+        const llm: ExtractedField[] = [
+            { name: 'speakername', description: 'Full speaker name from presentation data', type: 'string', optional: false },
+        ];
+
+        const result = supplementDeterministicWithLLM(det, llm);
+        expect(result[0].description).toBe('Full speaker name from presentation data');
+    });
+});
+
+// ═══════════════════════════════════════════════════
+// Destructive null behavior — regression tests
+// ═══════════════════════════════════════════════════
+
+describe('Non-destructive field handling when extraction fails', () => {
+    it('should produce non-null finalFields for explicit SELECT columns even without LLM', () => {
+        // This simulates the production bug: a query with explicit columns,
+        // LLM fails, and without the fix, finalFields would be null → fields deleted.
+        const sql = `SELECT s.Name AS SpeakerName, COUNT(*) AS Total
+FROM Speakers s GROUP BY s.Name`;
+
+        const selectColumns = SQLParser.ExtractSelectColumns(sql, tsqlDialect);
+        const fields = BuildFieldsFromSelectColumns(selectColumns);
+
+        // With the fix, deterministic extraction produces fields even without LLM
+        expect(fields).not.toBeNull();
+        expect(fields!.length).toBeGreaterThan(0);
+    });
+
+    it('should produce non-null fields for complex production query that previously failed', () => {
+        // Simulates the "Speaker Performance And Rating Metrics" query from CASE DB
+        const sql = `SELECT
+    s.Name,
+    s.Title,
+    COUNT(DISTINCT sess.ID) AS TotalSessions,
+    AVG(CAST(r.Rating AS FLOAT)) AS AvgRating,
+    SUM(sess.AttendeeCount) AS TotalAttendees,
+    MIN(sess.Date) AS FirstSession,
+    MAX(sess.Date) AS LastSession
+FROM Speakers s
+JOIN Sessions sess ON s.ID = sess.SpeakerID
+LEFT JOIN Ratings r ON sess.ID = r.SessionID
+WHERE sess.Year >= {{ StartYear | sqlNumber }}
+{% if SpeakerCategory %}AND s.Category = {{ SpeakerCategory | sqlString }}{% endif %}
+GROUP BY s.Name, s.Title
+ORDER BY AvgRating DESC`;
+
+        const selectColumns = SQLParser.ExtractSelectColumns(sql, tsqlDialect);
+        const fields = BuildFieldsFromSelectColumns(selectColumns);
+
+        expect(fields).not.toBeNull();
+        expect(fields).toHaveLength(7);
+
+        // Verify computed vs non-computed classification
+        const computed = fields!.filter(f => f.isComputed);
+        const direct = fields!.filter(f => !f.isComputed);
+
+        expect(direct.map(f => f.name).sort()).toEqual(['Name', 'Title']);
+        expect(computed.length).toBe(5); // TotalSessions, AvgRating, TotalAttendees, FirstSession, LastSession
+    });
+});
+
+// ═══════════════════════════════════════════════════
+// UNION ALL and subquery handling
+// ═══════════════════════════════════════════════════
+
+describe('Complex SQL patterns', () => {
+    it('should extract fields from CTE-based queries', () => {
+        const sql = `WITH TopSpeakers AS (
+    SELECT s.Name, COUNT(*) AS SessionCount
+    FROM Speakers s JOIN Sessions sess ON s.ID = sess.SpeakerID
+    GROUP BY s.Name
+)
+SELECT Name, SessionCount FROM TopSpeakers WHERE SessionCount > 5`;
+
+        const selectColumns = SQLParser.ExtractSelectColumns(sql, tsqlDialect);
+        const fields = BuildFieldsFromSelectColumns(selectColumns);
+
+        // Should extract from the outermost SELECT
+        expect(fields).not.toBeNull();
+        expect(fields!.length).toBeGreaterThanOrEqual(2);
+    });
+});

--- a/packages/MJCoreEntitiesServer/src/custom/query-extraction/pipeline.ts
+++ b/packages/MJCoreEntitiesServer/src/custom/query-extraction/pipeline.ts
@@ -1,4 +1,3 @@
-import { IMetadataProvider, LogError, UserInfo } from "@memberjunction/core";
 import type { QuerySyncContext, ExtractedField, ResolveResult } from "./types";
 import { parseQuerySQL } from "./parse";
 import {
@@ -7,9 +6,9 @@ import {
     MergePassthroughParams,
     ExtractEntityMetadataFromSQL,
     BuildFieldsForSelectStar,
+    BuildFieldsFromSelectColumns,
     EnrichFieldTypesFromCompositions,
     EnrichFieldTypesFromEntityMetadata,
-    DetectDependencyCycles,
 } from "./resolve";
 import { RunLLMEnrichment, MergeParametersWithLLM } from "./enrich";
 import { SyncParameters, SyncFields, SyncEntities, SyncDependencies, RemoveAllRecords } from "./sync";
@@ -87,15 +86,16 @@ function resolve(ctx: QuerySyncContext, parseResult: ReturnType<typeof parseQuer
     // Entity metadata (for LLM context and entity sync)
     const entityMetadata = ExtractEntityMetadataFromSQL(ctx.sql, parseResult.tableRefs, md);
 
-    // Field resolution: SELECT * expansion or null
-    const selectStarFields = BuildFieldsForSelectStar(ctx.sql, parseResult.tableRefs, parseResult.selectColumns, md);
+    // Field resolution: try SELECT * expansion first (uses entity metadata), fall back to explicit SELECT columns
+    const resolvedFields = BuildFieldsForSelectStar(ctx.sql, parseResult.tableRefs, parseResult.selectColumns, md)
+        ?? BuildFieldsFromSelectColumns(parseResult.selectColumns);
 
     return {
         resolvedCompositionRefs,
         allDeterministicParams,
         passthroughContext,
         entityMetadata,
-        selectStarFields,
+        resolvedFields,
     };
 }
 
@@ -112,11 +112,16 @@ function merge(
         ? MergeParametersWithLLM(resolveResult.allDeterministicParams, llmResult, resolveResult.passthroughContext)
         : null;
 
-    // Fields: use SELECT * expansion or LLM select clause, then enrich
-    const rawFields = resolveResult.selectStarFields
-        ?? (llmResult?.selectClause && Array.isArray(llmResult.selectClause) && llmResult.selectClause.length > 0
-            ? llmResult.selectClause
-            : null);
+    // Fields priority: deterministic (SELECT * or explicit columns) → LLM selectClause
+    const resolvedFields = resolveResult.resolvedFields;
+    const llmFields = llmResult?.selectClause && Array.isArray(llmResult.selectClause) && llmResult.selectClause.length > 0
+        ? llmResult.selectClause
+        : null;
+
+    // When we have deterministic fields, supplement them with LLM descriptions
+    const rawFields = resolvedFields
+        ? supplementDeterministicWithLLM(resolvedFields, llmFields)
+        : llmFields;
 
     const finalFields = rawFields
         ? EnrichFieldTypesFromEntityMetadata(
@@ -145,12 +150,12 @@ async function sync(
         syncPromises.push(RemoveAllRecords(ctx.queryID, 'MJ: Query Parameters', ctx.contextUser, ctx.runViewProvider, ctx.isSaved));
     }
 
-    // Fields
+    // Fields: when finalFields is null, preserve existing fields instead of deleting them.
+    // Deletion only happens when we have a positive new field list (handled inside SyncFields via diff).
     if (finalFields) {
         syncPromises.push(SyncFields(ctx.queryID, finalFields, ctx.contextUser, ctx.metadataProvider, ctx.runViewProvider, ctx.isSaved));
-    } else {
-        syncPromises.push(RemoveAllRecords(ctx.queryID, 'MJ: Query Fields', ctx.contextUser, ctx.runViewProvider, ctx.isSaved));
     }
+    // When finalFields is null, we intentionally do NOT call RemoveAllRecords — existing fields are preserved.
 
     // Entities
     if (resolveResult.entityMetadata.length > 0) {
@@ -163,4 +168,39 @@ async function sync(
     syncPromises.push(SyncDependencies(ctx.queryID, resolveResult.resolvedCompositionRefs, ctx.contextUser, ctx.metadataProvider, ctx.runViewProvider, ctx.isSaved));
 
     await Promise.all(syncPromises);
+}
+
+/**
+ * Supplements deterministic fields with richer descriptions from LLM output.
+ * The deterministic field list is authoritative for names; the LLM may provide
+ * better descriptions, type hints, and computation descriptions.
+ */
+function supplementDeterministicWithLLM(
+    resolvedFields: ExtractedField[],
+    llmFields: ExtractedField[] | null
+): ExtractedField[] {
+    if (!llmFields || llmFields.length === 0) return resolvedFields;
+
+    const llmByName = new Map<string, ExtractedField>();
+    for (const lf of llmFields) {
+        llmByName.set(lf.name.toLowerCase(), lf);
+    }
+
+    return resolvedFields.map(df => {
+        const llmMatch = llmByName.get(df.name.toLowerCase());
+        if (!llmMatch) return df;
+
+        return {
+            ...df,
+            // LLM provides richer descriptions than the deterministic defaults
+            description: llmMatch.description || df.description,
+            // LLM may provide a better type guess for expression columns
+            type: df.isComputed ? (llmMatch.type || df.type) : df.type,
+            // LLM may identify summary/computed nature better
+            isSummary: llmMatch.isSummary ?? df.isSummary,
+            computationDescription: llmMatch.computationDescription ?? df.computationDescription,
+            // LLM may identify source entity for columns the parser can't resolve
+            sourceEntity: df.sourceEntity ?? llmMatch.sourceEntity,
+        };
+    });
 }

--- a/packages/MJCoreEntitiesServer/src/custom/query-extraction/resolve.ts
+++ b/packages/MJCoreEntitiesServer/src/custom/query-extraction/resolve.ts
@@ -250,6 +250,51 @@ export function MapQueryParamTypeToParserType(
 // ═══════════════════════════════════════════════════
 
 /**
+ * Builds ExtractedField[] deterministically from the parsed SELECT columns.
+ *
+ * This is the PRIMARY deterministic field extraction path, handling explicit
+ * column lists like `SELECT col1, col2 AS Alias, COUNT(*) AS Total`.
+ * For each parsed column, it creates an ExtractedField with:
+ *   - name: the output name (alias if present, otherwise source column)
+ *   - isComputed: true for expression columns (aggregates, calculations)
+ *   - sourceFieldName: the original column name (before AS alias)
+ *
+ * Returns null only if selectColumns is empty (e.g., a stored procedure call
+ * or non-SELECT statement).
+ */
+export function BuildFieldsFromSelectColumns(
+    selectColumns: SQLSelectColumn[]
+): ExtractedField[] | null {
+    if (selectColumns.length === 0) return null;
+
+    // Skip if ALL columns are wildcards — BuildFieldsForSelectStar handles that
+    if (selectColumns.every(col => col.SourceColumn === '*')) return null;
+
+    return selectColumns
+        .filter(col => col.SourceColumn !== '*')
+        .map(col => buildFieldFromSelectColumn(col));
+}
+
+/**
+ * Converts a single parsed SELECT column into an ExtractedField.
+ */
+function buildFieldFromSelectColumn(col: SQLSelectColumn): ExtractedField {
+    return {
+        name: col.OutputName,
+        description: col.IsExpression
+            ? `Computed column: ${col.SourceColumn}`
+            : col.OutputName !== col.SourceColumn
+                ? `${col.SourceColumn} (aliased as ${col.OutputName})`
+                : col.OutputName,
+        type: 'string', // default; enrichment stages refine this from entity/composition metadata
+        optional: false,
+        sourceFieldName: col.IsExpression ? null : col.SourceColumn,
+        isComputed: col.IsExpression,
+        isSummary: false,
+    };
+}
+
+/**
  * Detects SELECT * and builds the complete field list deterministically
  * from entity metadata and/or composition ref fields.
  * Returns null if the SQL doesn't use SELECT * or if entities can't be resolved.

--- a/packages/MJCoreEntitiesServer/src/custom/query-extraction/types.ts
+++ b/packages/MJCoreEntitiesServer/src/custom/query-extraction/types.ts
@@ -103,8 +103,8 @@ export interface ResolveResult {
     allDeterministicParams: MJParameterInfo[];
     passthroughContext: Map<string, PassthroughParamContext>;
     entityMetadata: EntityMetadataEntry[];
-    /** Non-null if SELECT * was detected and fields were expanded deterministically */
-    selectStarFields: ExtractedField[] | null;
+    /** Fields resolved from the SQL — via SELECT * expansion against entity metadata, or parsed from explicit SELECT columns */
+    resolvedFields: ExtractedField[] | null;
 }
 
 /**


### PR DESCRIPTION
## Summary
- Add `BuildFieldsFromSelectColumns()` to deterministically extract QueryFields from explicit SELECT columns, using already-parsed `SQLSelectColumn` data from the PARSE stage
- Previously, queries with explicit columns (non-SELECT-*) relied solely on LLM fallback for field extraction — when the LLM failed (e.g., expired Gemini API key in CASE DB), all existing QueryField records were deleted
- LLM now supplements deterministic fields with richer descriptions rather than being the primary source (same pattern as QueryParameters)
- Remove destructive deletion of fields when extraction returns null — existing fields are preserved

## Test plan
- [x] Build `@memberjunction/core-entities-server` — passes
- [x] Run all 199 unit tests — all pass (6 test files, 0 failures)
- [x] Verified against CASE database: all 11 Golden-Queries went from 0 fields to correct field counts after `mj sync push`
- [ ] Verify field extraction on queries with UNION ALL, subqueries
- [ ] Confirm LLM supplementation works when API key is valid (enriches descriptions on deterministic fields)

🤖 Generated with [Claude Code](https://claude.com/claude-code)