### PR TITLE
fix(server): 3 defects from the integration-test audit (query injection, OAuth XSS, log hygiene)

### DIFF
--- a/metadata/queries/SQL/get-conversations-for-memory-manager.sql
+++ b/metadata/queries/SQL/get-conversations-for-memory-manager.sql
@@ -67,7 +67,7 @@ WHERE EXISTS (
     SELECT 1 FROM [__mj].[vwConversationDetails] cd_new
     WHERE cd_new.ConversationID = c.ID
     {% if since %}
-    AND cd_new.__mj_CreatedAt >= '{{ since }}'
+    AND cd_new.__mj_CreatedAt >= {{ since | sqlDate }}
     {% endif %}
 )
 

--- a/packages/MJServer/src/__tests__/OAuthCallbackHandler.xss.test.ts
+++ b/packages/MJServer/src/__tests__/OAuthCallbackHandler.xss.test.ts
@@ -1,0 +1,83 @@
+import { describe, it, expect } from 'vitest';
+import type express from 'express';
+import { OAuthCallbackHandler } from '../rest/OAuthCallbackHandler.js';
+
+/**
+ * These tests verify that query-string-derived values interpolated into the OAuth
+ * success/error HTML pages are HTML-escaped, preventing reflected XSS (audit bug B6).
+ *
+ * The page renderers are private, so we reach them through a narrowly-typed view of
+ * the instance using the codebase's established `as unknown as` double-assertion pattern.
+ */
+interface PageRenderer {
+    handleSuccessPage(req: express.Request, res: express.Response): void;
+    handleErrorPage(req: express.Request, res: express.Response): void;
+    escapeHtml(value: string): string;
+}
+
+function makeRenderer(): PageRenderer {
+    const handler = new OAuthCallbackHandler({ publicUrl: 'https://example.test' });
+    return handler as unknown as PageRenderer;
+}
+
+/** Minimal Express request/response doubles that capture the rendered body. */
+function makeReqRes(query: Record<string, string>): {
+    req: express.Request;
+    res: express.Response;
+    getBody: () => string;
+} {
+    let body = '';
+    const res = {
+        status(): express.Response {
+            return res as unknown as express.Response;
+        },
+        send(html: string): express.Response {
+            body = html;
+            return res as unknown as express.Response;
+        }
+    };
+    return {
+        req: { query } as unknown as express.Request,
+        res: res as unknown as express.Response,
+        getBody: () => body
+    };
+}
+
+describe('OAuthCallbackHandler escapeHtml', () => {
+    it('neutralizes <script>, quotes, and ampersands', () => {
+        const renderer = makeRenderer();
+        const escaped = renderer.escapeHtml(`<script>alert("x")&'y'</script>`);
+        expect(escaped).toBe('&lt;script&gt;alert(&quot;x&quot;)&amp;&#39;y&#39;&lt;/script&gt;');
+        expect(escaped).not.toContain('<script>');
+    });
+
+    it('escapes & first so no double-encoding occurs', () => {
+        const renderer = makeRenderer();
+        expect(renderer.escapeHtml('&lt;')).toBe('&amp;lt;');
+    });
+});
+
+describe('OAuthCallbackHandler reflected-XSS protection', () => {
+    it('escapes a malicious connectionId on the success page', () => {
+        const renderer = makeRenderer();
+        const { req, res, getBody } = makeReqRes({ connectionId: '<script>alert(1)</script>' });
+        renderer.handleSuccessPage(req, res);
+        const body = getBody();
+        expect(body).not.toContain('<script>alert(1)</script>');
+        expect(body).toContain('&lt;script&gt;alert(1)&lt;/script&gt;');
+    });
+
+    it('escapes malicious error code and description on the error page', () => {
+        const renderer = makeRenderer();
+        const { req, res, getBody } = makeReqRes({
+            error: '"><img src=x onerror=alert(1)>',
+            error_description: `</div><script>evil()</script>`
+        });
+        renderer.handleErrorPage(req, res);
+        const body = getBody();
+        expect(body).not.toContain('<img src=x onerror=alert(1)>');
+        expect(body).not.toContain('<script>evil()</script>');
+        expect(body).toContain('&lt;img src=x onerror=alert(1)&gt;');
+        expect(body).toContain('&lt;script&gt;evil()&lt;/script&gt;');
+    });
+});

--- a/packages/MJServer/src/resolvers/QueryResolver.ts
+++ b/packages/MJServer/src/resolvers/QueryResolver.ts
@@ -202,7 +202,6 @@ export class RunQueryResolver extends ResolverBase {
     const provider = GetReadOnlyProvider(context.providers, {allowFallbackToReadWrite: true});
     const md = provider as unknown as IMetadataProvider;
     const rq = new RunQuery(provider as unknown as IRunQueryProvider);
-    console.log('GetQueryData called with:', { QueryID, Parameters, MaxRows, StartRow, ForceAuditLog, AuditLogDescription });
     const result = await rq.RunQuery(
       {
         QueryID: QueryID,
@@ -216,12 +215,7 @@ export class RunQueryResolver extends ResolverBase {
         Enrichment: Enrichment
       },
       context.userPayload.userRecord);
-    console.log('RunQuery result:', { 
-      Success: result.Success, 
-      ErrorMessage: result.ErrorMessage,
-      AppliedParameters: result.AppliedParameters 
-    });
-    
+
     // If QueryName is not populated by the provider, use efficient lookup
     let queryName = result.QueryName;
     if (!queryName) {

--- a/packages/MJServer/src/rest/OAuthCallbackHandler.ts
+++ b/packages/MJServer/src/rest/OAuthCallbackHandler.ts
@@ -98,7 +98,8 @@ export class OAuthCallbackHandler {
      * Renders a success page after OAuth authorization completes.
      */
     private handleSuccessPage(req: express.Request, res: express.Response): void {
-        const { state, connectionId } = req.query;
+        const { connectionId } = req.query;
+        const safeConnectionId = connectionId ? this.escapeHtml(String(connectionId)) : '';
         res.status(200).send(`
 <!DOCTYPE html>
 <html lang="en">
@@ -120,7 +121,7 @@ export class OAuthCallbackHandler {
         <div class="icon">✅</div>
         <h1>Authorization Successful</h1>
         <p>Your MCP server connection has been authorized. You can close this window and return to MemberJunction.</p>
-        ${connectionId ? `<div class="details">Connection ID: ${connectionId}</div>` : ''}
+        ${safeConnectionId ? `<div class="details">Connection ID: ${safeConnectionId}</div>` : ''}
     </div>
 </body>
 </html>
@@ -132,8 +133,8 @@ export class OAuthCallbackHandler {
      */
     private handleErrorPage(req: express.Request, res: express.Response): void {
         const { error, error_description } = req.query;
-        const errorCode = error ? String(error) : 'unknown_error';
-        const errorMessage = error_description ? String(error_description) : 'An error occurred during authorization.';
+        const errorCode = this.escapeHtml(error ? String(error) : 'unknown_error');
+        const errorMessage = this.escapeHtml(error_description ? String(error_description) : 'An error occurred during authorization.');
 
         res.status(200).send(`
 <!DOCTYPE html>
@@ -541,6 +542,23 @@ export class OAuthCallbackHandler {
     // ========================================
     // Helper Methods
     // ========================================
+
+    /**
+     * Escapes HTML-special characters in a string so untrusted (e.g. query-string-derived)
+     * values can be safely interpolated into an HTML response without introducing
+     * reflected-XSS. Escapes `&`, `<`, `>`, `"`, and `'`.
+     *
+     * @param value - The raw string to escape
+     * @returns The HTML-escaped string
+     */
+    private escapeHtml(value: string): string {
+        return value
+            .replace(/&/g, '&amp;')
+            .replace(/</g, '&lt;')
+            .replace(/>/g, '&gt;')
+            .replace(/"/g, '&quot;')
+            .replace(/'/g, '&#39;');
+    }
 
     /**
      * Gets the system user from cache.


### PR DESCRIPTION
Three surgical fixes for real defects surfaced by the integration-test quality audit. Bug IDs reference `plans/integration-test-expansion/bug-register.md`.

## B2 — SQL injection in a saved query's `since` param
`metadata/queries/SQL/get-conversations-for-memory-manager.sql` interpolated the `since` value inside manual single quotes with **no** Nunjucks SQL filter (`AND cd_new.__mj_CreatedAt >= '{{ since }}'`), so a single quote in the value could break out of the literal. Every other string param in the catalog uses a `| sql*` filter.

**Fix:** `AND cd_new.__mj_CreatedAt >= {{ since | sqlDate }}` — manual quotes removed, filter applied. `sqlDate` emits a correctly-quoted, escaped ISO date literal (`'…'`), which is the semantically correct choice for a date-column comparison (vs. `sqlString`). The surrounding `{% if since %}` guard is preserved.

## B3 — sensitive data logged to stdout
`GetQueryData` in `packages/MJServer/src/resolvers/QueryResolver.ts` logged query `Parameters` (sensitive filter values) and full `Results` / `AppliedParameters` to stdout on **every** call via two `console.log` statements.

**Fix:** removed both `console.log` statements. Genuine error logging (`console.error` on the query-name lookup path) is retained.

## B6 — reflected XSS in the OAuth callback pages
The success/error HTML pages in `packages/MJServer/src/rest/OAuthCallbackHandler.ts` interpolated `connectionId`, `error`, and `error_description` **from the query string** into HTML unescaped.

**Fix:** added a private `escapeHtml()` helper (escapes `& < > " '`, with `&` first to avoid double-encoding) and wrapped every query-derived value on both pages. Added a vitest suite (`OAuthCallbackHandler.xss.test.ts`) proving `<script>`, quotes, and ampersands are neutralized in both the helper and the rendered pages.

## Verification
- **B2:** static reasoning + `sqlDate`/`sqlString` filter review (`runQuerySQLFilterImplementations.ts`); Nunjucks braces balanced. Template file — not compiled.
- **B3:** static reasoning — pure deletion of two log lines.
- **B6:** new vitest suite — 4/4 pass, exercising the real `OAuthCallbackHandler` renderers with malicious inputs.
- Full MJServer vitest run: 487 passed. (The 9 failing test files fail on an environmental `type-graphql`/module-resolution gap in this worktree — unrelated to this change; the same failures reproduce on untouched files like `AdhocQueryResolver.ts`.)

## Honest caveats
- **No integration-test coverage yet.** These three defects do not have dedicated integration-test cases. Building the integration harness for them is a separate, planned initiative — this PR is the surgical source fix only.
- **Full-package `tsc` build could not be completed in this worktree** because `type-graphql` (a declared MJServer dependency) is not installed in the environment's resolution path — the identical `from 'type-graphql'` import on line 1 of `QueryResolver.ts` exists on untouched `next`, so this blocker is pre-existing and environmental, not introduced here. The incremental build of the two edited source files passed, and the vitest suite compiles/runs the edited `OAuthCallbackHandler.ts` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)