### PR TITLE
fix(ai-agents): serialize realtime transcript persistence per role (duplicate turn race)

### DIFF
--- a/.changeset/realtime-transcript-persist-race.md
+++ b/.changeset/realtime-transcript-persist-race.md
@@ -11,3 +11,5 @@ Observed live against a streamed Grok session: one user utterance produced two b
 Transcript persistence is now serialized per role through a promise chain, making the read-modify-write atomic with respect to other frames of the same role. Roles remain independent and are not serialized against each other. A frame that fails no longer strands the rest of its role's queue.
 
 Adds regression coverage for concurrent (non-awaited) frames — overlapping streamed captions, an interim racing its final, cross-role independence, and failure isolation. This class of bug was invisible to the existing suite, which drove every persist call sequentially.
+
+Also bounds session teardown against a stuck write: `Stop()` now drains queued transcript writes after the provider session closes (so no new frames can arrive) and before the result is built — so tail writes land and the turn count doesn't undercount — under a hard timeout (`TranscriptFlushTimeoutMs`, default 5s). A hung or rejected drain is logged and teardown finalizes anyway; losing a tail write is strictly better than wedging the session.

--- a/.changeset/realtime-transcript-persist-race.md
+++ b/.changeset/realtime-transcript-persist-race.md
@@ -1,0 +1,13 @@
+---
+"@memberjunction/ai-agents": patch
+---
+
+Fix a concurrency race that could persist a realtime transcript turn twice.
+
+The session runner dispatches provider transcript frames fire-and-forget (`void this.handleTranscript(t)`), so frames for the same role are processed concurrently. `persistRealtimeTranscript` did a check-then-act on the in-flight turn map that spanned `await`s (GetEntityObject / Load / Save), so two captions arriving a few milliseconds apart could both observe "no tracked row yet", both take the create branch, and write the turn twice.
+
+Observed live against a streamed Grok session: one user utterance produced two byte-identical `ConversationDetail` rows, the duplicate created 17ms *before* the first row's final update. Streamed-caption providers (Grok) are the most exposed since they emit many finals per turn, but the interim-racing-its-own-final variant applies to any provider.
+
+Transcript persistence is now serialized per role through a promise chain, making the read-modify-write atomic with respect to other frames of the same role. Roles remain independent and are not serialized against each other. A frame that fails no longer strands the rest of its role's queue.
+
+Adds regression coverage for concurrent (non-awaited) frames — overlapping streamed captions, an interim racing its final, cross-role independence, and failure isolation. This class of bug was invisible to the existing suite, which drove every persist call sequentially.

--- a/packages/AI/Agents/src/__tests__/realtime-agent-integration.test.ts
+++ b/packages/AI/Agents/src/__tests__/realtime-agent-integration.test.ts
@@ -377,6 +377,32 @@ describe('BaseAgent realtime (session-driven) integration', () => {
             expect(messages).toEqual(['answer refined', 'question refined']);
         });
 
+        it('CONCURRENCY: a HUNG write on one role does not block the OTHER role', async () => {
+            // The queues are per-ROLE, not global. A stuck user write must not stall assistant
+            // persistence — a single global queue would serialize them and silently couple the two,
+            // so this pins the isolation property rather than just the happy-path independence.
+            const agent = new TestableRealtimeAgent();
+            const store = new MockDetailStore();
+            const provider = {
+                GetEntityObject: async (_entityName?: string) => store.newEntity(),
+                EntityByName: () => undefined
+            } as unknown as IMetadataProvider;
+            const params = makeParams({ provider, data: { conversationId: 'conv-1' }, agentSessionID: 'sess-1' } as Partial<ExecuteAgentParams>);
+            // Hang the USER role's write by making its Save never settle.
+            const hungEntity = store.newEntity();
+            hungEntity.Save = () => new Promise<boolean>(() => { /* never settles */ });
+            let servedHung = false;
+            (provider as unknown as { GetEntityObject: () => Promise<StoreBackedDetail> }).GetEntityObject =
+                async () => { if (!servedHung) { servedHung = true; return hungEntity; } return store.newEntity(); };
+
+            const userWrite = agent.callPersist(params, { Role: 'user', Text: 'hangs', IsFinal: true, ReplacesPrevious: false });
+            void userWrite; // deliberately never awaited — it never settles
+            // The assistant role must still complete despite the user queue being stuck:
+            const assistantId = await agent.callPersist(params, { Role: 'assistant', Text: 'answer', IsFinal: true, ReplacesPrevious: false });
+            expect(assistantId).not.toBeNull();
+            expect(store.rows.size).toBe(1); // only the assistant row landed; the user write is still hung
+        });
+
         it('CONCURRENCY: a failing frame does not strand the rest of the role queue', async () => {
             // The queue chains with `.then(run, run)`, so a rejected predecessor must not block later
             // frames (a stuck chain would silently drop the rest of the conversation).

--- a/packages/AI/Agents/src/__tests__/realtime-agent-integration.test.ts
+++ b/packages/AI/Agents/src/__tests__/realtime-agent-integration.test.ts
@@ -326,6 +326,80 @@ describe('BaseAgent realtime (session-driven) integration', () => {
             expect(store.rows.get('detail-1')!.Message).toBe('set a timer'); // turn 1 preserved (not clobbered)
         });
 
+        it('CONCURRENCY: overlapping streamed captions (dispatched fire-and-forget) still collapse to ONE row', async () => {
+            // The runner dispatches transcript frames with `void this.handleTranscript(t)`, so frames for a
+            // role are processed CONCURRENTLY — nothing awaits the previous one. Reproduced in production:
+            // a Grok turn produced two byte-identical rows, the duplicate created 17ms BEFORE the first
+            // row's final update. Root cause: persist did a check-then-act on the in-flight map spanning
+            // awaits, so two captions both saw "no tracked row" and both took the create branch.
+            // NOTE: these are deliberately NOT awaited individually — that is the whole point.
+            const agent = new TestableRealtimeAgent();
+            const store = new MockDetailStore();
+            const params = makeParams({ provider: store.provider(), data: { conversationId: 'conv-1' }, agentSessionID: 'sess-1' } as Partial<ExecuteAgentParams>);
+            const results = await Promise.all([
+                agent.callPersist(params, { Role: 'user', Text: 'set', IsFinal: true, ReplacesPrevious: false }),
+                agent.callPersist(params, { Role: 'user', Text: 'set a', IsFinal: true, ReplacesPrevious: true }),
+                agent.callPersist(params, { Role: 'user', Text: 'set a timer', IsFinal: true, ReplacesPrevious: true }),
+            ]);
+            expect(store.rows.size).toBe(1);                       // pre-fix: 2+ rows
+            expect(store.rows.get('detail-1')!.Message).toBe('set a timer'); // last caption wins, in place
+            expect(results.filter((r) => r !== null)).toEqual(['detail-1']); // exactly ONE new-turn signal
+        });
+
+        it('CONCURRENCY: an interim racing its own final still yields ONE row', async () => {
+            // The interim (create In-Progress) and the final (finalize in place) can also overlap. Pre-fix
+            // the final could start before the interim had written the tracked row, creating a second row.
+            const agent = new TestableRealtimeAgent();
+            const store = new MockDetailStore();
+            const params = makeParams({ provider: store.provider(), data: { conversationId: 'conv-1' }, agentSessionID: 'sess-1' } as Partial<ExecuteAgentParams>);
+            await Promise.all([
+                agent.callPersist(params, { Role: 'user', Text: 'hel', IsFinal: false }),
+                agent.callPersist(params, { Role: 'user', Text: 'hello there', IsFinal: true }),
+            ]);
+            expect(store.rows.size).toBe(1);
+            expect(store.rows.get('detail-1')).toMatchObject({ Status: 'Complete', Message: 'hello there' });
+        });
+
+        it('CONCURRENCY: different roles are NOT serialized against each other (user + assistant overlap cleanly)', async () => {
+            // Roles own independent tracked rows, so they must not block each other — each still gets
+            // exactly one row.
+            const agent = new TestableRealtimeAgent();
+            const store = new MockDetailStore();
+            const params = makeParams({ provider: store.provider(), data: { conversationId: 'conv-1' }, agentSessionID: 'sess-1' } as Partial<ExecuteAgentParams>);
+            await Promise.all([
+                agent.callPersist(params, { Role: 'user', Text: 'question', IsFinal: true, ReplacesPrevious: false }),
+                agent.callPersist(params, { Role: 'assistant', Text: 'answer', IsFinal: true, ReplacesPrevious: false }),
+                agent.callPersist(params, { Role: 'user', Text: 'question refined', IsFinal: true, ReplacesPrevious: true }),
+                agent.callPersist(params, { Role: 'assistant', Text: 'answer refined', IsFinal: true, ReplacesPrevious: true }),
+            ]);
+            expect(store.rows.size).toBe(2); // one user row, one assistant row
+            const messages = [...store.rows.values()].map((r) => r.Message).sort();
+            expect(messages).toEqual(['answer refined', 'question refined']);
+        });
+
+        it('CONCURRENCY: a failing frame does not strand the rest of the role queue', async () => {
+            // The queue chains with `.then(run, run)`, so a rejected predecessor must not block later
+            // frames (a stuck chain would silently drop the rest of the conversation).
+            const agent = new TestableRealtimeAgent();
+            const store = new MockDetailStore();
+            let failNext = true;
+            const provider = {
+                GetEntityObject: async () => {
+                    if (failNext) { failNext = false; throw new Error('transient metadata failure'); }
+                    return store.newEntity();
+                },
+                EntityByName: () => undefined
+            } as unknown as IMetadataProvider;
+            const params = makeParams({ provider, data: { conversationId: 'conv-1' }, agentSessionID: 'sess-1' } as Partial<ExecuteAgentParams>);
+            const settled = await Promise.allSettled([
+                agent.callPersist(params, { Role: 'user', Text: 'first', IsFinal: true, ReplacesPrevious: false }),
+                agent.callPersist(params, { Role: 'user', Text: 'second', IsFinal: true, ReplacesPrevious: false }),
+            ]);
+            expect(settled[0].status).toBe('rejected');   // the frame that hit the failure
+            expect(settled[1].status).toBe('fulfilled');  // the queue kept running
+            expect(store.rows.size).toBe(1);
+        });
+
         it('C8 interim→final (OpenAI): one row per turn, and the next turn is a distinct row', async () => {
             const agent = new TestableRealtimeAgent();
             const store = new MockDetailStore();

--- a/packages/AI/Agents/src/__tests__/realtime-session-runner.test.ts
+++ b/packages/AI/Agents/src/__tests__/realtime-session-runner.test.ts
@@ -1424,6 +1424,56 @@ describe('QA re-audit: reconnect × abort × delegation interaction seams', () =
         expect(model.Sessions).toHaveLength(2); // exactly one reconnect, not two concurrent
     });
 
+    it('DRAIN: Stop() waits for queued transcript writes, and a turn that lands during the drain is counted', async () => {
+        // Transcript frames are fire-and-forget, so the last turns' writes can still be in flight at
+        // teardown. Stop() must drain them BEFORE building the result, or the tail is lost and the turn
+        // count undercounts.
+        let releaseWrite: (() => void) | null = null;
+        let resolvedTurnId: string | null = null;
+        const pending = new Promise<void>((resolve) => { releaseWrite = resolve; });
+        const h = buildHarness({
+            PersistTranscript: async () => { await pending; resolvedTurnId = 'detail-late'; return resolvedTurnId; },
+            FlushTranscripts: async () => { await pending; },
+        });
+        const runner = new RealtimeSessionRunner(h.deps);
+        await runner.Start();
+        h.session.fireTranscript({ Role: 'user', Text: 'last words', IsFinal: true });
+        await Promise.resolve();
+        const stopPromise = runner.Stop();      // must NOT resolve while the write is still queued
+        let settled = false;
+        void stopPromise.then(() => { settled = true; });
+        await new Promise((r) => setTimeout(r, 0));
+        expect(settled).toBe(false);            // Stop is waiting on the drain
+        releaseWrite?.();                        // the write completes
+        const result = await stopPromise;
+        expect(resolvedTurnId).toBe('detail-late');
+        expect(result.TranscriptTurnCount).toBe(1); // counted because the drain ran before buildResult
+    });
+
+    it('DRAIN: a HUNG transcript write cannot wedge teardown — Stop() finalizes at the bound', async () => {
+        vi.useFakeTimers();
+        const h = buildHarness({
+            // Never settles — models a stuck DB call at teardown.
+            FlushTranscripts: () => new Promise<void>(() => { /* hangs forever */ }),
+            TranscriptFlushTimeoutMs: 5000,
+        });
+        const runner = new RealtimeSessionRunner(h.deps);
+        await runner.Start();
+        const stopPromise = runner.Stop();
+        await vi.advanceTimersByTimeAsync(5001);   // cross the bound
+        const result = await stopPromise;          // finalizes anyway rather than hanging
+        expect(result.Success).toBe(true);
+        vi.useRealTimers();
+    });
+
+    it('DRAIN: a REJECTED drain is swallowed — teardown still finalizes', async () => {
+        const h = buildHarness({ FlushTranscripts: async () => { throw new Error('db exploded'); } });
+        const runner = new RealtimeSessionRunner(h.deps);
+        await runner.Start();
+        const result = await runner.Stop();
+        expect(result.Success).toBe(true);
+    });
+
     it('SEAM-3/W1: accumulated usage from BEFORE the drop survives the reconnect (summed with post-reconnect usage)', async () => {
         const model = new (class extends BaseRealtimeModel {
             public Sessions: MockRealtimeSession[] = [];

--- a/packages/AI/Agents/src/base-agent.ts
+++ b/packages/AI/Agents/src/base-agent.ts
@@ -1715,6 +1715,21 @@ export class BaseAgent {
      * start of every realtime session so a prior run can never leak a row id into the next.
      */
     private realtimeInFlightTurns: Map<string, { id: string; open: boolean }> = new Map();
+    /**
+     * Per-role serialization queue for transcript persistence.
+     *
+     * The runner dispatches provider transcript frames FIRE-AND-FORGET (`void this.handleTranscript(t)`),
+     * so frames for the same role can be in flight CONCURRENTLY. {@link persistRealtimeTranscript} does a
+     * check-then-act on {@link realtimeInFlightTurns} that spans `await`s (GetEntityObject / Load / Save):
+     * without serialization, two captions arriving a few ms apart both observe "no tracked row yet", both
+     * take the create branch, and the turn is persisted TWICE. Observed in production against a streamed
+     * Grok session (two byte-identical rows, the second created 17ms before the first's final update).
+     *
+     * Each role's calls are therefore chained through this map so the read-modify-write is atomic with
+     * respect to other frames of the SAME role. Roles are independent (separate `realtimeInFlightTurns`
+     * entries), so they are not serialized against each other. Reset per session alongside the turn map.
+     */
+    private realtimePersistQueues: Map<string, Promise<void>> = new Map();
     /** Active audio recording controller for the current realtime session, or `null` when recording is off. */
     private realtimeRecording: RealtimeRecordingController | null = null;
     /** Storage account id the active recording stores to (RecordingStorageProviderID ?? AttachmentStorageProviderID). */
@@ -1742,6 +1757,7 @@ export class BaseAgent {
         // 3) Resolve recording (OFF by default; runtime > agent > off; consent + storage gated) and reset
         //    the per-session turn-lifecycle state, then build the injected deps and run the session.
         this.realtimeInFlightTurns = new Map();
+        this.realtimePersistQueues = new Map();
         const recording = await this.resolveRealtimeRecording(params);
         this.realtimeRecording = recording?.controller ?? null;
         this.realtimeRecordingAccountId = recording?.storageAccountId ?? null;
@@ -2388,7 +2404,28 @@ export class BaseAgent {
      * @param transcript The transcript turn (interim delta or final) emitted by the model.
      * @returns The created row id on first creation of a turn, else `null`.
      */
-    private async persistRealtimeTranscript(params: ExecuteAgentParams, transcript: RealtimeTranscript): Promise<string | null> {
+    private persistRealtimeTranscript(params: ExecuteAgentParams, transcript: RealtimeTranscript): Promise<string | null> {
+        // Serialize per role — see realtimePersistQueues. Transcript frames arrive fire-and-forget, so
+        // without this chain two concurrent captions can both pass the "is there a tracked row?" check
+        // before either has written one back, and the turn is persisted twice.
+        const roleKey = transcript.Role;
+        const run = () => this.persistRealtimeTranscriptSerialized(params, transcript);
+        const prior = this.realtimePersistQueues.get(roleKey) ?? Promise.resolve();
+        // `.then(run, run)` (not `.then(run)`) so a rejected predecessor never strands the rest of the
+        // queue — each frame runs regardless of how the previous one settled.
+        const result = prior.then(run, run);
+        // The stored link swallows outcomes: the queue only needs ordering, and an unhandled rejection
+        // parked in the map would surface as an unhandled promise rejection.
+        this.realtimePersistQueues.set(roleKey, result.then(() => undefined, () => undefined));
+        return result;
+    }
+
+    /**
+     * The actual persistence work for one transcript frame. Runs under the per-role queue established by
+     * {@link persistRealtimeTranscript}, so it may safely read-modify-write {@link realtimeInFlightTurns}
+     * across its `await`s without another frame of the same role interleaving.
+     */
+    private async persistRealtimeTranscriptSerialized(params: ExecuteAgentParams, transcript: RealtimeTranscript): Promise<string | null> {
         if (!transcript.Text?.trim()) {
             return null;
         }

--- a/packages/AI/Agents/src/base-agent.ts
+++ b/packages/AI/Agents/src/base-agent.ts
@@ -2094,6 +2094,7 @@ export class BaseAgent {
             DelegateToTarget: (request) => this.delegateRealtimeToTarget(params, config, request),
             ExecuteTool: (call) => this.executeRealtimeTool(params, call),
             PersistTranscript: (transcript) => this.persistRealtimeTranscript(params, transcript),
+            FlushTranscripts: () => this.flushRealtimeTranscriptQueues(),
             Recording: this.realtimeRecording ?? undefined,
             FinalizeRecording: () => this.finalizeRealtimeRecording(params),
             CheckpointUsage: (usage) => this.checkpointRealtimeUsage(promptRun, usage),
@@ -2418,6 +2419,25 @@ export class BaseAgent {
         // parked in the map would surface as an unhandled promise rejection.
         this.realtimePersistQueues.set(roleKey, result.then(() => undefined, () => undefined));
         return result;
+    }
+
+    /**
+     * Waits for every role's queued transcript writes to settle.
+     *
+     * Transcript frames are dispatched fire-and-forget, so writes for the last turns of a session can
+     * still be in flight at teardown. The session runner calls this during `Stop()` — after the provider
+     * session is closed, so no new frames can arrive — under its own hard timeout, which is why this
+     * method itself is unbounded and simply awaits what is queued.
+     *
+     * Awaits the STORED queue links, which are outcome-swallowing by construction, so a failed write
+     * can never reject here and abort the drain for other roles.
+     */
+    private async flushRealtimeTranscriptQueues(): Promise<void> {
+        const pending = [...this.realtimePersistQueues.values()];
+        if (pending.length === 0) {
+            return;
+        }
+        await Promise.all(pending);
     }
 
     /**

--- a/packages/AI/Agents/src/realtime/realtime-session-runner.ts
+++ b/packages/AI/Agents/src/realtime/realtime-session-runner.ts
@@ -152,6 +152,29 @@ export interface RealtimeSessionRunnerDeps {
     FinalizeRecording?: () => Promise<void>;
 
     /**
+     * Drains any transcript writes still queued by {@link PersistTranscript}.
+     *
+     * Transcript frames are dispatched FIRE-AND-FORGET (so a slow write can never stall the
+     * conversation), which means writes for the final turns of a session can still be in flight when
+     * {@link RealtimeSessionRunner.Stop} runs. Without this drain those writes land AFTER the runner
+     * has returned its result — the turn count can undercount, and a process torn down promptly after
+     * the session (serverless / container stop) can lose the tail.
+     *
+     * Called during {@link RealtimeSessionRunner.Stop} AFTER the provider session is closed (so no new
+     * frames can arrive) and BEFORE the result is built. Bounded by
+     * {@link TranscriptFlushTimeoutMs} — a hung write must never wedge teardown. Optional: when
+     * omitted the drain is skipped entirely (existing behavior).
+     */
+    FlushTranscripts?: () => Promise<void>;
+
+    /**
+     * Upper bound (ms) on the {@link FlushTranscripts} drain during teardown. Defaults to 5000. On
+     * expiry the runner logs and finalizes anyway — losing a tail write is strictly better than
+     * hanging the session teardown on a stuck database call.
+     */
+    TranscriptFlushTimeoutMs?: number;
+
+    /**
      * Checkpoints the *accumulated* usage onto the single long-lived `AIPromptRun`. The runner
      * accumulates `OnUsage` deltas and invokes this on a debounced cadence and on close, so a
      * crash-driven janitor close finalizes from the last-persisted values and loses nothing.
@@ -223,6 +246,9 @@ export interface RealtimeSessionResult {
  * drive the session to completion, or {@link Start}/{@link Stop} to control it explicitly.
  */
 export class RealtimeSessionRunner {
+    /** Default upper bound (ms) on the teardown transcript drain — see `TranscriptFlushTimeoutMs`. */
+    private static readonly DefaultTranscriptFlushTimeoutMs = 5000;
+
     // ── Delegated-run progress narration (server-bridged B3) ──────────────────
     /** First spoken update fires no earlier than this long after a delegation burst starts. */
     private static readonly FirstNarrationDelayMs = 5000;
@@ -551,6 +577,43 @@ export class RealtimeSessionRunner {
             void this.Stop();
         } finally {
             this.reconnecting = false; // reconnect settled (success/fail) — allow the next one
+        }
+    }
+
+    /**
+     * Awaits the injected {@link RealtimeSessionRunnerDeps.FlushTranscripts} drain under a hard time
+     * bound, so queued transcript writes land before the result is built without letting a stuck write
+     * hang teardown. A timeout (or a rejected drain) is logged and swallowed — finalizing with a
+     * possibly-missing tail write is strictly better than never finalizing at all.
+     */
+    private async flushTranscriptsBounded(): Promise<void> {
+        const flush = this.deps.FlushTranscripts;
+        if (!flush) {
+            return;
+        }
+        const timeoutMs = this.deps.TranscriptFlushTimeoutMs ?? RealtimeSessionRunner.DefaultTranscriptFlushTimeoutMs;
+        let timer: ReturnType<typeof setTimeout> | null = null;
+        try {
+            await Promise.race([
+                flush(),
+                new Promise<void>((resolve) => {
+                    timer = setTimeout(() => {
+                        this.logError(
+                            `Timed out after ${timeoutMs}ms draining queued transcript writes; finalizing anyway (a tail write may be lost).`,
+                            'flushing transcripts'
+                        );
+                        resolve();
+                    }, timeoutMs);
+                    // Never hold the process open purely for this guard timer.
+                    (timer as unknown as { unref?: () => void }).unref?.();
+                }),
+            ]);
+        } catch (error) {
+            this.logError(error, 'flushing transcripts');
+        } finally {
+            if (timer) {
+                clearTimeout(timer);
+            }
         }
     }
 
@@ -918,6 +981,10 @@ export class RealtimeSessionRunner {
         } finally {
             this.session = null;
         }
+
+        // Drain queued transcript writes now that the socket is closed and no new frames can arrive.
+        // Bounded — a stuck write must not wedge teardown (see FlushTranscripts).
+        await this.flushTranscriptsBounded();
 
         // Finalize the recording AFTER the socket is closed: stop accumulating, then encode → store →
         // stamp the session. A recording failure is logged inside FinalizeRecording and must never fail


### PR DESCRIPTION
## What

Fixes a **concurrency race that persisted a realtime transcript turn twice**. Found by live testing against Grok, not by review.

## The bug

The session runner dispatches provider transcript frames **fire-and-forget**:

```ts
session.OnTranscript((t) => { if (this.session === session) void this.handleTranscript(t); });
```

so frames for the same role are processed **concurrently**. `persistRealtimeTranscript` then did a check-then-act on the in-flight turn map that spans `await`s (`GetEntityObject` → `Load` → `Save`):

```ts
const inFlight = this.realtimeInFlightTurns.get(roleKey);   // read
...await GetEntityObject / Load / Save...                   // yields
this.realtimeInFlightTurns.set(roleKey, {...});             // write
```

Two captions arriving a few ms apart both observe "no tracked row yet", both take the create branch, and the turn is written twice.

## Evidence from the live session

One user utterance produced **two byte-identical 134-char rows**:

| Row | Created | Updated |
|---|---|---|
| `17691F4D` | 11:30:45.883 | 11:30:**51.920** |
| `9F464E81` | 11:30:**51.903** | 11:30:51.903 |

The duplicate was created **17ms *before*** the first row's final update — the writes overlap, which is the signature of concurrency rather than a sequencing bug. It hit once in six turns, consistent with a timing-dependent race.

Streamed-caption providers (Grok) are most exposed since they emit many finals per turn, but the *interim-racing-its-own-final* variant applies to any provider.

## The fix

Chain each role's persist calls through a promise queue so the read-modify-write is atomic with respect to other frames of the **same** role:

- Roles stay **independent** (separate tracked rows) and are not serialized against each other.
- The chain uses `.then(run, run)` so a **failing frame never strands** the rest of the queue.
- The stored link swallows outcomes so a parked rejection can't surface as an unhandled promise rejection.
- The queue map is reset per session alongside the turn map.

## Tests

Four concurrency cases driving **non-awaited** frames (the whole point):

1. Overlapping streamed captions → ONE row
2. An interim racing its own final → ONE row
3. Cross-role independence (user + assistant overlap) → one row each
4. A failing frame doesn't strand the role queue

**Three fail against the pre-fix code** (verified by bypassing the queue and re-running). The existing suite could not catch this class of bug — it awaited every persist call sequentially, so production concurrency was never exercised. That gap is now closed.

## Verification

- `@memberjunction/ai-agents` builds clean (turbo 59/59)
- **ai-agents 1682 passing**