### PR TITLE
chore(server): pin MagicLink provisioned-user notice as deliberate default-log policy

### DIFF
--- a/.changeset/magic-link-provision-log-policy.md
+++ b/.changeset/magic-link-provision-log-policy.md
@@ -1,0 +1,5 @@
+---
+"@memberjunction/server": patch
+---
+
+Pin the MagicLink provisioned-external-user notice as a deliberate default-log line. Following the startup-notice cleanup that made the ephemeral-keypair and provider-registered messages verbose-only, this documents at the call site why the provisioning notice in `MagicLinkService.createScopedUser` is intentionally NOT verbose-gated — provisioning an external account via magic-link redemption is a security-relevant event that belongs in the default server log — and adds a unit test asserting it still emits with `MJ_VERBOSE` unset, so a future log-cleanup sweep cannot silently quiet it. No runtime behavior change.

--- a/packages/MJServer/src/__tests__/magicLinkService.provisionLog.test.ts
+++ b/packages/MJServer/src/__tests__/magicLinkService.provisionLog.test.ts
@@ -1,0 +1,106 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+// MagicLinkService is the imperative shell — importing it pulls the full
+// data-provider and communication stacks in at module load. Stub those out;
+// this suite only exercises provisioning's console-log behavior, so
+// @memberjunction/core (the logging implementation) stays real.
+vi.mock('@memberjunction/sqlserver-dataprovider', () => ({
+  UserCache: { Instance: { Users: [] } },
+}));
+vi.mock('@memberjunction/communication-engine', () => ({
+  CommunicationEngine: { Instance: {} },
+}));
+vi.mock('@memberjunction/communication-types', () => ({
+  Message: class {},
+}));
+vi.mock('../config.js', () => ({
+  configInfo: {},
+}));
+
+import { Metadata, type IMetadataProvider, type RoleInfo, type UserInfo } from '@memberjunction/core';
+import type { MJMagicLinkInviteEntity } from '@memberjunction/core-entities';
+import type { MagicLinkConfig } from '../config.js';
+import { MagicLinkService } from '../auth/magicLink/MagicLinkService.js';
+
+/** Minimal BaseEntity stand-in: NewRecord/Save/GetAll plus writable fields. */
+interface MockEntity {
+  NewRecord: () => void;
+  Save: () => Promise<boolean>;
+  GetAll: () => Record<string, unknown>;
+  LatestResult?: { CompleteMessage: string };
+  [field: string]: unknown;
+}
+
+function makeMockEntity(id: string): MockEntity {
+  const entity: MockEntity = {
+    NewRecord: () => {
+      entity.ID = id;
+    },
+    Save: async () => true,
+    GetAll: () => ({
+      ID: entity.ID,
+      Name: entity.Name,
+      Email: entity.Email,
+      FirstName: entity.FirstName,
+      LastName: entity.LastName,
+    }),
+  };
+  return entity;
+}
+
+describe('MagicLinkService provisioning log policy', () => {
+  const originalVerbose = process.env.MJ_VERBOSE;
+  let service: MagicLinkService;
+  let invite: MJMagicLinkInviteEntity;
+  let role: RoleInfo;
+  let contextUser: UserInfo;
+
+  beforeEach(() => {
+    const provider = {
+      BeginTransaction: async () => undefined,
+      CommitTransaction: async () => undefined,
+      RollbackTransaction: async () => undefined,
+      GetEntityObject: async (entityName: string) => makeMockEntity(`mock-${entityName}`),
+    };
+    Metadata.Provider = provider as unknown as IMetadataProvider;
+
+    service = new MagicLinkService('https://mj.example.com', {} as MagicLinkConfig);
+    invite = {
+      Email: 'guest@example.com',
+      RoleID: 'role-1',
+      ApplicationID: 'app-1',
+    } as unknown as MJMagicLinkInviteEntity;
+    role = { ID: 'role-1', Name: 'External Guest' } as RoleInfo;
+    contextUser = { ID: 'ctx-user' } as UserInfo;
+  });
+
+  afterEach(() => {
+    Metadata.Provider = null as unknown as IMetadataProvider;
+    if (originalVerbose === undefined) {
+      delete process.env.MJ_VERBOSE;
+    } else {
+      process.env.MJ_VERBOSE = originalVerbose;
+    }
+  });
+
+  async function provisionAndCollectLogs(): Promise<{ success: boolean; provisionLines: string[] }> {
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => undefined);
+    const result = await service['createScopedUser'](invite, role, contextUser);
+    const provisionLines = logSpy.mock.calls
+      .map((call) => String(call[0]))
+      .filter((line) => line.includes('[MagicLink] Provisioned'));
+    return { success: result.success, provisionLines };
+  }
+
+  // Deliberate policy (do not verbose-gate this like the startup notices in 2ddb865e40):
+  // magic-link redemption provisioning a new external account is a security-relevant
+  // event and must stay visible in the DEFAULT server log, so operators see the vector
+  // being exercised without needing MJ_VERBOSE.
+  it('emits the provisioned-user notice on the default (non-verbose) server log', async () => {
+    delete process.env.MJ_VERBOSE;
+    const { success, provisionLines } = await provisionAndCollectLogs();
+    expect(success).toBe(true);
+    expect(provisionLines).toHaveLength(1);
+    expect(provisionLines[0]).toContain("guest@example.com with role 'External Guest'");
+  });
+});

--- a/packages/MJServer/src/auth/magicLink/MagicLinkService.ts
+++ b/packages/MJServer/src/auth/magicLink/MagicLinkService.ts
@@ -549,6 +549,10 @@ export class MagicLinkService {
       // resolves this user without a full cache refresh.
       this.pushUserToCache(user, role);
 
+      // Deliberately NOT verbose-gated, unlike the MagicLink startup notices (2ddb865e40):
+      // provisioning a new external account via magic-link redemption is a security-relevant
+      // event that belongs in the default server log. At-scale deployments can revisit
+      // tapering this if volume ever makes it noise.
       LogStatus(`[MagicLink] Provisioned external user ${email} with role '${role.Name}'.`);
       return { success: true, userId: user.ID, email, firstName, lastName };
     } catch (txErr) {


### PR DESCRIPTION
Follow-up to the MagicLink log cleanup in `2ddb865e40` (PR #3185), which made the two startup notices (`MagicLinkKeys.ts` ephemeral-keypair, `MagicLinkRouter.ts` provider-registered) verbose-only. One `[MagicLink]` line remained on the default log: the provisioned-external-user notice in `MagicLinkService.createScopedUser` (`MagicLinkService.ts:552`).

The obvious next step was to gate that one too — I had that change written. Reviewer guidance went the other way: provisioning a new external account via magic-link redemption is a security-relevant event (magic links are a non-trivial vector), so this line should stay visible in the **default** server log, unlike the boot-time notices. At-scale deployments can revisit tapering if volume ever makes it noise.

This PR pins that decision so a future log-cleanup sweep can't silently reverse it:

- **`MagicLinkService.ts`** — 4-line comment at the call site explaining why this `LogStatus` is deliberately not `LogStatusEx({verboseOnly: true})`. No behavior change.
- **`magicLinkService.provisionLog.test.ts`** (new) — asserts through the real `@memberjunction/core` logging stack that a successful `createScopedUser` emits the `[MagicLink] Provisioned` notice on `console.log` with `MJ_VERBOSE` unset. Heavy transitive imports (`sqlserver-dataprovider`, `communication-engine`, `config`) are stubbed; the logging path is real, so the test fails if anyone verbose-gates or deletes the line.

The test harness was validated in both directions: with the line verbose-gated, the inverse assertion passed and this one fails — it genuinely discriminates the two behaviors rather than passing vacuously.

Evidence: new test green (`npx vitest run src/__tests__/magicLinkService.provisionLog.test.ts` — 1 passed), full MJServer suite green during development (716 passed, 0 failed, 56 skipped), `npm run build` clean.

No linked issue — this came out of a Slack thread on keeping the MJAPI default log clean; the verbose-gating half of that thread already landed in #3185.