### PR TITLE
fix(explorer): keep tabs and dynamic nav items in sync with saved records

### DIFF
--- a/.changeset/quiet-tabs-resync.md
+++ b/.changeset/quiet-tabs-resync.md
@@ -1,0 +1,10 @@
+---
+"@memberjunction/ng-shared": patch
+"@memberjunction/ng-base-application": patch
+"@memberjunction/ng-explorer-core": patch
+"@memberjunction/ng-dashboards": patch
+"@memberjunction/ng-bootstrap": patch
+"@memberjunction/ng-bootstrap-lite": patch
+---
+
+Fix several entity-record save flow issues in MJ Explorer: re-key the tab and component cache when a "Create New Record" form transitions to a saved record so subsequent new-record clicks open a blank form; correct the URL-segment format used by ResourceRecordSaved so the form no longer fails to reload after save with a doubled-prefix key; wire up the previously no-op tab title refresh after save (including refreshing the Home app's dynamic nav-item label) so the user sees the latest entity name without navigating away.

--- a/packages/Angular/Bootstrap/src/generated/mj-class-registrations.ts
+++ b/packages/Angular/Bootstrap/src/generated/mj-class-registrations.ts
@@ -1109,7 +1109,7 @@ export const CLASS_REGISTRATIONS: any[] = [
 export const CLASS_REGISTRATIONS_MANIFEST_LOADED = true;
 
 /** Total @RegisterClass decorated classes discovered in dependency tree */
-export const CLASS_REGISTRATIONS_COUNT = 512;
+export const CLASS_REGISTRATIONS_COUNT = 513;
 
 /** Packages imported by this manifest */
 export const CLASS_REGISTRATIONS_PACKAGES = [

--- a/packages/Angular/BootstrapLite/src/generated/mj-class-registrations.ts
+++ b/packages/Angular/BootstrapLite/src/generated/mj-class-registrations.ts
@@ -907,7 +907,7 @@ export const CLASS_REGISTRATIONS: any[] = [
 export const CLASS_REGISTRATIONS_MANIFEST_LOADED = true;
 
 /** Total @RegisterClass decorated classes discovered in dependency tree */
-export const CLASS_REGISTRATIONS_COUNT = 415;
+export const CLASS_REGISTRATIONS_COUNT = 416;
 
 /** Packages imported by this manifest */
 export const CLASS_REGISTRATIONS_PACKAGES = [

--- a/packages/Angular/Explorer/base-application/src/lib/__tests__/base-application.test.ts
+++ b/packages/Angular/Explorer/base-application/src/lib/__tests__/base-application.test.ts
@@ -287,6 +287,58 @@ describe('WorkspaceStateManager', () => {
     });
   });
 
+  describe('UpdateTabResourceRecordId', () => {
+    it('should re-key a new-record tab to its saved record id', async () => {
+      const { createDefaultWorkspaceConfiguration } = await import('../interfaces/workspace-configuration.interface');
+      manager.UpdateConfiguration(createDefaultWorkspaceConfiguration());
+
+      // Simulate "Create New Record" — empty resourceRecordId, isNew flag in configuration
+      const tabId = manager.OpenTab(
+        {
+          ApplicationId: 'app-1',
+          Title: 'New Entities',
+          IsPinned: true,
+          Configuration: { resourceType: 'Records', Entity: 'Entities', recordId: '', isNew: true },
+          ResourceRecordId: ''
+        },
+        '#ff0000'
+      );
+
+      const newId = 'abc-123-uuid';
+      manager.UpdateTabResourceRecordId(tabId, newId);
+
+      const tab = manager.GetTab(tabId)!;
+      expect(tab.resourceRecordId).toBe(newId);
+      expect(tab.configuration.recordId).toBe(newId);
+      expect(tab.configuration.isNew).toBeUndefined();
+    });
+
+    it('should be a no-op when configuration is not initialized', () => {
+      // No throw, no crash — just silently does nothing.
+      expect(() => manager.UpdateTabResourceRecordId('nonexistent', 'xyz')).not.toThrow();
+    });
+
+    it('should leave OTHER tabs untouched when re-keying one tab', async () => {
+      const { createDefaultWorkspaceConfiguration } = await import('../interfaces/workspace-configuration.interface');
+      manager.UpdateConfiguration(createDefaultWorkspaceConfiguration());
+
+      // Use OpenTabForced to create separate pinned tabs (OpenTab replaces temp tabs)
+      const newRecordTabId = manager.OpenTabForced(
+        { ApplicationId: 'app-1', Title: 'New', IsPinned: true, Configuration: { resourceType: 'Records', Entity: 'Foo' }, ResourceRecordId: '' },
+        '#ff0000'
+      );
+      const otherTabId = manager.OpenTabForced(
+        { ApplicationId: 'app-1', Title: 'Other', IsPinned: true, Configuration: { resourceType: 'Records', Entity: 'Bar' }, ResourceRecordId: 'bar-id' },
+        '#ff0000'
+      );
+
+      manager.UpdateTabResourceRecordId(newRecordTabId, 'foo-saved');
+
+      expect(manager.GetTab(newRecordTabId)!.resourceRecordId).toBe('foo-saved');
+      expect(manager.GetTab(otherTabId)!.resourceRecordId).toBe('bar-id');
+    });
+  });
+
   describe('CloseOtherTabs', () => {
     it('should close all tabs except specified one', async () => {
       const { createDefaultWorkspaceConfiguration } = await import('../interfaces/workspace-configuration.interface');

--- a/packages/Angular/Explorer/base-application/src/lib/workspace-state-manager.ts
+++ b/packages/Angular/Explorer/base-application/src/lib/workspace-state-manager.ts
@@ -654,6 +654,43 @@ export class WorkspaceStateManager {
   }
 
   /**
+   * Update a tab's top-level `resourceRecordId` (and mirror it into `configuration.recordId`).
+   *
+   * Used when a "new record" tab transitions to a saved record — the tab was opened with
+   * an empty recordId, but once the user saves, the tab now represents an actual record.
+   * Without this, the next "Create New Record" request would match this tab (both have
+   * empty `resourceRecordId`) and focus the stale form instead of opening a fresh one.
+   *
+   * Also clears `configuration.isNew` since the record now exists.
+   */
+  UpdateTabResourceRecordId(tabId: string, newRecordId: string): void {
+    const config = this.configuration$.value;
+    if (!config) {
+      return;
+    }
+
+    const updatedTabs = config.tabs.map(tab => {
+      if (tab.id === tabId) {
+        const { isNew: _isNew, ...restConfig } = tab.configuration;
+        return {
+          ...tab,
+          resourceRecordId: newRecordId,
+          configuration: {
+            ...restConfig,
+            recordId: newRecordId
+          }
+        };
+      }
+      return tab;
+    });
+
+    this.UpdateConfiguration({
+      ...config,
+      tabs: updatedTabs
+    });
+  }
+
+  /**
    * Get the ID of the currently active tab
    */
   GetActiveTabId(): string | null {

--- a/packages/Angular/Explorer/dashboards/src/Home/home-application.ts
+++ b/packages/Angular/Explorer/dashboards/src/Home/home-application.ts
@@ -61,11 +61,16 @@ export class HomeApplication extends BaseApplication {
   private _storageLoadPromise: Promise<void> | null = null;
 
   /**
-   * Fingerprint of the last-processed active tab state (tabId::resourceRecordId).
+   * Fingerprint of the last-processed active tab state (tabId::resourceRecordId::title).
    * Guards against redundant stack mutations while still detecting content changes.
    * In single-resource mode the tab ID stays constant when navigating between records
    * (OpenTab replaces the temp tab's content but keeps its ID), so we must also
    * include the resourceRecordId to detect when the tab shows a different record.
+   *
+   * Title is also included so an in-place display-name change (e.g. user edits a
+   * record's Name field and saves — tabId and resourceRecordId stay the same but the
+   * title changes) triggers a re-evaluation. Without this, the dynamic nav item keeps
+   * showing the pre-edit name forever.
    */
   private _lastSeenTabFingerprint: string | null = null;
 
@@ -223,10 +228,25 @@ export class HomeApplication extends BaseApplication {
       return;
     }
 
-    // Build a fingerprint from tab ID + record content. In single-resource mode,
-    // OpenTab replaces the temp tab's content but keeps the same tab ID, so we
-    // need the resourceRecordId to detect when a different record is shown.
-    const fingerprint = `${activeTab.id}::${activeTab.resourceRecordId ?? ''}`;
+    // ALWAYS refresh the matching snapshot's label first — BEFORE the fingerprint
+    // bail. A burst of configuration$ emissions (typical on save) causes multiple
+    // concurrent updateCachedData calls; the first one proceeds past the fingerprint
+    // check and gets stuck awaiting createSnapshotIfOrphan, while the rest bail at
+    // fingerprint and race ahead with the *stale* snapshot. By the time the first
+    // call's async work completes and updates the snapshot, the gen-check in
+    // AppNav.updateCachedData has already discarded its results. The user is left
+    // with the right data in memory but rendered against the wrong label.
+    //
+    // Refreshing here is cheap (cache hit after my save-handler's pre-warm) and
+    // ensures every call — even fast bailers — produces fresh dynamic nav items.
+    await this.refreshExistingSnapshotLabel(activeTab);
+
+    // Build a fingerprint from tab ID + record content + title. In single-resource
+    // mode, OpenTab replaces the temp tab's content but keeps the same tab ID, so we
+    // need the resourceRecordId to detect when a different record is shown. Title is
+    // included so an in-place rename (record's Name field edited and saved — tabId
+    // and resourceRecordId stay the same but title changes) also triggers a refresh.
+    const fingerprint = `${activeTab.id}::${activeTab.resourceRecordId ?? ''}::${activeTab.title ?? ''}`;
     if (fingerprint === this._lastSeenTabFingerprint) {
       return;
     }
@@ -239,9 +259,13 @@ export class HomeApplication extends BaseApplication {
       return;
     }
 
-    // If this item is already in the stack, leave the order unchanged.
-    // Reordering on every click is visually jarring — items shift around
-    // while the user is clicking between existing nav items.
+    // If this item is already in the stack, leave the ORDER unchanged (reordering
+    // on every click is visually jarring) — but DO refresh its `resolvedLabel` if the
+    // underlying display name has changed. Without this, editing a record's Name
+    // field would leave the dynamic nav item showing the pre-edit name forever.
+    // Already-tracked snapshots are kept in their existing position (no jarring
+    // reorder) and have their label kept fresh by refreshExistingSnapshotLabel
+    // above — so here we only need to handle the NEW-snapshot case.
     const alreadyTracked = this.recentOrphanStack.some(
       s => s.resourceRecordId === snapshot.resourceRecordId
     );
@@ -256,6 +280,42 @@ export class HomeApplication extends BaseApplication {
     }
 
     this.saveStackToStorage();
+  }
+
+  /**
+   * Refreshes an already-tracked snapshot's `resolvedLabel` against the latest cached
+   * record name. Called unconditionally at the top of `updateRecentStack` (BEFORE the
+   * fingerprint bail), so even no-op-fingerprint calls don't render stale labels.
+   *
+   * Why this matters: when a record is saved, `configuration$` typically emits multiple
+   * times in quick succession (UpdateTabTitle, UpdateConfiguration, etc.). AppNav's
+   * subscription kicks off a `updateCachedData` for each. The first call wins the
+   * fingerprint race and starts the slow async `createSnapshotIfOrphan` chain;
+   * subsequent calls bail at fingerprint and race ahead with the still-unrefreshed
+   * snapshot. AppNav's `_updateGeneration` then discards the slow call's results.
+   * Without this method, the freshly-saved label lands in the snapshot — but never
+   * makes it to the rendered nav until some unrelated event triggers another cycle.
+   */
+  private async refreshExistingSnapshotLabel(activeTab: WorkspaceTab): Promise<void> {
+    if (!activeTab.resourceRecordId) {
+      return;
+    }
+    const existing = this.recentOrphanStack.find(
+      s => s.resourceRecordId === activeTab.resourceRecordId
+    );
+    if (!existing || !existing.entityName) {
+      return;
+    }
+    const newLabel = await this.resolveRecordLabel(
+      existing.entityName,
+      activeTab.resourceRecordId,
+      activeTab.title
+    );
+    if (newLabel && newLabel !== existing.resolvedLabel) {
+      existing.resolvedLabel = newLabel;
+      existing.title = activeTab.title;
+      this.saveStackToStorage();
+    }
   }
 
   /**

--- a/packages/Angular/Explorer/explorer-core/src/lib/shell/components/header/app-nav.component.ts
+++ b/packages/Angular/Explorer/explorer-core/src/lib/shell/components/header/app-nav.component.ts
@@ -140,6 +140,18 @@ export class AppNavComponent implements OnInit, OnDestroy {
     const config = this.workspaceManager.GetConfiguration();
     this.updateActiveStates(config);
     this.cdr.markForCheck();
+
+    // In Angular 21 zoneless mode, markForCheck() alone is unreliable when the trigger
+    // is an RxJS subscription (workspaceManager.Configuration here) not tracked by the
+    // zoneless scheduler — the dirty flag is set but no follow-up tick is scheduled.
+    // detectChanges() runs CD synchronously on this view, rendering the new data
+    // immediately. Wrapped because detectChanges throws if invoked re-entrantly during
+    // another in-flight CD pass — harmless if so.
+    try {
+      this.cdr.detectChanges();
+    } catch {
+      // Re-entrant CD — harmless, the in-flight pass picks up our markForCheck.
+    }
   }
 
   /**

--- a/packages/Angular/Explorer/explorer-core/src/lib/shell/components/tabs/component-cache-manager.ts
+++ b/packages/Angular/Explorer/explorer-core/src/lib/shell/components/tabs/component-cache-manager.ts
@@ -179,6 +179,45 @@ export class ComponentCacheManager {
   }
 
   /**
+   * Re-key a cached component when its underlying record identity changes.
+   *
+   * Used when a "new record" component (cached at `recordId = ''`) becomes a saved record
+   * (now identified by its new PK). Without re-keying, the next "new record" request would
+   * still resolve to this same cache entry, surfacing the previously-saved record on a form
+   * the user expects to be blank.
+   *
+   * Preserves the live component instance — only the cache key + stored identity change.
+   * Returns true if a matching entry was found and re-keyed, false otherwise.
+   */
+  rekeyComponent(
+    resourceType: string,
+    oldRecordId: string,
+    newRecordId: string,
+    appId: string
+  ): boolean {
+    const oldKey = this.getCacheKey(resourceType, oldRecordId, appId);
+    const info = this.cache.get(oldKey);
+    if (!info) {
+      return false;
+    }
+
+    const newKey = this.getCacheKey(resourceType, newRecordId, appId);
+    if (oldKey === newKey) {
+      return false;
+    }
+
+    info.resourceRecordId = newRecordId;
+    info.lastUsed = new Date();
+    if (info.resourceData) {
+      info.resourceData.ResourceRecordID = newRecordId;
+    }
+
+    this.cache.delete(oldKey);
+    this.cache.set(newKey, info);
+    return true;
+  }
+
+  /**
    * Find a cached component by tab ID and detach it.
    * This is a convenience wrapper for callers that only know the tab ID
    * (e.g., Golden Layout tab close events). It resolves the tab ID to

--- a/packages/Angular/Explorer/explorer-core/src/lib/shell/components/tabs/tab-container.component.ts
+++ b/packages/Angular/Explorer/explorer-core/src/lib/shell/components/tabs/tab-container.component.ts
@@ -31,7 +31,7 @@ import { MJGlobal } from '@memberjunction/global';
 import { BaseResourceComponent, HomeAppPinService } from '@memberjunction/ng-shared';
 import { ResourceData, MJResourceTypeEntity, ResourcePermissionEngine } from '@memberjunction/core-entities';
 import { MJNotificationService } from '@memberjunction/ng-notifications';
-import { DatasetResultType, LogError, Metadata } from '@memberjunction/core';
+import { BaseEntity, DatasetResultType, LogError, Metadata } from '@memberjunction/core';
 import { ComponentCacheManager, CachedComponentInfo } from './component-cache-manager';
 
 import { BaseAngularComponent } from '@memberjunction/ng-base-types';
@@ -646,6 +646,12 @@ export class TabContainerComponent extends BaseAngularComponent implements OnIni
       }
     };
 
+    // When a record is saved, re-key the tab and cache (new-record → saved transition)
+    // and refresh the tab title to reflect the entity's current display name.
+    instance.ResourceRecordSavedEvent = (entity: BaseEntity) => {
+      this.handleResourceRecordSaved(driverClass, activeTab.applicationId, activeTab.id, instance, entity);
+    };
+
     // Get the native element and append to container
     const nativeElement = (componentRef.hostView as unknown as { rootNodes: HTMLElement[] }).rootNodes[0];
     container.appendChild(nativeElement);
@@ -734,6 +740,110 @@ export class TabContainerComponent extends BaseAngularComponent implements OnIni
         container.removeChild(container.firstChild);
       }
     }
+  }
+
+  /**
+   * Handle a record-saved event from a hosted resource component.
+   *
+   * Does two things on every save:
+   *
+   * 1. **Re-key new-record tabs.** When a tab opened as "Create New Record" (empty
+   *    `resourceRecordId`) transitions to a saved record, we update both the workspace
+   *    tab's id and the component-cache key to the new PK. Without this, the next
+   *    `OpenNewEntityRecord(<sameEntity>)` would match this tab (both have empty
+   *    `resourceRecordId`) and focus the stale form instead of opening a fresh one.
+   *    For existing records being re-saved, this step is a no-op.
+   *
+   * 2. **Refresh the tab title.** Whether new or existing, the entity's display name
+   *    (typically its `Name` field) may have changed. We call the resource component's
+   *    `GetResourceDisplayName` and push the result to the tab — so a tab that read
+   *    "New Foo Record" before save now reads the actual entered name.
+   */
+  private handleResourceRecordSaved(
+    driverClass: string,
+    appId: string,
+    tabId: string,
+    instance: BaseResourceComponent,
+    entity: BaseEntity
+  ): void {
+    const tab = this.workspaceManager.GetTab(tabId);
+    if (!tab) {
+      return;
+    }
+
+    const oldRecordId = tab.resourceRecordId || '';
+    // ToURLSegment, NOT ToString — must match the format NavigationService.OpenEntityRecord
+    // uses and that EntityRecordResource.GetPrimaryKey expects via LoadFromURLSegment.
+    const newRecordId = entity?.PrimaryKey?.ToURLSegment?.() ?? '';
+    const isNewRecordTransition = oldRecordId === '' && !!newRecordId;
+
+    if (isNewRecordTransition) {
+      // Re-key the cache entry first, so when the workspace config emission triggers
+      // signature/needsReload checks below, the cache lookup at the new id succeeds.
+      this.cacheManager.rekeyComponent(driverClass, oldRecordId, newRecordId, appId);
+
+      // Keep the in-memory single-resource identity in sync so detach uses the correct key.
+      if (this.singleResourceCacheIdentity?.tabId === tabId) {
+        this.singleResourceCacheIdentity = {
+          ...this.singleResourceCacheIdentity,
+          recordId: newRecordId
+        };
+      }
+
+      // Pre-compute and stamp the new signature so the configuration-subscription path
+      // in single-resource mode doesn't see a "content changed" delta and trigger a
+      // needless reload cycle (which would destroy the currently attached component).
+      if (this.useSingleResourceMode && this.currentSingleResourceSignature !== null) {
+        const updatedTab: WorkspaceTab = {
+          ...tab,
+          resourceRecordId: newRecordId,
+          configuration: { ...tab.configuration, recordId: newRecordId, isNew: undefined }
+        };
+        this.currentSingleResourceSignature = this.getTabContentSignature(updatedTab);
+      }
+
+      // Propagate the new id to the workspace tab.
+      this.workspaceManager.UpdateTabResourceRecordId(tabId, newRecordId);
+    }
+
+    // Always refresh the tab title — the entity's display-name field (typically Name)
+    // may have just been set or changed. Done after the rekey so the resource component's
+    // Data.ResourceRecordID reflects the saved PK before GetResourceDisplayName reads it.
+    //
+    // ProviderBase caches GetEntityRecordName results, so a plain call here would return
+    // the pre-edit name. Pre-warm the cache with a forceRefresh so the downstream read
+    // inside GetResourceDisplayName picks up the saved name. Only meaningful for entity
+    // records with a PK; other resource types' GetResourceDisplayName doesn't hit the
+    // record-name cache and will work either way.
+    void this.refreshTabTitleAfterSave(tabId, instance, entity);
+  }
+
+  /**
+   * After a save, invalidate the entity-record-name cache for the saved record and then
+   * push the resource component's current display name into the tab title.
+   *
+   * Errors are swallowed (logged via the inner call paths) — failing to refresh a tab
+   * title should never break the save flow.
+   */
+  private async refreshTabTitleAfterSave(
+    tabId: string,
+    instance: BaseResourceComponent,
+    entity: BaseEntity
+  ): Promise<void> {
+    try {
+      const entityName = entity?.EntityInfo?.Name;
+      const pk = entity?.PrimaryKey;
+      if (entityName && pk?.HasValue) {
+        // forceRefresh: true overwrites the cached (pre-edit) name with the fresh one.
+        // GetResourceDisplayName (called next) reads the same cache and now sees fresh data.
+        const md = instance.ProviderToUse;
+        await md.GetEntityRecordName(entityName, pk, md.CurrentUser, true);
+      }
+    } catch {
+      // Cache pre-warm failures are non-fatal — the title update below will fall back
+      // to whatever the cache has and the user can still interact with the form.
+    }
+    await this.updateTabTitleFromResource(tabId, instance, instance.Data);
   }
 
   /**
@@ -902,11 +1012,8 @@ export class TabContainerComponent extends BaseAngularComponent implements OnIni
         this.emitFirstLoadCompleteOnce();
       };
 
-      instance.ResourceRecordSavedEvent = (entity: { Get?: (key: string) => unknown }) => {
-        // Update tab title if needed
-        if (entity && entity.Get && entity.Get('Name')) {
-          // TODO: Implement UpdateTabTitle in WorkspaceStateManager
-        }
+      instance.ResourceRecordSavedEvent = (entity: BaseEntity) => {
+        this.handleResourceRecordSaved(driverClass, tab.applicationId, tabId, instance, entity);
       };
 
       // Wire up display name change notifications

--- a/packages/Angular/Explorer/explorer-core/src/lib/single-record/single-record.component.ts
+++ b/packages/Angular/Explorer/explorer-core/src/lib/single-record/single-record.component.ts
@@ -17,8 +17,44 @@ import { BaseAngularComponent } from '@memberjunction/ng-base-types';
 })
 export class SingleRecordComponent extends BaseAngularComponent implements OnInit, AfterViewInit, OnDestroy {
   @ViewChild(Container, {static: true}) formContainer!: Container;
-  @Input() public PrimaryKey: CompositeKey = new CompositeKey();
-  @Input() public entityName: string | null = '';
+
+  private _primaryKey: CompositeKey = new CompositeKey();
+  @Input()
+  public set PrimaryKey(value: CompositeKey) {
+    const changed = !this.compositeKeysEqual(this._primaryKey, value);
+    this._primaryKey = value ?? new CompositeKey();
+    if (!changed || !this._viewInitialized) {
+      return;
+    }
+    // Skip reload when the incoming key just reflects the current record's now-saved PK.
+    // After a new-record save, BaseResourceComponent updates parent.Data.ResourceRecordID,
+    // the parent's PrimaryKey getter then returns a fresh CK with the saved ID, and Angular
+    // pushes it down to us. The form already represents that record in-place — destroying
+    // and rebuilding it here would lose edit state, refetch from DB, and spawn a redundant
+    // GetRecordFavoriteStatus call. Genuine external swaps (parent rebinds to a different
+    // record) still trigger the reload because `value` won't match `_currentRecord.PrimaryKey`.
+    if (this._currentRecord && this.compositeKeysEqual(value, this._currentRecord.PrimaryKey)) {
+      return;
+    }
+    this.reloadCurrentForm();
+  }
+  public get PrimaryKey(): CompositeKey {
+    return this._primaryKey;
+  }
+
+  private _entityName: string | null = '';
+  @Input()
+  public set entityName(value: string | null) {
+    const changed = this._entityName !== value;
+    this._entityName = value;
+    if (changed && this._viewInitialized) {
+      this.reloadCurrentForm();
+    }
+  }
+  public get entityName(): string | null {
+    return this._entityName;
+  }
+
   @Input() public newRecordValues: string | Record<string, unknown> | null = '';
 
   @Output() public loadComplete: EventEmitter<any> = new EventEmitter<any>();
@@ -46,12 +82,80 @@ export class SingleRecordComponent extends BaseAngularComponent implements OnIni
   private _currentRecord: BaseEntity | null = null;
   private _eventHandlerSubscription: Subscription | null = null;
   private _formEventSubscriptions: Subscription[] = [];
+  private _viewInitialized = false;
 
   ngOnInit(): void {
   }
 
   ngAfterViewInit() {
-    this.LoadForm(this.PrimaryKey, <string>this.entityName)
+    this._viewInitialized = true;
+    this.LoadForm(this._primaryKey, <string>this._entityName)
+  }
+
+  /**
+   * Re-run LoadForm when an @Input changes after initial view init.
+   *
+   * Defense-in-depth: the tab/cache rekey on save (in TabContainerComponent) is the
+   * primary fix that prevents stale-form bugs after creating a new record. This setter
+   * path ensures we self-heal if a host ever swaps the bound inputs without recreating
+   * the component — without it, LoadForm only ever runs once per component instance.
+   *
+   * Tears down the previous form (component, record, event handlers) before loading the
+   * new one so we don't leak references or stack multiple forms in the container.
+   */
+  private reloadCurrentForm(): void {
+    this.teardownActiveForm();
+    if (!this._entityName) {
+      return;
+    }
+    this.loading = true;
+    this.LoadForm(this._primaryKey, this._entityName);
+  }
+
+  /**
+   * Compare two CompositeKey instances by their key/value contents.
+   * Two different instances representing the same key should NOT count as a change.
+   *
+   * Filters out KVPs with empty Values before comparing. Different callers represent
+   * "no key" differently — some use an empty KeyValuePairs list, others use a single
+   * KVP with an empty Value (e.g. `LoadFromURLSegment(entity, '')`). Both mean the
+   * same thing semantically and must not trigger a change.
+   */
+  private compositeKeysEqual(a: CompositeKey | null | undefined, b: CompositeKey | null | undefined): boolean {
+    if (a === b) return true;
+    if (!a || !b) return false;
+    const aKvps = (a.KeyValuePairs || []).filter(kvp => String(kvp.Value ?? '').length > 0);
+    const bKvps = (b.KeyValuePairs || []).filter(kvp => String(kvp.Value ?? '').length > 0);
+    if (aKvps.length !== bKvps.length) return false;
+    for (let i = 0; i < aKvps.length; i++) {
+      if (aKvps[i].FieldName !== bKvps[i].FieldName) return false;
+      if (String(aKvps[i].Value ?? '') !== String(bKvps[i].Value ?? '')) return false;
+    }
+    return true;
+  }
+
+  /**
+   * Tear down the currently rendered form so a new one can be loaded in its place.
+   * Mirrors the cleanup done in ngOnDestroy, minus the final state reset.
+   */
+  private teardownActiveForm(): void {
+    this.cleanupFormSubscriptions();
+
+    if (this._eventHandlerSubscription) {
+      this._eventHandlerSubscription.unsubscribe();
+      this._eventHandlerSubscription = null;
+    }
+
+    if (this._formComponentRef) {
+      try { this._formComponentRef.destroy(); } catch { /* noop */ }
+      this._formComponentRef = null;
+    }
+
+    this._currentRecord = null;
+
+    if (this.formContainer?.viewContainerRef) {
+      this.formContainer.viewContainerRef.clear();
+    }
   }
 
   public async LoadForm(primaryKey: CompositeKey, entityName: string) {
@@ -63,15 +167,18 @@ export class SingleRecordComponent extends BaseAngularComponent implements OnIni
       return;
     }
 
-    this.entityName = entityName;
-    if (primaryKey.HasValue) {
-      // we have an existing record to load up
-      this.PrimaryKey = primaryKey;
-    }
-    else {
-      // new record, no existing primary key
-      this.PrimaryKey = new CompositeKey();
-    }
+    // Write through to backing fields directly. Going through the setters here would
+    // re-trigger reloadCurrentForm() and recurse — we're already inside LoadForm.
+    //
+    // Use the parameter as-is rather than substituting `new CompositeKey()` for the
+    // !HasValue branch. The parent's getter (e.g. EntityRecordResource.GetPrimaryKey)
+    // builds its CK via `LoadFromURLSegment(entity, '')`, which yields `[{FieldName: 'ID',
+    // Value: ''}]` for a new record — a single KVP with an empty value, NOT an empty
+    // KVP list. Substituting an empty CK here creates a structural mismatch that makes
+    // the setter's compositeKeysEqual see a phantom change on the very next CD cycle,
+    // which triggers reload → LoadForm → CD → setter → reload (infinite loop).
+    this._entityName = entityName;
+    this._primaryKey = primaryKey ?? new CompositeKey();
 
     const md = this.ProviderToUse;
     const entity = md.EntityByName(entityName);

--- a/packages/Angular/Explorer/shared/src/lib/base-resource-component.ts
+++ b/packages/Angular/Explorer/shared/src/lib/base-resource-component.ts
@@ -222,7 +222,12 @@ export abstract class BaseResourceComponent extends BaseNavigationComponent impl
     }
 
     protected ResourceRecordSaved(resourceRecordEntity: BaseEntity) {
-        this.Data.ResourceRecordID = resourceRecordEntity.PrimaryKey.ToString();
+        // Use ToURLSegment, NOT ToString. ResourceRecordID is consumed by
+        // EntityRecordResource.GetPrimaryKey → CompositeKey.LoadFromURLSegment, which
+        // expects URL-segment format (e.g. "ID|<uuid>"). ToString produces "ID=<uuid>",
+        // which LoadFromURLSegment treats as a raw value and double-prefixes —
+        // breaking any code path that re-reads this field after save.
+        this.Data.ResourceRecordID = resourceRecordEntity.PrimaryKey.ToURLSegment();
         if (this._resourceRecordSavedEvent) {
             this._resourceRecordSavedEvent(resourceRecordEntity);
         }


### PR DESCRIPTION
## Summary
- Re-key the tab and component cache when a "Create New Record" form transitions to a saved record, so subsequent "Create New Record" requests open a fresh form instead of focusing the stale one (the originally-reported bug).
- Fix a latent bug in `BaseResourceComponent.ResourceRecordSaved` that wrote `Data.ResourceRecordID` via `.ToString()` ("ID=<uuid>") instead of `.ToURLSegment()` ("ID|<uuid>"), causing a doubled-prefix key and `InnerLoad` failure after save.
- Wire up the previously no-op tab-title refresh after save, including pre-warming the provider's `_entityRecordNameCache` with `forceRefresh` so the freshly-saved Name is rendered everywhere it's read.
- Fix the Home app's dynamic nav-item label (recent-orphan stack snapshot) staying frozen at its capture-time value — `HomeApplication` now refreshes the matching snapshot's `resolvedLabel` unconditionally on each `updateRecentStack`, avoiding a race between concurrent `updateCachedData` calls.
- Defensive setter-based input change detection on `SingleRecordComponent` to self-heal if inputs are swapped without recreating the component, tolerant of structural `CompositeKey` variants to avoid infinite loops.
- `AppNavComponent` pairs `markForCheck` with `detectChanges` so RxJS-driven updates render synchronously in Angular 21 zoneless mode.

## Test plan
- [ ] From any View, click "Create New Record" → fill out → Save → go back to the View → click "Create New Record" again → form opens blank (no stale data from previous save).
- [ ] Edit an existing entity record's Name field → Save → tab title at the top updates to the new Name immediately (no navigation required).
- [ ] Edit an existing record's Name field → Save → the Home app's dynamic nav-item label updates to the new Name immediately.
- [ ] After saving a new record, no `InnerLoad` errors and no "Entity Form Overrides" error spam in console; the form stays in place (no destroy/rebuild flicker).
- [ ] Save an existing record that was opened via a normal "open record" flow — title and nav both still update; no regressions.
- [ ] Run `cd packages/Angular/Explorer/base-application && npx vitest run` — all 19 tests pass (16 pre-existing + 3 new for `UpdateTabResourceRecordId`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)