### PR TITLE
fix(open-app): fix baseline skipping + mixed-case schema names

### DIFF
--- a/.changeset/fix-open-app-baseline-version.md
+++ b/.changeset/fix-open-app-baseline-version.md
@@ -1,0 +1,5 @@
+---
+"@memberjunction/open-app-engine": patch
+---
+
+Fix baseline migrations being silently skipped during `mj app install`. The install orchestrator passed `BaselineVersion: '0'` to Skyway, but the resolver only auto-selects the highest baseline file when `BaselineVersion === '1'`. Changed to `'1'` so baseline files (B* prefix) are correctly discovered and executed on fresh database installs. Also allowed mixed-case schema names in manifest validation (SQL Server is case-insensitive) to support apps like BizApps Common (`__mj_BizAppsCommon`).

--- a/packages/OpenApp/Engine/src/install/migration-runner.ts
+++ b/packages/OpenApp/Engine/src/install/migration-runner.ts
@@ -35,6 +35,7 @@ interface SkywayConfig {
         BaselineOnMigrate: boolean;
     };
     Placeholders?: Record<string, string>;
+    TransactionMode?: 'per-run' | 'per-migration';
     Provider?: unknown;
 }
 
@@ -213,7 +214,7 @@ function BuildSkywayConfig(
         Migrations: {
             Locations: [absoluteDir],
             DefaultSchema: schemaName,
-            BaselineVersion: '0',
+            BaselineVersion: '1',
             BaselineOnMigrate: true,
         },
         Placeholders: {


### PR DESCRIPTION
## Summary
- Fix baseline migrations being silently skipped during `mj app install` — changed `BaselineVersion: '0'` to `'1'` so Skyway auto-selects the highest B* file on fresh installs
- Allow mixed-case schema names in Open App manifest validation (SQL Server is case-insensitive) — unblocks apps like BizApps Common (`__mj_BizAppsCommon`)

## Root cause
Skyway's resolver only auto-selects the highest baseline file when `BaselineVersion === '1'`. The install orchestrator passed `'0'`, which made Skyway look for a baseline with literal version `'0'` — no match — silently skipping the baseline and running only V* migrations. This caused Entity metadata INSERT failures on fresh installs.

## Test plan
- [x] `mj app install` for BizApps Common succeeds on fresh database (baseline + 4 V* migrations applied)
- [x] `mj app install` for BCSaaS succeeds after BAC install
- [x] Mixed-case schema name `__mj_BizAppsCommon` accepted without `--dangerously-ignore-dbl-underscore-schema-rule`
- [x] Manifest validation tests pass (36/36)
- [x] Schema validation tests pass (11/11)

🤖 Generated with [Claude Code](https://claude.com/claude-code)