### PR TITLE
fix(scheduling): allowlist server-global provider use in agent-run sweep

### DIFF
--- a/packages/MJServer/src/index.ts
+++ b/packages/MJServer/src/index.ts
@@ -942,8 +942,8 @@ export const serve = async (resolverPaths: Array<string>, app: Application = cre
   // terminal-state write never landed. Staleness-based, so it never touches runs another healthy
   // instance is still heart-beating. The watchdog also self-registers for graceful-shutdown
   // cancellation (via ShutdownRegistry) once it begins tracking this process's first live run.
-  if (resumeUser && Metadata.Provider instanceof DatabaseProviderBase) {
-    AgentRunWatchdog.SweepOrphanedRuns(Metadata.Provider, resumeUser)
+  if (resumeUser && Metadata.Provider instanceof DatabaseProviderBase) { // global-provider-ok: server startup recovery — one-shot orphaned-run sweep at boot
+    AgentRunWatchdog.SweepOrphanedRuns(Metadata.Provider, resumeUser) // global-provider-ok: server startup recovery — one-shot orphaned-run sweep at boot
       .catch(err => console.warn(`[AgentRunWatchdog] Startup sweep failed: ${err}`));
   }
 

--- a/packages/Scheduling/engine/src/drivers/AgentRunSweepScheduledJobDriver.ts
+++ b/packages/Scheduling/engine/src/drivers/AgentRunSweepScheduledJobDriver.ts
@@ -35,7 +35,7 @@ export class AgentRunSweepScheduledJobDriver extends BaseScheduledJob {
     public async Execute(context: ScheduledJobExecutionContext): Promise<ScheduledJobResult> {
         // A scheduled maintenance sweep is a server-global task, so the global default provider is
         // the correct source here (not a per-request/per-tenant provider).
-        const provider = Metadata.Provider;
+        const provider = Metadata.Provider; // global-provider-ok: scheduled maintenance sweep is a server-global task, not per-request/per-tenant
         if (!(provider instanceof DatabaseProviderBase)) {
             return { Success: false, ErrorMessage: 'AgentRunSweep: no database provider available' };
         }

--- a/packages/ServerBootstrap/src/generated/mj-class-registrations.ts
+++ b/packages/ServerBootstrap/src/generated/mj-class-registrations.ts
@@ -1112,9 +1112,10 @@ import {
     TeamsMessagingExtension,
 } from '@memberjunction/messaging-adapters';
 
-// @memberjunction/scheduling-engine (3 classes)
+// @memberjunction/scheduling-engine (4 classes)
 import {
     ActionScheduledJobDriver,
+    AgentRunSweepScheduledJobDriver,
     AgentScheduledJobDriver,
     IntegrationSyncScheduledJobDriver,
 } from '@memberjunction/scheduling-engine';
@@ -1953,6 +1954,7 @@ export const CLASS_REGISTRATIONS: any[] = [
     SlackMessagingExtension,
     TeamsMessagingExtension,
     ActionScheduledJobDriver,
+    AgentRunSweepScheduledJobDriver,
     AgentScheduledJobDriver,
     IntegrationSyncScheduledJobDriver,
     AgentEvalDriver,
@@ -1967,7 +1969,7 @@ export const CLASS_REGISTRATIONS: any[] = [
 export const CLASS_REGISTRATIONS_MANIFEST_LOADED = true;
 
 /** Total @RegisterClass decorated classes discovered in dependency tree */
-export const CLASS_REGISTRATIONS_COUNT = 818;
+export const CLASS_REGISTRATIONS_COUNT = 819;
 
 /** Packages imported by this manifest */
 export const CLASS_REGISTRATIONS_PACKAGES = [

--- a/packages/ServerBootstrapLite/src/generated/mj-class-registrations.ts
+++ b/packages/ServerBootstrapLite/src/generated/mj-class-registrations.ts
@@ -978,9 +978,10 @@ import {
     XMLParserAction,
 } from '@memberjunction/core-actions';
 
-// @memberjunction/scheduling-engine (3 classes)
+// @memberjunction/scheduling-engine (4 classes)
 import {
     ActionScheduledJobDriver,
+    AgentRunSweepScheduledJobDriver,
     AgentScheduledJobDriver,
     IntegrationSyncScheduledJobDriver,
 } from '@memberjunction/scheduling-engine';
@@ -1740,6 +1741,7 @@ export const CLASS_REGISTRATIONS: any[] = [
     WebSearchAction,
     XMLParserAction,
     ActionScheduledJobDriver,
+    AgentRunSweepScheduledJobDriver,
     AgentScheduledJobDriver,
     IntegrationSyncScheduledJobDriver,
     AgentEvalDriver,
@@ -1749,7 +1751,7 @@ export const CLASS_REGISTRATIONS: any[] = [
 export const CLASS_REGISTRATIONS_MANIFEST_LOADED = true;
 
 /** Total @RegisterClass decorated classes discovered in dependency tree */
-export const CLASS_REGISTRATIONS_COUNT = 747;
+export const CLASS_REGISTRATIONS_COUNT = 748;
 
 /** Packages imported by this manifest */
 export const CLASS_REGISTRATIONS_PACKAGES = [


### PR DESCRIPTION
## Summary

Unblocks `npm run test` at the repo root. Turbo was failing because `@memberjunction/global`'s **`MultiProviderCompliance`** guard test found three non-allowlisted `Metadata.Provider` references. This PR annotates those three references with the established `// global-provider-ok:` marker — they are genuine server-global usages, not per-request/per-tenant bugs — and includes the regenerated bootstrap manifests that pick up the new sweep driver class.

## Background

`MultiProviderCompliance.test.ts` scans the entire `packages/` tree for `new Metadata()` / `Metadata.Provider` references, which resolve to the **process-global** default `IMetadataProvider`. In multi-provider scenarios (parallel client connections, transaction-isolated server requests) those silently use the wrong provider. The guard runs in strict mode: **any** non-allowlisted hit fails the suite. Legitimate server-global uses are exempted with an inline `// global-provider-ok: <reason>` marker (see the rule in `/CLAUDE.md`).

Two recently-merged features added global-provider references without the marker:
- the agent-run **watchdog** startup sweep (`5ab1e73092`)
- the scheduled **agent-run sweep** job driver (`f8135ffa8c`)

## The three violations (all legitimate, all server-global)

| File | Context |
|------|---------|
| `packages/MJServer/src/index.ts:945-946` | One-shot orphaned-agent-run sweep during **server startup recovery** — runs once at boot, before any per-request context exists |
| `packages/Scheduling/engine/src/drivers/AgentRunSweepScheduledJobDriver.ts:38` | **Scheduled maintenance sweep** — a server-global task, not per-request/per-tenant (the code already carried a prose comment explaining this; it was just missing the scanner's marker) |

These mirror the 8 existing `// global-provider-ok: bootstrap` markers already in `index.ts`, so the fix is the marker — not a refactor.

## Changes

- **`MJServer/src/index.ts`** — added `// global-provider-ok:` markers to the two startup-recovery sweep lines.
- **`Scheduling/engine/.../AgentRunSweepScheduledJobDriver.ts`** — added the marker to the scheduled-sweep provider line.
- **`ServerBootstrap` + `ServerBootstrapLite` generated manifests** — regenerated; they now register `AgentRunSweepScheduledJobDriver` (class counts 818→819 and 747→748).

## Testing

- `@memberjunction/global` `MultiProviderCompliance` test now passes (0 violations).
- Full root `npm run test` re-run in progress to confirm no other regressions.
