### PR TITLE
fix(cli): baseline cross-db login probe fails to compile on Azure SQL (defer into sp_executesql)

### DIFF
--- a/packages/MJCLI/src/baseline/__tests__/emitter.principals.test.ts
+++ b/packages/MJCLI/src/baseline/__tests__/emitter.principals.test.ts
@@ -1,0 +1,69 @@
+import { describe, it, expect } from 'vitest';
+import { emitBaselineTsql, EmitInput } from '../emitter';
+import type { DatabasePrincipalDef, SchemaSnapshot, BaselineEmitOptions } from '../types';
+
+/** Emit a baseline containing only the given principals (everything else empty). */
+function emitWith(principals: DatabasePrincipalDef[]): string {
+  const snapshot: SchemaSnapshot = {
+    dialect: 'mssql',
+    schemas: [], tables: [], views: [], procedures: [], functions: [],
+    triggers: [], sequences: [], userDefinedTypes: [], extendedProperties: [],
+    principals, roleMemberships: [], permissions: [],
+  };
+  const options: BaselineEmitOptions = {
+    baselineVersion: '5.99',
+    description: 'test',
+    generatedAtUtc: new Date('2026-01-01T00:00:00Z'),
+    includeData: false,
+    excludedDataTables: new Set<string>(),
+    batchSize: 100,
+  };
+  const input: EmitInput = { snapshot, dataDumps: [], options };
+  return emitBaselineTsql(input);
+}
+
+const sqlUser = (name: string): DatabasePrincipalDef => ({ name, kind: 'sql_user' });
+
+describe('emitPrincipals — Azure SQL login probe', () => {
+  it('defers the cross-database login probe into sp_executesql', () => {
+    const sql = emitWith([sqlUser('MJ_CodeGen')]);
+    expect(sql).toContain('EXEC sp_executesql');
+    // The probe is parameterized (@n) inside the dynamic statement...
+    expect(sql).toContain('WHERE name = @n');
+    // ...and its result flows back through the OUTPUT parameter into @login_exists_*.
+    expect(sql).toContain('@e = @login_exists_MJ_CodeGen OUTPUT');
+    expect(sql).toContain("@n = N'MJ_CodeGen'");
+  });
+
+  it('never emits a STATIC master.sys.* reference in the batch (the Azure compile-time failure)', () => {
+    const sql = emitWith([sqlUser('MJ_CodeGen')]);
+    // The old broken form referenced the cross-db catalog with a literal name directly in the
+    // batch, which Azure SQL fails to compile up front. That exact form must be gone.
+    expect(sql).not.toContain("ELSE IF EXISTS (SELECT 1 FROM master.sys.server_principals");
+    expect(sql).not.toMatch(/master\.sys\.server_principals WHERE name = N'/);
+    // Every surviving reference to the cross-db catalog must live inside the sp_executesql
+    // string literal (i.e. immediately after `N'IF EXISTS (SELECT 1 FROM `).
+    const refs = sql.match(/master\.sys\.server_principals/g) ?? [];
+    expect(refs.length).toBe(1);
+    expect(sql).toContain("N'IF EXISTS (SELECT 1 FROM master.sys.server_principals WHERE name = @n) SET @e = 1'");
+  });
+
+  it('keeps the runtime EngineEdition guard and both user-creation branches', () => {
+    const sql = emitWith([sqlUser('MJ_CodeGen')]);
+    expect(sql).toContain("IF SERVERPROPERTY('EngineEdition') = 5");
+    expect(sql).toContain('CREATE USER [MJ_CodeGen] FOR LOGIN [MJ_CodeGen]');
+    expect(sql).toContain('CREATE USER [MJ_CodeGen] WITHOUT LOGIN');
+    expect(sql).toContain('DATABASE_PRINCIPAL_ID');
+  });
+
+  it('emits an independent, correctly-named probe for each of the four MJ service logins', () => {
+    const names = ['MJ_CodeGen', 'MJ_CodeGen_Dev', 'MJ_Connect', 'MJ_Connect_Dev'];
+    const sql = emitWith(names.map(sqlUser));
+    for (const n of names) {
+      expect(sql).toContain(`@n = N'${n}', @e = @login_exists_${n} OUTPUT`);
+    }
+    // One sp_executesql probe per user, none left as static batch SQL.
+    expect((sql.match(/EXEC sp_executesql/g) ?? []).length).toBe(names.length);
+    expect((sql.match(/master\.sys\.server_principals/g) ?? []).length).toBe(names.length);
+  });
+});

--- a/packages/MJCLI/src/baseline/emitter.ts
+++ b/packages/MJCLI/src/baseline/emitter.ts
@@ -510,11 +510,20 @@ function emitPrincipals(principals: readonly DatabasePrincipalDef[]): string {
     lines.push(`IF DATABASE_PRINCIPAL_ID(${quoteString(u.name)}) IS NULL`);
     lines.push('BEGIN');
     lines.push(`    DECLARE @login_exists_${safeSuffix(u.name)} BIT = 0;`);
-    lines.push(
-      `    IF SERVERPROPERTY('EngineEdition') = 5 SET @login_exists_${safeSuffix(u.name)} = 1; ` +
-      `ELSE IF EXISTS (SELECT 1 FROM master.sys.server_principals WHERE name = ${quoteString(u.name)}) ` +
-      `SET @login_exists_${safeSuffix(u.name)} = 1;`,
-    );
+    // On Azure SQL DB (EngineEdition=5) there are no server logins, so treat the login as
+    // present (the contained-user path below). Otherwise probe master.sys.server_principals —
+    // but via sp_executesql so the cross-database reference is COMPILED only when the ELSE
+    // branch actually runs. Azure SQL compiles the entire batch up front, so a *static*
+    // master.sys.* reference fails to compile there even though this runtime EngineEdition
+    // guard would skip it. Deferring it into a dynamic statement keeps it out of the batch's
+    // compile pass, and it is never compiled on Azure SQL because the ELSE branch is dead there.
+    lines.push(`    IF SERVERPROPERTY('EngineEdition') = 5`);
+    lines.push(`        SET @login_exists_${safeSuffix(u.name)} = 1;`);
+    lines.push('    ELSE');
+    lines.push('        EXEC sp_executesql');
+    lines.push(`            N'IF EXISTS (SELECT 1 FROM master.sys.server_principals WHERE name = @n) SET @e = 1',`);
+    lines.push(`            N'@n NVARCHAR(128), @e BIT OUTPUT',`);
+    lines.push(`            @n = ${quoteString(u.name)}, @e = @login_exists_${safeSuffix(u.name)} OUTPUT;`);
     lines.push(`    IF @login_exists_${safeSuffix(u.name)} = 1`);
     lines.push(`        EXEC('CREATE USER ${quoteIdent(u.name)} FOR LOGIN ${quoteIdent(u.name)}');`);
     lines.push('    ELSE');


### PR DESCRIPTION
## The bug
Fresh-install baselines **cannot execute on Azure SQL Database**. The baseline emitter guards the server-login existence check like this:

```sql
DECLARE @login_exists_MJ_CodeGen BIT = 0;
IF SERVERPROPERTY('EngineEdition') = 5 SET @login_exists_MJ_CodeGen = 1;
ELSE IF EXISTS (SELECT 1 FROM master.sys.server_principals WHERE name = N'MJ_CodeGen')
    SET @login_exists_MJ_CodeGen = 1;
```

The `ELSE IF EXISTS (… master.sys.server_principals …)` is **static batch SQL**. Azure SQL DB **compiles the entire batch up front**, so the cross-database `master.sys.*` reference fails to compile there — *even though* the runtime `EngineEdition = 5` guard would never take that branch. The runtime guard is too late; the failure is at compile time. Result: baseline execution dies on Azure SQL.

## The fix
Defer the probe into `EXEC sp_executesql` with an `OUTPUT` parameter. Dynamic SQL is compiled only when the statement actually runs (the `ELSE` branch, which is dead on Azure SQL), so the cross-db reference never enters the batch's compile pass:

```sql
IF SERVERPROPERTY('EngineEdition') = 5
    SET @login_exists_MJ_CodeGen = 1;
ELSE
    EXEC sp_executesql
        N'IF EXISTS (SELECT 1 FROM master.sys.server_principals WHERE name = @n) SET @e = 1',
        N'@n NVARCHAR(128), @e BIT OUTPUT',
        @n = N'MJ_CodeGen', @e = @login_exists_MJ_CodeGen OUTPUT;
```

The change is in the **generator** — `packages/MJCLI/src/baseline/emitter.ts` (`emitPrincipals`) — so every future `mj baseline build` is correct. It covers all four MJ service logins (`MJ_CodeGen`, `MJ_CodeGen_Dev`, `MJ_Connect`, `MJ_Connect_Dev`).

## Tests
- 4 new emitter tests (`emitter.principals.test.ts`): probe deferred into `sp_executesql`; **no static `master.sys.*` reference left in the batch** (the cross-db catalog appears only inside the dynamic string literal); EngineEdition guard + FOR LOGIN / WITHOUT LOGIN branches preserved; one independent probe per service login.
- Full MJCLI suite: **207 pass**. Builds clean.

## ⚠️ Open question for the team — already-shipped baselines
This PR fixes the **generator**, but two **already-committed** baselines still carry the old static form (4 occurrences each), and the latest is what fresh installs auto-apply:
- `migrations/v5/B202605132116__v5.34.x__Baseline.sql`
- `migrations/v5/B202605241137__v5.37.x__Baseline.sql`

So the generator fix alone does **not** make the currently-shipped baseline Azure-runnable. Options, with trade-offs — **need a decision**:

1. **Regenerate (normal flow):** leave the committed files; the next release's `mj baseline build` emits a correct baseline. Follows MJ's "new baseline per release" convention, **zero checksum risk** — but Azure stays blocked until that new baseline ships.
2. **Patch v5.34 + v5.37 in place:** apply the same `sp_executesql` transform to the 8 occurrences so the existing latest baseline is immediately Azure-runnable. **But editing shipped migration files changes their checksums**, which can trip Flyway/Skyway `validate` on any install that already applied them.
3. **Patch v5.37 only:** smaller blast radius (just the baseline fresh installs use); same checksum caveat for installs already on it.

I scoped this PR to the generator fix only; happy to add (2) or (3) as follow-up commits once the team picks — it's a mechanical, verifiable edit. The decision hinges on whether any deployed install has already applied those baselines (on SQL Server they apply fine; on Azure they never could).

🤖 Generated with [Claude Code](https://claude.com/claude-code)