### PR TITLE
Fix CodeGen SP generation, sync push exit code, and AI prompt observability

### DIFF
--- a/.changeset/bright-foxes-jump.md
+++ b/.changeset/bright-foxes-jump.md
@@ -1,0 +1,7 @@
+---
+"@memberjunction/codegen-lib": patch
+"@memberjunction/cli": patch
+"@memberjunction/server": patch
+---
+
+Fix CodeGen SP generation for PK-only entities, fix mj sync push exit code on failure, and use GetSystemUser for API Key scope checks

--- a/packages/AI/CorePlus/src/MJAIPromptRunEntityExtended.ts
+++ b/packages/AI/CorePlus/src/MJAIPromptRunEntityExtended.ts
@@ -4,11 +4,34 @@ import { MJAIPromptRunEntity } from '@memberjunction/core-entities';
 import { ChatMessage } from '@memberjunction/ai';
 
 /**
- * Extended MJAIPromptRunEntity class with helper methods for extracting 
+ * Tracks how a malformed JSON response was repaired during prompt execution.
+ * Stored transiently on the prompt run entity and persisted into ValidationSummary JSON.
+ */
+export interface JSONRepairInfo {
+    /** Whether the JSON was repaired */
+    repaired: true;
+    /** Which repair strategy succeeded */
+    method: 'JSON5' | 'AIRepair';
+    /** The original JSON parse error message */
+    originalError: string;
+    /** First 200 characters of the raw LLM output (for diagnostics) */
+    rawOutputPrefix: string;
+    /** The prompt run ID of the repair prompt execution (AI repair only) */
+    repairPromptRunId?: string;
+}
+
+/**
+ * Extended MJAIPromptRunEntity class with helper methods for extracting
  * conversation messages and data from the stored JSON.
  */
 @RegisterClass(BaseEntity, 'MJ: AI Prompt Runs')
 export class MJAIPromptRunEntityExtended extends MJAIPromptRunEntity {
+    /**
+     * Transient property to carry JSON repair info from attemptJSONRepair
+     * to the ValidationSummary persistence step. Not saved to the database directly —
+     * it is serialized into the ValidationSummary JSON field.
+     */
+    public _jsonRepairInfo: JSONRepairInfo | null = null;
     
     /**
      * Parses and extracts all message data from the Messages field.

--- a/packages/AI/Prompts/src/AIPromptRunner.ts
+++ b/packages/AI/Prompts/src/AIPromptRunner.ts
@@ -4873,27 +4873,27 @@ export class AIPromptRunner {
         jsonToParse = CleanJSON(rawOutput);
       }
       catch (cleanError) {
-        if (params.verbose) {
-          this.logError(cleanError, {
-            category: 'JSONCleaningFailed',
-            metadata: {
-              originalError: originalError.message,
-              rawOutput: rawOutput.substring(0, 500)
-            },
-            maxErrorLength: params.maxErrorLength
-          });
-        }
+        this.logError(cleanError, {
+          category: 'JSONCleaningFailed',
+          metadata: {
+            originalError: originalError.message,
+            rawOutput: rawOutput.substring(0, 500)
+          },
+          maxErrorLength: params.maxErrorLength
+        });
       }
       const json5Result = JSON5.parse(jsonToParse);
-      if (params.verbose) {
-        this.logStatus('   ✅ JSON5 successfully parsed the malformed JSON', true, params);
-      }
+      this.logStatus('   ✅ JSON5 successfully parsed the malformed JSON', true, params);
+      currentPromptRun._jsonRepairInfo = {
+        repaired: true,
+        method: 'JSON5',
+        originalError: originalError.message,
+        rawOutputPrefix: rawOutput.substring(0, 200)
+      };
       return json5Result;
     } catch (json5Error) {
       // Step 2: Use AI to repair the JSON
-      if (params.verbose) {
-        this.logStatus('   🤖 JSON5 failed, attempting AI-based JSON repair...', true, params);
-      }
+      this.logStatus('   🤖 JSON5 failed, attempting AI-based JSON repair...', true, params);
       
       try {
         // Find the "Repair JSON" prompt in the "MJ: System" category
@@ -4927,21 +4927,26 @@ export class AIPromptRunner {
 
         // if we get here, we successfully repaired the JSON!!!
         this.logStatus('   ✅ AI successfully repaired the JSON', true, params);
+        currentPromptRun._jsonRepairInfo = {
+          repaired: true,
+          method: 'AIRepair',
+          originalError: originalError.message,
+          rawOutputPrefix: rawOutput.substring(0, 200),
+          repairPromptRunId: repairResult.promptRun?.ID
+        };
         return repairedJSON;
       } catch (aiRepairError) {
-        // Both repair attempts failed
-        if (params.verbose) {
-          this.logError(aiRepairError, {
-            category: 'JSONRepairFailed',
-            metadata: {
-              originalError: originalError.message,
-              json5Error: json5Error.message,
-              aiError: aiRepairError.message,
-              rawOutput: rawOutput.substring(0, 500)
-            },
-            maxErrorLength: params.maxErrorLength
-          });
-        }        
+        // Both repair attempts failed — always log, this is unexpected LLM behavior
+        this.logError(aiRepairError, {
+          category: 'JSONRepairFailed',
+          metadata: {
+            originalError: originalError.message,
+            json5Error: json5Error.message,
+            aiError: aiRepairError.message,
+            rawOutput: rawOutput.substring(0, 500)
+          },
+          maxErrorLength: params.maxErrorLength
+        });
         
         throw new Error(`JSON repair failed after both JSON5 and AI attempts: ${originalError.message}`);
       }
@@ -5229,7 +5234,8 @@ export class AIPromptRunner {
             parsedResult.validationResult?.Success || false,
             validationAttempts.length,
             promptRun.ValidationBehavior || 'Warn'
-          )
+          ),
+          jsonRepairInfo: promptRun._jsonRepairInfo || null
         });
       } else {
         // No validation attempts (possibly skipped validation)
@@ -5238,6 +5244,13 @@ export class AIPromptRunner {
         promptRun.FinalValidationPassed = parsedResult.validationResult?.Success !== false;
         promptRun.LastAttemptAt = endTime;
         promptRun.TotalRetryDurationMS = 0;
+
+        // Even without validation, persist JSON repair info if a repair occurred
+        if (promptRun._jsonRepairInfo) {
+          promptRun.ValidationSummary = JSON.stringify({
+            jsonRepairInfo: promptRun._jsonRepairInfo
+          });
+        }
       }
 
       // Set Success flag based on validation result

--- a/packages/CodeGenLib/src/Database/codeGenDatabaseProvider.ts
+++ b/packages/CodeGenLib/src/Database/codeGenDatabaseProvider.ts
@@ -1,5 +1,6 @@
 import { EntityInfo, EntityFieldInfo, EntityPermissionInfo } from '@memberjunction/core';
 import { DatabasePlatform, SQLDialect } from '@memberjunction/sql-dialect';
+import { logWarning } from '../Misc/status_logging';
 
 // ─── CONNECTION ABSTRACTION ──────────────────────────────────────────────────
 
@@ -643,6 +644,11 @@ export abstract class CodeGenDatabaseProvider {
                 parts.push(paramRef);
             }
         }
+
+        if (parts.length === 0 && !excludePrimaryKey) {
+            logWarning(`[CodeGen] generateInsertFieldString produced an empty column list for entity "${entity.Name}" (${entity.SchemaName}.${entity.BaseTable}). This typically means all columns are PKs with no additional data columns.`);
+        }
+
         return parts.join(',\n                ');
     }
 

--- a/packages/CodeGenLib/src/Database/codeGenDatabaseProvider.ts
+++ b/packages/CodeGenLib/src/Database/codeGenDatabaseProvider.ts
@@ -1,6 +1,5 @@
 import { EntityInfo, EntityFieldInfo, EntityPermissionInfo } from '@memberjunction/core';
 import { DatabasePlatform, SQLDialect } from '@memberjunction/sql-dialect';
-import { logWarning } from '../Misc/status_logging';
 
 // ─── CONNECTION ABSTRACTION ──────────────────────────────────────────────────
 
@@ -646,7 +645,7 @@ export abstract class CodeGenDatabaseProvider {
         }
 
         if (parts.length === 0 && !excludePrimaryKey) {
-            logWarning(`[CodeGen] generateInsertFieldString produced an empty column list for entity "${entity.Name}" (${entity.SchemaName}.${entity.BaseTable}). This typically means all columns are PKs with no additional data columns.`);
+            console.warn(`[CodeGen] generateInsertFieldString produced an empty column list for entity "${entity.Name}" (${entity.SchemaName}.${entity.BaseTable}). This typically means all columns are PKs with no additional data columns.`);
         }
 
         return parts.join(',\n                ');

--- a/packages/CodeGenLib/src/Database/providers/postgresql/PostgreSQLCodeGenProvider.ts
+++ b/packages/CodeGenLib/src/Database/providers/postgresql/PostgreSQLCodeGenProvider.ts
@@ -714,18 +714,13 @@ ${permissions}
 
         const trigger = this.generateTimestampTrigger(entity);
 
-        return `
-------------------------------------------------------------
------ UPDATE FUNCTION FOR ${entity.BaseTable}
-------------------------------------------------------------
-${this.generateDropAllOverloadsBlock(entity.SchemaName, fnName)}
-CREATE OR REPLACE FUNCTION ${pgDialect.QuoteSchema(entity.SchemaName, fnName)}(
-    ${paramString}
-) RETURNS SETOF ${pgDialect.QuoteSchema(entity.SchemaName, viewName)} AS $$
-DECLARE
-    v_updated_count INTEGER;
-BEGIN
-    UPDATE ${pgDialect.QuoteSchema(entity.SchemaName, entity.BaseTable)}
+        // PK-only entities (e.g. junction tables with only PK + __mj timestamp columns)
+        // have no updatable fields. Generate a no-op function that just returns the
+        // existing row rather than emitting an invalid UPDATE with an empty SET clause.
+        const hasUpdatableFields = updateFields.trim().length > 0;
+
+        const fnBody = hasUpdatableFields
+            ? `    UPDATE ${pgDialect.QuoteSchema(entity.SchemaName, entity.BaseTable)}
     SET
         ${updateFields}
     WHERE
@@ -741,7 +736,26 @@ BEGIN
     -- Return the updated record from the base view
     RETURN QUERY
     SELECT * FROM ${pgDialect.QuoteSchema(entity.SchemaName, viewName)}
-    WHERE ${selectWhereClause};
+    WHERE ${selectWhereClause};`
+            : `    -- No updatable fields (PK-only entity, e.g. junction table). Return the existing row.
+    RETURN QUERY
+    SELECT * FROM ${pgDialect.QuoteSchema(entity.SchemaName, viewName)}
+    WHERE ${selectWhereClause};`;
+
+        // Only declare v_updated_count when we actually perform an UPDATE.
+        const declareBlock = hasUpdatableFields ? '\n    v_updated_count INTEGER;' : '';
+
+        return `
+------------------------------------------------------------
+----- UPDATE FUNCTION FOR ${entity.BaseTable}
+------------------------------------------------------------
+${this.generateDropAllOverloadsBlock(entity.SchemaName, fnName)}
+CREATE OR REPLACE FUNCTION ${pgDialect.QuoteSchema(entity.SchemaName, fnName)}(
+    ${paramString}
+) RETURNS SETOF ${pgDialect.QuoteSchema(entity.SchemaName, viewName)} AS $$
+DECLARE${declareBlock}
+BEGIN
+${fnBody}
 END;
 $$ LANGUAGE plpgsql;
 ${permissions}
@@ -2087,13 +2101,15 @@ WHERE p.prokind IN ('f', 'p')
 
         if ((firstKey.Type.toLowerCase().trim() === 'uniqueidentifier' || firstKey.Type.toLowerCase().trim() === 'uuid') && entity.PrimaryKeys.length === 1) {
             const paramName = `p_${this.toSnakeCase(firstKey.CodeName)}`;
+            const hasNonPkFields = insertColumns.trim().length > 0;
             return {
                 preInsert: `v_new_id := COALESCE(${paramName}, gen_random_uuid());\n    `,
                 returningClause: '',
                 selectClause: `SELECT * FROM ${pgDialect.QuoteSchema(entity.SchemaName, viewName)}\n    WHERE ${pkCol} = v_new_id`,
-                // Include the PK column in the INSERT so caller-provided IDs are respected
-                finalColumns: `${pkCol},\n            ${insertColumns}`,
-                finalValues: `v_new_id,\n            ${insertValues}`,
+                // Include the PK column in the INSERT so caller-provided IDs are respected.
+                // When there are no non-PK columns, omit the trailing comma.
+                finalColumns: hasNonPkFields ? `${pkCol},\n            ${insertColumns}` : pkCol,
+                finalValues: hasNonPkFields ? `v_new_id,\n            ${insertValues}` : 'v_new_id',
             };
         }
 
@@ -2105,6 +2121,8 @@ WHERE p.prokind IN ('f', 'p')
         // Composite-PK tables: every PK column has AllowUpdateAPI=0, so generateInsertFieldString
         // filters them all out. Prepend them to finalColumns/finalValues so the INSERT is valid.
         // (The single-PK uniqueidentifier case is already handled above via v_new_id.)
+        // When insertColumns is empty (PK-only entities like junction tables), we must not
+        // emit a trailing comma after the PK columns.
         let finalColumns = insertColumns;
         let finalValues = insertValues;
         if (entity.PrimaryKeys.length > 1) {
@@ -2114,8 +2132,9 @@ WHERE p.prokind IN ('f', 'p')
             const pkValues = entity.PrimaryKeys
                 .map((k: EntityFieldInfo) => `p_${this.toSnakeCase(k.CodeName)}`)
                 .join(',\n            ');
-            finalColumns = `${pkColumns},\n            ${insertColumns}`;
-            finalValues = `${pkValues},\n            ${insertValues}`;
+            const hasNonPkColumns = insertColumns.trim().length > 0;
+            finalColumns = hasNonPkColumns ? `${pkColumns},\n            ${insertColumns}` : pkColumns;
+            finalValues = hasNonPkColumns ? `${pkValues},\n            ${insertValues}` : pkValues;
         }
 
         return {

--- a/packages/CodeGenLib/src/Database/providers/sqlserver/SQLServerCodeGenProvider.ts
+++ b/packages/CodeGenLib/src/Database/providers/sqlserver/SQLServerCodeGenProvider.ts
@@ -134,21 +134,28 @@ ${whereClause}GO`;
             const hasDefaultValue = firstKey.DefaultValue && firstKey.DefaultValue.trim().length > 0;
 
             if (hasDefaultValue) {
+                // UUID with DB default (e.g. NEWSEQUENTIALID()): two-branch INSERT —
+                // one with caller-supplied PK, one letting the DB fill it in.
+                // When there are no non-PK writable columns, omit the comma after the PK.
+                const nonPkCols = this.generateInsertFieldString(entity, entity.Fields, '', true);
+                const nonPkVals = this.generateInsertFieldString(entity, entity.Fields, '@', true);
+                const hasNonPkFields = nonPkCols.trim().length > 0;
+                const colSeparator = hasNonPkFields ? ',\n                ' : '';
+                const valSeparator = hasNonPkFields ? ',\n                ' : '';
+
                 preInsertCode = `DECLARE @InsertedRow TABLE ([${firstKey.Name}] UNIQUEIDENTIFIER)
-    
+
     IF @${firstKey.Name} IS NOT NULL
     BEGIN
         -- User provided a value, use it
         INSERT INTO [${entity.SchemaName}].[${entity.BaseTable}]
             (
-                [${firstKey.Name}],
-                ${this.generateInsertFieldString(entity, entity.Fields, '', true)}
+                [${firstKey.Name}]${colSeparator}${nonPkCols}
             )
         OUTPUT INSERTED.[${firstKey.Name}] INTO @InsertedRow
         VALUES
             (
-                @${firstKey.Name},
-                ${this.generateInsertFieldString(entity, entity.Fields, '@', true)}
+                @${firstKey.Name}${valSeparator}${nonPkVals}
             )
     END
     ELSE
@@ -156,12 +163,12 @@ ${whereClause}GO`;
         -- No value provided, let database use its default (e.g., NEWSEQUENTIALID())
         INSERT INTO [${entity.SchemaName}].[${entity.BaseTable}]
             (
-                ${this.generateInsertFieldString(entity, entity.Fields, '', true)}
+                ${hasNonPkFields ? nonPkCols : `[${firstKey.Name}]`}
             )
         OUTPUT INSERTED.[${firstKey.Name}] INTO @InsertedRow
         VALUES
             (
-                ${this.generateInsertFieldString(entity, entity.Fields, '@', true)}
+                ${hasNonPkFields ? nonPkVals : `DEFAULT`}
             )
     END`;
 
@@ -170,9 +177,12 @@ ${whereClause}GO`;
                 outputCode = '';
                 selectInsertedRecord = `SELECT * FROM [${entity.SchemaName}].[${entity.BaseView}] WHERE [${firstKey.Name}] = (SELECT [${firstKey.Name}] FROM @InsertedRow)`;
             } else {
+                // UUID without DB default: generate via ISNULL(@PK, NEWID()).
+                // PK is added via additionalFieldList; no leading comma — the
+                // insertBlock logic below handles the separator.
                 preInsertCode = `DECLARE @ActualID UNIQUEIDENTIFIER = ISNULL(@${firstKey.Name}, NEWID())`;
-                additionalFieldList = ',\n                [' + firstKey.Name + ']';
-                additionalValueList = ',\n                @ActualID';
+                additionalFieldList = '[' + firstKey.Name + ']';
+                additionalValueList = '@ActualID';
                 outputCode = '';
                 selectInsertedRecord = `SELECT * FROM [${entity.SchemaName}].[${entity.BaseView}] WHERE [${firstKey.Name}] = @ActualID`;
             }
@@ -184,10 +194,14 @@ ${whereClause}GO`;
             // INSERT would list the PK columns twice and SQL Server raises "The column name 'X'
             // is specified more than once". This pairs with the excludePrimaryKey=true argument
             // at the call sites at the bottom of this method.
+            const pkColumns: string[] = [];
+            const pkValues: string[] = [];
             for (const k of entity.PrimaryKeys) {
-                additionalFieldList += ',\n                [' + k.Name + ']';
-                additionalValueList += ',\n                @' + k.CodeName;
+                pkColumns.push('[' + k.Name + ']');
+                pkValues.push('@' + k.CodeName);
             }
+            additionalFieldList = pkColumns.join(',\n                ');
+            additionalValueList = pkValues.join(',\n                ');
             selectInsertedRecord = `SELECT * FROM [${entity.SchemaName}].[${entity.BaseView}] WHERE `;
             let isFirst = true;
             for (const k of entity.PrimaryKeys) {
@@ -195,6 +209,42 @@ ${whereClause}GO`;
                 selectInsertedRecord += `[${k.Name}] = @${k.CodeName}`;
                 isFirst = false;
             }
+        }
+
+        // Build the INSERT column and value lists. For the non-hasDefaultValue branches,
+        // additionalFieldList holds PK columns (without leading commas) and
+        // generateInsertFieldString (with excludePrimaryKey=true) holds non-PK columns.
+        // When the non-PK list is empty (PK-only entities), we must not emit a stray comma.
+        let insertBlock = '';
+        if (!preInsertCode.includes('INSERT INTO')) {
+            const nonPkColumns = this.generateInsertFieldString(entity, entity.Fields, '', true);
+            const nonPkValues = this.generateInsertFieldString(entity, entity.Fields, '@', true);
+            const hasNonPkFields = nonPkColumns.trim().length > 0;
+            const hasAdditionalFields = additionalFieldList.trim().length > 0;
+
+            let columnList: string;
+            let valueList: string;
+            if (hasNonPkFields && hasAdditionalFields) {
+                columnList = `${nonPkColumns},\n                ${additionalFieldList}`;
+                valueList = `${nonPkValues},\n                ${additionalValueList}`;
+            } else if (hasAdditionalFields) {
+                columnList = additionalFieldList;
+                valueList = additionalValueList;
+            } else {
+                columnList = nonPkColumns;
+                valueList = nonPkValues;
+            }
+
+            insertBlock = `
+    INSERT INTO
+    [${entity.SchemaName}].[${entity.BaseTable}]
+        (
+            ${columnList}
+        )
+    ${outputCode}VALUES
+        (
+            ${valueList}
+        )`;
         }
 
         return `
@@ -210,16 +260,7 @@ CREATE PROCEDURE [${entity.SchemaName}].[${spName}]
 AS
 BEGIN
     SET NOCOUNT ON;
-    ${preInsertCode}${preInsertCode.includes('INSERT INTO') ? '' : `
-    INSERT INTO
-    [${entity.SchemaName}].[${entity.BaseTable}]
-        (
-            ${this.generateInsertFieldString(entity, entity.Fields, '', true)}${additionalFieldList}
-        )
-    ${outputCode}VALUES
-        (
-            ${this.generateInsertFieldString(entity, entity.Fields, '@', true)}${additionalValueList}
-        )`}
+    ${preInsertCode}${insertBlock}
     -- return the new record from the base view, which might have some calculated fields
     ${selectInsertedRecord}
 END
@@ -241,6 +282,7 @@ GO${permissions}
         const permissions = this.generateCRUDPermissions(entity, spName, 'Update');
         const hasUpdatedAtField = entity.Fields.find(f => f.Name.toLowerCase().trim() === EntityInfo.UpdatedAtFieldName.trim().toLowerCase()) !== undefined;
         const updatedAtTrigger = hasUpdatedAtField ? this.generateTimestampTrigger(entity) : '';
+        const updateFields = this.generateUpdateFieldString(entity.Fields);
         const selectUpdatedRecord = `SELECT
                                         *
                                     FROM
@@ -248,6 +290,29 @@ GO${permissions}
                                     WHERE
                                         ${entity.PrimaryKeys.map(k => `[${k.Name}] = @${k.CodeName}`).join(' AND ')}
                                     `;
+
+        // PK-only entities (e.g. junction tables with only PK + __mj timestamp columns)
+        // have no updatable fields. Generate a no-op SP that just returns the existing row
+        // rather than emitting an invalid UPDATE with an empty SET clause.
+        const hasUpdatableFields = updateFields.trim().length > 0;
+
+        const spBody = hasUpdatableFields
+            ? `    UPDATE
+        [${entity.SchemaName}].[${entity.BaseTable}]
+    SET
+        ${updateFields}
+    WHERE
+        ${entity.PrimaryKeys.map(k => `[${k.Name}] = @${k.CodeName}`).join(' AND ')}
+
+    -- Check if the update was successful
+    IF @@ROWCOUNT = 0
+        -- Nothing was updated, return no rows, but column structure from base view intact, semantically correct this way.
+        SELECT TOP 0 * FROM [${entity.SchemaName}].[${entity.BaseView}] WHERE 1=0
+    ELSE
+        -- Return the updated record so the caller can see the updated values and any calculated fields
+        ${selectUpdatedRecord}`
+            : `    -- No updatable fields (PK-only entity, e.g. junction table). Return the existing row.
+    ${selectUpdatedRecord}`;
 
         return `
 ------------------------------------------------------------
@@ -262,20 +327,7 @@ CREATE PROCEDURE [${entity.SchemaName}].[${spName}]
 AS
 BEGIN
     SET NOCOUNT ON;
-    UPDATE
-        [${entity.SchemaName}].[${entity.BaseTable}]
-    SET
-        ${this.generateUpdateFieldString(entity.Fields)}
-    WHERE
-        ${entity.PrimaryKeys.map(k => `[${k.Name}] = @${k.CodeName}`).join(' AND ')}
-
-    -- Check if the update was successful
-    IF @@ROWCOUNT = 0
-        -- Nothing was updated, return no rows, but column structure from base view intact, semantically correct this way.
-        SELECT TOP 0 * FROM [${entity.SchemaName}].[${entity.BaseView}] WHERE 1=0
-    ELSE
-        -- Return the updated record so the caller can see the updated values and any calculated fields
-        ${selectUpdatedRecord}
+${spBody}
 END
 GO
 ${permissions}

--- a/packages/CodeGenLib/src/Database/providers/sqlserver/__tests__/SQLServerCodeGenProvider.test.ts
+++ b/packages/CodeGenLib/src/Database/providers/sqlserver/__tests__/SQLServerCodeGenProvider.test.ts
@@ -420,6 +420,145 @@ describe('SQLServerCodeGenProvider — tolerant SP signatures', () => {
         });
     });
 
+    describe('PK-only entities (no non-PK data columns) — issue #2448', () => {
+        // Entities like junction tables where ALL non-__mj columns are PKs.
+        // These produced invalid SQL: leading/trailing commas in INSERT and
+        // empty SET clauses in UPDATE.
+
+        function createPkOnlyJunctionEntity(): EntityInfo {
+            return createMockEntity(
+                { Name: 'RoundJudges', BaseTable: 'RoundJudge', BaseTableCodeName: 'RoundJudge' },
+                [
+                    { ID: 'pk1', Name: 'RoundID', Type: 'uniqueidentifier', Length: 16, IsPrimaryKey: true, AllowsNull: false, AllowUpdateAPI: false, IsVirtual: false, AutoIncrement: false, DefaultValue: '' },
+                    { ID: 'pk2', Name: 'JudgeUserID', Type: 'uniqueidentifier', Length: 16, IsPrimaryKey: true, AllowsNull: false, AllowUpdateAPI: false, IsVirtual: false, AutoIncrement: false, DefaultValue: '' },
+                ],
+            );
+        }
+
+        describe('generateCRUDCreate — composite PK with no data columns', () => {
+            it('produces valid INSERT with only PK columns, no leading/trailing commas', () => {
+                const entity = createPkOnlyJunctionEntity();
+                const sql = provider.generateCRUDCreate(entity);
+
+                // Must not have a leading or trailing comma in the column list
+                const columnMatch = sql.match(/INSERT INTO[^(]*\(([^)]*)\)/);
+                expect(columnMatch, 'Expected INSERT INTO ... (...) block').toBeTruthy();
+                const columnList = columnMatch![1].trim();
+                expect(columnList).not.toMatch(/^,/); // no leading comma
+                expect(columnList).not.toMatch(/,\s*$/); // no trailing comma
+
+                // Both PK columns must appear
+                expect(columnList).toContain('[RoundID]');
+                expect(columnList).toContain('[JudgeUserID]');
+            });
+
+            it('VALUES clause has matching PK parameters, no leading/trailing commas', () => {
+                const entity = createPkOnlyJunctionEntity();
+                const sql = provider.generateCRUDCreate(entity);
+
+                const valuesMatch = sql.match(/VALUES\s*\(([^)]*)\)/);
+                expect(valuesMatch, 'Expected VALUES (...) block').toBeTruthy();
+                const valueList = valuesMatch![1].trim();
+                expect(valueList).not.toMatch(/^,/);
+                expect(valueList).not.toMatch(/,\s*$/);
+                expect(valueList).toContain('@RoundID');
+                expect(valueList).toContain('@JudgeUserID');
+            });
+        });
+
+        describe('generateCRUDUpdate — composite PK with no data columns', () => {
+            it('produces valid SP with no UPDATE/SET (no-op), just returns existing row', () => {
+                const entity = createPkOnlyJunctionEntity();
+                const sql = provider.generateCRUDUpdate(entity);
+
+                // Must not contain an UPDATE ... SET with empty body
+                expect(sql).not.toMatch(/SET\s*\n\s*WHERE/);
+
+                // Should contain a comment about no updatable fields
+                expect(sql).toContain('No updatable fields');
+
+                // Must still return a SELECT from the base view
+                expect(sql).toContain('SELECT');
+                expect(sql).toContain(entity.BaseView);
+            });
+        });
+
+        describe('generateCRUDCreate — single UUID PK without default, no data columns', () => {
+            it('produces valid INSERT with PK only, no stray commas', () => {
+                // Matches the lineup.Person / lineup.Position / lineup.Seat / lineup.Team shape:
+                // single UUID PK, no DefaultValue, no non-PK writable columns.
+                const entity = createMockEntity(
+                    { Name: 'Person', BaseTable: 'Person', BaseTableCodeName: 'Person' },
+                    [
+                        { ID: 'pk1', Name: 'ID', Type: 'uniqueidentifier', Length: 16, IsPrimaryKey: true, AllowsNull: false, AllowUpdateAPI: false, IsVirtual: false, AutoIncrement: false, DefaultValue: '' },
+                    ],
+                );
+                const sql = provider.generateCRUDCreate(entity);
+
+                // Should use the @ActualID coalesce path
+                expect(sql).toContain('DECLARE @ActualID UNIQUEIDENTIFIER');
+
+                // Every INSERT INTO ... (...) block must be comma-clean
+                const allInserts = [...sql.matchAll(/INSERT INTO[^(]*\(([^)]*)\)/gi)];
+                for (const m of allInserts) {
+                    const cols = m[1].trim();
+                    expect(cols).not.toMatch(/^,/);
+                    expect(cols).not.toMatch(/,\s*$/);
+                    expect(cols.length).toBeGreaterThan(0);
+                }
+            });
+        });
+
+        describe('generateCRUDCreate — single UUID PK with default, no data columns', () => {
+            it('produces valid INSERT with PK only, no trailing comma after PK', () => {
+                const entity = createMockEntity(
+                    { Name: 'Widget', BaseTable: 'Widget', BaseTableCodeName: 'Widget' },
+                    [
+                        { ID: 'pk1', Name: 'ID', Type: 'uniqueidentifier', Length: 16, IsPrimaryKey: true, AllowsNull: false, AllowUpdateAPI: false, IsVirtual: false, AutoIncrement: false, DefaultValue: 'newsequentialid()' },
+                    ],
+                );
+                const sql = provider.generateCRUDCreate(entity);
+
+                // Should use the @InsertedRow two-branch path
+                expect(sql).toContain('DECLARE @InsertedRow TABLE');
+
+                // Every INSERT INTO ... (...) block must be comma-clean
+                const allInserts = [...sql.matchAll(/INSERT INTO[^(]*\(([^)]*)\)/gi)];
+                expect(allInserts.length).toBeGreaterThan(0);
+                for (const m of allInserts) {
+                    const cols = m[1].trim();
+                    expect(cols).not.toMatch(/^,/);
+                    expect(cols).not.toMatch(/,\s*$/);
+                    expect(cols.length).toBeGreaterThan(0);
+                }
+
+                // Every VALUES (...) block must be comma-clean
+                const allValues = [...sql.matchAll(/VALUES\s*\(([^)]*)\)/gi)];
+                for (const m of allValues) {
+                    const vals = m[1].trim();
+                    expect(vals).not.toMatch(/^,/);
+                    expect(vals).not.toMatch(/,\s*$/);
+                    expect(vals.length).toBeGreaterThan(0);
+                }
+            });
+        });
+
+        describe('generateInsertFieldString — PK-only entity returns empty when excludePrimaryKey=true', () => {
+            it('returns empty string for PK-only entity with excludePrimaryKey=true', () => {
+                const entity = createPkOnlyJunctionEntity();
+                const result = provider.generateInsertFieldString(entity, entity.Fields, '', true);
+                expect(result.trim()).toBe('');
+            });
+
+            it('returns PK columns for PK-only entity with excludePrimaryKey=false', () => {
+                const entity = createPkOnlyJunctionEntity();
+                const result = provider.generateInsertFieldString(entity, entity.Fields, '', false);
+                expect(result).toContain('[RoundID]');
+                expect(result).toContain('[JudgeUserID]');
+            });
+        });
+    });
+
     describe('generateSingleCascadeOperation — _Clear flag for nullable FK', () => {
         it('cascade update emits _Clear = 1 for the nullable FK field being NULLed', () => {
             // Parent entity (Conversation) being deleted

--- a/packages/CodeGenLib/src/Misc/entity_subclasses_codegen.ts
+++ b/packages/CodeGenLib/src/Misc/entity_subclasses_codegen.ts
@@ -649,7 +649,12 @@ ${validationFunctions}`
           const quotes = e.NeedsQuotes ? "'" : '';
           // Sort deterministically by Sequence, CreatedAt, then Value to prevent flip-flopping across runs
           const sortedValues = sortBySequenceAndCreatedAt([...e.EntityFieldValues]);
-          typeString = `union([${sortedValues.map((v) => `z.literal(${quotes}${v.Value}${quotes})`).join(', ')}])`;
+          // z.union() requires at least 2 members. When there's only one allowed
+          // value (single-value CHECK constraint), emit z.literal() directly.
+          const literals = sortedValues.map((v) => `z.literal(${quotes}${v.Value}${quotes})`);
+          typeString = literals.length === 1
+            ? literals[0].substring(2) // strip leading 'z.' since caller prepends it
+            : `union([${literals.join(', ')}])`;
           if (e.ValueListTypeEnum === EntityFieldValueListType.ListOrUserEntry) {
             // special case becuase a user can enter whatever they want
             typeString += `.or(z.${TypeScriptTypeFromSQLType(e.Type)}()) `;

--- a/packages/MJCLI/src/commands/sync/push.ts
+++ b/packages/MJCLI/src/commands/sync/push.ts
@@ -54,6 +54,7 @@ export default class Push extends Command {
     const { flags } = await this.parse(Push);
     const spinner = ora();
     const startTime = Date.now();
+    let exitCode = 0;
 
     try {
       // Load configurations
@@ -263,8 +264,8 @@ export default class Push extends Command {
       const errorMessage = error instanceof Error ? error.message : String(error);
       this.log(chalk.red(`\n❌ Error: ${errorMessage}\n`));
 
-      // Exit with error code but don't show stack trace again (already logged by handlers)
-      this.exit(1);
+      // Set error exit code — actual process.exit() happens in the finally block
+      exitCode = 1;
     } finally {
       // Reset singletons + close DB pool so the process can exit cleanly.
       // Without cleanupProvider, the pg.Pool / mssql.ConnectionPool keep the
@@ -281,9 +282,8 @@ export default class Push extends Command {
       // event loop open (e.g. @huggingface/transformers ONNX worker threads
       // spawned for embedding compute, or pg.Pool clients that didn't release
       // cleanly). Without this the CLI hangs indefinitely after a successful
-      // push when local embedding generation ran. Use exit code 0 here because
-      // any error path above has already called this.exit(1).
-      process.exit(0);
+      // push when local embedding generation ran.
+      process.exit(exitCode);
     }
   }
 }

--- a/packages/MJServer/src/generic/ResolverBase.ts
+++ b/packages/MJServer/src/generic/ResolverBase.ts
@@ -638,7 +638,7 @@ export class ResolverBase {
     // user has. The API key's associated user (in userPayload.userRecord) is
     // used later when the actual operation executes - their permissions are
     // the ultimate ceiling that scopes can only narrow, never expand.
-    const systemUser = UserCache.Instance.Users.find(u => u.Type === 'System');
+    const systemUser = UserCache.Instance.GetSystemUser();
     if (!systemUser) {
       throw new Error('System user not found');
     }


### PR DESCRIPTION
## Summary
- **CodeGen**: Fix stored procedure generation for PK-only entities (tables with no non-PK data columns) for both SQL Server and PostgreSQL providers
- **MJCLI**: Fix `mj sync push` always exiting with code 0 even on failure — now properly propagates non-zero exit codes
- **MJServer**: Use `GetSystemUser` instead of manually filtering for system user in API Key scope check
- **AI Prompts**: Add JSON repair observability to `AIPromptRunner` — links repair prompt runs to parent prompt run and agent run

## Test plan
- [x] Unit tests added for PK-only entity SP generation (`SQLServerCodeGenProvider.test.ts`)
- [ ] Verify `mj sync push` returns non-zero exit code on validation/push failure
- [ ] Verify API Key scope check works correctly with `GetSystemUser`
- [ ] Verify JSON repair prompt runs are linked to parent runs in AI Agent Run Steps

🤖 Generated with [Claude Code](https://claude.com/claude-code)