### PR TITLE
feat(integration): optional out-of-process integration sync worker

### DIFF
--- a/.changeset/integration-sync-worker.md
+++ b/.changeset/integration-sync-worker.md
@@ -1,0 +1,5 @@
+---
+"@memberjunction/integration-sync-worker": minor
+---
+
+New optional out-of-process integration-sync worker. Runs the same `SchedulingEngine` + `IntegrationSyncScheduledJobDriver` as MJAPI but in a standalone process (no Apollo/GraphQL), claiming scheduled syncs via the existing DB-atomic lease and propagating writes through the Redis `remote-invalidate` bus. Opt-in via `scheduledJobs.enabled=true` on the worker + `false` on MJAPI; if the worker isn't deployed, in-process behavior is unchanged.

--- a/package-lock.json
+++ b/package-lock.json
@@ -700,7 +700,6 @@
       "resolved": "https://registry.npmjs.org/@angular/animations/-/animations-21.1.3.tgz",
       "integrity": "sha512-UADMncDd9lkmIT1NPVFcufyP5gJHMPzxNaQpojiGrxT1aT8Du30mao0KSrB4aTwcicv6/cdD5bZbIyg+FL6LkQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "tslib": "^2.3.0"
       },
@@ -1470,7 +1469,6 @@
       "resolved": "https://registry.npmjs.org/@angular/cdk/-/cdk-21.1.3.tgz",
       "integrity": "sha512-jMiEKCcZMIAnyx2jxrJHmw5c7JXAiN56ErZ4X+OuQ5yFvYRocRVEs25I0OMxntcXNdPTJQvpGwGlhWhS0yDorg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "parse5": "^8.0.0",
         "tslib": "^2.3.0"
@@ -2061,7 +2059,6 @@
       "resolved": "https://registry.npmjs.org/@angular/common/-/common-21.1.3.tgz",
       "integrity": "sha512-Wdbln/UqZM5oVnpfIydRdhhL8A9x3bKZ9Zy1/mM0q+qFSftPvmFZIXhEpFqbDwNYbGUhGzx7t8iULC4sVVp/zA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "tslib": "^2.3.0"
       },
@@ -2090,7 +2087,6 @@
       "resolved": "https://registry.npmjs.org/@angular/compiler-cli/-/compiler-cli-21.1.3.tgz",
       "integrity": "sha512-nKxoQ89W2B1WdonNQ9kgRnvLNS6DAxDrRHBslsKTlV+kbdv7h59M9PjT4ZZ2sp1M/M8LiofnUfa/s2jd/xYj5w==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/core": "7.28.5",
         "@jridgewell/sourcemap-codec": "^1.4.14",
@@ -2293,7 +2289,6 @@
       "resolved": "https://registry.npmjs.org/@angular/core/-/core-21.1.3.tgz",
       "integrity": "sha512-TbhQxRC7Lb/3WBdm1n8KRsktmVEuGBBp0WRF5mq0Ze4s1YewIM6cULrSw9ACtcL5jdcq7c74ms+uKQsaP/gdcQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "tslib": "^2.3.0"
       },
@@ -2335,7 +2330,6 @@
       "resolved": "https://registry.npmjs.org/@angular/forms/-/forms-21.1.3.tgz",
       "integrity": "sha512-YW/YdjM9suZUeJam9agHFXIEE3qQIhGYXMjnnX7xGjOe+CuR2R0qsWn1AR0yrKrNmFspb0lKgM7kTTJyzt8gZg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@standard-schema/spec": "^1.0.0",
         "tslib": "^2.3.0"
@@ -2355,7 +2349,6 @@
       "resolved": "https://registry.npmjs.org/@angular/localize/-/localize-21.1.3.tgz",
       "integrity": "sha512-o/zFe8t578OP1j9+7iYibkwcE19zVC8xRFl/+f8bLSwqxwqasMNu1/zCa1B2nq8Gd2xwbvX/7kDhAn25yM4FJg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/core": "7.28.5",
         "@types/babel__core": "7.20.5",
@@ -2538,7 +2531,6 @@
       "resolved": "https://registry.npmjs.org/@angular/platform-browser/-/platform-browser-21.1.3.tgz",
       "integrity": "sha512-W+ZMXAioaP7CsACafBCHsIxiiKrRTPOlQ+hcC7XNBwy+bn5mjGONoCgLreQs76M8HNWLtr/OAUAr6h26OguOuA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "tslib": "^2.3.0"
       },
@@ -2579,7 +2571,6 @@
       "resolved": "https://registry.npmjs.org/@angular/router/-/router-21.1.3.tgz",
       "integrity": "sha512-uAw4LAMHXAPCe4SywhlUEWjMYVbbLHwTxLyduSp1b+9aVwep0juy5O/Xttlxd/oigVe0NMnOyJG9y1Br/ubnrg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "tslib": "^2.3.0"
       },
@@ -2998,7 +2989,6 @@
       "resolved": "https://registry.npmjs.org/@auth0/auth0-angular/-/auth0-angular-2.6.0.tgz",
       "integrity": "sha512-+LcdhiawKUdhEMkILl9Pq1yb1a9haNLHVG5kBTQXXtbocFDobtw8dvA/S74lBAzweCoDpFmNbMzORCFQLKyCOw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@auth0/auth0-spa-js": "^2.11.0",
         "tslib": "^2.0.0"
@@ -3036,6 +3026,7 @@
       "resolved": "https://registry.npmjs.org/@aws-amplify/analytics/-/analytics-7.0.93.tgz",
       "integrity": "sha512-3WoB0VzATJyupTNQ+ZnzE0pLYnpZPtqNN4deZ8gadG5uzGhhvkt9uZtgVnn/QFGb35DnP8qNDTRiM0rL3vjyZQ==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@aws-sdk/client-firehose": "3.982.0",
         "@aws-sdk/client-kinesis": "3.982.0",
@@ -3052,6 +3043,7 @@
       "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-2.2.0.tgz",
       "integrity": "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "tslib": "^2.6.2"
       },
@@ -3064,6 +3056,7 @@
       "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-2.2.0.tgz",
       "integrity": "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@smithy/is-array-buffer": "^2.2.0",
         "tslib": "^2.6.2"
@@ -3077,6 +3070,7 @@
       "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.0.0.tgz",
       "integrity": "sha512-rctU1VkziY84n5OXe3bPNpKR001ZCME2JCaBBFgtiM2hfKbHFudc/BkMuPab8hRbLd0j3vbnBTTZ1igBf0wgiQ==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@smithy/util-buffer-from": "^2.0.0",
         "tslib": "^2.5.0"
@@ -3090,6 +3084,7 @@
       "resolved": "https://registry.npmjs.org/@aws-amplify/api/-/api-6.3.24.tgz",
       "integrity": "sha512-19CVHj+0J35aHMPNzy12nO1mJS4oP68yFUfiMnulSsiVGV5XhUDc/bkdcX0uI7U1SsUSs+9TOBwZg27bzYIGkg==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@aws-amplify/api-graphql": "4.8.5",
         "@aws-amplify/api-rest": "4.6.3",
@@ -3106,6 +3101,7 @@
       "resolved": "https://registry.npmjs.org/@aws-amplify/api-graphql/-/api-graphql-4.8.5.tgz",
       "integrity": "sha512-Xu45+MizoethsRfCFIdN9RORenCu0e41tMkiTFVE5oKC76eoOlYHg2LlhG2Lmmasby/Ggi5bZouVxJIcP4IeIA==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@aws-amplify/api-rest": "4.6.3",
         "@aws-amplify/core": "6.16.1",
@@ -3122,6 +3118,7 @@
       "resolved": "https://registry.npmjs.org/graphql/-/graphql-15.8.0.tgz",
       "integrity": "sha512-5gghUc24tP9HRznNpV2+FIoq3xKkj5dTQqf4v0CpdPbFVwFkWoxOM+o+2OC9ZSvjEMTjfmG9QT+gcvggTwW1zw==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 10.x"
       }
@@ -3135,6 +3132,7 @@
         "https://github.com/sponsors/ctavan"
       ],
       "license": "MIT",
+      "peer": true,
       "bin": {
         "uuid": "dist/esm/bin/uuid"
       }
@@ -3144,6 +3142,7 @@
       "resolved": "https://registry.npmjs.org/@aws-amplify/api-rest/-/api-rest-4.6.3.tgz",
       "integrity": "sha512-SPhttyB9SR2p5PkUPmUPfkXNqGrgvdqiNHNHhx7FjHnqFBXLDRtGhzqRbE7faDeAwrcWz1HCtcpk7MLHYt94yg==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "tslib": "^2.5.0"
       },
@@ -3156,6 +3155,7 @@
       "resolved": "https://registry.npmjs.org/@aws-amplify/auth/-/auth-6.19.1.tgz",
       "integrity": "sha512-N6bqBUEly/xUiho0X5oGhLEDlQTWsj1i0FquDYsyuav5e9HHQBLNgG1zmpq28lyxtDaUREi/IDx+CD10EpcPcQ==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@aws-crypto/sha256-js": "5.2.0",
         "@smithy/types": "^3.3.0",
@@ -3176,6 +3176,7 @@
       "resolved": "https://registry.npmjs.org/@smithy/types/-/types-3.7.2.tgz",
       "integrity": "sha512-bNwBYYmN8Eh9RyjS1p2gW6MIhSO2rl7X9QeLM8iTdcGRP+eDiIWDt66c9IysCc22gefKszZv+ubV9qZc7hdESg==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "tslib": "^2.6.2"
       },
@@ -3205,6 +3206,7 @@
       "resolved": "https://registry.npmjs.org/@smithy/util-hex-encoding/-/util-hex-encoding-2.0.0.tgz",
       "integrity": "sha512-c5xY+NUnFqG6d7HFh1IFfrm3mGl29lC+vF+geHv4ToiuJCBmIfzx6IeHLg+OgRdPFKDXIw6pvi+p3CsscaMcMA==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "tslib": "^2.5.0"
       },
@@ -3216,7 +3218,8 @@
       "version": "9.0.8",
       "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-9.0.8.tgz",
       "integrity": "sha512-jg+97EGIcY9AGHJJRaaPVgetKDsrTgbRjQ5Msgjh/DQKEFl0DtyRr/VCOyD1T2R1MNeWPK/u7JoGhlDZnKBAfA==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@aws-amplify/core/node_modules/uuid": {
       "version": "11.1.0",
@@ -3227,6 +3230,7 @@
         "https://github.com/sponsors/ctavan"
       ],
       "license": "MIT",
+      "peer": true,
       "bin": {
         "uuid": "dist/esm/bin/uuid"
       }
@@ -3236,6 +3240,7 @@
       "resolved": "https://registry.npmjs.org/@aws-amplify/data-schema/-/data-schema-1.25.4.tgz",
       "integrity": "sha512-2vN1gdU/zzCuxpul6xnD8ii0Chl94lAJmsv0uOeztlNUoYYYiZ1CWlwRkSYe+Y6D4pJOSpO2wvcBsEi9/nVVmw==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@aws-amplify/data-schema-types": "*",
         "@smithy/util-base64": "^3.0.0",
@@ -3249,6 +3254,7 @@
       "resolved": "https://registry.npmjs.org/@aws-amplify/data-schema-types/-/data-schema-types-1.2.1.tgz",
       "integrity": "sha512-SuYVcy9Hg8Ox9P0QCXEPwqHxX5zVPgVo2YvNBOm5TpkZr4UK6ir3USame7dELZsk5/9f6KoP70QAYhTvp/j1Og==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "graphql": "15.8.0",
         "rxjs": "^7.8.1"
@@ -3259,6 +3265,7 @@
       "resolved": "https://registry.npmjs.org/graphql/-/graphql-15.8.0.tgz",
       "integrity": "sha512-5gghUc24tP9HRznNpV2+FIoq3xKkj5dTQqf4v0CpdPbFVwFkWoxOM+o+2OC9ZSvjEMTjfmG9QT+gcvggTwW1zw==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 10.x"
       }
@@ -3268,6 +3275,7 @@
       "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-3.0.0.tgz",
       "integrity": "sha512-+Fsu6Q6C4RSJiy81Y8eApjEB5gVtM+oFKTffg+jSuwtvomJJrhUJBu2zS8wjXSgH/g1MKEWrzyChTBe6clb5FQ==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "tslib": "^2.6.2"
       },
@@ -3280,6 +3288,7 @@
       "resolved": "https://registry.npmjs.org/@smithy/util-base64/-/util-base64-3.0.0.tgz",
       "integrity": "sha512-Kxvoh5Qtt0CDsfajiZOCpJxgtPHXOKwmM+Zy4waD43UoEMA+qPxxa98aE/7ZhdnBFZFXMOiBR5xbcaMhLtznQQ==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@smithy/util-buffer-from": "^3.0.0",
         "@smithy/util-utf8": "^3.0.0",
@@ -3294,6 +3303,7 @@
       "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-3.0.0.tgz",
       "integrity": "sha512-aEOHCgq5RWFbP+UDPvPot26EJHjOC+bRgse5A8V3FSShqd5E5UN4qc7zkwsvJPPAVsf73QwYcHN1/gt/rtLwQA==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@smithy/is-array-buffer": "^3.0.0",
         "tslib": "^2.6.2"
@@ -3307,6 +3317,7 @@
       "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-3.0.0.tgz",
       "integrity": "sha512-rUeT12bxFnplYDe815GXbq/oixEGHfRFFtcTF3YdDi/JaENIM6aSYYLJydG83UNzLXeRI5K8abYd/8Sp/QM0kA==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@smithy/util-buffer-from": "^3.0.0",
         "tslib": "^2.6.2"
@@ -3320,6 +3331,7 @@
       "resolved": "https://registry.npmjs.org/@aws-amplify/datastore/-/datastore-5.1.5.tgz",
       "integrity": "sha512-/9o4eYqWOlxVxe/riDd282FmUHHSiGUEAwle464T8wzNSqPTB7yTeQfzt2LFYTWsrYLCSR0OtOM1bY5VPSVmew==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@aws-amplify/api": "6.3.24",
         "@aws-amplify/api-graphql": "4.8.5",
@@ -3338,6 +3350,7 @@
       "resolved": "https://registry.npmjs.org/buffer/-/buffer-4.9.2.tgz",
       "integrity": "sha512-xq+q3SRMOxGivLhBNaUdC64hDTQwejJ+H0T/NB1XMtTVEwNTrfFF3gAxiyW0Bu/xWEGhjVKgUcMhCrUy2+uCWg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "base64-js": "^1.0.2",
         "ieee754": "^1.1.4",
@@ -3348,19 +3361,22 @@
       "version": "5.0.6",
       "resolved": "https://registry.npmjs.org/idb/-/idb-5.0.6.tgz",
       "integrity": "sha512-/PFvOWPzRcEPmlDt5jEvzVZVs0wyd/EvGvkDIcbBpGuMMLQKrTPG0TxvE2UJtgZtCQCmOtM2QD7yQJBVEjKGOw==",
-      "license": "ISC"
+      "license": "ISC",
+      "peer": true
     },
     "node_modules/@aws-amplify/datastore/node_modules/isarray": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
       "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@aws-amplify/notifications": {
       "version": "2.0.93",
       "resolved": "https://registry.npmjs.org/@aws-amplify/notifications/-/notifications-2.0.93.tgz",
       "integrity": "sha512-NtHKusaiWzkPXuaKsTyvKAWE8JnQcXmQoaidQ5/a9/nWWTzs983l5xgc4OPvfVR+3N63K+3iTmYHtKcEbhgS6w==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@aws-sdk/types": "3.973.1",
         "lodash": "^4.17.21",
@@ -3375,6 +3391,7 @@
       "resolved": "https://registry.npmjs.org/@aws-amplify/storage/-/storage-6.13.2.tgz",
       "integrity": "sha512-XMhFXrEYD/x/cd5qvTnMa/xhbpJjZZyva2ea0wmLedLqY1glWyhKPmSi2PAfhhpkWcvA50XnQ/g9KaZsog5hww==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@aws-sdk/types": "3.973.1",
         "@smithy/md5-js": "2.0.7",
@@ -3392,6 +3409,7 @@
       "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-2.2.0.tgz",
       "integrity": "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "tslib": "^2.6.2"
       },
@@ -3404,6 +3422,7 @@
       "resolved": "https://registry.npmjs.org/@smithy/md5-js/-/md5-js-2.0.7.tgz",
       "integrity": "sha512-2i2BpXF9pI5D1xekqUsgQ/ohv5+H//G9FlawJrkOJskV18PgJ8LiNbLiskMeYt07yAsSTZR7qtlcAaa/GQLWww==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@smithy/types": "^2.3.1",
         "@smithy/util-utf8": "^2.0.0",
@@ -3415,6 +3434,7 @@
       "resolved": "https://registry.npmjs.org/@smithy/types/-/types-2.12.0.tgz",
       "integrity": "sha512-QwYgloJ0sVNBeBuBs65cIkTbfzV/Q6ZNPCJ99EICFEdJYG50nGIY/uYXp+TbsdJReIuPr0a0kXmCvren3MbRRw==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "tslib": "^2.6.2"
       },
@@ -3427,6 +3447,7 @@
       "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-2.2.0.tgz",
       "integrity": "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@smithy/is-array-buffer": "^2.2.0",
         "tslib": "^2.6.2"
@@ -3440,6 +3461,7 @@
       "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.3.0.tgz",
       "integrity": "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@smithy/util-buffer-from": "^2.2.0",
         "tslib": "^2.6.2"
@@ -3453,6 +3475,7 @@
       "resolved": "https://registry.npmjs.org/buffer/-/buffer-4.9.2.tgz",
       "integrity": "sha512-xq+q3SRMOxGivLhBNaUdC64hDTQwejJ+H0T/NB1XMtTVEwNTrfFF3gAxiyW0Bu/xWEGhjVKgUcMhCrUy2+uCWg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "base64-js": "^1.0.2",
         "ieee754": "^1.1.4",
@@ -3470,6 +3493,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fast-xml-builder": "^1.1.4",
         "path-expression-matcher": "^1.2.1",
@@ -3483,7 +3507,8 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
       "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@aws-crypto/crc32": {
       "version": "5.2.0",
@@ -3920,6 +3945,7 @@
       "resolved": "https://registry.npmjs.org/@aws-sdk/client-firehose/-/client-firehose-3.982.0.tgz",
       "integrity": "sha512-Qur2Siqep+gRReTjlKXcdpyX/MUnzm5OgNNudDPxzpmzdnc3ZKlUwGlbEoS1VA5cFS6N4zg6WfZqlwcXg//TSg==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@aws-crypto/sha256-browser": "5.2.0",
         "@aws-crypto/sha256-js": "5.2.0",
@@ -3970,6 +3996,7 @@
       "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.982.0.tgz",
       "integrity": "sha512-M27u8FJP7O0Of9hMWX5dipp//8iglmV9jr7R8SR8RveU+Z50/8TqH68Tu6wUWBGMfXjzbVwn1INIAO5lZrlxXQ==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@aws-sdk/types": "^3.973.1",
         "@smithy/types": "^4.12.0",
@@ -3986,6 +4013,7 @@
       "resolved": "https://registry.npmjs.org/@aws-sdk/client-kinesis/-/client-kinesis-3.982.0.tgz",
       "integrity": "sha512-Gh3xyumdz3IRj91HIBR48TohQyA3VSn/blDcGXzl4dwQKXgM0ISdHgyniNo2GQNhORJF3d01MSMx72s5NNQxUA==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@aws-crypto/sha256-browser": "5.2.0",
         "@aws-crypto/sha256-js": "5.2.0",
@@ -4040,6 +4068,7 @@
       "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.982.0.tgz",
       "integrity": "sha512-M27u8FJP7O0Of9hMWX5dipp//8iglmV9jr7R8SR8RveU+Z50/8TqH68Tu6wUWBGMfXjzbVwn1INIAO5lZrlxXQ==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@aws-sdk/types": "^3.973.1",
         "@smithy/types": "^4.12.0",
@@ -4107,6 +4136,7 @@
       "resolved": "https://registry.npmjs.org/@aws-sdk/client-personalize-events/-/client-personalize-events-3.982.0.tgz",
       "integrity": "sha512-JllssIZCPxAgYy4gkIM2e/kXxWT0xQzzZd5y9rRStm0bl5MiLAxzX4q9WhGG7glyB++EuhYskiT1N+DzyM5nTw==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@aws-crypto/sha256-browser": "5.2.0",
         "@aws-crypto/sha256-js": "5.2.0",
@@ -4157,6 +4187,7 @@
       "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.982.0.tgz",
       "integrity": "sha512-M27u8FJP7O0Of9hMWX5dipp//8iglmV9jr7R8SR8RveU+Z50/8TqH68Tu6wUWBGMfXjzbVwn1INIAO5lZrlxXQ==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@aws-sdk/types": "^3.973.1",
         "@smithy/types": "^4.12.0",
@@ -4632,7 +4663,6 @@
       "resolved": "https://registry.npmjs.org/@aws-sdk/credential-providers/-/credential-providers-3.984.0.tgz",
       "integrity": "sha512-nlOxl2+nQztLA+YNgLR8j0U7pi4XPXxpSCLQ3uOu+Csq8TU8RG0OBDXlny7qb6bwc9KcrFYSg4MfKd/ZnemcCg==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@aws-sdk/client-cognito-identity": "3.984.0",
         "@aws-sdk/core": "^3.973.6",
@@ -5324,7 +5354,6 @@
       "resolved": "https://registry.npmjs.org/@azure/core-client/-/core-client-1.10.1.tgz",
       "integrity": "sha512-Nh5PhEOeY6PrnxNPsEHRr9eimxLwgLlpmguQaHKBinFYA/RU9+kOYVOQqOrTsCL+KSxrLLl1gD8Dk5BFW/7l/w==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@azure/abort-controller": "^2.1.2",
         "@azure/core-auth": "^1.10.0",
@@ -5386,7 +5415,6 @@
       "resolved": "https://registry.npmjs.org/@azure/core-rest-pipeline/-/core-rest-pipeline-1.22.2.tgz",
       "integrity": "sha512-MzHym+wOi8CLUlKCQu12de0nwcq9k9Kuv43j4Wa++CsCpJwps2eeBQwD2Bu8snkxTtDKDx4GwjuR9E8yC8LNrg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@azure/abort-controller": "^2.1.2",
         "@azure/core-auth": "^1.10.0",
@@ -5544,7 +5572,6 @@
       "resolved": "https://registry.npmjs.org/@azure/msal-angular/-/msal-angular-5.0.3.tgz",
       "integrity": "sha512-GLKET/JQK52fZYeceBjXKDu8Tv4jRpO7IFH4Id/65a3MU3l/fYhuiuMe4JceQT1ZdbiPfPjsScPZtIOQ2oh6aA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "tslib": "^2.3.0"
       },
@@ -5558,7 +5585,6 @@
       "resolved": "https://registry.npmjs.org/@azure/msal-browser/-/msal-browser-5.17.0.tgz",
       "integrity": "sha512-/yTnW2TCk9Mh+2b/NOaHAN+MryUNxzRTaJD/YtrqOA9bpBWfTXn/iyReRbaLrK/btBo3stEzLyEvuWp2NZ5DuA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@azure/msal-common": "16.11.1"
       },
@@ -5571,7 +5597,6 @@
       "resolved": "https://registry.npmjs.org/@azure/msal-common/-/msal-common-16.11.1.tgz",
       "integrity": "sha512-yPohvMwWLv1XnaWnIUyKUh8CvcVChCGqG/VluGwfGmaAfrZTNt5yQ+sIs462Sgw6+e2K83KGmMJ860p73ZSCrw==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.8.0"
       }
@@ -5662,7 +5687,6 @@
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.0.tgz",
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -9411,7 +9435,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       },
@@ -9450,7 +9473,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       }
@@ -10926,7 +10948,6 @@
       "resolved": "https://registry.npmjs.org/@expo/metro-runtime/-/metro-runtime-6.1.2.tgz",
       "integrity": "sha512-nvM+Qv45QH7pmYvP8JB1G8JpScrWND3KrMA6ZKe62cwwNiX/BjHU28Ear0v/4bQWXlOY0mv6B8CDIm8JxXde9g==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "anser": "^1.4.9",
         "pretty-format": "^29.7.0",
@@ -11345,7 +11366,6 @@
       "resolved": "https://registry.npmjs.org/@foblex/2d/-/2d-1.2.2.tgz",
       "integrity": "sha512-nVl2iw6hF0RDE2+E4U1tSRX5lOI2toG9nY1VaMlQ0RdIB+0mEK1+lhjJDn/qDrBsMYpNCaTZ2CC3Jy54ItOnsQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "tslib": "^2.3.0"
       },
@@ -11377,7 +11397,6 @@
       "resolved": "https://registry.npmjs.org/@foblex/mediator/-/mediator-1.1.3.tgz",
       "integrity": "sha512-Yuvu4lpefFo0N1oo1xDBL7UItUe5KuasPniurcQITY3wvBRITSHZCPIEpB/FEWuaoknyC8t1blxDyOh11U+daA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "tslib": "^2.3.0"
       },
@@ -11392,7 +11411,6 @@
       "resolved": "https://registry.npmjs.org/@foblex/platform/-/platform-1.0.4.tgz",
       "integrity": "sha512-GLbqPX9xL/w2pRX51J8RSjMrZcTKb8rmi9+EcrPtpRXCa4KETY4mpIzfKlaOthZusFY++UUFecM07aXRnp+sMw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "tslib": "^2.3.0"
       },
@@ -11406,7 +11424,6 @@
       "resolved": "https://registry.npmjs.org/@foblex/utils/-/utils-1.1.1.tgz",
       "integrity": "sha512-w4g49vLAIogIXNYHWQzcv2p5jJKi/XAoTw7LvuEzKvEXDJ8ezL0BZJfbeg43q2+PyKvlUfu+6ySvNxnXYrb/Bg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "tslib": "^2.3.0"
       }
@@ -15452,6 +15469,10 @@
       "resolved": "packages/Integration/schema-builder",
       "link": true
     },
+    "node_modules/@memberjunction/integration-sync-worker": {
+      "resolved": "packages/Integration/SyncWorker",
+      "link": true
+    },
     "node_modules/@memberjunction/integration-ui-types": {
       "resolved": "packages/Integration/ui-types",
       "link": true
@@ -17990,7 +18011,6 @@
       "resolved": "https://registry.npmjs.org/@octokit/core/-/core-6.1.6.tgz",
       "integrity": "sha512-kIU8SLQkYWGp3pVKiYzA5OSaNF5EE03P/R8zEmmrG6XwOg5oBjXyQVVIauQ0dgau4zYhpZEhJrvIYt6oM+zZZA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@octokit/auth-token": "^5.0.0",
         "@octokit/graphql": "^8.2.2",
@@ -19330,6 +19350,7 @@
       "resolved": "https://registry.npmjs.org/@primeuix/motion/-/motion-0.0.10.tgz",
       "integrity": "sha512-PsZwOPq79Scp7/ionshRcQ5xKVf9+zuLcyY5mf6onK8chHT5C9JGphmcIZ4CzcqxuGEpsm8AIbTGy+zS3RtzLA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@primeuix/utils": "^0.6.3"
       },
@@ -19342,6 +19363,7 @@
       "resolved": "https://registry.npmjs.org/@primeuix/styled/-/styled-0.7.4.tgz",
       "integrity": "sha512-QSO/NpOQg8e9BONWRBx9y8VGMCMYz0J/uKfNJEya/RGEu7ARx0oYW0ugI1N3/KB1AAvyGxzKBzGImbwg0KUiOQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@primeuix/utils": "^0.6.1"
       },
@@ -19354,6 +19376,7 @@
       "resolved": "https://registry.npmjs.org/@primeuix/styles/-/styles-2.0.3.tgz",
       "integrity": "sha512-2ykAB6BaHzR/6TwF8ShpJTsZrid6cVIEBVlookSdvOdmlWuevGu5vWOScgIwqWwlZcvkFYAGR/SUV3OHCTBMdw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@primeuix/styled": "^0.7.4"
       }
@@ -19363,6 +19386,7 @@
       "resolved": "https://registry.npmjs.org/@primeuix/utils/-/utils-0.6.4.tgz",
       "integrity": "sha512-pZ5f+vj7wSzRhC7KoEQRU5fvYAe+RP9+m39CTscZ3UywCD1Y2o6Fe1rRgklMPSkzUcty2jzkA0zMYkiJBD1hgg==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12.11.0"
       }
@@ -20388,7 +20412,6 @@
       "resolved": "https://registry.npmjs.org/@react-navigation/native/-/native-7.3.5.tgz",
       "integrity": "sha512-lzcRpMoLCIypXXKm8KhpyZ81XpQBO/i8Oy1due4kUR97kG8kBlJxKUeP8yNnT5Fcl85rNdLXWbpwEr+9HPu4Ig==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@react-navigation/core": "^7.21.3",
         "escape-string-regexp": "^4.0.0",
@@ -22448,7 +22471,8 @@
       "version": "8.10.161",
       "resolved": "https://registry.npmjs.org/@types/aws-lambda/-/aws-lambda-8.10.161.tgz",
       "integrity": "sha512-rUYdp+MQwSFocxIOcSsYSF3YYYC/uUpMbCY/mbO21vGqfrEYvNSoPyKYDj6RhXXpPfS0KstW9RwG3qXh9sL7FQ==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@types/axios": {
       "version": "0.14.4",
@@ -22822,7 +22846,6 @@
       "integrity": "sha512-vIChWdVG3LG1SMxEvI/AK+FWJthlrqlTu7fbrlywTkkaONwk/UAGaULXRlf8vkzFBLVm0zkMdCquhL5aOjhXPQ==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/ms": "*"
       }
@@ -22845,7 +22868,8 @@
       "version": "1.0.22",
       "resolved": "https://registry.npmjs.org/@types/dom-mediacapture-record/-/dom-mediacapture-record-1.0.22.tgz",
       "integrity": "sha512-mUMZLK3NvwRLcAAT9qmcK+9p7tpU2FHdDsntR3YI4+GY88XrgG4XiE7u1Q2LAN2/FZOz/tdMDC3GQCR4T8nFuw==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@types/dom-mediacapture-transform": {
       "version": "0.1.11",
@@ -22861,7 +22885,8 @@
       "version": "0.1.18",
       "resolved": "https://registry.npmjs.org/@types/dom-webcodecs/-/dom-webcodecs-0.1.18.tgz",
       "integrity": "sha512-vAvE8C9DGWR+tkb19xyjk1TSUlJ7RUzzp4a9Anu7mwBT+fpyePWK1UxmH14tMO5zHmrnrRIMg5NutnnDztLxgg==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@types/eslint": {
       "version": "9.6.1",
@@ -23132,7 +23157,6 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-20.14.2.tgz",
       "integrity": "sha512-xyu6WAMVwv6AKFLB+e/7ySZVr/0zLCzOa7rSpq6jNwpqOrUbcACDWC+53d4n2QHOnDou0fbIsg8wZu/sxrnI4Q==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~5.26.4"
       }
@@ -23142,7 +23166,6 @@
       "resolved": "https://registry.npmjs.org/@types/node-fetch/-/node-fetch-2.6.13.tgz",
       "integrity": "sha512-QGpRVpzSaUs30JBSGPjOg4Uveu384erbHBoT1zeONvyCfwQxIkUshLAOqN/k9EjGviPRmWTTe6aH2qySWKTVSw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/node": "*",
         "form-data": "^4.0.4"
@@ -23528,7 +23551,6 @@
       "integrity": "sha512-dm/J2UDY3oV3TKius2OUZIFHsomQmpHtsV0FTh1WO8EKgHLQ1QCADUqscPgTpU+ih1e21FQSRjXckHn3txn6kQ==",
       "dev": true,
       "license": "BSD-2-Clause",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "7.12.0",
         "@typescript-eslint/types": "7.12.0",
@@ -24472,8 +24494,7 @@
       "version": "0.20.1",
       "resolved": "https://registry.npmjs.org/@workos-inc/authkit-js/-/authkit-js-0.20.1.tgz",
       "integrity": "sha512-ThIC/LrN2I9QbdJFCLmCNW6YAwOMmO7IYDz+KKN+gV9lUpY6grRU7dxfb6tjt0vNK8adQ9mSpNRoRQQFuEDGRQ==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@xenova/transformers": {
       "version": "2.17.2",
@@ -24609,7 +24630,6 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -24723,7 +24743,6 @@
       "resolved": "https://registry.npmjs.org/ag-grid-angular/-/ag-grid-angular-35.0.1.tgz",
       "integrity": "sha512-+Y1K/ZxiEbd3GhZcRWzLf60yiP4ECNoTCCqI65EgHiiRGInz3g1pDueArR7hE7V+z5gluA3NMGB3VrOZYUBKLg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "ag-grid-community": "35.0.1",
         "tslib": "^2.3.0"
@@ -24738,7 +24757,6 @@
       "resolved": "https://registry.npmjs.org/ag-grid-community/-/ag-grid-community-35.0.1.tgz",
       "integrity": "sha512-fYYZdymWKsN9/tZv+R6uZRnuiWYEQr+GHl85ZrB0ixbFcE8opYK4NJI29NnMc9ShYiCBnAO9hj54IFa+FI4aDA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "ag-charts-types": "13.0.1"
       }
@@ -25479,7 +25497,6 @@
       "resolved": "https://registry.npmjs.org/axios/-/axios-1.13.6.tgz",
       "integrity": "sha512-ChTCHMouEe2kn713WHbQGcuYrr6fXTBiu460OTwWrWob16g1bXn4vtz07Ope7ewMozJAnEquLk5lWQWtBig9DQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "follow-redirects": "^1.15.11",
         "form-data": "^4.0.5",
@@ -25873,7 +25890,6 @@
       "resolved": "https://registry.npmjs.org/bare-events/-/bare-events-2.8.2.tgz",
       "integrity": "sha512-riJjyv1/mHLIPX4RwiK+oW9/4c3TEUeORHKefKAKnZ5kyslbN+HXowtbaVEqt4IMUB7OXlfixcs6gsFeo/jhiQ==",
       "license": "Apache-2.0",
-      "peer": true,
       "peerDependencies": {
         "bare-abort-controller": "*"
       },
@@ -26771,7 +26787,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -28646,7 +28661,6 @@
       "resolved": "https://registry.npmjs.org/cytoscape/-/cytoscape-3.33.1.tgz",
       "integrity": "sha512-iJc4TwyANnOGR1OmWhsS9ayRS3s+XQ185FmuHObThD+5AeJCakAAbWv8KimMTt08xCCLNgneQwFp+JRJOr9qGQ==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10"
       }
@@ -29074,7 +29088,6 @@
       "resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-3.0.0.tgz",
       "integrity": "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==",
       "license": "ISC",
-      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -29301,7 +29314,6 @@
       "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-3.6.0.tgz",
       "integrity": "sha512-fRHTG8g/Gif+kSh50gaGEdToemgfj74aRX3swtiouboip5JDLAyDE9F11nHMIcvOaXeOC6D7SpNhi7uFyB7Uww==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/kossnocorp"
@@ -30054,8 +30066,7 @@
       "resolved": "https://registry.npmjs.org/effect/-/effect-3.5.7.tgz",
       "integrity": "sha512-PzEncc0R3ZZhqNTR+fXrSX+anF/4Ai6ftKie1ZrUUWY7WPE7d4KjB6wjpeWoGMOC7xWFPGSkBBUudyJN1mx3+g==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/ejs": {
       "version": "3.1.10",
@@ -30615,7 +30626,6 @@
       "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",
@@ -30672,7 +30682,6 @@
       "integrity": "sha512-NSWl5BFQWEPi1j4TjVNItzYV7dZXZ+wP6I6ZhrBGpChQhZRUaElihE9uRRkcbRnNb76UMKDF3r+WTmNcGPKsqw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "eslint-config-prettier": "bin/cli.js"
       },
@@ -30796,7 +30805,6 @@
       "integrity": "sha512-hYfi3FXaM8WPLf4S1cikh/r4IxnO6zrhZbEGz2b660EJRbuxgpDS5gkCuYgGWg2xxh2rBuIr4Pvhve/7c31koA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "array-includes": "^3.1.4",
         "array.prototype.flat": "^1.2.5",
@@ -31309,7 +31317,6 @@
       "resolved": "https://registry.npmjs.org/expo/-/expo-54.0.35.tgz",
       "integrity": "sha512-E+tXpQwjGm5fK/uwa55p0Xx/kuo5dXDKfVJ95IargTNa5KiFt26lSTXXa9KnHbI4EDLwFD38/xTKZvzPTlGTdg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.20.0",
         "@expo/cli": "54.0.25",
@@ -31371,7 +31378,6 @@
       "resolved": "https://registry.npmjs.org/expo-asset/-/expo-asset-12.0.13.tgz",
       "integrity": "sha512-x/p7WvQUnkn6K43b9eL6SPeq5Vnf1E8BDe9bDrWrvMqzyUvJnUFvl+ctg3034s/+UHe7Ne2pAmc0+yzbl8CrDQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@expo/image-utils": "^0.8.8",
         "expo-constants": "~18.0.13"
@@ -31479,7 +31485,6 @@
       "resolved": "https://registry.npmjs.org/expo-font/-/expo-font-14.0.12.tgz",
       "integrity": "sha512-QQzunE2Mxk45AsCWm3tK7OpVljbtVnKD58q4/qliev+cbye1IOduUnRIdD+P7DyButw17G9MTX795kgaQiz5hQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fontfaceobserver": "^2.1.0"
       },
@@ -31927,7 +31932,6 @@
       "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
       "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "accepts": "^2.0.0",
         "body-parser": "^2.2.1",
@@ -32184,6 +32188,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "path-expression-matcher": "^1.1.3"
       }
@@ -32901,7 +32906,6 @@
       "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-6.1.1.tgz",
       "integrity": "sha512-a4tiq7E0/5fTjxPAaH4jpjkSv/uCaU2p5KC6HVGrvl0cDjA8iBZv4vv1gyzlmK0ZUKqwpOyQMKzZQe3lTit77A==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "gaxios": "^6.1.1",
         "google-logging-utils": "^0.0.2",
@@ -33261,8 +33265,7 @@
       "version": "2.6.0",
       "resolved": "https://registry.npmjs.org/golden-layout/-/golden-layout-2.6.0.tgz",
       "integrity": "sha512-sIVQCiRWOymHbVD1Aw/T9/ijbPYAVGBlgGYd1N9MRKfcyBNSpjr87Vg9nSHm+RCT8ELrvK8IJYJV0QRJuVUkCQ==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/google-auth-library": {
       "version": "9.15.1",
@@ -33567,7 +33570,6 @@
       "resolved": "https://registry.npmjs.org/graphql/-/graphql-16.12.0.tgz",
       "integrity": "sha512-DKKrynuQRne0PNpEbzuEdHlYOMksHSUI8Zc9Unei5gTsMNA2/vMpoMz/yKba50pejK56qj98qM0SjYxAKi13gQ==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": "^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0"
       }
@@ -33601,7 +33603,6 @@
       "resolved": "https://registry.npmjs.org/graphql-scalars/-/graphql-scalars-1.25.0.tgz",
       "integrity": "sha512-b0xyXZeRFkne4Eq7NAnL400gStGqG/Sx9VqX0A05nHyEbv57UJnWKsjNnrpVqv5e/8N1MUxkt0wwcRXbiyKcFg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "tslib": "^2.5.0"
       },
@@ -33877,7 +33878,6 @@
       "resolved": "https://registry.npmjs.org/hono/-/hono-4.11.7.tgz",
       "integrity": "sha512-l7qMiNee7t82bH3SeyUCt9UF15EVmaBvsppY2zQtrbIhl/yzBTny+YUxsVjSjQ6gaqaeVtZmGocom8TzBlA4Yw==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=16.9.0"
       }
@@ -34385,6 +34385,7 @@
       "resolved": "https://registry.npmjs.org/immer/-/immer-9.0.6.tgz",
       "integrity": "sha512-G95ivKpy+EvVAnAab4fVa4YGYn24J1SpEktnJX7JJ45Bd7xqME/SCplFzYFmTbrkwZbQ4xJK1xMTUYBkN6pWsQ==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/immer"
@@ -35663,7 +35664,6 @@
       "integrity": "sha512-Cvc9WUhxSMEo4McES3P7oK3QaXldCfNWp7pl2NNeiIFlCoLr3kfq9kb1fxftiwk1FLV7CvpvDfonxtzUDeSOPg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "cssstyle": "^4.2.1",
         "data-urls": "^5.0.0",
@@ -35800,7 +35800,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -35824,7 +35823,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -35965,7 +35963,6 @@
       "resolved": "https://registry.npmjs.org/jsep/-/jsep-1.4.0.tgz",
       "integrity": "sha512-B7qPcEVE3NVkmSJbaYxvv4cHkVW7DQsZz13pUMrfS8z8Q/BuShN+gcTXrUlPiGqM2/t/EEaI030bpxMqY8gMlw==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">= 10.16.0"
       }
@@ -36529,7 +36526,6 @@
       "integrity": "sha512-j1n1IuTX1VQjIy3tT7cyGbX7nvQOsFLoIqobZv4ttI5axP923gA44zUj6miiA6R5Aoms4sEGVIIcucXUbRI14g==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "copy-anything": "^2.0.1",
         "parse-node-version": "^1.0.1",
@@ -36976,7 +36972,6 @@
       "integrity": "sha512-ME4Fb83LgEgwNw96RKNvKV4VTLuXfoKudAmm2lP8Kk87KaMK0/Xrx/aAkMWmT8mDb+3MlFDspfbCs7adjRxA2g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "cli-truncate": "^5.0.0",
         "colorette": "^2.0.20",
@@ -37117,7 +37112,6 @@
       "resolved": "https://registry.npmjs.org/livekit-client/-/livekit-client-2.19.2.tgz",
       "integrity": "sha512-Kvk07QYDWRAbmYNLRll04ZIuxMQobW/oLPYnmR1kCy8GGHpU0gqyHf704Rz+29zfy8IJZRjKqeVbzGSKn9sumw==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@livekit/mutex": "1.1.1",
         "@livekit/protocol": "1.45.8",
@@ -38030,7 +38024,6 @@
       "resolved": "https://registry.npmjs.org/marked/-/marked-17.0.1.tgz",
       "integrity": "sha512-boeBdiS0ghpWcSwoNm/jJBwdpFaMnZWRzjA6SkUMYb40SVaN1x7mmfGKp0jvexGcx+7y2La5zRZsYFZI6Qpypg==",
       "license": "MIT",
-      "peer": true,
       "bin": {
         "marked": "bin/marked.js"
       },
@@ -39525,7 +39518,6 @@
       "integrity": "sha512-UlQOhH8DRlaYsBGQMjOYvg70J70hD4i/55NV9vAsYvsxEskmp86xjUtZgEeVKeoLq8tYMjMXDgaYjYde153sZQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@ampproject/remapping": "^2.3.0",
         "@rollup/plugin-json": "^6.1.0",
@@ -42318,6 +42310,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=14.0.0"
       }
@@ -42461,7 +42454,6 @@
       "resolved": "https://registry.npmjs.org/pg/-/pg-8.18.0.tgz",
       "integrity": "sha512-xqrUDL1b9MbkydY/s+VZ6v+xiMUmOUk7SS9d/1kpyQxoJ6U9AO1oIJyUWVZojbfe5Cc/oluutcgFG4L9RDP1iQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "pg-connection-string": "^2.11.0",
         "pg-pool": "^3.11.0",
@@ -42765,7 +42757,6 @@
       "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.58.1.tgz",
       "integrity": "sha512-+2uTZHxSCcxjvGc5C891LrS1/NlxglGxzrC4seZiVjcYVQfUa87wBL6rTDqzGjuoWNjnBzRqKmF6zRYGMvQUaQ==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "playwright-core": "1.58.1"
       },
@@ -42909,7 +42900,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -43104,7 +43094,6 @@
       "integrity": "sha512-UOnG6LftzbdaHZcKoPFtOcCKztrQ57WkHDeRD9t/PTQtmT0NHSeWWepj6pS0z/N7+08BHFDQVUrfmfMRcZwbMg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -43680,7 +43669,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.1.0.tgz",
       "integrity": "sha512-FS+XFBNvn3GTAWq26joslQgWNoFu08F4kl0J4CgdNKADkdSGXQyTCnKteIAJy96Br6YbpEU1LSzV5dYtjMkMDg==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -43721,7 +43709,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.1.0.tgz",
       "integrity": "sha512-Xs1hdnE+DyKgeHJeJznQmYMIBG3TKIHJJT95Q58nHLSrElKlGQqDTR2HQ9fx5CN/Gk6Vh/kupBTDLU11/nDk/g==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "scheduler": "^0.26.0"
       },
@@ -43758,7 +43745,6 @@
       "resolved": "https://registry.npmjs.org/react-native/-/react-native-0.81.5.tgz",
       "integrity": "sha512-1w+/oSjEXZjMqsIvmkCRsOc8UBYv163bTWKTI8+1mxztvQPhCRYGTvZ/PL1w16xXHneIj/SLGfxWg2GWN2uexw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jest/create-cache-key-function": "^29.7.0",
         "@react-native/assets-registry": "0.81.5",
@@ -43974,7 +43960,6 @@
       "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.14.2.tgz",
       "integrity": "sha512-jCvmsr+1IUSMUyzOkRcvnVbX3ZYC6g9TDrDbFuFmRDq7PD4yaGbLKNQL6k2jnArV8hjYxh7hVhAZB6s9HDGpZA==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -44639,7 +44624,6 @@
       "integrity": "sha512-kPmlKCGFES2VWtY7Y7SCB8ZeXRMsgX5deza9cu4OwmfM/ZUimd461kC3hRyccoyVxE4POlHUx0gg2jcGfusHFg==",
       "hasInstallScript": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.21.0"
       }
@@ -44649,7 +44633,6 @@
       "resolved": "https://registry.npmjs.org/rete-area-plugin/-/rete-area-plugin-2.1.5.tgz",
       "integrity": "sha512-iquEvwkQlcsO4cmgM3Z37TG0AWaE536dfA+lCJAze5YJzVx4RBaViUCqdB4dUA/utSytpBCkiDC4D3ztM9akGQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.21.0"
       },
@@ -44794,7 +44777,6 @@
       "integrity": "sha512-oQL6lgK3e2QZeQ7gcgIkS2YZPg5slw37hYufJ3edKlfQSGGm8ICoxswK15ntSzF/a8+h7ekRy7k7oWc3BQ7y8A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/estree": "1.0.8"
       },
@@ -45040,7 +45022,6 @@
       "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.2.tgz",
       "integrity": "sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "tslib": "^2.1.0"
       }
@@ -45150,7 +45131,6 @@
       "integrity": "sha512-uf6HoO8fy6ClsrShvMgaKUn14f2EHQLQRtpsZZLeU/Mv0Q1K5P0+x2uvH6Cub39TVVbWNSrraUhDAoFph6vh0A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "chokidar": "^4.0.0",
         "immutable": "^5.0.2",
@@ -45249,7 +45229,6 @@
       "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -46098,7 +46077,6 @@
       "resolved": "https://registry.npmjs.org/socks/-/socks-2.8.7.tgz",
       "integrity": "sha512-HLpt+uLy/pxB+bum/9DzAgiKS8CX1EvbWxI4zlmgGCExImLdiad2iCwXT5Z4c9c3Eq8rP2318mPW2c+QbtjK8A==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "ip-address": "^10.0.1",
         "smart-buffer": "^4.2.0"
@@ -49111,7 +49089,6 @@
       "integrity": "sha512-x4xW77QC3i5DUFMBp0qjukOTnr/sSg+oEs86nB3LjDslvAmwe/PUGDWbe3GrIqt59oTqoXK5GRK9tAa0sYMiog==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@gerrit0/mini-shiki": "^3.17.0",
         "lunr": "^2.3.9",
@@ -49145,7 +49122,6 @@
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -49172,6 +49148,7 @@
       "resolved": "https://registry.npmjs.org/ulid/-/ulid-2.4.0.tgz",
       "integrity": "sha512-fIRiVTJNcSRmXKPZtGzFQv9WRrZ3M9eoptl/teFJvjOzmpU+/K/JH6HZ8deBfb5vMEpicJcLn7JmvdknlMq7Zg==",
       "license": "MIT",
+      "peer": true,
       "bin": {
         "ulid": "bin/cli.js"
       }
@@ -49673,7 +49650,6 @@
       "integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",
@@ -50283,7 +50259,6 @@
       "integrity": "sha512-hOQuK7h0FGKgBAas7v0mSAsnvrIgAvWmRFjmzpJ7SwFHH3g1k2u37JtYwOwmEKhK6ZO3v9ggDBBm0La1LCK4uQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@vitest/expect": "4.0.18",
         "@vitest/mocker": "4.0.18",
@@ -50558,7 +50533,6 @@
       "integrity": "sha512-gX/dMkRQc7QOMzgTe6KsYFM7DxeIONQSui1s0n/0xht36HvrgbxtM1xBlgx596NbpHuQU8P7QpKwrZYwUX48nw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/eslint-scope": "^3.7.7",
         "@types/estree": "^1.0.8",
@@ -50608,7 +50582,6 @@
       "integrity": "sha512-MfwFQ6SfwinsUVi0rNJm7rHZ31GyTcpVE5pgVA3hwFRb7COD4TzjUUwhGWKfO50+xdc2MQPuEBBJoqIMGt3JDw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@discoveryjs/json-ext": "^0.6.1",
         "@webpack-cli/configtest": "^3.0.1",
@@ -50692,7 +50665,6 @@
       "integrity": "sha512-QcQ72gh8a+7JO63TAx/6XZf/CWhgMzu5m0QirvPfGvptOusAxG12w2+aua1Jkjr7hzaWDnJ2n6JFeexMHI+Zjg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/bonjour": "^3.5.13",
         "@types/connect-history-api-fallback": "^1.5.4",
@@ -51946,7 +51918,6 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
       "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }
@@ -53674,7 +53645,6 @@
     "packages/AI/Prompts/node_modules/date-fns": {
       "version": "2.30.0",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.21.0"
       },
@@ -53923,7 +53893,9 @@
       "license": "ISC",
       "dependencies": {
         "@memberjunction/ai": "5.48.0",
-        "@memberjunction/global": "5.48.0"
+        "@memberjunction/ai-openai": "5.48.0",
+        "@memberjunction/global": "5.48.0",
+        "openai": "6.18.0"
       },
       "devDependencies": {
         "typescript": "^5.9.3"
@@ -64189,6 +64161,30 @@
         "vitest": "^4.0.18"
       }
     },
+    "packages/Integration/SyncWorker": {
+      "name": "@memberjunction/integration-sync-worker",
+      "version": "5.48.0",
+      "license": "ISC",
+      "dependencies": {
+        "@memberjunction/core": "5.48.0",
+        "@memberjunction/generic-database-provider": "5.48.0",
+        "@memberjunction/integration-engine": "5.48.0",
+        "@memberjunction/redis-provider": "5.48.0",
+        "@memberjunction/scheduling-engine": "5.48.0",
+        "@memberjunction/server-bootstrap": "5.48.0",
+        "@memberjunction/sqlserver-dataprovider": "5.48.0",
+        "dotenv": "^17.2.4",
+        "env-var": "^7.3.0",
+        "mj_generatedentities": "1.0.0",
+        "mssql": "^12.2.0"
+      },
+      "devDependencies": {
+        "@types/node": "^24.10.11",
+        "rimraf": "^6.1.2",
+        "tsc-alias": "^1.8.10",
+        "typescript": "^5.9.3"
+      }
+    },
     "packages/Integration/ui-types": {
       "name": "@memberjunction/integration-ui-types",
       "version": "5.48.0",
@@ -71983,7 +71979,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -72007,7 +72002,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       }

--- a/packages/Integration/SyncWorker/README.md
+++ b/packages/Integration/SyncWorker/README.md
@@ -1,0 +1,56 @@
+# @memberjunction/integration-sync-worker
+
+An **optional**, out-of-process host for MemberJunction **scheduled integration syncs**. It runs the
+exact same `SchedulingEngine` poll loop MJAPI runs in-process — but in a dedicated process with no
+GraphQL/Apollo — so long, memory- and CPU-heavy syncs stop competing with request serving.
+
+## Deployment model — in-process is the DEFAULT; the container is a CHOICE
+
+**Nothing here changes default behavior.** MJAPI continues to run the scheduler in-process out of the box.
+This worker is a deployment *option* that a given operator (e.g. MJC) can choose to turn on:
+
+| Scenario | MJAPI `scheduledJobs.enabled` | Deploy this worker? | Where scheduled sync runs |
+|---|---|---|---|
+| **Default (unchanged)** | `true` | No | In-process, in MJAPI |
+| **Offloaded (opt-in)** | `false` | Yes (`scheduledJobs.enabled=true` in the worker's env) | In this worker container |
+
+Because job claiming goes through the **DB-atomic lease** (`spAcquireScheduledJobLock` + heartbeat), the two
+modes never double-dispatch — you could even run both during a migration. To actually offload, set MJAPI's
+`scheduledJobs.enabled=false` so only the worker claims jobs.
+
+## Why this is safe (no engine changes)
+
+Sync is already decoupled from the serving process:
+- It only reads external data and writes DB rows via `BaseEntity.Save()`, which propagates to every serving
+  instance through the **existing Redis `remote-invalidate` bus** (set `REDIS_URL` so the worker participates).
+- Boot-time `ResumeOrphanedSyncs` picks up any sync a prior crash left in-progress, from durable
+  watermark/keyset checkpoints.
+- `RunSync` already accepts an injectable provider; no in-memory serving state is required.
+
+This worker adds **zero** changes to the engine, MJServer, drivers, or resolvers — it is purely a new host.
+
+## Scope (v1)
+
+- **In scope:** scheduled integration syncs (claimed via the lease).
+- **Out of scope (stays in-process):** on-demand sync (the fire-and-forget GraphQL mutation); post-sync
+  custom-column promotion (a no-callback host is a supported mode — auto-promote is default-OFF, and MJAPI's
+  existing RSU-pending path performs any promotion).
+
+## Configuration (env)
+
+| Var | Required | Default | Purpose |
+|---|---|---|---|
+| `DB_HOST` / `DB_PORT` / `DB_USERNAME` / `DB_PASSWORD` / `DB_DATABASE` | yes | — / 1433 | Same target DB as MJAPI |
+| `MJ_CORE_SCHEMA` | no | `__mj` | Core schema |
+| `SCHEDULED_JOBS_SYSTEM_USER_EMAIL` | yes | — | MJ user the jobs run as |
+| `METADATA_AUTO_REFRESH_INTERVAL` | no | `180000` | Metadata refresh cadence (ms) |
+| `SCHEDULED_JOBS_MAX_CONCURRENT` | no | `5` | Max concurrent dispatched jobs |
+| `SCHEDULED_JOBS_LEASE_TIMEOUT_MS` | no | `600000` | DB lease timeout (ms) |
+| `REDIS_URL` | recommended | — | Cross-process cache invalidation |
+
+## Run
+
+```bash
+npm run build
+node dist/index.js   # or: npm start
+```

--- a/packages/Integration/SyncWorker/README.md
+++ b/packages/Integration/SyncWorker/README.md
@@ -12,7 +12,7 @@ This worker is a deployment *option* that a given operator (e.g. MJC) can choose
 | Scenario | MJAPI `scheduledJobs.enabled` | Deploy this worker? | Where scheduled sync runs |
 |---|---|---|---|
 | **Default (unchanged)** | `true` | No | In-process, in MJAPI |
-| **Offloaded (opt-in)** | `false` | Yes (`scheduledJobs.enabled=true` in the worker's env) | In this worker container |
+| **Offloaded (opt-in)** | `false` | Yes — deploying the worker *is* the opt-in; once running it always polls | In this worker container |
 
 Because job claiming goes through the **DB-atomic lease** (`spAcquireScheduledJobLock` + heartbeat), the two
 modes never double-dispatch — you could even run both during a migration. To actually offload, set MJAPI's

--- a/packages/Integration/SyncWorker/package.json
+++ b/packages/Integration/SyncWorker/package.json
@@ -1,0 +1,41 @@
+{
+  "name": "@memberjunction/integration-sync-worker",
+  "type": "module",
+  "version": "5.48.0",
+  "description": "Optional out-of-process worker that runs MemberJunction scheduled integration syncs off the serving MJAPI process. Reuses the SchedulingEngine + DB-atomic lease; no engine changes.",
+  "main": "dist/index.js",
+  "scripts": {
+    "dev": "ts-node-dev --transpile-only --respawn --project tsconfig.json src/index.ts",
+    "build": "tsc && tsc-alias -f",
+    "watch": "tsc -w",
+    "start": "node dist/index.js",
+    "clean": "rimraf dist",
+    "lint:tsc": "tsc --noemit"
+  },
+  "author": "",
+  "license": "ISC",
+  "dependencies": {
+    "@memberjunction/core": "5.48.0",
+    "@memberjunction/core-entities": "5.48.0",
+    "@memberjunction/generic-database-provider": "5.48.0",
+    "@memberjunction/integration-engine": "5.48.0",
+    "@memberjunction/redis-provider": "5.48.0",
+    "@memberjunction/scheduling-engine": "5.48.0",
+    "@memberjunction/server-bootstrap": "5.48.0",
+    "@memberjunction/sqlserver-dataprovider": "5.48.0",
+    "dotenv": "^17.2.4",
+    "env-var": "^7.3.0",
+    "mj_generatedentities": "5.48.0",
+    "mssql": "^12.2.0"
+  },
+  "devDependencies": {
+    "@types/node": "^24.10.11",
+    "rimraf": "^6.1.2",
+    "tsc-alias": "^1.8.10",
+    "typescript": "^5.9.3"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/MemberJunction/MJ"
+  }
+}

--- a/packages/Integration/SyncWorker/package.json
+++ b/packages/Integration/SyncWorker/package.json
@@ -16,7 +16,6 @@
   "license": "ISC",
   "dependencies": {
     "@memberjunction/core": "5.48.0",
-    "@memberjunction/core-entities": "5.48.0",
     "@memberjunction/generic-database-provider": "5.48.0",
     "@memberjunction/integration-engine": "5.48.0",
     "@memberjunction/redis-provider": "5.48.0",
@@ -25,7 +24,7 @@
     "@memberjunction/sqlserver-dataprovider": "5.48.0",
     "dotenv": "^17.2.4",
     "env-var": "^7.3.0",
-    "mj_generatedentities": "5.48.0",
+    "mj_generatedentities": "1.0.0",
     "mssql": "^12.2.0"
   },
   "devDependencies": {

--- a/packages/Integration/SyncWorker/package.json
+++ b/packages/Integration/SyncWorker/package.json
@@ -12,7 +12,7 @@
     "clean": "rimraf dist",
     "lint:tsc": "tsc --noemit"
   },
-  "author": "",
+  "author": "MemberJunction.com",
   "license": "ISC",
   "dependencies": {
     "@memberjunction/core": "5.48.0",

--- a/packages/Integration/SyncWorker/package.json
+++ b/packages/Integration/SyncWorker/package.json
@@ -4,6 +4,10 @@
   "version": "5.48.0",
   "description": "Optional out-of-process worker that runs MemberJunction scheduled integration syncs off the serving MJAPI process. Reuses the SchedulingEngine + DB-atomic lease; no engine changes.",
   "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "files": [
+    "/dist"
+  ],
   "scripts": {
     "dev": "ts-node-dev --transpile-only --respawn --project tsconfig.json src/index.ts",
     "build": "tsc && tsc-alias -f",

--- a/packages/Integration/SyncWorker/src/config.ts
+++ b/packages/Integration/SyncWorker/src/config.ts
@@ -1,0 +1,36 @@
+/**
+ * Configuration for the Integration Sync Worker, read from environment variables
+ * (mirrors the ScheduledActionsServer pattern). The worker deliberately does NOT
+ * read mj.config.cjs directly so it can be deployed as an independent process with
+ * only the DB + scheduling env it needs.
+ */
+import env from 'env-var';
+import dotenv from 'dotenv';
+
+dotenv.config({ quiet: true });
+
+// --- Database (same target DB as MJAPI) ---
+export const dbHost = env.get('DB_HOST').required().asString();
+export const dbPort = env.get('DB_PORT').default('1433').asPortNumber();
+export const dbUsername = env.get('DB_USERNAME').required().asString();
+export const dbPassword = env.get('DB_PASSWORD').required().asString();
+export const dbDatabase = env.get('DB_DATABASE').required().asString();
+export const dbTrustServerCertificate = env.get('DB_TRUST_SERVER_CERTIFICATE').default('true').asBool();
+export const dbEncrypt = env.get('DB_ENCRYPT').default('true').asBool();
+
+export const mjCoreSchema = env.get('MJ_CORE_SCHEMA').default('__mj').asString();
+
+/**
+ * Metadata cache refresh interval (ms). Defaults to 180000 (3 min) — the same
+ * cross-server convergence cadence MJAPI uses, so the worker sees schema/metadata
+ * changes another process made without a restart.
+ */
+export const autoRefreshInterval = env.get('METADATA_AUTO_REFRESH_INTERVAL').default('180000').asIntPositive();
+
+// --- Scheduled jobs (the worker's whole job) ---
+/** The MJ user the worker runs scheduled jobs as. Must exist in the DB. */
+export const systemUserEmail = env.get('SCHEDULED_JOBS_SYSTEM_USER_EMAIL').required().asString();
+/** Max concurrently-dispatched scheduled jobs (engine default 5). */
+export const maxConcurrentJobs = env.get('SCHEDULED_JOBS_MAX_CONCURRENT').default('5').asIntPositive();
+/** Lease timeout (ms) for the DB-atomic job lock (engine default 600000). */
+export const leaseTimeoutMs = env.get('SCHEDULED_JOBS_LEASE_TIMEOUT_MS').default('600000').asIntPositive();

--- a/packages/Integration/SyncWorker/src/db.ts
+++ b/packages/Integration/SyncWorker/src/db.ts
@@ -1,0 +1,24 @@
+/**
+ * SQL Server connection pool for the worker (mirrors ScheduledActionsServer/db.ts).
+ * A generous requestTimeout because a sync run can be long-lived.
+ */
+import sql from 'mssql';
+import { dbDatabase, dbEncrypt, dbHost, dbPassword, dbPort, dbTrustServerCertificate, dbUsername } from './config.js';
+
+const config: sql.config = {
+    server: dbHost,
+    port: dbPort,
+    user: dbUsername,
+    password: dbPassword,
+    database: dbDatabase,
+    requestTimeout: 300000, // 5 min — a sync batch can run long
+    options: {
+        encrypt: dbEncrypt,
+        enableArithAbort: true,
+        trustServerCertificate: dbTrustServerCertificate,
+    },
+};
+
+const pool = new sql.ConnectionPool(config);
+
+export default pool;

--- a/packages/Integration/SyncWorker/src/index.ts
+++ b/packages/Integration/SyncWorker/src/index.ts
@@ -16,9 +16,11 @@
  *    from durable watermarks/keyset checkpoints.
  *
  * Opt-in / preserving in-process default:
- *  - Deploy this worker with `scheduledJobs.enabled=true` (its own env) and set the
- *    MJAPI serving process's `scheduledJobs.enabled=false`. If the worker is NOT
- *    deployed, MJAPI keeps running the scheduler in-process — behavior unchanged.
+ *  - Deploying this worker IS the opt-in: once running it always polls (there is no
+ *    per-worker enable flag — it reads only its documented env vars via config.ts).
+ *    To OFFLOAD, set the MJAPI serving process's `scheduledJobs.enabled=false` so only
+ *    the worker claims jobs. If the worker is NOT deployed, MJAPI keeps running the
+ *    scheduler in-process — behavior unchanged.
  *
  * Not handled here (by design, PR 1 scope):
  *  - On-demand sync (the fire-and-forget GraphQL mutation) stays in-process.

--- a/packages/Integration/SyncWorker/src/index.ts
+++ b/packages/Integration/SyncWorker/src/index.ts
@@ -1,0 +1,121 @@
+/**
+ * MemberJunction Integration Sync Worker
+ * ======================================
+ * An OPTIONAL, out-of-process host for scheduled integration syncs. It runs the
+ * SAME `SchedulingEngine` poll loop that MJAPI runs in-process, but in a dedicated
+ * process with no GraphQL/Apollo — so long, memory/CPU-heavy syncs stop competing
+ * with request serving.
+ *
+ * Why this is safe (see SYNC_OUT_OF_PROCESS_NOTE):
+ *  - Sync is already decoupled: it only reads external data and writes DB rows via
+ *    BaseEntity.Save(), which propagates cross-process through the existing Redis
+ *    `remote-invalidate` bus — no new mechanism.
+ *  - Jobs are claimed via the DB-atomic lease (spAcquireScheduledJobLock + heartbeat),
+ *    so this worker and any MJAPI instance can coexist with no double-dispatch.
+ *  - Boot-time `ResumeOrphanedSyncs` picks up syncs a prior crash left in-progress
+ *    from durable watermarks/keyset checkpoints.
+ *
+ * Opt-in / preserving in-process default:
+ *  - Deploy this worker with `scheduledJobs.enabled=true` (its own env) and set the
+ *    MJAPI serving process's `scheduledJobs.enabled=false`. If the worker is NOT
+ *    deployed, MJAPI keeps running the scheduler in-process — behavior unchanged.
+ *
+ * Not handled here (by design, PR 1 scope):
+ *  - On-demand sync (the fire-and-forget GraphQL mutation) stays in-process.
+ *  - Post-sync custom-column promotion callback is NOT registered here (a no-callback
+ *    host is a supported promotion mode; auto-promote is default-OFF, and MJAPI's
+ *    existing RSU-pending path performs any promotion).
+ */
+
+// --- Class registrations (drivers + connectors must be registered before the engine runs) ---
+import 'mj_generatedentities';
+import '@memberjunction/server-bootstrap/mj-class-registrations';
+
+import { LogError, LogStatus, Metadata, UserInfo } from '@memberjunction/core';
+import { GenericDatabaseProvider } from '@memberjunction/generic-database-provider';
+import { SQLServerProviderConfigData, setupSQLServerClient, UserCache } from '@memberjunction/sqlserver-dataprovider';
+import { SchedulingEngine } from '@memberjunction/scheduling-engine';
+import { IntegrationEngine } from '@memberjunction/integration-engine';
+import { RedisLocalStorageProvider } from '@memberjunction/redis-provider';
+import pool from './db.js';
+import {
+    autoRefreshInterval,
+    leaseTimeoutMs,
+    maxConcurrentJobs,
+    mjCoreSchema,
+    systemUserEmail,
+} from './config.js';
+
+let shuttingDown = false;
+
+/** Bootstrap the MJ provider standalone (no Apollo), then start the scheduler poll loop. */
+async function bootstrap(): Promise<void> {
+    // 1. Provider + metadata + UserCache (the ScheduledActionsServer / AICLI pattern)
+    await pool.connect();
+    const providerConfig = new SQLServerProviderConfigData(pool, mjCoreSchema, autoRefreshInterval);
+    await setupSQLServerClient(providerConfig);
+    LogStatus(`[SyncWorker] Provider initialized against ${mjCoreSchema} (metadata refresh every ${autoRefreshInterval}ms)`);
+
+    // 2. Redis so this worker's BaseEntity.Save() writes invalidate MJAPI's caches cross-process
+    if (process.env.REDIS_URL) {
+        const redis = new RedisLocalStorageProvider({
+            url: process.env.REDIS_URL,
+            keyPrefix: process.env.REDIS_KEY_PREFIX || 'mj',
+            enablePubSub: true,
+        });
+        (Metadata.Provider as GenericDatabaseProvider).SetLocalStorageProvider(redis);
+        await redis.StartListening();
+        LogStatus(`[SyncWorker] Redis cache invalidation connected: ${process.env.REDIS_URL}`);
+    } else {
+        LogStatus('[SyncWorker] REDIS_URL not set — cross-process cache invalidation disabled (single-instance only)');
+    }
+
+    // 3. Resolve the system user the jobs run as
+    const systemUser: UserInfo | undefined = UserCache.Users.find(
+        (u) => u.Email?.toLowerCase() === systemUserEmail.toLowerCase(),
+    );
+    if (!systemUser) {
+        throw new Error(`[SyncWorker] System user not found with email: ${systemUserEmail}`);
+    }
+
+    // 4. Resume any syncs a prior worker/server crash left in-progress (durable watermark/keyset resume)
+    try {
+        await IntegrationEngine.Instance.ResumeOrphanedSyncs(systemUser);
+    } catch (err) {
+        LogError('[SyncWorker] ResumeOrphanedSyncs failed (continuing to start scheduler)', undefined, err);
+    }
+
+    // 5. Start the scheduler poll loop — claims due jobs via the DB-atomic lease
+    const engine = SchedulingEngine.Instance;
+    await engine.Config(false, systemUser);
+    engine.MaxConcurrentJobs = maxConcurrentJobs;
+    engine.LeaseTimeoutMs = leaseTimeoutMs;
+    await engine.StartPolling(systemUser);
+    LogStatus(`[SyncWorker] Started — ${engine.ScheduledJobs.length} active scheduled job(s), max ${maxConcurrentJobs} concurrent`);
+}
+
+async function shutdown(signal: string): Promise<void> {
+    if (shuttingDown) return;
+    shuttingDown = true;
+    LogStatus(`[SyncWorker] ${signal} received — draining in-flight jobs (max 30s)...`);
+    try {
+        await SchedulingEngine.Instance.StopPolling({ waitForInflight: true, maxWaitMs: 30_000 });
+    } catch (err) {
+        LogError('[SyncWorker] Error stopping polling', undefined, err);
+    }
+    try {
+        await pool.close();
+    } catch {
+        /* best-effort */
+    }
+    LogStatus('[SyncWorker] Shutdown complete');
+    process.exit(0);
+}
+
+process.on('SIGTERM', () => void shutdown('SIGTERM'));
+process.on('SIGINT', () => void shutdown('SIGINT'));
+
+bootstrap().catch((err) => {
+    LogError('[SyncWorker] Bootstrap failed', undefined, err);
+    process.exit(1);
+});

--- a/packages/Integration/SyncWorker/src/index.ts
+++ b/packages/Integration/SyncWorker/src/index.ts
@@ -63,7 +63,7 @@ async function bootstrap(): Promise<void> {
             keyPrefix: process.env.REDIS_KEY_PREFIX || 'mj',
             enablePubSub: true,
         });
-        (Metadata.Provider as GenericDatabaseProvider).SetLocalStorageProvider(redis);
+        (Metadata.Provider as GenericDatabaseProvider).SetLocalStorageProvider(redis); // global-provider-ok: bootstrap (Redis cache wiring for the worker process)
         await redis.StartListening();
         LogStatus(`[SyncWorker] Redis cache invalidation connected: ${process.env.REDIS_URL}`);
     } else {

--- a/packages/Integration/SyncWorker/tsconfig.json
+++ b/packages/Integration/SyncWorker/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../../tsconfig.server.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist"]
+}


### PR DESCRIPTION
## What
Adds **`@memberjunction/integration-sync-worker`** — an **optional**, standalone host that runs scheduled integration syncs off the serving MJAPI process. It runs the *same* `SchedulingEngine` poll loop MJAPI runs in-process, but in a dedicated process with no GraphQL/Apollo, so long, memory- and CPU-heavy syncs stop competing with request serving.

## In-process stays the default; the container is a choice
**Nothing changes by default.** MJAPI keeps running the scheduler in-process. This worker is a deployment *option* an operator (e.g. MJC) can turn on:

| Scenario | MJAPI `scheduledJobs.enabled` | Deploy worker? | Scheduled sync runs |
|---|---|---|---|
| **Default (unchanged)** | `true` | No | In-process, in MJAPI |
| **Offloaded (opt-in)** | `false` | Yes | In this worker container |

Because jobs are claimed via the **DB-atomic lease** (`spAcquireScheduledJobLock` + heartbeat), the two modes never double-dispatch. If the worker is never deployed, behavior is identical to today.

## Why it's safe — zero engine changes
Sync is already decoupled from serving-process state:
- Writes go through `BaseEntity.Save()` → propagate cross-process via the **existing Redis `remote-invalidate` bus** (set `REDIS_URL`).
- Boot-time `ResumeOrphanedSyncs` recovers in-progress syncs from durable watermark/keyset checkpoints.
- `RunSync` already takes an injectable provider.

**No changes to the engine, MJServer, drivers, or resolvers** — this is purely a new host package.

## Scope (v1)
- **In:** scheduled integration syncs.
- **Out (stays in-process):** on-demand sync (fire-and-forget mutation); post-sync custom-column promotion (a no-callback host is a supported mode; auto-promote is default-OFF, and MJAPI's RSU-pending path handles promotion).

## Testing
- Builds + typechecks clean (0 errors) against the real `@memberjunction/*` types.
- **Boot-verified** against a live SQL Server: provider init → `SchedulingEngine` start (found active scheduled jobs) → clean SIGTERM drain.
- Not yet covered: a full "claims + runs a real scheduled sync to completion" e2e (needs a configured connector + credentials) — recommend before enabling in production.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
