### PR TITLE
fix(pg): clean MJAPI engine load on PostgreSQL (AutoUpdatePath bool + orphan related-name virtual fields)

### DIFF
--- a/migrations-pg/v5/V202606180000__v5.42.x__Fix_PG_Orphan_RelatedName_Virtual_Fields.pg-only.sql
+++ b/migrations-pg/v5/V202606180000__v5.42.x__Fix_PG_Orphan_RelatedName_Virtual_Fields.pg-only.sql
@@ -1,0 +1,31 @@
+-- PG-ONLY: remove orphan related-entity-name virtual EntityField rows.
+--
+-- The SS->PG converted baseline seeds related-entity-name virtual EntityField rows (e.g.
+-- EntityActionFilter."EntityAction") whose backing column is NOT present in the generated PG base
+-- view. PG base-view generation only emits the related-name column when the related entity has a
+-- designated NameField; for name-less targets (Test Runs, Scheduled Job Runs, AI Prompt Models,
+-- Entity Actions, ...) there is no name to join, so the column is correctly never produced — but the
+-- virtual field still claims to exist. At runtime, engines `RunView` that field and PostgreSQL raises
+-- `column "<X>" does not exist`, which prevents EntityActionEngine, AI Credential Bindings, and the
+-- Scheduling engine from loading.
+--
+-- Fix: delete virtual EntityField rows whose column is absent from their entity's base view, so the
+-- metadata is consistent with what the view actually provides. Guarded so it ONLY removes a virtual
+-- field when the base view EXISTS but does not contain the column (never when a view is missing, which
+-- would otherwise wrongly drop every virtual field for that entity). Non-virtual fields and virtual
+-- fields whose column IS present (the normal related-name columns) are untouched. SQL Server is
+-- unaffected (its baseline views contain these columns), so this is PG-only.
+
+DELETE FROM ${flyway:defaultSchema}."EntityField" ef
+USING ${flyway:defaultSchema}."Entity" e
+WHERE ef."EntityID" = e."ID"
+  AND ef."IsVirtual" = true
+  AND e."BaseView" IS NOT NULL
+  AND EXISTS (
+        SELECT 1 FROM information_schema.views v
+        WHERE v.table_schema = e."SchemaName" AND v.table_name = e."BaseView")
+  AND NOT EXISTS (
+        SELECT 1 FROM information_schema.columns col
+        WHERE col.table_schema = e."SchemaName"
+          AND col.table_name = e."BaseView"
+          AND LOWER(col.column_name) = LOWER(ef."Name"));

--- a/packages/CodeGenLib/src/Database/manage-metadata.ts
+++ b/packages/CodeGenLib/src/Database/manage-metadata.ts
@@ -4418,7 +4418,7 @@ export class ManageMetadataBase {
             .replace(/^-|-$/g, '');         // trim hyphens from start/end
 
          const sSQL = `INSERT INTO ${this.qs(mj_core_schema(), 'Application')} (ID, Name, Description, SchemaAutoAddNewEntities, Path, AutoUpdatePath)
-                       VALUES ('${appID}', '${appName}', 'Generated for schema', '${schemaName}', '${path}', 1)`;
+                       VALUES ('${appID}', '${appName}', 'Generated for schema', '${schemaName}', '${path}', ${this.dialect.BooleanLiteral(true)})`;
          await this.LogSQLAndExecute(pool, sSQL, `SQL generated to create new application ${appName}`);
          LogStatus(`Created new application ${appName} with Path: ${path}`);
 


### PR DESCRIPTION
Targets the #2795 split-and-regenerate branch. Two PG-runtime fixes found while booting MJAPI against a freshly converted PG baseline — together they take MJAPI from "starts but 3 engines fail to load" to a clean boot on PostgreSQL.

## 1. App auto-creation crash (`AutoUpdatePath` int → boolean)
`manage-metadata.ts` inserted `AutoUpdatePath` (a `BOOLEAN` column) as integer literal `1`:
```
error: column "AutoUpdatePath" is of type boolean but expression is of type integer
```
On PG this aborts the transaction during new-schema Application auto-creation, which cascades and blocks CRUD-sproc/view generation for the new schema. Fixed with `dialect.BooleanLiteral(true)` (`true` on PG, `1` on SS).

## 2. Orphan related-name virtual fields break engine load
The converted baseline seeds related-entity-name virtual `EntityField` rows (e.g. `EntityActionFilter."EntityAction"`) whose backing column the PG base view never produces — the related entity has **no `NameField`**, so there's nothing to join. At runtime, engines `RunView` those fields and PG raises `column "..." does not exist`, preventing **EntityActionEngine**, **AI Credential Bindings**, and the **Scheduling** engine from loading (flooding the log on every retry).

New pg-only migration deletes virtual `EntityField` rows whose column is absent from their **existing** base view, making metadata consistent with what the view actually provides. Guarded so it only acts when the base view exists (never drops fields when a view is missing); non-virtual fields and the ~771 present related-name columns are untouched.

Both are PG-only — SQL Server baselines already contain these columns and store the TS verbatim.

## Verification
On a fresh PG DB built from the converted baseline, with both fixes applied:
- MJAPI boots clean — **0** `column does not exist`; EntityAction / AI Credential Bindings / Scheduling all load; scheduled jobs run with no EXEC error.
- Custom-entity (hubspot) codegen fully generates (9 CRUD sprocs + 3 views), single-run idempotent.
- The ~771 working related-name columns are unchanged.

## Note for reviewers
Fix #2 is the **remove-orphans** approach (makes the metadata honest so engines load). A small subset of the removed fields target entities that *do* have a Name field — for those, the ideal long-term fix is to **emit** the related-name column in `generateBaseView` instead of removing the field (best done with a SQL-Server diff so the 771 don't regress). This PR prioritizes a clean, correct boot; emitting those convenience columns can be a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)