### PR TITLE
fix(open-app): dialect-driven teardown + full PostgreSQL parity (closes out #3053 review)

### DIFF
--- a/.changeset/openapp-teardown-pg-parity.md
+++ b/.changeset/openapp-teardown-pg-parity.md
@@ -1,0 +1,6 @@
+---
+"@memberjunction/open-app-engine": patch
+"@memberjunction/sql-dialect": patch
+---
+
+Make the Open-App metadata teardown dialect-driven with full PostgreSQL parity. The FK-graph cascade in `RemoveAppEntityMetadata` (introduced for SQL Server) now runs on **both SQL Server and PostgreSQL**: identifier quoting comes from the provider's `SQLDialect` (`QuoteSchema`/`QuoteIdentifier`) and the FK-graph catalog query comes from a new `SQLDialect.ForeignKeyGraphSQL(schema)` (SQL Server `sys.foreign_keys`; PostgreSQL `pg_catalog.pg_constraint`, with source-column nullability + composite-FK column-count). Previously PostgreSQL fell back to a hardcoded ~6-entity delete list that **under-deleted** (missing e.g. `RecordChange`), so a used PG app could fail remove/reinstall on a foreign-key violation — that path is now the same complete cascade as SQL Server. The provider-selection gate is `has-a-Dialect` (no longer `!== 'postgresql'`), and only a caller that passes no provider uses the legacy entity-layer fallback. Polymorphic tables are covered via their real single-column `EntityID` FK (nullable → `SET NULL`, NOT-NULL → `DELETE`); the FK-less `RecordID` string half is out of scope (a separate single-record-delete concern).

--- a/packages/OpenApp/Engine/src/__tests__/entity-teardown-enumerate.test.ts
+++ b/packages/OpenApp/Engine/src/__tests__/entity-teardown-enumerate.test.ts
@@ -1,0 +1,66 @@
+/**
+ * Unit tests for `EnumerateMjEntityFkGraph` — the FK-graph reader. It runs the provider's
+ * dialect-supplied `ForeignKeyGraphSQL(schema)` and normalizes the rows into `FkEdge[]`, excluding
+ * composite (multi-column) FKs with a warning. Mocked provider (`Dialect` + `ExecuteSQL`); no DB.
+ *
+ * Parametrized over both dialects to prove it drives the dialect's own catalog query (SQL Server's
+ * `sys.foreign_keys` vs. PostgreSQL's `pg_constraint`) and coerces nullability from either shape.
+ */
+import { describe, it, expect, vi } from 'vitest';
+import { GetDialect, type DatabasePlatform } from '@memberjunction/sql-dialect';
+import { EnumerateMjEntityFkGraph } from '../install/entity-teardown.js';
+import type { DatabaseProviderBase } from '@memberjunction/core';
+
+/** A mock provider that reports the given dialect and returns canned rows for any ExecuteSQL. */
+function mockProvider(platform: DatabasePlatform, rows: Array<Record<string, unknown>>) {
+  const executeSQL = vi.fn(async () => rows);
+  const provider = {
+    Dialect: GetDialect(platform),
+    ExecuteSQL: executeSQL,
+  } as unknown as DatabaseProviderBase;
+  return { provider, executeSQL };
+}
+
+const platforms: DatabasePlatform[] = ['sqlserver', 'postgresql'];
+
+describe.each(platforms)('EnumerateMjEntityFkGraph [%s]', (platform) => {
+  it('runs the dialect FK-graph query and builds single-column edges (nullability coerced)', async () => {
+    // childNullable arrives as SQL Server bit-ish (1/0) OR PostgreSQL boolean (true/false); both coerce.
+    const rows = [
+      { parentTable: 'Entity', parentRefCol: 'ID', childTable: 'RecordChange', childCol: 'EntityID', childNullable: platform === 'postgresql' ? false : 0, fkName: 'FK_RecordChange_EntityID', colCount: 1 },
+      { parentTable: 'Entity', parentRefCol: 'ID', childTable: 'AuditLog', childCol: 'EntityID', childNullable: platform === 'postgresql' ? true : 1, fkName: 'FK_AuditLog_Entity', colCount: 1 },
+    ];
+    const { provider, executeSQL } = mockProvider(platform, rows);
+    const edges = await EnumerateMjEntityFkGraph(provider, '__mj');
+
+    // Ran the dialect's own catalog query for this platform.
+    const sqlRun = executeSQL.mock.calls[0][0] as string;
+    expect(sqlRun).toBe(GetDialect(platform).ForeignKeyGraphSQL('__mj'));
+    expect(sqlRun).toContain(platform === 'postgresql' ? 'pg_catalog.pg_constraint' : 'sys.foreign_keys');
+
+    expect(edges).toHaveLength(2);
+    expect(edges.find((e) => e.childTable === 'RecordChange')!.childNullable).toBe(false);
+    expect(edges.find((e) => e.childTable === 'AuditLog')!.childNullable).toBe(true);
+  });
+
+  it('excludes composite (colCount > 1) FKs and warns via OnWarn', async () => {
+    const rows = [
+      { parentTable: 'Entity', parentRefCol: 'ID', childTable: 'RecordChange', childCol: 'EntityID', childNullable: 0, fkName: 'FK_RecordChange_EntityID', colCount: 1 },
+      // a composite FK — two rows share the constraint; colCount = 2 → excluded + warned
+      { parentTable: 'Entity', parentRefCol: 'ID', childTable: 'WeirdTable', childCol: 'EntityID', childNullable: 0, fkName: 'FK_Weird_Composite', colCount: 2 },
+    ];
+    const { provider } = mockProvider(platform, rows);
+    const onWarn = vi.fn();
+    const edges = await EnumerateMjEntityFkGraph(provider, '__mj', { OnWarn: onWarn } as never);
+
+    expect(edges).toHaveLength(1);
+    expect(edges[0].childTable).toBe('RecordChange');
+    expect(onWarn).toHaveBeenCalledTimes(1);
+    expect(String(onWarn.mock.calls[0][1])).toContain('FK_Weird_Composite');
+  });
+
+  it('returns [] on an empty catalog result', async () => {
+    const { provider } = mockProvider(platform, []);
+    expect(await EnumerateMjEntityFkGraph(provider, '__mj')).toEqual([]);
+  });
+});

--- a/packages/OpenApp/Engine/src/__tests__/entity-teardown-plan.test.ts
+++ b/packages/OpenApp/Engine/src/__tests__/entity-teardown-plan.test.ts
@@ -1,28 +1,46 @@
 /**
- * Unit tests for the PURE FK-graph teardown planner (`buildEntityTeardownPlan`).
+ * Unit tests for the PURE FK-graph teardown planner (`buildEntityTeardownPlan`) and the atomic
+ * batch wrapper (`buildTeardownBatchScript`).
  *
- * These validate the recursion/ordering/null-vs-delete logic the SQL-Server teardown relies on,
- * without a DB. A real TS import (no `Function()` extraction) since the planner is a normal export.
+ * These validate the recursion / ordering / null-vs-delete logic the teardown relies on, without a
+ * DB. The suite is PARAMETRIZED over both dialects (SQL Server + PostgreSQL) so we prove the SAME
+ * walk emits correctly-quoted SQL on either backend (`[__mj].[X]` vs. `"__mj"."X"`). Real TS imports
+ * (no `Function()` extraction) since the planner is a normal export.
+ *
+ * Polymorphic-key note: MJ's polymorphic tables (RecordChange, TaggedItem, …) carry a REAL
+ * single-column FK on their `EntityID` discriminator, so the FK-graph reaches them here. A NOT-NULL
+ * `EntityID` (e.g. RecordChange) is DELETEd; a nullable `EntityID` (e.g. AuditLog) is SET NULL and
+ * the row survives — both are correct at teardown granularity. The FK-less `RecordID` string half
+ * has no constraint and only dangles on single-record deletes, which is a separate spDelete concern.
  */
 import { describe, it, expect } from 'vitest';
-import { buildEntityTeardownPlan, type FkEdge } from '../install/entity-teardown.js';
+import { GetDialect, type SQLDialect } from '@memberjunction/sql-dialect';
+import { buildEntityTeardownPlan, buildTeardownBatchScript, buildRootDoomedPredicate, type FkEdge } from '../install/entity-teardown.js';
 
-const ROOT = "[SchemaName] = 'x'";
+const dialects: Array<[string, SQLDialect]> = [
+  ['SQLServer', GetDialect('sqlserver')],
+  ['PostgreSQL', GetDialect('postgresql')],
+];
+
 const at = (s: string[], t: string): number => s.findIndex((x) => x.includes(t));
 
-describe('buildEntityTeardownPlan (pure FK-walk)', () => {
-  it('NOT-NULL dependent is DELETEd, scoped by a nested subquery, ordered before Entity before SchemaInfo', () => {
+describe.each(dialects)('buildEntityTeardownPlan (pure FK-walk) [%s]', (_name, dialect) => {
+  const q = (t: string): string => dialect.QuoteSchema('__mj', t);
+  const col = (c: string): string => dialect.QuoteIdentifier(c);
+  const ROOT = buildRootDoomedPredicate(dialect, 'x');
+
+  it('NOT-NULL polymorphic dependent (RecordChange) is DELETEd, scoped by a nested subquery, before Entity before SchemaInfo', () => {
     const edges: FkEdge[] = [
       { parentTable: 'Entity', parentRefCol: 'ID', childTable: 'RecordChange', childCol: 'EntityID', childNullable: false },
     ];
-    const { statements } = buildEntityTeardownPlan(edges, '__mj', ROOT);
-    const rc = at(statements, 'DELETE FROM [__mj].[RecordChange]');
-    const ent = at(statements, 'DELETE FROM [__mj].[Entity] WHERE');
-    const si = at(statements, 'DELETE FROM [__mj].[SchemaInfo]');
+    const { statements } = buildEntityTeardownPlan(edges, dialect, '__mj', ROOT);
+    const rc = at(statements, `DELETE FROM ${q('RecordChange')}`);
+    const ent = at(statements, `DELETE FROM ${q('Entity')} WHERE`);
+    const si = at(statements, `DELETE FROM ${q('SchemaInfo')}`);
     expect(rc).toBeGreaterThan(-1);
     expect(rc).toBeLessThan(ent);
     expect(ent).toBeLessThan(si);
-    expect(statements[rc]).toContain("[EntityID] IN (SELECT [ID] FROM [__mj].[Entity] WHERE [SchemaName] = 'x')");
+    expect(statements[rc]).toContain(`${col('EntityID')} IN (SELECT ${col('ID')} FROM ${q('Entity')} WHERE ${ROOT})`);
   });
 
   it('transitive NOT-NULL chain: grandchild deleted before child before Entity', () => {
@@ -30,9 +48,9 @@ describe('buildEntityTeardownPlan (pure FK-walk)', () => {
       { parentTable: 'Entity', parentRefCol: 'ID', childTable: 'A', childCol: 'EntityID', childNullable: false },
       { parentTable: 'A', parentRefCol: 'ID', childTable: 'B', childCol: 'AID', childNullable: false },
     ];
-    const { statements } = buildEntityTeardownPlan(edges, '__mj', ROOT);
-    expect(at(statements, 'DELETE FROM [__mj].[B]')).toBeLessThan(at(statements, 'DELETE FROM [__mj].[A]'));
-    expect(at(statements, 'DELETE FROM [__mj].[A]')).toBeLessThan(at(statements, 'DELETE FROM [__mj].[Entity] WHERE'));
+    const { statements } = buildEntityTeardownPlan(edges, dialect, '__mj', ROOT);
+    expect(at(statements, `DELETE FROM ${q('B')}`)).toBeLessThan(at(statements, `DELETE FROM ${q('A')}`));
+    expect(at(statements, `DELETE FROM ${q('A')}`)).toBeLessThan(at(statements, `DELETE FROM ${q('Entity')} WHERE`));
   });
 
   it('nullable link → SET NULL (row survives), and does NOT recurse into its children', () => {
@@ -40,9 +58,18 @@ describe('buildEntityTeardownPlan (pure FK-walk)', () => {
       { parentTable: 'Entity', parentRefCol: 'ID', childTable: 'Conversation', childCol: 'LinkedEntityID', childNullable: true },
       { parentTable: 'Conversation', parentRefCol: 'ID', childTable: 'ConversationDetail', childCol: 'ConversationID', childNullable: false },
     ];
-    const { statements } = buildEntityTeardownPlan(edges, '__mj', ROOT);
-    expect(statements.some((s) => s.includes('UPDATE [__mj].[Conversation] SET [LinkedEntityID] = NULL'))).toBe(true);
-    expect(statements.some((s) => s.includes('[__mj].[ConversationDetail]'))).toBe(false);
+    const { statements } = buildEntityTeardownPlan(edges, dialect, '__mj', ROOT);
+    expect(statements.some((s) => s.includes(`UPDATE ${q('Conversation')} SET ${col('LinkedEntityID')} = NULL`))).toBe(true);
+    expect(statements.some((s) => s.includes(q('ConversationDetail')))).toBe(false);
+  });
+
+  it('nullable polymorphic discriminator (AuditLog.EntityID) → SET NULL, row survives (safe orphan)', () => {
+    const edges: FkEdge[] = [
+      { parentTable: 'Entity', parentRefCol: 'ID', childTable: 'AuditLog', childCol: 'EntityID', childNullable: true },
+    ];
+    const { statements } = buildEntityTeardownPlan(edges, dialect, '__mj', ROOT);
+    expect(statements.some((s) => s.includes(`UPDATE ${q('AuditLog')} SET ${col('EntityID')} = NULL`))).toBe(true);
+    expect(statements.some((s) => s.startsWith(`DELETE FROM ${q('AuditLog')}`))).toBe(false);
   });
 
   it('self-ref nullable (Entity.ParentID) → SET NULL before the Entity delete; terminates', () => {
@@ -50,10 +77,10 @@ describe('buildEntityTeardownPlan (pure FK-walk)', () => {
       { parentTable: 'Entity', parentRefCol: 'ID', childTable: 'Entity', childCol: 'ParentID', childNullable: true },
       { parentTable: 'Entity', parentRefCol: 'ID', childTable: 'RecordChange', childCol: 'EntityID', childNullable: false },
     ];
-    const { statements } = buildEntityTeardownPlan(edges, '__mj', ROOT);
-    const setNull = at(statements, 'UPDATE [__mj].[Entity] SET [ParentID] = NULL');
+    const { statements } = buildEntityTeardownPlan(edges, dialect, '__mj', ROOT);
+    const setNull = at(statements, `UPDATE ${q('Entity')} SET ${col('ParentID')} = NULL`);
     expect(setNull).toBeGreaterThan(-1);
-    expect(setNull).toBeLessThan(at(statements, 'DELETE FROM [__mj].[Entity] WHERE'));
+    expect(setNull).toBeLessThan(at(statements, `DELETE FROM ${q('Entity')} WHERE`));
   });
 
   it('cross-table cycle A→B→A terminates and warns (no stack overflow)', () => {
@@ -62,10 +89,44 @@ describe('buildEntityTeardownPlan (pure FK-walk)', () => {
       { parentTable: 'A', parentRefCol: 'ID', childTable: 'B', childCol: 'AID', childNullable: false },
       { parentTable: 'B', parentRefCol: 'ID', childTable: 'A', childCol: 'BID', childNullable: false },
     ];
-    const { statements, warnings } = buildEntityTeardownPlan(edges, '__mj', ROOT);
+    const { statements, warnings } = buildEntityTeardownPlan(edges, dialect, '__mj', ROOT);
     expect(warnings.some((w) => w.toLowerCase().includes('cycle'))).toBe(true);
     // still terminates with the Entity + SchemaInfo deletes present
-    expect(at(statements, 'DELETE FROM [__mj].[Entity] WHERE')).toBeGreaterThan(-1);
-    expect(at(statements, 'DELETE FROM [__mj].[SchemaInfo]')).toBeGreaterThan(-1);
+    expect(at(statements, `DELETE FROM ${q('Entity')} WHERE`)).toBeGreaterThan(-1);
+    expect(at(statements, `DELETE FROM ${q('SchemaInfo')}`)).toBeGreaterThan(-1);
+  });
+});
+
+describe('buildRootDoomedPredicate — dialect-quoted', () => {
+  it('SQL Server brackets the column', () => {
+    expect(buildRootDoomedPredicate(GetDialect('sqlserver'), 'app_x')).toBe("[SchemaName] = 'app_x'");
+  });
+  it('PostgreSQL double-quotes the column', () => {
+    expect(buildRootDoomedPredicate(GetDialect('postgresql'), 'app_x')).toBe('"SchemaName" = \'app_x\'');
+  });
+  it("escapes a single-quote in the schema name (no injection)", () => {
+    expect(buildRootDoomedPredicate(GetDialect('sqlserver'), "a'b")).toBe("[SchemaName] = 'a''b'");
+  });
+});
+
+describe('buildTeardownBatchScript — per-dialect atomic wrapper', () => {
+  it('empty statement list → empty script (no-op)', () => {
+    expect(buildTeardownBatchScript(GetDialect('sqlserver'), [])).toBe('');
+    expect(buildTeardownBatchScript(GetDialect('postgresql'), [])).toBe('');
+  });
+  it('SQL Server wraps with SET pragmas + BEGIN/COMMIT TRANSACTION', () => {
+    const s = buildTeardownBatchScript(GetDialect('sqlserver'), ['DELETE FROM [__mj].[A] WHERE 1=1']);
+    expect(s).toContain('SET QUOTED_IDENTIFIER ON;');
+    expect(s).toContain('SET ANSI_NULLS ON;');
+    expect(s).toContain('SET XACT_ABORT ON;');
+    expect(s).toContain('BEGIN TRANSACTION;');
+    expect(s).toContain('COMMIT TRANSACTION;');
+  });
+  it('PostgreSQL wraps with plain BEGIN/COMMIT and NO SQL-Server pragmas', () => {
+    const s = buildTeardownBatchScript(GetDialect('postgresql'), ['DELETE FROM "__mj"."A" WHERE 1=1']);
+    expect(s.startsWith('BEGIN;')).toBe(true);
+    expect(s.trimEnd().endsWith('COMMIT;')).toBe(true);
+    expect(s).not.toContain('QUOTED_IDENTIFIER');
+    expect(s).not.toContain('XACT_ABORT');
   });
 });

--- a/packages/OpenApp/Engine/src/install/entity-teardown.ts
+++ b/packages/OpenApp/Engine/src/install/entity-teardown.ts
@@ -6,17 +6,19 @@
  * FKs (which are NO ACTION, not CASCADE) block the delete. The naive entity-layer approach
  * (RunView + per-row `Delete()`) UNDER-deletes: RunView reads base VIEWS (e.g. `vwRecordChanges`
  * INNER JOINs to `[User]`/`[Entity]`), so rows whose join is orphaned are invisible while the
- * base-TABLE FK still enforces them. This module instead enumerates the LIVE FK graph from
- * `sys.foreign_keys` and clears every one of `Entity`'s dependents — deepest-first, set-based,
- * in ONE atomic transaction.
+ * base-TABLE FK still enforces them. This module instead enumerates the LIVE FK graph and clears
+ * every one of `Entity`'s dependents — deepest-first, set-based, in ONE atomic transaction.
  *
- * **SQL Server only.** The `sys.foreign_keys` catalog query, bracket-quoting, and
- * `SET XACT_ABORT ON` transaction wrapper are SQL-Server-specific. PostgreSQL keeps the existing
- * entity-layer teardown path (see `RemoveAppEntityMetadata` in `install-orchestrator.ts`).
+ * **Dialect-neutral (SQL Server + PostgreSQL).** The FK-graph catalog query and identifier
+ * quoting come from the provider's {@link SQLDialect} (`ForeignKeyGraphSQL` / `QuoteSchema` /
+ * `QuoteIdentifier`), so the same walk runs on either backend. Only the atomic-batch session
+ * preamble (SQL Server `SET …` pragmas vs. PostgreSQL `BEGIN`/`COMMIT`) is branched per platform,
+ * because there is no dialect API for session setup. Callers that pass NO provider still get the
+ * legacy entity-layer path (see `RemoveAppEntityMetadata` in `install-orchestrator.ts`).
  */
 import type { DatabaseProviderBase } from '@memberjunction/core';
+import type { SQLDialect } from '@memberjunction/sql-dialect';
 import type { AppInstallCallbacks } from '../types/open-app-types.js';
-import { EscapeSqlString } from './schema-manager.js';
 
 /**
  * A single-column foreign key within the MJ core schema: `childTable.childCol` references
@@ -63,10 +65,16 @@ export interface TeardownPlan {
  * covered by the table's own set-delete) and cross-table cycles (path guard) are handled.
  *
  * @param fkEdges the single-column FK edges of the MJ core schema (from {@link EnumerateMjEntityFkGraph})
- * @param mjSchema the MJ core schema name (e.g. `__mj`), used for bracket-quoting `[mjSchema].[table]`
- * @param rootDoomedPredicate the predicate selecting the doomed `Entity` rows (e.g. `[SchemaName] = 'x'`)
+ * @param dialect the provider's {@link SQLDialect}, used to quote identifiers (`[x]` vs. `"x"`)
+ * @param mjSchema the MJ core schema name (e.g. `__mj`)
+ * @param rootDoomedPredicate the predicate selecting the doomed `Entity` rows (already dialect-quoted)
  */
-export function buildEntityTeardownPlan(fkEdges: FkEdge[], mjSchema: string, rootDoomedPredicate: string): TeardownPlan {
+export function buildEntityTeardownPlan(
+  fkEdges: FkEdge[],
+  dialect: SQLDialect,
+  mjSchema: string,
+  rootDoomedPredicate: string,
+): TeardownPlan {
   const byParent = new Map<string, FkEdge[]>();
   for (const e of fkEdges) {
     if (!byParent.has(e.parentTable)) byParent.set(e.parentTable, []);
@@ -76,18 +84,19 @@ export function buildEntityTeardownPlan(fkEdges: FkEdge[], mjSchema: string, roo
   const plan: TeardownPlanItem[] = [];
   const warnings: string[] = [];
   const emitted = new Set<string>();
-  const q = (t: string): string => `[${mjSchema}].[${t}]`;
-  const push = (sql: string, op: 'delete' | 'setnull', table: string, col: string | null, where: string): void => {
+  const q = (t: string): string => dialect.QuoteSchema(mjSchema, t);
+  const col = (c: string): string => dialect.QuoteIdentifier(c);
+  const push = (sql: string, op: 'delete' | 'setnull', table: string, colName: string | null, where: string): void => {
     if (emitted.has(sql)) return;
     emitted.add(sql);
     statements.push(sql);
-    plan.push({ op, table, col, where });
+    plan.push({ op, table, col: colName, where });
   };
   const walk = (parentTable: string, parentDoomed: string, path: Set<string>): void => {
     const children = byParent.get(parentTable) ?? [];
     for (const c of children) {
-      const where = `[${c.childCol}] IN (SELECT [${c.parentRefCol}] FROM ${q(parentTable)} WHERE ${parentDoomed})`;
-      const setNull = `UPDATE ${q(c.childTable)} SET [${c.childCol}] = NULL WHERE ${where}`;
+      const where = `${col(c.childCol)} IN (SELECT ${col(c.parentRefCol)} FROM ${q(parentTable)} WHERE ${parentDoomed})`;
+      const setNull = `UPDATE ${q(c.childTable)} SET ${col(c.childCol)} = NULL WHERE ${where}`;
       const del = `DELETE FROM ${q(c.childTable)} WHERE ${where}`;
       if (c.childTable === parentTable) {
         if (c.childNullable) push(setNull, 'setnull', c.childTable, c.childCol, where);
@@ -116,31 +125,29 @@ export function buildEntityTeardownPlan(fkEdges: FkEdge[], mjSchema: string, roo
 }
 
 /**
+ * Builds the dialect-quoted predicate that selects the doomed `Entity` rows for `appSchema`
+ * (`SchemaName = '<appSchema>'`). Shared by the caller (to seed the walk root) and used verbatim
+ * as `rootDoomedPredicate`. Kept here so the quoting stays owned by this module + the dialect.
+ */
+export function buildRootDoomedPredicate(dialect: SQLDialect, appSchema: string): string {
+  return `${dialect.QuoteIdentifier('SchemaName')} = ${dialect.QuoteStringLiteral(appSchema)}`;
+}
+
+/**
  * Enumerates every SINGLE-column FK within the MJ core schema (parent + child both in `mjSchema`).
  *
  * Composite FKs (a constraint spanning >1 column) are excluded and warned — `Entity` references
- * are all single-column, so this is safe. Runs the exact `sys.foreign_keys` catalog query and is
- * therefore SQL-Server-specific.
+ * are all single-column, so this is safe. The catalog query comes from the provider's dialect
+ * ({@link SQLDialect.ForeignKeyGraphSQL}), so this works on both SQL Server and PostgreSQL; the
+ * normalized row shape (`parentTable, parentRefCol, childTable, childCol, childNullable, fkName,
+ * colCount`) is identical across dialects.
  */
 export async function EnumerateMjEntityFkGraph(
   dbProvider: DatabaseProviderBase,
   mjSchema: string,
   callbacks?: AppInstallCallbacks,
 ): Promise<FkEdge[]> {
-  const s = EscapeSqlString(mjSchema);
-  const sql =
-    'SELECT rt.name AS parentTable, rc.name AS parentRefCol, pt.name AS childTable, ' +
-    'pc.name AS childCol, pc.is_nullable AS childNullable, fk.name AS fkName, ' +
-    '(SELECT COUNT(*) FROM sys.foreign_key_columns x WHERE x.constraint_object_id = fk.object_id) AS colCount ' +
-    'FROM sys.foreign_keys fk ' +
-    'JOIN sys.foreign_key_columns fkc ON fkc.constraint_object_id = fk.object_id ' +
-    'JOIN sys.objects rt ON rt.object_id = fk.referenced_object_id ' +
-    'JOIN sys.schemas rs ON rs.schema_id = rt.schema_id ' +
-    'JOIN sys.columns rc ON rc.object_id = fk.referenced_object_id AND rc.column_id = fkc.referenced_column_id ' +
-    'JOIN sys.objects pt ON pt.object_id = fk.parent_object_id ' +
-    'JOIN sys.schemas ps ON ps.schema_id = pt.schema_id ' +
-    'JOIN sys.columns pc ON pc.object_id = fk.parent_object_id AND pc.column_id = fkc.parent_column_id ' +
-    `WHERE rs.name = '${s}' AND ps.name = '${s}'`;
+  const sql = dbProvider.Dialect.ForeignKeyGraphSQL(mjSchema);
   const rows = await dbProvider.ExecuteSQL<Record<string, unknown>>(sql);
   const edges: FkEdge[] = [];
   const composite = new Set<string>();
@@ -174,6 +181,7 @@ export async function EnumerateMjEntityFkGraph(
  */
 export async function ReportTeardownPlan(
   dbProvider: DatabaseProviderBase,
+  dialect: SQLDialect,
   mjSchema: string,
   plan: TeardownPlanItem[],
   callbacks?: AppInstallCallbacks,
@@ -183,7 +191,7 @@ export async function ReportTeardownPlan(
   for (const p of plan) {
     try {
       const rows = await dbProvider.ExecuteSQL<Record<string, unknown>>(
-        `SELECT COUNT(*) AS n FROM [${mjSchema}].[${p.table}] WHERE ${p.where}`,
+        `SELECT COUNT(*) AS n FROM ${dialect.QuoteSchema(mjSchema, p.table)} WHERE ${p.where}`,
       );
       const n = rows && rows[0] ? Number(rows[0].n) : 0;
       if (n > 0) {
@@ -201,27 +209,49 @@ export async function ReportTeardownPlan(
 }
 
 /**
- * Executes all teardown statements as ONE batch inside a single transaction.
+ * Wraps the teardown statements in ONE atomic transaction for the given dialect. PURE (no DB).
  *
- * `SET QUOTED_IDENTIFIER ON` / `SET ANSI_NULLS ON` are required because some tables have filtered
- * / computed-column indexes or indexed views, against which an UPDATE (SET NULL) or DELETE fails
- * (Msg 1934) if those options are OFF — so we set them explicitly rather than depend on the
- * driver's connection defaults. `SET XACT_ABORT ON` makes any failure roll the whole batch back
- * (all-or-nothing atomicity). No-op on an empty statement list.
+ * - **SQL Server**: `SET QUOTED_IDENTIFIER ON` / `SET ANSI_NULLS ON` are required because some
+ *   tables have filtered / computed-column indexes or indexed views, against which an UPDATE
+ *   (SET NULL) or DELETE fails (Msg 1934) if those options are OFF — so we set them explicitly
+ *   rather than depend on the driver's connection defaults. `SET XACT_ABORT ON` makes any failure
+ *   roll the whole batch back (all-or-nothing atomicity).
+ * - **PostgreSQL**: no session pragmas are needed (`QUOTED_IDENTIFIER`/`ANSI_NULLS` are SQL-Server
+ *   concepts), and PostgreSQL already aborts the whole transaction on any error, so plain
+ *   `BEGIN … COMMIT` gives the same all-or-nothing semantics as `XACT_ABORT`.
+ *
+ * The per-platform branch lives here (not on the dialect) because session/transaction setup has no
+ * dialect API and there are only two platforms; `PlatformKey` is the single point of divergence.
+ * Returns an empty string for an empty statement list.
  */
-export async function ExecTeardownBatch(dbProvider: DatabaseProviderBase, statements: string[]): Promise<void> {
-  if (!statements || !statements.length) return;
-  const script =
-    'SET QUOTED_IDENTIFIER ON;\nSET ANSI_NULLS ON;\nSET XACT_ABORT ON;\nBEGIN TRANSACTION;\n' +
-    statements.join(';\n') +
-    ';\nCOMMIT TRANSACTION;';
+export function buildTeardownBatchScript(dialect: SQLDialect, statements: string[]): string {
+  if (!statements || !statements.length) return '';
+  const body = statements.join(';\n');
+  if (dialect.PlatformKey === 'postgresql') {
+    return `BEGIN;\n${body};\nCOMMIT;`;
+  }
+  // SQL Server (and any other T-SQL-family platform)
+  return `SET QUOTED_IDENTIFIER ON;\nSET ANSI_NULLS ON;\nSET XACT_ABORT ON;\nBEGIN TRANSACTION;\n${body};\nCOMMIT TRANSACTION;`;
+}
+
+/**
+ * Executes all teardown statements as ONE batch inside a single transaction, using the dialect's
+ * session/transaction wrapper ({@link buildTeardownBatchScript}). No-op on an empty statement list.
+ */
+export async function ExecTeardownBatch(
+  dbProvider: DatabaseProviderBase,
+  dialect: SQLDialect,
+  statements: string[],
+): Promise<void> {
+  const script = buildTeardownBatchScript(dialect, statements);
+  if (!script) return;
   await dbProvider.ExecuteSQL<Record<string, unknown>>(script);
 }
 
 /**
  * Orchestrates the full FK-graph teardown for the doomed entities of a schema:
  * enumerate the live FK graph → build the plan → surface any warnings → dry-run report →
- * execute the atomic batch. SQL Server only.
+ * execute the atomic batch. Runs on SQL Server or PostgreSQL (dialect-driven).
  */
 export async function RunFkGraphTeardown(
   dbProvider: DatabaseProviderBase,
@@ -229,9 +259,10 @@ export async function RunFkGraphTeardown(
   rootDoomedPredicate: string,
   callbacks?: AppInstallCallbacks,
 ): Promise<void> {
+  const dialect = dbProvider.Dialect;
   const fkEdges = await EnumerateMjEntityFkGraph(dbProvider, mjSchema, callbacks);
-  const planned = buildEntityTeardownPlan(fkEdges, mjSchema, rootDoomedPredicate);
+  const planned = buildEntityTeardownPlan(fkEdges, dialect, mjSchema, rootDoomedPredicate);
   for (const w of planned.warnings) callbacks?.OnWarn?.('Metadata', `Teardown: ${w}`);
-  await ReportTeardownPlan(dbProvider, mjSchema, planned.plan, callbacks);
-  await ExecTeardownBatch(dbProvider, planned.statements);
+  await ReportTeardownPlan(dbProvider, dialect, mjSchema, planned.plan, callbacks);
+  await ExecTeardownBatch(dbProvider, dialect, planned.statements);
 }

--- a/packages/OpenApp/Engine/src/install/install-orchestrator.ts
+++ b/packages/OpenApp/Engine/src/install/install-orchestrator.ts
@@ -17,7 +17,7 @@ import type { InstalledAppMap, DependencyValue } from '../dependency/dependency-
 import { FetchManifestFromGitHub, DownloadMigrations, GetLatestVersion, ListGitHubReleases, ListGitHubTags, ValidateGitHubTag, ParseGitHubUrl, type GitHubClientOptions, type MigrationDownloadResult } from '../github/github-client.js';
 import semver from 'semver';
 import { CreateAppSchema, DropAppSchema, SchemaExists, EscapeSqlString } from './schema-manager.js';
-import { RunFkGraphTeardown } from './entity-teardown.js';
+import { RunFkGraphTeardown, buildRootDoomedPredicate } from './entity-teardown.js';
 import { extractApplicationIds } from './migration-application-ids.js';
 import { RunAppMigrations, type SkywayDatabaseConfig } from './migration-runner.js';
 import { AddAppPackages, RemoveAppPackages, RunPackageInstall, BumpPrefixedDependencies, type PackageManagerType, type VersionStrategy, type WorkspaceTarget } from './package-manager.js';
@@ -1495,9 +1495,11 @@ export async function RemoveAppEntityMetadata(
       .map((id) => NormalizeUUID(id))
       .filter((id): id is string => !!id);
 
-    // The SQL-Server FK-graph teardown is used only when a non-Postgres provider is supplied.
-    // PostgreSQL (and any no-provider caller) keeps the existing entity-layer path unchanged.
-    const useFkGraph = !!options?.DatabaseProvider && options.DatabaseProvider.Dialect.PlatformKey !== 'postgresql';
+    // The dialect-driven FK-graph teardown is used whenever a DatabaseProvider is supplied — it
+    // runs on BOTH SQL Server and PostgreSQL (identifier quoting + the FK-graph catalog query come
+    // from the provider's SQLDialect). Only a caller that passes NO provider falls back to the
+    // legacy entity-layer path below (which under-deletes; see the comment on that branch).
+    const useFkGraph = !!options?.DatabaseProvider?.Dialect;
 
     const md = (provider ?? new Metadata()) as unknown as IMetadataProvider;
 
@@ -1541,16 +1543,21 @@ export async function RemoveAppEntityMetadata(
     const ownedAppIds = await FindAppOwnedApplications(rv, contextUser, entityIds, idList);
 
     if (useFkGraph) {
-      // SQL Server: dynamic, set-based, atomic FK-graph teardown on the base tables (covers ALL of
-      // Entity's dependents, incl. those the entity-layer path under-deletes via base-view joins).
-      // Replaces the hardcoded QueueDeleteEntitiesByFilter list + per-entity Delete + SchemaInfo delete.
+      // Dynamic, set-based, atomic FK-graph teardown on the base tables — runs on BOTH SQL Server
+      // and PostgreSQL via the provider's SQLDialect (covers ALL of Entity's dependents, incl.
+      // those the entity-layer path under-deletes via base-view joins). Replaces the hardcoded
+      // QueueDeleteEntitiesByFilter list + per-entity Delete + SchemaInfo delete.
+      const dbProvider = options!.DatabaseProvider!;
       const mjSchema = options?.MJCoreSchema ?? '__mj';
-      const rootPredicate = `[SchemaName] = '${escaped}'`;
-      await RunFkGraphTeardown(options!.DatabaseProvider!, mjSchema, rootPredicate, callbacks);
+      const rootPredicate = buildRootDoomedPredicate(dbProvider.Dialect, schemaName);
+      await RunFkGraphTeardown(dbProvider, mjSchema, rootPredicate, callbacks);
     } else {
-      // PostgreSQL / no provider: the existing entity-layer path — all deletes queued into ONE
-      // TransactionGroup and committed once (all-or-nothing; each un-grouped delete would otherwise
-      // autocommit on PostgreSQL, leaving partial orphan state on an FK violation — PG3).
+      // LEGACY FALLBACK (no DatabaseProvider passed): entity-layer path — all deletes queued into
+      // ONE TransactionGroup and committed once (all-or-nothing; each un-grouped delete would
+      // otherwise autocommit on PostgreSQL, leaving partial orphan state on an FK violation — PG3).
+      // NOTE: this UNDER-deletes — it clears only the hardcoded dependent list below and misses the
+      // rest of Entity's FK-dependents (e.g. RecordChange). Pass a DatabaseProvider (both SS and PG)
+      // to get the complete, dialect-driven FK-graph cascade above instead.
       const tg = await md.CreateTransactionGroup();
       const queueDeleteByFilterOrThrow = async (entityName: string, filter: string): Promise<void> => {
         const r = await QueueDeleteEntitiesByFilter(rv, contextUser, entityName, filter, tg);

--- a/packages/SQLDialect/src/__tests__/crossDialect.test.ts
+++ b/packages/SQLDialect/src/__tests__/crossDialect.test.ts
@@ -669,4 +669,37 @@ describe('Cross-Dialect Comparison Tests', () => {
             expect(pg.CanonicalSchemaName('__mj')).toBe('__mj');
         });
     });
+
+    // ─── FK-Graph Query (cascade planning) ───────────────────────────
+
+    describe('ForeignKeyGraphSQL', () => {
+        it('SQL Server reads sys.foreign_keys and embeds the schema literal (no bind params)', () => {
+            const sql = ss.ForeignKeyGraphSQL('__mj');
+            expect(sql).toContain('sys.foreign_keys');
+            expect(sql).toContain("rs.name = '__mj'");
+            expect(sql).toContain("ps.name = '__mj'");
+            expect(sql).not.toContain('@'); // no bind placeholder — runnable via ExecuteSQL(sql)
+        });
+
+        it('PostgreSQL reads pg_constraint and embeds the schema literal (no bind params)', () => {
+            const sql = pg.ForeignKeyGraphSQL('__mj');
+            expect(sql).toContain('pg_catalog.pg_constraint');
+            expect(sql).toContain("con.contype = 'f'");
+            expect(sql).toContain("cn.nspname = '__mj'");
+            expect(sql).not.toContain('$1'); // literal-embedded, not a positional placeholder
+        });
+
+        it('both dialects return the SAME normalized column aliases the planner parses', () => {
+            for (const sql of [ss.ForeignKeyGraphSQL('__mj'), pg.ForeignKeyGraphSQL('__mj')]) {
+                for (const alias of ['parentTable', 'parentRefCol', 'childTable', 'childCol', 'childNullable', 'fkName', 'colCount']) {
+                    expect(sql).toContain(alias);
+                }
+            }
+        });
+
+        it('escapes a single-quote in the schema name (no injection)', () => {
+            expect(ss.ForeignKeyGraphSQL("a'b")).toContain("rs.name = 'a''b'");
+            expect(pg.ForeignKeyGraphSQL("a'b")).toContain("cn.nspname = 'a''b'");
+        });
+    });
 });

--- a/packages/SQLDialect/src/postgresqlDialect.ts
+++ b/packages/SQLDialect/src/postgresqlDialect.ts
@@ -710,6 +710,34 @@ export class PostgreSQLDialect extends SQLDialect {
         };
     }
 
+    /**
+     * PostgreSQL FK-graph query for cascade planning — reads `pg_catalog.pg_constraint`
+     * (`contype = 'f'`). Returns one row per FK column (via `unnest(conkey, confkey)`, which
+     * preserves column pairing/order), with `childNullable` (`NOT attnotnull`) and `colCount`
+     * (`array_length(conkey, 1)`, for composite exclusion). Column aliases and semantics MATCH
+     * the SQL Server variant so a single caller parses both. `relname`/`attname` preserve the
+     * quoted mixed-case identifiers MJ creates on PG, so they feed straight into QuoteIdentifier.
+     * Both parent + child are filtered to `schema`; the schema is embedded as a literal.
+     */
+    ForeignKeyGraphSQL(schema: string): string {
+        const s = this.QuoteStringLiteral(schema);
+        return (
+            'SELECT pt.relname AS "parentTable", pa.attname AS "parentRefCol", ct.relname AS "childTable", ' +
+            'ca.attname AS "childCol", (NOT ca.attnotnull) AS "childNullable", con.conname AS "fkName", ' +
+            'array_length(con.conkey, 1) AS "colCount" ' +
+            'FROM pg_catalog.pg_constraint con ' +
+            'JOIN pg_catalog.pg_class ct ON ct.oid = con.conrelid ' +
+            'JOIN pg_catalog.pg_namespace cn ON cn.oid = ct.relnamespace ' +
+            'JOIN pg_catalog.pg_class pt ON pt.oid = con.confrelid ' +
+            'JOIN pg_catalog.pg_namespace pn ON pn.oid = pt.relnamespace ' +
+            'JOIN LATERAL unnest(con.conkey, con.confkey) WITH ORDINALITY AS k(child_attnum, parent_attnum, ord) ON true ' +
+            'JOIN pg_catalog.pg_attribute ca ON ca.attrelid = con.conrelid AND ca.attnum = k.child_attnum ' +
+            'JOIN pg_catalog.pg_attribute pa ON pa.attrelid = con.confrelid AND pa.attnum = k.parent_attnum ' +
+            `WHERE con.contype = 'f' AND cn.nspname = ${s} AND pn.nspname = ${s} ` +
+            'ORDER BY con.conname, k.ord'
+        );
+    }
+
     // ─── IIF ─────────────────────────────────────────────────────────
 
     IIF(condition: string, trueVal: string, falseVal: string): string {

--- a/packages/SQLDialect/src/sqlDialect.ts
+++ b/packages/SQLDialect/src/sqlDialect.ts
@@ -831,6 +831,28 @@ export abstract class SQLDialect implements SQLParserDialect {
      */
     abstract SchemaIntrospectionQueries(): SchemaIntrospectionSQL;
 
+    /**
+     * Returns a ready-to-run (no bind parameters) query that enumerates the foreign-key graph
+     * of a single schema, for FK-cascade planning (e.g. Open-App metadata teardown).
+     *
+     * Unlike {@link SchemaIntrospectionQueries}.`listForeignKeys` (a placeholder template), this
+     * embeds the schema literal directly (via {@link QuoteStringLiteral}) so it can be executed
+     * with `ExecuteSQL(sql)` on any provider without a dialect-specific bind convention. It also
+     * returns two extra columns the cascade planner needs:
+     *
+     * - `childNullable` — whether the referencing (child) column allows NULL, which decides
+     *   `UPDATE … SET NULL` (nullable) vs. `DELETE` + recurse (NOT NULL).
+     * - `colCount` — the number of columns in the FK constraint, so a caller can exclude
+     *   composite FKs (`colCount > 1`).
+     *
+     * Every row is one FK column. Column aliases are IDENTICAL across dialects:
+     * `parentTable, parentRefCol, childTable, childCol, childNullable, fkName, colCount`
+     * (both the referenced/parent and referencing/child tables are within `schema`).
+     *
+     * @param schema the schema whose intra-schema FK edges to enumerate (e.g. `__mj`)
+     */
+    abstract ForeignKeyGraphSQL(schema: string): string;
+
     // ─── Null Handling ───────────────────────────────────────────────
 
     /**

--- a/packages/SQLDialect/src/sqlServerDialect.ts
+++ b/packages/SQLDialect/src/sqlServerDialect.ts
@@ -615,6 +615,31 @@ export class SQLServerDialect extends SQLDialect {
         };
     }
 
+    /**
+     * SQL Server FK-graph query for cascade planning — reads the `sys.foreign_keys` catalog.
+     * Returns one row per FK column with `childNullable` (from `sys.columns.is_nullable`) and
+     * `colCount` (columns in the constraint, for composite exclusion). Both parent + child are
+     * filtered to `schema`. Schema is embedded as a literal (no bind params) so it runs via
+     * `ExecuteSQL(sql)`.
+     */
+    ForeignKeyGraphSQL(schema: string): string {
+        const s = this.QuoteStringLiteral(schema);
+        return (
+            'SELECT rt.name AS parentTable, rc.name AS parentRefCol, pt.name AS childTable, ' +
+            'pc.name AS childCol, pc.is_nullable AS childNullable, fk.name AS fkName, ' +
+            '(SELECT COUNT(*) FROM sys.foreign_key_columns x WHERE x.constraint_object_id = fk.object_id) AS colCount ' +
+            'FROM sys.foreign_keys fk ' +
+            'JOIN sys.foreign_key_columns fkc ON fkc.constraint_object_id = fk.object_id ' +
+            'JOIN sys.objects rt ON rt.object_id = fk.referenced_object_id ' +
+            'JOIN sys.schemas rs ON rs.schema_id = rt.schema_id ' +
+            'JOIN sys.columns rc ON rc.object_id = fk.referenced_object_id AND rc.column_id = fkc.referenced_column_id ' +
+            'JOIN sys.objects pt ON pt.object_id = fk.parent_object_id ' +
+            'JOIN sys.schemas ps ON ps.schema_id = pt.schema_id ' +
+            'JOIN sys.columns pc ON pc.object_id = fk.parent_object_id AND pc.column_id = fkc.parent_column_id ' +
+            `WHERE rs.name = ${s} AND ps.name = ${s}`
+        );
+    }
+
     // ─── IIF ─────────────────────────────────────────────────────────
 
     IIF(condition: string, trueVal: string, falseVal: string): string {


### PR DESCRIPTION
Stacked follow-up on #3053 (base = `feature/fix-open-app-uninstall`) that closes out @MS-BC's review. The FK-graph metadata teardown is now **dialect-driven and runs on both SQL Server and PostgreSQL**, deleting the divergent hardcoded PG path.

## Why
#3053's FK-graph cascade fixed the SQL Server under-delete (removing a *used* app failed on a FK violation from an orphaned `RecordChange`), but **PostgreSQL kept the old hardcoded ~6-entity list**, which under-deletes — so the same bug still bit on PG. The teardown also hardcoded SQL-Server syntax (`[__mj].[x]`, `sys.foreign_keys`, `SET XACT_ABORT`) instead of MJ's dialect abstraction.

## What changed
- **`@memberjunction/sql-dialect`** — new `ForeignKeyGraphSQL(schema)` (abstract + SS/PG impls). One dialect seam for the FK-graph catalog read: SS `sys.foreign_keys`, PG `pg_catalog.pg_constraint` (with `unnest(conkey,confkey) WITH ORDINALITY`). Returns the normalized shape the planner parses — incl. source-column **nullability** and **composite column-count** — with the schema embedded via `QuoteStringLiteral` (runnable via `ExecuteSQL(sql)`, no bind-param convention).
- **`entity-teardown.ts`** — all quoting via `dialect.QuoteSchema` / `QuoteIdentifier` (was hardcoded `[__mj].[x]`); FK graph read via the dialect; `buildTeardownBatchScript` (pure) branches the atomic-batch preamble per platform (SS `SET` pragmas + `BEGIN/COMMIT TRAN` vs PG `BEGIN/COMMIT`); `buildRootDoomedPredicate` builds the dialect-quoted `SchemaName` predicate.
- **`install-orchestrator.ts`** — provider gate is now **`has-a-Dialect`** (was `!== 'postgresql'`). The FK-graph cascade runs for a provider on **both** dialects; the legacy entity-layer hardcoded-list path remains **only** as the no-provider fallback (clearly commented as under-deleting).

## How each review comment is addressed
| Review comment | Resolution |
|---|---|
| *"looks hardcoded instead of using QuoteIdentifier … avoid SQL Server hardcoding"* (entity-teardown.ts:79) | Quoting via `dialect.QuoteSchema`/`QuoteIdentifier`. |
| *"the concerning set of lines … hardcoding deletes, is this the Postgres specific logic? … make both follow a similar deletion strategy"* (orchestrator:1581) | PG now runs the **same** dialect-driven FK-graph cascade. Hardcoded list survives only as no-provider fallback. |
| *"`!== postgresql` may be an overcorrection … `=== 'sqlserver'` at least"* + *"keep optional chaining consistent"* (orchestrator:1500) | Gate is `!!options?.DatabaseProvider?.Dialect` — dialect drives behavior, no platform-name gate. |
| *"tie in PG … use Dialect as much as possible"* | `SQLDialect.ForeignKeyGraphSQL` — the FK catalog read is now a first-class dialect seam on both dialects. |
| *"Hardcoded delete vs BaseEntity.delete() re record changes"* (entity-teardown.ts:91) | Set-based base-table deletes are intentional (base **views** hide FK-orphaned rows; this is a wholesale schema removal, not per-record) — documented in the module header. |
| Polymorphic keys | Covered via each polymorphic table's **real single-column `EntityID` FK**: nullable → `SET NULL` (row survives), NOT-NULL (e.g. `RecordChange`) → `DELETE`. The FK-less `RecordID` string half only dangles on single-record deletes — a separate `spDelete` concern, documented + out of scope. |

Delivers @MarceloT-BC's stated follow-up ("add a PostgreSQL FK-graph variant so PG gets Solution 1 too").

## Testing — both dialects proven on live databases
**Unit** — SQLDialect **234/234**, OpenApp/Engine **263/263**. New: pure planner parametrized over both dialects (`[__mj].[X]` vs `"__mj"."X"`), polymorphic cases (`RecordChange` NOT-NULL delete, `AuditLog` nullable SET NULL), batch-wrapper + predicate; `EnumerateMjEntityFkGraph` mocked-introspection (composite skip, nullability coercion); `ForeignKeyGraphSQL` shape tests. Pre-existing remove/teardown/order/cleanup tests pass unchanged (no-provider legacy path preserved).

**Live SQL Server** — fresh DB from scratch (`mj migrate` 56 → `mj codegen` 377 entities → `mj app install …/bizapps-tasks`, 19 entities). Reproduced the exact bug: after clearing only the old hardcoded ~6-list, the Entity delete fails on `FK_RecordChange_EntityID`. Then the **patched `mj app remove`** cleanly removed everything (entities, the injected `RecordChange`, SchemaInfo, schema dropped) while leaving the `bizapps-common` dependency untouched.

**Live PostgreSQL** — fresh Postgres from scratch (`mj migrate` 61 → `mj codegen` 373). `ForeignKeyGraphSQL` enumerated **769 FK edges** on the real `__mj` schema; `RunFkGraphTeardown` (actual built code, raw provider stub) torn down a seeded app under `__mj_pgtest` — `RecordChange` and all dependents cleared, **PG double-quoting** (`"SchemaName" = '…'`) and the **PG `BEGIN…COMMIT` atomic batch** (which matters — MJ's PG FKs are `DEFERRABLE INITIALLY DEFERRED`, so a naive teardown would fail at COMMIT). Full evidence in the PR comments.

🤖 Generated with [Claude Code](https://claude.com/claude-code)