### PR TITLE
feat(dbautodoc): dialect-aware description write-back for PostgreSQL

### DIFF
--- a/packages/DBAutoDoc/src/__tests__/SQLGenerator.test.ts
+++ b/packages/DBAutoDoc/src/__tests__/SQLGenerator.test.ts
@@ -147,4 +147,46 @@ describe('SQLGenerator', () => {
       expect(sql).toContain("@level1name = N'Users'");
     });
   });
+
+  describe('PostgreSQL provider — COMMENT ON (no sp_addextendedproperty / no GO)', () => {
+    it('emits COMMENT ON SCHEMA/TABLE/COLUMN with double-quoted identifiers', () => {
+      const sql = generator.generate(createState(), { provider: 'postgresql' });
+
+      expect(sql).toContain(`COMMENT ON SCHEMA "dbo" IS 'Default schema';`);
+      expect(sql).toContain(`COMMENT ON TABLE "dbo"."Users" IS 'Stores user accounts';`);
+      expect(sql).toContain(`COMMENT ON COLUMN "dbo"."Users"."ID" IS 'Primary key identifier';`);
+    });
+
+    it('does not emit any SQL Server T-SQL on the PG path', () => {
+      const sql = generator.generate(createState(), { provider: 'postgresql' });
+
+      expect(sql).not.toContain('sp_addextendedproperty');
+      expect(sql).not.toContain('sp_dropextendedproperty');
+      expect(sql).not.toContain('sys.extended_properties');
+      // No GO batch separators on PostgreSQL.
+      expect(sql.split('\n')).not.toContain('GO');
+    });
+
+    it('escapes single quotes in the comment literal', () => {
+      const state = createState();
+      state.schemas[0].tables[0].description = "User's account data";
+      const sql = generator.generate(state, { provider: 'postgresql' });
+
+      expect(sql).toContain(`COMMENT ON TABLE "dbo"."Users" IS 'User''s account data';`);
+    });
+
+    it('escapes embedded double quotes in identifiers', () => {
+      const state = createState();
+      state.schemas[0].tables[0].name = 'We"ird';
+      const sql = generator.generate(state, { provider: 'postgresql' });
+
+      expect(sql).toContain(`COMMENT ON TABLE "dbo"."We""ird"`);
+    });
+
+    it('defaults to the SQL Server form when no provider is given', () => {
+      const sql = generator.generate(createState());
+      expect(sql).toContain('sp_addextendedproperty');
+      expect(sql).not.toContain('COMMENT ON');
+    });
+  });
 });

--- a/packages/DBAutoDoc/src/commands/export.ts
+++ b/packages/DBAutoDoc/src/commands/export.ts
@@ -95,10 +95,13 @@ export default class Export extends Command {
       const generateCSV = flags.csv;
       const generateMermaid = flags.mermaid;
 
-      // Prepare generator options
+      // Prepare generator options. The SQL generator is dialect-aware (PostgreSQL
+      // emits COMMENT ON; SQL Server emits sp_addextendedproperty), so pass the
+      // configured provider through; defaults to 'sqlserver' when no config.
       const generatorOptions = {
         approvedOnly: flags['approved-only'],
-        confidenceThreshold: parseFloat(flags['confidence-threshold'])
+        confidenceThreshold: parseFloat(flags['confidence-threshold']),
+        provider: (config?.database?.provider as 'sqlserver' | 'mysql' | 'postgresql' | 'oracle') || 'sqlserver'
       };
 
       // Generate SQL

--- a/packages/DBAutoDoc/src/commands/init.ts
+++ b/packages/DBAutoDoc/src/commands/init.ts
@@ -19,9 +19,17 @@ export default class Init extends Command {
     // Database configuration
     const dbAnswers = await inquirer.prompt([
       {
+        type: 'list',
+        name: 'provider',
+        message: 'Database platform:',
+        choices: ['sqlserver', 'postgresql', 'mysql', 'oracle'],
+        default: 'sqlserver',
+        loop: false
+      },
+      {
         type: 'input',
         name: 'server',
-        message: 'SQL Server host:',
+        message: 'Database host:',
         default: 'localhost'
       },
       {
@@ -46,21 +54,26 @@ export default class Init extends Command {
         type: 'confirm',
         name: 'encrypt',
         message: 'Use encryption?',
-        default: true
+        default: true,
+        when: (answers: any) => answers.provider === 'sqlserver'
       },
       {
         type: 'confirm',
         name: 'trustServerCertificate',
         message: 'Trust server certificate?',
-        default: false
+        default: false,
+        when: (answers: any) => answers.provider === 'sqlserver'
       }
     ]);
+    // Default connection port per platform.
+    const defaultPort: Record<string, number> = { sqlserver: 1433, postgresql: 5432, mysql: 3306, oracle: 1521 };
 
     // Test connection
     this.log(chalk.yellow('\nTesting database connection...'));
     const dbConfig = {
-      provider: 'sqlserver' as const,
+      provider: dbAnswers.provider as 'sqlserver' | 'mysql' | 'postgresql' | 'oracle',
       host: dbAnswers.server,
+      port: defaultPort[dbAnswers.provider] ?? 1433,
       database: dbAnswers.database,
       user: dbAnswers.user,
       password: dbAnswers.password,
@@ -190,8 +203,9 @@ export default class Init extends Command {
 
     // Update with user inputs
     config.database = {
+      provider: dbAnswers.provider,
       server: dbAnswers.server,
-      port: 1433,
+      port: defaultPort[dbAnswers.provider] ?? 1433,
       database: dbAnswers.database,
       user: dbAnswers.user,
       password: dbAnswers.password,

--- a/packages/DBAutoDoc/src/generators/SQLGenerator.ts
+++ b/packages/DBAutoDoc/src/generators/SQLGenerator.ts
@@ -1,12 +1,26 @@
 /**
- * Generates SQL scripts with sp_addextendedproperty statements
+ * Generates SQL scripts that write object descriptions back to the database.
+ *
+ * Dialect-aware:
+ *  - SQL Server: `sp_addextendedproperty` / `sp_dropextendedproperty` against the
+ *    `MS_Description` extended property, batched with `GO`.
+ *  - PostgreSQL: ANSI `COMMENT ON SCHEMA/TABLE/COLUMN ... IS '...'` (idempotent —
+ *    a COMMENT ON replaces any existing comment, so no drop-if-exists is needed,
+ *    and no `GO` batch separator).
+ *
+ * MySQL/Oracle write-back is not yet implemented; those fall back to the SQL
+ * Server form (unchanged from the original behavior).
  */
 
 import { DatabaseDocumentation } from '../types/state.js';
 
+export type SQLGeneratorProvider = 'sqlserver' | 'mysql' | 'postgresql' | 'oracle';
+
 export interface SQLGeneratorOptions {
   approvedOnly?: boolean;
   confidenceThreshold?: number;
+  /** Target database platform. Defaults to 'sqlserver' for backward compatibility. */
+  provider?: SQLGeneratorProvider;
 }
 
 export class SQLGenerator {
@@ -17,6 +31,7 @@ export class SQLGenerator {
     state: DatabaseDocumentation,
     options: SQLGeneratorOptions = {}
   ): string {
+    const isPg = options.provider === 'postgresql';
     const lines: string[] = [];
 
     // Header
@@ -25,7 +40,11 @@ export class SQLGenerator {
     lines.push(`-- Database: ${state.database.name}`);
     lines.push(`-- Server: ${state.database.server}`);
     lines.push('');
-    lines.push('-- This script adds MS_Description extended properties to database objects');
+    lines.push(
+      isPg
+        ? '-- This script applies object descriptions via PostgreSQL COMMENT ON statements'
+        : '-- This script adds MS_Description extended properties to database objects'
+    );
     lines.push('');
 
     // Generate statements for each schema
@@ -36,8 +55,8 @@ export class SQLGenerator {
 
       // Schema description
       if (schema.description) {
-        lines.push(this.generateSchemaDescription(schema.name, schema.description));
-        lines.push('GO');
+        lines.push(this.generateSchemaDescription(schema.name, schema.description, isPg));
+        this.pushSeparator(lines, isPg);
         lines.push('');
       }
 
@@ -58,8 +77,8 @@ export class SQLGenerator {
         // Table description
         if (table.description) {
           lines.push(`-- Table: ${schema.name}.${table.name}`);
-          lines.push(this.generateTableDescription(schema.name, table.name, table.description));
-          lines.push('GO');
+          lines.push(this.generateTableDescription(schema.name, table.name, table.description, isPg));
+          this.pushSeparator(lines, isPg);
           lines.push('');
         }
 
@@ -71,10 +90,11 @@ export class SQLGenerator {
                 schema.name,
                 table.name,
                 column.name,
-                column.description
+                column.description,
+                isPg
               )
             );
-            lines.push('GO');
+            this.pushSeparator(lines, isPg);
           }
         }
 
@@ -86,10 +106,24 @@ export class SQLGenerator {
   }
 
   /**
+   * Pushes the statement separator. SQL Server batches with `GO`; PostgreSQL
+   * statements are already `;`-terminated and need no batch separator.
+   */
+  private pushSeparator(lines: string[], isPg: boolean): void {
+    if (!isPg) {
+      lines.push('GO');
+    }
+  }
+
+  /**
    * Generate schema description statement
    */
-  private generateSchemaDescription(schemaName: string, description: string): string {
+  private generateSchemaDescription(schemaName: string, description: string, isPg: boolean): string {
     const escapedDescription = this.escapeString(description);
+
+    if (isPg) {
+      return `COMMENT ON SCHEMA ${this.quotePgIdentifier(schemaName)} IS '${escapedDescription}';`;
+    }
 
     return `
 IF EXISTS (
@@ -119,9 +153,14 @@ EXEC sp_addextendedproperty
   private generateTableDescription(
     schemaName: string,
     tableName: string,
-    description: string
+    description: string,
+    isPg: boolean
   ): string {
     const escapedDescription = this.escapeString(description);
+
+    if (isPg) {
+      return `COMMENT ON TABLE ${this.quotePgIdentifier(schemaName)}.${this.quotePgIdentifier(tableName)} IS '${escapedDescription}';`;
+    }
 
     return `
 IF EXISTS (
@@ -159,9 +198,14 @@ EXEC sp_addextendedproperty
     schemaName: string,
     tableName: string,
     columnName: string,
-    description: string
+    description: string,
+    isPg: boolean
   ): string {
     const escapedDescription = this.escapeString(description);
+
+    if (isPg) {
+      return `COMMENT ON COLUMN ${this.quotePgIdentifier(schemaName)}.${this.quotePgIdentifier(tableName)}.${this.quotePgIdentifier(columnName)} IS '${escapedDescription}';`;
+    }
 
     return `
 IF EXISTS (
@@ -198,7 +242,14 @@ EXEC sp_addextendedproperty
   }
 
   /**
-   * Escape string for SQL
+   * Quote a PostgreSQL identifier, escaping embedded double quotes.
+   */
+  private quotePgIdentifier(name: string): string {
+    return `"${name.replace(/"/g, '""')}"`;
+  }
+
+  /**
+   * Escape string for a SQL string literal.
    */
   private escapeString(str: string): string {
     return str.replace(/'/g, "''");


### PR DESCRIPTION
## Problem
DBAutoDoc can introspect PostgreSQL/Aurora correctly (the PG driver uses `pg_catalog`/`information_schema`/`pg_description`), but its only write-back generator emitted SQL-Server-only T-SQL — `sp_addextendedproperty` / `sp_dropextendedproperty` / `sys.extended_properties` / `GO`. So `export --apply` errored against PostgreSQL and the whole point of the tool (writing documentation back to the DB) was SQL-Server-only.

## Fix
- `SQLGenerator` is now provider-aware: PostgreSQL emits ANSI `COMMENT ON SCHEMA/TABLE/COLUMN ... IS '...'` (idempotent, double-quoted identifiers, no `GO`); SQL Server keeps the existing extended-property path unchanged. Default remains `sqlserver` for backward compatibility.
- The `export` command threads the configured provider into the generator.
- The `init` wizard prompts for the database platform and persists the matching provider + default port (1433/5432/3306/1521); the SQL-Server-only encrypt/trust prompts are shown only for SQL Server.

## Testing
- **Unit:** new PostgreSQL `COMMENT ON` generator tests (incl. identifier/quote escaping and SS-default fallback); SQLGenerator suite **17/17**.
- **Live on PostgreSQL:** generated `COMMENT ON` statements applied to a real PG database (`3× COMMENT`) and the description read back via `obj_description()`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)