### PR TITLE
feat(dbautodoc): organic-key detection + PR #2193 per-column normalization

### DIFF
--- a/.changeset/dbautodoc-organic-keys-per-column-normalization.md
+++ b/.changeset/dbautodoc-organic-keys-per-column-normalization.md
@@ -1,0 +1,9 @@
+---
+"@memberjunction/db-auto-doc": minor
+"@memberjunction/core": patch
+---
+
+DBAutoDoc organic-key detection + PR #2193 per-column normalization:
+
+- **Organic-key detection phase** in DBAutoDoc's analyze pipeline (optional, off by default): prefilter → per-table LLM normalize (business-space descriptions + concept names + per-column normalization strategy + organic-key gate) → embed → agglomerative cluster → concept-name split → FK-graph transitive bridges → emit to `additionalSchemaInfo.json`. Runs on MemberJunction's AI infrastructure (`BaseLLM` / `BaseEmbeddings` via the ClassFactory), no standalone provider clients.
+- **Per-column normalization**: each emitted `EntityOrganicKey` carries its own normalization function for its column, so a cluster of differently-formatted columns (e.g. phone numbers across systems) each canonicalize to a shared form. Runtime (`EntityInfo.BuildOrganicKeyViewParams`) applies each side's own expression at match time, looking up the spoke entity's organic key by name.

--- a/packages/DBAutoDoc/README.md
+++ b/packages/DBAutoDoc/README.md
@@ -53,6 +53,7 @@ graph TD
 
 ### Advanced Features
 - **Relationship Discovery** -- Automatically detect missing primary and foreign keys using statistical analysis and LLM validation
+- **Organic Key Detection** -- Optional pass that finds cross-table *shared-identity* relationships (e.g. the same email or phone stored in different formats across systems) by clustering columns in business-meaning space, and emits MemberJunction PR #2193 organic-key metadata with per-column normalization
 - **Sample Query Generation** -- Generate reference SQL queries for AI agents with alignment tracking
 - **Ground Truth System** -- Provide authoritative descriptions for schemas, tables, and columns that AI analysis must respect
 - **Incremental State Saves** -- State persisted to disk after every phase (introspection, sampling, discovery, per-table analysis)
@@ -415,6 +416,23 @@ For legacy databases missing primary/foreign key constraints, DBAutoDoc can:
 Triggered automatically when:
 - Tables lack primary key constraints
 - Insufficient foreign key relationships detected (below threshold)
+
+### Organic Key Detection (Optional)
+
+Foreign keys require **shared exact values**. Organic keys (MemberJunction [PR #2193](https://github.com/MemberJunction/MJ/pull/2193)) capture the weaker-but-broader condition of **shared identity**: two columns refer to the same real-world thing once each is canonicalized through its own transformation. That joins far more cross-system data than exact-match FKs -- e.g. the same phone number stored as `+1 (555) 123-4567`, `5551234567`, and `555.123.4567` across HubSpot, Zendesk, and QuickBooks.
+
+This pass is **off by default** and runs after PK/FK detection. Enable it with `organicKeyDetection.enabled: true` (it reuses your existing `ai` provider for both the LLM and embeddings). The pipeline:
+
+1. **Prefilter** -- drop columns that can't carry identity (booleans, enums, measures, audit columns, free text, non-value-matchable types).
+2. **Normalize to business space** -- an LLM rewrites each column's description into a simplified, business-focused form and tags a *concept name* + a *normalization strategy*. Describing the same thing the same way pulls semantically-equal columns together in embedding space.
+3. **Embed & cluster** -- normalized descriptions are embedded (via MemberJunction's `BaseEmbeddings`) and grouped with agglomerative clustering using an auto-calibrated distance threshold.
+4. **Concept-name split** -- clusters that merged distinct concepts (e.g. `product_id` vs `product_category_id`) are split apart using the LLM concept tags.
+5. **Per-column normalization** -- each emitted organic key carries *its own* normalization function for its column, so differently-formatted columns each canonicalize to a shared form. One function per organic key, not one per cluster.
+6. **Transitive bridges** -- the FK graph is walked to find multi-hop paths between clustered tables; bridge-view SQL is generated and the transitive spoke fields are populated so PR #2193's runtime can surface multi-hop matches.
+
+Results are written into `additionalSchemaInfo.json` (see [CodeGen Integration](#codegen-integration-additional-schema-info)) as `OrganicKeys` entries, which CodeGen upserts into `EntityOrganicKey` / `EntityOrganicKeyRelatedEntity` metadata. At runtime, `EntityInfo.BuildOrganicKeyViewParams` applies each side's own normalization expression when matching records.
+
+> **Note:** Embeddings route through MemberJunction's `BaseEmbeddings` drivers (OpenAI, Mistral, Azure, Bedrock, Ollama, local), defaulting to `OpenAIEmbedding`. The detection pass therefore requires an embedding provider with a valid key configured.
 
 ### Sample Query Generation
 
@@ -815,6 +833,19 @@ This rich context enables AI to make accurate inferences.
       "backpropagation": {
         "enabled": true,
         "maxIterations": 5
+      }
+    },
+    "organicKeyDetection": {
+      "enabled": false,
+      "clusteringSensitivity": "balanced",
+      "minClusterSize": 2,
+      "minDistinctTables": 2,
+      "sampleValueCount": 5,
+      "refinementConcurrency": 4,
+      "maxRefinementRetries": 2,
+      "embedding": {
+        "provider": "openai",
+        "model": "text-embedding-3-small"
       }
     }
   },

--- a/packages/DBAutoDoc/src/core/AnalysisOrchestrator.ts
+++ b/packages/DBAutoDoc/src/core/AnalysisOrchestrator.ts
@@ -24,6 +24,8 @@ import { DBAutoDocConfig } from '../types/config.js';
 import { DatabaseDocumentation, AnalysisRun } from '../types/state.js';
 import { DiscoveryTriggerAnalyzer } from '../discovery/DiscoveryTriggerAnalyzer.js';
 import { DiscoveryEngine } from '../discovery/DiscoveryEngine.js';
+import { OrganicKeyDetector } from '../discovery/OrganicKeyDetector.js';
+import { DetectedOrganicKeysOutput } from '../discovery/OrganicKeyTranslator.js';
 
 export interface AnalysisOptions {
   config: DBAutoDocConfig;
@@ -395,6 +397,35 @@ export class AnalysisOrchestrator {
         await stateManager.save(state);
       }
 
+      // ── Organic Key Detection Phase (OPTIONAL) ─────────────────────────────
+      // Runs AFTER descriptions + PK/FK discovery, only when explicitly enabled.
+      // Clusters columns across tables/schemas by shared business identity (email,
+      // phone, customer id, …) using normalized descriptions → embeddings →
+      // clustering → per-concept split. Output is persisted into state.json AND
+      // fed to the additionalSchemaInfo generator so CodeGen writes the
+      // EntityOrganicKey / EntityOrganicKeyRelatedEntity metadata.
+      let organicKeyOutput: DetectedOrganicKeysOutput | undefined;
+      if (this.config.analysis.organicKeyDetection?.enabled) {
+        this.onProgress('Running organic-key detection');
+        try {
+          const detector = new OrganicKeyDetector(this.config.analysis.organicKeyDetection, this.config.ai);
+          const okResult = await detector.detect(state, {
+            onProgress: (msg) => this.onProgress(msg),
+          });
+          state.organicKeyClusters = okResult.clusters;
+          state.phases.organicKeyDetection = okResult.phase;
+          organicKeyOutput = okResult.output;
+          this.onProgress('Organic-key detection complete', {
+            clustersFound: okResult.summary.clustersFound,
+            clustersEmitted: okResult.summary.clustersEmitted,
+            outputKeys: okResult.summary.outputKeys,
+          });
+        } catch (err) {
+          // Non-fatal — organic-key detection is optional enrichment. Log and continue.
+          this.onProgress(`Organic-key detection failed (continuing): ${(err as Error).message}`);
+        }
+      }
+
       // Final state update
       stateManager.updateSummary(state);
       await stateManager.save(state);
@@ -411,9 +442,9 @@ export class AnalysisOrchestrator {
       const mdPath = path.join(runFolder, 'summary.md');
       await fs.writeFile(mdPath, markdown, 'utf-8');
 
-      // Generate additionalSchemaInfo.json for CodeGen soft FK/PK support
+      // Generate additionalSchemaInfo.json for CodeGen soft FK/PK + organic key support
       const schemaInfoGen = new AdditionalSchemaInfoGenerator();
-      const schemaInfo = schemaInfoGen.generate(state, {});
+      const schemaInfo = schemaInfoGen.generate(state, { organicKeys: organicKeyOutput });
       const schemaInfoPath = path.join(runFolder, 'additionalSchemaInfo.json');
       await fs.writeFile(schemaInfoPath, schemaInfo, 'utf-8');
 

--- a/packages/DBAutoDoc/src/discovery/BridgeViewSQLGenerator.ts
+++ b/packages/DBAutoDoc/src/discovery/BridgeViewSQLGenerator.ts
@@ -1,0 +1,148 @@
+/**
+ * BridgeViewSQLGenerator — Pattern 3 SQL emission.
+ *
+ * Takes a BridgePath (from FKGraphWalker) and produces the CREATE VIEW SQL
+ * statement that PR #2193's CodeGen ingest (`processOrganicKeyConfig`) will
+ * EXECUTE when materializing the organic-key configuration.
+ *
+ * Output SQL shape — minimal valid bridge view per the PR #2193 docs example:
+ *
+ *   CREATE OR ALTER VIEW [schema].[viewName] AS
+ *   SELECT
+ *       [hub].[hubKeyField] AS [hubKeyField],
+ *       [spoke].[spokePK]   AS [spokeOutputAlias]
+ *   FROM [spokeSchema].[spokeTable] [spoke]
+ *   INNER JOIN [interSchema].[interTable] [t1]
+ *       ON [spoke].[fkCol] = [t1].[pkCol]
+ *   INNER JOIN [hubSchema].[hubTable] [hub]
+ *       ON [t1].[fkCol] = [hub].[pkCol]
+ *
+ * The aliases t1, t2, … are auto-assigned per intermediate hop. The HUB carries
+ * the organic-key field; the SPOKE is what the form panel will list as related
+ * records. PR #2193's transitive runtime substitutes the hub value (e.g. a
+ * specific email address) at query time:
+ *
+ *   [ID] IN (SELECT [spokeOutputAlias] FROM <viewName> WHERE [hubKeyField] = ?)
+ *
+ * The SPOKE's primary key is what the bridge view projects in addition to the
+ * hub's key column — that's what `TransitiveOutputFieldName` references.
+ *
+ * The caller (TransitiveBridgeDetector) supplies the spoke PK because the
+ * walker doesn't know it.
+ */
+
+import { BridgePath } from './FKGraphWalker.js';
+
+/** Bundle returned for each bridge path. */
+export interface GeneratedBridgeView {
+    /** View name suitable for the PR #2193 TransitiveView.Name field. */
+    viewName: string;
+    /** Default schema (caller may override). */
+    schemaName: string;
+    /** The CREATE OR ALTER VIEW DDL — exactly what TransitiveView.SQL should carry. */
+    sql: string;
+    /** The hub-key field projected by the view (matches TransitiveMatchFieldNames[0]). */
+    hubKeyField: string;
+    /** The output column projected for the spoke (matches TransitiveOutputFieldName). */
+    spokeOutputField: string;
+    /** The spoke PK column the form-panel join joins ON (matches RelatedEntityJoinFieldName). */
+    spokeJoinField: string;
+}
+
+export interface BridgeViewSQLGeneratorOptions {
+    /**
+     * Pattern for the view name. Tokens substituted:
+     *   {hub}      → hub table name
+     *   {spoke}    → spoke table name
+     *   {key}      → hub key field name
+     * Default `"vw{spoke}_{key}_bridge"`.
+     *
+     * The generator lowercases the result and replaces non-alphanumeric chars
+     * with underscores, since the view must be a valid SQL identifier.
+     */
+    viewNamePattern?: string;
+    /** Override the view's schema. Defaults to the SPOKE's schema (where it'll be most natural to find). */
+    viewSchema?: string;
+}
+
+const DEFAULTS: Required<BridgeViewSQLGeneratorOptions> = {
+    viewNamePattern: 'vw{spoke}_{key}_bridge',
+    viewSchema: '',
+};
+
+export function generateBridgeView(
+    path: BridgePath,
+    spokePKColumn: string,
+    opts: BridgeViewSQLGeneratorOptions = {},
+): GeneratedBridgeView {
+    const o = { ...DEFAULTS, ...opts };
+    const viewName = buildViewName(o.viewNamePattern, path);
+    const schemaName = o.viewSchema || path.spokeSchema;
+    const spokeOutputField = `${path.spokeTable}_${spokePKColumn}`;
+
+    // ─── Build alias map ────────────────────────────────────────────────────
+    // hop[0].fromTable = spoke   (alias "spoke")
+    // hop[i].toTable for 0<i<len-1 = intermediate (alias t1, t2, ...)
+    // hop[last].toTable = hub    (alias "hub")
+    const aliases: string[] = [];
+    aliases.push('spoke'); // index 0 = spoke
+    for (let i = 1; i < path.hops.length; i++) {
+        aliases.push(`t${i}`);
+    }
+    aliases.push('hub'); // final = hub
+
+    // ─── JOIN clauses ───────────────────────────────────────────────────────
+    const fromClause = `FROM ${qident(path.spokeSchema)}.${qident(path.spokeTable)} ${aliases[0]}`;
+    const joinClauses: string[] = [];
+    for (let i = 0; i < path.hops.length; i++) {
+        const hop = path.hops[i];
+        const fromAlias = aliases[i];
+        const toAlias = aliases[i + 1];
+        joinClauses.push(
+            `INNER JOIN ${qident(hop.toSchema)}.${qident(hop.toTable)} ${toAlias} ON ${fromAlias}.${qident(hop.fromColumn)} = ${toAlias}.${qident(hop.toColumn)}`,
+        );
+    }
+
+    // ─── SELECT list ────────────────────────────────────────────────────────
+    const selectList = [
+        `hub.${qident(path.hubKeyField)} AS ${qident(path.hubKeyField)}`,
+        `spoke.${qident(spokePKColumn)} AS ${qident(spokeOutputField)}`,
+    ];
+
+    // ─── Final SQL — body only ──────────────────────────────────────────────
+    // PR #2193's CodeGen processOrganicKeyConfig() prepends `CREATE OR ALTER
+    // VIEW <schema>.<name> AS\n` to whatever's in TransitiveView.SQL. So we
+    // emit ONLY the SELECT body — never the CREATE VIEW header — otherwise
+    // SQL Server rejects the double-prefixed statement.
+    const sql = [
+        `SELECT`,
+        '    ' + selectList.join(',\n    '),
+        fromClause,
+        ...joinClauses,
+    ].join('\n');
+
+    return {
+        viewName,
+        schemaName,
+        sql,
+        hubKeyField: path.hubKeyField,
+        spokeOutputField,
+        spokeJoinField: spokePKColumn,
+    };
+}
+
+// ─── Helpers ────────────────────────────────────────────────────────────────
+
+function buildViewName(pattern: string, path: BridgePath): string {
+    const raw = pattern
+        .replace(/\{hub\}/g, path.hubTable)
+        .replace(/\{spoke\}/g, path.spokeTable)
+        .replace(/\{key\}/g, path.hubKeyField);
+    // Sanitize: SQL identifier — alphanumeric + underscore only, max 128 chars.
+    const cleaned = raw.replace(/[^A-Za-z0-9_]/g, '_').slice(0, 128);
+    return cleaned;
+}
+
+function qident(name: string): string {
+    return `[${name.replace(/]/g, ']]')}]`;
+}

--- a/packages/DBAutoDoc/src/discovery/ColumnClusterer.ts
+++ b/packages/DBAutoDoc/src/discovery/ColumnClusterer.ts
@@ -1,0 +1,245 @@
+/**
+ * ColumnClusterer — average-linkage agglomerative clustering on cosine distance.
+ *
+ * Input:  N columns each with a unit-normalized embedding vector.
+ * Output: clusters of ≥2 members spanning ≥2 distinct tables, sorted biggest-first.
+ *
+ * Algorithm:
+ *   1. Compute the full N×N upper-triangular pairwise cosine-distance matrix.
+ *   2. Repeatedly find the closest two clusters; if their distance ≤ mergeThreshold,
+ *      merge them and update the distance to every other cluster as the AVERAGE
+ *      pairwise distance between their members. Stop when the closest pair exceeds
+ *      the threshold.
+ *   3. Filter clusters by minClusterSize + minDistinctTables.
+ *
+ * Why average-linkage:
+ *   Complete-linkage requires EVERY pair across two clusters to be close before
+ *   merging — too tight in practice. Single-linkage chains unrelated points
+ *   through bridges. Average-linkage merges when clusters are similar on average,
+ *   which matches the actual "cluster = one concept" question.
+ */
+
+import { OrganicKeyClusterMember } from '../types/organic-keys.js';
+
+/** A column ready to cluster — identity + embedding + structural metadata. */
+export interface ClustererInputColumn {
+    schema: string;
+    table: string;
+    column: string;
+    embedding: Float32Array;
+    participatesInFK: boolean;
+    fkTarget?: { schema: string; table: string; column: string } | null;
+    isPrimaryKey?: boolean;
+}
+
+/** A raw cluster from the clusterer — naming/normalization filled in by the caller. */
+export interface RawCluster {
+    memberIndexes: number[];
+    members: OrganicKeyClusterMember[];
+    /** Max pairwise distance among members (cluster "tightness" — lower is tighter). */
+    maxIntraDistance: number;
+}
+
+export interface ClustererOptions {
+    /**
+     * Explicit merge-distance threshold. When provided, used directly.
+     * When omitted, the clusterer auto-calibrates from the actual distance
+     * distribution (threshold = pN of pairwise distances, default p5).
+     */
+    mergeThreshold?: number;
+    /** Percentile (0–100) of the pairwise distance distribution for auto-calibration. Default 5. */
+    mergeThresholdPercentile?: number;
+    /** Minimum cluster size to report. */
+    minClusterSize: number;
+    /** Minimum distinct tables a cluster must span. */
+    minDistinctTables: number;
+}
+
+export class ColumnClusterer {
+    public lastResolvedThreshold = 0;
+
+    constructor(private readonly opts: ClustererOptions) {}
+
+    public cluster(columns: ClustererInputColumn[]): RawCluster[] {
+        const n = columns.length;
+        if (n < this.opts.minClusterSize) return [];
+
+        // Step 1 — pairwise cosine-distance matrix.
+        const distance = computePairwiseDistance(columns);
+        const resolvedThreshold = this.opts.mergeThreshold !== undefined
+            ? this.opts.mergeThreshold
+            : computeThresholdFromDistribution(distance, this.opts.mergeThresholdPercentile ?? 5);
+        this.lastResolvedThreshold = resolvedThreshold;
+
+        // Step 2 — agglomerative merge with average-linkage.
+        const clusters = new Map<number, number[]>();
+        for (let i = 0; i < n; i++) clusters.set(i, [i]);
+
+        const avgDist = new Map<number, Map<number, number>>();
+        for (let i = 0; i < n; i++) {
+            const row = new Map<number, number>();
+            for (let j = 0; j < n; j++) {
+                if (i !== j) row.set(j, distanceAt(distance, n, i, j));
+            }
+            avgDist.set(i, row);
+        }
+
+        while (clusters.size > 1) {
+            let bestA = -1;
+            let bestB = -1;
+            let bestD = Number.POSITIVE_INFINITY;
+            for (const [a, aRow] of avgDist) {
+                for (const [b, d] of aRow) {
+                    if (a < b && d < bestD) {
+                        bestD = d;
+                        bestA = a;
+                        bestB = b;
+                    }
+                }
+            }
+            if (bestD > resolvedThreshold || bestA < 0) break;
+
+            const membersA = clusters.get(bestA)!;
+            const membersB = clusters.get(bestB)!;
+            const sizeA = membersA.length;
+            const sizeB = membersB.length;
+            const rowA = avgDist.get(bestA)!;
+            const rowB = avgDist.get(bestB)!;
+            for (const c of clusters.keys()) {
+                if (c === bestA || c === bestB) continue;
+                const dAC = rowA.get(c)!;
+                const dBC = rowB.get(c)!;
+                const newD = (sizeA * dAC + sizeB * dBC) / (sizeA + sizeB);
+                rowA.set(c, newD);
+                avgDist.get(c)!.set(bestA, newD);
+                avgDist.get(c)!.delete(bestB);
+            }
+            rowA.delete(bestB);
+            avgDist.delete(bestB);
+
+            clusters.set(bestA, membersA.concat(membersB));
+            clusters.delete(bestB);
+        }
+
+        // Step 3 — filter + emit.
+        const out: RawCluster[] = [];
+        for (const memberIdxs of clusters.values()) {
+            if (memberIdxs.length < this.opts.minClusterSize) continue;
+            const tableSet = new Set(memberIdxs.map((i) => `${columns[i].schema}.${columns[i].table}`));
+            if (tableSet.size < this.opts.minDistinctTables) continue;
+            const members: OrganicKeyClusterMember[] = memberIdxs.map((i) => ({
+                schema: columns[i].schema,
+                table: columns[i].table,
+                column: columns[i].column,
+                participatesInFK: !!columns[i].participatesInFK,
+                fkTarget: columns[i].fkTarget ?? null,
+                isPrimaryKey: !!columns[i].isPrimaryKey,
+            }));
+            out.push({
+                memberIndexes: memberIdxs,
+                members,
+                maxIntraDistance: maxIntraDistance(memberIdxs, distance, n),
+            });
+        }
+        out.sort((a, b) => b.members.length - a.members.length);
+        return out;
+    }
+}
+
+// ─── Helpers ────────────────────────────────────────────────────────────────
+
+function computePairwiseDistance(columns: ClustererInputColumn[]): Float32Array {
+    const n = columns.length;
+    const len = (n * (n - 1)) / 2;
+    const out = new Float32Array(len);
+    for (let i = 0; i < n; i++) {
+        const ei = columns[i].embedding;
+        for (let j = i + 1; j < n; j++) {
+            const ej = columns[j].embedding;
+            let s = 0;
+            const dim = Math.min(ei.length, ej.length);
+            for (let k = 0; k < dim; k++) s += ei[k] * ej[k];
+            const d = 1 - s;
+            out[flatIndex(i, j, n)] = d > 0 ? d : 0;
+        }
+    }
+    return out;
+}
+
+function flatIndex(i: number, j: number, n: number): number {
+    return i * n - (i * (i + 1)) / 2 + (j - i - 1);
+}
+
+/**
+ * Auto-calibrate the merge threshold from the actual distance distribution.
+ *
+ * Real embedding-distance distributions for "same vs different concept" data
+ * are usually BIMODAL: a dense cluster of small distances (same concept) and
+ * a dense cluster of large distances (different concept), with a clear gap
+ * between them. A flat percentile (p5) breaks in the degenerate cases where
+ * many descriptions land exactly identically — p5 becomes 0 and the merge
+ * loop refuses to merge anything that isn't byte-equal.
+ *
+ * Robust approach: find the largest gap in the BOTTOM half of the sorted
+ * distance distribution (where the same-concept / different-concept split
+ * lives), and place the threshold inside that gap so all same-concept pairs
+ * merge and no different-concept pair does.
+ *
+ * Fallback when no clear gap exists: use the pN percentile (legacy behavior).
+ * Floor the result so we still merge near-identical descriptions even when
+ * the geometry is degenerate.
+ */
+function computeThresholdFromDistribution(distances: Float32Array, percentile: number): number {
+    if (distances.length === 0) return 0;
+    const sorted = Array.from(distances).sort((a, b) => a - b);
+    const N = sorted.length;
+
+    // Search the entire distribution for the largest gap whose START is in the
+    // "same-concept territory" (≤0.40 cosine distance). Anything above 0.40 is
+    // already inter-concept, and the gaps up there are irrelevant noise.
+    //
+    // For Gemini clustering embeddings, same-concept pairs concentrate ≤0.15
+    // and different-concept pairs ≥0.30, so the boundary gap lives somewhere in
+    // [0.05, 0.35]. Searching that window finds it whether the intra-concept
+    // pairs are 10% or 60% of all pairs.
+    const GAP_START_MAX = 0.40;
+    const MIN_MEANINGFUL_GAP = 0.03;
+    const FLOOR = 0.05;
+
+    let bestGap = 0;
+    let bestGapStart = 0;
+    for (let i = 0; i < N - 1; i++) {
+        if (sorted[i] > GAP_START_MAX) break;
+        const gap = sorted[i + 1] - sorted[i];
+        if (gap > bestGap) {
+            bestGap = gap;
+            bestGapStart = sorted[i];
+        }
+    }
+
+    if (bestGap >= MIN_MEANINGFUL_GAP) {
+        return Math.max(FLOOR, bestGapStart + bestGap * 0.5);
+    }
+
+    // No clear gap — use the pN percentile, floored to merge near-identical pairs.
+    const p = Math.max(0, Math.min(100, percentile));
+    const idx = Math.floor((N * p) / 100);
+    return Math.max(FLOOR, sorted[Math.min(idx, N - 1)]);
+}
+
+function distanceAt(matrix: Float32Array, n: number, i: number, j: number): number {
+    if (i === j) return 0;
+    if (i > j) [i, j] = [j, i];
+    return matrix[flatIndex(i, j, n)];
+}
+
+function maxIntraDistance(memberIdxs: number[], matrix: Float32Array, n: number): number {
+    let max = 0;
+    for (let a = 0; a < memberIdxs.length; a++) {
+        for (let b = a + 1; b < memberIdxs.length; b++) {
+            const d = distanceAt(matrix, n, memberIdxs[a], memberIdxs[b]);
+            if (d > max) max = d;
+        }
+    }
+    return max;
+}

--- a/packages/DBAutoDoc/src/discovery/ColumnNormalizer.ts
+++ b/packages/DBAutoDoc/src/discovery/ColumnNormalizer.ts
@@ -1,0 +1,465 @@
+/**
+ * TableNormalizer — one LLM call per TABLE (not per column), upstream of embedding.
+ *
+ * For each in-scope table, a single LLM call sees:
+ *   - The table's name + description + sibling columns
+ *   - Every column's identity + description + sample values + FK/PK status
+ *
+ * The call returns one normalized entry per column with:
+ *   - conceptName            : canonical snake_case (`email_address`, `customer_id`, ...)
+ *   - normalizationStrategy  : how values should be compared
+ *   - normalizedDescription  : business-concept-focused, system-agnostic sentence
+ *   - isUsefulOrganicKey     : false for audit/system/free-form (filtered out)
+ *   - confidence + reasoning
+ *
+ * Why per-table instead of per-column:
+ *   - Fewer calls (5K cols across 500 tables → 500 calls instead of 5K). At
+ *     Gemini Flash pricing, that's ~$0.04 instead of ~$0.20 for APTIFY-scale.
+ *   - System prompt amortizes across all columns in the table.
+ *   - The LLM sees siblings as context — knowing the table has FirstName + LastName
+ *     next to an Email column reveals it's a person email, not a server hostname.
+ *   - More token-efficient: one JSON array out instead of N independent objects.
+ *
+ * The single most important constraint: same-concept columns from DIFFERENT
+ * TABLES (across systems) must produce the same conceptName and a similar
+ * normalizedDescription so the embedding step naturally clusters them. The
+ * prompt enforces this via a canonical concept-name list.
+ */
+
+import { BaseLLM, ChatParams, ChatResult } from '@memberjunction/ai';
+import { createLLMInstance } from '../utils/llm-factory.js';
+import { AIConfig } from '../types/config.js';
+import { OrganicKeyNormalizationStrategy } from '../types/organic-keys.js';
+import { cleanAndParseJSON } from '../utils/json.js';
+
+/** One column's input to the normalizer. */
+export interface NormalizerInputColumn {
+    schema: string;
+    table: string;
+    column: string;
+    dataType: string;
+    /** Original LLM-generated description from DBAutoDoc's prior analysis pass. */
+    originalDescription: string;
+    /** Sample values from the column's actual data. */
+    sampleValues: string[];
+    /** Whether the column participates in any FK (declared or detected). */
+    participatesInFK: boolean;
+    fkTarget?: { schema: string; table: string; column: string } | null;
+    isPrimaryKey: boolean;
+}
+
+/** All columns of one table, batched for a single LLM call. */
+export interface TableNormalizationInput {
+    schema: string;
+    schemaDescription?: string;
+    table: string;
+    tableDescription?: string;
+    columns: NormalizerInputColumn[];
+}
+
+/** One column's normalized output. */
+export interface NormalizedColumn extends NormalizerInputColumn {
+    conceptName: string;
+    normalizationStrategy: OrganicKeyNormalizationStrategy;
+    customNormalizationExpression?: string;
+    normalizedDescription: string;
+    isUsefulOrganicKey: boolean;
+    confidence: number;
+    reasoning: string;
+}
+
+/** Aggregate result of normalizing many tables. */
+export interface NormalizationBatchResult {
+    /** Useful organic-key columns surviving normalization (filtered to isUsefulOrganicKey=true). */
+    normalized: NormalizedColumn[];
+    /** Columns the normalizer marked isUsefulOrganicKey=false (audit, free-form, etc.). */
+    rejected: number;
+    /** Tables where the LLM call failed entirely. */
+    errors: number;
+    tokens: { total: number; input: number; output: number };
+}
+
+export interface NormalizerOptions {
+    /** Concurrency for per-table LLM calls. Default 8. */
+    concurrency?: number;
+    /** Max retries per table on transient failures. Default 2. */
+    maxRetries?: number;
+    /** Progress callback (done count, total count). */
+    onProgress?: (done: number, total: number) => void;
+}
+
+export class TableNormalizer {
+    private readonly llm: BaseLLM;
+
+    constructor(private readonly aiConfig: AIConfig) {
+        this.llm = createLLMInstance(aiConfig.provider, aiConfig.apiKey);
+    }
+
+    /** Normalize one table — one LLM call returning per-column entries. */
+    public async normalizeTable(
+        input: TableNormalizationInput,
+        maxRetries = 2,
+    ): Promise<{
+        normalized: NormalizedColumn[];
+        tokens: { total: number; input: number; output: number };
+        errorMessage?: string;
+    }> {
+        if (input.columns.length === 0) {
+            return { normalized: [], tokens: { total: 0, input: 0, output: 0 } };
+        }
+
+        const userPrompt = buildUserPrompt(input);
+        const params: ChatParams = {
+            model: this.aiConfig.model,
+            messages: [
+                { role: 'system', content: SYSTEM_PROMPT },
+                { role: 'user', content: userPrompt },
+            ],
+            temperature: this.aiConfig.temperature ?? 0,
+            maxOutputTokens: this.aiConfig.maxTokens,
+            responseFormat: 'JSON',
+        };
+
+        let lastError = '';
+        let cumTokens = { total: 0, input: 0, output: 0 };
+        for (let attempt = 0; attempt <= maxRetries; attempt++) {
+            let result: ChatResult | undefined;
+            try {
+                result = await this.llm.ChatCompletion(params);
+            } catch (err) {
+                lastError = `LLM call threw: ${(err as Error).message}`;
+                continue;
+            }
+            if (!result.success) {
+                lastError = `LLM call failed: ${result.errorMessage ?? 'unknown'}`;
+                continue;
+            }
+
+            const content = result.data?.choices?.[0]?.message?.content ?? '';
+            const usage = result.data?.usage;
+            cumTokens = {
+                total: cumTokens.total + (usage?.totalTokens ?? 0),
+                input: cumTokens.input + (usage?.promptTokens ?? 0),
+                output: cumTokens.output + (usage?.completionTokens ?? 0),
+            };
+
+            let parsed: LLMTableResponse | null = null;
+            try {
+                parsed = cleanAndParseJSON<LLMTableResponse>(content);
+            } catch (err) {
+                lastError = `JSON parse threw: ${(err as Error).message}. Content prefix: ${content.slice(0, 200)}`;
+                if (attempt < maxRetries) continue;
+                return { normalized: [], tokens: cumTokens, errorMessage: lastError };
+            }
+            if (!parsed || !Array.isArray(parsed.columns)) {
+                lastError = `JSON parse returned bad shape. Content prefix: ${content.slice(0, 200)}`;
+                if (attempt < maxRetries) continue;
+                return { normalized: [], tokens: cumTokens, errorMessage: lastError };
+            }
+
+            // Match the LLM's response entries back to input columns by name.
+            const byName = new Map(input.columns.map((c) => [c.column.toLowerCase(), c]));
+            const normalized: NormalizedColumn[] = [];
+            for (const entry of parsed.columns) {
+                if (!entry || typeof entry.column !== 'string') continue;
+                const inputCol = byName.get(entry.column.toLowerCase());
+                if (!inputCol) continue; // LLM hallucinated a column name; skip
+                normalized.push({
+                    ...inputCol,
+                    conceptName: entry.conceptName ?? '',
+                    normalizationStrategy: entry.normalizationStrategy ?? 'LowerCaseTrim',
+                    customNormalizationExpression: sanitizePlaceholder(entry.customNormalizationExpression),
+                    normalizedDescription: entry.normalizedDescription ?? '',
+                    isUsefulOrganicKey: !!entry.isUsefulOrganicKey,
+                    confidence: clamp01(entry.confidence),
+                    reasoning: entry.reasoning ?? '',
+                });
+            }
+            return { normalized, tokens: cumTokens };
+        }
+        return { normalized: [], tokens: cumTokens, errorMessage: lastError || 'unknown failure after retries' };
+    }
+
+    /** Batch normalize many tables with bounded concurrency. */
+    public async normalizeAll(
+        tables: TableNormalizationInput[],
+        opts: NormalizerOptions = {},
+    ): Promise<NormalizationBatchResult> {
+        const concurrency = Math.max(1, opts.concurrency ?? 8);
+        const maxRetries = Math.max(0, opts.maxRetries ?? 2);
+
+        const allNormalized: NormalizedColumn[] = [];
+        let rejected = 0;
+        let errors = 0;
+        let total = 0;
+        let input = 0;
+        let output = 0;
+        let completed = 0;
+
+        let cursor = 0;
+        const runners = Array.from({ length: concurrency }, async () => {
+            while (true) {
+                const idx = cursor++;
+                if (idx >= tables.length) return;
+                const r = await this.normalizeTable(tables[idx], maxRetries);
+                total += r.tokens.total;
+                input += r.tokens.input;
+                output += r.tokens.output;
+
+                if (r.errorMessage) {
+                    errors++;
+                } else {
+                    for (const n of r.normalized) {
+                        if (n.isUsefulOrganicKey) allNormalized.push(n);
+                        else rejected++;
+                    }
+                }
+                completed++;
+                opts.onProgress?.(completed, tables.length);
+            }
+        });
+        await Promise.all(runners);
+        return { normalized: allNormalized, rejected, errors, tokens: { total, input, output } };
+    }
+}
+
+// ─── Prompt ─────────────────────────────────────────────────────────────────
+
+const SYSTEM_PROMPT = `You are translating database columns into a NORMALIZED BUSINESS-CONCEPT REPRESENTATION
+for organic-key detection per MemberJunction PR #2193.
+
+═══ PR #2193 — WHAT AN ORGANIC KEY IS ═══
+
+An organic key is a column whose value can be used to MATCH two rows that
+refer to the SAME real-world entity, WITHOUT going through a declared foreign
+key. PR #2193 lets the framework "join by value" wherever the schema lacks an
+explicit FK link (cross-system data, late-bound integrations, denormalized
+warehouses, partial schemas).
+
+KEEP a column as an organic-key candidate when this test passes:
+
+  "If I take two rows that have the same value in this column, do they
+   refer to the SAME real-world entity (the same customer, the same person,
+   the same order, the same product, the same location, the same legal
+   entity, the same communication endpoint)?"
+
+This test is SATISFIED by:
+  - Customer / member / employee / person / company / product / order IDs —
+    natural OR surrogate. Within a database an EmployeeID of 42 in one table
+    DOES refer to the same employee as EmployeeID 42 in another table. That
+    is the WHOLE POINT of PR #2193 — these are the matches it makes navigable.
+  - Email addresses, phone numbers, fax numbers, URLs.
+  - Tax IDs, social security numbers, account numbers, license numbers.
+  - ISBNs, SKUs, product codes, part numbers.
+  - Postal codes, street addresses, geocodes (they identify a delivery point
+    or location entity).
+  - Full names, first names, last names, organization names — identifiers of
+    persons or organizations even when fuzzy.
+
+FK columns are EXPLICITLY ALLOWED. PR #2193 organic keys often overlap with
+FK columns by design — the same EmployeeID that's a declared FK in one table
+is the organic match key for tables where the FK isn't declared. Do not
+disqualify a column just because it participates in a FK.
+
+REJECT (isUsefulOrganicKey=false) ONLY in these cases:
+
+  - Categorical / enum-like values with a small fixed vocabulary (status =
+    'Active'/'Pending'/'Closed'; type = 'A'/'B'/'C'; region code = 'NA'/'EMEA';
+    country code = 'US'/'UK'/'FR'). Two rows sharing status='Active' do NOT
+    refer to the same real-world entity — they're just both active.
+
+  - Booleans / flags (IsActive, HasDiscount).
+
+  - Measurements, quantities, prices, percentages, aggregates (price, qty,
+    discount, count, score, weight).
+
+  - Audit metadata (created_at, modified_by, version, row_version, rowguid,
+    last_login_at).
+
+  - Free-form descriptive text (notes, comments, description paragraphs,
+    long-text fields).
+
+  - System paths / blob references (photo_path, file_url, attachment_uri)
+    when they're pointers to assets rather than the asset's identity.
+
+DO NOT REJECT a column just because:
+  - It is auto-increment (auto-increment IDs are still valid organic keys
+    across tables in the same system).
+  - It is a foreign key (FKs are valid organic keys, see above).
+  - It "identifies a location, not the parent row's entity" (a postal code
+    DOES identify a delivery location entity, which is a valid organic-key
+    use; clustering will decide whether it's useful).
+  - Names "could collide" (low uniqueness lowers confidence but does NOT
+    disqualify — names are valid organic-key candidates per PR #2193).
+
+═══ YOUR TASK ═══
+
+For each column you receive, produce a JSON object with these fields. Look at
+the sibling columns and the table's purpose for context — they often clarify
+whether a value identifies or categorizes.
+
+1. normalizedDescription — A STRUCTURED BUSINESS-FOCUSED SENTENCE that any
+   reader (or embedding model) can use to recognize this kind of value. Use
+   this exact structural template:
+
+     "<value-kind> identifying <entity-kind>; <normalization rule>."
+
+   Example shapes:
+     "RFC-5322 email address identifying a natural person; case-insensitive
+      whitespace-trimmed equality."
+     "E.164 phone number identifying a person or organization; digits-only
+      equality after stripping formatting."
+     "Customer identifier (auto-increment or business code) identifying a
+      customer entity across tables; exact equality after trimming."
+     "Employee identifier identifying an employee across HR tables; exact
+      equality."
+     "Postal / ZIP code identifying a delivery area; exact equality after
+      trimming."
+     "Family name (last name) identifying a natural person; case-insensitive
+      whitespace-trimmed equality."
+
+   For REJECTED columns, the template flips:
+     "ISO-3166 country code (categorical, 250 buckets); not an entity
+      identifier; not applicable."
+     "Order line quantity (measurement); not an entity identifier; not
+      applicable."
+     "Modification timestamp (audit metadata); not applicable."
+
+   Same-concept columns from different tables MUST produce highly similar
+   normalizedDescription strings so they cluster geometrically. Generic prose
+   ("a code", "an identifier") is NOT acceptable — name the value kind
+   (email address, phone number, customer id, postal code, family name, etc.)
+   and the entity kind explicitly.
+
+2. conceptName — A canonical snake_case label for this value kind
+   (e.g. "email_address", "phone_number", "postal_code", "customer_id",
+   "employee_id", "person_family_name"). Use the same name for the same
+   concept across tables. Used as a cluster label hint downstream.
+
+3. normalizationStrategy — How equality should be tested at match time:
+     "LowerCaseTrim"  (default for case-insensitive text)
+     "Trim"           (whitespace only)
+     "ExactMatch"     (codes, IDs that are case-sensitive)
+     "Custom"         (provide customNormalizationExpression — a SQL expression
+                      that MUST use the literal placeholder {{FieldName}} where the
+                      column reference goes, e.g.
+                      REPLACE(REPLACE({{FieldName}}, '-', ''), ' ', ''). Do NOT use
+                      'value', 'x', or a column name — only {{FieldName}}.)
+
+4. isUsefulOrganicKey — Apply the test at the top of the prompt:
+   "If I take two rows with the same value in this column, do they refer to
+   the SAME real-world entity?" True for IDs, emails, phones, names,
+   addresses, codes that are entity-level. False ONLY for categorical
+   enums, booleans, measurements, audit metadata, free-form text, and
+   asset paths.
+
+5. confidence — 0.0 to 1.0. Reflect uncertainty honestly; sample values that
+   contradict the column name should lower confidence even if you commit to
+   a judgment.
+
+6. reasoning — One short sentence stating why this kind of value satisfies
+   or fails the test in field 4.
+
+Sample values are the strongest signal. If the column is named "Status" but
+samples are all distinct uuid-like tokens, trust the data over the name.
+
+Output STRICT JSON only, no markdown fences:
+{
+  "columns": [
+    {
+      "column": "<exact column name from input>",
+      "conceptName": "snake_case_name",
+      "normalizationStrategy": "LowerCaseTrim" | "Trim" | "ExactMatch" | "Custom",
+      "customNormalizationExpression": "...",
+      "normalizedDescription": "<structured sentence per template above>",
+      "isUsefulOrganicKey": true,
+      "confidence": 0.95,
+      "reasoning": "One short sentence."
+    }
+  ]
+}
+
+Include EVERY column from the input, in the same order. Match the "column" field
+exactly to the input column name.`;
+
+/**
+ * Normalize whatever column placeholder the LLM used in a Custom expression to the
+ * canonical {{FieldName}} token that CodeGen + the PR #2193 runtime substitute. The
+ * prompt asks for {{FieldName}}, but models frequently emit `value`, `x`, `col`, or
+ * `column` instead — this guards against the resulting silent runtime breakage where
+ * the literal placeholder would survive into the executed SQL.
+ */
+function sanitizePlaceholder(expr: string | undefined): string | undefined {
+    if (!expr) return expr;
+    let out = expr;
+    // Already correct — leave alone.
+    if (/\{\{\s*FieldName\s*\}\}/.test(out)) {
+        return out.replace(/\{\{\s*FieldName\s*\}\}/g, '{{FieldName}}');
+    }
+    // Replace common standalone placeholder identifiers (word-boundary, not inside quotes).
+    // Order matters: longer tokens first.
+    for (const token of ['column', 'value', 'col', 'x']) {
+        const re = new RegExp(`\\b${token}\\b`, 'g');
+        if (re.test(out)) {
+            out = out.replace(re, '{{FieldName}}');
+            break; // only the first matching convention is the placeholder
+        }
+    }
+    return out;
+}
+
+
+
+// ─── Internal types ─────────────────────────────────────────────────────────
+
+interface LLMColumnEntry {
+    column: string;
+    conceptName: string;
+    normalizationStrategy: OrganicKeyNormalizationStrategy;
+    customNormalizationExpression?: string;
+    normalizedDescription: string;
+    isUsefulOrganicKey: boolean;
+    confidence: number;
+    reasoning: string;
+}
+
+interface LLMTableResponse {
+    columns: LLMColumnEntry[];
+}
+
+// ─── Helpers ────────────────────────────────────────────────────────────────
+
+function buildUserPrompt(input: TableNormalizationInput): string {
+    const lines: string[] = [];
+    lines.push(`Table: ${input.schema}.${input.table}`);
+    if (input.schemaDescription) lines.push(`Schema purpose: ${truncate(input.schemaDescription, 240)}`);
+    if (input.tableDescription) lines.push(`Table purpose:  ${truncate(input.tableDescription, 240)}`);
+    lines.push('');
+    lines.push(`Columns (${input.columns.length}):`);
+    for (const c of input.columns) {
+        lines.push(`  - ${c.column}  [${c.dataType}]${c.isPrimaryKey ? '  PK' : ''}${c.participatesInFK ? `  FK${c.fkTarget ? `→${c.fkTarget.schema}.${c.fkTarget.table}.${c.fkTarget.column}` : ''}` : ''}`);
+        if (c.originalDescription) lines.push(`      description: ${truncate(c.originalDescription, 240)}`);
+        if (c.sampleValues && c.sampleValues.length > 0) {
+            const samples = c.sampleValues
+                .slice(0, 5)
+                .map((v) => JSON.stringify(truncate(String(v), 80)))
+                .join(', ');
+            lines.push(`      samples: [${samples}]`);
+        }
+    }
+    lines.push('');
+    lines.push('Output the normalized JSON per the system prompt — one entry per column, in order.');
+    return lines.join('\n');
+}
+
+function clamp01(x: number): number {
+    if (!Number.isFinite(x)) return 0;
+    if (x < 0) return 0;
+    if (x > 1) return 1;
+    return x;
+}
+
+function truncate(s: string, n: number): string {
+    if (!s) return '';
+    return s.length > n ? s.slice(0, n - 1) + '…' : s;
+}

--- a/packages/DBAutoDoc/src/discovery/Composer.ts
+++ b/packages/DBAutoDoc/src/discovery/Composer.ts
@@ -1,0 +1,123 @@
+/**
+ * Composer — flag-and-emit (no destructive filtering).
+ *
+ * Computes `isFKRedundant` for each cluster (PR #2193 organic keys are meant
+ * to be used "in place of a foreign-key reference" — when every non-PK member
+ * is a declared FK pointing to the PK member, the cluster adds no new
+ * navigation). Sets the flag on the cluster but does NOT drop — well-modeled
+ * OLTP schemas would lose 30-50% of valid organic-key candidates if we
+ * dropped, and the discovery value (cross-system extension, naming
+ * consistency checks) survives the redundancy.
+ *
+ * The dashboard surfaces a "hide FK-redundant" filter so users get the lookup-
+ * table-PK noise out of view without losing the underlying candidates.
+ */
+
+import { OrganicKeyCluster, OrganicKeyClusterMember } from '../types/organic-keys.js';
+import {
+    DetectedOrganicKeysOutput,
+    TransitiveSpokeInput,
+    translateClusters,
+    countOutputEntries,
+} from './OrganicKeyTranslator.js';
+import { TransitiveBridgeFinding } from './TransitiveBridgeDetector.js';
+
+/** Output of the compose step: the PR #2193 JSON, the FK-redundancy-annotated clusters, and emit counts. */
+export interface ComposerResult {
+    output: DetectedOrganicKeysOutput;
+    /** Clusters with isFKRedundant filled in — callers that persist the cluster list
+     *  (e.g. detector → state.json → dashboard) should use THIS, not the pre-compose
+     *  input, otherwise the flag is silently lost. */
+    annotatedClusters: OrganicKeyCluster[];
+    emitted: number;
+    flaggedFKRedundant: number;
+    summary: { outputSchemas: number; outputTables: number; outputKeys: number; outputSpokes: number };
+}
+
+/**
+ * Compose detected clusters + transitive bridges into the PR #2193 emit JSON.
+ *
+ * Each cluster is annotated with `isFKRedundant` (true when it's already navigable via a
+ * declared foreign key — kept but flagged, not dropped). Matching transitive bridges are
+ * attached as spokes. Returns the JSON plus the annotated clusters and emit counts.
+ */
+export function compose(
+    clusters: OrganicKeyCluster[],
+    bridges: TransitiveBridgeFinding[],
+): ComposerResult {
+    let flaggedCount = 0;
+    const annotated: OrganicKeyCluster[] = clusters.map((c) => {
+        const redundant = isFKRedundant(c);
+        if (redundant) flaggedCount += 1;
+        return { ...c, isFKRedundant: redundant };
+    });
+
+    const hubKeys = new Set<string>();
+    for (const c of annotated) {
+        for (const m of c.members) hubKeys.add(`${m.schema}.${m.table}.${m.column}`);
+    }
+    const spokes: TransitiveSpokeInput[] = bridges
+        .filter((b) => hubKeys.has(`${b.hubSchema}.${b.hubTable}.${b.hubKeyFields[0]}`))
+        .map((b) => ({
+            hubSchema: b.hubSchema,
+            hubTable: b.hubTable,
+            hubKeyFields: b.hubKeyFields,
+            spokeSchema: b.spokeSchema,
+            spokeTable: b.spokeTable,
+            transitiveView: { Name: b.view.viewName, SchemaName: b.view.schemaName, SQL: b.view.sql },
+            transitiveMatchFieldNames: [b.view.hubKeyField],
+            transitiveOutputFieldName: b.view.spokeOutputField,
+            relatedEntityJoinFieldName: b.view.spokeJoinField,
+            hubConcept: b.hubConcept,
+        }));
+
+    const output = translateClusters(annotated, spokes);
+    const counts = countOutputEntries(output);
+
+    return {
+        output,
+        annotatedClusters: annotated,
+        emitted: annotated.length,
+        flaggedFKRedundant: flaggedCount,
+        summary: {
+            outputSchemas: counts.schemas,
+            outputTables: counts.tables,
+            outputKeys: counts.keys,
+            outputSpokes: counts.spokes,
+        },
+    };
+}
+
+/**
+ * A cluster is FK-redundant when ALL non-PK members are declared FKs pointing
+ * at the same target column (typically the PK member of the cluster). PR #2193
+ * organic keys are "used in place of a foreign-key reference" — if the FK is
+ * already declared, the cluster doesn't add navigability.
+ *
+ * Requires at least one PK and at least one FK in the cluster to apply.
+ * Returns false for clusters that are entirely PKs, entirely non-FKs, or that
+ * have mixed FK targets (the latter is a genuine value-based correlation that
+ * no single FK covers).
+ */
+function isFKRedundant(cluster: OrganicKeyCluster): boolean {
+    const pkMembers = cluster.members.filter((m) => m.isPrimaryKey);
+    const nonPK = cluster.members.filter((m) => !m.isPrimaryKey);
+    if (pkMembers.length === 0 || nonPK.length === 0) return false;
+
+    // Build the set of plausible "target" identifiers from the PK members.
+    const pkTargets = new Set<string>(
+        pkMembers.map((m) => `${m.schema}.${m.table}.${m.column}`.toLowerCase()),
+    );
+
+    // Every non-PK member must be a FK pointing into one of the PK targets.
+    for (const m of nonPK) {
+        if (!m.participatesInFK || !m.fkTarget) return false;
+        const key = `${m.fkTarget.schema}.${m.fkTarget.table}.${m.fkTarget.column}`.toLowerCase();
+        if (!pkTargets.has(key)) return false;
+    }
+    return true;
+}
+
+/** Re-export for tests / observability. */
+export const __test__ = { isFKRedundant };
+export type { OrganicKeyClusterMember };

--- a/packages/DBAutoDoc/src/discovery/EmbeddingProvider.ts
+++ b/packages/DBAutoDoc/src/discovery/EmbeddingProvider.ts
@@ -1,0 +1,114 @@
+/**
+ * EmbeddingProvider — thin wrapper over MemberJunction's `BaseEmbeddings` infrastructure.
+ *
+ * Embeddings are produced through the same MJ ClassFactory + driver pattern that
+ * `llm-factory` uses for LLMs (so DBAutoDoc stays coupled to MJ's AI stack rather
+ * than talking to provider REST endpoints directly). The concrete driver class is
+ * resolved from the provider name and instantiated with the supplied API key.
+ *
+ * Vectors are unit-normalized so the clustering step can use cosine distance
+ * directly regardless of whether the underlying model returns normalized output.
+ */
+
+import { BaseEmbeddings } from '@memberjunction/ai';
+import { MJGlobal } from '@memberjunction/global';
+
+/** Provider names that map to a registered `BaseEmbeddings` driver class. */
+export type EmbeddingProviderName = 'openai' | 'mistral' | 'azure' | 'bedrock' | 'ollama' | 'local';
+
+export interface EmbeddingProviderConfig {
+    provider: EmbeddingProviderName;
+    apiKey: string;
+    model?: string;
+    dimensions?: number;
+    batchSize?: number;
+    endpoint?: string;
+}
+
+export interface EmbeddingProvider {
+    readonly provider: EmbeddingProviderName;
+    embed(texts: string[]): Promise<Float32Array[]>;
+}
+
+/** Provider name → registered MJ embedding driver class (see `@RegisterClass(BaseEmbeddings, ...)`). */
+const PROVIDER_TO_DRIVER_CLASS: Record<EmbeddingProviderName, string> = {
+    openai: 'OpenAIEmbedding',
+    mistral: 'MistralEmbedding',
+    azure: 'AzureEmbedding',
+    bedrock: 'BedrockEmbedding',
+    ollama: 'OllamaEmbedding',
+    local: 'LocalEmbedding',
+};
+
+/** Sensible default embedding model per provider when the config doesn't specify one. */
+const PROVIDER_DEFAULT_MODEL: Partial<Record<EmbeddingProviderName, string>> = {
+    openai: 'text-embedding-3-small',
+    mistral: 'mistral-embed',
+};
+
+export function createEmbeddingProvider(config: EmbeddingProviderConfig): EmbeddingProvider {
+    const driverClass = PROVIDER_TO_DRIVER_CLASS[config.provider];
+    if (!driverClass) {
+        const supported = Object.keys(PROVIDER_TO_DRIVER_CLASS).join(', ');
+        throw new Error(`Embedding provider not supported: ${config.provider}. Supported: ${supported}`);
+    }
+    return new MJEmbeddingProvider(config, driverClass);
+}
+
+/** Wraps a registered `BaseEmbeddings` driver behind the simple `embed(texts)` contract. */
+class MJEmbeddingProvider implements EmbeddingProvider {
+    public readonly provider: EmbeddingProviderName;
+    private readonly embeddings: BaseEmbeddings;
+    private readonly model: string;
+    private readonly batchSize: number;
+
+    constructor(config: EmbeddingProviderConfig, driverClass: string) {
+        this.provider = config.provider;
+        this.model = config.model || PROVIDER_DEFAULT_MODEL[config.provider] || '';
+        this.batchSize = config.batchSize ?? 100;
+
+        const instance = MJGlobal.Instance.ClassFactory.CreateInstance<BaseEmbeddings>(
+            BaseEmbeddings,
+            driverClass,
+            config.apiKey,
+        );
+        if (!instance) {
+            throw new Error(
+                `Failed to create embedding instance for provider '${config.provider}' (driver class: ${driverClass}). ` +
+                    `Check that the provider package is installed and registered via server-bootstrap.`,
+            );
+        }
+        this.embeddings = instance;
+    }
+
+    public async embed(texts: string[]): Promise<Float32Array[]> {
+        const out = new Array<Float32Array>(texts.length);
+        for (let i = 0; i < texts.length; i += this.batchSize) {
+            const batch = texts.slice(i, i + this.batchSize);
+            const vectors = await this.embedBatch(batch);
+            for (let j = 0; j < vectors.length; j++) out[i + j] = vectors[j];
+        }
+        return out;
+    }
+
+    private async embedBatch(texts: string[]): Promise<Float32Array[]> {
+        const result = await this.embeddings.EmbedTexts({ texts, model: this.model });
+        const vectors = result?.vectors;
+        if (!vectors || vectors.length !== texts.length) {
+            throw new Error(
+                `Embedding driver returned ${vectors?.length ?? 0} vectors for ${texts.length} inputs (provider: ${this.provider}).`,
+            );
+        }
+        return vectors.map((v) => normalizeVec(Float32Array.from(v)));
+    }
+}
+
+/** Unit-normalize a vector in place so the clustering step can use cosine distance. */
+function normalizeVec(v: Float32Array): Float32Array {
+    let sum = 0;
+    for (let i = 0; i < v.length; i++) sum += v[i] * v[i];
+    const norm = Math.sqrt(sum);
+    if (norm === 0) return v;
+    for (let i = 0; i < v.length; i++) v[i] = v[i] / norm;
+    return v;
+}

--- a/packages/DBAutoDoc/src/discovery/FKGraphWalker.ts
+++ b/packages/DBAutoDoc/src/discovery/FKGraphWalker.ts
@@ -1,0 +1,264 @@
+/**
+ * FKGraphWalker — Pattern 3 graph traversal.
+ *
+ * Given the foreign-key relationships of a database (hard declared + DBAutoDoc-
+ * discovered soft FKs), build an undirected join graph and find all paths of
+ * length ≤ maxHops from each "spoke" table to each "hub" table carrying an
+ * organic key. A path of length 2-3 means the spoke can reach the hub through
+ * intermediate tables — that's a transitive bridge candidate.
+ *
+ * Why a graph, not just FK chains:
+ *   Many natural bridges traverse FKs in both directions. Example:
+ *     Subscriber ←─ CampaignSend           (CampaignSend.SubscriberID → Subscriber.ID)
+ *     Contact (hub) — Email column
+ *   To reach CampaignSend from Contact via "email", the path goes:
+ *     Contact.Email ↔ Subscriber.Email (organic key match)
+ *     Subscriber.ID ← CampaignSend.SubscriberID (FK navigation, reverse direction)
+ *
+ *   The FK arrow points CampaignSend → Subscriber, but the bridge traversal
+ *   goes Subscriber → CampaignSend. Modeling the graph as undirected handles
+ *   this naturally; the edge metadata still tells us which side is the FK
+ *   source vs target.
+ *
+ * Output: structural paths the BridgeViewSQLGenerator turns into CREATE VIEW
+ * SQL conformant with PR #2193's TransitiveView contract.
+ */
+
+/** One foreign-key relationship between two tables. */
+export interface FKEdge {
+    sourceSchema: string;
+    sourceTable: string;
+    sourceColumn: string;
+    targetSchema: string;
+    targetTable: string;
+    targetColumn: string;
+    /** Hard (declared) vs soft (DBAutoDoc-detected). Affects ranking only. */
+    kind: 'hard' | 'soft';
+    /** Soft-FK confidence (0-1). Hard FKs are always 1. */
+    confidence: number;
+}
+
+/** A discovered transitive path from spoke to hub. */
+export interface BridgePath {
+    /** The table reachable through the chain (the "spoke" in organic-key terms). */
+    spokeSchema: string;
+    spokeTable: string;
+    /** The table carrying the organic key (the "hub"). */
+    hubSchema: string;
+    hubTable: string;
+    /** Field name on the hub being projected (the organic-key match field). */
+    hubKeyField: string;
+    /**
+     * Ordered list of join hops. hops[0].fromTable === spokeTable;
+     * hops[last].toTable === hubTable. For a length-2 path:
+     *   hops = [ { fromTable: spoke, toTable: intermediate, ... },
+     *            { fromTable: intermediate, toTable: hub, ... } ]
+     */
+    hops: BridgeHop[];
+    /** Total path length (number of FK joins). */
+    pathLength: number;
+    /**
+     * Path confidence = product of edge confidences. Hard-only paths = 1.
+     * Soft FKs on the path drag the confidence down (1 × 0.85 = 0.85).
+     */
+    pathConfidence: number;
+}
+
+/** One join hop in a bridge path. */
+export interface BridgeHop {
+    fromSchema: string;
+    fromTable: string;
+    fromColumn: string;
+    toSchema: string;
+    toTable: string;
+    toColumn: string;
+    /** Edge kind for ranking; same as FKEdge.kind. */
+    kind: 'hard' | 'soft';
+}
+
+export interface FKGraphWalkerOptions {
+    /** Maximum path length to explore. PR #2193 examples cap at 3. Default 3. */
+    maxHops?: number;
+    /**
+     * Minimum confidence threshold for soft FKs to be included in the graph.
+     * Hard FKs are always included. Default 0.6.
+     */
+    minSoftFKConfidence?: number;
+    /**
+     * When true, paths through the same table twice are pruned (no cycles).
+     * Default true.
+     */
+    pruneCycles?: boolean;
+}
+
+const DEFAULTS: Required<FKGraphWalkerOptions> = {
+    maxHops: 3,
+    minSoftFKConfidence: 0.6,
+    pruneCycles: true,
+};
+
+/**
+ * Build the join graph and find all bridge paths from each spoke candidate to
+ * each hub candidate.
+ *
+ * @param edges - all FK relationships in the database (hard + soft).
+ * @param hubs  - tables that carry an organic key (output of Pattern 1/2). Each
+ *                entry names the hub's match field — this becomes the projected
+ *                column in the bridge view.
+ * @param spokes - tables to attempt to reach from each hub. Typically every
+ *                 table in the database except the hub itself.
+ */
+export function findBridgePaths(
+    edges: FKEdge[],
+    hubs: Array<{ schema: string; table: string; keyField: string }>,
+    spokes: Array<{ schema: string; table: string }>,
+    opts: FKGraphWalkerOptions = {},
+): BridgePath[] {
+    const o = { ...DEFAULTS, ...opts };
+
+    // Build the adjacency map keyed by "schema.table".
+    const adjacency = buildAdjacency(edges, o.minSoftFKConfidence);
+
+    const out: BridgePath[] = [];
+    for (const hub of hubs) {
+        const hubKey = `${hub.schema}.${hub.table}`;
+        for (const spoke of spokes) {
+            const spokeKey = `${spoke.schema}.${spoke.table}`;
+            if (spokeKey === hubKey) continue;
+            // BFS from spoke → hub.
+            const paths = bfsPaths(adjacency, spokeKey, hubKey, o.maxHops, o.pruneCycles);
+            for (const p of paths) {
+                if (p.length === 0) continue; // self
+                if (p.length === 1) continue; // direct FK already handled by existing relationship system
+                out.push(materializeBridgePath(p, hub, spoke));
+            }
+        }
+    }
+    // Sort: shortest paths first, then highest confidence.
+    out.sort((a, b) => {
+        if (a.pathLength !== b.pathLength) return a.pathLength - b.pathLength;
+        return b.pathConfidence - a.pathConfidence;
+    });
+    return out;
+}
+
+// ─── Adjacency construction ─────────────────────────────────────────────────
+
+/** Edge with the endpoints expressed as "schema.table" keys (undirected). */
+interface AdjacencyEdge {
+    fromKey: string;
+    toKey: string;
+    /** Original FK source side — for SQL generation we still need to know which side is the FK source. */
+    fkSourceKey: string;
+    fkSourceColumn: string;
+    fkTargetColumn: string;
+    kind: 'hard' | 'soft';
+    confidence: number;
+}
+
+function buildAdjacency(edges: FKEdge[], minSoftFKConfidence: number): Map<string, AdjacencyEdge[]> {
+    const out = new Map<string, AdjacencyEdge[]>();
+    for (const e of edges) {
+        if (e.kind === 'soft' && e.confidence < minSoftFKConfidence) continue;
+        const aKey = `${e.sourceSchema}.${e.sourceTable}`;
+        const bKey = `${e.targetSchema}.${e.targetTable}`;
+        const forward: AdjacencyEdge = {
+            fromKey: aKey,
+            toKey: bKey,
+            fkSourceKey: aKey,
+            fkSourceColumn: e.sourceColumn,
+            fkTargetColumn: e.targetColumn,
+            kind: e.kind,
+            confidence: e.confidence,
+        };
+        const reverse: AdjacencyEdge = {
+            fromKey: bKey,
+            toKey: aKey,
+            fkSourceKey: aKey,
+            fkSourceColumn: e.sourceColumn,
+            fkTargetColumn: e.targetColumn,
+            kind: e.kind,
+            confidence: e.confidence,
+        };
+        push(out, aKey, forward);
+        push(out, bKey, reverse);
+    }
+    return out;
+}
+
+function push<K, V>(map: Map<K, V[]>, key: K, value: V): void {
+    const list = map.get(key);
+    if (list) list.push(value);
+    else map.set(key, [value]);
+}
+
+// ─── BFS ────────────────────────────────────────────────────────────────────
+
+/** Path of adjacency edges from `start` to `goal`. Returns empty if none found. */
+function bfsPaths(
+    adjacency: Map<string, AdjacencyEdge[]>,
+    start: string,
+    goal: string,
+    maxHops: number,
+    pruneCycles: boolean,
+): AdjacencyEdge[][] {
+    if (start === goal) return [[]];
+    const queue: { node: string; pathEdges: AdjacencyEdge[]; visited: Set<string> }[] = [
+        { node: start, pathEdges: [], visited: new Set([start]) },
+    ];
+    const found: AdjacencyEdge[][] = [];
+    while (queue.length > 0) {
+        const { node, pathEdges, visited } = queue.shift()!;
+        if (pathEdges.length >= maxHops) continue;
+        const neighbors = adjacency.get(node) ?? [];
+        for (const edge of neighbors) {
+            const nextNode = edge.toKey;
+            if (pruneCycles && visited.has(nextNode)) continue;
+            const newPath = [...pathEdges, edge];
+            if (nextNode === goal) {
+                found.push(newPath);
+                continue; // don't extend past the goal
+            }
+            const nextVisited = new Set(visited);
+            nextVisited.add(nextNode);
+            queue.push({ node: nextNode, pathEdges: newPath, visited: nextVisited });
+        }
+    }
+    return found;
+}
+
+// ─── Bridge path materialization ────────────────────────────────────────────
+
+function materializeBridgePath(
+    edgePath: AdjacencyEdge[],
+    hub: { schema: string; table: string; keyField: string },
+    spoke: { schema: string; table: string },
+): BridgePath {
+    const hops: BridgeHop[] = edgePath.map((e) => {
+        const [fromSchema, fromTable] = e.fromKey.split('.');
+        const [toSchema, toTable] = e.toKey.split('.');
+        // The column on the "from" side is the FK-source column if from is the FK source;
+        // otherwise it's the FK-target column.
+        const fromIsFKSource = e.fromKey === e.fkSourceKey;
+        return {
+            fromSchema,
+            fromTable,
+            fromColumn: fromIsFKSource ? e.fkSourceColumn : e.fkTargetColumn,
+            toSchema,
+            toTable,
+            toColumn: fromIsFKSource ? e.fkTargetColumn : e.fkSourceColumn,
+            kind: e.kind,
+        };
+    });
+    const pathConfidence = edgePath.reduce((acc, e) => acc * e.confidence, 1);
+    return {
+        spokeSchema: spoke.schema,
+        spokeTable: spoke.table,
+        hubSchema: hub.schema,
+        hubTable: hub.table,
+        hubKeyField: hub.keyField,
+        hops,
+        pathLength: edgePath.length,
+        pathConfidence,
+    };
+}

--- a/packages/DBAutoDoc/src/discovery/OrganicKeyDetector.ts
+++ b/packages/DBAutoDoc/src/discovery/OrganicKeyDetector.ts
@@ -1,0 +1,116 @@
+/**
+ * OrganicKeyDetector — the thin orchestrator.
+ *
+ *   1. SemanticPhase    LLM identifies organic-key concept per column,
+ *                       groups columns by canonical concept name into clusters
+ *                       spanning ≥2 distinct tables.
+ *
+ *   2. StructuralPhase  Walks the FK graph from each cluster's hubs to find
+ *                       reachable tables 2-3 hops away → bridge view SQL.
+ *
+ *   3. Composer         Drops fk-redundant clusters (already navigable via
+ *                       declared FK per PR #2193), attaches matching bridges,
+ *                       emits PR #2193 JSON.
+ *
+ * No knobs. The LLM is the algorithm; the graph is deterministic; the filter
+ * is the one PR #2193 explicitly defines.
+ */
+
+import { AIConfig, OrganicKeyDetectionConfig } from '../types/config.js';
+import { DatabaseDocumentation } from '../types/state.js';
+import { OrganicKeyCluster, OrganicKeyDetectionPhase } from '../types/organic-keys.js';
+import { runSemanticPhase, ProgressCallback } from './SemanticPhase.js';
+import { runStructuralPhase } from './StructuralPhase.js';
+import { compose } from './Composer.js';
+import { DetectedOrganicKeysOutput } from './OrganicKeyTranslator.js';
+
+export interface OrganicKeyDetectionResult {
+    clusters: OrganicKeyCluster[];
+    output: DetectedOrganicKeysOutput;
+    phase: OrganicKeyDetectionPhase;
+    summary: {
+        columnsInScope: number;
+        columnsNormalized: number;
+        columnsRejectedByNormalizer: number;
+        clustersFound: number;
+        clustersEmitted: number;
+        clustersDropped: number;
+        outputSchemas: number;
+        outputTables: number;
+        outputKeys: number;
+        outputSpokes: number;
+        transitiveBridges: number;
+    };
+}
+
+export interface DetectorRunOptions {
+    onProgress?: ProgressCallback;
+}
+
+export class OrganicKeyDetector {
+    constructor(
+        private readonly config: OrganicKeyDetectionConfig,
+        private readonly aiConfig: AIConfig,
+    ) {}
+
+    public async detect(
+        state: DatabaseDocumentation,
+        opts: DetectorRunOptions = {},
+    ): Promise<OrganicKeyDetectionResult> {
+        const progress = opts.onProgress ?? (() => {});
+        const startedAt = new Date().toISOString();
+
+        const a = await runSemanticPhase(state, this.config, this.aiConfig, progress);
+        const b = runStructuralPhase(state, a.clusters);
+        progress(`structural: ${b.summary.transitiveBridgesFound} bridges`);
+        const c = compose(a.clusters, b.bridges);
+        progress(`compose: emitted ${c.emitted}/${a.clusters.length} clusters (${c.summary.outputKeys} keys, ${c.summary.outputSpokes} spokes)`);
+
+        // Net additional clusters produced by the concept-name split (sub-clusters created
+        // beyond the raw clusterer output, counting both kept and dropped sub-clusters).
+        const splitClusterCount = Math.max(
+            0,
+            a.summary.clustersFound + a.summary.clustersDropped - a.summary.clustersBeforeSplit,
+        );
+
+        return {
+            clusters: c.annotatedClusters,
+            output: c.output,
+            phase: {
+                triggered: true,
+                startedAt,
+                completedAt: new Date().toISOString(),
+                status: 'completed',
+                candidateClusterCount: a.clusters.length,
+                confirmedClusterCount: c.emitted,
+                rejectedClusterCount: a.summary.columnsRejectedByNormalizer,
+                splitClusterCount,
+                tokensUsed: a.tokens.total,
+                inputTokens: a.tokens.input,
+                outputTokens: a.tokens.output,
+                estimatedCost: this.estimateCost(a.tokens.input, a.tokens.output),
+                refinementModelUsed: this.aiConfig.model,
+            },
+            summary: {
+                columnsInScope: a.summary.columnsInScope,
+                columnsNormalized: a.summary.columnsNormalized,
+                columnsRejectedByNormalizer: a.summary.columnsRejectedByNormalizer,
+                clustersFound: a.clusters.length,
+                clustersEmitted: c.emitted,
+                clustersDropped: a.summary.clustersDropped,
+                outputSchemas: c.summary.outputSchemas,
+                outputTables: c.summary.outputTables,
+                outputKeys: c.summary.outputKeys,
+                outputSpokes: c.summary.outputSpokes,
+                transitiveBridges: b.summary.transitiveBridgesFound,
+            },
+        };
+    }
+
+    private estimateCost(inputTokens: number, outputTokens: number): number {
+        const pricing = this.aiConfig.pricing;
+        if (!pricing) return 0;
+        return (inputTokens / 1_000_000) * (pricing.inputCostPer1MTokens ?? 0)
+             + (outputTokens / 1_000_000) * (pricing.outputCostPer1MTokens ?? 0);
+    }
+}

--- a/packages/DBAutoDoc/src/discovery/OrganicKeyTranslator.ts
+++ b/packages/DBAutoDoc/src/discovery/OrganicKeyTranslator.ts
@@ -1,0 +1,254 @@
+/**
+ * OrganicKeyTranslator — PURE EMISSION.
+ *
+ * Takes a list of clusters that have ALREADY been gated by the Composer, plus
+ * the transitive spokes for those that survived, and fans them out into PR
+ * #2193's per-schema/per-table JSON.
+ *
+ * No filtering, no thresholds, no scoring logic in here. The Composer is the
+ * single emission gate; this file is its render-to-JSON helper.
+ *
+ * Same-concept consolidation: clusters that the LLM normalizer assigned the
+ * same canonical concept name (e.g. four separate geometric clusters all
+ * named `product_id`) are MERGED here into a single conceptual cluster before
+ * fan-out — deterministic equivalent of an LLM concept-merge pass.
+ */
+
+import {
+    OrganicKeyCluster,
+    OrganicKeyClusterMember,
+    OrganicKeyNormalizationStrategy,
+    memberColumns,
+    isCompoundMember,
+} from '../types/organic-keys.js';
+
+// ─── PR #2193 output shape ───────────────────────────────────────────────────
+// These interfaces are the public contract emitted into additionalSchemaInfo.json and
+// consumed by CodeGen's organic-key processing to upsert EntityOrganicKey /
+// EntityOrganicKeyRelatedEntity metadata. Field casing matches the PR #2193 schema.
+
+/** A generated SQL bridge view backing a transitive (multi-hop) spoke. */
+export interface TransitiveViewConfig {
+    Name: string;
+    SchemaName?: string;
+    SQL: string;
+}
+
+/** One related entity (spoke) reachable from an organic key — either a direct field match or a transitive (bridge-view) match. */
+export interface OrganicKeyRelatedEntityConfig {
+    SchemaName: string;
+    TableName: string;
+    RelatedFieldNames?: string[];
+    TransitiveView?: TransitiveViewConfig;
+    TransitiveMatchFieldNames?: string[];
+    TransitiveOutputFieldName?: string;
+    RelatedEntityJoinFieldName?: string;
+    DisplayName?: string;
+}
+
+/** A single organic key anchored on one table's column(s), with its own normalization and its spokes. */
+export interface OrganicKeyConfig {
+    Name: string;
+    Description?: string;
+    MatchFieldNames: string[];
+    NormalizationStrategy: OrganicKeyNormalizationStrategy;
+    CustomNormalizationExpression?: string;
+    AutoCreateRelatedViewOnForm?: boolean;
+    RelatedEntities: OrganicKeyRelatedEntityConfig[];
+}
+
+/** All organic keys anchored on a given table. */
+export interface TableOrganicKeyConfig {
+    TableName: string;
+    OrganicKeys: OrganicKeyConfig[];
+}
+
+/** The full emit payload: schema name → its tables' organic-key configs. */
+export type DetectedOrganicKeysOutput = Record<string, TableOrganicKeyConfig[]>;
+
+// ─── Transitive spoke input (from Phase B) ──────────────────────────────────
+
+export interface TransitiveSpokeInput {
+    hubSchema: string;
+    hubTable: string;
+    hubKeyFields: string[];
+    spokeSchema: string;
+    spokeTable: string;
+    transitiveView: TransitiveViewConfig;
+    transitiveMatchFieldNames: string[];
+    transitiveOutputFieldName: string;
+    relatedEntityJoinFieldName: string;
+    hubConcept?: string;
+}
+
+// ─── Entry point — pure fan-out ─────────────────────────────────────────────
+
+/**
+ * Render gated clusters into PR #2193 JSON. Same-concept consolidation +
+ * per-table fan-out + transitive spoke attachment. No filters, no thresholds.
+ *
+ * The caller (Composer) is responsible for filtering. Anything passed in
+ * gets emitted.
+ */
+export function translateClusters(
+    clusters: OrganicKeyCluster[],
+    transitiveSpokes: TransitiveSpokeInput[] = [],
+): DetectedOrganicKeysOutput {
+    // Step 1 — group by normalized canonical concept name.
+    const byConcept = new Map<string, OrganicKeyCluster[]>();
+    for (const cluster of clusters) {
+        if (cluster.members.length < 2) continue;
+        const key = normalizeConceptName(cluster.concept);
+        const bucket = byConcept.get(key);
+        if (bucket) bucket.push(cluster);
+        else byConcept.set(key, [cluster]);
+    }
+
+    const out: DetectedOrganicKeysOutput = {};
+
+    for (const group of byConcept.values()) {
+        // Step 2 — union members across all clusters in the group, deduped by
+        // full column key (schema.table.col1,col2,...).
+        const memberMap = new Map<string, OrganicKeyClusterMember>();
+        for (const c of group) {
+            for (const m of c.members) {
+                const k = `${m.schema}.${m.table}.${memberColumns(m).join(',')}`;
+                if (!memberMap.has(k)) memberMap.set(k, m);
+            }
+        }
+        const allMembers = Array.from(memberMap.values());
+        if (allMembers.length < 2) continue;
+        const distinctTables = new Set(allMembers.map((m) => `${m.schema}.${m.table}`));
+        if (distinctTables.size < 2) continue;
+
+        // Pick the anchor (highest confidence, ties by member count).
+        const anchor = group
+            .slice()
+            .sort((a, b) => (b.confidence - a.confidence) || (b.members.length - a.members.length))[0];
+        const name = prettyConceptName(anchor.concept);
+
+        // Step 3 — fan out: one entry per unique owner, spokes = all OTHER unique members.
+        for (const owner of allMembers) {
+            const tableEntry = upsertTable(out, owner.schema, owner.table);
+
+            const seenSpokes = new Set<string>();
+            const spokes: OrganicKeyRelatedEntityConfig[] = [];
+
+            // Direct spokes — every other cluster member.
+            for (const target of allMembers) {
+                if (target === owner) continue;
+                const targetColumns = memberColumns(target);
+                const k = `${target.schema}.${target.table}.${targetColumns.join(',')}`;
+                if (seenSpokes.has(k)) continue;
+                seenSpokes.add(k);
+                spokes.push({
+                    SchemaName: target.schema,
+                    TableName: target.table,
+                    RelatedFieldNames: targetColumns,
+                    DisplayName: `${target.schema}.${target.table}`,
+                });
+            }
+
+            // Transitive spokes — bridge views attached to matching hubs.
+            const ownerColumns = memberColumns(owner);
+            const matchingTransitive = transitiveSpokes.filter(
+                (t) =>
+                    t.hubSchema === owner.schema &&
+                    t.hubTable === owner.table &&
+                    t.hubKeyFields.length === ownerColumns.length &&
+                    t.hubKeyFields.every((f, idx) => f === ownerColumns[idx]),
+            );
+            for (const t of matchingTransitive) {
+                spokes.push({
+                    SchemaName: t.spokeSchema,
+                    TableName: t.spokeTable,
+                    TransitiveView: t.transitiveView,
+                    TransitiveMatchFieldNames: t.transitiveMatchFieldNames,
+                    TransitiveOutputFieldName: t.transitiveOutputFieldName,
+                    RelatedEntityJoinFieldName: t.relatedEntityJoinFieldName,
+                    DisplayName: `${t.spokeSchema}.${t.spokeTable} (via ${t.hubConcept ?? 'bridge'})`,
+                });
+            }
+
+            const compoundSuffix = isCompoundMember(owner) ? ` (compound: ${ownerColumns.join('+')})` : '';
+            // Per-column normalization: each emitted EntityOrganicKey row carries the
+            // transformation for ITS owner column. The runtime looks up each side's
+            // own expression at match time (see EntityInfo.BuildOrganicKeyViewParams),
+            // so different columns in the same cluster can carry different functions.
+            // Falls back to cluster-level normalization if a member didn't get its own.
+            const ownerNormalization = owner.normalizationStrategy ?? anchor.normalization;
+            const ownerCustomExpression =
+                owner.customNormalizationExpression ?? anchor.customNormalizationExpression;
+            tableEntry.OrganicKeys.push({
+                Name: name + compoundSuffix,
+                Description: anchor.reasoning,
+                MatchFieldNames: ownerColumns,
+                NormalizationStrategy: ownerNormalization,
+                CustomNormalizationExpression: ownerCustomExpression,
+                AutoCreateRelatedViewOnForm: true,
+                RelatedEntities: spokes,
+            });
+        }
+    }
+
+    return out;
+}
+
+// ─── Helpers ────────────────────────────────────────────────────────────────
+
+function normalizeConceptName(name: string): string {
+    return (name ?? '')
+        .toLowerCase()
+        .replace(/[\s\-]+/g, '_')
+        .replace(/_+/g, '_')
+        .replace(/^_|_$/g, '')
+        .trim();
+}
+
+function prettyConceptName(concept: string): string {
+    const pretty = concept
+        .split('_')
+        .filter((p) => p.length > 0)
+        .map((p) => p[0].toUpperCase() + p.slice(1))
+        .join(' ');
+    return `${pretty} Match`;
+}
+
+function upsertTable(
+    out: DetectedOrganicKeysOutput,
+    schema: string,
+    table: string,
+): TableOrganicKeyConfig {
+    let bySchema = out[schema];
+    if (!bySchema) {
+        bySchema = [];
+        out[schema] = bySchema;
+    }
+    let entry = bySchema.find((t) => t.TableName === table);
+    if (!entry) {
+        entry = { TableName: table, OrganicKeys: [] };
+        bySchema.push(entry);
+    }
+    return entry;
+}
+
+/** Tally the emit payload: number of schemas, tables, organic keys, and spokes it contains. */
+export function countOutputEntries(out: DetectedOrganicKeysOutput): {
+    schemas: number;
+    tables: number;
+    keys: number;
+    spokes: number;
+} {
+    let tables = 0;
+    let keys = 0;
+    let spokes = 0;
+    const schemas = Object.keys(out).length;
+    for (const tableList of Object.values(out)) {
+        tables += tableList.length;
+        for (const t of tableList) {
+            keys += t.OrganicKeys.length;
+            for (const k of t.OrganicKeys) spokes += k.RelatedEntities.length;
+        }
+    }
+    return { schemas, tables, keys, spokes };
+}

--- a/packages/DBAutoDoc/src/discovery/SemanticPhase.ts
+++ b/packages/DBAutoDoc/src/discovery/SemanticPhase.ts
@@ -1,0 +1,509 @@
+/**
+ * Phase A — SEMANTIC.
+ *
+ * The defensible PR #2193 pipeline:
+ *
+ *   1. PREFILTER (deterministic)
+ *        Drop columns that cannot be organic keys regardless of semantics:
+ *        binary/blob types, audit-named columns, ultra-low-cardinality.
+ *
+ *   2. NORMALIZE TO BUSINESS SPACE (LLM, one call per table)
+ *        For each surviving column, produce a structured business-focused
+ *        description that encodes PR #2193's "if two rows share this value,
+ *        do they refer to the same real-world entity?" test, plus a canonical
+ *        snake_case conceptName, normalization strategy, and isOrganicKey gate.
+ *        Columns the normalizer rejects (audit, categorical, surrogate, free-
+ *        text, etc.) are dropped here.
+ *
+ *   3. EMBED the normalized descriptions
+ *        Same-concept descriptions geometrically converge regardless of
+ *        source-system, table, or column-name conventions. Sample values are
+ *        appended to distinguish e.g. emails from phones even when both
+ *        describe "identifying a person".
+ *
+ *   4. CLUSTER (agglomerative average-linkage, gap-detected threshold)
+ *        Each cluster is a candidate organic-key concept. The threshold is
+ *        auto-calibrated by finding the largest gap in the bottom of the
+ *        pairwise-distance distribution — robust across schemas/providers.
+ *
+ *   5. SPLIT-BY-CONCEPT
+ *        When the LLM has already assigned DIFFERENT conceptNames to columns
+ *        the embeddings put in the same cluster (e.g. product_id /
+ *        product_model_id / product_category_id all describe "an identifier
+ *        for a product-related entity" and embed close together), honor the
+ *        LLM's distinction by splitting the cluster along conceptName.
+ *        Catches Gemini's tight description-space compression without losing
+ *        cross-table merging when the LLM does converge on one name.
+ *
+ *   6. LABEL each cluster from its members' conceptName votes.
+ *
+ * No vocabulary discovery, no LLM cluster judge, no per-cluster refinement —
+ * the normalize step IS the PR #2193 judgment, the cluster + split steps ARE
+ * the cross-table identity proof.
+ */
+
+import { AIConfig, OrganicKeyDetectionConfig } from '../types/config.js';
+import { DatabaseDocumentation } from '../types/state.js';
+import {
+    DEFAULT_DETECTOR_CONFIG,
+    OrganicKeyCluster,
+    OrganicKeyClusterMember,
+    OrganicKeyNormalizationStrategy,
+} from '../types/organic-keys.js';
+import {
+    TableNormalizer,
+    NormalizedColumn,
+    NormalizerInputColumn,
+    TableNormalizationInput,
+} from './ColumnNormalizer.js';
+import { ColumnClusterer, ClustererInputColumn } from './ColumnClusterer.js';
+import { createEmbeddingProvider, EmbeddingProviderName } from './EmbeddingProvider.js';
+
+const AUDIT_COLUMN_PATTERN = /^(modified|created|updated|inserted|changed)(date|at|time|by|on)?$|^rowguid$|^timestamp$|^row_?version$|^__mj_.*$/i;
+const NON_VALUEMATCHABLE_TYPES = /(binary|blob|image|varbinary|xml|geography|geometry|hierarchyid|sql_variant)/i;
+
+// ─── Prefilter cardinality cutoffs ───────────────────────────────────────────
+/**
+ * A column with fewer than this many distinct values AND a uniqueness ratio below
+ * {@link MIN_UNIQUENESS_RATIO} is treated as a low-cardinality categorical (boolean/enum),
+ * not an identity-bearing column, and is dropped before clustering.
+ */
+const MIN_DISTINCT_FOR_KEY = 10;
+const MIN_UNIQUENESS_RATIO = 0.001;
+
+// ─── Embedding-input sample caps ─────────────────────────────────────────────
+/** At most this many sample values are appended to a column's embedding text. */
+const EMBED_SAMPLE_COUNT = 4;
+/** Each appended sample value is truncated to this many characters. */
+const EMBED_SAMPLE_MAX_CHARS = 60;
+
+// ─── Cluster-confidence tightness penalty ────────────────────────────────────
+/**
+ * Cluster confidence = mean member confidence − (maxIntraDistance × {@link TIGHTNESS_PENALTY_SLOPE}),
+ * with the penalty capped at {@link TIGHTNESS_PENALTY_MAX} so a loose-but-real cluster isn't
+ * over-penalized into irrelevance.
+ */
+const TIGHTNESS_PENALTY_SLOPE = 0.5;
+const TIGHTNESS_PENALTY_MAX = 0.2;
+
+/**
+ * Clustering sensitivity → percentile of the pairwise cosine-distance distribution used as the
+ * auto-calibrated merge threshold. A lower percentile yields tighter (stricter) clusters.
+ */
+const SENSITIVITY_PERCENTILE: Record<'strict' | 'balanced' | 'permissive', number> = {
+    strict: 1,
+    balanced: 5,
+    permissive: 15,
+};
+
+/** A cluster as produced by the clusterer / concept-split step: member indexes into the
+ *  normalized-column array, the emitted member descriptors, and the cluster's intra-distance. */
+type RawCluster = { memberIndexes: number[]; members: OrganicKeyClusterMember[]; maxIntraDistance: number };
+
+/** Result of the semantic (organic-key clustering) phase. */
+export interface SemanticPhaseResult {
+    clusters: OrganicKeyCluster[];
+    tokens: { input: number; output: number; total: number };
+    summary: {
+        columnsInScope: number;
+        columnsNormalized: number;
+        columnsRejectedByNormalizer: number;
+        /** Clusters formed by the embedding clusterer, before the concept-name split. */
+        clustersBeforeSplit: number;
+        /** Final clusters after splitting by concept name and dropping sub-threshold sub-clusters. */
+        clustersFound: number;
+        /** Sub-clusters discarded during the split for falling below minClusterSize / minDistinctTables. */
+        clustersDropped: number;
+    };
+}
+
+/** Receives human-readable progress messages as the semantic phase advances. */
+export type ProgressCallback = (message: string) => void;
+
+export async function runSemanticPhase(
+    state: DatabaseDocumentation,
+    config: OrganicKeyDetectionConfig,
+    aiConfig: AIConfig,
+    progress: ProgressCallback = () => {},
+): Promise<SemanticPhaseResult> {
+    // ─── 1. Prefilter ────────────────────────────────────────────────────────
+    const candidates = prefilter(state, config);
+    progress(`semantic: ${candidates.length} columns in scope`);
+    if (candidates.length < (config.minClusterSize ?? DEFAULT_DETECTOR_CONFIG.minClusterSize)) {
+        return emptyResult(candidates.length);
+    }
+
+    // ─── 2. Normalize to business space (LLM per-table) ──────────────────────
+    progress('semantic: normalizing column descriptions to business space');
+    const tableInputs = groupColumnsByTable(state, candidates);
+    const normResult = await new TableNormalizer(aiConfig).normalizeAll(tableInputs, {
+        concurrency: config.refinementConcurrency ?? DEFAULT_DETECTOR_CONFIG.refinementConcurrency,
+        maxRetries: config.maxRefinementRetries ?? 2,
+        onProgress: () => {},
+    });
+    progress(`semantic: ${normResult.normalized.length} columns kept (${normResult.rejected} rejected by PR-#2193 axes)`);
+
+    if (normResult.normalized.length < (config.minClusterSize ?? DEFAULT_DETECTOR_CONFIG.minClusterSize)) {
+        return {
+            clusters: [],
+            tokens: normResult.tokens,
+            summary: {
+                columnsInScope: candidates.length,
+                columnsNormalized: normResult.normalized.length,
+                columnsRejectedByNormalizer: normResult.rejected,
+                clustersBeforeSplit: 0,
+                clustersFound: 0,
+                clustersDropped: 0,
+            },
+        };
+    }
+
+    // ─── 3. Embed the normalized descriptions ────────────────────────────────
+    const embedProvider = resolveEmbeddingProvider(config, aiConfig);
+    progress(`semantic: embedding ${normResult.normalized.length} descriptions via ${embedProvider.name}`);
+    const texts = normResult.normalized.map((n) => buildEmbeddingText(n));
+    const embeddings = await embedProvider.embed(texts);
+
+    // ─── 4. Cluster columns by embedding distance ────────────────────────────
+    const sensitivity = config.clusteringSensitivity ?? 'balanced';
+    const percentile = sensitivityToPercentile(sensitivity);
+    const clusterer = new ColumnClusterer({
+        mergeThreshold: config.mergeThreshold,
+        mergeThresholdPercentile: percentile,
+        minClusterSize: config.minClusterSize ?? DEFAULT_DETECTOR_CONFIG.minClusterSize,
+        minDistinctTables: config.minDistinctTables ?? DEFAULT_DETECTOR_CONFIG.minDistinctTables,
+    });
+    const clustererInputs: ClustererInputColumn[] = normResult.normalized.map((n, i) => ({
+        schema: n.schema,
+        table: n.table,
+        column: n.column,
+        embedding: embeddings[i],
+        participatesInFK: n.participatesInFK,
+        fkTarget: n.fkTarget,
+        isPrimaryKey: n.isPrimaryKey,
+    }));
+    const rawClusters = clusterer.cluster(clustererInputs);
+    progress(`semantic: ${rawClusters.length} clusters formed (threshold=${clusterer.lastResolvedThreshold.toFixed(3)})`);
+
+    // ─── 5. Split clusters that contain multiple distinct conceptNames ──────
+    const minClusterSize = config.minClusterSize ?? DEFAULT_DETECTOR_CONFIG.minClusterSize;
+    const minDistinctTables = config.minDistinctTables ?? DEFAULT_DETECTOR_CONFIG.minDistinctTables;
+    const { clusters: split, dropped } = splitClustersByConceptName(
+        rawClusters,
+        normResult.normalized,
+        minClusterSize,
+        minDistinctTables,
+    );
+    if (split.length !== rawClusters.length) {
+        progress(`semantic: ${split.length} clusters after concept-name split`);
+    }
+
+    // ─── 6. Label clusters from member votes ─────────────────────────────────
+    const clusters: OrganicKeyCluster[] = split.map((rc, idx) => {
+        const memberNormalized = rc.memberIndexes.map((i) => normResult.normalized[i]);
+        return labelCluster(memberNormalized, rc.members, rc.maxIntraDistance, idx);
+    });
+
+    return {
+        clusters,
+        tokens: normResult.tokens,
+        summary: {
+            columnsInScope: candidates.length,
+            columnsNormalized: normResult.normalized.length,
+            columnsRejectedByNormalizer: normResult.rejected,
+            clustersBeforeSplit: rawClusters.length,
+            clustersFound: clusters.length,
+            clustersDropped: dropped,
+        },
+    };
+}
+
+/**
+ * Split each raw embedding cluster into sub-clusters by distinct conceptName.
+ *
+ * Embedding clustering over-merges when distinct concepts produce similar descriptions
+ * (e.g. product_id vs product_model_id vs product_category_id all describe "identifier
+ * for a product-related entity"). The LLM normalize step already distinguished them by
+ * assigning different concept names — we honor that here by splitting any cluster whose
+ * members carry multiple distinct conceptName values.
+ *
+ * Sub-clusters that fall below `minClusterSize` / `minDistinctTables` are dropped (a concept
+ * with one column in one table isn't a cross-table organic key). Returns the surviving
+ * sub-clusters (sorted largest-first) and the count of dropped sub-clusters.
+ */
+function splitClustersByConceptName(
+    rawClusters: RawCluster[],
+    normalized: NormalizedColumn[],
+    minClusterSize: number,
+    minDistinctTables: number,
+): { clusters: RawCluster[]; dropped: number } {
+    const split: RawCluster[] = [];
+    let dropped = 0;
+    for (const rc of rawClusters) {
+        const byConcept = groupMemberIndexesByConcept(rc.memberIndexes, normalized);
+        if (byConcept.size === 1) {
+            split.push(rc);
+            continue;
+        }
+        for (const [, idxs] of byConcept) {
+            const members = idxs.map((i) => toClusterMember(normalized[i]));
+            const tableSet = new Set(members.map((m) => `${m.schema}.${m.table}`));
+            if (members.length < minClusterSize || tableSet.size < minDistinctTables) {
+                dropped++;
+                continue;
+            }
+            split.push({ memberIndexes: idxs, members, maxIntraDistance: rc.maxIntraDistance });
+        }
+    }
+    split.sort((a, b) => b.members.length - a.members.length);
+    return { clusters: split, dropped };
+}
+
+/**
+ * Bucket member indexes by normalized conceptName. The grouping key is lowercased with all
+ * non-alphanumeric chars stripped, collapsing LLM stochastic variants (`sales_person_id` vs
+ * `salesPersonId`) into one bucket — they're the same identifier written differently.
+ */
+function groupMemberIndexesByConcept(memberIndexes: number[], normalized: NormalizedColumn[]): Map<string, number[]> {
+    const byConcept = new Map<string, number[]>();
+    for (const ci of memberIndexes) {
+        const cn = (normalized[ci].conceptName || '__unnamed__').toLowerCase().replace(/[^a-z0-9]/g, '');
+        const bucket = byConcept.get(cn);
+        if (bucket) bucket.push(ci);
+        else byConcept.set(cn, [ci]);
+    }
+    return byConcept;
+}
+
+/** Project a normalized column into the cluster-member descriptor (sans per-column normalization). */
+function toClusterMember(n: NormalizedColumn): OrganicKeyClusterMember {
+    return {
+        schema: n.schema,
+        table: n.table,
+        column: n.column,
+        participatesInFK: n.participatesInFK,
+        fkTarget: n.fkTarget,
+        isPrimaryKey: n.isPrimaryKey,
+    };
+}
+
+// ─── Helpers ────────────────────────────────────────────────────────────────
+
+function prefilter(state: DatabaseDocumentation, config: OrganicKeyDetectionConfig): NormalizerInputColumn[] {
+    const sampleValueCount = config.sampleValueCount ?? DEFAULT_DETECTOR_CONFIG.sampleValueCount;
+    const out: NormalizerInputColumn[] = [];
+    for (const schema of state.schemas) {
+        for (const table of schema.tables) {
+            for (const col of table.columns) {
+                if (NON_VALUEMATCHABLE_TYPES.test(col.dataType)) continue;
+                if (AUDIT_COLUMN_PATTERN.test(col.name)) continue;
+                if (col.statistics) {
+                    const distinct = col.statistics.distinctCount ?? 0;
+                    const ratio = col.statistics.uniquenessRatio ?? 0;
+                    // Drop ultra-low-cardinality / near-boolean columns.
+                    if (distinct < MIN_DISTINCT_FOR_KEY && ratio < MIN_UNIQUENESS_RATIO) continue;
+                }
+                out.push({
+                    schema: schema.name,
+                    table: table.name,
+                    column: col.name,
+                    dataType: col.dataType,
+                    originalDescription: col.userDescription ?? col.description ?? '',
+                    sampleValues: extractSampleValues(col, sampleValueCount),
+                    participatesInFK: !!col.isForeignKey,
+                    fkTarget: col.foreignKeyReferences
+                        ? {
+                              schema: col.foreignKeyReferences.schema,
+                              table: col.foreignKeyReferences.table,
+                              column: col.foreignKeyReferences.referencedColumn,
+                          }
+                        : null,
+                    isPrimaryKey: !!col.isPrimaryKey,
+                });
+            }
+        }
+    }
+    return out;
+}
+
+function groupColumnsByTable(state: DatabaseDocumentation, columns: NormalizerInputColumn[]): TableNormalizationInput[] {
+    const schemaDesc = new Map<string, string | undefined>();
+    const tableDesc = new Map<string, string | undefined>();
+    for (const s of state.schemas) {
+        schemaDesc.set(s.name, s.description);
+        for (const t of s.tables) tableDesc.set(`${s.name}.${t.name}`, t.description);
+    }
+    const buckets = new Map<string, NormalizerInputColumn[]>();
+    for (const c of columns) {
+        const k = `${c.schema}.${c.table}`;
+        const b = buckets.get(k);
+        if (b) b.push(c);
+        else buckets.set(k, [c]);
+    }
+    return Array.from(buckets.entries()).map(([k, cols]) => {
+        const [schema, table] = k.split('.');
+        return {
+            schema,
+            table,
+            schemaDescription: schemaDesc.get(schema),
+            tableDescription: tableDesc.get(k),
+            columns: cols,
+        };
+    });
+}
+
+/**
+ * Build the embedding input text from a normalized column.
+ *
+ * Gemini clustering embeddings compress "database column description" text into
+ * a tight neighborhood ([0, 0.15] cosine distance). To pull distinct concepts
+ * apart in that compressed geometry, we lead with the concept name repeated
+ * three times — embedding models give more weight to repeated tokens, so a
+ * column labeled "product_category_id" lands distinguishably away from one
+ * labeled "product_id" even though their template descriptions look similar.
+ *
+ * Sample values are appended last (when present) to add concrete value-format
+ * signal that distinguishes e.g. an email from a phone even when both describe
+ * "identifying a person".
+ */
+function buildEmbeddingText(n: NormalizedColumn): string {
+    const concept = (n.conceptName || 'unknown').replace(/_/g, ' ');
+    const parts: string[] = [];
+    parts.push(`${concept}. ${concept}. ${concept}.`);
+    parts.push(n.normalizedDescription);
+    if (n.sampleValues && n.sampleValues.length > 0) {
+        const samples = n.sampleValues.slice(0, EMBED_SAMPLE_COUNT).map((v) => String(v).slice(0, EMBED_SAMPLE_MAX_CHARS));
+        parts.push(`Sample values: ${samples.join(' | ')}.`);
+    }
+    return parts.join(' ');
+}
+
+function labelCluster(
+    members: NormalizedColumn[],
+    outMembers: OrganicKeyClusterMember[],
+    maxIntraDistance: number,
+    index: number,
+): OrganicKeyCluster {
+    // Cluster concept = majority concept name (ties → highest confidence).
+    const conceptVotes = new Map<string, { count: number; sumConf: number }>();
+    for (const m of members) {
+        const key = m.conceptName || 'unknown';
+        const cur = conceptVotes.get(key) ?? { count: 0, sumConf: 0 };
+        cur.count += 1;
+        cur.sumConf += m.confidence;
+        conceptVotes.set(key, cur);
+    }
+    const concept = Array.from(conceptVotes.entries())
+        .sort((a, b) => b[1].count - a[1].count || b[1].sumConf - a[1].sumConf || a[0].localeCompare(b[0]))[0][0];
+
+    // Per-column normalization — each member keeps its own strategy + expression so
+    // the emitted EntityOrganicKey hub row for THAT column carries the right transformation.
+    // The runtime applies each side's own expression at match time (see
+    // BuildOrganicKeyViewParams in MJCore). The cluster-level `normalization` field is
+    // computed by majority vote as a summary / fallback for legacy consumers.
+    const stratCounts = new Map<OrganicKeyNormalizationStrategy, number>();
+    for (const m of members) {
+        stratCounts.set(m.normalizationStrategy, (stratCounts.get(m.normalizationStrategy) ?? 0) + 1);
+    }
+    const normalization = Array.from(stratCounts.entries())
+        .sort((a, b) => b[1] - a[1] || a[0].localeCompare(b[0]))[0][0];
+
+    // Highest-confidence member's customNormalizationExpression becomes the cluster-level
+    // fallback (only used if a member doesn't carry its own — shouldn't normally happen).
+    const customFallback = members
+        .slice()
+        .sort((a, b) => b.confidence - a.confidence)
+        .find((m) => m.customNormalizationExpression)?.customNormalizationExpression;
+
+    // Decorate outMembers with per-column normalization. Members are aligned by index
+    // with `members` (the NormalizedColumn array) via the caller's memberIndexes mapping.
+    const decoratedMembers: OrganicKeyClusterMember[] = outMembers.map((om, i) => {
+        const nm = members[i];
+        return {
+            ...om,
+            normalizationStrategy: nm?.normalizationStrategy,
+            customNormalizationExpression: nm?.customNormalizationExpression,
+        };
+    });
+
+    // Cluster confidence = mean of member confidences, lightly penalized by tightness.
+    const meanConf = members.reduce((s, n) => s + n.confidence, 0) / members.length;
+    const tightnessPenalty = Math.min(TIGHTNESS_PENALTY_MAX, maxIntraDistance * TIGHTNESS_PENALTY_SLOPE);
+    const confidence = Math.max(0, Math.min(1, meanConf - tightnessPenalty));
+
+    // Reasoning from the highest-confidence member.
+    const repr = members.slice().sort((a, b) => b.confidence - a.confidence)[0];
+
+    return {
+        id: `cluster_${index}`,
+        concept,
+        normalization,
+        customNormalizationExpression: customFallback,
+        members: decoratedMembers,
+        confidence,
+        reasoning: repr.reasoning,
+        maxIntraDistance,
+    };
+}
+
+function extractSampleValues(
+    col: { statistics?: { sampleValues?: unknown[] }; possibleValues?: unknown[] },
+    max: number,
+): string[] {
+    const raw = col.statistics?.sampleValues ?? col.possibleValues ?? [];
+    if (!Array.isArray(raw)) return [];
+    const out: string[] = [];
+    for (const v of raw) {
+        if (v == null) continue;
+        const s = String(v).trim();
+        if (s.length === 0) continue;
+        out.push(s);
+        if (out.length >= max) break;
+    }
+    return out;
+}
+
+function sensitivityToPercentile(s: 'strict' | 'balanced' | 'permissive'): number {
+    return SENSITIVITY_PERCENTILE[s] ?? SENSITIVITY_PERCENTILE.balanced;
+}
+
+interface EmbeddingProviderHandle {
+    name: string;
+    embed: (texts: string[]) => Promise<Float32Array[]>;
+}
+
+function resolveEmbeddingProvider(
+    config: OrganicKeyDetectionConfig,
+    aiConfig: AIConfig,
+): EmbeddingProviderHandle {
+    const cfg = config.embedding ?? {};
+    const provider = (cfg.provider ?? 'openai') as EmbeddingProviderName;
+    const apiKey = aiConfig.apiKey;
+    const impl = createEmbeddingProvider({
+        provider,
+        apiKey,
+        model: cfg.model,
+        dimensions: cfg.dimensions,
+        batchSize: cfg.batchSize,
+        endpoint: cfg.endpoint,
+    });
+    return {
+        name: `${provider}:${cfg.model ?? 'default'}`,
+        embed: (texts: string[]) => impl.embed(texts),
+    };
+}
+
+function emptyResult(columnsInScope: number): SemanticPhaseResult {
+    return {
+        clusters: [],
+        tokens: { input: 0, output: 0, total: 0 },
+        summary: {
+            columnsInScope,
+            columnsNormalized: 0,
+            columnsRejectedByNormalizer: 0,
+            clustersBeforeSplit: 0,
+            clustersFound: 0,
+            clustersDropped: 0,
+        },
+    };
+}

--- a/packages/DBAutoDoc/src/discovery/StructuralPhase.ts
+++ b/packages/DBAutoDoc/src/discovery/StructuralPhase.ts
@@ -1,0 +1,38 @@
+/**
+ * Phase B — STRUCTURAL.
+ *
+ * Single responsibility: walk the FK graph from each cluster's hubs to find
+ * tables reachable via 2-3 FK hops, and emit bridge view SQL for each.
+ *
+ * PR #2193's transitive-match pattern: when a value-bearing column lives on
+ * table H and another table T doesn't carry the value directly but is
+ * reachable via FK navigation, a bridge view exposes the value on T's join
+ * path so the form can navigate.
+ *
+ * No scoring, no thresholds — just deterministic graph traversal.
+ */
+
+import { DatabaseDocumentation } from '../types/state.js';
+import { OrganicKeyCluster } from '../types/organic-keys.js';
+import {
+    detectTransitiveBridges,
+    collectFKEdgesFromState,
+    TransitiveBridgeFinding,
+} from './TransitiveBridgeDetector.js';
+
+export interface StructuralPhaseResult {
+    bridges: TransitiveBridgeFinding[];
+    summary: { transitiveBridgesFound: number };
+}
+
+export function runStructuralPhase(
+    state: DatabaseDocumentation,
+    clusters: OrganicKeyCluster[],
+): StructuralPhaseResult {
+    if (clusters.length === 0) {
+        return { bridges: [], summary: { transitiveBridgesFound: 0 } };
+    }
+    const edges = collectFKEdgesFromState(state);
+    const bridges = detectTransitiveBridges(clusters, edges, state);
+    return { bridges, summary: { transitiveBridgesFound: bridges.length } };
+}

--- a/packages/DBAutoDoc/src/discovery/TransitiveBridgeDetector.ts
+++ b/packages/DBAutoDoc/src/discovery/TransitiveBridgeDetector.ts
@@ -1,0 +1,279 @@
+/**
+ * TransitiveBridgeDetector — Pattern 3 orchestrator.
+ *
+ * Reads the existing Pattern 1/2 organic-key clusters (the "hubs") + the FK
+ * relationships of the database (hard + soft) and finds tables that can reach
+ * each hub via 2-3 FK hops without carrying the key directly. For each such
+ * spoke, it generates the CREATE VIEW SQL the bridge needs, packaged in PR
+ * #2193's `TransitiveView` config block.
+ *
+ * Outputs `TransitiveBridgeFinding[]` — one per (hub, spoke, path) triple. The
+ * caller (OrganicKeyDetector) merges these into the OrganicKeyTranslator's
+ * spokes list so that PR #2193's CodeGen can pick them up.
+ *
+ * Notes:
+ *   - Direct-FK paths (length 1) are SKIPPED — those tables are already
+ *     reachable via the existing relationship system; no bridge needed.
+ *   - When multiple paths exist from the same spoke to the same hub, only the
+ *     SHORTEST one is kept (paths of length 2 beat paths of length 3); ties
+ *     broken by highest confidence.
+ *   - Spoke PK is resolved from state.json. Tables without a single-column PK
+ *     are skipped (composite-PK bridge join is future work).
+ */
+
+import { findBridgePaths, FKEdge } from './FKGraphWalker.js';
+import { generateBridgeView, GeneratedBridgeView } from './BridgeViewSQLGenerator.js';
+import { OrganicKeyCluster, memberColumns } from '../types/organic-keys.js';
+import { DatabaseDocumentation, ForeignKeyReference } from '../types/state.js';
+
+/** One transitive bridge finding ready for spoke emission. */
+export interface TransitiveBridgeFinding {
+    hubSchema: string;
+    hubTable: string;
+    hubKeyFields: string[];          // = MatchFieldNames on the hub's organic key
+    spokeSchema: string;
+    spokeTable: string;
+    spokeJoinField: string;          // = RelatedEntityJoinFieldName (spoke PK)
+    view: GeneratedBridgeView;       // CREATE VIEW SQL + projected aliases
+    pathLength: number;
+    pathConfidence: number;
+    /** Concept name from the underlying organic key (e.g. "email_address"). Used for the spoke's DisplayName. */
+    hubConcept: string;
+}
+
+export interface TransitiveBridgeDetectorOptions {
+    maxHops?: number;
+    minSoftFKConfidence?: number;
+    /** Drop bridges whose path confidence falls below this. Default 0.7. */
+    minPathConfidence?: number;
+    /** Limit bridges per (hub, spoke) pair — keeps only the best path. Default true. */
+    keepShortestOnly?: boolean;
+}
+
+const DEFAULTS: Required<TransitiveBridgeDetectorOptions> = {
+    maxHops: 3,
+    minSoftFKConfidence: 0.6,
+    minPathConfidence: 0.7,
+    keepShortestOnly: true,
+};
+
+/**
+ * Detect transitive bridges for every hub × spoke pair whose graph distance
+ * falls in [2, maxHops].
+ *
+ * @param organicKeyClusters - Pattern 1 + 2 output. Hubs are derived as the
+ *                             unique (schema, table) of every cluster member.
+ * @param edges              - FK edges (hard + soft) to walk.
+ * @param state              - DatabaseDocumentation, used to look up spoke PKs.
+ */
+export function detectTransitiveBridges(
+    organicKeyClusters: OrganicKeyCluster[],
+    edges: FKEdge[],
+    state: DatabaseDocumentation,
+    opts: TransitiveBridgeDetectorOptions = {},
+): TransitiveBridgeFinding[] {
+    const o = { ...DEFAULTS, ...opts };
+
+    // ─── 1. Build the hub set from existing organic-key clusters ────────────
+    // Each hub is a (schema, table) carrying one or more organic-key match field(s).
+    // We emit one hub entry per (schema, table, primary match field) because
+    // PR #2193's MatchFieldNames is a tuple; we use the FIRST field of the
+    // tuple as the projected bridge column (the rest are positional siblings
+    // emitted via TransitiveMatchFieldNames).
+    interface HubEntry {
+        schema: string;
+        table: string;
+        keyFields: string[];          // Full MatchFieldNames tuple
+        concept: string;
+    }
+    const hubsByKey = new Map<string, HubEntry>();
+    for (const cluster of organicKeyClusters) {
+        for (const member of cluster.members) {
+            const cols = memberColumns(member);
+            const k = `${member.schema}.${member.table}.${cols.join(',')}`;
+            if (hubsByKey.has(k)) continue;
+            hubsByKey.set(k, {
+                schema: member.schema,
+                table: member.table,
+                keyFields: cols,
+                concept: cluster.concept,
+            });
+        }
+    }
+
+    // ─── 2. Build the spoke candidate set (every table in the DB) ──────────
+    const allTables: Array<{ schema: string; table: string }> = [];
+    const spokePKByKey = new Map<string, string>();
+    for (const s of state.schemas) {
+        for (const t of s.tables) {
+            allTables.push({ schema: s.name, table: t.name });
+            const pk = pickSinglePK(t.columns);
+            if (pk) spokePKByKey.set(`${s.name}.${t.name}`, pk);
+        }
+    }
+
+    // ─── 3. Run BFS per hub × spoke pair ────────────────────────────────────
+    const hubsForWalker: Array<{ schema: string; table: string; keyField: string }> = [];
+    for (const h of hubsByKey.values()) {
+        hubsForWalker.push({ schema: h.schema, table: h.table, keyField: h.keyFields[0] });
+    }
+    const allPaths = findBridgePaths(edges, hubsForWalker, allTables, {
+        maxHops: o.maxHops,
+        minSoftFKConfidence: o.minSoftFKConfidence,
+        pruneCycles: true,
+    });
+
+    // ─── 4. For each path, materialize the bridge view ─────────────────────
+    const findings: TransitiveBridgeFinding[] = [];
+    for (const path of allPaths) {
+        if (path.pathConfidence < o.minPathConfidence) continue;
+        const spokeKey = `${path.spokeSchema}.${path.spokeTable}`;
+        const spokePK = spokePKByKey.get(spokeKey);
+        if (!spokePK) continue; // skip composite-PK spokes for now
+
+        // Resolve the originating hub entry to recover the full keyFields tuple + concept.
+        const hubMatch = Array.from(hubsByKey.values()).find(
+            (h) => h.schema === path.hubSchema && h.table === path.hubTable && h.keyFields[0] === path.hubKeyField,
+        );
+        if (!hubMatch) continue;
+
+        const view = generateBridgeView(path, spokePK);
+        findings.push({
+            hubSchema: hubMatch.schema,
+            hubTable: hubMatch.table,
+            hubKeyFields: hubMatch.keyFields,
+            spokeSchema: path.spokeSchema,
+            spokeTable: path.spokeTable,
+            spokeJoinField: spokePK,
+            view,
+            pathLength: path.pathLength,
+            pathConfidence: path.pathConfidence,
+            hubConcept: hubMatch.concept,
+        });
+    }
+
+    // ─── 5. Dedupe per (hub, spoke) — keep shortest, then highest-confidence ─
+    if (o.keepShortestOnly) {
+        const byPair = new Map<string, TransitiveBridgeFinding>();
+        for (const f of findings) {
+            const k = `${f.hubSchema}.${f.hubTable}::${f.spokeSchema}.${f.spokeTable}::${f.hubKeyFields[0]}`;
+            const existing = byPair.get(k);
+            if (!existing) {
+                byPair.set(k, f);
+                continue;
+            }
+            if (f.pathLength < existing.pathLength) byPair.set(k, f);
+            else if (f.pathLength === existing.pathLength && f.pathConfidence > existing.pathConfidence) {
+                byPair.set(k, f);
+            }
+        }
+        return Array.from(byPair.values());
+    }
+    return findings;
+}
+
+// ─── Helpers ────────────────────────────────────────────────────────────────
+
+/**
+ * Pick the single-column PK from a table's column list. Returns null when no PK
+ * is declared OR when the table has a composite PK (we skip those for now —
+ * compound-PK bridge joins are Pattern 4 territory).
+ */
+function pickSinglePK(columns: Array<{ name: string; isPrimaryKey?: boolean }>): string | null {
+    const pks = columns.filter((c) => c.isPrimaryKey);
+    if (pks.length !== 1) return null;
+    return pks[0].name;
+}
+
+/**
+ * Pull FK edges out of state.json's keyDetection.discovered.foreignKeys block
+ * AND from any schema-declared hard FKs in the dependencies array. Returns the
+ * combined set ready for the walker.
+ */
+export function collectFKEdgesFromState(state: DatabaseDocumentation): FKEdge[] {
+    const out: FKEdge[] = [];
+
+    // Hard FKs from the FK-SOURCE side via `dependsOn`. Each entry on table
+    // T's `dependsOn` array describes an FK that T holds pointing at another
+    // table.
+    //
+    // We deliberately use `dependsOn` rather than the reverse `dependents`
+    // array because in observed state.json files `dependents` sometimes contains
+    // inverted/duplicate entries (e.g. on Campaign.dependents you may see both
+    // `column: ID, referencedColumn: CampaignID` AND
+    // `column: CampaignID, referencedColumn: ID` — only one is real). The
+    // `dependsOn` side is canonical: it's authored from the table that actually
+    // owns the FK column.
+    for (const schema of state.schemas) {
+        for (const table of schema.tables) {
+            const deps: ForeignKeyReference[] = table.dependsOn ?? [];
+            for (const d of deps) {
+                out.push({
+                    sourceSchema: schema.name,
+                    sourceTable: table.name,
+                    sourceColumn: d.column,
+                    targetSchema: d.schema,
+                    targetTable: d.table,
+                    targetColumn: d.referencedColumn,
+                    kind: 'hard',
+                    confidence: 1,
+                });
+            }
+        }
+    }
+
+    // Dedup hard FKs (a single FK can sometimes appear twice in state.json).
+    const dedupHard = dedupEdges(out.splice(0));
+    out.push(...dedupHard);
+
+    // Soft FKs from the keyDetection phase.
+    const softFKs =
+        (state as unknown as { phases?: { keyDetection?: { discovered?: { foreignKeys?: Array<Record<string, unknown>> } } } })
+            .phases?.keyDetection?.discovered?.foreignKeys ?? [];
+    for (const f of softFKs) {
+        if (
+            typeof f.schemaName === 'string' &&
+            typeof f.sourceTable === 'string' &&
+            typeof f.sourceColumn === 'string' &&
+            typeof f.targetSchema === 'string' &&
+            typeof f.targetTable === 'string' &&
+            typeof f.targetColumn === 'string' &&
+            typeof f.confidence === 'number'
+        ) {
+            out.push({
+                sourceSchema: f.schemaName,
+                sourceTable: f.sourceTable,
+                sourceColumn: f.sourceColumn,
+                targetSchema: f.targetSchema,
+                targetTable: f.targetTable,
+                targetColumn: f.targetColumn,
+                kind: 'soft',
+                confidence: f.confidence / 100, // state stores 0-100
+            });
+        }
+    }
+    // Final dedup — if a soft FK redundantly describes a hard FK, keep one.
+    // We keep the HARD one (confidence=1) when both exist.
+    return dedupEdges(out);
+}
+
+/**
+ * Dedupe FK edges by (source, target) column pair. When duplicates exist,
+ * prefer the entry with kind='hard' (highest confidence); for two soft
+ * entries with the same pair, keep the higher-confidence one.
+ */
+function dedupEdges(edges: FKEdge[]): FKEdge[] {
+    const byKey = new Map<string, FKEdge>();
+    for (const e of edges) {
+        const k = `${e.sourceSchema}.${e.sourceTable}.${e.sourceColumn}->${e.targetSchema}.${e.targetTable}.${e.targetColumn}`;
+        const existing = byKey.get(k);
+        if (!existing) {
+            byKey.set(k, e);
+            continue;
+        }
+        if (existing.kind === 'hard') continue;
+        if (e.kind === 'hard') { byKey.set(k, e); continue; }
+        if (e.confidence > existing.confidence) byKey.set(k, e);
+    }
+    return Array.from(byKey.values());
+}

--- a/packages/DBAutoDoc/src/generators/AdditionalSchemaInfoGenerator.ts
+++ b/packages/DBAutoDoc/src/generators/AdditionalSchemaInfoGenerator.ts
@@ -19,6 +19,7 @@
 
 import { DatabaseDocumentation, SchemaDefinition, TableDefinition, ColumnDefinition } from '../types/state.js';
 import { PKCandidate, FKCandidate } from '../types/discovery.js';
+import { DetectedOrganicKeysOutput, OrganicKeyConfig } from '../discovery/OrganicKeyTranslator.js';
 
 export interface AdditionalSchemaInfoOptions {
   /** Only include AI-discovered keys, not keys already present in the database schema */
@@ -33,6 +34,12 @@ export interface AdditionalSchemaInfoOptions {
   valueListConfidenceThreshold?: number;
   /** If true, skip emitting Fields[] entirely. Default false. */
   excludeValueLists?: boolean;
+  /**
+   * Organic-key detection output (per-schema/per-table OrganicKeys). When present,
+   * merged into each table's OrganicKeys[] so CodeGen's processOrganicKeyConfig
+   * writes EntityOrganicKey / EntityOrganicKeyRelatedEntity metadata.
+   */
+  organicKeys?: DetectedOrganicKeysOutput;
 }
 
 interface SoftPKEntry {
@@ -65,6 +72,8 @@ interface TableSchemaInfo {
   ForeignKeys?: SoftFKEntry[];
   /** Enum/value-list fields discovered by LLM analysis */
   Fields?: FieldValueListEntry[];
+  /** Organic-key configurations consumed by CodeGen's processOrganicKeyConfig */
+  OrganicKeys?: OrganicKeyConfig[];
 }
 
 interface SchemaNameInfo {
@@ -128,7 +137,25 @@ export class AdditionalSchemaInfoGenerator {
         );
 
         if (tableInfo) {
+          // Attach organic keys for this table when detection output is present.
+          const orgKeys = this.getOrganicKeysForTable(options.organicKeys, schema.name, table.name);
+          if (orgKeys.length > 0) {
+            tableInfo.OrganicKeys = orgKeys;
+          }
           tables.push(tableInfo);
+        }
+      }
+
+      // A table may have organic keys even if buildTableInfo returned null (no
+      // soft PK/FK and no value lists). Emit a minimal entry so they aren't lost.
+      if (options.organicKeys) {
+        const emittedTables = new Set(tables.map((t) => t.TableName));
+        for (const table of schema.tables) {
+          if (emittedTables.has(table.name)) continue;
+          const orgKeys = this.getOrganicKeysForTable(options.organicKeys, schema.name, table.name);
+          if (orgKeys.length > 0) {
+            tables.push({ TableName: table.name, OrganicKeys: orgKeys });
+          }
         }
       }
 
@@ -138,6 +165,22 @@ export class AdditionalSchemaInfoGenerator {
     }
 
     return JSON.stringify(result, null, 4);
+  }
+
+  /**
+   * Look up the organic keys detected for a specific schema.table from the
+   * detector's per-schema/per-table output. Returns [] when none.
+   */
+  private getOrganicKeysForTable(
+    organicKeys: DetectedOrganicKeysOutput | undefined,
+    schemaName: string,
+    tableName: string,
+  ): OrganicKeyConfig[] {
+    if (!organicKeys) return [];
+    const tablesForSchema = organicKeys[schemaName];
+    if (!tablesForSchema) return [];
+    const entry = tablesForSchema.find((t) => t.TableName === tableName);
+    return entry?.OrganicKeys ?? [];
   }
 
   /**

--- a/packages/DBAutoDoc/src/types/config.ts
+++ b/packages/DBAutoDoc/src/types/config.ts
@@ -157,6 +157,88 @@ export interface AnalysisConfig {
   guardrails?: GuardrailsConfig;
   relationshipDiscovery?: RelationshipDiscoveryConfig;
   sampleQueryGeneration?: SampleQueryGenerationConfig;
+  organicKeyDetection?: OrganicKeyDetectionConfig;
+}
+
+/**
+ * Configuration for organic-key cluster detection.
+ *
+ * Organic keys (per MJ PR #2193) are cross-entity navigation rules based on
+ * shared business values rather than declared FKs (e.g. matching contact records
+ * across CRM systems by email). This pass clusters columns whose descriptions +
+ * sample values indicate they share a value space, and emits proposed clusters
+ * for human review.
+ *
+ * Off by default — opt-in via `enabled: true`. Requires an AI provider (the
+ * existing `ai` config) for both embeddings and per-cluster refinement.
+ *
+ * NOTE: This pass deliberately does NOT iterate. Clustering happens once, the
+ * LLM refiner runs once per cluster, and the pass terminates. No convergence
+ * loop, no multi-pass expansion. If a future version reintroduces iteration,
+ * `maxIterations` would join this config section.
+ */
+export interface OrganicKeyDetectionConfig {
+  /** Enable the organic-key detection pass (default: false). */
+  enabled: boolean;
+
+  // ─── Clustering ──────────────────────────────────────────────────────
+  /**
+   * How aggressive should clustering be? The detector auto-calibrates the
+   * merge distance from the actual embedding geometry — this knob just picks
+   * how loose to be when deciding what counts as "close enough" to merge:
+   *
+   *   - 'strict':     few, tight clusters. Only obvious matches. Lower recall, higher precision.
+   *   - 'balanced':   default. Catches most real organic keys without too much noise.
+   *   - 'permissive': more clusters, including borderline cases. Higher recall, more LLM review work.
+   *
+   * Internally maps to a percentile of the pairwise distance distribution
+   * (strict ~ p1, balanced ~ p5, permissive ~ p15).
+   */
+  clusteringSensitivity?: 'strict' | 'balanced' | 'permissive';
+  /**
+   * Advanced / debugging override — explicit cosine-distance threshold. Set ONLY
+   * to bypass auto-calibration (e.g. ablation studies, reproducing a specific run).
+   * Normal users should set `clusteringSensitivity` instead.
+   */
+  mergeThreshold?: number;
+  /** Minimum members for a cluster to be reported. Default: 2. */
+  minClusterSize?: number;
+  /** Minimum distinct tables a cluster must span. Default: 2. */
+  minDistinctTables?: number;
+  /** Number of sample values per column to include in the embedding input and refiner prompt. Default: 5. */
+  sampleValueCount?: number;
+
+  // ─── LLM Refinement ──────────────────────────────────────────────────
+  /** Concurrency for per-cluster LLM refinement calls. Default: 4. */
+  refinementConcurrency?: number;
+  /** Max retries per LLM call on transient failure. Default: 2. */
+  maxRefinementRetries?: number;
+  /** When a single cluster's refinement errors, fail the whole pass or just skip that cluster. Default: 'skip'. */
+  onRefinementError?: 'fail' | 'skip';
+
+  // ─── Budget / Cost ───────────────────────────────────────────────────
+  /** Soft token budget for the entire detection pass (warns when exceeded). Default: 0 = unlimited. */
+  tokenBudget?: number;
+
+  // ─── Embeddings ──────────────────────────────────────────────────────
+  /**
+   * Embedding provider override. Maps to a MemberJunction `BaseEmbeddings` driver
+   * (resolved via the ClassFactory). Defaults to `openai` when absent. The API key
+   * is taken from the top-level `ai` config.
+   */
+  embedding?: {
+    provider?: 'openai' | 'mistral' | 'azure' | 'bedrock' | 'ollama' | 'local';
+    model?: string;
+    dimensions?: number;
+    batchSize?: number;
+    endpoint?: string;
+    /** Disk path for the embedding cache. Default: `<outputDir>/embedding-cache.json`. */
+    cachePath?: string;
+  };
+
+  // ─── Output ──────────────────────────────────────────────────────────
+  /** Path (relative to outputDir) for the detected-organic-keys JSON output. Default: `detected-organic-keys.json`. */
+  outputFile?: string;
 }
 
 export interface SampleQueryGenerationConfig {

--- a/packages/DBAutoDoc/src/types/organic-keys.ts
+++ b/packages/DBAutoDoc/src/types/organic-keys.ts
@@ -1,0 +1,157 @@
+/**
+ * Organic-Key Cluster Detection — types.
+ *
+ * A cluster is N≥2 columns across ≥2 tables sharing a single business-meaningful
+ * value space (email addresses, customer IDs, phone numbers, etc.). The runtime
+ * organic-key feature (see PR #2193) matches records across tables by literal
+ * value equality; clusters propose which columns should form such match groups.
+ *
+ * See plans/dbautodoc-organic-keys.md.
+ */
+
+/** Strategy used to normalize values before equality comparison (matches PR #2193). */
+export type OrganicKeyNormalizationStrategy = 'LowerCaseTrim' | 'Trim' | 'ExactMatch' | 'Custom';
+
+
+/** A single column (Pattern 1) or compound tuple (Pattern 2) participating in a cluster. */
+export interface OrganicKeyClusterMember {
+    schema: string;
+    table: string;
+    /** Primary column for Pattern 1; first column of the tuple for Pattern 2. */
+    column: string;
+    /**
+     * Pattern 2 — additional columns of a compound key tuple, in positional order.
+     * Undefined or empty for single-column (Pattern 1) members. When set, the full
+     * compound match is `[column, ...additionalColumns]` which the translator emits
+     * as `MatchFieldNames` for PR #2193's runtime.
+     */
+    additionalColumns?: string[];
+    /** Whether the column appears in any FK relationship (declared or DBAutoDoc-discovered). */
+    participatesInFK: boolean;
+    /** FK target column if `participatesInFK` is true. */
+    fkTarget?: { schema: string; table: string; column: string } | null;
+    /** Whether the column is a PK (informational; affects tagging). */
+    isPrimaryKey?: boolean;
+    /**
+     * Per-column normalization strategy — the function that should be applied to THIS
+     * column's values at match time. Persisted into THIS column's hub `EntityOrganicKey`
+     * row at emission. Different members of the same cluster can have different strategies
+     * (e.g. one column already canonical → ExactMatch, another needs LowerCaseTrim).
+     * Falls back to the cluster-level `normalization` when not set.
+     */
+    normalizationStrategy?: OrganicKeyNormalizationStrategy;
+    /** Custom SQL expression for this column when normalizationStrategy='Custom'. */
+    customNormalizationExpression?: string;
+}
+
+/** Helper: returns the complete column list for a member (single or compound). */
+export function memberColumns(m: OrganicKeyClusterMember): string[] {
+    return [m.column, ...(m.additionalColumns ?? [])];
+}
+
+/** Helper: true when the member represents a compound tuple (Pattern 2). */
+export function isCompoundMember(m: OrganicKeyClusterMember): boolean {
+    return (m.additionalColumns?.length ?? 0) > 0;
+}
+
+
+/** A confirmed cluster after LLM refinement — one business concept, N member columns. */
+export interface OrganicKeyCluster {
+    /** Stable identifier for this cluster within the analysis run. */
+    id: string;
+    /** Canonical snake_case concept name (e.g. "email_address", "customer_id"). */
+    concept: string;
+    /** Cluster-level normalization strategy. */
+    normalization: OrganicKeyNormalizationStrategy;
+    /** Optional custom normalization SQL expression when normalization='Custom'. */
+    customNormalizationExpression?: string;
+    /** Members surviving the LLM refinement pass. */
+    members: OrganicKeyClusterMember[];
+    /** Cluster-level confidence (0–1). */
+    confidence: number;
+    /** LLM reasoning for why this cluster is a coherent business concept. */
+    reasoning: string;
+    /** Maximum pairwise embedding distance among members at clustering time (legacy field; 0 with the LLM-only pipeline). */
+    maxIntraDistance: number;
+    /**
+     * Set when EVERY non-PK member is a declared FK pointing at the PK member's column.
+     * PR #2193 organic keys exist to provide value-based matching "in place of a FK";
+     * when the FK is already declared, the cluster adds no navigation value and may
+     * indicate a lookup-table-PK pattern (country/currency/state codes). The dashboard
+     * can use this to offer a "hide FK-redundant" filter without losing the data.
+     */
+    isFKRedundant?: boolean;
+}
+
+/**
+ * Algorithmic configuration the detector actually runs with at execution time.
+ *
+ * Layering note: these are DBAutoDoc-internal tuning knobs. DBAutoDoc is a
+ * standalone tool that does NOT depend on MemberJunction, so these settings
+ * must be exposed through DBAutoDoc's own config system (see DBAutoDocConfig
+ * in types/config.ts) — NOT through mj.config.cjs.
+ *
+ * Cross-MJ-tool project facts (e.g. the project-wide table-exclusion list that
+ * CodeGen, mj-sync, and DBAutoDoc all need to agree on) DO live in mj.config.cjs;
+ * algorithm tuning does not.
+ *
+ * DEFAULT_DETECTOR_CONFIG values are the fallbacks used when DBAutoDoc's config
+ * doesn't override them; they are not authoritative.
+ */
+export interface OrganicKeyDetectorConfig {
+    /** Cosine-distance threshold for the agglomerative merge step. Lower = tighter clusters. */
+    mergeThreshold: number;
+    /** Minimum cluster size to report. */
+    minClusterSize: number;
+    /** Minimum number of distinct tables a cluster must span. */
+    minDistinctTables: number;
+    /** Sample values per column to include in the embedding input (and refiner prompt). */
+    sampleValueCount: number;
+    /** Concurrency for per-cluster LLM refinement. */
+    refinementConcurrency: number;
+}
+
+/** Fallback values used when DBAutoDoc's config doesn't override them. Not authoritative. */
+export const DEFAULT_DETECTOR_CONFIG: OrganicKeyDetectorConfig = {
+    mergeThreshold: 0.35,
+    minClusterSize: 2,
+    minDistinctTables: 2,
+    sampleValueCount: 5,
+    refinementConcurrency: 4,
+};
+
+/** Per-run phase tracking persisted in state.json. */
+export interface OrganicKeyDetectionPhase {
+    triggered: boolean;
+    startedAt: string;
+    completedAt?: string;
+    status: 'running' | 'completed' | 'failed' | 'skipped';
+    candidateClusterCount: number;
+    confirmedClusterCount: number;
+    rejectedClusterCount: number;
+    splitClusterCount: number;
+    tokensUsed: number;
+    inputTokens: number;
+    outputTokens: number;
+    estimatedCost: number;
+    embeddingModelUsed?: string;
+    refinementModelUsed?: string;
+    skipReason?: string;
+    errorMessage?: string;
+}
+
+/** Outcome of refining a single cluster. */
+export interface ClusterRefinementOutcome {
+    outcome: 'keep' | 'split' | 'reject' | 'error';
+    /** For 'keep' — refined cluster with concept + normalization + outliers ejected. */
+    refinedCluster?: OrganicKeyCluster;
+    /** For 'split' — coherent sub-clusters the LLM partitioned the input into. */
+    subClusters?: OrganicKeyCluster[];
+    /** For 'reject' — LLM-provided reason. */
+    rejectReason?: string;
+    /** For 'error' — failure detail. */
+    errorMessage?: string;
+    tokensUsed: number;
+    inputTokens: number;
+    outputTokens: number;
+}

--- a/packages/DBAutoDoc/src/types/state.ts
+++ b/packages/DBAutoDoc/src/types/state.ts
@@ -5,6 +5,7 @@
 
 import { RelationshipDiscoveryPhase, CachedColumnStats } from './discovery.js';
 import { SampleQuery, SampleQueryGenerationSummary } from './sample-queries.js';
+import { OrganicKeyCluster, OrganicKeyDetectionPhase } from './organic-keys.js';
 
 export interface DatabaseDocumentation {
   version: string;
@@ -14,6 +15,11 @@ export interface DatabaseDocumentation {
   phases: AnalysisPhases; // Multi-phase workflow organization
   schemas: SchemaDefinition[]; // Deliverable: Database structure with descriptions
   sampleQueries?: SampleQueriesDeliverable; // Deliverable: Training queries generated from schemas
+  /**
+   * Deliverable: organic-key clusters detected by the optional organic-key
+   * detection phase. Empty/absent when that phase didn't run.
+   */
+  organicKeyClusters?: OrganicKeyCluster[];
   resumedFromFile?: string; // Path to the state file this analysis resumed from
 }
 
@@ -62,6 +68,7 @@ export interface AnalysisPhases {
   keyDetection?: RelationshipDiscoveryPhase; // Primary key and foreign key detection
   descriptionGeneration: AnalysisRun[]; // Table and column description analysis
   queryGeneration?: QueryGenerationPhase; // Metadata about query generation process
+  organicKeyDetection?: OrganicKeyDetectionPhase; // Optional organic-key cluster detection (runs after description + PK/FK)
 }
 
 /**

--- a/packages/DBAutoDoc/src/utils/json.ts
+++ b/packages/DBAutoDoc/src/utils/json.ts
@@ -1,0 +1,142 @@
+/**
+ * JSON utilities — DBAutoDoc-local, no external dependencies.
+ *
+ * Faithful port of @memberjunction/global's CleanAndParseJSON / CleanJSON /
+ * SafeJSONParse so DBAutoDoc runs standalone without depending on
+ * @memberjunction/global. Preserves the multi-stage fallback chain MJ uses
+ * to handle real-world LLM output:
+ *   1. Try direct JSON.parse
+ *   2. Try removing or adding a trailing `}` (common LLM truncation/over-close artifact)
+ *   3. Strip non-escaped newlines/tabs
+ *   4. Undo double-escaped sequences (\\n, \\", etc.)
+ *   5. Try JSON.parse again
+ *   6. Extract from ``` ... ``` markdown fences (recursive)
+ *   7. Fall back to balanced-{...}/[...] extraction from mixed prose
+ *
+ * Behavior must match MJ exactly so PromptEngine / LLMSanityChecker /
+ * LLMDiscoveryValidator (which currently rely on this fallback chain) keep
+ * working on the same LLM responses they handle today.
+ */
+
+/**
+ * Strip optional markdown code fences, run the multi-stage cleanup pipeline,
+ * and parse the resulting JSON.
+ *
+ * @param inputString  Raw string possibly wrapped in code fences, double-escaped,
+ *                     or mixed with explanatory prose.
+ * @param logErrors    When true, parse errors are logged to console (default false).
+ * @returns Parsed value cast to `T`, or `null` on parse failure.
+ */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export function cleanAndParseJSON<T = any>(inputString: string | null, logErrors = false): T | null {
+    if (!inputString) return null;
+    const cleaned = cleanJSON(inputString);
+    if (!cleaned) return null;
+    return safeJSONParse<T>(cleaned, logErrors);
+}
+
+/**
+ * Extract a valid-JSON string from arbitrary input. Returns null if no usable
+ * JSON can be salvaged. Behavior matches @memberjunction/global's CleanJSON.
+ */
+export function cleanJSON(inputString: string | null): string | null {
+    if (!inputString) return null;
+
+    let processedString = inputString.trim();
+    let originalException: Error | null = null;
+
+    // 1. Try parsing as-is. Preserves any embedded JSON or markdown inside string values.
+    try {
+        const parsed = JSON.parse(processedString);
+        return JSON.stringify(parsed, null, 2);
+    } catch (e) {
+        originalException = e instanceof Error ? e : new Error(String(e));
+
+        // 2. Common LLM artifacts: extra trailing `}` or missing final `}`.
+        if (processedString.endsWith('}')) {
+            const withoutLast = processedString.slice(0, -1);
+            const withoutLastResult = safeJSONParse(withoutLast);
+            if (withoutLastResult) return JSON.stringify(withoutLastResult, null, 2);
+
+            const withExtra = processedString + '}';
+            const withExtraResult = safeJSONParse(withExtra);
+            if (withExtraResult) return JSON.stringify(withExtraResult, null, 2);
+        }
+    }
+
+    // 3. Strip formatting newlines/tabs — but preserve \n and \t inside string values.
+    processedString = processedString.replace(/(?<!\\)\n/g, '').replace(/(?<!\\)\t/g, '');
+
+    // 4. Undo double-escaped sequences (\\n → \n, \\" → ", etc.).
+    if (processedString.includes('\\\\') || processedString.includes('\\"')) {
+        try {
+            processedString = JSON.parse('"' + processedString + '"');
+        } catch {
+            processedString = processedString
+                .replace(/\\\\n/g, '\n')
+                .replace(/\\\\t/g, '\t')
+                .replace(/\\\\r/g, '\r')
+                .replace(/\\\\"/g, '"')
+                .replace(/\\\\\\/g, '\\');
+        }
+    }
+
+    // 5. Try again after unescaping.
+    try {
+        const parsed = JSON.parse(processedString);
+        return JSON.stringify(parsed, null, 2);
+    } catch {
+        // fall through to extraction logic
+    }
+
+    // 6. Pull JSON from ``` ... ``` markdown fences (json/JSON tag optional, also handles \` escapes).
+    const markdownRegex = /(?:```|\\`\\`\\`)(?:json|JSON)?\s*([\s\S]*?)(?:```|\\`\\`\\`)/gi;
+    const matches = Array.from(processedString.matchAll(markdownRegex));
+    if (matches.length > 0) {
+        const extracted = matches.map((m) => m[1].trim()).join('\n');
+        return cleanJSON(extracted); // recurse — extracted content may need its own cleanup
+    }
+
+    // 7. Last resort: find first `[` or `{`, take everything to the last matching close-bracket.
+    const firstBracketIndex = processedString.indexOf('[');
+    const firstBraceIndex = processedString.indexOf('{');
+    let startIndex = -1;
+    let endIndex = -1;
+
+    if ((firstBracketIndex !== -1 && firstBracketIndex < firstBraceIndex) || firstBraceIndex === -1) {
+        startIndex = firstBracketIndex;
+        endIndex = processedString.lastIndexOf(']');
+    } else if (firstBraceIndex !== -1) {
+        startIndex = firstBraceIndex;
+        endIndex = processedString.lastIndexOf('}');
+    }
+
+    if (startIndex === -1 || endIndex === -1 || endIndex < startIndex) {
+        console.warn('No JSON found in the input.');
+        return processedString;
+    }
+
+    const potentialJSON = processedString.substring(startIndex, endIndex + 1);
+    try {
+        const jsonObject = JSON.parse(potentialJSON);
+        return JSON.stringify(jsonObject, null, 2);
+    } catch {
+        // All paths exhausted — throw with the original message preserved.
+        throw new Error(`Failed to find a path to CleanJSON\n\n${originalException?.message}`);
+    }
+}
+
+/**
+ * Safe wrapper around JSON.parse. Catches errors; optionally logs them.
+ * Matches @memberjunction/global's SafeJSONParse.
+ */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export function safeJSONParse<T = any>(jsonString: string, logErrors = false): T | null {
+    if (!jsonString) return null;
+    try {
+        return JSON.parse(jsonString) as T;
+    } catch (e) {
+        if (logErrors) console.error('Error parsing JSON string:', e);
+        return null;
+    }
+}

--- a/packages/MJCore/src/generic/entityInfo.ts
+++ b/packages/MJCore/src/generic/entityInfo.ts
@@ -2280,6 +2280,12 @@ export class EntityInfo extends BaseInfo {
 
     /**
      * Builds an ExtraFilter for direct organic key matching (field-to-field comparison).
+     *
+     * Per-column normalization: each side of the comparison uses its OWN normalization
+     * function (the spoke entity's organic key carries its own expression; the hub uses
+     * the parent organic key's expression). At runtime we look up the spoke entity's
+     * matching organic key (same Name) to find its expression. Falls back to the hub's
+     * expression on both sides if the spoke doesn't carry its own.
      */
     private static BuildDirectOrganicKeyFilter(
         record: BaseEntity,
@@ -2290,6 +2296,10 @@ export class EntityInfo extends BaseInfo {
         const relatedFields = relatedEntity.RelatedEntityFieldNamesArray;
         const conditions: string[] = [];
 
+        // Resolve the spoke entity's own organic key (matching by Name) to pull its
+        // per-column normalization. Falls back to the hub's expression if not found.
+        const spokeOrganicKey = EntityInfo.ResolveSpokeOrganicKey(relatedEntity, organicKey);
+
         for (let i = 0; i < matchFields.length; i++) {
             const value = record.Get(matchFields[i]);
             if (value == null) {
@@ -2298,12 +2308,30 @@ export class EntityInfo extends BaseInfo {
             }
             const relatedField = relatedFields[i] || matchFields[i];
             const escapedValue = String(value).replace(/'/g, "''");
-            conditions.push(EntityInfo.WrapWithNormalization(
-                `[${relatedField}]`, organicKey, escapedValue
+            conditions.push(EntityInfo.WrapBothSidesWithNormalization(
+                `[${relatedField}]`, spokeOrganicKey ?? organicKey,
+                escapedValue, organicKey
             ));
         }
 
         return conditions.join(' AND ');
+    }
+
+    /**
+     * Look up the spoke entity's organic key matching the hub's by Name, so we can apply
+     * the spoke's own normalization function on the spoke side. Returns undefined if the
+     * spoke entity doesn't have a parallel organic key — caller falls back to the hub's.
+     */
+    private static ResolveSpokeOrganicKey(
+        relatedEntity: EntityOrganicKeyRelatedEntityInfo,
+        hubOrganicKey: EntityOrganicKeyInfo
+    ): EntityOrganicKeyInfo | undefined {
+        const md = Metadata.Provider;
+        if (!md) return undefined;
+        const spokeEntity = md.EntityByName?.(relatedEntity.RelatedEntity)
+            ?? md.Entities?.find?.((e: EntityInfo) => e.Name === relatedEntity.RelatedEntity);
+        if (!spokeEntity) return undefined;
+        return spokeEntity.OrganicKeys?.find((ok) => ok.Name === hubOrganicKey.Name);
     }
 
     /**
@@ -2318,6 +2346,9 @@ export class EntityInfo extends BaseInfo {
         const transitiveMatchFields = relatedEntity.TransitiveObjectMatchFieldNamesArray;
         const conditions: string[] = [];
 
+        // Transitive bridge values are normalized using the HUB's expression on both sides —
+        // the bridge view is a synthetic projection of hub-side values, not the spoke's raw
+        // column, so the spoke's own expression doesn't apply here.
         for (let i = 0; i < matchFields.length; i++) {
             const value = record.Get(matchFields[i]);
             if (value == null) {
@@ -2364,6 +2395,60 @@ export class EntityInfo extends BaseInfo {
             }
             default:
                 return `${fieldExpression} = '${escapedValue}'`;
+        }
+    }
+
+    /**
+     * Like WrapWithNormalization but takes a separate organic key for each side — so the
+     * spoke field uses the spoke entity's own expression while the literal value (sourced
+     * from the hub record) uses the hub's expression. Same canonical form on both sides
+     * when the expressions agree; different transforms applied independently when they
+     * don't (the per-column normalization case).
+     */
+    private static WrapBothSidesWithNormalization(
+        fieldExpression: string,
+        fieldOrganicKey: EntityOrganicKeyInfo,
+        escapedValue: string,
+        valueOrganicKey: EntityOrganicKeyInfo
+    ): string {
+        const leftSide = EntityInfo.NormalizeFieldExpression(fieldExpression, fieldOrganicKey);
+        const rightSide = EntityInfo.NormalizeLiteralExpression(escapedValue, valueOrganicKey);
+        return `${leftSide} = ${rightSide}`;
+    }
+
+    /** Apply an organic key's normalization to a SQL field expression (left side of compare). */
+    private static NormalizeFieldExpression(
+        fieldExpression: string,
+        organicKey: EntityOrganicKeyInfo
+    ): string {
+        switch (organicKey.NormalizationStrategy) {
+            case 'LowerCaseTrim': return `LOWER(LTRIM(RTRIM(${fieldExpression})))`;
+            case 'Trim':          return `LTRIM(RTRIM(${fieldExpression}))`;
+            case 'ExactMatch':    return fieldExpression;
+            case 'Custom': {
+                const expr = organicKey.CustomNormalizationExpression;
+                if (!expr) return fieldExpression;
+                return expr.replace(/\{\{FieldName\}\}/g, fieldExpression);
+            }
+            default: return fieldExpression;
+        }
+    }
+
+    /** Apply an organic key's normalization to a quoted literal value (right side of compare). */
+    private static NormalizeLiteralExpression(
+        escapedValue: string,
+        organicKey: EntityOrganicKeyInfo
+    ): string {
+        switch (organicKey.NormalizationStrategy) {
+            case 'LowerCaseTrim': return `LOWER(LTRIM(RTRIM('${escapedValue}')))`;
+            case 'Trim':          return `LTRIM(RTRIM('${escapedValue}'))`;
+            case 'ExactMatch':    return `'${escapedValue}'`;
+            case 'Custom': {
+                const expr = organicKey.CustomNormalizationExpression;
+                if (!expr) return `'${escapedValue}'`;
+                return expr.replace(/\{\{FieldName\}\}/g, `'${escapedValue}'`);
+            }
+            default: return `'${escapedValue}'`;
         }
     }
 

--- a/plans/dbautodoc-organic-keys.md
+++ b/plans/dbautodoc-organic-keys.md
@@ -1,0 +1,143 @@
+# DBAutoDoc Organic-Key Detection + Findings App
+
+> Working spec. Not a PR yet. Goal: prove a parsimonious alternative to PR #2582 head-to-head against the same benchmark schemas, then decide whether to ship.
+
+## Context
+
+[PR #2193](https://github.com/MemberJunction/MJ/pull/2193) (merged March 2026) shipped the **Entity Organic Keys** runtime: two metadata tables (`EntityOrganicKey` + `EntityOrganicKeyRelatedEntity`), `EntityInfo.OrganicKeys`, `BuildOrganicKeyViewParams()` SQL generation, Angular form panels with collapsible sections + lazy-loaded `EntityDataGrid`, detail-panel match counts, Entity admin "Organic Keys" rail, and CodeGen ingest of `additionalSchemaInfo.json` `OrganicKeys[]` per-table arrays. The runtime is fully working; what's missing is anything that *proposes* organic keys automatically.
+
+[PR #2582](https://github.com/MemberJunction/MJ/pull/2582) (open) attempts that proposal layer with 8,200+ lines: agglomerative clustering, business-concept projector, business gate, semantic expansion, missing-concepts discovery, concept-merge pass, convergence loop, MinHash, embeddings, and several LLM passes. The output lands in a top-level `OrganicKeyClusters` array that **no consumer reads** — there is no bridge to PR #2193's per-table `OrganicKeys[]` shape, so the proposals never reach MJ Explorer.
+
+The empirical APTIFY run produced 204 clusters in ~40 minutes at ~1.4M tokens **with MinHash and business projection both defaulted OFF** — meaning the heavyweight infrastructure didn't even participate in the headline result.
+
+## What we're building
+
+A complete alternative on this branch:
+
+1. **A clustering algorithm** at roughly 1/5 the LOC, doing one LLM call per cluster with a business-aware prompt instead of six bolted-on LLM passes.
+2. **A translator** that turns clusters into PR #2193's per-table `OrganicKeys[]` shape so CodeGen and the existing Explorer panels just work.
+3. **A `DBAutoDoc` app** in MJ Explorer (opt-in) that browses everything DBAutoDoc produces — descriptions, soft PK/FK candidates, organic-key clusters, value lists, sample queries, runs — with approve/reject actions that persist across server restarts.
+4. **Two new MJ entities** for persistence: `MJ: DBAutoDoc Run` (per-run summary, written by CodeGen) and `MJ: DBAutoDoc Run Finding Decision` (human approve/reject log).
+
+## Algorithm — five steps, one LLM pass
+
+1. **Prefilter** (deterministic, no API): drop tables matching `mj.config.cjs schemaScope.excludeTablePatterns`; drop columns already classified by soft-FK to a single target; drop low-cardinality, binary/blob/float, and well-known audit columns.
+
+2. **Embed column descriptors** (batched, disk-cached). Each input is *description + a few sample values* with a clustering task hint. Sample values are the key signal — they let the embedding model see `alice@acme.com`-shaped values vs `internal-bot@company.com`-shaped values and discriminate. Sample values are already available from `ColumnStatsCache`; no extra DB work.
+
+3. **Average-linkage agglomerative clustering** on cosine distance. Average-linkage (not complete-linkage as PR #2582 uses) means clusters are "similar on average" rather than "every pair must be close" — this eliminates the same-concept-multiple-clusters problem PR #2582 needs `ConceptMergePass` to fix. Filter: ≥2 members, ≥2 distinct tables.
+
+4. **One LLM call per cluster** with a single prompt that handles keep/split/reject + canonical concept naming + normalization choice + outlier ejection. Canonical concept names (`email_address`, `customer_id`, etc.) instructed in the prompt mean same-concept clusters from disconnected geometric regions converge to the same output name — eliminating the need for a post-pass.
+
+5. **Translate keeps to PR #2193's hub-and-spoke shape**. Each cluster fans out: N members → N hub-and-spoke entries with the other N-1 as spokes. Skip `fk-redundant-single-target` clusters (declared FK already does the job). Set `AutoCreateRelatedViewOnForm = true` so the runtime knows these are detected, not curated. Output to a separate file (`detected-organic-keys.json`), not directly into `additionalSchemaInfo.json` — human curation required to promote.
+
+## What we explicitly do NOT build (v1)
+
+| Feature in PR #2582 | Why deferred |
+|---|---|
+| `BusinessConceptProjector` (anchor-axis projection) | LLM prompt encodes business judgment; projecting generic embeddings into a 14-axis space over-merges distinct concepts (author confirmed empirically). |
+| `MinHash` value-overlap signatures | Organic keys describe *schema capacity* for value matching, not proof of current overlap. The Mailchimp-just-connected case shows why value overlap as a hard filter would reject the most valuable proposals. Sample values in the embed input give us value-awareness implicitly. |
+| Convergence loop (multi-iteration) | One pass is sufficient; iteration is unjustified without ablation. |
+| `SemanticClusterExpander` | If embedding misses a member, lower the merge threshold — fix clustering, don't bolt on a second pass. |
+| `MissingConceptsDetector` | Same. |
+| `ConceptMergePass` | Eliminated by average-linkage + canonical concept names in the refiner prompt. |
+| Schema-level hierarchical clustering | v2 — promising direction for dirty production schemas but ship flat first, measure, then layer. |
+| Cluster-shape metadata table (Option C) | Translate to existing PR #2193 schema; revisit only if N²-expansion proves painful. |
+
+Each of these is add-back-able if v1 measurement shows it's needed. Default: simplest thing that could work.
+
+## App — `DBAutoDoc`
+
+Opt-in MJ Explorer app (`DefaultForNewUser: false`). Nine dashboards:
+
+| Dashboard | Reads from |
+|---|---|
+| Overview | Run summary entity + state.json coverage stats |
+| Tables | state.json table descriptions |
+| Columns | state.json column descriptions (searchable) |
+| PK Candidates | state.json soft-PK detections + decisions log |
+| FK Candidates | state.json soft-FK detections + decisions log |
+| Organic Key Clusters | state.json organic-key output + decisions log |
+| Value Lists | state.json valueListVerdict + decisions log |
+| Sample Queries | state.json sampleQueries |
+| Analysis Runs | `MJ: DBAutoDoc Run` entity (timeline + diff) |
+
+GraphQL resolver reads `state.json` (path stored on the Run record) and joins with the decisions table. Gracefully degrades when state.json isn't accessible (DB summary still works; deep audit shows "state file not available on this server").
+
+Plus the inline tweak: PR #2193's form-component organic-key panels render with a small `[auto-detected ●]` badge when `AutoCreateRelatedViewOnForm = true`, with `[Confirm] [Hide]` actions that write to the decisions log via the same mutation the dashboard uses.
+
+## Persistence — two new MJ entities
+
+```sql
+MJ: DBAutoDoc Run
+  ID, RunStartedAt, RunCompletedAt, Status,
+  DatabaseName, SchemaCount, TableCount, ColumnCount,
+  DescriptionsGenerated, PKCandidatesFound, FKCandidatesFound,
+  ValueListsFound, OrganicClustersFound, SampleQueriesGenerated,
+  TokensUsed, EstimatedCost, StateFilePath, GitCommit, Notes
+
+MJ: DBAutoDoc Run Finding Decision
+  ID, DBAutoDocRunID (FK), FindingType, FindingKey,
+  Decision (Approved | Rejected | Modified | Pending),
+  ConfidenceAtDecision, ModificationData (JSON),
+  DecidedByUserID, DecidedAt, Status (Active | Superseded), Notes
+```
+
+CodeGen writes the Run row after consuming output. CodeGen also reads prior decisions from the Decision table on each run and honors them (Approved → applied, Rejected → skipped, Pending → applied with `AutoCreateRelatedViewOnForm = true`). Closes the feedback loop: human curation persists across runs.
+
+Retroactive benefit: soft PK/FK detection has never had a curation surface. Building these entities for organic keys gives PK/FK detection the same approve/reject workflow for free.
+
+## Sequencing — three slices, each independently shippable
+
+### v0 — App + existing DBAutoDoc output (no algorithm work yet)
+Two new entities + migration. App metadata + lazy nav. `DBAutoDocFindingsResolver` reads state.json. Dashboards: Overview, Tables, Columns, PK Candidates, FK Candidates, Sample Queries, Runs. Approve/reject actions for PK/FK. CodeGen writes Run rows. Surfaces 6+ months of DBAutoDoc output that was previously invisible. **Zero algorithm risk.**
+
+### v1 — Algorithm + Organic Clusters dashboard
+The clustering pipeline (~1,000 LOC source + tests). Organic Clusters dashboard. Inline `[auto-detected]` badge on form panels. Value Lists dashboard. Run-diff view. Completes the end-to-end story.
+
+### v2 — Polish
+Iteration Detail view (LLM transcript audit). Save sample queries as MJ Queries. Schema-level hierarchical clustering. Knowledge Hub cross-linking. CLI for disconnected workflows.
+
+**Disk embedding cache** (deferred from v1): a small persistent cache that writes embedding vectors to a JSON file after each run so re-runs skip the API call. Costs cents to skip in v1 (embeddings on free tiers, ~5 min wallclock at APTIFY scale) but saves real wallclock during development iteration on clusterer/refiner tuning. Worth ~30-50 LOC when added; deferred until needed.
+
+## How we decide v1 ships
+
+Three acceptance criteria against the same benchmarks PR #2582 ran:
+
+1. **Precision**: ≥80% of KEEP clusters at confidence ≥0.85 are genuinely useful organic keys (manual review of 50 random clusters).
+2. **Recall**: every canonical concept from PR #2193's Hubspot+Mailchimp example is found.
+3. **Cost**: APTIFY-scale (~5K columns post-filter): <200K tokens, <5 min wallclock on Gemini Flash.
+
+If v1 hits all three, ship v0+v1 to `next`. If v1's algorithm is comparable to or better than PR #2582 on these benchmarks, PR #2582 doesn't merge.
+
+## Branch hygiene
+
+- Branched from `origin/next` (NOT from PR #2582). Clean base.
+- No push, no PR until v1 is proven against the acceptance criteria.
+- Worktree at `../MJ-dbautodoc-organic-keys` keeps this work isolated from any other in-flight branches.
+
+## Scope additions during build
+
+### MJ-dependency removal (bundled into this branch)
+
+Mid-build, the team identified that DBAutoDoc's `package.json` was declaring four `@memberjunction/*` runtime dependencies (`@memberjunction/ai`, `@memberjunction/global`, `@memberjunction/core`, `@memberjunction/server-bootstrap`), contradicting the package's own description as a "standalone" tool. Removed in scope rather than as a separate PR — the new organic-key code would have either inherited the coupling or introduced inconsistency between new and existing code paths.
+
+What changed:
+
+| Component | Replacement |
+|---|---|
+| `@memberjunction/ai`'s `BaseLLM` / `ChatParams` / `ChatResult` | New `src/llm/LLMProvider.ts` — direct-REST clients for Anthropic + Gemini + OpenAI; abstract base class with default batch `ChatCompletions` |
+| `MJGlobal.ClassFactory` dispatch (LLMs) | Plain `switch` in `createLLMInstance()` |
+| `MJGlobal.ClassFactory` dispatch (DB drivers) | Plain `switch` in `createDriver()` with named imports |
+| `@RegisterClass` decorators on three drivers | Removed; drivers become plain classes |
+| `CleanAndParseJSON` from `@memberjunction/global` | New `src/utils/json.ts` — faithful port preserving the multi-stage fallback chain (direct parse → trailing-`}` recovery → newline/tab strip → double-escape undo → markdown fence extraction → balanced-`{...}` extraction) |
+| `LogError` / `LogStatus` from `@memberjunction/core` | `console.error` / `console.log` (DBAutoDoc is a CLI tool; console is appropriate) |
+| `utils/llm-factory.ts` (MJ ClassFactory wrapper) | Deleted; `createLLMInstance` lives in `llm/LLMProvider.ts` |
+
+Verification: `npm run build` clean, `npm ls @memberjunction/ai @memberjunction/global @memberjunction/core @memberjunction/server-bootstrap` returns empty for DBAutoDoc's tree. JSON parser behavior is byte-for-byte equivalent to MJ's implementation per the port checklist.
+
+### What this enables
+
+DBAutoDoc can now be installed as a standalone npm package — `npm install -g @memberjunction/db-auto-doc` pulls in DBAutoDoc + its DB driver + LLM client deps and nothing else from MJ. Users running DBAutoDoc against an arbitrary SQL Server / PostgreSQL / MySQL database don't need MJ's server, schema, or runtime at all. The `@memberjunction/` scope on the package name is now branding-only (which was always the intent).
+
+Cross-MJ-tool concerns (e.g., the project-wide `schemaScope.excludeTablePatterns` in `mj.config.cjs`) remain unaddressed here — that's a separate workstream because it requires MJ to be present.


### PR DESCRIPTION
## Organic Keys for DBAutoDoc + PR #2193 per-column normalization

Adds an **optional organic-key detection phase** to DBAutoDoc (runs after descriptions and PK/FK detection), plus the MJCore runtime to surface those matches in MemberJunction forms.

### What is an organic key?
Where a foreign key requires **shared exact values**, an organic key operates on the weaker-but-broader condition of **shared identity**: two columns refer to the same real-world thing once each is canonicalized through its own transformation. That joins far more cross-system data than exact-match FKs (e.g. the same phone number stored four different ways across HubSpot, Zendesk, and QuickBooks).

### Detection pipeline (`SemanticPhase`)
Columns that describe the same concept embed close together, so detection clusters on **descriptions**, not raw values (raw values diverge by format — exactly what we bridge):

1. **Prefilter** — drop columns that can't be identity (booleans, enums, measures, audit, free text).
2. **LLM normalize** — rewrite each column's description to a simplified, business-focused form so semantically-equal columns embed together. Also tags a per-column **concept name** and a **normalization strategy**.
3. **Embed → agglomerative cluster** with a gap-detected distance threshold.
4. **Concept-name split** — break over-merged clusters apart using the LLM concept tags.
5. **Per-column normalization** *(PR #2193)* — each emitted `EntityOrganicKey` carries **its own** normalization function for its column. One function per organic key, **not** per cluster — so differently-formatted columns each canonicalize to a shared form independently.
6. **FK-graph transitive bridges** — `FKGraphWalker` finds multi-hop paths, `BridgeViewSQLGenerator` emits the bridge-view SQL, and the transitive `EntityOrganicKeyRelatedEntity` fields are populated so the runtime's transitive matcher (already in #2193) can surface multi-hop matches.

### Runs on MemberJunction's AI infrastructure
Detection uses MJ's `BaseLLM` (via the existing `llm-factory` / ClassFactory) and `BaseEmbeddings` (same ClassFactory pattern) — **no standalone provider REST clients**. DBAutoDoc stays coupled to the MJ AI stack exactly as before.

### Runtime (`EntityInfo.BuildOrganicKeyViewParams`, MJCore)
At match time each side normalizes through **its own** expression (`WrapBothSidesWithNormalization` / `ResolveSpokeOrganicKey` look up the spoke entity's own organic key by name). `Custom` strategy with no expression falls back to exact-match, never errors.

### Scope
Detection + emit + MJCore runtime only. No Explorer app, no GraphQL resolver, no schema/migration changes, no decoupling — DBAutoDoc's MJ infrastructure (drivers via `ClassFactory`, `llm-factory`, package deps) is unchanged from `next`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
