### PR TITLE
fix(content-autotag): address PR #3275 follow-up feedback (#3287)

### DIFF
--- a/.changeset/content-autotag-followup-3287.md
+++ b/.changeset/content-autotag-followup-3287.md
@@ -14,8 +14,8 @@ Follow-up polish for #3275 (resolves #3287) — no behavior change:
   construction is extracted into a new `protected buildVectorRecord(...)`, and `buildVectorRecords`
   plus its collaborators (`resolveChunkVectorId`, `buildVectorMetadata`, `buildProviderDirectives`,
   `resolveItemVectorStorageConfig`, `isItemLevelVector`) are now `protected` with TSDoc.
-- **O(1) by-id lookups in `KnowledgeHubMetadataEngine`**: `GetContentSourceById`,
-  `GetContentTypeById`, `GetContentSourceTypeById`, `GetContentFileTypeById` (plus the existing
-  `GetVectorIndexById` / `GetEntityDocumentById`) are now backed by lazily-built id indexes that
+- **O(1) by-id lookups in `KnowledgeHubMetadataEngine`**: `GetContentSourceByID`,
+  `GetContentTypeByID`, `GetContentSourceTypeByID`, `GetContentFileTypeByID` (plus the existing
+  `GetVectorIndexByID` / `GetEntityDocumentByID`) are now backed by lazily-built id indexes that
   self-invalidate on the engine's `DataChange$`. `AutotagBaseEngine` now routes its by-id lookups
   through these helpers instead of repeated `.find()` scans.

--- a/.changeset/content-autotag-followup-3287.md
+++ b/.changeset/content-autotag-followup-3287.md
@@ -1,0 +1,21 @@
+---
+'@memberjunction/content-autotagging': patch
+'@memberjunction/core-entities': patch
+---
+
+Follow-up polish for #3275 (resolves #3287) — no behavior change:
+
+- **Export the vector-config interfaces** from `@memberjunction/content-autotagging` with TSDoc
+  (`ResolvedVectorInfrastructure`, `ResolvedVectorStorageConfig`, `EmbeddingChunk`, `PersistedChunk`,
+  `ChunkPurgeStats`, `ChunkEmbedStats`, and the `VectorIDStrategy` / `ChunkTextStorage` /
+  `VectorMetadataConfig` / `VectorMetadataFieldConfig` aliases) so downstream consumers can reason
+  about resolved vector infrastructure.
+- **`AutotagBaseEngine` chunk-record shaping is now subclass-overridable**: the per-chunk record
+  construction is extracted into a new `protected buildVectorRecord(...)`, and `buildVectorRecords`
+  plus its collaborators (`resolveChunkVectorId`, `buildVectorMetadata`, `buildProviderDirectives`,
+  `resolveItemVectorStorageConfig`, `isItemLevelVector`) are now `protected` with TSDoc.
+- **O(1) by-id lookups in `KnowledgeHubMetadataEngine`**: `GetContentSourceById`,
+  `GetContentTypeById`, `GetContentSourceTypeById`, `GetContentFileTypeById` (plus the existing
+  `GetVectorIndexById` / `GetEntityDocumentById`) are now backed by lazily-built id indexes that
+  self-invalidate on the engine's `DataChange$`. `AutotagBaseEngine` now routes its by-id lookups
+  through these helpers instead of repeated `.find()` scans.

--- a/packages/AI/Vectors/Dupe/src/__tests__/duplicateRecordDetector.test.ts
+++ b/packages/AI/Vectors/Dupe/src/__tests__/duplicateRecordDetector.test.ts
@@ -157,8 +157,8 @@ vi.mock('@memberjunction/core-entities', () => ({
             Config: vi.fn().mockResolvedValue(undefined),
             EntityDocuments: [],
             VectorIndexes: [],
-            GetEntityDocumentById: vi.fn().mockReturnValue(undefined),
-            GetVectorIndexById: vi.fn().mockReturnValue({
+            GetEntityDocumentByID: vi.fn().mockReturnValue(undefined),
+            GetVectorIndexByID: vi.fn().mockReturnValue({
                 ID: 'vi-1',
                 Name: 'mj-knowledge-index',
                 VectorDatabaseID: 'vdb-1',

--- a/packages/AI/Vectors/Dupe/src/duplicateRecordDetector.ts
+++ b/packages/AI/Vectors/Dupe/src/duplicateRecordDetector.ts
@@ -537,7 +537,7 @@ export class DuplicateRecordDetector extends VectorBase {
     protected async ValidateEntityDocument(entityDocumentID: string): Promise<MJEntityDocumentEntity | null> {
         // Ensure KH engine is initialized (no-op if already loaded)
         await KnowledgeHubMetadataEngine.Instance.Config(false, this.CurrentUser);
-        const doc = KnowledgeHubMetadataEngine.Instance.GetEntityDocumentById(entityDocumentID);
+        const doc = KnowledgeHubMetadataEngine.Instance.GetEntityDocumentByID(entityDocumentID);
         return doc ?? null;
     }
 
@@ -591,7 +591,7 @@ export class DuplicateRecordDetector extends VectorBase {
         // Resolve the vector index name from the entity document's VectorIndexID
         // Uses KnowledgeHubMetadataEngine cache instead of a RunView query
         if (entityDocument.VectorIndexID) {
-            const vectorIndex = KnowledgeHubMetadataEngine.Instance.GetVectorIndexById(entityDocument.VectorIndexID);
+            const vectorIndex = KnowledgeHubMetadataEngine.Instance.GetVectorIndexByID(entityDocument.VectorIndexID);
             if (vectorIndex) {
                 this.indexName = vectorIndex.Name;
             }

--- a/packages/AI/Vectors/Sync/src/__tests__/EntityDocumentCache.test.ts
+++ b/packages/AI/Vectors/Sync/src/__tests__/EntityDocumentCache.test.ts
@@ -19,11 +19,11 @@ vi.mock('@memberjunction/core', () => {
   };
 });
 
-const { mockKHConfig, mockKHEntityDocuments, mockKHGetEntityDocumentById } = vi.hoisted(() => {
+const { mockKHConfig, mockKHEntityDocuments, mockKHGetEntityDocumentByID } = vi.hoisted(() => {
   return {
     mockKHConfig: vi.fn().mockResolvedValue(undefined),
     mockKHEntityDocuments: [] as { ID: string; Name: string; EntityID?: string; Status?: string; TypeID?: string; Entity?: string }[],
-    mockKHGetEntityDocumentById: vi.fn((id: string) => {
+    mockKHGetEntityDocumentByID: vi.fn((id: string) => {
       return mockKHEntityDocuments.find(d => d.ID === id) ?? undefined;
     }),
   };
@@ -36,7 +36,7 @@ vi.mock('@memberjunction/core-entities', () => ({
     Instance: {
       Config: mockKHConfig,
       EntityDocuments: mockKHEntityDocuments,
-      GetEntityDocumentById: mockKHGetEntityDocumentById,
+      GetEntityDocumentByID: mockKHGetEntityDocumentByID,
     },
   },
 }));

--- a/packages/AI/Vectors/Sync/src/models/EntityDocumentCache.ts
+++ b/packages/AI/Vectors/Sync/src/models/EntityDocumentCache.ts
@@ -28,7 +28,7 @@ export class EntityDocumentCache extends BaseSingleton<EntityDocumentCache> {
     }
 
     public GetDocument(EntityDocumentID: string): MJEntityDocumentEntity | null {
-        const document = KnowledgeHubMetadataEngine.Instance.GetEntityDocumentById(EntityDocumentID);
+        const document = KnowledgeHubMetadataEngine.Instance.GetEntityDocumentByID(EntityDocumentID);
         if (!document) {
             LogStatus(`EntityDocumentCache.GetDocument: Cache miss for EntityDocumentID: ${EntityDocumentID}`);
         }

--- a/packages/AI/Vectors/Sync/src/models/entityVectorSync.ts
+++ b/packages/AI/Vectors/Sync/src/models/entityVectorSync.ts
@@ -1082,7 +1082,7 @@ export class EntityVectorSyncer extends VectorBase {
       );
     }
 
-    const vectorIndex = KnowledgeHubMetadataEngine.Instance.GetVectorIndexById(entityDocument.VectorIndexID);
+    const vectorIndex = KnowledgeHubMetadataEngine.Instance.GetVectorIndexByID(entityDocument.VectorIndexID);
     if (!vectorIndex) {
       throw new Error(
         `Vector Index with ID "${entityDocument.VectorIndexID}" not found for Entity Document "${entityDocument.Name}". ` +
@@ -1353,7 +1353,7 @@ export class EntityVectorSyncer extends VectorBase {
     contextUser: UserInfo
   ): Promise<void> {
     const vectorIndexID: string = String(embeddingData.VectorIndexID);
-    const vectorIndex = KnowledgeHubMetadataEngine.Instance.GetVectorIndexById(vectorIndexID);
+    const vectorIndex = KnowledgeHubMetadataEngine.Instance.GetVectorIndexByID(vectorIndexID);
     if (!vectorIndex) {
       LogError(`Vector Index with ID ${vectorIndexID} not found in KnowledgeHubMetadataEngine cache`);
       return;

--- a/packages/Actions/ContentAutotag/src/__tests__/content-autotag.test.ts
+++ b/packages/Actions/ContentAutotag/src/__tests__/content-autotag.test.ts
@@ -93,7 +93,7 @@ vi.mock('@memberjunction/core-entities', async (importOriginal) => {
         ContentSourceTypes: [],
         ContentFileTypes: [],
         VectorIndexes: [],
-        GetVectorIndexById: vi.fn().mockReturnValue(undefined),
+        GetVectorIndexByID: vi.fn().mockReturnValue(undefined),
     };
     return {
         ...actual,

--- a/packages/Angular/Explorer/dashboards/src/AI/components/autotagging/tabs/sources-tab.component.ts
+++ b/packages/Angular/Explorer/dashboards/src/AI/components/autotagging/tabs/sources-tab.component.ts
@@ -368,7 +368,7 @@ export class ClassifySourcesTabComponent extends BaseAngularComponent {
     private resolveVectorIndexName(indexId: string): string {
         if (!indexId) return 'System default';
         const engine = KnowledgeHubMetadataEngine.Instance;
-        const idx = engine.GetVectorIndexById(indexId);
+        const idx = engine.GetVectorIndexByID(indexId);
         return idx ? idx.Name : 'Unknown';
     }
 

--- a/packages/Angular/Explorer/dashboards/src/AI/components/tags/tags-resource.component.ts
+++ b/packages/Angular/Explorer/dashboards/src/AI/components/tags/tags-resource.component.ts
@@ -3481,7 +3481,7 @@ export class TagsResourceComponent extends BaseResourceComponent implements Afte
     private resolveVectorIndexName(indexId: string): string {
         if (!indexId) return 'System default';
         const engine = KnowledgeHubMetadataEngine.Instance;
-        const idx = engine.GetVectorIndexById(indexId);
+        const idx = engine.GetVectorIndexByID(indexId);
         return idx ? idx.Name : 'Unknown';
     }
 

--- a/packages/ContentAutotagging/src/Engine/generic/AutotagBaseEngine.ts
+++ b/packages/ContentAutotagging/src/Engine/generic/AutotagBaseEngine.ts
@@ -37,7 +37,7 @@ import { KnowledgeHubMetadataEngine } from '@memberjunction/core-entities'
  * Resolved vector infrastructure for a specific (embeddingModel + vectorIndex) pair.
  * Items sharing the same pair are batched together for efficient processing.
  */
-interface ResolvedVectorInfrastructure {
+export interface ResolvedVectorInfrastructure {
     embedding: BaseEmbeddings;
     vectorDB: VectorDBBase;
     indexName: string;
@@ -59,16 +59,27 @@ interface ResolvedVectorInfrastructure {
 }
 
 /**
- * Vector-storage behavior resolved for a single content item, derived from its ContentSource
- * configuration (falling back to its ContentType defaults, then hardcoded defaults). Union types
- * are derived from the generated JSONType interface so they track the metadata definition — see
- * {@link resolveItemVectorStorageConfig}.
+ * How a chunk's vector-DB record id is derived — `'recordId'` (the chunk's own PK, purge-safe) or
+ * `'hash'` (deterministic, EntityDocument-parity). Derived from the generated JSONType interface so
+ * it tracks the metadata definition. See {@link AutotagBaseEngine.resolveChunkVectorId}.
  */
-type VectorIDStrategy = NonNullable<MJContentSourceEntity_IContentSourceConfiguration['VectorIDStrategy']>;
-type ChunkTextStorage = NonNullable<MJContentSourceEntity_IContentSourceConfiguration['ChunkTextStorage']>;
-type VectorMetadataConfig = NonNullable<MJContentSourceEntity_IContentSourceConfiguration['VectorMetadata']>;
-type VectorMetadataFieldConfig = NonNullable<VectorMetadataConfig['Fields']>[string];
-interface ResolvedVectorStorageConfig {
+export type VectorIDStrategy = NonNullable<MJContentSourceEntity_IContentSourceConfiguration['VectorIDStrategy']>;
+/**
+ * Whether an item always embeds as chunk rows (`'alwaysChunk'`) or embeds as a single item-level
+ * vector when it fits in one chunk (`'mixed'`). Derived from the generated JSONType interface.
+ */
+export type ChunkTextStorage = NonNullable<MJContentSourceEntity_IContentSourceConfiguration['ChunkTextStorage']>;
+/** Vector-metadata shaping config (field strategy, per-field rules, curated toggles). Derived from the generated JSONType interface. */
+export type VectorMetadataConfig = NonNullable<MJContentSourceEntity_IContentSourceConfiguration['VectorMetadata']>;
+/** Per-field vector-metadata rule (inclusion, truncation, StoreAs coercion). Derived from {@link VectorMetadataConfig}. */
+export type VectorMetadataFieldConfig = NonNullable<VectorMetadataConfig['Fields']>[string];
+
+/**
+ * Vector-storage behavior resolved for a single content item, derived from its ContentSource
+ * configuration (falling back to its ContentType defaults, then hardcoded defaults). Produced by
+ * {@link AutotagBaseEngine.resolveItemVectorStorageConfig}.
+ */
+export interface ResolvedVectorStorageConfig {
     vectorIDStrategy: VectorIDStrategy;
     chunkTextStorage: ChunkTextStorage;
     /** How vector metadata is shaped (undefined ⇒ the curated default set). */
@@ -92,7 +103,7 @@ const DEFAULT_CHUNK_TEXT_STORAGE: ChunkTextStorage = 'alwaysChunk';
  * the 'recordId' strategy), so it is known at metadata-build time — which lets a chunk vector carry
  * its own identity ({@link buildVectorMetadata}) even though the chunk row is written later.
  */
-interface EmbeddingChunk {
+export interface EmbeddingChunk {
     item: MJContentItemEntity;
     chunkIndex: number;
     text: string;
@@ -104,7 +115,7 @@ interface EmbeddingChunk {
  * `chunkId` becomes the row PK; `vectorRecordID` is the id the vector was actually stored under
  * (equal to chunkId under 'recordId', a hash under 'hash').
  */
-interface PersistedChunk {
+export interface PersistedChunk {
     chunkIndex: number;
     text: string;
     vectorRecordID: string;
@@ -112,7 +123,7 @@ interface PersistedChunk {
 }
 
 /** Running tally for a PurgeDeletedChunks pass. */
-interface ChunkPurgeStats {
+export interface ChunkPurgeStats {
     /** Chunks whose vector was removed from the store and row flipped to 'Deleted'. */
     purged: number;
     /** Chunks that could not be purged this run (left 'Pending', retried next run). */
@@ -122,7 +133,7 @@ interface ChunkPurgeStats {
 }
 
 /** Running tally for an EmbedPendingChunks pass. */
-interface ChunkEmbedStats {
+export interface ChunkEmbedStats {
     /** Chunks whose text was embedded, upserted, and row flipped to EmbeddingStatus='Complete'. */
     embedded: number;
     /** Chunks that could not be embedded this run (left 'Pending', retried next run). */
@@ -800,7 +811,7 @@ export class AutotagBaseEngine extends BaseEngine<AutotagBaseEngine> {
         const hasPreviousResults = Object.keys(previousResults).length > 0;
 
         // Check if this source type requires content type validation in the prompt
-        const sourceType = this.ContentSourceTypes.find(st => UUIDsEqual(st.ID, params.contentSourceTypeID));
+        const sourceType = this.khEngine.GetContentSourceTypeById(params.contentSourceTypeID);
         const sourceConfig = sourceType?.ConfigurationObject;
         const requiresContentType = sourceConfig?.RequiresContentType !== false;
 
@@ -852,7 +863,7 @@ export class AutotagBaseEngine extends BaseEngine<AutotagBaseEngine> {
         if (!contentSourceID) {
             return null;
         }
-        const source = this.khEngine.ContentSources.find(s => UUIDsEqual(s.ID, contentSourceID));
+        const source = this.khEngine.GetContentSourceById(contentSourceID);
         if (!source) {
             return null;
         }
@@ -1295,7 +1306,7 @@ export class AutotagBaseEngine extends BaseEngine<AutotagBaseEngine> {
     }
 
     public GetContentItemParams(contentTypeID: string): { modelID: string; minTags: number; maxTags: number } {
-        const contentType = this.ContentTypes.find(ct => UUIDsEqual(ct.ID, contentTypeID));
+        const contentType = this.khEngine.GetContentTypeById(contentTypeID);
         if (!contentType) {
             throw new Error(`Content Type with ID ${contentTypeID} not found in cached metadata`);
         }
@@ -1307,7 +1318,7 @@ export class AutotagBaseEngine extends BaseEngine<AutotagBaseEngine> {
     }
 
     public GetContentSourceTypeName(contentSourceTypeID: string): string {
-        const sourceType = this.ContentSourceTypes.find(st => UUIDsEqual(st.ID, contentSourceTypeID));
+        const sourceType = this.khEngine.GetContentSourceTypeById(contentSourceTypeID);
         if (!sourceType) {
             throw new Error(`Content Source Type with ID ${contentSourceTypeID} not found in cached metadata`);
         }
@@ -1315,7 +1326,7 @@ export class AutotagBaseEngine extends BaseEngine<AutotagBaseEngine> {
     }
 
     public GetContentTypeName(contentTypeID: string): string {
-        const contentType = this.ContentTypes.find(ct => UUIDsEqual(ct.ID, contentTypeID));
+        const contentType = this.khEngine.GetContentTypeById(contentTypeID);
         if (!contentType) {
             throw new Error(`Content Type with ID ${contentTypeID} not found in cached metadata`);
         }
@@ -1714,7 +1725,7 @@ export class AutotagBaseEngine extends BaseEngine<AutotagBaseEngine> {
      * each item's storage config once and shares the item-level-vs-chunk decision between the
      * vector id and the metadata so the two always agree.
      */
-    private buildVectorRecords(
+    protected buildVectorRecords(
         allChunks: EmbeddingChunk[],
         vectors: number[][],
         tagMap: Map<string, string[]>,
@@ -1727,21 +1738,46 @@ export class AutotagBaseEngine extends BaseEngine<AutotagBaseEngine> {
         // The ContentItem entity metadata drives config-selected display fields (types, MaxLength,
         // eligibility). Resolved once per batch — every chunk shares the same source entity.
         const contentItemEntity = this.ProviderToUse.EntityByName('MJ: Content Items');
-        return allChunks.map((chunk, idx) => {
-            const count = countByItem.get(chunk.item.ID) ?? 1;
-            const config = this.resolveItemVectorStorageConfig(chunk.item);
-            const itemLevel = this.isItemLevelVector(config, count);
-            const record: VectorRecord = {
-                id: this.resolveChunkVectorId(chunk, config, itemLevel),
-                values: vectors[idx],
-                metadata: this.buildVectorMetadata(chunk, itemLevel, tagMap.get(chunk.item.ID), config, contentItemEntity)
-            };
-            const directives = this.buildProviderDirectives(chunk.item, infra);
-            if (directives) {
-                record.providerTemporaryDirectives = directives;
-            }
-            return record;
-        });
+        return allChunks.map((chunk, idx) =>
+            this.buildVectorRecord(chunk, vectors[idx], countByItem.get(chunk.item.ID) ?? 1, tagMap.get(chunk.item.ID), contentItemEntity, infra)
+        );
+    }
+
+    /**
+     * Build the single {@link VectorRecord} for one embedding chunk. Resolves the item's storage
+     * config, decides item-level-vs-chunk once, and shares that decision between the vector id and
+     * the metadata so the two always agree. `protected` so subclasses can override per-record
+     * shaping (id, metadata, or provider directives) without reimplementing the batch loop in
+     * {@link buildVectorRecords}.
+     *
+     * @param chunk              The embedding unit (item slice + minted chunk id).
+     * @param vector             The embedding produced for `chunk`.
+     * @param chunkCountForItem  Total chunks produced for `chunk.item` this batch — drives the
+     *                           item-level-vs-chunk decision ({@link isItemLevelVector}).
+     * @param tags               Resolved tag names for `chunk.item`, if any.
+     * @param contentItemEntity  The 'MJ: Content Items' entity metadata, for display-field resolution.
+     * @param infra              Resolved vector infrastructure (source of provider directives).
+     */
+    protected buildVectorRecord(
+        chunk: EmbeddingChunk,
+        vector: number[],
+        chunkCountForItem: number,
+        tags: string[] | undefined,
+        contentItemEntity: EntityInfo | undefined,
+        infra: ResolvedVectorInfrastructure
+    ): VectorRecord {
+        const config = this.resolveItemVectorStorageConfig(chunk.item);
+        const itemLevel = this.isItemLevelVector(config, chunkCountForItem);
+        const record: VectorRecord = {
+            id: this.resolveChunkVectorId(chunk, config, itemLevel),
+            values: vector,
+            metadata: this.buildVectorMetadata(chunk, itemLevel, tags, config, contentItemEntity)
+        };
+        const directives = this.buildProviderDirectives(chunk.item, infra);
+        if (directives) {
+            record.providerTemporaryDirectives = directives;
+        }
+        return record;
     }
 
     /**
@@ -1753,7 +1789,7 @@ export class AutotagBaseEngine extends BaseEngine<AutotagBaseEngine> {
      * Namespace is resolved from the parent ContentItem (org-level), the same source for a chunk's
      * vector as for an item-level vector.
      */
-    private buildProviderDirectives(
+    protected buildProviderDirectives(
         item: MJContentItemEntity,
         infra: ResolvedVectorInfrastructure
     ): Record<string, unknown> | undefined {
@@ -1772,7 +1808,7 @@ export class AutotagBaseEngine extends BaseEngine<AutotagBaseEngine> {
      *   case uses a per-(item, chunkIndex) hash. Deterministic ⇒ unsafe with re-chunk + purge
      *   (documented on the config), but preserves 5.49 EntityDocument parity when opted into.
      */
-    private resolveChunkVectorId(
+    protected resolveChunkVectorId(
         chunk: EmbeddingChunk,
         config: ResolvedVectorStorageConfig,
         isItemLevel: boolean
@@ -2581,11 +2617,11 @@ export class AutotagBaseEngine extends BaseEngine<AutotagBaseEngine> {
      * ContentSource override -> ContentType default -> hardcoded default. Reads the strongly-typed
      * ConfigurationObject accessors emitted by CodeGen for each entity's Configuration JSONType.
      */
-    private resolveItemVectorStorageConfig(item: MJContentItemEntity): ResolvedVectorStorageConfig {
-        const source = this.khEngine.ContentSources.find(s => UUIDsEqual(s.ID, item.ContentSourceID));
+    protected resolveItemVectorStorageConfig(item: MJContentItemEntity): ResolvedVectorStorageConfig {
+        const source = this.khEngine.GetContentSourceById(item.ContentSourceID);
         const srcCfg = source?.ConfigurationObject;
 
-        const contentType = this.ContentTypes.find(t => UUIDsEqual(t.ID, item.ContentTypeID));
+        const contentType = this.khEngine.GetContentTypeById(item.ContentTypeID);
         const typeCfg = contentType?.ConfigurationObject;
 
         return {
@@ -2602,7 +2638,7 @@ export class AutotagBaseEngine extends BaseEngine<AutotagBaseEngine> {
      * always writes a chunk row (item-level id stays null). buildVectorRecords and
      * persistVectorReferences share this predicate so the vector id and its persistence agree.
      */
-    private isItemLevelVector(config: ResolvedVectorStorageConfig, chunkCount: number): boolean {
+    protected isItemLevelVector(config: ResolvedVectorStorageConfig, chunkCount: number): boolean {
         return config.chunkTextStorage === 'mixed' && chunkCount === 1;
     }
 
@@ -2668,7 +2704,7 @@ export class AutotagBaseEngine extends BaseEngine<AutotagBaseEngine> {
      * `Entity` is kept so content search results stay labeled (record id is recovered from the
      * vector id under the default 'recordId' strategy).
      */
-    private buildVectorMetadata(
+    protected buildVectorMetadata(
         chunk: EmbeddingChunk,
         isItemLevel: boolean,
         tags: string[] | undefined,

--- a/packages/ContentAutotagging/src/Engine/generic/AutotagBaseEngine.ts
+++ b/packages/ContentAutotagging/src/Engine/generic/AutotagBaseEngine.ts
@@ -61,7 +61,7 @@ export interface ResolvedVectorInfrastructure {
 /**
  * How a chunk's vector-DB record id is derived — `'recordId'` (the chunk's own PK, purge-safe) or
  * `'hash'` (deterministic, EntityDocument-parity). Derived from the generated JSONType interface so
- * it tracks the metadata definition. See {@link AutotagBaseEngine.resolveChunkVectorId}.
+ * it tracks the metadata definition. See {@link AutotagBaseEngine.resolveChunkVectorID}.
  */
 export type VectorIDStrategy = NonNullable<MJContentSourceEntity_IContentSourceConfiguration['VectorIDStrategy']>;
 /**
@@ -99,7 +99,7 @@ const DEFAULT_CHUNK_TEXT_STORAGE: ChunkTextStorage = 'alwaysChunk';
 
 /**
  * One embedding unit produced from a ContentItem: a slice of its text plus the id minted for the
- * chunk up front. `chunkId` becomes BOTH the ContentItemChunk row's PK and its vector-DB id (under
+ * chunk up front. `chunkID` becomes BOTH the ContentItemChunk row's PK and its vector-DB id (under
  * the 'recordId' strategy), so it is known at metadata-build time — which lets a chunk vector carry
  * its own identity ({@link buildVectorMetadata}) even though the chunk row is written later.
  */
@@ -107,19 +107,19 @@ export interface EmbeddingChunk {
     item: MJContentItemEntity;
     chunkIndex: number;
     text: string;
-    chunkId: string;
+    chunkID: string;
 }
 
 /**
  * A chunk whose vector has been upserted and is ready to be written as a ContentItemChunk row.
- * `chunkId` becomes the row PK; `vectorRecordID` is the id the vector was actually stored under
- * (equal to chunkId under 'recordId', a hash under 'hash').
+ * `chunkID` becomes the row PK; `vectorRecordID` is the id the vector was actually stored under
+ * (equal to chunkID under 'recordId', a hash under 'hash').
  */
 export interface PersistedChunk {
     chunkIndex: number;
     text: string;
     vectorRecordID: string;
-    chunkId: string;
+    chunkID: string;
 }
 
 /** Running tally for a PurgeDeletedChunks pass. */
@@ -811,7 +811,7 @@ export class AutotagBaseEngine extends BaseEngine<AutotagBaseEngine> {
         const hasPreviousResults = Object.keys(previousResults).length > 0;
 
         // Check if this source type requires content type validation in the prompt
-        const sourceType = this.khEngine.GetContentSourceTypeById(params.contentSourceTypeID);
+        const sourceType = this.khEngine.GetContentSourceTypeByID(params.contentSourceTypeID);
         const sourceConfig = sourceType?.ConfigurationObject;
         const requiresContentType = sourceConfig?.RequiresContentType !== false;
 
@@ -863,7 +863,7 @@ export class AutotagBaseEngine extends BaseEngine<AutotagBaseEngine> {
         if (!contentSourceID) {
             return null;
         }
-        const source = this.khEngine.GetContentSourceById(contentSourceID);
+        const source = this.khEngine.GetContentSourceByID(contentSourceID);
         if (!source) {
             return null;
         }
@@ -1306,7 +1306,7 @@ export class AutotagBaseEngine extends BaseEngine<AutotagBaseEngine> {
     }
 
     public GetContentItemParams(contentTypeID: string): { modelID: string; minTags: number; maxTags: number } {
-        const contentType = this.khEngine.GetContentTypeById(contentTypeID);
+        const contentType = this.khEngine.GetContentTypeByID(contentTypeID);
         if (!contentType) {
             throw new Error(`Content Type with ID ${contentTypeID} not found in cached metadata`);
         }
@@ -1318,7 +1318,7 @@ export class AutotagBaseEngine extends BaseEngine<AutotagBaseEngine> {
     }
 
     public GetContentSourceTypeName(contentSourceTypeID: string): string {
-        const sourceType = this.khEngine.GetContentSourceTypeById(contentSourceTypeID);
+        const sourceType = this.khEngine.GetContentSourceTypeByID(contentSourceTypeID);
         if (!sourceType) {
             throw new Error(`Content Source Type with ID ${contentSourceTypeID} not found in cached metadata`);
         }
@@ -1326,7 +1326,7 @@ export class AutotagBaseEngine extends BaseEngine<AutotagBaseEngine> {
     }
 
     public GetContentTypeName(contentTypeID: string): string {
-        const contentType = this.khEngine.GetContentTypeById(contentTypeID);
+        const contentType = this.khEngine.GetContentTypeByID(contentTypeID);
         if (!contentType) {
             throw new Error(`Content Type with ID ${contentTypeID} not found in cached metadata`);
         }
@@ -1714,7 +1714,7 @@ export class AutotagBaseEngine extends BaseEngine<AutotagBaseEngine> {
                 // PK and (under the 'recordId' strategy) its vector-DB id, so a re-chunk produces
                 // NEW rows with NEW ids — old (soft-deleted) and new chunks never collide on a
                 // vector id, which is what makes the purge safe.
-                allChunks.push({ item, chunkIndex: ci, text: chunks[ci], chunkId: uuidv4() });
+                allChunks.push({ item, chunkIndex: ci, text: chunks[ci], chunkID: uuidv4() });
             }
         }
         return allChunks;
@@ -1769,7 +1769,7 @@ export class AutotagBaseEngine extends BaseEngine<AutotagBaseEngine> {
         const config = this.resolveItemVectorStorageConfig(chunk.item);
         const itemLevel = this.isItemLevelVector(config, chunkCountForItem);
         const record: VectorRecord = {
-            id: this.resolveChunkVectorId(chunk, config, itemLevel),
+            id: this.resolveChunkVectorID(chunk, config, itemLevel),
             values: vector,
             metadata: this.buildVectorMetadata(chunk, itemLevel, tags, config, contentItemEntity)
         };
@@ -1801,24 +1801,24 @@ export class AutotagBaseEngine extends BaseEngine<AutotagBaseEngine> {
 
     /**
      * Choose the vector-DB record id for one chunk based on the item's resolved config.
-     * - 'recordId' (default): the chunk's own id (chunkId), which is also the ContentItemChunk PK.
+     * - 'recordId' (default): the chunk's own id (chunkID), which is also the ContentItemChunk PK.
      *   Purge-safe — a re-chunk mints fresh ids, so a superseded chunk and its replacement never
      *   collide.
      * - 'hash': deterministic. An item-level single vector uses the bare item hash; every other
      *   case uses a per-(item, chunkIndex) hash. Deterministic ⇒ unsafe with re-chunk + purge
      *   (documented on the config), but preserves 5.49 EntityDocument parity when opted into.
      */
-    protected resolveChunkVectorId(
+    protected resolveChunkVectorID(
         chunk: EmbeddingChunk,
         config: ResolvedVectorStorageConfig,
         isItemLevel: boolean
     ): string {
         if (config.vectorIDStrategy === 'hash') {
             return isItemLevel
-                ? this.contentItemVectorId(chunk.item.ID)
-                : this.contentItemChunkVectorId(chunk.item.ID, chunk.chunkIndex);
+                ? this.contentItemVectorID(chunk.item.ID)
+                : this.contentItemChunkVectorID(chunk.item.ID, chunk.chunkIndex);
         }
-        return chunk.chunkId;
+        return chunk.chunkID;
     }
 
     /**
@@ -1848,7 +1848,7 @@ export class AutotagBaseEngine extends BaseEngine<AutotagBaseEngine> {
             const c = allChunks[idx];
             const key = NormalizeUUID(c.item.ID);
             const list = byItem.get(key) ?? [];
-            list.push({ chunkIndex: c.chunkIndex, text: c.text, vectorRecordID: String(records[idx].id), chunkId: c.chunkId });
+            list.push({ chunkIndex: c.chunkIndex, text: c.text, vectorRecordID: String(records[idx].id), chunkID: c.chunkID });
             byItem.set(key, list);
         }
 
@@ -1927,12 +1927,12 @@ export class AutotagBaseEngine extends BaseEngine<AutotagBaseEngine> {
         for (const chunk of chunks) {
             const row = await md.GetEntityObject<MJContentItemChunkEntity>('MJ: Content Item Chunks', contextUser);
             row.NewRecord();
-            // Pin the row PK to the id minted up front (chunkId) so the chunk's identity is stable
+            // Pin the row PK to the id minted up front (chunkID) so the chunk's identity is stable
             // and known before it is written — it is the same value put in the vector metadata's
             // RecordID (Chunk-Identity Contract), so a search hit resolves to this row by id.
             // NewRecord() applies an explicit PK last, so this overrides the auto-generated uuid.
-            row.ID = chunk.chunkId;
-            // VectorRecordID is the id the vector was actually upserted under (equal to chunkId
+            row.ID = chunk.chunkID;
+            // VectorRecordID is the id the vector was actually upserted under (equal to chunkID
             // under 'recordId', a hash under 'hash'). A re-chunk mints fresh ids for its new rows,
             // so a superseded (soft-deleted) chunk and its replacement never share one — which is
             // what makes PurgeDeletedChunks safe.
@@ -2258,7 +2258,7 @@ export class AutotagBaseEngine extends BaseEngine<AutotagBaseEngine> {
     }
 
     /**
-     * Pair each persisted chunk with its parent item as an {@link EmbeddingChunk} (chunkId = the
+     * Pair each persisted chunk with its parent item as an {@link EmbeddingChunk} (chunkID = the
      * chunk's existing PK, so the vector id + metadata identity match the live write path). Chunks
      * with empty text or a missing parent are counted as skipped and dropped.
      */
@@ -2275,7 +2275,7 @@ export class AutotagBaseEngine extends BaseEngine<AutotagBaseEngine> {
                 stats.skipped++;
                 continue;
             }
-            embeddable.push({ row, chunk: { item, chunkIndex: row.Sequence, text, chunkId: row.ID } });
+            embeddable.push({ row, chunk: { item, chunkIndex: row.Sequence, text, chunkID: row.ID } });
         }
         return embeddable;
     }
@@ -2309,7 +2309,7 @@ export class AutotagBaseEngine extends BaseEngine<AutotagBaseEngine> {
         const records: VectorRecord[] = embeddable.map((e, idx) => {
             const config = this.resolveItemVectorStorageConfig(e.chunk.item);
             const record: VectorRecord = {
-                id: this.resolveChunkVectorId(e.chunk, config, false),
+                id: this.resolveChunkVectorID(e.chunk, config, false),
                 values: runResult.Vectors[idx],
                 metadata: this.buildVectorMetadata(e.chunk, false, tagMap.get(e.chunk.item.ID), config, contentItemEntity),
             };
@@ -2489,7 +2489,7 @@ export class AutotagBaseEngine extends BaseEngine<AutotagBaseEngine> {
         vectorIndexID: string,
         _contextUser: UserInfo
     ): Promise<ResolvedVectorInfrastructure> {
-        const vectorIndex = this.khEngine.GetVectorIndexById(vectorIndexID);
+        const vectorIndex = this.khEngine.GetVectorIndexByID(vectorIndexID);
         if (!vectorIndex) {
             throw new Error(`Vector index ${vectorIndexID} not found in KnowledgeHubMetadataEngine cache`);
         }
@@ -2598,7 +2598,7 @@ export class AutotagBaseEngine extends BaseEngine<AutotagBaseEngine> {
     }
 
     /** SHA-1 deterministic vector ID for a content item */
-    private contentItemVectorId(contentItemId: string): string {
+    private contentItemVectorID(contentItemId: string): string {
         return crypto.createHash('sha1').update(`content-item_${contentItemId}`).digest('hex');
     }
 
@@ -2608,7 +2608,7 @@ export class AutotagBaseEngine extends BaseEngine<AutotagBaseEngine> {
      * (contentItemId, chunkIndex), which is exactly what makes 'hash' unsafe with re-chunk +
      * purge — a re-chunk that produces the same index reuses the id (documented on the config).
      */
-    private contentItemChunkVectorId(contentItemId: string, chunkIndex: number): string {
+    private contentItemChunkVectorID(contentItemId: string, chunkIndex: number): string {
         return crypto.createHash('sha1').update(`content-item-chunk_${contentItemId}_${chunkIndex}`).digest('hex');
     }
 
@@ -2618,10 +2618,10 @@ export class AutotagBaseEngine extends BaseEngine<AutotagBaseEngine> {
      * ConfigurationObject accessors emitted by CodeGen for each entity's Configuration JSONType.
      */
     protected resolveItemVectorStorageConfig(item: MJContentItemEntity): ResolvedVectorStorageConfig {
-        const source = this.khEngine.GetContentSourceById(item.ContentSourceID);
+        const source = this.khEngine.GetContentSourceByID(item.ContentSourceID);
         const srcCfg = source?.ConfigurationObject;
 
-        const contentType = this.khEngine.GetContentTypeById(item.ContentTypeID);
+        const contentType = this.khEngine.GetContentTypeByID(item.ContentTypeID);
         const typeCfg = contentType?.ConfigurationObject;
 
         return {
@@ -2756,7 +2756,7 @@ export class AutotagBaseEngine extends BaseEngine<AutotagBaseEngine> {
         if (isItemLevel) {
             meta['RecordID'] = chunk.item.ID;
         } else {
-            meta['RecordID'] = chunk.chunkId;
+            meta['RecordID'] = chunk.chunkID;
             meta['ContentItemID'] = chunk.item.ID;
             meta['Sequence'] = chunk.chunkIndex;
         }

--- a/packages/ContentAutotagging/src/__tests__/AutotagBaseEngine.test.ts
+++ b/packages/ContentAutotagging/src/__tests__/AutotagBaseEngine.test.ts
@@ -237,18 +237,18 @@ vi.mock('@memberjunction/core-entities', async (importOriginal) => {
     ContentSourceTypes: [],
     ContentFileTypes: [],
     VectorIndexes: mockVectorIndexes,
-    GetVectorIndexById: vi.fn().mockImplementation((id: string) =>
+    GetVectorIndexByID: vi.fn().mockImplementation((id: string) =>
       mockVectorIndexes.find(v => v.ID === id)
     ),
     // Mirror the real KnowledgeHubMetadataEngine O(1) by-id helpers (which the engine now calls
     // instead of `.find` at the call sites). Read the live arrays so tests that push after setup work.
-    GetContentSourceById: vi.fn().mockImplementation((id: string) =>
+    GetContentSourceByID: vi.fn().mockImplementation((id: string) =>
       mockKHInstance.ContentSources.find((s: { ID: string }) => s.ID === id)
     ),
-    GetContentTypeById: vi.fn().mockImplementation((id: string) =>
+    GetContentTypeByID: vi.fn().mockImplementation((id: string) =>
       mockKHInstance.ContentTypes.find((t: { ID: string }) => t.ID === id)
     ),
-    GetContentSourceTypeById: vi.fn().mockImplementation((id: string) =>
+    GetContentSourceTypeByID: vi.fn().mockImplementation((id: string) =>
       mockKHInstance.ContentSourceTypes.find((t: { ID: string }) => t.ID === id)
     ),
   };

--- a/packages/ContentAutotagging/src/__tests__/AutotagBaseEngine.test.ts
+++ b/packages/ContentAutotagging/src/__tests__/AutotagBaseEngine.test.ts
@@ -240,6 +240,17 @@ vi.mock('@memberjunction/core-entities', async (importOriginal) => {
     GetVectorIndexById: vi.fn().mockImplementation((id: string) =>
       mockVectorIndexes.find(v => v.ID === id)
     ),
+    // Mirror the real KnowledgeHubMetadataEngine O(1) by-id helpers (which the engine now calls
+    // instead of `.find` at the call sites). Read the live arrays so tests that push after setup work.
+    GetContentSourceById: vi.fn().mockImplementation((id: string) =>
+      mockKHInstance.ContentSources.find((s: { ID: string }) => s.ID === id)
+    ),
+    GetContentTypeById: vi.fn().mockImplementation((id: string) =>
+      mockKHInstance.ContentTypes.find((t: { ID: string }) => t.ID === id)
+    ),
+    GetContentSourceTypeById: vi.fn().mockImplementation((id: string) =>
+      mockKHInstance.ContentSourceTypes.find((t: { ID: string }) => t.ID === id)
+    ),
   };
   return {
     ...actual,

--- a/packages/MJCoreEntities/src/__tests__/knowledgeHubMetadata.test.ts
+++ b/packages/MJCoreEntities/src/__tests__/knowledgeHubMetadata.test.ts
@@ -17,6 +17,12 @@ vi.mock('@memberjunction/global', async (importOriginal) => {
 vi.mock('@memberjunction/core', () => {
     return {
         BaseEngine: class MockBaseEngine {
+            // Minimal stand-in for BaseEngine.DataChange$ so the engine constructor's
+            // invalidation subscription is satisfied. Tests reset the index cache directly
+            // in beforeEach (they poke private arrays, bypassing the event path).
+            get DataChange$() {
+                return { subscribe: () => ({ unsubscribe: () => { /* no-op */ } }) };
+            }
             static getInstance<T>(): T {
                 const ctor = this as unknown as { _testInstance?: T; new (): T };
                 if (!ctor._testInstance) {
@@ -82,6 +88,20 @@ function createMockVectorIndex(overrides: Partial<MockVectorIndex> = {}): MockVe
     };
 }
 
+interface MockContentSource { ID: string; Name: string; }
+interface MockContentType { ID: string; Name: string; }
+interface MockContentSourceType { ID: string; Name: string; }
+
+function createMockContentSource(overrides: Partial<MockContentSource> = {}): MockContentSource {
+    return { ID: 'CS-0001-0000-0000-000000000001', Name: 'default-source', ...overrides };
+}
+function createMockContentType(overrides: Partial<MockContentType> = {}): MockContentType {
+    return { ID: 'CT-0001-0000-0000-000000000001', Name: 'default-type', ...overrides };
+}
+function createMockContentSourceType(overrides: Partial<MockContentSourceType> = {}): MockContentSourceType {
+    return { ID: 'CST-0001-0000-0000-000000000001', Name: 'default-source-type', ...overrides };
+}
+
 
 // ---------------------------------------------------------------------------
 // Tests
@@ -105,6 +125,19 @@ describe('KnowledgeHubMetadataEngine', () => {
             createMockVectorIndex({ ID: 'VI-AAA', Name: 'contacts-idx' }),
             createMockVectorIndex({ ID: 'VI-BBB', Name: 'accounts-idx' }),
         ];
+        (engine as unknown as Record<string, MockContentSource[]>)['_contentSources'] = [
+            createMockContentSource({ ID: 'CS-AAA', Name: 'RSS Feed' }),
+            createMockContentSource({ ID: 'CS-BBB', Name: 'Website' }),
+        ];
+        (engine as unknown as Record<string, MockContentType[]>)['_contentTypes'] = [
+            createMockContentType({ ID: 'CT-AAA', Name: 'Article' }),
+        ];
+        (engine as unknown as Record<string, MockContentSourceType[]>)['_contentSourceTypes'] = [
+            createMockContentSourceType({ ID: 'CST-AAA', Name: 'RSS' }),
+        ];
+        // Tests inject data directly into the private arrays, bypassing the engine's event-driven
+        // invalidation, so reset the by-id index cache too (mirrors clearing the arrays above).
+        (engine as unknown as { _idIndexes: Map<unknown, unknown> })._idIndexes.clear();
     });
 
     // ================================================================
@@ -256,6 +289,52 @@ describe('KnowledgeHubMetadataEngine', () => {
         it('should return undefined for empty string', () => {
             const result = engine.GetVectorIndexById('');
             expect(result).toBeUndefined();
+        });
+    });
+
+    // ================================================================
+    // O(1) by-id finders (content sources / types / source types)
+    // ================================================================
+
+    describe('GetContentSourceById', () => {
+        it('should find a content source by ID', () => {
+            expect(engine.GetContentSourceById('CS-AAA')?.Name).toBe('RSS Feed');
+        });
+        it('should be case-insensitive', () => {
+            expect(engine.GetContentSourceById('cs-bbb')?.Name).toBe('Website');
+        });
+        it('should return undefined for non-existent ID', () => {
+            expect(engine.GetContentSourceById('CS-ZZZ')).toBeUndefined();
+        });
+        it('should return undefined for empty string', () => {
+            expect(engine.GetContentSourceById('')).toBeUndefined();
+        });
+        it('should reflect a swapped-out array (index rebuilds on next call after cache reset)', () => {
+            expect(engine.GetContentSourceById('CS-AAA')?.Name).toBe('RSS Feed'); // builds index
+            (engine as unknown as Record<string, MockContentSource[]>)['_contentSources'] = [
+                createMockContentSource({ ID: 'CS-NEW', Name: 'Fresh Source' }),
+            ];
+            (engine as unknown as { _idIndexes: Map<unknown, unknown> })._idIndexes.clear();
+            expect(engine.GetContentSourceById('CS-AAA')).toBeUndefined();
+            expect(engine.GetContentSourceById('CS-NEW')?.Name).toBe('Fresh Source');
+        });
+    });
+
+    describe('GetContentTypeById', () => {
+        it('should find a content type by ID (case-insensitive)', () => {
+            expect(engine.GetContentTypeById('ct-aaa')?.Name).toBe('Article');
+        });
+        it('should return undefined for non-existent ID', () => {
+            expect(engine.GetContentTypeById('CT-ZZZ')).toBeUndefined();
+        });
+    });
+
+    describe('GetContentSourceTypeById', () => {
+        it('should find a content source type by ID (case-insensitive)', () => {
+            expect(engine.GetContentSourceTypeById('cst-aaa')?.Name).toBe('RSS');
+        });
+        it('should return undefined for non-existent ID', () => {
+            expect(engine.GetContentSourceTypeById('CST-ZZZ')).toBeUndefined();
         });
     });
 

--- a/packages/MJCoreEntities/src/__tests__/knowledgeHubMetadata.test.ts
+++ b/packages/MJCoreEntities/src/__tests__/knowledgeHubMetadata.test.ts
@@ -237,57 +237,57 @@ describe('KnowledgeHubMetadataEngine', () => {
     });
 
     // ================================================================
-    // GetEntityDocumentById
+    // GetEntityDocumentByID
     // ================================================================
 
-    describe('GetEntityDocumentById', () => {
+    describe('GetEntityDocumentByID', () => {
         it('should find a document by exact ID', () => {
-            const result = engine.GetEntityDocumentById('ED-AAA');
+            const result = engine.GetEntityDocumentByID('ED-AAA');
             expect(result).toBeDefined();
             expect(result!.Entity).toBe('Contacts');
         });
 
         it('should find by ID with case-insensitive UUID comparison', () => {
             // UUIDsEqual mock compares lowercase
-            const result = engine.GetEntityDocumentById('ed-aaa');
+            const result = engine.GetEntityDocumentByID('ed-aaa');
             expect(result).toBeDefined();
             expect(result!.Entity).toBe('Contacts');
         });
 
         it('should return undefined for non-existent ID', () => {
-            const result = engine.GetEntityDocumentById('non-existent-id');
+            const result = engine.GetEntityDocumentByID('non-existent-id');
             expect(result).toBeUndefined();
         });
 
         it('should return undefined for empty string', () => {
-            const result = engine.GetEntityDocumentById('');
+            const result = engine.GetEntityDocumentByID('');
             expect(result).toBeUndefined();
         });
     });
 
     // ================================================================
-    // GetVectorIndexById
+    // GetVectorIndexByID
     // ================================================================
 
-    describe('GetVectorIndexById', () => {
+    describe('GetVectorIndexByID', () => {
         it('should find a vector index by ID', () => {
-            const result = engine.GetVectorIndexById('VI-AAA');
+            const result = engine.GetVectorIndexByID('VI-AAA');
             expect(result).toBeDefined();
             expect(result!.Name).toBe('contacts-idx');
         });
 
         it('should be case-insensitive via UUIDsEqual', () => {
-            const result = engine.GetVectorIndexById('vi-aaa');
+            const result = engine.GetVectorIndexByID('vi-aaa');
             expect(result).toBeDefined();
         });
 
         it('should return undefined for non-existent ID', () => {
-            const result = engine.GetVectorIndexById('no-such-id');
+            const result = engine.GetVectorIndexByID('no-such-id');
             expect(result).toBeUndefined();
         });
 
         it('should return undefined for empty string', () => {
-            const result = engine.GetVectorIndexById('');
+            const result = engine.GetVectorIndexByID('');
             expect(result).toBeUndefined();
         });
     });
@@ -296,45 +296,45 @@ describe('KnowledgeHubMetadataEngine', () => {
     // O(1) by-id finders (content sources / types / source types)
     // ================================================================
 
-    describe('GetContentSourceById', () => {
+    describe('GetContentSourceByID', () => {
         it('should find a content source by ID', () => {
-            expect(engine.GetContentSourceById('CS-AAA')?.Name).toBe('RSS Feed');
+            expect(engine.GetContentSourceByID('CS-AAA')?.Name).toBe('RSS Feed');
         });
         it('should be case-insensitive', () => {
-            expect(engine.GetContentSourceById('cs-bbb')?.Name).toBe('Website');
+            expect(engine.GetContentSourceByID('cs-bbb')?.Name).toBe('Website');
         });
         it('should return undefined for non-existent ID', () => {
-            expect(engine.GetContentSourceById('CS-ZZZ')).toBeUndefined();
+            expect(engine.GetContentSourceByID('CS-ZZZ')).toBeUndefined();
         });
         it('should return undefined for empty string', () => {
-            expect(engine.GetContentSourceById('')).toBeUndefined();
+            expect(engine.GetContentSourceByID('')).toBeUndefined();
         });
         it('should reflect a swapped-out array (index rebuilds on next call after cache reset)', () => {
-            expect(engine.GetContentSourceById('CS-AAA')?.Name).toBe('RSS Feed'); // builds index
+            expect(engine.GetContentSourceByID('CS-AAA')?.Name).toBe('RSS Feed'); // builds index
             (engine as unknown as Record<string, MockContentSource[]>)['_contentSources'] = [
                 createMockContentSource({ ID: 'CS-NEW', Name: 'Fresh Source' }),
             ];
             (engine as unknown as { _idIndexes: Map<unknown, unknown> })._idIndexes.clear();
-            expect(engine.GetContentSourceById('CS-AAA')).toBeUndefined();
-            expect(engine.GetContentSourceById('CS-NEW')?.Name).toBe('Fresh Source');
+            expect(engine.GetContentSourceByID('CS-AAA')).toBeUndefined();
+            expect(engine.GetContentSourceByID('CS-NEW')?.Name).toBe('Fresh Source');
         });
     });
 
-    describe('GetContentTypeById', () => {
+    describe('GetContentTypeByID', () => {
         it('should find a content type by ID (case-insensitive)', () => {
-            expect(engine.GetContentTypeById('ct-aaa')?.Name).toBe('Article');
+            expect(engine.GetContentTypeByID('ct-aaa')?.Name).toBe('Article');
         });
         it('should return undefined for non-existent ID', () => {
-            expect(engine.GetContentTypeById('CT-ZZZ')).toBeUndefined();
+            expect(engine.GetContentTypeByID('CT-ZZZ')).toBeUndefined();
         });
     });
 
-    describe('GetContentSourceTypeById', () => {
+    describe('GetContentSourceTypeByID', () => {
         it('should find a content source type by ID (case-insensitive)', () => {
-            expect(engine.GetContentSourceTypeById('cst-aaa')?.Name).toBe('RSS');
+            expect(engine.GetContentSourceTypeByID('cst-aaa')?.Name).toBe('RSS');
         });
         it('should return undefined for non-existent ID', () => {
-            expect(engine.GetContentSourceTypeById('CST-ZZZ')).toBeUndefined();
+            expect(engine.GetContentSourceTypeByID('CST-ZZZ')).toBeUndefined();
         });
     });
 

--- a/packages/MJCoreEntities/src/engines/knowledgeHubMetadata.ts
+++ b/packages/MJCoreEntities/src/engines/knowledgeHubMetadata.ts
@@ -1,5 +1,5 @@
-import { BaseEngine, BaseEnginePropertyConfig, IMetadataProvider, UserInfo } from "@memberjunction/core";
-import { UUIDsEqual } from "@memberjunction/global";
+import { BaseEngine, BaseEnginePropertyConfig, BaseEntity, IMetadataProvider, UserInfo } from "@memberjunction/core";
+import { NormalizeUUID } from "@memberjunction/global";
 import {
     MJEntityDocumentEntity,
     MJVectorIndexEntity,
@@ -25,12 +25,27 @@ export class KnowledgeHubMetadataEngine extends BaseEngine<KnowledgeHubMetadataE
         return super.getInstance<KnowledgeHubMetadataEngine>();
     }
 
+    protected constructor() {
+        super();
+        // Any data change (add/update/delete or full refresh, on any cached array) invalidates the
+        // by-id indexes wholesale — the cheapest correct strategy, since NotifyDataChange fires on
+        // every BaseEngine mutation path. Lazily rebuilt on the next lookup.
+        this.DataChange$.subscribe(() => this._idIndexes.clear());
+    }
+
     private _entityDocuments: MJEntityDocumentEntity[] = [];
     private _vectorIndexes: MJVectorIndexEntity[] = [];
     private _contentSources: MJContentSourceEntity[] = [];
     private _contentTypes: MJContentTypeEntity[] = [];
     private _contentSourceTypes: MJContentSourceTypeEntity[] = [];
     private _contentFileTypes: MJContentFileTypeEntity[] = [];
+
+    /**
+     * Lazily-built `NormalizeUUID(ID) → row` indexes, one per cached array (keyed by array name),
+     * powering the O(1) `Get…ById` helpers. Cleared wholesale on any {@link DataChange$} emission
+     * (see the constructor) so entries never go stale as the underlying caches mutate.
+     */
+    private _idIndexes = new Map<string, Map<string, BaseEntity>>();
 
     public async Config(forceRefresh?: boolean, contextUser?: UserInfo, provider?: IMetadataProvider) {
         const c: Partial<BaseEnginePropertyConfig>[] = [
@@ -117,10 +132,54 @@ export class KnowledgeHubMetadataEngine extends BaseEngine<KnowledgeHubMetadataE
         return this._entityDocuments.filter(d => d.Status === 'Active');
     }
 
-    /** Find an entity document by ID (case-insensitive UUID comparison) */
+    /**
+     * Returns a cached `NormalizeUUID(ID) → row` index for one of the engine's cached arrays,
+     * building it on first use. The whole index cache is cleared on any {@link DataChange$}
+     * emission, so a returned index is always consistent with the current cache contents.
+     * O(N) to build once, then O(1) per lookup.
+     */
+    private getIdIndex<T extends BaseEntity>(key: string, rows: T[], idOf: (row: T) => string): Map<string, T> {
+        // Downcast is safe by construction: each `key` is only ever paired with one row type.
+        let index = this._idIndexes.get(key) as Map<string, T> | undefined;
+        if (!index) {
+            index = new Map<string, T>();
+            for (const row of rows) {
+                const id = idOf(row);
+                if (id) index.set(NormalizeUUID(id), row);
+            }
+            this._idIndexes.set(key, index);
+        }
+        return index;
+    }
+
+    /** Find an entity document by ID (case-insensitive UUID comparison). O(1) after first hit. */
     public GetEntityDocumentById(id: string): MJEntityDocumentEntity | undefined {
         if (!id) return undefined;
-        return this._entityDocuments.find(d => UUIDsEqual(d.ID, id));
+        return this.getIdIndex('entityDocuments', this._entityDocuments, d => d.ID).get(NormalizeUUID(id));
+    }
+
+    /** Find a content source by ID (case-insensitive UUID comparison). O(1) after first hit. */
+    public GetContentSourceById(id: string): MJContentSourceEntity | undefined {
+        if (!id) return undefined;
+        return this.getIdIndex('contentSources', this._contentSources, s => s.ID).get(NormalizeUUID(id));
+    }
+
+    /** Find a content type by ID (case-insensitive UUID comparison). O(1) after first hit. */
+    public GetContentTypeById(id: string): MJContentTypeEntity | undefined {
+        if (!id) return undefined;
+        return this.getIdIndex('contentTypes', this._contentTypes, t => t.ID).get(NormalizeUUID(id));
+    }
+
+    /** Find a content source type by ID (case-insensitive UUID comparison). O(1) after first hit. */
+    public GetContentSourceTypeById(id: string): MJContentSourceTypeEntity | undefined {
+        if (!id) return undefined;
+        return this.getIdIndex('contentSourceTypes', this._contentSourceTypes, t => t.ID).get(NormalizeUUID(id));
+    }
+
+    /** Find a content file type by ID (case-insensitive UUID comparison). O(1) after first hit. */
+    public GetContentFileTypeById(id: string): MJContentFileTypeEntity | undefined {
+        if (!id) return undefined;
+        return this.getIdIndex('contentFileTypes', this._contentFileTypes, t => t.ID).get(NormalizeUUID(id));
     }
 
     /** Find all entity documents for a given entity name (case-insensitive) */
@@ -130,10 +189,10 @@ export class KnowledgeHubMetadataEngine extends BaseEngine<KnowledgeHubMetadataE
         return this._entityDocuments.filter(d => d.Entity?.trim().toLowerCase() === lower);
     }
 
-    /** Find a vector index by ID (case-insensitive UUID comparison) */
+    /** Find a vector index by ID (case-insensitive UUID comparison). O(1) after first hit. */
     public GetVectorIndexById(id: string): MJVectorIndexEntity | undefined {
         if (!id) return undefined;
-        return this._vectorIndexes.find(v => UUIDsEqual(v.ID, id));
+        return this.getIdIndex('vectorIndexes', this._vectorIndexes, v => v.ID).get(NormalizeUUID(id));
     }
 
     /**

--- a/packages/MJCoreEntities/src/engines/knowledgeHubMetadata.ts
+++ b/packages/MJCoreEntities/src/engines/knowledgeHubMetadata.ts
@@ -42,7 +42,7 @@ export class KnowledgeHubMetadataEngine extends BaseEngine<KnowledgeHubMetadataE
 
     /**
      * Lazily-built `NormalizeUUID(ID) → row` indexes, one per cached array (keyed by array name),
-     * powering the O(1) `Get…ById` helpers. Cleared wholesale on any {@link DataChange$} emission
+     * powering the O(1) `Get…ByID` helpers. Cleared wholesale on any {@link DataChange$} emission
      * (see the constructor) so entries never go stale as the underlying caches mutate.
      */
     private _idIndexes = new Map<string, Map<string, BaseEntity>>();
@@ -138,7 +138,7 @@ export class KnowledgeHubMetadataEngine extends BaseEngine<KnowledgeHubMetadataE
      * emission, so a returned index is always consistent with the current cache contents.
      * O(N) to build once, then O(1) per lookup.
      */
-    private getIdIndex<T extends BaseEntity>(key: string, rows: T[], idOf: (row: T) => string): Map<string, T> {
+    private getIDIndex<T extends BaseEntity>(key: string, rows: T[], idOf: (row: T) => string): Map<string, T> {
         // Downcast is safe by construction: each `key` is only ever paired with one row type.
         let index = this._idIndexes.get(key) as Map<string, T> | undefined;
         if (!index) {
@@ -153,33 +153,33 @@ export class KnowledgeHubMetadataEngine extends BaseEngine<KnowledgeHubMetadataE
     }
 
     /** Find an entity document by ID (case-insensitive UUID comparison). O(1) after first hit. */
-    public GetEntityDocumentById(id: string): MJEntityDocumentEntity | undefined {
+    public GetEntityDocumentByID(id: string): MJEntityDocumentEntity | undefined {
         if (!id) return undefined;
-        return this.getIdIndex('entityDocuments', this._entityDocuments, d => d.ID).get(NormalizeUUID(id));
+        return this.getIDIndex('entityDocuments', this._entityDocuments, d => d.ID).get(NormalizeUUID(id));
     }
 
     /** Find a content source by ID (case-insensitive UUID comparison). O(1) after first hit. */
-    public GetContentSourceById(id: string): MJContentSourceEntity | undefined {
+    public GetContentSourceByID(id: string): MJContentSourceEntity | undefined {
         if (!id) return undefined;
-        return this.getIdIndex('contentSources', this._contentSources, s => s.ID).get(NormalizeUUID(id));
+        return this.getIDIndex('contentSources', this._contentSources, s => s.ID).get(NormalizeUUID(id));
     }
 
     /** Find a content type by ID (case-insensitive UUID comparison). O(1) after first hit. */
-    public GetContentTypeById(id: string): MJContentTypeEntity | undefined {
+    public GetContentTypeByID(id: string): MJContentTypeEntity | undefined {
         if (!id) return undefined;
-        return this.getIdIndex('contentTypes', this._contentTypes, t => t.ID).get(NormalizeUUID(id));
+        return this.getIDIndex('contentTypes', this._contentTypes, t => t.ID).get(NormalizeUUID(id));
     }
 
     /** Find a content source type by ID (case-insensitive UUID comparison). O(1) after first hit. */
-    public GetContentSourceTypeById(id: string): MJContentSourceTypeEntity | undefined {
+    public GetContentSourceTypeByID(id: string): MJContentSourceTypeEntity | undefined {
         if (!id) return undefined;
-        return this.getIdIndex('contentSourceTypes', this._contentSourceTypes, t => t.ID).get(NormalizeUUID(id));
+        return this.getIDIndex('contentSourceTypes', this._contentSourceTypes, t => t.ID).get(NormalizeUUID(id));
     }
 
     /** Find a content file type by ID (case-insensitive UUID comparison). O(1) after first hit. */
-    public GetContentFileTypeById(id: string): MJContentFileTypeEntity | undefined {
+    public GetContentFileTypeByID(id: string): MJContentFileTypeEntity | undefined {
         if (!id) return undefined;
-        return this.getIdIndex('contentFileTypes', this._contentFileTypes, t => t.ID).get(NormalizeUUID(id));
+        return this.getIDIndex('contentFileTypes', this._contentFileTypes, t => t.ID).get(NormalizeUUID(id));
     }
 
     /** Find all entity documents for a given entity name (case-insensitive) */
@@ -190,9 +190,9 @@ export class KnowledgeHubMetadataEngine extends BaseEngine<KnowledgeHubMetadataE
     }
 
     /** Find a vector index by ID (case-insensitive UUID comparison). O(1) after first hit. */
-    public GetVectorIndexById(id: string): MJVectorIndexEntity | undefined {
+    public GetVectorIndexByID(id: string): MJVectorIndexEntity | undefined {
         if (!id) return undefined;
-        return this.getIdIndex('vectorIndexes', this._vectorIndexes, v => v.ID).get(NormalizeUUID(id));
+        return this.getIDIndex('vectorIndexes', this._vectorIndexes, v => v.ID).get(NormalizeUUID(id));
     }
 
     /**


### PR DESCRIPTION
Non-behavioral polish for the merged content-autotag vectorization work:

1. Export the vector-config interfaces from @memberjunction/content-autotagging with TSDoc (ResolvedVectorInfrastructure, ResolvedVectorStorageConfig, EmbeddingChunk, PersistedChunk, ChunkPurgeStats, ChunkEmbedStats + the VectorIDStrategy/ChunkTextStorage/VectorMetadataConfig/VectorMetadataFieldConfig aliases) so downstream consumers can reason about resolved vector infra.

2. Make AutotagBaseEngine chunk-record shaping subclass-overridable: extract per-chunk construction into protected buildVectorRecord(), and make buildVectorRecords + its collaborators (resolveChunkVectorId, buildVectorMetadata, buildProviderDirectives, resolveItemVectorStorageConfig, isItemLevelVector) protected with TSDoc.

3. Add O(1) by-id lookups to KnowledgeHubMetadataEngine (GetContentSourceById + siblings; upgrade GetVectorIndexById/GetEntityDocumentById) via lazily-built id indexes that self-invalidate on DataChange$. Route AutotagBaseEngine's six by-id lookups through these helpers instead of repeated .find() scans.

Tests: content-autotagging 194/194, core-entities 563/563 (+9 new finder tests).