### PR TITLE
chore: move live-embedding-checks out of repo root (follow-up to #3003)

### DIFF
--- a/packages/AI/Core/scripts/live-embedding-checks/README.md
+++ b/packages/AI/Core/scripts/live-embedding-checks/README.md
@@ -19,7 +19,7 @@ text**, i.e. no batch collapse (the GAP-8 bug this work fixes and generalizes ag
 3. From the repo root:
 
    ```bash
-   node --env-file=.env scripts/live-embedding-checks/live-embedding-check.mjs <provider>
+   node --env-file=.env packages/AI/Core/scripts/live-embedding-checks/live-embedding-check.mjs <provider>
    ```
 
    `<provider>` is one of `gemini`, `openai`, `cohere`, `local`.

--- a/packages/AI/Core/scripts/live-embedding-checks/live-embedding-check.mjs
+++ b/packages/AI/Core/scripts/live-embedding-checks/live-embedding-check.mjs
@@ -17,7 +17,7 @@ import { fileURLToPath, pathToFileURL } from 'node:url';
 import { dirname, resolve } from 'node:path';
 
 const HERE = dirname(fileURLToPath(import.meta.url));
-const distOf = (pkgDir) => resolve(HERE, '../../packages/AI/Providers', pkgDir, 'dist/index.js');
+const distOf = (pkgDir) => resolve(HERE, '../../../Providers', pkgDir, 'dist/index.js');
 
 /** Per-provider config. `keyEnv` lists accepted env-var names (first one set wins); empty = no key. */
 const PROVIDERS = {


### PR DESCRIPTION
Follow-up to #3003, per @AN-BC's review request there:

> after merge, move this into a scripts folder under the proper section, not in root. raise and merge that PR with that change so we retain this script but it isn't in the root of repo

Moves the live embedding-check runner from the repo-root `scripts/` folder to **`packages/AI/Core/scripts/live-embedding-checks/`** — under the AI section, alongside where `BaseEmbeddings` lives — so it's retained but no longer in the repo root.

- `git mv` of the folder (the runner + its README)
- fixed the relative provider-`dist` paths for the new folder depth
- updated the README's run command

No behavior change — the `local` check was re-verified passing from the new path. No changeset: this only relocates a manual, non-published tooling script (it reads keys from a gitignored `.env`; no secrets in the repo).
