### PR TITLE
fix(explorer): isolate new-record cache by entity + clean up on discard

### DIFF
--- a/.changeset/clever-forms-dismiss.md
+++ b/.changeset/clever-forms-dismiss.md
@@ -1,0 +1,7 @@
+---
+"@memberjunction/ng-base-forms": patch
+"@memberjunction/ng-shared": patch
+"@memberjunction/ng-explorer-core": patch
+---
+
+Fix two new-record form lifecycle issues in MJ Explorer: add an entity-name discriminator to the component cache key so distinct "new record" tabs of different entities no longer collide (clicking "+ New Record" on one entity after opening another no longer reuses the wrong form), and close the tab when the user clicks Discard on a never-saved record (via a new 'dismiss' FormNavigationEvent kind that destroys the cached component so the next "Create New Record" click for the same entity gets a fresh edit-mode form instead of the stale view-mode one).

--- a/packages/Angular/Explorer/explorer-core/src/lib/resource-wrappers/record-resource.component.ts
+++ b/packages/Angular/Explorer/explorer-core/src/lib/resource-wrappers/record-resource.component.ts
@@ -8,7 +8,7 @@ import { Metadata, CompositeKey, EntityInfo, IMetadataProvider } from '@memberju
   standalone: false,
     selector: 'mj-record-resource',
     styles: [`:host { display: block; height: 100%; width: 100%; }`],
-    template: `<mj-single-record [PrimaryKey]="this.PrimaryKey" [entityName]="Data.Configuration.Entity" [newRecordValues]="Data.Configuration.NewRecordValues" (loadComplete)="NotifyLoadComplete()" (recordSaved)="ResourceRecordSaved($event)" ></mj-single-record>`
+    template: `<mj-single-record [PrimaryKey]="this.PrimaryKey" [entityName]="Data.Configuration.Entity" [newRecordValues]="Data.Configuration.NewRecordValues" (loadComplete)="NotifyLoadComplete()" (recordSaved)="ResourceRecordSaved($event)" (recordDismissed)="NotifyCloseRequested()"></mj-single-record>`
 })
 export class EntityRecordResource extends BaseResourceComponent {
     public get PrimaryKey(): CompositeKey {

--- a/packages/Angular/Explorer/explorer-core/src/lib/shell/components/tabs/component-cache-manager.ts
+++ b/packages/Angular/Explorer/explorer-core/src/lib/shell/components/tabs/component-cache-manager.ts
@@ -17,6 +17,12 @@ export interface CachedComponentInfo {
   resourceRecordId: string;
   applicationId: string;
 
+  // Optional tiebreaker used when recordId is empty (e.g., "new record" tabs for
+  // different entities all have recordId='' but must NOT share a cache entry).
+  // For entity-record resources this is the entity name; null/undefined for
+  // resource types that don't need disambiguation.
+  keyDiscriminator?: string;
+
   // Usage tracking
   isAttached: boolean;        // Currently attached to a tab/container?
   attachedToTabId: string | null;  // Which tab is it attached to? (metadata only, NOT used for lookup)
@@ -74,17 +80,24 @@ export class ComponentCacheManager {
   /**
    * Generate a unique cache key from resource identity.
    * This is the ONE canonical key format used by ALL cache operations.
+   *
+   * `discriminator` is appended into the recordId slot only when recordId is empty.
+   * It exists to prevent collisions between distinct "new record" tabs that share
+   * an empty recordId — e.g., a new MJ:Companies form and a new MJ:Employees form
+   * would otherwise both cache at `appId::RecordResource::__no_record__` and clobber
+   * each other. Passing the entity name as discriminator keeps them separate.
    */
-  private getCacheKey(resourceType: string, recordId: string, appId: string): string {
-    const normalizedRecordId = recordId || '__no_record__';
+  private getCacheKey(resourceType: string, recordId: string, appId: string, discriminator?: string): string {
+    const normalizedRecordId = recordId
+      || (discriminator ? `__new__::${discriminator}` : '__no_record__');
     return `${appId}::${resourceType}::${normalizedRecordId}`;
   }
 
   /**
    * Check if a component exists in cache and is available for reuse.
    */
-  hasAvailableComponent(resourceType: string, recordId: string, appId: string): boolean {
-    const key = this.getCacheKey(resourceType, recordId, appId);
+  hasAvailableComponent(resourceType: string, recordId: string, appId: string, discriminator?: string): boolean {
+    const key = this.getCacheKey(resourceType, recordId, appId, discriminator);
     const info = this.cache.get(key);
     return info !== undefined && !info.isAttached;
   }
@@ -93,8 +106,8 @@ export class ComponentCacheManager {
    * Get a cached component if available (not currently attached).
    * Lookup is by resource identity, not tab ID.
    */
-  getCachedComponent(resourceType: string, recordId: string, appId: string): CachedComponentInfo | null {
-    const key = this.getCacheKey(resourceType, recordId, appId);
+  getCachedComponent(resourceType: string, recordId: string, appId: string, discriminator?: string): CachedComponentInfo | null {
+    const key = this.getCacheKey(resourceType, recordId, appId, discriminator);
     const info = this.cache.get(key);
 
     if (!info) {
@@ -124,10 +137,14 @@ export class ComponentCacheManager {
     const resolvedResourceType = resourceData.Configuration?.resourceTypeDriverClass
       || resourceData.Configuration?.driverClass
       || resourceData.ResourceType;
+    // Entity name discriminates between distinct "new record" tabs (empty recordId).
+    // For non-Records resource types this is undefined, leaving the key unchanged.
+    const discriminator = resourceData.Configuration?.Entity as string | undefined;
     const key = this.getCacheKey(
       resolvedResourceType,
       resourceData.ResourceRecordID || '',
-      resourceData.Configuration?.applicationId || ''
+      resourceData.Configuration?.applicationId || '',
+      discriminator
     );
 
     const info: CachedComponentInfo = {
@@ -136,6 +153,7 @@ export class ComponentCacheManager {
       resourceType: resolvedResourceType,
       resourceRecordId: resourceData.ResourceRecordID || '',
       applicationId: resourceData.Configuration?.applicationId || '',
+      keyDiscriminator: discriminator,
       isAttached: true,
       attachedToTabId: tabId,
       lastUsed: new Date(),
@@ -149,8 +167,8 @@ export class ComponentCacheManager {
   /**
    * Mark a component as attached. Lookup by resource identity.
    */
-  markAsAttached(resourceType: string, recordId: string, appId: string, tabId: string): void {
-    const key = this.getCacheKey(resourceType, recordId, appId);
+  markAsAttached(resourceType: string, recordId: string, appId: string, tabId: string, discriminator?: string): void {
+    const key = this.getCacheKey(resourceType, recordId, appId, discriminator);
     const info = this.cache.get(key);
 
     if (info) {
@@ -166,8 +184,8 @@ export class ComponentCacheManager {
    * This is the ONLY way to detach a component. Both single-resource mode and
    * Golden Layout mode use this same method to ensure consistent cache behavior.
    */
-  markAsDetached(resourceType: string, recordId: string, appId: string): CachedComponentInfo | null {
-    const key = this.getCacheKey(resourceType, recordId, appId);
+  markAsDetached(resourceType: string, recordId: string, appId: string, discriminator?: string): CachedComponentInfo | null {
+    const key = this.getCacheKey(resourceType, recordId, appId, discriminator);
     const info = this.cache.get(key);
     if (!info) return null;
 
@@ -193,20 +211,25 @@ export class ComponentCacheManager {
     resourceType: string,
     oldRecordId: string,
     newRecordId: string,
-    appId: string
+    appId: string,
+    oldDiscriminator?: string,
+    newDiscriminator?: string
   ): boolean {
-    const oldKey = this.getCacheKey(resourceType, oldRecordId, appId);
+    const oldKey = this.getCacheKey(resourceType, oldRecordId, appId, oldDiscriminator);
     const info = this.cache.get(oldKey);
     if (!info) {
       return false;
     }
 
-    const newKey = this.getCacheKey(resourceType, newRecordId, appId);
+    // Once a record has a real id, the discriminator no longer matters (the id is unique).
+    // Default the new discriminator to undefined unless explicitly provided.
+    const newKey = this.getCacheKey(resourceType, newRecordId, appId, newDiscriminator);
     if (oldKey === newKey) {
       return false;
     }
 
     info.resourceRecordId = newRecordId;
+    info.keyDiscriminator = newDiscriminator;
     info.lastUsed = new Date();
     if (info.resourceData) {
       info.resourceData.ResourceRecordID = newRecordId;
@@ -230,7 +253,7 @@ export class ComponentCacheManager {
     if (!entry) return null;
 
     const [_, info] = entry;
-    return this.markAsDetached(info.resourceType, info.resourceRecordId, info.applicationId);
+    return this.markAsDetached(info.resourceType, info.resourceRecordId, info.applicationId, info.keyDiscriminator);
   }
 
   /**
@@ -266,8 +289,8 @@ export class ComponentCacheManager {
   /**
    * Remove and destroy a specific component from cache by resource identity.
    */
-  destroyComponent(resourceType: string, recordId: string, appId: string): void {
-    const key = this.getCacheKey(resourceType, recordId, appId);
+  destroyComponent(resourceType: string, recordId: string, appId: string, discriminator?: string): void {
+    const key = this.getCacheKey(resourceType, recordId, appId, discriminator);
     const info = this.cache.get(key);
 
     if (!info) return;

--- a/packages/Angular/Explorer/explorer-core/src/lib/shell/components/tabs/tab-container.component.ts
+++ b/packages/Angular/Explorer/explorer-core/src/lib/shell/components/tabs/tab-container.component.ts
@@ -92,7 +92,7 @@ export class TabContainerComponent extends BaseAngularComponent implements OnIni
   useSingleResourceMode = false;
   private singleResourceComponentRef: ComponentRef<BaseResourceComponent> | null = null;
   /** Cache identity of the current single-resource component for detachment */
-  private singleResourceCacheIdentity: { driverClass: string; recordId: string; appId: string; tabId: string } | null = null;
+  private singleResourceCacheIdentity: { driverClass: string; recordId: string; appId: string; tabId: string; discriminator?: string } | null = null;
   private previousTabBarVisible: boolean | null = null;
   private currentSingleResourceSignature: string | null = null; // Track loaded content signature to avoid unnecessary reloads
   private isCreatingInitialTabs = false; // Flag to prevent syncTabsWithConfiguration during initial tab creation
@@ -530,12 +530,16 @@ export class TabContainerComponent extends BaseAngularComponent implements OnIni
 
     // Get driver class for component lookup
     const driverClass = resourceData.Configuration?.resourceTypeDriverClass || resourceData.ResourceType;
+    // Entity name discriminates between "new record" tabs of different entities (all
+    // have empty ResourceRecordID otherwise). For non-Records resources this is undefined.
+    const cacheDiscriminator = resourceData.Configuration?.Entity as string | undefined;
 
     // **OPTIMIZATION: Check cache first to reuse existing loaded component**
     const cached = this.cacheManager.getCachedComponent(
       driverClass,
       resourceData.ResourceRecordID || '',
-      activeTab.applicationId
+      activeTab.applicationId,
+      cacheDiscriminator
     );
 
     if (cached) {
@@ -549,7 +553,8 @@ export class TabContainerComponent extends BaseAngularComponent implements OnIni
         driverClass,
         resourceData.ResourceRecordID || '',
         activeTab.applicationId,
-        activeTab.id
+        activeTab.id,
+        cacheDiscriminator
       );
 
       // Reattach the cached wrapper element to single-resource container
@@ -558,7 +563,7 @@ export class TabContainerComponent extends BaseAngularComponent implements OnIni
 
       // Store reference and identity for cleanup/detachment
       this.singleResourceComponentRef = cached.componentRef;
-      this.singleResourceCacheIdentity = { driverClass, recordId: resourceData.ResourceRecordID || '', appId: activeTab.applicationId, tabId: activeTab.id };
+      this.singleResourceCacheIdentity = { driverClass, recordId: resourceData.ResourceRecordID || '', appId: activeTab.applicationId, tabId: activeTab.id, discriminator: cacheDiscriminator };
 
       // Reconcile the cached component's preserved queryParams with any INCOMING navigation
       // intent already on the tab config (e.g. a Home pin / deep link that targeted a specific
@@ -652,6 +657,13 @@ export class TabContainerComponent extends BaseAngularComponent implements OnIni
       this.handleResourceRecordSaved(driverClass, activeTab.applicationId, activeTab.id, instance, entity);
     };
 
+    // Resource asked to be closed (e.g., user discarded a brand-new record — there's
+    // no actual record to view, so leaving the tab open serves no purpose and would
+    // also poison the cache for the next "Create New" click of the same entity).
+    instance.ResourceCloseRequestedEvent = () => {
+      this.handleResourceCloseRequested(activeTab.id, instance);
+    };
+
     // Get the native element and append to container
     const nativeElement = (componentRef.hostView as unknown as { rootNodes: HTMLElement[] }).rootNodes[0];
     container.appendChild(nativeElement);
@@ -672,7 +684,7 @@ export class TabContainerComponent extends BaseAngularComponent implements OnIni
 
     // Store reference and identity for cleanup/detachment
     this.singleResourceComponentRef = componentRef as ComponentRef<BaseResourceComponent>;
-    this.singleResourceCacheIdentity = { driverClass, recordId: resourceData.ResourceRecordID || '', appId: activeTab.applicationId, tabId: activeTab.id };
+    this.singleResourceCacheIdentity = { driverClass, recordId: resourceData.ResourceRecordID || '', appId: activeTab.applicationId, tabId: activeTab.id, discriminator: cacheDiscriminator };
   }
 
   /**
@@ -723,9 +735,9 @@ export class TabContainerComponent extends BaseAngularComponent implements OnIni
   private cleanupSingleResourceComponent(): void {
     if (this.singleResourceComponentRef) {
       if (this.singleResourceCacheIdentity) {
-        const { driverClass, recordId, appId } = this.singleResourceCacheIdentity;
+        const { driverClass, recordId, appId, discriminator } = this.singleResourceCacheIdentity;
         // Mark as DETACHED by resource identity — the ONE consistent key used everywhere.
-        this.cacheManager.markAsDetached(driverClass, recordId, appId);
+        this.cacheManager.markAsDetached(driverClass, recordId, appId, discriminator);
       }
       this.singleResourceComponentRef = null;
       this.singleResourceCacheIdentity = null;
@@ -776,17 +788,23 @@ export class TabContainerComponent extends BaseAngularComponent implements OnIni
     // uses and that EntityRecordResource.GetPrimaryKey expects via LoadFromURLSegment.
     const newRecordId = entity?.PrimaryKey?.ToURLSegment?.() ?? '';
     const isNewRecordTransition = oldRecordId === '' && !!newRecordId;
+    // The cache entry for an empty-recordId tab was keyed with the entity name as
+    // discriminator (to avoid new-record collisions across entities). Re-key has to
+    // pass that same old discriminator to find the entry. After save the record has
+    // a real PK, so the new key needs no discriminator.
+    const oldDiscriminator = tab.configuration?.['Entity'] as string | undefined;
 
     if (isNewRecordTransition) {
       // Re-key the cache entry first, so when the workspace config emission triggers
       // signature/needsReload checks below, the cache lookup at the new id succeeds.
-      this.cacheManager.rekeyComponent(driverClass, oldRecordId, newRecordId, appId);
+      this.cacheManager.rekeyComponent(driverClass, oldRecordId, newRecordId, appId, oldDiscriminator, undefined);
 
       // Keep the in-memory single-resource identity in sync so detach uses the correct key.
       if (this.singleResourceCacheIdentity?.tabId === tabId) {
         this.singleResourceCacheIdentity = {
           ...this.singleResourceCacheIdentity,
-          recordId: newRecordId
+          recordId: newRecordId,
+          discriminator: undefined
         };
       }
 
@@ -844,6 +862,71 @@ export class TabContainerComponent extends BaseAngularComponent implements OnIni
       // to whatever the cache has and the user can still interact with the form.
     }
     await this.updateTabTitleFromResource(tabId, instance, instance.Data);
+  }
+
+  /**
+   * A resource component asked to be dismissed — typically the user clicked Discard
+   * on a brand-new record. Behavior depends on workspace state:
+   *
+   * - **Multi-tab mode (or > 1 tab)**: just close the tab. `WorkspaceStateManager.CloseTab`
+   *   activates the next tab, `syncTabsWithConfiguration` removes the tab from Golden
+   *   Layout, and the user lands on whatever tab was previously active.
+   *
+   * - **Last tab in the workspace**: `CloseTab` intentionally keeps the last tab around
+   *   (just unpins it) so the workspace is never empty — correct for the
+   *   user-clicked-X-button case, wrong here. We want the user OFF this discarded form.
+   *   Workaround: `CloseTab` makes the tab unpinned (= a temp tab), then we open the
+   *   app's default tab via `CreateDefaultTab()` which goes through `OpenTab` and
+   *   replaces the now-temp tab. End result: user lands on the app's home/default view.
+   */
+  private async handleResourceCloseRequested(tabId: string, _instance: BaseResourceComponent): Promise<void> {
+    const config = this.workspaceManager.GetConfiguration();
+    const tab = config?.tabs.find(t => t.id === tabId);
+    const isLastTab = config?.tabs.length === 1 && config.tabs[0].id === tabId;
+
+    // DESTROY (not just detach) the cached component before closing. The default
+    // tab-close path detaches and keeps components alive for reuse — but the
+    // discarded form is exactly what we DON'T want to keep: it holds a stale
+    // BaseEntity in view mode. The next "Create New Record" click for the same
+    // entity would otherwise hit the cache discriminator lookup, find this stale
+    // component, and reattach it — surfacing a blank form in view mode instead
+    // of a fresh edit-mode form. Destroy here forces a cache miss on the next click.
+    if (this.singleResourceCacheIdentity?.tabId === tabId) {
+      // Single-resource mode: the component is tracked via singleResource* fields,
+      // and its cache entry is currently marked attached. Use the identity directly
+      // to destroy it (markAsDetached would clear attachedToTabId and break a
+      // subsequent destroyComponentByTabId lookup).
+      const { driverClass, recordId, appId, discriminator } = this.singleResourceCacheIdentity;
+      this.cacheManager.destroyComponent(driverClass, recordId, appId, discriminator);
+      this.singleResourceComponentRef = null;
+      this.singleResourceCacheIdentity = null;
+      // Clear the host container's DOM so the user isn't briefly looking at the
+      // destroyed component's wrapper between CloseTab and the default-tab load.
+      const directContainer = this.directContentContainer?.nativeElement;
+      if (directContainer) {
+        while (directContainer.firstChild) directContainer.removeChild(directContainer.firstChild);
+      }
+    } else {
+      // Multi-tab mode: cache entry is keyed by attachedToTabId; the convenience
+      // method handles the lookup.
+      this.cacheManager.destroyComponentByTabId(tabId);
+      this.componentRefs.delete(tabId);
+    }
+
+    this.workspaceManager.CloseTab(tabId);
+
+    if (isLastTab && tab) {
+      // CloseTab kept the tab around but unpinned it. Replace it with the app's
+      // default tab so the user lands on a meaningful surface (typically the
+      // home dashboard) instead of staying on the discarded form.
+      const app = this.appManager.GetAppById(tab.applicationId);
+      if (app) {
+        const defaultTabRequest = await app.CreateDefaultTab();
+        if (defaultTabRequest) {
+          this.workspaceManager.OpenTab(defaultTabRequest, app.GetColor());
+        }
+      }
+    }
   }
 
   /**
@@ -939,12 +1022,16 @@ export class TabContainerComponent extends BaseAngularComponent implements OnIni
 
       // Get driver class for cache lookup (resolves to actual component class name)
       const driverClass = resourceData.Configuration?.resourceTypeDriverClass || resourceData.ResourceType;
+      // Discriminate distinct "new record" tabs of different entities (all have empty
+      // ResourceRecordID otherwise — would silently collide in the cache).
+      const cacheDiscriminator = resourceData.Configuration?.Entity as string | undefined;
 
       // Check if we have a cached component for this resource
       const cached = this.cacheManager.getCachedComponent(
         driverClass,
         resourceData.ResourceRecordID || '',
-        tab.applicationId
+        tab.applicationId,
+        cacheDiscriminator
       );
 
       if (cached) {
@@ -956,7 +1043,8 @@ export class TabContainerComponent extends BaseAngularComponent implements OnIni
           driverClass,
           resourceData.ResourceRecordID || '',
           tab.applicationId,
-          tabId
+          tabId,
+          cacheDiscriminator
         );
 
         // Keep legacy componentRefs map updated
@@ -1014,6 +1102,11 @@ export class TabContainerComponent extends BaseAngularComponent implements OnIni
 
       instance.ResourceRecordSavedEvent = (entity: BaseEntity) => {
         this.handleResourceRecordSaved(driverClass, tab.applicationId, tabId, instance, entity);
+      };
+
+      // Resource asked to be closed (e.g., user discarded a brand-new record).
+      instance.ResourceCloseRequestedEvent = () => {
+        this.handleResourceCloseRequested(tabId, instance);
       };
 
       // Wire up display name change notifications

--- a/packages/Angular/Explorer/explorer-core/src/lib/single-record/single-record.component.ts
+++ b/packages/Angular/Explorer/explorer-core/src/lib/single-record/single-record.component.ts
@@ -59,6 +59,11 @@ export class SingleRecordComponent extends BaseAngularComponent implements OnIni
 
   @Output() public loadComplete: EventEmitter<any> = new EventEmitter<any>();
   @Output() public recordSaved: EventEmitter<BaseEntity> = new EventEmitter<BaseEntity>();
+  /**
+   * Emitted when the hosted form asks to be dismissed (e.g., user clicked Discard on
+   * a brand-new record). Parent components should close the tab / route the user back.
+   */
+  @Output() public recordDismissed: EventEmitter<void> = new EventEmitter<void>();
 
   private recentAccessService: RecentAccessService;
   private navigationService = inject(NavigationService);
@@ -469,6 +474,11 @@ export class SingleRecordComponent extends BaseAngularComponent implements OnIni
         break;
       case 'email':
         window.open(`mailto:${event.EmailAddress}`, '_self');
+        break;
+      case 'dismiss':
+        // Form asked to be dismissed (typically Discard on a new record).
+        // Re-emit so the parent (EntityRecordResource) can close the tab.
+        this.recordDismissed.emit();
         break;
     }
   }

--- a/packages/Angular/Explorer/shared/src/lib/base-resource-component.ts
+++ b/packages/Angular/Explorer/shared/src/lib/base-resource-component.ts
@@ -65,6 +65,14 @@ export abstract class BaseResourceComponent extends BaseNavigationComponent impl
         this._resourceRecordSavedEvent = value;
     }
 
+    private _resourceCloseRequestedEvent: (() => void) | null = null;
+    public get ResourceCloseRequestedEvent(): (() => void) | null {
+        return this._resourceCloseRequestedEvent;
+    }
+    public set ResourceCloseRequestedEvent(value: (() => void) | null) {
+        this._resourceCloseRequestedEvent = value;
+    }
+
     private _displayNameChangedEvent: ((newName: string) => void) | null = null;
     public get DisplayNameChangedEvent(): ((newName: string) => void) | null {
         return this._displayNameChangedEvent;
@@ -230,6 +238,19 @@ export abstract class BaseResourceComponent extends BaseNavigationComponent impl
         this.Data.ResourceRecordID = resourceRecordEntity.PrimaryKey.ToURLSegment();
         if (this._resourceRecordSavedEvent) {
             this._resourceRecordSavedEvent(resourceRecordEntity);
+        }
+    }
+
+    /**
+     * Ask the host shell to close/dismiss this resource (typically: close the tab).
+     * Called by subclasses that hosted a form that emitted a 'dismiss' navigation
+     * event — most often, a brand-new record where the user clicked Discard. The
+     * record was never saved, the form is empty, and leaving it open serves no
+     * purpose. The tab-container listens for this and closes the workspace tab.
+     */
+    protected NotifyCloseRequested(): void {
+        if (this._resourceCloseRequestedEvent) {
+            this._resourceCloseRequestedEvent();
         }
     }
 

--- a/packages/Angular/Generic/base-forms/src/lib/base-form-component.ts
+++ b/packages/Angular/Generic/base-forms/src/lib/base-form-component.ts
@@ -374,6 +374,11 @@ export abstract class BaseFormComponent extends BaseRecordComponent implements A
   public CancelEdit() {
     if (this.record) {
       const r = <BaseEntity>this.record;
+      // Capture BEFORE any mutation — Revert() can clear the "new" flag on some
+      // entities. We need to know whether this record was ever persisted so we
+      // can tell the host to dismiss the form (there's nothing to view).
+      const wasNeverSaved = !r.IsSaved;
+
       if (r.Dirty || this.PendingRecordsDirty()) {
         // Revert is safe here — the toolbar's discard dialog already confirmed with the user
         r.Revert();
@@ -388,6 +393,15 @@ export abstract class BaseFormComponent extends BaseRecordComponent implements A
         this.RaiseEvent(BaseFormComponentEventCodes.REVERT_PENDING_CHANGES);
       }
       this.EndEditMode();
+
+      // For never-saved records, ask the host to dismiss the form — leaving it
+      // in view mode shows an empty record (there IS no record) and any
+      // subsequent "Create New" click for the same entity would silently
+      // reuse this abandoned form. Hosts that don't have a meaningful close
+      // semantic can ignore this event.
+      if (wasNeverSaved) {
+        this.Navigate.emit({ Kind: 'dismiss', Reason: 'new-record-discarded' });
+      }
     }
   }
 

--- a/packages/Angular/Generic/base-forms/src/lib/types/navigation-events.ts
+++ b/packages/Angular/Generic/base-forms/src/lib/types/navigation-events.ts
@@ -24,7 +24,8 @@ export type FormNavigationEvent =
   | EmailLinkNavigationEvent
   | EntityHierarchyNavigationEvent
   | ChildEntityTypeNavigationEvent
-  | NewRecordNavigationEvent;
+  | NewRecordNavigationEvent
+  | DismissFormNavigationEvent;
 
 /**
  * User clicked a foreign key link to view a related record.
@@ -97,4 +98,23 @@ export interface NewRecordNavigationEvent {
   EntityName: string;
   /** Default field values (e.g., foreign key pointing back to current record) */
   DefaultValues: Record<string, unknown>;
+}
+
+/**
+ * Form is asking the host to close/dismiss it.
+ *
+ * Emitted by `BaseFormComponent.CancelEdit` when the discarded record was never
+ * saved (`!record.IsSaved`) — there's no actual record to view, so leaving the
+ * form open in view mode shows blank fields and confuses users. The host
+ * application should close the tab/dialog/route that contained the form and
+ * return the user to whatever surface they came from (typically a list view).
+ *
+ * Hosts that don't have a meaningful "close" semantic (e.g., a form embedded
+ * inline on a dashboard) can safely ignore this — the form has already
+ * reverted state and returned to view mode.
+ */
+export interface DismissFormNavigationEvent {
+  Kind: 'dismiss';
+  /** Reason for the dismiss request — useful for analytics / different host behaviors. */
+  Reason: 'new-record-discarded';
 }


### PR DESCRIPTION
Follow-up to #2705 — two related fixes for the new-record form lifecycle that were caught in additional manual testing after that PR merged.

## Summary

- **Cache collision across entities (significant bug)**: The component cache key was `(driverClass, recordId, appId)`. Two "new record" tabs for different entities both had `recordId=''` and silently shared a cache entry, so opening "New MJ: Companies" and then clicking "+ New Record" from the MJ: Employees View reused the Companies form. Added an optional `discriminator` (the entity name) to the cache key; new-record tabs of different entities now hash to distinct keys. For real (non-empty) `recordId`s the key is unchanged.

- **Discard on a never-saved record now closes the tab**. A new `Kind: 'dismiss'` `FormNavigationEvent` is emitted from `BaseFormComponent.CancelEdit` only when `!record.IsSaved` (captured before `Revert()`, which can clear that flag). The event flows up through `SingleRecordComponent` → `EntityRecordResource` → `BaseResourceComponent.NotifyCloseRequested` → tab-container's `ResourceCloseRequestedEvent` handler, which destroys the cached component (so the stale view-mode form isn't reattached on the next "Create New Record" click for the same entity), closes the tab, and opens the app's default tab when the discarded tab was the last one (`CloseTab` deliberately keeps the last tab unpinned for single-resource mode, which is wrong for this case).

- The dismiss path is tightly scoped to never-saved records via the `wasNeverSaved` gate. Existing-record cancels, saves, and tab-X-button closes all go through different code paths and leave the cache intact.

## Test plan

- [ ] Open MJ: Companies View → "+ New Record" → (without saving) navigate to MJ: Employees View → "+ New Record" → should open a fresh **Employees** form, not a Companies form.
- [ ] Open MJ: Companies View → "+ New Record" → click Discard with no changes → tab closes, land on app's default surface (Home dashboard in single-resource mode; previous tab in multi-tab mode).
- [ ] After discard, click "+ New Record" again from MJ: Companies View → opens a **fresh edit-mode form** (not the stale view-mode form from before).
- [ ] Open existing MJ: Companies record → click Cancel → form returns to view mode in place (tab stays open, cache preserved) — no regression.
- [ ] Save flow: open "+ New Record" → fill out → Save → tab persists as the saved record's tab (tested in #2705 — verify no regression).
- [ ] Close existing record tab via the X button → cache stays available for re-open (no regression).

🤖 Generated with [Claude Code](https://claude.com/claude-code)