### PR TITLE
fix(core-entity-forms): use UUIDsEqual for suite test ID comparison

### DIFF
--- a/packages/Angular/Explorer/core-entity-forms/src/lib/custom/Tests/test-suite-form.component.ts
+++ b/packages/Angular/Explorer/core-entity-forms/src/lib/custom/Tests/test-suite-form.component.ts
@@ -2264,7 +2264,7 @@ export class MJTestSuiteFormComponentExtended extends MJTestSuiteFormComponent i
     try {
       const ok = await suiteTest.Delete();
       if (ok) {
-        this.suiteTests = this.suiteTests.filter(t => t.ID !== suiteTest.ID);
+        this.suiteTests = this.suiteTests.filter(t => !UUIDsEqual(t.ID, suiteTest.ID));
         SharedService.Instance.CreateSimpleNotification('Test removed from suite', 'success', 2000);
       } else {
         const detail = suiteTest.LatestResult?.CompleteMessage || 'Failed to remove test';


### PR DESCRIPTION
Replaces a direct `!==` UUID comparison in test-suite-form with `!UUIDsEqual(...)` so cross-platform (SQL Server uppercase vs. PG lowercase) casing differences don't break removal. Resolves the @memberjunction/global UUIDCompliance test failure.