### PR TITLE
fix: own ConversationDetailAttachment deprecation via SQL Server extended property

### DIFF
--- a/.changeset/tidy-suits-shop.md
+++ b/.changeset/tidy-suits-shop.md
@@ -1,0 +1,5 @@
+---
+"@memberjunction/core": minor
+---
+
+Drop the SQL Server MS_Description extended property on ConversationDetailAttachment to the DEPRECATED notice text so R\_\_RefreshMetadata propagates it into Entity.Description on every migrate cycle — eliminating the drift that the metadata-sync file alone could not fix.

--- a/metadata/entities/.conversation-detail-attachments-deprecation.json
+++ b/metadata/entities/.conversation-detail-attachments-deprecation.json
@@ -1,15 +1,15 @@
 [
   {
     "fields": {
-      "Status": "Deprecated",
-      "Description": "DEPRECATED: file uploads now flow through ConversationArtifactVersion so they share storage, identity, versioning, permissions, and the artifact-tool dispatch path. Table, generated entity class, GraphQL types, and stored procedures all remain functional — runtime use produces a console warning per the framework's standard handling of Status='Deprecated'. See packages/AI/Agents/docs/ARTIFACT_TOOLS_GUIDE.md for migration guidance. Originally: Stores attachments (images, videos, audio, documents) for conversation messages."
+      "Name": "MJ: Conversation Detail Attachments",
+      "Status": "Deprecated"
     },
     "primaryKey": {
       "ID": "@lookup:MJ: Entities.Name=MJ: Conversation Detail Attachments"
     },
     "sync": {
-      "lastModified": "2026-06-02T13:26:49.884Z",
-      "checksum": "d1fbd161fd1ff39347607648d3909d9c0617412623a6d39db5f39a5fbca4648e"
+      "lastModified": "2026-06-02T19:37:04.740Z",
+      "checksum": "a8efbd05640f470f66513347f451ce704a893a9d4b9ad5ad4049c18726fa6d1e"
     }
   }
 ]

--- a/migrations/v5/V202606021427__v5.39.x__Deprecate_ConversationDetailAttachment_Description.sql
+++ b/migrations/v5/V202606021427__v5.39.x__Deprecate_ConversationDetailAttachment_Description.sql
@@ -1,0 +1,42 @@
+-- =====================================================
+-- v5.39.x — Deprecate ConversationDetailAttachment table description
+-- =====================================================
+-- Updates the MS_Description extended property on the ConversationDetailAttachment
+-- table to mark it deprecated. Because the corresponding Entity record has
+-- AutoUpdateDescription=1, R__RefreshMetadata's spUpdateExistingEntitiesFromSchema
+-- propagates this extended property into Entity.Description on every migrate cycle.
+--
+-- Without this migration, the metadata-sync file
+-- metadata/entities/.conversation-detail-attachments-deprecation.json showed
+-- perpetual "drift" on Entity.Description because each migrate cycle reverted
+-- it back to the original "Stores attachments..." text from the stale extended
+-- property. The metadata file now sets Status='Deprecated' only; the description
+-- is owned here, by the extended property.
+--
+-- File uploads have moved to ConversationArtifactVersion. Table, generated
+-- entity class, GraphQL types, and stored procedures all remain functional —
+-- runtime use produces a console warning per the framework's standard handling
+-- of Status='Deprecated'. See packages/AI/Agents/docs/ARTIFACT_TOOLS_GUIDE.md
+-- for migration guidance.
+
+IF EXISTS (
+    SELECT 1
+    FROM sys.extended_properties
+    WHERE major_id = OBJECT_ID('${flyway:defaultSchema}.ConversationDetailAttachment')
+      AND minor_id = 0
+      AND name = 'MS_Description'
+)
+BEGIN
+    EXEC sp_dropextendedproperty
+        @name = N'MS_Description',
+        @level0type = N'SCHEMA', @level0name = N'${flyway:defaultSchema}',
+        @level1type = N'TABLE',  @level1name = N'ConversationDetailAttachment';
+END;
+GO
+
+EXEC sp_addextendedproperty
+    @name = N'MS_Description',
+    @value = N'DEPRECATED: file uploads now flow through ConversationArtifactVersion so they share storage, identity, versioning, permissions, and the artifact-tool dispatch path. Table, generated entity class, GraphQL types, and stored procedures all remain functional — runtime use produces a console warning per the framework''s standard handling of Status=''Deprecated''. See packages/AI/Agents/docs/ARTIFACT_TOOLS_GUIDE.md for migration guidance. Originally: Stores attachments (images, videos, audio, documents) for conversation messages.',
+    @level0type = N'SCHEMA', @level0name = N'${flyway:defaultSchema}',
+    @level1type = N'TABLE',  @level1name = N'ConversationDetailAttachment';
+GO


### PR DESCRIPTION
## Summary

The `metadata/entities/.conversation-detail-attachments-deprecation.json` file set `Entity.Description` to the DEPRECATED notice on the `ConversationDetailAttachment` entity, but every `mj migrate` cycle silently reverted it back to the original \"Stores attachments...\" text. This PR moves ownership of the description to the SQL Server extended property (the single source of truth when `AutoUpdateDescription=1`), eliminating the drift permanently.

## The bug

Reproduction on a fresh DB:

1. `mj migrate` applies the v5.38 Metadata_Sync migration → `Entity.Description = DEPRECATED text` ✓
2. `mj migrate` continues to `R__RefreshMetadata` (repeatable migration that runs every cycle by design — embedded `${flyway:timestamp}` ensures its checksum is always new)
3. `R__RefreshMetadata` calls `spUpdateExistingEntitiesFromSchema`. That sproc's logic ([proven via `OBJECT_DEFINITION` query](https://github.com/MemberJunction/MJ/pull/2738)):

   ```sql
   IIF(e.AutoUpdateDescription = 1, fromSQL.EntityDescription, e.Description) AS NewDescription
   ```

   For entities with `AutoUpdateDescription = 1` (the default), the extended property wins. Since the `ConversationDetailAttachment` table's `MS_Description` extended property was still the original \"Stores attachments...\" text, `Entity.Description` got reverted.

4. `mj sync push` then detects the drift, re-applies DEPRECATED, and reports `Updated: 1` — but the next `mj migrate` reverts it again. Perpetual drift loop.

## The fix

**Migration:** [`V202606021427__v5.39.x__Deprecate_ConversationDetailAttachment_Description.sql`](https://github.com/MemberJunction/MJ/blob/fix/deprecate-conversation-detail-attachments/migrations/v5/V202606021427__v5.39.x__Deprecate_ConversationDetailAttachment_Description.sql) drops + re-adds the table-level `MS_Description` extended property with the DEPRECATED notice text. Because `AutoUpdateDescription = 1`, the next `R__RefreshMetadata` run propagates it into `Entity.Description` correctly — and keeps doing so on every subsequent migrate cycle. Follows the same pattern as 5 other v5 migrations (e.g. [`V202605190912__v5.35.x__Artifact_Attachment_Unification.sql`](https://github.com/MemberJunction/MJ/blob/next/migrations/v5/V202605190912__v5.35.x__Artifact_Attachment_Unification.sql)).

**Metadata file trim:** [`metadata/entities/.conversation-detail-attachments-deprecation.json`](https://github.com/MemberJunction/MJ/blob/fix/deprecate-conversation-detail-attachments/metadata/entities/.conversation-detail-attachments-deprecation.json) now sets only `Name` and `Status: Deprecated`. The `Description` field has been removed — that ownership now belongs to the migration. `Status` stays in the metadata file because it has no extended-property equivalent and isn't auto-synced.

## Architectural note

The bug surfaced a class of problem: any metadata file setting `Description` (or any other field with a `spUpdateExistingEntitiesFromSchema` propagation path) on an entity with `AutoUpdateDescription = 1` will silently drift forever. Worth considering a future MetadataSync validator that flags this conflict pattern (refuses or warns when `Description` is set on an entity with `AutoUpdateDescription = 1`, directing the developer to either author an extended-property migration or explicitly set `AutoUpdateDescription: false`). Out of scope for this PR.

## Test plan

Verified end-to-end on a fresh `DEP_TEST` SQL Server database:

- [x] `mj migrate` applies the new v5.39 migration cleanly
- [x] `Entity.Description` is the DEPRECATED text immediately after `mj migrate` (no `mj sync push` needed)
- [x] `R__RefreshMetadata` re-runs on a second `mj migrate` and does NOT revert the value
- [x] `mj sync push` after a clean migrate produces an empty git diff on the deprecation metadata file (no checksum bump, no DB write — confirmed via `__mj_UpdatedAt` unchanged from migrate time)
- [x] No CodeGen needed (extended-property text change has no impact on generated code, sprocs, views, or types)

🤖 Generated with [Claude Code](https://claude.com/claude-code)