### PR TITLE
test(ci): enable 17 previously-disabled vitest suites

### DIFF
--- a/packages/Actions/ApolloEnrichment/package.json
+++ b/packages/Actions/ApolloEnrichment/package.json
@@ -11,7 +11,7 @@
   "scripts": {
     "start": "ts-node-dev src/index.ts",
     "build": "tsc && tsc-alias -f",
-    "test": "echo \"No tests configured yet\""
+    "test": "vitest run"
   },
   "author": "MemberJunction.com",
   "license": "ISC",

--- a/packages/Actions/BizApps/Accounting/package.json
+++ b/packages/Actions/BizApps/Accounting/package.json
@@ -9,7 +9,7 @@
     "build": "tsc && tsc-alias -f",
     "watch": "tsc -w",
     "clean": "rimraf dist",
-    "test": "echo \"No tests yet\""
+    "test": "vitest run"
   },
   "keywords": [
     "memberjunction",

--- a/packages/Actions/BizApps/CRM/package.json
+++ b/packages/Actions/BizApps/CRM/package.json
@@ -9,7 +9,7 @@
     "build": "tsc && tsc-alias -f",
     "watch": "tsc -w",
     "clean": "rimraf dist",
-    "test": "echo \"No tests yet\""
+    "test": "vitest run"
   },
   "keywords": [
     "memberjunction",

--- a/packages/Actions/BizApps/FormBuilders/package.json
+++ b/packages/Actions/BizApps/FormBuilders/package.json
@@ -9,7 +9,7 @@
     "build": "tsc && tsc-alias -f",
     "watch": "tsc -w",
     "clean": "rimraf dist",
-    "test": "echo \"No tests yet\""
+    "test": "vitest run"
   },
   "keywords": [
     "memberjunction",

--- a/packages/Actions/ScheduledActions/package.json
+++ b/packages/Actions/ScheduledActions/package.json
@@ -11,7 +11,7 @@
   "scripts": {
     "start": "ts-node-dev src/index.ts",
     "build": "tsc && tsc-alias -f",
-    "test": "echo \"No tests configured yet\""
+    "test": "vitest run"
   },
   "author": "MemberJunction.com",
   "license": "ISC",

--- a/packages/Actions/ScheduledActions/src/__tests__/scheduler.test.ts
+++ b/packages/Actions/ScheduledActions/src/__tests__/scheduler.test.ts
@@ -55,6 +55,11 @@ vi.mock('cron-parser', () => ({
 vi.mock('@memberjunction/global', () => ({
     SafeJSONParse: (val: string) => {
         try { return JSON.parse(val); } catch { return null; }
+    },
+    UUIDsEqual: (uuid1: string | null | undefined, uuid2: string | null | undefined): boolean => {
+        if (uuid1 == null && uuid2 == null) return true;
+        if (uuid1 == null || uuid2 == null) return false;
+        return uuid1.trim().toLowerCase() === uuid2.trim().toLowerCase();
     }
 }));
 

--- a/packages/Angular/Explorer/auth-services/package.json
+++ b/packages/Angular/Explorer/auth-services/package.json
@@ -8,7 +8,7 @@
     "/dist"
   ],
   "scripts": {
-    "test": "echo \"No tests configured yet\"",
+    "test": "vitest run",
     "build": "ngc"
   },
   "keywords": [],

--- a/packages/Angular/Explorer/auth-services/src/lib/__tests__/auth-services.test.ts
+++ b/packages/Angular/Explorer/auth-services/src/lib/__tests__/auth-services.test.ts
@@ -13,6 +13,7 @@ vi.mock('@angular/core', () => ({
   Injector: class {},
 }));
 
+const __mockGlobalObjectStore: Record<string, unknown> = {};
 vi.mock('@memberjunction/global', () => ({
   MJGlobal: {
     Instance: {
@@ -23,6 +24,7 @@ vi.mock('@memberjunction/global', () => ({
       },
     }
   },
+  GetGlobalObjectStore: () => __mockGlobalObjectStore,
 }));
 
 vi.mock('@memberjunction/core', () => ({

--- a/packages/Angular/Explorer/base-application/package.json
+++ b/packages/Angular/Explorer/base-application/package.json
@@ -8,7 +8,7 @@
     "/dist"
   ],
   "scripts": {
-    "test": "echo \"No tests configured yet\"",
+    "test": "vitest run",
     "build": "ngc",
     "watch": "ngc -w"
   },

--- a/packages/Angular/Explorer/entity-form-dialog/package.json
+++ b/packages/Angular/Explorer/entity-form-dialog/package.json
@@ -8,7 +8,7 @@
     "/dist"
   ],
   "scripts": {
-    "test": "echo \"No tests configured yet\"",
+    "test": "vitest run",
     "build": "ngc"
   },
   "keywords": [],

--- a/packages/Angular/Explorer/explorer-core/package.json
+++ b/packages/Angular/Explorer/explorer-core/package.json
@@ -8,7 +8,7 @@
     "/dist"
   ],
   "scripts": {
-    "test": "echo \"No tests configured yet\"",
+    "test": "vitest run",
     "prebuild": "mj codegen manifest --exclude-packages @memberjunction --appDir ../../../../packages/MJExplorer --output /dev/null --lazy-config ./src/generated/lazy-feature-config.ts || echo 'Warning: mj codegen manifest not available, using existing lazy-feature-config'",
     "build": "ngc",
     "watch": "ngc -w"

--- a/packages/Angular/Explorer/explorer-modules/package.json
+++ b/packages/Angular/Explorer/explorer-modules/package.json
@@ -8,7 +8,7 @@
     "/dist"
   ],
   "scripts": {
-    "test": "echo \"No tests configured yet\"",
+    "test": "vitest run",
     "build": "ngc"
   },
   "keywords": [

--- a/packages/Angular/Explorer/explorer-settings/package.json
+++ b/packages/Angular/Explorer/explorer-settings/package.json
@@ -18,7 +18,7 @@
     "/dist"
   ],
   "scripts": {
-    "test": "echo \"No tests configured yet\"",
+    "test": "vitest run",
     "build": "ngc"
   },
   "keywords": [],

--- a/packages/Angular/Explorer/link-directives/package.json
+++ b/packages/Angular/Explorer/link-directives/package.json
@@ -8,7 +8,7 @@
     "/dist"
   ],
   "scripts": {
-    "test": "echo \"No tests configured yet\"",
+    "test": "vitest run",
     "build": "ngc"
   },
   "keywords": [

--- a/packages/Angular/Explorer/link-directives/src/__tests__/link-directives.test.ts
+++ b/packages/Angular/Explorer/link-directives/src/__tests__/link-directives.test.ts
@@ -13,6 +13,9 @@ vi.mock('@angular/core', () => ({
   Renderer2: class {},
   OnInit: class {},
   HostListener: () => () => {},
+  // Ivy compiler internals referenced by compiled @memberjunction/ng-base-types dist
+  ɵɵdefineDirective: () => ({}),
+  ɵsetClassMetadata: () => {},
 }));
 
 vi.mock('@memberjunction/core', () => ({

--- a/packages/Angular/Explorer/list-detail-grid/package.json
+++ b/packages/Angular/Explorer/list-detail-grid/package.json
@@ -8,7 +8,7 @@
     "/dist"
   ],
   "scripts": {
-    "test": "echo \"No tests configured yet\"",
+    "test": "vitest run",
     "build": "ngc"
   },
   "keywords": [],

--- a/packages/Angular/Explorer/simple-record-list/package.json
+++ b/packages/Angular/Explorer/simple-record-list/package.json
@@ -8,7 +8,7 @@
     "/dist"
   ],
   "scripts": {
-    "test": "echo \"No tests configured yet\"",
+    "test": "vitest run",
     "build": "ngc"
   },
   "keywords": [],

--- a/packages/Communication/entity-comm-base/package.json
+++ b/packages/Communication/entity-comm-base/package.json
@@ -11,7 +11,7 @@
   "scripts": {
     "start": "ts-node-dev src/index.ts",
     "build": "tsc && tsc-alias -f",
-    "test": "echo \"No tests configured yet\""
+    "test": "vitest run"
   },
   "author": "MemberJunction.com",
   "license": "ISC",

--- a/packages/Communication/entity-comm-client/package.json
+++ b/packages/Communication/entity-comm-client/package.json
@@ -11,7 +11,7 @@
   "scripts": {
     "start": "ts-node-dev src/index.ts",
     "build": "tsc && tsc-alias -f",
-    "test": "echo \"No tests configured yet\""
+    "test": "vitest run"
   },
   "author": "MemberJunction.com",
   "license": "ISC",

--- a/packages/Communication/entity-comm-server/package.json
+++ b/packages/Communication/entity-comm-server/package.json
@@ -11,7 +11,7 @@
   "scripts": {
     "start": "ts-node-dev src/index.ts",
     "build": "tsc && tsc-alias -f",
-    "test": "echo \"No tests configured yet\""
+    "test": "vitest run"
   },
   "author": "MemberJunction.com",
   "license": "ISC",


### PR DESCRIPTION
## Summary

A repo-wide scan turned up **64 packages whose `test` script was a no-op** (`echo "No tests configured yet"`), so CI silently never ran them. This PR enables the **17** that have genuine tests **and pass today**, by flipping their script to `vitest run`.

This is a CI-coverage fix — no production source is changed.

## Enabled (with pass counts, all green)

| Package | Tests |
|---|---|
| Actions/BizApps/CRM | 24 |
| Actions/BizApps/Accounting | 24 |
| Actions/ApolloEnrichment | 24 |
| Actions/BizApps/FormBuilders | 19 |
| Actions/ScheduledActions | 6 |
| Communication/entity-comm-client | 11 |
| Communication/entity-comm-server | 8 |
| Communication/entity-comm-base | 6 |
| Angular/Explorer/base-application | 19 |
| Angular/Explorer/auth-services | 20 |
| Angular/Explorer/explorer-core | 15 |
| Angular/Explorer/link-directives | 4 |
| Angular/Explorer/explorer-settings | 1 |
| Angular/Explorer/explorer-modules | 1 |
| Angular/Explorer/list-detail-grid | 1 |
| Angular/Explorer/simple-record-list | 1 |
| Angular/Explorer/entity-form-dialog | 1 |

## Trivial test-only fixes (no production code, no assertions changed)
Three suites needed a missing **mock export** added to compile:
- `ScheduledActions` — faithful `UUIDsEqual` added to the `@memberjunction/global` mock.
- `auth-services` — `GetGlobalObjectStore` (backing store) added to the global mock.
- `link-directives` — Ivy internals (`ɵɵdefineDirective` / `ɵsetClassMetadata`) added to the `@angular/core` mock (referenced by compiled `ng-base-types`).

## Deferred (intentionally left disabled — NOT in this PR)
- **Angular/Explorer/workspace-initializer** — its `classifyError` has a real test-vs-production mismatch: a `"Cannot read properties of undefined (reading 'ResourceTypes')"` error classifies as `unknown`, but a test expects `no_roles`. Needs a product decision on whether the classifier or the test is wrong — out of scope here. Left exactly as found.
- **~37 packages** have scaffold-only test files (vitest config present but zero assertions). Left untouched until real tests are written.

## Note
This is one of three related branches from the same review session (the other two are the #2839 / #2841 perf-hardening branches). It is independent and based directly on `next`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)