### PR TITLE
fix(ai-vector-dupe): remove committed merge-conflict markers from run-dupe-detection script

### DIFF
--- a/.changeset/calm-rivers-mend.md
+++ b/.changeset/calm-rivers-mend.md
@@ -1,0 +1,5 @@
+---
+"@memberjunction/ai-vector-dupe": patch
+---
+
+Remove committed merge-conflict markers from scripts/run-dupe-detection.ts, keeping the provider-parameter variants of createAndTriggerRun and pollUntilDone

--- a/packages/AI/Vectors/Dupe/scripts/run-dupe-detection.ts
+++ b/packages/AI/Vectors/Dupe/scripts/run-dupe-detection.ts
@@ -76,14 +76,8 @@ async function wipeEventsRuns(pool: sql.ConnectionPool, schema: string): Promise
     LogStatus(`Wiped prior Events duplicate-run data (rows affected: ${JSON.stringify(result.rowsAffected)}).`);
 }
 
-<<<<<<< fix/runview-cache-miss-fields-projection
 async function createAndTriggerRun(provider: IMetadataProvider, user: UserInfo): Promise<string> {
     const run = await provider.GetEntityObject<MJDuplicateRunEntity>('MJ: Duplicate Runs', user);
-=======
-async function createAndTriggerRun(user): Promise<string> {
-    const md = new Metadata(); // global-provider-ok: one-off CLI script, global default provider is correct
-    const run = await md.GetEntityObject<MJDuplicateRunEntity>('MJ: Duplicate Runs', user);
->>>>>>> next
     run.NewRecord();
     run.EntityID = EVENTS_ENTITY_ID;
     run.StartedByUserID = user.ID;
@@ -97,12 +91,7 @@ async function createAndTriggerRun(user): Promise<string> {
     return run.ID;
 }
 
-<<<<<<< fix/runview-cache-miss-fields-projection
 async function pollUntilDone(provider: IMetadataProvider, user: UserInfo, runID: string): Promise<string> {
-=======
-async function pollUntilDone(user, runID: string): Promise<string> {
-    const md = new Metadata(); // global-provider-ok: one-off CLI script, global default provider is correct
->>>>>>> next
     const start = Date.now();
     while (Date.now() - start < POLL_TIMEOUT_MS) {
         await new Promise(r => setTimeout(r, POLL_INTERVAL_MS));


### PR DESCRIPTION
## Summary
- A prior `next` merge accidentally committed merge-conflict markers (`<<<<<<<` / `=======` / `>>>>>>>`) into `packages/AI/Vectors/Dupe/scripts/run-dupe-detection.ts`
- Resolves the conflict to the provider-parameter variants of `createAndTriggerRun(provider, user)` and `pollUntilDone(provider, user, runID)`, dropping the duplicated `new Metadata()` branches
- Adds a patch changeset for `@memberjunction/ai-vector-dupe`

🤖 Generated with [Claude Code](https://claude.com/claude-code)