### PR TITLE
S0 preflight: projection-only 'rail' chat-area slot + slice spec

### DIFF
--- a/.changeset/conversations-rail-slot.md
+++ b/.changeset/conversations-rail-slot.md
@@ -1,0 +1,12 @@
+---
+"@memberjunction/ng-conversations": minor
+---
+
+Add a seventh chat-area slot: `rail` — a right-side companion surface rendered as the last
+child of the chat content area (sibling of the message pane and artifact pane). Projection-only:
+unlike the other six slots it has NO default component, so when no consumer projects an
+`mjChatSlot="rail"` template the chat-area renders byte-for-byte as before — existing embedders
+are unaffected. Template context is the new `IMJChatRailSlotContext` (`Conversation` — also the
+`$implicit` — and `IsArtifactOpen`, true while the artifact viewer pane is open, so a rail can
+compact/overlay/defer when the pane owns the right side). This is the mount seam for the
+composed-shell Companion Rail; the context is deliberately minimal and will grow additively.

--- a/packages/Angular/Generic/conversations/README.md
+++ b/packages/Angular/Generic/conversations/README.md
@@ -10,7 +10,7 @@ The widget exposes three layers of extension:
 
 | Surface | What it lets you do |
 |---|---|
-| **6 named slots** (`mjChatSlot` directive) | Replace the `header`, `emptyState`, `agentPresence`, `messageRenderer`, `messageExtra`, or `demonstrationSurface` regions with your own templates. Three consumption modes: project an ad-hoc template, wrap the exported default for containment, or subclass the default. |
+| **7 named slots** (`mjChatSlot` directive) | Replace the `header`, `emptyState`, `agentPresence`, `messageRenderer`, `messageExtra`, or `demonstrationSurface` regions with your own templates, or project a right-side companion surface into `rail`. Three consumption modes for the six defaulted slots: project an ad-hoc template, wrap the exported default for containment, or subclass the default. `rail` is projection-only — it has **no default component**, so hosts that don't use it are completely unaffected (context contract: `IMJChatRailSlotContext`). |
 | **Before/After cancelable events** | `(beforeAgentTurn)`, `(beforeToolInvoked)`, `(beforeResponseFormSubmitted)` let you observe AND veto (`event.Cancel = true`) before the action runs. Plus informational `(sessionStarted)` / `(sessionChannelStateChanged)` / `(sessionEnded)` for realtime lifecycle. |
 | **`--mj-chat-*` design tokens** | Override bubble colors, composer chrome, character accents, and voice-state hues via standard CSS custom-property overrides. Defaults adapt to dark mode through semantic `--mj-*` tokens. |
 

--- a/packages/Angular/Generic/conversations/src/__tests__/slot-defaults.test.ts
+++ b/packages/Angular/Generic/conversations/src/__tests__/slot-defaults.test.ts
@@ -38,7 +38,9 @@ import type {
     IMJChatMessageExtraComponent,
     IMJChatDemonstrationSurfaceComponent,
     IMJChatMessageRendererComponent,
+    IMJChatRailSlotContext,
 } from '../lib/components/slots/slot-interfaces';
+import { ChatSlotDirective, type MJChatSlotName } from '../lib/directives/chat-slot.directive';
 
 describe('Slot default components — exports + interface conformance', () => {
     it('MJChatEmptyStateDefaultComponent is exported as a class', () => {
@@ -97,5 +99,49 @@ describe('Slot default components — exports + interface conformance', () => {
             : never;
         const _interfaceCheck: _Check = true;
         expect(_interfaceCheck).toBe(true);
+    });
+});
+
+describe('rail slot — name registration + context contract (S0, composed shell)', () => {
+    it("'rail' is a valid MJChatSlotName and the directive accepts it", () => {
+        // Type-level: the union must include 'rail'.
+        const name: MJChatSlotName = 'rail';
+        expect(name).toBe('rail');
+
+        // Runtime: the directive stores it like any other slot name.
+        const fakeTemplate = {} as ConstructorParameters<typeof ChatSlotDirective>[0];
+        const directive = new ChatSlotDirective(fakeTemplate);
+        directive.SlotName = 'rail';
+        expect(directive.SlotName).toBe('rail');
+        expect(directive.Template).toBe(fakeTemplate);
+    });
+
+    it('IMJChatRailSlotContext contract holds (Conversation + IsArtifactOpen)', () => {
+        // Mirrors exactly what conversation-chat-area.component.html supplies
+        // to the outlet. If the template's context and this interface drift,
+        // fix one or the other — consumers type their let-bindings against it.
+        const context: IMJChatRailSlotContext = {
+            Conversation: null,
+            IsArtifactOpen: false,
+        };
+        expect(context.IsArtifactOpen).toBe(false);
+        expect(context.Conversation).toBeNull();
+    });
+
+    it('rail deliberately has NO default slot component', () => {
+        // Design contract (SLICE-S0): with no consumer projection the chat-area
+        // renders nothing for this slot — existing consumers are unaffected.
+        // This test documents the absence; if a default is ever added, that is
+        // a conscious contract change and this expectation should be updated
+        // alongside the slot-interfaces JSDoc.
+        const slotDefaultModules = [
+            'mj-chat-empty-state-default.component',
+            'mj-chat-agent-presence-default.component',
+            'mj-chat-header-default.component',
+            'mj-chat-message-extra-default.component',
+            'mj-chat-demonstration-surface-default.component',
+            'mj-chat-message-bubble-default.component',
+        ];
+        expect(slotDefaultModules).not.toContain('mj-chat-rail-default.component');
     });
 });

--- a/packages/Angular/Generic/conversations/src/lib/components/conversation/conversation-chat-area.component.html
+++ b/packages/Angular/Generic/conversations/src/lib/components/conversation/conversation-chat-area.component.html
@@ -398,6 +398,19 @@
       </div>
     }
 
+    <!-- rail slot — right-side companion surface (Companion Rail seam).
+         Renders ONLY when a consumer projects an mjChatSlot="rail" template;
+         there is no default component, so with no projection this block is
+         inert and every pre-slot consumer lays out byte-for-byte as before.
+         Context contract: IMJChatRailSlotContext (slot-interfaces). -->
+    @if (slotTemplate('rail'); as railTemplate) {
+      <ng-container *ngTemplateOutlet="railTemplate; context: {
+        $implicit: conversation,
+        Conversation: conversation,
+        IsArtifactOpen: showArtifactPanel && !!selectedArtifactId
+      }"></ng-container>
+    }
+
     <!-- Artifact Share Modal -->
     <mj-artifact-share-modal
       [isOpen]="isArtifactShareModalOpen"

--- a/packages/Angular/Generic/conversations/src/lib/components/slots/slot-interfaces.ts
+++ b/packages/Angular/Generic/conversations/src/lib/components/slots/slot-interfaces.ts
@@ -100,3 +100,28 @@ export interface IMJChatMessageRendererComponent {
     /** The conversation detail row to render. */
     Message: import('@memberjunction/core-entities').MJConversationDetailEntity | null;
 }
+
+/**
+ * Template context for the `rail` slot — a right-side companion surface
+ * rendered as the last child of the chat content area (a sibling of the
+ * message pane and the artifact pane).
+ *
+ * Unlike the other slots, `rail` has NO default component: when no consumer
+ * projects an `mjChatSlot="rail"` template, nothing renders and the chat-area
+ * lays out exactly as it did before the slot existed. Hosts own the rail's
+ * entire appearance and behavior (when it slides in/out, what it shows);
+ * the chat-area only supplies placement and this context.
+ *
+ * Deliberately minimal for now — the composed-shell work (slice S6) extends
+ * it as the Companion Rail design requires; keep additions additive.
+ */
+export interface IMJChatRailSlotContext {
+    /** The active conversation (also supplied as `$implicit`). */
+    Conversation: import('@memberjunction/core-entities').MJConversationEntity | null;
+    /**
+     * True while the artifact viewer pane is open (the "studio" state) —
+     * lets a rail render compactly, overlay, or defer when the artifact
+     * pane owns the right side of the layout.
+     */
+    IsArtifactOpen: boolean;
+}

--- a/packages/Angular/Generic/conversations/src/lib/directives/chat-slot.directive.ts
+++ b/packages/Angular/Generic/conversations/src/lib/directives/chat-slot.directive.ts
@@ -33,7 +33,8 @@ export type MJChatSlotName =
     | 'header'
     | 'messageExtra'
     | 'demonstrationSurface'
-    | 'messageRenderer';
+    | 'messageRenderer'
+    | 'rail';
 
 /**
  * Marks an `<ng-template>` as a slot fill for the chat-area.

--- a/plans/conversations-phase1/slices/SLICE-S0.md
+++ b/plans/conversations-phase1/slices/SLICE-S0.md
@@ -1,0 +1,49 @@
+# SLICE-S0 — Preflight · spec (2026-07-22)
+
+> Reviewed-before-code per IMPLEMENTATION-PLAN §2b. Branch: `s0-preflight` off
+> `conversations-shell`, PR back into `conversations-shell`.
+
+## 1. Ledger rows
+Carries (CONTRACT): "6 host slots + cancelable before-events — architecture preserved" (adds a
+7th slot, additively). Discharges nothing (preflight). Resolves one BASELINE §C1 open question
+(composer seam — see §5).
+
+## 2. Mockup references
+Companion Rail behavior: `functional-mockup-src/app.js` — `railRunCard` (cancel-run/keep-open),
+`companionHtml`, rail-over-studio CSS (template `.chat-wrap.studio .companion`). The slot built
+here is the MOUNT seam S6 fills with that design.
+
+## 3. Code: the `rail` slot (the only code in S0)
+- `directives/chat-slot.directive.ts`: extend `MJChatSlotName` union with `'rail'`.
+- `models/slot-interfaces` module: add `MJChatRailContext` (activeTasks/run state, artifact-open
+  flag, collapse callback — final shape drafted in PR, kept minimal).
+- `conversation-chat-area.component.html`: outlet inside `.chat-content-area` as a sibling
+  after the artifact pane (~line 375 region), rendered ONLY when a consumer projects
+  `mjChatSlot="rail"`; **no default component** (absent = nothing renders — today's behavior,
+  byte-for-byte, for every existing consumer).
+- README slot table + package changeset (minor). Unit test: slot registers + projects.
+
+## 4. State/persistence keys
+None in S0.
+
+## 5. Verification results (research, done)
+- **Composer seam: RESOLVED — nothing to build.** `mj-conversation-empty-state` already is the
+  mountable composer surface (greeting, suggested prompts, mentions/attachments toggles,
+  `messageSent {text, attachments}` out; host creates the conversation — the exact
+  send-to-create pattern ChatConversationsResource uses today). Front Door (S3) composes it.
+  BASELINE §C1's "composer slot possibly mooted by ng-composer" → confirmed moot.
+- **Drift check: CLEAN.** `next` +7 commits since branch cut = v5.49.0 release train; zero
+  touches on conversations/composer/runtime/explorer-core/app paths.
+
+## 6. Coordination (not code)
+- Refresh + post the PR #2953 comment (adds: mockup/ledger/plan now committed at `4864c39028`,
+  ADR-1 ratification ask, D-S9 owner ask, ⚖1/⚖2/⚖4 agenda, mega-migration prune) — **needs
+  Matt's go to post**.
+- ADR-1 (shell in ng-conversations + thin wrapper) — ratify with Amith via that comment.
+
+## 7. Exclusions
+No shell components yet (S1). No rail visuals/behavior (S6). No wrapper changes.
+
+## 8. Review checklist
+Diff of the three touched files + test run + changeset; no screenshots (no visible change —
+that's the point: S0 must be invisible to every existing consumer).


### PR DESCRIPTION
First slice of the composed-shell build (see `plans/conversations-phase1/IMPLEMENTATION-PLAN.md` and `slices/SLICE-S0.md`).

## What
- Adds the seventh `mjChatSlot` — `rail`, the Companion Rail mount seam — to `@memberjunction/ng-conversations`: slot-name union + `IMJChatRailSlotContext` + template outlet after the artifact pane.
- **Projection-only, no default component**: with no consumer template projected, the chat-area renders byte-for-byte as before. Every existing embedder (Explorer, Form Builder, Component Studio, Predictive Studio, overlay, Betty) is unaffected by construction.
- SLICE-S0 spec records the two verification results: the composer seam already exists (`mj-conversation-empty-state` send-to-create — nothing to build), and the drift check vs `next` is clean (v5.49.0 release train only).

## Verification
- `ng-conversations` builds clean; **884/884 unit tests pass** incl. a new rail-slot suite (name registration, context contract, documented absence of a default component).
- Changeset included (minor).
- No screenshots by design — this slice must be invisible.

S6 fills this seam with the mockup's Companion Rail (run-driven slide-in, cancel-run, rail-over-studio).

🤖 Generated with [Claude Code](https://claude.com/claude-code)