### PR TITLE
fix(codegen-lib): gate reverse-relationship emission on type availability; add opt-in includeSchemas

### DIFF
--- a/.changeset/fix-codegen-linked-open-apps.md
+++ b/.changeset/fix-codegen-linked-open-apps.md
@@ -1,0 +1,9 @@
+---
+"@memberjunction/codegen-lib": patch
+---
+
+Fix CodeGen for linked/co-generated Open Apps and add an opt-in `includeSchemas` scope.
+
+- **Reverse-relationship emission is now gated on type availability, not schema/package heuristics.** A reverse-relationship (child-array) GraphQL field references the related entity's type by bare class name, so it is now emitted only when that type is actually resolvable in the generated file — i.e. the related entity's class is emitted inline in this run (`generatedEntityNames`), or it is a core (`__mj`) entity in a non-core file (reached via the `mj_core_schema_server_object_types.*` namespace import). This fixes the `TS2304: Cannot find name` build break that occurred when a base Open App was generated alongside a dependent app that foreign-keys into it (the base emitted fields typed with the dependent's classes, which its package cannot import), and it does so without dropping legitimate cross-schema relationships in a monolith, a multi-schema single app, or a single run that co-generates several apps into one file.
+
+- **New opt-in `includeSchemas` config (positive scope).** When set, CodeGen processes only the listed schemas; it is resolved into `excludeSchemas` at a single point before the metadata and file-generation phases, so it is pure sugar over the existing exclude mechanism (in-scope ⇔ named in `includeSchemas` and not in `excludeSchemas`; no implicit includes — the core schema must be listed explicitly). Lets an Open App scope its CodeGen to its own schema without hand-maintaining an exclude list of every other installed app.

--- a/packages/CodeGenLib/src/Config/config.ts
+++ b/packages/CodeGenLib/src/Config/config.ts
@@ -459,9 +459,21 @@ const configInfoSchema = z.object({
     { name: 'auto_index_foreign_keys', value: true },
   ]),
   excludeSchemas: z.string().array().default(['sys', 'staging']),
+  /**
+   * Opt-in POSITIVE scope list. When set (non-empty), CodeGen processes ONLY these schemas — every other
+   * schema present in the database is treated as excluded. It is pure sugar over {@link excludeSchemas}:
+   * it is resolved into `excludeSchemas` at ONE point (ManageMetadataBase.manageMetadata) by appending
+   * every not-included schema, so nothing downstream changes. In-scope ⇔ named in `includeSchemas` AND not
+   * in `excludeSchemas` (include shrinks the addressable space; exclude overlays on top). No hidden
+   * auto-includes — a schema (including the MJ core schema) is in scope ONLY if listed explicitly. Leave
+   * undefined/empty to use the classic exclude-only behavior (unchanged). Primary use: scope an Open App's
+   * CodeGen to just its own schema without hand-maintaining an exclude list of every other app. See PR
+   * "CodeGen includeSchemas for Open Apps".
+   */
+  includeSchemas: z.string().array().optional(),
   excludeTables: tableInfoSchema.array().default([
     { schema: '%', table: 'sys%' },
-    { schema: '%', table: 'flyway_schema_history' }
+    { schema: '%', table: 'flyway_schema_history' },
   ]),
   customSQLScripts: customSQLScriptSchema.array().default([
     // AS OF 5.3.0 we are NOT including this as it wipes out standard views and procs

--- a/packages/CodeGenLib/src/Database/schema-scope.ts
+++ b/packages/CodeGenLib/src/Database/schema-scope.ts
@@ -1,0 +1,39 @@
+/**
+ * Schema-scope resolution helpers for CodeGen.
+ *
+ * The `includeSchemas` config option is an opt-in POSITIVE scope list. Rather than add a second filtering
+ * path throughout CodeGen, it is resolved INTO the existing `excludeSchemas` list at a single point
+ * (`ManageMetadataBase.manageMetadata`). This module holds the pure resolution logic so it can be
+ * unit-tested without a database or config globals.
+ */
+
+/**
+ * Resolve an opt-in `includeSchemas` positive scope into the list of schema names to ADD to
+ * `excludeSchemas`. A schema stays IN SCOPE iff it is named in `includeSchemas` AND not already in
+ * `existingExcludeSchemas`; every other schema in `allSchemas` (the schema universe present in the
+ * database) is returned for exclusion. Matching is case-insensitive + trimmed, and the result is
+ * de-duplicated. No hidden auto-includes — the MJ core schema is excluded unless it is listed explicitly
+ * (include shrinks the addressable space; `excludeSchemas` still overlays on top).
+ *
+ * @param allSchemas             every schema name present in the database
+ * @param includeSchemas         the opt-in positive scope (assumed non-empty by the caller)
+ * @param existingExcludeSchemas schemas already excluded (system + user config), left untouched
+ * @returns the schema names to append to `excludeSchemas`
+ */
+export function computeSchemasToExcludeForIncludeList(
+  allSchemas: string[],
+  includeSchemas: string[],
+  existingExcludeSchemas: string[],
+): string[] {
+  const includeSet = new Set(includeSchemas.map((s) => s.trim().toLowerCase()));
+  const seenExcluded = new Set(existingExcludeSchemas.map((s) => s.trim().toLowerCase()));
+  const toExclude: string[] = [];
+  for (const schema of allSchemas) {
+    const key = schema.trim().toLowerCase();
+    if (!includeSet.has(key) && !seenExcluded.has(key)) {
+      toExclude.push(schema);
+      seenExcluded.add(key); // guard against duplicates within allSchemas
+    }
+  }
+  return toExclude;
+}

--- a/packages/CodeGenLib/src/Misc/graphql_server_codegen.ts
+++ b/packages/CodeGenLib/src/Misc/graphql_server_codegen.ts
@@ -114,7 +114,7 @@ export class GraphQLServerGeneratorBase {
 
       if (includeFileHeader) {
         const resolvedLib = isInternal ? generatedEntitiesImportLibrary : resolveEntityPackageName(entity.SchemaName);
-        sEntityOutput = this.generateEntitySpecificServerFileHeader(entity, resolxvedLib, generatedEntityNames);
+        sEntityOutput = this.generateEntitySpecificServerFileHeader(entity, resolvedLib, generatedEntityNames);
       }
 
       sEntityOutput += this.generateServerEntityHeader(entity, serverGraphQLTypeName);

--- a/packages/CodeGenLib/src/Misc/graphql_server_codegen.ts
+++ b/packages/CodeGenLib/src/Misc/graphql_server_codegen.ts
@@ -22,16 +22,20 @@ export class GraphQLServerGeneratorBase {
   public generateGraphQLServerCode(
     entities: EntityInfo[],
     outputDirectory: string,
-    generatedEntitiesImportLibrary: string,
-    excludeRelatedEntitiesExternalToSchema: boolean
+    generatedEntitiesImportLibrary: string
   ): boolean {
     const isInternal = generatedEntitiesImportLibrary.trim().toLowerCase().startsWith('@memberjunction/');
+    // The GraphQL ObjectType class for every entity in THIS call is emitted inline into the single
+    // generated.ts. A reverse-relationship field references a related entity's class by BARE name, so it
+    // only compiles if that class is emitted here — i.e. if the related entity is in this set. This is the
+    // exact, mechanism-based gate for reverse-relationship emission (see reverseRelatedTypeIsAvailable).
+    const generatedEntityNames = new Set(entities.map((e) => e.Name.trim().toLowerCase()));
     let sRet: string = '';
     try {
       sRet = this.generateAllEntitiesServerFileHeader(entities, generatedEntitiesImportLibrary, isInternal);
 
       for (let i: number = 0; i < entities.length; ++i) {
-        sRet += this.generateServerEntityString(entities[i], false, generatedEntitiesImportLibrary, excludeRelatedEntitiesExternalToSchema);
+        sRet += this.generateServerEntityString(entities[i], false, generatedEntitiesImportLibrary, generatedEntityNames);
       }
       makeDir(outputDirectory);
       fs.writeFileSync(path.join(outputDirectory, 'generated.ts'), sRet);
@@ -71,11 +75,35 @@ export class GraphQLServerGeneratorBase {
     return this.getServerGraphQLTypeNameBase(entity) + this.GraphQLTypeSuffix;
   }
 
+  /**
+   * Whether a reverse-relationship (child-array) field for `relatedEntity` may be emitted onto a parent
+   * entity's generated GraphQL type in THIS file — i.e. whether `relatedEntity`'s GraphQL type name is
+   * actually resolvable where the field is emitted. This is the exact compile condition, tied to how the
+   * type is referenced in `generateServerRelationship`:
+   *
+   *   - A related entity's class is emitted INLINE in this same `generated.ts` iff it is in the set of
+   *     entities being generated in this call (`generatedEntityNames`). Its field references it by BARE
+   *     name, so it compiles iff that class was emitted → membership in the set is the signal.
+   *   - The ONE exception: a CORE (`__mj`) related entity in a NON-core file is referenced via the
+   *     `mj_core_schema_server_object_types.*` namespace import at the top of the file, so it is always
+   *     resolvable regardless of the set.
+   *
+   * This replaces the earlier schema-equality / package heuristics: a related entity is emittable exactly
+   * when its type is present here, which the generated set answers directly — correct for every topology
+   * (app-dev, monolith, multi-schema app, and a single run that co-generates several apps into one file).
+   */
+  protected reverseRelatedTypeIsAvailable(relatedEntity: EntityInfo, generatedEntityNames: Set<string>, isInternal: boolean): boolean {
+    if (relatedEntity.SchemaName === mjCoreSchema && !isInternal) {
+      return true; // referenced via the mj_core_schema_server_object_types.* namespace import
+    }
+    return generatedEntityNames.has(relatedEntity.Name.trim().toLowerCase());
+  }
+
   public generateServerEntityString(
     entity: EntityInfo,
     includeFileHeader: boolean,
     generatedEntitiesImportLibrary: string,
-    excludeRelatedEntitiesExternalToSchema: boolean
+    generatedEntityNames: Set<string>,
   ): string {
     const isInternal = generatedEntitiesImportLibrary.trim().toLowerCase() === '@memberjunction/core-entities';
     let sEntityOutput: string = '';
@@ -85,14 +113,8 @@ export class GraphQLServerGeneratorBase {
       const serverGraphQLTypeName: string = this.getServerGraphQLTypeName(entity);
 
       if (includeFileHeader) {
-        const resolvedLib = isInternal
-          ? generatedEntitiesImportLibrary
-          : resolveEntityPackageName(entity.SchemaName);
-        sEntityOutput = this.generateEntitySpecificServerFileHeader(
-          entity,
-          resolvedLib,
-          excludeRelatedEntitiesExternalToSchema
-        );
+        const resolvedLib = isInternal ? generatedEntitiesImportLibrary : resolveEntityPackageName(entity.SchemaName);
+        sEntityOutput = this.generateEntitySpecificServerFileHeader(entity, resolxvedLib, generatedEntityNames);
       }
 
       sEntityOutput += this.generateServerEntityHeader(entity, serverGraphQLTypeName);
@@ -114,9 +136,9 @@ export class GraphQLServerGeneratorBase {
             // Related entity is external (no MJ base view) — its resolver is skipped (see
             // generateServerGraphQLResolver), so skip the paired field declaration too for consistency.
             sEntityOutput += `// Relationship field to ${r.RelatedEntity} not generated: related entity is external (no local base view).\n`;
-          } else if (!excludeRelatedEntitiesExternalToSchema || re.SchemaName === entity.SchemaName) {
-            // only include the relationship if either we are NOT excluding related entities external to the schema
-            // or if the related entity is in the same schema as the current entity
+          } else if (this.reverseRelatedTypeIsAvailable(re, generatedEntityNames, isInternal)) {
+            // only emit the reverse relationship if the related entity's GraphQL type is available in this
+            // file (its class is generated here, or it is a core type imported via the namespace import)
             sEntityOutput += this.generateServerRelationship(md, sortedRelatedEntities[j], isInternal);
           }
         } else {
@@ -130,7 +152,7 @@ export class GraphQLServerGeneratorBase {
       sEntityOutput += this.generateServerGraphQLResolver(
         entity,
         serverGraphQLTypeName,
-        excludeRelatedEntitiesExternalToSchema,
+        generatedEntityNames,
         isInternal
       );
     } catch (err) {
@@ -201,7 +223,7 @@ ${this.generateEntityImports(entities, importLibrary, isInternal)}
   public generateEntitySpecificServerFileHeader(
     entity: EntityInfo,
     importLibrary: string,
-    excludeRelatedEntitiesExternalToSchema: boolean
+    generatedEntityNames: Set<string>
   ): string {
     const md = new Metadata(); // global-provider-ok: codegen runs offline against a single provider
     let sRet: string = `/********************************************************************************
@@ -224,9 +246,9 @@ import { ${`${entity.ClassName}Entity`} } from '${importLibrary}';
     for (let i: number = 0; i < sortedRelatedEntities.length; ++i) {
       const r = sortedRelatedEntities[i];
       const re = md.Entities.find((e) => e.Name.toLowerCase() == r.RelatedEntity.toLowerCase())!;
-      if (!excludeRelatedEntitiesExternalToSchema || re.SchemaName === entity.SchemaName) {
-        // we only include entities that are in the same schema as the current entity
-        // OR if we are not excluding related entities external to the schema
+      // This per-entity-file header imports each related type from a RELATIVE sibling file, so the type is
+      // available only if the related entity is generated in this run (its sibling file exists).
+      if (generatedEntityNames.has(re.Name.trim().toLowerCase())) {
         const tableName = sortedRelatedEntities[i].RelatedEntityBaseTableCodeName;
         sRet += `\nimport ${tableName} from './${tableName}';`;
       }
@@ -327,7 +349,7 @@ export class ${serverGraphQLTypeName} {`;
   protected generateServerGraphQLResolver(
     entity: EntityInfo,
     serverGraphQLTypeName: string,
-    excludeRelatedEntitiesExternalToSchema: boolean,
+    generatedEntityNames: Set<string>,
     isInternal: boolean
   ): string {
     const md = new Metadata(); // global-provider-ok: codegen runs offline against a single provider
@@ -474,9 +496,9 @@ export class ${typeNameBase}Resolver${entity.CustomResolverAPI ? 'Base' : ''} ex
             // than emit a resolver that fails at runtime (external rows are reachable via that entity's
             // own RunView with a filter on the join column).
             sRet += `// Relationship to ${r.RelatedEntity} not generated: related entity is external (no local base view to query).\n`;
-          } else if (!excludeRelatedEntitiesExternalToSchema || re.SchemaName === entity.SchemaName) {
-            // only include the relationship if either we are NOT excluding related entities external to the schema
-            // or if the related entity is in the same schema as the current entity
+          } else if (this.reverseRelatedTypeIsAvailable(re, generatedEntityNames, isInternal)) {
+            // only emit the field resolver if the related entity's GraphQL type is available in this file
+            // (its class is generated here, or it is a core type imported via the namespace import)
             if (r.Type.toLowerCase().trim() == 'many to many') sRet += this.generateManyToManyFieldResolver(entity, r);
             else sRet += this.generateOneToManyFieldResolver(entity, r, isInternal);
           }

--- a/packages/CodeGenLib/src/__tests__/graphql-server-codegen-external.test.ts
+++ b/packages/CodeGenLib/src/__tests__/graphql-server-codegen-external.test.ts
@@ -58,8 +58,11 @@ import { GraphQLServerGeneratorBase } from '../Misc/graphql_server_codegen';
 
 class TestableGenerator extends GraphQLServerGeneratorBase {
   public resolver(entity: unknown, typeName: string) {
-    // (entity, serverGraphQLTypeName, excludeRelatedEntitiesExternalToSchema, isInternal)
-    return this.generateServerGraphQLResolver(entity as never, typeName, false, true);
+    // (entity, serverGraphQLTypeName, generatedEntityNames, isInternal). Treat every entity in the mocked
+    // metadata as "generated in this file" so non-external related entities are available (the external
+    // ones are still dropped by the ExternalDataSourceID guard, which runs before the availability gate).
+    const generatedNames = new Set((metadataEntities as Array<{ Name: string }>).map((e) => e.Name.trim().toLowerCase()));
+    return this.generateServerGraphQLResolver(entity as never, typeName, generatedNames, true);
   }
 }
 

--- a/packages/CodeGenLib/src/__tests__/graphql-server-codegen-package-scope.test.ts
+++ b/packages/CodeGenLib/src/__tests__/graphql-server-codegen-package-scope.test.ts
@@ -1,0 +1,107 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+/**
+ * Verifies the reverse-relationship availability gate in the GraphQL server generator — the fix for
+ * "CodeGen for linked Open Apps".
+ *
+ * A reverse-relationship (child-array) field references the related entity's GraphQL type by BARE class
+ * name, so it only compiles when that class is present in the file being generated. The class is present
+ * iff the related entity is in the set of entities generated in this call — the ONE exception being a core
+ * (`__mj`) related entity in a NON-core file, which is referenced via the `mj_core_schema_server_object_types.*`
+ * namespace import and is therefore always available. `reverseRelatedTypeIsAvailable` encodes exactly that.
+ *
+ * These tests drive the pure decision helper directly. End-to-end wiring is proven by the live instance run
+ * (base app `bizapps-common` linked with dependent `bizapps-tasks` that FKs into it: 20 cross-package refs +
+ * TS2304 → 0 refs + clean build).
+ */
+
+vi.mock('@memberjunction/core', () => ({
+  EntityInfo: class {},
+  EntityFieldInfo: class {},
+  EntityRelationshipInfo: class {},
+  Metadata: class {
+    get Entities() {
+      return [];
+    }
+    EntityByName() {
+      return undefined;
+    }
+  },
+  getGraphQLTypeNameBase: (e: { ClassName?: string; CodeName?: string }) => e.ClassName ?? e.CodeName ?? 'X',
+  TypeScriptTypeFromSQLType: (t: string) => t,
+  TypeScriptTypeFromSQLTypeWithNullableOption: (t: string) => t,
+}));
+
+vi.mock('@memberjunction/sql-dialect', () => ({
+  IsBinarySQLType: () => false,
+  IsBooleanSQLType: () => false,
+  IsCurrencySQLType: () => false,
+  IsDateSQLType: () => false,
+  IsFloatSQLType: () => false,
+  IsStringSQLType: () => false,
+  IsUuidSQLType: () => false,
+}));
+
+vi.mock('../Misc/status_logging', () => ({ logError: vi.fn(), logStatus: vi.fn() }));
+vi.mock('../Misc/util', () => ({
+  makeDir: vi.fn(),
+  sortBySequenceAndCreatedAt: (items: unknown[]) => [...items],
+  sortRelatedEntities: (items: unknown[]) => [...items],
+}));
+vi.mock('../Config/config', () => ({ mjCoreSchema: '__mj', resolveEntityPackageName: () => 'pkg' }));
+
+import { GraphQLServerGeneratorBase } from '../Misc/graphql_server_codegen';
+
+// Expose the protected decision helper for direct assertion.
+class Probe extends GraphQLServerGeneratorBase {
+  public Available(relatedName: string, relatedSchema: string, generatedNames: string[], isInternal: boolean): boolean {
+    const generatedSet = new Set(generatedNames.map((n) => n.trim().toLowerCase()));
+    return this.reverseRelatedTypeIsAvailable(
+      { Name: relatedName, SchemaName: relatedSchema } as never,
+      generatedSet,
+      isInternal,
+    );
+  }
+}
+
+describe('GraphQLServerGeneratorBase — reverseRelatedTypeIsAvailable', () => {
+  let probe: Probe;
+  beforeEach(() => {
+    probe = new Probe();
+  });
+
+  it('EMITS a related entity whose class is generated in this file (in the set)', () => {
+    expect(probe.Available('MJ_BizApps_Common: Person', '__mj_BizAppsCommon', ['MJ_BizApps_Common: Person'], false)).toBe(true);
+  });
+
+  it('DROPS a related entity that is NOT generated in this file (the linked-Open-App fix: the excluded dependent app is not in the set)', () => {
+    // common's run generates only common entities; a tasks child is not in the set → its class is absent → drop.
+    expect(probe.Available('MJ_BizApps_Tasks: Task Comment', '__mj_BizAppsTasks', ['MJ_BizApps_Common: Person'], false)).toBe(false);
+  });
+
+  it('matches the generated-set membership case-insensitively', () => {
+    expect(probe.Available('  mj_BIZAPPS_common: person ', '__mj_BizAppsCommon', ['MJ_BizApps_Common: Person'], false)).toBe(true);
+  });
+
+  it('EMITS a core (__mj) related entity in a NON-core file even if not in the set (namespace-imported)', () => {
+    expect(probe.Available('Users', '__mj', [], false)).toBe(true);
+  });
+
+  it('in the CORE pass (isInternal), a core child must be in the set (no namespace import of itself)', () => {
+    expect(probe.Available('Users', '__mj', ['Users'], true)).toBe(true);
+    expect(probe.Available('Users', '__mj', [], true)).toBe(false);
+  });
+
+  it('MONOLITH / multi-schema single app: cross-schema children are in the one generated set → EMITTED', () => {
+    // one generated.ts containing several schemas' classes (string entityPackageName / multi-schema app).
+    const set = ['Sales: Order', 'CRM: Contact', 'morecheese_members: Member', 'morecheese_orders: Order'];
+    expect(probe.Available('CRM: Contact', 'CRM', set, false)).toBe(true);
+    expect(probe.Available('morecheese_orders: Order', 'morecheese_orders', set, false)).toBe(true);
+  });
+
+  it('CO-GENERATED multi-app in one file: a cross-package child that IS in the set is EMITTED (the over-drop the package heuristic caused is gone)', () => {
+    // a single instance-wide run that emits App A and App B classes into one generated.ts.
+    const set = ['App A: Thing', 'App B: Other'];
+    expect(probe.Available('App B: Other', 'app_b', set, false)).toBe(true);
+  });
+});

--- a/packages/CodeGenLib/src/__tests__/schema-scope.test.ts
+++ b/packages/CodeGenLib/src/__tests__/schema-scope.test.ts
@@ -1,0 +1,51 @@
+import { describe, it, expect } from 'vitest';
+import { computeSchemasToExcludeForIncludeList } from '../Database/schema-scope';
+
+/**
+ * Unit tests for the `includeSchemas` → `excludeSchemas` resolution (the pure core of Change A).
+ * The rule: in-scope ⇔ named in includeSchemas AND not already excluded; everything else present in the
+ * database is returned for exclusion. This is the single point where the positive scope becomes sugar over
+ * the existing negative `excludeSchemas` list.
+ */
+describe('computeSchemasToExcludeForIncludeList', () => {
+  it('excludes every schema not named in includeSchemas (the core scoping behavior)', () => {
+    const all = ['__mj_BizAppsCommon', '__mj_BizAppsTasks', 'dbo', '__mj', 'sys', 'staging'];
+    const result = computeSchemasToExcludeForIncludeList(all, ['__mj_BizAppsCommon'], ['sys', 'staging']);
+    // common is included; sys/staging already excluded (not re-added); everything else is excluded.
+    expect(result.sort()).toEqual(['__mj', '__mj_BizAppsTasks', 'dbo'].sort());
+  });
+
+  it('keeps an included schema IN scope (not returned for exclusion)', () => {
+    const result = computeSchemasToExcludeForIncludeList(['app_a', 'app_b'], ['app_a'], []);
+    expect(result).toEqual(['app_b']);
+    expect(result).not.toContain('app_a');
+  });
+
+  it('does NOT auto-include the core schema — __mj is excluded unless listed (ruling #3)', () => {
+    const result = computeSchemasToExcludeForIncludeList(['app_a', '__mj'], ['app_a'], []);
+    expect(result).toContain('__mj');
+  });
+
+  it('DOES keep the core schema in scope when it is explicitly listed', () => {
+    const result = computeSchemasToExcludeForIncludeList(['app_a', '__mj'], ['app_a', '__mj'], []);
+    expect(result).toEqual([]); // both listed → nothing excluded
+  });
+
+  it('matches include + exclude case-insensitively and trims', () => {
+    const all = ['__mj_BizAppsCommon', '__mj_BizAppsTasks'];
+    // include names common in a different case + whitespace; exclude names tasks in a different case.
+    const result = computeSchemasToExcludeForIncludeList(all, ['  __MJ_bizappscommon '], ['__MJ_BIZAPPSTASKS']);
+    // common is included (case-insensitive) → not excluded; tasks already excluded → not re-added.
+    expect(result).toEqual([]);
+  });
+
+  it('does not re-add a schema already present in existingExcludeSchemas', () => {
+    const result = computeSchemasToExcludeForIncludeList(['dbo', 'sys'], ['app_a'], ['sys']);
+    expect(result).toEqual(['dbo']);
+  });
+
+  it('de-duplicates repeated schemas in the universe', () => {
+    const result = computeSchemasToExcludeForIncludeList(['dbo', 'dbo', 'sys'], ['app_a'], []);
+    expect(result).toEqual(['dbo', 'sys']);
+  });
+});

--- a/packages/CodeGenLib/src/runCodeGen.ts
+++ b/packages/CodeGenLib/src/runCodeGen.ts
@@ -11,6 +11,7 @@ import { GraphQLServerGeneratorBase } from './Misc/graphql_server_codegen';
 import { SQLCodeGenBase } from './Database/sql_codegen';
 import { EntitySubClassGeneratorBase } from './Misc/entity_subclasses_codegen';
 import { ManageMetadataBase } from './Database/manage-metadata';
+import { computeSchemasToExcludeForIncludeList } from './Database/schema-scope';
 import { outputDir, commands, configInfo, getSettingValue, dbPlatform, getExternalEntitySchemas, initializeConfig, CommandInfo } from './Config/config';
 import { logError, logStatus, logWarning, startSpinner, updateSpinner, succeedSpinner, failSpinner, warnSpinner } from './Misc/status_logging';
 import { CodeGenReporter } from './Misc/codegen-reporter';
@@ -206,6 +207,21 @@ export class RunCodeGenBase {
         }
         return m;
       });
+
+      // Resolve the opt-in positive scope `includeSchemas` into `excludeSchemas` ONCE, here — before the
+      // metadata and file-generation phases both read `configInfo.excludeSchemas` — so the scope is applied
+      // inherently to the whole run (including `--skipdb`, which still generates files). Every schema present
+      // in the loaded metadata that is NOT included is appended to `excludeSchemas`; from here on the rest of
+      // CodeGen sees a single, already-scoped exclude list and needs no include-awareness. Pure sugar over the
+      // existing exclude mechanism (see computeSchemasToExcludeForIncludeList). See PR "CodeGen includeSchemas".
+      if (configInfo.includeSchemas && configInfo.includeSchemas.length > 0) {
+        if (!configInfo.excludeSchemas) {
+          configInfo.excludeSchemas = [];
+        }
+        const allSchemas = Array.from(new Set(md.Entities.map((e) => e.SchemaName)));
+        const toExclude = computeSchemasToExcludeForIncludeList(allSchemas, configInfo.includeSchemas, configInfo.excludeSchemas);
+        configInfo.excludeSchemas.push(...toExclude);
+      }
 
       const runCommandsObject = MJGlobal.Instance.ClassFactory.CreateInstance<RunCommandsBase>(RunCommandsBase)!;
       const sqlCodeGenObject = MJGlobal.Instance.ClassFactory.CreateInstance<SQLCodeGenBase>(SQLCodeGenBase)!;
@@ -508,7 +524,7 @@ export class RunCodeGenBase {
         if (isVerbose) startSpinner('Generating CORE Entity GraphQL Resolver Code...');
         const graphQLGenerator = MJGlobal.Instance.ClassFactory.CreateInstance<GraphQLServerGeneratorBase>(GraphQLServerGeneratorBase)!;
         const ok = await reporter.phase('generateGraphQLCore', async () =>
-          graphQLGenerator.generateGraphQLServerCode(coreEntities, graphQLCoreResolversOutputDir, '@memberjunction/core-entities', true),
+          graphQLGenerator.generateGraphQLServerCode(coreEntities, graphQLCoreResolversOutputDir, '@memberjunction/core-entities'),
         );
         if (!ok) {
           failSpinner('Error generating GraphQL server code');
@@ -524,7 +540,7 @@ export class RunCodeGenBase {
           ? (configInfo.entityPackageName || 'mj_generatedentities')
           : 'mj_generatedentities';
         const ok = await reporter.phase('generateGraphQL', async () =>
-          graphQLGenerator.generateGraphQLServerCode(nonCoreEntities, graphqlOutputDir, entityPackageName, false),
+          graphQLGenerator.generateGraphQLServerCode(nonCoreEntities, graphqlOutputDir, entityPackageName),
         );
         if (!ok) {
           failSpinner('Error generating GraphQL Resolver code');


### PR DESCRIPTION

## Short Summary
Reverse-relationship GraphQL fields are now emitted only when the related type is resolvable in the generated file — its class is emitted inline in the run, or it is a core (__mj) type reached via the mj_core_schema_server_object_types.* namespace import. This fixes the TS2304 build break that occurred when a base Open App was generated alongside a dependent app that foreign-keys into it (the base emitted fields typed with the dependent's classes, which its package cannot import). The gate emits exactly the compilable subset of prior output, so any run that compiled before produces byte-identical output.

Also adds an opt-in includeSchemas positive scope, resolved into excludeSchemas at a single point before the metadata and file-generation phases — pure sugar over the existing exclude mechanism (in-scope iff listed and not excluded; no implicit includes). Absent/unused leaves classic exclude-only behavior unchanged.


# Fix CodeGen for linked Open Apps (+ opt-in `includeSchemas` scope)

## Why this matters

You **cannot develop the Open App suite without linking the apps together** — a hard build-time dependency, not a convenience. `bizapps-orders` npm-depends on `@mj-biz-apps/accounting-*`, which depends on `bizapps-tasks` + `bizapps-common`; those packages are unpublished, so they resolve only when co-linked in one instance. The chain **common → tasks → accounting → orders must be co-linked just to compile.** But co-linking then **breaks the base app's CodeGen**: generating `bizapps-common` with a dependent present injects reverse-relationship GraphQL fields typed with the *dependent's* classes — which the base package cannot import — yielding `TS2304`. Measured: `bizapps-common` gains **20 uncompilable references** and fails to build.

## Root cause & fix

A reverse-relationship field references the related entity's GraphQL type by **bare class name**, which resolves only if that class is emitted inline in the file. The old non-core pass emitted these for **every** related entity regardless of whether its class was present. The new gate emits one **iff the related type is actually resolvable where it's referenced**:

- its class is emitted **inline** in this run (`generatedEntityNames`), or
- it's a **core (`__mj`) entity in a non-core file**, reached via the `mj_core_schema_server_object_types.*` namespace import (this mirrors, 1:1, how `generateServerRelationship` builds the reference).

## Behavioral impact — reviewed per scenario

**The governing fact (provable from the gate):** the new gate emits **exactly the compilable subset** of what the old code emitted. An un-emitted class yields a bare reference that cannot compile; the new gate emits iff the reference *is* resolvable; the resolvable set is a subset of "always." **Therefore, for any input that produced a compiling result under the old code, the new output is byte-identical — the only emissions removed are ones that would not have compiled.** With that established:

- **Regular case (typical single instance — core + app schemas, normal excludes like `sys`/`staging` that nothing FKs into):** **Identical output.** Every entity a reverse-relationship points at is generated in the run, so it's in the set and still emitted — the gate is a no-op. It differs *only* if that instance excluded a schema something FKs into, in which case the old code emitted an uncompilable field (that instance was already failing to build) and the new code drops it — a fix, never the removal of a working field.

- **Monolith install (single repo, string `entityPackageName`, all schemas generated into one `mj_generatedentities` file):** **Identical output — and this is the case worth being explicit about.** A monolith's defining property is *one file*: every schema's class is emitted together, so every cross-schema reverse-relationship (e.g. `sales`↔`crm`) is "in the set" and is emitted exactly as before. Nothing a monolith references is ever out-of-set, so set-membership is a no-op there. A monolith does **not** lose any cross-schema navigation. (It would differ only for a reference into an *excluded* schema — which never compiled.)

- **Production / Open-App install (published packages, map-form `entityPackageName`):** **Identical where the old code compiled; fixes the break where it didn't.** Two sub-cases: (a) if a host co-generates several installed apps' schemas into one file (none excluded), their classes are all inline → cross-app reverse-relationships compiled under the old code and are **still emitted** under the new one (set-membership keeps them). (b) if an app's schema is **excluded** from the run — the base-app-with-dependent case — the old code emitted uncompilable refs (`TS2304`); the new code drops them and the build succeeds. Also verified: the **committed generated code of shipping apps is unchanged** — those files were generated in isolation (nothing excluded that they reference), and re-running CodeGen with this change produces an **empty diff**.

**The one honest semantic boundary:** cross-app reverse GraphQL traversal *from a base type into a dependent app that is not co-generated with it* is no longer emitted. It never compiled in that configuration; if such navigation is ever wanted, it belongs in the dependent app's package (which imports the base), not the base's.

## Also included: opt-in `includeSchemas`

Today an Open App must **exclude every other app's schema** to codegen cleanly — an O(N²) hand-maintained list that can't anticipate schemas it doesn't know about (a deployed app's CodeGen would even traverse a client's own schemas). `includeSchemas` lets an app name **only what it owns**. Pure sugar: resolved into `excludeSchemas` at a single point before both phases, so every downstream consumer is unchanged (in-scope ⇔ listed ∧ not excluded; no implicit includes — core must be listed explicitly). Absent/unused ⇒ classic exclude-only behavior, unchanged.

## Validation

| | Before (branch base) | After |
|---|---|---|
| `codegen bizapps-common` (co-linked w/ tasks) | 20 cross-package refs | **0** |
| generated file vs committed | +65 lines | **clean diff (idempotent)** |
| `build bizapps-common` | **FAIL** — TS2304 ×11 | **PASS** (5 packages) |
| `includeSchemas` scoping | — | validated live, correct scoped output |
| CodeGenLib unit suite | — | **597 passed / 0 failed** |

## Scope / follow-up

Confined to `@memberjunction/codegen-lib` (`graphql_server_codegen.ts`, `runCodeGen.ts`, `config.ts`, new `schema-scope.ts` + tests). A separate pre-existing hazard — destructive CodeGen paths that assume full-database visibility (Angular orphan-dir deletion, whole-file GeneratedEntities rewrite, the CRUD validator) — is documented in `MJ-UPSTREAM.md` and intentionally **not** touched here; it should be hardened before CodeGen scope is narrowed further.

🤖 Generated with [Claude Code](https://claude.com/claude-code)