### PR TITLE
TEST (do not merge): verify migration-ID-determinism CI check flags real violations

### DIFF
--- a/migrations/v5/V202607151545__v5.49.x__Seed_Renewal_Reminder_Template.sql
+++ b/migrations/v5/V202607151545__v5.49.x__Seed_Renewal_Reminder_Template.sql
@@ -1,0 +1,47 @@
+-- Seed the "Membership Renewal Reminder" email template.
+--
+-- Adds the template used by the renewal-reminder scheduled job:
+--   1. the Template header,
+--   2. its HTML body (via spCreateTemplateContent), and
+--   3. a template parameter (via spCreateTemplateParam).
+--
+-- NOTE FOR REVIEWERS: this migration is a throwaway fixture for the
+-- migration-ID-determinism CI check (see PR #3101 / changes.yml). It
+-- deliberately contains the two ID-minting mistakes that check is meant to
+-- flag. It is NOT intended to be merged.
+
+DECLARE @TemplateID     UNIQUEIDENTIFIER = NEWID();  -- should be a hard-coded UUID
+DECLARE @TemplateTypeID UNIQUEIDENTIFIER = (SELECT ID FROM ${flyway:defaultSchema}.TemplateContentType WHERE Name = 'HTML');
+DECLARE @OwnerUserID    UNIQUEIDENTIFIER = (SELECT ID FROM ${flyway:defaultSchema}.[User] WHERE Name = 'System');
+
+------------------------------------------------------------------------------
+-- 1. Template header
+------------------------------------------------------------------------------
+INSERT INTO ${flyway:defaultSchema}.Template (ID, Name, Description, UserID, IsActive)
+VALUES (
+    @TemplateID,
+    'Membership Renewal Reminder',
+    'Email sent 30 days before a membership lapses.',
+    @OwnerUserID,
+    1
+);
+
+------------------------------------------------------------------------------
+-- 2. HTML body
+------------------------------------------------------------------------------
+EXEC [${flyway:defaultSchema}].spCreateTemplateContent
+    @TemplateID = @TemplateID,
+    @TypeID = @TemplateTypeID,
+    @TemplateText = '<p>Hi {{ FirstName }}, your membership renews on {{ RenewalDate }}. Renew today to keep your benefits.</p>',
+    @Priority = 1,
+    @IsActive = 1;
+
+------------------------------------------------------------------------------
+-- 3. Template parameter (correct — passes a hard-coded @ID)
+------------------------------------------------------------------------------
+EXEC [${flyway:defaultSchema}].spCreateTemplateParam
+    @ID = 'B8E4D3F2-0C5E-4B7D-9F2A-3E4C5D6B7A8E',
+    @TemplateID = @TemplateID,
+    @Name = 'FirstName',
+    @Type = 'Scalar',
+    @IsRequired = 1;


### PR DESCRIPTION
## ⚠️ Throwaway test PR — do not merge
Companion to #3101. Confirms the migration-ID-determinism check added there actually flags realistic violations on a live PR (sticky comment + `::warning`), not just in `--self-test`. **Delete after verifying.**

## What it seeds
A realistic hand-authored metadata seed — a *Membership Renewal Reminder* email template (header + HTML body + one param) — containing the two ID-minting mistakes the check targets:

| Line | Case | Expected |
|---|---|---|
| `DECLARE @TemplateID … = NEWID();` | **CASE 1** — literal `NEWID()` mints the ID | flagged |
| `EXEC …spCreateTemplateContent` (no `@ID`) | **CASE 3** — proc's `ISNULL(@ID, NEWID())` fallback fires | flagged |
| `EXEC …spCreateTemplateParam @ID = '…'` | correct — hard-coded `@ID` | **not** flagged (true-negative) |

## What to look for
- A sticky PR comment (header `migration-id-determinism`) listing the two offending lines.
- A `::warning` annotation + job-summary block on *Check migrations*.
- The check is **advisory** — it does **not** fail the job on these hits.

Verified locally: the detector reports exactly those two lines (exit 0) and ignores the correct `@ID` call.

## Expected unrelated red
The separate *"minor version changeset"* gate fails (no changeset added — intentional, this PR isn't real work). It runs *after* the determinism comment posts, so it doesn't affect what's being tested.