### PR TITLE
fix(installer): scaffold a .gitignore protecting .env secrets

### DIFF
--- a/.changeset/installer-scaffold-gitignore-env.md
+++ b/.changeset/installer-scaffold-gitignore-env.md
@@ -1,0 +1,7 @@
+---
+"@memberjunction/installer": patch
+---
+
+fix(installer): scaffold a `.gitignore` that ignores `.env` so generated projects can't leak secrets
+
+The configure phase writes a real `.env` (DB credentials, API keys) but emitted no `.gitignore`, so a freshly scaffolded project could commit secrets to a public repo via `git init && git add .`. The phase now guarantees a `.gitignore` ignoring `.env`/`.env.*` (keeping `.env.example`). Idempotent — appends only the missing entries to an existing `.gitignore`, never rewriting user lines.

--- a/packages/MJInstaller/src/__tests__/ConfigurePhase.test.ts
+++ b/packages/MJInstaller/src/__tests__/ConfigurePhase.test.ts
@@ -75,6 +75,58 @@ describe('ConfigurePhase', () => {
     mockFs.ListFiles.mockResolvedValue([]);
   });
 
+  // ─── .gitignore secret protection ──────────────────────────────────
+
+  describe('.gitignore secret protection', () => {
+    it('creates a .gitignore ignoring .env when none exists', async () => {
+      // beforeEach default: FileExists → false (no .gitignore present)
+      const ctx = makeContext({ Yes: true });
+      const result = await phase.Run(ctx);
+
+      const gitignore = findWrittenContent('.gitignore');
+      expect(gitignore).toBeDefined();
+      expect(gitignore).toContain('.env');
+      expect(gitignore).toContain('.env.*');
+      expect(gitignore).toContain('!.env.example');
+      expect(result.FilesWritten.some((f) => f.endsWith('.gitignore'))).toBe(true);
+    });
+
+    it('appends only the missing env entries to an existing .gitignore (preserves user lines)', async () => {
+      mockFs.FileExists.mockImplementation(async (p: string) => p.endsWith('.gitignore'));
+      mockFs.ReadText.mockImplementation(async (p: string) =>
+        p.endsWith('.gitignore') ? 'node_modules/\n.env\n' : '',
+      );
+
+      const ctx = makeContext({ Yes: true });
+      await phase.Run(ctx);
+
+      const gitignore = findWrittenContent('.gitignore');
+      expect(gitignore).toBeDefined();
+      expect(gitignore).toContain('node_modules/'); // existing line preserved
+      expect(gitignore).toContain('.env.*'); // missing entries appended
+      expect(gitignore).toContain('!.env.example');
+      // .env already present → not duplicated as a standalone line
+      const envLines = gitignore!.split(/\r?\n/).filter((l) => l.trim() === '.env');
+      expect(envLines).toHaveLength(1);
+    });
+
+    it('does not rewrite a .gitignore that already covers env secrets', async () => {
+      const complete = '.env\n.env.*\n!.env.example\n';
+      mockFs.FileExists.mockImplementation(async (p: string) => p.endsWith('.gitignore'));
+      mockFs.ReadText.mockImplementation(async (p: string) =>
+        p.endsWith('.gitignore') ? complete : '',
+      );
+
+      const ctx = makeContext({ Yes: true });
+      await phase.Run(ctx);
+
+      const wroteGitignore = (mockFs.WriteText.mock.calls as [string, string][]).some(([p]) =>
+        p.endsWith('.gitignore'),
+      );
+      expect(wroteGitignore).toBe(false);
+    });
+  });
+
   // ─── yes mode with full config ─────────────────────────────────────
 
   describe('yes mode with full config', () => {

--- a/packages/MJInstaller/src/phases/ConfigurePhase.ts
+++ b/packages/MJInstaller/src/phases/ConfigurePhase.ts
@@ -170,6 +170,16 @@ export class ConfigurePhase {
       }
     }
 
+    // Step 2.5: .gitignore — guarantee the secrets just written (.env, .env.*) are
+    // git-ignored. Scaffolded MJ projects historically shipped without a .gitignore,
+    // so a `git init && git add .` committed real .env credentials into public repos.
+    const gitignoreResult = await this.ensureGitignoreProtectsEnv(context.Dir);
+    if (gitignoreResult.Written) {
+      filesWritten.push(gitignoreResult.Path);
+    } else {
+      filesPreserved.push(gitignoreResult.Path);
+    }
+
     // Step 3: mj.config.cjs — preserve existing, create if missing, patch encryption + user
     const configCjsPath = path.join(context.Dir, 'mj.config.cjs');
     if (!overwrite && await this.fileSystem.FileExists(configCjsPath)) {
@@ -407,6 +417,54 @@ export class ConfigurePhase {
   // ---------------------------------------------------------------------------
   // File generation
   // ---------------------------------------------------------------------------
+
+  /**
+   * Ensures the install directory has a `.gitignore` that ignores environment
+   * secret files (`.env`, `.env.*`) while keeping the committed `.env.example`.
+   *
+   * Idempotent: creates the file when absent, and appends only the missing entries
+   * when one already exists (never reorders or rewrites the user's existing lines).
+   *
+   * Fixes the original scaffolding gap where a generated project shipped without a
+   * `.gitignore`, so the real `.env` written by this phase could be committed to a
+   * public repo.
+   *
+   * @param dir - Install directory root.
+   * @returns The `.gitignore` path and whether it was created/modified.
+   */
+  private async ensureGitignoreProtectsEnv(dir: string): Promise<{ Path: string; Written: boolean }> {
+    const gitignorePath = path.join(dir, '.gitignore');
+    // `.env.*` also matches `.env.example`, so re-include it with a negation that
+    // must follow the broad pattern to take effect.
+    const requiredEntries = ['.env', '.env.*', '!.env.example'];
+
+    if (await this.fileSystem.FileExists(gitignorePath)) {
+      const existing = await this.fileSystem.ReadText(gitignorePath);
+      const lines = existing.split(/\r?\n/).map((l) => l.trim());
+      const missing = requiredEntries.filter((entry) => !lines.includes(entry));
+      if (missing.length === 0) {
+        return { Path: gitignorePath, Written: false };
+      }
+      const appended =
+        existing.replace(/\s*$/, '') +
+        '\n\n# Environment secrets (added by MJ installer)\n' +
+        missing.join('\n') +
+        '\n';
+      await this.fileSystem.WriteText(gitignorePath, appended);
+      return { Path: gitignorePath, Written: true };
+    }
+
+    const body =
+      '# Environment secrets — never commit real credentials\n' +
+      '.env\n' +
+      '.env.*\n' +
+      '!.env.example\n\n' +
+      '# Dependencies & build output\n' +
+      'node_modules/\n' +
+      'dist/\n';
+    await this.fileSystem.WriteText(gitignorePath, body);
+    return { Path: gitignorePath, Written: true };
+  }
 
   /**
    * Write a fresh `.env` file with all config values including the encryption key.


### PR DESCRIPTION
## Problem
The installer's configure phase writes a real `.env` (DB credentials, API keys) into a scaffolded project but **emits no `.gitignore`** — so `git init && git add .` in a generated project commits secrets to a public repo. This is the secret-leak path observed in scaffolded OpenApp/MJ projects.

## Fix
`ConfigurePhase` now guarantees a `.gitignore` (right after the `.env` is written) that ignores `.env`/`.env.*` while keeping the committed `.env.example`. **Idempotent**: creates the file when absent; when one already exists, appends only the missing entries and never reorders/rewrites the user's lines. (Root-level `.env`/`.env.*` patterns also cover nested env files like `packages/MJAPI/.env`.)

## Tests
3 new cases (create-when-absent / idempotent-append-preserving-user-lines / no-rewrite-when-already-complete). **38/38** ConfigurePhase tests pass; MJInstaller builds clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)