### PR TITLE
Business-user usability — Phase 1 foundation (vocabulary, safe defaults, theme picker)

### DIFF
--- a/metadata/notifications/.agent-completion-type.json
+++ b/metadata/notifications/.agent-completion-type.json
@@ -11,7 +11,7 @@
     "Name": "Agent Completion",
     "Description": "Notifications sent when an AI agent completes a task and creates an artifact",
     "DefaultInApp": true,
-    "DefaultEmail": false,
+    "DefaultEmail": true,
     "DefaultSMS": false,
     "AllowUserPreference": true,
     "EmailTemplateID": "@lookup:MJ: Templates.Name=Agent Completion - Email",

--- a/migrations/v5/V202607041200__v5.45.x__Entity_DisplayNamePlural.sql
+++ b/migrations/v5/V202607041200__v5.45.x__Entity_DisplayNamePlural.sql
@@ -1,0 +1,44 @@
+-- Adds DisplayNamePlural + AutoUpdateDisplayNamePlural to the Entity table.
+--
+-- WHY: business-user surfaces (grid headers, "no records" empty states, counts) read
+-- better with the entity's own domain noun in PLURAL form — "No Contacts yet",
+-- "142 Companies" — instead of the platform meta-noun "entity" or a generic "records".
+-- The runtime already derives a plural algorithmically (EntityInfo.DisplayNamePlural →
+-- generatePluralName), but an algorithm mis-handles some words and only speaks English.
+-- These columns let the correct plural be STORED (and edited), mirroring the existing
+-- DisplayName / AutoUpdateDescription pattern already on this table:
+--
+--   * DisplayNamePlural           — the stored plural. When set, it is used verbatim.
+--                                   This is where an admin (or CodeGen's LLM) fixes a
+--                                   word the algorithm gets wrong, and the seam for
+--                                   non-English plurals.
+--   * AutoUpdateDisplayNamePlural — when 1 (default), CodeGen may (re)derive
+--                                   DisplayNamePlural on each run; set to 0 to LOCK a
+--                                   human-authored value so codegen won't overwrite it.
+--                                   Parallels the entity's AutoUpdateDescription flag.
+--
+-- The runtime getter prefers the stored value and falls back to the algorithmic plural
+-- when it is null — so behavior is unchanged until CodeGen populates the column, and any
+-- entity created before this migration keeps working via the fallback.
+--
+-- NOTE: the EntityField rows for these columns, the regenerated vwEntities view, and the
+-- spCreate/spUpdate procs are all produced by CodeGen — do NOT hand-write them here.
+-- Run `mj codegen` after applying this migration.
+
+ALTER TABLE ${flyway:defaultSchema}.Entity ADD
+    DisplayNamePlural NVARCHAR(255) NULL,
+    AutoUpdateDisplayNamePlural BIT NOT NULL DEFAULT 1;
+
+EXEC sp_addextendedproperty
+    @name = N'MS_Description',
+    @value = N'Optional business-friendly PLURAL of the entity''s display name (e.g. "Contacts", "Companies", "Addresses"). When set, it is used verbatim on business-user surfaces (grid headers, empty states, counts); when null, the runtime derives a plural from DisplayName/Name via generatePluralName. Lets an admin or CodeGen override cases the algorithmic pluralizer gets wrong, and is the seam for non-English plurals. Display-only — never a lookup key.',
+    @level0type = N'SCHEMA', @level0name = N'${flyway:defaultSchema}',
+    @level1type = N'TABLE',  @level1name = N'Entity',
+    @level2type = N'COLUMN', @level2name = N'DisplayNamePlural';
+
+EXEC sp_addextendedproperty
+    @name = N'MS_Description',
+    @value = N'When 1 (default), allows the system/LLM to auto-update DisplayNamePlural during CodeGen; when 0, the user has locked this field and codegen will not overwrite it. Mirrors AutoUpdateDescription.',
+    @level0type = N'SCHEMA', @level0name = N'${flyway:defaultSchema}',
+    @level1type = N'TABLE',  @level1name = N'Entity',
+    @level2type = N'COLUMN', @level2name = N'AutoUpdateDisplayNamePlural';

--- a/packages/Angular/Explorer/dashboards/src/DataExplorer/data-explorer-dashboard.component.html
+++ b/packages/Angular/Explorer/dashboards/src/DataExplorer/data-explorer-dashboard.component.html
@@ -72,7 +72,7 @@
             <i [class]="displayIcon" class="entity-icon"></i>
           }
           <h2 class="entity-title">{{ displayTitle }}</h2>
-          <span class="record-count">{{ entities.length }} entities available</span>
+          <span class="record-count">{{ entities.length }} types of data</span>
         }
       </div>
 
@@ -127,7 +127,7 @@
         <div class="home-view-concept-d">
           @if (isLoadingEntities) {
             <div class="loading-state">
-              <mj-loading text="Loading entities..." size="medium"></mj-loading>
+              <mj-loading text="Getting your data ready..." size="medium"></mj-loading>
             </div>
           } @else {
             <div class="home-main-area" [class.panel-open]="state.quickAccessPanelOpen">
@@ -139,7 +139,7 @@
                     #filterInput
                     type="text"
                     class="search-hero-input"
-                    placeholder="Search entities..."
+                    placeholder="Search your data..."
                     [(ngModel)]="entityFilterText"
                   />
                   @if (entityFilterText) {
@@ -154,9 +154,9 @@
                 <!-- Meta row: entity count + All/Favorites pills -->
                 <div class="search-meta-row">
                   <span class="search-entity-count">
-                    {{ filteredEntityCount }} entities
+                    {{ filteredEntityCount }} types of data
                     @if (applicationCount > 0) {
-                      across {{ applicationCount }} applications
+                      across {{ applicationCount }} apps
                     }
                   </span>
                   <div class="pill-toggle">
@@ -164,7 +164,7 @@
                       class="pill-btn"
                       [class.active]="state.homeViewMode === 'all'"
                       (click)="setHomeViewMode('all')">
-                      All Entities
+                      All Data
                     </button>
                     <button
                       class="pill-btn"
@@ -257,13 +257,13 @@
                 <!-- No results -->
                 @if (filteredEntityCount === 0 && entities.length > 0) {
                   <mj-empty-state Variant="no-results"
-                    Title="No entities found"
+                    Title="No matches found"
                     [Message]="NoEntityResultsMessage" />
                 }
                 @if (entities.length === 0) {
                   <mj-empty-state Icon="fa-solid fa-database"
-                    Title="No Entities Available"
-                    Message="There are no entities configured for this application." />
+                    Title="Nothing here yet"
+                    Message="This app doesn't have any data set up yet. An administrator can add data for you to explore here." />
                 }
               </div>
             </div>
@@ -305,7 +305,7 @@
                 <mj-accordion-panel [Expanded]="isQuickAccessSectionExpanded('recentEntities')" (ExpandedChange)="toggleQuickAccessSection('recentEntities')">
                   <ng-template mjAccordionTitle>
                     <i class="fa-solid fa-table qa-section-icon"></i>
-                    <span>Recent Entities</span>
+                    <span>Recently Viewed</span>
                     <span class="mj-accordion-badge mj-accordion-badge--right">{{ quickAccessRecentEntities.length }}</span>
                   </ng-template>
                   @for (entity of quickAccessRecentEntities; track entity.ID) {
@@ -319,7 +319,7 @@
                     </div>
                   }
                   @if (quickAccessRecentEntities.length === 0) {
-                    <div class="qa-empty">No recent entities</div>
+                    <div class="qa-empty">Nothing viewed yet</div>
                   }
                 </mj-accordion-panel>
 

--- a/packages/Angular/Explorer/dashboards/src/DataExplorer/data-explorer-dashboard.component.ts
+++ b/packages/Angular/Explorer/dashboards/src/DataExplorer/data-explorer-dashboard.component.ts
@@ -247,7 +247,7 @@ export class DataExplorerDashboardComponent extends BaseDashboard implements OnI
 
   /** No-results message for the entity list (echoes the filter text). */
   get NoEntityResultsMessage(): string {
-    return `No entities match "${this.entityFilterText}".`;
+    return `Nothing matches "${this.entityFilterText}".`;
   }
 
   /**

--- a/packages/Angular/Explorer/explorer-settings/src/lib/appearance-settings/appearance-settings.component.css
+++ b/packages/Angular/Explorer/explorer-settings/src/lib/appearance-settings/appearance-settings.component.css
@@ -15,48 +15,8 @@
   margin: 0 0 1.5rem 0;
 }
 
-.coming-soon-banner {
-  display: flex;
-  align-items: center;
-  gap: 1.5rem;
-  padding: 2rem;
-  background: color-mix(in srgb, var(--mj-brand-primary) 10%, var(--mj-bg-surface));
-  border-radius: 16px;
-  margin-bottom: 2rem;
-}
-
-.banner-icon {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  width: 4rem;
-  height: 4rem;
-  background: var(--mj-bg-surface);
-  border-radius: 12px;
-  box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.1);
-  flex-shrink: 0;
-}
-
-.banner-icon i {
-  font-size: 2rem;
-  color: var(--mj-brand-primary);
-}
-
-.banner-content h3 {
-  font-size: 1.25rem;
-  font-weight: 600;
-  color: var(--mj-text-primary);
-  margin: 0 0 0.5rem 0;
-}
-
-.banner-content p {
-  font-size: 0.875rem;
-  color: var(--mj-text-secondary);
-  margin: 0;
-}
-
-.planned-features {
-  margin-top: 1rem;
+.theme-section {
+  margin-top: 0.5rem;
 }
 
 .features-title {
@@ -68,24 +28,38 @@
   margin: 0 0 1rem 0;
 }
 
-.features-grid {
-  display: flex;
-  flex-direction: column;
+.theme-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(220px, 1fr));
   gap: 0.75rem;
 }
 
-.feature-card {
+.theme-card {
+  position: relative;
   display: flex;
   align-items: center;
   gap: 1rem;
   padding: 1rem 1.25rem;
   background: var(--mj-bg-surface-card);
-  border: 1px solid var(--mj-border-default);
+  border: 2px solid var(--mj-border-default);
   border-radius: 12px;
-  opacity: 0.7;
+  cursor: pointer;
+  text-align: left;
+  transition: border-color 0.15s ease, background 0.15s ease;
+  color: var(--mj-text-primary);
 }
 
-.feature-icon {
+.theme-card:hover {
+  background: var(--mj-bg-surface-hover);
+  border-color: var(--mj-border-strong);
+}
+
+.theme-card.selected {
+  border-color: var(--mj-brand-primary);
+  background: color-mix(in srgb, var(--mj-brand-primary) 8%, var(--mj-bg-surface));
+}
+
+.theme-card-icon {
   display: flex;
   align-items: center;
   justify-content: center;
@@ -96,29 +70,52 @@
   flex-shrink: 0;
 }
 
-.feature-icon i {
-  font-size: 1rem;
-  color: var(--mj-text-secondary);
+.theme-card-icon i {
+  font-size: 1.1rem;
+  color: var(--mj-brand-primary);
 }
 
-.feature-info {
+.theme-card-info {
   display: flex;
   flex-direction: column;
+  gap: 0.15rem;
+  min-width: 0;
 }
 
-.feature-title {
+.theme-card-name {
   font-weight: 500;
   color: var(--mj-text-primary);
 }
 
-.feature-desc {
-  font-size: 0.875rem;
+.theme-card-desc {
+  font-size: 0.8rem;
   color: var(--mj-text-secondary);
 }
 
+.theme-card-swatches {
+  display: flex;
+  gap: 0.25rem;
+  margin-left: auto;
+  flex-shrink: 0;
+}
+
+.theme-swatch {
+  width: 0.9rem;
+  height: 0.9rem;
+  border-radius: 50%;
+  border: 1px solid var(--mj-border-subtle);
+}
+
+.theme-card-check {
+  position: absolute;
+  top: 0.5rem;
+  right: 0.5rem;
+  color: var(--mj-brand-primary);
+  font-size: 1rem;
+}
+
 @media (max-width: 480px) {
-  .coming-soon-banner {
-    flex-direction: column;
-    text-align: center;
+  .theme-grid {
+    grid-template-columns: 1fr;
   }
 }

--- a/packages/Angular/Explorer/explorer-settings/src/lib/appearance-settings/appearance-settings.component.html
+++ b/packages/Angular/Explorer/explorer-settings/src/lib/appearance-settings/appearance-settings.component.html
@@ -1,30 +1,36 @@
 <div class="appearance-settings">
   <h2 class="section-title">Appearance</h2>
-  <p class="section-description">Customize how MemberJunction looks and feels</p>
+  <p class="section-description">Choose how MemberJunction looks. Your choice is saved to your account, so it follows you on every device.</p>
 
-  <div class="coming-soon-banner">
-    <div class="banner-icon">
-      <i class="fa-solid fa-palette"></i>
-    </div>
-    <div class="banner-content">
-      <h3>Coming Soon</h3>
-      <p>We're working on bringing you more customization options.</p>
-    </div>
-  </div>
-
-  <div class="planned-features">
-    <h4 class="features-title">Planned Features</h4>
-    <div class="features-grid">
-      @for (feature of PlannedFeatures; track feature.title) {
-        <div class="feature-card">
-          <div class="feature-icon">
-            <i [class]="feature.icon"></i>
-          </div>
-          <div class="feature-info">
-            <span class="feature-title">{{ feature.title }}</span>
-            <span class="feature-desc">{{ feature.description }}</span>
-          </div>
-        </div>
+  <div class="theme-section">
+    <h4 class="features-title">Theme</h4>
+    <div class="theme-grid">
+      @for (option of ThemeOptions; track option.Id) {
+        <button
+          type="button"
+          class="theme-card"
+          [class.selected]="IsSelected(option.Id)"
+          (click)="SelectTheme(option.Id)">
+          <span class="theme-card-icon">
+            <i [class]="option.Icon"></i>
+          </span>
+          <span class="theme-card-info">
+            <span class="theme-card-name">{{ option.Name }}</span>
+            @if (option.Description) {
+              <span class="theme-card-desc">{{ option.Description }}</span>
+            }
+          </span>
+          @if (option.PreviewColors && option.PreviewColors.length > 0) {
+            <span class="theme-card-swatches">
+              @for (color of option.PreviewColors; track color) {
+                <span class="theme-swatch" [style.background]="color"></span>
+              }
+            </span>
+          }
+          @if (IsSelected(option.Id)) {
+            <span class="theme-card-check"><i class="fa-solid fa-circle-check"></i></span>
+          }
+        </button>
       }
     </div>
   </div>

--- a/packages/Angular/Explorer/explorer-settings/src/lib/appearance-settings/appearance-settings.component.ts
+++ b/packages/Angular/Explorer/explorer-settings/src/lib/appearance-settings/appearance-settings.component.ts
@@ -1,8 +1,29 @@
-import { Component } from '@angular/core';
+import { Component, OnDestroy, OnInit, inject } from '@angular/core';
+import { Subscription } from 'rxjs';
+import { ThemeService, ThemeDefinition } from '@memberjunction/ng-shared-generic';
 
 /**
- * Placeholder component for future appearance settings.
- * Will include: theme selection, display density, font size.
+ * A selectable theme option shown in the picker — one per registered theme, plus a
+ * synthetic "System" option that follows the OS setting.
+ */
+interface ThemeOption {
+  /** Registered theme id, or the literal 'system' for OS auto-detect. */
+  Id: string;
+  Name: string;
+  Description?: string;
+  Icon: string;
+  PreviewColors?: string[];
+}
+
+/**
+ * Appearance settings — a real, functional theme picker.
+ *
+ * MJ's theming system (light / dark / registered custom themes + a "system" auto-detect
+ * mode) is fully implemented in `ThemeService`; this panel simply exposes it in Settings
+ * (it was previously a "Coming Soon" placeholder). Selecting a theme persists the choice
+ * per-user via `ThemeService.SetTheme`, which writes to `MJ: User Settings` and applies it
+ * immediately across the app. The same preference is honored by the avatar-menu theme
+ * switcher, so the two stay in sync through the shared `Preference$` stream.
  */
 @Component({
   standalone: false,
@@ -10,23 +31,60 @@ import { Component } from '@angular/core';
   templateUrl: './appearance-settings.component.html',
   styleUrls: ['./appearance-settings.component.css']
 })
-export class AppearanceSettingsComponent {
-  // Future planned features
-  PlannedFeatures = [
-    {
-      icon: 'fa-solid fa-moon',
-      title: 'Theme',
-      description: 'Switch between light, dark, or system theme'
-    },
-    {
-      icon: 'fa-solid fa-text-height',
-      title: 'Font Size',
-      description: 'Adjust text size for better readability'
-    },
-    {
-      icon: 'fa-solid fa-expand',
-      title: 'Display Density',
-      description: 'Choose between comfortable and compact layouts'
+export class AppearanceSettingsComponent implements OnInit, OnDestroy {
+  private themeService = inject(ThemeService);
+  private preferenceSub?: Subscription;
+
+  /** The theme cards rendered in the picker (registered themes + a System option). */
+  public ThemeOptions: ThemeOption[] = [];
+
+  /** The currently-selected preference — a theme id or 'system'. Kept in sync reactively. */
+  public SelectedPreference = 'system';
+
+  ngOnInit(): void {
+    this.ThemeOptions = this.buildThemeOptions();
+    this.SelectedPreference = this.themeService.Preference;
+    // Stay in sync if the theme is changed elsewhere (e.g. the avatar-menu switcher).
+    this.preferenceSub = this.themeService.Preference$.subscribe(p => (this.SelectedPreference = p));
+  }
+
+  ngOnDestroy(): void {
+    this.preferenceSub?.unsubscribe();
+  }
+
+  /** Apply and persist the chosen theme. */
+  public async SelectTheme(id: string): Promise<void> {
+    await this.themeService.SetTheme(id);
+  }
+
+  public IsSelected(id: string): boolean {
+    return this.SelectedPreference === id;
+  }
+
+  private buildThemeOptions(): ThemeOption[] {
+    const options: ThemeOption[] = this.themeService.AvailableThemes.map(t => ({
+      Id: t.Id,
+      Name: t.Name,
+      Description: t.Description,
+      Icon: this.iconForTheme(t),
+      PreviewColors: t.PreviewColors
+    }));
+    // Append a "System" option that auto-detects the OS light/dark preference,
+    // mirroring the avatar-menu theme switcher.
+    options.push({
+      Id: 'system',
+      Name: 'System',
+      Description: 'Follow your operating system setting',
+      Icon: 'fa-solid fa-desktop'
+    });
+    return options;
+  }
+
+  private iconForTheme(theme: ThemeDefinition): string {
+    if (theme.IsBuiltIn) {
+      return theme.Id === 'dark' ? 'fa-solid fa-moon' : 'fa-solid fa-sun';
     }
-  ];
+    // Custom themes: hint at their base with the moon/sun, else a generic palette.
+    return theme.BaseTheme === 'dark' ? 'fa-solid fa-moon' : 'fa-solid fa-palette';
+  }
 }

--- a/packages/Angular/Explorer/explorer-settings/src/lib/settings/settings.component.ts
+++ b/packages/Angular/Explorer/explorer-settings/src/lib/settings/settings.component.ts
@@ -77,8 +77,7 @@ export class SettingsComponent extends BaseNavigationComponent implements OnInit
       id: 'appearance',
       label: 'Appearance',
       icon: 'fa-solid fa-palette',
-      description: 'Theme and display settings',
-      disabled: true
+      description: 'Theme and display settings'
     }
   ];
 

--- a/packages/Angular/Explorer/explorer-settings/src/lib/settings/settings.component.ts
+++ b/packages/Angular/Explorer/explorer-settings/src/lib/settings/settings.component.ts
@@ -114,7 +114,7 @@ export class SettingsComponent extends BaseNavigationComponent implements OnInit
       id: 'applications',
       tabId: 'applications',
       sectionId: 'applications',
-      label: 'MJ: Application Settings',
+      label: 'Applications',
       keywords: ['applications', 'apps', 'switcher', 'order', 'visibility', 'menu'],
       description: 'Choose which applications appear in your app switcher'
     },

--- a/packages/Angular/Generic/conversations/src/__tests__/empty-state-default-prompts.test.ts
+++ b/packages/Angular/Generic/conversations/src/__tests__/empty-state-default-prompts.test.ts
@@ -1,0 +1,31 @@
+// The component is decorated with @Component; importing it triggers Angular's JIT path,
+// which needs the compiler present (the render-based DOM tests get this via ng-test-utils).
+import '@angular/compiler';
+import { describe, it, expect } from 'vitest';
+import { MJChatEmptyStateDefaultComponent } from '../lib/components/slots/mj-chat-empty-state-default.component';
+
+/**
+ * The default `emptyState` slot component ships with generic starter prompts so a business
+ * user never faces a blank box, while still letting a host override or suppress them. The
+ * subtle contract is the null-coalescing fallback: `undefined` → defaults, but an explicit
+ * empty array → nothing (a deliberate "no chips" from the host). These tests lock that in.
+ */
+describe('MJChatEmptyStateDefaultComponent.EffectiveSuggestedPrompts', () => {
+  it('shows the built-in default prompts when the host supplies none', () => {
+    const c = new MJChatEmptyStateDefaultComponent();
+    expect(c.EffectiveSuggestedPrompts).toBe(MJChatEmptyStateDefaultComponent.DefaultSuggestedPrompts);
+    expect(c.EffectiveSuggestedPrompts.length).toBeGreaterThan(0);
+  });
+
+  it('uses the host-supplied prompts when provided', () => {
+    const c = new MJChatEmptyStateDefaultComponent();
+    c.SuggestedPrompts = ['Custom one', 'Custom two'];
+    expect(c.EffectiveSuggestedPrompts).toEqual(['Custom one', 'Custom two']);
+  });
+
+  it('renders nothing when the host explicitly passes an empty array (suppression)', () => {
+    const c = new MJChatEmptyStateDefaultComponent();
+    c.SuggestedPrompts = [];
+    expect(c.EffectiveSuggestedPrompts).toEqual([]);
+  });
+});

--- a/packages/Angular/Generic/conversations/src/lib/components/slots/mj-chat-empty-state-default.component.ts
+++ b/packages/Angular/Generic/conversations/src/lib/components/slots/mj-chat-empty-state-default.component.ts
@@ -30,9 +30,9 @@ import type { IMJChatEmptyStateComponent } from './slot-interfaces';
             @if (Subtext) {
                 <div class="mj-chat-empty-state-default__subtext">{{ Subtext }}</div>
             }
-            @if (SuggestedPrompts && SuggestedPrompts.length > 0) {
+            @if (EffectiveSuggestedPrompts.length > 0) {
                 <div class="mj-chat-empty-state-default__prompts">
-                    @for (prompt of SuggestedPrompts; track prompt) {
+                    @for (prompt of EffectiveSuggestedPrompts; track prompt) {
                         <button
                             type="button"
                             class="mj-chat-empty-state-default__prompt-chip"
@@ -86,9 +86,31 @@ import type { IMJChatEmptyStateComponent } from './slot-interfaces';
     ],
 })
 export class MJChatEmptyStateDefaultComponent implements IMJChatEmptyStateComponent {
+    /**
+     * Generic, deployment-agnostic starter prompts shown out-of-the-box so a business
+     * user never faces a blank box. Intentionally broad (they work regardless of what
+     * data or agents a deployment has). A host overrides them by binding `SuggestedPrompts`
+     * to its own list, or suppresses them entirely by binding an empty array.
+     */
+    public static readonly DefaultSuggestedPrompts: readonly string[] = [
+        'What can you help me with?',
+        'Summarize my recent activity',
+        'Help me find a record',
+        'What should I focus on today?',
+    ];
+
     @Input() public Greeting: string = 'How can I help you?';
     @Input() public Subtext?: string;
     @Input() public SuggestedPrompts?: string[];
 
     @Output() public PromptSelected = new EventEmitter<string>();
+
+    /**
+     * The prompts actually rendered: the host-supplied list when provided (including an
+     * explicit empty array to suppress), otherwise the built-in defaults. `??` only falls
+     * back on null/undefined, so `[]` correctly renders nothing.
+     */
+    public get EffectiveSuggestedPrompts(): readonly string[] {
+        return this.SuggestedPrompts ?? MJChatEmptyStateDefaultComponent.DefaultSuggestedPrompts;
+    }
 }

--- a/packages/Angular/Generic/conversations/src/lib/components/workspace/conversation-workspace.component.html
+++ b/packages/Angular/Generic/conversations/src/lib/components/workspace/conversation-workspace.component.html
@@ -16,7 +16,7 @@
   <!-- Loading spinner while initializing agents -->
   @if (!isWorkspaceReady) {
     <div class="workspace-loading">
-      <mj-loading text="Loading agents..." size="large"></mj-loading>
+      <mj-loading text="Getting your agents ready..." size="large"></mj-loading>
     </div>
   }
 

--- a/packages/Angular/Generic/entity-viewer/src/lib/entity-cards/entity-cards.component.html
+++ b/packages/Angular/Generic/entity-viewer/src/lib/entity-cards/entity-cards.component.html
@@ -107,7 +107,7 @@
       <mj-empty-state
         class="no-results"
         Variant="no-results"
-        Title="No records to display" />
+        [Title]="entity ? 'No ' + entity.DisplayNamePlural + ' to display' : 'No records to display'" />
     }
     </div>
   }

--- a/packages/Angular/Generic/entity-viewer/src/lib/entity-data-grid/entity-data-grid.component.html
+++ b/packages/Angular/Generic/entity-viewer/src/lib/entity-data-grid/entity-data-grid.component.html
@@ -339,7 +339,7 @@
       <mj-empty-state
         class="mj-grid-state-fill"
         Icon="fa-solid fa-inbox"
-        Title="No data to display" />
+        [Title]="EntityInfo ? 'No ' + EntityInfo.DisplayNamePlural + ' to display' : 'No data to display'" />
     }
 
     <!-- AG Grid (Client-side mode) -->

--- a/packages/Angular/Generic/entity-viewer/src/lib/entity-viewer/entity-viewer.component.ts
+++ b/packages/Angular/Generic/entity-viewer/src/lib/entity-viewer/entity-viewer.component.ts
@@ -717,7 +717,14 @@ export class EntityViewerComponent extends BaseAngularComponent implements OnIni
 
   /** Title shown in the "no records" empty state — varies with the active filter. */
   get NoRecordsTitle(): string {
-    return this.DebouncedFilterText ? 'No matching records' : 'No records found';
+    if (this.DebouncedFilterText) {
+      return 'No matching records';
+    }
+    // Prefer the entity's business-friendly plural ("No Contacts yet") over the
+    // generic "No records found" so the empty state speaks the user's own domain
+    // language. Falls back to "records" when no entity is in scope.
+    const plural = this.EffectiveEntity?.DisplayNamePlural;
+    return plural ? `No ${plural} yet` : 'No records found';
   }
 
   /** True when the "no records" empty state is the result of an active filter. */

--- a/packages/Angular/Generic/resource-permissions/src/lib/user-sharing-center.component.dom.test.ts
+++ b/packages/Angular/Generic/resource-permissions/src/lib/user-sharing-center.component.dom.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect } from 'vitest';
 import { ComponentFixture } from '@angular/core/testing';
 import { NormalizedPermission } from '@memberjunction/core';
 import { renderComponentFixture, query, queryAll, text, hasClass, click, capture, createFakeProvider } from '@memberjunction/ng-test-utils';
-import { UserSharingCenterComponent, SharingCenterDomainGroup, SharingCenterTab } from './user-sharing-center.component';
+import { UserSharingCenterComponent, SharingCenterDomainGroup, SharingCenterTab, sharingDomainDisplayLabel } from './user-sharing-center.component';
 
 /**
  * DOM-level spec for <mj-user-sharing-center> — a standalone, data-bound component with
@@ -33,8 +33,13 @@ function permission(overrides: Partial<NormalizedPermission> = {}): NormalizedPe
 }
 
 function group(overrides: Partial<SharingCenterDomainGroup> = {}): SharingCenterDomainGroup {
+  const domainName = overrides.DomainName ?? 'Dashboard Permissions';
   return {
-    DomainName: 'Dashboard Permissions',
+    DomainName: domainName,
+    // Mirror production: groupByDomain sets Label to the business-friendly heading
+    // while leaving DomainName as the lookup key. Deriving it here keeps the two in
+    // step when a test overrides DomainName.
+    Label: sharingDomainDisplayLabel(domainName),
     Icon: 'fa-solid fa-gauge',
     Rows: [permission()],
     Expanded: true,
@@ -75,7 +80,9 @@ describe('UserSharingCenterComponent (DOM, data-bound)', () => {
     const f = render({}, (c) => {
       c.SharedWithMe = [group({ Rows: [permission(), permission({ SourceRecordID: 'perm2' })] })];
     });
-    expect(text(f, '.group-name')).toBe('Dashboard Permissions');
+    // The section heading shows the business-friendly label ("Dashboards"), NOT the raw
+    // domain lookup key ("Dashboard Permissions").
+    expect(text(f, '.group-name')).toBe('Dashboards');
     // The per-group row count now renders as the accordion title's badge.
     expect(text(f, '.mj-accordion-badge')).toBe('2');
   });
@@ -166,5 +173,24 @@ describe('UserSharingCenterComponent (DOM, data-bound)', () => {
       c.SharedWithMe = [group({ Rows: [permission({ Actions: ['Read', 'Update'] })] })];
     });
     expect(text(f, '.row .actions')).toBe('Read, Update');
+  });
+});
+
+describe('sharingDomainDisplayLabel', () => {
+  it('maps each built-in permission domain to a business-friendly heading', () => {
+    expect(sharingDomainDisplayLabel('Dashboard Permissions')).toBe('Dashboards');
+    expect(sharingDomainDisplayLabel('Artifact Permissions')).toBe('Files');
+    expect(sharingDomainDisplayLabel('Collection Permissions')).toBe('Collections');
+    expect(sharingDomainDisplayLabel('Access Control Rules')).toBe('Rules');
+    expect(sharingDomainDisplayLabel('Resource Permissions')).toBe('Shared items');
+  });
+
+  it('falls back to the domain name with a trailing " Permissions" stripped', () => {
+    // An unmapped custom domain still reads cleanly instead of showing "… Permissions".
+    expect(sharingDomainDisplayLabel('Widget Permissions')).toBe('Widget');
+  });
+
+  it('falls back to the raw domain name when there is nothing to strip', () => {
+    expect(sharingDomainDisplayLabel('Something Custom')).toBe('Something Custom');
   });
 });

--- a/packages/Angular/Generic/resource-permissions/src/lib/user-sharing-center.component.html
+++ b/packages/Angular/Generic/resource-permissions/src/lib/user-sharing-center.component.html
@@ -46,7 +46,7 @@
                     (ExpandedChange)="OnGroupExpandedChange(group, $event)">
                     <ng-template mjAccordionTitle>
                         <span class="group-icon"><i [class]="group.Icon"></i></span>
-                        <span class="group-name">{{ group.DomainName }}</span>
+                        <span class="group-name">{{ group.Label }}</span>
                         <span class="mj-accordion-badge mj-accordion-badge--right">{{ group.Rows.length }}</span>
                     </ng-template>
                     <ng-template mjAccordionBody>
@@ -83,7 +83,7 @@
                     (ExpandedChange)="OnGroupExpandedChange(group, $event)">
                     <ng-template mjAccordionTitle>
                         <span class="group-icon"><i [class]="group.Icon"></i></span>
-                        <span class="group-name">{{ group.DomainName }}</span>
+                        <span class="group-name">{{ group.Label }}</span>
                         <span class="mj-accordion-badge mj-accordion-badge--right">{{ group.Rows.length }}</span>
                     </ng-template>
                     <ng-template mjAccordionBody>

--- a/packages/Angular/Generic/resource-permissions/src/lib/user-sharing-center.component.ts
+++ b/packages/Angular/Generic/resource-permissions/src/lib/user-sharing-center.component.ts
@@ -29,10 +29,41 @@ export type SharingCenterTab = 'shared-with-me' | 'shared-by-me';
  * around the same shape.
  */
 export interface SharingCenterDomainGroup {
+    /**
+     * The permission domain's identity — a LOOKUP KEY that drives Revoke resolution,
+     * audit-entity mapping, and icon selection in PermissionEngine. Never renamed.
+     */
     DomainName: string;
+    /** Business-friendly heading shown to the user (see `sharingDomainDisplayLabel`). */
+    Label: string;
     Icon: string;
     Rows: NormalizedPermission[];
     Expanded: boolean;
+}
+
+/**
+ * Display-only friendly headings for the built-in permission domains, used purely for
+ * the Sharing Center section labels. The underlying `DomainName` is a LOOKUP KEY (it
+ * drives Revoke resolution, audit-entity mapping, and icon selection in PermissionEngine)
+ * and MUST NOT be renamed — so this map translates only what the user *reads*, never what
+ * the code *matches on*.
+ */
+export const SharingDomainDisplayLabels: Record<string, string> = {
+    'Dashboard Permissions': 'Dashboards',
+    'Artifact Permissions': 'Files',
+    'Collection Permissions': 'Collections',
+    'Access Control Rules': 'Rules',
+    'Resource Permissions': 'Shared items',
+};
+
+/**
+ * Returns a business-friendly heading for a permission domain. Falls back to the domain
+ * name with a trailing " Permissions" stripped (so an unmapped custom domain like
+ * "Widget Permissions" reads as "Widget"), then to the raw domain name.
+ */
+export function sharingDomainDisplayLabel(domainName: string): string {
+    return SharingDomainDisplayLabels[domainName]
+        ?? (domainName.replace(/\s+Permissions$/i, '').trim() || domainName);
 }
 
 /**
@@ -295,6 +326,7 @@ export class UserSharingCenterComponent extends BaseAngularComponent implements 
         for (const [domainName, list] of bucket) {
             groups.push({
                 DomainName: domainName,
+                Label: sharingDomainDisplayLabel(domainName),
                 Icon: PermissionEngine.DomainIconFor(domainName),
                 Rows: list.sort((a, b) => (a.ResourceName ?? '').localeCompare(b.ResourceName ?? '')),
                 Expanded: list.length <= 10,

--- a/packages/Angular/Generic/user-routines/src/lib/new-routine.component.html
+++ b/packages/Angular/Generic/user-routines/src/lib/new-routine.component.html
@@ -1,6 +1,6 @@
 @if (IsLoading) {
   <div class="editor-loading">
-    <mj-loading text="Loading editor..." size="medium"></mj-loading>
+    <mj-loading text="Getting the editor ready..." size="medium"></mj-loading>
   </div>
 } @else {
   <div class="routine-editor">

--- a/packages/MJCore/src/__tests__/entityInfo.displayNamePlural.test.ts
+++ b/packages/MJCore/src/__tests__/entityInfo.displayNamePlural.test.ts
@@ -1,0 +1,55 @@
+/**
+ * Tests for EntityInfo.DisplayNamePlural — the business-user-friendly plural mechanism.
+ *
+ * DisplayNamePlural is the seam that lets MJ surface a client's own domain nouns ("Members",
+ * "Matters") in place of the platform meta-noun "entity" on business-user surfaces (grid headers,
+ * empty states, counts). It derives from DisplayNameOrName so a per-deployment DisplayName override
+ * flows through automatically, and it delegates pluralization to generatePluralName (irregulars,
+ * -y → -ies, -s/ch/sh/x/z → -es, and idempotence when the name is already plural).
+ *
+ * See plans/business-user-usability.md §4.
+ */
+import { describe, it, expect } from 'vitest';
+import { EntityInfo } from '../generic/entityInfo';
+
+/** Minimal EntityInfo with a controllable Name / DisplayName. */
+function makeEntity(name: string, displayName: string | null = null): EntityInfo {
+    return new EntityInfo({
+        ID: `ent-${name}`,
+        Name: name,
+        DisplayName: displayName,
+        SchemaName: 'app',
+        BaseTable: name.replace(/\s+/g, ''),
+        EntityFields: [
+            { ID: 'f1', EntityID: `ent-${name}`, Name: 'ID', Type: 'uniqueidentifier', IsPrimaryKey: true, IsUnique: true, Sequence: 1, Status: 'Active', AllowsNull: false },
+        ],
+    });
+}
+
+describe('EntityInfo.DisplayNamePlural', () => {
+    it('pluralizes a singular display name with the default rule', () => {
+        expect(makeEntity('Contact').DisplayNamePlural).toBe('Contacts');
+    });
+
+    it('applies the consonant + y → ies rule', () => {
+        expect(makeEntity('Company').DisplayNamePlural).toBe('Companies');
+    });
+
+    it('applies the -s/ch/sh/x/z → es rule', () => {
+        expect(makeEntity('Address').DisplayNamePlural).toBe('Addresses');
+    });
+
+    it('prefers DisplayName over Name (per-deployment override flows through)', () => {
+        // A membership org renames the "Contact" entity's DisplayName to "Member".
+        expect(makeEntity('Contact', 'Member').DisplayNamePlural).toBe('Members');
+    });
+
+    it('falls back to Name when DisplayName is not set', () => {
+        expect(makeEntity('Invoice').DisplayNamePlural).toBe('Invoices');
+    });
+
+    it('is idempotent when the display name is already plural', () => {
+        // generatePluralName returns an already-plural name unchanged rather than double-pluralizing.
+        expect(makeEntity('Contacts').DisplayNamePlural).toBe('Contacts');
+    });
+});

--- a/packages/MJCore/src/generic/entityInfo.ts
+++ b/packages/MJCore/src/generic/entityInfo.ts
@@ -8,7 +8,7 @@ import { TypeScriptTypeFromSQLType, SQLFullType, SQLMaxLength, FormatValue, Code
 import { IsFixedWidthStringSQLType } from "@memberjunction/sql-dialect"
 import { LogError } from "./logging"
 import { CompositeKey } from "./compositeKey"
-import { WarningManager, SafeJSONParse, UUIDsEqual } from "@memberjunction/global"
+import { WarningManager, SafeJSONParse, UUIDsEqual, generatePluralName } from "@memberjunction/global"
 
 /**
  * Valid values for EntityField.ExtendedType.
@@ -1992,7 +1992,21 @@ export class EntityInfo extends BaseInfo {
     }
 
     /**
-     * Returns the EntityField object for the Field that has IsNameField set to true. If multiple fields have IsNameField on, the function will return the first field (by sequence) that matches. 
+     * Returns a business-user-friendly PLURAL of the entity's display name — e.g. "Contacts", "Companies",
+     * "Addresses". Derived from `DisplayNameOrName` via `generatePluralName`, so it respects a
+     * per-deployment `DisplayName` override (rename the entity's DisplayName to "Member" and this returns
+     * "Members") and handles irregular plurals and the common English rules (`-y → -ies`, `-s/ch/sh/x/z → -es`).
+     *
+     * This is the mechanism for surfacing the user's own domain nouns in place of the platform meta-noun
+     * "entity" on business-user surfaces (grid headers, empty states, counts). It is display-only — never
+     * use it as a lookup key. If the display name is already plural, `generatePluralName` returns it unchanged.
+     */
+    get DisplayNamePlural(): string {
+        return generatePluralName(this.DisplayNameOrName);
+    }
+
+    /**
+     * Returns the EntityField object for the Field that has IsNameField set to true. If multiple fields have IsNameField on, the function will return the first field (by sequence) that matches.
      * If no fields match, if there is a field called "Name", that is returned. If there is no field called "Name", null is returned.
      */
     get NameField(): EntityFieldInfo | null {

--- a/plans/business-user-usability.md
+++ b/plans/business-user-usability.md
@@ -1,0 +1,166 @@
+# Making MemberJunction Feel Like Home for Business Users
+
+**Status:** Active · Phase 1 (Foundation) in progress
+**Branch:** `claude/mj-business-user-usability-onfrmz`
+**Owner:** Platform / Explorer
+
+---
+
+## 1. Why this work exists
+
+MemberJunction is, today, an exceptional platform *for the people who build on it*. The README says it plainly — "the open-source, AI-native data platform," "175 modular TypeScript packages," "one object model that runs identically on the server, in the browser, in the CLI." Every hero example is a code snippet. The docs speak of metadata, CodeGen, providers, schema, GraphQL. That framing is correct and it is a strength: MJ's technical depth is real and hard-won.
+
+But there is a second audience who never writes a line of that code and yet is supposed to get value from the platform every day: the **business user**. The membership director who wants to know who's about to lapse. The events coordinator updating a batch of registrations. The ops manager who just wants to ask a question about the data and trust the answer. For that person, MJ's technical excellence is invisible at best and intimidating at worst.
+
+The good news — and the thesis of this entire effort — is this:
+
+> **MJ has already built almost every consumer-grade primitive a business user needs. They are just latent, off-by-default, and wearing developer vocabulary.**
+
+This is not a "build a business-user product" problem. It is a **framing, defaults, and on-ramp** problem. That is dramatically cheaper to solve and it compounds: every fix makes the next feature land better.
+
+### The evidence (from a four-surface audit)
+
+A structured audit of the surfaces business users actually touch — Explorer end-user UX, the conversational/agent surface, the no-code building tools, and the cross-cutting onboarding/permissions/sharing concerns — found the same story on every surface:
+
+**The friendly parts already exist.** The Google-Docs-grade share dialog. The unified notification engine (in-app + email + SMS, per-user prefs, per-type templates). Self-service User Routines with a genuinely approachable "run this for me every weekday morning" form. A personalized Home with drag-to-reorder pins, favorites, and recents. Sage as a zero-config default agent. And the standout: the **Bulk Operations Studio** with its dry-run → diff → confirm → apply flow — the single most business-user-friendly pattern in the codebase.
+
+**But they are gated behind developer wiring or turned off.** Chat ships a blank box with *no* starter prompts. Email/SMS notifications default **off** for "your agent finished." The Appearance/theme tab is literally `disabled: true`. Tool-confirmation safety gates only fire if a developer coded a handler. The app "marketplace" (Open Apps) is Git-and-CLI only, with no in-product browse-and-click.
+
+**And developer nouns leak everywhere a user navigates.** The default Data Explorer app — pitched as data browsing — says *"Search entities…"*, *"142 entities across 8 applications"*, *"No Entities Available."* Record labels fall back to `Contacts: 8f3a1b2…` truncated GUIDs. The Sharing Center groups by *"Access Control Rules"* and *"Resource Permissions."* `MJ:` schema prefixes surface in settings labels. "Entity" is a data-modeling term; a business user thinks *Contacts*, *Invoices*, *Members* — never "entities."
+
+### The north star
+
+MJ's real differentiator for business users is the combination it already has: **unified data + agents that operate on that data + dry-run safety.** The one-sentence promise is:
+
+> **Ask questions about your data, and safely act on it — without code.**
+
+The three pillars of that promise already ship (Sage chat, Bulk Ops dry-run, Predictive Studio's "Predictions" door). This effort is about making that promise **visible, humane, and on by default**.
+
+---
+
+## 2. Design principles
+
+Every change in this effort is measured against these.
+
+1. **Use the user's domain nouns, not the platform's meta-nouns.** A user never thinks "entity." Show the thing (*Contacts*, *Members*) via each entity's configured `DisplayName`; only fall back to a generic word ("data," "records") when there is genuinely no specific name. The *specific* name should win almost always.
+2. **Match the word to the reader.** Keep technical terms where the audience is technical — the Admin app, developer docs, and **agent-tool contracts** (tool names like `OpenEntityData` are a machine interface, not user copy). Only translate on surfaces a business user lands on: Home, Data Explorer, Chat, Search, Sharing Center, Settings, notifications.
+3. **One word per concept, everywhere.** The View / Query / Report / Dashboard tangle confuses because it is four overlapping words for "saved output" with no explanation. Pick the smallest vocabulary and reuse it relentlessly.
+4. **Safe, humane defaults.** A preference a user would obviously want on (email me when my agent finishes) should be on. Safety a user would obviously expect (confirm before an agent sends an email) should not depend on a developer having wired it.
+5. **Latent capability must be switched on and dressed up, not rebuilt.** Before building anything, check whether the primitive already exists. It usually does.
+6. **Configurable per deployment.** MJ serves many organizations. Vocabulary is not a hardcode — a membership org should see "Members," a law firm "Matters," and neither should ever see "entity." The mechanism is metadata (`DisplayName`), not string literals.
+
+---
+
+## 3. The vocabulary translation
+
+This is the heart of Phase 1. The mapping below is the agreed target. Note: **"agent" stays** — it has crossed into common usage and renaming it to "assistant" would make MJ read as *behind*, not friendlier. We translate only the genuinely platform-internal terms.
+
+### Core data browsing (the worst offender — the default Data Explorer app)
+
+| Current (leaks) | Target | Rationale |
+|---|---|---|
+| "Entity" / "Entities" | The entity's `DisplayName` (plural) — *Contacts, Invoices*. Generic fallback: **"data"** / **"records"** | Never show the meta-noun; show the thing |
+| "Search entities…" | **"Search your data…"** | Plain, action-oriented |
+| "142 entities across 8 applications" | **"142 types of data across 8 apps"** — or hide the count | The count is a schema fact, not a user need |
+| "No Entities Available" | **"Nothing here yet"** + a teaching CTA | Empty state as a teaching moment |
+| `Contacts: 8f3a1b2…` (GUID fallback) | A resolved name, or **"Untitled …"** | GUIDs erode trust instantly |
+
+### Permissions & sharing (the share *dialog* is already good; the Sharing *Center* leaks)
+
+| Current | Target |
+|---|---|
+| "Access Control Rules" | **"Rules"** or fold into the resource it governs |
+| "Resource Permissions" | **"Shared items"**; group by the real thing: *Dashboards, Files, Collections* |
+| "Dashboard Permissions" / "Artifact Permissions" | **"Dashboards"** / **"Files"** — drop "Permissions"; the "Shared with me" tab already implies it |
+| "Revoke access… cannot be undone" | **"Remove access"** with **Undo** (match the dialog's gentler model) |
+
+### AI surface (keep "agent")
+
+| Current | Target |
+|---|---|
+| "Agent" | **Keep** |
+| "Auto (use default)" | **"Sage (default agent)"** — name it |
+| "Loading agents…" | **"Getting your agents ready…"** |
+| "Plan Mode" | **"Review before acting"** — describe the benefit, not the mechanism |
+| `/skill` (undiscoverable) | Vocabulary is fine; the fix is *teaching* it exists, not renaming |
+
+### Saved outputs (collapse the four-word tangle)
+
+| Current | Target framing |
+|---|---|
+| View / Query / Report / Dashboard | Lead with two user-facing ideas: **"Views"** (a saved, filtered list of your data) and **"Dashboards"** (a page of charts). Treat Query/Report as plumbing that *produces* those, not user-facing choices. |
+| "Shared view" (unexplained toggle) | **"Let teammates see this view"** |
+| "Scope" | **"Which records"** / **"Where to look"** |
+
+### Routines (the Advanced pane leaks hardest)
+
+| Current | Target |
+|---|---|
+| "Monitoring vs Scheduled" | **"Watch for changes"** vs **"Run on a schedule"** |
+| "Cron expression" | Hide behind the friendly frequency control; reveal only under a clearly-labeled Advanced |
+| "IANA timezone" | **"Time zone"** with a friendly dropdown |
+| "Starting payload (JSON)" | **"Extra instructions"** — plain text for the default case |
+| "NotifyCondition: OnChange" | **"Tell me only when something changes"** |
+
+### Cross-cutting
+
+Strip the `MJ:` prefix and platform words (*metadata, schema, provider, CodeGen, GraphQL*) from anything a business user reads. Those belong to the Admin app and developer docs only.
+
+---
+
+## 4. The mechanism: a display-vocabulary layer, not scattered edits
+
+The durable version of this is **not** find-and-replace across templates. It is a thin, one-place vocabulary layer with two tiers:
+
+1. **Per-entity, admin-configurable (the primary path).** Every entity already carries a `DisplayName` (`EntityInfo.DisplayNameOrName`). The moment an admin renames an entity's DisplayName to the client's own language ("Members"), every surface that respects it updates for free. This turns vocabulary from a one-time cleanup into a **per-deployment configuration** — exactly what a multi-tenant data platform needs.
+   - **Gap closed in Phase 1:** there was no *plural* form. A grid header, an empty state ("No **Members** yet"), a count ("142 **Members**") all want the plural. Phase 1 adds `EntityInfo.DisplayNamePlural`, deriving it from `DisplayNameOrName` via the existing `generatePluralName` helper in `@memberjunction/global` (which already handles irregulars, `-y → -ies`, `-s/ch/sh/x/z → -es`). Admin renames DisplayName → correct plural flows automatically.
+
+2. **Generic fallback words (the last resort).** Where no single entity is in scope — "Search your data…", "142 types of data" — the generic noun ("data," "records") is UI copy. Short-term these are direct string edits on the handful of business-user surfaces. **Long-term the proper home is Angular's i18n (`$localize`)**, which also closes the localization gap the audit flagged (no multi-language support today). Vocabulary cleanup and localization are the *same effort* done properly — a strong reason to route generic UI copy through `$localize` as the effort matures.
+
+**What must NOT change:** property bindings (`[entities]="entities"`), CSS class names (`.entity-icon`), TypeScript identifiers, and **agent-tool/context contracts** (`OpenEntityData`, `SelectedEntityName`, `VisibleEntityCount`). These are machine interfaces. Only human-visible display text is translated.
+
+---
+
+## 5. Roadmap
+
+### Phase 1 — Foundation: vocabulary + safe defaults (weeks, high leverage) — IN PROGRESS
+
+The multiplier. Everything else lands better once a user isn't tripping over "entities" and blank boxes on day one.
+
+- **1a. `EntityInfo.DisplayNamePlural`** — the plural mechanism, unit-tested. *(this PR)*
+- **1b. Data Explorer vocabulary** — translate the display strings on the default data-browsing app (Search placeholder, loading text, counts, empty states, "Recent Entities"). Bindings/classes/agent-tools untouched. *(this PR — the first, highest-visibility application)*
+- **1c. Safe defaults** — flip email/in-app notifications on for Agent Completion + Routine types; enable the Appearance/theme tab; ship default "try asking…" starter prompts in the chat empty state.
+- **1d. Sharing Center vocabulary** — humanize the permission-domain section labels.
+- **1e. First-run experience** — a lightweight tour over the shell (app switcher → search → Home pins → chat) and consistent teaching empty states. There is *none* today.
+
+### Phase 2 — Turn latent power into a product (the strategic bets)
+
+- **2a. Lean into the agent as the no-code path.** Seed the planned NL→FieldRules authoring agent for Bulk Ops — erases the one friction point (raw formula/lookup/condition expressions) in the closest-to-ready no-code surface. Same pattern for "ask for a view in plain English → get a saved view."
+- **2b. In-product app/template marketplace.** Expose Open Apps as a browse-and-click gallery of **role-specific starter workspaces** (Membership Director, Events Coordinator) with sample content — the shipped apps today skew admin/developer.
+- **2c. Agent catalog in chat.** A browsable "here's what your agents can do" with plain-language descriptions and safe/consequential labeling — discovery is `@`-typeahead only today.
+- **2d. Trust made human, by default.** Make tool-confirmation ("Allow the agent to send this email?") a framework default for consequential actions rather than dev-wired; render "here's what I'm about to do / did" as plain-language summaries.
+
+### Phase 3 — Bigger directional bets
+
+- **3a. No-code dashboard/report assembler.** Dashboards are developer-only authoring today (write an Angular component). A lightweight "pin these views and charts into a page" composer opens the biggest remaining self-service gap. Views + Filter Builder are already fully no-code — extend that energy upward.
+- **3b. Role-based onboarding.** On first login, "What do you do?" → provision a role-appropriate workspace, sample data, and the relevant agents/routines already switched on.
+
+---
+
+## 6. What's explicitly in vs. out for Phase 1 (this PR)
+
+**In:**
+- `EntityInfo.DisplayNamePlural` getter + unit tests (the plural mechanism).
+- Data Explorer display-string vocabulary cleanup (the first, most-visible application).
+
+**Out (later phases, tracked above):** notification defaults, theme tab, chat starter prompts, first-run tour, Sharing Center labels, the marketplace, the NL-authoring agent, the dashboard assembler. These are real feature work and are sequenced deliberately — not crammed into the foundation.
+
+---
+
+## 7. Guardrails for anyone extending this effort
+
+- **Never translate a binding, class, TS identifier, or agent-tool/context name.** Only human-visible copy.
+- **Prefer `DisplayName`/`DisplayNamePlural` over a literal.** If a specific entity is in scope, use its configured name so per-deployment renaming works.
+- **Route generic UI copy toward `$localize`** as the effort matures — it doubles as localization.
+- **Default toward "on" for preferences a user would obviously want, and toward "safe" for gates a user would obviously expect** — but never toward surprising outbound side effects.
+- **Check for the existing primitive first.** The audit's recurring finding is that it already exists.

--- a/plans/business-user-usability.md
+++ b/plans/business-user-usability.md
@@ -123,15 +123,19 @@ The durable version of this is **not** find-and-replace across templates. It is 
 
 ## 5. Roadmap
 
-### Phase 1 — Foundation: vocabulary + safe defaults (weeks, high leverage) — IN PROGRESS
+### Phase 1 — Foundation: vocabulary + safe defaults (weeks, high leverage) — LARGELY SHIPPED
 
 The multiplier. Everything else lands better once a user isn't tripping over "entities" and blank boxes on day one.
 
-- **1a. `EntityInfo.DisplayNamePlural`** — the plural mechanism, unit-tested. *(this PR)*
-- **1b. Data Explorer vocabulary** — translate the display strings on the default data-browsing app (Search placeholder, loading text, counts, empty states, "Recent Entities"). Bindings/classes/agent-tools untouched. *(this PR — the first, highest-visibility application)*
-- **1c. Safe defaults** — flip email/in-app notifications on for Agent Completion + Routine types; enable the Appearance/theme tab; ship default "try asking…" starter prompts in the chat empty state.
-- **1d. Sharing Center vocabulary** — humanize the permission-domain section labels.
-- **1e. First-run experience** — a lightweight tour over the shell (app switcher → search → Home pins → chat) and consistent teaching empty states. There is *none* today.
+- **1a. `EntityInfo.DisplayNamePlural`** — the plural mechanism, unit-tested. ✅ **Done** (commit 1).
+- **1b. Data Explorer vocabulary** — translate the display strings on the default data-browsing app (Search placeholder, loading text, counts, empty states, "Recent Entities"). Bindings/classes/agent-tools untouched. ✅ **Done** (commit 1).
+- **1b-ext. `DisplayNamePlural` wired into entity-viewer** — the grid / cards / data-grid "no records" empty states now read "No **Contacts** yet" instead of "No records found," using the entity's business-friendly plural with a graceful fallback. ✅ **Done** (commit 2).
+- **1c. Safe defaults** — ✅ **Partly done** (commit 2):
+  - **Notifications**: flipped `DefaultEmail` on for **Agent Completion** (it has an email template, so this is complete). **User Routine** was intentionally left off — it has *no* `EmailTemplateID`, so enabling email alone would be a broken default; in-app is already on. Authoring the routine email template + flipping it is Phase 2.
+  - **Theme**: the Appearance settings tab was a "Coming Soon" stub even though MJ's theming (`ThemeService`) is fully functional (light/dark/registered themes/system, already wired into the avatar menu). Rather than surface a dead-end, **built a real theme picker** in `AppearanceSettingsComponent` (registered themes + a System option, persisted per-user via `ThemeService.SetTheme`, reactively synced with the avatar switcher) and **enabled the tab**.
+  - **Chat starter prompts**: the `emptyState` slot default component shipped blank; added generic, deployment-agnostic default starter prompts (override-safe — a host binding `[]` still suppresses) and softened "Loading agents…" → "Getting your agents ready…".
+- **1d. Sharing Center vocabulary** — ✅ **Done** (commit 2). Humanized the permission-domain section headings ("Dashboard Permissions" → "Dashboards", "Access Control Rules" → "Rules", etc.) via a **display-only** label map. Critically, the underlying `DomainName` is a *lookup key* (drives Revoke resolution, audit-entity mapping, and icon selection) and was left untouched — only what the user reads changed.
+- **1e. First-run experience** — a lightweight tour over the shell (app switcher → search → Home pins → chat) and consistent teaching empty states. There is *none* today. **Not yet built** — this is genuinely new UI surface (a tour/coach-mark component) and is the remaining Phase 1 item.
 
 ### Phase 2 — Turn latent power into a product (the strategic bets)
 
@@ -147,13 +151,23 @@ The multiplier. Everything else lands better once a user isn't tripping over "en
 
 ---
 
-## 6. What's explicitly in vs. out for Phase 1 (this PR)
+## 6. What shipped in Phase 1
 
-**In:**
+**Commit 1 — plan + mechanism + first application:**
 - `EntityInfo.DisplayNamePlural` getter + unit tests (the plural mechanism).
-- Data Explorer display-string vocabulary cleanup (the first, most-visible application).
+- Data Explorer display-string vocabulary cleanup.
 
-**Out (later phases, tracked above):** notification defaults, theme tab, chat starter prompts, first-run tour, Sharing Center labels, the marketplace, the NL-authoring agent, the dashboard assembler. These are real feature work and are sequenced deliberately — not crammed into the foundation.
+**Commit 2 — the rest of the foundation (all built + verified: every touched package builds via `ngc`, every touched package's test suite passes, new tests added for the new behavior):**
+- `DisplayNamePlural` wired into the three entity-viewer empty states.
+- Notification default: Agent Completion email on (template-backed).
+- A real, functional theme picker + the enabled Appearance tab.
+- Chat empty-state default starter prompts + softened loading copy.
+- Sharing Center friendly headings (display-only, lookup keys preserved).
+
+**Still open (deliberately sequenced, not crammed in):** the first-run tour (Phase 1e — new UI surface), the User Routine email template (Phase 2), and all of Phase 2/3 (marketplace, NL-authoring agent, dashboard assembler, role-based onboarding). These are real feature work.
+
+### Verification note
+This work was verified in-environment: `@memberjunction/core` + the five touched Angular packages (`ng-entity-viewer`, `ng-resource-permissions`, `ng-conversations`, `ng-explorer-settings`, `ng-dashboards`) all build cleanly through the Angular compiler (which type-checks templates), and their vitest suites all pass (MJCore DisplayNamePlural 6; entity-viewer 101; resource-permissions 15 incl. 4 updated/new; conversations 863 + 3 new; explorer-settings 40). The metadata notification change is a declarative seed edit that takes effect on the next `mj sync push`.
 
 ---
 

--- a/plans/display-name-plural-hardening.md
+++ b/plans/display-name-plural-hardening.md
@@ -1,0 +1,97 @@
+# DisplayNamePlural — Hardening Plan (the 5 improvements)
+
+**Status:** Migration authored (this branch). Runtime completion **blocked on migration + CodeGen being applied locally** — the stored fields don't exist in generated types until then, and per the repo rule we don't write code against not-yet-generated fields.
+**Context:** `DisplayNamePlural` began as a runtime getter delegating to `generatePluralName` (a CodeGen-era utility). Moving a build-time helper onto the render hot path changes its requirements — these five items address that.
+
+---
+
+## Where this stands
+
+- ✅ **Migration authored** — `migrations/v5/V202607041200__v5.45.x__Entity_DisplayNamePlural.sql` adds `Entity.DisplayNamePlural NVARCHAR(255) NULL` + `Entity.AutoUpdateDisplayNamePlural BIT NOT NULL DEFAULT 1`, with extended properties. Mirrors the existing `DisplayName` / `AutoUpdateDescription` pattern already on the table.
+- ⏳ **Everything below waits for the human to:** pull this branch, apply the migration, run `mj codegen` (regenerates `vwEntities`, the `EntityField` rows, the `spCreate/spUpdate` Entity procs, and `entity_subclasses.ts`), then hand back to complete the runtime code against the now-generated fields.
+
+The two ideas that are **independent of the migration** (#3 algorithm, #4 golden tests, #5 irregulars) can be executed **any time** — they live entirely in `@memberjunction/global` and are fully buildable/testable in isolation. They're sequenced here with #1 only for narrative coherence; say the word and I'll do them without waiting.
+
+---
+
+## Idea #1 — Store the plural in metadata (the headline)
+
+**Goal:** stored value wins, algorithmic plural is the fallback. Gives admin/LLM override, non-English support, and (with #2) zero runtime compute.
+
+### 1a. Migration — ✅ DONE (authored)
+See the file above. No code depends on it until CodeGen runs.
+
+### 1b. CodeGen emitter — populate `DisplayNamePlural` during codegen
+Mirror exactly how CodeGen derives/sets `Entity.DisplayName` and honors an auto-update lock (the entity already has `AutoUpdateDescription` as the precedent for a lock flag). The emitter should, for each entity where `AutoUpdateDisplayNamePlural = 1`:
+- compute the plural (via `generatePluralName(DisplayNameOrName)` at minimum; optionally the codegen LLM for better results), and
+- write it to `Entity.DisplayNamePlural`,
+- and **never** overwrite when the flag is `0` (human-locked).
+
+> **Exact seam to edit:** _pending the CodeGen investigation_ — the function that assigns `Entity.DisplayName` during a run and the `AutoUpdate*` guard around it. Fill this in with the confirmed file/function before executing. (If CodeGen derives DisplayName purely algorithmically, mirror that; if via LLM, add plural to the same prompt/pass.)
+
+### 1c. Runtime — `EntityInfo` (in `packages/MJCore/src/generic/entityInfo.ts`)
+Once the columns are generated, mirror the `DisplayName` / `DisplayNameOrName` shape:
+
+```typescript
+// Raw stored value (populated from metadata by BaseInfo, like DisplayName):
+public DisplayNamePlural: string = null;
+public AutoUpdateDisplayNamePlural: boolean = true;
+
+// The accessor consumers call — stored wins, algorithm is the fallback:
+get DisplayNamePluralOrComputed(): string {
+    if (this.DisplayNamePlural) return this.DisplayNamePlural;
+    return this._displayNamePluralComputed ??= generatePluralName(this.DisplayNameOrName); // memoized — see #2
+}
+```
+
+**Naming decision (resolve on execute):** the current shipped getter is named `DisplayNamePlural` and returns the computed value. Since the DB column is also `DisplayNamePlural`, the raw field and a same-named getter collide. Two options:
+- **(A) Mirror `DisplayName`/`DisplayNameOrName` exactly** — raw field `DisplayNamePlural`, accessor `DisplayNamePluralOrComputed`. Most consistent with the existing idiom; requires renaming the shipped getter + updating the 3 entity-viewer consumers + the fallback expression + the MJCore test. **Recommended.**
+- **(B) Keep the getter name `DisplayNamePlural`**, name the stored column/field `DisplayNamePluralOverride`. Zero consumer churn, stable public API, but diverges slightly from the `DisplayName` naming precedent. (If chosen, the migration's column name must change to `DisplayNamePluralOverride`.)
+
+Recommendation: **(A)** for consistency — the churn is ~5 sites, all on this branch.
+
+### 1d. Consumers + tests
+- Update the three entity-viewer bindings (`entity-viewer` `NoRecordsTitle`, `entity-cards`, `entity-data-grid`) and the fallback expressions to call the accessor.
+- Update `entityInfo.displayNamePlural.test.ts`: the computed path becomes "stored is null → falls back to computed"; add cases for "stored value wins" and "AutoUpdate lock is carried."
+
+---
+
+## Idea #2 — Memoize the computed fallback
+Template getters run on **every** change-detection cycle; recomputing the regex+table+casing pipeline each time is waste on a hot path (CodeGen never cared — it ran once). Cache the computed value on the instance, following the existing `_nameFieldCache` precedent in `EntityInfo`:
+
+```typescript
+private _displayNamePluralComputed?: string;   // lazy, cleared naturally on metadata reload (instance is rebuilt)
+```
+
+Only the **computed fallback** needs memoizing; when a stored value exists there's nothing to compute. Safe because `DisplayName` is immutable per metadata load (same assumption `_nameFieldCache` relies on).
+
+---
+
+## Idea #3 — Harden `generatePluralName` (in `@memberjunction/global/src/util.ts`)
+Independent of the migration; buildable + testable now.
+
+1. **Consult the irregular table BEFORE the "already-plural?" heuristic (correctness bug fix).** Today `generatePluralName` calls `getSingularForm` first; for `-is`/`-us` words (`analysis`, `radius`, `cactus`, `focus`, `diagnosis`, …) that heuristic strips the trailing `s`, decides the input "is already plural," and bails — so the ~30 Latin/Greek entries already in `__irregularPlurals` are **currently unreachable**. Reordering so `getIrregularPlural(singularName)` is checked first fixes `analysis → analyses`, `radius → radii`, `cactus → cacti`, etc.
+2. **Pluralize the LAST word of a multi-word name.** Split on whitespace, pluralize the final token, rejoin. Common cases already work (suffix rules coincide with the last word), but this correctly handles an irregular *tail* — e.g. `Data Analysis → Data Analyses` — which whole-string irregular lookup misses.
+3. **Skip acronyms / ALL-CAPS tokens.** If the (last) token is all-uppercase (length ≥ 2), just append `s` (`API → APIs`, `URL → URLs`) instead of applying the `-es` rule to a trailing `S`/`X`.
+
+**Determinism caveat (important):** `generatePluralName` is also a CodeGen consumer. Changing it can change generated plural identifiers on the next codegen run. All three changes above are strict *corrections* (they fix words that are currently wrong or unchanged), and CodeGen regenerates consistently — but the PR should call this out, and #4 exists precisely to lock the contract so neither consumer drifts silently.
+
+---
+
+## Idea #4 — Shared golden test set for `generatePluralName`
+Now that **two** subsystems depend on it (CodeGen artifacts + runtime display), add a table-driven vitest suite in `@memberjunction/global` pinning input → expected plural: the regular rules, every irregular in the table (regression-guarding the #3 reorder), idempotence (already-plural in → unchanged out), multi-word, and acronym cases. This is the safety net that lets #3/#5 evolve without silently changing generated code or UI copy.
+
+---
+
+## Idea #5 — Expand the irregular table
+`__irregularPlurals` is already good, but common data-model words are missing or (per #3.1) unreachable. Add and verify via #4: `axis → axes`, `basis → bases`, `ellipsis → ellipses`, `hypothesis → hypotheses`, `parenthesis → parentheses`, `oasis → oases`, `synopsis → synopses`, `series → series`, `species → species`, `quiz → quizzes`. Deliberately **under-invest** here — with #1's stored override in place, edge cases have an escape hatch, so chasing algorithmic perfection has diminishing returns and real regression risk.
+
+---
+
+## Execution order when unblocked
+1. (Now, migration-independent) #3 + #4 + #5 in `@memberjunction/global` — one PR-able unit, fully verifiable.
+2. (After human applies migration + `mj codegen`) #1c/#1d + #2 in MJCore + entity-viewer, against the now-generated fields.
+3. (During #1) #1b CodeGen emitter — confirm the seam, mirror the `DisplayName` derivation + lock.
+
+## Explicitly NOT doing yet
+Per the human's call: only the migration is authored in this pass. The runtime code that references the new fields waits until the fields exist locally (migration + CodeGen), to honor the "no code against not-yet-generated fields" rule.


### PR DESCRIPTION
## Why

MJ is exceptional for the people who *build* on it, but the day-to-day **business user** — the one who never writes a line of code — meets developer vocabulary, blank boxes, and off-by-default preferences. A four-surface audit (Explorer UX, conversational/agent surface, no-code builders, onboarding/permissions) found the same story everywhere: **the consumer-grade primitives already exist; they're just latent, off-by-default, and wearing developer language.** This PR delivers the Phase 1 *foundation* — turning that latent capability into an approachable out-of-the-box experience — plus the migration that begins hardening the plural mechanism.

Full strategy + roadmap: [`plans/business-user-usability.md`](plans/business-user-usability.md).

## What's in this PR

**Vocabulary — speak the user's language, not the schema's**
- `EntityInfo.DisplayNamePlural` — derives a business-friendly plural from an entity's `DisplayName` (so per-deployment renaming — "Members", "Matters" — flows through for free), unit-tested.
- Data Explorer: "entity" translated out of the default data-browsing app (search placeholder, loading text, counts, empty states, "Recent" section) — **bindings, CSS classes, and agent-tool contracts left untouched**.
- `DisplayNamePlural` wired into the entity-viewer grid / cards / data-grid empty states ("No **Contacts** yet" instead of "No records found", with a graceful fallback).
- Sharing Center: friendly section headings ("Dashboard Permissions" → "Dashboards", "Access Control Rules" → "Rules") via a **display-only** label map — the underlying `DomainName` is a lookup key (drives Revoke/audit/icons) and is deliberately untouched.
- Two more copy leaks stripped ("MJ: Application Settings" → "Applications"; softened routine/agent loading text).

**Safe, humane defaults**
- Agent Completion notifications now default **email on** (it has an email template, so delivery is complete). User Routine email left off deliberately — it has no template yet; in-app is already on.
- **A real, functional theme picker** — the Appearance settings tab was a "Coming Soon" stub even though `ThemeService` is fully functional. Built an actual picker (registered themes + a System option, persisted per-user, reactively synced with the avatar-menu switcher) and enabled the tab.
- Chat empty-state slot default now ships generic, override-safe starter prompts (a host binding `[]` still suppresses).

**DisplayNamePlural hardening — migration + plan**
- Migration `V202607041200__v5.45.x__Entity_DisplayNamePlural.sql` adds `Entity.DisplayNamePlural` + `Entity.AutoUpdateDisplayNamePlural`, mirroring the existing `DisplayName` / `AutoUpdateDescription` pattern — promoting the algorithmic runtime plural to a **stored, admin/CodeGen-editable** value (stored wins, algorithm is the fallback; also the seam for non-English plurals).
- The runtime/CodeGen completion is intentionally **not** in this PR — per the repo rule (no code against not-yet-generated fields), it waits until the migration + `mj codegen` are applied. The full completion plan (incl. `generatePluralName` algorithm/irregulars/golden-test hardening) is captured in [`plans/display-name-plural-hardening.md`](plans/display-name-plural-hardening.md).

## Verification

Built + tested in-environment: `@memberjunction/core` and the touched Angular packages (`ng-entity-viewer`, `ng-resource-permissions`, `ng-conversations`, `ng-explorer-settings`, `ng-dashboards`, `ng-user-routines`) all compile through the Angular compiler (which type-checks templates), and every touched package's vitest suite passes — MJCore DisplayNamePlural **6**, entity-viewer **101**, resource-permissions **15** (incl. updated/new label tests), conversations **863** (+3 new), explorer-settings **40**. New tests were added for the new behavior. The notification change is a declarative metadata seed that takes effect on the next `mj sync push`.

## Not in scope (sequenced deliberately, see the plan)

The first-run tour, the User Routine email template, and all of Phase 2/3 (NL→FieldRules authoring agent, in-product app marketplace, agent trust-by-default, dashboard assembler, role-based onboarding). These are real feature work, not foundation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TQEeSeQJcM1LynEd1q9dXQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01TQEeSeQJcM1LynEd1q9dXQ)_