### PR TITLE
fix(actions): export MJLruCache in EntityActionEngine test mock

### DIFF
--- a/packages/Actions/Engine/src/__tests__/EntityActionEngine.test.ts
+++ b/packages/Actions/Engine/src/__tests__/EntityActionEngine.test.ts
@@ -30,6 +30,16 @@ vi.mock('@memberjunction/global', () => ({
             return new this();
         }
     },
+    // Bounded LRU cache backing EntityActionInvocation*._scriptCache (field initializer
+    // runs in the constructor, so the mock MUST export it or every invocation construct throws).
+    MJLruCache: class MJLruCacheMock<K, V> {
+        constructor(_maxSize?: number) {}
+        get(_key: K): V | undefined { return undefined; }
+        set(_key: K, _value: V): void {}
+        has(_key: K): boolean { return false; }
+        delete(_key: K): boolean { return false; }
+        clear(): void {}
+    },
 }));
 
 // Mock @memberjunction/core


### PR DESCRIPTION
## Problem
The **Run unit tests** CI gate is red on `next`: `packages/Actions/Engine/src/__tests__/EntityActionEngine.test.ts` fails **22/26**.

```
Error: [vitest] No "MJLruCache" export is defined on the "@memberjunction/global" mock.
  ❯ new EntityActionInvocationBase EntityActionInvocationTypes.ts:80:32
    80| private _scriptCache = new MJLruCache<string, ...>(...)
```

A recent change switched `EntityActionInvocationTypes`'s script cache from `new Map()` to **`new MJLruCache(...)`** (a bounded LRU newly exported from `@memberjunction/global`), but this test's `vi.mock('@memberjunction/global')` returns only `MJGlobal`/`RegisterClass`/`SafeJSONParse`/`UUIDsEqual`/`NormalizeUUID`/`BaseSingleton` — not `MJLruCache`. Since the field initializer runs in the constructor, **every** `new EntityActionInvocation*` throws → 22 tests fail.

## Fix
Add a minimal `MJLruCache` stub (no-op `get`/`set`/`has`/`delete`/`clear`) to the test's `@memberjunction/global` mock, matching the file's explicit per-export mock style. **Test-only — no runtime/src change.**

## Verification
`npx vitest run src/__tests__/EntityActionEngine.test.ts` → **26/26 pass** (was 4/26).

🤖 Generated with [Claude Code](https://claude.com/claude-code)