### PR TITLE
fix(pg-codegen): flat ParameterRef for all CRUD param names (multi-word PK save fails on Postgres)

### DIFF
--- a/.changeset/pg-codegen-multiword-pk-param-naming.md
+++ b/.changeset/pg-codegen-multiword-pk-param-naming.md
@@ -1,0 +1,10 @@
+---
+"@memberjunction/codegen-lib": patch
+"@memberjunction/postgresql-dataprovider": patch
+---
+
+Fix PostgreSQL CRUD save/update/delete/cascade failing on entities whose primary key has a multi-word (camelCase/PascalCase) name.
+
+The PG CodeGen provider declared CRUD function parameters with the canonical flat builder (`ParameterRef` → `p_<lower>`, e.g. `p_recordkey`) but *referenced* the primary key in several body clauses via `toSnakeCase` (`p_record_key`). Because `toLowerCase()` and `toSnakeCase()` produce the *same* string for single-word/`ID` keys, this was invisible on every `ID`-keyed entity — but a table keyed on a multi-word soft-PK (e.g. a connector's `recordKey`) generated a function that declared `p_recordkey` and referenced `p_record_key`, so every save/update/delete failed on PostgreSQL with `column "p_record_key" does not exist`.
+
+All parameter names now route through the single `ParameterRef` builder in both `PostgreSQLCodeGenProvider` (create/update/delete/cascade bodies) and `PostgreSQLDataProvider` (the save-call binding). This is a no-op for `ID`/single-word keys and fixes multi-word keys. Regenerate CRUD functions (`mj codegen`) after upgrading to apply the fix — no data migration required.

--- a/packages/CodeGenLib/src/Database/providers/postgresql/PostgreSQLCodeGenProvider.ts
+++ b/packages/CodeGenLib/src/Database/providers/postgresql/PostgreSQLCodeGenProvider.ts
@@ -793,8 +793,8 @@ ${permissions}
         const paramString = this.generateCRUDParamString(entity.Fields, true);
         const permissions = this.generateCRUDPermissions(entity, fnName, CRUDType.Update);
         const updateFields = this.generateUpdateFieldString(entity.Fields);
-        const whereClause = this.buildPrimaryKeyWhereClause(entity, 'p_');
-        const selectWhereClause = this.buildPrimaryKeyWhereClause(entity, 'p_');
+        const whereClause = this.buildPrimaryKeyWhereClause(entity);
+        const selectWhereClause = this.buildPrimaryKeyWhereClause(entity);
 
         const trigger = this.generateTimestampTrigger(entity);
 
@@ -1424,7 +1424,11 @@ END $$;
             varDecls.push(`${varName} ${sqlType}`);
             selectFlds.push(pgDialect.QuoteIdentifier(pk.Name));
             fetchVars.push(varName);
-            routineParamParts.push(`p_${this.toSnakeCase(pk.CodeName)} := ${varName}`);
+            // Param NAME must use the canonical flat builder (ParameterRef → `p_<lower>`) so it
+            // matches the CRUD routine's declared signature; only the local VARIABLE (v_…) uses
+            // snake_case. Using toSnakeCase here produced `p_record_key` for a multi-word PK while
+            // the routine declared `p_recordkey`, breaking cascade delete/update-to-NULL on PG.
+            routineParamParts.push(`${pgDialect.ParameterRef(pk.CodeName)} := ${varName}`);
         }
 
         return {
@@ -2163,9 +2167,13 @@ WHERE p.prokind IN ('f', 'p')
     }
 
     /** Builds a WHERE clause using primary key fields with a parameter prefix */
-    private buildPrimaryKeyWhereClause(entity: EntityInfo, prefix: string): string {
+    private buildPrimaryKeyWhereClause(entity: EntityInfo): string {
+        // Param name via the canonical flat builder (ParameterRef → `p_<lower>`), NOT toSnakeCase,
+        // so the WHERE matches the CRUD function's declared parameter. A `p_${toSnakeCase}` here
+        // emitted `p_record_key` for a multi-word PK while the signature declared `p_recordkey`,
+        // so every UPDATE failed on PostgreSQL with `column "p_record_key" does not exist`.
         return entity.PrimaryKeys.map((k: EntityFieldInfo) =>
-            `${pgDialect.QuoteIdentifier(k.Name)} = ${prefix}${this.toSnakeCase(k.CodeName)}`
+            `${pgDialect.QuoteIdentifier(k.Name)} = ${pgDialect.ParameterRef(k.CodeName)}`
         ).join(' AND ');
     }
 
@@ -2190,7 +2198,7 @@ WHERE p.prokind IN ('f', 'p')
         }
 
         if ((firstKey.Type.toLowerCase().trim() === 'uniqueidentifier' || firstKey.Type.toLowerCase().trim() === 'uuid') && entity.PrimaryKeys.length === 1) {
-            const paramName = `p_${this.toSnakeCase(firstKey.CodeName)}`;
+            const paramName = pgDialect.ParameterRef(firstKey.CodeName);
             const hasNonPkFields = insertColumns.trim().length > 0;
             return {
                 preInsert: `v_new_id := COALESCE(${paramName}, gen_random_uuid());\n    `,
@@ -2205,7 +2213,7 @@ WHERE p.prokind IN ('f', 'p')
 
         // Composite keys or non-auto, non-UUID PKs
         const selectWhere = entity.PrimaryKeys.map((k: EntityFieldInfo) =>
-            `${pgDialect.QuoteIdentifier(k.Name)} = p_${this.toSnakeCase(k.CodeName)}`
+            `${pgDialect.QuoteIdentifier(k.Name)} = ${pgDialect.ParameterRef(k.CodeName)}`
         ).join(' AND ');
 
         // Composite-PK tables: every PK column has AllowUpdateAPI=0, so generateInsertFieldString
@@ -2220,7 +2228,7 @@ WHERE p.prokind IN ('f', 'p')
                 .map((k: EntityFieldInfo) => pgDialect.QuoteIdentifier(k.Name))
                 .join(',\n            ');
             const pkValues = entity.PrimaryKeys
-                .map((k: EntityFieldInfo) => `p_${this.toSnakeCase(k.CodeName)}`)
+                .map((k: EntityFieldInfo) => pgDialect.ParameterRef(k.CodeName))
                 .join(',\n            ');
             const hasNonPkColumns = insertColumns.trim().length > 0;
             finalColumns = hasNonPkColumns ? `${pkColumns},\n            ${insertColumns}` : pkColumns;
@@ -2248,14 +2256,14 @@ WHERE p.prokind IN ('f', 'p')
         const nullParts: string[] = [];
 
         for (const k of entity.PrimaryKeys) {
-            const paramName = `p_${this.toSnakeCase(k.CodeName)}`;
+            const paramName = pgDialect.ParameterRef(k.CodeName);
             paramParts.push(`${paramName} ${this.mapSQLType(k.SQLFullType)}`);
             selectParts.push(`${paramName} AS ${pgDialect.QuoteIdentifier(k.Name)}`);
             nullParts.push(`NULL::${this.mapSQLType(k.SQLFullType)} AS ${pgDialect.QuoteIdentifier(k.Name)}`);
         }
 
         const whereClause = entity.PrimaryKeys.map((k: EntityFieldInfo) =>
-            `${pgDialect.QuoteIdentifier(k.Name)} = p_${this.toSnakeCase(k.CodeName)}`
+            `${pgDialect.QuoteIdentifier(k.Name)} = ${pgDialect.ParameterRef(k.CodeName)}`
         ).join(' AND ');
 
         let deleteBody: string;
@@ -2294,7 +2302,7 @@ WHERE p.prokind IN ('f', 'p')
         }
 
         const updateFnName = this.getCRUDRoutineName(relatedEntity, CRUDType.Update);
-        const whereClause = `${pgDialect.QuoteIdentifier(fkField.Name)} = p_${this.toSnakeCase(parentEntity.FirstPrimaryKey.CodeName)}`;
+        const whereClause = `${pgDialect.QuoteIdentifier(fkField.Name)} = ${pgDialect.ParameterRef(parentEntity.FirstPrimaryKey.CodeName)}`;
 
         return `    -- Cascade: Set ${relatedEntity.Name}.${fkField.Name} to NULL
     FOR v_rec IN
@@ -2317,7 +2325,7 @@ WHERE p.prokind IN ('f', 'p')
         }
 
         const deleteFnName = this.getCRUDRoutineName(relatedEntity, CRUDType.Delete);
-        const whereClause = `${pgDialect.QuoteIdentifier(fkField.Name)} = p_${this.toSnakeCase(parentEntity.FirstPrimaryKey.CodeName)}`;
+        const whereClause = `${pgDialect.QuoteIdentifier(fkField.Name)} = ${pgDialect.ParameterRef(parentEntity.FirstPrimaryKey.CodeName)}`;
 
         return `    -- Cascade: Delete ${relatedEntity.Name} records via ${fkField.Name}
     FOR v_rec IN

--- a/packages/CodeGenLib/src/__tests__/PostgreSQLCodeGenProvider.test.ts
+++ b/packages/CodeGenLib/src/__tests__/PostgreSQLCodeGenProvider.test.ts
@@ -854,4 +854,40 @@ describe('PostgreSQLCodeGenProvider', () => {
             expect(sql).toContain('WARNING');
         });
     });
+
+    // Regression: a multi-word (camelCase) PRIMARY KEY must yield a FLAT param name
+    // (`p_recordkey`) consistently across create/update/delete — never the snake form
+    // (`p_record_key`). Before the ParameterRef unification the CRUD *declaration* used
+    // the flat builder while several body references hand-built the name with toSnakeCase,
+    // so a save/delete against a connector table keyed on a soft-PK like `recordKey`
+    // failed on PostgreSQL with `column "p_record_key" does not exist`. ID-keyed entities
+    // were immune because toLowerCase('id') === toSnakeCase('ID'), which is why the bug
+    // stayed hidden until a connector minted its own multi-word PK.
+    describe('multi-word primary key — flat param-name consistency (regression: p_record_key)', () => {
+        const recordKeyEntity = () => createMockEntity(
+            { BaseTable: 'Customer', BaseTableCodeName: 'Customer', SchemaName: 'mj_connector_acgi', BaseView: 'vwCustomers' },
+            [
+                { ID: 'pk-rk', Name: 'recordKey', CodeName: 'recordKey', Type: 'nvarchar', Length: 400, IsPrimaryKey: true, AllowsNull: false, AllowUpdateAPI: false, IsVirtual: false, AutoIncrement: false, DefaultValue: '' },
+                { ID: 'f-cust', Name: 'custId', CodeName: 'custId', Type: 'nvarchar', Length: 100, IsPrimaryKey: false, AllowsNull: true, AllowUpdateAPI: true, IsVirtual: false, AutoIncrement: false, DefaultValue: '' },
+            ]
+        );
+
+        it('create references the PK param flat (p_recordkey), never snake (p_record_key)', () => {
+            const sql = provider.generateCRUDCreate(recordKeyEntity());
+            expect(sql).toContain('p_recordkey');
+            expect(sql).not.toContain('p_record_key');
+        });
+
+        it('update references the PK param flat, never snake', () => {
+            const sql = provider.generateCRUDUpdate(recordKeyEntity());
+            expect(sql).toContain('p_recordkey');
+            expect(sql).not.toContain('p_record_key');
+        });
+
+        it('delete declares AND references the PK param flat, never snake', () => {
+            const sql = provider.generateCRUDDelete(recordKeyEntity(), '');
+            expect(sql).toContain('p_recordkey');
+            expect(sql).not.toContain('p_record_key');
+        });
+    });
 });

--- a/packages/PostgreSQLDataProvider/src/PostgreSQLDataProvider.ts
+++ b/packages/PostgreSQLDataProvider/src/PostgreSQLDataProvider.ts
@@ -882,10 +882,12 @@ export class PostgreSQLDataProvider extends GenericDatabaseProvider implements I
         let paramIndex = 0;
         for (const [field, value] of fieldValues) {
             values.push(PGQueryParameterProcessor.ProcessParameterValue(value));
-            // Baseline-shipped sp* CRUD functions use `p_<lowercased flat field name>`
-            // (no inner separator) — e.g. `p_categoryid` for column "CategoryID".
-            // toSnakeCase would produce `p_category_id` and fail every Save.
-            placeholders.push(`p_${field.Name.toLowerCase()} => $${paramIndex + 1}`);
+            // Param name via the canonical builder (ParameterRef → `p_<lowercased CodeName>`,
+            // no inner separator) so it EXACTLY matches the CRUD function's declared signature,
+            // which is emitted by PostgreSQLCodeGenProvider using the same ParameterRef. Using
+            // CodeName (not Name) also keeps this correct for fields whose display Name differs
+            // from the code identifier (e.g. spaces). See ParameterRef in postgresqlDialect.ts.
+            placeholders.push(`${pgDialect.ParameterRef(field.CodeName)} => $${paramIndex + 1}`);
             paramIndex++;
 
             if ((value === null || value === undefined) && field.NeedsClearCompanion) {
@@ -900,7 +902,7 @@ export class PostgreSQLDataProvider extends GenericDatabaseProvider implements I
         if (isUpdate) {
             for (const pkv of entity.PrimaryKey.KeyValuePairs) {
                 values.push(PGQueryParameterProcessor.ProcessParameterValue(pkv.Value));
-                placeholders.push(`p_${pkv.FieldName.toLowerCase()} => $${paramIndex + 1}`);
+                placeholders.push(`${pgDialect.ParameterRef(pkv.FieldName)} => $${paramIndex + 1}`);
                 paramIndex++;
             }
         }


### PR DESCRIPTION
## The bug
PostgreSQL CRUD save/update/delete **fails on any entity whose primary key has a multi-word name** (camelCase/PascalCase), e.g. a connector table keyed on a soft-PK `recordKey`:

```
PostgreSQLDataProvider.ExecuteSQL failed [Save Customers]: column "p_record_key" does not exist
```

## Root cause
The PG CodeGen provider **declared** CRUD function parameters with the canonical flat builder `ParameterRef` (`p_recordkey`) but **referenced** the PK in several body clauses via `toSnakeCase` (`p_record_key`). Because `toLowerCase()` and `toSnakeCase()` produce the **same** string for single-word / `ID` keys (`p_id` either way), this was invisible on every `ID`-keyed entity — so it stayed dormant until a connector minted its own multi-word PK.

## Fix
Route **all** parameter names through the single `ParameterRef` builder:
- **`PostgreSQLCodeGenProvider`** — create (`buildInsertStrategy`), update (`buildPrimaryKeyWhereClause`), delete (`buildDeleteStrategy`), cascade (`buildPrimaryKeyComponents`, `generateCascadeUpdateToNull`, `generateCascadeCursorDelete`).
- **`PostgreSQLDataProvider`** — the save-call binding now calls `ParameterRef(field.CodeName)` (also fixes the Name-vs-CodeName edge for fields whose display name has spaces).

**No-op for `ID`/single-word keys** (`p_id` both ways → zero risk to existing entities); **fixes multi-word keys**. Object names and `v_` local variables intentionally keep `snake_case` (their own self-consistent namespace). No data migration — regenerate CRUD functions (`mj codegen`) after upgrade.

## Tests
3 new multi-word-PK (`recordKey`) regressions asserting create/update/delete emit flat `p_recordkey`, never `p_record_key`. The update-WHERE site was caught by these tests (a `${prefix}${toSnakeCase}` form a literal grep missed).

- `@memberjunction/codegen-lib`: **64/64** tests, build clean
- `@memberjunction/postgresql-dataprovider`: **140/140** tests, build clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)