### PR TITLE
fix(vectors): stop keyset pagination infinite loop in vector sync

### DIFF
--- a/.changeset/keyset-pagination-vector-sync-loop.md
+++ b/.changeset/keyset-pagination-vector-sync-loop.md
@@ -1,0 +1,7 @@
+---
+"@memberjunction/core": patch
+"@memberjunction/ai-vectors": patch
+"@memberjunction/ai-vector-sync": patch
+---
+
+Fix keyset (AfterKey) pagination infinite loop in vector sync. `GenerateRunViewFingerprint` omitted `AfterKey`, so sequential keyset pages produced identical fingerprints and the dedup/linger layer returned page N's result for page N+1, freezing the seek cursor (observed on multi-page entities like a 2k-row Members table). The fingerprint now includes `AfterKey` (appended only when present, so non-keyset fingerprints are unchanged), fixing all keyset callers. The vectorizer's page reads now also set `BypassCache` since full-table sweeps read each page once, and `EntityVectorSyncer` halts with a clear error if the cursor ever fails to advance.

--- a/packages/AI/Vectors/Core/src/models/VectorBase.ts
+++ b/packages/AI/Vectors/Core/src/models/VectorBase.ts
@@ -70,6 +70,12 @@ export class VectorBase {
             EntityName: entity.Name,
             ResultType: params.ResultType,
             MaxRows: params.PageSize,
+            // Vectorization sweeps the entire entity one page at a time; each page is read
+            // exactly once. Caching these bulk pages is pure downside — it pollutes the local
+            // cache with single-use results and pulls in the dedup/linger layer (which keyed
+            // sequential keyset pages identically and froze the seek cursor). Bypass all caching
+            // so every page is a fresh DB read.
+            BypassCache: true,
             ...(useKeyset
                 ? { AfterKey: params.AfterKey, OrderBy: entity.FirstPrimaryKey!.Name }
                 : { StartRow: Math.max(0, (params.PageNumber - 1) * params.PageSize) }),

--- a/packages/AI/Vectors/Sync/src/models/entityVectorSync.ts
+++ b/packages/AI/Vectors/Sync/src/models/entityVectorSync.ts
@@ -536,6 +536,15 @@ export class EntityVectorSyncer extends VectorBase {
             LogError(`Keyset pagination: last record on page ${pageIndex + 1} has null PK; halting iteration.`);
             break;
           }
+          // Safety net: the cursor must strictly advance each page. If it doesn't, the seek
+          // window is repeating (e.g. the query isn't ordered by the PK, or a caching layer
+          // is returning a stale page) and we'd loop forever. Bail with a clear diagnostic.
+          const prevKeyValue = lastSeenKey?.KeyValuePairs?.[0]?.Value;
+          if (prevKeyValue != null && String(prevKeyValue) === String(lastValue)) {
+            LogError(`Keyset cursor did not advance (stuck at ${pkField.Name}=${lastValue}); halting to avoid an infinite loop. ` +
+              `The seek page is repeating — check that the query is ordered by ${pkField.Name} and not served from a stale cache.`);
+            break;
+          }
           lastSeenKey = CompositeKey.FromKeyValuePair(pkField.Name, lastValue);
         } else {
           pageNumber++;

--- a/packages/MJCore/src/__tests__/localCacheManager.afterKeyFingerprint.test.ts
+++ b/packages/MJCore/src/__tests__/localCacheManager.afterKeyFingerprint.test.ts
@@ -1,0 +1,44 @@
+import { describe, it, expect } from 'vitest';
+import { LocalCacheManager } from '../generic/localCacheManager';
+import { CompositeKey } from '../generic/compositeKey';
+import type { RunViewParams } from '../views/runView';
+
+/**
+ * Regression coverage for the keyset (AfterKey) pagination infinite-loop bug.
+ *
+ * GenerateRunViewFingerprint is the key used by both the local result cache AND the
+ * dedup/linger layer in ProviderBase. It originally omitted AfterKey, so sequential
+ * keyset pages — identical in every param except the seek cursor — produced the same
+ * fingerprint. The dedup linger window then returned page N's result for page N+1,
+ * freezing the cursor and looping forever (observed against the 2k-row Members entity).
+ */
+describe('GenerateRunViewFingerprint — AfterKey (keyset) participation', () => {
+    const cache = LocalCacheManager.Instance;
+    const base = { EntityName: 'Members', OrderBy: 'ID', MaxRows: 50 } as unknown as RunViewParams;
+
+    it('produces distinct fingerprints for different AfterKey seek cursors', () => {
+        const page2 = cache.GenerateRunViewFingerprint({
+            ...base,
+            AfterKey: CompositeKey.FromKeyValuePair('ID', '61D4CB4C-0B10-44D7-984E-0643338C1AE3'),
+        } as RunViewParams);
+        const page3 = cache.GenerateRunViewFingerprint({
+            ...base,
+            AfterKey: CompositeKey.FromKeyValuePair('ID', 'B6990264-B95B-4CAC-9A7A-0DADD1AF9F21'),
+        } as RunViewParams);
+
+        expect(page2).not.toBe(page3);
+    });
+
+    it('leaves non-keyset fingerprints unchanged (no AfterKey segment when absent)', () => {
+        const fp = cache.GenerateRunViewFingerprint(base);
+        expect(fp).not.toContain('ak:');
+    });
+
+    it('includes the seek cursor value in the fingerprint when AfterKey is present', () => {
+        const fp = cache.GenerateRunViewFingerprint({
+            ...base,
+            AfterKey: CompositeKey.FromKeyValuePair('ID', 'B6990264-B95B-4CAC-9A7A-0DADD1AF9F21'),
+        } as RunViewParams);
+        expect(fp).toContain('ak:ID=B6990264-B95B-4CAC-9A7A-0DADD1AF9F21');
+    });
+});

--- a/packages/MJCore/src/generic/localCacheManager.ts
+++ b/packages/MJCore/src/generic/localCacheManager.ts
@@ -1131,6 +1131,15 @@ export class LocalCacheManager extends BaseSingleton<LocalCacheManager> {
             userSearch || '_'        // User search string (generates LIKE/FTS clauses)
         ];
 
+        // Keyset (AfterKey) seek cursor MUST be part of the fingerprint. Each keyset page
+        // sends a different AfterKey but otherwise-identical params; without this, sequential
+        // pages collide on the same fingerprint and the dedup/linger layer hands page N+1 the
+        // result of page N — freezing the cursor and looping forever. Appended only when present
+        // so non-keyset fingerprints stay byte-for-byte identical (no cache invalidation).
+        if (params.AfterKey) {
+            parts.push(`ak:${params.AfterKey.ToString()}`);
+        }
+
         // Only include connection if provided
         if (connection) {
             parts.push(connection);


### PR DESCRIPTION
## Summary
Fixes an infinite loop in vector sync when keyset (`AfterKey`) pagination iterates a multi-page entity (observed on a 2k-row Members table — it spun to 100k+ pages, re-fetching the same 50 rows).

**Root cause:** `GenerateRunViewFingerprint` omitted `AfterKey`. On the server, `AfterKey` queries bypass the result cache but fall through to `RunViews`, whose dedup/linger layer is keyed by that fingerprint. Sequential keyset pages (identical except the seek cursor) produced the same fingerprint, so page N+1 got a linger hit and received page N's rows — freezing the cursor.

## Changes
- **`@memberjunction/core`** — include `AfterKey` in `GenerateRunViewFingerprint`, appended only when present so non-keyset fingerprints stay byte-identical (no cache invalidation). Fixes all keyset callers, not just vectorization.
- **`@memberjunction/ai-vectors`** — `VectorBase` sets `BypassCache` on the vectorizer's page reads; full-table sweeps read each page once, so caching them is pure downside and pulls in the dedup layer.
- **`@memberjunction/ai-vector-sync`** — `EntityVectorSyncer` halts with a clear error if the keyset cursor fails to advance, instead of spinning.
- New regression test for `AfterKey` fingerprint participation.

## Test plan
- [x] New `localCacheManager.afterKeyFingerprint.test.ts` (3 tests) pass
- [x] Full MJCore suite (1160 tests) pass
- [x] Vectors/Core suite (58 tests) pass
- [x] All three packages build clean
- [x] Verified live: Members vector sync now pages cleanly through all ~40 pages and finishes

## Note
This branch also includes two pre-existing conversations commits (`2cc886415f`, `2c905e36c4`) that predate this work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)