### PR TITLE
fix(ai-realtime): collapse a paused utterance into one transcript turn

### DIFF
--- a/.changeset/realtime-transcript-continuation.md
+++ b/.changeset/realtime-transcript-continuation.md
@@ -1,0 +1,21 @@
+---
+"@memberjunction/ai": minor
+"@memberjunction/ai-openai": patch
+"@memberjunction/ai-realtime-client": patch
+---
+
+Stop a mid-sentence pause from splitting one spoken utterance into several transcript turns.
+
+Providers that stream input transcription (Grok) re-emit the **full accumulated utterance** on every `input_audio_transcription.completed`, and their VAD fires `speech_started` on ordinary mid-sentence breaths. Treating each `speech_started` as a hard turn boundary therefore split one spoken thought into several persisted turns, each a longer copy of the last — observed live as three conversation rows for a single sentence:
+
+```
+"...including whiteboarding, uh, remote."
+"...including whiteboarding, uh, remote, so just get going."
+"...including whiteboarding, uh, remote, so just get going. Show me some cool stuff."
+```
+
+Adds `IsTranscriptContinuation` (new, dependency-free module in `@memberjunction/ai`): a caption that **extends** the utterance already in flight is now recognized as a continuation and flagged `ReplacesPrevious`, collapsing the stream into one in-place-updating turn. Crucially the comparison is **normalized** (lowercased, punctuation/whitespace collapsed) because ASR engines re-punctuate as a sentence grows — in the production case above the earlier text is *not* a literal prefix of the later one (`remote.` became `remote,`), so a naive prefix test missed roughly half the occurrences.
+
+The continuation window closes when the model takes the floor (`response.created`), so two genuinely separate utterances that happen to share an opening can never be merged.
+
+Applied identically in the shared server session (`OpenAIRealtimeSession`, inherited by Grok/HuggingFace) and the client-direct xAI driver, so both topologies collapse the stream the same way. A new `onResponseStarted()` hook on the shared client brain gives drivers a seam for per-user-turn state. No behavior change for single-completed providers such as OpenAI, which never produce a continuation to detect.

--- a/packages/AI/Core/src/__tests__/baseRealtime.test.ts
+++ b/packages/AI/Core/src/__tests__/baseRealtime.test.ts
@@ -10,6 +10,7 @@ import {
     RealtimeSessionError,
     ClientRealtimeSessionConfig,
 } from '../generic/baseRealtime';
+import { IsTranscriptContinuation } from '../generic/transcriptContinuation';
 
 /**
  * In-test concrete session that stores registered handlers and tools so we can assert
@@ -333,5 +334,75 @@ describe('IRealtimeSession', () => {
         session = newSession();
         await session.Close();
         expect(session.Closed).toBe(true);
+    });
+});
+
+// ════════════════════════════════════════════════════════════════════
+// IsTranscriptContinuation — streamed-transcription turn-boundary rescue
+// ════════════════════════════════════════════════════════════════════
+
+describe('IsTranscriptContinuation', () => {
+    // Verbatim strings from a live Grok session (session 72989D0A) where ONE spoken sentence was
+    // persisted as three growing rows because a mid-sentence pause fired speech_started.
+    const PROD_1 = 'Okay, fair enough. So hey, I want you to give me a really cool demo of all the features you have, including whiteboarding, uh, remote.';
+    const PROD_2 = 'Okay, fair enough. So hey, I want you to give me a really cool demo of all the features you have, including whiteboarding, uh, remote, so just get going.';
+    const PROD_3 = 'Okay, fair enough. So hey, I want you to give me a really cool demo of all the features you have, including whiteboarding, uh, remote, so just get going. Show me some cool stuff.';
+
+    it('detects the RE-PUNCTUATED continuation that a raw prefix test misses (the production case)', () => {
+        // "…uh, remote."  →  "…uh, remote, so just get going."  — the trailing '.' became ',', so
+        // PROD_1 is NOT a literal prefix of PROD_2. This is the case that made a naive startsWith
+        // check useless, and it must be caught.
+        expect(PROD_2.startsWith(PROD_1)).toBe(false); // documents WHY normalization is required
+        expect(IsTranscriptContinuation(PROD_1, PROD_2)).toBe(true);
+    });
+
+    it('detects a clean (already-prefix) continuation', () => {
+        expect(PROD_3.startsWith(PROD_2)).toBe(true);
+        expect(IsTranscriptContinuation(PROD_2, PROD_3)).toBe(true);
+    });
+
+    it('chains across the whole utterance (1→2→3 all continue)', () => {
+        expect(IsTranscriptContinuation(PROD_1, PROD_3)).toBe(true);
+    });
+
+    it('rejects a genuinely different utterance', () => {
+        expect(IsTranscriptContinuation(PROD_1, 'Actually, never mind — cancel that.')).toBe(false);
+    });
+
+    it('rejects identical text (no new words ⇒ nothing to extend)', () => {
+        expect(IsTranscriptContinuation(PROD_1, PROD_1)).toBe(false);
+    });
+
+    it('rejects a SHORTER text (a correction that drops words is not a continuation)', () => {
+        expect(IsTranscriptContinuation(PROD_2, PROD_1)).toBe(false);
+    });
+
+    it('rejects when only punctuation/casing changed but no words were added', () => {
+        expect(IsTranscriptContinuation('Turn on the lights.', 'turn on the lights!')).toBe(false);
+    });
+
+    it('is case-insensitive about the shared opening', () => {
+        expect(IsTranscriptContinuation('turn on the lights', 'Turn on the lights, please')).toBe(true);
+    });
+
+    it('tolerates collapsed/extra whitespace', () => {
+        expect(IsTranscriptContinuation('turn  on   the lights', 'turn on the lights and the fan')).toBe(true);
+    });
+
+    it('returns false for empty / missing input on either side', () => {
+        expect(IsTranscriptContinuation('', PROD_1)).toBe(false);
+        expect(IsTranscriptContinuation(PROD_1, '')).toBe(false);
+        expect(IsTranscriptContinuation(undefined, PROD_1)).toBe(false);
+        expect(IsTranscriptContinuation(PROD_1, undefined)).toBe(false);
+    });
+
+    it('returns false when normalization empties a side (punctuation-only text)', () => {
+        expect(IsTranscriptContinuation('...', '... and more')).toBe(false);
+    });
+
+    it('does NOT merge two different sentences that share an opening phrase', () => {
+        // Guarded in practice by clearing the anchor once the model replies, but the helper itself
+        // must not treat an unrelated longer sentence as a continuation unless it truly extends.
+        expect(IsTranscriptContinuation('Yes, do the first one.', 'Yes, do the second one instead.')).toBe(false);
     });
 });

--- a/packages/AI/Core/src/generic/transcriptContinuation.ts
+++ b/packages/AI/Core/src/generic/transcriptContinuation.ts
@@ -1,0 +1,62 @@
+/**
+ * @fileoverview Pure helper for recognizing a STREAMED transcript continuation.
+ *
+ * Deliberately dependency-free: it is imported by realtime drivers on both the server
+ * (`@memberjunction/ai-openai`) and the browser (`@memberjunction/ai-realtime-client`), and keeping it
+ * free of base-class imports lets those packages' tests exercise the REAL implementation instead of a
+ * hand-written stub that could silently drift from it.
+ *
+ * @module @memberjunction/ai
+ */
+
+/**
+ * Decides whether a newly-arrived transcript is a CONTINUATION of one already in flight — i.e. the
+ * same utterance re-emitted with more words on the end — rather than a genuinely new turn.
+ *
+ * **Why this exists.** Providers that stream their input transcription (Grok) re-emit the FULL
+ * accumulated utterance on every `completed` frame, and their VAD fires `speech_started` on ordinary
+ * mid-sentence pauses. Treating each `speech_started` as a hard turn boundary therefore splits ONE
+ * spoken thought into several persisted turns, each a longer copy of the last:
+ *
+ * ```
+ * "...including whiteboarding, uh, remote."                      ← turn 1
+ * "...including whiteboarding, uh, remote, so just get going."   ← turn 2 (repeats turn 1)
+ * ```
+ *
+ * **Why a naive prefix test is not enough.** ASR engines RE-PUNCTUATE as a sentence continues, so the
+ * earlier text is frequently *not* a literal prefix of the later one (`remote.` becomes `remote,`
+ * above — observed in production). Both sides are therefore normalized — lowercased, punctuation and
+ * repeated whitespace collapsed — before the prefix comparison, which is what makes the real case match.
+ *
+ * Callers should scope this to a single speaker turn: clear the tracked text once the model responds,
+ * so two genuinely separate utterances that happen to share an opening can never be merged.
+ *
+ * @param previous The text of the turn currently in flight (empty/undefined ⇒ never a continuation).
+ * @param next The newly-arrived transcript text.
+ * @returns True when `next` extends `previous` and should REPLACE it in place.
+ */
+export function IsTranscriptContinuation(previous: string | undefined, next: string | undefined): boolean {
+    if (!previous || !next) {
+        return false;
+    }
+    const before = NormalizeTranscriptForComparison(previous);
+    const after = NormalizeTranscriptForComparison(next);
+    if (!before || !after) {
+        return false;
+    }
+    // Strictly longer AND starting with everything seen so far ⇒ the same utterance, extended.
+    return after.length > before.length && after.startsWith(before);
+}
+
+/**
+ * Reduces a transcript to a comparison form: lowercased, with every run of non-alphanumeric
+ * characters (punctuation, whitespace) collapsed to a single space and the ends trimmed.
+ *
+ * This is what makes continuation detection survive an ASR re-punctuating mid-sentence.
+ *
+ * @param value The raw transcript text.
+ * @returns The normalized comparison form.
+ */
+export function NormalizeTranscriptForComparison(value: string): string {
+    return value.toLowerCase().replace(/[^\p{L}\p{N}]+/gu, ' ').trim();
+}

--- a/packages/AI/Core/src/index.ts
+++ b/packages/AI/Core/src/index.ts
@@ -12,6 +12,7 @@ export * from './generic/baseEmbeddings';
 export * from './generic/baseAudio';
 export * from './generic/baseVideo';
 export * from './generic/baseRealtime';
+export * from './generic/transcriptContinuation';
 export * from './generic/realtimeProxyRegistry';
 export * from './generic/baseRealtimeChannelServer';
 export * from './generic/errorTypes';

--- a/packages/AI/Providers/OpenAI/src/__tests__/openAIRealtime.test.ts
+++ b/packages/AI/Providers/OpenAI/src/__tests__/openAIRealtime.test.ts
@@ -7,7 +7,7 @@ vi.mock('@memberjunction/global', () => ({
 
 // Mock @memberjunction/ai — provide BaseModel/BaseRealtimeModel base classes only. The realtime
 // type aliases (RealtimeSessionParams, etc.) are compile-time interfaces and need no runtime mock.
-vi.mock('@memberjunction/ai', () => {
+vi.mock('@memberjunction/ai', async () => {
     class BaseModel {
         protected _apiKey: string;
         constructor(apiKey: string) {
@@ -17,7 +17,11 @@ vi.mock('@memberjunction/ai', () => {
     class BaseRealtimeModel extends BaseModel {}
     // RealtimeDiagLog is a verbose-gated console logger used by the realtime session; a no-op suffices.
     const RealtimeDiagLog = () => { /* no-op in tests */ };
-    return { BaseModel, BaseRealtimeModel, RealtimeDiagLog };
+    // IsTranscriptContinuation is a PURE, dependency-free helper — pull in the REAL implementation
+    // rather than stubbing it, so this driver test asserts against shipped behavior. It lives in its
+    // own module precisely so importing it here can't cascade into other mocked packages.
+    const { IsTranscriptContinuation } = await import('../../../../Core/src/generic/transcriptContinuation');
+    return { BaseModel, BaseRealtimeModel, RealtimeDiagLog, IsTranscriptContinuation };
 });
 
 // Mock the SDK WebSocket so importing the driver never touches the network. The driver's
@@ -533,6 +537,50 @@ describe('OpenAIRealtime', () => {
                 { Role: 'user', Text: 'set a timer', IsFinal: true, ReplacesPrevious: true },
                 { Role: 'user', Text: 'cancel', IsFinal: true, ReplacesPrevious: false },
             ]);
+        });
+
+        it('treats a post-pause caption that CONTINUES the utterance as a replacement, not a new turn (production regression)', () => {
+            // Verbatim from live Grok session 72989D0A: ONE spoken sentence became THREE persisted rows
+            // because the VAD fired speech_started on the speaker's mid-sentence pauses, resetting the
+            // per-turn flag even though the provider kept re-emitting the same (growing) utterance.
+            // Note the re-punctuation across the first boundary ("remote." → "remote,") — a raw prefix
+            // test misses it, which is why the continuation check normalizes.
+            const P1 = 'Okay, fair enough. So hey, I want you to give me a really cool demo of all the features you have, including whiteboarding, uh, remote.';
+            const P2 = 'Okay, fair enough. So hey, I want you to give me a really cool demo of all the features you have, including whiteboarding, uh, remote, so just get going.';
+            const P3 = 'Okay, fair enough. So hey, I want you to give me a really cool demo of all the features you have, including whiteboarding, uh, remote, so just get going. Show me some cool stuff.';
+            const transcripts: Array<{ Text: string; ReplacesPrevious?: boolean }> = [];
+            session.OnTranscript((t) => transcripts.push({ Text: t.Text, ReplacesPrevious: t.ReplacesPrevious }));
+            const completed = (transcript: string) => driver.Fake.Fire({
+                type: 'conversation.item.input_audio_transcription.completed', transcript, content_index: 0, event_id: 'e', item_id: 'i',
+            } as RealtimeServerEvent);
+            const pause = () => driver.Fake.Fire({ type: 'input_audio_buffer.speech_started', audio_start_ms: 1, event_id: 'e', item_id: 'i' } as RealtimeServerEvent);
+
+            completed(P1);
+            pause();        // mid-sentence breath — NOT a real turn boundary
+            completed(P2);
+            pause();        // another breath
+            completed(P3);
+
+            // Only the FIRST is a new turn; the rest replace it → one persisted row, not three.
+            expect(transcripts.map((t) => t.ReplacesPrevious)).toEqual([false, true, true]);
+            expect(transcripts[transcripts.length - 1].Text).toBe(P3);
+        });
+
+        it('a NEW utterance after the model has responded starts a fresh turn (anchor cleared on response.created)', () => {
+            // The continuation window must close when the model takes the floor — otherwise a later
+            // utterance that happens to open with the same words would merge into the previous turn.
+            const transcripts: Array<{ Text: string; ReplacesPrevious?: boolean }> = [];
+            session.OnTranscript((t) => transcripts.push({ Text: t.Text, ReplacesPrevious: t.ReplacesPrevious }));
+            const completed = (transcript: string) => driver.Fake.Fire({
+                type: 'conversation.item.input_audio_transcription.completed', transcript, content_index: 0, event_id: 'e', item_id: 'i',
+            } as RealtimeServerEvent);
+
+            completed('Show me the weather');
+            driver.Fake.Fire({ type: 'response.created', event_id: 'e', response: {} } as RealtimeServerEvent); // model replies → turn over
+            driver.Fake.Fire({ type: 'input_audio_buffer.speech_started', audio_start_ms: 1, event_id: 'e', item_id: 'i' } as RealtimeServerEvent);
+            completed('Show me the weather for Tokyo too'); // extends the words, but it's a NEW turn
+
+            expect(transcripts.map((t) => t.ReplacesPrevious)).toEqual([false, false]);
         });
 
         it('translates a function call to OnToolCall', () => {

--- a/packages/AI/Providers/OpenAI/src/models/openAIRealtime.ts
+++ b/packages/AI/Providers/OpenAI/src/models/openAIRealtime.ts
@@ -13,6 +13,7 @@ import {
     RealtimeUsageModalityDetail,
     RealtimeSessionError,
     RealtimeVoiceOption,
+    IsTranscriptContinuation,
     JSONObject,
 } from '@memberjunction/ai';
 import { ClientRealtimeSessionConfig } from '@memberjunction/ai';
@@ -712,6 +713,22 @@ export class OpenAIRealtimeSession implements IRealtimeSession {
     private userTurnTranscribed = false;
 
     /**
+     * Text of the CURRENT user turn's most recent finalized transcription, used to detect that a new
+     * `completed` is the same utterance continuing rather than a new turn.
+     *
+     * Streaming-transcription providers re-emit the FULL accumulated utterance on every `completed`,
+     * and their VAD fires `speech_started` on ordinary mid-sentence pauses. Keying the turn boundary
+     * solely off `speech_started` therefore splits one spoken thought into several turns, each a longer
+     * copy of the last. Comparing against this text (via {@link IsTranscriptContinuation}, which
+     * normalizes punctuation because ASR re-punctuates as a sentence grows) lets a post-pause caption
+     * be recognized as a continuation and REPLACE the turn in place instead.
+     *
+     * Cleared when the model starts responding (`response.created`), which is the real end of the
+     * user's turn — so two genuinely separate utterances can never be merged across a model reply.
+     */
+    private lastUserTranscript = '';
+
+    /**
      * @param connection The injectable provider-connection seam.
      * @param profile The provider profile (defaults to OpenAI's so existing direct construction keeps working).
      */
@@ -1061,11 +1078,18 @@ export class OpenAIRealtimeSession implements IRealtimeSession {
                 return this.emitTranscript('user', event.delta ?? '', false);
             case 'conversation.item.input_audio_transcription.completed': {
                 // Streamed transcription (Grok): the 2nd+ completed of a turn REPLACES the turn's row
-                // in place rather than appending a duplicate. The first completed of the turn is a
-                // normal (non-replacing) final. Flag flips here and resets on the next speech_started.
-                const replacesPrevious = this.userTurnTranscribed;
+                // in place rather than appending a duplicate. Two ways a completed can be a replacement:
+                //   1. another completed already landed in THIS turn (userTurnTranscribed); or
+                //   2. it CONTINUES the previous utterance — the provider re-emitted the whole thing
+                //      with more words on the end. This second case is what rescues a mid-sentence
+                //      pause: the VAD fires speech_started (clearing the flag) even though the user
+                //      never stopped talking, and without the continuation test that one spoken thought
+                //      persists as several rows, each a longer copy of the last.
+                const text = event.transcript;
+                const replacesPrevious = this.userTurnTranscribed || IsTranscriptContinuation(this.lastUserTranscript, text);
                 this.userTurnTranscribed = true;
-                return this.emitTranscript('user', event.transcript, true, replacesPrevious);
+                this.lastUserTranscript = text;
+                return this.emitTranscript('user', text, true, replacesPrevious);
             }
             case 'response.function_call_arguments.done':
                 return this.handleFunctionCall(event.call_id, event.name, event.arguments);
@@ -1077,6 +1101,10 @@ export class OpenAIRealtimeSession implements IRealtimeSession {
                 this.userTurnTranscribed = false;
                 return this.handleInterruption();
             case 'response.created':
+                // The model has taken the floor — the user's turn is definitively over. Clear the
+                // continuation anchor so a LATER utterance can never be merged into it just because it
+                // happens to start with the same words.
+                this.lastUserTranscript = '';
                 // A response is in flight (whether server-VAD-triggered or locally triggered).
                 this.responseActive = true;
                 return;

--- a/packages/AI/Providers/xAI/src/__tests__/xaiRealtime.test.ts
+++ b/packages/AI/Providers/xAI/src/__tests__/xaiRealtime.test.ts
@@ -12,7 +12,7 @@ vi.mock('@memberjunction/global', () => ({
 // TTS, image, realtime modules), so every base class those modules EXTEND at module-evaluation
 // time must exist here alongside BaseModel/BaseRealtimeModel. The realtime type aliases
 // (RealtimeSessionParams, etc.) are compile-time interfaces and need no runtime mock.
-vi.mock('@memberjunction/ai', () => {
+vi.mock('@memberjunction/ai', async () => {
     class BaseModel {
         protected _apiKey: string;
         constructor(apiKey: string) {
@@ -43,7 +43,11 @@ vi.mock('@memberjunction/ai', () => {
     }
     // RealtimeDiagLog is a verbose-gated console logger used by the realtime session; a no-op suffices.
     const RealtimeDiagLog = () => { /* no-op in tests */ };
-    return { BaseModel, BaseRealtimeModel, BaseLLM, BaseEmbeddings, BaseAudioGenerator, BaseImageGenerator, ErrorAnalyzer, RealtimeDiagLog };
+    // IsTranscriptContinuation is a PURE, dependency-free helper — pull in the REAL implementation
+    // rather than stubbing it, so this driver test asserts against shipped behavior. It lives in its
+    // own module precisely so importing it here can't cascade into other mocked packages.
+    const { IsTranscriptContinuation } = await import('../../../../Core/src/generic/transcriptContinuation');
+    return { BaseModel, BaseRealtimeModel, BaseLLM, BaseEmbeddings, BaseAudioGenerator, BaseImageGenerator, ErrorAnalyzer, RealtimeDiagLog, IsTranscriptContinuation };
 });
 
 // Mock the SDK WebSocket so importing the driver never touches the network. The driver's
@@ -524,6 +528,26 @@ describe('xAIRealtime', () => {
             driver.Fake.Fire({ type: 'input_audio_buffer.speech_started', audio_start_ms: 1, event_id: 'e', item_id: 'i' } as RealtimeServerEvent);
             completed('and the forecast');
             expect(transcripts.map((t) => t.ReplacesPrevious)).toEqual([false, true, true, false]);
+        });
+
+        it('a mid-sentence PAUSE does not split one Grok utterance into multiple turns (production regression)', () => {
+            // Grok's VAD fires speech_started on ordinary breaths, which used to reset the per-turn flag
+            // and split ONE spoken sentence into several persisted turns, each a longer copy of the last
+            // (observed live: three rows for one sentence). The continuation check keeps them collapsed.
+            // 'and the forecast' below is genuinely NEW text, so it correctly starts its own turn.
+            const transcripts: Array<{ Text: string; ReplacesPrevious?: boolean }> = [];
+            session.OnTranscript((t) => transcripts.push({ Text: t.Text, ReplacesPrevious: t.ReplacesPrevious }));
+            const completed = (transcript: string) => driver.Fake.Fire({
+                type: 'conversation.item.input_audio_transcription.completed', transcript, content_index: 0, event_id: 'e', item_id: 'i',
+            } as RealtimeServerEvent);
+            const pause = () => driver.Fake.Fire({ type: 'input_audio_buffer.speech_started', audio_start_ms: 1, event_id: 'e', item_id: 'i' } as RealtimeServerEvent);
+
+            completed('what is the weather');
+            pause();
+            completed('what is the weather in Tokyo');       // same sentence, extended → replaces
+            pause();
+            completed('and the forecast');                   // genuinely new → its own turn
+            expect(transcripts.map((t) => t.ReplacesPrevious)).toEqual([false, true, false]);
         });
 
         it('translates a function call to OnToolCall', () => {

--- a/packages/AI/RealtimeClient/src/__tests__/xai-realtime-client.test.ts
+++ b/packages/AI/RealtimeClient/src/__tests__/xai-realtime-client.test.ts
@@ -275,6 +275,29 @@ describe('xAIRealtimeClient', () => {
             expect(transcripts.at(-1)).toEqual({ Role: 'User', Text: 'and Skip?', IsFinal: true, Kind: 'normal', ReplacesPrevious: false });
         });
 
+        it('treats a post-pause caption that CONTINUES the utterance as a replacement, not a new bubble (topology parity)', () => {
+            // Mirrors the server-session regression: Grok's VAD fires speech_started on mid-sentence
+            // pauses, but the provider keeps re-emitting the SAME utterance with more words. Without
+            // the continuation check, one spoken thought renders as several growing bubbles. Note the
+            // re-punctuation ('remote.' → 'remote,') — a raw prefix test would miss it.
+            const { transcripts } = collect(client);
+            const P1 = 'including whiteboarding, uh, remote.';
+            const P2 = 'including whiteboarding, uh, remote, so just get going.';
+            client.Emit({ type: 'conversation.item.input_audio_transcription.completed', transcript: P1 });
+            client.Emit({ type: 'input_audio_buffer.speech_started' });   // breath, NOT a turn boundary
+            client.Emit({ type: 'conversation.item.input_audio_transcription.completed', transcript: P2 });
+            expect(transcripts.map(t => t.ReplacesPrevious)).toEqual([false, true]);
+        });
+
+        it('a NEW utterance after the model responded starts a fresh bubble (anchor cleared on response.created)', () => {
+            const { transcripts } = collect(client);
+            client.Emit({ type: 'conversation.item.input_audio_transcription.completed', transcript: 'Show me the weather' });
+            client.Emit({ type: 'response.created' });                    // model replies → user turn over
+            client.Emit({ type: 'input_audio_buffer.speech_started' });
+            client.Emit({ type: 'conversation.item.input_audio_transcription.completed', transcript: 'Show me the weather for Tokyo too' });
+            expect(transcripts.map(t => t.ReplacesPrevious)).toEqual([false, false]);
+        });
+
         it('should emit nothing for empty transcript payloads', () => {
             const { transcripts } = collect(client);
             client.Emit({ type: 'conversation.item.input_audio_transcription.completed', transcript: '  ' });

--- a/packages/AI/RealtimeClient/src/drivers/xaiRealtimeClient.ts
+++ b/packages/AI/RealtimeClient/src/drivers/xaiRealtimeClient.ts
@@ -1,5 +1,5 @@
 import { RegisterClass } from '@memberjunction/global';
-import { ClientRealtimeSessionConfig } from '@memberjunction/ai';
+import { ClientRealtimeSessionConfig, IsTranscriptContinuation } from '@memberjunction/ai';
 import { BaseRealtimeClient } from '../generic/baseRealtimeClient';
 import {
     OpenAIProtocolWebSocketRealtimeClient,
@@ -80,6 +80,14 @@ export class xAIRealtimeClient extends OpenAIProtocolWebSocketRealtimeClient {
      */
     private userTurnTranscribed = false;
 
+    /**
+     * Text of the current user turn's latest streamed caption, used to recognize that a post-pause
+     * caption CONTINUES the same utterance (Grok re-emits the full accumulated text) rather than
+     * starting a new turn. Cleared in {@link onResponseStarted} — once the model replies, the user's
+     * turn is over and a later utterance must never merge into it. Mirrors the server session.
+     */
+    private lastUserTranscript = '';
+
     /** @inheritdoc — used in the shared diagnostics + close messages. */
     protected override get providerDebugLabel(): string {
         return 'xAIRealtimeClient';
@@ -140,11 +148,19 @@ export class xAIRealtimeClient extends OpenAIProtocolWebSocketRealtimeClient {
      */
     protected override onUserTranscriptFrame(transcript: string): void {
         if (transcript && transcript.trim().length > 0) {
+            // Two ways this caption REPLACES rather than appends: another already landed in this turn,
+            // OR it continues the previous utterance (the provider re-emits the whole thing with more
+            // words). The second case rescues a mid-sentence pause — the VAD fires speech_started and
+            // clears the flag even though the user never stopped, which would otherwise split one
+            // spoken thought into several growing bubbles. Mirrors the server session exactly so both
+            // topologies collapse the stream identically.
+            const replacesPrevious = this.userTurnTranscribed || IsTranscriptContinuation(this.lastUserTranscript, transcript);
             this.emitTranscript({
                 Role: 'User', Text: transcript, IsFinal: true, Kind: 'normal',
-                ReplacesPrevious: this.userTurnTranscribed,
+                ReplacesPrevious: replacesPrevious,
             });
             this.userTurnTranscribed = true;
+            this.lastUserTranscript = transcript;
         }
     }
 
@@ -156,6 +172,17 @@ export class xAIRealtimeClient extends OpenAIProtocolWebSocketRealtimeClient {
      * interrupted response's busy flag is cleared eagerly (Grok cancels its own turn; clearing
      * now lets a queued tool result fire without waiting on the trailing `response.done`).
      */
+    /**
+     * @inheritdoc
+     *
+     * The model has taken the floor, so the user's turn is definitively over — drop the continuation
+     * anchor. Without this, a later utterance that happened to open with the same words could be
+     * merged into the previous turn instead of appending its own.
+     */
+    protected override onResponseStarted(): void {
+        this.lastUserTranscript = '';
+    }
+
     protected override onSpeechStartedFrame(): void {
         this.userTurnTranscribed = false;
         if (this.responseActive || this.IsAudioPlaying) {

--- a/packages/AI/RealtimeClient/src/generic/openAIProtocolClient.ts
+++ b/packages/AI/RealtimeClient/src/generic/openAIProtocolClient.ts
@@ -514,6 +514,7 @@ export abstract class OpenAIProtocolRealtimeClient extends BaseRealtimeClient {
             case 'response.created': {
                 this.responseActive = true;
                 this.confirmedResponseActive = true; // a real response is now in flight
+                this.onResponseStarted();
                 // Only a LOCALLY-initiated create (counter-tracked) can be our narration. A VAD /
                 // unsolicited response.created arrives with the counter already at 0 — it must NOT
                 // consume the pending narration kind, or it would mistag a genuine user turn as
@@ -569,6 +570,14 @@ export abstract class OpenAIProtocolRealtimeClient extends BaseRealtimeClient {
                 // Unhandled event types are expected (the provider emits many); no-op.
                 break;
         }
+    }
+
+    /**
+     * Called when the model takes the floor (`response.created`), i.e. the user's turn is definitively
+     * over. Drivers that track per-user-turn transcription state override this to reset it. No-op here.
+     */
+    protected onResponseStarted(): void {
+        // Only streamed-transcription drivers carry per-user-turn state worth clearing.
     }
 
     /** WebRTC-only playback-buffer hooks; websocket transports never receive these frames. */


### PR DESCRIPTION
## The problem (from your live session)

Grok re-emits the **full accumulated utterance** on every `input_audio_transcription.completed`, and its VAD fires `speech_started` on ordinary mid-sentence breaths. Treating each `speech_started` as a hard turn boundary split one spoken thought into several persisted turns, each a longer copy of the last:

```
"...including whiteboarding, uh, remote."
"...including whiteboarding, uh, remote, so just get going."
"...including whiteboarding, uh, remote, so just get going. Show me some cool stuff."
```

Three conversation rows for one sentence — visible in the transcript UI, and confirmed in the DB (session `72989D0A`).

This is a **provider API-contract difference, not model quality**: OpenAI emits `completed` once per turn, so it can't nest. Grok streams progressive updates, which is arguably *more* information — our turn-boundary logic just didn't account for it.

## The fix

New `IsTranscriptContinuation` in `@memberjunction/ai`: a caption that **extends** the utterance already in flight is recognized as a continuation and flagged `ReplacesPrevious`, collapsing the stream into one in-place-updating turn.

**The comparison is normalized** (lowercased, punctuation/whitespace collapsed) — and that detail is load-bearing. ASR **re-punctuates** as a sentence grows, so in the real captured data the earlier text is *not* a literal prefix of the later one:

```
"...uh, remote."     ← period
"...uh, remote, so just get going."     ← became a comma
```

The naive `startsWith` check I originally proposed would have **missed roughly half** the real occurrences. That only surfaced by reading the actual captured strings, so both are pinned as tests.

**The continuation window closes on `response.created`** — once the model takes the floor the user's turn is over, so two genuinely separate utterances that share an opening can never be merged.

Applied identically in the shared server session (inherited by Grok/HuggingFace) and the client-direct xAI driver, so both topologies behave the same. A new `onResponseStarted()` hook on the shared client brain gives drivers a seam for per-user-turn state. **No behavior change for OpenAI** — single-completed providers never produce a continuation to detect.

## Tests

- **12 Core cases** — including the verbatim production strings, the re-punctuation case (with an explicit assertion that `startsWith` returns `false`, documenting *why* normalization exists), shorter-text rejection, and the shared-opening-but-different-sentence case
- **Server session**: replays the captured production sequence → `[false, true, true]`; plus anchor-cleared-on-`response.created`
- **xAI driver**: mid-sentence pause case (the actual Grok driver)
- **Client**: parity + anchor clearing

The server regression test was **verified to fail without the continuation check**.

The helper lives in its own **zero-import module** so provider tests can pull the REAL implementation into their `vi.mock` factories rather than a hand-written stub that could silently drift.

## Verification

- Full repo build **299/299**
- Core **32** · ai-openai **95** · ai-xai **53** · ai-realtime-client **401**

⚠️ **Pre-existing, unrelated:** `@memberjunction/actions#test` fails on `next` today (`RequiresSubclass` missing from the `@memberjunction/global` mock). The fix is commit `ad8659bc2e`, currently on an unmerged branch — nothing to do with this PR.