### PR TITLE
docs(testing): phased plan for Angular DOM unit-testing rollout

### DIFF
--- a/plans/testing/angular-dom-testing-rollout.md
+++ b/plans/testing/angular-dom-testing-rollout.md
@@ -1,0 +1,172 @@
+# Angular DOM Unit-Testing Rollout — Phased Plan
+
+**Status:** Plan / RFC. To be implemented by a follow-up agent.
+**Owner:** TBD
+**Related:** discovered while adding the LiveKit room UX stack (PR #2860); the new Angular packages
+currently ship class-level component tests because the repo has no DOM-rendering harness.
+
+---
+
+## 1. Goal
+
+Enable **DOM-level unit tests** for MemberJunction Angular components — render a component into a real DOM
+tree with Angular `TestBed` + `ComponentFixture`, drive it (set `@Input`s, dispatch DOM events), and assert
+on **rendered output** and **`@Output` emissions** — and roll this out across `packages/Angular/**`.
+
+Today we can only test component *classes* (instantiate with `new`, assert on state/emissions). That misses
+the half of a component's contract that lives in the **template**: gating (`@if` shows/hides the right
+controls), bindings, event wiring (`(click)` → handler → `@Output`), conditional classes, accessibility.
+
+## 2. Current state (verified)
+
+- Root `vitest.shared.ts` sets **`environment: 'node'`** for every package. No `jsdom` / `happy-dom`.
+- No `zone.js` test bootstrap, no `@analogjs/vite-plugin-angular`, no Angular vitest unit-test builder.
+- Existing "Angular tests" (e.g. `ng-conversations`, `ng-base-forms`, `ng-dashboards`) are **class-level**:
+  they `new` the component and assert on `@Output`/state, often loading `@angular/compiler` for JIT but
+  **never rendering to DOM**. Several explicitly comment "without Angular TestBed."
+- Angular version: **21.1.3** (supports zoneless change detection — `provideZonelessChangeDetection()`).
+
+**Implication:** DOM testing is a one-time, repo-wide **infra** addition, then a per-package rollout. It is
+not a per-package flip of an existing capability.
+
+## 3. Non-goals / explicit exclusions
+
+- **WebRTC / live-media paths are NOT in scope for DOM unit tests.** jsdom does not implement WebRTC,
+  `navigator.mediaDevices.getUserMedia`, `AudioContext`, `MediaStreamTrack`, real `<video>`/`<audio>`
+  playback, or `requestAnimationFrame`-driven media. Components that *touch* these (the LiveKit
+  `livekit-client` paths, camera/mic capture, `track.attach()`, audio metering) must be **live-tested**
+  via the existing Playwright CLI workflow / a future e2e suite — **not** mocked into a fake "pass."
+  - For such components, DOM-unit-test only the **presentational, media-free** surface (gating, labels,
+    button states, `@Output` emission on click) with the media client mocked, and cover the actual media
+    behavior with a live test. Document this split per component.
+- Not changing the existing class-level tests — they stay; DOM tests are additive.
+- Not introducing Karma/Jasmine. Vitest remains the single runner.
+
+## 4. Technical approach
+
+**Renderer:** `@analogjs/vite-plugin-angular` (compiles Angular templates/decorators for Vite/vitest) +
+`environment: 'jsdom'` + a setup file that initializes `TestBed` once with
+`provideZonelessChangeDetection()` (zoneless — avoids `zone.js` and its async-stability quirks; matches our
+OnPush components). Use `await fixture.whenStable()` / `fixture.detectChanges()` for CD.
+
+> Alternative considered: Angular's first-party `@angular/build:unit-test` (experimental, vitest-based).
+> Rejected for now because our libraries build with `ngc`, not the application builder; Analog is the proven
+> path for **library** packages and decouples test runner from build pipeline. Re-evaluate when the
+> first-party builder is stable for libraries.
+
+**Shared preset:** add `vitest.dom.shared.ts` at repo root (peer to `vitest.shared.ts`):
+- `plugins: [angular(), tsconfigPaths()]`
+- `test.environment: 'jsdom'`, `test.setupFiles: ['<root>/vitest.dom.setup.ts']`, `globals: true`
+- `vitest.dom.setup.ts` initializes the Angular testing environment (`getTestBed().initTestEnvironment(...)`
+  or the zoneless equivalent) once.
+
+**Per-package opt-in:** a package that wants DOM tests has its `vitest.config.ts` extend
+`vitest.dom.shared` instead of `vitest.shared`. Node-only packages stay on the node preset. (Optionally
+support both in one package via a `projects` config so pure-logic specs stay fast on node and DOM specs run
+on jsdom — decide in Phase 0.)
+
+**Dependencies (dev):** `@analogjs/vite-plugin-angular`, `jsdom`, and whatever Analog peer-deps it requires
+(`@angular/compiler-cli` already present in Angular packages). Pin to versions compatible with Angular 21.
+
+**Scaffold:** extend `scripts/scaffold-tests.mjs` with a `--dom` flag that emits a DOM-preset
+`vitest.config.ts` + a starter `ComponentFixture` spec.
+
+## 5. What a DOM test looks like (target pattern)
+
+```typescript
+import { TestBed } from '@angular/core/testing';
+import { LiveKitControlBarComponent } from '../components/livekit-control-bar.component';
+
+describe('LiveKitControlBarComponent (DOM)', () => {
+  it('hides the screen-share button when EnableScreenShareControl is false', async () => {
+    const fixture = TestBed.createComponent(LiveKitControlBarComponent);
+    fixture.componentInstance.EnableScreenShareControl = false;
+    fixture.detectChanges();
+    expect(fixture.nativeElement.querySelector('[title="Share screen"]')).toBeNull();
+  });
+
+  it('emits ToggleMicrophone when the mic button is clicked', async () => {
+    const fixture = TestBed.createComponent(LiveKitControlBarComponent);
+    const spy = vi.fn();
+    fixture.componentInstance.ToggleMicrophone.subscribe(spy);
+    fixture.detectChanges();
+    fixture.nativeElement.querySelector('.lk-bar__btn').click();
+    expect(spy).toHaveBeenCalled();
+  });
+});
+```
+
+**Mocking strategy for DOM tests:**
+- Data: provide a fake `IMetadataProvider` / mock `RunView` (reuse `@memberjunction/test-utils`).
+- Container components that internally `new` an engine/controller: refactor to make the dependency
+  **injectable** (constructor `inject()` of a factory token), so tests inject a fake. (LiveKit's
+  `LiveKitRoomComponent` is the worked example — its leaf components are already pure `@Input`/`@Output`.)
+- Media APIs: stub at the seam, and defer real behavior to live tests (see §3).
+
+## 6. Phasing
+
+### Phase 0 — Infra spike (1 package, prove it renders)
+- Add `@analogjs/vite-plugin-angular` + `jsdom` devDeps; create `vitest.dom.shared.ts` + `vitest.dom.setup.ts`.
+- Pick **one simple generic package** (candidate: `@memberjunction/ng-user-avatar` or a leaf in
+  `@memberjunction/ng-ui-components`) and convert its `vitest.config.ts` to the DOM preset.
+- Write **2–3 real `ComponentFixture` specs** that render and assert on DOM.
+- **Exit criteria:** `npm test` for that package renders a component to DOM and asserts pass; runs in CI;
+  no zone.js; documented run time.
+
+### Phase 1 — Pilot on a few components + write the guide
+- Add DOM specs for **~5 leaf components across 2–3 packages**, including the **LiveKit leaf components**
+  (`control-bar`, `participant-tile` [media mocked], `chat-panel`, `device-menu`, `agent-state`,
+  `connection-overlay`) as the headline proof — they're small, gating-heavy, and `@Output`-driven.
+- Do the **injectable-controller refactor** on `LiveKitRoomComponent` and add a container-level DOM spec
+  driven by a fake controller.
+- Author `guides/ANGULAR_TESTING_GUIDE.md`: when to class-test vs DOM-test vs live-test; the mocking
+  recipes; the WebRTC/live-media exclusion; the fixture patterns; `@angular/compiler` JIT note for
+  partial-compiled libs.
+- Update `scripts/scaffold-tests.mjs` (`--dom`).
+- **Exit criteria:** ~5 components with green DOM specs in CI; guide merged; patterns validated on a
+  media-touching package (LiveKit) proving the presentational/live split works.
+
+### Phase 2 — `packages/Angular/Generic/**` rollout
+- Package-by-package: convert/added DOM specs for leaf + presentational components. Prioritize high-traffic
+  shared UI (`ng-ui-components`, `ng-base-forms`, `ng-conversations`, `ng-data-context`, …).
+- Track coverage in a checklist; one PR per package (or small batches) to keep reviews tractable.
+- **Exit criteria:** every Generic package has a DOM `vitest.config` and meaningful DOM specs for its
+  primary components; agreed coverage threshold met.
+
+### Phase 3 — `packages/Angular/Explorer/**` rollout
+- Same approach for Explorer packages (`explorer-core`, `dashboards`, `core-entity-forms`, `shared`, …).
+  Heavier components (resource wrappers, dashboards) lean on mocked providers + `NavigationService` fakes.
+- **Exit criteria:** Explorer packages covered to the agreed threshold.
+
+### Phase 4 — Gates & coverage
+- Add a coverage threshold for Angular packages in CI (start lenient, ratchet up).
+- Document the live-media e2e suite location/runner for the excluded WebRTC paths.
+
+## 7. Risks & mitigations
+
+| Risk | Mitigation |
+|---|---|
+| jsdom missing APIs (ResizeObserver, matchMedia, IntersectionObserver, rAF) | Add polyfills/stubs in `vitest.dom.setup.ts`; document the standard stub set. |
+| Partial-compiled (Ivy) libraries need JIT at test time | `import '@angular/compiler'` in the setup file (already the repo convention). |
+| Zoneless CD surprises | Standardize on `fixture.detectChanges()` / `await fixture.whenStable()`; document in the guide. |
+| CI time growth | Keep pure-logic specs on the node preset; only DOM specs pay the jsdom cost. Use vitest `projects`. |
+| Over-mocking hides real bugs (esp. media) | Hard rule: media behavior is **live-tested**, never asserted via mocks (§3). |
+| Analog version drift vs Angular 21 | Pin versions; gate the upgrade behind Phase 0 validation. |
+
+## 8. Deliverables for the implementing agent
+
+1. `vitest.dom.shared.ts` + `vitest.dom.setup.ts` (root) and devDep additions.
+2. Phase 0 package converted with 2–3 passing DOM specs.
+3. Phase 1 pilot specs (incl. LiveKit leaf components) + `LiveKitRoomComponent` injectable refactor.
+4. `guides/ANGULAR_TESTING_GUIDE.md`.
+5. `scripts/scaffold-tests.mjs --dom`.
+6. A rollout checklist (this doc's §6.2/§6.3) tracked in the PR description.
+
+Each phase is its own PR. Phases 0–1 land first and must be proven green before Phase 2 begins.
+
+## 9. Estimated effort (rough)
+
+- Phase 0: ~0.5–1 day (infra + spike).
+- Phase 1: ~1–2 days (pilot specs + refactor + guide).
+- Phase 2: ongoing, ~per-package; parallelizable across agents once the pattern is fixed.
+- Phase 3: ongoing.


### PR DESCRIPTION
## Summary

A **planning/RFC PR** (docs only — no code) for introducing **DOM-level Angular component unit tests** and rolling them out across `packages/Angular/**`. To be implemented by a follow-up agent, in phases.

Adds [`plans/testing/angular-dom-testing-rollout.md`](plans/testing/angular-dom-testing-rollout.md).

## Why

Today every package runs vitest with `environment: 'node'` — no jsdom, no zone/TestBed bootstrap. The existing "Angular tests" are **class-level** (instantiate with `new`, assert on `@Output`/state); they never render templates. That misses the half of a component's contract that lives in the template: gating (`@if`), bindings, `(click)` → handler → `@Output` wiring, conditional classes, a11y. This plan adds a real `TestBed` + `ComponentFixture` harness so we can assert on rendered DOM.

## Approach (in the doc)

- `@analogjs/vite-plugin-angular` + `environment: 'jsdom'` + **zoneless** `TestBed` (Angular 21), wired as a shared `vitest.dom.shared.ts` preset packages opt into. Node-only packages stay as-is.
- Worked fixture-test patterns + mocking recipes (fake provider/RunView; make container components' internal engines injectable so a fake drives the DOM).

## Phasing

0. **Infra spike** — stand up the preset on one simple package, 2–3 real DOM specs, prove it runs in CI.
1. **Pilot** — ~5 leaf components across 2–3 packages (incl. the **LiveKit leaf components** from #2860) + the injectable-controller refactor + author `guides/ANGULAR_TESTING_GUIDE.md` + `scaffold-tests --dom`.
2. **`Angular/Generic/**` rollout** (package-by-package).
3. **`Angular/Explorer/**` rollout.**
4. **Coverage gates** in CI.

Each phase is its own PR; 0–1 must be green before 2 begins.

## Explicit exclusion: WebRTC / live media

jsdom can't run WebRTC, `getUserMedia`, `AudioContext`, real `<video>`/`<audio>`, or rAF-driven media. Per the request, those paths (the LiveKit `livekit-client` media flows, capture, `track.attach()`, audio metering) are **live-tested** (Playwright/e2e) and **never mocked into a fake pass**. DOM unit tests cover only the presentational, media-free surface of such components; the doc spells out the split.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JFnXteXK79zsomTQbHp6bi

---
_Generated by [Claude Code](https://claude.ai/code/session_01JFnXteXK79zsomTQbHp6bi)_