### PR TITLE
fix(pg): runtime correctness bundle — engine load, uninstall, entity search

### DIFF
--- a/.changeset/pg-runtime-correctness.md
+++ b/.changeset/pg-runtime-correctness.md
@@ -1,0 +1,17 @@
+---
+"@memberjunction/codegen-lib": minor
+"@memberjunction/open-app-engine": patch
+"@memberjunction/postgresql-dataprovider": patch
+---
+
+PostgreSQL runtime correctness, found during fresh-DB PG end-to-end testing:
+
+- **codegen-lib**: clean MJAPI engine load on PostgreSQL — `AutoUpdatePath` written as a
+  dialect-correct boolean literal, plus a PG-only migration removing orphan related-entity-name
+  virtual EntityField rows whose column the generated PG base view never emits (these crashed
+  EntityActionEngine / AI Credential Bindings / Scheduling with `column "..." does not exist`).
+- **open-app-engine**: app uninstall now deletes all FK-dependent metadata (Entity Field Values,
+  Entity Settings) in dependency order and reports a real failure instead of swallowing errors
+  into a false "success".
+- **postgresql-dataprovider**: dialect-correct per-field entity-search predicate (no `N'...'`
+  literal prefix, no `ESCAPE` clause) — fixes `syntax error at or near "ESCAPE"` on live search.

--- a/migrations-pg/v5/V202606180000__v5.42.x__Fix_PG_Orphan_RelatedName_Virtual_Fields.pg-only.sql
+++ b/migrations-pg/v5/V202606180000__v5.42.x__Fix_PG_Orphan_RelatedName_Virtual_Fields.pg-only.sql
@@ -1,0 +1,31 @@
+-- PG-ONLY: remove orphan related-entity-name virtual EntityField rows.
+--
+-- The SS->PG converted baseline seeds related-entity-name virtual EntityField rows (e.g.
+-- EntityActionFilter."EntityAction") whose backing column is NOT present in the generated PG base
+-- view. PG base-view generation only emits the related-name column when the related entity has a
+-- designated NameField; for name-less targets (Test Runs, Scheduled Job Runs, AI Prompt Models,
+-- Entity Actions, ...) there is no name to join, so the column is correctly never produced — but the
+-- virtual field still claims to exist. At runtime, engines `RunView` that field and PostgreSQL raises
+-- `column "<X>" does not exist`, which prevents EntityActionEngine, AI Credential Bindings, and the
+-- Scheduling engine from loading.
+--
+-- Fix: delete virtual EntityField rows whose column is absent from their entity's base view, so the
+-- metadata is consistent with what the view actually provides. Guarded so it ONLY removes a virtual
+-- field when the base view EXISTS but does not contain the column (never when a view is missing, which
+-- would otherwise wrongly drop every virtual field for that entity). Non-virtual fields and virtual
+-- fields whose column IS present (the normal related-name columns) are untouched. SQL Server is
+-- unaffected (its baseline views contain these columns), so this is PG-only.
+
+DELETE FROM ${flyway:defaultSchema}."EntityField" ef
+USING ${flyway:defaultSchema}."Entity" e
+WHERE ef."EntityID" = e."ID"
+  AND ef."IsVirtual" = true
+  AND e."BaseView" IS NOT NULL
+  AND EXISTS (
+        SELECT 1 FROM information_schema.views v
+        WHERE v.table_schema = e."SchemaName" AND v.table_name = e."BaseView")
+  AND NOT EXISTS (
+        SELECT 1 FROM information_schema.columns col
+        WHERE col.table_schema = e."SchemaName"
+          AND col.table_name = e."BaseView"
+          AND LOWER(col.column_name) = LOWER(ef."Name"));

--- a/packages/CodeGenLib/src/Database/manage-metadata.ts
+++ b/packages/CodeGenLib/src/Database/manage-metadata.ts
@@ -4418,7 +4418,7 @@ export class ManageMetadataBase {
             .replace(/^-|-$/g, '');         // trim hyphens from start/end
 
          const sSQL = `INSERT INTO ${this.qs(mj_core_schema(), 'Application')} (ID, Name, Description, SchemaAutoAddNewEntities, Path, AutoUpdatePath)
-                       VALUES ('${appID}', '${appName}', 'Generated for schema', '${schemaName}', '${path}', 1)`;
+                       VALUES ('${appID}', '${appName}', 'Generated for schema', '${schemaName}', '${path}', ${this.dialect.BooleanLiteral(true)})`;
          await this.LogSQLAndExecute(pool, sSQL, `SQL generated to create new application ${appName}`);
          LogStatus(`Created new application ${appName} with Path: ${path}`);
 

--- a/packages/OpenApp/Engine/src/install/install-orchestrator.ts
+++ b/packages/OpenApp/Engine/src/install/install-orchestrator.ts
@@ -643,20 +643,40 @@ export async function RemoveApp(options: RemoveOptions, context: OrchestratorCon
     }
 
     // Step 6: Remove metadata (entity registrations, SchemaInfo, etc.)
+    let metadataResult: { Success: boolean; ErrorMessage?: string } = { Success: true };
     if (existingApp.SchemaName) {
       Callbacks?.OnProgress?.('Metadata', `Removing entity metadata for schema '${existingApp.SchemaName}'...`);
-      await RemoveAppEntityMetadata(existingApp.SchemaName, context.ContextUser, Callbacks);
+      metadataResult = await RemoveAppEntityMetadata(existingApp.SchemaName, context.ContextUser, Callbacks);
     }
 
     // Step 7: Drop schema (unless --keep-data)
+    let schemaDropError: string | undefined;
     if (!options.KeepData && existingApp.SchemaName) {
       Callbacks?.OnProgress?.('Schema', `Dropping schema '${existingApp.SchemaName}'...`);
       const dropResult = await DropAppSchema(existingApp.SchemaName, context.DatabaseProvider, {
         allowDoubleUnderscore: options.AllowDoubleUnderscoreSchema === true,
       });
       if (!dropResult.Success) {
-        Callbacks?.OnWarn?.('Schema', `Failed to drop schema: ${dropResult.ErrorMessage}`);
+        schemaDropError = dropResult.ErrorMessage;
+        Callbacks?.OnError?.('Schema', `Failed to drop schema: ${dropResult.ErrorMessage}`);
       }
+    }
+
+    // If metadata removal or schema drop failed, the app is NOT cleanly removed — report it
+    // as a failure (don't mark the app 'Removed') instead of silently claiming success.
+    const removalErrors = [metadataResult.Success ? undefined : metadataResult.ErrorMessage, schemaDropError]
+      .filter((e): e is string => !!e);
+    if (removalErrors.length > 0) {
+      const combined = removalErrors.join('; ');
+      await RecordInstallHistoryEntry(context.ContextUser, existingApp.ID, 'Remove', manifest, {
+        Success: false,
+        DurationSeconds: GetDurationSeconds(startTime),
+        StartedAt: new Date(startTime),
+        EndedAt: new Date(),
+        Summary: `Remove failed: ${combined}`,
+      });
+      await SetAppStatus(context.ContextUser, existingApp.ID, 'Error');
+      return BuildFailureResult('Remove', options.AppName, existingApp.Version, 'Schema', startTime, combined);
     }
 
     // Step 8: Update records
@@ -1148,12 +1168,21 @@ async function ExecuteHook(command: string, cwd: string): Promise<void> {
  * Removes all MJ entity metadata associated with an app's schema.
  * Deletes in FK-dependency order to avoid constraint violations.
  */
-async function RemoveAppEntityMetadata(schemaName: string, contextUser: UserInfo, callbacks?: AppInstallCallbacks): Promise<void> {
+async function RemoveAppEntityMetadata(schemaName: string, contextUser: UserInfo, callbacks?: AppInstallCallbacks): Promise<{ Success: boolean; ErrorMessage?: string }> {
   try {
     const rv = new RunView();
     const escaped = EscapeSqlString(schemaName);
 
-    // First, find all entity IDs in this schema so we can clean FK-dependent records
+    // Helper: delete by filter and throw on any failure so the outer catch reports it
+    // (MJ metadata FKs are NO ACTION, not CASCADE, so dependents must be removed in order).
+    const del = async (entityName: string, filter: string): Promise<void> => {
+      const r = await DeleteEntitiesByFilter(rv, contextUser, entityName, filter);
+      if (!r.Success) {
+        throw new Error(r.ErrorMessage ?? `Failed to delete ${entityName} records`);
+      }
+    };
+
+    // First, find all entity IDs in this schema so we can clean FK-dependent records.
     const entityResult = await rv.RunView<BaseEntity>(
       {
         EntityName: 'MJ: Entities',
@@ -1162,49 +1191,70 @@ async function RemoveAppEntityMetadata(schemaName: string, contextUser: UserInfo
       },
       contextUser,
     );
+    if (!entityResult.Success) {
+      throw new Error(`Failed to query entities for schema '${schemaName}': ${entityResult.ErrorMessage}`);
+    }
 
-    if (!entityResult.Success || entityResult.Results.length === 0) {
+    if (entityResult.Results.length === 0) {
       // No entities found — just clean up SchemaInfo
-      await DeleteEntitiesByFilter(rv, contextUser, 'MJ: Schema Info', `SchemaName = '${escaped}'`);
+      await del('MJ: Schema Info', `SchemaName = '${escaped}'`);
       callbacks?.OnSuccess?.('Metadata', `Entity metadata for schema '${schemaName}' removed`);
-      return;
+      return { Success: true };
     }
 
     const entityIds = entityResult.Results.map((e) => String(e.Get('ID')));
     const idList = entityIds.map((id) => `'${EscapeSqlString(id)}'`).join(',');
-    const entityIdFilter = `EntityID IN (${idList})`;
 
-    // Delete FK-dependent records in order (parallel where safe)
-    await Promise.all([
-      DeleteEntitiesByFilter(rv, contextUser, 'MJ: Entity Permissions', entityIdFilter),
-      DeleteEntitiesByFilter(rv, contextUser, 'MJ: Application Entities', entityIdFilter),
-    ]);
+    // Entity Field Values (FK on EntityFieldID) must go before the Entity Fields they
+    // reference — collect this schema's field IDs first.
+    const fieldResult = await rv.RunView<BaseEntity>(
+      {
+        EntityName: 'MJ: Entity Fields',
+        ExtraFilter: `EntityID IN (${idList})`,
+        ResultType: 'entity_object',
+      },
+      contextUser,
+    );
+    if (!fieldResult.Success) {
+      throw new Error(`Failed to query entity fields for schema '${schemaName}': ${fieldResult.ErrorMessage}`);
+    }
+    const fieldIdList = fieldResult.Results.map((f) => `'${EscapeSqlString(String(f.Get('ID')))}'`).join(',');
 
+    // Delete FK-dependent records in dependency order.
+    if (fieldIdList.length > 0) {
+      await del('MJ: Entity Field Values', `EntityFieldID IN (${fieldIdList})`);
+    }
+    await del('MJ: Entity Permissions', `EntityID IN (${idList})`);
+    await del('MJ: Application Entities', `EntityID IN (${idList})`);
+    await del('MJ: Entity Settings', `EntityID IN (${idList})`);
     // Entity Relationships reference EntityID on both sides
-    await DeleteEntitiesByFilter(rv, contextUser, 'MJ: Entity Relationships', `EntityID IN (${idList}) OR RelatedEntityID IN (${idList})`);
-
-    // Delete Entity Fields (FK on EntityID)
-    await DeleteEntitiesByFilter(rv, contextUser, 'MJ: Entity Fields', `EntityID IN (${idList})`);
+    await del('MJ: Entity Relationships', `EntityID IN (${idList}) OR RelatedEntityID IN (${idList})`);
+    // Entity Fields (FK on EntityID)
+    await del('MJ: Entity Fields', `EntityID IN (${idList})`);
 
     // Delete Entities themselves
     for (const entity of entityResult.Results) {
-      await entity.Delete();
+      if (!(await entity.Delete())) {
+        throw new Error(`Failed to delete entity '${String(entity.Get('Name'))}': ${entity.LatestResult?.CompleteMessage ?? 'unknown error'}`);
+      }
     }
 
     // Delete SchemaInfo last
-    await DeleteEntitiesByFilter(rv, contextUser, 'MJ: Schema Info', `SchemaName = '${escaped}'`);
+    await del('MJ: Schema Info', `SchemaName = '${escaped}'`);
 
     callbacks?.OnSuccess?.('Metadata', `Entity metadata for schema '${schemaName}' removed`);
+    return { Success: true };
   } catch (error: unknown) {
     const message = error instanceof Error ? error.message : String(error);
-    callbacks?.OnWarn?.('Metadata', `Failed to remove entity metadata: ${message}`);
+    callbacks?.OnError?.('Metadata', `Failed to remove entity metadata: ${message}`);
+    return { Success: false, ErrorMessage: `Failed to remove entity metadata for schema '${schemaName}': ${message}` };
   }
 }
 
 /**
  * Helper: loads entities by filter and deletes them one by one.
  */
-async function DeleteEntitiesByFilter(rv: RunView, contextUser: UserInfo, entityName: string, filter: string): Promise<void> {
+async function DeleteEntitiesByFilter(rv: RunView, contextUser: UserInfo, entityName: string, filter: string): Promise<{ Success: boolean; ErrorMessage?: string }> {
   const result = await rv.RunView<BaseEntity>(
     {
       EntityName: entityName,
@@ -1213,11 +1263,15 @@ async function DeleteEntitiesByFilter(rv: RunView, contextUser: UserInfo, entity
     },
     contextUser,
   );
-  if (result.Success) {
-    for (const record of result.Results) {
-      await record.Delete();
+  if (!result.Success) {
+    return { Success: false, ErrorMessage: `Failed to query ${entityName}: ${result.ErrorMessage}` };
+  }
+  for (const record of result.Results) {
+    if (!(await record.Delete())) {
+      return { Success: false, ErrorMessage: `Failed to delete a ${entityName} record: ${record.LatestResult?.CompleteMessage ?? 'unknown error'}` };
     }
   }
+  return { Success: true };
 }
 
 /** Calculates elapsed seconds from a `Date.now()` start timestamp. */

--- a/packages/OpenApp/Engine/src/install/install-orchestrator.ts
+++ b/packages/OpenApp/Engine/src/install/install-orchestrator.ts
@@ -1175,7 +1175,7 @@ async function RemoveAppEntityMetadata(schemaName: string, contextUser: UserInfo
 
     // Helper: delete by filter and throw on any failure so the outer catch reports it
     // (MJ metadata FKs are NO ACTION, not CASCADE, so dependents must be removed in order).
-    const del = async (entityName: string, filter: string): Promise<void> => {
+    const deleteByFilterOrThrow = async (entityName: string, filter: string): Promise<void> => {
       const r = await DeleteEntitiesByFilter(rv, contextUser, entityName, filter);
       if (!r.Success) {
         throw new Error(r.ErrorMessage ?? `Failed to delete ${entityName} records`);
@@ -1197,7 +1197,7 @@ async function RemoveAppEntityMetadata(schemaName: string, contextUser: UserInfo
 
     if (entityResult.Results.length === 0) {
       // No entities found — just clean up SchemaInfo
-      await del('MJ: Schema Info', `SchemaName = '${escaped}'`);
+      await deleteByFilterOrThrow('MJ: Schema Info', `SchemaName = '${escaped}'`);
       callbacks?.OnSuccess?.('Metadata', `Entity metadata for schema '${schemaName}' removed`);
       return { Success: true };
     }
@@ -1222,15 +1222,15 @@ async function RemoveAppEntityMetadata(schemaName: string, contextUser: UserInfo
 
     // Delete FK-dependent records in dependency order.
     if (fieldIdList.length > 0) {
-      await del('MJ: Entity Field Values', `EntityFieldID IN (${fieldIdList})`);
+      await deleteByFilterOrThrow('MJ: Entity Field Values', `EntityFieldID IN (${fieldIdList})`);
     }
-    await del('MJ: Entity Permissions', `EntityID IN (${idList})`);
-    await del('MJ: Application Entities', `EntityID IN (${idList})`);
-    await del('MJ: Entity Settings', `EntityID IN (${idList})`);
+    await deleteByFilterOrThrow('MJ: Entity Permissions', `EntityID IN (${idList})`);
+    await deleteByFilterOrThrow('MJ: Application Entities', `EntityID IN (${idList})`);
+    await deleteByFilterOrThrow('MJ: Entity Settings', `EntityID IN (${idList})`);
     // Entity Relationships reference EntityID on both sides
-    await del('MJ: Entity Relationships', `EntityID IN (${idList}) OR RelatedEntityID IN (${idList})`);
+    await deleteByFilterOrThrow('MJ: Entity Relationships', `EntityID IN (${idList}) OR RelatedEntityID IN (${idList})`);
     // Entity Fields (FK on EntityID)
-    await del('MJ: Entity Fields', `EntityID IN (${idList})`);
+    await deleteByFilterOrThrow('MJ: Entity Fields', `EntityID IN (${idList})`);
 
     // Delete Entities themselves
     for (const entity of entityResult.Results) {
@@ -1240,7 +1240,7 @@ async function RemoveAppEntityMetadata(schemaName: string, contextUser: UserInfo
     }
 
     // Delete SchemaInfo last
-    await del('MJ: Schema Info', `SchemaName = '${escaped}'`);
+    await deleteByFilterOrThrow('MJ: Schema Info', `SchemaName = '${escaped}'`);
 
     callbacks?.OnSuccess?.('Metadata', `Entity metadata for schema '${schemaName}' removed`);
     return { Success: true };

--- a/packages/PostgreSQLDataProvider/src/PostgreSQLDataProvider.ts
+++ b/packages/PostgreSQLDataProvider/src/PostgreSQLDataProvider.ts
@@ -594,6 +594,33 @@ export class PostgreSQLDataProvider extends GenericDatabaseProvider implements I
     }
 
     /**
+     * PostgreSQL per-field search predicate. The base (SQL Server) form emits
+     * `N'...'` string literals and `ESCAPE '\'` on LIKE — both invalid on PostgreSQL
+     * (`N'...'` is not a PG literal prefix, and the auto-quoting wraps the bare `ESCAPE`
+     * keyword, producing `syntax error at or near "ESCAPE"`). PostgreSQL's default
+     * backslash-escape behavior in LIKE makes the explicit ESCAPE clause unnecessary,
+     * so we emit plain quoted literals with no `N` prefix and no `ESCAPE`.
+     */
+    protected override buildPerFieldSearchPredicate(field: EntityFieldInfo, escapedTerm: string, rawSafeTerm: string): string {
+        if (field.UserSearchParamFormatAPI && field.UserSearchParamFormatAPI.length > 0) {
+            return field.UserSearchParamFormatAPI.replace('{0}', rawSafeTerm);
+        }
+        if (!this.isTextSearchableType(field)) return '';
+        const pred = (field.UserSearchPredicateAPI ?? 'Contains').trim();
+        switch (pred) {
+            case 'Exact':
+                return ` = '${rawSafeTerm}'`;
+            case 'BeginsWith':
+                return ` LIKE '${escapedTerm}%'`;
+            case 'EndsWith':
+                return ` LIKE '%${escapedTerm}'`;
+            case 'Contains':
+            default:
+                return ` LIKE '%${escapedTerm}%'`;
+        }
+    }
+
+    /**
      * Transforms user-provided SQL clauses (ExtraFilter, OrderBy) to quote
      * mixed-case identifiers and convert [bracket] notation for PostgreSQL.
      * Also coerces SQL Server bit literals (`= 1` / `= 0`) on boolean fields


### PR DESCRIPTION
Consolidates three small PostgreSQL runtime-correctness fixes found during fresh-DB PG end-to-end testing. **Supersedes #2878, #2879, #2880.**

- **codegen-lib** — clean MJAPI engine load on PG: `AutoUpdatePath` as a dialect-correct boolean literal + a PG-only migration removing orphan related-entity-name virtual `EntityField` rows (these crashed EntityActionEngine / AI Credential Bindings / Scheduling with `column "..." does not exist`). *(migration → minor)*
- **open-app-engine** — app uninstall deletes all FK-dependent metadata (Entity Field Values, Entity Settings) in dependency order, and reports a real failure instead of swallowing errors into a false "success". *(code → patch)*
- **postgresql-dataprovider** — dialect-correct per-field entity-search predicate (no `N'...'`, no `ESCAPE`); fixes `syntax error at or near "ESCAPE"` on live search. *(code → patch)*

Includes a changeset. Targets `feature/pg-split-and-regenerate` (not `next`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)