### PR TITLE
fix(graphql): expose RunViewParams.BypassCache through the GraphQL surface

### DIFF
--- a/.changeset/early-bars-occur.md
+++ b/.changeset/early-bars-occur.md
@@ -1,0 +1,6 @@
+---
+"@memberjunction/graphql-dataprovider": patch
+"@memberjunction/server": patch
+---
+
+Expose RunViewParams.BypassCache through GraphQL surface

--- a/packages/GraphQLDataProvider/src/graphQLDataProvider.ts
+++ b/packages/GraphQLDataProvider/src/graphQLDataProvider.ts
@@ -836,6 +836,13 @@ export class GraphQLDataProvider extends ProviderBase implements IEntityDataProv
                 innerParams.ResultType = params.ResultType ? params.ResultType : 'simple';
                 if (params.AuditLogDescription && params.AuditLogDescription.length > 0)
                     innerParams.AuditLogDescription = params.AuditLogDescription;
+                // BypassCache instructs the server to skip its RunView cache layer for this
+                // query — used for cross-entity subqueries the cache invalidator can't follow
+                // (e.g. WHERE … IN (SELECT … FROM vwListDetails …)) or for maintenance reads
+                // that need true DB state. Only forward when explicitly set so default behavior
+                // (server caching enabled) is unchanged.
+                if (params.BypassCache !== undefined)
+                    innerParams.BypassCache = params.BypassCache;
 
                 if (!dynamicView) {
                     innerParams.ExcludeUserViewRunID = params.ExcludeUserViewRunID ? params.ExcludeUserViewRunID : "";
@@ -1004,6 +1011,9 @@ export class GraphQLDataProvider extends ProviderBase implements IEntityDataProv
                     innerParam.ResultType = param.ResultType || 'simple';
                     if (param.AuditLogDescription && param.AuditLogDescription.length > 0){
                         innerParam.AuditLogDescription = param.AuditLogDescription;
+                    }
+                    if (param.BypassCache !== undefined) {
+                        innerParam.BypassCache = param.BypassCache;
                     }
 
                     if (!dynamicView) {

--- a/packages/MJServer/src/generic/ResolverBase.ts
+++ b/packages/MJServer/src/generic/ResolverBase.ts
@@ -359,7 +359,8 @@ export class ResolverBase {
           viewInput.Aggregates,
           viewInput.AfterKey
             ? CompositeKey.FromKeyValuePairs((viewInput.AfterKey as { KeyValuePairs: { FieldName: string; Value: string }[] }).KeyValuePairs)
-            : undefined
+            : undefined,
+          viewInput.BypassCache
         );
       }
       else {
@@ -400,7 +401,9 @@ export class ResolverBase {
         userPayload,
         viewInput.MaxRows,
         viewInput.StartRow,
-        viewInput.Aggregates
+        viewInput.Aggregates,
+        undefined,
+        viewInput.BypassCache
       );
     } catch (err) {
       console.log(err);
@@ -444,7 +447,9 @@ export class ResolverBase {
         userPayload,
         viewInput.MaxRows,
         viewInput.StartRow,
-        viewInput.Aggregates
+        viewInput.Aggregates,
+        undefined,
+        viewInput.BypassCache
       );
     } catch (err) {
       console.log(err);
@@ -517,6 +522,7 @@ export class ResolverBase {
           resultType: viewInput.ResultType,
           userPayload,
           aggregates: viewInput.Aggregates,
+          bypassCache: viewInput.BypassCache,
         });
       } catch (err) {
         LogError(err);
@@ -693,7 +699,8 @@ export class ResolverBase {
     maxRows: number | undefined,
     startRow: number | undefined,
     aggregates?: AggregateExpression[],
-    afterKey?: CompositeKey
+    afterKey?: CompositeKey,
+    bypassCache?: boolean
   ) {
     try {
       if (!viewInfo || !userPayload) return null;
@@ -757,6 +764,7 @@ export class ResolverBase {
           AuditLogDescription: auditLogDescription,
           ResultType: rt,
           Aggregates: aggregates,
+          BypassCache: bypassCache,
         },
         user
       );
@@ -870,6 +878,7 @@ export class ResolverBase {
           AuditLogDescription: param.auditLogDescription,
           ResultType: rt,
           Aggregates: param.aggregates,
+          BypassCache: param.bypassCache,
         });
       }
 

--- a/packages/MJServer/src/generic/RunViewResolver.ts
+++ b/packages/MJServer/src/generic/RunViewResolver.ts
@@ -170,6 +170,13 @@ export class RunViewByIDInput {
     description: 'Optional aggregate expressions to calculate on the full result set (e.g., SUM, COUNT, AVG). Results are returned in AggregateResults.',
   })
   Aggregates?: AggregateExpressionInput[];
+
+  @Field(() => Boolean, {
+    nullable: true,
+    description:
+      'Optional, when true bypasses ALL server-side caching for this view run — the pre-check cache lookup is skipped and the result is not stored in the cache. Use for maintenance/audit queries that must see true database state, or to force-refresh views whose filters reference rows the server cache invalidator cannot follow (e.g., cross-entity subqueries against vwListDetails).',
+  })
+  BypassCache?: boolean;
 }
 
 @InputType()
@@ -277,6 +284,13 @@ export class RunViewByNameInput {
     description: 'Optional aggregate expressions to calculate on the full result set (e.g., SUM, COUNT, AVG). Results are returned in AggregateResults.',
   })
   Aggregates?: AggregateExpressionInput[];
+
+  @Field(() => Boolean, {
+    nullable: true,
+    description:
+      'Optional, when true bypasses ALL server-side caching for this view run — the pre-check cache lookup is skipped and the result is not stored in the cache. Use for maintenance/audit queries that must see true database state, or to force-refresh views whose filters reference rows the server cache invalidator cannot follow (e.g., cross-entity subqueries against vwListDetails).',
+  })
+  BypassCache?: boolean;
 }
 
 @InputType()
@@ -370,6 +384,13 @@ export class RunDynamicViewInput {
     description: 'Optional aggregate expressions to calculate on the full result set (e.g., SUM, COUNT, AVG). Results are returned in AggregateResults.',
   })
   Aggregates?: AggregateExpressionInput[];
+
+  @Field(() => Boolean, {
+    nullable: true,
+    description:
+      'Optional, when true bypasses ALL server-side caching for this view run — the pre-check cache lookup is skipped and the result is not stored in the cache. Use for maintenance/audit queries that must see true database state, or to force-refresh views whose filters reference rows the server cache invalidator cannot follow (e.g., cross-entity subqueries against vwListDetails).',
+  })
+  BypassCache?: boolean;
 }
 
 @InputType()
@@ -492,6 +513,13 @@ export class RunViewGenericInput {
     description: 'Optional aggregate expressions to calculate on the full result set (e.g., SUM, COUNT, AVG). Results are returned in AggregateResults.',
   })
   Aggregates?: AggregateExpressionInput[];
+
+  @Field(() => Boolean, {
+    nullable: true,
+    description:
+      'Optional, when true bypasses ALL server-side caching for this view run — the pre-check cache lookup is skipped and the result is not stored in the cache. Use for maintenance/audit queries that must see true database state, or to force-refresh views whose filters reference rows the server cache invalidator cannot follow (e.g., cross-entity subqueries against vwListDetails).',
+  })
+  BypassCache?: boolean;
 }
 
 //****************************************************************************

--- a/packages/MJServer/src/types.ts
+++ b/packages/MJServer/src/types.ts
@@ -101,6 +101,12 @@ export type RunViewGenericParams = {
   resultType?: string;
   userPayload?: UserPayload;
   aggregates?: AggregateExpression[];
+  /**
+   * When true, the server-side cache layer is bypassed for this view run —
+   * neither the pre-check cache lookup nor the post-query cache write
+   * happens. Propagated to `RunViewParams.BypassCache`.
+   */
+  bypassCache?: boolean;
 };
 
 


### PR DESCRIPTION
## Summary

`RunViewParams.BypassCache` was honored on the server (via `ProviderBase`) but never exposed on the GraphQL surface — browser-originated `RunView({BypassCache: true})` calls were silently dropped before reaching the wire. This plumbs the flag end-to-end.

- All four `Run*Input` GraphQL input classes now declare `BypassCache?: boolean`
- `RunViewGenericParams` carries it through the resolver layer
- `GraphQLDataProvider.InternalRunView` / `InternalRunViews` forward `params.BypassCache` only when explicitly set, so default cache behavior is unchanged
- Existing Angular callers that already pass `BypassCache: true` (KnowledgeHub config, DatabaseDesigner) become effective — they were no-ops at the server before
- Server-side direct callers (UserInfoEngine, SearchScopePermissionResolver, scheduled-geocoding, MetadataSync) were unaffected and remain so

## Test plan
- [x] MJServer build & unit tests pass (`@memberjunction/server`: 213 tests pre-fix)
- [x] Open a list-detail grid (or any Angular view that sets `BypassCache: true`) → confirm the GraphQL request payload includes the field and the server no longer rejects it with `Field "BypassCache" is not defined by type "..."`
- [x] Verify default (no BypassCache set) RunView calls still hit the server cache as before — no regression in cache hit rates on unfiltered ≤250-row queries

🤖 Generated with [Claude Code](https://claude.com/claude-code)