### PR TITLE
ci(test): fix turbo flag order breaking unit-test CI on every PR

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -117,7 +117,7 @@ jobs:
         run: |
           if [ -n "$TURBO_FILTER" ]; then
             echo "::group::Affected build"
-            npx turbo --log-order=stream run build "$TURBO_FILTER"
+            npx turbo run build --log-order=stream "$TURBO_FILTER"
             echo "::endgroup::"
             npx turbo run test "$TURBO_FILTER"
           else


### PR DESCRIPTION
## Summary
- The affected-packages fast path added in #2990 invokes `npx turbo --log-order=stream run build`, but turbo 2.8 (the version locked in `package-lock.json`) strictly rejects run-scoped flags placed before the `run` subcommand: `ERROR Cannot use run arguments before `run` subcommand`. Since #2990 merged, the **Build + run unit tests** step fails on every PR.
- One-line fix: move `--log-order=stream` after `run build`.
- #2990's own CI stayed green because `pull_request` runs execute the workflow file from the base branch — the new line was never exercised until after merge.

## Test plan
- [x] Reproduced the CI error locally with turbo 2.8.3 using the old flag order
- [x] Verified the corrected command parses and resolves the affected-package scope with CI's exact filter: `npx turbo run build --log-order=stream --dry-run "--filter=...[origin/next]"`

🤖 Generated with [Claude Code](https://claude.com/claude-code)