### PR TITLE
fix(pg): dialect-correct entity-search predicate (no N'' / no ESCAPE)

### DIFF
--- a/packages/PostgreSQLDataProvider/src/PostgreSQLDataProvider.ts
+++ b/packages/PostgreSQLDataProvider/src/PostgreSQLDataProvider.ts
@@ -594,6 +594,33 @@ export class PostgreSQLDataProvider extends GenericDatabaseProvider implements I
     }
 
     /**
+     * PostgreSQL per-field search predicate. The base (SQL Server) form emits
+     * `N'...'` string literals and `ESCAPE '\'` on LIKE — both invalid on PostgreSQL
+     * (`N'...'` is not a PG literal prefix, and the auto-quoting wraps the bare `ESCAPE`
+     * keyword, producing `syntax error at or near "ESCAPE"`). PostgreSQL's default
+     * backslash-escape behavior in LIKE makes the explicit ESCAPE clause unnecessary,
+     * so we emit plain quoted literals with no `N` prefix and no `ESCAPE`.
+     */
+    protected override buildPerFieldSearchPredicate(field: EntityFieldInfo, escapedTerm: string, rawSafeTerm: string): string {
+        if (field.UserSearchParamFormatAPI && field.UserSearchParamFormatAPI.length > 0) {
+            return field.UserSearchParamFormatAPI.replace('{0}', rawSafeTerm);
+        }
+        if (!this.isTextSearchableType(field)) return '';
+        const pred = (field.UserSearchPredicateAPI ?? 'Contains').trim();
+        switch (pred) {
+            case 'Exact':
+                return ` = '${rawSafeTerm}'`;
+            case 'BeginsWith':
+                return ` LIKE '${escapedTerm}%'`;
+            case 'EndsWith':
+                return ` LIKE '%${escapedTerm}'`;
+            case 'Contains':
+            default:
+                return ` LIKE '%${escapedTerm}%'`;
+        }
+    }
+
+    /**
      * Transforms user-provided SQL clauses (ExtraFilter, OrderBy) to quote
      * mixed-case identifiers and convert [bracket] notation for PostgreSQL.
      * Also coerces SQL Server bit literals (`= 1` / `= 0`) on boolean fields


### PR DESCRIPTION
## Problem
Live Explorer search against a PostgreSQL backend died with `syntax error at or near "ESCAPE"`. `EntitySearchProvider` builds per-field `LIKE` predicates via the shared `buildPerFieldSearchPredicate`, whose base (SQL Server) form emits `N'...'` literals and a trailing `ESCAPE '\'` clause. On PostgreSQL:
- `N'...'` is not a valid literal prefix, and
- the identifier auto-quoting wraps the bare `ESCAPE` keyword → the syntax error.

PostgreSQL's `LIKE` already treats backslash as the default escape, so the explicit clause is unnecessary.

## Fix
Override `buildPerFieldSearchPredicate` on `PostgreSQLDataProvider` to emit plain quoted literals — **no `N` prefix, no `ESCAPE`** — while honoring the same `UserSearchPredicateAPI` / `UserSearchParamFormatAPI` contract (Exact / BeginsWith / EndsWith / Contains).

## Verification
Found via live Explorer search on a PG backend; override produces valid PG `LIKE` predicates.

Targets `feature/pg-split-and-regenerate` (not `next`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)