### PR TITLE
fix(compliance): clear MultiProvider + UUID compliance test violations

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -633,6 +633,7 @@
       "resolved": "https://registry.npmjs.org/@angular/animations/-/animations-21.1.3.tgz",
       "integrity": "sha512-UADMncDd9lkmIT1NPVFcufyP5gJHMPzxNaQpojiGrxT1aT8Du30mao0KSrB4aTwcicv6/cdD5bZbIyg+FL6LkQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "tslib": "^2.3.0"
       },
@@ -648,6 +649,7 @@
       "resolved": "https://registry.npmjs.org/@angular/cdk/-/cdk-21.1.3.tgz",
       "integrity": "sha512-jMiEKCcZMIAnyx2jxrJHmw5c7JXAiN56ErZ4X+OuQ5yFvYRocRVEs25I0OMxntcXNdPTJQvpGwGlhWhS0yDorg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "parse5": "^8.0.0",
         "tslib": "^2.3.0"
@@ -1238,6 +1240,7 @@
       "resolved": "https://registry.npmjs.org/@angular/common/-/common-21.1.3.tgz",
       "integrity": "sha512-Wdbln/UqZM5oVnpfIydRdhhL8A9x3bKZ9Zy1/mM0q+qFSftPvmFZIXhEpFqbDwNYbGUhGzx7t8iULC4sVVp/zA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "tslib": "^2.3.0"
       },
@@ -1254,6 +1257,7 @@
       "resolved": "https://registry.npmjs.org/@angular/compiler/-/compiler-21.1.3.tgz",
       "integrity": "sha512-gDNLh7MEf7Qf88ktZzS4LJQXCA5U8aQTfK9ak+0mi2ruZ0x4XSjQCro4H6OPKrrbq94+6GcnlSX5+oVIajEY3w==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "tslib": "^2.3.0"
       },
@@ -1266,6 +1270,7 @@
       "resolved": "https://registry.npmjs.org/@angular/compiler-cli/-/compiler-cli-21.1.3.tgz",
       "integrity": "sha512-nKxoQ89W2B1WdonNQ9kgRnvLNS6DAxDrRHBslsKTlV+kbdv7h59M9PjT4ZZ2sp1M/M8LiofnUfa/s2jd/xYj5w==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/core": "7.28.5",
         "@jridgewell/sourcemap-codec": "^1.4.14",
@@ -1468,6 +1473,7 @@
       "resolved": "https://registry.npmjs.org/@angular/core/-/core-21.1.3.tgz",
       "integrity": "sha512-TbhQxRC7Lb/3WBdm1n8KRsktmVEuGBBp0WRF5mq0Ze4s1YewIM6cULrSw9ACtcL5jdcq7c74ms+uKQsaP/gdcQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "tslib": "^2.3.0"
       },
@@ -1509,6 +1515,7 @@
       "resolved": "https://registry.npmjs.org/@angular/forms/-/forms-21.1.3.tgz",
       "integrity": "sha512-YW/YdjM9suZUeJam9agHFXIEE3qQIhGYXMjnnX7xGjOe+CuR2R0qsWn1AR0yrKrNmFspb0lKgM7kTTJyzt8gZg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@standard-schema/spec": "^1.0.0",
         "tslib": "^2.3.0"
@@ -1528,6 +1535,7 @@
       "resolved": "https://registry.npmjs.org/@angular/localize/-/localize-21.1.3.tgz",
       "integrity": "sha512-o/zFe8t578OP1j9+7iYibkwcE19zVC8xRFl/+f8bLSwqxwqasMNu1/zCa1B2nq8Gd2xwbvX/7kDhAn25yM4FJg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/core": "7.28.5",
         "@types/babel__core": "7.20.5",
@@ -1710,6 +1718,7 @@
       "resolved": "https://registry.npmjs.org/@angular/platform-browser/-/platform-browser-21.1.3.tgz",
       "integrity": "sha512-W+ZMXAioaP7CsACafBCHsIxiiKrRTPOlQ+hcC7XNBwy+bn5mjGONoCgLreQs76M8HNWLtr/OAUAr6h26OguOuA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "tslib": "^2.3.0"
       },
@@ -1750,6 +1759,7 @@
       "resolved": "https://registry.npmjs.org/@angular/router/-/router-21.1.3.tgz",
       "integrity": "sha512-uAw4LAMHXAPCe4SywhlUEWjMYVbbLHwTxLyduSp1b+9aVwep0juy5O/Xttlxd/oigVe0NMnOyJG9y1Br/ubnrg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "tslib": "^2.3.0"
       },
@@ -2168,6 +2178,7 @@
       "resolved": "https://registry.npmjs.org/@auth0/auth0-angular/-/auth0-angular-2.6.0.tgz",
       "integrity": "sha512-+LcdhiawKUdhEMkILl9Pq1yb1a9haNLHVG5kBTQXXtbocFDobtw8dvA/S74lBAzweCoDpFmNbMzORCFQLKyCOw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@auth0/auth0-spa-js": "^2.11.0",
         "tslib": "^2.0.0"
@@ -2205,7 +2216,6 @@
       "resolved": "https://registry.npmjs.org/@aws-amplify/analytics/-/analytics-7.0.93.tgz",
       "integrity": "sha512-3WoB0VzATJyupTNQ+ZnzE0pLYnpZPtqNN4deZ8gadG5uzGhhvkt9uZtgVnn/QFGb35DnP8qNDTRiM0rL3vjyZQ==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@aws-sdk/client-firehose": "3.982.0",
         "@aws-sdk/client-kinesis": "3.982.0",
@@ -2222,7 +2232,6 @@
       "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-2.2.0.tgz",
       "integrity": "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "tslib": "^2.6.2"
       },
@@ -2235,7 +2244,6 @@
       "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-2.2.0.tgz",
       "integrity": "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@smithy/is-array-buffer": "^2.2.0",
         "tslib": "^2.6.2"
@@ -2249,7 +2257,6 @@
       "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.0.0.tgz",
       "integrity": "sha512-rctU1VkziY84n5OXe3bPNpKR001ZCME2JCaBBFgtiM2hfKbHFudc/BkMuPab8hRbLd0j3vbnBTTZ1igBf0wgiQ==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@smithy/util-buffer-from": "^2.0.0",
         "tslib": "^2.5.0"
@@ -2263,7 +2270,6 @@
       "resolved": "https://registry.npmjs.org/@aws-amplify/api/-/api-6.3.24.tgz",
       "integrity": "sha512-19CVHj+0J35aHMPNzy12nO1mJS4oP68yFUfiMnulSsiVGV5XhUDc/bkdcX0uI7U1SsUSs+9TOBwZg27bzYIGkg==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@aws-amplify/api-graphql": "4.8.5",
         "@aws-amplify/api-rest": "4.6.3",
@@ -2280,7 +2286,6 @@
       "resolved": "https://registry.npmjs.org/@aws-amplify/api-graphql/-/api-graphql-4.8.5.tgz",
       "integrity": "sha512-Xu45+MizoethsRfCFIdN9RORenCu0e41tMkiTFVE5oKC76eoOlYHg2LlhG2Lmmasby/Ggi5bZouVxJIcP4IeIA==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@aws-amplify/api-rest": "4.6.3",
         "@aws-amplify/core": "6.16.1",
@@ -2297,7 +2302,6 @@
       "resolved": "https://registry.npmjs.org/graphql/-/graphql-15.8.0.tgz",
       "integrity": "sha512-5gghUc24tP9HRznNpV2+FIoq3xKkj5dTQqf4v0CpdPbFVwFkWoxOM+o+2OC9ZSvjEMTjfmG9QT+gcvggTwW1zw==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">= 10.x"
       }
@@ -2311,7 +2315,6 @@
         "https://github.com/sponsors/ctavan"
       ],
       "license": "MIT",
-      "peer": true,
       "bin": {
         "uuid": "dist/esm/bin/uuid"
       }
@@ -2321,7 +2324,6 @@
       "resolved": "https://registry.npmjs.org/@aws-amplify/api-rest/-/api-rest-4.6.3.tgz",
       "integrity": "sha512-SPhttyB9SR2p5PkUPmUPfkXNqGrgvdqiNHNHhx7FjHnqFBXLDRtGhzqRbE7faDeAwrcWz1HCtcpk7MLHYt94yg==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "tslib": "^2.5.0"
       },
@@ -2334,7 +2336,6 @@
       "resolved": "https://registry.npmjs.org/@aws-amplify/auth/-/auth-6.19.1.tgz",
       "integrity": "sha512-N6bqBUEly/xUiho0X5oGhLEDlQTWsj1i0FquDYsyuav5e9HHQBLNgG1zmpq28lyxtDaUREi/IDx+CD10EpcPcQ==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@aws-crypto/sha256-js": "5.2.0",
         "@smithy/types": "^3.3.0",
@@ -2355,7 +2356,6 @@
       "resolved": "https://registry.npmjs.org/@smithy/types/-/types-3.7.2.tgz",
       "integrity": "sha512-bNwBYYmN8Eh9RyjS1p2gW6MIhSO2rl7X9QeLM8iTdcGRP+eDiIWDt66c9IysCc22gefKszZv+ubV9qZc7hdESg==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "tslib": "^2.6.2"
       },
@@ -2385,7 +2385,6 @@
       "resolved": "https://registry.npmjs.org/@smithy/util-hex-encoding/-/util-hex-encoding-2.0.0.tgz",
       "integrity": "sha512-c5xY+NUnFqG6d7HFh1IFfrm3mGl29lC+vF+geHv4ToiuJCBmIfzx6IeHLg+OgRdPFKDXIw6pvi+p3CsscaMcMA==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "tslib": "^2.5.0"
       },
@@ -2397,8 +2396,7 @@
       "version": "9.0.8",
       "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-9.0.8.tgz",
       "integrity": "sha512-jg+97EGIcY9AGHJJRaaPVgetKDsrTgbRjQ5Msgjh/DQKEFl0DtyRr/VCOyD1T2R1MNeWPK/u7JoGhlDZnKBAfA==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@aws-amplify/core/node_modules/uuid": {
       "version": "11.1.0",
@@ -2409,7 +2407,6 @@
         "https://github.com/sponsors/ctavan"
       ],
       "license": "MIT",
-      "peer": true,
       "bin": {
         "uuid": "dist/esm/bin/uuid"
       }
@@ -2419,7 +2416,6 @@
       "resolved": "https://registry.npmjs.org/@aws-amplify/data-schema/-/data-schema-1.25.4.tgz",
       "integrity": "sha512-2vN1gdU/zzCuxpul6xnD8ii0Chl94lAJmsv0uOeztlNUoYYYiZ1CWlwRkSYe+Y6D4pJOSpO2wvcBsEi9/nVVmw==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@aws-amplify/data-schema-types": "*",
         "@smithy/util-base64": "^3.0.0",
@@ -2433,7 +2429,6 @@
       "resolved": "https://registry.npmjs.org/@aws-amplify/data-schema-types/-/data-schema-types-1.2.1.tgz",
       "integrity": "sha512-SuYVcy9Hg8Ox9P0QCXEPwqHxX5zVPgVo2YvNBOm5TpkZr4UK6ir3USame7dELZsk5/9f6KoP70QAYhTvp/j1Og==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "graphql": "15.8.0",
         "rxjs": "^7.8.1"
@@ -2444,7 +2439,6 @@
       "resolved": "https://registry.npmjs.org/graphql/-/graphql-15.8.0.tgz",
       "integrity": "sha512-5gghUc24tP9HRznNpV2+FIoq3xKkj5dTQqf4v0CpdPbFVwFkWoxOM+o+2OC9ZSvjEMTjfmG9QT+gcvggTwW1zw==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">= 10.x"
       }
@@ -2454,7 +2448,6 @@
       "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-3.0.0.tgz",
       "integrity": "sha512-+Fsu6Q6C4RSJiy81Y8eApjEB5gVtM+oFKTffg+jSuwtvomJJrhUJBu2zS8wjXSgH/g1MKEWrzyChTBe6clb5FQ==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "tslib": "^2.6.2"
       },
@@ -2467,7 +2460,6 @@
       "resolved": "https://registry.npmjs.org/@smithy/util-base64/-/util-base64-3.0.0.tgz",
       "integrity": "sha512-Kxvoh5Qtt0CDsfajiZOCpJxgtPHXOKwmM+Zy4waD43UoEMA+qPxxa98aE/7ZhdnBFZFXMOiBR5xbcaMhLtznQQ==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@smithy/util-buffer-from": "^3.0.0",
         "@smithy/util-utf8": "^3.0.0",
@@ -2482,7 +2474,6 @@
       "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-3.0.0.tgz",
       "integrity": "sha512-aEOHCgq5RWFbP+UDPvPot26EJHjOC+bRgse5A8V3FSShqd5E5UN4qc7zkwsvJPPAVsf73QwYcHN1/gt/rtLwQA==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@smithy/is-array-buffer": "^3.0.0",
         "tslib": "^2.6.2"
@@ -2496,7 +2487,6 @@
       "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-3.0.0.tgz",
       "integrity": "sha512-rUeT12bxFnplYDe815GXbq/oixEGHfRFFtcTF3YdDi/JaENIM6aSYYLJydG83UNzLXeRI5K8abYd/8Sp/QM0kA==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@smithy/util-buffer-from": "^3.0.0",
         "tslib": "^2.6.2"
@@ -2510,7 +2500,6 @@
       "resolved": "https://registry.npmjs.org/@aws-amplify/datastore/-/datastore-5.1.5.tgz",
       "integrity": "sha512-/9o4eYqWOlxVxe/riDd282FmUHHSiGUEAwle464T8wzNSqPTB7yTeQfzt2LFYTWsrYLCSR0OtOM1bY5VPSVmew==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@aws-amplify/api": "6.3.24",
         "@aws-amplify/api-graphql": "4.8.5",
@@ -2529,7 +2518,6 @@
       "resolved": "https://registry.npmjs.org/buffer/-/buffer-4.9.2.tgz",
       "integrity": "sha512-xq+q3SRMOxGivLhBNaUdC64hDTQwejJ+H0T/NB1XMtTVEwNTrfFF3gAxiyW0Bu/xWEGhjVKgUcMhCrUy2+uCWg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "base64-js": "^1.0.2",
         "ieee754": "^1.1.4",
@@ -2540,22 +2528,19 @@
       "version": "5.0.6",
       "resolved": "https://registry.npmjs.org/idb/-/idb-5.0.6.tgz",
       "integrity": "sha512-/PFvOWPzRcEPmlDt5jEvzVZVs0wyd/EvGvkDIcbBpGuMMLQKrTPG0TxvE2UJtgZtCQCmOtM2QD7yQJBVEjKGOw==",
-      "license": "ISC",
-      "peer": true
+      "license": "ISC"
     },
     "node_modules/@aws-amplify/datastore/node_modules/isarray": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
       "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@aws-amplify/notifications": {
       "version": "2.0.93",
       "resolved": "https://registry.npmjs.org/@aws-amplify/notifications/-/notifications-2.0.93.tgz",
       "integrity": "sha512-NtHKusaiWzkPXuaKsTyvKAWE8JnQcXmQoaidQ5/a9/nWWTzs983l5xgc4OPvfVR+3N63K+3iTmYHtKcEbhgS6w==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@aws-sdk/types": "3.973.1",
         "lodash": "^4.17.21",
@@ -2570,7 +2555,6 @@
       "resolved": "https://registry.npmjs.org/@aws-amplify/storage/-/storage-6.13.2.tgz",
       "integrity": "sha512-XMhFXrEYD/x/cd5qvTnMa/xhbpJjZZyva2ea0wmLedLqY1glWyhKPmSi2PAfhhpkWcvA50XnQ/g9KaZsog5hww==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@aws-sdk/types": "3.973.1",
         "@smithy/md5-js": "2.0.7",
@@ -2588,7 +2572,6 @@
       "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-2.2.0.tgz",
       "integrity": "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "tslib": "^2.6.2"
       },
@@ -2601,7 +2584,6 @@
       "resolved": "https://registry.npmjs.org/@smithy/md5-js/-/md5-js-2.0.7.tgz",
       "integrity": "sha512-2i2BpXF9pI5D1xekqUsgQ/ohv5+H//G9FlawJrkOJskV18PgJ8LiNbLiskMeYt07yAsSTZR7qtlcAaa/GQLWww==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@smithy/types": "^2.3.1",
         "@smithy/util-utf8": "^2.0.0",
@@ -2613,7 +2595,6 @@
       "resolved": "https://registry.npmjs.org/@smithy/types/-/types-2.12.0.tgz",
       "integrity": "sha512-QwYgloJ0sVNBeBuBs65cIkTbfzV/Q6ZNPCJ99EICFEdJYG50nGIY/uYXp+TbsdJReIuPr0a0kXmCvren3MbRRw==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "tslib": "^2.6.2"
       },
@@ -2626,7 +2607,6 @@
       "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-2.2.0.tgz",
       "integrity": "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@smithy/is-array-buffer": "^2.2.0",
         "tslib": "^2.6.2"
@@ -2640,7 +2620,6 @@
       "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.3.0.tgz",
       "integrity": "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@smithy/util-buffer-from": "^2.2.0",
         "tslib": "^2.6.2"
@@ -2654,7 +2633,6 @@
       "resolved": "https://registry.npmjs.org/buffer/-/buffer-4.9.2.tgz",
       "integrity": "sha512-xq+q3SRMOxGivLhBNaUdC64hDTQwejJ+H0T/NB1XMtTVEwNTrfFF3gAxiyW0Bu/xWEGhjVKgUcMhCrUy2+uCWg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "base64-js": "^1.0.2",
         "ieee754": "^1.1.4",
@@ -2672,7 +2650,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fast-xml-builder": "^1.1.4",
         "path-expression-matcher": "^1.2.1",
@@ -2686,8 +2663,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
       "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@aws-crypto/crc32": {
       "version": "5.2.0",
@@ -3124,7 +3100,6 @@
       "resolved": "https://registry.npmjs.org/@aws-sdk/client-firehose/-/client-firehose-3.982.0.tgz",
       "integrity": "sha512-Qur2Siqep+gRReTjlKXcdpyX/MUnzm5OgNNudDPxzpmzdnc3ZKlUwGlbEoS1VA5cFS6N4zg6WfZqlwcXg//TSg==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@aws-crypto/sha256-browser": "5.2.0",
         "@aws-crypto/sha256-js": "5.2.0",
@@ -3175,7 +3150,6 @@
       "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.982.0.tgz",
       "integrity": "sha512-M27u8FJP7O0Of9hMWX5dipp//8iglmV9jr7R8SR8RveU+Z50/8TqH68Tu6wUWBGMfXjzbVwn1INIAO5lZrlxXQ==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@aws-sdk/types": "^3.973.1",
         "@smithy/types": "^4.12.0",
@@ -3192,7 +3166,6 @@
       "resolved": "https://registry.npmjs.org/@aws-sdk/client-kinesis/-/client-kinesis-3.982.0.tgz",
       "integrity": "sha512-Gh3xyumdz3IRj91HIBR48TohQyA3VSn/blDcGXzl4dwQKXgM0ISdHgyniNo2GQNhORJF3d01MSMx72s5NNQxUA==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@aws-crypto/sha256-browser": "5.2.0",
         "@aws-crypto/sha256-js": "5.2.0",
@@ -3247,7 +3220,6 @@
       "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.982.0.tgz",
       "integrity": "sha512-M27u8FJP7O0Of9hMWX5dipp//8iglmV9jr7R8SR8RveU+Z50/8TqH68Tu6wUWBGMfXjzbVwn1INIAO5lZrlxXQ==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@aws-sdk/types": "^3.973.1",
         "@smithy/types": "^4.12.0",
@@ -3315,7 +3287,6 @@
       "resolved": "https://registry.npmjs.org/@aws-sdk/client-personalize-events/-/client-personalize-events-3.982.0.tgz",
       "integrity": "sha512-JllssIZCPxAgYy4gkIM2e/kXxWT0xQzzZd5y9rRStm0bl5MiLAxzX4q9WhGG7glyB++EuhYskiT1N+DzyM5nTw==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@aws-crypto/sha256-browser": "5.2.0",
         "@aws-crypto/sha256-js": "5.2.0",
@@ -3366,7 +3337,6 @@
       "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.982.0.tgz",
       "integrity": "sha512-M27u8FJP7O0Of9hMWX5dipp//8iglmV9jr7R8SR8RveU+Z50/8TqH68Tu6wUWBGMfXjzbVwn1INIAO5lZrlxXQ==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@aws-sdk/types": "^3.973.1",
         "@smithy/types": "^4.12.0",
@@ -4489,6 +4459,7 @@
       "resolved": "https://registry.npmjs.org/@azure/core-client/-/core-client-1.10.1.tgz",
       "integrity": "sha512-Nh5PhEOeY6PrnxNPsEHRr9eimxLwgLlpmguQaHKBinFYA/RU9+kOYVOQqOrTsCL+KSxrLLl1gD8Dk5BFW/7l/w==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@azure/abort-controller": "^2.1.2",
         "@azure/core-auth": "^1.10.0",
@@ -4550,6 +4521,7 @@
       "resolved": "https://registry.npmjs.org/@azure/core-rest-pipeline/-/core-rest-pipeline-1.22.2.tgz",
       "integrity": "sha512-MzHym+wOi8CLUlKCQu12de0nwcq9k9Kuv43j4Wa++CsCpJwps2eeBQwD2Bu8snkxTtDKDx4GwjuR9E8yC8LNrg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@azure/abort-controller": "^2.1.2",
         "@azure/core-auth": "^1.10.0",
@@ -4729,6 +4701,7 @@
       "resolved": "https://registry.npmjs.org/@azure/msal-angular/-/msal-angular-5.0.3.tgz",
       "integrity": "sha512-GLKET/JQK52fZYeceBjXKDu8Tv4jRpO7IFH4Id/65a3MU3l/fYhuiuMe4JceQT1ZdbiPfPjsScPZtIOQ2oh6aA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "tslib": "^2.3.0"
       },
@@ -4742,6 +4715,7 @@
       "resolved": "https://registry.npmjs.org/@azure/msal-browser/-/msal-browser-5.1.0.tgz",
       "integrity": "sha512-5tZcp1zcALSLJvnxkmJ8MYxLtZzEyq28wX2jSV4Kz2QaHty4eYIb/Pc44DARLfgHD+G9F82k9nD7J89MbFRQxA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@azure/msal-common": "16.0.3"
       },
@@ -4754,6 +4728,7 @@
       "resolved": "https://registry.npmjs.org/@azure/msal-common/-/msal-common-16.0.3.tgz",
       "integrity": "sha512-3aedNnM0CHVuVZ+BqembdZWgovqe96BJ4YxGoIK0+qhoBZQsAhfwXdhjen72K94pkSQHtzlJ7fAq6w7knFZsng==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.8.0"
       }
@@ -4863,6 +4838,7 @@
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.0.tgz",
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -7326,6 +7302,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       },
@@ -7364,6 +7341,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       }
@@ -8038,6 +8016,7 @@
       "resolved": "https://registry.npmjs.org/@foblex/2d/-/2d-1.2.2.tgz",
       "integrity": "sha512-nVl2iw6hF0RDE2+E4U1tSRX5lOI2toG9nY1VaMlQ0RdIB+0mEK1+lhjJDn/qDrBsMYpNCaTZ2CC3Jy54ItOnsQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "tslib": "^2.3.0"
       },
@@ -8069,6 +8048,7 @@
       "resolved": "https://registry.npmjs.org/@foblex/mediator/-/mediator-1.1.3.tgz",
       "integrity": "sha512-Yuvu4lpefFo0N1oo1xDBL7UItUe5KuasPniurcQITY3wvBRITSHZCPIEpB/FEWuaoknyC8t1blxDyOh11U+daA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "tslib": "^2.3.0"
       },
@@ -8083,6 +8063,7 @@
       "resolved": "https://registry.npmjs.org/@foblex/platform/-/platform-1.0.4.tgz",
       "integrity": "sha512-GLbqPX9xL/w2pRX51J8RSjMrZcTKb8rmi9+EcrPtpRXCa4KETY4mpIzfKlaOthZusFY++UUFecM07aXRnp+sMw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "tslib": "^2.3.0"
       },
@@ -8096,6 +8077,7 @@
       "resolved": "https://registry.npmjs.org/@foblex/utils/-/utils-1.1.1.tgz",
       "integrity": "sha512-w4g49vLAIogIXNYHWQzcv2p5jJKi/XAoTw7LvuEzKvEXDJ8ezL0BZJfbeg43q2+PyKvlUfu+6ySvNxnXYrb/Bg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "tslib": "^2.3.0"
       }
@@ -14040,6 +14022,7 @@
       "resolved": "https://registry.npmjs.org/@octokit/core/-/core-6.1.6.tgz",
       "integrity": "sha512-kIU8SLQkYWGp3pVKiYzA5OSaNF5EE03P/R8zEmmrG6XwOg5oBjXyQVVIauQ0dgau4zYhpZEhJrvIYt6oM+zZZA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@octokit/auth-token": "^5.0.0",
         "@octokit/graphql": "^8.2.2",
@@ -15032,7 +15015,6 @@
       "resolved": "https://registry.npmjs.org/@primeuix/motion/-/motion-0.0.10.tgz",
       "integrity": "sha512-PsZwOPq79Scp7/ionshRcQ5xKVf9+zuLcyY5mf6onK8chHT5C9JGphmcIZ4CzcqxuGEpsm8AIbTGy+zS3RtzLA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@primeuix/utils": "^0.6.3"
       },
@@ -15045,7 +15027,6 @@
       "resolved": "https://registry.npmjs.org/@primeuix/styled/-/styled-0.7.4.tgz",
       "integrity": "sha512-QSO/NpOQg8e9BONWRBx9y8VGMCMYz0J/uKfNJEya/RGEu7ARx0oYW0ugI1N3/KB1AAvyGxzKBzGImbwg0KUiOQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@primeuix/utils": "^0.6.1"
       },
@@ -15058,7 +15039,6 @@
       "resolved": "https://registry.npmjs.org/@primeuix/styles/-/styles-2.0.3.tgz",
       "integrity": "sha512-2ykAB6BaHzR/6TwF8ShpJTsZrid6cVIEBVlookSdvOdmlWuevGu5vWOScgIwqWwlZcvkFYAGR/SUV3OHCTBMdw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@primeuix/styled": "^0.7.4"
       }
@@ -15068,7 +15048,6 @@
       "resolved": "https://registry.npmjs.org/@primeuix/utils/-/utils-0.6.4.tgz",
       "integrity": "sha512-pZ5f+vj7wSzRhC7KoEQRU5fvYAe+RP9+m39CTscZ3UywCD1Y2o6Fe1rRgklMPSkzUcty2jzkA0zMYkiJBD1hgg==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12.11.0"
       }
@@ -17126,8 +17105,7 @@
       "version": "8.10.161",
       "resolved": "https://registry.npmjs.org/@types/aws-lambda/-/aws-lambda-8.10.161.tgz",
       "integrity": "sha512-rUYdp+MQwSFocxIOcSsYSF3YYYC/uUpMbCY/mbO21vGqfrEYvNSoPyKYDj6RhXXpPfS0KstW9RwG3qXh9sL7FQ==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@types/axios": {
       "version": "0.14.4",
@@ -17501,6 +17479,7 @@
       "integrity": "sha512-vIChWdVG3LG1SMxEvI/AK+FWJthlrqlTu7fbrlywTkkaONwk/UAGaULXRlf8vkzFBLVm0zkMdCquhL5aOjhXPQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/ms": "*"
       }
@@ -17749,6 +17728,7 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-20.14.2.tgz",
       "integrity": "sha512-xyu6WAMVwv6AKFLB+e/7ySZVr/0zLCzOa7rSpq6jNwpqOrUbcACDWC+53d4n2QHOnDou0fbIsg8wZu/sxrnI4Q==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "undici-types": "~5.26.4"
       }
@@ -17758,6 +17738,7 @@
       "resolved": "https://registry.npmjs.org/@types/node-fetch/-/node-fetch-2.6.13.tgz",
       "integrity": "sha512-QGpRVpzSaUs30JBSGPjOg4Uveu384erbHBoT1zeONvyCfwQxIkUshLAOqN/k9EjGviPRmWTTe6aH2qySWKTVSw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/node": "*",
         "form-data": "^4.0.4"
@@ -17834,6 +17815,7 @@
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.13.tgz",
       "integrity": "sha512-KkiJeU6VbYbUOp5ITMIc7kBfqlYkKA5KhEHVrGMmUUMt7NeaZg65ojdPk+FtNrBAOXNVM5QM72jnADjM+XVRAQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -18106,6 +18088,7 @@
       "integrity": "sha512-dm/J2UDY3oV3TKius2OUZIFHsomQmpHtsV0FTh1WO8EKgHLQ1QCADUqscPgTpU+ih1e21FQSRjXckHn3txn6kQ==",
       "dev": true,
       "license": "BSD-2-Clause",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "7.12.0",
         "@typescript-eslint/types": "7.12.0",
@@ -18761,6 +18744,7 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -18867,6 +18851,7 @@
       "resolved": "https://registry.npmjs.org/ag-grid-angular/-/ag-grid-angular-35.0.1.tgz",
       "integrity": "sha512-+Y1K/ZxiEbd3GhZcRWzLf60yiP4ECNoTCCqI65EgHiiRGInz3g1pDueArR7hE7V+z5gluA3NMGB3VrOZYUBKLg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "ag-grid-community": "35.0.1",
         "tslib": "^2.3.0"
@@ -18881,6 +18866,7 @@
       "resolved": "https://registry.npmjs.org/ag-grid-community/-/ag-grid-community-35.0.1.tgz",
       "integrity": "sha512-fYYZdymWKsN9/tZv+R6uZRnuiWYEQr+GHl85ZrB0ixbFcE8opYK4NJI29NnMc9ShYiCBnAO9hj54IFa+FI4aDA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "ag-charts-types": "13.0.1"
       }
@@ -19568,6 +19554,7 @@
       "resolved": "https://registry.npmjs.org/axios/-/axios-1.13.6.tgz",
       "integrity": "sha512-ChTCHMouEe2kn713WHbQGcuYrr6fXTBiu460OTwWrWob16g1bXn4vtz07Ope7ewMozJAnEquLk5lWQWtBig9DQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "follow-redirects": "^1.15.11",
         "form-data": "^4.0.5",
@@ -19764,6 +19751,7 @@
       "resolved": "https://registry.npmjs.org/bare-events/-/bare-events-2.8.2.tgz",
       "integrity": "sha512-riJjyv1/mHLIPX4RwiK+oW9/4c3TEUeORHKefKAKnZ5kyslbN+HXowtbaVEqt4IMUB7OXlfixcs6gsFeo/jhiQ==",
       "license": "Apache-2.0",
+      "peer": true,
       "peerDependencies": {
         "bare-abort-controller": "*"
       },
@@ -20592,6 +20580,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -22232,6 +22221,7 @@
       "resolved": "https://registry.npmjs.org/cytoscape/-/cytoscape-3.33.1.tgz",
       "integrity": "sha512-iJc4TwyANnOGR1OmWhsS9ayRS3s+XQ185FmuHObThD+5AeJCakAAbWv8KimMTt08xCCLNgneQwFp+JRJOr9qGQ==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10"
       }
@@ -22659,6 +22649,7 @@
       "resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-3.0.0.tgz",
       "integrity": "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==",
       "license": "ISC",
+      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -22885,6 +22876,7 @@
       "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-3.6.0.tgz",
       "integrity": "sha512-fRHTG8g/Gif+kSh50gaGEdToemgfj74aRX3swtiouboip5JDLAyDE9F11nHMIcvOaXeOC6D7SpNhi7uFyB7Uww==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/kossnocorp"
@@ -23577,7 +23569,8 @@
       "resolved": "https://registry.npmjs.org/effect/-/effect-3.5.7.tgz",
       "integrity": "sha512-PzEncc0R3ZZhqNTR+fXrSX+anF/4Ai6ftKie1ZrUUWY7WPE7d4KjB6wjpeWoGMOC7xWFPGSkBBUudyJN1mx3+g==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/ejs": {
       "version": "3.1.10",
@@ -24119,6 +24112,7 @@
       "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",
@@ -24175,6 +24169,7 @@
       "integrity": "sha512-NSWl5BFQWEPi1j4TjVNItzYV7dZXZ+wP6I6ZhrBGpChQhZRUaElihE9uRRkcbRnNb76UMKDF3r+WTmNcGPKsqw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "eslint-config-prettier": "bin/cli.js"
       },
@@ -24298,6 +24293,7 @@
       "integrity": "sha512-hYfi3FXaM8WPLf4S1cikh/r4IxnO6zrhZbEGz2b660EJRbuxgpDS5gkCuYgGWg2xxh2rBuIr4Pvhve/7c31koA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "array-includes": "^3.1.4",
         "array.prototype.flat": "^1.2.5",
@@ -24817,6 +24813,7 @@
       "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
       "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "accepts": "^2.0.0",
         "body-parser": "^2.2.1",
@@ -25060,7 +25057,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "path-expression-matcher": "^1.1.3"
       }
@@ -26064,7 +26060,8 @@
       "version": "2.6.0",
       "resolved": "https://registry.npmjs.org/golden-layout/-/golden-layout-2.6.0.tgz",
       "integrity": "sha512-sIVQCiRWOymHbVD1Aw/T9/ijbPYAVGBlgGYd1N9MRKfcyBNSpjr87Vg9nSHm+RCT8ELrvK8IJYJV0QRJuVUkCQ==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/google-auth-library": {
       "version": "9.15.1",
@@ -26369,6 +26366,7 @@
       "resolved": "https://registry.npmjs.org/graphql/-/graphql-16.12.0.tgz",
       "integrity": "sha512-DKKrynuQRne0PNpEbzuEdHlYOMksHSUI8Zc9Unei5gTsMNA2/vMpoMz/yKba50pejK56qj98qM0SjYxAKi13gQ==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": "^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0"
       }
@@ -26402,6 +26400,7 @@
       "resolved": "https://registry.npmjs.org/graphql-scalars/-/graphql-scalars-1.25.0.tgz",
       "integrity": "sha512-b0xyXZeRFkne4Eq7NAnL400gStGqG/Sx9VqX0A05nHyEbv57UJnWKsjNnrpVqv5e/8N1MUxkt0wwcRXbiyKcFg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "tslib": "^2.5.0"
       },
@@ -26640,6 +26639,7 @@
       "resolved": "https://registry.npmjs.org/hono/-/hono-4.11.7.tgz",
       "integrity": "sha512-l7qMiNee7t82bH3SeyUCt9UF15EVmaBvsppY2zQtrbIhl/yzBTny+YUxsVjSjQ6gaqaeVtZmGocom8TzBlA4Yw==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=16.9.0"
       }
@@ -27149,7 +27149,6 @@
       "resolved": "https://registry.npmjs.org/immer/-/immer-9.0.6.tgz",
       "integrity": "sha512-G95ivKpy+EvVAnAab4fVa4YGYn24J1SpEktnJX7JJ45Bd7xqME/SCplFzYFmTbrkwZbQ4xJK1xMTUYBkN6pWsQ==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/immer"
@@ -28148,6 +28147,7 @@
       "integrity": "sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "jiti": "lib/jiti-cli.mjs"
       }
@@ -28215,6 +28215,7 @@
       "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-28.0.0.tgz",
       "integrity": "sha512-KDYJgZ6T2TKdU8yBfYueq5EPG/EylMsBvCaenWMJb2OXmjgczzwveRCoJ+Hgj1lXPDyasvrgneSn4GBuR1hYyA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@acemir/cssom": "^0.9.31",
         "@asamuzakjp/dom-selector": "^6.7.6",
@@ -28313,6 +28314,7 @@
       "resolved": "https://registry.npmjs.org/jsep/-/jsep-1.4.0.tgz",
       "integrity": "sha512-B7qPcEVE3NVkmSJbaYxvv4cHkVW7DQsZz13pUMrfS8z8Q/BuShN+gcTXrUlPiGqM2/t/EEaI030bpxMqY8gMlw==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 10.16.0"
       }
@@ -28858,6 +28860,7 @@
       "integrity": "sha512-j1n1IuTX1VQjIy3tT7cyGbX7nvQOsFLoIqobZv4ttI5axP923gA44zUj6miiA6R5Aoms4sEGVIIcucXUbRI14g==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "copy-anything": "^2.0.1",
         "parse-node-version": "^1.0.1",
@@ -29035,6 +29038,7 @@
       "integrity": "sha512-ME4Fb83LgEgwNw96RKNvKV4VTLuXfoKudAmm2lP8Kk87KaMK0/Xrx/aAkMWmT8mDb+3MlFDspfbCs7adjRxA2g==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "cli-truncate": "^5.0.0",
         "colorette": "^2.0.20",
@@ -29997,6 +30001,7 @@
       "resolved": "https://registry.npmjs.org/marked/-/marked-17.0.1.tgz",
       "integrity": "sha512-boeBdiS0ghpWcSwoNm/jJBwdpFaMnZWRzjA6SkUMYb40SVaN1x7mmfGKp0jvexGcx+7y2La5zRZsYFZI6Qpypg==",
       "license": "MIT",
+      "peer": true,
       "bin": {
         "marked": "bin/marked.js"
       },
@@ -30975,6 +30980,7 @@
       "integrity": "sha512-UlQOhH8DRlaYsBGQMjOYvg70J70hD4i/55NV9vAsYvsxEskmp86xjUtZgEeVKeoLq8tYMjMXDgaYjYde153sZQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@ampproject/remapping": "^2.3.0",
         "@rollup/plugin-json": "^6.1.0",
@@ -33674,7 +33680,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=14.0.0"
       }
@@ -33818,6 +33823,7 @@
       "resolved": "https://registry.npmjs.org/pg/-/pg-8.18.0.tgz",
       "integrity": "sha512-xqrUDL1b9MbkydY/s+VZ6v+xiMUmOUk7SS9d/1kpyQxoJ6U9AO1oIJyUWVZojbfe5Cc/oluutcgFG4L9RDP1iQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "pg-connection-string": "^2.11.0",
         "pg-pool": "^3.11.0",
@@ -33885,18 +33891,6 @@
       "resolved": "https://registry.npmjs.org/pg-protocol/-/pg-protocol-1.11.0.tgz",
       "integrity": "sha512-pfsxk2M9M3BuGgDOfuy37VNRRX3jmKgMjcvAcWqNDpZSf4cUmv8HSOl5ViRQFsfARFn0KuUQTgLxVMbNq5NW3g==",
       "license": "MIT"
-    },
-    "node_modules/pg-query-stream": {
-      "version": "4.15.0",
-      "resolved": "https://registry.npmjs.org/pg-query-stream/-/pg-query-stream-4.15.0.tgz",
-      "integrity": "sha512-hyCs0PaOyCWqC90N9vyHL2wVNyR3OjnqFrLvgX74Pyh0JihTKUywpPyhKnuVp9TCCcGz7Fc9LdtxoBU+3nv10A==",
-      "license": "MIT",
-      "dependencies": {
-        "pg-cursor": "^2.20.0"
-      },
-      "peerDependencies": {
-        "pg": "^8"
-      }
     },
     "node_modules/pg-types": {
       "version": "2.2.0",
@@ -34036,6 +34030,7 @@
       "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.58.1.tgz",
       "integrity": "sha512-+2uTZHxSCcxjvGc5C891LrS1/NlxglGxzrC4seZiVjcYVQfUa87wBL6rTDqzGjuoWNjnBzRqKmF6zRYGMvQUaQ==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "playwright-core": "1.58.1"
       },
@@ -34138,6 +34133,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -34332,6 +34328,7 @@
       "integrity": "sha512-UOnG6LftzbdaHZcKoPFtOcCKztrQ57WkHDeRD9t/PTQtmT0NHSeWWepj6pS0z/N7+08BHFDQVUrfmfMRcZwbMg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -34781,6 +34778,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.4.tgz",
       "integrity": "sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -35323,6 +35321,7 @@
       "integrity": "sha512-kPmlKCGFES2VWtY7Y7SCB8ZeXRMsgX5deza9cu4OwmfM/ZUimd461kC3hRyccoyVxE4POlHUx0gg2jcGfusHFg==",
       "hasInstallScript": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.21.0"
       }
@@ -35332,6 +35331,7 @@
       "resolved": "https://registry.npmjs.org/rete-area-plugin/-/rete-area-plugin-2.1.5.tgz",
       "integrity": "sha512-iquEvwkQlcsO4cmgM3Z37TG0AWaE536dfA+lCJAze5YJzVx4RBaViUCqdB4dUA/utSytpBCkiDC4D3ztM9akGQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.21.0"
       },
@@ -35463,6 +35463,7 @@
       "integrity": "sha512-oQL6lgK3e2QZeQ7gcgIkS2YZPg5slw37hYufJ3edKlfQSGGm8ICoxswK15ntSzF/a8+h7ekRy7k7oWc3BQ7y8A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/estree": "1.0.8"
       },
@@ -35708,6 +35709,7 @@
       "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.2.tgz",
       "integrity": "sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "tslib": "^2.1.0"
       }
@@ -35798,6 +35800,7 @@
       "integrity": "sha512-uf6HoO8fy6ClsrShvMgaKUn14f2EHQLQRtpsZZLeU/Mv0Q1K5P0+x2uvH6Cub39TVVbWNSrraUhDAoFph6vh0A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "chokidar": "^4.0.0",
         "immutable": "^5.0.2",
@@ -35896,6 +35899,7 @@
       "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -37772,6 +37776,7 @@
       "integrity": "sha512-t/R3R/n0MSwnnazuPpPNVO60LX0SKL45pyl9YlvxIdkH0Of7D5qM2EVe+yASRIlY5pZ73nclYJfNANGWPwFDZw==",
       "dev": true,
       "license": "BSD-2-Clause",
+      "peer": true,
       "dependencies": {
         "@jridgewell/source-map": "^0.3.3",
         "acorn": "^8.15.0",
@@ -38539,7 +38544,8 @@
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-      "license": "0BSD"
+      "license": "0BSD",
+      "peer": true
     },
     "node_modules/tsx": {
       "version": "4.21.0",
@@ -39385,6 +39391,7 @@
       "integrity": "sha512-x4xW77QC3i5DUFMBp0qjukOTnr/sSg+oEs86nB3LjDslvAmwe/PUGDWbe3GrIqt59oTqoXK5GRK9tAa0sYMiog==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@gerrit0/mini-shiki": "^3.17.0",
         "lunr": "^2.3.9",
@@ -39418,6 +39425,7 @@
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -39444,7 +39452,6 @@
       "resolved": "https://registry.npmjs.org/ulid/-/ulid-2.4.0.tgz",
       "integrity": "sha512-fIRiVTJNcSRmXKPZtGzFQv9WRrZ3M9eoptl/teFJvjOzmpU+/K/JH6HZ8deBfb5vMEpicJcLn7JmvdknlMq7Zg==",
       "license": "MIT",
-      "peer": true,
       "bin": {
         "ulid": "bin/cli.js"
       }
@@ -39867,6 +39874,7 @@
       "integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",
@@ -40476,6 +40484,7 @@
       "integrity": "sha512-hOQuK7h0FGKgBAas7v0mSAsnvrIgAvWmRFjmzpJ7SwFHH3g1k2u37JtYwOwmEKhK6ZO3v9ggDBBm0La1LCK4uQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@vitest/expect": "4.0.18",
         "@vitest/mocker": "4.0.18",
@@ -40722,6 +40731,7 @@
       "integrity": "sha512-gX/dMkRQc7QOMzgTe6KsYFM7DxeIONQSui1s0n/0xht36HvrgbxtM1xBlgx596NbpHuQU8P7QpKwrZYwUX48nw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/eslint-scope": "^3.7.7",
         "@types/estree": "^1.0.8",
@@ -40771,6 +40781,7 @@
       "integrity": "sha512-MfwFQ6SfwinsUVi0rNJm7rHZ31GyTcpVE5pgVA3hwFRb7COD4TzjUUwhGWKfO50+xdc2MQPuEBBJoqIMGt3JDw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@discoveryjs/json-ext": "^0.6.1",
         "@webpack-cli/configtest": "^3.0.1",
@@ -40854,6 +40865,7 @@
       "integrity": "sha512-QcQ72gh8a+7JO63TAx/6XZf/CWhgMzu5m0QirvPfGvptOusAxG12w2+aua1Jkjr7hzaWDnJ2n6JFeexMHI+Zjg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/bonjour": "^3.5.13",
         "@types/connect-history-api-fallback": "^1.5.4",
@@ -41875,6 +41887,7 @@
       "integrity": "sha512-mplynKqc1C2hTVYxd0PU2xQAc22TI1vShAYGksCCfxbn/dFwnHTNi1bvYsBTkhdUNtGIf5xNOg938rrSSYvS9A==",
       "dev": true,
       "license": "ISC",
+      "peer": true,
       "bin": {
         "yaml": "bin.mjs"
       },
@@ -41968,6 +41981,7 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
       "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }
@@ -43560,6 +43574,7 @@
     "packages/AI/Prompts/node_modules/date-fns": {
       "version": "2.30.0",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.21.0"
       },
@@ -47189,6 +47204,7 @@
       "integrity": "sha512-dZwN5L1VlUBewiP6H9s2+B3e3Jg96D0vzN+Ry73sOefebhYr9f94wwkMNN/9ouoU8pV1BqA1d1zGk8928cx0rg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",
@@ -51348,7 +51364,7 @@
         "mssql": "^11.0.1",
         "ora-classic": "^5.4.2",
         "pg": "^8.13.1",
-        "pg-query-stream": "^4.7.1",
+        "pg-query-stream": "~4.8.0",
         "recast": "^0.23.11",
         "simple-git": "^3.30.0",
         "zod": "~3.24.4"
@@ -51613,6 +51629,18 @@
       },
       "engines": {
         "node": ">=18"
+      }
+    },
+    "packages/MJCLI/node_modules/pg-query-stream": {
+      "version": "4.8.1",
+      "resolved": "https://registry.npmjs.org/pg-query-stream/-/pg-query-stream-4.8.1.tgz",
+      "integrity": "sha512-kZo6C6HSzYFF6mlwl+etDk5QZD9CMdlHUXpof6PkK9+CHHaBLvOd2lZMwErOOpC/ldg4thrAojS8sG1B8PZ9Yw==",
+      "license": "MIT",
+      "dependencies": {
+        "pg-cursor": "^2.13.1"
+      },
+      "peerDependencies": {
+        "pg": "^8"
       }
     },
     "packages/MJCLI/node_modules/sprintf-js": {
@@ -52468,6 +52496,7 @@
       "integrity": "sha512-dZwN5L1VlUBewiP6H9s2+B3e3Jg96D0vzN+Ry73sOefebhYr9f94wwkMNN/9ouoU8pV1BqA1d1zGk8928cx0rg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",

--- a/packages/Actions/CoreActions/src/custom/interactive-forms/_shared.ts
+++ b/packages/Actions/CoreActions/src/custom/interactive-forms/_shared.ts
@@ -6,6 +6,7 @@
  */
 import { ActionResultSimple, RunActionParams } from "@memberjunction/actions-base";
 import { IMetadataProvider, UserInfo } from "@memberjunction/core";
+import { UUIDsEqual } from "@memberjunction/global";
 import {
     MJComponentEntity,
     MJEntityFormOverrideEntity,
@@ -168,7 +169,7 @@ export function checkOverrideOwnership(
     const ID = override.ID;
     switch (override.Scope) {
         case 'User': {
-            if (override.UserID !== user.ID) {
+            if (!UUIDsEqual(override.UserID, user.ID)) {
                 return failure(
                     "FORBIDDEN",
                     `Override ${ID} is User-scoped to a different user. Only the owning user can mutate it.`,

--- a/packages/Actions/CoreActions/src/custom/interactive-forms/revert-interactive-form.action.ts
+++ b/packages/Actions/CoreActions/src/custom/interactive-forms/revert-interactive-form.action.ts
@@ -1,7 +1,7 @@
 import { ActionResultSimple, RunActionParams } from "@memberjunction/actions-base";
 import { BaseAction } from "@memberjunction/actions";
 import { Metadata, LogError, RunView } from "@memberjunction/core";
-import { RegisterClass } from "@memberjunction/global";
+import { RegisterClass, UUIDsEqual } from "@memberjunction/global";
 import {
     addOutput, checkOverrideOwnership, failure, getNumberParam, getStringParam, loadComponent, loadOverride, mapToComponentStatus,
 } from "./_shared";
@@ -107,7 +107,7 @@ export class RevertInteractiveFormAction extends BaseAction {
             if (!target) {
                 return failure("COMPONENT_NOT_FOUND", "Could not resolve target Component.");
             }
-            if (target.ID === currentComponent.ID) {
+            if (UUIDsEqual(target.ID, currentComponent.ID)) {
                 addOutput(params, "OverrideID", override.ID);
                 addOutput(params, "ComponentID", target.ID);
                 addOutput(params, "PreviousComponentID", null);

--- a/packages/Angular/Explorer/dashboards/src/ComponentStudio/components/ai-assistant/ai-assistant-panel.component.ts
+++ b/packages/Angular/Explorer/dashboards/src/ComponentStudio/components/ai-assistant/ai-assistant-panel.component.ts
@@ -6,8 +6,9 @@ import {
     OnInit,
     inject,
 } from '@angular/core';
-import { CompositeKey, LogError, Metadata } from '@memberjunction/core';
+import { CompositeKey, LogError } from '@memberjunction/core';
 import type { UserInfo } from '@memberjunction/core';
+import { UUIDsEqual } from '@memberjunction/global';
 import { AIEngineBase } from '@memberjunction/ai-engine-base';
 import { BaseAngularComponent } from '@memberjunction/ng-base-types';
 import { Subject, Subscription, takeUntil } from 'rxjs';
@@ -156,7 +157,7 @@ export class AIAssistantPanelComponent extends BaseAngularComponent implements O
                 LogError(`AIAssistantPanel: '${AIAssistantPanelComponent.CODESMITH_AGENT_NAME}' not found in AIEngineBase cache`);
             }
 
-            const md = new Metadata();
+            const md = this.ProviderToUse;
             const app = md.Applications?.find(
                 a => a.Name?.trim().toLowerCase() === AIAssistantPanelComponent.COCKPIT_APP_NAME.toLowerCase()
             );
@@ -279,7 +280,7 @@ export class AIAssistantPanelComponent extends BaseAngularComponent implements O
     }
 
     public OnConversationRenamed(event: { conversationId: string; name: string; description: string }): void {
-        if (this.ChatConversation && this.ChatConversation.ID === event.conversationId) {
+        if (this.ChatConversation && UUIDsEqual(this.ChatConversation.ID, event.conversationId)) {
             this.ChatConversation.Name = event.name;
             if (event.description !== undefined) {
                 this.ChatConversation.Description = event.description;

--- a/packages/Angular/Explorer/dashboards/src/FormBuilder/form-builder-resource.component.ts
+++ b/packages/Angular/Explorer/dashboards/src/FormBuilder/form-builder-resource.component.ts
@@ -6,7 +6,7 @@ import {
     OnDestroy,
     inject,
 } from '@angular/core';
-import { BaseEntity, BaseEntityEvent, CompositeKey, LogError, Metadata, RunView } from '@memberjunction/core';
+import { BaseEntity, BaseEntityEvent, CompositeKey, LogError, RunView } from '@memberjunction/core';
 import { MJGlobal, MJEventType, MJEvent } from '@memberjunction/global';
 import type { IMetadataProvider, UserInfo } from '@memberjunction/core';
 import { ResourceData, MJEnvironmentEntityExtended, UserInfoEngine, ComponentMetadataEngine, InteractiveFormsEngine } from '@memberjunction/core-entities';
@@ -510,7 +510,7 @@ export class FormBuilderResourceComponent
             // cache. Used to scope chat conversations to this cockpit so
             // they don't pollute the main Chat list. Deterministic name-
             // based lookup against in-memory data — no RunView.
-            const md = new Metadata();
+            const md = this.provider;
             const app = md.Applications?.find(
                 a => a.Name?.trim().toLowerCase() === FormBuilderResourceComponent.COCKPIT_APP_NAME.toLowerCase()
             );
@@ -1139,7 +1139,7 @@ export class FormBuilderResourceComponent
         const form = this.ContextMenuForm;
         this.CloseContextMenu();
         if (!form) return;
-        if (this.SelectedFormID !== form.ID) await this.OnFormPicked(form);
+        if (!UUIDsEqual(this.SelectedFormID, form.ID)) await this.OnFormPicked(form);
         await this.OnDelete();
     }
 
@@ -1157,7 +1157,7 @@ export class FormBuilderResourceComponent
         const form = this.ContextMenuForm;
         this.CloseContextMenu();
         if (!form) return;
-        if (this.SelectedFormID !== form.ID) {
+        if (!UUIDsEqual(this.SelectedFormID, form.ID)) {
             this.notifications.CreateSimpleNotification(
                 `Open "${form.Name}" first, then export from there.`, 'info', 4000);
             return;
@@ -1523,7 +1523,7 @@ export class FormBuilderResourceComponent
         // title in the chat-area stays in sync if we ever re-render. The
         // chat-area updates its own title via the conversation entity,
         // but we keep this hook here for parity with the workspace shell.
-        if (this.ChatConversation && this.ChatConversation.ID === event.conversationId) {
+        if (this.ChatConversation && UUIDsEqual(this.ChatConversation.ID, event.conversationId)) {
             this.ChatConversation.Name = event.name;
             if (event.description !== undefined) {
                 this.ChatConversation.Description = event.description;
@@ -1739,7 +1739,7 @@ export class FormBuilderResourceComponent
      */
     public async PickLineageConversation(c: { ID: string; Name: string | null }): Promise<void> {
         this.ConversationHistoryDropdownOpen = false;
-        if (c.ID === this.ChatConversationId) {
+        if (UUIDsEqual(c.ID, this.ChatConversationId)) {
             this.cdr.markForCheck();
             return;
         }
@@ -2001,7 +2001,7 @@ export class FormBuilderResourceComponent
      * push, etc.).
      */
     public async OnVersionRowClick(v: ComponentVersionRow): Promise<void> {
-        if (v.ID === this.SelectedFormID) return;
+        if (UUIDsEqual(v.ID, this.SelectedFormID)) return;
         const summary: FormComponentSummary = {
             ID: v.ID,
             Name: v.Name,
@@ -2030,7 +2030,7 @@ export class FormBuilderResourceComponent
             this.cdr.markForCheck();
             return;
         }
-        if (this.DiffSourceVersionID === v.ID) {
+        if (UUIDsEqual(this.DiffSourceVersionID, v.ID)) {
             // Same version clicked again — cancel selection.
             this.DiffSourceVersionID = null;
             this.cdr.markForCheck();
@@ -3075,7 +3075,7 @@ export class FormBuilderResourceComponent
             // Resolve RelatedEntity name from the ID. EntityRelationshipInfo
             // doesn't carry the friendly name directly; look it up from
             // the provider's cached entity list.
-            const related = provider.Entities?.find(e => e.ID === r.RelatedEntityID);
+            const related = provider.Entities?.find(e => UUIDsEqual(e.ID, r.RelatedEntityID));
             const name = related?.Name ?? '(unknown)';
             const type = (r.Type ?? 'One To Many').trim();
             const display = r.DisplayName && r.DisplayName !== name ? ` — ${r.DisplayName}` : '';

--- a/packages/Angular/Explorer/explorer-core/src/lib/services/form-resolver.service.ts
+++ b/packages/Angular/Explorer/explorer-core/src/lib/services/form-resolver.service.ts
@@ -204,7 +204,7 @@ export class FormResolverService {
         // all three; pickActive() filters to Active separately). Replaces
         // a per-LoadForm RunView with an in-memory predicate — sub-ms.
         const applicable = InteractiveFormsEngine.Instance.Overrides.filter(o => {
-            if (!o.EntityID || o.EntityID.toLowerCase() !== entity.ID.toLowerCase()) return false;
+            if (!o.EntityID || !UUIDsEqual(o.EntityID, entity.ID)) return false;
             if (o.Scope === 'User')   return !!o.UserID && o.UserID.toLowerCase() === user.ID.toLowerCase();
             if (o.Scope === 'Role')   return !!o.RoleID && userRoleIds.has(o.RoleID);
             if (o.Scope === 'Global') return true;

--- a/packages/Angular/Generic/base-forms/src/lib/container/record-form-container.component.ts
+++ b/packages/Angular/Generic/base-forms/src/lib/container/record-form-container.component.ts
@@ -5,6 +5,7 @@ import {
   ViewChild, ViewEncapsulation
 } from '@angular/core';
 import { BaseEntity, CompositeKey, EntityInfo, Metadata, RunView } from '@memberjunction/core';
+import { UUIDsEqual } from '@memberjunction/global';
 import { BaseAngularComponent } from '@memberjunction/ng-base-types';
 import { UserInfoEngine } from '@memberjunction/core-entities';
 import { Subject } from 'rxjs';
@@ -822,7 +823,7 @@ export class MjRecordFormContainerComponent extends BaseAngularComponent impleme
 
   /** Label for the currently-selected variant (or "Default form" if none). */
   get CurrentVariantLabel(): string {
-    const v = this.EffectiveVariants?.find(x => x.ID === this.EffectiveCurrentVariantID);
+    const v = this.EffectiveVariants?.find(x => UUIDsEqual(x.ID, this.EffectiveCurrentVariantID));
     return v?.Label ?? 'Default form';
   }
 

--- a/packages/Angular/Generic/base-forms/src/lib/toolbar/form-toolbar.component.ts
+++ b/packages/Angular/Generic/base-forms/src/lib/toolbar/form-toolbar.component.ts
@@ -1,5 +1,6 @@
 import { Component, Input, Output, EventEmitter, ChangeDetectionStrategy, TemplateRef, ChangeDetectorRef, inject, DoCheck } from '@angular/core';
 import { BaseEntity, EntityInfo, CompositeKey } from '@memberjunction/core';
+import { UUIDsEqual } from '@memberjunction/global';
 import { FormToolbarConfig, DEFAULT_TOOLBAR_CONFIG } from '../types/toolbar-config';
 import { FormNavigationEvent } from '../types/navigation-events';
 import { DiscoverISADescendants, BuildDescendantTree, IsaRelatedItem } from '../isa-related-panel/isa-hierarchy-utils';
@@ -566,7 +567,7 @@ export class MjFormToolbarComponent implements DoCheck {
 
   /** Label for the currently-active variant, or "Default form" when none. */
   public get CurrentVariantLabel(): string {
-    const v = this.Variants?.find(x => x.ID === this.CurrentVariantID);
+    const v = this.Variants?.find(x => UUIDsEqual(x.ID, this.CurrentVariantID));
     return v?.Label ?? 'Default form';
   }
 

--- a/packages/MJCore/src/generic/entityInfo.ts
+++ b/packages/MJCore/src/generic/entityInfo.ts
@@ -1,5 +1,6 @@
 import { BaseInfo } from "./baseInfo"
 import { Metadata } from "./metadata"
+import { IMetadataProvider } from "./interfaces"
 import { RunViewParams } from "../views/runView"
 import { BaseEntity } from "./baseEntity"
 import { RowLevelSecurityFilterInfo, UserInfo, UserRoleInfo } from "./securityInfo"
@@ -2345,9 +2346,10 @@ export class EntityInfo extends BaseInfo {
      */
     private static ResolveSpokeOrganicKey(
         relatedEntity: EntityOrganicKeyRelatedEntityInfo,
-        hubOrganicKey: EntityOrganicKeyInfo
+        hubOrganicKey: EntityOrganicKeyInfo,
+        provider?: IMetadataProvider
     ): EntityOrganicKeyInfo | undefined {
-        const md = Metadata.Provider;
+        const md = provider ?? Metadata.Provider;
         if (!md) return undefined;
         const spokeEntity = md.EntityByName?.(relatedEntity.RelatedEntity)
             ?? md.Entities?.find?.((e: EntityInfo) => e.Name === relatedEntity.RelatedEntity);

--- a/packages/TestingFramework/CLI/src/commands/compare.ts
+++ b/packages/TestingFramework/CLI/src/commands/compare.ts
@@ -171,7 +171,7 @@ export class CompareCommand {
             }
 
             // Load both suite runs
-            const md = new Metadata();
+            const md = new Metadata(); // global-provider-ok: CLI tool runs in single-user, single-connection context
             const previousRun = await md.GetEntityObject<MJTestSuiteRunEntity>('MJ: Test Suite Runs', contextUser);
             const currentRun = await md.GetEntityObject<MJTestSuiteRunEntity>('MJ: Test Suite Runs', contextUser);
 


### PR DESCRIPTION
## Summary

Clears the two MJGlobal compliance gates (`MultiProviderCompliance` and `UUIDCompliance`) that started failing when their last allowlist baselines were lifted. These tests scan the entire `packages/` tree for two anti-patterns; this PR migrates the remaining offenders to the patterns each test prescribes.

The violations were pre-existing on `next` — not introduced by recent work. They're holdovers from the April 30 multi-provider refactor ([9cab2794cc](https://github.com/MemberJunction/MJ/commit/9cab2794cc), "thread IMetadataProvider through ~780 sites across 110+ packages") that slipped past the sweep, plus a few stale UUID comparisons.

## Multi-provider compliance (4 sites)

The scanner flags any non-allowlisted `new Metadata()` / `Metadata.Provider` reference because in multi-provider scenarios these silently resolve to the wrong provider. Per the test's own error message, the prescribed fixes (in priority order) are: `this.ProviderToUse` → optional `provider?:` param with `??` fallback → `// global-provider-ok:` comment.

| File | Fix |
|---|---|
| `Angular/Explorer/dashboards/.../ai-assistant-panel.component.ts:159` | `new Metadata()` → `this.ProviderToUse` (component extends `BaseAngularComponent`) |
| `Angular/Explorer/dashboards/.../form-builder-resource.component.ts:513` | `new Metadata()` → `this.provider` (existing getter wrapping `ProviderToUse`) |
| `MJCore/src/generic/entityInfo.ts:2350` | `ResolveSpokeOrganicKey` now accepts optional `provider?: IMetadataProvider`; uses `provider ?? Metadata.Provider` fallback (recognized as the legitimate terminal pattern by the scanner) |
| `TestingFramework/CLI/src/commands/compare.ts:174` | `// global-provider-ok:` — CLI tool, single-user / single-connection context |

Unused `Metadata` imports removed where edits orphaned them.

## UUID compliance (13 sites across 7 files)

The scanner flags `.ID === / !==` and similar direct comparisons because SQL Server returns UUIDs uppercase and PostgreSQL returns them lowercase — `===` breaks cross-database compatibility. All flagged comparisons replaced with `UUIDsEqual()` from `@memberjunction/global` (handles null/undefined and case-insensitive matching natively).

Notable: `form-resolver.service.ts:207` collapsed its `.toLowerCase() !== .toLowerCase()` workaround into a single `!UUIDsEqual(...)` call.

| File | Sites |
|---|---|
| `Actions/CoreActions/.../interactive-forms/_shared.ts` | 1 |
| `Actions/CoreActions/.../interactive-forms/revert-interactive-form.action.ts` | 1 |
| `Angular/Explorer/dashboards/.../ai-assistant-panel.component.ts` | 1 |
| `Angular/Explorer/dashboards/.../form-builder-resource.component.ts` | 7 |
| `Angular/Explorer/explorer-core/.../form-resolver.service.ts` | 1 |
| `Angular/Generic/base-forms/.../record-form-container.component.ts` | 1 |
| `Angular/Generic/base-forms/.../form-toolbar.component.ts` | 1 |

`UUIDsEqual` import added to 5 files; the other 2 already imported it.

## Test plan

- [x] `@memberjunction/global` tests — was 430/432, now **432/432** (both compliance tests green)
- [x] `@memberjunction/core` tests — 1178/1178
- [x] `@memberjunction/core-actions` tests — 206/206
- [x] `@memberjunction/testing-cli` tests — 23/23
- [x] Type-check / build clean: MJCore, CoreActions, TestingFramework/CLI, ng-base-forms, ng-explorer-core, ng-dashboards

🤖 Generated with [Claude Code](https://claude.com/claude-code)
