### PR TITLE
ci: exclude docs/ and plans/ dirs from UI color/button gates

### DIFF
--- a/.changeset/ui-gates-skip-docs-plans.md
+++ b/.changeset/ui-gates-skip-docs-plans.md
@@ -1,0 +1,12 @@
+---
+---
+
+ci: exclude `docs/` and `plans/` directories from the UI color/button gates
+
+The hardcoded-color and `.mj-btn`-override CI gates scanned the whole repo for
+`.css`/`.scss` files (filtering only `node_modules` and `dist`), so mockup,
+prototype, and documentation stylesheets under `plans/` (and any `docs/` dir)
+were eligible to be flagged even though they are not shipped component styles.
+Both gates now skip any `.css`/`.scss` under a `docs/` or `plans/` path segment
+in their `diff` and `--all` modes. No published package is affected (tooling-only
+change), so this changeset is intentionally empty.

--- a/.changeset/ui-gates-skip-docs-plans.md
+++ b/.changeset/ui-gates-skip-docs-plans.md
@@ -1,12 +1,12 @@
 ---
 ---
 
-ci: exclude `docs/` and `plans/` directories from the UI color/button gates
+ci: exclude `docs/`, `plans/`, and `guides/` directories from the UI color/button gates
 
 The hardcoded-color and `.mj-btn`-override CI gates scanned the whole repo for
 `.css`/`.scss` files (filtering only `node_modules` and `dist`), so mockup,
-prototype, and documentation stylesheets under `plans/` (and any `docs/` dir)
+prototype, and documentation stylesheets under `plans/`, `docs/`, or `guides/`
 were eligible to be flagged even though they are not shipped component styles.
-Both gates now skip any `.css`/`.scss` under a `docs/` or `plans/` path segment
-in their `diff` and `--all` modes. No published package is affected (tooling-only
-change), so this changeset is intentionally empty.
+Both gates now skip any `.css`/`.scss` under a `docs/`, `plans/`, or `guides/`
+path segment in their `diff` and `--all` modes. No published package is affected
+(tooling-only change), so this changeset is intentionally empty.

--- a/.github/scripts/check-css-hex-tokens.sh
+++ b/.github/scripts/check-css-hex-tokens.sh
@@ -10,9 +10,9 @@
 # these are neutral black/white opacities used for shadows/overlays where
 # no semantic token equivalent exists.
 #
-# Files under any `docs/` or `plans/` directory are skipped entirely —
-# they hold mockups, prototypes, and documentation snippets, not shipped
-# component styles.
+# Files under any `docs/`, `plans/`, or `guides/` directory are skipped
+# entirely — they hold mockups, prototypes, and documentation snippets,
+# not shipped component styles.
 #
 # Usage:
 #   ./check-css-hex-tokens.sh                # check files changed vs origin/next
@@ -117,6 +117,7 @@ get_files_to_check() {
                 -not -path '*/dist/*' \
                 -not -path '*/docs/*' \
                 -not -path '*/plans/*' \
+                -not -path '*/guides/*' \
                 | sed "s|^$REPO_ROOT/||"
             ;;
         diff)
@@ -125,7 +126,7 @@ get_files_to_check() {
                 | grep -E '\.(css|scss)$' \
                 | grep -v node_modules \
                 | grep -v '/dist/' \
-                | grep -vE '(^|/)(docs|plans)/' \
+                | grep -vE '(^|/)(docs|plans|guides)/' \
                 || true
             ;;
     esac

--- a/.github/scripts/check-css-hex-tokens.sh
+++ b/.github/scripts/check-css-hex-tokens.sh
@@ -10,6 +10,10 @@
 # these are neutral black/white opacities used for shadows/overlays where
 # no semantic token equivalent exists.
 #
+# Files under any `docs/` or `plans/` directory are skipped entirely —
+# they hold mockups, prototypes, and documentation snippets, not shipped
+# component styles.
+#
 # Usage:
 #   ./check-css-hex-tokens.sh                # check files changed vs origin/next
 #   ./check-css-hex-tokens.sh --base <ref>   # check files changed vs <ref>
@@ -111,6 +115,8 @@ get_files_to_check() {
                 \( -name '*.css' -o -name '*.scss' \) \
                 -not -path '*/node_modules/*' \
                 -not -path '*/dist/*' \
+                -not -path '*/docs/*' \
+                -not -path '*/plans/*' \
                 | sed "s|^$REPO_ROOT/||"
             ;;
         diff)
@@ -119,6 +125,7 @@ get_files_to_check() {
                 | grep -E '\.(css|scss)$' \
                 | grep -v node_modules \
                 | grep -v '/dist/' \
+                | grep -vE '(^|/)(docs|plans)/' \
                 || true
             ;;
     esac

--- a/.github/scripts/check-mj-btn-override.sh
+++ b/.github/scripts/check-mj-btn-override.sh
@@ -6,9 +6,9 @@
 # stylesheet defines `.mj-btn` rules. The `mjButton` directive owns the
 # button's appearance — overrides silently fork the styling.
 #
-# Files under any `docs/` or `plans/` directory are skipped entirely —
-# they hold mockups, prototypes, and documentation snippets, not shipped
-# component styles.
+# Files under any `docs/`, `plans/`, or `guides/` directory are skipped
+# entirely — they hold mockups, prototypes, and documentation snippets,
+# not shipped component styles.
 #
 # Usage:
 #   ./check-mj-btn-override.sh                # check files changed vs origin/next
@@ -90,6 +90,7 @@ get_files_to_check() {
                 -not -path '*/dist/*' \
                 -not -path '*/docs/*' \
                 -not -path '*/plans/*' \
+                -not -path '*/guides/*' \
                 | sed "s|^$REPO_ROOT/||"
             ;;
         diff)
@@ -98,7 +99,7 @@ get_files_to_check() {
                 | grep -E '\.(css|scss)$' \
                 | grep -v node_modules \
                 | grep -v '/dist/' \
-                | grep -vE '(^|/)(docs|plans)/' \
+                | grep -vE '(^|/)(docs|plans|guides)/' \
                 || true
             ;;
     esac

--- a/.github/scripts/check-mj-btn-override.sh
+++ b/.github/scripts/check-mj-btn-override.sh
@@ -6,6 +6,10 @@
 # stylesheet defines `.mj-btn` rules. The `mjButton` directive owns the
 # button's appearance — overrides silently fork the styling.
 #
+# Files under any `docs/` or `plans/` directory are skipped entirely —
+# they hold mockups, prototypes, and documentation snippets, not shipped
+# component styles.
+#
 # Usage:
 #   ./check-mj-btn-override.sh                # check files changed vs origin/next
 #   ./check-mj-btn-override.sh --base <ref>   # check files changed vs <ref>
@@ -84,6 +88,8 @@ get_files_to_check() {
                 \( -name '*.css' -o -name '*.scss' \) \
                 -not -path '*/node_modules/*' \
                 -not -path '*/dist/*' \
+                -not -path '*/docs/*' \
+                -not -path '*/plans/*' \
                 | sed "s|^$REPO_ROOT/||"
             ;;
         diff)
@@ -92,6 +98,7 @@ get_files_to_check() {
                 | grep -E '\.(css|scss)$' \
                 | grep -v node_modules \
                 | grep -v '/dist/' \
+                | grep -vE '(^|/)(docs|plans)/' \
                 || true
             ;;
     esac


### PR DESCRIPTION
## What

The two UI consistency CI gates — hardcoded-color enforcement (`check-css-hex-tokens.sh`) and `.mj-btn`-override prevention (`check-mj-btn-override.sh`) — now skip any `.css`/`.scss` file under a `docs/` or `plans/` directory.

## Why

Both gates select files by scanning the whole repo for `.css`/`.scss`, filtering only `node_modules` and `dist`. That meant the mockup, prototype, and documentation stylesheets under `plans/` (and any `docs/` dir) were eligible to be flagged for hardcoded colors or `.mj-btn` overrides — even though they are illustrative artifacts, not shipped component styles. There are already 11 such files under `plans/` (mockups + a full Angular prototype), and any future doc/plan stylesheet would trip the gate on the PR that adds it.

## Change

- **`diff` mode** (the PR path): added `| grep -vE '(^|/)(docs|plans)/'` to the file selector.
- **`--all` mode** (whole-tree audit): added `-not -path '*/docs/*'` and `-not -path '*/plans/*'` to the `find`.
- **`--file` mode** is intentionally left unfiltered — pointing the checker at a single explicit path is a manual override.
- Updated each script's header comment to document the exclusion.

The `(^|/)(docs|plans)/` pattern matches a `docs`/`plans` segment at the repo root **or** nested inside a package (e.g. `packages/MJCore/docs/...`).

## Testing

- `bash -n` syntax check on both scripts — clean.
- Functional test with two deliberately-violating stylesheets (throwaway commit, then backed out):
  - `plans/_gate_test/bad.scss` (hex **+** `.mj-btn`) → **excluded**, not even selected. ✅
  - `scratch_gate_test/bad.scss` (hex, outside `plans/`) → **flagged** (`1 checked, 1 violation`). ✅

No published package is affected (tooling-only change), so the included changeset is intentionally empty.

🤖 Generated with [Claude Code](https://claude.com/claude-code)