### PR TITLE
fix(conversations): show ALL distinct artifacts on a message, not just the last

### DIFF
--- a/.changeset/many-artifacts-surface.md
+++ b/.changeset/many-artifacts-surface.md
@@ -1,0 +1,6 @@
+---
+"@memberjunction/ng-conversations": patch
+"@memberjunction/ng-artifacts": patch
+---
+
+Show all distinct artifacts on a conversation message instead of only the most recently created one — a message that carries both a report and a standalone generated image now renders a card for each. Multiple versions of the same artifact still collapse to the latest. Also halves the inline image/video preview height (280px → 140px) so thumbnails don't dominate the message.

--- a/packages/Angular/Generic/artifacts/src/lib/components/previews/image-artifact-preview.component.ts
+++ b/packages/Angular/Generic/artifacts/src/lib/components/previews/image-artifact-preview.component.ts
@@ -2,9 +2,15 @@ import { ChangeDetectorRef, Component, inject, OnInit } from '@angular/core';
 import { BaseArtifactPreviewComponent } from './base-artifact-preview.component';
 
 /**
- * Inline preview for image artifacts. Renders a single contained `<img>` (max 280px tall) inside
+ * Inline preview for image artifacts. Renders a single contained `<img>` (max 140px tall) inside
  * the conversation message card. Read-only — no toolbar, no zoom, no download. Clicking it bubbles
  * up through the card's clickable wrapper to open the full-size image viewer.
+ *
+ * Height note: this is a *thumbnail*, not the full view — kept deliberately compact (140px) so a
+ * message with an image artifact doesn't dominate the conversation. `max-width: 100%` (rather than a
+ * fixed width) is the only width constraint, so the aspect ratio is preserved and portrait images
+ * aren't distorted; the height cap is the single lever for overall size. Kept in sync with the video
+ * preview's cap so both visual media previews stay visually consistent.
  */
 @Component({
     standalone: false,
@@ -33,7 +39,7 @@ import { BaseArtifactPreviewComponent } from './base-artifact-preview.component'
             .image-preview__img {
                 display: block;
                 max-width: 100%;
-                max-height: 280px;
+                max-height: 140px;
                 width: auto;
                 height: auto;
                 object-fit: contain;

--- a/packages/Angular/Generic/artifacts/src/lib/components/previews/video-artifact-preview.component.ts
+++ b/packages/Angular/Generic/artifacts/src/lib/components/previews/video-artifact-preview.component.ts
@@ -33,10 +33,14 @@ import { BaseArtifactPreviewComponent } from './base-artifact-preview.component'
                 display: block;
             }
 
+            /* Compact thumbnail height — kept in sync with the image preview (140px) so both
+               visual media previews stay consistent and neither dominates the conversation.
+               Video keeps width:100% (unlike image) because the player chrome reads better at
+               full card width. */
             .video-preview__video {
                 display: block;
                 max-width: 100%;
-                max-height: 280px;
+                max-height: 140px;
                 width: 100%;
                 height: auto;
                 border-radius: 6px;

--- a/packages/Angular/Generic/conversations/src/__tests__/distinct-artifacts.test.ts
+++ b/packages/Angular/Generic/conversations/src/__tests__/distinct-artifacts.test.ts
@@ -1,0 +1,66 @@
+import { describe, it, expect } from 'vitest';
+import { selectDistinctLatestArtifacts } from '../lib/utils/distinct-artifacts';
+
+/**
+ * Regression guard for the bug where a message carrying TWO distinct artifacts
+ * (e.g. a research report + a standalone generated infographic) only ever showed
+ * ONE of them — the message list previously displayed `artifactList[length - 1]`,
+ * silently hiding the report behind the image. The fix surfaces every distinct
+ * artifact (latest version each); these tests lock that behavior in.
+ */
+describe('selectDistinctLatestArtifacts', () => {
+  const make = (artifactId: string, versionNumber: number, tag = '') =>
+    ({ artifactId, versionNumber, tag });
+
+  it('returns an empty array for empty input', () => {
+    expect(selectDistinctLatestArtifacts([])).toEqual([]);
+  });
+
+  it('keeps BOTH distinct artifacts (the report-hidden-behind-image bug)', () => {
+    const report = make('report-id', 1, 'report');
+    const image = make('image-id', 1, 'image');
+    const result = selectDistinctLatestArtifacts([report, image]);
+
+    expect(result).toHaveLength(2);
+    expect(result.map(r => r.artifactId)).toEqual(['report-id', 'image-id']);
+  });
+
+  it('collapses multiple versions of the SAME artifact to the latest', () => {
+    const v1 = make('a', 1, 'v1');
+    const v2 = make('a', 2, 'v2');
+    const v3 = make('a', 3, 'v3');
+    const result = selectDistinctLatestArtifacts([v1, v3, v2]);
+
+    expect(result).toHaveLength(1);
+    expect(result[0].versionNumber).toBe(3);
+    expect(result[0].tag).toBe('v3');
+  });
+
+  it('handles a mix: distinct artifacts each collapsed to their latest version', () => {
+    const reportV1 = make('report', 1, 'r1');
+    const reportV2 = make('report', 2, 'r2');
+    const image = make('image', 1, 'img');
+    const result = selectDistinctLatestArtifacts([reportV1, image, reportV2]);
+
+    expect(result).toHaveLength(2);
+    const byId = Object.fromEntries(result.map(r => [r.artifactId, r]));
+    expect(byId['report'].versionNumber).toBe(2);
+    expect(byId['report'].tag).toBe('r2');
+    expect(byId['image'].versionNumber).toBe(1);
+  });
+
+  it('preserves first-seen ordering of distinct artifacts', () => {
+    const image = make('image', 1);
+    const report = make('report', 1);
+    // image seen first → image stays first even though report has a later update
+    const result = selectDistinctLatestArtifacts([image, report, make('report', 2)]);
+    expect(result.map(r => r.artifactId)).toEqual(['image', 'report']);
+  });
+
+  it('does not mutate the input array', () => {
+    const input = [make('a', 1), make('a', 2), make('b', 1)];
+    const copy = [...input];
+    selectDistinctLatestArtifacts(input);
+    expect(input).toEqual(copy);
+  });
+});

--- a/packages/Angular/Generic/conversations/src/lib/components/message/message-item.component.html
+++ b/packages/Angular/Generic/conversations/src/lib/components/message/message-item.component.html
@@ -110,13 +110,13 @@
           </div>
         }
 
-        <!-- Artifact Message Card -->
-        @if (hasArtifact && artifact && artifactVersion) {
-          <div class="artifact-wrapper" [class.system-artifact]="isSystemArtifact">
+        <!-- Artifact Message Cards — one per distinct artifact on this message -->
+        @for (a of displayArtifacts; track a.artifact.ID) {
+          <div class="artifact-wrapper" [class.system-artifact]="a.artifact.Visibility === 'System Only'">
             <mj-artifact-message-card
-              [artifactId]="artifact.ID"
-              [artifact]="artifact"
-              [artifactVersion]="artifactVersion"
+              [artifactId]="a.artifact.ID"
+              [artifact]="a.artifact"
+              [artifactVersion]="a.version"
               [currentUser]="currentUser"
               (actionPerformed)="onArtifactActionPerformed($event)">
             </mj-artifact-message-card>

--- a/packages/Angular/Generic/conversations/src/lib/components/message/message-item.component.ts
+++ b/packages/Angular/Generic/conversations/src/lib/components/message/message-item.component.ts
@@ -47,6 +47,17 @@ export interface MessageAttachment {
 }
 
 /**
+ * A fully-loaded artifact + its version to render as a card under a message.
+ * A single message can carry more than one DISTINCT artifact (e.g. a research
+ * report plus a standalone generated infographic), so the message renders an
+ * array of these — one card each.
+ */
+export interface MessageArtifactRef {
+  artifact: MJArtifactEntity;
+  version: MJArtifactVersionEntity;
+}
+
+/**
  * Component for displaying a single message in a conversation
  * Follows the dynamic rendering pattern from skip-chat for optimal performance
  * This component is created dynamically via ViewContainerRef.createComponent()
@@ -68,6 +79,12 @@ export class MessageItemComponent extends BaseAngularComponent implements OnInit
   @Input() public isProcessing: boolean = false;
   @Input() public artifact?: MJArtifactEntity;
   @Input() public artifactVersion?: MJArtifactVersionEntity;
+  /**
+   * All distinct artifacts attached to this message, each at its latest version.
+   * Preferred over the single `artifact`/`artifactVersion` inputs above (which are
+   * retained for backward compatibility and kept pointed at the first entry).
+   */
+  @Input() public artifacts: MessageArtifactRef[] = [];
   @Input() public agentRun: MJAIAgentRunEntityExtended | null = null; // Passed from parent, loaded once per conversation
   @Input() public userAvatarMap: Map<string, {imageUrl: string | null; iconClass: string | null}> = new Map();
   @Input() public ratings?: RatingJSON[]; // Pre-loaded ratings from parent (RatingsJSON from query)
@@ -665,8 +682,23 @@ export class MessageItemComponent extends BaseAngularComponent implements OnInit
     return this.shouldShowRating();
   }
 
+  /**
+   * The artifacts to render under this message, one card each. Prefers the
+   * `artifacts` array; falls back to the legacy single `artifact`/`artifactVersion`
+   * inputs so older callers that set only those keep working.
+   */
+  public get displayArtifacts(): MessageArtifactRef[] {
+    if (this.artifacts && this.artifacts.length > 0) {
+      return this.artifacts;
+    }
+    if (this.artifact && this.artifactVersion) {
+      return [{ artifact: this.artifact, version: this.artifactVersion }];
+    }
+    return [];
+  }
+
   public get hasArtifact(): boolean {
-    return !!this.artifactVersion;
+    return this.displayArtifacts.length > 0;
   }
 
   /**

--- a/packages/Angular/Generic/conversations/src/lib/components/message/message-list.component.ts
+++ b/packages/Angular/Generic/conversations/src/lib/components/message/message-list.component.ts
@@ -19,6 +19,7 @@ import { UserInfo, CompositeKey } from '@memberjunction/core';
 import { BaseAngularComponent } from '@memberjunction/ng-base-types';
 import { MessageItemComponent, MessageAttachment } from './message-item.component';
 import { LazyArtifactInfo } from '../../models/lazy-artifact-info';
+import { selectDistinctLatestArtifacts } from '../../utils/distinct-artifacts';
 import { MJAIAgentRunEntityExtended } from '@memberjunction/ai-core-plus';
 
 /**
@@ -208,32 +209,9 @@ export class MessageListComponent extends BaseAngularComponent implements OnInit
           instance.userAvatarMap = this.userAvatarMap;
           instance.isLastMessage = (index === messages.length - 1); // Update last message flag
 
-          // Get artifact from lazy-loading map
-          const artifactList = this.artifactMap.get(message.ID);
-          // Use LAST artifact (most recent) instead of first for display
-          const lastArtifact = artifactList && artifactList.length > 0
-            ? artifactList[artifactList.length - 1]
-            : undefined;
-
-          // Trigger lazy load and set properties
-          if (lastArtifact) {
-            // Lazy load in background - don't block UI
-            Promise.all([
-              lastArtifact.getArtifact(),
-              lastArtifact.getVersion()
-            ]).then(([artifact, version]) => {
-              instance.artifact = artifact;
-              instance.artifactVersion = version;
-              // zone.js 0.15: parent detectChanges doesn't propagate to dynamically created children
-              existing.changeDetectorRef.detectChanges();
-              this.cdRef.detectChanges();
-            }).catch(err => {
-              console.error('Failed to lazy-load artifact:', err);
-            });
-          } else {
-            instance.artifact = undefined;
-            instance.artifactVersion = undefined;
-          }
+          // Surface ALL distinct artifacts on this message (latest version each),
+          // not just the most recent one. Loads lazily in the background.
+          this.applyArtifactsToInstance(instance, message.ID, existing.changeDetectorRef);
 
           // Update agent run from map
           instance.agentRun = this.agentRunMap.get(message.ID) || null;
@@ -265,29 +243,8 @@ export class MessageListComponent extends BaseAngularComponent implements OnInit
           instance.userAvatarMap = this.userAvatarMap;
           instance.isLastMessage = (index === messages.length - 1); // Mark last message
 
-          // Get artifact from lazy-loading map
-          const artifactList = this.artifactMap.get(message.ID);
-          // Use LAST artifact (most recent) instead of first for display
-          const lastArtifact = artifactList && artifactList.length > 0
-            ? artifactList[artifactList.length - 1]
-            : undefined;
-
-          // Trigger lazy load and set properties
-          if (lastArtifact) {
-            // Lazy load in background - don't block UI
-            Promise.all([
-              lastArtifact.getArtifact(),
-              lastArtifact.getVersion()
-            ]).then(([artifact, version]) => {
-              instance.artifact = artifact;
-              instance.artifactVersion = version;
-              // zone.js 0.15: parent detectChanges doesn't propagate to dynamically created children
-              componentRef.changeDetectorRef.detectChanges();
-              this.cdRef.detectChanges();
-            }).catch(err => {
-              console.error('Failed to lazy-load artifact:', err);
-            });
-          }
+          // Surface ALL distinct artifacts on this message (latest version each).
+          this.applyArtifactsToInstance(instance, message.ID, componentRef.changeDetectorRef);
 
           // Pass agent run from map (loaded once per conversation)
           instance.agentRun = this.agentRunMap.get(message.ID) || null;
@@ -340,6 +297,72 @@ export class MessageListComponent extends BaseAngularComponent implements OnInit
       this.cdRef.reattach();
       this.cdRef.detectChanges();
     }
+  }
+
+  /**
+   * Resolves the DISTINCT artifacts for a message (one entry per artifactId at its
+   * latest version), lazy-loads them all, and applies them to the rendered
+   * message-item. Loads in the background so the UI never blocks.
+   *
+   * WHY WE SURFACE THEM ALL (design rationale — see PR discussion w/ Pranav & Ethan):
+   * A single message can legitimately carry more than one DISTINCT artifact — e.g. a
+   * research report PLUS a *standalone* generated infographic. This is deliberately
+   * NOT in conflict with the server-side consolidation in AgentRunner
+   * (Pranav, 5664b86: "keep the report's embedded image in the report, not as a
+   * duplicate artifact"): that logic only suppresses media that is *embedded inline*
+   * (base64) in another artifact's payload — a true duplicate. Genuinely standalone
+   * sibling artifacts (the report uses SVG charts; the infographic is a separate JPEG)
+   * are correctly kept as separate artifacts, and the UI must show every one of them.
+   *
+   * The earlier `artifactList[length - 1]` ("show only the most recent") approach
+   * (EL-BC, 95492622) assumed consolidation always left exactly one artifact per
+   * message; when it legitimately leaves two, that silently hid the report behind the
+   * image. Grouping by artifactId (latest version each) shows all distinct artifacts
+   * while still collapsing multiple *versions* of the same artifact to one card.
+   */
+  private applyArtifactsToInstance(
+    instance: MessageItemComponent,
+    messageId: string,
+    childCdRef: ChangeDetectorRef
+  ): void {
+    const infos = this.resolveDistinctArtifacts(messageId);
+    if (infos.length === 0) {
+      instance.artifacts = [];
+      instance.artifact = undefined;
+      instance.artifactVersion = undefined;
+      return;
+    }
+
+    Promise.all(
+      infos.map(info =>
+        Promise.all([info.getArtifact(), info.getVersion()]).then(([artifact, version]) => ({ artifact, version }))
+      )
+    )
+      .then(refs => {
+        instance.artifacts = refs;
+        // Keep the legacy single inputs pointed at the first entry for back-compat.
+        instance.artifact = refs[0]?.artifact;
+        instance.artifactVersion = refs[0]?.version;
+        // zone.js 0.15: parent detectChanges doesn't propagate to dynamically created children
+        childCdRef.detectChanges();
+        this.cdRef.detectChanges();
+      })
+      .catch(err => {
+        console.error('Failed to lazy-load artifacts:', err);
+      });
+  }
+
+  /**
+   * Groups a message's artifact list by artifactId, keeping the highest version of
+   * each. Multiple versions of the SAME artifact collapse to one card (latest wins),
+   * while genuinely distinct artifacts are all retained.
+   */
+  private resolveDistinctArtifacts(messageId: string): LazyArtifactInfo[] {
+    const list = this.artifactMap.get(messageId);
+    if (!list || list.length === 0) {
+      return [];
+    }
+    return selectDistinctLatestArtifacts(list);
   }
 
   /**

--- a/packages/Angular/Generic/conversations/src/lib/utils/distinct-artifacts.ts
+++ b/packages/Angular/Generic/conversations/src/lib/utils/distinct-artifacts.ts
@@ -1,0 +1,32 @@
+/**
+ * Artifact-grouping utilities for rendering a message's attached artifacts.
+ *
+ * A single conversation message can carry more than one DISTINCT artifact — for
+ * example a research report PLUS a standalone generated infographic. The UI must
+ * surface all of them. At the same time, a single artifact can have multiple
+ * versions, and only the latest should render. This helper reconciles both.
+ */
+
+/** Minimal shape needed to dedupe artifacts — satisfied by `LazyArtifactInfo`. */
+export interface DistinctArtifactKey {
+  artifactId: string;
+  versionNumber: number;
+}
+
+/**
+ * Collapses a message's artifact list to one entry per distinct `artifactId`,
+ * keeping the highest `versionNumber` for each. Distinct artifacts are all
+ * retained (so a report and an image both surface); multiple versions of the
+ * SAME artifact collapse to the latest. Input order of distinct artifacts is
+ * preserved (first-seen wins for ordering).
+ */
+export function selectDistinctLatestArtifacts<T extends DistinctArtifactKey>(list: readonly T[]): T[] {
+  const latestByArtifact = new Map<string, T>();
+  for (const info of list) {
+    const existing = latestByArtifact.get(info.artifactId);
+    if (!existing || info.versionNumber > existing.versionNumber) {
+      latestByArtifact.set(info.artifactId, info);
+    }
+  }
+  return Array.from(latestByArtifact.values());
+}


### PR DESCRIPTION
## Problem

A conversation message that carries **more than one distinct artifact** only ever rendered **one** of them. The Research Agent attaches both a **Research Content** report (SVG charts + HTML) *and* a separate standalone **Generated image** infographic to the same AI message — but users only saw the infographic. The board-ready report was silently hidden, even though both artifacts were correctly created, versioned, and linked in the DB (`ConversationDetailArtifact`). It looked like a missing-artifact bug; it was purely a **display** bug.

## Root cause

`message-list` rendered `artifactList[artifactList.length - 1]` — "show only the most recently created artifact" (EL-BC, `95492622`). The infographic was created ~336 ms **after** the report, so it won the "last" race and the report never rendered. `message-item` also only had single `artifact`/`artifactVersion` inputs, so there was no way to surface a second one.

## Why this is **not** in conflict with the server-side consolidation

@pranavtjk added server-side de-duplication in `AgentRunner` (`5664b86` — *"keep the report's embedded image in the report, not as a duplicate artifact"*), which **also reverted an earlier "show-all" workaround** in the message list, assuming consolidation would always leave exactly one artifact per message.

That assumption holds **only** for media embedded inline (base64) inside another artifact's payload — a genuine duplicate, which consolidation correctly suppresses. It does **not** hold for genuinely **standalone sibling** artifacts: here the report uses SVG charts and the infographic is a separate JPEG, so they're legitimately two distinct artifacts. The two mechanisms are complementary:

- **server:** collapse embedded/duplicate media into its host artifact *(unchanged)*
- **client:** render every **distinct** artifact that remains *(this PR)*

The code now carries comments spelling this out so we don't accidentally "re-consolidate" in the UI.

## What changed

- **`message-list.component.ts`** — replaced the two duplicated "last artifact" blocks with a shared `applyArtifactsToInstance()` helper that resolves **all distinct artifacts** (grouped by `artifactId`, latest version each), lazy-loads them, and passes an array down. Multiple **versions** of the same artifact still collapse to one card (latest wins).
- **`message-item.component.{ts,html}`** — added `@Input() artifacts: MessageArtifactRef[]` + a `displayArtifacts` getter that falls back to the legacy single inputs (back-compat preserved); template renders one card per artifact via `@for`.
- **`utils/distinct-artifacts.ts`** — extracted the pure `selectDistinctLatestArtifacts()` grouping logic so it's unit-testable without an Angular harness.
- **`__tests__/distinct-artifacts.test.ts`** — regression coverage including the exact "report hidden behind image" scenario.

### Also: inline media preview height 280px → 140px
Inline image/video previews in a message card are thumbnails (click to open the full viewer), so they shouldn't dominate the conversation. Halved `max-height` on both for consistency; width behavior unchanged. *(An experiment capping card width was reverted — a blanket cap clips naturally-wide artifacts; UX team will advise on card width separately.)*

## Verification
- Conversation `196E848F…` now shows **both** the report card and the image card.
- `ng-conversations` build ✅, `ng-artifacts` build ✅, **121 conversations tests pass** (incl. 6 new).

cc @pranavtjk @ethanluskbc — this re-enables multi-artifact display on top of your server-side consolidation; please sanity-check the layering above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)