### PR TITLE
fix(ci): update retired Claude model IDs in workflows

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -34,7 +34,7 @@ jobs:
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
 
-          model: claude-opus-4-0
+          model: claude-opus-4-8
 
           direct_prompt: |
             Please review this PR and provide inline feedback using the GitHub review system. Follow these steps:

--- a/.github/workflows/generate-release-notes.yml
+++ b/.github/workflows/generate-release-notes.yml
@@ -29,7 +29,7 @@ jobs:
         uses: anthropics/claude-code-action@beta
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
-          model: claude-sonnet-4-0
+          model: claude-sonnet-4-6
 
           direct_prompt: |
             You are a technical analyst working as a release coordinator for MemberJunction. Your task is to create release notes in markdown and update the PR description.


### PR DESCRIPTION
## Problem
The **Generate Release Notes** workflow started failing on every PR to `next` (e.g. [run 27597818961](https://github.com/MemberJunction/MJ/actions/runs/27597818961)) with:

```
API Error: 404 not_found_error — "model: claude-sonnet-4-0"
```

The workflow file hadn't changed (model line last edited 2025-07-20) and the same job ran green on June 9–10 (v5.40.x). The cause is **server-side**: the `claude-sonnet-4-0` model alias was retired from the Anthropic API, so the action 404s on its first call (`num_turns: 1`, ~750ms) before doing any work.

## Fix
Bump both workflows off the retired `-4-0` aliases to current model IDs (tier-preserving):

| File | From | To |
|---|---|---|
| `.github/workflows/generate-release-notes.yml` | `claude-sonnet-4-0` | `claude-sonnet-4-6` |
| `.github/workflows/claude.yml` | `claude-opus-4-0` | `claude-opus-4-8` |

`claude.yml` was the same latent failure (same retired alias family) and would 404 the same way whenever `@claude` is triggered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
