### PR TITLE
fix(pg): core + codegen type correctness on PostgreSQL (+ SS→PG converter TS-corruption fix)

### DIFF
--- a/migrations-pg/v5/V202606161300__v5.41.x__Fix_PG_GeneratedCode_TypeScript_Quoting.pg-only.sql
+++ b/migrations-pg/v5/V202606161300__v5.41.x__Fix_PG_GeneratedCode_TypeScript_Quoting.pg-only.sql
@@ -1,0 +1,27 @@
+-- PG-ONLY forward fix: repair TypeScript corrupted by the SS->PG baseline converter.
+--
+-- The SS->PG baseline conversion applied SQL identifier-quoting to TypeScript that is
+-- stored INSIDE data columns (__mj."GeneratedCode"."Code" — the AI-generated field
+-- validators). It rewrote TS member access like `this.GranteeType` into
+-- `this."GranteeType"`, which is invalid TypeScript. When `mj codegen` reads those
+-- validators back and emits them into entity_subclasses.ts, the generated file fails to
+-- compile (TS1003 "Identifier expected"), which blocks the entire build on a fresh PG DB.
+-- The SQL Server baseline is unaffected (it stores the TS verbatim), so this is PG-only.
+--
+-- Scope is deliberately narrow and auditable: only TypeScript rows, and only the three
+-- member-access prefixes the generated validators ever use — `this.`, `result.`, and
+-- `ValidationErrorType.`. We do NOT touch the general `."Ident"` form, because in other
+-- columns (Query SQL, view definitions, etc.) `."Ident"` is *correct* PostgreSQL identifier
+-- quoting and must be preserved. A string literal is never preceded by `<ident>."`, so
+-- these three replacements cannot corrupt legitimate string content.
+
+UPDATE ${flyway:defaultSchema}."GeneratedCode"
+SET "Code" = regexp_replace(
+               regexp_replace(
+                 regexp_replace(
+                   "Code",
+                   'this\."([A-Za-z_][A-Za-z0-9_]*)"', 'this.\1', 'g'),
+                 'result\."([A-Za-z_][A-Za-z0-9_]*)"', 'result.\1', 'g'),
+               'ValidationErrorType\."([A-Za-z_][A-Za-z0-9_]*)"', 'ValidationErrorType.\1', 'g')
+WHERE "Language" = 'TypeScript'
+  AND "Code" ~ '(this|result|ValidationErrorType)\."[A-Za-z_]';

--- a/packages/Actions/Base/src/ActionEngine-Base.ts
+++ b/packages/Actions/Base/src/ActionEngine-Base.ts
@@ -297,7 +297,7 @@ export class ActionEngineBase extends BaseEngine<ActionEngineBase> {
     private _Filters: MJActionFilterEntity[];
     private _Params: MJActionParamEntity[];
     private _ActionResultCodes: MJActionResultCodeEntity[];
-    private _ActionLibraries: MJActionLibraryEntity[];
+    private _ActionLibraries: MJActionLibraryEntity[] = [];
 
    /**
     * This method is called to configure the ActionEngine. It loads the metadata for the actions, filters, and result codes and caches them in the GlobalObjectStore. You must call this method before running any actions.

--- a/packages/CodeGenLib/src/Database/sql_codegen.ts
+++ b/packages/CodeGenLib/src/Database/sql_codegen.ts
@@ -1657,24 +1657,28 @@ export class SQLCodeGenBase {
         // that don't have native GeoLatitude/GeoLongitude fields (those get aliased directly).
         // Skip for Record Geo Codes itself to avoid circular self-reference in the view.
         if (entity.SupportsGeoCoding && !this.hasNativeGeoFields(entityFields) && entity.Name.trim().toLowerCase() !== 'mj: record geo codes') {
-            const qi = this._dbProvider.Dialect.QuoteIdentifier.bind(this._dbProvider.Dialect);
-            const qs = this._dbProvider.Dialect.QuoteSchema.bind(this._dbProvider.Dialect);
+            const dialect = this._dbProvider.Dialect;
+            const qi = dialect.QuoteIdentifier.bind(dialect);
+            const qs = dialect.QuoteSchema.bind(dialect);
             sOutput += (sOutput === '' ? '' : '\n');
 
             // Build RecordID expression that handles both single and composite primary keys.
-            // Format: for single PK → CAST(e.ID AS NVARCHAR(450))
-            //         for composite PK → e.Field1 + '||' + e.Field2 (concatenated with || separator)
+            // Dialect-aware: CastToBoundedString emits NVARCHAR(N) on SQL Server and VARCHAR(N)
+            // on PostgreSQL, and ConcatOperator() is `+` on SQL Server / `||` on PostgreSQL.
+            //   single PK    → CAST(e.ID AS <string(450)>)
+            //   composite PK → CAST(e.F1 AS <string(200)>) <concat> '||' <concat> CAST(e.F2 AS <string(200)>)
             // This must match the format used by GeoCodeSyncService when storing RecordGeoCode rows.
             const pkFields = entity.PrimaryKeys;
             let recordIdExpr: string;
             if (pkFields.length === 1) {
-                recordIdExpr = `CAST(${qi(classNameFirstChar)}.${qi(pkFields[0].Name)} AS NVARCHAR(450))`;
+                recordIdExpr = dialect.CastToBoundedString(`${qi(classNameFirstChar)}.${qi(pkFields[0].Name)}`, 450);
             } else {
-                // Composite key: concatenate all PK values with || separator
+                // Composite key: concatenate all PK values with a '||' separator literal
+                const concat = dialect.ConcatOperator();
                 const parts = pkFields.map(pk =>
-                    `CAST(${qi(classNameFirstChar)}.${qi(pk.Name)} AS NVARCHAR(200))`
+                    dialect.CastToBoundedString(`${qi(classNameFirstChar)}.${qi(pk.Name)}`, 200)
                 );
-                recordIdExpr = parts.join(` + '||' + `);
+                recordIdExpr = parts.join(` ${concat} '||' ${concat} `);
             }
 
             sOutput += `LEFT OUTER JOIN\n    ${qs(mjCoreSchema, 'vwRecordGeoCodes')} AS __mj_rgc\n  ON\n    __mj_rgc.${qi('EntityID')} = '${entity.ID}'\n    AND __mj_rgc.${qi('RecordID')} = ${recordIdExpr}\n    AND __mj_rgc.${qi('LocationType')} = 'Primary'`;

--- a/packages/CodeGenLib/src/Misc/action_subclasses_codegen.ts
+++ b/packages/CodeGenLib/src/Misc/action_subclasses_codegen.ts
@@ -19,7 +19,9 @@ export class ActionSubClassGeneratorBase {
         // get all of the libraries from the combination of distinct libraries from all of the actions we have here
         const allActionLibraries: {Library: string, LibraryID: string, ItemsUsedArray: string[]}[] = [];
         actions.forEach(action => {
-            action.Libraries.forEach(lib => {
+            // Libraries can be undefined if the engine cache hasn't populated it
+            // (e.g. accessed before/around Config); guard rather than crash codegen.
+            action.Libraries?.forEach(lib => {
                 if (!allActionLibraries.find(l => UUIDsEqual(l.LibraryID, lib.LibraryID))) {
                     allActionLibraries.push({
                         Library: lib.Library ?? '',

--- a/packages/MJCore/src/__tests__/entityInfo.tsTypeAndDerived.test.ts
+++ b/packages/MJCore/src/__tests__/entityInfo.tsTypeAndDerived.test.ts
@@ -72,6 +72,29 @@ describe('EntityFieldInfo.TSType — every distinct SQL-type branch', () => {
     });
 });
 
+describe('EntityFieldInfo.IsUniqueIdentifier — SQL Server + PostgreSQL type names', () => {
+    it('is true for SQL Server uniqueidentifier', () => {
+        expect(makeField('uniqueidentifier').IsUniqueIdentifier).toBe(true);
+    });
+
+    it('is true for PostgreSQL uuid (the regression this guards)', () => {
+        // On PG the metadata Type is reported as `uuid`; a uniqueidentifier-only
+        // check would miss every UUID PK and break NewRecord() UUID generation.
+        expect(makeField('uuid').IsUniqueIdentifier).toBe(true);
+    });
+
+    it('is case- and whitespace-insensitive', () => {
+        expect(makeField('  UUID ').IsUniqueIdentifier).toBe(true);
+        expect(makeField('UNIQUEIDENTIFIER').IsUniqueIdentifier).toBe(true);
+    });
+
+    it('is false for non-GUID types', () => {
+        expect(makeField('nvarchar').IsUniqueIdentifier).toBe(false);
+        expect(makeField('int').IsUniqueIdentifier).toBe(false);
+        expect(makeField('varchar').IsUniqueIdentifier).toBe(false);
+    });
+});
+
 describe('EntityInfo.FieldByName — lookup edge cases', () => {
     function entity(): EntityInfo {
         return new EntityInfo({

--- a/packages/MJCore/src/generic/baseEntity.ts
+++ b/packages/MJCore/src/generic/baseEntity.ts
@@ -369,8 +369,9 @@ export class EntityField {
                     this.Value = null;
                 }
             }
-            else if (fieldInfo.Type.trim().toLowerCase() === "uniqueidentifier") {
-                // special handling for GUIDs, we don't want to populate anything here because the server always sets the value, leave blank
+            else if (fieldInfo.IsUniqueIdentifier) {
+                // special handling for GUIDs (SQL Server `uniqueidentifier` / PostgreSQL `uuid`),
+                // we don't want to populate anything here because the server always sets the value, leave blank
                 this.Value = null;
             }
             else if (fieldInfo.TSType === EntityFieldTSType.Date) {
@@ -2205,11 +2206,12 @@ export abstract class BaseEntity<T = unknown> {
         this._childEntity = null;
         this._childEntities = null;
         this._childEntityDiscoveryDone = false;
-        // Generate UUID for non-auto-increment uniqueidentifier primary keys
+        // Generate UUID for non-auto-increment GUID/UUID primary keys
+        // (SQL Server `uniqueidentifier` / PostgreSQL `uuid`)
         if (this.EntityInfo.PrimaryKeys.length === 1) {
             const pk = this.EntityInfo.PrimaryKeys[0];
             if (!pk.AutoIncrement &&
-                pk.Type.toLowerCase().trim() === 'uniqueidentifier' &&
+                pk.IsUniqueIdentifier &&
                 !this.Get(pk.Name)) {
                 // Generate and set UUID for this primary key
                 const uuid = uuidv4();

--- a/packages/MJCore/src/generic/entityInfo.ts
+++ b/packages/MJCore/src/generic/entityInfo.ts
@@ -1083,10 +1083,14 @@ export class EntityFieldInfo extends BaseInfo {
     }
 
     /**
-     * Returns true if the field is a uniqueidentifier in the database.
+     * Returns true if the field is a GUID/UUID column in the database.
+     * Accepts both the SQL Server type name (`uniqueidentifier`) and the
+     * PostgreSQL type name (`uuid`) — on PG the metadata `Type` is reported as
+     * `uuid`, so a `uniqueidentifier`-only check would miss every UUID column.
      */
     get IsUniqueIdentifier(): boolean {
-        return this.Type.trim().toLowerCase() === 'uniqueidentifier';
+        const t = this.Type.trim().toLowerCase();
+        return t === 'uniqueidentifier' || t === 'uuid';
     }
 
     /**

--- a/packages/SQLConverter/src/__tests__/PostProcessor.test.ts
+++ b/packages/SQLConverter/src/__tests__/PostProcessor.test.ts
@@ -626,4 +626,39 @@ describe('postProcess', () => {
       expect(result).toContain('=TRUE');
     });
   });
+
+  // ============================================================
+  // schema.PascalCase quoting must NOT reach into string literals
+  // (regression: TypeScript stored in GeneratedCode.Code / Action.Code
+  //  INSERT VALUES had `this.GranteeType` rewritten to `this."GranteeType"`,
+  //  producing invalid TS that broke the build on a fresh PostgreSQL DB)
+  // ============================================================
+  describe('schema.PascalCase quoting skips string literals', () => {
+    it('still quotes a real schema.Table reference in code', () => {
+      expect(postProcess('SELECT * FROM __mj.OpenApp')).toContain('__mj."OpenApp"');
+    });
+
+    it('still quotes a quoted-schema.PascalCase reference in code', () => {
+      expect(postProcess('SELECT * FROM "app".MyTable')).toContain('"app"."MyTable"');
+    });
+
+    it('does NOT quote TypeScript member access inside a single-quoted string literal', () => {
+      const input = `INSERT INTO __mj.GeneratedCode ("Code") VALUES ('if (!allowedValues.includes(this.GranteeType)) { result.Errors.push(ValidationErrorType.Failure); }');`;
+      const result = postProcess(input);
+      expect(result).toContain('this.GranteeType');
+      expect(result).toContain('result.Errors');
+      expect(result).toContain('ValidationErrorType.Failure');
+      expect(result).not.toContain('this."GranteeType"');
+      expect(result).not.toContain('result."Errors"');
+    });
+
+    it('does NOT quote arbitrary accessors (params., p.) inside a string literal', () => {
+      const input = `INSERT INTO __mj.Action ("Code") VALUES ('const name = params.Params.find(p => p.Name === ''x'')?.Value;');`;
+      const result = postProcess(input);
+      expect(result).toContain('params.Params');
+      expect(result).toContain('p.Name');
+      expect(result).not.toContain('params."Params"');
+      expect(result).not.toContain('p."Name"');
+    });
+  });
 });

--- a/packages/SQLConverter/src/rules/PostProcessor.ts
+++ b/packages/SQLConverter/src/rules/PostProcessor.ts
@@ -7,6 +7,7 @@
  */
 
 import { createHash } from 'node:crypto';
+import { transformCodeOnly } from './ExpressionHelpers.js';
 
 /**
  * Final cleanup pass on the complete converted SQL output.
@@ -226,10 +227,22 @@ export function postProcess(sql: string): string {
   // Quote unquoted table names after any schema prefix (PascalCase identifiers)
   // e.g., __mj.OpenApp → __mj."OpenApp"   but NOT __mj."OpenApp" (already quoted)
   // Also skip all-lowercase names like __mj.information_schema
-  sql = sql.replace(/(\b\w+)\.(?!")([A-Z][a-zA-Z_]\w*)/g, '$1."$2"');
+  //
+  // transformCodeOnly is REQUIRED here: these regexes match `<word>.<PascalCase>`,
+  // which also occurs inside single-quoted string literals that carry TypeScript
+  // code (e.g. `GeneratedCode.Code` / `Action.Code` INSERT VALUES contain
+  // `this.GranteeType`, `result.Errors`, `params.Params`). Without skipping string
+  // literals, those TS member accesses get rewritten to `this."GranteeType"` etc.,
+  // producing invalid TypeScript that breaks the build when CodeGen re-emits it.
+  // A SQL->SQL converter must treat string-literal content as opaque data.
+  sql = transformCodeOnly(sql, (code) =>
+    code.replace(/(\b\w+)\.(?!")([A-Z][a-zA-Z_]\w*)/g, '$1."$2"')
+  );
 
   // Also handle quoted schema: "schema".PascalCase → "schema"."PascalCase"
-  sql = sql.replace(/"(\w+)"\.(?!")([A-Z][a-zA-Z_]\w*)/g, '"$1"."$2"');
+  sql = transformCodeOnly(sql, (code) =>
+    code.replace(/"(\w+)"\.(?!")([A-Z][a-zA-Z_]\w*)/g, '"$1"."$2"')
+  );
 
   // ISNULL → COALESCE (SQL Server function)
   sql = sql.replace(/\bISNULL\s*\(/gi, 'COALESCE(');


### PR DESCRIPTION
## Summary
Three related PostgreSQL correctness items. The **headline, build-breaking fix** is the SS→PG converter corrupting TypeScript stored in data columns; the other two are smaller correctness/parity items, scoped honestly below.

## 1. SS→PG converter corrupts TypeScript in data columns — the real bug (build-breaking)
`PostProcessor`'s `schema.PascalCase` quoting ran two global regexes over the entire converted output with **no string-literal protection**. They rewrote `<word>.<PascalCase>` member access **inside single-quoted string literals** — the TypeScript stored in `GeneratedCode.Code` (AI-generated field validators) and `Action.Code` — turning `this.GranteeType` into `this."GranteeType"`. When CodeGen re-emits those validators into `entity_subclasses.ts`, `tsc` fails with TS1003 and the entire build breaks on a fresh PostgreSQL DB.

**Fix:** wrap both replacements in `transformCodeOnly` so they skip single-quoted string literals (and dollar/comment segments) while still quoting real DDL/plpgsql `schema.Table` references. A SQL→SQL converter must treat string-literal content as opaque data. A **PG-only forward-fix migration** also repairs the already-shipped v5.38 baseline's corrupted `GeneratedCode` validators (narrowly scoped to `Language='TypeScript'` rows and the 3 accessor prefixes the validators use — `this.` / `result.` / `ValidationErrorType.`; the general `."Ident"` form is deliberately untouched because elsewhere it is correct PG quoting).

**Verified live on PostgreSQL:**
- Unfixed converter → **409** corrupted accessors on a single GeneratedCode INSERT; fixed → **0**.
- Re-converting the full v5.38 SS baseline: `this."`/`result."`/`params."` drop **296+ → 0**, while real DDL quoting is fully intact (325 `CREATE TABLE __mj."..."`, 3030 `__mj."vw..."` refs).
- Forward-fix end-to-end: corrupted `GeneratedCode` rows **456 → 0**, codegen re-emits `entity_subclasses.ts` clean, and `@memberjunction/core-entities` builds with **zero TS errors** (was hundreds of TS1003).
- Unit: **PostProcessor 63/63** (+4 new regression tests). The 4 pre-existing `pg-migration-regression` failures are unrelated (fail identically with/without this change).

## 2. Geocoding view generator hardcodes NVARCHAR — real but DORMANT
`sql_codegen.ts` built the geo RecordID expression with hardcoded `CAST(... AS NVARCHAR(...))` + T-SQL `+` concat. On PG, `CAST(... AS NVARCHAR)` fails (`type "nvarchar" does not exist`), so view generation would crash — **but only for entities with `SupportsGeoCoding=1`, which defaults to 0**, so it is dormant on a stock install. Fixed to use dialect helpers (`CastToBoundedString` → `NVARCHAR`/`VARCHAR`, `ConcatOperator` → `+`/`||`).

## 3. `uuid` type recognition — parity/robustness, NOT an active crash-fix
PG reports a GUID PK's metadata `Type` as `uuid`, not `uniqueidentifier`. `entityInfo.IsUniqueIdentifier` and the two `baseEntity` GUID paths (field-init + `NewRecord()` UUID generation) only matched `uniqueidentifier`, so client-side PK generation was skipped on PG. This PR makes them accept both.

**Honest scope:** this does **not** fix an active insert failure. On this PG database **348 of 350** UUID PK columns carry a `gen_random_uuid()` DB default (so the insert succeeds without client-side generation), and the 2 without it (`ArtifactType`, `AIVendorTypeDefinition`) are lookup tables seeded with explicit IDs. The original "AIAgentRun insert fails on PG" report was a **false positive**. The fix is still correct — it restores SQL-Server-parity client-side PK generation and removes a fragile dependency on the metadata default — but it is a robustness/parity improvement, not a crash-fix. (A live AI agent run did create an `MJ: AI Agent Runs` row with a valid UUID PK on PG, confirming entity creation works.)

Also includes a trivial defensive null-guard on the action-subclass codegen `Libraries.forEach`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)