### PR TITLE
fix(ci): restore release commit push + version tag in publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -156,6 +156,12 @@ jobs:
           echo "Release for verison $VERSION" >> $GITHUB_STEP_SUMMARY
           echo "VERSION=$VERSION" >> $GITHUB_OUTPUT
 
+      - name: Push release commit and tag
+        if: ${{ env.BRANCH == 'main' }}
+        env:
+          VERSION: ${{ steps.version.outputs.VERSION }}
+        run: npm run commitpush
+
       - name: Merge main into next and update package-lock
         if: ${{ env.BRANCH == 'main' }}
         run: |

--- a/ci/commit_push.mjs
+++ b/ci/commit_push.mjs
@@ -1,14 +1,30 @@
 import { simpleGit } from 'simple-git';
 
+// Run by the publish workflow (main branch only) after `changeset publish`.
+// `changeset version` has already committed the version bump locally; this script
+// pushes that release commit to origin/main and publishes the vX.Y.Z release tag.
+// Historically this also committed the bootstrap zip — that step is gone, but the
+// commit-and-tag responsibility lived here and must stay (see commit 4f03b0113a).
 const git = simpleGit();
 const version = process.env.VERSION;
 
-await git.add('./*').commit('Update distribution zip [skip ci]');
+if (!version) {
+  throw new Error('VERSION env var is required to tag the release — refusing to push an untagged release.');
+}
 
-console.log('\nPushing to origin/main...');
+// The build step regenerates version-stamped files (e.g. version.generated.ts and the
+// class-registration manifests) into the working tree. Commit them so main matches what
+// was published and the tree is clean for the subsequent `git checkout next`.
+await git.add('./*');
+const stagedCount = (await git.status()).staged.length;
+if (stagedCount > 0) {
+  console.log(`Committing ${stagedCount} post-release generated file(s)...`);
+  await git.commit('chore: post-release generated files [skip ci]');
+}
+
+console.log('Pushing release commit to origin/main...');
 await git.push('origin', 'HEAD:main');
 
-if (version) {
-  await git.addTag(version);
-  await git.push('origin', `refs/tags/${version}`);
-}
+console.log(`Publishing release tag ${version}...`);
+await git.addTag(version);
+await git.push('origin', `refs/tags/${version}`);


### PR DESCRIPTION
## Summary

Release publishing stopped pushing the per-release **`vX.Y.Z` git tag** (and stopped pushing the `RELEASING` version-bump commit to `main`). `v5.39.0` published to npm last night with no git tag and had to be tagged by hand.

## Root cause

The `vX.Y.Z` tag was created and pushed in exactly one place — `ci/commit_push.mjs` (`git.addTag` + `git.push refs/tags/...`). Its only caller is `npm run commitpush`, which was invoked **only** from the **"Create distribution zip"** step of `publish.yml`. That step also did the `git push origin HEAD:main` that landed the changeset `RELEASING` commit on `main`.

Commit `4f03b0113a` ("remove bootstrap zip step blocking publish workflow") deleted that entire step to unblock the `v5.38.0` publish — the 114 MB bootstrap zip exceeded GitHub's 100 MB push limit and was killing the workflow *after* npm publish had already succeeded. Removing the step was correct for the zip, but it also removed the only `commitpush` invocation, silently dropping **both** the `main` push and the tag push. Since then the `RELEASING` commit and tags have been pushed manually (evidence: the latest `RELEASING` commit is authored by a human rather than `GitHub Actions`).

## What changed

- **`publish.yml`** — re-added a dedicated, self-contained **"Push release commit and tag"** step (gated on `main`, passes `VERSION`), no longer coupled to the deleted zip.
- **`ci/commit_push.mjs`** — repurposed from "commit the zip" to its surviving job: commit any build-regenerated version-stamped files, push the `RELEASING` commit to `main`, and publish the `vX.Y.Z` tag. Hardening:
  - **Throws if `VERSION` is unset** instead of silently skipping the tag (the exact silent-skip failure mode that hid this class of bug).
  - **Guards the empty-commit case** (`status().staged.length`) so it doesn't fail when there's nothing to commit and leaves a clean tree for the subsequent `git checkout next`.
  - Dropped the now-false `"Update distribution zip"` commit message.

## Verification

- `node --check ci/commit_push.mjs` passes; `publish.yml` parsed with a YAML parser — new step is correctly positioned (after "Get version string", before "Merge main into next").
- `simple-git`'s `staged` array is populated for any A/M/D/R/C index status, so the empty-commit guard is correct.
- No unit tests exist for `ci/` scripts (standalone CI scripts, not part of a package suite).

## Reviewer notes

- This automated push+tag path hasn't run successfully since `v5.37.0` — worth watching the **first release after this merges** end-to-end.
- **Separate, pre-existing issue (not fixed here):** the manually-pushed `v5.39.0` tag points at a commit where `MJServer/package.json` still reads `5.38.0`, so that tag may be mis-pointed. Worth correcting independently of this workflow fix.
- No changeset is included — only `.github/` and `ci/` are touched, so no published package is affected. Add an empty changeset if the PR gate requires one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)