### PR TITLE
fix(data-explorer): contain body view z-indices so they can't cover header dropdowns

### DIFF
--- a/.changeset/fix-map-view-zindex-isolation.md
+++ b/.changeset/fix-map-view-zindex-isolation.md
@@ -1,0 +1,14 @@
+---
+"@memberjunction/ng-map-view": patch
+---
+
+fix(map-view): isolate stacking context so the map no longer paints over app overlays
+
+Leaflet's internal panes/controls and the map toolbar use z-index values up to
+~1000 but the component never established its own stacking context, so those
+values competed directly with overlays opened above the map (e.g. the Data
+Explorer view-selector "new view" dropdown) — and since the map renders later in
+the DOM, equal z-index meant the map won and obscured the menu. Adding
+`isolation: isolate` to the component `:host` flattens Leaflet's z-indices into
+the map's own stacking context so external overlays layer correctly. No z-index
+values changed; the map's internal layering is unaffected.

--- a/.changeset/fix-map-view-zindex-isolation.md
+++ b/.changeset/fix-map-view-zindex-isolation.md
@@ -1,14 +1,24 @@
 ---
 "@memberjunction/ng-map-view": patch
+"@memberjunction/ng-dashboards": patch
 ---
 
-fix(map-view): isolate stacking context so the map no longer paints over app overlays
+fix(data-explorer): stop body view content from painting over header dropdowns
 
-Leaflet's internal panes/controls and the map toolbar use z-index values up to
-~1000 but the component never established its own stacking context, so those
-values competed directly with overlays opened above the map (e.g. the Data
-Explorer view-selector "new view" dropdown) — and since the map renders later in
-the DOM, equal z-index meant the map won and obscured the menu. Adding
-`isolation: isolate` to the component `:host` flattens Leaflet's z-indices into
-the map's own stacking context so external overlays layer correctly. No z-index
-values changed; the map's internal layering is unaffected.
+After #2701 lowered the Data Explorer `.content-header` to `z-index: 2` (to keep
+it below the shell header), body view content that leaks a higher z-index began
+painting over the header's own dropdowns. The map view was the visible symptom —
+its Leaflet panes/toolbar (z-index up to ~1000) covered the view-selector "new
+view" dropdown — and the entity grid's option menu (z-index 1000) is the same
+latent class.
+
+Two complementary fixes, both pure containment (no z-index values changed):
+
+- **`@memberjunction/ng-map-view`** — add `isolation: isolate` to the component
+  `:host` so Leaflet's z-indices stay contained in the map's own stacking
+  context. Generic hygiene that protects the map in any consumer.
+- **`@memberjunction/ng-dashboards`** — add `isolation: isolate` to the Data
+  Explorer `.content-body` so all body view content (grid menus, map, cards,
+  timeline, future view modes) is contained beneath the header in one stacking
+  context. Safe because modals and the record detail panel render at the
+  dashboard root, outside `.content-body`, so they still overlay everything.

--- a/packages/Angular/Explorer/dashboards/src/DataExplorer/data-explorer-dashboard.component.css
+++ b/packages/Angular/Explorer/dashboards/src/DataExplorer/data-explorer-dashboard.component.css
@@ -440,6 +440,15 @@
   padding: 20px 24px;
   display: flex;
   flex-direction: column;
+  /* Contain the body's stacking context. The view components inside (grid
+     option menus, the map's Leaflet panes/toolbar, etc.) use z-index values up
+     to ~1000; .content-header sits at z-index 2 (kept below the shell header —
+     see #2701). Without this, those body z-indices leak into the shared context
+     and paint over the header's own dropdowns (view-selector, date-field).
+     `isolation: isolate` flattens all body z-indices into one context beneath
+     the header. Safe because modals + the detail panel render at the dashboard
+     root (outside .content-body), so they still overlay everything. */
+  isolation: isolate;
 }
 
 .loading-container,

--- a/packages/Angular/Generic/ng-map-view/src/lib/map-view.component.css
+++ b/packages/Angular/Generic/ng-map-view/src/lib/map-view.component.css
@@ -2,6 +2,13 @@
     display: block;
     width: 100%;
     height: 100%;
+    /* Contain the map's internal stacking context. Leaflet's panes/controls and
+       the toolbar use z-index values up to ~1000; without isolation those leak
+       into the shared context and paint over app overlays that open above the
+       map (e.g. the Data Explorer view-selector dropdown). `isolation: isolate`
+       flattens all of them into this host's single stacking context so external
+       overlays layer correctly. */
+    isolation: isolate;
 }
 
 .mj-map-view-wrapper {


### PR DESCRIPTION
## Problem

In Data Explorer's **map view**, the map paints **over** the view-selector's "create new view" dropdown — the menu opens behind the map and is unusable.

## Root cause

`.content-body` doesn't contain its children's stacking contexts, and its view components leak z-indices into the shared context. After **#2701** (merged 2026-05-28) lowered `.content-header` from `z-index: 1100` → `2` (to keep it below the shell header), the header's own dropdowns — which are trapped at that `z-index: 2` — drop below any body content leaking a higher z-index:

- **`mj-map-view`** — Leaflet panes/toolbar (~1000). Persistent, so always-visible → the reported bug.
- **`mj-entity-data-grid`** — option menu at `z-index: 1000`. Same class, **latent** (only when that menu is open and overlaps a header dropdown).
- The header's **date-field selector** dropdown is exposed identically to the view-selector.

The map's z-index has been latent since 2026-04-08 (`5f1924065f`); #2701 exposed it. **Renumbering can't fix it:** the body's modals legitimately use `z-index 2000+`, higher than the shell's `500`, so there's no value that puts `.content-header` above the body yet below the shell. The only correct lever is **containment**.

## Fix — two complementary `isolation: isolate`, no z-index values changed

- **`@memberjunction/ng-map-view`** — on the component `:host`, so Leaflet's z-indices stay contained in *any* consumer (generic hygiene).
- **`@memberjunction/ng-dashboards`** — on the Data Explorer `.content-body`, so **all** body view content (grid menus, map, cards, timeline, future view modes) is contained beneath the header in one stacking context. This also closes the latent grid-menu leak.

**Why it's safe:** every modal (confirm / quick-save / duplicate-view / shared-view-warning / aggregate-setup at 2000/2001, view-config-panel at 1201) and the record **detail panel** render at the **dashboard root**, *outside* `.content-body` — so they still overlay everything, including the header.

## Verification

Confirmed against the **live** Members map view (`?entity=Members&view=map&mapMode=choropleth`):
- `.content-body` → computed `isolation: isolate` ✓
- `mj-map-view` → computed `isolation: isolate` ✓
- `.content-header` → `z-index: 2` ✓
- `@memberjunction/ng-map-view` and `@memberjunction/ng-dashboards` build clean.

Unrelated to the concise-chrome PR (#2747) and #2616; this is the #2701 follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)