### PR TITLE
feat(integration): Eventbrite Platform REST API v3 connector (contract-verified)

### DIFF
--- a/.changeset/eventbrite-connector.md
+++ b/.changeset/eventbrite-connector.md
@@ -1,0 +1,15 @@
+---
+"@memberjunction/integration-connectors": minor
+"@memberjunction/integration-engine": patch
+---
+
+Add the **Eventbrite** connector — Eventbrite Platform REST API v3.
+
+- **`EventbriteConnector`** (`@memberjunction/integration-connectors`) extends `BaseRESTIntegrationConnector`: OAuth2 Bearer / private-token auth, `continuation`-cursor pagination, and `changed_since` incremental sync on Orders & Attendees. CRUD is delegated to the generic per-operation column path (v5.39.x); the documented write surfaces (Event, EventSeries, Venue, TicketClass, TicketGroup, Discount, Webhook, Question) are wired with wrapped/flat bodies, while Orders & Attendees stay read-only per the public API.
+- **Metadata** (`metadata/integrations/eventbrite/`): 18 Integration Objects / 242 fields / 23 FK edges, all docs-derived from the official Eventbrite Platform API v3 reference (no invented fields). Organization-/event-scoped list paths declare `Configuration.parentObjectName` so the engine resolves `{organization_id}` / `{event_id}` via parent-iteration — no base-class change required. Passes the bijection, dag-completeness, and fk-lookup-qualifier floor graders.
+- **Credential type** `Eventbrite OAuth Token` (private token or OAuth2 authorization-code app credentials).
+- **Tests**: 74 credential-free mock tests covering every table (flat tables end-to-end; parent/connection-scoped tables at the response-contract layer), TestConnection, NormalizeResponse, cursor pagination, `changed_since` emission, watermark advancement, CRUD body shaping, and the capability⟺per-op-column bijection over the shipped metadata.
+
+Verification ceiling: **contract-verified** (matches Eventbrite's published Platform API v3). No live API calls — Eventbrite tokens are self-serve, so a live read-only pass can be added later via `/test-connector` without a rebuild.
+
+Also fixes a pre-existing duplicate `ExtraParams` declaration in `@memberjunction/integration-engine`'s `OAuth2TokenManager` interface that blocked the engine from compiling.

--- a/metadata/credential-types/.credential-types.json
+++ b/metadata/credential-types/.credential-types.json
@@ -626,5 +626,15 @@
       "IconClass": "fa-solid fa-users",
       "ValidationEndpoint": null
     }
+  },
+  {
+    "fields": {
+      "Name": "Eventbrite OAuth Token",
+      "Description": "Eventbrite Platform API v3 auth: a per-app private OAuth token used directly as a Bearer token (single-user), or the OAuth2 authorization-code flow (API key + client secret + redirect URI) for multi-user apps.",
+      "Category": "Authentication",
+      "FieldSchema": "@file:schemas/eventbrite-oauth-token.schema.json",
+      "IconClass": "fa-brands fa-eventbrite",
+      "ValidationEndpoint": null
+    }
   }
 ]

--- a/metadata/credential-types/schemas/eventbrite-oauth-token.schema.json
+++ b/metadata/credential-types/schemas/eventbrite-oauth-token.schema.json
@@ -1,0 +1,33 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "title": "Eventbrite OAuth Token",
+  "description": "Eventbrite Platform API v3 credentials. A single private OAuth token (issued per app from the user's API Keys page) is used directly as a Bearer token for single-user integrations. For multi-user apps, the full OAuth2 authorization-code flow is used: ApiKey/ClientSecret identify the app, the user is redirected to the authorize URL, and the returned code is exchanged for an access token. Provide either the PrivateToken, or the OAuth app credentials.",
+  "properties": {
+    "PrivateToken": {
+      "type": "string",
+      "title": "Private Token",
+      "description": "Per-app private OAuth token from the Eventbrite API Keys page. Sent as Authorization: Bearer on every request (single-user integration). Preferred when present."
+    },
+    "ApiKey": {
+      "type": "string",
+      "title": "API Key (Client ID)",
+      "description": "Eventbrite app API key / client id. Identifies the app in the OAuth2 authorization-code handshake (not secret)."
+    },
+    "ClientSecret": {
+      "type": "string",
+      "title": "Client Secret",
+      "description": "Eventbrite app client secret, used to exchange the authorization code for an access token in the OAuth2 authorization-code flow."
+    },
+    "RedirectURI": {
+      "type": "string",
+      "title": "Redirect URI",
+      "description": "OAuth2 redirect URI registered for the app; required for the authorization-code flow."
+    }
+  },
+  "anyOf": [
+    { "required": ["PrivateToken"] },
+    { "required": ["ApiKey", "ClientSecret"] }
+  ],
+  "additionalProperties": false
+}

--- a/metadata/integrations/eventbrite/.eventbrite.integration.json
+++ b/metadata/integrations/eventbrite/.eventbrite.integration.json
@@ -1,0 +1,3369 @@
+[
+  {
+    "fields": {
+      "Name": "Eventbrite",
+      "ClassName": "EventbriteConnector",
+      "Description": "Eventbrite Platform REST API v3 connector. Read events, organizations, venues, organizers, ticket classes, orders, attendees, discounts and reference data; incremental on orders/attendees (changed_since); create/update/delete on events, ticket classes, venues, discounts, webhooks. OAuth2 bearer / private token.",
+      "ImportPath": "@memberjunction/integration-connectors",
+      "NavigationBaseURL": "https://www.eventbrite.com/",
+      "BatchMaxRequestCount": 20,
+      "BatchRequestWaitTime": 1,
+      "CredentialTypeID": "@lookup:MJ: Credential Types.Name=Eventbrite OAuth Token",
+      "Configuration": {
+        "AuthFlow": "oauth2-bearer",
+        "AuthHeaderPattern": "Authorization: Bearer <token>",
+        "AuthModes": [
+          "private-token (OAuth2 bearer)",
+          "oauth2-authorization-code"
+        ],
+        "AuthorizeURL": "https://www.eventbrite.com/oauth/authorize",
+        "TokenURL": "https://www.eventbrite.com/oauth/token",
+        "ProductionBaseURL": "https://www.eventbriteapi.com/v3/",
+        "AuthNote": "All requests must carry a valid OAuth token. Two modes: (1) Personal/private token issued per app from the user's apps page (single-user integration) — used directly as a Bearer token; (2) full OAuth2 authorization-code flow for multi-user apps (redirect user to authorizeURL, exchange code at tokenURL). Token may also be passed as a query param ?token=<token> but the Authorization header is preferred. An App Key identifies the app in the OAuth handshake (not secret).",
+        "APIVersioningStrategy": "url-path",
+        "APIVersioningNote": "Version encoded in the URL path as /v3/.",
+        "PaginationDefaults": {
+          "type": "Cursor",
+          "requestParams": {
+            "continuationParam": "continuation",
+            "pageSizeParam": "page_size",
+            "pageParam": "page"
+          },
+          "responseObject": {
+            "wrapperKey": "pagination",
+            "hasMoreKey": "has_more_items",
+            "continuationKey": "continuation",
+            "pageNumberKey": "page_number",
+            "pageSizeKey": "page_size",
+            "pageCountKey": "page_count",
+            "objectCountKey": "object_count"
+          },
+          "notes": "List responses are an object with a `pagination` sub-object plus the resource array under a named key (e.g. `events`, `attendees`, `orders`, `venues`, `categories`). The `pagination` object: object_count (optional), page_number (required, starts at 1), page_size (required), page_count (optional), continuation (string token, optional), has_more_items (boolean). Preferred paging is the continuation token: when `has_more_items` is true, re-request with ?continuation=<continuation>. When all records are returned, the `continuation` key is absent. page_number is also available but continuation is the canonical mechanism."
+        },
+        "IncrementalSyncCapability": true,
+        "IncrementalSyncDescription": "List endpoints for Orders (by Event / by User / by Organization / search) and Attendees (by Event / by Organization) accept a `changed_since` (datetime) query param returning resources changed on or after that time. Both Order and Attendee carry a `changed` response field that is the change timestamp to use as the watermark cursor. Order/Attendee list-by-event also accept `last_item_seen` for keyset-style resume in conjunction with changed_since. Events, Venues, Organizers, etc. expose a `changed` field on the object but the list endpoints are not documented to accept changed_since; lookups (Category/Subcategory/Format) are static reference data with no incremental filter.",
+        "IncrementalWatermarkByObject": {
+          "orders": "changed_since",
+          "attendees": "changed_since"
+        },
+        "RateLimit": {
+          "perWindow": "1000 calls per hour (default)",
+          "notes": "Documented default rate limit is 1,000 calls per hour. Exceeding it returns HTTP 429 with error code HIT_RATE_LIMIT. Higher limits may be granted on request."
+        },
+        "Webhooks": {
+          "available": true,
+          "createPath": "/organizations/{organization_id}/webhooks/",
+          "legacyCreatePath": "/webhooks/",
+          "listPath": "/webhooks/",
+          "deletePath": "/webhooks/{webhook_id}/",
+          "objectFields": [
+            "id",
+            "endpoint_url",
+            "actions",
+            "event_id"
+          ],
+          "objectsCovered": [
+            "event",
+            "order",
+            "attendee",
+            "organizer",
+            "ticket_class",
+            "venue"
+          ],
+          "actions": [
+            "order.placed",
+            "order.updated",
+            "order.refunded",
+            "event.created",
+            "event.published",
+            "event.unpublished",
+            "event.updated",
+            "attendee.updated",
+            "attendee.checked_in",
+            "attendee.checked_out",
+            "ticket_class.created",
+            "ticket_class.updated",
+            "ticket_class.deleted",
+            "organizer.updated",
+            "venue.updated"
+          ],
+          "notes": "Create a webhook by POSTing { endpoint_url, actions, event_id? } to the organization webhooks endpoint (legacy global /webhooks/ also documented). The webhook payload delivered to endpoint_url contains api_url, action, endpoint_url, user_id, and webhook_id; the api_url points at the changed resource to GET. event_id is optional and scopes a webhook to a single event."
+        },
+        "ErrorResponseShape": {
+          "description": "Eventbrite errors return JSON with status_code, error (machine code), and error_description.",
+          "fields": {
+            "status_code": "integer",
+            "error": "string",
+            "error_description": "string"
+          }
+        }
+      }
+    },
+    "relatedEntities": {
+      "MJ: Integration Objects": [
+        {
+          "fields": {
+            "Name": "User",
+            "DisplayName": "User",
+            "IntegrationID": "@parent:ID",
+            "APIPath": "/users/me/",
+            "PaginationType": "None",
+            "SupportsPagination": false,
+            "SupportsIncrementalSync": false,
+            "SupportsWrite": false,
+            "ResponseDataKey": null,
+            "Status": "Active",
+            "Description": "An Eventbrite account. Users are members of Organizations.",
+            "SupportsCreate": false,
+            "SupportsUpdate": false,
+            "SupportsDelete": false,
+            "Configuration": {
+              "ListMethod": "GET",
+              "GetOnePath": "/users/{user_id}/",
+              "ListResponseKey": null,
+              "AccessPath": {
+                "door": "/users/me/",
+                "nesting": "self",
+                "args": []
+              }
+            }
+          },
+          "relatedEntities": {
+            "MJ: Integration Object Fields": [
+              {
+                "fields": {
+                  "Name": "id",
+                  "Type": "string",
+                  "Source": "Declared",
+                  "IsPrimaryKey": true,
+                  "IsUniqueKey": true,
+                  "IsReadOnly": true,
+                  "AllowsNull": false,
+                  "Description": "User ID.",
+                  "Status": "Active",
+                  "IntegrationObjectID": "@parent:ID"
+                }
+              },
+              {
+                "fields": {
+                  "Name": "name",
+                  "Type": "string",
+                  "Source": "Declared",
+                  "Description": "User display name.",
+                  "Status": "Active",
+                  "IntegrationObjectID": "@parent:ID"
+                }
+              },
+              {
+                "fields": {
+                  "Name": "first_name",
+                  "Type": "string",
+                  "Source": "Declared",
+                  "Description": "User first name.",
+                  "Status": "Active",
+                  "IntegrationObjectID": "@parent:ID"
+                }
+              },
+              {
+                "fields": {
+                  "Name": "last_name",
+                  "Type": "string",
+                  "Source": "Declared",
+                  "Description": "User last name.",
+                  "Status": "Active",
+                  "IntegrationObjectID": "@parent:ID"
+                }
+              },
+              {
+                "fields": {
+                  "Name": "emails",
+                  "Type": "json",
+                  "Source": "Declared",
+                  "Description": "List of the user's email addresses (each with email, verified, primary).",
+                  "Status": "Active",
+                  "IntegrationObjectID": "@parent:ID"
+                }
+              }
+            ]
+          }
+        },
+        {
+          "fields": {
+            "Name": "Organization",
+            "DisplayName": "Organization",
+            "IntegrationID": "@parent:ID",
+            "APIPath": "/users/me/organizations/",
+            "PaginationType": "Cursor",
+            "SupportsPagination": true,
+            "SupportsIncrementalSync": false,
+            "SupportsWrite": false,
+            "ResponseDataKey": "organizations",
+            "Status": "Active",
+            "Description": "A business structure in which Events are created and managed. Owned by one User; groups Members, Roles, Venues.",
+            "SupportsCreate": false,
+            "SupportsUpdate": false,
+            "SupportsDelete": false,
+            "Configuration": {
+              "ListMethod": "GET",
+              "GetOnePath": "/organizations/{organization_id}/",
+              "ListResponseKey": "organizations",
+              "AccessPath": {
+                "door": "/users/me/organizations/",
+                "nesting": "User -> organizations[]",
+                "args": []
+              }
+            }
+          },
+          "relatedEntities": {
+            "MJ: Integration Object Fields": [
+              {
+                "fields": {
+                  "Name": "id",
+                  "Type": "string",
+                  "Source": "Declared",
+                  "IsPrimaryKey": true,
+                  "IsUniqueKey": true,
+                  "IsReadOnly": true,
+                  "AllowsNull": false,
+                  "Description": "Organization ID.",
+                  "Status": "Active",
+                  "IntegrationObjectID": "@parent:ID"
+                }
+              },
+              {
+                "fields": {
+                  "Name": "name",
+                  "Type": "string",
+                  "Source": "Declared",
+                  "IsRequired": true,
+                  "Description": "Organization name.",
+                  "Status": "Active",
+                  "IntegrationObjectID": "@parent:ID"
+                }
+              },
+              {
+                "fields": {
+                  "Name": "vertical",
+                  "Type": "string",
+                  "Source": "Declared",
+                  "Description": "Business vertical: default or music.",
+                  "Status": "Active",
+                  "IntegrationObjectID": "@parent:ID"
+                }
+              },
+              {
+                "fields": {
+                  "Name": "locale",
+                  "Type": "string",
+                  "Source": "Declared",
+                  "Description": "Organization locale (e.g. en_US).",
+                  "Status": "Active",
+                  "IntegrationObjectID": "@parent:ID"
+                }
+              },
+              {
+                "fields": {
+                  "Name": "image_id",
+                  "Type": "string",
+                  "Source": "Declared",
+                  "RelatedIntegrationObjectID": "@lookup:MJ: Integration Objects.Name=Media&IntegrationID=@parent:IntegrationID",
+                  "Description": "ID of the image for the Organization.",
+                  "Status": "Active",
+                  "IntegrationObjectID": "@parent:ID"
+                }
+              },
+              {
+                "fields": {
+                  "Name": "_type",
+                  "Type": "string",
+                  "Source": "Declared",
+                  "IsReadOnly": true,
+                  "Description": "Resource type marker, always 'organization'.",
+                  "Status": "Active",
+                  "IntegrationObjectID": "@parent:ID"
+                }
+              }
+            ]
+          }
+        },
+        {
+          "fields": {
+            "Name": "Event",
+            "DisplayName": "Event",
+            "IntegrationID": "@parent:ID",
+            "APIPath": "/organizations/{organization_id}/events/",
+            "PaginationType": "Cursor",
+            "SupportsPagination": true,
+            "SupportsIncrementalSync": false,
+            "SupportsWrite": true,
+            "ResponseDataKey": "events",
+            "Status": "Active",
+            "Description": "An Eventbrite Event, owned by one Organization. Holds listing, scheduling, status and capacity details.",
+            "SupportsCreate": true,
+            "CreateAPIPath": "/organizations/{organization_id}/events/",
+            "CreateMethod": "POST",
+            "CreateBodyShape": "wrapped",
+            "CreateIDLocation": "body",
+            "CreateBodyKey": "event",
+            "SupportsUpdate": true,
+            "UpdateAPIPath": "/events/{event_id}/",
+            "UpdateMethod": "POST",
+            "UpdateBodyShape": "wrapped",
+            "UpdateIDLocation": "path",
+            "UpdateBodyKey": "event",
+            "SupportsDelete": true,
+            "DeleteAPIPath": "/events/{event_id}/",
+            "DeleteMethod": "DELETE",
+            "DeleteIDLocation": "path",
+            "Configuration": {
+              "ListMethod": "GET",
+              "GetOnePath": "/events/{event_id}/",
+              "ListResponseKey": "events",
+              "AccessPath": {
+                "door": "/organizations/{organization_id}/events/",
+                "nesting": "Organization -> events[]",
+                "args": [
+                  "status",
+                  "order_by",
+                  "start_date.range_start",
+                  "start_date.range_end",
+                  "time_filter",
+                  "name_filter",
+                  "venue_filter",
+                  "organizer_filter",
+                  "show_series_parent",
+                  "expand"
+                ]
+              },
+              "parentObjectName": "Organization",
+              "parentObjectIDFieldName": "organization_id"
+            }
+          },
+          "relatedEntities": {
+            "MJ: Integration Object Fields": [
+              {
+                "fields": {
+                  "Name": "id",
+                  "Type": "string",
+                  "Source": "Declared",
+                  "IsPrimaryKey": true,
+                  "IsUniqueKey": true,
+                  "IsReadOnly": true,
+                  "AllowsNull": false,
+                  "Description": "Event ID.",
+                  "Status": "Active",
+                  "IntegrationObjectID": "@parent:ID"
+                }
+              },
+              {
+                "fields": {
+                  "Name": "name.text",
+                  "Type": "string",
+                  "Source": "Declared",
+                  "IsRequired": true,
+                  "Description": "Event name (plain text).",
+                  "Status": "Active",
+                  "IntegrationObjectID": "@parent:ID"
+                }
+              },
+              {
+                "fields": {
+                  "Name": "name.html",
+                  "Type": "string",
+                  "Source": "Declared",
+                  "Description": "Event name (HTML).",
+                  "Status": "Active",
+                  "IntegrationObjectID": "@parent:ID"
+                }
+              },
+              {
+                "fields": {
+                  "Name": "summary",
+                  "Type": "string",
+                  "Source": "Declared",
+                  "Description": "Short event summary (max 140 chars; mutually exclusive with description).",
+                  "Status": "Active",
+                  "IntegrationObjectID": "@parent:ID"
+                }
+              },
+              {
+                "fields": {
+                  "Name": "description.text",
+                  "Type": "string",
+                  "Source": "Declared",
+                  "Description": "Event description (plain text).",
+                  "Status": "Active",
+                  "IntegrationObjectID": "@parent:ID"
+                }
+              },
+              {
+                "fields": {
+                  "Name": "description.html",
+                  "Type": "string",
+                  "Source": "Declared",
+                  "Description": "Event description (HTML).",
+                  "Status": "Active",
+                  "IntegrationObjectID": "@parent:ID"
+                }
+              },
+              {
+                "fields": {
+                  "Name": "url",
+                  "Type": "string",
+                  "Source": "Declared",
+                  "IsReadOnly": true,
+                  "Description": "URL of the event listing page on eventbrite.com.",
+                  "Status": "Active",
+                  "IntegrationObjectID": "@parent:ID"
+                }
+              },
+              {
+                "fields": {
+                  "Name": "vanity_url",
+                  "Type": "string",
+                  "Source": "Declared",
+                  "Description": "Vanity URL of the event listing page.",
+                  "Status": "Active",
+                  "IntegrationObjectID": "@parent:ID"
+                }
+              },
+              {
+                "fields": {
+                  "Name": "start.timezone",
+                  "Type": "string",
+                  "Source": "Declared",
+                  "Description": "Olson timezone for event start.",
+                  "Status": "Active",
+                  "IntegrationObjectID": "@parent:ID"
+                }
+              },
+              {
+                "fields": {
+                  "Name": "start.local",
+                  "Type": "datetime",
+                  "Source": "Declared",
+                  "Description": "Event start in local naive time.",
+                  "Status": "Active",
+                  "IntegrationObjectID": "@parent:ID"
+                }
+              },
+              {
+                "fields": {
+                  "Name": "start.utc",
+                  "Type": "datetime",
+                  "Source": "Declared",
+                  "Description": "Event start in UTC.",
+                  "Status": "Active",
+                  "IntegrationObjectID": "@parent:ID"
+                }
+              },
+              {
+                "fields": {
+                  "Name": "end.timezone",
+                  "Type": "string",
+                  "Source": "Declared",
+                  "Description": "Olson timezone for event end.",
+                  "Status": "Active",
+                  "IntegrationObjectID": "@parent:ID"
+                }
+              },
+              {
+                "fields": {
+                  "Name": "end.local",
+                  "Type": "datetime",
+                  "Source": "Declared",
+                  "Description": "Event end in local naive time.",
+                  "Status": "Active",
+                  "IntegrationObjectID": "@parent:ID"
+                }
+              },
+              {
+                "fields": {
+                  "Name": "end.utc",
+                  "Type": "datetime",
+                  "Source": "Declared",
+                  "Description": "Event end in UTC.",
+                  "Status": "Active",
+                  "IntegrationObjectID": "@parent:ID"
+                }
+              },
+              {
+                "fields": {
+                  "Name": "created",
+                  "Type": "datetime",
+                  "Source": "Declared",
+                  "IsReadOnly": true,
+                  "Description": "Event creation date and time.",
+                  "Status": "Active",
+                  "IntegrationObjectID": "@parent:ID"
+                }
+              },
+              {
+                "fields": {
+                  "Name": "changed",
+                  "Type": "datetime",
+                  "Source": "Declared",
+                  "IsReadOnly": true,
+                  "Description": "Date and time of most recent change to the Event.",
+                  "Status": "Active",
+                  "IntegrationObjectID": "@parent:ID"
+                }
+              },
+              {
+                "fields": {
+                  "Name": "status",
+                  "Type": "string",
+                  "Source": "Declared",
+                  "Description": "Event status: draft, live, started, ended, completed, canceled.",
+                  "Status": "Active",
+                  "IntegrationObjectID": "@parent:ID"
+                }
+              },
+              {
+                "fields": {
+                  "Name": "currency",
+                  "Type": "string",
+                  "Source": "Declared",
+                  "Description": "ISO 4217 currency code.",
+                  "Status": "Active",
+                  "IntegrationObjectID": "@parent:ID"
+                }
+              },
+              {
+                "fields": {
+                  "Name": "online_event",
+                  "Type": "boolean",
+                  "Source": "Declared",
+                  "Description": "True if the event is online-only (no venue).",
+                  "Status": "Active",
+                  "IntegrationObjectID": "@parent:ID"
+                }
+              },
+              {
+                "fields": {
+                  "Name": "organization_id",
+                  "Type": "string",
+                  "Source": "Declared",
+                  "RelatedIntegrationObjectID": "@lookup:MJ: Integration Objects.Name=Organization&IntegrationID=@parent:IntegrationID",
+                  "Description": "Organization owning the event.",
+                  "Status": "Active",
+                  "IntegrationObjectID": "@parent:ID"
+                }
+              },
+              {
+                "fields": {
+                  "Name": "organizer_id",
+                  "Type": "string",
+                  "Source": "Declared",
+                  "RelatedIntegrationObjectID": "@lookup:MJ: Integration Objects.Name=Organizer&IntegrationID=@parent:IntegrationID",
+                  "Description": "ID of the event organizer.",
+                  "Status": "Active",
+                  "IntegrationObjectID": "@parent:ID"
+                }
+              },
+              {
+                "fields": {
+                  "Name": "venue_id",
+                  "Type": "string",
+                  "Source": "Declared",
+                  "RelatedIntegrationObjectID": "@lookup:MJ: Integration Objects.Name=Venue&IntegrationID=@parent:IntegrationID",
+                  "Description": "Event venue ID.",
+                  "Status": "Active",
+                  "IntegrationObjectID": "@parent:ID"
+                }
+              },
+              {
+                "fields": {
+                  "Name": "format_id",
+                  "Type": "string",
+                  "Source": "Declared",
+                  "RelatedIntegrationObjectID": "@lookup:MJ: Integration Objects.Name=Format&IntegrationID=@parent:IntegrationID",
+                  "Description": "Event format ID.",
+                  "Status": "Active",
+                  "IntegrationObjectID": "@parent:ID"
+                }
+              },
+              {
+                "fields": {
+                  "Name": "category_id",
+                  "Type": "string",
+                  "Source": "Declared",
+                  "RelatedIntegrationObjectID": "@lookup:MJ: Integration Objects.Name=Category&IntegrationID=@parent:IntegrationID",
+                  "Description": "Event category ID.",
+                  "Status": "Active",
+                  "IntegrationObjectID": "@parent:ID"
+                }
+              },
+              {
+                "fields": {
+                  "Name": "subcategory_id",
+                  "Type": "string",
+                  "Source": "Declared",
+                  "RelatedIntegrationObjectID": "@lookup:MJ: Integration Objects.Name=Subcategory&IntegrationID=@parent:IntegrationID",
+                  "Description": "Event subcategory ID.",
+                  "Status": "Active",
+                  "IntegrationObjectID": "@parent:ID"
+                }
+              },
+              {
+                "fields": {
+                  "Name": "logo_id",
+                  "Type": "string",
+                  "Source": "Declared",
+                  "RelatedIntegrationObjectID": "@lookup:MJ: Integration Objects.Name=Media&IntegrationID=@parent:IntegrationID",
+                  "Description": "Image ID of the event logo.",
+                  "Status": "Active",
+                  "IntegrationObjectID": "@parent:ID"
+                }
+              },
+              {
+                "fields": {
+                  "Name": "listed",
+                  "Type": "boolean",
+                  "Source": "Declared",
+                  "Description": "True if publicly searchable on Eventbrite.",
+                  "Status": "Active",
+                  "IntegrationObjectID": "@parent:ID"
+                }
+              },
+              {
+                "fields": {
+                  "Name": "shareable",
+                  "Type": "boolean",
+                  "Source": "Declared",
+                  "Description": "True if social sharing buttons are shown.",
+                  "Status": "Active",
+                  "IntegrationObjectID": "@parent:ID"
+                }
+              },
+              {
+                "fields": {
+                  "Name": "invite_only",
+                  "Type": "boolean",
+                  "Source": "Declared",
+                  "Description": "True if only invitees can see the event page.",
+                  "Status": "Active",
+                  "IntegrationObjectID": "@parent:ID"
+                }
+              },
+              {
+                "fields": {
+                  "Name": "show_remaining",
+                  "Type": "boolean",
+                  "Source": "Declared",
+                  "Description": "True if remaining ticket count is shown on the event page.",
+                  "Status": "Active",
+                  "IntegrationObjectID": "@parent:ID"
+                }
+              },
+              {
+                "fields": {
+                  "Name": "password",
+                  "Type": "string",
+                  "Source": "Declared",
+                  "Description": "Event password for unlisted mode.",
+                  "Status": "Active",
+                  "IntegrationObjectID": "@parent:ID"
+                }
+              },
+              {
+                "fields": {
+                  "Name": "capacity",
+                  "Type": "integer",
+                  "Source": "Declared",
+                  "Description": "Maximum number of tickets that can be sold.",
+                  "Status": "Active",
+                  "IntegrationObjectID": "@parent:ID"
+                }
+              },
+              {
+                "fields": {
+                  "Name": "capacity_is_custom",
+                  "Type": "boolean",
+                  "Source": "Declared",
+                  "Description": "True if capacity is custom-set rather than summed from ticket classes.",
+                  "Status": "Active",
+                  "IntegrationObjectID": "@parent:ID"
+                }
+              },
+              {
+                "fields": {
+                  "Name": "tx_time_limit",
+                  "Type": "integer",
+                  "Source": "Declared",
+                  "Description": "Maximum duration (seconds) of a transaction.",
+                  "Status": "Active",
+                  "IntegrationObjectID": "@parent:ID"
+                }
+              },
+              {
+                "fields": {
+                  "Name": "hide_start_date",
+                  "Type": "boolean",
+                  "Source": "Declared",
+                  "Description": "True if the start date is hidden.",
+                  "Status": "Active",
+                  "IntegrationObjectID": "@parent:ID"
+                }
+              },
+              {
+                "fields": {
+                  "Name": "hide_end_date",
+                  "Type": "boolean",
+                  "Source": "Declared",
+                  "Description": "True if the end date is hidden.",
+                  "Status": "Active",
+                  "IntegrationObjectID": "@parent:ID"
+                }
+              },
+              {
+                "fields": {
+                  "Name": "locale",
+                  "Type": "string",
+                  "Source": "Declared",
+                  "Description": "Event locale (e.g. en_US).",
+                  "Status": "Active",
+                  "IntegrationObjectID": "@parent:ID"
+                }
+              },
+              {
+                "fields": {
+                  "Name": "is_locked",
+                  "Type": "boolean",
+                  "Source": "Declared",
+                  "Description": "True if the event is locked.",
+                  "Status": "Active",
+                  "IntegrationObjectID": "@parent:ID"
+                }
+              },
+              {
+                "fields": {
+                  "Name": "privacy_setting",
+                  "Type": "string",
+                  "Source": "Declared",
+                  "Description": "Privacy setting (e.g. unlocked).",
+                  "Status": "Active",
+                  "IntegrationObjectID": "@parent:ID"
+                }
+              },
+              {
+                "fields": {
+                  "Name": "is_externally_ticketed",
+                  "Type": "boolean",
+                  "Source": "Declared",
+                  "Description": "True if the event is externally ticketed.",
+                  "Status": "Active",
+                  "IntegrationObjectID": "@parent:ID"
+                }
+              },
+              {
+                "fields": {
+                  "Name": "is_series",
+                  "Type": "boolean",
+                  "Source": "Declared",
+                  "Description": "True if the event is part of a series.",
+                  "Status": "Active",
+                  "IntegrationObjectID": "@parent:ID"
+                }
+              },
+              {
+                "fields": {
+                  "Name": "is_series_parent",
+                  "Type": "boolean",
+                  "Source": "Declared",
+                  "Description": "True if the event is the series parent.",
+                  "Status": "Active",
+                  "IntegrationObjectID": "@parent:ID"
+                }
+              },
+              {
+                "fields": {
+                  "Name": "is_reserved_seating",
+                  "Type": "boolean",
+                  "Source": "Declared",
+                  "Description": "True if the event uses reserved seating.",
+                  "Status": "Active",
+                  "IntegrationObjectID": "@parent:ID"
+                }
+              },
+              {
+                "fields": {
+                  "Name": "show_pick_a_seat",
+                  "Type": "boolean",
+                  "Source": "Declared",
+                  "Description": "For reserved seating, whether attendees can pick seats.",
+                  "Status": "Active",
+                  "IntegrationObjectID": "@parent:ID"
+                }
+              },
+              {
+                "fields": {
+                  "Name": "show_seatmap_thumbnail",
+                  "Type": "boolean",
+                  "Source": "Declared",
+                  "Description": "For reserved seating, whether the seatmap thumbnail is shown.",
+                  "Status": "Active",
+                  "IntegrationObjectID": "@parent:ID"
+                }
+              },
+              {
+                "fields": {
+                  "Name": "show_colors_in_seatmap_thumbnail",
+                  "Type": "boolean",
+                  "Source": "Declared",
+                  "Description": "For reserved seating, whether the seatmap thumbnail has colors.",
+                  "Status": "Active",
+                  "IntegrationObjectID": "@parent:ID"
+                }
+              },
+              {
+                "fields": {
+                  "Name": "is_free",
+                  "Type": "boolean",
+                  "Source": "Declared",
+                  "Description": "True if the event is free.",
+                  "Status": "Active",
+                  "IntegrationObjectID": "@parent:ID"
+                }
+              },
+              {
+                "fields": {
+                  "Name": "source",
+                  "Type": "string",
+                  "Source": "Declared",
+                  "Description": "Source of the event (defaults to api).",
+                  "Status": "Active",
+                  "IntegrationObjectID": "@parent:ID"
+                }
+              },
+              {
+                "fields": {
+                  "Name": "version",
+                  "Type": "string",
+                  "Source": "Declared",
+                  "Description": "Event version.",
+                  "Status": "Active",
+                  "IntegrationObjectID": "@parent:ID"
+                }
+              },
+              {
+                "fields": {
+                  "Name": "resource_uri",
+                  "Type": "string",
+                  "Source": "Declared",
+                  "IsReadOnly": true,
+                  "Description": "Absolute URL to the canonical event representation.",
+                  "Status": "Active",
+                  "IntegrationObjectID": "@parent:ID"
+                }
+              }
+            ]
+          }
+        },
+        {
+          "fields": {
+            "Name": "EventSeries",
+            "DisplayName": "Event Series",
+            "IntegrationID": "@parent:ID",
+            "APIPath": "/series/{event_series_id}/",
+            "PaginationType": "None",
+            "SupportsPagination": false,
+            "SupportsIncrementalSync": false,
+            "SupportsWrite": true,
+            "ResponseDataKey": null,
+            "Status": "Active",
+            "Description": "A repeating Event with a sequence of dates. Made up of a parent Event and child Events for each date.",
+            "SupportsCreate": true,
+            "CreateAPIPath": "/organizations/{organization_id}/series/",
+            "CreateMethod": "POST",
+            "CreateBodyShape": "wrapped",
+            "CreateIDLocation": "body",
+            "CreateBodyKey": "series",
+            "SupportsUpdate": true,
+            "UpdateAPIPath": "/series/{event_series_id}/",
+            "UpdateMethod": "POST",
+            "UpdateBodyShape": "wrapped",
+            "UpdateIDLocation": "path",
+            "UpdateBodyKey": "series",
+            "SupportsDelete": true,
+            "DeleteAPIPath": "/series/{event_series_id}/",
+            "DeleteMethod": "DELETE",
+            "DeleteIDLocation": "path",
+            "Configuration": {
+              "ListMethod": "GET",
+              "GetOnePath": "/series/{event_series_id}/",
+              "ListResponseKey": null,
+              "AccessPath": {
+                "door": "/series/{event_series_id}/",
+                "nesting": "get-one",
+                "args": [
+                  "expand"
+                ]
+              }
+            }
+          },
+          "relatedEntities": {
+            "MJ: Integration Object Fields": [
+              {
+                "fields": {
+                  "Name": "id",
+                  "Type": "string",
+                  "Source": "Declared",
+                  "IsPrimaryKey": true,
+                  "IsUniqueKey": true,
+                  "IsReadOnly": true,
+                  "AllowsNull": false,
+                  "Description": "Event Series ID (the parent event ID).",
+                  "Status": "Active",
+                  "IntegrationObjectID": "@parent:ID"
+                }
+              },
+              {
+                "fields": {
+                  "Name": "name.text",
+                  "Type": "string",
+                  "Source": "Declared",
+                  "IsRequired": true,
+                  "Description": "Series name (plain text).",
+                  "Status": "Active",
+                  "IntegrationObjectID": "@parent:ID"
+                }
+              },
+              {
+                "fields": {
+                  "Name": "description.text",
+                  "Type": "string",
+                  "Source": "Declared",
+                  "Description": "Series description (plain text).",
+                  "Status": "Active",
+                  "IntegrationObjectID": "@parent:ID"
+                }
+              },
+              {
+                "fields": {
+                  "Name": "start.utc",
+                  "Type": "datetime",
+                  "Source": "Declared",
+                  "Description": "Series parent start in UTC.",
+                  "Status": "Active",
+                  "IntegrationObjectID": "@parent:ID"
+                }
+              },
+              {
+                "fields": {
+                  "Name": "start.timezone",
+                  "Type": "string",
+                  "Source": "Declared",
+                  "Description": "Olson timezone for series start.",
+                  "Status": "Active",
+                  "IntegrationObjectID": "@parent:ID"
+                }
+              },
+              {
+                "fields": {
+                  "Name": "end.utc",
+                  "Type": "datetime",
+                  "Source": "Declared",
+                  "Description": "Series parent end in UTC.",
+                  "Status": "Active",
+                  "IntegrationObjectID": "@parent:ID"
+                }
+              },
+              {
+                "fields": {
+                  "Name": "currency",
+                  "Type": "string",
+                  "Source": "Declared",
+                  "Description": "ISO 4217 currency code.",
+                  "Status": "Active",
+                  "IntegrationObjectID": "@parent:ID"
+                }
+              },
+              {
+                "fields": {
+                  "Name": "organizer_id",
+                  "Type": "string",
+                  "Source": "Declared",
+                  "RelatedIntegrationObjectID": "@lookup:MJ: Integration Objects.Name=Organizer&IntegrationID=@parent:IntegrationID",
+                  "Description": "ID of the series organizer.",
+                  "Status": "Active",
+                  "IntegrationObjectID": "@parent:ID"
+                }
+              },
+              {
+                "fields": {
+                  "Name": "venue_id",
+                  "Type": "string",
+                  "Source": "Declared",
+                  "RelatedIntegrationObjectID": "@lookup:MJ: Integration Objects.Name=Venue&IntegrationID=@parent:IntegrationID",
+                  "Description": "Series venue ID.",
+                  "Status": "Active",
+                  "IntegrationObjectID": "@parent:ID"
+                }
+              },
+              {
+                "fields": {
+                  "Name": "is_series",
+                  "Type": "boolean",
+                  "Source": "Declared",
+                  "Description": "True (series flag).",
+                  "Status": "Active",
+                  "IntegrationObjectID": "@parent:ID"
+                }
+              },
+              {
+                "fields": {
+                  "Name": "is_series_parent",
+                  "Type": "boolean",
+                  "Source": "Declared",
+                  "Description": "True if this is the series parent.",
+                  "Status": "Active",
+                  "IntegrationObjectID": "@parent:ID"
+                }
+              }
+            ]
+          }
+        },
+        {
+          "fields": {
+            "Name": "Venue",
+            "DisplayName": "Venue",
+            "IntegrationID": "@parent:ID",
+            "APIPath": "/organizations/{organization_id}/venues/",
+            "PaginationType": "Cursor",
+            "SupportsPagination": true,
+            "SupportsIncrementalSync": false,
+            "SupportsWrite": true,
+            "ResponseDataKey": "venues",
+            "Status": "Active",
+            "Description": "The location where an Event takes place. Venues are grouped by Organization.",
+            "SupportsCreate": true,
+            "CreateAPIPath": "/organizations/{organization_id}/venues/",
+            "CreateMethod": "POST",
+            "CreateBodyShape": "wrapped",
+            "CreateIDLocation": "body",
+            "CreateBodyKey": "venue",
+            "SupportsUpdate": true,
+            "UpdateAPIPath": "/venues/{venue_id}/",
+            "UpdateMethod": "POST",
+            "UpdateBodyShape": "wrapped",
+            "UpdateIDLocation": "path",
+            "UpdateBodyKey": "venue",
+            "SupportsDelete": false,
+            "Configuration": {
+              "ListMethod": "GET",
+              "GetOnePath": "/venues/{venue_id}/",
+              "ListResponseKey": "venues",
+              "AccessPath": {
+                "door": "/organizations/{organization_id}/venues/",
+                "nesting": "Organization -> venues[]",
+                "args": []
+              },
+              "parentObjectName": "Organization",
+              "parentObjectIDFieldName": "organization_id"
+            }
+          },
+          "relatedEntities": {
+            "MJ: Integration Object Fields": [
+              {
+                "fields": {
+                  "Name": "id",
+                  "Type": "string",
+                  "Source": "Declared",
+                  "IsPrimaryKey": true,
+                  "IsUniqueKey": true,
+                  "IsReadOnly": true,
+                  "AllowsNull": false,
+                  "Description": "Venue ID.",
+                  "Status": "Active",
+                  "IntegrationObjectID": "@parent:ID"
+                }
+              },
+              {
+                "fields": {
+                  "Name": "name",
+                  "Type": "string",
+                  "Source": "Declared",
+                  "Description": "Venue name.",
+                  "Status": "Active",
+                  "IntegrationObjectID": "@parent:ID"
+                }
+              },
+              {
+                "fields": {
+                  "Name": "age_restriction",
+                  "Type": "string",
+                  "Source": "Declared",
+                  "Description": "Age restriction of the venue.",
+                  "Status": "Active",
+                  "IntegrationObjectID": "@parent:ID"
+                }
+              },
+              {
+                "fields": {
+                  "Name": "capacity",
+                  "Type": "integer",
+                  "Source": "Declared",
+                  "Description": "Maximum number of tickets sellable for the venue.",
+                  "Status": "Active",
+                  "IntegrationObjectID": "@parent:ID"
+                }
+              },
+              {
+                "fields": {
+                  "Name": "latitude",
+                  "Type": "string",
+                  "Source": "Declared",
+                  "Description": "Latitude coordinate of the venue address.",
+                  "Status": "Active",
+                  "IntegrationObjectID": "@parent:ID"
+                }
+              },
+              {
+                "fields": {
+                  "Name": "longitude",
+                  "Type": "string",
+                  "Source": "Declared",
+                  "Description": "Longitude coordinate of the venue address.",
+                  "Status": "Active",
+                  "IntegrationObjectID": "@parent:ID"
+                }
+              },
+              {
+                "fields": {
+                  "Name": "address.address_1",
+                  "Type": "string",
+                  "Source": "Declared",
+                  "Description": "Street/location address part 1.",
+                  "Status": "Active",
+                  "IntegrationObjectID": "@parent:ID"
+                }
+              },
+              {
+                "fields": {
+                  "Name": "address.address_2",
+                  "Type": "string",
+                  "Source": "Declared",
+                  "Description": "Street/location address part 2.",
+                  "Status": "Active",
+                  "IntegrationObjectID": "@parent:ID"
+                }
+              },
+              {
+                "fields": {
+                  "Name": "address.city",
+                  "Type": "string",
+                  "Source": "Declared",
+                  "Description": "City.",
+                  "Status": "Active",
+                  "IntegrationObjectID": "@parent:ID"
+                }
+              },
+              {
+                "fields": {
+                  "Name": "address.region",
+                  "Type": "string",
+                  "Source": "Declared",
+                  "Description": "ISO 3166-2 region/state/province code.",
+                  "Status": "Active",
+                  "IntegrationObjectID": "@parent:ID"
+                }
+              },
+              {
+                "fields": {
+                  "Name": "address.postal_code",
+                  "Type": "string",
+                  "Source": "Declared",
+                  "Description": "Postal code.",
+                  "Status": "Active",
+                  "IntegrationObjectID": "@parent:ID"
+                }
+              },
+              {
+                "fields": {
+                  "Name": "address.country",
+                  "Type": "string",
+                  "Source": "Declared",
+                  "Description": "ISO 3166-1 2-character country code.",
+                  "Status": "Active",
+                  "IntegrationObjectID": "@parent:ID"
+                }
+              },
+              {
+                "fields": {
+                  "Name": "address.latitude",
+                  "Type": "decimal",
+                  "Source": "Declared",
+                  "Description": "Latitude portion of the address coordinates.",
+                  "Status": "Active",
+                  "IntegrationObjectID": "@parent:ID"
+                }
+              },
+              {
+                "fields": {
+                  "Name": "address.longitude",
+                  "Type": "decimal",
+                  "Source": "Declared",
+                  "Description": "Longitude portion of the address coordinates.",
+                  "Status": "Active",
+                  "IntegrationObjectID": "@parent:ID"
+                }
+              },
+              {
+                "fields": {
+                  "Name": "address.localized_address_display",
+                  "Type": "string",
+                  "Source": "Declared",
+                  "Description": "Address display localized to the address country.",
+                  "Status": "Active",
+                  "IntegrationObjectID": "@parent:ID"
+                }
+              },
+              {
+                "fields": {
+                  "Name": "address.localized_area_display",
+                  "Type": "string",
+                  "Source": "Declared",
+                  "Description": "Area display localized to the address country.",
+                  "Status": "Active",
+                  "IntegrationObjectID": "@parent:ID"
+                }
+              }
+            ]
+          }
+        },
+        {
+          "fields": {
+            "Name": "Organizer",
+            "DisplayName": "Organizer",
+            "IntegrationID": "@parent:ID",
+            "APIPath": "/organizations/{organization_id}/organizers/",
+            "PaginationType": "Cursor",
+            "SupportsPagination": true,
+            "SupportsIncrementalSync": false,
+            "SupportsWrite": false,
+            "ResponseDataKey": "organizers",
+            "Status": "Active",
+            "Description": "The public-facing entity organizing an Event. Does not own events and has no Eventbrite account.",
+            "SupportsCreate": false,
+            "SupportsUpdate": false,
+            "SupportsDelete": false,
+            "Configuration": {
+              "ListMethod": "GET",
+              "GetOnePath": "/organizers/{organizer_id}/",
+              "ListResponseKey": "organizers",
+              "AccessPath": {
+                "door": "/organizations/{organization_id}/organizers/",
+                "nesting": "Organization -> organizers[]",
+                "args": []
+              },
+              "parentObjectName": "Organization",
+              "parentObjectIDFieldName": "organization_id"
+            }
+          },
+          "relatedEntities": {
+            "MJ: Integration Object Fields": [
+              {
+                "fields": {
+                  "Name": "id",
+                  "Type": "string",
+                  "Source": "Declared",
+                  "IsPrimaryKey": true,
+                  "IsUniqueKey": true,
+                  "IsReadOnly": true,
+                  "AllowsNull": false,
+                  "Description": "Organizer ID.",
+                  "Status": "Active",
+                  "IntegrationObjectID": "@parent:ID"
+                }
+              },
+              {
+                "fields": {
+                  "Name": "name",
+                  "Type": "string",
+                  "Source": "Declared",
+                  "Description": "Organizer name.",
+                  "Status": "Active",
+                  "IntegrationObjectID": "@parent:ID"
+                }
+              },
+              {
+                "fields": {
+                  "Name": "description.text",
+                  "Type": "string",
+                  "Source": "Declared",
+                  "Description": "Organizer description (plain text).",
+                  "Status": "Active",
+                  "IntegrationObjectID": "@parent:ID"
+                }
+              },
+              {
+                "fields": {
+                  "Name": "description.html",
+                  "Type": "string",
+                  "Source": "Declared",
+                  "Description": "Organizer description (HTML).",
+                  "Status": "Active",
+                  "IntegrationObjectID": "@parent:ID"
+                }
+              },
+              {
+                "fields": {
+                  "Name": "long_description.text",
+                  "Type": "string",
+                  "Source": "Declared",
+                  "Description": "Organizer long description (plain text).",
+                  "Status": "Active",
+                  "IntegrationObjectID": "@parent:ID"
+                }
+              },
+              {
+                "fields": {
+                  "Name": "long_description.html",
+                  "Type": "string",
+                  "Source": "Declared",
+                  "Description": "Organizer long description (HTML).",
+                  "Status": "Active",
+                  "IntegrationObjectID": "@parent:ID"
+                }
+              },
+              {
+                "fields": {
+                  "Name": "logo_id",
+                  "Type": "string",
+                  "Source": "Declared",
+                  "RelatedIntegrationObjectID": "@lookup:MJ: Integration Objects.Name=Media&IntegrationID=@parent:IntegrationID",
+                  "Description": "Image ID of the organizer logo.",
+                  "Status": "Active",
+                  "IntegrationObjectID": "@parent:ID"
+                }
+              },
+              {
+                "fields": {
+                  "Name": "url",
+                  "Type": "string",
+                  "Source": "Declared",
+                  "IsReadOnly": true,
+                  "Description": "URL to the organizer's page on Eventbrite.",
+                  "Status": "Active",
+                  "IntegrationObjectID": "@parent:ID"
+                }
+              },
+              {
+                "fields": {
+                  "Name": "num_past_events",
+                  "Type": "integer",
+                  "Source": "Declared",
+                  "IsReadOnly": true,
+                  "Description": "Number of past events the organizer has.",
+                  "Status": "Active",
+                  "IntegrationObjectID": "@parent:ID"
+                }
+              },
+              {
+                "fields": {
+                  "Name": "num_future_events",
+                  "Type": "integer",
+                  "Source": "Declared",
+                  "IsReadOnly": true,
+                  "Description": "Number of upcoming events the organizer has.",
+                  "Status": "Active",
+                  "IntegrationObjectID": "@parent:ID"
+                }
+              },
+              {
+                "fields": {
+                  "Name": "twitter",
+                  "Type": "string",
+                  "Source": "Declared",
+                  "Description": "Organizer Twitter handle.",
+                  "Status": "Active",
+                  "IntegrationObjectID": "@parent:ID"
+                }
+              },
+              {
+                "fields": {
+                  "Name": "facebook",
+                  "Type": "string",
+                  "Source": "Declared",
+                  "Description": "Organizer Facebook page.",
+                  "Status": "Active",
+                  "IntegrationObjectID": "@parent:ID"
+                }
+              },
+              {
+                "fields": {
+                  "Name": "resource_uri",
+                  "Type": "string",
+                  "Source": "Declared",
+                  "IsReadOnly": true,
+                  "Description": "Absolute URL to the canonical organizer representation.",
+                  "Status": "Active",
+                  "IntegrationObjectID": "@parent:ID"
+                }
+              }
+            ]
+          }
+        },
+        {
+          "fields": {
+            "Name": "TicketClass",
+            "DisplayName": "Ticket Class",
+            "IntegrationID": "@parent:ID",
+            "APIPath": "/events/{event_id}/ticket_classes/",
+            "PaginationType": "Cursor",
+            "SupportsPagination": true,
+            "SupportsIncrementalSync": false,
+            "SupportsWrite": true,
+            "ResponseDataKey": "ticket_classes",
+            "Status": "Active",
+            "Description": "A ticket type (free, paid or donation) for an Event. Multiple ticket classes can belong to one Event.",
+            "SupportsCreate": true,
+            "CreateAPIPath": "/events/{event_id}/ticket_classes/",
+            "CreateMethod": "POST",
+            "CreateBodyShape": "wrapped",
+            "CreateIDLocation": "body",
+            "CreateBodyKey": "ticket_class",
+            "SupportsUpdate": true,
+            "UpdateAPIPath": "/events/{event_id}/ticket_classes/{ticket_class_id}/",
+            "UpdateMethod": "POST",
+            "UpdateBodyShape": "wrapped",
+            "UpdateIDLocation": "path",
+            "UpdateBodyKey": "ticket_class",
+            "SupportsDelete": true,
+            "DeleteAPIPath": "/events/{event_id}/ticket_classes/{ticket_class_id}/",
+            "DeleteMethod": "DELETE",
+            "DeleteIDLocation": "path",
+            "Configuration": {
+              "ListMethod": "GET",
+              "GetOnePath": "/events/{event_id}/ticket_classes/{ticket_class_id}/",
+              "ListResponseKey": "ticket_classes",
+              "AccessPath": {
+                "door": "/events/{event_id}/ticket_classes/",
+                "nesting": "Event -> ticket_classes[]",
+                "args": [
+                  "pos"
+                ]
+              },
+              "parentObjectName": "Event",
+              "parentObjectIDFieldName": "event_id"
+            }
+          },
+          "relatedEntities": {
+            "MJ: Integration Object Fields": [
+              {
+                "fields": {
+                  "Name": "id",
+                  "Type": "string",
+                  "Source": "Declared",
+                  "IsPrimaryKey": true,
+                  "IsUniqueKey": true,
+                  "IsReadOnly": true,
+                  "AllowsNull": false,
+                  "Description": "Ticket Class ID.",
+                  "Status": "Active",
+                  "IntegrationObjectID": "@parent:ID"
+                }
+              },
+              {
+                "fields": {
+                  "Name": "event_id",
+                  "Type": "string",
+                  "Source": "Declared",
+                  "RelatedIntegrationObjectID": "@lookup:MJ: Integration Objects.Name=Event&IntegrationID=@parent:IntegrationID",
+                  "Description": "Event the ticket class belongs to.",
+                  "Status": "Active",
+                  "IntegrationObjectID": "@parent:ID"
+                }
+              },
+              {
+                "fields": {
+                  "Name": "name",
+                  "Type": "string",
+                  "Source": "Declared",
+                  "Description": "Ticket Class name.",
+                  "Status": "Active",
+                  "IntegrationObjectID": "@parent:ID"
+                }
+              },
+              {
+                "fields": {
+                  "Name": "description",
+                  "Type": "string",
+                  "Source": "Declared",
+                  "Description": "Ticket Class description.",
+                  "Status": "Active",
+                  "IntegrationObjectID": "@parent:ID"
+                }
+              },
+              {
+                "fields": {
+                  "Name": "cost.currency",
+                  "Type": "string",
+                  "Source": "Declared",
+                  "Description": "Display cost currency (ISO 4217).",
+                  "Status": "Active",
+                  "IntegrationObjectID": "@parent:ID"
+                }
+              },
+              {
+                "fields": {
+                  "Name": "cost.value",
+                  "Type": "integer",
+                  "Source": "Declared",
+                  "Description": "Display cost value in minor currency units.",
+                  "Status": "Active",
+                  "IntegrationObjectID": "@parent:ID"
+                }
+              },
+              {
+                "fields": {
+                  "Name": "cost.display",
+                  "Type": "string",
+                  "Source": "Declared",
+                  "Description": "Formatted display cost.",
+                  "Status": "Active",
+                  "IntegrationObjectID": "@parent:ID"
+                }
+              },
+              {
+                "fields": {
+                  "Name": "fee.currency",
+                  "Type": "string",
+                  "Source": "Declared",
+                  "Description": "Display fee currency (ISO 4217).",
+                  "Status": "Active",
+                  "IntegrationObjectID": "@parent:ID"
+                }
+              },
+              {
+                "fields": {
+                  "Name": "fee.value",
+                  "Type": "integer",
+                  "Source": "Declared",
+                  "Description": "Display fee value in minor currency units.",
+                  "Status": "Active",
+                  "IntegrationObjectID": "@parent:ID"
+                }
+              },
+              {
+                "fields": {
+                  "Name": "donation",
+                  "Type": "boolean",
+                  "Source": "Declared",
+                  "Description": "True if the ticket class is a donation.",
+                  "Status": "Active",
+                  "IntegrationObjectID": "@parent:ID"
+                }
+              },
+              {
+                "fields": {
+                  "Name": "free",
+                  "Type": "boolean",
+                  "Source": "Declared",
+                  "Description": "True if the ticket class is free.",
+                  "Status": "Active",
+                  "IntegrationObjectID": "@parent:ID"
+                }
+              },
+              {
+                "fields": {
+                  "Name": "minimum_quantity",
+                  "Type": "integer",
+                  "Source": "Declared",
+                  "Description": "Minimum number of tickets per order.",
+                  "Status": "Active",
+                  "IntegrationObjectID": "@parent:ID"
+                }
+              },
+              {
+                "fields": {
+                  "Name": "maximum_quantity",
+                  "Type": "integer",
+                  "Source": "Declared",
+                  "Description": "Maximum number of tickets per order.",
+                  "Status": "Active",
+                  "IntegrationObjectID": "@parent:ID"
+                }
+              },
+              {
+                "fields": {
+                  "Name": "has_pdf_ticket",
+                  "Type": "boolean",
+                  "Source": "Declared",
+                  "Description": "True if attendee receives a PDF order confirmation.",
+                  "Status": "Active",
+                  "IntegrationObjectID": "@parent:ID"
+                }
+              },
+              {
+                "fields": {
+                  "Name": "delivery_methods",
+                  "Type": "json",
+                  "Source": "Declared",
+                  "Description": "List of delivery methods: electronic, will_call, standard_shipping.",
+                  "Status": "Active",
+                  "IntegrationObjectID": "@parent:ID"
+                }
+              },
+              {
+                "fields": {
+                  "Name": "category",
+                  "Type": "string",
+                  "Source": "Declared",
+                  "Description": "Ticket class category: admission, add_on, donation.",
+                  "Status": "Active",
+                  "IntegrationObjectID": "@parent:ID"
+                }
+              },
+              {
+                "fields": {
+                  "Name": "quantity_total",
+                  "Type": "integer",
+                  "Source": "Declared",
+                  "Description": "Number of this ticket class available for sale.",
+                  "Status": "Active",
+                  "IntegrationObjectID": "@parent:ID"
+                }
+              },
+              {
+                "fields": {
+                  "Name": "quantity_sold",
+                  "Type": "integer",
+                  "Source": "Declared",
+                  "IsReadOnly": true,
+                  "Description": "Number of this ticket class previously sold.",
+                  "Status": "Active",
+                  "IntegrationObjectID": "@parent:ID"
+                }
+              },
+              {
+                "fields": {
+                  "Name": "hidden",
+                  "Type": "boolean",
+                  "Source": "Declared",
+                  "Description": "True if the ticket class is hidden from the public.",
+                  "Status": "Active",
+                  "IntegrationObjectID": "@parent:ID"
+                }
+              },
+              {
+                "fields": {
+                  "Name": "sales_start",
+                  "Type": "datetime",
+                  "Source": "Declared",
+                  "Description": "Date and time sales begin.",
+                  "Status": "Active",
+                  "IntegrationObjectID": "@parent:ID"
+                }
+              },
+              {
+                "fields": {
+                  "Name": "sales_end",
+                  "Type": "datetime",
+                  "Source": "Declared",
+                  "Description": "Date and time sales end.",
+                  "Status": "Active",
+                  "IntegrationObjectID": "@parent:ID"
+                }
+              },
+              {
+                "fields": {
+                  "Name": "sales_start_after",
+                  "Type": "string",
+                  "Source": "Declared",
+                  "RelatedIntegrationObjectID": "@lookup:MJ: Integration Objects.Name=TicketClass&IntegrationID=@parent:IntegrationID",
+                  "Description": "ID of a ticket class whose sell-out triggers this class's sales start.",
+                  "Status": "Active",
+                  "IntegrationObjectID": "@parent:ID"
+                }
+              },
+              {
+                "fields": {
+                  "Name": "include_fee",
+                  "Type": "boolean",
+                  "Source": "Declared",
+                  "Description": "True if the fee is included in the displayed price.",
+                  "Status": "Active",
+                  "IntegrationObjectID": "@parent:ID"
+                }
+              },
+              {
+                "fields": {
+                  "Name": "split_fee",
+                  "Type": "boolean",
+                  "Source": "Declared",
+                  "Description": "True if fee is shown separately from price.",
+                  "Status": "Active",
+                  "IntegrationObjectID": "@parent:ID"
+                }
+              },
+              {
+                "fields": {
+                  "Name": "hide_description",
+                  "Type": "boolean",
+                  "Source": "Declared",
+                  "Description": "True if the description is hidden on the listing page.",
+                  "Status": "Active",
+                  "IntegrationObjectID": "@parent:ID"
+                }
+              },
+              {
+                "fields": {
+                  "Name": "auto_hide",
+                  "Type": "boolean",
+                  "Source": "Declared",
+                  "Description": "True if the ticket class auto-hides when not on sale.",
+                  "Status": "Active",
+                  "IntegrationObjectID": "@parent:ID"
+                }
+              },
+              {
+                "fields": {
+                  "Name": "auto_hide_before",
+                  "Type": "datetime",
+                  "Source": "Declared",
+                  "Description": "Override reveal date for auto-hide.",
+                  "Status": "Active",
+                  "IntegrationObjectID": "@parent:ID"
+                }
+              },
+              {
+                "fields": {
+                  "Name": "auto_hide_after",
+                  "Type": "datetime",
+                  "Source": "Declared",
+                  "Description": "Override re-hide date for auto-hide.",
+                  "Status": "Active",
+                  "IntegrationObjectID": "@parent:ID"
+                }
+              },
+              {
+                "fields": {
+                  "Name": "order_confirmation_message",
+                  "Type": "string",
+                  "Source": "Declared",
+                  "Description": "Confirmation message displayed when an order completes.",
+                  "Status": "Active",
+                  "IntegrationObjectID": "@parent:ID"
+                }
+              },
+              {
+                "fields": {
+                  "Name": "sales_channels",
+                  "Type": "json",
+                  "Source": "Declared",
+                  "Description": "Supported sales channels: online, atd.",
+                  "Status": "Active",
+                  "IntegrationObjectID": "@parent:ID"
+                }
+              },
+              {
+                "fields": {
+                  "Name": "resource_uri",
+                  "Type": "string",
+                  "Source": "Declared",
+                  "IsReadOnly": true,
+                  "Description": "Absolute URL to the canonical ticket class representation.",
+                  "Status": "Active",
+                  "IntegrationObjectID": "@parent:ID"
+                }
+              }
+            ]
+          }
+        },
+        {
+          "fields": {
+            "Name": "TicketGroup",
+            "DisplayName": "Ticket Group",
+            "IntegrationID": "@parent:ID",
+            "APIPath": "/organizations/{organization_id}/ticket_groups/",
+            "PaginationType": "Cursor",
+            "SupportsPagination": true,
+            "SupportsIncrementalSync": false,
+            "SupportsWrite": true,
+            "ResponseDataKey": "ticket_groups",
+            "Status": "Active",
+            "Description": "A grouping of Ticket Classes, commonly used to apply a cross-event Discount to multiple ticket classes.",
+            "SupportsCreate": true,
+            "CreateAPIPath": "/organizations/{organization_id}/ticket_groups/",
+            "CreateMethod": "POST",
+            "CreateBodyShape": "wrapped",
+            "CreateIDLocation": "body",
+            "CreateBodyKey": "ticket_group",
+            "SupportsUpdate": true,
+            "UpdateAPIPath": "/ticket_groups/{ticket_group_id}/",
+            "UpdateMethod": "POST",
+            "UpdateBodyShape": "wrapped",
+            "UpdateIDLocation": "path",
+            "UpdateBodyKey": "ticket_group",
+            "SupportsDelete": true,
+            "DeleteAPIPath": "/ticket_groups/{ticket_group_id}/",
+            "DeleteMethod": "DELETE",
+            "DeleteIDLocation": "path",
+            "Configuration": {
+              "ListMethod": "GET",
+              "GetOnePath": "/ticket_groups/{ticket_group_id}/",
+              "ListResponseKey": "ticket_groups",
+              "AccessPath": {
+                "door": "/organizations/{organization_id}/ticket_groups/",
+                "nesting": "Organization -> ticket_groups[]",
+                "args": [
+                  "status"
+                ]
+              },
+              "parentObjectName": "Organization",
+              "parentObjectIDFieldName": "organization_id"
+            }
+          },
+          "relatedEntities": {
+            "MJ: Integration Object Fields": [
+              {
+                "fields": {
+                  "Name": "id",
+                  "Type": "string",
+                  "Source": "Declared",
+                  "IsPrimaryKey": true,
+                  "IsUniqueKey": true,
+                  "IsReadOnly": true,
+                  "AllowsNull": false,
+                  "Description": "Ticket Group ID.",
+                  "Status": "Active",
+                  "IntegrationObjectID": "@parent:ID"
+                }
+              },
+              {
+                "fields": {
+                  "Name": "name",
+                  "Type": "string",
+                  "Source": "Declared",
+                  "Description": "Ticket Group name (truncated past 20 chars).",
+                  "Status": "Active",
+                  "IntegrationObjectID": "@parent:ID"
+                }
+              },
+              {
+                "fields": {
+                  "Name": "status",
+                  "Type": "string",
+                  "Source": "Declared",
+                  "Description": "Ticket Group status: transfer, live, deleted, archived.",
+                  "Status": "Active",
+                  "IntegrationObjectID": "@parent:ID"
+                }
+              },
+              {
+                "fields": {
+                  "Name": "event_ticket_ids",
+                  "Type": "json",
+                  "Source": "Declared",
+                  "Description": "Dictionary of ticket class IDs associated with each event ID.",
+                  "Status": "Active",
+                  "IntegrationObjectID": "@parent:ID"
+                }
+              },
+              {
+                "fields": {
+                  "Name": "tickets",
+                  "Type": "json",
+                  "Source": "Declared",
+                  "Description": "List of ticket classes (id, event_id, sales_channels, variants, name); populated via expansion.",
+                  "Status": "Active",
+                  "IntegrationObjectID": "@parent:ID"
+                }
+              }
+            ]
+          }
+        },
+        {
+          "fields": {
+            "Name": "Order",
+            "DisplayName": "Order",
+            "IntegrationID": "@parent:ID",
+            "APIPath": "/organizations/{organization_id}/orders/",
+            "PaginationType": "Cursor",
+            "SupportsPagination": true,
+            "SupportsIncrementalSync": true,
+            "SupportsWrite": false,
+            "ResponseDataKey": "orders",
+            "Status": "Active",
+            "Description": "An order placed against Eventbrite for one or more ticket classes. Holds financial and transactional info. Private.",
+            "IncrementalWatermarkField": "changed",
+            "SupportsCreate": false,
+            "SupportsUpdate": false,
+            "SupportsDelete": false,
+            "Configuration": {
+              "ListMethod": "GET",
+              "GetOnePath": "/orders/{order_id}/",
+              "ListResponseKey": "orders",
+              "AccessPath": {
+                "door": "/organizations/{organization_id}/orders/",
+                "nesting": "Organization -> orders[]; also Event -> orders[] (/events/{event_id}/orders) and User -> orders[] (/users/{user_id}/orders)",
+                "args": [
+                  "status",
+                  "changed_since",
+                  "only_emails",
+                  "exclude_emails",
+                  "expand"
+                ]
+              },
+              "parentObjectName": "Organization",
+              "parentObjectIDFieldName": "organization_id"
+            }
+          },
+          "relatedEntities": {
+            "MJ: Integration Object Fields": [
+              {
+                "fields": {
+                  "Name": "id",
+                  "Type": "string",
+                  "Source": "Declared",
+                  "IsPrimaryKey": true,
+                  "IsUniqueKey": true,
+                  "IsReadOnly": true,
+                  "AllowsNull": false,
+                  "Description": "Order ID.",
+                  "Status": "Active",
+                  "IntegrationObjectID": "@parent:ID"
+                }
+              },
+              {
+                "fields": {
+                  "Name": "created",
+                  "Type": "datetime",
+                  "Source": "Declared",
+                  "IsReadOnly": true,
+                  "Description": "When the order was placed.",
+                  "Status": "Active",
+                  "IntegrationObjectID": "@parent:ID"
+                }
+              },
+              {
+                "fields": {
+                  "Name": "changed",
+                  "Type": "datetime",
+                  "Source": "Declared",
+                  "IsReadOnly": true,
+                  "Description": "When the order was last changed (incremental watermark).",
+                  "Status": "Active",
+                  "IntegrationObjectID": "@parent:ID"
+                }
+              },
+              {
+                "fields": {
+                  "Name": "name",
+                  "Type": "string",
+                  "Source": "Declared",
+                  "Description": "Order owner name (prefer over first_name/last_name).",
+                  "Status": "Active",
+                  "IntegrationObjectID": "@parent:ID"
+                }
+              },
+              {
+                "fields": {
+                  "Name": "first_name",
+                  "Type": "string",
+                  "Source": "Declared",
+                  "Description": "Order owner first name.",
+                  "Status": "Active",
+                  "IntegrationObjectID": "@parent:ID"
+                }
+              },
+              {
+                "fields": {
+                  "Name": "last_name",
+                  "Type": "string",
+                  "Source": "Declared",
+                  "Description": "Order owner last name.",
+                  "Status": "Active",
+                  "IntegrationObjectID": "@parent:ID"
+                }
+              },
+              {
+                "fields": {
+                  "Name": "email",
+                  "Type": "string",
+                  "Source": "Declared",
+                  "Description": "Order owner email address.",
+                  "Status": "Active",
+                  "IntegrationObjectID": "@parent:ID"
+                }
+              },
+              {
+                "fields": {
+                  "Name": "event_id",
+                  "Type": "string",
+                  "Source": "Declared",
+                  "RelatedIntegrationObjectID": "@lookup:MJ: Integration Objects.Name=Event&IntegrationID=@parent:IntegrationID",
+                  "Description": "Order's Event ID.",
+                  "Status": "Active",
+                  "IntegrationObjectID": "@parent:ID"
+                }
+              },
+              {
+                "fields": {
+                  "Name": "time_remaining",
+                  "Type": "integer",
+                  "Source": "Declared",
+                  "Description": "Time remaining to complete the order (seconds).",
+                  "Status": "Active",
+                  "IntegrationObjectID": "@parent:ID"
+                }
+              },
+              {
+                "fields": {
+                  "Name": "status",
+                  "Type": "string",
+                  "Source": "Declared",
+                  "Description": "Order status: started, pending, placed, abandoned.",
+                  "Status": "Active",
+                  "IntegrationObjectID": "@parent:ID"
+                }
+              },
+              {
+                "fields": {
+                  "Name": "promo_code",
+                  "Type": "string",
+                  "Source": "Declared",
+                  "Description": "Discount code applied to the order.",
+                  "Status": "Active",
+                  "IntegrationObjectID": "@parent:ID"
+                }
+              },
+              {
+                "fields": {
+                  "Name": "costs.base_price.value",
+                  "Type": "integer",
+                  "Source": "Declared",
+                  "Description": "Order amount excluding fees and tax (minor units).",
+                  "Status": "Active",
+                  "IntegrationObjectID": "@parent:ID"
+                }
+              },
+              {
+                "fields": {
+                  "Name": "costs.base_price.currency",
+                  "Type": "string",
+                  "Source": "Declared",
+                  "Description": "Base price currency (ISO 4217).",
+                  "Status": "Active",
+                  "IntegrationObjectID": "@parent:ID"
+                }
+              },
+              {
+                "fields": {
+                  "Name": "costs.gross.value",
+                  "Type": "integer",
+                  "Source": "Declared",
+                  "Description": "Total amount of the order (minor units).",
+                  "Status": "Active",
+                  "IntegrationObjectID": "@parent:ID"
+                }
+              },
+              {
+                "fields": {
+                  "Name": "costs.gross.currency",
+                  "Type": "string",
+                  "Source": "Declared",
+                  "Description": "Gross currency (ISO 4217).",
+                  "Status": "Active",
+                  "IntegrationObjectID": "@parent:ID"
+                }
+              },
+              {
+                "fields": {
+                  "Name": "costs.eventbrite_fee.value",
+                  "Type": "integer",
+                  "Source": "Declared",
+                  "Description": "Eventbrite fee portion of gross (minor units).",
+                  "Status": "Active",
+                  "IntegrationObjectID": "@parent:ID"
+                }
+              },
+              {
+                "fields": {
+                  "Name": "costs.payment_fee.value",
+                  "Type": "integer",
+                  "Source": "Declared",
+                  "Description": "Payment processor fee portion of gross (minor units).",
+                  "Status": "Active",
+                  "IntegrationObjectID": "@parent:ID"
+                }
+              },
+              {
+                "fields": {
+                  "Name": "costs.tax.value",
+                  "Type": "integer",
+                  "Source": "Declared",
+                  "Description": "Tax portion of gross (minor units).",
+                  "Status": "Active",
+                  "IntegrationObjectID": "@parent:ID"
+                }
+              },
+              {
+                "fields": {
+                  "Name": "resource_uri",
+                  "Type": "string",
+                  "Source": "Declared",
+                  "IsReadOnly": true,
+                  "Description": "Absolute URL to the canonical order representation.",
+                  "Status": "Active",
+                  "IntegrationObjectID": "@parent:ID"
+                }
+              }
+            ]
+          }
+        },
+        {
+          "fields": {
+            "Name": "Attendee",
+            "DisplayName": "Attendee",
+            "IntegrationID": "@parent:ID",
+            "APIPath": "/events/{event_id}/attendees/",
+            "PaginationType": "Cursor",
+            "SupportsPagination": true,
+            "SupportsIncrementalSync": true,
+            "SupportsWrite": false,
+            "ResponseDataKey": "attendees",
+            "Status": "Active",
+            "Description": "A ticket holder for an Event (one attendee per sold ticket). Holds profile, barcode and cost info. Private.",
+            "IncrementalWatermarkField": "changed",
+            "SupportsCreate": false,
+            "SupportsUpdate": false,
+            "SupportsDelete": false,
+            "Configuration": {
+              "ListMethod": "GET",
+              "GetOnePath": "/events/{event_id}/attendees/{attendee_id}/",
+              "ListResponseKey": "attendees",
+              "AccessPath": {
+                "door": "/events/{event_id}/attendees/",
+                "nesting": "Event -> attendees[]; also Organization -> attendees[] (/organizations/{organization_id}/attendees)",
+                "args": [
+                  "status",
+                  "changed_since",
+                  "last_item_seen",
+                  "attendee_ids",
+                  "expand"
+                ]
+              },
+              "parentObjectName": "Event",
+              "parentObjectIDFieldName": "event_id"
+            }
+          },
+          "relatedEntities": {
+            "MJ: Integration Object Fields": [
+              {
+                "fields": {
+                  "Name": "id",
+                  "Type": "string",
+                  "Source": "Declared",
+                  "IsPrimaryKey": true,
+                  "IsUniqueKey": true,
+                  "IsReadOnly": true,
+                  "AllowsNull": false,
+                  "Description": "Attendee ID.",
+                  "Status": "Active",
+                  "IntegrationObjectID": "@parent:ID"
+                }
+              },
+              {
+                "fields": {
+                  "Name": "created",
+                  "Type": "datetime",
+                  "Source": "Declared",
+                  "IsReadOnly": true,
+                  "Description": "When the attendee was created (order placed).",
+                  "Status": "Active",
+                  "IntegrationObjectID": "@parent:ID"
+                }
+              },
+              {
+                "fields": {
+                  "Name": "changed",
+                  "Type": "datetime",
+                  "Source": "Declared",
+                  "IsReadOnly": true,
+                  "Description": "When the attendee was last changed (incremental watermark).",
+                  "Status": "Active",
+                  "IntegrationObjectID": "@parent:ID"
+                }
+              },
+              {
+                "fields": {
+                  "Name": "ticket_class_id",
+                  "Type": "string",
+                  "Source": "Declared",
+                  "RelatedIntegrationObjectID": "@lookup:MJ: Integration Objects.Name=TicketClass&IntegrationID=@parent:IntegrationID",
+                  "Description": "Ticket class used by the attendee.",
+                  "Status": "Active",
+                  "IntegrationObjectID": "@parent:ID"
+                }
+              },
+              {
+                "fields": {
+                  "Name": "ticket_class_name",
+                  "Type": "string",
+                  "Source": "Declared",
+                  "Description": "Name of the ticket class at registration.",
+                  "Status": "Active",
+                  "IntegrationObjectID": "@parent:ID"
+                }
+              },
+              {
+                "fields": {
+                  "Name": "variant_id",
+                  "Type": "string",
+                  "Source": "Declared",
+                  "Description": "Composite ticket-class+discount id (T12345-D12345).",
+                  "Status": "Active",
+                  "IntegrationObjectID": "@parent:ID"
+                }
+              },
+              {
+                "fields": {
+                  "Name": "quantity",
+                  "Type": "integer",
+                  "Source": "Declared",
+                  "Description": "Always 1.",
+                  "Status": "Active",
+                  "IntegrationObjectID": "@parent:ID"
+                }
+              },
+              {
+                "fields": {
+                  "Name": "event_id",
+                  "Type": "string",
+                  "Source": "Declared",
+                  "RelatedIntegrationObjectID": "@lookup:MJ: Integration Objects.Name=Event&IntegrationID=@parent:IntegrationID",
+                  "Description": "Event the attendee is attending.",
+                  "Status": "Active",
+                  "IntegrationObjectID": "@parent:ID"
+                }
+              },
+              {
+                "fields": {
+                  "Name": "order_id",
+                  "Type": "string",
+                  "Source": "Declared",
+                  "RelatedIntegrationObjectID": "@lookup:MJ: Integration Objects.Name=Order&IntegrationID=@parent:IntegrationID",
+                  "Description": "Order under which the attendee's ticket was purchased.",
+                  "Status": "Active",
+                  "IntegrationObjectID": "@parent:ID"
+                }
+              },
+              {
+                "fields": {
+                  "Name": "guestlist_id",
+                  "Type": "string",
+                  "Source": "Declared",
+                  "Description": "Guest list ID; null if not a guest.",
+                  "Status": "Active",
+                  "IntegrationObjectID": "@parent:ID"
+                }
+              },
+              {
+                "fields": {
+                  "Name": "invited_by",
+                  "Type": "string",
+                  "Source": "Declared",
+                  "Description": "Name of the person who invited the guest; null if not a guest.",
+                  "Status": "Active",
+                  "IntegrationObjectID": "@parent:ID"
+                }
+              },
+              {
+                "fields": {
+                  "Name": "checked_in",
+                  "Type": "boolean",
+                  "Source": "Declared",
+                  "Description": "True if the attendee is checked in.",
+                  "Status": "Active",
+                  "IntegrationObjectID": "@parent:ID"
+                }
+              },
+              {
+                "fields": {
+                  "Name": "cancelled",
+                  "Type": "boolean",
+                  "Source": "Declared",
+                  "Description": "True if the attendee is cancelled.",
+                  "Status": "Active",
+                  "IntegrationObjectID": "@parent:ID"
+                }
+              },
+              {
+                "fields": {
+                  "Name": "refunded",
+                  "Type": "boolean",
+                  "Source": "Declared",
+                  "Description": "True if the attendee is refunded.",
+                  "Status": "Active",
+                  "IntegrationObjectID": "@parent:ID"
+                }
+              },
+              {
+                "fields": {
+                  "Name": "status",
+                  "Type": "string",
+                  "Source": "Declared",
+                  "Description": "Attendee status (scheduled to be deprecated).",
+                  "Status": "Active",
+                  "IntegrationObjectID": "@parent:ID"
+                }
+              },
+              {
+                "fields": {
+                  "Name": "affiliate",
+                  "Type": "string",
+                  "Source": "Declared",
+                  "Description": "Attendee affiliate code.",
+                  "Status": "Active",
+                  "IntegrationObjectID": "@parent:ID"
+                }
+              },
+              {
+                "fields": {
+                  "Name": "delivery_method",
+                  "Type": "string",
+                  "Source": "Declared",
+                  "Description": "Ticket delivery method: will_call, electronic, standard_shipping.",
+                  "Status": "Active",
+                  "IntegrationObjectID": "@parent:ID"
+                }
+              },
+              {
+                "fields": {
+                  "Name": "profile.name",
+                  "Type": "string",
+                  "Source": "Declared",
+                  "Description": "Attendee name.",
+                  "Status": "Active",
+                  "IntegrationObjectID": "@parent:ID"
+                }
+              },
+              {
+                "fields": {
+                  "Name": "profile.email",
+                  "Type": "string",
+                  "Source": "Declared",
+                  "Description": "Attendee email address.",
+                  "Status": "Active",
+                  "IntegrationObjectID": "@parent:ID"
+                }
+              },
+              {
+                "fields": {
+                  "Name": "profile.first_name",
+                  "Type": "string",
+                  "Source": "Declared",
+                  "Description": "Attendee first name.",
+                  "Status": "Active",
+                  "IntegrationObjectID": "@parent:ID"
+                }
+              },
+              {
+                "fields": {
+                  "Name": "profile.last_name",
+                  "Type": "string",
+                  "Source": "Declared",
+                  "Description": "Attendee last name.",
+                  "Status": "Active",
+                  "IntegrationObjectID": "@parent:ID"
+                }
+              },
+              {
+                "fields": {
+                  "Name": "profile.prefix",
+                  "Type": "string",
+                  "Source": "Declared",
+                  "Description": "Attendee title/honorific (Mr., Ms.).",
+                  "Status": "Active",
+                  "IntegrationObjectID": "@parent:ID"
+                }
+              },
+              {
+                "fields": {
+                  "Name": "profile.suffix",
+                  "Type": "string",
+                  "Source": "Declared",
+                  "Description": "Attendee suffix (Jr., Sr.).",
+                  "Status": "Active",
+                  "IntegrationObjectID": "@parent:ID"
+                }
+              },
+              {
+                "fields": {
+                  "Name": "profile.age",
+                  "Type": "integer",
+                  "Source": "Declared",
+                  "Description": "Attendee age.",
+                  "Status": "Active",
+                  "IntegrationObjectID": "@parent:ID"
+                }
+              },
+              {
+                "fields": {
+                  "Name": "profile.job_title",
+                  "Type": "string",
+                  "Source": "Declared",
+                  "Description": "Attendee job title.",
+                  "Status": "Active",
+                  "IntegrationObjectID": "@parent:ID"
+                }
+              },
+              {
+                "fields": {
+                  "Name": "profile.company",
+                  "Type": "string",
+                  "Source": "Declared",
+                  "Description": "Attendee company name.",
+                  "Status": "Active",
+                  "IntegrationObjectID": "@parent:ID"
+                }
+              },
+              {
+                "fields": {
+                  "Name": "profile.website",
+                  "Type": "string",
+                  "Source": "Declared",
+                  "Description": "Attendee website address.",
+                  "Status": "Active",
+                  "IntegrationObjectID": "@parent:ID"
+                }
+              },
+              {
+                "fields": {
+                  "Name": "profile.blog",
+                  "Type": "string",
+                  "Source": "Declared",
+                  "Description": "Attendee blog address.",
+                  "Status": "Active",
+                  "IntegrationObjectID": "@parent:ID"
+                }
+              },
+              {
+                "fields": {
+                  "Name": "profile.gender",
+                  "Type": "string",
+                  "Source": "Declared",
+                  "Description": "Attendee gender: male or female.",
+                  "Status": "Active",
+                  "IntegrationObjectID": "@parent:ID"
+                }
+              },
+              {
+                "fields": {
+                  "Name": "profile.birth_date",
+                  "Type": "date",
+                  "Source": "Declared",
+                  "Description": "Attendee birth date.",
+                  "Status": "Active",
+                  "IntegrationObjectID": "@parent:ID"
+                }
+              },
+              {
+                "fields": {
+                  "Name": "profile.cell_phone",
+                  "Type": "string",
+                  "Source": "Declared",
+                  "Description": "Attendee cell/mobile phone number.",
+                  "Status": "Active",
+                  "IntegrationObjectID": "@parent:ID"
+                }
+              },
+              {
+                "fields": {
+                  "Name": "profile.work_phone",
+                  "Type": "string",
+                  "Source": "Declared",
+                  "Description": "Attendee work phone number.",
+                  "Status": "Active",
+                  "IntegrationObjectID": "@parent:ID"
+                }
+              },
+              {
+                "fields": {
+                  "Name": "costs.base_price.value",
+                  "Type": "integer",
+                  "Source": "Declared",
+                  "Description": "Attendee ticket price excluding fees/tax (minor units).",
+                  "Status": "Active",
+                  "IntegrationObjectID": "@parent:ID"
+                }
+              },
+              {
+                "fields": {
+                  "Name": "costs.gross.value",
+                  "Type": "integer",
+                  "Source": "Declared",
+                  "Description": "Attendee total cost (minor units).",
+                  "Status": "Active",
+                  "IntegrationObjectID": "@parent:ID"
+                }
+              },
+              {
+                "fields": {
+                  "Name": "costs.eventbrite_fee.value",
+                  "Type": "integer",
+                  "Source": "Declared",
+                  "Description": "Attendee Eventbrite fee (minor units).",
+                  "Status": "Active",
+                  "IntegrationObjectID": "@parent:ID"
+                }
+              },
+              {
+                "fields": {
+                  "Name": "costs.payment_fee.value",
+                  "Type": "integer",
+                  "Source": "Declared",
+                  "Description": "Attendee payment processing fee (minor units).",
+                  "Status": "Active",
+                  "IntegrationObjectID": "@parent:ID"
+                }
+              },
+              {
+                "fields": {
+                  "Name": "costs.tax.value",
+                  "Type": "integer",
+                  "Source": "Declared",
+                  "Description": "Tax charged for the attendee ticket (minor units).",
+                  "Status": "Active",
+                  "IntegrationObjectID": "@parent:ID"
+                }
+              },
+              {
+                "fields": {
+                  "Name": "barcodes",
+                  "Type": "json",
+                  "Source": "Declared",
+                  "Description": "List of entry barcodes (barcode, status, created, changed, checkin_type, is_printed).",
+                  "Status": "Active",
+                  "IntegrationObjectID": "@parent:ID"
+                }
+              },
+              {
+                "fields": {
+                  "Name": "answers",
+                  "Type": "json",
+                  "Source": "Declared",
+                  "Description": "Attendee answers to custom questions (requires expansion).",
+                  "Status": "Active",
+                  "IntegrationObjectID": "@parent:ID"
+                }
+              },
+              {
+                "fields": {
+                  "Name": "resource_uri",
+                  "Type": "string",
+                  "Source": "Declared",
+                  "IsReadOnly": true,
+                  "Description": "Absolute URL to the canonical attendee representation.",
+                  "Status": "Active",
+                  "IntegrationObjectID": "@parent:ID"
+                }
+              }
+            ]
+          }
+        },
+        {
+          "fields": {
+            "Name": "Discount",
+            "DisplayName": "Discount",
+            "IntegrationID": "@parent:ID",
+            "APIPath": "/organizations/{organization_id}/discounts/",
+            "PaginationType": "Cursor",
+            "SupportsPagination": true,
+            "SupportsIncrementalSync": false,
+            "SupportsWrite": true,
+            "ResponseDataKey": "discounts",
+            "Status": "Active",
+            "Description": "A discount an order owner can use when buying tickets. Types: public, coded, access, hold. Single-event or cross-event.",
+            "SupportsCreate": true,
+            "CreateAPIPath": "/organizations/{organization_id}/discounts/",
+            "CreateMethod": "POST",
+            "CreateBodyShape": "wrapped",
+            "CreateIDLocation": "body",
+            "CreateBodyKey": "discount",
+            "SupportsUpdate": true,
+            "UpdateAPIPath": "/discounts/{discount_id}/",
+            "UpdateMethod": "POST",
+            "UpdateBodyShape": "wrapped",
+            "UpdateIDLocation": "path",
+            "UpdateBodyKey": "discount",
+            "SupportsDelete": true,
+            "DeleteAPIPath": "/discounts/{discount_id}/",
+            "DeleteMethod": "DELETE",
+            "DeleteIDLocation": "path",
+            "Configuration": {
+              "ListMethod": "GET",
+              "GetOnePath": "/discounts/{discount_id}/",
+              "ListResponseKey": "discounts",
+              "AccessPath": {
+                "door": "/organizations/{organization_id}/discounts/",
+                "nesting": "Organization -> discounts[]",
+                "args": [
+                  "scope"
+                ]
+              },
+              "parentObjectName": "Organization",
+              "parentObjectIDFieldName": "organization_id"
+            }
+          },
+          "relatedEntities": {
+            "MJ: Integration Object Fields": [
+              {
+                "fields": {
+                  "Name": "id",
+                  "Type": "string",
+                  "Source": "Declared",
+                  "IsPrimaryKey": true,
+                  "IsUniqueKey": true,
+                  "IsReadOnly": true,
+                  "AllowsNull": false,
+                  "Description": "Discount ID.",
+                  "Status": "Active",
+                  "IntegrationObjectID": "@parent:ID"
+                }
+              },
+              {
+                "fields": {
+                  "Name": "code",
+                  "Type": "string",
+                  "Source": "Declared",
+                  "Description": "Discount name (public) or secret code (coded/access).",
+                  "Status": "Active",
+                  "IntegrationObjectID": "@parent:ID"
+                }
+              },
+              {
+                "fields": {
+                  "Name": "type",
+                  "Type": "string",
+                  "Source": "Declared",
+                  "Description": "Discount type: access, coded, public, hold.",
+                  "Status": "Active",
+                  "IntegrationObjectID": "@parent:ID"
+                }
+              },
+              {
+                "fields": {
+                  "Name": "amount_off",
+                  "Type": "decimal",
+                  "Source": "Declared",
+                  "Description": "Fixed amount off (in event currency, 0.01-99999.99). Null for access codes.",
+                  "Status": "Active",
+                  "IntegrationObjectID": "@parent:ID"
+                }
+              },
+              {
+                "fields": {
+                  "Name": "percent_off",
+                  "Type": "decimal",
+                  "Source": "Declared",
+                  "Description": "Percentage off (1.00-100.00). Null for access codes.",
+                  "Status": "Active",
+                  "IntegrationObjectID": "@parent:ID"
+                }
+              },
+              {
+                "fields": {
+                  "Name": "quantity_available",
+                  "Type": "integer",
+                  "Source": "Declared",
+                  "Description": "Times the discount can be used; 0 = unlimited.",
+                  "Status": "Active",
+                  "IntegrationObjectID": "@parent:ID"
+                }
+              },
+              {
+                "fields": {
+                  "Name": "quantity_sold",
+                  "Type": "integer",
+                  "Source": "Declared",
+                  "IsReadOnly": true,
+                  "Description": "Times the discount has been used.",
+                  "Status": "Active",
+                  "IntegrationObjectID": "@parent:ID"
+                }
+              },
+              {
+                "fields": {
+                  "Name": "start_date",
+                  "Type": "datetime",
+                  "Source": "Declared",
+                  "Description": "Local datetime the discount becomes usable.",
+                  "Status": "Active",
+                  "IntegrationObjectID": "@parent:ID"
+                }
+              },
+              {
+                "fields": {
+                  "Name": "start_date_relative",
+                  "Type": "integer",
+                  "Source": "Declared",
+                  "Description": "Seconds before event start the discount becomes usable.",
+                  "Status": "Active",
+                  "IntegrationObjectID": "@parent:ID"
+                }
+              },
+              {
+                "fields": {
+                  "Name": "end_date",
+                  "Type": "datetime",
+                  "Source": "Declared",
+                  "Description": "Local datetime until which the discount is usable.",
+                  "Status": "Active",
+                  "IntegrationObjectID": "@parent:ID"
+                }
+              },
+              {
+                "fields": {
+                  "Name": "end_date_relative",
+                  "Type": "integer",
+                  "Source": "Declared",
+                  "Description": "Seconds before event start until which the discount is usable.",
+                  "Status": "Active",
+                  "IntegrationObjectID": "@parent:ID"
+                }
+              },
+              {
+                "fields": {
+                  "Name": "ticket_class_ids",
+                  "Type": "json",
+                  "Source": "Declared",
+                  "Description": "List of discounted ticket class IDs for a single event.",
+                  "Status": "Active",
+                  "IntegrationObjectID": "@parent:ID"
+                }
+              },
+              {
+                "fields": {
+                  "Name": "event_id",
+                  "Type": "string",
+                  "Source": "Declared",
+                  "RelatedIntegrationObjectID": "@lookup:MJ: Integration Objects.Name=Event&IntegrationID=@parent:IntegrationID",
+                  "Description": "Single event the discount applies to.",
+                  "Status": "Active",
+                  "IntegrationObjectID": "@parent:ID"
+                }
+              },
+              {
+                "fields": {
+                  "Name": "ticket_group_id",
+                  "Type": "string",
+                  "Source": "Declared",
+                  "RelatedIntegrationObjectID": "@lookup:MJ: Integration Objects.Name=TicketGroup&IntegrationID=@parent:IntegrationID",
+                  "Description": "Ticket group the discount applies to.",
+                  "Status": "Active",
+                  "IntegrationObjectID": "@parent:ID"
+                }
+              },
+              {
+                "fields": {
+                  "Name": "hold_ids",
+                  "Type": "json",
+                  "Source": "Declared",
+                  "Description": "Seat hold IDs the discount can unlock.",
+                  "Status": "Active",
+                  "IntegrationObjectID": "@parent:ID"
+                }
+              }
+            ]
+          }
+        },
+        {
+          "fields": {
+            "Name": "Question",
+            "DisplayName": "Question",
+            "IntegrationID": "@parent:ID",
+            "APIPath": "/events/{event_id}/questions/",
+            "PaginationType": "Cursor",
+            "SupportsPagination": true,
+            "SupportsIncrementalSync": false,
+            "SupportsWrite": true,
+            "ResponseDataKey": "questions",
+            "Status": "Active",
+            "Description": "A custom question presented to an order owner during registration (e.g. terms acknowledgement).",
+            "SupportsCreate": true,
+            "CreateAPIPath": "/events/{event_id}/questions/",
+            "CreateMethod": "POST",
+            "CreateBodyShape": "wrapped",
+            "CreateIDLocation": "body",
+            "CreateBodyKey": "question",
+            "SupportsUpdate": false,
+            "SupportsDelete": false,
+            "Configuration": {
+              "ListMethod": "GET",
+              "GetOnePath": "/events/{event_id}/questions/{question_id}/",
+              "ListResponseKey": "questions",
+              "AccessPath": {
+                "door": "/events/{event_id}/questions/",
+                "nesting": "Event -> questions[]",
+                "args": []
+              },
+              "parentObjectName": "Event",
+              "parentObjectIDFieldName": "event_id"
+            }
+          },
+          "relatedEntities": {
+            "MJ: Integration Object Fields": [
+              {
+                "fields": {
+                  "Name": "id",
+                  "Type": "string",
+                  "Source": "Declared",
+                  "IsPrimaryKey": true,
+                  "IsUniqueKey": true,
+                  "IsReadOnly": true,
+                  "AllowsNull": false,
+                  "Description": "Custom question ID.",
+                  "Status": "Active",
+                  "IntegrationObjectID": "@parent:ID"
+                }
+              },
+              {
+                "fields": {
+                  "Name": "label",
+                  "Type": "string",
+                  "Source": "Declared",
+                  "Description": "Custom question label.",
+                  "Status": "Active",
+                  "IntegrationObjectID": "@parent:ID"
+                }
+              },
+              {
+                "fields": {
+                  "Name": "type",
+                  "Type": "string",
+                  "Source": "Declared",
+                  "Description": "Answer type: text, url, email, date, number, address, dropdown.",
+                  "Status": "Active",
+                  "IntegrationObjectID": "@parent:ID"
+                }
+              },
+              {
+                "fields": {
+                  "Name": "required",
+                  "Type": "boolean",
+                  "Source": "Declared",
+                  "Description": "True if an answer is required.",
+                  "Status": "Active",
+                  "IntegrationObjectID": "@parent:ID"
+                }
+              }
+            ]
+          }
+        },
+        {
+          "fields": {
+            "Name": "Answer",
+            "DisplayName": "Answer",
+            "IntegrationID": "@parent:ID",
+            "APIPath": "/",
+            "PaginationType": "None",
+            "SupportsPagination": false,
+            "SupportsIncrementalSync": false,
+            "SupportsWrite": false,
+            "ResponseDataKey": "answers",
+            "Status": "Active",
+            "Description": "An attendee's answer to a custom Question. Returned nested on Attendee/Order via expansion; not a standalone top-level endpoint.",
+            "SupportsCreate": false,
+            "SupportsUpdate": false,
+            "SupportsDelete": false,
+            "Configuration": {
+              "ListMethod": "GET",
+              "GetOnePath": null,
+              "ListResponseKey": "answers",
+              "AccessPath": {
+                "door": "/events/{event_id}/attendees/",
+                "nesting": "Attendee -> answers[] (expand=answers)",
+                "args": [
+                  "expand=answers"
+                ]
+              }
+            }
+          },
+          "relatedEntities": {
+            "MJ: Integration Object Fields": [
+              {
+                "fields": {
+                  "Name": "question_id",
+                  "Type": "string",
+                  "Source": "Declared",
+                  "RelatedIntegrationObjectID": "@lookup:MJ: Integration Objects.Name=Question&IntegrationID=@parent:IntegrationID",
+                  "Description": "Custom question ID.",
+                  "Status": "Active",
+                  "IntegrationObjectID": "@parent:ID"
+                }
+              },
+              {
+                "fields": {
+                  "Name": "attendee_id",
+                  "Type": "string",
+                  "Source": "Declared",
+                  "RelatedIntegrationObjectID": "@lookup:MJ: Integration Objects.Name=Attendee&IntegrationID=@parent:IntegrationID",
+                  "Description": "Attendee ID who answered.",
+                  "Status": "Active",
+                  "IntegrationObjectID": "@parent:ID"
+                }
+              },
+              {
+                "fields": {
+                  "Name": "question",
+                  "Type": "string",
+                  "Source": "Declared",
+                  "Description": "Custom question text.",
+                  "Status": "Active",
+                  "IntegrationObjectID": "@parent:ID"
+                }
+              },
+              {
+                "fields": {
+                  "Name": "type",
+                  "Type": "string",
+                  "Source": "Declared",
+                  "Description": "Answer type: text, url, email, date, number, address, dropdown.",
+                  "Status": "Active",
+                  "IntegrationObjectID": "@parent:ID"
+                }
+              },
+              {
+                "fields": {
+                  "Name": "answer",
+                  "Type": "string",
+                  "Source": "Declared",
+                  "Description": "The answer value (generally a string).",
+                  "Status": "Active",
+                  "IntegrationObjectID": "@parent:ID"
+                }
+              }
+            ]
+          }
+        },
+        {
+          "fields": {
+            "Name": "Category",
+            "DisplayName": "Category",
+            "IntegrationID": "@parent:ID",
+            "APIPath": "/categories/",
+            "PaginationType": "Cursor",
+            "SupportsPagination": true,
+            "SupportsIncrementalSync": false,
+            "SupportsWrite": false,
+            "ResponseDataKey": "categories",
+            "Status": "Active",
+            "Description": "An Event class (e.g. Music) used to classify Events. Static reference data.",
+            "SupportsCreate": false,
+            "SupportsUpdate": false,
+            "SupportsDelete": false,
+            "Configuration": {
+              "ListMethod": "GET",
+              "GetOnePath": "/categories/{category_id}/",
+              "ListResponseKey": "categories",
+              "AccessPath": {
+                "door": "/categories/",
+                "nesting": "top-level list",
+                "args": []
+              }
+            }
+          },
+          "relatedEntities": {
+            "MJ: Integration Object Fields": [
+              {
+                "fields": {
+                  "Name": "id",
+                  "Type": "string",
+                  "Source": "Declared",
+                  "IsPrimaryKey": true,
+                  "IsUniqueKey": true,
+                  "IsReadOnly": true,
+                  "AllowsNull": false,
+                  "Description": "Category ID.",
+                  "Status": "Active",
+                  "IntegrationObjectID": "@parent:ID"
+                }
+              },
+              {
+                "fields": {
+                  "Name": "name",
+                  "Type": "string",
+                  "Source": "Declared",
+                  "Description": "Category name.",
+                  "Status": "Active",
+                  "IntegrationObjectID": "@parent:ID"
+                }
+              },
+              {
+                "fields": {
+                  "Name": "name_localized",
+                  "Type": "string",
+                  "Source": "Declared",
+                  "Description": "Translated category name.",
+                  "Status": "Active",
+                  "IntegrationObjectID": "@parent:ID"
+                }
+              },
+              {
+                "fields": {
+                  "Name": "short_name",
+                  "Type": "string",
+                  "Source": "Declared",
+                  "Description": "Shorter category name for small UI spaces.",
+                  "Status": "Active",
+                  "IntegrationObjectID": "@parent:ID"
+                }
+              },
+              {
+                "fields": {
+                  "Name": "short_name_localized",
+                  "Type": "string",
+                  "Source": "Declared",
+                  "Description": "Translated short category name.",
+                  "Status": "Active",
+                  "IntegrationObjectID": "@parent:ID"
+                }
+              },
+              {
+                "fields": {
+                  "Name": "resource_uri",
+                  "Type": "string",
+                  "Source": "Declared",
+                  "IsReadOnly": true,
+                  "Description": "Absolute URL to the canonical category representation.",
+                  "Status": "Active",
+                  "IntegrationObjectID": "@parent:ID"
+                }
+              }
+            ]
+          }
+        },
+        {
+          "fields": {
+            "Name": "Subcategory",
+            "DisplayName": "Subcategory",
+            "IntegrationID": "@parent:ID",
+            "APIPath": "/subcategories/",
+            "PaginationType": "Cursor",
+            "SupportsPagination": true,
+            "SupportsIncrementalSync": false,
+            "SupportsWrite": false,
+            "ResponseDataKey": "subcategories",
+            "Status": "Active",
+            "Description": "A Category subclass (e.g. Classical under Music) used to further classify Events. Static reference data.",
+            "SupportsCreate": false,
+            "SupportsUpdate": false,
+            "SupportsDelete": false,
+            "Configuration": {
+              "ListMethod": "GET",
+              "GetOnePath": "/subcategories/{subcategory_id}/",
+              "ListResponseKey": "subcategories",
+              "AccessPath": {
+                "door": "/subcategories/",
+                "nesting": "top-level list",
+                "args": []
+              }
+            }
+          },
+          "relatedEntities": {
+            "MJ: Integration Object Fields": [
+              {
+                "fields": {
+                  "Name": "id",
+                  "Type": "string",
+                  "Source": "Declared",
+                  "IsPrimaryKey": true,
+                  "IsUniqueKey": true,
+                  "IsReadOnly": true,
+                  "AllowsNull": false,
+                  "Description": "Subcategory ID.",
+                  "Status": "Active",
+                  "IntegrationObjectID": "@parent:ID"
+                }
+              },
+              {
+                "fields": {
+                  "Name": "name",
+                  "Type": "string",
+                  "Source": "Declared",
+                  "Description": "Subcategory name.",
+                  "Status": "Active",
+                  "IntegrationObjectID": "@parent:ID"
+                }
+              },
+              {
+                "fields": {
+                  "Name": "parent_category.id",
+                  "Type": "string",
+                  "Source": "Declared",
+                  "RelatedIntegrationObjectID": "@lookup:MJ: Integration Objects.Name=Category&IntegrationID=@parent:IntegrationID",
+                  "Description": "ID of the parent Category this subcategory belongs to.",
+                  "Status": "Active",
+                  "IntegrationObjectID": "@parent:ID"
+                }
+              },
+              {
+                "fields": {
+                  "Name": "resource_uri",
+                  "Type": "string",
+                  "Source": "Declared",
+                  "IsReadOnly": true,
+                  "Description": "Absolute URL to the canonical subcategory representation.",
+                  "Status": "Active",
+                  "IntegrationObjectID": "@parent:ID"
+                }
+              }
+            ]
+          }
+        },
+        {
+          "fields": {
+            "Name": "Format",
+            "DisplayName": "Format",
+            "IntegrationID": "@parent:ID",
+            "APIPath": "/formats/",
+            "PaginationType": "Cursor",
+            "SupportsPagination": true,
+            "SupportsIncrementalSync": false,
+            "SupportsWrite": false,
+            "ResponseDataKey": "formats",
+            "Status": "Active",
+            "Description": "An Event format (e.g. Seminar or Talk) describing the style of an Event. Static reference data.",
+            "SupportsCreate": false,
+            "SupportsUpdate": false,
+            "SupportsDelete": false,
+            "Configuration": {
+              "ListMethod": "GET",
+              "GetOnePath": "/formats/{format_id}/",
+              "ListResponseKey": "formats",
+              "AccessPath": {
+                "door": "/formats/",
+                "nesting": "top-level list",
+                "args": []
+              }
+            }
+          },
+          "relatedEntities": {
+            "MJ: Integration Object Fields": [
+              {
+                "fields": {
+                  "Name": "id",
+                  "Type": "string",
+                  "Source": "Declared",
+                  "IsPrimaryKey": true,
+                  "IsUniqueKey": true,
+                  "IsReadOnly": true,
+                  "AllowsNull": false,
+                  "Description": "Format ID.",
+                  "Status": "Active",
+                  "IntegrationObjectID": "@parent:ID"
+                }
+              },
+              {
+                "fields": {
+                  "Name": "name",
+                  "Type": "string",
+                  "Source": "Declared",
+                  "Description": "Format name.",
+                  "Status": "Active",
+                  "IntegrationObjectID": "@parent:ID"
+                }
+              },
+              {
+                "fields": {
+                  "Name": "name_localized",
+                  "Type": "string",
+                  "Source": "Declared",
+                  "Description": "Localized format name.",
+                  "Status": "Active",
+                  "IntegrationObjectID": "@parent:ID"
+                }
+              },
+              {
+                "fields": {
+                  "Name": "short_name",
+                  "Type": "string",
+                  "Source": "Declared",
+                  "Description": "Short name for the format.",
+                  "Status": "Active",
+                  "IntegrationObjectID": "@parent:ID"
+                }
+              },
+              {
+                "fields": {
+                  "Name": "short_name_localized",
+                  "Type": "string",
+                  "Source": "Declared",
+                  "Description": "Localized short format name.",
+                  "Status": "Active",
+                  "IntegrationObjectID": "@parent:ID"
+                }
+              },
+              {
+                "fields": {
+                  "Name": "resource_uri",
+                  "Type": "string",
+                  "Source": "Declared",
+                  "IsReadOnly": true,
+                  "Description": "Absolute URL to the canonical format representation.",
+                  "Status": "Active",
+                  "IntegrationObjectID": "@parent:ID"
+                }
+              }
+            ]
+          }
+        },
+        {
+          "fields": {
+            "Name": "Media",
+            "DisplayName": "Media",
+            "IntegrationID": "@parent:ID",
+            "APIPath": "/media/{media_id}/",
+            "PaginationType": "None",
+            "SupportsPagination": false,
+            "SupportsIncrementalSync": false,
+            "SupportsWrite": true,
+            "ResponseDataKey": null,
+            "Status": "Active",
+            "Description": "An image that can be attached to an Event listing (logo, branding). Retrieved by media id; uploaded via a token flow.",
+            "SupportsCreate": true,
+            "CreateAPIPath": "/media/upload/",
+            "CreateMethod": "POST",
+            "CreateBodyShape": "flat",
+            "CreateIDLocation": "body",
+            "SupportsUpdate": false,
+            "SupportsDelete": false,
+            "Configuration": {
+              "ListMethod": "GET",
+              "GetOnePath": "/media/{media_id}/",
+              "ListResponseKey": null,
+              "AccessPath": {
+                "door": "/media/{media_id}/",
+                "nesting": "get-one",
+                "args": [
+                  "width",
+                  "height"
+                ]
+              }
+            }
+          },
+          "relatedEntities": {
+            "MJ: Integration Object Fields": [
+              {
+                "fields": {
+                  "Name": "id",
+                  "Type": "string",
+                  "Source": "Declared",
+                  "IsPrimaryKey": true,
+                  "IsUniqueKey": true,
+                  "IsReadOnly": true,
+                  "IsRequired": true,
+                  "AllowsNull": false,
+                  "Description": "Image/media ID.",
+                  "Status": "Active",
+                  "IntegrationObjectID": "@parent:ID"
+                }
+              },
+              {
+                "fields": {
+                  "Name": "url",
+                  "Type": "string",
+                  "Source": "Declared",
+                  "IsReadOnly": true,
+                  "IsRequired": true,
+                  "Description": "URL of the image.",
+                  "Status": "Active",
+                  "IntegrationObjectID": "@parent:ID"
+                }
+              }
+            ]
+          }
+        },
+        {
+          "fields": {
+            "Name": "Webhook",
+            "DisplayName": "Webhook",
+            "IntegrationID": "@parent:ID",
+            "APIPath": "/webhooks/",
+            "PaginationType": "Cursor",
+            "SupportsPagination": true,
+            "SupportsIncrementalSync": false,
+            "SupportsWrite": true,
+            "ResponseDataKey": "webhooks",
+            "Status": "Active",
+            "Description": "A subscription delivering JSON payloads to an endpoint when chosen Eventbrite actions occur (order/event/attendee/etc.).",
+            "SupportsCreate": true,
+            "CreateAPIPath": "/organizations/{organization_id}/webhooks/",
+            "CreateMethod": "POST",
+            "CreateBodyShape": "flat",
+            "CreateIDLocation": "body",
+            "SupportsUpdate": false,
+            "SupportsDelete": true,
+            "DeleteAPIPath": "/webhooks/{webhook_id}/",
+            "DeleteMethod": "DELETE",
+            "DeleteIDLocation": "path",
+            "Configuration": {
+              "ListMethod": "GET",
+              "GetOnePath": "/webhooks/{webhook_id}/",
+              "ListResponseKey": "webhooks",
+              "AccessPath": {
+                "door": "/organizations/{organization_id}/webhooks/",
+                "nesting": "Organization -> webhooks[]; legacy global list at /webhooks/",
+                "args": []
+              }
+            }
+          },
+          "relatedEntities": {
+            "MJ: Integration Object Fields": [
+              {
+                "fields": {
+                  "Name": "id",
+                  "Type": "string",
+                  "Source": "Declared",
+                  "IsPrimaryKey": true,
+                  "IsUniqueKey": true,
+                  "IsReadOnly": true,
+                  "AllowsNull": false,
+                  "Description": "Webhook ID.",
+                  "Status": "Active",
+                  "IntegrationObjectID": "@parent:ID"
+                }
+              },
+              {
+                "fields": {
+                  "Name": "endpoint_url",
+                  "Type": "string",
+                  "Source": "Declared",
+                  "IsRequired": true,
+                  "Description": "Developer-provided URL to which webhook payloads are POSTed.",
+                  "Status": "Active",
+                  "IntegrationObjectID": "@parent:ID"
+                }
+              },
+              {
+                "fields": {
+                  "Name": "actions",
+                  "Type": "json",
+                  "Source": "Declared",
+                  "Description": "List of action triggers (e.g. order.placed, event.published, attendee.updated).",
+                  "Status": "Active",
+                  "IntegrationObjectID": "@parent:ID"
+                }
+              },
+              {
+                "fields": {
+                  "Name": "event_id",
+                  "Type": "string",
+                  "Source": "Declared",
+                  "RelatedIntegrationObjectID": "@lookup:MJ: Integration Objects.Name=Event&IntegrationID=@parent:IntegrationID",
+                  "Description": "Optional Event ID scoping the webhook to a single event.",
+                  "Status": "Active",
+                  "IntegrationObjectID": "@parent:ID"
+                }
+              }
+            ]
+          }
+        }
+      ]
+    }
+  }
+]

--- a/packages/Integration/connectors/src/EventbriteConnector.ts
+++ b/packages/Integration/connectors/src/EventbriteConnector.ts
@@ -1,0 +1,549 @@
+import { RegisterClass } from '@memberjunction/global';
+import { Metadata, type IMetadataProvider, type UserInfo } from '@memberjunction/core';
+import type { MJCompanyIntegrationEntity, MJCredentialEntity, MJIntegrationObjectEntity } from '@memberjunction/core-entities';
+import {
+    BaseIntegrationConnector,
+    BaseRESTIntegrationConnector,
+    type RESTAuthContext,
+    type RESTResponse,
+    type PaginationState,
+    type PaginationType,
+    type ConnectionTestResult,
+    type FetchContext,
+    type FetchBatchResult,
+    type RateLimitPolicy,
+} from '@memberjunction/integration-engine';
+
+// ─── Constants ────────────────────────────────────────────────────────
+
+const DEFAULT_BASE_URL = 'https://www.eventbriteapi.com/v3';
+const DEFAULT_REQUEST_TIMEOUT_MS = 30000;
+const DEFAULT_MAX_RETRIES = 4;
+/**
+ * Eventbrite documents a global limit of 1,000 calls/hour per token (~0.27/s). Run under that
+ * ceiling; the engine's AIMD bucket throttles + backs off on the 429 `HIT_RATE_LIMIT` response.
+ */
+const RATE_LIMIT_TOKENS_PER_SEC = 0.27;
+const RATE_LIMIT_BURST = 10;
+/** Minimum spacing between outbound requests (ms) — conservative under the per-hour cap. */
+const DEFAULT_MIN_REQUEST_INTERVAL_MS = 200;
+
+// ─── Connection configuration ─────────────────────────────────────────
+
+/**
+ * Per-connection configuration for the Eventbrite connector.
+ *
+ * Eventbrite has a single shared API host (`https://www.eventbriteapi.com/v3`). Auth is a
+ * Bearer token — either a per-app PRIVATE TOKEN (single-user integration) or an OAuth2
+ * authorization-code access token (multi-user app). Both are sent verbatim as
+ * `Authorization: Bearer <token>`. The tenant's `OrganizationID` (and optionally `UserID`)
+ * scope the organization-nested list endpoints and are resolved from
+ * `CompanyIntegration.Configuration` at runtime — NEVER hardcoded.
+ */
+export interface EventbriteConnectionConfig {
+    /** Bearer token: a private token or an OAuth2 access token. From the credential store. */
+    Token?: string;
+    /**
+     * Eventbrite organization id (digits, e.g. `123456789012`). Scopes the
+     * `/organizations/{organization_id}/...` list endpoints. Tenant-specific — resolved from
+     * Configuration at runtime; if absent, the connector resolves it from `/users/me/organizations/`.
+     */
+    OrganizationID?: string;
+    /** Eventbrite user id; used to substitute `{user_id}` where a path requires it. */
+    UserID?: string;
+    /**
+     * Non-secret API host override (e.g. a local mock for replay/contract testing). When set it
+     * wins over the production host. Mirrors the ApiBaseUrl override other connectors expose for
+     * the credential-free mock-floor tier.
+     */
+    ApiBaseUrl?: string;
+    /** HTTP request timeout in milliseconds. Default: 30000. */
+    RequestTimeoutMs?: number;
+    /** Maximum retries for rate-limited / transient failures. Default: 4. */
+    MaxRetries?: number;
+    /** Minimum interval between outbound requests (ms). Default: 200. */
+    MinRequestIntervalMs?: number;
+}
+
+/** Authenticated context carried through one request cycle. */
+interface EventbriteAuthContext extends RESTAuthContext {
+    Token: string;
+    BaseUrl: string;
+    Config: EventbriteConnectionConfig;
+}
+
+/** Eventbrite list-response envelope: a `pagination` object plus the resource array under a named key. */
+interface EventbritePagination {
+    object_count?: number;
+    page_number?: number;
+    page_size?: number;
+    page_count?: number;
+    continuation?: string;
+    has_more_items?: boolean;
+}
+
+/**
+ * Eventbrite Platform REST API v3 connector.
+ *
+ * Read-first with documented write surfaces: events, ticket classes, ticket groups, venues,
+ * discounts and webhooks expose create/update/delete (POST/DELETE, wrapped bodies); orders and
+ * attendees are read-only with `changed_since` incremental sync. Pagination is the `continuation`
+ * cursor. Auth is a Bearer private token or OAuth2 access token. CRUD is delegated to the generic
+ * per-operation column path on {@link BaseRESTIntegrationConnector} (v5.39.x) — the metadata's
+ * per-IO `Create*`/`Update*`/`Delete*` columns drive every write.
+ *
+ * Registered against the GRANDPARENT base ({@link BaseIntegrationConnector}) so the connector
+ * factory dispatches off the right type.
+ */
+@RegisterClass(BaseIntegrationConnector, 'EventbriteConnector')
+export class EventbriteConnector extends BaseRESTIntegrationConnector {
+    private authState: EventbriteAuthContext | null = null;
+    /** Timestamp of the last outbound request, used for throttling. */
+    private lastRequestTime = 0;
+    /** Watermark for the current FetchChanges cycle, emitted as the IO's IncrementalWatermarkField. */
+    protected currentWatermark: string | undefined;
+
+    // ── Identity + capability getters ───────────────────────────────────
+
+    /** Verbatim from the metadata Integration row — part of the three-way name invariant. */
+    public override get IntegrationName(): string { return 'Eventbrite'; }
+
+    // Eventbrite exposes documented write endpoints on a SUBSET of objects. The generic
+    // per-operation path enforces null-capability honesty per IO (an IO with no CreateAPIPath
+    // throws on create), so these getters reflect that SOME IOs are writable; the actual writable
+    // set is the metadata's per-op columns (Event / EventSeries / Venue / TicketClass / TicketGroup
+    // / Discount / Webhook / Question for create; Order & Attendee stay read-only).
+    public override get SupportsCreate(): boolean { return true; }
+    public override get SupportsUpdate(): boolean { return true; }
+    public override get SupportsDelete(): boolean { return true; }
+
+    // ── Sync-efficiency hooks ───────────────────────────────────────────
+
+    /**
+     * Eventbrite documents 1,000 calls/hour per token. Run under that rate; the engine's AIMD
+     * bucket throttles + backs off on the 429 `HIT_RATE_LIMIT` response.
+     */
+    public override get RateLimitPolicy(): RateLimitPolicy | null {
+        return { TokensPerSec: RATE_LIMIT_TOKENS_PER_SEC, Burst: RATE_LIMIT_BURST, ThrottleBackoffFactor: 0.5 };
+    }
+
+    /** Parse a `Retry-After` header (delta-seconds or HTTP-date) into milliseconds. */
+    public override ExtractRetryAfterMs(error: unknown): number | undefined {
+        const headers = (error as { Headers?: Record<string, string> })?.Headers;
+        if (!headers) return undefined;
+        const retryAfter = headers['retry-after'] ?? headers['Retry-After'];
+        if (typeof retryAfter !== 'string' || retryAfter.length === 0) return undefined;
+        const asSeconds = Number(retryAfter);
+        if (!isNaN(asSeconds) && asSeconds >= 0) return Math.round(asSeconds * 1000);
+        const asDate = Date.parse(retryAfter);
+        if (!isNaN(asDate)) {
+            const delta = asDate - Date.now();
+            if (delta > 0) return delta;
+        }
+        return undefined;
+    }
+
+    // ─── TestConnection ──────────────────────────────────────────────
+
+    /**
+     * Verifies connectivity by fetching the current user (`/users/me/`). A 2xx confirms the
+     * Bearer token is valid; a 401/403 means it was rejected.
+     */
+    public async TestConnection(
+        companyIntegration: MJCompanyIntegrationEntity,
+        contextUser: UserInfo
+    ): Promise<ConnectionTestResult> {
+        try {
+            const auth = await this.Authenticate(companyIntegration, contextUser) as EventbriteAuthContext;
+            const headers = this.BuildHeaders(auth);
+            const probeUrl = `${auth.BaseUrl}/users/me/`;
+            const resp = await this.MakeHTTPRequest(auth, probeUrl, 'GET', headers);
+            if (resp.Status === 401 || resp.Status === 403) {
+                return { Success: false, Message: `Eventbrite TestConnection failed: HTTP ${resp.Status} (token rejected)` };
+            }
+            if (resp.Status >= 500) {
+                return { Success: false, Message: `Eventbrite TestConnection failed: HTTP ${resp.Status} (server error)` };
+            }
+            if (resp.Status < 200 || resp.Status >= 300) {
+                return { Success: false, Message: `Eventbrite returned HTTP ${resp.Status} from ${probeUrl}` };
+            }
+            return {
+                Success: true,
+                Message: `Connected to Eventbrite at ${auth.BaseUrl}`,
+                ServerVersion: 'Eventbrite Platform API v3',
+            };
+        } catch (err: unknown) {
+            const message = err instanceof Error ? err.message : String(err);
+            return { Success: false, Message: `Connection failed: ${message}` };
+        }
+    }
+
+    // ─── FetchChanges (watermark-aware) ───────────────────────────────
+
+    /**
+     * Sets the watermark context that {@link BuildPaginatedURL} emits as `changed_since` for the
+     * IO's `IncrementalWatermarkField`, delegates the fetch + cursor pagination to the base, then
+     * advances the watermark from the returned records' `changed` field on the FINAL batch only
+     * (HasMore=false) so a partial-failure mid-pagination leaves the watermark unchanged.
+     */
+    public override async FetchChanges(ctx: FetchContext): Promise<FetchBatchResult> {
+        this.currentWatermark = ctx.WatermarkValue ?? undefined;
+
+        const result = await super.FetchChanges(ctx);
+
+        const obj = this.GetCachedObject(ctx.CompanyIntegration.IntegrationID, ctx.ObjectName);
+        if (obj.SupportsIncrementalSync && obj.IncrementalWatermarkField && !result.HasMore) {
+            const advanced = this.ExtractLatestWatermark(result.Records, obj.IncrementalWatermarkField);
+            const newWatermark = advanced ?? ctx.WatermarkValue ?? undefined;
+            if (newWatermark != null) return { ...result, NewWatermarkValue: newWatermark };
+        }
+        return result;
+    }
+
+    /**
+     * Scans a batch for the latest watermark value. The IO's `IncrementalWatermarkField` (`changed`)
+     * names the record-level ISO timestamp; we take the max so the next run resumes from there.
+     */
+    protected ExtractLatestWatermark(
+        records: { Fields: Record<string, unknown> }[],
+        watermarkField: string
+    ): string | null {
+        let latest: Date | null = null;
+        for (const rec of records) {
+            const raw = rec.Fields?.[watermarkField] ?? rec.Fields?.['changed'];
+            if (typeof raw !== 'string' || raw.length === 0) continue;
+            const d = new Date(raw);
+            if (!isNaN(d.getTime()) && (latest === null || d > latest)) latest = d;
+        }
+        return latest ? latest.toISOString() : null;
+    }
+
+    // ─── Auth + transport (abstract base requirements) ────────────────
+
+    protected async Authenticate(
+        companyIntegration: MJCompanyIntegrationEntity,
+        contextUser: UserInfo
+    ): Promise<RESTAuthContext> {
+        if (this.authState) return this.authState;
+        const config = await this.parseConfig(companyIntegration, contextUser);
+        const state: EventbriteAuthContext = {
+            Token: config.Token ?? '',
+            BaseUrl: this.resolveBaseUrl(config),
+            Config: config,
+        };
+        this.authState = state;
+        return state;
+    }
+
+    /** Builds the Eventbrite Bearer auth header. */
+    protected BuildHeaders(auth: RESTAuthContext): Record<string, string> {
+        const ebAuth = auth as EventbriteAuthContext;
+        return {
+            'Authorization': `Bearer ${ebAuth.Token}`,
+            'Accept': 'application/json',
+            'Content-Type': 'application/json',
+        };
+    }
+
+    /**
+     * Unwraps Eventbrite's response envelopes:
+     *  - List endpoints: `{ pagination: {...}, <key>: [ ... ] }` → the resource array under
+     *    `responseDataKey` (the IO's `ListResponseKey`, e.g. `events`, `attendees`, `orders`).
+     *  - Single-record detail: a bare object → a one-element array.
+     */
+    protected NormalizeResponse(rawBody: unknown, responseDataKey: string | null): Record<string, unknown>[] {
+        if (rawBody == null) return [];
+        const asObj = this.asObject(rawBody);
+
+        // Explicit metadata-declared envelope key wins (list endpoints).
+        if (responseDataKey && asObj && responseDataKey in asObj) {
+            return this.coerceToArray(asObj[responseDataKey]);
+        }
+        if (asObj) {
+            // Heuristic: a `pagination` wrapper present but no declared key — take the first array value.
+            if ('pagination' in asObj) {
+                for (const [key, value] of Object.entries(asObj)) {
+                    if (key !== 'pagination' && Array.isArray(value)) return this.coerceToArray(value);
+                }
+            }
+            // Bare single object (detail / users/me).
+            return [asObj];
+        }
+        // Bare array fallback.
+        if (Array.isArray(rawBody)) return rawBody.filter(this.isRecord) as Record<string, unknown>[];
+        return [];
+    }
+
+    private coerceToArray(node: unknown): Record<string, unknown>[] {
+        if (Array.isArray(node)) return node.filter(this.isRecord) as Record<string, unknown>[];
+        if (node && typeof node === 'object') return [node as Record<string, unknown>];
+        return [];
+    }
+
+    private isRecord(node: unknown): node is Record<string, unknown> {
+        return node != null && typeof node === 'object' && !Array.isArray(node);
+    }
+
+    /**
+     * Cursor pagination: Eventbrite reports `pagination.has_more_items` + a `continuation` token.
+     * There are more records while `has_more_items` is true; the next request carries
+     * `?continuation=<token>`. (When all records are returned, `continuation` is absent.)
+     */
+    protected ExtractPaginationInfo(
+        rawBody: unknown,
+        paginationType: PaginationType,
+        currentPage: number,
+        currentOffset: number,
+        _pageSize: number
+    ): PaginationState {
+        if (paginationType !== 'Cursor') {
+            return { HasMore: false, NextPage: currentPage, NextOffset: currentOffset };
+        }
+        const asObj = this.asObject(rawBody);
+        const pag = (asObj && this.asObject(asObj['pagination'])) as EventbritePagination | undefined;
+        const hasMore = pag?.has_more_items === true && typeof pag?.continuation === 'string' && pag.continuation.length > 0;
+        return {
+            HasMore: hasMore,
+            NextCursor: hasMore ? pag!.continuation : undefined,
+            NextPage: (pag?.page_number ?? currentPage) + 1,
+            TotalRecords: typeof pag?.object_count === 'number' ? pag.object_count : undefined,
+        };
+    }
+
+    /**
+     * Eventbrite cursor pagination uses the `continuation` token (NOT the base default `cursor`), and
+     * incremental list endpoints (Orders / Attendees) accept `changed_since`. This override emits
+     * `continuation` + `changed_since` — both metadata-driven, never keyed off a hardcoded object name.
+     * Organization-/event-scoped path vars (`{organization_id}` / `{event_id}`) are resolved by the
+     * base's parent-iteration machinery from the IO's `Configuration.parentObjectName` / FK metadata.
+     */
+    protected override BuildPaginatedURL(
+        basePath: string,
+        obj: MJIntegrationObjectEntity,
+        _page: number,
+        _offset: number,
+        cursor?: string,
+        _effectivePageSize?: number
+    ): string {
+        const separator = basePath.includes('?') ? '&' : '?';
+        const params = new URLSearchParams();
+
+        const watermarkField = obj.IncrementalWatermarkField;
+        if (obj.SupportsIncrementalSync && watermarkField && this.currentWatermark) {
+            // The documented incremental query param is `changed_since`.
+            params.set('changed_since', this.currentWatermark);
+        }
+        if (obj.PaginationType === 'Cursor' && cursor) {
+            params.set('continuation', cursor);
+        }
+
+        const qs = params.toString();
+        return qs ? `${basePath}${separator}${qs}` : basePath;
+    }
+
+    protected GetBaseURL(
+        _companyIntegration: MJCompanyIntegrationEntity,
+        auth: RESTAuthContext
+    ): string {
+        return (auth as EventbriteAuthContext).BaseUrl;
+    }
+
+    // ─── HTTP transport with retry + throttling ───────────────────────
+
+    protected async MakeHTTPRequest(
+        auth: RESTAuthContext,
+        url: string,
+        method: string,
+        headers: Record<string, string>,
+        body?: unknown
+    ): Promise<RESTResponse> {
+        const ebAuth = auth as EventbriteAuthContext;
+        const cfg = ebAuth.Config;
+        const maxRetries = cfg.MaxRetries ?? DEFAULT_MAX_RETRIES;
+        const timeoutMs = cfg.RequestTimeoutMs ?? DEFAULT_REQUEST_TIMEOUT_MS;
+        const minInterval = cfg.MinRequestIntervalMs ?? DEFAULT_MIN_REQUEST_INTERVAL_MS;
+
+        for (let attempt = 0; attempt <= maxRetries; attempt++) {
+            await this.throttle(minInterval);
+            try {
+                const resp = await this.doFetch(url, method, headers, body, timeoutMs);
+                this.lastRequestTime = Date.now();
+
+                if ((resp.Status === 429 || resp.Status === 503) && attempt < maxRetries) {
+                    await this.sleep(this.backoffFromResponse(resp, attempt));
+                    continue;
+                }
+                return resp;
+            } catch (err: unknown) {
+                if (attempt === maxRetries) throw err;
+                if (!this.isRetryableError(err)) throw err;
+                await this.sleep(this.backoffMs(attempt));
+            }
+        }
+        throw new Error(`Eventbrite request to ${url} exhausted ${maxRetries + 1} attempts`);
+    }
+
+    /** Single fetch() with an AbortController-backed timeout. */
+    private async doFetch(
+        url: string,
+        method: string,
+        headers: Record<string, string>,
+        body: unknown,
+        timeoutMs: number
+    ): Promise<RESTResponse> {
+        const controller = new AbortController();
+        const handle = setTimeout(() => controller.abort(), timeoutMs);
+        try {
+            const resp = await fetch(url, {
+                method,
+                headers,
+                body: body !== undefined && method !== 'GET' ? JSON.stringify(body) : undefined,
+                signal: controller.signal,
+            });
+            const respHeaders: Record<string, string> = {};
+            resp.headers.forEach((value, key) => { respHeaders[key.toLowerCase()] = value; });
+            const text = await resp.text();
+            const parsed = text.length > 0 ? this.safeParseJSON(text) : null;
+            return { Status: resp.status, Body: parsed, Headers: respHeaders };
+        } finally {
+            clearTimeout(handle);
+        }
+    }
+
+    private safeParseJSON(text: string): unknown {
+        try { return JSON.parse(text) as unknown; } catch { return text; }
+    }
+
+    private isRetryableError(err: unknown): boolean {
+        const msg = err instanceof Error ? err.message : String(err);
+        return /abort|timeout|ECONNRESET|ENOTFOUND|ETIMEDOUT|ECONNREFUSED|fetch failed|network/i.test(msg);
+    }
+
+    private backoffMs(attempt: number): number {
+        const base = Math.min(1000 * Math.pow(2, attempt), 20000);
+        const jitter = Math.floor(Math.random() * 500);
+        return base + jitter;
+    }
+
+    private backoffFromResponse(resp: RESTResponse, attempt: number): number {
+        const fromHeader = this.ExtractRetryAfterMs({ Headers: resp.Headers });
+        if (fromHeader != null) return Math.min(fromHeader, 30000);
+        return this.backoffMs(attempt);
+    }
+
+    private async throttle(minIntervalMs: number): Promise<void> {
+        const elapsed = Date.now() - this.lastRequestTime;
+        if (elapsed < minIntervalMs) await this.sleep(minIntervalMs - elapsed);
+    }
+
+    private sleep(ms: number): Promise<void> {
+        return new Promise(resolve => setTimeout(resolve, ms));
+    }
+
+    private asObject(node: unknown): Record<string, unknown> | undefined {
+        return node && typeof node === 'object' && !Array.isArray(node) ? node as Record<string, unknown> : undefined;
+    }
+
+    // ─── Config parsing ───────────────────────────────────────────────
+
+    /**
+     * Resolves the connection config: the Bearer token from the credential store; the tenant
+     * organization/user ids + non-secret overrides from CompanyIntegration.Configuration.
+     * Secrets are NEVER baked into code.
+     */
+    private async parseConfig(
+        companyIntegration: MJCompanyIntegrationEntity,
+        contextUser: UserInfo
+    ): Promise<EventbriteConnectionConfig> {
+        const fromCredential = companyIntegration.CredentialID
+            ? await this.loadFromCredential(companyIntegration.CredentialID, contextUser)
+            : null;
+        const fromConfig = this.parseConfigurationJson(companyIntegration.Configuration);
+
+        const merged: EventbriteConnectionConfig = { ...fromConfig, ...fromCredential };
+        merged.OrganizationID = merged.OrganizationID ?? fromConfig.OrganizationID;
+        merged.UserID = merged.UserID ?? fromConfig.UserID;
+        merged.ApiBaseUrl = merged.ApiBaseUrl ?? fromConfig.ApiBaseUrl;
+        merged.RequestTimeoutMs = merged.RequestTimeoutMs ?? fromConfig.RequestTimeoutMs;
+        merged.MaxRetries = merged.MaxRetries ?? fromConfig.MaxRetries;
+        merged.MinRequestIntervalMs = merged.MinRequestIntervalMs ?? fromConfig.MinRequestIntervalMs;
+
+        if (!merged.Token) {
+            throw new Error('EventbriteConnector: a Bearer token (PrivateToken / Token) must be provided via the credential store.');
+        }
+        return merged;
+    }
+
+    /** Resolves the API host; the non-secret ApiBaseUrl override wins (mock/contract testing), else the production host. */
+    private resolveBaseUrl(config: EventbriteConnectionConfig): string {
+        const raw = (config.ApiBaseUrl ?? DEFAULT_BASE_URL).trim();
+        return raw.replace(/\/+$/, '');
+    }
+
+    /** Parses the non-secret tenant/overrides config from CompanyIntegration.Configuration JSON. */
+    private parseConfigurationJson(raw: string | null): EventbriteConnectionConfig {
+        if (!raw || raw.trim().length === 0) return {};
+        let parsed: Record<string, unknown>;
+        try {
+            parsed = JSON.parse(raw) as Record<string, unknown>;
+        } catch {
+            throw new Error('EventbriteConnector: CompanyIntegration.Configuration is not valid JSON.');
+        }
+        const str = (...keys: string[]): string | undefined => {
+            for (const k of keys) {
+                const hit = Object.entries(parsed).find(([key]) => key.toLowerCase() === k.toLowerCase());
+                if (hit && typeof hit[1] === 'string' && hit[1].length > 0) return hit[1] as string;
+            }
+            return undefined;
+        };
+        const num = (...keys: string[]): number | undefined => {
+            for (const k of keys) {
+                const hit = Object.entries(parsed).find(([key]) => key.toLowerCase() === k.toLowerCase());
+                if (hit && typeof hit[1] === 'number') return hit[1] as number;
+            }
+            return undefined;
+        };
+        return {
+            Token: str('token', 'privateToken', 'private_token', 'accessToken', 'access_token'),
+            OrganizationID: str('organizationId', 'organization_id', 'orgId'),
+            UserID: str('userId', 'user_id'),
+            ApiBaseUrl: str('apiBaseUrl', 'api_base_url', 'baseUrl', 'base_url'),
+            RequestTimeoutMs: num('requestTimeoutMs'),
+            MaxRetries: num('maxRetries'),
+            MinRequestIntervalMs: num('minRequestIntervalMs'),
+        };
+    }
+
+    /** Loads the Bearer token (and optional org/user ids) from the MJ credential store. */
+    private async loadFromCredential(
+        credentialID: string,
+        contextUser: UserInfo,
+        provider?: IMetadataProvider
+    ): Promise<EventbriteConnectionConfig | null> {
+        const md = provider ?? new Metadata();
+        const credential = await md.GetEntityObject<MJCredentialEntity>('MJ: Credentials', contextUser);
+        const loaded = await credential.Load(credentialID);
+        if (!loaded || !credential.Values) return null;
+        let raw: Record<string, unknown>;
+        try {
+            raw = JSON.parse(credential.Values) as Record<string, unknown>;
+        } catch {
+            return null;
+        }
+        const get = (...keys: string[]): string | undefined => {
+            for (const k of keys) {
+                const hit = Object.entries(raw).find(([key]) => key.toLowerCase() === k.toLowerCase());
+                if (hit && typeof hit[1] === 'string') return hit[1] as string;
+            }
+            return undefined;
+        };
+        return {
+            Token: get('PrivateToken', 'Token', 'privateToken', 'private_token', 'AccessToken', 'access_token', 'apiKey'),
+            OrganizationID: get('OrganizationID', 'organizationId', 'organization_id'),
+            UserID: get('UserID', 'userId', 'user_id'),
+        };
+    }
+}
+
+/** Tree-shaking prevention function — import and call from the package entry point. */
+export function LoadEventbriteConnector(): void { /* no-op */ }

--- a/packages/Integration/connectors/src/__tests__/EventbriteConnector.test.ts
+++ b/packages/Integration/connectors/src/__tests__/EventbriteConnector.test.ts
@@ -1,0 +1,325 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, resolve } from 'node:path';
+import type {
+    RESTResponse,
+    RESTAuthContext,
+    FetchContext,
+    CreateRecordContext,
+    PaginationType,
+} from '@memberjunction/integration-engine';
+import type {
+    MJCompanyIntegrationEntity,
+    MJIntegrationObjectEntity,
+    MJIntegrationObjectFieldEntity,
+} from '@memberjunction/core-entities';
+import { EventbriteConnector } from '../EventbriteConnector.js';
+
+// ─── Load the REAL committed metadata so the suite proves EVERY table the connector ships ─────
+// (5 levels up: __tests__ → src → connectors → Integration → packages → repo root)
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const META_PATH = resolve(__dirname, '..', '..', '..', '..', '..', 'metadata/integrations/eventbrite/.eventbrite.integration.json');
+const META = JSON.parse(readFileSync(META_PATH, 'utf8')) as MetaInt[];
+
+interface MetaIOF { fields: Record<string, unknown>; }
+interface MetaIO { fields: Record<string, unknown>; relatedEntities: { 'MJ: Integration Object Fields': MetaIOF[] }; }
+interface MetaInt { fields: Record<string, unknown>; relatedEntities: { 'MJ: Integration Objects': MetaIO[] }; }
+
+const INTEGRATION = META[0];
+const IOS = INTEGRATION.relatedEntities['MJ: Integration Objects'];
+
+const MOCK_HOST = 'https://mock.eventbrite.test';
+const CONFIG_JSON = JSON.stringify({ Token: 'test-token', ApiBaseUrl: MOCK_HOST });
+
+// A flat object's APIPath has NO `{template_var}`; parent-/connection-scoped objects do and are
+// resolved by the engine's parent-iteration (DB-backed) — those are proven at the connector-contract
+// layer here, and end-to-end in the live/hybrid e2e.
+function hasTemplateVar(apiPath: string): boolean { return /\{\w+\}/.test(apiPath); }
+
+// ─── Build MJ entity shapes from the metadata rows (so the test drives the SHIPPED config) ────
+
+function ioEntityFromMeta(io: MetaIO): MJIntegrationObjectEntity {
+    const f = io.fields;
+    return {
+        ID: `io-${String(f.Name)}`,
+        Name: f.Name,
+        APIPath: f.APIPath ?? '/',
+        PaginationType: f.PaginationType ?? 'None',
+        SupportsPagination: f.SupportsPagination ?? false,
+        SupportsIncrementalSync: f.SupportsIncrementalSync ?? false,
+        IncrementalWatermarkField: f.IncrementalWatermarkField ?? null,
+        SupportsWrite: f.SupportsWrite ?? false,
+        ResponseDataKey: f.ResponseDataKey ?? null,
+        DefaultPageSize: 50,
+        DefaultQueryParams: null,
+        CreateAPIPath: f.CreateAPIPath ?? null, CreateMethod: f.CreateMethod ?? null,
+        CreateBodyShape: f.CreateBodyShape ?? null, CreateBodyKey: f.CreateBodyKey ?? null, CreateIDLocation: f.CreateIDLocation ?? null,
+        UpdateAPIPath: f.UpdateAPIPath ?? null, UpdateMethod: f.UpdateMethod ?? null,
+        UpdateBodyShape: f.UpdateBodyShape ?? null, UpdateBodyKey: f.UpdateBodyKey ?? null, UpdateIDLocation: f.UpdateIDLocation ?? null,
+        DeleteAPIPath: f.DeleteAPIPath ?? null, DeleteMethod: f.DeleteMethod ?? null, DeleteIDLocation: f.DeleteIDLocation ?? null,
+        Status: 'Active',
+    } as unknown as MJIntegrationObjectEntity;
+}
+
+function iofEntitiesFromMeta(io: MetaIO): MJIntegrationObjectFieldEntity[] {
+    return io.relatedEntities['MJ: Integration Object Fields'].map((iof, i) => {
+        const f = iof.fields;
+        return {
+            Name: f.Name, Type: f.Type ?? 'string',
+            IsPrimaryKey: f.IsPrimaryKey ?? false, IsRequired: f.IsRequired ?? false,
+            IsReadOnly: f.IsReadOnly ?? false, IsUniqueKey: f.IsUniqueKey ?? false,
+            Status: 'Active', Sequence: i, DisplayName: f.Name,
+            RelatedIntegrationObjectID: f.RelatedIntegrationObjectID ?? null,
+        } as unknown as MJIntegrationObjectFieldEntity;
+    });
+}
+
+const OBJ_TABLE: Record<string, { obj: MJIntegrationObjectEntity; fields: MJIntegrationObjectFieldEntity[]; meta: MetaIO }> = {};
+for (const io of IOS) OBJ_TABLE[String(io.fields.Name)] = { obj: ioEntityFromMeta(io), fields: iofEntitiesFromMeta(io), meta: io };
+
+interface CapturedCall { url: string; method: string; headers: Record<string, string>; body?: unknown; }
+
+/**
+ * Test connector: real Authenticate (driven by Configuration JSON → no credential store needed),
+ * real NormalizeResponse / pagination / CRUD path; only HTTP transport + cached-metadata accessors
+ * are stubbed. Exposes the protected response/pagination/watermark hooks for direct assertions.
+ */
+class MockedEventbriteConnector extends EventbriteConnector {
+    public Calls: CapturedCall[] = [];
+    public Responder: (call: CapturedCall) => RESTResponse = () => ({ Status: 200, Body: {}, Headers: {} });
+
+    protected override async MakeHTTPRequest(_a: RESTAuthContext, url: string, method: string, headers: Record<string, string>, body?: unknown): Promise<RESTResponse> {
+        const call: CapturedCall = { url, method, headers, body };
+        this.Calls.push(call);
+        return this.Responder(call);
+    }
+    protected override GetCachedObject(_i: string, objectName: string): MJIntegrationObjectEntity { return OBJ_TABLE[objectName].obj; }
+    protected override GetCachedFields(objectID: string): MJIntegrationObjectFieldEntity[] { return OBJ_TABLE[objectID.replace(/^io-/, '')].fields; }
+
+    // Protected-hook probes
+    public Normalize(body: unknown, key: string | null) { return this.NormalizeResponse(body, key); }
+    public Paginate(body: unknown, type: PaginationType, page: number, offset: number, size: number) { return this.ExtractPaginationInfo(body, type, page, offset, size); }
+    public Watermark(records: { Fields: Record<string, unknown> }[], field: string) { return this.ExtractLatestWatermark(records, field); }
+    public BuildURL(obj: MJIntegrationObjectEntity, cursor?: string, watermark?: string) {
+        this.currentWatermark = watermark;
+        return this.BuildPaginatedURL('https://h/p', obj, 1, 0, cursor, 50);
+    }
+}
+
+function companyIntegration(cfg = CONFIG_JSON): MJCompanyIntegrationEntity {
+    return { IntegrationID: 'int-1', CredentialID: null, Configuration: cfg } as unknown as MJCompanyIntegrationEntity;
+}
+function fetchCtx(objectName: string, watermark: string | null = null): FetchContext {
+    return { CompanyIntegration: companyIntegration(), ObjectName: objectName, WatermarkValue: watermark, BatchSize: 1000, ContextUser: {} as never };
+}
+
+function syntheticRecord(name: string): Record<string, unknown> {
+    const t = OBJ_TABLE[name];
+    const pk = t.fields.find(f => f.IsPrimaryKey);
+    const rec: Record<string, unknown> = { _probe: 'x' };
+    if (pk) rec[pk.Name] = `${name.toLowerCase()}-1`;
+    const wm = t.obj.IncrementalWatermarkField as string | null;
+    if (wm) rec[wm] = '2026-05-15T10:00:00Z';
+    return rec;
+}
+/** A list-envelope body for an object: { pagination, <RDK>: [record] } or a bare object when no list key. */
+function listBody(name: string, hasMore = false, continuation?: string): unknown {
+    const key = OBJ_TABLE[name].obj.ResponseDataKey as string | null;
+    const rec = syntheticRecord(name);
+    if (key) return { pagination: { has_more_items: hasMore, continuation: hasMore ? (continuation ?? 'CONT') : undefined, page_number: 1, object_count: hasMore ? 2 : 1 }, [key]: [rec] };
+    return rec;
+}
+
+// ─── Identity + capabilities ──────────────────────────────────────────
+
+describe('EventbriteConnector — identity & capabilities', () => {
+    const c = new EventbriteConnector();
+    it('instantiates with the verbatim IntegrationName matching the metadata', () => {
+        expect(c).toBeInstanceOf(EventbriteConnector);
+        expect(c.IntegrationName).toBe('Eventbrite');
+        expect(INTEGRATION.fields.Name).toBe('Eventbrite');
+    });
+    it('declares write capability (documented write surfaces)', () => {
+        expect(c.SupportsCreate).toBe(true);
+        expect(c.SupportsUpdate).toBe(true);
+        expect(c.SupportsDelete).toBe(true);
+    });
+    it('declares a RateLimitPolicy under the 1000/hour cap', () => {
+        const p = c.RateLimitPolicy;
+        expect(p).not.toBeNull();
+        expect(p!.TokensPerSec).toBeLessThanOrEqual(1);
+        expect(p!.Burst).toBe(10);
+    });
+    it('parses Retry-After (seconds) into ms; empty → undefined', () => {
+        expect(c.ExtractRetryAfterMs({ Headers: { 'retry-after': '3' } })).toBe(3000);
+        expect(c.ExtractRetryAfterMs({ Headers: {} })).toBeUndefined();
+    });
+});
+
+// ─── TestConnection ───────────────────────────────────────────────────
+
+describe('EventbriteConnector — TestConnection', () => {
+    let c: MockedEventbriteConnector;
+    beforeEach(() => { c = new MockedEventbriteConnector(); });
+    it('happy path: a 200 from /users/me/ yields Success', async () => {
+        c.Responder = () => ({ Status: 200, Body: { id: 'u-1' }, Headers: {} });
+        const res = await c.TestConnection(companyIntegration(), {} as never);
+        expect(res.Success).toBe(true);
+        expect(c.Calls[0].url).toBe(`${MOCK_HOST}/users/me/`);
+    });
+    it('auth-fail path: a 401 yields failure', async () => {
+        c.Responder = () => ({ Status: 401, Body: null, Headers: {} });
+        const res = await c.TestConnection(companyIntegration(), {} as never);
+        expect(res.Success).toBe(false);
+        expect(res.Message).toContain('401');
+    });
+    it('sends Authorization: Bearer <token> + Accept JSON', async () => {
+        c.Responder = () => ({ Status: 200, Body: { id: 'u-1' }, Headers: {} });
+        await c.TestConnection(companyIntegration(), {} as never);
+        expect(c.Calls[0].headers['Authorization']).toBe('Bearer test-token');
+        expect(c.Calls[0].headers['Accept']).toBe('application/json');
+    });
+    it('fails with a config error when no token is supplied', async () => {
+        const res = await c.TestConnection(companyIntegration(JSON.stringify({ ApiBaseUrl: MOCK_HOST })), {} as never);
+        expect(res.Success).toBe(false);
+        expect(res.Message).toContain('token');
+    });
+});
+
+// ─── NormalizeResponse + pagination contract ──────────────────────────
+
+describe('EventbriteConnector — NormalizeResponse / pagination', () => {
+    let c: MockedEventbriteConnector;
+    beforeEach(() => { c = new MockedEventbriteConnector(); });
+
+    it('unwraps the list envelope by ResponseDataKey', () => {
+        const recs = c.Normalize({ pagination: {}, events: [{ id: 'e1' }, { id: 'e2' }] }, 'events');
+        expect(recs.map(r => r.id)).toEqual(['e1', 'e2']);
+    });
+    it('falls back to the first array under a pagination wrapper when no key is given', () => {
+        expect(c.Normalize({ pagination: {}, attendees: [{ id: 'a1' }] }, null).length).toBe(1);
+    });
+    it('treats a bare object as one record and null as empty', () => {
+        expect(c.Normalize({ id: 'x' }, null)).toEqual([{ id: 'x' }]);
+        expect(c.Normalize(null, 'events')).toEqual([]);
+    });
+    it('Cursor: HasMore + NextCursor from pagination.continuation', () => {
+        const s = c.Paginate({ pagination: { has_more_items: true, continuation: 'TOK', object_count: 9 } }, 'Cursor', 1, 0, 50);
+        expect(s.HasMore).toBe(true);
+        expect(s.NextCursor).toBe('TOK');
+        expect(s.TotalRecords).toBe(9);
+    });
+    it('Cursor: terminal page (no continuation) → HasMore false; non-Cursor → false', () => {
+        expect(c.Paginate({ pagination: { has_more_items: false } }, 'Cursor', 2, 0, 50).HasMore).toBe(false);
+        expect(c.Paginate({}, 'None', 1, 0, 50).HasMore).toBe(false);
+    });
+});
+
+// ─── BuildPaginatedURL: continuation + changed_since ──────────────────
+
+describe('EventbriteConnector — BuildPaginatedURL', () => {
+    let c: MockedEventbriteConnector;
+    beforeEach(() => { c = new MockedEventbriteConnector(); });
+
+    it('appends ?continuation=<token> for a cursor object on a subsequent page', () => {
+        const url = c.BuildURL(OBJ_TABLE['Event'].obj, 'C1');
+        expect(url).toContain('continuation=C1');
+    });
+    it('emits changed_since for an incremental object when a watermark is set', () => {
+        const url = c.BuildURL(OBJ_TABLE['Order'].obj, undefined, '2026-02-01T00:00:00Z');
+        expect(url).toContain('changed_since=2026-02-01');
+    });
+    it('emits neither for a non-incremental object with no cursor', () => {
+        const url = c.BuildURL(OBJ_TABLE['Category'].obj);
+        expect(url).not.toContain('continuation');
+        expect(url).not.toContain('changed_since');
+    });
+});
+
+// ─── ALL-TABLES coverage: every IO proven; flat tables end-to-end, scoped tables at contract layer ──
+
+describe('EventbriteConnector — full-catalog coverage (every table)', () => {
+    let c: MockedEventbriteConnector;
+    beforeEach(() => { c = new MockedEventbriteConnector(); });
+
+    it(`covers all ${IOS.length} objects (metadata sanity)`, () => {
+        expect(IOS.length).toBe(18);
+        expect(Object.keys(OBJ_TABLE).length).toBe(18);
+    });
+
+    for (const io of IOS) {
+        const name = String(io.fields.Name);
+        const flat = !hasTemplateVar(String(io.fields.APIPath));
+
+        if (flat) {
+            it(`${name}: (flat endpoint) FetchChanges lands a record end-to-end + full-record pass-through`, async () => {
+                c.Responder = () => ({ Status: 200, Body: listBody(name, false), Headers: {} });
+                const res = await c.FetchChanges(fetchCtx(name));
+                expect(res.Records.length).toBeGreaterThan(0);
+                expect(Object.keys(res.Records[0].Fields).length).toBeGreaterThan(1); // full record, not a subset
+                const pk = OBJ_TABLE[name].fields.find(f => f.IsPrimaryKey);
+                if (pk) expect(res.Records[0].ExternalID).toBe(`${name.toLowerCase()}-1`);
+                else expect(typeof res.Records[0].ExternalID).toBe('string'); // keyless → content-hash identity
+            });
+        } else {
+            it(`${name}: (parent/connection-scoped) connector parses its list envelope into records`, () => {
+                const recs = c.Normalize(listBody(name, false), OBJ_TABLE[name].obj.ResponseDataKey as string | null);
+                expect(recs.length).toBeGreaterThan(0);
+                expect(OBJ_TABLE[name].meta.fields.Configuration).toBeTruthy();
+            });
+        }
+
+        if (io.fields.SupportsCreate === true) {
+            it(`${name}: CreateRecord POSTs with the declared method + body shape + extracts the new id`, async () => {
+                c.Responder = () => ({ Status: 201, Body: { id: `${name.toLowerCase()}-new` }, Headers: {} });
+                const res = await c.CreateRecord({
+                    CompanyIntegration: companyIntegration(), ObjectName: name, ContextUser: {} as unknown, Attributes: { _probe: 'v' },
+                } as unknown as CreateRecordContext);
+                expect(res.Success).toBe(true);
+                expect(res.ExternalID).toBe(`${name.toLowerCase()}-new`);
+                expect(c.Calls[0].method).toBe(String(io.fields.CreateMethod));
+                if (io.fields.CreateBodyShape === 'wrapped') {
+                    expect(c.Calls[0].body as Record<string, unknown>).toHaveProperty(String(io.fields.CreateBodyKey));
+                }
+            });
+        } else {
+            it(`${name}: is read-only (no SupportsCreate) — matches the catalog`, () => {
+                expect(io.fields.SupportsCreate).not.toBe(true);
+            });
+        }
+    }
+});
+
+// ─── Incremental watermark advancement (Order / Attendee) ─────────────
+
+describe('EventbriteConnector — watermark advance', () => {
+    const c = new MockedEventbriteConnector();
+    for (const name of ['Order', 'Attendee']) {
+        it(`${name}: takes the max 'changed' across a batch`, () => {
+            const recs = [
+                { Fields: { id: 'a', changed: '2026-03-01T10:00:00Z' } },
+                { Fields: { id: 'b', changed: '2026-05-15T10:00:00Z' } },
+                { Fields: { id: 'c', changed: '2026-01-01T10:00:00Z' } },
+            ];
+            expect(c.Watermark(recs, OBJ_TABLE[name].obj.IncrementalWatermarkField as string)).toBe(new Date('2026-05-15T10:00:00Z').toISOString());
+        });
+    }
+    it('returns null when no record carries a watermark', () => {
+        expect(c.Watermark([{ Fields: { id: 'x' } }], 'changed')).toBeNull();
+    });
+});
+
+// ─── Bijection sanity over the SHIPPED metadata (capability ⟺ per-op columns) ───
+
+describe('EventbriteConnector — metadata bijection (capability ⟺ columns)', () => {
+    for (const io of IOS) {
+        const f = io.fields;
+        it(`${String(f.Name)}: each declared write capability has its required per-op columns`, () => {
+            if (f.SupportsCreate === true) { expect(f.CreateAPIPath).toBeTruthy(); expect(f.CreateMethod).toBeTruthy(); expect(f.CreateBodyShape).toBeTruthy(); expect(f.CreateIDLocation).toBeTruthy(); }
+            if (f.SupportsUpdate === true) { expect(f.UpdateAPIPath).toBeTruthy(); expect(f.UpdateMethod).toBeTruthy(); }
+            if (f.SupportsDelete === true) { expect(f.DeleteAPIPath).toBeTruthy(); expect(f.DeleteMethod).toBeTruthy(); }
+            if (f.SupportsIncrementalSync === true) { expect(f.IncrementalWatermarkField).toBeTruthy(); }
+        });
+    }
+});

--- a/packages/Integration/connectors/src/index.ts
+++ b/packages/Integration/connectors/src/index.ts
@@ -34,3 +34,4 @@ export { PheedLoopConnector } from './PheedLoopConnector.js';
 export { RhythmConnector, LoadRhythmConnector, type RhythmConnectionConfig } from './RhythmConnector.js';
 export { NoviConnector, LoadNoviConnector, type NoviConnectionConfig } from './NoviConnector.js';
 export { MemberSuiteConnector } from './MemberSuiteConnector.js';
+export { EventbriteConnector, LoadEventbriteConnector, type EventbriteConnectionConfig } from './EventbriteConnector.js';

--- a/packages/Integration/engine/src/auth-helpers/OAuth2TokenManager.ts
+++ b/packages/Integration/engine/src/auth-helpers/OAuth2TokenManager.ts
@@ -63,14 +63,6 @@ export interface OAuth2TokenRequest {
     ExtraParams?: Record<string, string>;
     /** Request timeout in ms. Default 30000. */
     TimeoutMs?: number;
-    /**
-     * Extra `application/x-www-form-urlencoded` parameters appended to the grant body for vendors
-     * whose token endpoint requires non-standard inputs — e.g. Auth0's `audience` on a
-     * `client_credentials` grant, or a vendor-specific `resource`/`tenant` param. Applies to every
-     * grant type; standard params (grant_type, client_id/secret, scope, refresh_token, username,
-     * password) take precedence and are never overwritten by this map.
-     */
-    ExtraParams?: Record<string, string>;
 }
 
 /** A minted access token plus its derived expiry. */


### PR DESCRIPTION
## Eventbrite connector — Eventbrite Platform REST API v3

Adds a credential-free, **contract-verified** Eventbrite connector built docs-first from the official Eventbrite Platform API v3 reference (no invented fields/endpoints).

### What's here
- **`EventbriteConnector`** (`@memberjunction/integration-connectors`) — extends `BaseRESTIntegrationConnector`. OAuth2 Bearer / private-token auth, `continuation`-cursor pagination, `changed_since` incremental sync on Orders & Attendees. CRUD is delegated to the generic v5.39.x per-operation column path; documented write surfaces (Event, EventSeries, Venue, TicketClass, TicketGroup, Discount, Webhook, Question) are wired with wrapped/flat bodies. Orders & Attendees stay read-only per the public API.
- **Metadata** (`metadata/integrations/eventbrite/`) — **18 Integration Objects / 242 fields / 23 FK edges**. Organization-/event-scoped list paths declare `Configuration.parentObjectName`, so the engine resolves `{organization_id}` / `{event_id}` via parent-iteration — **no base-class change required**.
- **Credential type** `Eventbrite OAuth Token` (private token, or OAuth2 authorization-code app credentials).
- **74 credential-free mock tests** — every table covered (flat tables end-to-end; parent/connection-scoped tables at the response-contract layer), plus TestConnection, NormalizeResponse, cursor pagination, `changed_since` emission, watermark advancement, CRUD body shaping, and the capability⟺per-op-column bijection over the shipped metadata.

### Floor graders (all green)
- `bijection` ✓ — every declared capability has its required per-operation columns
- `dag-completeness` ✓ — DAG complete over all 18 objects, every FK resolves, no hard-@lookup cycle
- `fk-lookup-qualifier` ✓ — every FK `@lookup` uses `&IntegrationID=@parent:IntegrationID`

### Verification ceiling
**Contract-verified** (matches Eventbrite's published Platform API v3). No live API calls in this run — Eventbrite tokens are self-serve, so a live **read-only** pass can be added later via `/test-connector` with no rebuild.

### Note
Also fixes a **pre-existing** duplicate `ExtraParams` declaration in `@memberjunction/integration-engine`'s `OAuth2TokenManager` interface that blocked the engine from compiling on `next`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)