### PR TITLE
Add Agent Framework Comparison guide (MJ vs LangGraph, CrewAI, AG2/AutoGen & friends)

### DIFF
--- a/guides/AGENT_FRAMEWORK_COMPARISON.md
+++ b/guides/AGENT_FRAMEWORK_COMPARISON.md
@@ -1,0 +1,212 @@
+# MemberJunction vs. Agent Frameworks (LangGraph, CrewAI, AG2/AutoGen & Friends) — An Objective Comparison
+
+> **Purpose** — If you're evaluating MemberJunction's AI agent framework against the orchestration libraries you already know — LangGraph, CrewAI, AG2/AutoGen, the OpenAI Agents SDK, Semantic Kernel, Mastra, and the rest — this guide gives you a fair, dimension-by-dimension comparison: what each tool is genuinely great at, where MJ differs, and how to choose. Like its sibling [Framework Comparison](FRAMEWORK_COMPARISON.md) (which covers Next.js, Supabase, Rails, Django), it is deliberately **not** a "MJ wins everything" pitch — different tools win different jobs, and knowing which is which saves you months.
+
+**Companions:** [Framework Comparison](FRAMEWORK_COMPARISON.md) (web/app stacks) · [Building Applications on MemberJunction](BUILDING_APPS_ON_MJ.md).
+
+---
+
+## How to read this guide
+
+The single most important thing to get straight before any feature-by-feature comparison: **these are not all the same *kind* of thing.**
+
+- **LangGraph** is a **graph orchestration library** — code-first control over agent state machines, from the LangChain team.
+- **CrewAI** is a **role-based multi-agent library** — the fastest way to prototype a "crew" of collaborating agents.
+- **AG2 / AutoGen** is a **conversation-driven multi-agent library** — agents that collaborate by talking to each other (AutoGen 0.4+ rebuilt it as an event-driven actor runtime; AG2 is the community fork continuing the classic API; Microsoft's successor path folds into the Microsoft Agent Framework).
+- **OpenAI Agents SDK / Claude Agent SDK** are **thin vendor loops** — excellent minimal agent runtimes, leaning toward one model family.
+- **MemberJunction** is a **metadata-driven application platform** in which agents are one first-class layer — defined as *data*, executed by a generic runtime, and wired into the platform's security, observability, memory, scheduling, and UI.
+
+In those libraries, an agent is code you write: a Python/TypeScript object graph that lives in your repo and exists only while your process runs. In MJ, an agent is a **row in the `AI Agents` entity** — its prompts, tools, sub-agent relationships, memory policy, and permissions are all related metadata entities, executed by a generic engine (`BaseAgent` in [`packages/AI/Agents`](../packages/AI/Agents/)). Custom code (`@RegisterClass(BaseAgent, 'MyDriverClass')`) is an *optional* behavioral override — most agents need none.
+
+That one decision cascades into everything else in this guide: agents editable in a UI without a deploy, versioned via `mj sync` metadata files in Git, permissioned per user/role, audited in your own database, schedulable by end users. The trade-off is equally real: you adopt the MJ platform (TypeScript, SQL Server/PostgreSQL, the entity model) to get it — while LangGraph is a `pip install` into whatever you already have.
+
+So the honest question isn't "which framework is best" but **"do you need an orchestration loop, or do you need agents as governed citizens of a data platform?"**
+
+---
+
+## At a glance
+
+| Dimension | **MemberJunction** | LangGraph | CrewAI | AG2 / AutoGen |
+|---|---|---|---|---|
+| **Category** | Metadata-driven platform (agents = data) | Graph orchestration library | Role-based multi-agent library | Conversation-driven multi-agent library |
+| **Agent definition** | DB metadata + optional code override | Code (`StateGraph`) | Code (roles/goals/tasks) | Code (conversable agents) |
+| **Orchestration paradigms** | **Loop** (ReAct-style), **Flow** (deterministic graph), **Realtime** (voice/session) — swappable per agent via metadata | Graph (+ prebuilt ReAct helper) | Crews (roles) + Flows | Group chat / handoffs; 0.4+ event-driven actors |
+| **Shared state** | Typed payload with **path-level read/write ACLs per agent**, diff-based mutations | Channels + reducers, checkpointed | Task outputs / context passing | Message history |
+| **Human-in-the-loop** | Durable request/approve queue + **Plan Mode** gate, built in | `interrupt()` + checkpointer (DIY infra) | `human_input` flag | Human-proxy agent |
+| **Model gateway** | ~30 providers, DB-driven selection, instant failover, cost tables | Via LangChain integrations | Via LiteLLM | Model clients |
+| **Observability** | Relational, in **your** DB (runs, steps, tokens, cost, failover) | LangSmith (SaaS) | AgentOps et al. (SaaS) | Varies |
+| **Memory** | 3-tier governed memory + scheduled Memory Manager, built in | Add-on (LangMem/Zep/Mem0) | Built-in (decent) | Minimal / add-on |
+| **Permissions on agents** | ✅ Per user/role View/Run/Edit/Delete, enforced at execution | ✗ | ✗ | ✗ |
+| **Data-layer security** | ✅ Agents inherit RLS, field perms, audit — run *as* a user | BYO | BYO | BYO |
+| **End-user surfaces** | ✅ Chat UI, voice, scheduling, batch execution out of the box | BYO | BYO | BYO |
+| **Language** | TypeScript | Python + JS | Python | Python (+ .NET) |
+| **Hosting** | Self-host **or managed via [MJ Central](https://central.memberjunction.com)** | LangGraph Platform | CrewAI Enterprise | Azure AI Foundry / MS Agent Framework |
+| **Ecosystem / community** | Small | Very large | Large | Large but split (AG2 fork vs. MS path) |
+| **Best at** | Many agents, many users, governed business data | Novel/complex orchestration control | Fastest multi-agent prototype | Conversational agent collaboration |
+
+✅ = first-class/out of the box · ✗ = not provided · "BYO" = you build/assemble it.
+
+---
+
+## Framework by framework
+
+### LangGraph
+
+**What it's great at.** The most **controllable orchestration** in the ecosystem: explicit state graphs with typed channels and reducers, checkpointing for persistence and time-travel, `interrupt()` for human-in-the-loop, fine-grained streaming, subgraphs, and a functional API. Backed by the largest community, example corpus, and integration surface in the agent world, plus LangSmith for tracing and LangGraph Platform for managed deployment. If your product *is* a novel orchestration pattern, LangGraph gives researchers and engineers more knobs than anything else here.
+
+**How MJ differs.** MJ ships a LangGraph-shaped capability as *one of its paradigms*: `FlowAgentType` is a deterministic directed graph where nodes are `AI Agent Steps` rows and edges are `AI Agent Step Paths` with priority-ordered boolean conditions evaluated in a sandboxed expression evaluator — and `Prompt` nodes can inject LLM decision points into an otherwise deterministic flow. The difference is *where the graph lives*: in LangGraph it's code in your repo; in MJ it's metadata — editable in a UI, diffable via `mj sync`, permissioned, and executed by a generic engine. On state, LangGraph's shared channels let any node write anything; MJ's `PayloadManager` enforces declarative per-agent path ACLs (see the deep-dive below). On HITL, LangGraph's `interrupt()` is elegant but leaves the checkpoint store, approval inbox, and routing to you; MJ's pause creates a durable `AI Agent Requests` row with assignment strategies and auto-resume.
+
+**Pick LangGraph when** you need maximal loop control, you're Python-first, or you're building a standalone AI product where a platform is overhead. **Pick MJ when** the graph is a means to an end and the hard part is governance, users, and business data.
+
+### CrewAI
+
+**What it's great at.** The **fastest multi-agent prototype** in the business: define agents by role/goal/backstory, give them tasks, compose a crew, and you have collaborating agents in minutes. Later "Flows" added deterministic orchestration; built-in short/long-term/entity memory is genuinely decent; a huge template ecosystem and CrewAI Enterprise for deployment round it out.
+
+**How MJ differs.** CrewAI optimizes for *time-to-first-demo*; MJ optimizes for *time-to-governed-production*. MJ's role equivalents are agent metadata (prompts, hierarchy, relationships) rather than role-play strings, and its multi-agent composition adds things CrewAI doesn't attempt: per-agent payload ACLs (a sub-agent literally cannot see or write outside its granted paths), parallel sub-agent fan-out with payload isolation and bounded concurrency, permission checks on who may run which agent, and full per-step relational audit. MJ's memory system is also a tier heavier: three lifecycle stages (scratchpad → provisional → active), vector retrieval with scoping across user/company/global, and a scheduled Memory Manager agent doing consolidation, contradiction detection, and decay ([Agent Memory Guide](AGENT_MEMORY_GUIDE.md)).
+
+**Pick CrewAI when** you want a working multi-agent demo this afternoon and production governance isn't the bottleneck. **Pick MJ when** the agents will touch real business data on behalf of real users with real permission boundaries.
+
+### AG2 / AutoGen
+
+**What it's great at.** Pioneered **conversation-driven collaboration** — agents that solve problems by talking to each other (group chats, nested chats, human-proxy agents), with strong research pedigree from Microsoft. AutoGen 0.4 rebuilt the core as a cross-language, event-driven actor runtime; AG2 continues the beloved classic API as a community fork; Microsoft's enterprise path consolidates into the Microsoft Agent Framework with Azure AI Foundry hosting.
+
+**How MJ differs.** Two things. First, **stability of direction**: the AutoGen lineage is split across a fork and a platform migration, which is a real evaluation factor for anything long-lived. Second, **conversation as coordination vs. conversation as product**: AutoGen uses chat *between agents* as its control flow; MJ uses explicit control flow (Loop decisions, Flow graphs, typed payload diffs) and treats conversation as a *user-facing surface* — the full conversations stack ([Conversations UX Stack Guide](CONVERSATIONS_UX_STACK_GUIDE.md)) with streaming, artifacts, mentions, and embedded agents ships as a reusable runtime + Angular widget. Inter-agent message history as shared state is also harder to audit and bound than MJ's diff-based payload with ACLs.
+
+**Pick AG2/AutoGen when** emergent multi-agent conversation is the paradigm you want, or you're committed to the Microsoft/Azure agent stack. **Pick MJ when** you want deterministic-when-needed control flow and conversation as a polished end-user surface rather than plumbing.
+
+### OpenAI Agents SDK / Claude Agent SDK
+
+**What they're great at.** Thin, excellent, minimal agent loops from the model vendors themselves — handoffs, guardrails, sessions, tool use — with the least ceremony of anything here and first-class support for their own models' newest capabilities.
+
+**How MJ differs.** These are roughly MJ's `LoopAgentType` *minus everything around it* — and minus vendor neutrality. MJ's model gateway abstracts ~30 providers behind one interface with DB-driven selection, instant failover with error classification, and temporal cost tables; a vendor SDK naturally leans toward that vendor. If you're happily single-vendor and need a lightweight loop, they're a fine choice; MJ is the answer when you need portability, failover, cost governance, and the platform layers.
+
+### Semantic Kernel / Microsoft Agent Framework
+
+**What it's great at.** The enterprise-.NET/Azure analog to MJ's ambitions: plugins, planners, agent orchestration, deep Azure integration, and Microsoft's support umbrella.
+
+**How MJ differs.** Closest in *spirit* (enterprise, governance-aware) but anchored to the Azure cloud and application-agnostic — it orchestrates agents, but it doesn't own your data model. MJ's differentiation is that agents operate *on* the platform's governed entities: row-level security, field permissions, and change tracking apply to what an agent reads and writes because the agent runs through the same entity layer as the UI, as a specific user. MJ is also cloud-neutral: self-host anywhere, or use [MJ Central](https://central.memberjunction.com) for managed hosting.
+
+### LlamaIndex (Workflows / Agents)
+
+**What it's great at.** RAG-centric, event-driven workflows with the best document-ingestion ecosystem around.
+
+**How MJ differs.** LlamaIndex competes more with MJ's Knowledge/RAG layer (entity vector sync, pgvector/Qdrant/Pinecone providers, rerankers, pre-execution RAG injection) than with its agent layer. If your product is "chat with a document corpus," LlamaIndex is superb. MJ's RAG is one integrated capability among many, operating over the same governed entities as everything else.
+
+### Mastra / Vercel AI SDK (the TypeScript natives)
+
+**What they're great at.** First-class TypeScript DX. Mastra bundles workflows, memory, and evals into a coherent TS framework; the Vercel AI SDK is the best-in-class streaming/UI primitive layer for AI features in web apps.
+
+**How MJ differs.** These are the closest *library-shaped* comparisons for a TypeScript team — but they remain code-first and application-agnostic. MJ is the only one where the agent definition itself is portable metadata riding on a full data platform. Notably, the Vercel AI SDK and MJ compose well: MJ's conversations runtime is pure TS with adapter seams, so a bespoke React frontend can sit on an MJ agent backend.
+
+### n8n and low-code workflow tools
+
+**What they're great at.** Visual workflow assembly with hundreds of integration nodes; "define behavior as data" for integrations — an instinct MJ shares.
+
+**How MJ differs.** Low-code tools bolt LLM nodes onto integration pipelines; there's no typed shared state, no real agent loop, no data platform underneath. MJ's Actions layer plays the integration-catalog role (CRM, accounting, LMS connectors — see [`packages/Actions`](../packages/Actions/CLAUDE.md)) but with typed parameters, code-approval workflows, and agents as first-class callers.
+
+---
+
+## Dimension deep-dive
+
+### Orchestration: two paradigms behind one engine
+
+MJ ships **both dominant orchestration styles as pluggable strategies**, selected per agent by metadata with no code change:
+
+- **`LoopAgentType`** — the autonomous, ReAct-style loop. The LLM returns a structured "next step" decision (run actions, invoke sub-agents, chat with the user, activate a skill, iterate with for-each/while), heavily validated with corrective retries against prose drift. This is the CrewAI/AutoGen/vendor-SDK analog.
+- **`FlowAgentType`** — the deterministic conditional graph (the LangGraph analog), with metadata-defined nodes and edges, sandboxed condition evaluation, priority-ordered paths, explicit failure-recovery edges, and optional LLM decision nodes inside the deterministic structure.
+- **`RealtimeAgentType`** — a third, session-driven paradigm for live voice/duplex agents ([Real-Time Co-Agents Guide](REALTIME_CO_AGENTS_GUIDE.md)) that none of the compared libraries has as a first-class peer.
+
+Every compared framework picks one paradigm and asks you to build the others on top. MJ's `BaseAgentType` strategy contract means the same agent can be re-based from autonomous to deterministic by changing a metadata reference.
+
+### State: the payload ACL model (MJ's most distinctive capability)
+
+LangGraph's state is a shared dict with reducers — any node can write anything. CrewAI passes task outputs; AutoGen shares message history. MJ's `PayloadManager` enforces **declarative, per-agent access control on the shared state itself**:
+
+- `PayloadDownstreamPaths` — what a sub-agent is allowed to *see* (the payload is projected before handoff).
+- `PayloadUpstreamPaths` — what a sub-agent is allowed to *write back* (merges outside the grant are blocked and recorded as audit violations).
+- `PayloadSelfWritePaths` — what an agent may mutate in its own payload each turn.
+- `PayloadScope` — confine an agent's entire world-view to a subtree.
+
+And mutations are **diffs, not replacements**: the LLM emits add/update/remove change requests, never the full payload — which eliminates the classic failure where a truncated response silently erases half the state. A change analyzer diffs every transition and flags suspicious changes. In any of the compared frameworks, this entire layer is something you'd design and build yourself.
+
+### Human-in-the-loop: durable and governed
+
+MJ's pause creates a persistent **`AI Agent Requests`** row with a resolution chain for *who* should answer (per-invocation → agent type → category → request type default), sets the run to `AwaitingFeedback`, and auto-resumes when the response is saved. **Plan Mode** adds a per-request gate: the agent must present a plan and receive human approval before *any* action or sub-agent executes, with rejection forcing a re-plan ([Agent Skills & Plan Mode Guide](AGENT_SKILLS_AND_PLAN_MODE_GUIDE.md)). LangGraph's `interrupt()` + checkpointers is the strongest library-side answer, but the checkpoint store, the approval inbox UI, and the routing logic are all yours to build; CrewAI and AutoGen offer thinner hooks.
+
+### The model gateway: what LiteLLM does, plus governance
+
+MJ's model layer ([`packages/AI/Core`](../packages/AI/Core/), [`packages/AI/Providers`](../packages/AI/Providers/), [`packages/AI/Prompts`](../packages/AI/Prompts/)) covers the LiteLLM slot and then some:
+
+- **~30 provider drivers** behind one `BaseLLM` abstraction, with the model↔vendor split modeled properly: a model *developer* (who trained it) is distinct from an *inference provider* (who serves it) — one Llama, many hosts, each with its own priority, API name, and driver.
+- **Selection strategies** per prompt: explicit model pools, by power rank, or filtered by named **AI Configurations** (dev/staging/prod-style environments with inheritance).
+- **Instant failover** across the candidate list, with error classification (rate-limit vs. auth vs. context-length treated differently), credential-binding chains, and every failover attempt persisted to the run record.
+- **Cost as data**: temporal pricing tables (`MJ: AI Model Costs`) with pluggable price-unit drivers compute normalized cost per run, rolled up hierarchically through agent → sub-agent → prompt trees.
+
+All of it is DB metadata — adding a provider is a driver class plus data, and re-pointing production traffic is a row update, not a deploy.
+
+### Prompts: managed, composed, validated
+
+Prompts are entities with Nunjucks templates, hierarchical composition (agent-type system prompt → agent prompts → embedded child prompts), per-prompt model pools, and an output-validation pipeline: type-aware parsing, an example-driven JSON validator, configurable retry strategies, and a JSON-repair cascade (clean → JSON5 → LLM-assisted repair). Parallel multi-model execution with judge/selection is built in. In the library world this is a separate product (prompt registries, output parsers, guardrails libraries) that you integrate yourself.
+
+### Observability: relational, in your database
+
+Every prompt run and agent step is a row in **your** database: tokens (including cache read/write), normalized cost with hierarchical rollups, the full model-selection rationale (every candidate considered and why the winner won), failover history, validation attempts, and payload state before/after every step. LangSmith, Langfuse, and AgentOps are more polished as *analysis UIs* — but they're external SaaS with instrumentation to wire up. MJ's telemetry requires zero instrumentation code, is queryable with plain SQL alongside your business data, and never leaves your infrastructure.
+
+### Memory: governed, not just persistent
+
+MJ's agent memory ([Agent Memory Guide](AGENT_MEMORY_GUIDE.md)) is three-tier (per-run scratchpad → provisional notes with TTL → active long-term notes), vector-retrieved with explicit precedence rules, and scoped across agent/user/company/global dimensions. In-flight memory writes pass a hardened guard pipeline — type restrictions that double as prompt-injection defense, per-run caps, scope clamps, near-duplicate detection — and a scheduled **Memory Manager agent** consolidates, detects contradictions, and applies decay. CrewAI's built-in memory is the best of the compared libraries; LangGraph and AutoGen expect an add-on (Mem0, Zep, LangMem). None govern *what agents are allowed to remember* the way MJ does.
+
+### Tools: a permissioned catalog, not a decorator
+
+Library tools are code functions (with MCP now common across all of them — MJ speaks MCP too, plus A2A). MJ's **Actions** are a metadata-driven catalog: typed input/output parameters, result codes, a code-approval workflow for AI-generated actions, a large prebuilt integration library, and per-agent grants via junction entities. **Skills** ([Agent Skills & Plan Mode Guide](AGENT_SKILLS_AND_PLAN_MODE_GUIDE.md)) bundle instructions + actions + sub-agents into reusable, *individually permissioned* capabilities with progressive disclosure (agents see only name + description until activation) and a double activation gate so capabilities can't silently leak into agents.
+
+### Security and governance: the structural moat
+
+These aren't features the libraries lack by accident — they're things a library *can't* provide because they require owning the data layer:
+
+1. **Agents inherit data security.** An MJ agent's actions run through the same entity layer as the UI — row-level security, field permissions, and change tracking apply to everything the agent reads and writes, automatically, because the agent runs *as* a specific user. In every compared framework, "the agent respects the caller's permissions" is a project you build.
+2. **Permissions on the agents themselves.** Per user/role View/Run/Edit/Delete grants on agents *and* skills, enforced at the execution gate and reflected in the UI pickers ([Unified Permissions Guide](UNIFIED_PERMISSIONS_GUIDE.md)). The libraries have no concept of who may run an agent.
+3. **Ops-grade run lifecycle.** Wall-clock timeouts chained with cancellation signals, watchdogs for stuck runs, per-agent execution bounds, durable step persistence — production hardening the library quickstarts leave to you.
+
+### End-user surfaces: the last mile ships in the box
+
+With the libraries, a working agent is where the *product* work starts: chat UI, streaming, scheduling, batch execution, voice. With MJ these ship as platform features: the conversations stack (runtime + Angular widgets with slots, events, and theming), **User Routines** ("run this agent every morning, notify me only when something changes" — [User Routines Guide](USER_ROUTINES_GUIDE.md)), **Record Set Processing** (run an agent over ten thousand records with batching, rate limiting, circuit breakers, dry-run, and per-record audit — [Record Set Processing Guide](RECORD_SET_PROCESSING_GUIDE.md)), and the realtime layer (one co-agent voices any agent; bridges into Zoom/Teams/telephony; a live remote-browser channel for demo/walkthrough agents).
+
+### Deployment: self-host or MJ Central
+
+MJ runs anywhere Node and SQL Server/PostgreSQL run — on-prem, any cloud, air-gapped — which matters to the data-governance buyers the platform is built for. And for teams who don't want to operate it themselves, **[MJ Central](https://central.memberjunction.com)** provides fully managed MJ hosting — the "Easy Button" for MJ, playing the role WP Engine plays for WordPress: the same open platform, run for you. That puts MJ's deployment story at parity with LangGraph Platform, CrewAI Enterprise, and Azure AI Foundry — with the difference that the self-host option is the *same* full platform, not a feature-reduced tier.
+
+### Ecosystem & talent: be honest
+
+**LangGraph, CrewAI, and the AutoGen lineage have far larger communities**, more examples, more tutorials, more integrations, and a deeper hiring pool than MJ. When you hit a weird edge with LangGraph, someone on the internet has hit it before you; with MJ you're reading source and guides (the source is well-documented, and the [guides](README.md) are extensive — but it's not Stack Overflow). Python-first teams and teams leaning on the Python ML ecosystem will find the libraries sit more naturally. MJ's counter is the same as in the [app-stack comparison](FRAMEWORK_COMPARISON.md): much of what you'd assemble that ecosystem *for* — observability, memory, HITL, permissions, UI — is already in the platform. Factor your team's existing skills heavily.
+
+---
+
+## When MemberJunction is the strong choice
+
+- You're deploying **many agents for many users** — where "who can run what, on which data, with what approval" is a real requirement, not a future nice-to-have.
+- Your agents act on **governed business data** — CRM, membership, finance, operations — and must respect row/field security and leave an audit trail.
+- You want **non-developers to configure agent behavior** — prompts, tools, flows, schedules — through a UI, with changes versioned as metadata rather than redeployed as code.
+- You need the **whole surrounding stack** — chat UI, voice, scheduling, batch execution, memory, observability — and would rather adopt it than assemble it.
+- You're **TypeScript end-to-end** and on (or fine adopting) SQL Server or PostgreSQL.
+- You want **deployment freedom**: self-host anywhere, or managed hosting via [MJ Central](https://central.memberjunction.com).
+
+## When to reach for something else
+
+- You're building a **standalone AI product or research prototype** where a platform is overhead → **LangGraph** (control) or **CrewAI** (speed).
+- Your team is **Python-first** or leans on the Python ML ecosystem → any of the Python libraries.
+- You need **maximal orchestration control** for a novel pattern → **LangGraph**.
+- You're **committed to Azure** and Microsoft's agent stack → **Microsoft Agent Framework / Semantic Kernel**.
+- You're happily **single-model-vendor** and need a minimal loop → **OpenAI Agents SDK / Claude Agent SDK**.
+- Your product is **"chat with a document corpus"** → **LlamaIndex**.
+- You **can't adopt** TypeScript or SQL Server/PostgreSQL → weight that decisively.
+
+---
+
+## The one-line summary
+
+> **LangGraph** gives you the most controllable graph. **CrewAI** gives you the fastest multi-agent prototype. **AG2/AutoGen** gives you conversation-driven collaboration (now splitting into a fork and a Microsoft platform). **MJ** gives you agents as *governed platform citizens* — metadata-defined, permissioned, audited, memory-equipped, human-gated, voice-capable — operating directly on your business data, in exchange for adopting the whole platform (self-hosted, or managed on [MJ Central](https://central.memberjunction.com)).
+
+If the hard part of your problem is a novel orchestration pattern or a standalone AI product, use a library. If the hard part is *many agents, many users, real business data, security, auditability, and non-developers configuring behavior* — that's the exact column MJ pre-builds, and it's where the libraries hand you a year of infrastructure work.
+
+For the full picture of building on MJ, see **[Building Applications on MemberJunction](BUILDING_APPS_ON_MJ.md)**; for the web/app-stack comparison, see **[Framework Comparison](FRAMEWORK_COMPARISON.md)**.

--- a/guides/FRAMEWORK_COMPARISON.md
+++ b/guides/FRAMEWORK_COMPARISON.md
@@ -2,7 +2,7 @@
 
 > **Purpose** — If you're evaluating MemberJunction against stacks you already know (Next.js/Vercel, Supabase, Ruby on Rails, Django, or a hand-rolled Node + ORM + SPA), this guide gives you a fair, dimension-by-dimension comparison: what each tool is genuinely great at, where MJ differs, and how to choose. It is deliberately **not** a "MJ wins everything" pitch — different tools win different jobs, and knowing which is which saves you months.
 
-**Companion to:** [Building Applications on MemberJunction](BUILDING_APPS_ON_MJ.md).
+**Companions:** [Building Applications on MemberJunction](BUILDING_APPS_ON_MJ.md) · [Agent Framework Comparison](AGENT_FRAMEWORK_COMPARISON.md) (MJ vs. LangGraph, CrewAI, AG2/AutoGen & other agent frameworks).
 
 ---
 

--- a/guides/README.md
+++ b/guides/README.md
@@ -8,6 +8,7 @@ If you're about to start work in one of the areas below, **read the guide first*
 
 - **[Building Applications on MemberJunction](BUILDING_APPS_ON_MJ.md)** — The hub guide for using MJ as a first-class application development platform. Explains the metadata-driven, schema-to-app model, the unified-TypeScript / isomorphic object model, AI-native app patterns, and links out to the authoritative README/guide for every layer (data modeling, CodeGen, entities, API, UI, Actions, AI, deployment). Start here if you've got data in MJ and want to build on it.
 - **[Framework Comparison](FRAMEWORK_COMPARISON.md)** — Objective comparison of MJ against Next.js/Vercel, Supabase, Rails, Django, and a hand-rolled Node+ORM+SPA stack: where each shines, where MJ differs, and how to choose. Companion to the app-building guide.
+- **[Agent Framework Comparison](AGENT_FRAMEWORK_COMPARISON.md)** — Objective comparison of MJ's AI agent framework and infrastructure against LangGraph, CrewAI, AG2/AutoGen, the vendor agent SDKs, Semantic Kernel, LlamaIndex, and the TypeScript-native frameworks: orchestration paradigms, payload/state governance, HITL, model gateway, observability, memory, permissions, and deployment (self-host or managed via MJ Central). Companion to the app-stack comparison above.
 
 ## Framework fundamentals
 


### PR DESCRIPTION
## Summary

Adds **`guides/AGENT_FRAMEWORK_COMPARISON.md`** — an objective, dimension-by-dimension comparison of MJ's AI agent framework and infrastructure against the agent-orchestration ecosystem, written in the same balanced tone as the existing `FRAMEWORK_COMPARISON.md` (which covers web/app stacks).

### What it covers

- **The category difference**: LangGraph/CrewAI/AutoGen are orchestration *libraries* (agents = code); MJ is a *platform* (agents = metadata executed by a generic runtime, code optional).
- **At-a-glance table** + framework-by-framework sections: LangGraph, CrewAI, AG2/AutoGen, OpenAI/Claude agent SDKs, Semantic Kernel / Microsoft Agent Framework, LlamaIndex, Mastra / Vercel AI SDK, n8n/low-code.
- **Dimension deep-dives** grounded in the codebase: Loop/Flow/Realtime orchestration paradigms, the PayloadManager path-ACL state model, durable HITL + Plan Mode, the multi-provider model gateway with failover and cost tables, relational observability, three-tier governed memory, Actions/Skills as a permissioned tool catalog, data-layer security inheritance, and end-user surfaces (conversations, routines, record-set processing, realtime/voice).
- **Deployment**: self-host anywhere, or fully managed via **MJ Central** (central.memberjunction.com) — positioned as the "Easy Button" for MJ, analogous to WP Engine for WordPress.
- **Honest counter-strengths**: ecosystem/community size, Python-first teams, prototype speed, fine-grained loop control.
- Closes with "when MJ is the strong choice / when to reach for something else" and a one-line summary, mirroring the app-stack guide's structure.

### Cross-links

- Added a one-line entry to `guides/README.md` under "Start here".
- Updated `guides/FRAMEWORK_COMPARISON.md`'s companion line to point at the new guide.

No code changes — documentation only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011zcKscwYYrtV4eZau2JLSj

---
_Generated by [Claude Code](https://claude.ai/code/session_011zcKscwYYrtV4eZau2JLSj)_