### PR TITLE
fix(metadata): restore generic oauth2-client-credentials schema (unblocks mj sync push)

### DIFF
--- a/.changeset/restore-oauth2-client-credentials-schema.md
+++ b/.changeset/restore-oauth2-client-credentials-schema.md
@@ -1,0 +1,5 @@
+---
+"@memberjunction/core": patch
+---
+
+Restore `metadata/credential-types/schemas/oauth2-client-credentials.schema.json`, which was inadvertently deleted in #2942 alongside the connector-specific credential-type schemas. It is a **generic** OAuth2 client-credentials schema still referenced (via `@file:`) by a retained credential type in `.credential-types.json`, so its removal broke `mj sync push --dir metadata` with a "File reference not found" validation error. No other `@file:` references are dangling.

--- a/metadata/credential-types/schemas/oauth2-client-credentials.schema.json
+++ b/metadata/credential-types/schemas/oauth2-client-credentials.schema.json
@@ -1,0 +1,36 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "properties": {
+    "clientId": {
+      "type": "string",
+      "title": "Client ID",
+      "description": "OAuth2 client identifier",
+      "isSecret": false,
+      "order": 0
+    },
+    "clientSecret": {
+      "type": "string",
+      "title": "Client Secret",
+      "description": "OAuth2 client secret",
+      "isSecret": true,
+      "order": 1
+    },
+    "tokenUrl": {
+      "type": "string",
+      "title": "Token URL",
+      "description": "OAuth2 token endpoint URL",
+      "format": "uri",
+      "isSecret": false,
+      "order": 2
+    },
+    "scope": {
+      "type": "string",
+      "title": "Scope",
+      "description": "OAuth2 scopes (space-separated)",
+      "isSecret": false,
+      "order": 3
+    }
+  },
+  "required": ["clientId", "clientSecret", "tokenUrl"]
+}


### PR DESCRIPTION
#2942 deleted `metadata/credential-types/schemas/oauth2-client-credentials.schema.json` along with the connector-specific credential-type schemas — but it is a **generic** OAuth2 client-credentials schema still referenced (via `@file:`) by a retained credential type in `.credential-types.json`.

Result: `mj sync push --dir metadata` failed validation with `File reference not found: "schemas/oauth2-client-credentials.schema.json"` (1 reference error). Restoring the file (recovered verbatim from `942f806479^`) fixes it.

Verified it's the **only** dangling reference: all 15 other `@file:` schemas referenced by the kept credential types exist, and the validation report showed exactly 1 error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)