### PR TITLE
fix(codegen-lib): keep devDependency trees out of lazy configs + package-qualify colliding loader names (fixes red next)

### DIFF
--- a/.changeset/lazy-loaders-align.md
+++ b/.changeset/lazy-loaders-align.md
@@ -1,0 +1,5 @@
+---
+"@memberjunction/codegen-lib": patch
+---
+
+Fix `mj codegen manifest --lazy-config` generating invalid TypeScript when build tooling entered the app's dependency tree. Two fixes: (1) the lazy-config dependency walk now follows runtime `dependencies` only — packages reachable solely through a root `devDependency` (e.g. `@memberjunction/cli` and its server-side tree) no longer contribute browser lazy chunks; (2) loader variable names are package-qualified when two packages expose the same subpath export, so `./plugins` in two packages can never again emit duplicate `const loadPlugins` declarations (TS2451). Broke `next` after #3139 declared the CLI as a devDependency of MJExplorer.

--- a/packages/CodeGenLib/src/Manifest/GenerateClassRegistrationsManifest.ts
+++ b/packages/CodeGenLib/src/Manifest/GenerateClassRegistrationsManifest.ts
@@ -263,7 +263,8 @@ function isPackageExcluded(packageName: string, excludePackages: string[]): bool
 function walkDependencyTree(
     appDir: string,
     log: (msg: string) => void,
-    excludePackages: string[] = []
+    excludePackages: string[] = [],
+    includeRootDevDependencies: boolean = true
 ): Map<string, string> {
     // Map of package name -> resolved directory
     const visited = new Map<string, string>();
@@ -280,8 +281,14 @@ function walkDependencyTree(
         log(`Excluding packages matching: ${excludePackages.join(', ')}`);
     }
 
-    // Seed queue with all direct dependencies (both deps and devDeps for the root app)
-    const allDeps = { ...appPkg.dependencies, ...appPkg.devDependencies };
+    // Seed queue with the root app's direct dependencies. devDeps are included by default
+    // (eager manifests may legitimately register classes from build-time packages), but the
+    // lazy-config walk passes false: lazy chunks become dynamic import() statements in a
+    // BROWSER bundle, and a build tool in devDependencies (e.g. @memberjunction/cli) must not
+    // drag its server-side dependency tree into the app's lazy-load surface.
+    const allDeps = includeRootDevDependencies
+        ? { ...appPkg.dependencies, ...appPkg.devDependencies }
+        : { ...appPkg.dependencies };
     for (const depName of Object.keys(allDeps)) {
         queue.push({ depName, fromDir: appDir });
     }
@@ -1599,7 +1606,38 @@ function groupClassesIntoChunks(
         });
     }
 
-    return Array.from(chunks.values()).sort((a, b) => a.importPath.localeCompare(b.importPath));
+    const sorted = Array.from(chunks.values()).sort((a, b) => a.importPath.localeCompare(b.importPath));
+    uniquifyLoaderVarNames(sorted);
+    return sorted;
+}
+
+/**
+ * Ensures every chunk's loader variable name is unique in the generated file. Subpath-derived
+ * names collide when two packages expose the same subpath export (e.g. './plugins' in both
+ * codegen-lib and metadata-sync produced two `const loadPlugins` → TS2451). Non-colliding
+ * names are left untouched so existing generated files don't churn; every member of a colliding
+ * group is package-qualified, which is deterministic regardless of chunk discovery order.
+ */
+function uniquifyLoaderVarNames(chunks: LazyChunk[]): void {
+    const byName = new Map<string, LazyChunk[]>();
+    for (const chunk of chunks) {
+        const group = byName.get(chunk.loaderVarName) ?? [];
+        group.push(chunk);
+        byName.set(chunk.loaderVarName, group);
+    }
+
+    for (const [name, group] of byName.entries()) {
+        if (group.length < 2) continue;
+        const suffix = name.replace(/^load/, '');
+        group.forEach((chunk, index) => {
+            const qualified = `${buildLoaderVarName(chunk.packageName, '.')}${suffix}`;
+            // Same package + same-named subpaths can't happen (chunkKey is unique per subpath),
+            // but guard against pathological sanitized-name ties with an index suffix.
+            const stillTaken = group.some((other, i) => i < index &&
+                `${buildLoaderVarName(other.packageName, '.')}${suffix}` === qualified);
+            chunk.loaderVarName = stillTaken ? `${qualified}${index}` : qualified;
+        });
+    }
 }
 
 /**
@@ -1904,8 +1942,13 @@ export async function generateClassRegistrationsManifest(
         log('--- Lazy Config Generation ---');
 
         try {
-            // Walk full dep tree (no excludes) to find packages excluded from the eager manifest
-            const fullDepTree = walkDependencyTree(absoluteAppDir, log, []);
+            // Walk full dep tree (no excludes) to find packages excluded from the eager manifest.
+            // Runtime dependencies ONLY (includeRootDevDependencies=false): lazy chunks are
+            // dynamic import()s bundled into the browser app, so packages reachable only through
+            // a devDependency (build tooling like @memberjunction/cli) must never contribute
+            // chunks — they'd pull node-only code into the bundle and collide on loader names
+            // (two packages exposing './plugins' both produced `const loadPlugins`, #3139 fallout).
+            const fullDepTree = walkDependencyTree(absoluteAppDir, log, [], false);
 
             // Detect the package that hosts the lazy config file to prevent self-imports
             const hostPackageName = resolveHostPackage(lazyConfigPath, fullDepTree);

--- a/packages/CodeGenLib/src/__tests__/manifest.test.ts
+++ b/packages/CodeGenLib/src/__tests__/manifest.test.ts
@@ -1232,4 +1232,124 @@ describe('Lazy Config Generation - Integration', () => {
         // Should report an error for the collision
         expect(result.errors.some(e => e.includes('collision') || e.includes('AIModels'))).toBe(true);
     });
+
+    it('should not include packages reachable only through root devDependencies (build tooling)', async () => {
+        // Mirror the #3139 fallout: the app devDepends on a build tool whose RUNTIME deps
+        // include a server-side package with subpath exports + keyed classes. That package
+        // must never contribute browser lazy chunks.
+        virtualFiles[`${appDir}/package.json`] = JSON.stringify({
+            name: 'test-lazy-app',
+            dependencies: { '@test/dashboards': '1.0.0' },
+            devDependencies: { '@test/buildtool': '1.0.0' }
+        }, null, 2);
+
+        virtualFiles[`${appDir}/node_modules/@test/buildtool/package.json`] = JSON.stringify({
+            name: '@test/buildtool',
+            version: '1.0.0',
+            dependencies: { '@test/serverlib': '1.0.0' }
+        });
+
+        virtualFiles[`${appDir}/node_modules/@test/serverlib/package.json`] = JSON.stringify({
+            name: '@test/serverlib',
+            version: '1.0.0',
+            exports: {
+                '.': { types: './dist/index.d.ts', default: './dist/index.js' },
+                './plugins': { types: './dist/plugins.d.ts', default: './dist/plugins.js' }
+            },
+            dependencies: {}
+        });
+        virtualFiles[`${appDir}/node_modules/@test/serverlib/dist/index.d.ts`] = 'export {};\n';
+        virtualFiles[`${appDir}/node_modules/@test/serverlib/dist/plugins.d.ts`] =
+            'import * as i0 from "./plugins/server.plugin";\nexport declare class ServerPluginsModule {}\n';
+        virtualFiles[`${appDir}/node_modules/@test/serverlib/dist/plugins/server.plugin.d.ts`] =
+            'export declare class ServerPlugin extends BaseResourceComponent {}\n';
+        virtualFiles[`${appDir}/node_modules/@test/serverlib/src/plugins/server.plugin.ts`] = [
+            "import { RegisterClass } from '@memberjunction/global';",
+            "@RegisterClass(BaseResourceComponent, 'ServerPlugin')",
+            "export class ServerPlugin extends BaseResourceComponent {}"
+        ].join('\n');
+
+        const result = await generateClassRegistrationsManifest({
+            outputPath,
+            appDir,
+            verbose: false,
+            syncDependencies: false,
+            excludePackages: ['@test/'],
+            lazyConfigPath,
+            lazyBaseClasses: ['BaseResourceComponent'],
+        });
+
+        expect(result.success).toBe(true);
+        const lazyWrite = writtenFiles.find(w => w.path === lazyConfigPath);
+        expect(lazyWrite).toBeDefined();
+        const content = lazyWrite!.content;
+
+        // Runtime-dependency chunks are present...
+        expect(content).toContain("'BaseResourceComponent::AIModels'");
+        // ...but nothing reachable only via the devDependency made it in
+        expect(content).not.toContain('@test/serverlib');
+        expect(content).not.toContain('ServerPlugin');
+    });
+
+    it('should package-qualify loader variable names when two packages share a subpath name', async () => {
+        // Two runtime dependencies both exposing './plugins' — subpath-derived loader names
+        // would both be `loadPlugins` (TS2451 redeclaration in the generated file).
+        function addPluginPackage(shortName: string, key: string): void {
+            const pkgRoot = `${appDir}/node_modules/@test/${shortName}`;
+            virtualFiles[`${pkgRoot}/package.json`] = JSON.stringify({
+                name: `@test/${shortName}`,
+                version: '1.0.0',
+                exports: {
+                    '.': { types: './dist/index.d.ts', default: './dist/index.js' },
+                    './plugins': { types: './dist/plugins.d.ts', default: './dist/plugins.js' }
+                },
+                dependencies: {}
+            });
+            virtualFiles[`${pkgRoot}/dist/index.d.ts`] = 'export {};\n';
+            virtualFiles[`${pkgRoot}/dist/plugins.d.ts`] =
+                `import * as i0 from "./plugins/${shortName}.plugin";\nexport declare class ${key}Module {}\n`;
+            virtualFiles[`${pkgRoot}/dist/plugins/${shortName}.plugin.d.ts`] =
+                `export declare class ${key} extends BaseResourceComponent {}\n`;
+            virtualFiles[`${pkgRoot}/src/plugins/${shortName}.plugin.ts`] = [
+                "import { RegisterClass } from '@memberjunction/global';",
+                `@RegisterClass(BaseResourceComponent, '${key}')`,
+                `export class ${key} extends BaseResourceComponent {}`
+            ].join('\n');
+        }
+
+        virtualFiles[`${appDir}/package.json`] = JSON.stringify({
+            name: 'test-lazy-app',
+            dependencies: { '@test/alpha': '1.0.0', '@test/beta': '1.0.0' }
+        }, null, 2);
+        addPluginPackage('alpha', 'AlphaPlugin');
+        addPluginPackage('beta', 'BetaPlugin');
+
+        const result = await generateClassRegistrationsManifest({
+            outputPath,
+            appDir,
+            verbose: false,
+            syncDependencies: false,
+            excludePackages: ['@test/'],
+            lazyConfigPath,
+            lazyBaseClasses: ['BaseResourceComponent'],
+        });
+
+        expect(result.success).toBe(true);
+        const lazyWrite = writtenFiles.find(w => w.path === lazyConfigPath);
+        expect(lazyWrite).toBeDefined();
+        const content = lazyWrite!.content;
+
+        // No bare collision-prone name — both members of the colliding group get qualified
+        expect(content).not.toContain('const loadPlugins ');
+        expect(content).toContain('const loadAlphaPlugins ');
+        expect(content).toContain('const loadBetaPlugins ');
+
+        // Every declared loader const is unique (the actual TS2451 guarantee)
+        const declared = [...content.matchAll(/const (load\w+) =/g)].map(m => m[1]);
+        expect(new Set(declared).size).toBe(declared.length);
+
+        // Keys still map to their (renamed) loaders
+        expect(content).toMatch(/'BaseResourceComponent::AlphaPlugin':\s*loadAlphaPlugins/);
+        expect(content).toMatch(/'BaseResourceComponent::BetaPlugin':\s*loadBetaPlugins/);
+    });
 });


### PR DESCRIPTION
## Summary

`next` went red after #3139 merged — its full-suite build fails in `ng-explorer-core` with:

```
src/generated/lazy-feature-config.ts:20:7 - error TS2451: Cannot redeclare block-scoped variable 'loadPlugins'.
src/generated/lazy-feature-config.ts:23:7 - error TS2451: Cannot redeclare block-scoped variable 'loadPlugins'.
```

This is second-order fallout from #3139 working as intended: with `@memberjunction/cli` now a devDependency of MJExplorer (and the CLI actually built in CI), `ng-explorer-core`'s prebuild regenerates `lazy-feature-config.ts` for real — and the generator has two latent defects that the new dependency edge exposed:

1. **The lazy-config dependency walk seeded from `dependencies` + `devDependencies`** at the app root. The CLI devDep pulled its runtime tree (`codegen-lib`, `metadata-sync`) into the scan; both expose a `./plugins` subpath export with keyed `@RegisterClass` classes, so both became browser lazy chunks. Server-side build tooling must never enter an Angular app's lazy-load surface — those chunks are dynamic `import()`s that would drag node-only code into the bundle.
2. **`buildLoaderVarName` derives subpath-chunk names from the subpath alone**, so two packages exposing `./plugins` both emitted `const loadPlugins` → TS2451.

## Fix

- `walkDependencyTree` gains an `includeRootDevDependencies` flag (default `true`, eager-manifest behavior unchanged). The **lazy-config walk passes `false`** — lazy chunks now come only from packages reachable via runtime `dependencies`.
- New `uniquifyLoaderVarNames` post-pass: any group of chunks sharing a loader name gets package-qualified names (`loadPlugins` → `loadCodegenLibPlugins` / `loadMetadataSyncPlugins` style), deterministically regardless of discovery order, with non-colliding names left untouched (zero churn in existing generated files). Defense-in-depth for the day two *legitimate* Angular packages share a subpath name.

## Verification

- `tsc --noEmit` clean on `CodeGenLib`
- Full CodeGenLib suite: **583 passed / 60 skipped**, including two new regression tests:
  - `should not include packages reachable only through root devDependencies (build tooling)` — mirrors the exact #3139 topology (root devDep → its runtime dep with `./plugins` + keyed classes)
  - `should package-qualify loader variable names when two packages share a subpath name` — asserts no duplicate `const load*` declarations and that keys map to the renamed loaders
- Reproduction fidelity: all four packages in the committed `lazy-feature-config.ts` (`ng-dashboards`, `ng-explorer-settings`, `ng-file-storage`, `ng-react`) are reachable via runtime `dependencies`, so the runtime-only walk regenerates the committed file byte-identically — CI's regeneration becomes a no-op again, exactly as before #3139.

## Notes

- Changeset included (`@memberjunction/codegen-lib`: patch).
- The eager-manifest walk intentionally still includes root devDependencies — only the lazy path changes, since that's the browser-bundle surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)