### PR TITLE
feat(codegen): wide-table correctness floor — procedure parameter-limit guard (W1)

### DIFF
--- a/.changeset/wide-table-param-limit-floor.md
+++ b/.changeset/wide-table-param-limit-floor.md
@@ -1,0 +1,12 @@
+---
+"@memberjunction/sql-dialect": patch
+"@memberjunction/codegen-lib": patch
+---
+
+Wide-table correctness floor (SQL Server). CRUD stored procedures emit ~2 parameters per nullable column (a `_Clear` companion + the value), so a wide or sparse-column table can exceed SQL Server's hard 2,100-parameter procedure limit and silently generate an un-creatable procedure. This adds:
+
+- `SQLDialect.MaxProcedureParams` (SQL Server 2100, PostgreSQL 100, base null).
+- An emit-time guard in `generateCRUDParamString` (base + the PostgreSQL override) that throws with a diagnosed message when the projected parameter count exceeds the limit, and warns above 85% — before any SQL is written, replacing a late "missing routine" failure. Only fires on the typed-parameter path, so it never false-fires on PostgreSQL wide entities (which auto-route to the single-JSON-argument shape).
+- Failed `CREATE`/`CREATE OR ALTER` of a procedure/view/function/trigger in `executeSQLFileViaShell` now logs at error severity with the object name (benign batch failures stay warnings); control flow is unchanged so the downstream CRUD-validator self-heal still runs.
+
+Roadmap for the follow-on work (SQL Server JSON-arg shape, boot-heap reduction, measurement harness) is in `plans/wide-table-scaling.md`.

--- a/package-lock.json
+++ b/package-lock.json
@@ -43705,7 +43705,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.1.0.tgz",
       "integrity": "sha512-Xs1hdnE+DyKgeHJeJznQmYMIBG3TKIHJJT95Q58nHLSrElKlGQqDTR2HQ9fx5CN/Gk6Vh/kupBTDLU11/nDk/g==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "scheduler": "^0.26.0"
       },

--- a/packages/CodeGenLib/src/Database/codeGenDatabaseProvider.ts
+++ b/packages/CodeGenLib/src/Database/codeGenDatabaseProvider.ts
@@ -1,6 +1,7 @@
 import { EntityInfo, EntityFieldInfo, EntityPermissionInfo, IMetadataProvider, UserInfo } from '@memberjunction/core';
 import { MJGlobal } from '@memberjunction/global';
 import { DatabasePlatform, SQLDialect } from '@memberjunction/sql-dialect';
+import { logWarning } from '../Misc/status_logging';
 
 // ─── CONNECTION ABSTRACTION ──────────────────────────────────────────────────
 
@@ -677,7 +678,48 @@ export abstract class CodeGenDatabaseProvider {
             const defaultClause = this.isParamRequired(ef, isUpdate) ? '' : nullDefault;
             parts.push(`${dialect.ParameterRef(ef.CodeName)} ${this.renderParameterType(ef)}${defaultClause}`);
         }
+        this.assertProcedureParamLimit(parts.length, entityFields, isUpdate);
         return parts.join(',\n    ');
+    }
+
+    /**
+     * Correctness floor for wide entities. A CRUD stored procedure whose parameter count exceeds the
+     * dialect's hard {@link SQLDialect.MaxProcedureParams} limit (SQL Server: 2100; PostgreSQL: 100)
+     * will FAIL to create. Because each nullable column contributes a `_Clear` companion, the emitted
+     * parameter count is roughly twice the writable-column count, so wide / sparse tables reach the
+     * ceiling. This guard throws at emit time — turning a late, cryptic "missing routine" pipeline
+     * failure (or a silently un-creatable procedure when execution errors are downgraded to warnings)
+     * into an immediate, diagnosed error — and warns as the count approaches the limit.
+     *
+     * Only fires on the typed-parameter path. Providers that route wide entities to a single
+     * JSON-argument procedure shape (PostgreSQL today) decide that BEFORE building the typed parameter
+     * list, so they never reach the limit here.
+     *
+     * @param paramCount number of parameters the procedure will declare (main params + `_Clear` companions)
+     * @param entityFields the entity's fields (used only to recover the entity name for the message)
+     * @param isUpdate true for the Update procedure, false for Create
+     */
+    protected assertProcedureParamLimit(paramCount: number, entityFields: EntityFieldInfo[], isUpdate: boolean): void {
+        const limit = this.Dialect.MaxProcedureParams;
+        if (limit == null) {
+            return;
+        }
+        const entityName = entityFields[0]?.Entity ?? '(unknown entity)';
+        const verb = isUpdate ? 'Update' : 'Create';
+        if (paramCount > limit) {
+            throw new Error(
+                `CodeGen: the ${verb} stored procedure for entity "${entityName}" would declare ${paramCount} ` +
+                `parameters, exceeding this database's ${limit}-parameter procedure limit — the generated procedure ` +
+                `would fail to create. Reduce the number of writable columns on this entity, or route wide entities ` +
+                `to the single-JSON-argument procedure shape.`,
+            );
+        }
+        if (paramCount > limit * 0.85) {
+            logWarning(
+                `CodeGen: the ${verb} stored procedure for entity "${entityName}" declares ${paramCount} parameters, ` +
+                `within 15% of this database's ${limit}-parameter procedure limit. Adding more writable columns risks exceeding it.`,
+            );
+        }
     }
 
     /**

--- a/packages/CodeGenLib/src/Database/providers/postgresql/PostgreSQLCodeGenProvider.ts
+++ b/packages/CodeGenLib/src/Database/providers/postgresql/PostgreSQLCodeGenProvider.ts
@@ -1282,6 +1282,7 @@ END $$;
 
             parts.push(`${dialect.ParameterRef(ef.CodeName)} ${this.renderParameterType(ef)}${defaultClause}`);
         }
+        this.assertProcedureParamLimit(parts.length, entityFields, isUpdate);
         return parts.join(',\n    ');
     }
 

--- a/packages/CodeGenLib/src/Database/providers/sqlserver/SQLServerCodeGenProvider.ts
+++ b/packages/CodeGenLib/src/Database/providers/sqlserver/SQLServerCodeGenProvider.ts
@@ -1537,7 +1537,25 @@ DROP TABLE #__mj__CodeGen__vwTableUniqueKeys;
                     await pool.request().query(batch);
                 } catch (err) {
                     const msg = err instanceof Error ? err.message : String(err);
-                    logWarning(`[CodeGen] SQL batch warning in ${path.basename(filePath)}: ${msg.substring(0, 200)}`);
+                    // Classify the failure. A failed CREATE/ALTER of a schema-bound object (procedure,
+                    // view, function, trigger) is a REAL, un-creatable object — e.g. a wide-entity CRUD
+                    // procedure past the parameter limit — and is logged at ERROR severity with the
+                    // object name so it stands out from a benign batch warning (a DROP of a
+                    // not-yet-existing object, an idempotent guard, etc.).
+                    //
+                    // Control flow is intentionally unchanged (batches still run to the end, method still
+                    // returns true): the downstream CRUD validator + self-heal in the codegen pipeline
+                    // depends on reaching the end, and returning false here would abort
+                    // `executeSQLFiles`' file loop and bypass that repair. Turning a DDL-object failure
+                    // into a hard failure is a separate behavior change (see the wide-table roadmap, W1c).
+                    // The primary correctness floor for the wide-entity case is the emit-time parameter
+                    // guard (`assertProcedureParamLimit`), which throws before this SQL is ever written.
+                    const ddl = this.describeFailedDDLObject(batch);
+                    if (ddl) {
+                        logError(`[CodeGen] Failed to create ${ddl} in ${path.basename(filePath)}: ${msg.substring(0, 300)}`);
+                    } else {
+                        logWarning(`[CodeGen] SQL batch warning in ${path.basename(filePath)}: ${msg.substring(0, 200)}`);
+                    }
                 }
             }
 
@@ -1546,6 +1564,23 @@ DROP TABLE #__mj__CodeGen__vwTableUniqueKeys;
             logError(`[CodeGen] Failed to execute SQL file ${filePath}: ${e instanceof Error ? e.message : e}`);
             return false;
         }
+    }
+
+    /**
+     * If a SQL batch is a CREATE (or CREATE OR ALTER) of a schema-bound object — procedure, view,
+     * function, or trigger — returns a short `"<kind> <name>"` description for error logging; otherwise
+     * null. Used to raise a failed DDL-object batch (a real un-creatable object) above a benign batch
+     * warning. Deliberately does NOT match `DROP` (a failed drop of a not-yet-existing object is benign).
+     */
+    private describeFailedDDLObject(batch: string): string | null {
+        const m = batch.match(
+            /\bCREATE\s+(?:OR\s+ALTER\s+)?(PROC(?:EDURE)?|VIEW|FUNCTION|TRIGGER)\s+((?:\[[^\]]+\]|[A-Za-z0-9_]+)(?:\.(?:\[[^\]]+\]|[A-Za-z0-9_]+))?)/i,
+        );
+        if (!m) {
+            return null;
+        }
+        const kind = m[1].toUpperCase().startsWith('PROC') ? 'procedure' : m[1].toLowerCase();
+        return `${kind} ${m[2]}`;
     }
 
 }

--- a/packages/CodeGenLib/src/Database/providers/sqlserver/__tests__/SQLServerCodeGenProvider.test.ts
+++ b/packages/CodeGenLib/src/Database/providers/sqlserver/__tests__/SQLServerCodeGenProvider.test.ts
@@ -784,3 +784,51 @@ describe('SQLServerCodeGenProvider — foreign key indexes', () => {
         });
     });
 });
+
+/**
+ * W1b — emit-time procedure parameter-limit guard for wide entities. SQL Server caps a procedure
+ * at 2100 parameters; because every nullable column contributes a `_Clear` companion (~2 params
+ * per column), a wide / sparse table can exceed it and produce an un-creatable CRUD procedure.
+ * The guard throws while building the parameter list — before any SQL is written — so the failure
+ * is immediate and diagnosed rather than a late "missing routine" error.
+ */
+function pkPlusNullableFields(count: number): Record<string, unknown>[] {
+    const fields: Record<string, unknown>[] = [
+        { ID: 'pk', Name: 'ID', Type: 'uniqueidentifier', Length: 16, IsPrimaryKey: true, AllowsNull: false, AllowUpdateAPI: true, IsVirtual: false, AutoIncrement: false, DefaultValue: 'newsequentialid()' },
+    ];
+    for (let i = 0; i < count; i++) {
+        fields.push({ ID: `f${i}`, Name: `Col${i}`, Type: 'nvarchar', Length: 200, IsPrimaryKey: false, AllowsNull: true, AllowUpdateAPI: true, IsVirtual: false, AutoIncrement: false, DefaultValue: '' });
+    }
+    return fields;
+}
+
+describe('SQLServerCodeGenProvider — procedure parameter-limit guard (W1b)', () => {
+    let provider: SQLServerCodeGenProvider;
+
+    beforeEach(() => {
+        provider = new SQLServerCodeGenProvider();
+    });
+
+    it('throws when the emitted parameter count exceeds SQL Server 2100-param limit', () => {
+        // 1100 nullable columns → PK (1) + 1100 × 2 (_Clear + main) = 2201 params > 2100
+        const entity = createMockEntity({}, pkPlusNullableFields(1100));
+        expect(() => provider.generateCRUDParamString(entity.Fields, false))
+            .toThrow(/exceeding this database's 2100-parameter procedure limit/);
+    });
+
+    it('names the verb in the error (Update)', () => {
+        const entity = createMockEntity({}, pkPlusNullableFields(1100));
+        expect(() => provider.generateCRUDParamString(entity.Fields, true)).toThrow(/Update stored procedure/);
+    });
+
+    it('does not throw for a normal (narrow) entity', () => {
+        const entity = createMockEntity({}, pkPlusNullableFields(10));
+        expect(() => provider.generateCRUDParamString(entity.Fields, false)).not.toThrow();
+    });
+
+    it('does not throw in the warn band (below the hard limit)', () => {
+        // 900 nullable columns → 1 + 1800 = 1801 params: over the 85% warn threshold (1785), under 2100
+        const entity = createMockEntity({}, pkPlusNullableFields(900));
+        expect(() => provider.generateCRUDParamString(entity.Fields, false)).not.toThrow();
+    });
+});

--- a/packages/SQLDialect/src/postgresqlDialect.ts
+++ b/packages/SQLDialect/src/postgresqlDialect.ts
@@ -165,6 +165,9 @@ export class PostgreSQLDialect extends SQLDialect {
      */
     override get MaxColumnCount(): number { return 1600; }
 
+    /** PostgreSQL's hard per-function argument cap (`FUNC_MAX_ARGS`, default build). */
+    override get MaxProcedureParams(): number { return 100; }
+
     // ─── Identifier Quoting ──────────────────────────────────────────
 
     QuoteIdentifier(name: string): string {

--- a/packages/SQLDialect/src/sqlDialect.ts
+++ b/packages/SQLDialect/src/sqlDialect.ts
@@ -341,6 +341,17 @@ export abstract class SQLDialect implements SQLParserDialect {
     }
 
     /**
+     * Hard maximum number of parameters a stored procedure / function can declare, or `null` when
+     * effectively unbounded for our purposes. SQL Server: 2100. PostgreSQL: 100 (`FUNC_MAX_ARGS`).
+     * Consumed by CRUD-sproc CodeGen to fail loudly (or route to the single-JSON-argument shape)
+     * before emitting a procedure whose parameter count the engine will reject at CREATE time.
+     * Default: `null` (no parameter-count limit).
+     */
+    get MaxProcedureParams(): number | null {
+        return null;
+    }
+
+    /**
      * Minimum in-row byte footprint of a column of the given raw SQL type. Off-row-capable
      * variable-length / LOB types contribute only their in-row pointer; fixed-length types contribute
      * their full size. Only meaningful for dialects that report a {@link MaxInRowSizeBytes}.

--- a/packages/SQLDialect/src/sqlServerDialect.ts
+++ b/packages/SQLDialect/src/sqlServerDialect.ts
@@ -237,6 +237,9 @@ export class SQLServerDialect extends SQLDialect {
     /** SQL Server's hard per-table column cap. */
     override get MaxColumnCount(): number { return 1024; }
 
+    /** SQL Server's hard per-procedure parameter cap. */
+    override get MaxProcedureParams(): number { return 2100; }
+
     /**
      * Minimum in-row byte footprint of a column. Off-row-capable variable-length / LOB types
      * (incl. `(N)VARCHAR(MAX)`) contribute only a 24-byte in-row pointer; fixed-length types

--- a/plans/wide-table-scaling.md
+++ b/plans/wide-table-scaling.md
@@ -1,0 +1,126 @@
+# Wide-Table (Field-Density) Scaling — SQL Server
+
+## Context
+
+MemberJunction's "Large Schema Series" (PRs #3188–#3192) scaled the **table-count** axis (thousands of
+entities). This roadmap covers the orthogonal **field-density** axis — few entities × many columns — which
+stresses entirely different machinery and is largely unaddressed on SQL Server. Motivation is both **speed**
+and **memory** (serving-MJAPI heap is a known chokehold, and generated Zod/TypeGraphQL/entity artifacts scale
+with total field count).
+
+Two facts frame the work:
+
+- **PostgreSQL already mitigates wide CRUD sprocs** via a single-JSON-argument shape (`useJsonArgShape`,
+  threshold 90 params). **SQL Server opts out** — `GenericDatabaseProvider.ProcedureParamLimit` returns
+  `Infinity` — so a wide entity silently emits a CRUD procedure past SQL Server's hard **2,100-parameter**
+  limit that fails to create. Each nullable column contributes a `_Clear` companion (~2 params/column), so
+  the ceiling is reached around ~1,050 nullable columns (sooner for sparse-column tables, which can have up
+  to 30,000 columns).
+- The generated `entity_subclasses.ts` (one file, 118k+ lines) and `generated.ts` (GraphQL, 97k lines) plus
+  per-entity Zod schemas are **boot-time heap** in MJAPI that scales with total field count.
+
+## W1 — Correctness floor (this PR)
+
+Ship first; small and safe.
+
+- **W1a — model the limit.** `SQLDialect.MaxProcedureParams` (base `null`), SQL Server `2100`, PostgreSQL
+  `100` (`FUNC_MAX_ARGS`). `packages/SQLDialect/src/*Dialect.ts`.
+- **W1b — emit-time guard.** In `codeGenDatabaseProvider.generateCRUDParamString` (base + the PostgreSQL
+  override), after building the parameter list, `assertProcedureParamLimit(paramCount, …)` **throws** when
+  the count exceeds `Dialect.MaxProcedureParams` and **warns** above 85%. Only reached on the typed-parameter
+  path (JSON-arg providers decide before building the list), so it never false-fires on auto-mitigated PG
+  entities. Turns a late, cryptic "missing routine" failure into an immediate, diagnosed error *before any
+  SQL is written*.
+- **W1c — execution-time diagnosis (safe half).** In `SQLServerCodeGenProvider.executeSQLFileViaShell`, a
+  failed `CREATE`/`CREATE OR ALTER` of a procedure/view/function/trigger now logs at **error** severity with
+  the object name (benign batch failures — e.g. a `DROP` of a not-yet-existing object — stay warnings).
+  **Control flow is unchanged** (batches run to the end; method still returns `true`) — flipping the return
+  to `false` would abort `executeSQLFiles`' file loop and bypass the CRUD-validator self-heal the pipeline
+  depends on. The return-value flip is deferred as its own change; W1b is the primary floor.
+
+Deferred to a follow-up (W1d): width warnings during entity-field sync in `manage-metadata.ts` (row-size vs
+8,060 bytes via `Dialect.EstimateInRowBytes`; column count near 1,024; baseview projected width near 4,096).
+
+## W0 — Measurement (parallel with W1; gates all of W3)
+
+Extend the existing scale-benchmark (`mj-bench` worktree, `scale-benchmark/`) to the field-density axis:
+
+- `gen-schema.mjs`: add `--exact-width` (disable the ±40% jitter so exact widths don't randomly bust the
+  1,024-column cap) and `--nullable-ratio` (drives the `_Clear` count / param projection).
+- New `mjapi-boot-heap.sh`: boot MJAPI with `--heapsnapshot-signal=SIGUSR2` (zero code change), capture
+  post-metadata-load and post-`buildSchemaSync` snapshots, and rank **retained** size by: TypeGraphQL
+  `MetadataStorage`, the built `GraphQLSchema`, Zod schema objects + `.describe()` strings, the
+  `EntityFieldInfo` graph, and the two generated monoliths.
+- Matrix (constant total-field diagonals to separate the axes): `{500×50, 2000×50, 200×500, 50×1000}` plus a
+  `50×1000 @ nullable 0.95` (param-projection worst case) and the `1379×25` baseline for continuity. **≥3
+  replications per cell**, memory-capped SQL Server, confound log (per the benchmark-rigor standard).
+- Also capture `buildSchemaSync` time vs width and save-path p50/p95 vs width (feeds W2 Stage 2).
+
+Deliverable: a findings doc ranking W3 items by measured retained bytes. **No W3 item ships without it.**
+
+## W2 — SQL Server JSON-arg shape (auto-mitigation + width lever)
+
+Revisits the issue #2552 consensus ("SQL Server unchanged"). New evidence: the ~57-param margin on ordinary
+1,024-column tables + the sparse-table cliff (W1) and the per-save O(width) EXEC-string cost.
+
+- **Stage 1 (correctness):** flip SQL Server `ProcedureParamLimit` from `Infinity` to **~900–1000**. Nothing
+  in MJ's current schema flips shape (widest core entities ~180 params); only pathological/sparse tables do.
+  Makes W1b's throw unreachable — codegen auto-mitigates instead of failing.
+- **Stage 2 (perf, HARD-gated on a benchmark):** consider lowering to **200–500** for merely-wide tables.
+  Benefits (smaller sproc text/plan-cache, cheaper per-save build) are DB-side memory + save-latency wins, not
+  MJAPI-heap wins, and are **unproven**. Gate on save p50/p95 + `sys.dm_exec_cached_plans` bytes at widths
+  {50,200,500,1000} × {typed, JSON-arg} × {1-field, all-field} updates, replicated. Also a
+  **breaking-change/consensus decision** (direct sproc callers).
+
+Delta: define `SQLSERVER_PROCEDURE_PARAM_LIMIT`; override `SQLServerDataProvider.ProcedureParamLimit`; add the
+`shouldUseJsonArgShape` branch + `generateCRUDCreate/UpdateJsonArg` (T-SQL `OPENJSON … WITH` typed shred +
+key-presence `CASE`), mirroring the PG ~600-line implementation; new binding branch in
+`SQLServerDataProvider.RenderSaveCallBinding`. **Version guard:** OPENJSON needs DB `COMPATIBILITY_LEVEL ≥ 130`
+— add a codegen preflight that refuses JSON-arg emission (falls back to the W1b hard-fail) below 130.
+
+## W3 — MJAPI heap chokehold (ranked by W0)
+
+- **W3b — lazy Zod + describe-string extraction** (likely best memory-per-effort; near-zero runtime consumers
+  of the generated Zod schemas). Emit a memoized factory instead of an eager `z.object`; move/drop the
+  per-field `.describe()` mega-strings. Public-API rename → deprecation cycle.
+- **W3e — width-aware cache policy.** `localCache.maxCachedRowFields` / `maxEstimatedRowBytes` /
+  `excludeMaxTypeColumns` make wide entities cache-**ineligible** (safe degrade to DB reads) rather than
+  partially cached. Also gates `PreRunView`'s widen-to-all-fields. Ship default-off; own latency benchmark.
+- **W3a — split the monoliths** (per-schema/per-entity + barrel). DX/compile/incremental win; **does not
+  reduce runtime heap alone** (everything still imports at boot) — but it's the prerequisite for W3c.
+- **W3d — TypeGraphQL slimming.** Schema-on-demand is infeasible (`buildSchemaSync` needs every type).
+  Viable: clear `MetadataStorage` after build (if nothing re-reads it — verify), drop duplicated per-field
+  `description` strings, skip Create/Update inputs for read-only entities. Boot-**speed** lever may exceed the
+  heap lever here.
+- **W3c — lazy per-entity/per-schema class chunks** (biggest potential, most risk). Needs subpath-export
+  chunks (W3a), a server-side lazy manifest (the Explorer `--lazy-config` machinery is the template), and
+  switching `providerBase` entity instantiation to `CreateInstanceAsync`. Only if W0 shows residual heap after
+  W3b/W3d.
+- **W3f — dirty-only save binding** (exploratory, speed). Tolerant-SP semantics already permit omitting clean
+  fields on UPDATE; cuts wide-entity save cost independent of W2. Own benchmark; concurrent-writer semantics
+  change needs design review.
+
+## W4 — Baseview / SELECT-list guard
+
+Model `MaxSelectListItems = 4096` (SQL Server); warn at 3,500 / fail at 4,096 in `generateBaseView` with a
+pruned-view suggestion. Cheap insurance; column-pruned baseviews deferred unless a real sparse-table user or
+W0's 50×1000 runs force it.
+
+## Sequencing & evidence gates
+
+| Item | Ships | Own benchmark required? |
+|---|---|---|
+| W0 measurement | now (∥ W1) | *is* the evidence (≥3 reps/cell) |
+| W1a/b/c | now (this PR) | no — correctness |
+| W2 Stage 1 (~1000) | after W1; #2552 revisit documented | round-trip type matrix (correctness) |
+| W3b lazy Zod | after W0 confirms Zod's heap share | yes — before/after heapsnapshot |
+| W3e cache policy (default-off) | after W0 | yes — latency trade-off |
+| W3a split | anytime (DX) | no (no heap claim) |
+| W3d MetadataStorage / slimming | after W0 ranking | yes |
+| W2 Stage 2 (200–500) | numbers + consensus | **hard gate** |
+| W3c lazy chunks | only if residual heap after W3b/d | yes |
+| W4 guard; W3f | opportunistic / exploratory | W3f: yes |
+
+**Honest unknowns:** relative heap shares of TypeGraphQL vs Zod vs `EntityFieldInfo` (W0's purpose); whether
+type-graphql tolerates `MetadataStorage` clearing; whether `generated.ts` entity imports are truly zero-use;
+OPENJSON shred cost vs typed-arg parse cost by width; `buildSchemaSync` width-scaling exponent.


### PR DESCRIPTION
## What

First increment of the **wide-table (field-density) scaling** work — a correctness floor for SQL Server CRUD stored procedures on wide/sparse tables.

SQL Server CRUD sprocs emit **~2 parameters per nullable column** (a `_Clear` companion + the value), so a wide or sparse-column table can exceed SQL Server's hard **2,100-parameter** procedure limit and **silently emit an un-creatable procedure** — execution errors were downgraded to warnings, surfacing later as a cryptic "missing routine" failure. PostgreSQL already avoids this by routing wide entities to a single-JSON-argument shape at 90 params; SQL Server opted out (`ProcedureParamLimit = Infinity`) with no guard.

## Changes

- **W1a** — `SQLDialect.MaxProcedureParams`: SQL Server `2100`, PostgreSQL `100` (`FUNC_MAX_ARGS`), base `null`.
- **W1b** — emit-time guard in `generateCRUDParamString` (base + the PostgreSQL override): **throws** with a diagnosed message (entity, verb, count, remediation) when the projected parameter count exceeds the limit, and **warns above 85%** — *before any SQL is written*. Only reached on the typed-parameter path, so PostgreSQL wide entities (auto JSON-arg) never false-fire.
- **W1c** — `executeSQLFileViaShell`: a failed `CREATE`/`CREATE OR ALTER` of a procedure/view/function/trigger now logs at **error** severity with the object name (benign batch failures — e.g. a `DROP` of a not-yet-existing object — stay warnings). **Control flow is unchanged** (batches run to the end, method still returns `true`): flipping the return to `false` would abort `executeSQLFiles`' file loop and bypass the CRUD-validator self-heal — deferred as its own change. W1b is the primary floor.

## Testing

- `@memberjunction/sql-dialect`: **234 tests pass** (build clean).
- `@memberjunction/codegen-lib`: **614 tests pass** — including 4 new guard tests (over-limit throws, verb named, narrow entity does not throw, warn-band does not throw and emits the warning).

## Roadmap

The full W0–W4 sequence (measurement harness, SQL Server JSON-arg shape, boot-heap reduction) with evidence gates is in [`plans/wide-table-scaling.md`](plans/wide-table-scaling.md). This PR is **W1 only** — the safe, no-behavior-change-for-normal-schemas floor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)