### PR TITLE
feat(runview): add keyset (seek) pagination via AfterKey

### DIFF
--- a/.changeset/keyset-pagination.md
+++ b/.changeset/keyset-pagination.md
@@ -1,0 +1,37 @@
+---
+"@memberjunction/core": minor
+"@memberjunction/generic-database-provider": minor
+"@memberjunction/sqlserver-dataprovider": patch
+"@memberjunction/postgresql-dataprovider": patch
+"@memberjunction/graphql-dataprovider": patch
+"@memberjunction/server": patch
+"@memberjunction/ai-vectors": minor
+"@memberjunction/ai-vector-sync": patch
+"@memberjunction/core-actions": patch
+---
+
+Add keyset (seek) pagination to `RunView` via the new `RunViewParams.AfterKey: CompositeKey` field. Iterating large entities (background jobs, scheduled actions, bulk processing) now stays O(log N) per page regardless of depth — `StartRow`-based OFFSET pagination is unchanged and remains the right choice for UI grids.
+
+**Framework changes**
+- New `RunViewParams.AfterKey: CompositeKey` accepted by all RunView entry points (TS, GraphQL, REST flows that go through RunView).
+- New exported error class `AfterKeyNotSupportedError` (with `Reason` codes `CompositePK | UnsupportedPKType | IncompatibleOrderBy | StartRowConflict | AfterKeyShape`).
+- New exported helper `IsKeysetPaginationOrderableType(sqlType)` and constant `KEYSET_PAGINATION_ORDERABLE_PK_TYPES`.
+- Keyset queries bypass server cache (read + write) automatically — they're inherently single-use so caching is pure overhead.
+- v1 constraint: single-column PK only. Composite-PK entities throw `AfterKeyNotSupportedError` with `Reason: 'CompositePK'`.
+
+**Migrated callers (now use keyset by default when entity has a single-column PK)**
+- `ScheduledGeocodingAction` (`processMissingForEntity`) — falls back to OFFSET on composite-PK entities.
+- `VectorBase.PageRecordsByEntityID` + `EntityVectorSyncer.startDataPaging` — auto-promotes to keyset when possible. New helper `VectorBase.CanUseKeysetPagination()`. New optional `PageRecordsParams.AfterKey`.
+
+**Metadata**
+- `Geocoding Maintenance` scheduled job cron updated to weekly (Saturdays 2 AM UTC); description reworded to not hard-code a cadence. Administrators can adjust the `CronExpression` as needed.
+
+**Documentation**
+- New guide: `guides/KEYSET_PAGINATION_GUIDE.md`.
+- `CLAUDE.md` performance section updated.
+
+**Out of scope for v1**
+- `ExternalChangeDetection.ChangeDetector` uses `RunQuery` (saved queries with arbitrary SQL), which the framework can't safely rewrite. Stays on OFFSET; tracked as a follow-up.
+
+**Backwards compatibility**
+- Fully additive. Existing callers that don't pass `AfterKey` are unaffected.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -818,6 +818,36 @@ Key principles:
 - Group related queries together in a single batch operation
 - Example: Load all dashboard data in 2-3 calls instead of 30+
 
+### Deep Pagination — Use Keyset (`AfterKey`), not `StartRow`
+
+For background jobs, scheduled actions, or bulk processing that iterates through *all* records of a large entity, use **`RunViewParams.AfterKey`** (keyset / seek pagination) instead of `StartRow`. Keyset stays O(log N) per page regardless of depth — `StartRow` becomes progressively expensive as the offset grows (each page must enumerate and discard the skipped rows).
+
+```typescript
+import { CompositeKey } from '@memberjunction/core';
+
+let lastSeenKey: CompositeKey | undefined;
+while (true) {
+    const result = await rv.RunView({
+        EntityName: 'Tax Returns',
+        ExtraFilter: 'AddressLine1 IS NOT NULL',
+        AfterKey: lastSeenKey,
+        MaxRows: 500,
+        ResultType: 'entity_object'
+    }, contextUser);
+
+    if (!result.Success || result.Results.length === 0) break;
+    for (const r of result.Results) { /* process */ }
+    if (result.Results.length < 500) break;
+
+    const last = result.Results[result.Results.length - 1];
+    lastSeenKey = CompositeKey.FromID(last.ID);
+}
+```
+
+**Constraints**: single-column PK only; throws `AfterKeyNotSupportedError` for composite-PK entities (fall back to `StartRow`). UI grid pagination (a few hundred pages of a few hundred rows) should stay on `StartRow` — keyset isn't necessary there.
+
+See **[guides/KEYSET_PAGINATION_GUIDE.md](guides/KEYSET_PAGINATION_GUIDE.md)** for full details, examples, and the reference implementations (`ScheduledGeocodingAction`, `VectorBase`, `EntityVectorSyncer`).
+
 ### Client-Side Data Aggregation
 - Load raw data once, aggregate in memory
 - More efficient than multiple filtered queries

--- a/guides/KEYSET_PAGINATION_GUIDE.md
+++ b/guides/KEYSET_PAGINATION_GUIDE.md
@@ -1,0 +1,170 @@
+# Keyset (Seek) Pagination Guide
+
+**Status:** Stable — available from v5.x onward.
+
+## When to use this
+
+Use **keyset pagination** (`RunViewParams.AfterKey`) when your code iterates through *all* records of a large entity in batches — typically a background job, scheduled action, vectorization run, or bulk export. It stays **O(log N) per page** regardless of how deep you go.
+
+Keep using **OFFSET-based pagination** (`RunViewParams.StartRow`) for UI grid pagination — a few hundred pages of a few hundred rows each, where users jump around to arbitrary pages. OFFSET is correct for that workload and supports arbitrary `OrderBy`.
+
+| Workload | Use |
+|---|---|
+| Background job iterating a large entity | **`AfterKey`** |
+| Vectorization / classification / sync of large entities | **`AfterKey`** |
+| Bulk maintenance ("find missing X across the table") | **`AfterKey`** |
+| UI grid paged by user (jump-to-page) | `StartRow` |
+| Small result sets (a few thousand rows) | Either is fine |
+
+## Why keyset is fast
+
+`OFFSET N FETCH N` requires the DB engine to enumerate the first N rows and discard them before returning the page. At offset 2,000,000 on a 2.6M-row table that's millions of rows of work for every page.
+
+Keyset pagination instead does `WHERE pk > @lastSeenKey ORDER BY pk LIMIT N`, which the optimizer resolves as a single clustered-index seek + range scan. Every page costs roughly the same, whether it's page 1 or page 50,000.
+
+| Page (on a 2.6M-row entity, warm cache) | OFFSET | Keyset |
+|---|---|---|
+| 0 (first page) | 6 ms | 6 ms |
+| 1 (offset 500) | <1 ms | <1 ms |
+| 100 (offset 50,000) | ~25 ms | ~1 ms |
+| 5000 (offset 2,500,000) | **~770 ms** | ~5 ms |
+
+## How to use it
+
+### Single-column PK (the common case)
+
+```typescript
+import { CompositeKey, RunView } from '@memberjunction/core';
+
+const rv = new RunView();
+let lastSeenKey: CompositeKey | undefined; // undefined => first page
+
+while (true) {
+    const result = await rv.RunView({
+        EntityName: 'Tax Returns',
+        ExtraFilter: '(AddressLine1 IS NOT NULL)',
+        AfterKey: lastSeenKey,         // undefined on first call
+        MaxRows: 500,
+        ResultType: 'entity_object',
+        BypassCache: true,              // optional — AfterKey already bypasses cache, this is just explicit
+    }, contextUser);
+
+    if (!result.Success || result.Results.length === 0) break;
+
+    for (const record of result.Results) {
+        // ... process record ...
+    }
+
+    // End-of-data signal: partial page means we've reached the last page.
+    if (result.Results.length < 500) break;
+
+    // Advance the keyset cursor to the last record's PK.
+    const last = result.Results[result.Results.length - 1];
+    lastSeenKey = CompositeKey.FromID(last.ID);
+}
+```
+
+### Custom PK column name (not `ID`)
+
+```typescript
+const last = result.Results[result.Results.length - 1];
+lastSeenKey = CompositeKey.FromKeyValuePair('CustomerCode', last.CustomerCode);
+```
+
+### Using the helper to check entity compatibility upfront
+
+When you're writing a generic helper that might be called for any entity, guard with `IsKeysetPaginationOrderableType` and `entity.PrimaryKeys.length === 1`:
+
+```typescript
+import { IsKeysetPaginationOrderableType } from '@memberjunction/core';
+
+const pkField = entity.FirstPrimaryKey;
+const canUseKeyset = entity.PrimaryKeys.length === 1
+    && pkField != null
+    && IsKeysetPaginationOrderableType(pkField.Type);
+
+if (canUseKeyset) {
+    // … iterate with AfterKey
+} else {
+    // … fall back to StartRow / pageNumber
+}
+```
+
+## Constraints — and the errors you'll see if you violate them
+
+`RunView` throws `AfterKeyNotSupportedError` (in `@memberjunction/core`) when AfterKey can't be honored. The error carries an `EntityName` and a `Reason` code so caller logic can branch sensibly.
+
+| `Reason` | When it fires | What to do |
+|---|---|---|
+| `CompositePK` | The entity has more than one PK column. | Fall back to `StartRow` (OFFSET), or restructure to query a single-PK projection. |
+| `UnsupportedPKType` | PK column type is exotic (`xml`, `sql_variant`, `varbinary`). Essentially never happens with real MJ entities. | Use `StartRow`. |
+| `StartRowConflict` | You passed both `AfterKey` and a non-zero `StartRow`. | Pick one. |
+| `AfterKeyShape` | The `CompositeKey` shape doesn't match the entity's PK (wrong column name, > 1 pair, null/empty value). | Build the key correctly via `CompositeKey.FromID()` or `CompositeKey.FromKeyValuePair(<pk-col>, value)`. |
+| `IncompatibleOrderBy` | You passed `OrderBy` that references columns other than the PK. | Drop the OrderBy (the framework auto-applies `ORDER BY pk`) or use `<pk-col> ASC`/`DESC`. |
+
+```typescript
+import { AfterKeyNotSupportedError } from '@memberjunction/core';
+
+try {
+    await rv.RunView({ EntityName: 'Something', AfterKey: key, MaxRows: 500 }, user);
+} catch (e) {
+    if (e instanceof AfterKeyNotSupportedError && e.Reason === 'CompositePK') {
+        // Fall back to OFFSET-based iteration
+    } else {
+        throw e;
+    }
+}
+```
+
+## Cache interaction
+
+Keyset queries **automatically bypass both the client-side and server-side caches**. This is intentional — each call uses a different seek key, so a cached entry would never be reusable. You can pass `BypassCache: true` explicitly for clarity, but it's not required.
+
+This also means keyset queries do **not** trigger `OnDataChanged` callbacks via Redis pub/sub — they're not subscribing to anything cacheable in the first place.
+
+## Direction handling
+
+The seek predicate inverts automatically based on the `OrderBy` direction:
+
+| `OrderBy` | Predicate generated |
+|---|---|
+| (unset) | `WHERE pk > @lastSeenKey ORDER BY pk ASC` |
+| `'ID'` or `'ID ASC'` | `WHERE pk > @lastSeenKey ORDER BY pk ASC` |
+| `'ID DESC'` | `WHERE pk < @lastSeenKey ORDER BY pk DESC` |
+
+## End-of-data signal
+
+Same as `StartRow`-mode: when a page returns **fewer rows than `MaxRows`**, you've reached the end. Stop iterating.
+
+## What about `RunQuery`?
+
+`RunQuery` (saved queries with arbitrary SQL) doesn't support keyset pagination in v1, because the framework can't safely rewrite a user-authored query to add a seek predicate. If you're iterating through a saved query's results, OFFSET-mode `StartRow` is the only option today. A future enhancement may add saved-query conventions for keyset.
+
+## Reference implementations
+
+These callers in the codebase use the pattern and are good examples to copy from:
+
+- **`packages/Actions/CoreActions/src/custom/geo/scheduled-geocoding.action.ts`** — `processMissingForEntity()` iterates entities marked `SupportsGeoCoding`, using keyset when the entity has a single-column PK and falling back to OFFSET otherwise.
+- **`packages/AI/Vectors/Core/src/models/VectorBase.ts`** — `PageRecordsByEntityID()` accepts an optional `AfterKey` in its `PageRecordsParams`, with the helper `CanUseKeysetPagination(entityID)` for callers to check compatibility upfront.
+- **`packages/AI/Vectors/Sync/src/models/entityVectorSync.ts`** — `startDataPaging()` auto-promotes to keyset when possible, falls back to OFFSET when `StartingOffset` is set (since keyset can't skip to an arbitrary offset).
+
+## Migration checklist for existing OFFSET callers
+
+When you find a caller iterating a large entity with `StartRow`, ask:
+
+1. **Does the entity have a single-column PK?** If composite, leave it alone for now.
+2. **Does the OrderBy reference only the PK?** If it sorts by something else (e.g. `RetryCount ASC, CreatedAt ASC`), keyset doesn't apply — the workload may not need keyset anyway if the result set is small.
+3. **Is the StartRow value typically growing > a few thousand?** If always small (UI pagination), leave it on OFFSET. If it climbs into the millions on big tables, migrate it.
+
+The migration itself is small:
+- Remove `StartRow: offset + 1`
+- Add `AfterKey: lastSeenKey`
+- Track the last record's PK after each page and rebuild the `CompositeKey`
+- That's it — `MaxRows` and `ExtraFilter` stay the same
+
+## Implementation details (for framework maintainers)
+
+- The seek predicate is built by `GenericDatabaseProvider.BuildKeysetSeekClause()` and appended to `viewSQL` (data query only) — not to `countSQL` (total count should reflect all matching rows, not "rows after the seek key").
+- Seek values are inlined as SQL literals with type-aware escaping in `formatKeysetSeekValue()` rather than parameter-bound, consistent with how the rest of the WHERE clause is assembled. UUID values are validated against a strict pattern; numeric values are validated as finite numbers; string/date values are escape-quoted and rejected if they contain semicolons, comment markers, or other suspicious patterns.
+- Cache bypass is enforced at three layers: `LocalCacheManager.SetRunViewResult` short-circuits writes; `ProviderBase.RunView`/`PreRunView`/`PreRunViews` short-circuit reads; `GenericDatabaseProvider.RunViewsWithCacheCheck` routes keyset items to the no-cache-check pipeline.
+- The GraphQL surface uses the existing `CompositeKeyInputType` so the `AfterKey` field doesn't require any new scalar shape on the wire.

--- a/metadata/scheduled-jobs/.geocoding-maintenance-job.json
+++ b/metadata/scheduled-jobs/.geocoding-maintenance-job.json
@@ -2,9 +2,9 @@
   {
     "fields": {
       "Name": "Geocoding Maintenance",
-      "Description": "Runs every 4 hours to find missing geocodes, retry failed attempts, and clean up orphaned RecordGeoCode rows.",
+      "Description": "Runs on a recurring basis as a safety net for records that bypass BaseEntity.Save() (bulk SQL imports, direct DB operations). Live geocoding is handled inline during entity saves; this job finds and geocodes missing rows, retries failed attempts, and cleans up orphaned RecordGeoCode rows. Default cadence is weekly (Saturdays 2 AM UTC); administrators can adjust the CronExpression as needed.",
       "JobTypeID": "@lookup:MJ: Scheduled Job Types.DriverClass=ActionScheduledJobDriver",
-      "CronExpression": "0 */15 * * * *",
+      "CronExpression": "0 0 2 * * 6",
       "Timezone": "UTC",
       "Status": "Active",
       "Configuration": {

--- a/packages/AI/Vectors/Core/README.md
+++ b/packages/AI/Vectors/Core/README.md
@@ -20,7 +20,7 @@ npm install @memberjunction/ai-vectors
 | `IVectorIndex` | Interface | Contract for CRUD operations on vector records within an index |
 | `ChunkTextParams` | Type | Configuration for `TextChunker.ChunkText()` |
 | `TextChunk` | Type | Output chunk with text, offsets, token count, and index |
-| `PageRecordsParams` | Type | Paginated entity record retrieval configuration |
+| `PageRecordsParams` | Type | Paginated entity record retrieval configuration. Supports both OFFSET-based pagination (`PageNumber`) and keyset/seek pagination (`AfterKey`) — see [KEYSET_PAGINATION_GUIDE.md](../../../../guides/KEYSET_PAGINATION_GUIDE.md). |
 
 ## Architecture
 
@@ -320,8 +320,46 @@ export class MyVectorProcessor extends VectorBase {
             page++;
         }
     }
+
+    // Preferred for deep iteration: keyset (seek) pagination via AfterKey.
+    // O(log N) per page regardless of depth — `PageNumber`-based OFFSET pagination
+    // gets progressively slower as pages climb into the thousands.
+    async ProcessInKeysetPages(entityId: string): Promise<void> {
+        // Check upfront — falls back to PageNumber path if the entity has a composite PK.
+        if (!this.CanUseKeysetPagination(entityId)) {
+            // ... use the PageNumber loop above
+            return;
+        }
+        const entity = this.Metadata.Entities.find(e => e.ID === entityId)!;
+        const pkField = entity.FirstPrimaryKey!;
+
+        let lastSeenKey: CompositeKey | undefined; // undefined => first page
+        while (true) {
+            const records = await this.PageRecordsByEntityID<Record<string, unknown>>({
+                EntityID: entityId,
+                PageNumber: 0, // ignored when AfterKey is set
+                PageSize: 500,
+                ResultType: 'simple',
+                Filter: "Status = 'Active'",
+                AfterKey: lastSeenKey,
+            });
+            if (records.length === 0) break;
+            for (const r of records) { /* process */ }
+            if (records.length < 500) break;
+            lastSeenKey = CompositeKey.FromKeyValuePair(pkField.Name, records[records.length - 1][pkField.Name]);
+        }
+    }
 }
 ```
+
+### Keyset Pagination Helpers
+
+`VectorBase` exposes two helpers for keyset (seek) pagination:
+
+- **`PageRecordsParams.AfterKey?: CompositeKey`** — optional cursor that switches `PageRecordsByEntityID` from OFFSET (`PageNumber`) mode to keyset mode. When set, the query uses `WHERE pk > @lastSeen ORDER BY pk LIMIT N` and stays O(log N) per page.
+- **`CanUseKeysetPagination(entityID)`** — returns true if the entity has a single-column PK on an orderable type (i.e. it's safe to pass `AfterKey`). Use it to choose between the keyset and OFFSET paths.
+
+See **[KEYSET_PAGINATION_GUIDE.md](../../../../guides/KEYSET_PAGINATION_GUIDE.md)** for the full pattern, constraints (composite-PK entities throw `AfterKeyNotSupportedError`), and reference implementations across the framework.
 
 ### Filtering with Composite Keys
 

--- a/packages/AI/Vectors/Core/src/generic/VectorCore.types.ts
+++ b/packages/AI/Vectors/Core/src/generic/VectorCore.types.ts
@@ -1,10 +1,16 @@
+import type { CompositeKey } from '@memberjunction/core';
+
 export type PageRecordsParams = {
     /**
      * The ID of the entitiy to get the records from
      */
     EntityID: string | number;
     /**
-     * Number of records to offset. This number will be multiplied by the PageSize to get the actual offset
+     * OFFSET-mode pagination cursor — multiplied by PageSize to compute SQL OFFSET.
+     *
+     * Ignored when `AfterKey` is provided (keyset mode). For deep iteration over large
+     * entities, prefer the keyset form — pass an undefined `AfterKey` on the first call,
+     * then pass the PK of the last record returned on each subsequent call.
      */
     PageNumber: number;
     /**
@@ -19,4 +25,15 @@ export type PageRecordsParams = {
      * Filter to apply to the query
      */
     Filter?: string;
+    /**
+     * Keyset (seek) pagination cursor — when present, the query returns records ordered
+     * by the entity's single-column PK with `WHERE pk > @lastSeen`. Keep each page O(log N)
+     * regardless of how deep you go. Requires a single-column PK on the target entity.
+     *
+     * Pass `undefined` (or omit) to fetch the first page. On subsequent calls, pass a
+     * CompositeKey containing the PK column name and the last returned record's PK value.
+     *
+     * See `guides/KEYSET_PAGINATION_GUIDE.md` for the full pattern.
+     */
+    AfterKey?: CompositeKey;
 };

--- a/packages/AI/Vectors/Core/src/models/VectorBase.ts
+++ b/packages/AI/Vectors/Core/src/models/VectorBase.ts
@@ -61,19 +61,45 @@ export class VectorBase {
           throw new Error(`Entity with ID ${params.EntityID} not found.`);
         }
 
+        // Prefer keyset (seek) pagination when the caller provides AfterKey.
+        // The framework will throw AfterKeyNotSupportedError if the entity has a composite
+        // PK — callers iterating those entities must use the PageNumber path.
+        const useKeyset = !!params.AfterKey;
+
         const rvResult: RunViewResult<T> = await this._runView.RunView<T>({
             EntityName: entity.Name,
             ResultType: params.ResultType,
             MaxRows: params.PageSize,
-            StartRow: Math.max(0, (params.PageNumber - 1) * params.PageSize),
+            ...(useKeyset
+                ? { AfterKey: params.AfterKey, OrderBy: entity.FirstPrimaryKey!.Name }
+                : { StartRow: Math.max(0, (params.PageNumber - 1) * params.PageSize) }),
             ExtraFilter: params.Filter
         }, this.CurrentUser);
-    
+
         if (!rvResult.Success) {
           throw new Error(rvResult.ErrorMessage);
         }
-    
+
         return rvResult.Results;
+    }
+
+    /**
+     * Returns true when {@link PageRecordsByEntityID} can serve the given entity via
+     * keyset (seek) pagination — i.e. the entity has a single-column PK on a comparable
+     * type. Callers iterating large tables should consult this and pass `AfterKey` when true.
+     */
+    protected CanUseKeysetPagination(entityID: string | number): boolean {
+        const entity = this.Metadata.Entities.find(e => UUIDsEqual(e.ID, entityID as string));
+        if (!entity || !entity.FirstPrimaryKey) return false;
+        if (entity.PrimaryKeys.length !== 1) return false;
+        // Inline allowlist check (avoid pulling in the helper here)
+        const t = (entity.FirstPrimaryKey.Type || '').replace(/\s*\([^)]*\)\s*$/, '').trim().toLowerCase();
+        // Same set as KEYSET_PAGINATION_ORDERABLE_PK_TYPES in @memberjunction/core
+        return ['uniqueidentifier','uuid','int','bigint','smallint','tinyint','decimal','numeric','money','smallmoney',
+            'float','real','double precision','char','varchar','nchar','nvarchar','text','ntext',
+            'date','datetime','datetime2','datetimeoffset','smalldatetime','time','bit',
+            'integer','bigserial','serial','character varying','character','timestamp',
+            'timestamp with time zone','timestamp without time zone','boolean'].includes(t);
     }
 
     /**

--- a/packages/AI/Vectors/Sync/README.md
+++ b/packages/AI/Vectors/Sync/README.md
@@ -210,6 +210,8 @@ await syncer.VectorizeEntity({
 }, contextUser);
 ```
 
+Note: `StartingOffset` forces OFFSET-based pagination for that run (keyset can't skip ahead without knowing the PK at the offset). For runs from the start, the syncer **auto-promotes to keyset (seek) pagination** when the entity has a single-column orderable PK — each page stays O(log N) regardless of how deep into the entity you go, which makes a meaningful difference on multi-million-row entities. Falls back to `PageNumber`-based OFFSET when the entity has a composite PK. See **[KEYSET_PAGINATION_GUIDE.md](../../../../guides/KEYSET_PAGINATION_GUIDE.md)** for details.
+
 ### Manage Entity Documents
 
 ```typescript

--- a/packages/AI/Vectors/Sync/src/models/entityVectorSync.ts
+++ b/packages/AI/Vectors/Sync/src/models/entityVectorSync.ts
@@ -3,7 +3,7 @@ import { BaseEmbeddings, EmbedTextsResult, GetAIAPIKey } from '@memberjunction/a
 import { CredentialEngine } from '@memberjunction/credentials';
 import { BaseResponse, VectorDBBase, VectorRecord } from '@memberjunction/ai-vectordb';
 import { PageRecordsParams, VectorBase } from '@memberjunction/ai-vectors';
-import { BaseEntity, EntityField, EntityFieldInfo, EntityInfo, IMetadataProvider, LogError, LogStatus, Metadata, RunView, RunViewResult, UserInfo } from '@memberjunction/core';
+import { BaseEntity, CompositeKey, EntityField, EntityFieldInfo, EntityInfo, IMetadataProvider, LogError, LogStatus, Metadata, RunView, RunViewResult, UserInfo } from '@memberjunction/core';
 import { MJAIModelEntity, MJEntityDocumentEntity, MJEntityDocumentTypeEntity, MJEntityRecordDocumentEntity, MJTemplateContentEntity,
   MJTemplateContentTypeEntity, MJTemplateEntity, MJTemplateEntityExtended, MJTemplateParamEntity, MJVectorDatabaseEntity, MJVectorIndexEntity } from '@memberjunction/core-entities';
 import { MJGlobal, UUIDsEqual } from '@memberjunction/global';
@@ -465,20 +465,38 @@ export class EntityVectorSyncer extends VectorBase {
     pageSize: number
   ): void {
     const getData = async (): Promise<void> => {
+      // Prefer keyset (seek) pagination for entities with a single-column orderable PK.
+      // Keyset stays O(log N) per page regardless of depth, which matters for the
+      // millions-of-records entities that vectorization sometimes ingests.
+      // Falls back to OFFSET-based PageNumber when the entity has a composite PK
+      // (correct but progressively slower on deep pages).
+      const canUseKeyset = this.CanUseKeysetPagination(params.entityID);
+      const pkField = entity.FirstPrimaryKey;
       let pageNumber = 0;
+      let lastSeenKey: CompositeKey | undefined;
 
       if (params.StartingOffset) {
-        pageNumber = params.StartingOffset * pageSize;
-        LogStatus(`Starting at offset ${params.StartingOffset} (skipping first ${pageNumber} records)`);
+        if (canUseKeyset) {
+          // Keyset can't "skip ahead" without knowing the PK at that offset. If callers
+          // pass StartingOffset (rare), we fall back to OFFSET mode for this run.
+          LogStatus(`StartingOffset=${params.StartingOffset} is set — using OFFSET-based pagination for this run (keyset unavailable when skipping ahead).`);
+        } else {
+          pageNumber = params.StartingOffset * pageSize;
+          LogStatus(`Starting at offset ${params.StartingOffset} (skipping first ${pageNumber} records)`);
+        }
       }
+
+      const useKeysetForThisRun = canUseKeyset && !params.StartingOffset;
+      let pageIndex = 0;
 
       let hasMore = true;
       while (hasMore) {
         const pageRecordRequest: PageRecordsParams = {
           EntityID: params.entityID,
-          PageNumber: pageNumber,
+          PageNumber: useKeysetForThisRun ? 0 : pageNumber,
           PageSize: pageSize,
           ResultType: 'simple',
+          AfterKey: useKeysetForThisRun ? lastSeenKey : undefined,
         };
 
         if (params.listID) {
@@ -490,7 +508,7 @@ export class EntityVectorSyncer extends VectorBase {
         const relatedData: TemplateParamData[] = await this.GetRelatedTemplateDataForBatch(entity, recordsPage, template);
         const items: Record<string, unknown>[] = [];
 
-        LogStatus(`Fetched page ${pageNumber + 1} with ${recordsPage.length} records to process`);
+        LogStatus(`Fetched page ${pageIndex + 1} with ${recordsPage.length} records to process`);
 
         for (const record of recordsPage) {
           const typedRecord = record as Record<string, unknown>;
@@ -509,7 +527,20 @@ export class EntityVectorSyncer extends VectorBase {
           break;
         }
 
-        pageNumber++;
+        if (useKeysetForThisRun && pkField) {
+          // Advance the keyset cursor to the last record's PK value
+          const lastRecord = recordsPage[recordsPage.length - 1] as Record<string, unknown>;
+          const lastValue = lastRecord[pkField.Name];
+          if (lastValue == null) {
+            // Defensive: PK should never be null. If it is, we can't keyset-advance, so stop.
+            LogError(`Keyset pagination: last record on page ${pageIndex + 1} has null PK; halting iteration.`);
+            break;
+          }
+          lastSeenKey = CompositeKey.FromKeyValuePair(pkField.Name, lastValue);
+        } else {
+          pageNumber++;
+        }
+        pageIndex++;
       }
 
       dataStream.endStream();

--- a/packages/Actions/CoreActions/README.md
+++ b/packages/Actions/CoreActions/README.md
@@ -86,6 +86,14 @@ Several abstract base classes reduce duplication across related actions:
 
 The file `src/generated/action_subclasses.ts` contains actions produced by the MJ CodeGen system from natural-language `UserPrompt` descriptions stored in the database. Generated actions use a **composition pattern** -- they always extend `BaseAction` (never their parent action class) and invoke the parent action via `ActionEngineServer.Instance.RunAction()` at runtime. See the [parent README](../README.md) for details on the generated/child action architecture.
 
+### Scheduled Geocoding (`Scheduled Geocoding` action)
+
+`src/custom/geo/scheduled-geocoding.action.ts` is a safety-net maintenance action that finds records in geo-enabled entities (`Entity.SupportsGeoCoding = 1`) missing a `RecordGeoCode` row, retries failed geocoding attempts, and cleans up orphaned `RecordGeoCode` rows. **Live geocoding-on-save runs inline via `BaseEntity.OnSaveCompleted`** — this scheduled action is only needed to catch records inserted via bulk SQL imports or direct DB writes that bypass `BaseEntity.Save()`.
+
+The "find missing records" phase uses **keyset (seek) pagination** when the target entity has a single-column orderable PK (the common case for MJ entities). This keeps each page O(log N) regardless of how deep the iteration goes — important on multi-million-row entities like `Tax Returns`. Composite-PK entities fall back to `StartRow`-based OFFSET pagination automatically. See **[KEYSET_PAGINATION_GUIDE.md](../../../guides/KEYSET_PAGINATION_GUIDE.md)** for the pattern.
+
+Default cadence is **Saturday 2 AM UTC** (configured in `metadata/scheduled-jobs/.geocoding-maintenance-job.json`). Administrators can adjust the `CronExpression` per environment.
+
 ### Configuration
 
 External API keys used by certain actions (Perplexity, Google Custom Search, Gamma) are loaded from `mj.config.cjs` or environment variables via the `config.ts` module:

--- a/packages/Actions/CoreActions/src/custom/geo/scheduled-geocoding.action.ts
+++ b/packages/Actions/CoreActions/src/custom/geo/scheduled-geocoding.action.ts
@@ -3,7 +3,8 @@ import { BaseAction } from '@memberjunction/actions';
 import { RegisterClass, MJGlobal, MJEventType } from '@memberjunction/global';
 import {
     RunView, Metadata, LogStatus, LogError, UserInfo, EntityInfo,
-    CompositeKey, BaseEntity, BaseEntityEvent, IMetadataProvider, DatabaseProviderBase
+    CompositeKey, BaseEntity, BaseEntityEvent, IMetadataProvider, DatabaseProviderBase,
+    IsKeysetPaginationOrderableType
 } from '@memberjunction/core';
 import { MJRecordGeoCodeEntity } from '@memberjunction/core-entities';
 import { GeoCodeSyncService, ExistingGeoCodeInfo } from '@memberjunction/geo-core';
@@ -147,6 +148,10 @@ export class ScheduledGeocodingAction extends BaseAction {
         const pkField = entityInfo.FirstPrimaryKey;
         if (!pkField) return { Processed: 0, Success: 0 };
 
+        // Keyset pagination requires a single-column PK. For composite-PK entities, the action
+        // falls back to OFFSET-based pagination (slower on deep pages but correct).
+        const canUseKeyset = entityInfo.PrimaryKeys.length === 1 && IsKeysetPaginationOrderableType(pkField.Type);
+
         const geoFields = this.getGeoAddressFields(entityInfo);
         if (geoFields.length === 0) return { Processed: 0, Success: 0 };
 
@@ -159,13 +164,16 @@ export class ScheduledGeocodingAction extends BaseAction {
             const nonNullConditions = geoFields.map(f => `${f.Name} IS NOT NULL`).join(' OR ');
             let totalProcessed = 0;
             let totalSuccess = 0;
-            let pageOffset = 0;
+            let pageOffset = 0;             // OFFSET-mode (composite-PK fallback)
+            let lastSeenKey: CompositeKey | undefined; // keyset mode
 
-            // Paginate through entity records to avoid loading all into memory at once
+            // Paginate through entity records to avoid loading all into memory at once.
+            // Keyset pagination keeps each page O(log N) regardless of depth — a critical
+            // win when the entity has millions of rows. See guides/KEYSET_PAGINATION_GUIDE.md.
             while (totalProcessed < maxRows) {
-                const pageResult = await this.loadEntityPage(
-                    entityInfo.Name, nonNullConditions, pageOffset, contextUser
-                );
+                const pageResult = canUseKeyset
+                    ? await this.loadEntityPageKeyset(entityInfo.Name, pkField.Name, nonNullConditions, lastSeenKey, contextUser)
+                    : await this.loadEntityPageOffset(entityInfo.Name, nonNullConditions, pageOffset, contextUser);
 
                 if (!pageResult.Success || pageResult.Results.length === 0) break;
 
@@ -190,7 +198,16 @@ export class ScheduledGeocodingAction extends BaseAction {
 
                 // If this page was smaller than PAGE_SIZE, we've exhausted the entity
                 if (pageEntities.length < ScheduledGeocodingAction.PAGE_SIZE) break;
-                pageOffset += ScheduledGeocodingAction.PAGE_SIZE;
+
+                if (canUseKeyset) {
+                    // Advance the seek cursor to the last record's PK on this page
+                    const lastRecord = pageEntities[pageEntities.length - 1];
+                    const lastValue = (lastRecord as unknown as Record<string, unknown>)[pkField.Name];
+                    if (lastValue == null) break;
+                    lastSeenKey = CompositeKey.FromKeyValuePair(pkField.Name, lastValue);
+                } else {
+                    pageOffset += ScheduledGeocodingAction.PAGE_SIZE;
+                }
             }
 
             return { Processed: totalProcessed, Success: totalSuccess };
@@ -202,11 +219,44 @@ export class ScheduledGeocodingAction extends BaseAction {
     }
 
     /**
-     * Load a single page of entity records with non-null geo fields.
-     * Uses OrderBy on PK + MaxRows + offset simulation via GreaterThan filter
-     * to paginate without loading the full result set.
+     * Load a single page of entity records using **keyset (seek) pagination**.
+     *
+     * Each page costs O(log N) regardless of depth because the server resolves
+     * `WHERE pk > @lastSeen ORDER BY pk LIMIT N` as a clustered-index seek — the
+     * deeper-page slowdown of OFFSET-based pagination doesn't apply.
+     *
+     * On the first page, `lastSeenKey` is undefined and the query reduces to
+     * `WHERE (filter) ORDER BY pk LIMIT N`.
      */
-    private async loadEntityPage(
+    private async loadEntityPageKeyset(
+        entityName: string,
+        pkColumnName: string,
+        nonNullFilter: string,
+        lastSeenKey: CompositeKey | undefined,
+        contextUser: UserInfo
+    ): Promise<{ Success: boolean; Results: BaseEntity[] }> {
+        const rv = new RunView();
+        const result = await rv.RunView({
+            EntityName: entityName,
+            ExtraFilter: `(${nonNullFilter})`,
+            OrderBy: pkColumnName,
+            MaxRows: ScheduledGeocodingAction.PAGE_SIZE,
+            AfterKey: lastSeenKey,
+            BypassCache: true,
+            ResultType: 'entity_object'
+        }, contextUser);
+
+        return {
+            Success: result.Success,
+            Results: result.Success ? (result.Results as unknown as BaseEntity[]) : []
+        };
+    }
+
+    /**
+     * Load a single page using OFFSET-based pagination — the fallback path for entities
+     * with composite primary keys. Slower on deep pages but correctness is preserved.
+     */
+    private async loadEntityPageOffset(
         entityName: string,
         nonNullFilter: string,
         offset: number,

--- a/packages/GenericDatabaseProvider/README.md
+++ b/packages/GenericDatabaseProvider/README.md
@@ -40,12 +40,14 @@ DatabaseProviderBase (@memberjunction/core — no heavy deps, abstract)
 | `DisposeAllSqlLoggingSessions()` | Disposes all active logging sessions (used on shutdown) |
 | `LogSQLStatement()` | Static method to log SQL from external sources (e.g., transaction groups) |
 | `RenderViewWhereClause()` | Resolves `{%UserView "id"%}` templates in saved view WHERE clauses |
-| `InternalRunView()` | Shared view execution engine: view resolution, permissions, field selection, WHERE clause, ORDER BY, pagination, aggregates, audit logging |
+| `InternalRunView()` | Shared view execution engine: view resolution, permissions, field selection, WHERE clause, ORDER BY, OFFSET *or* keyset (`AfterKey`) pagination, aggregates, audit logging |
 | `InternalRunViews()` | Parallel wrapper for multiple InternalRunView calls |
 | `getRunTimeViewFieldString()` | Builds dialect-neutral field list string for view queries |
 | `getRunTimeViewFieldArray()` | Resolves EntityFieldInfo list from params/view/entity |
 | `createViewUserSearchSQL()` | Builds full-text search and LIKE-based user search SQL |
 | `BuildPaginationSQL()` | Abstract: platform-specific OFFSET/FETCH or LIMIT/OFFSET |
+| `BuildKeysetSeekClause()` | Validates entity + `RunViewParams.AfterKey` and returns the `<pk> > value` (or `<`) seek predicate. Throws `AfterKeyNotSupportedError` on incompatible entities. See [KEYSET_PAGINATION_GUIDE.md](../../guides/KEYSET_PAGINATION_GUIDE.md). |
+| `formatKeysetSeekValue()` | Type-aware SQL literal escaping for the seek value (UUID validation, numeric/date/string handling, SQL-injection defense). |
 | `BuildTopClause()` | Virtual: SQL Server TOP N, PG returns empty (default) |
 | `BuildNonPaginatedLimitSQL()` | Virtual: PG LIMIT N for non-paginated row limits (default: empty) |
 | `TransformExternalSQLClause()` | Virtual: PG overrides to quote mixed-case identifiers (default: no-op) |
@@ -82,6 +84,22 @@ export class MyDatabaseProvider extends GenericDatabaseProvider {
     // Override PostProcessRows if you need platform-specific row processing (call super first)
 }
 ```
+
+## Keyset (Seek) Pagination
+
+`InternalRunView` honors `RunViewParams.AfterKey` (a `CompositeKey`) to emit keyset-style SQL — `WHERE pk > @lastSeen ORDER BY pk LIMIT N` — instead of `OFFSET ... FETCH NEXT N`. Keyset stays O(log N) regardless of depth, making it the right tool for background jobs iterating large entities.
+
+The same code path works on both SQL Server (uses `TOP N` via `BuildTopClause`) and PostgreSQL (uses `LIMIT N` via `BuildNonPaginatedLimitSQL`) — no per-provider override needed.
+
+Keyset queries automatically bypass `LocalCacheManager` (both read and write) and are routed past the smart cache check in `RunViewsWithCacheCheck` because each call uses a different seek key.
+
+Validation enforced by `BuildKeysetSeekClause`:
+- Entity must have a single-column PK (composite throws `AfterKeyNotSupportedError` with `Reason: 'CompositePK'`)
+- PK type must be in the orderable allowlist (everything sensible is)
+- `OrderBy`, if set, must reference only the PK column
+- Cannot be combined with non-zero `StartRow`
+
+See **[KEYSET_PAGINATION_GUIDE.md](../../guides/KEYSET_PAGINATION_GUIDE.md)** for the full pattern and reference implementations.
 
 ## Server-Side Cache Backend
 

--- a/packages/GenericDatabaseProvider/src/GenericDatabaseProvider.ts
+++ b/packages/GenericDatabaseProvider/src/GenericDatabaseProvider.ts
@@ -63,6 +63,8 @@ import {
     SaveContext,
     SaveContextField,
     SaveSQLResult,
+    AfterKeyNotSupportedError,
+    IsKeysetPaginationOrderableType,
 } from '@memberjunction/core';
 
 import { MJGlobal, SQLExpressionValidator, UUIDsEqual } from '@memberjunction/global';
@@ -999,6 +1001,193 @@ export abstract class GenericDatabaseProvider extends DatabaseProviderBase {
     }
 
     /**
+     * Validates that the entity and RunViewParams are compatible with keyset (AfterKey) pagination,
+     * then returns the SQL predicate (`<pk> > 'value'` or `<pk> < 'value'`) and the resolved
+     * order-by direction.
+     *
+     * See {@link AfterKeyNotSupportedError} for the validation rules and {@link RunViewParams.AfterKey}
+     * for the API contract.
+     *
+     * @throws AfterKeyNotSupportedError on validation failure
+     */
+    protected BuildKeysetSeekClause(
+        entityInfo: EntityInfo,
+        params: RunViewParams
+    ): { seekPredicate: string; direction: 'ASC' | 'DESC'; pkColumnName: string } {
+        const afterKey = params.AfterKey!;
+
+        // 1. Single-column PK requirement
+        const pkFields = entityInfo.PrimaryKeys;
+        if (!pkFields || pkFields.length === 0) {
+            throw new AfterKeyNotSupportedError(
+                entityInfo.Name, 'CompositePK',
+                `AfterKey requires a primary key on entity "${entityInfo.Name}", but none is defined.`
+            );
+        }
+        if (pkFields.length > 1) {
+            throw new AfterKeyNotSupportedError(
+                entityInfo.Name, 'CompositePK',
+                `AfterKey requires a single-column primary key. Entity "${entityInfo.Name}" has a composite PK (${pkFields.length} columns: ${pkFields.map(f => f.Name).join(', ')}). Use StartRow-based pagination for composite-PK entities, or restructure the workload.`
+            );
+        }
+        const pkField = pkFields[0];
+
+        // 2. Orderable PK type
+        if (!IsKeysetPaginationOrderableType(pkField.Type)) {
+            throw new AfterKeyNotSupportedError(
+                entityInfo.Name, 'UnsupportedPKType',
+                `AfterKey is not supported for entity "${entityInfo.Name}" because its PK column "${pkField.Name}" has type "${pkField.Type}", which is not in the keyset-orderable allowlist.`
+            );
+        }
+
+        // 3. StartRow conflict
+        if (params.StartRow !== undefined && params.StartRow > 0) {
+            throw new AfterKeyNotSupportedError(
+                entityInfo.Name, 'StartRowConflict',
+                `AfterKey cannot be combined with StartRow > 0. Use one or the other.`
+            );
+        }
+
+        // 4. AfterKey shape — must contain exactly one key matching the PK column
+        const pairs = afterKey.KeyValuePairs ?? [];
+        if (pairs.length !== 1) {
+            throw new AfterKeyNotSupportedError(
+                entityInfo.Name, 'AfterKeyShape',
+                `AfterKey must contain exactly one key/value pair matching the entity's PK column "${pkField.Name}". Got ${pairs.length} pairs.`
+            );
+        }
+        const pair = pairs[0];
+        if (pair.FieldName?.toLowerCase().trim() !== pkField.Name.toLowerCase().trim()) {
+            throw new AfterKeyNotSupportedError(
+                entityInfo.Name, 'AfterKeyShape',
+                `AfterKey key name "${pair.FieldName}" does not match the entity's PK column "${pkField.Name}".`
+            );
+        }
+        if (pair.Value === null || pair.Value === undefined || pair.Value === '') {
+            throw new AfterKeyNotSupportedError(
+                entityInfo.Name, 'AfterKeyShape',
+                `AfterKey value for "${pkField.Name}" is null/empty. To request the first page, omit AfterKey entirely.`
+            );
+        }
+
+        // 5. OrderBy compatibility — must be empty, or reference only the PK column
+        let direction: 'ASC' | 'DESC' = 'ASC';
+        const rawOrderBy = (params.OrderBy as string | undefined)?.trim() ?? '';
+        if (rawOrderBy.length > 0) {
+            // Accept: "ID", "ID ASC", "ID DESC", "[ID]", "[ID] DESC", '"ID"', etc.
+            // Strip quoting characters and split on whitespace.
+            const stripped = rawOrderBy.replace(/[\[\]"`]/g, '').trim();
+            const tokens = stripped.split(/\s+/);
+            const colName = tokens[0]?.trim();
+            const dirToken = tokens[1]?.toUpperCase().trim();
+            if (!colName || colName.toLowerCase() !== pkField.Name.toLowerCase()) {
+                throw new AfterKeyNotSupportedError(
+                    entityInfo.Name, 'IncompatibleOrderBy',
+                    `When AfterKey is set, OrderBy must reference only the PK column "${pkField.Name}". Got "${rawOrderBy}".`
+                );
+            }
+            if (tokens.length > 2 || (dirToken && dirToken !== 'ASC' && dirToken !== 'DESC')) {
+                throw new AfterKeyNotSupportedError(
+                    entityInfo.Name, 'IncompatibleOrderBy',
+                    `When AfterKey is set, OrderBy may only specify a direction (ASC/DESC). Got "${rawOrderBy}".`
+                );
+            }
+            if (dirToken === 'DESC') direction = 'DESC';
+        }
+
+        // 6. Build the seek predicate. Comparison operator depends on direction.
+        const op = direction === 'ASC' ? '>' : '<';
+        const pkColumnName = this.QuoteIdentifier(pkField.Name);
+        const literalValue = this.formatKeysetSeekValue(pair.Value, pkField.Type);
+        const seekPredicate = `${pkColumnName} ${op} ${literalValue}`;
+
+        return { seekPredicate, direction, pkColumnName };
+    }
+
+    /**
+     * Formats a CompositeKey value as a SQL literal for use in a keyset seek predicate.
+     *
+     * This bypasses parameter binding because the entire WHERE clause is built as a string
+     * elsewhere in this provider (consistent with ExtraFilter / OrderBy handling). The seek
+     * value comes from server-side application code, not raw user input — but we still type-
+     * check and escape to defend against any caller passing a tainted value.
+     *
+     * Strategy:
+     * - UUID types: validate strict UUID format, wrap in single quotes
+     * - Numeric types: validate finite number, output bare
+     * - Boolean: output 0/1 (SQL Server) or TRUE/FALSE (caller can override if needed)
+     * - Date/time types: validate ISO-ish string, wrap in single quotes
+     * - String types: escape single quotes by doubling, wrap in single quotes
+     *
+     * @throws AfterKeyNotSupportedError if the value fails type-specific validation
+     */
+    protected formatKeysetSeekValue(value: unknown, sqlType: string): string {
+        const t = (sqlType || '').replace(/\s*\([^)]*\)\s*$/, '').trim().toLowerCase();
+        const asStr = String(value);
+
+        // UUIDs — validate format strictly
+        if (t === 'uniqueidentifier' || t === 'uuid') {
+            const uuidPattern = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+            if (!uuidPattern.test(asStr)) {
+                throw new AfterKeyNotSupportedError(
+                    '', 'AfterKeyShape',
+                    `AfterKey value "${asStr}" is not a valid UUID for ${sqlType} primary key.`
+                );
+            }
+            return `'${asStr}'`;
+        }
+
+        // Numeric types
+        const numericTypes = new Set([
+            'int', 'bigint', 'smallint', 'tinyint', 'integer', 'bigserial', 'serial',
+            'decimal', 'numeric', 'money', 'smallmoney', 'float', 'real', 'double precision'
+        ]);
+        if (numericTypes.has(t)) {
+            const n = typeof value === 'number' ? value : Number(asStr);
+            if (!Number.isFinite(n)) {
+                throw new AfterKeyNotSupportedError(
+                    '', 'AfterKeyShape',
+                    `AfterKey value "${asStr}" is not a valid numeric value for ${sqlType} primary key.`
+                );
+            }
+            return String(n);
+        }
+
+        // Boolean / bit
+        if (t === 'bit' || t === 'boolean') {
+            const v = value === true || asStr === 'true' || asStr === '1';
+            return v ? '1' : '0';
+        }
+
+        // Date / time — accept anything ISO-ish; quote and escape single quotes
+        const dateTypes = new Set([
+            'date', 'datetime', 'datetime2', 'datetimeoffset', 'smalldatetime', 'time',
+            'timestamp', 'timestamp with time zone', 'timestamp without time zone'
+        ]);
+        if (dateTypes.has(t)) {
+            const escaped = asStr.replace(/'/g, "''");
+            // Reject anything containing semicolons or comment markers as a defense-in-depth check
+            if (/;|--|\/\*|\*\//.test(escaped)) {
+                throw new AfterKeyNotSupportedError(
+                    '', 'AfterKeyShape',
+                    `AfterKey value for ${sqlType} primary key contains disallowed characters.`
+                );
+            }
+            return `'${escaped}'`;
+        }
+
+        // String types (default)
+        const escaped = asStr.replace(/'/g, "''");
+        if (/;|--|\/\*|\*\//.test(escaped)) {
+            throw new AfterKeyNotSupportedError(
+                '', 'AfterKeyShape',
+                `AfterKey value contains disallowed characters.`
+            );
+        }
+        return `'${escaped}'`;
+    }
+
+    /**
      * Transforms a user-provided SQL clause (ExtraFilter, OrderBy, etc.) for platform compatibility.
      * PostgreSQL overrides to quote mixed-case identifiers and convert bracket notation.
      * Default: returns the clause unchanged.
@@ -1067,7 +1256,22 @@ export abstract class GenericDatabaseProvider extends DatabaseProviderBase {
             const saveViewResults: boolean = params.SaveViewResults ?? false;
 
             // ── TOP / pagination mode ──
-            const usingPagination = !!(params.MaxRows && params.MaxRows > 0 && params.StartRow !== undefined && params.StartRow >= 0);
+            // Keyset (AfterKey) takes precedence: validate now so failures are early, predictable,
+            // and never silently degrade to OFFSET. Throws AfterKeyNotSupportedError if invalid.
+            const usingKeyset = !!params.AfterKey;
+            let keysetSeekPredicate = '';
+            let keysetDirection: 'ASC' | 'DESC' = 'ASC';
+            let keysetPkColumnName = '';
+            if (usingKeyset) {
+                const seek = this.BuildKeysetSeekClause(entityInfo, params);
+                keysetSeekPredicate = seek.seekPredicate;
+                keysetDirection = seek.direction;
+                keysetPkColumnName = seek.pkColumnName;
+            }
+
+            // usingPagination is the OFFSET-based path; keyset uses TOP/LIMIT semantics like a
+            // non-paginated query, so we never set usingPagination=true when AfterKey is present.
+            const usingPagination = !usingKeyset && !!(params.MaxRows && params.MaxRows > 0 && params.StartRow !== undefined && params.StartRow >= 0);
             let topSQL = '';
             let maxRowsForQuery = 0;
             if (params.IgnoreMaxRows === true) {
@@ -1075,6 +1279,12 @@ export abstract class GenericDatabaseProvider extends DatabaseProviderBase {
             } else if (usingPagination) {
                 // pagination — no TOP, will add OFFSET/FETCH or LIMIT/OFFSET later
                 maxRowsForQuery = params.MaxRows!;
+            } else if (usingKeyset) {
+                // Keyset uses TOP/LIMIT like a non-paginated query — bounded by MaxRows.
+                // MaxRows is required for keyset to make sense (otherwise return whole table).
+                const keysetMaxRows = params.MaxRows && params.MaxRows > 0 ? params.MaxRows : (entityInfo.UserViewMaxRows && entityInfo.UserViewMaxRows > 0 ? entityInfo.UserViewMaxRows : 1000);
+                topSQL = this.BuildTopClause(keysetMaxRows);
+                maxRowsForQuery = keysetMaxRows;
             } else if (params.MaxRows && params.MaxRows > 0) {
                 topSQL = this.BuildTopClause(params.MaxRows);
                 maxRowsForQuery = params.MaxRows;
@@ -1147,14 +1357,32 @@ export abstract class GenericDatabaseProvider extends DatabaseProviderBase {
                 }
             }
 
+            // 6. Keyset (AfterKey) seek predicate — only on the data query, NOT the count query.
+            //    The count is the total matching the user-visible filters; the seek predicate is
+            //    a pagination cursor, conceptually distinct from "how many records match overall".
+            const seekPredicateForData = usingKeyset ? keysetSeekPredicate : '';
+
             if (bHasWhere) {
                 viewSQL += ` WHERE ${whereSQL}`;
                 if (countSQL) countSQL += ` WHERE ${whereSQL}`;
             }
+            if (seekPredicateForData) {
+                viewSQL += bHasWhere ? ` AND (${seekPredicateForData})` : ` WHERE (${seekPredicateForData})`;
+            }
 
             // ── ORDER BY (transform user-provided clause for platform compatibility) ──
-            const rawOrderBy: string = params.OrderBy ? (params.OrderBy as string) : (viewEntity ? viewEntity.OrderByClause ?? '' : '');
-            const orderBy: string = rawOrderBy.length > 0 ? this.TransformExternalSQLClause(rawOrderBy, entityInfo) : '';
+            // For keyset (AfterKey) mode, we force ORDER BY <pk> <direction> regardless of the
+            // caller's OrderBy — BuildKeysetSeekClause already validated that any caller-provided
+            // OrderBy referenced the PK and we use the resolved direction.
+            let rawOrderBy: string;
+            if (usingKeyset) {
+                rawOrderBy = `${keysetPkColumnName} ${keysetDirection}`;
+            } else {
+                rawOrderBy = params.OrderBy ? (params.OrderBy as string) : (viewEntity ? viewEntity.OrderByClause ?? '' : '');
+            }
+            const orderBy: string = rawOrderBy.length > 0
+                ? (usingKeyset ? rawOrderBy : this.TransformExternalSQLClause(rawOrderBy, entityInfo))
+                : '';
 
             // View run logging (SQL Server-specific, others return null)
             let userViewRunID = '';
@@ -1166,11 +1394,11 @@ export abstract class GenericDatabaseProvider extends DatabaseProviderBase {
                     viewSQL = logResult.executeViewSQL;
                     userViewRunID = logResult.runID;
                 } else if (orderBy.length > 0) {
-                    if (!this.ValidateUserProvidedSQLClause(orderBy)) throw new Error(`Invalid Order By clause: ${orderBy}, contains one more for forbidden keywords`);
+                    if (!usingKeyset && !this.ValidateUserProvidedSQLClause(orderBy)) throw new Error(`Invalid Order By clause: ${orderBy}, contains one more for forbidden keywords`);
                     viewSQL += ` ORDER BY ${orderBy}`;
                 }
             } else if (orderBy.length > 0) {
-                if (!this.ValidateUserProvidedSQLClause(orderBy)) throw new Error(`Invalid Order By clause: ${orderBy}, contains one more for forbidden keywords`);
+                if (!usingKeyset && !this.ValidateUserProvidedSQLClause(orderBy)) throw new Error(`Invalid Order By clause: ${orderBy}, contains one more for forbidden keywords`);
                 viewSQL += ` ORDER BY ${orderBy}`;
             }
 
@@ -1181,7 +1409,9 @@ export abstract class GenericDatabaseProvider extends DatabaseProviderBase {
                 }
                 viewSQL += ' ' + this.BuildPaginationSQL(params.MaxRows!, params.StartRow!);
             } else if (!topSQL && maxRowsForQuery > 0) {
-                // Platform doesn't use TOP (e.g., PG uses LIMIT at end of query)
+                // Platform doesn't use TOP (e.g., PG uses LIMIT at end of query).
+                // This also covers the usingKeyset case on PG: topSQL is set to empty by PG's
+                // BuildTopClause, so we fall here and emit LIMIT N at the end.
                 const limitSQL = this.BuildNonPaginatedLimitSQL(maxRowsForQuery);
                 if (limitSQL) viewSQL += ' ' + limitSQL;
             }
@@ -1605,7 +1835,10 @@ export abstract class GenericDatabaseProvider extends DatabaseProviderBase {
 
             for (let i = 0; i < params.length; i++) {
                 const item = params[i];
-                if (!item.cacheStatus) {
+                // Keyset queries bypass the cache entirely (per the AfterKey API contract):
+                // each call uses a different seek key, so cached entries would never be
+                // reusable. Route directly to standard execution path.
+                if (!item.cacheStatus || item.params.AfterKey) {
                     itemsWithoutCacheCheck.push({ index: i, item });
                     continue;
                 }

--- a/packages/GenericDatabaseProvider/src/__tests__/keyset-pagination.test.ts
+++ b/packages/GenericDatabaseProvider/src/__tests__/keyset-pagination.test.ts
@@ -1,0 +1,355 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// Mock sql-formatter (used by SqlLoggingSessionImpl, transitively imported)
+vi.mock('sql-formatter', () => ({ format: (sql: string) => sql }));
+
+// Mock encryption engine (transitively required)
+vi.mock('@memberjunction/encryption', () => ({
+    EncryptionEngine: {
+        get Instance() {
+            return {
+                Config: vi.fn(),
+                Encrypt: vi.fn(),
+                IsEncrypted: vi.fn().mockReturnValue(false),
+                GetKeyByID: vi.fn().mockReturnValue({ Marker: '$ENC$' }),
+            };
+        }
+    }
+}));
+
+import { GenericDatabaseProvider } from '../GenericDatabaseProvider';
+import {
+    AfterKeyNotSupportedError,
+    CompositeKey,
+    EntityFieldInfo,
+    EntityInfo,
+    IsKeysetPaginationOrderableType,
+    KEYSET_PAGINATION_ORDERABLE_PK_TYPES,
+    RunViewParams,
+    SaveSQLResult,
+    DeleteSQLResult,
+} from '@memberjunction/core';
+
+/**
+ * Concrete test subclass — only implements the bare minimum needed to call
+ * BuildKeysetSeekClause + formatKeysetSeekValue. We aren't running real queries.
+ */
+class TestProvider extends GenericDatabaseProvider {
+    private static readonly _uuidPattern = /^\s*(gen_random_uuid|uuid_generate_v4)\s*\(\s*\)\s*$/i;
+    private static readonly _defaultPattern = /^\s*(now|current_timestamp)\s*\(\s*\)\s*$/i;
+
+    protected get UUIDFunctionPattern(): RegExp { return TestProvider._uuidPattern; }
+    protected get DBDefaultFunctionPattern(): RegExp { return TestProvider._defaultPattern; }
+
+    public QuoteIdentifier(name: string): string { return `[${name}]`; } // SQL Server style for clarity
+    public QuoteSchemaAndView(schema: string, obj: string): string { return `[${schema}].[${obj}]`; }
+    protected BuildChildDiscoverySQL(): string { return ''; }
+    protected BuildHardLinkDependencySQL(): string { return ''; }
+    protected BuildSoftLinkDependencySQL(): string { return ''; }
+    protected async GenerateSaveSQL(): Promise<SaveSQLResult> { return { fullSQL: '' }; }
+    protected GenerateDeleteSQL(): DeleteSQLResult { return { fullSQL: '' }; }
+    protected BuildRecordChangeSQL(): { sql: string; parameters?: unknown[] } | null { return null; }
+    protected BuildSiblingRecordChangeSQL(): string { return ''; }
+    protected BuildPaginationSQL(maxRows: number, startRow: number): string {
+        return `OFFSET ${startRow} ROWS FETCH NEXT ${maxRows} ROWS ONLY`;
+    }
+    async BeginTransaction(): Promise<void> {}
+    async CommitTransaction(): Promise<void> {}
+    async RollbackTransaction(): Promise<void> {}
+
+    // Test wrappers
+    public testBuildKeysetSeekClause(entityInfo: EntityInfo, params: RunViewParams) {
+        return this.BuildKeysetSeekClause(entityInfo, params);
+    }
+    public testFormatKeysetSeekValue(value: unknown, sqlType: string): string {
+        return this.formatKeysetSeekValue(value, sqlType);
+    }
+}
+
+// Helper: build a minimal EntityInfo with one or more PK columns
+function makeEntity(name: string, pkColumns: Array<{ name: string; type: string }>): EntityInfo {
+    const fields: EntityFieldInfo[] = pkColumns.map((pk, i) => ({
+        Name: pk.name,
+        Type: pk.type,
+        IsPrimaryKey: true,
+        Sequence: i,
+    } as EntityFieldInfo));
+    return {
+        Name: name,
+        SchemaName: 'test',
+        BaseView: `vw${name}`,
+        Fields: fields,
+        PrimaryKeys: fields,
+        FirstPrimaryKey: fields[0],
+    } as EntityInfo;
+}
+
+describe('Keyset (AfterKey) pagination', () => {
+    let provider: TestProvider;
+
+    beforeEach(() => {
+        provider = new TestProvider();
+    });
+
+    describe('IsKeysetPaginationOrderableType', () => {
+        it('accepts uniqueidentifier', () => {
+            expect(IsKeysetPaginationOrderableType('uniqueidentifier')).toBe(true);
+        });
+        it('accepts uuid (PG)', () => {
+            expect(IsKeysetPaginationOrderableType('uuid')).toBe(true);
+        });
+        it('accepts numeric types', () => {
+            expect(IsKeysetPaginationOrderableType('int')).toBe(true);
+            expect(IsKeysetPaginationOrderableType('bigint')).toBe(true);
+            expect(IsKeysetPaginationOrderableType('decimal')).toBe(true);
+        });
+        it('accepts string types', () => {
+            expect(IsKeysetPaginationOrderableType('nvarchar')).toBe(true);
+            expect(IsKeysetPaginationOrderableType('varchar')).toBe(true);
+        });
+        it('strips type parameterization', () => {
+            expect(IsKeysetPaginationOrderableType('nvarchar(255)')).toBe(true);
+            expect(IsKeysetPaginationOrderableType('decimal(10, 2)')).toBe(true);
+        });
+        it('is case-insensitive', () => {
+            expect(IsKeysetPaginationOrderableType('UNIQUEIDENTIFIER')).toBe(true);
+            expect(IsKeysetPaginationOrderableType('Int')).toBe(true);
+        });
+        it('rejects exotic types', () => {
+            expect(IsKeysetPaginationOrderableType('xml')).toBe(false);
+            expect(IsKeysetPaginationOrderableType('sql_variant')).toBe(false);
+            expect(IsKeysetPaginationOrderableType('varbinary')).toBe(false);
+        });
+        it('rejects empty / null / undefined', () => {
+            expect(IsKeysetPaginationOrderableType('')).toBe(false);
+            expect(IsKeysetPaginationOrderableType(null)).toBe(false);
+            expect(IsKeysetPaginationOrderableType(undefined)).toBe(false);
+        });
+        it('exports the allowlist as a readonly array', () => {
+            expect(KEYSET_PAGINATION_ORDERABLE_PK_TYPES.length).toBeGreaterThan(10);
+            expect(KEYSET_PAGINATION_ORDERABLE_PK_TYPES).toContain('uniqueidentifier');
+        });
+    });
+
+    describe('BuildKeysetSeekClause — happy paths', () => {
+        it('emits `[ID] > value` for a uniqueidentifier PK with ASC ordering (default)', () => {
+            const entity = makeEntity('Users', [{ name: 'ID', type: 'uniqueidentifier' }]);
+            const afterKey = CompositeKey.FromID('a1b2c3d4-1234-5678-9abc-def012345678');
+            const result = provider.testBuildKeysetSeekClause(entity, {
+                EntityName: 'Users',
+                MaxRows: 100,
+                AfterKey: afterKey,
+            });
+            expect(result.seekPredicate).toBe(`[ID] > 'a1b2c3d4-1234-5678-9abc-def012345678'`);
+            expect(result.direction).toBe('ASC');
+            expect(result.pkColumnName).toBe('[ID]');
+        });
+
+        it('emits `[ID] < value` when OrderBy specifies DESC', () => {
+            const entity = makeEntity('Users', [{ name: 'ID', type: 'uniqueidentifier' }]);
+            const afterKey = CompositeKey.FromID('a1b2c3d4-1234-5678-9abc-def012345678');
+            const result = provider.testBuildKeysetSeekClause(entity, {
+                EntityName: 'Users',
+                MaxRows: 100,
+                OrderBy: 'ID DESC',
+                AfterKey: afterKey,
+            });
+            expect(result.seekPredicate).toContain('<');
+            expect(result.direction).toBe('DESC');
+        });
+
+        it('accepts OrderBy with quoting variations', () => {
+            const entity = makeEntity('Users', [{ name: 'ID', type: 'uniqueidentifier' }]);
+            const afterKey = CompositeKey.FromID('a1b2c3d4-1234-5678-9abc-def012345678');
+            // Brackets, quotes, backticks
+            for (const ob of ['[ID]', '"ID"', '`ID`', 'ID', 'ID ASC']) {
+                const result = provider.testBuildKeysetSeekClause(entity, {
+                    EntityName: 'Users',
+                    MaxRows: 100,
+                    OrderBy: ob,
+                    AfterKey: afterKey,
+                });
+                expect(result.direction).toBe('ASC');
+            }
+        });
+
+        it('works with int PK', () => {
+            const entity = makeEntity('Things', [{ name: 'ThingID', type: 'int' }]);
+            const afterKey = CompositeKey.FromKeyValuePair('ThingID', 42);
+            const result = provider.testBuildKeysetSeekClause(entity, {
+                EntityName: 'Things',
+                MaxRows: 100,
+                AfterKey: afterKey,
+            });
+            expect(result.seekPredicate).toBe('[ThingID] > 42');
+        });
+
+        it('works with string PK and escapes single quotes', () => {
+            const entity = makeEntity('Things', [{ name: 'Code', type: 'nvarchar' }]);
+            const afterKey = CompositeKey.FromKeyValuePair('Code', "O'Brien");
+            const result = provider.testBuildKeysetSeekClause(entity, {
+                EntityName: 'Things',
+                MaxRows: 100,
+                AfterKey: afterKey,
+            });
+            expect(result.seekPredicate).toBe(`[Code] > 'O''Brien'`);
+        });
+    });
+
+    describe('BuildKeysetSeekClause — validation throws', () => {
+        it('throws CompositePK on entities with > 1 PK column', () => {
+            const entity = makeEntity('Link', [
+                { name: 'TenantID', type: 'uniqueidentifier' },
+                { name: 'RecordID', type: 'uniqueidentifier' },
+            ]);
+            const afterKey = CompositeKey.FromID('any');
+            expect(() => provider.testBuildKeysetSeekClause(entity, {
+                EntityName: 'Link', MaxRows: 100, AfterKey: afterKey,
+            })).toThrow(AfterKeyNotSupportedError);
+
+            try {
+                provider.testBuildKeysetSeekClause(entity, { EntityName: 'Link', MaxRows: 100, AfterKey: afterKey });
+            } catch (e) {
+                expect((e as AfterKeyNotSupportedError).Reason).toBe('CompositePK');
+            }
+        });
+
+        it('throws UnsupportedPKType on exotic PK types', () => {
+            const entity = makeEntity('Weird', [{ name: 'ID', type: 'xml' }]);
+            const afterKey = CompositeKey.FromID('any');
+            expect(() => provider.testBuildKeysetSeekClause(entity, {
+                EntityName: 'Weird', MaxRows: 100, AfterKey: afterKey,
+            })).toThrow(AfterKeyNotSupportedError);
+        });
+
+        it('throws StartRowConflict when AfterKey + StartRow > 0', () => {
+            const entity = makeEntity('Users', [{ name: 'ID', type: 'uniqueidentifier' }]);
+            const afterKey = CompositeKey.FromID('a1b2c3d4-1234-5678-9abc-def012345678');
+            expect(() => provider.testBuildKeysetSeekClause(entity, {
+                EntityName: 'Users',
+                MaxRows: 100,
+                StartRow: 100,
+                AfterKey: afterKey,
+            })).toThrow(/AfterKey cannot be combined with StartRow/);
+        });
+
+        it('permits AfterKey with StartRow: 0 (first-page semantics)', () => {
+            const entity = makeEntity('Users', [{ name: 'ID', type: 'uniqueidentifier' }]);
+            const afterKey = CompositeKey.FromID('a1b2c3d4-1234-5678-9abc-def012345678');
+            // Should not throw
+            const r = provider.testBuildKeysetSeekClause(entity, {
+                EntityName: 'Users',
+                MaxRows: 100,
+                StartRow: 0,
+                AfterKey: afterKey,
+            });
+            expect(r.seekPredicate).toBeTruthy();
+        });
+
+        it('throws AfterKeyShape on multi-pair CompositeKey', () => {
+            const entity = makeEntity('Users', [{ name: 'ID', type: 'uniqueidentifier' }]);
+            const afterKey = CompositeKey.FromKeyValuePairs([
+                { FieldName: 'ID', Value: 'a1b2c3d4-1234-5678-9abc-def012345678' },
+                { FieldName: 'Other', Value: 'extra' },
+            ]);
+            expect(() => provider.testBuildKeysetSeekClause(entity, {
+                EntityName: 'Users', MaxRows: 100, AfterKey: afterKey,
+            })).toThrow(/exactly one key/);
+        });
+
+        it('throws AfterKeyShape when key name does not match PK column', () => {
+            const entity = makeEntity('Users', [{ name: 'ID', type: 'uniqueidentifier' }]);
+            const afterKey = CompositeKey.FromKeyValuePair('NotID', 'a1b2c3d4-1234-5678-9abc-def012345678');
+            expect(() => provider.testBuildKeysetSeekClause(entity, {
+                EntityName: 'Users', MaxRows: 100, AfterKey: afterKey,
+            })).toThrow(/does not match/);
+        });
+
+        it('throws AfterKeyShape on null/empty value', () => {
+            const entity = makeEntity('Users', [{ name: 'ID', type: 'uniqueidentifier' }]);
+            const afterKey = CompositeKey.FromKeyValuePair('ID', '');
+            expect(() => provider.testBuildKeysetSeekClause(entity, {
+                EntityName: 'Users', MaxRows: 100, AfterKey: afterKey,
+            })).toThrow(/null\/empty/);
+        });
+
+        it('throws IncompatibleOrderBy when OrderBy references non-PK column', () => {
+            const entity = makeEntity('Users', [{ name: 'ID', type: 'uniqueidentifier' }]);
+            const afterKey = CompositeKey.FromID('a1b2c3d4-1234-5678-9abc-def012345678');
+            expect(() => provider.testBuildKeysetSeekClause(entity, {
+                EntityName: 'Users',
+                MaxRows: 100,
+                OrderBy: 'Name',
+                AfterKey: afterKey,
+            })).toThrow(/OrderBy must reference only the PK column/);
+        });
+
+        it('throws IncompatibleOrderBy when OrderBy has multiple columns', () => {
+            const entity = makeEntity('Users', [{ name: 'ID', type: 'uniqueidentifier' }]);
+            const afterKey = CompositeKey.FromID('a1b2c3d4-1234-5678-9abc-def012345678');
+            expect(() => provider.testBuildKeysetSeekClause(entity, {
+                EntityName: 'Users',
+                MaxRows: 100,
+                OrderBy: 'ID, Name',
+                AfterKey: afterKey,
+            })).toThrow(/OrderBy/);
+        });
+    });
+
+    describe('formatKeysetSeekValue', () => {
+        it('formats valid UUID with single quotes', () => {
+            expect(provider.testFormatKeysetSeekValue('a1b2c3d4-1234-5678-9abc-def012345678', 'uniqueidentifier'))
+                .toBe(`'a1b2c3d4-1234-5678-9abc-def012345678'`);
+        });
+
+        it('rejects malformed UUID', () => {
+            expect(() => provider.testFormatKeysetSeekValue('not-a-uuid', 'uniqueidentifier'))
+                .toThrow(/not a valid UUID/);
+        });
+
+        it('formats integers without quotes', () => {
+            expect(provider.testFormatKeysetSeekValue(42, 'int')).toBe('42');
+            expect(provider.testFormatKeysetSeekValue('42', 'int')).toBe('42');
+            expect(provider.testFormatKeysetSeekValue(-7, 'bigint')).toBe('-7');
+        });
+
+        it('rejects non-numeric values for numeric types', () => {
+            expect(() => provider.testFormatKeysetSeekValue('abc', 'int'))
+                .toThrow(/not a valid numeric/);
+        });
+
+        it('formats strings with single-quote escaping', () => {
+            expect(provider.testFormatKeysetSeekValue("O'Brien", 'nvarchar')).toBe(`'O''Brien'`);
+        });
+
+        it('rejects SQL injection patterns in string values', () => {
+            expect(() => provider.testFormatKeysetSeekValue("'; DROP TABLE Users--", 'nvarchar'))
+                .toThrow(/disallowed characters/);
+        });
+
+        it('formats date strings with quoting', () => {
+            const r = provider.testFormatKeysetSeekValue('2026-01-01T00:00:00Z', 'datetime');
+            expect(r).toBe(`'2026-01-01T00:00:00Z'`);
+        });
+
+        it('formats booleans as 0/1', () => {
+            expect(provider.testFormatKeysetSeekValue(true, 'bit')).toBe('1');
+            expect(provider.testFormatKeysetSeekValue(false, 'bit')).toBe('0');
+            expect(provider.testFormatKeysetSeekValue('1', 'bit')).toBe('1');
+        });
+    });
+
+    describe('AfterKeyNotSupportedError', () => {
+        it('stores the entity name and reason', () => {
+            const err = new AfterKeyNotSupportedError('Users', 'CompositePK', 'test message');
+            expect(err.name).toBe('AfterKeyNotSupportedError');
+            expect(err.EntityName).toBe('Users');
+            expect(err.Reason).toBe('CompositePK');
+            expect(err.message).toBe('test message');
+        });
+        it('is an instanceof Error', () => {
+            const err = new AfterKeyNotSupportedError('Users', 'CompositePK', 'test');
+            expect(err).toBeInstanceOf(Error);
+        });
+    });
+});

--- a/packages/GraphQLDataProvider/README.md
+++ b/packages/GraphQLDataProvider/README.md
@@ -176,6 +176,28 @@ async function getMultipleDatasets() {
   return results;
 }
 
+// Iterate through a large entity using keyset (seek) pagination
+// O(log N) per page, regardless of depth — ideal for background jobs and bulk processing
+async function iterateAllTaxReturns() {
+  let lastSeenKey: CompositeKey | undefined; // undefined => first page
+  while (true) {
+    const result = await dataProvider.RunView({
+      EntityName: 'Tax Returns',
+      ExtraFilter: 'AddressLine1 IS NOT NULL',
+      AfterKey: lastSeenKey,
+      MaxRows: 500,
+      ResultType: 'entity_object',
+    });
+    if (!result.Success || result.Results.length === 0) break;
+    for (const r of result.Results) { /* process */ }
+    if (result.Results.length < 500) break;
+    lastSeenKey = CompositeKey.FromID(result.Results[result.Results.length - 1].ID);
+  }
+}
+// AfterKey is forwarded through the GraphQL wire via CompositeKeyInputType.
+// See guides/KEYSET_PAGINATION_GUIDE.md for the full pattern, constraints,
+// and reference implementations.
+
 // Execute a report
 async function getSalesReport(reportId: string) {
   const params = {

--- a/packages/GraphQLDataProvider/src/graphQLDataProvider.ts
+++ b/packages/GraphQLDataProvider/src/graphQLDataProvider.ts
@@ -995,6 +995,11 @@ export class GraphQLDataProvider extends ProviderBase implements IEntityDataProv
                         innerParam.MaxRows = param.MaxRows;
                     if (param.StartRow !== undefined)
                         innerParam.StartRow = param.StartRow; // Add StartRow parameter
+                    if (param.AfterKey) {
+                        // Keyset (seek) pagination cursor. Server validates and throws
+                        // AfterKeyNotSupportedError on composite-PK / unsupported types.
+                        innerParam.AfterKey = { KeyValuePairs: param.AfterKey.KeyValuePairs };
+                    }
                     innerParam.ForceAuditLog = param.ForceAuditLog || false;
                     innerParam.ResultType = param.ResultType || 'simple';
                     if (param.AuditLogDescription && param.AuditLogDescription.length > 0){
@@ -1112,6 +1117,7 @@ export class GraphQLDataProvider extends ProviderBase implements IEntityDataProv
                     IgnoreMaxRows: item.params.IgnoreMaxRows || false,
                     MaxRows: item.params.MaxRows,
                     StartRow: item.params.StartRow,
+                    AfterKey: item.params.AfterKey ? { KeyValuePairs: item.params.AfterKey.KeyValuePairs } : null,
                     ForceAuditLog: item.params.ForceAuditLog || false,
                     AuditLogDescription: item.params.AuditLogDescription || '',
                     ResultType: item.params.ResultType || 'simple',

--- a/packages/MJCore/readme.md
+++ b/packages/MJCore/readme.md
@@ -555,6 +555,59 @@ const result = await rv.RunView<OrderEntity>({
 // Aggregate results are in result.AggregateResults[]
 ```
 
+#### Keyset (Seek) Pagination — `AfterKey`
+
+For background jobs and bulk processing that iterate through *all* records of a large entity, use `AfterKey` instead of `StartRow`. Keyset pagination stays **O(log N) per page** regardless of depth — `StartRow`/OFFSET pagination becomes progressively slower as the offset grows.
+
+```typescript
+import { CompositeKey } from '@memberjunction/core';
+
+let lastSeenKey: CompositeKey | undefined; // undefined => first page
+
+while (true) {
+    const result = await rv.RunView({
+        EntityName: 'Tax Returns',
+        ExtraFilter: 'AddressLine1 IS NOT NULL',
+        AfterKey: lastSeenKey,
+        MaxRows: 500,
+        ResultType: 'entity_object'
+    }, contextUser);
+
+    if (!result.Success || result.Results.length === 0) break;
+    for (const r of result.Results) { /* process */ }
+    if (result.Results.length < 500) break; // partial page = end of data
+
+    const last = result.Results[result.Results.length - 1];
+    lastSeenKey = CompositeKey.FromID(last.ID);
+}
+```
+
+**Constraints** (throw `AfterKeyNotSupportedError` on violation):
+- Entity must have a **single-column primary key** on a comparable type.
+- `OrderBy`, if set, must reference only the PK column (any `ASC`/`DESC` direction).
+- Cannot be combined with non-zero `StartRow`.
+
+Keyset queries automatically bypass the server cache (read + write) — each call uses a different seek key, so caching them is pure overhead.
+
+UI grid pagination (a few hundred pages of a few hundred rows) should stay on `StartRow` — keyset isn't necessary there. See **[KEYSET_PAGINATION_GUIDE.md](../../guides/KEYSET_PAGINATION_GUIDE.md)** for the full pattern, validation rules, and reference implementations.
+
+```typescript
+// Defensive: catch the framework's typed error if you want to fall back to OFFSET
+import { AfterKeyNotSupportedError } from '@memberjunction/core';
+
+try {
+    await rv.RunView({ EntityName: 'SomeEntity', AfterKey: key, MaxRows: 500 }, user);
+} catch (e) {
+    if (e instanceof AfterKeyNotSupportedError && e.Reason === 'CompositePK') {
+        // entity has composite PK — fall back to StartRow-based iteration
+    } else {
+        throw e;
+    }
+}
+```
+
+Helper: `IsKeysetPaginationOrderableType(sqlTypeName)` — returns true if a column type is acceptable as a keyset PK (essentially all standard SQL types; defensively rejects exotics like `xml`/`sql_variant`/`varbinary`).
+
 #### ResultType and Fields Optimization
 
 ```typescript
@@ -592,7 +645,8 @@ const countResult = await rv.RunView({
 | `Fields` | `string[]` | Field names to return (simple mode only) |
 | `UserSearchString` | `string` | User search term |
 | `MaxRows` | `number` | Maximum rows to return |
-| `StartRow` | `number` | Row offset for pagination |
+| `StartRow` | `number` | Row offset (OFFSET-based pagination). Use for UI grids. For deep iteration over large tables, prefer `AfterKey`. |
+| `AfterKey` | `CompositeKey` | Keyset (seek) pagination cursor — O(log N) per page regardless of depth. Requires single-column PK. Throws `AfterKeyNotSupportedError` on incompatible entities. See [KEYSET_PAGINATION_GUIDE.md](../../guides/KEYSET_PAGINATION_GUIDE.md). |
 | `ResultType` | `'simple' \| 'entity_object' \| 'count_only'` | Result format |
 | `IgnoreMaxRows` | `boolean` | Bypass entity MaxRows setting |
 | `SaveViewResults` | `boolean` | Store run results for future exclusion |

--- a/packages/MJCore/src/__tests__/runView.afterKey.test.ts
+++ b/packages/MJCore/src/__tests__/runView.afterKey.test.ts
@@ -1,0 +1,99 @@
+import { describe, it, expect } from 'vitest';
+import { CompositeKey } from '../generic/compositeKey';
+import {
+    AfterKeyNotSupportedError,
+    IsKeysetPaginationOrderableType,
+    KEYSET_PAGINATION_ORDERABLE_PK_TYPES,
+    RunViewParams,
+} from '../views/runView';
+
+describe('RunViewParams.AfterKey support', () => {
+    describe('AfterKeyNotSupportedError', () => {
+        it('exposes EntityName, Reason, and a sensible message', () => {
+            const err = new AfterKeyNotSupportedError('My Entity', 'CompositePK', 'because');
+            expect(err).toBeInstanceOf(Error);
+            expect(err.EntityName).toBe('My Entity');
+            expect(err.Reason).toBe('CompositePK');
+            expect(err.message).toBe('because');
+            expect(err.name).toBe('AfterKeyNotSupportedError');
+        });
+
+        it('supports all defined reason codes', () => {
+            const reasons = ['CompositePK', 'UnsupportedPKType', 'IncompatibleOrderBy', 'StartRowConflict', 'AfterKeyShape'] as const;
+            for (const r of reasons) {
+                const err = new AfterKeyNotSupportedError('E', r, 'msg');
+                expect(err.Reason).toBe(r);
+            }
+        });
+    });
+
+    describe('IsKeysetPaginationOrderableType', () => {
+        it('accepts standard PK types', () => {
+            for (const t of ['uniqueidentifier', 'uuid', 'int', 'bigint', 'nvarchar', 'datetime', 'date', 'bit']) {
+                expect(IsKeysetPaginationOrderableType(t)).toBe(true);
+            }
+        });
+
+        it('strips parameter-style suffixes', () => {
+            expect(IsKeysetPaginationOrderableType('nvarchar(255)')).toBe(true);
+            expect(IsKeysetPaginationOrderableType('decimal(18, 2)')).toBe(true);
+        });
+
+        it('is case-insensitive', () => {
+            expect(IsKeysetPaginationOrderableType('UNIQUEIDENTIFIER')).toBe(true);
+            expect(IsKeysetPaginationOrderableType('INT')).toBe(true);
+        });
+
+        it('rejects unsupported types', () => {
+            for (const t of ['xml', 'sql_variant', 'varbinary', '', null, undefined as unknown as string]) {
+                expect(IsKeysetPaginationOrderableType(t)).toBe(false);
+            }
+        });
+
+        it('exports the readonly allowlist', () => {
+            expect(Array.isArray(KEYSET_PAGINATION_ORDERABLE_PK_TYPES)).toBe(true);
+            expect(KEYSET_PAGINATION_ORDERABLE_PK_TYPES).toContain('uniqueidentifier');
+        });
+    });
+
+    describe('RunViewParams.Equals — AfterKey awareness', () => {
+        it('returns true when both params omit AfterKey', () => {
+            const a: RunViewParams = { EntityName: 'X', MaxRows: 100 };
+            const b: RunViewParams = { EntityName: 'X', MaxRows: 100 };
+            expect(RunViewParams.Equals(a, b)).toBe(true);
+        });
+
+        it('returns true when both params have identical AfterKey', () => {
+            const a: RunViewParams = {
+                EntityName: 'X', MaxRows: 100,
+                AfterKey: CompositeKey.FromID('a1b2c3d4-1234-5678-9abc-def012345678'),
+            };
+            const b: RunViewParams = {
+                EntityName: 'X', MaxRows: 100,
+                AfterKey: CompositeKey.FromID('a1b2c3d4-1234-5678-9abc-def012345678'),
+            };
+            expect(RunViewParams.Equals(a, b)).toBe(true);
+        });
+
+        it('returns false when AfterKey differs', () => {
+            const a: RunViewParams = {
+                EntityName: 'X', MaxRows: 100,
+                AfterKey: CompositeKey.FromID('a1b2c3d4-1234-5678-9abc-def012345678'),
+            };
+            const b: RunViewParams = {
+                EntityName: 'X', MaxRows: 100,
+                AfterKey: CompositeKey.FromID('b1b2c3d4-1234-5678-9abc-def012345678'),
+            };
+            expect(RunViewParams.Equals(a, b)).toBe(false);
+        });
+
+        it('returns false when only one side has AfterKey', () => {
+            const a: RunViewParams = {
+                EntityName: 'X', MaxRows: 100,
+                AfterKey: CompositeKey.FromID('a1b2c3d4-1234-5678-9abc-def012345678'),
+            };
+            const b: RunViewParams = { EntityName: 'X', MaxRows: 100 };
+            expect(RunViewParams.Equals(a, b)).toBe(false);
+        });
+    });
+});

--- a/packages/MJCore/src/generic/localCacheManager.ts
+++ b/packages/MJCore/src/generic/localCacheManager.ts
@@ -1226,6 +1226,14 @@ export class LocalCacheManager extends BaseSingleton<LocalCacheManager> {
     ): Promise<void> {
         if (!this._storageProvider || !this._config.enabled) return;
 
+        // Keyset (AfterKey) queries are inherently single-use — each call uses a different
+        // seek key, so a cached entry would never be reusable by a subsequent caller.
+        // Skip the cache write entirely to avoid polluting the cache with one-shot entries.
+        if (params.AfterKey) {
+            LogStatusEx({ message: `[CACHE-WRITE-GATE] Skipping cache write for keyset (AfterKey) query on "${params.EntityName}"`, verboseOnly: true });
+            return;
+        }
+
         // Short-circuit: if the entity has AllowCaching = false, do not write to the cache.
         // The invalidation path (HandleBaseEntityEvent line 552) already short-circuits for
         // these entities, so any entry we write here would never be invalidated and would

--- a/packages/MJCore/src/generic/providerBase.ts
+++ b/packages/MJCore/src/generic/providerBase.ts
@@ -484,7 +484,10 @@ export abstract class ProviderBase implements IMetadataProvider, IRunViewProvide
      * @returns The view results
      */
     public async RunView<T = any>(params: RunViewParams, contextUser?: UserInfo): Promise<RunViewResult<T>> {
-        if (this.TrustLocalCacheCompletely && !params.BypassCache) {
+        // Keyset (AfterKey) queries always bypass the server cache: each call uses a
+        // different seek key, so a cached entry would never be reusable. Treat them like
+        // explicit BypassCache=true requests.
+        if (this.TrustLocalCacheCompletely && !params.BypassCache && !params.AfterKey) {
             // Server-side: use direct Pre → Internal → Post pipeline.
             // Cache is kept in sync via BaseEntity events + Redis pub/sub,
             // so PreRunView cache hits are returned immediately with no DB round-trip.
@@ -1259,8 +1262,11 @@ export abstract class ProviderBase implements IMetadataProvider, IRunViewProvide
         // end-to-end — there's no cache-coherence concern to preserve.
         const entity = params.EntityName ? this.EntityByName(params.EntityName) : null;
         const entityCacheAllowed = this.IsServerCacheAllowedForEntity(params);
+        // Keyset (AfterKey) queries are inherently single-use, so we never read from or
+        // write to the cache for them. See RunViewParams.AfterKey JSDoc for rationale.
         const willCache =
             !params.BypassCache &&
+            !params.AfterKey &&
             (params.CacheLocal || this.TrustLocalCacheCompletely) &&
             entityCacheAllowed;
         if (entity && willCache) {
@@ -1400,8 +1406,10 @@ export abstract class ProviderBase implements IMetadataProvider, IRunViewProvide
             // end-to-end — there's no cache-coherence concern to preserve.
             const batchEntity = param.EntityName ? this.EntityByName(param.EntityName) : null;
             const batchEntityCacheAllowed = this.IsServerCacheAllowedForEntity(param);
+            // Keyset (AfterKey) queries are inherently single-use; never use the cache for them.
             const batchWillCache =
                 !param.BypassCache &&
+                !param.AfterKey &&
                 (param.CacheLocal || this.TrustLocalCacheCompletely) &&
                 batchEntityCacheAllowed;
             if (batchEntity && batchWillCache) {

--- a/packages/MJCore/src/views/runView.ts
+++ b/packages/MJCore/src/views/runView.ts
@@ -3,7 +3,73 @@ import { IMetadataProvider, IRunViewProvider, RunViewResult } from '../generic/i
 import { UserInfo } from '../generic/securityInfo';
 import { BaseEntity } from '../generic/baseEntity';
 import { PlatformSQL, IsPlatformSQL } from '../generic/platformSQL';
+import { CompositeKey } from '../generic/compositeKey';
 import type { CacheChangedEvent } from '../generic/localCacheManager';
+
+/**
+ * Reason codes for {@link AfterKeyNotSupportedError}. Use these to make caller
+ * fallback logic explicit (e.g., "if reason is CompositePK, fall back to OFFSET pagination").
+ */
+export type AfterKeyNotSupportedReason =
+    | 'CompositePK'             // Entity has > 1 PK column
+    | 'UnsupportedPKType'       // PK column type is not in the orderable allowlist
+    | 'IncompatibleOrderBy'     // OrderBy references columns other than the PK
+    | 'StartRowConflict'        // AfterKey was combined with StartRow
+    | 'AfterKeyShape';          // AfterKey CompositeKey doesn't match the entity's PK shape
+
+/**
+ * Thrown by {@link RunView} / RunViews when `AfterKey` is provided but cannot be honored.
+ *
+ * See the keyset-pagination guide for caller patterns. The most common case is `CompositePK`:
+ * an entity with a composite primary key cannot use keyset pagination in v1 — callers should
+ * either iterate with OFFSET-based `StartRow` (acceptable for small result sets) or restructure
+ * the workload around a single-PK projection.
+ *
+ * @since v5.x
+ */
+export class AfterKeyNotSupportedError extends Error {
+    constructor(
+        public readonly EntityName: string,
+        public readonly Reason: AfterKeyNotSupportedReason,
+        message: string
+    ) {
+        super(message);
+        this.name = 'AfterKeyNotSupportedError';
+    }
+}
+
+/**
+ * Orderable SQL types that can be used as the primary key column for keyset pagination.
+ *
+ * Excludes types where `WHERE pk > @last` is either unsupported or semantically meaningless
+ * (`xml`, `sql_variant`, large binary types, etc.). In practice every reasonable primary key
+ * type is on this list — this is defensive against exotic future PKs, not a real constraint
+ * for any standard MJ entity.
+ *
+ * Case-insensitive comparison via the helper {@link IsKeysetPaginationOrderableType}.
+ */
+export const KEYSET_PAGINATION_ORDERABLE_PK_TYPES: ReadonlyArray<string> = [
+    'uniqueidentifier',
+    'int', 'bigint', 'smallint', 'tinyint',
+    'decimal', 'numeric', 'money', 'smallmoney',
+    'float', 'real', 'double precision',
+    'char', 'varchar', 'nchar', 'nvarchar', 'text', 'ntext',
+    'date', 'datetime', 'datetime2', 'datetimeoffset', 'smalldatetime', 'time',
+    'bit',
+    // PostgreSQL native names that may appear in EntityField.Type when running on PG
+    'uuid', 'integer', 'bigserial', 'serial', 'numeric', 'character varying', 'character', 'timestamp', 'timestamp with time zone', 'timestamp without time zone', 'boolean'
+];
+
+/**
+ * Returns true if the given SQL type name is acceptable as a keyset-pagination PK column.
+ * Comparison is case-insensitive and trims any precision/scale parens (e.g. `nvarchar(255)` → `nvarchar`).
+ */
+export function IsKeysetPaginationOrderableType(sqlTypeName: string | null | undefined): boolean {
+    if (!sqlTypeName) return false;
+    // Strip parameterization like "nvarchar(255)" or "decimal(10, 2)"
+    const normalized = sqlTypeName.replace(/\s*\([^)]*\)\s*$/, '').trim().toLowerCase();
+    return KEYSET_PAGINATION_ORDERABLE_PK_TYPES.includes(normalized);
+}
 
 /**
  * Single aggregate expression to compute alongside the main view query.
@@ -123,8 +189,67 @@ export class RunViewParams {
     MaxRows?: number;
     /**
      * optional - if provided, this value will be used to offset the rows returned.
+     *
+     * **Note on deep pagination**: `StartRow` is implemented via SQL `OFFSET` semantics,
+     * which is O(N) in the offset value — early pages are fine, but deep pages (offset
+     * in the tens or hundreds of thousands) get progressively slower because the server
+     * has to enumerate and discard the skipped rows.
+     *
+     * For background jobs and bulk processing that iterate through entire tables, prefer
+     * {@link AfterKey} (keyset / seek pagination), which stays O(log N) regardless of depth.
+     * UI grid pagination (a few hundred pages at most) is fine to keep on `StartRow`.
      */
     StartRow?: number;
+    /**
+     * optional - keyset (a.k.a. "seek") pagination using the entity's primary key.
+     *
+     * When set, the query returns the next page of records **after** the given PK value,
+     * ordered by the PK column. Unlike `StartRow` (which uses `OFFSET` and is O(N) in
+     * the offset), keyset pagination stays O(log N) regardless of how deep you go —
+     * making it the right choice for jobs that walk entire large tables.
+     *
+     * @example Single-column PK (the only shape supported in v1)
+     * ```typescript
+     * // Page 1
+     * let result = await rv.RunView({
+     *     EntityName: 'Tax Returns',
+     *     ExtraFilter: 'AddressLine1 IS NOT NULL',
+     *     MaxRows: 500,
+     *     ResultType: 'entity_object'
+     * }, contextUser);
+     *
+     * // Page 2+
+     * while (result.Results.length === 500) {
+     *     const lastId = result.Results[result.Results.length - 1].ID;
+     *     result = await rv.RunView({
+     *         EntityName: 'Tax Returns',
+     *         ExtraFilter: 'AddressLine1 IS NOT NULL',
+     *         AfterKey: CompositeKey.FromID(lastId),
+     *         MaxRows: 500,
+     *         ResultType: 'entity_object'
+     *     }, contextUser);
+     * }
+     * ```
+     *
+     * **Constraints (throw {@link AfterKeyNotSupportedError} when violated):**
+     * - Entity must have a single-column primary key (use `RunViewParams.StartRow`
+     *   for composite-PK entities).
+     * - The PK column type must be in {@link KEYSET_PAGINATION_ORDERABLE_PK_TYPES}
+     *   (essentially all standard SQL types).
+     * - `OrderBy`, if set, must reference only the PK column (any `ASC`/`DESC` direction).
+     * - Cannot be combined with `StartRow`.
+     *
+     * **Caching behavior**: When `AfterKey` is present, the query bypasses the server
+     * cache (both read and write) — keyset queries are inherently single-use (each call
+     * uses a different seek key), so caching them is pure overhead.
+     *
+     * **End-of-data signal**: When a page returns fewer rows than `MaxRows`, you've
+     * reached the end of the result set.
+     *
+     * @see {@link AfterKeyNotSupportedError}
+     * @since v5.x
+     */
+    AfterKey?: CompositeKey;
     /**
      * optional - if set to true, the view run will ALWAYS be logged to the Audit Log, regardless of the entity's property settings for logging view runs.
      */
@@ -261,6 +386,7 @@ export class RunViewParams {
         if (a.IgnoreMaxRows !== b.IgnoreMaxRows) return false;
         if (a.MaxRows !== b.MaxRows) return false;
         if (a.StartRow !== b.StartRow) return false;
+        if (!RunViewParams.afterKeyEqual(a.AfterKey, b.AfterKey)) return false;
         if (a.ForceAuditLog !== b.ForceAuditLog) return false;
         if (a.AuditLogDescription !== b.AuditLogDescription) return false;
         if (a.ResultType !== b.ResultType) return false;
@@ -288,6 +414,23 @@ export class RunViewParams {
         if (a.length !== b.length) return false;
         for (let i = 0; i < a.length; i++) {
             if (a[i] !== b[i]) return false;
+        }
+        return true;
+    }
+
+    /**
+     * Helper method to compare two AfterKey (CompositeKey) values for equality.
+     * Two AfterKeys are equal if they contain the same key/value pairs (order-insensitive).
+     */
+    private static afterKeyEqual(a: CompositeKey | undefined, b: CompositeKey | undefined): boolean {
+        if (a === b) return true;
+        if (!a || !b) return false;
+        const aPairs = a.KeyValuePairs ?? [];
+        const bPairs = b.KeyValuePairs ?? [];
+        if (aPairs.length !== bPairs.length) return false;
+        for (const pair of aPairs) {
+            const match = bPairs.find(p => p.FieldName === pair.FieldName);
+            if (!match || match.Value !== pair.Value) return false;
         }
         return true;
     }

--- a/packages/MJServer/README.md
+++ b/packages/MJServer/README.md
@@ -415,7 +415,7 @@ The server includes resolvers for the following domains:
 | Resolver | Operations |
 |----------|------------|
 | `EntityResolver` | CRUD operations for all entities |
-| `RunViewResolver` | RunView by ID, name, or dynamic entity |
+| `RunViewResolver` | RunView by ID, name, or dynamic entity. All four input types (`RunViewByIDInput`, `RunViewByNameInput`, `RunDynamicViewInput`, `RunViewGenericInput`) expose an optional `AfterKey: CompositeKeyInputType` for keyset (seek) pagination — see [KEYSET_PAGINATION_GUIDE.md](../../guides/KEYSET_PAGINATION_GUIDE.md). |
 | `RunAIPromptResolver` | Execute AI prompts, simple prompts, text embeddings |
 | `RunAIAgentResolver` | Execute AI agents with session and streaming support |
 | `ActionResolver` | Execute MJ Actions |
@@ -482,6 +482,7 @@ All built-in resolvers extend `ResolverBase`, which provides:
 | `RunViewByNameGeneric()` | Execute a saved view by name |
 | `RunDynamicViewGeneric()` | Execute an ad-hoc view on an entity |
 | `RunViewsGeneric()` | Batch-execute multiple views |
+| `RunViewGenericInternal()` | Shared internal: extracts and forwards all RunView params including `AfterKey` (keyset pagination — see [KEYSET_PAGINATION_GUIDE.md](../../guides/KEYSET_PAGINATION_GUIDE.md)) |
 | `CheckUserReadPermissions()` | Validate entity-level read access |
 | `CheckAPIKeyScopeAuthorization()` | Validate API key scope |
 | `MapFieldNamesToCodeNames()` | Map field names for GraphQL transport |

--- a/packages/MJServer/src/generic/ResolverBase.ts
+++ b/packages/MJServer/src/generic/ResolverBase.ts
@@ -356,7 +356,10 @@ export class ResolverBase {
           userPayload,
           viewInput.MaxRows,
           viewInput.StartRow,
-          viewInput.Aggregates
+          viewInput.Aggregates,
+          viewInput.AfterKey
+            ? CompositeKey.FromKeyValuePairs((viewInput.AfterKey as { KeyValuePairs: { FieldName: string; Value: string }[] }).KeyValuePairs)
+            : undefined
         );
       }
       else {
@@ -505,6 +508,9 @@ export class ResolverBase {
           ignoreMaxRows: viewInput.IgnoreMaxRows,
           maxRows: viewInput.MaxRows,
           startRow: viewInput.StartRow,
+          afterKey: viewInput.AfterKey
+            ? CompositeKey.FromKeyValuePairs((viewInput.AfterKey as { KeyValuePairs: { FieldName: string; Value: string }[] }).KeyValuePairs)
+            : undefined,
           excludeDataFromAllPriorViewRuns: viewInput.EntityName ? false : viewInput.ExcludeDataFromAllPriorViewRuns,
           forceAuditLog: viewInput.ForceAuditLog,
           auditLogDescription: viewInput.AuditLogDescription,
@@ -686,7 +692,8 @@ export class ResolverBase {
     userPayload: UserPayload | null,
     maxRows: number | undefined,
     startRow: number | undefined,
-    aggregates?: AggregateExpression[]
+    aggregates?: AggregateExpression[],
+    afterKey?: CompositeKey
   ) {
     try {
       if (!viewInfo || !userPayload) return null;
@@ -745,6 +752,7 @@ export class ResolverBase {
           IgnoreMaxRows: ignoreMaxRows,
           MaxRows: maxRows,
           StartRow: startRow,
+          AfterKey: afterKey,
           ForceAuditLog: forceAuditLog,
           AuditLogDescription: auditLogDescription,
           ResultType: rt,
@@ -857,6 +865,7 @@ export class ResolverBase {
           IgnoreMaxRows: param.ignoreMaxRows,
           MaxRows: param.maxRows,
           StartRow: param.startRow,
+          AfterKey: param.afterKey,
           ForceAuditLog: param.forceAuditLog,
           AuditLogDescription: param.auditLogDescription,
           ResultType: rt,

--- a/packages/MJServer/src/generic/RunViewResolver.ts
+++ b/packages/MJServer/src/generic/RunViewResolver.ts
@@ -1,12 +1,12 @@
 import { Arg, Ctx, Field, InputType, Int, ObjectType, PubSubEngine, Query, Resolver } from 'type-graphql';
 import { AppContext } from '../types.js';
 import { ResolverBase } from './ResolverBase.js';
-import { LogError, LogStatus, EntityInfo, RunViewWithCacheCheckResult, RunViewsWithCacheCheckResponse, RunViewWithCacheCheckParams, AggregateResult } from '@memberjunction/core';
+import { LogError, LogStatus, EntityInfo, RunViewWithCacheCheckResult, RunViewsWithCacheCheckResponse, RunViewWithCacheCheckParams, AggregateResult, CompositeKey } from '@memberjunction/core';
 import { UUIDsEqual } from '@memberjunction/global';
 import { RequireSystemUser } from '../directives/RequireSystemUser.js';
 import { GetReadOnlyProvider } from '../util.js';
 import { MJUserViewEntityExtended } from '@memberjunction/core-entities';
-import { KeyValuePairOutputType } from './KeyInputOutputTypes.js';
+import { CompositeKeyInputType, KeyValuePairOutputType } from './KeyInputOutputTypes.js';
 import { SQLServerDataProvider } from '@memberjunction/sqlserver-dataprovider';
 
 /********************************************************************************
@@ -159,6 +159,12 @@ export class RunViewByIDInput {
   })
   StartRow?: number;
 
+  @Field(() => CompositeKeyInputType, {
+    nullable: true,
+    description: 'Keyset (seek) pagination cursor. When provided, returns the next page of records after the given PK value, ordered by the PK column. Requires a single-column PK on the entity. Cannot be combined with StartRow.',
+  })
+  AfterKey?: CompositeKeyInputType;
+
   @Field(() => [AggregateExpressionInput], {
     nullable: true,
     description: 'Optional aggregate expressions to calculate on the full result set (e.g., SUM, COUNT, AVG). Results are returned in AggregateResults.',
@@ -260,6 +266,12 @@ export class RunViewByNameInput {
   })
   StartRow?: number;
 
+  @Field(() => CompositeKeyInputType, {
+    nullable: true,
+    description: 'Keyset (seek) pagination cursor. When provided, returns the next page of records after the given PK value, ordered by the PK column. Requires a single-column PK on the entity. Cannot be combined with StartRow.',
+  })
+  AfterKey?: CompositeKeyInputType;
+
   @Field(() => [AggregateExpressionInput], {
     nullable: true,
     description: 'Optional aggregate expressions to calculate on the full result set (e.g., SUM, COUNT, AVG). Results are returned in AggregateResults.',
@@ -346,6 +358,12 @@ export class RunDynamicViewInput {
     description: 'If a value > 0 is provided, this value will be used to offset the rows returned.',
   })
   StartRow?: number;
+
+  @Field(() => CompositeKeyInputType, {
+    nullable: true,
+    description: 'Keyset (seek) pagination cursor. When provided, returns the next page of records after the given PK value, ordered by the PK column. Requires a single-column PK on the entity. Cannot be combined with StartRow.',
+  })
+  AfterKey?: CompositeKeyInputType;
 
   @Field(() => [AggregateExpressionInput], {
     nullable: true,
@@ -462,6 +480,12 @@ export class RunViewGenericInput {
     description: 'If a value > 0 is provided, this value will be used to offset the rows returned.',
   })
   StartRow?: number;
+
+  @Field(() => CompositeKeyInputType, {
+    nullable: true,
+    description: 'Keyset (seek) pagination cursor. When provided, returns the next page of records after the given PK value, ordered by the PK column. Requires a single-column PK on the entity. Cannot be combined with StartRow.',
+  })
+  AfterKey?: CompositeKeyInputType;
 
   @Field(() => [AggregateExpressionInput], {
     nullable: true,
@@ -1017,6 +1041,9 @@ export class RunViewResolver extends ResolverBase {
           AuditLogDescription: item.params.AuditLogDescription,
           ResultType: (item.params.ResultType || 'simple') as 'simple' | 'entity_object' | 'count_only',
           StartRow: item.params.StartRow,
+          AfterKey: item.params.AfterKey
+            ? CompositeKey.FromKeyValuePairs(item.params.AfterKey.KeyValuePairs)
+            : undefined,
         },
         cacheStatus: item.cacheStatus ? {
           maxUpdatedAt: item.cacheStatus.maxUpdatedAt,

--- a/packages/MJServer/src/types.ts
+++ b/packages/MJServer/src/types.ts
@@ -1,4 +1,4 @@
-import { AggregateExpression, DatabaseProviderBase, UserInfo } from '@memberjunction/core';
+import { AggregateExpression, CompositeKey, DatabaseProviderBase, UserInfo } from '@memberjunction/core';
 import { MJUserViewEntityExtended } from '@memberjunction/core-entities';
 import { GraphQLSchema } from 'graphql';
 import sql from 'mssql';
@@ -90,6 +90,11 @@ export type RunViewGenericParams = {
   ignoreMaxRows?: boolean;
   maxRows?: number;
   startRow?: number;
+  /**
+   * Keyset (seek) pagination cursor — see {@link RunViewParams.AfterKey}.
+   * When set, the entity must have a single-column PK; throws AfterKeyNotSupportedError otherwise.
+   */
+  afterKey?: CompositeKey;
   excludeDataFromAllPriorViewRuns?: boolean;
   forceAuditLog?: boolean;
   auditLogDescription?: string;

--- a/packages/PostgreSQLDataProvider/README.md
+++ b/packages/PostgreSQLDataProvider/README.md
@@ -34,7 +34,7 @@ CodeGenDatabaseProvider (@memberjunction/codegen-lib)
 
 | File | Purpose |
 |------|---------|
-| `PostgreSQLDataProvider.ts` | Main provider: CRUD, queries, view execution, dataset handling, caching |
+| `PostgreSQLDataProvider.ts` | Main provider: CRUD, queries, view execution (supports both OFFSET `StartRow` and keyset `AfterKey` pagination — see [KEYSET_PAGINATION_GUIDE.md](../../guides/KEYSET_PAGINATION_GUIDE.md)), dataset handling, caching |
 | `pgConnectionManager.ts` | Connection pool lifecycle with `pg.Pool`, shared pool support |
 | `queryParameterProcessor.ts` | Boolean, date, UUID, number, and binary type conversion |
 | `types.ts` | `PostgreSQLProviderConfigData` and `PostgreSQLProviderConfigOptions` interfaces |

--- a/packages/SQLServerDataProvider/README.md
+++ b/packages/SQLServerDataProvider/README.md
@@ -69,7 +69,7 @@ graph TB
 
 - **Full CRUD Operations** -- Create, Read, Update, Delete for all MemberJunction entities via generated stored procedures
 - **Transaction Support** -- Both transaction groups (multi-entity atomic operations) and instance-level transactions with nested savepoint support
-- **View Execution** -- Run database views with filtering, sorting, pagination, and aggregation
+- **View Execution** -- Run database views with filtering, sorting, pagination (both OFFSET-based `StartRow` and keyset-based `AfterKey` — see [KEYSET_PAGINATION_GUIDE.md](../../guides/KEYSET_PAGINATION_GUIDE.md)), and aggregation
 - **Report and Query Execution** -- Execute reports and parameterized queries with Nunjucks template processing
 - **Connection Pooling** -- Efficient shared connection pool management with configurable sizing
 - **SQL Logging** -- Real-time SQL statement capture to files with session management, pattern filtering, and Flyway migration formatting (inherited from `GenericDatabaseProvider`)

--- a/plans/keyset-pagination.md
+++ b/plans/keyset-pagination.md
@@ -1,0 +1,333 @@
+# Keyset (Seek) Pagination for RunView
+
+**Status:** Draft for review
+**Author:** Claude (paired with Amith)
+**Date:** 2026-05-13
+
+## 1. Why
+
+MJ's `RunView` pagination uses OFFSET/FETCH in SQL Server and LIMIT/OFFSET in PostgreSQL ([GenericDatabaseProvider.ts:1182](../packages/GenericDatabaseProvider/src/GenericDatabaseProvider.ts#L1182), [SQLServerDataProvider.ts:576](../packages/SQLServerDataProvider/src/SQLServerDataProvider.ts#L576), [PostgreSQLDataProvider.ts:562](../packages/PostgreSQLDataProvider/src/PostgreSQLDataProvider.ts#L562)). This works fine for UI grids paging through a few hundred rows, but degrades badly when callers iterate large tables:
+
+| `StartRow` (vwTaxReturns, 2.6M rows, local SSD warm cache) | Elapsed |
+|---|---|
+| 0 (page 0) | 6 ms |
+| 500 (page 1) | 0 ms |
+| 450,000 | 54 ms |
+| 2,000,000 | **773 ms** |
+
+In production this is much worse — cold-cache pages hit physical I/O and the same query runs 37k times/day with avg 2.2 sec each. Audited callers that paginate deeply through large entities (i.e. abuse OFFSET as a "give me all of it, in chunks" mechanism):
+
+- `packages/Actions/CoreActions/src/custom/geo/scheduled-geocoding.action.ts:221` — iterates every entity with `SupportsGeoCoding`, in pages of 500
+- `packages/ExternalChangeDetection/src/ChangeDetector.ts:292` — paginates entity record sets for change detection
+- `packages/AI/Vectors/Core/src/models/VectorBase.ts:68` — vectorization sync paginates source records
+- (likely) duplicate detection, content autotag, archive runs — audit confirms during implementation
+
+Live geocoding-on-save already runs inline in `GenericDatabaseProvider.OnSaveCompleted` ([line 582-588](../packages/GenericDatabaseProvider/src/GenericDatabaseProvider.ts#L582-L588)), so the scheduled job is only a backfill safety net — it doesn't need to be aggressive, but it shouldn't be *broken* either.
+
+The fix is **keyset (seek) pagination**: instead of `OFFSET N`, the caller passes "the key of the last row I saw" and the query becomes `WHERE pk > @lastSeen ORDER BY pk LIMIT N`. Every page is O(log n) regardless of depth.
+
+## 2. Design decisions
+
+### 2.1 Scope: single-column PK only, throw on composite
+
+Keyset paging across composite PKs requires expanded boolean clauses on SQL Server (no native row-value comparison) and tight coordination between OrderBy and the AfterKey shape. Most MJ entities have a single-column PK (overwhelmingly `uniqueidentifier`), so the simpler API serves the common case cleanly. Callers needing keyset on composite PKs have two options: refactor the entity, or use raw SQL via `RunQuery`.
+
+**Validation rule:** When `AfterKey` is present, throw `AfterKeyNotSupportedError` if:
+- The entity has more than one PK column, OR
+- The single PK column's `Type` is not in the orderable allowlist (see §2.3), OR
+- The `OrderBy` is set to something other than the PK column (we don't try to keyset on arbitrary orderings — see §2.4).
+
+### 2.2 Use `CompositeKey` as the parameter type
+
+`CompositeKey` is MJ's canonical PK representation ([packages/MJCore/src/generic/compositeKey.ts:339](../packages/MJCore/src/generic/compositeKey.ts#L339)). It already has `FromID(value)` for the single-column case and round-trips cleanly through GraphQL (it's the same shape used for entity loads, deletes, etc.). Even though we only accept single-key form initially, using `CompositeKey` keeps the door open for future composite-PK support without an API break.
+
+```typescript
+// New RunViewParams field
+AfterKey?: CompositeKey;
+```
+
+### 2.3 Orderable type allowlist
+
+All native SQL types that are sane PKs are orderable. We allowlist defensively rather than blacklist:
+
+```
+uniqueidentifier, int, bigint, smallint, tinyint, decimal, numeric, money, smallmoney,
+float, real, char, varchar, nchar, nvarchar, date, datetime, datetime2, datetimeoffset,
+smalldatetime, time
+```
+
+Anything outside this set (e.g. `xml`, `sql_variant`, `varbinary`) throws. This is essentially a no-op in practice for real MJ entities but protects future maintainability.
+
+### 2.4 OrderBy interaction
+
+When `AfterKey` is present:
+- If the caller passes `OrderBy`, it must be exactly the PK column (with optional `ASC`/`DESC`). Otherwise throw.
+- If the caller omits `OrderBy`, the provider auto-applies `ORDER BY <pk>` and a default `ASC` direction (matching today's pagination behavior at line 1180).
+
+This restriction is the price of simplicity. Arbitrary-ORDER-BY keyset paging is technically possible but requires the caller to know which columns are covered by which index, and degenerates to a sort-then-skip if not. Out of scope for v1.
+
+### 2.5 Direction handling
+
+For `OrderBy: 'ID DESC'`, the seek inverts: `WHERE id < @lastSeen`. Provider builds the correct comparison from the OrderBy direction.
+
+## 3. API
+
+### 3.1 New `RunViewParams` field
+
+```typescript
+// packages/MJCore/src/generic/interfaces.ts
+export interface RunViewParams {
+    // ... existing fields ...
+
+    /**
+     * Keyset (seek) pagination: when set, the query returns the next page of records
+     * after the given PK value, ordered by the PK column. Use this in place of
+     * StartRow when iterating large result sets (e.g. background jobs, bulk processing).
+     *
+     * Constraints:
+     * - Entity must have a single-column primary key
+     * - PK column type must be in the orderable allowlist (most types are; see docs)
+     * - OrderBy, if set, must reference only the PK column (any direction)
+     * - Cannot be combined with StartRow
+     *
+     * Example:
+     *   const result = await rv.RunView({
+     *     EntityName: 'Tax Returns',
+     *     ExtraFilter: '(AddressLine1 IS NOT NULL)',
+     *     AfterKey: CompositeKey.FromID(lastSeenId),
+     *     MaxRows: 500,
+     *     ResultType: 'entity_object'
+     *   }, contextUser);
+     *
+     * @throws AfterKeyNotSupportedError if the entity has a composite PK or unsupported PK type
+     * @throws Error if AfterKey is combined with StartRow, or if OrderBy is incompatible
+     *
+     * @since v5.x
+     */
+    AfterKey?: CompositeKey;
+}
+```
+
+### 3.2 New error type
+
+```typescript
+// packages/MJCore/src/generic/runViewKeysetError.ts
+export class AfterKeyNotSupportedError extends Error {
+    constructor(
+        public readonly EntityName: string,
+        public readonly Reason: 'CompositePK' | 'UnsupportedPKType' | 'IncompatibleOrderBy',
+        message: string
+    ) {
+        super(message);
+        this.name = 'AfterKeyNotSupportedError';
+    }
+}
+```
+
+### 3.3 GraphQL surface
+
+The GraphQL `RunViewsWithCacheCheckQuery` / `RunViewsQuery` inputs need a new optional `AfterKey` field (CompositeKey scalar — already a JSON-stringified shape in MJ's resolvers). Client-side `GraphQLDataProvider` forwards it through to the server provider.
+
+## 4. Provider implementation
+
+### 4.1 New abstract method on `GenericDatabaseProvider`
+
+```typescript
+// packages/GenericDatabaseProvider/src/GenericDatabaseProvider.ts
+/**
+ * Build the SQL fragment for keyset (seek) pagination.
+ * Called when RunViewParams.AfterKey is set.
+ *
+ * @param pkColumnName  The quoted PK column name (e.g. "[ID]" for SQL Server, '"ID"' for PG)
+ * @param keyParamPlaceholder  The parameter placeholder for the seek key value (e.g. "@p0")
+ * @param direction  'ASC' (use >) or 'DESC' (use <)
+ * @param maxRows  Page size
+ * @returns SQL fragment to append after WHERE/ORDER BY clauses, e.g.
+ *          "ORDER BY [ID] ASC OFFSET 0 ROWS FETCH NEXT 500 ROWS ONLY"
+ *          (no, that's OFFSET — keyset returns: "ORDER BY [ID] ASC" + the WHERE clause is built separately)
+ *
+ * NB: This method ONLY emits the ORDER BY + TOP/LIMIT fragment. The WHERE
+ * predicate (pkColumn > @keyValue) is built by the shared
+ * applyKeysetSeekPredicate() helper and added to whereSQL before this method
+ * is called. Each provider only needs to differ in TOP-vs-LIMIT syntax.
+ */
+protected abstract BuildKeysetPaginationSQL(
+    pkColumnName: string,
+    direction: 'ASC' | 'DESC',
+    maxRows: number
+): string;
+```
+
+### 4.2 SQL Server implementation
+
+```typescript
+// packages/SQLServerDataProvider/src/SQLServerDataProvider.ts
+protected override BuildKeysetPaginationSQL(
+    pkColumnName: string,
+    direction: 'ASC' | 'DESC',
+    maxRows: number
+): string {
+    // SQL Server: TOP N already emitted at SELECT site by BuildTopClause; just ORDER BY here.
+    return `ORDER BY ${pkColumnName} ${direction}`;
+}
+```
+
+Wait — SQL Server emits `TOP N` at the SELECT level via `BuildTopClause`, but `BuildPaginationSQL` currently emits `OFFSET 0 ROWS FETCH NEXT N ROWS ONLY` and is appended AFTER ORDER BY. For keyset we want `TOP N ... WHERE pk > @last ORDER BY pk`. The implementation has to:
+
+1. When `AfterKey` is set, **bypass** the existing pagination branch at line 1178-1187.
+2. Append the seek predicate to `whereSQL` BEFORE the ORDER BY is emitted.
+3. Force a `TOP N` clause at the SELECT site (treat it like a non-paginated query for emit purposes).
+4. Emit the ORDER BY as usual.
+
+So the structural change in `GenericDatabaseProvider.RunView` is:
+
+```typescript
+const usingKeyset = !!params.AfterKey;
+if (usingKeyset) {
+    // 1. Validate (single-col PK, orderable type, OrderBy compatibility) — throw if violated
+    // 2. Apply seek predicate to whereSQL: `${pk} > @keyValue` (or < for DESC)
+    // 3. Force topSQL emission (TOP N for SQL Server, LIMIT N for PG via BuildNonPaginatedLimitSQL)
+    // 4. Force ORDER BY pk if no OrderBy specified
+    // 5. Skip the existing OFFSET branch
+}
+```
+
+So we don't actually need `BuildKeysetPaginationSQL` per-provider. The provider methods we already have (`BuildTopClause`, `BuildNonPaginatedLimitSQL`, `BuildParameterPlaceholder`) are sufficient. The keyset logic lives in `GenericDatabaseProvider` and uses existing per-provider primitives.
+
+This simplifies the implementation — no new abstract methods, just a new branch in the shared `RunView` method.
+
+### 4.3 PostgreSQL — same approach
+
+PG already uses `LIMIT N` at the end (via `BuildNonPaginatedLimitSQL`) when not paginating. For keyset, we use that same LIMIT plus a seek predicate in WHERE. No PG-specific changes needed.
+
+### 4.4 SQL injection / parameter safety
+
+The seek key value gets bound as a parameter (using existing `BuildParameterPlaceholder` / parameter array mechanism), not interpolated. Type matches the PK column type. This goes through the same parameter-binding path that `whereSQL` already uses for view parameters.
+
+## 5. Migration
+
+### 5.1 Callers to migrate (priority order)
+
+1. **`packages/Actions/CoreActions/src/custom/geo/scheduled-geocoding.action.ts`** — `loadEntityPage` at line 209-230. Replace `StartRow: offset+1` with `AfterKey: lastSeenKey`. Track the last-seen ID across pages. This is the canonical reference adoption — get it right and document it as the example.
+
+2. **`packages/AI/Vectors/Core/src/models/VectorBase.ts:68`** (`PageRecordsByEntityID`) and **`packages/AI/Vectors/Sync/src/models/entityVectorSync.ts:479`** (the loop in `getData`) — vectorization iterates entire entities via `PageNumber → StartRow`. Migrate the core helper to use `AfterKey` so all vectorization callers benefit.
+
+3. **Classifier / Autotag (Content Autotagging)** — the `@memberjunction/actions-content-autotag` action surfaces in the UI as "Classifier". The orchestrator action (`content-autotag-and-vectorize.action.ts`) doesn't paginate itself, but it triggers vectorization tasks that flow through #2. **Migrating #2 fixes the classifier's deep-page cost indirectly.** No direct changes needed in the autotag package — but verify by running a classifier task end-to-end after the vectorization migration.
+
+4. **`packages/ExternalChangeDetection/src/ChangeDetector.ts:292`** — verify the iteration pattern (StartRow grows per page?). If yes, migrate.
+
+5. **(Audit during implementation)** — grep for any other places that pass non-zero `StartRow` to RunView in non-UI contexts. UI grid pagination via `packages/Angular/Generic/pagination/` stays on `StartRow` (small page numbers, no real benefit from keyset, plus arbitrary OrderBy is needed).
+
+6. **Audit AI/Vectors/Dupe, Archive Runs, any custom user actions** — confirm whether they iterate large tables.
+
+### 5.2 What does NOT migrate
+
+- UI grid pagination (`Angular/Generic/pagination`, `entity-viewer`, dialog selectors with shallow paging) — they use arbitrary `OrderBy` and shallow page numbers, exactly where OFFSET is fine.
+- GraphQL `GetQueryData` resolver — query results, not view rows. Separate code path.
+- Anything with `StartRow: 0` — already first-page, no migration needed.
+
+## 6. Tests
+
+### 6.1 Unit tests (vitest)
+
+- `packages/GenericDatabaseProvider/src/__tests__/keyset-pagination.test.ts` (new) — covers SQL emission:
+  - Single-col PK + ASC: emits `WHERE pk > @key ORDER BY pk`
+  - Single-col PK + DESC: emits `WHERE pk < @key ORDER BY pk DESC`
+  - Throws `AfterKeyNotSupportedError` on composite PK
+  - Throws on unsupported PK type
+  - Throws when OrderBy references non-PK columns
+  - Throws when AfterKey + StartRow both set
+  - First-page case: AfterKey omitted → standard TOP/LIMIT N
+- `packages/SQLServerDataProvider/src/__tests__/keyset.test.ts` — verifies SQL Server-specific TOP N + ORDER BY + WHERE assembly
+- `packages/PostgreSQLDataProvider/src/__tests__/keyset.test.ts` — verifies PG LIMIT N + ORDER BY + WHERE assembly
+
+### 6.2 Integration tests
+
+- Live against the workbench SQL Server: iterate a real entity (e.g. `MJ: Audit Logs`) in keyset pages, verify all rows returned exactly once, no duplicates, no gaps.
+- Run against PostgreSQL (Docker workbench) — same assertions.
+- Regression: existing OFFSET-based pagination still works for callers that didn't migrate.
+
+### 6.3 Caller regression tests
+
+- Migrated callers (geocoding, change detector, vectorization) get integration tests that walk a seeded dataset and assert all rows visited exactly once.
+
+## 7. Documentation
+
+- New: `/guides/KEYSET_PAGINATION_GUIDE.md` — when to use, when not to, API examples, common pitfalls (using non-PK OrderBy, composite PK entities, tracking last-seen key across pages).
+- Update: `RunViewParams` JSDoc with the new field + cross-link to the guide.
+- Update: `/CLAUDE.md` performance section — add a "Use AfterKey for large iteration" note alongside the existing `RunViews` (batch) guidance.
+- Update: package `README.md` for `@memberjunction/core` to mention the addition.
+- Update: scheduled-geocoding action's docstring to point at the keyset pattern.
+
+## 8. Open questions — resolved
+
+### 8.1 Cache interaction — **resolved: AfterKey bypasses cache; rely on existing `AllowCaching` gate**
+
+Three relevant facts:
+
+1. **`LocalCacheManager` already gates writes by `EntityInfo.AllowCaching`** ([line 1229](../packages/MJCore/src/generic/localCacheManager.ts#L1229)). Entities with `AllowCaching=false` (the default for most entities, including the large iteration tables this plan targets) **never get written to the cache at all** — the short-circuit fires before fingerprinting matters.
+
+2. **The audit raised in this plan applies only to `AllowCaching=true` entities**, which are deliberately limited to metadata-shaped tables (small, frequently-read reference data). Those entities aren't the ones callers iterate with `AfterKey`.
+
+3. **`AfterKey` queries are single-use by design**: each call uses a different seek key, so a cached entry would never be reusable. Caching them is pure overhead.
+
+**Decision: When `AfterKey` is present, RunView treats the query as if `BypassCache: true` were set** — skips both cache read and cache write, regardless of `AllowCaching`. This is the cleanest semantic and doesn't require touching the fingerprint logic at all. The recent cache hardening PR (`4ea20fb737`, see §8.4) is unaffected — its `schemaHash`, timestamp precision, and remote-index fixes all sit on the cache write/read path that AfterKey skips entirely.
+
+Verify during implementation: for the actual entities we plan to migrate (TaxReturn, TaxReturnContractor, Contact, vectorization source entities, etc.), confirm `AllowCaching=false` so even the bypass is theoretically redundant. If any have `AllowCaching=true`, the bypass still saves us from polluting their metadata cache with one-shot iteration reads.
+
+### 8.2 Cursor end-of-data signal
+
+Currently `RunView` returns `Results.length < MaxRows` as the natural "no more pages" signal. With keyset that still works: when a page returns fewer rows than `MaxRows`, the caller knows to stop. **Document this contract clearly in the keyset guide.**
+
+### 8.3 GraphQL `CompositeKey` scalar shape
+
+`CompositeKey` already round-trips through GraphQL today for entity loads/deletes. We need to verify the existing input shape works for a `RunViewsParams.AfterKey` field on `RunViewsWithCacheCheckQuery`/`RunViewsQuery`. If the existing input types don't accept it directly, add a `KeyValuePair[]` input type field to the GraphQL schema. **Action: confirm during implementation by reading `packages/MJServer/src/resolvers/RunViewResolver.ts` and the corresponding input types.**
+
+### 8.4 Compatibility with recent cache hardening PR (`4ea20fb737`)
+
+Reviewed the PR (`fix(mjcore): cache architecture fixes from audit`, merged via `next`). Its scope:
+
+- **Schema upgrade detection** — adds `schemaHash` to `CachedRunViewData` so a cache entry is invalidated when the entity's column set changes
+- **Empty-result timestamp fix** — `extractMaxUpdatedAt` returns `''` for empty results instead of "now"
+- **Timestamp precision** — `isCacheCurrent` uses millisecond comparison with 1-second tolerance
+- **Remote fingerprint index** — `resolveFingerprintsForEntity` populates the local entity index after Redis scans
+- **Null PK handling** — `UpsertSingleEntity`/`RemoveSingleEntity` skip null-PK rows
+
+**No conflict** with keyset pagination — these changes harden the cache read/write path. Our decision to bypass that path entirely for `AfterKey` (per §8.1) means we don't intersect with any of these fixes. Confirm during implementation that the bypass branches above the schemaHash + isCacheCurrent gates so we don't accidentally trigger their stale-detection logic with unrelated query shapes.
+
+## 9. Execution order
+
+1. **DONE** — Geocoding cron metadata: Saturdays 2 AM UTC.
+2. **Audit** — Confirm all caller locations to migrate (grep + read each context). Expand caller list in §5.1 if needed.
+3. **Implementation** —
+   - Add `AfterKey` to `RunViewParams` + `AfterKeyNotSupportedError`
+   - Implement validation + SQL assembly in `GenericDatabaseProvider.RunView`
+   - Update SQL Server + PostgreSQL providers (likely no per-provider changes needed — see §4.2)
+   - Implement cache bypass for `AfterKey` queries in `LocalCacheManager` (per §8.1 — no fingerprint changes needed)
+   - Extend GraphQL input types + `GraphQLDataProvider` client to forward `AfterKey`
+4. **Tests** — Unit + integration per §6.
+5. **Migrate** — Geocoding first (reference adoption), then change detection, then vectorization, then remainder.
+6. **Docs** — Guide + JSDoc + README + CLAUDE.md updates per §7.
+7. **Changeset** — Add a `.changeset/` entry describing the new API and (no) breaking changes. Verify nothing in `RunViewParams` becomes required.
+
+## 10. Risks & non-risks
+
+- **Risk: misuse of `OrderBy` invalidating seek** — mitigated by runtime validation throwing early. Documented.
+- **Risk: GraphQL serialization edge case for `CompositeKey`** — mitigated by reusing the existing `CompositeKey` GQL shape used for `LoadEntity` etc.
+- **Risk: server cache pollution** — mitigated by bypassing cache writes for AfterKey queries (per §8.1).
+- **Non-risk: existing UI pagination** — untouched, no behavior change.
+- **Non-risk: backward compatibility** — `AfterKey` is purely additive; absence preserves current behavior.
+
+## 11. Acceptance criteria
+
+- [x] Geocoding scheduled job runs weekly (Saturdays 2 AM UTC) per the metadata change
+- [ ] `RunViewParams.AfterKey: CompositeKey` accepted by the framework
+- [ ] Composite-PK / unsupported-type entities throw `AfterKeyNotSupportedError` with a clear message
+- [ ] SQL Server + PostgreSQL both emit keyset-style SQL when `AfterKey` is present
+- [ ] `AfterKey` queries bypass cache read AND write (verified by inspecting `LocalCacheManager` behavior in unit test)
+- [ ] `ScheduledGeocodingAction.loadEntityPage` migrated and verified to iterate a million-row entity without OFFSET cost growth
+- [ ] `VectorBase.PageRecordsByEntityID` (and `entityVectorSync`) migrated; classifier task verified end-to-end after migration
+- [ ] At least one full integration test walks a seeded dataset end-to-end in keyset pages on SQL Server AND PostgreSQL
+- [ ] Guide + JSDoc + CLAUDE.md updated
+- [ ] All affected packages build green; all tests pass
+- [ ] Changeset committed


### PR DESCRIPTION
Adds RunViewParams.AfterKey: CompositeKey to keep iteration over large entities O(log N) per page regardless of depth — fixes the deep-page cost growth of OFFSET-based StartRow pagination on background jobs and bulk processing. Fully additive; StartRow remains the right tool for UI grids.

Framework
- New RunViewParams.AfterKey (CompositeKey) with full JSDoc + example
- New exported AfterKeyNotSupportedError with Reason codes (CompositePK | UnsupportedPKType | IncompatibleOrderBy | StartRowConflict | AfterKeyShape)
- New IsKeysetPaginationOrderableType helper + KEYSET_PAGINATION_ORDERABLE_PK_TYPES
- GenericDatabaseProvider.BuildKeysetSeekClause validates entity + params and emits the seek predicate; formatKeysetSeekValue type-aware SQL literal escaping with UUID/numeric/date validation + SQL-injection defense
- Single-column PK only in v1; composite-PK entities throw with a clear message
- AfterKey queries bypass server cache (read + write) at three layers: LocalCacheManager.SetRunViewResult, ProviderBase.RunView/PreRunView/PreRunViews, and RunViewsWithCacheCheck routing
- GraphQL: AfterKey: CompositeKeyInputType added to all four RunView input types; client GraphQLDataProvider forwards it; server ResolverBase + RunViewResolver reconstitute CompositeKey on receive

Migrated callers
- ScheduledGeocodingAction.processMissingForEntity — keyset when entity has single-column PK, OFFSET fallback for composites
- VectorBase.PageRecordsByEntityID + EntityVectorSyncer.startDataPaging — auto-promote to keyset when possible; new VectorBase.CanUseKeysetPagination helper; new optional PageRecordsParams.AfterKey

Metadata
- Geocoding Maintenance scheduled job cron: every 15min -> Saturday 2 AM UTC; description reworded to not hard-code a cadence

Tests
- 44 new unit tests passing (11 in MJCore, 33 in GenericDatabaseProvider) covering SQL emission, validation throws, value formatting, and the new Equals helper

Docs
- New guides/KEYSET_PAGINATION_GUIDE.md
- README updates in MJCore, GenericDatabaseProvider, GraphQLDataProvider, AI/Vectors/Core, AI/Vectors/Sync, Actions/CoreActions, SQL/PG providers, MJServer — all link to the guide
- CLAUDE.md performance section updated
- plans/keyset-pagination.md (design doc)

Out of scope for v1
- ExternalChangeDetection.ChangeDetector uses RunQuery (saved queries with arbitrary SQL the framework can't safely rewrite) — stays on OFFSET; tracked as a follow-up in the guide