### PR TITLE
fix(codegen-lib): gate reverse-relationship emission on type availability; add opt-in includeSchemas

### DIFF
--- a/.changeset/codegen-type-availability-gate.md
+++ b/.changeset/codegen-type-availability-gate.md
@@ -1,0 +1,11 @@
+---
+"@memberjunction/codegen-lib": minor
+---
+
+Gate reverse-relationship emission on actual GraphQL type availability, and add an opt-in `includeSchemas` scope.
+
+- **Reverse-relationship emission is now decided by the generated entity set, not a schema/package heuristic.** A reverse-relationship (child-array) `@Field`/`@FieldResolver` references the related entity's GraphQL type by bare class name, so it only compiles when that class is declared in the file being generated. `isRelatedTypeOutOfScope` now answers that from `GeneratedTypeAvailability` — the exact set of entities handed to the generator for the file — with one exception: a core (`__mj`) related entity in a non-core file, which resolves through the `mj_core_schema_server_object_types` namespace import. The previous predicate inferred the set from the `entityPackageName` schema→package map alone, but `runCodeGen` narrows the generated entities by *both* that map and the `excludeSchemas`/inclusion filters, so anything dropped by the latter still produced a dangling reference (`TS2304: Cannot find name`) — the break seen when a base Open App is generated alongside a dependent app that foreign-keys into it. The gate emits exactly the compilable subset of prior output, so any run that compiled before is unaffected.
+
+- **New opt-in `includeSchemas` config (positive scope).** When set, CodeGen processes only the listed schemas. It is resolved into `excludeSchemas` — pure sugar over the existing exclude mechanism (in-scope ⇔ named in `includeSchemas` and not in `excludeSchemas`; no implicit includes, so the core schema must be listed explicitly). The authoritative resolution runs in `ManageMetadataBase.manageMetadata` against the **database's** schema list, so schemas MJ has never seen are excluded before `createNewEntities()` discovers their tables; a second idempotent pass in `runCodeGen` keeps the scope applied on the `--skipdb` path. Lets an Open App scope its CodeGen to its own schema without hand-maintaining an exclude list of every other installed app. Absent/empty leaves classic exclude-only behavior unchanged.
+
+Both `GraphQLServerGeneratorBase` signature changes are additive (a new optional trailing `availability` parameter), so existing subclasses and callers keep compiling and retain their previous behavior.

--- a/packages/CodeGenLib/src/Config/config.ts
+++ b/packages/CodeGenLib/src/Config/config.ts
@@ -459,6 +459,22 @@ const configInfoSchema = z.object({
     { name: 'auto_index_foreign_keys', value: true },
   ]),
   excludeSchemas: z.string().array().default(['sys', 'staging']),
+  /**
+   * Opt-in POSITIVE scope list. When set (non-empty), CodeGen processes ONLY these schemas — every
+   * other schema present in the DATABASE is treated as excluded, including schemas MJ has never seen
+   * before. It is pure sugar over {@link excludeSchemas}: it is resolved into `excludeSchemas` (see
+   * `applyIncludeSchemaScope`) before metadata management and again before file generation, so
+   * nothing downstream changes. In-scope ⇔ named in `includeSchemas` AND not in `excludeSchemas`
+   * (include shrinks the addressable space; exclude overlays on top). No hidden auto-includes — a
+   * schema, including the MJ core schema, is in scope ONLY if listed explicitly. Leave
+   * undefined/empty for the classic exclude-only behavior (unchanged).
+   *
+   * Primary use: scope an Open App's CodeGen to just its own schema without hand-maintaining an
+   * exclude list naming every other installed app — a list that is O(N²) to maintain and, more
+   * importantly, cannot name schemas the app does not know about (such as a client's own schemas in
+   * a deployed instance).
+   */
+  includeSchemas: z.string().array().optional(),
   excludeTables: tableInfoSchema.array().default([
     { schema: '%', table: 'sys%' },
     { schema: '%', table: 'flyway_schema_history' }

--- a/packages/CodeGenLib/src/Database/manage-metadata.ts
+++ b/packages/CodeGenLib/src/Database/manage-metadata.ts
@@ -10,6 +10,7 @@ import { ApplicationInfo, CodeNameFromString, EntityFieldExtendedType, EntityFie
 import { MJApplicationEntity, MJEntityFieldSchema } from "@memberjunction/core-entities";
 import { logError, logMessage, logStatus, startSpinner, updateSpinner, succeedSpinner } from "../Misc/status_logging";
 import { SQLUtilityBase } from "./sql";
+import { applyIncludeSchemaScope } from "./schema-scope";
 import { AdvancedGeneration, EntityDescriptionResult, EntityNameResult, SmartFieldIdentificationResult, FormLayoutResult, VirtualEntityDecorationResult } from "../Misc/advanced_generation";
 import { CodeGenReporter } from "../Misc/codegen-reporter";
 import { mapExternalNativeTypeToMJ } from "../Misc/externalTypeMapping";
@@ -1302,8 +1303,6 @@ export class ManageMetadataBase {
             }
          }
       }
-      const excludeSchemas = configInfo.excludeSchemas ? [...configInfo.excludeSchemas] : [];
-
       // Ensure the platform's metadata-management support objects exist and
       // match this CodeGenLib version. These routines/views are CodeGen's own
       // machinery — when the provider supplies DDL (PostgreSQL), we install it
@@ -1320,6 +1319,35 @@ export class ManageMetadataBase {
             return false;
          }
       }
+
+      // Resolve the opt-in `includeSchemas` positive scope into excludeSchemas, BEFORE the exclude
+      // snapshot below and before createNewEntities() runs. The universe is queried from the DATABASE
+      // rather than taken from loaded metadata on purpose: createNewEntities() discovers tables with no
+      // EntityID straight from the database, so a schema MJ has never seen — the exact case an include
+      // list exists to protect against, e.g. a client's own schemas in a deployed instance — is absent
+      // from Metadata.Entities and would otherwise be adopted on the first run (and then excluded on
+      // every run after, orphaning its entity records). No-op when includeSchemas is unset.
+      if (configInfo.includeSchemas && configInfo.includeSchemas.length > 0) {
+         try {
+            const schemaSQL = `SELECT DISTINCT ${this.qi('SchemaName')} FROM ${this.qs(mj_core_schema(), 'vwSQLTablesAndEntities')}`;
+            const schemaResult = await this.runQuery(pool, schemaSQL);
+            const allSchemas: string[] = (schemaResult.recordset ?? [])
+               .map((r: { SchemaName?: string }) => r.SchemaName)
+               .filter((s: string | undefined): s is string => !!s);
+            const newlyExcluded = applyIncludeSchemaScope(allSchemas, configInfo);
+            logStatus(
+               `   Applied includeSchemas scope [${configInfo.includeSchemas.join(', ')}] — excluded ${newlyExcluded.length} other schema(s) present in the database`
+            );
+         }
+         catch (e) {
+            // Proceeding would let CodeGen traverse schemas the include list was meant to keep it off,
+            // which can create entity metadata for another app's (or a client's) tables. Fail instead.
+            logError(`   Error resolving includeSchemas scope: ${e instanceof Error ? e.message : e}`);
+            return false;
+         }
+      }
+
+      const excludeSchemas = configInfo.excludeSchemas ? [...configInfo.excludeSchemas] : [];
 
       let bSuccess = true;
       let start = new Date();

--- a/packages/CodeGenLib/src/Database/schema-scope.ts
+++ b/packages/CodeGenLib/src/Database/schema-scope.ts
@@ -1,0 +1,82 @@
+/**
+ * Schema-scope resolution helpers for CodeGen.
+ *
+ * `includeSchemas` is an opt-in POSITIVE scope list. Rather than add a second filtering path
+ * throughout CodeGen, it is resolved INTO the existing `excludeSchemas` list, so every downstream
+ * consumer (metadata management, `createExcludeTablesAndSchemasFilter`, the file-generation phases)
+ * keeps reading a single already-scoped exclude list and needs no include-awareness.
+ *
+ * This module holds the pure resolution logic so it can be unit-tested without a database or config
+ * globals.
+ */
+
+/**
+ * Resolve an opt-in `includeSchemas` positive scope into the list of schema names to ADD to
+ * `excludeSchemas`. A schema stays IN SCOPE iff it is named in `includeSchemas` AND not already in
+ * `existingExcludeSchemas`; every other schema in `allSchemas` is returned for exclusion. Matching is
+ * case-insensitive + trimmed, and the result is de-duplicated. No hidden auto-includes — the MJ core
+ * schema is excluded unless it is listed explicitly (include shrinks the addressable space;
+ * `excludeSchemas` still overlays on top).
+ *
+ * @param allSchemas             the schema universe to scope against — see {@link applyIncludeSchemaScope}
+ *                               for why this must be sourced from the DATABASE, not from loaded metadata
+ * @param includeSchemas         the opt-in positive scope (assumed non-empty by the caller)
+ * @param existingExcludeSchemas schemas already excluded (system + user config), left untouched
+ * @returns the schema names to append to `excludeSchemas`
+ */
+export function computeSchemasToExcludeForIncludeList(
+  allSchemas: string[],
+  includeSchemas: string[],
+  existingExcludeSchemas: string[],
+): string[] {
+  const includeSet = new Set(includeSchemas.map((s) => s.trim().toLowerCase()));
+  const seenExcluded = new Set(existingExcludeSchemas.map((s) => s.trim().toLowerCase()));
+  const toExclude: string[] = [];
+  for (const schema of allSchemas) {
+    const key = schema.trim().toLowerCase();
+    if (!includeSet.has(key) && !seenExcluded.has(key)) {
+      toExclude.push(schema);
+      seenExcluded.add(key); // guard against duplicates within allSchemas
+    }
+  }
+  return toExclude;
+}
+
+/** The subset of the CodeGen config this module reads and mutates. */
+export interface SchemaScopeConfig {
+  includeSchemas?: string[];
+  excludeSchemas?: string[];
+}
+
+/**
+ * Apply an `includeSchemas` positive scope by appending every out-of-scope schema in `allSchemas` to
+ * `config.excludeSchemas` in place. No-op when `includeSchemas` is absent or empty, which preserves
+ * classic exclude-only behavior exactly. Idempotent, so it is safe to call from more than one phase
+ * as the schema universe becomes better known.
+ *
+ * **`allSchemas` must be the DATABASE's schema list, not the schemas present in loaded metadata.**
+ * The primary job of an include list is to keep CodeGen off schemas it does not own — and the
+ * highest-risk case is a schema MJ has never seen before, because `createNewEntities()` discovers
+ * tables with no `EntityID` straight from the database and filters them only through
+ * `excludeSchemas`. A universe derived from `Metadata.Entities` contains, by definition, only schemas
+ * that ALREADY have entities, so it cannot exclude a never-seen schema: that schema would be adopted
+ * into metadata on the first run and then excluded on every subsequent run, leaving its entity
+ * records permanently orphaned. Callers without database access (e.g. the `--skipdb` file-generation
+ * path) may pass the metadata-derived universe as a secondary safety net, but it is not sufficient on
+ * its own.
+ *
+ * @param allSchemas the schema universe to scope against
+ * @param config     the config to mutate; `excludeSchemas` is created if absent
+ * @returns the schema names that were newly appended (empty when the scope is unused or already applied)
+ */
+export function applyIncludeSchemaScope(allSchemas: string[], config: SchemaScopeConfig): string[] {
+  if (!config.includeSchemas || config.includeSchemas.length === 0) {
+    return []; // classic exclude-only behavior, unchanged
+  }
+  if (!config.excludeSchemas) {
+    config.excludeSchemas = [];
+  }
+  const toExclude = computeSchemasToExcludeForIncludeList(allSchemas, config.includeSchemas, config.excludeSchemas);
+  config.excludeSchemas.push(...toExclude);
+  return toExclude;
+}

--- a/packages/CodeGenLib/src/Misc/graphql_server_codegen.ts
+++ b/packages/CodeGenLib/src/Misc/graphql_server_codegen.ts
@@ -15,6 +15,31 @@ import { getExternalEntitySchemas, mjCoreSchema, resolveEntityPackageName } from
 import { makeDir, sortBySequenceAndCreatedAt, sortRelatedEntities } from './util';
 
 /**
+ * Describes which GraphQL ObjectTypes are actually resolvable in the file being generated, so the
+ * generator can decide whether a reverse-relationship (child-array) member may reference a related
+ * entity's type by name.
+ *
+ * A reverse-relationship member references the related entity's type by BARE class name, which only
+ * compiles when that class is declared in the same file. This carries the ground truth for that
+ * question — the exact set of entities handed to the generator for this file — instead of inferring
+ * it from schema/package heuristics, which can only ever approximate the set.
+ */
+export interface GeneratedTypeAvailability {
+  /**
+   * Lower-cased, trimmed names of every entity whose ObjectType is emitted inline into the file being
+   * generated. Membership is the compile condition for a bare-name reference.
+   */
+  generatedEntityNames: Set<string>;
+  /**
+   * True when generating the CORE entity file. The core file has NO
+   * `mj_core_schema_server_object_types` namespace import (it *is* that module), so core related
+   * entities must satisfy set membership like everything else. In a non-core file, core types resolve
+   * through that namespace import regardless of the set.
+   */
+  isInternal: boolean;
+}
+
+/**
  * This class is responsible for generating the GraphQL Server resolvers and types for the entities, you can sub-class this class to extend/modify the logic, make sure to use @memberjunction/global RegisterClass decorator
  * so that your class is used.
  */
@@ -26,12 +51,24 @@ export class GraphQLServerGeneratorBase {
     excludeRelatedEntitiesExternalToSchema: boolean
   ): boolean {
     const isInternal = generatedEntitiesImportLibrary.trim().toLowerCase().startsWith('@memberjunction/');
+    // Every entity in THIS call gets its ObjectType emitted inline into the single generated.ts, so this
+    // set is exactly the set of types a reverse-relationship member may reference by bare name.
+    const availability: GeneratedTypeAvailability = {
+      generatedEntityNames: new Set(entities.map((e) => e.Name.trim().toLowerCase())),
+      isInternal,
+    };
     let sRet: string = '';
     try {
       sRet = this.generateAllEntitiesServerFileHeader(entities, generatedEntitiesImportLibrary, isInternal);
 
       for (let i: number = 0; i < entities.length; ++i) {
-        sRet += this.generateServerEntityString(entities[i], false, generatedEntitiesImportLibrary, excludeRelatedEntitiesExternalToSchema);
+        sRet += this.generateServerEntityString(
+          entities[i],
+          false,
+          generatedEntitiesImportLibrary,
+          excludeRelatedEntitiesExternalToSchema,
+          availability
+        );
       }
       makeDir(outputDirectory);
       fs.writeFileSync(path.join(outputDirectory, 'generated.ts'), sRet);
@@ -64,25 +101,43 @@ export class GraphQLServerGeneratorBase {
 
   /**
    * True when the related entity's GraphQL ObjectType will NOT be declared in the file being
-   * generated, so emitting a `@Field`/`@FieldResolver` that names it would not compile.
+   * generated, so emitting a `@Field`/`@FieldResolver` that names it would not compile (TS2304).
    *
-   * Two cases:
-   * - the caller asked for a schema-scoped file (`excludeRelatedEntitiesExternalToSchema`) and the
-   *   related entity is in another schema;
-   * - the related entity's schema is owned by a different npm package (the `entityPackageName`
-   *   schema→package map). `runCodeGen` withholds those entities from the generated set so two
-   *   packages can't both declare an ObjectType for the same entity, so the name is undefined here.
+   * When `availability` is supplied (every in-tree caller supplies it), the decision is made against
+   * the ACTUAL set of entities being generated into this file rather than inferred from schema or
+   * package heuristics. That set is ground truth: a bare-name reference compiles iff the class is
+   * emitted here, and the class is emitted here iff the entity was in the array handed to the
+   * generator. Heuristics can only approximate that set — `runCodeGen` narrows the generated entities
+   * by BOTH the `entityPackageName` schema→package map AND the `excludeSchemas`/inclusion filters, so
+   * a predicate that models only the package map still emits uncompilable references for anything
+   * dropped by the other filter (the linked-Open-App break: a base app generated alongside a
+   * dependent app that foreign-keys into it).
    *
-   * MJ-core-schema related entities are deliberately NOT out of scope: they are absent from the
-   * generated set too, but they resolve through the `mj_core_schema_server_object_types` namespace
-   * import instead of a local declaration.
+   * The one exception is a CORE (`__mj`) related entity in a NON-core file: it is absent from the
+   * generated set but resolves through the `mj_core_schema_server_object_types` namespace import, so
+   * it is always in scope. In the core file itself there is no such import (that file *is* the
+   * module), so core related entities must satisfy set membership like everything else.
+   *
+   * `excludeRelatedEntitiesExternalToSchema` is honored first and unchanged: it asks for a
+   * schema-scoped file, which is a narrower request than type availability.
+   *
+   * @param availability the types resolvable in this file; when omitted, falls back to the legacy
+   *                     `entityPackageName` schema→package heuristic so that existing subclasses and
+   *                     callers using the pre-availability signature keep their previous behavior.
    */
   protected isRelatedTypeOutOfScope(
     entity: EntityInfo,
     relatedEntity: EntityInfo,
-    excludeRelatedEntitiesExternalToSchema: boolean
+    excludeRelatedEntitiesExternalToSchema: boolean,
+    availability?: GeneratedTypeAvailability
   ): boolean {
     if (excludeRelatedEntitiesExternalToSchema && relatedEntity.SchemaName !== entity.SchemaName) return true;
+    if (availability) {
+      // Core types in a non-core file come from the namespace import, not a local declaration.
+      if (relatedEntity.SchemaName === mjCoreSchema && !availability.isInternal) return false;
+      return !availability.generatedEntityNames.has(relatedEntity.Name.trim().toLowerCase());
+    }
+    // Legacy path (no availability supplied): approximate the generated set from the package map.
     if (relatedEntity.SchemaName === mjCoreSchema) return false;
     const schema = relatedEntity.SchemaName.toLowerCase();
     return getExternalEntitySchemas().some((s) => s.toLowerCase() === schema);
@@ -101,7 +156,8 @@ export class GraphQLServerGeneratorBase {
     entity: EntityInfo,
     includeFileHeader: boolean,
     generatedEntitiesImportLibrary: string,
-    excludeRelatedEntitiesExternalToSchema: boolean
+    excludeRelatedEntitiesExternalToSchema: boolean,
+    availability?: GeneratedTypeAvailability
   ): string {
     const isInternal = generatedEntitiesImportLibrary.trim().toLowerCase() === '@memberjunction/core-entities';
     let sEntityOutput: string = '';
@@ -117,7 +173,8 @@ export class GraphQLServerGeneratorBase {
         sEntityOutput = this.generateEntitySpecificServerFileHeader(
           entity,
           resolvedLib,
-          excludeRelatedEntitiesExternalToSchema
+          excludeRelatedEntitiesExternalToSchema,
+          availability
         );
       }
 
@@ -140,7 +197,7 @@ export class GraphQLServerGeneratorBase {
             // Related entity is external (no MJ base view) — its resolver is skipped (see
             // generateServerGraphQLResolver), so skip the paired field declaration too for consistency.
             sEntityOutput += `// Relationship field to ${r.RelatedEntity} not generated: related entity is external (no local base view).\n`;
-          } else if (this.isRelatedTypeOutOfScope(entity, re, excludeRelatedEntitiesExternalToSchema)) {
+          } else if (this.isRelatedTypeOutOfScope(entity, re, excludeRelatedEntitiesExternalToSchema, availability)) {
             sEntityOutput += `// Relationship field to ${r.RelatedEntity} not generated: its GraphQL type is not declared in this file.\n`;
           } else {
             sEntityOutput += this.generateServerRelationship(md, sortedRelatedEntities[j], isInternal);
@@ -157,7 +214,8 @@ export class GraphQLServerGeneratorBase {
         entity,
         serverGraphQLTypeName,
         excludeRelatedEntitiesExternalToSchema,
-        isInternal
+        isInternal,
+        availability
       );
     } catch (err) {
       logError(err as string);
@@ -227,7 +285,8 @@ ${this.generateEntityImports(entities, importLibrary, isInternal)}
   public generateEntitySpecificServerFileHeader(
     entity: EntityInfo,
     importLibrary: string,
-    excludeRelatedEntitiesExternalToSchema: boolean
+    excludeRelatedEntitiesExternalToSchema: boolean,
+    availability?: GeneratedTypeAvailability
   ): string {
     const md = new Metadata(); // global-provider-ok: codegen runs offline against a single provider
     let sRet: string = `/********************************************************************************
@@ -250,7 +309,15 @@ import { ${`${entity.ClassName}Entity`} } from '${importLibrary}';
     for (let i: number = 0; i < sortedRelatedEntities.length; ++i) {
       const r = sortedRelatedEntities[i];
       const re = md.Entities.find((e) => e.Name.toLowerCase() == r.RelatedEntity.toLowerCase())!;
-      if (!this.isRelatedTypeOutOfScope(entity, re, excludeRelatedEntitiesExternalToSchema)) {
+      // This per-entity file imports each related type from a RELATIVE SIBLING file, so the rule here is
+      // narrower than the field gate: a sibling file exists only for an entity generated in this run.
+      // Core types are deliberately NOT sibling-imported — in a non-core file they resolve through the
+      // `mj_core_schema_server_object_types` namespace import, so emitting `./MJUser` would break the
+      // build. Hence set membership directly rather than isRelatedTypeOutOfScope.
+      const emitSiblingImport = availability
+        ? availability.generatedEntityNames.has(re.Name.trim().toLowerCase())
+        : !this.isRelatedTypeOutOfScope(entity, re, excludeRelatedEntitiesExternalToSchema);
+      if (emitSiblingImport) {
         const tableName = sortedRelatedEntities[i].RelatedEntityBaseTableCodeName;
         sRet += `\nimport ${tableName} from './${tableName}';`;
       }
@@ -352,7 +419,8 @@ export class ${serverGraphQLTypeName} {`;
     entity: EntityInfo,
     serverGraphQLTypeName: string,
     excludeRelatedEntitiesExternalToSchema: boolean,
-    isInternal: boolean
+    isInternal: boolean,
+    availability?: GeneratedTypeAvailability
   ): string {
     const md = new Metadata(); // global-provider-ok: codegen runs offline against a single provider
     const typeNameBase = this.getServerGraphQLTypeNameBase(entity);
@@ -498,7 +566,7 @@ export class ${typeNameBase}Resolver${entity.CustomResolverAPI ? 'Base' : ''} ex
             // than emit a resolver that fails at runtime (external rows are reachable via that entity's
             // own RunView with a filter on the join column).
             sRet += `// Relationship to ${r.RelatedEntity} not generated: related entity is external (no local base view to query).\n`;
-          } else if (this.isRelatedTypeOutOfScope(entity, re, excludeRelatedEntitiesExternalToSchema)) {
+          } else if (this.isRelatedTypeOutOfScope(entity, re, excludeRelatedEntitiesExternalToSchema, availability)) {
             sRet += `// Relationship to ${r.RelatedEntity} not generated: its GraphQL type is not declared in this file.\n`;
           } else {
             if (r.Type.toLowerCase().trim() == 'many to many') sRet += this.generateManyToManyFieldResolver(entity, r);

--- a/packages/CodeGenLib/src/__tests__/graphql-type-availability.test.ts
+++ b/packages/CodeGenLib/src/__tests__/graphql-type-availability.test.ts
@@ -1,0 +1,183 @@
+/**
+ * Reverse-relationship emission is gated on TYPE AVAILABILITY, not on schema/package heuristics.
+ *
+ * A reverse-relationship (child-array) `@Field`/`@FieldResolver` references the related entity's
+ * GraphQL type by BARE class name, so it only compiles when that class is declared in the file being
+ * generated. `GeneratedTypeAvailability` carries the exact set of entities handed to the generator for
+ * the file, which is ground truth for that question.
+ *
+ * Why the set and not a heuristic: `runCodeGen` narrows the generated entity list by BOTH the
+ * `entityPackageName` schema→package map AND the `excludeSchemas`/inclusion filters. A predicate that
+ * models only the package map still emits uncompilable references for anything dropped by the other
+ * filter — which is exactly the linked-Open-App break (a base app generated alongside a dependent app
+ * that foreign-keys into it emits fields typed with the dependent's classes → TS2304).
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const configState: { entityPackageName: string | Record<string, string> } = {
+    entityPackageName: 'mj_generatedentities',
+};
+
+vi.mock('../Config/config', () => ({
+    mjCoreSchema: '__mj',
+    resolveEntityPackageName: (schema: string) => {
+        const epn = configState.entityPackageName;
+        if (typeof epn === 'string') return epn;
+        const hit = Object.keys(epn).find((k) => k.toLowerCase() === schema.toLowerCase());
+        return hit ? epn[hit] : 'mj_generatedentities';
+    },
+    getExternalEntitySchemas: () =>
+        typeof configState.entityPackageName === 'string' ? [] : Object.keys(configState.entityPackageName),
+}));
+
+import { GraphQLServerGeneratorBase, GeneratedTypeAvailability } from '../Misc/graphql_server_codegen';
+import { Metadata } from '@memberjunction/core';
+
+function field(name: string, type = 'uniqueidentifier') {
+    return {
+        Name: name,
+        CodeName: name,
+        Type: type,
+        AllowsNull: false,
+        MaxLength: 16,
+        Description: '',
+        Sequence: 1,
+        IsVirtual: false,
+        __mj_CreatedAt: new Date(0),
+    };
+}
+
+function entity(opts: { name: string; schema: string; related?: object[] }) {
+    const codeName = opts.name.replace(/[ :]/g, '');
+    const fields = [field('ID'), field('Name', 'nvarchar')];
+    return {
+        Name: opts.name,
+        ClassName: codeName,
+        BaseTable: codeName,
+        BaseTableCodeName: codeName,
+        BaseView: `vw${codeName}`,
+        SchemaName: opts.schema,
+        Description: '',
+        IncludeInAPI: true,
+        ExternalDataSourceID: null,
+        AllowCreateAPI: false,
+        AllowUpdateAPI: false,
+        AllowDeleteAPI: false,
+        Fields: fields,
+        FirstPrimaryKey: fields[0],
+        PrimaryKeys: [fields[0]],
+        RelatedEntities: opts.related ?? [],
+        _floatCount: 0,
+    };
+}
+
+function oneToMany(relatedName: string) {
+    const codeName = relatedName.replace(/[ :]/g, '');
+    return {
+        ID: `rel-${codeName}`,
+        Type: 'One To Many',
+        RelatedEntity: relatedName,
+        RelatedEntityCodeName: codeName,
+        RelatedEntityBaseView: `vw${codeName}`,
+        RelatedEntityBaseTableCodeName: codeName,
+        RelatedEntityJoinField: 'OwnerID',
+        EntityKeyField: '',
+        DisplayInForm: true,
+        Sequence: 1,
+        __mj_CreatedAt: new Date(0),
+    };
+}
+
+// A base Open App entity with a child in a DEPENDENT app's schema. Neither schema is in the package
+// map — the dependent is simply not part of this generation run.
+const COMMON_PERSON = entity({
+    name: 'MJ_BizApps_Common: Person',
+    schema: '__mj_BizAppsCommon',
+    related: [oneToMany('MJ_BizApps_Tasks: Task Comment')],
+});
+const TASKS_COMMENT = entity({ name: 'MJ_BizApps_Tasks: Task Comment', schema: '__mj_BizAppsTasks' });
+// A local entity whose child lives in the MJ core schema.
+const COMMON_NOTE = entity({
+    name: 'MJ_BizApps_Common: Note',
+    schema: '__mj_BizAppsCommon',
+    related: [oneToMany('Users')],
+});
+const CORE_USER = entity({ name: 'Users', schema: '__mj' });
+// Monolith: two app schemas emitted into one file, with a cross-schema relationship.
+const SALES_ORDER = entity({ name: 'Sales: Order', schema: 'sales', related: [oneToMany('CRM: Contact')] });
+const CRM_CONTACT = entity({ name: 'CRM: Contact', schema: 'crm' });
+
+const ALL = [COMMON_PERSON, TASKS_COMMENT, COMMON_NOTE, CORE_USER, SALES_ORDER, CRM_CONTACT];
+
+function availability(names: string[], isInternal = false): GeneratedTypeAvailability {
+    return {
+        generatedEntityNames: new Set(names.map((n) => n.trim().toLowerCase())),
+        isInternal,
+    };
+}
+
+function generate(e: object, avail?: GeneratedTypeAvailability): string {
+    return new GraphQLServerGeneratorBase().generateServerEntityString(
+        e as never,
+        false,
+        '@mj-biz-apps/bizapps-common',
+        false,
+        avail,
+    );
+}
+
+describe('GraphQL codegen: reverse-relationship type-availability gate', () => {
+    beforeEach(() => {
+        vi.spyOn(Metadata.prototype, 'Entities', 'get').mockReturnValue(ALL as never);
+        vi.spyOn(Metadata.prototype, 'EntityByName').mockImplementation(
+            ((n: string) => ALL.find((e) => e.Name.toLowerCase() === n.toLowerCase())) as never,
+        );
+        configState.entityPackageName = 'mj_generatedentities';
+    });
+
+    it('EMITS a reverse relationship whose related type is generated in this file', () => {
+        const out = generate(COMMON_PERSON, availability(['MJ_BizApps_Common: Person', 'MJ_BizApps_Tasks: Task Comment']));
+        expect(out).toContain('MJ_BizApps_TasksTaskComment_OwnerIDArray');
+        expect(out).not.toContain('not generated: its GraphQL type is not declared in this file');
+    });
+
+    it('DROPS a reverse relationship into a schema NOT generated in this file (the linked-Open-App fix)', () => {
+        // The dependent app is absent from this run but is NOT in the entityPackageName map, so the
+        // legacy package heuristic would wrongly emit here. Availability catches it.
+        const out = generate(COMMON_PERSON, availability(['MJ_BizApps_Common: Person']));
+        expect(out).not.toContain('MJ_BizApps_TasksTaskComment_OwnerIDArray');
+        // Both the @Field member and its @FieldResolver must be dropped together.
+        expect(out).toContain('Relationship field to MJ_BizApps_Tasks: Task Comment not generated');
+        expect(out).toContain('Relationship to MJ_BizApps_Tasks: Task Comment not generated');
+    });
+
+    it('LEGACY (no availability): the package-map heuristic is preserved for existing callers', () => {
+        // Same input, no availability supplied → falls back to the schema→package heuristic, which with
+        // no map declared emits the relationship. This is what pre-existing subclasses/callers get.
+        const out = generate(COMMON_PERSON);
+        expect(out).toContain('MJ_BizApps_TasksTaskComment_OwnerIDArray');
+    });
+
+    it('EMITS a CORE related type in a NON-core file even when absent from the set (namespace import)', () => {
+        const out = generate(COMMON_NOTE, availability(['MJ_BizApps_Common: Note']));
+        expect(out).toContain('mj_core_schema_server_object_types.MJUsers_');
+    });
+
+    it('DROPS a CORE related type in the CORE file itself when absent from the set (no namespace import there)', () => {
+        // The core file IS the mj_core_schema_server_object_types module, so there is nothing to
+        // namespace-import from; a core child must satisfy set membership like anything else.
+        const out = generate(COMMON_NOTE, availability(['MJ_BizApps_Common: Note'], /* isInternal */ true));
+        expect(out).toContain('Relationship field to Users not generated');
+    });
+
+    it('MONOLITH: cross-schema relationships survive because every class is in the one generated set', () => {
+        const out = generate(SALES_ORDER, availability(['Sales: Order', 'CRM: Contact']));
+        expect(out).toContain('CRMContact_OwnerIDArray');
+        expect(out).not.toContain('not generated: its GraphQL type is not declared in this file');
+    });
+
+    it('matches set membership case-insensitively and trims', () => {
+        const out = generate(SALES_ORDER, availability(['  sales: ORDER ', '  crm: contact  ']));
+        expect(out).toContain('CRMContact_OwnerIDArray');
+    });
+});

--- a/packages/CodeGenLib/src/__tests__/schema-scope.test.ts
+++ b/packages/CodeGenLib/src/__tests__/schema-scope.test.ts
@@ -1,0 +1,97 @@
+import { describe, it, expect } from 'vitest';
+import { applyIncludeSchemaScope, computeSchemasToExcludeForIncludeList } from '../Database/schema-scope';
+
+/**
+ * Unit tests for the `includeSchemas` → `excludeSchemas` resolution.
+ * The rule: in-scope ⇔ named in includeSchemas AND not already excluded; everything else in the schema
+ * universe is returned for exclusion. This is the single mechanism by which the positive scope becomes
+ * sugar over the existing negative `excludeSchemas` list.
+ */
+describe('computeSchemasToExcludeForIncludeList', () => {
+  it('excludes every schema not named in includeSchemas (the core scoping behavior)', () => {
+    const all = ['__mj_BizAppsCommon', '__mj_BizAppsTasks', 'dbo', '__mj', 'sys', 'staging'];
+    const result = computeSchemasToExcludeForIncludeList(all, ['__mj_BizAppsCommon'], ['sys', 'staging']);
+    // common is included; sys/staging already excluded (not re-added); everything else is excluded.
+    expect(result.sort()).toEqual(['__mj', '__mj_BizAppsTasks', 'dbo'].sort());
+  });
+
+  it('keeps an included schema IN scope (not returned for exclusion)', () => {
+    const result = computeSchemasToExcludeForIncludeList(['app_a', 'app_b'], ['app_a'], []);
+    expect(result).toEqual(['app_b']);
+    expect(result).not.toContain('app_a');
+  });
+
+  it('does NOT auto-include the core schema — __mj is excluded unless listed', () => {
+    const result = computeSchemasToExcludeForIncludeList(['app_a', '__mj'], ['app_a'], []);
+    expect(result).toContain('__mj');
+  });
+
+  it('DOES keep the core schema in scope when it is explicitly listed', () => {
+    const result = computeSchemasToExcludeForIncludeList(['app_a', '__mj'], ['app_a', '__mj'], []);
+    expect(result).toEqual([]); // both listed → nothing excluded
+  });
+
+  it('matches include + exclude case-insensitively and trims', () => {
+    const all = ['__mj_BizAppsCommon', '__mj_BizAppsTasks'];
+    const result = computeSchemasToExcludeForIncludeList(all, ['  __MJ_bizappscommon '], ['__MJ_BIZAPPSTASKS']);
+    // common is included (case-insensitive) → not excluded; tasks already excluded → not re-added.
+    expect(result).toEqual([]);
+  });
+
+  it('does not re-add a schema already present in existingExcludeSchemas', () => {
+    const result = computeSchemasToExcludeForIncludeList(['dbo', 'sys'], ['app_a'], ['sys']);
+    expect(result).toEqual(['dbo']);
+  });
+
+  it('de-duplicates repeated schemas in the universe', () => {
+    const result = computeSchemasToExcludeForIncludeList(['dbo', 'dbo', 'sys'], ['app_a'], []);
+    expect(result).toEqual(['dbo', 'sys']);
+  });
+});
+
+describe('applyIncludeSchemaScope', () => {
+  it('is a NO-OP when includeSchemas is absent — classic exclude-only behavior is unchanged', () => {
+    const config = { excludeSchemas: ['sys', 'staging'] };
+    const added = applyIncludeSchemaScope(['dbo', 'app_a', 'sys'], config);
+    expect(added).toEqual([]);
+    expect(config.excludeSchemas).toEqual(['sys', 'staging']);
+  });
+
+  it('is a NO-OP when includeSchemas is an empty array', () => {
+    const config = { includeSchemas: [], excludeSchemas: ['sys'] };
+    applyIncludeSchemaScope(['dbo', 'app_a'], config);
+    expect(config.excludeSchemas).toEqual(['sys']);
+  });
+
+  it('appends out-of-scope schemas to excludeSchemas in place', () => {
+    const config = { includeSchemas: ['app_a'], excludeSchemas: ['sys'] };
+    applyIncludeSchemaScope(['app_a', 'app_b', 'dbo', 'sys'], config);
+    expect(config.excludeSchemas).toEqual(['sys', 'app_b', 'dbo']);
+  });
+
+  it('creates excludeSchemas when the config has none', () => {
+    const config: { includeSchemas?: string[]; excludeSchemas?: string[] } = { includeSchemas: ['app_a'] };
+    applyIncludeSchemaScope(['app_a', 'app_b'], config);
+    expect(config.excludeSchemas).toEqual(['app_b']);
+  });
+
+  it('is IDEMPOTENT — the metadata-phase and file-phase passes may both run', () => {
+    // manageMetadata resolves against the DB schema list; runCodeGen resolves again against the
+    // metadata schema list (for --skipdb). The second pass must not duplicate entries.
+    const config = { includeSchemas: ['app_a'], excludeSchemas: ['sys'] };
+    applyIncludeSchemaScope(['app_a', 'app_b', 'dbo'], config);
+    const secondPass = applyIncludeSchemaScope(['app_a', 'app_b', 'dbo'], config);
+    expect(secondPass).toEqual([]);
+    expect(config.excludeSchemas).toEqual(['sys', 'app_b', 'dbo']);
+  });
+
+  it('excludes a schema that has NO entities in metadata yet (the never-before-seen schema case)', () => {
+    // This is why the authoritative pass sources its universe from the DATABASE: createNewEntities()
+    // discovers tables with no EntityID, so a client schema absent from Metadata.Entities must still be
+    // excluded or it gets adopted on the first run and orphaned on every run after.
+    const config = { includeSchemas: ['app_a'], excludeSchemas: [] as string[] };
+    const dbSchemas = ['app_a', 'client_private']; // client_private has zero MJ entities
+    applyIncludeSchemaScope(dbSchemas, config);
+    expect(config.excludeSchemas).toContain('client_private');
+  });
+});

--- a/packages/CodeGenLib/src/runCodeGen.ts
+++ b/packages/CodeGenLib/src/runCodeGen.ts
@@ -11,6 +11,7 @@ import { GraphQLServerGeneratorBase } from './Misc/graphql_server_codegen';
 import { SQLCodeGenBase } from './Database/sql_codegen';
 import { EntitySubClassGeneratorBase } from './Misc/entity_subclasses_codegen';
 import { ManageMetadataBase } from './Database/manage-metadata';
+import { applyIncludeSchemaScope } from './Database/schema-scope';
 import { outputDir, commands, configInfo, getSettingValue, dbPlatform, getExternalEntitySchemas, initializeConfig, CommandInfo } from './Config/config';
 import { logError, logStatus, logWarning, startSpinner, updateSpinner, succeedSpinner, failSpinner, warnSpinner } from './Misc/status_logging';
 import { CodeGenReporter } from './Misc/codegen-reporter';
@@ -206,6 +207,14 @@ export class RunCodeGenBase {
         }
         return m;
       });
+
+      // Secondary application of the opt-in `includeSchemas` scope, against the schemas present in
+      // metadata. The authoritative pass runs inside ManageMetadataBase.manageMetadata against the
+      // DATABASE's schema list (it is the one that can see never-before-seen schemas); this one exists
+      // so the scope still applies on the `--skipdb` path, which skips manageMetadata entirely but
+      // still generates files from configInfo.excludeSchemas. applyIncludeSchemaScope is idempotent, so
+      // running both is safe and the second pass is a no-op when the first already ran.
+      applyIncludeSchemaScope(Array.from(new Set(md.Entities.map((e) => e.SchemaName))), configInfo);
 
       const runCommandsObject = MJGlobal.Instance.ClassFactory.CreateInstance<RunCommandsBase>(RunCommandsBase)!;
       const sqlCodeGenObject = MJGlobal.Instance.ClassFactory.CreateInstance<SQLCodeGenBase>(SQLCodeGenBase)!;


### PR DESCRIPTION
Replaces #3304, rebuilt cleanly on current `next`. See that PR for the original diagnosis and the live-instance validation — this carries forward its sharper mechanism and adds a fix for a hole in its `includeSchemas` design.

## Why this exists rather than a rebase of #3304

#3304 branched from `next` at `2ded59e1` (Jul 27, 10:57). Later that day, `f96804b9c` ("fix(codegen): omit relationship members whose GraphQL type was withheld", 18:30) landed on `next` and fixed the same TS2304 break via `isRelatedTypeOutOfScope`. #3304 went un-mergeable and the two fixes needed reconciling rather than stacking. This PR keeps `next`'s method name, signature shape, and drop-comment output, and replaces only the predicate body.

## Change A — decide from the generated set, not a heuristic

A reverse-relationship (child-array) `@Field`/`@FieldResolver` references the related entity's GraphQL type by **bare class name**, so it only compiles when that class is declared in the file being generated. `isRelatedTypeOutOfScope` now answers that from `GeneratedTypeAvailability` — the exact set of entities handed to the generator for this file — with one exception: a core (`__mj`) related entity in a **non-core** file, which resolves through the `mj_core_schema_server_object_types` namespace import.

The predicate on `next` infers the generated set from the `entityPackageName` schema→package map alone. But `runCodeGen` narrows the entity list by **both** that map and the `excludeSchemas`/inclusion filters (`runCodeGen.ts:499-511`), so anything dropped by the latter still yields a dangling reference. That is the linked-Open-App break: a base app generated alongside a dependent app that foreign-keys into it emits fields typed with the dependent's classes. The set is ground truth — it cannot drift from what was actually emitted.

The gate emits exactly the **compilable subset** of prior output: an un-emitted class yields a reference that cannot compile, and the gate emits iff the reference is resolvable. Any run that compiled before produces identical output. Monoliths are unaffected — every schema's class is in the one generated set, so cross-schema relationships stay emitted.

**In the core pass**, a core related entity must now satisfy set membership too. The core file *is* the `mj_core_schema_server_object_types` module, so there is no namespace import to resolve through — `next`'s unconditional core exemption was wrong there, though only reachable for a core entity excluded by a non-schema filter.

Signature changes are **additive** — a new optional trailing `availability` parameter on `generateGraphQLServerCode`, `generateServerEntityString`, `generateEntitySpecificServerFileHeader`, and `generateServerGraphQLResolver`. Omitting it preserves the previous heuristic exactly. `GraphQLServerGeneratorBase` is documented as a `RegisterClass` extension point, so removing the existing parameter would break customer subclasses silently; the legacy fallback is covered by a test.

Also fixed on the way through: the per-entity file header emits **relative sibling** imports, so it needs set membership directly — a core type there comes from the namespace import and must not get a `./MJUser` sibling import.

## Change B — opt-in `includeSchemas` positive scope

When set, CodeGen processes only the listed schemas. Pure sugar over `excludeSchemas` (in-scope ⇔ listed ∧ not excluded; no implicit includes — core must be listed explicitly). Absent/empty leaves classic exclude-only behavior untouched.

**The resolution is sourced from the database, not from loaded metadata.** `createNewEntities()` discovers tables with no `EntityID` straight from the DB, filtered only through `excludeSchemas`. A universe derived from `Metadata.Entities` contains by definition only schemas that *already* have entities, so it cannot exclude a never-before-seen schema — precisely the case the feature exists for (a client's own schemas in a deployed instance). That schema would be adopted into metadata on the first run and then excluded on every run after, leaving its entity records permanently orphaned. So:

- **Authoritative pass** in `ManageMetadataBase.manageMetadata`, against `SELECT DISTINCT SchemaName FROM vwSQLTablesAndEntities`, before `createNewEntities()`. If that query fails the run aborts — an include list that silently doesn't apply can create entity metadata for another app's tables.
- **Secondary idempotent pass** in `runCodeGen`, against the metadata schema list, so the scope still applies on `--skipdb` (which bypasses `manageMetadata` entirely but still generates files).

## Testing

- `packages/CodeGenLib` unit suite: **642 passed, 0 failed, 60 skipped** (skipped = PG integration tests, which need a database).
- New `graphql-type-availability.test.ts` covers: emit-when-in-set; drop-when-not-in-set where the schema is *not* in the package map (the case the old heuristic missed); the legacy no-availability fallback; core-in-non-core emitted via namespace import; core-in-core-file dropped when absent from the set; monolith cross-schema preserved; case-insensitive matching.
- New `schema-scope.test.ts` covers the include→exclude resolution, no-op when unset, idempotency across the two passes, and the never-before-seen-schema case.
- The two pre-existing GraphQL codegen suites pass unchanged, which is what demonstrates the additive signature preserved old behavior.

**Not run here:** the deterministic integration tier — this environment has no database. Worth running before merge.

**Not reproduced here:** #3304's live-instance numbers (`bizapps-common` 20 cross-package refs → 0, clean build). Those came from a linked Open App instance I have no way to stand up; they are cited as the origin of the diagnosis, not as something re-verified.

## Scope

Confined to `@memberjunction/codegen-lib`. Changeset is **minor** (new config surface), not patch.

The pre-existing hazard #3304 flagged — destructive CodeGen paths assuming full-database visibility (Angular orphan-dir deletion, whole-file GeneratedEntities rewrite, the CRUD validator) — is **not** touched here and should be hardened before CodeGen scope narrows further.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UUnZf9oDYm3c9No7toVfFc

---
_Generated by [Claude Code](https://claude.ai/code/session_01UUnZf9oDYm3c9No7toVfFc)_