### PR TITLE
fix(ai-agents): realtime media library uses canonical 'MJ: AI Agents' entity name

### DIFF
--- a/.changeset/fix-realtime-media-library-entity-name.md
+++ b/.changeset/fix-realtime-media-library-entity-name.md
@@ -1,0 +1,5 @@
+---
+"@memberjunction/ai-agents": patch
+---
+
+Fix realtime agent media library failing with "Entity AI Agents not found in metadata" — the agent lookup in `resolveAgentMediaCollectionID` used the pre-v5 unprefixed entity name `'AI Agents'` instead of the canonical `'MJ: AI Agents'`, so an agent's media kit (`DefaultMediaCollectionID` collection) silently never loaded at realtime session start. Adds a regression test pinning the canonical entity name.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -880,11 +880,12 @@ protected generateSingleOperation(operation: Operation): string {
 - **ALWAYS** use `/packages/MJCoreEntities/src/generated/entity_subclasses.ts` to find correct entity names
 - Entity names are in the `@RegisterClass` decorator JSDoc comments
 - Examples:
-  - `AIPromptEntity` → `"AI Prompts"`
-  - `AIAgentEntity` → `"AI Agents"`
-  - `AIModelEntity` → `"AI Models"`
-  - `AIPromptRunEntity` → `"MJ: AI Prompt Runs"` (newer entities use "MJ: " prefix)
-  - `AIAgentRunEntity` → `"MJ: AI Agent Runs"`
+  - `MJAIPromptEntity` → `"MJ: AI Prompts"`
+  - `MJAIAgentEntity` → `"MJ: AI Agents"`
+  - `MJAIModelEntity` → `"MJ: AI Models"`
+  - `MJAIPromptRunEntity` → `"MJ: AI Prompt Runs"`
+  - `MJAIAgentRunEntity` → `"MJ: AI Agent Runs"`
+- **As of v5.0, ALL core entities use the `MJ: ` prefix** (and `MJ*` class names) — an unprefixed name like `'AI Agents'` no longer resolves and throws `Entity AI Agents not found in metadata`
 
 ### Using Metadata Class
 - Create a single instance: `const md = new Metadata()`
@@ -953,9 +954,9 @@ function gateCacheWrite(name: string, provider?: IMetadataProvider) {
 
 ### 🚨 CRITICAL: Entity Naming Convention Warning
 
-**ALWAYS** use the correct entity names with the "MJ: " prefix where required. To prevent naming collisions on client systems, all new core entities use the "MJ: " prefix, while older entities do not.
+**ALWAYS** use the correct entity names with the "MJ: " prefix. To prevent naming collisions on client systems, ALL core entities use the "MJ: " prefix as of v5.0 — pre-v5 unprefixed names (e.g. `'AI Agents'`) no longer resolve in metadata.
 
-#### Core Entities with "MJ: " Prefix (MUST use full name):
+#### Examples of Core Entities with "MJ: " Prefix (MUST use full name):
 - **AI Entities**: `MJ: AI Agent Prompts`, `MJ: AI Agent Run Steps`, `MJ: AI Agent Runs`, `MJ: AI Agent Types`, `MJ: AI Configuration Params`, `MJ: AI Configurations`, `MJ: AI Model Costs`, `MJ: AI Model Price Types`, `MJ: AI Model Price Unit Types`, `MJ: AI Model Vendors`, `MJ: AI Prompt Models`, `MJ: AI Prompt Runs`, `MJ: AI Vendor Type Definitions`, `MJ: AI Vendor Types`, `MJ: AI Vendors`
 - **Artifact Entities**: `MJ: Artifact Types`, `MJ: Conversation Artifact Permissions`, `MJ: Conversation Artifact Versions`, `MJ: Conversation Artifacts`
 - **Dashboard Entities**: `MJ: Dashboard User Preferences`, `MJ: Dashboard User States`
@@ -964,12 +965,12 @@ function gateCacheWrite(name: string, provider?: IMetadataProvider) {
 #### Common Mistakes to Avoid:
 ```typescript
 // ❌ WRONG - Missing "MJ: " prefix
-const agentRun = await md.GetEntityObject<AIAgentRunEntity>('AI Agent Runs', contextUser);
-const agentPrompt = await md.GetEntityObject<AIAgentPromptEntity>('AI Agent Prompts', contextUser);
+const agentRun = await md.GetEntityObject<MJAIAgentRunEntity>('AI Agent Runs', contextUser);
+const agentPrompt = await md.GetEntityObject<MJAIAgentPromptEntity>('AI Agent Prompts', contextUser);
 
 // ✅ CORRECT - Full entity name with "MJ: " prefix
-const agentRun = await md.GetEntityObject<AIAgentRunEntity>('MJ: AI Agent Runs', contextUser);
-const agentPrompt = await md.GetEntityObject<AIAgentPromptEntity>('MJ: AI Agent Prompts', contextUser);
+const agentRun = await md.GetEntityObject<MJAIAgentRunEntity>('MJ: AI Agent Runs', contextUser);
+const agentPrompt = await md.GetEntityObject<MJAIAgentPromptEntity>('MJ: AI Agent Prompts', contextUser);
 ```
 
 **Always verify entity names** by checking `/packages/MJCoreEntities/src/generated/entity_subclasses.ts` or the `@RegisterClass` decorator JSDoc comments.

--- a/packages/AI/Agents/src/__tests__/agent-media-library.test.ts
+++ b/packages/AI/Agents/src/__tests__/agent-media-library.test.ts
@@ -98,6 +98,18 @@ describe('resolveAgentMediaCollectionID', () => {
         runViewMock.mockResolvedValueOnce({ Success: true, Results: [] });
         expect(await resolveAgentMediaCollectionID(PROVIDER, USER, 'agent-1')).toBeNull();
     });
+
+    it("looks the agent up via the canonical 'MJ: AI Agents' entity name", async () => {
+        // The AIAgent entity was renamed to 'MJ: AI Agents' in v5; the unprefixed name no longer
+        // resolves in metadata, so RunView throws "Entity AI Agents not found in metadata" and the
+        // realtime media kit silently never loads.
+        runViewMock.mockResolvedValueOnce({ Success: true, Results: [{ DefaultMediaCollectionID: 'agent-col' }] });
+        await resolveAgentMediaCollectionID(PROVIDER, USER, 'agent-1');
+        expect(runViewMock).toHaveBeenCalledWith(
+            expect.objectContaining({ EntityName: 'MJ: AI Agents' }),
+            USER,
+        );
+    });
 });
 
 describe('resolveAgentMediaManifest', () => {

--- a/packages/AI/Agents/src/realtime/agent-media-library.ts
+++ b/packages/AI/Agents/src/realtime/agent-media-library.ts
@@ -80,7 +80,7 @@ export async function resolveAgentMediaCollectionID(
     }
     const rv = RunView.FromMetadataProvider(provider);
     const result = await rv.RunView<MJAIAgentEntity>(
-        { EntityName: 'AI Agents', ExtraFilter: `ID='${agentID}'`, ResultType: 'entity_object' },
+        { EntityName: 'MJ: AI Agents', ExtraFilter: `ID='${agentID}'`, ResultType: 'entity_object' },
         contextUser,
     );
     if (!result.Success || result.Results.length === 0) {


### PR DESCRIPTION
## Summary

Fixes the realtime agent media library failing on every session start with:

```
[agent-media-library] Failed to build media manifest for agent <ID>: Entity AI Agents not found in metadata
```

The agent lookup in `resolveAgentMediaCollectionID` (`packages/AI/Agents/src/realtime/agent-media-library.ts`) queried `EntityName: 'AI Agents'` — the pre-v5 unprefixed name. All core entities have been `MJ: `-prefixed since v5.0 (today **all 379** registered entities carry the prefix; zero unprefixed names remain), so the lookup threw on every realtime session since the media library shipped in v5.44.

## Why the bug is legit — yet realtime kept working

Both are true, which is exactly why this went unnoticed for four releases:

1. **The bug is real**: the unprefixed name cannot resolve — `ProviderBase.EntityByName` throws `"Entity AI Agents not found in metadata"` verbatim. Reproduced live against an MJ 5.47 database: the pre-fix code throws this exact error for any agent ID.
2. **But it never broke a call**: `buildAgentMediaContextNote` is deliberately best-effort — it catches everything, logs, and returns `null` so it "can never break session start" (per its own docstring). Voice sessions proceed normally; the error is just a log line.
3. **And the broken behavior was invisible**: the only casualty is the agent's media kit (`DefaultMediaCollectionID` collection) silently never loading. For agents with no media kit configured — the common case — the buggy path and the correct path produce the identical outcome (`null`, no manifest). Only an agent that *has* a curated media kit would ever show a symptom, and even then the symptom is "media just doesn't appear," not an error.
4. **Why tests missed it**: the unit suite mocks `RunView` wholesale, so the entity name was never validated against real metadata. The new regression test pins the canonical name at the mock boundary.

**Root cause**: the media-library code was written (v5.44, June 2026) months *after* the v5.0 rename, following stale guidance — the root `CLAUDE.md` still documented `AIAgentEntity` → `"AI Agents"` as a correct example. This PR fixes that documentation too, so the same bug doesn't get bred again.

## Changes

- `agent-media-library.ts` — one-line fix: `'AI Agents'` → `'MJ: AI Agents'`
- `agent-media-library.test.ts` — regression test asserting the agent lookup uses the canonical entity name (fails RED on the old code)
- `CLAUDE.md` — corrected the three stale entity-naming spots (examples block, "older entities do not [use the prefix]" claim, and dead `AIAgentRunEntity`/`AIAgentPromptEntity` class names)
- Patch changeset for `@memberjunction/ai-agents`

## Verification

- TDD red→green: new test fails against the old code, passes with the fix
- Full `@memberjunction/ai-agents` suite: **1639/1639 pass**; package builds clean
- Live smoke test against an MJ 5.47 dev DB (real `SQLServerDataProvider` stack, integration-harness bootstrap): unpatched code reproduces the customer's exact error; patched `resolveAgentMediaCollectionID` and `buildAgentMediaContextNote` complete cleanly
- Grep confirms the fixed line was the only unprefixed `'AI Agents'` RunView usage in `packages/`
- Opus code review of the diff: no defects found (one pre-existing, low-severity defense-in-depth note about `agentID` interpolation outside this diff's scope)

🤖 Generated with [Claude Code](https://claude.com/claude-code)