### PR TITLE
fix(v5.45): patch migration bugs + add publish version override [version:5.45.1]

### DIFF
--- a/.changeset/gentle-rocks-mend.md
+++ b/.changeset/gentle-rocks-mend.md
@@ -1,0 +1,5 @@
+---
+"@memberjunction/server": patch
+---
+
+Fix v5.45 migration bugs: dynamically resolve FK constraint name in APIKeyUsageLog cascade delete (SQL Server + PostgreSQL) and deactivate Skip agent instead of deleting it in Metadata Sync. Add commit-message version override (`[version:X.Y.Z]`) to publish workflow.

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -108,8 +108,17 @@ jobs:
         env:
           REPO_PAT: ${{ secrets.MJ_GH_BOT_GITHUB_TOKEN }}
 
+      - name: Check for version override in commit message
+        id: commit_override
+        run: |
+          COMMIT_MSG=$(git log -1 --format=%B)
+          if [[ "$COMMIT_MSG" =~ \[version:([0-9]+\.[0-9]+\.[0-9]+)\] ]]; then
+            echo "VERSION_OVERRIDE=${BASH_REMATCH[1]}" >> "$GITHUB_OUTPUT"
+            echo "Found version override in commit message: ${BASH_REMATCH[1]}"
+          fi
+
       - name: Determine next expected version
-        if: ${{ env.BRANCH == 'main' && !github.event.inputs.targetVersion }}
+        if: ${{ env.BRANCH == 'main' && !github.event.inputs.targetVersion && !steps.commit_override.outputs.VERSION_OVERRIDE }}
         id: version_check
         run: |
           git fetch --tags
@@ -128,7 +137,7 @@ jobs:
       - name: Update version and check against expected
         if: ${{ env.BRANCH == 'main' }}
         run: |
-          EXPECTED_NEXT_VERSION="${{ github.event.inputs.targetVersion || steps.version_check.outputs.EXPECTED_NEXT_VERSION }}"
+          EXPECTED_NEXT_VERSION="${{ github.event.inputs.targetVersion || steps.commit_override.outputs.VERSION_OVERRIDE || steps.version_check.outputs.EXPECTED_NEXT_VERSION }}"
           npm run version
 
           NEXT_VERSION=$(jq -r .version packages/MJServer/package.json)

--- a/metadata/agents/.skip-proxy-agent.json
+++ b/metadata/agents/.skip-proxy-agent.json
@@ -1,15 +1,15 @@
 [
   {
-    "__mj_sync_notes": "The 'Skip' agent moved to the @memberjunction/skip-client Open App. This deleteRecord tombstone removes the legacy core-seeded agent from instances that received it via earlier core syncs (no-op where it was never seeded). It may be FK-blocked on instances with Skip agent-run history — benign, since those instances manage the agent via the installed app. Once propagated, this tombstone can be removed in a later release.",
     "fields": {
-      "Name": "Skip"
+      "Name": "Skip",
+      "Status": "Disabled"
     },
     "primaryKey": {
       "ID": "A829FAAC-9E64-440C-B650-83F92A37E990"
     },
-    "deleteRecord": {
-      "delete": true,
-      "deletedAt": "2026-07-07T15:18:41.187Z"
+    "sync": {
+      "lastModified": "2026-07-08T17:58:11.385Z",
+      "checksum": "d81f3341552992527137129b3059ad3f80a95a74bd051756438f95b4f97d5cda"
     }
   }
 ]

--- a/migrations-pg/v5/V202607061429__v5.45.x__APIKeyUsageLog_Cascade_Delete.pg.sql
+++ b/migrations-pg/v5/V202607061429__v5.45.x__APIKeyUsageLog_Cascade_Delete.pg.sql
@@ -10,10 +10,49 @@ CREATE SCHEMA IF NOT EXISTS __mj;
 SET search_path TO __mj, public;
 SET standard_conforming_strings = on;
 
-ALTER TABLE __mj."APIKeyUsageLog"
-DROP CONSTRAINT "FK__APIKeyUsa__APIKe__56D4A469" /* Migration: APIKeyUsageLog -> APIKey ON DELETE CASCADE */ /* Description: The APIKeyUsageLog.APIKeyID foreign key was created with NO ACTION, */ /*              which blocks deleting an APIKey once any usage-log rows exist for it. */ /*              spDeleteAPIKey performs a plain DELETE FROM APIKey and relies on */ /*              DB-level cascade for its children; the sibling child FKs */ /*              (APIKeyScope.APIKeyID, APIKeyApplication.APIKeyID) are already */ /*              ON DELETE CASCADE. This aligns APIKeyUsageLog with them. */ /* Tradeoff: deleting an APIKey now also deletes its APIKeyUsageLog audit rows. */ /* FK-only change: no table columns change, so no CodeGen / entity regeneration */ /* is required (spDeleteAPIKey already relies on DB cascade for its children). */;
+-- Migration: APIKeyUsageLog -> APIKey ON DELETE CASCADE
+-- Description: The APIKeyUsageLog.APIKeyID foreign key was created with NO ACTION,
+--              which blocks deleting an APIKey once any usage-log rows exist for it.
+--              spDeleteAPIKey performs a plain DELETE FROM APIKey and relies on
+--              DB-level cascade for its children; the sibling child FKs
+--              (APIKeyScope.APIKeyID, APIKeyApplication.APIKeyID) are already
+--              ON DELETE CASCADE. This aligns APIKeyUsageLog with them.
+--
+-- Tradeoff: deleting an APIKey now also deletes its APIKeyUsageLog audit rows.
+--
+-- FK-only change: no table columns change, so no CodeGen / entity regeneration
+-- is required (spDeleteAPIKey already relies on DB cascade for its children).
+
+-- Dynamically look up the FK constraint name since PostgreSQL auto-generates
+-- the suffix when no explicit name is provided, and the name may differ per
+-- database instance.
+DO $$
+DECLARE
+    v_fk_name TEXT;
+BEGIN
+    SELECT con.conname INTO v_fk_name
+    FROM pg_constraint con
+    JOIN pg_class rel ON rel.oid = con.conrelid
+    JOIN pg_namespace nsp ON nsp.oid = rel.relnamespace
+    JOIN pg_class ref ON ref.oid = con.confrelid
+    JOIN pg_attribute att ON att.attrelid = con.conrelid
+                         AND att.attnum = ANY(con.conkey)
+    WHERE rel.relname   = 'APIKeyUsageLog'
+      AND nsp.nspname   = '__mj'
+      AND att.attname    = 'APIKeyID'
+      AND ref.relname    = 'APIKey'
+      AND con.contype    = 'f';
+
+    IF v_fk_name IS NOT NULL THEN
+        EXECUTE format(
+            'ALTER TABLE __mj."APIKeyUsageLog" DROP CONSTRAINT %I',
+            v_fk_name
+        );
+    END IF;
+END
+$$;
 
 ALTER TABLE __mj."APIKeyUsageLog"
-  ADD CONSTRAINT "FK__APIKeyUsa__APIKe__56D4A469" FOREIGN KEY ("APIKeyID") REFERENCES __mj."APIKey" (
-    "ID"
-  ) ON DELETE CASCADE;
+  ADD CONSTRAINT "FK_APIKeyUsageLog_APIKeyID"
+  FOREIGN KEY ("APIKeyID") REFERENCES __mj."APIKey" ("ID")
+  ON DELETE CASCADE;

--- a/migrations/v5/V202607061429__v5.45.x__APIKeyUsageLog_Cascade_Delete.sql
+++ b/migrations/v5/V202607061429__v5.45.x__APIKeyUsageLog_Cascade_Delete.sql
@@ -11,12 +11,26 @@
 -- FK-only change: no table columns change, so no CodeGen / entity regeneration
 -- is required (spDeleteAPIKey already relies on DB cascade for its children).
 
-ALTER TABLE [${flyway:defaultSchema}].[APIKeyUsageLog]
-    DROP CONSTRAINT [FK__APIKeyUsa__APIKe__56D4A469];
+-- Dynamically look up the FK constraint name since SQL Server auto-generates
+-- the suffix based on object IDs, which differ per database instance.
+DECLARE @fkName NVARCHAR(256);
+SELECT @fkName = fk.name
+FROM sys.foreign_keys fk
+JOIN sys.foreign_key_columns fkc ON fkc.constraint_object_id = fk.object_id
+JOIN sys.columns c ON c.object_id = fkc.parent_object_id AND c.column_id = fkc.parent_column_id
+WHERE OBJECT_NAME(fk.parent_object_id) = 'APIKeyUsageLog'
+  AND SCHEMA_NAME(fk.schema_id) = '${flyway:defaultSchema}'
+  AND c.name = 'APIKeyID'
+  AND OBJECT_NAME(fk.referenced_object_id) = 'APIKey';
+
+IF @fkName IS NOT NULL
+BEGIN
+    EXEC('ALTER TABLE [${flyway:defaultSchema}].[APIKeyUsageLog] DROP CONSTRAINT [' + @fkName + ']');
+END
 GO
 
 ALTER TABLE [${flyway:defaultSchema}].[APIKeyUsageLog]
-    ADD CONSTRAINT [FK__APIKeyUsa__APIKe__56D4A469]
+    ADD CONSTRAINT [FK_APIKeyUsageLog_APIKeyID]
     FOREIGN KEY ([APIKeyID]) REFERENCES [${flyway:defaultSchema}].[APIKey] ([ID])
     ON DELETE CASCADE;
 GO

--- a/migrations/v5/V202607071019__v5.45.x__Metadata_Sync.sql
+++ b/migrations/v5/V202607071019__v5.45.x__Metadata_Sync.sql
@@ -11763,8 +11763,268 @@ SET
 
 GO
 
--- Delete MJ: AI Agents (core SP call only)
-EXEC [${flyway:defaultSchema}].[spDeleteAIAgent] @ID = 'A829FAAC-9E64-440C-B650-83F92A37E990';
+
+-- Save MJ: AI Agents (core SP call only)
+DECLARE @Name_15595692 NVARCHAR(255),
+@Description_15595692 NVARCHAR(MAX),
+@LogoURL_15595692 NVARCHAR(255),
+@ParentID_15595692 UNIQUEIDENTIFIER,
+@ExposeAsAction_15595692 BIT,
+@ExecutionOrder_15595692 INT,
+@ExecutionMode_15595692 NVARCHAR(20),
+@EnableContextCompression_15595692 BIT,
+@ContextCompressionMessageThreshold_15595692 INT,
+@ContextCompressionPromptID_15595692 UNIQUEIDENTIFIER,
+@ContextCompressionMessageRetentionCount_15595692 INT,
+@TypeID_15595692 UNIQUEIDENTIFIER,
+@Status_15595692 NVARCHAR(20),
+@DriverClass_15595692 NVARCHAR(255),
+@IconClass_15595692 NVARCHAR(100),
+@ModelSelectionMode_15595692 NVARCHAR(50),
+@PayloadDownstreamPaths_15595692 NVARCHAR(MAX),
+@PayloadUpstreamPaths_15595692 NVARCHAR(MAX),
+@PayloadSelfReadPaths_15595692 NVARCHAR(MAX),
+@PayloadSelfWritePaths_15595692 NVARCHAR(MAX),
+@PayloadScope_15595692 NVARCHAR(MAX),
+@FinalPayloadValidation_15595692 NVARCHAR(MAX),
+@FinalPayloadValidationMode_15595692 NVARCHAR(25),
+@FinalPayloadValidationMaxRetries_15595692 INT,
+@MaxCostPerRun_15595692 DECIMAL(10, 4),
+@MaxTokensPerRun_15595692 INT,
+@MaxIterationsPerRun_15595692 INT,
+@MaxTimePerRun_15595692 INT,
+@MinExecutionsPerRun_15595692 INT,
+@MaxExecutionsPerRun_15595692 INT,
+@StartingPayloadValidation_15595692 NVARCHAR(MAX),
+@StartingPayloadValidationMode_15595692 NVARCHAR(25),
+@DefaultPromptEffortLevel_15595692 INT,
+@ChatHandlingOption_15595692 NVARCHAR(30),
+@DefaultArtifactTypeID_15595692 UNIQUEIDENTIFIER,
+@OwnerUserID_15595692 UNIQUEIDENTIFIER,
+@InvocationMode_15595692 NVARCHAR(20),
+@ArtifactCreationMode_15595692 NVARCHAR(20),
+@FunctionalRequirements_15595692 NVARCHAR(MAX),
+@TechnicalDesign_15595692 NVARCHAR(MAX),
+@InjectNotes_15595692 BIT,
+@MaxNotesToInject_15595692 INT,
+@NoteInjectionStrategy_15595692 NVARCHAR(20),
+@InjectExamples_15595692 BIT,
+@MaxExamplesToInject_15595692 INT,
+@ExampleInjectionStrategy_15595692 NVARCHAR(20),
+@IsRestricted_15595692 BIT,
+@MessageMode_15595692 NVARCHAR(50),
+@MaxMessages_15595692 INT,
+@AttachmentStorageProviderID_15595692 UNIQUEIDENTIFIER,
+@AttachmentRootPath_15595692 NVARCHAR(500),
+@InlineStorageThresholdBytes_15595692 INT,
+@AgentTypePromptParams_15595692 NVARCHAR(MAX),
+@ScopeConfig_15595692 NVARCHAR(MAX),
+@NoteRetentionDays_15595692 INT,
+@ExampleRetentionDays_15595692 INT,
+@AutoArchiveEnabled_15595692 BIT,
+@RerankerConfiguration_15595692 NVARCHAR(MAX),
+@CategoryID_15595692 UNIQUEIDENTIFIER,
+@AllowEphemeralClientTools_15595692 BIT,
+@DefaultStorageAccountID_15595692 UNIQUEIDENTIFIER,
+@SearchScopeAccess_15595692 NVARCHAR(20),
+@AcceptUnregisteredFiles_15595692 BIT,
+@DefaultCoAgentID_15595692 UNIQUEIDENTIFIER,
+@TypeConfiguration_15595692 NVARCHAR(MAX),
+@AllowMemoryWrite_15595692 BIT,
+@RecordingDefault_15595692 NVARCHAR(20),
+@RecordingStorageProviderID_15595692 UNIQUEIDENTIFIER,
+@DefaultMediaCollectionID_15595692 UNIQUEIDENTIFIER,
+@SupportsPlanMode_15595692 BIT,
+@AcceptsSkills_15595692 NVARCHAR(20),
+@SkillActivationMode_15595692 NVARCHAR(20),
+@RequirePlanMode_15595692 BIT,
+@ID_15595692 UNIQUEIDENTIFIER
+SET
+  @Name_15595692 = N'Skip'
+SET
+  @Description_15595692 = N'Data analytics and reporting expert that can create charts, graphs, dashboards and provide insights on data'
+SET
+  @ExposeAsAction_15595692 = 1
+SET
+  @ExecutionOrder_15595692 = 0
+SET
+  @ExecutionMode_15595692 = N'Sequential'
+SET
+  @EnableContextCompression_15595692 = 0
+SET
+  @TypeID_15595692 = 'F7926101-5099-4FA5-836A-479D9707C818'
+SET
+  @Status_15595692 = N'Disabled'
+SET
+  @DriverClass_15595692 = N'SkipProxyAgent'
+SET
+  @IconClass_15595692 = N'mj-icon-skip'
+SET
+  @ModelSelectionMode_15595692 = N'Agent Type'
+SET
+  @PayloadDownstreamPaths_15595692 = N'["*"]'
+SET
+  @PayloadUpstreamPaths_15595692 = N'["*"]'
+SET
+  @FinalPayloadValidationMode_15595692 = N'Retry'
+SET
+  @FinalPayloadValidationMaxRetries_15595692 = 3
+SET
+  @StartingPayloadValidationMode_15595692 = N'Fail'
+SET
+  @DefaultArtifactTypeID_15595692 = 'E8BA10A3-019F-4C51-A8AA-397AB124F212'
+SET
+  @OwnerUserID_15595692 = 'ECAFCCEC-6A37-EF11-86D4-000D3A4E707E'
+SET
+  @InvocationMode_15595692 = N'Any'
+SET
+  @ArtifactCreationMode_15595692 = N'Always'
+SET
+  @InjectNotes_15595692 = 1
+SET
+  @MaxNotesToInject_15595692 = 5
+SET
+  @NoteInjectionStrategy_15595692 = N'Relevant'
+SET
+  @InjectExamples_15595692 = 0
+SET
+  @MaxExamplesToInject_15595692 = 3
+SET
+  @ExampleInjectionStrategy_15595692 = N'Semantic'
+SET
+  @IsRestricted_15595692 = 0
+SET
+  @MessageMode_15595692 = N'None'
+SET
+  @AutoArchiveEnabled_15595692 = 1
+SET
+  @CategoryID_15595692 = 'B9CB7669-D205-484A-9E9C-4C609827113A'
+SET
+  @AllowEphemeralClientTools_15595692 = 1
+SET
+  @SearchScopeAccess_15595692 = N'None'
+SET
+  @AcceptUnregisteredFiles_15595692 = 0
+SET
+  @AllowMemoryWrite_15595692 = 1
+SET
+  @SupportsPlanMode_15595692 = 1
+SET
+  @AcceptsSkills_15595692 = N'None'
+SET
+  @SkillActivationMode_15595692 = N'RequestedOnly'
+SET
+  @RequirePlanMode_15595692 = 0
+SET
+  @ID_15595692 = 'A829FAAC-9E64-440C-B650-83F92A37E990' EXEC [${flyway:defaultSchema}].spUpdateAIAgent @Name = @Name_15595692,
+  @Description = @Description_15595692,
+  @LogoURL = @LogoURL_15595692,
+  @LogoURL_Clear = 1,
+  @ParentID = @ParentID_15595692,
+  @ParentID_Clear = 1,
+  @ExposeAsAction = @ExposeAsAction_15595692,
+  @ExecutionOrder = @ExecutionOrder_15595692,
+  @ExecutionMode = @ExecutionMode_15595692,
+  @EnableContextCompression = @EnableContextCompression_15595692,
+  @ContextCompressionMessageThreshold = @ContextCompressionMessageThreshold_15595692,
+  @ContextCompressionMessageThreshold_Clear = 1,
+  @ContextCompressionPromptID = @ContextCompressionPromptID_15595692,
+  @ContextCompressionPromptID_Clear = 1,
+  @ContextCompressionMessageRetentionCount = @ContextCompressionMessageRetentionCount_15595692,
+  @ContextCompressionMessageRetentionCount_Clear = 1,
+  @TypeID = @TypeID_15595692,
+  @Status = @Status_15595692,
+  @DriverClass = @DriverClass_15595692,
+  @IconClass = @IconClass_15595692,
+  @ModelSelectionMode = @ModelSelectionMode_15595692,
+  @PayloadDownstreamPaths = @PayloadDownstreamPaths_15595692,
+  @PayloadUpstreamPaths = @PayloadUpstreamPaths_15595692,
+  @PayloadSelfReadPaths = @PayloadSelfReadPaths_15595692,
+  @PayloadSelfReadPaths_Clear = 1,
+  @PayloadSelfWritePaths = @PayloadSelfWritePaths_15595692,
+  @PayloadSelfWritePaths_Clear = 1,
+  @PayloadScope = @PayloadScope_15595692,
+  @PayloadScope_Clear = 1,
+  @FinalPayloadValidation = @FinalPayloadValidation_15595692,
+  @FinalPayloadValidation_Clear = 1,
+  @FinalPayloadValidationMode = @FinalPayloadValidationMode_15595692,
+  @FinalPayloadValidationMaxRetries = @FinalPayloadValidationMaxRetries_15595692,
+  @MaxCostPerRun = @MaxCostPerRun_15595692,
+  @MaxCostPerRun_Clear = 1,
+  @MaxTokensPerRun = @MaxTokensPerRun_15595692,
+  @MaxTokensPerRun_Clear = 1,
+  @MaxIterationsPerRun = @MaxIterationsPerRun_15595692,
+  @MaxIterationsPerRun_Clear = 1,
+  @MaxTimePerRun = @MaxTimePerRun_15595692,
+  @MaxTimePerRun_Clear = 1,
+  @MinExecutionsPerRun = @MinExecutionsPerRun_15595692,
+  @MinExecutionsPerRun_Clear = 1,
+  @MaxExecutionsPerRun = @MaxExecutionsPerRun_15595692,
+  @MaxExecutionsPerRun_Clear = 1,
+  @StartingPayloadValidation = @StartingPayloadValidation_15595692,
+  @StartingPayloadValidation_Clear = 1,
+  @StartingPayloadValidationMode = @StartingPayloadValidationMode_15595692,
+  @DefaultPromptEffortLevel = @DefaultPromptEffortLevel_15595692,
+  @DefaultPromptEffortLevel_Clear = 1,
+  @ChatHandlingOption = @ChatHandlingOption_15595692,
+  @ChatHandlingOption_Clear = 1,
+  @DefaultArtifactTypeID = @DefaultArtifactTypeID_15595692,
+  @OwnerUserID = @OwnerUserID_15595692,
+  @InvocationMode = @InvocationMode_15595692,
+  @ArtifactCreationMode = @ArtifactCreationMode_15595692,
+  @FunctionalRequirements = @FunctionalRequirements_15595692,
+  @FunctionalRequirements_Clear = 1,
+  @TechnicalDesign = @TechnicalDesign_15595692,
+  @TechnicalDesign_Clear = 1,
+  @InjectNotes = @InjectNotes_15595692,
+  @MaxNotesToInject = @MaxNotesToInject_15595692,
+  @NoteInjectionStrategy = @NoteInjectionStrategy_15595692,
+  @InjectExamples = @InjectExamples_15595692,
+  @MaxExamplesToInject = @MaxExamplesToInject_15595692,
+  @ExampleInjectionStrategy = @ExampleInjectionStrategy_15595692,
+  @IsRestricted = @IsRestricted_15595692,
+  @MessageMode = @MessageMode_15595692,
+  @MaxMessages = @MaxMessages_15595692,
+  @MaxMessages_Clear = 1,
+  @AttachmentStorageProviderID = @AttachmentStorageProviderID_15595692,
+  @AttachmentStorageProviderID_Clear = 1,
+  @AttachmentRootPath = @AttachmentRootPath_15595692,
+  @AttachmentRootPath_Clear = 1,
+  @InlineStorageThresholdBytes = @InlineStorageThresholdBytes_15595692,
+  @InlineStorageThresholdBytes_Clear = 1,
+  @AgentTypePromptParams = @AgentTypePromptParams_15595692,
+  @AgentTypePromptParams_Clear = 1,
+  @ScopeConfig = @ScopeConfig_15595692,
+  @ScopeConfig_Clear = 1,
+  @NoteRetentionDays = @NoteRetentionDays_15595692,
+  @NoteRetentionDays_Clear = 1,
+  @ExampleRetentionDays = @ExampleRetentionDays_15595692,
+  @ExampleRetentionDays_Clear = 1,
+  @AutoArchiveEnabled = @AutoArchiveEnabled_15595692,
+  @RerankerConfiguration = @RerankerConfiguration_15595692,
+  @RerankerConfiguration_Clear = 1,
+  @CategoryID = @CategoryID_15595692,
+  @AllowEphemeralClientTools = @AllowEphemeralClientTools_15595692,
+  @DefaultStorageAccountID = @DefaultStorageAccountID_15595692,
+  @DefaultStorageAccountID_Clear = 1,
+  @SearchScopeAccess = @SearchScopeAccess_15595692,
+  @AcceptUnregisteredFiles = @AcceptUnregisteredFiles_15595692,
+  @DefaultCoAgentID = @DefaultCoAgentID_15595692,
+  @DefaultCoAgentID_Clear = 1,
+  @TypeConfiguration = @TypeConfiguration_15595692,
+  @TypeConfiguration_Clear = 1,
+  @AllowMemoryWrite = @AllowMemoryWrite_15595692,
+  @RecordingDefault = @RecordingDefault_15595692,
+  @RecordingDefault_Clear = 1,
+  @RecordingStorageProviderID = @RecordingStorageProviderID_15595692,
+  @RecordingStorageProviderID_Clear = 1,
+  @DefaultMediaCollectionID = @DefaultMediaCollectionID_15595692,
+  @DefaultMediaCollectionID_Clear = 1,
+  @SupportsPlanMode = @SupportsPlanMode_15595692,
+  @AcceptsSkills = @AcceptsSkills_15595692,
+  @SkillActivationMode = @SkillActivationMode_15595692,
+  @RequirePlanMode = @RequirePlanMode_15595692,
+  @ID = @ID_15595692;
 
 GO
 


### PR DESCRIPTION
## Summary
- **APIKeyUsageLog cascade delete**: dynamically resolve FK constraint name via system catalogs instead of hardcoding the auto-generated name (SQL Server + PostgreSQL) — the hardcoded name differs per database instance
- **Metadata Sync**: deactivate the Skip proxy agent (`spUpdateAIAgent` with `Status='Disabled'`) instead of deleting it (`spDeleteAIAgent`), preserving the record and its relationships
- **Publish workflow**: add `[version:X.Y.Z]` commit-message override so merge commits can force a specific version without cancelling the auto-triggered workflow and re-triggering via `workflow_dispatch`
- **Changeset**: patch bump for v5.45.1

## Test plan
- [ ] Run `mj migrate` against a fresh SQL Server database — APIKeyUsageLog FK migration succeeds regardless of auto-generated constraint name
- [ ] Run `mj migrate` against a fresh PostgreSQL database — same FK migration succeeds via `pg_constraint` catalog lookup
- [ ] Verify Metadata Sync migration updates (not deletes) the Skip agent record
- [ ] Verify publish workflow parses `[version:5.45.1]` from the merge commit title and uses it as the expected version

🤖 Generated with [Claude Code](https://claude.com/claude-code)