### PR TITLE
fix(open-app): mj.config.cjs corruption — comma-terminate preceding property on section insert (#2975)

### DIFF
--- a/.changeset/fix-openapp-config-comma-2975.md
+++ b/.changeset/fix-openapp-config-comma-2975.md
@@ -1,0 +1,5 @@
+---
+"@memberjunction/open-app-engine": patch
+---
+
+Fix `mj app install` corrupting `mj.config.cjs` (#2975). When inserting a new top-level section (`dynamicPackages` / `entityPackageName`) before the closing brace of `module.exports = { ... }`, the preceding property is now comma-terminated, so a config whose last property is a brace-terminated block (e.g. `openApps: { ... }` with no trailing comma) stays valid JavaScript instead of breaking the next `require('mj.config.cjs')` (the `mj migrate` / `mj codegen` / build steps an install runs). The comma logic is string- and comment-aware so a `//` inside a value like `'http://x'` or braces inside strings are never miscounted. Additionally, every config write (all six add/remove/toggle functions) now passes through a post-write parse guard that compiles the result first and, on any malformed output, fails loudly with the file left untouched — so a bad edit can never silently ship a broken config.

--- a/packages/OpenApp/Engine/src/__tests__/config-manager-dynamic.test.ts
+++ b/packages/OpenApp/Engine/src/__tests__/config-manager-dynamic.test.ts
@@ -221,3 +221,33 @@ describe('Remove round-trip leaves valid JS', () => {
         expect(afterRemove).not.toContain('@mj-biz-apps/common-server');
     });
 });
+
+describe('Parse guard (#2975 safety net) — never silently writes a broken config', () => {
+    it('refuses to write and reports failure when string surgery would corrupt the config', () => {
+        // A regex literal containing `}` defeats the brace scanner (a limitation shared with the
+        // existing FindMatchingBracket): the insert lands mid-token and the result is invalid JS.
+        // The guard catches it, so the file is left UNTOUCHED rather than silently corrupted —
+        // turning any string-surgery brittleness into a loud, safe failure.
+        const exotic = [
+            'module.exports = {',
+            '  weird: /}/,',
+            '  openApps: { token: process.env.X }',
+            '};',
+            '',
+        ].join('\n');
+        setupConfigFile(exotic);
+
+        const result = AddServerDynamicPackages(REPO_ROOT, makeServerManifest());
+
+        expect(result.Success).toBe(false);
+        expect(result.ErrorMessage).toMatch(/invalid JavaScript|left unchanged/);
+        expect(mockedWriteFileSync).not.toHaveBeenCalled(); // file untouched on a bad edit
+    });
+
+    it('writes exactly once when the resulting config is valid', () => {
+        setupConfigFile(issueTemplateConfig());
+        const result = AddServerDynamicPackages(REPO_ROOT, makeServerManifest());
+        expect(result.Success).toBe(true);
+        expect(mockedWriteFileSync).toHaveBeenCalledTimes(1);
+    });
+});

--- a/packages/OpenApp/Engine/src/__tests__/config-manager-dynamic.test.ts
+++ b/packages/OpenApp/Engine/src/__tests__/config-manager-dynamic.test.ts
@@ -1,0 +1,223 @@
+/**
+ * Tests for the dynamicPackages / entityPackageName section INSERTION path in config-manager,
+ * focused on issue #2975: appending a new top-level section to mj.config.cjs must comma-terminate
+ * the preceding property, or the file becomes invalid JS and every later `require()` of it
+ * (mj migrate / codegen / build) throws `SyntaxError: Unexpected identifier`.
+ *
+ * Validity is asserted by compiling the written content with `new Function(src)` — construction
+ * throws SyntaxError on malformed JS without executing it (so `process.env` / `require` references
+ * are harmless).
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { resolve } from 'node:path';
+
+// ── Mock node:fs before importing the module under test ──────────────────
+vi.mock('node:fs', () => ({
+    readFileSync: vi.fn(),
+    writeFileSync: vi.fn(),
+    existsSync: vi.fn(),
+}));
+
+import { readFileSync, writeFileSync, existsSync } from 'node:fs';
+import {
+    AddServerDynamicPackages,
+    AddEntityPackageMapping,
+    RemoveServerDynamicPackages,
+} from '../install/config-manager.js';
+
+const mockedExistsSync = vi.mocked(existsSync);
+const mockedReadFileSync = vi.mocked(readFileSync);
+const mockedWriteFileSync = vi.mocked(writeFileSync);
+
+const REPO_ROOT = '/fake/repo';
+const CONFIG_PATH = resolve(REPO_ROOT, 'mj.config.cjs');
+
+// ── Helpers ──────────────────────────────────────────────────────────────
+
+/** Sets up mocks so the config file exists and has the given content. */
+function setupConfigFile(content: string): void {
+    mockedExistsSync.mockReturnValue(true);
+    mockedReadFileSync.mockReturnValue(content);
+}
+
+/** Returns the most-recent content string written via writeFileSync. */
+function writtenContent(): string {
+    expect(mockedWriteFileSync).toHaveBeenCalled();
+    const calls = mockedWriteFileSync.mock.calls;
+    return calls[calls.length - 1][1] as string;
+}
+
+/**
+ * Asserts that `src` is syntactically-valid JavaScript by compiling it. `new Function` throws
+ * a SyntaxError on malformed input at *construction* time without running the body — so the
+ * `module` / `process` / `require` references in a real mj.config.cjs never execute.
+ */
+function assertValidConfig(src: string): void {
+    // eslint-disable-next-line no-new-func
+    expect(() => new Function(src)).not.toThrow();
+}
+
+/**
+ * The exact #2975 template: the last top-level property is a brace-terminated block with NO
+ * trailing comma (the normal shape of a hand-written mj.config.cjs). Pre-fix, inserting a new
+ * section after `openApps` produced `}\n  dynamicPackages: {…}` — invalid JS.
+ */
+function issueTemplateConfig(): string {
+    return [
+        'module.exports = {',
+        '  openApps: {',
+        "    serverPackagePath: 'apps/MJAPI',",
+        "    clientPackagePath: 'apps/MJExplorer',",
+        '    github: { token: process.env.GITHUB_TOKEN }',
+        '  }',
+        '};',
+        '',
+    ].join('\n');
+}
+
+/** Minimal manifest with a server bootstrap package (mirrors bizapps-common's common-server). */
+function makeServerManifest(name = 'mj-bizapps-common') {
+    const manifest: Record<string, unknown> = {
+        name,
+        packages: {
+            server: [
+                { name: '@mj-biz-apps/common-server', role: 'bootstrap', startupExport: 'LoadBizAppsCommonServer' },
+            ],
+        },
+    };
+    return manifest as Parameters<typeof AddServerDynamicPackages>[1];
+}
+
+/** Minimal manifest with a schema + entities library (drives the entityPackageName insert). */
+function makeSchemaManifest(name = 'mj-bizapps-common', schemaName = '__mj_BizAppsCommon') {
+    const manifest: Record<string, unknown> = {
+        name,
+        schema: { name: schemaName },
+        packages: {
+            shared: [{ name: '@mj-biz-apps/common-entities', role: 'library' }],
+        },
+    };
+    return manifest as Parameters<typeof AddEntityPackageMapping>[1];
+}
+
+// ── Tests ────────────────────────────────────────────────────────────────
+
+beforeEach(() => {
+    vi.resetAllMocks();
+});
+
+describe('AddServerDynamicPackages — comma safety (#2975)', () => {
+    it('comma-terminates a brace-terminated last property before inserting dynamicPackages', () => {
+        setupConfigFile(issueTemplateConfig());
+
+        const result = AddServerDynamicPackages(REPO_ROOT, makeServerManifest());
+
+        expect(result.Success).toBe(true);
+        const written = writtenContent();
+        assertValidConfig(written); // pre-fix this was invalid JS
+        // openApps block is now comma-separated from the new section
+        expect(written).toMatch(/},\s*dynamicPackages\s*:/);
+        expect(written).toContain('dynamicPackages');
+        expect(written).toContain('@mj-biz-apps/common-server');
+        // the config file at CONFIG_PATH was the one written
+        expect(mockedWriteFileSync).toHaveBeenCalledWith(CONFIG_PATH, expect.any(String), 'utf-8');
+    });
+
+    it('inserts a comma after a string-valued last property without being fooled by // in the value', () => {
+        setupConfigFile(
+            ['module.exports = {', "  baseUrl: 'https://api.example.com'", '};', ''].join('\n'),
+        );
+
+        const result = AddServerDynamicPackages(REPO_ROOT, makeServerManifest());
+
+        expect(result.Success).toBe(true);
+        const written = writtenContent();
+        assertValidConfig(written);
+        // the closing quote got the comma; the `//` inside the URL was not treated as a comment
+        expect(written).toMatch(/'https:\/\/api\.example\.com',/);
+        expect(written).toContain('dynamicPackages');
+    });
+
+    it('is a no-op separator when the last property already ends with a comma', () => {
+        setupConfigFile(
+            ['module.exports = {', "  coreSchema: '__mj',", '};', ''].join('\n'),
+        );
+
+        const result = AddServerDynamicPackages(REPO_ROOT, makeServerManifest());
+
+        expect(result.Success).toBe(true);
+        const written = writtenContent();
+        assertValidConfig(written);
+        // no doubled comma introduced
+        expect(written).not.toMatch(/,\s*,/);
+    });
+
+    it('handles an empty module.exports object', () => {
+        setupConfigFile('module.exports = {};\n');
+
+        const result = AddServerDynamicPackages(REPO_ROOT, makeServerManifest());
+
+        expect(result.Success).toBe(true);
+        const written = writtenContent();
+        assertValidConfig(written);
+        expect(written).toContain('dynamicPackages');
+    });
+});
+
+describe('AddEntityPackageMapping — comma safety (#2975)', () => {
+    it('comma-terminates a brace-terminated last property before inserting entityPackageName', () => {
+        setupConfigFile(issueTemplateConfig());
+
+        const result = AddEntityPackageMapping(REPO_ROOT, makeSchemaManifest());
+
+        expect(result.Success).toBe(true);
+        const written = writtenContent();
+        assertValidConfig(written);
+        expect(written).toMatch(/},\s*entityPackageName\s*:/);
+        expect(written).toContain("'__mj_BizAppsCommon': '@mj-biz-apps/common-entities'");
+    });
+});
+
+describe('Full install config write (bizapps-common shape) stays valid JS', () => {
+    it('writes dynamicPackages then entityPackageName sequentially without corrupting the file', () => {
+        // Step 1: AddServerDynamicPackages (as HandleServerConfig does first)
+        setupConfigFile(issueTemplateConfig());
+        const r1 = AddServerDynamicPackages(REPO_ROOT, makeServerManifest());
+        expect(r1.Success).toBe(true);
+        const afterServer = writtenContent();
+        assertValidConfig(afterServer);
+
+        // Step 2: AddEntityPackageMapping reads the file produced by step 1
+        vi.resetAllMocks();
+        setupConfigFile(afterServer);
+        const r2 = AddEntityPackageMapping(REPO_ROOT, makeSchemaManifest());
+        expect(r2.Success).toBe(true);
+        const afterEntity = writtenContent();
+
+        assertValidConfig(afterEntity);
+        expect(afterEntity).toContain('dynamicPackages');
+        expect(afterEntity).toContain('entityPackageName');
+        expect(afterEntity).toContain('@mj-biz-apps/common-server');
+        expect(afterEntity).toContain("'__mj_BizAppsCommon': '@mj-biz-apps/common-entities'");
+    });
+});
+
+describe('Remove round-trip leaves valid JS', () => {
+    it('add then remove server dynamic packages keeps mj.config.cjs parseable', () => {
+        // add
+        setupConfigFile(issueTemplateConfig());
+        AddServerDynamicPackages(REPO_ROOT, makeServerManifest());
+        const afterAdd = writtenContent();
+        assertValidConfig(afterAdd);
+
+        // remove
+        vi.resetAllMocks();
+        setupConfigFile(afterAdd);
+        const result = RemoveServerDynamicPackages(REPO_ROOT, 'mj-bizapps-common');
+        expect(result.Success).toBe(true);
+        const afterRemove = writtenContent();
+
+        assertValidConfig(afterRemove);
+        expect(afterRemove).not.toContain('@mj-biz-apps/common-server');
+    });
+});

--- a/packages/OpenApp/Engine/src/install/config-manager.ts
+++ b/packages/OpenApp/Engine/src/install/config-manager.ts
@@ -14,6 +14,7 @@
  */
 import { readFileSync, writeFileSync, existsSync } from 'node:fs';
 import { resolve } from 'node:path';
+import { compileFunction } from 'node:vm';
 import type { MJAppManifest } from '../manifest/manifest-schema.js';
 
 /** Config file name. All MJ projects use mj.config.cjs. */
@@ -73,7 +74,7 @@ export function AddServerDynamicPackages(
             content = AddEntryToDynamicArray(content, entry, 'server');
         }
 
-        writeFileSync(configPath, content, 'utf-8');
+        WriteConfigChecked(configPath, content);
         return { Success: true };
     }
     catch (error: unknown) {
@@ -118,7 +119,7 @@ export function AddClientDynamicPackages(
             content = AddEntryToDynamicArray(content, entry, 'client');
         }
 
-        writeFileSync(configPath, content, 'utf-8');
+        WriteConfigChecked(configPath, content);
         return { Success: true };
     }
     catch (error: unknown) {
@@ -148,7 +149,7 @@ export function RemoveServerDynamicPackages(
     try {
         let content = readFileSync(configPath, 'utf-8');
         content = RemoveEntriesForApp(content, appName);
-        writeFileSync(configPath, content, 'utf-8');
+        WriteConfigChecked(configPath, content);
         return { Success: true };
     }
     catch (error: unknown) {
@@ -178,7 +179,7 @@ export function ToggleServerDynamicPackages(
     try {
         let content = readFileSync(configPath, 'utf-8');
         content = ToggleEntriesForApp(content, appName, enabled);
-        writeFileSync(configPath, content, 'utf-8');
+        WriteConfigChecked(configPath, content);
         return { Success: true };
     }
     catch (error: unknown) {
@@ -194,6 +195,31 @@ export function ToggleServerDynamicPackages(
 function resolveConfigPath(repoRoot: string): string | undefined {
     const candidate = resolve(repoRoot, CONFIG_FILE_NAME);
     return existsSync(candidate) ? candidate : undefined;
+}
+
+/**
+ * Writes updated mj.config.cjs content, but ONLY after verifying it still parses as valid
+ * JavaScript. Every edit in this module is string surgery; this post-write parse guard turns a
+ * malformed edit — from this code OR any future change, including config shapes the brace/comment
+ * scanner can't perfectly handle (e.g. regex literals containing braces) — into a LOUD failure
+ * that leaves the file UNTOUCHED, instead of silently shipping a broken config that breaks the
+ * next `require('mj.config.cjs')` (the mj migrate / codegen / build steps an install runs) — #2975.
+ *
+ * `compileFunction` parses the content (throwing SyntaxError on malformed JS) WITHOUT executing
+ * it, so the `require(...)` / `process.env` references in a real config never run. It throws on
+ * failure so the caller's existing try/catch surfaces it as `{ Success: false, ErrorMessage }`.
+ */
+function WriteConfigChecked(configPath: string, content: string): void {
+    try {
+        compileFunction(content);
+    } catch (parseError: unknown) {
+        const message = parseError instanceof Error ? parseError.message : String(parseError);
+        throw new Error(
+            `the edit would produce invalid JavaScript (${message}); the file was left unchanged. ` +
+            `This is a bug in the Open App config editor — please report it with your mj.config.cjs shape.`,
+        );
+    }
+    writeFileSync(configPath, content, 'utf-8');
 }
 
 /**
@@ -560,7 +586,7 @@ export function AddEntityPackageMapping(
         let content = readFileSync(configPath, 'utf-8');
         content = EnsureEntityPackageNameSection(content);
         content = AddEntityPackageEntry(content, schemaName, entityPkg);
-        writeFileSync(configPath, content, 'utf-8');
+        WriteConfigChecked(configPath, content);
         return { Success: true };
     }
     catch (error: unknown) {
@@ -592,7 +618,7 @@ export function RemoveEntityPackageMapping(
     try {
         let content = readFileSync(configPath, 'utf-8');
         content = RemoveEntityPackageEntry(content, schemaName);
-        writeFileSync(configPath, content, 'utf-8');
+        WriteConfigChecked(configPath, content);
         return { Success: true };
     }
     catch (error: unknown) {

--- a/packages/OpenApp/Engine/src/install/config-manager.ts
+++ b/packages/OpenApp/Engine/src/install/config-manager.ts
@@ -433,6 +433,66 @@ function FindMatchingBracket(content: string, openPos: number): number {
 }
 
 /**
+ * Returns the index of the last *significant* character (not whitespace, not inside a string
+ * literal, and not inside a `//` line or block comment) within `content[0, end)`, or -1 if
+ * there is none. Mirrors {@link FindMatchingBracket}'s string/comment state machine so a `//`
+ * inside a value like `'http://x'`, or a brace/quote inside a string, is never miscounted.
+ */
+function LastSignificantCharIndex(content: string, end: number): number {
+    let pos = 0;
+    let last = -1;
+    let inString: string | null = null;
+    let inLineComment = false;
+    let inBlockComment = false;
+
+    while (pos < end) {
+        const ch = content[pos];
+
+        if (inLineComment) {
+            if (ch === '\n') inLineComment = false;
+            pos++;
+            continue;
+        }
+        if (inBlockComment) {
+            if (ch === '*' && content[pos + 1] === '/') { inBlockComment = false; pos += 2; continue; }
+            pos++;
+            continue;
+        }
+        if (inString) {
+            if (ch === '\\') { pos += 2; continue; } // skip escaped char
+            if (ch === inString) { inString = null; last = pos; } // the closing quote is significant
+            pos++;
+            continue;
+        }
+
+        if (ch === '/' && content[pos + 1] === '/') { inLineComment = true; pos += 2; continue; }
+        if (ch === '/' && content[pos + 1] === '*') { inBlockComment = true; pos += 2; continue; }
+        if (ch === '"' || ch === "'" || ch === '`') { inString = ch; last = pos; pos++; continue; }
+
+        if (ch !== ' ' && ch !== '\t' && ch !== '\r' && ch !== '\n') {
+            last = pos;
+        }
+        pos++;
+    }
+    return last;
+}
+
+/**
+ * Ensures the object body in `before` (the text up to — but excluding — an object's closing
+ * brace) is comma-terminated, so a new property spliced in right after it is a valid sibling
+ * (#2975). No-op when the preceding token is already a comma, or when the body is empty.
+ * `openBracePos` is the index of the object's own opening `{`; the inserted section carries
+ * its own trailing comma, so an otherwise-empty literal stays valid.
+ */
+function EnsureTrailingComma(before: string, openBracePos: number): string {
+    const idx = LastSignificantCharIndex(before, before.length);
+    if (idx <= openBracePos || before[idx] === ',') {
+        return before;
+    }
+    return before.slice(0, idx + 1) + ',' + before.slice(idx + 1);
+}
+
+/**
  * Inserts a section just before the closing brace of the `module.exports = { ... }` object
  * literal. Anchoring to that brace (via FindMatchingBracket) is correct even when the file
  * has trailing code or a later `};` — unlike `lastIndexOf('};')`, which lands in the wrong
@@ -453,7 +513,13 @@ function InsertBeforeModuleExportsClose(content: string, section: string): strin
     if (closePos === -1) {
         throw new Error('Could not locate the closing brace of module.exports in mj.config.cjs.');
     }
-    return content.slice(0, closePos) + section + content.slice(closePos);
+    // Comma-terminate the property immediately before the insertion point so the new section
+    // is a valid sibling rather than a syntax error (#2975). Without this, a config whose last
+    // top-level property is a brace-terminated block (e.g. `openApps: { ... }` with no trailing
+    // comma) becomes `}\n  dynamicPackages: { ... }` — invalid JS that breaks every later
+    // `require('mj.config.cjs')`, including the mj migrate / codegen / build steps an install runs.
+    const before = EnsureTrailingComma(content.slice(0, closePos), bracePos);
+    return before + section + content.slice(closePos);
 }
 
 // ─────────────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Fixes #2975. `mj app install <app>` corrupted the repo's `mj.config.cjs`: it inserted a new top-level key (`dynamicPackages` / `entityPackageName`) just before the closing `}` of `module.exports = { ... }` **without comma-terminating the preceding property**. When the last property is a brace-terminated block (e.g. `openApps: { ... }` with no trailing comma — the normal shape of a `mj app`-enabled config), the file became invalid JS. The install itself never re-`require()`s the file, so it reports success — but the **next** command to load it (the `mj migrate` / `mj codegen` / build steps an install runs) dies with `SyntaxError: Unexpected identifier`. This is exactly why **`mj app install bizapps-common`** appeared to fail.

The bug is pure string surgery in `config-manager.ts` and is **database-independent**.

## Root cause

The shared helper `InsertBeforeModuleExportsClose` did `content.slice(0, closePos) + section + content.slice(closePos)` with no separator between the prior property and the new section. Both `EnsureDynamicPackagesSection` and `EnsureEntityPackageNameSection` route through it, so the corruption hit both insert paths.

## Fix

Comma-terminate the property immediately before the insertion point:

- **`LastSignificantCharIndex`** — a string/comment-aware scanner mirroring the existing `FindMatchingBracket` state machine, so a `//` inside a value like `'http://x'`, or a brace/quote inside a string, is never miscounted.
- **`EnsureTrailingComma`** — no-op when the object body is empty or already ends with a comma; otherwise splices a `,` after the last significant token.

One change fixes **all** insert callers (server + client `dynamicPackages`, and `entityPackageName`). `remove` / `disable` / `enable` never insert top-level sections (they only delete entries with their own trailing comma, or toggle `Enabled`), so they were never affected — an add→remove round-trip test confirms removal also stays valid.

## Tests & verification

- `npm run build` green; **28 unit tests pass** — 7 new in `config-manager-dynamic.test.ts`: the #2975 issue template, a string value containing `//`, an already-comma'd last property, empty `module.exports`, the combined bizapps-common shape (server + entity sections), and an add→remove round-trip. Each compiles the written config to assert validity.
- **Real-compiled-code proof (DB-free)** driving the *built* `@memberjunction/open-app-engine` config-manager against the bizapps-common manifest + a real comment-heavy `mj.config.cjs`, parse-checked with `node --check` (exactly what `require()` does at load):
  - **pre-fix:** `SyntaxError` at `dynamicPackages:` (reproduces #2975)
  - **post-fix:** parses clean — `openApps: { ... },` now comma-separated from `dynamicPackages` + `entityPackageName`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
