### PR TITLE
feat(metadata): add Gemini 3.6 Flash and Gemini 3.5 Flash-Lite

### DIFF
--- a/.changeset/gemini-3-6-flash-and-3-5-flash-lite.md
+++ b/.changeset/gemini-3-6-flash-and-3-5-flash-lite.md
@@ -1,0 +1,19 @@
+---
+"@memberjunction/ai": minor
+---
+
+Add the **Gemini 3.6 Flash** (`gemini-3.6-flash`) and **Gemini 3.5 Flash-Lite** (`gemini-3.5-flash-lite`) AI models to the model catalog metadata.
+
+Both shipped GA/Stable on July 21, 2026 and are driven by the existing `GeminiLLM` / `VertexLLM` / `OpenRouterLLM` drivers. Each is registered with Google and Vertex AI as Model Developer + Inference Provider plus an OpenRouter inference row, and chained via `PriorVersionID` to its predecessor.
+
+- **Gemini 3.6 Flash** (`PriorVersionID` → Gemini 3.5 Flash) — a token-efficiency refresh, not a new capability tier; the model card states it "is based on Gemini 3.5 Flash" and defers architecture, training data, and safety policy to the 3.5 Flash card. 1,048,576 input / 65,536 output tokens, thinking supported, knowledge cutoff March 2026. Output drops to `$7.50`/1M from 3.5 Flash's `$9.00` while emitting ~17% fewer output tokens; input is unchanged at `$1.50`/1M. Cache read `$0.15`/1M (0.1× input, Gemini Family A), no cache-write charge. Leads on computer use (OSWorld-Verified 83.0), chart reasoning, and long-context recall; trails frontier models on SWE-Bench Pro and Terminal-bench 2.1. Live API and image/audio generation are not supported.
+- **Gemini 3.5 Flash-Lite** (`PriorVersionID` → Gemini 3.1 Flash-Lite) — cost-optimized tier at `$0.30`/`$2.50` per 1M, cache read `$0.03`/1M (0.1× input). Same 1M/64K token envelope with configurable thinking levels; 74.0 on OSWorld-Verified. Prices text, image, video **and** audio input at one unified rate — a departure from Gemini 2.5 Flash and 3.1 Flash-Lite, which charged an audio premium. Google is the only real inference host: OpenRouter is a router whose upstreams resolve to Google AI Studio and Vertex only, so there is no third-party failover path.
+
+Neither model is context-length tiered — both are flat-rate across the full 1M window, unlike the Pro line.
+
+Two notes carried in the cost-row `Comments` for whoever reads this later:
+
+- **Do not route Gemini 3.6 Flash via the `gemini-flash-latest` alias.** The Gemini API changelog only ever repointed that alias to `gemini-3.5-flash` (May 19, 2026); the July 21 entry does not repoint it. Traffic assuming otherwise silently lands on 3.5 Flash at `$9.00`/1M output — a 20% overspend. Pin the explicit id.
+- **Same-day-launch recency.** Specs and pricing were verified against primary Google sources (per-model `ai.google.dev` pages, the pricing page, the launch blog, the API changelog, and the DeepMind model card PDFs) on the launch date itself, 2026-07-21. Same-day docs are the least stable kind — re-verify before these figures back a contractual cost model. LiteLLM's `model_prices_and_context_window.json` does not yet carry either model, so LiteLLM-based cost tracking will not price them correctly until that map updates.
+
+Delivered as declarative metadata only (`.ai-models.json`: 2 models + 10 vendor rows + 4 cost rows, CLI-`uuidgen` primaryKeys, no sync blocks) — the consolidated metadata-sync migration is generated at release time by the build engineer's `mj sync push` against a clean last-release DB, per the release workflow documented in `metadata/CLAUDE.md`.

--- a/metadata/ai-models/.ai-models.json
+++ b/metadata/ai-models/.ai-models.json
@@ -19755,5 +19755,303 @@
     "primaryKey": {
       "ID": "08C1B881-EAEF-42DB-B8F3-E621DC940C6F"
     }
+  },
+  {
+    "fields": {
+      "Name": "Gemini 3.6 Flash",
+      "PowerRank": 24,
+      "Description": "Google's token-efficiency refresh of the Flash line, released July 21, 2026. Built on Gemini 3.5 Flash (the model card defers architecture, training data, and safety policy to the 3.5 Flash card) and positioned as a cost-per-task improvement rather than a new capability tier: output price drops from $9.00 to $7.50 per 1M while emitting roughly 17% fewer output tokens. Features a 1M token input context window and 64K output capacity with configurable thinking. Leads its class on computer use (OSWorld-Verified 83.0), chart reasoning (CharXiv), and long-context recall (GDM-MRCR v2), but trails frontier coding models on SWE-Bench Pro and Terminal-bench 2.1. Supports multimodal input (text, image, video, audio, PDF) with text-only output, function calling, code execution, search grounding, and structured outputs. Live API and image/audio generation are NOT supported. Knowledge cutoff March 2026.",
+      "AIModelTypeID": "@lookup:MJ: AI Model Types.Name=LLM",
+      "IsActive": true,
+      "SpeedRank": 11,
+      "CostRank": 6,
+      "InheritTypeModalities": true,
+      "PriorVersionID": "@lookup:MJ: AI Models.Name=Gemini 3.5 Flash"
+    },
+    "relatedEntities": {
+      "MJ: AI Model Vendors": [
+        {
+          "fields": {
+            "ModelID": "@parent:ID",
+            "VendorID": "@lookup:MJ: AI Vendors.Name=Google",
+            "Priority": 0,
+            "Status": "Active",
+            "SupportedResponseFormats": "Any",
+            "SupportsEffortLevel": true,
+            "SupportsStreaming": false,
+            "TypeID": "@lookup:MJ: AI Vendor Type Definitions.Name=Model Developer"
+          },
+          "primaryKey": {
+            "ID": "E3F3EBCF-F1AF-4114-A697-769B4DA4327A"
+          }
+        },
+        {
+          "fields": {
+            "ModelID": "@parent:ID",
+            "VendorID": "@lookup:MJ: AI Vendors.Name=Google",
+            "Priority": 1,
+            "Status": "Active",
+            "DriverClass": "GeminiLLM",
+            "APIName": "gemini-3.6-flash",
+            "MaxInputTokens": 1048576,
+            "MaxOutputTokens": 65536,
+            "SupportedResponseFormats": "Any, JSON",
+            "SupportsEffortLevel": true,
+            "SupportsStreaming": true,
+            "TypeID": "@lookup:MJ: AI Vendor Type Definitions.Name=Inference Provider"
+          },
+          "primaryKey": {
+            "ID": "600C29AF-62EF-4E0A-8942-7BA6338BF682"
+          }
+        },
+        {
+          "fields": {
+            "ModelID": "@parent:ID",
+            "VendorID": "@lookup:MJ: AI Vendors.Name=Vertex AI",
+            "Priority": 0,
+            "Status": "Active",
+            "SupportedResponseFormats": "Any",
+            "SupportsEffortLevel": true,
+            "SupportsStreaming": false,
+            "TypeID": "@lookup:MJ: AI Vendor Type Definitions.Name=Model Developer"
+          },
+          "primaryKey": {
+            "ID": "2C2E258E-06B7-4911-A850-A9BFAA1EF4D4"
+          }
+        },
+        {
+          "fields": {
+            "ModelID": "@parent:ID",
+            "VendorID": "@lookup:MJ: AI Vendors.Name=Vertex AI",
+            "Priority": 1,
+            "Status": "Active",
+            "DriverClass": "VertexLLM",
+            "APIName": "gemini-3.6-flash",
+            "MaxInputTokens": 1048576,
+            "MaxOutputTokens": 65536,
+            "SupportedResponseFormats": "Any, JSON",
+            "SupportsEffortLevel": true,
+            "SupportsStreaming": true,
+            "TypeID": "@lookup:MJ: AI Vendor Type Definitions.Name=Inference Provider"
+          },
+          "primaryKey": {
+            "ID": "A79D244E-5124-4FA7-B0A6-BDD39FF88C9D"
+          }
+        },
+        {
+          "fields": {
+            "ModelID": "@parent:ID",
+            "VendorID": "@lookup:MJ: AI Vendors.Name=OpenRouter",
+            "Priority": 50,
+            "Status": "Active",
+            "DriverClass": "OpenRouterLLM",
+            "APIName": "google/gemini-3.6-flash",
+            "MaxInputTokens": 1048576,
+            "MaxOutputTokens": 65536,
+            "SupportedResponseFormats": "Any, JSON",
+            "SupportsEffortLevel": true,
+            "SupportsStreaming": true,
+            "TypeID": "@lookup:MJ: AI Vendor Type Definitions.Name=Inference Provider"
+          },
+          "primaryKey": {
+            "ID": "3694A0F6-FA92-4949-82E9-6BFB4E0C7B04"
+          }
+        }
+      ],
+      "MJ: AI Model Costs": [
+        {
+          "fields": {
+            "ModelID": "@parent:ID",
+            "VendorID": "@lookup:MJ: AI Vendors.Name=Google",
+            "StartedAt": "2026-07-21T00:00:00.000Z",
+            "Status": "Active",
+            "Currency": "USD",
+            "PriceTypeID": "@lookup:MJ: AI Model Price Types.Name=Tokens",
+            "InputPricePerUnit": 1.5,
+            "OutputPricePerUnit": 7.5,
+            "UnitTypeID": "@lookup:MJ: AI Model Price Unit Types.Name=Per 1M Tokens",
+            "ProcessingType": "Realtime",
+            "Comments": "Gemini 3.6 Flash pricing on Google as of the July 21, 2026 GA launch. Standard: $1.50/1M input, $7.50/1M output (output INCLUDES thinking tokens). Batch is exactly half: $0.75/$3.75. Cache read $0.15/1M = 0.1x input (Gemini Family A, implicit caching); Google does not charge for cache writes, so CacheWritePricePerUnit is null. NOT representable here: the explicit context-cache storage charge of $1.00 per 1M tokens per hour. Pricing is flat across the full 1M window - NOT tiered by prompt length (the Vertex page renders <=200K and >200K columns but the values are identical, unlike Gemini 3.1 Pro). RECENCY: verified 2026-07-21, the same day the model shipped; same-day launch docs are the least stable kind, so re-verify before relying on these figures for contractual cost models. Do NOT route via the gemini-flash-latest alias expecting this model - the changelog only ever repointed that alias to gemini-3.5-flash (May 19, 2026), and hitting 3.5 Flash instead costs $9.00/1M output, a silent 20% overspend. Sources: https://ai.google.dev/gemini-api/docs/models/gemini-3.6-flash ; https://ai.google.dev/gemini-api/docs/pricing ; https://storage.googleapis.com/deepmind-media/Model-Cards/Gemini-3-6-Flash-Model-Card.pdf",
+            "CacheReadPricePerUnit": 0.15,
+            "CacheWritePricePerUnit": null
+          },
+          "primaryKey": {
+            "ID": "93FF11C9-ECFD-4093-895F-B8AB7D5A56EA"
+          }
+        },
+        {
+          "fields": {
+            "ModelID": "@parent:ID",
+            "VendorID": "@lookup:MJ: AI Vendors.Name=Vertex AI",
+            "StartedAt": "2026-07-21T00:00:00.000Z",
+            "Status": "Active",
+            "Currency": "USD",
+            "PriceTypeID": "@lookup:MJ: AI Model Price Types.Name=Tokens",
+            "InputPricePerUnit": 1.5,
+            "OutputPricePerUnit": 7.5,
+            "UnitTypeID": "@lookup:MJ: AI Model Price Unit Types.Name=Per 1M Tokens",
+            "ProcessingType": "Realtime",
+            "Comments": "Gemini 3.6 Flash pricing on Vertex AI as of the July 21, 2026 GA launch. Matches Google direct exactly: $1.50/1M input, $7.50/1M output, $0.15/1M cache read (0.1x input, Family A; no cache-write charge). Verified on cloud.google.com/vertex-ai/generative-ai/pricing, which loads normally and lists the model. NOTE: per-model Vertex doc deep-links have moved to docs.cloud.google.com under 'Gemini Enterprise Agent Platform' branding, so a 404 on a legacy cloud.google.com/vertex-ai/.../models/gemini/3-6-flash path does NOT mean the model is absent from Vertex. UNVERIFIED: the exact Vertex/GEAP-flavored model id string and its regional availability - confirm before pinning a region or Cloud-side id. RECENCY: verified 2026-07-21, same-day launch; re-verify before contractual cost models. Sources: https://cloud.google.com/vertex-ai/generative-ai/pricing ; https://ai.google.dev/gemini-api/docs/pricing",
+            "CacheReadPricePerUnit": 0.15,
+            "CacheWritePricePerUnit": null
+          },
+          "primaryKey": {
+            "ID": "01EB7DF7-3B6B-453D-B853-ABAEE61D34B3"
+          }
+        }
+      ]
+    },
+    "primaryKey": {
+      "ID": "BD266132-109B-4701-86F8-52F90C8A9E3E"
+    }
+  },
+  {
+    "fields": {
+      "Name": "Gemini 3.5 Flash-Lite",
+      "PowerRank": 19,
+      "Description": "Google's most cost-effective 3.5-generation model, released July 21, 2026 as a Stable (non-preview) model. Designed for high-volume, latency-sensitive workloads at $0.30/$2.50 per 1M tokens with a 1M token input context window and 64K output capacity. Supports configurable thinking levels for trading reasoning depth against cost. Scores 74.0 on OSWorld-Verified, unusually strong for a lite-tier model. Notably prices text, image, video AND audio input at a single unified rate - a departure from Gemini 2.5 Flash and 3.1 Flash-Lite, which charged an audio premium - and is flat-rate across the full 1M window with no context-length tiering. Supports function calling, structured outputs, and search grounding; audio generation, image generation, the Live API, and the dedicated Computer Use API surface are NOT supported. Knowledge cutoff March 2026.",
+      "AIModelTypeID": "@lookup:MJ: AI Model Types.Name=LLM",
+      "IsActive": true,
+      "SpeedRank": 12,
+      "CostRank": 3,
+      "InheritTypeModalities": true,
+      "PriorVersionID": "@lookup:MJ: AI Models.Name=Gemini 3.1 Flash-Lite"
+    },
+    "relatedEntities": {
+      "MJ: AI Model Vendors": [
+        {
+          "fields": {
+            "ModelID": "@parent:ID",
+            "VendorID": "@lookup:MJ: AI Vendors.Name=Google",
+            "Priority": 0,
+            "Status": "Active",
+            "SupportedResponseFormats": "Any",
+            "SupportsEffortLevel": true,
+            "SupportsStreaming": false,
+            "TypeID": "@lookup:MJ: AI Vendor Type Definitions.Name=Model Developer"
+          },
+          "primaryKey": {
+            "ID": "6CD7D83B-D462-4D2E-B416-8C8E57996EF3"
+          }
+        },
+        {
+          "fields": {
+            "ModelID": "@parent:ID",
+            "VendorID": "@lookup:MJ: AI Vendors.Name=Google",
+            "Priority": 1,
+            "Status": "Active",
+            "DriverClass": "GeminiLLM",
+            "APIName": "gemini-3.5-flash-lite",
+            "MaxInputTokens": 1048576,
+            "MaxOutputTokens": 65536,
+            "SupportedResponseFormats": "Any, JSON",
+            "SupportsEffortLevel": true,
+            "SupportsStreaming": true,
+            "TypeID": "@lookup:MJ: AI Vendor Type Definitions.Name=Inference Provider"
+          },
+          "primaryKey": {
+            "ID": "7037C52C-7431-4323-BB5F-73B58ED49840"
+          }
+        },
+        {
+          "fields": {
+            "ModelID": "@parent:ID",
+            "VendorID": "@lookup:MJ: AI Vendors.Name=Vertex AI",
+            "Priority": 0,
+            "Status": "Active",
+            "SupportedResponseFormats": "Any",
+            "SupportsEffortLevel": true,
+            "SupportsStreaming": false,
+            "TypeID": "@lookup:MJ: AI Vendor Type Definitions.Name=Model Developer"
+          },
+          "primaryKey": {
+            "ID": "5306F4D3-3411-4165-B0C5-8E8137AC0FF4"
+          }
+        },
+        {
+          "fields": {
+            "ModelID": "@parent:ID",
+            "VendorID": "@lookup:MJ: AI Vendors.Name=Vertex AI",
+            "Priority": 1,
+            "Status": "Active",
+            "DriverClass": "VertexLLM",
+            "APIName": "gemini-3.5-flash-lite",
+            "MaxInputTokens": 1048576,
+            "MaxOutputTokens": 65536,
+            "SupportedResponseFormats": "Any, JSON",
+            "SupportsEffortLevel": true,
+            "SupportsStreaming": true,
+            "TypeID": "@lookup:MJ: AI Vendor Type Definitions.Name=Inference Provider"
+          },
+          "primaryKey": {
+            "ID": "75525A5A-B3D7-4BFD-BA97-57098757F2FB"
+          }
+        },
+        {
+          "fields": {
+            "ModelID": "@parent:ID",
+            "VendorID": "@lookup:MJ: AI Vendors.Name=OpenRouter",
+            "Priority": 50,
+            "Status": "Active",
+            "DriverClass": "OpenRouterLLM",
+            "APIName": "google/gemini-3.5-flash-lite",
+            "MaxInputTokens": 1048576,
+            "MaxOutputTokens": 65536,
+            "SupportedResponseFormats": "Any, JSON",
+            "SupportsEffortLevel": true,
+            "SupportsStreaming": true,
+            "TypeID": "@lookup:MJ: AI Vendor Type Definitions.Name=Inference Provider"
+          },
+          "primaryKey": {
+            "ID": "DAC60079-D8F9-4891-B12F-D9C453CEE15F"
+          }
+        }
+      ],
+      "MJ: AI Model Costs": [
+        {
+          "fields": {
+            "ModelID": "@parent:ID",
+            "VendorID": "@lookup:MJ: AI Vendors.Name=Google",
+            "StartedAt": "2026-07-21T00:00:00.000Z",
+            "Status": "Active",
+            "Currency": "USD",
+            "PriceTypeID": "@lookup:MJ: AI Model Price Types.Name=Tokens",
+            "InputPricePerUnit": 0.3,
+            "OutputPricePerUnit": 2.5,
+            "UnitTypeID": "@lookup:MJ: AI Model Price Unit Types.Name=Per 1M Tokens",
+            "ProcessingType": "Realtime",
+            "Comments": "Gemini 3.5 Flash-Lite pricing on Google as of the July 21, 2026 launch (Stable, not preview). Standard: $0.30/1M input, $2.50/1M output (output includes reasoning/thinking tokens). Batch: $0.15/$1.25. The $0.30 input rate is UNIFIED across text, image, video and audio - there is no audio premium, unlike Gemini 2.5 Flash and 3.1 Flash-Lite. Cache read $0.03/1M = 0.1x input (Gemini Family A); Google does not charge for cache writes, so CacheWritePricePerUnit is null. NOT representable here: the explicit context-cache storage charge of $1.00 per 1M tokens per hour, and the batch cache-read rate of $0.02. Pricing is flat across the full 1M window - no context-length tiering. AVAILABILITY: Google is the only real inference host; OpenRouter is a router whose upstreams resolve to Google AI Studio and Vertex only, so there is no Groq/Bedrock/Together failover path for this model. RECENCY: verified 2026-07-21, the same day the model shipped; re-verify before relying on these figures for contractual cost models. Sources: https://ai.google.dev/gemini-api/docs/models/gemini-3.5-flash-lite ; https://ai.google.dev/gemini-api/docs/pricing ; DeepMind Gemini 3.5 Flash-Lite model card",
+            "CacheReadPricePerUnit": 0.03,
+            "CacheWritePricePerUnit": null
+          },
+          "primaryKey": {
+            "ID": "46CBEC73-BE59-4942-90DD-80032C624AC3"
+          }
+        },
+        {
+          "fields": {
+            "ModelID": "@parent:ID",
+            "VendorID": "@lookup:MJ: AI Vendors.Name=Vertex AI",
+            "StartedAt": "2026-07-21T00:00:00.000Z",
+            "Status": "Active",
+            "Currency": "USD",
+            "PriceTypeID": "@lookup:MJ: AI Model Price Types.Name=Tokens",
+            "InputPricePerUnit": 0.3,
+            "OutputPricePerUnit": 2.5,
+            "UnitTypeID": "@lookup:MJ: AI Model Price Unit Types.Name=Per 1M Tokens",
+            "ProcessingType": "Realtime",
+            "Comments": "Gemini 3.5 Flash-Lite pricing on Vertex AI as of the July 21, 2026 launch. Global-endpoint Standard tier matches Google direct: $0.30/1M input, $2.50/1M output, $0.03/1M cache read (0.1x input, Family A; no cache-write charge). Vertex availability confirmed via the DeepMind model card's Distribution section, which lists Gemini App, Google AI Studio, Gemini Enterprise Agent Platform, and Gemini API. NOTE: the legacy cloud.google.com/vertex-ai/generative-ai/docs/models/gemini/3-5-flash-lite path is dead because Vertex per-model docs moved to docs.cloud.google.com under 'Gemini Enterprise Agent Platform' branding - that 404 is not evidence of absence. UNVERIFIED and deliberately NOT encoded here: a reported non-global endpoint surcharge (~$0.33/$2.75) and Priority tier (~$0.54/$4.50); no Vertex pricing page was fetched showing them, so only the global Standard tier is recorded. RECENCY: verified 2026-07-21, same-day launch; re-verify before contractual cost models. Sources: https://ai.google.dev/gemini-api/docs/pricing ; DeepMind Gemini 3.5 Flash-Lite model card",
+            "CacheReadPricePerUnit": 0.03,
+            "CacheWritePricePerUnit": null
+          },
+          "primaryKey": {
+            "ID": "E5A8B134-B282-411B-A436-16D7C357892A"
+          }
+        }
+      ]
+    },
+    "primaryKey": {
+      "ID": "CA2A5DA9-E471-44E2-A712-48A2C9145DDB"
+    }
   }
 ]


### PR DESCRIPTION
Google shipped two Flash-line models GA/Stable on **2026-07-21**. This adds both to the model catalog as declarative metadata: 2 models, 10 `MJ: AI Model Vendors` rows, 4 `MJ: AI Model Costs` rows, plus a changeset. No code, no migration.

There is no tracking issue for this — it is routine catalog upkeep, opened off the back of the model launch.

## The two models

| | Gemini 3.6 Flash | Gemini 3.5 Flash-Lite |
|---|---|---|
| API id | `gemini-3.6-flash` | `gemini-3.5-flash-lite` |
| `PriorVersionID` | Gemini 3.5 Flash | Gemini 3.1 Flash-Lite |
| Input / output tokens | 1,048,576 / 65,536 | 1,048,576 / 65,536 |
| Price per 1M | `$1.50` / `$7.50` | `$0.30` / `$2.50` |
| Cache read | `$0.15` (0.1×) | `$0.03` (0.1×) |
| Knowledge cutoff | March 2026 | March 2026 |
| Power / Speed / Cost | 24 / 11 / 6 | 19 / 12 / 3 |

**Gemini 3.6 Flash is an efficiency refresh, not a new capability tier.** The model card says plainly that it "is based on Gemini 3.5 Flash" and defers architecture, training data, hardware, and safety policy to the 3.5 Flash card. Input price is unchanged; only output drops, from `$9.00` to `$7.50`, compounded by roughly 17% fewer output tokens emitted. On Google's own benchmark table it trails frontier coding models on SWE-Bench Pro and Terminal-bench 2.1, and leads on computer use (OSWorld-Verified 83.0), chart reasoning, and long-context recall. `PowerRank` 24 places it above Gemini 3.5 Flash (23) and below Grok 4.5 (25) accordingly.

**Gemini 3.5 Flash-Lite prices text, image, video and audio input at one unified `$0.30` rate.** That is a real departure from Gemini 2.5 Flash and 3.1 Flash-Lite, which both charged an audio premium, and it is the reason its `CostRank` is 3 rather than matching 3.1 Flash-Lite's 2 despite being in the same tier.

Neither model is context-length tiered — both are flat-rate across the full 1M window, unlike the Pro line. The Vertex pricing page renders `<=200K` and `>200K` columns for 3.6 Flash but the values are identical in both, which is what distinguishes it from a genuinely tiered model such as Gemini 3.1 Pro on the same page.

Cache rows follow the Gemini Family A convention from the add-model guidance: read at 0.1× input, `CacheWritePricePerUnit` left `null` because Google does not charge for cache writes. The schema cannot express the explicit context-cache storage charge (`$1.00` per 1M tokens per hour) or the batch cache-read rate, so both are recorded in `Comments` rather than silently dropped.

## Hazards

**This PR changes nothing in any environment on merge.** Records under `metadata/**` are inert until `mj sync push` runs. Per `metadata/CLAUDE.md` rule 1b that is a release-time, build-engineer step against a clean DB at the last released version, which produces one consolidated sync migration for the whole release. That is why the new records carry CLI-`uuidgen` `primaryKey`s, **no** `sync` blocks, and no hand-authored `*__Metadata_Sync.sql`. If you pull this branch and push it locally to try the models, note that `mj sync push` writes `sync` blocks back into the JSON (`packages/MetadataSync/src/lib/json-write-helper.ts:81`) — strip them before committing.

**Do not route Gemini 3.6 Flash through the `gemini-flash-latest` alias.** The Gemini API changelog only ever repointed that alias to `gemini-3.5-flash`, in the 2026-05-19 entry; the 2026-07-21 entry does not repoint it, and `ai.google.dev/gemini-api/docs/latest-model` carries no mapping to 3.6. Traffic sent through the alias expecting the new model lands on 3.5 Flash at `$9.00`/1M output instead of `$7.50` — a silent 20% overspend. Every row here pins the explicit id.

**These models are exposed to the `vwAIModels` flattened-`APIName` footgun described in #3066.** Each carries an OpenRouter inference row at `Priority` 50, and the view takes `TOP 1 ... ORDER BY mv.[Priority] DESC`, so the highest number wins and the flattened `APIName` resolves to the OpenRouter form (`google/gemini-3.6-flash`), not the Google form. Anything reading `Model.APIName` and handing it to the `@google/genai` SDK will 404, which is exactly the 2026-07-06 incident in that issue. This is **not** a new deviation — Gemini 3.5 Flash and Gemini 3.1 Flash-Lite already use `Priority` 50 for their OpenRouter rows and I matched them deliberately for consistency. Flagging it because this PR widens the blast radius of an open issue by two models. Consumers should pin `{ modelId, vendorId }` via `AIPromptParams.override`.

## Verification

No test surface exists for a metadata-only change, so I verified the claims instead:

| Check | Result |
|---|---|
| `npx mj sync validate --dir=metadata` | **0 errors, 0 warnings** across 314 files / 1711 entities |
| JSON parses | 172 models |
| All 10 `@lookup` targets resolve | `Google`, `Vertex AI`, `OpenRouter` present in `.ai-vendors.json`; both `PriorVersionID` targets present |
| Model names unique | `Gemini 3.6 Flash` ×1, `Gemini 3.5 Flash-Lite` ×1 |
| 16 new `primaryKey` UUIDs | each appears exactly once |
| No `sync` blocks on new records | 0 |
| Diff is only this branch's work | merge-base equals the `origin/next` tip; 2 files, 317 insertions |

Specs were verified against primary Google sources on launch day: the per-model `ai.google.dev` pages, the pricing page, the launch blog, the API changelog, and both DeepMind model card PDFs (downloaded and read rather than quoted second-hand — the knowledge cutoffs appear only in the PDFs' Known Limitations sections and are single-sourced there).

I have **not** made a live API call to either model, and nothing here has been pushed to any database.

Two caveats I chose to record rather than encode. A reported Vertex non-global endpoint surcharge for 3.5 Flash-Lite (~`$0.33`/`$2.75`) and a Priority tier (~`$0.54`/`$4.50`) are **not** in the cost rows — no Vertex pricing page showing them could be fetched, so only the confirmed global Standard tier is recorded. And because both models launched the same day this was written, same-day pricing and aliases are the least stable kind; the cost `Comments` say so explicitly for whoever revisits this.

## Pre-existing issue found, deliberately not fixed here

`metadata/ai-models/.ai-models.json` on `next` already contains 4 duplicated `primaryKey` UUIDs, each appearing twice: `CCA0A4DC-497D-4E11-BEBB-392E0074A7CA`, `6C644B8C-CB68-461D-A00B-36F62855539B`, `A727C77A-6F00-4990-9E1D-67B95F49CCF5`, `DA3A0E18-83DD-4329-AC87-0D8E9D563F01`. I confirmed all four predate this branch (`git show origin/next:...` shows 2 occurrences each) and left them alone as outside this change's blast radius. Worth a ticket — duplicate primary keys will collide on the release-time push.