### PR TITLE
[New Event System Integration] OpenWater and GrowthZone enhancement

### DIFF
--- a/migrations/v5/V202606072000__v5.39.x__Integration_RecordMap_Identity_Index.sql
+++ b/migrations/v5/V202606072000__v5.39.x__Integration_RecordMap_Identity_Index.sql
@@ -1,0 +1,29 @@
+-- Integration record-map identity index (PR #2752 leftover C2).
+--
+-- The triple (CompanyIntegrationID, EntityID, ExternalSystemRecordID) is the external↔MJ identity the
+-- engine keys CREATE-vs-UPDATE on (MatchEngine.FindRecordMapEntry / IntegrationEngine upsert). It is
+-- looked up once per incoming record, every sync. Today only the two single-column FK indexes exist,
+-- so that 3-column lookup is an unindexed scan — fine at small volume, slow once the ledger is large.
+--
+-- This adds a NON-UNIQUE composite index covering the lookup, turning the scan into a seek. Chosen
+-- non-unique deliberately: it gets the speedup with ZERO risk of failing on a populated DB that might
+-- already hold a duplicate map from a past bug, and never blocks a sync. The one-external ↔ one-MJ
+-- invariant is still enforced in app code (IntegrationEngine's upsert-by-identity). A UNIQUE variant
+-- (DB-level race protection) can be substituted later once existing data is confirmed dupe-free.
+--
+-- Key size is safe: 16 (CompanyIntegrationID) + 16 (EntityID) + NVARCHAR(750)=1500 bytes
+-- (ExternalSystemRecordID) = 1532 bytes, under SQL Server's 1700-byte nonclustered index-key limit.
+--
+-- Idempotent: guarded so a re-run is a no-op.
+
+IF NOT EXISTS (
+    SELECT 1 FROM sys.indexes
+    WHERE name = 'IDX_CompanyIntegrationRecordMap_Identity'
+      AND object_id = OBJECT_ID('${flyway:defaultSchema}.CompanyIntegrationRecordMap')
+)
+BEGIN
+    CREATE NONCLUSTERED INDEX [IDX_CompanyIntegrationRecordMap_Identity]
+    ON ${flyway:defaultSchema}.CompanyIntegrationRecordMap
+        ([CompanyIntegrationID], [EntityID], [ExternalSystemRecordID]);
+END
+GO

--- a/packages/Angular/Explorer/dashboards/src/Integration/components/connections/connections.component.html
+++ b/packages/Angular/Explorer/dashboards/src/Integration/components/connections/connections.component.html
@@ -343,6 +343,14 @@
                     title="Select source objects and create entity tables">
               <i class="fa-solid fa-table"></i> Create Tables
             </button>
+            <button class="add-map-btn" (click)="FindAndAddNewTables()" [disabled]="IsCreatingTables"
+                    title="Discover and add every source object that isn't mapped yet, in one step">
+              @if (IsCreatingTables) {
+                <i class="fa-solid fa-spinner fa-spin"></i> Finding…
+              } @else {
+                <i class="fa-solid fa-magnifying-glass-plus"></i> Find New Tables
+              }
+            </button>
             <button class="add-map-btn" (click)="ToggleAutoMapPanel()" [class.active]="ShowAutoMapPanel">
               <i class="fa-solid fa-wand-magic-sparkles"></i> Auto-Map Schema
             </button>

--- a/packages/Angular/Explorer/dashboards/src/Integration/components/connections/connections.component.ts
+++ b/packages/Angular/Explorer/dashboards/src/Integration/components/connections/connections.component.ts
@@ -1351,6 +1351,78 @@ export class ConnectionsComponent extends BaseResourceComponent implements OnIni
   }
 
   /**
+   * One-click "find new tables": discovers every source object the connector now exposes that has
+   * NO entity map yet, and provisions them all (table + entity map + field maps) in a single
+   * ApplyAllBatch — no manual picker. This is the "find custom tables" affordance: a layer on top of
+   * entity-map selection that surfaces whole new objects the source started exposing after setup
+   * (distinct from custom COLUMNS, which the post-sync promoter handles automatically).
+   *
+   * Low-overhead by design: the only cost beyond a normal create is ONE DiscoverObjects call to
+   * learn what's new; the apply itself is identical to provisioning known tables. A no-op when the
+   * source exposes nothing new.
+   */
+  async FindAndAddNewTables(): Promise<void> {
+    if (!this.SelectedSummary || this.IsCreatingTables) return;
+    // CRITICAL: ApplyAllBatch runs RSU + CodeGen + an MJAPI restart. Doing that mid-sync would kill
+    // the running sync, so block until no sync is active (see feedback: never restart mid-sync).
+    if (this.SyncingIntegrationID) {
+      this.CreateTablesResult = {
+        Success: false,
+        Message: 'A sync is in progress — wait for it to finish before adding new tables (adding tables restarts the API).',
+      };
+      this.cdr.detectChanges();
+      return;
+    }
+
+    this.IsCreatingTables = true;
+    this.CreateTablesResult = null;
+    this.cdr.detectChanges();
+
+    try {
+      const integrationID = this.SelectedSummary.Integration.ID;
+      // 1. One live DiscoverObjects call → keep only objects that aren't already mapped.
+      const listed = await this.dataService.ListSourceObjects(integrationID);
+      if (!listed.Success) {
+        this.CreateTablesResult = { Success: false, Message: listed.Message ?? 'Discovery failed' };
+        return;
+      }
+      const mappedNames = new Set(this.DetailEntityMaps.map(m => m.ExternalObjectName));
+      const newObjects = (listed.Data ?? []).filter(o => !mappedNames.has(o.Name));
+      if (newObjects.length === 0) {
+        this.CreateTablesResult = {
+          Success: true,
+          Message: 'No new tables found — everything the source currently exposes is already mapped.',
+        };
+        return;
+      }
+
+      // 2. Provision all the new objects in a single batch (same path as the manual picker).
+      const selections = newObjects.map(o => ({
+        SourceObjectID: o.IntegrationObjectID ?? undefined,
+        SourceObjectName: o.Name,
+      }));
+      const result = await this.dataService.ApplyAllBatch(integrationID, selections);
+      this.CreateTablesResult = {
+        Success: result.Success,
+        Message: result.Success
+          ? `Added ${newObjects.length} new table${newObjects.length === 1 ? '' : 's'}: ${newObjects.map(o => o.Name).join(', ')}.`
+          : (result.Message ?? 'Apply failed'),
+      };
+
+      if (result.Success) {
+        this.DetailEntityMaps = await this.loadEntityMapsForIntegration(integrationID);
+        this.DetailFilteredMaps = this.applyDetailFilter();
+        this.EntityMapCounts = this.countMapsByIntegration(await this.loadAllEntityMaps());
+      }
+    } catch (err) {
+      this.CreateTablesResult = { Success: false, Message: err instanceof Error ? err.message : String(err) };
+    } finally {
+      this.IsCreatingTables = false;
+      this.cdr.detectChanges();
+    }
+  }
+
+  /**
    * Search-only filter for the picker. Standard/Custom/Registered state
    * shows up as badges — never hides anything — so Select All covers
    * everything the user can see.

--- a/packages/Integration/connectors/src/YourMembershipConnector.ts
+++ b/packages/Integration/connectors/src/YourMembershipConnector.ts
@@ -3619,11 +3619,19 @@ export class YourMembershipConnector extends BaseRESTIntegrationConnector {
         typeList: GroupTypeListItem[],
         objectType: string
     ): FetchBatchResult {
-        const records = typeList.map(gt => ({
-            ExternalID: String(gt.Id ?? ''),
-            ObjectType: objectType,
-            Fields: { Id: gt.Id, TypeName: gt.TypeName, SortIndex: gt.SortIndex } as Record<string, unknown>,
-        }));
+        const records = typeList.map(gt => {
+            // Full-record pass-through (§0 forward-compat contract): spread the WHOLE GroupType so any
+            // custom fields YM returns reach ExternalRecord.Fields for the custom-column capture — NOT a
+            // hand-picked subset (the prior {Id,TypeName,SortIndex} dropped customs). Exclude only the
+            // nested Groups child collection, which is emitted as separate group records (FlattenGroupRecords).
+            const fields: Record<string, unknown> = { ...gt };
+            delete fields.Groups;
+            return {
+                ExternalID: String(gt.Id ?? ''),
+                ObjectType: objectType,
+                Fields: fields,
+            };
+        });
         return { Records: records, HasMore: false };
     }
 

--- a/packages/Integration/engine/scripts/prove-custom-columns.mts
+++ b/packages/Integration/engine/scripts/prove-custom-columns.mts
@@ -1,0 +1,101 @@
+/**
+ * Runnable end-to-end proof of the custom-column feature (gaps.md §2), using the REAL
+ * production functions from the built packages — no mocks, no claims. Simulates a
+ * schema-less flat-file feed (the PropFuel class) whose static catalog maps 3 fields
+ * while the feed actually returns extra columns, then drives the full pipeline:
+ *
+ *   capture → stats → plan → DDL (SQL Server AND PostgreSQL) → spread → re-baseline → terminate
+ *
+ * Run:  npx tsx scripts/prove-custom-columns.mts   (from packages/Integration/engine)
+ */
+import {
+    FieldMappingEngine,
+    buildOverflowStats,
+    planPromotions,
+    sanitizeColumnName,
+    computeContentHash,
+    type ExternalRecord,
+    type PromotionCandidate,
+} from '../dist/index.js';
+import { DDLGenerator } from '@memberjunction/integration-schema-builder';
+import type { TargetColumnConfig, DatabasePlatform } from '@memberjunction/integration-schema-builder';
+
+const line = (s = '') => process.stdout.write(s + '\n');
+const hr = () => line('─'.repeat(78));
+
+// ── The connector's STATIC (declared) catalog: it only knows 3 fields ──────────────
+const fieldMaps = [
+    { SourceFieldName: 'Id', DestinationFieldName: 'ExternalID', Status: 'Active', Priority: 0 },
+    { SourceFieldName: 'Name', DestinationFieldName: 'Name', Status: 'Active', Priority: 0 },
+    { SourceFieldName: 'Email', DestinationFieldName: 'Email', Status: 'Active', Priority: 0 },
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+] as any;
+const declaredColumns = new Set(['ExternalID', 'Name', 'Email']);
+
+// ── The flat-file feed ACTUALLY returns extra columns the catalog never declared ───
+const feed: ExternalRecord[] = [
+    { ExternalID: '1', ObjectType: 'Contact', Fields: { Id: '1', Name: 'Ada',  Email: 'a@x.com', Region: 'West', Score: 5, SignupDate: '2026-01-15', IsVip: true } },
+    { ExternalID: '2', ObjectType: 'Contact', Fields: { Id: '2', Name: 'Babb', Email: 'b@x.com', Region: 'East', Score: 7, SignupDate: '2026-02-20', IsVip: false } },
+    { ExternalID: '3', ObjectType: 'Contact', Fields: { Id: '3', Name: 'Cyd',  Email: 'c@x.com', Region: 'West', Score: 9, SignupDate: '2026-03-01', IsVip: true } },
+    { ExternalID: '4', ObjectType: 'Contact', Fields: { Id: '4', Name: 'Dot',  Email: 'd@x.com', Region: 'West',            SignupDate: '2026-03-05', IsVip: false, JunkOnce: 'noise' } },
+];
+
+const engine = new FieldMappingEngine();
+
+// ── 1. CAPTURE — real FieldMappingEngine.Apply ─────────────────────────────────────
+hr(); line('1. CAPTURE  (FieldMappingEngine.Apply — only declared fields map; extras parked)');
+const mapped = engine.Apply(feed, fieldMaps, 'Contacts');
+line(`   row1 MappedFields   : ${JSON.stringify(mapped[0].MappedFields)}`);
+line(`   row1 UnmappedFields : ${JSON.stringify(mapped[0].UnmappedFields)}`);
+line(`   row4 UnmappedFields : ${JSON.stringify(mapped[3].UnmappedFields)}   (note JunkOnce)`);
+// What M1 writes into __mj_integration_CustomOverflow on each row:
+const overflowColumn = mapped.map(m =>
+    Object.keys(m.UnmappedFields ?? {}).length ? JSON.stringify(m.UnmappedFields) : null,
+);
+line(`   overflow column written on ${overflowColumn.filter(Boolean).length}/4 rows`);
+
+// ── 2. STATS + 3. PLAN — real buildOverflowStats + planPromotions ──────────────────
+hr(); line('2/3. SCAN + PLAN  (coverage over the overflow column → promotion decision)');
+const stats = buildOverflowStats(overflowColumn);
+for (const s of stats) line(`   ${s.Key.padEnd(12)} coverage=${(s.Occurrences / s.TotalRows).toFixed(2)}  samples=${JSON.stringify(s.SampleValues.slice(0, 3))}`);
+const plan = planPromotions(stats, { ExistingColumnNames: declaredColumns });
+line('');
+line('   PROMOTE:');
+for (const c of plan) line(`     ${c.Key.padEnd(12)} → ${c.Inferred.SchemaFieldType.padEnd(8)} (SS ${c.Inferred.SqlServerType} / PG ${c.Inferred.PostgresType})`);
+const dropped = stats.filter(s => !plan.some(c => c.Key === s.Key)).map(s => s.Key);
+line(`   NOT promoted (sub-threshold/sparse): ${dropped.join(', ') || '(none)'}`);
+
+// ── 4. DDL — real DDLGenerator, BOTH dialects (the "no PG bugs" proof) ──────────────
+hr(); line('4. DDL  (real DDLGenerator.GenerateAlterTableAddColumn — SQL Server AND PostgreSQL)');
+const ddl = new DDLGenerator();
+const toCol = (c: PromotionCandidate, p: DatabasePlatform): TargetColumnConfig => ({
+    SourceFieldName: c.Key,
+    TargetColumnName: sanitizeColumnName(c.Key),
+    TargetSqlType: p === 'sqlserver' ? c.Inferred.SqlServerType : c.Inferred.PostgresType,
+    IsNullable: true, MaxLength: c.Inferred.MaxLength, Precision: null, Scale: null, DefaultValue: null,
+});
+for (const platform of ['sqlserver', 'postgresql'] as DatabasePlatform[]) {
+    line(`   ── ${platform} ──`);
+    for (const c of plan) line('   ' + ddl.GenerateAlterTableAddColumn('crm', 'Contact', toCol(c, platform), platform).replace(/\n/g, '\n   '));
+    line('');
+}
+
+// ── 5. SPREAD + RE-BASELINE — real computeContentHash ──────────────────────────────
+hr(); line('5. SPREAD + RE-BASELINE  (values land in columns; content hash re-baselined)');
+const hashBefore = computeContentHash(mapped[0].MappedFields);              // declared-only (what the sync stored)
+const promotedRow = { ...mapped[0].MappedFields } as Record<string, unknown>;
+for (const c of plan) promotedRow[sanitizeColumnName(c.Key)] = (mapped[0].UnmappedFields ?? {})[c.Key]; // spread
+const hashAfter = computeContentHash(promotedRow);                          // declared + promoted (next-sync value)
+line(`   row1 after spread   : ${JSON.stringify(promotedRow)}`);
+line(`   stored hash (before): ${hashBefore.slice(0, 16)}…`);
+line(`   re-baselined (after): ${hashAfter.slice(0, 16)}…   ${hashBefore === hashAfter ? '!! SAME (bug)' : '✓ differs → re-baseline REQUIRED, and computed'}`);
+
+// ── 6. TERMINATE — re-plan once the columns exist ──────────────────────────────────
+hr(); line('6. TERMINATE  (second pass: columns now exist → nothing re-promoted)');
+const afterColumns = new Set([...declaredColumns, ...plan.map(c => sanitizeColumnName(c.Key))]);
+const plan2 = planPromotions(stats, { ExistingColumnNames: afterColumns });
+line(`   second-pass promotions: ${plan2.length}   ${plan2.length === 0 ? '✓ converged (loop terminates)' : '!! would re-promote (bug)'}`);
+hr();
+line(plan.length > 0 && hashBefore !== hashAfter && plan2.length === 0
+    ? 'RESULT: full pipeline proven on real functions — capture → plan → SS+PG DDL → spread → re-baseline → terminate.'
+    : 'RESULT: UNEXPECTED — inspect output above.');

--- a/packages/Integration/engine/src/BaseIntegrationConnector.ts
+++ b/packages/Integration/engine/src/BaseIntegrationConnector.ts
@@ -26,6 +26,7 @@ import {
     type StreamDiscoveryOptions,
     type PkPickOptions,
 } from './StreamingDiscovery.js';
+import { AdaptiveConcurrencyController, RunAdaptive, type AdaptiveItemOutcome } from './AdaptiveConcurrency.js';
 
 /** Result of testing a connection to an external system */
 export interface ConnectionTestResult {
@@ -665,108 +666,99 @@ export abstract class BaseIntegrationConnector {
         const objects = wanted ? allObjects.filter(o => wanted.has(o.Name)) : allObjects;
         const result: SourceSchemaInfo = { Objects: [] };
 
-        // Parallel describe — sequential is brutal when a connector has
-        // hundreds of objects to introspect (Sage Intacct can run ~30 minutes
-        // sequentially on a large catalog). 8-way is a safe default that
-        // mirrors the Salesforce override and respects most APIs' rate limits.
-        const CONCURRENCY = 8;
+        // Parallel describe via the SAME control law the sync engine uses for its layers —
+        // `RunAdaptive` + `AdaptiveConcurrencyController` (AIMD). Discovery IS the sync read path with
+        // the save removed, so it shares the concurrency machinery rather than a separate fixed pool:
+        // it ramps UP on clean describes and CUTS on a throttle (detected via the connector's
+        // `ExtractRetryAfterMs`). The cap honors the connector's `MaxConcurrencyHint` + a per-connection
+        // `Configuration.maxConcurrency` override (the same `IntegrationSetSyncConfig` knob that tunes
+        // sync). Default start is 8 — a read-only introspection sweep tolerates more parallelism than
+        // the write path's default of 1; sequential introspection is brutal (Sage Intacct ~30 min).
         const total = objects.length;
         const startMs = Date.now();
-        let nextIdx = 0;
         let succeeded = 0;
         let skipped = 0;
 
-        const worker = async (): Promise<void> => {
-            while (true) {
-                const myIdx = nextIdx++;
-                if (myIdx >= total) return;
-                const obj = objects[myIdx];
-                const objStart = Date.now();
-                console.log(JSON.stringify({
-                    ts: new Date().toISOString(),
-                    event: 'introspect.object.start',
-                    objectIndex: myIdx + 1,
-                    total,
-                    objectName: obj.Name,
-                }));
-                let fields: ExternalFieldSchema[];
-                try {
-                    fields = await this.DiscoverFields(companyIntegration, obj.Name, contextUser);
-                } catch (err) {
-                    const msg = err instanceof Error ? err.message : String(err);
-                    console.warn(`WARNING: Skipping object "${obj.Name}" — DiscoverFields failed: ${msg}`);
-                    console.log(JSON.stringify({
-                        ts: new Date().toISOString(),
-                        event: 'introspect.object.skipped',
-                        objectIndex: myIdx + 1,
-                        total,
-                        objectName: obj.Name,
-                        error: msg,
-                        durationMs: Date.now() - objStart,
-                    }));
-                    skipped++;
-                    continue;
-                }
-                console.log(JSON.stringify({
-                    ts: new Date().toISOString(),
-                    event: 'introspect.object.complete',
-                    objectIndex: myIdx + 1,
-                    total,
-                    objectName: obj.Name,
-                    fieldsDiscovered: fields.length,
-                    primaryKeyFields: fields.filter(f => f.IsPrimaryKey).map(f => f.Name),
-                    foreignKeyFields: fields.filter(f => f.IsForeignKey).length,
-                    durationMs: Date.now() - objStart,
-                }));
-                result.Objects.push({
-                    ExternalName: obj.Name,
-                    ExternalLabel: obj.Label,
-                    Description: obj.Description,
-                    Fields: fields.map(f => ({
-                        Name: f.Name,
-                        Label: f.Label,
-                        Description: f.Description,
-                        SourceType: f.DataType,
-                        IsRequired: f.IsRequired,
-                        AllowsNull: f.AllowsNull,
-                        MaxLength: f.MaxLength ?? null,
-                        Precision: f.Precision ?? null,
-                        Scale: f.Scale ?? null,
-                        DefaultValue: f.DefaultValue ?? null,
-                        IsPrimaryKey: f.IsPrimaryKey ?? false,
-                        IsUniqueKey: f.IsUniqueKey,
-                        IsReadOnly: f.IsReadOnly,
-                        IsForeignKey: f.IsForeignKey ?? false,
-                        ForeignKeyTarget: f.ForeignKeyTarget ?? null,
-                    })),
-                    // Honest PK selection: only IsPrimaryKey=true fields qualify.
-                    // Prior behavior used IsUniqueKey which is wrong — an object
-                    // can have multiple unique fields (e.g. email + phone) of which
-                    // only one is the PK. Connectors that don't yet set IsPrimaryKey
-                    // on their DiscoverFields output will return an empty PrimaryKeyFields;
-                    // the runtime PK classifier (Phase 0 D2/D4) handles the residual.
-                    PrimaryKeyFields: fields.filter(f => f.IsPrimaryKey).map(f => f.Name),
-                    Relationships: fields
-                        .filter(f => (f.IsForeignKey ?? false) && f.ForeignKeyTarget)
-                        .map(f => ({
-                            FieldName: f.Name,
-                            TargetObject: f.ForeignKeyTarget!,
-                            TargetField: 'ID',
-                        })),
-                });
-                succeeded++;
-                const done = succeeded + skipped;
-                if (done % 100 === 0 || done === total) {
-                    const elapsedSec = ((Date.now() - startMs) / 1000).toFixed(1);
-                    console.log(
-                        `[IntrospectSchema] progress: ${done}/${total} (ok=${succeeded}, skipped=${skipped}) — ${elapsedSec}s elapsed`
-                    );
-                }
+        const DEFAULT_DISCOVERY_CONCURRENCY = 8;
+        let maxConcurrency = Math.max(DEFAULT_DISCOVERY_CONCURRENCY, this.MaxConcurrencyHint ?? 0);
+        try {
+            const raw = companyIntegration.Configuration;
+            if (raw) {
+                const m = (JSON.parse(raw) as { maxConcurrency?: number }).maxConcurrency;
+                if (typeof m === 'number' && Number.isFinite(m) && m >= 1) maxConcurrency = Math.floor(m);
             }
+        } catch { /* malformed Configuration → defaults */ }
+        const controller = new AdaptiveConcurrencyController({
+            start: Math.min(DEFAULT_DISCOVERY_CONCURRENCY, Math.max(1, maxConcurrency)),
+            min: 1,
+            max: Math.max(1, maxConcurrency),
+        });
+
+        const introspectOne = async (obj: ExternalObjectSchema): Promise<AdaptiveItemOutcome> => {
+            const objStart = Date.now();
+            console.log(JSON.stringify({
+                ts: new Date().toISOString(), event: 'introspect.object.start', objectName: obj.Name, total,
+            }));
+            let fields: ExternalFieldSchema[];
+            try {
+                fields = await this.DiscoverFields(companyIntegration, obj.Name, contextUser);
+            } catch (err) {
+                const msg = err instanceof Error ? err.message : String(err);
+                console.warn(`WARNING: Skipping object "${obj.Name}" — DiscoverFields failed: ${msg}`);
+                console.log(JSON.stringify({
+                    ts: new Date().toISOString(), event: 'introspect.object.skipped',
+                    objectName: obj.Name, total, error: msg, durationMs: Date.now() - objStart,
+                }));
+                skipped++;
+                // A real rate-limit failure cuts the in-flight cap (AIMD); a plain describe error does not.
+                return { ok: false, throttled: this.ExtractRetryAfterMs(err) !== undefined };
+            }
+            console.log(JSON.stringify({
+                ts: new Date().toISOString(), event: 'introspect.object.complete',
+                objectName: obj.Name, total, fieldsDiscovered: fields.length,
+                primaryKeyFields: fields.filter(f => f.IsPrimaryKey).map(f => f.Name),
+                foreignKeyFields: fields.filter(f => f.IsForeignKey).length, durationMs: Date.now() - objStart,
+            }));
+            // Single-threaded async → these mutations are atomic across concurrent introspectOne calls
+            // (same safety the sync engine's per-map aggregate mutations rely on).
+            result.Objects.push({
+                ExternalName: obj.Name,
+                ExternalLabel: obj.Label,
+                Description: obj.Description,
+                Fields: fields.map(f => ({
+                    Name: f.Name,
+                    Label: f.Label,
+                    Description: f.Description,
+                    SourceType: f.DataType,
+                    IsRequired: f.IsRequired,
+                    AllowsNull: f.AllowsNull,
+                    MaxLength: f.MaxLength ?? null,
+                    Precision: f.Precision ?? null,
+                    Scale: f.Scale ?? null,
+                    DefaultValue: f.DefaultValue ?? null,
+                    IsPrimaryKey: f.IsPrimaryKey ?? false,
+                    IsUniqueKey: f.IsUniqueKey,
+                    IsReadOnly: f.IsReadOnly,
+                    IsForeignKey: f.IsForeignKey ?? false,
+                    ForeignKeyTarget: f.ForeignKeyTarget ?? null,
+                })),
+                // Honest PK selection: only IsPrimaryKey=true fields qualify (an object can have several
+                // unique fields of which only one is the PK). Connectors that don't set IsPrimaryKey
+                // return an empty PrimaryKeyFields; the runtime PK classifier (D2/D4) handles the residual.
+                PrimaryKeyFields: fields.filter(f => f.IsPrimaryKey).map(f => f.Name),
+                Relationships: fields
+                    .filter(f => (f.IsForeignKey ?? false) && f.ForeignKeyTarget)
+                    .map(f => ({ FieldName: f.Name, TargetObject: f.ForeignKeyTarget!, TargetField: 'ID' })),
+            });
+            succeeded++;
+            const done = succeeded + skipped;
+            if (done % 100 === 0 || done === total) {
+                console.log(`[IntrospectSchema] progress: ${done}/${total} (ok=${succeeded}, skipped=${skipped}) — ${((Date.now() - startMs) / 1000).toFixed(1)}s elapsed`);
+            }
+            return { ok: true, throttled: false };
         };
 
-        const workerCount = Math.min(CONCURRENCY, total);
-        await Promise.all(Array.from({ length: workerCount }, () => worker()));
+        await RunAdaptive(objects, introspectOne, controller);
 
         return result;
     }

--- a/packages/Integration/engine/src/BaseIntegrationConnector.ts
+++ b/packages/Integration/engine/src/BaseIntegrationConnector.ts
@@ -20,6 +20,12 @@ import type {
     ListContext,
     ListResult,
 } from './types.js';
+import {
+    discoverFromStream,
+    pickPrimaryKeyFromStats,
+    type StreamDiscoveryOptions,
+    type PkPickOptions,
+} from './StreamingDiscovery.js';
 
 /** Result of testing a connection to an external system */
 export interface ConnectionTestResult {
@@ -264,6 +270,17 @@ export interface RateLimitPolicy {
     Burst?: number;
     /** Multiplicative-decrease factor applied on a throttle signal (0 < f < 1). */
     ThrottleBackoffFactor?: number;
+    /**
+     * How fast the effective rate ramps back up per successful call after a throttle (additive
+     * increase). Lower = more conservative recovery. Default: TokensPerSec/10 (≈10 successes to
+     * fully recover). Set low for an API that stays throttled for a while after a 429.
+     */
+    SuccessRampPerCall?: number;
+    /**
+     * Floor the effective rate never drops below, even after repeated throttles (tokens/sec).
+     * Default: TokensPerSec/20. Set when the vendor guarantees a minimum service rate.
+     */
+    MinTokensPerSec?: number;
 }
 
 export abstract class BaseIntegrationConnector {
@@ -443,6 +460,67 @@ export abstract class BaseIntegrationConnector {
      * applies target-type constraint enforcement; this is the connector-side complement.
      */
     public PostProcessRecord(record: ExternalRecord): ExternalRecord { return record; }
+
+    /**
+     * Stage-2 field discovery for sources WITHOUT a describe/introspection endpoint (file feeds,
+     * undocumented JSON list endpoints): stream the source's actual records — READ-ONLY, no save,
+     * no ack — and derive the full field set + data-informed PK/uniqueness/nullability from the
+     * gathered statistics. The connector supplies whatever read-only fetch yields the records; this
+     * helper turns that stream into `ExternalFieldSchema[]`.
+     *
+     * Why data-informed instead of nominal: streaming the real values lets us prove which column is
+     * unique + non-null over a statistically significant N (`pickPrimaryKeyFromStats`, p<0.05) and
+     * pick the PK from evidence rather than a name guess. The scan is time-bounded — it stops on
+     * exhaustion OR `opts.Discovery.TimeBudgetMs`, whichever comes first, and uses what it gathered;
+     * more rows simply mean stronger claims.
+     *
+     * Provable-only encoding into the standard flags:
+     *  - `IsPrimaryKey` — set ONLY on the single statistics-first pick. Multiple equally-ranked unique
+     *    columns leave PK unset here (ambiguous → the pipeline's `SoftPKClassifier` LLM tiebreaker
+     *    decides, fed these same stats). Zero unique columns → no PK is fabricated.
+     *  - `IsUniqueKey` — set when the column was all-distinct over the scan AND uniqueness was provable
+     *    (the distinct-cap wasn't hit).
+     *  - `AllowsNull` — asserted `true` ONLY when a null/absent value was actually observed; otherwise
+     *    left undefined (permissive default). Never fabricates NOT NULL — critical under a time-capped
+     *    partial scan where unseen rows could still be null.
+     *
+     * The PK emitted here is SOFT (it rides additionalSchemaInfo via the persist + DDL path; it is
+     * NEVER a hard DB key), so a wrong inference can never reject a valid row — the engine dedupes via
+     * the record-map. `IsReadOnly` defaults to true (stream discovery targets read feeds); a writable
+     * source overrides via `opts.ReadOnly`.
+     *
+     * @param records - A read-only sync/async iterable of source records (the caller's fetch yields them).
+     * @param opts.Discovery - Time budget / sample caps for the scan (see {@link StreamDiscoveryOptions}).
+     * @param opts.Pk - Significance threshold + naming-rank tiebreaker (see {@link PkPickOptions}).
+     * @param opts.ReadOnly - Whether discovered fields are read-only. Default true.
+     */
+    protected async DiscoverFieldsViaStream(
+        records: AsyncIterable<Record<string, unknown>> | Iterable<Record<string, unknown>>,
+        opts: { Discovery?: StreamDiscoveryOptions; Pk?: PkPickOptions; ReadOnly?: boolean } = {}
+    ): Promise<ExternalFieldSchema[]> {
+        const scan = await discoverFromStream(records, opts.Discovery);
+        const pk = pickPrimaryKeyFromStats(scan.Columns, opts.Pk);
+        const readOnly = opts.ReadOnly ?? true;
+
+        return scan.Columns.map(c => {
+            const provablyUnique = !c.DistinctCapped && c.Occurrences > 0 && c.DistinctNonNull === c.Occurrences;
+            const sawNull = c.Occurrences < c.TotalRows;
+            const field: ExternalFieldSchema = {
+                Name: c.Key,
+                Label: c.Key,
+                DataType: c.Inferred.SchemaFieldType,
+                IsRequired: false,
+                IsUniqueKey: provablyUnique,
+                IsReadOnly: readOnly,
+            };
+            // Provable-only: only assert nullability we actually observed; never fabricate NOT NULL.
+            if (sawNull) field.AllowsNull = true;
+            // Statistics-first PK: set only on the unambiguous pick; defer ties to the LLM tiebreaker.
+            if (pk.Field === c.Key) field.IsPrimaryKey = true;
+            if (c.Inferred.MaxLength != null) field.MaxLength = c.Inferred.MaxLength;
+            return field;
+        });
+    }
 
     // ─── Core Abstract Methods ───────────────────────────────────────
 

--- a/packages/Integration/engine/src/BaseRESTIntegrationConnector.ts
+++ b/packages/Integration/engine/src/BaseRESTIntegrationConnector.ts
@@ -189,6 +189,41 @@ export abstract class BaseRESTIntegrationConnector extends BaseIntegrationConnec
         return raw;
     }
 
+    /**
+     * Source keys a connector DELIBERATELY removes in its {@link TransformRecord} override
+     * (vendor noise, a flattened parent blob, a nested child collection emitted as its own object).
+     * These are the only sanctioned drops — excluded from the {@link applyTransformPreservingKeys}
+     * re-add. Default: none. Override per-object to declare intentional removals.
+     */
+    protected ExcludedSourceKeys(_objectName: string): string[] {
+        return [];
+    }
+
+    /**
+     * Runs {@link TransformRecord}, then RE-ADDS any source key the transform dropped (present in
+     * `raw`, absent from the output) unless declared in {@link ExcludedSourceKeys}. This makes the
+     * base-fetch path structurally full-record (§0 forward-compat contract): a TransformRecord
+     * override may reshape/coerce but cannot SILENTLY drop a source key from `ExternalRecord.Fields`,
+     * so the framework's custom-column capture sees everything the source returned. The default
+     * identity transform returns `raw` unchanged → fast-path no-op (zero overhead, zero behavior
+     * change for connectors that don't override TransformRecord).
+     */
+    protected applyTransformPreservingKeys(
+        raw: Record<string, unknown>,
+        obj: MJIntegrationObjectEntity,
+        fields: MJIntegrationObjectFieldEntity[]
+    ): Record<string, unknown> {
+        const transformed = this.TransformRecord(raw, obj, fields);
+        if (transformed === raw) return raw; // identity (default) — nothing dropped
+        const excluded = new Set(this.ExcludedSourceKeys(obj.Name));
+        const out: Record<string, unknown> = { ...transformed };
+        for (const key of Object.keys(raw)) {
+            if (key in out || excluded.has(key)) continue;
+            out[key] = raw[key]; // re-add a key the transform dropped but did not exclude
+        }
+        return out;
+    }
+
     // ── BaseIntegrationConnector implementations ─────────────────────
 
     /**
@@ -393,7 +428,7 @@ export abstract class BaseRESTIntegrationConnector extends BaseIntegrationConnec
         }
         const records = this.NormalizeResponse(response.Body, obj.ResponseDataKey);
         if (records.length === 0) return null;
-        const transformed = this.TransformRecord(records[0], obj, fields);
+        const transformed = this.applyTransformPreservingKeys(records[0], obj, fields);
         return this.ToExternalRecord(transformed, ctx.ObjectName, this.FindPrimaryKeyFieldNames(fields));
     }
 
@@ -494,7 +529,7 @@ export abstract class BaseRESTIntegrationConnector extends BaseIntegrationConnec
 
         return {
             Records: result.Records.map(r => this.ToExternalRecord(
-                this.TransformRecord(r, obj, fields),
+                this.applyTransformPreservingKeys(r, obj, fields),
                 ctx.ObjectName,
                 pkFieldNames
             )),
@@ -588,7 +623,7 @@ export abstract class BaseRESTIntegrationConnector extends BaseIntegrationConnec
             const result = await this.FetchWithPagination(auth, fullURL, obj, ctx);
             for (const r of result.Records) {
                 for (const [k, v] of Object.entries(fkTags)) r[k] = v;
-                const transformed = this.TransformRecord(r, obj, fields);
+                const transformed = this.applyTransformPreservingKeys(r, obj, fields);
                 out.push(this.ToExternalRecord(transformed, ctx.ObjectName, pkFieldNames));
             }
             return;

--- a/packages/Integration/engine/src/CustomColumnPromotion.ts
+++ b/packages/Integration/engine/src/CustomColumnPromotion.ts
@@ -1,0 +1,256 @@
+/**
+ * Promotion planner — the brain of the post-sync custom-column step (gaps.md §2, M2).
+ *
+ * After a sync, the values a source returned with no field map are parked as JSON in the
+ * {@link CUSTOM_OVERFLOW_COLUMN} system column (M1 capture). This module decides, from a
+ * coverage scan of that column, WHICH of those keys earn a real column and WHAT bounded
+ * type each should get. It is PURE — no DB, no RSU, no I/O — so the genuinely new logic is
+ * fully unit-testable. The server-side orchestrator (M2b) feeds the resulting plan into the
+ * EXISTING refresh pipeline (SchemaEvolution ADD COLUMN → RSU → IntegrationSchemaSync IOF →
+ * field map); this module never touches schema itself.
+ *
+ * Design rules (from gaps.md §2 + the connector-code conventions):
+ * - Provable-only / never fabricate: a key earns a column only on PERVASIVENESS evidence
+ *   (coverage ≥ threshold), never on a single malformed row. PK/FK are NEVER inferred here —
+ *   customs are always emitted nullable, non-PK, non-FK (classification is deferred to D4).
+ * - Generous bounded typing (the NVARCHAR(MAX) problem): size columns comfortably from the
+ *   observed samples and err LARGER — a roomy bounded column beats a truncating tight one,
+ *   and both beat MAX. Only fall back to MAX/TEXT when the observed length genuinely can't be
+ *   bounded. Narrow to number/boolean/datetime ONLY when every non-null sample unambiguously
+ *   supports it; otherwise default to a (generously bounded) string — that is the safe choice
+ *   that can hold anything the source later returns.
+ * - Terminate / never re-promote: a key whose column already exists is skipped, so the
+ *   capture→promote loop converges instead of re-promoting forever.
+ */
+
+/** The schema-builder field-type family + the concrete per-dialect SQL types we infer. */
+export interface InferredColumnType {
+    /** Schema-builder SchemaFieldType family ('string' | 'number' | 'boolean' | 'datetime'). */
+    SchemaFieldType: 'string' | 'number' | 'boolean' | 'datetime';
+    /** Concrete SQL Server column type, e.g. `NVARCHAR(255)`, `BIGINT`, `DATETIMEOFFSET`. */
+    SqlServerType: string;
+    /** Concrete PostgreSQL column type, e.g. `VARCHAR(255)`, `BIGINT`, `TIMESTAMPTZ`. */
+    PostgresType: string;
+    /** Bound for string types (null for non-string or when unbounded → MAX/TEXT). */
+    MaxLength: number | null;
+}
+
+/** Per-key statistics from a coverage scan of the overflow column for one (CompanyIntegration, entity). */
+export interface OverflowKeyStats {
+    /** The source key as it appears in the overflow JSON. */
+    Key: string;
+    /** Rows in which the key was present with a non-null value. */
+    Occurrences: number;
+    /** Total rows scanned (rows that had any overflow JSON). */
+    TotalRows: number;
+    /** A bounded sample of observed values for this key, for type inference. */
+    SampleValues: unknown[];
+}
+
+/** A key that earned a real column, with its inferred bounded type. */
+export interface PromotionCandidate {
+    /** The source key → becomes both the SourceFieldName (field map) and the column name. */
+    Key: string;
+    /** Pervasiveness in [0,1] = Occurrences / TotalRows. */
+    Coverage: number;
+    /** The inferred, generously-bounded column type. */
+    Inferred: InferredColumnType;
+}
+
+/** Tuning + context for {@link planPromotions}. */
+export interface PromotionPlanOptions {
+    /**
+     * Minimum coverage (in [0,1]) a key must clear to earn a column. Default 0.5 — a key
+     * present on at least half the rows that carried any overflow. Below this it stays in the
+     * overflow JSON (queryable, never lost) rather than minting a sparse column from noise.
+     */
+    CoverageThreshold?: number;
+    /**
+     * Column names that already exist on the target entity (case-insensitive). A key whose
+     * column already exists is NOT re-promoted — this is what makes the loop terminate.
+     */
+    ExistingColumnNames?: ReadonlySet<string>;
+}
+
+const DEFAULT_COVERAGE_THRESHOLD = 0.5;
+/** SQL Server's largest bounded NVARCHAR before MAX; above this we must use MAX/TEXT. */
+const MAX_BOUNDED_STRING = 4000;
+/** Floor for a generous string bound — never size a custom string column tighter than this. */
+const MIN_STRING_BOUND = 255;
+
+/** Matches an ISO-8601-ish date / datetime so we don't mistake "5" or "2020" for a date. */
+const ISO_DATE_RE = /^\d{4}-\d{2}-\d{2}([T ]\d{2}:\d{2}(:\d{2}(\.\d+)?)?(Z|[+-]\d{2}:?\d{2})?)?$/;
+
+/**
+ * Plans which overflow keys to promote to real columns. Pure; deterministic (sorted by key).
+ *
+ * @param stats - per-key coverage statistics from the overflow scan
+ * @param opts  - coverage threshold + the set of already-existing column names
+ * @returns the promotion candidates, sorted by key for stable, replayable output
+ */
+export function planPromotions(
+    stats: OverflowKeyStats[],
+    opts: PromotionPlanOptions = {}
+): PromotionCandidate[] {
+    const threshold = opts.CoverageThreshold ?? DEFAULT_COVERAGE_THRESHOLD;
+    const existing = lowercaseSet(opts.ExistingColumnNames);
+    const candidates: PromotionCandidate[] = [];
+
+    for (const stat of stats) {
+        // Terminate / never re-promote: the column already exists.
+        if (existing.has(stat.Key.toLowerCase())) continue;
+        // Pervasiveness floor — never mint a column from a junk key in one malformed row.
+        if (stat.TotalRows <= 0) continue;
+        const coverage = stat.Occurrences / stat.TotalRows;
+        if (coverage < threshold) continue;
+
+        candidates.push({
+            Key: stat.Key,
+            Coverage: coverage,
+            Inferred: inferColumnTypeFromSamples(stat.SampleValues),
+        });
+    }
+
+    return candidates.sort((a, b) => a.Key.localeCompare(b.Key));
+}
+
+/**
+ * Infers a generously-bounded column type from observed sample values. Narrows to
+ * boolean/number/datetime ONLY when EVERY non-null sample unambiguously supports it;
+ * otherwise defaults to a comfortably-bounded string. Never returns MAX/TEXT unless the
+ * observed string length genuinely can't be bounded.
+ */
+export function inferColumnTypeFromSamples(samples: unknown[]): InferredColumnType {
+    const nonNull = samples.filter(v => v !== null && v !== undefined);
+
+    // No evidence → a safe, generous default string.
+    if (nonNull.length === 0) return stringType(MIN_STRING_BOUND);
+
+    if (nonNull.every(isBoolean)) {
+        return { SchemaFieldType: 'boolean', SqlServerType: 'BIT', PostgresType: 'BOOLEAN', MaxLength: null };
+    }
+
+    if (nonNull.every(isFiniteNumber)) {
+        const allIntegers = nonNull.every(v => Number.isInteger(v as number));
+        return allIntegers
+            ? { SchemaFieldType: 'number', SqlServerType: 'BIGINT', PostgresType: 'BIGINT', MaxLength: null }
+            // Generous fixed-point — wide precision so we don't truncate decimals.
+            : { SchemaFieldType: 'number', SqlServerType: 'DECIMAL(38,10)', PostgresType: 'DECIMAL(38,10)', MaxLength: null };
+    }
+
+    if (nonNull.every(isIsoDateString)) {
+        return { SchemaFieldType: 'datetime', SqlServerType: 'DATETIMEOFFSET', PostgresType: 'TIMESTAMPTZ', MaxLength: null };
+    }
+
+    // Default: a generously-bounded string sized to comfortably hold the longest observed value.
+    const longest = Math.max(...nonNull.map(v => String(v).length));
+    return stringType(generousStringBound(longest));
+}
+
+/** Builds a string {@link InferredColumnType}; bound===null ⇒ unbounded (MAX/TEXT). */
+function stringType(bound: number | null): InferredColumnType {
+    if (bound === null) {
+        return { SchemaFieldType: 'string', SqlServerType: 'NVARCHAR(MAX)', PostgresType: 'TEXT', MaxLength: null };
+    }
+    return { SchemaFieldType: 'string', SqlServerType: `NVARCHAR(${bound})`, PostgresType: `VARCHAR(${bound})`, MaxLength: bound };
+}
+
+/**
+ * Generous bound for a string column: double the longest observed length (room to grow),
+ * floored at {@link MIN_STRING_BOUND}; if that would exceed the bounded limit, fall back to
+ * unbounded (null → MAX/TEXT) since it genuinely can't be bounded safely.
+ */
+function generousStringBound(longestObserved: number): number | null {
+    const doubled = Math.max(longestObserved * 2, MIN_STRING_BOUND);
+    return doubled > MAX_BOUNDED_STRING ? null : doubled;
+}
+
+function isBoolean(v: unknown): boolean {
+    return typeof v === 'boolean';
+}
+
+function isFiniteNumber(v: unknown): boolean {
+    return typeof v === 'number' && Number.isFinite(v);
+}
+
+function isIsoDateString(v: unknown): boolean {
+    return typeof v === 'string' && ISO_DATE_RE.test(v) && !Number.isNaN(Date.parse(v));
+}
+
+function lowercaseSet(set: ReadonlySet<string> | undefined): ReadonlySet<string> {
+    if (!set || set.size === 0) return new Set<string>();
+    return new Set([...set].map(s => s.toLowerCase()));
+}
+
+/** Max distinct sample values retained per key for type inference (bounded memory). */
+const DEFAULT_SAMPLE_CAP = 20;
+
+/**
+ * Builds per-key coverage statistics from a SAMPLE of rows that carried overflow JSON.
+ * Each row's overflow column is a JSON object string (what M1 parked); this tallies, per key,
+ * how many sampled rows had it non-null and collects a bounded sample of its values for type
+ * inference. Robust to malformed/empty JSON (such rows contribute to TotalRows but no keys).
+ *
+ * Coverage is therefore computed over the SAMPLE (bounded memory at any table size) — a
+ * statistically sound basis for the pervasiveness decision; the exactness the threshold needs
+ * (a key on ~half the rows vs. a junk key on one) survives sampling.
+ *
+ * @param overflowJsonStrings - the raw overflow-column value from each sampled row
+ * @param sampleCap - max values retained per key (default {@link DEFAULT_SAMPLE_CAP})
+ */
+export function buildOverflowStats(
+    overflowJsonStrings: Array<string | null | undefined>,
+    sampleCap: number = DEFAULT_SAMPLE_CAP
+): OverflowKeyStats[] {
+    const byKey = new Map<string, { occurrences: number; samples: unknown[] }>();
+    let totalRows = 0;
+
+    for (const raw of overflowJsonStrings) {
+        totalRows++;
+        const parsed = safeParseObject(raw);
+        if (!parsed) continue;
+        for (const [key, value] of Object.entries(parsed)) {
+            if (value === null || value === undefined) continue;
+            let entry = byKey.get(key);
+            if (!entry) {
+                entry = { occurrences: 0, samples: [] };
+                byKey.set(key, entry);
+            }
+            entry.occurrences++;
+            if (entry.samples.length < sampleCap) entry.samples.push(value);
+        }
+    }
+
+    return [...byKey.entries()].map(([key, e]) => ({
+        Key: key,
+        Occurrences: e.occurrences,
+        TotalRows: totalRows,
+        SampleValues: e.samples,
+    }));
+}
+
+/**
+ * Sanitizes a source key into a safe SQL/MJ column identifier (letters, digits, underscore;
+ * never leading-digit; bounded length). The original key is kept as the field map's
+ * SourceFieldName; the sanitized form becomes the column + DestinationFieldName. Returns the
+ * BASE name only — collision resolution (suffixing) is the orchestrator's job since it needs
+ * the existing-column context.
+ */
+export function sanitizeColumnName(key: string): string {
+    let name = key.replace(/[^A-Za-z0-9_]/g, '_').replace(/_+/g, '_').replace(/^_+|_+$/g, '');
+    if (name.length === 0) name = 'Custom';
+    if (/^[0-9]/.test(name)) name = `c_${name}`;
+    return name.length > 120 ? name.slice(0, 120) : name;
+}
+
+function safeParseObject(raw: string | null | undefined): Record<string, unknown> | null {
+    if (!raw || typeof raw !== 'string') return null;
+    try {
+        const parsed: unknown = JSON.parse(raw);
+        return parsed && typeof parsed === 'object' && !Array.isArray(parsed)
+            ? (parsed as Record<string, unknown>)
+            : null;
+    } catch {
+        return null;
+    }
+}

--- a/packages/Integration/engine/src/CustomOverflow.ts
+++ b/packages/Integration/engine/src/CustomOverflow.ts
@@ -1,0 +1,76 @@
+/**
+ * Name of the per-record custom-overflow column. Written on every integration table
+ * alongside the other `__mj_integration_*` columns when present. Holds a JSON object of
+ * the source fields a record returned that have NO field map — the "extra" keys the
+ * target table doesn't (yet) have a column for.
+ *
+ * This is the capture half of framework-level custom-column support (gaps.md §2). A
+ * source with no schema/describe endpoint (the PropFuel class) can only learn its full
+ * field set by reading data; a static catalog then silently drops any extra key at
+ * {@link MapSingleRecord} (only mapped fields get persisted). Rather than lose them, the
+ * unmapped keys are parked here, on the row, in the SAME write as the mapped fields — so
+ * capture costs no extra round-trip. A post-sync Runtime-Schema-Updation (RSU) pass later
+ * reads this column back out, promotes pervasive keys to real columns, spreads the values
+ * in, and clears them from here (at which point they are mapped → no longer "unmapped" →
+ * not re-captured: the loop converges).
+ *
+ * Shape mirrors {@link CONTENT_HASH_COLUMN}: a JSON-serialized string sidecar, identical
+ * in kind to `__mj_integration_LastSyncedSnapshot`. SS `NVARCHAR(MAX)` / PG `TEXT`; the
+ * post-sync coverage scan + spread cast `::jsonb` on Postgres when they query it.
+ *
+ * This is BACKEND PLUMBING, not user-facing metadata. It is a SYSTEM field — in the same
+ * hidden/internal class as `__mj_integration_ContentHash` & the other `__mj_integration_*`
+ * columns: metadata-registered only so the engine's `entity.Set(...)`/`entity.Fields` write
+ * path is permitted to touch it (so it is NOT an out-of-band "phantom" column the engine
+ * writes blind), but NOT surfaced or managed through the metadata-driven framework — not in
+ * forms, not user-mappable, not "a field" anyone works with. It is machinery.
+ *
+ * The things that genuinely ENTER the metadata-driven framework are the columns this gets
+ * PROMOTED into: a pervasive key here is turned into a real user-facing, mappable EntityField
+ * (IntegrationSchemaSync IOF → RSU ADD COLUMN → CodeGen → md.Refresh) BEFORE the engine maps
+ * to it. So: backend staging until promotion, first-class metadata-driven schema after. Only
+ * the JSON *values* parked here are ever transient.
+ *
+ * Gated everywhere by EntityInfo field presence, so it is a no-op on tables that predate
+ * the column. CRUCIAL invariant: when a record has NO unmapped keys, NOTHING is written
+ * here — empty across all rows is the signal that no RSU pass is needed, which is what
+ * keeps a customs-free sync byte-identical to today (single-stage, zero overhead).
+ */
+export const CUSTOM_OVERFLOW_COLUMN = '__mj_integration_CustomOverflow';
+
+/**
+ * Computes the unmapped subset of a record's external fields: every key the source
+ * returned that is NOT the SourceFieldName of any active field map.
+ *
+ * Pure + O(columns) — no per-row allocation beyond the result object, which is empty
+ * (and discarded by the caller) for the common no-customs case.
+ *
+ * Honest limit (documented in gaps.md §2): a field consumed only indirectly — e.g. as a
+ * `combine`/`custom` transform input rather than as a map's own SourceFieldName — will
+ * also appear here. That is harmless (the value is still in `Fields`); the post-sync
+ * promotion stage applies a coverage + novelty filter before it ever creates a column.
+ *
+ * @param externalFields - the full source record (`ExternalRecord.Fields`)
+ * @param mappedSourceFieldNames - SourceFieldName of every active field map
+ * @returns the extra keys + values, or an empty object when everything was mapped
+ */
+export function computeUnmappedFields(
+    externalFields: Record<string, unknown>,
+    mappedSourceFieldNames: ReadonlySet<string>
+): Record<string, unknown> {
+    const unmapped: Record<string, unknown> = {};
+    for (const key of Object.keys(externalFields)) {
+        if (!mappedSourceFieldNames.has(key)) {
+            unmapped[key] = externalFields[key];
+        }
+    }
+    return unmapped;
+}
+
+/**
+ * Whether a computed unmapped-field object carries anything worth persisting. Used by
+ * both the per-record write gate and (later) the post-sync RSU trigger gate.
+ */
+export function hasUnmappedFields(unmapped: Record<string, unknown> | undefined | null): boolean {
+    return unmapped != null && Object.keys(unmapped).length > 0;
+}

--- a/packages/Integration/engine/src/FieldMappingEngine.ts
+++ b/packages/Integration/engine/src/FieldMappingEngine.ts
@@ -1,4 +1,5 @@
 import { MJLruCache } from '@memberjunction/global';
+import { computeUnmappedFields } from './CustomOverflow.js';
 import type { ICompanyIntegrationFieldMap } from './entity-types.js';
 import type { ExternalRecord, MappedRecord } from './types.js';
 import type {
@@ -59,19 +60,28 @@ export class FieldMappingEngine {
         entityName: string
     ): MappedRecord {
         const mappedFields: Record<string, unknown> = {};
+        const mappedSourceNames = new Set<string>();
 
         for (const fieldMap of fieldMaps) {
+            mappedSourceNames.add(fieldMap.SourceFieldName);
             const value = this.ApplyFieldMapping(record, fieldMap);
             if (value !== undefined) {
                 mappedFields[fieldMap.DestinationFieldName] = value;
             }
         }
 
+        // Capture the source keys with no field map (gaps.md §2). Cheap O(columns) diff;
+        // the result is empty (and discarded by the writer) in the common all-mapped case,
+        // so this adds no measurable cost to a customs-free sync. The engine parks any extras
+        // in the __mj_integration_CustomOverflow system column — see {@link CustomOverflow}.
+        const unmappedFields = computeUnmappedFields(record.Fields, mappedSourceNames);
+
         return {
             ExternalRecord: record,
             MJEntityName: entityName,
             MappedFields: mappedFields,
             ChangeType: record.IsDeleted ? 'Delete' : 'Create',
+            UnmappedFields: unmappedFields,
         };
     }
 

--- a/packages/Integration/engine/src/IntegrationConnectorCreationPipeline.ts
+++ b/packages/Integration/engine/src/IntegrationConnectorCreationPipeline.ts
@@ -92,7 +92,68 @@ export interface ConnectorCreationPipelineResult {
  * `__mj.Entity`. The pipeline emits `entity.skipped-no-pk` events for visibility.
  */
 export class IntegrationConnectorCreationPipeline {
+    /** In-flight runs by CompanyIntegrationID — coalesces a concurrent duplicate onto the same promise. */
+    private static readonly inFlightRuns = new Map<string, Promise<ConnectorCreationPipelineResult>>();
+    /** Just-completed runs by CompanyIntegrationID — coalesces a *sequential* duplicate within the window. */
+    private static readonly recentRuns = new Map<string, { result: ConnectorCreationPipelineResult; at: number }>();
+    /** Default coalesce window (ms) when the env override is unset/invalid. */
+    private static readonly DEFAULT_COALESCE_WINDOW_MS = 5000;
+
+    /**
+     * How long a just-completed run is reused for a duplicate invocation of the SAME CompanyIntegration.
+     * Sized only to absorb the create-time double-fire (the `IsActive` Save-hook runs the pipeline, then
+     * `IntegrationCreateConnection` calls it again milliseconds later) — short enough that a genuine,
+     * later operator-initiated re-refresh always runs fresh. Override via the
+     * `MJ_CONNECTOR_PIPELINE_COALESCE_WINDOW_MS` env var (a positive integer of milliseconds; set 0/unset
+     * to use the default). Env-based, matching the RSU env-var convention (RSU_WORK_DIR, etc.).
+     */
+    private static get COALESCE_WINDOW_MS(): number {
+        const override = Number(process.env.MJ_CONNECTOR_PIPELINE_COALESCE_WINDOW_MS);
+        return Number.isFinite(override) && override > 0 ? override : IntegrationConnectorCreationPipeline.DEFAULT_COALESCE_WINDOW_MS;
+    }
+
+    /**
+     * Public entry. De-dups the known create-time double-invocation: the connection's `IsActive`
+     * false→true Save fires the entity-server hook (which runs this pipeline WITH LLM PK inference),
+     * and the create resolver then calls it again. Both converge here, so we run the pipeline ONCE
+     * per CompanyIntegration and hand both callers the same result — no double introspect/persist/
+     * classify, no double live API calls, and the resolver still gets a real summary. A legitimate
+     * re-refresh later (outside the window) runs fresh.
+     */
     public async Run(opts: ConnectorCreationPipelineOptions): Promise<ConnectorCreationPipelineResult> {
+        const ciID = opts.CompanyIntegration?.ID;
+        if (!ciID) return this.runInternal(opts); // no key to de-dup on — run directly
+
+        const cls = IntegrationConnectorCreationPipeline;
+        const inFlight = cls.inFlightRuns.get(ciID);
+        if (inFlight) return inFlight; // a concurrent run is already going — share it
+
+        cls.pruneRecentRuns();
+        const recent = cls.recentRuns.get(ciID);
+        if (recent) return recent.result; // a run just completed (within the window) — reuse it
+
+        const promise = this.runInternal(opts);
+        cls.inFlightRuns.set(ciID, promise);
+        try {
+            const result = await promise;
+            cls.recentRuns.set(ciID, { result, at: Date.now() });
+            return result;
+        } finally {
+            cls.inFlightRuns.delete(ciID);
+        }
+    }
+
+    /** Drops recent-run entries older than the coalesce window so the map stays bounded. */
+    private static pruneRecentRuns(): void {
+        const now = Date.now();
+        for (const [key, entry] of IntegrationConnectorCreationPipeline.recentRuns) {
+            if (now - entry.at >= IntegrationConnectorCreationPipeline.COALESCE_WINDOW_MS) {
+                IntegrationConnectorCreationPipeline.recentRuns.delete(key);
+            }
+        }
+    }
+
+    private async runInternal(opts: ConnectorCreationPipelineOptions): Promise<ConnectorCreationPipelineResult> {
         const runID = opts.RunID ?? IntegrationProgressEmitter.newRunID('connector');
         const manifest: IntegrationRunManifest = {
             runID,

--- a/packages/Integration/engine/src/IntegrationEngine.ts
+++ b/packages/Integration/engine/src/IntegrationEngine.ts
@@ -31,14 +31,19 @@ import type {
     IntegrationSyncOptions,
     EntityMapSyncResult,
     SyncProgressSnapshot,
+    SchemaPromotionResult,
+    PostSyncSchemaPromotionCallback,
 } from './types.js';
-import { ClassifyError } from './types.js';
+import { ClassifyError, IsRetryableError } from './types.js';
+import { WithRetry } from './RetryRunner.js';
+import { WithTimeout, DEFAULT_OPERATION_TIMEOUTS } from './BaseIntegrationConnector.js';
 import { ConnectorFactory } from './ConnectorFactory.js';
 import { FieldMappingEngine } from './FieldMappingEngine.js';
 import { MatchEngine } from './MatchEngine.js';
 import { WatermarkService } from './WatermarkService.js';
 import { SyncLogger } from './SyncLogger.js';
 import { CONTENT_HASH_COLUMN, computeContentHash } from './ContentHash.js';
+import { CUSTOM_OVERFLOW_COLUMN, hasUnmappedFields } from './CustomOverflow.js';
 import { partitionRecords, partitionRollupHash, diffPartitions, partitionKeyForIdentity } from './HashDiff.js';
 import { RateLimiter } from './RateLimiter.js';
 import { AdaptiveConcurrencyController, RunAdaptive } from './AdaptiveConcurrency.js';
@@ -48,6 +53,41 @@ import type { BaseIntegrationConnector, FetchContext, FetchBatchResult } from '.
 
 /** Default batch size for fetching records from external systems */
 const DEFAULT_BATCH_SIZE = 200;
+
+/**
+ * Hard ceiling on records the opt-in partitionReconcile (Merkle) mode may accumulate in RAM
+ * before it fails loud rather than risking an OOM crash. That mode buffers the ENTIRE fetched
+ * set (see applyViaPartitionReconcile) — intended for watermark-less small/medium objects. This
+ * cap is generous (well above the "tens of thousands" the mode targets); crossing it means the
+ * object is too large for partitionReconcile and the operator should disable it (the default
+ * streaming path has no such limit). Turns a silent OOM into an actionable error.
+ */
+const PARTITION_RECONCILE_MAX_ACCUMULATION = 500_000;
+
+/**
+ * Ceiling on the in-memory set of fetched ExternalIDs used for full-sync orphan detection. Past this,
+ * we stop tracking + skip the orphan sweep for that entity-map (surfaced as a SyncWarning) rather than
+ * grow the set unbounded and risk OOM on a multi-million-row full sync. Incremental syncs don't build
+ * this set; only full-sync / partition-reconcile do. Generous on purpose — most objects never hit it.
+ */
+const ORPHAN_DETECTION_MAX_IDS = 1_000_000;
+
+/**
+ * Cap on the retained per-record error SAMPLE in the aggregate run result. RecordsErrored keeps the
+ * true count; only this many error objects are kept for diagnostics (FinalizeRun persists the first
+ * 100). Prevents a multi-million-row failing run from holding every error object in RAM.
+ */
+const MAX_AGGREGATE_ERRORS = 200;
+
+/**
+ * In-memory safety ceiling for a FULL push (every row of an MJ entity is loaded into RAM before
+ * pushing). Past this we fail loud + actionable instead of risking an OOM. Env-overridable for the
+ * rare legitimate large full push. The proper long-term fix is a streaming/keyset push.
+ */
+const FULL_PUSH_MAX_RECORDS = (() => {
+    const override = Number(process.env.MJ_INTEGRATION_FULL_PUSH_MAX_RECORDS);
+    return Number.isFinite(override) && override > 0 ? Math.floor(override) : 1_000_000;
+})();
 
 /**
  * Server-side Integration Engine.
@@ -120,6 +160,19 @@ export class IntegrationEngine extends BaseSingleton<IntegrationEngine> {
 
     /** Optional provider override; falls back to Metadata.Provider when not set. */
     private _provider?: IMetadataProvider;
+
+    /**
+     * Server-registered hook for post-sync custom-column promotion (gaps.md §2 / M2). The
+     * engine has no dependency on RSU/CodeGen — the server registers an implementation via
+     * {@link SetPostSyncSchemaPromotionCallback}. Undefined ⇒ promotion is simply not wired
+     * (e.g. unit tests, non-server hosts), which is a no-op.
+     */
+    private postSyncSchemaPromotionCallback?: PostSyncSchemaPromotionCallback;
+
+    /** Registers (or clears, with undefined) the post-sync custom-column promotion hook. */
+    public SetPostSyncSchemaPromotionCallback(callback: PostSyncSchemaPromotionCallback | undefined): void {
+        this.postSyncSchemaPromotionCallback = callback;
+    }
 
     /** Returns the active provider — explicit override if set, otherwise the global default. */
     protected get ProviderToUse(): IMetadataProvider {
@@ -419,6 +472,22 @@ export class IntegrationEngine extends BaseSingleton<IntegrationEngine> {
                 result.ErrorMessage = `Sync completed with ${result.RecordsErrored} error(s)`;
             }
             await this.FinalizeRun(run, result, contextUser, onNotification, abortSignal?.aborted);
+            // Post-sync custom-column promotion (gaps.md §2 / M2). Self-gated server-side: a
+            // customs-free sync does no work. Skipped for an aborted run. Never throws into the sync.
+            if (!abortSignal?.aborted) {
+                result.SchemaUpdate = await this.invokePostSyncPromotionSafe(companyIntegrationID, contextUser, result);
+                // Restart-signal (M3): when columns were promoted, surface it on the structured
+                // stream so a watching client (IntegrationTailRunEvents) knows an MJAPI restart is
+                // needed to expose the new columns over GraphQL — read as intentional, not a crash.
+                // No new columns ⇒ no event ⇒ no restart (the convergence/1× guarantee). The new
+                // columns are already usable by the NEXT sync without a restart (metadata refreshed).
+                if (result.SchemaUpdate?.SchemaUpdatePending) {
+                    logger.emit('sync.schema_update', {
+                        columnsAdded: result.SchemaUpdate.ColumnsAdded,
+                        restartRequiredForGraphQL: true,
+                    });
+                }
+            }
             const summary = this.buildSyncResultBody(config.companyIntegration.Integration, result);
             logger.emit('sync.run.complete', {
                 success: result.Success && result.RecordsErrored === 0,
@@ -690,8 +759,8 @@ export class IntegrationEngine extends BaseSingleton<IntegrationEngine> {
         // Per-map processing. Extracted so it can run sequentially OR concurrently within a
         // dependency layer. Aggregate mutations run when each promise resolves — atomic under
         // single-threaded async, so concurrent maps in a layer are safe.
-        const processOne = async (entityMap: ICompanyIntegrationEntityMap): Promise<boolean> => {
-            if (abortSignal?.aborted) return true;
+        const processOne = async (entityMap: ICompanyIntegrationEntityMap): Promise<{ ok: boolean; throttled: boolean }> => {
+            if (abortSignal?.aborted) return { ok: true, throttled: false };
             const i = globalIndex++;
             const mapStartTime = Date.now();
             const direction = config.syncDirection ?? entityMap.SyncDirection ?? 'Pull';
@@ -723,7 +792,7 @@ export class IntegrationEngine extends BaseSingleton<IntegrationEngine> {
                     recordsErrored: mapResult.RecordsErrored,
                 });
                 this.checkSecondLayerEmpty(entityMap, mapResult, depGraph, processedByIoId, ioNameById, ioCategoryById, logger);
-                return mapResult.Success;
+                return { ok: mapResult.Success, throttled: mapResult.Throttled === true };
             } catch (err) {
                 const objName = entityMap.ExternalObjectName ?? entityMap.ID;
                 const errMsg = err instanceof Error ? err.message : String(err);
@@ -758,7 +827,7 @@ export class IntegrationEngine extends BaseSingleton<IntegrationEngine> {
                     RecordsSkipped: 0,
                     Duration: Date.now() - mapStartTime,
                 });
-                return false;
+                return { ok: false, throttled: ClassifyError(err).Code === 'RATE_LIMIT_EXCEEDED' };
             }
         };
 
@@ -774,7 +843,8 @@ export class IntegrationEngine extends BaseSingleton<IntegrationEngine> {
         // MaxConcurrencyHint on clean maps, cut on map failure. With no hint and default
         // syncConcurrency=1, min=max=1 → strictly sequential (unchanged behavior). The per-request
         // RateLimiter is the backstop that keeps the source within its real rate as parallelism rises.
-        const maxConcurrency = Math.max(concurrency, config.connector.MaxConcurrencyHint ?? concurrency);
+        // Configuration override (IntegrationSetSyncConfig) wins over the connector's MaxConcurrencyHint constant.
+        const maxConcurrency = Math.max(concurrency, this.getConfigOverrides(config).maxConcurrency ?? config.connector.MaxConcurrencyHint ?? concurrency);
         const concController = new AdaptiveConcurrencyController({ start: concurrency, min: 1, max: maxConcurrency });
 
         // Second-layer silent-empty detection state (see checkSecondLayerEmpty): a per-IO running
@@ -792,6 +862,20 @@ export class IntegrationEngine extends BaseSingleton<IntegrationEngine> {
             }
         }
 
+        // §4 OPT-IN: cross-layer pipelining overlaps independent DAG branches (a child starts when ITS
+        // parents finish, not when the whole parent layer does). Default OFF → the strict layer-barrier
+        // loop below (unchanged). Falls back to the barrier if the per-map dependency graph can't build.
+        const mapDeps = this.getCrossLayerPipelineEnabled(config) ? this.buildMapDependencies(config) : null;
+        if (mapDeps) {
+            logger?.emit('sync.config.loaded', { crossLayerPipeline: true, totalMaps });
+            await this.runPipelinedDAG(config.entityMaps, mapDeps, concController, processOne, abortSignal);
+            if (abortSignal?.aborted) {
+                aggregate.Success = false;
+                aggregate.ErrorMessage = 'Sync cancelled by user';
+            }
+            return aggregate;
+        }
+
         for (const layer of layers) {
             if (abortSignal?.aborted) {
                 console.log(`[IntegrationEngine] Sync cancelled (${globalIndex}/${totalMaps} maps processed)`);
@@ -801,12 +885,12 @@ export class IntegrationEngine extends BaseSingleton<IntegrationEngine> {
             }
             await RunAdaptive(layer, async (m) => {
                 if (abortSignal?.aborted) return { ok: true, throttled: false };
-                const ok = await processOne(m);
-                // A data failure (FK/validation/transform) must NOT cut the in-flight cap — only a
-                // real source throttle should, and the per-request RateLimiter already backs off on
-                // 429s. We have no clean per-map 429 signal here (fetch 429s break the loop), so we
-                // never mark `throttled` from a plain failure; concurrency only ramps UP on success.
-                return { ok, throttled: false };
+                const { ok, throttled } = await processOne(m);
+                // §5 Gap 2: a real source throttle (RATE_LIMIT_EXCEEDED on fetch) now also cuts the
+                // per-layer in-flight cap, not just the per-request token bucket. A plain data failure
+                // (FK/validation/transform) carries throttled=false, so concurrency only drops on an
+                // actual rate-limit signal — never on ordinary record errors.
+                return { ok, throttled };
             }, concController);
         }
 
@@ -968,6 +1052,100 @@ export class IntegrationEngine extends BaseSingleton<IntegrationEngine> {
         return 1;
     }
 
+    /**
+     * §4 OPT-IN cross-layer pipelining (CompanyIntegration.Configuration {"crossLayerPipeline": true}).
+     * Default OFF → strict layer-barrier execution (unchanged). When ON, a child map starts as soon as
+     * ITS OWN parents finish, instead of waiting for the entire parent LAYER — overlapping independent
+     * branches of the DAG. Correctness is preserved because a child still gates on parent COMPLETION
+     * (the parent's row writes are committed and its record-count recorded before the child begins).
+     * Off by default because the throughput win is only measurable against a live run.
+     */
+    private getCrossLayerPipelineEnabled(config: RunConfiguration): boolean {
+        try {
+            const raw = config.companyIntegration.Configuration;
+            if (raw) return (JSON.parse(raw) as { crossLayerPipeline?: boolean }).crossLayerPipeline === true;
+        } catch { /* fall through */ }
+        return false;
+    }
+
+    /**
+     * Per-map parent dependencies (entityMap.ID → set of parent entityMap.IDs) from the FK graph.
+     * Used by the §4 pipelined scheduler. Returns null when the graph can't be resolved (caller then
+     * falls back to layer-barrier execution).
+     */
+    private buildMapDependencies(config: RunConfiguration): Map<string, Set<string>> | null {
+        const graph = this.computeSelectedDependencyGraph(config);
+        if (!graph) return null;
+        const { mapToIoId, parentsByIoId } = graph;
+        // Invert mapToIoId: IO.ID → the maps targeting it (an IO can back more than one map).
+        const mapsByIoId = new Map<string, string[]>();
+        for (const [mapId, ioId] of mapToIoId) {
+            if (!mapsByIoId.has(ioId)) mapsByIoId.set(ioId, []);
+            mapsByIoId.get(ioId)!.push(mapId);
+        }
+        const deps = new Map<string, Set<string>>();
+        for (const m of config.entityMaps) {
+            const ioId = mapToIoId.get(m.ID);
+            const parentMapIds = new Set<string>();
+            if (ioId) {
+                for (const parentIoId of parentsByIoId.get(ioId) ?? []) {
+                    for (const pm of mapsByIoId.get(parentIoId) ?? []) {
+                        if (pm !== m.ID) parentMapIds.add(pm);
+                    }
+                }
+            }
+            deps.set(m.ID, parentMapIds);
+        }
+        return deps;
+    }
+
+    /**
+     * §4 dependency-aware scheduler: runs every map concurrently, but each map first awaits its
+     * parents' completion, THEN gates on the live AIMD cap before doing work. Deadlock-free even at
+     * cap=1: a map awaiting parents does NOT hold a concurrency slot (the slot is acquired only AFTER
+     * the parent-await resolves), so parents always get to run. The cap gate counts only ACTIVE work.
+     */
+    private async runPipelinedDAG(
+        maps: ICompanyIntegrationEntityMap[],
+        mapDeps: Map<string, Set<string>>,
+        controller: AdaptiveConcurrencyController,
+        process: (m: ICompanyIntegrationEntityMap) => Promise<{ ok: boolean; throttled: boolean }>,
+        abortSignal?: AbortSignal,
+    ): Promise<void> {
+        const resolvers = new Map<string, () => void>();
+        const donePromises = new Map<string, Promise<void>>();
+        for (const m of maps) donePromises.set(m.ID, new Promise<void>(r => resolvers.set(m.ID, r)));
+        const inFlight = { count: 0 };
+
+        const scheduleOne = async (m: ICompanyIntegrationEntityMap): Promise<void> => {
+            try {
+                const deps = mapDeps.get(m.ID);
+                if (deps && deps.size > 0) {
+                    await Promise.all([...deps].map(d => donePromises.get(d)).filter((p): p is Promise<void> => !!p));
+                }
+                if (abortSignal?.aborted) return;
+                // Gate on the LIVE cap (yield on a macrotask so in-flight I/O isn't starved — mirrors
+                // adaptiveWorker). Only ACTIVE work counts toward the cap; waiting-on-parents does not.
+                while (inFlight.count >= controller.Cap) {
+                    await new Promise<void>(r => setTimeout(r, 0));
+                    if (abortSignal?.aborted) return;
+                }
+                inFlight.count++;
+                try {
+                    const outcome = await process(m);
+                    if (outcome.throttled || !outcome.ok) controller.OnThrottleOrError();
+                    else controller.OnSuccess();
+                } finally {
+                    inFlight.count--;
+                }
+            } finally {
+                resolvers.get(m.ID)!();   // unblock children whether we ran, aborted, or threw
+            }
+        };
+
+        await Promise.all(maps.map(m => scheduleOne(m)));
+    }
+
     /** Runs `fn` over items with at most `cap` concurrent executions. cap&lt;=1 → strictly sequential. */
     private async runBounded<T>(items: T[], cap: number, fn: (item: T) => Promise<void>): Promise<void> {
         if (cap <= 1) {
@@ -1018,19 +1196,48 @@ export class IntegrationEngine extends BaseSingleton<IntegrationEngine> {
      * the same vendor have independent budgets and must not share one bucket. {@link reportRateOutcome}
      * feeds 429s/successes back so the rate auto-tunes (AIMD).
      */
+    /**
+     * Per-connection numeric tuning overrides from CompanyIntegration.Configuration — the typed
+     * fields the IntegrationSetSyncConfig GraphQL mutation writes. These let an operator override
+     * the connector's code-constant rate limit / concurrency / discovery budget per connection,
+     * via the API, instead of editing code. Only positive finite values are honored.
+     */
+    private getConfigOverrides(config: RunConfiguration): {
+        maxConcurrency?: number; rateLimitTokensPerSec?: number; rateLimitBurst?: number; discoveryTimeBudgetMs?: number;
+    } {
+        try {
+            const raw = config.companyIntegration.Configuration;
+            if (!raw) return {};
+            const p = JSON.parse(raw) as Record<string, unknown>;
+            const num = (v: unknown) => (typeof v === 'number' && Number.isFinite(v) && v > 0 ? Math.floor(v) : undefined);
+            return {
+                maxConcurrency: num(p.maxConcurrency),
+                rateLimitTokensPerSec: typeof p.rateLimitTokensPerSec === 'number' && p.rateLimitTokensPerSec > 0 ? p.rateLimitTokensPerSec : undefined,
+                rateLimitBurst: num(p.rateLimitBurst),
+                discoveryTimeBudgetMs: num(p.discoveryTimeBudgetMs),
+            };
+        } catch { return {}; }
+    }
+
     private getRateLimiter(config: RunConfiguration): RateLimiter {
         const key = config.companyIntegration.ID as string;
         let rl = this._rateLimiters.get(key);
         if (!rl) {
             const policy = config.connector.RateLimitPolicy;
+            const overrides = this.getConfigOverrides(config);
             const spacingMs = this.getRequestSpacingMs(config);
-            const tokensPerSec = policy?.TokensPerSec ?? (spacingMs > 0 ? 1000 / spacingMs : 10);
+            // Configuration override wins over the connector's code constant (the "not just constants" goal).
+            const tokensPerSec = overrides.rateLimitTokensPerSec ?? policy?.TokensPerSec ?? (spacingMs > 0 ? 1000 / spacingMs : 10);
             rl = new RateLimiter({
                 TokensPerSec: tokensPerSec,
                 // Floor Burst at 1 so a slow-spacing integration (fractional tokens/sec) still gets
                 // one immediate token instead of stalling ~1s on the very first request.
-                Burst: Math.max(1, policy?.Burst ?? Math.ceil(tokensPerSec)),
+                Burst: Math.max(1, overrides.rateLimitBurst ?? policy?.Burst ?? Math.ceil(tokensPerSec)),
                 ThrottleBackoffFactor: policy?.ThrottleBackoffFactor,
+                // Thread the connector's recovery tuning through; RateLimiter applies its own sane
+                // defaults (ramp = rate/10, floor = rate/20) when these are omitted.
+                SuccessRampPerCall: policy?.SuccessRampPerCall,
+                MinTokensPerSec: policy?.MinTokensPerSec,
             });
             this._rateLimiters.set(key, rl);
         }
@@ -1217,8 +1424,11 @@ export class IntegrationEngine extends BaseSingleton<IntegrationEngine> {
         let batchCount = 0;
         let previousBatchFingerprint: string | undefined;
         let fetchCompletedCleanly = true; // flipped to false if fetch aborted or errored mid-way
+        let consecutiveEmptyBatches = 0;  // P3-D: detect a connector that pages empty-but-HasMore forever
         const MAX_BATCHES_PER_MAP = 5000;
+        const EMPTY_BATCH_WARN_THRESHOLD = 5; // warn once after this many empty-but-HasMore batches in a row
         const fetchedExternalIDs = new Set<string>(); // Track all IDs seen during this pull for orphan detection
+        let orphanTrackingOverflowed = false; // set if the ID set exceeds ORPHAN_DETECTION_MAX_IDS → skip the sweep, don't OOM
         const accumulatedMapped: MappedRecord[] = []; // partition-reconcile mode: collect mapped records, apply post-loop
 
         while (hasMore) {
@@ -1261,7 +1471,25 @@ export class IntegrationEngine extends BaseSingleton<IntegrationEngine> {
             const fetchStart = Date.now();
             try {
                 await this.rateLimit(config);
-                batch = await config.connector.FetchChanges(ctx);
+                // Resilient fetch: bound each attempt with a timeout (a hung vendor API must not
+                // hold the sync lock forever) and retry only transient errors (network/throttle/DB).
+                // A non-retryable error (auth, 4xx, parse) throws immediately as before.
+                batch = await WithRetry(
+                    () => WithTimeout(
+                        config.connector.FetchChanges(ctx),
+                        DEFAULT_OPERATION_TIMEOUTS.FetchChangesMs,
+                        `FetchChanges(${entityMap.ExternalObjectName})`,
+                    ),
+                    undefined,
+                    (err) => IsRetryableError(ClassifyError(err).Code),
+                    (attempt, err, delayMs) => logger?.emit('sync.fetch.retry', {
+                        externalObjectName: entityMap.ExternalObjectName,
+                        batchIndex: batchCount,
+                        attempt,
+                        delayMs,
+                        error: err instanceof Error ? err.message : String(err),
+                    }),
+                );
                 this.reportRateOutcome(config);   // clean fetch → ramp the adaptive rate back up
                 // §10: connector type-driven post-processing hook (default no-op) — enforce/normalize
                 // record values to their resolved formats before mapping + write.
@@ -1271,8 +1499,12 @@ export class IntegrationEngine extends BaseSingleton<IntegrationEngine> {
             } catch (fetchErr) {
                 const errMsg = fetchErr instanceof Error ? fetchErr.message : String(fetchErr);
                 // A throttle (429 / rate-limit) backs the adaptive limiter off (honoring Retry-After);
-                // other errors don't touch the rate.
-                if (ClassifyError(fetchErr).Code === 'RATE_LIMIT_EXCEEDED') this.reportRateOutcome(config, fetchErr);
+                // other errors don't touch the rate. §5 Gap 2: also flag the map result so the per-layer
+                // AIMD controller reduces in-flight concurrency, not just the per-request token bucket.
+                if (ClassifyError(fetchErr).Code === 'RATE_LIMIT_EXCEEDED') {
+                    this.reportRateOutcome(config, fetchErr);
+                    result.Throttled = true;
+                }
                 console.error(`[IntegrationEngine] FetchChanges error for ${entityMap.ExternalObjectName}: ${errMsg}`);
                 logger?.emit('sync.record.error', {
                     phase: 'fetch',
@@ -1326,8 +1558,17 @@ export class IntegrationEngine extends BaseSingleton<IntegrationEngine> {
                 previousBatchFingerprint = fingerprint;
             }
 
-            for (const rec of batch.Records) {
-                fetchedExternalIDs.add(rec.ExternalID);
+            if (!orphanTrackingOverflowed) {
+                for (const rec of batch.Records) {
+                    fetchedExternalIDs.add(rec.ExternalID);
+                }
+                // OOM guard: a multi-million-row full sync would grow this set without bound. Past the
+                // ceiling, drop it + flag so orphan detection is skipped (a SyncWarning is emitted below)
+                // rather than risk crashing the run.
+                if (fetchedExternalIDs.size > ORPHAN_DETECTION_MAX_IDS) {
+                    orphanTrackingOverflowed = true;
+                    fetchedExternalIDs.clear();
+                }
             }
 
             const mapped = this.fieldMappingEngine.Apply(
@@ -1335,7 +1576,20 @@ export class IntegrationEngine extends BaseSingleton<IntegrationEngine> {
             );
             // Partition (Merkle) reconcile defers match + apply: accumulate mapped records now; the
             // partition-diff + selective apply runs once after the full fetch (applyViaPartitionReconcile).
-            if (partitionReconcile) accumulatedMapped.push(...mapped);
+            if (partitionReconcile) {
+                accumulatedMapped.push(...mapped);
+                // OOM guard: this mode buffers the ENTIRE fetched set in RAM. Past a generous ceiling,
+                // fail loud (caught by the per-map error path → other maps continue) instead of crashing
+                // the whole run with an OOM. The default streaming path has no such limit.
+                if (accumulatedMapped.length > PARTITION_RECONCILE_MAX_ACCUMULATION) {
+                    throw new Error(
+                        `partitionReconcile accumulated ${accumulatedMapped.length} records for ` +
+                        `${entityMap.ExternalObjectName} (cap ${PARTITION_RECONCILE_MAX_ACCUMULATION}). This mode ` +
+                        `buffers the whole set in RAM and is unsafe at this size — disable Configuration.partitionReconcile ` +
+                        `for this object to stream via per-record content-hash instead.`
+                    );
+                }
+            }
             const resolved = partitionReconcile
                 ? []
                 : await this.matchEngine.Resolve(mapped, entityMap, fieldMaps, contextUser);
@@ -1427,6 +1681,23 @@ export class IntegrationEngine extends BaseSingleton<IntegrationEngine> {
                     await this.watermarkService.SaveKeysetPosition(entityMapID, currentAfterKey, contextUser);
                 }
             }
+            // P3-D: a connector returning empty pages with HasMore=true would otherwise spin silently
+            // to MAX_BATCHES_PER_MAP. Surface a structured warning once the empty streak crosses the
+            // threshold so the connector bug is visible, not buried.
+            if (batch.Records.length === 0 && batch.HasMore === true) {
+                consecutiveEmptyBatches++;
+                if (consecutiveEmptyBatches === EMPTY_BATCH_WARN_THRESHOLD) {
+                    logger?.warning(
+                        entityMap.ExternalObjectName ?? entityMap.ID,
+                        'CONSECUTIVE_EMPTY_BATCHES',
+                        `'${entityMap.ExternalObjectName}' returned ${EMPTY_BATCH_WARN_THRESHOLD} empty batches in a row while still reporting HasMore=true ` +
+                        `(batch ${batchCount}/${MAX_BATCHES_PER_MAP}). Likely a connector pagination bug (cursor not advancing / HasMore stuck true).`,
+                        { batchCount, consecutiveEmptyBatches },
+                    );
+                }
+            } else {
+                consecutiveEmptyBatches = 0;
+            }
             hasMore = batch.HasMore === true; // Explicit boolean check — prevents truthy undefined from looping
         }
 
@@ -1491,6 +1762,17 @@ export class IntegrationEngine extends BaseSingleton<IntegrationEngine> {
         if ((config.fullSync || partitionReconcile) && fetchedExternalIDs.size > 0 && fetchCompletedCleanly) {
             await this.DeleteOrphanedRecords(
                 config.companyIntegration, entityMap, fetchedExternalIDs, result, contextUser, logger
+            );
+        } else if (orphanTrackingOverflowed && fetchCompletedCleanly) {
+            // We deliberately stopped tracking IDs to avoid OOM — orphan/delete detection can't run
+            // safely this pass (a partial set would delete live records). Surface it, don't hide it.
+            logger?.warning(
+                entityMap.ExternalObjectName ?? entityMap.ID,
+                'ORPHAN_DETECTION_SKIPPED_TOO_LARGE',
+                `'${entityMap.ExternalObjectName}' returned more than ${ORPHAN_DETECTION_MAX_IDS.toLocaleString()} records, ` +
+                `so orphan/delete detection was skipped this run to avoid excessive memory use. Records were synced normally; ` +
+                `deletions in the source will not be reflected until a smaller/incremental run or a raised cap.`,
+                { cap: ORPHAN_DETECTION_MAX_IDS },
             );
         }
 
@@ -1705,13 +1987,28 @@ export class IntegrationEngine extends BaseSingleton<IntegrationEngine> {
     ): Promise<Array<{ RecordID: string; Type: string; ChangedAt: string; Fields: Record<string, unknown> }>> {
         const rv = new RunView();
 
-        // Load all records from the MJ entity
+        // Load all records from the MJ entity. OOM SAFETY VALVE: a full push materializes every row of
+        // the MJ entity in RAM. Past a generous ceiling, fail LOUD + actionable (caught by the per-map
+        // error path → other maps continue) rather than risk an OOM that kills the whole run. A genuine
+        // full push of a multi-million-row entity should use incremental push or raise the limit; we do
+        // NOT silently partial-push (that would advance the watermark past unsent rows → dropped data).
+        // NOTE: a true streaming/keyset push refactor is the proper long-term fix; this guard makes the
+        // failure mode safe in the meantime without touching the delicate push-watermark clamp logic.
         const allResult = await rv.RunView<Record<string, unknown>>({
             EntityName: entityMap.Entity,
             ResultType: 'simple',
+            MaxRows: FULL_PUSH_MAX_RECORDS + 1,   // +1 so we can detect "exceeded" vs "exactly at cap"
         }, contextUser);
 
         if (!allResult.Success || allResult.Results.length === 0) return [];
+        if (allResult.Results.length > FULL_PUSH_MAX_RECORDS) {
+            throw new Error(
+                `Full push of '${entityMap.Entity}' exceeds the in-memory safety limit of ` +
+                `${FULL_PUSH_MAX_RECORDS.toLocaleString()} records. A full push loads every row into memory; ` +
+                `use incremental push (set a push watermark) or raise MJ_INTEGRATION_FULL_PUSH_MAX_RECORDS. ` +
+                `Refusing to partial-push (that would advance the watermark past unsent rows and drop data).`
+            );
+        }
 
         // Load existing record maps to know which records already exist externally
         const mapResult = await rv.RunView<{ EntityRecordID: string; ExternalSystemRecordID: string }>({
@@ -1992,7 +2289,7 @@ export class IntegrationEngine extends BaseSingleton<IntegrationEngine> {
                 resolution,
             });
             if (manualConflict) {
-                await this.markConflictOnMJRecord(change.RecordID, entityMap, conflictFields, contextUser);
+                await this.markConflictOnMJRecord(change.RecordID, entityMap, conflictFields, contextUser, logger);
                 return { action: 'skip', attributes: {} };
             }
         }
@@ -2023,7 +2320,8 @@ export class IntegrationEngine extends BaseSingleton<IntegrationEngine> {
         mjRecordID: string,
         entityMap: ICompanyIntegrationEntityMap,
         conflictFields: string[],
-        contextUser: UserInfo
+        contextUser: UserInfo,
+        logger?: SyncLogger
     ): Promise<void> {
         try {
             const md = this.ProviderToUse;
@@ -2038,9 +2336,24 @@ export class IntegrationEngine extends BaseSingleton<IntegrationEngine> {
             if (hasField('__mj_integration_SyncMessage')) {
                 entity.Set('__mj_integration_SyncMessage', `Bidirectional conflict: external changed ${conflictFields.join(', ')} since last sync; awaiting manual resolution.`);
             }
-            await entity.Save();
-        } catch {
-            // best-effort
+            // Surface a failed conflict-mark: the engine thinks the row is quarantined, but without the
+            // marker the operator has no signal. A silent failure here leaves the record in limbo.
+            const ok = await entity.Save();
+            if (!ok) {
+                logger?.warning(
+                    entityMap.ExternalObjectName ?? entityMap.Entity ?? entityMap.ID,
+                    'CONFLICT_MARK_FAILED',
+                    `Could not mark MJ record ${mjRecordID} in-conflict: ${entity.LatestResult?.CompleteMessage ?? 'Save() returned false'}`,
+                    { mjRecordID, conflictFields },
+                );
+            }
+        } catch (markErr) {
+            logger?.warning(
+                entityMap.ExternalObjectName ?? entityMap.Entity ?? entityMap.ID,
+                'CONFLICT_MARK_FAILED',
+                `Could not mark MJ record ${mjRecordID} in-conflict: ${markErr instanceof Error ? markErr.message : String(markErr)}`,
+                { mjRecordID, conflictFields },
+            );
         }
     }
 
@@ -2770,25 +3083,42 @@ export class IntegrationEngine extends BaseSingleton<IntegrationEngine> {
         if (!entityInfo) return undefined;
         if (!entityInfo.Fields.some(f => f.Name === CONTENT_HASH_COLUMN)) return undefined;
         const pkFields = entityInfo.PrimaryKeys ?? [];
-        if (pkFields.length !== 1) return undefined; // single-PK fast path only
-        const pk = pkFields[0].Name;
+        if (pkFields.length === 0) return undefined;
+        // Map keys must match `record.MatchedMJRecordID`, which is the PK value(s) joined by '|' in
+        // PrimaryKeys order (single value for single-PK, "v1|v2" for composite — see MatchEngine).
+        const pkNames = pkFields.map(f => f.Name);
 
         try {
-            const escaped = ids.map(id => `'${String(id).replace(/'/g, "''")}'`).join(',');
             const rv = new RunView();
+            let extraFilter: string;
+            if (pkNames.length === 1) {
+                // Single-PK fast path: WHERE pk IN (...).
+                const escaped = ids.map(id => `'${String(id).replace(/'/g, "''")}'`).join(',');
+                extraFilter = `${pkNames[0]} IN (${escaped})`;
+            } else {
+                // Composite-PK: each MatchedMJRecordID is "v1|v2|..." in PrimaryKeys order. Build
+                // an OR of per-record (pk1='v1' AND pk2='v2') clauses — bounded by batch size.
+                // Plain (unbracketed) identifiers → dialect-agnostic (SS brackets break Postgres).
+                extraFilter = ids.map(mid => {
+                    const parts = String(mid).split('|');
+                    return '(' + pkNames.map((name, i) =>
+                        `${name} = '${String(parts[i] ?? '').replace(/'/g, "''")}'`).join(' AND ') + ')';
+                }).join(' OR ');
+            }
             const res = await rv.RunView<Record<string, string>>({
                 EntityName: entityName,
-                Fields: [pk, CONTENT_HASH_COLUMN],
-                ExtraFilter: `${pk} IN (${escaped})`,
+                Fields: [...pkNames, CONTENT_HASH_COLUMN],
+                ExtraFilter: extraFilter,
                 ResultType: 'simple',
             }, contextUser);
             if (!res.Success) return undefined;
             const map = new Map<string, string>();
             for (const row of res.Results) {
-                const id = row[pk];
+                // Re-key by the same '|'-join the matcher produced, so the lookup in ApplySingleRecord hits.
+                const key = pkNames.map(n => row[n] ?? '').join('|');
                 const hash = row[CONTENT_HASH_COLUMN];
-                if (id != null && typeof hash === 'string' && hash.length > 0) {
-                    map.set(String(id), hash);
+                if (typeof hash === 'string' && hash.length > 0) {
+                    map.set(key, hash);
                 }
             }
             return map;
@@ -3072,6 +3402,14 @@ export class IntegrationEngine extends BaseSingleton<IntegrationEngine> {
         if (hasField(CONTENT_HASH_COLUMN)) {
             entity.Set(CONTENT_HASH_COLUMN, computeContentHash(record.MappedFields ?? {}));
         }
+        // Custom-overflow capture (gaps.md §2): park any source keys with no field map as JSON,
+        // in THIS same row write (no extra round-trip → a customs-free sync stays byte-identical).
+        // Only written when there ARE extras; when empty, this is the signal that no post-sync RSU
+        // promotion is needed for this row. Backend staging only — never user-facing metadata until
+        // a key is promoted to a real column. No-op on tables predating the column. See CustomOverflow.
+        if (hasField(CUSTOM_OVERFLOW_COLUMN) && hasUnmappedFields(record.UnmappedFields)) {
+            entity.Set(CUSTOM_OVERFLOW_COLUMN, JSON.stringify(record.UnmappedFields));
+        }
 
         // ── Per-record sync ledger (plan §2.5) ───────────────────────────────────────
         // The external system's version token for optimistic-concurrency on bidirectional
@@ -3180,11 +3518,22 @@ export class IntegrationEngine extends BaseSingleton<IntegrationEngine> {
         detail.Action = result.RecordsCreated > 0 ? 'INSERT' : 'UPDATE';
         detail.IsSuccess = result.RecordsErrored === 0;
 
-        const detailSaved = await detail.Save();
-        if (!detailSaved) {
-            console.warn(
-                `[IntegrationEngine] Failed to save run detail for entity map ${entityMap.ID}: ` +
-                `${detail.LatestResult?.CompleteMessage ?? 'unknown error'}`
+        // Retry: this row IS the per-entity-map audit trail the GraphQL GetRun API reads. A lost save
+        // makes a working sync look like it processed zero maps. Retry transient failures before giving up.
+        try {
+            await WithRetry(
+                async () => {
+                    const ok = await detail.Save();
+                    if (!ok) throw new Error(detail.LatestResult?.CompleteMessage ?? 'detail.Save() returned false');
+                    return true;
+                },
+                { MaxAttempts: 3, InitialBackoffMs: 500, MaxBackoffMs: 5000, JitterFraction: 0.1 },
+            );
+        } catch (detailErr) {
+            console.error(
+                `[IntegrationEngine] Failed to save run detail for entity map ${entityMap.ID} after retries: ` +
+                `${detailErr instanceof Error ? detailErr.message : String(detailErr)}. ` +
+                `The run's per-map audit row is missing; GetRun will under-report processed maps.`
             );
         }
     }
@@ -3197,9 +3546,15 @@ export class IntegrationEngine extends BaseSingleton<IntegrationEngine> {
         aggregate.RecordsCreated += mapResult.RecordsCreated;
         aggregate.RecordsUpdated += mapResult.RecordsUpdated;
         aggregate.RecordsDeleted += mapResult.RecordsDeleted;
-        aggregate.RecordsErrored += mapResult.RecordsErrored;
+        aggregate.RecordsErrored += mapResult.RecordsErrored;   // true count, always exact
         aggregate.RecordsSkipped += mapResult.RecordsSkipped;
-        aggregate.Errors.push(...mapResult.Errors);
+        // Bound the retained error SAMPLE: only the first MAX_AGGREGATE_ERRORS are ever persisted
+        // (FinalizeRun slices to 100). Accumulating every per-record error across a multi-million-row
+        // failing run would hold the whole set in RAM for no gain — RecordsErrored already has the count.
+        if (aggregate.Errors.length < MAX_AGGREGATE_ERRORS && mapResult.Errors.length > 0) {
+            const room = MAX_AGGREGATE_ERRORS - aggregate.Errors.length;
+            aggregate.Errors.push(...mapResult.Errors.slice(0, room));
+        }
 
         if (mapResult.RecordsErrored > 0) {
             aggregate.Success = false;
@@ -3257,11 +3612,23 @@ export class IntegrationEngine extends BaseSingleton<IntegrationEngine> {
                 run.ErrorLog = JSON.stringify(result.Errors.slice(0, 100));
             }
         }
-        const saved = await run.Save();
-        if (!saved) {
-            console.warn(
-                `[IntegrationEngine] Failed to finalize run ${run.ID}: ` +
-                `${run.LatestResult?.CompleteMessage ?? 'unknown error'}`
+        // Retry the finalize save: a failed save leaves the run 'In Progress', which ResumeOrphanedSyncs
+        // re-queues on next startup → the whole sync re-runs (re-fetch + re-apply). Worth a few retries to
+        // make the terminal status durable. Both a thrown infra error and a `false` logical-failure retry.
+        try {
+            await WithRetry(
+                async () => {
+                    const ok = await run.Save();
+                    if (!ok) throw new Error(run.LatestResult?.CompleteMessage ?? 'run.Save() returned false');
+                    return true;
+                },
+                { MaxAttempts: 3, InitialBackoffMs: 500, MaxBackoffMs: 5000, JitterFraction: 0.1 },
+            );
+        } catch (saveErr) {
+            console.error(
+                `[IntegrationEngine] Failed to finalize run ${run.ID} after retries: ` +
+                `${saveErr instanceof Error ? saveErr.message : String(saveErr)}. ` +
+                `Run may remain 'In Progress' and be re-queued as orphaned on next startup.`
             );
         }
 
@@ -3396,6 +3763,34 @@ export class IntegrationEngine extends BaseSingleton<IntegrationEngine> {
             callback(notification);
         } catch (notifyErr) {
             console.warn('[IntegrationEngine] Notification callback threw:', notifyErr);
+        }
+    }
+
+    /**
+     * Invokes the post-sync custom-column promotion hook (gaps.md §2 / M2) without ever
+     * propagating an exception into the sync — a promotion failure must never fail a sync that
+     * already landed its data. Returns undefined when no hook is registered (a no-op host) or
+     * the hook throws. The hook is self-gated: a customs-free sync does no work.
+     */
+    private async invokePostSyncPromotionSafe(
+        companyIntegrationID: string,
+        contextUser: UserInfo,
+        result: SyncResult
+    ): Promise<SchemaPromotionResult | undefined> {
+        if (!this.postSyncSchemaPromotionCallback) return undefined;
+        try {
+            const syncedEntityNames = [
+                ...new Set((result.EntityMapResults ?? []).map(r => r.EntityName).filter(Boolean)),
+            ];
+            return await this.postSyncSchemaPromotionCallback({
+                CompanyIntegrationID: companyIntegrationID,
+                ContextUser: contextUser,
+                SyncedEntityNames: syncedEntityNames,
+                Provider: this._provider,
+            });
+        } catch (promoteErr) {
+            console.warn('[IntegrationEngine] Post-sync schema promotion callback threw:', promoteErr);
+            return undefined;
         }
     }
 

--- a/packages/Integration/engine/src/MatchEngine.ts
+++ b/packages/Integration/engine/src/MatchEngine.ts
@@ -177,7 +177,10 @@ export class MatchEngine {
                 const value = record.MappedFields[pkField.Name];
                 if (value == null) continue;
                 const escaped = String(value).replace(/'/g, "''");
-                const clause = `[${pkField.Name}] = '${escaped}'`;
+                // Plain (unbracketed) identifier — RunView resolves it per active dialect.
+                // SQL-Server `[brackets]` are a syntax error on Postgres; every other
+                // ExtraFilter in this engine uses plain names, so match that.
+                const clause = `${pkField.Name} = '${escaped}'`;
                 if (!filterClauses.includes(clause)) {
                     filterClauses.push(clause);
                 }
@@ -214,7 +217,8 @@ export class MatchEngine {
             const value = record.MappedFields[kf.DestinationFieldName];
             if (value == null) continue;
             const escaped = String(value).replace(/'/g, "''");
-            clauses.push(`[${kf.DestinationFieldName}] = '${escaped}'`);
+            // Plain (unbracketed) identifier — dialect-agnostic; see CompositePK note above.
+            clauses.push(`${kf.DestinationFieldName} = '${escaped}'`);
         }
         return clauses;
     }

--- a/packages/Integration/engine/src/StreamingDiscovery.ts
+++ b/packages/Integration/engine/src/StreamingDiscovery.ts
@@ -1,0 +1,204 @@
+/**
+ * Time-bounded streaming discovery (the final discovery abstraction).
+ *
+ * Stage-2 of `DiscoverFields` for sources with no describe endpoint: stream the source's actual
+ * records (read-only — no save, no ack) and, in ONE pass, accumulate two things:
+ *   1. the full COLUMN corpus (every key seen) + a bounded sample of values per key for typing, and
+ *   2. per-column UNIQUENESS / NULL statistics — the evidence a data-informed (not nominal) PK
+ *      decision is made from.
+ *
+ * It stops when the stream is exhausted OR a TIME BUDGET is hit — whichever comes first — and
+ * returns whatever it gathered. More rows → stronger claims; the budget guarantees discovery never
+ * runs away. Memory stays bounded regardless of row count: only the key-set + capped per-key
+ * sample-values + a capped distinct-set per key are retained (never the rows themselves).
+ *
+ * Pure + clock-injectable, so it's deterministically testable. Reuses {@link inferColumnTypeFromSamples}.
+ */
+import { inferColumnTypeFromSamples, type InferredColumnType } from './CustomColumnPromotion.js';
+
+export interface StreamDiscoveryOptions {
+    /** Wall-clock budget; once exceeded, stop and use what was gathered. Default 30s. */
+    TimeBudgetMs?: number;
+    /** Max sample values retained per column for type inference. Default 10. */
+    SampleValueCap?: number;
+    /**
+     * Max distinct values tracked per column before we give up proving uniqueness exactly. Beyond
+     * this the column is flagged `DistinctCapped` (uniqueness no longer provable from this scan, so
+     * it can't be a confident PK candidate). Bounds memory. Default 100000.
+     */
+    MaxDistinctTracked?: number;
+    /** Injectable clock (for tests). Defaults to Date.now. */
+    Now?: () => number;
+}
+
+/** Per-column evidence gathered from the stream. */
+export interface DiscoveredColumnStat {
+    Key: string;
+    /** Rows where the key was present + non-null. */
+    Occurrences: number;
+    /** Total rows scanned. */
+    TotalRows: number;
+    /** Distinct non-null values seen (exact, up to the cap). */
+    DistinctNonNull: number;
+    /** True if the distinct-cap was hit → uniqueness NOT provable from this scan. */
+    DistinctCapped: boolean;
+    /** Bounded sample of observed values (for type inference). */
+    SampleValues: unknown[];
+    /** Generously-bounded inferred type (both dialects). */
+    Inferred: InferredColumnType;
+}
+
+export interface StreamDiscoveryResult {
+    Columns: DiscoveredColumnStat[];
+    RowsScanned: number;
+    /** Why the scan ended — surfaced so a time-capped (partial) corpus is never silently treated as complete. */
+    StoppedReason: 'exhausted' | 'time-budget';
+}
+
+const DEFAULT_TIME_BUDGET_MS = 30_000;
+const DEFAULT_SAMPLE_VALUE_CAP = 10;
+const DEFAULT_MAX_DISTINCT_TRACKED = 100_000;
+
+interface ColumnAcc {
+    occurrences: number;
+    samples: unknown[];
+    distinct: Set<string>;
+    capped: boolean;
+}
+
+/**
+ * Streams records (sync or async iterable), accumulating the column corpus + uniqueness/null stats
+ * until exhaustion or the time budget. Read-only; the caller supplies whatever read-only fetch
+ * yields the records (no save, no ack happens here).
+ */
+export async function discoverFromStream(
+    records: AsyncIterable<Record<string, unknown>> | Iterable<Record<string, unknown>>,
+    opts: StreamDiscoveryOptions = {},
+): Promise<StreamDiscoveryResult> {
+    const timeBudgetMs = opts.TimeBudgetMs ?? DEFAULT_TIME_BUDGET_MS;
+    const sampleCap = opts.SampleValueCap ?? DEFAULT_SAMPLE_VALUE_CAP;
+    const distinctCap = opts.MaxDistinctTracked ?? DEFAULT_MAX_DISTINCT_TRACKED;
+    const now = opts.Now ?? (() => Date.now());
+    const start = now();
+
+    const acc = new Map<string, ColumnAcc>();
+    let totalRows = 0;
+    let stoppedReason: 'exhausted' | 'time-budget' = 'exhausted';
+
+    for await (const record of toAsyncIterable(records)) {
+        totalRows++;
+        accumulateRecord(record, acc, sampleCap, distinctCap);
+        if (now() - start > timeBudgetMs) {
+            stoppedReason = 'time-budget';
+            break;
+        }
+    }
+
+    const columns: DiscoveredColumnStat[] = [...acc.entries()].map(([key, e]) => ({
+        Key: key,
+        Occurrences: e.occurrences,
+        TotalRows: totalRows,
+        DistinctNonNull: e.distinct.size,
+        DistinctCapped: e.capped,
+        SampleValues: e.samples,
+        Inferred: inferColumnTypeFromSamples(e.samples),
+    }));
+    return { Columns: columns, RowsScanned: totalRows, StoppedReason: stoppedReason };
+}
+
+/** Folds one record into the accumulator — O(columns), bounded memory. */
+function accumulateRecord(
+    record: Record<string, unknown>,
+    acc: Map<string, ColumnAcc>,
+    sampleCap: number,
+    distinctCap: number,
+): void {
+    for (const [key, value] of Object.entries(record)) {
+        let e = acc.get(key);
+        if (!e) {
+            e = { occurrences: 0, samples: [], distinct: new Set(), capped: false };
+            acc.set(key, e);
+        }
+        if (value === null || value === undefined) continue;
+        e.occurrences++;
+        if (e.samples.length < sampleCap) e.samples.push(value);
+        if (!e.capped) {
+            if (e.distinct.size < distinctCap) e.distinct.add(stableValueKey(value));
+            else e.capped = true;
+        }
+    }
+}
+
+/** Options for the data-informed PK pick. */
+export interface PkPickOptions {
+    /**
+     * Minimum rows scanned before a unique+non-null column is trusted as a PK (statistical
+     * significance — uniqueness over a tiny sample is not evidence). Default 50.
+     */
+    MinRowsForSignificance?: number;
+    /** A naming-rank tiebreaker, used ONLY to choose among multiple equally-unique columns. */
+    NameRank?: (columnName: string) => number;
+}
+
+/** The data-informed PK verdict (statistics-first). */
+export interface PkStatVerdict {
+    /** The chosen PK column, or null when no column clears the bar. */
+    Field: string | null;
+    /** All columns that are provably unique + non-null over enough rows (the candidate set). */
+    UniqueCandidates: string[];
+    /** True when there were ≥2 unique candidates and naming couldn't break the tie → defer to the LLM tiebreaker. */
+    AmbiguousForLLM: boolean;
+    Reason: string;
+}
+
+/**
+ * Statistics-first PK pick from streamed evidence. A column is a candidate ONLY if it is, over a
+ * statistically meaningful number of rows, **non-null on every row** AND **all-distinct** (and its
+ * uniqueness was provable — the distinct-cap wasn't hit). One candidate → that's the PK (p<0.05:
+ * all-distinct over a large N is not chance). Several candidates → naming breaks the tie if it can;
+ * otherwise it's flagged ambiguous for the LLM tiebreaker. Zero candidates → no PK (no fabrication).
+ */
+export function pickPrimaryKeyFromStats(
+    columns: DiscoveredColumnStat[],
+    opts: PkPickOptions = {},
+): PkStatVerdict {
+    const minRows = opts.MinRowsForSignificance ?? 50;
+    const candidates = columns.filter(c =>
+        c.TotalRows >= minRows &&
+        c.Occurrences === c.TotalRows &&     // non-null on EVERY row
+        !c.DistinctCapped &&                  // uniqueness was provable from the scan
+        c.DistinctNonNull === c.Occurrences,  // all values distinct → no duplicates
+    );
+    const names = candidates.map(c => c.Key);
+
+    if (candidates.length === 0) {
+        return { Field: null, UniqueCandidates: [], AmbiguousForLLM: false, Reason: 'No column is provably unique + non-null over a significant sample.' };
+    }
+    if (candidates.length === 1) {
+        return { Field: names[0], UniqueCandidates: names, AmbiguousForLLM: false, Reason: `"${names[0]}" is unique + non-null across ${candidates[0].TotalRows} rows (statistically the key).` };
+    }
+    // Multiple unique columns — naming tiebreaker, else hand to the LLM judge with the stats in view.
+    const rank = opts.NameRank ?? (() => 0);
+    const ranked = [...candidates].sort((a, b) => rank(b.Key) - rank(a.Key));
+    if (rank(ranked[0].Key) > rank(ranked[1].Key)) {
+        return { Field: ranked[0].Key, UniqueCandidates: names, AmbiguousForLLM: false, Reason: `${candidates.length} unique columns; naming chose "${ranked[0].Key}".` };
+    }
+    return { Field: null, UniqueCandidates: names, AmbiguousForLLM: true, Reason: `${candidates.length} equally-named unique columns — ambiguous; defer to the evidence-fed LLM tiebreaker.` };
+}
+
+/** Stable string key for a value so distinct-counting is correct across primitives + objects. */
+function stableValueKey(value: unknown): string {
+    if (typeof value === 'object') {
+        try { return 'o:' + JSON.stringify(value); } catch { return 'o:[unserializable]'; }
+    }
+    return typeof value + ':' + String(value);
+}
+
+/** Normalizes a sync or async iterable to an async iterable so the loop handles both. */
+async function* toAsyncIterable<T>(src: AsyncIterable<T> | Iterable<T>): AsyncIterable<T> {
+    if (Symbol.asyncIterator in Object(src)) {
+        yield* src as AsyncIterable<T>;
+    } else {
+        for (const item of src as Iterable<T>) yield item;
+    }
+}

--- a/packages/Integration/engine/src/SyncLogger.ts
+++ b/packages/Integration/engine/src/SyncLogger.ts
@@ -46,6 +46,7 @@ export type SyncLogEvent =
     | 'sync.partition.reconcile'
     | 'sync.fetch.batch.start'
     | 'sync.fetch.batch.complete'
+    | 'sync.fetch.retry'
     | 'sync.record.decision'
     | 'sync.record.saved'
     | 'sync.record.error'
@@ -58,6 +59,7 @@ export type SyncLogEvent =
     | 'sync.run.complete'
     | 'sync.run.fail'
     | 'sync.run.cancelled'
+    | 'sync.schema_update'
     | 'sync.warning';
 
 import type { IntegrationProgressEmitter } from '@memberjunction/integration-progress-artifacts';

--- a/packages/Integration/engine/src/__tests__/CustomColumnPromotion.test.ts
+++ b/packages/Integration/engine/src/__tests__/CustomColumnPromotion.test.ts
@@ -1,0 +1,176 @@
+import { describe, it, expect } from 'vitest';
+import {
+    planPromotions,
+    inferColumnTypeFromSamples,
+    buildOverflowStats,
+    sanitizeColumnName,
+    type OverflowKeyStats,
+} from '../CustomColumnPromotion.js';
+
+function stat(key: string, occurrences: number, totalRows: number, sampleValues: unknown[] = ['x']): OverflowKeyStats {
+    return { Key: key, Occurrences: occurrences, TotalRows: totalRows, SampleValues: sampleValues };
+}
+
+describe('CustomColumnPromotion', () => {
+    describe('inferColumnTypeFromSamples', () => {
+        it('defaults to a generously-bounded string when there is no evidence', () => {
+            const t = inferColumnTypeFromSamples([null, undefined]);
+            expect(t.SchemaFieldType).toBe('string');
+            expect(t.SqlServerType).toBe('NVARCHAR(255)');
+            expect(t.PostgresType).toBe('VARCHAR(255)');
+            expect(t.MaxLength).toBe(255);
+        });
+
+        it('infers boolean only when every non-null sample is a real boolean', () => {
+            expect(inferColumnTypeFromSamples([true, false, true]).SchemaFieldType).toBe('boolean');
+            // "true"/"false" strings are NOT coerced to boolean — stays string (safe default).
+            expect(inferColumnTypeFromSamples(['true', 'false']).SchemaFieldType).toBe('string');
+        });
+
+        it('infers BIGINT for all-integer numbers', () => {
+            const t = inferColumnTypeFromSamples([1, 2, 300, -5]);
+            expect(t.SchemaFieldType).toBe('number');
+            expect(t.SqlServerType).toBe('BIGINT');
+            expect(t.PostgresType).toBe('BIGINT');
+        });
+
+        it('infers wide DECIMAL for non-integer numbers (no truncation)', () => {
+            const t = inferColumnTypeFromSamples([1.5, 2, 3.14159]);
+            expect(t.SchemaFieldType).toBe('number');
+            expect(t.SqlServerType).toBe('DECIMAL(38,10)');
+        });
+
+        it('does NOT treat numeric strings as numbers (stays string)', () => {
+            // Numeric-looking strings are ambiguous; provable-only ⇒ keep them string.
+            expect(inferColumnTypeFromSamples(['42', '43']).SchemaFieldType).toBe('string');
+        });
+
+        it('infers datetime only for ISO-shaped date strings', () => {
+            expect(inferColumnTypeFromSamples(['2026-01-15', '2026-06-07T12:30:00Z']).SchemaFieldType).toBe('datetime');
+            expect(inferColumnTypeFromSamples(['2026-06-07T12:30:00Z']).SqlServerType).toBe('DATETIMEOFFSET');
+            expect(inferColumnTypeFromSamples(['2026-06-07T12:30:00Z']).PostgresType).toBe('TIMESTAMPTZ');
+            // A bare year or a number-like string is NOT a date.
+            expect(inferColumnTypeFromSamples(['2026']).SchemaFieldType).toBe('string');
+            expect(inferColumnTypeFromSamples(['5']).SchemaFieldType).toBe('string');
+        });
+
+        it('sizes a string column generously (double the longest observed, floor 255)', () => {
+            const longest = 'x'.repeat(400);
+            const t = inferColumnTypeFromSamples(['short', longest]);
+            expect(t.SchemaFieldType).toBe('string');
+            expect(t.MaxLength).toBe(800); // 400 * 2
+        });
+
+        it('falls back to MAX/TEXT only when the value genuinely cannot be bounded', () => {
+            const huge = 'x'.repeat(3000); // *2 = 6000 > 4000 bounded limit
+            const t = inferColumnTypeFromSamples([huge]);
+            expect(t.SqlServerType).toBe('NVARCHAR(MAX)');
+            expect(t.PostgresType).toBe('TEXT');
+            expect(t.MaxLength).toBeNull();
+        });
+
+        it('mixed types default to string (the safe choice that holds anything)', () => {
+            expect(inferColumnTypeFromSamples([1, 'two', true]).SchemaFieldType).toBe('string');
+        });
+    });
+
+    describe('planPromotions', () => {
+        it('promotes a pervasive key and skips a sparse one', () => {
+            const out = planPromotions([
+                stat('Pervasive', 9, 10),   // 0.9 coverage
+                stat('Sparse', 1, 10),      // 0.1 coverage
+            ]);
+            expect(out.map(c => c.Key)).toEqual(['Pervasive']);
+            expect(out[0].Coverage).toBeCloseTo(0.9);
+        });
+
+        it('honors a custom coverage threshold', () => {
+            const out = planPromotions([stat('Half', 5, 10)], { CoverageThreshold: 0.6 });
+            expect(out).toHaveLength(0);
+        });
+
+        it('NEVER re-promotes a key whose column already exists (terminate / convergence)', () => {
+            const out = planPromotions(
+                [stat('Custom1', 10, 10), stat('AlreadyHere', 10, 10)],
+                { ExistingColumnNames: new Set(['alreadyhere']) }, // case-insensitive
+            );
+            expect(out.map(c => c.Key)).toEqual(['Custom1']);
+        });
+
+        it('skips keys when no rows were scanned (no fabrication from nothing)', () => {
+            expect(planPromotions([stat('K', 0, 0)])).toHaveLength(0);
+        });
+
+        it('is deterministic — output sorted by key', () => {
+            const out = planPromotions([stat('Zebra', 10, 10), stat('Apple', 10, 10)]);
+            expect(out.map(c => c.Key)).toEqual(['Apple', 'Zebra']);
+        });
+
+        it('carries the inferred type onto each candidate', () => {
+            const out = planPromotions([stat('Count', 10, 10, [1, 2, 3])]);
+            expect(out[0].Inferred.SqlServerType).toBe('BIGINT');
+        });
+
+        it('end-to-end: stats from overflow rows → plan', () => {
+            const rows = [
+                JSON.stringify({ Region: 'West', Score: 5 }),
+                JSON.stringify({ Region: 'East', Score: 7 }),
+                JSON.stringify({ Region: 'West' }),            // Score missing here
+                JSON.stringify({ JunkOnce: 'x' }),             // sparse junk in one row
+            ];
+            const stats = buildOverflowStats(rows);
+            const plan = planPromotions(stats, { CoverageThreshold: 0.5 });
+            // Region (4/4) and Score (2/4) clear 0.5; JunkOnce (1/4) does not.
+            expect(plan.map(c => c.Key).sort()).toEqual(['Region', 'Score']);
+        });
+    });
+
+    describe('buildOverflowStats', () => {
+        it('tallies occurrences + totalRows over the sampled rows', () => {
+            const rows = [
+                JSON.stringify({ A: 1, B: 'x' }),
+                JSON.stringify({ A: 2 }),
+                JSON.stringify({ A: 3, B: 'y' }),
+            ];
+            const stats = buildOverflowStats(rows);
+            const a = stats.find(s => s.Key === 'A')!;
+            const b = stats.find(s => s.Key === 'B')!;
+            expect(a.Occurrences).toBe(3);
+            expect(a.TotalRows).toBe(3);
+            expect(b.Occurrences).toBe(2);
+            expect(b.TotalRows).toBe(3);
+        });
+
+        it('counts a malformed/empty row toward TotalRows but yields no keys from it', () => {
+            const rows = ['not json', '', null, JSON.stringify({ A: 1 })];
+            const stats = buildOverflowStats(rows);
+            expect(stats.find(s => s.Key === 'A')!.TotalRows).toBe(4);
+            expect(stats.find(s => s.Key === 'A')!.Occurrences).toBe(1);
+        });
+
+        it('ignores null-valued keys (JSON.stringify already drops undefined)', () => {
+            const stats = buildOverflowStats([JSON.stringify({ A: null, B: 2 })]);
+            expect(stats.map(s => s.Key)).toEqual(['B']);
+        });
+
+        it('caps retained sample values per key', () => {
+            const rows = Array.from({ length: 50 }, (_, i) => JSON.stringify({ K: i }));
+            const stats = buildOverflowStats(rows, 5);
+            expect(stats[0].SampleValues).toHaveLength(5);
+            expect(stats[0].Occurrences).toBe(50);
+        });
+    });
+
+    describe('sanitizeColumnName', () => {
+        it('replaces invalid characters with underscores', () => {
+            expect(sanitizeColumnName('Custom Field!')).toBe('Custom_Field');
+            expect(sanitizeColumnName('a.b/c')).toBe('a_b_c');
+        });
+        it('prefixes a leading digit', () => {
+            expect(sanitizeColumnName('123abc')).toBe('c_123abc');
+        });
+        it('never returns an empty name', () => {
+            expect(sanitizeColumnName('***')).toBe('Custom');
+        });
+    });
+});

--- a/packages/Integration/engine/src/__tests__/CustomOverflow.test.ts
+++ b/packages/Integration/engine/src/__tests__/CustomOverflow.test.ts
@@ -1,0 +1,62 @@
+import { describe, it, expect } from 'vitest';
+import { computeUnmappedFields, hasUnmappedFields, CUSTOM_OVERFLOW_COLUMN } from '../CustomOverflow.js';
+
+describe('CustomOverflow', () => {
+    describe('CUSTOM_OVERFLOW_COLUMN', () => {
+        it('uses the __mj_integration_* system-column naming convention', () => {
+            // Same family as __mj_integration_ContentHash — a hidden backend system field,
+            // never user-facing metadata.
+            expect(CUSTOM_OVERFLOW_COLUMN).toBe('__mj_integration_CustomOverflow');
+            expect(CUSTOM_OVERFLOW_COLUMN.startsWith('__mj_integration_')).toBe(true);
+        });
+    });
+
+    describe('computeUnmappedFields', () => {
+        it('returns an empty object when every source key is mapped', () => {
+            const mapped = new Set(['FirstName', 'LastName']);
+            const out = computeUnmappedFields({ FirstName: 'Alice', LastName: 'Smith' }, mapped);
+            expect(out).toEqual({});
+        });
+
+        it('returns only the keys with no field map', () => {
+            const mapped = new Set(['FirstName']);
+            const out = computeUnmappedFields(
+                { FirstName: 'Alice', WeirdCustom: 'x', Another: 42 },
+                mapped
+            );
+            expect(out).toEqual({ WeirdCustom: 'x', Another: 42 });
+        });
+
+        it('returns every key when nothing is mapped', () => {
+            const out = computeUnmappedFields({ A: 1, B: 2 }, new Set<string>());
+            expect(out).toEqual({ A: 1, B: 2 });
+        });
+
+        it('preserves falsy and structured values verbatim', () => {
+            const mapped = new Set<string>();
+            const out = computeUnmappedFields(
+                { zero: 0, no: false, empty: '', nested: { k: 'v' }, list: [1, 2] },
+                mapped
+            );
+            expect(out).toEqual({ zero: 0, no: false, empty: '', nested: { k: 'v' }, list: [1, 2] });
+        });
+
+        it('excludes a key even when it carries a null value, if mapped', () => {
+            const mapped = new Set(['Phone']);
+            const out = computeUnmappedFields({ Phone: null, Extra: 'keep' }, mapped);
+            expect(out).toEqual({ Extra: 'keep' });
+        });
+    });
+
+    describe('hasUnmappedFields', () => {
+        it('is false for undefined / null / empty', () => {
+            expect(hasUnmappedFields(undefined)).toBe(false);
+            expect(hasUnmappedFields(null)).toBe(false);
+            expect(hasUnmappedFields({})).toBe(false);
+        });
+
+        it('is true when at least one key is present', () => {
+            expect(hasUnmappedFields({ a: 1 })).toBe(true);
+        });
+    });
+});

--- a/packages/Integration/engine/src/__tests__/DiscoverFieldsViaStream.test.ts
+++ b/packages/Integration/engine/src/__tests__/DiscoverFieldsViaStream.test.ts
@@ -1,0 +1,117 @@
+import { describe, it, expect } from 'vitest';
+import { RegisterClass } from '@memberjunction/global';
+import { BaseIntegrationConnector } from '../BaseIntegrationConnector.js';
+import type {
+    ConnectionTestResult,
+    ExternalObjectSchema,
+    ExternalFieldSchema,
+    FetchContext,
+    FetchBatchResult,
+} from '../BaseIntegrationConnector.js';
+import type { StreamDiscoveryOptions, PkPickOptions } from '../StreamingDiscovery.js';
+
+/**
+ * Minimal concrete connector that exposes the protected `DiscoverFieldsViaStream` bridge so the
+ * mapping from streamed statistics → ExternalFieldSchema can be exercised directly. (BaseEntity-free
+ * — the helper only touches the record stream + the stats math, not any provider.)
+ */
+@RegisterClass(BaseIntegrationConnector, 'StreamDiscoveryTestConnector')
+class StreamDiscoveryTestConnector extends BaseIntegrationConnector {
+    public async TestConnection(): Promise<ConnectionTestResult> { return { Success: true, Message: 'OK' }; }
+    public async DiscoverObjects(): Promise<ExternalObjectSchema[]> { return []; }
+    public async DiscoverFields(): Promise<ExternalFieldSchema[]> { return []; }
+    public async FetchChanges(_ctx: FetchContext): Promise<FetchBatchResult> { return { Records: [], HasMore: false }; }
+
+    /** Public passthrough to the protected helper for testing. */
+    public Run(
+        records: AsyncIterable<Record<string, unknown>> | Iterable<Record<string, unknown>>,
+        opts?: { Discovery?: StreamDiscoveryOptions; Pk?: PkPickOptions; ReadOnly?: boolean }
+    ): Promise<ExternalFieldSchema[]> {
+        return this.DiscoverFieldsViaStream(records, opts);
+    }
+}
+
+/** A clock that advances by `step` each call — for deterministic time-budget tests. */
+function steppedClock(step: number): () => number {
+    let t = 0;
+    return () => { const v = t; t += step; return v; };
+}
+
+/** Builds N rows: a unique non-null `id`, a repeating `region`, a sometimes-missing `score`. */
+function sampleRows(n: number): Record<string, unknown>[] {
+    return Array.from({ length: n }, (_, i) => {
+        const row: Record<string, unknown> = { id: `id-${i}`, region: i % 2 === 0 ? 'West' : 'East' };
+        if (i % 3 !== 0) row.score = i; // present on ~2/3 of rows → nullable
+        return row;
+    });
+}
+
+describe('BaseIntegrationConnector.DiscoverFieldsViaStream', () => {
+    const connector = new StreamDiscoveryTestConnector();
+    const find = (fields: ExternalFieldSchema[], name: string) => fields.find(f => f.Name === name)!;
+
+    it('encodes the data-informed PK + uniqueness + nullability into the standard flags', async () => {
+        const fields = await connector.Run(sampleRows(60), { Pk: { MinRowsForSignificance: 50 } });
+
+        const id = find(fields, 'id');
+        const region = find(fields, 'region');
+        const score = find(fields, 'score');
+
+        // id: unique + non-null over 60 rows → the statistics-first PK + unique key
+        expect(id.IsPrimaryKey).toBe(true);
+        expect(id.IsUniqueKey).toBe(true);
+        expect(id.AllowsNull).toBeUndefined(); // never observed null → not asserted nullable
+
+        // region: non-null but repeats → NOT a PK, NOT unique
+        expect(region.IsPrimaryKey).toBeUndefined();
+        expect(region.IsUniqueKey).toBe(false);
+
+        // score: observed missing on some rows → asserted nullable; not unique; not a PK
+        expect(score.AllowsNull).toBe(true);
+        expect(score.IsPrimaryKey).toBeUndefined();
+    });
+
+    it('defaults fields to read-only (stream discovery targets read feeds), overridable via opts', async () => {
+        const ro = await connector.Run(sampleRows(3));
+        expect(ro.every(f => f.IsReadOnly)).toBe(true);
+
+        const rw = await connector.Run(sampleRows(3), { ReadOnly: false });
+        expect(rw.every(f => !f.IsReadOnly)).toBe(true);
+    });
+
+    it('never asserts NOT NULL — leaves AllowsNull undefined for columns no null was seen on', async () => {
+        const fields = await connector.Run([{ a: '1' }, { a: '2' }, { a: '3' }]);
+        expect(find(fields, 'a').AllowsNull).toBeUndefined();
+    });
+
+    it('fabricates no PK when nothing is provably unique (sub-threshold sample)', async () => {
+        // Only 3 rows; default significance is 50 → no column clears the bar.
+        const fields = await connector.Run(sampleRows(3));
+        expect(fields.some(f => f.IsPrimaryKey)).toBe(false);
+    });
+
+    it('fabricates no PK when no column is unique even over a large sample', async () => {
+        // Every row identical on the only column → never unique.
+        const rows = Array.from({ length: 60 }, () => ({ tag: 'same' }));
+        const fields = await connector.Run(rows, { Pk: { MinRowsForSignificance: 50 } });
+        expect(find(fields, 'tag').IsPrimaryKey).toBeUndefined();
+        expect(find(fields, 'tag').IsUniqueKey).toBe(false);
+    });
+
+    it('stops at the time budget and still emits fields from what it gathered', async () => {
+        const rows = Array.from({ length: 1000 }, (_, i) => ({ id: String(i) }));
+        // clock steps 10ms/call; budget 25ms → stops after a few rows, but still returns the column.
+        const fields = await connector.Run(rows, { Discovery: { TimeBudgetMs: 25, Now: steppedClock(10) } });
+        expect(fields.map(f => f.Name)).toContain('id');
+        // Partial scan must NOT fabricate NOT NULL on the unseen tail.
+        expect(find(fields, 'id').AllowsNull).toBeUndefined();
+    });
+
+    it('carries the inferred data type + bounded MaxLength onto the field schema', async () => {
+        const fields = await connector.Run([{ name: 'abc' }, { name: 'de' }, { name: 'fghi' }]);
+        const name = find(fields, 'name');
+        expect(name.DataType).toBe('string');
+        expect(typeof name.MaxLength).toBe('number');
+        expect(name.MaxLength!).toBeGreaterThan(0);
+    });
+});

--- a/packages/Integration/engine/src/__tests__/FieldMappingEngine.test.ts
+++ b/packages/Integration/engine/src/__tests__/FieldMappingEngine.test.ts
@@ -428,6 +428,50 @@ describe('FieldMappingEngine', () => {
         });
     });
 
+    describe('custom-overflow capture (gaps.md §2)', () => {
+        const fieldMaps = [createFieldMap('FirstName', 'FirstName'), createFieldMap('LastName', 'LastName')];
+
+        it('captures no extras when every source key is mapped', () => {
+            const records = [createExternalRecord({ FirstName: 'Alice', LastName: 'Smith' })];
+            const result = engine.Apply(records, fieldMaps, 'Contacts');
+            expect(result[0].UnmappedFields).toEqual({});
+        });
+
+        it('captures exactly the unmapped source keys (and their values)', () => {
+            const records = [createExternalRecord({
+                FirstName: 'Alice', LastName: 'Smith', WeirdCustom: 'x', Score: 42,
+            })];
+            const result = engine.Apply(records, fieldMaps, 'Contacts');
+            expect(result[0].UnmappedFields).toEqual({ WeirdCustom: 'x', Score: 42 });
+        });
+
+        it('GOLDEN A/B: capturing extras does NOT alter the mapped output', () => {
+            // The no-op-safety proof: a record with extra keys must produce byte-identical
+            // MappedFields to the same record without them. Capture is additive only.
+            const clean = engine.Apply(
+                [createExternalRecord({ FirstName: 'Alice', LastName: 'Smith' })],
+                fieldMaps, 'Contacts',
+            )[0];
+            const withExtras = engine.Apply(
+                [createExternalRecord({ FirstName: 'Alice', LastName: 'Smith', Custom1: 'x', Custom2: 7 })],
+                fieldMaps, 'Contacts',
+            )[0];
+            expect(withExtras.MappedFields).toEqual(clean.MappedFields);
+            expect(clean.UnmappedFields).toEqual({});
+            expect(withExtras.UnmappedFields).toEqual({ Custom1: 'x', Custom2: 7 });
+        });
+
+        it('still maps + transforms normally while capturing extras alongside', () => {
+            const pipeline: TransformStep[] = [
+                { Type: 'coerce', Config: { TargetType: 'number' } },
+            ];
+            const records = [createExternalRecord({ Age: '42', UnknownField: 'park-me' })];
+            const result = engine.Apply(records, [createFieldMap('Age', 'Age', pipeline)], 'Contacts');
+            expect(result[0].MappedFields['Age']).toBe(42);
+            expect(result[0].UnmappedFields).toEqual({ UnknownField: 'park-me' });
+        });
+    });
+
     describe('OnError mid-pipeline', () => {
         it('should skip field when error occurs mid-pipeline with Skip', () => {
             const records = [createExternalRecord({ Val: 'abc' })];

--- a/packages/Integration/engine/src/__tests__/MatchEngine.test.ts
+++ b/packages/Integration/engine/src/__tests__/MatchEngine.test.ts
@@ -190,8 +190,10 @@ describe('MatchEngine', () => {
             expect(results[0].MatchedMJRecordID).toBe('mj-multi-key');
 
             const callArgs = mockRunViewFn.mock.calls[0][0] as { ExtraFilter: string };
-            expect(callArgs.ExtraFilter).toContain('[Email]');
-            expect(callArgs.ExtraFilter).toContain('[CompanyName]');
+            // Plain (unbracketed) identifiers — dialect-agnostic; SQL-Server brackets break Postgres.
+            expect(callArgs.ExtraFilter).toContain('Email =');
+            expect(callArgs.ExtraFilter).toContain('CompanyName =');
+            expect(callArgs.ExtraFilter).not.toContain('[Email]');
             expect(callArgs.ExtraFilter).toContain('AND');
         });
     });

--- a/packages/Integration/engine/src/__tests__/StreamingDiscovery.test.ts
+++ b/packages/Integration/engine/src/__tests__/StreamingDiscovery.test.ts
@@ -1,0 +1,116 @@
+import { describe, it, expect } from 'vitest';
+import { discoverFromStream, pickPrimaryKeyFromStats, type DiscoveredColumnStat } from '../StreamingDiscovery.js';
+
+/** A clock that advances by `step` each call — for deterministic time-budget tests. */
+function steppedClock(step: number): () => number {
+    let t = 0;
+    return () => { const v = t; t += step; return v; };
+}
+
+function col(over: Partial<DiscoveredColumnStat> & { Key: string }): DiscoveredColumnStat {
+    return {
+        Occurrences: 100, TotalRows: 100, DistinctNonNull: 100, DistinctCapped: false,
+        SampleValues: ['x'], Inferred: { SchemaFieldType: 'string', SqlServerType: 'NVARCHAR(255)', PostgresType: 'VARCHAR(255)', MaxLength: 255 },
+        ...over,
+    };
+}
+
+describe('discoverFromStream', () => {
+    it('accumulates the full column corpus + per-column uniqueness/null stats in one pass', async () => {
+        const rows = [
+            { id: '1', region: 'West', score: 5 },
+            { id: '2', region: 'East', score: 7 },
+            { id: '3', region: 'West' },          // score missing → null
+        ];
+        const res = await discoverFromStream(rows);
+        expect(res.RowsScanned).toBe(3);
+        expect(res.StoppedReason).toBe('exhausted');
+
+        const id = res.Columns.find(c => c.Key === 'id')!;
+        const region = res.Columns.find(c => c.Key === 'region')!;
+        const score = res.Columns.find(c => c.Key === 'score')!;
+
+        // id: present on all 3, all distinct → unique + non-null
+        expect(id.Occurrences).toBe(3);
+        expect(id.DistinctNonNull).toBe(3);
+        // region: present on all 3, only 2 distinct (West repeats) → non-null but NOT unique
+        expect(region.Occurrences).toBe(3);
+        expect(region.DistinctNonNull).toBe(2);
+        // score: present on 2 of 3 → nullable
+        expect(score.Occurrences).toBe(2);
+        expect(score.TotalRows).toBe(3);
+    });
+
+    it('catches a column that appears in only one row (completeness, not sampling)', async () => {
+        const rows = [{ a: 1 }, { a: 2 }, { a: 3, rareCustom: 'x' }];
+        const res = await discoverFromStream(rows);
+        expect(res.Columns.map(c => c.Key).sort()).toEqual(['a', 'rareCustom']);
+    });
+
+    it('stops at the time budget and reports it, using what it gathered', async () => {
+        const rows = Array.from({ length: 1000 }, (_, i) => ({ id: String(i) }));
+        // clock steps 10ms/call; budget 25ms → stops after ~3 rows
+        const res = await discoverFromStream(rows, { TimeBudgetMs: 25, Now: steppedClock(10) });
+        expect(res.StoppedReason).toBe('time-budget');
+        expect(res.RowsScanned).toBeLessThan(1000);
+        expect(res.RowsScanned).toBeGreaterThan(0);
+    });
+
+    it('caps retained sample values per column (bounded memory)', async () => {
+        const rows = Array.from({ length: 50 }, (_, i) => ({ k: i }));
+        const res = await discoverFromStream(rows, { SampleValueCap: 5 });
+        expect(res.Columns[0].SampleValues).toHaveLength(5);
+        expect(res.Columns[0].Occurrences).toBe(50);
+    });
+
+    it('flags DistinctCapped when distinct values exceed the cap (uniqueness unprovable)', async () => {
+        const rows = Array.from({ length: 20 }, (_, i) => ({ k: `v${i}` }));
+        const res = await discoverFromStream(rows, { MaxDistinctTracked: 5 });
+        expect(res.Columns[0].DistinctCapped).toBe(true);
+    });
+});
+
+describe('pickPrimaryKeyFromStats', () => {
+    it('picks the single unique + non-null column (statistically the key)', () => {
+        const v = pickPrimaryKeyFromStats([
+            col({ Key: 'id', Occurrences: 100, TotalRows: 100, DistinctNonNull: 100 }),
+            col({ Key: 'region', Occurrences: 100, TotalRows: 100, DistinctNonNull: 4 }), // not unique
+        ]);
+        expect(v.Field).toBe('id');
+        expect(v.AmbiguousForLLM).toBe(false);
+    });
+
+    it('returns no PK when nothing is provably unique+non-null (no fabrication)', () => {
+        const v = pickPrimaryKeyFromStats([
+            col({ Key: 'region', DistinctNonNull: 4 }),
+            col({ Key: 'note', Occurrences: 40, TotalRows: 100 }), // nullable
+        ]);
+        expect(v.Field).toBeNull();
+    });
+
+    it('does not trust uniqueness over too small a sample', () => {
+        const v = pickPrimaryKeyFromStats([col({ Key: 'id', Occurrences: 5, TotalRows: 5, DistinctNonNull: 5 })], { MinRowsForSignificance: 50 });
+        expect(v.Field).toBeNull();
+    });
+
+    it('does not treat a distinct-capped column as a candidate (uniqueness unprovable)', () => {
+        const v = pickPrimaryKeyFromStats([col({ Key: 'id', DistinctCapped: true })]);
+        expect(v.Field).toBeNull();
+    });
+
+    it('breaks a multi-unique tie by naming when it can', () => {
+        const v = pickPrimaryKeyFromStats(
+            [col({ Key: 'id' }), col({ Key: 'email' })],
+            { NameRank: (n) => (n === 'id' ? 10 : 1) },
+        );
+        expect(v.Field).toBe('id');
+        expect(v.AmbiguousForLLM).toBe(false);
+    });
+
+    it('defers to the LLM tiebreaker when multiple unique columns rank equally', () => {
+        const v = pickPrimaryKeyFromStats([col({ Key: 'id' }), col({ Key: 'uuid' })]); // no NameRank → equal
+        expect(v.Field).toBeNull();
+        expect(v.AmbiguousForLLM).toBe(true);
+        expect(v.UniqueCandidates.sort()).toEqual(['id', 'uuid']);
+    });
+});

--- a/packages/Integration/engine/src/index.ts
+++ b/packages/Integration/engine/src/index.ts
@@ -42,6 +42,8 @@ export type {
   SearchResult,
   ListContext,
   ListResult,
+  SchemaPromotionResult,
+  PostSyncSchemaPromotionCallback,
 } from './types.js';
 
 // Error classification helpers
@@ -114,6 +116,11 @@ export type { PersistSchemaOptions, PersistSchemaResult } from './IntegrationSch
 
 // ── Restored module exports dropped by the origin/next index.ts merge (union) ──
 export { computeContentHash, CONTENT_HASH_COLUMN } from './ContentHash.js';
+export { CUSTOM_OVERFLOW_COLUMN, computeUnmappedFields, hasUnmappedFields } from './CustomOverflow.js';
+export { planPromotions, inferColumnTypeFromSamples, buildOverflowStats, sanitizeColumnName } from './CustomColumnPromotion.js';
+export { discoverFromStream, pickPrimaryKeyFromStats } from './StreamingDiscovery.js';
+export type { StreamDiscoveryOptions, DiscoveredColumnStat, StreamDiscoveryResult, PkPickOptions, PkStatVerdict } from './StreamingDiscovery.js';
+export type { InferredColumnType, OverflowKeyStats, PromotionCandidate, PromotionPlanOptions } from './CustomColumnPromotion.js';
 export { partitionRecords, partitionRollupHash, diffPartitions, partitionKeyForIdentity } from './HashDiff.js';
 export type { PartitionDiff } from './HashDiff.js';
 export { mostRecentWinner, parseTimestamp } from './ConflictRecency.js';

--- a/packages/Integration/engine/src/types.ts
+++ b/packages/Integration/engine/src/types.ts
@@ -111,6 +111,15 @@ export interface MappedRecord {
     ChangeType: RecordChangeType;
     /** ID of an existing MJ record if matched */
     MatchedMJRecordID?: string;
+    /**
+     * Source keys the record returned that have NO active field map — the "extra" fields
+     * the target table has no column for (yet). Computed at {@link MapSingleRecord} as
+     * `keys(ExternalRecord.Fields) − active map SourceFieldNames`. Empty/undefined in the
+     * common case (everything mapped). When non-empty, the engine parks it as JSON in the
+     * `__mj_integration_CustomOverflow` system column so a post-sync RSU pass can promote
+     * pervasive keys to real columns. Backend staging only — see {@link CustomOverflow}.
+     */
+    UnmappedFields?: Record<string, unknown>;
 }
 
 /** Aggregate result of a sync operation */
@@ -141,7 +150,52 @@ export interface SyncResult {
     EntityMapResults?: EntityMapSyncResult[];
     /** Duration of the sync in milliseconds */
     Duration?: number;
+    /**
+     * True if this map hit a rate-limit/throttle during fetch. Feeds the per-layer AIMD controller
+     * so a throttle (not just a per-request token-bucket backoff) also reduces in-flight concurrency.
+     * Transient signal — not persisted.
+     */
+    Throttled?: boolean;
+    /**
+     * Outcome of the post-sync custom-column promotion pass (gaps.md §2). Present only when a
+     * promotion callback is registered AND ran; undefined for a customs-free sync (the common
+     * case). Lets the resolver surface SchemaUpdatePending to the client.
+     */
+    SchemaUpdate?: SchemaPromotionResult;
 }
+
+/** Outcome of the post-sync custom-column promotion pass (gaps.md §2 / M2). */
+export interface SchemaPromotionResult {
+    /** Whether any new column was promoted to real schema this run. */
+    Promoted: boolean;
+    /** The columns promoted, per target entity. */
+    ColumnsAdded: Array<{ EntityName: string; ColumnName: string }>;
+    /**
+     * Whether a schema change was applied that needs an MJAPI restart for the new columns to
+     * be exposed over GraphQL — surfaced so the client reads the restart as intentional, not a
+     * crash. False when nothing was promoted. (Restart orchestration itself: M3.)
+     */
+    SchemaUpdatePending: boolean;
+    /** Non-fatal detail when promotion was attempted but partially/fully failed. */
+    Message?: string;
+}
+
+/**
+ * Server-registered hook that runs the post-sync custom-column promotion (gaps.md §2). The
+ * engine never depends on RSU/CodeGen — the server registers an implementation that performs
+ * the coverage scan → RSU ADD COLUMN → IOF/field-map. Self-gated INSIDE the callback: a cheap
+ * EXISTS over the overflow column means a customs-free sync does no promotion work, so the
+ * two-stage process collapses to single-stage (1×) when there is nothing to promote.
+ *
+ * ContextUser/Provider are typed `unknown` to avoid a circular import; the engine passes a real
+ * UserInfo / IMetadataProvider and the server implementation narrows them back.
+ */
+export type PostSyncSchemaPromotionCallback = (ctx: {
+    CompanyIntegrationID: string;
+    ContextUser: unknown;
+    SyncedEntityNames: string[];
+    Provider?: unknown;
+}) => Promise<SchemaPromotionResult>;
 
 /** Per-entity-map result within a sync run */
 export interface EntityMapSyncResult {

--- a/packages/Integration/pk-classifier/src/SoftPKClassifier.ts
+++ b/packages/Integration/pk-classifier/src/SoftPKClassifier.ts
@@ -214,13 +214,15 @@ export class SoftPKClassifier {
     }
 
     /**
-     * Terminal tier. When syntheticFallback is on (default), nominates the
-     * synthetic identity-hash column so no table is left PK-less (plan.md §4).
-     * When off, returns the honest 'none' verdict.
+     * Terminal tier. Default is the **honest 'none'** verdict — NO fabrication. A PK is emitted only
+     * on real evidence (naming + streamed-data statistics at p<0.05, with the LLM as a tiebreaker);
+     * when none of those resolve, the entity is simply not generated until a PK does (surfaced, not
+     * guessed). The synthetic identity-hash fallback is now OFF by default (opt-in only) — it was
+     * never materialized downstream, so emitting it only produced a confident-but-dropped verdict.
      */
     private finalVerdict(opts: ClassifyOptions, prefix?: string): PKClassifierResult {
         const note = prefix ? `${prefix} ` : '';
-        if (opts.syntheticFallback ?? true) {
+        if (opts.syntheticFallback ?? false) {
             return {
                 Confident: true,
                 Nominee: SYNTHETIC_PK_FIELD_NAME,

--- a/packages/Integration/pk-classifier/src/__tests__/SoftPKClassifier.test.ts
+++ b/packages/Integration/pk-classifier/src/__tests__/SoftPKClassifier.test.ts
@@ -113,6 +113,7 @@ describe('SoftPKClassifier', () => {
                 fields,
                 sampleRows,
                 maxCompositeKeySize: 2,
+                syntheticFallback: true, // opt in to still exercise the composite-too-small → synthetic path
             });
 
             expect(result.Strategy).toBe('synthetic');
@@ -127,11 +128,25 @@ describe('SoftPKClassifier', () => {
             { color: 'red', size: 'L' }, // exact dup → nothing is unique, even composite
         ];
 
-        it('nominates the synthetic identity-hash column when nothing is unique (default on)', async () => {
+        it('returns the honest none verdict by DEFAULT when nothing is unique (no fabrication)', async () => {
             const result = await classifier.Classify({
                 object: makeObject('Tags'),
                 fields: ambiguousFields,
                 sampleRows: ambiguousRows,
+            });
+
+            // Default is now honest 'none' — synthetic is opt-in only, never fabricated.
+            expect(result.Confident).toBe(false);
+            expect(result.Strategy).toBe('none');
+            expect(result.Nominee).toBeUndefined();
+        });
+
+        it('still nominates the synthetic key when syntheticFallback is explicitly opted in', async () => {
+            const result = await classifier.Classify({
+                object: makeObject('Tags'),
+                fields: ambiguousFields,
+                sampleRows: ambiguousRows,
+                syntheticFallback: true,
             });
 
             expect(result.Confident).toBe(true);
@@ -141,28 +156,14 @@ describe('SoftPKClassifier', () => {
             expect(result.Confidence).toBeGreaterThanOrEqual(0.7);
         });
 
-        it('returns the honest none verdict when syntheticFallback is false', async () => {
-            const result = await classifier.Classify({
-                object: makeObject('Tags'),
-                fields: ambiguousFields,
-                sampleRows: ambiguousRows,
-                syntheticFallback: false,
-            });
-
-            expect(result.Confident).toBe(false);
-            expect(result.Strategy).toBe('none');
-            expect(result.Nominee).toBeUndefined();
-            expect(result.Confidence).toBe(0);
-        });
-
-        it('falls back to synthetic with no sample rows at all (default on)', async () => {
+        it('returns honest none with no sample rows at all (default — no fabrication)', async () => {
             const result = await classifier.Classify({
                 object: makeObject('Mystery'),
                 fields: [makeField('foo'), makeField('bar')],
             });
 
-            expect(result.Strategy).toBe('synthetic');
-            expect(result.Nominee).toBe(SYNTHETIC_PK_FIELD_NAME);
+            expect(result.Strategy).toBe('none');
+            expect(result.Nominee).toBeUndefined();
         });
     });
 

--- a/packages/Integration/progress-artifacts/src/IntegrationProgressEmitter.ts
+++ b/packages/Integration/progress-artifacts/src/IntegrationProgressEmitter.ts
@@ -16,7 +16,19 @@ export interface EmitterOptions {
     rootDir?: string;
     /** Optional human-facing console mirror (default false — file is the primary record). */
     consoleMirror?: boolean;
+    /**
+     * Max number of per-run subdirs to retain under rootDir. On each new run, older run dirs beyond
+     * this count (by mtime) are pruned so the logs directory never grows unbounded across runs.
+     * Defaults to MJ_INTEGRATION_MAX_RUN_DIRS env or 200. Set 0 to disable pruning.
+     */
+    maxRunDirs?: number;
 }
+
+/** Default retained run-dir count; env-overridable. Prevents unbounded logs/ growth over many runs. */
+const DEFAULT_MAX_RUN_DIRS = (() => {
+    const n = Number(process.env.MJ_INTEGRATION_MAX_RUN_DIRS);
+    return Number.isFinite(n) && n >= 0 ? Math.floor(n) : 200;
+})();
 
 /**
  * Side-channel hook invoked for EVERY emitted event. The server layer registers this once at
@@ -62,16 +74,20 @@ export class IntegrationProgressEmitter {
         IntegrationProgressEmitter._publishHook = hook;
     }
 
+    private readonly root: string;
+    private readonly maxRunDirs: number;
+
     constructor(
         private readonly manifest: IntegrationRunManifest,
         opts: EmitterOptions = {}
     ) {
-        const root = opts.rootDir ?? join(process.cwd(), 'logs', 'integration-runs');
-        this.runDir = join(root, this.manifest.runID);
+        this.root = opts.rootDir ?? join(process.cwd(), 'logs', 'integration-runs');
+        this.runDir = join(this.root, this.manifest.runID);
         this.progressPath = join(this.runDir, 'progress.jsonl');
         this.manifestPath = join(this.runDir, 'manifest.json');
         this.resultPath = join(this.runDir, 'result.json');
         this.consoleMirror = opts.consoleMirror ?? false;
+        this.maxRunDirs = opts.maxRunDirs ?? DEFAULT_MAX_RUN_DIRS;
         this.writeChain = this.bootstrap();
     }
 
@@ -235,6 +251,36 @@ export class IntegrationProgressEmitter {
     private async bootstrap(): Promise<void> {
         await fs.mkdir(this.runDir, { recursive: true });
         await fs.writeFile(this.manifestPath, JSON.stringify(this.manifest, null, 2), 'utf-8');
+        // Retention: prune oldest run dirs so logs/ never grows unbounded across runs. Best-effort —
+        // a pruning failure must never break the run (the new run dir is already created above).
+        await this.pruneOldRuns().catch(() => { /* best-effort retention */ });
+    }
+
+    /**
+     * Deletes the oldest per-run subdirs under the root, keeping the most recent `maxRunDirs` (by
+     * mtime). Disabled when maxRunDirs <= 0. Never removes the current run dir (it's the newest).
+     */
+    private async pruneOldRuns(): Promise<void> {
+        if (this.maxRunDirs <= 0) return;
+        let entries: import('node:fs').Dirent[];
+        try {
+            entries = await fs.readdir(this.root, { withFileTypes: true });
+        } catch {
+            return; // root not readable yet — nothing to prune
+        }
+        const dirs = entries.filter(e => e.isDirectory());
+        if (dirs.length <= this.maxRunDirs) return;
+        // Stat each for mtime, newest-first; delete everything past the retention count.
+        const withTime = await Promise.all(dirs.map(async d => {
+            const p = join(this.root, d.name);
+            try { return { p, mtime: (await fs.stat(p)).mtimeMs }; }
+            catch { return { p, mtime: 0 }; }
+        }));
+        withTime.sort((a, b) => b.mtime - a.mtime);
+        const toDelete = withTime.slice(this.maxRunDirs);
+        await Promise.all(toDelete.map(d =>
+            fs.rm(d.p, { recursive: true, force: true }).catch(() => { /* best-effort */ })
+        ));
     }
 
     private async writeTerminal(partial: { success: boolean; exitReason: IntegrationRunResult['exitReason'] }): Promise<void> {

--- a/packages/Integration/progress-artifacts/src/__tests__/IntegrationProgressEmitter.test.ts
+++ b/packages/Integration/progress-artifacts/src/__tests__/IntegrationProgressEmitter.test.ts
@@ -284,4 +284,37 @@ describe('IntegrationProgressEmitter', () => {
             expect(result.exitReason).toBe('completed');
         });
     });
+
+    describe('run-dir retention', () => {
+        async function listDirs(): Promise<string[]> {
+            const entries = await fs.readdir(rootDir, { withFileTypes: true });
+            return entries.filter(e => e.isDirectory()).map(e => e.name).sort();
+        }
+
+        it('prunes oldest run dirs beyond maxRunDirs, always keeping the newest', async () => {
+            // Create old-1 and force its mtime to the epoch so it is deterministically the oldest.
+            const e1 = new IntegrationProgressEmitter(makeManifest('old-1'), { rootDir, maxRunDirs: 2 });
+            await e1.flush();
+            await fs.utimes(join(rootDir, 'old-1'), new Date(0), new Date(0));
+
+            const e2 = new IntegrationProgressEmitter(makeManifest('old-2'), { rootDir, maxRunDirs: 2 });
+            await e2.flush();
+            // Third run: 3 dirs > cap of 2 → bootstrap prunes the single oldest (old-1).
+            const e3 = new IntegrationProgressEmitter(makeManifest('new-3'), { rootDir, maxRunDirs: 2 });
+            await e3.flush();
+
+            const remaining = await listDirs();
+            expect(remaining.length).toBe(2);
+            expect(remaining).toContain('new-3');     // newest always kept
+            expect(remaining).not.toContain('old-1');  // oldest pruned
+        });
+
+        it('disables pruning when maxRunDirs is 0', async () => {
+            for (const id of ['a', 'b', 'c']) {
+                const e = new IntegrationProgressEmitter(makeManifest(id), { rootDir, maxRunDirs: 0 });
+                await e.flush();
+            }
+            expect((await listDirs()).length).toBe(3); // nothing pruned
+        });
+    });
 });

--- a/packages/Integration/schema-builder/src/DDLGenerator.ts
+++ b/packages/Integration/schema-builder/src/DDLGenerator.ts
@@ -24,7 +24,10 @@ export class DDLGenerator {
 
     /**
      * Generate a full CREATE TABLE statement.
-     * PK fields keep their natural names from the source system and get a UNIQUE constraint.
+     * PK fields keep their natural names from the source system and are emitted as ORDINARY columns —
+     * NO database constraint (not PRIMARY KEY, not UNIQUE). Their PK-ness is SOFT: it lives only in
+     * additionalSchemaInfo, which CodeGen reads (via applySoftPKFKConfig) to set the entity's METADATA
+     * PK + IsSoftPrimaryKey flag — never a DB key. See the detailed note at the soft-PK block below.
      * Standard integration columns (__mj_integration_*) are added automatically.
      */
     GenerateCreateTable(config: TargetTableConfig, platform: DatabasePlatform): string {
@@ -53,12 +56,12 @@ export class DDLGenerator {
         // Standard integration columns (prefixed to avoid collisions)
         lines.push(...this.StandardColumns(platform));
 
-        // UNIQUE constraint on PK field(s) — no DB-level PK, soft PK via additionalSchemaInfo
-        if (config.PrimaryKeyFields.length > 0) {
-            const pkColNames = config.PrimaryKeyFields.map(f => q(f)).join(', ');
-            const uqName = `UQ_${config.SchemaName}_${config.TableName}_PK`;
-            lines.push(`    CONSTRAINT ${q(uqName)} UNIQUE (${pkColNames})`);
-        }
+        // PK is SOFT-ONLY — declared in additionalSchemaInfo (which CodeGen reads to set the entity's
+        // metadata PK), and emitted as NO database constraint here: not a PRIMARY KEY, and not even a
+        // UNIQUE. Integration PKs are *inferred* (naming + streamed-data statistics at p<0.05), so
+        // enforcing one — even as UNIQUE — would reject valid rows the moment an inference is wrong.
+        // Dedupe is the engine's job via the record-map, not a DB key. So the table carries the PK
+        // columns as ordinary columns; their PK-ness lives only in additionalSchemaInfo.
 
         const body = lines.join(',\n');
         // Idempotent create: skip if the physical table already exists. Makes re-running
@@ -124,6 +127,7 @@ export class DDLGenerator {
             '__mj_integration_LastSyncedSnapshot': 'The external record values as of the last successful sync, serialized as JSON. The last-known external state, kept independent of local edits, used to detect changes without a watermark and as the common ancestor for field-level merge (combine) on bidirectional push.',
             '__mj_integration_SyncMessage': 'Human-readable detail when SyncStatus is Error or Conflict (the conflicting fields and values, or the apply error). NULL when Active.',
             '__mj_integration_ContentHash': 'SHA-256 (hex) of the last-synced external field values. Lets the engine detect changes and skip re-loading/re-writing unchanged records for sources that have no usable watermark.',
+            '__mj_integration_CustomOverflow': 'Backend staging (system) column: JSON of source fields a record returned that have no field map yet — the "extra" keys this table has no column for. A post-sync Runtime-Schema-Updation pass promotes pervasive keys to real columns and clears them here. Not user-facing metadata; transient until promotion.',
         };
 
         for (const [colName, desc] of Object.entries(standardDescriptions)) {
@@ -269,6 +273,7 @@ export class DDLGenerator {
                 `    ${q('__mj_integration_LastSyncedSnapshot')} NVARCHAR(MAX) NULL`,
                 `    ${q('__mj_integration_SyncMessage')} NVARCHAR(MAX) NULL`,
                 `    ${q('__mj_integration_ContentHash')} NVARCHAR(64) NULL`,
+                `    ${q('__mj_integration_CustomOverflow')} NVARCHAR(MAX) NULL`,
                 `    ${q('__mj_integration_ExternalVersion')} NVARCHAR(255) NULL`,
                 `    ${q('__mj_integration_LastSeenModifiedValue')} NVARCHAR(255) NULL`,
                 `    ${q('__mj_integration_LastReconciledAt')} DATETIMEOFFSET NULL`,
@@ -283,6 +288,7 @@ export class DDLGenerator {
             `    ${q('__mj_integration_LastSyncedSnapshot')} TEXT NULL`,
             `    ${q('__mj_integration_SyncMessage')} TEXT NULL`,
             `    ${q('__mj_integration_ContentHash')} VARCHAR(64) NULL`,
+            `    ${q('__mj_integration_CustomOverflow')} TEXT NULL`,
             `    ${q('__mj_integration_ExternalVersion')} VARCHAR(255) NULL`,
             `    ${q('__mj_integration_LastSeenModifiedValue')} VARCHAR(255) NULL`,
             `    ${q('__mj_integration_LastReconciledAt')} TIMESTAMPTZ NULL`,

--- a/packages/Integration/schema-builder/src/SchemaBuilder.ts
+++ b/packages/Integration/schema-builder/src/SchemaBuilder.ts
@@ -330,6 +330,13 @@ export class SchemaBuilder {
                 IsNullable: true,
                 Description: 'SHA-256 (hex) of the last-synced external field values. Lets the engine detect changes and skip re-loading/re-writing unchanged records for sources that have no usable watermark (e.g. YourMembership, which re-fetches every record each sync).',
             },
+            {
+                Name: '__mj_integration_CustomOverflow',
+                Type: 'string' as SchemaFieldType,
+                RawSqlType: platform === 'sqlserver' ? 'NVARCHAR(MAX)' : 'TEXT',
+                IsNullable: true,
+                Description: 'Backend staging (system) column: JSON of source fields a record returned that have no field map yet — the extra keys this table has no column for. A post-sync Runtime-Schema-Updation pass promotes pervasive keys to real columns and clears them here. Not user-facing metadata; transient until promotion.',
+            },
             // ── Per-record sync ledger (plan §2.5) ──────────────────────────────────────
             {
                 Name: '__mj_integration_ExternalVersion',

--- a/packages/Integration/schema-builder/src/SchemaEvolution.ts
+++ b/packages/Integration/schema-builder/src/SchemaEvolution.ts
@@ -40,7 +40,7 @@ export class SchemaEvolution {
                                        '__mj_createdat', '__mj_updatedat',
                                        '__mj_integration_syncstatus', '__mj_integration_lastsyncedat',
                                        '__mj_integration_lastsyncedsnapshot', '__mj_integration_syncmessage',
-                                       '__mj_integration_contenthash',
+                                       '__mj_integration_contenthash', '__mj_integration_customoverflow',
                                        '__mj_integration_externalversion', '__mj_integration_lastseenmodifiedvalue',
                                        '__mj_integration_lastreconciledat', '__mj_integration_lastwriterdirection',
                                        '__mj_integration_istombstoned', '__mj_integration_deleteddetectedat']);
@@ -119,6 +119,7 @@ export class SchemaEvolution {
             { SourceFieldName: '__mj_integration_LastSyncedSnapshot', TargetColumnName: '__mj_integration_LastSyncedSnapshot', TargetSqlType: isSql ? 'NVARCHAR(MAX)' : 'TEXT', IsNullable: true, MaxLength: null, Precision: null, Scale: null, DefaultValue: null },
             { SourceFieldName: '__mj_integration_SyncMessage', TargetColumnName: '__mj_integration_SyncMessage', TargetSqlType: isSql ? 'NVARCHAR(MAX)' : 'TEXT', IsNullable: true, MaxLength: null, Precision: null, Scale: null, DefaultValue: null },
             { SourceFieldName: '__mj_integration_ContentHash', TargetColumnName: '__mj_integration_ContentHash', TargetSqlType: isSql ? 'NVARCHAR(64)' : 'VARCHAR(64)', IsNullable: true, MaxLength: 64, Precision: null, Scale: null, DefaultValue: null },
+            { SourceFieldName: '__mj_integration_CustomOverflow', TargetColumnName: '__mj_integration_CustomOverflow', TargetSqlType: isSql ? 'NVARCHAR(MAX)' : 'TEXT', IsNullable: true, MaxLength: null, Precision: null, Scale: null, DefaultValue: null },
             // Per-record sync ledger (plan §2.5)
             { SourceFieldName: '__mj_integration_ExternalVersion', TargetColumnName: '__mj_integration_ExternalVersion', TargetSqlType: isSql ? 'NVARCHAR(255)' : 'VARCHAR(255)', IsNullable: true, MaxLength: 255, Precision: null, Scale: null, DefaultValue: null },
             { SourceFieldName: '__mj_integration_LastSeenModifiedValue', TargetColumnName: '__mj_integration_LastSeenModifiedValue', TargetSqlType: isSql ? 'NVARCHAR(255)' : 'VARCHAR(255)', IsNullable: true, MaxLength: 255, Precision: null, Scale: null, DefaultValue: null },

--- a/packages/Integration/schema-builder/src/__tests__/DDLGenerator.test.ts
+++ b/packages/Integration/schema-builder/src/__tests__/DDLGenerator.test.ts
@@ -108,12 +108,14 @@ describe('DDLGenerator', () => {
             expect(sql).toContain('[Notes] NVARCHAR(MAX) NULL');
         });
 
-        it('should include UNIQUE constraint on PK fields', () => {
+        it('emits NO DB constraint for the PK — soft-only (PK-ness lives in additionalSchemaInfo)', () => {
             const config = MakeTableConfig();
             const sql = gen.GenerateCreateTable(config, 'sqlserver');
-            expect(sql).toContain('CONSTRAINT [UQ_hubspot_Contact_PK] UNIQUE ([ContactID])');
-            // Should NOT contain old PK constraint
-            expect(sql).not.toContain('PRIMARY KEY ([ID])');
+            // There is NO enforced key: not a PRIMARY KEY, and (now) not a UNIQUE either.
+            // Integration PKs are inferred, so enforcing one could reject valid rows on a wrong guess —
+            // PK-ness lives only in additionalSchemaInfo, which CodeGen reads for the entity's metadata PK.
+            expect(sql).not.toContain('PRIMARY KEY');
+            expect(sql).not.toContain('UNIQUE');
         });
 
         it('should include default values when specified', () => {

--- a/packages/Integration/schema-builder/src/__tests__/SchemaEvolution.test.ts
+++ b/packages/Integration/schema-builder/src/__tests__/SchemaEvolution.test.ts
@@ -45,6 +45,7 @@ function MakeExistingTable(columns: Array<{ Name: string; SqlType: string; IsNul
         { Name: '__mj_integration_LastSyncedSnapshot', SqlType: 'NVARCHAR(MAX)', IsNullable: true },
         { Name: '__mj_integration_SyncMessage', SqlType: 'NVARCHAR(MAX)', IsNullable: true },
         { Name: '__mj_integration_ContentHash', SqlType: 'NVARCHAR(64)', IsNullable: true },
+        { Name: '__mj_integration_CustomOverflow', SqlType: 'NVARCHAR(MAX)', IsNullable: true },
         // Per-record sync ledger (plan §2.5)
         { Name: '__mj_integration_ExternalVersion', SqlType: 'NVARCHAR(255)', IsNullable: true },
         { Name: '__mj_integration_LastSeenModifiedValue', SqlType: 'NVARCHAR(255)', IsNullable: true },

--- a/packages/Integration/schema-builder/src/__tests__/integration.test.ts
+++ b/packages/Integration/schema-builder/src/__tests__/integration.test.ts
@@ -228,6 +228,7 @@ describe('SchemaBuilder (integration)', () => {
                         { Name: '__mj_integration_LastSyncedSnapshot', SqlType: 'NVARCHAR(MAX)', IsNullable: true, MaxLength: null, Precision: null, Scale: null },
                         { Name: '__mj_integration_SyncMessage', SqlType: 'NVARCHAR(MAX)', IsNullable: true, MaxLength: null, Precision: null, Scale: null },
                         { Name: '__mj_integration_ContentHash', SqlType: 'NVARCHAR(64)', IsNullable: true, MaxLength: 64, Precision: null, Scale: null },
+                        { Name: '__mj_integration_CustomOverflow', SqlType: 'NVARCHAR(MAX)', IsNullable: true, MaxLength: null, Precision: null, Scale: null },
                         // Per-record sync ledger (plan §2.5)
                         { Name: '__mj_integration_ExternalVersion', SqlType: 'NVARCHAR(255)', IsNullable: true, MaxLength: 255, Precision: null, Scale: null },
                         { Name: '__mj_integration_LastSeenModifiedValue', SqlType: 'NVARCHAR(255)', IsNullable: true, MaxLength: 255, Precision: null, Scale: null },

--- a/packages/MJServer/src/index.ts
+++ b/packages/MJServer/src/index.ts
@@ -9,6 +9,7 @@ import { resolveDbPlatformFromEnv } from '@memberjunction/generic-database-provi
 import { MJGlobal, MJEventType, UUIDsEqual, ShutdownRegistry } from '@memberjunction/global';
 import { setupSQLServerClient, SQLServerDataProvider, SQLServerProviderConfigData, UserCache } from '@memberjunction/sqlserver-dataprovider';
 import { extendConnectionPoolWithQuery } from './util.js';
+import { registerIntegrationCustomColumnPromoter } from './integration/CustomColumnPromoter.js';
 import { default as BodyParser } from 'body-parser';
 import compression from 'compression'; // Add compression middleware
 import cors from 'cors';
@@ -500,6 +501,14 @@ export const serve = async (resolverPaths: Array<string>, app: Application = cre
         console.warn(`RSU DDL provider setup failed (RSU will fall back to default provider): ${(err as Error).message}`);
       }
     }
+  }
+
+  // Register the post-sync custom-column promotion hook (gaps.md §2). Safe to call regardless of
+  // RSU config: the hook self-gates on captured overflow data and uses RSU only at fire time.
+  try {
+    registerIntegrationCustomColumnPromoter();
+  } catch (err) {
+    console.warn(`Custom-column promoter registration failed (post-sync promotion disabled): ${(err as Error).message}`);
   }
 
   let tServe = performance.now();

--- a/packages/MJServer/src/integration/CustomColumnPromoter.ts
+++ b/packages/MJServer/src/integration/CustomColumnPromoter.ts
@@ -1,0 +1,521 @@
+/**
+ * Post-sync custom-column promoter (gaps.md §2 / M2b-server).
+ *
+ * Registered onto {@link IntegrationEngine} as the post-sync schema-promotion hook (the engine
+ * itself has no dependency on RSU/CodeGen — see SetPostSyncSchemaPromotionCallback). After a
+ * sync drains, the engine invokes this for the synced entities; here we:
+ *
+ *   1. GATE — sample the overflow column per entity. No overflow rows → no work (this is what
+ *      keeps a customs-free sync single-stage / 1×; your hard rule).
+ *   2. PLAN — {@link buildOverflowStats} + {@link planPromotions} decide which keys earn a real
+ *      column and the generously-bounded type for each (pure engine logic, unit-tested).
+ *   3. PROMOTE — for the winners: ADD COLUMN via {@link DDLGenerator} + {@link RuntimeSchemaManager}
+ *      (CodeGen reflects the column into a real EntityField), an IOF row per field (IsCustom,
+ *      MetadataSource='Discovered'), and a field map so the next sync maps it natively → the
+ *      capture/promote loop terminates.
+ *
+ * DIALECT PARITY (crucial, per PR #2752): the coverage scan is RunView (dialect-agnostic); DDL
+ * goes through DDLGenerator driven by provider.PlatformKey ('sqlserver' | 'postgresql'); RSU has
+ * dual SS/PG setup; IOF + field map are BaseEntity. No SS-only SQL anywhere in this file.
+ *
+ * The MJAPI restart (so the new column is exposed over GraphQL) + the JSON spread of staged
+ * values into the new columns are M3 — this stage applies the schema only (SkipRestart).
+ */
+import {
+    LogError,
+    LogStatus,
+    Metadata,
+    RunView,
+    type UserInfo,
+    type IMetadataProvider,
+    type DatabaseProviderBase,
+    type EntityInfo,
+} from '@memberjunction/core';
+import {
+    IntegrationEngine,
+    CUSTOM_OVERFLOW_COLUMN,
+    CONTENT_HASH_COLUMN,
+    computeContentHash,
+    buildOverflowStats,
+    planPromotions,
+    sanitizeColumnName,
+    type SchemaPromotionResult,
+    type PromotionCandidate,
+} from '@memberjunction/integration-engine';
+import type { BaseEntity } from '@memberjunction/core';
+import { DDLGenerator, type TargetColumnConfig, type DatabasePlatform } from '@memberjunction/integration-schema-builder';
+import { RuntimeSchemaManager, type RSUPipelineInput } from '@memberjunction/schema-engine';
+import {
+    MJCompanyIntegrationEntity,
+    MJCompanyIntegrationEntityMapEntity,
+    MJCompanyIntegrationFieldMapEntity,
+    MJIntegrationObjectEntity,
+    MJIntegrationObjectFieldEntity,
+} from '@memberjunction/core-entities';
+
+/** Max rows sampled from the overflow column to compute coverage + infer types (bounded memory). */
+const OVERFLOW_SAMPLE_SIZE = 1000;
+
+/**
+ * Max columns promoted in a SINGLE pass, so a feed that suddenly exposes hundreds of distinct
+ * high-coverage keys can't mint hundreds of columns in one sync (bounded schema churn). The
+ * remainder is logged + deferred; it promotes on subsequent syncs (the keys stay captured).
+ */
+const MAX_PROMOTIONS_PER_PASS = 25;
+
+/** A coverage-passing key with its resolved column + what work it still needs (M4: promote OR recover). */
+interface WorkItem {
+    candidate: PromotionCandidate;
+    /** Original source key — the field map's SourceFieldName + the IOF Name. */
+    sourceKey: string;
+    /** Sanitized, collision-resolved column / DestinationFieldName / EntityField name. */
+    columnName: string;
+    /** The real DB column does not exist yet → needs ADD COLUMN. */
+    needsColumn: boolean;
+    /** No active field map for this source key → needs one (covers the partial-promotion crash window). */
+    needsFieldMap: boolean;
+}
+
+/** Registers the post-sync custom-column promotion hook on the IntegrationEngine singleton. */
+export function registerIntegrationCustomColumnPromoter(): void {
+    IntegrationEngine.Instance.SetPostSyncSchemaPromotionCallback(async (ctx) => {
+        const promoter = new IntegrationCustomColumnPromoter(
+            ctx.ContextUser as UserInfo,
+            ctx.Provider as IMetadataProvider | undefined,
+        );
+        return promoter.PromoteForSync(ctx.CompanyIntegrationID, ctx.SyncedEntityNames);
+    });
+    LogStatus('[CustomColumnPromoter] Registered post-sync custom-column promotion hook.');
+}
+
+const NOT_PROMOTED: SchemaPromotionResult = { Promoted: false, ColumnsAdded: [], SchemaUpdatePending: false };
+
+/**
+ * Orchestrates promotion for one sync run. One instance per invocation (carries the per-sync
+ * context user + provider so it respects the bound provider, never the global default blindly).
+ */
+class IntegrationCustomColumnPromoter {
+    constructor(
+        private readonly user: UserInfo,
+        private readonly providerOverride?: IMetadataProvider,
+    ) {}
+
+    private get provider(): IMetadataProvider {
+        return this.providerOverride ?? Metadata.Provider;
+    }
+
+    private get dbProvider(): DatabaseProviderBase {
+        return this.provider as unknown as DatabaseProviderBase;
+    }
+
+    /** Entry point: promote custom columns for every entity touched by the sync. */
+    public async PromoteForSync(
+        companyIntegrationID: string,
+        syncedEntityNames: string[],
+    ): Promise<SchemaPromotionResult> {
+        const integrationID = await this.resolveIntegrationID(companyIntegrationID);
+        if (!integrationID) return NOT_PROMOTED;
+
+        const columnsAdded: Array<{ EntityName: string; ColumnName: string }> = [];
+        for (const entityName of syncedEntityNames) {
+            try {
+                const added = await this.promoteEntity(companyIntegrationID, integrationID, entityName);
+                columnsAdded.push(...added);
+            } catch (err) {
+                // One entity's promotion failure must not abort the others, and never the sync.
+                LogError(`[CustomColumnPromoter] Promotion failed for entity '${entityName}': ${this.msg(err)}`);
+            }
+        }
+
+        const promoted = columnsAdded.length > 0;
+        if (promoted) {
+            // Make the freshly-created EntityFields visible in-process for the next sync's mapping.
+            try { await this.provider.Refresh(); } catch (err) { LogError(`[CustomColumnPromoter] provider.Refresh failed: ${this.msg(err)}`); }
+        }
+        return { Promoted: promoted, ColumnsAdded: columnsAdded, SchemaUpdatePending: promoted };
+    }
+
+    /** Gate → plan → promote for a single target entity. Returns the columns it added. */
+    private async promoteEntity(
+        companyIntegrationID: string,
+        integrationID: string,
+        entityName: string,
+    ): Promise<Array<{ EntityName: string; ColumnName: string }>> {
+        const entityInfo = this.provider.EntityByName(entityName);
+        if (!entityInfo?.SchemaName || !entityInfo.BaseTable) return [];
+        // No overflow column on this table (predates the feature) → nothing to promote.
+        if (!entityInfo.Fields.some(f => f.Name === CUSTOM_OVERFLOW_COLUMN)) return [];
+
+        // 1. GATE + scan (dialect-agnostic via RunView).
+        const overflowJson = await this.scanOverflow(entityName);
+        if (overflowJson.length === 0) return []; // no customs captured → no work (1× guarantee)
+
+        // 2. PLAN — coverage-passing + typed keys (existing-column handled per-item below, so recovery
+        //    of a partially-promoted key — column added but field map missing — is also caught).
+        const passing = planPromotions(buildOverflowStats(overflowJson), {});
+        if (passing.length === 0) return [];
+
+        const entityMap = await this.findEntityMap(companyIntegrationID, entityName);
+        if (!entityMap) {
+            LogError(`[CustomColumnPromoter] No entity map for ${entityName} on CI ${companyIntegrationID}; skipping promotion.`);
+            return [];
+        }
+
+        // 3. Resolve per-key work: skip fully-terminated keys (column + field map both exist), keep
+        //    the rest as promote (needs column) or recover (column exists, field map missing).
+        const fieldMapSources = await this.activeFieldMapSources(entityMap.ID);
+        let work = this.resolveWorkItems(passing, entityInfo, fieldMapSources);
+        if (work.length === 0) return []; // everything already promoted + mapped → converged
+
+        // M4a: bound schema churn per pass — the remainder stays captured and promotes next sync.
+        if (work.length > MAX_PROMOTIONS_PER_PASS) {
+            LogStatus(`[CustomColumnPromoter] ${work.length} candidates on ${entityName}; promoting ${MAX_PROMOTIONS_PER_PASS} this pass, ${work.length - MAX_PROMOTIONS_PER_PASS} deferred to next sync.`);
+            work = work.slice(0, MAX_PROMOTIONS_PER_PASS);
+        }
+
+        // 4. PROMOTE: ADD COLUMN+CodeGen (only the keys that need a column) → IOF rows → field maps → spread.
+        const newColumns = work.filter(w => w.needsColumn);
+        if (newColumns.length > 0 && !await this.applySchemaChange(entityInfo, newColumns)) {
+            return []; // DDL failed — leave everything captured; retry next sync (no partial commit lost)
+        }
+        await this.createIntegrationObjectFields(integrationID, entityMap.ExternalObjectName, work);
+        await this.createFieldMaps(entityMap.ID, work.filter(w => w.needsFieldMap));
+        // M3: spread staged values into the real columns + re-baseline the content hash.
+        // CRITICAL: refresh metadata FIRST. applySchemaChange just added the columns AND had RSU
+        // regenerate the spUpdate sproc to include them — but the running provider's in-memory entity
+        // metadata still predates the column add (the Refresh at the top ran before it). Without this,
+        // the spread's row.Save() builds a sproc call from the STALE field list that doesn't match the
+        // regenerated sproc → "Error executing SQL" (the spread-save failures). Re-loading metadata
+        // here aligns the entity's field set with the new DB sproc so the backfill saves succeed.
+        try { await this.provider.Refresh(); } catch (err) { LogError(`[CustomColumnPromoter] pre-spread Refresh failed: ${this.msg(err)}`); }
+        const refreshedEntityInfo = this.provider.EntityByName(entityName) ?? entityInfo;
+        await this.spreadAndRebaseline(entityName, entityMap.ID, refreshedEntityInfo, work);
+
+        LogStatus(`[CustomColumnPromoter] Promoted/recovered ${work.length} custom column(s) on ${entityName}: ${work.map(w => w.columnName).join(', ')}`);
+        return work.map(w => ({ EntityName: entityName, ColumnName: w.columnName }));
+    }
+
+    /** Samples the overflow column (rows where it is non-null) — dialect-agnostic via RunView. */
+    private async scanOverflow(entityName: string): Promise<Array<string | null>> {
+        const rv = new RunView();
+        const res = await rv.RunView<Record<string, unknown>>({
+            EntityName: entityName,
+            Fields: [CUSTOM_OVERFLOW_COLUMN],
+            ExtraFilter: `${CUSTOM_OVERFLOW_COLUMN} IS NOT NULL`,
+            MaxRows: OVERFLOW_SAMPLE_SIZE,
+            ResultType: 'simple',
+        }, this.user);
+        if (!res.Success) {
+            LogError(`[CustomColumnPromoter] Overflow scan failed for ${entityName}: ${res.ErrorMessage}`);
+            return [];
+        }
+        return (res.Results ?? []).map(r => (r[CUSTOM_OVERFLOW_COLUMN] as string | null) ?? null);
+    }
+
+    /**
+     * Splits coverage-passing keys into actionable work items, dropping any that are fully
+     * terminated (column AND field map both exist). A key whose column exists but whose field
+     * map is missing becomes a RECOVERY item (covers the crash window between ADD COLUMN and the
+     * field-map write) — needsColumn=false, needsFieldMap=true.
+     */
+    private resolveWorkItems(
+        passing: PromotionCandidate[],
+        entityInfo: EntityInfo,
+        fieldMapSources: ReadonlySet<string>,
+    ): WorkItem[] {
+        const existingByLower = new Map(entityInfo.Fields.map(f => [f.Name.toLowerCase(), f.Name]));
+        const taken = new Set(entityInfo.Fields.map(f => f.Name.toLowerCase()));
+        const items: WorkItem[] = [];
+        for (const candidate of passing) {
+            const existingCol = existingByLower.get(sanitizeColumnName(candidate.Key).toLowerCase());
+            const hasColumn = !!existingCol;
+            const hasFieldMap = fieldMapSources.has(candidate.Key.toLowerCase());
+            if (hasColumn && hasFieldMap) continue; // terminated — nothing to do
+            const columnName = existingCol ?? this.uniqueColumnName(sanitizeColumnName(candidate.Key), taken);
+            if (!hasColumn) taken.add(columnName.toLowerCase());
+            items.push({ candidate, sourceKey: candidate.Key, columnName, needsColumn: !hasColumn, needsFieldMap: !hasFieldMap });
+        }
+        return items;
+    }
+
+    /** Active field-map SOURCE field names for an entity map (lowercased) — for the terminate/recovery check. */
+    private async activeFieldMapSources(entityMapID: string): Promise<ReadonlySet<string>> {
+        const rv = new RunView();
+        const res = await rv.RunView<MJCompanyIntegrationFieldMapEntity>({
+            EntityName: 'MJ: Company Integration Field Maps',
+            ExtraFilter: `EntityMapID='${entityMapID}' AND Status='Active'`,
+            Fields: ['SourceFieldName'],
+            ResultType: 'simple',
+        }, this.user);
+        return new Set(res.Success ? (res.Results ?? []).map(r => (r.SourceFieldName ?? '').toLowerCase()) : []);
+    }
+
+    /** Suffixes _2, _3, … until the sanitized name does not collide with an existing/assigned one. */
+    private uniqueColumnName(base: string, taken: Set<string>): string {
+        if (!taken.has(base.toLowerCase())) return base;
+        for (let i = 2; i < 1000; i++) {
+            const candidate = `${base}_${i}`;
+            if (!taken.has(candidate.toLowerCase())) return candidate;
+        }
+        return `${base}_${Date.now() % 100000}`; // pathological fallback (never expected)
+    }
+
+    /** Generates ADD COLUMN DDL for the new columns and runs it through RSU (CodeGen reflects them). */
+    private async applySchemaChange(entityInfo: EntityInfo, named: WorkItem[]): Promise<boolean> {
+        const platform = this.dbProvider.PlatformKey as DatabasePlatform;
+        const ddl = new DDLGenerator();
+        const statements = named.map(n =>
+            ddl.GenerateAlterTableAddColumn(
+                entityInfo.SchemaName,
+                entityInfo.BaseTable,
+                this.toTargetColumn(n, platform),
+                platform,
+            ),
+        );
+        const input: RSUPipelineInput = {
+            MigrationSQL: statements.join('\n'),
+            Description: `Promote ${named.length} custom column(s) on ${entityInfo.Name}`,
+            AffectedTables: [`${entityInfo.SchemaName}.${entityInfo.BaseTable}`],
+            // M3 owns the restart-signal + restart; this stage applies schema only. Runtime
+            // promotion creates no git commit (the dev RSU flow does; a per-sync commit is noise).
+            SkipRestart: true,
+            SkipGitCommit: true,
+        };
+        const result = await RuntimeSchemaManager.Instance.RunPipeline(input);
+        if (!result.Success) {
+            LogError(`[CustomColumnPromoter] RSU ADD COLUMN failed on ${entityInfo.Name}: ${result.ErrorMessage ?? result.ErrorStep ?? 'unknown'}`);
+        }
+        return result.Success;
+    }
+
+    /** Builds a per-platform TargetColumnConfig from a planned candidate. */
+    private toTargetColumn(n: WorkItem, platform: DatabasePlatform): TargetColumnConfig {
+        const inferred = n.candidate.Inferred;
+        return {
+            SourceFieldName: n.sourceKey,
+            TargetColumnName: n.columnName,
+            TargetSqlType: platform === 'sqlserver' ? inferred.SqlServerType : inferred.PostgresType,
+            IsNullable: true, // customs are always nullable (never fabricate NOT NULL)
+            MaxLength: inferred.MaxLength,
+            Precision: null,
+            Scale: null,
+            DefaultValue: null,
+        };
+    }
+
+    /** Creates an IOF row per promoted field (IsCustom, MetadataSource='Discovered'). */
+    private async createIntegrationObjectFields(
+        integrationID: string,
+        externalObjectName: string,
+        named: WorkItem[],
+    ): Promise<void> {
+        const objectID = await this.resolveIntegrationObjectID(integrationID, externalObjectName);
+        if (!objectID) {
+            LogError(`[CustomColumnPromoter] No IntegrationObject '${externalObjectName}' for integration ${integrationID}; IOF rows skipped.`);
+            return;
+        }
+        // Idempotent: a recovery item (column existed, field map missing) may already have its IOF.
+        const existingIOF = await this.existingIOFNames(objectID);
+        for (const n of named) {
+            if (existingIOF.has(n.sourceKey.toLowerCase())) continue;
+            const iof = await this.provider.GetEntityObject<MJIntegrationObjectFieldEntity>('MJ: Integration Object Fields', this.user);
+            iof.NewRecord();
+            iof.IntegrationObjectID = objectID;
+            iof.Name = n.sourceKey;
+            iof.DisplayName = n.sourceKey;
+            iof.Description = `Custom field discovered during sync; promoted to column ${n.columnName}.`;
+            iof.Type = n.candidate.Inferred.SchemaFieldType;
+            iof.Length = n.candidate.Inferred.MaxLength;
+            iof.AllowsNull = true;
+            iof.IsPrimaryKey = false;   // never fabricated for customs (deferred to D4)
+            iof.IsUniqueKey = false;
+            iof.IsReadOnly = false;
+            iof.IsRequired = false;
+            iof.IsCustom = true;
+            // Provenance is STAMPED by this write path, never inferred later. 'Discovered' = the
+            // system found it automatically (vs 'Declared' curated / 'Custom' customer-added). The
+            // Configuration marker records the finer truth: it was data-sampled from a flat-file
+            // feed (not an authoritative describe endpoint) with this coverage, and its type was
+            // INFERRED — so consumers can treat it as soft / safely re-typable.
+            iof.MetadataSource = 'Discovered';
+            iof.Configuration = JSON.stringify({
+                promotedFrom: 'overflow',
+                coverage: Number(n.candidate.Coverage.toFixed(3)),
+                typeInferredFromData: true,
+            });
+            iof.Status = 'Active';
+            if (!await iof.Save()) {
+                LogError(`[CustomColumnPromoter] IOF save failed for ${n.sourceKey}: ${iof.LatestResult?.CompleteMessage ?? 'unknown'}`);
+            }
+        }
+    }
+
+    /** Creates a field map (source key → new column) so the next sync maps natively → terminate. */
+    private async createFieldMaps(entityMapID: string, named: WorkItem[]): Promise<void> {
+        for (const n of named) {
+            const fm = await this.provider.GetEntityObject<MJCompanyIntegrationFieldMapEntity>('MJ: Company Integration Field Maps', this.user);
+            fm.NewRecord();
+            fm.EntityMapID = entityMapID;
+            fm.SourceFieldName = n.sourceKey;
+            fm.DestinationFieldName = n.columnName;
+            fm.IsKeyField = false;
+            fm.IsRequired = false;
+            fm.Status = 'Active';
+            if (!await fm.Save()) {
+                LogError(`[CustomColumnPromoter] Field map save failed for ${n.sourceKey}: ${fm.LatestResult?.CompleteMessage ?? 'unknown'}`);
+            }
+        }
+    }
+
+    /**
+     * Spreads the staged overflow JSON values into the freshly-created real columns, then
+     * re-baselines the content hash (gaps.md §2 step 3). JS per-row pass — dialect-agnostic (no
+     * cast SQL, which is where PG bugs hide); BaseEntity handles the dialect on write. The overflow
+     * column is intentionally NOT cleared: once the field map exists the key is no longer "unmapped",
+     * so the next sync stops re-capturing it and planPromotions skips the now-existing column — the
+     * stale value self-heals. Bounded to rows that carry overflow, paged, once on the discovery sync.
+     */
+    private async spreadAndRebaseline(
+        entityName: string,
+        entityMapID: string,
+        entityInfo: EntityInfo,
+        named: WorkItem[],
+    ): Promise<void> {
+        const hasHashCol = entityInfo.Fields.some(f => f.Name === CONTENT_HASH_COLUMN);
+        const mappedDestFields = hasHashCol ? await this.activeDestinationFields(entityMapID) : [];
+
+        let startRow = 0;
+        const pageSize = 500;
+        for (;;) {
+            const rv = new RunView();
+            const res = await rv.RunView<BaseEntity>({
+                EntityName: entityName,
+                ExtraFilter: `${CUSTOM_OVERFLOW_COLUMN} IS NOT NULL`,
+                ResultType: 'entity_object',
+                MaxRows: pageSize,
+                StartRow: startRow,
+            }, this.user);
+            if (!res.Success) {
+                LogError(`[CustomColumnPromoter] Spread scan failed for ${entityName}: ${res.ErrorMessage}`);
+                return;
+            }
+            const rows = res.Results ?? [];
+            for (const row of rows) {
+                await this.spreadOneRow(row, named, hasHashCol, mappedDestFields);
+            }
+            if (rows.length < pageSize) break;
+            startRow += pageSize;
+        }
+    }
+
+    /** Applies the staged values + re-baselined hash to a single row entity and saves it. */
+    private async spreadOneRow(
+        row: BaseEntity,
+        named: WorkItem[],
+        hasHashCol: boolean,
+        mappedDestFields: string[],
+    ): Promise<void> {
+        // Dynamic .Get/.Set is REQUIRED here: these columns were created at runtime and have no
+        // generated typed property in this still-running process (full typed access arrives on the
+        // post-promotion restart). This is the sanctioned exception to the no-.Get/.Set rule.
+        const overflow = this.parseOverflow(row.Get(CUSTOM_OVERFLOW_COLUMN));
+        if (!overflow) return;
+        let changed = false;
+        for (const n of named) {
+            if (Object.prototype.hasOwnProperty.call(overflow, n.sourceKey)) {
+                row.Set(n.columnName, overflow[n.sourceKey]);
+                changed = true;
+            }
+        }
+        if (!changed) return;
+        if (hasHashCol) {
+            // Re-baseline to the next-sync value: hash over all active mapped destination columns
+            // (now incl. the new ones) as they sit on the row — matches what the next sync computes.
+            const mapped: Record<string, unknown> = {};
+            for (const dest of mappedDestFields) mapped[dest] = row.Get(dest);
+            row.Set(CONTENT_HASH_COLUMN, computeContentHash(mapped));
+        }
+        if (!await row.Save()) {
+            LogError(`[CustomColumnPromoter] Spread save failed: ${row.LatestResult?.CompleteMessage ?? 'unknown'}`);
+        }
+    }
+
+    /** Active field-map destination column names for an entity map (for hash re-baseline). */
+    private async activeDestinationFields(entityMapID: string): Promise<string[]> {
+        const rv = new RunView();
+        const res = await rv.RunView<MJCompanyIntegrationFieldMapEntity>({
+            EntityName: 'MJ: Company Integration Field Maps',
+            ExtraFilter: `EntityMapID='${entityMapID}' AND Status='Active'`,
+            Fields: ['DestinationFieldName'],
+            ResultType: 'simple',
+        }, this.user);
+        return res.Success ? (res.Results ?? []).map(r => r.DestinationFieldName).filter(Boolean) : [];
+    }
+
+    private parseOverflow(raw: unknown): Record<string, unknown> | null {
+        if (typeof raw !== 'string' || raw.length === 0) return null;
+        try {
+            const parsed: unknown = JSON.parse(raw);
+            return parsed && typeof parsed === 'object' && !Array.isArray(parsed) ? (parsed as Record<string, unknown>) : null;
+        } catch {
+            return null;
+        }
+    }
+
+    /** Loads the CompanyIntegration's IntegrationID. */
+    private async resolveIntegrationID(companyIntegrationID: string): Promise<string | null> {
+        const ci = await this.provider.GetEntityObject<MJCompanyIntegrationEntity>('MJ: Company Integrations', this.user);
+        const loaded = await ci.Load(companyIntegrationID);
+        return loaded ? ci.IntegrationID : null;
+    }
+
+    /** Finds the entity map (ExternalObject↔Entity) for this CI + target entity. */
+    private async findEntityMap(
+        companyIntegrationID: string,
+        entityName: string,
+    ): Promise<{ ID: string; ExternalObjectName: string } | null> {
+        const rv = new RunView();
+        const res = await rv.RunView<MJCompanyIntegrationEntityMapEntity>({
+            EntityName: 'MJ: Company Integration Entity Maps',
+            ExtraFilter: `CompanyIntegrationID='${companyIntegrationID}' AND Entity='${this.escape(entityName)}'`,
+            ResultType: 'simple',
+            MaxRows: 1,
+        }, this.user);
+        const row = res.Success ? res.Results?.[0] : undefined;
+        return row ? { ID: row.ID, ExternalObjectName: row.ExternalObjectName } : null;
+    }
+
+    /** Existing IOF field names (lowercased) for an object — for idempotent IOF creation. */
+    private async existingIOFNames(objectID: string): Promise<ReadonlySet<string>> {
+        const rv = new RunView();
+        const res = await rv.RunView<MJIntegrationObjectFieldEntity>({
+            EntityName: 'MJ: Integration Object Fields',
+            ExtraFilter: `IntegrationObjectID='${objectID}'`,
+            Fields: ['Name'],
+            ResultType: 'simple',
+        }, this.user);
+        return new Set(res.Success ? (res.Results ?? []).map(r => (r.Name ?? '').toLowerCase()) : []);
+    }
+
+    /** Resolves the IntegrationObject ID for an external object name under an integration. */
+    private async resolveIntegrationObjectID(integrationID: string, externalObjectName: string): Promise<string | null> {
+        const rv = new RunView();
+        const res = await rv.RunView<MJIntegrationObjectEntity>({
+            EntityName: 'MJ: Integration Objects',
+            ExtraFilter: `IntegrationID='${integrationID}' AND Name='${this.escape(externalObjectName)}'`,
+            Fields: ['ID', 'Name', 'IntegrationID'],
+            ResultType: 'simple',
+            MaxRows: 1,
+        }, this.user);
+        const row = res.Success ? res.Results?.[0] : undefined;
+        return row ? row.ID : null;
+    }
+
+    private escape(value: string): string {
+        return value.replace(/'/g, "''");
+    }
+
+    private msg(err: unknown): string {
+        return err instanceof Error ? err.message : String(err);
+    }
+}

--- a/packages/MJServer/src/resolvers/IntegrationDiscoveryResolver.ts
+++ b/packages/MJServer/src/resolvers/IntegrationDiscoveryResolver.ts
@@ -1,4 +1,4 @@
-import { Resolver, Query, Mutation, Arg, Ctx, ObjectType, Field, InputType } from "type-graphql";
+import { Resolver, Query, Mutation, Arg, Ctx, ObjectType, Field, InputType, Int, Float } from "type-graphql";
 import { CompositeKey, DatabaseProviderBase, LocalCacheManager, Metadata, RunView, UserInfo, LogError, LogStatus, IMetadataProvider, TransactionGroupBase } from "@memberjunction/core";
 import { GetReadOnlyProvider, GetReadWriteProvider } from "../util.js";
 import { CronExpressionHelper } from "@memberjunction/scheduling-engine";
@@ -568,6 +568,34 @@ class CreateConnectionOutput {
 class MutationResultOutput {
     @Field() Success: boolean;
     @Field() Message: string;
+}
+
+// ─── Typed sync-config (rate-limit / concurrency / time-budget as STRUCTURED fields, not a raw
+//     Configuration JSON blob). These map to the CompanyIntegration.Configuration keys the engine
+//     reads at runtime, so they are customizable per-connection via the API instead of hidden code
+//     constants. Set merges (preserves other Configuration keys); Get reads them back typed. ──────
+@InputType()
+class IntegrationSyncConfigInput {
+    @Field(() => Int, { nullable: true, description: 'Entity maps processed concurrently within a dependency layer (clamped 1-16). Default 1 (sequential).' }) SyncConcurrency?: number;
+    @Field(() => Int, { nullable: true, description: 'Upper bound the per-layer AIMD controller ramps toward. Default = connector MaxConcurrencyHint.' }) MaxConcurrency?: number;
+    @Field(() => Float, { nullable: true, description: 'Override the source rate limit (requests/sec). Default = connector RateLimitPolicy / derived.' }) RateLimitTokensPerSec?: number;
+    @Field(() => Int, { nullable: true, description: 'Override the rate-limiter burst capacity (tokens).' }) RateLimitBurst?: number;
+    @Field(() => Boolean, { nullable: true, description: '§4 cross-layer pipelining: a child map starts when ITS parents finish, not the whole layer.' }) CrossLayerPipeline?: boolean;
+    @Field(() => Boolean, { nullable: true, description: 'Merkle/partition hash-diff reconcile for watermark-less change detection (buffers the set in RAM).' }) PartitionReconcile?: boolean;
+    @Field(() => Int, { nullable: true, description: 'Time budget (ms) for stage-2 streaming field discovery before it stops and uses what it gathered.' }) DiscoveryTimeBudgetMs?: number;
+}
+
+@ObjectType()
+class IntegrationSyncConfigOutput {
+    @Field() Success: boolean;
+    @Field() Message: string;
+    @Field(() => Int, { nullable: true }) SyncConcurrency?: number;
+    @Field(() => Int, { nullable: true }) MaxConcurrency?: number;
+    @Field(() => Float, { nullable: true }) RateLimitTokensPerSec?: number;
+    @Field(() => Int, { nullable: true }) RateLimitBurst?: number;
+    @Field(() => Boolean, { nullable: true }) CrossLayerPipeline?: boolean;
+    @Field(() => Boolean, { nullable: true }) PartitionReconcile?: boolean;
+    @Field(() => Int, { nullable: true }) DiscoveryTimeBudgetMs?: number;
 }
 
 @InputType()
@@ -2571,6 +2599,81 @@ export class IntegrationDiscoveryResolver extends ResolverBase {
             LogError(`IntegrationUpdateConnection error: ${e}`);
             return { Success: false, Message: this.formatError(e) };
         }
+    }
+
+    /**
+     * Sets the per-connection sync tuning (rate limit, concurrency, time budget, pipeline flags) as
+     * STRUCTURED typed fields, merged into CompanyIntegration.Configuration (other keys preserved).
+     * These are the exact keys the IntegrationEngine reads at runtime, so they become customizable
+     * via the API instead of hidden code constants. Returns the merged config typed.
+     */
+    @Mutation(() => IntegrationSyncConfigOutput)
+    async IntegrationSetSyncConfig(
+        @Arg("companyIntegrationID") companyIntegrationID: string,
+        @Arg("config", () => IntegrationSyncConfigInput) config: IntegrationSyncConfigInput,
+        @Ctx() ctx: AppContext
+    ): Promise<IntegrationSyncConfigOutput> {
+        try {
+            const user = this.getAuthenticatedUser(ctx);
+            const md = GetReadWriteProvider(ctx.providers, { allowFallbackToReadOnly: true }) as unknown as IMetadataProvider;
+            const ci = await md.GetEntityObject<MJCompanyIntegrationEntity>('MJ: Company Integrations', user);
+            if (!await ci.InnerLoad(CompositeKey.FromID(companyIntegrationID))) {
+                return { Success: false, Message: 'CompanyIntegration not found' };
+            }
+            let cfg: Record<string, unknown> = {};
+            try { if (ci.Configuration) cfg = JSON.parse(ci.Configuration) as Record<string, unknown>; } catch { cfg = {}; }
+            const set = (key: string, val: unknown) => { if (val !== undefined && val !== null) cfg[key] = val; };
+            set('syncConcurrency', config.SyncConcurrency);
+            set('maxConcurrency', config.MaxConcurrency);
+            set('rateLimitTokensPerSec', config.RateLimitTokensPerSec);
+            set('rateLimitBurst', config.RateLimitBurst);
+            set('crossLayerPipeline', config.CrossLayerPipeline);
+            set('partitionReconcile', config.PartitionReconcile);
+            set('discoveryTimeBudgetMs', config.DiscoveryTimeBudgetMs);
+            ci.Configuration = JSON.stringify(cfg);
+            if (!await ci.Save()) return { Success: false, Message: `Failed to save: ${ci.LatestResult?.CompleteMessage ?? 'unknown'}` };
+            return { Success: true, Message: 'Sync config updated', ...this.readSyncConfig(cfg) };
+        } catch (e) {
+            LogError(`IntegrationSetSyncConfig error: ${e}`);
+            return { Success: false, Message: this.formatError(e) };
+        }
+    }
+
+    /** Reads the per-connection sync tuning back as STRUCTURED typed fields. */
+    @Query(() => IntegrationSyncConfigOutput)
+    async IntegrationGetSyncConfig(
+        @Arg("companyIntegrationID") companyIntegrationID: string,
+        @Ctx() ctx: AppContext
+    ): Promise<IntegrationSyncConfigOutput> {
+        try {
+            const user = this.getAuthenticatedUser(ctx);
+            const md = GetReadWriteProvider(ctx.providers, { allowFallbackToReadOnly: true }) as unknown as IMetadataProvider;
+            const ci = await md.GetEntityObject<MJCompanyIntegrationEntity>('MJ: Company Integrations', user);
+            if (!await ci.InnerLoad(CompositeKey.FromID(companyIntegrationID))) {
+                return { Success: false, Message: 'CompanyIntegration not found' };
+            }
+            let cfg: Record<string, unknown> = {};
+            try { if (ci.Configuration) cfg = JSON.parse(ci.Configuration) as Record<string, unknown>; } catch { cfg = {}; }
+            return { Success: true, Message: 'OK', ...this.readSyncConfig(cfg) };
+        } catch (e) {
+            LogError(`IntegrationGetSyncConfig error: ${e}`);
+            return { Success: false, Message: this.formatError(e) };
+        }
+    }
+
+    /** Extracts the typed sync-config fields from a parsed Configuration object (type-guarded). */
+    private readSyncConfig(cfg: Record<string, unknown>): Partial<IntegrationSyncConfigOutput> {
+        const num = (v: unknown) => (typeof v === 'number' && Number.isFinite(v) ? v : undefined);
+        const bool = (v: unknown) => (typeof v === 'boolean' ? v : undefined);
+        return {
+            SyncConcurrency: num(cfg.syncConcurrency),
+            MaxConcurrency: num(cfg.maxConcurrency),
+            RateLimitTokensPerSec: num(cfg.rateLimitTokensPerSec),
+            RateLimitBurst: num(cfg.rateLimitBurst),
+            CrossLayerPipeline: bool(cfg.crossLayerPipeline),
+            PartitionReconcile: bool(cfg.partitionReconcile),
+            DiscoveryTimeBudgetMs: num(cfg.discoveryTimeBudgetMs),
+        };
     }
 
     /**
@@ -5024,13 +5127,19 @@ export class IntegrationDiscoveryResolver extends ResolverBase {
                 return { Success: false, Message: 'Transaction failed — all deletes rolled back' };
             }
 
-            if (deleteData) {
-                LogError(`IntegrationDeleteConnection: deleteData=true requested but table deletion not yet implemented for ${companyIntegrationID}`);
-            }
+            // deleteData=true asks us to also DROP the physical mirror tables. We deliberately do NOT:
+            // RuntimeSchemaManager rejects DROP TABLE on the __mj schema by design (a destructive-op
+            // safety guard), and there is no DROP generator. Dropping integration tables is real data
+            // loss and must be an explicit, separately-designed operation — not a silent side effect of
+            // removing a connection. So we delete the connection + all METADATA (maps/fields/schedules/
+            // credential) and RETAIN the data tables, and we say so honestly rather than claim otherwise.
+            const dataNote = deleteData
+                ? ' The physical data tables were RETAINED (dropping integration tables is not performed automatically — it is a separate, explicit operation).'
+                : '';
 
             return {
                 Success: true,
-                Message: `Deleted connection and all associated records`,
+                Message: `Deleted connection and all associated metadata records.${dataNote}`,
                 EntityMapsDeleted: entityMapsDeleted,
                 FieldMapsDeleted: fieldMapsDeleted,
                 SchedulesDeleted: schedulesDeleted,

--- a/plans/openwater-growthzone-event-system.md
+++ b/plans/openwater-growthzone-event-system.md
@@ -1,0 +1,101 @@
+# [New Event System] OpenWater + GrowthZone enhancement — Plan
+
+**Branch:** `connectors/openwater_growthzone`
+**Worktree:** `/Users/madhavsubramaniyam/Projects/MJ/MJ-openwater`
+**Status:** Draft plan (pre-PR). No PR raised yet.
+
+## 1. Context
+
+Two distinct pieces of work united by the **event-management** theme:
+
+- **OpenWater — new connector (green-field).** OpenWater is an event / awards / abstracts / application
+  management platform with a REST API. No connector exists in the repo today
+  (`packages/Integration/connectors/src/` has no `OpenWaterConnector.ts`). This is a from-scratch
+  `BaseRESTIntegrationConnector` build.
+- **GrowthZone — enhance the existing connector.** `GrowthZoneConnector.ts` already ships on `next`
+  (`IntegrationName: 'GrowthZone'`, extends `BaseRESTIntegrationConnector`), but it is currently
+  **read-only** and shallow on events:
+  - Objects: Contacts, Groups/committees, **Events**, Invoices, Payments, Certifications — **all
+    `SupportsWrite: false`**.
+  - Incremental: **only** `/api/contacts/delta` (contacts). Other objects fall back to Offset pagination
+    with no incremental signal.
+  - Custom-field discovery via `POST /api/customfields/getall`; field discovery is live.
+
+  The "Event System" framing points the enhancement squarely at GrowthZone's **event surface** — the
+  current single read-only `Events` object is too thin for an event-system integration.
+
+## 2. OpenWater connector — scope (new)
+
+Standard connector build per repo conventions (`.claude/rules/connector-code-conventions.md`):
+- `@RegisterClass(BaseIntegrationConnector, 'OpenWaterConnector')`, `IntegrationName: 'OpenWater'`,
+  extends `BaseRESTIntegrationConnector`.
+- **Auth** — confirm scheme from OpenWater docs (API key / token); use `auth-helpers`, never inline crypto.
+- **Discovery** — pick the mode by what OpenWater exposes (rule: customs must be captured):
+  - LIVE introspection if a schema/describe endpoint exists; else
+  - SAMPLE-discovery (fetch a page, union flattened keys, emit extras as nullable) if data is reachable; else
+  - STATIC catalog **only** if the schema is genuinely fixed.
+- **Objects (to confirm from docs/API, not invented)** — the event-system core: Programs/Events,
+  Applications/Submissions, Registrations/Attendees, Forms, Users/Judges, Payments. Curate from the real
+  API surface.
+- **CRUD + incremental** — wire per-operation columns only for capabilities OpenWater actually supports;
+  set `IncrementalWatermarkField` if a modified-since cursor exists.
+
+## 3. GrowthZone enhancement — scope (event-focused)
+
+Keep changes additive and provable; do not regress the working read-only objects (repo memory: "never
+change working code to fix broken code").
+
+1. **Deepen the event surface** — add the event child/related objects GrowthZone's API exposes
+   (event registrations / attendees, sessions, ticket types) as their own IOs with correct FK
+   (`IsForeignKey` + `ForeignKeyTarget`) back to `Events`, so the sync DAG/traversal order is right.
+2. **Incremental for events** — investigate whether GrowthZone offers a delta/modified-since endpoint for
+   events analogous to `/api/contacts/delta`; if yes, set `SupportsIncrementalSync` + `IncrementalWatermarkField`.
+   If not, use the keyset/content-hash path and **log** the absence (no fabricated watermark).
+3. **Write support (only if the vendor supports it)** — if GrowthZone's API allows event registration
+   writes, wire the per-operation Create/Update/Delete columns + `BuildCreatedResult`. Otherwise leave
+   `SupportsWrite: false` honestly — no `501` stubs behind a `true` flag.
+
+## 4. Provable-only discipline
+
+- Do **not** hardcode invented OpenWater or GrowthZone object/field lists. Confirm every object, field,
+  endpoint, PK/FK, and capability flag from the vendor API docs / OpenAPI / a real response, with
+  PROVENANCE.json or CODE_EVIDENCE.json backing each hard-constraint emission.
+- Emit `undefined` (not `false`) for unprovable booleans (PK/required/nullable) so the persist-time overlay
+  doesn't wipe curated values.
+
+## 5. Testing approach (credential triage first)
+
+Per `.claude/rules/connector-credential-testing.md`, classify credential obtainability up front and report
+the achievable ceiling for **each** vendor independently:
+- **Live (PATH 1)** — if an OpenWater and/or GrowthZone sandbox/dev credential is broker-held or self-serve,
+  run the ordered §1→§7 live E2E on SQL Server (PG suspended for the per-connector loop).
+- **Credential-free (PATH 2)** — otherwise mock each REST surface from documented response shapes, replay
+  fixtures, status-probe endpoints, and prove discovery→map→CRUD→incremental against a spec-driven mock.
+  Label the ceiling `format-verified-no-creds` honestly.
+- Mocked vitest tiers (T4/T5): new `OpenWaterConnector.test.ts`; extend `GrowthZoneConnector.test.ts` for
+  the new event objects + any incremental/write additions.
+
+## 6. Deliverables for the PR
+
+- [ ] `OpenWaterConnector.ts` + registration in `index.ts` + metadata (provenance-backed)
+- [ ] GrowthZone event-surface enhancement (additive, no regression) + metadata updates
+- [ ] Tests at the achieved tier for both, with honest residual-gap statements
+- [ ] Changeset
+
+## 7. Open questions
+
+1. **Credentials** — is an OpenWater and/or GrowthZone sandbox reachable to us (broker / self-serve)?
+   Sets each vendor's test ceiling.
+2. **OpenWater object scope** — full surface, or a prioritized v1 (Events + Registrations + Submissions)?
+3. **GrowthZone enhancement depth** — events-only, or also add write-back for registrations if the API
+   supports it?
+4. **GrowthZone event incremental** — does a delta/modified-since endpoint exist for events, or do we ride
+   keyset/content-hash?
+
+## Links
+
+- GrowthZone connector: `packages/Integration/connectors/src/GrowthZoneConnector.ts`
+- GrowthZone tests: `packages/Integration/connectors/src/__tests__/GrowthZoneConnector.test.ts`
+- Connector code conventions: `.claude/rules/connector-code-conventions.md`
+- Credential/testing conventions: `.claude/rules/connector-credential-testing.md`
+- Metadata file conventions: `.claude/rules/metadata-file-conventions.md`


### PR DESCRIPTION
OpenWater is a green-field new connector (event/awards/abstracts platform); GrowthZone already ships read-only on next with a thin single Events object and contacts-only incremental. Plan scopes a new OpenWater connector plus an additive, event-focused GrowthZone enhancement (deeper event objects, event incremental if the API supports it, write-back only if supported), with credential triage and provable-only discipline. Open questions captured.