### PR TITLE
fix(generic-database-provider): use UUIDsEqual for AIModel ID comparison

### DIFF
--- a/.changeset/fix-genericdb-uuid-comparison.md
+++ b/.changeset/fix-genericdb-uuid-comparison.md
@@ -1,0 +1,5 @@
+---
+"@memberjunction/generic-database-provider": patch
+---
+
+Use `UUIDsEqual()` instead of `===` for the AIModel ID comparison in `searchEntitiesSemanticPass`, fixing the repo-wide UUID-comparison compliance check.

--- a/packages/GenericDatabaseProvider/src/GenericDatabaseProvider.ts
+++ b/packages/GenericDatabaseProvider/src/GenericDatabaseProvider.ts
@@ -3815,7 +3815,7 @@ export abstract class GenericDatabaseProvider extends DatabaseProviderBase {
         let queryVector: number[] | null = null;
         try {
             if (embeddingAIModelId) {
-                const model = AIEngine.Instance.Models.find(m => m.ID === embeddingAIModelId);
+                const model = AIEngine.Instance.Models.find(m => UUIDsEqual(m.ID, embeddingAIModelId));
                 if (!model) {
                     LogError(`searchEntitiesSemanticPass: EntityDocument AIModelID="${embeddingAIModelId}" not found in AIEngine.Models. Index/query model mismatch is likely — refusing to fall back silently.`);
                     return [];


### PR DESCRIPTION
One-line compliance fix, independent of any feature work.

`GenericDatabaseProvider.searchEntitiesSemanticPass` compared an AIModel ID with `===`:

```ts
const model = AIEngine.Instance.Models.find(m => m.ID === embeddingAIModelId);
```

This trips the repo-wide UUID-comparison compliance check (`@memberjunction/global` `UUIDCompliance.test.ts`), which currently fails on `next`. `UUIDsEqual` is already imported and used throughout this file — switched the comparison to match:

```ts
const model = AIEngine.Instance.Models.find(m => UUIDsEqual(m.ID, embeddingAIModelId));
```

Verified the `UUIDCompliance` test passes with this change. Includes a patch changeset for `@memberjunction/generic-database-provider`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)