### PR TITLE
fix(MJServer): handle string | string[] for Express route params

### DIFF
--- a/.changeset/fix-signature-webhook-params.md
+++ b/.changeset/fix-signature-webhook-params.md
@@ -1,0 +1,5 @@
+---
+"@memberjunction/server": patch
+---
+
+Fix type error in SignatureWebhookHandler where req.params.driverKey could be string | string[] per Express type definitions, causing build failures in downstream projects using moduleResolution: "node" with declarationMap: true.

--- a/packages/MJServer/src/rest/SignatureWebhookHandler.ts
+++ b/packages/MJServer/src/rest/SignatureWebhookHandler.ts
@@ -42,11 +42,12 @@ function captureRawBody(req: express.Request, _res: express.Response, buf: Buffe
 }
 
 async function handleWebhook(req: express.Request, res: express.Response): Promise<void> {
-    const driverKey = req.params.driverKey;
-    if (!driverKey) {
+    const rawDriverKey = req.params.driverKey;
+    if (!rawDriverKey) {
         res.status(400).json({ error: 'Missing driver key in path.' });
         return;
     }
+    const driverKey: string = Array.isArray(rawDriverKey) ? rawDriverKey[0] : rawDriverKey;
 
     const contextUser = getSystemUser();
     if (!contextUser) {


### PR DESCRIPTION
## Summary
- Fixes a type error in `SignatureWebhookHandler.ts` where `req.params.driverKey` is typed as `string | string[]` in Express type definitions, but passed to `RecordWebhookEvent` which expects `string`
- This error surfaces in downstream projects (e.g. Skip-Brain) that use `moduleResolution: "node"` with `declarationMap: true`, since TypeScript follows the declaration map back to the source `.ts` files and type-checks them
- Projects using `moduleResolution: "bundler"` (MJ, CDP, etc.) don't see this because `skipLibCheck: true` skips the compiled `.d.ts` files

## Test plan
- [x] MJServer compiles cleanly with `npx tsc --noEmit`
- [ ] Verify Skip-Brain MJAPI builds against the patched `@memberjunction/server`

🤖 Generated with [Claude Code](https://claude.com/claude-code)