### PR TITLE
fix(ci): skip private packages in the npm-existence publish gate

### DIFF
--- a/.changeset/validate-npm-packages-skip-private.md
+++ b/.changeset/validate-npm-packages-skip-private.md
@@ -1,0 +1,11 @@
+---
+"@memberjunction/integration-test-suite": patch
+---
+
+Skip `private: true` packages in `validate-npm-packages.sh`, the `publish.yml` gate that checks every `@memberjunction/*` package already exists on npm.
+
+The gate exists to predict whether `npm run change publish` will succeed, but it filtered only on the `@memberjunction/` scope and never read `.private`. Changesets never publishes a private package (`@changesets/cli`: `packages.filter(pkg => !pkg.packageJson.private)`), so for a private package the gate was asking a question with no bearing on the outcome it gates, and failing the release over the answer.
+
+The gap had been masked by workarounds rather than hit: `@memberjunction/mobile-app` and `@memberjunction/ng-test-utils` are both `private: true` yet sit on npm at `0.0.0` and `0.0.1`, throwaway placeholders published purely to satisfy this check. They have stayed frozen at those versions ever since while the in-repo versions moved on, which is what a placeholder for a private package always decays into. `@memberjunction/integration-test-suite` is the first private package added since, so v5.49.0 is the first release where the gate actually fails.
+
+Skips are logged rather than silent, so an accidental `"private": true` on a package that should ship is still visible in CI output — preserving the only real signal the old behavior provided, without blocking the release on it. The gate still fails correctly for genuinely missing public packages.

--- a/.github/scripts/validate-npm-packages.sh
+++ b/.github/scripts/validate-npm-packages.sh
@@ -24,6 +24,7 @@ new_packages=()
 missing_count=0
 checked_count=0
 mj_checked_count=0
+private_skipped_count=0
 total_count=$(echo "$packages" | wc -l | tr -d ' ')
 error_count=0
 max_errors=5
@@ -96,6 +97,19 @@ for pkg_file in $packages; do
     continue
   fi
 
+  # Skip packages marked private. This gate exists to predict whether `npm run change publish`
+  # will succeed, and changesets never publishes a private package
+  # (@changesets/cli: `packages.filter(pkg => !pkg.packageJson.private)`), so requiring an npm
+  # entry for one asks a question that has no bearing on the outcome it gates.
+  # Logged rather than silent so an accidental `"private": true` is still visible in CI output.
+  # A jq failure yields an empty string here, which falls through to the normal npm check --
+  # the conservative direction.
+  if [[ "$(jq -r '.private // false' "$pkg_file" 2>/dev/null)" == "true" ]]; then
+    echo "   ⏭️  $pkg_name - private, never published (skipped)"
+    private_skipped_count=$((private_skipped_count + 1))
+    continue
+  fi
+
   mj_checked_count=$((mj_checked_count + 1))
 
   # Show progress every 10 packages (more frequent updates)
@@ -130,7 +144,10 @@ done
 # Report results
 if [ $missing_count -eq 0 ]; then
   echo ""
-  echo "✅ All $mj_checked_count @memberjunction packages exist on npm"
+  echo "✅ All $mj_checked_count publishable @memberjunction packages exist on npm"
+  if [ $private_skipped_count -gt 0 ]; then
+    echo "   ($private_skipped_count private package(s) skipped - never published)"
+  fi
   exit 0
 else
   echo "❌ Found $missing_count package(s) without npm placeholders:"


### PR DESCRIPTION
`publish.yml` runs `validate-npm-packages.sh` to check that every `@memberjunction/*` package already exists on npm, because OIDC trusted publishing cannot create a brand-new package name from CI. The gate filtered on one condition — the name starts with `@memberjunction/` — and never read `.private`.

That makes it wrong about its own question. The gate exists to predict whether `npm run change publish` will succeed, and changesets never publishes a private package:

```js
// node_modules/@changesets/cli/dist/changesets-cli.cjs.js:850
const publicPackages = packages.filter(pkg => !pkg.packageJson.private);
```

So for a `private: true` package the gate was asking something with no bearing on the outcome it gates, and failing the release over the answer.

```bash
if [[ "$(jq -r '.private // false' "$pkg_file" 2>/dev/null)" == "true" ]]; then
  echo "   ⏭️  $pkg_name - private, never published (skipped)"
  private_skipped_count=$((private_skipped_count + 1))
  continue
fi
```

## Why this surfaced now

The gap was masked by workarounds rather than hit. `@memberjunction/mobile-app` and `@memberjunction/ng-test-utils` are both `private: true` yet sit on npm at `0.0.0` and `0.0.1` — throwaway placeholders published purely to satisfy this check, then frozen forever while the in-repo versions moved on. `ng-test-utils` is at `5.48.0` in-repo, carries a `minor` changeset this release, and will still be `0.0.1` on npm afterwards. That is what a placeholder for a private package always decays into.

`@memberjunction/integration-test-suite` is the first private package added since, so v5.49.0 is the first release where the gate actually fails.

## Design choices worth defending

**Logged, not silent.** The old behavior had one accidental virtue: a package marked `private` by mistake got noticed. Logging the skip keeps that signal while removing the release block. It is also strictly better than before, where the signal only fired on `main` after the release PR merged — the worst place for it.

**A `jq` failure falls through to the npm check rather than to skip.** An unparseable `package.json` yields an empty string, which is not `"true"`, so the package is still checked. Conservative direction.

**The success line now says `publishable`** and reports the skipped count, so the number is not quietly wrong about what it verified.

**Not a new exclusion list.** `private: true` is npm's own declaration for this and is the exact field changesets reads. A separate list would be a second source of truth that drifts — someone adds a private package, forgets the list, and the gate fails again in a new place.

## Evidence

Ran the real gate script against the real registry, before and after.

**Before** (recorded earlier in this release prep):

```
❌ @memberjunction/integration-test-suite - NOT FOUND on npm
❌ Found 2 package(s) without npm placeholders:
  - @memberjunction/testing-integration
  - @memberjunction/integration-test-suite
```

**After** — all three private packages skipped, and the genuinely-missing public package still caught:

```
   ⏭️  @memberjunction/mobile-app - private, never published (skipped)
   ⏭️  @memberjunction/ng-test-utils - private, never published (skipped)
❌ @memberjunction/testing-integration - NOT FOUND on npm
   ⏭️  @memberjunction/integration-test-suite - private, never published (skipped)

❌ Found 1 package(s) without npm placeholders:

  - @memberjunction/testing-integration
```

Exit code `1`, down from `2` missing before the change. The full sweep covered 306 `package.json` files against the live registry.

Those two adjacent lines are the whole proof: the private package is skipped, and the gate is **not** blunted — it still fails on `@memberjunction/testing-integration`, which is public, is a hard `dependencies` entry of the published `server-bootstrap` and `testing-cli`, and genuinely needs its npm placeholder. This PR does not paper over that; it is being handled separately as DEPLOYMENT.md Step 5.

`bash -n` parses clean. `shellcheck` is not installed locally, so it was not run.

There is no test harness for this script — `.github/scripts/__tests__` covers only `check-esm-imports.mjs`, since this one is network-bound on `npm view`. Making it unit-testable would mean parameterising the hardcoded `packages` root, which is not work worth doing inside a release. Verified empirically against the real gate instead.

## Scope

Does not remove the need for a placeholder for `@memberjunction/testing-integration` — that one is public and forced by two published dependents. It removes the need for a **third throwaway placeholder for a package that must never be published**, and for every private package added after this one.

Changeset: `patch` on `@memberjunction/integration-test-suite`, matching the precedent set by the `repository.url` fix on the same package. It is `private`, so changesets versions it in-repo and publishes nothing.
