### PR TITLE
fix(conversations): allow creating a collection from empty Save-to-Collection state

### DIFF
--- a/.changeset/collection-picker-empty-create.md
+++ b/.changeset/collection-picker-empty-create.md
@@ -1,0 +1,5 @@
+---
+"@memberjunction/ng-conversations": patch
+---
+
+Fix Save-to-Collection dialog so a new collection can be created from the empty state. Previously the "Create new collection…" affordance only rendered inside the collection tree, which is hidden when the user has no editable collections — leaving no way to create the first one.

--- a/packages/Angular/Generic/conversations/src/lib/components/collection/artifact-collection-picker-modal.component.ts
+++ b/packages/Angular/Generic/conversations/src/lib/components/collection/artifact-collection-picker-modal.component.ts
@@ -113,7 +113,36 @@ interface SaveResult {
                   } @else {
                     <i class="fa-solid fa-folder-open"></i>
                     <p>No editable collections yet</p>
-                    <p class="hint">Create one to get started</p>
+                    @if (showCreateForm) {
+                      <div class="empty-create-form">
+                        <input #newNameInput type="text"
+                               class="create-input"
+                               [(ngModel)]="newCollectionName"
+                               (keydown.enter)="createCollection()"
+                               (keydown.escape)="cancelCreate()"
+                               placeholder="Collection name"
+                               [disabled]="isCreatingCollection" />
+                        <div class="empty-create-actions">
+                          <button mjButton variant="primary" size="sm"
+                                  (click)="createCollection()"
+                                  [disabled]="isCreatingCollection || !newCollectionName.trim()">
+                            @if (isCreatingCollection) {
+                              <i class="fa-solid fa-spinner fa-spin"></i>
+                            } @else {
+                              Create
+                            }
+                          </button>
+                          <button mjButton size="sm" (click)="cancelCreate()" [disabled]="isCreatingCollection">
+                            Cancel
+                          </button>
+                        </div>
+                      </div>
+                    } @else {
+                      <p class="hint">Create one to get started</p>
+                      <button mjButton variant="primary" size="sm" (click)="openCreateForm()">
+                        <i class="fa-solid fa-plus"></i> New collection
+                      </button>
+                    }
                   }
                 </div>
               } @else {
@@ -499,6 +528,13 @@ interface SaveResult {
     }
     .state-block .link-btn:hover { color: var(--mj-text-link-hover); text-decoration: underline; }
     .state-block p { margin: 0; font-size: 13.5px; }
+    /* Buttons inside state blocks: keep their icons at button scale, not the 28px empty-state glyph size */
+    .state-block button i { font-size: inherit; opacity: 1; }
+    .empty-create-form {
+      display: flex; flex-direction: column; gap: 8px;
+      width: 100%; max-width: 280px; margin-top: 4px;
+    }
+    .empty-create-actions { display: flex; gap: 8px; justify-content: center; }
 
     /* ===== Right pane ===== */
     .preview-block { padding: 16px 18px; border-bottom: 1px solid var(--mj-border-subtle); }


### PR DESCRIPTION
## Summary

The Save-to-Collection dialog's **"Create new collection…"** affordance only rendered *inside* the collection tree, which is hidden when the user has zero editable collections. The empty state showed *"No editable collections yet / Create one to get started"* — text instructing the user to create a collection, but with no button to do so. A chicken-and-egg dead end.

## Fix

Added the create affordance directly to the empty state:
- A **"New collection"** button when no form is open
- The inline name input + Create/Cancel buttons when the form is open

Reuses the existing `openCreateForm()` / `createCollection()` / `cancelCreate()` methods — no logic changes, template + scoped CSS only. Patch changeset included for `@memberjunction/ng-conversations`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)