### PR TITLE
feat(realtime): agent media library — Collections as agent media kits (MJ-core, additive)

### DIFF
--- a/.changeset/agent-media-library.md
+++ b/.changeset/agent-media-library.md
@@ -1,0 +1,5 @@
+---
+"@memberjunction/ai-agents": minor
+---
+
+Agent media library: a realtime agent can now draw on a curated, governed **media kit** during a conversation — a `MJ: Collections` of `MJ: Artifacts` bound to the agent via the new `AIAgent.DefaultMediaCollectionID`, with per-membership `ContextDescription` ("when to show it") and `Preload` on `MJ: Collection Artifacts`. The `MediaChannelServer` resolves the kit at session start and feeds the model a manifest so it can surface items via the existing `Media_ShowMedia` tool. Additive only; reuses Files/streaming/viewers/versioning/permissions (no new top-level entity). Requires the companion migration + CodeGen.

--- a/guides/REALTIME_CO_AGENTS_GUIDE.md
+++ b/guides/REALTIME_CO_AGENTS_GUIDE.md
@@ -463,6 +463,17 @@ The whiteboard now lives in **two layers**, and the split is the point:
 
 **Restore-on-resume**: `RestoreState` rehydrates a prior session's board **in place** into the same `WhiteboardState` instance (`LoadFromJSON`), so the save subscription and any later surface binding keep pointing at one engine. Malformed payloads return `false` and the board starts fresh.
 
+### The Media channel's agent media library (Collections as kits)
+
+The **Media** channel (`MediaChannelServer` / `RealtimeMediaChannel`, seeded row `Name: 'Media'`) lets the agent put images/video/audio/PDF/web on a shared surface. Beyond ad-hoc `Media_ShowMedia({ url | fileId })`, an agent can be given a **curated, governed media kit** it reasons over — built by **reusing Artifacts + Collections**, not a bespoke entity:
+
+- **A `MJ: Collections` of `MJ: Artifacts` IS the kit.** The artifact (+ current version) describes the media — `FileID → MJ: Files`, `MimeType`, name, viewer, versioning, permissions. Bytes stream through the authenticated `/media` route. Nothing is duplicated.
+- **Agent-reasoning metadata lives per-membership** on `MJ: Collection Artifacts`: `Sequence` (priority/order, pre-existing) + **`ContextDescription`** (the agent-facing "what this is / when to show it") + **`Preload`** (eager hint). Per-membership means the same artifact can be framed differently in different kits.
+- **Binding:** `AIAgent.DefaultMediaCollectionID` (FK → `Collection`) is the agent's default kit; per-session resolution is `runtime override > agent default > none`.
+- **Server-side resolution, existing client tool.** `MediaChannelServer` implements `IRealtimeChannelServerDataAware` (the host hands it the session `contextUser` + `provider` between `Initialize` and `OnSessionStarted`); on start it resolves the kit via `agent-media-library.ts` (`buildAgentMediaContextNote`) and `SendContextNote`s a manifest (`fileId`, type, display name, when-to-show, PRELOAD). The agent then surfaces items with the **existing** `Media_ShowMedia({ fileId, mediaType, displayName })` — no new client tool, no client round-trips. An agent with no kit is unaffected.
+
+The resolver (`mediaTypeFromMimeType` / `resolveAgentMediaManifest` / `formatAgentMediaManifest`) is exported from `@memberjunction/ai-agents` and unit-tested. See `plans/praxis/AGENT_MEDIA_LIBRARY_PLAN.md`.
+
 ### Interactions between channels
 
 The channels are not silos — they converge on the one shared model context and the one overlay shell:

--- a/migrations/v5/V202606271600__v5.44.x__Agent_Media_Library.sql
+++ b/migrations/v5/V202606271600__v5.44.x__Agent_Media_Library.sql
@@ -1,0 +1,63 @@
+/*----------------------------------------------------------------------------------------------------
+  Agent Media Library (Praxis WBS: S1 follow-up) — MJ-core, additive only.
+
+  Lets a realtime agent draw on a curated, governed media kit during a conversation by REUSING the
+  existing Artifacts + Collections stack instead of a bespoke media-resource entity:
+
+    - A Collection of Artifacts IS the agent's "media kit". Each membership row (MJ: Collection
+      Artifacts) already carries Sequence (priority/order); this migration adds the two pieces a
+      realtime agent needs to reason over an item WITHOUT a new top-level entity:
+        * ContextDescription — the agent-facing "what this is / when to show it", PER-MEMBERSHIP so
+          the same artifact can be framed differently in different kits.
+        * Preload            — eager hint: show / prefetch this item at session start.
+      (The artifact itself keeps describing the media — MJ: Files link, MimeType, name, viewer,
+       versioning, permissions. Nothing is duplicated; bytes stream via the existing /media route.)
+
+    - AIAgent gains DefaultMediaCollectionID (FK -> Collection): the agent's default media kit. A
+      per-session runtime override (supplied by the calling app, e.g. a Praxis Protocol) takes
+      precedence; when neither is set the agent simply has no kit and the call-time Media_ShowMedia
+      tool still works for ad-hoc media.
+----------------------------------------------------------------------------------------------------*/
+
+/*--------------------------------------------------------------------------------------------------
+  1. CollectionArtifact — agent-facing media metadata (per-membership; Sequence already exists)
+--------------------------------------------------------------------------------------------------*/
+ALTER TABLE ${flyway:defaultSchema}.CollectionArtifact ADD
+    ContextDescription NVARCHAR(MAX) NULL,
+    Preload BIT NOT NULL CONSTRAINT DF_CollectionArtifact_Preload DEFAULT (0);
+GO
+
+EXEC sp_addextendedproperty
+    @name = N'MS_Description',
+    @value = N'Agent-facing description of what this media item is and WHEN to show it during a conversation. Read by a realtime agent (alongside the artifact''s own name/type) to decide autonomously whether/when to surface the item. Per-membership: the same artifact can carry different guidance in different Collections (media kits).',
+    @level0type = N'SCHEMA', @level0name = N'${flyway:defaultSchema}',
+    @level1type = N'TABLE',  @level1name = N'CollectionArtifact',
+    @level2type = N'COLUMN', @level2name = N'ContextDescription';
+
+EXEC sp_addextendedproperty
+    @name = N'MS_Description',
+    @value = N'Eager-load hint for a realtime media kit: when 1, the agent is told to show / the client to prefetch this item at session start rather than waiting until it is contextually relevant. Default 0 (lazy — surfaced only when the agent chooses).',
+    @level0type = N'SCHEMA', @level0name = N'${flyway:defaultSchema}',
+    @level1type = N'TABLE',  @level1name = N'CollectionArtifact',
+    @level2type = N'COLUMN', @level2name = N'Preload';
+GO
+
+/*--------------------------------------------------------------------------------------------------
+  2. AIAgent — default media kit binding (a Collection used as the agent's media library)
+--------------------------------------------------------------------------------------------------*/
+ALTER TABLE ${flyway:defaultSchema}.AIAgent ADD
+    DefaultMediaCollectionID UNIQUEIDENTIFIER NULL;
+GO
+
+ALTER TABLE ${flyway:defaultSchema}.AIAgent
+    ADD CONSTRAINT FK_AIAgent_DefaultMediaCollection
+        FOREIGN KEY (DefaultMediaCollectionID) REFERENCES ${flyway:defaultSchema}.Collection(ID);
+GO
+
+EXEC sp_addextendedproperty
+    @name = N'MS_Description',
+    @value = N'OPTIONAL default media kit for this agent: a Collection of Artifacts the agent may show on the realtime Media channel during a conversation. Resolved per session as runtime-override > this agent default > none. When set, the agent is given a manifest (each item''s display name, media type, when-to-show ContextDescription and Preload flag) so it can surface items via the Media_ShowMedia tool. When NULL the agent has no curated kit (ad-hoc Media_ShowMedia still works).',
+    @level0type = N'SCHEMA', @level0name = N'${flyway:defaultSchema}',
+    @level1type = N'TABLE',  @level1name = N'AIAgent',
+    @level2type = N'COLUMN', @level2name = N'DefaultMediaCollectionID';
+GO

--- a/packages/AI/Agents/src/__tests__/agent-media-library.test.ts
+++ b/packages/AI/Agents/src/__tests__/agent-media-library.test.ts
@@ -1,0 +1,167 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { IMetadataProvider, UserInfo } from '@memberjunction/core';
+
+// One RunView mock instance shared across the static FromMetadataProvider() the resolvers call.
+const runViewMock = vi.fn();
+vi.mock('@memberjunction/core', () => ({
+    RunView: class {
+        static FromMetadataProvider() {
+            return { RunView: runViewMock };
+        }
+    },
+    LogError: vi.fn(),
+}));
+// The resolvers import entity types for generics only (erased at runtime); stub the heavy module.
+vi.mock('@memberjunction/core-entities', () => ({}));
+
+import {
+    mediaTypeFromMimeType,
+    formatAgentMediaManifest,
+    resolveAgentMediaManifest,
+    resolveAgentMediaCollectionID,
+    buildAgentMediaContextNote,
+    type AgentMediaManifestItem,
+} from '../realtime/agent-media-library';
+
+const PROVIDER = {} as unknown as IMetadataProvider;
+const USER = { ID: 'user-1' } as unknown as UserInfo;
+
+beforeEach(() => {
+    runViewMock.mockReset();
+});
+
+describe('mediaTypeFromMimeType', () => {
+    it('maps each media family to its kind', () => {
+        expect(mediaTypeFromMimeType('image/png')).toBe('image');
+        expect(mediaTypeFromMimeType('video/mp4')).toBe('video');
+        expect(mediaTypeFromMimeType('audio/mpeg')).toBe('audio');
+        expect(mediaTypeFromMimeType('application/pdf')).toBe('pdf');
+        expect(mediaTypeFromMimeType('text/html')).toBe('web');
+    });
+
+    it('is case- and whitespace-insensitive', () => {
+        expect(mediaTypeFromMimeType('  IMAGE/PNG ')).toBe('image');
+    });
+
+    it('returns null for non-media / missing types', () => {
+        expect(mediaTypeFromMimeType('text/plain')).toBeNull();
+        expect(mediaTypeFromMimeType('')).toBeNull();
+        expect(mediaTypeFromMimeType(null)).toBeNull();
+        expect(mediaTypeFromMimeType(undefined)).toBeNull();
+    });
+});
+
+describe('formatAgentMediaManifest', () => {
+    it('returns null for an empty kit', () => {
+        expect(formatAgentMediaManifest([])).toBeNull();
+    });
+
+    it('numbers items, includes fileId + when-to-show + PRELOAD, and does not ask to read it aloud', () => {
+        const items: AgentMediaManifestItem[] = [
+            { ResourceID: 'r1', FileID: 'f1', MediaType: 'image', DisplayName: 'Q3 Chart', ContextDescription: 'Show when discussing Q3', Preload: true },
+            { ResourceID: 'r2', FileID: 'f2', MediaType: 'pdf', DisplayName: 'Brochure', ContextDescription: null, Preload: false },
+        ];
+        const note = formatAgentMediaManifest(items)!;
+        expect(note).toContain('Media_ShowMedia');
+        expect(note).toContain('1. "Q3 Chart" (image)');
+        expect(note).toContain('Show when discussing Q3');
+        expect(note).toContain('fileId: f1');
+        expect(note).toContain('[PRELOAD: show at the start of the call]');
+        expect(note).toContain('2. "Brochure" (pdf)');
+        expect(note).toContain('fileId: f2');
+        expect(note.toLowerCase()).toContain('do not read this list aloud');
+    });
+});
+
+describe('resolveAgentMediaCollectionID', () => {
+    it('prefers an explicit override and skips the agent lookup', async () => {
+        const id = await resolveAgentMediaCollectionID(PROVIDER, USER, 'agent-1', 'override-col');
+        expect(id).toBe('override-col');
+        expect(runViewMock).not.toHaveBeenCalled();
+    });
+
+    it('falls back to AIAgent.DefaultMediaCollectionID', async () => {
+        runViewMock.mockResolvedValueOnce({ Success: true, Results: [{ DefaultMediaCollectionID: 'agent-col' }] });
+        const id = await resolveAgentMediaCollectionID(PROVIDER, USER, 'agent-1');
+        expect(id).toBe('agent-col');
+    });
+
+    it('returns null when the agent is not found', async () => {
+        runViewMock.mockResolvedValueOnce({ Success: true, Results: [] });
+        expect(await resolveAgentMediaCollectionID(PROVIDER, USER, 'agent-1')).toBeNull();
+    });
+});
+
+describe('resolveAgentMediaManifest', () => {
+    it('orders by membership, maps fields, and falls back ContextDescription to the version description', async () => {
+        runViewMock
+            .mockResolvedValueOnce({
+                Success: true,
+                Results: [
+                    { ID: 'm1', ArtifactVersionID: 'v1', Sequence: 1, ContextDescription: 'Per-kit guidance', Preload: true },
+                    { ID: 'm2', ArtifactVersionID: 'v2', Sequence: 2, ContextDescription: null, Preload: false },
+                ],
+            })
+            .mockResolvedValueOnce({
+                Success: true,
+                Results: [
+                    { ID: 'v1', FileID: 'f1', MimeType: 'image/png', Name: 'Chart', Description: 'A chart' },
+                    { ID: 'v2', FileID: 'f2', MimeType: 'application/pdf', Name: 'Doc', Description: 'A doc' },
+                ],
+            });
+        const items = await resolveAgentMediaManifest(PROVIDER, USER, 'col-1');
+        expect(items).toHaveLength(2);
+        expect(items[0]).toMatchObject({ ResourceID: 'm1', FileID: 'f1', MediaType: 'image', DisplayName: 'Chart', ContextDescription: 'Per-kit guidance', Preload: true });
+        expect(items[1]).toMatchObject({ ResourceID: 'm2', FileID: 'f2', MediaType: 'pdf', ContextDescription: 'A doc', Preload: false });
+    });
+
+    it('drops memberships whose version has no FileID or a non-media MIME type', async () => {
+        runViewMock
+            .mockResolvedValueOnce({
+                Success: true,
+                Results: [
+                    { ID: 'm1', ArtifactVersionID: 'v1', Sequence: 1, ContextDescription: null, Preload: false },
+                    { ID: 'm2', ArtifactVersionID: 'v2', Sequence: 2, ContextDescription: null, Preload: false },
+                    { ID: 'm3', ArtifactVersionID: 'v3', Sequence: 3, ContextDescription: null, Preload: false },
+                ],
+            })
+            .mockResolvedValueOnce({
+                Success: true,
+                Results: [
+                    { ID: 'v1', FileID: null, MimeType: 'image/png', Name: 'NoFile', Description: '' }, // dropped: no FileID
+                    { ID: 'v2', FileID: 'f2', MimeType: 'text/plain', Name: 'TextArtifact', Description: '' }, // dropped: non-media
+                    { ID: 'v3', FileID: 'f3', MimeType: 'video/mp4', Name: 'Clip', Description: '' }, // kept
+                ],
+            });
+        const items = await resolveAgentMediaManifest(PROVIDER, USER, 'col-1');
+        expect(items).toHaveLength(1);
+        expect(items[0]).toMatchObject({ ResourceID: 'm3', FileID: 'f3', MediaType: 'video' });
+    });
+
+    it('returns [] for an empty collection', async () => {
+        runViewMock.mockResolvedValueOnce({ Success: true, Results: [] });
+        expect(await resolveAgentMediaManifest(PROVIDER, USER, 'col-1')).toEqual([]);
+    });
+});
+
+describe('buildAgentMediaContextNote', () => {
+    it('returns null when the agent has no kit', async () => {
+        runViewMock.mockResolvedValueOnce({ Success: true, Results: [{ DefaultMediaCollectionID: null }] });
+        expect(await buildAgentMediaContextNote(PROVIDER, USER, 'agent-1')).toBeNull();
+    });
+
+    it('builds a note end-to-end from the agent default kit', async () => {
+        runViewMock
+            .mockResolvedValueOnce({ Success: true, Results: [{ DefaultMediaCollectionID: 'col-1' }] }) // agent lookup
+            .mockResolvedValueOnce({ Success: true, Results: [{ ID: 'm1', ArtifactVersionID: 'v1', Sequence: 1, ContextDescription: 'When relevant', Preload: false }] }) // memberships
+            .mockResolvedValueOnce({ Success: true, Results: [{ ID: 'v1', FileID: 'f1', MimeType: 'image/png', Name: 'Chart', Description: '' }] }); // versions
+        const note = await buildAgentMediaContextNote(PROVIDER, USER, 'agent-1');
+        expect(note).toContain('"Chart" (image)');
+        expect(note).toContain('fileId: f1');
+    });
+
+    it('never throws — resolves to null on failure', async () => {
+        runViewMock.mockRejectedValueOnce(new Error('db down'));
+        expect(await buildAgentMediaContextNote(PROVIDER, USER, 'agent-1')).toBeNull();
+    });
+});

--- a/packages/AI/Agents/src/index.ts
+++ b/packages/AI/Agents/src/index.ts
@@ -60,6 +60,8 @@ export * from './realtime/whiteboard-channel-server';
 export * from './realtime/meeting-controls-state';
 export * from './realtime/meeting-controls-channel-server';
 export * from './realtime/media-channel-server';
+export * from './realtime/realtime-channel-server-data-context';
+export * from './realtime/agent-media-library';
 export * from './realtime/realtime-recording-capture';
 export * from './realtime/realtime-recording-store';
 

--- a/packages/AI/Agents/src/realtime/agent-media-library.ts
+++ b/packages/AI/Agents/src/realtime/agent-media-library.ts
@@ -1,0 +1,205 @@
+/**
+ * @fileoverview Resolves an agent's curated **media kit** — a `MJ: Collections` of `MJ: Artifacts`
+ * bound to the agent (or supplied as a per-session override) — into a compact, model-readable
+ * manifest the realtime agent reasons over to decide what to show on the Media channel.
+ *
+ * Design: a Collection IS the kit; each `MJ: Collection Artifacts` membership row carries the
+ * per-kit `Sequence` (priority), `ContextDescription` (agent "when to show it") and `Preload`
+ * (eager hint). The artifact's current version supplies the actual media (`FileID` -> `MJ: Files`,
+ * `MimeType`, display name). We add NO new top-level entity — the agent reuses the existing
+ * `Media_ShowMedia({ fileId, mediaType, displayName })` client tool to surface a chosen item, which
+ * streams through the authenticated `/media` route. Nothing here duplicates `MJ: Files`.
+ *
+ * Pure helpers ({@link mediaTypeFromMimeType}, {@link formatAgentMediaManifest}) are exported for
+ * unit testing; the DB-touching resolvers accept an explicit `provider` + `contextUser` so they are
+ * multi-provider safe and mockable.
+ *
+ * @module @memberjunction/ai-agents
+ * @author MemberJunction.com
+ */
+
+import { IMetadataProvider, RunView, UserInfo, LogError } from '@memberjunction/core';
+import { MJCollectionArtifactEntity, MJArtifactVersionEntity, MJAIAgentEntity } from '@memberjunction/core-entities';
+
+/** The media kinds the realtime Media channel can render (mirrors the client `Media_ShowMedia` enum). */
+export type AgentMediaKind = 'image' | 'video' | 'audio' | 'pdf' | 'web';
+
+/** One resolved, model-readable media item in an agent's kit (ordered by its membership `Sequence`). */
+export interface AgentMediaManifestItem {
+    /** The `MJ: Collection Artifacts` membership id (stable per kit). */
+    ResourceID: string;
+    /** The `MJ: Files` id to show — streamed securely via the `/media` route by `Media_ShowMedia`. */
+    FileID: string;
+    /** The media kind derived from the artifact version's MIME type. */
+    MediaType: AgentMediaKind;
+    /** Short label for the item's tab (the artifact version's name). */
+    DisplayName: string;
+    /** Agent-facing "what this is / when to show it" (membership override, else the version description). */
+    ContextDescription: string | null;
+    /** When true, the agent is told to show this at session start rather than waiting for relevance. */
+    Preload: boolean;
+}
+
+/**
+ * Maps an artifact version's MIME type to a Media-channel kind. Returns `null` for types the Media
+ * surface can't render as media (so the caller drops the item from the kit).
+ */
+export function mediaTypeFromMimeType(mimeType: string | null | undefined): AgentMediaKind | null {
+    const mime = (mimeType ?? '').trim().toLowerCase();
+    if (mime.startsWith('image/')) return 'image';
+    if (mime.startsWith('video/')) return 'video';
+    if (mime.startsWith('audio/')) return 'audio';
+    if (mime === 'application/pdf') return 'pdf';
+    if (mime === 'text/html' || mime === 'application/xhtml+xml') return 'web';
+    return null;
+}
+
+/**
+ * Resolves the Collection id that is the agent's media kit for this session:
+ * `override > AIAgent.DefaultMediaCollectionID > null`.
+ */
+export async function resolveAgentMediaCollectionID(
+    provider: IMetadataProvider,
+    contextUser: UserInfo,
+    agentID: string,
+    overrideCollectionID?: string | null,
+): Promise<string | null> {
+    if (overrideCollectionID) {
+        return overrideCollectionID;
+    }
+    const rv = RunView.FromMetadataProvider(provider);
+    const result = await rv.RunView<MJAIAgentEntity>(
+        { EntityName: 'AI Agents', ExtraFilter: `ID='${agentID}'`, ResultType: 'entity_object' },
+        contextUser,
+    );
+    if (!result.Success || result.Results.length === 0) {
+        return null;
+    }
+    return result.Results[0].DefaultMediaCollectionID ?? null;
+}
+
+/**
+ * Loads a Collection's artifacts (ordered by membership `Sequence`) and resolves each to a media
+ * manifest item, dropping memberships whose current version has no `FileID` or a non-media MIME type.
+ */
+export async function resolveAgentMediaManifest(
+    provider: IMetadataProvider,
+    contextUser: UserInfo,
+    collectionID: string,
+): Promise<AgentMediaManifestItem[]> {
+    const rv = RunView.FromMetadataProvider(provider);
+    const memberships = await rv.RunView<MJCollectionArtifactEntity>(
+        {
+            EntityName: 'MJ: Collection Artifacts',
+            ExtraFilter: `CollectionID='${collectionID}'`,
+            OrderBy: 'Sequence ASC',
+            ResultType: 'entity_object',
+        },
+        contextUser,
+    );
+    if (!memberships.Success || memberships.Results.length === 0) {
+        return [];
+    }
+
+    const versionsByID = await loadArtifactVersions(rv, contextUser, memberships.Results.map((m) => m.ArtifactVersionID));
+    const items: AgentMediaManifestItem[] = [];
+    for (const membership of memberships.Results) {
+        const item = toManifestItem(membership, versionsByID.get(membership.ArtifactVersionID));
+        if (item) {
+            items.push(item);
+        }
+    }
+    return items;
+}
+
+/** Loads the artifact versions referenced by a kit's memberships, keyed by id. */
+async function loadArtifactVersions(
+    rv: RunView,
+    contextUser: UserInfo,
+    versionIDs: string[],
+): Promise<Map<string, MJArtifactVersionEntity>> {
+    const byID = new Map<string, MJArtifactVersionEntity>();
+    const uniqueIDs = [...new Set(versionIDs.filter((id) => !!id))];
+    if (uniqueIDs.length === 0) {
+        return byID;
+    }
+    const inList = uniqueIDs.map((id) => `'${id}'`).join(',');
+    const result = await rv.RunView<MJArtifactVersionEntity>(
+        { EntityName: 'MJ: Artifact Versions', ExtraFilter: `ID IN (${inList})`, ResultType: 'entity_object' },
+        contextUser,
+    );
+    if (result.Success) {
+        for (const version of result.Results) {
+            byID.set(version.ID, version);
+        }
+    }
+    return byID;
+}
+
+/** Resolves one membership + its artifact version to a manifest item, or `null` if not showable. */
+function toManifestItem(
+    membership: MJCollectionArtifactEntity,
+    version: MJArtifactVersionEntity | undefined,
+): AgentMediaManifestItem | null {
+    if (!version || !version.FileID) {
+        return null; // text-only / unresolved versions can't be shown as media
+    }
+    const mediaType = mediaTypeFromMimeType(version.MimeType);
+    if (!mediaType) {
+        return null; // non-media MIME type — drop from the kit
+    }
+    return {
+        ResourceID: membership.ID,
+        FileID: version.FileID,
+        MediaType: mediaType,
+        DisplayName: version.Name?.trim() || 'Media',
+        ContextDescription: membership.ContextDescription?.trim() || version.Description?.trim() || null,
+        Preload: !!membership.Preload,
+    };
+}
+
+/**
+ * Formats a media manifest into a single background context note for the realtime agent. Lists each
+ * item with its `fileId`, media type, display name and when-to-show guidance, and instructs the agent
+ * to surface items with the existing `Media_ShowMedia` tool. Returns `null` for an empty manifest.
+ */
+export function formatAgentMediaManifest(items: AgentMediaManifestItem[]): string | null {
+    if (items.length === 0) {
+        return null;
+    }
+    const lines = items.map((item, index) => {
+        const when = item.ContextDescription ? ` — ${item.ContextDescription}` : '';
+        const preload = item.Preload ? ' [PRELOAD: show at the start of the call]' : '';
+        return `${index + 1}. "${item.DisplayName}" (${item.MediaType})${when} fileId: ${item.FileID}${preload}`;
+    });
+    return (
+        '[media-library] You have a curated media kit you can show on the shared Media surface during this call. ' +
+        'To show an item, call Media_ShowMedia with its fileId, mediaType and displayName. Show an item only when ' +
+        'it is relevant (or now, if it is marked PRELOAD). Do NOT read this list aloud. Available items, in priority order:\n' +
+        lines.join('\n')
+    );
+}
+
+/**
+ * End-to-end: resolves the agent's media kit (override > agent default) and returns the formatted
+ * agent context note, or `null` when there is no kit / no showable items. Best-effort: logs and
+ * returns `null` on any failure so it can never break session start.
+ */
+export async function buildAgentMediaContextNote(
+    provider: IMetadataProvider,
+    contextUser: UserInfo,
+    agentID: string,
+    overrideCollectionID?: string | null,
+): Promise<string | null> {
+    try {
+        const collectionID = await resolveAgentMediaCollectionID(provider, contextUser, agentID, overrideCollectionID);
+        if (!collectionID) {
+            return null;
+        }
+        const items = await resolveAgentMediaManifest(provider, contextUser, collectionID);
+        return formatAgentMediaManifest(items);
+    } catch (error) {
+        LogError(`[agent-media-library] Failed to build media manifest for agent ${agentID}: ${error instanceof Error ? error.message : String(error)}`);
+        return null;
+    }
+}

--- a/packages/AI/Agents/src/realtime/media-channel-server.ts
+++ b/packages/AI/Agents/src/realtime/media-channel-server.ts
@@ -18,7 +18,9 @@
 
 import { BaseRealtimeChannelServer } from '@memberjunction/ai';
 import { RegisterClass } from '@memberjunction/global';
-import { LogError } from '@memberjunction/core';
+import { IMetadataProvider, LogError, UserInfo } from '@memberjunction/core';
+import { IRealtimeChannelServerDataAware } from './realtime-channel-server-data-context';
+import { buildAgentMediaContextNote } from './agent-media-library';
 
 /**
  * Server half of the Media interactive channel. One instance per realtime session (created by
@@ -31,10 +33,46 @@ import { LogError } from '@memberjunction/core';
  *    flag-don't-drop is the safe posture, matching `WhiteboardChannelServer`).
  */
 @RegisterClass(BaseRealtimeChannelServer, 'MediaChannelServer')
-export class MediaChannelServer extends BaseRealtimeChannelServer {
+export class MediaChannelServer extends BaseRealtimeChannelServer implements IRealtimeChannelServerDataAware {
+    /** The session's data context, handed over by the host before {@link OnSessionStarted}. */
+    private sessionContextUser: UserInfo | null = null;
+    private sessionProvider: IMetadataProvider | null = null;
+
     /** Matches the seeded `MJ: AI Agent Channels` row's `Name`. */
     public get ChannelName(): string {
         return 'Media';
+    }
+
+    /**
+     * Receives the session's MJ data context from the host (between `Initialize` and
+     * `OnSessionStarted`) — used by {@link OnSessionStarted} to resolve the agent's media kit.
+     */
+    public SetSessionDataContext(contextUser: UserInfo, provider: IMetadataProvider): void {
+        this.sessionContextUser = contextUser;
+        this.sessionProvider = provider;
+    }
+
+    /**
+     * Resolves the agent's curated media kit (a bound `MJ: Collections` of artifacts) into a manifest
+     * and feeds it to the live model as a background context note, so the agent knows what it can show
+     * (and surfaces items via the existing `Media_ShowMedia` tool). Best-effort: any failure is logged
+     * and the session proceeds with no kit (the host also wraps this in try/catch).
+     */
+    public override async OnSessionStarted(): Promise<void> {
+        const agentID = this.Context?.AgentID;
+        if (!agentID || !this.sessionContextUser || !this.sessionProvider) {
+            return; // no agent / data context — nothing to resolve (ad-hoc Media_ShowMedia still works)
+        }
+        const note = await buildAgentMediaContextNote(this.sessionProvider, this.sessionContextUser, agentID);
+        if (note) {
+            this.Context?.SendContextNote?.(note);
+        }
+    }
+
+    public override Dispose(): void {
+        this.sessionContextUser = null;
+        this.sessionProvider = null;
+        super.Dispose();
     }
 
     /**

--- a/packages/AI/Agents/src/realtime/realtime-channel-server-data-context.ts
+++ b/packages/AI/Agents/src/realtime/realtime-channel-server-data-context.ts
@@ -1,0 +1,50 @@
+/**
+ * @fileoverview Optional capability a server-side realtime channel plugin can implement when it
+ * needs MJ data access (a `UserInfo` + `IMetadataProvider`) to do its session-start work.
+ *
+ * The base {@link import('@memberjunction/ai').BaseRealtimeChannelServer} contract is deliberately
+ * core-free (plain string ids only, "zero MJ dependencies past `@memberjunction/global`"), so it
+ * cannot carry `UserInfo` / `IMetadataProvider` on its lifecycle hooks. Most server channels only
+ * validate persisted state and never touch the DB. A channel that DOES need to query MJ at session
+ * start (e.g. the Media channel resolving an agent's media kit) implements this interface; the
+ * per-session host ({@link import('./realtime-channel-server-host').RealtimeChannelServerHost})
+ * detects it right after `Initialize(ctx)` and hands over the session's `contextUser` + `provider`
+ * BEFORE calling `OnSessionStarted()`.
+ *
+ * @module @memberjunction/ai-agents
+ * @author MemberJunction.com
+ */
+
+import { IMetadataProvider, UserInfo } from '@memberjunction/core';
+
+/**
+ * Implemented by server-side channel plugins that need MJ data access for their session-start work.
+ * The host calls {@link SetSessionDataContext} once, after `Initialize(ctx)` and before
+ * `OnSessionStarted()`, with the SAME `contextUser` + `provider` the session authenticated on.
+ */
+export interface IRealtimeChannelServerDataAware {
+    /**
+     * Hands the channel the session's MJ data context. Called exactly once per session by the host
+     * between `Initialize(ctx)` and `OnSessionStarted()`. Implementations should just stash the
+     * values for use in their own `OnSessionStarted()`.
+     *
+     * @param contextUser The user the realtime session is running as (for `RunView` / entity loads).
+     * @param provider The metadata provider the session authenticated on (multi-provider safe).
+     */
+    SetSessionDataContext(contextUser: UserInfo, provider: IMetadataProvider): void;
+}
+
+/**
+ * Structural type-guard the host uses to decide whether a resolved server channel plugin wants the
+ * session data context. Keeps the host decoupled from any concrete channel class.
+ *
+ * @param plugin The resolved server channel plugin (typed as the core-free base by the host).
+ * @returns `true` when the plugin implements {@link IRealtimeChannelServerDataAware}.
+ */
+export function isRealtimeChannelServerDataAware(plugin: unknown): plugin is IRealtimeChannelServerDataAware {
+    return (
+        typeof plugin === 'object' &&
+        plugin !== null &&
+        typeof (plugin as IRealtimeChannelServerDataAware).SetSessionDataContext === 'function'
+    );
+}

--- a/packages/AI/Agents/src/realtime/realtime-channel-server-host.ts
+++ b/packages/AI/Agents/src/realtime/realtime-channel-server-host.ts
@@ -36,6 +36,7 @@ import {
 import { BaseSingleton, MJGlobal } from '@memberjunction/global';
 import { IMetadataProvider, UserInfo, LogError, LogStatus } from '@memberjunction/core';
 import { AIEngineBase } from '@memberjunction/ai-engine-base';
+import { isRealtimeChannelServerDataAware } from './realtime-channel-server-data-context';
 
 /** Entity name — kept in sync with the session machinery's `MJ:`-prefix convention. */
 const CHANNEL_ENTITY = 'MJ: AI Agent Channels';
@@ -239,7 +240,7 @@ export class RealtimeChannelServerHost extends BaseSingleton<RealtimeChannelServ
                 return;
             }
             const rows = await this.fetchChannelDefinitions(contextUser, provider);
-            const plugins = await this.instantiateSessionPlugins(rows, ctx);
+            const plugins = await this.instantiateSessionPlugins(rows, ctx, contextUser, provider);
             if (plugins.size > 0) {
                 this.sessions.set(key, { plugins, disposeTimer: null });
             }
@@ -363,6 +364,8 @@ export class RealtimeChannelServerHost extends BaseSingleton<RealtimeChannelServ
     private async instantiateSessionPlugins(
         rows: RealtimeChannelServerDefinitionRow[],
         ctx: RealtimeChannelServerContext,
+        contextUser: UserInfo,
+        provider: IMetadataProvider,
     ): Promise<Map<string, BaseRealtimeChannelServer>> {
         const plugins = new Map<string, BaseRealtimeChannelServer>();
         for (const row of rows) {
@@ -372,6 +375,11 @@ export class RealtimeChannelServerHost extends BaseSingleton<RealtimeChannelServ
             }
             try {
                 plugin.Initialize(ctx);
+                // Hand the session's MJ data context to channels that need DB access at start
+                // (e.g. the Media channel resolving an agent's media kit), BEFORE OnSessionStarted.
+                if (isRealtimeChannelServerDataAware(plugin)) {
+                    plugin.SetSessionDataContext(contextUser, provider);
+                }
                 await plugin.OnSessionStarted();
                 plugins.set(this.channelKey(row.Name), plugin);
             } catch (error) {

--- a/plans/praxis/AGENT_MEDIA_LIBRARY_PLAN.md
+++ b/plans/praxis/AGENT_MEDIA_LIBRARY_PLAN.md
@@ -1,0 +1,94 @@
+# Agent Media Library — MJ-core Plan
+
+> **Scope:** A small, additive MJ-core capability that lets a realtime agent draw on a **curated,
+> governed media kit** during a conversation, by **reusing the existing Artifacts + Collections
+> stack** instead of a bespoke media-resource entity. This is a follow-up to the Media channel (S1)
+> shipped in [PR #2941](https://github.com/MemberJunction/MJ/pull/2941) and targets **MJ 5.44**.
+>
+> Origin: while standing up **Praxis** (`bizapps-praxis`), we found the planned `AIAgentResource`
+> entity was descoped from PR #2941 — media is currently only ever supplied ad-hoc at call-time
+> (`Media_ShowMedia({ url | fileId })`), with no persisted, model-reasoned catalog. Rather than
+> reintroduce a parallel entity that would duplicate `MJ: Files` + Artifacts + Collections (storage,
+> MIME, versioning, viewers, permissions, grouping), we add the **two missing fields** + a binding.
+
+## Decision (locked)
+
+- **Model:** a `MJ: Collections` of `MJ: Artifacts` **is** an agent's media kit. The artifact (+ its
+  current version) describes the media (`FileID → MJ: Files`, `MimeType`, name, viewer, versioning,
+  permissions). Nothing is duplicated; bytes stream via the existing authenticated `/media` route.
+- **Agent-reasoning metadata lives on the membership** (`MJ: Collection Artifacts`), per-kit, so the
+  same artifact can be framed differently in different kits. `Sequence` (priority/order) already
+  exists; we add `ContextDescription` (agent "when to show it") + `Preload` (eager hint).
+- **Binding:** `AIAgent.DefaultMediaCollectionID` (FK → `MJ: Collections`) is the agent's default
+  kit. Per-session resolution is `runtime override > agent default > none`. The call-time
+  `Media_ShowMedia` tool is unchanged and still works for ad-hoc media.
+- **No new top-level entity.** `AIAgentResource` is **not** built — this decision supersedes it.
+
+## What ships
+
+### 1. Migration (additive) — `migrations/v5/V202606271600__v5.44.x__Agent_Media_Library.sql`
+- `CollectionArtifact` ADD `ContextDescription NVARCHAR(MAX) NULL`, `Preload BIT NOT NULL DEFAULT 0`.
+- `AIAgent` ADD `DefaultMediaCollectionID UNIQUEIDENTIFIER NULL` + FK → `Collection(ID)`.
+- Extended properties on all three columns. CodeGen then regenerates the entity types.
+
+### 2. Resolver (reusable, unit-tested) — `packages/AI/Agents/src/realtime/agent-media-library.ts`
+- `mediaTypeFromMimeType(mime)` — MIME → `image|video|audio|pdf|web|null` (pure).
+- `resolveAgentMediaCollectionID(provider, user, agentID, override?)` — `override > AIAgent default`.
+- `resolveAgentMediaManifest(provider, user, collectionID)` — loads memberships (ordered by
+  `Sequence`) + their artifact versions, drops items with no `FileID` or a non-media MIME, returns an
+  ordered `AgentMediaManifestItem[]` (`{ ResourceID, FileID, MediaType, DisplayName,
+  ContextDescription, Preload }`).
+- `formatAgentMediaManifest(items)` — one background context note listing each item's `fileId`,
+  type, display name, when-to-show + PRELOAD marker, instructing the agent to use `Media_ShowMedia`
+  (pure).
+- `buildAgentMediaContextNote(...)` — end-to-end orchestrator; best-effort (logs + returns `null`).
+
+### 3. Channel wiring — server-side, no new client tool
+- `realtime-channel-server-data-context.ts` — `IRealtimeChannelServerDataAware` + a type guard. The
+  core-free base channel can't carry `UserInfo`/`IMetadataProvider`; a channel that needs DB access
+  at start implements this and the host hands over the session's `contextUser` + `provider`.
+- `RealtimeChannelServerHost.instantiateSessionPlugins(...)` — now threads `contextUser` + `provider`
+  and calls `SetSessionDataContext(...)` on data-aware plugins between `Initialize` and
+  `OnSessionStarted` (backward compatible; other channels are untouched).
+- `MediaChannelServer` — implements `IRealtimeChannelServerDataAware`; `OnSessionStarted()` resolves
+  the agent's kit → `SendContextNote(manifest)`. The agent then surfaces items with the **existing**
+  `Media_ShowMedia({ fileId, mediaType, displayName })` client tool — no new tool, no client
+  round-trips, no client changes.
+
+### 4. Tests — `packages/AI/Agents/src/__tests__/agent-media-library.test.ts`
+MIME mapping, manifest ordering/mapping/fallbacks, FileID/non-media filtering, override-vs-default
+resolution, end-to-end note, and fail-closed behavior.
+
+### 5. Docs
+- This plan. A "Media Library" section appended to `guides/REALTIME_CO_AGENTS_GUIDE.md`.
+- A `minor` changeset for `@memberjunction/ai-agents`.
+
+## Tasks
+
+- [x] **T1 — Migration** authored (additive; CollectionArtifact + AIAgent). <!-- @2026-06-27 -->
+- [x] **T2 — Resolver/formatter** (`agent-media-library.ts`) written against post-CodeGen types. <!-- @2026-06-27 -->
+- [x] **T3 — Channel wiring** (data-context capability + host handoff + `MediaChannelServer.OnSessionStarted`). <!-- @2026-06-27 -->
+- [x] **T4 — Unit tests** for the resolver/formatter. <!-- @2026-06-27 -->
+- [x] **T5 — Docs + changeset.** <!-- @2026-06-27 -->
+- [ ] **T6 — Run migration + CodeGen locally, build `@memberjunction/ai-agents`, run its tests.** Done
+  by a maintainer who can reach the DB (the code is written assuming CodeGen has produced
+  `MJCollectionArtifactEntity.ContextDescription/.Preload` and `MJAIAgentEntity.DefaultMediaCollectionID`).
+- [ ] **T7 — Per-session runtime override delivery (follow-up).** The resolver already accepts an
+  `overrideCollectionID`; wiring the *source* of that override (the calling app — e.g. a Praxis
+  Protocol — supplying a per-session collection at session start, likely via the Media channel's
+  session config) is a thin follow-up. Until then, the agent default (`DefaultMediaCollectionID`)
+  fully covers the common case (one kit per protocol-bound agent).
+
+## Acceptance
+- ☐ Migration applies cleanly; CodeGen regenerates the three new typed props.
+- ☐ `@memberjunction/ai-agents` builds; `agent-media-library` tests pass.
+- ☐ A realtime session whose agent has a `DefaultMediaCollectionID` receives a media-kit context note
+  at start and can show kit items via `Media_ShowMedia`.
+- ☐ An agent with no kit is unaffected (ad-hoc `Media_ShowMedia` still works).
+
+## Notes
+- **Why server-side resolution:** the client channel context has no `AgentID`; the server channel
+  context does (`+UserID`, `+SendContextNote`). Resolving the kit where the agent + user are known,
+  then injecting a manifest the model reasons over, is the minimal correct seam.
+- **Security:** kit `fileId`s are deployment-curated; playback is still permission-gated at token
+  mint (`CreateMediaAccessToken` checks the session user) and streamed via `/media`.


### PR DESCRIPTION
## What this delivers

Lets a realtime agent draw on a **curated, governed media kit** during a conversation — by **reusing the existing Artifacts + Collections stack** instead of a bespoke media-resource entity. This **supersedes the descoped `AIAgentResource`** concept (found missing while standing up the Praxis OpenApp): media was previously only ever supplied ad-hoc at call-time (`Media_ShowMedia({ url | fileId })`), with no persisted, model-reasoned catalog.

Additive only, targets **5.44**, and reuses `MJ: Files` + Artifacts + Collections (storage, MIME, viewers, versioning, permissions, grouping) — **no new top-level entity**.

## The model

- A **`MJ: Collections` of `MJ: Artifacts` IS the agent's media kit.** The artifact (+ current version) describes the media (`FileID → MJ: Files`, `MimeType`, name, viewer, versioning, permissions). Bytes stream through the existing authenticated `/media` route. Nothing is duplicated.
- **Agent-reasoning metadata lives per-membership** on `MJ: Collection Artifacts`: `Sequence` (priority, pre-existing) + new **`ContextDescription`** (agent "when to show it") + **`Preload`** (eager hint). Per-membership ⇒ the same artifact can be framed differently in different kits.
- **Binding:** new `AIAgent.DefaultMediaCollectionID` (FK → `Collection`). Per-session resolution is `runtime override > agent default > none`; ad-hoc `Media_ShowMedia` still works for an agent with no kit.

## Changes

- **Migration** (`migrations/v5/V202606271600__v5.44.x__Agent_Media_Library.sql`, additive): `CollectionArtifact` +`ContextDescription`/+`Preload`; `AIAgent` +`DefaultMediaCollectionID` FK. Extended properties on all three.
- **Resolver** (`packages/AI/Agents/src/realtime/agent-media-library.ts`, reusable + unit-tested): MIME→media-kind, collection resolution (override > agent default), ordered manifest build (drops items with no `FileID` / non-media MIME), and the agent context-note formatter.
- **Channel wiring** (server-side, no new client tool): `IRealtimeChannelServerDataAware` lets a data-aware server channel receive the session `contextUser`+`provider` (the core-free base can't carry them); `RealtimeChannelServerHost` hands them over between `Initialize` and `OnSessionStarted` (backward compatible). `MediaChannelServer.OnSessionStarted()` resolves the kit and `SendContextNote`s a manifest — the agent surfaces items via the **existing** `Media_ShowMedia({ fileId, mediaType, displayName })` tool (no client changes, no round-trips).
- **Tests** (`agent-media-library.test.ts`), a **guide** section in `REALTIME_CO_AGENTS_GUIDE.md`, the plan `plans/praxis/AGENT_MEDIA_LIBRARY_PLAN.md`, and a `minor` changeset for `@memberjunction/ai-agents`.

## ⚠️ Needs migration + CodeGen before it compiles

The TypeScript is written against the **post-CodeGen** typed props (`MJCollectionArtifactEntity.ContextDescription`/`.Preload`, `MJAIAgentEntity.DefaultMediaCollectionID`). Run the migration + `mj codegen`, then build `@memberjunction/ai-agents` and run its tests (`agent-media-library.test.ts`). The schema change drives a CodeGen run that will append generated SQL/entities as usual.

## Follow-up (not blocking)

Per-session **runtime override delivery**: the resolver already accepts an `overrideCollectionID`; wiring the *source* (the calling app — e.g. a Praxis Protocol — passing a per-session kit) is a thin follow-up. The agent default covers the common case (one kit per protocol-bound agent) today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_011scEcafpLPLLzTHmmV8ZMu)_