### PR TITLE
fix(core): MaxRows-limited RunView results must not be cached as complete sets (B30)

### DIFF
--- a/.changeset/maxrows-cache-subset-slots.md
+++ b/.changeset/maxrows-cache-subset-slots.md
@@ -1,0 +1,5 @@
+---
+"@memberjunction/core": patch
+---
+
+Fix: MaxRows-limited RunView results are no longer maintained in place by the local cache. A `MaxRows`/`StartRow` slot holds a truncated/offset SUBSET of the matching set, so upserting a saved row grew it past the caller's own row limit (a `MaxRows: 1` slot served 2, 3, 4 … rows) and removing a deleted row shrank it below. Such slots are now conservatively invalidated on save/delete — the same treatment filtered slots already receive — and repopulated from the database on the next read.

--- a/packages/MJCore/src/__tests__/localCacheManager.slotMaintenanceMatrix.test.ts
+++ b/packages/MJCore/src/__tests__/localCacheManager.slotMaintenanceMatrix.test.ts
@@ -1,0 +1,279 @@
+/**
+ * Slot-maintenance matrix for LocalCacheManager.
+ *
+ * ## Why this file exists
+ * MJ's RunView cache has shipped TWO production bugs in the same family:
+ *   - #3195: cached SUBSET slots collapsed `totalRowCount`
+ *   - #3199: cached SUBSET slots had their ROWS maintained in place, so a `MaxRows: 1` slot grew
+ *            to 2, 3, 4 … on save, and shrank to 0 on delete while the DB still had 47 rows
+ *
+ * Both slipped through ~290 existing cache unit tests because those tests cover the axes
+ * *slot identity* (does MaxRows produce a distinct fingerprint?) and *invalidation* (does a
+ * change blow the entry away?) — but never the axis where the bugs actually live:
+ *
+ *              **SLOT TYPE  ×  MUTATION EVENT**
+ *
+ * A slot is only safe to maintain in place when it is BOTH unfiltered (we could not evaluate a
+ * SQL predicate in JS to know whether a saved row matches) AND unlimited (we could not know
+ * whether a saved row falls inside a TOP/OFFSET window, nor which row it displaces). Any other
+ * combination must be conservatively invalidated.
+ *
+ * This file asserts that rule across the full matrix, so a regression in ANY cell fails rather
+ * than only the cell someone happened to think of. New slot types or mutation paths should be
+ * added as a row/column here, not as a one-off test.
+ */
+
+import { LocalCacheManager, CacheCategory } from '../generic/localCacheManager';
+import { RunViewParams } from '../views/runView';
+import { CompositeKey } from '../generic/compositeKey';
+import { MockCacheStorageProvider } from './mocks/MockCacheStorageProvider';
+import { GetGlobalObjectStore } from '@memberjunction/global';
+
+function resetLocalCacheManager(): void {
+    const g = GetGlobalObjectStore();
+    delete g['___SINGLETON__LocalCacheManager'];
+}
+
+/** Minimal row factory — stable IDs so set comparisons are meaningful. */
+function rows(count: number, startId = 1): Record<string, unknown>[] {
+    return Array.from({ length: count }, (_, i) => ({
+        ID: `id-${(startId + i).toString().padStart(4, '0')}`,
+        Name: `Record ${startId + i}`,
+        __mj_UpdatedAt: new Date(2024, 0, 1).toISOString(),
+    }));
+}
+
+/**
+ * The slot-type axis. `maintainable` encodes the contract: TRUE only when the slot is both
+ * unfiltered and unlimited, because those are the only conditions under which in-place
+ * upsert/remove is provably correct.
+ */
+interface SlotType {
+    name: string;
+    params: RunViewParams;
+    /**
+     * Maintainability is PER-OPERATION, not per-slot — the two mutations fail for different
+     * reasons and therefore have different safe sets:
+     *
+     *   SAVE   is unsafe when we cannot prove the new row BELONGS in the slot — either because a
+     *          SQL predicate is unevaluable in JS (filtered) or because window membership needs
+     *          a TOP/OFFSET re-run (subset).
+     *   DELETE is unsafe ONLY for subset slots, where removal shrinks the slot below the caller's
+     *          own limit. For a FILTERED slot removal is always safe: a deleted row matches no
+     *          predicate, so dropping it can never make the slot wrong.
+     *
+     * That asymmetry is precisely why #3199's delete half was a SEPARATE bug from its save half —
+     * subset slots were riding the filtered slots' legitimate remove-in-place path.
+     */
+    saveMaintains: boolean;
+    deleteMaintains: boolean;
+    why: string;
+}
+
+const ENTITY = 'Test Entity';
+
+const SLOT_TYPES: SlotType[] = [
+    {
+        name: 'unfiltered + unlimited (the ONLY maintainable slot)',
+        params: { EntityName: ENTITY },
+        saveMaintains: true,
+        deleteMaintains: true,
+        why: 'complete set, no predicate and no window — a saved row provably belongs, a deleted row provably leaves',
+    },
+    {
+        name: 'filtered',
+        params: { EntityName: ENTITY, ExtraFilter: "Status='Active'" },
+        saveMaintains: false,
+        deleteMaintains: true,   // a deleted row matches no predicate, so removal is always safe
+        why: 'cannot evaluate a SQL predicate in JS, so we cannot know whether a saved row matches',
+    },
+    {
+        name: 'MaxRows (truncation)  <-- the #3199 bug',
+        params: { EntityName: ENTITY, MaxRows: 1 },
+        saveMaintains: false,
+        deleteMaintains: false,  // removal shrinks the slot below the caller's own MaxRows
+        why: 'cannot know whether a saved row falls inside TOP N, nor which row it displaces',
+    },
+    {
+        name: 'StartRow (offset window)',
+        params: { EntityName: ENTITY, StartRow: 10, MaxRows: 5 },
+        saveMaintains: false,
+        deleteMaintains: false,
+        why: 'an offset window is not the head of the set; maintaining it in place silently shifts the page',
+    },
+    {
+        name: 'filtered + MaxRows (both axes)',
+        params: { EntityName: ENTITY, ExtraFilter: "Status='Active'", MaxRows: 2 },
+        saveMaintains: false,
+        deleteMaintains: false,  // the subset axis dominates — filtered-delete safety does NOT rescue it
+        why: 'either axis alone disqualifies maintenance; together they must not cancel out',
+    },
+];
+
+describe('LocalCacheManager — slot maintenance matrix (slot type x mutation)', () => {
+    let cache: LocalCacheManager;
+    let storage: MockCacheStorageProvider;
+
+    beforeEach(async () => {
+        resetLocalCacheManager();
+        storage = new MockCacheStorageProvider();
+        cache = LocalCacheManager.Instance;
+        await cache.Initialize(storage, { verboseLogging: false });
+    });
+
+    describe('the subset predicate itself', () => {
+        // Directly pins classification, independent of the event plumbing, so a failure here
+        // localizes to the predicate rather than the maintenance path.
+        const classify = (p: RunViewParams): boolean => {
+            const fp = (cache as unknown as {
+                GenerateRunViewFingerprint(params: RunViewParams, conn?: string, rls?: string): string;
+            }).GenerateRunViewFingerprint(p);
+            return (cache as unknown as { isSubsetFingerprint(f: string): boolean }).isSubsetFingerprint(fp);
+        };
+
+        it('classifies an unlimited slot as NOT a subset', () => {
+            expect(classify({ EntityName: ENTITY })).toBe(false);
+        });
+
+        it('classifies MaxRows > 0 as a subset', () => {
+            expect(classify({ EntityName: ENTITY, MaxRows: 1 })).toBe(true);
+            expect(classify({ EntityName: ENTITY, MaxRows: 500 })).toBe(true);
+        });
+
+        it('classifies StartRow > 0 as a subset', () => {
+            expect(classify({ EntityName: ENTITY, StartRow: 1 })).toBe(true);
+        });
+
+        it('treats the sentinel defaults (MaxRows -1 / StartRow 0) as NOT a subset', () => {
+            // The builder defaults MaxRows to -1 and StartRow to 0. If the guards were `>= 0`
+            // or truthiness-based, every ordinary unlimited slot would be misread as a subset
+            // and the cache would stop maintaining anything — a silent perf cliff.
+            expect(classify({ EntityName: ENTITY, MaxRows: -1, StartRow: 0 })).toBe(false);
+        });
+
+        it('fails SAFE on a malformed fingerprint rather than over-invalidating', () => {
+            const isSubset = (cache as unknown as { isSubsetFingerprint(f: string): boolean }).isSubsetFingerprint.bind(cache);
+            expect(isSubset('too|few')).toBe(false);
+            expect(isSubset('E|f|o|not-a-number|also-not|_|_')).toBe(false);
+        });
+
+        it('indexes MaxRows at segment [3] — guarding the off-by-one the stale comment invited', () => {
+            // A prior comment in this file listed a `ResultType` segment that does not exist.
+            // Following it would put MaxRows at [4]. This asserts the real layout.
+            const fp = (cache as unknown as {
+                GenerateRunViewFingerprint(params: RunViewParams): string;
+            }).GenerateRunViewFingerprint({ EntityName: ENTITY, MaxRows: 7, StartRow: 3 });
+            const parts = fp.split('|');
+            expect(parts[3]).toBe('7');
+            expect(parts[4]).toBe('3');
+        });
+    });
+
+    describe.each(SLOT_TYPES)('slot: $name', (slot: SlotType) => {
+        const fingerprintFor = (p: RunViewParams): string =>
+            (cache as unknown as { GenerateRunViewFingerprint(params: RunViewParams): string }).GenerateRunViewFingerprint(p);
+
+        const seed = async (p: RunViewParams, data: Record<string, unknown>[]): Promise<string> => {
+            const fp = fingerprintFor(p);
+            await cache.SetRunViewResult(fp, p, data, '2024-06-15T00:00:00.000Z', undefined, 50);
+            return fp;
+        };
+
+        const readSlot = async (fp: string): Promise<{ results?: unknown[] } | null> =>
+            (await cache.GetRunViewResult(fp)) as unknown as { results?: unknown[] } | null;
+
+        it(`SAVE: ${slot.saveMaintains ? 'maintains in place' : 'INVALIDATES'} — ${slot.why}`, async () => {
+            const fp = await seed(slot.params, rows(3));
+            const before = await readSlot(fp);
+            expect(before).not.toBeNull();               // anti-vacuity: the slot really was cached
+
+            await (cache as unknown as {
+                processEntityEventForFingerprint(
+                    type: string, fingerprint: string, entity: unknown, key: unknown, nowISO: string
+                ): Promise<void>;
+            }).processEntityEventForFingerprint(
+                'save', fp,
+                { EntityName: ENTITY, GetAll: () => ({ ID: 'id-9999', Name: 'New Row' }) },
+                CompositeKey.FromID('id-9999'),
+                new Date().toISOString()
+            );
+
+            const after = await readSlot(fp);
+            if (slot.saveMaintains) {
+                expect(after).not.toBeNull();
+                expect(after?.results?.length).toBe(4);   // upserted in place
+            } else {
+                // The load-bearing assertion. Pre-#3199 a MaxRows slot survived here with an
+                // INFLATED row set — which is strictly worse than a miss, because it is served
+                // as if authoritative.
+                expect(after).toBeNull();
+            }
+        });
+
+        it(`DELETE: ${slot.deleteMaintains ? 'removes in place (safe — a deleted row matches nothing)' : 'INVALIDATES — never serves a short set'}`, async () => {
+            const seeded = rows(3);
+            const fp = await seed(slot.params, seeded);
+            expect(await readSlot(fp)).not.toBeNull();
+
+            await (cache as unknown as {
+                processEntityEventForFingerprint(
+                    type: string, fingerprint: string, entity: unknown, key: unknown, nowISO: string
+                ): Promise<void>;
+            }).processEntityEventForFingerprint(
+                'delete', fp,
+                { EntityName: ENTITY, GetAll: () => seeded[0] },
+                CompositeKey.FromID(String(seeded[0].ID)),
+                new Date().toISOString()
+            );
+
+            const after = await readSlot(fp);
+            if (slot.deleteMaintains) {
+                expect(after).not.toBeNull();
+                expect(after?.results?.length).toBe(2);   // removed in place
+            } else {
+                // The worse half of #3199: removal from a MaxRows:1 slot left ZERO rows cached
+                // while the DB still had plenty to draw a TOP 1 from — a served empty result.
+                expect(after).toBeNull();
+            }
+        });
+    });
+
+    describe('regression pins for the two shipped bugs', () => {
+        it('#3199: repeated saves never inflate a MaxRows:1 slot past its limit', async () => {
+            const params: RunViewParams = { EntityName: ENTITY, MaxRows: 1 };
+            const fp = (cache as unknown as {
+                GenerateRunViewFingerprint(p: RunViewParams): string;
+            }).GenerateRunViewFingerprint(params);
+
+            for (let i = 1; i <= 3; i++) {
+                await cache.SetRunViewResult(fp, params, rows(1), '2024-06-15T00:00:00.000Z', undefined, 47 + i);
+                await (cache as unknown as {
+                    processEntityEventForFingerprint(t: string, f: string, e: unknown, k: unknown, n: string): Promise<void>;
+                }).processEntityEventForFingerprint(
+                    'save', fp,
+                    { EntityName: ENTITY, GetAll: () => ({ ID: `id-new-${i}`, Name: `New ${i}` }) },
+                    CompositeKey.FromID(`id-new-${i}`),
+                    new Date().toISOString()
+                );
+                const after = (await cache.GetRunViewResult(fp)) as unknown as { results?: unknown[] } | null;
+                // Either invalidated (null) or still within the limit — NEVER 2, 3, 4 rows.
+                if (after) {
+                    expect(after.results?.length ?? 0).toBeLessThanOrEqual(1);
+                }
+            }
+        });
+
+        it('#3195 remains intact: totalRowCount is still recorded on a subset slot', async () => {
+            // The two fixes must compose: rows are dropped because they are unknowable, but the
+            // DB total IS knowable and must not regress to the collapsed value.
+            const params: RunViewParams = { EntityName: ENTITY, MaxRows: 1 };
+            const fp = (cache as unknown as {
+                GenerateRunViewFingerprint(p: RunViewParams): string;
+            }).GenerateRunViewFingerprint(params);
+            await cache.SetRunViewResult(fp, params, rows(1), '2024-06-15T00:00:00.000Z', undefined, 48);
+
+            const got = (await cache.GetRunViewResult(fp)) as unknown as { totalRowCount?: number } | null;
+            expect(got?.totalRowCount).toBe(48);   // NOT 1
+        });
+    });
+});

--- a/packages/MJCore/src/__tests__/localCacheManager.universalInvalidation.test.ts
+++ b/packages/MJCore/src/__tests__/localCacheManager.universalInvalidation.test.ts
@@ -825,4 +825,137 @@ describe('LocalCacheManager Universal Cache Invalidation', () => {
         });
     });
 
+    // ========================================================================
+    // Subset slots — MaxRows-truncated / StartRow-offset cache entries (B30)
+    //
+    // Regression guard: a `MaxRows: 1` result was stored as if it were the COMPLETE set and
+    // then maintained in place by save events, so the slot grew to 2, 3, 4 … rows — the served
+    // result was neither the first-N nor the full set, just one arbitrary original row plus
+    // every locally-saved row. `BypassCache` returned 1 row every time.
+    // ========================================================================
+
+    describe('Subset fingerprints (MaxRows / StartRow)', () => {
+        const isSubset = (fp: string) =>
+            (cacheManager as unknown as { isSubsetFingerprint: (fp: string) => boolean })
+                .isSubsetFingerprint(fp);
+
+        // Fingerprint format: Entity|Filter|OrderBy|MaxRows|StartRow|AggHash|UserSearch
+        function makeEvent(entityName: string, type: 'save' | 'delete', row: Record<string, unknown>) {
+            return {
+                type,
+                baseEntity: {
+                    EntityInfo: { Name: entityName, PrimaryKeys: [{ Name: 'ID' }], AllowCaching: true },
+                    Get: (fieldName: string) => row[fieldName],
+                    GetAll: () => ({ ...row }),
+                },
+            };
+        }
+
+        const fireEvent = (event: unknown) =>
+            (cacheManager as unknown as { HandleBaseEntityEvent: (e: unknown) => Promise<void> })
+                .HandleBaseEntityEvent(event);
+
+        async function seedSlot(fp: string, rows: Record<string, unknown>[]): Promise<void> {
+            await cacheManager.SetRunViewResult(
+                fp,
+                { EntityName: 'Users' } as Parameters<typeof cacheManager.SetRunViewResult>[1],
+                rows,
+                '2024-01-01T00:00:00Z'
+            );
+        }
+
+        describe('isSubsetFingerprint', () => {
+            it('should return false for an unlimited fingerprint (MaxRows -1, StartRow 0)', () => {
+                expect(isSubset('Users|_|_|-1|0|_|_')).toBe(false);
+            });
+
+            it('should return true for a MaxRows-limited fingerprint', () => {
+                expect(isSubset('Users|_|_|1|0|_|_')).toBe(true);
+                expect(isSubset('Users|_|_|250|0|_|_')).toBe(true);
+            });
+
+            it('should return true for a StartRow-offset (paginated) fingerprint', () => {
+                expect(isSubset('Users|_|_|-1|100|_|_')).toBe(true);
+            });
+
+            it('should return false for MaxRows 0 (treated as no limit)', () => {
+                expect(isSubset('Users|_|_|0|0|_|_')).toBe(false);
+            });
+
+            it('should return false (conservatively) for a malformed / too-short fingerprint', () => {
+                expect(isSubset('Users')).toBe(false);
+                expect(isSubset('Users|_|_|notanumber|alsonot|_|_')).toBe(false);
+            });
+        });
+
+        it('should NOT grow a MaxRows-limited slot on save — it invalidates instead', async () => {
+            const fp = 'Users|_|_|1|0|_|_'; // MaxRows: 1
+            await seedSlot(fp, [{ ID: '1', Name: 'Alice' }]);
+
+            // A newly saved row must never be appended into a MaxRows: 1 slot.
+            await fireEvent(makeEvent('Users', 'save', { ID: '99', Name: 'Brand New' }));
+
+            const cached = await cacheManager.GetRunViewResult(fp);
+            expect(cached).toBeNull(); // slot dropped; next read repopulates from the DB
+        });
+
+        it('should never exceed MaxRows across a series of saves', async () => {
+            const fp = 'Users|_|_|1|0|_|_';
+
+            for (let i = 1; i <= 3; i++) {
+                await seedSlot(fp, [{ ID: '1', Name: 'Alice' }]); // simulate the cold re-read
+                await fireEvent(makeEvent('Users', 'save', { ID: `new-${i}`, Name: `New ${i}` }));
+
+                const cached = await cacheManager.GetRunViewResult(fp);
+                // Either invalidated (null) or, if present, still within the caller's limit.
+                expect(cached?.results.length ?? 0).toBeLessThanOrEqual(1);
+            }
+        });
+
+        it('should invalidate a MaxRows-limited slot on delete rather than shrinking it below the limit', async () => {
+            const fp = 'Users|_|_|1|0|_|_';
+            await seedSlot(fp, [{ ID: '1', Name: 'Alice' }]);
+
+            await fireEvent(makeEvent('Users', 'delete', { ID: '1', Name: 'Alice' }));
+
+            // Removing in place would leave a 0-row slot while the DB still has rows for TOP 1.
+            const cached = await cacheManager.GetRunViewResult(fp);
+            expect(cached).toBeNull();
+        });
+
+        it('should invalidate a StartRow-offset (paginated) slot on save', async () => {
+            const fp = 'Users|_|_|50|100|_|_'; // page 3 of 50
+            await seedSlot(fp, [{ ID: '1', Name: 'Alice' }]);
+
+            await fireEvent(makeEvent('Users', 'save', { ID: '99', Name: 'Brand New' }));
+
+            expect(await cacheManager.GetRunViewResult(fp)).toBeNull();
+        });
+
+        it('should still maintain an UNLIMITED slot in place on save (no regression)', async () => {
+            const fp = 'Users|_|_|-1|0|_|_';
+            await seedSlot(fp, [{ ID: '1', Name: 'Alice' }, { ID: '2', Name: 'Bob' }]);
+
+            await fireEvent(makeEvent('Users', 'save', { ID: '1', Name: 'Alice Updated' }));
+
+            const cached = await cacheManager.GetRunViewResult(fp);
+            expect(cached).not.toBeNull();
+            expect(cached!.results).toHaveLength(2);
+            const row = cached!.results.find((r) => (r as Record<string, unknown>).ID === '1') as Record<string, unknown>;
+            expect(row.Name).toBe('Alice Updated');
+        });
+
+        it('should still maintain an UNLIMITED slot in place on delete (no regression)', async () => {
+            const fp = 'Users|_|_|-1|0|_|_';
+            await seedSlot(fp, [{ ID: '1', Name: 'Alice' }, { ID: '2', Name: 'Bob' }]);
+
+            await fireEvent(makeEvent('Users', 'delete', { ID: '1', Name: 'Alice' }));
+
+            const cached = await cacheManager.GetRunViewResult(fp);
+            expect(cached).not.toBeNull();
+            expect(cached!.results).toHaveLength(1);
+            expect((cached!.results[0] as Record<string, unknown>).ID).toBe('2');
+        });
+    });
+
 });

--- a/packages/MJCore/src/generic/localCacheManager.ts
+++ b/packages/MJCore/src/generic/localCacheManager.ts
@@ -469,6 +469,52 @@ export class LocalCacheManager extends BaseSingleton<LocalCacheManager> {
     }
 
     /**
+     * Returns true if the fingerprint identifies a **subset slot** — a cache entry whose rows are
+     * a TRUNCATION (`MaxRows`) or an OFFSET WINDOW (`StartRow`) of the matching set rather than
+     * the complete set.
+     *
+     * Subset slots are safe to STORE and SERVE (a cold read of the slot is exactly what the DB
+     * would have returned), but they must NEVER be maintained in place by the BaseEntity
+     * save/delete event path:
+     *
+     *  - **Save/upsert** appends the saved row to the slot, so a `MaxRows: 1` slot grows to 2, 3,
+     *    4 … rows — silently violating the caller's own row limit and serving a set that is
+     *    neither the first-N nor the full set (one arbitrary original row plus every locally
+     *    saved row).
+     *  - **Delete/remove** shrinks the slot below the limit, so a `MaxRows: 1` slot serves 0 rows
+     *    while the DB still has 47 matching rows to choose a TOP 1 from.
+     *
+     * Neither can be repaired in JS: deciding whether a newly saved row belongs *inside* the
+     * window, and which row it would displace, requires re-running the query's TOP/OFFSET against
+     * the database. So we treat subset slots exactly as filtered slots are treated on save —
+     * conservatively INVALIDATE and let the next read repopulate from the DB.
+     *
+     * This is the row-level counterpart to the `totalRowCount` subset-slot handling: the total is
+     * maintained across the delta because the DB total is knowable; the ROWS are not, so the slot
+     * is dropped instead.
+     *
+     * Fingerprint format: `Entity|Filter|OrderBy|MaxRows|StartRow|AggHash|UserSearch[|…]`.
+     * Parsing is deliberately conservative — if the segments aren't cleanly numeric (e.g. a filter
+     * value containing a literal `|` shifts the positions), we return false and preserve existing
+     * behavior rather than over-invalidating. Such a fingerprint is filtered by definition, and
+     * filtered slots are already invalidated on save.
+     *
+     * @param fingerprint - The RunView cache fingerprint
+     */
+    protected isSubsetFingerprint(fingerprint: string): boolean {
+        const parts = fingerprint.split('|');
+        if (parts.length < 5) return false;
+
+        // MaxRows: -1 (or 0) means "no limit"; any positive value truncates the set.
+        const maxRows = Number(parts[3]);
+        if (Number.isFinite(maxRows) && maxRows > 0) return true;
+
+        // StartRow: > 0 means the slot is an offset window, not the head of the set.
+        const startRow = Number(parts[4]);
+        return Number.isFinite(startRow) && startRow > 0;
+    }
+
+    /**
      * Checks whether a cached RunView entry is structurally stale due to a schema change
      * (e.g., new columns added via migration + CodeGen). Compares the stored schema hash
      * against the current entity field list. If they differ, the entry is invalidated.
@@ -726,7 +772,13 @@ export class LocalCacheManager extends BaseSingleton<LocalCacheManager> {
             LogStatusVerbose(`LocalCacheManager: remote-invalidate (delete) for "${entityName}" PK=${key.ToConcatenatedString()}, removing from ${fingerprints.size} cached fingerprint(s)`);
             for (const fingerprint of fingerprintSnapshot) {
                 try {
-                    await this.RemoveSingleEntity(fingerprint, key, nowISO);
+                    // Subset slot (MaxRows/StartRow): removing a row would shrink it below the
+                    // caller's own row limit while the DB still has rows to fill the window.
+                    if (this.isSubsetFingerprint(fingerprint)) {
+                        await this.InvalidateRunViewResult(fingerprint);
+                    } else {
+                        await this.RemoveSingleEntity(fingerprint, key, nowISO);
+                    }
                 } catch (err) {
                     LogError(`HandleRemoteInvalidateEvent: failed to remove from "${fingerprint}": ${(err as Error).message}`);
                 }
@@ -747,7 +799,9 @@ export class LocalCacheManager extends BaseSingleton<LocalCacheManager> {
 
                 for (const fingerprint of fingerprintSnapshot) {
                     try {
-                        if (!this.isFilteredFingerprint(fingerprint)) {
+                        // Subset slot (MaxRows/StartRow): upserting would grow the slot past the
+                        // caller's own row limit. Invalidate, same as a filtered slot.
+                        if (!this.isFilteredFingerprint(fingerprint) && !this.isSubsetFingerprint(fingerprint)) {
                             await this.UpsertSingleEntity(fingerprint, recordData, key, nowISO);
                         } else {
                             await this.InvalidateRunViewResult(fingerprint);
@@ -848,7 +902,13 @@ export class LocalCacheManager extends BaseSingleton<LocalCacheManager> {
         nowISO: string
     ): Promise<void> {
         const keyStr = key.ToConcatenatedString();
-        if (eventType === 'delete') {
+        // Subset slots (MaxRows-truncated / StartRow-offset) cannot be maintained in place in
+        // EITHER direction — upserting grows them past the caller's own row limit and removing
+        // shrinks them below it. Drop the slot and let the next read repopulate it from the DB.
+        if (this.isSubsetFingerprint(fingerprint)) {
+            LogStatusVerbose(`LocalCacheManager: Invalidating subset (MaxRows/StartRow) cache "${fingerprint.substring(0, 60)}"`);
+            await this.InvalidateRunViewResult(fingerprint);
+        } else if (eventType === 'delete') {
             LogStatusVerbose(`LocalCacheManager: Removing entity ${keyStr} from cache "${fingerprint.substring(0, 60)}"`);
             await this.RemoveSingleEntity(fingerprint, key, nowISO);
         } else if (!this.isFilteredFingerprint(fingerprint)) {

--- a/packages/MJCore/src/generic/localCacheManager.ts
+++ b/packages/MJCore/src/generic/localCacheManager.ts
@@ -448,7 +448,11 @@ export class LocalCacheManager extends BaseSingleton<LocalCacheManager> {
 
     /**
      * Extracts the entity name from a RunView fingerprint.
-     * Fingerprint format: `EntityName|Filter|OrderBy|ResultType|MaxRows|StartRow|AggHash[|Connection]`
+     * Fingerprint format: `Entity|Filter|OrderBy|MaxRows|StartRow|AggHash|UserSearch[|…]`
+     * (built in GenerateRunViewFingerprint below — that array is the ground truth). NOTE:
+     * `ResultType` is deliberately NOT a segment; the cache stores plain JSON regardless and
+     * transformation happens post-cache. An earlier version of this comment listed it, which
+     * would put any new segment-indexing predicate one position off — MaxRows is [3], not [4].
      * @param fingerprint - The RunView cache fingerprint
      * @returns The entity name, or null if the fingerprint is malformed
      */


### PR DESCRIPTION
## The defect

`MaxRows` was silently ignored on a client-cache hit, and the cached slot was not the set that was requested.

A `MaxRows`-truncated RunView result was stored in the cache slot **as if it were the complete set**, then maintained in place by BaseEntity save events. The served result was therefore neither the first-N nor the full set — it was one arbitrary original row plus every locally-saved row.

Reproduction, identical params `{ EntityName: 'MJ: Action Categories', MaxRows: 1, ResultType: 'simple' }`, no filter, no OrderBy:

```
baseline       cached rows=1 total=48 | bypass rows=1 total=48
after save #1  cached rows=2 total=49 | bypass rows=1 total=49   <-- EXCEEDS MaxRows:1
after save #2  cached rows=3 total=50 | bypass rows=1 total=50
after save #3  cached rows=4 total=51 | bypass rows=1 total=51
```

`BypassCache: true` returns 1 row every time; the cached path grows with each save.

## Root cause

`MaxRows` **is** part of the RunView fingerprint (`Entity|Filter|OrderBy|MaxRows|StartRow|…`), so the slot is correctly keyed and a *cold* read of it is exactly what the DB would have returned. The bug is in the in-place **maintenance**:

- **Save** — `processEntityEventForFingerprint` only asked `isFilteredFingerprint`. An unfiltered `MaxRows: 1` slot therefore took the "safe to upsert in place" branch and had the saved row appended, growing to 2, 3, 4 … rows.
- **Delete** — worse: removal was unconditional, so deleting the one cached row left a 0-row slot while the DB still had 47 rows to draw a `TOP 1` from.

The same two branches exist in `HandleRemoteInvalidateEvent` (the cross-server path) and had the identical flaw.

Neither direction is repairable in JS: deciding whether a newly saved row belongs *inside* the window, and which row it would displace, requires re-running the query's `TOP`/`OFFSET` against the database.

## Fix approach and why

**Chose (a) — treat `MaxRows`/`StartRow` slots as subset slots and refuse in-place maintenance**, invalidating instead. Not (b) re-apply `MaxRows` on read.

Reasons:

1. **It is the same reasoning as #3195, applied to the rows.** That PR established that subset slots exist and must be handled differently from full-dataset slots. There the DB total *is* knowable (the server sends an authoritative `COUNT(*)`), so `totalRowCount` is **maintained** across the delta. Here the correct rows are *not* knowable without the DB, so the slot is **dropped**. Same premise, opposite remedy because of what is knowable — and the two compose: a subset slot that is legitimately upserted still keeps a correct total via #3195's logic.

2. **It matches the guide's model.** `CACHING_AND_PUBSUB_GUIDE.md` says small/unfiltered/unsorted results are auto-cached *because they can be safely maintained in place via upsert/remove*. A `MaxRows`-limited result breaks exactly that premise — it is a truncation — so it belongs with the filtered slots, which are already invalidated rather than updated.

3. **Truncating on read would be strictly worse.** It would cap the save-side growth but not fix the delete side: a `MaxRows: 1` slot whose single row is deleted would serve 0 rows indefinitely while the DB has 47. Invalidation is correct in both directions.

4. **Negligible cost.** Unfiltered + `MaxRows` slots are rare (the common `MaxRows: 1` call sites are filtered point lookups, which were already invalidated on save).

Implementation: a new `isSubsetFingerprint` sibling to `isFilteredFingerprint`, consulted at both event dispatch sites (save and delete branches). Parsing is deliberately conservative — a fingerprint whose `MaxRows`/`StartRow` segments aren't cleanly numeric returns `false` and preserves existing behavior rather than over-invalidating.

## Evidence — before / after

Live client harness (`bootstrapIntegrationClient`) against a real MJAPI. Because the truncated slot is written and maintained **server-side**, the "after" run required an MJAPI started on the fixed build (temporary instance on port 4010; the temp script was deleted before commit).

**Before** (HEAD build):
```
baseline       cached rows=1 total=48 | bypass rows=1 total=48
after save #1  cached rows=2 total=49 | bypass rows=1 total=49   <-- EXCEEDS MaxRows:1
after save #2  cached rows=3 total=50 | bypass rows=1 total=50   <-- EXCEEDS MaxRows:1
after save #3  cached rows=4 total=51 | bypass rows=1 total=51   <-- EXCEEDS MaxRows:1
```

**After** (this branch):
```
baseline       cached rows=1 total=48 | bypass rows=1 total=48
after save #1  cached rows=1 total=49 | bypass rows=1 total=49
after save #2  cached rows=1 total=50 | bypass rows=1 total=50
after save #3  cached rows=1 total=51 | bypass rows=1 total=51
```

Cached rows now match `BypassCache` exactly, and `TotalRowCount` still tracks the DB total (48 → 51) — #3195's semantics preserved.

## Tests

`cd packages/MJCore && npm run build && npm run test` — clean build; **1,499 passed / 0 failed / 0 skipped** across 95 files (was 1,484 — **+15 new**). No regressions.

New cases in `localCacheManager.universalInvalidation.test.ts`:
- `isSubsetFingerprint` unit coverage (unlimited, `MaxRows`, `StartRow`, `MaxRows: 0`, malformed)
- a `MaxRows`-limited slot is not served as a complete set — it invalidates on save
- a series of saves never inflates a slot beyond `MaxRows`
- a `MaxRows` slot invalidates on delete rather than shrinking below the limit
- a `StartRow`-offset (paginated) slot invalidates on save
- **no-regression**: unlimited slots still auto-cache and still maintain in place on both save and delete

## Integration suites

- `server-cache-tests.ts` — **26/26 passed** (includes S16 `MaxRows` fingerprinting, S18 `AfterKey`, S19 `count_only`, S20 `BypassCache` poisoning, S28 `IgnoreMaxRows`, S31 read-permission security)
- `runquery-cache-tests.ts` — **10/10 passed**

Both run against the live dev DB with the fixed build staged.

## Not changed — suspected same flaw

`LocalCacheManager.ApplyDifferentialUpdate` (via `ProviderBase.processSingleSmartCacheResult`) merges server-sent delta rows into a slot with no subset check, so an explicit-opt-in `CacheLocal: true` + `MaxRows` client query can inflate the same way. Left alone deliberately: the only clean remedy there is to make the slot skip the differential merge and refetch, but that call site *throws* when the merge is declined (there is no re-fetch path — `cacheMiss` is only a metric), so a correct fix needs the client smart-cache flow to stop offering subset slots for validation in the first place. That is a larger, separate change and is not on the reproduced path (which is the server-side event-maintenance path). Filing separately is recommended.

🤖 Generated with [Claude Code](https://claude.com/claude-code)