### PR TITLE
fix(ci): declare @memberjunction/cli devDependency in MJExplorer + MJAPI (unblocks PR unit-test runs)

### DIFF
--- a/.changeset/steady-graphs-link.md
+++ b/.changeset/steady-graphs-link.md
@@ -1,0 +1,5 @@
+---
+"@memberjunction/cli": patch
+---
+
+Declare `@memberjunction/cli` as a devDependency of the MJExplorer and MJAPI apps so their `prebuild` invocation of `mj codegen manifest` always runs against a built CLI. Without the edge, turbo's affected-package PR filtering (`--filter=...[origin/next]`) never selected or ordered the CLI build, leaving the workspace `mj` bin an empty oclif shell — `Error: command codegen:manifest not found` — and MJExplorer's build then failed hard (TS2307) because its generated class-registrations manifest is gitignored and has no committed fallback. The apps themselves are unpublished (`mj_*` is changeset-ignored); this entry records the CLI-consumption contract fix in the release notes.

--- a/package-lock.json
+++ b/package-lock.json
@@ -64791,6 +64791,7 @@
         "mj_generatedentities": "1.0.0"
       },
       "devDependencies": {
+        "@memberjunction/cli": "5.47.0",
         "dotenv": "17.2.4",
         "nodemon": "^3.1.11",
         "ts-node": "^10.9.2",
@@ -65708,6 +65709,7 @@
         "@angular-devkit/build-angular": "21.1.3",
         "@angular/cli": "21.1.3",
         "@angular/compiler-cli": "21.1.3",
+        "@memberjunction/cli": "5.47.0",
         "@types/body-parser": "^1.19.6",
         "typed-assert": "^1.0.9",
         "typescript": "^5.9.3"

--- a/packages/MJAPI/package.json
+++ b/packages/MJAPI/package.json
@@ -19,6 +19,7 @@
   "author": "",
   "license": "ISC",
   "devDependencies": {
+    "@memberjunction/cli": "5.47.0",
     "dotenv": "17.2.4",
     "nodemon": "^3.1.11",
     "ts-node": "^10.9.2",

--- a/packages/MJExplorer/package.json
+++ b/packages/MJExplorer/package.json
@@ -64,6 +64,7 @@
     "@angular-devkit/build-angular": "21.1.3",
     "@angular/cli": "21.1.3",
     "@angular/compiler-cli": "21.1.3",
+    "@memberjunction/cli": "5.47.0",
     "@types/body-parser": "^1.19.6",
     "typed-assert": "^1.0.9",
     "typescript": "^5.9.3"


### PR DESCRIPTION
## Summary

PR-event unit-test runs have been failing since the affected-package filtering landed (#2990, Jul 7) whenever the turbo scope includes `mj_explorer` but not `@memberjunction/cli`:

```
› Error: command codegen:manifest not found
✘ [ERROR] TS2307: Cannot find module './generated/class-registrations-manifest'
```

This declares the missing workspace edge — `@memberjunction/cli` as a `devDependency` of `mj_explorer` and `mj_api`, the two apps whose `prebuild` scripts invoke `mj codegen manifest` and whose generated manifests are **gitignored** (untracked since `22a1d25b34`, Feb 2026), so they hard-fail when the CLI isn't built.

## Root cause

- PR runs build only affected packages: `turbo run build --filter=...[origin/next]`. Nothing declared a dependency on the CLI, so an Angular-touching PR selects the ng packages + `mj_explorer` but never builds `packages/MJCLI` — after a fresh `npm ci` the workspace `mj` bin is an empty oclif shell (`prepack` only, no `prepare`).
- The prebuild's `|| echo 'Warning: … using existing manifest'` fallback swallows the CLI error, but MJExplorer has no committed manifest to fall back to → TS2307.
- **Why it looked flaky**: the same branch (`claude/vibrant-bardeen-xpmgi2`) passed on Jul 11 (stale/huge diff vs `next` happened to pull the CLI into scope) and failed on Jul 12 after syncing with `next` (diff shrank to ng packages only). Deterministic per-scope, not a flake.
- Full-suite push runs on `next` only pass by scheduling luck — the CLI's shallow graph finishes before the apps build. Their logs still show the same `codegen:manifest not found` error mid-run for other packages (which silently fall back to stale committed manifests).

## Fix

One `devDependencies` entry in each app + the two resulting lockfile lines. The edge gives turbo both **selection** (filtered runs now pull `@memberjunction/cli#build` into the task graph) and **ordering** (`dependsOn: ["^build"]` builds the CLI first) — in PR runs, full builds, and fresh local clones alike. Same lesson as the `mj app` dynamic-import bug documented in CLAUDE.md: undeclared dependencies are the bug.

No cycle: the CLI's dependency tree is entirely server-side; nothing in it depends on these apps.

## Verification

- `turbo build --dry=json --filter=mj_explorer` → `@memberjunction/cli#build` present in the task graph (224 tasks, no cycle error)
- `turbo build --dry=json --filter=mj_api` → `@memberjunction/cli#build` present
- Lockfile diff is exactly the two `devDependencies` entries (`npm install --package-lock-only`)
- This PR's own unit-test run is the live proof: it touches `package.json`/`package-lock.json`, which triggers the workflow's full-suite path — but any subsequent Angular-only PR exercises the filtered path with the new edge

## Follow-up (not in this PR)

`ng-bootstrap`, `ng-bootstrap-lite`, `ng-explorer-core`, `mj_codegen_api`, `a2aserver`, and `ai-mcp-server` also invoke `mj codegen manifest` at build and currently fall back silently to stale committed manifests when the CLI isn't built — same edge would fix them (`server-bootstrap-lite` excepted: the CLI depends on it, hence its existing two-phase `.needs-manifest-rebuild` mechanism).

🤖 Generated with [Claude Code](https://claude.com/claude-code)