### PR TITLE
docs(deployment): gate PG migration content + fix the runbook gaps v5.49.0 exposed

### DIFF
--- a/.changeset/pg-migration-content-gate.md
+++ b/.changeset/pg-migration-content-gate.md
@@ -1,0 +1,43 @@
+---
+"@memberjunction/sql-converter": patch
+---
+
+Add a content gate for converted PostgreSQL migrations. `mj migrate convert` can emit an
+empty `.pg.sql` while printing `unhandled stmts: 0` and exiting `0`, and nothing caught it —
+**an empty migration applies perfectly cleanly, so the fresh-database apply that the release
+process treats as authoritative is structurally incapable of failing on it.** The parity check
+only asserts the counterpart file exists.
+
+This already shipped once. `V202607071019__v5.45.x__Metadata_Sync.pg.sql` is 126 bytes against
+a 12,041-line T-SQL source, so PostgreSQL deployments migrating through v5.45 silently received
+none of that release's curated metadata (#3253). The same behavior recurred three times during
+the v5.49.0 build — header-only stubs, and one file with six bare `;` where six `CREATE INDEX`
+statements belonged. It was found by hand-diffing line counts against sources.
+
+`scripts/check-pg-migration-content.mjs` now runs in `pg-migrations.yml` before the apply step,
+so a failure points at conversion rather than at SQL. Two design points:
+
+- **It counts statements, not lines.** The bare-`;` output was 23 lines carrying zero statements;
+  a line-count heuristic scores that 23 and passes it. Header boilerplate is excluded, since every
+  converted file has it regardless of whether content survived.
+- **The rule is "empty AND undeclared".** Some counterparts are correctly empty — the SQL Server
+  migration may alter a routine PostgreSQL maintains in TypeScript (`metadataSupportObjects.ts`).
+  A blunt "empty fails" rule would produce false positives and get disabled, so an intentional
+  no-op declares itself with `-- PG-EMPTY-BY-DESIGN: <reason>`. The judgement stays with the
+  author; the check only enforces that it was recorded.
+
+Five pre-existing empty counterparts are grandfathered with written reasons, because committed
+`.pg.sql` files are Flyway-checksummed and immutable — editing one breaks `mj migrate` on any
+deployment that already applied it. It is a ratchet rather than an amnesty: the v5.45 entry
+records that it is **not** correct. Investigating another entry narrowed the problem — `v5.38
+Fix_AllowUpdateAPI_On_Virtual_Transition`, previously suspected as a second escape, is correctly
+empty, so confirmed shipped escapes drop from two to one.
+
+The detector self-tests against the real failure shapes, and that step is wired into CI too: a
+neutered comparison and a broken declaration-token regex were both verified to fail it. Without
+it a broken detector would pass everything silently.
+
+This compensates for the converter defect rather than fixing it (#3252, #3254) — `mj migrate
+convert` still writes empty files while reporting success. The `/pg-migrate-experimental` runbook
+and `DEPLOYMENT.md` Step 8 gain the same content check plus a recipe for recovering counterparts
+that feature PRs authored and later deleted by policy.

--- a/.claude/commands/pg-migrate-experimental.md
+++ b/.claude/commands/pg-migrate-experimental.md
@@ -465,7 +465,17 @@ Each of these cost real time. Heed them.
 - For pg_dump, exclude `__mj.flyway_schema_history`, strip `\restrict` and `\unrestrict`, and make `CREATE SCHEMA` idempotent. The data section goes between pre-data and post-data.
 - For the browser test, use the Owner user, build the servers once and early and in parallel, and never restart to fix permissions. Kill a delegated agent that loops on a permission workaround.
 - Run the L3 and L4 scripts from the host, because they use `docker exec`. L1 needs no database. L2 needs the SQL Server compare database, so build it in parallel.
-- The real gate is a clean `mj migrate` on a fresh database. A "0 gaps" result from convert is structural only.
+- The real gate is a clean `mj migrate` on a fresh database. A "0 gaps" result from convert is structural only. **But that gate is blind to an EMPTIED migration — empty SQL applies cleanly.** The converter can write a header-only stub (or bare `;` statements) while printing `unhandled stmts: 0` and exiting 0. This shipped in v5.45 (`Metadata_Sync.pg.sql` = 126 bytes against 12,041 lines) and recurred 3× in v5.49. Run the content check before copy-back — it is also a CI gate in `pg-migrations.yml`:
+  ```bash
+  node scripts/check-pg-migration-content.mjs        # exits 1 on a silently-emptied counterpart
+  ```
+  A counterpart that is *correctly* empty (PG maintains the routine in `metadataSupportObjects.ts`, or never had the defect) must declare itself so it is distinguishable from the bug: `-- PG-EMPTY-BY-DESIGN: <reason>`.
+- **Before hand-authoring a `.needs-hand`, check git history.** Feature PRs sometimes author a counterpart that is later deleted under the "build engineer creates PG migrations" policy — that work is reviewed and recoverable. In v5.49 this recovered a 7,002-line file including a hand-written `BEFORE INSERT FOR EACH ROW` trigger using `pg_advisory_xact_lock`, ~30 minutes before it would have been rewritten from scratch.
+  ```bash
+  git log --all --oneline --diff-filter=A -- '*<MigrationName>.pg.sql'
+  git show <deleting-commit>^:migrations-pg/v5/<file>.pg.sql > /tmp/recovered.pg.sql
+  git log --oneline <deleting-commit>..HEAD -- migrations/v5/<MigrationName>.sql   # blank = SS unchanged, safe to reuse
+  ```
 - Committed `.pg.sql` and `.pg-only.sql` files are immutable. Only ever produce PG counterparts for new SQL Server migrations. Never reconvert or hand-patch a committed one.
 - For `mj codegen`, always use `scripts/pg-codegen-await.mjs`. The bare CLI can fire-and-forget and exit 0 as a silent no-op.
 - The converter's own "EntityField Sequence deduplication" pass edits committed `.pg.sql` files — check `git status migrations-pg/` after every convert. They never ship (Phase-5 copy-back is selective); restoring them in-container needs a `git diff` confirmation + explicit approval first (`git checkout --`/`git restore` are Rule-#3 destructive commands, never run blind). The gate proves whether the dedup mattered (so far: it did not).

--- a/.github/scripts/__tests__/check-pg-migration-content.test.mjs
+++ b/.github/scripts/__tests__/check-pg-migration-content.test.mjs
@@ -1,0 +1,162 @@
+import { describe, it, expect } from 'vitest';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { execFile } from 'node:child_process';
+import { promisify } from 'node:util';
+import {
+    countContentStatements,
+    classify,
+    staleGrandfatherWarnings,
+    SOURCE_STATEMENT_FLOOR,
+    PG_EMPTY_CEILING,
+} from '../../../scripts/check-pg-migration-content.mjs';
+
+const execFileAsync = promisify(execFile);
+const SCRIPT = join(dirname(fileURLToPath(import.meta.url)), '..', '..', '..', 'scripts', 'check-pg-migration-content.mjs');
+
+// The converted-file header every fixture shares — all boilerplate, must count as 0.
+const HEADER = `-- ============================================================================
+-- MemberJunction PostgreSQL Migration — X.sql
+-- ============================================================================
+CREATE EXTENSION IF NOT EXISTS "pgcrypto";
+CREATE SCHEMA IF NOT EXISTS __mj;
+SET search_path TO __mj, public;
+SET standard_conforming_strings = on;
+`;
+
+const indexes = (n) =>
+    Array.from({ length: n }, (_, i) => `CREATE INDEX IX_${i} ON __mj.T${i} (C${i});`).join('\n');
+
+describe('countContentStatements', () => {
+    it('scores bare semicolons as zero — the v5.49 Backfill_Missing_FK_Auto_Indexes shape', () => {
+        expect(countContentStatements(HEADER + '\n;\n\n;\n\n;\n\n;\n\n;\n\n;\n')).toBe(0);
+    });
+
+    it('scores header boilerplate as zero', () => {
+        expect(countContentStatements(HEADER)).toBe(0);
+    });
+
+    it('ignores content wrapped in block comments', () => {
+        expect(countContentStatements('/* CREATE INDEX IX_0 ON __mj.T0 (C0); */')).toBe(0);
+    });
+
+    it('does not count a line comment ending in a semicolon', () => {
+        expect(countContentStatements('-- a comment ending in a semicolon;\nCREATE INDEX "IX" ON __mj."T" ("C");')).toBe(1);
+    });
+
+    it('counts a multi-line DO $mj$ block as one statement', () => {
+        const doBlock = 'DO $mj$\nBEGIN\n  PERFORM __mj."spCreateThing"();\nEND $mj$;';
+        // The naive `;`-splitter sees the internal `PERFORM …;` terminator too, so the block
+        // scores >= 1 — what matters for the gate is that it never scores 0.
+        expect(countContentStatements(doBlock)).toBeGreaterThanOrEqual(1);
+    });
+
+    it('counts each terminated DDL statement', () => {
+        expect(countContentStatements(indexes(12))).toBe(12);
+    });
+
+    it('counts a trailing unterminated statement', () => {
+        expect(countContentStatements('CREATE INDEX IX_0 ON __mj.T0 (C0)')).toBe(1);
+    });
+});
+
+describe('classify — threshold constants are load-bearing', () => {
+    // The floor/ceiling values were validated empirically against every committed pair
+    // (193 at the time): all five real escapes scored pg=0, all legitimately-thin
+    // counterparts scored pg=1 with ss <= 4. Changing either constant changes what
+    // ships silently — this test forces that change to be deliberate.
+    it('locks SOURCE_STATEMENT_FLOOR at 5 and PG_EMPTY_CEILING at 1', () => {
+        expect(SOURCE_STATEMENT_FLOOR).toBe(5);
+        expect(PG_EMPTY_CEILING).toBe(1);
+    });
+});
+
+describe('classify — the pg=0 band (converter dropped everything)', () => {
+    // Statement fusion can shrink output but never to zero. Every real escape in the
+    // committed corpus (v5.45 Metadata_Sync, the v5.49 stubs) scored exactly 0.
+    it('flags a large source emptied to nothing', () => {
+        expect(classify(indexes(12), HEADER).verdict).toBe('suspect');
+    });
+
+    it('flags a 5-statement source emptied to nothing — the review coverage-gap case', () => {
+        // A 5-index FK backfill emptied to a header-only stub previously slipped under
+        // the old `ssStmts <= SOURCE_STATEMENT_FLOOR` short-circuit.
+        expect(classify(indexes(5), HEADER).verdict).toBe('suspect');
+    });
+
+    it('flags even a single-statement source emptied to nothing', () => {
+        expect(classify('ALTER TABLE __mj.T ADD C INT NULL;', HEADER).verdict).toBe('suspect');
+    });
+
+    it('accepts an emptied counterpart of any size when PG-EMPTY-BY-DESIGN is declared', () => {
+        const declared = HEADER + '\n-- PG-EMPTY-BY-DESIGN: PG maintains this proc in metadataSupportObjects.ts.\n';
+        expect(classify(indexes(12), declared).verdict).toBe('documented');
+        expect(classify('ALTER TABLE __mj.T ADD C INT NULL;', declared).verdict).toBe('documented');
+    });
+
+    it('accepts a comment-only source with an empty counterpart — nothing to preserve', () => {
+        expect(classify('-- notes only, no statements\n', HEADER).verdict).toBe('ok');
+    });
+});
+
+describe('classify — the pg=1 band (near-empty, where fusion is real)', () => {
+    it('accepts a thin source fused to one statement — the committed v5.39 extended-property shape', () => {
+        // SS: IF EXISTS guard + sp_dropextendedproperty + sp_addextendedproperty (4 stmts)
+        // legitimately fuses to a single COMMENT ON TABLE in PG.
+        const ss = ['IF EXISTS (SELECT 1 FROM sys.extended_properties) BEGIN EXEC sp_dropextendedproperty @name = N\'MS_Description\';',
+            'END;', 'EXEC sp_addextendedproperty @name = N\'MS_Description\';', 'GO'].join('\n');
+        const pg = HEADER + 'COMMENT ON TABLE __mj."T" IS \'text\';\n';
+        expect(classify(ss, pg).verdict).toBe('ok');
+    });
+
+    it('accepts a single-statement source converted to a single statement', () => {
+        expect(classify('ALTER TABLE __mj.T ADD C INT NULL;', HEADER + 'ALTER TABLE __mj."T" ADD COLUMN "C" INT NULL;\n').verdict).toBe('ok');
+    });
+
+    it('flags a large source shrunk to one undeclared statement', () => {
+        expect(classify(indexes(12), HEADER + 'CREATE INDEX IX_0 ON __mj.T0 (C0);\n').verdict).toBe('suspect');
+    });
+});
+
+describe('classify — full conversions', () => {
+    it('accepts a genuine full conversion', () => {
+        expect(classify(indexes(12), HEADER + indexes(12)).verdict).toBe('ok');
+    });
+});
+
+describe('staleGrandfatherWarnings', () => {
+    it('stays silent while an entry still shields a suspect', () => {
+        const verdicts = new Map([['V1__x', 'suspect']]);
+        expect(staleGrandfatherWarnings(['V1__x'], verdicts)).toEqual([]);
+    });
+
+    it('warns when a grandfathered stem no longer matches any checked pair', () => {
+        const warnings = staleGrandfatherWarnings(['V1__renamed_away'], new Map());
+        expect(warnings).toHaveLength(1);
+        expect(warnings[0]).toContain('V1__renamed_away');
+        expect(warnings[0]).toMatch(/no committed counterpart/i);
+    });
+
+    it('warns when a grandfathered stem no longer classifies as suspect', () => {
+        const warnings = staleGrandfatherWarnings(['V1__x'], new Map([['V1__x', 'ok']]));
+        expect(warnings).toHaveLength(1);
+        expect(warnings[0]).toContain('V1__x');
+        expect(warnings[0]).toMatch(/no longer classifies as suspect/i);
+    });
+});
+
+describe('CLI contract', () => {
+    it('--self-test exits 0 with SELF-TEST PASSED', async () => {
+        const { stdout } = await execFileAsync('node', [SCRIPT, '--self-test']);
+        expect(stdout).toContain('SELF-TEST PASSED');
+    });
+
+    it('an unknown argument exits 2', async () => {
+        await expect(execFileAsync('node', [SCRIPT, '--bogus'])).rejects.toMatchObject({ code: 2 });
+    });
+
+    it('--help exits 0 and prints usage', async () => {
+        const { stdout } = await execFileAsync('node', [SCRIPT, '--help']);
+        expect(stdout).toContain('usage:');
+    });
+});

--- a/.github/workflows/pg-migrations.yml
+++ b/.github/workflows/pg-migrations.yml
@@ -100,6 +100,27 @@ jobs:
             echo "skip_apply=false" >> "$GITHUB_OUTPUT"
           fi
 
+      # ─── Step 3b: Verify PG counterparts have CONTENT, not just existence ──
+      # Step 3 (and the parity test) assert a .pg.sql counterpart EXISTS. Nothing
+      # asserted it contains anything, and that gap shipped a broken release:
+      # v5.45's Metadata_Sync.pg.sql is 126 bytes against 12,041 lines of T-SQL,
+      # so PG deployments migrating through v5.45 silently received none of that
+      # release's metadata.
+      #
+      # Critically, the apply step below CANNOT catch this. An empty migration
+      # applies perfectly cleanly — there is nothing in it to fail. So this must
+      # be its own gate, and it must run BEFORE the apply, where the failure is
+      # still attributable to conversion rather than to SQL.
+      #
+      # The detector self-tests first (same convention as changes.yml running
+      # check-migration-id-determinism.sh --self-test), so a broken detector
+      # fails loudly instead of silently passing everything.
+      - name: Self-test the PG content detector
+        run: node scripts/check-pg-migration-content.mjs --self-test
+
+      - name: Verify PG migration content
+        run: node scripts/check-pg-migration-content.mjs
+
       # ─── Step 4: Bootstrap PG roles ─────────────────────────────────
       # Skyway creates `__mj.flyway_schema_history` itself at startup, so the
       # only thing CI has to seed is the cdp_* roles that migration GRANT

--- a/.github/workflows/pg-migrations.yml
+++ b/.github/workflows/pg-migrations.yml
@@ -14,12 +14,16 @@ on:
       - 'packages/SQLConverter/**'
       - 'packages/CodeGenLib/src/Database/providers/postgresql/**'
       - '.github/workflows/pg-migrations.yml'
+      # The content detector runs in this workflow (self-test + verify steps), so a
+      # PR that changes only the detector must still exercise it here.
+      - 'scripts/check-pg-migration-content.mjs'
   push:
     branches: [next]
     paths:
       - 'migrations/**'
       - 'migrations-pg/**'
       - 'packages/SQLConverter/**'
+      - 'scripts/check-pg-migration-content.mjs'
 
 jobs:
   pg-parity:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,6 +21,10 @@ on:
       - '.github/scripts/check-esm-imports.mjs'
       - '.github/scripts/vitest.config.mts'
       - '.github/scripts/__tests__/**'
+      # The PG migration content detector's unit suite lives in __tests__ above but the
+      # script itself lives in scripts/ — without this entry a detector-only PR never
+      # runs its tests.
+      - 'scripts/check-pg-migration-content.mjs'
   # Full-suite backstop: every merge into next runs ALL package tests, so a runtime-only
   # break (MJ's dynamic @RegisterClass / ClassFactory wiring can couple packages without a
   # package.json edge that turbo's graph sees) can never slip through PR affected-filtering.

--- a/.gitignore
+++ b/.gitignore
@@ -91,6 +91,11 @@ Thumbs.db
 
 *.env
 .env.*
+# Template for the gitignored docker/workbench/.env.database — must stay tracked so a
+# clean checkout can create that file. (docker/workbench/.env.example predates the
+# .env.* rule above and is tracked by grandfathering; this one needs the explicit
+# negation because git only ignores files it isn't already tracking.)
+!docker/workbench/.env.database.example
 mj server info.txt
 member_junction_code_for_documentation.pdf
 member_junction_code_for_documentation.txt

--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -4,11 +4,11 @@ This document covers the end-to-end process for releasing a new version of Membe
 
 > ### 🤖 If you are an AI coding agent running this release
 >
-> **Build a persistent checklist of all 13 steps (0–12) before you start, and tick each one off as it completes.** A release spans hours, several CI waits, and a Docker workbench session, so steps get silently skipped — **Step 5 was nearly missed in v5.49.0** precisely because it sits between two long-running steps and has no CI equivalent to remind you.
+> **Build a persistent checklist of all 12 steps (0–11) before you start, and tick each one off as it completes.** A release spans hours, several CI waits, and a Docker workbench session, so steps get silently skipped — **Step 5 was nearly missed in v5.49.0** precisely because it sits between two long-running steps and has no CI equivalent to remind you.
 >
-> Include the sub-steps that are separately skippable: 3.8 (commit the mj-sync writeback), 4.2 (seed integration metadata), 4.2b (the `UserSetting` floor), 5 (new-package npm placeholders), 7's parity gate, and 11/12.
+> Include the sub-steps that are separately skippable: 3.8 (commit the mj-sync writeback), 4.2 (seed integration metadata), 4.2b (the `UserSetting` floor), 5 (new-package npm placeholders), 7's parity gate, and 11 (the changelog).
 >
-> Steps 5, 11 and 12 are the ones with no automated backstop. If you skip a CI-covered step, something goes red. If you skip those three, nothing does.
+> Steps 5 and 11 are the ones with no automated backstop. If you skip a CI-covered step, something goes red. If you skip those two, nothing does.
 
 > ### Local values differ per engineer — resolve them, don't copy them
 >
@@ -684,19 +684,13 @@ Runs `npm ci` → `npm run build` → `npx typedoc` → deploy to GitHub Pages. 
 
 ## Post-Release Updates
 
-### Step 11: Update MJ Documentation Site
+> ### ⚠️ Removed step — "Update MJ Documentation Site" (the download-page edit)
+>
+> Older releases had a step here to update a per-version download link on the ReadMe docs site. **It no longer exists.** The versioned distribution zip (`Distributions/MemberJunction_Code_Bootstrap.zip`) was retired — the `Distributions/` folder is gone — and `mj install` sparse-fetches from the tagged source on demand, so there is no per-version URL to update each release. The old **Downloads** page (URL slug `quickstart-download`) is hidden/unpublished; its content moved to **"Installation in Minutes"**, which points users at `npx @memberjunction/cli install`.
+>
+> **Nothing to do here per release.** The only residual concern is drift: if "Installation in Minutes" ever shows a hardcoded version link, fix it — but that's a rare one-off, not a release task, so it is no longer a numbered step.
 
-Go to [ReadMe Dashboard](https://dash.readme.com/) → **Guides** → **Getting Started** → **Quick Start Guide**:
-
-1. Open the page titled **"Installation in Minutes"** — this is the live quickstart.
-2. Confirm it points users at the CLI installer — `npx @memberjunction/cli install` (online) or `npx @memberjunction/cli bundle` for an offline/air-gapped zip — rather than a per-version download link.
-3. **Save** — this can be done while the post-merge actions are still running.
-
-> **The page you want is "Installation in Minutes", not "Downloads".** Earlier revisions of this guide said to navigate to the `quickstart-download` slug. That page still exists in the sidebar as **Downloads** but is **hidden/unpublished** — its content moved to "Installation in Minutes". Searching for "quickstart-download" as a title finds nothing, because that is the URL slug, not the display name.
-
-> **Note:** The legacy per-version distribution zip (`Distributions/MemberJunction_Code_Bootstrap.zip`) has been retired — the `Distributions/` folder no longer exists in the repo. `mj install` sparse-fetches and assembles the project from the tagged source on demand, so there is no version-specific URL to update each release. **This step is now a verification, not an edit** — its purpose is to catch drift back toward a hardcoded versioned link, which would be a live 404 for every new user. Read the page rather than assuming.
-
-### Step 12: Update Changelog
+### Step 11: Update Changelog
 
 **Wait until ALL of the following are complete before saving:**
 - [ ] npm packages published
@@ -750,7 +744,7 @@ gh pr view <release-pr-number> --json body --jq .body | pbcopy
 | Git tag `vX.Y.Z` | repo tags | `ci/commit_push.mjs` |
 | Docker images | Docker Hub `memberjunction/api`, Azure ACR | `docker.yml` |
 | API docs | https://memberjunction.github.io/MJ/ | `docs.yml` |
-| Public changelog | ReadMe → Changelog | **manual, Step 12** |
+| Public changelog | ReadMe → Changelog | **manual, Step 11** |
 | ~~GitHub Release~~ | — | **nothing creates one** |
 
 ```bash

--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -30,6 +30,44 @@ This document covers the end-to-end process for releasing a new version of Membe
 > workflow, commit to your prep branch instead — it reaches `next` through the PR.
 > The steps use `next` as shorthand for "the branch that becomes the release."
 
+### Step 0: Preflight — check the environment before you start
+
+These are cheap to verify and expensive to discover mid-release. Every item below cost real time in a previous build.
+
+**1. The workbench env file exists (needed in Step 8).** `docker/workbench/.env.database` is **gitignored** and must exist locally, or `docker compose up` fails with `env file … not found`. Copy the tracked template:
+
+```bash
+cp -n docker/workbench/.env.database.example docker/workbench/.env.database
+```
+
+> The template is the single source for those values — do not retype them here or anywhere else. If you override `SA_PASSWORD` / `PG_PASSWORD` in `docker/workbench/.env`, update `.env.database` to match.
+
+**2. Provider API keys are *valid*, not merely present.** The live-model tier has **no credential preflight** — a dead key fails the tier and the failures look exactly like product defects. In one build an expired Gemini key produced 11 red agent tests that were triaged as a `BaseAgent` regression before the real cause surfaced. Verify before you start:
+
+```bash
+# Google — 200 = good, 400 = dead key
+curl -s -o /dev/null -w 'gemini=%{http_code}\n' \
+  -H "x-goog-api-key: $(grep '^AI_VENDOR_API_KEY__GeminiLLM=' .env | cut -d= -f2- | tr -d "'\"")" \
+  https://generativelanguage.googleapis.com/v1beta/models
+# OpenAI
+curl -s -o /dev/null -w 'openai=%{http_code}\n' https://api.openai.com/v1/models \
+  -H "Authorization: Bearer $(grep '^AI_VENDOR_API_KEY__OpenAILLM=' .env | cut -d= -f2- | tr -d "'\"")"
+```
+
+**3. `MJ_API_KEY` is in repo-root `.env`, not just your shell.** It is a **self-chosen shared secret** — no registry issues it; `MJServer` reads `process.env.MJ_API_KEY` and string-compares it against the `x-mj-api-key` header. Both MJAPI *and* the test run need the same value, so `.env` is the only channel that reliably reaches both. Generate one if absent:
+
+```bash
+grep -q '^MJ_API_KEY=' .env || printf 'MJ_API_KEY=%s\n' "$(openssl rand -hex 32)" >> .env
+```
+
+**4. Docker has headroom.** Step 8's workbench adds four containers plus two turbo builds. Check before you start — an unrelated hot container has starved SQL Server badly enough to masquerade as migration timeouts for over an hour:
+
+```bash
+docker stats --no-stream --format '{{.Name}}\t{{.CPUPerc}}\t{{.MemUsage}}'
+```
+
+Stop anything unrelated. On a < 8 GiB Docker VM, cap every turbo build with `--concurrency=2`.
+
 ### Step 1: Verify CI on `next`
 
 Before anything else, confirm the `next` branch is healthy:
@@ -241,6 +279,8 @@ With those rows present all 7 cache-gauntlet checks pass and the tier reaches 52
 cd packages/MJAPI && npm run start
 ```
 
+> ⚠️ **Run it from `packages/MJAPI`, not `npm run start:api` from the repo root.** The root script is `turbo start --filter=mj_api`, and **turbo passes through only the environment variables declared in `turbo.json`** — anything else is stripped before the task sees it. Overriding the database with `DB_DATABASE=… npm run start:api` therefore fails with `Error parsing config file … "path": ["dbDatabase"] … "received": "undefined"`, which reads like a config-file problem rather than an env-passthrough one. Running from the package directory bypasses turbo entirely and the variables arrive intact.
+
 - `MJ_API_KEY` must be set (process env or repo-root `.env`), and **the same value must be set for the test run** — MJServer reads it from `process.env.MJ_API_KEY` too (`packages/MJServer/src/config.ts`).
 - **Start MJAPI from the *current* build — after Step 7, not before.** For the 19 client-transport bundles, the running server *is* the artifact under test, so a stale `packages/MJServer/dist/` silently tests last week's server. This is not theoretical: a server built before this release's merge fails `transaction-groups.TG5` with `SCOPE BYPASS (bug-register B1): a view:run-only API key executed a Create via ExecuteTransactionGroup` — the check working exactly as designed, reporting that the server it reached lacks the scope gate. Confirm before blaming the product:
   ```bash
@@ -389,10 +429,22 @@ npx turbo run test --force --filter=@memberjunction/integration-test-suite
   - `packages/ServerBootstrapLite/src/generated/`
   - `packages/Angular/Bootstrap/src/generated/`
   - `packages/Angular/BootstrapLite/src/generated/`
-- **You will likely see diffs in these generated files.** This is normal — different PRs merge class registrations independently, and the full build reconciles them into the correct combined manifest. Commit these regenerated files to `next` before creating the release PR.
+- **You will likely see diffs in these generated files.** This is normal — different PRs merge class registrations independently, and the full build reconciles them into the correct combined manifest.
+
+**Decide whether the diff is substantive before committing it.** There are two very different cases, and only one needs a commit:
 
 ```bash
-# If bootstrap files changed, commit them
+# Substantive? Compare the registration COUNT, not the diff size.
+git diff packages/ServerBootstrap/src/generated/mj-class-registrations.ts | grep -E '^[+-]' | grep -vE '^[+-]{3}'
+```
+
+| What changed | Action |
+|---|---|
+| **Import/registration lines added or removed** (the count in the header comment moved, e.g. `105 contain @RegisterClass` → `107`) | **Commit it.** This is the case the step exists for — a missing registration is a runtime failure |
+| **Only the header comment's package-walk count** (e.g. `1211 packages walked` → `1207`), registrations unchanged | **Leave it uncommitted.** `publish.yml` regenerates and commits these post-release itself — `9cc0a42fa5 chore: post-release generated files [skip ci]` did exactly that for v5.48, covering `mj-class-registrations.ts` for both bootstraps plus `version.generated.ts` |
+
+```bash
+# ONLY if registrations actually changed:
 git add packages/ServerBootstrap/src/generated/ packages/ServerBootstrapLite/src/generated/ \
        packages/Angular/Bootstrap/src/generated/ packages/Angular/BootstrapLite/src/generated/
 git commit -m "chore: regenerate bootstrap manifests for release"
@@ -400,6 +452,8 @@ git push origin next
 ```
 
 > **Why this matters:** Git merging catches code-level conflicts, but bootstrap manifests are generated files that concatenate registrations from all packages. Two PRs each adding a new `@RegisterClass` will merge cleanly (no git conflict) but the manifest won't contain both registrations until a full build regenerates it. Skipping this step can cause missing class registrations at runtime.
+>
+> The same reasoning is why a *cosmetic* diff should be left alone: committing it adds release-PR noise for a file CI is about to rewrite anyway. `package-lock.json` changes from `npm install` fall in the same bucket — `publish.yml` updates lock files during the `main` → `next` back-merge.
 
 ---
 
@@ -423,6 +477,49 @@ MemberJunction ships migrations for **both** SQL Server and PostgreSQL. SS migra
 6. The verified `.pg.sql` files are copied back to the host as **uncommitted** changes for review, along with a `migrations-pg/PG_MIGRATION_REPORT.md`.
 
 **After the skill finishes:** review the converted `.pg.sql` files and the report, then **commit them to `next`** so they're included in the release PR. Confirm no `.needs-hand` files were copied back (that would mean conversion is incomplete).
+
+#### 🚨 Verify content, not just existence — the gate cannot do this for you
+
+**The "clean apply" gate is structurally blind to an emptied migration, because empty SQL applies cleanly.** So does the L1 parity script, which only checks that a counterpart file *exists*. A silently-emptied `.pg.sql` passes every automated check in this step and ships.
+
+This is not hypothetical. It has happened in both directions:
+
+- **v5.45** shipped `Metadata_Sync.pg.sql` as a **126-byte marker** — 12,041 lines of SQL Server metadata DML reduced to two comment lines. PostgreSQL deployments migrating through v5.45 silently received none of that release's curated metadata (issue #3253).
+- In a later build the converter emitted **three** header-only stubs and one file containing six bare `;` statements where six `CREATE INDEX` statements belonged — while reporting `unhandled stmts: 0` and exiting successfully (issue #3252).
+
+**Always diff output size against source before committing:**
+
+```bash
+# Every new .pg.sql vs its SS original — investigate anything suspiciously small
+for f in migrations/v5/V*.sql; do
+  b=$(basename "$f" .sql); pg="migrations-pg/v5/${b}.pg.sql"
+  [ -f "$pg" ] || continue
+  ss=$(wc -l < "$f"); p=$(wc -l < "$pg")
+  [ "$p" -le 25 ] && [ "$ss" -gt 60 ] && printf 'SUSPECT %-58s SS=%s PG=%s\n' "${b:0:56}" "$ss" "$p"
+done
+```
+
+**An empty counterpart is sometimes correct** — do not blindly treat every hit as a defect. Two legitimate cases:
+
+- The SS migration modifies a routine that PostgreSQL maintains in **TypeScript** rather than a migration (e.g. `spUpdateExistingEntityFieldsFromSchema` lives in `packages/CodeGenLib/src/Database/providers/postgresql/metadataSupportObjects.ts`). Verify the TS side actually received the equivalent change in this release.
+- PostgreSQL genuinely never had the defect the SS migration fixes.
+
+**When an empty file is correct, say so in the file.** A bare stub is indistinguishable from the silent-emptying bug. Write a header explaining *why* it is empty and what carries the change instead — that turns "empty" from an invisible state into a documented decision a reviewer can check.
+
+#### Check git history before hand-authoring anything
+
+Feature PRs sometimes author their own `.pg.sql` counterparts, which are then **deliberately deleted** under the "build engineer creates PG migrations during the build" policy. That work is reviewed and recoverable — search for it before writing your own:
+
+```bash
+git log --all --oneline --diff-filter=A -- '*<MigrationName>.pg.sql'   # was it ever authored?
+git show <deleting-commit>^:migrations-pg/v5/<file>.pg.sql > /tmp/recovered.pg.sql
+```
+
+In one build this recovered a hand-authored PL/pgSQL trigger (a `BEFORE INSERT FOR EACH ROW` using `pg_advisory_xact_lock`) plus a full CodeGen bake — 7,002 lines that would otherwise have been re-authored from scratch and re-reviewed. Confirm the SS source hasn't changed since the deletion before reusing it:
+
+```bash
+git log --oneline <deleting-commit>..HEAD -- migrations/v5/<MigrationName>.sql   # blank = still matches
+```
 
 > **Invariant:** committed `migrations-pg/v5/*.pg.sql` / `*.pg-only.sql` are a deployed historical ledger — byte-for-byte immutable. This step only ever produces PG counterparts for the **new** SS migrations in this release.
 
@@ -469,6 +566,15 @@ Enabling it is a **code change, not configuration**: a platform branch (and a PG
 
    > Two traps in this list: the hardcoded-UUID scan for migrations is now an **advisory, non-blocking** step *inside* `changes.yml` (the old `claude.yml` workflow was deleted) — it posts a sticky PR comment plus a `::warning` and **never fails the job**, so you must read it, not just wait for green. And `dependency-check.yml` only triggers on PRs into `next`, so it will not appear on this PR at all.
 
+   **Which absences are expected.** "Missing rather than green means go back to Step 1" applies only to checks that *should* have run. Two legitimately never appear on a release PR, and reading their absence as a failure will send you chasing nothing:
+
+   | Check | Why it's absent |
+   |---|---|
+   | `build.yml` ("Build all packages for testing") | Path-filtered to `package-lock.json` and `packages/**`. A release whose only changes are `migrations/`, `migrations-pg/` and `metadata/` does not trigger it. Confirm it was green on the last commit that *did* touch `packages/**` |
+   | `dependency-check.yml` | Triggers on PRs into `next` only |
+
+   To read the advisory UUID scan when no PR comment appears (a clean scan *clears* its comment rather than posting one), check the job log — the step is `Check migration ID determinism (hard-coded UUIDs, not NEWID())`, and the following step being `Clear stale non-deterministic ID comment` is the clean outcome.
+
 ### Step 10: Merge the PR
 
 Once all checks pass, merge the PR into `main`.
@@ -478,6 +584,28 @@ Once all checks pass, merge the PR into `main`.
 ## Post-Merge: Automated Pipeline
 
 Merging to `main` triggers a chain of automated workflows. Monitor each one.
+
+> ## 🚨 Do not cancel `publish.yml`
+>
+> **GitHub's "Cancel workflow" button has no confirmation dialog.** One click, immediate, no undo — and `publish.yml` spends most of its runtime inside a loop publishing ~300 packages to npm. A cancel during that loop leaves the **fixed-version group split across two versions on npm**, and npm has no transaction to roll back.
+>
+> This happened in v5.49.0: an accidental click mid-publish left `@memberjunction/core` and `@memberjunction/global` at the new version while `@memberjunction/cli`, `@memberjunction/sqlserver-dataprovider` and the release's new package stayed behind. The version-bump commit, the git tag, and the `main` → `next` back-merge never ran.
+>
+> **Recovery — it is recoverable, do not panic:**
+>
+> ```bash
+> gh run rerun <run-id> --failed     # re-runs only the failed job; test-migrations is not repeated
+> ```
+>
+> `changeset publish` **skips versions already on npm**, so the re-run publishes only the remainder and then proceeds to bump, tag, and back-merge. Afterwards, verify explicitly rather than trusting the exit code:
+>
+> ```bash
+> npm view @memberjunction/cli version                              # expect the new version
+> git fetch origin --tags && git tag --sort=-creatordate | head -1  # expect vX.Y.Z
+> git show origin/main:packages/MJCore/package.json | grep version  # expect the new version
+> ```
+>
+> If you want to prevent this structurally, a GitHub **environment with a required reviewer** on the publish job makes the dangerous phase distinct from the harmless build phase.
 
 ### 10a. `publish.yml` — Build & Publish Packages
 
@@ -507,7 +635,11 @@ Builds and pushes multi-platform Docker images (`linux/amd64`, `linux/arm64`):
 
 **Triggered by:** `publish.yml` completion
 
-Builds TypeDoc documentation and deploys to GitHub Pages.
+Runs `npm ci` → `npm run build` → `npx typedoc` → deploy to GitHub Pages. Publishes the API reference for every shipped package (`typedoc.json` `entryPoints: ["packages/**"]`, excluding CLI/CodeGen/MJAPI/MJExplorer and generated packages) to **https://memberjunction.github.io/MJ/**.
+
+> This workflow failed silently on every release from v5.45.1 through v5.48.0 — the published docs sat weeks stale while each release otherwise looked green, because `docs.yml` is downstream of the tag and nobody checks it. **Look at its result, not just `publish.yml`'s.**
+
+> **Both 10b and 10c chain off `publish.yml` *completion*, not success.** If `publish.yml` is cancelled or fails, these fire anyway and fail with nothing to install or build — that failure is **collateral, not a real defect**. After re-running `publish.yml` successfully, both trigger again; judge them on the *later* run.
 
 ### Post-Merge Checklist
 
@@ -523,14 +655,15 @@ Builds TypeDoc documentation and deploys to GitHub Pages.
 
 ### Step 11: Update MJ Documentation Site
 
-Go to [ReadMe Dashboard](https://dash.readme.com/):
+Go to [ReadMe Dashboard](https://dash.readme.com/) → **Guides** → **Getting Started** → **Quick Start Guide**:
 
-1. Click **Edit**
-2. Navigate to **quickstart-download**
-3. Confirm the quickstart points users at the CLI installer — `npx @memberjunction/cli install` (online) or `npx @memberjunction/cli bundle` for an offline zip — rather than a per-version download link.
-4. **Save** — this can be done while the post-merge actions are still running
+1. Open the page titled **"Installation in Minutes"** — this is the live quickstart.
+2. Confirm it points users at the CLI installer — `npx @memberjunction/cli install` (online) or `npx @memberjunction/cli bundle` for an offline/air-gapped zip — rather than a per-version download link.
+3. **Save** — this can be done while the post-merge actions are still running.
 
-> **Note:** The legacy per-version distribution zip (`Distributions/MemberJunction_Code_Bootstrap.zip`) has been retired. `mj install` now sparse-fetches and assembles the project from the tagged source on demand, so there is no longer a version-specific zip URL to update each release.
+> **The page you want is "Installation in Minutes", not "Downloads".** Earlier revisions of this guide said to navigate to the `quickstart-download` slug. That page still exists in the sidebar as **Downloads** but is **hidden/unpublished** — its content moved to "Installation in Minutes". Searching for "quickstart-download" as a title finds nothing, because that is the URL slug, not the display name.
+
+> **Note:** The legacy per-version distribution zip (`Distributions/MemberJunction_Code_Bootstrap.zip`) has been retired — the `Distributions/` folder no longer exists in the repo. `mj install` sparse-fetches and assembles the project from the tagged source on demand, so there is no version-specific URL to update each release. **This step is now a verification, not an edit** — its purpose is to catch drift back toward a hardcoded versioned link, which would be a live 404 for every new user. Read the page rather than assuming.
 
 ### Step 12: Update Changelog
 
@@ -538,7 +671,25 @@ Go to [ReadMe Dashboard](https://dash.readme.com/):
 - [ ] npm packages published
 - [ ] Docker images pushed
 
-> Saving the changelog sends a notification to users, so everything must be live first.
+> Saving the changelog **publishes it and notifies your users.** There is no draft-then-notify-later. Everything must be live first.
+
+**Where the content comes from:** the release notes were already written for you. `generate-release-notes.yml` rewrote the `next → main` PR's title and body when you opened it (Step 9), producing a structured `# <headline>` / `## New Features` / `## Improvements` / `## Bug Fixes` document. That PR body **is** the changelog entry.
+
+```bash
+gh pr view <release-pr-number> --json body --jq .body | pbcopy
+```
+
+**Then, in ReadMe:**
+
+1. Left sidebar → **Changelog**
+2. Create a **new** entry (do not edit the previous release's)
+3. **Title:** `vX.Y.Z` — match the existing convention
+4. **Body:** paste. ReadMe renders markdown natively, so backticks and bold survive
+5. Publish
+
+> Two things worth doing before you publish. The body opens with an H1 headline, which may duplicate the entry title — check how the previous release's entry handled it and match. And **skim the Bug Fixes section for accuracy**: the notes are generated from the diff, and this is the one release artifact that goes to users under your name.
+
+> **There is no GitHub Release.** No workflow creates one — `ci/commit_push.mjs` pushes the `vX.Y.Z` *tag* only, and a repo-wide search for `gh release create` / `action-gh-release` finds nothing. Release information lives in three places: this ReadMe changelog entry (users), the release PR body (the source text), and per-package `CHANGELOG.md` files written by changesets (developers).
 
 ---
 
@@ -557,6 +708,25 @@ Go to [ReadMe Dashboard](https://dash.readme.com/):
 | `docs.yml` | After `publish.yml` | Deploy TypeDoc to GitHub Pages |
 | `generate-release-notes.yml` | PR to `main` | Auto-generate PR description |
 | `integration.yml` | PR to `next` + push to `next` | Deterministic integration tier against a fresh SQL Server |
+
+### Where release information lives
+
+| Artifact | Location | Produced by |
+|---|---|---|
+| **Release notes** (the text you paste into chat / the changelog) | Body of the `next → main` PR | `generate-release-notes.yml`, on PR open |
+| Per-package changelogs | `packages/*/CHANGELOG.md` | changesets, in the `RELEASING: Releasing N package(s)` commit |
+| npm packages | `latest` dist-tag | `publish.yml` |
+| Git tag `vX.Y.Z` | repo tags | `ci/commit_push.mjs` |
+| Docker images | Docker Hub `memberjunction/api`, Azure ACR | `docker.yml` |
+| API docs | https://memberjunction.github.io/MJ/ | `docs.yml` |
+| Public changelog | ReadMe → Changelog | **manual, Step 12** |
+| ~~GitHub Release~~ | — | **nothing creates one** |
+
+```bash
+gh pr view <release-pr> --json body --jq .body     # the release notes
+git show <releasing-commit>:packages/MJCore/CHANGELOG.md | head -40
+git log v5.48.0..v5.49.0 --oneline | wc -l          # raw commit count for a release
+```
 
 ### Migration Naming Convention
 

--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -2,6 +2,27 @@
 
 This document covers the end-to-end process for releasing a new version of MemberJunction. All `@memberjunction/*` packages are versioned together (fixed group via changesets).
 
+> ### 🤖 If you are an AI coding agent running this release
+>
+> **Build a persistent checklist of all 13 steps (0–12) before you start, and tick each one off as it completes.** A release spans hours, several CI waits, and a Docker workbench session, so steps get silently skipped — **Step 5 was nearly missed in v5.49.0** precisely because it sits between two long-running steps and has no CI equivalent to remind you.
+>
+> Include the sub-steps that are separately skippable: 3.8 (commit the mj-sync writeback), 4.2 (seed integration metadata), 4.2b (the `UserSetting` floor), 5 (new-package npm placeholders), 7's parity gate, and 11/12.
+>
+> Steps 5, 11 and 12 are the ones with no automated backstop. If you skip a CI-covered step, something goes red. If you skip those three, nothing does.
+
+> ### Local values differ per engineer — resolve them, don't copy them
+>
+> Every port, container name, database name and path in this guide is **an example from one machine**. Ports collide, containers get named differently, and `.env` varies. Read your own before running anything:
+>
+> ```bash
+> grep -E '^(DB_HOST|DB_PORT|DB_DATABASE|GRAPHQL_PORT)=' .env   # your DB + API port
+> docker ps --format '{{.Names}}\t{{.Ports}}'                    # your container names
+> ```
+>
+> Known to vary: the SQL Server container name (`mj-sqlserver-1455` here) and its host port; `GRAPHQL_PORT` (this repo's `.env` uses **4000**, while root `CLAUDE.md` still says 4001); the Explorer port (4200 in the workbench, 4201 on a desktop dev setup); and the scratch release database name. The workbench's own ports are set by `MJAPI_HOST_PORT` / `EXPLORER_HOST_PORT` in `docker/workbench/.env`.
+>
+> Where a command must agree with a running service, derive it rather than typing it — e.g. the integration suite builds its URL from `GRAPHQL_PORT`, so MJAPI and the test run cannot disagree if both read `.env`.
+
 ---
 
 ## Release Types
@@ -76,6 +97,10 @@ Before anything else, confirm the `next` branch is healthy:
 - [ ] **"Test migrations"** (`migrations.yml`) — passes if migrations were changed
 - [ ] **"Unit Tests"** (`test.yml`) — passes on any open PR, and on the **push-to-`next`** run (that unfiltered backstop is the one that actually proves integration-bundle ↔ `MJ: Tests` metadata sibling parity; a metadata-only PR never triggers `test.yml` at all)
 - [ ] **"Integration Tier"** (`integration.yml`) — passes on `next`. Runs the deterministic suite against a fresh SQL Server on PRs into `next` plus an unfiltered push-to-`next` backstop. It is **not** a substitute for Step 4: CI runs no MJAPI (so client-transport bundles skip) and no live-model tier.
+
+> **Don't idle here.** These runs take ~15 minutes. **Step 3 (fresh database + migrate + metadata push) is independent of them** — it works on a local scratch database and reads nothing from CI. Start Step 3 while Step 1 runs and check back. The only ordering that matters is that Step 3's results are committed before the release PR.
+>
+> Step 2 must still precede Step 3, since its model metadata has to be present before the sync push.
 
 ### Step 2: Pull In New AI Models (REQUIRED — every release)
 
@@ -281,7 +306,12 @@ cd packages/MJAPI && npm run start
 
 > ⚠️ **Run it from `packages/MJAPI`, not `npm run start:api` from the repo root.** The root script is `turbo start --filter=mj_api`, and **turbo passes through only the environment variables declared in `turbo.json`** — anything else is stripped before the task sees it. Overriding the database with `DB_DATABASE=… npm run start:api` therefore fails with `Error parsing config file … "path": ["dbDatabase"] … "received": "undefined"`, which reads like a config-file problem rather than an env-passthrough one. Running from the package directory bypasses turbo entirely and the variables arrive intact.
 
-- `MJ_API_KEY` must be set (process env or repo-root `.env`), and **the same value must be set for the test run** — MJServer reads it from `process.env.MJ_API_KEY` too (`packages/MJServer/src/config.ts`).
+- `MJ_API_KEY` must be in **repo-root `.env`** (Step 0.3), not just your shell — MJAPI and the test run are separate processes and both must see the same value. You invent this value; nothing issues it (`MJServer` string-compares `process.env.MJ_API_KEY` against the `x-mj-api-key` header). Confirm it authenticates end-to-end before running the suite, rather than discovering it 19 tests later:
+  ```bash
+  curl -s -o /dev/null -w '%{http_code}\n' -X POST "http://localhost:${GRAPHQL_PORT:-4000}/" \
+    -H 'Content-Type: application/json' -H "x-mj-api-key: $(grep '^MJ_API_KEY=' .env | cut -d= -f2-)" \
+    -d '{"query":"{ __typename }"}'      # 200 = good; 401 = key mismatch
+  ```
 - **Start MJAPI from the *current* build — after Step 7, not before.** For the 19 client-transport bundles, the running server *is* the artifact under test, so a stale `packages/MJServer/dist/` silently tests last week's server. This is not theoretical: a server built before this release's merge fails `transaction-groups.TG5` with `SCOPE BYPASS (bug-register B1): a view:run-only API key executed a Create via ExecuteTransactionGroup` — the check working exactly as designed, reporting that the server it reached lacks the scope gate. Confirm before blaming the product:
   ```bash
   ls -t packages/MJServer/dist/resolvers/TransactionGroupResolver.js \
@@ -358,6 +388,7 @@ The exit code is driven by `failedTests`, which counts **only** status `Failed`.
   ```bash
   MJ_INTEGRATION_TEST=1 npx mj test run "IT## - <name>"
   ```
+  > 🚨 **Do NOT use single-bundle re-run to triage the live-agent bundles (IT53–IT62).** `mj test run` takes a **different transport path** than the same bundle inside the suite: `agent-loop-live` is not in the `CLIENT_BUNDLES` set (`IntegrationTestDriver.ts`), so standalone it executes the agent **in-process** with no server `contextUser`, fails 7/7, and floods the log with `[CRITICAL] … must provide the contextUser parameter`. In-suite it passes, because an earlier client bundle rebinds the process's global provider. Re-run the **whole live suite** for those. Tracked as **#3251**. Single-bundle triage remains valid for deterministic bundles.
 
 Do **not** reorder suite membership (client-transport members are deliberately sequenced last — the client bootstrap rebinds the process's global provider), and do not declare the gate green on the exit code alone.
 

--- a/docker/workbench/.env.database.example
+++ b/docker/workbench/.env.database.example
@@ -1,0 +1,34 @@
+# Template for docker/workbench/.env.database
+#
+#   cp docker/workbench/.env.database.example docker/workbench/.env.database
+#
+# The real .env.database is GITIGNORED (.gitignore:93 `.env.*`) and is NOT in the repo.
+# docker-compose.yml requires it (`env_file:` on claude-dev, plus a read-only mount at
+# /workspace/.env.database), so `docker compose up` on a clean checkout fails with
+# "env file ... not found" until you create it.
+#
+# These are docker-internal credentials for throwaway containers on a private network —
+# not secrets. They mirror the defaults in entrypoint.sh and docker-compose.yml. If you
+# override SA_PASSWORD / PG_PASSWORD in docker/workbench/.env, change them here to match.
+
+# ─── SQL Server (sql-claude container) ───────────────────────────────────────
+DB_HOST=sql-claude
+DB_PORT=1433
+DB_USERNAME=sa
+DB_PASSWORD=Claude2Sql99
+CODEGEN_DB_USERNAME=sa
+CODEGEN_DB_PASSWORD=Claude2Sql99
+DB_DATABASE=MJ_Workbench
+DB_TRUST_SERVER_CERTIFICATE=true
+DB_ENCRYPT=false
+
+# ─── PostgreSQL (postgres-claude container; opt-in via --profile postgres) ────
+PG_HOST=postgres-claude
+PG_PORT=5432
+PG_USERNAME=mj_admin
+PG_PASSWORD=Claude2Pg99
+PG_DATABASE=MJ_Workbench_PG
+
+# ─── MJ ──────────────────────────────────────────────────────────────────────
+MJ_CORE_SCHEMA=__mj
+GRAPHQL_PORT=4000

--- a/docker/workbench/README.md
+++ b/docker/workbench/README.md
@@ -666,7 +666,8 @@ docker compose down -v     # removes containers AND all data volumes
 | `auth-setup.sh` | Interactive Auth0 credential setup + Angular environment generation |
 | `db-bootstrap.sh` | Database creation and migration script |
 | `.zshrc` | Oh-My-Zsh config with all aliases (including browser automation) |
-| `.env.database` | SQL + MJAPI connection details (committed, docker-internal only) |
+| `.env.database` | SQL + MJAPI connection details, docker-internal only. **Gitignored — you must create it** (`cp .env.database.example .env.database`) or `docker compose up` fails with `env file … not found` |
+| `.env.database.example` | Template for the above (tracked) |
 | `.env.example` | Template for user-specific settings |
 | `claude-settings.json` | Pre-approved Claude Code permissions (includes playwright-cli) |
 | `start.sh` | One-command setup script |

--- a/scripts/check-pg-migration-content.mjs
+++ b/scripts/check-pg-migration-content.mjs
@@ -1,0 +1,315 @@
+#!/usr/bin/env node
+/**
+ * PG migration CONTENT check — the sibling of check-pg-migration-parity.mjs.
+ *
+ * WHY THIS EXISTS
+ * ---------------
+ * check-pg-migration-parity.mjs asserts a `.pg.sql` counterpart EXISTS. Nothing
+ * asserts it contains anything. That gap has shipped a broken release:
+ *
+ *   v5.45  V202607071019__v5.45.x__Metadata_Sync.sql   12,041 lines
+ *          V202607071019__v5.45.x__Metadata_Sync.pg.sql   126 BYTES (2 comments)
+ *
+ * PostgreSQL deployments migrating through v5.45 silently received none of that
+ * release's curated metadata. Every automated check passed, because the check
+ * everyone treats as authoritative — a clean `mj migrate` on a fresh PG database —
+ * is structurally incapable of catching it: EMPTY SQL APPLIES CLEANLY.
+ *
+ * The same failure recurred during the v5.49.0 build: `mj migrate convert` emitted
+ * three header-only stubs and one file containing six bare `;` where six
+ * CREATE INDEX statements belonged, while reporting `unhandled stmts: 0` and
+ * exiting 0. It was caught by hand-diffing line counts. This script is that diff,
+ * made non-optional.
+ *
+ * WHAT IT DOES NOT DO
+ * -------------------
+ * It does not judge SQL correctness — `mj migrate` on a fresh DB does that, and
+ * does it well. This only answers "did the converter silently drop everything?"
+ *
+ * INTENTIONALLY-EMPTY COUNTERPARTS
+ * --------------------------------
+ * Some counterparts are legitimately empty. In v5.49.0 two were: the SS migration
+ * altered `spUpdateExistingEntityFieldsFromSchema`, which PostgreSQL maintains in
+ * TypeScript (CodeGenLib/.../postgresql/metadataSupportObjects.ts), not in a
+ * migration. A blunt "empty = fail" rule would cry wolf and be disabled inside two
+ * releases.
+ *
+ * So the rule is not "is this empty?" but "is this empty AND undocumented?".
+ * An intentionally-empty counterpart must declare itself:
+ *
+ *     -- PG-EMPTY-BY-DESIGN: <reason>
+ *
+ * That converts a convention a reviewer might notice into a postcondition that
+ * cannot be skipped, while leaving the judgement itself with the human.
+ *
+ * USAGE
+ *   node scripts/check-pg-migration-content.mjs              # check the repo
+ *   node scripts/check-pg-migration-content.mjs --self-test  # validate the detector
+ *
+ * EXIT  0 = clean · 1 = suspect counterpart(s) · 2 = usage error
+ */
+
+import { readFileSync, existsSync, readdirSync } from 'node:fs';
+import { join, basename, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const SS_DIR = 'migrations/v5';
+const PG_DIR = 'migrations-pg/v5';
+
+/** A source this small can legitimately produce a near-empty counterpart. */
+const SOURCE_STATEMENT_FLOOR = 5;
+/** At/below this many real statements, a counterpart is "effectively empty". */
+const PG_EMPTY_CEILING = 1;
+
+const DESIGN_TOKEN = /^\s*--\s*PG-EMPTY-BY-DESIGN:\s*\S/m;
+
+/**
+ * Grandfathered counterparts — a RATCHET, not an amnesty.
+ *
+ * These predate the PG-EMPTY-BY-DESIGN convention and CANNOT be retrofitted:
+ * committed `.pg.sql` files are byte-for-byte immutable because Flyway checksums
+ * them, so editing one breaks `mj migrate` on every deployment that already applied
+ * it. The reason therefore lives here instead of in the file.
+ *
+ * Anything NOT on this list must be fixed or must declare itself. Do not add
+ * entries to silence a new failure — that is the exact reflex this script exists
+ * to prevent. Add one only for a file that is genuinely immutable AND genuinely
+ * correct, with the reason written out.
+ */
+const GRANDFATHERED = new Map([
+  ['V202605281538__v5.38.x__Fix_AllowUpdateAPI_On_Virtual_Transition',
+   'Correctly empty. Alters spUpdateExistingEntityFieldsFromSchema, which PostgreSQL ' +
+   'maintains in CodeGenLib/.../postgresql/metadataSupportObjects.ts, not in a migration.'],
+
+  ['V202607071019__v5.45.x__Metadata_Sync',
+   'NOT correct — a real, shipped gap (issue #3253). The converter emitted a 126-byte ' +
+   'reseed marker for 12,041 lines of metadata DML. PG deployments that migrated through ' +
+   'v5.45 need `mj sync push` to be whole. Immutable now; tracked for a forward-fix.'],
+
+  ['V202607202000__v5.49.x__SS_Materialize_Catalog_Views_spUpdateExistingEntityFields',
+   'Correctly empty — same proc/TypeScript split as the v5.38 entry above. Committed ' +
+   'before this check existed; PG side landed in metadataSupportObjects.ts via d23aa8952c.'],
+
+  ['V202607202100__v5.49.x__SoftPK_Guard_Materialized_spUpdateExistingEntityFieldsFromSchema',
+   'Correctly empty — same proc/TypeScript split. The U2 soft-PK guard is present in ' +
+   'metadataSupportObjects.ts with matching semantics.'],
+
+  ['V202607202110__v5.49.x__Fix_ConversationDetail_Sequence_Deadlock',
+   'Correctly empty — PostgreSQL never had the AFTER-trigger deadlock the SS migration ' +
+   'fixes; its trigger is already BEFORE ROW + pg_advisory_xact_lock. The file carries a ' +
+   'prose explanation but predates the machine-readable token.'],
+]);
+
+/**
+ * Boilerplate every converted file carries. These are real statements but say
+ * nothing about whether the migration's CONTENT survived, so they don't count.
+ */
+const BOILERPLATE = [
+  /^\s*CREATE\s+EXTENSION\s+IF\s+NOT\s+EXISTS/i,
+  /^\s*CREATE\s+SCHEMA\s+IF\s+NOT\s+EXISTS/i,
+  /^\s*SET\s+search_path/i,
+  /^\s*SET\s+standard_conforming_strings/i,
+];
+
+/**
+ * Count statements that carry actual migration content.
+ *
+ * Deliberately counts STATEMENTS, not lines: the v5.49 `Backfill_Missing_FK_Auto_Indexes`
+ * failure emitted six bare `;` — 23 lines of "output" carrying zero statements. A
+ * line-count heuristic scores that 23 and waves it through; this scores it 0.
+ */
+export function countContentStatements(sql) {
+  const withoutBlockComments = sql.replace(/\/\*[\s\S]*?\*\//g, ' ');
+  const lines = withoutBlockComments
+    .split('\n')
+    .map((l) => l.replace(/--.*$/, '').trim())
+    .filter(Boolean);
+
+  let count = 0;
+  let buffer = '';
+  for (const line of lines) {
+    buffer += (buffer ? ' ' : '') + line;
+    if (!line.endsWith(';')) continue;
+
+    const stmt = buffer.trim();
+    buffer = '';
+    if (stmt === ';') continue;                              // a bare `;` is not content
+    if (BOILERPLATE.some((re) => re.test(stmt))) continue;   // header scaffolding
+    count++;
+  }
+  if (buffer.trim()) count++;                                // trailing unterminated block
+  return count;
+}
+
+/** @returns {{verdict:'ok'|'documented'|'suspect', ssStmts:number, pgStmts:number}} */
+export function classify(ssSql, pgSql) {
+  const ssStmts = countContentStatements(ssSql);
+  const pgStmts = countContentStatements(pgSql);
+
+  if (ssStmts <= SOURCE_STATEMENT_FLOOR) return { verdict: 'ok', ssStmts, pgStmts };
+  if (pgStmts > PG_EMPTY_CEILING) return { verdict: 'ok', ssStmts, pgStmts };
+  if (DESIGN_TOKEN.test(pgSql)) return { verdict: 'documented', ssStmts, pgStmts };
+  return { verdict: 'suspect', ssStmts, pgStmts };
+}
+
+function runCheck() {
+  if (!existsSync(SS_DIR) || !existsSync(PG_DIR)) {
+    console.error(`Run from the repo root — ${SS_DIR} / ${PG_DIR} not found.`);
+    return 2;
+  }
+
+  const suspects = [];
+  let checked = 0;
+  let documented = 0;
+  let grandfathered = 0;
+
+  for (const f of readdirSync(SS_DIR).filter((f) => /^V\d{12}__.*\.sql$/.test(f)).sort()) {
+    const stem = basename(f, '.sql');
+    const pgPath = join(PG_DIR, `${stem}.pg.sql`);
+    if (!existsSync(pgPath)) continue;   // existence is check-pg-migration-parity.mjs's job
+
+    checked++;
+    const { verdict, ssStmts, pgStmts } = classify(
+      readFileSync(join(SS_DIR, f), 'utf8'),
+      readFileSync(pgPath, 'utf8'),
+    );
+    if (verdict === 'documented') {
+      documented++;
+      console.log(`ok (documented no-op): ${stem}`);
+    } else if (verdict === 'suspect') {
+      if (GRANDFATHERED.has(stem)) {
+        grandfathered++;
+        console.log(`ok (grandfathered)   : ${stem}`);
+      } else {
+        suspects.push({ stem, ssStmts, pgStmts });
+      }
+    }
+  }
+
+  if (suspects.length === 0) {
+    console.log(
+      `PG content OK — ${checked} counterpart(s) checked, ` +
+      `${documented} documented no-op(s), ${grandfathered} grandfathered, 0 suspect.`,
+    );
+    return 0;
+  }
+
+  console.error(`\nPG content FAILED — ${suspects.length} counterpart(s) look silently emptied:\n`);
+  for (const s of suspects) {
+    console.error(`  ${s.stem}`);
+    console.error(`      source has ${s.ssStmts} content statement(s); PG counterpart has ${s.pgStmts}.`);
+  }
+  console.error(`
+This is the failure mode that shipped in v5.45 (see the header of this script) and
+recurred during the v5.49.0 build. The converter can report success while writing
+nothing, and a clean 'mj migrate' cannot detect it because empty SQL applies fine.
+
+For each file above, do ONE of:
+
+  1. Re-convert / hand-author the missing DDL. Check git history first — feature PRs
+     sometimes authored a counterpart that was later deleted by policy:
+         git log --all --oneline --diff-filter=A -- '*<Name>.pg.sql'
+
+  2. If the counterpart is CORRECTLY empty (e.g. PostgreSQL maintains that routine in
+     TypeScript, or never had the defect the SS migration fixes), declare it in the file:
+         -- PG-EMPTY-BY-DESIGN: <why, and what carries the change instead>
+`);
+  return 1;
+}
+
+// ── Self-test ───────────────────────────────────────────────────────────────────
+// Fixtures are the REAL shapes seen in production, not invented ones.
+function selfTest() {
+  let fail = 0;
+  const assert = (expected, ss, pg, label) => {
+    const { verdict } = classify(ss, pg);
+    if (verdict === expected) {
+      console.log(`ok   (${expected.padEnd(10)}): ${label}`);
+    } else {
+      console.log(`FAIL (expected ${expected}, got ${verdict}): ${label}`);
+      fail = 1;
+    }
+  };
+
+  const HEADER = `-- ============================================================================
+-- MemberJunction PostgreSQL Migration — X.sql
+-- ============================================================================
+CREATE EXTENSION IF NOT EXISTS "pgcrypto";
+CREATE SCHEMA IF NOT EXISTS __mj;
+SET search_path TO __mj, public;
+SET standard_conforming_strings = on;
+`;
+
+  const REAL_SOURCE = Array.from(
+    { length: 12 },
+    (_, i) => `CREATE INDEX IX_${i} ON __mj.T${i} (C${i});`,
+  ).join('\n');
+
+  // ── Must FLAG ──
+  assert('suspect', REAL_SOURCE, HEADER + '\n-- X.sql — no DDL to translate.\n',
+    'header-only stub ("no DDL to translate") [v5.49 Fix_ConversationDetail_Sequence_Deadlock]');
+
+  assert('suspect', REAL_SOURCE, HEADER + '\n;\n\n;\n\n;\n\n;\n\n;\n\n;\n',
+    'bare semicolons, no statements [v5.49 Backfill_Missing_FK_Auto_Indexes]');
+
+  assert('suspect',
+    Array.from({ length: 400 }, (_, i) => `EXEC __mj.spCreateThing @ID='${i}';`).join('\n'),
+    '-- Metadata_Sync.sql — no DDL to translate.\n-- Metadata is re-seeded via `mj sync push` against PG.\n',
+    '126-byte reseed marker [v5.45 Metadata_Sync — actually shipped]');
+
+  assert('suspect', REAL_SOURCE, HEADER,
+    'header only, nothing after it at all');
+
+  assert('suspect', REAL_SOURCE,
+    HEADER + '\n/* CREATE INDEX IX_0 ON __mj.T0 (C0); */\n',
+    'content present but entirely commented out');
+
+  // ── Must NOT flag ──
+  assert('documented', REAL_SOURCE,
+    HEADER + '\n-- PG-EMPTY-BY-DESIGN: PG maintains this proc in metadataSupportObjects.ts.\n',
+    'intentionally empty WITH the declaration token');
+
+  assert('ok', REAL_SOURCE,
+    HEADER + Array.from({ length: 12 }, (_, i) =>
+      `CREATE INDEX IF NOT EXISTS "IX_${i}" ON __mj."T${i}" USING btree ("C${i}");`).join('\n'),
+    'genuine full conversion');
+
+  assert('ok', 'ALTER TABLE __mj.T ADD C INT NULL;', HEADER,
+    'tiny source (1 statement) — must not false-positive on a legitimately thin migration');
+
+  assert('ok', REAL_SOURCE,
+    HEADER + '\nDO $mj$\nDECLARE p_ID UUID;\nBEGIN\n  p_ID := gen_random_uuid();\n  PERFORM __mj."spCreateThing"(p_ID := p_ID);\nEND $mj$;\n',
+    'multi-line DO $mj$ block counts as content [v5.49 Metadata_Sync, correct output]');
+
+  assert('ok', REAL_SOURCE,
+    HEADER + '\n-- a comment ending in a semicolon;\nCREATE INDEX "IX_a" ON __mj."T" ("C");\nCREATE INDEX "IX_b" ON __mj."T" ("D");\n',
+    'comment ending in `;` must not be miscounted as a statement');
+
+  if (fail) {
+    console.log('\nSELF-TEST FAILED');
+    return 1;
+  }
+  console.log('\nSELF-TEST PASSED');
+  return 0;
+}
+
+// ── Entry point ─────────────────────────────────────────────────────────────────
+// Guarded so the module can be IMPORTED without executing. `classify` and
+// `countContentStatements` are exported for unit tests; without this guard a bare
+// `import` would run the full repo check and call process.exit, making them
+// unreachable to any test that imports them.
+function main() {
+  const arg = process.argv[2] ?? '';
+  if (arg === '--self-test') return selfTest();
+  if (arg === '-h' || arg === '--help') {
+    console.log('usage: node scripts/check-pg-migration-content.mjs [--self-test]');
+    return 0;
+  }
+  if (arg === '') return runCheck();
+  console.error(`unknown argument: ${arg}`);
+  return 2;
+}
+
+const invokedDirectly =
+  process.argv[1] && resolve(process.argv[1]) === fileURLToPath(import.meta.url);
+if (invokedDirectly) process.exit(main());

--- a/scripts/check-pg-migration-content.mjs
+++ b/scripts/check-pg-migration-content.mjs
@@ -56,10 +56,18 @@ import { fileURLToPath } from 'node:url';
 const SS_DIR = 'migrations/v5';
 const PG_DIR = 'migrations-pg/v5';
 
-/** A source this small can legitimately produce a near-empty counterpart. */
-const SOURCE_STATEMENT_FLOOR = 5;
+/**
+ * A source this small can legitimately FUSE to a single PG statement — e.g. the
+ * committed v5.39 pair where an IF EXISTS guard + sp_dropextendedproperty +
+ * sp_addextendedproperty (4 SS statements) correctly becomes one COMMENT ON TABLE.
+ * The floor applies ONLY to the pg=1 band. A counterpart with ZERO content
+ * statements is suspect at ANY source size: fusion can shrink output, but never
+ * to nothing. Empirically (all 193 committed pairs as of v5.49.0): every real
+ * escape scored pg=0; every legitimately-thin counterpart scored pg=1 with ss<=4.
+ */
+export const SOURCE_STATEMENT_FLOOR = 5;
 /** At/below this many real statements, a counterpart is "effectively empty". */
-const PG_EMPTY_CEILING = 1;
+export const PG_EMPTY_CEILING = 1;
 
 const DESIGN_TOKEN = /^\s*--\s*PG-EMPTY-BY-DESIGN:\s*\S/m;
 
@@ -117,6 +125,14 @@ const BOILERPLATE = [
  * Deliberately counts STATEMENTS, not lines: the v5.49 `Backfill_Missing_FK_Auto_Indexes`
  * failure emitted six bare `;` — 23 lines of "output" carrying zero statements. A
  * line-count heuristic scores that 23 and waves it through; this scores it 0.
+ *
+ * KNOWN HEURISTIC EDGES (accepted — this is a magnitude detector, not a parser):
+ * - `--` or `/*` inside a string literal is mis-stripped as a comment. Worst case a
+ *   statement is miscounted, never zeroed, so the empty-vs-nonempty verdict holds.
+ * - The SS side assumes `;`-terminated statements. A T-SQL file written with bare
+ *   `GO` batches and no semicolons under-counts (each batch scores as one trailing
+ *   block at most). MJ migrations are semicolon-terminated by convention; if that
+ *   ever changes, revisit this before trusting the ss counts.
  */
 export function countContentStatements(sql) {
   const withoutBlockComments = sql.replace(/\/\*[\s\S]*?\*\//g, ' ');
@@ -145,11 +161,44 @@ export function countContentStatements(sql) {
 export function classify(ssSql, pgSql) {
   const ssStmts = countContentStatements(ssSql);
   const pgStmts = countContentStatements(pgSql);
+  const ok = { verdict: 'ok', ssStmts, pgStmts };
+  const emptyVerdict = { verdict: DESIGN_TOKEN.test(pgSql) ? 'documented' : 'suspect', ssStmts, pgStmts };
 
-  if (ssStmts <= SOURCE_STATEMENT_FLOOR) return { verdict: 'ok', ssStmts, pgStmts };
-  if (pgStmts > PG_EMPTY_CEILING) return { verdict: 'ok', ssStmts, pgStmts };
-  if (DESIGN_TOKEN.test(pgSql)) return { verdict: 'documented', ssStmts, pgStmts };
-  return { verdict: 'suspect', ssStmts, pgStmts };
+  if (ssStmts === 0) return ok;                        // comment-only source: nothing to preserve
+  if (pgStmts === 0) return emptyVerdict;              // fusion never reaches zero — suspect at ANY source size
+  if (pgStmts > PG_EMPTY_CEILING) return ok;
+  if (ssStmts <= SOURCE_STATEMENT_FLOOR) return ok;    // pg=1 from a thin source: plausible statement fusion
+  return emptyVerdict;                                 // pg=1 from a big source: near-empty, must declare
+}
+
+/**
+ * The GRANDFATHERED map is load-bearing — the gate is green partly because of it.
+ * An entry whose stem no longer matches a checked pair (renamed/removed file, or a
+ * typo when the entry was added), or whose pair no longer classifies as suspect, is
+ * dead weight that silently misstates what the map shields. Warn, don't fail:
+ * committed `.pg.sql` files are immutable, so a stale entry can't mask a NEW escape
+ * (an unmatched suspect still fails loudly) — it can only lie about history.
+ *
+ * @param {Iterable<string>} grandfatheredStems
+ * @param {Map<string,string>} verdictByStem verdict for every checked pair
+ * @returns {string[]} one warning per stale entry
+ */
+export function staleGrandfatherWarnings(grandfatheredStems, verdictByStem) {
+  const warnings = [];
+  for (const stem of grandfatheredStems) {
+    if (!verdictByStem.has(stem)) {
+      warnings.push(
+        `stale GRANDFATHERED entry "${stem}" — no committed counterpart pair matches it ` +
+        `(file renamed/removed, or a typo in the entry). Remove or correct the entry.`,
+      );
+    } else if (verdictByStem.get(stem) !== 'suspect') {
+      warnings.push(
+        `stale GRANDFATHERED entry "${stem}" — it no longer classifies as suspect ` +
+        `(verdict: ${verdictByStem.get(stem)}), so the entry shields nothing. Remove it.`,
+      );
+    }
+  }
+  return warnings;
 }
 
 function runCheck() {
@@ -159,6 +208,7 @@ function runCheck() {
   }
 
   const suspects = [];
+  const verdictByStem = new Map();
   let checked = 0;
   let documented = 0;
   let grandfathered = 0;
@@ -173,6 +223,7 @@ function runCheck() {
       readFileSync(join(SS_DIR, f), 'utf8'),
       readFileSync(pgPath, 'utf8'),
     );
+    verdictByStem.set(stem, verdict);
     if (verdict === 'documented') {
       documented++;
       console.log(`ok (documented no-op): ${stem}`);
@@ -184,6 +235,11 @@ function runCheck() {
         suspects.push({ stem, ssStmts, pgStmts });
       }
     }
+  }
+
+  for (const w of staleGrandfatherWarnings(GRANDFATHERED.keys(), verdictByStem)) {
+    console.warn(`WARNING: ${w}`);
+    if (process.env.GITHUB_ACTIONS) console.log(`::warning::${w}`);
   }
 
   if (suspects.length === 0) {
@@ -264,18 +320,36 @@ SET standard_conforming_strings = on;
     HEADER + '\n/* CREATE INDEX IX_0 ON __mj.T0 (C0); */\n',
     'content present but entirely commented out');
 
+  assert('suspect',
+    Array.from({ length: 5 }, (_, i) => `CREATE INDEX IX_${i} ON __mj.T${i} (C${i});`).join('\n'),
+    HEADER,
+    '5-statement source emptied — small backfills are exactly the shape that gets silently dropped');
+
+  assert('suspect', 'ALTER TABLE __mj.T ADD C INT NULL;', HEADER,
+    'single-statement source emptied — fusion can shrink output but never to zero');
+
   // ── Must NOT flag ──
   assert('documented', REAL_SOURCE,
     HEADER + '\n-- PG-EMPTY-BY-DESIGN: PG maintains this proc in metadataSupportObjects.ts.\n',
     'intentionally empty WITH the declaration token');
+
+  assert('documented', 'ALTER TABLE __mj.T ADD C INT NULL;',
+    HEADER + '\n-- PG-EMPTY-BY-DESIGN: PG maintains this proc in metadataSupportObjects.ts.\n',
+    'tiny source, intentionally empty WITH the declaration token');
 
   assert('ok', REAL_SOURCE,
     HEADER + Array.from({ length: 12 }, (_, i) =>
       `CREATE INDEX IF NOT EXISTS "IX_${i}" ON __mj."T${i}" USING btree ("C${i}");`).join('\n'),
     'genuine full conversion');
 
-  assert('ok', 'ALTER TABLE __mj.T ADD C INT NULL;', HEADER,
-    'tiny source (1 statement) — must not false-positive on a legitimately thin migration');
+  assert('ok', 'ALTER TABLE __mj.T ADD C INT NULL;',
+    HEADER + 'ALTER TABLE __mj."T" ADD COLUMN "C" INT NULL;\n',
+    'tiny source converted 1:1 — must not false-positive on a legitimately thin migration');
+
+  assert('ok',
+    'IF EXISTS (SELECT 1 FROM x) BEGIN EXEC sp_dropextendedproperty @a = 1; END;\nEXEC sp_addextendedproperty @a = 1;\nGO',
+    HEADER + 'COMMENT ON TABLE __mj."T" IS \'text\';\n',
+    'thin source FUSED to one statement [committed v5.39 extended-property pair] — pg=1 band keeps the floor');
 
   assert('ok', REAL_SOURCE,
     HEADER + '\nDO $mj$\nDECLARE p_ID UUID;\nBEGIN\n  p_ID := gen_random_uuid();\n  PERFORM __mj."spCreateThing"(p_ID := p_ID);\nEND $mj$;\n',


### PR DESCRIPTION
**A PostgreSQL migration can be silently emptied by the converter and pass every check we have, including the one the runbook calls "the real gate."** It has already shipped: `migrations-pg/v5/V202607071019__v5.45.x__Metadata_Sync.pg.sql` is **126 bytes** against a **12,041-line** T-SQL source. PostgreSQL deployments that migrated through v5.45 silently received none of that release's curated metadata, and nobody noticed for two months.

The same thing happened three more times during the v5.49.0 build. This PR adds the gate that catches it, plus the runbook corrections for everything else that cost time in that release.

## The gate

`mj migrate convert` can write a header-only stub while printing `unhandled stmts: 0` and exiting `0`. Real output from this release, in full:

```sql
-- ============================================================================
-- MemberJunction PostgreSQL Migration — ...Fix_ConversationDetail_Sequence_Deadlock.sql
-- ============================================================================
CREATE EXTENSION IF NOT EXISTS "pgcrypto";
CREATE SCHEMA IF NOT EXISTS __mj;
SET search_path TO __mj, public;

-- V202607202110__..._Fix_ConversationDetail_Sequence_Deadlock.sql — no DDL to translate.
```

The source contains a `CREATE OR ALTER TRIGGER`. Another file emitted **six bare `;`** where six `CREATE INDEX` statements belonged.

Every automated check passed, and not by accident — **an empty migration applies perfectly cleanly, so the fresh-database apply cannot fail on it.** `check-pg-migration-parity.mjs` only asserts the counterpart *exists*. It was caught by hand-diffing line counts.

`scripts/check-pg-migration-content.mjs` closes that, wired into `pg-migrations.yml` as Step 3b — **before** the apply (content check at line 121, apply at 152), so a failure is attributable to conversion rather than to SQL.

### Two design choices worth defending

**It counts statements, not lines.** The bare-`;` failure was 23 lines of nothing. A line-count heuristic scores that 23 and waves it through; a statement count scores it 0. Boilerplate (`CREATE EXTENSION IF NOT EXISTS`, `CREATE SCHEMA IF NOT EXISTS`, `SET search_path`, `SET standard_conforming_strings`) is excluded, since every converted file carries it and it says nothing about whether content survived.

**The rule is "empty AND undeclared", not "empty".** Some counterparts are legitimately empty — the SS migration alters `spUpdateExistingEntityFieldsFromSchema`, which PostgreSQL maintains in `packages/CodeGenLib/src/Database/providers/postgresql/metadataSupportObjects.ts` rather than in a migration. A blunt rule would produce false positives and get switched off inside two releases. An intentional no-op must instead declare itself:

```sql
-- PG-EMPTY-BY-DESIGN: <why, and what carries the change instead>
```

The judgement stays with the human; the machine only enforces that it was recorded. Illustrating the point, `Fix_ConversationDetail_Sequence_Deadlock.pg.sql` already carries a *prose* explanation written during the release, and the detector still flags it — prose is not machine-checkable.

### Grandfathering, and why it is not an amnesty

Five existing counterparts are effectively empty and **cannot** be retrofitted with the token: committed `migrations-pg/v5/*.pg.sql` are byte-for-byte immutable because Flyway checksums them, so editing one breaks `mj migrate` on any deployment that already applied it. That includes the three that shipped in v5.49.0 hours before this branch was cut.

They sit in a `GRANDFATHERED` map with a written reason each, following the `ai-providers.AIP1` precedent ("known-dead allowlist, fails on any NEW unresolvable driver"). **The v5.45 entry says plainly that it is not correct** and points at #3253 rather than pretending it is fine. The map's own comment reads: *"Do not add entries to silence a new failure — that is the exact reflex this script exists to prevent."*

One entry changed the story. #3252 originally listed `v5.38 Fix_AllowUpdateAPI_On_Virtual_Transition` as an unverified second suspected escape. Building this forced the investigation: it alters the same proc PostgreSQL keeps in TypeScript, so it is **correctly** empty. **Confirmed shipped escapes drop from two to one.**

## Evidence

Detector self-test — fixtures are real production shapes, not invented:

| | |
|---|---|
| `--self-test` (14 fixtures after the review follow-up below) | **14/14, exit 0** |
| Repo as-is | **exit 0** — 193 counterparts checked, 5 grandfathered, 0 suspect |
| Sabotage `Add_Theme_Entity.pg.sql` (1026 lines → 11-line stub) | **exit 1** — `source has 84 content statement(s); PG counterpart has 0.` |
| Same file + `PG-EMPTY-BY-DESIGN` line | **exit 0**, counted as documented no-op |
| Restore | `git status migrations-pg/` clean |

CI-shape and edge cases:

| | |
|---|---|
| Wrong working directory | exit **2** (errors, does not falsely pass) |
| Unknown argument | exit 2 |
| `--help` | exit 0 without checking |
| SS migration with no counterpart at all | exit 0 (that is parity's job) |
| No migrations at all (tooling-only PR) | exit 0 |

Meta-gate — if someone breaks the detector, does CI notice?

| | |
|---|---|
| Neuter `classify()` to always return `ok` | self-test **exit 1** ✓ (repo check still exits 0 — which is exactly why the self-test step exists) |
| Break the `PG-EMPTY-BY-DESIGN` regex only | self-test **exit 1** ✓, naming the fixture |

The CLI dispatch is guarded by an `import.meta.url` check so the module can be imported. Without it, `classify` and `countContentStatements` were exported but unreachable — importing ran the whole repo check and called `process.exit`, which would have silently killed any unit-test process before its first assertion.

## Runbook corrections

Each one is a thing that cost time in v5.49.0, not a hypothetical.

- **Step 0 (new)** — preflight. The gitignored `.env.database`; live credential probes (an expired Gemini key produced 11 red agent tests triaged as a `BaseAgent` regression before the real cause surfaced); `MJ_API_KEY` placement; Docker headroom.
- **Agent checklist** — a release spans hours and several CI waits, so steps get skipped. **Step 5 was nearly missed** because it sits between two long-running steps. Names the sub-steps that are separately skippable, and flags that Steps 5 and 11 have no automated backstop.
- **Per-engineer local values** — every port, container name and database name in the guide is one machine's example. Adds the two commands to resolve your own, and lists the known-variable ones (including that `.env` says `GRAPHQL_PORT=4000` while root `CLAUDE.md` still claims 4001).
- **Step 3 runs in parallel with Step 1** — Step 1's CI takes ~15 minutes and Step 3 reads nothing from it.
- **Step 4.3** — `npm run start:api` goes through turbo, which **strips env vars it does not declare**; `DB_DATABASE` vanished and surfaced as `Error parsing config file … "path": ["dbDatabase"]`, which reads as a config-file problem. Run from `packages/MJAPI`.
- **Step 4.6 (#3251)** — the "re-run the single bundle" triage advice is **wrong** for IT53–IT62. `mj test run` takes a different transport path than the same bundle in-suite (`agent-loop-live` is not in the `CLIENT_BUNDLES` set), so standalone it runs the agent in-process with no server `contextUser` and fails 7/7 while passing in-suite. Re-run the whole live suite instead.
- **Step 7** — was "commit the regenerated manifests"; CI commits them post-release (`9cc0a42fa5`). Now a decision table keyed on whether the registration *count* changed.
- **Step 8** — the content-verification section, and check-git-history-before-hand-authoring. Two counterparts this release already existed, authored and reviewed in feature PRs then deleted by policy; recovered from `f0ceec06fb^`, including a `BEFORE INSERT FOR EACH ROW` trigger using `pg_advisory_xact_lock`.
- **Step 9** — which CI absences are expected (`build.yml` is path-filtered to `packages/**`; `dependency-check.yml` is PR-into-`next` only), so absence stops reading as failure.
- **Post-merge** — GitHub's "Cancel workflow" has **no confirmation dialog**, and a cancel mid-`npm publish` splits the fixed-version group across two versions on npm with no rollback. This happened in v5.49.0. Documents the `gh run rerun --failed` recovery and explicit post-recovery verification.
- **10c** — what `docs.yml` publishes, and that it failed silently from v5.45.1 through v5.48.0 while each release looked green.
- **Doc-site download step — retired.** The old Step 11 edited a per-version download link that no longer exists (the `Distributions/` zip is gone; `mj install` fetches from the tagged source). Removed as a numbered step, replaced with a deprecation note; the release now runs 0–11.
- **Step 11 (Changelog, was Step 12)** — said only *when*, never *where*. The release PR body is the changelog entry; adds the fetch command and notes that **no GitHub Release exists** (verified — no workflow creates one).

## Workbench

`docker/workbench/.env.database` is gitignored, so `docker compose up` fails on a clean checkout with `env file … not found`, and `README.md` described the file as "committed". Ships a tracked `.env.database.example` and corrects the README.

The `.gitignore` negation is deliberate: `docker/workbench/.env.example` is tracked only by **grandfathering** (committed before the `.env.*` rule existed, and git ignores untracked files only). A new `.example` file gets no such grace, so it needs an explicit negation rather than a silent `git add -f` that leaves no record of the decision.

## Risk

Low, and mostly self-limiting. The only behavioural change outside documentation is a new CI step on `pg-migrations.yml`, which is path-filtered to migration and converter changes. It passes on `next` today (verified above), and **this PR exercises it against itself** since it touches `.github/workflows/pg-migrations.yml` — so if the wiring is wrong, this PR is where it surfaces.

The grandfathered list is load-bearing: the gate is green today because of those five entries. That is the intended ratchet, but it means a future engineer tempted to silence a failure by appending to the map is doing the precise thing the check exists to prevent.

## Related

Nothing is closed here. #3252 (converter still writes empty files while reporting success) and #3254 (parity script checks existence only) are both **compensated, not fixed** — the tool defect is untouched. #3253 (v5.45's shipped marker) is recorded in the grandfathered map. #3251 is the Step 4.6 correction. #3257 (integration suite cannot run on PostgreSQL) is unrelated to this diff.

## Review response (`5711961a36`)

Follow-ups from review, TDD'd (7 red → green):

- **The `SOURCE_STATEMENT_FLOOR` coverage gap is closed — by narrowing where the floor applies, not lowering it.** An empirical sweep of all 193 committed pairs showed every real escape scored **pg=0** and every legitimately-thin counterpart scored **pg=1** (e.g. the v5.39 pair where an `IF EXISTS` guard + two `sp_*extendedproperty` calls genuinely fuse into one `COMMENT ON TABLE`). `classify()` is now two-band: **zero content statements is suspect at any source size** (fusion never reaches zero); the floor governs only the pg=1 band. This catches the reviewed 5-statement case *and* the 1-statement case that lowering the floor to 1 would still miss — with zero new suspects on the committed corpus.
- **Grandfather staleness guard**: `staleGrandfatherWarnings()` warns (never fails; `::warning` in CI) when an entry no longer matches a checked pair or no longer classifies as suspect. Warn is correct because a stale entry can't mask a *new* escape — an unmatched suspect still fails loudly.
- **The promised unit suite now exists**: `.github/scripts/__tests__/check-pg-migration-content.test.mjs`, 23 tests in the existing guard-suite convention, locking the exported API, both threshold constants, and the CLI contract. Full guard config: 73/73.
- **Parser heuristic edges documented** in `countContentStatements` (string-literal comment mis-stripping miscounts but never zeroes; `;`-termination assumed, `GO`-batch T-SQL under-counts).
- **CI wiring gap found and fixed**: neither workflow path-filtered on the detector itself, so a detector-only PR would have run *neither* suite. Both now do.
- `#3252` / `#3253` remain open — this still compensates for the converter defect, it does not fix it.

Smoke-tested end-to-end with real fixture files through `runCheck`: emptied 5-stmt and 1-stmt counterparts fail the gate naming the file, a `PG-EMPTY-BY-DESIGN` declaration passes as documented, a genuine conversion passes; sabotaging the rule back to the old short-circuit is caught by 4 unit tests + the self-test, and a bogus grandfather entry triggers the staleness warning.
