### PR TITLE
fix: surface swallowed action errors + scope MetadataSync required-field warnings to new records

### DIFF
--- a/.changeset/action-error-logging-and-required-field-scope.md
+++ b/.changeset/action-error-logging-and-required-field-scope.md
@@ -1,0 +1,12 @@
+---
+"@memberjunction/actions": minor
+"@memberjunction/metadata-sync": minor
+---
+
+fix(actions): surface real action errors instead of swallowing them
+
+`ActionEngine.InternalRunAction`'s catch block called `LogError(message, e)`, but `LogError`'s second positional parameter is `logToFileName` — so the thrown `Error` was consumed as a (non-string) filename and never printed. Every failed action logged only `Error running action <name>:` with no message or stack. It now uses `LogErrorEx({ message, error })` so the real message and stack trace are logged, and the returned result `Message` handles non-`Error` throws.
+
+feat(metadata-sync): only warn about missing required fields for NEW records
+
+The "Required field X is missing" best-practice warning fired for existing records too (e.g. `BaseView` on `MJ: Entities`), even though the value is already persisted in the DB. Since metadata files commonly set only a subset of fields on an update, this produced noise that masked genuine warnings. The validator now threads the record's `primaryKey` presence down to the required-field check and runs it only for new (unsaved) records.

--- a/packages/AI/Vectors/scripts/test-vectorize-entity.ts
+++ b/packages/AI/Vectors/scripts/test-vectorize-entity.ts
@@ -1,0 +1,141 @@
+/**
+ * test-vectorize-entity.ts — live, full-visibility harness for the entity
+ * vectorization pipeline (`EntityVectorSyncer`).
+ *
+ * WHY THIS EXISTS
+ * ---------------
+ * The "Entity Vector Sync" scheduled job drives the "Vectorize Entity" action,
+ * which in turn calls `EntityVectorSyncer.Config()` → `GetActiveEntityDocuments()`
+ * → `VectorizeEntity()`. When that path fails *outside* the per-document
+ * try/catch (e.g. in `Config` or `GetActiveEntityDocuments`), the error bubbles
+ * up to the ActionEngine where it can be hard to see the true cause from the
+ * scheduler logs. This script runs the exact same sequence directly, with the
+ * raw error + stack printed, so you can diagnose vector-sync issues without
+ * standing up MJAPI or waiting for the cron poll.
+ *
+ * It mirrors the sibling `scripts/test-search-entity.ts` harness (which exercises
+ * `Provider.SearchEntity`) — same bootstrap, same config resolution, same
+ * ContextUser selection — but targets the *write* side of the pipeline.
+ *
+ * WHAT IT DOES
+ * ------------
+ *   1. Boots the SQL Server provider from `mj.config.cjs` + `.env`.
+ *   2. Picks an Owner (or first) user as the ContextUser.
+ *   3. Runs `EntityVectorSyncer.Config()`.
+ *   4. Lists the Active Entity Documents for the requested type (default "Search",
+ *      matching the scheduled job) and prints their key config (VectorIndex /
+ *      AIModel / Template) so misconfiguration is obvious at a glance.
+ *   5. Vectorizes each one, surfacing any error with a full stack trace.
+ *
+ * USAGE (run from the REPO ROOT so cwd-relative `.env` / `mj.config.cjs`
+ * resolution and workspace package linking work):
+ *   npx tsx packages/AI/Vectors/scripts/test-vectorize-entity.ts
+ *   npx tsx packages/AI/Vectors/scripts/test-vectorize-entity.ts "Record Duplicate"
+ *
+ * The single positional arg is the EntityDocumentType to filter on; it defaults
+ * to "Search" (the type the daily scheduled job uses).
+ */
+
+import { setupSQLServerClient, SQLServerProviderConfigData, UserCache } from '@memberjunction/sqlserver-dataprovider';
+import { EntityVectorSyncer } from '@memberjunction/ai-vector-sync';
+import type { MJEntityDocumentEntity } from '@memberjunction/core-entities';
+import sql from 'mssql';
+import dotenv from 'dotenv';
+import path from 'path';
+
+// Bootstrap registers entity subclasses, AI providers (LocalEmbedding),
+// VectorDB drivers (SimpleVectorServiceProvider), etc. so the ClassFactory can
+// resolve every @RegisterClass-decorated type the pipeline instantiates.
+import '@memberjunction/server-bootstrap-lite';
+
+// `.env` lives at the repo root; load it relative to the process cwd (run from root).
+dotenv.config({ path: path.resolve(process.cwd(), '.env'), quiet: true });
+
+/**
+ * Connect to the configured MJ database and stand up the SQL Server provider.
+ * Config precedence: `mj.config.cjs` databaseSettings → `.env` → sensible defaults.
+ */
+async function bootstrapProvider() {
+    // Resolve mj.config.cjs via cosmiconfig — same pattern as the other dev scripts.
+    const { cosmiconfig } = await import('cosmiconfig');
+    const explorer = cosmiconfig('mj');
+    const configResult = await explorer.search();
+    if (!configResult) {
+        throw new Error('No mj.config.cjs found. Run this script from the repo root.');
+    }
+    const config = configResult.config;
+    const dbSettings = config.databaseSettings ?? {};
+
+    const sqlConfig: sql.config = {
+        server: dbSettings.host || process.env.DB_HOST || 'localhost',
+        port: Number(dbSettings.port ?? process.env.DB_PORT ?? 1433),
+        user: dbSettings.user || process.env.DB_USERNAME,
+        password: dbSettings.password || process.env.DB_PASSWORD,
+        database: dbSettings.database || process.env.DB_DATABASE,
+        options: { encrypt: false, trustServerCertificate: true },
+    };
+
+    const pool = await new sql.ConnectionPool(sqlConfig).connect();
+    const schema = config.mjCoreSchema || dbSettings.mjCoreSchema || '__mj';
+
+    const pcfg = new SQLServerProviderConfigData(pool, schema);
+    const provider = await setupSQLServerClient(pcfg);
+
+    // The vector syncer needs a real ContextUser for its RunView/Save calls.
+    await UserCache.Instance.Refresh(pool);
+    const ownerUser = UserCache.Users.find(u => u?.Type?.trim().toLowerCase() === 'owner') ?? UserCache.Users[0];
+    if (!ownerUser) throw new Error('No user found in cache to act as ContextUser.');
+
+    return { provider, contextUser: ownerUser, pool };
+}
+
+async function main(): Promise<void> {
+    // Default to "Search" — the EntityDocumentType the daily scheduled job uses.
+    const entityDocumentType = process.argv[2] ?? 'Search';
+    console.log(`\nTest Vectorize Entity\n${'='.repeat(78)}`);
+    console.log(`EntityDocumentType: "${entityDocumentType}"`);
+
+    const { contextUser, pool } = await bootstrapProvider();
+    console.log(`ContextUser       : ${contextUser.Name} (${contextUser.Email})`);
+
+    const vectorizer = new EntityVectorSyncer();
+
+    // [1/3] Warm the caches/engines the pipeline depends on (EntityDocumentCache,
+    // AIEngine, KnowledgeHubMetadataEngine, TemplateEngineServer).
+    console.log('\n[1/3] Config()...');
+    await vectorizer.Config(false, contextUser);
+    console.log('  ok');
+
+    // [2/3] Resolve the Active Entity Documents for the requested type. This is
+    // where the scheduled job historically failed ("No EntityDocuments found for
+    // type ...") — printing the resolved set + their config makes that obvious.
+    console.log(`\n[2/3] GetActiveEntityDocuments(undefined, "${entityDocumentType}")...`);
+    const entityDocuments: MJEntityDocumentEntity[] = await vectorizer.GetActiveEntityDocuments(undefined, entityDocumentType);
+    console.log(`  found ${entityDocuments.length} entity document(s):`);
+    for (const d of entityDocuments) {
+        console.log(`    - ${d.Name}  (Entity=${d.Entity}, VectorIndexID=${d.VectorIndexID ?? 'NULL'}, AIModelID=${d.AIModelID ?? 'NULL'}, TemplateID=${d.TemplateID ?? 'NULL'})`);
+    }
+
+    // [3/3] Vectorize each document. Any failure throws with a full stack (caught
+    // by the top-level handler below) instead of being swallowed by the scheduler.
+    console.log('\n[3/3] VectorizeEntity() per document...');
+    for (const entityDocument of entityDocuments) {
+        console.log(`  → ${entityDocument.Name}`);
+        await vectorizer.VectorizeEntity({
+            entityID: entityDocument.EntityID,
+            entityDocumentID: entityDocument.ID,
+            listBatchCount: 20,
+            options: {},
+        }, contextUser);
+        console.log(`    done`);
+    }
+
+    await pool.close();
+    console.log('\n✅ Done.');
+}
+
+main().catch(err => {
+    console.error('\n❌ REAL ERROR (full stack):');
+    console.error(err instanceof Error ? (err.stack ?? err.message) : err);
+    process.exit(1);
+});

--- a/packages/Actions/Engine/src/generic/ActionEngine.ts
+++ b/packages/Actions/Engine/src/generic/ActionEngine.ts
@@ -1,4 +1,4 @@
-import { LogError, Metadata } from "@memberjunction/core";
+import { LogError, LogErrorEx, Metadata } from "@memberjunction/core";
 import { MJActionExecutionLogEntity, MJActionEntity_IRuntimeActionConfiguration, MJActionFilterEntity, MJActionParamEntity, MJActionResultCodeEntity } from "@memberjunction/core-entities";
 import { MJGlobal, SafeJSONParse, UUIDsEqual } from "@memberjunction/global";
 import { BaseAction } from "./BaseAction";
@@ -270,12 +270,15 @@ export class ActionEngineServer extends ActionEngineBase {
          return result;
       }
       catch (e) {
-         // if we get here, something went wrong in the action code
-         LogError(`Error running action ${params.Action.Name}:`, e);
+         // if we get here, something went wrong in the action code.
+         // NOTE: LogError's 2nd positional arg is `logToFileName`, NOT the error —
+         // passing the error there silently swallows it. Use LogErrorEx so the
+         // real message + stack trace actually print to the console.
+         LogErrorEx({ message: `Error running action ${params.Action.Name}`, error: e instanceof Error ? e : new Error(String(e)) });
          const result: ActionResult = {
             RunParams: params,
             Success: false,
-            Message: `Error running action ${params.Action.Name}: ${e.message}`,
+            Message: `Error running action ${params.Action.Name}: ${e instanceof Error ? e.message : String(e)}`,
             LogEntry: logEntry,
             Params: params.Params,
             Result: undefined

--- a/packages/MetadataSync/src/__tests__/ValidationService.test.ts
+++ b/packages/MetadataSync/src/__tests__/ValidationService.test.ts
@@ -703,6 +703,49 @@ describe('ValidationService - Field Value List Validation (comma-delimited multi
   });
 });
 
+describe('ValidationService - Required-field warning is NEW-record-only', () => {
+  // A NOT-NULL field with no default — e.g. BaseView on MJ: Entities. Existing
+  // records already hold its value in the DB, so a metadata file that omits it
+  // (because it only updates some other field) must NOT be warned about.
+  function makeEntityInfoWithRequiredField(): any {
+    return {
+      Name: 'MJ: Entities',
+      Fields: [
+        { Name: 'Name', AllowsNull: true, DefaultValue: null, RelatedEntity: null, AutoIncrement: false, ReadOnly: false, IsForeignKey: false },
+        { Name: 'BaseView', AllowsNull: false, DefaultValue: null, RelatedEntity: null, AutoIncrement: false, ReadOnly: false, IsForeignKey: false },
+      ],
+    };
+  }
+
+  async function callValidateFields(
+    fields: Record<string, any>,
+    isExistingRecord: boolean,
+  ): Promise<{ errors: any[]; warnings: any[] }> {
+    const svc = new ValidationService({ checkBestPractices: true } as any);
+    (svc as any).errors = [];
+    (svc as any).warnings = [];
+    await (svc as any).validateFields(fields, makeEntityInfoWithRequiredField(), '/test/entities.json', undefined, isExistingRecord);
+    return { errors: (svc as any).errors, warnings: (svc as any).warnings };
+  }
+
+  it('warns about a missing required field for a NEW record (no primaryKey)', async () => {
+    const { warnings } = await callValidateFields({}, false);
+    expect(warnings).toHaveLength(1);
+    expect(warnings[0].field).toBe('BaseView');
+    expect(warnings[0].message).toContain('BaseView');
+  });
+
+  it('does NOT warn about a missing required field for an EXISTING record (has primaryKey)', async () => {
+    const { warnings } = await callValidateFields({}, true);
+    expect(warnings).toHaveLength(0);
+  });
+
+  it('does not warn for a NEW record when the required field IS provided', async () => {
+    const { warnings } = await callValidateFields({ BaseView: 'vwTest' }, false);
+    expect(warnings).toHaveLength(0);
+  });
+});
+
 describe('ValidationService - Dependency Order Checking Logic', () => {
   it('should detect order violations', () => {
     const directoryOrder = ['B', 'A']; // B comes first but depends on A

--- a/packages/MetadataSync/src/services/ValidationService.ts
+++ b/packages/MetadataSync/src/services/ValidationService.ts
@@ -269,8 +269,11 @@ export class ValidationService {
       return; // Can't continue validation without fields
     }
 
-    // Validate fields
-    await this.validateFields(entityData.fields, entityInfo, filePath, parentContext);
+    // Validate fields. Pass whether this record already exists (has a primaryKey
+    // block) so the required-field best-practice check can be limited to NEW
+    // records — an existing record already holds the value in the DB, so a
+    // missing NOT-NULL field in the file is not a problem and would only be noise.
+    await this.validateFields(entityData.fields, entityInfo, filePath, parentContext, !!entityData.primaryKey);
 
     // Track dependencies
     this.trackEntityDependencies(entityData, entityInfo.Name, filePath);
@@ -306,6 +309,7 @@ export class ValidationService {
     entityInfo: EntityInfo,
     filePath: string,
     parentContext?: { entity: string; field: string },
+    isExistingRecord: boolean = false,
   ): Promise<void> {
     const entityFields = entityInfo.Fields;
     const fieldMap = new Map(entityFields.map((f) => [f.Name, f]));
@@ -369,8 +373,13 @@ export class ValidationService {
       await this.validateFieldValue(fieldValue, fieldInfo, entityInfo, filePath, parentContext);
     }
 
-    // Check for required fields
-    if (this.options.checkBestPractices) {
+    // Check for required fields — only for NEW records. An existing record
+    // (identified by a primaryKey block) already has values persisted in the
+    // DB for any NOT-NULL field; metadata files routinely set only a subset of
+    // fields on an update, so warning about "missing" required fields there is
+    // pure noise that masks genuine warnings. New records (no primaryKey) still
+    // get the full check since their required fields must be supplied to insert.
+    if (this.options.checkBestPractices && !isExistingRecord) {
       for (const field of entityFields) {
         // Skip if field allows null or has a value already (use 'in' to handle falsy values like 0, false, "")
         if (field.AllowsNull || field.Name in fields) {


### PR DESCRIPTION
## Summary

Two fixes uncovered while debugging a failing **Entity Vector Sync** scheduled job, plus a dev harness.

### 1. `@memberjunction/actions` — action errors were silently swallowed
`ActionEngine.InternalRunAction`'s catch called `LogError(message, e)`, but `LogError`'s second positional arg is `logToFileName`. The thrown `Error` was consumed as a (non-string) filename and never printed — so **every** failed action logged just `Error running action <name>:` with no message or stack. This is what made the vector-sync failure impossible to diagnose from the scheduler logs.

- Now uses `LogErrorEx({ message, error })` → full message + stack trace.
- Result `Message` hardened for non-`Error` throws.

### 2. `@memberjunction/metadata-sync` — required-field warning noise on updates
The `Required field "X" is missing` best-practice warning fired for **existing** records too (e.g. `BaseView` on `MJ: Entities`), even though the value is already in the DB. Metadata files routinely set only a subset of fields on an update, so this was pure noise that masked real warnings (9 such warnings on a normal `mj sync validate` here → 0 after the fix).

- `validateFields` now receives `isExistingRecord` (derived from the record's `primaryKey` block) and runs the required-field check **only for new/unsaved records**.
- New records still get the full check (their NOT-NULL fields must be supplied to insert).
- 3 tests added; MetadataSync suite: 234 passing.

### 3. Dev tooling
Adds `packages/AI/Vectors/scripts/test-vectorize-entity.ts` — a live, full-stack harness for the `EntityVectorSyncer` pipeline (`Config` → `GetActiveEntityDocuments` → `VectorizeEntity`), mirroring the sibling `test-search-entity.ts`. Useful for diagnosing vector-sync issues without standing up MJAPI or waiting for the cron poll.

## Testing
- `cd packages/MetadataSync && npm run test` → 234 passing (10 files).
- `npm run build` clean for both `@memberjunction/actions` and `@memberjunction/metadata-sync`.
- `npx mj sync validate --dir=metadata` → warnings 9 → 0, validation still passes.

## Changeset
Minor bumps for `@memberjunction/actions` and `@memberjunction/metadata-sync`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)