### PR TITLE
fix(core): explicit ClassFactory resolution failure + permission provider isolation (B34/B35)

### DIFF
--- a/.changeset/classfactory-explicit-resolution-failure.md
+++ b/.changeset/classfactory-explicit-resolution-failure.md
@@ -1,0 +1,26 @@
+---
+'@memberjunction/global': patch
+'@memberjunction/core': patch
+'@memberjunction/core-entities': patch
+---
+
+Explicit ClassFactory resolution failure + permission provider fault isolation (B34/B35)
+
+`ClassFactory.CreateInstance` has never returned `null` for an unregistered key — it falls back to
+instantiating the anchor base class — so every call site written as `if (instance) { use } else { error }`
+had a dead failure branch and silently installed a hollow base-class object.
+
+- **`@memberjunction/global`**: adds `TryCreateInstance` / `TryCreateInstanceAsync`, which return an
+  explicit `ClassResolutionResult<T>` (`Resolved` / `Instance` / `Reason`). Bases that cannot function
+  standalone opt in with `static readonly RequiresSubclass = true`: on a fallback they now throw from
+  `CreateInstance` and return `{Resolved: false, Instance: null}` from `TryCreateInstance`. Bases without
+  the marker keep the historical base-class fallback (e.g. `BaseEntity`) and emit a structured, once-per-key
+  warning listing the registered keys for that base plus the call-site stack. `CreateInstance`,
+  `CreateInstanceAsync`, and the `Try*` variants all route through one shared resolution path.
+- **`@memberjunction/core`**: `PermissionProviderBase` declares `RequiresSubclass = true` — every member is
+  abstract, so a base instance is a method-less stub.
+- **`@memberjunction/core-entities`**: `PermissionEngine.instantiateProviders` uses `TryCreateInstance`, so
+  an unresolvable `ProviderClassName` is now genuinely skipped instead of installing a stub as a live
+  provider. The `GetAllUserPermissions` / `GetPermissionsGrantedByUser` / `GetPermissionsSharedWithUser`
+  fan-outs defer each provider call into a promise body so a SYNCHRONOUS throw (a missing method) is
+  isolated by `Promise.allSettled` instead of rejecting the entire aggregate for every user.

--- a/packages/MJCore/src/generic/permissionInterfaces.ts
+++ b/packages/MJCore/src/generic/permissionInterfaces.ts
@@ -176,6 +176,19 @@ export interface IPermissionProvider {
  * ```
  */
 export abstract class PermissionProviderBase implements IPermissionProvider {
+    /**
+     * Opt-in marker read by `ClassFactory` (see `ClassResolutionResult`): this class CANNOT
+     * function standalone — every member below is abstract, so a base instance is a method-less
+     * stub. TypeScript's `abstract` is erased at runtime, so the factory cannot detect that on its
+     * own; without this marker an unresolvable `ProviderClassName` would silently be handed back
+     * as a live "provider" and blow up later at the first method call.
+     *
+     * With the marker set, `CreateInstance` throws and `TryCreateInstance` returns
+     * `{Resolved: false, Instance: null}` — both of which `PermissionEngine` handles by skipping
+     * the domain.
+     */
+    public static readonly RequiresSubclass = true;
+
     abstract readonly DomainName: string;
     abstract readonly Description: string;
     abstract readonly SupportedGranteeTypes: GranteeType[];

--- a/packages/MJCoreEntities/src/__tests__/PermissionEngine.test.ts
+++ b/packages/MJCoreEntities/src/__tests__/PermissionEngine.test.ts
@@ -263,6 +263,76 @@ describe('PermissionEngine', () => {
         });
     });
 
+    // ────────────────────────────────────────────────────────────────────────────────────
+    // B34: a provider whose method is MISSING (a hollow ClassFactory base-class stub) throws
+    // SYNCHRONOUSLY inside `.map()` — before Promise.allSettled ever sees a promise — which
+    // used to reject the ENTIRE aggregate for every user. The fan-out defers each invocation
+    // into a promise body so a sync throw is isolated exactly like an async rejection.
+    // ────────────────────────────────────────────────────────────────────────────────────
+    describe('fan-out isolation of a hollow (method-less) provider', () => {
+        /** Stands in for the abstract-base stub ClassFactory used to hand back for unknown keys. */
+        const makeHollowProvider = (domainName: string): PermissionProviderBase =>
+            ({ DomainName: domainName } as unknown as PermissionProviderBase);
+
+        const healthyRow = {
+            DomainName: 'Entity Permissions',
+            ResourceType: 'Users',
+            ResourceID: null,
+            GranteeType: 'User' as const,
+            GranteeID: 'U1',
+            Actions: ['Read' as const],
+            Effect: 'Allow' as const,
+        };
+
+        // Built as a plain object rather than via makeMockProvider, because the sharing-facing
+        // methods (GetPermissionsGrantedByUser / GetPermissionsSharedWithUser) are not part of
+        // that helper's override surface and would silently stay undefined.
+        const withHollowAlongsideHealthy = (healthyOverrides: Partial<PermissionProviderBase>) => {
+            const healthy = {
+                ...(makeMockProvider({ DomainName: 'Entity Permissions' }) as unknown as Record<string, unknown>),
+                ...healthyOverrides,
+            } as unknown as PermissionProviderBase;
+            engine._SetProvidersForTesting(
+                new Map<string, PermissionProviderBase>([
+                    ['Entity Permissions', healthy],
+                    ['Hollow Domain', makeHollowProvider('Hollow Domain')],
+                ])
+            );
+            return healthy;
+        };
+
+        it('GetAllUserPermissions resolves instead of rejecting, and healthy domains still contribute', async () => {
+            withHollowAlongsideHealthy({ GetUserResources: vi.fn(async () => [healthyRow]) });
+
+            const all = await engine.GetAllUserPermissions(MOCK_USER);
+
+            expect(all).toHaveLength(1);
+            expect(all[0].DomainName).toBe('Entity Permissions');
+        });
+
+        it('GetPermissionsGrantedByUser is isolated the same way', async () => {
+            withHollowAlongsideHealthy({ GetPermissionsGrantedByUser: vi.fn(async () => [healthyRow]) });
+
+            const rows = await engine.GetPermissionsGrantedByUser(MOCK_USER);
+            expect(rows).toHaveLength(1);
+        });
+
+        it('GetPermissionsSharedWithUser is isolated the same way', async () => {
+            withHollowAlongsideHealthy({ GetPermissionsSharedWithUser: vi.fn(async () => [healthyRow]) });
+
+            const rows = await engine.GetPermissionsSharedWithUser(MOCK_USER);
+            expect(rows).toHaveLength(1);
+        });
+
+        it('a hollow provider as the ONLY provider degrades to an empty aggregate, not a rejection', async () => {
+            engine._SetProvidersForTesting(
+                new Map<string, PermissionProviderBase>([['Hollow Domain', makeHollowProvider('Hollow Domain')]])
+            );
+
+            await expect(engine.GetAllUserPermissions(MOCK_USER)).resolves.toEqual([]);
+        });
+    });
+
     describe('GetResourcePermissions', () => {
         it('returns rows from the matching provider', async () => {
             const rows = [

--- a/packages/MJCoreEntities/src/engines/PermissionEngine.ts
+++ b/packages/MJCoreEntities/src/engines/PermissionEngine.ts
@@ -118,16 +118,22 @@ export class PermissionEngine extends BaseEngine<PermissionEngine> {
         const activeDomains = this._domains.filter((d) => d.IsActive);
         for (const domain of activeDomains) {
             try {
-                const instance = MJGlobal.Instance.ClassFactory.CreateInstance<PermissionProviderBase>(
+                // TryCreateInstance (NOT CreateInstance) because CreateInstance never returns null
+                // for an unregistered key — it falls back to the anchor base class. Using the
+                // explicit-result API is what makes the "skip unresolvable domains" branch below
+                // actually reachable, instead of installing a method-less abstract-base stub as a
+                // live provider (which then poisons every fan-out in this engine).
+                const resolution = MJGlobal.Instance.ClassFactory.TryCreateInstance<PermissionProviderBase>(
                     PermissionProviderBase,
                     domain.ProviderClassName
                 );
-                if (instance) {
-                    this._providers.set(domain.Name, instance);
+                if (resolution.Resolved && resolution.Instance) {
+                    this._providers.set(domain.Name, resolution.Instance);
                 } else {
                     LogError(
                         `PermissionEngine: no provider registered for ProviderClassName '${domain.ProviderClassName}' ` +
-                            `(domain '${domain.Name}'). Domain will be skipped until a provider is registered.`
+                            `(domain '${domain.Name}'). Domain will be skipped until a provider is registered. ` +
+                            `${resolution.Reason ?? ''}`
                     );
                 }
             } catch (err) {
@@ -171,8 +177,28 @@ export class PermissionEngine extends BaseEngine<PermissionEngine> {
      * Powers the Sharing Center "User Access Report" view.
      */
     public async GetAllUserPermissions(user: UserInfo): Promise<NormalizedPermission[]> {
+        return this.fanOutAcrossProviders('GetAllUserPermissions', (p) => p.GetUserResources(user));
+    }
+
+    /**
+     * Runs `invoke` against every registered provider in parallel and concatenates the results,
+     * isolating per-provider failures so one broken domain degrades to "contributes nothing"
+     * rather than rejecting the whole aggregate.
+     *
+     * The `Promise.resolve().then(...)` wrapper is load-bearing and NOT ceremony: `allSettled`
+     * only isolates *rejections*, but a mapper that throws SYNCHRONOUSLY (the classic case being a
+     * provider whose method is `undefined`, e.g. a hollow stub) throws inside `.map()` — before
+     * `allSettled` is ever called — and rejects the entire call. Deferring the invocation into a
+     * promise body converts that synchronous throw into a rejection `allSettled` can contain.
+     * Defense in depth: `instantiateProviders` should prevent hollow providers from being
+     * installed at all, but this fan-out must not be the thing that fails if one ever slips in.
+     */
+    private async fanOutAcrossProviders(
+        callerName: string,
+        invoke: (provider: PermissionProviderBase) => Promise<NormalizedPermission[]>
+    ): Promise<NormalizedPermission[]> {
         const providers = Array.from(this._providers.values());
-        const settled = await Promise.allSettled(providers.map((p) => p.GetUserResources(user)));
+        const settled = await Promise.allSettled(providers.map((p) => Promise.resolve().then(() => invoke(p))));
 
         const results: NormalizedPermission[] = [];
         settled.forEach((outcome, i) => {
@@ -180,7 +206,7 @@ export class PermissionEngine extends BaseEngine<PermissionEngine> {
             if (outcome.status === 'fulfilled') {
                 if (outcome.value?.length) results.push(...outcome.value);
             } else {
-                LogError(`PermissionEngine.GetAllUserPermissions: provider '${provider.DomainName}' threw: ${outcome.reason}`);
+                LogError(`PermissionEngine.${callerName}: provider '${provider?.DomainName}' threw: ${outcome.reason}`);
             }
         });
         return results;
@@ -195,21 +221,7 @@ export class PermissionEngine extends BaseEngine<PermissionEngine> {
      * Providers are queried in parallel; failures are logged and skipped.
      */
     public async GetPermissionsGrantedByUser(grantor: UserInfo): Promise<NormalizedPermission[]> {
-        const providers = Array.from(this._providers.values());
-        const settled = await Promise.allSettled(providers.map((p) => p.GetPermissionsGrantedByUser(grantor)));
-
-        const results: NormalizedPermission[] = [];
-        settled.forEach((outcome, i) => {
-            const provider = providers[i];
-            if (outcome.status === 'fulfilled') {
-                if (outcome.value?.length) results.push(...outcome.value);
-            } else {
-                LogError(
-                    `PermissionEngine.GetPermissionsGrantedByUser: provider '${provider.DomainName}' threw: ${outcome.reason}`
-                );
-            }
-        });
-        return results;
+        return this.fanOutAcrossProviders('GetPermissionsGrantedByUser', (p) => p.GetPermissionsGrantedByUser(grantor));
     }
 
     /**
@@ -218,21 +230,7 @@ export class PermissionEngine extends BaseEngine<PermissionEngine> {
      * access. Providers are queried in parallel; failures are logged and skipped.
      */
     public async GetPermissionsSharedWithUser(grantee: UserInfo): Promise<NormalizedPermission[]> {
-        const providers = Array.from(this._providers.values());
-        const settled = await Promise.allSettled(providers.map((p) => p.GetPermissionsSharedWithUser(grantee)));
-
-        const results: NormalizedPermission[] = [];
-        settled.forEach((outcome, i) => {
-            const provider = providers[i];
-            if (outcome.status === 'fulfilled') {
-                if (outcome.value?.length) results.push(...outcome.value);
-            } else {
-                LogError(
-                    `PermissionEngine.GetPermissionsSharedWithUser: provider '${provider.DomainName}' threw: ${outcome.reason}`
-                );
-            }
-        });
-        return results;
+        return this.fanOutAcrossProviders('GetPermissionsSharedWithUser', (p) => p.GetPermissionsSharedWithUser(grantee));
     }
 
     /**

--- a/packages/MJGlobal/src/ClassFactory.ts
+++ b/packages/MJGlobal/src/ClassFactory.ts
@@ -40,7 +40,48 @@ export class ClassRegistration {
  
 
 /**
- * ClassFactory is used to register and create instances of classes. It is a singleton class that can be used to register a sub-class for a given base class and key. Do NOT directly attempt to instantiate this class, 
+ * The outcome of a {@link ClassFactory.TryCreateInstance} call — an EXPLICIT resolution result
+ * so callers can distinguish "a registered subclass was found and instantiated" from "no
+ * registration matched the key and we fell back to the anchor base class".
+ *
+ * ## Why this type exists
+ * {@link ClassFactory.CreateInstance} has NEVER returned `null` for an unregistered key — it
+ * falls back to `new BaseClass(...)`. Call sites written as `const x = CreateInstance(Base, key);
+ * if (x) { use it } else { error }` therefore have a DEAD else-branch and silently install a
+ * hollow base-class object. That failure mode is invisible until something calls a method the
+ * base does not implement. `TryCreateInstance` makes the distinction explicit and checkable.
+ */
+export type ClassResolutionResult<T> = {
+    /**
+     * `true` only when a REGISTERED subclass matched the requested key. `false` means the key did
+     * not resolve — check {@link Instance} to see whether a base-class fallback was produced.
+     */
+    Resolved: boolean;
+    /**
+     * The instance to use, or `null`.
+     *
+     * - `Resolved: true` → the registered subclass instance.
+     * - `Resolved: false` and the anchor base declares `static RequiresSubclass = true` → `null`
+     *   (the base cannot function standalone, so no fallback is produced).
+     * - `Resolved: false` and no marker → the base-class fallback instance. This is a legitimate,
+     *   long-standing pattern (e.g. `BaseEntity`, which is fully functional standalone).
+     */
+    Instance: T | null;
+    /** Human-readable explanation, present whenever `Resolved` is `false`. */
+    Reason?: string;
+};
+
+/**
+ * Shape of a base class that opts in to the "I cannot be instantiated standalone" contract.
+ *
+ * TypeScript's `abstract` keyword is ERASED at runtime — there is no marker property, and plain
+ * JS will happily `new` an abstract class — so abstractness cannot be introspected. Bases that
+ * genuinely cannot function without a subclass therefore declare this static marker explicitly.
+ */
+type SubclassRequiringClass = { RequiresSubclass?: boolean };
+
+/**
+ * ClassFactory is used to register and create instances of classes. It is a singleton class that can be used to register a sub-class for a given base class and key. Do NOT directly attempt to instantiate this class,
  * instead use the static Instance property of the MJGlobal class to get the instance of the ClassFactory for your application.
  */
 export class ClassFactory {
@@ -67,6 +108,12 @@ export class ClassFactory {
      * successfully loaded the module containing the requested class registration.
      */
     private _lazyLoaders: ((baseClassName: string, key: string) => Promise<boolean>)[] = [];
+
+    /**
+     * `baseClassName|normalizedKey` pairs whose base-class-fallback diagnostic has already been
+     * emitted, so a hot-path resolution failure logs once instead of on every call.
+     */
+    private _reportedResolutionFailures: Set<string> = new Set();
 
     /**
      * Registers a lazy loader callback that will be called when a class registration cannot
@@ -121,7 +168,8 @@ export class ClassFactory {
      * retrying and creating the instance.
      *
      * Falls back to instantiating the base class directly if no registration is found even
-     * after lazy loading (same behavior as the sync CreateInstance).
+     * after lazy loading (same behavior as the sync CreateInstance) — including throwing when the
+     * anchor base declares `static RequiresSubclass = true`.
      */
     public async CreateInstanceAsync<T>(baseClass: unknown, key: string | null = null, ...params: unknown[]): Promise<T | null> {
         if (!baseClass) {
@@ -129,17 +177,23 @@ export class ClassFactory {
         }
 
         const reg = await this.GetRegistrationAsync(baseClass, key);
-        if (reg) {
-            const SubClassConstructor = reg.SubClass as new (...args: unknown[]) => T;
-            if (params !== undefined) {
-                return new SubClassConstructor(...params);
-            }
-            return new SubClassConstructor();
+        const result = this.resolveAndInstantiate<T>(baseClass, reg, key, params);
+        if (!result.Resolved && result.Instance === null) {
+            throw new Error(result.Reason);
         }
+        return result.Instance;
+    }
 
-        // Fallback to base class (same as sync CreateInstance)
-        const BaseClassConstructor = baseClass as new (...args: unknown[]) => T;
-        return new BaseClassConstructor(...params);
+    /**
+     * Explicit-result, lazy-loading-aware sibling of {@link TryCreateInstance}. Never throws for
+     * an unresolved key.
+     */
+    public async TryCreateInstanceAsync<T>(baseClass: unknown, key: string | null = null, ...params: unknown[]): Promise<ClassResolutionResult<T>> {
+        if (!baseClass) {
+            return { Resolved: false, Instance: null, Reason: 'ClassFactory: no base class was provided.' };
+        }
+        const reg = await this.GetRegistrationAsync(baseClass, key);
+        return this.resolveAndInstantiate<T>(baseClass, reg, key, params);
     }
 
     /**
@@ -208,34 +262,126 @@ export class ClassFactory {
             // Invalidate the GetRegistration memo — a new registration may change the
             // highest-priority winner for any (baseClass, key) bucket.
             this._registrationCache.clear();
+            // A new registration may resolve a key that previously fell back, so allow the
+            // diagnostic to be emitted again if it fails a second time.
+            this._reportedResolutionFailures.clear();
         }
     }
 
     /**
-     * Creates an instance of the class registered for the given base class and key. 
-     * If no registration is found, will return an instance of the base class.
+     * Creates an instance of the class registered for the given base class and key.
+     *
+     * If no registration is found, falls back to instantiating the base class itself — a
+     * long-standing, deliberate behavior that legitimate consumers (notably `BaseEntity`) rely on.
+     * **This method therefore does NOT return `null` for an unregistered key**, so `if (instance)`
+     * is not a valid resolution-failure test. Use {@link TryCreateInstance} when you need to know
+     * whether the key actually resolved.
+     *
+     * @throws when the key does not resolve AND the anchor base class declares
+     *         `static RequiresSubclass = true` (i.e. it cannot function standalone). Bases without
+     *         that marker keep the historical fallback behavior and only emit a structured warning.
      */
     public CreateInstance<T>(baseClass: unknown, key: string | null = null, ...params: unknown[]): T | null {
-        if (baseClass) {
-            let reg = this.GetRegistration(baseClass, key);
-            if (reg) {
-                const SubClassConstructor = reg.SubClass as new (...args: unknown[]) => T;
-                let instance: T | null = null;
-                if (params !== undefined)
-                    instance = new SubClassConstructor(...params);
-                else
-                    instance = new SubClassConstructor(); // dont pass in anything if we got undefined for that parameter into our function because it is different to call a function with no params than to pass in a single null/undefined param
+        const result = this.resolveAndInstantiate<T>(baseClass, this.GetRegistration(baseClass, key), key, params);
+        if (!result.Resolved && result.Instance === null && baseClass) {
+            // The base explicitly cannot stand alone — fail LOUD rather than handing back a hollow object.
+            throw new Error(result.Reason);
+        }
+        return result.Instance;
+    }
 
-                return instance;
-            }
-            else {
-                // this is a normal condition to use the base class if we can't find a registration
-                const BaseClassConstructor = baseClass as new (...args: unknown[]) => T;
-                return new BaseClassConstructor(...params); // if we can't find a registration, just return a new instance of the base class
-            }
+    /**
+     * Explicit-result sibling of {@link CreateInstance}. Never throws for an unresolved key —
+     * returns a {@link ClassResolutionResult} so the caller can branch on `Resolved`.
+     *
+     * ```typescript
+     * const res = MJGlobal.Instance.ClassFactory.TryCreateInstance<MyProvider>(MyProviderBase, key);
+     * if (!res.Resolved || !res.Instance) {
+     *     LogError(`provider '${key}' did not resolve: ${res.Reason}`);
+     *     return; // skip — do NOT install a hollow base instance
+     * }
+     * use(res.Instance);
+     * ```
+     */
+    public TryCreateInstance<T>(baseClass: unknown, key: string | null = null, ...params: unknown[]): ClassResolutionResult<T> {
+        return this.resolveAndInstantiate<T>(baseClass, this.GetRegistration(baseClass, key), key, params);
+    }
+
+    /**
+     * Single shared resolution path behind `CreateInstance`, `TryCreateInstance`, and
+     * `CreateInstanceAsync` — so the sync and async surfaces (and the throwing and non-throwing
+     * surfaces) can never drift apart in how they treat a fallback.
+     */
+    private resolveAndInstantiate<T>(
+        baseClass: unknown,
+        reg: ClassRegistration | null,
+        key: string | null,
+        params: unknown[]
+    ): ClassResolutionResult<T> {
+        if (!baseClass) {
+            return { Resolved: false, Instance: null, Reason: 'ClassFactory: no base class was provided.' };
         }
 
-        return null;
+        if (reg) {
+            const SubClassConstructor = reg.SubClass as new (...args: unknown[]) => T;
+            return { Resolved: true, Instance: new SubClassConstructor(...params) };
+        }
+
+        // ── Fallback path: the requested key did not resolve to any registered subclass. ──
+        const requiresSubclass = (baseClass as SubclassRequiringClass).RequiresSubclass === true;
+        const reason = this.describeResolutionFailure(baseClass, key, requiresSubclass);
+        this.reportResolutionFailure(baseClass, key, requiresSubclass, reason);
+
+        if (requiresSubclass) {
+            return { Resolved: false, Instance: null, Reason: reason };
+        }
+
+        // No marker — the base is presumed usable standalone (e.g. BaseEntity). Preserve the
+        // historical fallback so existing, CORRECT consumers keep working.
+        const BaseClassConstructor = baseClass as new (...args: unknown[]) => T;
+        return { Resolved: false, Instance: new BaseClassConstructor(...params), Reason: reason };
+    }
+
+    /**
+     * Builds the diagnostic message for a failed key resolution. The registered-key list is the
+     * highest-value part: a typo'd or tree-shaken key is immediately obvious next to the keys the
+     * factory actually knows about.
+     */
+    private describeResolutionFailure(baseClass: unknown, key: string | null, requiresSubclass: boolean): string {
+        const baseClassName = (baseClass as NamedClass).name;
+        const known = this.GetAllRegistrations(baseClass)
+            .map(r => r.Key)
+            .filter((k): k is string => k != null);
+        const uniqueKnown = Array.from(new Set(known)).sort();
+        const knownText = uniqueKnown.length > 0 ? uniqueKnown.map(k => `'${k}'`).join(', ') : '(none)';
+
+        return (
+            `ClassFactory: no registration found for base class '${baseClassName}' with key '${key ?? '(null)'}'. ` +
+            `Registered keys for '${baseClassName}': ${knownText}. ` +
+            `RequiresSubclass=${requiresSubclass}. ` +
+            (requiresSubclass
+                ? `'${baseClassName}' declares 'static RequiresSubclass = true', so it CANNOT be used as a fallback — ` +
+                  `no instance was created. Likely causes: a typo in the key, a class that was never imported ` +
+                  `(tree-shaken out — check the class-registration manifest), or a missing @RegisterClass decorator.`
+                : `Falling back to an instance of '${baseClassName}' itself. If that base cannot function standalone, ` +
+                  `declare 'static readonly RequiresSubclass = true' on it so this becomes a hard error.`)
+        );
+    }
+
+    /**
+     * Emits the fallback diagnostic exactly once per (baseClass, key) pair — resolution happens on
+     * very hot paths (once per entity-field hydration), so an un-deduped log would be a firehose.
+     * A captured stack is included so the offending call site is identifiable.
+     */
+    private reportResolutionFailure(baseClass: unknown, key: string | null, requiresSubclass: boolean, reason: string): void {
+        const logKey = `${(baseClass as NamedClass).name}|${key == null ? '' : key.trim().toLowerCase()}`;
+        if (this._reportedResolutionFailures.has(logKey)) return;
+        this._reportedResolutionFailures.add(logKey);
+
+        const stack = new Error().stack ?? '(stack unavailable)';
+        const message = `${reason}\nCall site:\n${stack}`;
+        if (requiresSubclass) console.error(message);
+        else console.warn(message);
     }
 
     /**

--- a/packages/MJGlobal/src/__tests__/ClassFactory.test.ts
+++ b/packages/MJGlobal/src/__tests__/ClassFactory.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { ClassFactory, ClassRegistration } from '../ClassFactory';
 
 // ---- Test class hierarchies ----
@@ -730,6 +730,130 @@ describe('ClassFactory', () => {
       const after = factory.GetRegistration(Animal, 'pet');
       expect(after!.SubClass).toBe(before!.SubClass);
       expect(after!.SubClass).toBe(Dog);
+    });
+  });
+
+  // ────────────────────────────────────────────────────────────────────────────────────
+  // Explicit resolution failure (B35): CreateInstance never returned null for an unknown
+  // key, so `if (instance)` was a broken failure test at every call site.
+  // ────────────────────────────────────────────────────────────────────────────────────
+  describe('resolution failure reporting', () => {
+    /** A base that CAN stand alone — the BaseEntity-style legitimate fallback. */
+    class StandaloneBase {
+      Kind = 'standalone';
+    }
+    class StandaloneSub extends StandaloneBase {
+      Kind = 'sub';
+    }
+    /** A base that CANNOT stand alone — opts in via the explicit static marker. */
+    class MarkedBase {
+      public static readonly RequiresSubclass = true;
+      DoWork(): string {
+        throw new Error('must be overridden');
+      }
+    }
+    class MarkedSub extends MarkedBase {
+      override DoWork(): string {
+        return 'real work';
+      }
+    }
+
+    let warnSpy: ReturnType<typeof vi.spyOn>;
+    let errorSpy: ReturnType<typeof vi.spyOn>;
+
+    beforeEach(() => {
+      warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+      errorSpy = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+    });
+
+    afterEach(() => {
+      warnSpy.mockRestore();
+      errorSpy.mockRestore();
+    });
+
+    it('successful resolution is unchanged and reports Resolved: true', () => {
+      factory.Register(StandaloneBase, StandaloneSub, 'known', 0, true);
+      const result = factory.TryCreateInstance<StandaloneBase>(StandaloneBase, 'known');
+      expect(result.Resolved).toBe(true);
+      expect(result.Instance).toBeInstanceOf(StandaloneSub);
+      expect(result.Reason).toBeUndefined();
+      // The legacy surface behaves identically.
+      expect(factory.CreateInstance<StandaloneBase>(StandaloneBase, 'known')).toBeInstanceOf(StandaloneSub);
+    });
+
+    it('fallback WITHOUT the marker returns the base instance and warns (BaseEntity-style fallback preserved)', () => {
+      const result = factory.TryCreateInstance<StandaloneBase>(StandaloneBase, 'no-such-key');
+      expect(result.Resolved).toBe(false);
+      expect(result.Instance).toBeInstanceOf(StandaloneBase);
+      expect(result.Reason).toContain('no-such-key');
+      expect(warnSpy).toHaveBeenCalled();
+      expect(errorSpy).not.toHaveBeenCalled();
+    });
+
+    it('CreateInstance still falls back to the base class when the base has no marker', () => {
+      const instance = factory.CreateInstance<StandaloneBase>(StandaloneBase, 'no-such-key');
+      expect(instance).toBeInstanceOf(StandaloneBase);
+    });
+
+    it('fallback WITH the marker throws from CreateInstance instead of returning a hollow stub', () => {
+      expect(() => factory.CreateInstance<MarkedBase>(MarkedBase, 'no-such-key')).toThrow(/MarkedBase/);
+      expect(errorSpy).toHaveBeenCalled();
+    });
+
+    it('fallback WITH the marker returns Resolved: false / Instance: null from TryCreateInstance', () => {
+      const result = factory.TryCreateInstance<MarkedBase>(MarkedBase, 'no-such-key');
+      expect(result.Resolved).toBe(false);
+      expect(result.Instance).toBeNull();
+      expect(result.Reason).toContain('RequiresSubclass=true');
+    });
+
+    it('a marked base still resolves its registered subclass normally', () => {
+      factory.Register(MarkedBase, MarkedSub, 'real', 0, true);
+      const result = factory.TryCreateInstance<MarkedBase>(MarkedBase, 'real');
+      expect(result.Resolved).toBe(true);
+      expect(result.Instance!.DoWork()).toBe('real work');
+    });
+
+    it('the diagnostic lists the registered keys for the base class so typos are obvious', () => {
+      factory.Register(MarkedBase, MarkedSub, 'CorrectKey', 0, true);
+      const result = factory.TryCreateInstance<MarkedBase>(MarkedBase, 'CorectKey');
+      expect(result.Reason).toContain("'CorrectKey'");
+      expect(result.Reason).toContain('CorectKey');
+    });
+
+    it('the diagnostic names the anchor base class and reports the marker state', () => {
+      const result = factory.TryCreateInstance<StandaloneBase>(StandaloneBase, 'missing');
+      expect(result.Reason).toContain('StandaloneBase');
+      expect(result.Reason).toContain('RequiresSubclass=false');
+    });
+
+    it('repeated failures for the same base/key log only once (hot-path safety)', () => {
+      factory.TryCreateInstance<StandaloneBase>(StandaloneBase, 'missing');
+      factory.TryCreateInstance<StandaloneBase>(StandaloneBase, 'missing');
+      factory.TryCreateInstance<StandaloneBase>(StandaloneBase, 'missing');
+      expect(warnSpy).toHaveBeenCalledTimes(1);
+    });
+
+    it('a null base class yields Resolved: false with a null instance and never throws', () => {
+      const result = factory.TryCreateInstance<StandaloneBase>(null, 'anything');
+      expect(result.Resolved).toBe(false);
+      expect(result.Instance).toBeNull();
+      expect(factory.CreateInstance<StandaloneBase>(null, 'anything')).toBeNull();
+    });
+
+    it('constructor params still flow through both surfaces', () => {
+      factory.Register(Animal, Dog, 'pet', 0, true);
+      const viaTry = factory.TryCreateInstance<Animal>(Animal, 'pet', 'Rex', 'Lab');
+      expect((viaTry.Instance as Dog).Breed).toBe('Lab');
+      const viaCreate = factory.CreateInstance<Animal>(Animal, 'pet', 'Rex', 'Lab');
+      expect((viaCreate as Dog).Name).toBe('Rex');
+    });
+
+    it('the async surface honors the marker too', async () => {
+      await expect(factory.CreateInstanceAsync<MarkedBase>(MarkedBase, 'no-such-key')).rejects.toThrow(/MarkedBase/);
+      const result = await factory.TryCreateInstanceAsync<MarkedBase>(MarkedBase, 'no-such-key');
+      expect(result.Resolved).toBe(false);
+      expect(result.Instance).toBeNull();
     });
   });
 });


### PR DESCRIPTION
Fixes two related, confirmed defects: a systemic one in `ClassFactory` (B35) and a concrete High-severity instance of it in `PermissionEngine` (B34).

## The two mechanisms

**B35 — `ClassFactory.CreateInstance` never signals resolution failure.** For an unregistered key it does not return `null`; it falls back to `new BaseClass(...)`. Every call site written as `const x = CreateInstance(Base, key); if (x) { use } else { LogError; skip }` therefore has a **dead else-branch** and silently installs a hollow object. The failure only surfaces later, somewhere else, as `x.Method is not a function`.

**B34 — `PermissionEngine` is that pattern, and the consequence is user-facing.** `instantiateProviders()` installed a method-less `PermissionProviderBase` stub as a live provider. `GetAllUserPermissions` then does `Promise.allSettled(providers.map(p => p.GetUserResources(user)))` — `allSettled` isolates *rejections*, but the stub's method is `undefined`, so the mapper throws **synchronously inside `.map()`, before `allSettled` ever sees a promise**. One bad or tree-shaken provider class turned the Sharing Center, "shared with me", and every permission-audit view into a hard error **for all users**. Fail-loud, not fail-closed. (An *async*-throwing provider was always correctly isolated — the hole was specific to the sync path.)

## Why abstractness can't be detected at runtime — and what is used instead

TypeScript's `abstract` is **fully erased at compile time**. There is no marker property on the constructor, and plain JS will happily `new` an abstract class. Two runtime proxies do exist (an abstract method leaves no prototype entry; `inst.constructor === AnchorBase` proves fallback occurred), but both are **inference**, and a base with no abstract methods is indistinguishable from a fully-abstract one.

So this PR uses an **explicit opt-in marker** instead:

```ts
export abstract class PermissionProviderBase {
    public static readonly RequiresSubclass = true;
    ...
}
```

Explicit beats inference here: it is greppable, self-documenting, and cannot misfire on a base that legitimately stands alone.

On a fallback:
- **marker present** → `CreateInstance` **throws**; `TryCreateInstance` returns `{Resolved: false, Instance: null}`.
- **marker absent** → structured **warning**, and the base instance is returned exactly as before.

## `ClassFactory` changes

- New `TryCreateInstance<T>()` / `TryCreateInstanceAsync<T>()` returning `ClassResolutionResult<T>` = `{ Resolved, Instance, Reason? }`.
- `CreateInstance`, `CreateInstanceAsync`, and both `Try*` variants route through **one shared private `resolveAndInstantiate`** so the sync/async and throwing/non-throwing surfaces cannot drift.
- `CreateInstance`'s signature and behavior are unchanged for every existing caller (it has many), apart from now throwing for marked bases.

### Instrumentation (the highest-value part — B34's real damage was that it was invisible)

Every fallback logs: the **anchor base class name**, the **requested key**, **the list of registered keys for that base** (so a typo or a tree-shaken class is obvious at a glance), the **marker state**, and a **captured call-site stack**. Deduped per `(baseClass, key)` because resolution runs on very hot paths (once per entity-field hydration) — `console.error` when the marker is set, `console.warn` otherwise. The dedupe set is cleared on `Register()` so a later failure of the same key is still reported.

## `BaseEntity`'s fallback is preserved

`BaseEntity` does **not** carry the marker, so the base-class fallback it relies on — deliberately added recently — behaves exactly as before, now with a diagnostic warning attached. Only `PermissionProviderBase` is marked in this PR. Marking was applied conservatively: a wrong marker turns a working fallback into a thrown exception, so anything ambiguous was left alone and is reported for follow-up rather than changed.

## `PermissionEngine` changes

1. `instantiateProviders()` uses `TryCreateInstance`, so the intended "skip unresolvable domains" branch is finally reachable — no stub is installed.
2. **Independently** (defense in depth, so the fan-out is not the thing that fails if a hollow provider ever slips in again), the three fan-outs now defer each provider call into a promise body: `providers.map(p => Promise.resolve().then(() => invoke(p)))`. A synchronous throw becomes a rejection `allSettled` can contain. The three duplicated blocks (`GetAllUserPermissions`, `GetPermissionsGrantedByUser`, `GetPermissionsSharedWithUser`) were collapsed into one shared `fanOutAcrossProviders` helper so the fix cannot be applied to one and forgotten on another.

## PE13

`packages/TestingFramework/testing-integration/.../permission-engine.checks.ts` **PE13** pins B34 and is deliberately RED. Both of its stated fix conditions are met by this PR — the stub is never installed (fix 1) *and* the mapper is wrapped (fix 2) — so it flips green. **PE11** (unresolvable domain contained, nothing granted) and **PE12** (async-throwing provider isolated) also continue to hold: an unresolvable domain now yields `GetProvider(name) === undefined`, so `CheckPermission` returns the existing `Allowed: false, 'Unknown permission domain'` result.

The check itself was **not modified**.

⚠️ **Note for the reviewer:** the `permission-engine` check bundle is **not on `next`** (this PR's base) — it lives on the unmerged `an-dev-35` branch, and is therefore absent from this worktree, so PE13 could not be executed here. Its exact failure mechanism is instead pinned by four new unit tests that install a hollow, method-less provider alongside a healthy one and assert the aggregate resolves rather than rejecting. Please run `RUN_MUTATION_TESTS=1 npx tsx packages/MJServer/integration-test-scripts/permission-engine-tests.ts` once these commits and the check bundle are on the same branch.

## Tests

| Package | Before | After |
|---|---|---|
| `@memberjunction/global` | 558 passed | **570 passed** (+12) |
| `@memberjunction/core` | 1488 passed | **1488 passed** |
| `@memberjunction/core-entities` | 522 passed | **526 passed** (+4) |

All three packages build clean. New coverage:
- successful resolution unchanged; params still flow through both surfaces
- fallback **without** marker → warns, returns the base instance (the `BaseEntity` guarantee)
- fallback **with** marker → `CreateInstance` throws, `TryCreateInstance` returns `null`
- the diagnostic names the base, the key, the registered keys, and the marker state
- repeated failures log once (hot-path safety); async surface honors the marker
- a hollow provider is isolated across all three `PermissionEngine` fan-outs, and degrades to an empty aggregate when it is the *only* provider

🤖 Generated with [Claude Code](https://claude.com/claude-code)