### PR TITLE
fix(content-autotagging): wire EmbeddingStatus updates into vectorizeGroup

### DIFF
--- a/.changeset/silent-vectors-update.md
+++ b/.changeset/silent-vectors-update.md
@@ -1,0 +1,5 @@
+---
+"@memberjunction/content-autotagging": patch
+---
+
+Fix Content Item EmbeddingStatus never transitioning out of `Pending` during vectorization. `updateEmbeddingStatusBatch` was defined on `AutotagBaseEngine` but never called from anywhere — items would have their vectors successfully embedded and upserted to the vector database, yet `EmbeddingStatus`, `EmbeddingModelID`, and `LastEmbeddedAt` would remain at their initial values forever, leaving dashboards permanently showing items as Pending. `vectorizeGroup` now marks every item in the group as `Processing` before processing begins, transitions each batch to `Complete` (with the resolved embedding model ID and timestamp) on a successful upsert, and to `Failed` when either the embedding API returns the wrong vector count or the vector DB upsert reports failure.

--- a/packages/ContentAutotagging/src/Engine/generic/AutotagBaseEngine.ts
+++ b/packages/ContentAutotagging/src/Engine/generic/AutotagBaseEngine.ts
@@ -295,15 +295,23 @@ export class AutotagBaseEngine extends BaseEngine<AutotagBaseEngine> {
         embeddingModelID?: string
     ): Promise<void> {
         for (const item of items) {
+            item.EmbeddingStatus = status;
+            if (status === 'Complete') {
+                item.LastEmbeddedAt = new Date();
+                if (embeddingModelID) item.EmbeddingModelID = embeddingModelID;
+            }
+            // Status updates are best-effort relative to the vectorization itself: the vectors
+            // are already (or are about to be) in the vector DB, so a status-save failure on a
+            // single row must not abort the rest of the pipeline. We log on both logical failure
+            // (Save returns false) and infrastructure failure (Save throws) so the gap is visible.
             try {
-                item.EmbeddingStatus = status;
-                if (status === 'Complete') {
-                    item.LastEmbeddedAt = new Date();
-                    if (embeddingModelID) item.EmbeddingModelID = embeddingModelID;
+                const saved = await item.Save();
+                if (!saved) {
+                    LogError(`updateEmbeddingStatusBatch: Save returned false for item ${item.ID} (status='${status}'): ${item.LatestResult?.CompleteMessage ?? 'unknown error'}`);
                 }
-                await item.Save();
-            } catch {
-                // Non-critical
+            } catch (e) {
+                const msg = e instanceof Error ? e.message : String(e);
+                LogError(`updateEmbeddingStatusBatch: infrastructure error saving item ${item.ID} (status='${status}'): ${msg}`);
             }
         }
     }
@@ -1329,6 +1337,11 @@ export class AutotagBaseEngine extends BaseEngine<AutotagBaseEngine> {
         const promptRunIDs: string[] = [];
         const modelRunner = new AIModelRunner();
 
+        // Mark every item in this infra group as Processing up front so dashboards
+        // reflect in-flight state. Each batch will transition its items to Complete
+        // or Failed as outcomes are known.
+        await this.updateEmbeddingStatusBatch(items, 'Processing', contextUser);
+
         // Resolve the "Content Embedding" prompt ID for tracking
         const embeddingPromptID = this.resolveEmbeddingPromptID();
 
@@ -1353,6 +1366,7 @@ export class AutotagBaseEngine extends BaseEngine<AutotagBaseEngine> {
 
             if (!runResult.Success || runResult.Vectors.length !== allChunks.length) {
                 LogError(`VectorizeContentItems: embedding returned ${runResult.Vectors.length} vectors for ${allChunks.length} texts — ${runResult.ErrorMessage ?? 'unknown error'}`);
+                await this.updateEmbeddingStatusBatch(batch, 'Failed', contextUser);
                 onBatchComplete(batch.length);
                 continue;
             }
@@ -1367,6 +1381,9 @@ export class AutotagBaseEngine extends BaseEngine<AutotagBaseEngine> {
             const batchSuccess = await this.upsertVectorRecords(records, infra);
             if (batchSuccess) {
                 vectorized += batch.length;
+                await this.updateEmbeddingStatusBatch(batch, 'Complete', contextUser, infra.embeddingModelID);
+            } else {
+                await this.updateEmbeddingStatusBatch(batch, 'Failed', contextUser);
             }
 
             onBatchComplete(batch.length);

--- a/packages/ContentAutotagging/src/__tests__/AutotagBaseEngine.test.ts
+++ b/packages/ContentAutotagging/src/__tests__/AutotagBaseEngine.test.ts
@@ -767,6 +767,125 @@ describe('AutotagBaseEngine', () => {
 
       expect(progressFn).toHaveBeenCalledWith(2, 2);
     });
+
+    describe('EmbeddingStatus transitions', () => {
+      // Mirror of createMockItem with a Save spy and the embedding-status fields
+      // initialized so we can assert how vectorizeGroup mutates them.
+      function createMockItemWithSave(id: string, text: string) {
+        return {
+          ID: id,
+          Text: text,
+          Name: `Item ${id}`,
+          Description: `Description for ${id}`,
+          URL: `https://example.com/${id}`,
+          ContentSourceID: 'source-1',
+          ContentSourceTypeID: 'type-1',
+          ContentFileTypeID: 'file-type-1',
+          ContentTypeID: 'content-type-1',
+          EmbeddingStatus: 'Pending' as 'Pending' | 'Processing' | 'Complete' | 'Failed',
+          LastEmbeddedAt: null as Date | null,
+          EmbeddingModelID: null as string | null,
+          Save: vi.fn().mockResolvedValue(true),
+        };
+      }
+
+      it('should transition items through Processing then Complete on a successful batch', async () => {
+        await setupVectorMocks();
+        const item = createMockItemWithSave('item-success', 'Hello world content');
+
+        await engine.VectorizeContentItems([item] as never[], mockUser);
+
+        // Two saves: Processing (group-level) + Complete (per-batch)
+        expect(item.Save).toHaveBeenCalledTimes(2);
+        expect(item.EmbeddingStatus).toBe('Complete');
+        expect(item.EmbeddingModelID).toBe('embed-model-1');
+        expect(item.LastEmbeddedAt).toBeInstanceOf(Date);
+      });
+
+      it('should transition items to Failed when the embedding API returns no vectors', async () => {
+        await setupVectorMocks();
+        // Force the embedding call to fail with mismatched vector count.
+        // vectorizeGroup treats this as a batch-level failure.
+        mockRunEmbeddingFn.mockResolvedValueOnce({
+          Success: false,
+          Vectors: [],
+          PromptRunID: null,
+          TokensUsed: 0,
+          Cost: 0,
+          ErrorMessage: 'simulated rate limit',
+          ExecutionTimeMs: 1,
+        });
+        const item = createMockItemWithSave('item-embed-fail', 'Some content');
+
+        await engine.VectorizeContentItems([item] as never[], mockUser);
+
+        // Two saves: Processing then Failed. No Complete metadata set.
+        expect(item.Save).toHaveBeenCalledTimes(2);
+        expect(item.EmbeddingStatus).toBe('Failed');
+        expect(item.LastEmbeddedAt).toBeNull();
+        expect(item.EmbeddingModelID).toBeNull();
+      });
+
+      it('should transition items to Failed when the vector DB upsert fails', async () => {
+        const { mockCreateRecords } = await setupVectorMocks();
+        // Make Pinecone reject the upsert
+        mockCreateRecords.mockResolvedValueOnce({
+          success: false,
+          message: 'upsert refused — dimension mismatch',
+        });
+        const item = createMockItemWithSave('item-upsert-fail', 'Content for upsert');
+
+        await engine.VectorizeContentItems([item] as never[], mockUser);
+
+        // Two saves: Processing then Failed. Complete metadata must NOT be set.
+        expect(item.Save).toHaveBeenCalledTimes(2);
+        expect(item.EmbeddingStatus).toBe('Failed');
+        expect(item.LastEmbeddedAt).toBeNull();
+        expect(item.EmbeddingModelID).toBeNull();
+      });
+
+      it('should LogError and keep going when Save returns false (logical failure)', async () => {
+        await setupVectorMocks();
+        const { LogError } = await import('@memberjunction/core');
+        const loggedErrorFn = vi.mocked(LogError);
+
+        // Logical-failure shape: Save returns false, surface error via LatestResult.CompleteMessage
+        const item = createMockItemWithSave('item-save-false', 'Content with failing save');
+        item.Save = vi.fn().mockResolvedValue(false);
+        (item as Record<string, unknown>).LatestResult = { CompleteMessage: 'simulated validation failure' };
+
+        // Pipeline must complete cleanly even though every Save returns false
+        await expect(
+          engine.VectorizeContentItems([item] as never[], mockUser)
+        ).resolves.not.toThrow();
+
+        // Save was still attempted twice (Processing + Complete)
+        expect(item.Save).toHaveBeenCalledTimes(2);
+
+        // LogError fired with the offending item ID and the CompleteMessage
+        const errorMessages = loggedErrorFn.mock.calls.map(call => String(call[0]));
+        expect(errorMessages.some(m => m.includes('item-save-false') && m.includes('simulated validation failure'))).toBe(true);
+      });
+
+      it('should LogError and keep going when Save throws (infrastructure failure)', async () => {
+        await setupVectorMocks();
+        const { LogError } = await import('@memberjunction/core');
+        const loggedErrorFn = vi.mocked(LogError);
+
+        // Infrastructure-failure shape: Save throws (e.g. network/connection error)
+        const item = createMockItemWithSave('item-save-throw', 'Content with throwing save');
+        item.Save = vi.fn().mockRejectedValue(new Error('connection reset by peer'));
+
+        // Pipeline must NOT abort on a single status-save infrastructure error
+        await expect(
+          engine.VectorizeContentItems([item] as never[], mockUser)
+        ).resolves.not.toThrow();
+
+        // LogError fired with the offending item ID and the thrown error message
+        const errorMessages = loggedErrorFn.mock.calls.map(call => String(call[0]));
+        expect(errorMessages.some(m => m.includes('item-save-throw') && m.includes('connection reset by peer'))).toBe(true);
+      });
+    });
   });
 
   describe('Circuit breaker', () => {


### PR DESCRIPTION
## Summary

  - `updateEmbeddingStatusBatch` on `AutotagBaseEngine` was defined but **never called from anywhere** —
  vectors successfully landed in the vector database (Pinecone / pgvector / Qdrant) but
  `ContentItem.EmbeddingStatus`, `EmbeddingModelID`, and `LastEmbeddedAt` stayed at their initial values
  forever, so dashboards permanently showed items as Pending. `vectorizeGroup` now invokes it at three
  points: `Processing` up front for the whole group, `Complete` (with resolved embedding-model ID +
  timestamp) per batch on successful upsert, and `Failed` per batch on either embedding-API or vector-DB
  upsert failure.
  - Also tightens `updateEmbeddingStatusBatch` itself to match the project's `Save()` rules in `CLAUDE.md`:
  replaces the silent `try { … } catch { /* Non-critical */ }` swallow with explicit `Save()` return-value
  checking (logs via `LatestResult.CompleteMessage` on `false`) and a separate `try/catch` for genuine
  infrastructure errors (e.g. connection loss) that logs the thrown error. Status updates remain best-effort
  — a single-row save failure no longer aborts the pipeline, but it is no longer invisible.
  - Adds 5 unit tests in `AutotagBaseEngine.test.ts` covering: Pending→Processing→Complete success path with
  metadata population, embedding-API failure → Failed, vector-DB upsert failure → Failed, `Save` returns
  `false` → `LogError` fires with `LatestResult.CompleteMessage` and pipeline continues, `Save` throws →
  `LogError` fires with thrown message and pipeline continues.
  
  ## Test plan

  - [x] `cd packages/ContentAutotagging && npm run build` — clean compile, no TypeScript errors.
  - [x] `cd packages/ContentAutotagging && npm run test` — all 119 tests pass (114 baseline + 5 new).
  - [ ] Live verification on a Content Source with new/modified items: run the autotag-and-vectorize
  pipeline, then `SELECT EmbeddingStatus, EmbeddingModelID, LastEmbeddedAt FROM __mj.ContentItem WHERE …` to
  confirm transition to `Complete` with model ID + timestamp populated.
  - [ ] Force-fail a batch by pointing a Content Source at an embedding model whose vendor has no API key,
  run pipeline, and confirm items land at `EmbeddingStatus='Failed'` instead of stuck `Pending`.
  - [ ] Confirm Knowledge Hub / autotagging dashboards now show non-Pending items after a real run.

  🤖 Generated with [Claude Code](https://claude.com/claude-code)