### PR TITLE
fix(core-entities): add missing @deprecated JSDoc to Conversation Detail Attachments entity

### DIFF
--- a/.changeset/conversation-detail-attachment-deprecated-jsdoc.md
+++ b/.changeset/conversation-detail-attachment-deprecated-jsdoc.md
@@ -1,0 +1,5 @@
+---
+"@memberjunction/core-entities": patch
+---
+
+Add the missing `@deprecated` JSDoc tag to the generated `MJConversationDetailAttachmentEntity` class. This is a CodeGen catch from the attachment-unification work — the entity is deprecated in metadata but the generated class was not regenerated with the corresponding JSDoc. Comment-only change, no runtime impact.

--- a/packages/MJCoreEntities/src/generated/entity_subclasses.ts
+++ b/packages/MJCoreEntities/src/generated/entity_subclasses.ts
@@ -57344,6 +57344,7 @@ export class MJConversationDetailArtifactEntity extends BaseEntity<MJConversatio
  * @extends {BaseEntity}
  * @class
  * @public
+ * @deprecated This entity is deprecated and will be removed in a future version. Using it will result in console warnings.
  */
 @RegisterClass(BaseEntity, 'MJ: Conversation Detail Attachments')
 export class MJConversationDetailAttachmentEntity extends BaseEntity<MJConversationDetailAttachmentEntityType> {


### PR DESCRIPTION
## Summary
- CodeGen catch: the `@deprecated` JSDoc on `MJConversationDetailAttachmentEntity` was not regenerated as part of the attachment-unification work.
- This is the single-line generated-code change that should have been included in that PR.

## Test plan
- [x] `packages/MJCoreEntities` builds (generated file, JSDoc-only change)
- [ ] No runtime impact — comment-only addition

🤖 Generated with [Claude Code](https://claude.com/claude-code)