### PR TITLE
feat(openapp): PostgreSQL support for app schema install + migrations

### DIFF
--- a/packages/OpenApp/Engine/src/__tests__/schema-validation.test.ts
+++ b/packages/OpenApp/Engine/src/__tests__/schema-validation.test.ts
@@ -2,8 +2,8 @@
  * Tests for schema name validation, including the double-underscore override.
  */
 import { describe, it, expect, vi } from 'vitest';
-import type { DatabaseProviderBase } from '@memberjunction/core';
-import { CreateAppSchema, ValidateSchemaName } from '../install/schema-manager.js';
+import type { DatabaseProviderBase, DatabasePlatform } from '@memberjunction/core';
+import { CreateAppSchema, DropAppSchema, SchemaExists, ValidateSchemaName } from '../install/schema-manager.js';
 
 describe('ValidateSchemaName', () => {
     it('accepts a normal schema name', () => {
@@ -44,14 +44,20 @@ describe('ValidateSchemaName', () => {
  * queue, then empty. Lets us simulate "schema does not yet exist" for the
  * existence check, followed by a no-op for CREATE SCHEMA.
  */
-function makeMockProvider(sqlResults: Array<Array<Record<string, unknown>>>): {
+function makeMockProvider(
+    sqlResults: Array<Array<Record<string, unknown>>>,
+    platform: DatabasePlatform = 'sqlserver'
+): {
     provider: DatabaseProviderBase;
     executeSql: ReturnType<typeof vi.fn>;
 } {
     const queue = [...sqlResults];
     const executeSql = vi.fn(async () => queue.shift() ?? []);
-    // Only the ExecuteSQL surface is used by CreateAppSchema.
-    return { provider: { ExecuteSQL: executeSql } as unknown as DatabaseProviderBase, executeSql };
+    // ExecuteSQL + Dialect.PlatformKey are the surfaces used by the schema-manager.
+    return {
+        provider: { ExecuteSQL: executeSql, Dialect: { PlatformKey: platform } } as unknown as DatabaseProviderBase,
+        executeSql,
+    };
 }
 
 describe('CreateAppSchema with allowDoubleUnderscore override', () => {
@@ -96,5 +102,61 @@ describe('CreateAppSchema with allowDoubleUnderscore override', () => {
         const result = await CreateAppSchema('bcsaas', provider);
         expect(result.Success).toBe(false);
         expect(result.ErrorMessage).toMatch(/already exists/);
+    });
+});
+
+describe('SchemaExists — ANSI information_schema (dialect-neutral)', () => {
+    it('queries information_schema.schemata, not the SQL-Server-only sys.schemas', async () => {
+        const { provider, executeSql } = makeMockProvider([[]], 'postgresql');
+        await SchemaExists('bcsaas', provider);
+        const sql = executeSql.mock.calls[0][0] as string;
+        expect(sql).toContain('information_schema.schemata');
+        expect(sql).toContain('schema_name');
+        expect(sql).not.toContain('sys.schemas');
+    });
+});
+
+describe('CreateAppSchema — dialect-aware identifier quoting', () => {
+    it('SQL Server quotes with [brackets]', async () => {
+        const { provider, executeSql } = makeMockProvider([[]], 'sqlserver');
+        const result = await CreateAppSchema('bcsaas', provider);
+        expect(result.Success).toBe(true);
+        expect(executeSql.mock.calls[1][0] as string).toBe('CREATE SCHEMA [bcsaas]');
+    });
+
+    it('PostgreSQL quotes with "double quotes"', async () => {
+        const { provider, executeSql } = makeMockProvider([[]], 'postgresql');
+        const result = await CreateAppSchema('bcsaas', provider);
+        expect(result.Success).toBe(true);
+        expect(executeSql.mock.calls[1][0] as string).toBe('CREATE SCHEMA "bcsaas"');
+    });
+});
+
+describe('DropAppSchema — PostgreSQL CASCADE vs SQL Server object-drop', () => {
+    it('PostgreSQL uses a single DROP SCHEMA ... CASCADE (no sys.* object enumeration)', async () => {
+        // [0] existence probe returns a row (exists), then [1] the DROP.
+        const { provider, executeSql } = makeMockProvider([[{ Exists_: 1 }]], 'postgresql');
+        const result = await DropAppSchema('bcsaas', provider);
+        expect(result.Success).toBe(true);
+        // Exactly two calls: existence check + the cascading drop.
+        expect(executeSql).toHaveBeenCalledTimes(2);
+        expect(executeSql.mock.calls[1][0] as string).toBe('DROP SCHEMA "bcsaas" CASCADE');
+        // No T-SQL catalog enumeration on PG.
+        for (const call of executeSql.mock.calls) {
+            expect(call[0] as string).not.toContain('sys.');
+            expect(call[0] as string).not.toContain('sp_executesql');
+        }
+    });
+
+    it('SQL Server empties the schema first (sys.* drops), then DROP SCHEMA without CASCADE', async () => {
+        // [0] existence probe (exists) + 7 object-drop batches + final DROP SCHEMA.
+        const { provider, executeSql } = makeMockProvider([[{ Exists_: 1 }]], 'sqlserver');
+        const result = await DropAppSchema('bcsaas', provider);
+        expect(result.Success).toBe(true);
+        const allSql = executeSql.mock.calls.map((c) => c[0] as string).join('\n');
+        expect(allSql).toContain('sp_executesql'); // object-drop batches ran
+        const lastSql = executeSql.mock.calls[executeSql.mock.calls.length - 1][0] as string;
+        expect(lastSql).toBe('DROP SCHEMA [bcsaas]');
+        expect(lastSql).not.toContain('CASCADE');
     });
 });

--- a/packages/OpenApp/Engine/src/install/install-orchestrator.ts
+++ b/packages/OpenApp/Engine/src/install/install-orchestrator.ts
@@ -944,6 +944,8 @@ async function HandleMigrations(manifest: MJAppManifest, context: OrchestratorCo
     DatabaseConfig: context.DatabaseConfig,
     MJCoreSchema: context.MJCoreSchema,
     ExtraPlaceholders: context.MigrationPlaceholders,
+    // Select the Skyway provider matching the live DB platform.
+    Platform: context.DatabaseProvider.Dialect.PlatformKey,
   });
 
   return { Success: migrationResult.Success, ErrorMessage: migrationResult.ErrorMessage };

--- a/packages/OpenApp/Engine/src/install/migration-runner.ts
+++ b/packages/OpenApp/Engine/src/install/migration-runner.ts
@@ -9,6 +9,7 @@
  * `@skyway/core` is not installed (e.g. in CI builds that don't need it).
  */
 import path from 'node:path';
+import type { DatabasePlatform } from '@memberjunction/core';
 
 /**
  * Minimal type definition for Skyway config so we don't need
@@ -66,6 +67,12 @@ export interface MigrationRunOptions {
     MJCoreSchema?: string;
     /** Extra user placeholders merged into Skyway's Placeholders map. Overrides built-ins on key collision. */
     ExtraPlaceholders?: Record<string, string>;
+    /**
+     * Target database platform. Selects the Skyway provider
+     * (`@memberjunction/skyway-sqlserver` vs `@memberjunction/skyway-postgres`).
+     * Defaults to `'sqlserver'` for backward compatibility.
+     */
+    Platform?: DatabasePlatform;
 }
 
 /**
@@ -124,22 +131,19 @@ export interface MigrationRunResult {
  */
 export async function RunAppMigrations(options: MigrationRunOptions): Promise<MigrationRunResult> {
     const { MigrationsDir, SchemaName, DatabaseConfig, Verbose, MJCoreSchema, ExtraPlaceholders } = options;
+    const platform: DatabasePlatform = options.Platform ?? 'sqlserver';
 
     let skyway: SkywayInstance | undefined;
 
     try {
         // Use variables to prevent TypeScript from resolving the modules at compile time.
-        // @memberjunction/skyway-core + @memberjunction/skyway-sqlserver are published
-        // as dependencies of the host process (e.g. MJCLI).
+        // The skyway provider packages are published as (optional) dependencies of the
+        // host process (e.g. MJCLI). Install the one matching the target platform.
         const skywayModuleId = '@memberjunction/skyway-core';
-        const sqlServerProviderModuleId = '@memberjunction/skyway-sqlserver';
         const { Skyway } = await import(skywayModuleId);
-        const { SqlServerProvider } = await import(sqlServerProviderModuleId);
-        const config = BuildSkywayConfig(MigrationsDir, SchemaName, DatabaseConfig, MJCoreSchema, ExtraPlaceholders);
-        // Skyway 0.6.x requires an explicit provider. OpenApp migrations target
-        // SQL Server (Azure auto-detection is SQL-Server-specific), so we always
-        // attach the SqlServerProvider here.
-        config.Provider = new SqlServerProvider(config.Database);
+        const config = BuildSkywayConfig(MigrationsDir, SchemaName, DatabaseConfig, MJCoreSchema, ExtraPlaceholders, platform);
+        // Skyway 0.6.x requires an explicit provider, selected by platform.
+        config.Provider = await CreateSkywayProvider(platform, config.Database);
 
         if (Verbose) {
             console.log(`Running Skyway migrations for schema '${SchemaName}'`);
@@ -180,6 +184,34 @@ export async function RunAppMigrations(options: MigrationRunOptions): Promise<Mi
 }
 
 /**
+ * Creates the Skyway database provider matching the target platform. The
+ * provider packages are optional peer dependencies of the host process —
+ * install the one matching your database. Mirrors MJCLI's `createSkywayProvider`.
+ */
+async function CreateSkywayProvider(platform: DatabasePlatform, dbConfig: SkywayConfig['Database']): Promise<unknown> {
+    if (platform === 'postgresql') {
+        const postgresProviderModuleId = '@memberjunction/skyway-postgres';
+        try {
+            const { PostgresProvider } = await import(postgresProviderModuleId);
+            return new PostgresProvider(dbConfig);
+        } catch {
+            throw new Error(
+                'PostgreSQL provider not found. Install @memberjunction/skyway-postgres to run Open App migrations against PostgreSQL.'
+            );
+        }
+    }
+    const sqlServerProviderModuleId = '@memberjunction/skyway-sqlserver';
+    try {
+        const { SqlServerProvider } = await import(sqlServerProviderModuleId);
+        return new SqlServerProvider(dbConfig);
+    } catch {
+        throw new Error(
+            'SQL Server provider not found. Install @memberjunction/skyway-sqlserver to run Open App migrations against SQL Server.'
+        );
+    }
+}
+
+/**
  * Builds the SkywayConfig for running app migrations.
  */
 function BuildSkywayConfig(
@@ -187,14 +219,17 @@ function BuildSkywayConfig(
     schemaName: string,
     dbConfig: SkywayDatabaseConfig,
     mjCoreSchema?: string,
-    extraPlaceholders?: Record<string, string>
+    extraPlaceholders?: Record<string, string>,
+    platform: DatabasePlatform = 'sqlserver'
 ): SkywayConfig {
     const absoluteDir = path.isAbsolute(migrationsDir)
         ? migrationsDir
         : path.resolve(migrationsDir);
 
-    // Auto-detect Azure SQL: if host ends with .database.windows.net, encrypt is required
-    const isAzureSql = dbConfig.Host.includes('.database.windows.net');
+    // Azure SQL auto-detection is SQL-Server-specific (host ends with
+    // .database.windows.net → encryption required). For PostgreSQL the encrypt/
+    // trust flags are honored as provided and never Azure-inferred.
+    const isAzureSql = platform === 'sqlserver' && dbConfig.Host.includes('.database.windows.net');
     const encrypt = dbConfig.Encrypt ?? isAzureSql;
     const trustCert = dbConfig.TrustServerCertificate ?? !isAzureSql;
 

--- a/packages/OpenApp/Engine/src/install/schema-manager.ts
+++ b/packages/OpenApp/Engine/src/install/schema-manager.ts
@@ -81,8 +81,11 @@ export async function SchemaExists(
   schemaName: string,
   provider: DatabaseProviderBase
 ): Promise<boolean> {
+  // information_schema.schemata is ANSI-standard and present on both SQL Server
+  // and PostgreSQL, so schema existence needs no dialect branch (sys.schemas is
+  // SQL-Server-only and errors on PG).
   const results = await provider.ExecuteSQL<Record<string, unknown>>(
-    `SELECT 1 AS Exists_ FROM sys.schemas WHERE name = '${EscapeSqlString(schemaName)}'`
+    `SELECT 1 AS Exists_ FROM information_schema.schemata WHERE schema_name = '${EscapeSqlString(schemaName)}'`
   );
   return results.length > 0;
 }
@@ -113,7 +116,7 @@ export async function CreateAppSchema(
   }
 
   try {
-    await provider.ExecuteSQL(`CREATE SCHEMA [${EscapeSqlIdentifier(schemaName)}]`);
+    await provider.ExecuteSQL(`CREATE SCHEMA ${QuoteSchemaIdentifier(schemaName, provider)}`);
     return { Success: true };
   }
   catch (error: unknown) {
@@ -148,9 +151,14 @@ export async function DropAppSchema(
   }
 
   try {
-    // Drop all objects in the schema first (SQL Server doesn't support CASCADE on DROP SCHEMA)
-    await DropAllSchemaObjects(schemaName, provider);
-    await provider.ExecuteSQL(`DROP SCHEMA [${EscapeSqlIdentifier(schemaName)}]`);
+    if (provider.Dialect.PlatformKey === 'postgresql') {
+      // PostgreSQL supports CASCADE: drop the schema and everything it contains atomically.
+      await provider.ExecuteSQL(`DROP SCHEMA ${QuoteSchemaIdentifier(schemaName, provider)} CASCADE`);
+    } else {
+      // SQL Server has no CASCADE on DROP SCHEMA — the schema must be emptied first.
+      await DropAllSchemaObjects(schemaName, provider);
+      await provider.ExecuteSQL(`DROP SCHEMA ${QuoteSchemaIdentifier(schemaName, provider)}`);
+    }
     return { Success: true };
   }
   catch (error: unknown) {
@@ -164,7 +172,11 @@ export async function DropAppSchema(
 
 /**
  * Drops all objects within a schema before the schema itself can be dropped.
- * SQL Server requires schemas to be empty before they can be dropped.
+ * SQL-Server-only: SQL Server requires schemas to be empty before they can be
+ * dropped (it has no `DROP SCHEMA ... CASCADE`). PostgreSQL uses native CASCADE
+ * in {@link DropAppSchema} and never calls this. The generated T-SQL here
+ * (sys.* catalogs, QUOTENAME, sp_executesql) is therefore intentionally
+ * SQL-Server-specific.
  *
  * Uses QUOTENAME() for all dynamic identifiers in generated SQL to prevent
  * injection via object names. The schema name is passed as a parameterized
@@ -245,8 +257,13 @@ export function EscapeSqlString(value: string): string {
 }
 
 /**
- * Escapes a string for use as a SQL identifier (within square brackets).
+ * Quotes a schema name as a SQL identifier for the provider's dialect, escaping
+ * the dialect's own quote character. SQL Server -> `[name]` (`]` doubled);
+ * PostgreSQL -> `"name"` (`"` doubled).
  */
-function EscapeSqlIdentifier(value: string): string {
-  return value.replace(/\]/g, ']]');
+function QuoteSchemaIdentifier(value: string, provider: DatabaseProviderBase): string {
+  if (provider.Dialect.PlatformKey === 'postgresql') {
+    return `"${value.replace(/"/g, '""')}"`;
+  }
+  return `[${value.replace(/\]/g, ']]')}]`;
 }


### PR DESCRIPTION
## Problem
`mj app install` was hard-bound to SQL Server and could not create/drop an app schema or run app migrations on PostgreSQL:
- `schema-manager.ts` used the SQL-Server-only `sys.schemas` for existence, `[bracket]` quoting for `CREATE SCHEMA`, and a `QUOTENAME`/`sp_executesql`/`NVARCHAR`/`sys.*` object-drop teardown for `DROP SCHEMA`.
- `migration-runner.ts` unconditionally attached `SqlServerProvider`, with Azure-SQL encrypt auto-detection applied regardless of platform.

The first failure on PG is `SchemaExists` querying `sys.schemas` (relation does not exist).

## Fix
- `SchemaExists` uses ANSI `information_schema.schemata` (present on both dialects).
- `CreateAppSchema` / `DropAppSchema` quote via a dialect-aware `QuoteSchemaIdentifier` (`[name]` on SS, `"name"` on PG).
- `DropAppSchema` uses native `DROP SCHEMA ... CASCADE` on PostgreSQL; the SQL-Server object-drop path is kept and documented as SS-only.
- `migration-runner` adds a `Platform` option and selects the Skyway provider accordingly (`@memberjunction/skyway-postgres` vs `-sqlserver`), mirroring MJCLI; Azure auto-detect is gated to SQL Server. The orchestrator threads the live platform from `context.DatabaseProvider.Dialect.PlatformKey`.

## Testing
- **Unit:** new dialect-aware schema-manager tests (existence via information_schema, `[..]` vs `".."` quoting, PG CASCADE vs SS object-drop); full OpenApp engine suite **149/149** (existing mocks updated for the new `Dialect` surface).
- **Live on PostgreSQL:** end-to-end through the engine — `CreateAppSchema` (`CREATE SCHEMA "x"`) → `SchemaExists` true → `DropAppSchema` (`DROP SCHEMA "x" CASCADE`) → `SchemaExists` false.

🤖 Generated with [Claude Code](https://claude.com/claude-code)