### PR TITLE
feat(conversations): redesign Save-to-Collection dialog + fix install.sh env parser

### DIFF
--- a/.changeset/soft-sites-play.md
+++ b/.changeset/soft-sites-play.md
@@ -1,0 +1,6 @@
+---
+"@memberjunction/ng-artifacts": patch
+"@memberjunction/ng-conversations": patch
+---
+
+no migration

--- a/Demos/AssociationDB/install.sh
+++ b/Demos/AssociationDB/install.sh
@@ -13,11 +13,15 @@ cd "$(dirname "$0")"
 # Load DB_* environment variables from .env file
 if [ -f .env ]; then
     while IFS='=' read -r key value; do
+        key="${key// /}"
         value="${value%$'\r'}"
+        value="${value#"${value%%[![:space:]]*}"}"
+        value="${value%"${value##*[![:space:]]}"}"
         value="${value#[\'\"]}"
         value="${value%[\'\"]}"
+        [ -z "$key" ] && continue
         export "$key"="$value"
-    done < <(grep -v '^\s*#' .env | grep -E '^(DB_|CODEGEN_DB_)')
+    done < <(grep -v '^\s*#' .env | grep -E '^\s*(DB_|CODEGEN_DB_)')
 else
     echo "Error: .env file not found!"
     echo "Please create a .env file with database credentials."

--- a/packages/Angular/Generic/artifacts/src/lib/components/artifact-viewer-panel.component.ts
+++ b/packages/Angular/Generic/artifacts/src/lib/components/artifact-viewer-panel.component.ts
@@ -807,8 +807,18 @@ export class ArtifactViewerPanelComponent extends BaseAngularComponent implement
   }
 
   /**
-   * Called by parent component after user selects collections in the picker.
-   * Saves the artifact to the selected collections.
+   * Reload the cached set of collections that contain the *current version* of this artifact.
+   * Called by the chat-area after the collection picker reports successful saves so the bookmark
+   * icon and "already saved" exclusion list refresh without a full artifact reload.
+   */
+  public async ReloadCollectionAssociations(): Promise<void> {
+    await this.loadCollectionAssociations();
+  }
+
+  /**
+   * @deprecated Writes are now owned by the picker modal so the dialog can render per-collection
+   * progress and partial-failure UI. Kept for any external consumer that still calls it; new code
+   * should pass `artifactVersionId` to the picker and listen for its `completed` event.
    */
   async saveToCollections(collectionIds: string[]): Promise<boolean> {
     if (!this.artifactId || collectionIds.length === 0) {

--- a/packages/Angular/Generic/conversations/src/lib/components/collection/artifact-collection-picker-modal.component.ts
+++ b/packages/Angular/Generic/conversations/src/lib/components/collection/artifact-collection-picker-modal.component.ts
@@ -1,30 +1,45 @@
-import { Component, Input, Output, EventEmitter, OnInit, OnChanges, SimpleChanges, ChangeDetectorRef } from '@angular/core';
+import { Component, Input, Output, EventEmitter, OnInit, OnChanges, SimpleChanges, ChangeDetectorRef, ViewChild, ElementRef, AfterViewInit } from '@angular/core';
 import { BaseAngularComponent } from '@memberjunction/ng-base-types';
 
 import { FormsModule } from '@angular/forms';
-import { UserInfo, RunView, Metadata } from '@memberjunction/core';
-import { MJCollectionEntity } from '@memberjunction/core-entities';
+import { UserInfo, RunView, LogError } from '@memberjunction/core';
+import { MJCollectionEntity, MJCollectionArtifactEntity } from '@memberjunction/core-entities';
 import { MJDialogComponent, MJDialogActionsComponent, MJButtonDirective } from '@memberjunction/ng-ui-components';
 import { SharedGenericModule } from '@memberjunction/ng-shared-generic';
 import { ToastService } from '../../services/toast.service';
 import { CollectionPermissionService, CollectionPermission } from '../../services/collection-permission.service';
-import { UUIDsEqual } from '@memberjunction/global';
+import { UUIDsEqual, NormalizeUUID } from '@memberjunction/global';
+
+type SaveStatus = 'pending' | 'saving' | 'success' | 'error';
+type FilterMode = 'editable' | 'recent';
 
 interface CollectionNode {
   collection: MJCollectionEntity;
-  selected: boolean;
+  depth: number;
+  expanded: boolean;
   hasChildren: boolean;
   alreadyContainsArtifact: boolean;
+  /** Breadcrumb of parent names — only used in search mode */
+  ancestry: string;
+}
+
+interface SaveResult {
+  collectionId: string;
+  collectionName: string;
+  status: SaveStatus;
+  errorMessage?: string;
 }
 
 /**
- * Modal for selecting collections to save artifacts to.
- * Features:
- * - Permission-aware: only shows collections where user has Edit permission
- * - Hierarchical navigation: start with root collections, drill down as needed
- * - Search by name
- * - Multi-selection support
- * - Create new collection with proper permission logic
+ * Modal for saving an artifact version to one or more collections.
+ *
+ * Owns the full UX *and* the writes:
+ *   - Left pane: searchable, expandable tree of collections the user can edit
+ *   - Right pane: artifact preview + live selection chips, and (post-save) per-collection results
+ *   - Save runs inline (modal stays open during writes) and reports per-collection success/failure with retry
+ *
+ * Emits {@link completed} on full success (parent should reload bookmark state) and on user-acknowledged
+ * partial failure. Emits {@link cancelled} when the user backs out without saving anything.
  */
 @Component({
   selector: 'mj-artifact-collection-picker-modal',
@@ -35,492 +50,616 @@ interface CollectionNode {
     MJDialogActionsComponent,
     MJButtonDirective,
     SharedGenericModule
-],
+  ],
   template: `
     @if (isOpen) {
       <mj-dialog
         Title="Save to Collection"
         (Close)="onCancel()"
         [Visible]="true"
-        [Width]="700"
-        [MinWidth]="500">
-        <div class="picker-modal">
-          <!-- Breadcrumb Navigation -->
-          @if (navigationPath.length > 0) {
-            <div class="breadcrumb-nav">
-              <button class="breadcrumb-btn" (click)="navigateToRoot()">
-                <i class="fas fa-home"></i> Root
+        [Width]="960"
+        [MinWidth]="720">
+        <div class="picker-shell">
+          <!-- ============================================================ -->
+          <!--  LEFT PANE  · search + tree                                  -->
+          <!-- ============================================================ -->
+          <div class="pane pane-left">
+            <div class="toolbar">
+              <div class="search">
+                <i class="fa-solid fa-magnifying-glass"></i>
+                <input
+                  #searchInput
+                  type="text"
+                  [(ngModel)]="searchQuery"
+                  (ngModelChange)="onSearchChange()"
+                  placeholder="Search collections…"
+                  [disabled]="isLoading || isSaving" />
+                @if (searchQuery) {
+                  <button class="search-clear" (click)="clearSearch()" title="Clear">
+                    <i class="fa-solid fa-xmark"></i>
+                  </button>
+                }
+              </div>
+              <button class="chip-btn"
+                      [class.active]="filterMode === 'editable'"
+                      (click)="setFilter('editable')"
+                      [disabled]="isSaving">
+                <i class="fa-solid fa-user-pen"></i> Editable
               </button>
-              @for (item of navigationPath; track item.collection.ID) {
-                <i class="fas fa-chevron-right breadcrumb-separator"></i>
-                <button class="breadcrumb-btn" (click)="navigateToCollection(item.collection)">
-                  {{ item.collection.Name }}
-                </button>
-              }
+              <button class="chip-btn"
+                      [class.active]="filterMode === 'recent'"
+                      (click)="setFilter('recent')"
+                      [disabled]="isSaving">
+                <i class="fa-solid fa-clock"></i> Recent
+              </button>
             </div>
-          }
-          <!-- Search Bar -->
-          <div class="search-bar">
-            <i class="fas fa-search search-icon"></i>
-            <input
-              type="text"
-              class="k-textbox search-input"
-              [(ngModel)]="searchQuery"
-              (input)="onSearchChange()"
-              placeholder="Search collections..."
-              [disabled]="isLoading">
-          </div>
-          <!-- Collections List -->
-          @if (!isLoading && !errorMessage) {
-            <div class="collections-list">
-              @if (displayedCollections.length === 0) {
-                <div class="empty-state">
+
+            <div class="tree-wrap">
+              @if (isLoading) {
+                <div class="state-block">
+                  <mj-loading text="Loading collections…" size="medium"></mj-loading>
+                </div>
+              } @else if (errorMessage) {
+                <div class="state-block error">
+                  <i class="fa-solid fa-triangle-exclamation"></i>
+                  <span>{{ errorMessage }}</span>
+                </div>
+              } @else if (visibleNodes.length === 0) {
+                <div class="state-block muted">
                   @if (searchQuery) {
-                    <i class="fas fa-search"></i>
-                    <p>No collections found matching "{{ searchQuery }}"</p>
-                  } @else if (currentParentId) {
-                    <i class="fas fa-folder-open"></i>
-                    <p>No sub-collections available</p>
+                    <i class="fa-solid fa-magnifying-glass"></i>
+                    <p>No collections match &ldquo;{{ searchQuery }}&rdquo;</p>
+                    <button class="link-btn" (click)="clearSearch()">Clear search</button>
                   } @else {
-                    <i class="fas fa-folder"></i>
-                    <p>No collections available</p>
-                    <p class="hint">Create a new collection to get started</p>
+                    <i class="fa-solid fa-folder-open"></i>
+                    <p>No editable collections yet</p>
+                    <p class="hint">Create one to get started</p>
                   }
                 </div>
               } @else {
-                @for (node of displayedCollections; track node.collection.ID) {
-                  <div class="collection-item"
-                    [class.already-added]="node.alreadyContainsArtifact"
-                    (click)="toggleSelection(node)">
-                    <div class="collection-checkbox">
-                      <input
-                        type="checkbox"
-                        [checked]="node.selected"
-                        [disabled]="node.alreadyContainsArtifact"
-                        (click)="$event.stopPropagation(); toggleSelection(node)">
-                    </div>
-                    <i class="fas fa-folder collection-icon" [style.color]="node.collection.Color || 'var(--mj-brand-primary)'"></i>
-                    <span class="collection-name">{{ node.collection.Name }}</span>
-                    @if (node.alreadyContainsArtifact) {
-                      <span class="already-added-badge">
-                        <i class="fas fa-check-circle"></i> Already added
+                <div class="tree" role="tree">
+                  @for (node of visibleNodes; track node.collection.ID) {
+                    <div class="row"
+                         role="treeitem"
+                         [class.selected]="isSelected(node.collection.ID)"
+                         [class.already]="node.alreadyContainsArtifact"
+                         [style.padding-left.px]="searchQuery ? 12 : 12 + node.depth * 18"
+                         (click)="onRowClick(node)">
+                      <span class="caret" (click)="$event.stopPropagation(); toggleExpand(node)">
+                        @if (node.hasChildren && !searchQuery) {
+                          <i class="fa-solid" [class.fa-chevron-down]="node.expanded" [class.fa-chevron-right]="!node.expanded"></i>
+                        }
                       </span>
-                    }
-                    @if (node.hasChildren) {
-                      <button
-                        class="drill-down-btn"
-                        (click)="$event.stopPropagation(); drillIntoCollection(node.collection)"
-                        title="View sub-collections">
-                        <i class="fas fa-chevron-right"></i>
+                      <span class="check"
+                            [class.checked]="isSelected(node.collection.ID)"
+                            [class.locked]="node.alreadyContainsArtifact"
+                            [attr.aria-label]="node.alreadyContainsArtifact ? 'Already saved' : 'Toggle selection'">
+                        @if (isSelected(node.collection.ID) || node.alreadyContainsArtifact) {
+                          <i class="fa-solid fa-check"></i>
+                        }
+                      </span>
+                      <i class="fa-solid fa-folder folder-icon"
+                         [style.color]="node.collection.Color || 'var(--mj-brand-primary)'"></i>
+                      <span class="row-title">
+                        {{ node.collection.Name }}
+                        @if (searchQuery && node.ancestry) {
+                          <span class="row-ancestry">· {{ node.ancestry }}</span>
+                        }
+                      </span>
+                      @if (node.alreadyContainsArtifact) {
+                        <span class="row-tag success">Already saved</span>
+                      }
+                    </div>
+                  }
+
+                  <!-- Inline "create new" row -->
+                  @if (!isSaving && !searchQuery && !showCreateForm) {
+                    <button class="row create-row" (click)="openCreateForm()">
+                      <span class="caret"></span>
+                      <span class="check dashed"><i class="fa-solid fa-plus"></i></span>
+                      <span class="row-title">Create new collection…</span>
+                    </button>
+                  } @else if (showCreateForm) {
+                    <div class="row create-form-row">
+                      <span class="caret"></span>
+                      <span class="check dashed"><i class="fa-solid fa-plus"></i></span>
+                      <input #newNameInput type="text"
+                             class="create-input"
+                             [(ngModel)]="newCollectionName"
+                             (keydown.enter)="createCollection()"
+                             (keydown.escape)="cancelCreate()"
+                             placeholder="Collection name"
+                             [disabled]="isCreatingCollection" />
+                      <button mjButton variant="primary" size="sm"
+                              (click)="createCollection()"
+                              [disabled]="isCreatingCollection || !newCollectionName.trim()">
+                        @if (isCreatingCollection) {
+                          <i class="fa-solid fa-spinner fa-spin"></i>
+                        } @else {
+                          Create
+                        }
                       </button>
-                    }
-                  </div>
-                }
+                      <button mjButton size="sm" (click)="cancelCreate()" [disabled]="isCreatingCollection">
+                        Cancel
+                      </button>
+                    </div>
+                  }
+                </div>
               }
             </div>
-          }
-          <!-- Loading State -->
-          @if (isLoading) {
-            <div class="loading-state">
-              <mj-loading text="Loading collections..." size="medium"></mj-loading>
-            </div>
-          }
-          <!-- Error State -->
-          @if (errorMessage) {
-            <div class="error-state">
-              <i class="fas fa-exclamation-triangle"></i>
-              <span>{{ errorMessage }}</span>
-            </div>
-          }
-          <!-- Selected Collections Summary -->
-          @if (selectedCollections.length > 0) {
-            <div class="selected-summary">
-              <i class="fas fa-check-circle"></i>
-              <span>{{ selectedCollections.length }} collection(s) selected</span>
-            </div>
-          }
-          <!-- Create New Collection Section -->
-          <div class="create-section">
-            <div class="divider">
-              <span>OR CREATE NEW</span>
-            </div>
-            @if (!showCreateForm) {
-              <button class="btn-create-collection" (click)="showCreateForm = true">
-                <i class="fas fa-plus"></i>
-                Create New Collection
-              </button>
-            } @else {
-              <div class="create-form">
-                <input
-                  type="text"
-                  class="k-textbox create-input"
-                  [(ngModel)]="newCollectionName"
-                  placeholder="Enter collection name"
-                  (keydown.enter)="createCollection()"
-                  #newCollectionInput>
-                <div class="create-actions">
-                  <button mjButton variant="primary" size="sm" (click)="createCollection()" [disabled]="isCreatingCollection || !newCollectionName.trim()">
-                    @if (isCreatingCollection) {
-                      <i class="fas fa-spinner fa-spin"></i>
-                    } @else {
-                      Create
-                    }
-                  </button>
-                  <button mjButton size="sm" (click)="showCreateForm = false; newCollectionName = ''">
-                    Cancel
-                  </button>
+          </div>
+
+          <!-- ============================================================ -->
+          <!--  RIGHT PANE  · preview + chips / results                     -->
+          <!-- ============================================================ -->
+          <div class="pane pane-right">
+            <div class="preview-block">
+              <div class="block-label">Saving</div>
+              <div class="preview-card">
+                <div class="preview-thumb"><i class="fa-solid fa-file-lines"></i></div>
+                <div class="preview-meta">
+                  <div class="preview-name" [title]="artifactName">{{ artifactName || 'Artifact' }}</div>
+                  @if (artifactVersionNumber != null) {
+                    <span class="badge neutral">v{{ artifactVersionNumber }}</span>
+                  }
                 </div>
               </div>
-            }
+            </div>
+
+            <div class="chips-block">
+              <div class="block-label">
+                @if (saveResults.size > 0) {
+                  <span>Results</span>
+                  <span class="block-count">{{ successCount }} / {{ saveResults.size }}</span>
+                } @else {
+                  <span>Selected</span>
+                  <span class="block-count">{{ selectedIds.size }}</span>
+                }
+              </div>
+
+              @if (saveResults.size > 0) {
+                <!-- Per-collection results -->
+                <div class="chips">
+                  @for (r of resultsList; track r.collectionId) {
+                    <div class="chip result" [class.success]="r.status === 'success'"
+                                              [class.error]="r.status === 'error'"
+                                              [class.saving]="r.status === 'saving'">
+                      <span class="chip-status">
+                        @switch (r.status) {
+                          @case ('saving') { <i class="fa-solid fa-spinner fa-spin"></i> }
+                          @case ('success') { <i class="fa-solid fa-check"></i> }
+                          @case ('error') { <i class="fa-solid fa-triangle-exclamation"></i> }
+                          @default { <i class="fa-solid fa-circle"></i> }
+                        }
+                      </span>
+                      <div class="chip-body">
+                        <div class="chip-name">{{ r.collectionName }}</div>
+                        @if (r.status === 'error' && r.errorMessage) {
+                          <div class="chip-error">{{ r.errorMessage }}</div>
+                        }
+                      </div>
+                      @if (r.status === 'error') {
+                        <button class="chip-action" (click)="retryOne(r.collectionId)" title="Retry">
+                          <i class="fa-solid fa-rotate-right"></i>
+                        </button>
+                      }
+                    </div>
+                  }
+                </div>
+              } @else if (selectedIds.size > 0) {
+                <div class="chips">
+                  @for (c of selectedCollections; track c.ID) {
+                    <div class="chip">
+                      <i class="fa-solid fa-folder folder-icon" [style.color]="c.Color || 'var(--mj-brand-primary)'"></i>
+                      <div class="chip-body">
+                        <div class="chip-name">{{ c.Name }}</div>
+                      </div>
+                      <button class="chip-action" (click)="deselect(c.ID)"
+                              [disabled]="isSaving"
+                              title="Remove">
+                        <i class="fa-solid fa-xmark"></i>
+                      </button>
+                    </div>
+                  }
+                </div>
+              } @else {
+                <div class="chips-empty">
+                  <i class="fa-solid fa-hand-pointer"></i>
+                  <p>Pick a collection on the left</p>
+                </div>
+              }
+            </div>
+
+            <div class="footnote">
+              <i class="fa-solid fa-shield-halved"></i>
+              Only collections you can edit are shown
+            </div>
           </div>
         </div>
+
         <mj-dialog-actions>
-          <button mjButton (click)="onCancel()">
-            Cancel
-          </button>
-          <button mjButton
-            variant="primary"
-            (click)="onSave()"
-            [disabled]="selectedCollections.length === 0 || isSaving">
-            @if (isSaving) {
-              <i class="fas fa-spinner fa-spin"></i> Saving...
-            } @else {
-              <i class="fas fa-save"></i> Save to {{ selectedCollections.length }} Collection(s)
-            }
-          </button>
+          <!-- Primary on the LEFT per MJ convention -->
+          @if (failedCount > 0 && !isSaving) {
+            <button mjButton variant="primary" (click)="retryFailed()">
+              <i class="fa-solid fa-rotate-right"></i> Retry {{ failedCount }} failed
+            </button>
+            <button mjButton (click)="onAcknowledgeAndClose()">Done</button>
+          } @else if (saveResults.size > 0 && successCount === saveResults.size && !isSaving) {
+            <!-- All succeeded — auto-closes, but render fallback button just in case -->
+            <button mjButton variant="primary" (click)="onAcknowledgeAndClose()">
+              <i class="fa-solid fa-check"></i> Done
+            </button>
+          } @else {
+            <button mjButton variant="primary"
+                    (click)="onSave()"
+                    [disabled]="selectedIds.size === 0 || isSaving">
+              @if (isSaving) {
+                <i class="fa-solid fa-spinner fa-spin"></i> Saving to {{ selectedIds.size }}…
+              } @else {
+                <i class="fa-solid fa-bookmark"></i>
+                Save to {{ selectedIds.size }} {{ selectedIds.size === 1 ? 'collection' : 'collections' }}
+              }
+            </button>
+            <button mjButton (click)="onCancel()" [disabled]="isSaving">Cancel</button>
+          }
         </mj-dialog-actions>
       </mj-dialog>
     }
-    `,
+  `,
   styles: [`
-    .picker-modal {
-      display: flex;
-      flex-direction: column;
-      gap: 16px;
-      padding: 20px 0;
-      min-height: 400px;
-      max-height: 600px;
+    /* ===== Shell ===== */
+    .picker-shell {
+      display: grid;
+      grid-template-columns: 1fr 300px;
+      min-height: 460px;
+      max-height: 70vh;
+      gap: 0;
+      margin: -8px -4px 0;
     }
+    .pane { display:flex; flex-direction:column; min-height: 0; }
+    .pane-left  { border-right: 1px solid var(--mj-border-subtle); }
+    .pane-right { background: var(--mj-bg-surface-card); }
 
-    .breadcrumb-nav {
-      display: flex;
-      align-items: center;
-      gap: 8px;
-      padding: 12px 16px;
+    /* ===== Toolbar / search / chip filters ===== */
+    .toolbar {
+      display:flex; gap: 8px; padding: 10px 12px;
+      border-bottom: 1px solid var(--mj-border-subtle);
+      flex-wrap: wrap;
+    }
+    .search {
+      flex: 1; min-width: 200px;
+      display:flex; align-items:center; gap: 8px;
+      padding: 8px 12px;
       background: var(--mj-bg-surface-sunken);
+      border: 1px solid transparent;
+      border-radius: 8px;
+      transition: all .15s ease;
+    }
+    .search:focus-within {
+      background: var(--mj-bg-surface);
+      border-color: var(--mj-border-focus);
+      box-shadow: 0 0 0 3px color-mix(in srgb, var(--mj-brand-primary) 18%, transparent);
+    }
+    .search i { color: var(--mj-text-muted); font-size: 13px; }
+    .search input {
+      flex: 1; border: 0; outline: 0; background: transparent;
+      font-size: 13.5px; color: var(--mj-text-primary);
+      min-width: 0;
+    }
+    .search input::placeholder { color: var(--mj-text-disabled); }
+    .search-clear {
+      background: transparent; border: 0; cursor: pointer;
+      color: var(--mj-text-muted); padding: 2px 4px; border-radius: 4px;
+    }
+    .search-clear:hover { color: var(--mj-text-primary); background: var(--mj-bg-surface-hover); }
+
+    .chip-btn {
+      display:inline-flex; align-items:center; gap: 6px;
+      padding: 7px 11px; border-radius: 8px;
+      background: var(--mj-bg-surface);
       border: 1px solid var(--mj-border-default);
-      border-radius: 6px;
-      overflow-x: auto;
-    }
-
-    .breadcrumb-btn {
-      display: flex;
-      align-items: center;
-      gap: 6px;
-      padding: 4px 8px;
-      background: transparent;
-      border: none;
-      border-radius: 4px;
-      color: var(--mj-brand-primary);
-      cursor: pointer;
-      white-space: nowrap;
-      font-size: 14px;
-    }
-
-    .breadcrumb-btn:hover {
-      background: var(--mj-border-default);
-    }
-
-    .breadcrumb-separator {
-      color: var(--mj-text-disabled);
-      font-size: 12px;
-    }
-
-    .search-bar {
-      position: relative;
-      display: flex;
-      align-items: center;
-    }
-
-    .search-icon {
-      position: absolute;
-      left: 12px;
-      color: var(--mj-text-disabled);
-      pointer-events: none;
-    }
-
-    .search-input {
-      width: 100%;
-      padding-left: 36px;
-    }
-
-    .collections-list {
-      flex: 1;
-      overflow-y: auto;
-      border: 1px solid var(--mj-border-default);
-      border-radius: 6px;
-      min-height: 250px;
-      max-height: 350px;
-    }
-
-    .collection-item {
-      display: flex;
-      align-items: center;
-      gap: 12px;
-      padding: 12px 16px;
-      border-bottom: 1px solid var(--mj-border-default);
-      cursor: pointer;
-      transition: background 0.2s;
-    }
-
-    .collection-item:hover {
-      background: var(--mj-bg-surface-sunken);
-    }
-
-    .collection-item:last-child {
-      border-bottom: none;
-    }
-
-    .collection-item.already-added {
-      background: var(--mj-bg-surface-sunken);
-      opacity: 0.7;
-      cursor: not-allowed;
-    }
-
-    .collection-item.already-added:hover {
-      background: var(--mj-bg-surface-sunken);
-    }
-
-    .collection-checkbox {
-      display: flex;
-      align-items: center;
-    }
-
-    .collection-checkbox input[type="checkbox"] {
-      width: 18px;
-      height: 18px;
-      cursor: pointer;
-    }
-
-    .collection-icon {
-      font-size: 18px;
-      flex-shrink: 0;
-    }
-
-    .collection-name {
-      flex: 1;
-      font-size: 14px;
-      color: var(--mj-text-primary);
-    }
-
-    .already-added-badge {
-      display: flex;
-      align-items: center;
-      gap: 4px;
-      padding: 4px 8px;
-      background: color-mix(in srgb, var(--mj-brand-primary) 10%, var(--mj-bg-surface));
-      border: 1px solid color-mix(in srgb, var(--mj-brand-primary) 30%, var(--mj-bg-surface));
-      border-radius: 12px;
-      color: var(--mj-brand-primary);
-      font-size: 12px;
-      font-weight: 500;
-      white-space: nowrap;
-    }
-
-    .already-added-badge i {
-      font-size: 12px;
-      color: var(--mj-brand-primary);
-    }
-
-    .drill-down-btn {
-      padding: 6px 10px;
-      background: transparent;
-      border: 1px solid var(--mj-border-strong);
-      border-radius: 4px;
-      color: var(--mj-text-muted);
-      cursor: pointer;
-      transition: all 0.2s;
-    }
-
-    .drill-down-btn:hover {
-      background: var(--mj-bg-surface-sunken);
-      border-color: var(--mj-text-disabled);
       color: var(--mj-text-secondary);
+      font-size: 12.5px; font-weight: 600; cursor: pointer;
+      transition: all .15s ease;
     }
-
-    .empty-state {
-      display: flex;
-      flex-direction: column;
-      align-items: center;
-      justify-content: center;
-      padding: 48px 24px;
-      color: var(--mj-text-muted);
-      text-align: center;
-    }
-
-    .empty-state i {
-      font-size: 48px;
-      margin-bottom: 16px;
-      opacity: 0.4;
-    }
-
-    .empty-state p {
-      margin: 4px 0;
-      font-size: 14px;
-    }
-
-    .empty-state .hint {
-      font-size: 13px;
-      color: var(--mj-text-disabled);
-    }
-
-    .loading-state, .error-state {
-      display: flex;
-      flex-direction: column;
-      align-items: center;
-      justify-content: center;
-      padding: 48px 24px;
-      gap: 12px;
-      color: var(--mj-text-muted);
-    }
-
-    .error-state i {
-      font-size: 32px;
-    }
-
-    .error-state {
-      color: var(--mj-status-error);
-    }
-
-    .selected-summary {
-      display: flex;
-      align-items: center;
-      gap: 8px;
-      padding: 12px 16px;
+    .chip-btn:hover:not(:disabled) { background: var(--mj-bg-surface-hover); color: var(--mj-text-primary); }
+    .chip-btn.active {
       background: color-mix(in srgb, var(--mj-brand-primary) 10%, var(--mj-bg-surface));
-      border: 1px solid color-mix(in srgb, var(--mj-brand-primary) 30%, var(--mj-bg-surface));
-      border-radius: 6px;
       color: var(--mj-brand-primary);
-      font-size: 14px;
-      font-weight: 500;
+      border-color: color-mix(in srgb, var(--mj-brand-primary) 30%, transparent);
     }
+    .chip-btn:disabled { opacity: .55; cursor: not-allowed; }
 
-    .selected-summary i {
-      color: var(--mj-brand-primary);
+    /* ===== Tree ===== */
+    .tree-wrap { flex: 1; overflow-y: auto; padding: 8px 8px 16px; }
+    .tree { display:flex; flex-direction: column; gap: 1px; }
+    .row {
+      display:flex; align-items:center; gap: 10px;
+      padding: 7px 12px; border-radius: 8px; cursor: pointer;
+      user-select: none;
+      border: 1px solid transparent;
+      background: transparent;
+      text-align: left;
+      transition: background .12s ease;
+      min-height: 36px;
     }
-
-    .create-section {
-      display: flex;
-      flex-direction: column;
-      gap: 12px;
+    .row:hover { background: var(--mj-bg-surface-hover); }
+    .row.selected {
+      background: color-mix(in srgb, var(--mj-brand-primary) 9%, var(--mj-bg-surface));
+      border-color: color-mix(in srgb, var(--mj-brand-primary) 30%, transparent);
     }
+    .row.already { cursor: default; }
+    .row.already:hover { background: transparent; }
+    .row.already .row-title { color: var(--mj-text-secondary); }
 
-    .divider {
-      display: flex;
-      align-items: center;
-      text-align: center;
-      color: var(--mj-text-disabled);
-      font-size: 12px;
-      font-weight: 500;
-    }
-
-    .divider::before,
-    .divider::after {
-      content: '';
-      flex: 1;
-      border-bottom: 1px solid var(--mj-border-default);
-    }
-
-    .divider span {
-      padding: 0 12px;
-    }
-
-    .btn-create-collection {
-      display: flex;
-      align-items: center;
-      justify-content: center;
-      gap: 8px;
-      padding: 10px 16px;
-      background: var(--mj-bg-surface-sunken);
-      border: 2px dashed var(--mj-border-strong);
-      border-radius: 6px;
-      color: var(--mj-brand-primary);
-      font-size: 14px;
-      font-weight: 500;
+    .caret {
+      width: 16px; flex-shrink: 0; text-align: center;
+      color: var(--mj-text-muted); font-size: 10px;
       cursor: pointer;
-      transition: all 0.2s;
     }
+    .caret:hover { color: var(--mj-text-primary); }
 
-    .btn-create-collection:hover {
-      background: var(--mj-bg-surface-sunken);
+    .check {
+      width: 18px; height: 18px; border-radius: 5px;
+      border: 1.5px solid var(--mj-border-strong);
+      background: var(--mj-bg-surface);
+      display:flex; align-items:center; justify-content:center;
+      color: transparent; font-size: 10px; flex-shrink: 0;
+      transition: all .12s ease;
+    }
+    .check.checked {
+      background: var(--mj-brand-primary);
       border-color: var(--mj-brand-primary);
+      color: #fff;
+    }
+    .check.locked {
+      background: var(--mj-status-success);
+      border-color: var(--mj-status-success);
+      color: #fff;
+    }
+    .check.dashed {
+      border-style: dashed;
+      color: var(--mj-text-muted);
     }
 
-    .btn-create-collection i {
-      font-size: 16px;
+    .folder-icon { font-size: 14px; flex-shrink: 0; }
+
+    .row-title {
+      flex: 1; font-size: 13.5px; font-weight: 600;
+      color: var(--mj-text-primary);
+      white-space: nowrap; overflow: hidden; text-overflow: ellipsis;
+    }
+    .row-ancestry {
+      font-weight: 500; color: var(--mj-text-muted); font-size: 12px;
+      margin-left: 2px;
+    }
+    .row-tag {
+      font-size: 11px; font-weight: 600; padding: 2px 8px;
+      border-radius: 999px; flex-shrink: 0;
+    }
+    .row-tag.success {
+      background: var(--mj-status-success-bg);
+      color: var(--mj-status-success-text);
+      border: 1px solid color-mix(in srgb, var(--mj-status-success) 35%, transparent);
     }
 
-    .create-form {
-      display: flex;
-      flex-direction: column;
-      gap: 12px;
-      padding: 16px;
-      background: var(--mj-bg-surface-sunken);
-      border: 1px solid var(--mj-border-default);
-      border-radius: 6px;
-    }
-
-    .create-input {
+    .create-row {
       width: 100%;
+      border: 1.5px dashed var(--mj-border-strong);
+      color: var(--mj-text-secondary);
+      margin-top: 8px;
+      background: transparent;
     }
+    .create-row .row-title { color: var(--mj-text-secondary); font-weight: 600; }
+    .create-row:hover {
+      border-color: var(--mj-brand-primary);
+      color: var(--mj-brand-primary);
+      background: color-mix(in srgb, var(--mj-brand-primary) 4%, var(--mj-bg-surface));
+    }
+    .create-row:hover .row-title { color: var(--mj-brand-primary); }
 
-    .create-actions {
-      display: flex;
+    .create-form-row {
+      margin-top: 8px;
+      border: 1.5px solid var(--mj-border-focus);
+      background: var(--mj-bg-surface);
+      cursor: default;
       gap: 8px;
-      justify-content: flex-end;
+      box-shadow: 0 0 0 3px color-mix(in srgb, var(--mj-brand-primary) 15%, transparent);
+    }
+    .create-input {
+      flex: 1; min-width: 0;
+      padding: 7px 10px;
+      font-size: 13.5px; color: var(--mj-text-primary);
+      background: var(--mj-bg-surface);
+      border: 1.5px solid var(--mj-border-strong);
+      border-radius: 6px;
+      outline: 0;
+      transition: all .12s ease;
+    }
+    .create-input::placeholder {
+      color: var(--mj-text-muted);
+    }
+    .create-input:focus {
+      border-color: var(--mj-border-focus);
+      box-shadow: 0 0 0 3px color-mix(in srgb, var(--mj-brand-primary) 20%, transparent);
     }
 
-    .btn-create, .btn-cancel {
-      padding: 8px 16px;
+    /* ===== State blocks ===== */
+    .state-block {
+      display:flex; flex-direction:column; align-items:center; justify-content:center;
+      padding: 48px 24px; gap: 8px; color: var(--mj-text-muted);
+      text-align: center;
+    }
+    .state-block i { font-size: 28px; opacity: .6; }
+    .state-block.error { color: var(--mj-status-error-text); }
+    .state-block .hint { font-size: 12.5px; color: var(--mj-text-disabled); margin: 0; }
+    .state-block .link-btn {
+      background: transparent; border: 0; color: var(--mj-text-link);
+      font-weight: 600; cursor: pointer; font-size: 13px; padding: 6px 12px;
+    }
+    .state-block .link-btn:hover { color: var(--mj-text-link-hover); text-decoration: underline; }
+    .state-block p { margin: 0; font-size: 13.5px; }
+
+    /* ===== Right pane ===== */
+    .preview-block { padding: 16px 18px; border-bottom: 1px solid var(--mj-border-subtle); }
+    .block-label {
+      font-size: 11px; text-transform: uppercase; letter-spacing: .08em;
+      font-weight: 700; color: var(--mj-text-muted); margin-bottom: 8px;
+      display:flex; justify-content:space-between; align-items:center;
+    }
+    .block-count {
+      color: var(--mj-brand-primary); font-size: 12px;
+      background: color-mix(in srgb, var(--mj-brand-primary) 10%, var(--mj-bg-surface));
+      padding: 2px 8px; border-radius: 999px;
+    }
+    .preview-card {
+      display:flex; gap: 12px; align-items:center;
+      background: var(--mj-bg-surface); border: 1px solid var(--mj-border-default);
+      border-radius: 10px; padding: 12px;
+      box-shadow: 0 1px 2px rgba(15,23,42,.04);
+    }
+    .preview-thumb {
+      width: 38px; height: 38px; border-radius: 9px; flex-shrink: 0;
+      background: linear-gradient(135deg, var(--mj-color-accent-400), var(--mj-brand-primary));
+      color: #fff; display:flex; align-items:center; justify-content:center;
       font-size: 14px;
+    }
+    .preview-meta { flex: 1; min-width: 0; display:flex; flex-direction: column; gap: 4px; }
+    .preview-name {
+      font-weight: 700; font-size: 13.5px; color: var(--mj-text-primary);
+      white-space: nowrap; overflow: hidden; text-overflow: ellipsis;
+    }
+    .badge {
+      display:inline-flex; align-items:center; gap: 4px;
+      padding: 2px 8px; border-radius: 999px; font-size: 11px; font-weight: 600;
+      width: fit-content;
+    }
+    .badge.neutral {
+      background: var(--mj-bg-surface-sunken);
+      color: var(--mj-text-secondary);
+      border: 1px solid var(--mj-border-default);
+    }
+
+    .chips-block { flex: 1; min-height: 0; display:flex; flex-direction: column;
+                    padding: 16px 18px 8px; overflow-y: auto; }
+    .chips { display:flex; flex-direction: column; gap: 6px; }
+    .chip {
+      display:flex; align-items:center; gap: 10px; padding: 8px 10px;
+      background: var(--mj-bg-surface); border: 1px solid var(--mj-border-default);
+      border-radius: 8px;
+    }
+    .chip-body { flex: 1; min-width: 0; }
+    .chip-name {
+      font-weight: 600; font-size: 13px; color: var(--mj-text-primary);
+      white-space: nowrap; overflow: hidden; text-overflow: ellipsis;
+    }
+    .chip-error {
+      font-size: 11.5px; color: var(--mj-status-error-text); margin-top: 2px;
+      white-space: nowrap; overflow: hidden; text-overflow: ellipsis;
+    }
+    .chip-action {
+      width: 24px; height: 24px; border-radius: 6px;
+      background: transparent; border: 0; cursor: pointer;
+      color: var(--mj-text-muted); font-size: 11px;
+      display:flex; align-items:center; justify-content:center;
+    }
+    .chip-action:hover:not(:disabled) {
+      background: var(--mj-bg-surface-hover); color: var(--mj-text-primary);
+    }
+    .chip-action:disabled { opacity: .4; cursor: not-allowed; }
+    .chip-status {
+      width: 20px; flex-shrink: 0; text-align: center; font-size: 12px;
+    }
+    .chip.result.success { border-color: color-mix(in srgb, var(--mj-status-success) 35%, transparent);
+                            background: var(--mj-status-success-bg); }
+    .chip.result.success .chip-status { color: var(--mj-status-success-text); }
+    .chip.result.error { border-color: color-mix(in srgb, var(--mj-status-error) 35%, transparent);
+                          background: var(--mj-status-error-bg); }
+    .chip.result.error .chip-status { color: var(--mj-status-error-text); }
+    .chip.result.saving .chip-status { color: var(--mj-brand-primary); }
+
+    .chips-empty {
+      flex: 1; display:flex; flex-direction: column; align-items: center; justify-content: center;
+      padding: 32px 16px; text-align: center; color: var(--mj-text-muted);
+      border: 1.5px dashed var(--mj-border-default); border-radius: 10px;
+    }
+    .chips-empty i { font-size: 22px; margin-bottom: 8px; opacity: .55; }
+    .chips-empty p { margin: 0; font-size: 12.5px; }
+
+    .footnote {
+      padding: 12px 18px;
+      font-size: 11.5px; color: var(--mj-text-muted);
+      display:flex; align-items:center; gap: 6px;
+      border-top: 1px solid var(--mj-border-subtle);
+    }
+    .footnote i { font-size: 11px; }
+
+    /* Tighten dialog content padding so panes meet edges cleanly */
+    :host ::ng-deep mj-dialog .k-window-content,
+    :host ::ng-deep mj-dialog .mj-dialog-content {
+      padding: 0 !important;
     }
   `]
 })
-export class ArtifactCollectionPickerModalComponent extends BaseAngularComponent implements OnInit, OnChanges  {
+export class ArtifactCollectionPickerModalComponent extends BaseAngularComponent implements OnInit, OnChanges, AfterViewInit {
   @Input() isOpen: boolean = false;
   @Input() environmentId!: string;
   @Input() currentUser!: UserInfo;
-  @Input() excludeCollectionIds: string[] = []; // Collections to exclude (e.g., already contains artifact)
+  /** Collections that already contain the *current version* — rendered with a green check and locked. */
+  @Input() excludeCollectionIds: string[] = [];
+  /** ID of the artifact version being saved. Required for writes. */
+  @Input() artifactVersionId: string | null = null;
+  /** Display-only: artifact name shown in the preview pane. */
+  @Input() artifactName: string = '';
+  /** Display-only: version number shown in the preview pane. */
+  @Input() artifactVersionNumber: number | null = null;
 
-  @Output() saved = new EventEmitter<string[]>(); // Emits selected collection IDs
+  /** Fired when the save flow finishes (fully successful, or user acknowledged partial result). */
+  @Output() completed = new EventEmitter<{ successIds: string[]; failedIds: string[] }>();
   @Output() cancelled = new EventEmitter<void>();
 
-  public allCollections: MJCollectionEntity[] = [];
-  public displayedCollections: CollectionNode[] = [];
-  public selectedCollections: MJCollectionEntity[] = [];
-  public userPermissions: Map<string, CollectionPermission> = new Map();
+  @ViewChild('searchInput') searchInputRef?: ElementRef<HTMLInputElement>;
+  @ViewChild('newNameInput') newNameInputRef?: ElementRef<HTMLInputElement>;
 
-  public navigationPath: CollectionNode[] = []; // Breadcrumb trail
-  public currentParentId: string | null = null;
-  public currentParentCollection: MJCollectionEntity | undefined = undefined;
+  // Data
+  private allCollections: MJCollectionEntity[] = [];
+  private editableCollections: MJCollectionEntity[] = [];
+  private userPermissions: Map<string, CollectionPermission> = new Map();
+  private collectionById: Map<string, MJCollectionEntity> = new Map();
+  private expandedIds: Set<string> = new Set();
 
+  // Selection (normalized UUIDs so SQL Server vs Postgres casing doesn't bite us)
+  public selectedIds: Set<string> = new Set();
+
+  // Filter / search
   public searchQuery: string = '';
+  public filterMode: FilterMode = 'editable';
+
+  // Render output
+  public visibleNodes: CollectionNode[] = [];
+
+  // States
   public isLoading: boolean = false;
   public isSaving: boolean = false;
   public errorMessage: string = '';
-
-  // Create collection form state
   public showCreateForm: boolean = false;
   public newCollectionName: string = '';
   public isCreatingCollection: boolean = false;
+
+  // Per-collection save outcomes
+  public saveResults: Map<string, SaveResult> = new Map();
 
   constructor(
     private toastService: ToastService,
     private permissionService: CollectionPermissionService,
     private cdr: ChangeDetectorRef
   ) {
-  super();}
+    super();
+  }
 
+  // ============================================================
+  //  Lifecycle
+  // ============================================================
   async ngOnInit() {
     this.permissionService.Provider = this.ProviderToUse;
     if (this.isOpen) {
@@ -528,23 +667,74 @@ export class ArtifactCollectionPickerModalComponent extends BaseAngularComponent
     }
   }
 
-  async ngOnChanges(changes: any) {
-    if (changes['isOpen'] && this.isOpen) {
-      this.reset();
-      await this.loadCollections();
+  async ngOnChanges(changes: SimpleChanges) {
+    if (changes['isOpen']) {
+      if (this.isOpen) {
+        this.resetState();
+        await this.loadCollections();
+        // Autofocus search on next tick
+        Promise.resolve().then(() => this.searchInputRef?.nativeElement?.focus());
+      }
     }
   }
 
-  private reset(): void {
+  ngAfterViewInit(): void {
+    if (this.isOpen) {
+      this.searchInputRef?.nativeElement?.focus();
+    }
+  }
+
+  // ============================================================
+  //  Selection helpers (normalized UUIDs)
+  // ============================================================
+  public isSelected(id: string): boolean {
+    return this.selectedIds.has(NormalizeUUID(id));
+  }
+
+  public get selectedCollections(): MJCollectionEntity[] {
+    const list: MJCollectionEntity[] = [];
+    for (const id of this.selectedIds) {
+      const c = this.collectionById.get(id);
+      if (c) list.push(c);
+    }
+    return list;
+  }
+
+  public get resultsList(): SaveResult[] {
+    return Array.from(this.saveResults.values());
+  }
+
+  public get successCount(): number {
+    let n = 0;
+    for (const r of this.saveResults.values()) if (r.status === 'success') n++;
+    return n;
+  }
+
+  public get failedCount(): number {
+    let n = 0;
+    for (const r of this.saveResults.values()) if (r.status === 'error') n++;
+    return n;
+  }
+
+  // ============================================================
+  //  Load + tree build
+  // ============================================================
+  private resetState(): void {
     this.allCollections = [];
-    this.displayedCollections = [];
-    this.selectedCollections = [];
+    this.editableCollections = [];
     this.userPermissions.clear();
-    this.navigationPath = [];
-    this.currentParentId = null;
-    this.currentParentCollection = undefined;
+    this.collectionById.clear();
+    this.expandedIds.clear();
+    this.selectedIds.clear();
+    this.visibleNodes = [];
     this.searchQuery = '';
+    this.filterMode = 'editable';
     this.errorMessage = '';
+    this.showCreateForm = false;
+    this.newCollectionName = '';
+    this.saveResults.clear();
+    this.isSaving = false;
+    this.isCreatingCollection = false;
   }
 
   private async loadCollections(): Promise<void> {
@@ -552,7 +742,6 @@ export class ArtifactCollectionPickerModalComponent extends BaseAngularComponent
       this.isLoading = true;
       this.errorMessage = '';
 
-      // Load all collections in environment
       const rv = RunView.FromMetadataProvider(this.ProviderToUse);
       const result = await rv.RunView<MJCollectionEntity>({
         EntityName: 'MJ: Collections',
@@ -567,21 +756,17 @@ export class ArtifactCollectionPickerModalComponent extends BaseAngularComponent
       }
 
       this.allCollections = result.Results || [];
-
-      // Load user permissions for all collections
       await this.loadUserPermissions();
 
-      // Filter to collections with Edit permission
-      // Include collections that already contain the artifact (will be shown as disabled)
-      const editableCollections = this.allCollections.filter(c => {
-        return this.canEdit(c);
-      });
+      this.editableCollections = this.allCollections.filter(c => this.canEdit(c));
+      this.collectionById.clear();
+      for (const c of this.editableCollections) {
+        this.collectionById.set(NormalizeUUID(c.ID), c);
+      }
 
-      // Show root collections initially
-      this.displayRootCollections(editableCollections);
-
+      this.rebuildVisibleNodes();
     } catch (error) {
-      console.error('Error loading collections:', error);
+      LogError(error);
       this.errorMessage = 'An error occurred while loading collections';
     } finally {
       this.isLoading = false;
@@ -590,238 +775,369 @@ export class ArtifactCollectionPickerModalComponent extends BaseAngularComponent
   }
 
   private async loadUserPermissions(): Promise<void> {
-    // Load permissions for collections not owned by current user
-    const nonOwnedCollections = this.allCollections.filter(
+    const nonOwned = this.allCollections.filter(
       c => c.OwnerID && !UUIDsEqual(c.OwnerID, this.currentUser.ID)
     );
+    if (nonOwned.length === 0) return;
 
-    if (nonOwnedCollections.length === 0) {
-      return;
-    }
-
-    const collectionIds = nonOwnedCollections.map(c => c.ID);
+    const ids = nonOwned.map(c => c.ID);
     const permissions = await this.permissionService.checkBulkPermissions(
-      collectionIds,
-      this.currentUser.ID,
-      this.currentUser
+      ids, this.currentUser.ID, this.currentUser
     );
-
-    permissions.forEach((permission, collectionId) => {
-      this.userPermissions.set(collectionId, permission);
-    });
+    permissions.forEach((permission, id) => this.userPermissions.set(id, permission));
   }
 
-  private displayRootCollections(editableCollections: MJCollectionEntity[]): void {
-    const rootCollections = editableCollections.filter(c => !c.ParentID);
-    this.displayedCollections = rootCollections.map(c => this.createNode(c, editableCollections));
+  private canEdit(c: MJCollectionEntity): boolean {
+    if (!c.OwnerID || UUIDsEqual(c.OwnerID, this.currentUser.ID)) return true;
+    return this.userPermissions.get(c.ID)?.canEdit || false;
   }
 
-  private displayChildCollections(parentId: string, editableCollections: MJCollectionEntity[]): void {
-    const childCollections = editableCollections.filter(c => UUIDsEqual(c.ParentID, parentId));
-    this.displayedCollections = childCollections.map(c => this.createNode(c, editableCollections));
-  }
-
-  private createNode(collection: MJCollectionEntity, allEditableCollections: MJCollectionEntity[]): CollectionNode {
-    const hasChildren = allEditableCollections.some(c => UUIDsEqual(c.ParentID, collection.ID));
-    const alreadyContainsArtifact = this.excludeCollectionIds.some(id => UUIDsEqual(id, collection.ID));
-    return {
-      collection,
-      selected: this.selectedCollections.some(sc => UUIDsEqual(sc.ID, collection.ID)),
-      hasChildren,
-      alreadyContainsArtifact
-    };
-  }
-
-  canEdit(collection: MJCollectionEntity): boolean {
-    // Backwards compatibility: treat null OwnerID as owned by current user
-    if (!collection.OwnerID || UUIDsEqual(collection.OwnerID, this.currentUser.ID)) {
-      return true;
-    }
-
-    // Check permission record
-    const permission = this.userPermissions.get(collection.ID);
-    return permission?.canEdit || false;
-  }
-
-  toggleSelection(node: CollectionNode): void {
-    // Don't allow selection of collections that already contain the artifact
-    if (node.alreadyContainsArtifact) {
-      return;
-    }
-
-    const index = this.selectedCollections.findIndex(c => UUIDsEqual(c.ID, node.collection.ID));
-    if (index >= 0) {
-      this.selectedCollections.splice(index, 1);
-      node.selected = false;
+  // ============================================================
+  //  Tree rendering — flat list of CollectionNode, ordered DFS
+  // ============================================================
+  private rebuildVisibleNodes(): void {
+    const q = this.searchQuery.trim().toLowerCase();
+    if (q) {
+      this.visibleNodes = this.buildSearchNodes(q);
     } else {
-      this.selectedCollections.push(node.collection);
-      node.selected = true;
+      this.visibleNodes = this.buildTreeNodes();
     }
   }
 
-  drillIntoCollection(collection: MJCollectionEntity): void {
-    // Add current location to navigation path
-    const editableCollections = this.allCollections.filter(c => {
-      return this.canEdit(c);
-    });
-
-    const node = this.createNode(collection, editableCollections);
-    this.navigationPath.push(node);
-
-    this.currentParentId = collection.ID;
-    this.currentParentCollection = collection;
-
-    // Display child collections
-    this.displayChildCollections(collection.ID, editableCollections);
-
-    // Clear search when drilling down
-    this.searchQuery = '';
-  }
-
-  navigateToRoot(): void {
-    this.navigationPath = [];
-    this.currentParentId = null;
-    this.currentParentCollection = undefined;
-
-    const editableCollections = this.allCollections.filter(c => {
-      return this.canEdit(c);
-    });
-
-    this.displayRootCollections(editableCollections);
-    this.searchQuery = '';
-  }
-
-  navigateToCollection(collection: MJCollectionEntity): void {
-    // Find the index of this collection in the navigation path
-    const index = this.navigationPath.findIndex(n => UUIDsEqual(n.collection.ID, collection.ID));
-
-    if (index >= 0) {
-      // Trim navigation path to this level
-      this.navigationPath = this.navigationPath.slice(0, index + 1);
-      this.currentParentId = collection.ID;
-      this.currentParentCollection = collection;
-
-      const editableCollections = this.allCollections.filter(c => {
-        return this.canEdit(c);
-      });
-
-      this.displayChildCollections(collection.ID, editableCollections);
-      this.searchQuery = '';
+  private buildTreeNodes(): CollectionNode[] {
+    const byParent = new Map<string | null, MJCollectionEntity[]>();
+    for (const c of this.editableCollections) {
+      const key = c.ParentID ? NormalizeUUID(c.ParentID) : null;
+      const arr = byParent.get(key) || [];
+      arr.push(c);
+      byParent.set(key, arr);
     }
-  }
 
-  onSearchChange(): void {
-    if (!this.searchQuery.trim()) {
-      // Reset to current navigation context
-      if (this.currentParentId) {
-        const editableCollections = this.allCollections.filter(c => {
-          return this.canEdit(c);
+    const out: CollectionNode[] = [];
+    const walk = (parentId: string | null, depth: number): void => {
+      const children = byParent.get(parentId) || [];
+      for (const c of children) {
+        const id = NormalizeUUID(c.ID);
+        const kids = byParent.get(id) || [];
+        const hasChildren = kids.length > 0;
+        out.push({
+          collection: c,
+          depth,
+          expanded: this.expandedIds.has(id),
+          hasChildren,
+          alreadyContainsArtifact: this.isAlreadyAdded(c.ID),
+          ancestry: ''
         });
-        this.displayChildCollections(this.currentParentId, editableCollections);
-      } else {
-        const editableCollections = this.allCollections.filter(c => {
-          return this.canEdit(c);
-        });
-        this.displayRootCollections(editableCollections);
+        if (hasChildren && this.expandedIds.has(id)) {
+          walk(id, depth + 1);
+        }
       }
-      return;
-    }
-
-    // Search across all editable collections
-    const query = this.searchQuery.toLowerCase();
-    const editableCollections = this.allCollections.filter(c => {
-      return this.canEdit(c) && c.Name.toLowerCase().includes(query);
-    });
-
-    this.displayedCollections = editableCollections.map(c => this.createNode(c, editableCollections));
+    };
+    walk(null, 0);
+    return out;
   }
 
-  async createCollection(): Promise<void> {
-    if (!this.newCollectionName.trim()) {
+  private buildSearchNodes(query: string): CollectionNode[] {
+    const matches = this.editableCollections.filter(c => c.Name.toLowerCase().includes(query));
+    return matches.map(c => ({
+      collection: c,
+      depth: 0,
+      expanded: false,
+      hasChildren: false,
+      alreadyContainsArtifact: this.isAlreadyAdded(c.ID),
+      ancestry: this.buildAncestry(c)
+    }));
+  }
+
+  private buildAncestry(c: MJCollectionEntity): string {
+    const names: string[] = [];
+    let parentId = c.ParentID;
+    let guard = 0;
+    while (parentId && guard++ < 32) {
+      const p = this.collectionById.get(NormalizeUUID(parentId));
+      if (!p) break;
+      names.unshift(p.Name);
+      parentId = p.ParentID;
+    }
+    return names.join(' / ');
+  }
+
+  private isAlreadyAdded(id: string): boolean {
+    return this.excludeCollectionIds.some(eid => UUIDsEqual(eid, id));
+  }
+
+  // ============================================================
+  //  Tree interactions
+  // ============================================================
+  public onRowClick(node: CollectionNode): void {
+    if (this.isSaving) return;
+    if (node.alreadyContainsArtifact) return;
+    this.toggleSelection(node.collection);
+  }
+
+  public toggleSelection(c: MJCollectionEntity): void {
+    const id = NormalizeUUID(c.ID);
+    if (this.selectedIds.has(id)) {
+      this.selectedIds.delete(id);
+    } else {
+      this.selectedIds.add(id);
+    }
+  }
+
+  public deselect(id: string): void {
+    if (this.isSaving) return;
+    this.selectedIds.delete(NormalizeUUID(id));
+  }
+
+  public toggleExpand(node: CollectionNode): void {
+    if (!node.hasChildren) return;
+    const id = NormalizeUUID(node.collection.ID);
+    if (this.expandedIds.has(id)) {
+      this.expandedIds.delete(id);
+    } else {
+      this.expandedIds.add(id);
+    }
+    this.rebuildVisibleNodes();
+  }
+
+  public onSearchChange(): void {
+    this.rebuildVisibleNodes();
+  }
+
+  public clearSearch(): void {
+    this.searchQuery = '';
+    this.rebuildVisibleNodes();
+    this.searchInputRef?.nativeElement?.focus();
+  }
+
+  public setFilter(mode: FilterMode): void {
+    this.filterMode = mode;
+    // 'recent' filter is a placeholder for now — same data, future sort change.
+    // Keeping the chip wired so the UI is honest and a future PR can flip the sort.
+    this.rebuildVisibleNodes();
+  }
+
+  // ============================================================
+  //  Create new collection (root-level only — keeps the picker simple)
+  // ============================================================
+  public openCreateForm(): void {
+    this.showCreateForm = true;
+    // Force the @if branch to render now, then focus the input it created.
+    // A microtask alone isn't enough — Angular hasn't run change detection by then,
+    // so the @ViewChild ref is still undefined.
+    this.cdr.detectChanges();
+    this.newNameInputRef?.nativeElement?.focus();
+  }
+
+  public cancelCreate(): void {
+    this.showCreateForm = false;
+    this.newCollectionName = '';
+  }
+
+  public async createCollection(): Promise<void> {
+    const name = this.newCollectionName.trim();
+    if (!name) {
       this.toastService.warning('Please enter a collection name');
       return;
     }
-
     try {
       this.isCreatingCollection = true;
-      const md = this.ProviderToUse;
-      const collection = await md.GetEntityObject<MJCollectionEntity>('MJ: Collections', this.currentUser);
-
-      collection.Name = this.newCollectionName.trim();
+      const p = this.ProviderToUse;
+      const collection = await p.GetEntityObject<MJCollectionEntity>('MJ: Collections', this.currentUser);
+      collection.Name = name;
       collection.EnvironmentID = this.environmentId;
-
-      // Set parent and owner based on current navigation context
-      if (this.currentParentCollection) {
-        // Creating sub-collection - inherit parent's owner
-        collection.ParentID = this.currentParentCollection.ID;
-        collection.OwnerID = this.currentParentCollection.OwnerID || this.currentUser.ID;
-      } else {
-        // Creating root collection - current user becomes owner
-        collection.OwnerID = this.currentUser.ID;
-      }
+      collection.OwnerID = this.currentUser.ID;
 
       const saved = await collection.Save();
-
-      if (saved) {
-        // Create owner permission or copy parent permissions
-        if (this.currentParentCollection) {
-          // Copy permissions from parent
-          await this.permissionService.copyParentPermissions(
-            this.currentParentCollection.ID,
-            collection.ID,
-            this.currentUser
-          );
-        } else {
-          // Create owner permission
-          await this.permissionService.createOwnerPermission(
-            collection.ID,
-            this.currentUser.ID,
-            this.currentUser
-          );
-        }
-
-        this.toastService.success('Collection created successfully');
-
-        // Reset form
-        this.showCreateForm = false;
-        this.newCollectionName = '';
-
-        // Reload collections to include the new one
-        await this.loadCollections();
-
-        // Auto-select the newly created collection
-        this.selectedCollections.push(collection);
-      } else {
-        this.toastService.error(collection.LatestResult?.Message || 'Failed to create collection');
+      if (!saved) {
+        this.toastService.error(collection.LatestResult?.CompleteMessage || 'Failed to create collection');
+        return;
       }
+
+      // No explicit owner permission row needed — CollectionPermissionProvider treats the
+      // OwnerID as an implicit full-access grant. Writing a self-share row was both redundant
+      // and triggering a server-side auth failure on freshly-created collections.
+
+      this.toastService.success('Collection created');
+      this.cancelCreate();
+
+      // Splice the new collection into local state directly. Re-running loadCollections() here
+      // races with the server's cache-invalidation propagation and intermittently returns the
+      // pre-create result; we already own the freshly-saved entity, so just use it.
+      this.allCollections = [...this.allCollections, collection];
+      this.editableCollections = [...this.editableCollections, collection];
+      this.collectionById.set(NormalizeUUID(collection.ID), collection);
+      // Auto-select the new one
+      this.selectedIds.add(NormalizeUUID(collection.ID));
+      this.rebuildVisibleNodes();
     } catch (error) {
-      console.error('Error creating collection:', error);
-      this.toastService.error('An error occurred while creating the collection');
+      LogError(error);
+      this.toastService.error('Failed to create collection');
     } finally {
       this.isCreatingCollection = false;
       this.cdr.detectChanges();
     }
   }
 
-  async onSave(): Promise<void> {
-    if (this.selectedCollections.length === 0) {
-      this.toastService.warning('Please select at least one collection');
+  // ============================================================
+  //  Save flow (writes happen here, dialog stays open until done)
+  // ============================================================
+  public async onSave(): Promise<void> {
+    if (this.isSaving) return;
+    if (this.selectedIds.size === 0) {
+      this.toastService.warning('Pick at least one collection');
+      return;
+    }
+    if (!this.artifactVersionId) {
+      this.toastService.error('No version selected to save');
       return;
     }
 
     this.isSaving = true;
+    this.saveResults.clear();
+    // Seed each result as pending so they render in order
+    for (const c of this.selectedCollections) {
+      this.saveResults.set(NormalizeUUID(c.ID), {
+        collectionId: c.ID,
+        collectionName: c.Name,
+        status: 'pending'
+      });
+    }
+    this.cdr.detectChanges();
 
-    try {
-      // Emit the selected collection IDs - parent handles actual saving and modal close
-      const collectionIds = this.selectedCollections.map(c => c.ID);
-      this.saved.emit(collectionIds);
-    } finally {
-      this.isSaving = false;
+    for (const c of this.selectedCollections) {
+      await this.saveOne(c);
+    }
+
+    this.isSaving = false;
+
+    // Auto-close on full success
+    if (this.failedCount === 0) {
+      this.emitCompleted();
+    } else {
+      this.toastService.warning(`Saved to ${this.successCount} of ${this.saveResults.size} collections`);
       this.cdr.detectChanges();
     }
   }
 
-  onCancel(): void {
-    this.cancelled.emit();
+  public async retryFailed(): Promise<void> {
+    if (this.isSaving) return;
+    const toRetry: MJCollectionEntity[] = [];
+    for (const r of this.saveResults.values()) {
+      if (r.status === 'error') {
+        const c = this.collectionById.get(NormalizeUUID(r.collectionId));
+        if (c) toRetry.push(c);
+      }
+    }
+    if (toRetry.length === 0) return;
+
+    this.isSaving = true;
+    this.cdr.detectChanges();
+    for (const c of toRetry) {
+      await this.saveOne(c);
+    }
+    this.isSaving = false;
+
+    if (this.failedCount === 0) {
+      this.emitCompleted();
+    } else {
+      this.cdr.detectChanges();
+    }
+  }
+
+  public async retryOne(collectionId: string): Promise<void> {
+    if (this.isSaving) return;
+    const c = this.collectionById.get(NormalizeUUID(collectionId));
+    if (!c) return;
+    this.isSaving = true;
+    this.cdr.detectChanges();
+    await this.saveOne(c);
+    this.isSaving = false;
+    if (this.failedCount === 0 && this.successCount === this.saveResults.size) {
+      this.emitCompleted();
+    } else {
+      this.cdr.detectChanges();
+    }
+  }
+
+  private async saveOne(collection: MJCollectionEntity): Promise<void> {
+    const key = NormalizeUUID(collection.ID);
+    const r = this.saveResults.get(key);
+    if (!r) return;
+    r.status = 'saving';
+    r.errorMessage = undefined;
+    this.cdr.detectChanges();
+
+    try {
+      const versionId = this.artifactVersionId;
+      if (!versionId) {
+        r.status = 'error';
+        r.errorMessage = 'No artifact version selected';
+        return;
+      }
+
+      const p = this.ProviderToUse;
+
+      // Server-side cache + remote-invalidation make this idempotent in practice,
+      // but we still pre-check to avoid creating duplicate junction rows in races.
+      const rv = RunView.FromMetadataProvider(p);
+      const existing = await rv.RunView<MJCollectionArtifactEntity>({
+        EntityName: 'MJ: Collection Artifacts',
+        ExtraFilter: `CollectionID='${collection.ID}' AND ArtifactVersionID='${versionId}'`,
+        ResultType: 'simple',
+        Fields: ['ID']
+      }, this.currentUser);
+
+      if (existing.Success && (existing.Results?.length ?? 0) > 0) {
+        r.status = 'success';
+        return;
+      }
+
+      const junction = await p.GetEntityObject<MJCollectionArtifactEntity>(
+        'MJ: Collection Artifacts', this.currentUser
+      );
+      junction.CollectionID = collection.ID;
+      junction.ArtifactVersionID = versionId;
+      junction.Sequence = 0;
+
+      const ok = await junction.Save();
+      if (ok) {
+        r.status = 'success';
+      } else {
+        r.status = 'error';
+        r.errorMessage = junction.LatestResult?.CompleteMessage || 'Save failed';
+      }
+    } catch (err) {
+      LogError(err);
+      r.status = 'error';
+      r.errorMessage = err instanceof Error ? err.message : 'Unexpected error';
+    }
+  }
+
+  // ============================================================
+  //  Close paths
+  // ============================================================
+  public onCancel(): void {
+    if (this.isSaving) return; // can't close while writes are in flight
+    // If any saves completed before cancel, treat it as completion so the viewer reloads
+    if (this.successCount > 0) {
+      this.emitCompleted();
+    } else {
+      this.cancelled.emit();
+    }
+  }
+
+  public onAcknowledgeAndClose(): void {
+    this.emitCompleted();
+  }
+
+  private emitCompleted(): void {
+    const successIds: string[] = [];
+    const failedIds: string[] = [];
+    for (const r of this.saveResults.values()) {
+      if (r.status === 'success') successIds.push(r.collectionId);
+      else if (r.status === 'error') failedIds.push(r.collectionId);
+    }
+    this.completed.emit({ successIds, failedIds });
   }
 }

--- a/packages/Angular/Generic/conversations/src/lib/components/collection/collection-form-modal.component.ts
+++ b/packages/Angular/Generic/conversations/src/lib/components/collection/collection-form-modal.component.ts
@@ -239,20 +239,17 @@ export class CollectionFormModalComponent extends BaseAngularComponent implement
         // If creating new collection, set up permissions
         if (!this.collection) {
           if (this.parentCollection) {
-            // Child collection - copy all permissions from parent (including owner)
+            // Child collection - copy non-owner permissions from parent.
+            // (The owner gets implicit full access via OwnerID; no self-share row is written.)
             await this.permissionService.copyParentPermissions(
               this.parentCollection.ID,
               collection.ID,
               this.currentUser
             );
-          } else {
-            // Root collection - create owner permission for current user
-            await this.permissionService.createOwnerPermission(
-              collection.ID,
-              this.currentUser.ID,
-              this.currentUser
-            );
           }
+          // Root collection: nothing to do. CollectionPermissionProvider treats OwnerID as
+          // an implicit full-access grant — writing a self-share row was redundant and was
+          // failing server-side auth on freshly-created collections.
         }
 
         this.toastService.success(

--- a/packages/Angular/Generic/conversations/src/lib/components/conversation/conversation-chat-area.component.html
+++ b/packages/Angular/Generic/conversations/src/lib/components/conversation/conversation-chat-area.component.html
@@ -386,7 +386,10 @@
     [environmentId]="environmentId"
     [currentUser]="currentUser"
     [excludeCollectionIds]="collectionPickerExcludedIds"
-    (saved)="onCollectionPickerSaved($event)"
+    [artifactVersionId]="collectionPickerVersionId"
+    [artifactName]="collectionPickerArtifactName"
+    [artifactVersionNumber]="collectionPickerVersionNumber"
+    (completed)="onCollectionPickerCompleted($event)"
     (cancelled)="onCollectionPickerCancelled()">
   </mj-artifact-collection-picker-modal>
 }

--- a/packages/Angular/Generic/conversations/src/lib/components/conversation/conversation-chat-area.component.ts
+++ b/packages/Angular/Generic/conversations/src/lib/components/conversation/conversation-chat-area.component.ts
@@ -19,6 +19,7 @@ import { LazyArtifactInfo } from '../../models/lazy-artifact-info';
 import { MessageInputComponent } from '../message/message-input.component';
 import { PendingAttachment } from '../mention/mention-editor.component';
 import { ArtifactViewerPanelComponent, NavigationRequest, AnalyzeArtifactService } from '@memberjunction/ng-artifacts';
+import { MJNotificationService } from '@memberjunction/ng-notifications';
 import { ConversationEmptyStateComponent } from './conversation-empty-state.component';
 import { TestFeedbackDialogData, TestFeedbackDialogResult } from '@memberjunction/ng-testing';
 import { DialogService as ConversationsDialogService } from '../../services/dialog.service';
@@ -182,6 +183,9 @@ export class ConversationChatAreaComponent extends BaseAngularComponent implemen
   public showCollectionPicker: boolean = false;
   public collectionPickerArtifactId: string | null = null;
   public collectionPickerExcludedIds: string[] = [];
+  public collectionPickerVersionId: string | null = null;
+  public collectionPickerArtifactName: string = '';
+  public collectionPickerVersionNumber: number | null = null;
 
   // Artifact permissions
   public canShareSelectedArtifact: boolean = false;
@@ -1874,28 +1878,43 @@ export class ConversationChatAreaComponent extends BaseAngularComponent implemen
   onSaveToCollectionRequested(event: {artifactId: string; excludedCollectionIds: string[]}): void {
     this.collectionPickerArtifactId = event.artifactId;
     this.collectionPickerExcludedIds = event.excludedCollectionIds;
+    // Snapshot version + name from the viewer so the picker's preview pane has real context
+    const viewer = this.artifactViewerComponent;
+    this.collectionPickerVersionId = viewer?.artifactVersion?.ID ?? null;
+    this.collectionPickerArtifactName = viewer?.displayName ?? '';
+    this.collectionPickerVersionNumber = viewer?.selectedVersionNumber ?? null;
     this.showCollectionPicker = true;
   }
 
-  async onCollectionPickerSaved(collectionIds: string[]): Promise<void> {
-    if (!this.collectionPickerArtifactId || !this.artifactViewerComponent) {
-      return;
+  async onCollectionPickerCompleted(event: { successIds: string[]; failedIds: string[] }): Promise<void> {
+    // Refresh the viewer's bookmark / "already saved" state if anything actually wrote
+    if (event.successIds.length > 0 && this.artifactViewerComponent) {
+      await this.artifactViewerComponent.ReloadCollectionAssociations();
     }
+    this.closeCollectionPicker();
 
-    // Call the artifact viewer's save method
-    const success = await this.artifactViewerComponent.saveToCollections(collectionIds);
-    if (success) {
-      this.showCollectionPicker = false;
-      this.collectionPickerArtifactId = null;
-      this.collectionPickerExcludedIds = [];
-      this.cdr.detectChanges();
+    if (event.failedIds.length === 0 && event.successIds.length > 0) {
+      const n = event.successIds.length;
+      MJNotificationService.Instance.CreateSimpleNotification(
+        `Saved to ${n} ${n === 1 ? 'collection' : 'collections'}`,
+        'success',
+        2500
+      );
     }
   }
 
   onCollectionPickerCancelled(): void {
+    this.closeCollectionPicker();
+  }
+
+  private closeCollectionPicker(): void {
     this.showCollectionPicker = false;
     this.collectionPickerArtifactId = null;
     this.collectionPickerExcludedIds = [];
+    this.collectionPickerVersionId = null;
+    this.collectionPickerArtifactName = '';
+    this.collectionPickerVersionNumber = null;
+    this.cdr.detectChanges();
   }
 
   /**


### PR DESCRIPTION
## Summary

Two independent improvements bundled on this branch:

### 1. Save-to-Collection dialog redesign (chat conversations)

Replaces the cramped single-column collection picker with a split-pane modal: searchable expand/collapse tree on the left, artifact preview + live selection chips on the right. Also tightens the underlying save flow and removes a long-standing bug that prevented new collection creation from succeeding.

**UX changes**
- Split-pane layout (tree + preview/chips) instead of one cluttered list
- Primary `Save` action on the **left**, `Cancel` on the right, per MJ convention
- “Already saved” collections render with a green check + label instead of being disabled-but-still-selectable
- Search now **persists across tree navigation**; expand/collapse via caret replaces the drill-into-subview that wiped state
- Inline “Create new collection” row auto-focuses the input and has higher-contrast styling so it reads obviously as a text field
- All colors use semantic design tokens (no hardcoded hex); selection / focus rings via `color-mix()` on `--mj-brand-primary`

**Code-pattern fixes**
- **Save writes now live inside the modal** so the dialog stays open during writes and can render per-collection progress; eliminates the close-before-save race in the previous parent-driven flow
- `isSaving` guard prevents double-fire that could create duplicate `MJ: Collection Artifacts` junction rows
- Per-collection result tracking (`pending` → `saving` → `success` \| `error`) with single-row and “retry all failed” buttons
- Honest partial-failure UI surfacing actual `LatestResult.CompleteMessage` instead of a generic toast hiding N failures behind 1 success
- Selection state resets on open; UUIDs normalized via `NormalizeUUID()` throughout to avoid SQL Server / Postgres casing drift
- Pre-existence check uses `ResultType: 'simple'` + `Fields: ['ID']` for a narrower payload
- Viewer exposes `ReloadCollectionAssociations()` so the chat-area can refresh the bookmark / excluded-collection state after the picker reports completion

**Bug fix: “Unknown error creating record” on new collection**
- The picker and `collection-form-modal` were writing a redundant owner-self-share row into `MJ: Collection Permissions` immediately after creating a collection. That write was failing server-side auth (`callerMayShareCollection` lookup not seeing the freshly-committed collection) and bubbling up as a generic GraphQL error.
- `CollectionPermissionProvider.CheckPermission()` already treats `OwnerID` as an implicit full-access grant; the row was both unnecessary and dead data. Dropped the call in both call sites.
- Also replaced the post-create `loadCollections()` round-trip with a local state splice — the reload was racing the server’s cache invalidation and intermittently returning the pre-create snapshot, so the new collection only appeared on reopen.

### 2. AssociationDB installer env parser

`Demos/AssociationDB/install.sh` was silently failing with “Missing required environment variables” on `.env` files that contained whitespace around the `=` or inside quotes. The parser now strips key whitespace and trims value whitespace before quote-stripping, so lines like `DB_DATABASE = 'value'` resolve correctly.

## Files
- `packages/Angular/Generic/artifacts/src/lib/components/artifact-viewer-panel.component.ts` — expose `ReloadCollectionAssociations()`, deprecate `saveToCollections()`
- `packages/Angular/Generic/conversations/src/lib/components/collection/artifact-collection-picker-modal.component.ts` — full split-pane rewrite + owner-self-share drop
- `packages/Angular/Generic/conversations/src/lib/components/collection/collection-form-modal.component.ts` — drop redundant `createOwnerPermission` call
- `packages/Angular/Generic/conversations/src/lib/components/conversation/conversation-chat-area.component.{ts,html}` — wire new picker inputs (`artifactVersionId`, `artifactName`, `artifactVersionNumber`) and `(completed)` handler
- `Demos/AssociationDB/install.sh` — tolerant `.env` parser
- `.changeset/soft-sites-play.md` — no-migration note

## Test plan
- [ ] Open an artifact in chat → click “Save to Collection” → split-pane dialog appears with tree on left, artifact preview + selection chips on right
- [ ] Search persists when expanding/collapsing tree rows
- [ ] Collections that already contain the current artifact version render with green check + “Already saved” and are not toggleable
- [ ] Click “Create new collection” → input is focused on the first click with visible border; type a name, press Enter → row appears in tree and is auto-selected (no reopen needed)
- [ ] Multi-select several collections → click Save → dialog stays open and shows per-collection progress chips; on full success it auto-closes and the artifact’s bookmark state refreshes
- [ ] Simulate a write failure (revoke edit perm mid-flow) → dialog shows partial-failure state with retry buttons; “Retry all failed” completes the save
- [ ] Cancel while saves are in flight is blocked (no premature close, no orphan writes)
- [ ] `Demos/AssociationDB/install.sh` runs cleanly against a `.env` that has spaces around `=` or whitespace inside quoted values