### PR TITLE
fix(search): use UUIDsEqual in buildLaneExplanations — unbreaks Unit Tests on next

### DIFF
--- a/.changeset/search-engine-uuid-lane-comparisons.md
+++ b/.changeset/search-engine-uuid-lane-comparisons.md
@@ -1,0 +1,7 @@
+---
+"@memberjunction/search-engine": patch
+---
+
+Use `UUIDsEqual` instead of `===` when matching rendered constraints to their scope rows in `SearchEngine.buildLaneExplanations` (external-index, entity and storage-account lanes).
+
+PostgreSQL returns UUIDs lowercased where SQL Server returns them uppercased, so on a case mismatch the `find` returned `undefined` and the lane reported `RenderedFilter: null` — `ExplainScope` telling an admin a lane carries no filter when it does. Silent, and a wrong answer from the one feature whose purpose is answering that question. Also unbreaks the `Unit Tests` job on `next`, where the repo's `UUIDCompliance` gate flagged the three comparisons.

--- a/packages/SearchEngine/src/generic/SearchEngine.ts
+++ b/packages/SearchEngine/src/generic/SearchEngine.ts
@@ -1035,7 +1035,7 @@ export class SearchEngine extends BaseSingleton<SearchEngine> {
         const lanes: LaneExplanation[] = [];
 
         for (const row of bundle.ExternalIndexes) {
-            const rendered = constraints.ExternalIndexes?.find((c) => c.SearchScopeExternalIndexID === row.ID);
+            const rendered = constraints.ExternalIndexes?.find((c) => UUIDsEqual(c.SearchScopeExternalIndexID, row.ID));
             lanes.push({
                 Kind: 'ExternalIndex',
                 Target: row.ExternalIndexName ?? row.ID,
@@ -1048,7 +1048,7 @@ export class SearchEngine extends BaseSingleton<SearchEngine> {
         }
 
         for (const row of bundle.Entities) {
-            const rendered = constraints.Entities?.find((c) => c.SearchScopeEntityID === row.ID);
+            const rendered = constraints.Entities?.find((c) => UUIDsEqual(c.SearchScopeEntityID, row.ID));
             lanes.push({
                 Kind: 'Entity',
                 Target: this.lookupEntityName(row.EntityID) || row.EntityID,
@@ -1061,7 +1061,7 @@ export class SearchEngine extends BaseSingleton<SearchEngine> {
         }
 
         for (const row of bundle.StorageAccounts) {
-            const rendered = constraints.StorageAccounts?.find((c) => c.SearchScopeStorageAccountID === row.ID);
+            const rendered = constraints.StorageAccounts?.find((c) => UUIDsEqual(c.SearchScopeStorageAccountID, row.ID));
             lanes.push({
                 Kind: 'StorageAccount',
                 Target: row.FileStorageAccountID,


### PR DESCRIPTION
## Summary

`next` is red. The merge of #3339 turned the `Unit Tests` job red: `UUIDCompliance` flagged three direct `===` UUID comparisons in `SearchEngine.buildLaneExplanations`. One failing test out of 586 — the Integration Tier, `Test migrations`, PostgreSQL parity and Build jobs all passed on the same commit, so this is a single-cause failure.

This replaces those three comparisons with `UUIDsEqual`, which was already imported and already used elsewhere in the same file.

## Changes

`packages/SearchEngine/src/generic/SearchEngine.ts` — three lines:

```diff
-const rendered = constraints.ExternalIndexes?.find((c) => c.SearchScopeExternalIndexID === row.ID);
+const rendered = constraints.ExternalIndexes?.find((c) => UUIDsEqual(c.SearchScopeExternalIndexID, row.ID));
```

…and the equivalent for the `Entities` and `StorageAccounts` lanes.

## Not only a compliance nit

PostgreSQL returns UUIDs lowercased where SQL Server returns them uppercased. On a case mismatch the `find` returns `undefined`, so the lane reports `RenderedFilter: null` — `ExplainScope` telling an admin a lane carries **no filter** when it does. That is a wrong answer from the one feature whose entire job is answering that question, and it would have been silent.

## Why #3339's CI was green

Worth flagging, because it means the gate is not currently protecting most PRs.

`turbo.json` declares the `test` task's inputs as package-local:

```
"inputs": ["src/**/*.ts", "src/**/*.tsx", "src/**/__tests__/**", ...]
```

`UUIDCompliance` lives in `@memberjunction/global` but scans all of `packages/`. Its cache key therefore excludes `packages/SearchEngine/src/**`, so #3339 restored a cached pass and never executed the gate against the new code. **The gate is effectively inert on any PR that does not touch MJGlobal.**

Deliberately not fixed here — widening those inputs changes caching behaviour repo-wide and deserves its own PR rather than riding along with a red-main fix. Happy to open one.

Note this also means *this* PR's own `Unit Tests` job may go green by restoring a cached pass without re-running the gate. The meaningful signal is the post-merge run on `next`, which will re-execute for real — turbo does not cache failures, so the failed task is not memoised.

## Tests

- `packages/SearchEngine` — **427 tests / 30 files pass**
- A replica of the gate's own scan (same regexes, same exclusion list) reports **zero** SearchEngine violations; the other 40 repo-wide matches are pre-existing `KNOWN_EXCEPTIONS`
- Branch is a direct descendant of `b3e14188c`, the current `next` head and the commit that broke it — no rebase needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)