### PR TITLE
fix(react-runtime): use global setInterval to match Node Timeout typing

### DIFF
--- a/.changeset/react-runtime-cache-timer-typing.md
+++ b/.changeset/react-runtime-cache-timer-typing.md
@@ -1,0 +1,5 @@
+---
+"@memberjunction/react-runtime": patch
+---
+
+Fix `cache-manager` build failure under Node typings — the cleanup timer used `window.setInterval`/`window.clearInterval` (DOM-typed, returns `number`) while `cleanupTimer` is declared as `ReturnType<typeof setInterval>` (Node's `Timeout`), causing `TS2322: Type 'number' is not assignable to type 'Timeout'`. Switched to the bare global `setInterval`/`clearInterval`, whose return type matches the declaration and works in both browser and Node runtimes.

--- a/packages/React/runtime/src/utilities/cache-manager.ts
+++ b/packages/React/runtime/src/utilities/cache-manager.ts
@@ -258,7 +258,7 @@ export class CacheManager<T = unknown> {
    * Start the cleanup timer
    */
   private startCleanupTimer(): void {
-    this.cleanupTimer = window.setInterval(() => {
+    this.cleanupTimer = setInterval(() => {
       this.cleanup();
     }, this.options.cleanupInterval);
   }
@@ -268,7 +268,7 @@ export class CacheManager<T = unknown> {
    */
   private stopCleanupTimer(): void {
     if (this.cleanupTimer) {
-      window.clearInterval(this.cleanupTimer);
+      clearInterval(this.cleanupTimer);
       this.cleanupTimer = undefined;
     }
   }


### PR DESCRIPTION
## Summary

Fixes a TypeScript build failure in `@memberjunction/react-runtime` that surfaced after merging into `next`.

`cache-manager` declares `cleanupTimer` as `ReturnType<typeof setInterval>` (resolves to Node's `Timeout`) but called `window.setInterval` / `window.clearInterval`, which are DOM-typed and return `number`:

```
src/utilities/cache-manager.ts:261:5 - error TS2322: Type 'number' is not assignable to type 'Timeout'.
```

Switched to the bare global `setInterval` / `clearInterval`, whose return type matches the `cleanupTimer` declaration and works correctly in both browser and Node runtimes.

## Changes
- `packages/React/runtime/src/utilities/cache-manager.ts` — drop `window.` prefix on the cleanup timer's `setInterval`/`clearInterval`
- Changeset: patch bump for `@memberjunction/react-runtime`

## Testing
- `npm run build` completes successfully (react-runtime compiles + UMD bundle emits)

🤖 Generated with [Claude Code](https://claude.com/claude-code)