### PR TITLE
feat: engine load health in diagnostics, recovery telemetry, cache architecture fixes

### DIFF
--- a/.changeset/bright-engines-pulse.md
+++ b/.changeset/bright-engines-pulse.md
@@ -1,0 +1,8 @@
+---
+"@memberjunction/core": patch
+"@memberjunction/generic-database-provider": patch
+"@memberjunction/ng-dashboards": patch
+"@memberjunction/ng-base-application": patch
+---
+
+Surface engine load health in System Diagnostics with per-property success/failure status and error messages, add recovery telemetry to ApplicationManager, cache architecture fixes including schema hash staleness detection, empty result timestamp handling, and timestamp precision tolerance

--- a/packages/Angular/Explorer/base-application/src/lib/application-manager.ts
+++ b/packages/Angular/Explorer/base-application/src/lib/application-manager.ts
@@ -310,7 +310,14 @@ export class ApplicationManager {
       const hasMetadataApps = md.Applications.some(a => a.Status === 'Active');
       if (activeApps.length === 0 && hasMetadataApps && !ApplicationManager._recoveryAttempted) {
         ApplicationManager._recoveryAttempted = true;
-        LogStatus('ApplicationManager: No user apps loaded despite Active apps in metadata — attempting recovery');
+        const activeAppCount = md.Applications.filter(a => a.Status === 'Active').length;
+        const engineHealthy = UserInfoEngine.Instance.AllPropertiesLoadedSuccessfully;
+        const userAppCount = UserInfoEngine.Instance.UserApplications?.length ?? 0;
+        LogStatus(
+          `ApplicationManager: Recovery triggered — ` +
+          `activeApps=0, metadataActiveApps=${activeAppCount}, ` +
+          `engineHealthy=${engineHealthy}, userAppRecords=${userAppCount}`
+        );
         await this.attemptRecovery();
       }
 
@@ -394,6 +401,14 @@ export class ApplicationManager {
       const engine = UserInfoEngine.Instance;
       await engine.Config(true);
       await this.loadUserApplicationConfig();
+
+      const recoveredCount = this.applications$.value.length;
+      const engineHealthy = engine.AllPropertiesLoadedSuccessfully;
+      if (recoveredCount > 0) {
+        LogStatus(`ApplicationManager: Recovery succeeded — ${recoveredCount} apps loaded, engineHealthy=${engineHealthy}`);
+      } else {
+        LogError(`ApplicationManager: Recovery completed but still 0 apps — engineHealthy=${engineHealthy}`);
+      }
     } catch (error) {
       LogError('ApplicationManager: Recovery attempt failed:', undefined, error instanceof Error ? error.message : String(error));
     }

--- a/packages/Angular/Explorer/dashboards/src/SystemDiagnostics/system-diagnostics.component.css
+++ b/packages/Angular/Explorer/dashboards/src/SystemDiagnostics/system-diagnostics.component.css
@@ -2991,6 +2991,29 @@
     word-break: break-all;
 }
 
+/* Health status indicators for config items */
+.config-health-icon {
+    font-size: 12px;
+    flex-shrink: 0;
+}
+.config-health-icon.health-success {
+    color: var(--mj-status-success);
+}
+.config-health-icon.health-failure {
+    color: var(--mj-status-error);
+}
+.config-detail-row--error {
+    background: color-mix(in srgb, var(--mj-status-error) 6%, transparent);
+    border-radius: 4px;
+    padding: 4px 8px;
+}
+.detail-value--error {
+    color: var(--mj-status-error-text) !important;
+    background: none !important;
+    font-family: inherit !important;
+    word-break: break-word;
+}
+
 /* Sample Data Section */
 .sample-data-section {
     margin-top: 16px;

--- a/packages/Angular/Explorer/dashboards/src/SystemDiagnostics/system-diagnostics.component.ts
+++ b/packages/Angular/Explorer/dashboards/src/SystemDiagnostics/system-diagnostics.component.ts
@@ -38,6 +38,10 @@ export interface EngineConfigItemDisplay {
     memoryDisplay: string;
     sampleData: unknown[];
     expanded: boolean;
+    /** Whether this property loaded successfully during engine startup */
+    loadedSuccessfully: boolean;
+    /** Error message if the property failed to load */
+    errorMessage?: string;
     // Paging support
     displayedData: unknown[];
     allDataLoaded: boolean;
@@ -1371,6 +1375,12 @@ export interface SystemDiagnosticsUserPreferences {
                       <div class="config-item" [class.expanded]="item.expanded">
                         <div class="config-item-header" (click)="toggleConfigItemExpanded(item)">
                           <div class="config-item-info">
+                            <i class="fa-solid config-health-icon"
+                               [class.fa-circle-check]="item.loadedSuccessfully"
+                               [class.fa-circle-xmark]="!item.loadedSuccessfully"
+                               [class.health-success]="item.loadedSuccessfully"
+                               [class.health-failure]="!item.loadedSuccessfully"
+                               [title]="item.loadedSuccessfully ? 'Loaded successfully' : ('Load failed: ' + (item.errorMessage || 'unknown'))"></i>
                             <span class="config-type-chip" [class]="'type-' + item.type">{{ item.type }}</span>
                             <span class="config-name">{{ item.entityName || item.datasetName || item.propertyName }}</span>
                           </div>
@@ -1399,7 +1409,13 @@ export interface SystemDiagnosticsUserPreferences {
                                 <code class="detail-value">{{ item.orderBy }}</code>
                               </div>
                             }
-        
+                            @if (!item.loadedSuccessfully && item.errorMessage) {
+                              <div class="config-detail-row config-detail-row--error">
+                                <span class="detail-label">Error:</span>
+                                <span class="detail-value detail-value--error">{{ item.errorMessage }}</span>
+                              </div>
+                            }
+
                             <!-- Data Table with Paging -->
                             @if (item.displayedData.length > 0) {
                               <div class="sample-data-section">
@@ -3803,12 +3819,18 @@ export class SystemDiagnosticsComponent extends BaseResourceComponent implements
         const engineObj = engineInstance as Record<string, unknown>;
         const items: EngineConfigItemDisplay[] = [];
 
+        // Get load health data from DataMapEntries (if available)
+        const dataMapEntries = (engineObj as { DataMapEntries?: ReadonlyMap<string, { loadedSuccessfully: boolean; errorMessage?: string }> }).DataMapEntries;
+
         for (const config of engineInstance.Configs) {
             const propValue = engineObj[config.PropertyName];
             const dataArray = Array.isArray(propValue) ? propValue : [];
             const estimatedBytes = this.estimateArrayMemory(dataArray);
             const initialPageSize = 10;
             const initialData = dataArray.slice(0, initialPageSize);
+
+            // Look up load health from _dataMap
+            const healthEntry = dataMapEntries?.get(config.PropertyName);
 
             items.push({
                 propertyName: config.PropertyName,
@@ -3822,6 +3844,8 @@ export class SystemDiagnosticsComponent extends BaseResourceComponent implements
                 memoryDisplay: this.formatBytes(estimatedBytes),
                 sampleData: dataArray, // Store all data for paging
                 expanded: false,
+                loadedSuccessfully: healthEntry?.loadedSuccessfully ?? true,
+                errorMessage: healthEntry?.errorMessage,
                 // Paging support
                 displayedData: initialData,
                 allDataLoaded: dataArray.length <= initialPageSize,

--- a/packages/MJCore/src/generic/baseEngine.ts
+++ b/packages/MJCore/src/generic/baseEngine.ts
@@ -1586,6 +1586,16 @@ export abstract class BaseEngine<T> extends BaseSingleton<T> implements IStartup
     }
 
     /**
+     * Returns a read-only snapshot of all engine property load states.
+     * Each entry maps a property name to its load status, including entity/dataset name,
+     * row count, success/failure flag, and error message if applicable.
+     * Used by dev tools for diagnostics and health monitoring.
+     */
+    public get DataMapEntries(): ReadonlyMap<string, EngineDataMapEntry> {
+        return this._dataMap;
+    }
+
+    /**
      * Returns the loading subject. You can call await Config() and after Config() comes back as true that means you're loaded. However you can also directly subscribe to this subject to get updates on the loading status.
      */
     public get LoadingSubject(): BehaviorSubject<boolean> {


### PR DESCRIPTION
## Summary

Follow-on to PR #2587 addressing review feedback from AN-BC.

### Engine Load Health in System Diagnostics
- Add public `DataMapEntries` accessor on `BaseEngine` to expose per-property load state (success/failure, error messages, row counts)
- Integrate into existing **Admin → Monitoring → Diagnostics** engine detail panel rather than creating a separate dev tools inspector
- Each config item now shows a green checkmark or red X status icon with error details on expand

### Recovery Telemetry
- `ApplicationManager.attemptRecovery()` now logs diagnostic context on trigger: metadata active app count, engine health status, user app record count
- Logs recovery result (success/failure) with app count and engine health

### Cache Architecture Fixes (from audit)
- **Schema upgrade detection**: Cache entries store a `schemaHash` (hash of entity field names). On read, if schema changed (new columns after migration), entry is auto-invalidated. Eliminates need to clear browser cache after MJ upgrades.
- **Empty result timestamp**: `extractMaxUpdatedAt()` returns empty string instead of current server time for empty results
- **Timestamp precision tolerance**: `isCacheCurrent()` uses millisecond comparison with 1-second tolerance
- **Remote fingerprint index rebuild**: `resolveFingerprintsForEntity()` populates local index after Redis scan
- **Null PK field handling**: Skip cached rows with null PK values in upsert/remove
- **maxUpdatedAt type guard**: Coerce non-string values to ISO string with error logging

## Changed Packages
| Package | Changes |
|---------|---------|
| `@memberjunction/core` | `baseEngine.ts` (DataMapEntries accessor), `localCacheManager.ts` (schema hash, null PK, type guard, fingerprint index), `providerBase.ts` (empty timestamp) |
| `@memberjunction/generic-database-provider` | `isCacheCurrent()` timestamp tolerance + empty sentinel handling |
| `@memberjunction/ng-dashboards` | System Diagnostics engine health status indicators |
| `@memberjunction/ng-base-application` | Recovery telemetry logging |

## Test Plan
- [x] 18 new unit tests for cache fixes (schema hash, empty timestamps, null PKs, type guard)
- [x] All 1128 MJCore tests pass
- [x] All 503 GenericDatabaseProvider tests pass
- [x] Dashboards package builds clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)