### PR TITLE
docs: pluggable artifact inline-preview architecture (proposal)

### DIFF
--- a/plans/artifact-inline-preview-architecture.md
+++ b/plans/artifact-inline-preview-architecture.md
@@ -1,130 +1,139 @@
 # Artifact Inline Preview — Pluggable Architecture (Proposal)
 
-**Status:** proposal for review · **Author:** (draft) · **Reviewers:** AN-BC / Amith
+**Status:** proposal for review · **Reviewers:** AN-BC / Amith
 
-> Quick architecture writeup for the pluggable inline-preview extension. A working
-> implementation exists on `fix/research-agent-report-display` for reference, but this doc
-> is the design — comment here and the code follows the feedback.
+> Architecture for the pluggable inline-preview extension. A working reference implementation
+> exists on `fix/research-agent-report-display`; this doc is the design — the code will be
+> refactored to match the decision below.
 
 ## Motivation
 
 Now that conversation outputs are uniformly **artifact-based**, every artifact renders the
 same way inline in a message: a generic rectangular info-bar (icon + name + type badge),
-regardless of what it is. An image artifact should show the **image** inline; a video should
-show a **player**; the full-size view still belongs in the right-side viewer panel.
+regardless of what it is. An image artifact should show the **image** inline; a video a
+**player**; the full-size view still belongs in the right-side viewer panel.
 
-We want this to be **pluggable per artifact type — not a hardcoded `if (type === 'Image')`
-switch in the card** — so new media types (or downstream/custom types) get a preview by
-registering a handler, exactly like the existing full-size viewer plugins.
+We want this **pluggable per artifact type — not a hardcoded `if (type === 'Image')` switch in
+the card** — so new media types (or downstream/custom types) get a preview by registering a
+handler, exactly like the existing full-size viewer plugins.
 
-## Reuse the existing viewer-plugin pattern
+## Decision (updated after review)
 
-There is already a plugin system for the **full-size right-side viewer**, and the preview
-tier deliberately mirrors it 1:1:
+**Extend the existing `IArtifactViewerPlugin` with an optional preview slot — do NOT add a
+second parallel plugin/registry.** (Per Amith: avoid yet another class; preview and viewer are
+the same concept and share logic — `canHandle` and content resolution.) The one capability the
+two-registry sketch had that's worth keeping — letting preview and viewer resolve to *different*
+plugins, and preventing a viewer override from clobbering a base preview — is preserved by
+**resolving each slot independently within the single registry** (see Resolution).
 
-| Concern | Existing (full viewer) | New (inline preview) |
-|---|---|---|
-| Contract | `IArtifactViewerPlugin` | `IArtifactPreviewPlugin` |
-| Base component | `BaseArtifactViewerComponent` | `BaseArtifactPreviewComponent` |
-| Resolver | `ArtifactTypePluginViewerComponent` | `ArtifactTypePluginPreviewComponent` |
-| Match | `canHandle(typeName, contentType)` | `CanHandle(typeName, contentType)` (static) |
-| Registration | `@RegisterClass` → `MJGlobal.ClassFactory` | same |
-| Surface | right-side panel | inline message card |
-
-Two **independent registries**, same mechanism. A type can have a preview, a viewer, both,
-or neither.
+So: **one interface, two component slots, per-slot resolution.**
 
 ## Design
 
-```
-ArtifactMessageCard (per artifact in a message)
-        │  (artifactTypeName, contentType)
-        ▼
-ArtifactTypePluginPreviewComponent  ── resolver
-        │  enumerate ClassFactory registrations of BaseArtifactPreviewComponent
-        │  first whose static CanHandle(typeName, contentType) === true wins
-        ├─ match  ──► dynamically render that preview component (image/video/audio/…)
-        └─ no match ──► emit (noPreviewAvailable) ──► card renders the default info-bar box
-```
-
-### Pieces
-
-- **`IArtifactPreviewPlugin` / `BaseArtifactPreviewComponent`** — a *lightweight* contract:
-  `@Input() artifactVersion`, a **static `CanHandle(typeName, contentType?)`**, and
-  `componentType`. Intentionally no toolbar / feedback / tabs / snapshot machinery — those
-  belong to the full viewer. Static `CanHandle` lets the resolver match **without
-  instantiating** components (which carry Angular DI deps).
-
-- **`ArtifactTypePluginPreviewComponent`** (resolver) — enumerates registered preview
-  components via `MJGlobal.Instance.ClassFactory`, picks the first whose static `CanHandle`
-  matches the artifact's `(typeName, contentType)`, and dynamically `createComponent`s it into
-  a `ViewContainerRef`. Emits `noPreviewAvailable` when nothing matches.
-
-- **Preview plugins** (initial set):
-  - `ImageArtifactPreview` — inline `<img>`, `max-height` capped, `object-fit: contain`.
-    `CanHandle`: `image/*` content-type or type name `Image` / `SVG Image`.
-  - `VideoArtifactPreview` — `<video controls preload="metadata">`; stops click propagation so
-    scrubbing doesn't open the full viewer. `CanHandle`: `video/*`.
-  - `AudioArtifactPreview` — `<audio controls>`. `CanHandle`: `audio/*`.
-
-- **`ArtifactMessageCard`** — consults the resolver up front (synchronous `CanHandle` check to
-  avoid a flash / `ExpressionChanged`); if a preview matches it renders the preview card
-  (media on top, compact meta footer), otherwise the **existing info-bar box, byte-for-byte
-  unchanged**. Click-to-open-full-viewer and all current outputs (`actionPerformed`, …) are
-  preserved on both variants.
-
-### Content resolution
-
-Preview components read the artifact bytes the **same way the matching full viewer already
-does** (inline data URL vs. file-storage download URL) — no new content path. Reuses the
-existing `ArtifactFileService` for file-backed artifacts.
-
-## Extensibility
-
-Adding a preview for a new type is self-contained — no card or resolver changes:
+### Interface (additive, backward-compatible)
 
 ```ts
-@RegisterClass(BaseArtifactPreviewComponent, 'MyTypePreviewPlugin')
-@Component({ /* standalone:false, selector, template */ })
-export class MyTypeArtifactPreview extends BaseArtifactPreviewComponent {
-  static CanHandle(typeName: string, contentType?: string): boolean {
-    return contentType?.startsWith('model/') === true; // e.g. 3D models
-  }
+interface IArtifactViewerPlugin {
+  canHandle(typeName: string, contentType?: string): boolean;   // shared by both roles
+
+  componentType: Type<IArtifactViewerComponent>;                // full right-side viewer (existing, unchanged)
+  previewComponentType?: Type<IArtifactPreviewComponent>;       // NEW — inline card preview, optional
+
+  getMetadata?(version: MJArtifactVersionEntity): ArtifactMetadata;
 }
 ```
 
-Declare/export it, and it participates. No hardcoded type list lives in the card.
+- `componentType` (the viewer) stays **required and unchanged** → existing plugins
+  (JSON/HTML/PDF/Code/Image/…) keep compiling and behave exactly as today.
+- `previewComponentType` is **optional**. A plugin that omits it → the card shows today's
+  default info-bar box for that artifact (no behavior change).
+- The preview and viewer are **separate Angular components** (the preview is lightweight — no
+  toolbar/feedback/tabs). They are *referenced from one plugin registration*, which is the whole
+  point: one `canHandle`, one registration per type, no duplication.
 
-## Open questions (where I'd like feedback)
+### Resolution (per-slot, independent)
 
-1. **One plugin or two?** Should preview + viewer be a *single* plugin exposing two component
-   slots (`previewComponentType` + `viewerComponentType`) rather than two parallel registries?
-   Trade-off: one registration per type & guaranteed consistency **vs.** clean separation
-   (a type can want a preview but no special viewer, or vice-versa). Current proposal = two
-   registries.
-2. **Preview affordances** — max-height (currently ~280px for images), whether to lazy-load /
-   thumbnail large media instead of streaming full bytes inline, and the click target
-   (whole card vs. an explicit expand button).
-3. **Default fallback** — keep the current info-bar box as the universal default (proposed), or
-   give *every* type at least a richer default (e.g. first-line text preview for text-y types)?
-4. **Where the doc/types should live** — colocate plugin authoring docs in
-   `packages/Angular/Generic/artifacts` (alongside the viewer-plugin docs) once the contract is
-   locked.
+The viewer panel and the inline card consult the **same registry** but ask different questions:
 
-## Files (in the reference implementation)
+```
+Full viewer (right panel):
+    highest-priority plugin whose canHandle(type, ct) === true            → render componentType
+
+Inline preview (message card):
+    highest-priority plugin whose canHandle(type, ct) === true
+        AND has a previewComponentType                                    → render previewComponentType
+    none → default info-bar box (unchanged)
+```
+
+Resolving the preview slot independently (rather than "the viewer winner also owns the preview")
+buys two things the merged-but-naive version would lose:
+
+- **Override safety.** A downstream/custom plugin that overrides the *viewer* for a type (wins on
+  priority) but doesn't set `previewComponentType` will **not** suppress the base plugin's
+  preview — the card falls through to the highest-priority plugin that *does* provide one. (MJ
+  leans heavily on `@RegisterClass` overrides, so this matters.)
+- **Divergent matching.** A broad viewer (e.g. "any text") can coexist with a specialized
+  preview (e.g. markdown only) without one dictating the other.
+
+### Shared logic = a service, not a base class
+
+The genuinely shared part is **content resolution** (inline data URL vs. file-storage download
+URL — image preview and image viewer load bytes identically) and MIME/type matching. That lives
+in a **shared service/helper** used by both component kinds. The preview must **not** extend the
+heavy `BaseArtifactViewerComponent` (toolbar/feedback/snapshot); it gets a thin
+`BaseArtifactPreviewComponent` (`@Input() artifactVersion` + the shared content helper).
+
+### Registration
+
+Plugins register once, as today:
+
+```ts
+@RegisterClass(BaseArtifactViewerPlugin, 'ImageArtifactViewerPlugin')
+export class ImageArtifactViewerPlugin implements IArtifactViewerPlugin {
+  canHandle(type, ct?) { return ct?.startsWith('image/') === true || type === 'Image' || type === 'SVG Image'; }
+  componentType = ImageArtifactViewer;          // full viewer (existing)
+  previewComponentType = ImageArtifactPreview;  // NEW inline preview
+}
+```
+
+Add a **registration-time check** that at least one of `componentType` / `previewComponentType`
+is present (defends against a plugin that renders nothing). Today `componentType` is required so
+this is automatically satisfied; the check guards future loosening.
+
+## Extensibility
+
+Giving a new type an inline preview is one optional field on its (existing or new) viewer plugin
+plus a lightweight preview component — no card or resolver changes, no hardcoded type list.
+
+## Files (reference implementation — will be refactored to the single-interface model)
 
 ```
 packages/Angular/Generic/artifacts/src/lib/
-  interfaces/artifact-preview-plugin.interface.ts        (new) contract
-  components/base-artifact-preview.component.ts           (new) base + ComponentClass shape
-  components/artifact-type-plugin-preview.component.ts    (new) resolver
-  components/previews/image-artifact-preview.component.ts (new)
-  components/previews/video-artifact-preview.component.ts (new)
-  components/previews/audio-artifact-preview.component.ts (new)
-  components/artifact-message-card.component.ts           (mod) preview-vs-box branch
-  artifacts.module.ts, public-api.ts                      (mod) declare/export/register
+  interfaces/artifact-viewer-plugin.interface.ts          (mod) add previewComponentType + IArtifactPreviewComponent
+  components/base-artifact-preview.component.ts            (new) thin base for preview components
+  services/…content-resolution                            (mod/new) shared by viewer + preview
+  components/previews/image-artifact-preview.component.ts  (new)
+  components/previews/video-artifact-preview.component.ts  (new)
+  components/previews/audio-artifact-preview.component.ts  (new)
+  components/plugins/image-artifact-viewer… etc.           (mod) set previewComponentType on existing plugins
+  components/artifact-message-card.component.ts            (mod) resolve preview slot; else default box
+  artifacts.module.ts, public-api.ts                       (mod)
 ```
 
-(Related, separate change: agents no longer create a *duplicate* standalone artifact for media
-that's already embedded inline in a report — so the preview tier only ever renders genuinely
-standalone media, not the report's inlined infographic.)
+> Note: the reference impl currently uses a *separate* `IArtifactPreviewPlugin` + its own
+> resolver. The refactor collapses that into the single `IArtifactViewerPlugin` with per-slot
+> resolution above. The preview *components* themselves are unaffected.
+
+## Remaining open questions
+
+1. ~~One plugin or two?~~ **Decided: one** (`IArtifactViewerPlugin` + optional preview slot, per-slot resolution).
+2. **Preview affordances** — image `max-height` (~280px today), whether to lazy-load/thumbnail
+   large media vs. stream full bytes inline, and the click target (whole card vs. explicit expand).
+3. **Default fallback** — keep the current info-bar box as the universal default (proposed), or
+   give text-y types at least a first-line text preview?
+
+## Related (separate change)
+
+Agents no longer create a *duplicate* standalone artifact for media already embedded inline in a
+report (e.g. the research agent's base64 `<img>` infographic) — so the preview tier only ever
+renders genuinely standalone media, not the report's inlined image.

--- a/plans/artifact-inline-preview-architecture.md
+++ b/plans/artifact-inline-preview-architecture.md
@@ -1,0 +1,130 @@
+# Artifact Inline Preview — Pluggable Architecture (Proposal)
+
+**Status:** proposal for review · **Author:** (draft) · **Reviewers:** AN-BC / Amith
+
+> Quick architecture writeup for the pluggable inline-preview extension. A working
+> implementation exists on `fix/research-agent-report-display` for reference, but this doc
+> is the design — comment here and the code follows the feedback.
+
+## Motivation
+
+Now that conversation outputs are uniformly **artifact-based**, every artifact renders the
+same way inline in a message: a generic rectangular info-bar (icon + name + type badge),
+regardless of what it is. An image artifact should show the **image** inline; a video should
+show a **player**; the full-size view still belongs in the right-side viewer panel.
+
+We want this to be **pluggable per artifact type — not a hardcoded `if (type === 'Image')`
+switch in the card** — so new media types (or downstream/custom types) get a preview by
+registering a handler, exactly like the existing full-size viewer plugins.
+
+## Reuse the existing viewer-plugin pattern
+
+There is already a plugin system for the **full-size right-side viewer**, and the preview
+tier deliberately mirrors it 1:1:
+
+| Concern | Existing (full viewer) | New (inline preview) |
+|---|---|---|
+| Contract | `IArtifactViewerPlugin` | `IArtifactPreviewPlugin` |
+| Base component | `BaseArtifactViewerComponent` | `BaseArtifactPreviewComponent` |
+| Resolver | `ArtifactTypePluginViewerComponent` | `ArtifactTypePluginPreviewComponent` |
+| Match | `canHandle(typeName, contentType)` | `CanHandle(typeName, contentType)` (static) |
+| Registration | `@RegisterClass` → `MJGlobal.ClassFactory` | same |
+| Surface | right-side panel | inline message card |
+
+Two **independent registries**, same mechanism. A type can have a preview, a viewer, both,
+or neither.
+
+## Design
+
+```
+ArtifactMessageCard (per artifact in a message)
+        │  (artifactTypeName, contentType)
+        ▼
+ArtifactTypePluginPreviewComponent  ── resolver
+        │  enumerate ClassFactory registrations of BaseArtifactPreviewComponent
+        │  first whose static CanHandle(typeName, contentType) === true wins
+        ├─ match  ──► dynamically render that preview component (image/video/audio/…)
+        └─ no match ──► emit (noPreviewAvailable) ──► card renders the default info-bar box
+```
+
+### Pieces
+
+- **`IArtifactPreviewPlugin` / `BaseArtifactPreviewComponent`** — a *lightweight* contract:
+  `@Input() artifactVersion`, a **static `CanHandle(typeName, contentType?)`**, and
+  `componentType`. Intentionally no toolbar / feedback / tabs / snapshot machinery — those
+  belong to the full viewer. Static `CanHandle` lets the resolver match **without
+  instantiating** components (which carry Angular DI deps).
+
+- **`ArtifactTypePluginPreviewComponent`** (resolver) — enumerates registered preview
+  components via `MJGlobal.Instance.ClassFactory`, picks the first whose static `CanHandle`
+  matches the artifact's `(typeName, contentType)`, and dynamically `createComponent`s it into
+  a `ViewContainerRef`. Emits `noPreviewAvailable` when nothing matches.
+
+- **Preview plugins** (initial set):
+  - `ImageArtifactPreview` — inline `<img>`, `max-height` capped, `object-fit: contain`.
+    `CanHandle`: `image/*` content-type or type name `Image` / `SVG Image`.
+  - `VideoArtifactPreview` — `<video controls preload="metadata">`; stops click propagation so
+    scrubbing doesn't open the full viewer. `CanHandle`: `video/*`.
+  - `AudioArtifactPreview` — `<audio controls>`. `CanHandle`: `audio/*`.
+
+- **`ArtifactMessageCard`** — consults the resolver up front (synchronous `CanHandle` check to
+  avoid a flash / `ExpressionChanged`); if a preview matches it renders the preview card
+  (media on top, compact meta footer), otherwise the **existing info-bar box, byte-for-byte
+  unchanged**. Click-to-open-full-viewer and all current outputs (`actionPerformed`, …) are
+  preserved on both variants.
+
+### Content resolution
+
+Preview components read the artifact bytes the **same way the matching full viewer already
+does** (inline data URL vs. file-storage download URL) — no new content path. Reuses the
+existing `ArtifactFileService` for file-backed artifacts.
+
+## Extensibility
+
+Adding a preview for a new type is self-contained — no card or resolver changes:
+
+```ts
+@RegisterClass(BaseArtifactPreviewComponent, 'MyTypePreviewPlugin')
+@Component({ /* standalone:false, selector, template */ })
+export class MyTypeArtifactPreview extends BaseArtifactPreviewComponent {
+  static CanHandle(typeName: string, contentType?: string): boolean {
+    return contentType?.startsWith('model/') === true; // e.g. 3D models
+  }
+}
+```
+
+Declare/export it, and it participates. No hardcoded type list lives in the card.
+
+## Open questions (where I'd like feedback)
+
+1. **One plugin or two?** Should preview + viewer be a *single* plugin exposing two component
+   slots (`previewComponentType` + `viewerComponentType`) rather than two parallel registries?
+   Trade-off: one registration per type & guaranteed consistency **vs.** clean separation
+   (a type can want a preview but no special viewer, or vice-versa). Current proposal = two
+   registries.
+2. **Preview affordances** — max-height (currently ~280px for images), whether to lazy-load /
+   thumbnail large media instead of streaming full bytes inline, and the click target
+   (whole card vs. an explicit expand button).
+3. **Default fallback** — keep the current info-bar box as the universal default (proposed), or
+   give *every* type at least a richer default (e.g. first-line text preview for text-y types)?
+4. **Where the doc/types should live** — colocate plugin authoring docs in
+   `packages/Angular/Generic/artifacts` (alongside the viewer-plugin docs) once the contract is
+   locked.
+
+## Files (in the reference implementation)
+
+```
+packages/Angular/Generic/artifacts/src/lib/
+  interfaces/artifact-preview-plugin.interface.ts        (new) contract
+  components/base-artifact-preview.component.ts           (new) base + ComponentClass shape
+  components/artifact-type-plugin-preview.component.ts    (new) resolver
+  components/previews/image-artifact-preview.component.ts (new)
+  components/previews/video-artifact-preview.component.ts (new)
+  components/previews/audio-artifact-preview.component.ts (new)
+  components/artifact-message-card.component.ts           (mod) preview-vs-box branch
+  artifacts.module.ts, public-api.ts                      (mod) declare/export/register
+```
+
+(Related, separate change: agents no longer create a *duplicate* standalone artifact for media
+that's already embedded inline in a report — so the preview tier only ever renders genuinely
+standalone media, not the report's inlined infographic.)


### PR DESCRIPTION
Quick architecture proposal for **type-specific inline artifact previews** — image/video/audio render inline in the conversation message card (full size still opens in the right-side viewer), built as a **preview-plugin tier that mirrors the existing viewer-plugin pattern** (`canHandle(type, contentType)` + `@RegisterClass`), so it's pluggable per artifact type rather than a hardcoded switch.

Doc-only PR for fast feedback before the implementation lands. The design + open questions are in [`plans/artifact-inline-preview-architecture.md`](plans/artifact-inline-preview-architecture.md).

**Looking for feedback on the open questions**, especially: one plugin with two component slots (preview + viewer) vs. two parallel registries; preview affordances (max-height, lazy/thumbnail large media); and the default-fallback policy.

A working reference implementation exists on `fix/research-agent-report-display` — this PR is intentionally just the doc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)