### PR TITLE
fix(pg): translate T-SQL date functions in runtime SQL clauses

### DIFF
--- a/packages/Angular/Explorer/dashboards/src/MCP/mcp-dashboard.component.ts
+++ b/packages/Angular/Explorer/dashboards/src/MCP/mcp-dashboard.component.ts
@@ -597,11 +597,14 @@ export class MCPDashboardComponent extends BaseDashboard implements OnInit, Afte
             // forceRefresh=true is needed after sync operations since backend changes
             // won't trigger local BaseEntity events
             const rv = RunView.FromMetadataProvider(this.ProviderToUse);
+            // Dialect-neutral 7-day cutoff: compute in JS and inject an ISO-8601
+            // literal rather than DATEADD/GETUTCDATE, which don't exist on PostgreSQL.
+            const sevenDaysAgoIso = new Date(Date.now() - 7 * 24 * 60 * 60 * 1000).toISOString();
             const [, logsResult] = await Promise.all([
                 MCPEngine.Instance.Config(forceRefresh),
                 rv.RunView<MJMCPToolExecutionLogEntity>({
                     EntityName: 'MJ: MCP Tool Execution Logs',
-                    ExtraFilter: `StartedAt >= DATEADD(day, -7, GETUTCDATE())`,
+                    ExtraFilter: `StartedAt >= '${sevenDaysAgoIso}'`,
                     OrderBy: 'StartedAt DESC',
                     MaxRows: 100,
                     ResultType: 'simple'

--- a/packages/Angular/Generic/entity-communication/src/lib/preview.component.ts
+++ b/packages/Angular/Generic/entity-communication/src/lib/preview.component.ts
@@ -42,10 +42,13 @@ export class EntityCommunicationsPreviewComponent implements OnInit  {
   async loadTemplates() {
     // load up all template metadata
     const rv = new RunView();
+    // Dialect-neutral "active now" cutoff: GETDATE() does not exist on PostgreSQL,
+    // so inject a JS-computed ISO-8601 literal instead.
+    const nowIso = new Date().toISOString();
     const result = await rv.RunView<MJTemplateEntityExtended>(
       {
         EntityName: "MJ: Templates",
-        ExtraFilter: `(IsActive = 1 AND (ActiveAt IS NULL OR ActiveAt <= GETDATE())) ${this.templateFilter ? `AND ${this.templateFilter}` : ''}`,
+        ExtraFilter: `(IsActive = 1 AND (ActiveAt IS NULL OR ActiveAt <= '${nowIso}')) ${this.templateFilter ? `AND ${this.templateFilter}` : ''}`,
         ResultType: 'entity_object'
       }
     );

--- a/packages/Archiving/Engine/src/ArchiveProcessor.ts
+++ b/packages/Archiving/Engine/src/ArchiveProcessor.ts
@@ -155,7 +155,10 @@ export class ArchiveProcessor {
         const filterParts: string[] = [];
 
         if (retentionDays != null && dateField) {
-            filterParts.push(`${dateField} < DATEADD(day, -${retentionDays}, GETUTCDATE())`);
+            // Dialect-neutral retention cutoff: compute in JS and inject an ISO-8601
+            // literal rather than DATEADD/GETUTCDATE, which don't exist on PostgreSQL.
+            const cutoffIso = new Date(Date.now() - retentionDays * 24 * 60 * 60 * 1000).toISOString();
+            filterParts.push(`${dateField} < '${cutoffIso}'`);
         }
 
         if (customFilter) {

--- a/packages/MJCoreEntities/src/custom/PermissionProviders/AccessControlRuleProvider.ts
+++ b/packages/MJCoreEntities/src/custom/PermissionProviders/AccessControlRuleProvider.ts
@@ -120,7 +120,7 @@ export class AccessControlRuleProvider extends PermissionProviderBase {
         }
         const granteeFilter = granteeClauses.join(' OR ');
 
-        let filter = `(${granteeFilter}) AND (ExpiresAt IS NULL OR ExpiresAt > GETUTCDATE())`;
+        let filter = `(${granteeFilter}) AND ${this.unexpiredClause()}`;
         if (resourceType) {
             const entityId = this.resolveEntityId(resourceType, provider);
             if (!entityId) return [];
@@ -194,7 +194,7 @@ export class AccessControlRuleProvider extends PermissionProviderBase {
             'MJ: Access Control Rules',
             `GranteeType='User' AND GranteeID='${grantee.ID}' ` +
                 `AND GrantedByUserID <> '${grantee.ID}' ` +
-                `AND (ExpiresAt IS NULL OR ExpiresAt > GETUTCDATE())`,
+                `AND ${this.unexpiredClause()}`,
             ACR_GRANT_FIELDS,
             'GetPermissionsSharedWithUser'
         );
@@ -221,7 +221,7 @@ export class AccessControlRuleProvider extends PermissionProviderBase {
     override async GetPermissionsGrantedByUser(grantor: UserInfo): Promise<NormalizedPermission[]> {
         const rows = await this.fetchRows<AccessControlRuleRow>(
             'MJ: Access Control Rules',
-            `GrantedByUserID='${grantor.ID}' AND (ExpiresAt IS NULL OR ExpiresAt > GETUTCDATE())`,
+            `GrantedByUserID='${grantor.ID}' AND ${this.unexpiredClause()}`,
             ACR_GRANT_FIELDS,
             'GetPermissionsGrantedByUser'
         );
@@ -244,6 +244,17 @@ export class AccessControlRuleProvider extends PermissionProviderBase {
         return results;
     }
 
+    /**
+     * Dialect-neutral "not yet expired" predicate. Uses a JS-computed ISO-8601
+     * timestamp literal rather than a SQL function — SQL Server's `GETUTCDATE()`
+     * does not exist on PostgreSQL and would crash the underlying RunView query
+     * there. An ISO-8601 literal compares correctly against `datetimeoffset`
+     * (SQL Server) and `timestamptz` (PostgreSQL) alike.
+     */
+    private unexpiredClause(): string {
+        return `(ExpiresAt IS NULL OR ExpiresAt > '${new Date().toISOString()}')`;
+    }
+
     private resolveEntityId(entityName: string, provider?: IMetadataProvider): string | null {
         const md = provider ?? new Metadata();
         const entity = md.EntityByName(entityName);
@@ -253,7 +264,7 @@ export class AccessControlRuleProvider extends PermissionProviderBase {
     private async fetchActiveRules(entityId: string, recordId: string): Promise<AccessControlRuleRow[]> {
         return this.fetchRows<AccessControlRuleRow>(
             'MJ: Access Control Rules',
-            `EntityID='${entityId}' AND RecordID='${recordId}' AND (ExpiresAt IS NULL OR ExpiresAt > GETUTCDATE())`,
+            `EntityID='${entityId}' AND RecordID='${recordId}' AND ${this.unexpiredClause()}`,
             ACR_GRANT_FIELDS.filter((f) => f !== 'GrantedByUserID' && f !== 'Entity'),
             'fetchActiveRules'
         );

--- a/packages/PostgreSQLDataProvider/src/PostgreSQLDataProvider.ts
+++ b/packages/PostgreSQLDataProvider/src/PostgreSQLDataProvider.ts
@@ -605,7 +605,130 @@ export class PostgreSQLDataProvider extends GenericDatabaseProvider implements I
     protected override TransformExternalSQLClause(clause: string, entityInfo: EntityInfo): string {
         if (!clause || clause.length === 0) return clause;
         const quoted = this.quoteIdentifiersInSQL(clause, entityInfo);
-        return this.coerceBooleanLiteralsInSQL(quoted, entityInfo);
+        // Translate SQL Server date/time functions AFTER identifier quoting so the
+        // injected PG idioms (`AT TIME ZONE`, `INTERVAL`) are not re-quoted.
+        const dialectFns = this.translateTSQLDateFunctions(quoted);
+        return this.coerceBooleanLiteralsInSQL(dialectFns, entityInfo);
+    }
+
+    /**
+     * Translates the SQL Server date/time functions that show up in hand-written
+     * `ExtraFilter` / `OrderBy` clauses across the codebase into their PostgreSQL
+     * equivalents. PG has no `GETUTCDATE`/`GETDATE`/`DATEADD` and there is no shim
+     * function, so an untranslated clause errors with
+     * `function getutcdate() does not exist`. This is the framework backstop —
+     * app-layer call sites should prefer dialect-neutral literals, but any clause
+     * that still carries these forms is rewritten here. Covers the forms actually
+     * used in MJ filters:
+     *   - `GETUTCDATE()`           -> `(NOW() AT TIME ZONE 'UTC')`
+     *   - `SYSDATETIMEOFFSET()`    -> `NOW()`
+     *   - `GETDATE()`              -> `CURRENT_TIMESTAMP`
+     *   - `DATEADD(unit, n, expr)` -> `(expr + (n) * INTERVAL '1 <pg-unit>')`
+     *
+     * Public so it can be unit-tested directly (same convention as
+     * `autoQuoteIdentifiers`).
+     */
+    public translateTSQLDateFunctions(sql: string): string {
+        if (!sql || sql.length === 0) return sql;
+        let out = sql;
+        // Zero-arg "now" variants first, so a DATEADD's inner expression is
+        // already PG-native before the DATEADD rewrite walks it.
+        out = out.replace(/\bGETUTCDATE\s*\(\s*\)/gi, "(NOW() AT TIME ZONE 'UTC')");
+        out = out.replace(/\bSYSDATETIMEOFFSET\s*\(\s*\)/gi, 'NOW()');
+        out = out.replace(/\bGETDATE\s*\(\s*\)/gi, 'CURRENT_TIMESTAMP');
+        out = this.translateDateAdd(out);
+        return out;
+    }
+
+    /**
+     * Rewrites every `DATEADD(unit, n, expr)` occurrence using balanced-paren
+     * argument parsing (the 3rd argument can itself contain parentheses and even
+     * a nested `DATEADD`). Unknown date-parts or unparseable calls are left
+     * verbatim rather than guessed.
+     */
+    private translateDateAdd(sql: string): string {
+        const re = /\bDATEADD\s*\(/gi;
+        let result = '';
+        let cursor = 0;
+        let m: RegExpExecArray | null;
+        while ((m = re.exec(sql)) !== null) {
+            const openParen = m.index + m[0].length - 1; // index of '('
+            const parsed = this.splitBalancedArgs(sql, openParen);
+            if (!parsed || parsed.args.length !== 3) {
+                continue; // can't parse — leave this occurrence verbatim
+            }
+            const pgUnit = this.mapDatePartToPGUnit(parsed.args[0]);
+            if (!pgUnit) {
+                continue; // unknown unit — leave verbatim
+            }
+            const n = parsed.args[1].trim();
+            const expr = this.translateDateAdd(parsed.args[2].trim()); // recurse for nesting
+            const replacement = `(${expr} + (${n}) * INTERVAL '1 ${pgUnit}')`;
+            result += sql.slice(cursor, m.index) + replacement;
+            cursor = parsed.end + 1;
+            re.lastIndex = parsed.end + 1;
+        }
+        result += sql.slice(cursor);
+        return result;
+    }
+
+    /**
+     * Splits the comma-separated arguments of a function call starting at the
+     * given open-paren index, respecting nested parentheses and single-quoted
+     * string literals (with `''` escaping). Returns the trimmed-by-caller arg
+     * strings and the index of the matching close paren, or null if unbalanced.
+     */
+    private splitBalancedArgs(sql: string, openParenIndex: number): { args: string[]; end: number } | null {
+        let depth = 0;
+        let inString = false;
+        const args: string[] = [];
+        let current = '';
+        for (let i = openParenIndex; i < sql.length; i++) {
+            const ch = sql[i];
+            if (inString) {
+                current += ch;
+                if (ch === "'") {
+                    if (sql[i + 1] === "'") { current += sql[i + 1]; i++; } // escaped quote
+                    else { inString = false; }
+                }
+                continue;
+            }
+            if (ch === "'") { inString = true; current += ch; continue; }
+            if (ch === '(') {
+                depth++;
+                if (depth === 1) { continue; } // skip the outer open paren
+                current += ch;
+                continue;
+            }
+            if (ch === ')') {
+                depth--;
+                if (depth === 0) { args.push(current); return { args, end: i }; }
+                current += ch;
+                continue;
+            }
+            if (ch === ',' && depth === 1) { args.push(current); current = ''; continue; }
+            current += ch;
+        }
+        return null; // unbalanced
+    }
+
+    /**
+     * Maps a SQL Server datepart token (with the common abbreviations) to the
+     * PostgreSQL interval unit. Returns null for parts PG `INTERVAL` can't
+     * express directly (e.g. quarter) so the caller leaves the call verbatim.
+     */
+    private mapDatePartToPGUnit(part: string): string | null {
+        const p = part.trim().toLowerCase().replace(/^'|'$/g, '');
+        switch (p) {
+            case 'year': case 'yy': case 'yyyy': return 'year';
+            case 'month': case 'mm': case 'm': return 'month';
+            case 'week': case 'wk': case 'ww': return 'week';
+            case 'day': case 'dd': case 'd': return 'day';
+            case 'hour': case 'hh': return 'hour';
+            case 'minute': case 'mi': case 'n': return 'minute';
+            case 'second': case 'ss': case 's': return 'second';
+            default: return null;
+        }
     }
 
     /**

--- a/packages/PostgreSQLDataProvider/src/__tests__/translateTSQLDateFunctions.test.ts
+++ b/packages/PostgreSQLDataProvider/src/__tests__/translateTSQLDateFunctions.test.ts
@@ -1,0 +1,92 @@
+import { describe, it, expect, vi } from 'vitest';
+import { PostgreSQLDataProvider } from '../PostgreSQLDataProvider.js';
+
+// Mock pg so we can instantiate the provider without a real DB
+vi.mock('pg', () => {
+    const mockPool = {
+        connect: vi.fn().mockResolvedValue({ query: vi.fn(), release: vi.fn() }),
+        query: vi.fn().mockResolvedValue({ rows: [] }),
+        end: vi.fn().mockResolvedValue(undefined),
+    };
+    return { default: { Pool: vi.fn(() => mockPool) } };
+});
+
+/**
+ * Tests for translateTSQLDateFunctions — the runtime backstop that rewrites the
+ * SQL Server date/time functions hand-written into ExtraFilter/OrderBy clauses
+ * into PostgreSQL equivalents. PG has no GETUTCDATE/GETDATE/DATEADD and there is
+ * no shim function, so without this an untranslated clause errors with
+ * `function getutcdate() does not exist`.
+ */
+describe('PostgreSQLDataProvider.translateTSQLDateFunctions', () => {
+    const provider = new PostgreSQLDataProvider();
+    const t = (sql: string) => provider.translateTSQLDateFunctions(sql);
+
+    describe('zero-arg now() variants', () => {
+        it('translates GETUTCDATE()', () => {
+            expect(t('ExpiresAt > GETUTCDATE()')).toBe("ExpiresAt > (NOW() AT TIME ZONE 'UTC')");
+        });
+
+        it('translates GETDATE()', () => {
+            expect(t('ActiveAt <= GETDATE()')).toBe('ActiveAt <= CURRENT_TIMESTAMP');
+        });
+
+        it('translates SYSDATETIMEOFFSET()', () => {
+            expect(t('x = SYSDATETIMEOFFSET()')).toBe('x = NOW()');
+        });
+
+        it('is case-insensitive and tolerates inner whitespace', () => {
+            expect(t('getutcdate(  )')).toBe("(NOW() AT TIME ZONE 'UTC')");
+        });
+
+        it('does not touch a column whose name merely starts with the token (no parens)', () => {
+            expect(t('GetdateColumn > 5')).toBe('GetdateColumn > 5');
+        });
+    });
+
+    describe('DATEADD', () => {
+        it('translates DATEADD(day, -7, GETUTCDATE())', () => {
+            expect(t('StartedAt >= DATEADD(day, -7, GETUTCDATE())'))
+                .toBe("StartedAt >= ((NOW() AT TIME ZONE 'UTC') + (-7) * INTERVAL '1 day')");
+        });
+
+        it('translates DATEADD with a non-literal numeric expression', () => {
+            expect(t('Created < DATEADD(day, -30, GETUTCDATE())'))
+                .toBe("Created < ((NOW() AT TIME ZONE 'UTC') + (-30) * INTERVAL '1 day')");
+        });
+
+        it('maps common datepart abbreviations', () => {
+            expect(t('a > DATEADD(hh, -1, GETDATE())'))
+                .toBe("a > (CURRENT_TIMESTAMP + (-1) * INTERVAL '1 hour')");
+            expect(t('a > DATEADD(mm, 3, GETDATE())'))
+                .toBe("a > (CURRENT_TIMESTAMP + (3) * INTERVAL '1 month')");
+        });
+
+        it('leaves an unknown datepart verbatim (provable-only — no guessing)', () => {
+            // quarter has no direct PG INTERVAL unit -> left as-is
+            expect(t('a > DATEADD(quarter, -1, GETDATE())'))
+                .toBe('a > DATEADD(quarter, -1, CURRENT_TIMESTAMP)');
+        });
+
+        it('handles a nested DATEADD in the expression arg', () => {
+            expect(t('DATEADD(day, 1, DATEADD(hour, 2, GETUTCDATE()))'))
+                .toBe("(((NOW() AT TIME ZONE 'UTC') + (2) * INTERVAL '1 hour') + (1) * INTERVAL '1 day')");
+        });
+    });
+
+    describe('safety', () => {
+        it('returns empty/blank input unchanged', () => {
+            expect(t('')).toBe('');
+        });
+
+        it('leaves a clause with no T-SQL date funcs unchanged', () => {
+            expect(t("Status = 'Active' AND Name LIKE '%foo%'"))
+                .toBe("Status = 'Active' AND Name LIKE '%foo%'");
+        });
+
+        it('does not corrupt single-quoted string literals containing commas/parens', () => {
+            expect(t("Note = 'a, b (c)' AND t > GETUTCDATE()"))
+                .toBe("Note = 'a, b (c)' AND t > (NOW() AT TIME ZONE 'UTC')");
+        });
+    });
+});


### PR DESCRIPTION
## Problem
Hand-written `ExtraFilter` / `OrderBy` strings across the codebase embed SQL Server date functions — `GETUTCDATE()`, `GETDATE()`, `DATEADD(...)`. PostgreSQL has none of these and there is no shim function, so on a PG deployment the underlying `RunView` query fails at runtime with `function getutcdate() does not exist`. Most damaging is `AccessControlRuleProvider` (4 filters), which is core record-level permission resolution and runs on every deployment; also affected: the MCP dashboard 7-day log filter, entity-communication template preview, and ArchiveProcessor retention.

## Fix
Two layers:
- **Framework backstop** — `PostgreSQLDataProvider.translateTSQLDateFunctions()`, wired into `TransformExternalSQLClause` (after identifier quoting). Translates `GETUTCDATE()` → `(NOW() AT TIME ZONE 'UTC')`, `GETDATE()` → `CURRENT_TIMESTAMP`, `SYSDATETIMEOFFSET()` → `NOW()`, and `DATEADD(unit, n, expr)` via balanced-paren parsing (nested-DATEADD aware; unknown dateparts left verbatim). Covers any current or future caller.
- **Call sites** — the 4 sources now build dialect-neutral ISO-8601 cutoffs in JS instead of T-SQL.

SQL Server behavior is unchanged (the translation is PG-provider only).

## Testing
- **Unit:** 13 new tests for the translation (each form + nesting + string-literal safety); full PG-provider suite **140/140** green.
- **Live on PostgreSQL:** ran `RunView` with `GETUTCDATE`/`GETDATE`/`DATEADD(day,-7,…)` filters against a real PG database — all returned `Success=true` with no error (pre-fix these throw `function getutcdate() does not exist`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)