### PR TITLE
fix(MJServer): repair RemoteBrowserAudioStream test ai-core-plus mock

### DIFF
--- a/.changeset/calm-otters-listen.md
+++ b/.changeset/calm-otters-listen.md
@@ -1,0 +1,5 @@
+---
+"@memberjunction/server": patch
+---
+
+Fix RemoteBrowserAudioStream unit test by adding a stub BaseArtifactToolLibrary export to the inert ai-core-plus mock, satisfying the runtime base class pulled in transitively via the artifact-tool manager.

--- a/package-lock.json
+++ b/package-lock.json
@@ -45130,23 +45130,6 @@
         "@livekit/rtc-node": "^0.13.0"
       }
     },
-    "packages/AI/RealtimeBridge/Providers/LiveKitNative/node_modules/@types/node": {
-      "version": "24.10.11",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.10.11.tgz",
-      "integrity": "sha512-/Af7O8r1frCVgOz0I62jWUtMohJ0/ZQU/ZoketltOJPZpnb17yoNc9BSoVuV9qlaIXJiPNOpsfq4ByFajSArNQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "undici-types": "~7.16.0"
-      }
-    },
-    "packages/AI/RealtimeBridge/Providers/LiveKitNative/node_modules/undici-types": {
-      "version": "7.16.0",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
-      "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
-      "dev": true,
-      "license": "MIT"
-    },
     "packages/AI/RealtimeBridge/Providers/RingCentral": {
       "name": "@memberjunction/ai-bridge-ringcentral",
       "version": "5.41.0",
@@ -58593,6 +58576,7 @@
         "@memberjunction/ai-bedrock": "5.41.0",
         "@memberjunction/ai-betty-bot": "5.41.0",
         "@memberjunction/ai-blackforestlabs": "5.41.0",
+        "@memberjunction/ai-bridge-server": "5.41.0",
         "@memberjunction/ai-cerebras": "5.41.0",
         "@memberjunction/ai-cohere": "5.41.0",
         "@memberjunction/ai-core-plus": "5.41.0",

--- a/packages/MJServer/src/__tests__/RemoteBrowserAudioStream.test.ts
+++ b/packages/MJServer/src/__tests__/RemoteBrowserAudioStream.test.ts
@@ -55,7 +55,10 @@ vi.mock('@memberjunction/remote-browser-server', () => ({
 // Keep the AI imports (visual interpreter) inert — they aren't exercised by the audio path.
 vi.mock('@memberjunction/aiengine', () => ({ AIEngine: { Instance: { Config: vi.fn(), Prompts: [] } } }));
 vi.mock('@memberjunction/ai-prompts', () => ({ AIPromptRunner: class {} }));
-vi.mock('@memberjunction/ai-core-plus', () => ({ AIPromptParams: class {} }));
+// `BaseArtifactToolLibrary` is a base class extended by tool libraries pulled in transitively via
+// `@memberjunction/ai-agents` (ArtifactToolManager → DataSnapshotToolLibrary), so the mock must export it
+// as a class for those subclasses to extend at module-load time.
+vi.mock('@memberjunction/ai-core-plus', () => ({ AIPromptParams: class {}, BaseArtifactToolLibrary: class {} }));
 
 import { RemoteBrowserActionResolver } from '../resolvers/RemoteBrowserActionResolver.js';
 


### PR DESCRIPTION
## Summary
- `RemoteBrowserAudioStream.test.ts` mocks `@memberjunction/ai-core-plus` as an inert module, but the resolver transitively pulls in `@memberjunction/ai-agents` (`ArtifactToolManager` → `DataSnapshotToolLibrary`), which `extends BaseArtifactToolLibrary` at module-load time.
- The mock only exported `AIPromptParams`, so the subclass had no base class to extend and vitest threw `No "BaseArtifactToolLibrary" export is defined on the mock`, failing the build's test gate.
- Added a stub `BaseArtifactToolLibrary: class {}` to the mock — keeps the AI imports inert while satisfying the runtime `extends`. Other ai-core-plus imports in that chain are type-only and need no stub.

## Test plan
- [x] `cd packages/MJServer && npx vitest run src/__tests__/RemoteBrowserAudioStream.test.ts` passes (6 tests)
- [x] Full MJServer suite green (28 files, 523 passed, 56 skipped, 0 failed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)