### PR TITLE
fix(codegen): route Smart Field / Form Layout prompts off Gemini Flash-Lite (empty output) to OpenAI

### DIFF
--- a/.changeset/route-heavy-codegen-prompts-off-flash-lite.md
+++ b/.changeset/route-heavy-codegen-prompts-off-flash-lite.md
@@ -1,0 +1,9 @@
+---
+"@memberjunction/cli": patch
+---
+
+fix(codegen): route heavy CodeGen prompts off Gemini Flash-Lite to OpenAI (issue #2765)
+
+The two heavy CodeGen prompts -- "CodeGen: Smart Field Identification" and "CodeGen: Form Layout Generation" -- had model candidate lists that topped out at Gemini 3.1 Flash-Lite (Priority 11/12). On these large prompts Flash-Lite returns 0 output tokens, producing empty output and breaking CodeGen's advanced generation.
+
+Adds a forward migration that raises the existing OpenAI 'GPT 5.5 Instant' `AIPromptModel` row for each of these two prompts to Priority 20 -- above every Gemini candidate -- so the prompt runner selects OpenAI first (validated live to return parseable output). Gemini rows remain in place as lower-priority fallbacks. The UPDATEs reference the prompts/model by name and are idempotent.

--- a/migrations/v5/V202606050200__v5.39.x__Route_Heavy_CodeGen_Prompts_To_OpenAI.sql
+++ b/migrations/v5/V202606050200__v5.39.x__Route_Heavy_CodeGen_Prompts_To_OpenAI.sql
@@ -1,0 +1,37 @@
+-- =====================================================================================
+-- Route heavy CodeGen prompts off Gemini 3.1 Flash-Lite to OpenAI (issue #2765)
+-- =====================================================================================
+-- Problem:
+--   The two heavy CodeGen prompts -- "CodeGen: Smart Field Identification" and
+--   "CodeGen: Form Layout Generation" -- have model candidate lists in
+--   ${flyway:defaultSchema}.AIPromptModel that top out at Gemini 3.1 Flash-Lite
+--   (Priority 11/12). On these large prompts Flash-Lite returns 0 output tokens,
+--   producing empty output and breaking CodeGen's advanced generation.
+--
+-- Fix:
+--   Raise the existing OpenAI 'GPT 5.5 Instant' AIPromptModel row for each of these
+--   two prompts to Priority 20 -- above every Gemini candidate (max Priority 12) --
+--   so the prompt runner selects OpenAI first. OpenAI was validated live to return
+--   parseable output for both prompts. Gemini rows are left in place as lower-priority
+--   fallbacks.
+--
+-- Notes:
+--   * Prompts are referenced by name via a subquery on AIPrompt.Name (no hardcoded
+--     PromptIDs) so the migration is resilient to environment differences.
+--   * The OpenAI model is referenced by name 'GPT 5.5 Instant' via AIModel.Name.
+--   * UPDATEs are idempotent: re-running sets Priority to the same value (20).
+-- =====================================================================================
+
+UPDATE apm
+SET apm.Priority = 20
+FROM ${flyway:defaultSchema}.AIPromptModel AS apm
+INNER JOIN ${flyway:defaultSchema}.AIPrompt AS p
+    ON apm.PromptID = p.ID
+INNER JOIN ${flyway:defaultSchema}.AIModel AS m
+    ON apm.ModelID = m.ID
+WHERE p.Name IN (
+        N'CodeGen: Smart Field Identification',
+        N'CodeGen: Form Layout Generation'
+    )
+  AND m.Name = N'GPT 5.5 Instant'
+  AND apm.Priority <> 20;


### PR DESCRIPTION
## Summary

Fixes #2765.

The two heavy CodeGen prompts — **"CodeGen: Smart Field Identification"** and **"CodeGen: Form Layout Generation"** — have model candidate lists in `__mj.AIPromptModel` that top out at **Gemini 3.1 Flash-Lite** (Priority 11/12). On these large prompts, Flash-Lite returns **0 output tokens**, producing empty output and breaking CodeGen's advanced generation.

## The fix

A forward migration (`migrations/v5/V202606050200__v5.39.x__Route_Heavy_CodeGen_Prompts_To_OpenAI.sql`, SQL Server dialect, `${flyway:defaultSchema}`) **raises the existing OpenAI `GPT 5.5 Instant` `AIPromptModel` row for each of these two prompts to Priority 20** — above every Gemini candidate (max Priority 12) — so the prompt runner selects OpenAI first.

OpenAI was **validated live** to return parseable output for both prompts, whereas Flash-Lite returns empty. Gemini rows are intentionally left in place as **lower-priority fallbacks**.

### Migration details

- References the two prompts **by name** via a subquery/join on `AIPrompt.Name` (no hardcoded PromptIDs) and the model **by name** `GPT 5.5 Instant` via `AIModel.Name` — resilient across environments.
- **Idempotent** `UPDATE`s (`Priority = 20`, guarded by `Priority <> 20`); safe to re-run.
- Pure metadata/config change — no schema DDL, no source-package code.

## Why this and not a runner change

Issue #2765 also mentions `AIPromptRunner` could fail over on an empty response — that's a broader resilience improvement. This PR is the targeted, low-risk config fix that unblocks CodeGen advanced generation immediately by routing the two known-failing prompts to a model validated to produce parseable output. The runner-level empty-response failover can be tackled separately.

## Changeset

Adds `.changeset/route-heavy-codegen-prompts-off-flash-lite.md` (patch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
