### PR TITLE
fix(vectors,geo): stop swallowing vector-DB errors + clearer geocoding logs

### DIFF
--- a/packages/AI/Vectors/Database/src/generic/VectorDBBase.ts
+++ b/packages/AI/Vectors/Database/src/generic/VectorDBBase.ts
@@ -135,4 +135,35 @@ export abstract class VectorDBBase {
     public BuildMetadataFilter(options: SharedIndexFilterOptions): object | undefined {
         return VectorMetadataFilter.FromOptions(options);
     }
+
+    /**
+     * Build a standard SUCCESS {@link BaseResponse}. Shared across all drivers so every
+     * provider reports results in a uniform shape.
+     *
+     * @param data - The provider-specific payload to attach to the response.
+     */
+    protected wrapSuccessResponse(data: unknown): BaseResponse {
+        return {
+            success: true,
+            message: '',
+            data,
+        };
+    }
+
+    /**
+     * Build a standard FAILURE {@link BaseResponse}.
+     *
+     * **Always** return this (never a success response) from a `catch` block — returning a
+     * success response on error silently swallows real failures and makes callers, and the
+     * vectorization pipeline, believe an operation worked when it did not.
+     *
+     * @param message - Optional human-readable error detail; falls back to a generic message.
+     */
+    protected wrapFailureResponse(message?: string): BaseResponse {
+        return {
+            success: false,
+            message: message || 'An error occurred',
+            data: null,
+        };
+    }
 }

--- a/packages/AI/Vectors/Providers/Pinecone/src/__tests__/PineconeDatabase.test.ts
+++ b/packages/AI/Vectors/Providers/Pinecone/src/__tests__/PineconeDatabase.test.ts
@@ -53,8 +53,16 @@ vi.mock('@memberjunction/global', () => ({
 }));
 
 vi.mock('@memberjunction/ai-vectordb', () => {
+  // Mirror the real VectorDBBase response helpers (now hoisted to the base class) so
+  // subclasses that call this.wrapSuccessResponse / this.wrapFailureResponse work under the mock.
   class MockVectorDBBase {
     constructor(_apiKey: string) {}
+    protected wrapSuccessResponse(data: unknown) {
+      return { success: true, message: '', data };
+    }
+    protected wrapFailureResponse(message?: string) {
+      return { success: false, message: message || 'An error occurred', data: null };
+    }
   }
   return {
     VectorDBBase: MockVectorDBBase,
@@ -275,6 +283,36 @@ describe('PineconeDatabase', () => {
       const result = await db.CreateRecords([{ id: 'r1', values: [1] }] as never, 'my-index');
       expect(result.success).toBe(true);
       expect(mockIndex).toHaveBeenCalledWith('my-index');
+    });
+
+    // Regression: a thrown upsert error (e.g. dimension mismatch) must surface as a FAILURE,
+    // not be swallowed into a success=true response that makes the pipeline claim it worked.
+    it('should return failure (not swallow) when upsert throws', async () => {
+      mockIndexInstance.upsert.mockRejectedValueOnce(
+        new Error('Vector dimension 1536 does not match the dimension of the index 512')
+      );
+      const result = await db.CreateRecords([{ id: 'r1', values: [1] }] as never, 'my-index');
+      expect(result.success).toBe(false);
+      expect(result.data).toBeNull();
+      expect(result.message).toContain('does not match the dimension');
+    });
+  });
+
+  /* ---- GetRecords ---- */
+  describe('GetRecords', () => {
+    it('should return fetched records on success', async () => {
+      mockIndexInstance.fetch.mockResolvedValueOnce({ records: {} });
+      const result = await db.GetRecords({ id: 'idx', data: ['r1'] } as never);
+      expect(result.success).toBe(true);
+    });
+
+    // Regression: a thrown fetch error must surface as a FAILURE, not a success with null data.
+    it('should return failure (not swallow) when fetch throws', async () => {
+      mockIndexInstance.fetch.mockRejectedValueOnce(new Error('fetch boom'));
+      const result = await db.GetRecords({ id: 'idx', data: ['r1'] } as never);
+      expect(result.success).toBe(false);
+      expect(result.data).toBeNull();
+      expect(result.message).toContain('fetch boom');
     });
   });
 

--- a/packages/AI/Vectors/Providers/Pinecone/src/models/PineconeDatabase.ts
+++ b/packages/AI/Vectors/Providers/Pinecone/src/models/PineconeDatabase.ts
@@ -165,8 +165,11 @@ export class PineconeDatabase extends VectorDBBase {
             return this.wrapSuccessResponse(result);
         }
         catch(ex){
-            console.log(ex);
-            return this.wrapSuccessResponse(null);
+            // Return a FAILURE response — never a success with null data. Reporting success here
+            // silently swallows real upsert errors (e.g. "Vector dimension 1536 does not match the
+            // dimension of the index 512"), making the whole vectorization pipeline claim it worked.
+            LogError("Error creating records", undefined, ex);
+            return this.wrapFailureResponse(ex instanceof Error ? ex.message : String(ex));
         }
     }
 
@@ -188,8 +191,10 @@ export class PineconeDatabase extends VectorDBBase {
             return this.wrapSuccessResponse(fetchResult);
         }
         catch(ex){
+            // Failure must report failure — returning a success response with null data swallows
+            // the fetch error and makes callers believe the records were retrieved.
             LogError("Error getting records", undefined, ex);
-            return this.wrapSuccessResponse(null);
+            return this.wrapFailureResponse(ex instanceof Error ? ex.message : String(ex));
         }
     }
 
@@ -277,19 +282,4 @@ export class PineconeDatabase extends VectorDBBase {
         }
     }
 
-    private wrapSuccessResponse(data: any): BaseResponse {
-        return {
-            success: true,
-            message: null,
-            data: data
-        }
-    };
-
-    private wrapFailureResponse(message?: string): BaseResponse {
-        return {
-            success: false,
-            message: message || "An error occurred",
-            data: null
-        }
-    }
 }

--- a/packages/AI/Vectors/Providers/Qdrant/src/models/QdrantDatabase.ts
+++ b/packages/AI/Vectors/Providers/Qdrant/src/models/QdrantDatabase.ts
@@ -153,10 +153,10 @@ export class QdrantDatabase extends VectorDBBase {
                 host: qdrantUrl,
             };
 
-            return this.WrapSuccessResponse(description);
+            return this.wrapSuccessResponse(description);
         } catch (ex) {
             LogError('Error getting Qdrant collection', undefined, ex);
-            return this.WrapFailureResponse(`Failed to get collection: ${params.id}`);
+            return this.wrapFailureResponse(`Failed to get collection: ${params.id}`);
         }
     }
 
@@ -182,10 +182,10 @@ export class QdrantDatabase extends VectorDBBase {
                 },
                 ...(params.additionalParams || {}),
             });
-            return this.WrapSuccessResponse(null);
+            return this.wrapSuccessResponse(null);
         } catch (ex) {
             LogError('Error creating Qdrant collection', undefined, ex);
-            return this.WrapFailureResponse(`Failed to create collection: ${params.id}`);
+            return this.wrapFailureResponse(`Failed to create collection: ${params.id}`);
         }
     }
 
@@ -199,10 +199,10 @@ export class QdrantDatabase extends VectorDBBase {
     public async DeleteIndex(params: BaseRequestParams): Promise<BaseResponse> {
         try {
             await this._client.deleteCollection(params.id);
-            return this.WrapSuccessResponse(null);
+            return this.wrapSuccessResponse(null);
         } catch (ex) {
             LogError('Error deleting Qdrant collection', undefined, ex);
-            return this.WrapFailureResponse(`Failed to delete collection: ${params.id}`);
+            return this.wrapFailureResponse(`Failed to delete collection: ${params.id}`);
         }
     }
 
@@ -220,10 +220,10 @@ export class QdrantDatabase extends VectorDBBase {
             await this._client.updateCollection(params.id, {
                 ...(params.data || {}),
             });
-            return this.WrapSuccessResponse(null);
+            return this.wrapSuccessResponse(null);
         } catch (ex) {
             LogError('Error updating Qdrant collection', undefined, ex);
-            return this.WrapFailureResponse(`Failed to update collection: ${params.id}`);
+            return this.wrapFailureResponse(`Failed to update collection: ${params.id}`);
         }
     }
 
@@ -254,7 +254,7 @@ export class QdrantDatabase extends VectorDBBase {
         try {
             const collectionName = this.ExtractCollectionName(params);
             if (!collectionName) {
-                return this.WrapFailureResponse('Collection name (id) is required for QueryIndex');
+                return this.wrapFailureResponse('Collection name (id) is required for QueryIndex');
             }
 
             const limit = params.topK || 10;
@@ -286,11 +286,11 @@ export class QdrantDatabase extends VectorDBBase {
                     with_vector: true,
                 });
                 if (points.length === 0) {
-                    return this.WrapFailureResponse(`Point not found: ${params.id}`);
+                    return this.wrapFailureResponse(`Point not found: ${params.id}`);
                 }
                 const pointVector = points[0].vector;
                 if (!pointVector || !Array.isArray(pointVector)) {
-                    return this.WrapFailureResponse('Point does not have a vector for querying');
+                    return this.wrapFailureResponse('Point does not have a vector for querying');
                 }
                 const response = await this._client.query(collectionName, {
                     query: pointVector as number[],
@@ -301,7 +301,7 @@ export class QdrantDatabase extends VectorDBBase {
                 });
                 scoredPoints = response.points as QdrantScoredPoint[];
             } else {
-                return this.WrapFailureResponse('Either vector or id is required for QueryIndex');
+                return this.wrapFailureResponse('Either vector or id is required for QueryIndex');
             }
 
             // Map Qdrant results to our standard format
@@ -312,13 +312,13 @@ export class QdrantDatabase extends VectorDBBase {
                 score: r.score,
             }));
 
-            return this.WrapSuccessResponse({
+            return this.wrapSuccessResponse({
                 matches,
                 namespace: '',
             });
         } catch (ex) {
             LogError('Error querying Qdrant collection', undefined, ex);
-            return this.WrapFailureResponse('Failed to query collection');
+            return this.wrapFailureResponse('Failed to query collection');
         }
     }
 
@@ -346,7 +346,7 @@ export class QdrantDatabase extends VectorDBBase {
     public async CreateRecords(records: VectorRecord[], indexName?: string): Promise<BaseResponse> {
         try {
             if (!indexName) {
-                return this.WrapFailureResponse('Collection name (indexName) is required for CreateRecords');
+                return this.wrapFailureResponse('Collection name (indexName) is required for CreateRecords');
             }
 
             const points = records.map((r) => ({
@@ -356,10 +356,10 @@ export class QdrantDatabase extends VectorDBBase {
             }));
 
             await this._client.upsert(indexName, { points });
-            return this.WrapSuccessResponse(null);
+            return this.wrapSuccessResponse(null);
         } catch (ex) {
             LogError('Error creating records in Qdrant', undefined, ex);
-            return this.WrapFailureResponse('Failed to create records');
+            return this.wrapFailureResponse('Failed to create records');
         }
     }
 
@@ -392,7 +392,7 @@ export class QdrantDatabase extends VectorDBBase {
             const ids: string[] = params.data?.ids || [params.id];
 
             if (!collectionName) {
-                return this.WrapFailureResponse('collectionName is required in params.data');
+                return this.wrapFailureResponse('collectionName is required in params.data');
             }
 
             const points = await this._client.retrieve(collectionName, {
@@ -407,10 +407,10 @@ export class QdrantDatabase extends VectorDBBase {
                 metadata: (p.payload || {}) as Record<string, string | boolean | number | string[]>,
             }));
 
-            return this.WrapSuccessResponse(records);
+            return this.wrapSuccessResponse(records);
         } catch (ex) {
             LogError('Error getting records from Qdrant', undefined, ex);
-            return this.WrapFailureResponse('Failed to get records');
+            return this.wrapFailureResponse('Failed to get records');
         }
     }
 
@@ -449,7 +449,7 @@ export class QdrantDatabase extends VectorDBBase {
             const collectionName = data.data?.collectionName as string | undefined;
 
             if (!collectionName) {
-                return this.WrapFailureResponse('collectionName is required in records.data for UpdateRecords');
+                return this.wrapFailureResponse('collectionName is required in records.data for UpdateRecords');
             }
 
             const recordsList: UpdateOptions[] = data.data?.records || [records];
@@ -474,10 +474,10 @@ export class QdrantDatabase extends VectorDBBase {
                 });
             }
 
-            return this.WrapSuccessResponse(null);
+            return this.wrapSuccessResponse(null);
         } catch (ex) {
             LogError('Error updating records in Qdrant', undefined, ex);
-            return this.WrapFailureResponse('Failed to update records');
+            return this.wrapFailureResponse('Failed to update records');
         }
     }
 
@@ -505,17 +505,17 @@ export class QdrantDatabase extends VectorDBBase {
     public async DeleteRecords(records: VectorRecord[], indexName?: string): Promise<BaseResponse> {
         try {
             if (!indexName) {
-                return this.WrapFailureResponse('Collection name (indexName) is required for DeleteRecords');
+                return this.wrapFailureResponse('Collection name (indexName) is required for DeleteRecords');
             }
 
             const ids = records.map((r) => r.id);
             await this._client.delete(indexName, {
                 points: ids,
             });
-            return this.WrapSuccessResponse(null);
+            return this.wrapSuccessResponse(null);
         } catch (ex) {
             LogError('Error deleting records from Qdrant', undefined, ex);
-            return this.WrapFailureResponse('Failed to delete records');
+            return this.wrapFailureResponse('Failed to delete records');
         }
     }
 
@@ -546,10 +546,10 @@ export class QdrantDatabase extends VectorDBBase {
                 });
             }
 
-            return this.WrapSuccessResponse(null);
+            return this.wrapSuccessResponse(null);
         } catch (ex) {
             LogError('Error deleting all records from Qdrant', undefined, ex);
-            return this.WrapFailureResponse('Failed to delete all records');
+            return this.wrapFailureResponse('Failed to delete all records');
         }
     }
 
@@ -691,19 +691,4 @@ export class QdrantDatabase extends VectorDBBase {
         return undefined;
     }
 
-    private WrapSuccessResponse(data: unknown): BaseResponse {
-        return {
-            success: true,
-            message: '',
-            data: data,
-        };
-    }
-
-    private WrapFailureResponse(message?: string): BaseResponse {
-        return {
-            success: false,
-            message: message || 'An error occurred',
-            data: null,
-        };
-    }
 }

--- a/packages/AI/Vectors/Providers/pgvector/src/models/PgVectorDatabase.ts
+++ b/packages/AI/Vectors/Providers/pgvector/src/models/PgVectorDatabase.ts
@@ -172,7 +172,7 @@ export class PgVectorDatabase extends VectorDBBase {
                 [params.id]
             );
             if (result.rows.length === 0) {
-                return this.WrapFailureResponse(`Index "${params.id}" not found`);
+                return this.wrapFailureResponse(`Index "${params.id}" not found`);
             }
             const row = result.rows[0] as { name: string; dimension: number; metric: string };
             const desc: IndexDescription = {
@@ -181,11 +181,11 @@ export class PgVectorDatabase extends VectorDBBase {
                 metric: row.metric as IndexModelMetricEnum,
                 host: `${this._config.Host}:${this._config.Port}`,
             };
-            return this.WrapSuccessResponse(desc);
+            return this.wrapSuccessResponse(desc);
         }
         catch (ex) {
             LogError('PgVectorDatabase.GetIndex error', undefined, ex);
-            return this.WrapFailureResponse('Error getting index');
+            return this.wrapFailureResponse('Error getting index');
         }
     }
 
@@ -250,11 +250,11 @@ export class PgVectorDatabase extends VectorDBBase {
             );
 
             LogStatus(`PgVectorDatabase: Created index "${tableName}" (dim=${dimension}, metric=${metric})`);
-            return this.WrapSuccessResponse({ name: tableName, dimension, metric });
+            return this.wrapSuccessResponse({ name: tableName, dimension, metric });
         }
         catch (ex) {
             LogError('PgVectorDatabase.CreateIndex error', undefined, ex);
-            return this.WrapFailureResponse('Error creating index');
+            return this.wrapFailureResponse('Error creating index');
         }
     }
 
@@ -275,11 +275,11 @@ export class PgVectorDatabase extends VectorDBBase {
                 `DELETE FROM ${this.QualifyTable(INDEX_REGISTRY_TABLE)} WHERE name = $1`,
                 [params.id]
             );
-            return this.WrapSuccessResponse(null);
+            return this.wrapSuccessResponse(null);
         }
         catch (ex) {
             LogError('PgVectorDatabase.DeleteIndex error', undefined, ex);
-            return this.WrapFailureResponse('Error deleting index');
+            return this.wrapFailureResponse('Error deleting index');
         }
     }
 
@@ -294,7 +294,7 @@ export class PgVectorDatabase extends VectorDBBase {
     public async EditIndex(params: EditIndexParams): Promise<BaseResponse> {
         // pgvector tables don't have many editable properties.
         // This is a placeholder that could support renaming or adding columns in the future.
-        return this.WrapFailureResponse('EditIndex is not currently supported for pgvector');
+        return this.wrapFailureResponse('EditIndex is not currently supported for pgvector');
     }
 
     // ----------------------------------------------------------------
@@ -333,10 +333,10 @@ export class PgVectorDatabase extends VectorDBBase {
             const indexName = 'id' in params ? (params as { id: string }).id : null;
 
             if (!vector) {
-                return this.WrapFailureResponse('QueryIndex requires a vector in the params');
+                return this.wrapFailureResponse('QueryIndex requires a vector in the params');
             }
             if (!indexName) {
-                return this.WrapFailureResponse('QueryIndex requires an index name (params.id)');
+                return this.wrapFailureResponse('QueryIndex requires an index name (params.id)');
             }
 
             const topK = params.topK || 10;
@@ -388,11 +388,11 @@ export class PgVectorDatabase extends VectorDBBase {
                 namespace: this._config.Schema,
             };
 
-            return this.WrapSuccessResponse(queryResponse);
+            return this.wrapSuccessResponse(queryResponse);
         }
         catch (ex) {
             LogError('PgVectorDatabase.QueryIndex error', undefined, ex);
-            return this.WrapFailureResponse('Error querying index');
+            return this.wrapFailureResponse('Error querying index');
         }
     }
 
@@ -411,7 +411,7 @@ export class PgVectorDatabase extends VectorDBBase {
      */
     public async CreateRecord(record: VectorRecord, indexName?: string): Promise<BaseResponse> {
         if (!indexName) {
-            return this.WrapFailureResponse('indexName is required for CreateRecord');
+            return this.wrapFailureResponse('indexName is required for CreateRecord');
         }
         return this.UpsertRecords([record], indexName);
     }
@@ -430,7 +430,7 @@ export class PgVectorDatabase extends VectorDBBase {
      */
     public async CreateRecords(records: VectorRecord[], indexName?: string): Promise<BaseResponse> {
         if (!indexName) {
-            return this.WrapFailureResponse('indexName is required for CreateRecords');
+            return this.wrapFailureResponse('indexName is required for CreateRecords');
         }
         return this.UpsertRecords(records, indexName);
     }
@@ -449,7 +449,7 @@ export class PgVectorDatabase extends VectorDBBase {
             const pool = this.GetPool();
             const indexName = params.data?.indexName as string;
             if (!indexName) {
-                return this.WrapFailureResponse('params.data.indexName is required');
+                return this.wrapFailureResponse('params.data.indexName is required');
             }
 
             const result = await pool.query(
@@ -460,7 +460,7 @@ export class PgVectorDatabase extends VectorDBBase {
             );
 
             if (result.rows.length === 0) {
-                return this.WrapFailureResponse(`Record "${params.id}" not found`);
+                return this.wrapFailureResponse(`Record "${params.id}" not found`);
             }
 
             const row = result.rows[0] as { id: string; embedding_text: string; metadata: Record<string, unknown> };
@@ -469,11 +469,11 @@ export class PgVectorDatabase extends VectorDBBase {
                 values: this.ParseVectorString(row.embedding_text),
                 metadata: row.metadata as Record<string, string | boolean | number | string[]>,
             };
-            return this.WrapSuccessResponse(record);
+            return this.wrapSuccessResponse(record);
         }
         catch (ex) {
             LogError('PgVectorDatabase.GetRecord error', undefined, ex);
-            return this.WrapFailureResponse('Error getting record');
+            return this.wrapFailureResponse('Error getting record');
         }
     }
 
@@ -493,10 +493,10 @@ export class PgVectorDatabase extends VectorDBBase {
             const indexName = params.data?.indexName as string;
             const ids = params.data?.ids as string[];
             if (!indexName) {
-                return this.WrapFailureResponse('params.data.indexName is required');
+                return this.wrapFailureResponse('params.data.indexName is required');
             }
             if (!ids || ids.length === 0) {
-                return this.WrapFailureResponse('params.data.ids is required');
+                return this.wrapFailureResponse('params.data.ids is required');
             }
 
             const placeholders = ids.map((_: string, i: number) => `$${i + 1}`).join(', ');
@@ -512,11 +512,11 @@ export class PgVectorDatabase extends VectorDBBase {
                 values: this.ParseVectorString(row['embedding_text'] as string),
                 metadata: row['metadata'] as Record<string, string | boolean | number | string[]>,
             }));
-            return this.WrapSuccessResponse(records);
+            return this.wrapSuccessResponse(records);
         }
         catch (ex) {
             LogError('PgVectorDatabase.GetRecords error', undefined, ex);
-            return this.WrapFailureResponse('Error getting records');
+            return this.wrapFailureResponse('Error getting records');
         }
     }
 
@@ -537,7 +537,7 @@ export class PgVectorDatabase extends VectorDBBase {
             const pool = this.GetPool();
             const indexName = (record as Record<string, unknown>)['indexName'] as string;
             if (!indexName) {
-                return this.WrapFailureResponse('indexName property is required on the UpdateOptions object');
+                return this.wrapFailureResponse('indexName property is required on the UpdateOptions object');
             }
 
             const setClauses: string[] = [];
@@ -556,7 +556,7 @@ export class PgVectorDatabase extends VectorDBBase {
             }
 
             if (setClauses.length === 0) {
-                return this.WrapSuccessResponse(null);
+                return this.wrapSuccessResponse(null);
             }
 
             queryParams.push(record.id);
@@ -567,11 +567,11 @@ export class PgVectorDatabase extends VectorDBBase {
                 queryParams
             );
 
-            return this.WrapSuccessResponse(null);
+            return this.wrapSuccessResponse(null);
         }
         catch (ex) {
             LogError('PgVectorDatabase.UpdateRecord error', undefined, ex);
-            return this.WrapFailureResponse('Error updating record');
+            return this.wrapFailureResponse('Error updating record');
         }
     }
 
@@ -599,7 +599,7 @@ export class PgVectorDatabase extends VectorDBBase {
      */
     public async DeleteRecord(record: VectorRecord, indexName?: string): Promise<BaseResponse> {
         if (!indexName) {
-            return this.WrapFailureResponse('indexName is required for DeleteRecord');
+            return this.wrapFailureResponse('indexName is required for DeleteRecord');
         }
         try {
             const pool = this.GetPool();
@@ -607,11 +607,11 @@ export class PgVectorDatabase extends VectorDBBase {
                 `DELETE FROM ${this.QualifyTable(indexName)} WHERE id = $1`,
                 [record.id]
             );
-            return this.WrapSuccessResponse(null);
+            return this.wrapSuccessResponse(null);
         }
         catch (ex) {
             LogError('PgVectorDatabase.DeleteRecord error', undefined, ex);
-            return this.WrapFailureResponse('Error deleting record');
+            return this.wrapFailureResponse('Error deleting record');
         }
     }
 
@@ -625,7 +625,7 @@ export class PgVectorDatabase extends VectorDBBase {
      */
     public async DeleteRecords(records: VectorRecord[], indexName?: string): Promise<BaseResponse> {
         if (!indexName) {
-            return this.WrapFailureResponse('indexName is required for DeleteRecords');
+            return this.wrapFailureResponse('indexName is required for DeleteRecords');
         }
         try {
             const pool = this.GetPool();
@@ -635,11 +635,11 @@ export class PgVectorDatabase extends VectorDBBase {
                 `DELETE FROM ${this.QualifyTable(indexName)} WHERE id IN (${placeholders})`,
                 ids
             );
-            return this.WrapSuccessResponse(null);
+            return this.wrapSuccessResponse(null);
         }
         catch (ex) {
             LogError('PgVectorDatabase.DeleteRecords error', undefined, ex);
-            return this.WrapFailureResponse('Error deleting records');
+            return this.wrapFailureResponse('Error deleting records');
         }
     }
 
@@ -656,11 +656,11 @@ export class PgVectorDatabase extends VectorDBBase {
         try {
             const pool = this.GetPool();
             await pool.query(`DELETE FROM ${this.QualifyTable(indexName)}`);
-            return this.WrapSuccessResponse(null);
+            return this.wrapSuccessResponse(null);
         }
         catch (ex) {
             LogError('PgVectorDatabase.DeleteAllRecords error', undefined, ex);
-            return this.WrapFailureResponse('Error deleting all records');
+            return this.wrapFailureResponse('Error deleting all records');
         }
     }
 
@@ -795,7 +795,7 @@ export class PgVectorDatabase extends VectorDBBase {
                     );
                 }
                 await client.query('COMMIT');
-                return this.WrapSuccessResponse({ upsertedCount: records.length });
+                return this.wrapSuccessResponse({ upsertedCount: records.length });
             }
             catch (txErr) {
                 await client.query('ROLLBACK');
@@ -807,7 +807,7 @@ export class PgVectorDatabase extends VectorDBBase {
         }
         catch (ex) {
             LogError('PgVectorDatabase.UpsertRecords error', undefined, ex);
-            return this.WrapFailureResponse('Error upserting records');
+            return this.wrapFailureResponse('Error upserting records');
         }
     }
 
@@ -938,19 +938,4 @@ export class PgVectorDatabase extends VectorDBBase {
         }
     }
 
-    private WrapSuccessResponse(data: unknown): BaseResponse {
-        return {
-            success: true,
-            message: '',
-            data: data,
-        };
-    }
-
-    private WrapFailureResponse(message?: string): BaseResponse {
-        return {
-            success: false,
-            message: message || 'An error occurred',
-            data: null,
-        };
-    }
 }

--- a/packages/AI/Vectors/Sync/src/models/entityVectorSync.ts
+++ b/packages/AI/Vectors/Sync/src/models/entityVectorSync.ts
@@ -27,6 +27,8 @@ export class EntityVectorSyncer extends VectorBase {
   _endTime: Date;
   /** Accumulates render errors across batches so they can be reported through the progress callback */
   private _renderErrors: { RecordID: string; Message: string }[] = [];
+  /** Accumulates vector-DB upsert errors across batches so a failed upsert is reflected in the run's success flag */
+  private _upsertErrors: { RecordID: string; Message: string }[] = [];
 
   /**
    * Returns the active metadata provider — explicit override (via `this.Provider = ...`)
@@ -69,6 +71,7 @@ export class EntityVectorSyncer extends VectorBase {
     const startTime: number = new Date().getTime();
     super.CurrentUser = contextUser;
     this._renderErrors = []; // reset for each vectorization run
+    this._upsertErrors = []; // reset for each vectorization run
     await TemplateEngineServer.Instance.Config(false, contextUser);
 
     const entityDocument: MJEntityDocumentEntity = await this.GetEntityDocument(params.entityDocumentID);
@@ -145,6 +148,7 @@ export class EntityVectorSyncer extends VectorBase {
     let lastEmittedPct = -1;
     let dataStreamEnded = false;
     const renderErrors = this._renderErrors; // capture reference for use in Transform closure
+    const upsertErrors = this._upsertErrors; // capture reference for use in Transform closure
     const progressTracker = new Transform({
       objectMode: true,
       transform(chunk: EmbeddingData, _encoding: BufferEncoding, callback: TransformCallback) {
@@ -155,13 +159,14 @@ export class EntityVectorSyncer extends VectorBase {
 
           // Detect when all records have been processed and data stream is done
           if (dataStreamEnded && processedRecords >= totalRecordsFed) {
+            const allErrors = [...renderErrors, ...upsertErrors];
             onProgress({
               TotalRecords: totalRecordsFed,
               ProcessedRecords: processedRecords,
-              Stage: 'complete',
+              Stage: allErrors.length > 0 ? 'error' : 'complete',
               PercentComplete: 100,
               ElapsedMs: elapsed,
-              Errors: renderErrors.length > 0 ? renderErrors : undefined,
+              Errors: allErrors.length > 0 ? allErrors : undefined,
             });
           } else {
             // Throttle: only emit on 5% boundaries to avoid flooding PubSub/WebSocket
@@ -215,22 +220,43 @@ export class EntityVectorSyncer extends VectorBase {
     const elapsedSeconds = elapsedMs / 1000;
     LogStatus(`Finished vectorizing ${entityDocument.Entity} entity in ${elapsedSeconds} seconds (${(elapsedSeconds / 60).toFixed(1)} minutes)`);
 
-    // Emit final 100% completion with any accumulated render errors
+    // Emit final 100% completion with any accumulated render + upsert errors.
+    // This post-pipeline emission is authoritative: by the time pipeline() resolves, every
+    // upsert batch has settled, so _upsertErrors is fully populated.
+    const allErrors = [...this._renderErrors, ...this._upsertErrors];
     if (onProgress) {
       onProgress({
         TotalRecords: totalRecordsFed,
         ProcessedRecords: processedRecords,
-        Stage: 'complete',
+        Stage: allErrors.length > 0 ? 'error' : 'complete',
         PercentComplete: 100,
         ElapsedMs: elapsedMs,
-        Errors: this._renderErrors.length > 0 ? this._renderErrors : undefined,
+        Errors: allErrors.length > 0 ? allErrors : undefined,
       });
     }
 
-    const errorSummary = this._renderErrors.length > 0
-      ? `${this._renderErrors.length} record(s) failed template rendering`
-      : '';
-    return { success: true, status: 'Complete', errorMessage: errorSummary };
+    // Reflect reality in the success flag: a run that failed every template render or every
+    // vector upsert must NOT report success. Callers that inspect `success` (KnowledgePipeline,
+    // KnowledgeAgent) already handle the false branch.
+    const success = allErrors.length === 0;
+    const errorMessage = this.buildVectorizeErrorSummary();
+    const status = success ? 'Complete' : 'CompletedWithErrors';
+    return { success, status, errorMessage };
+  }
+
+  /**
+   * Build a human-readable summary of render + upsert failures accumulated during the run,
+   * or an empty string when there were none.
+   */
+  private buildVectorizeErrorSummary(): string {
+    const parts: string[] = [];
+    if (this._renderErrors.length > 0) {
+      parts.push(`${this._renderErrors.length} record(s) failed template rendering`);
+    }
+    if (this._upsertErrors.length > 0) {
+      parts.push(`${this._upsertErrors.length} record(s) failed vector upsert`);
+    }
+    return parts.join('; ');
   }
 
   /**
@@ -481,7 +507,13 @@ export class EntityVectorSyncer extends VectorBase {
 
     const response: BaseResponse = await vectorDB.CreateRecords(vectorRecords, indexName);
     if (!response.success) {
-      LogError('Unable to save records to vector database', undefined, response.message);
+      const message = response.message || 'Unknown vector database error';
+      LogError('Unable to save records to vector database', undefined, message);
+      // Record one error per record in the failed batch so the run's success flag and the
+      // progress callback reflect the failure instead of silently reporting success.
+      for (const item of batch) {
+        this._upsertErrors.push({ RecordID: String(item.__mj_recordID ?? ''), Message: `Vector upsert failed: ${message}` });
+      }
     }
 
     await new Promise<void>((resolve) => setTimeout(resolve, delayTimeMS));

--- a/packages/Actions/CoreActions/src/custom/geo/scheduled-geocoding.action.ts
+++ b/packages/Actions/CoreActions/src/custom/geo/scheduled-geocoding.action.ts
@@ -11,6 +11,22 @@ import { GeoCodeSyncService, ExistingGeoCodeInfo } from '@memberjunction/geo-cor
 import { GetDialect, SQLDialect } from '@memberjunction/sql-dialect';
 
 /**
+ * Console progress context threaded into {@link ScheduledGeocodingAction.geocodeBatch}
+ * so that per-batch log lines read as one continuous, cumulative stream across
+ * every page of a group (entity) rather than resetting to `1/N` each page.
+ */
+type BatchProgress = {
+    /** Display label for the group, e.g. the entity name. */
+    Label: string;
+    /** Denominator: total records in scope for this group (0 = unknown → rendered as `?`). */
+    Total: number;
+    /** Records already processed for this group before the current call — anchors the cumulative range. */
+    Offset: number;
+    /** 1-based page number, shown in parens. Omitted for single-page groups. */
+    Page?: number;
+};
+
+/**
  * Scheduled geocoding maintenance action that handles three tasks:
  *
  * 1. **Missing records** — Finds records in geo-enabled entities that have
@@ -55,6 +71,8 @@ export class ScheduledGeocodingAction extends BaseAction {
     private static readonly DEFAULT_MAX_TOTAL = 50_000;
     /** Page size for RunView pagination — controls how many BaseEntity objects exist simultaneously. */
     private static readonly PAGE_SIZE = 500;
+    /** Indentation prefix for child log lines nested under a group/entity header. */
+    private static readonly INDENT = '   ';
 
     /**
      * Geocoding provider name in effect for the current run. Set at the top of
@@ -80,7 +98,7 @@ export class ScheduledGeocodingAction extends BaseAction {
         const geocodingProvider = this.getStringParam(params, 'GeocodingProvider');
         this.currentGeocodingProvider = geocodingProvider ?? null;
 
-        LogStatus(`ScheduledGeocodingAction: Starting maintenance run (BatchSize=${batchSize}, MaxTotal=${maxTotal}, GeocodingProvider=${geocodingProvider ?? 'config-default'})`);
+        LogStatus(`🌍 Scheduled Geocoding — starting (batch ${batchSize} · max ${this.fmt(maxTotal)} · provider ${geocodingProvider ?? 'config-default'})`);
 
         const stats = { MissingProcessed: 0, MissingSuccess: 0, RetriesProcessed: 0, RetriesSuccess: 0, OrphansRemoved: 0 };
 
@@ -100,10 +118,10 @@ export class ScheduledGeocodingAction extends BaseAction {
 
         const totalRecordsProcessed = stats.MissingProcessed + stats.RetriesProcessed;
         if (totalRecordsProcessed >= maxTotal) {
-            LogStatus(`ScheduledGeocodingAction: WARNING — MaxTotal limit (${maxTotal}) reached. There may be remaining records for the next run.`);
+            LogStatus(`⚠️  MaxTotal limit (${this.fmt(maxTotal)}) reached — remaining records will be picked up on the next run.`);
         }
 
-        LogStatus(`ScheduledGeocodingAction: Complete — Missing: ${stats.MissingProcessed} processed (${stats.MissingSuccess} success), Retries: ${stats.RetriesProcessed} (${stats.RetriesSuccess} success), Orphans: ${stats.OrphansRemoved} removed`);
+        LogStatus(`🏁 Scheduled Geocoding — complete · missing ${this.fmt(stats.MissingProcessed)} (${this.fmt(stats.MissingSuccess)} ✓) · retries ${this.fmt(stats.RetriesProcessed)} (${this.fmt(stats.RetriesSuccess)} ✓) · orphans ${this.fmt(stats.OrphansRemoved)} removed`);
 
         return {
             Success: true,
@@ -142,7 +160,7 @@ export class ScheduledGeocodingAction extends BaseAction {
         }
 
         if (totalProcessed > 0) {
-            LogStatus(`ScheduledGeocodingAction: Processed ${totalProcessed} missing records (${totalSuccess} geocoded successfully)`);
+            LogStatus(`✅ Missing-record geocoding complete — ${this.fmt(totalProcessed)} processed, ${this.fmt(totalSuccess)} geocoded`);
         }
 
         return { Processed: totalProcessed, Success: totalSuccess };
@@ -186,18 +204,26 @@ export class ScheduledGeocodingAction extends BaseAction {
             let totalSuccess = 0;
             let pageOffset = 0;             // OFFSET-mode (composite-PK fallback)
             let lastSeenKey: CompositeKey | undefined; // keyset mode
+            let pageNumber = 0;             // 1-based, shown in batch lines
+            let candidateTotal = 0;         // denominator: records with address data (from page-1 TotalRowCount)
+            let headerLogged = false;       // emit the entity header lazily, only when there's work to do
 
             // Paginate through entity records to avoid loading all into memory at once.
             // Keyset pagination keeps each page O(log N) regardless of depth — a critical
             // win when the entity has millions of rows. See guides/KEYSET_PAGINATION_GUIDE.md.
             while (totalProcessed < maxRows) {
+                pageNumber++;
                 const pageResult = canUseKeyset
                     ? await this.loadEntityPageKeyset(entityInfo.Name, pkField.Name, nonNullConditions, lastSeenKey, contextUser)
                     : await this.loadEntityPageOffset(entityInfo.Name, nonNullConditions, pageOffset, contextUser);
 
                 if (!pageResult.Success || pageResult.Results.length === 0) break;
 
-                const pageEntities = pageResult.Results as unknown as BaseEntity[];
+                // TotalRowCount reports the full count matching the filter regardless of the
+                // keyset seek predicate / page offset, so the first page gives us a stable denominator.
+                if (candidateTotal === 0) candidateTotal = pageResult.TotalRowCount;
+
+                const pageEntities = pageResult.Results;
 
                 // Filter to records missing geocodes (not in existingMap for any LocationType)
                 const missingRecords = pageEntities.filter(entity => {
@@ -209,9 +235,18 @@ export class ScheduledGeocodingAction extends BaseAction {
                 });
 
                 if (missingRecords.length > 0) {
+                    if (!headerLogged) {
+                        this.logEntityHeader(entityInfo, candidateTotal);
+                        headerLogged = true;
+                    }
                     const budget = maxRows - totalProcessed;
                     const toProcess = missingRecords.slice(0, budget);
-                    const stats = await this.geocodeBatch(toProcess, entityInfo, contextUser, batchSize, existingMap);
+                    const stats = await this.geocodeBatch(toProcess, entityInfo, contextUser, batchSize, existingMap, {
+                        Label: entityInfo.Name,
+                        Total: candidateTotal,
+                        Offset: totalProcessed,
+                        Page: pageNumber
+                    });
                     totalProcessed += stats.Processed;
                     totalSuccess += stats.Success;
                 }
@@ -228,6 +263,10 @@ export class ScheduledGeocodingAction extends BaseAction {
                 } else {
                     pageOffset += ScheduledGeocodingAction.PAGE_SIZE;
                 }
+            }
+
+            if (headerLogged) {
+                this.logEntityComplete(entityInfo, totalProcessed, totalSuccess, candidateTotal);
             }
 
             return { Processed: totalProcessed, Success: totalSuccess };
@@ -254,7 +293,7 @@ export class ScheduledGeocodingAction extends BaseAction {
         nonNullFilter: string,
         lastSeenKey: CompositeKey | undefined,
         contextUser: UserInfo
-    ): Promise<{ Success: boolean; Results: BaseEntity[] }> {
+    ): Promise<{ Success: boolean; Results: BaseEntity[]; TotalRowCount: number }> {
         const rv = new RunView();
         const result = await rv.RunView({
             EntityName: entityName,
@@ -268,7 +307,8 @@ export class ScheduledGeocodingAction extends BaseAction {
 
         return {
             Success: result.Success,
-            Results: result.Success ? (result.Results as unknown as BaseEntity[]) : []
+            Results: result.Success ? (result.Results as unknown as BaseEntity[]) : [],
+            TotalRowCount: result.Success ? result.TotalRowCount : 0
         };
     }
 
@@ -281,7 +321,7 @@ export class ScheduledGeocodingAction extends BaseAction {
         nonNullFilter: string,
         offset: number,
         contextUser: UserInfo
-    ): Promise<{ Success: boolean; Results: BaseEntity[] }> {
+    ): Promise<{ Success: boolean; Results: BaseEntity[]; TotalRowCount: number }> {
         const rv = new RunView();
         const result = await rv.RunView({
             EntityName: entityName,
@@ -295,7 +335,8 @@ export class ScheduledGeocodingAction extends BaseAction {
 
         return {
             Success: result.Success,
-            Results: result.Success ? (result.Results as unknown as BaseEntity[]) : []
+            Results: result.Success ? (result.Results as unknown as BaseEntity[]) : [],
+            TotalRowCount: result.Success ? result.TotalRowCount : 0
         };
     }
 
@@ -322,6 +363,7 @@ export class ScheduledGeocodingAction extends BaseAction {
         let totalProcessed = 0;
         let totalSuccess = 0;
         let pageOffset = 0;
+        let retryTotal = 0;   // denominator: total failed-and-retriable rows (from page-1 TotalRowCount)
 
         while (totalProcessed < maxTotal) {
             const pageResult = await rv.RunView<MJRecordGeoCodeEntity>({
@@ -340,7 +382,8 @@ export class ScheduledGeocodingAction extends BaseAction {
             const records = pageResult.Results.slice(0, budget);
 
             if (totalProcessed === 0) {
-                LogStatus(`ScheduledGeocodingAction: Processing failed records for retry`);
+                retryTotal = Math.min(pageResult.TotalRowCount, maxTotal);
+                LogStatus(`🔁 Retrying failed geocodes — ${this.fmt(retryTotal)} pending`);
             }
 
             // Group by entity for efficient processing
@@ -362,7 +405,11 @@ export class ScheduledGeocodingAction extends BaseAction {
                 const entities = await this.loadSourceEntities(geoRecords, entityInfo, contextUser, provider);
                 if (entities.length === 0) continue;
 
-                const stats = await this.geocodeBatch(entities, entityInfo, contextUser, batchSize);
+                const stats = await this.geocodeBatch(entities, entityInfo, contextUser, batchSize, undefined, {
+                    Label: entityInfo.Name,
+                    Total: retryTotal,
+                    Offset: totalProcessed
+                });
                 totalProcessed += stats.Processed;
                 totalSuccess += stats.Success;
             }
@@ -507,7 +554,7 @@ export class ScheduledGeocodingAction extends BaseAction {
         }
 
         if (entityRemoved > 0) {
-            LogStatus(`ScheduledGeocodingAction: Removed ${entityRemoved} orphaned geo records for ${entityInfo.Name}`);
+            LogStatus(`🧹 ${entityInfo.Name} — removed ${this.fmt(entityRemoved)} orphaned geo records`);
         }
         return entityRemoved;
     }
@@ -531,13 +578,17 @@ export class ScheduledGeocodingAction extends BaseAction {
      * @param contextUser - User context
      * @param batchSize - Number of concurrent geocoding operations per batch
      * @param existingGeoCodesMap - Optional pre-loaded map passed to GeoCodeSyncService
+     * @param progress - Optional console progress context. When supplied, each batch logs a
+     *   cumulative `records X–Y of Total` line (anchored to `progress.Offset`) instead of a
+     *   per-call `batch N/M` line that resets every page.
      */
     private async geocodeBatch(
         entities: BaseEntity[],
         entityInfo: EntityInfo,
         contextUser: UserInfo,
         batchSize: number,
-        existingGeoCodesMap?: Map<string, ExistingGeoCodeInfo>
+        existingGeoCodesMap?: Map<string, ExistingGeoCodeInfo>,
+        progress?: BatchProgress
     ): Promise<{ Processed: number; Success: number }> {
         let totalSuccess = 0;
 
@@ -551,8 +602,8 @@ export class ScheduledGeocodingAction extends BaseAction {
             const batchSuccess = results.filter(r => r.status === 'fulfilled' && r.value).length;
             totalSuccess += batchSuccess;
 
-            if (entities.length > batchSize) {
-                LogStatus(`ScheduledGeocodingAction: ${entityInfo.Name} batch ${Math.floor(i / batchSize) + 1}/${Math.ceil(entities.length / batchSize)} — ${batchSuccess}/${batch.length} success`);
+            if (progress) {
+                this.logBatchProgress(progress, i, batch.length, batchSuccess);
             }
         }
 
@@ -625,6 +676,59 @@ export class ScheduledGeocodingAction extends BaseAction {
             eventCode: BaseEntity.BaseEventCode,
             args: event
         });
+    }
+
+    // ================================================================
+    // Console UX helpers
+    // ================================================================
+
+    /**
+     * Format an integer with locale thousands separators for console output
+     * (e.g. `2000` → `2,000`). Pinned to `en-US` for deterministic logs.
+     */
+    private fmt(n: number): string {
+        return n.toLocaleString('en-US');
+    }
+
+    /**
+     * Emit the group header that precedes a single entity's batch lines, e.g.
+     * `📍 Members — 2,000 records with address data`.
+     */
+    private logEntityHeader(entityInfo: EntityInfo, candidateTotal: number): void {
+        const scope = candidateTotal > 0
+            ? `${this.fmt(candidateTotal)} records with address data`
+            : 'records with address data';
+        LogStatus(`📍 ${entityInfo.Name} — ${scope}`);
+    }
+
+    /**
+     * Emit one indented, cumulative batch line beneath the entity header, e.g.
+     * `   ✓ records 1,991–2,000 of 2,000 · 10/10  (page 4)`. The range is anchored
+     * to `progress.Offset` so the numbers run continuously across every page.
+     */
+    private logBatchProgress(progress: BatchProgress, localIndex: number, batchCount: number, batchSuccess: number): void {
+        const start = progress.Offset + localIndex + 1;
+        const end = progress.Offset + localIndex + batchCount;
+        const total = progress.Total > 0 ? this.fmt(progress.Total) : '?';
+        const allOk = batchSuccess === batchCount;
+        const icon = allOk ? '✓' : '⚠';
+        const failNote = allOk ? '' : ` · ${this.fmt(batchCount - batchSuccess)} failed`;
+        const pageNote = progress.Page != null ? `  (page ${progress.Page})` : '';
+        LogStatus(`${ScheduledGeocodingAction.INDENT}${icon} records ${this.fmt(start)}–${this.fmt(end)} of ${total} · ${batchSuccess}/${batchCount}${failNote}${pageNote}`);
+    }
+
+    /**
+     * Emit the indented per-entity completion line, reconciling geocoded vs.
+     * failed vs. already-current against the candidate total, e.g.
+     * `   ✅ Members — 1,974 geocoded, 26 already current`.
+     */
+    private logEntityComplete(entityInfo: EntityInfo, processed: number, success: number, candidateTotal: number): void {
+        const failed = processed - success;
+        const alreadyCurrent = candidateTotal > 0 ? Math.max(0, candidateTotal - processed) : 0;
+        const parts = [`${this.fmt(success)} geocoded`];
+        if (failed > 0) parts.push(`${this.fmt(failed)} failed`);
+        if (alreadyCurrent > 0) parts.push(`${this.fmt(alreadyCurrent)} already current`);
+        LogStatus(`${ScheduledGeocodingAction.INDENT}✅ ${entityInfo.Name} — ${parts.join(', ')}`);
     }
 
     // ================================================================

--- a/packages/MJServer/src/resolvers/VectorizeEntityResolver.ts
+++ b/packages/MJServer/src/resolvers/VectorizeEntityResolver.ts
@@ -90,7 +90,13 @@ export class VectorizeEntityResolver extends ResolverBase {
             };
 
             const result = await syncer.VectorizeEntity(params, currentUser);
-            LogStatus(`VectorizeEntity pipeline ${pipelineRunID} complete: success=${result.success}`);
+            if (result.success) {
+                LogStatus(`VectorizeEntity pipeline ${pipelineRunID} complete: success=true`);
+            } else {
+                // The run finished but some/all records failed to render or upsert. Surface it
+                // loudly instead of logging a bare "success=false" that reads like a clean finish.
+                LogError(`VectorizeEntity pipeline ${pipelineRunID} completed with errors (status=${result.status}): ${result.errorMessage}`);
+            }
         } catch (error) {
             const msg = error instanceof Error ? error.message : String(error);
             LogError(`VectorizeEntity pipeline ${pipelineRunID} failed: ${msg}`);
@@ -110,11 +116,18 @@ export class VectorizeEntityResolver extends ResolverBase {
      * Publish a progress update to the PipelineProgress subscription topic.
      */
     private publishProgress(pipelineRunID: string, update: VectorizeProgressUpdate): void {
+        // Carry a short error summary to the client via CurrentItem when the update reports failures,
+        // so the subscription reflects that the run didn't cleanly succeed.
+        const errorSummary = update.Errors && update.Errors.length > 0
+            ? `${update.Errors.length} record(s) failed — e.g. ${update.Errors[0].Message}`
+            : undefined;
+
         const notification: PipelineProgressNotification = {
             PipelineRunID: pipelineRunID,
             Stage: update.Stage,
             TotalItems: update.TotalRecords,
             ProcessedItems: update.ProcessedRecords,
+            CurrentItem: errorSummary,
             ElapsedMs: update.ElapsedMs,
             PercentComplete: update.PercentComplete,
         };


### PR DESCRIPTION
## Summary
- **Vector upserts no longer report success when they failed.** Pinecone `CreateRecords`/`GetRecords` now return a failure response on a thrown error instead of a success response with `null` data — the dimension-mismatch upsert error (`Vector dimension 1536 does not match the dimension of the index 512`) was being swallowed and the pipeline claimed "Complete".
- **`EntityVectorSyncer` now surfaces failures.** It accumulates per-record upsert errors alongside render errors and flips `VectorizeEntity`'s `success` flag + `status`/`errorMessage` when any occur; the resolver logs it and forwards an error summary through the progress subscription. This also covers the bad-template case (`filter not found: currency`) where every record failed to render but the run still reported success.
- **De-duplicated the response helpers.** Hoisted the three providers' copy-pasted `wrapSuccess/wrapFailureResponse` into `VectorDBBase` as shared `protected` (camelCase) members; removed the per-provider copies in Pinecone, Qdrant, and pgvector. A future provider gets correct failure semantics for free.
- **Clearer geocoding console output.** `ScheduledGeocodingAction` replaces the per-page `batch N/50` lines (which reset every page and read like the job re-running) with a continuous, indented per-entity log: a header, cumulative `records X–Y of Total (page N)` lines, and a reconciling completion line.

## Test plan
- [x] `ai-vectordb` (base), Pinecone, Qdrant, pgvector, Memory, Core, Dupe, Sync, MJServer, CoreActions all build
- [x] Pinecone unit tests pass (25), incl. new regressions asserting `CreateRecords`/`GetRecords` return `success: false` when the client throws
- [x] CoreActions (214) and MJServer (261) suites pass; Memory (85), Database (25) pass
- [ ] Manually run a vectorization with a deliberately mismatched index dimension and confirm the run reports failure (not "Complete")
- [ ] Manually run a scheduled geocoding pass over a multi-page entity and confirm the continuous `records X–Y of Total (page N)` logging

🤖 Generated with [Claude Code](https://claude.com/claude-code)