### PR TITLE
fix(connectors): make mj sync push idempotent — fill null batch fields

### DIFF
--- a/.changeset/connector-batch-null-idempotency.md
+++ b/.changeset/connector-batch-null-idempotency.md
@@ -1,5 +1,5 @@
 ---
-"@memberjunction/integration-connectors": patch
+"@memberjunction/integration-connectors": minor
 ---
 
 Make `mj sync push` idempotent for six connectors (SharePoint, Neon CRM, Fonteva, MemberSuite, PheedLoop, Rhythm) by filling their null `BatchMaxRequestCount` / `BatchRequestWaitTime`.

--- a/.changeset/connector-batch-null-idempotency.md
+++ b/.changeset/connector-batch-null-idempotency.md
@@ -1,0 +1,9 @@
+---
+"@memberjunction/integration-connectors": patch
+---
+
+Make `mj sync push` idempotent for six connectors (SharePoint, Neon CRM, Fonteva, MemberSuite, PheedLoop, Rhythm) by filling their null `BatchMaxRequestCount` / `BatchRequestWaitTime`.
+
+Those columns are NOT NULL but carry a default. `BaseEntity.Validate()` (the client-side check `mj sync push` runs before saving) permits a null on a **new** record — the column default applies — but rejects it on an **existing** record, because a prior non-null value is present (`<field> cannot be null`). So a fresh-DB create silently absorbs the null while any re-push that *updates* an existing connector row fails — i.e. the push is not idempotent for these files.
+
+This surfaced after PR #2916 added SharePoint's baseline `primaryKey`, which flips SharePoint's push from insert to update and tripped the latent null on the very next deploy. Set the unspecified fields to the `-1` "no-batching" sentinel already used by NetForum/Path LMS/PropFuel; SharePoint keeps its baked `BatchRequestWaitTime=250` so its update is a no-op. `NavigationBaseURL` nulls elsewhere (iMIS/NetForum/Nimble) are unaffected — that column is nullable. An audit of all NOT-NULL-with-default columns across every connector confirms these batch fields were the only such nulls.

--- a/metadata/integrations/fonteva/.fonteva.integration.json
+++ b/metadata/integrations/fonteva/.fonteva.integration.json
@@ -6,8 +6,8 @@
       "ImportPath": "@memberjunction/integration-connectors",
       "Description": "Fonteva AMS connector: syncs Salesforce-native OrderApi__* + EventApi__* association-management objects (commerce, membership, events, payments, badges, catalog) via FDService Apex REST + the Salesforce platform REST API. Extends SalesforceConnector.",
       "NavigationBaseURL": "https://login.salesforce.com",
-      "BatchMaxRequestCount": null,
-      "BatchRequestWaitTime": null,
+      "BatchMaxRequestCount": -1,
+      "BatchRequestWaitTime": -1,
       "CredentialTypeID": "@lookup:MJ: Credential Types.Name=Salesforce JWT Bearer",
       "Configuration": {
         "AuthFlow": "oauth2-authcode",

--- a/metadata/integrations/membersuite/.membersuite.integration.json
+++ b/metadata/integrations/membersuite/.membersuite.integration.json
@@ -7,8 +7,8 @@
       "Description": "MemberSuite AMS connector — syncs members, organizations, memberships, chapters, events, registrations, orders, and certifications via MemberSuite REST API v2.",
       "NavigationBaseURL": "https://rest.membersuite.com",
       "CredentialTypeID": "@lookup:MJ: Credential Types.Name=MemberSuite API",
-      "BatchMaxRequestCount": null,
-      "BatchRequestWaitTime": null,
+      "BatchMaxRequestCount": -1,
+      "BatchRequestWaitTime": -1,
       "Configuration": {
         "Auth": {
           "model": "two-step-signed-request",

--- a/metadata/integrations/neon-crm/.neon-crm.integration.json
+++ b/metadata/integrations/neon-crm/.neon-crm.integration.json
@@ -7,7 +7,7 @@
       "NavigationBaseURL": "https://api.neoncrm.com/v2",
       "Description": "Neon CRM (Neon One) connector — syncs accounts, donations, memberships, events, registrations, campaigns, activities, grants, orders, payments, pledges, volunteers, and custom objects via the Neon REST API v2 (HTTP Basic auth).",
       "BatchMaxRequestCount": 5,
-      "BatchRequestWaitTime": null,
+      "BatchRequestWaitTime": -1,
       "CredentialTypeID": "@lookup:MJ: Credential Types.Name=Neon CRM API Key",
       "Configuration": {
         "AuthFlow": "basic",

--- a/metadata/integrations/pheedloop/.pheedloop.integration.json
+++ b/metadata/integrations/pheedloop/.pheedloop.integration.json
@@ -6,8 +6,8 @@
       "ImportPath": "@memberjunction/connector-pheedloop",
       "NavigationBaseURL": "https://api.pheedloop.com/api/v3",
       "Description": "PheedLoop event-management connector — syncs attendees, events, sessions, speakers, exhibitors, sponsors, registrations, memberships and 20+ objects via PheedLoop REST API v3 (dual API-key + API-secret headers, org-scoped URL paths).",
-      "BatchMaxRequestCount": null,
-      "BatchRequestWaitTime": null,
+      "BatchMaxRequestCount": -1,
+      "BatchRequestWaitTime": -1,
       "CredentialTypeID": "@lookup:MJ: Credential Types.Name=PheedLoop API",
       "Configuration": {
         "AuthFlow": "api-key",

--- a/metadata/integrations/sharepoint/.sharepoint.integration.json
+++ b/metadata/integrations/sharepoint/.sharepoint.integration.json
@@ -12,7 +12,7 @@
       "Icon": "fa-brands fa-microsoft",
       "NavigationBaseURL": "https://graph.microsoft.com/v1.0",
       "BatchMaxRequestCount": 20,
-      "BatchRequestWaitTime": null,
+      "BatchRequestWaitTime": 250,
       "Configuration": {
         "AuthFlow": "oauth2-cc",
         "AuthFlowNote": "OAuth 2.0 Client Credentials grant (RFC 6749 \u00a74.4). The service application uses client_id + client_secret (or client_assertion for certificate-based) to obtain a Bearer token from the tenant-specific token endpoint without user interaction. No refresh_token is issued for client_credentials \u2014 re-acquire by submitting a new token request when the current token is within expiry. Source: Microsoft Entra v2-oauth2-client-creds-grant-flow docs.",


### PR DESCRIPTION
## Problem

`mj sync push` is **not idempotent** for six connectors. `BatchMaxRequestCount` / `BatchRequestWaitTime` are `NOT NULL` with a default, but six connector files leave them `null`:

| Connector | before | after |
|---|---|---|
| SharePoint | BMC=20, BRW=**null** | BMC=20, BRW=**250** |
| Neon CRM | BMC=5, BRW=**null** | BMC=5, BRW=**-1** |
| Fonteva | **null/null** | **-1/-1** |
| MemberSuite | **null/null** | **-1/-1** |
| PheedLoop | **null/null** | **-1/-1** |
| Rhythm | **null/null** | **-1/-1** |

`BaseEntity.Validate()` (the client-side check `mj sync push` runs before saving) **permits** a null on a **new** record — the column default applies — but **rejects** it on an **existing** record, because a prior non-null value is present (`<field> cannot be null`, baseEntity.ts:311–315). So a fresh-DB create silently absorbs the null, while any **re-push that updates** the row fails. That's the non-idempotency.

This became live after **#2916** added SharePoint's baseline `primaryKey` — that flips SharePoint's push from insert to **update**, tripping the latent null on the very next deploy to `next`. #2916 merged the `primaryKey` but **not** the batch fix (the fix commits landed on the branch after the merge), so `next` currently has SharePoint primed to fail.

## Fix

Fill the unspecified fields with the `-1` "no-batching" sentinel already used by NetForum / Path LMS / PropFuel (and equal to what the create path coalesces null to, so files are idempotent across create **and** update). SharePoint keeps its baked `BatchRequestWaitTime=250` so its update is a no-op.

Each diff touches **only** the two batch fields — nothing else.

## Why this is the complete fix

An audit of **every** NOT-NULL-with-default column across all three integration tables (`Integration`, `IntegrationObject`, `IntegrationObjectField`), cross-referenced against every connector file (top-level **and** nested IO/IOF rows), confirms these batch fields were the **only** nulls of this shape. `NavigationBaseURL` nulls elsewhere (iMIS/NetForum/Nimble) are unaffected — that column is nullable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)