### PR TITLE
ci(test): raise unit-test job timeout to 60 minutes

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -38,7 +38,10 @@ concurrency:
 jobs:
   test:
     name: Run unit tests
-    timeout-minutes: 30
+    # 60 (not 30): the full-suite backstop (push/nightly) builds + tests ALL packages and was
+    # still running at ~27 min when the old 30-min cap killed it. PR affected-runs finish in
+    # minutes and are unaffected by the higher ceiling.
+    timeout-minutes: 60
     runs-on: ubuntu-latest
     # issues:write so a red BACKSTOP run (push/schedule) can auto-file an alert issue (see final step).
     permissions:


### PR DESCRIPTION
## Summary
- The full-suite backstop run (`push` to `next` / nightly `schedule`) builds and tests **all** packages and was still mid-flight at ~27 minutes when the job's `timeout-minutes: 30` cancelled it — first observed on the merge backstop for #3067 ([run 28842148910](https://github.com/MemberJunction/MJ/actions/runs/28842148910)): checkout + `npm ci` ≈ 3 min, `Build + run unit tests` cancelled at the 30-minute mark.
- Raises the job timeout to 60 minutes so the backstop can complete. PR affected-package runs finish in minutes and are unaffected by the higher ceiling.
- Follow-up (separate change): persist the turbo cache across runs so full-suite backstops only rebuild/retest packages changed by the merge — `turbo.json` already declares cacheable `build`/`test` tasks with outputs, CI just never restores a cache. That would bring the backstop back down to minutes; this PR stops the bleeding on the next merge either way.

## Test plan
- [x] One-line setting change (plus explanatory comment); no behavior change for runs that finish under 30 minutes
- [ ] Next merge to `next` completes its full-suite backstop instead of being cancelled at 30:00

🤖 Generated with [Claude Code](https://claude.com/claude-code)