### PR TITLE
fix(MJServer): SkipProxyAgent accepts analysis-only responses

### DIFF
--- a/.changeset/brave-pandas-listen.md
+++ b/.changeset/brave-pandas-listen.md
@@ -1,0 +1,5 @@
+---
+"@memberjunction/server": patch
+---
+
+Fix SkipProxyAgent to accept analysis-only responses from Skip's Analysis Agent path, returning the analysis markdown as the success message when no componentOptions are present.

--- a/packages/MJServer/src/agents/skip-agent.ts
+++ b/packages/MJServer/src/agents/skip-agent.ts
@@ -347,12 +347,27 @@ export class SkipProxyAgent extends BaseAgent {
     }
 
     /**
-     * Handle analysis_complete phase — validates componentOptions before accessing
+     * Handle analysis_complete phase — supports both component-bearing responses
+     * (componentOptions populated) and analysis-only responses (markdown in `analysis`
+     * with no component, produced by Skip's Analysis Agent path).
      */
     private handleAnalysisComplete(
         response: SkipAPIAnalysisCompleteResponse
     ): BaseAgentNextStep<ComponentSpec> {
-        if (!response.componentOptions || response.componentOptions.length === 0) {
+        const hasComponentOptions = response.componentOptions && response.componentOptions.length > 0;
+        const skipMessage = response.messages?.filter(msg => msg.role === 'system').pop();
+        const analysisText = response.analysis?.trim();
+
+        if (!hasComponentOptions) {
+            if (analysisText || skipMessage?.content) {
+                return {
+                    terminate: true,
+                    step: 'Success',
+                    message: analysisText || skipMessage!.content,
+                    newPayload: undefined
+                };
+            }
+
             const msg = 'Skip completed analysis but returned no component options. '
                 + `Title: "${response.title || 'none'}". `
                 + `Result type: "${response.resultType || 'none'}"`;
@@ -366,8 +381,7 @@ export class SkipProxyAgent extends BaseAgent {
             };
         }
 
-        const componentSpec = response.componentOptions[0].option;
-        const skipMessage = response.messages?.filter(msg => msg.role === 'system').pop();
+        const componentSpec = response.componentOptions![0].option;
 
         return {
             terminate: true,


### PR DESCRIPTION
## Summary

- `SkipProxyAgent.handleAnalysisComplete` previously failed any `analysis_complete` response with empty `componentOptions`, returning "Skip completed analysis but returned no component options. Title: 'none'. Result type: 'none'".
- Skip's new Analysis Agent path (introduced in Skip-Brain) intentionally returns this shape: rich markdown in `response.analysis`, empty `componentOptions`, no component artifact.
- Patched `handleAnalysisComplete` to treat such responses as success when `response.analysis` (or the last system message) has content. The original failure branch is preserved for responses where both are empty.

## Behavior matrix

| Response shape | Before | After |
|---|---|---|
| `componentOptions` populated | Success (first option's spec as newPayload) | Success (unchanged) |
| `componentOptions` empty, `analysis` has text | **Failed** with "no component options" | **Success** (analysis as message, no payload) |
| `componentOptions` empty AND `analysis` empty | Failed | Failed (unchanged) |

## Files changed

- `packages/MJServer/src/agents/skip-agent.ts` — 18 added / 4 removed in `handleAnalysisComplete`.

## Test plan

- [x] Build `@memberjunction/server` cleanly (`npm run build` in `packages/MJServer`).
- [x] Component-bearing Skip response → proxy returns Success with the component spec as payload (no regression).
- [x] Analysis-only Skip response (componentOptions empty, analysis populated) → proxy returns Success with the markdown as the agent message; no payload.
- [x] Skip-Brain integration test: send `[ANALYSIS] <question>` against an existing component; confirm response phase is `analysis_complete` and the markdown reaches the user.

## Downstream impact

Consumers that wrapped `handleAnalysisComplete` failures (if any) should re-check assumptions: a previously-failed branch now returns Success. No interface signatures changed.