### PR TITLE
fix(ng-test-utils): caret @memberjunction/core peer to unblock v5.44.0 release

### DIFF
--- a/packages/Angular/Generic/test-utils/package.json
+++ b/packages/Angular/Generic/test-utils/package.json
@@ -29,7 +29,7 @@
   "license": "ISC",
   "peerDependencies": {
     "@angular/core": "21.1.3",
-    "@memberjunction/core": "5.43.0",
+    "@memberjunction/core": "^5.43.0",
     "vitest": "^4.0.18"
   },
   "devDependencies": {


### PR DESCRIPTION
## Problem
`publish.yml` for v5.44.0 aborted at the version guard: `changeset version` computed **6.0.0** instead of **5.44.0**.

## Root cause
`@memberjunction/ng-test-utils` pinned its peer dependency at an exact version:
```json
"peerDependencies": { "@memberjunction/core": "5.43.0" }
```
On the 5.44.0 minor bump, `@memberjunction/core` moves out of that exact range. Changesets (`onlyUpdatePeerDependentsWhenOutOfRange: true`) treats an out-of-range peer update as a **breaking change → major bump** of the dependent, and the `@memberjunction/*` **fixed group** propagates that major to the entire workspace → **6.0.0**. It was the only package with an exact `@memberjunction/*` peer pin.

## Fix
Loosen the peer to a caret (`^5.43.0`), matching MJ's peer-dep convention everywhere else. Verified in a throwaway worktree: `changeset version` then computes the correct **5.44.0** across the workspace.

Single-line change. Nothing was published or tagged by the failed run — clean to re-release once this lands on `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)