### PR TITLE
fix(ng-mj-livekit-room): add missing vitest.config.ts

### DIFF
--- a/.changeset/lively-otters-jump.md
+++ b/.changeset/lively-otters-jump.md
@@ -1,0 +1,5 @@
+---
+"@memberjunction/ng-mj-livekit-room": patch
+---
+
+Add missing vitest.config.ts so the package's test script no longer crashes by falling back to the root vitest config's project globs.

--- a/packages/Angular/Generic/mj-livekit-room/vitest.config.ts
+++ b/packages/Angular/Generic/mj-livekit-room/vitest.config.ts
@@ -1,0 +1,11 @@
+import { defineProject, mergeConfig } from 'vitest/config';
+import sharedConfig from '../../../../vitest.shared';
+
+export default mergeConfig(
+    sharedConfig,
+    defineProject({
+        test: {
+            environment: 'node',
+        },
+    }),
+);


### PR DESCRIPTION
## Summary
- `@memberjunction/ng-mj-livekit-room` declared a `vitest run` test script but had no local `vitest.config.ts`, so vitest fell back to the root config and resolved its `projects` globs relative to the package CWD — producing an invalid path (`.../mj-livekit-room/packages/MJGlobal`) and a startup crash in CI.
- Adds the same config used by sibling packages (`livekit-room`, `shared`): merges `vitest.shared.ts` with `environment: 'node'`. The shared config sets `passWithNoTests`, so the package passes cleanly until tests are added.
- Confirmed via a repo-wide scan that this was the only package with a vitest test script and no config.

## Test plan
- [ ] `cd packages/Angular/Generic/mj-livekit-room && npm run test` exits 0 ("No test files found")
- [ ] CI test job for `@memberjunction/ng-mj-livekit-room` passes (no startup error)
- [ ] Sibling vitest packages remain unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)