### PR TITLE
fix(actions): align ActionEngine test mock with LogErrorEx switch

### DIFF
--- a/.changeset/nimble-rabbits-test.md
+++ b/.changeset/nimble-rabbits-test.md
@@ -1,0 +1,5 @@
+---
+"@memberjunction/actions": patch
+---
+
+Align ActionEngine test mock with the recent LogErrorEx switch in InternalRunAction's catch block, restoring the previously failing "should catch errors from action execution" test and silencing stderr noise from two other passing tests.

--- a/packages/Actions/Engine/src/__tests__/ActionEngine.test.ts
+++ b/packages/Actions/Engine/src/__tests__/ActionEngine.test.ts
@@ -36,6 +36,7 @@ vi.mock('@memberjunction/core', async (importOriginal) => {
             return { GetEntityObject: vi.fn().mockResolvedValue(mockLogEntity) };
         }),
         LogError: vi.fn(),
+        LogErrorEx: vi.fn(),
         LogStatus: vi.fn(),
         LogStatusEx: vi.fn(),
         LogVerbose: vi.fn(),
@@ -178,7 +179,7 @@ vi.mock('@memberjunction/actions-base', () => {
 // ============================================================================
 import { ActionEngineServer } from '../generic/ActionEngine';
 import { BaseAction } from '../generic/BaseAction';
-import { Metadata, LogError } from '@memberjunction/core';
+import { Metadata, LogError, LogErrorEx } from '@memberjunction/core';
 import { MJGlobal } from '@memberjunction/global';
 
 // ============================================================================
@@ -506,7 +507,7 @@ describe('ActionEngineServer', () => {
             const result = await (engine as unknown as Record<string, Function>)['InternalRunAction'](params as unknown as Record<string, Function>);
             expect(result.Success).toBe(false);
             expect(result.Message).toContain('Action blew up');
-            expect(LogError).toHaveBeenCalled();
+            expect(LogErrorEx).toHaveBeenCalled();
         });
 
         it('should use Action.Name when DriverClass is not provided', async () => {


### PR DESCRIPTION
## Summary
- Commit 6245690bbd switched `InternalRunAction`'s catch block from `LogError` to `LogErrorEx` to stop swallowing the underlying error, but didn't update the corresponding test. As a result `ActionEngine.test.ts > should catch errors from action execution` started failing in CI.
- Adds `LogErrorEx: vi.fn()` to the `@memberjunction/core` mock and updates the one behavioral assertion that was checking `LogError` for that catch path.
- Side effect: the un-mocked `LogErrorEx` had been printing real stack traces to stderr from two other passing tests (`should throw when ClassFactory returns null` / `returns base BaseAction`); mocking it cleans up that noise too.

## Test plan
- [x] `cd packages/Actions/Engine && npm run test` — 144/144 pass (was 143/144)
- [x] Verified the three remaining `expect(LogError).toHaveBeenCalled()` assertions still map to call sites that use `LogError` (not `LogErrorEx`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)