### PR TITLE
fix(test): expose RequiresSubclass in global mocks — green the RequiresSubclass unit-test failures (actions + ai-vector-sync)

### DIFF
--- a/.changeset/fix-actions-engine-global-mock.md
+++ b/.changeset/fix-actions-engine-global-mock.md
@@ -1,0 +1,5 @@
+---
+"@memberjunction/actions": patch
+---
+
+Fix a broken unit test on `next`: the `vi.mock('@memberjunction/global')` factories in the ActionEngine / EntityActionEngine tests didn't expose `RequiresSubclass`, so the ActionEngine module graph (which now declares `@RequiresSubclass()`) threw `No "RequiresSubclass" export is defined on the mock` at module init, failing `@memberjunction/actions#test`. Added the missing no-op decorator to both mock factories. Test-only change.

--- a/.changeset/fix-actions-engine-global-mock.md
+++ b/.changeset/fix-actions-engine-global-mock.md
@@ -1,5 +1,10 @@
 ---
 "@memberjunction/actions": patch
+"@memberjunction/ai-vector-sync": patch
 ---
 
-Fix a broken unit test on `next`: the `vi.mock('@memberjunction/global')` factories in the ActionEngine / EntityActionEngine tests didn't expose `RequiresSubclass`, so the ActionEngine module graph (which now declares `@RequiresSubclass()`) threw `No "RequiresSubclass" export is defined on the mock` at module init, failing `@memberjunction/actions#test`. Added the missing no-op decorator to both mock factories. Test-only change.
+Fix the broken unit tests on `next` caused by `vi.mock('@memberjunction/global')` factories that don't expose `RequiresSubclass`. The module graphs under test now declare `@RequiresSubclass()`, so a mock omitting it throws `No "RequiresSubclass" export is defined on the mock` at module init.
+
+This covers the **complete** set of currently-failing suites (verified by a full `turbo run test` — exactly these two packages fail on this gap): `@memberjunction/actions` (`ActionEngine` / `EntityActionEngine` tests) and `@memberjunction/ai-vector-sync` (`entityDocumentConfig` test). Added the missing no-op decorator to each. Test-only change.
+
+Note: ~200 other test files also mock `@memberjunction/global` without listing `RequiresSubclass`, but they pass today — their module-under-test never imports a `@RequiresSubclass()`-decorated class (or they spread the real module). Those are latent, not failing, and are intentionally left untouched to keep this fix reviewable; a shared-mock refactor to kill the latent class is a separate cleanup.

--- a/package-lock.json
+++ b/package-lock.json
@@ -43705,7 +43705,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.1.0.tgz",
       "integrity": "sha512-Xs1hdnE+DyKgeHJeJznQmYMIBG3TKIHJJT95Q58nHLSrElKlGQqDTR2HQ9fx5CN/Gk6Vh/kupBTDLU11/nDk/g==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "scheduler": "^0.26.0"
       },

--- a/packages/AI/Vectors/Sync/src/__tests__/entityDocumentConfig.test.ts
+++ b/packages/AI/Vectors/Sync/src/__tests__/entityDocumentConfig.test.ts
@@ -18,6 +18,9 @@ vi.mock('@memberjunction/global', () => {
   }
   return {
     RegisterClass: () => (_target: unknown) => {},
+    // No-op decorator factory — classes in the ai-vector-sync module graph declare
+    // `@RequiresSubclass()`; the mock must expose it or module init throws on the missing export.
+    RequiresSubclass: () => (_target: unknown) => {},
     MJGlobal: { Instance: { ClassFactory: { GetRegistration: vi.fn() } } },
     UUIDsEqual: (a: string, b: string) => a?.toLowerCase() === b?.toLowerCase(),
     BaseSingleton: MockBaseSingleton,

--- a/packages/Actions/Engine/src/__tests__/ActionEngine.test.ts
+++ b/packages/Actions/Engine/src/__tests__/ActionEngine.test.ts
@@ -96,6 +96,9 @@ vi.mock('@memberjunction/global', async (importOriginal) => ({
         }
     }),
     RegisterClass: () => (target: Function) => target,
+    // No-op decorator factory — some classes in the ActionEngine module graph declare
+    // `@RequiresSubclass()`; the mock must expose it or module init throws on the missing export.
+    RequiresSubclass: () => (target: Function) => target,
     // Case-insensitive UUID equality. Used by ActionEngineServer when
     // matching action result codes and by EntityActionInvocation*.MapParams.
     UUIDsEqual: (a: unknown, b: unknown): boolean =>

--- a/packages/Actions/Engine/src/__tests__/EntityActionEngine.test.ts
+++ b/packages/Actions/Engine/src/__tests__/EntityActionEngine.test.ts
@@ -16,6 +16,9 @@ vi.mock('@memberjunction/global', async (importOriginal) => ({
         },
     },
     RegisterClass: () => (target: Function) => target,
+    // No-op decorator factory — some classes in the ActionEngine module graph declare
+    // `@RequiresSubclass()`; the mock must expose it or module init throws on the missing export.
+    RequiresSubclass: () => (target: Function) => target,
     SafeJSONParse: vi.fn((str: string) => {
         try { return JSON.parse(str); } catch { return null; }
     }),


### PR DESCRIPTION
## What

Fixes a **pre-existing broken unit test on `next`** that fails `@memberjunction/actions#test` — and therefore reddens **every open PR whose affected-set includes `@memberjunction/actions`** (e.g. #3188, #3210, #3212), even though none of those PRs touch Actions.

## Root cause

`@memberjunction/global` exports `RequiresSubclass` (a decorator), and the ActionEngine module graph now declares `@RequiresSubclass()`. But the hand-written `vi.mock('@memberjunction/global')` factories in `ActionEngine.test.ts` and `EntityActionEngine.test.ts` return a *partial* surface that omits it — so at module init vitest throws `No "RequiresSubclass" export is defined on the '@memberjunction/global' mock`. The mocks are identically stale on `next` itself.

## Fix

Add the missing no-op decorator factory (`RequiresSubclass: () => (target) => target`, matching the real `RequiresSubclass(): (ctor) => void` shape) to both mock factories — same pattern already used there for `RegisterClass`. **Test-only change.**

## Testing

`@memberjunction/actions`: **152 tests pass** (was failing at module init before). Once this lands on `next`, the affected PRs go green after they pick up `next`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)