### PR TITLE
Fix/scoped search context threading

### DIFF
--- a/.changeset/scoped-search-context-threading.md
+++ b/.changeset/scoped-search-context-threading.md
@@ -1,0 +1,5 @@
+---
+"@memberjunction/core-actions": patch
+---
+
+Thread per-call multi-tenant `SearchContext` through the `__Scoped_Search` action. Two new optional inputs — `PrimaryScopeRecordID` (string UUID) and `SecondaryScopes` (JSON object of dimension-name → value) — get assembled into a `SearchContext` and passed to `SearchEngine.Search()`. The engine renders them into the scope's Nunjucks `MetadataFilter` / `ExtraFilter` / `UserSearchString` / `FolderPath` at search time, so a single `MJ: Search Scope` definition can serve many tenants without per-tenant scope clones. `SecondaryScopes` values are validated against `string | number | boolean | string[]` — incompatible entries are dropped with a log rather than failing the call. Guide and class-level JSDoc updated.

--- a/.changeset/scoped-search-context-threading.md
+++ b/.changeset/scoped-search-context-threading.md
@@ -1,5 +1,5 @@
 ---
-"@memberjunction/core-actions": patch
+"@memberjunction/core-actions": minor
 ---
 
 Thread per-call multi-tenant `SearchContext` through the `__Scoped_Search` action. Two new optional inputs — `PrimaryScopeRecordID` (string UUID) and `SecondaryScopes` (JSON object of dimension-name → value) — get assembled into a `SearchContext` and passed to `SearchEngine.Search()`. The engine renders them into the scope's Nunjucks `MetadataFilter` / `ExtraFilter` / `UserSearchString` / `FolderPath` at search time, so a single `MJ: Search Scope` definition can serve many tenants without per-tenant scope clones. `SecondaryScopes` values are validated against `string | number | boolean | string[]` — incompatible entries are dropped with a log rather than failing the call. Guide and class-level JSDoc updated.

--- a/guides/SEARCH_SCOPES_AND_RAG_GUIDE.md
+++ b/guides/SEARCH_SCOPES_AND_RAG_GUIDE.md
@@ -146,8 +146,34 @@ Assign `__Scoped_Search` to an agent's action set. When the agent calls it, the 
 1. Resolves the agent identity from `params.Context.AgentID` (or explicit `AgentID` param).
 2. Enforces `SearchScopeAccess`.
 3. Resolves the target scope (explicit `ScopeID`, agent's default, or Global).
-4. Runs `SearchEngine.Search()` with `ScopeIDs: [resolvedScopeID]`.
-5. Returns ranked results + `ScopeID_Resolved` / `ScopeName_Resolved` output params.
+4. Reads the optional `PrimaryScopeRecordID` (string UUID) and `SecondaryScopes` (JSON string) inputs, assembling a `SearchContext` when at least one is supplied. See [§10](#10-multi-tenant-search-context) for the runtime context model.
+5. Runs `SearchEngine.Search()` with `ScopeIDs: [resolvedScopeID]` and `SearchContext: <assembled>`.
+6. Returns ranked results + `ScopeID_Resolved` / `ScopeName_Resolved` output params.
+
+#### Per-call multi-tenant inputs
+
+The action accepts two optional inputs whose values flow into `SearchParams.SearchContext` and are then Nunjucks-rendered into every scope-level filter (MetadataFilter, ExtraFilter, UserSearchString, FolderPath):
+
+| Input | Type | Purpose |
+|---|---|---|
+| `PrimaryScopeRecordID` | string (UUID) | Primary tenant key (e.g. `OrganizationID`). Available in templates as `{{ context.PrimaryScopeRecordID }}`. |
+| `SecondaryScopes` | JSON string | Flat object of additional dimensions as `{ "<key>": <value> }`. Each value must be `string \| number \| boolean \| string[]`. Available in templates as `{{ context.SecondaryScopes.<key> }}`. Incompatible value types are dropped at parse time with a log; malformed JSON falls back to `undefined` rather than failing the call. |
+
+Example agent tool call selecting only Finance-department content for Org `O1`:
+
+```json
+{
+  "tool": "Scoped Search",
+  "params": {
+    "Query":               "Q3 budget approval",
+    "AgentID":             "<agent-uuid>",
+    "PrimaryScopeRecordID":"O1",
+    "SecondaryScopes":     "{\"Department\":\"Finance\",\"Tags\":[\"q3\",\"approved\"]}"
+  }
+}
+```
+
+For this to actually narrow results, the scope's `SearchScopeEntity.ExtraFilter` (or `SearchScopeExternalIndex.MetadataFilter`) must reference the matching context fields, e.g. `OrganizationID = '{{ context.PrimaryScopeRecordID }}' AND Department = '{{ context.SecondaryScopes.Department }}'`. One scope definition then serves every tenant.
 
 ### Per-agent `FusionWeightsOverride`
 
@@ -301,7 +327,14 @@ After #2237 lands, update `metadata/artifact-types/.artifact-types.json` → cha
 
 ### Flowing context through agents
 
-`ExecuteAgentParams.primaryScopeRecordId` + `secondaryScopes` automatically flow into `AgentPreExecutionRAG` and `ScopedSearchAction` as `SearchContext`. No per-subsystem translation — the same `SecondaryScopeValue` type (`string | number | boolean | string[]`) is shared with the agent memory system via `@memberjunction/ai-core-plus`.
+Two distinct paths populate `SearchContext` at runtime. They use the same `SecondaryScopeValue` union (`string | number | boolean | string[]`) shared with the agent memory system via `@memberjunction/ai-core-plus`, so there is no per-subsystem translation regardless of how the values arrive:
+
+| Path | How context arrives | Where it's read |
+|---|---|---|
+| **Pre-execution RAG** (auto) | `ExecuteAgentParams.primaryScopeRecordId` + `secondaryScopes` flow directly from the agent run config | `AgentPreExecutionRAG` constructs `SearchContext` and calls `SearchEngine.Search()` before the agent's first LLM turn |
+| **Agent-invoked Scoped Search** (explicit) | `PrimaryScopeRecordID` and `SecondaryScopes` (JSON string) supplied as action params on each `__Scoped_Search` call | `ScopedSearchAction` parses and validates the inputs, builds `SearchContext`, and passes it via `SearchParams.SearchContext` to `SearchEngine.Search()` |
+
+The explicit-input path lets a single agent run multiple scoped queries with different tenant contexts (e.g. comparison across orgs in one turn) and lets callers other than `BaseAgent` — manual GraphQL invocations, external orchestrators — drive the action with per-call tenant info. Use `ActionInputMapping` on the agent step to wire `ExecuteAgentParams`-style values into the action's `PrimaryScopeRecordID` / `SecondaryScopes` inputs when you want a single agent payload to drive both paths consistently.
 
 ### Nunjucks rendering of scope config
 

--- a/metadata/actions/.scoped-search.json
+++ b/metadata/actions/.scoped-search.json
@@ -106,6 +106,28 @@
         {
           "fields": {
             "ActionID": "@parent:ID",
+            "Name": "PrimaryScopeRecordID",
+            "Type": "Input",
+            "ValueType": "Scalar",
+            "IsArray": false,
+            "Description": "Optional primary tenant identifier (e.g. OrganizationID) supplied per call. Threaded into SearchParams.SearchContext.PrimaryScopeRecordID so the engine can render `{{ context.PrimaryScopeRecordID }}` into the scope's MetadataFilter / ExtraFilter / UserSearchString / FolderPath templates at search time. One scope definition serves many tenants when this is populated.",
+            "IsRequired": false
+          }
+        },
+        {
+          "fields": {
+            "ActionID": "@parent:ID",
+            "Name": "SecondaryScopes",
+            "Type": "Input",
+            "ValueType": "Scalar",
+            "IsArray": false,
+            "Description": "Optional JSON string of additional runtime dimensions as key/value pairs, e.g. `{\"Department\":\"Finance\",\"Region\":\"US\",\"Tags\":[\"audit\"]}`. Each key becomes `{{ context.SecondaryScopes.<key> }}` available to the scope's Nunjucks-rendered templates. Values must be string, number, boolean, or string[] — incompatible entries are skipped with a log. Dimensions are fully dynamic at this layer; the engine handles any per-scope dimension validation.",
+            "IsRequired": false
+          }
+        },
+        {
+          "fields": {
+            "ActionID": "@parent:ID",
             "Name": "Results",
             "Type": "Output",
             "ValueType": "Simple Object",

--- a/packages/Actions/CoreActions/src/__tests__/scoped-search.action.test.ts
+++ b/packages/Actions/CoreActions/src/__tests__/scoped-search.action.test.ts
@@ -57,7 +57,8 @@ const loadedAgentStub: { ID: string; Name: string; SearchScopeAccess: string; Lo
 
 vi.mock('@memberjunction/core', () => ({
     LogError: vi.fn(),
-    LogStatus: vi.fn(),
+    LogStatusEx: vi.fn(),
+    IsVerboseLoggingEnabled: () => false,
     Metadata: class {
         GetEntityObject = async () => loadedAgentStub;
     },

--- a/packages/Actions/CoreActions/src/__tests__/scoped-search.action.test.ts
+++ b/packages/Actions/CoreActions/src/__tests__/scoped-search.action.test.ts
@@ -288,4 +288,107 @@ describe('ScopedSearchAction', () => {
             }));
         });
     });
+
+    describe('SearchContext threading (per-call multi-tenant inputs)', () => {
+        it('omits SearchContext entirely when neither input is provided', async () => {
+            loadedAgentStub.SearchScopeAccess = 'All';
+            const action = new ScopedSearchAction();
+            const result = await run(action, mkParams([
+                { Name: 'Query', Value: 'q' },
+                { Name: 'AgentID', Value: 'agent-1' }
+            ]));
+            expect(result.Success).toBe(true);
+            const callArgs = searchSpy.mock.calls[0][0];
+            expect(callArgs.SearchContext).toBeUndefined();
+        });
+
+        it('threads PrimaryScopeRecordID through to SearchParams.SearchContext', async () => {
+            loadedAgentStub.SearchScopeAccess = 'All';
+            const action = new ScopedSearchAction();
+            const result = await run(action, mkParams([
+                { Name: 'Query', Value: 'q' },
+                { Name: 'AgentID', Value: 'agent-1' },
+                { Name: 'PrimaryScopeRecordID', Value: 'ORG-O1' }
+            ]));
+            expect(result.Success).toBe(true);
+            const callArgs = searchSpy.mock.calls[0][0];
+            expect(callArgs.SearchContext).toEqual({
+                PrimaryScopeRecordID: 'ORG-O1',
+                SecondaryScopes: undefined,
+            });
+        });
+
+        it('parses SecondaryScopes JSON and supports string/number/boolean/string[] values', async () => {
+            loadedAgentStub.SearchScopeAccess = 'All';
+            const action = new ScopedSearchAction();
+            const payload = JSON.stringify({
+                Department: 'Finance',
+                HeadcountFloor: 50,
+                IsActive: true,
+                Tags: ['audit', 'q4-priorities']
+            });
+            const result = await run(action, mkParams([
+                { Name: 'Query', Value: 'q' },
+                { Name: 'AgentID', Value: 'agent-1' },
+                { Name: 'PrimaryScopeRecordID', Value: 'ORG-O1' },
+                { Name: 'SecondaryScopes', Value: payload }
+            ]));
+            expect(result.Success).toBe(true);
+            const callArgs = searchSpy.mock.calls[0][0];
+            expect(callArgs.SearchContext).toEqual({
+                PrimaryScopeRecordID: 'ORG-O1',
+                SecondaryScopes: {
+                    Department: 'Finance',
+                    HeadcountFloor: 50,
+                    IsActive: true,
+                    Tags: ['audit', 'q4-priorities']
+                }
+            });
+        });
+
+        it('drops SecondaryScopes entries with unsupported value types but keeps valid ones', async () => {
+            loadedAgentStub.SearchScopeAccess = 'All';
+            const action = new ScopedSearchAction();
+            // Object-valued, null, and mixed-array entries are unsupported and should be dropped.
+            const payload = JSON.stringify({
+                Region: 'US',                             // string — kept
+                NestedJunk: { foo: 'bar' },                // object — dropped
+                NullValue: null,                            // null   — dropped
+                MixedArray: ['ok', 42, true],               // mixed  — dropped
+                Tags: ['policy', 'audit']                  // string[] — kept
+            });
+            const result = await run(action, mkParams([
+                { Name: 'Query', Value: 'q' },
+                { Name: 'AgentID', Value: 'agent-1' },
+                { Name: 'SecondaryScopes', Value: payload }
+            ]));
+            expect(result.Success).toBe(true);
+            const callArgs = searchSpy.mock.calls[0][0];
+            expect(callArgs.SearchContext).toEqual({
+                PrimaryScopeRecordID: undefined,
+                SecondaryScopes: {
+                    Region: 'US',
+                    Tags: ['policy', 'audit']
+                }
+            });
+        });
+
+        it('treats malformed SecondaryScopes JSON as absent and still runs the search', async () => {
+            loadedAgentStub.SearchScopeAccess = 'All';
+            const action = new ScopedSearchAction();
+            const result = await run(action, mkParams([
+                { Name: 'Query', Value: 'q' },
+                { Name: 'AgentID', Value: 'agent-1' },
+                { Name: 'PrimaryScopeRecordID', Value: 'ORG-O1' },
+                { Name: 'SecondaryScopes', Value: '{not valid json' }
+            ]));
+            expect(result.Success).toBe(true);
+            const callArgs = searchSpy.mock.calls[0][0];
+            // Primary is still set; SecondaryScopes is dropped due to parse failure.
+            expect(callArgs.SearchContext).toEqual({
+                PrimaryScopeRecordID: 'ORG-O1',
+                SecondaryScopes: undefined,
+            });
+        });
+    });
 });

--- a/packages/Actions/CoreActions/src/custom/search/scoped-search.action.ts
+++ b/packages/Actions/CoreActions/src/custom/search/scoped-search.action.ts
@@ -14,6 +14,7 @@ import {
     MJSearchScopeEntity,
     MJAIAgentSearchScopeEntity
 } from "@memberjunction/core-entities";
+import type { SecondaryScopeValue } from "@memberjunction/ai-core-plus";
 
 /**
  * Formatted result item for serialization-safe output. Mirrors `SearchResultItem`
@@ -58,9 +59,41 @@ interface FormattedSearchResult {
  *       - If `ScopeID` supplied: used as-is.
  *       - If omitted: uses the Global scope.
  *
+ * Multi-tenant `SearchContext` (per-call):
+ *   Two optional inputs assemble a `SearchContext` that is threaded into
+ *   `SearchParams.SearchContext`. The engine renders the values into every
+ *   scope-level Nunjucks template (MetadataFilter, ExtraFilter, UserSearchString,
+ *   FolderPath) at search time — so one scope definition serves many tenants.
+ *
+ *   - `PrimaryScopeRecordID` (string) — primary tenant key (e.g. OrganizationID).
+ *     Available in templates as `{{ context.PrimaryScopeRecordID }}`.
+ *   - `SecondaryScopes` (JSON string) — flat object of additional dimensions.
+ *     Each value must be `string | number | boolean | string[]`. Available in
+ *     templates as `{{ context.SecondaryScopes.<key> }}`. Incompatible value
+ *     types are dropped with a log; malformed JSON falls back to undefined
+ *     rather than failing the call.
+ *
+ *   `SearchContext` is included only when at least one of the two inputs is
+ *   provided — omitting both preserves the original "no per-call tenant
+ *   filter" behavior. See `guides/SEARCH_SCOPES_AND_RAG_GUIDE.md` §10 for the
+ *   full multi-tenant model and template-rendering details.
+ *
  * @example Agent tool call
  * ```
  * { "tool": "Scoped Search", "params": { "Query": "refund policy", "AgentID": "<agent-uuid>" } }
+ * ```
+ *
+ * @example Per-tenant scoped call
+ * ```
+ * {
+ *   "tool": "Scoped Search",
+ *   "params": {
+ *     "Query":                "Q3 budget approval",
+ *     "AgentID":              "<agent-uuid>",
+ *     "PrimaryScopeRecordID": "<org-uuid>",
+ *     "SecondaryScopes":      "{\"Department\":\"Finance\",\"Tags\":[\"q3\",\"approved\"]}"
+ *   }
+ * }
  * ```
  */
 @RegisterClass(BaseAction, "__Scoped_Search")
@@ -91,10 +124,21 @@ export class ScopedSearchAction extends BaseAction {
             const maxResults = this.getNumericParam(params, "maxresults", 25);
             const minScore = this.getNumericParam(params, "minscore", 0);
             const streamingMode = (this.getStringParam(params, "streamingmode") ?? 'finalOnly').toLowerCase();
-            LogStatus(`ScopedSearchAction: Agent="${agent.Name}" scope="${scope?.Name ?? 'Global'}" query="${query}" streamingMode="${streamingMode}"`);
+            // Per-call multi-tenant context. PrimaryScopeRecordID is the
+            // primary tenant key (e.g. OrganizationID). SecondaryScopes is
+            // an opaque JSON object of additional dimensions; each key
+            // becomes `{{ context.SecondaryScopes.<key> }}` available to
+            // the scope's Nunjucks-rendered MetadataFilter / ExtraFilter /
+            // UserSearchString / FolderPath. Dimensions are fully dynamic
+            // here — validation against scope.SearchContextConfig.dimensions
+            // (if desired) is the engine's responsibility, not the action's.
+            const primaryScopeRecordID = this.getStringParam(params, "primaryscoperecordid");
+            const secondaryScopes = this.parseSecondaryScopes(params);
+            LogStatus(`ScopedSearchAction: Agent="${agent.Name}" scope="${scope?.Name ?? 'Global'}" query="${query}" streamingMode="${streamingMode}" primaryScopeRecordID="${primaryScopeRecordID ?? ''}" secondaryScopeKeys=[${Object.keys(secondaryScopes ?? {}).join(',')}]`);
             const exec = await this.runSearch({
                 query, maxResults, minScore, scopeID, agent,
                 contextUser: params.ContextUser, streamingMode,
+                primaryScopeRecordID, secondaryScopes,
             });
             if ('result' in exec) return exec.result;
 
@@ -254,7 +298,19 @@ export class ScopedSearchAction extends BaseAction {
         agent: MJAIAgentEntity;
         contextUser: UserInfo;
         streamingMode: string;
+        primaryScopeRecordID: string | undefined;
+        secondaryScopes: Record<string, SecondaryScopeValue> | undefined;
     }): Promise<{ ok: true; sr: SearchResult; progressEvents: Array<Record<string, unknown>> } | { ok: false; result: ActionResultSimple }> {
+        // Construct a SearchContext only when the caller supplied at least
+        // one runtime dimension. Leaving it undefined preserves the existing
+        // "no per-call tenant filter" behavior for callers that never pass
+        // these inputs.
+        const searchContext = (input.primaryScopeRecordID || (input.secondaryScopes && Object.keys(input.secondaryScopes).length > 0))
+            ? {
+                PrimaryScopeRecordID: input.primaryScopeRecordID,
+                SecondaryScopes: input.secondaryScopes,
+            }
+            : undefined;
         const baseParams = {
             Query: input.query,
             MaxResults: input.maxResults,
@@ -265,6 +321,11 @@ export class ScopedSearchAction extends BaseAction {
             // SearchExecutionLog.AIAgentID is populated. Mirror the pre-
             // execution RAG and Forbidden-path threading.
             AIAgentID: input.agent.ID,
+            // Multi-tenant runtime context. The engine renders this into the
+            // scope's Nunjucks MetadataFilter / ExtraFilter / UserSearchString
+            // / FolderPath fields at search time so a single scope definition
+            // can serve many tenants.
+            SearchContext: searchContext,
         };
         if (input.streamingMode !== 'partials') {
             const sr = await SearchEngine.Instance.Search(baseParams, input.contextUser);
@@ -508,6 +569,52 @@ export class ScopedSearchAction extends BaseAction {
         if (!param || param.Value === undefined || param.Value === null) return undefined;
         const value = String(param.Value).trim();
         return value.length > 0 ? value : undefined;
+    }
+
+    /**
+     * Parse the optional SecondaryScopes input. Accepts a JSON string
+     * containing a flat object of dimension keys to values. Values are
+     * passed through verbatim; the SearchEngine's Nunjucks render handles
+     * type coercion when interpolating into MetadataFilter / ExtraFilter
+     * templates. Malformed input is logged and treated as undefined rather
+     * than failing the whole search — a stray bad payload shouldn't kill
+     * an otherwise-valid query.
+     */
+    private parseSecondaryScopes(params: RunActionParams): Record<string, SecondaryScopeValue> | undefined {
+        const raw = this.getStringParam(params, "secondaryscopes");
+        if (!raw) return undefined;
+        let parsed: unknown;
+        try {
+            parsed = JSON.parse(raw);
+        } catch (e) {
+            LogError(`ScopedSearchAction: SecondaryScopes was not valid JSON; ignoring: ${e instanceof Error ? e.message : String(e)}`);
+            return undefined;
+        }
+        if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
+            LogError(`ScopedSearchAction: SecondaryScopes must be a JSON object, got ${Array.isArray(parsed) ? 'array' : typeof parsed} — ignoring.`);
+            return undefined;
+        }
+        // Validate each value against SecondaryScopeValue = string | number | boolean | string[].
+        // Drop incompatible entries (with a log) rather than failing the whole call — partial
+        // context is more useful than no context.
+        const cleaned: Record<string, SecondaryScopeValue> = {};
+        for (const [key, value] of Object.entries(parsed as Record<string, unknown>)) {
+            if (this.isSecondaryScopeValue(value)) {
+                cleaned[key] = value;
+            } else {
+                LogError(`ScopedSearchAction: SecondaryScopes key '${key}' has unsupported value type (${Array.isArray(value) ? 'mixed-array' : typeof value}); skipping.`);
+            }
+        }
+        return Object.keys(cleaned).length > 0 ? cleaned : undefined;
+    }
+
+    /** Type guard mirroring `SecondaryScopeValue` from @memberjunction/ai-core-plus. */
+    private isSecondaryScopeValue(value: unknown): value is SecondaryScopeValue {
+        if (value === null || value === undefined) return false;
+        const t = typeof value;
+        if (t === 'string' || t === 'number' || t === 'boolean') return true;
+        if (Array.isArray(value)) return value.every(v => typeof v === 'string');
+        return false;
     }
 
     private getNumericParam(params: RunActionParams, paramName: string, defaultValue: number): number {

--- a/packages/Actions/CoreActions/src/custom/search/scoped-search.action.ts
+++ b/packages/Actions/CoreActions/src/custom/search/scoped-search.action.ts
@@ -1,7 +1,7 @@
 import { ActionResultSimple, RunActionParams, ActionParam } from "@memberjunction/actions-base";
 import { BaseAction } from "@memberjunction/actions";
 import { RegisterClass, UUIDsEqual } from "@memberjunction/global";
-import { LogError, LogStatus, Metadata, UserInfo } from "@memberjunction/core";
+import { LogError, LogStatusEx, IsVerboseLoggingEnabled, Metadata, UserInfo } from "@memberjunction/core";
 import {
     SearchEngine,
     SearchResult,
@@ -134,7 +134,11 @@ export class ScopedSearchAction extends BaseAction {
             // (if desired) is the engine's responsibility, not the action's.
             const primaryScopeRecordID = this.getStringParam(params, "primaryscoperecordid");
             const secondaryScopes = this.parseSecondaryScopes(params);
-            LogStatus(`ScopedSearchAction: Agent="${agent.Name}" scope="${scope?.Name ?? 'Global'}" query="${query}" streamingMode="${streamingMode}" primaryScopeRecordID="${primaryScopeRecordID ?? ''}" secondaryScopeKeys=[${Object.keys(secondaryScopes ?? {}).join(',')}]`);
+            LogStatusEx({
+                message: `ScopedSearchAction: Agent="${agent.Name}" scope="${scope?.Name ?? 'Global'}" query="${query}" streamingMode="${streamingMode}" primaryScopeRecordID="${primaryScopeRecordID ?? ''}" secondaryScopeKeys=[${Object.keys(secondaryScopes ?? {}).join(',')}]`,
+                verboseOnly: true,
+                isVerboseEnabled: IsVerboseLoggingEnabled
+            });
             const exec = await this.runSearch({
                 query, maxResults, minScore, scopeID, agent,
                 contextUser: params.ContextUser, streamingMode,
@@ -248,7 +252,11 @@ export class ScopedSearchAction extends BaseAction {
             ContextUser: params.ContextUser,
         });
         if (!verdict.Allowed) {
-            LogStatus(`ScopedSearchAction denied: ${verdict.Reason} (scope=${scopeID}, source=${verdict.Source})`);
+            LogStatusEx({
+                message: `ScopedSearchAction denied: ${verdict.Reason} (scope=${scopeID}, source=${verdict.Source})`,
+                verboseOnly: true,
+                isVerboseEnabled: IsVerboseLoggingEnabled
+            });
             // ACCESS_DENIED is reserved for agent-side denials so calling code
             // can distinguish "the agent isn't permitted to use this scope"
             // from "the user isn't permitted".
@@ -270,7 +278,11 @@ export class ScopedSearchAction extends BaseAction {
         // Mirror the GraphQL resolvers' gate.
         if (verdict.Level === 'Read') {
             const reason = `User '${params.ContextUser.Name}' has Read-level access on this scope, which permits metadata visibility but not search execution. Search or Manage is required to run a query.`;
-            LogStatus(`ScopedSearchAction denied: ${reason} (scope=${scopeID}, source=${verdict.Source})`);
+            LogStatusEx({
+                message: `ScopedSearchAction denied: ${reason} (scope=${scopeID}, source=${verdict.Source})`,
+                verboseOnly: true,
+                isVerboseEnabled: IsVerboseLoggingEnabled
+            });
             await SearchEngine.Instance.LogForbiddenSearch({
                 Query: query,
                 ScopeIDs: [scopeID],


### PR DESCRIPTION
## Summary

- Adds `PrimaryScopeRecordID` and `SecondaryScopes` (JSON) inputs to `__Scoped_Search` so callers can supply per-call multi-tenant context. Both threaded through `SearchEngine.Search()` as `SearchParams.SearchContext` and Nunjucks-rendered into the scope's `MetadataFilter` / `ExtraFilter` / `UserSearchString` / `FolderPath` at search time — one Search Scope definition then serves many tenants without per-tenant scope clones.
- `SecondaryScopes` is parsed once and validated against the canonical `SecondaryScopeValue` union (`string | number | boolean | string[]`). Incompatible entries are dropped with a log; the search still proceeds with the valid keys. Malformed JSON falls back to no `SecondaryScopes` rather than rejecting the call.
- Action params metadata updated so the two new inputs appear in MJExplorer's Run Action UI. Guide §3 (Agent-Invoked Search) and §10 (Multi-Tenant Search Context) updated to document the new inputs and clarify the auto-flow vs. explicit-input distinction. Class-level JSDoc refreshed with a per-tenant `@example`.

## Test plan

- [x] `cd packages/Actions/CoreActions && npm run build` — clean compile.
- [x] `cd packages/Actions/CoreActions && npm run test` — 94 tests pass (11 pre-existing scoped-search + 5 new SearchContext-threading + the other suites).
- [ ] Manual smoke test: invoke `__Scoped_Search` from a Loop agent with `PrimaryScopeRecordID` set; confirm a scope with `ExtraFilter = "OrganizationID = '{{ context.PrimaryScopeRecordID }}'"` returns only matching rows.
- [ ] Manual smoke test: invoke with `SecondaryScopes = '{"Department":"Finance","Tags":["audit"]}'`; confirm templates referencing `{{ context.SecondaryScopes.Department }}` and `{{ context.SecondaryScopes.Tags }}` render correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
