### PR TITLE
ci: guard release-notes agent and harden @claude bot (defer claude.yml to #3101)

### DIFF
--- a/.github/workflows/claude-command.yml
+++ b/.github/workflows/claude-command.yml
@@ -8,10 +8,21 @@ on:
 
 jobs:
   claude:
+    # Gated to repo insiders (drive-by commenters on public issues/PRs can't spend
+    # API budget) and non-bot authors (prevents bot-to-bot trigger loops).
     if: |
-      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
-      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude'))
+      ((github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
+      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude'))) &&
+      contains(fromJson('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association) &&
+      github.event.comment.user.type != 'Bot'
     runs-on: ubuntu-latest
+    # Hard wall-clock cap — the GitHub default is 6 hours of billable agent time.
+    timeout-minutes: 20
+    # Rapid follow-up @claude comments on the same thread cancel the superseded run.
+    # issue.number is empty on pull_request_review_comment events, hence the fallback.
+    concurrency:
+      group: claude-cmd-${{ github.event.issue.number || github.event.pull_request.number }}
+      cancel-in-progress: true
     permissions:
       contents: read
       pull-requests: read
@@ -29,8 +40,15 @@ jobs:
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
 
-          # Optional: Specify model (defaults to Claude Sonnet 4, uncomment for Claude Opus 4)
-          # model: "claude-opus-4-8"
+          # Pinned so the tier can't drift with the action's default (this workflow
+          # rides the moving @beta tag). Interactive agent work stays on Sonnet.
+          model: claude-sonnet-4-6
+
+          # Web tools disabled: they inflate context/turn count and aren't needed
+          # for repo-scoped @claude requests. (Bash is already NOT granted by
+          # default — do not uncomment the allowed_tools Bash example below unless
+          # you intend to WIDEN the tool surface.)
+          disallowed_tools: 'WebSearch,WebFetch'
 
           # Optional: Customize the trigger phrase (default: @claude)
           # trigger_phrase: "/claude"

--- a/.github/workflows/claude-command.yml
+++ b/.github/workflows/claude-command.yml
@@ -10,6 +10,13 @@ jobs:
   claude:
     # Gated to repo insiders (drive-by commenters on public issues/PRs can't spend
     # API budget) and non-bot authors (prevents bot-to-bot trigger loops).
+    # KNOWN GOTCHA: author_association may report NONE/CONTRIBUTOR for org members
+    # whose membership is PRIVATE, silently not firing for them. Backstop: the
+    # claude-code-action performs its own write-access check, so this gate only
+    # saves runner spin-up — it is not the sole guard. If a maintainer reports
+    # @claude not responding, have them make their org membership public, or add
+    # their login to an explicit allowlist here. Verify post-merge with a test
+    # comment from a private-membership member.
     if: |
       ((github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
       (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude'))) &&
@@ -20,6 +27,10 @@ jobs:
     timeout-minutes: 20
     # Rapid follow-up @claude comments on the same thread cancel the superseded run.
     # issue.number is empty on pull_request_review_comment events, hence the fallback.
+    # TRADEOFF (accepted while the bot fires ~never): the group is per-thread, not
+    # per-user, so two people mentioning @claude on the same PR in quick succession
+    # means the second silently cancels the first person's in-flight run. If usage
+    # grows, revisit by dropping cancel-in-progress (runs then queue instead).
     concurrency:
       group: claude-cmd-${{ github.event.issue.number || github.event.pull_request.number }}
       cancel-in-progress: true

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -6,13 +6,12 @@ on:
     # Not re-running review on updates
     # types: [opened, synchronize]
     branches: [next]
-    # The review prompt below only covers migrations/*.sql — skip the whole run
-    # (zero runner minutes, zero API tokens) when a PR touches no migration SQL.
-    # NOTE: keep `claude-review` a NON-required status check. A paths-skipped run
-    # reports "pending" forever; if this check were ever made required it would
-    # block every non-migration PR from merging.
-    paths:
-      - 'migrations/**/*.sql'
+    # Optional: Only run on specific file changes
+    # paths:
+    #   - "src/**/*.ts"
+    #   - "src/**/*.tsx"
+    #   - "src/**/*.js"
+    #   - "src/**/*.jsx"
 
 jobs:
   claude-review:
@@ -35,9 +34,7 @@ jobs:
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
 
-          # Haiku is ~5x cheaper per token than Opus and sufficient for this
-          # deterministic SQL rule-check (hardcoded UUIDs in INSERT/spCreate*).
-          model: claude-haiku-4-5
+          model: claude-opus-4-8
 
           direct_prompt: |
             Please review this PR and provide inline feedback using the GitHub review system. Follow these steps:

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -6,12 +6,13 @@ on:
     # Not re-running review on updates
     # types: [opened, synchronize]
     branches: [next]
-    # Optional: Only run on specific file changes
-    # paths:
-    #   - "src/**/*.ts"
-    #   - "src/**/*.tsx"
-    #   - "src/**/*.js"
-    #   - "src/**/*.jsx"
+    # The review prompt below only covers migrations/*.sql — skip the whole run
+    # (zero runner minutes, zero API tokens) when a PR touches no migration SQL.
+    # NOTE: keep `claude-review` a NON-required status check. A paths-skipped run
+    # reports "pending" forever; if this check were ever made required it would
+    # block every non-migration PR from merging.
+    paths:
+      - 'migrations/**/*.sql'
 
 jobs:
   claude-review:
@@ -34,7 +35,9 @@ jobs:
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
 
-          model: claude-opus-4-8
+          # Haiku is ~5x cheaper per token than Opus and sufficient for this
+          # deterministic SQL rule-check (hardcoded UUIDs in INSERT/spCreate*).
+          model: claude-haiku-4-5
 
           direct_prompt: |
             Please review this PR and provide inline feedback using the GitHub review system. Follow these steps:

--- a/.github/workflows/generate-release-notes.yml
+++ b/.github/workflows/generate-release-notes.yml
@@ -38,9 +38,15 @@ jobs:
           COUNT=$(find .changeset -maxdepth 1 -name '*.md' ! -iname 'readme.md' | wc -l | tr -d ' ')
           echo "count=$COUNT" >> "$GITHUB_OUTPUT"
 
+      # The changeset gate applies only to the automated PR path. A manual
+      # workflow_dispatch is an explicit human ask — honor it even at 0 pending
+      # changesets (e.g. right after a release, when `changeset version` has
+      # consumed the .md files). Note the dispatch path has a pre-existing
+      # caveat regardless of this gate: the prompt calls get_pull_request with
+      # no PR context, so dispatch runs are only useful alongside an open PR.
       - name: Generate Release Notes with Claude
         id: claude-release-notes
-        if: steps.cs.outputs.count != '0'
+        if: github.event_name == 'workflow_dispatch' || steps.cs.outputs.count != '0'
         uses: anthropics/claude-code-action@beta
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}

--- a/.github/workflows/generate-release-notes.yml
+++ b/.github/workflows/generate-release-notes.yml
@@ -8,6 +8,11 @@ on:
 
 jobs:
   generate-release-notes:
+    # Only run for manual dispatch or genuine release PRs (next -> main). Any other
+    # PR opened to main would otherwise spin up the agent AND destructively overwrite
+    # the PR title/description with a version number. github.head_ref is empty on
+    # workflow_dispatch, so the first clause keeps manual runs working.
+    if: github.event_name == 'workflow_dispatch' || github.head_ref == 'next'
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -24,8 +29,18 @@ jobs:
       - name: Fetch all tags
         run: git fetch --tags
 
+      # Cheap pre-flight: if there is nothing to release (no pending changesets),
+      # skip the paid agent step entirely instead of letting it discover that
+      # after loading full context. find (not `ls | grep`) is pipefail-safe.
+      - name: Check for pending changesets
+        id: cs
+        run: |
+          COUNT=$(find .changeset -maxdepth 1 -name '*.md' ! -iname 'readme.md' | wc -l | tr -d ' ')
+          echo "count=$COUNT" >> "$GITHUB_OUTPUT"
+
       - name: Generate Release Notes with Claude
         id: claude-release-notes
+        if: steps.cs.outputs.count != '0'
         uses: anthropics/claude-code-action@beta
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}


### PR DESCRIPTION
## Why

An audit of our Claude API usage in CI found the spend concentrated in `claude.yml`: it ran Opus 4.8 on every PR opened to `next` (~224/month measured via `gh` for June), but only ~20% of PRs touch the migrations it reviews. That fix now lives in **#3101**, which deletes `claude.yml` and replaces the review with a deterministic grep inside the required "Check migrations" job (zero tokens). This PR carries the remaining two workflows.

## Changes

### `generate-release-notes.yml`
1. **Job guard** `if: github.event_name == 'workflow_dispatch' || github.head_ref == 'next'`. Previously any PR to `main` (hotfix, docs) fired the agent and overwrote the PR title and description with a version number. `head_ref` is empty on dispatch so manual runs keep working.
2. **Changeset pre-flight**. A plain shell step counts pending `.changeset/*.md`; the paid agent step is skipped when there is nothing to release. Manual `workflow_dispatch` bypasses the gate (an explicit human ask always runs). Verified against our changeset flow: `changeset version` runs in `publish.yml` after merge, so real release PRs always carry changesets.

### `claude-command.yml` (@claude bot)
Fires almost never (0 of the last 100 comments), so this is blast radius insurance:
3. Author gate (OWNER/MEMBER/COLLABORATOR + non-bot), pinned `model: claude-sonnet-4-6`, `disallowed_tools: WebSearch,WebFetch`, `timeout-minutes: 20` (default was 6h), and per-thread `concurrency` with `cancel-in-progress`. Known gotchas (private-membership `author_association`, cross-user cancellation) are documented in the file with remediations.

### `claude.yml`
No changes. This PR originally added a paths filter and a model downgrade here; both were dropped in `011717378c` to defer to #3101, whose zero token approach is strictly better for a deterministic rule check. The file is byte identical to `next`, so there is no conflict between the two PRs.

## Deliberately NOT included

- **`--max-turns` caps**: refuted during verification, anthropics/claude-code-action#1177 shows the value is silently dropped on both input paths; `timeout-minutes` is the working bound.
- **`@beta` to `@v1` migration**: breaking input schema change, deferred to a follow-up PR.

## Verification

- All files parse (js-yaml); ruleset re-checked (required check is "Check migrations" only)
- Changeset gate truth table tested, including the zero changeset path under `set -euo pipefail`
- Review feedback from @rkihm-BC addressed in `011717378c`, replies on each thread

🤖 Generated with [Claude Code](https://claude.com/claude-code)
