### PR TITLE
test(ci): enable 35 more disabled vitest suites (+6 stale-test fixes)

### DIFF
--- a/packages/Actions/ScheduledActionsServer/package.json
+++ b/packages/Actions/ScheduledActionsServer/package.json
@@ -7,7 +7,7 @@
   "scripts": {
     "dev:debug": "ts-node-dev --transpile-only --respawn --inspect=4321 --project tsconfig.json src/index.ts",
     "dev": "ts-node-dev --transpile-only --respawn --project tsconfig.json src/index.ts",
-    "test": "echo \"No tests configured yet\"",
+    "test": "vitest run",
     "build": "tsc && tsc-alias -f",
     "watch": "tsc -w",
     "clean": "rimraf output",

--- a/packages/Angular/Generic/Testing/package.json
+++ b/packages/Angular/Generic/Testing/package.json
@@ -8,7 +8,7 @@
     "/dist"
   ],
   "scripts": {
-    "test": "echo \"No tests configured yet\"",
+    "test": "vitest run",
     "build": "ngc",
     "test:watch": "vitest"
   },

--- a/packages/Angular/Generic/action-gallery/package.json
+++ b/packages/Angular/Generic/action-gallery/package.json
@@ -8,7 +8,7 @@
     "/dist"
   ],
   "scripts": {
-    "test": "echo \"No tests configured yet\"",
+    "test": "vitest run",
     "build": "ngc",
     "test:watch": "vitest"
   },

--- a/packages/Angular/Generic/actions/package.json
+++ b/packages/Angular/Generic/actions/package.json
@@ -8,7 +8,7 @@
     "/dist"
   ],
   "scripts": {
-    "test": "echo \"No tests configured yet\"",
+    "test": "vitest run",
     "build": "ngc",
     "test:watch": "vitest"
   },

--- a/packages/Angular/Generic/agents/package.json
+++ b/packages/Angular/Generic/agents/package.json
@@ -8,7 +8,7 @@
     "/dist"
   ],
   "scripts": {
-    "test": "echo \"No tests configured yet\"",
+    "test": "vitest run",
     "build": "ngc",
     "test:watch": "vitest"
   },

--- a/packages/Angular/Generic/ai-test-harness/package.json
+++ b/packages/Angular/Generic/ai-test-harness/package.json
@@ -8,7 +8,7 @@
     "/dist"
   ],
   "scripts": {
-    "test": "echo \"No tests configured yet\"",
+    "test": "vitest run",
     "build": "ngc",
     "test:watch": "vitest"
   },

--- a/packages/Angular/Generic/artifacts/package.json
+++ b/packages/Angular/Generic/artifacts/package.json
@@ -8,7 +8,7 @@
     "/dist"
   ],
   "scripts": {
-    "test": "echo \"No tests configured yet\"",
+    "test": "vitest run",
     "build": "ngc",
     "test:watch": "vitest"
   },

--- a/packages/Angular/Generic/artifacts/src/lib/__tests__/interactive-form-apply.service.test.ts
+++ b/packages/Angular/Generic/artifacts/src/lib/__tests__/interactive-form-apply.service.test.ts
@@ -40,9 +40,16 @@ vi.mock('@angular/core', () => ({
 
 const mockDialog = {
     Open: () => ({
+        // The real MJDialogRef.Result emits the clicked MJDialogAction object
+        // ({ text, primary }) — the service detects intent via `action.primary`.
+        // Map the test's 'apply'/'cancel' intent onto that shape.
         Result: {
-            subscribe: (cb: (r: { result: string }) => void) => {
-                cb({ result: hoisted.dialogResult });
+            subscribe: (cb: (r: { text: string; primary?: boolean }) => void) => {
+                cb(
+                    hoisted.dialogResult === 'apply'
+                        ? { text: 'Apply', primary: true }
+                        : { text: 'Cancel' },
+                );
             },
         },
     }),

--- a/packages/Angular/Generic/base-types/package.json
+++ b/packages/Angular/Generic/base-types/package.json
@@ -8,7 +8,7 @@
     "/dist"
   ],
   "scripts": {
-    "test": "echo \"No tests configured yet\"",
+    "test": "vitest run",
     "build": "ngc",
     "test:watch": "vitest"
   },

--- a/packages/Angular/Generic/chat/package.json
+++ b/packages/Angular/Generic/chat/package.json
@@ -8,7 +8,7 @@
     "/dist"
   ],
   "scripts": {
-    "test": "echo \"No tests configured yet\"",
+    "test": "vitest run",
     "build": "ngc",
     "test:watch": "vitest"
   },

--- a/packages/Angular/Generic/code-editor/package.json
+++ b/packages/Angular/Generic/code-editor/package.json
@@ -8,7 +8,7 @@
     "/dist"
   ],
   "scripts": {
-    "test": "echo \"No tests configured yet\"",
+    "test": "vitest run",
     "build": "ngc",
     "test:watch": "vitest"
   },

--- a/packages/Angular/Generic/container-directives/package.json
+++ b/packages/Angular/Generic/container-directives/package.json
@@ -8,7 +8,7 @@
     "/dist"
   ],
   "scripts": {
-    "test": "echo \"No tests configured yet\"",
+    "test": "vitest run",
     "build": "ngc",
     "test:watch": "vitest"
   },

--- a/packages/Angular/Generic/conversations/package.json
+++ b/packages/Angular/Generic/conversations/package.json
@@ -8,7 +8,7 @@
     "/dist"
   ],
   "scripts": {
-    "test": "echo \"No tests configured yet\"",
+    "test": "vitest run",
     "build": "ngc",
     "test:watch": "vitest"
   },

--- a/packages/Angular/Generic/credentials/package.json
+++ b/packages/Angular/Generic/credentials/package.json
@@ -8,7 +8,7 @@
     "/dist"
   ],
   "scripts": {
-    "test": "echo \"No tests configured yet\"",
+    "test": "vitest run",
     "build": "ngc",
     "test:watch": "vitest"
   },

--- a/packages/Angular/Generic/dashboard-viewer/package.json
+++ b/packages/Angular/Generic/dashboard-viewer/package.json
@@ -8,7 +8,7 @@
     "/dist"
   ],
   "scripts": {
-    "test": "echo \"No tests configured yet\"",
+    "test": "vitest run",
     "build": "ngc",
     "test:watch": "vitest"
   },

--- a/packages/Angular/Generic/data-context/package.json
+++ b/packages/Angular/Generic/data-context/package.json
@@ -8,7 +8,7 @@
     "/dist"
   ],
   "scripts": {
-    "test": "echo \"No tests configured yet\"",
+    "test": "vitest run",
     "build": "ngc",
     "test:watch": "vitest"
   },

--- a/packages/Angular/Generic/entity-communication/package.json
+++ b/packages/Angular/Generic/entity-communication/package.json
@@ -8,7 +8,7 @@
     "/dist"
   ],
   "scripts": {
-    "test": "echo \"No tests configured yet\"",
+    "test": "vitest run",
     "build": "ngc",
     "test:watch": "vitest"
   },

--- a/packages/Angular/Generic/export-service/package.json
+++ b/packages/Angular/Generic/export-service/package.json
@@ -8,7 +8,7 @@
     "/dist"
   ],
   "scripts": {
-    "test": "echo \"No tests configured yet\"",
+    "test": "vitest run",
     "build": "ngc",
     "test:watch": "vitest"
   },

--- a/packages/Angular/Generic/file-storage/package.json
+++ b/packages/Angular/Generic/file-storage/package.json
@@ -18,7 +18,7 @@
     "/dist"
   ],
   "scripts": {
-    "test": "echo \"No tests configured yet\"",
+    "test": "vitest run",
     "build": "ngc",
     "watch": "ngc -w",
     "test:watch": "vitest"

--- a/packages/Angular/Generic/filter-builder/package.json
+++ b/packages/Angular/Generic/filter-builder/package.json
@@ -8,7 +8,7 @@
     "/dist"
   ],
   "scripts": {
-    "test": "echo \"No tests configured yet\"",
+    "test": "vitest run",
     "build": "ngc",
     "test:watch": "vitest"
   },

--- a/packages/Angular/Generic/find-record/package.json
+++ b/packages/Angular/Generic/find-record/package.json
@@ -8,7 +8,7 @@
     "/dist"
   ],
   "scripts": {
-    "test": "echo \"No tests configured yet\"",
+    "test": "vitest run",
     "build": "ngc",
     "test:watch": "vitest"
   },

--- a/packages/Angular/Generic/flow-editor/package.json
+++ b/packages/Angular/Generic/flow-editor/package.json
@@ -8,7 +8,7 @@
     "/dist"
   ],
   "scripts": {
-    "test": "echo \"No tests configured yet\"",
+    "test": "vitest run",
     "build": "ngc",
     "test:watch": "vitest"
   },

--- a/packages/Angular/Generic/generic-dialog/package.json
+++ b/packages/Angular/Generic/generic-dialog/package.json
@@ -8,7 +8,7 @@
     "/dist"
   ],
   "scripts": {
-    "test": "echo \"No tests configured yet\"",
+    "test": "vitest run",
     "build": "ngc",
     "test:watch": "vitest"
   },

--- a/packages/Angular/Generic/join-grid/package.json
+++ b/packages/Angular/Generic/join-grid/package.json
@@ -8,7 +8,7 @@
     "/dist"
   ],
   "scripts": {
-    "test": "echo \"No tests configured yet\"",
+    "test": "vitest run",
     "build": "ngc",
     "test:watch": "vitest"
   },

--- a/packages/Angular/Generic/markdown/package.json
+++ b/packages/Angular/Generic/markdown/package.json
@@ -8,7 +8,7 @@
     "/dist"
   ],
   "scripts": {
-    "test": "echo \"No tests configured yet\"",
+    "test": "vitest run",
     "build": "ngc",
     "test:watch": "vitest"
   },

--- a/packages/Angular/Generic/markdown/src/__tests__/markdown-types.test.ts
+++ b/packages/Angular/Generic/markdown/src/__tests__/markdown-types.test.ts
@@ -56,7 +56,7 @@ describe('DEFAULT_MARKDOWN_CONFIG', () => {
   });
 
   it('should use default mermaid theme', () => {
-    expect(DEFAULT_MARKDOWN_CONFIG.mermaidTheme).toBe('default');
+    expect(DEFAULT_MARKDOWN_CONFIG.mermaidTheme).toBe('auto');
   });
 });
 

--- a/packages/Angular/Generic/notifications/package.json
+++ b/packages/Angular/Generic/notifications/package.json
@@ -8,7 +8,7 @@
     "/dist"
   ],
   "scripts": {
-    "test": "echo \"No tests configured yet\"",
+    "test": "vitest run",
     "build": "ngc",
     "test:watch": "vitest"
   },

--- a/packages/Angular/Generic/query-viewer/package.json
+++ b/packages/Angular/Generic/query-viewer/package.json
@@ -8,7 +8,7 @@
     "/dist"
   ],
   "scripts": {
-    "test": "echo \"No tests configured yet\"",
+    "test": "vitest run",
     "build": "ngc",
     "test:watch": "vitest"
   },

--- a/packages/Angular/Generic/record-selector/package.json
+++ b/packages/Angular/Generic/record-selector/package.json
@@ -8,7 +8,7 @@
     "/dist"
   ],
   "scripts": {
-    "test": "echo \"No tests configured yet\"",
+    "test": "vitest run",
     "build": "ngc",
     "test:watch": "vitest"
   },

--- a/packages/Angular/Generic/resource-permissions/package.json
+++ b/packages/Angular/Generic/resource-permissions/package.json
@@ -8,7 +8,7 @@
     "/dist"
   ],
   "scripts": {
-    "test": "echo \"No tests configured yet\"",
+    "test": "vitest run",
     "build": "ngc",
     "test:watch": "vitest"
   },

--- a/packages/Angular/Generic/tab-strip/package.json
+++ b/packages/Angular/Generic/tab-strip/package.json
@@ -8,7 +8,7 @@
     "/dist"
   ],
   "scripts": {
-    "test": "echo \"No tests configured yet\"",
+    "test": "vitest run",
     "build": "ngc",
     "test:watch": "vitest"
   },

--- a/packages/Angular/Generic/timeline/package.json
+++ b/packages/Angular/Generic/timeline/package.json
@@ -8,7 +8,7 @@
     "/dist"
   ],
   "scripts": {
-    "test": "echo \"No tests configured yet\"",
+    "test": "vitest run",
     "build": "ngc",
     "test:watch": "vitest"
   },

--- a/packages/Angular/Generic/trees/package.json
+++ b/packages/Angular/Generic/trees/package.json
@@ -8,7 +8,7 @@
     "/dist"
   ],
   "scripts": {
-    "test": "echo \"No tests configured yet\"",
+    "test": "vitest run",
     "build": "ngc",
     "test:watch": "vitest"
   },

--- a/packages/Angular/Generic/trees/src/__tests__/tree-types.test.ts
+++ b/packages/Angular/Generic/trees/src/__tests__/tree-types.test.ts
@@ -87,7 +87,7 @@ describe('createDefaultLeafConfig', () => {
       EntityName: 'MJ: Queries',
       ParentField: 'CategoryID'
     });
-    expect(config.EntityName).toBe('Queries');
+    expect(config.EntityName).toBe('MJ: Queries');
     expect(config.ParentField).toBe('CategoryID');
   });
 });

--- a/packages/Angular/Generic/user-avatar/package.json
+++ b/packages/Angular/Generic/user-avatar/package.json
@@ -8,7 +8,7 @@
     "/dist"
   ],
   "scripts": {
-    "test": "echo \"No tests configured yet\"",
+    "test": "vitest run",
     "build": "ngc",
     "test:watch": "vitest"
   },

--- a/packages/Angular/Generic/versions/package.json
+++ b/packages/Angular/Generic/versions/package.json
@@ -8,7 +8,7 @@
     "/dist"
   ],
   "scripts": {
-    "test": "echo \"No tests configured yet\"",
+    "test": "vitest run",
     "build": "ngc",
     "test:watch": "vitest"
   },

--- a/packages/Angular/Generic/versions/src/__tests__/types.test.ts
+++ b/packages/Angular/Generic/versions/src/__tests__/types.test.ts
@@ -11,7 +11,7 @@ describe('MicroViewData type', () => {
       FullRecordJSON: { Name: 'John', Email: 'john@test.com' },
       FieldDiffs: null
     };
-    expect(data.EntityName).toBe('Users');
+    expect(data.EntityName).toBe('MJ: Users');
     expect(data.RecordID).toBe('rec-1');
     expect(data.FullRecordJSON).toEqual({ Name: 'John', Email: 'john@test.com' });
   });

--- a/packages/Communication/base-types/package.json
+++ b/packages/Communication/base-types/package.json
@@ -11,7 +11,7 @@
   "scripts": {
     "start": "ts-node-dev src/index.ts",
     "build": "tsc && tsc-alias -f",
-    "test": "echo \"No tests configured yet\""
+    "test": "vitest run"
   },
   "author": "MemberJunction.com",
   "license": "ISC",

--- a/packages/Communication/base-types/src/__tests__/BaseEngine.test.ts
+++ b/packages/Communication/base-types/src/__tests__/BaseEngine.test.ts
@@ -8,6 +8,9 @@ const { mockSave, mockGetEntityObject } = vi.hoisted(() => ({
 vi.mock('@memberjunction/core', () => {
     class MockBaseEngine {
         protected ContextUser = { ID: 'user-1' };
+        protected get ProviderToUse() {
+            return { GetEntityObject: mockGetEntityObject };
+        }
         protected async Load() {}
         static _instances = new Map();
         static getInstance() {

--- a/packages/Templates/engine/package.json
+++ b/packages/Templates/engine/package.json
@@ -11,7 +11,7 @@
   "scripts": {
     "start": "ts-node-dev src/index.ts",
     "build": "tsc && tsc-alias -f",
-    "test": "echo \"No tests configured yet\""
+    "test": "vitest run"
   },
   "author": "MemberJunction.com",
   "license": "ISC",

--- a/packages/Templates/engine/src/__tests__/TemplateEngine.test.ts
+++ b/packages/Templates/engine/src/__tests__/TemplateEngine.test.ts
@@ -73,6 +73,7 @@ vi.mock('@memberjunction/global', () => ({
         },
     },
     RegisterClass: () => (target: Function) => target,
+    UUIDsEqual: (a: string, b: string) => a?.toLowerCase() === b?.toLowerCase(),
 }));
 
 vi.mock('@memberjunction/templates-base-types', () => ({


### PR DESCRIPTION
## Summary
Continues #2847. Enables **35** more packages whose real vitest suites were hidden behind a no-op `test` script (`echo "No tests configured yet"`), by flipping to `vitest run` — each **verified green** (I re-ran all 35 independently). **~700+ real assertions that never ran in CI now do**, headlined by `conversations` (**549 tests**). No production source changed.

### Notable enabled suites
`conversations` 549 · `Templates/engine` 74 · `Communication/base-types` 60 · `filter-builder` 42 · `artifacts` 38 · `Testing` 34 · `timeline` 24 · `trees` 19 · `markdown` 18 · `code-editor` 15 · `base-types` 12 · `export-service` 10 — plus ~23 smaller suites.

### Six trivial TEST-ONLY fixes (no assertion weakened)
| Package | Fix | Kind |
|---|---|---|
| artifacts | dialog mock emitted `{result}`; real `MJDialogRef.Result` emits `MJDialogAction {text, primary}` — corrected mock shape | stale mock |
| base-types | `BaseEngine` refactored `new Metadata()`→`this.ProviderToUse`; added missing `ProviderToUse` to mock | test drift |
| Templates/engine | added missing `UUIDsEqual` export to the `@memberjunction/global` mock | missing mock export |
| markdown | `mermaidTheme` default is `'auto'` not `'default'` — corrected expected literal | typo'd expectation |
| trees | `'MJ: Queries'` passes through verbatim; test asserted `'Queries'` | typo'd expectation |
| versions | `'MJ: Users'` passes through verbatim; test asserted `'Users'` | typo'd expectation |

Each fix makes the test **more** faithful to production, not less.

## Deferred (NOT in this PR — need follow-up)
- **`Angular/Explorer/shared`** — 12 tests need a jsdom/happy-dom env (they touch `document` / Angular DI under vitest's `node` env). 45 pure-logic tests pass; enabling the rest needs a vitest config change. Left disabled.
- **`Angular/Explorer/workspace-initializer`** — a **real product-decision blocker**. Its `classifyError` test asserts a `"Cannot read properties of undefined (reading 'ResourceTypes')"` TypeError should classify as `no_roles`. But evidence (`MJInstaller/CodeGenPhase.ts` flags the non-optional `_ResourceTypes.ResourceTypes` read as a bug to fix with `?.`, and the current `AppComponent` has no such handling) indicates that crash is a **load-order bug**, not a reliable no-roles signal — so mapping it to `no_roles` would mislabel generic init failures as permission problems. Needs an owner decision: harden the classifier, or correct the test to expect `unknown`. Tracked in #2848.

## Related
#2847 (first 17, merged) · #2848 (backlog doc) · #2839 / #2841 (perf).

🤖 Generated with [Claude Code](https://claude.com/claude-code)