### PR TITLE
feat(testing): edit + suite membership UX for Test/Test Suite forms

### DIFF
--- a/.changeset/eager-pandas-glide.md
+++ b/.changeset/eager-pandas-glide.md
@@ -2,4 +2,4 @@
 "@memberjunction/ng-core-entity-forms": patch
 ---
 
-Add an inline save/edit experience to the custom Test and Test Suite forms: editable Name, Description, Status, Parent Suite / Test Type, and tag-chip editor, plus a sticky save bar that slides up from the bottom whenever the record is dirty (Save/Discard, ⌘S shortcut, beforeunload guard, success/error toasts).
+Add an inline save/edit experience to the custom Test and Test Suite forms: editable Name, Description, Status, Parent Suite / Test Type, and tag-chip editor, plus a sticky save bar that slides up from the bottom whenever the record is dirty (Save/Discard, ⌘S shortcut, beforeunload guard, success/error toasts). Test Suite forms also gain in-place membership management — a searchable picker dialog for bulk-adding tests, hover-revealed remove with inline confirm, and drag-to-reorder via CDK with sequence persistence.

--- a/.changeset/eager-pandas-glide.md
+++ b/.changeset/eager-pandas-glide.md
@@ -1,0 +1,5 @@
+---
+"@memberjunction/ng-core-entity-forms": patch
+---
+
+Add an inline save/edit experience to the custom Test and Test Suite forms: editable Name, Description, Status, Parent Suite / Test Type, and tag-chip editor, plus a sticky save bar that slides up from the bottom whenever the record is dirty (Save/Discard, ⌘S shortcut, beforeunload guard, success/error toasts).

--- a/packages/Angular/Explorer/core-entity-forms/package.json
+++ b/packages/Angular/Explorer/core-entity-forms/package.json
@@ -25,6 +25,7 @@
     "@angular/forms": "21.1.3"
   },
   "dependencies": {
+    "@angular/cdk": "21.1.3",
     "@angular/router": "21.1.3",
     "@codemirror/language": "latest",
     "@codemirror/language-data": "^6.5.2",

--- a/packages/Angular/Explorer/core-entity-forms/src/lib/custom/Tests/test-form.component.css
+++ b/packages/Angular/Explorer/core-entity-forms/src/lib/custom/Tests/test-form.component.css
@@ -89,6 +89,7 @@
 
 /* Base Container */
 .test-form {
+  position: relative;
   display: flex;
   flex-direction: column;
   height: 100%;
@@ -1737,3 +1738,425 @@
     border: 1px solid var(--mj-border-default);
   }
 }
+
+/* ===========================
+   Editable Form Sections (Config tab)
+   =========================== */
+
+.edit-section {
+  background: var(--test-surface);
+  border-radius: var(--test-radius-lg);
+  padding: 24px;
+  box-shadow: var(--test-shadow-sm);
+}
+
+.edit-section-header {
+  margin: 0 0 18px 0;
+}
+
+.edit-section-header h3 {
+  margin: 0 0 4px 0;
+  font-size: 18px;
+  font-weight: 700;
+  color: var(--test-text);
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.edit-section-header h3 i {
+  color: var(--test-primary);
+}
+
+.edit-section-sub {
+  margin: 0;
+  font-size: 12px;
+  color: var(--test-text-muted);
+}
+
+.edit-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 18px;
+}
+
+@media (max-width: 720px) {
+  .edit-grid {
+    grid-template-columns: 1fr;
+  }
+}
+
+.edit-field {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  min-width: 0;
+}
+
+.edit-field--full {
+  grid-column: 1 / -1;
+}
+
+.edit-field label {
+  font-size: 12px;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  color: var(--test-text-muted);
+}
+
+.edit-field .required {
+  color: var(--mj-status-error);
+  margin-left: 2px;
+}
+
+.config-textarea {
+  resize: vertical;
+  min-height: 72px;
+  font-family: inherit;
+  line-height: 1.5;
+}
+
+.select-wrapper {
+  position: relative;
+}
+
+.select-wrapper select.config-input {
+  padding-right: 36px;
+  appearance: none;
+  background-color: var(--test-surface);
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='12' height='8' viewBox='0 0 12 8'%3E%3Cpath fill='%2364748b' d='M1.41 0L6 4.59 10.59 0 12 1.41l-6 6-6-6z'/%3E%3C/svg%3E");
+  background-repeat: no-repeat;
+  background-position: right 14px center;
+  background-size: 10px 7px;
+}
+
+/* Tag editor (chips + inline input) */
+.tag-editor {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  padding: 8px 10px;
+  border: 1px solid var(--test-border);
+  border-radius: var(--test-radius-sm);
+  background: var(--test-surface);
+  transition: var(--test-transition);
+  cursor: text;
+  min-height: 42px;
+  align-items: center;
+}
+
+.tag-editor:focus-within {
+  border-color: var(--test-primary);
+  box-shadow: 0 0 0 3px color-mix(in srgb, var(--mj-brand-primary) 15%, transparent);
+}
+
+.tag-chip-editable {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 3px 4px 3px 10px;
+  background: color-mix(in srgb, var(--mj-brand-primary) 12%, var(--mj-bg-surface));
+  color: var(--mj-brand-primary-hover);
+  border-radius: 999px;
+  font-size: 12px;
+  font-weight: 600;
+  line-height: 1;
+  border: 1px solid color-mix(in srgb, var(--mj-brand-primary) 25%, transparent);
+}
+
+.tag-chip-editable .tag-remove {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 18px;
+  height: 18px;
+  border-radius: 50%;
+  border: none;
+  background: transparent;
+  color: var(--mj-brand-primary);
+  cursor: pointer;
+  font-size: 10px;
+  transition: background 0.15s;
+}
+
+.tag-chip-editable .tag-remove:hover {
+  background: color-mix(in srgb, var(--mj-brand-primary) 25%, transparent);
+  color: var(--mj-brand-primary-hover);
+}
+
+.tag-input-inline {
+  flex: 1;
+  min-width: 140px;
+  border: none;
+  background: transparent;
+  outline: none;
+  font-size: 13px;
+  color: var(--test-text);
+  padding: 4px 2px;
+}
+
+.tag-input-inline::placeholder {
+  color: var(--test-text-muted);
+}
+
+/* Read-only metadata block at bottom of Config tab */
+.meta-section {
+  background: var(--mj-bg-surface-sunken);
+  border-radius: var(--test-radius-md);
+  padding: 14px 18px;
+  border: 1px solid var(--test-border);
+}
+
+.meta-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  gap: 14px;
+}
+
+.meta-item {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  min-width: 0;
+}
+
+.meta-label {
+  font-size: 10px;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  color: var(--test-text-muted);
+}
+
+.meta-value {
+  font-size: 12px;
+  color: var(--test-text-secondary);
+  font-weight: 500;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.meta-mono {
+  font-family: ui-monospace, SFMono-Regular, 'SF Mono', Menlo, monospace;
+  font-size: 11px;
+}
+
+/* Dirty indicator next to the title */
+.dirty-indicator {
+  display: inline-block;
+  margin-left: 8px;
+  font-size: 14px;
+  color: var(--mj-status-warning);
+  line-height: 1;
+  animation: pulseDot 1.8s ease-in-out infinite;
+  vertical-align: middle;
+}
+
+@keyframes pulseDot {
+  0%, 100% { opacity: 1; transform: scale(1); }
+  50% { opacity: 0.5; transform: scale(0.85); }
+}
+
+.unsaved-pill {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 4px 10px;
+  background: color-mix(in srgb, var(--mj-status-warning) 15%, var(--mj-bg-surface));
+  color: var(--mj-status-warning-text, var(--mj-status-warning));
+  border: 1px solid color-mix(in srgb, var(--mj-status-warning) 30%, transparent);
+  border-radius: 999px;
+  font-size: 11px;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.4px;
+}
+
+.unsaved-pill i {
+  font-size: 6px;
+  animation: pulseDot 1.8s ease-in-out infinite;
+}
+
+/* Pad the bottom of the tab content when the save bar is visible
+   so the bar doesn't cover the last form field. */
+.tab-content.has-savebar {
+  padding-bottom: 84px;
+}
+
+/* ===========================
+   Sticky Save Bar
+   =========================== */
+
+.save-bar {
+  position: absolute;
+  left: 16px;
+  right: 96px; /* leaves room for the bottom-right chat launcher */
+  bottom: 16px;
+  z-index: 50;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  padding: 12px 16px 12px 20px;
+  background: var(--mj-bg-surface-elevated, var(--test-surface));
+  border: 1px solid color-mix(in srgb, var(--mj-status-warning) 25%, var(--test-border));
+  border-radius: 14px;
+  box-shadow: 0 12px 32px color-mix(in srgb, var(--mj-status-warning) 10%, rgba(15, 23, 42, 0.18));
+  backdrop-filter: blur(8px);
+  /* Hidden / off-screen state by default. The .save-bar--visible class
+     animates it up into view. Using `transition` (not `animation`)
+     guarantees the change runs every time isDirty toggles. */
+  opacity: 0;
+  transform: translateY(calc(100% + 32px));
+  pointer-events: none;
+  transition:
+    transform 420ms cubic-bezier(0.16, 1, 0.3, 1),
+    opacity 260ms cubic-bezier(0.16, 1, 0.3, 1);
+  will-change: transform, opacity;
+}
+
+.save-bar--visible {
+  opacity: 1;
+  transform: translateY(0);
+  pointer-events: auto;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .save-bar {
+    transition: opacity 180ms ease-out;
+    transform: none;
+  }
+  .save-bar--visible {
+    transform: none;
+  }
+}
+
+.save-bar-message {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  min-width: 0;
+}
+
+.save-bar-dot {
+  color: var(--mj-status-warning);
+  font-size: 12px;
+  line-height: 1;
+  animation: pulseDot 1.8s ease-in-out infinite;
+}
+
+.save-bar-text {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  min-width: 0;
+}
+
+.save-bar-text strong {
+  font-size: 14px;
+  color: var(--test-text);
+  font-weight: 700;
+}
+
+.save-bar-fields {
+  font-size: 12px;
+  color: var(--test-text-muted);
+}
+
+.save-bar-actions {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-shrink: 0;
+}
+
+.save-bar-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 9px 16px;
+  font-size: 13px;
+  font-weight: 600;
+  border-radius: 8px;
+  border: 1px solid transparent;
+  cursor: pointer;
+  transition: var(--test-transition);
+  font-family: inherit;
+}
+
+.save-bar-btn:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+.save-bar-btn--primary {
+  background: var(--mj-brand-primary);
+  color: var(--mj-text-inverse, white);
+  border-color: var(--mj-brand-primary);
+  box-shadow: 0 2px 8px color-mix(in srgb, var(--mj-brand-primary) 35%, transparent);
+}
+
+.save-bar-btn--primary:hover:not(:disabled) {
+  background: var(--mj-brand-primary-hover, var(--mj-brand-primary));
+  transform: translateY(-1px);
+  box-shadow: 0 4px 12px color-mix(in srgb, var(--mj-brand-primary) 45%, transparent);
+}
+
+.save-bar-btn--primary:active:not(:disabled) {
+  transform: translateY(0);
+}
+
+.save-bar-btn--ghost {
+  background: transparent;
+  color: var(--test-text-secondary);
+  border-color: var(--test-border);
+}
+
+.save-bar-btn--ghost:hover:not(:disabled) {
+  background: var(--mj-bg-surface-hover, var(--mj-bg-surface-card));
+  color: var(--test-text);
+  border-color: var(--test-text-muted);
+}
+
+.save-bar-kbd {
+  display: inline-flex;
+  gap: 3px;
+  margin-left: 6px;
+  opacity: 0.85;
+}
+
+.save-bar-kbd kbd {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 18px;
+  height: 18px;
+  padding: 0 4px;
+  font-size: 10px;
+  font-weight: 600;
+  font-family: ui-monospace, SFMono-Regular, 'SF Mono', Menlo, monospace;
+  background: color-mix(in srgb, white 18%, transparent);
+  border: 1px solid color-mix(in srgb, white 35%, transparent);
+  border-radius: 4px;
+  color: inherit;
+}
+
+@media (max-width: 640px) {
+  .save-bar {
+    left: 8px;
+    right: 8px;
+    bottom: 88px; /* push above the chat launcher on small screens */
+    flex-direction: column;
+    align-items: stretch;
+    padding: 12px;
+  }
+  .save-bar-actions {
+    justify-content: space-between;
+  }
+  .save-bar-kbd {
+    display: none;
+  }
+}
+

--- a/packages/Angular/Explorer/core-entity-forms/src/lib/custom/Tests/test-form.component.html
+++ b/packages/Angular/Explorer/core-entity-forms/src/lib/custom/Tests/test-form.component.html
@@ -24,7 +24,12 @@
           <i class="fas fa-flask"></i>
         </div>
         <div class="test-info">
-          <h1>{{ record.Name }}</h1>
+          <h1>
+            {{ record.Name }}
+            @if (isDirty) {
+              <span class="dirty-indicator" title="You have unsaved changes" aria-label="Unsaved changes">●</span>
+            }
+          </h1>
           <div class="test-meta">
             <span class="status-badge" [ngClass]="getStatusClass()">
               <i class="fas" [ngClass]="getStatusIcon()"></i>
@@ -34,6 +39,11 @@
               <span class="test-type">
                 <i class="fas fa-tag"></i>
                 {{ record.Type }}
+              </span>
+            }
+            @if (isDirty) {
+              <span class="unsaved-pill" title="You have unsaved changes">
+                <i class="fas fa-circle"></i> Unsaved
               </span>
             }
           </div>
@@ -137,7 +147,7 @@
   </div>
 
   <!-- Tab Content -->
-  <div class="tab-content">
+  <div class="tab-content" [class.has-savebar]="isDirty">
     <!-- Overview Tab -->
     @if (activeTab === 'overview') {
       <div class="overview-tab">
@@ -234,32 +244,161 @@
     <!-- Configuration Tab -->
     @if (activeTab === 'config') {
       <div class="config-tab">
-        <div class="config-section">
-          <h3><i class="fas fa-cogs"></i> Execution Settings</h3>
-          <div class="config-grid">
-            <div class="config-item">
-              <label>Priority</label>
-              <input type="number" [(ngModel)]="record.Priority" class="config-input" placeholder="Lower = Higher Priority" />
+        <!-- Details -->
+        <section class="edit-section">
+          <header class="edit-section-header">
+            <h3><i class="fas fa-pen-to-square"></i> Details</h3>
+            <p class="edit-section-sub">Edit any field — changes are saved with the bar at the bottom.</p>
+          </header>
+          <div class="edit-grid">
+            <div class="edit-field edit-field--full">
+              <label for="test-name">Name <span class="required">*</span></label>
+              <input
+                id="test-name"
+                type="text"
+                class="config-input"
+                placeholder="e.g., Agent Response Quality Test"
+                [(ngModel)]="record.Name"
+              />
             </div>
-            <div class="config-item">
-              <label>Repeat Count</label>
-              <input type="number" [(ngModel)]="record.RepeatCount" class="config-input" min="1" />
+
+            <div class="edit-field edit-field--full">
+              <label for="test-description">Description</label>
+              <textarea
+                id="test-description"
+                class="config-input config-textarea"
+                rows="3"
+                placeholder="What does this test evaluate?"
+                [ngModel]="record.Description"
+                (ngModelChange)="record.Description = $event || null"
+              ></textarea>
             </div>
-            <div class="config-item">
-              <label>Estimated Duration (seconds)</label>
-              <input type="number" [(ngModel)]="record.EstimatedDurationSeconds" class="config-input" />
+
+            <div class="edit-field">
+              <label for="test-status">Status</label>
+              <div class="select-wrapper">
+                <select
+                  id="test-status"
+                  class="config-input"
+                  [(ngModel)]="record.Status"
+                >
+                  @for (opt of statusOptions; track opt) {
+                    <option [ngValue]="opt">{{ opt }}</option>
+                  }
+                </select>
+              </div>
             </div>
-            <div class="config-item">
-              <label>Estimated Cost (USD)</label>
-              <input type="number" step="0.000001" [(ngModel)]="record.EstimatedCostUSD" class="config-input" />
+
+            <div class="edit-field">
+              <label for="test-type">Test Type</label>
+              <select
+                id="test-type"
+                class="config-input"
+                [(ngModel)]="record.TypeID"
+              >
+                @for (t of testTypeOptions; track t.ID) {
+                  <option [ngValue]="t.ID">{{ t.Name }}</option>
+                }
+              </select>
             </div>
-            <div class="config-item full-width">
-              <label>Max Execution Time (ms)</label>
-              <input type="number" [(ngModel)]="record.MaxExecutionTimeMS" class="config-input" placeholder="Default: 300000 (5 min)" />
-              <span class="config-hint">Leave empty for default 5 minute timeout</span>
+
+            <div class="edit-field edit-field--full">
+              <label for="test-tags">Tags</label>
+              <div class="tag-editor" (click)="tagInput.focus()">
+                @for (tag of tags; track tag) {
+                  <span class="tag-chip-editable">
+                    {{ tag }}
+                    <button type="button" class="tag-remove" (click)="removeTag(tag); $event.stopPropagation()" [attr.aria-label]="'Remove tag ' + tag">
+                      <i class="fas fa-times"></i>
+                    </button>
+                  </span>
+                }
+                <input
+                  #tagInput
+                  id="test-tags"
+                  type="text"
+                  class="tag-input-inline"
+                  [placeholder]="tags.length === 0 ? 'Add tags, press Enter or comma...' : ''"
+                  [(ngModel)]="tagDraft"
+                  (keydown)="onTagInputKeydown($event)"
+                  (blur)="addTagFromDraft()"
+                />
+              </div>
+              <span class="config-hint">Press Enter or comma to add a tag. Backspace on empty input removes the last tag.</span>
             </div>
           </div>
-        </div>
+        </section>
+
+        <!-- Execution Settings -->
+        <section class="edit-section">
+          <header class="edit-section-header">
+            <h3><i class="fas fa-cogs"></i> Execution Settings</h3>
+          </header>
+          <div class="edit-grid">
+            <div class="edit-field">
+              <label for="test-priority">Priority</label>
+              <input
+                id="test-priority"
+                type="number"
+                class="config-input"
+                placeholder="0 (lower runs first)"
+                [ngModel]="record.Priority"
+                (ngModelChange)="record.Priority = $event === '' || $event === null ? null : +$event"
+              />
+              <span class="config-hint">Lower numbers run first.</span>
+            </div>
+            <div class="edit-field">
+              <label for="test-repeat">Repeat Count</label>
+              <input
+                id="test-repeat"
+                type="number"
+                class="config-input"
+                min="1"
+                placeholder="1"
+                [ngModel]="record.RepeatCount"
+                (ngModelChange)="record.RepeatCount = $event === '' || $event === null ? null : +$event"
+              />
+              <span class="config-hint">Number of times to repeat for statistical analysis.</span>
+            </div>
+            <div class="edit-field">
+              <label for="test-duration">Estimated Duration (seconds)</label>
+              <input
+                id="test-duration"
+                type="number"
+                class="config-input"
+                placeholder="0"
+                [ngModel]="record.EstimatedDurationSeconds"
+                (ngModelChange)="record.EstimatedDurationSeconds = $event === '' || $event === null ? null : +$event"
+              />
+            </div>
+            <div class="edit-field">
+              <label for="test-cost">Estimated Cost (USD)</label>
+              <input
+                id="test-cost"
+                type="number"
+                step="0.000001"
+                class="config-input"
+                placeholder="0.00"
+                [ngModel]="record.EstimatedCostUSD"
+                (ngModelChange)="record.EstimatedCostUSD = $event === '' || $event === null ? null : +$event"
+              />
+            </div>
+            <div class="edit-field edit-field--full">
+              <label for="test-timeout">Max Execution Time (ms)</label>
+              <input
+                id="test-timeout"
+                type="number"
+                class="config-input"
+                placeholder="Default: 300000 (5 min)"
+                [ngModel]="record.MaxExecutionTimeMS"
+                (ngModelChange)="record.MaxExecutionTimeMS = $event === '' || $event === null ? null : +$event"
+              />
+              <span class="config-hint">Leave empty for the default 5 minute timeout. Currently: {{ formatTimeout(record.MaxExecutionTimeMS) }}</span>
+            </div>
+          </div>
+        </section>
+
+        <!-- JSON editors (preserved from original layout) -->
         <div class="config-section">
           <h3><i class="fas fa-sign-in-alt"></i> Input Definition (JSON)</h3>
           <div class="config-editor-container">
@@ -296,18 +435,24 @@
             </mj-code-editor>
           </div>
         </div>
-        <div class="config-section">
-          <h3><i class="fas fa-tags"></i> Tags (JSON Array)</h3>
-          <div class="config-editor-container small">
-            <mj-code-editor
-              [value]="record.Tags || '[]'"
-              language="json"
-              [readonly]="false"
-              [lineWrapping]="true"
-              (change)="record.Tags = $event">
-            </mj-code-editor>
+
+        <!-- Metadata (read-only) -->
+        <section class="meta-section">
+          <div class="meta-grid">
+            <div class="meta-item">
+              <div class="meta-label">Created</div>
+              <div class="meta-value">{{ record.__mj_CreatedAt | date:'medium' }}</div>
+            </div>
+            <div class="meta-item">
+              <div class="meta-label">Last updated</div>
+              <div class="meta-value">{{ record.__mj_UpdatedAt | date:'medium' }}</div>
+            </div>
+            <div class="meta-item">
+              <div class="meta-label">Test ID</div>
+              <div class="meta-value meta-mono">{{ record.ID }}</div>
+            </div>
           </div>
-        </div>
+        </section>
       </div>
     }
 
@@ -759,6 +904,10 @@
       </div>
       <div class="shortcut-list">
         <div class="shortcut-item">
+          <span>Save changes</span>
+          <span class="shortcut-keys"><kbd>Cmd</kbd><kbd>S</kbd></span>
+        </div>
+        <div class="shortcut-item">
           <span>Refresh</span>
           <span class="shortcut-keys"><kbd>Cmd</kbd><kbd>R</kbd></span>
         </div>
@@ -790,4 +939,55 @@
       </app-test-run-dialog>
     </mj-slide-panel>
   }
+
+  <!-- Sticky Save Bar — always in the DOM so CSS transitions can fire reliably.
+       Visibility is controlled by the .save-bar--visible class, driven by isDirty. -->
+  <div
+    class="save-bar"
+    [class.save-bar--visible]="isDirty"
+    [attr.aria-hidden]="!isDirty"
+    role="region"
+    aria-label="Unsaved changes"
+  >
+    <div class="save-bar-message">
+      <span class="save-bar-dot" aria-hidden="true">●</span>
+      <span class="save-bar-text">
+        <strong>Unsaved changes</strong>
+        <span class="save-bar-fields">
+          @if (dirtyFieldNames.length === 1) {
+            {{ dirtyFieldNames[0] }} edited
+          } @else if (dirtyFieldNames.length > 1) {
+            {{ dirtyFieldNames.length }} fields edited
+          }
+        </span>
+      </span>
+    </div>
+    <div class="save-bar-actions">
+      <button
+        type="button"
+        class="save-bar-btn save-bar-btn--primary"
+        (click)="saveChanges()"
+        [disabled]="isSaving || !isDirty"
+        [attr.tabindex]="isDirty ? 0 : -1"
+        title="Save changes (⌘S)"
+      >
+        @if (isSaving) {
+          <i class="fas fa-spinner fa-spin"></i> Saving…
+        } @else {
+          <i class="fas fa-check"></i> Save changes
+          <span class="save-bar-kbd"><kbd>⌘</kbd><kbd>S</kbd></span>
+        }
+      </button>
+      <button
+        type="button"
+        class="save-bar-btn save-bar-btn--ghost"
+        (click)="discardChanges()"
+        [disabled]="isSaving || !isDirty"
+        [attr.tabindex]="isDirty ? 0 : -1"
+        title="Discard changes"
+      >
+        <i class="fas fa-undo"></i> Discard
+      </button>
+    </div>
+  </div>
 </div>

--- a/packages/Angular/Explorer/core-entity-forms/src/lib/custom/Tests/test-form.component.ts
+++ b/packages/Angular/Explorer/core-entity-forms/src/lib/custom/Tests/test-form.component.ts
@@ -2,7 +2,7 @@ import { Component, OnInit, OnDestroy, ChangeDetectionStrategy, HostListener, Vi
 import { Subject } from 'rxjs';
 import { takeUntil } from 'rxjs/operators';
 import { CompositeKey, Metadata, RunView } from '@memberjunction/core';
-import { MJTestEntity, MJTestRunEntity, MJTestSuiteTestEntity, MJTestSuiteRunEntity, MJUserSettingEntity, UserInfoEngine, MJTestRunFeedbackEntity } from '@memberjunction/core-entities';
+import { MJTestEntity, MJTestRunEntity, MJTestSuiteTestEntity, MJTestSuiteRunEntity, MJUserSettingEntity, UserInfoEngine, MJTestRunFeedbackEntity, MJTestTypeEntity } from '@memberjunction/core-entities';
 import { BaseFormComponent } from '@memberjunction/ng-base-forms';
 import { RegisterClass } from '@memberjunction/global';
 import { SharedService, NavigationService } from '@memberjunction/ng-shared';
@@ -114,9 +114,17 @@ export class MJTestFormComponentExtended extends MJTestFormComponent implements 
   private viewContainerRef = inject(ViewContainerRef);
   private appManager = inject(ApplicationManager);
 
+  // Edit state
+  isSaving = false;
+  testTypeOptions: MJTestTypeEntity[] = [];
+  tagDraft = '';
+  readonly statusOptions: readonly string[] = ['Active', 'Pending', 'Disabled'];
+
   async ngOnInit() {
     await super.ngOnInit();
     this.loadShortcutsSetting();
+    // Fire-and-forget: test type list for the edit form
+    this.loadTestTypeOptions();
 
     // Subscribe to evaluation preferences
     this.evalPrefsService.preferences$
@@ -148,6 +156,15 @@ export class MJTestFormComponentExtended extends MJTestFormComponent implements 
   handleKeyboardShortcut(event: KeyboardEvent) {
     if (!this.keyboardShortcutsEnabled) return;
 
+    // Cmd/Ctrl + S: Save (if dirty)
+    if ((event.metaKey || event.ctrlKey) && event.key === 's' && !event.shiftKey) {
+      if (this.isDirty) {
+        event.preventDefault();
+        this.saveChanges();
+      }
+      return;
+    }
+
     // Cmd/Ctrl + R: Refresh
     if ((event.metaKey || event.ctrlKey) && event.key === 'r' && !event.shiftKey) {
       event.preventDefault();
@@ -162,8 +179,8 @@ export class MJTestFormComponentExtended extends MJTestFormComponent implements 
       return;
     }
 
-    // Number keys for tabs (1-5)
-    if (!event.metaKey && !event.ctrlKey && !event.altKey) {
+    // Number keys for tabs (1-5) — skip when typing into form inputs
+    if (!event.metaKey && !event.ctrlKey && !event.altKey && !this.isTextInputFocused()) {
       switch (event.key) {
         case '1': this.changeTab('overview'); break;
         case '2': this.changeTab('config'); break;
@@ -172,6 +189,22 @@ export class MJTestFormComponentExtended extends MJTestFormComponent implements 
         case '5': this.changeTab('analytics'); break;
       }
     }
+  }
+
+  // Warn before tab close / hard navigation when there are unsaved changes
+  @HostListener('window:beforeunload', ['$event'])
+  handleBeforeUnload(event: BeforeUnloadEvent) {
+    if (this.isDirty) {
+      event.preventDefault();
+      event.returnValue = '';
+    }
+  }
+
+  private isTextInputFocused(): boolean {
+    const el = document.activeElement;
+    if (!el) return false;
+    const tag = el.tagName;
+    return tag === 'INPUT' || tag === 'TEXTAREA' || tag === 'SELECT' || (el as HTMLElement).isContentEditable;
   }
 
   private async loadTestRuns() {
@@ -845,6 +878,116 @@ export class MJTestFormComponentExtended extends MJTestFormComponent implements 
       await this.shortcutsSettingEntity.Save();
     } catch (error) {
       console.warn('Failed to save shortcuts setting:', error);
+    }
+  }
+
+  // ==========================================
+  // Edit / Save Methods
+  // ==========================================
+
+  /** True if the test record has any unsaved field changes. */
+  get isDirty(): boolean {
+    return this.record?.Dirty === true;
+  }
+
+  /** Names of fields with pending edits, used by the save bar. */
+  get dirtyFieldNames(): string[] {
+    if (!this.record?.Fields) return [];
+    return this.record.Fields.filter(f => f.Dirty).map(f => f.Name);
+  }
+
+  /** Parsed tags as a plain array — derived from record.Tags JSON. */
+  get tags(): string[] {
+    return TagsHelper.parseTags(this.record?.Tags);
+  }
+
+  /** Load test types for the Type dropdown. */
+  private async loadTestTypeOptions() {
+    try {
+      const rv = RunView.FromMetadataProvider(this.ProviderToUse);
+      const result = await rv.RunView<MJTestTypeEntity>({
+        EntityName: 'MJ: Test Types',
+        OrderBy: 'Name',
+        ResultType: 'entity_object'
+      });
+      if (result.Success) {
+        this.testTypeOptions = result.Results || [];
+        this.cdr.markForCheck();
+      }
+    } catch (error) {
+      console.warn('Failed to load test type options:', error);
+    }
+  }
+
+  /** Save all pending changes on the test record. */
+  async saveChanges(): Promise<void> {
+    if (!this.isDirty || this.isSaving) return;
+
+    this.isSaving = true;
+    this.cdr.markForCheck();
+    try {
+      const ok = await this.SaveRecord(false);
+      if (ok) {
+        SharedService.Instance.CreateSimpleNotification('Test saved', 'success', 2000);
+        // Re-parse JSON fields since editor content may have changed
+        this.parseJsonFields();
+      } else {
+        const detail = this.record?.LatestResult?.CompleteMessage || this.record?.LatestResult?.Message || 'Save failed';
+        SharedService.Instance.CreateSimpleNotification(detail, 'error', 4000);
+      }
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : 'Save failed';
+      SharedService.Instance.CreateSimpleNotification(msg, 'error', 4000);
+    } finally {
+      this.isSaving = false;
+      this.cdr.markForCheck();
+    }
+  }
+
+  /** Discard all pending field changes on the test. */
+  discardChanges(): void {
+    if (!this.isDirty) return;
+    if (!confirm('Discard your unsaved changes?')) return;
+    this.record.Revert();
+    this.tagDraft = '';
+    this.parseJsonFields();
+    this.cdr.markForCheck();
+  }
+
+  /** Add a tag from tagDraft (called on Enter / comma / blur). */
+  addTagFromDraft(): void {
+    const raw = this.tagDraft.trim();
+    if (!raw) return;
+    const incoming = raw.split(',').map(t => t.trim()).filter(t => t.length > 0);
+    const existing = this.tags;
+    const merged = [...existing];
+    for (const t of incoming) {
+      if (!merged.includes(t)) merged.push(t);
+    }
+    this.record.Tags = TagsHelper.toJson(merged);
+    this.tagDraft = '';
+    this.cdr.markForCheck();
+  }
+
+  /** Remove a single tag. */
+  removeTag(tag: string): void {
+    this.record.Tags = TagsHelper.removeTag(this.record.Tags, tag);
+    this.cdr.markForCheck();
+  }
+
+  /** Handle Enter / comma in the tag input to commit the draft tag. */
+  onTagInputKeydown(event: KeyboardEvent): void {
+    if (event.key === 'Enter' || event.key === ',') {
+      event.preventDefault();
+      this.addTagFromDraft();
+      return;
+    }
+    if (event.key === 'Backspace' && !this.tagDraft) {
+      const all = this.tags;
+      if (all.length > 0) {
+        event.preventDefault();
+        this.removeTag(all[all.length - 1]);
+      }
     }
   }
 }

--- a/packages/Angular/Explorer/core-entity-forms/src/lib/custom/Tests/test-suite-form.component.css
+++ b/packages/Angular/Explorer/core-entity-forms/src/lib/custom/Tests/test-suite-form.component.css
@@ -3090,3 +3090,629 @@
     display: none;
   }
 }
+
+/* ===========================
+   Tests Tab — Action Bar + Drag/Remove
+   =========================== */
+
+.tests-actionbar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 12px 16px;
+  margin-bottom: 16px;
+  background: var(--test-surface);
+  border: 1px solid var(--test-border);
+  border-radius: var(--test-radius-md);
+}
+
+.tests-actionbar-text {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  flex-wrap: wrap;
+  min-width: 0;
+}
+
+.tests-actionbar-text strong {
+  font-size: 14px;
+  color: var(--test-text);
+  font-weight: 700;
+}
+
+.tests-actionbar-count {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 22px;
+  height: 22px;
+  padding: 0 8px;
+  border-radius: 999px;
+  background: color-mix(in srgb, var(--mj-brand-primary) 12%, var(--mj-bg-surface));
+  color: var(--mj-brand-primary-hover);
+  font-size: 12px;
+  font-weight: 700;
+}
+
+.tests-actionbar-hint {
+  font-size: 12px;
+  color: var(--test-text-muted);
+}
+
+.tests-actionbar-actions {
+  display: flex;
+  gap: 8px;
+  flex-shrink: 0;
+}
+
+/* Override the default test-item hover translate so drag transforms don't fight it. */
+.tests-list[cdk-drop-list] .test-item:hover,
+.tests-list .test-item.cdk-drag:hover {
+  transform: none;
+}
+
+/* The whole row is draggable. .test-content keeps the click-to-open behavior. */
+.test-item.cdk-drag {
+  position: relative;
+}
+
+.test-item .test-content {
+  cursor: pointer;
+}
+
+/* Drag handle */
+.test-drag-handle {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 22px;
+  height: 28px;
+  border-radius: 4px;
+  color: var(--test-text-muted);
+  cursor: grab;
+  flex-shrink: 0;
+  transition: background 0.15s, color 0.15s;
+  user-select: none;
+}
+
+.test-drag-handle:hover {
+  background: color-mix(in srgb, var(--mj-brand-primary) 10%, transparent);
+  color: var(--test-primary);
+}
+
+.test-drag-handle:active,
+.cdk-drag-preview .test-drag-handle {
+  cursor: grabbing;
+}
+
+/* Remove (X) button — hover-revealed */
+.test-remove-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 28px;
+  height: 28px;
+  border-radius: 50%;
+  border: none;
+  background: transparent;
+  color: var(--test-text-muted);
+  cursor: pointer;
+  flex-shrink: 0;
+  opacity: 0;
+  transition: opacity 0.15s, background 0.15s, color 0.15s;
+}
+
+.test-item:hover .test-remove-btn,
+.test-remove-btn:focus-visible {
+  opacity: 1;
+}
+
+.test-remove-btn:hover {
+  background: color-mix(in srgb, var(--mj-status-error) 12%, transparent);
+  color: var(--mj-status-error);
+}
+
+.test-chevron {
+  cursor: pointer;
+}
+
+/* Inline remove-confirm */
+.test-remove-confirm {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 4px 8px 4px 12px;
+  border-radius: 999px;
+  background: color-mix(in srgb, var(--mj-status-error) 8%, var(--test-surface));
+  border: 1px solid color-mix(in srgb, var(--mj-status-error) 30%, transparent);
+  flex-shrink: 0;
+}
+
+.test-remove-confirm-text {
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--mj-status-error-text, var(--mj-status-error));
+}
+
+.test-remove-confirm-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 4px 10px;
+  border-radius: 6px;
+  border: 1px solid transparent;
+  font-size: 12px;
+  font-weight: 600;
+  cursor: pointer;
+  font-family: inherit;
+  transition: var(--test-transition);
+}
+
+.test-remove-confirm-btn:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+.test-remove-confirm-btn--danger {
+  background: var(--mj-status-error);
+  color: var(--mj-text-inverse, white);
+}
+
+.test-remove-confirm-btn--danger:hover:not(:disabled) {
+  background: color-mix(in srgb, var(--mj-status-error) 88%, black);
+}
+
+.test-remove-confirm-btn--ghost {
+  background: transparent;
+  color: var(--test-text-secondary);
+  border-color: var(--test-border);
+}
+
+.test-remove-confirm-btn--ghost:hover:not(:disabled) {
+  background: var(--mj-bg-surface-hover, var(--mj-bg-surface-card));
+  color: var(--test-text);
+}
+
+/* CDK drag-drop visuals */
+.cdk-drag-preview {
+  box-shadow: 0 12px 32px rgba(15, 23, 42, 0.25);
+  border-radius: var(--test-radius-md);
+  background: var(--test-surface);
+  opacity: 0.95;
+}
+
+.cdk-drag-placeholder {
+  opacity: 0;
+  background: color-mix(in srgb, var(--mj-brand-primary) 8%, transparent);
+  border: 2px dashed var(--test-primary);
+  border-radius: var(--test-radius-md);
+}
+
+.cdk-drag-placeholder * {
+  visibility: hidden;
+}
+
+.cdk-drag-animating {
+  transition: transform 250ms cubic-bezier(0, 0, 0.2, 1);
+}
+
+.tests-list.cdk-drop-list-dragging .test-item:not(.cdk-drag-placeholder) {
+  transition: transform 250ms cubic-bezier(0, 0, 0.2, 1);
+}
+
+/* ===========================
+   Add Tests Picker Dialog
+   =========================== */
+
+.picker-backdrop {
+  position: fixed;
+  inset: 0;
+  background: rgba(15, 23, 42, 0.45);
+  z-index: 200;
+  animation: pickerFadeIn 180ms ease-out;
+  backdrop-filter: blur(2px);
+}
+
+@keyframes pickerFadeIn {
+  from { opacity: 0; }
+  to { opacity: 1; }
+}
+
+.picker-dialog {
+  position: fixed;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  width: min(720px, calc(100vw - 32px));
+  max-height: min(80vh, 720px);
+  z-index: 201;
+  display: flex;
+  flex-direction: column;
+  background: var(--test-surface);
+  border-radius: var(--test-radius-lg);
+  box-shadow: 0 24px 64px rgba(15, 23, 42, 0.28);
+  animation: pickerSlideUp 220ms cubic-bezier(0.16, 1, 0.3, 1);
+  overflow: hidden;
+}
+
+@keyframes pickerSlideUp {
+  from {
+    opacity: 0;
+    transform: translate(-50%, calc(-50% + 16px));
+  }
+  to {
+    opacity: 1;
+    transform: translate(-50%, -50%);
+  }
+}
+
+.picker-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 18px 20px;
+  border-bottom: 1px solid var(--test-border);
+}
+
+.picker-title {
+  margin: 0;
+  font-size: 16px;
+  font-weight: 700;
+  color: var(--test-text);
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.picker-title i {
+  color: var(--test-primary);
+}
+
+.picker-close {
+  width: 32px;
+  height: 32px;
+  border-radius: 8px;
+  border: none;
+  background: transparent;
+  color: var(--test-text-muted);
+  cursor: pointer;
+  font-size: 14px;
+  transition: background 0.15s, color 0.15s;
+}
+
+.picker-close:hover:not(:disabled) {
+  background: var(--mj-bg-surface-hover, var(--mj-bg-surface-card));
+  color: var(--test-text);
+}
+
+.picker-close:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.picker-search {
+  position: relative;
+  padding: 14px 20px 0 20px;
+}
+
+.picker-search-icon {
+  position: absolute;
+  top: 50%;
+  left: 32px;
+  transform: translateY(-30%);
+  color: var(--test-text-muted);
+  font-size: 13px;
+  pointer-events: none;
+}
+
+.picker-search-input {
+  width: 100%;
+  padding: 10px 36px 10px 36px;
+  border: 1px solid var(--test-border);
+  border-radius: var(--test-radius-sm);
+  background: var(--test-surface);
+  font-size: 14px;
+  color: var(--test-text);
+  font-family: inherit;
+  transition: var(--test-transition);
+}
+
+.picker-search-input:focus {
+  outline: none;
+  border-color: var(--test-primary);
+  box-shadow: 0 0 0 3px color-mix(in srgb, var(--mj-brand-primary) 15%, transparent);
+}
+
+.picker-search-clear {
+  position: absolute;
+  top: 50%;
+  right: 32px;
+  transform: translateY(-30%);
+  width: 22px;
+  height: 22px;
+  border-radius: 50%;
+  border: none;
+  background: transparent;
+  color: var(--test-text-muted);
+  cursor: pointer;
+  font-size: 11px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.picker-search-clear:hover {
+  background: var(--mj-bg-surface-hover, var(--mj-bg-surface-card));
+  color: var(--test-text);
+}
+
+.picker-toolbar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 10px 20px;
+  border-bottom: 1px solid var(--test-border);
+}
+
+.picker-toolbar-status {
+  font-size: 12px;
+  color: var(--test-text-secondary);
+}
+
+.picker-toolbar-status strong {
+  color: var(--mj-brand-primary-hover);
+  font-weight: 700;
+}
+
+.picker-toolbar-actions {
+  display: flex;
+  gap: 14px;
+}
+
+.picker-link-btn {
+  border: none;
+  background: transparent;
+  color: var(--test-primary);
+  font-size: 12px;
+  font-weight: 600;
+  cursor: pointer;
+  padding: 0;
+  font-family: inherit;
+}
+
+.picker-link-btn:hover:not(:disabled) {
+  text-decoration: underline;
+}
+
+.picker-link-btn:disabled {
+  color: var(--test-text-muted);
+  cursor: not-allowed;
+}
+
+.picker-body {
+  flex: 1;
+  overflow-y: auto;
+  padding: 8px 12px;
+  min-height: 200px;
+}
+
+.picker-loading {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 40px;
+}
+
+.picker-empty {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  text-align: center;
+  padding: 40px 20px;
+  color: var(--test-text-muted);
+}
+
+.picker-empty i {
+  font-size: 32px;
+  margin-bottom: 14px;
+  color: var(--test-text-muted);
+}
+
+.picker-empty h4 {
+  margin: 0 0 6px 0;
+  font-size: 15px;
+  font-weight: 700;
+  color: var(--test-text);
+}
+
+.picker-empty p {
+  margin: 0;
+  font-size: 13px;
+}
+
+.picker-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.picker-row {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 10px 12px;
+  border-radius: 8px;
+  cursor: pointer;
+  transition: background 0.12s, border-color 0.12s;
+  border: 1px solid transparent;
+}
+
+.picker-row:hover {
+  background: var(--mj-bg-surface-hover, var(--mj-bg-surface-card));
+}
+
+.picker-row:focus-visible {
+  outline: none;
+  border-color: var(--test-primary);
+  box-shadow: 0 0 0 2px color-mix(in srgb, var(--mj-brand-primary) 15%, transparent);
+}
+
+.picker-row--selected {
+  background: color-mix(in srgb, var(--mj-brand-primary) 8%, var(--test-surface));
+  border-color: color-mix(in srgb, var(--mj-brand-primary) 30%, transparent);
+}
+
+.picker-row--selected:hover {
+  background: color-mix(in srgb, var(--mj-brand-primary) 12%, var(--test-surface));
+}
+
+.picker-check {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 20px;
+  height: 20px;
+  border-radius: 5px;
+  border: 1.5px solid var(--test-border);
+  background: var(--test-surface);
+  color: var(--mj-text-inverse, white);
+  font-size: 11px;
+  flex-shrink: 0;
+  transition: background 0.12s, border-color 0.12s;
+}
+
+.picker-row--selected .picker-check {
+  background: var(--mj-brand-primary);
+  border-color: var(--mj-brand-primary);
+}
+
+.picker-row-main {
+  flex: 1;
+  min-width: 0;
+}
+
+.picker-row-name {
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--test-text);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.picker-row-desc {
+  font-size: 12px;
+  color: var(--test-text-muted);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  margin-top: 2px;
+}
+
+.picker-row-meta {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  flex-shrink: 0;
+}
+
+.picker-row-pill {
+  display: inline-flex;
+  align-items: center;
+  padding: 2px 8px;
+  border-radius: 999px;
+  font-size: 10px;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.3px;
+  background: var(--mj-bg-surface-sunken, var(--test-bg));
+  color: var(--test-text-secondary);
+  border: 1px solid var(--test-border);
+}
+
+.picker-row-pill--status[data-status="active"] {
+  background: color-mix(in srgb, var(--mj-status-success) 12%, var(--mj-bg-surface));
+  color: var(--mj-status-success);
+  border-color: color-mix(in srgb, var(--mj-status-success) 30%, transparent);
+}
+
+.picker-row-pill--status[data-status="disabled"] {
+  background: var(--mj-bg-surface-sunken, var(--test-bg));
+  color: var(--test-text-muted);
+}
+
+.picker-row-pill--status[data-status="pending"] {
+  background: color-mix(in srgb, var(--mj-status-warning) 12%, var(--mj-bg-surface));
+  color: var(--mj-status-warning-text, var(--mj-status-warning));
+  border-color: color-mix(in srgb, var(--mj-status-warning) 30%, transparent);
+}
+
+.picker-footer {
+  display: flex;
+  gap: 8px;
+  padding: 14px 20px;
+  border-top: 1px solid var(--test-border);
+  background: var(--mj-bg-surface-sunken, var(--test-bg));
+}
+
+.picker-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 9px 16px;
+  font-size: 13px;
+  font-weight: 600;
+  border-radius: 8px;
+  border: 1px solid transparent;
+  cursor: pointer;
+  font-family: inherit;
+  transition: var(--test-transition);
+}
+
+.picker-btn:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+.picker-btn--primary {
+  background: var(--mj-brand-primary);
+  color: var(--mj-text-inverse, white);
+  border-color: var(--mj-brand-primary);
+}
+
+.picker-btn--primary:hover:not(:disabled) {
+  background: var(--mj-brand-primary-hover, var(--mj-brand-primary));
+}
+
+.picker-btn--ghost {
+  background: transparent;
+  color: var(--test-text-secondary);
+  border-color: var(--test-border);
+}
+
+.picker-btn--ghost:hover:not(:disabled) {
+  background: var(--mj-bg-surface-hover, var(--mj-bg-surface-card));
+  color: var(--test-text);
+}
+
+@media (max-width: 640px) {
+  .picker-dialog {
+    width: calc(100vw - 16px);
+    max-height: calc(100vh - 32px);
+  }
+  .tests-actionbar {
+    flex-direction: column;
+    align-items: stretch;
+  }
+  .tests-actionbar-actions {
+    justify-content: flex-end;
+  }
+  .test-remove-btn {
+    opacity: 1; /* always visible on touch */
+  }
+}
+

--- a/packages/Angular/Explorer/core-entity-forms/src/lib/custom/Tests/test-suite-form.component.css
+++ b/packages/Angular/Explorer/core-entity-forms/src/lib/custom/Tests/test-suite-form.component.css
@@ -28,6 +28,7 @@
 }
 
 .test-suite-form {
+  position: relative;
   display: flex;
   flex-direction: column;
   height: 100%;
@@ -2667,4 +2668,425 @@
 .totals-auto .count-label {
   font-size: 10px;
   opacity: 0.8;
+}
+
+/* ===========================
+   Editable Overview Form
+   =========================== */
+
+.edit-section {
+  background: var(--test-surface);
+  border-radius: var(--test-radius-lg);
+  padding: 24px;
+  box-shadow: var(--test-shadow-sm);
+}
+
+.edit-section-header {
+  margin: 0 0 18px 0;
+}
+
+.edit-section-header h3 {
+  margin: 0 0 4px 0;
+  font-size: 18px;
+  font-weight: 700;
+  color: var(--test-text);
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.edit-section-header h3 i {
+  color: var(--test-primary);
+}
+
+.edit-section-sub {
+  margin: 0;
+  font-size: 12px;
+  color: var(--test-text-muted);
+}
+
+.edit-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 18px;
+}
+
+@media (max-width: 720px) {
+  .edit-grid {
+    grid-template-columns: 1fr;
+  }
+}
+
+.edit-field {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  min-width: 0;
+}
+
+.edit-field--full {
+  grid-column: 1 / -1;
+}
+
+.edit-field label {
+  font-size: 12px;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  color: var(--test-text-muted);
+}
+
+.edit-field .required {
+  color: var(--mj-status-error);
+  margin-left: 2px;
+}
+
+.config-textarea {
+  resize: vertical;
+  min-height: 72px;
+  font-family: inherit;
+  line-height: 1.5;
+}
+
+.select-wrapper {
+  position: relative;
+}
+
+.select-wrapper select.config-input {
+  padding-right: 36px;
+  appearance: none;
+  background-color: var(--test-surface);
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='12' height='8' viewBox='0 0 12 8'%3E%3Cpath fill='%2364748b' d='M1.41 0L6 4.59 10.59 0 12 1.41l-6 6-6-6z'/%3E%3C/svg%3E");
+  background-repeat: no-repeat;
+  background-position: right 14px center;
+  background-size: 10px 7px;
+}
+
+/* Tag editor (chips + inline input) */
+.tag-editor {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  padding: 8px 10px;
+  border: 1px solid var(--test-border);
+  border-radius: var(--test-radius-sm);
+  background: var(--test-surface);
+  transition: var(--test-transition);
+  cursor: text;
+  min-height: 42px;
+  align-items: center;
+}
+
+.tag-editor:focus-within {
+  border-color: var(--test-primary);
+  box-shadow: 0 0 0 3px color-mix(in srgb, var(--mj-brand-primary) 15%, transparent);
+}
+
+.tag-chip-editable {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 3px 4px 3px 10px;
+  background: color-mix(in srgb, var(--mj-brand-primary) 12%, var(--mj-bg-surface));
+  color: var(--mj-brand-primary-hover);
+  border-radius: 999px;
+  font-size: 12px;
+  font-weight: 600;
+  line-height: 1;
+  border: 1px solid color-mix(in srgb, var(--mj-brand-primary) 25%, transparent);
+}
+
+.tag-chip-editable .tag-remove {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 18px;
+  height: 18px;
+  border-radius: 50%;
+  border: none;
+  background: transparent;
+  color: var(--mj-brand-primary);
+  cursor: pointer;
+  font-size: 10px;
+  transition: background 0.15s;
+}
+
+.tag-chip-editable .tag-remove:hover {
+  background: color-mix(in srgb, var(--mj-brand-primary) 25%, transparent);
+  color: var(--mj-brand-primary-hover);
+}
+
+.tag-input-inline {
+  flex: 1;
+  min-width: 140px;
+  border: none;
+  background: transparent;
+  outline: none;
+  font-size: 13px;
+  color: var(--test-text);
+  padding: 4px 2px;
+}
+
+.tag-input-inline::placeholder {
+  color: var(--test-text-muted);
+}
+
+/* Read-only metadata section */
+.meta-section {
+  background: var(--mj-bg-surface-sunken);
+  border-radius: var(--test-radius-md);
+  padding: 14px 18px;
+  border: 1px solid var(--test-border);
+}
+
+.meta-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  gap: 14px;
+}
+
+.meta-item {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  min-width: 0;
+}
+
+.meta-label {
+  font-size: 10px;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  color: var(--test-text-muted);
+}
+
+.meta-value {
+  font-size: 12px;
+  color: var(--test-text-secondary);
+  font-weight: 500;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.meta-mono {
+  font-family: ui-monospace, SFMono-Regular, 'SF Mono', Menlo, monospace;
+  font-size: 11px;
+}
+
+/* Dirty indicator next to the title */
+.dirty-indicator {
+  display: inline-block;
+  margin-left: 8px;
+  font-size: 14px;
+  color: var(--mj-status-warning);
+  line-height: 1;
+  animation: pulseDot 1.8s ease-in-out infinite;
+  vertical-align: middle;
+}
+
+@keyframes pulseDot {
+  0%, 100% { opacity: 1; transform: scale(1); }
+  50% { opacity: 0.5; transform: scale(0.85); }
+}
+
+.unsaved-pill {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 4px 10px;
+  background: color-mix(in srgb, var(--mj-status-warning) 15%, var(--mj-bg-surface));
+  color: var(--mj-status-warning-text, var(--mj-status-warning));
+  border: 1px solid color-mix(in srgb, var(--mj-status-warning) 30%, transparent);
+  border-radius: 999px;
+  font-size: 11px;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.4px;
+}
+
+.unsaved-pill i {
+  font-size: 6px;
+  animation: pulseDot 1.8s ease-in-out infinite;
+}
+
+/* Pad the bottom of the tab content when the save bar is visible
+   so the bar doesn't cover the last form field. */
+.tab-content.has-savebar {
+  padding-bottom: 84px;
+}
+
+/* ===========================
+   Sticky Save Bar
+   =========================== */
+
+.save-bar {
+  position: absolute;
+  left: 16px;
+  right: 96px; /* leaves room for the bottom-right chat launcher */
+  bottom: 16px;
+  z-index: 50;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  padding: 12px 16px 12px 20px;
+  background: var(--mj-bg-surface-elevated, var(--test-surface));
+  border: 1px solid color-mix(in srgb, var(--mj-status-warning) 25%, var(--test-border));
+  border-radius: 14px;
+  box-shadow: 0 12px 32px color-mix(in srgb, var(--mj-status-warning) 10%, rgba(15, 23, 42, 0.18));
+  backdrop-filter: blur(8px);
+  /* Hidden / off-screen state by default. The .save-bar--visible class
+     animates it up into view. Using `transition` (not `animation`)
+     guarantees the change runs every time isDirty toggles. */
+  opacity: 0;
+  transform: translateY(calc(100% + 32px));
+  pointer-events: none;
+  transition:
+    transform 420ms cubic-bezier(0.16, 1, 0.3, 1),
+    opacity 260ms cubic-bezier(0.16, 1, 0.3, 1);
+  will-change: transform, opacity;
+}
+
+.save-bar--visible {
+  opacity: 1;
+  transform: translateY(0);
+  pointer-events: auto;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .save-bar {
+    transition: opacity 180ms ease-out;
+    transform: none;
+  }
+  .save-bar--visible {
+    transform: none;
+  }
+}
+
+.save-bar-message {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  min-width: 0;
+}
+
+.save-bar-dot {
+  color: var(--mj-status-warning);
+  font-size: 12px;
+  line-height: 1;
+  animation: pulseDot 1.8s ease-in-out infinite;
+}
+
+.save-bar-text {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  min-width: 0;
+}
+
+.save-bar-text strong {
+  font-size: 14px;
+  color: var(--test-text);
+  font-weight: 700;
+}
+
+.save-bar-fields {
+  font-size: 12px;
+  color: var(--test-text-muted);
+}
+
+.save-bar-actions {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-shrink: 0;
+}
+
+.save-bar-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 9px 16px;
+  font-size: 13px;
+  font-weight: 600;
+  border-radius: 8px;
+  border: 1px solid transparent;
+  cursor: pointer;
+  transition: var(--test-transition);
+  font-family: inherit;
+}
+
+.save-bar-btn:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+.save-bar-btn--primary {
+  background: var(--mj-brand-primary);
+  color: var(--mj-text-inverse, white);
+  border-color: var(--mj-brand-primary);
+  box-shadow: 0 2px 8px color-mix(in srgb, var(--mj-brand-primary) 35%, transparent);
+}
+
+.save-bar-btn--primary:hover:not(:disabled) {
+  background: var(--mj-brand-primary-hover, var(--mj-brand-primary));
+  transform: translateY(-1px);
+  box-shadow: 0 4px 12px color-mix(in srgb, var(--mj-brand-primary) 45%, transparent);
+}
+
+.save-bar-btn--primary:active:not(:disabled) {
+  transform: translateY(0);
+}
+
+.save-bar-btn--ghost {
+  background: transparent;
+  color: var(--test-text-secondary);
+  border-color: var(--test-border);
+}
+
+.save-bar-btn--ghost:hover:not(:disabled) {
+  background: var(--mj-bg-surface-hover, var(--mj-bg-surface-card));
+  color: var(--test-text);
+  border-color: var(--test-text-muted);
+}
+
+.save-bar-kbd {
+  display: inline-flex;
+  gap: 3px;
+  margin-left: 6px;
+  opacity: 0.85;
+}
+
+.save-bar-kbd kbd {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 18px;
+  height: 18px;
+  padding: 0 4px;
+  font-size: 10px;
+  font-weight: 600;
+  font-family: ui-monospace, SFMono-Regular, 'SF Mono', Menlo, monospace;
+  background: color-mix(in srgb, white 18%, transparent);
+  border: 1px solid color-mix(in srgb, white 35%, transparent);
+  border-radius: 4px;
+  color: inherit;
+}
+
+@media (max-width: 640px) {
+  .save-bar {
+    left: 8px;
+    right: 8px;
+    bottom: 88px; /* push above the chat launcher on small screens */
+    flex-direction: column;
+    align-items: stretch;
+    padding: 12px;
+  }
+  .save-bar-actions {
+    justify-content: space-between;
+  }
+  .save-bar-kbd {
+    display: none;
+  }
 }

--- a/packages/Angular/Explorer/core-entity-forms/src/lib/custom/Tests/test-suite-form.component.html
+++ b/packages/Angular/Explorer/core-entity-forms/src/lib/custom/Tests/test-suite-form.component.html
@@ -24,7 +24,12 @@
           <i class="fas fa-layer-group"></i>
         </div>
         <div class="suite-info">
-          <h1>{{ record.Name }}</h1>
+          <h1>
+            {{ record.Name }}
+            @if (isDirty) {
+              <span class="dirty-indicator" title="You have unsaved changes" aria-label="Unsaved changes">●</span>
+            }
+          </h1>
           <div class="suite-meta">
             <span class="status-badge" [ngClass]="getStatusClass()">
               <i class="fas" [ngClass]="record.Status === 'Active' ? 'fa-circle-check' : 'fa-circle-pause'"></i>
@@ -34,6 +39,11 @@
               <span class="test-count">
                 <i class="fas fa-flask"></i>
                 {{ suiteTests.length }} tests
+              </span>
+            }
+            @if (isDirty) {
+              <span class="unsaved-pill" title="You have unsaved changes">
+                <i class="fas fa-circle"></i> Unsaved
               </span>
             }
           </div>
@@ -108,47 +118,135 @@
   </div>
 
   <!-- Tab Content -->
-  <div class="tab-content">
+  <div class="tab-content" [class.has-savebar]="isDirty">
     <!-- Overview Tab -->
     @if (activeTab === 'overview') {
       <div class="overview-tab">
-        <div class="info-section">
-          <h3><i class="fas fa-info-circle"></i> Suite Information</h3>
-          <div class="info-grid">
-            <div class="info-item">
-              <div class="info-label">Name</div>
-              <div class="info-value">{{ record.Name }}</div>
+        <!-- Editable Details -->
+        <section class="edit-section">
+          <header class="edit-section-header">
+            <h3><i class="fas fa-pen-to-square"></i> Details</h3>
+            <p class="edit-section-sub">Edit any field — changes are saved with the bar at the bottom.</p>
+          </header>
+          <div class="edit-grid">
+            <div class="edit-field edit-field--full">
+              <label for="suite-name">Name <span class="required">*</span></label>
+              <input
+                id="suite-name"
+                type="text"
+                class="config-input"
+                placeholder="e.g., Core Agent Test Suite"
+                [(ngModel)]="record.Name"
+              />
             </div>
-            <div class="info-item">
-              <div class="info-label">Status</div>
-              <div class="info-value">
-                <span class="status-badge-inline" [ngClass]="getStatusClass()">{{ record.Status }}</span>
+
+            <div class="edit-field edit-field--full">
+              <label for="suite-description">Description</label>
+              <textarea
+                id="suite-description"
+                class="config-input config-textarea"
+                rows="3"
+                placeholder="What does this suite cover?"
+                [ngModel]="record.Description"
+                (ngModelChange)="record.Description = $event || null"
+              ></textarea>
+            </div>
+
+            <div class="edit-field">
+              <label for="suite-status">Status</label>
+              <div class="select-wrapper">
+                <select
+                  id="suite-status"
+                  class="config-input"
+                  [(ngModel)]="record.Status"
+                >
+                  @for (opt of statusOptions; track opt) {
+                    <option [ngValue]="opt">{{ opt }}</option>
+                  }
+                </select>
               </div>
             </div>
-            <div class="info-item">
-              <div class="info-label">Created</div>
-              <div class="info-value">{{ record.__mj_CreatedAt | date:'medium' }}</div>
+
+            <div class="edit-field">
+              <label for="suite-parent">Parent Suite</label>
+              <select
+                id="suite-parent"
+                class="config-input"
+                [ngModel]="record.ParentID"
+                (ngModelChange)="record.ParentID = $event || null"
+              >
+                <option [ngValue]="null">— None (top-level) —</option>
+                @for (s of parentSuiteOptions; track s.ID) {
+                  <option [ngValue]="s.ID">{{ s.Name }}</option>
+                }
+              </select>
             </div>
-            <div class="info-item">
-              <div class="info-label">Updated</div>
-              <div class="info-value">{{ record.__mj_UpdatedAt | date:'medium' }}</div>
-            </div>
-            <div class="info-item">
-              <div class="info-label">Max Execution Time</div>
-              <div class="info-value">{{ formatTimeout(record.MaxExecutionTimeMS) }}</div>
+
+            <div class="edit-field edit-field--full">
+              <label for="suite-tags">Tags</label>
+              <div class="tag-editor" (click)="tagInput.focus()">
+                @for (tag of tags; track tag) {
+                  <span class="tag-chip-editable">
+                    {{ tag }}
+                    <button type="button" class="tag-remove" (click)="removeTag(tag); $event.stopPropagation()" [attr.aria-label]="'Remove tag ' + tag">
+                      <i class="fas fa-times"></i>
+                    </button>
+                  </span>
+                }
+                <input
+                  #tagInput
+                  id="suite-tags"
+                  type="text"
+                  class="tag-input-inline"
+                  [placeholder]="tags.length === 0 ? 'Add tags, press Enter or comma...' : ''"
+                  [(ngModel)]="tagDraft"
+                  (keydown)="onTagInputKeydown($event)"
+                  (blur)="addTagFromDraft()"
+                />
+              </div>
+              <span class="config-hint">Press Enter or comma to add a tag. Backspace on empty input removes the last tag.</span>
             </div>
           </div>
-        </div>
-        <div class="config-section">
-          <h3><i class="fas fa-cogs"></i> Execution Settings</h3>
-          <div class="config-grid">
-            <div class="config-item">
-              <label>Max Execution Time (ms)</label>
-              <input type="number" [(ngModel)]="record.MaxExecutionTimeMS" class="config-input" placeholder="Default: 300000 (5 min)" />
-              <span class="config-hint">Default timeout for tests in this suite</span>
+        </section>
+
+        <!-- Execution Settings -->
+        <section class="edit-section">
+          <header class="edit-section-header">
+            <h3><i class="fas fa-cogs"></i> Execution Settings</h3>
+          </header>
+          <div class="edit-grid">
+            <div class="edit-field">
+              <label for="suite-timeout">Max Execution Time (ms)</label>
+              <input
+                id="suite-timeout"
+                type="number"
+                class="config-input"
+                placeholder="Default: 300000 (5 min)"
+                [ngModel]="record.MaxExecutionTimeMS"
+                (ngModelChange)="record.MaxExecutionTimeMS = $event === '' || $event === null ? null : +$event"
+              />
+              <span class="config-hint">Default timeout for tests in this suite. Currently: {{ formatTimeout(record.MaxExecutionTimeMS) }}</span>
             </div>
           </div>
-        </div>
+        </section>
+
+        <!-- Metadata (read-only) -->
+        <section class="meta-section">
+          <div class="meta-grid">
+            <div class="meta-item">
+              <div class="meta-label">Created</div>
+              <div class="meta-value">{{ record.__mj_CreatedAt | date:'medium' }}</div>
+            </div>
+            <div class="meta-item">
+              <div class="meta-label">Last updated</div>
+              <div class="meta-value">{{ record.__mj_UpdatedAt | date:'medium' }}</div>
+            </div>
+            <div class="meta-item">
+              <div class="meta-label">Suite ID</div>
+              <div class="meta-value meta-mono">{{ record.ID }}</div>
+            </div>
+          </div>
+        </section>
       </div>
     }
 
@@ -996,6 +1094,10 @@
       </div>
       <div class="shortcut-list">
         <div class="shortcut-item">
+          <span>Save changes</span>
+          <span class="shortcut-keys"><kbd>Cmd</kbd><kbd>S</kbd></span>
+        </div>
+        <div class="shortcut-item">
           <span>Refresh</span>
           <span class="shortcut-keys"><kbd>Cmd</kbd><kbd>R</kbd></span>
         </div>
@@ -1027,4 +1129,55 @@
       </app-test-run-dialog>
     </mj-slide-panel>
   }
+
+  <!-- Sticky Save Bar — always in the DOM so CSS transitions can fire reliably.
+       Visibility is controlled by the .save-bar--visible class, driven by isDirty. -->
+  <div
+    class="save-bar"
+    [class.save-bar--visible]="isDirty"
+    [attr.aria-hidden]="!isDirty"
+    role="region"
+    aria-label="Unsaved changes"
+  >
+    <div class="save-bar-message">
+      <span class="save-bar-dot" aria-hidden="true">●</span>
+      <span class="save-bar-text">
+        <strong>Unsaved changes</strong>
+        <span class="save-bar-fields">
+          @if (dirtyFieldNames.length === 1) {
+            {{ dirtyFieldNames[0] }} edited
+          } @else if (dirtyFieldNames.length > 1) {
+            {{ dirtyFieldNames.length }} fields edited
+          }
+        </span>
+      </span>
+    </div>
+    <div class="save-bar-actions">
+      <button
+        type="button"
+        class="save-bar-btn save-bar-btn--primary"
+        (click)="saveChanges()"
+        [disabled]="isSaving || !isDirty"
+        [attr.tabindex]="isDirty ? 0 : -1"
+        title="Save changes (⌘S)"
+      >
+        @if (isSaving) {
+          <i class="fas fa-spinner fa-spin"></i> Saving…
+        } @else {
+          <i class="fas fa-check"></i> Save changes
+          <span class="save-bar-kbd"><kbd>⌘</kbd><kbd>S</kbd></span>
+        }
+      </button>
+      <button
+        type="button"
+        class="save-bar-btn save-bar-btn--ghost"
+        (click)="discardChanges()"
+        [disabled]="isSaving || !isDirty"
+        [attr.tabindex]="isDirty ? 0 : -1"
+        title="Discard changes"
+      >
+        <i class="fas fa-undo"></i> Discard
+      </button>
+    </div>
+  </div>
 </div>

--- a/packages/Angular/Explorer/core-entity-forms/src/lib/custom/Tests/test-suite-form.component.html
+++ b/packages/Angular/Explorer/core-entity-forms/src/lib/custom/Tests/test-suite-form.component.html
@@ -253,6 +253,22 @@
     <!-- Tests Tab -->
     @if (activeTab === 'tests') {
       <div class="tests-tab">
+        <!-- Header: action bar -->
+        <div class="tests-actionbar">
+          <div class="tests-actionbar-text">
+            <strong>Suite tests</strong>
+            @if (testsLoaded) {
+              <span class="tests-actionbar-count">{{ suiteTests.length }}</span>
+            }
+            <span class="tests-actionbar-hint">Drag to reorder · Hover a row to remove</span>
+          </div>
+          <div class="tests-actionbar-actions">
+            <button mjButton variant="primary" (click)="openAddTestsDialog()" [disabled]="isReorderingTests">
+              <i class="fas fa-plus"></i> Add tests
+            </button>
+          </div>
+        </div>
+
         <!-- Loading State -->
         @if (loadingTests) {
           <div class="loading-state">
@@ -272,12 +288,15 @@
         }
         <!-- Tests List -->
         @if (!loadingTests && suiteTests.length > 0) {
-          <div class="tests-list">
-            @for (test of suiteTests; track test) {
-              <div class="test-item" (click)="openTest(test.TestID)">
+          <div class="tests-list" cdkDropList (cdkDropListDropped)="onTestDrop($event)">
+            @for (test of suiteTests; track test.ID) {
+              <div class="test-item" cdkDrag [cdkDragDisabled]="isReorderingTests || isRemovingTest">
+                <span class="test-drag-handle" cdkDragHandle title="Drag to reorder" aria-label="Drag to reorder">
+                  <i class="fas fa-grip-vertical"></i>
+                </span>
                 <div class="test-sequence">{{ test.Sequence }}</div>
                 <div class="test-icon"><i class="fas fa-flask"></i></div>
-                <div class="test-content">
+                <div class="test-content" (click)="openTest(test.TestID)">
                   <div class="test-name">{{ test.Test }}</div>
                   <div class="test-status">
                     @if (test.Status) {
@@ -285,7 +304,43 @@
                     }
                   </div>
                 </div>
-                <i class="fas fa-chevron-right"></i>
+                <!-- Inline remove confirm OR hover-reveal X -->
+                @if (confirmingRemoveSuiteTestId === test.ID) {
+                  <div class="test-remove-confirm" (click)="$event.stopPropagation()">
+                    <span class="test-remove-confirm-text">Remove from suite?</span>
+                    <button
+                      type="button"
+                      class="test-remove-confirm-btn test-remove-confirm-btn--danger"
+                      (click)="confirmRemoveTest(test, $event)"
+                      [disabled]="isRemovingTest"
+                    >
+                      @if (isRemovingTest) {
+                        <i class="fas fa-spinner fa-spin"></i>
+                      } @else {
+                        Remove
+                      }
+                    </button>
+                    <button
+                      type="button"
+                      class="test-remove-confirm-btn test-remove-confirm-btn--ghost"
+                      (click)="cancelRemoveTest($event)"
+                      [disabled]="isRemovingTest"
+                    >
+                      Cancel
+                    </button>
+                  </div>
+                } @else {
+                  <button
+                    type="button"
+                    class="test-remove-btn"
+                    title="Remove from suite"
+                    aria-label="Remove from suite"
+                    (click)="requestRemoveTest(test, $event)"
+                  >
+                    <i class="fas fa-times"></i>
+                  </button>
+                  <i class="fas fa-chevron-right test-chevron" (click)="openTest(test.TestID)"></i>
+                }
               </div>
             }
           </div>
@@ -298,6 +353,9 @@
             </div>
             <h4>No Tests in Suite</h4>
             <p>Add tests to this suite to start running them together.</p>
+            <button mjButton variant="primary" (click)="openAddTestsDialog()">
+              <i class="fas fa-plus"></i> Add tests
+            </button>
           </div>
         }
       </div>
@@ -1128,6 +1186,137 @@
         (PanelClose)="OnPanelClosed()">
       </app-test-run-dialog>
     </mj-slide-panel>
+  }
+
+  <!-- Add Tests Picker Dialog -->
+  @if (showAddTestsDialog) {
+    <div class="picker-backdrop" (click)="closeAddTestsDialog()"></div>
+    <div class="picker-dialog" role="dialog" aria-modal="true" aria-labelledby="add-tests-dialog-title" (click)="$event.stopPropagation()">
+      <div class="picker-header">
+        <h2 id="add-tests-dialog-title" class="picker-title">
+          <i class="fas fa-plus-circle"></i> Add tests to suite
+        </h2>
+        <button type="button" class="picker-close" (click)="closeAddTestsDialog()" [disabled]="isAddingTests" aria-label="Close">
+          <i class="fas fa-times"></i>
+        </button>
+      </div>
+
+      <div class="picker-search">
+        <i class="fas fa-search picker-search-icon"></i>
+        <input
+          #pickerSearch
+          type="text"
+          class="picker-search-input"
+          placeholder="Search tests by name, description, or type..."
+          [(ngModel)]="addTestsSearch"
+          autofocus
+        />
+        @if (addTestsSearch) {
+          <button type="button" class="picker-search-clear" (click)="addTestsSearch = ''" aria-label="Clear search">
+            <i class="fas fa-times"></i>
+          </button>
+        }
+      </div>
+
+      <div class="picker-toolbar">
+        <span class="picker-toolbar-status">
+          @if (selectedTestIdsToAdd.size > 0) {
+            <strong>{{ selectedTestIdsToAdd.size }}</strong> selected
+          } @else if (!loadingAvailableTests) {
+            {{ filteredAvailableTests.length }} test{{ filteredAvailableTests.length === 1 ? '' : 's' }} available
+          }
+        </span>
+        <div class="picker-toolbar-actions">
+          <button type="button" class="picker-link-btn" (click)="selectAllFiltered()" [disabled]="loadingAvailableTests || filteredAvailableTests.length === 0">
+            Select all
+          </button>
+          <button type="button" class="picker-link-btn" (click)="clearAddSelection()" [disabled]="selectedTestIdsToAdd.size === 0">
+            Clear
+          </button>
+        </div>
+      </div>
+
+      <div class="picker-body">
+        @if (loadingAvailableTests) {
+          <div class="picker-loading">
+            <mj-loading text="Loading tests..."></mj-loading>
+          </div>
+        } @else if (filteredAvailableTests.length === 0) {
+          <div class="picker-empty">
+            @if (availableTests.length === 0) {
+              <i class="fas fa-check-circle"></i>
+              <h4>Everything's already in the suite</h4>
+              <p>This suite contains every available test. Create a new test first to add more.</p>
+            } @else {
+              <i class="fas fa-search"></i>
+              <h4>No matches</h4>
+              <p>No tests match "{{ addTestsSearch }}".</p>
+            }
+          </div>
+        } @else {
+          <ul class="picker-list">
+            @for (t of filteredAvailableTests; track t.ID) {
+              <li
+                class="picker-row"
+                [class.picker-row--selected]="isAddSelected(t.ID)"
+                (click)="toggleAddSelection(t.ID)"
+                role="checkbox"
+                [attr.aria-checked]="isAddSelected(t.ID)"
+                tabindex="0"
+              >
+                <span class="picker-check">
+                  @if (isAddSelected(t.ID)) {
+                    <i class="fas fa-check"></i>
+                  }
+                </span>
+                <div class="picker-row-main">
+                  <div class="picker-row-name">{{ t.Name }}</div>
+                  @if (t.Description) {
+                    <div class="picker-row-desc">{{ t.Description }}</div>
+                  }
+                </div>
+                <div class="picker-row-meta">
+                  @if (t.Type) {
+                    <span class="picker-row-pill">{{ t.Type }}</span>
+                  }
+                  <span class="picker-row-pill picker-row-pill--status" [attr.data-status]="t.Status?.toLowerCase()">{{ t.Status }}</span>
+                </div>
+              </li>
+            }
+          </ul>
+        }
+      </div>
+
+      <div class="picker-footer">
+        <button
+          type="button"
+          class="picker-btn picker-btn--primary"
+          (click)="confirmAddTests()"
+          [disabled]="selectedTestIdsToAdd.size === 0 || isAddingTests"
+        >
+          @if (isAddingTests) {
+            <i class="fas fa-spinner fa-spin"></i> Adding…
+          } @else {
+            <i class="fas fa-check"></i>
+            @if (selectedTestIdsToAdd.size === 0) {
+              Add tests
+            } @else if (selectedTestIdsToAdd.size === 1) {
+              Add 1 test
+            } @else {
+              Add {{ selectedTestIdsToAdd.size }} tests
+            }
+          }
+        </button>
+        <button
+          type="button"
+          class="picker-btn picker-btn--ghost"
+          (click)="closeAddTestsDialog()"
+          [disabled]="isAddingTests"
+        >
+          Cancel
+        </button>
+      </div>
+    </div>
   }
 
   <!-- Sticky Save Bar — always in the DOM so CSS transitions can fire reliably.

--- a/packages/Angular/Explorer/core-entity-forms/src/lib/custom/Tests/test-suite-form.component.ts
+++ b/packages/Angular/Explorer/core-entity-forms/src/lib/custom/Tests/test-suite-form.component.ts
@@ -3,7 +3,8 @@ import * as d3 from 'd3';
 import { Subject } from 'rxjs';
 import { takeUntil, debounceTime, distinctUntilChanged } from 'rxjs/operators';
 import { CompositeKey, Metadata, RunView } from '@memberjunction/core';
-import { MJTestSuiteEntity, MJTestSuiteTestEntity, MJTestSuiteRunEntity, MJTestRunEntity, MJTestRunFeedbackEntity, MJUserSettingEntity, UserInfoEngine } from '@memberjunction/core-entities';
+import { CdkDragDrop, moveItemInArray } from '@angular/cdk/drag-drop';
+import { MJTestEntity, MJTestSuiteEntity, MJTestSuiteTestEntity, MJTestSuiteRunEntity, MJTestRunEntity, MJTestRunFeedbackEntity, MJUserSettingEntity, UserInfoEngine } from '@memberjunction/core-entities';
 import { BaseFormComponent } from '@memberjunction/ng-base-forms';
 import { RegisterClass, UUIDsEqual } from '@memberjunction/global';
 import { SharedService, NavigationService } from '@memberjunction/ng-shared';
@@ -98,6 +99,21 @@ export class MJTestSuiteFormComponentExtended extends MJTestSuiteFormComponent i
   parentSuiteOptions: MJTestSuiteEntity[] = [];
   tagDraft = '';
   readonly statusOptions: readonly string[] = ['Active', 'Pending', 'Disabled'];
+
+  // Add Tests picker state
+  showAddTestsDialog = false;
+  availableTests: MJTestEntity[] = [];
+  loadingAvailableTests = false;
+  selectedTestIdsToAdd = new Set<string>();
+  addTestsSearch = '';
+  isAddingTests = false;
+
+  // Remove-confirm state (per-row inline confirm)
+  confirmingRemoveSuiteTestId: string | null = null;
+  isRemovingTest = false;
+
+  // Reorder state
+  isReorderingTests = false;
 
   // Service injections
   private navigationService = inject(NavigationService);
@@ -2064,6 +2080,254 @@ export class MJTestSuiteFormComponentExtended extends MJTestSuiteFormComponent i
         event.preventDefault();
         this.removeTag(all[all.length - 1]);
       }
+    }
+  }
+
+  // ==========================================
+  // Suite Membership: Add / Remove / Reorder Tests
+  // ==========================================
+
+  /** Open the picker dialog and load tests not yet in this suite. */
+  async openAddTestsDialog(): Promise<void> {
+    this.showAddTestsDialog = true;
+    this.selectedTestIdsToAdd = new Set<string>();
+    this.addTestsSearch = '';
+    this.loadingAvailableTests = true;
+    this.cdr.markForCheck();
+
+    try {
+      if (!this.testsLoaded) {
+        await this.loadTests();
+      }
+
+      const existingTestIds = new Set(this.suiteTests.map(st => st.TestID));
+      const rv = RunView.FromMetadataProvider(this.ProviderToUse);
+      const result = await rv.RunView<MJTestEntity>({
+        EntityName: 'MJ: Tests',
+        OrderBy: 'Name',
+        ResultType: 'entity_object'
+      });
+
+      if (result.Success) {
+        this.availableTests = (result.Results || []).filter(t => !existingTestIds.has(t.ID));
+      } else {
+        SharedService.Instance.CreateSimpleNotification('Failed to load tests', 'error', 3000);
+      }
+    } catch (err) {
+      console.error('Error loading available tests:', err);
+      SharedService.Instance.CreateSimpleNotification('Failed to load tests', 'error', 3000);
+    } finally {
+      this.loadingAvailableTests = false;
+      this.cdr.markForCheck();
+    }
+  }
+
+  closeAddTestsDialog(): void {
+    if (this.isAddingTests) return;
+    this.showAddTestsDialog = false;
+    this.selectedTestIdsToAdd = new Set<string>();
+    this.addTestsSearch = '';
+    this.cdr.markForCheck();
+  }
+
+  toggleAddSelection(testId: string): void {
+    if (this.selectedTestIdsToAdd.has(testId)) {
+      this.selectedTestIdsToAdd.delete(testId);
+    } else {
+      this.selectedTestIdsToAdd.add(testId);
+    }
+    // Set mutation alone doesn't trigger OnPush — assign a new reference
+    this.selectedTestIdsToAdd = new Set(this.selectedTestIdsToAdd);
+    this.cdr.markForCheck();
+  }
+
+  isAddSelected(testId: string): boolean {
+    return this.selectedTestIdsToAdd.has(testId);
+  }
+
+  /** Tests that match the picker search filter. */
+  get filteredAvailableTests(): MJTestEntity[] {
+    const q = this.addTestsSearch.trim().toLowerCase();
+    if (!q) return this.availableTests;
+    return this.availableTests.filter(t =>
+      (t.Name || '').toLowerCase().includes(q) ||
+      (t.Description || '').toLowerCase().includes(q) ||
+      (t.Type || '').toLowerCase().includes(q)
+    );
+  }
+
+  selectAllFiltered(): void {
+    for (const t of this.filteredAvailableTests) {
+      this.selectedTestIdsToAdd.add(t.ID);
+    }
+    this.selectedTestIdsToAdd = new Set(this.selectedTestIdsToAdd);
+    this.cdr.markForCheck();
+  }
+
+  clearAddSelection(): void {
+    this.selectedTestIdsToAdd = new Set<string>();
+    this.cdr.markForCheck();
+  }
+
+  /** Create suite-test rows for every selected test, appended after existing ones. */
+  async confirmAddTests(): Promise<void> {
+    if (this.selectedTestIdsToAdd.size === 0 || this.isAddingTests) return;
+
+    this.isAddingTests = true;
+    this.cdr.markForCheck();
+
+    const provider = this.ProviderToUse;
+    const startSequence = this.suiteTests.reduce((max, st) => Math.max(max, st.Sequence ?? 0), 0);
+    const idsToAdd = Array.from(this.selectedTestIdsToAdd);
+    // Snapshot test names from the picker so we can hydrate the joined "Test"
+    // column on the optimistic rows (BaseEntity's joined view fields aren't
+    // always populated through a TransactionGroup save).
+    const testNameById = new Map<string, string>(
+      this.availableTests.map(t => [t.ID, t.Name])
+    );
+
+    try {
+      const tg = await provider.CreateTransactionGroup();
+      const newRows: MJTestSuiteTestEntity[] = [];
+
+      for (let i = 0; i < idsToAdd.length; i++) {
+        const row = await provider.GetEntityObject<MJTestSuiteTestEntity>('MJ: Test Suite Tests', provider.CurrentUser);
+        row.NewRecord();
+        row.SuiteID = this.record.ID;
+        row.TestID = idsToAdd[i];
+        row.Sequence = startSequence + i + 1;
+        row.Status = 'Active';
+        row.TransactionGroup = tg;
+        await row.Save();
+        newRows.push(row);
+      }
+
+      const ok = await tg.Submit();
+      if (ok) {
+        // Optimistic UI update: append the saved rows immediately so the user
+        // sees the new tests right away. If the joined "Test" name field
+        // didn't come back from the save (TG quirk), hydrate it from the
+        // picker snapshot.
+        for (const row of newRows) {
+          if (!row.Test) {
+            const name = testNameById.get(row.TestID);
+            if (name) {
+              row.Set('Test', name);
+            }
+          }
+        }
+        this.suiteTests = [...this.suiteTests, ...newRows];
+        this.cdr.markForCheck();
+
+        SharedService.Instance.CreateSimpleNotification(
+          idsToAdd.length === 1 ? 'Test added to suite' : `${idsToAdd.length} tests added to suite`,
+          'success',
+          2000
+        );
+        this.showAddTestsDialog = false;
+        this.selectedTestIdsToAdd = new Set<string>();
+        this.addTestsSearch = '';
+      } else {
+        const failed = newRows.find(r => r.LatestResult && !r.LatestResult.Success);
+        const detail = failed?.LatestResult?.CompleteMessage || 'Failed to add tests';
+        SharedService.Instance.CreateSimpleNotification(detail, 'error', 4000);
+      }
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : 'Failed to add tests';
+      SharedService.Instance.CreateSimpleNotification(msg, 'error', 4000);
+    } finally {
+      this.isAddingTests = false;
+      this.cdr.markForCheck();
+    }
+  }
+
+  /** Show the inline remove-confirm for one suite-test row. */
+  requestRemoveTest(suiteTest: MJTestSuiteTestEntity, event?: Event): void {
+    if (event) event.stopPropagation();
+    this.confirmingRemoveSuiteTestId = suiteTest.ID;
+    this.cdr.markForCheck();
+  }
+
+  cancelRemoveTest(event?: Event): void {
+    if (event) event.stopPropagation();
+    this.confirmingRemoveSuiteTestId = null;
+    this.cdr.markForCheck();
+  }
+
+  /** Delete the suite-test join row and refresh the list. */
+  async confirmRemoveTest(suiteTest: MJTestSuiteTestEntity, event?: Event): Promise<void> {
+    if (event) event.stopPropagation();
+    if (this.isRemovingTest) return;
+    this.isRemovingTest = true;
+    this.cdr.markForCheck();
+
+    try {
+      const ok = await suiteTest.Delete();
+      if (ok) {
+        this.suiteTests = this.suiteTests.filter(t => t.ID !== suiteTest.ID);
+        SharedService.Instance.CreateSimpleNotification('Test removed from suite', 'success', 2000);
+      } else {
+        const detail = suiteTest.LatestResult?.CompleteMessage || 'Failed to remove test';
+        SharedService.Instance.CreateSimpleNotification(detail, 'error', 4000);
+      }
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : 'Failed to remove test';
+      SharedService.Instance.CreateSimpleNotification(msg, 'error', 4000);
+    } finally {
+      this.isRemovingTest = false;
+      this.confirmingRemoveSuiteTestId = null;
+      this.cdr.markForCheck();
+    }
+  }
+
+  /** Handle CDK drag-drop reordering — persists new Sequence values. */
+  async onTestDrop(event: CdkDragDrop<MJTestSuiteTestEntity[]>): Promise<void> {
+    if (event.previousIndex === event.currentIndex) return;
+
+    // Optimistic reorder
+    const reordered = [...this.suiteTests];
+    moveItemInArray(reordered, event.previousIndex, event.currentIndex);
+    this.suiteTests = reordered;
+    this.cdr.markForCheck();
+
+    // Compute which rows actually changed sequence (1-based contiguous numbering)
+    const dirty: MJTestSuiteTestEntity[] = [];
+    reordered.forEach((row, idx) => {
+      const newSeq = idx + 1;
+      if (row.Sequence !== newSeq) {
+        row.Sequence = newSeq;
+        dirty.push(row);
+      }
+    });
+
+    if (dirty.length === 0) return;
+
+    this.isReorderingTests = true;
+    this.cdr.markForCheck();
+
+    const provider = this.ProviderToUse;
+    try {
+      const tg = await provider.CreateTransactionGroup();
+      for (const row of dirty) {
+        row.TransactionGroup = tg;
+        await row.Save();
+      }
+      const ok = await tg.Submit();
+      if (!ok) {
+        const failed = dirty.find(r => r.LatestResult && !r.LatestResult.Success);
+        const detail = failed?.LatestResult?.CompleteMessage || 'Failed to save new order';
+        SharedService.Instance.CreateSimpleNotification(detail, 'error', 4000);
+        this.testsLoaded = false;
+        await this.loadTests();
+      }
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : 'Failed to save new order';
+      SharedService.Instance.CreateSimpleNotification(msg, 'error', 4000);
+      this.testsLoaded = false;
+      await this.loadTests();
+    } finally {
+      this.isReorderingTests = false;
+      this.cdr.markForCheck();
     }
   }
 }

--- a/packages/Angular/Explorer/core-entity-forms/src/lib/custom/Tests/test-suite-form.component.ts
+++ b/packages/Angular/Explorer/core-entity-forms/src/lib/custom/Tests/test-suite-form.component.ts
@@ -93,6 +93,12 @@ export class MJTestSuiteFormComponentExtended extends MJTestSuiteFormComponent i
   matrixTestFilter = '';
   private matrixFilterSubject$ = new Subject<string>();
 
+  // Edit state
+  isSaving = false;
+  parentSuiteOptions: MJTestSuiteEntity[] = [];
+  tagDraft = '';
+  readonly statusOptions: readonly string[] = ['Active', 'Pending', 'Disabled'];
+
   // Service injections
   private navigationService = inject(NavigationService);
   public testingDialogService = inject(TestingDialogService);
@@ -103,6 +109,8 @@ export class MJTestSuiteFormComponentExtended extends MJTestSuiteFormComponent i
   async ngOnInit() {
     await super.ngOnInit();
     this.loadShortcutsSetting();
+    // Fire-and-forget: parent suite list for the edit form
+    this.loadParentSuiteOptions();
 
     // Subscribe to evaluation preferences
     this.evalPrefsService.preferences$
@@ -150,6 +158,15 @@ export class MJTestSuiteFormComponentExtended extends MJTestSuiteFormComponent i
   handleKeyboardShortcut(event: KeyboardEvent) {
     if (!this.keyboardShortcutsEnabled) return;
 
+    // Cmd/Ctrl + S: Save (if dirty)
+    if ((event.metaKey || event.ctrlKey) && event.key === 's' && !event.shiftKey) {
+      if (this.isDirty) {
+        event.preventDefault();
+        this.saveChanges();
+      }
+      return;
+    }
+
     // Cmd/Ctrl + R: Refresh
     if ((event.metaKey || event.ctrlKey) && event.key === 'r' && !event.shiftKey) {
       event.preventDefault();
@@ -164,8 +181,8 @@ export class MJTestSuiteFormComponentExtended extends MJTestSuiteFormComponent i
       return;
     }
 
-    // Number keys for tabs (1-5)
-    if (!event.metaKey && !event.ctrlKey && !event.altKey) {
+    // Number keys for tabs (1-5) — skip when typing into form inputs
+    if (!event.metaKey && !event.ctrlKey && !event.altKey && !this.isTextInputFocused()) {
       switch (event.key) {
         case '1': this.changeTab('overview'); break;
         case '2': this.changeTab('tests'); break;
@@ -174,6 +191,22 @@ export class MJTestSuiteFormComponentExtended extends MJTestSuiteFormComponent i
         case '5': this.changeTab('compare'); break;
       }
     }
+  }
+
+  // Warn before tab close / hard navigation when there are unsaved changes
+  @HostListener('window:beforeunload', ['$event'])
+  handleBeforeUnload(event: BeforeUnloadEvent) {
+    if (this.isDirty) {
+      event.preventDefault();
+      event.returnValue = '';
+    }
+  }
+
+  private isTextInputFocused(): boolean {
+    const el = document.activeElement;
+    if (!el) return false;
+    const tag = el.tagName;
+    return tag === 'INPUT' || tag === 'TEXTAREA' || tag === 'SELECT' || (el as HTMLElement).isContentEditable;
   }
 
   changeTab(tab: string) {
@@ -1919,6 +1952,119 @@ export class MJTestSuiteFormComponentExtended extends MJTestSuiteFormComponent i
   /** Case-insensitive UUID check whether a run is the currently selected Run B (compare). */
   public IsCompareRunB(run: MJTestSuiteRunEntity): boolean {
     return UUIDsEqual(this.compareRunB?.ID, run.ID);
+  }
+
+  // ==========================================
+  // Edit / Save Methods
+  // ==========================================
+
+  /** True if the suite record has any unsaved field changes. */
+  get isDirty(): boolean {
+    return this.record?.Dirty === true;
+  }
+
+  /** Names of fields with pending edits, used by the save bar. */
+  get dirtyFieldNames(): string[] {
+    if (!this.record?.Fields) return [];
+    return this.record.Fields.filter(f => f.Dirty).map(f => f.Name);
+  }
+
+  /** Parsed tags as a plain array — derived from record.Tags JSON. */
+  get tags(): string[] {
+    return TagsHelper.parseTags(this.record?.Tags);
+  }
+
+  /**
+   * Load all suites for the Parent Suite dropdown. Excludes the current
+   * suite (a suite cannot be its own parent).
+   */
+  private async loadParentSuiteOptions() {
+    try {
+      const rv = RunView.FromMetadataProvider(this.ProviderToUse);
+      const result = await rv.RunView<MJTestSuiteEntity>({
+        EntityName: 'MJ: Test Suites',
+        ExtraFilter: this.record?.ID ? `ID <> '${this.record.ID}'` : '',
+        OrderBy: 'Name',
+        ResultType: 'entity_object'
+      });
+      if (result.Success) {
+        this.parentSuiteOptions = result.Results || [];
+        this.cdr.markForCheck();
+      }
+    } catch (error) {
+      console.warn('Failed to load parent suite options:', error);
+    }
+  }
+
+  /** Save all pending changes on the suite record. */
+  async saveChanges(): Promise<void> {
+    if (!this.isDirty || this.isSaving) return;
+
+    this.isSaving = true;
+    this.cdr.markForCheck();
+    try {
+      const ok = await this.SaveRecord(false);
+      if (ok) {
+        SharedService.Instance.CreateSimpleNotification('Suite saved', 'success', 2000);
+      } else {
+        const detail = this.record?.LatestResult?.CompleteMessage || this.record?.LatestResult?.Message || 'Save failed';
+        SharedService.Instance.CreateSimpleNotification(detail, 'error', 4000);
+      }
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : 'Save failed';
+      SharedService.Instance.CreateSimpleNotification(msg, 'error', 4000);
+    } finally {
+      this.isSaving = false;
+      this.cdr.markForCheck();
+    }
+  }
+
+  /** Discard all pending field changes on the suite. */
+  discardChanges(): void {
+    if (!this.isDirty) return;
+    if (!confirm('Discard your unsaved changes?')) return;
+    this.record.Revert();
+    this.tagDraft = '';
+    this.cdr.markForCheck();
+  }
+
+  /** Add a tag from tagDraft (called on Enter / comma / blur). */
+  addTagFromDraft(): void {
+    const raw = this.tagDraft.trim();
+    if (!raw) return;
+    // Allow comma-separated entry: "alpha, beta" → two tags
+    const incoming = raw.split(',').map(t => t.trim()).filter(t => t.length > 0);
+    const existing = this.tags;
+    const merged = [...existing];
+    for (const t of incoming) {
+      if (!merged.includes(t)) merged.push(t);
+    }
+    this.record.Tags = TagsHelper.toJson(merged);
+    this.tagDraft = '';
+    this.cdr.markForCheck();
+  }
+
+  /** Remove a single tag. */
+  removeTag(tag: string): void {
+    this.record.Tags = TagsHelper.removeTag(this.record.Tags, tag);
+    this.cdr.markForCheck();
+  }
+
+  /** Handle Enter / comma in the tag input to commit the draft tag. */
+  onTagInputKeydown(event: KeyboardEvent): void {
+    if (event.key === 'Enter' || event.key === ',') {
+      event.preventDefault();
+      this.addTagFromDraft();
+      return;
+    }
+    // Backspace on an empty draft pops the last chip
+    if (event.key === 'Backspace' && !this.tagDraft) {
+      const all = this.tags;
+      if (all.length > 0) {
+        event.preventDefault();
+        this.removeTag(all[all.length - 1]);
+      }
+    }
   }
 }
 

--- a/packages/Angular/Explorer/core-entity-forms/src/lib/custom/custom-forms.module.ts
+++ b/packages/Angular/Explorer/core-entity-forms/src/lib/custom/custom-forms.module.ts
@@ -1,6 +1,7 @@
 import { NgModule } from "@angular/core";
 import { CommonModule } from '@angular/common';
 import { FormsModule, ReactiveFormsModule } from '@angular/forms';
+import { DragDropModule } from '@angular/cdk/drag-drop';
 import { MJButtonDirective, MJAccordionPanelComponent, MJAccordionTitleDirective, MJDropdownComponent, MJComboboxComponent, MJSwitchComponent, MJDialogComponent, MJDialogTitlebarComponent, MJDialogActionsComponent, MJNumericInputComponent, MJWindowComponent, MJWindowTitlebarComponent, MJProgressBarComponent } from '@memberjunction/ng-ui-components';
 import { AngularSplitModule } from 'angular-split';
 import { AgGridModule } from 'ag-grid-angular';
@@ -118,6 +119,7 @@ import { SearchModule } from "@memberjunction/ng-search";
         CommonModule,
         FormsModule,
         ReactiveFormsModule,
+        DragDropModule,
         AgGridModule,
         MJButtonDirective,
         MJAccordionPanelComponent,


### PR DESCRIPTION
## Summary

Brings the custom Test and Test Suite forms up to a "world-class" inline-edit experience and adds in-place suite membership management.

Previously the custom Test Suite form (and the custom Test form) exposed editable fields (status, max execution time, JSON editors, etc.) but provided no way for users to actually save their changes — there was no save button, no dirty indicator, and no UI for managing the tests inside a suite. Users were silently losing every change. The Tests tab of the Test Suite form was also read-only, with no way to add tests, remove them, or reorder them.

This PR fixes both gaps inside `@memberjunction/ng-core-entity-forms` (the only package touched).

## What's new

### Inline edit + sticky save bar (both Test and Test Suite forms)
- Editable Name, Description, Status (dropdown), Parent Suite / Test Type (dropdowns), and execution settings on the Overview/Configuration tab
- Chip-style tag editor with Enter/comma to add, backspace-on-empty to pop, X to remove
- Dirty indicator (pulsing dot next to the title + "Unsaved" pill in the meta row) the moment any field becomes dirty
- Sticky save bar pinned to the bottom-right of the form that slides up on dirty (CSS `transition` on a class toggle so it's reliable across mounts) and slides back down on save/discard
- `⌘S` / `Ctrl+S` to save, hint badge rendered on the Save button
- `beforeunload` guard so accidental navigation prompts the user
- Toast notifications on save success / failure (with the entity's `CompleteMessage` on failure)

### Suite membership management (Test Suite form > Tests tab)
- New action bar with a count badge and **+ Add tests** button
- Searchable multi-select picker dialog (with status pills, type pills, "Select all" / "Clear" helpers)
- Optimistic local append after save (with joined `Test` name hydration so the new rows show up immediately — no refresh needed)
- Hover-revealed × on every row with an inline "Remove from suite?" confirm pill (Remove / Cancel)
- CDK drag-and-drop reordering: the row order in the UI reflects the new contiguous `Sequence` values, which are persisted via a single transaction group; falls back to a server refresh if the save fails
- Mobile fallback: × stays visible (no hover on touch), action bar stacks vertically

### Misc
- `@angular/cdk@21.1.3` declared as a direct dependency so downstream consumers don't rely on transitive hoisting from `explorer-core`
- `DragDropModule` registered in `custom-forms.module.ts`

## Commits

1. `feat(testing): add world-class save/edit UX to Test and Test Suite forms`
2. `docs(changeset): Add inline save/edit UX to Test and Test Suite forms`
3. `feat(testing): add/remove/reorder tests in Test Suite form`
4. `fix(ng-core-entity-forms): declare @angular/cdk dependency`

## Scope
- **Versioning**: `@memberjunction/ng-core-entity-forms` → `patch` (covered by `.changeset/eager-pandas-glide.md`)
- **Migrations**: none
- **Breaking changes**: none

## Test plan

- [x] Open a Test Suite from the Testing dashboard → edit Name/Description/Status → confirm pulsing dot + "Unsaved" pill appear immediately
- [x] Verify save bar slides up smoothly and `⌘S` triggers the save
- [x] Click Discard, verify the form reverts and the save bar slides back down
- [x] Edit a tag (add via Enter, add via comma, remove via X, remove last via backspace) → save → reopen → confirm persisted
- [x] Repeat the above for a Test record (Configuration tab)
- [x] Hover a suite-test row → click × → confirm pill appears → Remove → row disappears, toast shows
- [x] Drag a suite-test row to a new position → confirm Sequence numbers update visually, refresh the page, confirm the order persisted

## Screenshots
<img width="1800" height="970" alt="Screenshot 2026-05-20 at 9 37 32 AM" src="https://github.com/user-attachments/assets/2a9e3367-3cca-4933-9afe-836396719664" />
<img width="1800" height="970" alt="Screenshot 2026-05-20 at 9 38 09 AM" src="https://github.com/user-attachments/assets/830515d1-e5b2-4774-b876-22a1fedbdb3e" />
<img width="1800" height="970" alt="Screenshot 2026-05-20 at 10 23 16 AM" src="https://github.com/user-attachments/assets/5b843e8a-c075-4979-9c1e-d09e98db1292" />
<img width="1800" height="970" alt="Screenshot 2026-05-20 at 10 23 50 AM" src="https://github.com/user-attachments/assets/7448bbd2-4f15-4ce6-8880-c036d797045e" />


🤖 Generated with [Claude Code](https://claude.com/claude-code)
