### PR TITLE
v5.45.1

### DIFF
--- a/.changeset/agent-final-response-streaming.md
+++ b/.changeset/agent-final-response-streaming.md
@@ -1,8 +1,8 @@
 ---
-"@memberjunction/ai-core-plus": minor
-"@memberjunction/server": minor
-"@memberjunction/conversations-runtime": minor
-"@memberjunction/ng-conversations": minor
+"@memberjunction/ai-core-plus": patch
+"@memberjunction/server": patch
+"@memberjunction/conversations-runtime": patch
+"@memberjunction/ng-conversations": patch
 ---
 
 Render agent final-response streaming in the conversation chat. Adds an optional `kind` discriminator to agent streaming chunks — `'final-response'` marks deltas of the user-facing reply — passed through the server's PubSub payload; the conversation client now routes those chunks, accumulates deltas service-side, renders the growing text in the message bubble, and reconciles with the saved final message on completion. Unmarked streams (e.g. Loop-agent JSON turn envelopes) keep today's behavior exactly (dropped), so agents that don't opt in are unaffected.

--- a/.changeset/eds-core-fixes.md
+++ b/.changeset/eds-core-fixes.md
@@ -1,5 +1,5 @@
 ---
-"@memberjunction/external-data-sources": minor
+"@memberjunction/external-data-sources": patch
 "@memberjunction/external-data-source-sqlserver": patch
 "@memberjunction/external-data-source-mongodb": patch
 "@memberjunction/external-data-source-oracle": patch

--- a/.changeset/eds-ingestion-connector-abstractions.md
+++ b/.changeset/eds-ingestion-connector-abstractions.md
@@ -1,5 +1,5 @@
 ---
-"@memberjunction/integration-connectors": minor
+"@memberjunction/integration-connectors": patch
 ---
 
 Add the External-Data-Source-backed ingestion connector abstractions (the "heart"): `BaseExternalDataSourceConnector` (family-neutral — resolves the shared `MJ: External Data Sources` row via the EDS router, `TestConnection`, `IntrospectSchema` mapping `ExternalSchemaDescriptor` → `SourceSchemaInfo`, and generic incremental `FetchChanges` that passes a **structured `incrementalSince` watermark bound + raw ordering columns** to `driver.RunView` — the connector writes NO dialect SQL; the EDS driver renders the predicate, quoting, and literal formatting), plus the `BaseSqlExternalDataSourceConnector` (SQL family — **authoritative** discovery) and `BaseDocumentDataSourceConnector` (document/NoSQL family — **non-authoritative** sampled discovery) families. The connection binds to a shared EDS row via `Configuration.externalDataSourceID`; credentials flow through CredentialEngine. Deprecates the SQL-Server-hardcoded, inline-`mssql` `RelationalDBConnector`. Thin per-engine leaves ship as Open Apps in the MemberJunction/Integrations repo.


### PR DESCRIPTION
# EDS connectors, streaming conversations, and cross-DB bug fixes

## New Features
- **EDS Ingestion Connector Abstractions**: Added `BaseExternalDataSourceConnector`, `BaseSqlExternalDataSourceConnector`, and `BaseDocumentDataSourceConnector` families — connectors write zero dialect SQL; the EDS driver renders predicates, quoting, and literal formatting. Deprecates the SQL Server-hardcoded `RelationalDBConnector`.
- **Agent Final-Response Streaming**: Conversation chat widget now streams agent final-response chunks in real time. An optional `kind: 'final-response'` discriminator on streaming chunks routes deltas to the message bubble and reconciles with the saved message on completion; agents that don't opt in are unaffected.
- **Structured Incremental Watermark for EDS**: Added `incrementalSince: { Field, Value }` to `ExternalViewParams` — incremental-read consumers request "rows changed at/after a watermark" without writing dialect SQL across all five SQL drivers (SQL Server, Postgres, MySQL, Oracle, Snowflake) and MongoDB.

## Improvements
- **MongoDB Date Coercion**: `MongoFilterTranslator` now coerces ISO-8601 date-time literals to `Date` objects so watermark predicates match BSON `Date`-typed fields correctly.
- **Publish Workflow Version Override**: Added `[version:X.Y.Z]` commit-message token to the publish workflow for forcing a specific version on merge without changeset bumps.

## Bug Fixes
- **Migration Fixes (SQL Server + PostgreSQL)**: Dynamically resolve FK constraint name in `APIKeyUsageLog` cascade delete migration, fixing failures on databases where the constraint name differs from the hardcoded value.
- **Metadata Sync — Skip Agent**: Deactivate the Skip agent instead of deleting it during Metadata Sync to prevent FK violations and data loss.
- **Magic Link — PostgreSQL**: Fixed atomic single-use consume SQL that was T-SQL-only, causing a syntax error and failed redemption on PostgreSQL. `buildConsumeInviteSQL` is now dialect-aware.