### PR TITLE
fix(connectors): SoftPK synthetic-key auto-resolution + DB_ENCRYPT override

### DIFF
--- a/.changeset/connector-softpk-db-encrypt.md
+++ b/.changeset/connector-softpk-db-encrypt.md
@@ -1,0 +1,12 @@
+---
+"@memberjunction/integration-pk-classifier": minor
+"@memberjunction/integration-engine": minor
+"@memberjunction/server": patch
+"@memberjunction/codegen-lib": patch
+---
+
+Connector-build framework hardening: SoftPK synthetic-key auto-resolution + DB_ENCRYPT override.
+
+- **SoftPKClassifier**: renamed the synthetic PK column `__mj_integration_IdentityHash` → `IdentityKey` (the reserved `__mj_` prefix was never materialized by the schema builder, so the synthetic tier produced a confident-but-dropped verdict); enabled the synthetic content-hash fallback by default; added a `MIN_STATISTICAL_SAMPLE=8` significance gate on the statistical/composite tiers (stops thin-sample false positives such as nominating a boolean flag); excluded source-declared-nullable fields from PK candidates.
+- **IntegrationConnectorCreationPipeline.StagePKClassify**: creates the synthetic IOF when the verdict is `synthetic` (previously skipped an unknown nominee), so ApplyAll materializes the column and `ToExternalRecord` stamps a deterministic content hash — genuinely-keyless objects become syncable + dedupable.
+- **MJServer `orm.ts` + CodeGenLib `db-connection.ts`**: `DB_ENCRYPT` env override (defaults ON; only the literal `false` disables) so a local/Docker SQL Server presenting a self-signed cert can be used without TLS rejection.

--- a/packages/CodeGenLib/src/Config/db-connection.ts
+++ b/packages/CodeGenLib/src/Config/db-connection.ts
@@ -70,7 +70,9 @@ export function buildSqlConfig(): mssql.config {
        * spUpdateExistingEntityFieldsFromSchema run beyond the default.
        */
       requestTimeout,
-      encrypt: true,
+      // Encryption defaults ON. Set DB_ENCRYPT=false to disable TLS entirely for a local/Docker
+      // SQL Server whose self-signed cert the mssql TLS layer rejects. Only 'false' disables.
+      encrypt: (process.env.DB_ENCRYPT ?? 'true').toLowerCase() !== 'false',
       instanceName: dbInstanceName && dbInstanceName.trim().length > 0 ? dbInstanceName : undefined,
       trustServerCertificate: dbTrustServerCertificate === 'Y',
     },

--- a/packages/Integration/engine/src/IntegrationConnectorCreationPipeline.ts
+++ b/packages/Integration/engine/src/IntegrationConnectorCreationPipeline.ts
@@ -467,8 +467,31 @@ export class IntegrationConnectorCreationPipeline {
                         continue;
                     }
                     emitter.entityGenerated(obj.Name, obj.Name);
+                } else if (verdict.Strategy === 'synthetic') {
+                    // Synthetic content-hash identity: the field doesn't exist on the source, so create it
+                    // as a single-PK IOF. ApplyAll then materializes the column, and ToExternalRecord stamps
+                    // a deterministic content hash into it at sync (plan §4) so the keyless table is syncable.
+                    const iof = await md.GetEntityObject<MJIntegrationObjectFieldEntity>('MJ: Integration Object Fields', opts.ContextUser);
+                    iof.NewRecord();
+                    iof.IntegrationObjectID = obj.ID;
+                    iof.Name = verdict.Nominee;
+                    iof.Type = 'String';
+                    iof.IsPrimaryKey = true;
+                    iof.IsUniqueKey = true;
+                    iof.IsReadOnly = true;
+                    iof.IsRequired = false;
+                    iof.AllowsNull = false;
+                    iof.Status = 'Active';
+                    iof.Description = 'Synthetic content-hash identity — no natural PK exists in the source; a deterministic content hash is stamped at sync so the table is syncable + dedupable (plan §4).';
+                    const saved = await iof.Save();
+                    if (!saved) {
+                        emitter.stageError('PKClassify', `Failed to create synthetic PK ${obj.Name}.${verdict.Nominee}: ${iof.LatestResult?.CompleteMessage ?? 'unknown error'}`);
+                        unresolved.push(obj.Name);
+                        continue;
+                    }
+                    emitter.entityGenerated(obj.Name, obj.Name);
                 } else {
-                    // Classifier nominated a field that's not in our cache — refuse silently and skip.
+                    // Classifier nominated a natural field that's not in our cache — refuse silently and skip.
                     unresolved.push(obj.Name);
                     emitter.entitySkippedNoPK(obj.Name);
                 }

--- a/packages/Integration/pk-classifier/src/SoftPKClassifier.ts
+++ b/packages/Integration/pk-classifier/src/SoftPKClassifier.ts
@@ -14,12 +14,29 @@ export type PKClassifierStrategy =
     | 'none';
 
 /**
- * Canonical name of the synthetic identity-hash column nominated by the
- * synthetic-fallback tier. The framework materializes this column (an identity
- * hash of the record) so a table that has no provable natural PK is still
- * syncable (plan.md §4).
+ * Canonical name of the synthetic identity-key column nominated by the
+ * synthetic-fallback tier. `StagePKClassify` creates this as a real IOF (single
+ * PK), ApplyAll materializes the column, and `BaseRESTIntegrationConnector.ToExternalRecord`
+ * stamps a deterministic content hash into it at sync time — so a table with no
+ * provable natural PK is still syncable + dedupable (plan.md §4).
+ *
+ * IMPORTANT: this name is deliberately NOT `__mj_`-prefixed. A `__mj_`-prefixed
+ * name is treated as a framework-reserved/hidden column by CodeGen + the schema
+ * builder and is NEVER materialized as a business PK — which is exactly why the
+ * earlier `__mj_integration_IdentityHash` produced a "confident-but-dropped"
+ * verdict (nominated but never created downstream). A plain name materializes.
  */
-export const SYNTHETIC_PK_FIELD_NAME = '__mj_integration_IdentityHash' as const;
+export const SYNTHETIC_PK_FIELD_NAME = 'IdentityKey' as const;
+
+/**
+ * Minimum sample-row count before the statistical / composite tiers are trusted.
+ * Below this, "unique across the sample" is likely coincidental (a 2-row sample
+ * makes almost any column-combination look unique), so those tiers are skipped and
+ * the classifier falls through to the LLM tier or the honest synthetic fallback.
+ * This is the significance gate that stops thin-sample false positives (e.g.
+ * nominating a boolean flag like `IsDelivered`, or a nullable-member composite).
+ */
+export const MIN_STATISTICAL_SAMPLE = 8 as const;
 
 /** Result returned by SoftPKClassifier.Classify(). */
 export interface PKClassifierResult {
@@ -143,8 +160,9 @@ export class SoftPKClassifier {
             };
         }
 
-        // 3) Statistical (when sample rows present)
-        if (opts.sampleRows && opts.sampleRows.length > 0) {
+        // 3) Statistical — only on an ADEQUATE sample (significance gate). A tiny sample makes
+        //    coincidental uniqueness look real, so below the floor we skip to LLM / synthetic.
+        if (opts.sampleRows && opts.sampleRows.length >= MIN_STATISTICAL_SAMPLE) {
             const statMatch = this.statisticalUniqueness(opts.fields, opts.sampleRows);
             if (statMatch && statMatch.confidence >= floor) {
                 return {
@@ -160,7 +178,9 @@ export class SoftPKClassifier {
 
         // 3b) Composite uniqueness (when no single column is unique) — try minimal
         //     2- then 3-col concatenated key sets; smallest unique+stable set wins.
-        if (opts.sampleRows && opts.sampleRows.length > 0) {
+        //     Same significance gate: a composite over a thin sample is almost always a
+        //     coincidence (the [ContactId, IsDelivered] / nullable-member false positives).
+        if (opts.sampleRows && opts.sampleRows.length >= MIN_STATISTICAL_SAMPLE) {
             const maxSetSize = opts.maxCompositeKeySize ?? 3;
             const compMatch = this.compositeUniqueness(opts.fields, opts.sampleRows, maxSetSize);
             if (compMatch && compMatch.confidence >= floor) {
@@ -214,29 +234,33 @@ export class SoftPKClassifier {
     }
 
     /**
-     * Terminal tier. Default is the **honest 'none'** verdict — NO fabrication. A PK is emitted only
-     * on real evidence (naming + streamed-data statistics at p<0.05, with the LLM as a tiebreaker);
-     * when none of those resolve, the entity is simply not generated until a PK does (surfaced, not
-     * guessed). The synthetic identity-hash fallback is now OFF by default (opt-in only) — it was
-     * never materialized downstream, so emitting it only produced a confident-but-dropped verdict.
+     * Terminal tier. NO natural-key fabrication — a *natural* PK is emitted only on real evidence
+     * (naming + adequate-sample statistics, LLM tiebreaker). When none resolve, the honest outcome for
+     * a genuinely-keyless object is **a synthetic content-hash identity key**, which is now the DEFAULT
+     * (`syntheticFallback ?? true`). This is safe + correct because the whole path is real: `StagePKClassify`
+     * creates the `IdentityKey` IOF, ApplyAll materializes the column, and `ToExternalRecord` stamps a
+     * deterministic content hash into it (plan.md §4) so the table syncs + dedupes. The earlier OFF-by-default
+     * behavior existed only because the reserved `__mj_`-named field was never materialized — fixed by the
+     * non-reserved name + the pipeline wiring. Pass `syntheticFallback: false` to opt OUT (leave keyless
+     * objects ungenerated) for the rare case that's desired.
      */
     private finalVerdict(opts: ClassifyOptions, prefix?: string): PKClassifierResult {
         const note = prefix ? `${prefix} ` : '';
-        if (opts.syntheticFallback ?? false) {
+        if (opts.syntheticFallback ?? true) {
             return {
                 Confident: true,
                 Nominee: SYNTHETIC_PK_FIELD_NAME,
                 NomineeFields: [SYNTHETIC_PK_FIELD_NAME],
                 Confidence: 0.7,
                 Strategy: 'synthetic',
-                Reason: `${note}No natural PK proven via universal-convention, naming, statistical, composite, or LLM strategies. Falling back to a synthetic identity-hash key "${SYNTHETIC_PK_FIELD_NAME}" so the table remains syncable (plan.md §4).`,
+                Reason: `${note}No natural PK proven via universal-convention, naming, statistical, composite, or LLM strategies. Falling back to a synthetic content-hash identity key "${SYNTHETIC_PK_FIELD_NAME}" so the table remains syncable + dedupable (plan.md §4).`,
             };
         }
         return {
             Confident: false,
             Confidence: 0,
             Strategy: 'none',
-            Reason: `${note}No confident PK candidate via universal-convention, naming, statistical, composite, or LLM strategies, and synthetic fallback is disabled. IO row persists; MJ entity not generated until a PK resolves.`,
+            Reason: `${note}No confident PK candidate via universal-convention, naming, statistical, composite, or LLM strategies, and synthetic fallback is explicitly disabled. IO row persists; MJ entity not generated until a PK resolves.`,
         };
     }
 
@@ -278,6 +302,7 @@ export class SoftPKClassifier {
     ): { fieldName: string; confidence: number; reason: string } | undefined {
         const candidates: Array<{ fieldName: string; uniqueRatio: number; nullRatio: number }> = [];
         for (const f of fields) {
+            if (f.AllowsNull === true) continue; // a source-declared-nullable field can't be a PK member
             const values = rows.map(r => r[f.Name]);
             const nonNull = values.filter(v => this.isPresent(v));
             const nullRatio = 1 - (nonNull.length / rows.length);
@@ -335,6 +360,7 @@ export class SoftPKClassifier {
         rows: Array<Record<string, unknown>>
     ): string[] {
         return fields
+            .filter(f => f.AllowsNull !== true) // source-declared-nullable fields can't be PK members
             .filter(f => rows.every(r => this.isPresent(r[f.Name])))
             .map(f => f.Name);
     }

--- a/packages/Integration/pk-classifier/src/__tests__/SoftPKClassifier.test.ts
+++ b/packages/Integration/pk-classifier/src/__tests__/SoftPKClassifier.test.ts
@@ -12,7 +12,7 @@ import { SoftPKClassifier, SYNTHETIC_PK_FIELD_NAME } from '../SoftPKClassifier.j
  * subclasses can't be `new`-ed without a provider, so structural stubs are
  * the convention — production code never does this).
  */
-type FieldStub = Pick<MJIntegrationObjectFieldEntity, 'Name' | 'Type' | 'Length' | 'IsUniqueKey'>;
+type FieldStub = Pick<MJIntegrationObjectFieldEntity, 'Name' | 'Type' | 'Length' | 'IsUniqueKey' | 'AllowsNull'>;
 type ObjectStub = Pick<MJIntegrationObjectEntity, 'Name'>;
 
 function makeField(name: string, opts: Partial<Omit<FieldStub, 'Name'>> = {}): MJIntegrationObjectFieldEntity {
@@ -21,6 +21,7 @@ function makeField(name: string, opts: Partial<Omit<FieldStub, 'Name'>> = {}): M
         Type: opts.Type ?? 'nvarchar',
         Length: opts.Length ?? null,
         IsUniqueKey: opts.IsUniqueKey ?? false,
+        AllowsNull: opts.AllowsNull ?? undefined as unknown as boolean,
     };
     return stub as unknown as MJIntegrationObjectFieldEntity;
 }
@@ -36,12 +37,9 @@ describe('SoftPKClassifier', () => {
     describe('single-column statistical uniqueness', () => {
         it('nominates the sole unique + non-null column', async () => {
             // "code" is unique+non-null; "category" repeats. No naming/convention match.
+            // Adequate sample (>= MIN_STATISTICAL_SAMPLE) so the significance gate trusts the tier.
             const fields = [makeField('code'), makeField('category')];
-            const sampleRows = [
-                { code: 'A1', category: 'x' },
-                { code: 'A2', category: 'x' },
-                { code: 'A3', category: 'y' },
-            ];
+            const sampleRows = Array.from({ length: 10 }, (_, i) => ({ code: `A${i}`, category: i % 2 ? 'x' : 'y' }));
             const result = await classifier.Classify({
                 object: makeObject('WidgetThings'),
                 fields,
@@ -58,14 +56,12 @@ describe('SoftPKClassifier', () => {
 
     describe('composite-key uniqueness', () => {
         it('finds a minimal 2-column unique set when no single column is unique', async () => {
-            // Neither orgId nor year is unique alone, but (orgId, year) is.
+            // Neither orgId nor year is unique alone, but (orgId, year) is. Adequate sample:
+            // 5 orgs × 2 years = 10 unique pairs, each org repeats, each year repeats 5×.
             const fields = [makeField('orgId'), makeField('year'), makeField('label')];
-            const sampleRows = [
-                { orgId: 'O1', year: 2024, label: 'shared' },
-                { orgId: 'O1', year: 2025, label: 'shared' },
-                { orgId: 'O2', year: 2024, label: 'shared' },
-                { orgId: 'O2', year: 2025, label: 'shared' },
-            ];
+            const sampleRows = Array.from({ length: 10 }, (_, i) => ({
+                orgId: `O${Math.floor(i / 2)}`, year: 2024 + (i % 2), label: 'shared',
+            }));
             const result = await classifier.Classify({
                 object: makeObject('Allocations'),
                 fields,
@@ -82,12 +78,11 @@ describe('SoftPKClassifier', () => {
 
         it('prefers a 2-column set over a 3-column set (minimality)', async () => {
             // (a,b) is already unique; the scan must stop at size 2 and not return (a,b,c).
+            // Adequate sample: 5 values of a × 2 of b = 10 unique (a,b) pairs; a & b each repeat.
             const fields = [makeField('a'), makeField('b'), makeField('c')];
-            const sampleRows = [
-                { a: '1', b: 'x', c: 'p' },
-                { a: '1', b: 'y', c: 'p' },
-                { a: '2', b: 'x', c: 'q' },
-            ];
+            const sampleRows = Array.from({ length: 10 }, (_, i) => ({
+                a: String(Math.floor(i / 2)), b: i % 2 ? 'x' : 'y', c: 'p',
+            }));
             const result = await classifier.Classify({
                 object: makeObject('Pairs'),
                 fields,
@@ -128,27 +123,15 @@ describe('SoftPKClassifier', () => {
             { color: 'red', size: 'L' }, // exact dup → nothing is unique, even composite
         ];
 
-        it('returns the honest none verdict by DEFAULT when nothing is unique (no fabrication)', async () => {
+        it('nominates the synthetic content-hash key by DEFAULT when no natural PK is found', async () => {
             const result = await classifier.Classify({
                 object: makeObject('Tags'),
                 fields: ambiguousFields,
                 sampleRows: ambiguousRows,
             });
 
-            // Default is now honest 'none' — synthetic is opt-in only, never fabricated.
-            expect(result.Confident).toBe(false);
-            expect(result.Strategy).toBe('none');
-            expect(result.Nominee).toBeUndefined();
-        });
-
-        it('still nominates the synthetic key when syntheticFallback is explicitly opted in', async () => {
-            const result = await classifier.Classify({
-                object: makeObject('Tags'),
-                fields: ambiguousFields,
-                sampleRows: ambiguousRows,
-                syntheticFallback: true,
-            });
-
+            // Default is now the synthetic content-hash identity — the honest, syncable outcome for a
+            // genuinely-keyless object (StagePKClassify creates the field; ToExternalRecord stamps the hash).
             expect(result.Confident).toBe(true);
             expect(result.Strategy).toBe('synthetic');
             expect(result.Nominee).toBe(SYNTHETIC_PK_FIELD_NAME);
@@ -156,14 +139,49 @@ describe('SoftPKClassifier', () => {
             expect(result.Confidence).toBeGreaterThanOrEqual(0.7);
         });
 
-        it('returns honest none with no sample rows at all (default — no fabrication)', async () => {
+        it('returns the honest none verdict only when syntheticFallback is explicitly disabled', async () => {
+            const result = await classifier.Classify({
+                object: makeObject('Tags'),
+                fields: ambiguousFields,
+                sampleRows: ambiguousRows,
+                syntheticFallback: false,
+            });
+
+            expect(result.Confident).toBe(false);
+            expect(result.Strategy).toBe('none');
+            expect(result.Nominee).toBeUndefined();
+        });
+
+        it('defaults to synthetic with no sample rows at all', async () => {
             const result = await classifier.Classify({
                 object: makeObject('Mystery'),
                 fields: [makeField('foo'), makeField('bar')],
             });
 
-            expect(result.Strategy).toBe('none');
-            expect(result.Nominee).toBeUndefined();
+            expect(result.Strategy).toBe('synthetic');
+            expect(result.Nominee).toBe(SYNTHETIC_PK_FIELD_NAME);
+        });
+
+        it('significance gate: a thin sample (< MIN_STATISTICAL_SAMPLE) does NOT nominate a coincidental key → synthetic', async () => {
+            // 2 rows where (contactId, isDelivered) is coincidentally unique — the exact SentEmailRecipient
+            // false-positive. The gate must reject it and fall through to synthetic, not emit a bogus composite.
+            const fields = [makeField('contactId'), makeField('isDelivered'), makeField('email')];
+            const sampleRows = [
+                { contactId: 1, isDelivered: true, email: 'a@x.com' },
+                { contactId: 1, isDelivered: false, email: 'a@x.com' },
+            ];
+            const result = await classifier.Classify({ object: makeObject('SentEmailRecipient'), fields, sampleRows });
+            expect(result.Strategy).toBe('synthetic');
+        });
+
+        it('nullable-awareness: a source-declared-nullable field is never a PK member', async () => {
+            // eventRegId is unique+non-null across THIS adequate sample but declared AllowsNull → excluded.
+            // The only other unique column is the natural "code", so it wins; eventRegId must not be nominated.
+            const fields = [makeField('eventRegId', { AllowsNull: true }), makeField('code')];
+            const sampleRows = Array.from({ length: 10 }, (_, i) => ({ eventRegId: i, code: `C${i}` }));
+            const result = await classifier.Classify({ object: makeObject('Registrations'), fields, sampleRows });
+            expect(result.Nominee).not.toBe('eventRegId');
+            expect(result.Nominee).toBe('code');
         });
     });
 

--- a/packages/MJServer/src/orm.ts
+++ b/packages/MJServer/src/orm.ts
@@ -17,7 +17,11 @@ const createMSSQLConfig = (): sql.config => {
       acquireTimeoutMillis: configInfo.databaseSettings.connectionPool?.acquireTimeoutMillis ?? 30000,
     },
     options: {
-      encrypt: true, // Use encryption
+      // Encryption defaults ON (production behavior). Set DB_ENCRYPT=false to disable TLS
+      // entirely — required for a local/Docker SQL Server presenting a self-signed cert that
+      // the mssql client's TLS layer rejects (DEPTH_ZERO_SELF_SIGNED_CERT) even with
+      // trustServerCertificate. Only the literal 'false' disables; anything else stays ON.
+      encrypt: (process.env.DB_ENCRYPT ?? 'true').toLowerCase() !== 'false',
       enableArithAbort: true,
     },
   };


### PR DESCRIPTION
Framework hardening surfaced while rebuilding the Wild Apricot connector. These are reusable framework fixes (not connector-specific), so they're PR'd separately from the connector deliverable.

## What & why

### SoftPK classifier — genuinely-keyless objects now auto-resolve
- **Renamed** the synthetic PK column `__mj_integration_IdentityHash` → **`IdentityKey`**. The reserved `__mj_` prefix is treated as a framework-hidden column by CodeGen + the schema builder and is **never materialized** as a business PK — which is exactly why the synthetic tier produced a "confident-but-dropped" verdict. A plain name materializes (verified end-to-end).
- **Synthetic content-hash fallback now default ON** — the honest, syncable outcome for a keyless object instead of dropping it.
- **`MIN_STATISTICAL_SAMPLE = 8` significance gate** on the statistical/composite tiers — a 2-row sample makes almost any column-combination look unique, so below the floor the classifier no longer nominates coincidental keys (e.g. a boolean `IsDelivered` flag) and falls through to LLM/synthetic.
- **Nullable-awareness** — a source-declared-nullable field (`AllowsNull === true`) is excluded from PK candidates (a PK member can't be null).

### Pipeline — materialize the synthetic key
- `IntegrationConnectorCreationPipeline.StagePKClassify` now **creates** the `IdentityKey` IOF when the verdict is `synthetic` (it previously skipped an unknown nominee). ApplyAll then materializes the column and `BaseRESTIntegrationConnector.ToExternalRecord` stamps a deterministic content hash into it — so a keyless table syncs + dedupes.

### DB_ENCRYPT override
- `MJServer/orm.ts` + `CodeGenLib/db-connection.ts` hardcoded `encrypt: true`, so a local/Docker SQL Server presenting a self-signed cert was rejected (`DEPTH_ZERO_SELF_SIGNED_CERT`) even with `trustServerCertificate`. Now `encrypt` honors a `DB_ENCRYPT` env var — **defaults ON** (zero prod impact); only the literal `false` disables.

## Proof
- `packages/Integration/pk-classifier` unit tests: **11 pass** (originals updated to the new defaults + 2 new: significance-gate rejects a coincidental composite → synthetic; a nullable field is never a PK member).
- Verified end-to-end on Wild Apricot: 2 genuinely-keyless objects (Donation, SentEmailRecipient) materialized + synced, `IdentityKey` = real SHA-256 content hash.

🤖 Generated with [Claude Code](https://claude.com/claude-code)