### PR TITLE
fix(lists-base): extend root angular tsconfig to prevent drift

### DIFF
--- a/packages/Lists/base/tsconfig.json
+++ b/packages/Lists/base/tsconfig.json
@@ -1,18 +1,9 @@
 {
+  "extends": "../../../tsconfig.angular.json",
   "compilerOptions": {
-    "module": "es2022",
-    "target": "es2022",
-    "moduleResolution": "bundler",
-    "declaration": true,
-    "declarationMap": true,
-    "sourceMap": true,
-    "strict": true,
-    "skipLibCheck": true,
-    "esModuleInterop": true,
-    "lib": ["es2022"],
     "outDir": "dist",
     "rootDir": "src"
   },
   "include": ["src/**/*"],
-  "exclude": ["node_modules", "**/*.spec.ts", "**/*.test.ts", "**/__tests__/**", "src/__tests__/**", "src/**/*.test.ts", "src/**/*.spec.ts", "vitest.config.ts"]
+  "exclude": ["node_modules", "**/*.spec.ts", "**/*.test.ts", "**/__tests__/**", "vitest.config.ts"]
 }


### PR DESCRIPTION
## Summary

Follow-up to AN-BC's review comment on the merged PR #2610. `packages/Lists/base/tsconfig.json` was redefining the full `compilerOptions` block instead of extending a root tsconfig. That guarantees drift the next time the root settings change.

This switches it to:

```json
{
  "extends": "../../../tsconfig.angular.json",
  "compilerOptions": { "outDir": "dist", "rootDir": "src" },
  "include": ["src/**/*"],
  "exclude": [...]
}
```

## Test plan

- [x] `npm run build` in `packages/Lists/base/` succeeds with the new tsconfig
- [ ] CI passes (Unit Tests, Check migrations, Check Dependencies, PG migration parity)
- [ ] No downstream consumers regress (Angular UI consuming `MJListEntity` types, server `@memberjunction/lists` consuming the shared interfaces)
