### PR TITLE
perf(metadata-sync): batch deletion-audit FK reference scan (~36 min → seconds)

### DIFF
--- a/packages/MetadataSync/src/__tests__/database-reference-scanner.test.ts
+++ b/packages/MetadataSync/src/__tests__/database-reference-scanner.test.ts
@@ -1,0 +1,132 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { RunView } from '@memberjunction/core';
+import type { Metadata, UserInfo, RunViewParams, RunViewResult } from '@memberjunction/core';
+import { DatabaseReferenceScanner } from '../lib/database-reference-scanner';
+import type { FlattenedRecord } from '../lib/record-dependency-analyzer';
+import type { ReverseFKInfo } from '../lib/entity-foreign-key-helper';
+
+/**
+ * Tests for the batched FK reference scan. The scanner must issue ONE query per
+ * (target entity, FK field) using an IN() filter — not one query per record — and
+ * must still attribute each found DB row back to the exact record being deleted.
+ *
+ * Regression guard for the deletion-audit hang: deleting a re-seeded connector's
+ * Integration Objects previously fired thousands of serial RunView round trips.
+ */
+
+const TARGET = 'MJ: Integration Objects';
+const REFERENCING = 'MJ: Integration Object Fields';
+const FK_FIELD = 'IntegrationObjectID';
+
+// The scanner only reads `.Entities[].Name` and `.PrimaryKeys[].Name` off the metadata.
+const metadataStub = {
+  Entities: [
+    { Name: TARGET, PrimaryKeys: [{ Name: 'ID' }] },
+    { Name: REFERENCING, PrimaryKeys: [{ Name: 'ID' }] }
+  ]
+} as unknown as Metadata;
+
+const reverseFKMap = new Map<string, ReverseFKInfo[]>([
+  [TARGET, [{ entityName: REFERENCING, fieldName: FK_FIELD, relatedFieldName: 'ID' }]]
+]);
+
+function makeDeleteRecord(id: string): FlattenedRecord {
+  return {
+    record: { primaryKey: { ID: id }, fields: {} },
+    entityName: TARGET,
+    depth: 0,
+    path: `test/${id}`,
+    dependencies: new Set<string>(),
+    id,
+    originalIndex: 0
+  };
+}
+
+let runViewCalls: RunViewParams[];
+let runViewImpl: (params: RunViewParams) => RunViewResult;
+
+beforeEach(() => {
+  runViewCalls = [];
+  runViewImpl = () => ({ Success: true, Results: [] } as unknown as RunViewResult);
+  vi.spyOn(RunView.prototype, 'RunView').mockImplementation(
+    (async (params: RunViewParams) => {
+      runViewCalls.push(params);
+      return runViewImpl(params);
+    }) as typeof RunView.prototype.RunView
+  );
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('DatabaseReferenceScanner.scanForReferences', () => {
+  it('issues ONE batched IN() query per (entity, FK field), not one per record', async () => {
+    const scanner = new DatabaseReferenceScanner(metadataStub, {} as UserInfo);
+    const records = ['AAAA', 'BBBB', 'CCCC'].map(makeDeleteRecord);
+
+    await scanner.scanForReferences(records, reverseFKMap, []);
+
+    expect(runViewCalls).toHaveLength(1);
+    expect(runViewCalls[0].EntityName).toBe(REFERENCING);
+    expect(runViewCalls[0].ExtraFilter).toContain(`${FK_FIELD} IN (`);
+    for (const id of ['AAAA', 'BBBB', 'CCCC']) {
+      expect(runViewCalls[0].ExtraFilter).toContain(`'${id}'`);
+    }
+  });
+
+  it('attributes each found DB row back to the correct deleted record (case-insensitive FK match)', async () => {
+    const scanner = new DatabaseReferenceScanner(metadataStub, {} as UserInfo);
+    const records = ['aaaa-1111', 'bbbb-2222'].map(makeDeleteRecord);
+
+    // DB row whose FK points (in uppercase) at the lower-cased 'bbbb-2222' delete target.
+    runViewImpl = () =>
+      ({
+        Success: true,
+        Results: [{ ID: 'field-1', [FK_FIELD]: 'BBBB-2222' }]
+      } as unknown as RunViewResult);
+
+    const refs = await scanner.scanForReferences(records, reverseFKMap, []);
+
+    expect(refs).toHaveLength(1);
+    expect(refs[0].entityName).toBe(REFERENCING);
+    expect(refs[0].referencingField).toBe(FK_FIELD);
+    expect(refs[0].referencedEntity).toBe(TARGET);
+    // The referencing DB record's own PK
+    expect(refs[0].primaryKey.KeyValuePairs[0].Value).toBe('field-1');
+    // Attributed back to the 'bbbb-2222' delete target despite the case difference
+    expect(refs[0].referencedKey.KeyValuePairs[0].Value.toLowerCase()).toBe('bbbb-2222');
+  });
+
+  it('drops DB rows whose FK does not match any record in the delete batch', async () => {
+    const scanner = new DatabaseReferenceScanner(metadataStub, {} as UserInfo);
+    const records = ['keep-me'].map(makeDeleteRecord);
+
+    runViewImpl = () =>
+      ({
+        Success: true,
+        Results: [{ ID: 'field-x', [FK_FIELD]: 'unrelated-guid' }]
+      } as unknown as RunViewResult);
+
+    const refs = await scanner.scanForReferences(records, reverseFKMap, []);
+    expect(refs).toHaveLength(0);
+  });
+
+  it('chunks large delete sets across multiple queries (chunk size 500)', async () => {
+    const scanner = new DatabaseReferenceScanner(metadataStub, {} as UserInfo);
+    const records = Array.from({ length: 600 }, (_, i) => makeDeleteRecord(`id-${i}`));
+
+    await scanner.scanForReferences(records, reverseFKMap, []);
+
+    // 600 ids -> ceil(600 / 500) = 2 batched queries
+    expect(runViewCalls).toHaveLength(2);
+  });
+
+  it('issues no queries when the deleted entity has no referencing entities', async () => {
+    const scanner = new DatabaseReferenceScanner(metadataStub, {} as UserInfo);
+
+    await scanner.scanForReferences([makeDeleteRecord('X')], new Map(), []);
+
+    expect(runViewCalls).toHaveLength(0);
+  });
+});

--- a/packages/MetadataSync/src/lib/database-reference-scanner.ts
+++ b/packages/MetadataSync/src/lib/database-reference-scanner.ts
@@ -3,6 +3,13 @@ import { FlattenedRecord } from './record-dependency-analyzer';
 import { ReverseFKInfo } from './entity-foreign-key-helper';
 
 /**
+ * Maximum number of primary-key values to include in a single batched IN() filter when scanning
+ * for database references. Keeps each generated query within SQL Server / provider size limits
+ * while still collapsing thousands of per-record lookups into a handful of queries.
+ */
+const REFERENCE_SCAN_CHUNK_SIZE = 500;
+
+/**
  * Represents a database record that references a record being deleted
  */
 export interface DatabaseReference {
@@ -42,36 +49,45 @@ export class DatabaseReferenceScanner {
         const references: DatabaseReference[] = [];
         const rv = new RunView();
 
-        for (const record of recordsToDelete) {
-            const entityName = record.entityName;
-            const primaryKey = this.extractPrimaryKey(record);
+        // Group the records-to-delete by entity, capturing each one's primary-key value.
+        // We then issue ONE batched RunView per (target entity, FK field) using an IN() filter,
+        // instead of one query per (record × FK field). Deleting thousands of records (e.g. a
+        // re-seeded connector's Integration Objects) previously meant thousands of serial round
+        // trips against large tables; batching collapses that to a handful of queries.
+        const recordsByEntity = this.groupDeletesByEntity(recordsToDelete);
 
-            if (!primaryKey) {
-                console.warn(`Cannot scan references for ${entityName}: no primary key found`);
+        for (const [entityName, deletes] of recordsByEntity) {
+            const referencingEntities = reverseFKMap.get(entityName) || [];
+            if (referencingEntities.length === 0) {
                 continue;
             }
 
-            // Find all entities that could reference this one
-            const referencingEntities = reverseFKMap.get(entityName) || [];
+            // Normalized-PK -> referenced CompositeKey, used to attribute each found DB row back
+            // to the specific record being deleted. GUIDs differ in case across SQL Server (upper)
+            // and PostgreSQL (lower), so we key the map case-insensitively.
+            const referencedKeyByPk = new Map<string, CompositeKey>();
+            for (const d of deletes) {
+                referencedKeyByPk.set(d.pkValue.toLowerCase(), d.key);
+            }
+            const allPkValues = deletes.map(d => d.pkValue);
 
             for (const refInfo of referencingEntities) {
-                try {
-                    // Query database for existing references
-                    // Use the actual value from the primary key, not the concatenated string format
-                    const pkValue = primaryKey.KeyValuePairs.length === 1
-                        ? primaryKey.KeyValuePairs[0].Value
-                        : primaryKey.ToConcatenatedString();
+                for (const chunk of this.chunkArray(allPkValues, REFERENCE_SCAN_CHUNK_SIZE)) {
+                    try {
+                        const inList = chunk.map(v => `'${v.replace(/'/g, "''")}'`).join(', ');
+                        const filter = `${refInfo.fieldName} IN (${inList})`;
 
-                    const filter = `${refInfo.fieldName} = '${pkValue}'`;
+                        const result = await rv.RunView({
+                            EntityName: refInfo.entityName,
+                            ExtraFilter: filter,
+                            ResultType: 'simple' // More efficient - we don't need entity objects
+                        }, this.contextUser);
 
-                    const result = await rv.RunView({
-                        EntityName: refInfo.entityName,
-                        ExtraFilter: filter,
-                        ResultType: 'simple' // More efficient - we don't need entity objects
-                    }, this.contextUser);
+                        if (!result.Success || !result.Results || result.Results.length === 0) {
+                            continue;
+                        }
 
-                    if (result.Success && result.Results && result.Results.length > 0) {
-                        // Found database records that reference this record
+                        // Found database records that reference one of the records being deleted
                         for (const dbRecord of result.Results) {
                             const refPrimaryKey = this.getPrimaryKeyFromSimpleRecord(
                                 dbRecord,
@@ -83,12 +99,23 @@ export class DatabaseReferenceScanner {
                                 continue;
                             }
 
+                            // Map this DB row back to the exact record it references via its FK value.
+                            const fkValue = dbRecord[refInfo.fieldName];
+                            const referencedKey = fkValue != null
+                                ? referencedKeyByPk.get(String(fkValue).toLowerCase())
+                                : undefined;
+
+                            if (!referencedKey) {
+                                // FK value didn't match any record in this delete batch — skip defensively.
+                                continue;
+                            }
+
                             references.push({
                                 entityName: refInfo.entityName,
                                 primaryKey: refPrimaryKey,
                                 referencingField: refInfo.fieldName,
                                 referencedEntity: entityName,
-                                referencedKey: primaryKey,
+                                referencedKey,
                                 existsInMetadata: this.checkIfInMetadata(
                                     refInfo.entityName,
                                     refPrimaryKey,
@@ -96,18 +123,62 @@ export class DatabaseReferenceScanner {
                                 )
                             });
                         }
+                    } catch (error) {
+                        console.error(
+                            `Error scanning references from ${refInfo.entityName}.${refInfo.fieldName} ` +
+                            `to ${entityName}:`,
+                            error
+                        );
                     }
-                } catch (error) {
-                    console.error(
-                        `Error scanning references from ${refInfo.entityName}.${refInfo.fieldName} ` +
-                        `to ${entityName}:`,
-                        error
-                    );
                 }
             }
         }
 
         return references;
+    }
+
+    /**
+     * Group records-to-delete by entity name, resolving each one's single-value primary key.
+     * Records whose primary key cannot be resolved are skipped (with a warning), matching the
+     * prior behavior. Composite keys fall back to their concatenated-string form.
+     */
+    private groupDeletesByEntity(
+        recordsToDelete: FlattenedRecord[]
+    ): Map<string, { pkValue: string; key: CompositeKey }[]> {
+        const byEntity = new Map<string, { pkValue: string; key: CompositeKey }[]>();
+
+        for (const record of recordsToDelete) {
+            const key = this.extractPrimaryKey(record);
+            if (!key) {
+                console.warn(`Cannot scan references for ${record.entityName}: no primary key found`);
+                continue;
+            }
+
+            const pkValue = key.KeyValuePairs.length === 1
+                ? String(key.KeyValuePairs[0].Value)
+                : key.ToConcatenatedString();
+
+            const existing = byEntity.get(record.entityName);
+            if (existing) {
+                existing.push({ pkValue, key });
+            } else {
+                byEntity.set(record.entityName, [{ pkValue, key }]);
+            }
+        }
+
+        return byEntity;
+    }
+
+    /**
+     * Split an array into chunks of at most `size` elements. Used to keep batched IN() filters
+     * within SQL Server / provider query-size limits.
+     */
+    private chunkArray<T>(items: T[], size: number): T[][] {
+        const chunks: T[][] = [];
+        for (let i = 0; i < items.length; i += size) {
+            chunks.push(items.slice(i, i + size));
+        }
+        return chunks;
     }
 
     /**


### PR DESCRIPTION
## Problem

A full `mj sync push --dir=metadata` appears to **hang** right after `🔍 Analyzing deletion operations...` — no output, ~30+ minutes, before any records are saved. It's not actually frozen; it's grinding through the deletion audit's FK reference scan.

This surfaced after the new connector metadata landed (`metadata/integrations/` — Salesforce ~33k records, Dynamics ~18k, plus 14 others ≈ **64k records**) together with the `metadata/integration-object-deletes/` seed-cleanup files (**714 `delete: true` directives**, 558 still in the DB, all targeting `MJ: Integration Objects`).

### Confirmation
- `mj sync push --dir=metadata --exclude="integrations, integration-object-deletes, integration-source-types"` → completes in **~27s**.
- Full push → never reaches `[1/68]` (per-directory processing). It's stuck in the audit.

## Root cause

Instrumented timing of the deletion-audit path:

| Phase | Time |
|---|---|
| Flatten 92,493 records | 0.3s ✅ |
| `analyzeAllDependencies` | 3.9s ✅ |
| `checkRecordExistence` (714 → 558 exist) | 2.5s ✅ |
| **`scanForReferences` (558 records)** | **~36 min** 🔴 |

`DatabaseReferenceScanner.scanForReferences` was a nested loop firing **one serial `await RunView` per (record-to-delete × referencing-entity)** — ~1,100 sequential round trips, each an `IntegrationObjectID = '<guid>'` scan against the now-31k-row `MJ: Integration Object Fields` table (~2s each, CPU-bound, measured 3.9s/record). Previously instant because the integration tables were tiny; the new data made it pathological. No per-record logging, so it looks frozen.

## Fix

Batch the scan: group deletes by entity and issue **one `RunView` per (target entity, FK field) using an `IN()` filter**, chunked at 500 ids. Found rows are attributed back to the exact deleted record via the FK value (case-insensitive, to handle SQL Server upper / PostgreSQL lower GUIDs).

- ~1,100 serial queries → a handful. **~36 min → seconds.**
- Lives in the generic `DatabaseReferenceScanner`, so **every** large metadata delete benefits, not just integrations.
- Behavior preserved: same `DatabaseReference[]` output, same composite-key fallback, same error handling.

## Tests

Adds `database-reference-scanner.test.ts` (5 tests): batching (one IN() query, not per-record), result attribution, case-insensitive FK match, chunking at 500, and the no-referencing-entities short-circuit. Full package suite: **248 passing** (243 prior + 5 new).

## Notes / out of scope (separate follow-ups)
- **Progress logging** for the deletion-audit phase would prevent future "is it hung?" confusion — the whole reason this looked frozen is zero output during a multi-minute phase.
- The **~2s-per-RunView** cost itself is worth a look (FK index usage), but is mostly mooted by batching.
- `MJQueryEntityServer` / `MJTagEntityServer` compute embeddings in their `Save()` overrides **without honoring the `SkipEmbeddings` flag** the push sets — a separate latent bug (a one-time ~40s of `Xenova/all-mpnet-base-v2` embeddings showed up during the run; not the bottleneck here).

---

⚠️ This was written as a standalone proposal off `next`. **If the connectors dev already addresses the deletion-audit performance in their branch, just close this PR.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)