### PR TITLE
feat(forms): inline create-new from FK fields + new-record System Metadata default + create-perm gate

### DIFF
--- a/.changeset/fk-inline-create-and-create-perm-gate.md
+++ b/.changeset/fk-inline-create-and-create-perm-gate.md
@@ -1,0 +1,28 @@
+---
+"@memberjunction/core": patch
+"@memberjunction/ng-base-forms": patch
+"@memberjunction/ng-explorer-core": patch
+---
+
+feat(forms): inline "create new" from FK fields (event-based) + fold Allow\*API into entity permissions
+
+When the related record you need isn't in a foreign-key dropdown, you can now create it
+inline. A sticky "➕ Create …" footer (always visible at the bottom of the dropdown,
+prefilled with whatever you typed) requests creation; the new record is auto-selected into
+the field once saved. Gated on create permission + a new `@Input() AllowFKCreate` (default
+true); surface configurable via `@Input() FKCreatePresentation: 'dialog' | 'slide-in'`.
+
+**`@memberjunction/ng-base-forms`** — the Generic FK field stays generic: it only *emits* a
+new `create-related` `FormNavigationEvent` (carrying the entity, prefill `NewRecordValues`,
+preferred presentation, provider, and a `Complete(record)` callback). It does **not** open
+the form itself — that would couple a generic component to the app-level form presenter.
+
+**`@memberjunction/ng-explorer-core`** — `SingleRecordComponent` handles the new
+`create-related` event: opens the related entity's form via `MJFormPresenterService`
+(dialog/slide-in, prefilled), then calls `event.Complete(savedRecord)` so the field selects it.
+
+**`@memberjunction/core`** — `EntityInfo.GetUserPermisions()` now folds the entity's
+`Allow{Create,Update,Delete}API` flags into the corresponding `Can*` results. An API-driven
+action requires both a role grant **and** the entity allowing that action at all, so a user
+can no longer be reported as able to create/update/delete records of an entity whose API for
+that action is disabled. (Read is unchanged — it has no `Allow*API` flag.)

--- a/packages/Angular/Explorer/explorer-core/src/lib/single-record/single-record.component.ts
+++ b/packages/Angular/Explorer/explorer-core/src/lib/single-record/single-record.component.ts
@@ -1,6 +1,6 @@
 import { Component, EventEmitter, inject, Input, Output } from '@angular/core';
 import { CompositeKey, BaseEntity } from '@memberjunction/core';
-import { FormNavigationEvent, FormNotificationEvent } from '@memberjunction/ng-base-forms';
+import { FormNavigationEvent, FormNotificationEvent, MJFormPresenterService } from '@memberjunction/ng-base-forms';
 import { NavigationService, RecentAccessService, SharedService } from '@memberjunction/ng-shared';
 import { BaseAngularComponent } from '@memberjunction/ng-base-types';
 
@@ -36,6 +36,7 @@ export class SingleRecordComponent extends BaseAngularComponent {
 
   private navigationService = inject(NavigationService);
   private sharedService = inject(SharedService);
+  private formPresenter = inject(MJFormPresenterService);
   private recentAccessService = new RecentAccessService();
 
   /** Unblock the shell's first-resource-load gate (success or error). */
@@ -84,6 +85,19 @@ export class SingleRecordComponent extends BaseAngularComponent {
       case 'dismiss':
         this.recordDismissed.emit();
         break;
+      case 'create-related': {
+        // A FK field wants a new related record created. Open the related entity's form
+        // as a dialog/slide-in (prefilled), then hand the saved record back so the field
+        // can select it.
+        const ref = this.formPresenter.Open({
+          EntityName: event.EntityName,
+          Presentation: event.Presentation ?? 'dialog',
+          NewRecordValues: event.NewRecordValues,
+          Provider: event.Provider,
+        });
+        ref.AfterSaved().then(created => event.Complete(created));
+        break;
+      }
     }
   }
 }

--- a/packages/Angular/Generic/base-forms/src/lib/field/form-field.component.css
+++ b/packages/Angular/Generic/base-forms/src/lib/field/form-field.component.css
@@ -914,6 +914,107 @@
   white-space: nowrap;
 }
 
+/* ============================================
+   PINNED "CURRENTLY SELECTED" SECTION
+   ============================================ */
+.mj-fk-current {
+  border-bottom: 1px solid var(--mj-border-default);
+  background: color-mix(in srgb, var(--mj-brand-primary) 7%, var(--mj-bg-surface-card));
+  animation: mj-fk-current-in 220ms cubic-bezier(0.22, 1, 0.36, 1);
+}
+
+@keyframes mj-fk-current-in {
+  from { opacity: 0; transform: translateY(-6px); }
+  to   { opacity: 1; transform: translateY(0); }
+}
+
+.mj-fk-current-head {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 8px 12px 3px;
+  font-size: 10px;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--mj-brand-primary);
+}
+
+.mj-fk-current-head i {
+  font-size: 10px;
+}
+
+.mj-fk-current-row {
+  position: relative;
+  display: flex;
+  align-items: center;
+  gap: 9px;
+  padding: 6px 12px 10px;
+  cursor: pointer;
+  transition: background var(--mj-transition-base);
+}
+
+/* Accent bar on the left for a bit of sizzle. */
+.mj-fk-current-row::before {
+  content: '';
+  position: absolute;
+  left: 0;
+  top: 4px;
+  bottom: 8px;
+  width: 3px;
+  border-radius: 0 2px 2px 0;
+  background: var(--mj-brand-primary);
+}
+
+.mj-fk-current-row:hover {
+  background: color-mix(in srgb, var(--mj-brand-primary) 10%, transparent);
+}
+
+.mj-fk-current-icon {
+  flex-shrink: 0;
+  font-size: 13px;
+  color: var(--mj-text-muted);
+}
+
+.mj-fk-current-name {
+  font-weight: 600;
+  font-size: 14px;
+  color: var(--mj-text-primary);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.mj-fk-current-detail {
+  font-size: 13px;
+  color: var(--mj-text-muted);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.mj-fk-current-clear {
+  margin-left: auto;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 22px;
+  height: 22px;
+  flex-shrink: 0;
+  background: transparent;
+  border: none;
+  border-radius: 4px;
+  color: var(--mj-text-muted);
+  cursor: pointer;
+  font-size: 12px;
+  transition: background var(--mj-transition-base), color var(--mj-transition-base);
+}
+
+.mj-fk-current-clear:hover {
+  background: var(--mj-bg-surface-hover);
+  color: var(--mj-status-error);
+}
+
 @keyframes mj-dropdown-in {
   from { opacity: 0; transform: translateY(-4px); }
   to { opacity: 1; transform: translateY(0); }

--- a/packages/Angular/Generic/base-forms/src/lib/field/form-field.component.css
+++ b/packages/Angular/Generic/base-forms/src/lib/field/form-field.component.css
@@ -879,6 +879,41 @@
   font-style: italic;
 }
 
+/* Sticky "create new" footer — sits below the (scrolling) options as a direct child of
+   the dropdown panel, so it's always visible regardless of list length. */
+.mj-fk-create-footer {
+  display: flex;
+  align-items: center;
+  gap: 9px;
+  width: 100%;
+  padding: 10px 14px;
+  background: var(--mj-bg-surface-card);
+  border: none;
+  border-top: 1px solid var(--mj-border-default);
+  color: var(--mj-brand-primary);
+  font-size: 13px;
+  font-weight: 600;
+  font-family: inherit;
+  text-align: left;
+  cursor: pointer;
+  transition: background var(--mj-transition-base);
+}
+
+.mj-fk-create-footer:hover {
+  background: var(--mj-bg-surface-hover);
+}
+
+.mj-fk-create-icon {
+  font-size: 11px;
+  flex-shrink: 0;
+}
+
+.mj-fk-create-label {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
 @keyframes mj-dropdown-in {
   from { opacity: 0; transform: translateY(-4px); }
   to { opacity: 1; transform: translateY(0); }

--- a/packages/Angular/Generic/base-forms/src/lib/field/form-field.component.html
+++ b/packages/Angular/Generic/base-forms/src/lib/field/form-field.component.html
@@ -195,6 +195,27 @@
                   </div>
                 </ng-template>
 
+                <!-- Pinned "currently selected" — sticky at the top while browsing, so you can
+                     keep it or pick another without clearing first. -->
+                @if (FKSelectedSuggestion && !FKLoading) {
+                  <div class="mj-fk-current">
+                    <div class="mj-fk-current-head">
+                      <i class="fa-solid fa-circle-check"></i>
+                      <span>Currently selected</span>
+                    </div>
+                    <div class="mj-fk-current-row" (mousedown)="OnFKSelectItem(FKSelectedSuggestion, $event)" title="Keep this selection">
+                      @if (FKSelectedSuggestion.Icon) { <i class="mj-fk-current-icon" [class]="FKSelectedSuggestion.Icon"></i> }
+                      <span class="mj-fk-current-name" [innerHTML]="FKSelectedSuggestion.HighlightedName"></span>
+                      @if (FKSelectedSuggestion.ExtraColumns.length && FKSelectedSuggestion.ExtraColumns[0].Value) {
+                        <span class="mj-fk-current-detail">{{ FKSelectedSuggestion.ExtraColumns[0].Value }}</span>
+                      }
+                      <button type="button" class="mj-fk-current-clear" (mousedown)="OnFKClearClick($event)" title="Clear selection">
+                        <i class="fa-solid fa-xmark"></i>
+                      </button>
+                    </div>
+                  </div>
+                }
+
                 @if (FKLoading) {
                   <div class="mj-fk-status">
                     <i class="fa-solid fa-circle-notch fa-spin"></i>

--- a/packages/Angular/Generic/base-forms/src/lib/field/form-field.component.html
+++ b/packages/Angular/Generic/base-forms/src/lib/field/form-field.component.html
@@ -257,6 +257,15 @@
                     </div>
                   </div>
                 }
+
+                <!-- Sticky "create new" footer — always visible at the bottom (no scrolling),
+                     prefilled with the typed text. Gated on create permission. -->
+                @if (CanCreateFK) {
+                  <button type="button" class="mj-fk-create-footer" (mousedown)="OnFKCreateNew($event)" [title]="FKCreateLabel">
+                    <i class="fa-solid fa-plus mj-fk-create-icon"></i>
+                    <span class="mj-fk-create-label">{{ FKCreateLabel }}</span>
+                  </button>
+                }
               </div>
             }
           </div>

--- a/packages/Angular/Generic/base-forms/src/lib/field/form-field.component.ts
+++ b/packages/Angular/Generic/base-forms/src/lib/field/form-field.component.ts
@@ -666,6 +666,13 @@ export class MjFormFieldComponent extends BaseAngularComponent implements OnChan
   /** Suggestions returned from the FK entity search */
   FKSuggestions: FKSuggestion[] = [];
 
+  /**
+   * The currently-linked record, pinned as a sticky "Currently selected" section at the
+   * top of the dropdown (browse mode only). Null when there's no selection or the user is
+   * actively filtering. Removed from {@link FKSuggestions} so it isn't listed twice.
+   */
+  FKSelectedSuggestion: FKSuggestion | null = null;
+
   /** Whether the current FK value is a confirmed match (user selected from dropdown) */
   FKIsMatched = false;
 
@@ -704,6 +711,14 @@ export class MjFormFieldComponent extends BaseAngularComponent implements OnChan
 
   /** Text the user is currently typing in the FK search input. null = use display name. */
   private _fkInputText: string | null = null;
+
+  /**
+   * The active search query that produced the current results — `''` on a focus/clear
+   * browse (full list), the typed text when filtering. Distinct from {@link _fkInputText},
+   * which holds the *displayed* text (the selected record's name when not typing). This is
+   * the correct signal for "browse mode" and for the create-footer label.
+   */
+  private _fkQuery = '';
 
   /** Debounce timer for FK search */
   private _fkSearchTimeout: ReturnType<typeof setTimeout> | null = null;
@@ -1034,25 +1049,59 @@ export class MjFormFieldComponent extends BaseAngularComponent implements OnChan
 
   /** Apply a freshly-built suggestion list to the dropdown state + reposition + portal. */
   private applySuggestions(suggestions: FKSuggestion[], plan: FKColumnPlan): void {
+    // Pinned "currently selected" row: in browse mode (empty query) with a valid linked
+    // value, lift the selected record into a sticky section and remove it from the list so
+    // the user can keep it or pick another without clearing first.
+    this.FKSelectedSuggestion = null;
+    const browseMode = this._fkQuery.trim().length === 0;
+    if (browseMode && this.FKHasLinkedValue) {
+      const idx = suggestions.findIndex(s => this.IsFKRowSelected(s));
+      if (idx >= 0) {
+        this.FKSelectedSuggestion = suggestions[idx];
+        suggestions = suggestions.filter((_, i) => i !== idx);
+      } else {
+        // Selected record isn't in the (first-N) result — show a lightweight pinned row.
+        this.FKSelectedSuggestion = this.buildSelectedFallbackSuggestion(plan);
+      }
+    }
+
     this._fkSuggestionsNatural = suggestions;
     this.FKNameField = plan.NameFieldName;
     // Full ordered column list (incl. the name field) + matching headers.
     this.FKColumnFields = plan.ColumnFields;
     this.FKColumnHeaders = plan.ColumnFields.map(c => c === plan.NameFieldName ? 'Name' : this.labelForRelatedField(c));
-    this.FKHasIconColumn = suggestions.some(s => s.Icon != null);
-    this.FKHasIconColumn = suggestions.some(s => s.Icon != null);
+    this.FKHasIconColumn = (this.FKSelectedSuggestion?.Icon != null) || suggestions.some(s => s.Icon != null);
     this.FKSuggestions = this.sortSuggestions(suggestions);
     this.FKActiveIndex = this.FKSuggestions.length > 0 ? 0 : -1;
-    this.FKNoMatches = suggestions.length === 0;
+    this.FKNoMatches = suggestions.length === 0 && !this.FKSelectedSuggestion;
 
-    // Show the dropdown whenever we have rows OR a "no matches" state to surface.
-    this.ShowFKDropdown = suggestions.length > 0 || this.FKNoMatches;
+    // Show the dropdown for rows, a "no matches" state, or just the pinned selection.
+    this.ShowFKDropdown = suggestions.length > 0 || this.FKNoMatches || !!this.FKSelectedSuggestion;
     if (this.ShowFKDropdown && this._lastFKInputEl) {
       this.updateDropdownPosition(this._lastFKInputEl);
       this.startScrollListener();
       this.portalDropdownToBody();
     }
     this.cdr.markForCheck();
+  }
+
+  /**
+   * Build a lightweight pinned row for the selected record when it isn't present in the
+   * current result set (DB beyond first-N, or cached beyond the focus-show limit). We have
+   * its display name from the FK name resolution; extra-column values are left blank.
+   */
+  private buildSelectedFallbackSuggestion(plan: FKColumnPlan): FKSuggestion | null {
+    const name = this.FKDisplayName;
+    if (this.Value == null || this.Value === '' || !name) return null;
+    return {
+      PrimaryKeyValue: this.Value,
+      DisplayName: name,
+      HighlightedName: HighlightSearchMatches(name, '', 'mj-forms-search-highlight'),
+      ExtraColumns: plan.ExtraFieldNames.map((fn, i) => ({
+        FieldName: fn, Header: plan.ExtraHeaders[i], Value: '', HighlightedValue: ''
+      })),
+      Icon: plan.EntityIcon ?? null
+    };
   }
 
   /**
@@ -1147,9 +1196,9 @@ export class MjFormFieldComponent extends BaseAngularComponent implements OnChan
     this.cdr.markForCheck();
   }
 
-  /** Re-run the current query against the (possibly newly-chosen) search field. */
+  /** Re-run the active query against the (possibly newly-chosen) search field. */
   private rerunCurrentFKSearch(): void {
-    const query = this._fkInputText ?? '';
+    const query = this._fkQuery;
     const cached = this.getCachedRecordsForRelatedEntity();
     if (cached) this.searchCachedEntity(cached, query);
     else void this.searchRelatedEntity(query);
@@ -1374,6 +1423,7 @@ export class MjFormFieldComponent extends BaseAngularComponent implements OnChan
     const plan = this.buildColumnPlan();
     if (!plan) { this.closeFKDropdown(); this.cdr.markForCheck(); return; }
 
+    this._fkQuery = query;
     const accessor = (r: BaseEntity) => ({ get: (field: string) => r.Get(field) });
     const searchField = this.FKSearchField || plan.NameFieldName;
     const matches = FilterCachedFKRows(
@@ -1489,7 +1539,7 @@ export class MjFormFieldComponent extends BaseAngularComponent implements OnChan
   /** Footer label: prefilled with the typed text when present, else generic "create new". */
   get FKCreateLabel(): string {
     const entityLabel = this.getRelatedEntityInfo()?.DisplayName || this.FieldInfo?.RelatedEntity || 'record';
-    const query = (this._fkInputText ?? '').trim();
+    const query = this._fkQuery.trim();
     return query ? `Create "${query}"` : `Create new ${entityLabel}`;
   }
 
@@ -1505,7 +1555,7 @@ export class MjFormFieldComponent extends BaseAngularComponent implements OnChan
     const relatedEntity = this.FieldInfo?.RelatedEntity;
     if (!plan || !relatedEntity) return;
 
-    const query = (this._fkInputText ?? '').trim();
+    const query = this._fkQuery.trim();
     this.FKShowScopeMenu = false;
     this.FKFocused = false;
     this.closeFKDropdown();
@@ -1565,6 +1615,7 @@ export class MjFormFieldComponent extends BaseAngularComponent implements OnChan
     this.FKLoading = false;
     this.FKNoMatches = false;
     this.FKActiveIndex = -1;
+    this.FKSelectedSuggestion = null;
     this._portaledDropdownEl = null;
     this.stopScrollListener();
   }
@@ -1579,6 +1630,7 @@ export class MjFormFieldComponent extends BaseAngularComponent implements OnChan
     const fieldInfo = this.FieldInfo;
     if (!plan || !fieldInfo?.RelatedEntity) return;
 
+    this._fkQuery = query;
     const seq = ++this._fkSearchSeq;
     this.FKLoading = true;
     this.FKNoMatches = false;
@@ -1845,7 +1897,9 @@ export class MjFormFieldComponent extends BaseAngularComponent implements OnChan
       if (changes['Record']) {
         this._fkInputText = null;
         this.FKIsMatched = false;
+        this._fkQuery = '';
         this.FKSuggestions = [];
+        this.FKSelectedSuggestion = null;
         this.ShowFKDropdown = false;
         this.FKActiveIndex = -1;
         this.FKLoading = false;

--- a/packages/Angular/Generic/base-forms/src/lib/field/form-field.component.ts
+++ b/packages/Angular/Generic/base-forms/src/lib/field/form-field.component.ts
@@ -498,6 +498,16 @@ export class MjFormFieldComponent extends BaseAngularComponent implements OnChan
    */
   @Input() FKHighlightMatches = true;
 
+  /**
+   * Whether to offer inline "create new" for the related record when the one you need
+   * isn't found. The affordance only renders when this is true AND the current user can
+   * create records of the related entity (entity allows creation + role permits it).
+   */
+  @Input() AllowFKCreate = true;
+
+  /** Surface used for the inline create form: a modal dialog (default) or a slide-in. */
+  @Input() FKCreatePresentation: 'dialog' | 'slide-in' = 'dialog';
+
   /** Cleanup function for scroll/resize listeners */
   private _scrollCleanup: (() => void) | null = null;
 
@@ -1458,6 +1468,73 @@ export class MjFormFieldComponent extends BaseAngularComponent implements OnChan
     if (nameFieldMap) {
       this.Record.Set(nameFieldMap, suggestion.DisplayName);
     }
+    this.cdr.markForCheck();
+  }
+
+  // ---- Inline "create new related record" ----
+
+  /**
+   * Whether to show the inline-create affordance: the field opts in (`AllowFKCreate`),
+   * the related entity resolves, and the current user can create records of it (entity
+   * allows creation + role permits — `GetUserPermisions().CanCreate` folds in `AllowCreateAPI`).
+   */
+  get CanCreateFK(): boolean {
+    if (!this.AllowFKCreate) return false;
+    const re = this.getRelatedEntityInfo();
+    const user = this.ProviderToUse?.CurrentUser;
+    if (!re || !user) return false;
+    return re.GetUserPermisions(user)?.CanCreate === true;
+  }
+
+  /** Footer label: prefilled with the typed text when present, else generic "create new". */
+  get FKCreateLabel(): string {
+    const entityLabel = this.getRelatedEntityInfo()?.DisplayName || this.FieldInfo?.RelatedEntity || 'record';
+    const query = (this._fkInputText ?? '').trim();
+    return query ? `Create "${query}"` : `Create new ${entityLabel}`;
+  }
+
+  /**
+   * Ask the host (app layer) to create a new related record, prefilled with the typed
+   * text as the name. We only EMIT the request — opening the form is the app's job (the
+   * generic forms layer must not depend on the app-level form presenter). The host calls
+   * `Complete(record)` when saved and we select it.
+   */
+  OnFKCreateNew(event: MouseEvent): void {
+    event.preventDefault(); // don't blur the input before we capture the query
+    const plan = this.buildColumnPlan();
+    const relatedEntity = this.FieldInfo?.RelatedEntity;
+    if (!plan || !relatedEntity) return;
+
+    const query = (this._fkInputText ?? '').trim();
+    this.FKShowScopeMenu = false;
+    this.FKFocused = false;
+    this.closeFKDropdown();
+    this.cdr.markForCheck();
+
+    const newRecordValues: Record<string, unknown> = {};
+    if (query) newRecordValues[plan.NameFieldName] = query;
+
+    this.Navigate.emit({
+      Kind: 'create-related',
+      EntityName: relatedEntity,
+      NewRecordValues: Object.keys(newRecordValues).length ? newRecordValues : undefined,
+      Presentation: this.FKCreatePresentation,
+      Provider: this.Provider ?? undefined,
+      Complete: (created: BaseEntity | null) => { if (created) this.selectCreatedFKRecord(created, plan); },
+    });
+  }
+
+  /** Select a freshly-created related record as this field's value. */
+  private selectCreatedFKRecord(created: BaseEntity, plan: FKColumnPlan): void {
+    const pk = created.Get(plan.PkFieldName);
+    if (pk == null) return;
+    const name = this.formatCell(created.Get(plan.NameFieldName));
+    this._fkInputText = name;
+    this.Value = pk;
+    this.FKIsMatched = true;
+    const nameFieldMap = this.FieldInfo?.RelatedEntityNameFieldMap;
+    if (nameFieldMap) this.Record.Set(nameFieldMap, name);
+    this.closeFKDropdown();
     this.cdr.markForCheck();
   }
 

--- a/packages/Angular/Generic/base-forms/src/lib/host/entity-form-host.component.ts
+++ b/packages/Angular/Generic/base-forms/src/lib/host/entity-form-host.component.ts
@@ -276,7 +276,7 @@ export class MjEntityFormHostComponent extends BaseAngularComponent implements A
       const instance = componentRef.instance as BaseFormComponent & { userPermissions?: unknown };
       instance.record = record;
       instance.userPermissions = permissions;
-      instance.Config = this.Config;
+      instance.Config = this.effectiveConfigFor(record);
       instance.EditMode = this._editMode ?? this.Config?.StartInEditMode ?? !record.IsSaved;
 
       this.applyVariants(instance, resolution, entityName);
@@ -293,6 +293,21 @@ export class MjEntityFormHostComponent extends BaseAngularComponent implements A
       this.loading = false;
       this.cdr.detectChanges();
     }
+  }
+
+  /**
+   * The config to bind for a given record. For brand-new (unsaved) records we hide the
+   * `systemMetadata` section by default — its fields (audit timestamps, IDs, etc.) are
+   * empty and irrelevant until the record exists. Doesn't mutate the consumer's config,
+   * and defers entirely to a consumer that uses an explicit `VisibleSectionKeys` allowlist.
+   */
+  private effectiveConfigFor(record: BaseEntity): EntityFormConfig | null {
+    if (record.IsSaved) return this.Config;
+    if (this.Config?.VisibleSectionKeys?.length) return this.Config; // consumer owns visibility
+    const SYSTEM_METADATA_KEY = 'systemMetadata';
+    const hidden = this.Config?.HiddenSectionKeys ?? [];
+    if (hidden.includes(SYSTEM_METADATA_KEY)) return this.Config;
+    return { ...(this.Config ?? {}), HiddenSectionKeys: [...hidden, SYSTEM_METADATA_KEY] };
   }
 
   /**

--- a/packages/Angular/Generic/base-forms/src/lib/overlays/form-presenter.service.ts
+++ b/packages/Angular/Generic/base-forms/src/lib/overlays/form-presenter.service.ts
@@ -9,6 +9,7 @@ import { MjFormSlideInComponent } from './form-slide-in.component';
 import { MjFormWindowComponent } from './form-window.component';
 import { BaseFormOverlay, FormOverlayCloseReason } from './base-form-overlay';
 import { MJFormPresenterOptions, MJFormRef, MJFormPresentation } from './form-presenter.types';
+import { FormNavigationEvent } from '../types/navigation-events';
 
 /**
  * Imperatively opens any MemberJunction entity form as a dialog or slide-in
@@ -60,6 +61,11 @@ export class MJFormPresenterService {
         // Allow the close animation to finish before destroying the view.
         setTimeout(() => teardown(), 350);
       }),
+      // A form rendered INSIDE this overlay can ask to create a related record (e.g. an
+      // FK field's "+ Create" footer). Handle it by opening a nested form and handing the
+      // saved record back. This makes inline-create work for overlay-hosted forms, the same
+      // way SingleRecordComponent handles it for tab-hosted forms.
+      ref.instance.Navigate.subscribe((e: FormNavigationEvent) => this.handleOverlayNavigate(e)),
     ];
 
     let destroyed = false;
@@ -82,6 +88,22 @@ export class MJFormPresenterService {
       () => ref.instance.onCancel(),
       () => ref.instance.formInstance,
     );
+  }
+
+  /**
+   * Handle navigation events bubbling up from a form hosted inside an overlay. Currently
+   * the only one the presenter acts on is `create-related` — it opens a nested form and
+   * hands the saved record back via the event's `Complete` callback.
+   */
+  private handleOverlayNavigate(e: FormNavigationEvent): void {
+    if (e.Kind !== 'create-related') return;
+    const childRef = this.Open({
+      EntityName: e.EntityName,
+      Presentation: e.Presentation ?? 'dialog',
+      NewRecordValues: e.NewRecordValues,
+      Provider: e.Provider,
+    });
+    childRef.AfterSaved().then(created => e.Complete(created));
   }
 
   /** Maps a presentation to its (standalone) overlay shell component. */

--- a/packages/Angular/Generic/base-forms/src/lib/types/navigation-events.ts
+++ b/packages/Angular/Generic/base-forms/src/lib/types/navigation-events.ts
@@ -1,4 +1,4 @@
-import { CompositeKey } from '@memberjunction/core';
+import { BaseEntity, CompositeKey, IMetadataProvider } from '@memberjunction/core';
 
 /**
  * Union type for all navigation event kinds emitted by the forms package.
@@ -25,6 +25,7 @@ export type FormNavigationEvent =
   | EntityHierarchyNavigationEvent
   | ChildEntityTypeNavigationEvent
   | NewRecordNavigationEvent
+  | CreateRelatedNavigationEvent
   | DismissFormNavigationEvent;
 
 /**
@@ -117,4 +118,49 @@ export interface DismissFormNavigationEvent {
   Kind: 'dismiss';
   /** Reason for the dismiss request — useful for analytics / different host behaviors. */
   Reason: 'new-record-discarded';
+}
+
+/**
+ * A field (e.g. a foreign-key dropdown) is asking the host to create a NEW record of a
+ * related entity — typically because the user searched for one that doesn't exist yet.
+ *
+ * The Generic forms layer only *emits* this; it deliberately does not open the create
+ * form itself (that would couple a generic component to the app-layer form presenter).
+ * The host application opens the related entity's form (e.g. via `MJFormPresenterService`
+ * as a dialog or slide-in), prefilled with {@link NewRecordValues}, and — when the user
+ * saves — calls {@link Complete} with the new record so the requesting field can select it.
+ *
+ * @example Explorer handler:
+ * ```typescript
+ * case 'create-related': {
+ *   const ref = this.forms.Open({
+ *     EntityName: event.EntityName,
+ *     Presentation: event.Presentation ?? 'dialog',
+ *     NewRecordValues: event.NewRecordValues,
+ *     Provider: event.Provider,
+ *   });
+ *   event.Complete(await ref.AfterSaved());
+ *   break;
+ * }
+ * ```
+ */
+export interface CreateRelatedNavigationEvent {
+  Kind: 'create-related';
+  /** Entity to create a new record of (the FK field's related entity). */
+  EntityName: string;
+  /**
+   * Default field values to prefill on the new record — lets the requester seed any
+   * fields (e.g. `{ Name: 'Marketing' }` from the typed search text), not just the name.
+   */
+  NewRecordValues?: Record<string, unknown>;
+  /** Preferred surface for the create form. The host may honor or override it. */
+  Presentation?: 'dialog' | 'slide-in';
+  /** Metadata provider to use (multi-provider apps). */
+  Provider?: IMetadataProvider;
+  /**
+   * Host callback: invoke with the saved record (or `null` if the user cancelled) so the
+   * requesting field can select it. Optional for the host to call — a host with no create
+   * surface can ignore the whole event.
+   */
+  Complete: (created: BaseEntity | null) => void;
 }

--- a/packages/MJCore/src/generic/entityInfo.ts
+++ b/packages/MJCore/src/generic/entityInfo.ts
@@ -2075,11 +2075,15 @@ export class EntityInfo extends BaseInfo {
                 bucket.CanDelete = bucket.CanDelete || !!ep.CanDelete;
             }
 
+            // An API-driven action also requires that the entity ALLOWS that action at all
+            // (`Allow*API`). No role grant can create/update/delete records of an entity whose
+            // corresponding API is disabled — so fold the entity-level flag into the result.
+            // (Read has no `Allow*API` flag; it's governed by the entity view, so it's unchanged.)
             const userPermission: EntityUserPermissionInfo = new EntityUserPermissionInfo();
-            userPermission.CanCreate = allow.CanCreate && !deny.CanCreate;
+            userPermission.CanCreate = this.AllowCreateAPI && allow.CanCreate && !deny.CanCreate;
             userPermission.CanRead   = allow.CanRead   && !deny.CanRead;
-            userPermission.CanUpdate = allow.CanUpdate && !deny.CanUpdate;
-            userPermission.CanDelete = allow.CanDelete && !deny.CanDelete;
+            userPermission.CanUpdate = this.AllowUpdateAPI && allow.CanUpdate && !deny.CanUpdate;
+            userPermission.CanDelete = this.AllowDeleteAPI && allow.CanDelete && !deny.CanDelete;
             userPermission.Entity = this;
             userPermission.User = user;
 


### PR DESCRIPTION
## Summary

Two related improvements to the forms layer:

1. **Inline "create new" from foreign-key fields** — when the related record you need isn't in a FK dropdown, create it inline without leaving the form.
2. **New-record forms hide the System Metadata section by default**, and **`EntityInfo.GetUserPermisions()` now respects the entity's `Allow*API` flags.**

Built on the forms-as-tabs/dialogs/slide-ins stack from #2735.

## Inline create from FK fields

A sticky **"➕ Create …"** footer sits at the bottom of the FK dropdown (always visible, prefilled with whatever you typed). Clicking it opens the related entity's form (dialog or slide-in), prefilled; on save the new record is **auto-selected** into the field.

### Architecture — generic emits, app orchestrates
The FK field lives in the **Generic** package, so it must not reach up to the app-level form presenter. (The first attempt injected the presenter directly and produced a runtime circular dependency — `NG0919` — because the overlay components import `BaseFormsModule`, which declares the field.)

Instead:

- **`@memberjunction/ng-base-forms`** — `<mj-form-field>` only **emits** a new `create-related` `FormNavigationEvent`, carrying the entity, **`NewRecordValues`** (so the requester can prefill any fields, not just the name), preferred `Presentation`, `Provider`, and a `Complete(record)` callback. It rides the existing `Navigate` rail (field → form → host → app), so **no form regeneration**.
- **`@memberjunction/ng-explorer-core`** — `SingleRecordComponent` handles `create-related` for **tab-hosted** forms via `MJFormPresenterService`, then calls `Complete(savedRecord)`.
- **`MJFormPresenterService`** — handles `create-related` for **overlay-hosted** forms (a FK field inside a dialog/slide-in) by opening a **nested** form. So inline-create works on every surface.

Gated on create permission + a new `@Input() AllowFKCreate` (default true). Surface via `@Input() FKCreatePresentation: 'dialog' | 'slide-in'` (default dialog).

## New-record forms: hide System Metadata by default

The form host now hides the `systemMetadata` section for **brand-new (unsaved)** records of any entity — its audit/timestamp/ID fields are empty and irrelevant until the record exists. It doesn't mutate the consumer config, leaves saved records untouched, and defers to a consumer that uses an explicit `VisibleSectionKeys` allowlist.

## Permission fix (`@memberjunction/core`)

`EntityInfo.GetUserPermisions()` now folds the entity's `Allow{Create,Update,Delete}API` flags into the corresponding `Can*` results. An API-driven action requires **both** a role grant **and** the entity allowing that action at all — so a user can no longer be reported as able to create/update/delete records of an entity whose API for that action is disabled. (`CanRead` is unchanged; there's no read-API flag.) Verified safe against all ~40 callers (they gate UI/operations on `Can*` — folding the flag in only restricts where the API is disabled, which is correct).

## Testing
- `@memberjunction/ng-base-forms`: **87/87** unit tests green.
- `@memberjunction/core`: **1203/1203** unit tests green.
- `ng-explorer-core` builds clean.

## Changeset
`@memberjunction/core` + `@memberjunction/ng-base-forms` + `@memberjunction/ng-explorer-core` (patch).

---
_Generated by [Claude Code](https://claude.ai/code)_
