### PR TITLE
fix(angular): resolve two NG0100 change-detection errors (ArtifactViewer, MessageItem)

### DIFF
--- a/.changeset/cyan-dots-double.md
+++ b/.changeset/cyan-dots-double.md
@@ -1,0 +1,5 @@
+---
+"@memberjunction/ng-artifacts": patch
+---
+
+no migration

--- a/packages/Angular/Generic/artifacts/src/lib/components/artifact-viewer-panel.component.ts
+++ b/packages/Angular/Generic/artifacts/src/lib/components/artifact-viewer-panel.component.ts
@@ -223,15 +223,22 @@ export class ArtifactViewerPanelComponent extends BaseAngularComponent implement
       });
     }
 
-    // Load artifact with specified version if provided
-    await this.loadArtifact(this.versionNumber);
+    // Defer the initial load past Angular's first stable CD cycle so that the inner
+    // awaits in loadArtifact can't mutate `this.artifact`/`this.artifactVersion` between
+    // the main CD pass and dev-mode's verifyNoChanges pass (the classic NG0100
+    // "ExpressionChangedAfterItHasBeenCheckedError" we used to hit on the title).
+    // Using setTimeout(0) instead of Promise.resolve() because we need a fresh
+    // macrotask boundary — microtasks can still drain inside Angular's CD cycle.
+    setTimeout(async () => {
+      await this.loadArtifact(this.versionNumber);
 
-    // Track that user viewed this artifact
-    if (this.artifactVersion?.ID && this.currentUser) {
-      this.trackArtifactUsage('Viewed');
-      // Also log to User Record Logs for recents feature (fire-and-forget)
-      this.recentAccessService.logAccess('MJ: Artifacts', this.artifactId, 'artifact');
-    }
+      // Track that user viewed this artifact (deferred so it runs after the load)
+      if (this.artifactVersion?.ID && this.currentUser) {
+        this.trackArtifactUsage('Viewed');
+        // Also log to User Record Logs for recents feature (fire-and-forget)
+        this.recentAccessService.logAccess('MJ: Artifacts', this.artifactId, 'artifact');
+      }
+    }, 0);
   }
 
   async ngOnChanges(changes: SimpleChanges) {

--- a/packages/Angular/Generic/conversations/src/lib/components/message/message-item.component.ts
+++ b/packages/Angular/Generic/conversations/src/lib/components/message/message-item.component.ts
@@ -1155,40 +1155,55 @@ export class MessageItemComponent extends BaseAngularComponent implements OnInit
   /**
    * Get agent response form from message
    * Uses ResponseForm property from MJConversationDetailEntity
+   *
+   * Cached against the raw JSON string so the getter returns a stable object reference
+   * for the same input. Without caching, `JSON.parse` produces a new object every call,
+   * which makes Angular's `@if (responseForm)` template index churn between CD passes —
+   * the classic NG0100 "ExpressionChangedAfterItHasBeenCheckedError" we used to hit here.
    */
+  private _responseFormRaw: string | null | undefined = undefined;
+  private _responseFormCache: AgentResponseForm | null = null;
   public get responseForm(): AgentResponseForm | null {
-    try {
-      const rawData = this.message.ResponseForm;
-      if (!rawData) {
-        return null;
-      }
-
-      // Parse JSON string to AgentResponseForm object
-      const form = JSON.parse(rawData);
-
-      return form || null;
-    } catch (error) {
-      console.error('Failed to parse response form:', error, 'Raw data:', this.message.ResponseForm);
+    const rawData = this.message.ResponseForm ?? null;
+    if (rawData === this._responseFormRaw) return this._responseFormCache;
+    this._responseFormRaw = rawData;
+    if (!rawData) {
+      this._responseFormCache = null;
       return null;
     }
+    try {
+      this._responseFormCache = (JSON.parse(rawData) as AgentResponseForm) || null;
+    } catch (error) {
+      console.error('Failed to parse response form:', error, 'Raw data:', rawData);
+      this._responseFormCache = null;
+    }
+    return this._responseFormCache;
   }
 
   /**
    * Get actionable commands from message
    * Uses ActionableCommands property from MJConversationDetailEntity
+   *
+   * Cached against the raw JSON string (see {@link responseForm} for rationale).
    */
+  private _actionableCommandsRaw: string | null | undefined = undefined;
+  private _actionableCommandsCache: ActionableCommand[] = [];
   public get actionableCommands(): ActionableCommand[] {
+    const rawData = this.message.ActionableCommands ?? null;
+    if (rawData === this._actionableCommandsRaw) return this._actionableCommandsCache;
+    this._actionableCommandsRaw = rawData;
+    if (!rawData) {
+      this._actionableCommandsCache = [];
+      return this._actionableCommandsCache;
+    }
     try {
-      const rawData = this.message.ActionableCommands;
-      if (!rawData) return [];
-
-      // Parse JSON string to array of ActionableCommand objects
       const commands = JSON.parse(rawData);
-      return Array.isArray(commands) ? commands : [];
+      this._actionableCommandsCache = Array.isArray(commands) ? commands : [];
     } catch (error) {
       console.error('Failed to parse actionable commands:', error);
-      return [];
+      this._actionableCommandsCache = [];
     }
+    return this._actionableCommandsCache;
   }
 
   /**


### PR DESCRIPTION
## Summary

Fixes two unrelated `NG0100: ExpressionChangedAfterItHasBeenCheckedError` runtime errors observed in dev mode while interacting with the Conversations workspace. Both are change-detection stability issues — values that legitimately *should* be stable across a CD cycle were changing between Angular's main pass and the dev-mode `verifyNoChanges` pass.

No behavioral changes beyond eliminating the errors. Both packages build clean.

## Bug 1 — `ArtifactViewerPanelComponent`

**Symptom**

```
NG0100: ExpressionChangedAfterItHasBeenCheckedError: Expression has changed after it was checked.
  Previous value: 'Artifact'.
  Current value: 'Query Builder Payload - 5/13/2026, 7:33:33 PM'.
  Expression location: _ArtifactViewerPanelComponent component
  at ArtifactViewerPanelComponent_Conditional_1_Template (artifact-viewer-panel.component.html:7:11)
```

**Root cause**

`async ngOnInit()` awaited `loadArtifact()` directly. Internal awaits inside `loadArtifact` could resolve between Angular's main CD pass (showing the `'Artifact'` fallback from the `displayName` getter) and the dev-mode `verifyNoChanges` pass — mutating `this.artifact` mid-cycle. The verify pass then read the loaded name and tripped NG0100.

**Fix**

Defer the initial load to a fresh macrotask via `setTimeout(0)` so Angular's first stable CD cycle completes before any artifact assignment happens. The post-load "track viewed" follow-up moves inside the same timeout since it depends on `this.artifactVersion` being populated.

```ts
setTimeout(async () => {
  await this.loadArtifact(this.versionNumber);
  if (this.artifactVersion?.ID && this.currentUser) {
    this.trackArtifactUsage('Viewed');
    this.recentAccessService.logAccess('MJ: Artifacts', this.artifactId, 'artifact');
  }
}, 0);
```

Using `setTimeout(0)` (macrotask) rather than `Promise.resolve()` (microtask) because microtasks can still drain inside Angular's CD cycle.

## Bug 2 — `MessageItemComponent`

**Symptom**

```
NG0100: ExpressionChangedAfterItHasBeenCheckedError: Expression has changed after it was checked.
  Previous value: '-1'.
  Current value: '6'.
  Expression location: _MessageItemComponent component
  at MessageItemComponent_Conditional_17_Template (message-item.component.html:138:9)
```

**Root cause**

`responseForm` and `actionableCommands` were getters that called `JSON.parse()` on every read, producing a **new object reference** every time. Angular's `@if` template-instance tracking compares references for object-typed expressions — same JSON, different reference, different template index. The `-1 → 6` in the error is the internal Conditional index churn (template not-rendered → template rendered) flipping every CD pass.

**Fix**

Memoize both getters against the raw JSON string they parse from. Cache invalidates only when the underlying `message.ResponseForm` / `message.ActionableCommands` string actually changes. Same input → same object reference → stable across CD passes.

```ts
private _responseFormRaw: string | null | undefined = undefined;
private _responseFormCache: AgentResponseForm | null = null;
public get responseForm(): AgentResponseForm | null {
  const rawData = this.message.ResponseForm ?? null;
  if (rawData === this._responseFormRaw) return this._responseFormCache;
  this._responseFormRaw = rawData;
  // ... parse + cache ...
  return this._responseFormCache;
}
```

Same pattern applied to `actionableCommands`.

## Files changed

| File | +/− |
|---|---|
| `packages/Angular/Generic/artifacts/src/lib/components/artifact-viewer-panel.component.ts` | +16 / −9 |
| `packages/Angular/Generic/conversations/src/lib/components/message/message-item.component.ts` | +32 / −17 |

## Test plan

- [ ] Open a conversation with at least one message that has a `ResponseForm` populated — verify no NG0100 in the console when the message renders.
- [ ] Open an artifact in the viewer (especially a freshly-created one that hits the cold-load path) — verify the title shows the loaded artifact name without flickering through `'Artifact'`, and no NG0100 in the console.
- [ ] Navigate between artifacts and between conversations to confirm the cached getters invalidate correctly when the underlying message / artifact changes.
- [ ] `npm run build` in both `packages/Angular/Generic/artifacts` and `packages/Angular/Generic/conversations` — confirmed green locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)