### PR TITLE
fix(metadata): filter PG memory-manager query 'since' param through sqlDate

### DIFF
--- a/.changeset/pg-memory-manager-query-sqldate.md
+++ b/.changeset/pg-memory-manager-query-sqldate.md
@@ -1,0 +1,11 @@
+---
+"@memberjunction/ai-agents": patch
+---
+
+Filter the `since` parameter through `sqlDate` in the PostgreSQL dialect of the `GetConversationsForMemoryManager` query, which Memory Manager runs via `RunQuery` (`memory-manager-agent.ts:704`).
+
+The PG template interpolated the parameter straight into the SQL string (`>= '{{ since }}'`). The SQL Server sibling was fixed in `7cd4953574` (2026-07-18); that commit touched only `get-conversations-for-memory-manager.sql`, so the `.pg.sql` file kept the raw interpolation it has carried since it was added on 2026-04-28, and the two dialects drifted apart.
+
+`sqlDate` parses the value as a `Date`, throws on unparseable input, and returns `'${date.toISOString()}'` — it emits its own quotes, so the manual quotes in the old line were wrong twice over: the value was unfiltered, and a filtered value would have been double-quoted. The filter is dialect-agnostic (unlike `sqlBoolean` and `sqlIdentifier`, it has no platform-aware override in `RunQuerySQLFilterManager`), so the same filter is correct for both engines. The file already used `{{ agentIds | sqlIn }}`, so the filter mechanism was live here and `since` was simply the one that was missed.
+
+Metadata-only change — it reaches the database through the release's consolidated `mj sync push`, not through a migration.

--- a/metadata/queries/SQL/get-conversations-for-memory-manager.pg.sql
+++ b/metadata/queries/SQL/get-conversations-for-memory-manager.pg.sql
@@ -63,7 +63,7 @@ WHERE EXISTS (
     SELECT 1 FROM __mj."vwConversationDetails" cd_new
     WHERE cd_new."ConversationID" = c."ID"
     {% if since %}
-    AND cd_new."__mj_CreatedAt" >= '{{ since }}'
+    AND cd_new."__mj_CreatedAt" >= {{ since | sqlDate }}
     {% endif %}
 )
 


### PR DESCRIPTION
The PostgreSQL dialect of the `Get Conversations For Memory Manager` query interpolates the `since` parameter straight into the SQL string. The SQL Server half of the same query was fixed on 2026-07-18 in `7cd4953574` ("3 defects from the integration-test audit") — that commit touched only `get-conversations-for-memory-manager.sql` and left the `.pg.sql` sibling as it was, so the two dialects have been out of sync since. The PG file has carried the raw interpolation since it was added on 2026-04-28.

```sql
-- before (PG)
AND cd_new."__mj_CreatedAt" >= '{{ since }}'

-- after (PG), now matching the SS sibling
AND cd_new."__mj_CreatedAt" >= {{ since | sqlDate }}
```

`sqlDate` (`packages/MJCore/src/generic/runQuerySQLFilterImplementations.ts:109`) parses the value as a `Date`, throws on anything unparseable, and returns `'${date.toISOString()}'` — it emits its own quotes. The manual quotes in the old line were therefore wrong twice over: they left the value unfiltered, and they would have double-quoted a filtered one.

**Why `sqlDate` rather than a PG-specific filter:** `sqlBoolean` and `sqlIdentifier` both carry explicit `Default SQL Server behavior; overridden by platform-aware version in RunQuerySQLFilterManager` comments. `sqlDate` has no such override — an ISO-8601 string in single quotes is valid in both engines, so the same filter is correct for both dialects. The file already uses `{{ agentIds | sqlIn }}`, so the filter mechanism was live here; `since` was simply the one that was missed.

**Scope is deliberately this one file.** A repo-wide scan found other unfiltered interpolations — `{{ MinRating }}` / `{{ MaxRating }}` in `list-conversation-detail-feedback.sql` and `list-conversation-detail-feedback-stats.sql`, plus identifier interpolations under `external-change-detection/`. All are unchanged since `v5.48.0`, so they are pre-existing and already shipped rather than something this release introduces. They belong in separate work, not bundled here.

No related issue — found while reviewing the metadata delta during v5.49 release prep.

## Evidence

There is no test surface for the query templates themselves, so these are verified by reading the filter implementation and the consuming metadata record rather than by a test run.

| Check | Result |
|---|---|
| `sqlDate` emits its own quotes | `runQuerySQLFilterImplementations.ts:113` returns `'${date.toISOString()}'` |
| `sqlDate` is not platform-overridden | no override comment, unlike `sqlBoolean:117` and `sqlIdentifier:128` |
| Dialects now match | PG `:66` and SS `:70` are both `>= {{ since \| sqlDate }}` |
| No test or snapshot pins the old string | grep for the old literal across `*.ts` / `*.json` / `*.snap` returned no matches |
| The change reaches the database | `metadata/queries/.get-conversations-for-memory-manager.json:21` `@file:`-references this path |
| SS fix did not cover PG | `git show --stat 7cd4953574` lists only the `.sql` file |

## Merge order

**This needs to land on `next` before the v5.49 metadata sync push.** Files under `metadata/**` are not in any database until `mj sync push` runs, and that push is what generates the release's consolidated `Metadata_Sync.sql`. If the sync runs first, the unfiltered template is baked into the release migration and the migration has to be regenerated.

Changeset: `patch` on `@memberjunction/ai-agents`, the package that consumes this query (`memory-manager-agent.ts:704` runs it by name via `RunQuery`). No migration is added, so `changes.yml`'s minor-changeset requirement does not apply.
