### PR TITLE
feat: scoped API keys for Skip callbacks

### DIFF
--- a/metadata/.mj-sync.json
+++ b/metadata/.mj-sync.json
@@ -66,9 +66,9 @@
     "archiving",
     "entity-form-overrides",
     "entity-settings",
-    "users",
     "roles",
-    "entity-permissions"
+    "entity-permissions",
+    "users"
   ],
   "sqlLogging": {
     "enabled": true,

--- a/metadata/.mj-sync.json
+++ b/metadata/.mj-sync.json
@@ -66,6 +66,7 @@
     "archiving",
     "entity-form-overrides",
     "entity-settings",
+    "users",
     "roles",
     "entity-permissions"
   ],

--- a/metadata/api-application-scopes/.api-application-scopes.json
+++ b/metadata/api-application-scopes/.api-application-scopes.json
@@ -729,5 +729,107 @@
       "lastModified": "2026-02-01T00:26:51.018Z",
       "checksum": "935d143a3c66df7b033adfdd66625b0c78abedb49dff21cf03a8f439f46a0a27"
     }
+  },
+  {
+    "fields": {
+      "ApplicationID": "@lookup:MJ: API Applications.Name=MJAPI",
+      "ScopeID": "@lookup:MJ: API Scopes.FullPath=query:create",
+      "ResourcePattern": "*",
+      "PatternType": "Include",
+      "IsDeny": false,
+      "Priority": 0
+    },
+    "primaryKey": {
+      "ID": "12A62192-683C-4EEA-9F02-712FBBA79584"
+    },
+    "sync": {
+      "lastModified": "2026-06-11T18:15:09.763Z",
+      "checksum": "81d2beec61f3b18658fb5926fd764e9896c2dcfb52d2a45807713e6570bff934"
+    }
+  },
+  {
+    "fields": {
+      "ApplicationID": "@lookup:MJ: API Applications.Name=MJAPI",
+      "ScopeID": "@lookup:MJ: API Scopes.FullPath=query:update",
+      "ResourcePattern": "*",
+      "PatternType": "Include",
+      "IsDeny": false,
+      "Priority": 0
+    },
+    "primaryKey": {
+      "ID": "E646362A-7DD0-4FA7-BB08-BD662F0C1C0D"
+    },
+    "sync": {
+      "lastModified": "2026-06-11T18:15:09.779Z",
+      "checksum": "3f0d79b8bb6a19fde444fc03e08a0ceedc68092d865c4e491e76089afdf64da0"
+    }
+  },
+  {
+    "fields": {
+      "ApplicationID": "@lookup:MJ: API Applications.Name=MJAPI",
+      "ScopeID": "@lookup:MJ: API Scopes.FullPath=query:delete",
+      "ResourcePattern": "*",
+      "PatternType": "Include",
+      "IsDeny": false,
+      "Priority": 0
+    },
+    "primaryKey": {
+      "ID": "273797D9-C82C-49EE-A529-470BF5BDAEAE"
+    },
+    "sync": {
+      "lastModified": "2026-06-11T18:15:09.793Z",
+      "checksum": "8ab68108a7bf2c44488c264e97ce59244660e60d98baa36ecb7344c48b1098cf"
+    }
+  },
+  {
+    "fields": {
+      "ApplicationID": "@lookup:MJ: API Applications.Name=MJAPI",
+      "ScopeID": "@lookup:MJ: API Scopes.FullPath=query:test",
+      "ResourcePattern": "*",
+      "PatternType": "Include",
+      "IsDeny": false,
+      "Priority": 0
+    },
+    "primaryKey": {
+      "ID": "EB11E406-5F72-4467-A564-CAE8B1C5B931"
+    },
+    "sync": {
+      "lastModified": "2026-06-11T18:15:09.813Z",
+      "checksum": "758f4f3ba2e3227b4cf63198748fa3bc30e1a8db134e9c1d14aad36da9c692c6"
+    }
+  },
+  {
+    "fields": {
+      "ApplicationID": "@lookup:MJ: API Applications.Name=MJAPI",
+      "ScopeID": "@lookup:MJ: API Scopes.FullPath=view:batch",
+      "ResourcePattern": "*",
+      "PatternType": "Include",
+      "IsDeny": false,
+      "Priority": 0
+    },
+    "primaryKey": {
+      "ID": "F792F416-8B65-4CA2-9200-C64F2DAFC3F5"
+    },
+    "sync": {
+      "lastModified": "2026-06-11T18:15:09.826Z",
+      "checksum": "43f8a5fca7f074a5f80719231fae17f6ce6c22249acc7a20d21dd1a75be5533b"
+    }
+  },
+  {
+    "fields": {
+      "ApplicationID": "@lookup:MJ: API Applications.Name=MJAPI",
+      "ScopeID": "@lookup:MJ: API Scopes.FullPath=search:execute",
+      "ResourcePattern": "*",
+      "PatternType": "Include",
+      "IsDeny": false,
+      "Priority": 0
+    },
+    "primaryKey": {
+      "ID": "4EF05083-069A-45B0-A96B-62CFCFD858FA"
+    },
+    "sync": {
+      "lastModified": "2026-06-11T18:15:09.839Z",
+      "checksum": "3ae0f7b2cc8ee2e7f3f2dedcd2865bebfac6930a5410000d506d4cfb919c8638"
+    }
   }
 ]

--- a/metadata/api-scopes/.api-scopes.json
+++ b/metadata/api-scopes/.api-scopes.json
@@ -796,5 +796,135 @@
       "lastModified": "2026-02-01T00:26:50.140Z",
       "checksum": "825a4d5b3a35bdd3df1e3ffd15bdcd19dfe475b40ad487cd42245d23c2698c85"
     }
+  },
+  {
+    "fields": {
+      "Name": "batch",
+      "FullPath": "view:batch",
+      "ParentID": "@lookup:MJ: API Scopes.FullPath=view",
+      "Category": "Views",
+      "Description": "Batch execute multiple views in a single call via RunViews",
+      "ResourceType": "View",
+      "IsActive": true
+    },
+    "primaryKey": {
+      "ID": "7ED62962-C267-47E3-BA90-E8B6D08046D1"
+    },
+    "sync": {
+      "lastModified": "2026-06-11T04:53:12.757Z",
+      "checksum": "31e1444e2dad7217d0625537587abcd425a04c36ccd144718a91e489d74a0b5d"
+    }
+  },
+  {
+    "fields": {
+      "Name": "create",
+      "FullPath": "query:create",
+      "ParentID": "@lookup:MJ: API Scopes.FullPath=query",
+      "Category": "Queries",
+      "Description": "Create new query definitions",
+      "ResourceType": "Query",
+      "IsActive": true
+    },
+    "primaryKey": {
+      "ID": "A9E36770-536E-4B82-8F9D-805442E2B633"
+    },
+    "sync": {
+      "lastModified": "2026-06-11T04:53:12.771Z",
+      "checksum": "4d332874a78b6d01e56a34cd4806f4a4170c973d4ef465df195858fb18a7d544"
+    }
+  },
+  {
+    "fields": {
+      "Name": "update",
+      "FullPath": "query:update",
+      "ParentID": "@lookup:MJ: API Scopes.FullPath=query",
+      "Category": "Queries",
+      "Description": "Update existing query definitions",
+      "ResourceType": "Query",
+      "IsActive": true
+    },
+    "primaryKey": {
+      "ID": "61063598-BD04-4F76-B54B-4A5D1FB7BC20"
+    },
+    "sync": {
+      "lastModified": "2026-06-11T04:53:12.790Z",
+      "checksum": "459a53fd1a1f3c362cb1a0f6f7ca1563aa1e643b150d6fa325fc2367379ce537"
+    }
+  },
+  {
+    "fields": {
+      "Name": "delete",
+      "FullPath": "query:delete",
+      "ParentID": "@lookup:MJ: API Scopes.FullPath=query",
+      "Category": "Queries",
+      "Description": "Delete query definitions",
+      "ResourceType": "Query",
+      "IsActive": true
+    },
+    "primaryKey": {
+      "ID": "2AB09C9F-16CD-4394-8AF9-74FC2535AC65"
+    },
+    "sync": {
+      "lastModified": "2026-06-11T04:53:12.804Z",
+      "checksum": "233eb78e399503e3d0f0363c5d5721d86510b5d89767f63a22a26ac24989209f"
+    }
+  },
+  {
+    "fields": {
+      "Name": "test",
+      "FullPath": "query:test",
+      "ParentID": "@lookup:MJ: API Scopes.FullPath=query",
+      "Category": "Queries",
+      "Description": "Test transient SQL with composition and Nunjucks template processing",
+      "ResourceType": "Query",
+      "IsActive": true
+    },
+    "primaryKey": {
+      "ID": "E8407520-483E-4FAA-A02C-8AEE35EE8458"
+    },
+    "sync": {
+      "lastModified": "2026-06-11T04:53:12.824Z",
+      "checksum": "cad598365f6ef1abf5d15af7fbccf39294b1efdfcdc04f9ae1e5caf880effd6c"
+    }
+  },
+  {
+    "fields": {
+      "Name": "search",
+      "FullPath": "search",
+      "ParentID": null,
+      "Category": "Search",
+      "Description": "Parent scope for knowledge search operations",
+      "ResourceType": null,
+      "IsActive": true,
+      "UIConfig": {
+        "icon": "fa-solid fa-magnifying-glass",
+        "color": "#f43f5e"
+      }
+    },
+    "primaryKey": {
+      "ID": "411AA5E8-7F8E-4092-B6B1-9566847E2A3A"
+    },
+    "sync": {
+      "lastModified": "2026-06-11T04:53:12.720Z",
+      "checksum": "4efc78059a92d3357edbb9fd0cfdccc69848037e19cb89a1679717562ce0bfe5"
+    }
+  },
+  {
+    "fields": {
+      "Name": "execute",
+      "FullPath": "search:execute",
+      "ParentID": "@lookup:MJ: API Scopes.FullPath=search",
+      "Category": "Search",
+      "Description": "Execute knowledge search and preview search operations",
+      "ResourceType": "Entity",
+      "IsActive": true
+    },
+    "primaryKey": {
+      "ID": "BB1E7EDF-955E-44DA-821D-A385BC5DD150"
+    },
+    "sync": {
+      "lastModified": "2026-06-11T04:53:12.838Z",
+      "checksum": "9975eb617cd5c07d99a2e11cb2e05347598a23d0b521a8361bd436585fe1d601"
+    }
   }
 ]

--- a/metadata/entity-permissions/.entity-permissions.json
+++ b/metadata/entity-permissions/.entity-permissions.json
@@ -154,5 +154,141 @@
       "lastModified": "2026-06-09T06:32:37.016Z",
       "checksum": "6b43ad0f9ccf2ed20b57fe820c11d7d822abda933a1ba55c3b8e5322332f645d"
     }
+  },
+  {
+    "fields": {
+      "EntityID": "@lookup:MJ: Entities.Name=MJ: Queries",
+      "RoleID": "@lookup:MJ: Roles.Name=Skip Service",
+      "CanRead": true,
+      "CanCreate": true,
+      "CanUpdate": true,
+      "CanDelete": true
+    },
+    "primaryKey": {
+      "ID": "B7C1A009-197B-4987-9C45-11AE070AE02F"
+    },
+    "sync": {
+      "lastModified": "2026-06-11T17:53:47.287Z",
+      "checksum": "fe5466b93e76dbce22da78da443642cdbf2fa92e1f56180d1095e1e0eee53284"
+    }
+  },
+  {
+    "fields": {
+      "EntityID": "@lookup:MJ: Entities.Name=MJ: Query Categories",
+      "RoleID": "@lookup:MJ: Roles.Name=Skip Service",
+      "CanRead": true,
+      "CanCreate": true,
+      "CanUpdate": true,
+      "CanDelete": true
+    },
+    "primaryKey": {
+      "ID": "14E94742-B25D-478A-9409-394E658B32A7"
+    },
+    "sync": {
+      "lastModified": "2026-06-11T17:53:47.361Z",
+      "checksum": "16dd78dabf82ccadf6efe1e591775f8582d92eef28e0841231f5d1439720b00c"
+    }
+  },
+  {
+    "fields": {
+      "EntityID": "@lookup:MJ: Entities.Name=MJ: Query Fields",
+      "RoleID": "@lookup:MJ: Roles.Name=Skip Service",
+      "CanRead": true,
+      "CanCreate": true,
+      "CanUpdate": true,
+      "CanDelete": true
+    },
+    "primaryKey": {
+      "ID": "F1BD10D7-86C7-43BD-A8E0-75B77C2BA503"
+    },
+    "sync": {
+      "lastModified": "2026-06-11T17:53:47.391Z",
+      "checksum": "67677936d8d1bca8f32154bb7091f13e62455a6020c5ba280d34c1b8079856b2"
+    }
+  },
+  {
+    "fields": {
+      "EntityID": "@lookup:MJ: Entities.Name=MJ: Query Parameters",
+      "RoleID": "@lookup:MJ: Roles.Name=Skip Service",
+      "CanRead": true,
+      "CanCreate": true,
+      "CanUpdate": true,
+      "CanDelete": true
+    },
+    "primaryKey": {
+      "ID": "7E6AD1F0-1DAB-4441-923C-338997702ABC"
+    },
+    "sync": {
+      "lastModified": "2026-06-11T17:53:47.416Z",
+      "checksum": "f595b90985a0aaa40621a89cd9954eb22d8eb2709685ea88e7005021a8be2d20"
+    }
+  },
+  {
+    "fields": {
+      "EntityID": "@lookup:MJ: Entities.Name=MJ: Query Entities",
+      "RoleID": "@lookup:MJ: Roles.Name=Skip Service",
+      "CanRead": true,
+      "CanCreate": true,
+      "CanUpdate": true,
+      "CanDelete": true
+    },
+    "primaryKey": {
+      "ID": "52D4A00C-AE6A-4C73-B4B0-C40D922054EE"
+    },
+    "sync": {
+      "lastModified": "2026-06-11T17:53:47.440Z",
+      "checksum": "67a89c59fb3640e91e23d13a0577947fd826aefe29556837ac3243379450a93d"
+    }
+  },
+  {
+    "fields": {
+      "EntityID": "@lookup:MJ: Entities.Name=MJ: Query Permissions",
+      "RoleID": "@lookup:MJ: Roles.Name=Skip Service",
+      "CanRead": true,
+      "CanCreate": true,
+      "CanUpdate": true,
+      "CanDelete": true
+    },
+    "primaryKey": {
+      "ID": "22A6A4DC-39DF-4E3D-AC46-CAB491F7B308"
+    },
+    "sync": {
+      "lastModified": "2026-06-11T17:53:47.464Z",
+      "checksum": "ce46ceb379349d85fa3121d8d0d468cac6c88d2d35ac67c0b5255438c689d797"
+    }
+  },
+  {
+    "fields": {
+      "EntityID": "@lookup:MJ: Entities.Name=MJ: Query Dependencies",
+      "RoleID": "@lookup:MJ: Roles.Name=Skip Service",
+      "CanRead": true,
+      "CanCreate": true,
+      "CanUpdate": true,
+      "CanDelete": true
+    },
+    "primaryKey": {
+      "ID": "21E86DC8-3E03-41DC-B8E6-B36324666C21"
+    },
+    "sync": {
+      "lastModified": "2026-06-11T17:53:47.487Z",
+      "checksum": "714033336834420cb584c22f86d3c67dcb1ddefc34f4a98752304c69c71ad80b"
+    }
+  },
+  {
+    "fields": {
+      "EntityID": "@lookup:MJ: Entities.Name=MJ: Query SQLs",
+      "RoleID": "@lookup:MJ: Roles.Name=Skip Service",
+      "CanRead": true,
+      "CanCreate": true,
+      "CanUpdate": true,
+      "CanDelete": true
+    },
+    "primaryKey": {
+      "ID": "14BA1F89-0FB7-43E9-A283-2EB9A9FF4BBF"
+    },
+    "sync": {
+      "lastModified": "2026-06-11T17:53:47.511Z",
+      "checksum": "c044e30b3e361c357c2a0193b2a5d2090efdfb30304d819e581a5e984dc8f7eb"
+    }
   }
 ]

--- a/metadata/entity-permissions/.mj-sync.json
+++ b/metadata/entity-permissions/.mj-sync.json
@@ -12,7 +12,7 @@
     "mergeStrategy": "merge",
     "backupBeforeUpdate": true,
     "backupDirectory": ".backups",
-    "filter": "RoleID IN (SELECT ID FROM __mj.Role WHERE Name='Magic Link Baseline')",
+    "filter": "RoleID IN (SELECT ID FROM __mj.Role WHERE Name IN ('Magic Link Baseline', 'Skip Service'))",
     "externalizeFields": [],
     "ignoreNullFields": true,
     "ignoreVirtualFields": true,

--- a/metadata/roles/.roles.json
+++ b/metadata/roles/.roles.json
@@ -11,5 +11,18 @@
       "lastModified": "2026-06-09T06:32:36.750Z",
       "checksum": "54180cf11a738544eed68a64b8b5fe38ba34c68adeaf416e6a2cefe2cdbfd8e8"
     }
+  },
+  {
+    "fields": {
+      "Name": "Skip Service",
+      "Description": "Role for the Skip Service Account. Grants CRUD on query-related entities needed for Skip callback operations (query creation, update, deletion). Pair with the UI role for broad read access."
+    },
+    "primaryKey": {
+      "ID": "9933BBB6-4139-4256-8087-64F4B9E4351F"
+    },
+    "sync": {
+      "lastModified": "2026-06-11T17:53:47.227Z",
+      "checksum": "e8bce35e3f3394735a1c69504dcd22f429e88d006585aec75994e115b0680ad9"
+    }
   }
 ]

--- a/metadata/users/.mj-sync.json
+++ b/metadata/users/.mj-sync.json
@@ -1,0 +1,22 @@
+{
+  "entity": "MJ: Users",
+  "filePattern": "**/.*.json",
+  "defaults": {},
+  "pull": {
+    "createNewFileIfNotFound": true,
+    "newFileName": ".users.json",
+    "appendRecordsToExistingFile": true,
+    "updateExistingRecords": true,
+    "preserveFields": [],
+    "excludeFields": [],
+    "mergeStrategy": "merge",
+    "backupBeforeUpdate": true,
+    "backupDirectory": ".backups",
+    "filter": "Email='skip-service@skip.internal'",
+    "externalizeFields": [],
+    "ignoreNullFields": true,
+    "ignoreVirtualFields": true,
+    "lookupFields": {},
+    "relatedEntities": {}
+  }
+}

--- a/metadata/users/.mj-sync.json
+++ b/metadata/users/.mj-sync.json
@@ -17,6 +17,11 @@
     "ignoreNullFields": true,
     "ignoreVirtualFields": true,
     "lookupFields": {},
-    "relatedEntities": {}
+    "relatedEntities": {
+      "MJ: User Roles": {
+        "entity": "MJ: User Roles",
+        "foreignKey": "UserID"
+      }
+    }
   }
 }

--- a/metadata/users/.users.json
+++ b/metadata/users/.users.json
@@ -1,0 +1,20 @@
+[
+  {
+    "fields": {
+      "Name": "Skip Service Account",
+      "FirstName": "Skip",
+      "LastName": "Service",
+      "Email": "skip-service@skip.internal",
+      "Type": "User",
+      "IsActive": true,
+      "LinkedRecordType": "None"
+    },
+    "primaryKey": {
+      "ID": "0199FC9E-1468-57FC-8A4E-EF1131DA76EB"
+    },
+    "sync": {
+      "lastModified": "2026-06-11T04:53:12.872Z",
+      "checksum": "5cb83a61748a5d23d5d8114cff73e15976d7616dab1ac02e3aa2407e08b55120"
+    }
+  }
+]

--- a/metadata/users/.users.json
+++ b/metadata/users/.users.json
@@ -9,6 +9,36 @@
       "IsActive": true,
       "LinkedRecordType": "None"
     },
+    "relatedEntities": {
+      "MJ: User Roles": [
+        {
+          "fields": {
+            "UserID": "@parent:ID",
+            "RoleID": "@lookup:MJ: Roles.Name=UI"
+          },
+          "primaryKey": {
+            "ID": "65BC9077-D7B9-49BE-B610-90CA037217DC"
+          },
+          "sync": {
+            "lastModified": "2026-06-11T17:53:47.553Z",
+            "checksum": "4e123a385c7623f2e303780ba477e827c76cf9f5cbb387b72da9185701ac7e13"
+          }
+        },
+        {
+          "fields": {
+            "UserID": "@parent:ID",
+            "RoleID": "@lookup:MJ: Roles.Name=Skip Service"
+          },
+          "primaryKey": {
+            "ID": "60022E69-E534-4AE6-B399-814B36F721A3"
+          },
+          "sync": {
+            "lastModified": "2026-06-11T17:53:47.567Z",
+            "checksum": "6547214a273950b0449212f4eb4412489f9e8dfef2c6e92f864e1fec5a5dde29"
+          }
+        }
+      ]
+    },
     "primaryKey": {
       "ID": "0199FC9E-1468-57FC-8A4E-EF1131DA76EB"
     },

--- a/packages/MJServer/src/agents/skip-callback-key-provisioner.ts
+++ b/packages/MJServer/src/agents/skip-callback-key-provisioner.ts
@@ -1,0 +1,224 @@
+/**
+ * Skip Callback Key Provisioner
+ *
+ * Auto-provisions a scoped API key for Skip callbacks on the client MJAPI.
+ * On first request, checks for an existing key owned by the Skip service account;
+ * if none exists, creates one via APIKeyEngine and assigns the required scopes.
+ *
+ * The raw key is cached in memory for subsequent requests. The key survives
+ * server restarts because it's persisted in the database — SkipSDK rediscovers
+ * it by querying on the next startup.
+ *
+ * Thread safety: uses a promise-based mutex so concurrent first requests don't
+ * create duplicate keys.
+ *
+ * @see MJ/plans/skip-callback-scoped-api-keys.md Section 3.2
+ */
+
+import { LogError, LogStatus, Metadata, RunView, UserInfo } from '@memberjunction/core';
+import { GetAPIKeyEngine } from '@memberjunction/api-keys';
+import { UserCache } from '@memberjunction/sqlserver-dataprovider';
+
+/** The email used for the Skip service account (deployed via MJ metadata). */
+const SKIP_SERVICE_EMAIL = 'skip-service@skip.internal';
+
+/** Label used to identify the auto-provisioned callback key. */
+const SKIP_CALLBACK_KEY_LABEL = 'Skip Callback Key (auto-provisioned)';
+
+/**
+ * All scope FullPaths that a Skip callback key needs.
+ * These must match entries in MJ/metadata/api-scopes/.api-scopes.json.
+ */
+const REQUIRED_SCOPE_PATHS: string[] = [
+    'view:run',
+    'view:batch',
+    'query:run',
+    'query:create',
+    'query:update',
+    'query:delete',
+    'query:test',
+    'search:execute',
+    'prompt:execute',
+    'agent:execute',
+    'embedding:generate',
+];
+
+/** Cached raw key — only populated after successful provisioning or discovery. */
+let cachedRawKey: string | null = null;
+
+/** Promise-based mutex: if provisioning is in-flight, subsequent callers await it. */
+let provisioningPromise: Promise<string | null> | null = null;
+
+/**
+ * Returns the raw API key for Skip callbacks, auto-provisioning if needed.
+ *
+ * - If the key is cached, returns immediately.
+ * - If another call is already provisioning, awaits that result.
+ * - Otherwise, kicks off provisioning (discover or create + assign scopes).
+ *
+ * @returns The raw API key string, or null if provisioning failed (caller should
+ *          fall back to the legacy MJ_API_KEY env var during the transition period).
+ */
+export async function getSkipCallbackKey(): Promise<string | null> {
+    if (cachedRawKey) {
+        return cachedRawKey;
+    }
+
+    // Mutex: if provisioning is already in progress, piggyback on that promise
+    if (provisioningPromise) {
+        return provisioningPromise;
+    }
+
+    provisioningPromise = provisionInner();
+    try {
+        return await provisioningPromise;
+    } finally {
+        provisioningPromise = null;
+    }
+}
+
+/**
+ * The actual provisioning logic. Only one instance of this runs at a time.
+ */
+async function provisionInner(): Promise<string | null> {
+    try {
+        const systemUser = UserCache.Instance.GetSystemUser();
+        if (!systemUser) {
+            LogError('[SkipCallbackKeyProvisioner] System user not found in UserCache');
+            return null;
+        }
+
+        const serviceAccount = UserCache.Instance.Users.find(
+            u => u.Email.toLowerCase() === SKIP_SERVICE_EMAIL
+        );
+        if (!serviceAccount) {
+            LogError(`[SkipCallbackKeyProvisioner] Skip service account (${SKIP_SERVICE_EMAIL}) not found in UserCache. ` +
+                'Run MJ metadata sync to deploy the Skip Service Account user.');
+            return null;
+        }
+
+        // Check if a key already exists for this service account.
+        // MJ: API Keys is not cached in APIKeysEngineBase so we hit the DB here.
+        // This only runs once per server lifetime (result is cached either way).
+        const existingKey = await findExistingKey(serviceAccount.ID, systemUser);
+        if (existingKey) {
+            // We found the key record but can't recover the raw key (it's hashed).
+            // The raw key was only available at creation time. Since we can't send
+            // a hashed key to Skip, we log this and return null — the caller falls
+            // back to the legacy MJ_API_KEY flow.
+            //
+            // In practice, this only happens if the server restarts after key
+            // creation but before the raw key was used. The proper fix is Phase 5:
+            // store the raw key encrypted at rest (or rotate and re-provision).
+            LogStatus(`[SkipCallbackKeyProvisioner] Found existing Skip callback key (ID: ${existingKey.ID}) ` +
+                'but raw key is not recoverable. Using legacy MJ_API_KEY fallback.');
+            return null;
+        }
+
+        // No existing key — create one
+        const rawKey = await createKeyWithScopes(serviceAccount, systemUser);
+        if (rawKey) {
+            cachedRawKey = rawKey;
+            LogStatus('[SkipCallbackKeyProvisioner] Successfully auto-provisioned Skip callback key');
+        }
+        return rawKey;
+    } catch (error: unknown) {
+        const msg = error instanceof Error ? error.message : String(error);
+        LogError(`[SkipCallbackKeyProvisioner] Provisioning failed: ${msg}`);
+        return null;
+    }
+}
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+interface ExistingKeyRow {
+    ID: string;
+    Label: string;
+    Status: string;
+}
+
+async function findExistingKey(serviceAccountUserID: string, contextUser: UserInfo): Promise<ExistingKeyRow | null> {
+    const rv = new RunView();
+    const result = await rv.RunView<ExistingKeyRow>({
+        EntityName: 'MJ: API Keys',
+        ExtraFilter: `UserID='${serviceAccountUserID}' AND Label='${SKIP_CALLBACK_KEY_LABEL}' AND Status='Active'`,
+    }, contextUser);
+
+    if (result.Success && result.Results.length > 0) {
+        return result.Results[0];
+    }
+    return null;
+}
+
+/**
+ * Creates a new API key for the Skip service account and assigns all required scopes.
+ */
+async function createKeyWithScopes(serviceAccount: UserInfo, systemUser: UserInfo): Promise<string | null> {
+    const engine = GetAPIKeyEngine();
+
+    const createResult = await engine.CreateAPIKey({
+        UserId: serviceAccount.ID,
+        Label: SKIP_CALLBACK_KEY_LABEL,
+        Description: 'Auto-provisioned by SkipSDK for scoped Skip→client callbacks. ' +
+            'Do not delete — Skip will re-provision on next request if missing.',
+    }, systemUser);
+
+    if (!createResult.Success || !createResult.RawKey || !createResult.APIKeyId) {
+        LogError(`[SkipCallbackKeyProvisioner] Failed to create API key: ${createResult.Error}`);
+        return null;
+    }
+
+    const scopesAssigned = await assignScopes(createResult.APIKeyId, systemUser, engine);
+    if (!scopesAssigned) {
+        LogError('[SkipCallbackKeyProvisioner] Key created but scope assignment failed. ' +
+            `Key ID: ${createResult.APIKeyId}. Manual scope assignment may be needed.`);
+    }
+
+    return createResult.RawKey;
+}
+
+/**
+ * Resolves scope IDs from the APIKeyEngine's in-memory cache (no DB round-trip)
+ * and creates APIKeyScope records for each.
+ */
+async function assignScopes(apiKeyID: string, contextUser: UserInfo, engine: ReturnType<typeof GetAPIKeyEngine>): Promise<boolean> {
+    const md = new Metadata();
+
+    // Resolve scope IDs from the engine's cached Scopes (loaded at startup).
+    // This avoids a RunView query — scopes are already in memory.
+    const cachedScopes = engine.Scopes;
+    const scopeMap = new Map(cachedScopes.map(s => [s.FullPath, s.ID]));
+
+    const missing = REQUIRED_SCOPE_PATHS.filter(p => !scopeMap.has(p));
+    if (missing.length > 0) {
+        LogError(`[SkipCallbackKeyProvisioner] Missing scopes in engine cache: ${missing.join(', ')}. ` +
+            'Run MJ metadata sync to deploy API scope definitions.');
+        return false;
+    }
+
+    // Create an APIKeyScope record for each required scope
+    let allSaved = true;
+    for (const scopePath of REQUIRED_SCOPE_PATHS) {
+        const scopeID = scopeMap.get(scopePath)!;
+        const keyScopeEntity = await md.GetEntityObject('MJ: API Key Scopes', contextUser);
+        keyScopeEntity.NewRecord();
+        keyScopeEntity.Set('APIKeyID', apiKeyID);
+        keyScopeEntity.Set('ScopeID', scopeID);
+        keyScopeEntity.Set('ResourcePattern', '*');
+        keyScopeEntity.Set('PatternType', 'Include');
+        keyScopeEntity.Set('IsDeny', false);
+        keyScopeEntity.Set('Priority', 0);
+
+        const saved = await keyScopeEntity.Save();
+        if (!saved) {
+            LogError(`[SkipCallbackKeyProvisioner] Failed to assign scope ${scopePath} to key ${apiKeyID}`);
+            allSaved = false;
+        }
+    }
+
+    if (allSaved) {
+        LogStatus(`[SkipCallbackKeyProvisioner] Assigned ${REQUIRED_SCOPE_PATHS.length} scopes to callback key`);
+    }
+
+    return allSaved;
+}

--- a/packages/MJServer/src/agents/skip-callback-key-provisioner.ts
+++ b/packages/MJServer/src/agents/skip-callback-key-provisioner.ts
@@ -2,15 +2,15 @@
  * Skip Callback Key Provisioner
  *
  * Auto-provisions a scoped API key for Skip callbacks on the client MJAPI.
- * On first request, checks for an existing key owned by the Skip service account;
- * if none exists, creates one via APIKeyEngine and assigns the required scopes.
+ * On first request to a Skip host, creates a key and returns the raw value
+ * so SkipSDK can send it once. Skip persists it in its credential store.
  *
- * The raw key is cached in memory for subsequent requests. The key survives
- * server restarts because it's persisted in the database — SkipSDK rediscovers
- * it by querying on the next startup.
+ * On subsequent requests (including after MJ restart), the key record exists
+ * in the DB but the raw value is irrecoverable (hashed). Returns null to
+ * signal "key exists, don't send it — Skip already has it."
  *
- * Thread safety: uses a promise-based mutex so concurrent first requests don't
- * create duplicate keys.
+ * Thread safety: uses a promise-based mutex so concurrent first requests
+ * don't create duplicate keys.
  *
  * @see MJ/plans/skip-callback-scoped-api-keys.md Section 3.2
  */
@@ -18,12 +18,10 @@
 import { LogError, LogStatus, Metadata, RunView, UserInfo } from '@memberjunction/core';
 import { GetAPIKeyEngine } from '@memberjunction/api-keys';
 import { UserCache } from '@memberjunction/sqlserver-dataprovider';
+import { configInfo } from '../config.js';
 
 /** The email used for the Skip service account (deployed via MJ metadata). */
 const SKIP_SERVICE_EMAIL = 'skip-service@skip.internal';
-
-/** Label used to identify the auto-provisioned callback key. */
-const SKIP_CALLBACK_KEY_LABEL = 'Skip Callback Key (auto-provisioned)';
 
 /**
  * All scope FullPaths that a Skip callback key needs.
@@ -43,28 +41,48 @@ const REQUIRED_SCOPE_PATHS: string[] = [
     'embedding:generate',
 ];
 
-/** Cached raw key — only populated after successful provisioning or discovery. */
-let cachedRawKey: string | null = null;
-
 /** Promise-based mutex: if provisioning is in-flight, subsequent callers await it. */
 let provisioningPromise: Promise<string | null> | null = null;
 
 /**
- * Returns the raw API key for Skip callbacks, auto-provisioning if needed.
+ * Whether provisioning completed successfully this server lifetime (key exists
+ * or was just created). Exported so SkipSDK can distinguish "key exists, Skip
+ * has it" (don't send anything) from "provisioning failed" (fall back to legacy).
+ */
+export let provisioningComplete = false;
+
+/** Raw key from creation — only non-null during the server lifetime that created the key. */
+let createdRawKey: string | null = null;
+
+/**
+ * Builds the label for a Skip callback key scoped to a specific Skip host.
+ * Example: "Skip Callback: https://skip.example.com"
+ */
+function buildKeyLabel(): string {
+    const skipChatUrl = configInfo.askSkip?.chatURL;
+    if (!skipChatUrl) {
+        throw new Error('ASK_SKIP_CHAT_URL is not configured — cannot provision Skip callback key');
+    }
+    return `Skip Callback: ${skipChatUrl}`;
+}
+
+/**
+ * Returns the raw API key for Skip callbacks if one was just created,
+ * or null if the key already exists (Skip already has it stored).
  *
- * - If the key is cached, returns immediately.
- * - If another call is already provisioning, awaits that result.
- * - Otherwise, kicks off provisioning (discover or create + assign scopes).
+ * - First call ever (no key in DB): creates key, returns raw key (send to Skip once)
+ * - Subsequent calls (same server lifetime): returns null (key exists, Skip has it)
+ * - After restart (key in DB, raw lost): returns null (key exists, Skip has it)
  *
- * @returns The raw API key string, or null if provisioning failed (caller should
- *          fall back to the legacy MJ_API_KEY env var during the transition period).
+ * Returns null on provisioning failure — caller should fall back to legacy MJ_API_KEY.
  */
 export async function getSkipCallbackKey(): Promise<string | null> {
-    if (cachedRawKey) {
-        return cachedRawKey;
+    // Fast path: we've already checked this lifetime
+    if (provisioningComplete) {
+        return createdRawKey;
     }
 
-    // Mutex: if provisioning is already in progress, piggyback on that promise
+    // Mutex: if provisioning is in-flight, piggyback on that promise
     if (provisioningPromise) {
         return provisioningPromise;
     }
@@ -78,7 +96,7 @@ export async function getSkipCallbackKey(): Promise<string | null> {
 }
 
 /**
- * The actual provisioning logic. Only one instance of this runs at a time.
+ * The actual provisioning logic. Runs at most once per server lifetime.
  */
 async function provisionInner(): Promise<string | null> {
     try {
@@ -97,29 +115,25 @@ async function provisionInner(): Promise<string | null> {
             return null;
         }
 
-        // Check if a key already exists for this service account.
-        // MJ: API Keys is not cached in APIKeysEngineBase so we hit the DB here.
-        // This only runs once per server lifetime (result is cached either way).
-        const existingKey = await findExistingKey(serviceAccount.ID, systemUser);
+        const label = buildKeyLabel();
+
+        // Check if a key already exists for this service account + Skip host.
+        const existingKey = await findExistingKey(serviceAccount.ID, label, systemUser);
         if (existingKey) {
-            // We found the key record but can't recover the raw key (it's hashed).
-            // The raw key was only available at creation time. Since we can't send
-            // a hashed key to Skip, we log this and return null — the caller falls
-            // back to the legacy MJ_API_KEY flow.
-            //
-            // In practice, this only happens if the server restarts after key
-            // creation but before the raw key was used. The proper fix is Phase 5:
-            // store the raw key encrypted at rest (or rotate and re-provision).
-            LogStatus(`[SkipCallbackKeyProvisioner] Found existing Skip callback key (ID: ${existingKey.ID}) ` +
-                'but raw key is not recoverable. Using legacy MJ_API_KEY fallback.');
+            // Key exists — Skip already received the raw key when it was first created.
+            // We can't recover the raw value (it's hashed), but we don't need to.
+            LogStatus(`[SkipCallbackKeyProvisioner] Found existing Skip callback key (ID: ${existingKey.ID})`);
+            provisioningComplete = true;
+            createdRawKey = null; // Signal: don't send key, Skip already has it
             return null;
         }
 
-        // No existing key — create one
-        const rawKey = await createKeyWithScopes(serviceAccount, systemUser);
+        // No existing key — create one and return the raw value for SkipSDK to send once
+        const rawKey = await createKeyWithScopes(serviceAccount, label, systemUser);
         if (rawKey) {
-            cachedRawKey = rawKey;
-            LogStatus('[SkipCallbackKeyProvisioner] Successfully auto-provisioned Skip callback key');
+            provisioningComplete = true;
+            createdRawKey = rawKey;
+            LogStatus('[SkipCallbackKeyProvisioner] Auto-provisioned new Skip callback key — will send to Skip on this request');
         }
         return rawKey;
     } catch (error: unknown) {
@@ -137,11 +151,11 @@ interface ExistingKeyRow {
     Status: string;
 }
 
-async function findExistingKey(serviceAccountUserID: string, contextUser: UserInfo): Promise<ExistingKeyRow | null> {
+async function findExistingKey(serviceAccountUserID: string, label: string, contextUser: UserInfo): Promise<ExistingKeyRow | null> {
     const rv = new RunView();
     const result = await rv.RunView<ExistingKeyRow>({
         EntityName: 'MJ: API Keys',
-        ExtraFilter: `UserID='${serviceAccountUserID}' AND Label='${SKIP_CALLBACK_KEY_LABEL}' AND Status='Active'`,
+        ExtraFilter: `UserID='${serviceAccountUserID}' AND Label='${label.replace(/'/g, "''")}' AND Status='Active'`,
     }, contextUser);
 
     if (result.Success && result.Results.length > 0) {
@@ -153,12 +167,12 @@ async function findExistingKey(serviceAccountUserID: string, contextUser: UserIn
 /**
  * Creates a new API key for the Skip service account and assigns all required scopes.
  */
-async function createKeyWithScopes(serviceAccount: UserInfo, systemUser: UserInfo): Promise<string | null> {
+async function createKeyWithScopes(serviceAccount: UserInfo, label: string, systemUser: UserInfo): Promise<string | null> {
     const engine = GetAPIKeyEngine();
 
     const createResult = await engine.CreateAPIKey({
         UserId: serviceAccount.ID,
-        Label: SKIP_CALLBACK_KEY_LABEL,
+        Label: label,
         Description: 'Auto-provisioned by SkipSDK for scoped Skip→client callbacks. ' +
             'Do not delete — Skip will re-provision on next request if missing.',
     }, systemUser);
@@ -184,8 +198,6 @@ async function createKeyWithScopes(serviceAccount: UserInfo, systemUser: UserInf
 async function assignScopes(apiKeyID: string, contextUser: UserInfo, engine: ReturnType<typeof GetAPIKeyEngine>): Promise<boolean> {
     const md = new Metadata();
 
-    // Resolve scope IDs from the engine's cached Scopes (loaded at startup).
-    // This avoids a RunView query — scopes are already in memory.
     const cachedScopes = engine.Scopes;
     const scopeMap = new Map(cachedScopes.map(s => [s.FullPath, s.ID]));
 
@@ -196,7 +208,6 @@ async function assignScopes(apiKeyID: string, contextUser: UserInfo, engine: Ret
         return false;
     }
 
-    // Create an APIKeyScope record for each required scope
     let allSaved = true;
     for (const scopePath of REQUIRED_SCOPE_PATHS) {
         const scopeID = scopeMap.get(scopePath)!;

--- a/packages/MJServer/src/agents/skip-sdk.ts
+++ b/packages/MJServer/src/agents/skip-sdk.ts
@@ -29,7 +29,8 @@ import { MJConversationDetailEntity, QueryEngine } from '@memberjunction/core-en
 import { request as httpRequest } from 'http';
 import { request as httpsRequest } from 'https';
 import { gzip as gzipCompress, createGunzip } from 'zlib';
-import { configInfo, baseUrl, publicUrl, graphqlPort, graphqlRootPath, apiKey as callbackAPIKey } from '../config.js';
+import { configInfo, baseUrl, publicUrl, graphqlPort, graphqlRootPath, apiKey as legacyCallbackAPIKey } from '../config.js';
+import { getSkipCallbackKey } from './skip-callback-key-provisioner.js';
 import { getDbType } from '../index.js';
 import { GetAIAPIKey } from '@memberjunction/ai';
 import { AIEngine } from '@memberjunction/aiengine';
@@ -421,9 +422,18 @@ export class SkipSDK {
         const { notes, noteTypes } = includeNotes ? await this.buildAgentNotes(contextUser) : { notes: [], noteTypes: [] };
         // Note: requests would be built here if includeRequests is true
 
-        // Setup access token for Skip callbacks if needed
+        // Setup callback auth for Skip→client callbacks if needed
+        let callbackAPIKey: string | undefined;
         let accessToken: GetDataAccessToken | undefined;
         if (includeCallbackAuth) {
+            // Try the auto-provisioned scoped API key first; fall back to
+            // legacy MJ_API_KEY env var during the transition period.
+            const scopedKey = await getSkipCallbackKey();
+            callbackAPIKey = scopedKey ?? legacyCallbackAPIKey;
+
+            // Access token is still generated for the transition period — the
+            // legacy GetData resolver requires it. Once Phase 5 (cleanup) removes
+            // GetData usage, this can be removed.
             const tokenInfo = {
                 type: 'skip_api_request',
                 userEmail: contextUser.Email,
@@ -449,8 +459,8 @@ export class SkipSDK {
             organizationID: this.config.organizationId,
             organizationInfo: this.config.organizationInfo,
             apiKeys: this.buildAPIKeys(),
-            callingServerURL: accessToken ? (publicUrl || `${baseUrl}:${graphqlPort}${graphqlRootPath}`) : undefined,
-            callingServerAPIKey: accessToken ? callbackAPIKey : undefined,
+            callingServerURL: callbackAPIKey ? (publicUrl || `${baseUrl}:${graphqlPort}${graphqlRootPath}`) : undefined,
+            callingServerAPIKey: callbackAPIKey,
             callingServerAccessToken: accessToken ? accessToken.Token : undefined
         };
     }

--- a/packages/MJServer/src/agents/skip-sdk.ts
+++ b/packages/MJServer/src/agents/skip-sdk.ts
@@ -30,7 +30,7 @@ import { request as httpRequest } from 'http';
 import { request as httpsRequest } from 'https';
 import { gzip as gzipCompress, createGunzip } from 'zlib';
 import { configInfo, baseUrl, publicUrl, graphqlPort, graphqlRootPath, apiKey as legacyCallbackAPIKey } from '../config.js';
-import { getSkipCallbackKey } from './skip-callback-key-provisioner.js';
+import { getSkipCallbackKey, provisioningComplete as skipKeyProvisioned } from './skip-callback-key-provisioner.js';
 import { getDbType } from '../index.js';
 import { GetAIAPIKey } from '@memberjunction/ai';
 import { AIEngine } from '@memberjunction/aiengine';
@@ -423,13 +423,26 @@ export class SkipSDK {
         // Note: requests would be built here if includeRequests is true
 
         // Setup callback auth for Skip→client callbacks if needed
-        let callbackAPIKey: string | undefined;
+        let callingServerURL: string | undefined;
+        let callingServerAPIKey: string | undefined;
         let accessToken: GetDataAccessToken | undefined;
         if (includeCallbackAuth) {
-            // Try the auto-provisioned scoped API key first; fall back to
-            // legacy MJ_API_KEY env var during the transition period.
-            const scopedKey = await getSkipCallbackKey();
-            callbackAPIKey = scopedKey ?? legacyCallbackAPIKey;
+            callingServerURL = publicUrl || `${baseUrl}:${graphqlPort}${graphqlRootPath}`;
+
+            // Auto-provisioned scoped API key. Returns the raw key ONLY when
+            // a new key was just created (first time connecting to this Skip host).
+            // Returns null when key already exists — Skip already has it stored
+            // in its credential store from the initial request.
+            const newlyCreatedKey = await getSkipCallbackKey();
+            if (newlyCreatedKey) {
+                // First time: send raw key so Skip can persist it
+                callingServerAPIKey = newlyCreatedKey;
+            } else if (!skipKeyProvisioned && legacyCallbackAPIKey) {
+                // Provisioning failed (missing service account, scopes, etc.)
+                // Fall back to legacy MJ_API_KEY during transition period
+                callingServerAPIKey = legacyCallbackAPIKey;
+            }
+            // else: skipKeyProvisioned=true, key exists in DB, Skip already has it — omit callingServerAPIKey
 
             // Access token is still generated for the transition period — the
             // legacy GetData resolver requires it. Once Phase 5 (cleanup) removes
@@ -459,8 +472,8 @@ export class SkipSDK {
             organizationID: this.config.organizationId,
             organizationInfo: this.config.organizationInfo,
             apiKeys: this.buildAPIKeys(),
-            callingServerURL: callbackAPIKey ? (publicUrl || `${baseUrl}:${graphqlPort}${graphqlRootPath}`) : undefined,
-            callingServerAPIKey: callbackAPIKey,
+            callingServerURL,
+            callingServerAPIKey,
             callingServerAccessToken: accessToken ? accessToken.Token : undefined
         };
     }

--- a/packages/MJServer/src/generic/RunViewResolver.ts
+++ b/packages/MJServer/src/generic/RunViewResolver.ts
@@ -715,6 +715,7 @@ export class RunViewResolver extends ResolverBase {
     pubSub: PubSubEngine
   ) {
     try {
+      await this.CheckAPIKeyScopeAuthorization('view:run', input.ViewName, userPayload);
       const provider = GetReadOnlyProvider(providers, { allowFallbackToReadWrite: true });
       const rawData = await super.RunViewByNameGeneric(input, provider, userPayload, pubSub);
       if (rawData === null) 
@@ -746,6 +747,7 @@ export class RunViewResolver extends ResolverBase {
     pubSub: PubSubEngine
   ) {
     try {
+      await this.CheckAPIKeyScopeAuthorization('view:run', input.ViewID, userPayload);
       const provider = GetReadOnlyProvider(providers, { allowFallbackToReadWrite: true });
       const rawData = await super.RunViewByIDGeneric(input, provider, userPayload, pubSub);
       if (rawData === null) 
@@ -777,6 +779,7 @@ export class RunViewResolver extends ResolverBase {
     pubSub: PubSubEngine
   ) {
     try {
+      await this.CheckAPIKeyScopeAuthorization('view:run', input.EntityName, userPayload);
       const provider = GetReadOnlyProvider(providers, { allowFallbackToReadWrite: true });
       const rawData = await super.RunDynamicViewGeneric(input, provider, userPayload, pubSub);
       if (rawData === null) return null;
@@ -806,6 +809,7 @@ export class RunViewResolver extends ResolverBase {
     pubSub: PubSubEngine
   ) {
     try {
+      await this.CheckAPIKeyScopeAuthorization('view:batch', '*', userPayload);
       const provider = GetReadOnlyProvider(providers, { allowFallbackToReadWrite: true });
       // Note: RunViewsGeneric returns the core RunViewResult type, not the GraphQL type
       const rawData = await super.RunViewsGeneric(input, provider, userPayload);

--- a/packages/MJServer/src/resolvers/QuerySystemUserResolver.ts
+++ b/packages/MJServer/src/resolvers/QuerySystemUserResolver.ts
@@ -1,7 +1,7 @@
 import { Arg, Ctx, Field, InputType, Mutation, ObjectType, registerEnumType, Resolver, PubSub, PubSubEngine } from 'type-graphql';
 import { AppContext } from '../types.js';
 import { LogError, UserInfo, CompositeKey, DatabaseProviderBase, LogStatus } from '@memberjunction/core';
-import { RequireSystemUser } from '../directives/RequireSystemUser.js';
+// RequireSystemUser removed — these resolvers now use CheckAPIKeyScopeAuthorization
 import { MJQueryCategoryEntity, MJQueryPermissionEntity, MJQueryFieldEntity, MJQueryParameterEntity, MJQueryEntityEntity, QueryEngine } from '@memberjunction/core-entities';
 import { MJQueryResolver, MJQuery_, MJQueryField_, MJQueryParameter_, MJQueryEntity_, MJQueryPermission_ } from '../generated/generated.js';
 import { GetReadWriteProvider } from '../util.js';
@@ -229,19 +229,21 @@ export class DeleteQueryResultType {
 @Resolver()
 export class MJQueryResolverExtended extends MJQueryResolver {
     /**
-     * Creates a new query with the provided attributes. This mutation is restricted to system users only.
+     * Creates a new query with the provided attributes. Requires `query:create` scope for API key users;
+     * entity-level create permission on MJ: Queries for all users.
      * @param input - CreateQuerySystemUserInput containing all the query attributes
      * @param context - Application context containing user information
      * @returns CreateQueryResultType with success status and query data
      */
-    @RequireSystemUser()
     @Mutation(() => QueryMutationResultType)
-    async CreateQuerySystemUser(
+    async CreateQueryExtended(
         @Arg('input', () => CreateQuerySystemUserInput) input: CreateQuerySystemUserInput,
         @Ctx() context: AppContext,
         @PubSub() pubSub: PubSubEngine
     ): Promise<QueryMutationResultType> {
         try {
+            await this.CheckAPIKeyScopeAuthorization('query:create', '*', context.userPayload);
+
             // Handle CategoryPath if provided
             let finalCategoryID = input.CategoryID;
             const provider = GetReadWriteProvider(context.providers);
@@ -443,19 +445,21 @@ export class MJQueryResolverExtended extends MJQueryResolver {
     }
 
     /**
-     * Updates an existing query with the provided attributes. This mutation is restricted to system users only.
+     * Updates an existing query with the provided attributes. Requires `query:update` scope for API key users;
+     * entity-level update permission on MJ: Queries for all users.
      * @param input - UpdateQuerySystemUserInput containing the query ID and fields to update
      * @param context - Application context containing user information
      * @returns UpdateQueryResultType with success status and updated query data including related entities
      */
-    @RequireSystemUser()
     @Mutation(() => QueryMutationResultType)
-    async UpdateQuerySystemUser(
+    async UpdateQueryExtended(
         @Arg('input', () => UpdateQuerySystemUserInput) input: UpdateQuerySystemUserInput,
         @Ctx() context: AppContext,
         @PubSub() pubSub: PubSubEngine
     ): Promise<QueryMutationResultType> {
         try {
+            await this.CheckAPIKeyScopeAuthorization('query:update', input.ID, context.userPayload);
+
             // Load the existing query using MJQueryEntityServer
             const provider = GetReadWriteProvider(context.providers);
             const queryEntity = await provider.GetEntityObject<MJQueryEntityServer>('MJ: Queries', context.userPayload.userRecord);
@@ -547,21 +551,22 @@ export class MJQueryResolverExtended extends MJQueryResolver {
     }
 
     /**
-     * Deletes a query by ID. This mutation is restricted to system users only.
+     * Deletes a query by ID. Requires `query:delete` scope for API key users;
+     * entity-level delete permission on MJ: Queries is enforced by the entity framework.
      * @param ID - The ID of the query to delete
      * @param options - Delete options controlling action execution
      * @param context - Application context containing user information
      * @returns DeleteQueryResultType with success status and deleted query data
      */
-    @RequireSystemUser()
     @Mutation(() => DeleteQueryResultType)
-    async DeleteQuerySystemResolver(
+    async DeleteQueryExtended(
         @Arg('ID', () => String) ID: string,
         @Arg('options', () => DeleteOptionsInput, { nullable: true }) options: DeleteOptionsInput | null,
         @Ctx() context: AppContext,
         @PubSub() pubSub: PubSubEngine
     ): Promise<DeleteQueryResultType> {
         try {
+            await this.CheckAPIKeyScopeAuthorization('query:delete', ID, context.userPayload);
             // Validate ID is not null/undefined/empty
             if (!ID || ID.trim() === '') {
                 return {

--- a/packages/MJServer/src/resolvers/SearchKnowledgeResolver.ts
+++ b/packages/MJServer/src/resolvers/SearchKnowledgeResolver.ts
@@ -213,6 +213,7 @@ export class SearchKnowledgeResolver extends ResolverBase {
     ): Promise<SearchKnowledgeResult> {
         const startTime = Date.now();
         try {
+            await this.CheckAPIKeyScopeAuthorization('search:execute', '*', userPayload);
             const currentUser = this.GetUserFromPayload(userPayload);
             if (!currentUser) {
                 return this.errorResult('Unable to determine current user', startTime);
@@ -400,6 +401,7 @@ export class SearchKnowledgeResolver extends ResolverBase {
     ): Promise<SearchKnowledgeResult> {
         const startTime = Date.now();
         try {
+            await this.CheckAPIKeyScopeAuthorization('search:execute', '*', userPayload);
             const currentUser = this.GetUserFromPayload(userPayload);
             if (!currentUser) {
                 return this.errorResult('Unable to determine current user', startTime);

--- a/packages/MJServer/src/resolvers/TestQuerySQLResolver.ts
+++ b/packages/MJServer/src/resolvers/TestQuerySQLResolver.ts
@@ -2,7 +2,7 @@ import { Arg, Ctx, Field, InputType, Int, ObjectType, Query, Resolver } from 'ty
 import { GraphQLJSONObject } from 'graphql-type-json';
 import { RunQuery, IRunQueryProvider, LogError, LogStatus, QueryExecutionSpec } from '@memberjunction/core';
 import { AppContext } from '../types.js';
-import { RequireSystemUser } from '../directives/RequireSystemUser.js';
+// RequireSystemUser removed — this resolver now uses CheckAPIKeyScopeAuthorization
 import { GetReadOnlyProvider } from '../util.js';
 import { ResolverBase } from '../generic/ResolverBase.js';
 
@@ -85,7 +85,7 @@ export class TestQuerySQLResult {
  * enabling external systems (e.g., Skip-Brain) to test query SQL before saving to the database.
  *
  * Security:
- * - Requires system user authentication (@RequireSystemUser)
+ * - Requires `query:test` scope for API key users (no-op for JWT auth)
  * - Uses read-only database connection (no mutation possible)
  * - Enforces MaxRows limit (default 100) to prevent unbounded queries
  *
@@ -93,7 +93,6 @@ export class TestQuerySQLResult {
  */
 @Resolver()
 export class TestQuerySQLResolver extends ResolverBase {
-    @RequireSystemUser()
     @Query(() => TestQuerySQLResult, {
         description: 'Test transient SQL with full composition + Nunjucks template processing without requiring a saved query'
     })
@@ -102,6 +101,7 @@ export class TestQuerySQLResolver extends ResolverBase {
         @Ctx() context: AppContext
     ): Promise<TestQuerySQLResult> {
         try {
+            await this.CheckAPIKeyScopeAuthorization('query:test', '*', context.userPayload);
             // Use read-only provider for security — no mutation possible
             const provider = GetReadOnlyProvider(context.providers, { allowFallbackToReadWrite: false });
             if (!provider) {

--- a/plans/skip-callback-scoped-api-keys.md
+++ b/plans/skip-callback-scoped-api-keys.md
@@ -2,7 +2,7 @@
 
 **Date:** June 8, 2026  
 **Author:** Jordan Fanapour  
-**Status:** Draft — pending team review
+**Status:** Approved — Phase 1 & 2 complete, Phase 3 revised
 
 ---
 
@@ -45,7 +45,7 @@ When Skip calls back to a customer's MJAPI to execute views, queries, search, an
 
 ## 3. Proposed Solution
 
-Replace the `x-mj-api-key` system user authentication for Skip callbacks with **scoped API keys** generated through MJ's core `APIKeyEngine` infrastructure. Since every client MJAPI runs MJ core, the APIKeyEngine, scope tables, and scope evaluation are all available on the client side — no BCSaaS dependency required.
+Replace the `x-mj-api-key` system user authentication for Skip callbacks with **scoped API keys** generated through MJ's core `APIKeyEngine` infrastructure. Skip callbacks switch from calling `@RequireSystemUser` resolvers to calling the **regular (non-system) resolvers** that already have scope checking via `CheckAPIKeyScopeAuthorization()`. Since every client MJAPI runs MJ core, the APIKeyEngine, scope tables, and scope evaluation are all available on the client side — no BCSaaS dependency required.
 
 ### 3.1 Overview
 
@@ -56,22 +56,59 @@ CURRENT:
   → Full access to all @RequireSystemUser resolvers
 
 PROPOSED:
-  Client MJAPI (SkipSDK) provisions a scoped API key for Skip callbacks
+  Client MJAPI (SkipSDK) auto-provisions a scoped API key for Skip callbacks
   SkipSDK sends this scoped key to Skip API in the request
   Skip API calls back with X-API-Key: skip_cb_<key>
-  → client context.ts validates via APIKeyEngine → scoped resolver access
+  → client context.ts validates via APIKeyEngine → Skip service account user
+  → Skip calls regular (non-system) resolvers → scope checks enforced
 ```
 
-### 3.2 Key Provisioning (on the Client MJAPI)
+### 3.2 Key Provisioning (Auto-Provisioning via SkipSDK + Credential Storage on Skip)
 
-When a customer configures Skip on their MJAPI:
+> **Decision (June 9, 2026):** Auto-provisioning on first request. No manual env var or admin step needed for the callback key. A dedicated Skip service account user is created via MJ metadata and deployed to all client MJAPIs via metadata sync.
+>
+> **Revised (June 10, 2026):** API keys are stored as SHA-256 hashes in the DB — the raw key is only available at creation time and cannot be recovered after server restart. To solve this, SkipSDK sends the raw key to Skip on **first request only**. Skip persists it in BCSaaS's encrypted credential store (`BC: Organization Credentials`) keyed by organization. Future requests omit the key — Skip looks it up by org ID.
 
-1. `APIKeyEngine.CreateAPIKey()` generates a key with prefix `skip_cb_` (callback)
-2. The key is assigned to a **Skip service account user** on the client MJAPI (not the system user) with appropriate MJ roles
-3. Scopes are assigned to the key via `APIKeyScope` records (see Section 4)
-4. The SkipSDK on the client MJAPI includes this key in the `callingServerAPIKey` field of the request to Skip API — replacing the current `x-mj-api-key` value
+#### MJ Client Side (SkipSDK Provisioner)
 
-The key's owning user (the Skip service account on the client) determines the baseline entity permissions and RLS rules. This is how Skip's data access on the client's system can be constrained — the service account's roles define the ceiling, and scopes further narrow it.
+When SkipSDK on a client MJAPI processes a request to a Skip host:
+
+1. SkipSDK checks if a Skip callback key already exists by querying `MJ: API Keys` for a record labeled `"Skip Callback: {skipHostUrl}"` owned by the Skip service account
+2. **If no key exists** (first time connecting to this Skip host):
+   - SkipSDK calls `APIKeyEngine.CreateAPIKey()` to generate a scoped key
+   - The key is assigned to the **Skip service account user** (deployed via MJ metadata)
+   - Required scopes are assigned via `APIKeyScope` records (see Section 4)
+   - SkipSDK includes the raw key in `callingServerAPIKey` — this is the **only time** the raw key is transmitted
+   - Skip receives and persists it in its encrypted credential store (see Section 6.6)
+3. **If a key already exists** (any subsequent request, including after MJ restart):
+   - SkipSDK sends the request **without** `callingServerAPIKey`
+   - Skip looks up the stored credential by organization ID
+   - No caching of the raw key is needed — it's only used once at creation time
+
+The label convention `"Skip Callback: {skipHostUrl}"` (e.g., `"Skip Callback: https://skip.example.com"`) supports multiple Skip hosts per MJ instance. The URL comes from `ASK_SKIP_CHAT_URL` env var.
+
+This eliminates the `MJ_API_KEY` environment variable from client onboarding. The only env var needed is `ASK_SKIP_API_KEY` (which authenticates the client *to* Skip — a separate concern).
+
+The key's owning user (the Skip service account on the client) determines the baseline entity permissions and RLS rules. The service account's roles define the ceiling, and scopes further narrow it.
+
+#### Skip SaaS Side (Credential Storage)
+
+When Skip's API receives a request:
+
+1. **If `callingServerAPIKey` is present** in the request:
+   - Store or update it as a `BC: Organization Credential` linked to the "MJAPI Callback" credential use
+   - Encrypted at rest via MJ's credential encryption system
+2. **If `callingServerAPIKey` is absent**:
+   - Look up the stored credential for this organization's "MJAPI Callback" use
+   - If found → decrypt and inject into the request for downstream use
+   - If not found → halt execution with an authentication error
+
+**Concerns with auto-provisioning:**
+
+1. **SkipSDK needs API key creation permissions.** The provisioner uses the system user context for key creation, so no special permissions are needed on the calling user.
+2. **Race condition on first request.** The provisioning logic uses a promise-based mutex to prevent duplicate keys from concurrent requests.
+3. **Key visibility.** Admins cannot see or manage the auto-provisioned key without querying the API Keys table directly. A future Skip admin dashboard should surface this for key rotation, scope management, and revocation (see Section 10).
+4. **Key rotation.** If an admin deletes the API key record on the MJ side, the provisioner creates a new one on the next request and sends the raw key to Skip, which updates its stored credential. This is the rotation mechanism — delete the old key, let auto-provisioning handle the rest.
 
 ### 3.3 Authentication Flow
 
@@ -86,9 +123,10 @@ The key's owning user (the Skip service account on the client) determines the ba
 3. When Skip calls back to the client MJAPI:
    - Sends X-API-Key: skip_cb_<key> header
    - Client's context.ts validates via APIKeyEngine (User API Key path, line 85)
-   - userPayload populated with apiKeyHash + Skip service account user
+   - userPayload populated with apiKeyId + Skip service account user
+   - Skip calls REGULAR resolvers (not SystemUser variants)
 
-4. Client resolver calls CheckAPIKeyScopeAuthorization(scopePath, resource, userPayload)
+4. Regular resolver calls CheckAPIKeyScopeAuthorization(scopePath, resource, userPayload)
 
 5. APIKeyEngine.Authorize() evaluates scopes + logs the operation on the client's system
 
@@ -97,34 +135,43 @@ The key's owning user (the Skip service account on the client) determines the ba
 
 ## 4. Scope Definitions
 
-Define the following scopes in MJ core's `APIScope` table (available on every MJ deployment):
+> **Decision (June 9, 2026):** Use MJ's existing scope hierarchy, not a separate `skip:*` namespace. Skip callbacks use the regular (non-system) resolvers, so they need the same scopes as any other API key user. Missing scopes have been added to the existing hierarchy.
 
-| Scope Path | Description | Current SystemUser Resolver |
-|------------|-------------|----------------------------|
-| `skip:view:run` | Execute views (by name, ID, or dynamic) | RunViewByName/ID/DynamicSystemUser |
-| `skip:view:batch` | Batch view execution | RunViewsSystemUser |
-| `skip:query:run` | Execute queries (by name or ID) | GetQueryData/ByNameSystemUser |
-| `skip:query:create` | Create new queries | CreateQuerySystemUser |
-| `skip:query:update` | Update existing queries | UpdateQuerySystemUser |
-| `skip:query:delete` | Delete queries | DeleteQuerySystemResolver |
-| `skip:sql:test` | Test SQL with composition/Nunjucks | TestQuerySQL |
-| `skip:search` | Knowledge search and preview | SearchKnowledge/PreviewSearchAsSystemUser |
-| `skip:ai:prompt` | Execute AI prompts | RunAIPrompt/ExecuteSimplePromptSystemUser |
-| `skip:ai:agent` | Execute AI agents | RunAIAgentSystemUser |
-| `skip:ai:embed` | Generate text embeddings | EmbedTextSystemUser |
+Scopes are defined in MJ core's `APIScope` table (available on every MJ deployment) via metadata: `MJ/metadata/api-scopes/.api-scopes.json`.
 
-**Not included:** `GetData` (raw SQL execution). This is the highest-risk operation and is being superseded by `TestQuerySQL`. If needed in the future, it can be added as `skip:sql:raw` with additional safeguards.
+### 4.1 Scopes Required by Skip Callbacks
 
-### 4.1 Default Key Scope Assignment
+| Scope Path | Description | Target Resolver |
+|------------|-------------|-----------------|
+| `view:run` | Execute views (by name, ID, or dynamic) | `RunViewByName`, `RunViewByID`, `RunDynamicView` |
+| `view:batch` | Batch view execution | `RunViews` |
+| `query:run` | Execute queries (by name or ID) | `GetQueryData`, `GetQueryDataByName` |
+| `query:create` | Create new queries | `CreateQueryExtended` (converted from SystemUser) |
+| `query:update` | Update existing queries | `UpdateQueryExtended` (converted from SystemUser) |
+| `query:delete` | Delete queries | `DeleteQueryExtended` (converted from SystemUser) |
+| `query:test` | Test transient SQL with composition/Nunjucks | `TestQuerySQL` (converted from SystemUser) |
+| `search:execute` | Knowledge search and preview | `SearchKnowledge`, `PreviewSearch` |
+| `prompt:execute` | Execute AI prompts | `RunAIPrompt`, `ExecuteSimplePrompt` |
+| `agent:execute` | Execute AI agents | `RunAIAgent` |
+| `embedding:generate` | Generate text embeddings | `EmbedText` |
+
+**New scopes added to existing hierarchy** (Phase 1):
+- `view:batch` — under existing `view` parent
+- `query:create`, `query:update`, `query:delete`, `query:test` — under existing `query` parent
+- `search` (parent) + `search:execute` — new top-level category
+
+**Not included:** `GetData` (raw SQL execution). This is the highest-risk operation and is being superseded by `TestQuerySQL`. If needed in the future, it can be added as `query:raw` with additional safeguards.
+
+### 4.2 Default Key Scope Assignment
 
 A standard Skip callback key would receive all scopes above. Customers who want to restrict Skip's capabilities (e.g., no AI agent execution, no query creation) can remove specific scopes from their key.
 
-### 4.2 Resource-Level Restrictions (Future)
+### 4.3 Resource-Level Restrictions (Future)
 
 The `APIKeyScope` table supports `ResourcePattern` with glob/regex/literal matching. In a future phase, customers could restrict Skip to specific entities:
 
 ```
-Scope: skip:view:run
+Scope: view:run
 ResourcePattern: Contacts*    (glob)
 Effect: Skip can only run views on Contacts, ContactType, etc.
 ```
@@ -133,115 +180,287 @@ This is not required for the initial implementation but the infrastructure suppo
 
 ## 5. Resolver Changes
 
-### 5.1 Current Pattern
+> **Decision (June 9, 2026):** Skip callbacks use the regular (non-system) resolvers instead of overloading `@RequireSystemUser`. The `@RequireSystemUser` directive remains unchanged — it stays pure as system-user-only. Long-term, the SystemUser resolvers and `GraphQLSystemUserClient` are decommissioned entirely.
 
-Each operation has two resolver variants:
+### 5.1 Complete Resolver Mapping
+
+#### Already ready — have non-system variant with scope checks (6 resolvers)
+
+| SystemUser Resolver | Non-System Resolver | File | Existing Scope |
+|---|---|---|---|
+| `GetQueryDataSystemUser` | `GetQueryData` | `QueryResolver.ts:186` | `query:run` |
+| `GetQueryDataByNameSystemUser` | `GetQueryDataByName` | `QueryResolver.ts:251` | `query:run` |
+| `RunAIPromptSystemUser` | `RunAIPrompt` | `RunAIPromptResolver.ts:284` | `prompt:execute` |
+| `ExecuteSimplePromptSystemUser` | `ExecuteSimplePrompt` | `RunAIPromptResolver.ts:587` | `prompt:execute` |
+| `EmbedTextSystemUser` | `EmbedText` | `RunAIPromptResolver.ts:703` | `embedding:generate` |
+| `RunAIAgentSystemUser` | `RunAIAgent` | `RunAIAgentResolver.ts:608` | `agent:execute` |
+
+**Action:** Skip switches to calling these directly. No MJ-side changes needed.
+
+#### Need scope checks added to existing non-system variant (6 resolvers)
+
+| SystemUser Resolver | Non-System Resolver | File | Scope to Add |
+|---|---|---|---|
+| `RunViewByNameSystemUser` | `RunViewByName` | `RunViewResolver.ts:712` | `view:run` |
+| `RunViewByIDSystemUser` | `RunViewByID` | `RunViewResolver.ts:743` | `view:run` |
+| `RunDynamicViewSystemUser` | `RunDynamicView` | `RunViewResolver.ts:774` | `view:run` |
+| `RunViewsSystemUser` | `RunViews` | `RunViewResolver.ts:803` | `view:batch` |
+| `SearchKnowledgeAsSystemUser` | `SearchKnowledge` | `SearchKnowledgeResolver.ts:204` | `search:execute` |
+| `PreviewSearchAsSystemUser` | `PreviewSearch` | `SearchKnowledgeResolver.ts:396` | `search:execute` |
+
+**Action:** Add `CheckAPIKeyScopeAuthorization()` calls to these resolvers.
+
+#### No non-system variant — convert SystemUser resolvers in-place (4 resolvers)
+
+| Current Name | New Name | File | Scope | Codegen? |
+|---|---|---|---|---|
+| `CreateQuerySystemUser` | `CreateQueryExtended` | `QuerySystemUserResolver.ts:239` | `query:create` | No (hand-written, extends codegen `MJQueryResolver`) |
+| `UpdateQuerySystemUser` | `UpdateQueryExtended` | `QuerySystemUserResolver.ts:453` | `query:update` | No (hand-written) |
+| `DeleteQuerySystemResolver` | `DeleteQueryExtended` | `QuerySystemUserResolver.ts:558` | `query:delete` | No (hand-written) |
+| `TestQuerySQL` | `TestQuerySQL` (no rename needed) | `TestQuerySQLResolver.ts:100` | `query:test` | No (hand-written) |
+
+**Action:** Remove `@RequireSystemUser` decorator, add `CheckAPIKeyScopeAuthorization()` + entity permission checks, rename to "Extended" suffix (except TestQuerySQL which has no naming collision).
+
+**Naming collision analysis:** CodeGen generates `CreateMJQuery`, `UpdateMJQuery`, `DeleteMJQuery` (simple CRUD wrappers in `generated.ts:59877-59901`). These are thin `CreateRecord`/`UpdateRecord`/`DeleteRecord` calls with no business logic. The SystemUser variants have substantial additional logic (category path resolution, collision detection, AI processing via `MJQueryEntityServer`, permission management). The "Extended" naming convention avoids collisions and accurately describes the enhanced behavior.
+
+**No codegen blockers:** All 4 resolvers are fully hand-written. The `QuerySystemUserResolver` extends codegen `MJQueryResolver` for read operations only — the CRUD mutations are entirely custom.
+
+### 5.2 Conversion Pattern
+
+For the 4 SystemUser resolvers being converted:
 
 ```typescript
-// Regular user version — checks API key scopes
-@Query(() => QueryResultType)
-async GetQueryData(...) {
-    await this.CheckAPIKeyScopeAuthorization('query:run', QueryID, context.userPayload);
-    // ... execute
-}
-
-// System user version — only checks isSystemUser flag
+// BEFORE
 @RequireSystemUser()
-@Query(() => QueryResultType)
-async GetQueryDataSystemUser(...) {
-    // ... same execute logic, no scope check
+@Mutation(() => QueryMutationResultType)
+async CreateQuerySystemUser(...) { ... }
+
+// AFTER
+@Mutation(() => QueryMutationResultType)
+async CreateQueryExtended(
+    @Arg('input', () => CreateQueryExtendedInput) input: CreateQueryExtendedInput,
+    @Ctx() context: AppContext,
+    @PubSub() pubSub: PubSubEngine
+): Promise<QueryMutationResultType> {
+    // Scope check for API key users (no-op for JWT users)
+    await this.CheckAPIKeyScopeAuthorization('query:create', '*', context.userPayload);
+    // Entity permission check (applies to all users)
+    this.CheckUserCreatePermissions('MJ: Queries', context.userPayload);
+    // ... existing business logic unchanged
 }
 ```
-
-### 5.2 Proposed Change
-
-**Option A (Recommended): Modify the `@RequireSystemUser` directive to accept either auth method**
-
-Update the directive to accept either:
-- `isSystemUser: true` (legacy, for backward compatibility during migration)
-- A valid API key with the required scope
-
-```typescript
-// Pseudocode for the updated directive
-if (context.userPayload.isSystemUser) {
-    return resolve();  // Legacy system user — allow
-}
-if (context.userPayload.apiKeyHash) {
-    await CheckAPIKeyScopeAuthorization(requiredScope, resource, context.userPayload);
-    return resolve();  // Scoped API key — allow if scope matches
-}
-throw new AuthorizationError('Requires system user or scoped API key');
-```
-
-The scope parameter can be passed via the directive argument:
-
-```typescript
-@RequireSystemUser({ scope: 'skip:query:run' })
-@Query(() => QueryResultType)
-async GetQueryDataSystemUser(@Arg('QueryID') QueryID: string, @Ctx() context) {
-    // Directive handles auth (system user OR scoped API key)
-    // ... execute
-}
-```
-
-This approach:
-- Preserves backward compatibility (existing `x-mj-api-key` still works during migration)
-- Allows gradual migration (customers can switch to scoped keys at their own pace)
-- Requires minimal resolver changes (update directive + add scope annotations, not rewrite every resolver)
-
-**Option B: Create new Skip-specific resolvers**
-
-Create a third set of resolvers for each operation that use `CheckAPIKeyScopeAuthorization` with Skip-specific scopes. More code but zero risk to existing resolvers.
 
 ## 6. Skip-Side Changes
 
-### 6.1 ConnectionManager
+### 6.1 New Skip Callback Client
 
-Replace `GraphQLSystemUserClient` construction in `ConnectionManager.ts` (line 137):
+> **Decision (June 9, 2026):** Skip builds its own `SkipCallbackClient` wrapper around the raw `GraphQLClient` from `graphql-request`, replacing `GraphQLSystemUserClient` from `@memberjunction/graphql-dataprovider`. This gives Skip full control over its client lifecycle without depending on MJ's package for changes.
+
+**What `GraphQLSystemUserClient` provides today:**
+
+1. **Header construction** — Sets `x-mj-api-key`, `Authorization: Bearer <token>`, `x-session-id`. ~5 lines in the constructor.
+2. **Typed method wrappers** — Methods like `RunViewByName()`, `CreateQuery()` containing GraphQL query strings. All of these need to change to target non-system resolvers.
+3. **TypeScript types** — Input/output types for each operation. The SystemUser-specific types won't match the regular resolver signatures.
+
+**What Skip loses by not using it:** Effectively nothing. `GraphQLSystemUserClient` is a thin stateless wrapper — no caching, no token refresh, no WebSocket support. Everything it does needs to change for the new auth model anyway.
+
+**What Skip gains with its own client:**
+
+- Client lives in Skip-Brain's repo — no coordinating MJ releases for client changes
+- Clean `X-API-Key` header from day one, no backwards compatibility shims
+- Only the operations Skip actually needs — no `SyncData`, `SyncRolesAndUsers`, `GetAllRemoteEntities`, `GetData` dead weight
+- `RemoteMJUtilities` and the new client evolve together
+- Skip-specific concerns (per-operation audit logging, retry policies) can be added without polluting MJ
+
+**Location:** `Skip-Brain/packages/shared/src/connection/SkipCallbackClient.ts`
 
 ```typescript
-// CURRENT: System user client with x-mj-api-key
-const client = new GraphQLSystemUserClient(url, token, sessionId, mjAPIKey);
+// Conceptual structure
+class SkipCallbackClient {
+    private client: GraphQLClient;  // from graphql-request
 
-// PROPOSED: Standard client with X-API-Key header
-const client = new GraphQLClient(url, {
-    headers: {
-        'X-API-Key': skipCallbackApiKey,     // skip_cb_* key from the client MJAPI
-        'x-session-id': sessionId,
+    constructor(url: string, apiKey: string, sessionId: string) {
+        this.client = new GraphQLClient(url, {
+            headers: {
+                'X-API-Key': apiKey,       // skip_cb_* scoped key
+                'x-session-id': sessionId,
+            }
+        });
     }
-});
+
+    // Only the operations Skip actually uses:
+    async RunDynamicView(...): Promise<RunViewResult> { ... }
+    async RunViews(...): Promise<RunViewResult[]> { ... }
+    async GetQueryData(...): Promise<RunQueryResult> { ... }
+    async GetQueryDataByName(...): Promise<RunQueryResult> { ... }
+    async CreateQueryExtended(...): Promise<QueryMutationResult> { ... }
+    async UpdateQueryExtended(...): Promise<QueryMutationResult> { ... }
+    async DeleteQueryExtended(...): Promise<DeleteQueryResult> { ... }
+    async TestQuerySQL(...): Promise<TestQuerySQLResult> { ... }
+    async SearchKnowledge(...): Promise<SearchKnowledgeResult> { ... }
+    async PreviewSearch(...): Promise<SearchKnowledgeResult> { ... }
+    async RunAIPrompt(...): Promise<RunAIPromptResult> { ... }
+    async ExecuteSimplePrompt(...): Promise<SimplePromptResult> { ... }
+    async EmbedText(...): Promise<EmbedTextResult> { ... }
+    async RunAIAgent(...): Promise<ExecuteAgentResult> { ... }
+}
 ```
 
-### 6.2 Key Flow
+### 6.2 ConnectionManager Update
 
-The scoped callback key is provisioned on the client MJAPI and passed to Skip in the existing `callingServerAPIKey` field of the SkipAPIRequest. No new field is needed — the value just changes from the system API key to a scoped API key. Skip stores and uses it the same way it does today.
+`ConnectionManager.ts` switches from constructing `GraphQLSystemUserClient` to `SkipCallbackClient`:
 
-### 6.3 Access Token Removal
+```typescript
+// CURRENT
+const client = new GraphQLSystemUserClient(url, token, sessionId, mjAPIKey);
+
+// PROPOSED
+const client = new SkipCallbackClient(url, skipCallbackApiKey, sessionId);
+```
+
+### 6.3 RemoteMJUtilities Update
+
+Update all GraphQL query/mutation names in `RemoteMJUtilities.ts` to target the non-system resolvers:
+
+| Current Call | New Call |
+|---|---|
+| `RunViewByNameSystemUser` | `RunViewByName` |
+| `RunViewByIDSystemUser` | `RunViewByID` |
+| `RunDynamicViewSystemUser` | `RunDynamicView` |
+| `RunViewsSystemUser` | `RunViews` |
+| `GetQueryDataSystemUser` | `GetQueryData` |
+| `GetQueryDataByNameSystemUser` | `GetQueryDataByName` |
+| `CreateQuerySystemUser` | `CreateQueryExtended` |
+| `UpdateQuerySystemUser` | `UpdateQueryExtended` |
+| `DeleteQuerySystemResolver` | `DeleteQueryExtended` |
+| `TestQuerySQL` | `TestQuerySQL` (unchanged) |
+| `SearchKnowledgeAsSystemUser` | `SearchKnowledge` |
+| `PreviewSearchAsSystemUser` | `PreviewSearch` |
+| `RunAIPromptSystemUser` | `RunAIPrompt` |
+| `ExecuteSimplePromptSystemUser` | `ExecuteSimplePrompt` |
+| `EmbedTextSystemUser` | `EmbedText` |
+| `RunAIAgentSystemUser` | `RunAIAgent` |
+
+### 6.4 Key Flow
+
+The scoped callback key is auto-provisioned on the client MJAPI by SkipSDK. On the first request to a Skip host, SkipSDK includes the raw key in `callingServerAPIKey`. Skip persists it in `BC: Organization Credentials`. On subsequent requests (including after MJ restart), the key is omitted — Skip retrieves it from its credential store by organization ID.
+
+### 6.5 Access Token Removal
 
 With scoped API keys, the short-lived access token (`callingServerAccessToken`) is no longer needed for most operations. `GetData` is the only resolver that uses it, and `TestQuerySQL` replaces it without requiring a token. The access token can be deprecated in the SkipAPIRequest.
 
+### 6.6 Callback Credential Storage (Skip SaaS)
+
+> **Added June 10, 2026.** Resolves the hashed-key restart problem by persisting the raw key on the Skip side.
+
+Skip uses BCSaaS's `BC: Organization Credentials` system to store callback API keys received from client MJAPIs. This leverages the existing credential infrastructure: encryption at rest, org scoping, audit logging.
+
+**New Credential Use:** An "MJAPI Callback" entry is added to `Skip-Brain/metadata/credential-uses/.credential-uses.json`:
+- **Name:** MJAPI Callback
+- **Category:** Callback Server
+- **Credential Type:** API Key
+- **Status:** Active
+
+**Resolution logic** (in `chatController.ts`, runs before workflow execution):
+
+```typescript
+// Called after resolveOrgCredentials() and before WorkflowService.execute()
+async function resolveCallbackCredential(
+    skipRequest: SkipAPIRequest,
+    auth: SkipAuth,
+    contextUser: UserInfo
+): Promise<void> {
+    if (skipRequest.callingServerAPIKey) {
+        // Key provided — this is a first-time provisioning or key rotation.
+        // Store (or replace) in credential store. The MJ client only sends
+        // the key once at creation time, so receiving it means "new key."
+        await storeCallbackCredential(auth.organizationID, skipRequest.callingServerAPIKey, contextUser);
+    } else {
+        // Key absent — normal case (MJ already provisioned, Skip has stored key).
+        const storedKey = await lookupCallbackCredential(auth.organizationID, contextUser);
+        if (storedKey) {
+            skipRequest.callingServerAPIKey = storedKey;
+        } else {
+            // No key available — halt execution
+            throw new CallbackCredentialError(
+                "Your MJAPI server has not provided a callback API key. " +
+                "This usually means the MJAPI needs to be restarted to provision a new scoped key for Skip."
+            );
+        }
+    }
+}
+```
+
+**Lookup pattern** follows the existing `resolveOrgCredentials()` at `chatController.ts:263-330`:
+1. `BCCredentialEngine.Instance.OrganizationCredentials` filtered by org ID + Status='Active'
+2. `engine.GetUsesForOrgCredential(orgCred.ID)` → filter for name === 'MJAPI Callback'
+3. Decrypt via `CredentialEngine.Instance.getCredential()`
+
+**`callingServerURL` is not stored** — it's always present in the request payload and can change if the MJAPI moves domains. Only the API key needs persistence because its raw value is lost after MJ restart.
+
 ## 7. Migration Path
 
-### Phase 1: Infrastructure (no behavior change)
-- Add Skip callback scopes to MJ core's `APIScope` table via migration
-- Update `@RequireSystemUser` directive to accept scoped API keys (Option A)
-- Build and test — existing `x-mj-api-key` flow continues to work for all customers
+### Phase 1: Infrastructure (no behavior change) ✅
+- [x] Add missing scopes to MJ core's `APIScope` metadata: `view:batch`, `query:create`, `query:update`, `query:delete`, `query:test`, `search` + `search:execute`
+- [x] Add `CheckAPIKeyScopeAuthorization()` to the 6 non-system resolvers that are missing scope checks (RunView*, SearchKnowledge, PreviewSearch)
+- [x] Convert 4 SystemUser-only resolvers to regular resolvers with scope checks (CreateQuery → CreateQueryExtended, etc.)
+- [x] Add Skip service account user to MJ metadata (`MJ/metadata/users/`)
+- [x] Build and test — existing `x-mj-api-key` flow continues to work for all customers (SystemUser resolvers remain untouched, new/converted resolvers run in parallel)
+- **Note:** Scopes and service account are deployed via MJ metadata sync, not SQL migration
 
-### Phase 2: Key Provisioning (client MJAPI side)
-- Add Skip callback API key generation to the SkipSDK configuration flow on the client
-- Create a Skip service account user on the client MJAPI with appropriate roles
-- Assign Skip callback scopes to the generated key
-- SkipSDK sends the scoped key in `callingServerAPIKey` instead of `x-mj-api-key`
+### Phase 2: Skip-Side Client ✅
+- [x] Create `SkipCallbackClient` in `Skip-Brain/packages/shared/src/connection/` (see Section 6.1)
+- [x] Implement typed methods for all 14 operations Skip needs
+- [x] Wire `SkipCallbackClient` into `ConnectionManager` (replacing `GraphQLSystemUserClient` construction)
+- [x] Update `RemoteMJUtilities` to use the new client methods
+- [ ] Unit test the new client against regular resolver operation names
 
-### Phase 3: Skip-Side Migration
-- Update `ConnectionManager` to use `X-API-Key` header when the callback key has a `skip_cb_` prefix
-- Fall back to `x-mj-api-key` header when the key has no prefix (backward compatibility with clients not yet upgraded)
-- Deprecate `callingServerAccessToken` in SkipAPIRequest
+### Phase 3: Key Provisioning + Credential Storage
 
-### Phase 4: Deprecation
+> **Revised June 10, 2026.** Original design assumed the raw key could be recovered from the DB after restart. Since API keys are stored as SHA-256 hashes, the raw key is lost after server restart. Solution: SkipSDK sends the key once, Skip persists it encrypted in BCSaaS credential store.
+
+#### 3A. MJ Client — Provisioner (`skip-callback-key-provisioner.ts`) ✅
+- [x] Auto-provision scoped API key via `APIKeyEngine.CreateAPIKey()` on first request
+- [x] Assign all 11 required scopes from Section 4.1
+- [x] Promise-based mutex for concurrent first requests
+- [x] Label convention: `"Skip Callback: {ASK_SKIP_CHAT_URL}"` (supports multiple Skip hosts)
+- [x] Return `string | null` — non-null = key just created (send once), null = key exists (Skip has it)
+- [x] No raw key caching — key is only needed at creation time
+
+#### 3B. MJ Client — SkipSDK Integration (`skip-sdk.ts`) ✅
+- [x] Wire provisioner into `buildBaseRequest()`
+- [x] If provisioner returns raw key → set `callingServerAPIKey` (first request only)
+- [x] If provisioner returns null → omit `callingServerAPIKey` (Skip uses stored credential)
+- [x] Fall back to `legacyCallbackAPIKey` (`MJ_API_KEY`) during transition period if provisioner fails
+- [x] Always send `callingServerURL` when `includeCallbackAuth` is true (independent of key)
+
+#### 3C. Skip SaaS — Credential Use Metadata ✅
+- [x] Added "MJAPI Callback" entry to `Skip-Brain/metadata/credential-uses/.credential-uses.json`
+  - Category: "Callback Server", Type: "API Key", Status: "Active"
+
+#### 3D. Skip SaaS — Callback Credential Resolution (`chatController.ts`) ✅
+- [x] `resolveCallbackCredential()` function (see Section 6.6)
+- [x] Called after `resolveOrgCredentials()`, before `WorkflowService.execute()`
+- [x] Key present → store/update in `BC: Organization Credentials` via `BCCredentialEngine`
+- [x] Key absent → look up from credential store by org ID + "MJAPI Callback" use
+- [x] Neither → halt with authentication error
+- [x] Per-org mutex to prevent duplicate credential creation from concurrent requests
+
+### Phase 4: Deploy
+- Deploy latest MJ to all beta clients (brings in Skip service account + new scopes + converted resolvers + provisioner)
+- Deploy updated Skip API (with credential storage + SkipCallbackClient) simultaneously
+- First request from each client → SkipSDK provisions key, sends to Skip, Skip stores it
+- Subsequent requests (including after MJ restart) → key omitted, Skip uses stored credential
+- Verify scoped key flow works end-to-end on each client
+- Remove `MJ_API_KEY` env var from client environments once verified
+
+### Phase 5: Cleanup
+- Remove `legacyCallbackAPIKey` fallback from `skip-sdk.ts`
+- Remove SystemUser resolver variants that Skip was using (they're now dead code)
 - Remove `x-mj-api-key` support from Skip callback flow
-- Remove `GraphQLSystemUserClient` usage in Skip
+- Remove `GraphQLSystemUserClient` import from Skip-Brain
 - Remove access token creation from SkipSDK
+- Evaluate remaining `@RequireSystemUser` resolvers for future scope migration or removal
 
 ## 8. Security Improvements
 
@@ -255,12 +474,31 @@ With scoped API keys, the short-lived access token (`callingServerAccessToken`) 
 | **Resource restriction** | None | Glob/regex patterns on entities (future) |
 | **User context** | System user (broad permissions) | Skip service account (roles define permission ceiling) |
 
-## 9. Open Questions
+## 9. Decisions
 
-1. **Skip service account user** — should this be a dedicated user per customer, or a convention where every MJ deployment creates a "Skip Service" user with standardized roles? A convention is simpler but less flexible.
+### Resolved June 9, 2026
 
-2. **Key provisioning UX** — should the callback key be auto-generated when a customer configures Skip (e.g., via a "Connect to Skip" wizard in MJ Explorer), or manually provisioned by an admin?
+1. **Skip service account user** — **Dedicated user via MJ metadata.** A standardized "Skip Service" user is defined in MJ's metadata directory and deployed to every client MJAPI via metadata sync. This provides a consistent convention while allowing per-client role customization if needed.
 
-3. **Backward compatibility timeline** — how long do we maintain support for the legacy `x-mj-api-key` path before requiring scoped API keys for Skip callbacks?
+2. **Key provisioning** — **Auto-provisioning via SkipSDK.** On first request, SkipSDK checks for an existing key and creates one if none exists. No manual env var or admin step needed for the callback key. This removes `MJ_API_KEY` from client onboarding — the only env var needed is `ASK_SKIP_API_KEY`. See Section 3.2 for concerns.
 
-4. **Scope granularity** — are the proposed scopes the right level of granularity? For example, should `skip:query:run` and `skip:query:create` be separate, or combined as `skip:query:*`?
+3. **Backward compatibility timeline** — **Transition all beta clients ASAP.** Deploy all environments in tandem — MJ (with new scopes + service account + converted resolvers) and Skip (with updated RemoteMJUtilities + ConnectionManager) simultaneously. No gradual migration needed.
+
+4. **Scope granularity** — **Keep granular.** Each operation gets its own scope (e.g., `query:run` and `query:create` remain separate). The scope hierarchy supports wildcard grants via parent scopes (e.g., granting `query` gives all query sub-scopes).
+
+5. **Scope namespace** — **Use existing MJ scope hierarchy, not `skip:*`.** Since Skip callbacks use the regular resolvers (not SystemUser variants), they use the same scopes as any other API key user. This avoids a parallel scope tree and makes the scopes useful for non-Skip API keys too.
+
+6. **Resolver strategy** — **Use regular (non-system) resolvers, not overloaded `@RequireSystemUser`.** The `@RequireSystemUser` directive remains unchanged. Skip switches to calling regular resolvers. SystemUser resolvers that have no non-system equivalent are converted in-place with "Extended" naming convention to avoid codegen collisions.
+
+7. **GraphQL client** — **Skip builds its own `SkipCallbackClient`** wrapper around the raw `GraphQLClient` from `graphql-request`, replacing `GraphQLSystemUserClient` from `@memberjunction/graphql-dataprovider`. This decouples Skip's client lifecycle from MJ's package releases and eliminates dead-weight methods Skip never calls. `GraphQLSystemUserClient` provides only a thin header wrapper (~5 lines of real logic) plus typed method wrappers that all need rewriting anyway — Skip loses nothing by not using it.
+
+### Resolved June 10, 2026
+
+8. **Hashed key persistence** — **Skip stores the raw key, not the MJ client.** API keys are stored as SHA-256 hashes in MJ's database — the raw key is irrecoverable after server restart. Rather than weakening the hash model (accepting hashes as credentials) or adding encrypted storage to MJ, Skip persists the raw key in BCSaaS's `BC: Organization Credentials` system on first receipt. This leverages existing encryption-at-rest, org scoping, and audit logging. The MJ client labels keys by Skip host URL (`"Skip Callback: {url}"`) to support multiple Skip hosts.
+
+9. **Callback credential URL storage** — **Request-only.** `callingServerURL` is NOT stored in the credential — it's always present in the request payload and can change if the MJAPI moves domains. Only the API key is persisted because its raw value is lost after MJ restart.
+
+## 10. Future Enhancements
+
+- **Skip admin dashboard** — A dedicated page in MJ Explorer (or a Skip-specific admin portal) where admin users can view and manage the auto-provisioned Skip callback key. Features would include: key rotation, scope management (add/remove individual scopes), revocation, audit log viewing, and key health/usage statistics. This addresses the visibility concern with auto-provisioning (see Section 3.2, concern #3).
+- **SystemUser resolver deprecation** — Once all consumers of SystemUser resolvers are migrated to scoped API keys, evaluate removing the `@RequireSystemUser` directive and all SystemUser resolver variants entirely.


### PR DESCRIPTION
## Summary

Replaces the unrestricted `x-mj-api-key` system user authentication for Skip callbacks with scoped API keys validated through MJ's `APIKeyEngine`. Skip callbacks now use regular (non-system) resolvers with per-operation scope checks and audit logging.

- **10 resolvers** now have `CheckAPIKeyScopeAuthorization()` scope checks (RunView*, SearchKnowledge, PreviewSearch, CreateQueryExtended, UpdateQueryExtended, DeleteQueryExtended, TestQuerySQL)
- **4 SystemUser resolvers** converted to regular resolvers with scope checks (CreateQuery→CreateQueryExtended, UpdateQuery→UpdateQueryExtended, DeleteQuery→DeleteQueryExtended, TestQuerySQL)
- **Auto-provisioner** creates a scoped API key on first request to Skip, assigns 11 scopes, sends the raw key once (Skip persists it in encrypted credential store)
- **Skip Service Account** user deployed via metadata with UI + Skip Service roles
- **Skip Service role** with CRUD on 8 query-related entities
- **6 new MJAPI application scope ceilings** added (query:create/update/delete/test, view:batch, search:execute)
- **ResolverBase fix**: `CheckAPIKeyScopeAuthorization` now uses `UserCache.Instance.GetSystemUser()` instead of `Type='System'` filter

### Metadata changes
- `api-scopes/`: 7 new scopes (view:batch, query:create/update/delete/test, search + search:execute)
- `api-application-scopes/`: 6 new MJAPI application scope ceilings
- `roles/`: New "Skip Service" role
- `entity-permissions/`: 8 new CRUD permissions for Skip Service role on query entities
- `users/`: Skip Service Account with UI + Skip Service role assignments

## Test plan
- [x] MJServer builds clean
- [x] Scoped key auto-provisioned on first request, sent to Skip once
- [x] Subsequent requests omit key (Skip uses stored credential)
- [x] RunDynamicView, RunViews, CreateQueryExtended, TestQuerySQL all work through scoped key path
- [ ] Deploy to staging and verify end-to-end with beta clients

🤖 Generated with [Claude Code](https://claude.com/claude-code)