### PR TITLE
fix(CodeGenLib): Make CodeGen output order deterministic on fresh generation

### DIFF
--- a/packages/CodeGenLib/src/Database/manage-metadata.ts
+++ b/packages/CodeGenLib/src/Database/manage-metadata.ts
@@ -2243,7 +2243,7 @@ export class ManageMetadataBase {
                              RelatedEntityID IS NOT NULL AND
                              IsVirtual = ${this.boolLit(false)} AND
                              EntityID NOT IN (SELECT ID FROM ${this.qs(mj_core_schema(), 'Entity')} WHERE SchemaName IN (${excludeSchemas.map(s => `'${s}'`).join(',')}))
-                       ORDER BY RelatedEntityID`;
+                       ORDER BY RelatedEntity, Entity, Name`;
          const entityFieldsResult = await this.runQuery(pool, sSQL);
          const entityFields = entityFieldsResult.recordset;
 
@@ -2449,7 +2449,7 @@ export class ManageMetadataBase {
                              RelatedEntityID IS NOT NULL AND
                              IsVirtual = ${this.boolLit(false)} AND
                              EntityID NOT IN (SELECT ID FROM ${this.qs(mj_core_schema(), 'Entity')} WHERE SchemaName IN (${excludeSchemas.map(s => `'${s}'`).join(',')}))
-                       ORDER BY RelatedEntityID`;
+                       ORDER BY RelatedEntity, Entity, Name`;
          const entityFieldsResult = await this.runQuery(pool, sSQL);
          const entityFields = entityFieldsResult.recordset;
 
@@ -3079,7 +3079,8 @@ export class ManageMetadataBase {
                               WHERE
                                  VirtualEntity = ${this.boolLit(false)} AND
                                  TrackRecordChanges = ${this.boolLit(true)} AND
-                                 SchemaName NOT IN (${excludeSchemas.map(s => `'${s}'`).join(',')})`;
+                                 SchemaName NOT IN (${excludeSchemas.map(s => `'${s}'`).join(',')})
+                              ORDER BY ${this.qi('Name')}`;
          const entitiesResult = await this.runQuery(pool, sqlEntities);
       const entities = entitiesResult.recordset;
          let overallResult = true;
@@ -3517,11 +3518,21 @@ export class ManageMetadataBase {
     * @param relatedEntityNameFieldMap
     * @returns
     */
-   public async updateEntityFieldRelatedEntityNameFieldMap(pool: CodeGenConnection, entityFieldID: string, relatedEntityNameFieldMap: string): Promise<boolean> {
+   public async updateEntityFieldRelatedEntityNameFieldMap(pool: CodeGenConnection, entityFieldID: string, relatedEntityNameFieldMap: string, deferLog?: (sql: string, description: string) => void): Promise<boolean> {
       try   {
          const sSQL = this.dbProvider.callRoutineSQL(mj_core_schema(), 'spUpdateEntityFieldRelatedEntityNameFieldMap', [`'${entityFieldID}'`, `'${relatedEntityNameFieldMap}'`], ['EntityFieldID', 'RelatedEntityNameFieldMap']);
-
-         await this.LogSQLAndExecute(pool, sSQL, `SQL text to update entity field related entity name field map for entity field ID ${entityFieldID}`);
+         const description = `SQL text to update entity field related entity name field map for entity field ID ${entityFieldID}`;
+         if (deferLog) {
+            // Called from the CONCURRENT per-entity base-view generation. Execute now (the DB update
+            // is order-independent) but defer the migration-log line so the caller can emit it in a
+            // deterministic (entity-Name) order — otherwise these EXECs interleave across entities and
+            // make the generated migration non-deterministic. Mirrors LogSQLAndExecute's qsql-quoting.
+            const q = this.qsql(sSQL);
+            await pool.query(q);
+            deferLog(q, description);
+         } else {
+            await this.LogSQLAndExecute(pool, sSQL, description);
+         }
          return true;
       }
       catch (e) {
@@ -3736,7 +3747,7 @@ export class ManageMetadataBase {
          // for the field and sync that up with the EntityFieldValue table. If it is not a simple series of OR statements, we will not be able to parse it and we'll
          // just ignore it.
          const filter = this.dbProvider.getCheckConstraintsSchemaFilter(excludeSchemas);
-         const sSQL = `SELECT * FROM ${this.qs(mj_core_schema(), 'vwEntityFieldsWithCheckConstraints')}${filter}`
+         const sSQL = `SELECT * FROM ${this.qs(mj_core_schema(), 'vwEntityFieldsWithCheckConstraints')}${filter} ORDER BY EntityName, ColumnName`
          const resultResult = await this.runQuery(pool, sSQL);
          const result = resultResult.recordset;
 
@@ -4101,7 +4112,7 @@ export class ManageMetadataBase {
 
    protected async createNewEntities(pool: CodeGenConnection, currentUser: UserInfo): Promise<boolean> {
       try   {
-         const sSQL = `SELECT * FROM ${this.qs(mj_core_schema(), 'vwSQLTablesAndEntities')} WHERE ${this.qi('EntityID')} IS NULL ` + this.createExcludeTablesAndSchemasFilter('');
+         const sSQL = `SELECT * FROM ${this.qs(mj_core_schema(), 'vwSQLTablesAndEntities')} WHERE ${this.qi('EntityID')} IS NULL ` + this.createExcludeTablesAndSchemasFilter('') + ` ORDER BY ${this.qi('SchemaName')}, ${this.qi('TableName')}`;
          const newEntitiesResult = await this.runQuery(pool, sSQL);
       const newEntities = newEntitiesResult.recordset;
 

--- a/packages/CodeGenLib/src/Database/providers/sqlserver/SQLServerCodeGenProvider.ts
+++ b/packages/CodeGenLib/src/Database/providers/sqlserver/SQLServerCodeGenProvider.ts
@@ -1473,7 +1473,7 @@ NumberedRows AS (
    SELECT *
    FROM NumberedRows
    WHERE rn = 1
-   ORDER BY EntityID, Sequence;
+   ORDER BY EntityName, Sequence, FieldName;
 `;
     }
 

--- a/packages/CodeGenLib/src/Database/sql_codegen.ts
+++ b/packages/CodeGenLib/src/Database/sql_codegen.ts
@@ -86,6 +86,18 @@ export class SQLCodeGenBase {
      */
     protected orderedEntitiesForDeleteSPRegeneration: string[] = [];
 
+    /**
+     * Deterministic-logging buffer. Per-entity SQL is generated + executed CONCURRENTLY within a
+     * batch (see generateAndExecuteEntitySQLToSeparateFiles), so appending it to the migration log
+     * live — as it did — interleaves the entities in whichever order their async chains happen to
+     * resolve, making the generated CodeGen_Run migration non-deterministic run-to-run. When this
+     * buffer is non-null, logSQLForNewOrModifiedEntity captures each entity's log lines here
+     * (keyed by Entity ID) instead of writing them immediately; the batch loop then flushes the
+     * buffer in stable entity-Name order after Promise.all. Execution timing is unaffected — only
+     * the log write is deferred — so parallelism (and speed) is preserved.
+     */
+    protected orderedLogBuffer: Map<string, Array<{ sql: string; description: string }>> | null = null;
+
     public async manageSQLScriptsAndExecution(pool: CodeGenConnection, entities: EntityInfo[], directory: string, currentUser: UserInfo): Promise<boolean> {
         try {
             // Build list of entities qualified for forced regeneration if entityWhereClause is provided
@@ -594,6 +606,11 @@ export class SQLCodeGenBase {
                 options.entities.map(e => `${e.SchemaName}.${e.BaseView}`)
             );
 
+            // Enable deterministic per-entity log buffering for the batched generation below.
+            // Each batch's entities generate + execute concurrently, so their migration-log lines
+            // are captured per-entity and flushed in stable Name order after each Promise.all —
+            // making the generated CodeGen_Run migration byte-identical run-to-run.
+            this.orderedLogBuffer = new Map();
             for (let i = 0; i < totalEntities; i += options.batchSize) {
                 const batch = options.entities.slice(i, i + options.batchSize);
                 const promises = batch.map(async (e) => {
@@ -621,7 +638,20 @@ export class SQLCodeGenBase {
                         failedEntities.push(entity);
                     files.push(...result.Files); // add the files to the main files array
                 });
+
+                // Flush this batch's buffered SQL to the migration log in stable entity-Name order,
+                // so the concurrent (interleaved) generation above yields a deterministic migration.
+                const flushOrder = [...batch].sort((a, b) => a.Name.localeCompare(b.Name));
+                for (const e of flushOrder) {
+                    const entries = this.orderedLogBuffer.get(e.ID);
+                    if (entries) {
+                        for (const entry of entries)
+                            SQLLogging.appendToSQLLogFile(entry.sql, entry.description);
+                        this.orderedLogBuffer.delete(e.ID);
+                    }
+                }
             }
+            this.orderedLogBuffer = null;
 
             // Batch summary — makes the full failure scope visible in one pass instead of
             // forcing the operator to bisect across individually-logged per-entity errors.
@@ -637,6 +667,7 @@ export class SQLCodeGenBase {
             return {Success: failedEntities.length === 0, Files: files};
         }
         catch (err) {
+            this.orderedLogBuffer = null; // don't leak buffering state to later calls on error
             logError(err as string);
             return {Success: false, Files: files};
         }
@@ -964,7 +995,18 @@ export class SQLCodeGenBase {
         }
 
         if (shouldLog) {
-            SQLLogging.appendToSQLLogFile(sql, description);
+            if (this.orderedLogBuffer) {
+                // Deterministic-logging mode: defer the migration-log write into a per-entity
+                // buffer (flushed in stable Name order by the batch loop). See orderedLogBuffer.
+                let entries = this.orderedLogBuffer.get(entity.ID);
+                if (!entries) {
+                    entries = [];
+                    this.orderedLogBuffer.set(entity.ID, entries);
+                }
+                entries.push({ sql, description });
+            } else {
+                SQLLogging.appendToSQLLogFile(sql, description);
+            }
             TempBatchFile.appendToTempBatchFile(sql, entity.SchemaName);
         }
 
@@ -1839,8 +1881,19 @@ export class SQLCodeGenBase {
                             // first update the actul field in the metadata object so it can be used from this point forward
                             // and it also reflects what the DB will hold
                             ef.RelatedEntityNameFieldMap = ef._RelatedEntityNameFieldMap;
-                            // then update the database itself
-                            await manageMD.updateEntityFieldRelatedEntityNameFieldMap(pool, ef.ID, ef.RelatedEntityNameFieldMap);
+                            // then update the database itself. When deterministic-log buffering is
+                            // active (concurrent batch generation), defer this EXEC's log line into
+                            // the per-entity buffer (keyed by EntityID) so it flushes in stable Name
+                            // order with the rest of the entity's SQL instead of interleaving.
+                            const buf = this.orderedLogBuffer;
+                            await manageMD.updateEntityFieldRelatedEntityNameFieldMap(pool, ef.ID, ef.RelatedEntityNameFieldMap,
+                                buf
+                                    ? (sql, description) => {
+                                        let entries = buf.get(ef.EntityID);
+                                        if (!entries) { entries = []; buf.set(ef.EntityID, entries); }
+                                        entries.push({ sql, description });
+                                      }
+                                    : undefined);
                         }
                     }
                 }


### PR DESCRIPTION
# PR: Make CodeGen output order deterministic on fresh generation

**Branch:** `feature/codegen-determinism` (off `next`)
**Commit:** `fix(CodeGenLib): make CodeGen output deterministic on fresh generation`
**Attach:** `REPORT.md` (full findings + verification), `codegen-determinism-fix.patch`, and the four
before/after evidence migrations (`det-b_STOCK_run{1,2}.sql`, `det-a_FIXED_run{1,2}.sql`).

---

## Summary

CodeGen produces **non-deterministic SQL migrations** when generating metadata for *new* schema before entity GUIDs are pinned by a committed migration. Two identical runs against
the same schema differ in **~24% of the generated migration's lines**, purely from ordering. This PR
makes CodeGen fully deterministic (0 drift) by ordering every emission on stable names instead of random
GUIDs / physical row order, with **no change to what is generated** and **~1% runtime cost** (within noise).

## Why it matters

Committed apps pin their entity GUIDs + relationship Sequences in the squashed baseline, so re-running
CodeGen against a committed app just *matches* the pinned rows — deterministic. The non-determinism only
bites where it actually hurts: **first-time generation of an app's metadata/migrations**. There, two
developers (or CI, or a simple re-run) get gratuitously different migrations — noisy diffs, unreviewable
churn, and relationship ordering that changes every run. Deterministic CodeGen makes generated migrations
reproducible and diff-clean, which is a prerequisite for trusting them in review and CI.

## Root cause

Eight metadata queries / emission paths in `CodeGenLib` ordered by **random `newId()` GUIDs**
(`EntityID` / `EntityFieldID` / `RelatedEntityID`) or relied on **physical row order**, plus a
**concurrent** per-entity SQL-generation path that appended to the migration log in completion order.
With fresh random GUIDs each run, every one reshuffled the output.

## The fix — order by stable names, buffer the concurrent path

| # | Site | Was | Now |
|---|---|---|---|
| 1 | `manage-metadata.ts` · `ensureCreatedAtUpdatedAtFieldsExist` | *no ORDER BY* | `ORDER BY Name` |
| 2 | `manage-metadata.ts` · `manageOneToManyEntityRelationships` | `ORDER BY RelatedEntityID` | `ORDER BY RelatedEntity, Entity, Name` |
| 3 | `manage-metadata.ts` · `manageManyToManyEntityRelationships` | `ORDER BY RelatedEntityID` | `ORDER BY RelatedEntity, Entity, Name` |
| 4 | `SQLServerCodeGenProvider.ts` · `buildPendingFieldsMainQuery` | `ORDER BY EntityID, Sequence` | `ORDER BY EntityName, Sequence, FieldName` |
| 5 | `manage-metadata.ts` · check-constraint → `EntityFieldValue` sync | *no ORDER BY* | `ORDER BY EntityName, ColumnName` |
| 6 | `manage-metadata.ts` · `createNewEntities` (create + app-assign + permissions) | *no ORDER BY* | `ORDER BY SchemaName, TableName` |
| 7 | `sql_codegen.ts` · batched per-entity SP/view/permission generation | live append during `Promise.all` (completion order) | buffer each entity's log, flush in **Name** order after each batch |
| 8 | `manage-metadata.ts` · `updateEntityFieldRelatedEntityNameFieldMap` (from #7's concurrent path) | logged inline, interleaved | execute immediately, **defer the log line** into #7's buffer |

All keys are stable and unique (entity Name unique per schema; field Sequence/Name unique per entity;
SchemaName+TableName unique). **#7 keeps execution fully concurrent** — only the *log write* is deferred
and reordered, not the work.

*Files:* `packages/CodeGenLib/src/Database/manage-metadata.ts`,
`.../providers/sqlserver/SQLServerCodeGenProvider.ts`, `.../sql_codegen.ts` (+76 / −12).

## Verification (full detail + raw evidence in `REPORT.md`)

**Method.** Two fresh instances off `next`, identical except this fix. In both, an app's baseline was
truncated to schema-only (tables + FKs, no committed metadata) so CodeGen *creates* entities/relationships
fresh — with new random GUIDs — every run. Full workflow each run (`drop-schema → migrate → codegen →
sync`); compared run-to-run with random GUIDs/timestamps normalized.

- **Determinism (the headline):**

  | Instance | CodeGen | run1 vs run2 drift |
  |---|---|---|
  | stock `next` | — | **2,438 lines** |
  | + this fix | — | **0 lines** |

- **Content equivalence — the fix does not change *what* is generated.** Comparing stock vs fixed output
  (GUIDs normalized): the **set of objects is identical** (10 entities / 35 SPs / 20 views / 14
  relationships / 30 permissions; set-diff 0 for every category). After removing order, the *only*
  line-level differences are **relationship `Sequence` values** — 4 relationships get a different number,
  a permutation of the same `{1,2,3,4}` multiset (random-GUID order → name order). All DDL, all other
  INSERTs, permissions, and special fields are identical.

- **Downstream safety — `Sequence` is display-order only.** Swept the whole codebase: every consumer of
  relationship `Sequence` uses it as a **sort key** (`sort((a,b) => a.Sequence - b.Sequence)`); there are
  **no** value-dependent uses (no comparisons to constants, indexing, or keys). So the deterministic
  reassignment only changes the *display order* of related-entity grids — from random to stable name
  order. Nothing breaks.

- **Performance.** Same-instance fix-vs-stock (4 timed fresh-creation runs each): stock 50,016 ms vs fixed
  50,523 ms — **~+1% (~0.5 s), within measurement noise**; execution parallelism unchanged.

## Risk / compatibility

- **No behavioral change** to generated objects — same tables, views, SPs, relationships, permissions.
- Relationship `Sequence` values change on *newly generated* metadata (deterministic, name-ordered). This
  is display-order metadata only (verified above). Already-committed apps are unaffected — their metadata
  is pinned in committed migrations; nothing regenerates it.
- Scoped to `CodeGenLib`; no schema/runtime API changes.

## How to reproduce

Generate an app's metadata from schema-only twice (truncate the app baseline to remove committed codegen
output, drop schema, migrate, codegen — twice), and diff the generated `CodeGen_Run` migrations with GUIDs
normalized. Stock drifts ~24%; with this fix, 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
