### PR TITLE
fix(server): allowlist two legitimate global-provider references (green next)

### DIFF
--- a/.changeset/fix-global-provider-compliance-allowlist.md
+++ b/.changeset/fix-global-provider-compliance-allowlist.md
@@ -1,0 +1,5 @@
+---
+"@memberjunction/server": patch
+---
+
+Allowlist two legitimate global-provider references that were tripping the MultiProviderCompliance guard and holding `next` red. Comment-only change (no runtime or type impact): `context.ts`'s read-only-provider bootstrap pool-share (a verbatim twin of the already-blessed line at 746) and the `lists-tests.ts` integration-test harness now carry the documented `// global-provider-ok: <reason>` inline marker instead of being refactored — both are genuine single-provider/bootstrap uses, not per-provider request paths.

--- a/packages/MJServer/integration-test-scripts/lists-tests.ts
+++ b/packages/MJServer/integration-test-scripts/lists-tests.ts
@@ -95,7 +95,7 @@ async function drain(source: ListSource, startCursor: ProcessCursor | undefined,
 async function main(): Promise<void> {
     const { user } = await bootstrapAI();
     const suite = new TestRunner('Lists live integration (deterministic — ListSource keyset pagination)');
-    const md = new Metadata();
+    const md = new Metadata(); // global-provider-ok: integration-test harness runs as a single-provider script
 
     const entResult = await new RunView().RunView(
         { EntityName: 'MJ: Entities', ResultType: 'simple', MaxRows: 1 }, user,

--- a/packages/MJServer/src/context.ts
+++ b/packages/MJServer/src/context.ts
@@ -780,7 +780,7 @@ async function tryCreateReadOnlyPostgresProvider(): Promise<DatabaseProviderBase
       false,
     );
 
-    const primaryProvider = Metadata.Provider as unknown as { DatabaseConnection?: import('pg').Pool };
+    const primaryProvider = Metadata.Provider as unknown as { DatabaseConnection?: import('pg').Pool }; // global-provider-ok: bootstrap (share primary provider's PG pool with the read-only provider)
     if (primaryProvider?.DatabaseConnection) {
       await roProvider.ConfigWithSharedPool(roConfig, primaryProvider.DatabaseConnection);
     } else {


### PR DESCRIPTION
## What

`next` is currently red: the **MultiProviderCompliance** guard in `@memberjunction/global` (`MultiProviderCompliance.test.ts`) fails on **2 non-allowlisted global-provider references**. Both landed on `next` the same day (via #3145 and a pg read-only-provider fix). This PR annotates both with the documented `// global-provider-ok: <reason>` inline marker.

```
MJServer/src/context.ts:783                          Metadata.Provider as unknown as { DatabaseConnection?: ... }
MJServer/integration-test-scripts/lists-tests.ts:98  new Metadata()
```

## Why these are false positives (annotate, don't refactor)

- **`context.ts:783`** — grabs the primary provider's PG connection pool to share it with the **read-only** provider during bootstrap. It is a **verbatim copy** of the already-blessed pool-share at `context.ts:746` (`// global-provider-ok: bootstrap (per-connection PG pool sharing)`); it simply omitted the marker. Bootstrap pool-sharing is a legitimate global-default use, not a per-provider request path.
- **`lists-tests.ts:98`** — `new Metadata()` inside an **integration-test harness**, which runs as a single-provider script by nature.

Refactoring either to thread a `provider` would be wrong. The guard explicitly documents the inline marker as the correct resolution for genuine bootstrap / script global use.

## Change

Comment-only, zero runtime/type impact:

- `context.ts:783` → `// global-provider-ok: bootstrap (share primary provider's PG pool with the read-only provider)`
- `lists-tests.ts:98` → `// global-provider-ok: integration-test harness runs as a single-provider script`

## Verification

- `MultiProviderCompliance.test.ts` → **green** (was `Found 2 non-allowlisted...`)
- Full `@memberjunction/global` suite → **558/558 pass** (previously 557 pass / 1 fail)

Built via `/tdd`: reproduced RED (2 violations, matching CI), fixed one violation per slice, confirmed 0 remaining.

🤖 Generated with [Claude Code](https://claude.com/claude-code)