### PR TITLE
fix: Form apply, OpenApp schemas, RenderedSQL, MaxRows, codegen manifest, PG provider

### DIFF
--- a/.changeset/bright-foxes-dance.md
+++ b/.changeset/bright-foxes-dance.md
@@ -1,0 +1,13 @@
+---
+"@memberjunction/ng-artifacts": patch
+"@memberjunction/ng-conversations": patch
+"@memberjunction/ng-explorer-core": patch
+"@memberjunction/generic-database-provider": patch
+"@memberjunction/core": patch
+"@memberjunction/server": patch
+"@memberjunction/open-app-engine": patch
+"@memberjunction/codegen-lib": patch
+"@memberjunction/postgresql-dataprovider": patch
+---
+
+Fix Apply to my Form (resolve spec code, handle Pending overrides, improve # typeahead), auto-add app schemas to excludeSchemas on OpenApp install/upgrade, surface RenderedSQL through RunQueryResult and TestQuerySQL, strip ORDER BY before outer-wrapping unparseable SQL in MaxRows, fix lazy-config loader variable name collisions in codegen manifest, and add read-only provider support and missing SQL function keywords in PostgreSQL provider

--- a/packages/Angular/Explorer/explorer-core/src/generated/lazy-feature-config.ts
+++ b/packages/Angular/Explorer/explorer-core/src/generated/lazy-feature-config.ts
@@ -16,56 +16,62 @@ function featureLoader(importFn: () => Promise<unknown>): () => Promise<void> {
   return () => importFn().then(() => {});
 }
 
+// --- @memberjunction/codegen-lib → ./plugins (1 entries) ---
+const loadCodegenLibPlugins = featureLoader(() => import('@memberjunction/codegen-lib/plugins'));
+
+// --- @memberjunction/metadata-sync → ./plugins (2 entries) ---
+const loadMetadataSyncPlugins = featureLoader(() => import('@memberjunction/metadata-sync/plugins'));
+
 // --- @memberjunction/ng-dashboards → ./actions-dashboards.module (7 entries) ---
-const loadActionsDashboardsModule = featureLoader(() => import('@memberjunction/ng-dashboards/actions-dashboards.module'));
+const loadNgDashboardsActionsDashboardsModule = featureLoader(() => import('@memberjunction/ng-dashboards/actions-dashboards.module'));
 
 // --- @memberjunction/ng-dashboards → ./ai-dashboards.module (17 entries) ---
-const loadAiDashboardsModule = featureLoader(() => import('@memberjunction/ng-dashboards/ai-dashboards.module'));
+const loadNgDashboardsAiDashboardsModule = featureLoader(() => import('@memberjunction/ng-dashboards/ai-dashboards.module'));
 
 // --- @memberjunction/ng-dashboards → ./communication-dashboards.module (7 entries) ---
-const loadCommunicationDashboardsModule = featureLoader(() => import('@memberjunction/ng-dashboards/communication-dashboards.module'));
+const loadNgDashboardsCommunicationDashboardsModule = featureLoader(() => import('@memberjunction/ng-dashboards/communication-dashboards.module'));
 
 // --- @memberjunction/ng-dashboards → ./component-studio-dashboards.module (3 entries) ---
-const loadComponentStudioDashboardsModule = featureLoader(() => import('@memberjunction/ng-dashboards/component-studio-dashboards.module'));
+const loadNgDashboardsComponentStudioDashboardsModule = featureLoader(() => import('@memberjunction/ng-dashboards/component-studio-dashboards.module'));
 
 // --- @memberjunction/ng-dashboards → ./core-dashboards.module (30 entries) ---
-const loadCoreDashboardsModule = featureLoader(() => import('@memberjunction/ng-dashboards/core-dashboards.module'));
+const loadNgDashboardsCoreDashboardsModule = featureLoader(() => import('@memberjunction/ng-dashboards/core-dashboards.module'));
 
 // --- @memberjunction/ng-dashboards → ./credentials-dashboards.module (6 entries) ---
-const loadCredentialsDashboardsModule = featureLoader(() => import('@memberjunction/ng-dashboards/credentials-dashboards.module'));
+const loadNgDashboardsCredentialsDashboardsModule = featureLoader(() => import('@memberjunction/ng-dashboards/credentials-dashboards.module'));
 
 // --- @memberjunction/ng-dashboards → ./data-explorer-dashboards.module (2 entries) ---
-const loadDataExplorerDashboardsModule = featureLoader(() => import('@memberjunction/ng-dashboards/data-explorer-dashboards.module'));
+const loadNgDashboardsDataExplorerDashboardsModule = featureLoader(() => import('@memberjunction/ng-dashboards/data-explorer-dashboards.module'));
 
 // --- @memberjunction/ng-dashboards → ./integration.module (6 entries) ---
-const loadIntegrationModule = featureLoader(() => import('@memberjunction/ng-dashboards/integration.module'));
+const loadNgDashboardsIntegrationModule = featureLoader(() => import('@memberjunction/ng-dashboards/integration.module'));
 
 // --- @memberjunction/ng-dashboards → ./lists-dashboards.module (5 entries) ---
-const loadListsDashboardsModule = featureLoader(() => import('@memberjunction/ng-dashboards/lists-dashboards.module'));
+const loadNgDashboardsListsDashboardsModule = featureLoader(() => import('@memberjunction/ng-dashboards/lists-dashboards.module'));
 
 // --- @memberjunction/ng-dashboards → ./mcp.module (2 entries) ---
-const loadMcpModule = featureLoader(() => import('@memberjunction/ng-dashboards/mcp.module'));
+const loadNgDashboardsMcpModule = featureLoader(() => import('@memberjunction/ng-dashboards/mcp.module'));
 
 // --- @memberjunction/ng-dashboards → ./module (3 entries) ---
-const loadModule = featureLoader(() => import('@memberjunction/ng-dashboards/module'));
+const loadNgDashboardsModule = featureLoader(() => import('@memberjunction/ng-dashboards/module'));
 
 // --- @memberjunction/ng-dashboards → ./predictive-studio-dashboards.module (3 entries) ---
-const loadPredictiveStudioDashboardsModule = featureLoader(() => import('@memberjunction/ng-dashboards/predictive-studio-dashboards.module'));
+const loadNgDashboardsPredictiveStudioDashboardsModule = featureLoader(() => import('@memberjunction/ng-dashboards/predictive-studio-dashboards.module'));
 
 // --- @memberjunction/ng-dashboards → ./routines-dashboards.module (1 entries) ---
-const loadRoutinesDashboardsModule = featureLoader(() => import('@memberjunction/ng-dashboards/routines-dashboards.module'));
+const loadNgDashboardsRoutinesDashboardsModule = featureLoader(() => import('@memberjunction/ng-dashboards/routines-dashboards.module'));
 
 // --- @memberjunction/ng-dashboards → ./scheduling-dashboards.module (4 entries) ---
-const loadSchedulingDashboardsModule = featureLoader(() => import('@memberjunction/ng-dashboards/scheduling-dashboards.module'));
+const loadNgDashboardsSchedulingDashboardsModule = featureLoader(() => import('@memberjunction/ng-dashboards/scheduling-dashboards.module'));
 
 // --- @memberjunction/ng-dashboards → ./testing-dashboards.module (6 entries) ---
-const loadTestingDashboardsModule = featureLoader(() => import('@memberjunction/ng-dashboards/testing-dashboards.module'));
+const loadNgDashboardsTestingDashboardsModule = featureLoader(() => import('@memberjunction/ng-dashboards/testing-dashboards.module'));
 
 // --- @memberjunction/ng-explorer-settings → ./settings.module (6 entries) ---
-const loadSettingsModule = featureLoader(() => import('@memberjunction/ng-explorer-settings/settings.module'));
+const loadNgExplorerSettingsSettingsModule = featureLoader(() => import('@memberjunction/ng-explorer-settings/settings.module'));
 
 // --- @memberjunction/ng-file-storage → ./file-storage.module (1 entries) ---
-const loadFileStorageModule = featureLoader(() => import('@memberjunction/ng-file-storage/file-storage.module'));
+const loadNgFileStorageFileStorageModule = featureLoader(() => import('@memberjunction/ng-file-storage/file-storage.module'));
 
 // --- @memberjunction/ng-react → . (1 entries) ---
 const loadNgReact = featureLoader(() => import('@memberjunction/ng-react'));
@@ -75,152 +81,159 @@ const loadNgReact = featureLoader(() => import('@memberjunction/ng-react'));
  * Covers all @RegisterClass decorated classes in lazy-loaded packages.
  */
 export const LAZY_FEATURE_CONFIG: Record<string, () => Promise<void>> = {
+  // @memberjunction/codegen-lib → ./plugins
+  'BaseCLIPlugin::codegen': loadCodegenLibPlugins,
+
+  // @memberjunction/metadata-sync → ./plugins
+  'BaseCLIPlugin::sync:pull': loadMetadataSyncPlugins,
+  'BaseCLIPlugin::sync:push': loadMetadataSyncPlugins,
+
   // @memberjunction/ng-dashboards → ./actions-dashboards.module
-  'BaseResourceComponent::ActionExplorerResource': loadActionsDashboardsModule,
-  'BaseResourceComponent::ActionsCodeResource': loadActionsDashboardsModule,
-  'BaseResourceComponent::ActionsEntitiesResource': loadActionsDashboardsModule,
-  'BaseResourceComponent::ActionsMonitorResource': loadActionsDashboardsModule,
-  'BaseResourceComponent::ActionsOverviewResource': loadActionsDashboardsModule,
-  'BaseResourceComponent::ActionsScheduleResource': loadActionsDashboardsModule,
-  'BaseResourceComponent::ActionsSecurityResource': loadActionsDashboardsModule,
+  'BaseResourceComponent::ActionExplorerResource': loadNgDashboardsActionsDashboardsModule,
+  'BaseResourceComponent::ActionsCodeResource': loadNgDashboardsActionsDashboardsModule,
+  'BaseResourceComponent::ActionsEntitiesResource': loadNgDashboardsActionsDashboardsModule,
+  'BaseResourceComponent::ActionsMonitorResource': loadNgDashboardsActionsDashboardsModule,
+  'BaseResourceComponent::ActionsOverviewResource': loadNgDashboardsActionsDashboardsModule,
+  'BaseResourceComponent::ActionsScheduleResource': loadNgDashboardsActionsDashboardsModule,
+  'BaseResourceComponent::ActionsSecurityResource': loadNgDashboardsActionsDashboardsModule,
 
   // @memberjunction/ng-dashboards → ./ai-dashboards.module
-  'BaseResourceComponent::AIAgentRequestsResource': loadAiDashboardsModule,
-  'BaseResourceComponent::AIAgentsResource': loadAiDashboardsModule,
-  'BaseResourceComponent::AIAnalyticsResource': loadAiDashboardsModule,
-  'BaseResourceComponent::AIConfigResource': loadAiDashboardsModule,
-  'BaseResourceComponent::AIModelsResource': loadAiDashboardsModule,
-  'BaseResourceComponent::AIMonitorResource': loadAiDashboardsModule,
-  'BaseResourceComponent::AIPromptsResource': loadAiDashboardsModule,
-  'BaseResourceComponent::AnalyticsResource': loadAiDashboardsModule,
-  'BaseResourceComponent::AutotaggingPipelineResource': loadAiDashboardsModule,
-  'BaseResourceComponent::ClusterVisualizationResource': loadAiDashboardsModule,
-  'BaseResourceComponent::DuplicateDetectionResource': loadAiDashboardsModule,
-  'BaseResourceComponent::FeaturePipelinesResource': loadAiDashboardsModule,
-  'BaseResourceComponent::KnowledgeConfigResource': loadAiDashboardsModule,
-  'BaseResourceComponent::SchedulingResource': loadAiDashboardsModule,
-  'BaseResourceComponent::Tags': loadAiDashboardsModule,
-  'BaseResourceComponent::VectorManagementResource': loadAiDashboardsModule,
-  'BaseResourceComponent::VisualizationResource': loadAiDashboardsModule,
+  'BaseResourceComponent::AIAgentRequestsResource': loadNgDashboardsAiDashboardsModule,
+  'BaseResourceComponent::AIAgentsResource': loadNgDashboardsAiDashboardsModule,
+  'BaseResourceComponent::AIAnalyticsResource': loadNgDashboardsAiDashboardsModule,
+  'BaseResourceComponent::AIConfigResource': loadNgDashboardsAiDashboardsModule,
+  'BaseResourceComponent::AIModelsResource': loadNgDashboardsAiDashboardsModule,
+  'BaseResourceComponent::AIMonitorResource': loadNgDashboardsAiDashboardsModule,
+  'BaseResourceComponent::AIPromptsResource': loadNgDashboardsAiDashboardsModule,
+  'BaseResourceComponent::AnalyticsResource': loadNgDashboardsAiDashboardsModule,
+  'BaseResourceComponent::AutotaggingPipelineResource': loadNgDashboardsAiDashboardsModule,
+  'BaseResourceComponent::ClusterVisualizationResource': loadNgDashboardsAiDashboardsModule,
+  'BaseResourceComponent::DuplicateDetectionResource': loadNgDashboardsAiDashboardsModule,
+  'BaseResourceComponent::FeaturePipelinesResource': loadNgDashboardsAiDashboardsModule,
+  'BaseResourceComponent::KnowledgeConfigResource': loadNgDashboardsAiDashboardsModule,
+  'BaseResourceComponent::SchedulingResource': loadNgDashboardsAiDashboardsModule,
+  'BaseResourceComponent::Tags': loadNgDashboardsAiDashboardsModule,
+  'BaseResourceComponent::VectorManagementResource': loadNgDashboardsAiDashboardsModule,
+  'BaseResourceComponent::VisualizationResource': loadNgDashboardsAiDashboardsModule,
 
   // @memberjunction/ng-dashboards → ./communication-dashboards.module
-  'BaseDashboard::CommunicationDashboard': loadCommunicationDashboardsModule,
-  'BaseResourceComponent::CommunicationLogsResource': loadCommunicationDashboardsModule,
-  'BaseResourceComponent::CommunicationMonitorResource': loadCommunicationDashboardsModule,
-  'BaseResourceComponent::CommunicationProvidersResource': loadCommunicationDashboardsModule,
-  'BaseResourceComponent::CommunicationRunsResource': loadCommunicationDashboardsModule,
-  'BaseResourceComponent::CommunicationsNewMessageResource': loadCommunicationDashboardsModule,
-  'BaseResourceComponent::CommunicationTemplatesResource': loadCommunicationDashboardsModule,
+  'BaseDashboard::CommunicationDashboard': loadNgDashboardsCommunicationDashboardsModule,
+  'BaseResourceComponent::CommunicationLogsResource': loadNgDashboardsCommunicationDashboardsModule,
+  'BaseResourceComponent::CommunicationMonitorResource': loadNgDashboardsCommunicationDashboardsModule,
+  'BaseResourceComponent::CommunicationProvidersResource': loadNgDashboardsCommunicationDashboardsModule,
+  'BaseResourceComponent::CommunicationRunsResource': loadNgDashboardsCommunicationDashboardsModule,
+  'BaseResourceComponent::CommunicationsNewMessageResource': loadNgDashboardsCommunicationDashboardsModule,
+  'BaseResourceComponent::CommunicationTemplatesResource': loadNgDashboardsCommunicationDashboardsModule,
 
   // @memberjunction/ng-dashboards → ./component-studio-dashboards.module
-  'BaseDashboard::ComponentStudioDashboard': loadComponentStudioDashboardsModule,
-  'BaseResourceComponent::ComponentStudioResource': loadComponentStudioDashboardsModule,
-  'BaseResourceComponent::FormBuilderResource': loadComponentStudioDashboardsModule,
+  'BaseDashboard::ComponentStudioDashboard': loadNgDashboardsComponentStudioDashboardsModule,
+  'BaseResourceComponent::ComponentStudioResource': loadNgDashboardsComponentStudioDashboardsModule,
+  'BaseResourceComponent::FormBuilderResource': loadNgDashboardsComponentStudioDashboardsModule,
 
   // @memberjunction/ng-dashboards → ./core-dashboards.module
-  'BaseApplication::HomeApplication': loadCoreDashboardsModule,
-  'BaseDashboard::EntityAdmin': loadCoreDashboardsModule,
-  'BaseResourceComponent::AdminDataSchema': loadCoreDashboardsModule,
-  'BaseResourceComponent::AdminDeveloperTools': loadCoreDashboardsModule,
-  'BaseResourceComponent::AdminIdentityAccess': loadCoreDashboardsModule,
-  'BaseResourceComponent::AdminMonitoring': loadCoreDashboardsModule,
-  'BaseResourceComponent::APIKeysResource': loadCoreDashboardsModule,
-  'BaseResourceComponent::ApplicationRolesResource': loadCoreDashboardsModule,
-  'BaseResourceComponent::AppStateInspector': loadCoreDashboardsModule,
-  'BaseResourceComponent::BulkOperationsContainer': loadCoreDashboardsModule,
-  'BaseResourceComponent::BulkOperationsOperations': loadCoreDashboardsModule,
-  'BaseResourceComponent::BulkOperationsRunHistory': loadCoreDashboardsModule,
-  'BaseResourceComponent::ClassRegistryInspector': loadCoreDashboardsModule,
-  'BaseResourceComponent::DashboardBrowserResource': loadCoreDashboardsModule,
-  'BaseResourceComponent::EventMonitorInspector': loadCoreDashboardsModule,
-  'BaseResourceComponent::GraphQLConsoleInspector': loadCoreDashboardsModule,
-  'BaseResourceComponent::HomeDashboard': loadCoreDashboardsModule,
-  'BaseResourceComponent::LayoutInspector': loadCoreDashboardsModule,
-  'BaseResourceComponent::LazyModuleStatusInspector': loadCoreDashboardsModule,
-  'BaseResourceComponent::PermissionsAuditLogResource': loadCoreDashboardsModule,
-  'BaseResourceComponent::PermissionsResourceAccessResource': loadCoreDashboardsModule,
-  'BaseResourceComponent::PermissionsUserAccessResource': loadCoreDashboardsModule,
-  'BaseResourceComponent::QueryBrowserResource': loadCoreDashboardsModule,
-  'BaseResourceComponent::RealtimeRecordingsDashboard': loadCoreDashboardsModule,
-  'BaseResourceComponent::SettingsExplorerInspector': loadCoreDashboardsModule,
-  'BaseResourceComponent::SystemDiagnosticsResource': loadCoreDashboardsModule,
-  'BaseResourceComponent::VersionHistoryDiffResource': loadCoreDashboardsModule,
-  'BaseResourceComponent::VersionHistoryGraphResource': loadCoreDashboardsModule,
-  'BaseResourceComponent::VersionHistoryLabelsResource': loadCoreDashboardsModule,
-  'BaseResourceComponent::VersionHistoryRestoreResource': loadCoreDashboardsModule,
+  'BaseApplication::HomeApplication': loadNgDashboardsCoreDashboardsModule,
+  'BaseDashboard::EntityAdmin': loadNgDashboardsCoreDashboardsModule,
+  'BaseResourceComponent::AdminDataSchema': loadNgDashboardsCoreDashboardsModule,
+  'BaseResourceComponent::AdminDeveloperTools': loadNgDashboardsCoreDashboardsModule,
+  'BaseResourceComponent::AdminIdentityAccess': loadNgDashboardsCoreDashboardsModule,
+  'BaseResourceComponent::AdminMonitoring': loadNgDashboardsCoreDashboardsModule,
+  'BaseResourceComponent::APIKeysResource': loadNgDashboardsCoreDashboardsModule,
+  'BaseResourceComponent::ApplicationRolesResource': loadNgDashboardsCoreDashboardsModule,
+  'BaseResourceComponent::AppStateInspector': loadNgDashboardsCoreDashboardsModule,
+  'BaseResourceComponent::BulkOperationsContainer': loadNgDashboardsCoreDashboardsModule,
+  'BaseResourceComponent::BulkOperationsOperations': loadNgDashboardsCoreDashboardsModule,
+  'BaseResourceComponent::BulkOperationsRunHistory': loadNgDashboardsCoreDashboardsModule,
+  'BaseResourceComponent::ClassRegistryInspector': loadNgDashboardsCoreDashboardsModule,
+  'BaseResourceComponent::DashboardBrowserResource': loadNgDashboardsCoreDashboardsModule,
+  'BaseResourceComponent::EventMonitorInspector': loadNgDashboardsCoreDashboardsModule,
+  'BaseResourceComponent::GraphQLConsoleInspector': loadNgDashboardsCoreDashboardsModule,
+  'BaseResourceComponent::HomeDashboard': loadNgDashboardsCoreDashboardsModule,
+  'BaseResourceComponent::LayoutInspector': loadNgDashboardsCoreDashboardsModule,
+  'BaseResourceComponent::LazyModuleStatusInspector': loadNgDashboardsCoreDashboardsModule,
+  'BaseResourceComponent::PermissionsAuditLogResource': loadNgDashboardsCoreDashboardsModule,
+  'BaseResourceComponent::PermissionsResourceAccessResource': loadNgDashboardsCoreDashboardsModule,
+  'BaseResourceComponent::PermissionsUserAccessResource': loadNgDashboardsCoreDashboardsModule,
+  'BaseResourceComponent::QueryBrowserResource': loadNgDashboardsCoreDashboardsModule,
+  'BaseResourceComponent::RealtimeRecordingsDashboard': loadNgDashboardsCoreDashboardsModule,
+  'BaseResourceComponent::SettingsExplorerInspector': loadNgDashboardsCoreDashboardsModule,
+  'BaseResourceComponent::SystemDiagnosticsResource': loadNgDashboardsCoreDashboardsModule,
+  'BaseResourceComponent::VersionHistoryDiffResource': loadNgDashboardsCoreDashboardsModule,
+  'BaseResourceComponent::VersionHistoryGraphResource': loadNgDashboardsCoreDashboardsModule,
+  'BaseResourceComponent::VersionHistoryLabelsResource': loadNgDashboardsCoreDashboardsModule,
+  'BaseResourceComponent::VersionHistoryRestoreResource': loadNgDashboardsCoreDashboardsModule,
 
   // @memberjunction/ng-dashboards → ./credentials-dashboards.module
-  'BaseDashboard::CredentialsDashboard': loadCredentialsDashboardsModule,
-  'BaseResourceComponent::CredentialsAuditResource': loadCredentialsDashboardsModule,
-  'BaseResourceComponent::CredentialsCategoriesResource': loadCredentialsDashboardsModule,
-  'BaseResourceComponent::CredentialsListResource': loadCredentialsDashboardsModule,
-  'BaseResourceComponent::CredentialsOverviewResource': loadCredentialsDashboardsModule,
-  'BaseResourceComponent::CredentialsTypesResource': loadCredentialsDashboardsModule,
+  'BaseDashboard::CredentialsDashboard': loadNgDashboardsCredentialsDashboardsModule,
+  'BaseResourceComponent::CredentialsAuditResource': loadNgDashboardsCredentialsDashboardsModule,
+  'BaseResourceComponent::CredentialsCategoriesResource': loadNgDashboardsCredentialsDashboardsModule,
+  'BaseResourceComponent::CredentialsListResource': loadNgDashboardsCredentialsDashboardsModule,
+  'BaseResourceComponent::CredentialsOverviewResource': loadNgDashboardsCredentialsDashboardsModule,
+  'BaseResourceComponent::CredentialsTypesResource': loadNgDashboardsCredentialsDashboardsModule,
 
   // @memberjunction/ng-dashboards → ./data-explorer-dashboards.module
-  'BaseDashboard::DataExplorer': loadDataExplorerDashboardsModule,
-  'BaseResourceComponent::DataExplorerResource': loadDataExplorerDashboardsModule,
+  'BaseDashboard::DataExplorer': loadNgDashboardsDataExplorerDashboardsModule,
+  'BaseResourceComponent::DataExplorerResource': loadNgDashboardsDataExplorerDashboardsModule,
 
   // @memberjunction/ng-dashboards → ./integration.module
-  'BaseResourceComponent::IntegrationActivity': loadIntegrationModule,
-  'BaseResourceComponent::IntegrationConnections': loadIntegrationModule,
-  'BaseResourceComponent::IntegrationMappingWorkspace': loadIntegrationModule,
-  'BaseResourceComponent::IntegrationOverview': loadIntegrationModule,
-  'BaseResourceComponent::IntegrationPipelines': loadIntegrationModule,
-  'BaseResourceComponent::IntegrationSchedules': loadIntegrationModule,
+  'BaseResourceComponent::IntegrationActivity': loadNgDashboardsIntegrationModule,
+  'BaseResourceComponent::IntegrationConnections': loadNgDashboardsIntegrationModule,
+  'BaseResourceComponent::IntegrationMappingWorkspace': loadNgDashboardsIntegrationModule,
+  'BaseResourceComponent::IntegrationOverview': loadNgDashboardsIntegrationModule,
+  'BaseResourceComponent::IntegrationPipelines': loadNgDashboardsIntegrationModule,
+  'BaseResourceComponent::IntegrationSchedules': loadNgDashboardsIntegrationModule,
 
   // @memberjunction/ng-dashboards → ./lists-dashboards.module
-  'BaseResourceComponent::ListsBrowseResource': loadListsDashboardsModule,
-  'BaseResourceComponent::ListsCategoriesResource': loadListsDashboardsModule,
-  'BaseResourceComponent::ListsMyListsResource': loadListsDashboardsModule,
-  'BaseResourceComponent::ListsOperationsResource': loadListsDashboardsModule,
-  'BaseResourceComponent::ListsSharedWithMeResource': loadListsDashboardsModule,
+  'BaseResourceComponent::ListsBrowseResource': loadNgDashboardsListsDashboardsModule,
+  'BaseResourceComponent::ListsCategoriesResource': loadNgDashboardsListsDashboardsModule,
+  'BaseResourceComponent::ListsMyListsResource': loadNgDashboardsListsDashboardsModule,
+  'BaseResourceComponent::ListsOperationsResource': loadNgDashboardsListsDashboardsModule,
+  'BaseResourceComponent::ListsSharedWithMeResource': loadNgDashboardsListsDashboardsModule,
 
   // @memberjunction/ng-dashboards → ./mcp.module
-  'BaseDashboard::MCPDashboard': loadMcpModule,
-  'BaseResourceComponent::MCPResource': loadMcpModule,
+  'BaseDashboard::MCPDashboard': loadNgDashboardsMcpModule,
+  'BaseResourceComponent::MCPResource': loadNgDashboardsMcpModule,
 
   // @memberjunction/ng-dashboards → ./module
-  'BaseResourceComponent::ArchiveConfigResource': loadModule,
-  'BaseResourceComponent::ArchiveRunsResource': loadModule,
-  'BaseResourceComponent::DatabaseDesignerDashboard': loadModule,
+  'BaseResourceComponent::ArchiveConfigResource': loadNgDashboardsModule,
+  'BaseResourceComponent::ArchiveRunsResource': loadNgDashboardsModule,
+  'BaseResourceComponent::DatabaseDesignerDashboard': loadNgDashboardsModule,
 
   // @memberjunction/ng-dashboards → ./predictive-studio-dashboards.module
-  'BaseResourceComponent::PredictiveStudioModelsResource': loadPredictiveStudioDashboardsModule,
-  'BaseResourceComponent::PredictiveStudioPredictionsResource': loadPredictiveStudioDashboardsModule,
-  'BaseResourceComponent::PredictiveStudioStudioResource': loadPredictiveStudioDashboardsModule,
+  'BaseResourceComponent::PredictiveStudioModelsResource': loadNgDashboardsPredictiveStudioDashboardsModule,
+  'BaseResourceComponent::PredictiveStudioPredictionsResource': loadNgDashboardsPredictiveStudioDashboardsModule,
+  'BaseResourceComponent::PredictiveStudioStudioResource': loadNgDashboardsPredictiveStudioDashboardsModule,
 
   // @memberjunction/ng-dashboards → ./routines-dashboards.module
-  'BaseResourceComponent::UserRoutines': loadRoutinesDashboardsModule,
+  'BaseResourceComponent::UserRoutines': loadNgDashboardsRoutinesDashboardsModule,
 
   // @memberjunction/ng-dashboards → ./scheduling-dashboards.module
-  'BaseDashboard::SchedulingDashboard': loadSchedulingDashboardsModule,
-  'BaseResourceComponent::SchedulingActivityResource': loadSchedulingDashboardsModule,
-  'BaseResourceComponent::SchedulingDashboardResource': loadSchedulingDashboardsModule,
-  'BaseResourceComponent::SchedulingJobsResource': loadSchedulingDashboardsModule,
+  'BaseDashboard::SchedulingDashboard': loadNgDashboardsSchedulingDashboardsModule,
+  'BaseResourceComponent::SchedulingActivityResource': loadNgDashboardsSchedulingDashboardsModule,
+  'BaseResourceComponent::SchedulingDashboardResource': loadNgDashboardsSchedulingDashboardsModule,
+  'BaseResourceComponent::SchedulingJobsResource': loadNgDashboardsSchedulingDashboardsModule,
 
   // @memberjunction/ng-dashboards → ./testing-dashboards.module
-  'BaseDashboard::TestingDashboard': loadTestingDashboardsModule,
-  'BaseResourceComponent::TestingAnalyticsResource': loadTestingDashboardsModule,
-  'BaseResourceComponent::TestingDashboardTabResource': loadTestingDashboardsModule,
-  'BaseResourceComponent::TestingExplorerResource': loadTestingDashboardsModule,
-  'BaseResourceComponent::TestingReviewResource': loadTestingDashboardsModule,
-  'BaseResourceComponent::TestingRunsResource': loadTestingDashboardsModule,
+  'BaseDashboard::TestingDashboard': loadNgDashboardsTestingDashboardsModule,
+  'BaseResourceComponent::TestingAnalyticsResource': loadNgDashboardsTestingDashboardsModule,
+  'BaseResourceComponent::TestingDashboardTabResource': loadNgDashboardsTestingDashboardsModule,
+  'BaseResourceComponent::TestingExplorerResource': loadNgDashboardsTestingDashboardsModule,
+  'BaseResourceComponent::TestingReviewResource': loadNgDashboardsTestingDashboardsModule,
+  'BaseResourceComponent::TestingRunsResource': loadNgDashboardsTestingDashboardsModule,
 
   // @memberjunction/ng-explorer-settings → ./settings.module
-  'BaseDashboard::ApplicationManagement': loadSettingsModule,
-  'BaseDashboard::EntityPermissions': loadSettingsModule,
-  'BaseDashboard::RoleManagement': loadSettingsModule,
-  'BaseDashboard::SqlLogging': loadSettingsModule,
-  'BaseDashboard::UserManagement': loadSettingsModule,
-  'BaseNavigationComponent::Settings': loadSettingsModule,
+  'BaseDashboard::ApplicationManagement': loadNgExplorerSettingsSettingsModule,
+  'BaseDashboard::EntityPermissions': loadNgExplorerSettingsSettingsModule,
+  'BaseDashboard::RoleManagement': loadNgExplorerSettingsSettingsModule,
+  'BaseDashboard::SqlLogging': loadNgExplorerSettingsSettingsModule,
+  'BaseDashboard::UserManagement': loadNgExplorerSettingsSettingsModule,
+  'BaseNavigationComponent::Settings': loadNgExplorerSettingsSettingsModule,
 
   // @memberjunction/ng-file-storage → ./file-storage.module
-  'BaseResourceComponent::FileBrowserResource': loadFileStorageModule,
+  'BaseResourceComponent::FileBrowserResource': loadNgFileStorageFileStorageModule,
 
   // @memberjunction/ng-react → .
   'RuntimeUtilities::RuntimeUtilities': loadNgReact,
 
 };
 
-export const LAZY_FEATURE_CONFIG_COUNT = 110;
+export const LAZY_FEATURE_CONFIG_COUNT = 113;

--- a/packages/Angular/Generic/artifacts/src/lib/__tests__/interactive-form-apply.service.test.ts
+++ b/packages/Angular/Generic/artifacts/src/lib/__tests__/interactive-form-apply.service.test.ts
@@ -203,6 +203,30 @@ describe('InteractiveFormApplyService', () => {
         expect(calls).toEqual(['ACT-GET-ACTIVE', 'ACT-MODIFY']);
     });
 
+    it('existing Pending override (no Active) → calls Modify Interactive Form in-place', async () => {
+        hoisted.runViewResponses.push({ Success: true, Results: [{ ID: 'ACT-GET-ACTIVE' }] });
+        hoisted.runViewResponses.push({ Success: true, Results: [{ ID: 'ACT-MODIFY' }] });
+        hoisted.actionResponses.set('ACT-GET-ACTIVE', {
+            Success: true,
+            Message: JSON.stringify({
+                Active: null,
+                Variants: [{ OverrideID: 'OVER-PENDING', ComponentID: 'COMP-PENDING', ComponentVersion: '1.0.0', Status: 'Pending' }],
+            }),
+        });
+        hoisted.actionResponses.set('ACT-MODIFY', {
+            Success: true,
+            Message: JSON.stringify({ Mode: 'in-place', ComponentID: 'COMP-PENDING', OverrideID: 'OVER-PENDING', Version: '1.0.0' }),
+        });
+
+        const svc = new InteractiveFormApplyService();
+        const result = await svc.ConfirmAndApply(spec(), 'MJ: Apps', mockProvider());
+
+        expect(result.Success).toBe(true);
+        expect(result.Mode).toBe('modify-in-place');
+        const calls = hoisted.actionCalls.map(c => c.id);
+        expect(calls).toEqual(['ACT-GET-ACTIVE', 'ACT-MODIFY']);
+    });
+
     it('Get Active failure short-circuits with an error', async () => {
         hoisted.runViewResponses.push({ Success: true, Results: [{ ID: 'ACT-GET-ACTIVE' }] });
         hoisted.actionResponses.set('ACT-GET-ACTIVE', {

--- a/packages/Angular/Generic/artifacts/src/lib/components/plugins/component-artifact-viewer.component.css
+++ b/packages/Angular/Generic/artifacts/src/lib/components/plugins/component-artifact-viewer.component.css
@@ -13,6 +13,9 @@
   display: flex;
   flex-direction: column;
   min-height: 0;
+  min-width: 0;
+  width: 100%;
+  box-sizing: border-box;
 }
 
 /* Ensure React component takes full height */
@@ -236,6 +239,9 @@
   flex: 1;
   overflow: auto;
   background: var(--mj-bg-page);
+  min-width: 0;
+  width: 100%;
+  box-sizing: border-box;
 }
 
 /* ====================================================================

--- a/packages/Angular/Generic/artifacts/src/lib/components/plugins/component-artifact-viewer.component.html
+++ b/packages/Angular/Generic/artifacts/src/lib/components/plugins/component-artifact-viewer.component.html
@@ -91,6 +91,7 @@
       @if (formRecord && component) {
         <div class="form-artifact-form-host">
           <mj-interactive-form
+            #interactiveForm
             [componentSpec]="component"
             [record]="formRecord">
           </mj-interactive-form>

--- a/packages/Angular/Generic/artifacts/src/lib/components/plugins/component-artifact-viewer.component.ts
+++ b/packages/Angular/Generic/artifacts/src/lib/components/plugins/component-artifact-viewer.component.ts
@@ -5,6 +5,7 @@ import { MJReactComponent, AngularAdapterService } from '@memberjunction/ng-reac
 import { BuildComponentCompleteCode, ComponentSpec } from '@memberjunction/interactive-component-types';
 import { isFormRole, getDeclaredFormEntityName } from '@memberjunction/interactive-component-types/forms';
 import { BaseEntity, CompositeKey, DataSnapshot, EntityInfo, LogError, RunView } from '@memberjunction/core';
+import { InteractiveFormComponent } from '@memberjunction/ng-base-forms';
 import { DataRequirementsViewerComponent } from './data-requirements-viewer/data-requirements-viewer.component';
 import { evaluateComponentPermissions, PermissionEvaluationResult } from './component-permission-evaluation';
 
@@ -25,6 +26,7 @@ import { evaluateComponentPermissions, PermissionEvaluationResult } from './comp
 @RegisterClass(BaseArtifactViewerPluginComponent, 'ComponentArtifactViewerPlugin')
 export class ComponentArtifactViewerComponent extends BaseArtifactViewerPluginComponent implements OnInit, AfterViewInit, OnChanges {
   @ViewChild('reactComponent') reactComponent?: MJReactComponent;
+  @ViewChild('interactiveForm') interactiveForm?: InteractiveFormComponent;
   @Output() tabsChanged = new EventEmitter<void>();
   @Output() openEntityRecord = new EventEmitter<{entityName: string; compositeKey: CompositeKey}>();
 
@@ -546,12 +548,83 @@ export class ComponentArtifactViewerComponent extends BaseArtifactViewerPluginCo
     }
   }
 
-  /** Bubble Apply intent up to the host (Form Builder dashboard / Sage chat). */
-  public onApplyClicked(): void {
-    if (!this.component || !this.formEntityInfo) return;
+  /**
+   * Bubble Apply intent up to the host (Form Builder dashboard / Sage chat).
+   *
+   * Resolves the full ComponentSpec (with code) from multiple sources:
+   *   1. resolvedComponentSpec — live React bridge or cached copy (best for non-form artifacts)
+   *   2. Re-parse artifact version Content — the agent stores the full spec including code
+   *   3. DB fallback — fetch from MJ: Components by name
+   *
+   * Source #2 covers the common form-artifact case where the React component lives inside
+   * <mj-interactive-form> and resolvedComponentSpec falls back to the stripped local spec.
+   */
+  public async onApplyClicked(): Promise<void> {
+    if (!this.formEntityInfo) return;
+
+    const spec = await this.resolveSpecWithCode();
+    if (!spec) return;
+
     this.applyFormRequested.emit({
-      spec: this.component,
+      spec,
       entityName: this.formEntityInfo.Name,
     });
+  }
+
+  /**
+   * Resolve a ComponentSpec that includes code, trying multiple sources in order.
+   */
+  private async resolveSpecWithCode(): Promise<ComponentSpec | null> {
+    // 1. Prefer the live React bridge's resolved spec (non-form path).
+    const resolved = this.resolvedComponentSpec;
+    if (resolved?.code) return resolved;
+
+    // 2. For form artifacts, the React component lives inside <mj-interactive-form>.
+    //    Reach into it to get the resolved spec from the component registry.
+    const formReactSpec = this.interactiveForm?.reactComponent?.resolvedComponentSpec;
+    if (formReactSpec?.code) return formReactSpec;
+
+    // 3. Re-parse the artifact version's Content directly — the agent stores the
+    //    full spec including code. This handles the case where loadComponentSpec()
+    //    parsed early (before Content was fully populated) and the in-memory
+    //    `this.component` ended up without code.
+    if (this.artifactVersion?.Content) {
+      const freshParse = SafeJSONParse(this.artifactVersion.Content) as ComponentSpec | null;
+      if (freshParse?.code) return freshParse;
+    }
+
+    // 4. DB fallback — fetch from MJ: Components by name.
+    const name = resolved?.name ?? this.component?.name;
+    if (name) {
+      const dbSpec = await this.fetchFullSpecByName(name);
+      if (dbSpec?.code) return dbSpec;
+    }
+
+    LogError('ComponentArtifactViewer: could not resolve spec with code for Apply');
+    return null;
+  }
+
+  /**
+   * Fetch the full ComponentSpec (including code) from the MJ: Components table
+   * by component name. Returns null if not found or on error.
+   */
+  private async fetchFullSpecByName(name: string): Promise<ComponentSpec | null> {
+    try {
+      const rv = new RunView();
+      const result = await rv.RunView<{ Specification: string }>({
+        EntityName: 'MJ: Components',
+        ExtraFilter: `Name='${name.replace(/'/g, "''")}'`,
+        Fields: ['Specification'],
+        OrderBy: 'VersionSequence DESC',
+        MaxRows: 1,
+        ResultType: 'simple',
+      });
+      if (result.Success && result.Results?.length > 0 && result.Results[0].Specification) {
+        return JSON.parse(result.Results[0].Specification) as ComponentSpec;
+      }
+    } catch (err) {
+      LogError(`ComponentArtifactViewer: failed to fetch full spec for '${name}': ${err instanceof Error ? err.message : String(err)}`);
+    }
+    return null;
   }
 }

--- a/packages/Angular/Generic/artifacts/src/lib/services/interactive-form-apply.service.ts
+++ b/packages/Angular/Generic/artifacts/src/lib/services/interactive-form-apply.service.ts
@@ -78,27 +78,34 @@ export class InteractiveFormApplyService {
             return this.fail(`Could not check for existing override: ${activeResult.Message ?? 'unknown error'}`);
         }
         const payload = this.parseActiveResult(activeResult.Message);
-        const hasExistingActive = !!payload?.Active?.OverrideID;
+        const existingOverride = payload?.Active
+            ?? payload?.Variants?.find(v => v.Status === 'Pending')
+            ?? null;
+        const hasExistingOverride = !!existingOverride?.OverrideID;
 
         // Step 2: confirm with the user.
-        const proceed = await this.confirm(hasExistingActive, entityName, payload?.Active?.ComponentVersion);
+        const proceed = await this.confirm(hasExistingOverride, entityName, existingOverride?.ComponentVersion);
         if (!proceed) {
             return { Success: false, Message: 'Cancelled by user.' };
         }
 
         // Step 3: run Create or Modify.
         const formName = (spec as unknown as { name?: string }).name ?? 'Custom Form';
-        if (hasExistingActive) {
+        if (hasExistingOverride) {
             // MJ's Modify operates on a Component *lineage* keyed by Name — the spec
             // name must match the existing Component across versions. A freshly
             // generated form usually has a different name, so align it to the existing
             // lineage (spec.name + the root `function` declaration the linter checks)
             // before modifying.
-            if (payload?.Active?.ComponentName) {
-                this.alignSpecToLineage(spec, payload.Active.ComponentName);
+            if (existingOverride!.ComponentName) {
+                this.alignSpecToLineage(spec, existingOverride!.ComponentName);
             }
+            // For Pending overrides, use in-place modification (keep iterating on
+            // the same version). For Active overrides, bump a new version so the
+            // prior version is preserved.
+            const isPending = existingOverride!.Status === 'Pending';
             const modifyResult = await this.runActionByName(client, 'Modify Interactive Form', [
-                { Name: 'OverrideID', Value: payload!.Active!.OverrideID!, Type: 'Input' },
+                { Name: 'OverrideID', Value: existingOverride!.OverrideID!, Type: 'Input' },
                 { Name: 'Spec', Value: JSON.stringify(spec), Type: 'Input' },
                 { Name: 'Notes', Value: `Applied from chat artifact at ${new Date().toISOString()}`, Type: 'Input' },
                 // A user "Apply" is a deliberate save, never an in-flight refinement —
@@ -106,9 +113,10 @@ export class InteractiveFormApplyService {
                 // in-place overwrite. Passing an explicit bump makes this deterministic
                 // across every source status (the 'in-place' default only applies to a
                 // Pending source, which is the agent's iteration loop, not this path).
-                // The prior version is demoted to Inactive on activation and stays in
-                // Form Builder's version rail.
-                { Name: 'VersionBumpKind', Value: 'minor', Type: 'Input' },
+                // Exception: if the existing override is already Pending (no Active
+                // version exists yet), use in-place to avoid creating unnecessary
+                // version history.
+                { Name: 'VersionBumpKind', Value: isPending ? 'in-place' : 'minor', Type: 'Input' },
             ]);
             // Auto-activate the resulting version too. "Apply to my form" is an explicit
             // user action — they expect the applied form to go live, not sit as a Pending
@@ -275,11 +283,15 @@ export class InteractiveFormApplyService {
     }
 
     private parseActiveResult(message: string | undefined): {
-        Active?: { OverrideID?: string; ComponentVersion?: string; ComponentName?: string };
+        Active?: { OverrideID?: string; ComponentVersion?: string; ComponentName?: string; Status?: string };
+        Variants?: Array<{ OverrideID?: string; ComponentVersion?: string; ComponentName?: string; Status?: string }>;
     } | null {
         if (!message) return null;
         try {
-            return JSON.parse(message) as { Active?: { OverrideID?: string; ComponentVersion?: string; ComponentName?: string } };
+            return JSON.parse(message) as {
+                Active?: { OverrideID?: string; ComponentVersion?: string; ComponentName?: string; Status?: string };
+                Variants?: Array<{ OverrideID?: string; ComponentVersion?: string; ComponentName?: string; Status?: string }>;
+            };
         } catch {
             return null;
         }

--- a/packages/Angular/Generic/conversations/src/lib/services/mention-autocomplete.service.ts
+++ b/packages/Angular/Generic/conversations/src/lib/services/mention-autocomplete.service.ts
@@ -277,7 +277,7 @@ export class MentionAutocompleteService extends BaseSingleton<MentionAutocomplet
    */
   private getEntityAndQuerySuggestions(query: string): MentionSuggestion[] {
     const lowerQuery = query.toLowerCase().trim();
-    const MAX_SUGGESTIONS = 12;
+    const MAX_SUGGESTIONS = 50;
 
     const entityItems = this.entitiesCache.map(entity => ({
       label: entity.DisplayNameOrName,
@@ -312,6 +312,10 @@ export class MentionAutocompleteService extends BaseSingleton<MentionAutocomplet
       .filter(x => x.score > 0 || !lowerQuery)
       .sort((a, b) => {
         if (b.score !== a.score) return b.score - a.score;
+        // When scores tie, prioritize entities over queries
+        if (a.suggestion.type !== b.suggestion.type) {
+          return a.suggestion.type === 'entity' ? -1 : 1;
+        }
         return a.label.localeCompare(b.label);
       })
       .slice(0, MAX_SUGGESTIONS)

--- a/packages/CodeGenLib/src/Manifest/GenerateClassRegistrationsManifest.ts
+++ b/packages/CodeGenLib/src/Manifest/GenerateClassRegistrationsManifest.ts
@@ -1687,27 +1687,34 @@ function findClassSubpathByFile(
 /**
  * Builds a deterministic loader variable name from a package name and subpath.
  *
+ * Both package name and subpath are included to prevent collisions when
+ * different packages export the same subpath (e.g. two packages both
+ * exporting `./plugins` would otherwise both produce `loadPlugins`).
+ *
  * Examples:
- *   ('@memberjunction/ng-dashboards', './ai-dashboards.module') → 'loadAiDashboardsModule'
+ *   ('@memberjunction/ng-dashboards', './ai-dashboards.module') → 'loadNgDashboardsAiDashboardsModule'
  *   ('@memberjunction/ng-explorer-settings', '.')               → 'loadNgExplorerSettings'
+ *   ('@memberjunction/codegen-lib', './plugins')                → 'loadCodegenLibPlugins'
+ *   ('@memberjunction/metadata-sync', './plugins')              → 'loadMetadataSyncPlugins'
  */
 function buildLoaderVarName(packageName: string, subpath: string): string {
+    const pkgParts = sanitizePackageName(packageName).split('_').filter(Boolean);
+    const pkgPascal = pkgParts.map(p => p.charAt(0).toUpperCase() + p.slice(1)).join('');
+
     if (subpath === '.') {
-        // Whole-package chunk: derive from package name
-        const parts = sanitizePackageName(packageName).split('_').filter(Boolean);
-        const pascalParts = parts.map(p => p.charAt(0).toUpperCase() + p.slice(1));
-        return `load${pascalParts.join('')}`;
+        // Whole-package chunk: derive from package name only
+        return `load${pkgPascal}`;
     }
 
-    // Subpath chunk: derive from subpath name
+    // Subpath chunk: combine package name + subpath to avoid cross-package collisions
     const clean = subpath
         .replace(/^\.\//, '')
         .replace(/\.module$/, '-module')
         .replace(/\.[^.]+$/, ''); // strip file extensions
 
-    const parts = clean.split(/[-./]/).filter(Boolean);
-    const pascalParts = parts.map(p => p.charAt(0).toUpperCase() + p.slice(1));
-    return `load${pascalParts.join('')}`;
+    const subParts = clean.split(/[-./]/).filter(Boolean);
+    const subPascal = subParts.map(p => p.charAt(0).toUpperCase() + p.slice(1)).join('');
+    return `load${pkgPascal}${subPascal}`;
 }
 
 /**

--- a/packages/GenericDatabaseProvider/src/GenericDatabaseProvider.ts
+++ b/packages/GenericDatabaseProvider/src/GenericDatabaseProvider.ts
@@ -78,7 +78,7 @@ import { SqlLoggingSessionImpl } from './SqlLogger.js';
 import { SqlLoggingOptions, SqlLoggingSession } from './types.js';
 import { SQLDialect } from '@memberjunction/sql-dialect';
 // QueryCompositionEngine is now owned by RenderPipeline
-import { RenderPipeline } from './renderPipeline.js';
+import { RenderPipeline, type RenderResult } from './renderPipeline.js';
 import { CRUDSprocType, useJsonArgShape } from './crudSprocFieldRules.js';
 import { SaveCoercedValue, SaveCallBinding, SaveSQLFragment } from './saveTypes.js';
 import type { RecordChangePayload } from '@memberjunction/core';
@@ -3000,12 +3000,15 @@ export abstract class GenericDatabaseProvider extends DatabaseProviderBase {
             return this.ExecuteAdhocQuery(params, contextUser);
         }
 
+        let finalSQL: string | undefined;
         try {
             // Find and validate query
             const query = this.findAndValidateQuery(params, contextUser);
 
             // Process parameters (composition + Nunjucks templates)
-            const { finalSQL, appliedParameters } = this.processQueryParameters(query, params.Parameters, contextUser);
+            const resolved = this.processQueryParameters(query, params.Parameters, contextUser);
+            finalSQL = resolved.finalSQL;
+            const appliedParameters = resolved.appliedParameters;
 
             // ── External data source dispatch ──
             // Queries bound to an external data source execute their (now fully-rendered)
@@ -3102,6 +3105,7 @@ export abstract class GenericDatabaseProvider extends DatabaseProviderBase {
                 ExecutionTime: executionTime,
                 ErrorMessage: '',
                 AppliedParameters: appliedParameters,
+                RenderedSQL: finalSQL,
                 CacheHit: false
             };
         } catch (e) {
@@ -3120,6 +3124,7 @@ export abstract class GenericDatabaseProvider extends DatabaseProviderBase {
                 TotalRowCount: 0,
                 ExecutionTime: 0,
                 ErrorMessage: errorMessage,
+                RenderedSQL: finalSQL,
             };
         }
     }
@@ -3228,7 +3233,7 @@ export abstract class GenericDatabaseProvider extends DatabaseProviderBase {
         query: MJQueryEntityExtended,
         parameters?: Record<string, string>,
         contextUser?: UserInfo,
-    ): { finalSQL: string; appliedParameters: Record<string, string> } {
+    ): { finalSQL: string; appliedParameters: Record<string, string>; renderResult: RenderResult } {
         const result = RenderPipeline.Run(
             query.GetPlatformSQL(this.PlatformKey),
             {
@@ -3248,7 +3253,7 @@ export abstract class GenericDatabaseProvider extends DatabaseProviderBase {
             LogStatus('Warning: Parameters provided but query does not use templates. Parameters will be ignored.');
         }
 
-        return { finalSQL: result.FinalSQL, appliedParameters: result.AppliedParameters };
+        return { finalSQL: result.FinalSQL, appliedParameters: result.AppliedParameters, renderResult: result };
     }
 
     /**
@@ -3371,8 +3376,10 @@ export abstract class GenericDatabaseProvider extends DatabaseProviderBase {
         spec: QueryExecutionSpec,
         contextUser?: UserInfo,
     ): Promise<RunQueryResult> {
+        let finalSQL: string | undefined;
         try {
-            const { finalSQL, appliedParameters } = this.resolveSpecParameters(spec, contextUser);
+            const resolved = this.resolveSpecParameters(spec, contextUser);
+            finalSQL = resolved.finalSQL;
 
             // Execute
             const { result, executionTime } = await this.executeQueryWithTiming(finalSQL, contextUser);
@@ -3386,7 +3393,8 @@ export abstract class GenericDatabaseProvider extends DatabaseProviderBase {
                 TotalRowCount: result?.length ?? 0,
                 ExecutionTime: executionTime,
                 ErrorMessage: '',
-                AppliedParameters: appliedParameters,
+                AppliedParameters: resolved.appliedParameters,
+                RenderedSQL: finalSQL,
             };
         } catch (e) {
             LogError(e);
@@ -3400,6 +3408,7 @@ export abstract class GenericDatabaseProvider extends DatabaseProviderBase {
                 TotalRowCount: 0,
                 ExecutionTime: 0,
                 ErrorMessage: errorMessage,
+                RenderedSQL: finalSQL,
             };
         }
     }
@@ -3413,7 +3422,7 @@ export abstract class GenericDatabaseProvider extends DatabaseProviderBase {
     private resolveSpecParameters(
         spec: QueryExecutionSpec,
         contextUser?: UserInfo,
-    ): { finalSQL: string; appliedParameters: Record<string, string> } {
+    ): { finalSQL: string; appliedParameters: Record<string, string>; renderResult: RenderResult } {
         // QueryExecutionSpec.ParameterDefinitions is QueryParameterInfo[] (MJCore),
         // while RenderContext expects MJQueryParameterEntity[] (core-entities).
         // Both share the structural shape the processor needs (Name, DataType, IsRequired).
@@ -3436,7 +3445,7 @@ export abstract class GenericDatabaseProvider extends DatabaseProviderBase {
             LogStatus('Warning: Parameters provided but query does not use templates. Parameters will be ignored.');
         }
 
-        return { finalSQL: result.FinalSQL, appliedParameters: result.AppliedParameters };
+        return { finalSQL: result.FinalSQL, appliedParameters: result.AppliedParameters, renderResult: result };
     }
 
     // wrapWithMaxRows is now handled by RenderPipeline.applyMaxRows

--- a/packages/GenericDatabaseProvider/src/__tests__/GenericDatabaseProvider.test.ts
+++ b/packages/GenericDatabaseProvider/src/__tests__/GenericDatabaseProvider.test.ts
@@ -36,7 +36,9 @@ import {
     EntityDeleteOptions,
     QueryInfo,
     QueryCategoryInfo,
+    Metadata,
 } from '@memberjunction/core';
+import type { QueryExecutionSpec } from '@memberjunction/core';
 import type { ExecuteSQLBatchOptions } from '../GenericDatabaseProvider';
 
 /**
@@ -1166,5 +1168,130 @@ describe('SqlLoggingSessionImpl', () => {
             });
             expect(session.options.variableBatchThreshold).toBeUndefined();
         });
+    });
+});
+
+// ════════════════════════════════════════════════════════════════════
+// RenderedSQL — verify the executed SQL flows through RunQueryResult
+// ════════════════════════════════════════════════════════════════════
+
+describe('RenderedSQL in ExecuteQueryFromSpec', () => {
+    let provider: TestGenericProvider;
+
+    beforeEach(() => {
+        provider = new TestGenericProvider();
+        // Stub Metadata.Provider so RenderPipeline's composition step doesn't throw
+        vi.spyOn(Metadata, 'Provider', 'get').mockReturnValue({
+            Queries: [],
+            QueryDependencies: [],
+        } as unknown as typeof Metadata.Provider);
+    });
+
+    it('returns RenderedSQL on success — plain SQL without templates', async () => {
+        provider.executeSQLResults = [[{ ID: 1 }]];
+
+        const spec: QueryExecutionSpec = {
+            SQL: 'SELECT ID FROM [dbo].[vwMembers]',
+            MaxRows: 10,
+        };
+        const result = await provider.ExecuteQueryFromSpec(spec, mockUser);
+
+        expect(result.Success).toBe(true);
+        expect(result.RenderedSQL).toBeDefined();
+        expect(result.RenderedSQL).toMatch(/\bTOP\s+10\b/i);
+        expect(result.RenderedSQL).toContain('vwMembers');
+    });
+
+    it('returns RenderedSQL on success — with Nunjucks template resolution', async () => {
+        provider.executeSQLResults = [[{ ID: 1, Status: 'Active' }]];
+
+        const spec: QueryExecutionSpec = {
+            SQL: `SELECT ID FROM [dbo].[vwMembers] WHERE [Status] = {{ Status | sqlString }}`,
+            UsesTemplate: true,
+            Parameters: { Status: 'Active' },
+            MaxRows: 10,
+        };
+        const result = await provider.ExecuteQueryFromSpec(spec, mockUser);
+
+        expect(result.Success).toBe(true);
+        expect(result.RenderedSQL).toBeDefined();
+        // Nunjucks should be resolved
+        expect(result.RenderedSQL).not.toContain('{{');
+        expect(result.RenderedSQL).toContain("'Active'");
+        // MaxRows should be applied
+        expect(result.RenderedSQL).toMatch(/\bTOP\s+10\b/i);
+    });
+
+    it('returns RenderedSQL on error — making the executed SQL visible for debugging', async () => {
+        // Simulate a DB execution failure by making ExecuteSQL throw
+        vi.spyOn(provider, 'ExecuteSQL').mockRejectedValueOnce(
+            new Error('The ORDER BY clause is invalid in views, inline functions, derived tables')
+        );
+
+        const spec: QueryExecutionSpec = {
+            SQL: `SELECT ID FROM [dbo].[vwMembers] WHERE [Status] = {{ Status | sqlString }}`,
+            UsesTemplate: true,
+            Parameters: { Status: 'Active' },
+            MaxRows: 10,
+        };
+        const result = await provider.ExecuteQueryFromSpec(spec, mockUser);
+
+        expect(result.Success).toBe(false);
+        expect(result.ErrorMessage).toContain('ORDER BY');
+        // The rendered SQL should still be present even on failure
+        expect(result.RenderedSQL).toBeDefined();
+        expect(result.RenderedSQL).not.toContain('{{');
+        expect(result.RenderedSQL).toContain("'Active'");
+        expect(result.RenderedSQL).toMatch(/\bTOP\s+10\b/i);
+    });
+
+    it('RenderedSQL shows MaxRows outer-wrap transformation for unparseable SQL', async () => {
+        // Simulate a DB execution failure
+        vi.spyOn(provider, 'ExecuteSQL').mockRejectedValueOnce(
+            new Error('The ORDER BY clause is invalid')
+        );
+
+        const spec: QueryExecutionSpec = {
+            SQL: `SELECT t.ID, COUNT(DISTINCT mel.ID) AS Cnt
+FROM [document].[vwMemberEngagementLogs] mel
+INNER JOIN [__mj].[vwTaggedItems] ti ON mel.ID = TRY_CAST(ti.RecordID AS INT)
+INNER JOIN [__mj].[vwTags] t ON ti.TagID = t.ID
+WHERE mel.IsMemberInitiated = 1
+  AND mel.[Date] >= {{ StartDate | sqlDate }}
+GROUP BY t.ID
+ORDER BY Cnt DESC`,
+            UsesTemplate: true,
+            Parameters: { StartDate: '2024-01-01' },
+            MaxRows: 10,
+        };
+        const result = await provider.ExecuteQueryFromSpec(spec, mockUser);
+
+        expect(result.Success).toBe(false);
+        // RenderedSQL reveals the outer-wrap transformation that the error message alone cannot
+        expect(result.RenderedSQL).toBeDefined();
+        expect(result.RenderedSQL).toMatch(/_mj_capped/);
+        expect(result.RenderedSQL).toMatch(/\bTOP\s+10\b/i);
+        // Nunjucks tokens should be resolved
+        expect(result.RenderedSQL).not.toContain('{{');
+        expect(result.RenderedSQL).toMatch(/2024-01-01/);
+    });
+
+    it('RenderedSQL is undefined when rendering itself throws (before SQL is produced)', async () => {
+        // Make RenderPipeline.Run() throw by providing SQL with a composition
+        // token that triggers a Metadata.Provider access on a broken mock
+        vi.spyOn(Metadata, 'Provider', 'get').mockImplementation(() => {
+            throw new Error('Metadata not available');
+        });
+
+        const spec: QueryExecutionSpec = {
+            SQL: `SELECT * FROM {{query:"NonExistent/Query"}}`,
+            MaxRows: 10,
+        };
+        const result = await provider.ExecuteQueryFromSpec(spec, mockUser);
+
+        expect(result.Success).toBe(false);
+        expect(result.ErrorMessage).toBeTruthy();
+        // RenderedSQL is undefined because the rendering step itself failed
+        expect(result.RenderedSQL).toBeUndefined();
     });
 });

--- a/packages/GenericDatabaseProvider/src/__tests__/renderPipeline.test.ts
+++ b/packages/GenericDatabaseProvider/src/__tests__/renderPipeline.test.ts
@@ -1077,6 +1077,81 @@ describe('RenderTrace', () => {
 });
 
 // ════════════════════════════════════════════════════════════════════
+// RenderTrace — verifying trace captures the SQL state at each pipeline stage
+// ════════════════════════════════════════════════════════════════════
+
+describe('RenderTrace — pipeline stage visibility', () => {
+
+    it('AfterComposition preserves Nunjucks tokens, AfterTemplates resolves them', () => {
+        stubMetadata();
+        const sql = `SELECT * FROM [dbo].[vwMembers] WHERE [Status] = {{ Status | sqlString }}`;
+        const result = RenderPipeline.Run(sql, {
+            Platform: 'sqlserver',
+            UsesTemplate: true,
+            Parameters: { Status: 'Active' },
+        });
+        // AfterComposition still has the Nunjucks token (composition runs before templates)
+        expect(result.Trace.AfterComposition).toContain('{{ Status | sqlString }}');
+        // AfterTemplates has the resolved value
+        expect(result.Trace.AfterTemplates).toContain("'Active'");
+        expect(result.Trace.AfterTemplates).not.toContain('{{ Status');
+    });
+
+    it('MaxRows wrapping is visible in FinalSQL but not in AfterTemplates', () => {
+        stubMetadata();
+        const sql = `SELECT * FROM [dbo].[vwMembers]`;
+        const result = RenderPipeline.Run(sql, { Platform: 'sqlserver', MaxRows: 10 });
+        // AfterTemplates is the SQL BEFORE MaxRows wrapping
+        expect(result.Trace.AfterTemplates).not.toMatch(/_mj_capped/);
+        expect(result.Trace.AfterTemplates).not.toMatch(/\bTOP\b/i);
+        // FinalSQL has the cap applied
+        expect(result.FinalSQL).toMatch(/\bTOP\s+10\b/i);
+    });
+
+    it('trace captures every stage for TRY_CAST query with MaxRows (the Skip failure case)', () => {
+        stubMetadata();
+        const sql = `SELECT t.ID, COUNT(DISTINCT mel.ID) AS Cnt
+FROM [document].[vwMemberEngagementLogs] mel
+INNER JOIN [__mj].[vwTaggedItems] ti ON mel.ID = TRY_CAST(ti.RecordID AS INT)
+INNER JOIN [__mj].[vwTags] t ON ti.TagID = t.ID
+WHERE mel.IsMemberInitiated = 1
+  AND mel.[Date] >= {{ StartDate | sqlDate }}
+GROUP BY t.ID
+ORDER BY Cnt DESC`;
+        const result = RenderPipeline.Run(sql, {
+            Platform: 'sqlserver',
+            MaxRows: 10,
+            UsesTemplate: true,
+            Parameters: { StartDate: '2024-01-01' },
+        });
+        // AfterComposition: Nunjucks tokens still present
+        expect(result.Trace.AfterComposition).toContain('{{ StartDate | sqlDate }}');
+        expect(result.Trace.AfterComposition).toContain('TRY_CAST');
+        // AfterTemplates: Nunjucks resolved, but no MaxRows wrapping yet
+        expect(result.Trace.AfterTemplates).toMatch(/2024-01-01/);
+        expect(result.Trace.AfterTemplates).not.toMatch(/_mj_capped/);
+        // FinalSQL: MaxRows applied (outer wrap with ORDER BY moved outside)
+        expect(result.FinalSQL).toMatch(/\bTOP\s+10\b/i);
+        expect(result.FinalSQL).toMatch(/_mj_capped/);
+        // The trace makes it possible to diagnose the transformation
+        expect(result.Trace.AfterTemplates).toMatch(/ORDER\s+BY\s+Cnt\s+DESC/i);
+    });
+
+    it('FinalSQL differs from AfterTemplates when MaxRows is applied', () => {
+        stubMetadata();
+        const result = RenderPipeline.Run('SELECT * FROM t', {
+            Platform: 'sqlserver',
+            MaxRows: 5,
+        });
+        // AfterTemplates is the pre-cap SQL
+        expect(result.Trace.AfterTemplates).toBe('SELECT * FROM t');
+        // FinalSQL has the cap
+        expect(result.FinalSQL).not.toBe(result.Trace.AfterTemplates);
+        expect(result.FinalSQL).toMatch(/\bTOP\s+5\b/i);
+    });
+});
+
+// ════════════════════════════════════════════════════════════════════
 // Lexical disguise — keyword-looking content in literals/identifiers/comments
 // ════════════════════════════════════════════════════════════════════
 

--- a/packages/GenericDatabaseProvider/src/__tests__/renderPipeline.test.ts
+++ b/packages/GenericDatabaseProvider/src/__tests__/renderPipeline.test.ts
@@ -1772,6 +1772,130 @@ FROM [dbo].[vwMembers] m`;
     });
 });
 
+// ════════════════════════════════════════════════════════════════════
+// MaxRows — AST-unparseable T-SQL functions (TRY_CAST, IIF, STRING_AGG, etc.)
+//
+// node-sql-parser cannot parse certain T-SQL functions. When the AST path
+// returns 'unparseable', WrapWithMaxRows falls back to outerWrap which
+// wraps the SQL in SELECT TOP N * FROM (...). ORDER BY inside the derived
+// table is illegal on SQL Server — outerWrap must strip it and move it to
+// the outer SELECT.
+// ════════════════════════════════════════════════════════════════════
+
+describe('MaxRows row cap — AST-unparseable SQL with ORDER BY', () => {
+
+    it('TRY_CAST with ORDER BY — the exact Skip Query Writer failure pattern', () => {
+        stubMetadata();
+        const sql = `SELECT t.ID AS TagID, t.Name AS TagName, COUNT(DISTINCT mel.ID) AS EngagementCount
+FROM [document].[vwMemberEngagementLogs] mel
+INNER JOIN [__mj].[vwTaggedItems] ti ON mel.ID = TRY_CAST(ti.RecordID AS INT)
+INNER JOIN [__mj].[vwTags] t ON ti.TagID = t.ID
+WHERE mel.IsMemberInitiated = 1
+  AND ti.Entity = 'Member Engagement Logs'
+  AND mel.[Date] >= '2024-01-01'
+  AND mel.[Date] <= '2025-12-31'
+GROUP BY t.ID, t.Name
+ORDER BY EngagementCount DESC`;
+        const result = RenderPipeline.Run(sql, { Platform: 'sqlserver', MaxRows: 10 });
+        // Must be capped (outer wrap with TOP 10)
+        expect(result.FinalSQL).toMatch(/\bTOP\s+10\b/i);
+        expect(result.FinalSQL).toMatch(/_mj_capped/);
+        // ORDER BY must NOT be inside the derived table — it must be on the outer SELECT
+        const innerMatch = result.FinalSQL.match(/\([\s\S]*\)\s+AS\s+_mj_capped/i);
+        expect(innerMatch).not.toBeNull();
+        expect(innerMatch![0]).not.toMatch(/ORDER\s+BY/i);
+        // ORDER BY must appear after _mj_capped (on the outer SELECT)
+        const afterCapped = result.FinalSQL.split('_mj_capped')[1];
+        expect(afterCapped).toMatch(/ORDER\s+BY\s+EngagementCount\s+DESC/i);
+    });
+
+    it('TRY_CAST without ORDER BY — no ORDER BY to strip', () => {
+        stubMetadata();
+        const sql = `SELECT mel.ID, TRY_CAST(mel.RecordID AS INT) AS RecordNum
+FROM [document].[vwMemberEngagementLogs] mel
+WHERE mel.IsMemberInitiated = 1`;
+        const result = RenderPipeline.Run(sql, { Platform: 'sqlserver', MaxRows: 10 });
+        expect(result.FinalSQL).toMatch(/\bTOP\s+10\b/i);
+        expect(result.FinalSQL).toMatch(/_mj_capped/);
+        // No ORDER BY anywhere
+        expect(result.FinalSQL).not.toMatch(/ORDER\s+BY/i);
+    });
+
+    it('IIF function with ORDER BY', () => {
+        stubMetadata();
+        const sql = `SELECT m.ID, IIF(m.Status = 'Active', 'Yes', 'No') AS IsActive
+FROM [dbo].[vwMembers] m
+ORDER BY IsActive DESC`;
+        const result = RenderPipeline.Run(sql, { Platform: 'sqlserver', MaxRows: 10 });
+        assertCapEnforcedOrSafelyUntouched(sql, result.FinalSQL, 10);
+        // If outer-wrapped, ORDER BY must be outside the derived table
+        if (/_mj_capped/.test(result.FinalSQL)) {
+            const innerMatch = result.FinalSQL.match(/\([\s\S]*\)\s+AS\s+_mj_capped/i);
+            expect(innerMatch![0]).not.toMatch(/ORDER\s+BY/i);
+            const afterCapped = result.FinalSQL.split('_mj_capped')[1];
+            expect(afterCapped).toMatch(/ORDER\s+BY/i);
+        }
+    });
+
+    it('STRING_AGG with ORDER BY', () => {
+        stubMetadata();
+        const sql = `SELECT DepartmentID, STRING_AGG(Name, ', ') AS Members
+FROM [dbo].[vwMembers]
+GROUP BY DepartmentID
+ORDER BY Members`;
+        const result = RenderPipeline.Run(sql, { Platform: 'sqlserver', MaxRows: 10 });
+        assertCapEnforcedOrSafelyUntouched(sql, result.FinalSQL, 10);
+        if (/_mj_capped/.test(result.FinalSQL)) {
+            const innerMatch = result.FinalSQL.match(/\([\s\S]*\)\s+AS\s+_mj_capped/i);
+            expect(innerMatch![0]).not.toMatch(/ORDER\s+BY/i);
+        }
+    });
+
+    it('TRY_CONVERT with multi-column ORDER BY', () => {
+        stubMetadata();
+        const sql = `SELECT ID, TRY_CONVERT(DATE, CreatedAt) AS CreatedDate, Name
+FROM [dbo].[vwEvents]
+ORDER BY CreatedDate DESC, Name ASC`;
+        const result = RenderPipeline.Run(sql, { Platform: 'sqlserver', MaxRows: 50 });
+        assertCapEnforcedOrSafelyUntouched(sql, result.FinalSQL, 50);
+        if (/_mj_capped/.test(result.FinalSQL)) {
+            const afterCapped = result.FinalSQL.split('_mj_capped')[1];
+            expect(afterCapped).toMatch(/ORDER\s+BY\s+CreatedDate\s+DESC\s*,\s*Name\s+ASC/i);
+        }
+    });
+
+    it('end-to-end: Nunjucks template with TRY_CAST resolves and caps correctly', () => {
+        stubMetadata();
+        const sql = `SELECT t.ID, COUNT(DISTINCT mel.ID) AS Cnt
+FROM [document].[vwMemberEngagementLogs] mel
+INNER JOIN [__mj].[vwTaggedItems] ti ON mel.ID = TRY_CAST(ti.RecordID AS INT)
+INNER JOIN [__mj].[vwTags] t ON ti.TagID = t.ID
+WHERE mel.IsMemberInitiated = 1
+  AND mel.[Date] >= {{ StartDate | sqlDate }}
+  AND mel.[Date] <= {{ EndDate | sqlDate }}
+GROUP BY t.ID
+ORDER BY Cnt DESC`;
+        const result = RenderPipeline.Run(sql, {
+            Platform: 'sqlserver',
+            MaxRows: 10,
+            UsesTemplate: true,
+            Parameters: { StartDate: '2024-01-01', EndDate: '2025-12-31' },
+        });
+        // Nunjucks tokens should be resolved
+        expect(result.FinalSQL).not.toContain('{{');
+        expect(result.FinalSQL).toMatch(/2024-01-01/);
+        // Must be capped
+        expect(result.FinalSQL).toMatch(/\bTOP\s+10\b/i);
+        // ORDER BY must not be inside the derived table
+        if (/_mj_capped/.test(result.FinalSQL)) {
+            const innerMatch = result.FinalSQL.match(/\([\s\S]*\)\s+AS\s+_mj_capped/i);
+            expect(innerMatch![0]).not.toMatch(/ORDER\s+BY/i);
+            const afterCapped = result.FinalSQL.split('_mj_capped')[1];
+            expect(afterCapped).toMatch(/ORDER\s+BY/i);
+        }
+    });
+});
+
 describe('bulletproof — realistic Skip / Query Builder shapes (PostgreSQL)', () => {
 
     it('multi-CTE with double-quoted names', () => {

--- a/packages/GenericDatabaseProvider/src/queryPagingEngine.ts
+++ b/packages/GenericDatabaseProvider/src/queryPagingEngine.ts
@@ -132,6 +132,12 @@ export class QueryPagingEngine {
      * Used when the AST recognises the shape but cannot inject the cap
      * cleanly, or when the AST can't parse the input but the SQL is known
      * to be wrap-safe (no FOR JSON/FOR XML/OPTION at top level).
+     *
+     * Strips any top-level ORDER BY before wrapping: ORDER BY is illegal
+     * inside a derived table on SQL Server (unless TOP/OFFSET/FOR XML is
+     * present), and the outer SELECT doesn't preserve inner ordering anyway.
+     * The ORDER BY is moved to the outer SELECT so the final result retains
+     * the intended sort order.
      */
     private static outerWrap(sql: string, cap: number, dialect: SQLDialect): string {
         // Route the cap form through the dialect's LimitClause so there is a
@@ -139,7 +145,23 @@ export class QueryPagingEngine {
         const lc = dialect.LimitClause(cap);
         const prefix = lc.prefix ? `${lc.prefix} ` : '';   // 'TOP N ' (SQL Server) or ''
         const suffix = lc.suffix ? ` ${lc.suffix}` : '';   // ' LIMIT N' (PostgreSQL) or ''
-        return `SELECT ${prefix}* FROM (\n${sql}\n) AS _mj_capped${suffix}`;
+
+        // Strip top-level ORDER BY from the inner SQL to avoid SQL Server error:
+        // "The ORDER BY clause is invalid in views, inline functions, derived tables,
+        //  subqueries, and common table expressions, unless TOP, OFFSET or FOR XML
+        //  is also specified."
+        // Uses the lexer-based Tier 2 scanner which handles unparseable SQL
+        // (TRY_CAST, IIF, STRING_AGG, etc.) that the AST path cannot parse.
+        const orderByAnalysis = AnalyzeTopLevelOrderBy(sql, dialect);
+        const innerSQL = orderByAnalysis.OrderByClause && !orderByAnalysis.IsLegalInCTE
+            ? orderByAnalysis.SqlWithoutOrderBy
+            : sql;
+
+        const outerOrderBy = orderByAnalysis.OrderByClause && !orderByAnalysis.IsLegalInCTE
+            ? `\nORDER BY ${orderByAnalysis.OrderByClause}`
+            : '';
+
+        return `SELECT ${prefix}* FROM (\n${innerSQL}\n) AS _mj_capped${suffix}${outerOrderBy}`;
     }
 
     /**

--- a/packages/MJCore/src/generic/interfaces.ts
+++ b/packages/MJCore/src/generic/interfaces.ts
@@ -1329,6 +1329,13 @@ export type RunQueryResult = {
      */
     AppliedParameters?: Record<string, any>;
     /**
+     * The fully rendered SQL that was actually executed against the database.
+     * On error, this reveals transformations applied by the render pipeline
+     * (composition, Nunjucks templates, MaxRows wrapping, paging) that may
+     * have caused the failure — e.g., an ORDER BY moved into a derived table.
+     */
+    RenderedSQL?: string;
+    /**
      * Whether this result was served from cache
      */
     CacheHit?: boolean;

--- a/packages/MJServer/src/context.ts
+++ b/packages/MJServer/src/context.ts
@@ -705,7 +705,12 @@ async function createPerRequestProviders(
     { provider: p, type: 'Read-Write' }
   ];
 
-  if (!isPostgres) {
+  if (isPostgres) {
+    const rp = await tryCreateReadOnlyPostgresProvider();
+    if (rp) {
+      providers.push({ provider: rp, type: 'Read-Only' });
+    }
+  } else {
     const rp = await tryCreateReadOnlyProvider(dataSources);
     if (rp) {
       providers.push({ provider: rp, type: 'Read-Only' });
@@ -746,6 +751,46 @@ async function createPostgresProvider(): Promise<DatabaseProviderBase> {
   }
 
   return pgProvider;
+}
+
+/**
+ * Attempts to create a read-only PostgreSQL provider using DB_READ_ONLY_USERNAME/PASSWORD.
+ * Shares the connection pool from the primary provider. Returns null if no read-only credentials are configured.
+ */
+async function tryCreateReadOnlyPostgresProvider(): Promise<DatabaseProviderBase | null> {
+  const roUser = process.env.PG_READ_ONLY_USERNAME || process.env.DB_READ_ONLY_USERNAME;
+  const roPass = process.env.PG_READ_ONLY_PASSWORD || process.env.DB_READ_ONLY_PASSWORD;
+  if (!roUser || !roPass) {
+    return null;
+  }
+
+  try {
+    const { PostgreSQLDataProvider, PostgreSQLProviderConfigData } = await import('@memberjunction/postgresql-dataprovider');
+    const pgHost = process.env.PG_HOST || process.env.DB_HOST || 'localhost';
+    const pgPort = parseInt(process.env.PG_PORT || process.env.DB_PORT || '5432', 10);
+    const pgDatabase = process.env.PG_DATABASE || process.env.DB_DATABASE || '';
+
+    const roProvider = new PostgreSQLDataProvider();
+    const roConfig = new PostgreSQLProviderConfigData(
+      { Host: pgHost, Port: pgPort, Database: pgDatabase, User: roUser, Password: roPass },
+      mj_core_schema,
+      0,
+      undefined,
+      undefined,
+      false,
+    );
+
+    const primaryProvider = Metadata.Provider as unknown as { DatabaseConnection?: import('pg').Pool };
+    if (primaryProvider?.DatabaseConnection) {
+      await roProvider.ConfigWithSharedPool(roConfig, primaryProvider.DatabaseConnection);
+    } else {
+      await roProvider.Config(roConfig);
+    }
+
+    return roProvider;
+  } catch (_err) {
+    return null;
+  }
 }
 
 /**

--- a/packages/MJServer/src/resolvers/TestQuerySQLResolver.ts
+++ b/packages/MJServer/src/resolvers/TestQuerySQLResolver.ts
@@ -75,6 +75,9 @@ export class TestQuerySQLResult {
 
     @Field(() => String, { nullable: true, description: 'JSON-stringified applied parameters including defaults' })
     AppliedParameters?: string;
+
+    @Field(() => String, { nullable: true, description: 'The fully rendered SQL that was executed against the database. On error, reveals transformations (composition, templates, MaxRows wrapping) that may have caused the failure.' })
+    RenderedSQL?: string;
 }
 
 /**
@@ -133,6 +136,7 @@ export class TestQuerySQLResolver extends ResolverBase {
                 ExecutionTime: result.ExecutionTime,
                 ErrorMessage: result.ErrorMessage || undefined,
                 AppliedParameters: result.AppliedParameters ? JSON.stringify(result.AppliedParameters) : undefined,
+                RenderedSQL: result.RenderedSQL || undefined,
             };
         } catch (err) {
             LogError(err);

--- a/packages/OpenApp/Engine/src/install/config-manager.ts
+++ b/packages/OpenApp/Engine/src/install/config-manager.ts
@@ -582,6 +582,153 @@ function InsertBeforeModuleExportsClose(content: string, section: string): strin
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
+// EXCLUDE SCHEMAS (CodeGen)
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * Adds an app's schema to the `excludeSchemas` array in mj.config.cjs.
+ *
+ * CodeGen uses `excludeSchemas` to skip entity discovery, view generation,
+ * and Angular component generation for schemas owned by external apps.
+ * Without this, CodeGen will pick up app-owned tables (e.g. flyway_schema_history)
+ * and create unwanted entity metadata.
+ *
+ * @param repoRoot - Absolute path to the monorepo root
+ * @param schemaName - The schema name to exclude
+ * @param serverPackagePath - Optional server package path for config resolution
+ * @returns Operation result
+ */
+export function AddExcludeSchema(
+    repoRoot: string,
+    schemaName: string,
+    serverPackagePath?: string
+): ConfigOperationResult {
+    if (!schemaName) {
+        return { Success: true };
+    }
+
+    const configPath = resolveConfigPath(repoRoot, serverPackagePath);
+    if (!configPath) {
+        return { Success: false, ErrorMessage: `No MJ config file found in ${repoRoot}. Expected: ${CONFIG_FILE_NAME}` };
+    }
+
+    try {
+        let content = readFileSync(configPath, 'utf-8');
+        content = EnsureExcludeSchemasSection(content);
+        content = AddSchemaToExcludeArray(content, schemaName);
+        WriteConfigChecked(configPath, content);
+        return { Success: true };
+    }
+    catch (error: unknown) {
+        const message = error instanceof Error ? error.message : String(error);
+        return { Success: false, ErrorMessage: `Failed to update excludeSchemas config: ${message}` };
+    }
+}
+
+/**
+ * Removes an app's schema from the `excludeSchemas` array in mj.config.cjs.
+ *
+ * @param repoRoot - Absolute path to the monorepo root
+ * @param schemaName - The schema name to remove from exclusion
+ * @param serverPackagePath - Optional server package path for config resolution
+ * @returns Operation result
+ */
+export function RemoveExcludeSchema(
+    repoRoot: string,
+    schemaName: string,
+    serverPackagePath?: string
+): ConfigOperationResult {
+    if (!schemaName) {
+        return { Success: true };
+    }
+
+    const configPath = resolveConfigPath(repoRoot, serverPackagePath);
+    if (!configPath) {
+        return { Success: false, ErrorMessage: `No MJ config file found in ${repoRoot}` };
+    }
+
+    try {
+        let content = readFileSync(configPath, 'utf-8');
+        content = RemoveSchemaFromExcludeArray(content, schemaName);
+        WriteConfigChecked(configPath, content);
+        return { Success: true };
+    }
+    catch (error: unknown) {
+        const message = error instanceof Error ? error.message : String(error);
+        return { Success: false, ErrorMessage: `Failed to remove schema from excludeSchemas: ${message}` };
+    }
+}
+
+/**
+ * Ensures the config file has an excludeSchemas array.
+ * If it doesn't exist, adds one inside the module.exports object.
+ */
+function EnsureExcludeSchemasSection(content: string): string {
+    if (/excludeSchemas\s*:/.test(content)) {
+        return content;
+    }
+
+    const section = `\n  excludeSchemas: [],\n`;
+    return InsertBeforeModuleExportsClose(content, section);
+}
+
+/**
+ * Adds a schema name to the first excludeSchemas array if not already present.
+ */
+function AddSchemaToExcludeArray(content: string, schemaName: string): string {
+    // Check if the schema is already in the array (case-insensitive)
+    const alreadyExists = new RegExp(
+        `excludeSchemas\\s*:\\s*\\[[^\\]]*['"]${EscapeRegex(schemaName)}['"]`,
+        'i'
+    );
+    if (alreadyExists.test(content)) {
+        return content;
+    }
+
+    // Find the first excludeSchemas array's closing bracket
+    const arrayMatch = content.match(/excludeSchemas\s*:\s*\[/);
+    if (!arrayMatch || arrayMatch.index === undefined) {
+        return content;
+    }
+
+    const openBracketPos = arrayMatch.index + arrayMatch[0].length - 1;
+    const closingBracket = FindMatchingBracket(content, openBracketPos);
+    if (closingBracket === -1) {
+        return content;
+    }
+
+    // Check if the array has existing entries to determine formatting
+    const arrayContent = content.slice(openBracketPos + 1, closingBracket).trim();
+    const entry = arrayContent.length > 0
+        ? `, '${schemaName}'`
+        : `'${schemaName}'`;
+
+    return content.slice(0, closingBracket) + entry + content.slice(closingBracket);
+}
+
+/**
+ * Removes a schema name from all excludeSchemas arrays in the config.
+ */
+function RemoveSchemaFromExcludeArray(content: string, schemaName: string): string {
+    // Remove the schema entry (with optional leading comma+space or trailing comma+space)
+    const patterns = [
+        // Entry with leading comma: , 'schemaName'
+        new RegExp(`,\\s*'${EscapeRegex(schemaName)}'`, 'gi'),
+        // Entry with trailing comma (first in array): 'schemaName',
+        new RegExp(`'${EscapeRegex(schemaName)}'\\s*,\\s*`, 'gi'),
+        // Sole entry: 'schemaName'
+        new RegExp(`'${EscapeRegex(schemaName)}'`, 'gi'),
+    ];
+
+    for (const pattern of patterns) {
+        if (pattern.test(content)) {
+            return content.replace(pattern, '');
+        }
+    }
+    return content;
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
 // ENTITY PACKAGE NAME MAPPING
 // ─────────────────────────────────────────────────────────────────────────────
 

--- a/packages/OpenApp/Engine/src/install/install-orchestrator.ts
+++ b/packages/OpenApp/Engine/src/install/install-orchestrator.ts
@@ -23,7 +23,7 @@ import { RunFkGraphTeardown, buildRootDoomedPredicate } from './entity-teardown.
 import { extractApplicationIds } from './migration-application-ids.js';
 import { RunAppMigrations, type SkywayDatabaseConfig } from './migration-runner.js';
 import { AddAppPackages, RemoveAppPackages, RunPackageInstall, BumpPrefixedDependencies, type PackageManagerType, type VersionStrategy, type WorkspaceTarget } from './package-manager.js';
-import { AddServerDynamicPackages, AddClientDynamicPackages, RemoveServerDynamicPackages, ToggleServerDynamicPackages, AddEntityPackageMapping, RemoveEntityPackageMapping } from './config-manager.js';
+import { AddServerDynamicPackages, AddClientDynamicPackages, RemoveServerDynamicPackages, ToggleServerDynamicPackages, AddEntityPackageMapping, RemoveEntityPackageMapping, AddExcludeSchema, RemoveExcludeSchema } from './config-manager.js';
 import { AngularConfigManager } from './angular-config-manager.js';
 import { BaseEntity, DatabaseProviderBase, Metadata, RunView } from '@memberjunction/core';
 import type { UserInfo, IMetadataProvider, TransactionGroupBase } from '@memberjunction/core';
@@ -1125,6 +1125,7 @@ export async function RemoveApp(options: RemoveOptions, context: OrchestratorCon
       await Promise.all([
         Promise.resolve(RemoveServerDynamicPackages(context.RepoRoot, options.AppName, context.ServerPackagePath)),
         Promise.resolve(manifest.schema ? RemoveEntityPackageMapping(context.RepoRoot, manifest.schema.name, context.ServerPackagePath) : undefined),
+        Promise.resolve(manifest.schema ? RemoveExcludeSchema(context.RepoRoot, manifest.schema.name, context.ServerPackagePath) : undefined),
         Promise.resolve(HandleAngularPrebundleExcludeRemoval(manifest, otherManifests, context)),
         Promise.resolve(
           RemoveAppPackages({
@@ -1759,6 +1760,15 @@ function HandleServerConfig(manifest: MJAppManifest, context: OrchestratorContex
   const entityResult = AddEntityPackageMapping(context.RepoRoot, manifest, context.ServerPackagePath);
   if (!entityResult.Success) {
     return { Success: false, ErrorMessage: entityResult.ErrorMessage };
+  }
+
+  // Add app schema to excludeSchemas so CodeGen skips entity discovery,
+  // view generation, and Angular component generation for app-owned tables
+  if (manifest.schema?.name) {
+    const excludeResult = AddExcludeSchema(context.RepoRoot, manifest.schema.name, context.ServerPackagePath);
+    if (!excludeResult.Success) {
+      return { Success: false, ErrorMessage: excludeResult.ErrorMessage };
+    }
   }
 
   return { Success: true };

--- a/packages/PostgreSQLDataProvider/src/PostgreSQLDataProvider.ts
+++ b/packages/PostgreSQLDataProvider/src/PostgreSQLDataProvider.ts
@@ -1430,7 +1430,9 @@ WHERE ${pgDialect.QuoteIdentifier(pkName)} = '${safePKValue}';`;
         'NEWSEQUENTIALID', 'NEWID', 'GETUTCDATE', 'GETDATE', 'SYSDATETIMEOFFSET',
         'OBJECT_ID', 'SCOPE_IDENTITY',
         // Aggregate / scalar functions
-        'COUNT', 'MAX', 'MIN', 'SUM', 'AVG', 'COALESCE', 'CAST', 'CONVERT', 'ISNULL',
+        'COUNT', 'MAX', 'MIN', 'SUM', 'AVG', 'ROUND', 'NULLIF', 'ABS', 'CEIL', 'CEILING', 'FLOOR',
+        'SIGN', 'MOD', 'POWER', 'SQRT', 'LOG', 'EXP', 'RANDOM',
+        'COALESCE', 'CAST', 'CONVERT', 'ISNULL',
         'LEN', 'LENGTH', 'DATALENGTH', 'LOWER', 'UPPER', 'LTRIM', 'RTRIM', 'TRIM', 'REPLACE',
         'SUBSTRING', 'CHARINDEX', 'PATINDEX', 'STUFF', 'CONCAT', 'FORMAT',
         'POSITION', 'OVERLAY', 'EXTRACT', 'GREATEST', 'LEAST',


### PR DESCRIPTION
## Summary

- **fix: Apply to my Form** — resolve spec code, handle Pending overrides, improve `#` typeahead in conversations
- **feat(open-app): auto-add app schemas to `excludeSchemas`** on OpenApp install/upgrade
- **feat: surface `RenderedSQL`** through `RunQueryResult` and `TestQuerySQL` resolver
- **fix: strip `ORDER BY`** before outer-wrapping unparseable SQL in MaxRows paging
- **fix(codegen): lazy-config loader variable name collisions** — `buildLoaderVarName` now uniquifies names when multiple packages export the same subpath (e.g. two `./plugins` both producing `const loadPlugins` → TS2451)
- **fix(pg): add read-only provider support** and missing SQL function keywords in PostgreSQL provider

## Packages affected

`@memberjunction/ng-artifacts`, `@memberjunction/ng-conversations`, `@memberjunction/ng-explorer-core`, `@memberjunction/generic-database-provider`, `@memberjunction/core`, `@memberjunction/server`, `@memberjunction/open-app-engine`, `@memberjunction/codegen-lib`, `@memberjunction/postgresql-dataprovider`

## Test plan

- [x] `ng-explorer-core` builds successfully (was broken by duplicate `loadPlugins` variable)
- [ ] Verify `Apply to my Form` in conversations UI
- [ ] Verify OpenApp install correctly adds schemas to `excludeSchemas`
- [ ] Verify `RenderedSQL` appears in `RunQueryResult` and `TestQuerySQL` responses
- [ ] Verify MaxRows paging with queries containing `ORDER BY`
- [ ] Verify PostgreSQL read-only provider and SQL function keyword handling

🤖 Generated with [Claude Code](https://claude.com/claude-code)