### PR TITLE
fix(pg-converter): avoid `spawn E2BIG` from oversized BIT-column registry

### DIFF
--- a/.changeset/easy-hands-sin.md
+++ b/.changeset/easy-hands-sin.md
@@ -1,0 +1,6 @@
+---
+"@memberjunction/cli": patch
+"@memberjunction/sqlglot-ts": patch
+---
+
+Fix `spawn E2BIG` in PostgreSQL migration conversion. The cross-file BIT-column

--- a/packages/MJCLI/src/commands/migrate/convert.ts
+++ b/packages/MJCLI/src/commands/migrate/convert.ts
@@ -383,19 +383,29 @@ export default class MigrateConvert extends Command {
       this.error(err instanceof Error ? err.message : String(err));
     }
 
+    // Only the LATEST baseline feeds the cross-file BIT registry. A baseline is a full
+    // cumulative schema snapshot, so the newest one already contains every current
+    // table's BIT columns; older baselines only add stale/dropped columns. Collecting
+    // from ALL baselines both (a) bloats the registry with dead entries and (b) — since
+    // it is passed to the sqlglot subprocess as the MJ_EXTRA_BIT_COLS *environment
+    // variable* — pushes past the OS single-arg/env limit (Linux MAX_ARG_STRLEN, 128 KB)
+    // once enough baselines accumulate, making every spawn fail with `spawn E2BIG`.
+    // (Threshold first crossed at v5.46: 5 baselines = 4060 entries ≈ 134 KB. Latest
+    // baseline alone ≈ 1023 entries ≈ 34 KB.)
     const baselines = fs
       .readdirSync(sourceDir)
       .filter((f) => /^B\d.*\.sql$/.test(f) && !f.endsWith('.pg.sql') && !f.endsWith('.pg-only.sql'))
       .sort();
+    const latestBaseline = baselines.at(-1);
     const bitColumns: string[] = [];
-    for (const b of baselines) {
+    if (latestBaseline) {
       try {
-        const cols = await probe.collectBitColumns(fs.readFileSync(path.join(sourceDir, b), 'utf8'));
-        bitColumns.push(...cols);
+        const cols = await probe.collectBitColumns(fs.readFileSync(path.join(sourceDir, latestBaseline), 'utf8'));
+        bitColumns.push(...new Set(cols));
       } catch (err) {
         // A baseline that fails bit-column collection degrades 1/0→TRUE/FALSE
         // coercion for tables it declares — warn loudly, don't proceed silently.
-        this.warn(`Bit-column collection failed for ${b}: ${err instanceof Error ? err.message : String(err)}`);
+        this.warn(`Bit-column collection failed for ${latestBaseline}: ${err instanceof Error ? err.message : String(err)}`);
       }
     }
     return new MJPostgresTranspiler({ extraBitColumns: bitColumns });

--- a/packages/SQLGlotTS/src/MJPostgresTranspiler.ts
+++ b/packages/SQLGlotTS/src/MJPostgresTranspiler.ts
@@ -1,10 +1,14 @@
 import { spawn } from 'node:child_process';
-import { existsSync } from 'node:fs';
+import { existsSync, writeFileSync, unlinkSync } from 'node:fs';
+import os from 'node:os';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
+
+/** Process-unique sequence for temp bit-column registry files (no Date/random needed). */
+let bitColsFileSeq = 0;
 
 /** One statement the MJ dialect refused to emit — a reported conversion gap. */
 export interface MJUnhandledStatement {
@@ -77,12 +81,42 @@ export class MJPostgresTranspiler {
   private readonly dialectPath: string;
   private readonly extraBitColumns: string[];
   private readonly timeoutMs: number;
+  /** Lazily-written temp file holding the bit-col registry JSON. `undefined` = not yet computed, `null` = none. */
+  private bitColsFile: string | null | undefined;
 
   constructor(options?: MJPostgresTranspilerOptions) {
     this.pythonPath = options?.pythonPath ?? process.env.MJ_SQLGLOT_PYTHON ?? 'python3';
     this.dialectPath = resolveDialectPath();
     this.extraBitColumns = options?.extraBitColumns ?? [];
     this.timeoutMs = options?.timeoutMs ?? 120_000;
+  }
+
+  /**
+   * Serialize the cross-file BIT registry to a temp file and hand the dialect its
+   * PATH (via `MJ_EXTRA_BIT_COLS_FILE`), never the JSON itself. The registry grows
+   * with the schema (every baseline's BIT columns); passed inline as the
+   * `MJ_EXTRA_BIT_COLS` env var it exceeds the OS single-arg/env limit (Linux
+   * `MAX_ARG_STRLEN`, 128 KB) once baselines accumulate, and `spawn` fails with
+   * `E2BIG`. A file path is a few bytes, so there is no ceiling. Written once and
+   * reused across calls; removed on process exit.
+   */
+  private getBitColsFile(): string | null {
+    if (this.bitColsFile !== undefined) return this.bitColsFile;
+    if (this.extraBitColumns.length === 0) {
+      this.bitColsFile = null;
+      return null;
+    }
+    const file = path.join(os.tmpdir(), `mj-extra-bitcols-${process.pid}-${bitColsFileSeq++}.json`);
+    writeFileSync(file, JSON.stringify(this.extraBitColumns), 'utf8');
+    process.once('exit', () => {
+      try {
+        unlinkSync(file);
+      } catch {
+        /* best-effort cleanup */
+      }
+    });
+    this.bitColsFile = file;
+    return file;
   }
 
   /** Transpile T-SQL to PostgreSQL. Statements the dialect can't emit land in `unhandled`. */
@@ -116,11 +150,14 @@ export class MJPostgresTranspiler {
 
   private runDialect(args: string[], stdin: string): Promise<string> {
     return new Promise<string>((resolve, reject) => {
+      const bitColsFile = this.getBitColsFile();
       const proc = spawn(this.pythonPath, [this.dialectPath, ...args], {
         stdio: ['pipe', 'pipe', 'pipe'],
         env: {
           ...process.env,
-          MJ_EXTRA_BIT_COLS: JSON.stringify(this.extraBitColumns),
+          // Pass the registry by file path (see getBitColsFile) — never inline, to
+          // avoid `spawn E2BIG` when the registry outgrows the OS env-size limit.
+          ...(bitColsFile ? { MJ_EXTRA_BIT_COLS_FILE: bitColsFile } : {}),
         },
       });
 

--- a/packages/SQLGlotTS/src/python/mj_postgres.py
+++ b/packages/SQLGlotTS/src/python/mj_postgres.py
@@ -1454,7 +1454,20 @@ def mj_transpile(sql: str, *, pretty: bool = True, identify: bool = True) -> dic
     # coerce 1/0 → TRUE/FALSE in seed INSERTs that target core tables (e.g. User.IsActive).
     global _BIT_COLS
     _BIT_COLS = _collect_bit_columns(sql)
-    extra = _os.environ.get("MJ_EXTRA_BIT_COLS")
+    # Registry transport: prefer a file path (MJ_EXTRA_BIT_COLS_FILE) so a large
+    # registry never has to ride an env var (which caps at ~128 KB and fails the
+    # spawn with E2BIG). Fall back to the inline MJ_EXTRA_BIT_COLS env for callers
+    # (and tests) that still set it directly.
+    extra = None
+    extra_file = _os.environ.get("MJ_EXTRA_BIT_COLS_FILE")
+    if extra_file:
+        try:
+            with open(extra_file, "r", encoding="utf-8") as _f:
+                extra = _f.read()
+        except Exception:  # noqa: BLE001
+            extra = None
+    if extra is None:
+        extra = _os.environ.get("MJ_EXTRA_BIT_COLS")
     if extra:
         try:
             _BIT_COLS |= {(t.lower(), c.lower()) for t, c in _json.loads(extra)}


### PR DESCRIPTION
## Problem

`mj migrate convert --bake-codegen` (and the split path generally) invokes the Python `sqlglot` dialect as a subprocess, passing the cross-file BIT/BOOLEAN column registry as the **`MJ_EXTRA_BIT_COLS` environment variable**. The registry was collected from **every baseline**.

At **v5.46** the cumulative payload crossed a hard OS ceiling:

| | entries | bytes |
|---|--:|--:|
| all 5 baselines | 4060 | **134 KB** |
| Linux `MAX_ARG_STRLEN` (per arg/env string) | | 128 KB |

Result: every dialect spawn failed with **`spawn E2BIG`**, so `--bake-codegen` conversion aborted. This is a **threshold bug** — it first bites at 5.46 and worsens every release as baselines accumulate. It's the reason the 5.46 build had to fall back to deferred (deploy-time) CodeGen, which in turn shipped PG migrations **missing their regenerated views/sprocs** (e.g. `OpenApp_LastCompletedStep` — column added, but `vwOpenApps`/CRUD sprocs not regenerated).

## Fix

- **`convert.ts`** — build the registry from the **latest baseline only**. A baseline is a full cumulative snapshot, so the newest already contains every current table's BIT columns; older baselines only add stale/dropped entries. **134 KB → 34 KB**, and strictly more correct.
- **`MJPostgresTranspiler.ts`** — pass the registry to the dialect by **temp-file path** (`MJ_EXTRA_BIT_COLS_FILE`), never inline. Removes the size ceiling entirely (a path is a few bytes). Written once, reused, cleaned up on exit.
- **`mj_postgres.py`** — read the file when `MJ_EXTRA_BIT_COLS_FILE` is set, else fall back to inline `MJ_EXTRA_BIT_COLS` (back-compat for direct callers/tests). Transport-only; conversion semantics unchanged.

Either fix alone resolves the E2BIG; together they're belt-and-suspenders (smaller *and* uncapped).

## Validation (Docker workbench, against `origin/next`)

- Reproduced the exact failure: baking `Scoped_Prompt_Config` → `spawn E2BIG`; view inventory unchanged (ruling out the previously-suspected CASCADE-drop theory).
- With the fix: `Scoped_Prompt_Config` bakes clean (3058 lines, 23 CodeGen objects) and `OpenApp_LastCompletedStep` bakes clean (773 lines) with `vwOpenApps` + 6 CRUD sprocs + `LastCompletedStep` wired through — i.e. exactly the CodeGen that shipped missing in 5.46.
- Fix 2 in isolation: transpile with the full 134 KB registry via temp file → no E2BIG.
- Unit tests: **SQLGlotTS 69/69**, **MJCLI 426/426**.

## Notes

- Touches published packages (`@memberjunction/cli`, `@memberjunction/sqlglot-ts`) — a changeset is needed (left for the maintainer's `npm run change`).
- Piloting alongside the reworked `/pg-migrate-v2` skill in this release's build; the skill doc lands separately once validated in the real build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)