### PR TITLE
fix(metadata): declare AcceptsSkills='All' on top-level conversational agents

### DIFF
--- a/metadata/agents/.agents.json
+++ b/metadata/agents/.agents.json
@@ -535,6 +535,7 @@
       "Description": "Strategic orchestrator for marketing content creation workflows, managing sub-agents to deliver high-quality marketing materials. Good at writing blog post.",
       "TypeID": "@lookup:MJ: AI Agent Types.Name=Loop",
       "Status": "Active",
+      "AcceptsSkills": "All",
       "ExecutionOrder": 1,
       "ExposeAsAction": true,
       "DefaultArtifactTypeID": "@lookup:MJ: Artifact Types.Name=Marketing Content",

--- a/metadata/agents/.agents.json
+++ b/metadata/agents/.agents.json
@@ -1112,8 +1112,8 @@
       "ID": "4A7B4F1D-C536-409F-9206-F36FDEE64EDF"
     },
     "sync": {
-      "lastModified": "2026-03-13T19:10:48.506Z",
-      "checksum": "b61ad1d38dcafbacd300a4965ba3feba0bc057cc4eb3758730f95ae416e0803f"
+      "lastModified": "2026-07-01T23:32:33.092Z",
+      "checksum": "7d6f69aadf51db5b7327403847ee4416b0b5965cc76dc4a4ec2fa0f17d1b6110"
     }
   }
 ]

--- a/metadata/agents/.codesmith-agent.json
+++ b/metadata/agents/.codesmith-agent.json
@@ -6,6 +6,7 @@
       "Description": "Expert code generator and executor for data analysis and transformations. Generates JavaScript code, tests it in a secure sandbox, and iteratively refines it until successful. Supports lodash, date-fns, mathjs, papaparse, uuid, and validator libraries. Perfect for data manipulation, calculations, and analysis tasks.",
       "TypeID": "@lookup:MJ: AI Agent Types.Name=Loop",
       "Status": "Active",
+      "AcceptsSkills": "All",
       "ModelSelectionMode": "Agent",
       "ExposeAsAction": true,
       "InvocationMode": "Any",

--- a/metadata/agents/.codesmith-agent.json
+++ b/metadata/agents/.codesmith-agent.json
@@ -55,8 +55,8 @@
       "ID": "03E3675E-E8C7-41B3-92C6-99520FF35FAB"
     },
     "sync": {
-      "lastModified": "2026-03-13T19:10:49.055Z",
-      "checksum": "d556108b87971a2c734cd948927820e1b9b7a793b4cc65fc47d85daa033637e9"
+      "lastModified": "2026-07-01T23:32:33.160Z",
+      "checksum": "0bb95255bb574d1f8d0bfd302fc871b8f259116fa9f5a0c3e5b26bfdd18879b7"
     }
   }
 ]

--- a/metadata/agents/.knowledge-agent.json
+++ b/metadata/agents/.knowledge-agent.json
@@ -88,8 +88,8 @@
       "ID": "3755AD2D-B267-4356-BA18-279840EF4B2F"
     },
     "sync": {
-      "lastModified": "2026-04-02T19:13:37.760Z",
-      "checksum": "66a0f29b8b8ed3745c4c14e1786b1da7fa3c7774f317b65556f7921b8e6d71d8"
+      "lastModified": "2026-07-01T23:32:33.216Z",
+      "checksum": "192b6220c1dd60b27aeab6782bb784cb25716fb2f82a7f6c11b6378fe0746010"
     }
   }
 ]

--- a/metadata/agents/.knowledge-agent.json
+++ b/metadata/agents/.knowledge-agent.json
@@ -6,6 +6,7 @@
       "Description": "AI assistant specialized in knowledge management: semantic search, vectorization, duplicate detection, content navigation, and index configuration",
       "TypeID": "@lookup:MJ: AI Agent Types.Name=Loop",
       "Status": "Active",
+      "AcceptsSkills": "All",
       "ExecutionOrder": 10,
       "ModelSelectionMode": "Agent",
       "ArtifactCreationMode": "Never",

--- a/metadata/agents/.query-builder-agent.json
+++ b/metadata/agents/.query-builder-agent.json
@@ -399,8 +399,8 @@
       "ID": "204FF1D6-A807-4278-B71A-9D692F19E808"
     },
     "sync": {
-      "lastModified": "2026-06-16T01:17:22.121Z",
-      "checksum": "903631bcce151f68bc1069f91fc0f7e32f477f55b22cde5a017a0936680fa4bc"
+      "lastModified": "2026-07-01T23:32:33.277Z",
+      "checksum": "04d11aa4119d1098594d842f6c897b2ce1a058014e6febe0aa54b93610063885"
     }
   }
 ]

--- a/metadata/agents/.query-builder-agent.json
+++ b/metadata/agents/.query-builder-agent.json
@@ -6,6 +6,7 @@
       "Description": "Business-friendly orchestrator agent that helps users explore their data and build saved queries. Delegates technical SQL work to the Query Strategist sub-agent. Presents results visually with diagrams and formatted tables, hiding SQL complexity unless the user asks for it.",
       "TypeID": "@lookup:MJ: AI Agent Types.Name=Loop",
       "Status": "Active",
+      "AcceptsSkills": "All",
       "DefaultArtifactTypeID": "@lookup:MJ: Artifact Types.Name=Data",
       "ArtifactCreationMode": "Always",
       "ExecutionOrder": 0,

--- a/metadata/agents/.research-agent.json
+++ b/metadata/agents/.research-agent.json
@@ -845,8 +845,8 @@
       "ID": "E614D2BF-7C52-4A71-B90A-8C8DBB55BCFB"
     },
     "sync": {
-      "lastModified": "2026-03-13T19:10:49.923Z",
-      "checksum": "60a494e770cbb957cbb097efad5b1a0f33be9f448b10899197f2fa3bc4032b7d"
+      "lastModified": "2026-07-01T23:32:33.320Z",
+      "checksum": "859cbc50bdd926c0737f0d1dd02713ac0037761f36884344d0029e0fa08394ab"
     }
   }
 ]

--- a/metadata/agents/.research-agent.json
+++ b/metadata/agents/.research-agent.json
@@ -456,6 +456,7 @@
       "Description": "Orchestrator agent for comprehensive research across multiple domains. Analyzes research requests, delegates tasks to specialized sub-agents (Web Research, Database Research, File Research, Report Writer), and coordinates the research workflow. Uses iterative methodology with source validation and contradiction detection. Delegates final synthesis and report generation to the Report Writer sub-agent.",
       "TypeID": "@lookup:MJ: AI Agent Types.Name=Loop",
       "Status": "Active",
+      "AcceptsSkills": "All",
       "DefaultArtifactTypeID": "@lookup:MJ: Artifact Types.Name=Research Content",
       "ExecutionOrder": 0,
       "ModelSelectionMode": "Agent",

--- a/metadata/agents/.sage-agent.json
+++ b/metadata/agents/.sage-agent.json
@@ -920,8 +920,8 @@
       "ID": "3AB78346-897F-4238-AA6A-F10A131CC691"
     },
     "sync": {
-      "lastModified": "2026-06-14T22:05:07.568Z",
-      "checksum": "3ab753a812acabe0d216bf517b5ed2d668d606f2c9a9d13271d27e66e896500e"
+      "lastModified": "2026-07-01T23:32:33.335Z",
+      "checksum": "bfc3a34990d609087761870e973434d0d57abcfd3b09bbac272adf7dca298953"
     }
   }
 ]

--- a/metadata/agents/.sage-agent.json
+++ b/metadata/agents/.sage-agent.json
@@ -6,6 +6,7 @@
       "Description": "Ambient agent in MJ that is always present in all conversations to help the user navigate functionality in MJ, handle basic requests, and bring in other agents to delegate work to",
       "TypeID": "@lookup:MJ: AI Agent Types.Name=Loop",
       "Status": "Active",
+      "AcceptsSkills": "All",
       "ExecutionOrder": 0,
       "ModelSelectionMode": "Agent",
       "ArtifactCreationMode": "System Only",


### PR DESCRIPTION
## Problem

Requesting a skill via `/skill` mention on a mentioned agent silently does nothing — e.g. `@Marketing Agent do /Web Research …` responds *"I do not have direct access to a 'Web Search' tool."*

Root cause: **no agent metadata declares `AcceptsSkills`**, so every agent sits at the DB default `'None'`. `BaseAgent.preActivateRequestedSkills` intersects requested skill IDs with `GetSkillsForAgent(agent, user)`, which returns empty for `'None'` agents — the three-layer gate working exactly as designed, but with zero agents opted in. (The `requestedSkillIDs` threading through composer → service → runner → resolver is wired and was not the issue.)

## Fix

Declare `"AcceptsSkills": "All"` in metadata for the six top-level conversational Loop agents:

- Sage (also converts the raw-SQL dev-DB leftover into declared metadata)
- Marketing Agent
- Research Agent
- Knowledge Agent
- Query Builder
- Codesmith Agent

Sub-agents, Flow agents, and demo agents intentionally stay `'None'`. Per-user Run permission on each skill still gates activation independently.

## Post-merge step

`npx mj sync push --dir=metadata --include="agents"` then retest the Marketing Agent + `/Web Research` message.

🤖 Generated with [Claude Code](https://claude.com/claude-code)