### PR TITLE
feat(global): @RequiresSubclass() decorator + own-property semantics (follow-up to #3197)

### DIFF
--- a/.changeset/requires-subclass-decorator.md
+++ b/.changeset/requires-subclass-decorator.md
@@ -1,0 +1,14 @@
+---
+"@memberjunction/global": patch
+"@memberjunction/core": patch
+---
+
+Convert the `RequiresSubclass` marker from a static class property to a `@RequiresSubclass()` decorator, and fix an inheritance bug in how it was read.
+
+`@RequiresSubclass()` applies an own, non-enumerable marker (`__mj_RequiresSubclass`) to the class prototype, and `ClassRequiresSubclass(classOrInstance)` reads it via an **own-property** check.
+
+That own-property semantics is the substantive change. The previous `(baseClass as X).RequiresSubclass === true` read walked the constructor prototype chain, so **every subclass of a marked base also reported `true`** — meaning a ClassFactory resolution against a concrete, perfectly instantiable subclass would have wrongly thrown. The marker now applies to exactly the class that declared it.
+
+The decorator also matches the existing `@RegisterClass` idiom, keeps the marker key defined in one place rather than retyped as a literal per base, and centralizes the own-property check so call sites can't get it wrong.
+
+Backward compatible: the legacy `static RequiresSubclass = true` form is still honored (with the same own-property semantics).

--- a/packages/MJCore/src/generic/permissionInterfaces.ts
+++ b/packages/MJCore/src/generic/permissionInterfaces.ts
@@ -1,3 +1,4 @@
+import { RequiresSubclass } from '@memberjunction/global';
 import { UserInfo } from './securityInfo';
 import { LogError } from './logging';
 import { RunView } from '../views/runView';
@@ -175,6 +176,7 @@ export interface IPermissionProvider {
  * }
  * ```
  */
+@RequiresSubclass()
 export abstract class PermissionProviderBase implements IPermissionProvider {
     /**
      * Opt-in marker read by `ClassFactory` (see `ClassResolutionResult`): this class CANNOT
@@ -187,8 +189,6 @@ export abstract class PermissionProviderBase implements IPermissionProvider {
      * `{Resolved: false, Instance: null}` — both of which `PermissionEngine` handles by skipping
      * the domain.
      */
-    public static readonly RequiresSubclass = true;
-
     abstract readonly DomainName: string;
     abstract readonly Description: string;
     abstract readonly SupportedGranteeTypes: GranteeType[];

--- a/packages/MJGlobal/src/ClassFactory.ts
+++ b/packages/MJGlobal/src/ClassFactory.ts
@@ -7,6 +7,7 @@
  ******************************************************************************************************/
 
 import { GetRootClass, IsRootClass } from './ClassUtils';
+import { ClassRequiresSubclass } from './RequiresSubclass';
 
 /**
  * Type for constructor functions that have a name property
@@ -61,7 +62,7 @@ export type ClassResolutionResult<T> = {
      * The instance to use, or `null`.
      *
      * - `Resolved: true` → the registered subclass instance.
-     * - `Resolved: false` and the anchor base declares `static RequiresSubclass = true` → `null`
+     * - `Resolved: false` and the anchor base is marked `@RequiresSubclass()` → `null`
      *   (the base cannot function standalone, so no fallback is produced).
      * - `Resolved: false` and no marker → the base-class fallback instance. This is a legitimate,
      *   long-standing pattern (e.g. `BaseEntity`, which is fully functional standalone).
@@ -78,7 +79,10 @@ export type ClassResolutionResult<T> = {
  * JS will happily `new` an abstract class — so abstractness cannot be introspected. Bases that
  * genuinely cannot function without a subclass therefore declare this static marker explicitly.
  */
-type SubclassRequiringClass = { RequiresSubclass?: boolean };
+// NOTE: resolved via ClassRequiresSubclass(), which performs an OWN-property check. A plain
+// `cls.RequiresSubclass` read walks the constructor prototype chain, so every SUBCLASS of a
+// marked base would also report true — and resolving against a concrete subclass would then
+// wrongly throw. See RequiresSubclass.ts.
 
 /**
  * ClassFactory is used to register and create instances of classes. It is a singleton class that can be used to register a sub-class for a given base class and key. Do NOT directly attempt to instantiate this class,
@@ -169,7 +173,7 @@ export class ClassFactory {
      *
      * Falls back to instantiating the base class directly if no registration is found even
      * after lazy loading (same behavior as the sync CreateInstance) — including throwing when the
-     * anchor base declares `static RequiresSubclass = true`.
+     * anchor base is marked `@RequiresSubclass()`.
      */
     public async CreateInstanceAsync<T>(baseClass: unknown, key: string | null = null, ...params: unknown[]): Promise<T | null> {
         if (!baseClass) {
@@ -278,7 +282,7 @@ export class ClassFactory {
      * whether the key actually resolved.
      *
      * @throws when the key does not resolve AND the anchor base class declares
-     *         `static RequiresSubclass = true` (i.e. it cannot function standalone). Bases without
+     *         `@RequiresSubclass()` (i.e. it cannot function standalone). Bases without
      *         that marker keep the historical fallback behavior and only emit a structured warning.
      */
     public CreateInstance<T>(baseClass: unknown, key: string | null = null, ...params: unknown[]): T | null {
@@ -328,7 +332,7 @@ export class ClassFactory {
         }
 
         // ── Fallback path: the requested key did not resolve to any registered subclass. ──
-        const requiresSubclass = (baseClass as SubclassRequiringClass).RequiresSubclass === true;
+        const requiresSubclass = ClassRequiresSubclass(baseClass);
         const reason = this.describeResolutionFailure(baseClass, key, requiresSubclass);
         this.reportResolutionFailure(baseClass, key, requiresSubclass, reason);
 
@@ -360,11 +364,11 @@ export class ClassFactory {
             `Registered keys for '${baseClassName}': ${knownText}. ` +
             `RequiresSubclass=${requiresSubclass}. ` +
             (requiresSubclass
-                ? `'${baseClassName}' declares 'static RequiresSubclass = true', so it CANNOT be used as a fallback — ` +
+                ? `'${baseClassName}' is marked '@RequiresSubclass()', so it CANNOT be used as a fallback — ` +
                   `no instance was created. Likely causes: a typo in the key, a class that was never imported ` +
                   `(tree-shaken out — check the class-registration manifest), or a missing @RegisterClass decorator.`
                 : `Falling back to an instance of '${baseClassName}' itself. If that base cannot function standalone, ` +
-                  `declare 'static readonly RequiresSubclass = true' on it so this becomes a hard error.`)
+                  `apply the '@RequiresSubclass()' decorator to it so this becomes a hard error.`)
         );
     }
 

--- a/packages/MJGlobal/src/RequiresSubclass.ts
+++ b/packages/MJGlobal/src/RequiresSubclass.ts
@@ -1,0 +1,89 @@
+/**
+ * RequiresSubclass.ts — marks a base class that CANNOT function standalone.
+ *
+ * ## Why this exists
+ * MJ's ClassFactory resolves the highest-priority registered class for a (base, key) pair.
+ * When no registration matches, it FALLS BACK to instantiating the anchor base itself. For
+ * many bases that is correct and useful — `BaseEntity` does real work, so a browser without a
+ * given `*EntityServer` subclass still gets a functional object.
+ *
+ * For other bases it is not. An anchor whose methods are all abstract produces a hollow object
+ * whose members are `undefined`, and the failure surfaces later as a `TypeError` far from the
+ * cause. TypeScript's `abstract` cannot help here: it is erased at compile time, leaving no
+ * runtime marker, and `new AbstractBase()` succeeds in plain JS.
+ *
+ * `@RequiresSubclass()` is the explicit, runtime-visible declaration of that intent.
+ *
+ * ## Usage
+ * ```ts
+ * @RequiresSubclass()
+ * export abstract class PermissionProviderBase { ... }
+ *
+ * // elsewhere — the factory consults it automatically:
+ * ClassFactory.CreateInstance(PermissionProviderBase, 'NoSuchKey');  // throws, with context
+ * ClassFactory.TryCreateInstance(PermissionProviderBase, 'NoSuchKey'); // { Resolved: false }
+ * ```
+ *
+ * ## Why a decorator rather than `static RequiresSubclass = true`
+ * 1. It matches the existing `@RegisterClass` idiom, so the two read as siblings.
+ * 2. The marker key is defined once here instead of being retyped as a literal in every base.
+ * 3. Most importantly, it lets the OWN-PROPERTY check live in one helper. A plain
+ *    `cls.RequiresSubclass` read walks the constructor prototype chain, so every SUBCLASS of a
+ *    marked base reports `true` as well — resolving against a concrete subclass would then
+ *    wrongly throw. `ClassRequiresSubclass` checks for an OWN property, so the marker applies
+ *    to exactly the class that declared it.
+ */
+
+/**
+ * The marker key. Deliberately `__mj_`-prefixed and non-enumerable so it cannot collide with
+ * application fields, appear in object spreads, or show up in serialized instances.
+ */
+export const REQUIRES_SUBCLASS_KEY = '__mj_RequiresSubclass';
+
+/**
+ * Class decorator declaring that this class must never be used as a ClassFactory fallback.
+ *
+ * Applies an own, non-enumerable marker to the class prototype. Subclasses do NOT inherit the
+ * marker for the purposes of `ClassRequiresSubclass` (see the own-property note above), which
+ * is the point: a concrete subclass of a marked base is perfectly instantiable.
+ */
+export function RequiresSubclass(): (constructor: Function) => void {
+    return function (constructor: Function): void {
+        Object.defineProperty(constructor.prototype, REQUIRES_SUBCLASS_KEY, {
+            value: true,
+            enumerable: false,   // never appear in spreads / JSON / for-in
+            writable: false,
+            configurable: true,  // configurable so tests and hot-reload can redefine
+        });
+    };
+}
+
+/**
+ * True iff `target` itself is marked `@RequiresSubclass()`.
+ *
+ * Accepts either a class (constructor) or an instance, so callers don't have to normalize.
+ * Uses an OWN-property check, so a subclass of a marked base returns `false` — only the class
+ * that actually declared the marker is treated as non-instantiable.
+ *
+ * Also honors the legacy `static RequiresSubclass = true` form (same own-property semantics)
+ * so bases written before the decorator existed keep working. Prefer the decorator.
+ */
+export function ClassRequiresSubclass(target: unknown): boolean {
+    if (target == null) {
+        return false;
+    }
+    const proto = typeof target === 'function'
+        ? (target as { prototype?: object }).prototype
+        : Object.getPrototypeOf(target as object);
+
+    if (proto && Object.prototype.hasOwnProperty.call(proto, REQUIRES_SUBCLASS_KEY)) {
+        return (proto as Record<string, unknown>)[REQUIRES_SUBCLASS_KEY] === true;
+    }
+
+    // Legacy form: `static RequiresSubclass = true` declared directly on the class.
+    const ctor = typeof target === 'function' ? target : (target as object)?.constructor;
+    if (ctor && Object.prototype.hasOwnProperty.call(ctor, 'RequiresSubclass')) {
+        return (ctor as unknown as Record<string, unknown>)['RequiresSubclass'] === true;
+    }
+    return false;
+}

--- a/packages/MJGlobal/src/__tests__/RequiresSubclass.test.ts
+++ b/packages/MJGlobal/src/__tests__/RequiresSubclass.test.ts
@@ -1,0 +1,93 @@
+import { describe, it, expect } from 'vitest';
+import { RequiresSubclass, ClassRequiresSubclass, REQUIRES_SUBCLASS_KEY } from '../RequiresSubclass';
+
+@RequiresSubclass()
+abstract class MarkedBase {
+    abstract DoWork(): string;
+}
+
+class ConcreteChild extends MarkedBase {
+    DoWork(): string { return 'real'; }
+}
+
+abstract class UnmarkedBase {
+    abstract DoWork(): string;
+}
+
+/** Legacy form the decorator replaced — still honored so pre-decorator bases keep working. */
+class LegacyStaticBase {
+    public static readonly RequiresSubclass = true;
+}
+
+describe('RequiresSubclass', () => {
+    describe('the decorator', () => {
+        it('marks the decorated class', () => {
+            expect(ClassRequiresSubclass(MarkedBase)).toBe(true);
+        });
+
+        it('leaves an undecorated class unmarked', () => {
+            expect(ClassRequiresSubclass(UnmarkedBase)).toBe(false);
+        });
+
+        it('writes a NON-ENUMERABLE marker so it cannot leak into spreads or JSON', () => {
+            const descriptor = Object.getOwnPropertyDescriptor(MarkedBase.prototype, REQUIRES_SUBCLASS_KEY);
+            expect(descriptor?.enumerable).toBe(false);
+            // and therefore never shows up on an instance's enumerable surface
+            const instance = new ConcreteChild();
+            expect(Object.keys(instance)).not.toContain(REQUIRES_SUBCLASS_KEY);
+            expect(JSON.stringify({ ...instance })).not.toContain(REQUIRES_SUBCLASS_KEY);
+        });
+    });
+
+    describe('own-property semantics (the reason this is a decorator + helper)', () => {
+        it('a CONCRETE SUBCLASS of a marked base is NOT itself marked', () => {
+            // This is the correctness fix. A plain `cls.RequiresSubclass` read walks the
+            // constructor prototype chain, so a subclass would inherit `true` and resolving
+            // against it would wrongly throw even though it is perfectly instantiable.
+            expect(ClassRequiresSubclass(ConcreteChild)).toBe(false);
+        });
+
+        it('the naive inherited-property read WOULD have reported the subclass as marked', () => {
+            // Pins the bug being fixed: prove the inherited read is truthy for the subclass,
+            // so this test fails loudly if someone reverts to plain property access.
+            const inherited = (ConcreteChild.prototype as unknown as Record<string, unknown>)[REQUIRES_SUBCLASS_KEY];
+            expect(inherited).toBe(true);                       // inherited via the prototype chain
+            expect(ClassRequiresSubclass(ConcreteChild)).toBe(false); // but own-property check says no
+        });
+    });
+
+    describe('accepts a class or an instance', () => {
+        it('resolves an instance of a marked base', () => {
+            const hollow = Object.create(MarkedBase.prototype) as MarkedBase;
+            expect(ClassRequiresSubclass(hollow)).toBe(true);
+        });
+
+        it('resolves an instance of a concrete subclass as unmarked', () => {
+            expect(ClassRequiresSubclass(new ConcreteChild())).toBe(false);
+        });
+    });
+
+    describe('robustness', () => {
+        it('returns false for null/undefined rather than throwing', () => {
+            expect(ClassRequiresSubclass(null)).toBe(false);
+            expect(ClassRequiresSubclass(undefined)).toBe(false);
+        });
+
+        it('returns false for primitives and plain objects', () => {
+            expect(ClassRequiresSubclass(42)).toBe(false);
+            expect(ClassRequiresSubclass('nope')).toBe(false);
+            expect(ClassRequiresSubclass({})).toBe(false);
+        });
+    });
+
+    describe('backward compatibility', () => {
+        it('still honors the legacy `static RequiresSubclass = true` form', () => {
+            expect(ClassRequiresSubclass(LegacyStaticBase)).toBe(true);
+        });
+
+        it('does not let the legacy static leak to its subclasses either', () => {
+            class LegacyChild extends LegacyStaticBase {}
+            expect(ClassRequiresSubclass(LegacyChild)).toBe(false);
+        });
+    });
+});

--- a/packages/MJGlobal/src/index.ts
+++ b/packages/MJGlobal/src/index.ts
@@ -28,6 +28,7 @@ export * from './KeyedSerialTaskQueue'
 // Export the main classes
 export * from './Global'
 export * from './RegisterClass'
+export * from './RequiresSubclass'
 
 // NOTE: RegisterForStartup has moved to @memberjunction/core
 // Import from there instead of here


### PR DESCRIPTION
Follow-up to #3197. Converts the `RequiresSubclass` marker from a static class property into a decorator — and fixes an inheritance bug found while doing it.

## The correctness fix (the real reason to merge this)

#3197 read the marker as:

```ts
(baseClass as SubclassRequiringClass).RequiresSubclass === true
```

That's a plain property access, so it **walks the constructor prototype chain**. Every subclass of a marked base therefore also reported `true` — so a ClassFactory resolution against a **concrete, perfectly instantiable subclass** would have wrongly thrown.

`ClassRequiresSubclass()` now does an **own-property** check, so the marker applies to exactly the class that declared it.

A test pins the bug directly rather than just asserting the fix: it proves the naive inherited read **is** truthy for a subclass while the own-property check returns `false`. Reverting to plain property access fails that test loudly.

## The decorator

```ts
@RequiresSubclass()
export abstract class PermissionProviderBase { ... }
```

- Applies an own, **non-enumerable** marker (`__mj_RequiresSubclass`) to the class prototype — asserted against both the property descriptor and a real instance, so it can never leak into object spreads, `JSON.stringify`, or `for-in`
- `configurable: true`, so tests and hot-reload can redefine it
- `ClassRequiresSubclass()` accepts a **class or an instance**, so callers needn't normalize
- Matches the existing `@RegisterClass` idiom, and keeps the marker key defined once instead of retyped as a string literal in every base

## Why a decorator rather than the static

Beyond idiom consistency: it lets the own-property check live in **one helper**. With a raw static, every call site has to remember `Object.hasOwn` — and #3197 shows what happens when one doesn't.

## Backward compatible

The legacy `static RequiresSubclass = true` form is still honored, with the same own-property semantics, so any base written before the decorator keeps working. ClassFactory's failure-message guidance now prescribes the decorator, so developers who trip the gate are pointed at the new idiom.

## Verification

- `@memberjunction/global` — **103 tests** (11 new + 92 existing ClassFactory), all passing, clean build
- `@memberjunction/core` — **1,488 tests**, all passing, clean build

🤖 Generated with [Claude Code](https://claude.com/claude-code)