### PR TITLE
fix(core-actions): route adhoc-query row cap through AST path

### DIFF
--- a/.changeset/adhoc-action-distinct-aware-cap.md
+++ b/.changeset/adhoc-action-distinct-aware-cap.md
@@ -1,0 +1,5 @@
+---
+"@memberjunction/core-actions": patch
+---
+
+Route `RunAdhocQueryAction.ensureRowLimit` through `QueryPagingEngine.WrapWithMaxRows` instead of the regex it had been using. The prior regex produced invalid T-SQL for `SELECT DISTINCT …` inputs (injecting `TOP N` between `SELECT` and `DISTINCT`, but T-SQL requires `SELECT DISTINCT TOP N`), silently dropped the cap on `WITH`/CTE-headed inputs, and only capped the first branch of `UNION`/`INTERSECT`/`EXCEPT` queries. The agent's "Run Ad-hoc Query" tool routinely emits DISTINCT and was getting stuck in retry loops because every SQL it generated got mangled. Delegating to the AST-based path picks up the full DISTINCT / set-op / CTE / TOP-PERCENT / WITH-TIES handling already in place for saved queries via `RenderPipeline`, plus the hard-ceiling enforcement added on this branch.

--- a/packages/Actions/CoreActions/src/custom/data/run-adhoc-query.action.ts
+++ b/packages/Actions/CoreActions/src/custom/data/run-adhoc-query.action.ts
@@ -3,7 +3,7 @@ import { RegisterClass, SQLExpressionValidator } from "@memberjunction/global";
 import { BaseAction } from "@memberjunction/actions";
 import { MJGlobal } from "@memberjunction/global";
 import { BaseEntity, LogError } from "@memberjunction/core";
-import { QueryCompositionEngine } from "@memberjunction/generic-database-provider";
+import { QueryCompositionEngine, QueryPagingEngine } from "@memberjunction/generic-database-provider";
 import { SQLServerDataProvider } from "@memberjunction/sqlserver-dataprovider";
 import { AIPromptRunner } from '@memberjunction/ai-prompts';
 import { AIPromptParams } from '@memberjunction/ai-core-plus';
@@ -245,23 +245,34 @@ export class RunAdhocQueryAction extends BaseAction {
     }
 
     /**
-     * Ensures query has a row limit to prevent overwhelming results
+     * Ensures query has a row limit to prevent overwhelming results.
+     *
+     * The prior regex `query.replace(/^(\s*SELECT\s+)/i, \`$1TOP ${maxRows} \`)`
+     * produced INVALID T-SQL for `SELECT DISTINCT …` inputs — it injected
+     * `TOP N` between `SELECT` and `DISTINCT`, but T-SQL requires
+     * `SELECT DISTINCT TOP N …` (DISTINCT first). The agent's "Run Ad-hoc
+     * Query" tool routinely emits DISTINCT and was getting stuck in retry
+     * loops because every SQL it tried got mangled. The same regex also
+     * silently dropped the cap on WITH/CTE inputs and only capped the first
+     * branch of UNION/INTERSECT/EXCEPT queries.
+     *
+     * Delegating to QueryPagingEngine.WrapWithMaxRows uses the AST-based
+     * row-cap path with full DISTINCT / set-op / CTE / TOP-PERCENT / WITH-TIES
+     * handling. Same function used by RenderPipeline for saved queries.
      */
     private ensureRowLimit(query: string, maxRows: number): string {
-        // Check if query already has TOP clause
-        const hasTop = /SELECT\s+TOP\s+\d+/i.test(query);
-        if (hasTop) {
-            return query;
+        try {
+            const provider = BaseEntity.Provider as SQLServerDataProvider;
+            const platform = (provider?.PlatformKey ?? 'sqlserver') as 'sqlserver' | 'postgresql';
+            return QueryPagingEngine.WrapWithMaxRows(query, maxRows, platform);
+        } catch {
+            // Ultimate safety net: if WrapWithMaxRows throws, fall back to a
+            // DISTINCT-aware regex (still better than the original).
+            const hasTop = /SELECT\s+TOP\s+\d+/i.test(query);
+            const hasOffsetFetch = /OFFSET\s+\d+\s+ROWS\s+FETCH/i.test(query);
+            if (hasTop || hasOffsetFetch) return query;
+            return query.replace(/^(\s*SELECT\s+(?:DISTINCT\s+|ALL\s+)?)/i, `$1TOP ${maxRows} `);
         }
-
-        // Check if query has OFFSET-FETCH (SQL Server 2012+)
-        const hasOffsetFetch = /OFFSET\s+\d+\s+ROWS\s+FETCH/i.test(query);
-        if (hasOffsetFetch) {
-            return query;
-        }
-
-        // Add TOP clause
-        return query.replace(/^(\s*SELECT\s+)/i, `$1TOP ${maxRows} `);
     }
 
     /**


### PR DESCRIPTION
## Summary

Companion to #2675. `RunAdhocQueryAction.ensureRowLimit` had its own regex (`query.replace(/^(\s*SELECT\s+)/i, \`$1TOP ${maxRows} \`)`) that broke three shapes the agent's "Run Ad-hoc Query" tool emits regularly:

- `SELECT DISTINCT …` — `TOP N` got injected between `SELECT` and `DISTINCT`, producing invalid T-SQL. The agent retried indefinitely because every SQL it generated got mangled.
- `WITH … SELECT …` — the regex left the cap off entirely.
- `… UNION SELECT …` — only the first branch got capped; the second ran unbounded.

This PR routes the action through `QueryPagingEngine.WrapWithMaxRows`, which is the same AST-based path saved queries already use through `RenderPipeline` (per #2675 / 34feff76). One-line import addition + a 13-line method replacement; small regex fallback retained as a safety net (and even that now respects DISTINCT/ALL with `(?:DISTINCT\s+|ALL\s+)?`).

## Why target this branch (`CB-sql-pipeline-fixes`) rather than `next`

`WrapWithMaxRows` only exists on `CB-sql-pipeline-fixes` (introduced by #2675). Targeting `next` would not compile. Once #2675 lands in `next`, this can merge cleanly behind it as part of the same release.

## Context — NSTA production deployment

NSTA has been running this exact behavior in production as a `patch-package` patch against `@memberjunction/core-actions@5.36.0` since 2026-05-23. The compiled JS this PR produces is byte-equivalent to that deployed patch (verified via `npx turbo build --filter=@memberjunction/core-actions` + diff against `nsta_environment/patches/@memberjunction+core-actions+5.36.0.patch`). When this PR lands in 5.37.0, NSTA can drop its local patch.

Full rationale of NSTA's patch layer and what each patch fixes: [`nsta_environment/patches/PATCHES_RATIONALE.md`](../../nsta_environment/patches/PATCHES_RATIONALE.md) (NSTA-internal repo).

## Test plan

- [ ] `npx turbo build --filter=@memberjunction/core-actions` (verified locally — passes)
- [ ] Existing CoreActions test suite passes
- [ ] Manual: agent executes `SELECT DISTINCT col FROM t` via Run Ad-hoc Query → no more `Msg 156` syntax errors
- [ ] Manual: agent executes `WITH cte AS (…) SELECT * FROM cte` via Run Ad-hoc Query → row cap is now applied (was silently skipped before)
- [ ] Manual: agent executes `SELECT a FROM t1 UNION SELECT b FROM t2` via Run Ad-hoc Query → both branches respect the cap (was first-branch-only before)

🤖 Generated with [Claude Code](https://claude.com/claude-code)