### PR TITLE
fix(actions): rename copy-pasted duplicate class names; export auth providers

### DIFF
--- a/.changeset/coreactions-dupe-class-names.md
+++ b/.changeset/coreactions-dupe-class-names.md
@@ -1,0 +1,14 @@
+---
+"@memberjunction/core-actions": patch
+"@memberjunction/auth-providers": patch
+---
+
+Fix duplicate class names in CoreActions, and export the concrete auth providers.
+
+`find-candidate-actions.action.ts` and `find-candidate-agents.action.ts` were copy-pasted from their `find-best-*` siblings and the class name was never changed, so each pair declared the same TypeScript class name (`FindBestActionAction` / `FindBestAgentAction`) under **different** ClassFactory keys.
+
+This was not cosmetic. A barrel can only export one class per name, so only the copy was exported — which meant `find-best-action` / `find-best-agent` were **absent from the ServerBootstrap class manifest** and therefore unprotected from tree-shaking. A shaken-out registration resolves to `BaseAction`, producing a hollow action rather than a hard failure. It also made the manifest's `FindBestActionAction` symbol resolve to the *candidate* implementation, so the manifest was actively misleading.
+
+Renamed the copies to match their files and registration keys (`FindCandidateActionsAction` / `FindCandidateAgentsAction`) and exported all four.
+
+Also exports the six concrete auth providers (`Auth0Provider`, `CognitoProvider`, `GoogleProvider`, `MSALProvider`, `OktaProvider`, `WorkOSProvider`). They are `@RegisterClass` plugins resolved by key at runtime, so they were reachable through the factory but not importable by name — leaving downstream consumers unable to subclass or reference them. `MagicLinkProvider` was already exported; this brings the rest to parity.

--- a/packages/Actions/CoreActions/src/custom/ai/find-candidate-actions.action.ts
+++ b/packages/Actions/CoreActions/src/custom/ai/find-candidate-actions.action.ts
@@ -30,7 +30,7 @@ import { MJActionParamEntity } from "@memberjunction/core-entities";
  * ```
  */
 @RegisterClass(BaseAction, "Find Candidate Actions")
-export class FindBestActionAction extends BaseAction {
+export class FindCandidateActionsAction extends BaseAction {
     /**
      * Executes the Find Candidate Actions action.
      *

--- a/packages/Actions/CoreActions/src/custom/ai/find-candidate-agents.action.ts
+++ b/packages/Actions/CoreActions/src/custom/ai/find-candidate-agents.action.ts
@@ -29,7 +29,7 @@ import { AIAgentPermissionHelper } from "@memberjunction/ai-engine-base";
  * ```
  */
 @RegisterClass(BaseAction, "Find Candidate Agents")
-export class FindBestAgentAction extends BaseAction {
+export class FindCandidateAgentsAction extends BaseAction {
     // Singleton initialization removed - AIEngine handles embedding lifecycle
 
     /**

--- a/packages/Actions/CoreActions/src/index.ts
+++ b/packages/Actions/CoreActions/src/index.ts
@@ -110,6 +110,12 @@ export * from './custom/ai/test-runtime-action.action';
 export * from './custom/ai/summarize-content.action';
 export * from './custom/ai/find-candidate-agents.action';
 export * from './custom/ai/find-candidate-actions.action';
+// The find-best pair could not be exported until their classes were renamed apart from the
+// copy-pasted find-candidate pair (both declared FindBestActionAction/FindBestAgentAction).
+// Unexported meant absent from the ServerBootstrap manifest, hence unprotected from
+// tree-shaking — and a shaken-out registration silently resolves to BaseAction.
+export * from './custom/ai/find-best-action.action';
+export * from './custom/ai/find-best-agent.action';
 export * from './custom/ai/load-agent-spec.action';
 export * from './custom/ai/generate-image.action';
 export * from './custom/ai/run-cluster-analysis.action';

--- a/packages/AuthProviders/src/index.ts
+++ b/packages/AuthProviders/src/index.ts
@@ -11,3 +11,14 @@ export {
 
 // Re-export types consumers commonly need alongside the auth providers
 export type { AuthProviderConfig, AuthUserInfo } from '@memberjunction/core';
+
+// Concrete auth providers. These are @RegisterClass plugins resolved by key at runtime, so
+// they were reachable via the factory but not importable by name — leaving downstream
+// consumers unable to subclass or reference them directly. MagicLinkProvider (above) was
+// already exported; these are the remaining six, for parity.
+export { Auth0Provider } from './providers/Auth0Provider.js';
+export { CognitoProvider } from './providers/CognitoProvider.js';
+export { GoogleProvider } from './providers/GoogleProvider.js';
+export { MSALProvider } from './providers/MSALProvider.js';
+export { OktaProvider } from './providers/OktaProvider.js';
+export { WorkOSProvider } from './providers/WorkOSProvider.js';


### PR DESCRIPTION
Salvages the two genuinely useful findings from #3203 (now closed — its premise, making MJExplorer's manifest loadable headless, no longer applies).

## The duplicate class names — not cosmetic

`find-candidate-actions.action.ts` and `find-candidate-agents.action.ts` were copy-pasted from their `find-best-*` siblings and the class name was never changed:

```
find-best-action.action.ts        @RegisterClass(BaseAction, "Find Best Action")
                                  export class FindBestActionAction
find-candidate-actions.action.ts  @RegisterClass(BaseAction, "Find Candidate Actions")
                                  export class FindBestActionAction   <- same name
```

A barrel can only export one class per name, so **only the copy was exported**. Two consequences:

1. `find-best-action` / `find-best-agent` were **absent from the ServerBootstrap class manifest**, and therefore unprotected from tree-shaking. That matters because a shaken-out registration doesn't fail loudly — `CreateInstance(BaseAction, "Find Best Action")` falls back to `BaseAction` and yields a **hollow action**. Same failure family as #3197.
2. The manifest's `FindBestActionAction` symbol actually resolved to the **candidate** implementation, so the manifest was misleading about what it was protecting.

Renamed the copies to match their files and registration keys — `FindCandidateActionsAction` / `FindCandidateAgentsAction` — and exported all four.

**Runtime resolution is unchanged.** The ClassFactory keys were already distinct (`"Find Best Action"` vs `"Find Candidate Actions"`) and are untouched; only the TypeScript class names moved.

## Auth providers

Exports the six concrete providers (`Auth0Provider`, `CognitoProvider`, `GoogleProvider`, `MSALProvider`, `OktaProvider`, `WorkOSProvider`). They're `@RegisterClass` plugins resolved by key, so they were reachable through the factory but not importable by name — leaving downstream consumers unable to subclass or reference them. `MagicLinkProvider` was already exported; this brings the rest to parity.

Explicit named exports (not `export *`) with `.js` specifiers, matching the file's existing style.

## Verification

- `@memberjunction/core-actions` — **268 tests**, clean build
- `@memberjunction/auth-providers` — **17 tests**, clean build
- All four action classes confirmed distinctly named and barrel-exported

🤖 Generated with [Claude Code](https://claude.com/claude-code)