### PR TITLE
fix(server): make magic-link atomic consume dialect-aware for PostgreSQL (#3075)

### DIFF
--- a/.changeset/warm-seas-create.md
+++ b/.changeset/warm-seas-create.md
@@ -1,0 +1,5 @@
+---
+"@memberjunction/server": patch
+---
+
+Fix magic-link redemption on PostgreSQL. The atomic single-use consume SQL was T-SQL-only, so redemption on PG failed with a syntax error and minted no session. buildConsumeInviteSQL is now dialect-aware

--- a/.claude/commands/pg-migrate-v2.md
+++ b/.claude/commands/pg-migrate-v2.md
@@ -168,6 +168,38 @@ If the output does **not** contain `AUTH_OK`, stop and tell the user to run
 This is a hard gate — gap-authoring and the browser phases all delegate to CC in
 Docker. Do not proceed past this point unauthenticated.
 
+### Step 0g: Browser-login strategy — magic-link by default (self-contained, no external IdP)
+
+> **The recurring "login worked last week, not this week" trap — and why we don't
+> depend on an external IdP anymore.** MJExplorer's auth config lives in the GITIGNORED
+> `environment.development.ts`. The workbench entrypoint only makes it `AUTH_TYPE:'auth0'`
+> when `docker/workbench/.env` carries `TEST_AUTH0_*`; absent those, Explorer falls back
+> to the committed `environment.ts` (`AUTH_TYPE:'msal'`, Azure AD), and any hardcoded
+> Auth0 login fails with *"username may be incorrect."* The pipeline only ever "worked"
+> on leftover volume state. **Depending on Auth0/MSAL for headless automated login is the
+> fragility.** The fix: log in with **magic-link**, which needs no external IdP, works
+> **regardless of `AUTH_TYPE`** (the Explorer magic-link provider activates on a `#token=`
+> fragment even under MSAL — see `mjexplorer-magic-link-provider.service.ts`), and mints a
+> real session for an **existing seeded DB user**. This is **proven** to work headlessly on
+> PostgreSQL and is the default for Phases 4/4b. (Auth0 remains an OPTIONAL path for anyone
+> who wants to exercise the real IdP — see the note at the end of this step.)
+
+No preflight credentials are required for the default (magic-link) path — the login is
+provisioned in Phase 4 against the target DB. The only prerequisite is that
+`magicLink.enabled: true` in the config the container's MJAPI reads (`mj.config.cjs`
+ships it enabled for the dev/e2e flow; verify once):
+
+```bash
+docker exec claude-dev bash -lc 'grep -A2 "magicLink:" /workspace/MJ/mj.config.cjs | grep -q "enabled: true" && echo "magic-link enabled" || echo "SET magicLink.enabled=true in mj.config.cjs"'
+```
+
+> **Optional — real-IdP (Auth0) testing.** To exercise the actual Auth0 flow instead of
+> magic-link, set `TEST_AUTH0_DOMAIN`/`TEST_AUTH0_CLIENT_ID`/`TEST_AUTH0_CLIENT_SECRET`/
+> `TEST_UID`/`TEST_PWD` in `docker/workbench/.env`, `docker compose --profile postgres up
+> -d --build` (entrypoint regenerates the Explorer env as Auth0), then log in with
+> `$TEST_UID`/`$TEST_PWD`. This needs a live Auth0 tenant + test account; magic-link needs
+> neither, so prefer it for routine runs.
+
 ---
 
 ## Phase 1: Convert with `--split` (in Docker)
@@ -470,6 +502,25 @@ Your job: Run FULL STACK smoke tests against the PostgreSQL database {{PG_DB_NAM
 {{PG_DB_NAME}} on postgres-claude already has all v5 migrations applied (CodeGen objects are baked into the migrations — no separate codegen step) + metadata seed. Use it.
 - PostgreSQL: host=postgres-claude, port=5432, user=mj_admin, password=Claude2Pg99, database={{PG_DB_NAME}}
 
+## Browser login — MAGIC-LINK (default, self-contained; NEVER hardcode an IdP account)
+Log in via magic-link minted against an EXISTING seeded DB user (Step 5) — no Auth0/MSAL
+account, no `TEST_*` creds, works under any `AUTH_TYPE`. A hardcoded external IdP account
+is exactly what broke prior runs (an Auth0 account rejected by an MSAL-configured Explorer).
+
+**Access model — this is FULL access, not a restricted guest.** A *named* magic-link (email
+identity mode = the default) inherits the target user's **full DB roles** at request time
+(`context.ts` builds the session with `userRecord.UserRoles`; only `mj_anon` sessions are
+scope-restricted). So the session authorizes identically to that user logging in via
+Auth0/MSAL — enough for the whole UI suite (grids, records, admin surfaces, CRUD). The
+invite's `RoleID`/`ApplicationID` are only landing hints; they do NOT cap a named session.
+**Rule: the access ceiling = the user you mint for.** Pick a broad-role user (e.g. one with
+UI + Developer, or an Owner/admin) to exercise everything. Do NOT use anonymous mode
+(`mj_anon`) for testing — that IS the restricted external-guest path.
+
+(Optional real-IdP path: if you deliberately set `TEST_AUTH0_*` + `TEST_UID`/`TEST_PWD` and
+rebuilt so Explorer serves Auth0, you may instead drive the Auth0 Universal Login with
+`$TEST_UID`/`$TEST_PWD` — but magic-link is the default and needs nothing external.)
+
 ## TIER 1: API smoke
 
 ### Step 1: Build MJAPI
@@ -493,34 +544,103 @@ Only proceed if MJAPI started. SKIP is not allowed — every test is PASS or FAI
 
 ### Step 4: npx playwright install chromium  (|| npx playwright install --with-deps chromium)
 
-### Step 5: Ensure test user has roles in PG
-psql -h postgres-claude -U mj_admin -d {{PG_DB_NAME}} -c "INSERT INTO __mj.\"UserRole\" (\"UserID\", \"RoleID\") SELECT '3e5ac17f-0b2c-4aca-878f-9f744f2168f4', \"ID\" FROM __mj.\"Role\" ON CONFLICT DO NOTHING;"
-(If that user ID differs, look it up: SELECT "ID" FROM __mj."User" WHERE "Email" = 'da-robot-tester@bluecypress.io';)
+### Step 5: Mint a magic-link session (self-contained — no external IdP)
+This is the RELIABLE login: it needs no Auth0/MSAL account, works under any `AUTH_TYPE`
+(the Explorer magic-link provider activates on the `#token=` fragment even under MSAL),
+and mints a real session for an EXISTING seeded user. **Proven headless on PostgreSQL.**
+There is no authenticated admin to call `POST /magic-link/create`, so insert the invite
+row directly. All commands run in the container against {{PG_DB_NAME}}.
 
-### Step 6: Build + start MJExplorer on port 4200
+```bash
+# a. Verify magic-link routes are mounted (jwks 200; redeem GET = interstitial 200, NOT 401):
+curl -s -o /dev/null -w "jwks=%{http_code}\n" localhost:4000/magic-link/jwks.json
+curl -s -o /dev/null -w "redeem=%{http_code}\n" "localhost:4000/magic-link/redeem?token=probe"
+#   401 on redeem ⇒ magic-link not enabled in the config MJAPI actually read → set
+#   magicLink.enabled=true in mj.config.cjs and restart MJAPI before continuing.
+
+# b. Pick an EXISTING user with the most roles (boots the shell cleanly), plus an app + a role it holds:
+psql -h postgres-claude -U mj_admin -d {{PG_DB_NAME}} -tAc "SELECT u.\"ID\", u.\"Email\", count(ur.\"ID\") FROM __mj.\"User\" u LEFT JOIN __mj.\"UserRole\" ur ON ur.\"UserID\"=u.\"ID\" WHERE u.\"IsActive\" GROUP BY u.\"ID\",u.\"Email\" ORDER BY 3 DESC LIMIT 3;"
+psql -h postgres-claude -U mj_admin -d {{PG_DB_NAME}} -tAc "SELECT \"ID\",\"Name\" FROM __mj.\"Application\" LIMIT 1;"   # ApplicationID
+# RoleID: any role the chosen user has (e.g. its 'UI' role via UserRole join).
+
+# c. Generate a token + matching hash (server stores base64url(sha256(rawToken))):
+node -e 'const c=require("crypto");const raw="mj_ml_"+c.randomBytes(32).toString("hex");console.log(raw+"|"+c.createHash("sha256").update(raw).digest("base64url"))'
+#   -> RAW|HASH   (keep RAW for the browser; insert HASH)
+
+# d. Insert the invite (substitute HASH, the chosen USER_ID / APP_ID / ROLE_ID):
+psql -h postgres-claude -U mj_admin -d {{PG_DB_NAME}} -c "INSERT INTO __mj.\"MagicLinkInvite\" (\"TokenHash\",\"Email\",\"ApplicationID\",\"RoleID\",\"ExpiresAt\",\"CreatedByUserID\",\"MaxUses\",\"UseCount\",\"Status\") VALUES ('<HASH>','<user email>','<APP_ID>','<ROLE_ID>', now()+interval '1 day','<USER_ID>',1,0,'Active');"
+echo "<RAW>" > /tmp/ml_browser_token.txt   # the browser script reads this
+```
+(Sanity: `POST` redeeming a token returns `{"success":true,"token":"eyJ…"}` — a live proof the PG atomic-consume works; the pre-#3075 T-SQL consume returned `errorCode:"consumed"` with no token. Mint a FRESH token for the browser, since redeem is single-use.)
+
+### Step 6: Build + serve MJExplorer on 4200
+`--configuration=development` is REQUIRED so the app boots with a real dev config. The
+served `AUTH_TYPE` does NOT matter for magic-link — the provider activates on the
+`#token=` fragment regardless (msal/auth0/any). No Auth0 env provisioning needed.
+```bash
 cd /workspace/MJ && npx turbo build --filter=@memberjunction/ng-explorer
 cd /workspace/MJ/packages/MJExplorer
-# --configuration=development is REQUIRED (swaps environment.ts → environment.development.ts;
-# without it the Auth0/MSAL config is the placeholder and login lands on an AAD error page).
 NODE_OPTIONS=--max-old-space-size=16384 npx ng serve --port 4200 --host 0.0.0.0 --configuration=development > /tmp/mjexplorer.log 2>&1 &
+```
 Wait up to 180s for http://localhost:4200/. If it never compiles/serves, capture /tmp/mjexplorer.log — Tier 2 failure.
 
-### Step 7: Playwright tests (use playwright-cli or Playwright MCP tools), IN ORDER:
-- BROWSER_LOAD: app loads (login page or shell)
-- BROWSER_LOGIN (MANDATORY): Auth0 Universal Login is a standard HTML form. Email da-robot-tester@bluecypress.io, password !!SoDamnSecureItHurt$. Email first, then password, click Continue/Submit. Accept any consent screen. Wait for redirect to the app shell.
-- BROWSER_DATA_EXPLORER: Data Explorer loads a grid with data
-- BROWSER_ENTITY_LIST: 2–3 entity lists render rows
-- BROWSER_OPEN_RECORD: a record form opens with fields populated
-- BROWSER_ADMIN: admin area loads (ERD / settings / entity management)
-- BROWSER_CONSOLE: report any critical JS errors across the run
+### Step 7: Playwright login — DETERMINISTIC SCRIPT with a shell assertion (VERIFIED working)
+BROWSER_LOGIN is where prior runs silently lied ("Welcome Back" text matched *on the login
+page* → false PASS → phantom "0 rows"). Drive login with the script below (place it inside
+`/workspace/MJ` so ESM resolves `node_modules/playwright`, e.g. `/workspace/MJ/pg-login.mjs`).
+It redeems the magic link → `#token` → shell, asserts a POSITIVE shell-only signal, and
+hard-FAILs otherwise. **This exact flow is verified working headless on PG.**
+```js
+import { chromium } from 'playwright';
+import { readFileSync } from 'node:fs';
+const RAW = readFileSync('/tmp/ml_browser_token.txt','utf8').trim();
+const b = await chromium.launch(); const pg = await b.newPage();
+const shot = n => pg.screenshot({ path:`/tmp/login-${n}.png`, fullPage:true }).catch(()=>{});
+try {
+  // NEGATIVE CHECK first: before login the shell must be ABSENT (proves no false-positive).
+  await pg.goto('http://localhost:4200/', { waitUntil:'domcontentloaded' });
+  await pg.waitForTimeout(4000);
+  const preShell = await pg.locator('mj-shell').first().isVisible().catch(()=>false);
+  if (preShell) { console.log('LOGIN_FAIL negative-check: shell present before auth'); process.exit(1); }
+  // Redeem: GET interstitial → click Continue (POST) → 302 → Explorer #token.
+  await pg.goto(`http://localhost:4000/magic-link/redeem?token=${RAW}`, { waitUntil:'domcontentloaded' });
+  const cont = pg.locator('button, input[type=submit], a').filter({ hasText:/continue|sign ?in|proceed/i }).first();
+  if (await cont.isVisible().catch(()=>false)) await cont.click();
+  else { const f = pg.locator('form').first(); if (await f.count()) await f.evaluate(el=>el.submit()); }
+  await pg.waitForURL(/localhost:4200/, { timeout:60000 });
+  await pg.waitForSelector('mj-shell', { timeout:90000 }).catch(()=>{});   // shell bootstraps async
+  await pg.waitForLoadState('networkidle').catch(()=>{});
+  await pg.waitForTimeout(3000);
+  await shot('post');
+  const url = pg.url();
+  const onIdp = /auth0\.com|login\.microsoftonline\.com/i.test(url);
+  const loginFormPresent = await pg.locator('input[type="password"]').first().isVisible().catch(()=>false);
+  // `mj-shell` = MJExplorer's authenticated shell root (rendered inside <mj-explorer-app>
+  // only AFTER auth; absent on the login screen). VERIFIED live.
+  const shellPresent = await pg.locator('mj-shell').first().isVisible().catch(()=>false);
+  const ok = shellPresent && !onIdp && !loginFormPresent && /localhost:4200/.test(url);
+  if (!ok) { console.log('LOGIN_FAIL', JSON.stringify({url,onIdp,loginFormPresent,shellPresent})); console.log('DOM', (await pg.content()).slice(0,2000)); process.exit(1); }
+  console.log('LOGIN_OK', url);
+} catch (e) { await shot('err'); console.log('LOGIN_FAIL', String(e)); process.exit(1); }
+finally { await b.close(); }
+```
+Run: `cd /workspace/MJ && node pg-login.mjs`. `LOGIN_OK` + exit 0 ⇒ BROWSER_LOGIN PASS; any `LOGIN_FAIL`/non-zero ⇒ **FAIL** (attach `/tmp/login-*.png` — do NOT paper over it). PASS is the shell assertion, never matched page text. Tests IN ORDER:
+- BROWSER_LOAD: app origin responds before login
+- BROWSER_LOGIN (MANDATORY): script above returns `LOGIN_OK`
+- BROWSER_DATA: authenticated shell renders real DB data. **Reliable check:** assert seeded values are visible in the shell (e.g. a known user email `page.locator('body').innerText()` contains it) — this is verified working. NOTE: the landing surface (Identity & Access) is a *custom* editor, not an ag-grid.
+- BROWSER_ENTITY_GRID: to exercise the ag-grid data view, navigate via **in-app UI clicks** (Data Explorer → an entity), NOT a cold-load deep link — a fresh `page.goto('/…/view/…')` does NOT mount the entity-viewer (shell URL updates but the tab content doesn't hydrate). When mounted, the grid container is `.mj-ag-grid` and data rows are `.ag-row` (ag-grid; verified from source). Assert `.ag-row` count > 0.
+- BROWSER_OPEN_RECORD: open a record form via in-app click; fields populated
+- BROWSER_CONSOLE: report critical JS errors across the run
 
 ### Step 8: Cleanup — kill MJAPI + MJExplorer, close playwright.
 
 ### Step 9: Write /tmp/phase4-result.json
 { "tier1": {"mjapiStarted": bool, "startupError": "...", "tests": [{"name","status":"PASS|FAIL","details"}]},
-  "tier2": {"explorerStarted": bool, "startupError": "...", "loginSucceeded": bool, "tests": [...], "consoleErrors": [], "screenshots": []},
+  "tier2": {"explorerStarted": bool, "loginMethod": "magic-link|auth0", "loginUser": "<authenticated email>", "startupError": "...",
+            "loginSucceeded": bool, "loginAssertion": {"url":"...","onIdp":bool,"loginFormPresent":bool,"shellPresent":bool},
+            "tests": [...], "consoleErrors": [], "screenshots": []},
   "overallPass": bool, "notes": "..." }
-Status MUST be PASS or FAIL only — SKIP is not allowed. Also write /tmp/phase4-summary.txt.
+`loginSucceeded` MUST reflect the scripted shell assertion (LOGIN_OK), never a text match. Status MUST be PASS or FAIL only — SKIP is not allowed. Also write /tmp/phase4-summary.txt.
 
 IMPORTANT: When completely finished, write PIPELINE_DONE as the very last line of your output.
 ```
@@ -550,12 +670,12 @@ You are running inside the claude-dev Docker container with the MJ repo at /work
 
 Your job: Run a DEEP CRUD workflow test against PostgreSQL {{PG_DB_NAME}} using Playwright. MJAPI (:4000) and MJExplorer (:4200) should already be running from Phase 4; if not, start them with the same PG config (DB_PLATFORM=postgresql, PG_HOST=postgres-claude, PG_DATABASE={{PG_DB_NAME}}, MJ_CORE_SCHEMA=__mj; Explorer with --configuration=development).
 
-## Auth0: da-robot-tester@bluecypress.io / !!SoDamnSecureItHurt$
+## Auth: reuse the Phase 4 MAGIC-LINK login. Mint a FRESH invite (Phase 4 Step 5 recipe — the last token was single-use and is consumed), write RAW to /tmp/ml_browser_token.txt, and run the deterministic /workspace/MJ/pg-login.mjs (shell-assertion gated). NEVER hardcode an IdP account. CRUD_LOGIN PASSes only on LOGIN_OK, never on matched page text.
 ## DB: postgres-claude:5432, mj_admin / Claude2Pg99, {{PG_DB_NAME}}
 
-Run these tests IN ORDER (PASS/FAIL only — no SKIP):
-- CRUD_LOGIN: log in, reach app shell
-- CRUD_NAVIGATE_TO_ACTIONS: Data Explorer → Actions list shows a grid of rows
+Run these tests IN ORDER (PASS/FAIL only — no SKIP). Navigate via IN-APP UI CLICKS (Data Explorer → entity), not cold-load deep links — a fresh page.goto to a view URL does not mount the ag-grid:
+- CRUD_LOGIN: run pg-login.mjs; reach app shell (positive `mj-shell` assertion, not text)
+- CRUD_NAVIGATE_TO_ACTIONS: Data Explorer → Actions list shows a grid of rows (`.ag-row` > 0)
 - CRUD_OPEN_ACTION_RECORD: open first Action; form loads with populated fields; note Category
 - CRUD_NAVIGATE_TO_CATEGORY: open the Action's Action Category record; note its Name
 - CRUD_EDIT_CATEGORY_NAME: append " - PG Test" to the Name, Save, confirm no error
@@ -667,4 +787,6 @@ files are now on the host as uncommitted changes for the user to review.
 10. **Discover CLI syntax dynamically** — if `mj migrate convert`, `mj migrate`, `mj codegen`, or `mj sync push` flags differ from examples, run `--help` first.
 11. **Poll patiently** — delegated phases can take a while; poll for `__DONE__` every 30–60s with no timeout.
 12. **Auth gate (Phase 0f)** — if CC in Docker isn't authenticated, stop immediately; Phases 2/4/4b all delegate to it.
-13. **Don't commit** — leave converted files as uncommitted host changes for the user to review.
+13. **Browser login = magic-link by default (self-contained). Don't depend on an external IdP.** Explorer's auth provider lives in the GITIGNORED `environment.development.ts`, so an Auth0/MSAL login depends on non-reproducible volume state — that's why "it worked last week, not this week." Magic-link sidesteps this entirely: mint an invite for an existing seeded user (Phase 4 Step 5) and redeem it — the provider activates on the `#token=` fragment under ANY `AUTH_TYPE`, needs no external account, and is DB-agnostic (PG-safe since #3075). It is VERIFIED working headless on PG. Auth0 is an optional path only if you deliberately supply `TEST_AUTH0_*` creds + rebuild. **Never hardcode an IdP email/password.**
+14. **A login PASSes only on a positive authenticated-shell assertion — never on matched page text.** Prior runs matched "Welcome Back" *on the login page* and reported false success + phantom "0 rows". Use the deterministic login script (place it at `/workspace/MJ/pg-login.mjs` so ESM resolves `node_modules/playwright`): negative-check (shell absent pre-login) → redeem → `mj-shell` present + off the IdP domain + no password field. On failure, FAIL loudly with screenshots + DOM dump. Grid checks assert `.ag-row` count > 0 — but reach the grid via **in-app clicks**, not a cold-load `goto` (which won't mount the entity-viewer).
+15. **Don't commit** — leave converted files as uncommitted host changes for the user to review.

--- a/packages/MJServer/src/__tests__/magicLink.test.ts
+++ b/packages/MJServer/src/__tests__/magicLink.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import jwt from 'jsonwebtoken';
-import { createPublicKey } from 'node:crypto';
+import { createPublicKey, type JsonWebKey } from 'node:crypto';
 import {
   generateRawToken,
   hashToken,
@@ -228,6 +228,56 @@ describe('magic-link core', () => {
     });
   });
 
+  describe('buildConsumeInviteSQL (postgresql dialect)', () => {
+    // PG uses `schema.table` (unquoted — PostgreSQLDataProvider.ExecuteSQL auto-quotes
+    // the PascalCase identifiers). SS uses the bracket-quoted `[schema].[table]` form.
+    const pgTable = '__mj.MagicLinkInvite';
+    const pgSql = buildConsumeInviteSQL(pgTable, 'postgresql');
+
+    it('targets the supplied unquoted schema.table', () => {
+      expect(pgSql).toContain(`UPDATE ${pgTable} `);
+    });
+
+    it('uses UPDATE … RETURNING as the atomic single-use gate (no OUTPUT/DECLARE table var)', () => {
+      expect(pgSql).toContain('RETURNING ID;');
+      expect(pgSql).not.toContain('OUTPUT');
+      expect(pgSql).not.toContain('DECLARE');
+    });
+
+    it('binds the invite ID as PG positional param $1, not T-SQL @p0 (injection-safe)', () => {
+      expect(pgSql).toContain('ID = $1');
+      expect(pgSql).not.toContain('@p0');
+      expect(pgSql).not.toMatch(/@/); // no T-SQL @-anything survives on PG
+      expect(pgSql).not.toMatch(/ID = '/);
+    });
+
+    it('uses PG timestamp expressions, not T-SQL SYSUTCDATETIME()', () => {
+      expect(pgSql).not.toContain('SYSUTCDATETIME');
+      expect(pgSql).toContain("(now() AT TIME ZONE 'utc')");
+      expect(pgSql).toContain("ConsumedAt = COALESCE(ConsumedAt, (now() AT TIME ZONE 'utc'))");
+    });
+
+    it('guards atomically on Active + not-exhausted + not-expired (same predicate as SS)', () => {
+      const where = pgSql.slice(pgSql.indexOf('WHERE'));
+      expect(where).toContain("Status = 'Active'");
+      expect(where).toContain('UseCount < MaxUses');
+      expect(where).toContain("ExpiresAt > (now() AT TIME ZONE 'utc')");
+    });
+
+    it('increments UseCount and flips Status on the last use (same semantics as SS)', () => {
+      expect(pgSql).toContain('UseCount = UseCount + 1');
+      expect(pgSql).toContain("Status = CASE WHEN UseCount + 1 >= MaxUses THEN 'Consumed' ELSE Status END");
+    });
+
+    it('rejects a non-whitelisted PG table identifier (defense-in-depth against injection)', () => {
+      // Bracket-quoted (SS) form is not a valid PG identifier here.
+      expect(() => buildConsumeInviteSQL('[__mj].[MagicLinkInvite]', 'postgresql')).toThrow();
+      expect(() => buildConsumeInviteSQL('__mj.MagicLinkInvite; DROP TABLE x;--', 'postgresql')).toThrow();
+      expect(() => buildConsumeInviteSQL('__mj.Magic Link', 'postgresql')).toThrow();
+      expect(() => buildConsumeInviteSQL(pgTable, 'postgresql')).not.toThrow();
+    });
+  });
+
   describe('canIssueInvites', () => {
     it('always allows Owners, regardless of issuer-role config (case/space-insensitive)', () => {
       expect(canIssueInvites('Owner', [], [])).toBe(true);
@@ -351,7 +401,7 @@ describe('MagicLinkKeyManager', () => {
     expect(header.kid).toBe(jwk.kid);
 
     // Full verification against the public key reconstructed from the JWK.
-    const publicKey = createPublicKey({ key: jwk as object, format: 'jwk' });
+    const publicKey = createPublicKey({ key: jwk as unknown as JsonWebKey, format: 'jwk' });
     const decoded = jwt.verify(token, publicKey, {
       algorithms: ['RS256'],
       issuer: 'http://localhost:4051',
@@ -375,7 +425,7 @@ describe('MagicLinkKeyManager', () => {
       ttlSeconds: 3600,
     });
     const token = km.Sign(claims);
-    const publicKey = createPublicKey({ key: km.GetJWKS().keys[0] as object, format: 'jwk' });
+    const publicKey = createPublicKey({ key: km.GetJWKS().keys[0] as unknown as JsonWebKey, format: 'jwk' });
 
     // Flip a character in the payload segment.
     const parts = token.split('.');

--- a/packages/MJServer/src/auth/magicLink/MagicLinkService.ts
+++ b/packages/MJServer/src/auth/magicLink/MagicLinkService.ts
@@ -640,6 +640,13 @@ export class MagicLinkService {
    * a single atomic operation. Returns true ONLY when this call updated the row
    * (won the race); concurrent redemptions of a single-use link see 0 rows.
    *
+   * Dialect-aware: SQL Server uses an `OUTPUT`-into-table-variable win-detect;
+   * PostgreSQL uses `UPDATE … WHERE … RETURNING` (the WHERE guard is itself the
+   * atomic single-use gate). The platform is read from the provider itself
+   * (`PlatformKey`), not from process env, so this is correct even under a
+   * non-default per-connection provider. The invite ID always binds as a
+   * parameter (`@p0` / `$1`), never interpolated.
+   *
    * Fail-closed: any DB error returns false and the redemption is rejected.
    */
   private async consumeInvite(invite: MJMagicLinkInviteEntity, provider: DatabaseProviderBase, contextUser: UserInfo): Promise<boolean> {
@@ -649,9 +656,12 @@ export class MagicLinkService {
         LogError(`[MagicLink] Entity metadata for '${INVITE_ENTITY}' not found; cannot consume invite.`);
         return false;
       }
-      const table = `[${entityInfo.SchemaName}].[${entityInfo.BaseTable}]`;
-      // OUTPUT returns one row iff the WHERE matched — the atomic single-use gate.
-      const sql = buildConsumeInviteSQL(table);
+      const isPg = provider.PlatformKey === 'postgresql';
+      // PG identifiers are auto-quoted by PostgreSQLDataProvider.ExecuteSQL, so
+      // pass the bare `schema.table`; SQL Server takes the bracket-quoted form.
+      const table = isPg ? `${entityInfo.SchemaName}.${entityInfo.BaseTable}` : `[${entityInfo.SchemaName}].[${entityInfo.BaseTable}]`;
+      // OUTPUT/RETURNING yields one row iff the WHERE matched — the atomic single-use gate.
+      const sql = buildConsumeInviteSQL(table, isPg ? 'postgresql' : 'sqlserver');
       const rows = await provider.ExecuteSQL<{ ID: string }>(sql, [invite.ID], { isMutation: true }, contextUser);
       return Array.isArray(rows) && rows.length === 1;
     } catch (e) {

--- a/packages/MJServer/src/auth/magicLink/magicLinkCore.ts
+++ b/packages/MJServer/src/auth/magicLink/magicLinkCore.ts
@@ -106,35 +106,63 @@ export function evaluateInvite(invite: InviteEvaluationInput, nowMs: number): { 
   return { ok: true };
 }
 
+/** SQL dialect for {@link buildConsumeInviteSQL}. */
+export type ConsumeInviteDialect = 'sqlserver' | 'postgresql';
+
+/** SQL Server table identifier — bracket-quoted `[schema].[table]` (word chars only). */
+const QUALIFIED_TABLE_PATTERN = /^\[\w+\]\.\[\w+\]$/;
+/** PostgreSQL table identifier — `schema.table` (word chars only); auto-quoted downstream. */
+const QUALIFIED_TABLE_PATTERN_PG = /^\w+\.\w+$/;
+
 /**
- * Builds the atomic compare-and-swap UPDATE that consumes one use of an invite.
+ * Builds the atomic compare-and-swap UPDATE that consumes one use of an invite,
+ * in the given SQL dialect.
  *
  * The WHERE clause re-checks every eligibility condition at the DB level, so the
  * increment and the guard are a single atomic operation: concurrent redemptions
- * of a single-use link race on the row and exactly one matches (the matched row
- * is returned via OUTPUT). This is what actually enforces single-use — the
- * JS-side `evaluateInvite` is only a friendly pre-check.
+ * of a single-use link race on the row and exactly one matches. This is what
+ * actually enforces single-use — the JS-side `evaluateInvite` is only a friendly
+ * pre-check. The matched row's ID is returned to the caller (via `OUTPUT` on SQL
+ * Server, `RETURNING` on PostgreSQL) so it can detect a win (exactly one row).
  *
- * The invite ID MUST be bound as parameter `@p0` by the caller — it is never
- * interpolated into the string, so this builder is injection-safe regardless of
- * the ID's contents.
+ * The invite ID MUST be bound as a parameter by the caller (`@p0` on SQL Server,
+ * `$1` on PostgreSQL) — it is never interpolated into the string, so this builder
+ * is injection-safe regardless of the ID's contents.
  *
- * OUTPUT goes `INTO` a table variable (not a bare OUTPUT): SQL Server forbids a
- * bare OUTPUT clause on a table that has enabled triggers, and CodeGen adds an
- * `__mj_UpdatedAt` trigger to every MJ table. The trailing SELECT returns exactly
- * the matched row(s) so the caller can detect a win (exactly one row) regardless
- * of trigger behavior.
+ * **SQL Server** — `OUTPUT` goes `INTO` a table variable (not a bare OUTPUT):
+ * SQL Server forbids a bare OUTPUT clause on a table that has enabled triggers,
+ * and CodeGen adds an `__mj_UpdatedAt` trigger to every MJ table. The trailing
+ * SELECT returns the matched row(s) regardless of trigger behavior.
  *
- * `qualifiedTable` is asserted to be a bracket-quoted `[schema].[table]` (word
- * chars only) before interpolation. The caller derives it from `EntityInfo`
- * (never user input), so this is defense-in-depth: even a future careless caller
- * cannot turn this into an injection vector — a non-conforming table throws.
+ * **PostgreSQL** — the `UPDATE … WHERE` guard IS itself the atomic single-use
+ * gate: the row is locked for the UPDATE's duration, so concurrent redemptions
+ * serialize and only the first matching `Status='Active' AND UseCount < MaxUses`
+ * wins; `RETURNING` yields the row iff the guard matched (equivalent to the SS
+ * `OUTPUT`-into-table win-detect). PascalCase identifiers are auto-quoted by
+ * `PostgreSQLDataProvider.ExecuteSQL`, so the table is passed unquoted (`schema.table`).
  *
- * @param qualifiedTable  bracket-quoted `[schema].[table]` for MagicLinkInvite
+ * `qualifiedTable` is asserted to match the dialect's whitelist pattern before
+ * interpolation. The caller derives it from `EntityInfo` (never user input), so
+ * this is defense-in-depth: even a future careless caller cannot turn this into
+ * an injection vector — a non-conforming table throws.
+ *
+ * @param qualifiedTable  `[schema].[table]` (sqlserver) or `schema.table` (postgresql) for MagicLinkInvite
+ * @param dialect         target SQL dialect (defaults to `'sqlserver'`)
  */
-const QUALIFIED_TABLE_PATTERN = /^\[\w+\]\.\[\w+\]$/;
-
-export function buildConsumeInviteSQL(qualifiedTable: string): string {
+export function buildConsumeInviteSQL(qualifiedTable: string, dialect: ConsumeInviteDialect = 'sqlserver'): string {
+  if (dialect === 'postgresql') {
+    if (!QUALIFIED_TABLE_PATTERN_PG.test(qualifiedTable)) {
+      throw new Error(`buildConsumeInviteSQL: refusing to build SQL for non-whitelisted table identifier '${qualifiedTable}'.`);
+    }
+    return (
+      `UPDATE ${qualifiedTable} ` +
+      `SET UseCount = UseCount + 1, ` +
+      `ConsumedAt = COALESCE(ConsumedAt, (now() AT TIME ZONE 'utc')), ` +
+      `Status = CASE WHEN UseCount + 1 >= MaxUses THEN 'Consumed' ELSE Status END ` +
+      `WHERE ID = $1 AND Status = 'Active' AND UseCount < MaxUses AND ExpiresAt > (now() AT TIME ZONE 'utc') ` +
+      `RETURNING ID;`
+    );
+  }
   if (!QUALIFIED_TABLE_PATTERN.test(qualifiedTable)) {
     throw new Error(`buildConsumeInviteSQL: refusing to build SQL for non-whitelisted table identifier '${qualifiedTable}'.`);
   }


### PR DESCRIPTION
## What this does

This fixes issue #3075: magic-link login was completely broken on PostgreSQL. It also updates the `pg-migrate-v2` skill so the migration pipeline's browser tests log in reliably.

## What was broken

`buildConsumeInviteSQL()` produced SQL Server T-SQL only (`DECLARE @… TABLE`, `OUTPUT … INTO`, `@p0`, `SYSUTCDATETIME()`). On PostgreSQL that SQL threw `syntax error at or near "@"`. `consumeInvite()` caught the error and returned false, so `RedeemInvite()` reported `errorCode: "consumed"` and minted no session, even though the invite was still active and unused. SQL Server was not affected.

## The fix

In `packages/MJServer/src/auth/magicLink/`:

- `buildConsumeInviteSQL(qualifiedTable, dialect = 'sqlserver')` now takes a dialect; the PostgreSQL branch uses `UPDATE … WHERE … RETURNING`
- the `WHERE` guard (`UseCount < MaxUses AND Status = 'Active' AND ExpiresAt > now()`) is itself the atomic single-use gate: the row locks for the update, so two redemptions of a single-use link run one after another and only one wins
- `consumeInvite()` reads the platform from `provider.PlatformKey`, not an environment variable, so it stays correct under a non-default per-connection provider; it passes the bare `schema.table` on PostgreSQL and the bracket-quoted form on SQL Server
- the invite ID always binds as a parameter (`$1` or `@p0`), never inline
- the default dialect is `sqlserver`, so every existing caller is unchanged

## Reliable login for the migration pipeline

The `pg-migrate-v2` skill used to depend on the workbench's Auth0 or MSAL config, which lives in a gitignored file. When that leftover state was gone, login failed. This is the "worked last week, not this week" problem. The skill now logs in with magic-link by default:

- it needs no external identity provider and no stored credentials
- it works under any `AUTH_TYPE`, because the Explorer magic-link provider activates on the `#token` fragment
- it mints a session for an existing seeded user, so a named invite inherits that user's full database roles and can run the whole UI test suite

The login step is now a deterministic script. It checks the shell is absent before login, then asserts the authenticated `mj-shell` element after login, so a test can no longer pass by matching text on the login page.

## Testing

- unit tests: 54 of 54 pass in `packages/MJServer`, and the build is clean
- live on PostgreSQL: minting an invite and calling `POST /magic-link/redeem` returned a signed session token; before the fix the same call returned `errorCode: "consumed"` with no token
- a browser redeem reached the authenticated shell and rendered seeded data

## Before this merges

- add a changeset for a patch bump of `@memberjunction/server` by running `npm run change` on this branch
- the pipeline only logs in cleanly on a branch that contains this fix, so merge it to `next`, or cherry-pick it into the release branch, before the next `pg-migrate-v2` run

🤖 Generated with [Claude Code](https://claude.com/claude-code)