### PR TITLE
Use entityPrimaryKeys for DataGrid React row keys

### DIFF
--- a/.changeset/bright-clouds-dance.md
+++ b/.changeset/bright-clouds-dance.md
@@ -1,0 +1,5 @@
+---
+"@memberjunction/core": minor
+---
+
+Use entityPrimaryKeys for DataGrid React row keys and update metadata component definitions

--- a/metadata/components/.components.json
+++ b/metadata/components/.components.json
@@ -1743,8 +1743,8 @@
       "ID": "DB1253D8-5B43-4FB1-880D-908EE2E5B37F"
     },
     "sync": {
-      "lastModified": "2026-04-27T18:51:33.576Z",
-      "checksum": "a49927a74432e6d07388eaae49b4e606fcd1dc3c0908ddd0af1cc307eb144594"
+      "lastModified": "2026-07-02T01:37:21.145Z",
+      "checksum": "5b0d2c4feb7f9c5e6f09a9bf31fbb7e696173017544d32889e16c2206baf6673"
     }
   },
   {

--- a/metadata/components/code/generic/data-grid.js
+++ b/metadata/components/code/generic/data-grid.js
@@ -781,10 +781,13 @@ function DataGrid({
     
     return filteredData.map((row, index) => ({
       ...row,
-      // Use existing key, ID fields, or fall back to index
-      key: row?.key || row?.ID || row?.id || index
+      key: row?.key
+        || (entityPrimaryKeys?.length && entityPrimaryKeys.map(k => row?.[k]).filter(v => v != null).join('_'))
+        || row?.ID
+        || row?.id
+        || index
     }));
-  }, [filteredData]);
+  }, [filteredData, entityPrimaryKeys]);
   
   return (
     <div className="data-grid-component" style={{ width: '100%' }}>

--- a/metadata/components/descriptions/generic/data-grid.md
+++ b/metadata/components/descriptions/generic/data-grid.md
@@ -14,3 +14,5 @@ Flexible data grid component with its own simplified API. Accepts **data via pro
 - Need automatic caching and pagination logic → **Use EntityDataGrid instead**
 
 **Key difference from EntityDataGrid**: DataGrid is data-agnostic and passive (you pass data in). EntityDataGrid is entity-aware and active (it loads data via RunView). Choose DataGrid when you need control over data loading, EntityDataGrid for automatic entity record loading with smart caching.
+
+**Row keys**: DataGrid assigns each row's React key using this priority: `row.key` → `entityPrimaryKeys` (joined with `_`) → `row.ID` → `row.id` → `index`. When `entityPrimaryKeys` is provided, the primary key fields are used to build a unique key per row. For client-side joins where the output `ID` may not be unique, provide `entityPrimaryKeys` pointing to the field(s) that uniquely identify each row.

--- a/metadata/components/spec/generic/data-grid.spec.json
+++ b/metadata/components/spec/generic/data-grid.spec.json
@@ -59,7 +59,7 @@
     {
       "name": "entityPrimaryKeys",
       "type": "Array<string>",
-      "description": "Array of field names that constitute the primary key(s) for opening entity records. Required for OpenEntityRecord integration. When provided with entityName, clicking a row will open the entity record using these fields. Use for 1:1 record-to-row scenarios (not aggregated data). Example: ['ID'] for single key, ['OrderID', 'LineNumber'] for composite key.",
+      "description": "Array of field names that constitute the primary key(s). Used for two purposes: (1) React row keys — ensures unique keys per row, which is important for client-side joins where row.ID may not be unique, and (2) OpenEntityRecord integration — clicking a row opens the entity record using these fields. Example: ['ID'] for single key, ['OrderID', 'LineNumber'] for composite key.",
       "required": false,
       "exampleValue": "[\"ID\"]",
       "constraints": [


### PR DESCRIPTION
## Summary
- Update the generic DataGrid component to use `entityPrimaryKeys` for React row keys instead of index-based keys
- Update metadata component definitions and descriptions for the data-grid component
- Include minor version bump changeset for `@memberjunction/core`

## Test plan
- [ ] Verify DataGrid renders correctly with entity primary key-based row keys
- [ ] Test DataGrid with entities that have composite primary keys
- [ ] Confirm no regressions in existing DataGrid usage

🤖 Generated with [Claude Code](https://claude.com/claude-code)