### PR TITLE
chore(esignature): add required repository field to eSignature package.json files

### DIFF
--- a/packages/eSignature/Base/package.json
+++ b/packages/eSignature/Base/package.json
@@ -33,6 +33,10 @@
     "test:coverage": "vitest run --coverage"
   },
   "license": "ISC",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/MemberJunction/MJ"
+  },
   "dependencies": {
     "@memberjunction/global": "5.39.0",
     "@memberjunction/core": "5.39.0",

--- a/packages/eSignature/Providers/DocuSign/package.json
+++ b/packages/eSignature/Providers/DocuSign/package.json
@@ -23,5 +23,9 @@
   },
   "devDependencies": {
     "@types/jsonwebtoken": "^9.0.0"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/MemberJunction/MJ"
   }
 }

--- a/packages/eSignature/Providers/DropboxSign/package.json
+++ b/packages/eSignature/Providers/DropboxSign/package.json
@@ -16,6 +16,10 @@
     "test:coverage": "vitest run --coverage"
   },
   "license": "ISC",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/MemberJunction/MJ"
+  },
   "dependencies": {
     "@memberjunction/esignature": "5.39.0",
     "@memberjunction/global": "5.39.0"

--- a/packages/eSignature/Providers/PandaDoc/package.json
+++ b/packages/eSignature/Providers/PandaDoc/package.json
@@ -16,6 +16,10 @@
     "test:coverage": "vitest run --coverage"
   },
   "license": "ISC",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/MemberJunction/MJ"
+  },
   "dependencies": {
     "@memberjunction/esignature": "5.39.0",
     "@memberjunction/global": "5.39.0"


### PR DESCRIPTION


All @memberjunction packages must declare the standard repository field. Adds it to the four eSignature packages (esignature, esignature-docusign, esignature-dropboxsign, esignature-pandadoc).