### PR TITLE
docs(deployment): correct the integration-test step for the post-#3228 suite

### DIFF
--- a/.changeset/deployment-runbook-integration-tiers.md
+++ b/.changeset/deployment-runbook-integration-tiers.md
@@ -1,0 +1,22 @@
+---
+"@memberjunction/integration-test-suite": patch
+---
+
+Correct the release runbook's integration-testing step for the post-#3228 suite, and fix three stale sibling docs. Documentation only — no runtime code changes.
+
+`DEPLOYMENT.md` Step 4 described a world that no longer exists: it told the build engineer to run `RUN_MUTATION_TESTS=1 RUN_AGENT_TESTS=1 npm run test:integration` and claimed an aggregator collapsed all tiers into one exit code. That command runs **zero** live-model tests — `test:integration` is hardcoded to `mj test suite "Integration Tests — Deterministic"`, the live tests live in a **sibling** suite, and `mj test suite` does not recurse into child suites, so the runbook reported "all three tiers passed" while one never ran. The aggregator (`run-all.ts`) was deleted in the July-2026 restructure.
+
+Every command and behavior in the rewritten step was verified by executing it against a live throwaway database rather than inferred from source. That surfaced corrections that source-reading alone had gotten wrong:
+
+- **Seeding is mandatory, not optional.** The old text said skipping `metadata-optional/integration-test` "keeps the suite green"; an unseeded database actually exits **1** with `Test suite not found`. The suite/Test rows exist only in that root.
+- **Two false-green paths, neither visible in the exit code.** With MJAPI down, the 19 client-transport bundles **skip-as-PASS** (a green 52/52 that ran 33 tests); with `MJ_API_KEY` missing they return status `Error` — and `failedTests` counts only `Failed`, so both exit **0**. The step now requires `N === M === 52` plus a DB-side status tally, because the console prints `✗ FAILED` for `Error` too.
+- **`RUN_AGENT_TESTS` is default-ON** (`IsTierEnabled` returns `!== '0'`), so `=1` is a no-op and `=0` silently yields a green 15/15 that executed nothing.
+- **Missing provider keys FAIL the live tier, they do not skip** — verified by blanking `AI_VENDOR_API_KEY__*`. The build-engineering runbook claimed a clean skip, which would have made a keyless CI leg look safe.
+- **A virgin release database cannot reach 52/52.** `IT29 - Cache Gauntlet` enforces an anti-vacuity floor requiring `MJ: User Settings` to already hold ≥2 rows, so a fresh Step-3 database yields 51/52 until a baseline is seeded.
+- Counts and budgets corrected against reality: IT01–IT66 (67 records, 52 + 15), 242 seeded records, deterministic ≈133s, live ≈570s. `[COST]` reports `$0.0000` even on real model calls, so it must not be read as spend.
+
+Also documents two environment traps that cost real debugging time: the testing CLI loads dotenv with `override: true` (so an inline `DB_DATABASE=…` is silently ignored for `mj test` while it works for `mj sync push` — a mutating run against the wrong database), and a stale `dist/` orphan whose source was deleted will block MJAPI from booting entirely with a duplicate-GraphQL-type error that rebuilding does not clear.
+
+Finally, records the SQL Server / PostgreSQL parity position honestly: migration parity is verified every release (Step 8), but **runtime** parity is not — the integration suite cannot run on PostgreSQL today. The testing CLI builds an mssql pool and declares no PG driver, and `UserCache.Refresh` is mssql-typed and issues T-SQL, so the context-user cache stays empty regardless of database contents. Provisioning a PG database does not enable it; it needs a code + dependency change. The section is explicitly scoped so it reads as a roadmap gap and never as a reason to halt a release.
+
+Sibling docs corrected: `guides/INTEGRATION_TESTING_QUICKSTART.md` (member counts and tier-gating table), `.github/workflows/integration.yml` (stale IT-range comments), and `packages/TestingFramework/integration-test-suite/docs/build-engineering-runbook.md` (the credential-skip claim, `RUN_AGENT_TESTS` semantics, bundle count and measured duration).

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -20,8 +20,10 @@ name: Integration Tier
 #   * `mj sync push --dir=metadata` pushes the default metadata dir — which includes the inert
 #     "Integration Test" TestType (metadata/test-types/). A SECOND push then applies the sibling
 #     `metadata-optional/integration-test/` root, which holds the actual test-only records — the
-#     IT01–IT23 Tests, the integration suite, AND the RLS security principals (users + scoped role +
-#     grant). It is kept out of `metadata/` so those synthetic accounts never reach a production DB
+#     IT01–IT66 Tests (67 records), the integration suite hierarchy, the RLS security principals
+#     (users + scoped role + grant), AND the synthetic AI stack the live tier drives (14 `IT: *`
+#     agents, 14 prompts, 42 model bindings, a skill, a search scope) — 242 records in total.
+#     It is kept out of `metadata/` so those synthetic accounts never reach a production DB
 #     (R2). Order matters: this root after metadata (the IT records @lookup the TestType by name), and
 #     its own directoryOrder (tests → test-suites → roles → entity-permissions → users) resolves
 #     every @lookup ref.
@@ -148,7 +150,7 @@ jobs:
           MJ_MIGRATION_REQUEST_TIMEOUT: '120000'
         run: node packages/MJCLI/bin/run.js sync push --dir=metadata --ci
 
-      # The optional integration root holds the actual test-only records — the IT01–IT23 Tests, the
+      # The optional integration root holds the actual test-only records — the IT01–IT66 Tests, the
       # integration suite, AND the RLS security principals (users + scoped role + entity-permission
       # grant). (The inert "Integration Test" TestType itself lives in metadata/ and came in with the
       # main push above.) This root is deliberately kept OUT of the default-pushed metadata/ tree so

--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -36,7 +36,8 @@ Before anything else, confirm the `next` branch is healthy:
 
 - [ ] **"Build all packages for testing"** (`build.yml`) — passes on `next`
 - [ ] **"Test migrations"** (`migrations.yml`) — passes if migrations were changed
-- [ ] **"Unit Tests"** (`test.yml`) — passes on any open PR
+- [ ] **"Unit Tests"** (`test.yml`) — passes on any open PR, and on the **push-to-`next`** run (that unfiltered backstop is the one that actually proves integration-bundle ↔ `MJ: Tests` metadata sibling parity; a metadata-only PR never triggers `test.yml` at all)
+- [ ] **"Integration Tier"** (`integration.yml`) — passes on `next`. Runs the deterministic suite against a fresh SQL Server on PRs into `next` plus an unfiltered push-to-`next` backstop. It is **not** a substitute for Step 4: CI runs no MJAPI (so client-transport bundles skip) and no live-model tier.
 
 ### Step 2: Pull In New AI Models (REQUIRED — every release)
 
@@ -103,11 +104,16 @@ Check if there are any pending metadata changes (new/updated records in `metadat
    > This push includes the inert **"Integration Test" TestType** (it lives in the normal
    > `metadata/test-types/` tree) — that's fine, it's just a type definition. But **do NOT push
    > `metadata-optional/integration-test/` here.** That optional sibling root holds the actual
-   > test-only records — the IT01–IT23 Tests, the integration suite, and the RLS principals (three
-   > synthetic `it-*@integration.test` users + the "Integration Test: RLS Scoped Reader" role + its
-   > grant). It is deliberately kept out of `metadata/` so none of it enters the generated
-   > `Metadata_Sync.sql` migration — and thus never reaches production. It exists only for the
-   > Step 4 smoke test.
+   > test-only records — the **IT01–IT66 Tests (67 records: 52 in the Deterministic suite, 15 in
+   > the Live Model suite)**, the three-suite hierarchy, the RLS principals (three synthetic
+   > `it-*@integration.test` users + the "Integration Test: RLS Scoped Reader" role + its grants),
+   > **and the synthetic AI stack the live tier drives** (14 `IT: *` AI Agents — 12 of them
+   > root-level — 14 IT AI Prompts with 42 model bindings + templates, `IT: Probe Skill`,
+   > `IT: Integration Test Scope`).
+   > It is deliberately kept out of `metadata/` so none of it enters the generated
+   > `Metadata_Sync.sql` migration — and thus never reaches production, where those IT agents would
+   > surface in every user's `@agent` picker. It is pushed only into the throwaway Step-3 database,
+   > in Step 4.2.
 6. **Grab the generated SQL** from `metadata/sql_logging/` — find the most recent `MetadataSync_Push_*.sql` file
 7. **Copy it to the migrations folder** and rename using the naming convention:
    ```
@@ -121,6 +127,13 @@ Check if there are any pending metadata changes (new/updated records in `metadat
    - Timestamp format: `YYYYMMDDHHMM` (year, month, day, hour, minute)
    - Version: use the **next minor version** (e.g., if current release is `5.5.x`, use `v5.6.x`)
    - Timestamp must be **strictly greater** than all existing migration timestamps (enforced by CI)
+   - **Verify no test-only records leaked in.** No CI check catches this — `changes.yml` validates
+     naming, schema placeholders and timestamps only. Grep the newly copied file by name and
+     confirm zero hits:
+     ```bash
+     grep -c '@integration\.test\|Integration Test: RLS Scoped Reader\|IT: Probe Skill' \
+       migrations/v5/V<new-timestamp>__v5.X.x__Metadata_Sync.sql   # must print 0
+     ```
 
 8. **Commit the migration script to `next`** — push this new migration file to the `next` branch so it's included in the release PR. **Also commit the mj-sync writeback**: the push back-fills `primaryKey`/`sync` blocks into the new records' metadata JSON files (`metadata/**/.*.json`) — those belong in the same commit so future pushes recognize the records as existing.
 9. **Ensure a minor changeset exists** — if changesets only have `patch` bumps, you must add a changeset with `minor` on at least one `@memberjunction/*` package to indicate this is a minor release:
@@ -136,6 +149,16 @@ Check if there are any pending metadata changes (new/updated records in `metadat
 > captured entirely by `mj sync push`'s SQL log. Running codegen afterwards is an
 > *optional* drift check — expect zero output; if it emits a new `CodeGen_Run`
 > migration, stop and investigate before including anything.
+>
+> **Reconciling this with the suite's own runbook.** `build-engineering-runbook.md`
+> lists the build order as *migrations → `mj codegen` → `npm run build` → seed → MJAPI → run*.
+> That ordering is correct for a **developer's existing database**, where the schema may have
+> moved without codegen having been re-run. It is **not** the release path: Step 3 provisions a
+> *fresh* database, and `mj migrate` replays every historical `CodeGen_Run_*.sql`, so generated
+> objects are already current. On the release path, treat `mj codegen` as the drift check
+> described above — not a required step. Either way the invariant the runbook is protecting
+> holds: never run the suite before the schema is current, or `IT50 - CodeGen Artifact
+> Consistency` will (correctly) fail on an entity-count mismatch.
 
 #### If no metadata changes:
 - Skip this step. Changesets will determine patch vs minor based on what's already been added.
@@ -144,26 +167,161 @@ Check if there are any pending metadata changes (new/updated records in `metadat
 
 The database from Step 3 is now at the latest schema **and** metadata, so this is the point in the release where the schema, generated types, and engines should all agree. Run the headless integration suite against that database as a full-stack smoke test that they actually do.
 
+There are **two runnable suites**, and one `mj test suite` invocation runs exactly one of them, serially, in one process. There is no aggregator — `run-all.ts` and the per-bundle `tsx` dispatchers were deleted in the July-2026 restructure. Spell the names exactly: they contain an **em dash (—)**, not a hyphen.
+
+| Suite | Members | Gate |
+|---|---|---|
+| `Integration Tests — Deterministic` | 52 | **Required — must be 52/52.** Deterministic: any shortfall blocks the release |
+| `Integration Tests — Live Model` | 15 | **Required to run and be triaged — but *not* required to be 15/15.** Real LLM calls; see 4.4 |
+
+> **The two tiers have different pass criteria, and conflating them will either block a good release or wave through a bad one.** The deterministic tier is exactly that — 52/52 or stop. The live tier drives real models, and `agents-suite.md` documents run-to-run variance as a known characteristic "surfaced honestly rather than hidden": checks that need the model to take a specific action use a two-phase bounded retry (≤3 attempts) and then fail **loudly** with `model-noncompliance:`. So a live shortfall is not automatically a blocker — every failing live test must be **triaged individually** (see 4.6): `model-noncompliance:` is variance and may be accepted; anything else is a real defect and blocks.
+
+> ⚠️ Do **not** run `mj test suite "Integration Tests"`. That is the empty parent container (zero members); it exits **1** with `No tests found in suite: <id>`. A hyphen typed instead of the em dash also exits 1, with `Test suite not found: <arg>`.
+
+> 🐘 **Run this step against SQL Server — that is the supported path, and it is all this step requires.** Do not try to point Step 4 at a PostgreSQL database: the testing CLI builds an `mssql` pool (`packages/TestingFramework/CLI/src/lib/mj-provider.ts` → `setupSQLServerClient`, no platform branch), so `DB_PLATFORM=postgresql` is never consulted and the run would fail on connection before testing anything. **This is a limitation of the test harness only — it does not affect the release.** PostgreSQL still ships fully: its migrations are converted, verified, and committed in Step 8. See "What PG parity does and does NOT cover today" there.
+
+#### 4.1 Prerequisites (all required — miss one and the suite reports **green without testing**)
+
+1. **Step 3 is done** — `mj migrate` + `mj sync push --dir ./metadata` applied to the scratch database, and your `.env` points at it.
+
+   > 🚨 **Repoint the database by editing `.env` (Step 3.3) — an inline `DB_DATABASE=… npx mj test …` silently does NOT work.** The testing CLI loads dotenv with `override: true` (`packages/TestingFramework/CLI/src/lib/mj-provider.ts`), so `.env` clobbers the shell variable and the suite runs against whatever `.env` says. `mj sync push` behaves the **opposite** way (its init hook does not override), so the shell-var shortcut *appears* to work while seeding and then silently targets the wrong database for the run — and this tier mutates. Confirm the target on every run: the CLI prints `config.dbDatabase: <name>` at startup.
+2. **The repo is built — and the suite package's `dist/` is *current*.** `npm run build`. The suite loads compiled `dist/`, including the private, never-published `@memberjunction/integration-test-suite` package. A `dist/` that merely **exists is not enough**: if it predates the newest `src/checks/*.checks.ts`, every bundle added since compiles to nothing and the run fails with a wall of `Unknown integration check bundle '<name>'` — naming the *newest* bundles while older ones pass. Verify freshness rather than assuming:
+   ```bash
+   ls -t packages/TestingFramework/integration-test-suite/dist/index.js \
+         packages/TestingFramework/integration-test-suite/src/checks/*.checks.ts | head -1
+   # Must print the dist file. If a .checks.ts is newest, rebuild THROUGH TURBO:
+   npx turbo run build --filter=@memberjunction/integration-test-suite
+   ```
+   > Rebuild it with turbo, **not** `cd <pkg> && npm run build`. The check bundles depend on fixtures and context properties exported by `@memberjunction/testing-integration`; if that sibling is also stale, the direct build dies with dozens of `has no exported member 'AgentLiveFixture'` / `Property 'XFixture' does not exist on type 'IntegrationCheckContext'` errors. Turbo's `dependsOn: ["^build"]` builds the dependency first. A full `npm run build` (Step 7) covers this too.
+3. **`mj.config.cjs` still carries `testing.checkModules`** (`['@memberjunction/integration-test-suite']`) — that key is how check bundles are discovered.
+4. **The integration metadata is seeded** — see 4.2. This is **not** optional any more.
+5. **MJAPI is running** against the Step-3 database, with `MJ_API_KEY` set — see 4.3.
+6. **Use the repo-local CLI**, from the repo root (`npm run test:integration` / `npx mj …`). A globally-installed `mj` cannot load the private suite package.
+
+#### 4.2 Seed the integration metadata (REQUIRED)
+
+`mj test` dispatches from `MJ: Tests` / `MJ: Test Suites` rows that exist **only** in `metadata-optional/integration-test/`. Nothing in `metadata/` and no migration seeds them, so without this push Step 4 exits 1 on suite lookup before a single check runs.
+
 ```bash
-# From the repo root — deterministic + mutation + live-model (agent) tiers, all required
-RUN_MUTATION_TESTS=1 RUN_AGENT_TESTS=1 npm run test:integration
+# AFTER Step 3's `mj migrate` + `mj sync push --dir ./metadata` — order matters, the IT
+# records @lookup the "Integration Test" TestType and AI models from the base metadata.
+npx mj sync push --dir ./metadata-optional/integration-test --ci
 ```
 
-- All three tiers below **must pass** before proceeding — set both flags so they run together (the aggregator spawns each suite in its own process and collapses the per-suite results into one exit code):
-  - **Deterministic tier** (always on) — credential-light, self-cleaning fixtures, no LLM cost.
-  - **Mutation tier** (`RUN_MUTATION_TESTS=1`) — exercises real create/update/delete cache-invalidation paths with self-cleaning fixtures.
-  - **Live-model / agent tier** (`RUN_AGENT_TESTS=1`) — runs real agent/prompt executions, so it requires valid model-provider credentials in `.env` and incurs LLM cost.
-- Predictive Studio flows (`PS_INTEGRATION`) are intentionally **not** part of this gate.
+This seeds **242 records**: the **67 IT Test records** (IT01–IT66), the 3 suite rows and their 52 + 15 memberships, the RLS principals (3 synthetic `it-*@integration.test` users + the `Integration Test: RLS Scoped Reader` role + 2 entity-permission grants), and the synthetic AI stack the live tier drives (14 `IT: *` AI Agents — 12 root-level — 14 IT AI Prompts with 42 multi-vendor model bindings + templates, `IT: Probe Skill`, `IT: Integration Test Scope`, and the IT categories). Expect `Created 242 / Errors 0` in the push summary.
 
-> ⚠️ **The suite runs against the compiled packages (`dist/`), not source.** Ensure the repo has been built (`npm run build`) before running — a stale `dist/` can produce spurious failures. Run this only **after** migrations + metadata sync (Step 3) so it exercises the current schema. See [Integration Testing Quickstart](guides/INTEGRATION_TESTING_QUICKSTART.md) for full tier/gating details.
+Verify it actually landed — the push can exit 0 without seeding, which silently degrades the RLS checks to skip-as-pass (this is the same assertion `integration.yml` makes in CI):
 
-**Optional — seed the RLS fixtures so the multi-user checks execute (instead of skip-as-pass).** The `rls-isolation` deterministic checks (RLS8/9/10) skip-as-pass unless the integration-test principals are present in the DB. To upgrade that coverage from *skipped* to *executed*, push the optional integration root into the **throwaway Step-3 database** before running the suite (this covers the IT tests/suite AND the RLS principals; the TestType itself already came in with the Step-3 `metadata/` push):
-
-```bash
-mj sync push --dir ./metadata-optional/integration-test
+```sql
+SELECT COUNT(*) FROM __mj.[User] WHERE Email LIKE '%@integration.test';   -- must return 3
 ```
 
-> ⚠️ Only against the scratch Step-3 DB — **never a production database.** These are synthetic test accounts (plus MJ-internal test records); that is the entire reason they live outside `metadata/`. Skipping this step keeps the suite green (the RLS checks pass as skips and log the exact command above); seeding it just makes the multi-user isolation checks run for real.
+> 🚨 **Scratch Step-3 database ONLY — never a production database, and never move these files into `metadata/`.** Post-#3228 the blast radius is no longer inert test data: the 12 root-level `IT: *` agents would appear in **every** user's `@agent` picker and `IT: Probe Skill` in every user's `/skill` picker (both permission-open by default), on top of 3 live user accounts, a role, and its grants.
+
+> This push emits **no** SQL log, so it cannot contaminate the Step-3 `Metadata_Sync.sql` migration. It **does** rewrite `sync.lastModified`/`checksum` into the `metadata-optional/**` JSON files — **discard that churn.** Unlike the Step-3 `metadata/**` writeback (Step 3.8), it does not belong in the release commit.
+
+**One more precondition a virgin database does not satisfy.** `IT29 - Cache Gauntlet` enforces an explicit *anti-vacuity floor*: CG1/CG4/CG5 assert that `MJ: User Settings` already holds **≥ 2 rows** before they create their own, because "a `MaxRows:1` slot returned ≤ 1 row" would be trivially true against an empty table. A Step-3 database is brand new, so that table is empty and those three checks fail with `need >= 2 existing rows … (found 0)` — **51/52, and not a product regression.** Seed a baseline once, before running:
+
+```sql
+DECLARE @u UNIQUEIDENTIFIER = (SELECT TOP 1 ID FROM __mj.[User] ORDER BY __mj_CreatedAt);
+INSERT INTO __mj.UserSetting (ID, UserID, Setting, Value) VALUES
+  (NEWID(), @u, 'mj.baselineFloor.a', '1'),
+  (NEWID(), @u, 'mj.baselineFloor.b', '2'),
+  (NEWID(), @u, 'mj.baselineFloor.c', '3');
+```
+
+With those rows present all 7 cache-gauntlet checks pass and the tier reaches 52/52.
+
+#### 4.3 Start MJAPI (REQUIRED — 19 of the 52 deterministic tests need it)
+
+19 of the 52 deterministic members are **client-transport** and exercise the real GraphQL wire (IT03, IT15, IT23, IT25–IT28, IT31–IT34, IT37, IT40, IT43–IT45, IT47, IT50, IT52). Start MJAPI against the Step-3 database before running:
+
+```bash
+# In a separate shell, pointed at the Step-3 database
+cd packages/MJAPI && npm run start
+```
+
+- `MJ_API_KEY` must be set (process env or repo-root `.env`), and **the same value must be set for the test run** — MJServer reads it from `process.env.MJ_API_KEY` too (`packages/MJServer/src/config.ts`).
+- **Start MJAPI from the *current* build — after Step 7, not before.** For the 19 client-transport bundles, the running server *is* the artifact under test, so a stale `packages/MJServer/dist/` silently tests last week's server. This is not theoretical: a server built before this release's merge fails `transaction-groups.TG5` with `SCOPE BYPASS (bug-register B1): a view:run-only API key executed a Create via ExecuteTransactionGroup` — the check working exactly as designed, reporting that the server it reached lacks the scope gate. Confirm before blaming the product:
+  ```bash
+  ls -t packages/MJServer/dist/resolvers/TransactionGroupResolver.js \
+        packages/MJServer/src/resolvers/TransactionGroupResolver.ts | head -1   # want the dist file
+  ```
+- If MJAPI has been up a long time, restart it fresh — a resource-degraded server produces spurious timeouts.
+
+The two failure modes are **asymmetric, and neither shows up in the exit code**:
+
+| Condition | Result |
+|---|---|
+| MJAPI not reachable | 19 tests **skip-as-PASS** (`SKIPPED (environment gap)`) — a green 52/52 that really ran 33 tests |
+| `MJ_API_KEY` unset or rejected | 19 tests return status `Error` — which **also** exits 0 |
+
+#### 4.4 Run the two suites
+
+```bash
+# 1) Deterministic + mutation axis — from the repo root
+RUN_MUTATION_TESTS=1 npm run test:integration 2>&1 | tee release-deterministic.log
+```
+
+`npm run test:integration` expands to `MJ_INTEGRATION_TEST=1 mj test suite "Integration Tests — Deterministic"`.
+
+- `RUN_MUTATION_TESTS` must be **literally `1`** (`true` and `0` both disable it). The mutation checks are per-check gates *inside* the deterministic bundles, not a separate suite, and they skip **silently** when disabled — the only observable difference is a smaller total check count.
+- `RUN_AGENT_TESTS` does nothing here: the deterministic suite has zero live-model members.
+
+```bash
+# 2) Live-model tier — a SEPARATE suite with its own exit code
+MJ_INTEGRATION_TEST=1 npx mj test suite "Integration Tests — Live Model" 2>&1 | tee release-live-model.log
+```
+
+- **Selecting the suite *is* the opt-in.** The live-model tier is now **default-ON**: `IsTierEnabled` returns `RUN_AGENT_TESTS !== '0'`, so `=1` is a legacy no-op and `RUN_AGENT_TESTS=0` is the *opt-out* — which yields a green 15/15 that executed nothing. A green live run only counts if the log has no `tier 'live-model'` skip lines.
+- **Working provider credentials required.** Each IT prompt binds a 3-model ladder (Google → OpenAI → Groq) and a check asserts failover onto the *secondary* binding, so Google **and** OpenAI keys are the practical minimum; IT54 additionally drives the real shipped agents. **There is no credential preflight — a missing key FAILS the tier, it does not skip.** Verified by blanking `AI_VENDOR_API_KEY__*` and re-running a previously-green bundle: it failed at fixture setup and exited 1, with no skip message. So a keyless run produces red tests that look like product defects.
+- **This tier writes to the database** (agent runs, conversations, `MJ: AI Prompt Models` `Status` toggles) regardless of `RUN_MUTATION_TESTS`. Never point it at production. If a run is killed mid-check, grep the log for `RESTORE FAILED` and confirm the `IT: Failover Agent` bindings are back to `Active`.
+- On a slow release box, raise `AGENT_LIVE_SETTLE_MS` / `AGENT_SETTLE_MS` (default ~5000) rather than treating late fire-and-forget saves as defects.
+
+**Budget (measured on a fully-seeded local run, MJAPI up):** deterministic **≈ 133s** at $0; live model **≈ 570s** (~9.5 min). The runbook's older "~4–5 minutes" figure for the deterministic tier is a ceiling, not a floor — but time it on your own box.
+
+> ⚠️ **Do not read `[COST]` as your actual spend.** The live tier printed `[COST] $0.0000` on a run that made real model calls across 15 bundles, and the persisted `MJ: Test Runs.CostUSD` column was populated-but-zero for 68 of 69 rows. Cost roll-up into test telemetry is not wired through for agent runs, so use your provider dashboards to confirm spend.
+
+- Predictive Studio: the **deterministic PS stack-seam checks (IT14) DO run** in this gate, sidecar-free. Only the live Python-sidecar leg (`PS_INTEGRATION=1`) and the standalone `rigs/ps-*.ts` flows are excluded.
+
+#### 4.5 Verify the result — the exit code is NOT sufficient
+
+The exit code is driven by `failedTests`, which counts **only** status `Failed`. Statuses `Error` and `Timeout`, tier-gated skips, and MJAPI-absent skips all exit **0**. So for each of the two runs:
+
+1. Read the console block: `[SUMMARY] N/M passed (X%)`.
+2. **Deterministic:** require **N === M === 52**. A 100% summary over a smaller M means tests errored or were skipped — it did not pass.
+   **Live model:** require **M === 15** (everything actually ran); `N` may legitimately be < 15, so instead of a number gate, triage every failure per 4.6 — `model-noncompliance:` is accepted variance, anything else blocks.
+3. Confirm the log contains no `SKIPPED (environment gap)` and no `Bootstrap failed:`.
+4. **Get the real status breakdown from the database, not the console.** The console prints `✗ FAILED` for *any* non-passed test, so an `Error` is visually indistinguishable from a `Failed` — and only `Failed` moves the exit code. Query the run you just did:
+   ```sql
+   SELECT Status, COUNT(*) FROM __mj.TestRun
+   WHERE __mj_CreatedAt > DATEADD(minute, -30, GETUTCDATE())
+   GROUP BY Status;     -- want: Passed = 52, nothing else
+   ```
+   A tally like `Error = 19 / Failed = 15 / Passed = 18` is the signature of an environment problem (here: 19 client-transport bundles with no `MJ_API_KEY`), not 34 product defects.
+5. Record both `[SUMMARY]` lines in the release checklist. Per-run telemetry persists to `MJ: Test Runs` / `MJ: Test Suite Runs` (`DurationSeconds`, `CostUSD`, `MachineName`) — useful for trending a bundle that's slowing down.
+
+#### 4.6 On failure — classify before touching anything
+
+- **Environment gap** — `MJAPI is not reachable`, `MJ_API_KEY is not set`, `Bootstrap failed:`, or **exit code 2** (ran inside a process that already owns the cache, e.g. a live MJAPI). Fix the environment, re-run.
+- **A wall of `Unknown integration check bundle '<name>'`** — the private suite package wasn't built, `testing.checkModules` isn't loading, or a global `mj` / wrong cwd. Not a product regression.
+- **Seeding died with `Failed to process field 'TypeID' in MJ: Tests: Lookup failed: No record found in 'MJ: Test Types' where Name='Integration Test'`** — you ran 4.2 before Step 3's `mj sync push --dir ./metadata`, which is what supplies that TestType. The push rolls the DB transaction back and restores the file backups cleanly, so just do Step 3 first and re-run 4.2.
+- **MJAPI refuses to boot with `Schema must contain uniquely named types but contains multiple types named "<X>"`** — a **stale `dist/` orphan**, not a code defect: a resolver whose source was deleted or renamed still has compiled output, and TypeGraphQL loads every resolver in `dist/`, registering the type twice. `tsc` never deletes outputs for removed sources, so another incremental `npm run build` will **not** clear it. Find and remove the orphans, then restart:
+  ```bash
+  for d in packages/MJServer/dist/resolvers/*.js; do b=$(basename "$d" .js); \
+    [ -f "packages/MJServer/src/resolvers/$b.ts" ] || echo "ORPHAN: $d"; done
+  ```
+- **`Test suite not found: Integration Tests — Deterministic`, listing only unrelated suites** — 4.2 was never run against *this* database (or `.env` points somewhere else). Not a product regression.
+- **`IT50 - CodeGen Artifact Consistency` failing on an entity-count mismatch** — checked-in generated types and the migrated schema disagree. Same drift condition Step 3 warns about: **stop and investigate**; do not paper over it with `mj codegen`.
+- **`model-noncompliance:` in the message** — model-behaviour variance on the live tier (the model refused the instructed action after 3 billed attempts), not a product defect and not a flake to wave through. Re-run that bundle before calling it a blocker.
+- **Anything else red** — a real product defect. Re-run the single bundle before re-running the tier:
+  ```bash
+  MJ_INTEGRATION_TEST=1 npx mj test run "IT## - <name>"
+  ```
+
+Do **not** reorder suite membership (client-transport members are deliberately sequenced last — the client bootstrap rebinds the process's global provider), and do not declare the gate green on the exit code alone.
+
+> **Deeper docs:** [`packages/TestingFramework/integration-test-suite/docs/build-engineering-runbook.md`](packages/TestingFramework/integration-test-suite/docs/build-engineering-runbook.md) is the operational runbook (build order, tiers, telemetry, triage), also available as the `/run-integration-tests` slash command. [Integration Testing Quickstart](guides/INTEGRATION_TESTING_QUICKSTART.md) covers architecture and authoring — but its member counts and tier-gating table are currently stale, so take the numbers above as authoritative.
 
 ### Step 5: Check for New Packages
 
@@ -215,6 +373,12 @@ npm install
 
 # 3. Full repo build
 npm run build
+
+# 4. Integration sibling-parity gate (check bundle <-> MJ: Tests metadata drift).
+#    --force is required: turbo's `test` inputs are src/**, vitest.config.*, tsconfig* —
+#    NOT metadata-optional/** or mj.config.cjs — so a warm cache replays a stale PASS
+#    for exactly the metadata-side drift this gate exists to catch.
+npx turbo run test --force --filter=@memberjunction/integration-test-suite
 ```
 
 **Expected behavior:**
@@ -261,6 +425,32 @@ MemberJunction ships migrations for **both** SQL Server and PostgreSQL. SS migra
 
 > **Invariant:** committed `migrations-pg/v5/*.pg.sql` / `*.pg-only.sql` are a deployed historical ledger — byte-for-byte immutable. This step only ever produces PG counterparts for the **new** SS migrations in this release.
 
+#### What PG parity does and does NOT cover today
+
+This step proves **schema parity** — that every new migration lands correctly on PostgreSQL. It does **not** prove **runtime behavior parity**, and it is worth being precise about the gap, because the two are easy to conflate.
+
+| Parity | Covered? | By what |
+|---|---|---|
+| Migrations apply on PG | ✅ Yes | This step + `pg-migrations.yml` (a `postgres:17` service running `mj migrate` with `DB_PLATFORM: postgresql`) |
+| CodeGen / External-Data-Source PG paths | ✅ Partly | `pg-migrations.yml`, `eds-integration.yml` |
+| **Integration suite on PG** (runtime behavior: RunView/RunQuery SQL generation, provider code paths, UUID casing, identifier quoting) | ❌ **No** | Nothing. Zero PG bundles exist |
+
+> ✅ **Scope check — this does NOT block the release.** Ship as normal. The SQL Server integration tier (Step 4) runs and gates exactly as documented; PG migrations are converted, verified against a fresh PG database, and committed in this step; the rest of the release (Steps 5–12) is unaffected. The only thing missing is an *additional* PG run of the test suite, which has never existed. Do not treat any of the following as a reason to halt a build.
+
+**The stated intent is to run the integration suite twice per build — once per backend — for SS/PG parity. That is a roadmap item, not yet a release step.** It cannot be done today by configuration or by provisioning a database — three blockers, all in code:
+
+1. **The testing CLI is SQL-Server-hardcoded, and has no PG driver to switch to.** `packages/TestingFramework/CLI/src/lib/mj-provider.ts` imports `mssql` + `setupSQLServerClient` and builds an mssql pool with no platform branch; `commands/suite.ts` calls it unconditionally, so `DB_PLATFORM` is never read on the `mj test` path. Its `package.json` declares `mssql` and `@memberjunction/sqlserver-dataprovider` and **no PostgreSQL driver at all** — so this is a dependency change as well as a code change. Point `.env` at Postgres and the run dies at `mj-provider.ts` `connectionPool.connect()` — a TDS handshake against a PG server — before a single check executes.
+2. **The PG bootstrap that does exist throws by design.** `testing-integration/src/bootstrap.ts` dispatches to `setupPostgreSQLProvider` when `DB_PLATFORM=postgresql`, but `resolvePostgresContextUser` raises: *"UserCache.Refresh is mssql-only, so PG needs a PG-aware user-cache bootstrap before the integration suites can run against it (tracked Phase-0 prerequisite)."* Its own comment concludes: *"The PG parity CI lane is therefore non-blocking until that framework gap is closed."*
+
+   > **"Couldn't a freshly-migrated PG database with users in it fix this?" No — and it's worth knowing why, because it's the obvious first idea.** The cache is empty on PG for a *code* reason, not a *data* reason: `UserCache.Refresh` (`packages/SQLServerDataProvider/src/UserCache.ts:36`) takes an **`sql.ConnectionPool`** (an mssql type) and runs **T-SQL** — `new sql.Request(pool)` against `` SELECT * FROM [schema].vwUsers ``. On PostgreSQL there is no mssql pool to hand it, and the bracket syntax isn't valid PG anyway; it also swallows its own errors (`catch { LogError(err) }`), so the cache stays silently empty no matter how many users the database holds. Provisioning a database cannot change any of that.
+3. **Even if it ran, it would report false greens.** Bundles whose catalog queries are T-SQL key off the mssql pool, which the PG bootstrap leaves undefined — `metadata-consistency` documents that *"on PG every check skips-as-pass with a logged note."* A green PG run would mean "didn't execute," not "passed."
+
+Enabling it is a **code change, not configuration**: a platform branch (and a PG driver dependency) in `mj-provider.ts`, plus a PG-aware user-cache bootstrap — then a `pg-parity` bundle (Domain 8, catalogued but never built) and a CI lane. Until then, `integration.yml` provisions SQL Server 2022 only and there is no platform matrix.
+
+> **For whoever picks this up: the hard part is already solved elsewhere.** `PostgreSQLCodeGenProvider.SetupDataSource()` (`packages/CodeGenLib/src/Database/providers/postgresql/PostgreSQLCodeGenProvider.ts`) already performs a working PG-native user load — it hand-queries `SELECT * FROM "schema"."vwUsers"` / `"vwUserRoles"` and builds real `UserInfo[]` with the same audit-user semantics (Owner, else first user). Its own comment names the exact gap and the intended fix: *"SQL Server uses `UserCache.Instance.Refresh(pool)` which is hard-typed to `mssql.ConnectionPool`… Refactoring it to be cross-platform would touch that package's public API; until then PG hand-queries `vwUsers`/`vwUserRoles` here. Tracked for follow-up: unify behind a platform-agnostic cache."* So the Phase-0 prerequisite is a known, scoped refactor with a working reference implementation — not open-ended research.
+
+> Track it as a release-readiness gap rather than silently skipping it: PostgreSQL deployments of a release currently ship with migration parity verified and **runtime parity unverified**.
+
 ---
 
 ## Creating the Release
@@ -273,10 +463,10 @@ MemberJunction ships migrations for **both** SQL Server and PostgreSQL. SS migra
 2. The **"Generate Release Notes"** workflow (`generate-release-notes.yml`) will auto-populate the PR title (e.g., `v5.6.0`) and description with structured release notes
 3. Wait for the generated PR message to appear
 4. Wait for **all CI checks** to pass:
-   - `changes.yml` — validates migration filenames, version patterns, schema placeholder usage
-   - `test.yml` — unit tests
-   - `dependency-check.yml` — checks for missing npm dependencies
-   - `claude.yml` — reviews migration files for hardcoded UUIDs
+   - `changes.yml` — validates migration filenames, version patterns, schema placeholder usage. **This is the only workflow that triggers on the release PR itself** (it's the one workflow listening on PRs into `main`).
+   - Everything else you see on the PR is **surfaced from the push-to-`next` run on the same head SHA** — `test.yml` (unit tests), `integration.yml` ("Integration Tier", deterministic suite), `build.yml`, and `migrations.yml` / `pg-migrations.yml` when migrations changed. If any of those are missing rather than green, the `next` tip never got a clean run — go back to Step 1.
+
+   > Two traps in this list: the hardcoded-UUID scan for migrations is now an **advisory, non-blocking** step *inside* `changes.yml` (the old `claude.yml` workflow was deleted) — it posts a sticky PR comment plus a `::warning` and **never fails the job**, so you must read it, not just wait for green. And `dependency-check.yml` only triggers on PRs into `next`, so it will not appear on this PR at all.
 
 ### Step 10: Merge the PR
 
@@ -365,6 +555,7 @@ Go to [ReadMe Dashboard](https://dash.readme.com/):
 | `docker.yml` | After `publish.yml` | Build & push Docker images |
 | `docs.yml` | After `publish.yml` | Deploy TypeDoc to GitHub Pages |
 | `generate-release-notes.yml` | PR to `main` | Auto-generate PR description |
+| `integration.yml` | PR to `next` + push to `next` | Deterministic integration tier against a fresh SQL Server |
 
 ### Migration Naming Convention
 
@@ -392,13 +583,33 @@ mj migrate
 # Push metadata to database
 mj sync push --dir ./metadata
 
-# Push the optional integration metadata (IT tests/suite + RLS principals; the TestType
-# itself lives in normal metadata/) —
-# TEST/CI databases ONLY, never production (kept out of ./metadata on purpose)
-mj sync push --dir ./metadata-optional/integration-test
+# Seed the integration metadata — REQUIRED before Step 4 (IT01-IT66 Tests, the two tier suites,
+# the RLS principals, and the IT agent/prompt/skill/search fixtures; the TestType itself lives in
+# normal metadata/) — TEST/CI databases ONLY, never production (kept out of ./metadata on purpose)
+npx mj sync push --dir ./metadata-optional/integration-test --ci
 
 # SQL logs appear in
 metadata/sql_logging/MetadataSync_Push_*.sql
+```
+
+### Integration Suite Commands
+
+```bash
+# Repo root, repo-local CLI only. MJ_INTEGRATION_TEST=1 is mandatory — without it every
+# server-transport test errors out. Exit code 2 = ran inside a process that already owns
+# the cache (e.g. a live MJAPI).
+
+# Deterministic tier (52 tests) + mutation axis — the release gate
+RUN_MUTATION_TESTS=1 npm run test:integration
+
+# Live-model tier (15 tests) — SEPARATE suite, real LLM cost. Note the em dash.
+MJ_INTEGRATION_TEST=1 npx mj test suite "Integration Tests — Live Model"
+
+# Re-run one bundle during triage
+MJ_INTEGRATION_TEST=1 npx mj test run "IT## - <name>"
+
+# Validate Test/Suite definitions without executing anything
+npx mj test validate --type "Integration Test"
 ```
 
 ### Changeset Commands

--- a/guides/INTEGRATION_TESTING_QUICKSTART.md
+++ b/guides/INTEGRATION_TESTING_QUICKSTART.md
@@ -198,7 +198,7 @@ Every check (and every metadata Test) belongs to a **tier**
 |---|---|---|
 | `deterministic` | Credential-free, read-only or self-cleaning; **the blocking CI gate** | none — always runs |
 | `mutation` | Writes to the DB and cleans up unconditionally | `RUN_MUTATION_TESTS=1` |
-| `live-model` | Real LLM calls — costs tokens, needs model credentials | `RUN_AGENT_TESTS=1` |
+| `live-model` | Real LLM calls — costs tokens, needs model credentials | **default-ON**; opt *out* with `RUN_AGENT_TESTS=0` |
 
 `IsTierEnabled(tier)` is the **single predicate** every consumer (driver, rigs) calls, so a
 gate is honored identically everywhere. Gating exists at two granularities:
@@ -236,12 +236,12 @@ metadata-driven end to end:
 MJ: Test Types ──▶ "Integration Test"  { DriverClass: "IntegrationTestDriver", Status: Active }
       │                                  metadata/test-types/.integration-test-type.json  (normal metadata — inert type def)
       ▼
-MJ: Tests ───────▶ IT01…IT52            Configuration selects bundles + tier + transport
+MJ: Tests ───────▶ IT01…IT66            Configuration selects bundles + tier + transport
       │                                  metadata-optional/integration-test/tests/integration/.IT*.json
       ▼
-MJ: Test Suites ─▶ "Integration Tests"  (parent)
-                   ├─ "Integration Tests — Deterministic"   IT01–IT15, IT20–IT52  (48 members, the blocking tier)
-                   └─ "Integration Tests — Live Model"      IT16–IT19  (opt-in)
+MJ: Test Suites ─▶ "Integration Tests"  (parent — 0 members; running it errors, exit 1)
+                   ├─ "Integration Tests — Deterministic"   IT01–IT15, IT20–IT52, IT64–IT66  (52 members, the blocking tier)
+                   └─ "Integration Tests — Live Model"      IT16–IT19, IT53–IT63  (15 members)
                                          metadata-optional/integration-test/test-suites/.integration-suite.json
       ▼
 MJ: Test Runs ───▶ one row per execution; ResultDetails = the per-check OracleResult[]
@@ -479,7 +479,7 @@ cd packages/TestingFramework/integration-test-suite && npm run test
 | `DB_PLATFORM` | server bootstrap | `sqlserver` (default) or `postgresql` |
 | `MJ_TEST_USER_EMAIL` | server bootstrap | Context-user override (default: Owner-type user, else first user) |
 | `RUN_MUTATION_TESTS=1` | tier gate | Enables the mutation tier / `RequiresMutation` checks |
-| `RUN_AGENT_TESTS=1` | tier gate | Enables the live-model tier / `RequiresLiveModel` checks |
+| `RUN_AGENT_TESTS` | tier gate | Live-model tier / `RequiresLiveModel` checks. **Default-ON** — `IsTierEnabled` returns `RUN_AGENT_TESTS !== '0'`, so `=1` is a no-op kept for back-compat and only `=0` disables. Note `RUN_MUTATION_TESTS` is the opposite: strictly `=== '1'` |
 | `PS_INTEGRATION=1` | `ps-*` rigs | Enables the Predictive Studio flow rigs |
 | `MJ_API_KEY` | client bootstrap | System API key MJAPI accepts via `x-mj-api-key` |
 | `GRAPHQL_PORT` / `GRAPHQL_ROOT_PATH` / `MJAPI_URL` | client bootstrap | Endpoint resolution; `MJAPI_URL` overrides the composed localhost URL |
@@ -814,7 +814,7 @@ sidecar-dependent scripts (`cross-server-invalidation-tests.ts`, `agent-memory-t
 | [`packages/TestingFramework/testing-integration/`](../packages/TestingFramework/testing-integration/) | The **framework** (published): driver, registry, check contracts, bootstraps, tiers, instrumented cache |
 | [`packages/TestingFramework/integration-test-suite/`](../packages/TestingFramework/integration-test-suite/) | The **content** (private, never published): all 30 check bundles, their unit tests, and the standalone rigs |
 | [`metadata/test-types/.integration-test-type.json`](../metadata/test-types/.integration-test-type.json) | The `Integration Test` TestType — an inert type definition, kept in the normal `metadata/` tree |
-| [`metadata-optional/integration-test/`](../metadata-optional/integration-test/) | The optional sibling root — the IT01–IT52 Tests, the suite hierarchy, AND the seeded RLS test users/role/permission. Kept out of the default-pushed `metadata/` tree so these test-only records never reach production. **Must be seeded once per environment** |
+| [`metadata-optional/integration-test/`](../metadata-optional/integration-test/) | The optional sibling root — the IT01–IT66 Tests (67 records), the suite hierarchy, the seeded RLS test users/role/permission, AND the synthetic AI stack the live tier drives (14 `IT: *` agents, 14 prompts, 42 model bindings, a skill, a search scope). One push seeds 242 records. Kept out of the default-pushed `metadata/` tree so these test-only records never reach production. **Must be seeded once per environment** |
 | `mj.config.cjs` → `testing.checkModules` | The runtime seam that loads the private suite package (or a consumer's own check packages) into `mj test` |
 | [`packages/TestingFramework/Engine/`](../packages/TestingFramework/Engine/) | `TestEngine`, `BaseTestDriver`, suite fixture lifecycle |
 | [`packages/TestingFramework/CLI/`](../packages/TestingFramework/CLI/) | `mj test run` / `suite` / `list` / `validate` / `history` |

--- a/packages/TestingFramework/integration-test-suite/docs/build-engineering-runbook.md
+++ b/packages/TestingFramework/integration-test-suite/docs/build-engineering-runbook.md
@@ -25,24 +25,26 @@ Single entry path: **`mj test`** (dispatched from `MJ: Tests` / `MJ: Test Suites
 |---|---|---|---|
 | **Deterministic** (default) | `npm run test:integration` | **Yes — required to pass** | \$0, no LLM |
 | **+ Mutation axis** | `RUN_MUTATION_TESTS=1 npm run test:integration` | Recommended | \$0, self-cleaning writes |
-| **Live-model** | `RUN_AGENT_TESTS=1 MJ_INTEGRATION_TEST=1 mj test suite "Integration Tests — Live Model"` | Nightly / on-demand | Real tokens, < \$1/run |
+| **Live-model** | `MJ_INTEGRATION_TEST=1 mj test suite "Integration Tests — Live Model"` | Nightly / on-demand | Real tokens, < \$1/run |
 | **Predictive Studio** | `PS_INTEGRATION=1 …` | On-demand | Varies |
 
 `npm run test:integration` expands to `MJ_INTEGRATION_TEST=1 mj test suite "Integration Tests — Deterministic"`.
 
-**Environment flags:** `MJ_INTEGRATION_TEST=1` is **required** on every run (it marks the dedicated process whose instrumented cache must be the first `LocalCacheManager` caller). `RUN_MUTATION_TESTS=1`, `RUN_AGENT_TESTS=1`, `PS_INTEGRATION=1` each opt a tier in.
+**Environment flags:** `MJ_INTEGRATION_TEST=1` is **required** on every run (it marks the dedicated process whose instrumented cache must be the first `LocalCacheManager` caller). `RUN_MUTATION_TESTS=1` and `PS_INTEGRATION=1` each opt a tier in — strict `=== '1'`, so `true` does not work.
+
+`RUN_AGENT_TESTS` is **not** an opt-in any more: `IsTierEnabled('live-model')` returns `RUN_AGENT_TESTS !== '0'` (`packages/TestingFramework/testing-integration/src/tiers.ts`), so the live-model tier is **default-ON**, `=1` is a back-compat no-op, and only an explicit `RUN_AGENT_TESTS=0` disables it. What actually keeps live-model checks out of a normal run is **suite selection** — they are members of `"Integration Tests — Live Model"`, and `mj test suite` does not recurse into sibling or child suites. Setting `RUN_AGENT_TESTS=0` while running the live suite yields a green 15/15 that executed nothing.
 
 ### CI recommendation
 - **PR gate:** the deterministic tier (with mutation axis) must pass. It is credential-light, self-cleaning, and $0 — safe to run on every PR against a migrated ephemeral DB.
-- **Nightly:** add the live-model tier (needs provider API keys in the environment; skips cleanly with a loud message if keys are absent).
-- Provider keys are read from the environment / `mj.config.cjs`; the live tier degrades to a documented skip (never a false pass) when they're missing, so a keyless CI leg is safe.
+- **Nightly:** add the live-model tier. It needs working provider API keys in the environment — see the warning below.
+- Provider keys are read from the environment / `mj.config.cjs`. **A keyless leg is NOT safe: the live tier FAILS, it does not skip.** There is no credential preflight in the live bundles, so an absent key surfaces as an ordinary red test — verified by blanking `AI_VENDOR_API_KEY__*` and re-running a previously-green bundle, which failed at fixture setup (`agent-rag-search fixture setup failed: sentinel note save: undefined`) and exited 1, with no skip message anywhere. Gate a keyless CI leg by **not selecting the live suite**, not by relying on a graceful degrade.
 
 ## Reading the results
 
 - Console prints `[SUMMARY] N/M passed (X%)` and per-bundle lines; a failure shows `✗ FAILED` with the failing check's oracle message (e.g. `Oracle 'codegen-determinism.CD6' failed: …`).
 - **Results are persisted** (queryable via `RunView`/`RunQuery`, or a dashboard):
   - `MJ: Test Runs` — one row per bundle: `DurationSeconds`, `PassedChecks` / `FailedChecks` / `TotalChecks`, `Score`, `CostUSD`, `MachineName`, `RunByUserName`, Started/Completed.
-  - `MJ: Test Suite Runs` — one row per suite run: `TotalDurationSeconds`, `TotalTests` / `PassedTests`, `TotalCostUSD`. (Reference: a full deterministic tier is ~50 bundles, ~4–5 minutes wall-clock, \$0.)
+  - `MJ: Test Suite Runs` — one row per suite run: `TotalDurationSeconds`, `TotalTests` / `PassedTests`, `TotalCostUSD`. (Reference: the deterministic tier is **52** bundles, roughly 2–5 minutes wall-clock, \$0 — a fully-seeded local run with MJAPI up measured 127s.)
 - Use these to trend duration over builds and catch a bundle that's slowing down.
 
 ## Triaging a failure (do this before touching anything)


### PR DESCRIPTION
The release runbook's integration-test gate reported that all three tiers passed while one of them never ran. Step 4 told the build engineer to run this:

```bash
RUN_MUTATION_TESTS=1 RUN_AGENT_TESTS=1 npm run test:integration
```

and explained it as "the aggregator spawns each suite in its own process and collapses the per-suite results into one exit code." Neither half is true. `test:integration` is hardcoded to `MJ_INTEGRATION_TEST=1 mj test suite "Integration Tests — Deterministic"`; the live-model tests are members of a **sibling** suite and `mj test suite` does no ParentID walk, so `RUN_AGENT_TESTS=1` on that line ran **zero** live tests. The aggregator (`run-all.ts`) was deleted in the July-2026 restructure. PR #3228 grew the catalog from 30 to 65 bundles, and the runbook still described the pre-restructure world (`IT01–IT23`, one suite).

This is documentation only — no runtime code changes.

## Verified by execution, not by reading

Every command in the rewritten step was run against a throwaway clone of a dev database (`mj migrate` → full `mj sync push` → integration seed → MJAPI), never against the dev database itself.

| What was checked | Result |
|---|---|
| Unseeded DB → suite lookup | `Test suite not found: Integration Tests — Deterministic`, **exit 1** |
| Integration seed | `Created 242 / Errors 0`; the doc's `COUNT(*)` verification query returns `3` |
| Deterministic run, MJAPI down + no `MJ_API_KEY` | persisted tally `Error = 19 / Failed = 15 / Passed = 18` |
| Single client bundle, MJAPI down, key **set** | `Test completed: Passed (Score: 1)` — **exit 0** |
| Full run, migrated + fully synced, MJAPI up | `[SUMMARY] 51/52`, 133s, 0 env-gap skips |
| + baseline `MJ: User Settings` rows | cache-gauntlet 7/7 → **52/52** |
| Live-model suite | `[SUMMARY] 4/15`, 570s |
| Vendor keys blanked, previously-green bundle | **failed** at fixture setup, exit 1, no skip message |

That exercise corrected claims that source-reading alone had gotten wrong:

- **Seeding is mandatory.** The old text said skipping `metadata-optional/integration-test` "keeps the suite green." An unseeded database exits 1 before a single check runs — the suite and Test rows exist only in that root.
- **Two false-green paths, neither visible in the exit code.** `failedTests` counts only status `Failed`, so the 19 `Error` results above would have exited **0** on their own. With MJAPI merely unreachable the same 19 bundles skip-as-**PASS**. The step now requires `N === M === 52` plus a DB-side status tally, because the console prints `✗ FAILED` for `Error` too.
- **`RUN_AGENT_TESTS` is default-ON** (`IsTierEnabled` returns `!== '0'`), so `=1` is a no-op and `=0` silently yields a green 15/15 that executed nothing.
- **Missing provider keys fail the live tier, they do not skip.** `build-engineering-runbook.md` claimed a clean skip, which would make a keyless CI leg look safe.
- **A virgin release database cannot reach 52/52.** `IT29 - Cache Gauntlet` enforces an anti-vacuity floor requiring `MJ: User Settings` to already hold ≥2 rows — so the runbook's own prescribed fresh database could not meet the bar it set. The seeding SQL is now in the step.

## Two choices worth defending

**The live tier is deliberately not gated at 15/15.** `agents-suite.md` documents run-to-run model variance as intentional and "surfaced honestly rather than hidden" — checks use a bounded retry then fail loudly with `model-noncompliance:`. Gating on a pass count would either block good releases or train engineers to ignore reds. The step requires all 15 to *run*, then per-failure triage: `model-noncompliance:` is accepted variance, anything else blocks.

**PostgreSQL parity is documented as a gap, not added as a step.** The intent is to run the suite once per backend. It cannot be done today: the testing CLI builds an `mssql` pool (`mj-provider.ts` → `setupSQLServerClient`, no platform branch) and declares no PG driver, so `DB_PLATFORM` is never read and the run dies at `connectionPool.connect()`; `UserCache.Refresh` is typed to `sql.ConnectionPool` and issues T-SQL, so the context-user cache stays empty regardless of database contents. Provisioning a PG database does not enable it. The section is scoped with an explicit "this does not block the release" callout so neither a human nor an agent reads it as a reason to halt a build, and it points at `PostgreSQLCodeGenProvider.SetupDataSource()`, which already does a working PG-native user load, as the reference for the tracked Phase-0 refactor.

## Not fixed here

- `AIAgentPermissionHelper.ts` lines 138/177/189/201 pass a human message into `LogError`'s `logToFileName` slot, writing a file into the repo root named after the error and discarding the intended context. One-line fix each; product code, so left out of a docs branch.
- The live tier surfaced 216 × "must provide the contextUser parameter" and 14 × "fire-and-forget write never landed", concentrated on #3228's headless-agent area. A startup-mode hypothesis was tested with `MJ_STARTUP_MODE=full` and **refuted**. Unresolved, and deliberately not asserted anywhere in the docs. Confound not eliminated: only targeted turbo builds were run, not a full `npm run build`.

## Scope and risk

No migrations, no metadata, no scheduled jobs, nothing to deploy or push — merging changes no environment. The changeset names `@memberjunction/integration-test-suite`, which is `private: true`, so it is versioned but never published; CI would not have required one (`changes.yml` only gates on migrations), but 64 changesets are already pending and the fixed group bumps once regardless.

The PostgreSQL claims are from code-reading plus three independent traces, deliberately not smoke-tested. No related issue.