### PR TITLE
fix(integration): stop silently truncating nested-child data + two reliability bugs

### DIFF
--- a/.changeset/integration-nested-child-sync-completeness.md
+++ b/.changeset/integration-nested-child-sync-completeness.md
@@ -1,0 +1,11 @@
+---
+"@memberjunction/integration-engine": patch
+"@memberjunction/server": patch
+---
+
+Stop silently truncating nested-child data in REST integration sync, plus two reliability fixes.
+
+- **Nested-child completeness** — `DescendTemplateVars` now drains a parent's FULL paginated child collection instead of capping it at `ctx.BatchSize`. The outer batch size bounds how many PARENTS a call processes (resumable via the parent keyset, never mid-child), so applying it to the per-parent child fetch permanently dropped every record past the first batch with no bookmark to ever revisit it. Live-verified: Wild Apricot Donation/Event/Invoice/Payment (single-parent, capped at 200 each) and a Mailchimp list's full 501-member set now land completely.
+- **Write-verification errors** — classify a create that returns no rows (`"no rows returned from SQL"`) as a distinct, non-retryable `WRITE_VERIFICATION_ERROR` instead of the retryable `DATABASE_ERROR` catch-all; retrying an identical write only reproduces the identical miss.
+- **Narrower DATABASE_ERROR match** — the over-broad `"sql"` substring match was routing deterministic failures through retry-with-backoff for no reason; it now keys on real transient signals (deadlock / connection lost).
+- **StartSync run-detection window** — extend the poll for the run record (fast first 2s, longer tail) so a large connector's synchronous setup (e.g. HubSpot's 168 entity maps) isn't misreported as "no run created" while it is genuinely syncing.

--- a/packages/Integration/engine/src/BaseRESTIntegrationConnector.ts
+++ b/packages/Integration/engine/src/BaseRESTIntegrationConnector.ts
@@ -881,7 +881,22 @@ export abstract class BaseRESTIntegrationConnector extends BaseIntegrationConnec
     ): Promise<void> {
         if (level >= resolutions.length) {
             const fullURL = this.BuildFullURL(baseURL, path);
-            const result = await this.FetchWithPagination(auth, fullURL, obj, ctx);
+            // Leaf-scoped context: the outer ctx.BatchSize bounds how many PARENTS this call
+            // processes (see the resumable AfterKeyValue loop above the first call into this
+            // method) — it is NOT a per-parent record cap. Passing ctx as-is here made
+            // FetchPaginatedLoop cap THIS parent's own child collection at ctx.BatchSize and
+            // return HasMore/NextOffset/NextCursor, which this method then discards (only
+            // result.Records is read) before the caller moves on to the next parent — silently
+            // and PERMANENTLY dropping every record beyond the first batch for that parent, with
+            // no bookmark anywhere that would revisit it on a later sync. Live-verified against
+            // real data: Wild Apricot's Donation/Event/Invoice/Payment (all single-parent,
+            // `/accounts/{accountId}/...`) landed exactly 200 rows each — the batch cap — while
+            // Contact (same shape) landed all 1,275 real rows because it happens to bypass this
+            // path via a bespoke override. A per-parent child collection is finite, already-known
+            // data for an item the engine chose to sync this call; drain it to completion instead
+            // of truncating it.
+            const leafCtx: FetchContext = { ...ctx, BatchSize: Number.MAX_SAFE_INTEGER, CurrentPage: undefined, CurrentOffset: undefined, CurrentCursor: undefined };
+            const result = await this.FetchWithPagination(auth, fullURL, obj, leafCtx);
             for (const r of result.Records) {
                 for (const [k, v] of Object.entries(fkTags)) r[k] = v;
                 const transformed = this.applyTransformPreservingKeys(r, obj, fields);

--- a/packages/Integration/engine/src/__tests__/ErrorClassification.test.ts
+++ b/packages/Integration/engine/src/__tests__/ErrorClassification.test.ts
@@ -47,6 +47,10 @@ describe('IsRetryableError', () => {
         expect(IsRetryableError('CONFIGURATION_ERROR')).toBe(false);
     });
 
+    it('should return false for WRITE_VERIFICATION_ERROR', () => {
+        expect(IsRetryableError('WRITE_VERIFICATION_ERROR')).toBe(false);
+    });
+
     it('should return false for UNKNOWN_ERROR', () => {
         expect(IsRetryableError('UNKNOWN_ERROR')).toBe(false);
     });
@@ -210,10 +214,45 @@ describe('ClassifyError', () => {
             expect(result.Severity).toBe('Critical');
         });
 
-        it('should classify "sql" messages as DATABASE_ERROR', () => {
-            const result = ClassifyError(new Error('SQL Server error 50000'));
+        it('should classify "deadlock" messages as DATABASE_ERROR', () => {
+            const result = ClassifyError(new Error('Transaction was deadlocked on lock resources'));
             expect(result.Code).toBe('DATABASE_ERROR');
             expect(result.Severity).toBe('Critical');
+        });
+
+        it('should classify "connection lost" messages as DATABASE_ERROR', () => {
+            const result = ClassifyError(new Error('SQL Server connection lost'));
+            expect(result.Code).toBe('DATABASE_ERROR');
+            expect(result.Severity).toBe('Critical');
+        });
+
+        it('should NOT classify a bare "SQL" mention with no transient signal as DATABASE_ERROR', () => {
+            // A generic 'sql' substring match is too broad — it matched deterministic failures
+            // (e.g. "SQL Error: no rows returned") just as readily as real transient connection
+            // issues, sending non-retryable bugs through the retry-with-backoff path for no reason.
+            const result = ClassifyError(new Error('SQL Server error 50000'));
+            expect(result.Code).toBe('UNKNOWN_ERROR');
+            expect(result.Severity).toBe('Critical');
+        });
+    });
+
+    describe('WRITE_VERIFICATION_ERROR detection', () => {
+        it('should classify "no rows returned" messages as WRITE_VERIFICATION_ERROR', () => {
+            const result = ClassifyError(new Error('SQL Error: Error creating new record, no rows returned from SQL: ...'));
+            expect(result.Code).toBe('WRITE_VERIFICATION_ERROR');
+            expect(result.Severity).toBe('Critical');
+        });
+
+        it('should be non-retryable — retrying an identical write reproduces the identical miss', () => {
+            const classified = ClassifyError(new Error('Error creating new record, no rows returned from SQL: ...'));
+            expect(IsRetryableError(classified.Code)).toBe(false);
+        });
+
+        it('should take priority over the generic DATABASE_ERROR "sql" signal', () => {
+            // The mssql driver's own error text is "SQL Error: ...", which would otherwise match
+            // the DATABASE_ERROR catch-all — this case must resolve to WRITE_VERIFICATION_ERROR.
+            const result = ClassifyError(new Error('SQL Error: Error creating new record, no rows returned from SQL: SELECT ...'));
+            expect(result.Code).toBe('WRITE_VERIFICATION_ERROR');
         });
     });
 

--- a/packages/Integration/engine/src/__tests__/TemplateVarTraversal.test.ts
+++ b/packages/Integration/engine/src/__tests__/TemplateVarTraversal.test.ts
@@ -127,4 +127,56 @@ describe('BaseRESTIntegrationConnector — multi-level template traversal', () =
         expect(result.Records).toEqual([]);
         expect(c.urls).toEqual([]); // never fetched — bailed before loading
     });
+
+    // Regression for the nested-child pagination truncation bug (found 2026-07-22): a single
+    // parent's child collection larger than ctx.BatchSize must NOT be silently capped. Live-verified
+    // against Wild Apricot's real data — Donation/Event/Invoice/Payment (single-parent, same shape as
+    // this test) each landed exactly ctx.BatchSize (200) rows before the fix, permanently dropping the
+    // rest, with no bookmark to ever resume the excess.
+    it('drains a single parent\'s FULL paginated child collection even when it exceeds ctx.BatchSize', async () => {
+        // /accounts/{AccountId}/donations — one parent (one account), 3 pages of 100 = 300 real children.
+        const fields = [
+            f({ Name: 'AccountId', RelatedIntegrationObjectID: 'objAccount', Status: 'Active', Sequence: 1 }),
+        ];
+        const obj = {
+            ID: 'objDonation', Name: 'donations', APIPath: '/accounts/{AccountId}/donations',
+            SupportsPagination: true, PaginationType: 'Offset', ResponseDataKey: null, DefaultPageSize: 100,
+        } as unknown as MJIntegrationObjectEntity;
+
+        class PaginatingConnector extends TestConnector {
+            private callCount = 0;
+            protected override async MakeHTTPRequest(_a: RESTAuthContext, url: string): Promise<RESTResponse> {
+                this.urls.push(url);
+                this.callCount++;
+                // 3 pages of 100 records each = 300 total; page 4 is empty (end of data).
+                const page = this.callCount;
+                const records = page <= 3
+                    ? Array.from({ length: 100 }, (_, i) => ({ id: `d${(page - 1) * 100 + i}` }))
+                    : [];
+                return { Status: 200, Body: records, Headers: {} } as RESTResponse;
+            }
+            protected override ExtractPaginationInfo(): PaginationState {
+                // HasMore stays true until the 4th (empty) page — a real offset-paginated API's shape.
+                return { HasMore: this.callCount < 4 } as PaginationState;
+            }
+        }
+
+        OBJ_BY_ID['objAccount'] = { ID: 'objAccount', Name: 'Accounts' } as unknown as MJIntegrationObjectEntity;
+        FIELDS['objAccount'] = [f({ Name: 'AccountId', IsPrimaryKey: true, Status: 'Active', Sequence: 1 })];
+        runViewImpl = (params) => {
+            if (params.EntityName === 'MJ: Company Integration Entity Maps') {
+                if (params.ExtraFilter?.includes("ExternalObjectName='Accounts'")) return { Success: true, Results: [{ EntityID: 'eAccount', Entity: 'Accounts' }] };
+                return { Success: true, Results: [] };
+            }
+            if (params.EntityName === 'Accounts') return { Success: true, Results: [{ AccountId: 'acct1' }] };
+            return { Success: false, Results: [] };
+        };
+
+        const c = new PaginatingConnector(obj, fields);
+        // ctx.BatchSize=200 simulates the real per-call cap that used to truncate a single parent's
+        // child pagination. The fix must drain all 300, not stop at 200.
+        const result = await c.FetchChanges({ ...ctx(), ObjectName: 'donations', BatchSize: 200 });
+
+        expect(result.Records.length).toBe(300);
+    });
 });

--- a/packages/Integration/engine/src/types.ts
+++ b/packages/Integration/engine/src/types.ts
@@ -32,6 +32,7 @@ export type SyncErrorCode =
     | 'TRANSFORM_ERROR'
     | 'MATCH_RESOLUTION_ERROR'
     | 'DATABASE_ERROR'
+    | 'WRITE_VERIFICATION_ERROR'
     | 'WATERMARK_INVALID'
     | 'CONFIGURATION_ERROR'
     | 'UNKNOWN_ERROR';
@@ -61,6 +62,19 @@ export function ClassifyError(error: unknown): { Code: SyncErrorCode; Severity: 
     if (lower.includes('duplicate') || lower.includes('unique constraint') || lower.includes('primary key')) {
         return { Code: 'DUPLICATE_KEY', Severity: 'Warning' };
     }
+    // "no rows returned" from a Create's mandatory read-back (spCreate's `SELECT * FROM vw... WHERE
+    // <key columns>`) is a DETERMINISTIC failure — almost always a null/mismatched key-column value
+    // (the U1 class of bug: a PK column silently absent from the generated INSERT/EXEC call, so
+    // `WHERE col = NULL` matches zero rows). Retrying the SAME write with the SAME inputs reproduces
+    // the SAME miss every time — this is NOT a transient condition. Checked BEFORE the generic
+    // 'sql'-substring catch-all below (which this message would otherwise match, since the mssql
+    // driver's own error text is "SQL Error: ..."), and deliberately excluded from
+    // `IsRetryableError` — misclassifying it as `DATABASE_ERROR` sends it through exponential-backoff
+    // retry for the full retry budget before dead-lettering, burning many minutes for a failure that
+    // was never going to resolve on retry.
+    if (lower.includes('no rows returned')) {
+        return { Code: 'WRITE_VERIFICATION_ERROR', Severity: 'Critical' };
+    }
     if (lower.includes('validation') || lower.includes('validate')) {
         return { Code: 'VALIDATION_ERROR', Severity: 'Warning' };
     }
@@ -76,7 +90,11 @@ export function ClassifyError(error: unknown): { Code: SyncErrorCode; Severity: 
     if (lower.includes('configuration') || lower.includes('config')) {
         return { Code: 'CONFIGURATION_ERROR', Severity: 'Critical' };
     }
-    if (lower.includes('connect') || lower.includes('econnrefused') || lower.includes('sql')) {
+    // Genuinely transient/connection-level signals only — NOT a bare 'sql' substring, which matches
+    // almost any DB-flavored error message (including the deterministic one above) and made this
+    // catch-all classify far too much as retryable.
+    if (lower.includes('connect') || lower.includes('econnrefused') || lower.includes('deadlock')
+        || lower.includes('connection') || lower.includes('pool')) {
         return { Code: 'DATABASE_ERROR', Severity: 'Critical' };
     }
     if (lower.includes('connector')) {

--- a/packages/MJServer/src/resolvers/IntegrationDiscoveryResolver.ts
+++ b/packages/MJServer/src/resolvers/IntegrationDiscoveryResolver.ts
@@ -4041,10 +4041,21 @@ export class IntegrationDiscoveryResolver extends ResolverBase {
             // null RunID: an optimistic, untrackable result that read as "started" when nothing
             // could be followed. Poll briefly for ANY run for this connector stamped at/after the
             // fire instant; that catches both the still-running and the already-finished cases.
+            //
+            // The row itself isn't created until executeSyncInternal reaches CreateRunRecord,
+            // which runs AFTER LoadRunConfiguration (loads every entity map + field map + builds
+            // the connector instance) — for a large connector (HubSpot, 168 entity maps) that
+            // synchronous setup alone can take several seconds, so a short fixed poll window can
+            // elapse before the row exists at all, not because the sync failed. Live-verified: a
+            // HubSpot StartSync call reported "no run created" while the run (confirmed present in
+            // the DB moments later) was genuinely syncing. Keep the fast path fast (first 2s still
+            // polled every 200ms) but extend the tail so large connectors get a fair window before
+            // we honestly report failure.
             const firedAtFilter = firedAt.toISOString();
             let run: { ID: string; Status: string } | null = null;
-            for (let attempt = 0; attempt < 15 && !run; attempt++) {
-                await new Promise(resolve => setTimeout(resolve, 200));
+            const pollIntervalsMs = [...Array(10).fill(200), ...Array(20).fill(1000)];
+            for (let attempt = 0; attempt < pollIntervalsMs.length && !run; attempt++) {
+                await new Promise(resolve => setTimeout(resolve, pollIntervalsMs[attempt]));
                 const rv = new RunView();
                 const runResult = await rv.RunView<MJCompanyIntegrationRunEntity>({
                     EntityName: 'MJ: Company Integration Runs',


### PR DESCRIPTION
## Summary

Three real, live-verified bugs found while auditing today's connector test results for data completeness — a round-number rowcount was the tell (Wild Apricot's Donation/Event/Invoice/Payment were each capped at exactly 200 real rows, which turned out to be a batch-size coincidence, not a vendor fact).

1. **Nested-child pagination truncation** (`BaseRESTIntegrationConnector.DescendTemplateVars`) — for any object reached via a template-var/nested path (e.g. `/accounts/{id}/donations`), the leaf fetch discarded `HasMore`/`NextOffset`/`NextCursor` before the loop moved to the next parent, silently and **permanently** capping that parent's child collection at the per-call batch size, with no bookmark to ever resume the rest.
   - Fix: the leaf fetch uses a leaf-scoped context (`BatchSize: MAX_SAFE_INTEGER`) so a parent's own child collection drains to completion; the outer parent-batch bound (already correctly resumable via `AfterKeyValue`) is unaffected.
   - **Live-verified end-to-end** against Wild Apricot: `Donation 200→401`, `Event 200→350`, `Invoice 200→401`, `Payment 200→801` (full sync: 3,312 processed, 3,311 succeeded, 1 unrelated pre-existing failure).
   - New regression test (`TemplateVarTraversal.test.ts`) reproduces the bug directly: fails on the pre-fix code (returns 200 of 300 real records) and passes on the fix.

2. **`IntegrationStartSync` false-negative** (`IntegrationDiscoveryResolver.ts`) — the resolver polled for a newly-created run record for only ~3s (15×200ms) before reporting "no run created." For a large connector (e.g. a 168-object HubSpot instance), the synchronous `LoadRunConfiguration` step alone can take longer than that before `CreateRunRecord` ever runs — the row genuinely doesn't exist yet, the sync isn't actually failing.
   - **Live-verified**: a HubSpot `StartSync` call reported failure while the run (confirmed present moments later) was actively syncing.
   - Fix: keep the fast path fast (first 2s still polled every 200ms) but extend the tail to ~22s total before honestly reporting failure.

3. **`ClassifyError` misclassification** (`types.ts`) — a deterministic write-verification failure ("Error creating new record, no rows returned from SQL" — a null/mismatched key column) was caught by a generic `.includes('sql')` catch-all and classified as a retryable `DATABASE_ERROR`, sending it through the full exponential-backoff retry budget before dead-lettering, even though retrying it reproduces the identical failure every time.
   - Fix: new non-retryable `WRITE_VERIFICATION_ERROR` code + a narrowed transient-only catch-all (deadlock/connection/pool).
   - **Live-reverified** on a real PropFuel sync: 11,712 processed, 0 errors, 0 retries, in place of ~50 minutes of futile retries previously observed.

All three were found and fixed during a live connector-completeness testing session against real vendor data — not speculative or theoretical.

## Test plan
- [x] Engine test suite: 545/545 passing (was 544; +1 new regression test for the pagination fix)
- [x] Regression test proven to fail on pre-fix code and pass on the fix (reverted the fix, confirmed the test fails with the exact predicted symptom, restored the fix)
- [x] Live end-to-end re-verification against real Wild Apricot data (bug #1)
- [x] Live re-verification against real HubSpot sync (bug #2)
- [x] Live re-verification against real PropFuel sync (bug #3)

🤖 Generated with [Claude Code](https://claude.com/claude-code)