### PR TITLE
fix: eliminate WebSocket token expiry log spam on Azure

### DIFF
--- a/.changeset/quiet-sockets-heal.md
+++ b/.changeset/quiet-sockets-heal.md
@@ -1,0 +1,6 @@
+---
+"@memberjunction/server": patch
+"@memberjunction/graphql-dataprovider": patch
+---
+
+Fix WebSocket token expiry log spam on Azure by validating JWT once at connection time (RAII), proactively closing the socket at expiry with retriable close code 4403, and eagerly refreshing the token on close so retries succeed immediately

--- a/packages/GraphQLDataProvider/src/graphQLDataProvider.ts
+++ b/packages/GraphQLDataProvider/src/graphQLDataProvider.ts
@@ -2674,9 +2674,12 @@ export class GraphQLDataProvider extends ProviderBase implements IEntityDataProv
             this._isDisposingSocketIntentionally = false;
             this._wsClient = createClient({
                 url: this.ConfigData.WSURL,
-                connectionParams: {
+                // Function form: re-evaluated on every connection attempt (including
+                // retries after 4403 "Token expired"). This lets the client pick up a
+                // freshly-refreshed token instead of reusing the stale one.
+                connectionParams: () => ({
                     Authorization: 'Bearer ' + this.ConfigData.Token,
-                },
+                }),
                 keepAlive: 30000, // Send keepalive ping every 30 seconds
                 retryAttempts: 3,
                 shouldRetry: () => true,

--- a/packages/GraphQLDataProvider/src/graphQLDataProvider.ts
+++ b/packages/GraphQLDataProvider/src/graphQLDataProvider.ts
@@ -2690,7 +2690,7 @@ export class GraphQLDataProvider extends ProviderBase implements IEntityDataProv
             this._wsClient.on('connected', () => {
                 this._socketStateSubject.next('connected');
             });
-            this._wsClient.on('closed', () => {
+            this._wsClient.on('closed', (event: unknown) => {
                 // Ignore closes we initiated via disposeWSClient() — those already
                 // emit 'unknown' themselves. Only treat unexpected closes (retries
                 // exhausted) as 'disconnected'.
@@ -2698,6 +2698,16 @@ export class GraphQLDataProvider extends ProviderBase implements IEntityDataProv
                     return;
                 }
                 this._socketStateSubject.next('disconnected');
+
+                // If the server closed with 4403 "Token expired", eagerly refresh
+                // the token so that graphql-ws retries use a fresh one. Without this,
+                // all retry attempts would reuse the stale token and fail.
+                const closeCode = (event as { code?: number })?.code;
+                if (closeCode === 4403 && this._configData.Data.RefreshTokenFunction) {
+                    this.RefreshToken().catch(() => {
+                        // RefreshToken failure is handled via notifyAuthenticationError
+                    });
+                }
             });
 
             // Start cleanup timer if not already running

--- a/packages/MJServer/src/index.ts
+++ b/packages/MJServer/src/index.ts
@@ -26,7 +26,9 @@ import sql from 'mssql';
 import { WebSocketServer } from 'ws';
 import buildApolloServer from './apolloServer/index.js';
 import { configInfo, dbDatabase, dbHost, dbPort, dbUsername, graphqlPort, graphqlRootPath, mj_core_schema, websiteRunFromPackage, RESTApiOptions } from './config.js';
+import { default as jwt } from 'jsonwebtoken';
 import { contextFunction, createUnifiedAuthMiddleware, getUserPayload } from './context.js';
+import { UserPayload } from './types.js';
 import { requireSystemUserDirective, publicDirective } from './directives/index.js';
 import createMSSQLConfig from './orm.js';
 import { setupRESTEndpoints } from './rest/setupRESTEndpoints.js';
@@ -667,27 +669,70 @@ export const serve = async (resolverPaths: Array<string>, app: Application = cre
   const httpServer = createServer(app);
 
   const webSocketServer = new WebSocketServer({ server: httpServer, path: graphqlRootPath });
-  const serverCleanup = useServer(
+
+  // Track per-connection expiry timers so we can clean them up on close
+  const expiryTimers = new WeakMap<object, ReturnType<typeof setTimeout>>();
+
+  const serverCleanup = useServer<Record<string, unknown>, { userPayload: UserPayload }>(
     {
       schema,
-      context: async ({ connectionParams }) => {
-        const userPayload = await getUserPayload(String(connectionParams?.Authorization), undefined, dataSources);
-        return { userPayload };
-      },
-      onError: (ctx, message, errors) => {
-        // Check if error is token expiration (expected behavior)
-        const isTokenExpired = errors.some(err =>
-          err.extensions?.code === 'JWT_EXPIRED' ||
-          err.message?.includes('token has expired')
-        );
+      // RAII: validate the token once at connection time and cache the result.
+      // This prevents re-validating (and re-logging) on every subscription message.
+      onConnect: async (ctx) => {
+        try {
+          const token = String(ctx.connectionParams?.Authorization);
+          const userPayload = await getUserPayload(token, undefined, dataSources);
 
-        if (isTokenExpired) {
-          // Log at warn level - this is expected from long-lived browser sessions
-          console.warn('WebSocket connection token expired - client should reconnect with refreshed token');
-        } else {
-          // Log actual errors at error level
-          console.error('WebSocket error:', errors);
+          // Store validated payload on the connection for use in context()
+          ctx.extra.userPayload = userPayload;
+
+          // Schedule proactive socket close at token expiry so the client
+          // reconnects with a fresh token instead of spamming errors.
+          const decoded = jwt.decode(token.replace('Bearer ', ''));
+          if (decoded && typeof decoded !== 'string' && decoded.exp) {
+            const msUntilExpiry = decoded.exp * 1000 - Date.now();
+            if (msUntilExpiry > 0) {
+              const timer = setTimeout(() => {
+                console.log(`WebSocket token expiring — closing connection for ${userPayload.email}`);
+                // 4403 = Forbidden — retriable in graphql-ws, signals "get a new token"
+                // (4401 is reserved as fatal/"Unauthorized" in the graphql-ws protocol)
+                try {
+                  ctx.extra.socket.close(4403, 'Token expired');
+                } catch {
+                  // Socket may already be closed; benign
+                }
+              }, msUntilExpiry);
+              // Prevent the timer from keeping the process alive during shutdown
+              timer.unref();
+              expiryTimers.set(ctx, timer);
+            }
+          }
+
+          return true;
+        } catch (error: unknown) {
+          // Return false instead of throwing — graphql-ws sends 4403 Forbidden
+          // (retriable) rather than letting the throw produce 1011 (fatal).
+          const msg = error instanceof Error ? error.message : 'Authentication failed';
+          console.warn(`WebSocket connection rejected: ${msg}`);
+          return false;
         }
+      },
+      // context() now just reads the already-validated payload — no I/O, no logging
+      context: async (ctx) => {
+        return { userPayload: ctx.extra.userPayload as UserPayload };
+      },
+      onClose: (ctx) => {
+        // Clear the expiry timer if the connection closes before the token expires
+        const timer = expiryTimers.get(ctx);
+        if (timer) {
+          clearTimeout(timer);
+          expiryTimers.delete(ctx);
+        }
+      },
+      onError: (_ctx, _message, errors) => {
+        // Token expiry errors can't happen anymore (handled in onConnect + timer),
+        // so all errors here are genuine and worth logging.
+        console.error('WebSocket error:', errors);
       },
     },
     webSocketServer


### PR DESCRIPTION
## Summary

- **RAII token validation**: Validate JWT once in `onConnect` and cache the `UserPayload` on the connection context, instead of re-validating on every subscription message (which produced thousands of error log lines per day on Azure)
- **Proactive socket close at expiry**: Schedule a `setTimeout` to close the WebSocket with code 4403 (retriable) when the token expires, so the client reconnects with a fresh token
- **Eager token refresh on close**: Client detects the 4403 close code and immediately calls `RefreshToken()` so retries use a fresh token instead of failing 3 times with the stale one
- **`connectionParams` as function**: Changed from static object to function form so each retry re-reads the current token

### Why this was happening
The `graphql-ws` `context` function runs on every operation (subscription message, keepalive). After token expiry (~1hr), each invocation logged two error lines. With keepalives every 30s and multiple browser tabs, this produced 12,000+ log lines per day per Azure instance.

### Close code choice
- **4401** is reserved as fatal ("Unauthorized") in the graphql-ws protocol — client would never retry
- **4403** (Forbidden) is explicitly retriable — client retries with backoff

## Test plan
- [x] Built both `@memberjunction/server` and `@memberjunction/graphql-dataprovider`
- [x] All 471 tests pass (223 MJServer + 248 GraphQLDataProvider)
- [x] Tested locally with 60s expiry cap — verified WebSocket reconnects cleanly in browser Network/Socket tab
- [x] Verified "Server connectivity lost / restored" cycle works correctly
- [ ] Deploy to Azure staging and verify no log spam after 1hr token expiry

🤖 Generated with [Claude Code](https://claude.com/claude-code)