### PR TITLE
fix(scheduling): PostgreSQL-correct heartbeat lease extension

### DIFF
--- a/migrations-pg/v5/V202606161200__v5.41.x__Fix_PG_ScheduledJob_ExtendLease_RowCount.pg-only.sql
+++ b/migrations-pg/v5/V202606161200__v5.41.x__Fix_PG_ScheduledJob_ExtendLease_RowCount.pg-only.sql
@@ -1,0 +1,32 @@
+-- PG-ONLY forward fix for a PostgreSQL-specific defect in the v5.41 heartbeat-lease sproc.
+-- Does not exist on SQL Server (the T-SQL spExtendScheduledJobLease returns @@ROWCOUNT correctly),
+-- so there is no T-SQL counterpart — this is applied only on the PostgreSQL side.
+
+-- ---------------------------------------------------------------------------
+-- Defect: spExtendScheduledJobLease never captured the UPDATE row count
+-- ---------------------------------------------------------------------------
+-- V202606151055 (v5.41) created the plpgsql spExtendScheduledJobLease but DECLAREd
+-- _v_row_count without ever assigning it (the `GET DIAGNOSTICS _v_row_count = ROW_COUNT;`
+-- line its sibling lock sprocs have was missing). So `p_RowsAffected := _v_row_count`
+-- bound NULL and the function returned Extended = NULL — never 1 — meaning a heartbeat
+-- lease extension on PostgreSQL would always read as "not extended" even on success.
+-- Recreate the function with the diagnostics capture (and COALESCE to 0 for safety).
+CREATE OR REPLACE FUNCTION ${flyway:defaultSchema}."spExtendScheduledJobLease"(
+    IN p_JobID UUID,
+    IN p_ExpectedToken UUID,
+    IN p_NewExpectedCompletionAt TIMESTAMPTZ
+)
+RETURNS TABLE("Extended" INTEGER) AS
+$$
+DECLARE
+    _v_row_count INTEGER;
+BEGIN
+    UPDATE ${flyway:defaultSchema}."ScheduledJob"
+       SET ExpectedCompletionAt = p_NewExpectedCompletionAt
+     WHERE ID = p_JobID
+       AND LockToken = p_ExpectedToken;
+
+    GET DIAGNOSTICS _v_row_count = ROW_COUNT;
+    RETURN QUERY SELECT COALESCE(_v_row_count, 0) AS Extended;
+END;
+$$ LANGUAGE plpgsql;

--- a/migrations-pg/v5/V202606161200__v5.41.x__Fix_PG_ScheduledJob_ExtendLease_RowCount.pg-only.sql
+++ b/migrations-pg/v5/V202606161200__v5.41.x__Fix_PG_ScheduledJob_ExtendLease_RowCount.pg-only.sql
@@ -3,14 +3,21 @@
 -- so there is no T-SQL counterpart — this is applied only on the PostgreSQL side.
 
 -- ---------------------------------------------------------------------------
--- Defect: spExtendScheduledJobLease never captured the UPDATE row count
+-- Two defects in the v5.41 plpgsql spExtendScheduledJobLease (V202606151055)
 -- ---------------------------------------------------------------------------
--- V202606151055 (v5.41) created the plpgsql spExtendScheduledJobLease but DECLAREd
--- _v_row_count without ever assigning it (the `GET DIAGNOSTICS _v_row_count = ROW_COUNT;`
--- line its sibling lock sprocs have was missing). So `p_RowsAffected := _v_row_count`
--- bound NULL and the function returned Extended = NULL — never 1 — meaning a heartbeat
--- lease extension on PostgreSQL would always read as "not extended" even on success.
--- Recreate the function with the diagnostics capture (and COALESCE to 0 for safety).
+-- 1. Unquoted mixed-case columns. The UPDATE body referenced ScheduledJob columns
+--    bare — `SET ExpectedCompletionAt`, `WHERE ID`, `AND LockToken`. PostgreSQL
+--    folds unquoted identifiers to lower-case, so the function fails on EVERY call
+--    with `column "id" does not exist` (the columns are "ID"/"ExpectedCompletionAt"/
+--    "LockToken"). The function was therefore completely non-functional on PG — it
+--    never even reached the row-count line.
+-- 2. Row count never captured. It DECLAREd _v_row_count without ever assigning it
+--    (the `GET DIAGNOSTICS _v_row_count = ROW_COUNT;` line its sibling lock sprocs
+--    have was missing), so it would return Extended = NULL — never 1 — meaning a
+--    heartbeat lease extension always read as "not extended" even on success.
+-- Recreate the function with quoted identifiers AND the diagnostics capture
+-- (COALESCE to 0 for safety). Verified on PG: matching token -> Extended=1,
+-- non-matching token -> 0.
 CREATE OR REPLACE FUNCTION ${flyway:defaultSchema}."spExtendScheduledJobLease"(
     IN p_JobID UUID,
     IN p_ExpectedToken UUID,
@@ -22,9 +29,9 @@ DECLARE
     _v_row_count INTEGER;
 BEGIN
     UPDATE ${flyway:defaultSchema}."ScheduledJob"
-       SET ExpectedCompletionAt = p_NewExpectedCompletionAt
-     WHERE ID = p_JobID
-       AND LockToken = p_ExpectedToken;
+       SET "ExpectedCompletionAt" = p_NewExpectedCompletionAt
+     WHERE "ID" = p_JobID
+       AND "LockToken" = p_ExpectedToken;
 
     GET DIAGNOSTICS _v_row_count = ROW_COUNT;
     RETURN QUERY SELECT COALESCE(_v_row_count, 0) AS Extended;

--- a/packages/Scheduling/engine/src/ScheduledJobEngine.ts
+++ b/packages/Scheduling/engine/src/ScheduledJobEngine.ts
@@ -1144,11 +1144,13 @@ export class SchedulingEngine extends BaseSingleton<SchedulingEngine> {
         newExpectedCompletionAt: Date
     ): Promise<boolean> {
         const provider = this.Base.ProviderToUse as DatabaseProviderBase;
-        const schema = provider.MJCoreSchemaName;
-        // MJ pattern: positional placeholders; see tryAcquireLock for rationale.
+        // MJ pattern: positional parameter array. buildLockSprocCall picks the
+        // dialect-correct call wrapper (EXEC on SQL Server, SELECT * FROM fn() on
+        // PostgreSQL) — the previous hardcoded `EXEC [schema].[…]` form crashed on
+        // PG. The SAME value array serves both. See tryAcquireLock for rationale.
         const rows = await provider.ExecuteSQL<{ Extended: number }>(
-            `EXEC [${schema}].[spExtendScheduledJobLease] ` +
-                `@JobID=@p0, @ExpectedToken=@p1, @NewExpectedCompletionAt=@p2`,
+            this.buildLockSprocCall(provider, 'spExtendScheduledJobLease',
+                ['JobID', 'ExpectedToken', 'NewExpectedCompletionAt']),
             [jobId, expectedToken, newExpectedCompletionAt],
             { isMutation: true, description: 'spExtendScheduledJobLease' },
             this.Base.ContextUser

--- a/packages/Scheduling/engine/src/__tests__/ScheduledJobEngine.heartbeat.test.ts
+++ b/packages/Scheduling/engine/src/__tests__/ScheduledJobEngine.heartbeat.test.ts
@@ -561,3 +561,44 @@ describe('H7/H8: MaxRuntimeMinutes adjusts the acquire-time lease', () => {
         expect(offset).toBeLessThanOrEqual(TEN_MIN + (after - before) + 50);
     });
 });
+
+// ============================================================================
+// H9: extend-lease call is dialect-routed (regression: it used to hardcode EXEC)
+// ============================================================================
+
+describe('H9: spExtendScheduledJobLease is built via the dialect, not a hardcoded EXEC', () => {
+    it('emits the PostgreSQL SELECT * FROM fn($1,...) form when the provider is PG', async () => {
+        const engine = SchedulingEngine.Instance;
+        const provider = mockBase.ProviderToUse as unknown as {
+            PlatformKey: string;
+            Dialect: { ProcedureCallSyntax: (s: string, n: string, p: string[]) => string };
+        };
+        const originalPlatform = provider.PlatformKey;
+        const originalDialect = provider.Dialect;
+        // Flip the mock provider to PostgreSQL dialect for this test.
+        provider.PlatformKey = 'postgresql';
+        provider.Dialect = {
+            ProcedureCallSyntax: (schema: string, name: string, paramList: string[]) =>
+                `SELECT * FROM ${schema}."${name}"(${paramList.join(', ')})`,
+        };
+
+        try {
+            mockExecuteSQLQueue.push([{ Extended: 1 }]);
+            // @ts-expect-error: private method exercised directly
+            const extended = await engine.extendLeaseIfTokenMatches(
+                'job-x', '11111111-1111-1111-1111-111111111111', new Date()
+            );
+            expect(extended).toBe(true);
+
+            const call = lastSprocCall('spExtendScheduledJobLease');
+            expect(call).toBeDefined();
+            const sql = String(call?.[0]);
+            // PG positional placeholders + SELECT FROM function — NOT a T-SQL EXEC.
+            expect(sql).toBe('SELECT * FROM __mj."spExtendScheduledJobLease"($1, $2, $3)');
+            expect(sql).not.toContain('EXEC');
+        } finally {
+            provider.PlatformKey = originalPlatform;
+            provider.Dialect = originalDialect;
+        }
+    });
+});


### PR DESCRIPTION
## Problem
The opt-in heartbeat lease-extension path (GH #2749) had **three** PostgreSQL-specific defects (two in the plpgsql function, one in the engine call):

1. **Engine call hardcoded T-SQL.** `ScheduledJobEngine.extendLeaseIfTokenMatches` issued `EXEC [schema].[spExtendScheduledJobLease] @JobID=@p0, ...` — a syntax error on PostgreSQL. Every sibling lock sproc already routes through the dialect helper; this one didn't.
2. **PG function: unquoted mixed-case columns.** The function body referenced `ScheduledJob` columns bare — `SET ExpectedCompletionAt`, `WHERE ID`, `AND LockToken`. PostgreSQL folds unquoted identifiers to lower-case, so the function failed on **every** call with `column "id" does not exist`. It was completely non-functional on PG.
3. **PG function: row count never captured.** It DECLAREd `_v_row_count` without ever assigning it (missing `GET DIAGNOSTICS ... ROW_COUNT`), so it would return `Extended = NULL` — never 1 — even on a successful update.

Latent today because no shipped plugin calls `context.heartbeat()` and renewal failures are swallowed, but the feature was fully broken on PG.

## Fix
- Engine: route the lease call through `buildLockSprocCall` so it emits the dialect-correct wrapper (`EXEC` on SQL Server, `SELECT * FROM fn($1,...)` on PostgreSQL).
- PG forward-fix migration recreates `spExtendScheduledJobLease` with **quoted identifiers** (`"ID"` / `"ExpectedCompletionAt"` / `"LockToken"`) **and** `GET DIAGNOSTICS _v_row_count = ROW_COUNT;` (+ `COALESCE(...,0)`). SQL Server is unaffected.

## Testing
- **Unit:** H9 regression test asserting the engine's lease call is dialect-routed (PG `SELECT * FROM __mj."spExtendScheduledJobLease"($1,$2,$3)` form, never a hardcoded `EXEC`); heartbeat suite **11/11**, scheduling-engine suite **143 passed / 1 skipped**.
- **Live on PostgreSQL (function actually called, not just inspected):** with a matching lock token the function returns **`Extended=1`**; with a non-matching token it returns **`0`**. Defects (2) and (3) were both found precisely because the function was executed on a live PG DB rather than only reading its body. Separately, the scheduling engine ran a full job lifecycle (acquire → run → release → stats) on PG with **zero sproc errors**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)