### PR TITLE
feat: add PreShellGuard and request-scoped TenantContext

### DIFF
--- a/.changeset/bright-shields-guard.md
+++ b/.changeset/bright-shields-guard.md
@@ -1,0 +1,9 @@
+---
+"@memberjunction/ng-explorer-app": patch
+"@memberjunction/server": patch
+"@memberjunction/ng-bootstrap": patch
+"@memberjunction/ng-bootstrap-lite": patch
+"@memberjunction/graphql-dataprovider": patch
+---
+
+Add PreShellGuard for request-scoped TenantContext and auth fixes in MJServer CurrentUserContextResolver

--- a/packages/Angular/Bootstrap/src/generated/mj-class-registrations.ts
+++ b/packages/Angular/Bootstrap/src/generated/mj-class-registrations.ts
@@ -406,8 +406,9 @@ import {
     MJEntityCommunicationMessageTypeEntityExtended,
 } from '@memberjunction/entity-communications-base';
 
-// @memberjunction/ng-artifacts (11 classes)
+// @memberjunction/ng-artifacts (13 classes)
 import {
+    AudioArtifactViewerComponent,
     CodeArtifactViewerComponent,
     ComponentArtifactViewerComponent,
     DataArtifactViewerComponent,
@@ -418,6 +419,7 @@ import {
     MarkdownArtifactViewerComponent,
     PdfArtifactViewerComponent,
     SvgArtifactViewerComponent,
+    VideoArtifactViewerComponent,
     XlsxArtifactViewerComponent,
 } from '@memberjunction/ng-artifacts';
 
@@ -964,6 +966,7 @@ export const CLASS_REGISTRATIONS: any[] = [
     PerThousandTokensPriceUnitType,
     MJCommunicationProviderEntityExtended,
     MJEntityCommunicationMessageTypeEntityExtended,
+    AudioArtifactViewerComponent,
     CodeArtifactViewerComponent,
     ComponentArtifactViewerComponent,
     DataArtifactViewerComponent,
@@ -974,6 +977,7 @@ export const CLASS_REGISTRATIONS: any[] = [
     MarkdownArtifactViewerComponent,
     PdfArtifactViewerComponent,
     SvgArtifactViewerComponent,
+    VideoArtifactViewerComponent,
     XlsxArtifactViewerComponent,
     MJAuth0Provider,
     MJCognitoProvider,
@@ -1119,7 +1123,7 @@ export const CLASS_REGISTRATIONS: any[] = [
 export const CLASS_REGISTRATIONS_MANIFEST_LOADED = true;
 
 /** Total @RegisterClass decorated classes discovered in dependency tree */
-export const CLASS_REGISTRATIONS_COUNT = 516;
+export const CLASS_REGISTRATIONS_COUNT = 518;
 
 /** Packages imported by this manifest */
 export const CLASS_REGISTRATIONS_PACKAGES = [

--- a/packages/Angular/BootstrapLite/src/generated/mj-class-registrations.ts
+++ b/packages/Angular/BootstrapLite/src/generated/mj-class-registrations.ts
@@ -406,8 +406,9 @@ import {
     MJEntityCommunicationMessageTypeEntityExtended,
 } from '@memberjunction/entity-communications-base';
 
-// @memberjunction/ng-artifacts (11 classes)
+// @memberjunction/ng-artifacts (13 classes)
 import {
+    AudioArtifactViewerComponent,
     CodeArtifactViewerComponent,
     ComponentArtifactViewerComponent,
     DataArtifactViewerComponent,
@@ -418,6 +419,7 @@ import {
     MarkdownArtifactViewerComponent,
     PdfArtifactViewerComponent,
     SvgArtifactViewerComponent,
+    VideoArtifactViewerComponent,
     XlsxArtifactViewerComponent,
 } from '@memberjunction/ng-artifacts';
 
@@ -854,6 +856,7 @@ export const CLASS_REGISTRATIONS: any[] = [
     PerThousandTokensPriceUnitType,
     MJCommunicationProviderEntityExtended,
     MJEntityCommunicationMessageTypeEntityExtended,
+    AudioArtifactViewerComponent,
     CodeArtifactViewerComponent,
     ComponentArtifactViewerComponent,
     DataArtifactViewerComponent,
@@ -864,6 +867,7 @@ export const CLASS_REGISTRATIONS: any[] = [
     MarkdownArtifactViewerComponent,
     PdfArtifactViewerComponent,
     SvgArtifactViewerComponent,
+    VideoArtifactViewerComponent,
     XlsxArtifactViewerComponent,
     MJAuth0Provider,
     MJCognitoProvider,
@@ -911,7 +915,7 @@ export const CLASS_REGISTRATIONS: any[] = [
 export const CLASS_REGISTRATIONS_MANIFEST_LOADED = true;
 
 /** Total @RegisterClass decorated classes discovered in dependency tree */
-export const CLASS_REGISTRATIONS_COUNT = 418;
+export const CLASS_REGISTRATIONS_COUNT = 420;
 
 /** Packages imported by this manifest */
 export const CLASS_REGISTRATIONS_PACKAGES = [

--- a/packages/Angular/Explorer/explorer-app/src/lib/explorer-app.component.html
+++ b/packages/Angular/Explorer/explorer-app/src/lib/explorer-app.component.html
@@ -11,34 +11,36 @@
 
 <!-- Normal authenticated view (not OAuth callback) -->
 @if ((authBase.isAuthenticated() | async) && !isOAuthCallback) {
-  <div class="app-main">
-    <mj-server-connectivity-banner></mj-server-connectivity-banner>
-    <mj-system-validation-banner></mj-system-validation-banner>
-    @if (!HasError) {
-      <mj-shell class="app-body"></mj-shell>
+  @if (!preShellBlocked) {
+    <div class="app-main">
+      <mj-server-connectivity-banner></mj-server-connectivity-banner>
+      <mj-system-validation-banner></mj-system-validation-banner>
+      @if (!HasError) {
+        <mj-shell class="app-body"></mj-shell>
+      }
+      @if (HasError && !showValidationOnly) {
+        <div><h1>System Error</h1><hr/>{{this.ErrorMessage}}</div>
+      }
+    </div>
+    <!-- Floating chat overlay — persistent across navigation, hidden during load and in Conversations -->
+    @if (IsChatOverlayReady) {
+      <mj-chat-agents-overlay
+        [IsVisible]="!isChatRoute"
+        [AppContext]="$any(AppContextSnapshot)"
+        [EmptyStateGreeting]="'Ask me anything — I can navigate apps, search data, run queries, or help with tasks.'"
+        [TopBoundaryPx]="ChatOverlayTopBoundaryPx"
+        (ToolExecuted)="OnOverlayToolExecuted($event)"
+        (OpenEntityRecord)="OnOverlayOpenRecord($event)"
+        (OpenFullChatWorkspace)="OnOverlayOpenFullChatWorkspace($event)"
+      ></mj-chat-agents-overlay>
     }
-    @if (HasError && !showValidationOnly) {
-      <div><h1>System Error</h1><hr/>{{this.ErrorMessage}}</div>
-    }
-  </div>
-  <!-- Floating chat overlay — persistent across navigation, hidden during load and in Conversations -->
-  @if (IsChatOverlayReady) {
-    <mj-chat-agents-overlay
-      [IsVisible]="!isChatRoute"
-      [AppContext]="$any(AppContextSnapshot)"
-      [EmptyStateGreeting]="'Ask me anything — I can navigate apps, search data, run queries, or help with tasks.'"
-      [TopBoundaryPx]="ChatOverlayTopBoundaryPx"
-      (ToolExecuted)="OnOverlayToolExecuted($event)"
-      (OpenEntityRecord)="OnOverlayOpenRecord($event)"
-      (OpenFullChatWorkspace)="OnOverlayOpenFullChatWorkspace($event)"
-    ></mj-chat-agents-overlay>
+    <!-- Hidden router-outlet required for Angular's router to activate routes and update the browser URL.
+         The shell manages all visible content rendering through its tab system, not through routing.
+         Without this outlet, router.navigateByUrl() fails silently and the URL stays at '/'. -->
+    <div style="display:none;position:absolute;width:0;height:0;overflow:hidden">
+      <router-outlet></router-outlet>
+    </div>
   }
-  <!-- Hidden router-outlet required for Angular's router to activate routes and update the browser URL.
-       The shell manages all visible content rendering through its tab system, not through routing.
-       Without this outlet, router.navigateByUrl() fails silently and the URL stays at '/'. -->
-  <div style="display:none;position:absolute;width:0;height:0;overflow:hidden">
-    <router-outlet></router-outlet>
-  </div>
 }
 <!-- Login - shows when NOT authenticated AND not on OAuth callback -->
 @if (!(authBase.isAuthenticated() | async) && !isOAuthCallback) {

--- a/packages/Angular/Explorer/explorer-app/src/lib/explorer-app.component.ts
+++ b/packages/Angular/Explorer/explorer-app/src/lib/explorer-app.component.ts
@@ -8,7 +8,7 @@
  *   <mj-explorer-app></mj-explorer-app>
  */
 
-import { Component, OnInit, OnDestroy, Inject, ViewEncapsulation, ChangeDetectorRef } from '@angular/core';
+import { Component, OnInit, OnDestroy, Inject, Optional, ViewEncapsulation, ChangeDetectorRef, ViewContainerRef, ComponentRef, Type, EnvironmentInjector } from '@angular/core';
 import { DOCUMENT } from '@angular/common';
 import { Router, NavigationEnd } from '@angular/router';
 import { Subject } from 'rxjs';
@@ -27,6 +27,7 @@ import { ApplicationManager, WorkspaceStateManager } from '@memberjunction/ng-ba
 import { AppContextSnapshot } from '@memberjunction/ai-core-plus';
 
 import { BaseAngularComponent } from '@memberjunction/ng-base-types';
+import { MJ_PRE_SHELL_GUARD, PreShellGuard } from './pre-shell-guard';
 @Component({
   standalone: false,
   selector: 'mj-explorer-app',
@@ -57,6 +58,11 @@ export class MJExplorerAppComponent extends BaseAngularComponent implements OnIn
   public isChatRoute = false;
   /** Suppresses chat overlay during initial app load — set true after workspace initializes */
   public IsChatOverlayReady = false;
+
+  /** Component rendered by PreShellGuard (blocks the shell until dismissed) */
+  private _preShellOverlayRef: ComponentRef<unknown> | null = null;
+  /** Whether a pre-shell guard overlay is blocking the shell */
+  preShellBlocked = false;
 
   /** Application context snapshot for AI agent awareness — updated on every app/tab transition */
   public AppContextSnapshot: AppContextSnapshot | null = null;
@@ -95,6 +101,9 @@ export class MJExplorerAppComponent extends BaseAngularComponent implements OnIn
     private appManager: ApplicationManager,
     private workspaceState: WorkspaceStateManager,
     private cdr: ChangeDetectorRef,
+    @Optional() @Inject(MJ_PRE_SHELL_GUARD) private preShellGuard: PreShellGuard | null,
+    private environmentInjector: EnvironmentInjector,
+    private viewContainerRef: ViewContainerRef,
   ) {
     super();
     this.registerClientTools();
@@ -138,6 +147,17 @@ export class MJExplorerAppComponent extends BaseAngularComponent implements OnIn
         this.IsChatOverlayReady = true;
         this.cdr.detectChanges();
 
+        // Check if a pre-shell guard wants to block the shell (e.g., onboarding wizard)
+        if (this.preShellGuard) {
+          const blockComponent = await this.preShellGuard.CheckPreShellBlock(userInfo);
+          if (blockComponent) {
+            this.preShellBlocked = true;
+            this.cdr.detectChanges();
+            this.renderPreShellOverlay(blockComponent);
+            return;
+          }
+        }
+
         // Navigate to initial route
         if (this.initialPath === '/') {
           // use first nav item url instead
@@ -152,6 +172,15 @@ export class MJExplorerAppComponent extends BaseAngularComponent implements OnIn
       } else if (result.error) {
         // Handle errors based on type
         if (result.error.type === 'no_roles') {
+          // Check if a pre-shell guard wants to handle the no_roles case (e.g., onboarding wizard)
+          if (this.preShellGuard) {
+            const blockComponent = await this.preShellGuard.CheckPreShellBlock(userInfo);
+            if (blockComponent) {
+              this.preShellBlocked = true;
+              this.renderPreShellOverlay(blockComponent);
+              return;
+            }
+          }
           // Show validation banner instead of generic error
           this.showValidationOnly = true;
           this.HasError = true;
@@ -741,5 +770,34 @@ export class MJExplorerAppComponent extends BaseAngularComponent implements OnIn
     this.IsDarkMode = !this.IsDarkMode;
     localStorage.setItem(MJExplorerAppComponent.THEME_STORAGE_KEY, this.IsDarkMode ? 'dark' : 'light');
     this.applyThemeToDOM();
+  }
+
+  /**
+   * Render a pre-shell guard component as a full-page overlay.
+   * The component should emit a 'completed' event when done.
+   */
+  private renderPreShellOverlay(componentType: Type<unknown>): void {
+    this._preShellOverlayRef = this.viewContainerRef.createComponent(componentType, {
+      environmentInjector: this.environmentInjector
+    });
+
+    // Listen for a 'completed' output if the component has one
+    const instance = this._preShellOverlayRef.instance as Record<string, unknown>;
+    if (instance['completed'] && typeof (instance['completed'] as { subscribe?: Function }).subscribe === 'function') {
+      (instance['completed'] as { subscribe: (fn: () => void) => void }).subscribe(() => {
+        this.dismissPreShellOverlay();
+      });
+    }
+  }
+
+  /**
+   * Dismiss the pre-shell overlay and proceed to normal shell rendering.
+   * Reloads the page first so the user never sees a flash of stale shell state
+   * (e.g., "No Applications") while the old context is still in memory.
+   */
+  private dismissPreShellOverlay(): void {
+    // Reload first — the shell needs a full bootstrap to pick up new roles/context.
+    // Cleanup happens implicitly when the page unloads.
+    window.location.href = '/';
   }
 }

--- a/packages/Angular/Explorer/explorer-app/src/lib/pre-shell-guard.ts
+++ b/packages/Angular/Explorer/explorer-app/src/lib/pre-shell-guard.ts
@@ -1,0 +1,39 @@
+import { InjectionToken, Type } from '@angular/core';
+
+/**
+ * Minimal user identity passed to the guard. This is the auth-provider-level
+ * info available at guard-call time. Guards that need the full MJ UserInfo
+ * should read Metadata().CurrentUser (available in the success path) or
+ * query the server directly.
+ */
+export interface PreShellGuardUserInfo {
+  id: string;
+  email: string;
+  name: string;
+}
+
+/**
+ * Optional guard that runs after authentication but before the MJ shell renders.
+ * If CheckPreShellBlock() returns a component Type, the shell is blocked and
+ * the component is rendered as a full-page overlay. Return null to allow
+ * normal shell rendering.
+ *
+ * Consuming libraries provide their implementation via Angular DI:
+ *   { provide: MJ_PRE_SHELL_GUARD, useClass: MyGuardClass }
+ */
+export interface PreShellGuard {
+  CheckPreShellBlock(user: PreShellGuardUserInfo): Promise<Type<unknown> | null>;
+}
+
+/**
+ * Injection token for the pre-shell guard. Defaults to null (no guard).
+ * Uses providedIn: 'root' with a null factory so it is optional — consumers
+ * that don't provide a guard get null injected automatically.
+ */
+export const MJ_PRE_SHELL_GUARD = new InjectionToken<PreShellGuard | null>(
+  'MJ_PRE_SHELL_GUARD',
+  {
+    providedIn: 'root',
+    factory: () => null
+  }
+);

--- a/packages/Angular/Explorer/explorer-app/src/public-api.ts
+++ b/packages/Angular/Explorer/explorer-app/src/public-api.ts
@@ -4,3 +4,4 @@
 
 export * from './lib/explorer-app.module';
 export * from './lib/explorer-app.component';
+export * from './lib/pre-shell-guard';

--- a/packages/GraphQLDataProvider/src/version.generated.ts
+++ b/packages/GraphQLDataProvider/src/version.generated.ts
@@ -4,4 +4,4 @@
 // Used by BrowserIndexedDBStorageProvider to derive the IndexedDB DB_VERSION
 // so cache schema upgrades fire automatically on minor version bumps.
 
-export const PACKAGE_VERSION = '5.38.0';
+export const PACKAGE_VERSION = '5.39.0';

--- a/packages/MJServer/src/auth/index.ts
+++ b/packages/MJServer/src/auth/index.ts
@@ -235,13 +235,13 @@ export const verifyUserRecord = async (
           // to init it, including passing in the role list for the user.
           const md: Metadata = new Metadata(); // global-provider-ok: JWT validation + role lookup runs BEFORE AppContext.providers is built — no per-request provider yet
 
-          const initData: MJUserEntityType & { UserRoles: { UserID: string; RoleName: string; RoleID: string }[] } = newUser.GetAll();
+          const initData: MJUserEntityType & { UserRoles: { UserID: string; Role: string; RoleID: string }[] } = newUser.GetAll();
 
           initData.UserRoles = configInfo.userHandling.newUserRoles.map((role) => {
             const roleInfo: RoleInfo | undefined = md.Roles.find((r) => r.Name === role);
             const roleID: string = roleInfo ? roleInfo.ID : '';
 
-            return { UserID: initData.ID, RoleName: role, RoleID: roleID };
+            return { UserID: initData.ID, Role: role, RoleID: roleID };
           });
 
           user = new UserInfo(Metadata.Provider, initData); // global-provider-ok: same JWT-validation context — no per-request provider yet

--- a/packages/MJServer/src/resolvers/CurrentUserContextResolver.ts
+++ b/packages/MJServer/src/resolvers/CurrentUserContextResolver.ts
@@ -1,9 +1,15 @@
 /**
  * Resolver for the `CurrentUserTenantContext` GraphQL query.
  *
- * Returns the server-set `TenantContext` from the authenticated user's `UserInfo`.
- * This is populated by post-auth middleware (e.g., BCSaaS's `bcTenantContextMiddleware`)
- * and serialized as JSON so the client can auto-stamp `UserInfo.TenantContext`.
+ * Returns the server-set `TenantContext` for the authenticated user, serialized
+ * as JSON so the client can auto-stamp `UserInfo.TenantContext`.
+ *
+ * **Resolution order:**
+ * 1. Request-scoped context (`userPayload.__bcResolvedTenantContext`) — set by
+ *    post-auth middleware on the per-request UserPayload. Immune to race conditions
+ *    when concurrent requests share the same cached UserInfo object.
+ * 2. Fallback to `userRecord.TenantContext` — for middleware that stamps UserInfo
+ *    directly (vanilla MJ deployments or non-BCSaaS middleware).
  *
  * On the client, `GraphQLDataProvider.GetCurrentUser()` batches this query alongside
  * `CurrentUser` — making plugins stack-layer agnostic without any client-side code.
@@ -16,6 +22,9 @@ import { GraphQLJSONObject } from 'graphql-type-json';
 import { AppContext } from '../types.js';
 import { ResolverBase } from '../generic/ResolverBase.js';
 
+/** Well-known key for request-scoped TenantContext on UserPayload */
+const RESOLVED_TENANT_CONTEXT_KEY = '__bcResolvedTenantContext';
+
 @Resolver()
 export class CurrentUserContextResolver extends ResolverBase {
   @Query(() => GraphQLJSONObject, {
@@ -27,13 +36,20 @@ export class CurrentUserContextResolver extends ResolverBase {
   ): Promise<Record<string, unknown> | null> {
     await this.CheckAPIKeyScopeAuthorization('user:read', '*', context.userPayload);
 
+    // Prefer request-scoped context (set by BCSaaS middleware on userPayload).
+    // This avoids race conditions with concurrent requests mutating the shared
+    // UserInfo.TenantContext on the same cached UserInfo object from UserCache.
+    const requestScoped = (context.userPayload as Record<string, unknown>)[RESOLVED_TENANT_CONTEXT_KEY];
+    if (requestScoped && typeof requestScoped === 'object') {
+      return { ...(requestScoped as Record<string, unknown>) };
+    }
+
+    // Fallback: read from the shared UserInfo (vanilla MJ / non-BCSaaS middleware)
     const userRecord = context.userPayload.userRecord;
     if (!userRecord?.TenantContext) {
       return null;
     }
 
-    // Serialize the full TenantContext (which may be an extended type like BCTenantContext).
-    // JSON serialization captures all enumerable properties including those from subtypes.
     return { ...userRecord.TenantContext } as Record<string, unknown>;
   }
 }


### PR DESCRIPTION
## Summary

- **PreShellGuard**: New injectable guard (`MJ_PRE_SHELL_GUARD`) that runs after authentication but before the MJ shell renders. If the guard returns a component, it blocks the shell and renders that component as a full-page overlay (e.g., onboarding wizard). Also handles the `no_roles` error path.
- **Request-scoped TenantContext**: `CurrentUserContextResolver` now prefers a request-scoped `__bcResolvedTenantContext` on `userPayload` over the shared `UserInfo.TenantContext`. This fixes race conditions when concurrent requests share the same cached UserInfo object from UserCache.
- **Bootstrap updates**: Regenerated class registration manifests for `ng-bootstrap` and `ng-bootstrap-lite`.

## Test plan

- [x] Verify MJExplorer loads normally when no `PreShellGuard` is provided (default null injection)
- [x] Verify `CurrentUserTenantContext` query returns correct context for concurrent requests
- [x] Verify bootstrap manifests are up to date and build cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)