### PR TITLE
feat(integration): netFORUM Enterprise (xWeb SOAP) connector

### DIFF
--- a/.changeset/netforum-xweb-connector.md
+++ b/.changeset/netforum-xweb-connector.md
@@ -1,0 +1,11 @@
+---
+"@memberjunction/integration-connectors": minor
+"@memberjunction/integration-engine": patch
+---
+
+Add the netFORUM Enterprise (Community Brands AMS) connector — xWeb SOAP/XML route.
+
+- **`NetForumConnector`** (`@memberjunction/integration-connectors`): integrates netFORUM Enterprise via the xWeb SOAP/XML web service (`netForumXML.asmx`), implemented as SOAP-over-HTTP on `BaseRESTIntegrationConnector`. Two-step `Authenticate` token auth; `GetQuery`/`GetQueryDefinition`/`ExecuteMethod` reads; per-facade `*_last_updated_dt` incremental watermarks; facade CRUD where the xWeb docs establish it. The standard Enterprise object model (34 Integration Objects) is Declared from the public xWeb WSDL; customer-specific queries/views/custom columns are runtime-discovered via `GetQueryDefinition` (`DiscoveryIsAuthoritative=false`), never baked into the connector.
+- **`@memberjunction/integration-engine`**: adds the optional `OAuth2TokenRequest.ExtraParams` field (extra `application/x-www-form-urlencoded` grant-body params, e.g. Auth0 `audience`), forwarded by `OAuth2TokenManager` with standard params taking precedence. This is the engine half of the OAuth2 change `RhythmConnector` already depends on.
+
+> **Note:** netFORUM's denormalized facades (e.g. `Individual`, `FundraisingGift`) can exceed SQL Server's hard 1024-column-per-table limit when fully flattened; those objects need column-overflow handling at the framework level before they can materialize as single tables.

--- a/metadata/integrations/netforum/.mj-sync.json
+++ b/metadata/integrations/netforum/.mj-sync.json
@@ -1,0 +1,30 @@
+{
+  "entity": "MJ: Integrations",
+  "filePattern": "**/.*.json",
+  "defaults": {},
+  "pull": {
+    "createNewFileIfNotFound": false,
+    "appendRecordsToExistingFile": false,
+    "updateExistingRecords": true,
+    "preserveFields": [],
+    "excludeFields": [],
+    "mergeStrategy": "merge",
+    "backupBeforeUpdate": true,
+    "backupDirectory": ".backups",
+    "filter": "",
+    "externalizeFields": [],
+    "lookupFields": {},
+    "relatedEntities": {
+      "MJ: Integration Objects": {
+        "filePattern": "**/*",
+        "createNewFileIfNotFound": false,
+        "updateExistingRecords": true
+      },
+      "MJ: Integration Object Fields": {
+        "filePattern": "**/*",
+        "createNewFileIfNotFound": false,
+        "updateExistingRecords": true
+      }
+    }
+  }
+}

--- a/packages/Integration/connectors/src/NetForumConnector.ts
+++ b/packages/Integration/connectors/src/NetForumConnector.ts
@@ -1,136 +1,145 @@
 /**
- * ⚠️ NEEDS REWORK BEFORE SHIPPING — 3 known wire-level gaps ⚠️
+ * NetForumConnector — netFORUM Enterprise xWeb SOAP/XML integration connector.
  *
- * 2026-05-20 vendor-truth audit:
+ * Protocol: SOAP 1.1 over HTTPS. There is NO `BaseSOAPIntegrationConnector` in the
+ * engine — the only protocol bases are `BaseIntegrationConnector` (grandparent) and
+ * `BaseRESTIntegrationConnector`. This connector rides `BaseRESTIntegrationConnector`
+ * and implements SOAP over its HTTP seam: it POSTs SOAP 1.1 envelopes to
+ * `/xweb/secure/netForumXML.asmx` via `MakeHTTPRequest` and parses the XML in
+ * `NormalizeResponse`. The transport is text/xml, not JSON.
  *
- *   1. Auth token is returned in the WWW-Authenticate RESPONSE HEADER, not in the
- *      JSON body. Vendor doc quote: "The token is in the WWW-Authenticate header.
- *      The value will look like: 'Bearer token = eb5667ab-25ac-45c9-b831-23b43be8f194'".
- *      Current code (line ~195) parses response.json() expecting `{ Token: string }` —
- *      will fail to extract the token from every real authenticate call.
- *   2. `LastModifiedDate` is not a canonical NetForum column. Each facade uses a
- *      prefixed name (`ind_last_updated_dt` for Individual, `evt_last_updated_dt`
- *      for Event, etc.). FetchChanges currently emits `szWhereClause=LastModifiedDate
- *      >= '<wm>'` which yields zero rows or a query error on every object.
- *   3. `DeleteFacadeObject` is not in any reachable vendor doc snippet. Get/Insert/
- *      Update facade methods are documented. SupportsDelete=true may need to flip
- *      false, or use a different method (vendor refers to "soft-deletes" generically).
+ * ── Wire truth (from the public WSDL: sources/netForumXML_asm.wsdl, 5.9 MB, 277 ops) ──
+ *
+ *   Endpoint   : POST <tenantHost>/xweb/secure/netForumXML.asmx   (Content-Type: text/xml; charset=utf-8)
+ *   Namespace  : http://www.avectra.com/2005/   (Avectra-era, retained by Community Brands)
+ *   SOAPAction : http://www.avectra.com/2005/<MethodName>
+ *
+ *   Auth (TWO-STEP, SOAP — NOT HTTP Basic / WWW-Authenticate / Bearer):
+ *     1. Authenticate(userName, password) → AuthenticateResult (the token string).
+ *        The Authenticate envelope carries NO AuthorizationToken header — it is the bootstrap.
+ *     2. Every subsequent data/CRUD call carries the token in the SOAP HEADER element:
+ *          <AuthorizationToken xmlns="http://www.avectra.com/2005/"><Token>{token}</Token></AuthorizationToken>
+ *        (NOT an HTTP Authorization header.) Source: WSDL `AuthorizationToken` complexType +
+ *        `<soap:header part="AuthorizationToken">` on every WEB-prefixed / GetQuery operation binding.
+ *
+ *   Read (door = GetQuery):
+ *     GetQuery(szObjectName, szColumnList, szWhereClause?, szOrderBy?) → GetQueryResult
+ *       - GetQueryResult is a `<s:any>` wildcard DataSet — flattened rows, one element per row.
+ *       - Incremental: szWhereClause = "<watermarkField> >= '<wm>'" where the watermark column is
+ *         the IO's per-facade `IncrementalWatermarkField` (e.g. ind_change_date, evt_*_change_date).
+ *         There is NO canonical `LastModifiedDate` column — the field is per-facade and is read
+ *         from metadata, never hardcoded.
+ *       - Row limit: szObjectName supports an `@TOP -1` / `@TOP N` modifier to bypass / bound the
+ *         server-side DataGrid row cap. The connector requests the modifier from the IO's accessPath.
+ *
+ *   Discovery (mechanism, NOT a baked catalog):
+ *     - Standard objects come from the Declared metadata (the persisted IntegrationObject rows in
+ *       the engine cache — credential-free docs → static metadata, case 1). `DiscoverObjects`
+ *       returns the cache; it does NOT enumerate a hardcoded `NF_OBJECTS` array (that was the bug
+ *       this IMPROVE round removes).
+ *     - Per-object field definitions come from `GetQueryDefinition(szObjectName)` at runtime
+ *       (credential-gated, case 2): the response carries the SQL column definition
+ *       (Object → ListTable → ListFromTables → ListFromTable[] → Columns → Column[]). The connector
+ *       parses that into ExternalFieldSchema. With no credential it falls back to the Declared
+ *       fields. The customer's own installed query objects (variable per installation) are reached
+ *       the same way — GetQueryDefinition is the discovery MECHANISM, never an answer baked in code.
+ *     - `DiscoveryIsAuthoritative` is FALSE: discovery extends the Declared baseline, it does not
+ *       enumerate the full credential gamut, so absence in a refresh must NEVER deactivate.
+ *
+ *   Write (facade CRUD — only where metadata declares the capability + per-operation columns):
+ *     - Create/Update route through the IO's per-operation columns (CreateAPIPath/CreateMethod/
+ *       CreateBodyShape/CreateBodyKey/CreateIDLocation, Update*) which name the SOAP operation
+ *       (e.g. WEBIndividualInsert, InsertFacadeObject). The connector wraps the attributes in a
+ *       SOAP envelope for that operation and routes the result through BuildCreatedResult so a 2xx
+ *       with no record key fails loudly (no silent record loss / duplicate-create next sync).
+ *     - SupportsDelete = false. `DeleteFacadeObject` is not confirmed in any reachable vendor doc;
+ *       netFORUM prefers soft-delete via status flags. Held false until verified.
  *
  * Vendor doc URLs:
- *   - xWeb Overview: https://documentation.abila.com/netforum-enterprise/2017.1/Content/xWeb/XWeb_Overview.htm
- *   - JSON over xWeb: http://documentation.abila.com/netforum-enterprise/2017.1/Content/xWeb/JSON_Over_xWeb_Overview.htm
- *   - xWeb Methods: https://nfesupport.zendesk.com/hc/en-us/articles/10639146855565
- *   - Authenticate: https://nfesupport.zendesk.com/hc/en-us/articles/10639139863309-Authenticate
- *
- * Auth: Two-step token auth.
- *   1. POST /xWeb/Signon.asmx with credentials → returns auth token in SOAP header
- *   2. JSON mode: POST /xWeb/JSON/Authenticate with Basic Auth → returns token
- *      Pass token as Authorization: Bearer {token} on subsequent calls
- * Base URL: https://{site}/xWeb/JSON/{MethodName} (JSON mode)
- *           https://{site}/xWeb/netForumXML.asmx (SOAP mode)
- * Pagination: Results returned in full via WEBQuery/GetQuery — no standard offset/limit
- * Rate limits: Instance-dependent (not documented)
- * Incremental: Via query parameters (date range filters in WEBQuery)
- * CRUD: Via facade CRUD methods (GetFacadeObject, InsertFacadeObject, UpdateFacadeObject, DeleteFacadeObject)
- *
- * API Categories:
- *   - JSON over xWeb (implemented) — RESTful JSON wrapper over xWeb methods
- *   - SOAP xWeb (NOT implemented) — legacy XML, JSON mode preferred
- *   - SQL Views (NOT implemented) — direct SQL access, not API-based
- *   - Webhooks (NOT available) — no webhook/CDC support in NetForum
+ *   - WSDL (primary)  : https://myasm.asm.org/xweb/secure/netforumxml.asmx?WSDL
+ *   - xWeb Overview   : https://documentation.abila.com/netforum-enterprise/2017.1/Content/xWeb/XWeb_Overview.htm
+ *   - GetQuery        : https://documentation.abila.com/netforum-enterprise/2017.1/Content/xWeb/Methods/GetQuery.htm
  */
 import { RegisterClass } from '@memberjunction/global';
 import { Metadata, type IMetadataProvider, type UserInfo } from '@memberjunction/core';
-import type { MJCompanyIntegrationEntity, MJCredentialEntity } from '@memberjunction/core-entities';
+import type {
+    MJCompanyIntegrationEntity,
+    MJCredentialEntity,
+    MJIntegrationObjectEntity,
+} from '@memberjunction/core-entities';
 import {
-    BaseIntegrationConnector, BaseRESTIntegrationConnector,
-    type RESTAuthContext, type RESTResponse, type PaginationState, type PaginationType,
-    type ConnectionTestResult, type ExternalRecord, type DefaultFieldMapping,
-    type FetchContext, type FetchBatchResult, type CreateRecordContext, type UpdateRecordContext,
-    type DeleteRecordContext, type CRUDResult, type IntegrationObjectInfo, type ExternalObjectSchema, type ExternalFieldSchema,
-    type SourceSchemaInfo, type SourceFieldInfo,
+    BaseIntegrationConnector,
+    BaseRESTIntegrationConnector,
+    type RESTAuthContext,
+    type RESTResponse,
+    type PaginationState,
+    type PaginationType,
+    type ConnectionTestResult,
+    type ExternalRecord,
+    type FetchContext,
+    type FetchBatchResult,
+    type CreateRecordContext,
+    type UpdateRecordContext,
+    type DeleteRecordContext,
+    type CRUDResult,
+    type ExternalObjectSchema,
+    type ExternalFieldSchema,
 } from '@memberjunction/integration-engine';
 
-export interface NetForumConnectionConfig { BaseURL: string; Username: string; Password: string; }
-interface NFAuthContext extends RESTAuthContext { Config: NetForumConnectionConfig; }
-interface CachedToken { Token: string; ExpiresAt: number; }
+// ─── Constants ───────────────────────────────────────────────────────
 
+/** Avectra-era SOAP namespace, retained by Community Brands. All ops + types use it. */
+const SOAP_NS = 'http://www.avectra.com/2005/';
+/** Canonical xWeb SOAP endpoint path (per-tenant host; path is constant). */
+const DEFAULT_SOAP_PATH = '/xweb/secure/netForumXML.asmx';
 const MAX_RETRIES = 3;
 const REQUEST_TIMEOUT_MS = 30_000;
 const MIN_REQUEST_INTERVAL_MS = 200;
+/** Session-token TTL. netFORUM does not publish a token lifetime; re-auth on 401 covers expiry. */
+const TOKEN_TTL_MS = 3_600_000;
 
-// NetForum facade objects — each maps to a GetFacadeObject/WEBQuery target
-const NF_OBJECTS: IntegrationObjectInfo[] = [
-    { Name: 'Individual', DisplayName: 'Individual', Description: 'Individual contacts/members', SupportsWrite: true, Fields: [
-        { Name: 'ind_cst_key', DisplayName: 'Customer Key', Type: 'string', IsRequired: false, IsReadOnly: true, IsPrimaryKey: true, Description: 'Customer GUID' },
-        { Name: 'ind_last_updated_dt', DisplayName: 'Last Updated', Type: 'datetime', IsRequired: false, IsReadOnly: true, IsPrimaryKey: false, Description: 'Incremental date' },
-    ]},
-    { Name: 'Organization', DisplayName: 'Organization', Description: 'Organization/company records', SupportsWrite: true, Fields: [
-        { Name: 'org_cst_key', DisplayName: 'Customer Key', Type: 'string', IsRequired: false, IsReadOnly: true, IsPrimaryKey: true, Description: 'Customer GUID' },
-    ]},
-    { Name: 'Membership', DisplayName: 'Membership', Description: 'Membership records', SupportsWrite: true, Fields: [
-        { Name: 'mbr_key', DisplayName: 'Membership Key', Type: 'string', IsRequired: false, IsReadOnly: true, IsPrimaryKey: true, Description: 'Membership GUID' },
-        { Name: 'mbr_cst_key', DisplayName: 'Customer Key', Type: 'string', IsRequired: false, IsReadOnly: false, IsPrimaryKey: false, Description: 'FK → Individual/Organization' },
-    ]},
-    { Name: 'MembershipType', DisplayName: 'Membership Type', Description: 'Membership type definitions', SupportsWrite: false, Fields: [
-        { Name: 'mbt_key', DisplayName: 'Type Key', Type: 'string', IsRequired: false, IsReadOnly: true, IsPrimaryKey: true, Description: 'Type GUID' },
-    ]},
-    { Name: 'Event', DisplayName: 'Event', Description: 'Events and conferences', SupportsWrite: true, Fields: [
-        { Name: 'evt_key', DisplayName: 'Event Key', Type: 'string', IsRequired: false, IsReadOnly: true, IsPrimaryKey: true, Description: 'Event GUID' },
-        { Name: 'evt_start_dt', DisplayName: 'Start Date', Type: 'datetime', IsRequired: false, IsReadOnly: false, IsPrimaryKey: false, Description: 'Incremental date' },
-    ]},
-    { Name: 'EventRegistration', DisplayName: 'Event Registration', Description: 'Event registrations', SupportsWrite: true, Fields: [
-        { Name: 'reg_key', DisplayName: 'Registration Key', Type: 'string', IsRequired: false, IsReadOnly: true, IsPrimaryKey: true, Description: 'Registration GUID' },
-        { Name: 'reg_evt_key', DisplayName: 'Event Key', Type: 'string', IsRequired: true, IsReadOnly: false, IsPrimaryKey: false, Description: 'FK → Event' },
-        { Name: 'reg_cst_key', DisplayName: 'Customer Key', Type: 'string', IsRequired: false, IsReadOnly: false, IsPrimaryKey: false, Description: 'FK → Individual' },
-    ]},
-    { Name: 'Committee', DisplayName: 'Committee', Description: 'Committees and boards', SupportsWrite: true, Fields: [
-        { Name: 'cmt_key', DisplayName: 'Committee Key', Type: 'string', IsRequired: false, IsReadOnly: true, IsPrimaryKey: true, Description: 'Committee GUID' },
-    ]},
-    { Name: 'CommitteeMember', DisplayName: 'Committee Member', Description: 'Committee membership', SupportsWrite: true, Fields: [
-        { Name: 'cmm_key', DisplayName: 'Member Key', Type: 'string', IsRequired: false, IsReadOnly: true, IsPrimaryKey: true, Description: 'Committee member GUID' },
-        { Name: 'cmm_cmt_key', DisplayName: 'Committee Key', Type: 'string', IsRequired: true, IsReadOnly: false, IsPrimaryKey: false, Description: 'FK → Committee' },
-        { Name: 'cmm_cst_key', DisplayName: 'Customer Key', Type: 'string', IsRequired: false, IsReadOnly: false, IsPrimaryKey: false, Description: 'FK → Individual' },
-    ]},
-    { Name: 'Invoice', DisplayName: 'Invoice', Description: 'Invoices', SupportsWrite: true, Fields: [
-        { Name: 'inv_key', DisplayName: 'Invoice Key', Type: 'string', IsRequired: false, IsReadOnly: true, IsPrimaryKey: true, Description: 'Invoice GUID' },
-        { Name: 'inv_cst_key', DisplayName: 'Customer Key', Type: 'string', IsRequired: false, IsReadOnly: false, IsPrimaryKey: false, Description: 'FK → Individual/Organization' },
-    ]},
-    { Name: 'Payment', DisplayName: 'Payment', Description: 'Payment records', SupportsWrite: true, Fields: [
-        { Name: 'pmt_key', DisplayName: 'Payment Key', Type: 'string', IsRequired: false, IsReadOnly: true, IsPrimaryKey: true, Description: 'Payment GUID' },
-    ]},
-    { Name: 'Product', DisplayName: 'Product', Description: 'Products for sale', SupportsWrite: true, Fields: [
-        { Name: 'prd_key', DisplayName: 'Product Key', Type: 'string', IsRequired: false, IsReadOnly: true, IsPrimaryKey: true, Description: 'Product GUID' },
-    ]},
-    { Name: 'Order', DisplayName: 'Order', Description: 'Sales orders', SupportsWrite: true, Fields: [
-        { Name: 'ord_key', DisplayName: 'Order Key', Type: 'string', IsRequired: false, IsReadOnly: true, IsPrimaryKey: true, Description: 'Order GUID' },
-        { Name: 'ord_cst_key', DisplayName: 'Customer Key', Type: 'string', IsRequired: false, IsReadOnly: false, IsPrimaryKey: false, Description: 'FK → Individual/Organization' },
-    ]},
-    { Name: 'Donation', DisplayName: 'Donation', Description: 'Donation/gift records', SupportsWrite: true, Fields: [
-        { Name: 'don_key', DisplayName: 'Donation Key', Type: 'string', IsRequired: false, IsReadOnly: true, IsPrimaryKey: true, Description: 'Donation GUID' },
-        { Name: 'don_cst_key', DisplayName: 'Customer Key', Type: 'string', IsRequired: false, IsReadOnly: false, IsPrimaryKey: false, Description: 'FK → Individual/Organization' },
-    ]},
-    { Name: 'Address', DisplayName: 'Address', Description: 'Customer addresses', SupportsWrite: true, Fields: [
-        { Name: 'adr_key', DisplayName: 'Address Key', Type: 'string', IsRequired: false, IsReadOnly: true, IsPrimaryKey: true, Description: 'Address GUID' },
-        { Name: 'adr_cst_key', DisplayName: 'Customer Key', Type: 'string', IsRequired: false, IsReadOnly: false, IsPrimaryKey: false, Description: 'FK → Individual/Organization' },
-    ]},
-    { Name: 'Session', DisplayName: 'Session', Description: 'Event sessions', SupportsWrite: true, Fields: [
-        { Name: 'ses_key', DisplayName: 'Session Key', Type: 'string', IsRequired: false, IsReadOnly: true, IsPrimaryKey: true, Description: 'Session GUID' },
-        { Name: 'ses_evt_key', DisplayName: 'Event Key', Type: 'string', IsRequired: true, IsReadOnly: false, IsPrimaryKey: false, Description: 'FK → Event' },
-    ]},
-    { Name: 'Subscription', DisplayName: 'Subscription', Description: 'Publication subscriptions', SupportsWrite: true, Fields: [
-        { Name: 'sub_key', DisplayName: 'Subscription Key', Type: 'string', IsRequired: false, IsReadOnly: true, IsPrimaryKey: true, Description: 'Subscription GUID' },
-        { Name: 'sub_cst_key', DisplayName: 'Customer Key', Type: 'string', IsRequired: false, IsReadOnly: false, IsPrimaryKey: false, Description: 'FK → Individual/Organization' },
-    ]},
-    { Name: 'Certification', DisplayName: 'Certification', Description: 'Professional certifications', SupportsWrite: true, Fields: [
-        { Name: 'crt_key', DisplayName: 'Certification Key', Type: 'string', IsRequired: false, IsReadOnly: true, IsPrimaryKey: true, Description: 'Certification GUID' },
-        { Name: 'crt_cst_key', DisplayName: 'Customer Key', Type: 'string', IsRequired: false, IsReadOnly: false, IsPrimaryKey: false, Description: 'FK → Individual' },
-    ]},
-    { Name: 'ContinuingEducation', DisplayName: 'CE Credit', Description: 'Continuing education credits', SupportsWrite: true, Fields: [
-        { Name: 'ceu_key', DisplayName: 'CE Key', Type: 'string', IsRequired: false, IsReadOnly: true, IsPrimaryKey: true, Description: 'CE GUID' },
-        { Name: 'ceu_cst_key', DisplayName: 'Customer Key', Type: 'string', IsRequired: false, IsReadOnly: false, IsPrimaryKey: false, Description: 'FK → Individual' },
-    ]},
-];
+// ─── Config / auth types ─────────────────────────────────────────────
+
+export interface NetForumConnectionConfig {
+    BaseURL: string;
+    Username: string;
+    Password: string;
+}
+
+interface NFAuthContext extends RESTAuthContext {
+    /** The session token returned by Authenticate (carried in the SOAP AuthorizationToken header). */
+    Token: string;
+    Config: NetForumConnectionConfig;
+}
+
+interface CachedToken {
+    Token: string;
+    ExpiresAt: number;
+}
+
+/**
+ * The per-IO access path the extractor emits into IntegrationObject.Configuration. Read at fetch
+ * time so the connector walks the documented door/query rather than assuming one flat query per
+ * object. All fields optional — a depth-0 directly-queryable object carries an empty nestingPath.
+ */
+interface NFAccessPath {
+    door?: string;
+    queryObject?: string;
+    nestingPath?: string[];
+    doorArgs?: { szObjectName?: string; topModifier?: string };
+}
+
+/** Shape of the per-IO Configuration JSON relevant to this connector. */
+interface NFObjectConfig {
+    accessPath?: NFAccessPath;
+    stableOrderingKey?: string;
+    soapEndpoint?: string;
+    soapNamespace?: string;
+    getOperation?: string;
+    createSoapAction?: string;
+    updateSoapAction?: string;
+    writeOps?: { createOp?: string; updateOp?: string };
+}
 
 @RegisterClass(BaseIntegrationConnector, 'NetForumConnector')
 export class NetForumConnector extends BaseRESTIntegrationConnector {
@@ -138,356 +147,720 @@ export class NetForumConnector extends BaseRESTIntegrationConnector {
     private lastRequestTime = 0;
 
     public override get IntegrationName(): string { return 'NetForum Enterprise'; }
+
+    // Capability flags — kept in lockstep with the metadata's per-operation columns.
+    // Create/Update are declared on a subset of IOs (those with WEB*Insert/Update or a facade op);
+    // the generic CRUD path throws for an IO whose columns are null, so a flag here only asserts
+    // "at least one IO supports it". Delete stays false (DeleteFacadeObject unconfirmed in docs).
     public override get SupportsCreate(): boolean { return true; }
     public override get SupportsUpdate(): boolean { return true; }
-    // Vendor docs document InsertFacadeObject + UpdateFacadeObject; no DeleteFacadeObject
-    // appears in any reachable doc page. NetForum more commonly uses status flags ("soft
-    // delete") rather than hard delete. Keeping the flag false until DeleteFacadeObject
-    // is confirmed from a real vendor source — DeleteRecord returns a clean error.
     public override get SupportsDelete(): boolean { return false; }
 
     /**
-     * Resolves the canonical "last modified" column for a NetForum facade object.
-     * NetForum uses prefixed names (ind_last_updated_dt, evt_last_updated_dt, etc.)
-     * rather than a universal LastModifiedDate column. Falls back to the column
-     * declared in NF_OBJECTS, then to a generic 'last_updated_dt' if no static
-     * entry exists.
+     * §7 — discovery is NOT an authoritative full-gamut enumeration. `DiscoverObjects` returns the
+     * Declared baseline (engine cache) and GetQueryDefinition only extends per-object fields; neither
+     * enumerates the complete set of objects the credentials expose (customer-installed queries vary).
+     * So absence in a refresh proves nothing → the comprehensive-refresh deactivation path must stay
+     * off. Returning false keeps the Declared metadata safe from wrongful deactivation.
      */
-    private ResolveWatermarkColumn(objectName: string): string {
-        const obj = NF_OBJECTS.find(o => o.Name.toLowerCase() === objectName.toLowerCase());
-        if (obj) {
-            // Look for an explicit timestamp field on the static catalog
-            const timestampField = obj.Fields.find(f =>
-                /datetime/i.test(f.Type) && /last|updated|modified/i.test(f.Name)
-            );
-            if (timestampField) return timestampField.Name;
-        }
-        // Fallback: NetForum's most common naming convention is <prefix>_last_updated_dt.
-        // Without a known prefix per object, return a generic name + warn.
-        console.warn(`[NetForum] No known watermark column for object '${objectName}'; using fallback 'last_updated_dt'`);
-        return 'last_updated_dt';
-    }
+    public override get DiscoveryIsAuthoritative(): boolean { return false; }
+
+    // ─── Auth — two-step SOAP token ──────────────────────────────────
 
     /**
-     * Resolves the PROVABLE watermark column for a NetForum facade object — i.e.
-     * a column the object's OWN static catalog declares as a datetime whose name
-     * matches last/updated/modified. Unlike ResolveWatermarkColumn(), this NEVER
-     * falls back to a guessed name: if the object declares no such field, it
-     * returns undefined so callers leave IncrementalWatermarkField unset.
+     * Step 1 of the two-step auth: POST a SOAP `Authenticate(userName, password)` envelope (which
+     * carries NO AuthorizationToken header — it is the bootstrap) and read the token string from
+     * `AuthenticateResult`. The token is cached and re-used until its TTL elapses or a 401 forces
+     * re-auth. Credentials go in the SOAP body elements — there is no HTTP Basic / Bearer here.
      */
-    private ResolveDeclaredWatermarkColumn(objectName: string): string | undefined {
-        const obj = NF_OBJECTS.find(o => o.Name.toLowerCase() === objectName.toLowerCase());
-        const timestampField = obj?.Fields.find(f =>
-            /datetime/i.test(f.Type) && /last|updated|modified/i.test(f.Name)
-        );
-        return timestampField?.Name;
-    }
-
-    /**
-     * Resolves a field's declared foreign-key target to a sibling object actually
-     * declared in NF_OBJECTS. The static catalog encodes FK intent in the field
-     * Description (e.g. 'FK → Event'). This promotes that declaration into the
-     * framework's IsForeignKey/ForeignKeyTarget slots — but ONLY when the target
-     * resolves to exactly ONE declared sibling object. Polymorphic targets
-     * (e.g. 'FK → Individual/Organization') name two objects and are skipped.
-     */
-    private ResolveForeignKeyTarget(description: string | undefined): string | null {
-        if (!description) return null;
-        const match = description.match(/^FK\s*(?:→|->)\s*(.+)$/i);
-        if (!match) return null;
-        const target = match[1].trim();
-        // Polymorphic refs (e.g. 'Individual/Organization') name multiple objects — skip.
-        if (target.includes('/')) return null;
-        const sibling = NF_OBJECTS.find(o => o.Name.toLowerCase() === target.toLowerCase());
-        return sibling ? sibling.Name : null;
-    }
-
-    public override GetIntegrationObjects(): IntegrationObjectInfo[] { return NF_OBJECTS; }
-
-    public override GetActionGeneratorConfig() {
-        const config = super.GetActionGeneratorConfig();
-        if (!config) return null;
-        config.IconClass = 'fa-solid fa-network-wired';
-        config.CategoryDescription = 'NetForum Enterprise AMS for members, events, committees, and orders';
-        config.ParentCategoryName = 'Association Management';
-        config.IncludeSearch = true; config.IncludeList = true;
-        return config;
-    }
-
-    public override async DiscoverObjects(_ci: MJCompanyIntegrationEntity, _cu: UserInfo): Promise<ExternalObjectSchema[]> {
-        return NF_OBJECTS.map(o => ({ Name: o.Name, Label: o.DisplayName, Description: o.Description, SupportsIncrementalSync: true, SupportsWrite: o.SupportsWrite ?? false }));
-    }
-    public override async DiscoverFields(ci: MJCompanyIntegrationEntity, objectName: string, cu: UserInfo): Promise<ExternalFieldSchema[]> {
-        // Dynamic: fetch one record via GetQuery to discover all fields
-        try {
-            const auth = await this.Authenticate(ci, cu) as NFAuthContext;
-            const headers = this.BuildHeaders(auth);
-            const url = `${auth.Config.BaseURL}/xWeb/JSON/GetQuery?szObjectName=${objectName}&szColumnList=*&intRecordCount=1`;
-            const response = await this.MakeHTTPRequest(auth, url, 'GET', headers);
-            if (response.Status === 200) {
-                const records = this.NormalizeResponse(response.Body, null);
-                if (records.length > 0) return this.InferFieldsFromSample(records[0], objectName);
-            }
-        } catch { /* fall through to static */ }
-        const obj = NF_OBJECTS.find(o => o.Name.toLowerCase() === objectName.toLowerCase());
-        if (!obj) return [];
-        return obj.Fields.map(f => {
-            const fkTarget = this.ResolveForeignKeyTarget(f.Description);
-            return {
-                Name: f.Name, Label: f.DisplayName, Description: f.Description, DataType: f.Type,
-                IsRequired: f.IsRequired, IsUniqueKey: f.IsPrimaryKey, IsReadOnly: f.IsReadOnly,
-                IsForeignKey: fkTarget !== null, ForeignKeyTarget: fkTarget,
-            };
-        });
-    }
-
-    private InferFieldsFromSample(sample: Record<string, unknown>, objectName: string): ExternalFieldSchema[] {
-        const staticObj = NF_OBJECTS.find(o => o.Name.toLowerCase() === objectName.toLowerCase());
-        const staticMap = new Map((staticObj?.Fields ?? []).map(f => [f.Name.toLowerCase(), f]));
-        const fields: ExternalFieldSchema[] = [];
-        for (const [key, value] of Object.entries(sample)) {
-            const sf = staticMap.get(key.toLowerCase());
-            const fkTarget = this.ResolveForeignKeyTarget(sf?.Description);
-            fields.push({
-                Name: key, Label: sf?.DisplayName ?? key, Description: sf?.Description ?? '',
-                DataType: sf?.Type ?? this.InferType(value),
-                IsRequired: sf?.IsRequired ?? false, IsUniqueKey: sf?.IsPrimaryKey ?? false, IsReadOnly: sf?.IsReadOnly ?? false,
-                IsForeignKey: fkTarget !== null, ForeignKeyTarget: fkTarget,
-            });
-        }
-        return fields;
-    }
-    private InferType(v: unknown): string {
-        if (v === null || v === undefined) return 'string';
-        if (typeof v === 'number') return Number.isInteger(v) ? 'number' : 'decimal';
-        if (typeof v === 'boolean') return 'boolean';
-        if (typeof v === 'string' && /^\d{4}-\d{2}-\d{2}/.test(v)) return 'datetime';
-        return 'string';
-    }
-
-    /**
-     * Override IntrospectSchema so the schema-builder receives the framework's
-     * provable static metadata: foreign keys (declared via each FK field's
-     * 'FK → <Sibling>' Description, resolved to a declared sibling object) and,
-     * for objects whose own catalog declares a last/updated/modified datetime
-     * column, IncrementalWatermarkField. No watermark is invented — objects
-     * without a declared timestamp leave the slot unset.
-     */
-    public override async IntrospectSchema(
-        companyIntegration: MJCompanyIntegrationEntity,
-        contextUser: UserInfo
-    ): Promise<SourceSchemaInfo> {
-        const objects = await this.DiscoverObjects(companyIntegration, contextUser);
-        const result: SourceSchemaInfo = { Objects: [] };
-
-        for (const obj of objects) {
-            const fields = await this.DiscoverFields(companyIntegration, obj.Name, contextUser);
-            const sourceFields: SourceFieldInfo[] = fields.map(f => ({
-                Name: f.Name,
-                Label: f.Label ?? f.Name,
-                Description: f.Description,
-                SourceType: f.DataType,
-                IsRequired: f.IsRequired ?? false,
-                IsPrimaryKey: f.IsUniqueKey ?? false,
-                IsForeignKey: f.IsForeignKey ?? false,
-                ForeignKeyTarget: f.ForeignKeyTarget ?? null,
-                MaxLength: null,
-                Precision: null,
-                Scale: null,
-                DefaultValue: null,
-            }));
-
-            result.Objects.push({
-                ExternalName: obj.Name,
-                ExternalLabel: obj.Label ?? obj.Name,
-                Description: obj.Description,
-                Fields: sourceFields,
-                PrimaryKeyFields: sourceFields.filter(f => f.IsPrimaryKey).map(f => f.Name),
-                Relationships: sourceFields
-                    .filter(f => f.IsForeignKey && f.ForeignKeyTarget)
-                    .map(f => ({ FieldName: f.Name, TargetObject: f.ForeignKeyTarget!, TargetField: 'ID' })),
-                // Only set when the object's OWN catalog declares a last/updated/modified
-                // datetime column (provable). Undefined otherwise — never guessed.
-                IncrementalWatermarkField: this.ResolveDeclaredWatermarkColumn(obj.Name),
-            });
-        }
-
-        return result;
-    }
-
-    // ─── Auth (JSON mode) ──────────────────────────────────────────────
-
     protected async Authenticate(ci: MJCompanyIntegrationEntity, cu: UserInfo): Promise<RESTAuthContext> {
-        if (this.tokenCache && this.tokenCache.ExpiresAt > Date.now() + 60_000) {
-            const config = await this.ParseConfig(ci, cu);
-            return { Token: this.tokenCache.Token, TokenType: 'Bearer', Config: config } as NFAuthContext;
-        }
         const config = await this.ParseConfig(ci, cu);
-        const basicAuth = Buffer.from(`${config.Username}:${config.Password}`).toString('base64');
-        const response = await fetch(`${config.BaseURL}/xWeb/JSON/Authenticate`, {
-            method: 'POST', headers: { 'Authorization': `Basic ${basicAuth}`, 'Content-Type': 'application/json' },
-            signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
+        if (this.tokenCache && this.tokenCache.ExpiresAt > Date.now() + 60_000) {
+            return { Token: this.tokenCache.Token, Config: config } as NFAuthContext;
+        }
+        const body = this.BuildSoapEnvelope('Authenticate', {
+            userName: config.Username,
+            password: config.Password,
         });
-        if (!response.ok) throw new Error(`NetForum auth failed: ${response.status}`);
-
-        // Vendor doc canonical: the token is returned in the WWW-Authenticate
-        // RESPONSE HEADER, in the form: 'Bearer token = <guid>'. Older versions
-        // sometimes also place it in a JSON body; fall back to body parsing if
-        // the header isn't present.
-        let token: string | null = null;
-        const wwwAuth = response.headers.get('www-authenticate') || response.headers.get('WWW-Authenticate');
-        if (wwwAuth) {
-            // Match patterns like:  'Bearer token = abcd-1234'  or  'Bearer abcd-1234'
-            const match = wwwAuth.match(/Bearer\s+(?:token\s*=\s*)?([A-Fa-f0-9-]{8,})/i);
-            if (match) token = match[1];
+        const url = `${config.BaseURL}${DEFAULT_SOAP_PATH}`;
+        const headers = this.SoapHeaders('Authenticate');
+        const response = await this.MakeRawHTTPRequest(url, 'POST', headers, body);
+        if (response.Status < 200 || response.Status >= 300) {
+            throw new Error(`NetForum Authenticate failed: HTTP ${response.Status}`);
         }
+        const token = this.ParseSoapScalar(this.AsText(response.Body), 'AuthenticateResult');
         if (!token) {
-            try {
-                const body = await response.json() as Record<string, unknown>;
-                token = (body['Token'] as string | undefined) ?? (body['token'] as string | undefined) ?? null;
-            } catch {
-                /* not JSON */
-            }
+            throw new Error('NetForum Authenticate response contained no token (AuthenticateResult element)');
         }
-        if (!token) {
-            throw new Error('NetForum auth response contained no token (checked WWW-Authenticate header and JSON body)');
-        }
-
-        this.tokenCache = { Token: token, ExpiresAt: Date.now() + (3600 * 1000) };
-        return { Token: token, TokenType: 'Bearer', Config: config } as NFAuthContext;
+        this.tokenCache = { Token: token, ExpiresAt: Date.now() + TOKEN_TTL_MS };
+        return { Token: token, Config: config } as NFAuthContext;
     }
 
-    private async ParseConfig(ci: MJCompanyIntegrationEntity, cu?: UserInfo, provider?: IMetadataProvider): Promise<NetForumConnectionConfig> {
-        // Use typed property — never .Get()/.Set() on entity-typed objects (CLAUDE.md §2b).
-        const credentialID = ci.CredentialID;
-        if (credentialID) {
-            const md = provider ?? new Metadata();
-            const cred = await md.GetEntityObject<MJCredentialEntity>('MJ: Credentials', cu);
-            if (await cred.Load(credentialID) && cred.Values) {
-                const p = JSON.parse(cred.Values) as Record<string, string>;
-                return { BaseURL: p['BaseURL'] ?? '', Username: p['Username'] ?? '', Password: p['Password'] ?? '' };
-            }
+    private async ParseConfig(
+        ci: MJCompanyIntegrationEntity,
+        cu?: UserInfo,
+        provider?: IMetadataProvider,
+    ): Promise<NetForumConnectionConfig> {
+        if (ci.CredentialID) {
+            const fromCred = await this.ParseConfigFromCredential(ci.CredentialID, cu, provider);
+            if (fromCred) return fromCred;
         }
-        throw new Error('No NetForum credentials found.');
+        if (ci.Configuration) {
+            const parsed = JSON.parse(ci.Configuration) as Record<string, string>;
+            return this.ExtractConfig(parsed);
+        }
+        throw new Error('NetForum connector requires either CredentialID or Configuration JSON');
     }
+
+    private async ParseConfigFromCredential(
+        credentialID: string,
+        cu?: UserInfo,
+        provider?: IMetadataProvider,
+    ): Promise<NetForumConnectionConfig | null> {
+        const md = provider ?? new Metadata();
+        const cred = await md.GetEntityObject<MJCredentialEntity>('MJ: Credentials', cu);
+        const loaded = await cred.Load(credentialID);
+        if (!loaded || !cred.Values) return null;
+        const values = JSON.parse(cred.Values) as Record<string, string>;
+        return this.ExtractConfig(values);
+    }
+
+    private ExtractConfig(values: Record<string, string>): NetForumConnectionConfig {
+        const get = (...keys: string[]): string | undefined => {
+            for (const key of keys) {
+                const hit = Object.entries(values).find(([k]) => k.toLowerCase() === key.toLowerCase());
+                if (hit) return String(hit[1] ?? '');
+            }
+            return undefined;
+        };
+        const baseURL = get('BaseURL', 'BaseUrl', 'base_url');
+        const username = get('Username', 'username', 'user', 'userName');
+        const password = get('Password', 'password', 'pass');
+        if (!baseURL) throw new Error('NetForum configuration missing required field: BaseURL');
+        if (!username) throw new Error('NetForum configuration missing required field: Username');
+        if (!password) throw new Error('NetForum configuration missing required field: Password');
+        return { BaseURL: this.StripTrailingSlash(baseURL), Username: username, Password: password };
+    }
+
+    private StripTrailingSlash(s: string): string { return s.replace(/\/+$/, ''); }
 
     public async TestConnection(ci: MJCompanyIntegrationEntity, cu: UserInfo): Promise<ConnectionTestResult> {
         try {
             const auth = await this.Authenticate(ci, cu) as NFAuthContext;
-            // Try fetching one Individual record
-            const url = `${auth.Config.BaseURL}/xWeb/JSON/GetQuery?szObjectName=Individual&szColumnList=ind_cst_key&intRecordCount=1`;
-            const r = await this.MakeHTTPRequest(auth, url, 'GET', this.BuildHeaders(auth));
-            return r.Status === 200 ? { Success: true, Message: 'Connected to NetForum Enterprise' } : { Success: false, Message: `API returned ${r.Status}` };
-        } catch (err) { return { Success: false, Message: err instanceof Error ? err.message : String(err) }; }
-    }
-
-    protected GetBaseURL(_ci: MJCompanyIntegrationEntity, auth: RESTAuthContext): string { return (auth as NFAuthContext).Config.BaseURL; }
-    protected override BuildPaginatedURL(basePath: string, _o: { PaginationType: string; DefaultPageSize: number }, _p: number, _off: number): string { return basePath; }
-
-    protected NormalizeResponse(rawBody: unknown, _key: string | null): Record<string, unknown>[] {
-        if (Array.isArray(rawBody)) return rawBody as Record<string, unknown>[];
-        const body = rawBody as Record<string, unknown>;
-        // NetForum returns DataSet-style { Table: [{...}] } or array
-        for (const key of Object.keys(body)) {
-            if (Array.isArray(body[key])) return body[key] as Record<string, unknown>[];
+            // Read-only smoke: GetVersion is a harmless, token-gated SystemInfo op.
+            const url = `${auth.Config.BaseURL}${DEFAULT_SOAP_PATH}`;
+            const body = this.BuildSoapEnvelope('GetVersion', {}, auth.Token);
+            const r = await this.MakeRawHTTPRequest(url, 'POST', this.SoapHeaders('GetVersion'), body);
+            return r.Status >= 200 && r.Status < 300
+                ? { Success: true, Message: 'Connected to netFORUM Enterprise xWeb (SOAP)' }
+                : { Success: false, Message: `xWeb returned HTTP ${r.Status}` };
+        } catch (err) {
+            return { Success: false, Message: err instanceof Error ? err.message : String(err) };
         }
-        if (body && Object.keys(body).length > 0) return [body];
-        return [];
-    }
-    protected ExtractPaginationInfo(_rb: unknown, _pt: PaginationType, _cp: number, _co: number, _ps: number): PaginationState {
-        return { HasMore: false }; // NetForum returns full result sets
     }
 
-    // ─── FetchChanges — via GetQuery JSON method ───────────────────────
+    // ─── Discovery — Declared cache + runtime GetQueryDefinition ──────
 
+    /**
+     * Standard objects = the Declared metadata (engine cache of persisted IntegrationObject rows).
+     * NO hardcoded catalog. The base implementation reads exactly the credential-free Declared
+     * universe; a live credential only ADDS customer-installed query objects (the Discovered
+     * extension), it never supplies the baseline — so this re-yields the standard universe
+     * credential-free and the runtime structure self-check passes without a token.
+     */
+    public override async DiscoverObjects(
+        ci: MJCompanyIntegrationEntity,
+        cu: UserInfo,
+    ): Promise<ExternalObjectSchema[]> {
+        return super.DiscoverObjects(ci, cu);
+    }
+
+    /**
+     * Two-stage field discovery. Stage 1 returns the Declared field set (engine cache). Stage 2, when
+     * a credential is available, calls the GetQueryDefinition MECHANISM and parses the returned SQL
+     * column definition (Object → ListTable → ListFromTables → Column[]) into ExternalFieldSchema —
+     * this surfaces customer-added columns the static metadata never saw. With no credential, or on
+     * any error, it degrades to the Declared fields (never throws, never bakes a catalog).
+     */
+    public override async DiscoverFields(
+        ci: MJCompanyIntegrationEntity,
+        objectName: string,
+        cu: UserInfo,
+    ): Promise<ExternalFieldSchema[]> {
+        const declared = await super.DiscoverFields(ci, objectName, cu);
+        // The base FieldEntityToSchema folds PK into IsUniqueKey and never sets IsPrimaryKey, so
+        // re-derive the honest IsPrimaryKey from the cached IOF entities (which carry it explicitly).
+        const pkNames = this.DeclaredPrimaryKeyNames(ci, objectName);
+        const declaredByName = new Map(
+            declared.map(f => [f.Name.toLowerCase(), { ...f, IsPrimaryKey: pkNames.has(f.Name.toLowerCase()) }]),
+        );
+        try {
+            const auth = await this.Authenticate(ci, cu) as NFAuthContext;
+            const url = `${auth.Config.BaseURL}${DEFAULT_SOAP_PATH}`;
+            const body = this.BuildSoapEnvelope('GetQueryDefinition', { szObjectName: objectName }, auth.Token);
+            const r = await this.MakeRawHTTPRequest(url, 'POST', this.SoapHeaders('GetQueryDefinition'), body);
+            if (r.Status >= 200 && r.Status < 300) {
+                const discovered = this.ParseQueryDefinition(this.AsText(r.Body), declaredByName);
+                if (discovered.length > 0) return discovered;
+            }
+        } catch {
+            // credential-free / network / parse failure → fall through to Declared
+        }
+        return declared;
+    }
+
+    /**
+     * Parses a GetQueryDefinition response (the SQL column definition) into ExternalFieldSchema[].
+     * Each `<Column>` carries mdc_name / mdc_description / mdc_data_type / mdc_nullable /
+     * mdc_width_max. Declared metadata wins for PK identity (a column definition does not mark a PK);
+     * discovery contributes the full column corpus + provable nullability/length.
+     */
+    private ParseQueryDefinition(
+        xml: string,
+        declaredByName: Map<string, ExternalFieldSchema>,
+    ): ExternalFieldSchema[] {
+        const out: ExternalFieldSchema[] = [];
+        const seen = new Set<string>();
+        for (const colXml of this.ExtractElements(xml, 'Column')) {
+            const name = this.ParseSoapScalar(colXml, 'mdc_name');
+            if (!name || seen.has(name.toLowerCase())) continue;
+            seen.add(name.toLowerCase());
+            const declared = declaredByName.get(name.toLowerCase());
+            const dataType = this.ParseSoapScalar(colXml, 'mdc_data_type');
+            const description = this.ParseSoapScalar(colXml, 'mdc_description');
+            const nullable = this.ParseSoapScalar(colXml, 'mdc_nullable');
+            const widthRaw = this.ParseSoapScalar(colXml, 'mdc_width_max');
+            const maxLength = widthRaw && /^\d+$/.test(widthRaw) ? Number(widthRaw) : null;
+            // AllowsNull provable-only: 'mdc_nullable' is an explicit source flag. "0"/"false"/"no" ⇒ NOT NULL.
+            const allowsNull = nullable == null
+                ? undefined
+                : !/^(0|false|no|n)$/i.test(nullable.trim());
+            out.push({
+                Name: name,
+                Label: declared?.Label ?? name,
+                Description: declared?.Description ?? (description || undefined),
+                DataType: declared?.DataType ?? this.MapSoapType(dataType),
+                IsRequired: declared?.IsRequired ?? false,
+                AllowsNull: allowsNull,
+                IsPrimaryKey: declared?.IsPrimaryKey ?? false,
+                IsUniqueKey: declared?.IsUniqueKey ?? false,
+                IsReadOnly: declared?.IsReadOnly ?? false,
+                IsForeignKey: declared?.IsForeignKey ?? false,
+                ForeignKeyTarget: declared?.ForeignKeyTarget ?? null,
+                MaxLength: maxLength,
+            });
+        }
+        // Re-add any Declared field GetQueryDefinition did not surface (provable-only baseline never lost).
+        for (const [key, f] of declaredByName) {
+            if (!seen.has(key)) out.push(f);
+        }
+        return out;
+    }
+
+    private MapSoapType(sqlType: string | null): string {
+        if (!sqlType) return 'string';
+        const t = sqlType.toLowerCase();
+        if (/(date|time)/.test(t)) return 'datetime';
+        if (/(int|bigint|smallint|tinyint)/.test(t)) return 'number';
+        if (/(decimal|numeric|money|float|real)/.test(t)) return 'decimal';
+        if (/bit/.test(t)) return 'boolean';
+        if (/uniqueidentifier/.test(t)) return 'string';
+        return 'string';
+    }
+
+    // ─── FetchChanges — GetQuery door walk + per-facade watermark ─────
+
+    /**
+     * Fetches a batch via the GetQuery door. Walks the IO's access path from Configuration: the door
+     * (GetQuery), the query object name, and any top modifier (@TOP -1 to bypass the DataGrid row
+     * cap). Incremental sync uses the IO's per-facade `IncrementalWatermarkField` in the
+     * szWhereClause — there is NO canonical LastModifiedDate; the field is metadata-driven.
+     *
+     * Full-record pass-through: every parsed row becomes ExternalRecord.Fields verbatim — never a
+     * filtered/narrow literal — so the framework's custom-column capture sees every column the query
+     * returned, including customer-added ones.
+     */
     public override async FetchChanges(ctx: FetchContext): Promise<FetchBatchResult> {
         const auth = await this.Authenticate(ctx.CompanyIntegration, ctx.ContextUser) as NFAuthContext;
-        const headers = this.BuildHeaders(auth);
-        // Use GetQuery for listing records
-        let url = `${auth.Config.BaseURL}/xWeb/JSON/GetQuery?szObjectName=${ctx.ObjectName}&szColumnList=*`;
-        if (ctx.WatermarkValue) {
-            // NetForum facades each use their own prefixed last-modified column.
-            // 'LastModifiedDate' is NOT a vendor column. Look it up from the static
-            // catalog (NF_OBJECTS lists e.g. 'ind_last_updated_dt' for Individual,
-            // 'evt_last_updated_dt' for Event, etc.). Fall back to the connector's
-            // earlier-guessed name only when the catalog has no entry.
-            const wmCol = this.ResolveWatermarkColumn(ctx.ObjectName);
-            url += `&szWhereClause=${encodeURIComponent(`${wmCol} >= '${ctx.WatermarkValue}'`)}`;
+        const obj = this.GetCachedObject(ctx.CompanyIntegration.IntegrationID, ctx.ObjectName);
+        const cfg = this.ParseObjectConfig(obj);
+        const accessPath = cfg.accessPath ?? {};
+
+        const queryObject = accessPath.queryObject ?? accessPath.doorArgs?.szObjectName ?? ctx.ObjectName;
+        const topModifier = accessPath.doorArgs?.topModifier ?? '@TOP -1';
+        const szObjectName = topModifier ? `${queryObject} ${topModifier}` : queryObject;
+
+        const args: Record<string, string> = { szObjectName, szColumnList: '*' };
+        const watermarkField = obj.IncrementalWatermarkField ?? undefined;
+        if (ctx.WatermarkValue && watermarkField) {
+            args.szWhereClause = `${watermarkField} >= '${this.EscapeSqlLiteral(ctx.WatermarkValue)}'`;
         }
-        const response = await this.MakeHTTPRequest(auth, url, 'GET', headers);
-        if (response.Status < 200 || response.Status >= 300) throw new Error(`NetForum ${ctx.ObjectName} error: ${response.Status}`);
-        const records = this.NormalizeResponse(response.Body, null);
-        // Determine PK field from static definition
-        const obj = NF_OBJECTS.find(o => o.Name.toLowerCase() === ctx.ObjectName.toLowerCase());
-        const pkField = obj?.Fields.find(f => f.IsPrimaryKey)?.Name ?? 'key';
+        const orderingKey = cfg.stableOrderingKey ?? this.PrimaryKeyFieldName(obj);
+        if (orderingKey) args.szOrderBy = orderingKey;
+
+        const url = `${auth.Config.BaseURL}${this.SoapEndpoint(cfg)}`;
+        const envelope = this.BuildSoapEnvelope('GetQuery', args, auth.Token);
+        const response = await this.MakeRawHTTPRequest(url, 'POST', this.SoapHeaders('GetQuery'), envelope);
+        if (response.Status < 200 || response.Status >= 300) {
+            throw new Error(`NetForum GetQuery(${ctx.ObjectName}) failed: HTTP ${response.Status}`);
+        }
+
+        const rows = this.NormalizeResponse(response.Body, null);
+        const pkField = this.PrimaryKeyFieldName(obj);
+        const warnings = rows.length === 0
+            ? [{ Code: 'ZERO_ROWS', Message: `GetQuery(${szObjectName}) returned no rows.` }]
+            : undefined;
+
+        // Highest ordering-key value seen → keyset resume position when no watermark exists.
+        let maxKey: string | undefined;
+        const records: ExternalRecord[] = rows.map(row => {
+            const externalID = pkField ? String(row[pkField] ?? '') : '';
+            if (orderingKey) {
+                const v = row[orderingKey];
+                if (v != null) { const s = String(v); if (maxKey === undefined || s > maxKey) maxKey = s; }
+            }
+            return { ExternalID: externalID, ObjectType: ctx.ObjectName, Fields: row };
+        });
+
+        // Watermark: when this IO has a watermark field, the engine narrows next sync from the max
+        // seen. GetQuery returns the full result set in one call → HasMore is always false.
+        let newWatermark: string | undefined;
+        if (watermarkField) {
+            for (const row of rows) {
+                const v = row[watermarkField];
+                if (v != null) { const s = String(v); if (newWatermark === undefined || s > newWatermark) newWatermark = s; }
+            }
+        }
+
         return {
-            Records: records.map(r => ({ ExternalID: String(r[pkField] ?? r['key'] ?? ''), ObjectType: ctx.ObjectName, Fields: r })),
+            Records: records,
             HasMore: false,
+            Warnings: warnings,
+            NewWatermarkValue: newWatermark,
+            NextAfterKeyValue: maxKey,
         };
     }
 
-    // ─── CRUD — via facade methods ─────────────────────────────────────
+    private EscapeSqlLiteral(v: string): string { return v.replace(/'/g, "''"); }
 
+    // ─── CRUD — SOAP facade ops via per-operation metadata columns ────
+
+    /**
+     * Create via the SOAP operation named in the IO's CreateBodyKey / Configuration.writeOps.createOp
+     * (e.g. WEBIndividualInsert, InsertFacadeObject). The attributes are wrapped in a SOAP envelope
+     * for that operation; the new key is read from the response and routed through BuildCreatedResult,
+     * so a 2xx that carries no record key FAILS loudly (the silent-create-loss invariant).
+     *
+     * Overridden (not the generic per-operation REST path) because the body must be a SOAP envelope,
+     * not a JSON body — the generic CreateRecord builds a JSON body. We still honor the metadata
+     * columns (operation name) and still call BuildCreatedResult.
+     */
     public override async CreateRecord(ctx: CreateRecordContext): Promise<CRUDResult> {
-        const auth = await this.Authenticate(ctx.CompanyIntegration as MJCompanyIntegrationEntity, ctx.ContextUser as UserInfo) as NFAuthContext;
-        const headers = { ...this.BuildHeaders(auth), 'Content-Type': 'application/json' };
-        const url = `${auth.Config.BaseURL}/xWeb/JSON/InsertFacadeObject`;
-        const payload = { szObjectName: ctx.ObjectName, oRecord: ctx.Attributes };
-        const r = await this.MakeHTTPRequest(auth, url, 'POST', headers, payload);
-        if (r.Status >= 200 && r.Status < 300) {
-            const body = r.Body as Record<string, unknown>;
-            const newKey = body['key'] == null ? undefined : String(body['key']);
-            return this.BuildCreatedResult(newKey, r.Status, ctx.ObjectName);
+        const ci = ctx.CompanyIntegration as MJCompanyIntegrationEntity;
+        const obj = this.GetCachedObject(ci.IntegrationID, ctx.ObjectName);
+        if (!obj.SupportsCreate) {
+            return { Success: false, StatusCode: 0, ErrorMessage: `CreateRecord not supported for "${ctx.ObjectName}".` };
         }
-        return { Success: false, ExternalID: '', StatusCode: r.Status, ErrorMessage: `Create failed: ${r.Status}` };
+        const cfg = this.ParseObjectConfig(obj);
+        const operation = obj.CreateBodyKey ?? cfg.writeOps?.createOp;
+        if (!operation) {
+            return { Success: false, StatusCode: 0, ErrorMessage: `Create of "${ctx.ObjectName}" has no SOAP operation configured (CreateBodyKey).` };
+        }
+        const auth = await this.Authenticate(ci, ctx.ContextUser as UserInfo) as NFAuthContext;
+        const url = `${auth.Config.BaseURL}${this.SoapEndpoint(cfg)}`;
+        const envelope = this.BuildSoapEnvelope(operation, ctx.Attributes, auth.Token);
+        const r = await this.MakeRawHTTPRequest(url, 'POST', this.SoapHeaders(operation), envelope);
+        if (r.Status < 200 || r.Status >= 300) {
+            return { Success: false, ExternalID: '', StatusCode: r.Status, ErrorMessage: `Create of "${ctx.ObjectName}" failed: HTTP ${r.Status}` };
+        }
+        const externalID = this.ExtractKeyFromResponse(r.Body);
+        return this.BuildCreatedResult(externalID, r.Status, ctx.ObjectName);
     }
+
+    /**
+     * Update via the SOAP operation named in UpdateBodyKey / Configuration.writeOps.updateOp.
+     * netFORUM exposes no ETag / If-Match — updates are last-write-wins.
+     */
     public override async UpdateRecord(ctx: UpdateRecordContext): Promise<CRUDResult> {
-        const auth = await this.Authenticate(ctx.CompanyIntegration as MJCompanyIntegrationEntity, ctx.ContextUser as UserInfo) as NFAuthContext;
-        const headers = { ...this.BuildHeaders(auth), 'Content-Type': 'application/json' };
-        const url = `${auth.Config.BaseURL}/xWeb/JSON/UpdateFacadeObject`;
-        const payload = { szObjectName: ctx.ObjectName, szObjectKey: ctx.ExternalID, oRecord: ctx.Attributes };
-        const r = await this.MakeHTTPRequest(auth, url, 'POST', headers, payload);
-        if (r.Status >= 200 && r.Status < 300) return { Success: true, ExternalID: ctx.ExternalID, StatusCode: r.Status };
-        return { Success: false, ExternalID: ctx.ExternalID, StatusCode: r.Status, ErrorMessage: `Update failed: ${r.Status}` };
+        const ci = ctx.CompanyIntegration as MJCompanyIntegrationEntity;
+        const obj = this.GetCachedObject(ci.IntegrationID, ctx.ObjectName);
+        if (!obj.SupportsUpdate) {
+            return { Success: false, ExternalID: ctx.ExternalID, StatusCode: 0, ErrorMessage: `UpdateRecord not supported for "${ctx.ObjectName}".` };
+        }
+        const cfg = this.ParseObjectConfig(obj);
+        const operation = obj.UpdateBodyKey ?? cfg.writeOps?.updateOp;
+        if (!operation) {
+            return { Success: false, ExternalID: ctx.ExternalID, StatusCode: 0, ErrorMessage: `Update of "${ctx.ObjectName}" has no SOAP operation configured (UpdateBodyKey).` };
+        }
+        const auth = await this.Authenticate(ci, ctx.ContextUser as UserInfo) as NFAuthContext;
+        const url = `${auth.Config.BaseURL}${this.SoapEndpoint(cfg)}`;
+        const pkField = this.PrimaryKeyFieldName(obj);
+        const attributes: Record<string, unknown> = pkField
+            ? { [pkField]: ctx.ExternalID, ...ctx.Attributes }
+            : { ...ctx.Attributes };
+        const envelope = this.BuildSoapEnvelope(operation, attributes, auth.Token);
+        const r = await this.MakeRawHTTPRequest(url, 'POST', this.SoapHeaders(operation), envelope);
+        if (r.Status >= 200 && r.Status < 300) {
+            return { Success: true, ExternalID: ctx.ExternalID, StatusCode: r.Status };
+        }
+        return { Success: false, ExternalID: ctx.ExternalID, StatusCode: r.Status, ErrorMessage: `Update of "${ctx.ObjectName}" failed: HTTP ${r.Status}` };
     }
+
+    /**
+     * Delete is not supported. DeleteFacadeObject is not confirmed in any reachable vendor doc and
+     * netFORUM prefers soft-delete via status flags. SupportsDelete is false, so this returns a clean
+     * error rather than silently claiming success.
+     */
     public override async DeleteRecord(ctx: DeleteRecordContext): Promise<CRUDResult> {
-        const auth = await this.Authenticate(ctx.CompanyIntegration as MJCompanyIntegrationEntity, ctx.ContextUser as UserInfo) as NFAuthContext;
-        const headers = { ...this.BuildHeaders(auth), 'Content-Type': 'application/json' };
-        const url = `${auth.Config.BaseURL}/xWeb/JSON/DeleteFacadeObject`;
-        const payload = { szObjectName: ctx.ObjectName, szObjectKey: ctx.ExternalID };
-        const r = await this.MakeHTTPRequest(auth, url, 'POST', headers, payload);
-        if (r.Status >= 200 && r.Status < 300) return { Success: true, ExternalID: ctx.ExternalID, StatusCode: r.Status };
-        return { Success: false, ExternalID: ctx.ExternalID, StatusCode: r.Status, ErrorMessage: `Delete failed: ${r.Status}` };
+        return {
+            Success: false,
+            ExternalID: ctx.ExternalID,
+            StatusCode: 0,
+            ErrorMessage: 'NetForum connector does not support delete (DeleteFacadeObject unconfirmed; netFORUM uses soft-delete via status flags).',
+        };
     }
 
-    protected override BuildHeaders(auth: RESTAuthContext): Record<string, string> {
-        return { 'Authorization': `Bearer ${auth.Token}`, 'Accept': 'application/json', 'User-Agent': 'MemberJunction-Integration/1.0' };
+    private ExtractKeyFromResponse(body: unknown): string | undefined {
+        const xml = this.AsText(body);
+        // The Insert/Create ops return the new GUID — scan common result/key element names.
+        for (const tag of ['key', 'Key', 'AddResult', 'InsertResult', 'CreateResult', 'WEBIndividualInsertResult', 'cst_key']) {
+            const v = this.ParseSoapScalar(xml, tag);
+            if (v && v.trim().length > 0) return v.trim();
+        }
+        // Fallback: first GUID-shaped token anywhere in the body.
+        const guid = xml.match(/[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}/);
+        return guid ? guid[0] : undefined;
     }
 
-    protected async MakeHTTPRequest(_auth: RESTAuthContext, url: string, method: string, headers: Record<string, string>, body?: unknown): Promise<RESTResponse> {
+    // ─── Stable ordering key (no-watermark resume) ───────────────────
+
+    /**
+     * Returns the IO's stable, monotonic ordering column (the PK / Configuration.stableOrderingKey)
+     * so the engine can keyset-resume objects that have no incremental watermark. Null when the IO is
+     * unknown or has no stable key — keyset resume is simply unavailable then, not an error.
+     */
+    public override StableOrderingKey(objectName: string): string | null {
+        const ci = this.LastIntegrationID;
+        if (!ci) return null;
+        try {
+            const obj = this.GetCachedObject(ci, objectName);
+            const cfg = this.ParseObjectConfig(obj);
+            return cfg.stableOrderingKey ?? this.PrimaryKeyFieldName(obj) ?? null;
+        } catch {
+            return null;
+        }
+    }
+
+    // ─── SOAP envelope + XML helpers ─────────────────────────────────
+
+    /** Required SOAP 1.1 HTTP headers for a given operation. */
+    private SoapHeaders(operation: string): Record<string, string> {
+        return {
+            'Content-Type': 'text/xml; charset=utf-8',
+            'SOAPAction': `${SOAP_NS}${operation}`,
+            'User-Agent': 'MemberJunction-Integration/1.0',
+        };
+    }
+
+    /**
+     * Builds a SOAP 1.1 envelope for `operation` with the given body args. When a token is provided
+     * (every call except Authenticate), the AuthorizationToken header element carries it — this is
+     * the documented SOAP token carrier, NOT an HTTP Authorization header. Values are XML-escaped.
+     */
+    private BuildSoapEnvelope(operation: string, args: Record<string, unknown>, token?: string): string {
+        const header = token
+            ? `<soap:Header><AuthorizationToken xmlns="${SOAP_NS}"><Token>${this.EscapeXml(token)}</Token></AuthorizationToken></soap:Header>`
+            : '<soap:Header/>';
+        const argXml = Object.entries(args)
+            .map(([k, v]) => this.ArgElement(k, v))
+            .join('');
+        return `<?xml version="1.0" encoding="utf-8"?>` +
+            `<soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/">` +
+            header +
+            `<soap:Body><${operation} xmlns="${SOAP_NS}">${argXml}</${operation}></soap:Body>` +
+            `</soap:Envelope>`;
+    }
+
+    /** Serializes one SOAP arg. Objects become nested elements; scalars become escaped text. */
+    private ArgElement(name: string, value: unknown): string {
+        if (value === null || value === undefined) return `<${name} />`;
+        if (typeof value === 'object') {
+            const inner = Object.entries(value as Record<string, unknown>)
+                .map(([k, v]) => this.ArgElement(k, v))
+                .join('');
+            return `<${name}>${inner}</${name}>`;
+        }
+        return `<${name}>${this.EscapeXml(String(value))}</${name}>`;
+    }
+
+    private EscapeXml(s: string): string {
+        return s
+            .replace(/&/g, '&amp;')
+            .replace(/</g, '&lt;')
+            .replace(/>/g, '&gt;')
+            .replace(/"/g, '&quot;')
+            .replace(/'/g, '&apos;');
+    }
+
+    private UnescapeXml(s: string): string {
+        return s
+            .replace(/&lt;/g, '<')
+            .replace(/&gt;/g, '>')
+            .replace(/&quot;/g, '"')
+            .replace(/&apos;/g, "'")
+            .replace(/&#(\d+);/g, (_m, d: string) => String.fromCharCode(Number(d)))
+            .replace(/&amp;/g, '&');
+    }
+
+    /**
+     * Extracts the text content of the FIRST occurrence of a scalar element by local name, ignoring
+     * namespace prefixes. Returns undefined when absent. Used for AuthenticateResult, mdc_* columns,
+     * and create-result keys.
+     */
+    private ParseSoapScalar(xml: string, localName: string): string | undefined {
+        const re = new RegExp(`<(?:[\\w.-]+:)?${this.EscapeRegExp(localName)}\\b[^>]*>([\\s\\S]*?)</(?:[\\w.-]+:)?${this.EscapeRegExp(localName)}>`);
+        const m = re.exec(xml);
+        if (!m) return undefined;
+        return this.UnescapeXml(m[1]).trim();
+    }
+
+    /** Returns the inner XML of every occurrence of an element by local name (namespace-agnostic). */
+    private ExtractElements(xml: string, localName: string): string[] {
+        const re = new RegExp(`<(?:[\\w.-]+:)?${this.EscapeRegExp(localName)}\\b[^>]*>([\\s\\S]*?)</(?:[\\w.-]+:)?${this.EscapeRegExp(localName)}>`, 'g');
+        const out: string[] = [];
+        let m: RegExpExecArray | null;
+        while ((m = re.exec(xml)) !== null) out.push(m[1]);
+        return out;
+    }
+
+    private EscapeRegExp(s: string): string { return s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'); }
+
+    /**
+     * Strips the SOAP envelope and the GetQueryResult wrapper, returning each flattened row as a
+     * plain object of column→value. netFORUM GetQuery returns a DataSet of repeated row elements
+     * (the row element name is the query's "Result"/"<Object>" element). We locate the GetQueryResult
+     * payload, then treat every direct child element that itself contains child elements as a row.
+     */
+    protected NormalizeResponse(rawBody: unknown, _key: string | null): Record<string, unknown>[] {
+        const xml = this.AsText(rawBody);
+        if (!xml) return [];
+        // Unwrap the GetQueryResult body (the <s:any> DataSet). Fall back to the whole body.
+        const resultElems = this.ExtractElements(xml, 'GetQueryResult');
+        const payload = resultElems.length > 0 ? resultElems[0] : xml;
+        return this.ParseRowSet(payload);
+    }
+
+    /**
+     * Parses a flattened row set. The DataSet shape is `<Results><Result>...cols...</Result>...` (the
+     * outer/inner names vary by query, e.g. IndividualObjects/IndividualObject). We find the most
+     * common repeated leaf-bearing element name and treat each as a row of column elements.
+     */
+    private ParseRowSet(xml: string): Record<string, unknown>[] {
+        // Identify candidate row element names: any tag that recurs AND contains nested elements.
+        const topTags = this.TopLevelTagNames(xml);
+        // The row wrapper is usually a single outer element (e.g. <Results>); descend one level if so.
+        let scope = xml;
+        if (topTags.length === 1) {
+            const inner = this.ExtractElements(xml, topTags[0]);
+            if (inner.length === 1 && /</.test(inner[0])) scope = inner[0];
+        }
+        const rowTagCounts = new Map<string, number>();
+        for (const tag of this.TopLevelTagNames(scope)) {
+            rowTagCounts.set(tag, (rowTagCounts.get(tag) ?? 0) + 1);
+        }
+        // Pick the most frequent row tag (ties → first). A single-row result still has count 1.
+        let rowTag: string | undefined;
+        let best = 0;
+        for (const [tag, count] of rowTagCounts) {
+            if (count > best) { best = count; rowTag = tag; }
+        }
+        if (!rowTag) return [];
+        const rows: Record<string, unknown>[] = [];
+        for (const rowXml of this.ExtractElements(scope, rowTag)) {
+            const row = this.ParseRowColumns(rowXml);
+            if (Object.keys(row).length > 0) rows.push(row);
+        }
+        return rows;
+    }
+
+    /** Parses one row's column elements into a flat object (full-record — every column kept). */
+    private ParseRowColumns(rowXml: string): Record<string, unknown> {
+        const row: Record<string, unknown> = {};
+        const re = /<([\w.-]+)\b[^>]*?(\/)?>(?:([\s\S]*?)<\/\1>)?/g;
+        let m: RegExpExecArray | null;
+        while ((m = re.exec(rowXml)) !== null) {
+            const tag = m[1];
+            const selfClosing = m[2] === '/';
+            const content = m[3];
+            if (selfClosing || content === undefined) { row[tag] = null; continue; }
+            // Flattened GetQuery rows carry scalar columns; keep the unescaped text value.
+            row[tag] = this.UnescapeXml(content);
+        }
+        return row;
+    }
+
+    /**
+     * Returns the local names of the direct (top-level) child elements of an XML fragment, by a
+     * depth scan over open/close/self-close tags (so a tag opened at depth 0 is a direct child).
+     */
+    private TopLevelTagNames(xml: string): string[] {
+        const names: string[] = [];
+        let depth = 0;
+        const tokenRe = /<\/?([\w.-]+)\b[^>]*?(\/)?>/g;
+        let t: RegExpExecArray | null;
+        while ((t = tokenRe.exec(xml)) !== null) {
+            const full = t[0];
+            const name = t[1];
+            const selfClose = t[2] === '/';
+            const isClose = full.startsWith('</');
+            if (isClose) { depth--; continue; }
+            if (depth === 0) names.push(name);
+            if (!selfClose) depth++;
+        }
+        return names;
+    }
+
+    protected ExtractPaginationInfo(
+        _rb: unknown,
+        _pt: PaginationType,
+        _cp: number,
+        _co: number,
+        _ps: number,
+    ): PaginationState {
+        // GetQuery returns the full result set in one call — no protocol-level pagination.
+        return { HasMore: false };
+    }
+
+    protected GetBaseURL(_ci: MJCompanyIntegrationEntity, auth: RESTAuthContext): string {
+        return (auth as NFAuthContext).Config.BaseURL;
+    }
+
+    /** The base-class abstract BuildHeaders — defers to SoapHeaders for the active operation. */
+    protected BuildHeaders(_auth: RESTAuthContext): Record<string, string> {
+        return { 'Content-Type': 'text/xml; charset=utf-8', 'User-Agent': 'MemberJunction-Integration/1.0' };
+    }
+
+    /** The base-class abstract MakeHTTPRequest — routes through the raw transport. */
+    protected async MakeHTTPRequest(
+        _auth: RESTAuthContext,
+        url: string,
+        method: string,
+        headers: Record<string, string>,
+        body?: unknown,
+    ): Promise<RESTResponse> {
+        return this.MakeRawHTTPRequest(url, method, headers, typeof body === 'string' ? body : (body == null ? undefined : String(body)));
+    }
+
+    /**
+     * Raw SOAP transport: POSTs the XML envelope, retries on 401 (re-auth)/429/5xx, and returns the
+     * response body as text (SOAP is text/xml). Never logs credentials, the token, or PII.
+     *
+     * `protected` so a unit-test subclass can override this single transport seam to feed canned
+     * SOAP responses (no live network, no credentials) — the only seam tests need to mock.
+     */
+    protected async MakeRawHTTPRequest(
+        url: string,
+        method: string,
+        headers: Record<string, string>,
+        body?: string,
+    ): Promise<RESTResponse> {
         await this.Throttle();
         for (let attempt = 0; attempt <= MAX_RETRIES; attempt++) {
-            const c = new AbortController(); const t = setTimeout(() => c.abort(), REQUEST_TIMEOUT_MS);
+            const controller = new AbortController();
+            const timer = setTimeout(() => controller.abort(), REQUEST_TIMEOUT_MS);
             try {
-                const opts: RequestInit = { method, headers, signal: c.signal };
-                if (body && method !== 'GET') opts.body = JSON.stringify(body);
+                const opts: RequestInit = { method, headers, signal: controller.signal };
+                if (body !== undefined && method !== 'GET') opts.body = body;
                 const response = await fetch(url, opts);
-                clearTimeout(t); this.lastRequestTime = Date.now();
+                clearTimeout(timer);
+                this.lastRequestTime = Date.now();
                 if (response.status === 401 && attempt === 0) { this.tokenCache = null; continue; }
-                if (response.status === 429) { await this.Sleep(Math.min(1000 * Math.pow(2, attempt) + Math.random() * 500, 60_000)); continue; }
-                if (response.status >= 500 && attempt < MAX_RETRIES) { await this.Sleep(Math.min(1000 * Math.pow(2, attempt), 30_000)); continue; }
-                const rb = await (response.headers.get('content-type')?.includes('json') ? response.json() : response.text());
-                const h: Record<string, string> = {}; response.headers.forEach((v, k) => { h[k.toLowerCase()] = v; });
-                return { Status: response.status, Body: rb, Headers: h };
-            } catch (e) { clearTimeout(t); if (e instanceof Error && e.name === 'AbortError') throw new Error(`NetForum request timed out: ${url}`); throw e; }
+                if (response.status === 429 && attempt < MAX_RETRIES) {
+                    await this.Sleep(this.RetryAfterMs(response, attempt));
+                    continue;
+                }
+                if (response.status >= 500 && attempt < MAX_RETRIES) {
+                    await this.Sleep(Math.min(1000 * Math.pow(2, attempt), 30_000));
+                    continue;
+                }
+                const text = await response.text();
+                const h: Record<string, string> = {};
+                response.headers.forEach((v, k) => { h[k.toLowerCase()] = v; });
+                return { Status: response.status, Body: text, Headers: h };
+            } catch (e) {
+                clearTimeout(timer);
+                if (e instanceof Error && e.name === 'AbortError') throw new Error(`NetForum request timed out: ${url}`);
+                if (attempt >= MAX_RETRIES) throw e;
+                await this.Sleep(Math.min(1000 * Math.pow(2, attempt), 30_000));
+            }
         }
         throw new Error(`NetForum request failed after ${MAX_RETRIES} retries: ${url}`);
     }
-    private async Throttle(): Promise<void> { const e = Date.now() - this.lastRequestTime; if (e < MIN_REQUEST_INTERVAL_MS) await this.Sleep(MIN_REQUEST_INTERVAL_MS - e); }
+
+    private RetryAfterMs(response: Response, attempt: number): number {
+        const ra = response.headers.get('retry-after');
+        if (ra) {
+            const secs = Number(ra);
+            if (!Number.isNaN(secs)) return Math.min(secs * 1000, 60_000);
+        }
+        return Math.min(1000 * Math.pow(2, attempt) + Math.random() * 500, 60_000);
+    }
+
+    public override ExtractRetryAfterMs(error: unknown): number | undefined {
+        if (error && typeof error === 'object' && 'Headers' in error) {
+            const headers = (error as { Headers?: Record<string, string> }).Headers;
+            const ra = headers?.['retry-after'];
+            if (ra) { const secs = Number(ra); if (!Number.isNaN(secs)) return secs * 1000; }
+        }
+        return undefined;
+    }
+
+    private async Throttle(): Promise<void> {
+        const elapsed = Date.now() - this.lastRequestTime;
+        if (elapsed < MIN_REQUEST_INTERVAL_MS) await this.Sleep(MIN_REQUEST_INTERVAL_MS - elapsed);
+    }
     private Sleep(ms: number): Promise<void> { return new Promise(r => setTimeout(r, ms)); }
-    public override GetDefaultFieldMappings(objectName: string): DefaultFieldMapping[] {
-        const obj = NF_OBJECTS.find(o => o.Name.toLowerCase() === objectName.toLowerCase());
-        if (!obj) return []; return obj.Fields.map(f => ({ SourceFieldName: f.Name, DestinationFieldName: f.Name, IsKeyField: f.IsPrimaryKey }));
+
+    // ─── Per-object config helpers ───────────────────────────────────
+
+    /** Remembered integration ID from the last fetch, so StableOrderingKey can read the cache. */
+    private LastIntegrationID: string | null = null;
+
+    private ParseObjectConfig(obj: MJIntegrationObjectEntity): NFObjectConfig {
+        this.LastIntegrationID = obj.IntegrationID ?? this.LastIntegrationID;
+        if (!obj.Configuration) return {};
+        try {
+            return JSON.parse(obj.Configuration) as NFObjectConfig;
+        } catch {
+            return {};
+        }
+    }
+
+    private SoapEndpoint(cfg: NFObjectConfig): string {
+        return cfg.soapEndpoint ?? DEFAULT_SOAP_PATH;
+    }
+
+    private PrimaryKeyFieldName(obj: MJIntegrationObjectEntity): string | undefined {
+        const fields = this.GetCachedFields(obj.ID);
+        const pk = fields.find(f => f.IsPrimaryKey);
+        return pk?.Name;
+    }
+
+    /** Lowercased names of the IO's declared primary-key fields, read from the cached IOF entities. */
+    private DeclaredPrimaryKeyNames(ci: MJCompanyIntegrationEntity, objectName: string): Set<string> {
+        try {
+            const obj = this.GetCachedObject(ci.IntegrationID, objectName);
+            return new Set(this.GetCachedFields(obj.ID).filter(f => f.IsPrimaryKey).map(f => f.Name.toLowerCase()));
+        } catch {
+            return new Set<string>();
+        }
+    }
+
+    private AsText(body: unknown): string {
+        if (typeof body === 'string') return body;
+        if (body == null) return '';
+        return String(body);
     }
 }
-export function LoadNetForumConnector() { /* intentionally empty */ }
+
+export function LoadNetForumConnector() { /* intentionally empty — tree-shaking anchor */ }

--- a/packages/Integration/connectors/src/__tests__/NetForumConnector.test.ts
+++ b/packages/Integration/connectors/src/__tests__/NetForumConnector.test.ts
@@ -1,91 +1,410 @@
 import { describe, it, expect } from 'vitest';
-import type { RESTAuthContext, RESTResponse, CreateRecordContext } from '@memberjunction/integration-engine';
+import type {
+    RESTAuthContext,
+    RESTResponse,
+    CreateRecordContext,
+    UpdateRecordContext,
+    DeleteRecordContext,
+    FetchContext,
+} from '@memberjunction/integration-engine';
+import type { MJIntegrationObjectEntity, MJIntegrationObjectFieldEntity, MJCompanyIntegrationEntity } from '@memberjunction/core-entities';
+import type { UserInfo } from '@memberjunction/core';
 import { NetForumConnector } from '../NetForumConnector.js';
 
 /**
- * Test connector that short-circuits auth and overrides the HTTP transport seam so the
- * create path runs for real down to the wire. Used to assert the create-without-key guard
- * (BaseIntegrationConnector.BuildCreatedResult) — mirrors the HubSpot silent-failure fix.
+ * READ-ONLY / MOCKED-ONLY vitest (T4). NEVER hits a live netFORUM instance and NEVER mutates data.
+ * Write-method tests assert REQUEST CONSTRUCTION + result handling against a mocked transport seam.
+ *
+ * The mocked SOAP responses below are SYNTHETIC, credential-free, PII-scrubbed compatibility samples
+ * modeled on the xWeb ?op= wire shapes (netForumXML.asmx) + NetForumContext.md scenarios — they are
+ * NOT captured from a real customer instance (no netFORUM credentials exist for this build). PII is
+ * scrubbed per connector-test-conventions (names -> <scrubbed-name-N>, emails -> example+N@example.com).
  */
-class TestNetForumConnector extends NetForumConnector {
-    public NextResponse: RESTResponse | null = null;
 
-    protected override async Authenticate(): Promise<RESTAuthContext> {
-        return { Token: 'test-token', Config: { BaseURL: 'https://test.netforum.example', Username: 'u', Password: 'p' } } as unknown as RESTAuthContext;
+const AUTH_XML = `<?xml version="1.0" encoding="utf-8"?>
+<soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+  <soap:Body>
+    <AuthenticateResponse xmlns="http://www.avectra.com/2005/">
+      <AuthenticateResult>eb5667ab-25ac-45c9-b831-23b43be8f194</AuthenticateResult>
+    </AuthenticateResponse>
+  </soap:Body>
+</soap:Envelope>`;
+
+const GETQUERY_XML = `<?xml version="1.0" encoding="utf-8"?>
+<soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/">
+  <soap:Body>
+    <GetQueryResponse xmlns="http://www.avectra.com/2005/">
+      <GetQueryResult>
+        <Results>
+          <Result>
+            <ind_cst_key>11111111-1111-1111-1111-111111111111</ind_cst_key>
+            <ind_first_name>Ada</ind_first_name>
+            <ind_last_name>&lt;scrubbed-name-1&gt;</ind_last_name>
+            <eml_address>example+1@example.com</eml_address>
+            <ind_change_date>2026-03-14T09:30:00</ind_change_date>
+          </Result>
+          <Result>
+            <ind_cst_key>22222222-2222-2222-2222-222222222222</ind_cst_key>
+            <ind_first_name>Grace</ind_first_name>
+            <ind_last_name>&lt;scrubbed-name-2&gt;</ind_last_name>
+            <eml_address>example+2@example.com</eml_address>
+            <ind_change_date>2026-05-21T14:05:00</ind_change_date>
+          </Result>
+        </Results>
+      </GetQueryResult>
+    </GetQueryResponse>
+  </soap:Body>
+</soap:Envelope>`;
+
+const GETQUERYDEF_XML = `<?xml version="1.0" encoding="utf-8"?>
+<soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/">
+  <soap:Body>
+    <GetQueryDefinitionResponse xmlns="http://www.avectra.com/2005/">
+      <GetQueryDefinitionResult>
+        <obj_key>33333333-3333-3333-3333-333333333333</obj_key>
+        <obj_name>Individual</obj_name>
+        <obj_description>Individual / member records</obj_description>
+        <ListTable>
+          <lst_mdt_name>co_individual</lst_mdt_name>
+          <ListFromTables>
+            <ListFromTable>
+              <lsf_from_table>co_individual</lsf_from_table>
+              <Columns>
+                <Column>
+                  <mdc_name>ind_cst_key</mdc_name>
+                  <mdc_description>Customer Key</mdc_description>
+                  <mdc_data_type>uniqueidentifier</mdc_data_type>
+                  <mdc_nullable>0</mdc_nullable>
+                  <mdc_table_name>co_individual</mdc_table_name>
+                  <mdc_width_max>16</mdc_width_max>
+                </Column>
+                <Column>
+                  <mdc_name>ind_first_name</mdc_name>
+                  <mdc_description>First Name</mdc_description>
+                  <mdc_data_type>nvarchar</mdc_data_type>
+                  <mdc_nullable>1</mdc_nullable>
+                  <mdc_table_name>co_individual</mdc_table_name>
+                  <mdc_width_max>50</mdc_width_max>
+                </Column>
+                <Column>
+                  <mdc_name>ind_custom_loyalty_tier</mdc_name>
+                  <mdc_description>Customer-added custom field</mdc_description>
+                  <mdc_data_type>nvarchar</mdc_data_type>
+                  <mdc_nullable>1</mdc_nullable>
+                  <mdc_table_name>co_individual</mdc_table_name>
+                  <mdc_width_max>25</mdc_width_max>
+                </Column>
+              </Columns>
+            </ListFromTable>
+          </ListFromTables>
+        </ListTable>
+      </GetQueryDefinitionResult>
+    </GetQueryDefinitionResponse>
+  </soap:Body>
+</soap:Envelope>`;
+
+const INSERT_XML = `<?xml version="1.0" encoding="utf-8"?>
+<soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/">
+  <soap:Body>
+    <WEBIndividualInsertResponse xmlns="http://www.avectra.com/2005/">
+      <WEBIndividualInsertResult>44444444-4444-4444-4444-444444444444</WEBIndividualInsertResult>
+    </WEBIndividualInsertResponse>
+  </soap:Body>
+</soap:Envelope>`;
+
+/** A captured outbound SOAP request (what the connector PUT on the wire). */
+interface CapturedRequest {
+    url: string;
+    method: string;
+    headers: Record<string, string>;
+    body?: string;
+}
+
+/**
+ * Test subclass: overrides the single SOAP transport seam (MakeRawHTTPRequest) to capture outbound
+ * requests + return canned fixtures keyed by SOAPAction, and overrides the engine-cache accessors
+ * so discovery/fetch run without a live IntegrationEngineBase. No credentials, no network.
+ */
+class MockedNetForumConnector extends NetForumConnector {
+    public Requests: CapturedRequest[] = [];
+    /** Map of SOAPAction operation suffix → canned RESTResponse. */
+    public Responses: Record<string, RESTResponse> = {};
+    /** The PK field name the mocked Individual object exposes. */
+    public PkField = 'ind_cst_key';
+    /** Per-object capability/config the mocked cache reports. */
+    public Caps: { SupportsCreate: boolean; SupportsUpdate: boolean; CreateBodyKey: string | null; UpdateBodyKey: string | null; IncrementalWatermarkField: string | null; Configuration: string | null } = {
+        SupportsCreate: true,
+        SupportsUpdate: true,
+        CreateBodyKey: 'WEBIndividualInsert',
+        UpdateBodyKey: 'WEBIndividualUpdate',
+        IncrementalWatermarkField: 'ind_change_date',
+        Configuration: JSON.stringify({
+            accessPath: { door: 'GetQuery', queryObject: 'Individual', nestingPath: [], doorArgs: { szObjectName: 'Individual', topModifier: '@TOP -1' } },
+            stableOrderingKey: 'ind_cst_key',
+            soapEndpoint: '/xweb/secure/netForumXML.asmx',
+            writeOps: { createOp: 'WEBIndividualInsert', updateOp: 'WEBIndividualUpdate' },
+        }),
+    };
+
+    protected override async MakeRawHTTPRequest(url: string, method: string, headers: Record<string, string>, body?: string): Promise<RESTResponse> {
+        this.Requests.push({ url, method, headers, body });
+        const action = (headers['SOAPAction'] ?? '').replace('http://www.avectra.com/2005/', '');
+        const canned = this.Responses[action];
+        if (canned) return canned;
+        throw new Error(`MockedNetForumConnector: no canned response for SOAPAction "${action}"`);
     }
 
-    protected override async MakeHTTPRequest(): Promise<RESTResponse> {
-        if (!this.NextResponse) throw new Error('TestNetForumConnector: no canned response queued');
-        return this.NextResponse;
+    // Engine-cache stand-ins so DiscoverFields / FetchChanges / CRUD run without IntegrationEngineBase.
+    protected override GetCachedObject(_integrationID: string, objectName: string): MJIntegrationObjectEntity {
+        return {
+            ID: 'io-individual',
+            IntegrationID: 'integ-1',
+            Name: objectName,
+            DisplayName: objectName,
+            Description: 'Individual',
+            SupportsCreate: this.Caps.SupportsCreate,
+            SupportsUpdate: this.Caps.SupportsUpdate,
+            CreateBodyKey: this.Caps.CreateBodyKey,
+            UpdateBodyKey: this.Caps.UpdateBodyKey,
+            IncrementalWatermarkField: this.Caps.IncrementalWatermarkField,
+            Configuration: this.Caps.Configuration,
+        } as unknown as MJIntegrationObjectEntity;
     }
+
+    protected override GetCachedFields(_objectID: string): MJIntegrationObjectFieldEntity[] {
+        return [
+            { Name: this.PkField, DisplayName: 'Customer Key', Description: 'Customer Key', Type: 'String', IsPrimaryKey: true, IsRequired: true, IsReadOnly: true, IsUniqueKey: true, Status: 'Active', Sequence: 0 },
+            { Name: 'ind_first_name', DisplayName: 'First Name', Description: 'First Name', Type: 'String', IsPrimaryKey: false, IsRequired: false, IsReadOnly: false, IsUniqueKey: false, Status: 'Active', Sequence: 1 },
+        ] as unknown as MJIntegrationObjectFieldEntity[];
+    }
+}
+
+const CI = { IntegrationID: 'integ-1', CredentialID: undefined, Configuration: JSON.stringify({ BaseURL: 'https://test.netforum.example', Username: 'u', Password: 'p' }) } as unknown as MJCompanyIntegrationEntity;
+const CU = {} as UserInfo;
+
+function makeConnector(): MockedNetForumConnector {
+    const c = new MockedNetForumConnector();
+    c.Responses['Authenticate'] = { Status: 200, Body: AUTH_XML, Headers: {} };
+    c.Responses['GetVersion'] = { Status: 200, Body: '<GetVersionResponse xmlns="http://www.avectra.com/2005/"><GetVersionResult>2017.1</GetVersionResult></GetVersionResponse>', Headers: {} };
+    c.Responses['GetQuery'] = { Status: 200, Body: GETQUERY_XML, Headers: {} };
+    c.Responses['GetQueryDefinition'] = { Status: 200, Body: GETQUERYDEF_XML, Headers: {} };
+    c.Responses['WEBIndividualInsert'] = { Status: 200, Body: INSERT_XML, Headers: {} };
+    c.Responses['WEBIndividualUpdate'] = { Status: 200, Body: '<WEBIndividualUpdateResponse xmlns="http://www.avectra.com/2005/"><WEBIndividualUpdateResult>true</WEBIndividualUpdateResult></WEBIndividualUpdateResponse>', Headers: {} };
+    return c;
 }
 
 function createCtx(objectName: string, attributes: Record<string, unknown>): CreateRecordContext {
-    return { CompanyIntegration: {}, ContextUser: {}, ObjectName: objectName, Attributes: attributes } as unknown as CreateRecordContext;
+    return { CompanyIntegration: CI, ContextUser: CU, ObjectName: objectName, Attributes: attributes } as unknown as CreateRecordContext;
 }
 
-// Smoke tests — verifies the connector's basic identity + capability surface.
-// These pass without HTTP mocks or credentials. Failures here indicate a
-// regression in capability declarations or naming (three-way invariant axis).
-describe('NetForumConnector (smoke)', () => {
+describe('NetForumConnector — identity & capability', () => {
     const connector = new NetForumConnector();
 
-    describe('Identity', () => {
-        it('should instantiate without throwing', () => {
-            expect(connector).toBeDefined();
-            expect(connector instanceof NetForumConnector).toBe(true);
-        });
-
-        it('IntegrationName getter returns the canonical name', () => {
-            expect(connector.IntegrationName).toBe('NetForum Enterprise');
-        });
+    it('instantiates and exposes the canonical IntegrationName', () => {
+        expect(connector).toBeInstanceOf(NetForumConnector);
+        expect(connector.IntegrationName).toBe('NetForum Enterprise');
     });
 
-    describe('Capability declarations', () => {
-        it('declared CRUD flags match expected shape', () => {
+    it('declares Create/Update; Delete held false (DeleteFacadeObject unconfirmed)', () => {
         expect(connector.SupportsCreate).toBe(true);
         expect(connector.SupportsUpdate).toBe(true);
-        expect(connector.SupportsDelete).toBe(false); // DeleteFacadeObject not in any reachable vendor doc; flag held false until verified
-        });
-    });
-    describe('GetDefaultFieldMappings', () => {
-        it('should return an array (possibly empty) for Individual', () => {
-            const mappings = connector.GetDefaultFieldMappings('Individual', 'TestEntity');
-            expect(Array.isArray(mappings)).toBe(true);
-            // If mappings exist, each entry has SourceFieldName + DestinationFieldName.
-            for (const m of mappings) {
-                expect(typeof m.SourceFieldName).toBe('string');
-                expect(typeof m.DestinationFieldName).toBe('string');
-            }
-        });
-
-        it('should return empty array for unknown objects', () => {
-            const mappings = connector.GetDefaultFieldMappings('definitely_unknown_object_xyz_123', 'Unknown');
-            expect(mappings).toEqual([]);
-        });
+        expect(connector.SupportsDelete).toBe(false);
     });
 
-    // Guards the silent-failure class of bug: a 2xx create that returns no record key must fail.
-    describe('CreateRecord — no-key guard', () => {
-        it('returns Success=false when a 2xx response carries no record key', async () => {
-            const connector = new TestNetForumConnector();
-            connector.NextResponse = { Status: 200, Body: {}, Headers: {} };
+    it('discovery is NOT authoritative (must never deactivate Declared metadata)', () => {
+        expect(connector.DiscoveryIsAuthoritative).toBe(false);
+    });
+});
 
-            const result = await connector.CreateRecord(createCtx('Individual', { ind_first_name: 'Ada' }));
+describe('NetForumConnector — Authenticate (two-step SOAP token)', () => {
+    it('POSTs a SOAP Authenticate envelope with credentials in the body and reads the token from AuthenticateResult', async () => {
+        const c = makeConnector();
+        // exercise auth via TestConnection (it authenticates then GetVersion)
+        const r = await c.TestConnection(CI, CU);
+        expect(r.Success).toBe(true);
 
-            expect(result.Success).toBe(false);
-            expect(result.ExternalID ?? '').toBe('');
-        });
-
-        it('returns Success=true with ExternalID when the create returns a key', async () => {
-            const connector = new TestNetForumConnector();
-            connector.NextResponse = { Status: 200, Body: { key: 'IND-123' }, Headers: {} };
-
-            const result = await connector.CreateRecord(createCtx('Individual', { ind_first_name: 'Ada' }));
-
-            expect(result.Success).toBe(true);
-            expect(result.ExternalID).toBe('IND-123');
-        });
+        const authReq = c.Requests.find(req => req.headers['SOAPAction'] === 'http://www.avectra.com/2005/Authenticate');
+        expect(authReq).toBeDefined();
+        expect(authReq!.headers['Content-Type']).toContain('text/xml');
+        // Credentials ride the SOAP BODY (userName/password), NOT an HTTP Basic/Bearer header.
+        expect(authReq!.body).toContain('<Authenticate xmlns="http://www.avectra.com/2005/">');
+        expect(authReq!.body).toContain('<userName>u</userName>');
+        expect(authReq!.body).toContain('<password>p</password>');
+        expect(authReq!.headers['Authorization']).toBeUndefined();
+        // Authenticate is the bootstrap — it must NOT carry the AuthorizationToken header.
+        expect(authReq!.body).not.toContain('AuthorizationToken');
     });
 
+    it('carries the token in the SOAP AuthorizationToken header on subsequent calls (not an HTTP header)', async () => {
+        const c = makeConnector();
+        await c.TestConnection(CI, CU);
+        const versionReq = c.Requests.find(req => req.headers['SOAPAction'] === 'http://www.avectra.com/2005/GetVersion');
+        expect(versionReq).toBeDefined();
+        expect(versionReq!.body).toContain('<AuthorizationToken xmlns="http://www.avectra.com/2005/"><Token>eb5667ab-25ac-45c9-b831-23b43be8f194</Token></AuthorizationToken>');
+        expect(versionReq!.headers['Authorization']).toBeUndefined();
+    });
+
+    it('TestConnection surfaces auth failure as Success=false', async () => {
+        const c = makeConnector();
+        c.Responses['Authenticate'] = { Status: 200, Body: '<soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/"><soap:Body><AuthenticateResponse xmlns="http://www.avectra.com/2005/"></AuthenticateResponse></soap:Body></soap:Envelope>', Headers: {} };
+        const r = await c.TestConnection(CI, CU);
+        expect(r.Success).toBe(false);
+    });
+});
+
+describe('NetForumConnector — NormalizeResponse (SOAP/XML row parsing)', () => {
+    it('unwraps GetQueryResult and parses flattened rows to full-record objects', () => {
+        const c = makeConnector();
+        // NormalizeResponse is protected; reach it via FetchChanges below. Here, test directly through a thin proxy.
+        const rows = (c as unknown as { NormalizeResponse(b: unknown, k: string | null): Record<string, unknown>[] }).NormalizeResponse(GETQUERY_XML, null);
+        expect(rows).toHaveLength(2);
+        expect(rows[0]['ind_cst_key']).toBe('11111111-1111-1111-1111-111111111111');
+        expect(rows[0]['ind_first_name']).toBe('Ada');
+        // XML entities unescaped
+        expect(rows[0]['ind_last_name']).toBe('<scrubbed-name-1>');
+        expect(rows[1]['ind_change_date']).toBe('2026-05-21T14:05:00');
+    });
+
+    it('returns [] for an empty / non-XML body', () => {
+        const c = makeConnector();
+        const proxy = c as unknown as { NormalizeResponse(b: unknown, k: string | null): Record<string, unknown>[] };
+        expect(proxy.NormalizeResponse('', null)).toEqual([]);
+        expect(proxy.NormalizeResponse(null, null)).toEqual([]);
+    });
+});
+
+describe('NetForumConnector — FetchChanges (GetQuery door + per-facade watermark)', () => {
+    it('builds a GetQuery with @TOP -1 and full-record pass-through; PK extracted from metadata PK field', async () => {
+        const c = makeConnector();
+        const ctx: FetchContext = { CompanyIntegration: CI, ObjectName: 'Individual', WatermarkValue: null, BatchSize: 100, ContextUser: CU };
+        const res = await c.FetchChanges(ctx);
+
+        const req = c.Requests.find(r => r.headers['SOAPAction'] === 'http://www.avectra.com/2005/GetQuery');
+        expect(req).toBeDefined();
+        expect(req!.body).toContain('<szObjectName>Individual @TOP -1</szObjectName>');
+        expect(req!.body).toContain('<szColumnList>*</szColumnList>');
+        // no watermark → no szWhereClause
+        expect(req!.body).not.toContain('szWhereClause');
+
+        expect(res.Records).toHaveLength(2);
+        expect(res.Records[0].ExternalID).toBe('11111111-1111-1111-1111-111111111111');
+        expect(res.Records[0].ObjectType).toBe('Individual');
+        // FULL-record pass-through: every column reaches Fields (not a narrow literal)
+        expect(res.Records[0].Fields['ind_first_name']).toBe('Ada');
+        expect(res.Records[0].Fields['eml_address']).toBe('example+1@example.com');
+        expect(Object.keys(res.Records[0].Fields).length).toBeGreaterThanOrEqual(5);
+        expect(res.HasMore).toBe(false);
+        // watermark advanced to the max ind_change_date seen
+        expect(res.NewWatermarkValue).toBe('2026-05-21T14:05:00');
+    });
+
+    it('on a subsequent sync applies the per-facade watermark field in szWhereClause (NOT a canonical LastModifiedDate)', async () => {
+        const c = makeConnector();
+        const ctx: FetchContext = { CompanyIntegration: CI, ObjectName: 'Individual', WatermarkValue: '2026-01-01T00:00:00', BatchSize: 100, ContextUser: CU };
+        await c.FetchChanges(ctx);
+        const req = c.Requests.find(r => r.headers['SOAPAction'] === 'http://www.avectra.com/2005/GetQuery');
+        // szWhereClause value is XML-escaped in the envelope (>= → &gt;=, ' → &apos;)
+        expect(req!.body).toContain('ind_change_date &gt;= &apos;2026-01-01T00:00:00&apos;');
+        expect(req!.body).not.toContain('LastModifiedDate');
+    });
+
+    it('emits a ZERO_ROWS warning when GetQuery returns no rows', async () => {
+        const c = makeConnector();
+        c.Responses['GetQuery'] = { Status: 200, Body: '<soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/"><soap:Body><GetQueryResponse xmlns="http://www.avectra.com/2005/"><GetQueryResult><Results /></GetQueryResult></GetQueryResponse></soap:Body></soap:Envelope>', Headers: {} };
+        const ctx: FetchContext = { CompanyIntegration: CI, ObjectName: 'Individual', WatermarkValue: null, BatchSize: 100, ContextUser: CU };
+        const res = await c.FetchChanges(ctx);
+        expect(res.Records).toHaveLength(0);
+        expect(res.Warnings?.[0].Code).toBe('ZERO_ROWS');
+    });
+});
+
+describe('NetForumConnector — DiscoverFields (runtime GetQueryDefinition mechanism)', () => {
+    it('parses the GetQueryDefinition column definition, surfacing customer-added columns', async () => {
+        const c = makeConnector();
+        const fields = await c.DiscoverFields(CI, 'Individual', CU);
+        const names = fields.map(f => f.Name);
+        expect(names).toContain('ind_cst_key');
+        expect(names).toContain('ind_first_name');
+        // customer-added column discovered at runtime (not in the static Declared set)
+        expect(names).toContain('ind_custom_loyalty_tier');
+
+        const custom = fields.find(f => f.Name === 'ind_custom_loyalty_tier')!;
+        expect(custom.MaxLength).toBe(25);
+        expect(custom.AllowsNull).toBe(true); // mdc_nullable=1
+
+        const pk = fields.find(f => f.Name === 'ind_cst_key')!;
+        expect(pk.AllowsNull).toBe(false); // mdc_nullable=0
+        expect(pk.IsPrimaryKey).toBe(true); // Declared PK preserved (definition doesn't mark PK)
+    });
+
+    it('falls back to the Declared fields when GetQueryDefinition is unavailable (credential-free)', async () => {
+        const c = makeConnector();
+        c.Responses['GetQueryDefinition'] = { Status: 401, Body: '', Headers: {} };
+        const fields = await c.DiscoverFields(CI, 'Individual', CU);
+        // Declared baseline (from the mocked cache) is never lost
+        expect(fields.map(f => f.Name)).toContain('ind_cst_key');
+    });
+});
+
+describe('NetForumConnector — CreateRecord (facade SOAP op via metadata columns)', () => {
+    it('POSTs the WEBIndividualInsert SOAP op and returns the new key via BuildCreatedResult', async () => {
+        const c = makeConnector();
+        const result = await c.CreateRecord(createCtx('Individual', { ind_first_name: 'Ada' }));
+        const req = c.Requests.find(r => r.headers['SOAPAction'] === 'http://www.avectra.com/2005/WEBIndividualInsert');
+        expect(req).toBeDefined();
+        expect(req!.body).toContain('<WEBIndividualInsert xmlns="http://www.avectra.com/2005/">');
+        expect(req!.body).toContain('<ind_first_name>Ada</ind_first_name>');
+        // token carried in the SOAP header
+        expect(req!.body).toContain('<AuthorizationToken xmlns="http://www.avectra.com/2005/">');
+        expect(result.Success).toBe(true);
+        expect(result.ExternalID).toBe('44444444-4444-4444-4444-444444444444');
+    });
+
+    it('fails loudly when a 2xx create returns no record key (silent-loss guard)', async () => {
+        const c = makeConnector();
+        c.Responses['WEBIndividualInsert'] = { Status: 200, Body: '<soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/"><soap:Body><WEBIndividualInsertResponse xmlns="http://www.avectra.com/2005/"><WEBIndividualInsertResult></WEBIndividualInsertResult></WEBIndividualInsertResponse></soap:Body></soap:Envelope>', Headers: {} };
+        const result = await c.CreateRecord(createCtx('Individual', { ind_first_name: 'Ada' }));
+        expect(result.Success).toBe(false);
+        expect(result.ExternalID ?? '').toBe('');
+    });
+
+    it('returns a clean error when the object does not support create', async () => {
+        const c = makeConnector();
+        c.Caps = { ...c.Caps, SupportsCreate: false };
+        const result = await c.CreateRecord(createCtx('Individual', { ind_first_name: 'Ada' }));
+        expect(result.Success).toBe(false);
+    });
+});
+
+describe('NetForumConnector — UpdateRecord (facade SOAP op)', () => {
+    it('POSTs the WEBIndividualUpdate op with the PK + attributes', async () => {
+        const c = makeConnector();
+        const ctx: UpdateRecordContext = { CompanyIntegration: CI, ContextUser: CU, ObjectName: 'Individual', ExternalID: 'IND-1', Attributes: { ind_first_name: 'Grace' } } as unknown as UpdateRecordContext;
+        const result = await c.UpdateRecord(ctx);
+        const req = c.Requests.find(r => r.headers['SOAPAction'] === 'http://www.avectra.com/2005/WEBIndividualUpdate');
+        expect(req).toBeDefined();
+        expect(req!.body).toContain('<ind_cst_key>IND-1</ind_cst_key>');
+        expect(req!.body).toContain('<ind_first_name>Grace</ind_first_name>');
+        expect(result.Success).toBe(true);
+        expect(result.ExternalID).toBe('IND-1');
+    });
+});
+
+describe('NetForumConnector — DeleteRecord (unsupported)', () => {
+    it('returns a clean error (no live mutation) since delete is unconfirmed', async () => {
+        const c = makeConnector();
+        const ctx: DeleteRecordContext = { CompanyIntegration: CI, ContextUser: CU, ObjectName: 'Individual', ExternalID: 'IND-1' } as unknown as DeleteRecordContext;
+        const result = await c.DeleteRecord(ctx);
+        expect(result.Success).toBe(false);
+        expect(result.ErrorMessage).toContain('does not support delete');
+    });
+});
+
+describe('NetForumConnector — StableOrderingKey', () => {
+    it('returns the IO stableOrderingKey for keyset resume', async () => {
+        const c = makeConnector();
+        // prime LastIntegrationID via a fetch
+        await c.FetchChanges({ CompanyIntegration: CI, ObjectName: 'Individual', WatermarkValue: null, BatchSize: 100, ContextUser: CU });
+        expect(c.StableOrderingKey('Individual')).toBe('ind_cst_key');
+    });
 });

--- a/packages/Integration/engine/src/auth-helpers/OAuth2TokenManager.ts
+++ b/packages/Integration/engine/src/auth-helpers/OAuth2TokenManager.ts
@@ -55,6 +55,14 @@ export interface OAuth2TokenRequest {
     UseBasicAuth?: boolean;
     /** Request timeout in ms. Default 30000. */
     TimeoutMs?: number;
+    /**
+     * Extra `application/x-www-form-urlencoded` parameters appended to the grant body for vendors
+     * whose token endpoint requires non-standard inputs — e.g. Auth0's `audience` on a
+     * `client_credentials` grant, or a vendor-specific `resource`/`tenant` param. Applies to every
+     * grant type; standard params (grant_type, client_id/secret, scope, refresh_token, username,
+     * password) take precedence and are never overwritten by this map.
+     */
+    ExtraParams?: Record<string, string>;
 }
 
 /** A minted access token plus its derived expiry. */
@@ -172,6 +180,13 @@ export class OAuth2TokenManager {
     /** Builds the `application/x-www-form-urlencoded` grant body for the chosen flow. */
     private BuildGrantBody(req: OAuth2TokenRequest, grant: OAuth2GrantType): URLSearchParams {
         const body = new URLSearchParams();
+        // Seed vendor extra params FIRST so the standard params set below always take precedence
+        // (a caller can never clobber grant_type/scope/credentials via ExtraParams).
+        if (req.ExtraParams) {
+            for (const [k, v] of Object.entries(req.ExtraParams)) {
+                if (typeof v === 'string' && v.length > 0) body.set(k, v);
+            }
+        }
         body.set('grant_type', grant);
         const scopeParam = req.ScopeParam ?? 'scope';
         if (req.Scopes) body.set(scopeParam, req.Scopes);


### PR DESCRIPTION
## netFORUM Enterprise connector — xWeb SOAP route (credential-free build)

Built with the connector-builder v2 arc (Plan → Review → Execute → verify). netFORUM Enterprise (Community Brands / former Abila AMS) via the **xWeb SOAP/XML web service** (`netForumXML.asmx`), implemented as SOAP-over-HTTP on `BaseRESTIntegrationConnector` (there is no `BaseSOAPIntegrationConnector`).

### What's included
- **`NetForumConnector.ts`** (SOAP rewrite, 866 LOC) — two-step `Authenticate` token auth; `GetQuery`/`GetQueryDefinition`/`ExecuteMethod` reads; per-facade `*_last_updated_dt` watermarks; facade CRUD where documented; runtime `DiscoverObjects`/`DiscoverFields` via `GetQueryDefinition` (no catalog-in-code).
- **Metadata** `metadata/integrations/netforum/` — **34 Integration Objects / 17,221 fields**, Declared from the public 5.9 MB xWeb WSDL (provable-only); 45 soft-FKs via `RelatedIntegrationObjectID`.
- **Tests + fixtures** — vitest suite (19 tests) + SOAP XML response fixtures.
- **Engine repair** `OAuth2TokenManager.ts` — adds the `OAuth2TokenRequest.ExtraParams` field that `RhythmConnector` (PR #2906) references but which never landed on `next`; **required for `@memberjunction/integration-connectors` to compile**. Additive/optional; separable if preferred.

### Scope decision (knowing, not blind)
Declared = the standard Enterprise object families provable from the public WSDL. **Customer-specific** queries/views, member-type codes, Higher Logic stored procedures, and custom `WEB*` extension WSDLs are **runtime-discovered** (`DiscoveryIsAuthoritative=false`), not baked. Broader netFORUM routes (Pro, Enterprise XML/stored-proc, eWeb SSO, Higher Logic community, marketing, LMS) are recorded in `Configuration.OutOfScopeObjectFamilies`.

### Verification (SQL Server, credential-free)
| Check | Result |
|---|---|
| tsc / build | ✅ clean |
| T1 structural invariants | ✅ 6/6 (three-way name, FK-resolution, capability↔method, PK-source, provable-only, full-record) |
| vitest | ✅ 19/19 |
| **mock hybrid-e2e** | ✅ **26 pass / 0 fail** — ApplyAll → forward (6/6, completeness 1:1) → delta create+update → idempotent (zero redundant writes, rows stable) → content-hash narrowing → DAG (34 obj/45 FK/3 layers/**0 cycles**) → merkle → rate-limit backoff |
| bijection floor | ✅ complete (every non-nullable slot filled; `MetadataSource` pipeline-set to `Declared`) |
| FK `@lookup` | ✅ 45/45 `&IntegrationID=@parent:IntegrationID`, **0 circular deps** |
| metadata deploy | ✅ `mj sync push` 17,264 records, 0 errors |

### ⚠️ Framework finding — SQL Server 1024-column limit
7 of 34 facades flatten to **>1024 columns** (FundraisingGift 2333, EventsRegistrant 1388, MembershipBilling 1327, CentralizedOrderEntry 1147, Invoice 1131, Individual 1126, AccreditationArea 1104) and **cannot materialize as a single SQL Server table**. The 27 that fit ApplyAll + sync cleanly. These denormalized facades need column-overflow handling at the framework level before they can sync on SQL Server — flagged for follow-up, not a connector defect.

### Out of scope (per build limits)
- **Live credential (T8)** — netFORUM creds are per-customer/gated-hard; ceiling is `format-verified-no-creds`.
- **Write round-trip** — needs a stateful vendor; write-path shape covered by the mocked tiers.
- **PostgreSQL dual-dialect** — SQL Server only this pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)