### PR TITLE
docs(ai-huggingface): note ~32k-context minimum for the LLM backend

### DIFF
--- a/packages/AI/Providers/HuggingFace/readme.md
+++ b/packages/AI/Providers/HuggingFace/readme.md
@@ -33,6 +33,9 @@ All deployment config — no `mj.config.cjs` changes required:
 
 > The realtime resolver requires a *resolvable* API key for a model to be selectable, so a keyless endpoint should set `AI_VENDOR_API_KEY__HuggingFaceRealtime=none`.
 
+> [!IMPORTANT]
+> **Provision the LLM backend with ≥ 32k context.** MJ's realtime co-agent system prompt (identity framing + tool schemas + injected memory + conversation history) is large and burns context quickly, so the HF pipeline's LLM stage should run with a context window of **at least ~32k tokens** — a smaller window starves mid-conversation (the model loses the prompt/tools partway through). Confirmed during live bring-up. This is a provisioning requirement on your HF deployment, not an MJ setting.
+
 ## Metadata
 
 Seeded as the `HuggingFace Speech-to-Speech` model (`MJ: AI Models`, type `Realtime`) under the `Hugging Face` vendor, `DriverClass: HuggingFaceRealtime`. Its `PowerRank` is intentionally low so it is **opt-in**, never the default realtime provider.


### PR DESCRIPTION
## Capture a live bring-up finding — HF S2S needs ≥ 32k context

Follow-up to #3011 (the self-hosted HuggingFace speech-to-speech realtime provider, now merged). During live end-to-end testing, @pranavrao-BC found that the HF pipeline's LLM stage must be provisioned with a reasonably large context window:

> got it working fairly quickly... you need to provision a bare minimum of ~32k context, our system prompts use it up rapidly

That's a real operational gotcha worth not losing: MJ's realtime co-agent system prompt (identity framing + tool schemas + injected memory + conversation history) is large and burns context fast, so a small-context local model starves mid-conversation — it loses the prompt/tools partway through and quietly stops behaving.

This PR adds a short **`> [!IMPORTANT]`** note to the provider README (`packages/AI/Providers/HuggingFace/readme.md`) recording the ≥ 32k recommendation and framing it as a provisioning requirement on the HF deployment, not an MJ setting.

Docs-only — one file, three lines, no code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KhnN7q4p3dV1WnjNd49h2h

---
_Generated by [Claude Code](https://claude.ai/code/session_01KhnN7q4p3dV1WnjNd49h2h)_