### PR TITLE
v5.35.0

### DIFF
--- a/.changeset/tenant-switch-support.md
+++ b/.changeset/tenant-switch-support.md
@@ -1,7 +1,6 @@
 ---
 "@memberjunction/global": minor
 "@memberjunction/ng-explorer-core": minor
-"@memberjunction/open-app": patch
 "@memberjunction/codegen-lib": patch
 "@memberjunction/ng-dashboards": patch
 "@memberjunction/server": patch

--- a/.changeset/tenant-switch-support.md
+++ b/.changeset/tenant-switch-support.md
@@ -1,6 +1,7 @@
 ---
 "@memberjunction/global": minor
 "@memberjunction/ng-explorer-core": minor
+"@memberjunction/open-app-engine": patch
 "@memberjunction/codegen-lib": patch
 "@memberjunction/ng-dashboards": patch
 "@memberjunction/server": patch
@@ -9,7 +10,7 @@
 
 **Multi-tenant switching** (`@memberjunction/global`, `@memberjunction/ng-explorer-core`): Add `TenantChanged` event type to `MJEventType`. Add `clearCacheByPredicate()` on `ComponentCacheManager` for selective tenant-scoped cache clearing. Add `ClearComponentCache()` and `ReloadAllTabs()` on `TabContainerComponent` — destroys cached components and reloads the active tab immediately (inactive tabs reload lazily). Shell subscribes to `TenantChanged` with two-phase protocol: `TenantChanging` shows the loading screen, `TenantChanged` reloads tabs and hides it. Loading screen CSS made `position: fixed` with `z-index: 99999` to fully cover viewport during switches.
 
-**Open App fixes** (`@memberjunction/open-app`): Make `mj app upgrade` idempotent when already at target version. Allow mixed-case schema names in Open App manifest validation.
+**Open App fixes** (`@memberjunction/open-app-engine`): Make `mj app upgrade` idempotent when already at target version. Allow mixed-case schema names in Open App manifest validation.
 
 **CodeGen fix** (`@memberjunction/codegen-lib`): Emit `override` modifier on generated `Save()` method to satisfy strict TypeScript when entity subclasses override the base `Save()`.
 


### PR DESCRIPTION
# Multi-tenant support and AI agent enhancements

## New Features
- **Multi-tenant switching**: Add `TenantChanged` event system with component cache management for seamless tenant transitions in MJ Explorer
- **AI artifact tools expansion**: Add CSV and generic binary artifact tool libraries for enhanced agent capabilities  
- **Memory Manager contradiction detection**: Add missing prompt metadata to enable agent contradiction-detection phase
- **Developer delete permissions**: Grant Developer role delete permissions on ~218 developer-owned configuration and metadata entities
- **Metadata sync system**: Add comprehensive metadata synchronization capabilities for Open App deployments

## Improvements
- **Testing UX overhaul**: Add world-class inline save/edit experience to Test and Test Suite forms with add/remove/reorder capabilities
- **Keyset pagination fixes**: Fix infinite loop in vector sync when using `AfterKey` pagination by including it in fingerprint generation
- **SQL query processing**: Rewrite `RenderPipeline.applyMaxRows` to use AST parsing for better CTE query support and row limiting
- **Open App upgrades**: Make `mj app upgrade` idempotent when already at target version and allow mixed-case schema names
- **AI Analytics filtering**: Fix category filter bugs in AI Agents dashboard and improve filter extraction robustness
- **Collection creation**: Fix Save-to-Collection dialog to allow creating collections from empty state
- **Geocoding providers**: Add support for multiple geocoding providers (Google, HERE, Geocodio) with configurable fallback

## Bug Fixes
- **Gemini streaming**: Correct streaming chunk parsing for @google/genai SDK compatibility
- **Test form comparison**: Use `UUIDsEqual` for suite test ID comparison to handle cross-platform UUID formatting
- **Query parameter routing**: Fix deep link state round-trip for pins, back/forward navigation
- **CodeGen overrides**: Emit `override` modifier on generated `Save()` method for TypeScript strict mode compliance
- **GraphQL caching**: Expose `RunViewParams.BypassCache` through GraphQL surface for cache control
- **Conversation attachments**: Add proper `@deprecated` JSDoc to deprecated attachment entities