### PR TITLE
fix(open-app): never auto-drop a `__`-prefixed schema on install rollback (#2949 hardening)

### DIFF
--- a/packages/OpenApp/Engine/src/__tests__/install-orchestrator-order.test.ts
+++ b/packages/OpenApp/Engine/src/__tests__/install-orchestrator-order.test.ts
@@ -540,6 +540,31 @@ describe('InstallApp — schema rollback tracks actual creation (B18)', () => {
         // schema it merely adopted (someone else's data). Post-fix: Created=false → no drop.
         expect(vi.mocked(DropAppSchema)).not.toHaveBeenCalled();
     });
+
+    it('does NOT auto-drop a `__`-prefixed schema on rollback even with the override set (#2949 defense-in-depth)', async () => {
+        // Fresh install that genuinely CREATES a `__`-prefixed schema this run (override set), then a
+        // migration fails. Dropping a `__` schema on rollback is a higher risk class than create, so it
+        // is skipped and the operator is warned — protecting against a wrong "we created it" detection
+        // ever nuking a populated MJ-internal-adjacent schema (the `__BCSaaS` data-loss incident).
+        const underscoreManifest = JSON.parse(manifestWithMigrations('app-x'));
+        underscoreManifest.schema.name = '__mj_app_x';
+        serveManifests({ 'https://github.com/test/app-x': JSON.stringify(underscoreManifest) });
+
+        vi.mocked(FindInstalledApp).mockResolvedValue(undefined); // fresh install
+        vi.mocked(SchemaExists).mockResolvedValue(false); // absent → CreateAppSchema runs → Created=true
+
+        const onWarn = vi.fn();
+        const ctx = { ...migContext, Callbacks: { OnWarn: onWarn } } as unknown as OrchestratorContext;
+
+        const result = await InstallApp(
+            { Source: 'https://github.com/test/app-x', AllowDoubleUnderscoreSchema: true },
+            ctx,
+        );
+
+        expect(result.Success).toBe(false);
+        expect(vi.mocked(DropAppSchema)).not.toHaveBeenCalled(); // the catastrophic drop is skipped
+        expect(onWarn).toHaveBeenCalledWith('Rollback', expect.stringContaining('never'));
+    });
 });
 
 describe('UpgradeApp — migration failure is honest + recoverable (B21)', () => {

--- a/packages/OpenApp/Engine/src/install/install-orchestrator.ts
+++ b/packages/OpenApp/Engine/src/install/install-orchestrator.ts
@@ -371,6 +371,12 @@ async function RecordInstallationAtomically(
 /**
  * Compensating action: drops the schema if it was newly created during a failed install.
  * Notifies the user via callbacks before and after rollback.
+ *
+ * Defense-in-depth (#2949): a `__`-prefixed schema is NEVER auto-dropped on rollback, even when
+ * the create-time override (`AllowDoubleUnderscoreSchema`) is set. Drop-on-rollback is a higher
+ * risk class than create — if the "we created it this run" detection is ever wrong, dropping a
+ * `__` schema is catastrophic (the `__BCSaaS` data-loss incident). Leaving a half-created schema
+ * behind is recoverable and visible; the operator is told to clean it up manually instead.
  */
 async function CompensateSchemaOnFailure(
   manifest: MJAppManifest,
@@ -382,13 +388,23 @@ async function CompensateSchemaOnFailure(
   if (!schemaWasCreated || !manifest.schema) {
     return;
   }
+  const schemaName = manifest.schema.name;
+  if (schemaName.startsWith('__')) {
+    callbacks?.OnWarn?.(
+      'Rollback',
+      `Install failed after creating schema '${schemaName}', but '__'-prefixed schemas are never ` +
+      `auto-dropped during rollback (data-safety). If this schema was created solely by this failed ` +
+      `install and holds no data you need, drop it manually after verifying its contents.`,
+    );
+    return;
+  }
   try {
-    callbacks?.OnProgress?.('Rollback', `Rolling back: dropping schema '${manifest.schema.name}'...`);
-    await DropAppSchema(manifest.schema.name, context.DatabaseProvider, { allowDoubleUnderscore });
-    callbacks?.OnProgress?.('Rollback', `Schema '${manifest.schema.name}' dropped successfully`);
+    callbacks?.OnProgress?.('Rollback', `Rolling back: dropping schema '${schemaName}'...`);
+    await DropAppSchema(schemaName, context.DatabaseProvider, { allowDoubleUnderscore });
+    callbacks?.OnProgress?.('Rollback', `Schema '${schemaName}' dropped successfully`);
   } catch (rollbackError: unknown) {
     const msg = rollbackError instanceof Error ? rollbackError.message : String(rollbackError);
-    callbacks?.OnError?.('Rollback', `Failed to drop schema '${manifest.schema.name}' during rollback: ${msg}`);
+    callbacks?.OnError?.('Rollback', `Failed to drop schema '${schemaName}' during rollback: ${msg}`);
   }
 }
 


### PR DESCRIPTION
## Summary

Defense-in-depth hardening for the **#2949** schema-rollback data-loss class (the `__BCSaaS` incident Ian/`bc-izygmunt` reported: `mj app install` dropping a pre-existing schema on migration-failure rollback).

**The primary data-loss bug is already fixed on `next`** — `install-orchestrator.ts` only flags a schema for rollback-drop when the installer *actually created it this run* (`schemaCreated = schemaResult.Created === true`, commit `b2fca9ca7e`), with a passing regression test (`does NOT drop an adopted/reused schema we did not create`). The original three review follow-ups from #2949 are likewise fixed (commits `8948ae58c5`, `003bda6350`). This PR adds the one remaining belt-and-suspenders guardrail Ian suggested.

## Change

`CompensateSchemaOnFailure` now **never auto-drops a `__`-prefixed schema during rollback**, even when the create-time `AllowDoubleUnderscoreSchema` override is set. Drop-on-rollback is a higher risk class than drop-on-create: if the "we created it this run" detection is ever wrong, dropping a `__` (MJ-internal-adjacent) schema is catastrophic, whereas leaving a half-created schema behind is recoverable and visible. The operator gets an explicit manual-cleanup warning instead.

A schema the installer genuinely created this run that happens to be `__`-prefixed is left in place rather than dropped — the small, safe cost of eliminating the catastrophic case entirely.

## Tests & verification

- `npm run build` green; **226/226 OpenApp Engine tests pass**.
- New regression test in `install-orchestrator-order.test.ts`: a fresh install that creates a `__`-prefixed schema with the override set, then fails migration, asserts `DropAppSchema` is **not** called and a `Rollback` warning is emitted.

Closes the last open item on #2949 (the other items were already resolved on `next` — see the issue comment).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
