### PR TITLE
feat(explorer): promote Sharing Center to a standalone application

### DIFF
--- a/packages/Angular/Explorer/dashboards/src/SharingCenter/sharing-center-agent-context.test.ts
+++ b/packages/Angular/Explorer/dashboards/src/SharingCenter/sharing-center-agent-context.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from 'vitest';
+import {
+    buildSharingCenterAgentContext,
+    resolveSharingCenterTab,
+    sharingCenterTabLabel,
+} from './sharing-center-agent-context';
+
+describe('sharing-center-agent-context', () => {
+    it('builds concise context for the Inbox surface', () => {
+        expect(buildSharingCenterAgentContext({ ActiveTab: 'shared-with-me', IsRefreshing: false })).toEqual({
+            ActiveTab: 'shared-with-me',
+            ActiveTabLabel: 'Inbox',
+            IsRefreshing: false,
+        });
+    });
+
+    it('resolves stable tab keys and the inbox deep-link alias', () => {
+        expect(resolveSharingCenterTab('shared-by-me')).toBe('shared-by-me');
+        expect(resolveSharingCenterTab('inbox')).toBe('shared-with-me');
+        expect(resolveSharingCenterTab('activity')).toBeNull();
+    });
+
+    it('keeps human-readable labels aligned to the tab configuration', () => {
+        expect(sharingCenterTabLabel('shared-by-me')).toBe('Shared by me');
+    });
+});

--- a/packages/Angular/Explorer/dashboards/src/SharingCenter/sharing-center-agent-context.test.ts
+++ b/packages/Angular/Explorer/dashboards/src/SharingCenter/sharing-center-agent-context.test.ts
@@ -7,20 +7,40 @@ import {
 
 describe('sharing-center-agent-context', () => {
     it('builds concise context for the Inbox surface', () => {
-        expect(buildSharingCenterAgentContext({ ActiveTab: 'shared-with-me', IsRefreshing: false })).toEqual({
+        expect(buildSharingCenterAgentContext({
+            ActiveTab: 'shared-with-me',
+            IsRefreshing: false,
+            SearchTerm: 'sales',
+            DomainFilter: 'Dashboard Permissions',
+            MyAccessCount: 12,
+            ActivityEntryCount: 4,
+            AvailableDomainNames: ['Dashboard Permissions', 'Query Permissions'],
+        })).toEqual({
             ActiveTab: 'shared-with-me',
             ActiveTabLabel: 'Inbox',
             IsRefreshing: false,
+            SearchTerm: 'sales',
+            DomainFilter: 'Dashboard Permissions',
+            HasSearchTerm: true,
+            HasDomainFilter: true,
+            MyAccessCount: 12,
+            ActivityEntryCount: 4,
+            AvailableDomains: ['Dashboard Permissions', 'Query Permissions'],
+            AvailableDomainCount: 2,
+            AvailableDomainsTruncated: false,
         });
     });
 
     it('resolves stable tab keys and the inbox deep-link alias', () => {
         expect(resolveSharingCenterTab('shared-by-me')).toBe('shared-by-me');
         expect(resolveSharingCenterTab('inbox')).toBe('shared-with-me');
-        expect(resolveSharingCenterTab('activity')).toBeNull();
+        expect(resolveSharingCenterTab('activity')).toBe('activity');
+        expect(resolveSharingCenterTab('access')).toBe('my-access');
+        expect(resolveSharingCenterTab('requests')).toBeNull();
     });
 
     it('keeps human-readable labels aligned to the tab configuration', () => {
         expect(sharingCenterTabLabel('shared-by-me')).toBe('Shared by me');
+        expect(sharingCenterTabLabel('my-access')).toBe('My Access');
     });
 });

--- a/packages/Angular/Explorer/dashboards/src/SharingCenter/sharing-center-agent-context.ts
+++ b/packages/Angular/Explorer/dashboards/src/SharingCenter/sharing-center-agent-context.ts
@@ -1,20 +1,39 @@
-/** The two MVP surfaces exposed by the full Sharing Center application. */
-export type SharingCenterDashboardTab = 'shared-with-me' | 'shared-by-me';
+/** The read-only P2 surfaces exposed by the full Sharing Center application. */
+export type SharingCenterDashboardTab = 'shared-with-me' | 'shared-by-me' | 'my-access' | 'activity';
+
+export const SHARING_CENTER_DOMAIN_LIST_CAP = 25;
 
 export interface SharingCenterAgentContextInput {
     ActiveTab: SharingCenterDashboardTab;
     IsRefreshing: boolean;
+    SearchTerm: string;
+    DomainFilter: string;
+    MyAccessCount: number;
+    ActivityEntryCount: number;
+    AvailableDomainNames: string[];
 }
 
 /**
  * Build the concise, display-only Sharing Center context consumed by both the
  * asynchronous chat agent and realtime co-agent.
  */
-export function buildSharingCenterAgentContext(input: SharingCenterAgentContextInput): Record<string, string | boolean> {
+export function buildSharingCenterAgentContext(
+    input: SharingCenterAgentContextInput
+): Record<string, string | boolean | number | string[]> {
+    const availableDomains = input.AvailableDomainNames.slice(0, SHARING_CENTER_DOMAIN_LIST_CAP);
     return {
         ActiveTab: input.ActiveTab,
         ActiveTabLabel: sharingCenterTabLabel(input.ActiveTab),
         IsRefreshing: input.IsRefreshing,
+        SearchTerm: input.SearchTerm,
+        DomainFilter: input.DomainFilter,
+        HasSearchTerm: input.SearchTerm.length > 0,
+        HasDomainFilter: input.DomainFilter.length > 0,
+        MyAccessCount: input.MyAccessCount,
+        ActivityEntryCount: input.ActivityEntryCount,
+        AvailableDomains: availableDomains,
+        AvailableDomainCount: input.AvailableDomainNames.length,
+        AvailableDomainsTruncated: input.AvailableDomainNames.length > availableDomains.length,
     };
 }
 
@@ -26,11 +45,25 @@ export function resolveSharingCenterTab(value: string | undefined): SharingCente
             return 'shared-with-me';
         case 'shared-by-me':
             return 'shared-by-me';
+        case 'my-access':
+        case 'access':
+            return 'my-access';
+        case 'activity':
+            return 'activity';
         default:
             return null;
     }
 }
 
 export function sharingCenterTabLabel(tab: SharingCenterDashboardTab): string {
-    return tab === 'shared-with-me' ? 'Inbox' : 'Shared by me';
+    switch (tab) {
+        case 'shared-with-me':
+            return 'Inbox';
+        case 'shared-by-me':
+            return 'Shared by me';
+        case 'my-access':
+            return 'My Access';
+        case 'activity':
+            return 'Activity';
+    }
 }

--- a/packages/Angular/Explorer/dashboards/src/SharingCenter/sharing-center-agent-context.ts
+++ b/packages/Angular/Explorer/dashboards/src/SharingCenter/sharing-center-agent-context.ts
@@ -1,0 +1,36 @@
+/** The two MVP surfaces exposed by the full Sharing Center application. */
+export type SharingCenterDashboardTab = 'shared-with-me' | 'shared-by-me';
+
+export interface SharingCenterAgentContextInput {
+    ActiveTab: SharingCenterDashboardTab;
+    IsRefreshing: boolean;
+}
+
+/**
+ * Build the concise, display-only Sharing Center context consumed by both the
+ * asynchronous chat agent and realtime co-agent.
+ */
+export function buildSharingCenterAgentContext(input: SharingCenterAgentContextInput): Record<string, string | boolean> {
+    return {
+        ActiveTab: input.ActiveTab,
+        ActiveTabLabel: sharingCenterTabLabel(input.ActiveTab),
+        IsRefreshing: input.IsRefreshing,
+    };
+}
+
+/** Resolve only the stable query-param and client-tool tab keys. */
+export function resolveSharingCenterTab(value: string | undefined): SharingCenterDashboardTab | null {
+    switch (value) {
+        case 'shared-with-me':
+        case 'inbox':
+            return 'shared-with-me';
+        case 'shared-by-me':
+            return 'shared-by-me';
+        default:
+            return null;
+    }
+}
+
+export function sharingCenterTabLabel(tab: SharingCenterDashboardTab): string {
+    return tab === 'shared-with-me' ? 'Inbox' : 'Shared by me';
+}

--- a/packages/Angular/Explorer/dashboards/src/SharingCenter/sharing-center-dashboard.component.css
+++ b/packages/Angular/Explorer/dashboards/src/SharingCenter/sharing-center-dashboard.component.css
@@ -3,17 +3,384 @@
     height: 100%;
 }
 
-.sharing-center-dashboard__body {
+.sharing-center-dashboard {
+    display: flex;
+    flex-direction: column;
     height: 100%;
     min-height: 0;
+    gap: var(--mj-space-4);
+}
+
+.sharing-center-dashboard__stats {
+    display: grid;
+    grid-template-columns: repeat(4, minmax(0, 1fr));
+    gap: var(--mj-space-3);
+}
+
+.sharing-center-dashboard__stat {
+    display: flex;
+    align-items: center;
+    gap: var(--mj-space-3);
+    min-width: 0;
+    padding: var(--mj-space-4);
+    background: var(--mj-bg-surface);
     border: 1px solid var(--mj-border-default);
     border-radius: var(--mj-radius-lg);
-    overflow: hidden;
-    background: var(--mj-bg-surface);
     box-shadow: var(--mj-shadow-sm);
 }
 
-.sharing-center-dashboard__body mj-user-sharing-center {
+.sharing-center-dashboard__stat-icon {
+    display: inline-flex;
+    flex: 0 0 auto;
+    align-items: center;
+    justify-content: center;
+    width: 2.25rem;
+    height: 2.25rem;
+    border-radius: var(--mj-radius-md);
+    color: var(--mj-brand-primary);
+    background: color-mix(in srgb, var(--mj-brand-primary) 10%, var(--mj-bg-surface));
+}
+
+.sharing-center-dashboard__stat-copy {
+    display: flex;
+    flex-direction: column;
+    min-width: 0;
+}
+
+.sharing-center-dashboard__stat-label {
+    overflow: hidden;
+    color: var(--mj-text-secondary);
+    font-size: var(--mj-text-xs);
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+.sharing-center-dashboard__stat-value {
+    margin-top: var(--mj-space-1);
+    color: var(--mj-text-primary);
+    font-size: var(--mj-text-2xl);
+    line-height: 1.1;
+}
+
+.sharing-center-dashboard__filter-field {
+    display: flex;
+    flex-direction: column;
+    gap: var(--mj-space-1-5);
+}
+
+.sharing-center-dashboard__filter-field label {
+    color: var(--mj-text-secondary);
+    font-size: var(--mj-text-xs);
+    font-weight: var(--mj-font-semibold);
+}
+
+.sharing-center-dashboard__domain-select {
+    width: 100%;
+    min-height: 2.25rem;
+    padding: 0 var(--mj-space-2-5);
+    color: var(--mj-text-primary);
+    font: inherit;
+    background: var(--mj-bg-surface-card);
+    border: 1px solid var(--mj-border-default);
+    border-radius: var(--mj-radius-md);
+}
+
+.sharing-center-dashboard__domain-select:focus {
+    outline: none;
+    border-color: var(--mj-brand-primary);
+    box-shadow: 0 0 0 2px color-mix(in srgb, var(--mj-brand-primary) 15%, transparent);
+}
+
+.sharing-center-dashboard__share-panel,
+.sharing-center-dashboard__panel {
+    min-height: 0;
+    background: var(--mj-bg-surface);
+    border: 1px solid var(--mj-border-default);
+    border-radius: var(--mj-radius-lg);
+    box-shadow: var(--mj-shadow-sm);
+    overflow: hidden;
+}
+
+.sharing-center-dashboard__share-panel {
+    flex: 1;
+}
+
+.sharing-center-dashboard__share-panel--hidden {
+    display: none;
+}
+
+.sharing-center-dashboard__share-panel mj-user-sharing-center {
     display: block;
     height: 100%;
+}
+
+.sharing-center-dashboard__panel {
+    display: flex;
+    flex: 1;
+    flex-direction: column;
+}
+
+.sharing-center-dashboard__panel-header {
+    display: flex;
+    align-items: flex-start;
+    justify-content: space-between;
+    gap: var(--mj-space-4);
+    padding: var(--mj-space-5) var(--mj-space-5) var(--mj-space-4);
+    border-bottom: 1px solid var(--mj-border-subtle);
+}
+
+.sharing-center-dashboard__panel-header h2 {
+    margin: 0;
+    color: var(--mj-text-primary);
+    font-size: var(--mj-text-lg);
+}
+
+.sharing-center-dashboard__panel-header p {
+    margin: var(--mj-space-1) 0 0;
+    color: var(--mj-text-secondary);
+    font-size: var(--mj-text-sm);
+}
+
+.sharing-center-dashboard__panel-count {
+    flex: 0 0 auto;
+    padding: var(--mj-space-1) var(--mj-space-2);
+    color: var(--mj-text-secondary);
+    font-size: var(--mj-text-xs);
+    font-weight: var(--mj-font-semibold);
+    background: var(--mj-bg-surface-sunken);
+    border-radius: var(--mj-radius-md);
+}
+
+.sharing-center-dashboard__loading {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: var(--mj-space-2);
+    min-height: 12rem;
+    color: var(--mj-text-secondary);
+}
+
+.sharing-center-dashboard__groups {
+    flex: 1;
+    min-height: 0;
+    padding: var(--mj-space-3);
+    overflow: auto;
+}
+
+.sharing-center-dashboard__group-icon {
+    margin-right: var(--mj-space-2);
+    color: var(--mj-brand-primary);
+}
+
+.sharing-center-dashboard__group-name {
+    color: var(--mj-text-primary);
+    font-weight: var(--mj-font-semibold);
+}
+
+.sharing-center-dashboard__access-rows {
+    display: flex;
+    flex-direction: column;
+}
+
+.sharing-center-dashboard__access-row {
+    display: grid;
+    grid-template-columns: minmax(14rem, 1fr) auto minmax(10rem, 0.65fr);
+    align-items: center;
+    gap: var(--mj-space-3);
+    width: 100%;
+    padding: var(--mj-space-3) var(--mj-space-4);
+    color: var(--mj-text-primary);
+    text-align: left;
+    background: transparent;
+    border: 0;
+    border-bottom: 1px solid var(--mj-border-subtle);
+    cursor: pointer;
+}
+
+.sharing-center-dashboard__access-row:last-child {
+    border-bottom: 0;
+}
+
+.sharing-center-dashboard__access-row:hover {
+    background: var(--mj-bg-surface-hover);
+}
+
+.sharing-center-dashboard__access-row:focus-visible {
+    position: relative;
+    z-index: 1;
+    outline: 2px solid var(--mj-brand-primary);
+    outline-offset: -2px;
+}
+
+.sharing-center-dashboard__resource {
+    display: flex;
+    flex-direction: column;
+    min-width: 0;
+}
+
+.sharing-center-dashboard__resource strong {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+.sharing-center-dashboard__resource small {
+    margin-top: var(--mj-space-1);
+    color: var(--mj-text-muted);
+    font-size: var(--mj-text-xs);
+}
+
+.sharing-center-dashboard__source {
+    display: inline-flex;
+    justify-content: center;
+    padding: var(--mj-space-1) var(--mj-space-2);
+    border: 1px solid var(--mj-border-default);
+    border-radius: var(--mj-radius-md);
+    color: var(--mj-text-secondary);
+    font-size: var(--mj-text-xs);
+    font-weight: var(--mj-font-semibold);
+    white-space: nowrap;
+}
+
+.sharing-center-dashboard__source--owner {
+    color: var(--mj-status-success-text);
+    background: var(--mj-status-success-bg);
+    border-color: var(--mj-status-success-border);
+}
+
+.sharing-center-dashboard__source--direct {
+    color: var(--mj-brand-primary);
+    background: color-mix(in srgb, var(--mj-brand-primary) 8%, var(--mj-bg-surface));
+}
+
+.sharing-center-dashboard__source--role {
+    color: var(--mj-status-info-text);
+    background: var(--mj-status-info-bg);
+    border-color: var(--mj-status-info-border);
+}
+
+.sharing-center-dashboard__source--public {
+    color: var(--mj-status-warning-text);
+    background: var(--mj-status-warning-bg);
+    border-color: var(--mj-status-warning-border);
+}
+
+.sharing-center-dashboard__actions {
+    overflow: hidden;
+    color: var(--mj-text-secondary);
+    font-size: var(--mj-text-sm);
+    text-align: right;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+.sharing-center-dashboard__timeline {
+    display: flex;
+    flex: 1;
+    flex-direction: column;
+    gap: var(--mj-space-4);
+    min-height: 0;
+    margin: 0;
+    padding: var(--mj-space-5);
+    list-style: none;
+    overflow: auto;
+}
+
+.sharing-center-dashboard__timeline-entry {
+    display: grid;
+    grid-template-columns: 2rem minmax(0, 1fr);
+    gap: var(--mj-space-3);
+}
+
+.sharing-center-dashboard__timeline-icon {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 2rem;
+    height: 2rem;
+    color: var(--mj-brand-primary);
+    background: color-mix(in srgb, var(--mj-brand-primary) 10%, var(--mj-bg-surface));
+    border-radius: 50%;
+}
+
+.sharing-center-dashboard__timeline-content {
+    min-width: 0;
+    padding-bottom: var(--mj-space-4);
+    border-bottom: 1px solid var(--mj-border-subtle);
+}
+
+.sharing-center-dashboard__timeline-entry:last-child .sharing-center-dashboard__timeline-content {
+    padding-bottom: 0;
+    border-bottom: 0;
+}
+
+.sharing-center-dashboard__timeline-heading {
+    display: flex;
+    align-items: baseline;
+    justify-content: space-between;
+    gap: var(--mj-space-3);
+}
+
+.sharing-center-dashboard__timeline-heading strong {
+    color: var(--mj-text-primary);
+}
+
+.sharing-center-dashboard__timeline-heading time {
+    flex: 0 0 auto;
+    color: var(--mj-text-muted);
+    font-size: var(--mj-text-xs);
+}
+
+.sharing-center-dashboard__timeline-content p {
+    margin: var(--mj-space-1-5) 0 0;
+    color: var(--mj-text-secondary);
+    font-size: var(--mj-text-sm);
+}
+
+.sharing-center-dashboard__timeline-content .sharing-center-dashboard__timeline-summary {
+    color: var(--mj-text-muted);
+}
+
+@media (max-width: 900px) {
+    .sharing-center-dashboard__stats {
+        grid-template-columns: repeat(2, minmax(0, 1fr));
+    }
+
+    .sharing-center-dashboard__access-row {
+        grid-template-columns: minmax(0, 1fr) auto;
+    }
+
+    .sharing-center-dashboard__actions {
+        grid-column: 1 / -1;
+        text-align: left;
+    }
+}
+
+@media (max-width: 600px) {
+    .sharing-center-dashboard__stats {
+        grid-template-columns: 1fr;
+    }
+
+    .sharing-center-dashboard__panel-header {
+        flex-direction: column;
+    }
+
+    .sharing-center-dashboard__access-row {
+        grid-template-columns: 1fr;
+        gap: var(--mj-space-2);
+    }
+
+    .sharing-center-dashboard__source {
+        justify-self: start;
+    }
+
+    .sharing-center-dashboard__timeline {
+        padding: var(--mj-space-4);
+    }
+
+    .sharing-center-dashboard__timeline-heading {
+        align-items: flex-start;
+        flex-direction: column;
+        gap: var(--mj-space-1);
+    }
 }

--- a/packages/Angular/Explorer/dashboards/src/SharingCenter/sharing-center-dashboard.component.css
+++ b/packages/Angular/Explorer/dashboards/src/SharingCenter/sharing-center-dashboard.component.css
@@ -1,0 +1,19 @@
+:host {
+    display: block;
+    height: 100%;
+}
+
+.sharing-center-dashboard__body {
+    height: 100%;
+    min-height: 0;
+    border: 1px solid var(--mj-border-default);
+    border-radius: var(--mj-radius-lg);
+    overflow: hidden;
+    background: var(--mj-bg-surface);
+    box-shadow: var(--mj-shadow-sm);
+}
+
+.sharing-center-dashboard__body mj-user-sharing-center {
+    display: block;
+    height: 100%;
+}

--- a/packages/Angular/Explorer/dashboards/src/SharingCenter/sharing-center-dashboard.component.dom.test.ts
+++ b/packages/Angular/Explorer/dashboards/src/SharingCenter/sharing-center-dashboard.component.dom.test.ts
@@ -1,0 +1,105 @@
+import { Component, EventEmitter, Input, Output } from '@angular/core';
+import { describe, expect, it, vi } from 'vitest';
+import { BehaviorSubject, Subject } from 'rxjs';
+import { ApplicationManager } from '@memberjunction/ng-base-application';
+import { NormalizedPermission } from '@memberjunction/core';
+import { NavigationService } from '@memberjunction/ng-shared';
+import { capture, query, renderComponentFixture, text } from '@memberjunction/ng-test-utils';
+import { SharingCenterDashboardTab } from './sharing-center-agent-context';
+import { SharingCenterDashboardComponent } from './sharing-center-dashboard.component';
+
+@Component({ standalone: true, selector: 'mj-page-layout', template: '<ng-content></ng-content>' })
+class PageLayoutStub {}
+
+@Component({ standalone: true, selector: 'mj-page-header', template: '<header><h1>{{ Title }}</h1><p>{{ Subtitle }}</p><ng-content></ng-content></header>' })
+class PageHeaderStub {
+    @Input() Title = '';
+    @Input() Icon = '';
+    @Input() Subtitle = '';
+}
+
+@Component({ standalone: true, selector: 'mj-page-body', template: '<main><ng-content></ng-content></main>' })
+class PageBodyStub {}
+
+@Component({ standalone: true, selector: 'mj-tab-nav', template: '<button class="tab-switch" (click)="TabChange.emit(NextTab)">{{ ActiveKey }}</button>' })
+class TabNavStub {
+    @Input() Tabs: object[] = [];
+    @Input() ActiveKey = '';
+    @Input() NextTab = 'shared-by-me';
+    @Output() TabChange = new EventEmitter<string>();
+}
+
+@Component({ standalone: true, selector: 'mj-refresh-button', template: '<button class="refresh" (click)="Clicked.emit()">Refresh</button>' })
+class RefreshButtonStub {
+    @Input() Loading = false;
+    @Output() Clicked = new EventEmitter<void>();
+}
+
+@Component({ standalone: true, selector: 'mj-user-sharing-center', template: '<span class="embedded-tab">{{ ActiveTab }}</span>' })
+class UserSharingCenterStub {
+    @Input() Provider: object | null = null;
+    @Input() ActiveTab: SharingCenterDashboardTab = 'shared-with-me';
+    @Input() ShowTabBar = true;
+    @Input() ShowCloseButton = true;
+    @Output() ActiveTabChange = new EventEmitter<SharingCenterDashboardTab>();
+    @Output() ResourceClicked = new EventEmitter<NormalizedPermission>();
+}
+
+function navigationStub() {
+    const queryParams = new Subject<{ TabId: string; Params: Record<string, string> }>();
+    return {
+        QueryParamChanged$: queryParams,
+        ObserveTabQueryParams: () => new BehaviorSubject<Record<string, string>>({}),
+        UpdateActiveTabQueryParams: vi.fn(),
+        UpdateTabQueryParams: vi.fn(),
+        SetAgentContext: vi.fn(),
+        SetAgentClientTools: vi.fn(),
+    };
+}
+
+function render() {
+    const navigation = navigationStub();
+    const fixture = renderComponentFixture(SharingCenterDashboardComponent, {
+        imports: [PageLayoutStub, PageHeaderStub, PageBodyStub, TabNavStub, RefreshButtonStub, UserSharingCenterStub],
+        declarations: [SharingCenterDashboardComponent],
+        providers: [
+            { provide: NavigationService, useValue: navigation },
+            { provide: ApplicationManager, useValue: {} },
+        ],
+    });
+    return { fixture, navigation };
+}
+
+describe('SharingCenterDashboardComponent (DOM)', () => {
+    it('renders the shared page chrome and starts on Inbox', () => {
+        const { fixture } = render();
+        expect(text(fixture, 'h1')).toBe('Sharing Center');
+        expect(text(fixture, 'p')).toContain("See what's shared with you");
+        expect(text(fixture, '.embedded-tab')).toBe('shared-with-me');
+    });
+
+    it('switches the embedded list and writes the stable tab query parameter', () => {
+        const { fixture, navigation } = render();
+        (query(fixture, '.tab-switch') as HTMLElement).click();
+        fixture.detectChanges();
+
+        expect(fixture.componentInstance.ActiveTab).toBe('shared-by-me');
+        expect(text(fixture, '.embedded-tab')).toBe('shared-by-me');
+        expect(navigation.UpdateActiveTabQueryParams).toHaveBeenCalledWith({ tab: 'shared-by-me' });
+    });
+
+    it('restores a deep-linked tab without writing another query parameter', () => {
+        const { fixture, navigation } = render();
+        fixture.componentInstance.HandleQueryParamsChanged({ tab: 'shared-by-me' }, 'deeplink');
+        fixture.detectChanges();
+
+        expect(text(fixture, '.embedded-tab')).toBe('shared-by-me');
+        expect(navigation.UpdateActiveTabQueryParams).not.toHaveBeenCalled();
+    });
+
+    it('does not expose a permission-mutation client tool', () => {
+        const { navigation } = render();
+        const tools = navigation.SetAgentClientTools.mock.calls[0][1] as { Name: string }[];
+        expect(tools.map((tool) => tool.Name)).toEqual(['SwitchSharingCenterTab', 'RefreshSharingCenter']);
+    });
+});

--- a/packages/Angular/Explorer/dashboards/src/SharingCenter/sharing-center-dashboard.component.dom.test.ts
+++ b/packages/Angular/Explorer/dashboards/src/SharingCenter/sharing-center-dashboard.component.dom.test.ts
@@ -1,11 +1,13 @@
+import { CommonModule } from '@angular/common';
 import { Component, EventEmitter, Input, Output } from '@angular/core';
+import { FormsModule } from '@angular/forms';
 import { describe, expect, it, vi } from 'vitest';
 import { BehaviorSubject, Subject } from 'rxjs';
 import { ApplicationManager } from '@memberjunction/ng-base-application';
 import { NormalizedPermission } from '@memberjunction/core';
 import { NavigationService } from '@memberjunction/ng-shared';
-import { capture, query, renderComponentFixture, text } from '@memberjunction/ng-test-utils';
-import { SharingCenterDashboardTab } from './sharing-center-agent-context';
+import { SharingCenterTab } from '@memberjunction/ng-resource-permissions';
+import { query, renderComponentFixture, text } from '@memberjunction/ng-test-utils';
 import { SharingCenterDashboardComponent } from './sharing-center-dashboard.component';
 
 @Component({ standalone: true, selector: 'mj-page-layout', template: '<ng-content></ng-content>' })
@@ -35,14 +37,55 @@ class RefreshButtonStub {
     @Output() Clicked = new EventEmitter<void>();
 }
 
-@Component({ standalone: true, selector: 'mj-user-sharing-center', template: '<span class="embedded-tab">{{ ActiveTab }}</span>' })
+@Component({ standalone: true, selector: 'mj-page-search', template: '<button class="search" (click)="ValueChange.emit(NextValue)">{{ Value }}</button>' })
+class PageSearchStub {
+    @Input() Placeholder = '';
+    @Input() Value = '';
+    @Input() NextValue = 'sales';
+    @Output() ValueChange = new EventEmitter<string>();
+}
+
+@Component({ standalone: true, selector: 'mj-filter-popover', template: '<button class="clear-filters" (click)="ClearAllRequested.emit()">Clear</button><ng-content></ng-content>' })
+class FilterPopoverStub {
+    @Input() Label = '';
+    @Input() Icon = '';
+    @Input() ActiveCount = 0;
+    @Input() ShowClearAll = false;
+    @Output() ClearAllRequested = new EventEmitter<void>();
+}
+
+@Component({ standalone: true, selector: 'mj-alert', template: '<div class="alert"><ng-content></ng-content></div>' })
+class AlertStub {
+    @Input() Variant = '';
+}
+
+@Component({ standalone: true, selector: 'mj-empty-state', template: '<div class="empty-state">{{ Title }}</div>' })
+class EmptyStateStub {
+    @Input() Size = '';
+    @Input() Icon = '';
+    @Input() Title = '';
+    @Input() Variant = '';
+}
+
+@Component({ standalone: true, selector: 'mj-accordion-panel', template: '<ng-content></ng-content>' })
+class AccordionPanelStub {
+    @Input() Size = '';
+    @Input() FlushBody = false;
+    @Input() Expanded = false;
+    @Output() ExpandedChange = new EventEmitter<boolean>();
+}
+
+@Component({ standalone: true, selector: 'mj-user-sharing-center', template: '<span class="embedded-tab">{{ ActiveTab }}|{{ SearchTerm }}|{{ DomainFilter }}</span>' })
 class UserSharingCenterStub {
     @Input() Provider: object | null = null;
-    @Input() ActiveTab: SharingCenterDashboardTab = 'shared-with-me';
+    @Input() ActiveTab: SharingCenterTab = 'shared-with-me';
     @Input() ShowTabBar = true;
     @Input() ShowCloseButton = true;
-    @Output() ActiveTabChange = new EventEmitter<SharingCenterDashboardTab>();
+    @Input() SearchTerm = '';
+    @Input() DomainFilter = '';
+    @Output() ActiveTabChange = new EventEmitter<SharingCenterTab>();
     @Output() ResourceClicked = new EventEmitter<NormalizedPermission>();
+    @Output() SharesLoaded = new EventEmitter<SharingCenterTab>();
 }
 
 function navigationStub() {
@@ -60,7 +103,21 @@ function navigationStub() {
 function render() {
     const navigation = navigationStub();
     const fixture = renderComponentFixture(SharingCenterDashboardComponent, {
-        imports: [PageLayoutStub, PageHeaderStub, PageBodyStub, TabNavStub, RefreshButtonStub, UserSharingCenterStub],
+        imports: [
+            CommonModule,
+            FormsModule,
+            PageLayoutStub,
+            PageHeaderStub,
+            PageBodyStub,
+            TabNavStub,
+            RefreshButtonStub,
+            PageSearchStub,
+            FilterPopoverStub,
+            AlertStub,
+            EmptyStateStub,
+            AccordionPanelStub,
+            UserSharingCenterStub,
+        ],
         declarations: [SharingCenterDashboardComponent],
         providers: [
             { provide: NavigationService, useValue: navigation },
@@ -71,11 +128,12 @@ function render() {
 }
 
 describe('SharingCenterDashboardComponent (DOM)', () => {
-    it('renders the shared page chrome and starts on Inbox', () => {
+    it('renders the shared page chrome, summary cards, and starts on Inbox', () => {
         const { fixture } = render();
         expect(text(fixture, 'h1')).toBe('Sharing Center');
         expect(text(fixture, 'p')).toContain("See what's shared with you");
-        expect(text(fixture, '.embedded-tab')).toBe('shared-with-me');
+        expect(text(fixture, '.embedded-tab')).toBe('shared-with-me||');
+        expect(fixture.nativeElement.querySelectorAll('.sharing-center-dashboard__stat')).toHaveLength(4);
     });
 
     it('switches the embedded list and writes the stable tab query parameter', () => {
@@ -84,22 +142,48 @@ describe('SharingCenterDashboardComponent (DOM)', () => {
         fixture.detectChanges();
 
         expect(fixture.componentInstance.ActiveTab).toBe('shared-by-me');
-        expect(text(fixture, '.embedded-tab')).toBe('shared-by-me');
+        expect(text(fixture, '.embedded-tab')).toBe('shared-by-me||');
         expect(navigation.UpdateActiveTabQueryParams).toHaveBeenCalledWith({ tab: 'shared-by-me' });
     });
 
-    it('restores a deep-linked tab without writing another query parameter', () => {
+    it('switches to My Access without replacing the embedded share component', () => {
         const { fixture, navigation } = render();
-        fixture.componentInstance.HandleQueryParamsChanged({ tab: 'shared-by-me' }, 'deeplink');
+        fixture.componentInstance.OnTabChange('my-access');
+        fixture.componentInstance.HasLoadedMyAccess = true;
         fixture.detectChanges();
 
-        expect(text(fixture, '.embedded-tab')).toBe('shared-by-me');
+        expect(text(fixture, '#sharing-center-my-access-title')).toBe('My Access');
+        expect(query(fixture, '.embedded-tab')).not.toBeNull();
+        expect(navigation.UpdateActiveTabQueryParams).toHaveBeenCalledWith({ tab: 'my-access' });
+    });
+
+    it('propagates a shared search term to the embedded share list', () => {
+        const { fixture } = render();
+        (query(fixture, '.search') as HTMLElement).click();
+        fixture.detectChanges();
+
+        expect(fixture.componentInstance.SearchTerm).toBe('sales');
+        expect(text(fixture, '.embedded-tab')).toBe('shared-with-me|sales|');
+    });
+
+    it('restores a deep-linked activity tab without writing another query parameter', () => {
+        const { fixture, navigation } = render();
+        fixture.componentInstance.HandleQueryParamsChanged({ tab: 'activity' }, 'deeplink');
+        fixture.componentInstance.HasLoadedActivity = true;
+        fixture.detectChanges();
+
+        expect(text(fixture, '#sharing-center-activity-title')).toBe('Activity');
         expect(navigation.UpdateActiveTabQueryParams).not.toHaveBeenCalled();
     });
 
-    it('does not expose a permission-mutation client tool', () => {
+    it('exposes only view, filter, and refresh client tools', () => {
         const { navigation } = render();
         const tools = navigation.SetAgentClientTools.mock.calls[0][1] as { Name: string }[];
-        expect(tools.map((tool) => tool.Name)).toEqual(['SwitchSharingCenterTab', 'RefreshSharingCenter']);
+        expect(tools.map((tool) => tool.Name)).toEqual([
+            'SwitchSharingCenterTab',
+            'SearchSharingCenter',
+            'FilterSharingCenterDomain',
+            'RefreshSharingCenter',
+        ]);
     });
 });

--- a/packages/Angular/Explorer/dashboards/src/SharingCenter/sharing-center-dashboard.component.html
+++ b/packages/Angular/Explorer/dashboards/src/SharingCenter/sharing-center-dashboard.component.html
@@ -2,26 +2,234 @@
     <mj-page-header
         Title="Sharing Center"
         Icon="fa-solid fa-share-nodes"
-        Subtitle="See what's shared with you, manage what you've shared, and review everything you can access.">
+        Subtitle="See what's shared with you, manage what you've shared, and understand your access.">
         <div actions>
             <mj-refresh-button [Loading]="IsRefreshing" (Clicked)="OnRefresh()"></mj-refresh-button>
         </div>
 
         <div toolbar>
             <mj-tab-nav [Tabs]="Tabs" [ActiveKey]="ActiveTab" (TabChange)="OnTabChange($event)"></mj-tab-nav>
+            <mj-page-search
+                Placeholder="Search shared resources and activity..."
+                [Value]="SearchTerm"
+                (ValueChange)="OnSearchChange($event)">
+            </mj-page-search>
+            <mj-filter-popover
+                Label="Filters"
+                Icon="fa-solid fa-filter"
+                [ActiveCount]="ActiveFilterCount"
+                [ShowClearAll]="ActiveFilterCount > 0"
+                (ClearAllRequested)="OnResetFilters()">
+                <div class="sharing-center-dashboard__filter-field">
+                    <label for="sharing-center-domain-filter">Permission domain</label>
+                    <select
+                        id="sharing-center-domain-filter"
+                        class="sharing-center-dashboard__domain-select"
+                        [ngModel]="DomainFilter"
+                        (ngModelChange)="OnDomainFilterChange($event)">
+                        <option [ngValue]="''">All domains</option>
+                        @for (domain of AvailableDomains; track domain) {
+                            <option [ngValue]="domain">{{ domain }}</option>
+                        }
+                    </select>
+                </div>
+            </mj-filter-popover>
         </div>
     </mj-page-header>
 
     <mj-page-body>
-        <div class="sharing-center-dashboard__body">
-            <mj-user-sharing-center
-                [Provider]="Provider"
-                [ActiveTab]="ActiveTab"
-                [ShowTabBar]="false"
-                [ShowCloseButton]="false"
-                (ActiveTabChange)="OnTabChange($event)"
-                (ResourceClicked)="OnResourceClicked($event)">
-            </mj-user-sharing-center>
+        <div class="sharing-center-dashboard">
+            <section class="sharing-center-dashboard__stats" aria-label="Sharing summary">
+                <article class="sharing-center-dashboard__stat">
+                    <span class="sharing-center-dashboard__stat-icon"><i class="fa-solid fa-inbox"></i></span>
+                    <span class="sharing-center-dashboard__stat-copy">
+                        <span class="sharing-center-dashboard__stat-label">Shared with me</span>
+                        <strong class="sharing-center-dashboard__stat-value">
+                            @if (SharedWithMeCount === null) { — } @else { {{ SharedWithMeCount }} }
+                        </strong>
+                    </span>
+                </article>
+                <article class="sharing-center-dashboard__stat">
+                    <span class="sharing-center-dashboard__stat-icon"><i class="fa-solid fa-paper-plane"></i></span>
+                    <span class="sharing-center-dashboard__stat-copy">
+                        <span class="sharing-center-dashboard__stat-label">Shared by me</span>
+                        <strong class="sharing-center-dashboard__stat-value">
+                            @if (SharedByMeCount === null) { — } @else { {{ SharedByMeCount }} }
+                        </strong>
+                    </span>
+                </article>
+                <article class="sharing-center-dashboard__stat">
+                    <span class="sharing-center-dashboard__stat-icon"><i class="fa-solid fa-shield-halved"></i></span>
+                    <span class="sharing-center-dashboard__stat-copy">
+                        <span class="sharing-center-dashboard__stat-label">Resources I can access</span>
+                        <strong class="sharing-center-dashboard__stat-value">
+                            @if (HasLoadedMyAccess) { {{ MyAccessCount }} } @else { — }
+                        </strong>
+                    </span>
+                </article>
+                <article class="sharing-center-dashboard__stat">
+                    <span class="sharing-center-dashboard__stat-icon"><i class="fa-solid fa-clock-rotate-left"></i></span>
+                    <span class="sharing-center-dashboard__stat-copy">
+                        <span class="sharing-center-dashboard__stat-label">Recent activity</span>
+                        <strong class="sharing-center-dashboard__stat-value">
+                            @if (HasLoadedActivity) { {{ ActivityEntries.length }} } @else { — }
+                        </strong>
+                    </span>
+                </article>
+            </section>
+
+            @if (TransparencyErrorMessage) {
+                <mj-alert Variant="error">{{ TransparencyErrorMessage }}</mj-alert>
+            }
+
+            <section
+                class="sharing-center-dashboard__share-panel"
+                [class.sharing-center-dashboard__share-panel--hidden]="!IsShareTab">
+                <mj-user-sharing-center
+                    [Provider]="Provider"
+                    [ActiveTab]="ActiveShareTab"
+                    [ShowTabBar]="false"
+                    [ShowCloseButton]="false"
+                    [SearchTerm]="SearchTerm"
+                    [DomainFilter]="DomainFilter"
+                    (ActiveTabChange)="OnTabChange($event)"
+                    (ResourceClicked)="OnResourceClicked($event)"
+                    (SharesLoaded)="OnSharesLoaded($event)">
+                </mj-user-sharing-center>
+            </section>
+
+            @switch (ActiveTab) {
+                @case ('my-access') {
+                    <section class="sharing-center-dashboard__panel" aria-labelledby="sharing-center-my-access-title">
+                        <header class="sharing-center-dashboard__panel-header">
+                            <div>
+                                <h2 id="sharing-center-my-access-title">My Access</h2>
+                                <p>Everything you can reach, grouped by permission domain.</p>
+                            </div>
+                            @if (HasLoadedMyAccess) {
+                                <span class="sharing-center-dashboard__panel-count">{{ FilteredMyAccessGroups.length }} domains</span>
+                            }
+                        </header>
+
+                        @if (IsLoadingMyAccess) {
+                            <div class="sharing-center-dashboard__loading">
+                                <i class="fa-solid fa-spinner fa-spin"></i> Loading your access report…
+                            </div>
+                        } @else if (!HasLoadedMyAccess) {
+                            <mj-empty-state
+                                Size="compact"
+                                Icon="fa-solid fa-shield-halved"
+                                Title="Your access report is not available yet." />
+                        } @else if (MyAccessGroups.length === 0) {
+                            <mj-empty-state
+                                Size="compact"
+                                Icon="fa-solid fa-shield-halved"
+                                Title="No accessible resources were found." />
+                        } @else if (FilteredMyAccessGroups.length === 0) {
+                            <mj-empty-state
+                                Size="compact"
+                                Variant="no-results"
+                                Icon="fa-solid fa-magnifying-glass"
+                                Title="No access records match your filters." />
+                        } @else {
+                            <div class="sharing-center-dashboard__groups">
+                                @for (group of FilteredMyAccessGroups; track TrackByDomain($index, group)) {
+                                    <mj-accordion-panel
+                                        Size="sm"
+                                        [FlushBody]="true"
+                                        [Expanded]="group.Expanded"
+                                        (ExpandedChange)="OnAccessGroupExpandedChange(group, $event)">
+                                        <ng-template mjAccordionTitle>
+                                            <span class="sharing-center-dashboard__group-icon"><i [class]="group.Icon"></i></span>
+                                            <span class="sharing-center-dashboard__group-name">{{ group.DomainName }}</span>
+                                            <span class="mj-accordion-badge mj-accordion-badge--right">{{ group.Rows.length }}</span>
+                                        </ng-template>
+                                        <ng-template mjAccordionBody>
+                                            <div class="sharing-center-dashboard__access-rows">
+                                                @for (row of group.Rows; track TrackByPermission($index, row)) {
+                                                    <button
+                                                        type="button"
+                                                        class="sharing-center-dashboard__access-row"
+                                                        (click)="OnResourceClicked(row)">
+                                                        <span class="sharing-center-dashboard__resource">
+                                                            <strong>{{ row.ResourceName || row.ResourceID || row.ResourceType }}</strong>
+                                                            <small>{{ row.ResourceType }}</small>
+                                                        </span>
+                                                        <span
+                                                            class="sharing-center-dashboard__source"
+                                                            [class]="AccessSourceClass(row)">
+                                                            {{ AccessSourceLabel(row) }}
+                                                        </span>
+                                                        <span class="sharing-center-dashboard__actions">{{ ActionsLabel(row.Actions) }}</span>
+                                                    </button>
+                                                }
+                                            </div>
+                                        </ng-template>
+                                    </mj-accordion-panel>
+                                }
+                            </div>
+                        }
+                    </section>
+                }
+                @case ('activity') {
+                    <section class="sharing-center-dashboard__panel" aria-labelledby="sharing-center-activity-title">
+                        <header class="sharing-center-dashboard__panel-header">
+                            <div>
+                                <h2 id="sharing-center-activity-title">Activity</h2>
+                                <p>Recent permission changes you made, shown newest first.</p>
+                            </div>
+                            @if (HasLoadedActivity) {
+                                <span class="sharing-center-dashboard__panel-count">{{ FilteredActivityEntries.length }} changes</span>
+                            }
+                        </header>
+
+                        @if (IsLoadingActivity) {
+                            <div class="sharing-center-dashboard__loading">
+                                <i class="fa-solid fa-spinner fa-spin"></i> Loading recent activity…
+                            </div>
+                        } @else if (!HasLoadedActivity) {
+                            <mj-empty-state
+                                Size="compact"
+                                Icon="fa-solid fa-clock-rotate-left"
+                                Title="Your recent activity is not available yet." />
+                        } @else if (ActivityEntries.length === 0) {
+                            <mj-empty-state
+                                Size="compact"
+                                Icon="fa-solid fa-clock-rotate-left"
+                                Title="No recent permission changes." />
+                        } @else if (FilteredActivityEntries.length === 0) {
+                            <mj-empty-state
+                                Size="compact"
+                                Variant="no-results"
+                                Icon="fa-solid fa-magnifying-glass"
+                                Title="No activity matches your filters." />
+                        } @else {
+                            <ol class="sharing-center-dashboard__timeline">
+                                @for (entry of FilteredActivityEntries; track TrackByActivity($index, entry)) {
+                                    <li class="sharing-center-dashboard__timeline-entry">
+                                        <span class="sharing-center-dashboard__timeline-icon">
+                                            <i [class]="ChangeIcon(entry.ChangeType)"></i>
+                                        </span>
+                                        <div class="sharing-center-dashboard__timeline-content">
+                                            <div class="sharing-center-dashboard__timeline-heading">
+                                                <strong>{{ entry.ChangeType }} permission</strong>
+                                                <time>{{ entry.ChangedAt | date:'medium' }}</time>
+                                            </div>
+                                            <p>
+                                                {{ entry.ChangedByUserName || 'You' }} changed access in
+                                                <strong>{{ entry.DomainName }}</strong>.
+                                            </p>
+                                            @if (entry.Summary) {
+                                                <p class="sharing-center-dashboard__timeline-summary">{{ entry.Summary }}</p>
+                                            }
+                                        </div>
+                                    </li>
+                                }
+                            </ol>
+                        }
+                    </section>
+                }
+            }
         </div>
     </mj-page-body>
 </mj-page-layout>

--- a/packages/Angular/Explorer/dashboards/src/SharingCenter/sharing-center-dashboard.component.html
+++ b/packages/Angular/Explorer/dashboards/src/SharingCenter/sharing-center-dashboard.component.html
@@ -1,0 +1,27 @@
+<mj-page-layout>
+    <mj-page-header
+        Title="Sharing Center"
+        Icon="fa-solid fa-share-nodes"
+        Subtitle="See what's shared with you, manage what you've shared, and review everything you can access.">
+        <div actions>
+            <mj-refresh-button [Loading]="IsRefreshing" (Clicked)="OnRefresh()"></mj-refresh-button>
+        </div>
+
+        <div toolbar>
+            <mj-tab-nav [Tabs]="Tabs" [ActiveKey]="ActiveTab" (TabChange)="OnTabChange($event)"></mj-tab-nav>
+        </div>
+    </mj-page-header>
+
+    <mj-page-body>
+        <div class="sharing-center-dashboard__body">
+            <mj-user-sharing-center
+                [Provider]="Provider"
+                [ActiveTab]="ActiveTab"
+                [ShowTabBar]="false"
+                [ShowCloseButton]="false"
+                (ActiveTabChange)="OnTabChange($event)"
+                (ResourceClicked)="OnResourceClicked($event)">
+            </mj-user-sharing-center>
+        </div>
+    </mj-page-body>
+</mj-page-layout>

--- a/packages/Angular/Explorer/dashboards/src/SharingCenter/sharing-center-dashboard.component.ts
+++ b/packages/Angular/Explorer/dashboards/src/SharingCenter/sharing-center-dashboard.component.ts
@@ -1,25 +1,33 @@
 import { AfterViewInit, ChangeDetectionStrategy, ChangeDetectorRef, Component, Input, OnDestroy, ViewChild, inject } from '@angular/core';
-import { IMetadataProvider, NormalizedPermission } from '@memberjunction/core';
-import { ResourceData } from '@memberjunction/core-entities';
+import { IMetadataProvider, NormalizedPermission, PermissionAction, PermissionAuditEntry } from '@memberjunction/core';
+import { PermissionEngine, ResourceData } from '@memberjunction/core-entities';
 import { RegisterClass } from '@memberjunction/global';
 import { ApplicationManager } from '@memberjunction/ng-base-application';
-import { UserSharingCenterComponent } from '@memberjunction/ng-resource-permissions';
+import { SharingCenterDomainGroup, SharingCenterTab, UserSharingCenterComponent } from '@memberjunction/ng-resource-permissions';
 import { BaseDashboard, OpenSharedResourceInExplorer } from '@memberjunction/ng-shared';
 import { TabConfig } from '@memberjunction/ng-ui-components';
+
+import { PermissionsDomainGroup, groupPermissionsByDomain } from '../Permissions/permissions-shared';
 import {
     buildSharingCenterAgentContext,
     resolveSharingCenterTab,
     SharingCenterDashboardTab,
 } from './sharing-center-agent-context';
+import {
+    filterSharingCenterActivityEntries,
+    filterSharingCenterPermissionGroups,
+    getSharingCenterAccessSource,
+    getSharingCenterAccessSourceLabel,
+} from './sharing-center-view-models';
 
 interface SharingCenterDashboardState {
     activeTab?: SharingCenterDashboardTab;
 }
 
 /**
- * Full-page host for a user's direct shares. The generic child owns the actual
- * share grouping and revoke write, while this dashboard owns Explorer chrome,
- * URL state, navigation, and agent integration.
+ * Full-page host for direct sharing plus the P2 read-only transparency reports.
+ * The generic child owns share grouping and revoke writes; this dashboard owns
+ * Explorer chrome, shared filtering, URL state, and self-service visibility.
  */
 @Component({
     standalone: false,
@@ -45,7 +53,23 @@ export class SharingCenterDashboardComponent extends BaseDashboard implements Af
     }
 
     public ActiveTab: SharingCenterDashboardTab = 'shared-with-me';
+    public ActiveShareTab: SharingCenterTab = 'shared-with-me';
     public IsRefreshing = false;
+    public SearchTerm = '';
+    public DomainFilter = '';
+
+    public MyAccessGroups: PermissionsDomainGroup[] = [];
+    public ActivityEntries: PermissionAuditEntry[] = [];
+    public IsLoadingMyAccess = false;
+    public IsLoadingActivity = false;
+    public HasLoadedMyAccess = false;
+    public HasLoadedActivity = false;
+    public TransparencyErrorMessage: string | null = null;
+
+    private hasLoadedSharedWithMe = false;
+    private hasLoadedSharedByMe = false;
+    private myAccessRequest: Promise<void> | null = null;
+    private activityRequest: Promise<void> | null = null;
 
     private readonly cdr = inject(ChangeDetectorRef);
     private readonly appManager = inject(ApplicationManager);
@@ -53,7 +77,67 @@ export class SharingCenterDashboardComponent extends BaseDashboard implements Af
     public readonly Tabs: TabConfig[] = [
         { key: 'shared-with-me', label: 'Inbox', icon: 'fa-solid fa-inbox' },
         { key: 'shared-by-me', label: 'Shared by me', icon: 'fa-solid fa-paper-plane' },
+        { key: 'my-access', label: 'My Access', icon: 'fa-solid fa-shield-halved' },
+        { key: 'activity', label: 'Activity', icon: 'fa-solid fa-clock-rotate-left' },
     ];
+
+    public get FilteredMyAccessGroups(): PermissionsDomainGroup[] {
+        return filterSharingCenterPermissionGroups(this.MyAccessGroups, this.SearchTerm, this.DomainFilter);
+    }
+
+    public get FilteredActivityEntries(): PermissionAuditEntry[] {
+        return filterSharingCenterActivityEntries(this.ActivityEntries, this.SearchTerm, this.DomainFilter);
+    }
+
+    public get MyAccessCount(): number {
+        return this.MyAccessGroups.reduce((sum, group) => sum + group.Count, 0);
+    }
+
+    public get SharedWithMeCount(): number | null {
+        if (!this.hasLoadedSharedWithMe) {
+            return null;
+        }
+        return this.countShareRows(this.sharingCenter?.SharedWithMe ?? []);
+    }
+
+    public get SharedByMeCount(): number | null {
+        if (!this.hasLoadedSharedByMe) {
+            return null;
+        }
+        return this.countShareRows(this.sharingCenter?.SharedByMe ?? []);
+    }
+
+    public get AvailableDomains(): string[] {
+        const names = new Set<string>();
+        for (const domain of PermissionEngine.Instance.Domains) {
+            names.add(domain.Name);
+        }
+        for (const group of this.MyAccessGroups) {
+            names.add(group.DomainName);
+        }
+        for (const entry of this.ActivityEntries) {
+            names.add(entry.DomainName);
+        }
+        for (const group of this.sharingCenter?.SharedWithMe ?? []) {
+            names.add(group.DomainName);
+        }
+        for (const group of this.sharingCenter?.SharedByMe ?? []) {
+            names.add(group.DomainName);
+        }
+        return Array.from(names).sort((left, right) => left.localeCompare(right));
+    }
+
+    public get ActiveFilterCount(): number {
+        return this.DomainFilter ? 1 : 0;
+    }
+
+    public get IsShareTab(): boolean {
+        return this.ActiveTab === 'shared-with-me' || this.ActiveTab === 'shared-by-me';
+    }
+
+    public get HasActiveFilters(): boolean {
+        return this.SearchTerm.trim().length > 0 || this.DomainFilter.length > 0;
+    }
 
     async GetResourceDisplayName(_data: ResourceData): Promise<string> {
         return 'Sharing Center';
@@ -64,10 +148,13 @@ export class SharingCenterDashboardComponent extends BaseDashboard implements Af
         const savedTab = resolveSharingCenterTab(savedState?.activeTab);
         const queryTab = resolveSharingCenterTab(this.GetQueryParams()['tab']);
         this.ActiveTab = queryTab ?? savedTab ?? 'shared-with-me';
+        if (this.ActiveTab === 'shared-with-me' || this.ActiveTab === 'shared-by-me') {
+            this.ActiveShareTab = this.ActiveTab;
+        }
     }
 
     protected override loadData(): void {
-        // The embedded generic component owns the permission-engine queries.
+        void this.loadTransparencyData(false);
     }
 
     ngAfterViewInit(): void {
@@ -86,6 +173,9 @@ export class SharingCenterDashboardComponent extends BaseDashboard implements Af
         }
 
         this.ActiveTab = tab;
+        if (tab === 'shared-with-me' || tab === 'shared-by-me') {
+            this.ActiveShareTab = tab;
+        }
         this.UpdateQueryParams({ tab });
         this.UserStateChanged.emit({ activeTab: tab } satisfies SharingCenterDashboardState);
         this.publishAgentContext();
@@ -100,6 +190,30 @@ export class SharingCenterDashboardComponent extends BaseDashboard implements Af
         }
 
         this.ActiveTab = tab;
+        if (tab === 'shared-with-me' || tab === 'shared-by-me') {
+            this.ActiveShareTab = tab;
+        }
+        this.publishAgentContext();
+        this.cdr.markForCheck();
+    }
+
+    public OnSearchChange(searchTerm: string): void {
+        this.SearchTerm = searchTerm;
+        this.publishAgentContext();
+        this.cdr.markForCheck();
+    }
+
+    public OnDomainFilterChange(domainFilter: string): void {
+        this.DomainFilter = domainFilter;
+        this.publishAgentContext();
+        this.cdr.markForCheck();
+    }
+
+    public OnResetFilters(): void {
+        if (!this.DomainFilter) {
+            return;
+        }
+        this.DomainFilter = '';
         this.publishAgentContext();
         this.cdr.markForCheck();
     }
@@ -108,7 +222,10 @@ export class SharingCenterDashboardComponent extends BaseDashboard implements Af
         this.IsRefreshing = true;
         this.publishAgentContext();
         try {
-            await this.sharingCenter?.Refresh();
+            await Promise.all([
+                this.sharingCenter?.Refresh() ?? Promise.resolve(),
+                this.loadTransparencyData(true),
+            ]);
         } finally {
             this.IsRefreshing = false;
             this.publishAgentContext();
@@ -116,8 +233,161 @@ export class SharingCenterDashboardComponent extends BaseDashboard implements Af
         }
     }
 
+    public OnSharesLoaded(tab: SharingCenterTab): void {
+        if (tab === 'shared-with-me') {
+            this.hasLoadedSharedWithMe = true;
+        } else {
+            this.hasLoadedSharedByMe = true;
+        }
+        this.publishAgentContext();
+        this.cdr.markForCheck();
+    }
+
     public async OnResourceClicked(row: NormalizedPermission): Promise<void> {
         await OpenSharedResourceInExplorer(row, this.navigationService, this.appManager);
+    }
+
+    public OnAccessGroupExpandedChange(group: PermissionsDomainGroup, expanded: boolean): void {
+        const sourceGroup = this.MyAccessGroups.find((candidate) => candidate.DomainName === group.DomainName);
+        if (sourceGroup) {
+            sourceGroup.Expanded = expanded;
+        }
+        this.cdr.markForCheck();
+    }
+
+    public AccessSourceLabel(row: NormalizedPermission): string {
+        return getSharingCenterAccessSourceLabel(getSharingCenterAccessSource(row));
+    }
+
+    public AccessSourceClass(row: NormalizedPermission): string {
+        return `sharing-center-dashboard__source sharing-center-dashboard__source--${getSharingCenterAccessSource(row).toLocaleLowerCase()}`;
+    }
+
+    public ActionsLabel(actions: PermissionAction[]): string {
+        return actions.join(', ');
+    }
+
+    public ChangeIcon(changeType: PermissionAuditEntry['ChangeType']): string {
+        switch (changeType) {
+            case 'Create':
+                return 'fa-solid fa-plus';
+            case 'Update':
+                return 'fa-solid fa-pen';
+            case 'Delete':
+                return 'fa-solid fa-trash';
+            case 'Snapshot':
+                return 'fa-solid fa-camera';
+        }
+    }
+
+    public TrackByDomain(_index: number, group: PermissionsDomainGroup): string {
+        return group.DomainName;
+    }
+
+    public TrackByPermission(_index: number, row: NormalizedPermission): string {
+        return row.SourceRecordID ?? `${row.DomainName}|${row.ResourceType}|${row.ResourceID ?? ''}|${row.GranteeID ?? ''}`;
+    }
+
+    public TrackByActivity(_index: number, entry: PermissionAuditEntry): string {
+        return entry.SourceRecordChangeID;
+    }
+
+    private async loadTransparencyData(force: boolean): Promise<void> {
+        await Promise.all([this.loadMyAccess(force), this.loadActivity(force)]);
+    }
+
+    private loadMyAccess(force: boolean): Promise<void> {
+        if (this.myAccessRequest) {
+            return this.myAccessRequest;
+        }
+        if (this.HasLoadedMyAccess && !force) {
+            return Promise.resolve();
+        }
+
+        this.myAccessRequest = this.fetchMyAccess().finally(() => {
+            this.myAccessRequest = null;
+        });
+        return this.myAccessRequest;
+    }
+
+    private async fetchMyAccess(): Promise<void> {
+        const user = this.Provider?.CurrentUser ?? this.ProviderToUse?.CurrentUser;
+        if (!user) {
+            return;
+        }
+
+        this.IsLoadingMyAccess = true;
+        this.TransparencyErrorMessage = null;
+        this.cdr.markForCheck();
+        try {
+            const rows = await PermissionEngine.Instance.GetAllUserPermissions(user);
+            this.MyAccessGroups = groupPermissionsByDomain(rows, this.getDomainOrderMap());
+            this.HasLoadedMyAccess = true;
+        } catch (error) {
+            this.MyAccessGroups = [];
+            this.TransparencyErrorMessage = `Unable to load your access report: ${
+                error instanceof Error ? error.message : 'an unexpected error occurred'
+            }`;
+        } finally {
+            this.IsLoadingMyAccess = false;
+            this.publishAgentContext();
+            this.cdr.markForCheck();
+        }
+    }
+
+    private loadActivity(force: boolean): Promise<void> {
+        if (this.activityRequest) {
+            return this.activityRequest;
+        }
+        if (this.HasLoadedActivity && !force) {
+            return Promise.resolve();
+        }
+
+        this.activityRequest = this.fetchActivity().finally(() => {
+            this.activityRequest = null;
+        });
+        return this.activityRequest;
+    }
+
+    private async fetchActivity(): Promise<void> {
+        const user = this.Provider?.CurrentUser ?? this.ProviderToUse?.CurrentUser;
+        if (!user) {
+            return;
+        }
+
+        this.IsLoadingActivity = true;
+        this.TransparencyErrorMessage = null;
+        this.cdr.markForCheck();
+        try {
+            // The audit API is organization-wide when unfiltered. Restricting to
+            // the current actor keeps this self-service tab user-scoped.
+            this.ActivityEntries = await PermissionEngine.Instance.GetAuditTimeline({
+                ChangedByUserID: user.ID,
+                MaxRows: 100,
+            });
+            this.HasLoadedActivity = true;
+        } catch (error) {
+            this.ActivityEntries = [];
+            this.TransparencyErrorMessage = `Unable to load recent activity: ${
+                error instanceof Error ? error.message : 'an unexpected error occurred'
+            }`;
+        } finally {
+            this.IsLoadingActivity = false;
+            this.publishAgentContext();
+            this.cdr.markForCheck();
+        }
+    }
+
+    private getDomainOrderMap(): Map<string, number> {
+        const orderMap = new Map<string, number>();
+        for (const domain of PermissionEngine.Instance.Domains) {
+            orderMap.set(domain.Name, domain.DisplayOrder ?? 999);
+        }
+        return orderMap;
+    }
+
+    private countShareRows(groups: SharingCenterDomainGroup[]): number {
+        return groups.reduce((sum, group) => sum + group.Rows.length, 0);
     }
 
     /**
@@ -127,18 +397,26 @@ export class SharingCenterDashboardComponent extends BaseDashboard implements Af
     private publishAgentContext(): void {
         this.navigationService.SetAgentContext(
             this,
-            buildSharingCenterAgentContext({ ActiveTab: this.ActiveTab, IsRefreshing: this.IsRefreshing })
+            buildSharingCenterAgentContext({
+                ActiveTab: this.ActiveTab,
+                IsRefreshing: this.IsRefreshing,
+                SearchTerm: this.SearchTerm,
+                DomainFilter: this.DomainFilter,
+                MyAccessCount: this.MyAccessCount,
+                ActivityEntryCount: this.ActivityEntries.length,
+                AvailableDomainNames: this.AvailableDomains,
+            })
         );
         this.navigationService.SetAgentClientTools(this, [
             {
                 Name: 'SwitchSharingCenterTab',
-                Description: 'Switch the Sharing Center between Inbox and Shared by me. This only changes the visible tab.',
+                Description: 'Switch the Sharing Center tab. This only changes the visible section.',
                 ParameterSchema: {
                     type: 'object',
                     properties: {
                         tab: {
                             type: 'string',
-                            enum: ['shared-with-me', 'shared-by-me'],
+                            enum: ['shared-with-me', 'shared-by-me', 'my-access', 'activity'],
                             description: 'The Sharing Center tab to show.',
                         },
                     },
@@ -148,15 +426,60 @@ export class SharingCenterDashboardComponent extends BaseDashboard implements Af
                     const value = params['tab'];
                     const tab = typeof value === 'string' ? resolveSharingCenterTab(value) : null;
                     if (!tab) {
-                        return { Success: false, ErrorMessage: 'tab must be shared-with-me or shared-by-me.' };
+                        return { Success: false, ErrorMessage: 'tab must name a Sharing Center tab.' };
                     }
                     this.OnTabChange(tab);
                     return { Success: true, Data: { ActiveTab: tab } };
                 },
             },
             {
+                Name: 'SearchSharingCenter',
+                Description: 'Search the Sharing Center data currently loaded in each tab. Read-only — does not change access.',
+                ParameterSchema: {
+                    type: 'object',
+                    properties: { query: { type: 'string', description: 'Search text; empty clears the search.' } },
+                    required: ['query'],
+                },
+                Handler: async (params) => {
+                    const value = params['query'];
+                    if (typeof value !== 'string') {
+                        return { Success: false, ErrorMessage: 'query must be a string.' };
+                    }
+                    this.OnSearchChange(value);
+                    return { Success: true, Data: { SearchTerm: this.SearchTerm } };
+                },
+            },
+            {
+                Name: 'FilterSharingCenterDomain',
+                Description: 'Filter the Sharing Center to an available permission domain, or use an empty value to clear it. Read-only.',
+                ParameterSchema: {
+                    type: 'object',
+                    properties: { domainName: { type: 'string', description: 'Exact domain name, or empty to clear.' } },
+                    required: ['domainName'],
+                },
+                Handler: async (params) => {
+                    const value = params['domainName'];
+                    if (typeof value !== 'string') {
+                        return { Success: false, ErrorMessage: 'domainName must be a string.' };
+                    }
+                    const requestedDomain = value.trim();
+                    if (!requestedDomain) {
+                        this.OnDomainFilterChange('');
+                        return { Success: true, Data: { DomainFilter: '' } };
+                    }
+                    const domain = this.AvailableDomains.find(
+                        (candidate) => candidate.toLocaleLowerCase() === requestedDomain.toLocaleLowerCase()
+                    );
+                    if (!domain) {
+                        return { Success: false, ErrorMessage: `Unknown permission domain: ${requestedDomain}.` };
+                    }
+                    this.OnDomainFilterChange(domain);
+                    return { Success: true, Data: { DomainFilter: domain } };
+                },
+            },
+            {
                 Name: 'RefreshSharingCenter',
-                Description: 'Refresh the permission list displayed on the active Sharing Center tab. Does not change any access.',
+                Description: 'Refresh the loaded Sharing Center reports. Does not change any access.',
                 ParameterSchema: { type: 'object', properties: {} },
                 Handler: async () => {
                     await this.OnRefresh();

--- a/packages/Angular/Explorer/dashboards/src/SharingCenter/sharing-center-dashboard.component.ts
+++ b/packages/Angular/Explorer/dashboards/src/SharingCenter/sharing-center-dashboard.component.ts
@@ -1,0 +1,168 @@
+import { AfterViewInit, ChangeDetectionStrategy, ChangeDetectorRef, Component, Input, OnDestroy, ViewChild, inject } from '@angular/core';
+import { IMetadataProvider, NormalizedPermission } from '@memberjunction/core';
+import { ResourceData } from '@memberjunction/core-entities';
+import { RegisterClass } from '@memberjunction/global';
+import { ApplicationManager } from '@memberjunction/ng-base-application';
+import { UserSharingCenterComponent } from '@memberjunction/ng-resource-permissions';
+import { BaseDashboard, OpenSharedResourceInExplorer } from '@memberjunction/ng-shared';
+import { TabConfig } from '@memberjunction/ng-ui-components';
+import {
+    buildSharingCenterAgentContext,
+    resolveSharingCenterTab,
+    SharingCenterDashboardTab,
+} from './sharing-center-agent-context';
+
+interface SharingCenterDashboardState {
+    activeTab?: SharingCenterDashboardTab;
+}
+
+/**
+ * Full-page host for a user's direct shares. The generic child owns the actual
+ * share grouping and revoke write, while this dashboard owns Explorer chrome,
+ * URL state, navigation, and agent integration.
+ */
+@Component({
+    standalone: false,
+    selector: 'mj-sharing-center-dashboard',
+    templateUrl: './sharing-center-dashboard.component.html',
+    styleUrls: ['./sharing-center-dashboard.component.css'],
+    changeDetection: ChangeDetectionStrategy.OnPush,
+})
+@RegisterClass(BaseDashboard, 'SharingCenter')
+export class SharingCenterDashboardComponent extends BaseDashboard implements AfterViewInit, OnDestroy {
+    @ViewChild(UserSharingCenterComponent) private sharingCenter?: UserSharingCenterComponent;
+
+    /** Explicitly re-declared so Angular publishes the inherited provider as a component input. */
+    @Input() override Provider: IMetadataProvider | null = null;
+
+    /** The resource wrapper's data carries the tab's persisted query parameters. */
+    @Input()
+    override set Data(value: ResourceData) {
+        super.Data = value;
+    }
+    override get Data(): ResourceData {
+        return super.Data;
+    }
+
+    public ActiveTab: SharingCenterDashboardTab = 'shared-with-me';
+    public IsRefreshing = false;
+
+    private readonly cdr = inject(ChangeDetectorRef);
+    private readonly appManager = inject(ApplicationManager);
+
+    public readonly Tabs: TabConfig[] = [
+        { key: 'shared-with-me', label: 'Inbox', icon: 'fa-solid fa-inbox' },
+        { key: 'shared-by-me', label: 'Shared by me', icon: 'fa-solid fa-paper-plane' },
+    ];
+
+    async GetResourceDisplayName(_data: ResourceData): Promise<string> {
+        return 'Sharing Center';
+    }
+
+    protected override initDashboard(): void {
+        const savedState: SharingCenterDashboardState | undefined = this.Config?.userState;
+        const savedTab = resolveSharingCenterTab(savedState?.activeTab);
+        const queryTab = resolveSharingCenterTab(this.GetQueryParams()['tab']);
+        this.ActiveTab = queryTab ?? savedTab ?? 'shared-with-me';
+    }
+
+    protected override loadData(): void {
+        // The embedded generic component owns the permission-engine queries.
+    }
+
+    ngAfterViewInit(): void {
+        this.publishAgentContext();
+    }
+
+    override ngOnDestroy(): void {
+        super.ngOnDestroy();
+    }
+
+    /** Receives both tab-nav clicks and the generic component's two-way tab output. */
+    public OnTabChange(tabValue: string): void {
+        const tab = resolveSharingCenterTab(tabValue);
+        if (!tab || tab === this.ActiveTab) {
+            return;
+        }
+
+        this.ActiveTab = tab;
+        this.UpdateQueryParams({ tab });
+        this.UserStateChanged.emit({ activeTab: tab } satisfies SharingCenterDashboardState);
+        this.publishAgentContext();
+        this.cdr.markForCheck();
+    }
+
+    /** Applies deep links, pin clicks, and browser back/forward updates. */
+    public HandleQueryParamsChanged(params: Record<string, string>, _source: 'popstate' | 'deeplink'): void {
+        const tab = resolveSharingCenterTab(params['tab']);
+        if (!tab || tab === this.ActiveTab) {
+            return;
+        }
+
+        this.ActiveTab = tab;
+        this.publishAgentContext();
+        this.cdr.markForCheck();
+    }
+
+    public async OnRefresh(): Promise<void> {
+        this.IsRefreshing = true;
+        this.publishAgentContext();
+        try {
+            await this.sharingCenter?.Refresh();
+        } finally {
+            this.IsRefreshing = false;
+            this.publishAgentContext();
+            this.cdr.markForCheck();
+        }
+    }
+
+    public async OnResourceClicked(row: NormalizedPermission): Promise<void> {
+        await OpenSharedResourceInExplorer(row, this.navigationService, this.appManager);
+    }
+
+    /**
+     * Implements the dashboard-agent contract without exposing grant, revoke,
+     * or other permission mutations. Those remain explicit human UI actions.
+     */
+    private publishAgentContext(): void {
+        this.navigationService.SetAgentContext(
+            this,
+            buildSharingCenterAgentContext({ ActiveTab: this.ActiveTab, IsRefreshing: this.IsRefreshing })
+        );
+        this.navigationService.SetAgentClientTools(this, [
+            {
+                Name: 'SwitchSharingCenterTab',
+                Description: 'Switch the Sharing Center between Inbox and Shared by me. This only changes the visible tab.',
+                ParameterSchema: {
+                    type: 'object',
+                    properties: {
+                        tab: {
+                            type: 'string',
+                            enum: ['shared-with-me', 'shared-by-me'],
+                            description: 'The Sharing Center tab to show.',
+                        },
+                    },
+                    required: ['tab'],
+                },
+                Handler: async (params) => {
+                    const value = params['tab'];
+                    const tab = typeof value === 'string' ? resolveSharingCenterTab(value) : null;
+                    if (!tab) {
+                        return { Success: false, ErrorMessage: 'tab must be shared-with-me or shared-by-me.' };
+                    }
+                    this.OnTabChange(tab);
+                    return { Success: true, Data: { ActiveTab: tab } };
+                },
+            },
+            {
+                Name: 'RefreshSharingCenter',
+                Description: 'Refresh the permission list displayed on the active Sharing Center tab. Does not change any access.',
+                ParameterSchema: { type: 'object', properties: {} },
+                Handler: async () => {
+                    await this.OnRefresh();
+                    return { Success: true };
+                },
+            },
+        ]);
+    }
+}

--- a/packages/Angular/Explorer/dashboards/src/SharingCenter/sharing-center-resource.component.ts
+++ b/packages/Angular/Explorer/dashboards/src/SharingCenter/sharing-center-resource.component.ts
@@ -1,0 +1,97 @@
+import { ChangeDetectionStrategy, ChangeDetectorRef, Component, OnInit, ViewChild, inject } from '@angular/core';
+import { ResourceData } from '@memberjunction/core-entities';
+import { RegisterClass } from '@memberjunction/global';
+import { BaseResourceComponent } from '@memberjunction/ng-shared';
+import { SharingCenterDashboardComponent } from './sharing-center-dashboard.component';
+
+/**
+ * Explorer resource wrapper for the Sharing Center application. It forwards the
+ * shell's provider, resource data, load lifecycle, and URL changes to the
+ * inner BaseDashboard so cached tabs and deep links remain reliable.
+ */
+@Component({
+    standalone: false,
+    selector: 'mj-sharing-center-resource',
+    template: `
+        <div class="sharing-center-resource-container">
+            <mj-sharing-center-dashboard
+                [Provider]="Provider"
+                [Data]="Data"
+                [ParentTabId]="getTabId()">
+            </mj-sharing-center-dashboard>
+        </div>
+    `,
+    styles: [`
+        :host { display: block; width: 100%; height: 100%; }
+        .sharing-center-resource-container { width: 100%; height: 100%; }
+    `],
+    changeDetection: ChangeDetectionStrategy.OnPush,
+})
+@RegisterClass(BaseResourceComponent, 'SharingCenterResource')
+export class SharingCenterResourceComponent extends BaseResourceComponent implements OnInit {
+    @ViewChild(SharingCenterDashboardComponent) private dashboard?: SharingCenterDashboardComponent;
+
+    private readonly cdr = inject(ChangeDetectorRef);
+    private hasWiredDashboard = false;
+    private pendingQueryParams: Record<string, string> | null = null;
+
+    override set Data(value: ResourceData) {
+        super.Data = value;
+        if (!this.hasWiredDashboard) {
+            this.hasWiredDashboard = true;
+            this.wireDashboard();
+        }
+    }
+
+    override get Data(): ResourceData {
+        return super.Data;
+    }
+
+    override ngOnInit(): void {
+        super.ngOnInit();
+    }
+
+    async GetResourceDisplayName(data: ResourceData): Promise<string> {
+        return data.Name || 'Sharing Center';
+    }
+
+    async GetResourceIconClass(_data: ResourceData): Promise<string> {
+        return 'fa-solid fa-share-nodes';
+    }
+
+    protected override OnQueryParamsChanged(params: Record<string, string>, source: 'popstate' | 'deeplink'): void {
+        if (this.dashboard) {
+            this.dashboard.HandleQueryParamsChanged(params, source);
+            return;
+        }
+        this.pendingQueryParams = params;
+    }
+
+    private wireDashboard(): void {
+        this.cdr.detectChanges();
+        setTimeout(() => {
+            if (!this.dashboard) {
+                this.NotifyLoadComplete();
+                return;
+            }
+
+            this.dashboard.LoadCompleteEvent = () => this.NotifyLoadComplete();
+            if (this.pendingQueryParams) {
+                this.dashboard.HandleQueryParamsChanged(this.pendingQueryParams, 'deeplink');
+                this.pendingQueryParams = null;
+            }
+            void this.dashboard.Refresh();
+
+            // The child can complete in the microtask before the setTimeout wiring;
+            // forward that completion so direct application URLs never hang.
+            if (this.dashboard.LoadComplete) {
+                this.NotifyLoadComplete();
+            }
+        }, 0);
+    }
+}
+
+/** Tree-shaking prevention — referenced from the package public API. */
+export function LoadSharingCenterResource(): void {
+    // Intentionally empty: keeps the @RegisterClass side effect in the bundle.
+}

--- a/packages/Angular/Explorer/dashboards/src/SharingCenter/sharing-center-view-models.test.ts
+++ b/packages/Angular/Explorer/dashboards/src/SharingCenter/sharing-center-view-models.test.ts
@@ -1,0 +1,120 @@
+import { describe, expect, it } from 'vitest';
+import { NormalizedPermission, PermissionAuditEntry } from '@memberjunction/core';
+
+import { PermissionsDomainGroup } from '../Permissions/permissions-shared';
+import {
+    countSharingCenterExpiringSoon,
+    filterSharingCenterActivityEntries,
+    filterSharingCenterPermissionGroups,
+    getSharingCenterAccessSource,
+    getSharingCenterAccessSourceLabel,
+} from './sharing-center-view-models';
+
+function permission(overrides: Partial<NormalizedPermission> = {}): NormalizedPermission {
+    return {
+        DomainName: 'Dashboard Permissions',
+        ResourceType: 'Dashboards',
+        ResourceID: 'dashboard-1',
+        ResourceName: 'Sales Dashboard',
+        GranteeType: 'User',
+        GranteeID: 'user-1',
+        GranteeName: 'Taylor',
+        Actions: ['Read'],
+        Effect: 'Allow',
+        SourceRecordID: 'permission-1',
+        ...overrides,
+    };
+}
+
+function group(overrides: Partial<PermissionsDomainGroup> = {}): PermissionsDomainGroup {
+    return {
+        DomainName: 'Dashboard Permissions',
+        Icon: 'fa-solid fa-chart-line',
+        Count: 1,
+        Expanded: true,
+        Rows: [permission()],
+        ...overrides,
+    };
+}
+
+function activity(overrides: Partial<PermissionAuditEntry> = {}): PermissionAuditEntry {
+    return {
+        ChangedAt: new Date('2026-07-24T12:00:00.000Z'),
+        ChangedByUserID: 'user-1',
+        ChangedByUserName: 'Taylor',
+        DomainName: 'Dashboard Permissions',
+        EntityName: 'MJ: Dashboard Permissions',
+        RecordID: 'permission-1',
+        ChangeType: 'Create',
+        Summary: 'Granted read access to Sales Dashboard',
+        SourceRecordChangeID: 'change-1',
+        ...overrides,
+    };
+}
+
+describe('sharing-center-view-models', () => {
+    it('derives only evidence-backed access-source labels', () => {
+        expect(getSharingCenterAccessSource(permission())).toBe('Direct');
+        expect(getSharingCenterAccessSource(permission({ GranteeType: 'Role' }))).toBe('Role');
+        expect(getSharingCenterAccessSource(permission({ GranteeType: 'Everyone', GranteeID: null }))).toBe('Public');
+        expect(
+            getSharingCenterAccessSource(
+                permission({
+                    SourceRecordID: undefined,
+                    Actions: ['Read', 'Update', 'Delete', 'Share'],
+                })
+            )
+        ).toBe('Owner');
+        expect(getSharingCenterAccessSourceLabel('Public')).toBe('Public / Everyone');
+    });
+
+    it('filters access groups by shared search and exact domain without changing the source group', () => {
+        const groups = [
+            group({
+                Rows: [permission(), permission({ ResourceID: 'dashboard-2', ResourceName: 'Executive Overview' })],
+                Count: 2,
+            }),
+            group({
+                DomainName: 'Query Permissions',
+                Rows: [permission({ DomainName: 'Query Permissions', ResourceName: 'Pipeline Query' })],
+            }),
+        ];
+
+        const filtered = filterSharingCenterPermissionGroups(groups, 'executive', 'Dashboard Permissions');
+
+        expect(filtered).toHaveLength(1);
+        expect(filtered[0].Rows).toHaveLength(1);
+        expect(filtered[0].Rows[0].ResourceName).toBe('Executive Overview');
+        expect(filtered[0].Count).toBe(1);
+        expect(groups[0].Rows).toHaveLength(2);
+        expect(groups[0].Count).toBe(2);
+    });
+
+    it('filters activity entries by the same domain and search criteria', () => {
+        const entries = [
+            activity(),
+            activity({
+                DomainName: 'Query Permissions',
+                EntityName: 'MJ: Query Permissions',
+                ChangeType: 'Delete',
+                Summary: 'Revoked execute access',
+                SourceRecordChangeID: 'change-2',
+            }),
+        ];
+
+        expect(filterSharingCenterActivityEntries(entries, 'revoked', '')).toEqual([entries[1]]);
+        expect(filterSharingCenterActivityEntries(entries, '', 'Dashboard Permissions')).toEqual([entries[0]]);
+    });
+
+    it('counts only future grants expiring within thirty days', () => {
+        const now = new Date('2026-07-24T00:00:00.000Z');
+        const rows = [
+            permission({ ExpiresAt: new Date('2026-07-25T00:00:00.000Z') }),
+            permission({ ResourceID: '2', ExpiresAt: new Date('2026-08-23T00:00:00.000Z') }),
+            permission({ ResourceID: '3', ExpiresAt: new Date('2026-08-24T00:00:00.000Z') }),
+            permission({ ResourceID: '4', ExpiresAt: new Date('2026-07-23T00:00:00.000Z') }),
+        ];
+
+        expect(countSharingCenterExpiringSoon(rows, now)).toBe(2);
+    });
+});

--- a/packages/Angular/Explorer/dashboards/src/SharingCenter/sharing-center-view-models.ts
+++ b/packages/Angular/Explorer/dashboards/src/SharingCenter/sharing-center-view-models.ts
@@ -1,0 +1,123 @@
+import { NormalizedPermission, PermissionAction, PermissionAuditEntry } from '@memberjunction/core';
+
+import { PermissionsDomainGroup } from '../Permissions/permissions-shared';
+
+/** Source labels shown by the read-only My Access report. */
+export type SharingCenterAccessSource = 'Owner' | 'Direct' | 'Role' | 'Public';
+
+const OWNER_ACTIONS: PermissionAction[] = ['Read', 'Update', 'Delete', 'Share'];
+
+/**
+ * Derive the best available explanation for an effective permission. The
+ * normalized contract does not yet expose a dedicated provenance field, so a
+ * user-grantee row is only called Owner when it is a synthetic full-access row
+ * with no backing permission record. All other user rows are accurately shown
+ * as Direct rather than implying ownership.
+ */
+export function getSharingCenterAccessSource(row: NormalizedPermission): SharingCenterAccessSource {
+    switch (row.GranteeType) {
+        case 'Role':
+            return 'Role';
+        case 'Everyone':
+        case 'Public':
+            return 'Public';
+        case 'User':
+            return isSyntheticOwnerPermission(row) ? 'Owner' : 'Direct';
+    }
+}
+
+/** Human-readable source label used by the access badge. */
+export function getSharingCenterAccessSourceLabel(source: SharingCenterAccessSource): string {
+    return source === 'Public' ? 'Public / Everyone' : source;
+}
+
+/** Filter domain groups without mutating the permission data or expansion state. */
+export function filterSharingCenterPermissionGroups(
+    groups: PermissionsDomainGroup[],
+    searchTerm: string,
+    domainFilter: string
+): PermissionsDomainGroup[] {
+    const normalizedSearch = normalizeSearch(searchTerm);
+    const normalizedDomain = normalizeSearch(domainFilter);
+    if (!normalizedSearch && !normalizedDomain) {
+        return groups;
+    }
+
+    const filtered: PermissionsDomainGroup[] = [];
+    for (const group of groups) {
+        if (normalizedDomain && normalizeSearch(group.DomainName) !== normalizedDomain) {
+            continue;
+        }
+
+        const rows = group.Rows.filter((row) => matchesPermission(row, normalizedSearch));
+        if (rows.length > 0) {
+            filtered.push({ ...group, Rows: rows, Count: rows.length });
+        }
+    }
+    return filtered;
+}
+
+/** Filter timeline entries with the dashboard's shared search and domain state. */
+export function filterSharingCenterActivityEntries(
+    entries: PermissionAuditEntry[],
+    searchTerm: string,
+    domainFilter: string
+): PermissionAuditEntry[] {
+    const normalizedSearch = normalizeSearch(searchTerm);
+    const normalizedDomain = normalizeSearch(domainFilter);
+    return entries.filter((entry) => {
+        if (normalizedDomain && normalizeSearch(entry.DomainName) !== normalizedDomain) {
+            return false;
+        }
+        if (!normalizedSearch) {
+            return true;
+        }
+        return [
+            entry.ChangedByUserName,
+            entry.ChangedByUserID,
+            entry.DomainName,
+            entry.EntityName,
+            entry.RecordID,
+            entry.ChangeType,
+            entry.Summary,
+        ].some((value) => normalizeSearch(value ?? '').includes(normalizedSearch));
+    });
+}
+
+/** Count grants that will expire between now and the next thirty days. */
+export function countSharingCenterExpiringSoon(rows: NormalizedPermission[], now: Date): number {
+    const nowTime = now.getTime();
+    const threshold = nowTime + 30 * 24 * 60 * 60 * 1000;
+    return rows.filter((row) => {
+        if (!row.ExpiresAt) {
+            return false;
+        }
+        const expiresAt = row.ExpiresAt.getTime();
+        return expiresAt >= nowTime && expiresAt <= threshold;
+    }).length;
+}
+
+function isSyntheticOwnerPermission(row: NormalizedPermission): boolean {
+    return !row.SourceRecordID && OWNER_ACTIONS.every((action) => row.Actions.includes(action));
+}
+
+function matchesPermission(row: NormalizedPermission, normalizedSearch: string): boolean {
+    if (!normalizedSearch) {
+        return true;
+    }
+    return [
+        row.DomainName,
+        row.ResourceName,
+        row.ResourceID,
+        row.ResourceType,
+        row.GranteeName,
+        row.GranteeID,
+        row.GranteeType,
+        row.Actions.join(' '),
+        row.Effect,
+    ].some((value) => normalizeSearch(value ?? '').includes(normalizedSearch));
+}
+
+function normalizeSearch(value: string): string {
+    return value.trim().toLocaleLowerCase();
+}

--- a/packages/Angular/Explorer/dashboards/src/core-dashboards.module.ts
+++ b/packages/Angular/Explorer/dashboards/src/core-dashboards.module.ts
@@ -39,7 +39,7 @@ import { DashboardViewerModule } from '@memberjunction/ng-dashboard-viewer';
 import { VersionsModule } from '@memberjunction/ng-versions';
 import { ExportServiceModule } from '@memberjunction/ng-export-service';
 import { NgTreesModule } from '@memberjunction/ng-trees';
-import { ResourcePermissionsModule } from '@memberjunction/ng-resource-permissions';
+import { ResourcePermissionsModule, UserSharingCenterComponent } from '@memberjunction/ng-resource-permissions';
 import { SharedPipesModule } from './shared/shared-pipes.module';
 
 // Core components — eagerly loaded, most-visited pages
@@ -94,6 +94,8 @@ import { AngularSplitModule } from 'angular-split';
 import { PermissionsUserAccessResourceComponent } from './Permissions/user-access-resource.component';
 import { PermissionsResourceAccessResourceComponent } from './Permissions/resource-access-resource.component';
 import { PermissionsAuditLogResourceComponent } from './Permissions/audit-log-resource.component';
+import { SharingCenterDashboardComponent } from './SharingCenter/sharing-center-dashboard.component';
+import { SharingCenterResourceComponent } from './SharingCenter/sharing-center-resource.component';
 // Version History
 import { VersionHistoryLabelsResourceComponent } from './VersionHistory/components/labels-resource.component';
 import { VersionHistoryDiffResourceComponent } from './VersionHistory/components/diff-resource.component';
@@ -148,6 +150,9 @@ import { VersionHistoryGraphResourceComponent } from './VersionHistory/component
     PermissionsUserAccessResourceComponent,
     PermissionsResourceAccessResourceComponent,
     PermissionsAuditLogResourceComponent,
+    // Sharing Center
+    SharingCenterDashboardComponent,
+    SharingCenterResourceComponent,
     // Version History
     VersionHistoryLabelsResourceComponent,
     VersionHistoryDiffResourceComponent,
@@ -197,6 +202,7 @@ import { VersionHistoryGraphResourceComponent } from './VersionHistory/component
     ExportServiceModule,
     NgTreesModule,
     ResourcePermissionsModule,
+    UserSharingCenterComponent,
     SharedPipesModule,
     AngularSplitModule,
     MJStorageMediaPlayerComponent
@@ -238,6 +244,8 @@ import { VersionHistoryGraphResourceComponent } from './VersionHistory/component
     PermissionsUserAccessResourceComponent,
     PermissionsResourceAccessResourceComponent,
     PermissionsAuditLogResourceComponent,
+    SharingCenterDashboardComponent,
+    SharingCenterResourceComponent,
     VersionHistoryLabelsResourceComponent,
     VersionHistoryDiffResourceComponent,
     VersionHistoryRestoreResourceComponent,

--- a/packages/Angular/Explorer/dashboards/src/public-api.ts
+++ b/packages/Angular/Explorer/dashboards/src/public-api.ts
@@ -171,6 +171,12 @@ export { ApplicationRolesResourceComponent, LoadApplicationRolesResource } from 
 // Realtime Recordings — review & replay recorded realtime sessions (audio + transcript)
 export { RealtimeRecordingsDashboardComponent, LoadRealtimeRecordingsDashboard } from './RealtimeRecordings/realtime-recordings-dashboard.component';
 
+// Sharing Center — full-page host for a user's direct shares.
+export { SharingCenterDashboardComponent } from './SharingCenter/sharing-center-dashboard.component';
+export { SharingCenterResourceComponent, LoadSharingCenterResource } from './SharingCenter/sharing-center-resource.component';
+import { LoadSharingCenterResource } from './SharingCenter/sharing-center-resource.component';
+LoadSharingCenterResource();
+
 // Permissions admin — three independent resource tabs (Phase 2a/b/c — unified permissions)
 export {
     PermissionsUserAccessResourceComponent,

--- a/packages/Angular/Explorer/explorer-core/src/lib/shell/services/sharing-center-dialog-host.component.ts
+++ b/packages/Angular/Explorer/explorer-core/src/lib/shell/services/sharing-center-dialog-host.component.ts
@@ -1,10 +1,9 @@
 import { ChangeDetectionStrategy, Component, inject } from '@angular/core';
-import { firstValueFrom } from 'rxjs';
-import { CompositeKey, NormalizedPermission } from '@memberjunction/core';
-import { MJDialogRef } from '@memberjunction/ng-ui-components';
+import { NormalizedPermission } from '@memberjunction/core';
+import { MJButtonDirective, MJDialogRef } from '@memberjunction/ng-ui-components';
 import { UserSharingCenterComponent } from '@memberjunction/ng-resource-permissions';
-import { NavigationService } from '@memberjunction/ng-shared';
-import { ApplicationManager, BaseApplication } from '@memberjunction/ng-base-application';
+import { NavigationService, OpenSharedResourceInExplorer, OpenSharingCenterApplication } from '@memberjunction/ng-shared';
+import { ApplicationManager } from '@memberjunction/ng-base-application';
 
 /**
  * Thin Explorer-side wrapper around the Generic {@link UserSharingCenterComponent}.
@@ -19,15 +18,33 @@ import { ApplicationManager, BaseApplication } from '@memberjunction/ng-base-app
 @Component({
     standalone: true,
     selector: 'mj-explorer-sharing-center-dialog-host',
-    imports: [UserSharingCenterComponent],
+    imports: [UserSharingCenterComponent, MJButtonDirective],
     changeDetection: ChangeDetectionStrategy.OnPush,
     template: `
-        <mj-user-sharing-center
-            [ShowCloseButton]="false"
-            (ResourceClicked)="OnResourceClicked($event)"
-            (CloseRequested)="OnCloseRequested()">
-        </mj-user-sharing-center>
+        <div class="sharing-center-dialog-host">
+            <mj-user-sharing-center
+                [ShowCloseButton]="false"
+                (ResourceClicked)="OnResourceClicked($event)"
+                (CloseRequested)="OnCloseRequested()">
+            </mj-user-sharing-center>
+            <div class="sharing-center-dialog-host__footer">
+                <button mjButton variant="flat" size="sm" (click)="OnOpenFullSharingCenter()">
+                    Open full Sharing Center <i class="fa-solid fa-arrow-right"></i>
+                </button>
+            </div>
+        </div>
     `,
+    styles: [`
+        .sharing-center-dialog-host { display: flex; flex-direction: column; height: 100%; }
+        .sharing-center-dialog-host > mj-user-sharing-center { flex: 1; min-height: 0; }
+        .sharing-center-dialog-host__footer {
+            display: flex;
+            justify-content: flex-end;
+            padding: var(--mj-space-2) var(--mj-space-3);
+            border-top: 1px solid var(--mj-border-default);
+            background: var(--mj-bg-surface-card);
+        }
+    `],
 })
 export class SharingCenterDialogHostComponent {
     private readonly dialogRef = inject(MJDialogRef, { optional: true });
@@ -35,8 +52,7 @@ export class SharingCenterDialogHostComponent {
     private readonly appManager = inject(ApplicationManager);
 
     async OnResourceClicked(row: NormalizedPermission): Promise<void> {
-        if (!row.ResourceID) return;
-        const opened = await this.openResourceForExplorer(row);
+        const opened = await OpenSharedResourceInExplorer(row, this.navigationService, this.appManager);
         if (opened) {
             this.dialogRef?.Close();
         }
@@ -46,59 +62,10 @@ export class SharingCenterDialogHostComponent {
         this.dialogRef?.Close();
     }
 
-    private async openResourceForExplorer(row: NormalizedPermission): Promise<boolean> {
-        switch (row.DomainName) {
-            case 'Dashboard Permissions':
-                this.navigationService.OpenDashboard(row.ResourceID!, row.ResourceName ?? 'Dashboard');
-                return true;
-
-            case 'Artifact Permissions':
-                this.navigationService.OpenArtifact(row.ResourceID!, row.ResourceName);
-                return true;
-
-            case 'Collection Permissions':
-                return this.openCollection(row.ResourceID!);
-
-            case 'Query Permissions':
-                this.navigationService.OpenQuery(row.ResourceID!, row.ResourceName ?? 'Query');
-                return true;
-
-            case 'Resource Permissions':
-            case 'Access Control Rules':
-                if (row.ResourceType) {
-                    const key = new CompositeKey();
-                    key.KeyValuePairs.push({ FieldName: 'ID', Value: row.ResourceID! });
-                    this.navigationService.OpenEntityRecord(row.ResourceType, key);
-                    return true;
-                }
-                return false;
-
-            default:
-                return false;
+    async OnOpenFullSharingCenter(): Promise<void> {
+        const opened = await OpenSharingCenterApplication(this.navigationService, this.appManager);
+        if (opened) {
+            this.dialogRef?.Close();
         }
-    }
-
-    /**
-     * Collections have no NavigationService.Open* helper — they live behind the
-     * 'Collections' nav item of the Chat app. Find whichever app exposes that nav
-     * item (the Sharing Center can be opened from any app, so the ACTIVE app can't
-     * be assumed) and switch to it with the collectionId as query params, which
-     * drives both fresh tabs (initial param read) and cached ones (OnQueryParamsChanged).
-     */
-    private async openCollection(collectionId: string): Promise<boolean> {
-        const apps: BaseApplication[] = await firstValueFrom(this.appManager.Applications).catch(() => []);
-        for (const app of apps) {
-            const navItems = await app.GetNavItems();
-            // Match on DriverClass (stable identity — survives label renames/localization)
-            // and only consider Active items (Status defaults to Active when unset).
-            const collectionsNav = navItems.find(
-                (item) => item.DriverClass === 'ChatCollectionsResource' && (item.Status ?? 'Active') === 'Active'
-            );
-            if (collectionsNav) {
-                await this.navigationService.SwitchToApp(app.ID, collectionsNav.Label, { collectionId });
-                return true;
-            }
-        }
-        return false;
     }
 }

--- a/packages/Angular/Explorer/shared/src/lib/sharing-center-navigation.ts
+++ b/packages/Angular/Explorer/shared/src/lib/sharing-center-navigation.ts
@@ -1,0 +1,94 @@
+import { firstValueFrom } from 'rxjs';
+import { CompositeKey, NormalizedPermission } from '@memberjunction/core';
+import { ApplicationManager, BaseApplication } from '@memberjunction/ng-base-application';
+import { NavigationService } from './navigation.service';
+
+/**
+ * Opens a resource surfaced by the user Sharing Center with the Explorer route
+ * that understands that resource's permission domain.
+ *
+ * Both the quick-glance dialog and the full Sharing Center use this helper so
+ * a resource always opens to the same destination regardless of entry point.
+ */
+export async function OpenSharedResourceInExplorer(
+    row: NormalizedPermission,
+    navigationService: NavigationService,
+    appManager: ApplicationManager
+): Promise<boolean> {
+    if (!row.ResourceID) {
+        return false;
+    }
+
+    switch (row.DomainName) {
+        case 'Dashboard Permissions':
+            navigationService.OpenDashboard(row.ResourceID, row.ResourceName ?? 'Dashboard');
+            return true;
+
+        case 'Artifact Permissions':
+            navigationService.OpenArtifact(row.ResourceID, row.ResourceName);
+            return true;
+
+        case 'Collection Permissions':
+            return OpenSharedCollection(row.ResourceID, navigationService, appManager);
+
+        case 'Query Permissions':
+            navigationService.OpenQuery(row.ResourceID, row.ResourceName ?? 'Query');
+            return true;
+
+        case 'Resource Permissions':
+        case 'Access Control Rules':
+            if (!row.ResourceType) {
+                return false;
+            }
+            const key = new CompositeKey();
+            key.KeyValuePairs.push({ FieldName: 'ID', Value: row.ResourceID });
+            navigationService.OpenEntityRecord(row.ResourceType, key);
+            return true;
+
+        default:
+            return false;
+    }
+}
+
+/** Opens the full application from the quick-glance dialog without assuming an app ID. */
+export async function OpenSharingCenterApplication(
+    navigationService: NavigationService,
+    appManager: ApplicationManager
+): Promise<boolean> {
+    const apps = await firstValueFrom(appManager.Applications).catch((): BaseApplication[] => []);
+    const application = apps.find((app) => app.Name === 'Sharing Center');
+    if (!application) {
+        return false;
+    }
+
+    const navItems = await application.GetNavItems();
+    const navItem = navItems.find(
+        (item) => item.DriverClass === 'SharingCenterResource' && (item.Status ?? 'Active') === 'Active'
+    );
+    if (!navItem) {
+        return false;
+    }
+
+    await navigationService.SwitchToApp(application.ID, navItem.Label);
+    return true;
+}
+
+/** Collections live in the Chat app, whose identity is not fixed across deployments. */
+async function OpenSharedCollection(
+    collectionId: string,
+    navigationService: NavigationService,
+    appManager: ApplicationManager
+): Promise<boolean> {
+    const apps = await firstValueFrom(appManager.Applications).catch((): BaseApplication[] => []);
+    for (const app of apps) {
+        const navItems = await app.GetNavItems();
+        const collectionsNav = navItems.find(
+            (item) => item.DriverClass === 'ChatCollectionsResource' && (item.Status ?? 'Active') === 'Active'
+        );
+        if (collectionsNav) {
+            await navigationService.SwitchToApp(app.ID, collectionsNav.Label, { collectionId });
+            return true;
+        }
+    }
+    return false;
+}

--- a/packages/Angular/Explorer/shared/src/public-api.ts
+++ b/packages/Angular/Explorer/shared/src/public-api.ts
@@ -10,6 +10,7 @@ export * from './lib/base-resource-component'
 export * from './lib/base-navigation-component';
 export * from './lib/navigation.service';
 export * from './lib/navigation.interfaces';
+export * from './lib/sharing-center-navigation';
 export * from './lib/activity.service';
 export * from './lib/title.service';
 export * from './lib/developer-mode.service';

--- a/packages/Angular/Generic/resource-permissions/src/lib/user-sharing-center.component.dom.test.ts
+++ b/packages/Angular/Generic/resource-permissions/src/lib/user-sharing-center.component.dom.test.ts
@@ -71,6 +71,13 @@ describe('UserSharingCenterComponent (DOM, data-bound)', () => {
     expect(query(withoutClose, '.close')).toBeNull();
   });
 
+  it('hides its tab strip when a full-page host provides navigation chrome', () => {
+    const f = render({ ShowTabBar: false }, (c) => {
+      c.SharedWithMe = [group()];
+    });
+    expect(query(f, '.tabs')).toBeNull();
+  });
+
   it('renders a domain group with its name and row count', () => {
     const f = render({}, (c) => {
       c.SharedWithMe = [group({ Rows: [permission(), permission({ SourceRecordID: 'perm2' })] })];

--- a/packages/Angular/Generic/resource-permissions/src/lib/user-sharing-center.component.dom.test.ts
+++ b/packages/Angular/Generic/resource-permissions/src/lib/user-sharing-center.component.dom.test.ts
@@ -95,6 +95,27 @@ describe('UserSharingCenterComponent (DOM, data-bound)', () => {
     expect(text(f, '.rows .row .resource')).toBe('Sales Dashboard');
   });
 
+  it('filters the embedded share list by a host-provided search term', () => {
+    const f = render({ SearchTerm: 'sales' }, (c) => {
+      c.SharedWithMe = [group({
+        Rows: [
+          permission({ ResourceName: 'Sales Dashboard' }),
+          permission({ ResourceName: 'Executive Overview', SourceRecordID: 'perm2' })
+        ]
+      })];
+    });
+    expect(queryAll(f, '.rows .row').length).toBe(1);
+    expect(text(f, '.rows .row .resource')).toBe('Sales Dashboard');
+  });
+
+  it('shows a no-results state when a host-provided domain filter excludes every share', () => {
+    const f = render({ DomainFilter: 'Query Permissions' }, (c) => {
+      c.SharedWithMe = [group({ DomainName: 'Dashboard Permissions' })];
+    });
+    expect(query(f, '.rows')).toBeNull();
+    expect(text(f, 'mj-empty-state')).toContain('No shared resources match your filters.');
+  });
+
   it('hides rows when the group is collapsed', () => {
     const f = render({}, (c) => {
       c.SharedWithMe = [group({ Expanded: false })];

--- a/packages/Angular/Generic/resource-permissions/src/lib/user-sharing-center.component.html
+++ b/packages/Angular/Generic/resource-permissions/src/lib/user-sharing-center.component.html
@@ -1,4 +1,5 @@
 <div class="user-sharing-center">
+    @if (ShowTabBar) {
     <div class="tabs">
         <button
             class="tab"
@@ -21,6 +22,7 @@
             </button>
         }
     </div>
+    }
 
     @if (ErrorMessage) {
         <div class="error">

--- a/packages/Angular/Generic/resource-permissions/src/lib/user-sharing-center.component.html
+++ b/packages/Angular/Generic/resource-permissions/src/lib/user-sharing-center.component.html
@@ -41,8 +41,12 @@
             <mj-empty-state class="empty" Size="compact"
                 Icon="fa-solid fa-inbox"
                 Title="Nothing has been shared directly with you yet." />
+        } @else if (FilteredSharedWithMe.length === 0) {
+            <mj-empty-state class="empty" Size="compact" Variant="no-results"
+                Icon="fa-solid fa-magnifying-glass"
+                Title="No shared resources match your filters." />
         } @else {
-            @for (group of SharedWithMe; track TrackByDomain($index, group)) {
+            @for (group of FilteredSharedWithMe; track TrackByDomain($index, group)) {
                 <mj-accordion-panel Size="sm" [FlushBody]="true"
                     [Expanded]="group.Expanded"
                     (ExpandedChange)="OnGroupExpandedChange(group, $event)">
@@ -78,8 +82,12 @@
             <mj-empty-state class="empty" Size="compact"
                 Icon="fa-solid fa-paper-plane"
                 Title="You haven't shared anything with others yet." />
+        } @else if (FilteredSharedByMe.length === 0) {
+            <mj-empty-state class="empty" Size="compact" Variant="no-results"
+                Icon="fa-solid fa-magnifying-glass"
+                Title="No shared resources match your filters." />
         } @else {
-            @for (group of SharedByMe; track TrackByDomain($index, group)) {
+            @for (group of FilteredSharedByMe; track TrackByDomain($index, group)) {
                 <mj-accordion-panel Size="sm" [FlushBody]="true"
                     [Expanded]="group.Expanded"
                     (ExpandedChange)="OnGroupExpandedChange(group, $event)">

--- a/packages/Angular/Generic/resource-permissions/src/lib/user-sharing-center.component.ts
+++ b/packages/Angular/Generic/resource-permissions/src/lib/user-sharing-center.component.ts
@@ -4,8 +4,10 @@ import {
     Component,
     EventEmitter,
     Input,
+    OnChanges,
     OnInit,
     Output,
+    SimpleChanges,
     inject,
 } from '@angular/core';
 import { CommonModule } from '@angular/common';
@@ -92,7 +94,7 @@ export const DefaultSharingEntityResolver = (domainName: string): string | null 
     templateUrl: './user-sharing-center.component.html',
     styleUrls: ['./user-sharing-center.component.css'],
 })
-export class UserSharingCenterComponent extends BaseAngularComponent implements OnInit {
+export class UserSharingCenterComponent extends BaseAngularComponent implements OnInit, OnChanges {
     private readonly cdr = inject(ChangeDetectorRef);
     private readonly dialogService = inject(MJDialogService);
 
@@ -106,6 +108,13 @@ export class UserSharingCenterComponent extends BaseAngularComponent implements 
      * embedding container provides its own close affordance.
      */
     @Input() ShowCloseButton = true;
+
+    /**
+     * Controls the component-owned tab strip. Full-page hosts provide their own
+     * navigation chrome and set this to false while retaining the same list and
+     * revoke behavior.
+     */
+    @Input() ShowTabBar = true;
 
     /** Title text displayed in the confirm-revoke dialog. */
     @Input() RevokeConfirmTitle = 'Revoke access';
@@ -146,6 +155,13 @@ export class UserSharingCenterComponent extends BaseAngularComponent implements 
 
     async ngOnInit(): Promise<void> {
         await this.loadTab(this.ActiveTab);
+    }
+
+    ngOnChanges(changes: SimpleChanges): void {
+        const activeTabChange = changes['ActiveTab'];
+        if (activeTabChange && !activeTabChange.firstChange) {
+            void this.loadTab(this.ActiveTab);
+        }
     }
 
     // ─── Public methods (callable from parent via @ViewChild) ──────────────────

--- a/packages/Angular/Generic/resource-permissions/src/lib/user-sharing-center.component.ts
+++ b/packages/Angular/Generic/resource-permissions/src/lib/user-sharing-center.component.ts
@@ -116,6 +116,12 @@ export class UserSharingCenterComponent extends BaseAngularComponent implements 
      */
     @Input() ShowTabBar = true;
 
+    /** Shared full-page search text. Empty means do not constrain either share list. */
+    @Input() SearchTerm = '';
+
+    /** Optional exact domain name selected by an embedding host's filter UI. */
+    @Input() DomainFilter = '';
+
     /** Title text displayed in the confirm-revoke dialog. */
     @Input() RevokeConfirmTitle = 'Revoke access';
 
@@ -143,6 +149,9 @@ export class UserSharingCenterComponent extends BaseAngularComponent implements 
     /** Fired whenever an error is shown to the user. Useful for parent telemetry. */
     @Output() ErrorOccurred = new EventEmitter<string>();
 
+    /** Fired after either share list finishes loading or refreshing. */
+    @Output() SharesLoaded = new EventEmitter<SharingCenterTab>();
+
     // ─── Public state (read by template) ───────────────────────────────────────
 
     SharedWithMe: SharingCenterDomainGroup[] = [];
@@ -153,6 +162,18 @@ export class UserSharingCenterComponent extends BaseAngularComponent implements 
 
     ErrorMessage: string | null = null;
 
+    get FilteredSharedWithMe(): SharingCenterDomainGroup[] {
+        return this.filterGroups(this.SharedWithMe);
+    }
+
+    get FilteredSharedByMe(): SharingCenterDomainGroup[] {
+        return this.filterGroups(this.SharedByMe);
+    }
+
+    get HasActiveFilters(): boolean {
+        return this.SearchTerm.trim().length > 0 || this.DomainFilter.trim().length > 0;
+    }
+
     async ngOnInit(): Promise<void> {
         await this.loadTab(this.ActiveTab);
     }
@@ -161,6 +182,9 @@ export class UserSharingCenterComponent extends BaseAngularComponent implements 
         const activeTabChange = changes['ActiveTab'];
         if (activeTabChange && !activeTabChange.firstChange) {
             void this.loadTab(this.ActiveTab);
+        }
+        if (changes['SearchTerm'] || changes['DomainFilter']) {
+            this.cdr.markForCheck();
         }
     }
 
@@ -236,7 +260,11 @@ export class UserSharingCenterComponent extends BaseAngularComponent implements 
      * group. OnPush, so an explicit detectChanges() is required to reflect the change.
      */
     OnGroupExpandedChange(group: SharingCenterDomainGroup, expanded: boolean): void {
-        group.Expanded = expanded;
+        const groups = this.ActiveTab === 'shared-with-me' ? this.SharedWithMe : this.SharedByMe;
+        const sourceGroup = groups.find((candidate) => candidate.DomainName === group.DomainName);
+        if (sourceGroup) {
+            sourceGroup.Expanded = expanded;
+        }
         this.cdr.detectChanges();
     }
 
@@ -278,9 +306,11 @@ export class UserSharingCenterComponent extends BaseAngularComponent implements 
             this.SharedWithMe = this.groupByDomain(rows);
         } catch (e) {
             this.setError(`Failed to load shares: ${e instanceof Error ? e.message : String(e)}`);
+        } finally {
+            this.IsLoadingWithMe = false;
+            this.SharesLoaded.emit('shared-with-me');
+            this.cdr.detectChanges();
         }
-        this.IsLoadingWithMe = false;
-        this.cdr.detectChanges();
     }
 
     private async loadSharedByMe(): Promise<void> {
@@ -295,9 +325,11 @@ export class UserSharingCenterComponent extends BaseAngularComponent implements 
             this.SharedByMe = this.groupByDomain(rows);
         } catch (e) {
             this.setError(`Failed to load grants: ${e instanceof Error ? e.message : String(e)}`);
+        } finally {
+            this.IsLoadingByMe = false;
+            this.SharesLoaded.emit('shared-by-me');
+            this.cdr.detectChanges();
         }
-        this.IsLoadingByMe = false;
-        this.cdr.detectChanges();
     }
 
     private groupByDomain(rows: NormalizedPermission[]): SharingCenterDomainGroup[] {
@@ -317,6 +349,44 @@ export class UserSharingCenterComponent extends BaseAngularComponent implements 
             });
         }
         return groups.sort((a, b) => a.DomainName.localeCompare(b.DomainName));
+    }
+
+    private filterGroups(groups: SharingCenterDomainGroup[]): SharingCenterDomainGroup[] {
+        const searchTerm = this.SearchTerm.trim().toLocaleLowerCase();
+        const domainFilter = this.DomainFilter.trim().toLocaleLowerCase();
+        if (!searchTerm && !domainFilter) {
+            return groups;
+        }
+
+        const filtered: SharingCenterDomainGroup[] = [];
+        for (const group of groups) {
+            if (domainFilter && group.DomainName.toLocaleLowerCase() !== domainFilter) {
+                continue;
+            }
+
+            const rows = group.Rows.filter((row) => this.rowMatchesSearch(row, searchTerm));
+            if (rows.length > 0) {
+                filtered.push({ ...group, Rows: rows });
+            }
+        }
+        return filtered;
+    }
+
+    private rowMatchesSearch(row: NormalizedPermission, searchTerm: string): boolean {
+        if (!searchTerm) {
+            return true;
+        }
+        return [
+            row.DomainName,
+            row.ResourceName,
+            row.ResourceID,
+            row.ResourceType,
+            row.GranteeName,
+            row.GranteeID,
+            row.GranteeType,
+            row.Actions.join(' '),
+            row.Effect,
+        ].some((value) => (value ?? '').toLocaleLowerCase().includes(searchTerm));
     }
 
     private setError(message: string): void {


### PR DESCRIPTION
Add a Sharing Center dashboard app (BaseResourceComponent wrapper + BaseDashboard) that surfaces the unified-permission sharing views, promoting the capability from the user-menu modal into its own Explorer application.

- New SharingCenter dashboard component, resource wrapper, agent context, template, and styles
- Add unit + DOM tests for the new component and agent context
- Register the components in core-dashboards.module and public-api
- Add a shared sharing-center-navigation helper (+ export) and point the existing dialog host at it so both surfaces share one ResourceClicked -> NavigationService mapping
- Extend the generic user-sharing-center component/template/tests