### PR TITLE
mj migrate: print the batch context Skyway already collects

### DIFF
--- a/.changeset/migrate-error-detail.md
+++ b/.changeset/migrate-error-detail.md
@@ -1,0 +1,5 @@
+---
+'@memberjunction/cli': patch
+---
+
+`mj migrate` now prints the batch context Skyway already collects when a migration fails: the batch number and its line range in the script, how many batches applied before it, and either the lines matched to identifiers named in the error or a preview of the failing batch SQL. Previously only `Error.message` was shown, so a failure in a large generated migration gave a line range with no way to see what was in it.

--- a/packages/MJCLI/src/commands/migrate/index.ts
+++ b/packages/MJCLI/src/commands/migrate/index.ts
@@ -221,7 +221,7 @@ export default class Migrate extends Command {
           this.logToStderr(`    Version: ${detail.Migration.Version ?? '(repeatable)'}`);
           this.logToStderr(`    Description: ${detail.Migration.Description}`);
           if (detail.Error) {
-            this.logToStderr(`    Error: ${detail.Error.message}`);
+            this.printMigrationError(detail.Error);
           }
         }
       } else {
@@ -231,6 +231,64 @@ export default class Migrate extends Command {
       }
 
       this.error('Migrations failed');
+    }
+  }
+
+  /**
+   * Print everything Skyway captured about a failed migration.
+   *
+   * Skyway builds a `MigrationExecutionError` carrying the batch number, its line range in the
+   * script, and the lines within that batch which mention the identifiers named in the error — and
+   * we were printing only `Error.message`, discarding all of it. That is the difference between
+   * "a migration failed somewhere in 60,000 lines" and a file:line to open.
+   *
+   * Everything here is defensive: `BatchInfo` is optional on the error type, and a reporting path
+   * must never throw while reporting a failure.
+   */
+  private printMigrationError(error: Error): void {
+    this.logToStderr(`    Error: ${error.message}`);
+
+    const batch = (error as { BatchInfo?: {
+      BatchNumber?: number;
+      TotalBatches?: number;
+      StartLine?: number;
+      EndLine?: number;
+      SucceededBatches?: number;
+      ContextLines?: Array<{ LineNumber: number; Text: string }>;
+      BatchSQL?: string;
+    } }).BatchInfo;
+    if (!batch) {
+      return;
+    }
+
+    if (batch.BatchNumber != null && batch.TotalBatches != null) {
+      const range = batch.StartLine != null && batch.EndLine != null ? ` (lines ${batch.StartLine}-${batch.EndLine})` : '';
+      this.logToStderr(`    Batch: ${batch.BatchNumber} of ${batch.TotalBatches}${range}`);
+    }
+    if (batch.SucceededBatches != null) {
+      this.logToStderr(`    Batches applied before the failure: ${batch.SucceededBatches}`);
+    }
+
+    // The lines Skyway matched to identifiers in the error message. These carry FILE line numbers,
+    // so they paste straight into an editor.
+    if (batch.ContextLines?.length) {
+      this.logToStderr('    Related lines:');
+      for (const line of batch.ContextLines) {
+        this.logToStderr(`      ${line.LineNumber}: ${line.Text.trim()}`);
+      }
+    }
+
+    // When nothing could be matched, the batch SQL itself is the next best thing — without it the
+    // reader has a line range and no way to see what is in it.
+    else if (batch.BatchSQL) {
+      const preview = batch.BatchSQL.split('\n').slice(0, 10);
+      this.logToStderr('    Failing batch:');
+      for (const line of preview) {
+        this.logToStderr(`      ${line}`);
+      }
+      if (batch.BatchSQL.split('\n').length > preview.length) {
+        this.logToStderr('      ...');
+      }
     }
   }
 
@@ -247,7 +305,7 @@ export default class Migrate extends Command {
         this.logToStderr(`    Version: ${detail.Migration.Version ?? '(repeatable)'}`);
         this.logToStderr(`    Description: ${detail.Migration.Description}`);
         if (detail.Error) {
-          this.logToStderr(`    Error: ${detail.Error.message}`);
+          this.printMigrationError(detail.Error);
         }
       }
     } else if (lastMigrationStarted) {


### PR DESCRIPTION
## The problem

When a migration fails, `mj migrate` prints only `Error.message`:

```
Error: Failed at batch 283/954 (lines 5428-5430): Transaction (Process ID 77) was deadlocked
on lock resources with another process and has been chosen as the deadlock victim.
```

Skyway had **already built** a `MigrationExecutionError` carrying the batch number, its line range, how many batches succeeded, the batch SQL, and the lines within it matching identifiers named in the error — and we discarded all of it. For a 60,000-line generated migration, that leaves you a line range with no way to see what's in it.

## After

```
Error: Failed at batch 283/954 (lines 5428-5430): Msg 1205, Severity 13, State 55,
in trg_OrderLine_RollupTotals line 22: Transaction (Process ID 59) was deadlocked ...
Batch: 283 of 954 (lines 5428-5430)
Batches applied before the failure: 282
Failing batch:
  /* SQL text to add special date field __mj_CreatedAt to entity ...OrderLine */
  UPDATE [__mj_BizAppsOrders].[OrderLine] SET [__mj_CreatedAt] = GETUTCDATE() WHERE [__mj_CreatedAt] IS NULL;
```

The `Msg 1205 ... in trg_OrderLine_RollupTotals line 22` portion comes from a companion PR on the Skyway side — MemberJunction/skyway#22 — which stops `err.message` swallowing the procedure/line the driver reported. **This PR is independently useful without it**; together they turn an unattributed deadlock into a named object and a visible statement.

## Notes

- Both failure paths (`result.Details` and the `OnProgress` callback fallback) route through one `printMigrationError`, so they no longer report different amounts of detail.
- `BatchInfo` is read defensively — it's optional on the error type, and a reporting path must never throw while reporting a failure.
- Prefers Skyway's matched context lines (they carry **file** line numbers, so they paste straight into an editor) and falls back to a 10-line batch preview when nothing matched.

## How this came up

Debugging a genuine migration failure in a BizApps app. It took hours largely because the report named neither the object nor the statement — the failure read like server instability, so I chased connection pooling, `MAXDOP`, and stale sessions before running the same SQL through `sqlcmd`, which named the trigger immediately. The real bug was ordering in *my* migration; the CLI just never said so.

Verified end-to-end by reintroducing that failure and running it through the locally-built CLI — the before/after above is the actual output.