### PR TITLE
chore(release): v5.50.0 prep — PG counterpart, manifests, TS4111 fix

### DIFF
--- a/.changeset/fix-manifest-openapp-globalthis-index-access.md
+++ b/.changeset/fix-manifest-openapp-globalthis-index-access.md
@@ -1,0 +1,26 @@
+---
+"@memberjunction/cli": patch
+---
+
+Fix TS4111 in the Open App client manifest so MJExplorer can build when Open Apps are present
+
+`mj codegen manifest --open-app-client-bootstrap` emitted its `globalThis` anchor using dot
+access on a property that comes from an index signature (`globalThis` is cast to
+`Record<string, unknown>`). Consumers compile that generated file under their own tsconfig, and
+MJExplorer sets `noPropertyAccessFromIndexSignature: true` — so the generated manifest failed to
+type-check and the Explorer build exited 1 having emitted zero JS. `ng serve` printed
+"Watch mode enabled" after the error and then served nothing, which made it easy to misread as a
+working dev server.
+
+The anchor now uses bracket access. Runtime behavior is unchanged — JavaScript draws no
+distinction between dot- and bracket-written properties — and bracket access is valid under every
+strictness configuration, so no consumer is made worse.
+
+This affected any installation with at least one Open App in `dynamicPackages.client`, whether
+installed via `mj app install` or dev-linked. MJ core has none, which is why its CI never
+generated the line and never type-checked it.
+
+The regression escaped because the generator's test asserted the emitted *string* — it passed
+precisely because the text matched, while that text did not compile in the consumer. The test
+now type-checks the generated output under `noPropertyAccessFromIndexSignature` instead, so a
+type error in generated code fails here rather than in a downstream build.

--- a/migrations-pg/v5/V202607290900__v5.50.x__Scoped_Search_Dimensional_Bounds.pg.sql
+++ b/migrations-pg/v5/V202607290900__v5.50.x__Scoped_Search_Dimensional_Bounds.pg.sql
@@ -1,0 +1,4346 @@
+-- ============================================================================
+-- MemberJunction PostgreSQL Migration — V202607290900__v5.50.x__Scoped_Search_Dimensional_Bounds.sql
+-- Split-and-regenerate with INLINE NATIVE CodeGen baking: hand-written DDL transpiled
+-- (AST dialect), metadata DML inline, and CodeGen objects (views/sprocs/triggers/grants)
+-- baked natively from `mj codegen`. Applies standalone via `mj migrate` — no deploy codegen.
+-- ============================================================================
+
+CREATE EXTENSION IF NOT EXISTS "pgcrypto";
+CREATE SCHEMA IF NOT EXISTS __mj;
+SET search_path TO __mj, public;
+SET standard_conforming_strings = on;
+
+ALTER TABLE __mj."AISkill"
+ADD COLUMN "SearchScopeAccess" VARCHAR(20) NULL /* ############################################################################ */ /* A. A SKILL principal, plus tenant + time scoping on scope grants */ /* ############################################################################ */ /* 1. AISkill.SearchScopeAccess - the skill principal. NULL behaves as None, keeping every */ /*    existing skill inert. */;
+
+ALTER TABLE __mj."AISkill"
+  ADD CONSTRAINT "CK_AISkill_SearchScopeAccess" CHECK ("SearchScopeAccess" IS NULL OR "SearchScopeAccess" IN ('None', 'Assigned', 'All'));
+
+COMMENT ON COLUMN __mj."AISkill"."SearchScopeAccess" IS 'Which Search Scopes this skill may reach when activated. None = grants no retrieval scope; Assigned = only scopes listed in AISkillSearchScope; All = any active scope. NULL behaves as None so existing skills are unaffected. Mirrors AIAgent.SearchScopeAccess so a skill and an agent are interchangeable principals to SearchScopePermissionResolver.';
+
+/* 2. AISkillSearchScope - skill-keyed grant rows, mirroring AIAgentSearchScope. */
+CREATE TABLE __mj."AISkillSearchScope" (
+  "ID" UUID NOT NULL DEFAULT (
+    GEN_RANDOM_UUID()
+  ),
+  "SkillID" UUID NOT NULL,
+  "SearchScopeID" UUID NOT NULL,
+  "Status" VARCHAR(20) NOT NULL DEFAULT (
+    'Active'
+  ),
+  "StartAt" TIMESTAMPTZ NULL,
+  "EndAt" TIMESTAMPTZ NULL,
+  "Priority" INT NULL,
+  "IsDefault" BOOLEAN NOT NULL DEFAULT FALSE,
+  CONSTRAINT "PK_AISkillSearchScope" PRIMARY KEY ("ID"),
+  CONSTRAINT "FK_AISkillSearchScope_Skill" FOREIGN KEY ("SkillID") REFERENCES __mj."AISkill" (
+    "ID"
+  ),
+  CONSTRAINT "FK_AISkillSearchScope_SearchScope" FOREIGN KEY ("SearchScopeID") REFERENCES __mj."SearchScope" (
+    "ID"
+  ),
+  CONSTRAINT "CK_AISkillSearchScope_Status" CHECK ("Status" IN ('Active', 'Inactive')),
+  CONSTRAINT "UQ_AISkillSearchScope" UNIQUE (
+    "SkillID",
+    "SearchScopeID"
+  )
+);
+
+COMMENT ON TABLE __mj."AISkillSearchScope" IS 'Search Scopes an AI Skill may reach when activated, honoured when AISkill.SearchScopeAccess = ''Assigned''. Mirrors AIAgentSearchScope: Status plus an optional StartAt/EndAt window time-box a grant, and Priority/IsDefault pick among several. An empty table means no skill grants any scope - the pre-migration behaviour.';
+
+COMMENT ON COLUMN __mj."AISkillSearchScope"."SkillID" IS 'The skill this grant belongs to.';
+
+COMMENT ON COLUMN __mj."AISkillSearchScope"."SearchScopeID" IS 'The Search Scope this skill may reach.';
+
+COMMENT ON COLUMN __mj."AISkillSearchScope"."Status" IS 'Active or Inactive. Inactive rows are ignored during resolution.';
+
+COMMENT ON COLUMN __mj."AISkillSearchScope"."StartAt" IS 'Optional start of the window in which this grant is honoured. NULL = no lower bound. Evaluated against the current time on every resolution, so a window opening or closing needs no cache invalidation.';
+
+COMMENT ON COLUMN __mj."AISkillSearchScope"."EndAt" IS 'Optional end of the window in which this grant is honoured. NULL = no upper bound.';
+
+COMMENT ON COLUMN __mj."AISkillSearchScope"."Priority" IS 'Lower numbers win when several granted scopes are candidates and none is marked IsDefault.';
+
+COMMENT ON COLUMN __mj."AISkillSearchScope"."IsDefault" IS 'When set, this scope is chosen for the skill ahead of Priority ordering.';
+
+ALTER TABLE __mj."SearchScopePermission"
+  ADD COLUMN "StartAt" TIMESTAMPTZ NULL,
+  ADD COLUMN "EndAt" TIMESTAMPTZ NULL,
+  ADD COLUMN "PrimaryScopeRecordID" UUID NULL
+ /* 3 + 4. SearchScopePermission - a time window and a tenant key on the grant itself. */;
+
+COMMENT ON COLUMN __mj."SearchScopePermission"."StartAt" IS 'Optional start of the window in which this grant applies. NULL = no lower bound. SearchScopePermission was the only member of this family without a time window, so temporary grants previously needed a bespoke mechanism.';
+
+COMMENT ON COLUMN __mj."SearchScopePermission"."EndAt" IS 'Optional end of the window in which this grant applies. NULL = no upper bound.';
+
+COMMENT ON COLUMN __mj."SearchScopePermission"."PrimaryScopeRecordID" IS 'Optional tenant this grant is limited to, matched against SearchContext.PrimaryScopeRecordID at search time and type-checkable against the scope''s own PrimaryScopeEntityID. NULL = applies to every tenant, which is the pre-migration behaviour for all existing rows. Deliberately NOT called OrganizationID: MJ is domain-agnostic and a scope''s primary scope may be a Company, Client or Practice, so this reuses the existing primary-scope concept rather than inventing a parallel tenancy column.';
+
+ALTER TABLE __mj."SearchScopeExternalIndex"
+ADD COLUMN "RequiredMetadataKeys" TEXT NULL /* ############################################################################ */ /* B. The ingest label contract, and decision provenance on the execution log */ /* ############################################################################ */ /* ───────────────────────────────────────────────────────────────────────────────────── */ /* PHASE E: the ingest label contract */ /* ───────────────────────────────────────────────────────────────────────────────────── */;
+
+COMMENT ON COLUMN __mj."SearchScopeExternalIndex"."RequiredMetadataKeys" IS 'JSON array of metadata key names the rendered MetadataFilter MUST constrain on for this lane to be considered safe, e.g. ["OrganizationID","ContentSourceID"]. Checked against the RENDERED filter at search time: if a key is missing the lane is SKIPPED rather than queried, because a partially-rendered filter silently widens the search. This also documents the ingest contract — these are the labels the writer must stamp on every document in the index, since a filter on a key that was never written either matches nothing or (on providers that ignore unknown keys) matches everything. NULL = no contract declared, which is the pre-migration behaviour.';
+
+ALTER TABLE __mj."SearchExecutionLog"
+  ADD COLUMN "AISkillID" UUID NULL,
+  ADD COLUMN "PrimaryScopeRecordID" UUID NULL,
+  ADD COLUMN "ScopeDecisionJSON" TEXT NULL
+ /* ───────────────────────────────────────────────────────────────────────────────────── */ /* PHASE F: decision provenance on the execution log */ /* ───────────────────────────────────────────────────────────────────────────────────── */;
+
+ALTER TABLE __mj."SearchExecutionLog"
+  ADD CONSTRAINT "FK_SearchExecutionLog_AISkill" FOREIGN KEY ("AISkillID") REFERENCES __mj."AISkill" (
+    "ID"
+  );
+
+COMMENT ON COLUMN __mj."SearchExecutionLog"."AISkillID" IS 'The AI Skill on whose behalf this search ran, or NULL for a search with no active skill. Mirrors AIAgentID: since a skill is a search principal in its own right (AISkill.SearchScopeAccess plus MJ: AI Skill Search Scopes rows can reach a scope the user''s own roles do not grant), the log must record which skill was active or the entitlement decision cannot be reconstructed.';
+
+COMMENT ON COLUMN __mj."SearchExecutionLog"."PrimaryScopeRecordID" IS 'The tenant this search ran for, taken from SearchContext.PrimaryScopeRecordID. Lets a multi-tenant deployment partition, filter and retain search audit history per customer. NULL for untenanted searches. Named for the existing primary-scope concept rather than OrganizationID because a scope''s primary scope may be a Company, Client or Practice.';
+
+COMMENT ON COLUMN __mj."SearchExecutionLog"."ScopeDecisionJSON" IS 'Serialized ScopeExplanation recording WHY this search could reach what it reached: the entitlement decision and the grant that produced it, every dimension with its provenance (CallerSupplied / ServerDerived / Default / DiscardedCaller / Absent), and each lane''s rendered filter with its active-or-skipped status and reason. Identical in shape to the value returned by SearchEngine.ExplainScope(), so the dry-run an administrator previews before running a search is the same structure the audit log stores afterwards. NULL when the engine did not capture a decision (older writers, or a failure before scope resolution).';
+
+ALTER TABLE __mj."SearchScopeEntity"
+ADD COLUMN "RequiredMetadataKeys" TEXT NULL /* ############################################################################ */ /* C. The same label contract on the entity (SQL) lane */ /* ############################################################################ */;
+
+COMMENT ON COLUMN __mj."SearchScopeEntity"."RequiredMetadataKeys" IS 'JSON array of column or alias names the rendered ExtraFilter MUST reference for this lane to be considered safe, e.g. ["OrganizationID","ContentSourceID"]. Checked against the RENDERED filter at search time: if one is missing the lane is SKIPPED rather than queried, because a partially-rendered filter (an {% if %} clause dropped when its dimension was absent or discarded) is still valid SQL and silently widens the search. Same concept and same engine check as SearchScopeExternalIndex.RequiredMetadataKeys, applied to the SQL lane. NULL = no contract declared, which is the pre-migration behaviour.';
+
+/* ============================================================================ */
+/* CodeGen output — `mj codegen`, generated against a database at the repo's */
+/* CURRENT migration head with this migration's DDL applied and nothing else */
+/* outstanding. */
+/* Generated; do not hand-edit below this line. */
+/* Included because that is what the recent schema migrations do — see */
+/* V202607240220__v5.50.x__ContentItem_VectorRecordID_And_ContentItemChunk.sql. */
+/* The rule in migrations/CLAUDE.md about omitting CodeGen-owned objects governs */
+/* what you hand-write inside a CREATE TABLE, not whether this block ships. */
+/* TWO WAYS THIS BLOCK GOES SILENTLY WRONG, both hit during development: */
+/*  1. Generated against a database that ALREADY has the new objects, it omits */
+/*     the __mj_CreatedAt / __mj_UpdatedAt ALTERs. It then applies cleanly there */
+/*     and fails on a clean database with "Msg 207 invalid column name" inside */
+/*     trgUpdateAISkillSearchScope. */
+/*  2. Generated against a database BEHIND the repo head, it emits SQL for a */
+/*     schema shape later migrations changed — here, references to a column */
+/*     V202607241645 removed, producing "Invalid column name 'SummaryPromptRunID'" */
+/*     at batch 101 of 102. */
+/* So: generate against a database at CURRENT HEAD that does NOT yet have these */
+/* objects, and verify by running the whole chain on an empty database. */
+/* ============================================================================ */
+/* SQL generated to create new entity MJ: AI Skill Search Scopes */
+INSERT INTO __mj."Entity" (
+  "ID",
+  "Name",
+  "DisplayName",
+  "Description",
+  "NameSuffix",
+  "BaseTable",
+  "BaseView",
+  "SchemaName",
+  "IncludeInAPI",
+  "AllowUserSearchAPI",
+  "AllowCaching",
+  "TrackRecordChanges",
+  "AuditRecordAccess",
+  "AuditViewRuns",
+  "AllowAllRowsAPI",
+  "AllowCreateAPI",
+  "AllowUpdateAPI",
+  "AllowDeleteAPI",
+  "UserViewMaxRows",
+  "__mj_CreatedAt",
+  "__mj_UpdatedAt"
+)
+VALUES
+  (
+    'c084b950-88ad-4922-9f59-b8d5c2f36988',
+    'MJ: AI Skill Search Scopes',
+    'AI Skill Search Scopes',
+    'Search Scopes an AI Skill may reach when activated, honoured when AISkill.SearchScopeAccess = ''Assigned''. Mirrors AIAgentSearchScope: Status plus an optional StartAt/EndAt window time-box a grant, and Priority/IsDefault pick among several. An empty table means no skill grants any scope - the pre-migration behaviour.',
+    NULL,
+    'AISkillSearchScope',
+    'vwAISkillSearchScopes',
+    '__mj',
+    TRUE,
+    TRUE,
+    TRUE,
+    TRUE,
+    FALSE,
+    FALSE,
+    FALSE,
+    TRUE,
+    TRUE,
+    TRUE,
+    1000,
+    NOW(),
+    NOW()
+  );
+/* SQL generated to add new entity MJ: AI Skill Search Scopes to application ID: 'EBA5CCEC-6A37-EF11-86D4-000D3A4E707E' */
+INSERT INTO __mj."ApplicationEntity" (
+  "ApplicationID",
+  "EntityID",
+  "Sequence",
+  "__mj_CreatedAt",
+  "__mj_UpdatedAt"
+)
+VALUES
+  (
+    'EBA5CCEC-6A37-EF11-86D4-000D3A4E707E',
+    'c084b950-88ad-4922-9f59-b8d5c2f36988',
+    (
+      SELECT
+        COALESCE(MAX("Sequence"), 0) + 1
+      FROM __mj."ApplicationEntity"
+      WHERE
+        "ApplicationID" = 'EBA5CCEC-6A37-EF11-86D4-000D3A4E707E'
+    ),
+    NOW(),
+    NOW()
+  );
+/* SQL generated to add new permission for entity MJ: AI Skill Search Scopes for role UI */
+INSERT INTO __mj."EntityPermission" (
+  "EntityID",
+  "RoleID",
+  "CanRead",
+  "CanCreate",
+  "CanUpdate",
+  "CanDelete",
+  "__mj_CreatedAt",
+  "__mj_UpdatedAt"
+)
+VALUES
+  (
+    'c084b950-88ad-4922-9f59-b8d5c2f36988',
+    'E0AFCCEC-6A37-EF11-86D4-000D3A4E707E',
+    TRUE,
+    FALSE,
+    FALSE,
+    FALSE,
+    NOW(),
+    NOW()
+  );
+/* SQL generated to add new permission for entity MJ: AI Skill Search Scopes for role Developer */
+INSERT INTO __mj."EntityPermission" (
+  "EntityID",
+  "RoleID",
+  "CanRead",
+  "CanCreate",
+  "CanUpdate",
+  "CanDelete",
+  "__mj_CreatedAt",
+  "__mj_UpdatedAt"
+)
+VALUES
+  (
+    'c084b950-88ad-4922-9f59-b8d5c2f36988',
+    'DEAFCCEC-6A37-EF11-86D4-000D3A4E707E',
+    TRUE,
+    TRUE,
+    TRUE,
+    TRUE,
+    NOW(),
+    NOW()
+  );
+/* SQL generated to add new permission for entity MJ: AI Skill Search Scopes for role Integration */
+INSERT INTO __mj."EntityPermission" (
+  "EntityID",
+  "RoleID",
+  "CanRead",
+  "CanCreate",
+  "CanUpdate",
+  "CanDelete",
+  "__mj_CreatedAt",
+  "__mj_UpdatedAt"
+)
+VALUES
+  (
+    'c084b950-88ad-4922-9f59-b8d5c2f36988',
+    'DFAFCCEC-6A37-EF11-86D4-000D3A4E707E',
+    TRUE,
+    TRUE,
+    TRUE,
+    TRUE,
+    NOW(),
+    NOW()
+  );
+ALTER TABLE __mj."AISkillSearchScope"
+ADD COLUMN "__mj_CreatedAt" TIMESTAMPTZ NULL /* SQL text to add special date field __mj_CreatedAt to entity __mj.AISkillSearchScope */;
+
+/* SQL text to add special date field __mj_CreatedAt to entity __mj.AISkillSearchScope */
+UPDATE __mj."AISkillSearchScope" SET "__mj_CreatedAt" = NOW()
+WHERE
+  "__mj_CreatedAt" IS NULL;
+
+DO $$
+DECLARE r RECORD;
+BEGIN
+  FOR r IN
+    SELECT DISTINCT ns.nspname AS sch, dv.relname AS vw
+    FROM pg_depend d
+    JOIN pg_rewrite rw ON rw.oid = d.objid
+    JOIN pg_class dv ON dv.oid = rw.ev_class AND dv.relkind = 'v'
+    JOIN pg_namespace ns ON ns.oid = dv.relnamespace
+    JOIN pg_class tc ON tc.oid = d.refobjid
+    JOIN pg_attribute a ON a.attrelid = tc.oid AND a.attnum = d.refobjsubid
+    WHERE tc.relname = 'AISkillSearchScope' AND a.attname = '__mj_CreatedAt'
+  LOOP
+    EXECUTE format('DROP VIEW IF EXISTS %I.%I CASCADE', r.sch, r.vw);
+  END LOOP;
+END $$;
+ALTER TABLE __mj."AISkillSearchScope" ALTER COLUMN "__mj_CreatedAt" TYPE TIMESTAMPTZ, ALTER COLUMN "__mj_CreatedAt" SET NOT NULL;
+
+ALTER TABLE __mj."AISkillSearchScope" ALTER COLUMN "__mj_CreatedAt" SET DEFAULT NOW();
+
+ALTER TABLE __mj."AISkillSearchScope"
+ADD COLUMN "__mj_UpdatedAt" TIMESTAMPTZ NULL /* SQL text to add special date field __mj_UpdatedAt to entity __mj.AISkillSearchScope */;
+
+/* SQL text to add special date field __mj_UpdatedAt to entity __mj.AISkillSearchScope */
+UPDATE __mj."AISkillSearchScope" SET "__mj_UpdatedAt" = NOW()
+WHERE
+  "__mj_UpdatedAt" IS NULL;
+
+DO $$
+DECLARE r RECORD;
+BEGIN
+  FOR r IN
+    SELECT DISTINCT ns.nspname AS sch, dv.relname AS vw
+    FROM pg_depend d
+    JOIN pg_rewrite rw ON rw.oid = d.objid
+    JOIN pg_class dv ON dv.oid = rw.ev_class AND dv.relkind = 'v'
+    JOIN pg_namespace ns ON ns.oid = dv.relnamespace
+    JOIN pg_class tc ON tc.oid = d.refobjid
+    JOIN pg_attribute a ON a.attrelid = tc.oid AND a.attnum = d.refobjsubid
+    WHERE tc.relname = 'AISkillSearchScope' AND a.attname = '__mj_UpdatedAt'
+  LOOP
+    EXECUTE format('DROP VIEW IF EXISTS %I.%I CASCADE', r.sch, r.vw);
+  END LOOP;
+END $$;
+ALTER TABLE __mj."AISkillSearchScope" ALTER COLUMN "__mj_UpdatedAt" TYPE TIMESTAMPTZ, ALTER COLUMN "__mj_UpdatedAt" SET NOT NULL;
+
+ALTER TABLE __mj."AISkillSearchScope" ALTER COLUMN "__mj_UpdatedAt" SET DEFAULT NOW();
+
+DO $$
+BEGIN
+  IF NOT EXISTS (SELECT 1 FROM __mj."EntityField" WHERE "ID" = '01763e29-5f3a-49b2-9003-eca37b943d4e' OR ("EntityID" = '530982B5-5556-483A-A4D7-338A19E53548' AND "Name" = 'AISkillID')) THEN
+    INSERT INTO __mj."EntityField" ("ID", "EntityID", "Sequence", "Name", "DisplayName", "Description", "Type", "Length", "Precision", "Scale", "AllowsNull", "DefaultValue", "AutoIncrement", "AllowUpdateAPI", "IsVirtual", "IsComputed", "RelatedEntityID", "RelatedEntityFieldName", "IsNameField", "IncludeInUserSearchAPI", "IncludeRelatedEntityNameFieldInBaseView", "DefaultInView", "IsPrimaryKey", "IsUnique", "RelatedEntityDisplayType", "__mj_CreatedAt", "__mj_UpdatedAt") VALUES ('01763e29-5f3a-49b2-9003-eca37b943d4e', '530982B5-5556-483A-A4D7-338A19E53548' /* Entity: MJ: Search Execution Logs */, 100032, 'AISkillID', 'AI Skill ID', 'The AI Skill on whose behalf this search ran, or NULL for a search with no active skill. Mirrors AIAgentID: since a skill is a search principal in its own right (AISkill.SearchScopeAccess plus MJ: AI Skill Search Scopes rows can reach a scope the user''s own roles do not grant), the log must record which skill was active or the entitlement decision cannot be reconstructed.', 'uniqueidentifier', 16, 0, 0, TRUE, NULL, FALSE, TRUE, FALSE, FALSE, '1D52DE84-DD3F-4E46-8D2B-574B70080BB4', 'ID', FALSE, FALSE, TRUE, FALSE, FALSE, FALSE, 'Search', NOW(), NOW());
+  END IF;
+END $$;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (SELECT 1 FROM __mj."EntityField" WHERE "ID" = '83d237dc-ab22-4d8e-9a8e-d22f1604709b' OR ("EntityID" = '530982B5-5556-483A-A4D7-338A19E53548' AND "Name" = 'PrimaryScopeRecordID')) THEN
+    INSERT INTO __mj."EntityField" ("ID", "EntityID", "Sequence", "Name", "DisplayName", "Description", "Type", "Length", "Precision", "Scale", "AllowsNull", "DefaultValue", "AutoIncrement", "AllowUpdateAPI", "IsVirtual", "IsComputed", "RelatedEntityID", "RelatedEntityFieldName", "IsNameField", "IncludeInUserSearchAPI", "IncludeRelatedEntityNameFieldInBaseView", "DefaultInView", "IsPrimaryKey", "IsUnique", "RelatedEntityDisplayType", "__mj_CreatedAt", "__mj_UpdatedAt") VALUES ('83d237dc-ab22-4d8e-9a8e-d22f1604709b', '530982B5-5556-483A-A4D7-338A19E53548' /* Entity: MJ: Search Execution Logs */, 100033, 'PrimaryScopeRecordID', 'Primary Scope Record ID', 'The tenant this search ran for, taken from SearchContext.PrimaryScopeRecordID. Lets a multi-tenant deployment partition, filter and retain search audit history per customer. NULL for untenanted searches. Named for the existing primary-scope concept rather than OrganizationID because a scope''s primary scope may be a Company, Client or Practice.', 'uniqueidentifier', 16, 0, 0, TRUE, NULL, FALSE, TRUE, FALSE, FALSE, NULL, NULL, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, 'Search', NOW(), NOW());
+  END IF;
+END $$;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (SELECT 1 FROM __mj."EntityField" WHERE "ID" = '738adefc-6848-4be4-928e-85a9de477784' OR ("EntityID" = '530982B5-5556-483A-A4D7-338A19E53548' AND "Name" = 'ScopeDecisionJSON')) THEN
+    INSERT INTO __mj."EntityField" ("ID", "EntityID", "Sequence", "Name", "DisplayName", "Description", "Type", "Length", "Precision", "Scale", "AllowsNull", "DefaultValue", "AutoIncrement", "AllowUpdateAPI", "IsVirtual", "IsComputed", "RelatedEntityID", "RelatedEntityFieldName", "IsNameField", "IncludeInUserSearchAPI", "IncludeRelatedEntityNameFieldInBaseView", "DefaultInView", "IsPrimaryKey", "IsUnique", "RelatedEntityDisplayType", "__mj_CreatedAt", "__mj_UpdatedAt") VALUES ('738adefc-6848-4be4-928e-85a9de477784', '530982B5-5556-483A-A4D7-338A19E53548' /* Entity: MJ: Search Execution Logs */, 100034, 'ScopeDecisionJSON', 'Scope Decision JSON', 'Serialized ScopeExplanation recording WHY this search could reach what it reached: the entitlement decision and the grant that produced it, every dimension with its provenance (CallerSupplied / ServerDerived / Default / DiscardedCaller / Absent), and each lane''s rendered filter with its active-or-skipped status and reason. Identical in shape to the value returned by SearchEngine.ExplainScope(), so the dry-run an administrator previews before running a search is the same structure the audit log stores afterwards. NULL when the engine did not capture a decision (older writers, or a failure before scope resolution).', 'nvarchar', -1, 0, 0, TRUE, NULL, FALSE, TRUE, FALSE, FALSE, NULL, NULL, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, 'Search', NOW(), NOW());
+  END IF;
+END $$;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (SELECT 1 FROM __mj."EntityField" WHERE "ID" = '816274c5-1d6e-44f6-a883-d4baf7f85de2' OR ("EntityID" = '1D52DE84-DD3F-4E46-8D2B-574B70080BB4' AND "Name" = 'SearchScopeAccess')) THEN
+    INSERT INTO __mj."EntityField" ("ID", "EntityID", "Sequence", "Name", "DisplayName", "Description", "Type", "Length", "Precision", "Scale", "AllowsNull", "DefaultValue", "AutoIncrement", "AllowUpdateAPI", "IsVirtual", "IsComputed", "RelatedEntityID", "RelatedEntityFieldName", "IsNameField", "IncludeInUserSearchAPI", "IncludeRelatedEntityNameFieldInBaseView", "DefaultInView", "IsPrimaryKey", "IsUnique", "RelatedEntityDisplayType", "__mj_CreatedAt", "__mj_UpdatedAt") VALUES ('816274c5-1d6e-44f6-a883-d4baf7f85de2', '1D52DE84-DD3F-4E46-8D2B-574B70080BB4' /* Entity: MJ: AI Skills */, 100026, 'SearchScopeAccess', 'Search Scope Access', 'Which Search Scopes this skill may reach when activated. None = grants no retrieval scope; Assigned = only scopes listed in AISkillSearchScope; All = any active scope. NULL behaves as None so existing skills are unaffected. Mirrors AIAgent.SearchScopeAccess so a skill and an agent are interchangeable principals to SearchScopePermissionResolver.', 'nvarchar', 40, 0, 0, TRUE, NULL, FALSE, TRUE, FALSE, FALSE, NULL, NULL, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, 'Search', NOW(), NOW());
+  END IF;
+END $$;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (SELECT 1 FROM __mj."EntityField" WHERE "ID" = 'eb4ee1b5-83af-4652-b290-8763472e3c81' OR ("EntityID" = '20BCABEC-413F-4985-8F5A-6BC262E75F81' AND "Name" = 'RequiredMetadataKeys')) THEN
+    INSERT INTO __mj."EntityField" ("ID", "EntityID", "Sequence", "Name", "DisplayName", "Description", "Type", "Length", "Precision", "Scale", "AllowsNull", "DefaultValue", "AutoIncrement", "AllowUpdateAPI", "IsVirtual", "IsComputed", "RelatedEntityID", "RelatedEntityFieldName", "IsNameField", "IncludeInUserSearchAPI", "IncludeRelatedEntityNameFieldInBaseView", "DefaultInView", "IsPrimaryKey", "IsUnique", "RelatedEntityDisplayType", "__mj_CreatedAt", "__mj_UpdatedAt") VALUES ('eb4ee1b5-83af-4652-b290-8763472e3c81', '20BCABEC-413F-4985-8F5A-6BC262E75F81' /* Entity: MJ: Search Scope Entities */, 100017, 'RequiredMetadataKeys', 'Required Metadata Keys', 'JSON array of column or alias names the rendered ExtraFilter MUST reference for this lane to be considered safe, e.g. ["OrganizationID","ContentSourceID"]. Checked against the RENDERED filter at search time: if one is missing the lane is SKIPPED rather than queried, because a partially-rendered filter (an {% if %} clause dropped when its dimension was absent or discarded) is still valid SQL and silently widens the search. Same concept and same engine check as SearchScopeExternalIndex.RequiredMetadataKeys, applied to the SQL lane. NULL = no contract declared, which is the pre-migration behaviour.', 'nvarchar', -1, 0, 0, TRUE, NULL, FALSE, TRUE, FALSE, FALSE, NULL, NULL, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, 'Search', NOW(), NOW());
+  END IF;
+END $$;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (SELECT 1 FROM __mj."EntityField" WHERE "ID" = '83cb7d93-bc7d-4f0d-b27c-303cefe97243' OR ("EntityID" = 'B90FAB4E-0336-407A-B6AE-A49DEA84D083' AND "Name" = 'StartAt')) THEN
+    INSERT INTO __mj."EntityField" ("ID", "EntityID", "Sequence", "Name", "DisplayName", "Description", "Type", "Length", "Precision", "Scale", "AllowsNull", "DefaultValue", "AutoIncrement", "AllowUpdateAPI", "IsVirtual", "IsComputed", "RelatedEntityID", "RelatedEntityFieldName", "IsNameField", "IncludeInUserSearchAPI", "IncludeRelatedEntityNameFieldInBaseView", "DefaultInView", "IsPrimaryKey", "IsUnique", "RelatedEntityDisplayType", "__mj_CreatedAt", "__mj_UpdatedAt") VALUES ('83cb7d93-bc7d-4f0d-b27c-303cefe97243', 'B90FAB4E-0336-407A-B6AE-A49DEA84D083' /* Entity: MJ: Search Scope Permissions */, 100018, 'StartAt', 'Start At', 'Optional start of the window in which this grant applies. NULL = no lower bound. SearchScopePermission was the only member of this family without a time window, so temporary grants previously needed a bespoke mechanism.', 'datetimeoffset', 10, 34, 7, TRUE, NULL, FALSE, TRUE, FALSE, FALSE, NULL, NULL, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, 'Search', NOW(), NOW());
+  END IF;
+END $$;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (SELECT 1 FROM __mj."EntityField" WHERE "ID" = '259b26c8-001b-4801-b822-03e799669feb' OR ("EntityID" = 'B90FAB4E-0336-407A-B6AE-A49DEA84D083' AND "Name" = 'EndAt')) THEN
+    INSERT INTO __mj."EntityField" ("ID", "EntityID", "Sequence", "Name", "DisplayName", "Description", "Type", "Length", "Precision", "Scale", "AllowsNull", "DefaultValue", "AutoIncrement", "AllowUpdateAPI", "IsVirtual", "IsComputed", "RelatedEntityID", "RelatedEntityFieldName", "IsNameField", "IncludeInUserSearchAPI", "IncludeRelatedEntityNameFieldInBaseView", "DefaultInView", "IsPrimaryKey", "IsUnique", "RelatedEntityDisplayType", "__mj_CreatedAt", "__mj_UpdatedAt") VALUES ('259b26c8-001b-4801-b822-03e799669feb', 'B90FAB4E-0336-407A-B6AE-A49DEA84D083' /* Entity: MJ: Search Scope Permissions */, 100019, 'EndAt', 'End At', 'Optional end of the window in which this grant applies. NULL = no upper bound.', 'datetimeoffset', 10, 34, 7, TRUE, NULL, FALSE, TRUE, FALSE, FALSE, NULL, NULL, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, 'Search', NOW(), NOW());
+  END IF;
+END $$;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (SELECT 1 FROM __mj."EntityField" WHERE "ID" = 'dd1a55cc-884e-4044-b6e7-09428a943565' OR ("EntityID" = 'B90FAB4E-0336-407A-B6AE-A49DEA84D083' AND "Name" = 'PrimaryScopeRecordID')) THEN
+    INSERT INTO __mj."EntityField" ("ID", "EntityID", "Sequence", "Name", "DisplayName", "Description", "Type", "Length", "Precision", "Scale", "AllowsNull", "DefaultValue", "AutoIncrement", "AllowUpdateAPI", "IsVirtual", "IsComputed", "RelatedEntityID", "RelatedEntityFieldName", "IsNameField", "IncludeInUserSearchAPI", "IncludeRelatedEntityNameFieldInBaseView", "DefaultInView", "IsPrimaryKey", "IsUnique", "RelatedEntityDisplayType", "__mj_CreatedAt", "__mj_UpdatedAt") VALUES ('dd1a55cc-884e-4044-b6e7-09428a943565', 'B90FAB4E-0336-407A-B6AE-A49DEA84D083' /* Entity: MJ: Search Scope Permissions */, 100020, 'PrimaryScopeRecordID', 'Primary Scope Record ID', 'Optional tenant this grant is limited to, matched against SearchContext.PrimaryScopeRecordID at search time and type-checkable against the scope''s own PrimaryScopeEntityID. NULL = applies to every tenant, which is the pre-migration behaviour for all existing rows. Deliberately NOT called OrganizationID: MJ is domain-agnostic and a scope''s primary scope may be a Company, Client or Practice, so this reuses the existing primary-scope concept rather than inventing a parallel tenancy column.', 'uniqueidentifier', 16, 0, 0, TRUE, NULL, FALSE, TRUE, FALSE, FALSE, NULL, NULL, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, 'Search', NOW(), NOW());
+  END IF;
+END $$;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (SELECT 1 FROM __mj."EntityField" WHERE "ID" = '85387a57-2787-44df-a2cc-0cf0246cf0c9' OR ("EntityID" = 'C084B950-88AD-4922-9F59-B8D5C2F36988' AND "Name" = 'ID')) THEN
+    INSERT INTO __mj."EntityField" ("ID", "EntityID", "Sequence", "Name", "DisplayName", "Description", "Type", "Length", "Precision", "Scale", "AllowsNull", "DefaultValue", "AutoIncrement", "AllowUpdateAPI", "IsVirtual", "IsComputed", "RelatedEntityID", "RelatedEntityFieldName", "IsNameField", "IncludeInUserSearchAPI", "IncludeRelatedEntityNameFieldInBaseView", "DefaultInView", "IsPrimaryKey", "IsUnique", "RelatedEntityDisplayType", "__mj_CreatedAt", "__mj_UpdatedAt") VALUES ('85387a57-2787-44df-a2cc-0cf0246cf0c9', 'C084B950-88AD-4922-9F59-B8D5C2F36988' /* Entity: MJ: AI Skill Search Scopes */, 100001, 'ID', 'ID', NULL, 'uniqueidentifier', 16, 0, 0, FALSE, 'newsequentialid()', FALSE, FALSE, FALSE, FALSE, NULL, NULL, FALSE, TRUE, FALSE, FALSE, TRUE, TRUE, 'Search', NOW(), NOW());
+  END IF;
+END $$;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (SELECT 1 FROM __mj."EntityField" WHERE "ID" = '0e07fe6e-54e8-4282-a207-c69ed11ec095' OR ("EntityID" = 'C084B950-88AD-4922-9F59-B8D5C2F36988' AND "Name" = 'SkillID')) THEN
+    INSERT INTO __mj."EntityField" ("ID", "EntityID", "Sequence", "Name", "DisplayName", "Description", "Type", "Length", "Precision", "Scale", "AllowsNull", "DefaultValue", "AutoIncrement", "AllowUpdateAPI", "IsVirtual", "IsComputed", "RelatedEntityID", "RelatedEntityFieldName", "IsNameField", "IncludeInUserSearchAPI", "IncludeRelatedEntityNameFieldInBaseView", "DefaultInView", "IsPrimaryKey", "IsUnique", "RelatedEntityDisplayType", "__mj_CreatedAt", "__mj_UpdatedAt") VALUES ('0e07fe6e-54e8-4282-a207-c69ed11ec095', 'C084B950-88AD-4922-9F59-B8D5C2F36988' /* Entity: MJ: AI Skill Search Scopes */, 100002, 'SkillID', 'Skill ID', 'The skill this grant belongs to.', 'uniqueidentifier', 16, 0, 0, FALSE, NULL, FALSE, TRUE, FALSE, FALSE, '1D52DE84-DD3F-4E46-8D2B-574B70080BB4', 'ID', FALSE, FALSE, TRUE, FALSE, FALSE, TRUE, 'Search', NOW(), NOW());
+  END IF;
+END $$;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (SELECT 1 FROM __mj."EntityField" WHERE "ID" = '99e97675-3efa-4ea7-936c-f836b82ea832' OR ("EntityID" = 'C084B950-88AD-4922-9F59-B8D5C2F36988' AND "Name" = 'SearchScopeID')) THEN
+    INSERT INTO __mj."EntityField" ("ID", "EntityID", "Sequence", "Name", "DisplayName", "Description", "Type", "Length", "Precision", "Scale", "AllowsNull", "DefaultValue", "AutoIncrement", "AllowUpdateAPI", "IsVirtual", "IsComputed", "RelatedEntityID", "RelatedEntityFieldName", "IsNameField", "IncludeInUserSearchAPI", "IncludeRelatedEntityNameFieldInBaseView", "DefaultInView", "IsPrimaryKey", "IsUnique", "RelatedEntityDisplayType", "__mj_CreatedAt", "__mj_UpdatedAt") VALUES ('99e97675-3efa-4ea7-936c-f836b82ea832', 'C084B950-88AD-4922-9F59-B8D5C2F36988' /* Entity: MJ: AI Skill Search Scopes */, 100003, 'SearchScopeID', 'Search Scope ID', 'The Search Scope this skill may reach.', 'uniqueidentifier', 16, 0, 0, FALSE, NULL, FALSE, TRUE, FALSE, FALSE, '3F83C084-859F-49C3-A8A0-4693E0777BE8', 'ID', FALSE, FALSE, TRUE, FALSE, FALSE, TRUE, 'Search', NOW(), NOW());
+  END IF;
+END $$;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (SELECT 1 FROM __mj."EntityField" WHERE "ID" = 'ebc90c1d-a764-487d-a5a2-fc7561b20bc9' OR ("EntityID" = 'C084B950-88AD-4922-9F59-B8D5C2F36988' AND "Name" = 'Status')) THEN
+    INSERT INTO __mj."EntityField" ("ID", "EntityID", "Sequence", "Name", "DisplayName", "Description", "Type", "Length", "Precision", "Scale", "AllowsNull", "DefaultValue", "AutoIncrement", "AllowUpdateAPI", "IsVirtual", "IsComputed", "RelatedEntityID", "RelatedEntityFieldName", "IsNameField", "IncludeInUserSearchAPI", "IncludeRelatedEntityNameFieldInBaseView", "DefaultInView", "IsPrimaryKey", "IsUnique", "RelatedEntityDisplayType", "__mj_CreatedAt", "__mj_UpdatedAt") VALUES ('ebc90c1d-a764-487d-a5a2-fc7561b20bc9', 'C084B950-88AD-4922-9F59-B8D5C2F36988' /* Entity: MJ: AI Skill Search Scopes */, 100004, 'Status', 'Status', 'Active or Inactive. Inactive rows are ignored during resolution.', 'nvarchar', 40, 0, 0, FALSE, 'Active', FALSE, TRUE, FALSE, FALSE, NULL, NULL, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, 'Search', NOW(), NOW());
+  END IF;
+END $$;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (SELECT 1 FROM __mj."EntityField" WHERE "ID" = '197ef377-38f4-4253-95e2-89e5026fc49e' OR ("EntityID" = 'C084B950-88AD-4922-9F59-B8D5C2F36988' AND "Name" = 'StartAt')) THEN
+    INSERT INTO __mj."EntityField" ("ID", "EntityID", "Sequence", "Name", "DisplayName", "Description", "Type", "Length", "Precision", "Scale", "AllowsNull", "DefaultValue", "AutoIncrement", "AllowUpdateAPI", "IsVirtual", "IsComputed", "RelatedEntityID", "RelatedEntityFieldName", "IsNameField", "IncludeInUserSearchAPI", "IncludeRelatedEntityNameFieldInBaseView", "DefaultInView", "IsPrimaryKey", "IsUnique", "RelatedEntityDisplayType", "__mj_CreatedAt", "__mj_UpdatedAt") VALUES ('197ef377-38f4-4253-95e2-89e5026fc49e', 'C084B950-88AD-4922-9F59-B8D5C2F36988' /* Entity: MJ: AI Skill Search Scopes */, 100005, 'StartAt', 'Start At', 'Optional start of the window in which this grant is honoured. NULL = no lower bound. Evaluated against the current time on every resolution, so a window opening or closing needs no cache invalidation.', 'datetimeoffset', 10, 34, 7, TRUE, NULL, FALSE, TRUE, FALSE, FALSE, NULL, NULL, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, 'Search', NOW(), NOW());
+  END IF;
+END $$;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (SELECT 1 FROM __mj."EntityField" WHERE "ID" = '04c3191b-680e-4f98-b13d-59aeb3b5a6b5' OR ("EntityID" = 'C084B950-88AD-4922-9F59-B8D5C2F36988' AND "Name" = 'EndAt')) THEN
+    INSERT INTO __mj."EntityField" ("ID", "EntityID", "Sequence", "Name", "DisplayName", "Description", "Type", "Length", "Precision", "Scale", "AllowsNull", "DefaultValue", "AutoIncrement", "AllowUpdateAPI", "IsVirtual", "IsComputed", "RelatedEntityID", "RelatedEntityFieldName", "IsNameField", "IncludeInUserSearchAPI", "IncludeRelatedEntityNameFieldInBaseView", "DefaultInView", "IsPrimaryKey", "IsUnique", "RelatedEntityDisplayType", "__mj_CreatedAt", "__mj_UpdatedAt") VALUES ('04c3191b-680e-4f98-b13d-59aeb3b5a6b5', 'C084B950-88AD-4922-9F59-B8D5C2F36988' /* Entity: MJ: AI Skill Search Scopes */, 100006, 'EndAt', 'End At', 'Optional end of the window in which this grant is honoured. NULL = no upper bound.', 'datetimeoffset', 10, 34, 7, TRUE, NULL, FALSE, TRUE, FALSE, FALSE, NULL, NULL, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, 'Search', NOW(), NOW());
+  END IF;
+END $$;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (SELECT 1 FROM __mj."EntityField" WHERE "ID" = 'cc1d24a5-8e10-46db-9b35-0d4471856ae7' OR ("EntityID" = 'C084B950-88AD-4922-9F59-B8D5C2F36988' AND "Name" = 'Priority')) THEN
+    INSERT INTO __mj."EntityField" ("ID", "EntityID", "Sequence", "Name", "DisplayName", "Description", "Type", "Length", "Precision", "Scale", "AllowsNull", "DefaultValue", "AutoIncrement", "AllowUpdateAPI", "IsVirtual", "IsComputed", "RelatedEntityID", "RelatedEntityFieldName", "IsNameField", "IncludeInUserSearchAPI", "IncludeRelatedEntityNameFieldInBaseView", "DefaultInView", "IsPrimaryKey", "IsUnique", "RelatedEntityDisplayType", "__mj_CreatedAt", "__mj_UpdatedAt") VALUES ('cc1d24a5-8e10-46db-9b35-0d4471856ae7', 'C084B950-88AD-4922-9F59-B8D5C2F36988' /* Entity: MJ: AI Skill Search Scopes */, 100007, 'Priority', 'Priority', 'Lower numbers win when several granted scopes are candidates and none is marked IsDefault.', 'int', 4, 10, 0, TRUE, NULL, FALSE, TRUE, FALSE, FALSE, NULL, NULL, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, 'Search', NOW(), NOW());
+  END IF;
+END $$;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (SELECT 1 FROM __mj."EntityField" WHERE "ID" = '13aa1aea-c3b9-4f09-b73f-807f0502462e' OR ("EntityID" = 'C084B950-88AD-4922-9F59-B8D5C2F36988' AND "Name" = 'IsDefault')) THEN
+    INSERT INTO __mj."EntityField" ("ID", "EntityID", "Sequence", "Name", "DisplayName", "Description", "Type", "Length", "Precision", "Scale", "AllowsNull", "DefaultValue", "AutoIncrement", "AllowUpdateAPI", "IsVirtual", "IsComputed", "RelatedEntityID", "RelatedEntityFieldName", "IsNameField", "IncludeInUserSearchAPI", "IncludeRelatedEntityNameFieldInBaseView", "DefaultInView", "IsPrimaryKey", "IsUnique", "RelatedEntityDisplayType", "__mj_CreatedAt", "__mj_UpdatedAt") VALUES ('13aa1aea-c3b9-4f09-b73f-807f0502462e', 'C084B950-88AD-4922-9F59-B8D5C2F36988' /* Entity: MJ: AI Skill Search Scopes */, 100008, 'IsDefault', 'Is Default', 'When set, this scope is chosen for the skill ahead of Priority ordering.', 'bit', 1, 1, 0, FALSE, '(0)', FALSE, TRUE, FALSE, FALSE, NULL, NULL, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, 'Search', NOW(), NOW());
+  END IF;
+END $$;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (SELECT 1 FROM __mj."EntityField" WHERE "ID" = '24982b26-06dd-43b9-a4ba-6bc12dae17de' OR ("EntityID" = 'C084B950-88AD-4922-9F59-B8D5C2F36988' AND "Name" = '__mj_CreatedAt')) THEN
+    INSERT INTO __mj."EntityField" ("ID", "EntityID", "Sequence", "Name", "DisplayName", "Description", "Type", "Length", "Precision", "Scale", "AllowsNull", "DefaultValue", "AutoIncrement", "AllowUpdateAPI", "IsVirtual", "IsComputed", "RelatedEntityID", "RelatedEntityFieldName", "IsNameField", "IncludeInUserSearchAPI", "IncludeRelatedEntityNameFieldInBaseView", "DefaultInView", "IsPrimaryKey", "IsUnique", "RelatedEntityDisplayType", "__mj_CreatedAt", "__mj_UpdatedAt") VALUES ('24982b26-06dd-43b9-a4ba-6bc12dae17de', 'C084B950-88AD-4922-9F59-B8D5C2F36988' /* Entity: MJ: AI Skill Search Scopes */, 100009, '__mj_CreatedAt', 'Created At', NULL, 'datetimeoffset', 10, 34, 7, FALSE, 'getutcdate()', FALSE, FALSE, FALSE, FALSE, NULL, NULL, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, 'Search', NOW(), NOW());
+  END IF;
+END $$;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (SELECT 1 FROM __mj."EntityField" WHERE "ID" = '94f355b1-d831-4559-92c9-5d8492fb77d0' OR ("EntityID" = 'C084B950-88AD-4922-9F59-B8D5C2F36988' AND "Name" = '__mj_UpdatedAt')) THEN
+    INSERT INTO __mj."EntityField" ("ID", "EntityID", "Sequence", "Name", "DisplayName", "Description", "Type", "Length", "Precision", "Scale", "AllowsNull", "DefaultValue", "AutoIncrement", "AllowUpdateAPI", "IsVirtual", "IsComputed", "RelatedEntityID", "RelatedEntityFieldName", "IsNameField", "IncludeInUserSearchAPI", "IncludeRelatedEntityNameFieldInBaseView", "DefaultInView", "IsPrimaryKey", "IsUnique", "RelatedEntityDisplayType", "__mj_CreatedAt", "__mj_UpdatedAt") VALUES ('94f355b1-d831-4559-92c9-5d8492fb77d0', 'C084B950-88AD-4922-9F59-B8D5C2F36988' /* Entity: MJ: AI Skill Search Scopes */, 100010, '__mj_UpdatedAt', 'Updated At', NULL, 'datetimeoffset', 10, 34, 7, FALSE, 'getutcdate()', FALSE, FALSE, FALSE, FALSE, NULL, NULL, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, 'Search', NOW(), NOW());
+  END IF;
+END $$;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (SELECT 1 FROM __mj."EntityField" WHERE "ID" = '7753fc11-4e91-4bc7-ba3d-cbcdf1a06bc0' OR ("EntityID" = '3B80A286-D1E1-45C2-9648-C850009E1ADB' AND "Name" = 'RequiredMetadataKeys')) THEN
+    INSERT INTO __mj."EntityField" ("ID", "EntityID", "Sequence", "Name", "DisplayName", "Description", "Type", "Length", "Precision", "Scale", "AllowsNull", "DefaultValue", "AutoIncrement", "AllowUpdateAPI", "IsVirtual", "IsComputed", "RelatedEntityID", "RelatedEntityFieldName", "IsNameField", "IncludeInUserSearchAPI", "IncludeRelatedEntityNameFieldInBaseView", "DefaultInView", "IsPrimaryKey", "IsUnique", "RelatedEntityDisplayType", "__mj_CreatedAt", "__mj_UpdatedAt") VALUES ('7753fc11-4e91-4bc7-ba3d-cbcdf1a06bc0', '3B80A286-D1E1-45C2-9648-C850009E1ADB' /* Entity: MJ: Search Scope External Indexes */, 100021, 'RequiredMetadataKeys', 'Required Metadata Keys', 'JSON array of metadata key names the rendered MetadataFilter MUST constrain on for this lane to be considered safe, e.g. ["OrganizationID","ContentSourceID"]. Checked against the RENDERED filter at search time: if a key is missing the lane is SKIPPED rather than queried, because a partially-rendered filter silently widens the search. This also documents the ingest contract — these are the labels the writer must stamp on every document in the index, since a filter on a key that was never written either matches nothing or (on providers that ignore unknown keys) matches everything. NULL = no contract declared, which is the pre-migration behaviour.', 'nvarchar', -1, 0, 0, TRUE, NULL, FALSE, TRUE, FALSE, FALSE, NULL, NULL, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, 'Search', NOW(), NOW());
+  END IF;
+END $$;
+
+/* SQL text to insert entity field value with ID 0cbb84c7-ea7c-4875-b602-5204db1ffa28 */
+INSERT INTO __mj."EntityFieldValue" (
+  "ID",
+  "EntityFieldID",
+  "Sequence",
+  "Value",
+  "Code",
+  "__mj_CreatedAt",
+  "__mj_UpdatedAt"
+)
+VALUES
+  (
+    '0cbb84c7-ea7c-4875-b602-5204db1ffa28',
+    '816274C5-1D6E-44F6-A883-D4BAF7F85DE2',
+    1,
+    'All',
+    'All',
+    NOW(),
+    NOW()
+  );
+/* SQL text to insert entity field value with ID 34f84e26-1ec1-42e5-b363-fb1583da61ed */
+INSERT INTO __mj."EntityFieldValue" (
+  "ID",
+  "EntityFieldID",
+  "Sequence",
+  "Value",
+  "Code",
+  "__mj_CreatedAt",
+  "__mj_UpdatedAt"
+)
+VALUES
+  (
+    '34f84e26-1ec1-42e5-b363-fb1583da61ed',
+    '816274C5-1D6E-44F6-A883-D4BAF7F85DE2',
+    2,
+    'Assigned',
+    'Assigned',
+    NOW(),
+    NOW()
+  );
+/* SQL text to insert entity field value with ID d8619113-9de2-42b1-a4e2-99899e8858f3 */
+INSERT INTO __mj."EntityFieldValue" (
+  "ID",
+  "EntityFieldID",
+  "Sequence",
+  "Value",
+  "Code",
+  "__mj_CreatedAt",
+  "__mj_UpdatedAt"
+)
+VALUES
+  (
+    'd8619113-9de2-42b1-a4e2-99899e8858f3',
+    '816274C5-1D6E-44F6-A883-D4BAF7F85DE2',
+    3,
+    'None',
+    'None',
+    NOW(),
+    NOW()
+  );
+/* SQL text to update ValueListType for entity field ID 816274C5-1D6E-44F6-A883-D4BAF7F85DE2 */
+UPDATE __mj."EntityField" SET "ValueListType" = 'List'
+WHERE
+  "ID" = '816274C5-1D6E-44F6-A883-D4BAF7F85DE2';
+/* SQL text to insert entity field value with ID f6ec6980-4da0-4682-960f-b6a8c638aeb2 */
+INSERT INTO __mj."EntityFieldValue" (
+  "ID",
+  "EntityFieldID",
+  "Sequence",
+  "Value",
+  "Code",
+  "__mj_CreatedAt",
+  "__mj_UpdatedAt"
+)
+VALUES
+  (
+    'f6ec6980-4da0-4682-960f-b6a8c638aeb2',
+    'EBC90C1D-A764-487D-A5A2-FC7561B20BC9',
+    1,
+    'Active',
+    'Active',
+    NOW(),
+    NOW()
+  );
+/* SQL text to insert entity field value with ID 2ef42a8e-117c-4c71-958c-d5b725e66769 */
+INSERT INTO __mj."EntityFieldValue" (
+  "ID",
+  "EntityFieldID",
+  "Sequence",
+  "Value",
+  "Code",
+  "__mj_CreatedAt",
+  "__mj_UpdatedAt"
+)
+VALUES
+  (
+    '2ef42a8e-117c-4c71-958c-d5b725e66769',
+    'EBC90C1D-A764-487D-A5A2-FC7561B20BC9',
+    2,
+    'Inactive',
+    'Inactive',
+    NOW(),
+    NOW()
+  );
+/* SQL text to update ValueListType for entity field ID EBC90C1D-A764-487D-A5A2-FC7561B20BC9 */
+UPDATE __mj."EntityField" SET "ValueListType" = 'List'
+WHERE
+  "ID" = 'EBC90C1D-A764-487D-A5A2-FC7561B20BC9';
+/* Create Entity Relationship: MJ: Search Scopes -> MJ: AI Skill Search Scopes (One To Many via SearchScopeID) */;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (SELECT 1 FROM __mj."EntityRelationship" WHERE "ID" = '14bbedba-f0f9-4c77-8829-7cb5105ae620') THEN
+    INSERT INTO __mj."EntityRelationship" ("ID", "EntityID", "RelatedEntityID", "RelatedEntityJoinField", "Type", "BundleInAPI", "DisplayInForm", "Sequence", "__mj_CreatedAt", "__mj_UpdatedAt") VALUES ('14bbedba-f0f9-4c77-8829-7cb5105ae620', '3F83C084-859F-49C3-A8A0-4693E0777BE8', 'C084B950-88AD-4922-9F59-B8D5C2F36988', 'SearchScopeID', 'One To Many', TRUE, TRUE, 9, NOW(), NOW());
+  END IF;
+END $$;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (SELECT 1 FROM __mj."EntityRelationship" WHERE "ID" = '23e4e8d3-da28-431b-a0b1-b115c25aa69c') THEN
+    INSERT INTO __mj."EntityRelationship" ("ID", "EntityID", "RelatedEntityID", "RelatedEntityJoinField", "Type", "BundleInAPI", "DisplayInForm", "Sequence", "__mj_CreatedAt", "__mj_UpdatedAt") VALUES ('23e4e8d3-da28-431b-a0b1-b115c25aa69c', '1D52DE84-DD3F-4E46-8D2B-574B70080BB4', '530982B5-5556-483A-A4D7-338A19E53548', 'AISkillID', 'One To Many', TRUE, TRUE, 5, NOW(), NOW());
+  END IF;
+END $$;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (SELECT 1 FROM __mj."EntityRelationship" WHERE "ID" = 'd9f456ac-c35c-4a01-af40-68b016b4fe8b') THEN
+    INSERT INTO __mj."EntityRelationship" ("ID", "EntityID", "RelatedEntityID", "RelatedEntityJoinField", "Type", "BundleInAPI", "DisplayInForm", "Sequence", "__mj_CreatedAt", "__mj_UpdatedAt") VALUES ('d9f456ac-c35c-4a01-af40-68b016b4fe8b', '1D52DE84-DD3F-4E46-8D2B-574B70080BB4', 'C084B950-88AD-4922-9F59-B8D5C2F36988', 'SkillID', 'One To Many', TRUE, TRUE, 6, NOW(), NOW());
+  END IF;
+END $$;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (SELECT 1 FROM __mj."EntityField" WHERE "ID" = '12ec3fc5-68de-4bd8-9f0b-98bb07f83f42' OR ("EntityID" = '530982B5-5556-483A-A4D7-338A19E53548' AND "Name" = 'AISkill')) THEN
+    INSERT INTO __mj."EntityField" ("ID", "EntityID", "Sequence", "Name", "DisplayName", "Description", "Type", "Length", "Precision", "Scale", "AllowsNull", "DefaultValue", "AutoIncrement", "AllowUpdateAPI", "IsVirtual", "IsComputed", "RelatedEntityID", "RelatedEntityFieldName", "IsNameField", "IncludeInUserSearchAPI", "IncludeRelatedEntityNameFieldInBaseView", "DefaultInView", "IsPrimaryKey", "IsUnique", "RelatedEntityDisplayType", "__mj_CreatedAt", "__mj_UpdatedAt") VALUES ('12ec3fc5-68de-4bd8-9f0b-98bb07f83f42', '530982B5-5556-483A-A4D7-338A19E53548' /* Entity: MJ: Search Execution Logs */, 200055, 'AISkill', 'AI Skill', NULL, 'nvarchar', 510, 0, 0, TRUE, NULL, FALSE, FALSE, TRUE, FALSE, NULL, NULL, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, 'Search', NOW(), NOW());
+  END IF;
+END $$;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (SELECT 1 FROM __mj."EntityField" WHERE "ID" = '7386e75c-4f2f-4ee5-b6f7-9cc5f82c7370' OR ("EntityID" = 'C084B950-88AD-4922-9F59-B8D5C2F36988' AND "Name" = 'Skill')) THEN
+    INSERT INTO __mj."EntityField" ("ID", "EntityID", "Sequence", "Name", "DisplayName", "Description", "Type", "Length", "Precision", "Scale", "AllowsNull", "DefaultValue", "AutoIncrement", "AllowUpdateAPI", "IsVirtual", "IsComputed", "RelatedEntityID", "RelatedEntityFieldName", "IsNameField", "IncludeInUserSearchAPI", "IncludeRelatedEntityNameFieldInBaseView", "DefaultInView", "IsPrimaryKey", "IsUnique", "RelatedEntityDisplayType", "__mj_CreatedAt", "__mj_UpdatedAt") VALUES ('7386e75c-4f2f-4ee5-b6f7-9cc5f82c7370', 'C084B950-88AD-4922-9F59-B8D5C2F36988' /* Entity: MJ: AI Skill Search Scopes */, 200021, 'Skill', 'Skill', NULL, 'nvarchar', 510, 0, 0, FALSE, NULL, FALSE, FALSE, TRUE, FALSE, NULL, NULL, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, 'Search', NOW(), NOW());
+  END IF;
+END $$;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (SELECT 1 FROM __mj."EntityField" WHERE "ID" = 'afc34e72-784c-4060-b39e-9c2e7df9c5bd' OR ("EntityID" = 'C084B950-88AD-4922-9F59-B8D5C2F36988' AND "Name" = 'SearchScope')) THEN
+    INSERT INTO __mj."EntityField" ("ID", "EntityID", "Sequence", "Name", "DisplayName", "Description", "Type", "Length", "Precision", "Scale", "AllowsNull", "DefaultValue", "AutoIncrement", "AllowUpdateAPI", "IsVirtual", "IsComputed", "RelatedEntityID", "RelatedEntityFieldName", "IsNameField", "IncludeInUserSearchAPI", "IncludeRelatedEntityNameFieldInBaseView", "DefaultInView", "IsPrimaryKey", "IsUnique", "RelatedEntityDisplayType", "__mj_CreatedAt", "__mj_UpdatedAt") VALUES ('afc34e72-784c-4060-b39e-9c2e7df9c5bd', 'C084B950-88AD-4922-9F59-B8D5C2F36988' /* Entity: MJ: AI Skill Search Scopes */, 200022, 'SearchScope', 'Search Scope', NULL, 'nvarchar', 400, 0, 0, FALSE, NULL, FALSE, FALSE, TRUE, FALSE, NULL, NULL, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, 'Search', NOW(), NOW());
+  END IF;
+END $$;
+
+-- ===================== CodeGen (native PG, baked) =====================
+
+-- ============================================================
+-- PostgreSQL Generated SQL for Entity: MJ: AI Skill Search Scopes
+-- Item: Index for Foreign Keys
+-- ============================================================
+CREATE INDEX IF NOT EXISTS "idx_auto_mj_fkey_ai_skill_search_scope_skill_id"
+    ON __mj."AISkillSearchScope" ("SkillID");
+
+CREATE INDEX IF NOT EXISTS "idx_auto_mj_fkey_ai_skill_search_scope_search_scope_id"
+    ON __mj."AISkillSearchScope" ("SearchScopeID");
+
+-- ============================================================
+-- PostgreSQL Generated SQL for Entity: MJ: AI Skill Search Scopes
+-- Item: vwAISkillSearchScopes
+-- ============================================================
+
+------------------------------------------------------------
+----- BASE VIEW FOR ENTITY:      MJ: AI Skill Search Scopes
+-----               SCHEMA:      __mj
+-----               BASE TABLE:  AISkillSearchScope
+-----               PRIMARY KEY: ID
+------------------------------------------------------------
+DO $vw_regen$
+DECLARE
+  vsql CONSTANT TEXT := $vsql$CREATE OR REPLACE VIEW __mj."vwAISkillSearchScopes"
+AS
+SELECT
+    a.*,
+    MJAISkill_SkillID."Name" AS "Skill",
+    MJSearchScope_SearchScopeID."Name" AS "SearchScope"
+FROM
+    __mj."AISkillSearchScope" AS a
+INNER JOIN
+    __mj."AISkill" AS MJAISkill_SkillID
+  ON
+    "a"."SkillID" = MJAISkill_SkillID."ID"
+INNER JOIN
+    __mj."SearchScope" AS MJSearchScope_SearchScopeID
+  ON
+    "a"."SearchScopeID" = MJSearchScope_SearchScopeID."ID"
+$vsql$;
+  rec RECORD;
+BEGIN
+  EXECUTE vsql;
+EXCEPTION WHEN invalid_table_definition THEN
+  -- 42P16: column rename/reorder/type change. CREATE OR REPLACE can't handle
+  -- non-additive shape changes — must DROP CASCADE + recreate. CASCADE drops
+  -- every dependent view (anything that JOINs this view in its body), so we
+  -- capture each dependent's definition + grants BEFORE the drop and replay
+  -- them afterward (best-effort). Without this, on a fresh-DB replay where
+  -- one entity's wrapper triggers (e.g. vwAIModelTypes shape changed since
+  -- baseline V202605021056), CASCADE wipes downstream views (vwAIModels)
+  -- that the wrapper for this entity doesn't know how to recreate, and
+  -- those views stay permanently missing.
+  CREATE TEMP TABLE IF NOT EXISTS _vw_regen_deps (
+    schema_name TEXT,
+    view_name   TEXT,
+    relkind     CHAR(1),
+    definition  TEXT,
+    grants_sql  TEXT
+  ) ON COMMIT DROP;
+  DELETE FROM _vw_regen_deps;
+
+  -- Capture dependent FUNCTIONS too. CASCADE drops every function with
+  -- RETURNS SETOF <view> (the codegen-emitted spCreate/spUpdate/spDelete
+  -- pattern) when the target view is dropped. Without restoring them,
+  -- post-codegen CRUD validation reports those routines as missing —
+  -- e.g. "MJ: Recommendation Items → missing create routine
+  -- spCreateRecommendationItem" — even though the next codegen pass
+  -- emits them. The restored definitions are pg_get_functiondef() output
+  -- which is a complete CREATE OR REPLACE FUNCTION statement plus a
+  -- trailing semicolon; replaying them verbatim recreates the function
+  -- with its original body, parameter list, and return type.
+  CREATE TEMP TABLE IF NOT EXISTS _vw_regen_fn_deps (
+    schema_name TEXT,
+    fn_name     TEXT,
+    fn_oid      OID,
+    definition  TEXT
+  ) ON COMMIT DROP;
+  DELETE FROM _vw_regen_fn_deps;
+
+  -- Capture dependents. NOTES on the grants_sql build:
+  --   - Resolve role name via pg_get_userbyid(oid) — returns the bare,
+  --     unquoted role name (or 'unknown (OID=N)' if the oid no longer
+  --     exists). pg_get_userbyid is a public catalog function available to
+  --     every database user, including unprivileged accounts on managed
+  --     PostgreSQL services (Amazon RDS, Azure Database for PostgreSQL,
+  --     Cloud SQL) where pg_authid is restricted to the rds_superuser /
+  --     azure_pg_admin / cloudsqlsuperuser group. Earlier revisions joined
+  --     to pg_authid which works on self-hosted PG but fails with
+  --     "permission denied for table pg_authid" on managed services.
+  --   - The earlier (broken) approach cast (aclexplode).grantee::regrole::text
+  --     which RETURNS the role name pre-quoted when it contains uppercase
+  --     (e.g. cdp_Developer comes back already wrapped); calling quote_ident
+  --     on the already-quoted string double-wrapped and the GRANT failed at
+  --     replay with "role does not exist". Using
+  --     pg_get_userbyid returns a bare name and lets quote_ident wrap it
+  --     correctly exactly once.
+  --   - PUBLIC is grantee oid 0; pg_get_userbyid(0) returns 'unknown
+  --     (OID=0)' so handle the PUBLIC case explicitly and use it as the
+  --     literal 'PUBLIC' rather than quote_ident on the synthetic name.
+  INSERT INTO _vw_regen_deps (schema_name, view_name, relkind, definition, grants_sql)
+  SELECT DISTINCT
+      dn.nspname,
+      dc.relname,
+      dc.relkind,
+      pg_get_viewdef(dc.oid),
+      (SELECT string_agg(
+          'GRANT ' || g.privilege || ' ON ' || quote_ident(dn.nspname) || '.' || quote_ident(dc.relname) ||
+          ' TO ' || (CASE WHEN g.grantee_oid = 0 THEN 'PUBLIC' ELSE quote_ident(pg_get_userbyid(g.grantee_oid)) END) || ';',
+          E'
+')
+       FROM (
+           SELECT (aclexplode(dc.relacl)).grantee AS grantee_oid,
+                  (aclexplode(dc.relacl)).privilege_type AS privilege
+       ) g
+       WHERE g.privilege IN ('SELECT', 'INSERT', 'UPDATE', 'DELETE', 'TRUNCATE', 'REFERENCES', 'TRIGGER'))
+  FROM pg_depend d
+  JOIN pg_rewrite r ON r.oid = d.objid AND d.classid = 'pg_rewrite'::regclass
+  JOIN pg_class dc ON dc.oid = r.ev_class AND dc.relkind IN ('v', 'm')
+  JOIN pg_namespace dn ON dn.oid = dc.relnamespace
+  JOIN pg_class tc ON tc.oid = d.refobjid
+  JOIN pg_namespace tn ON tn.oid = tc.relnamespace
+  WHERE tn.nspname = '__mj'
+    AND tc.relname = 'vwAISkillSearchScopes'
+    AND tc.relkind IN ('v', 'm')
+    AND dc.oid <> tc.oid;
+
+  -- Capture dependent functions. Two paths matter on PG:
+  --   1. Functions whose RETURN type references the view (RETURNS SETOF
+  --      <view>) — pg_depend records this as type=pg_type → pg_class.
+  --   2. Functions whose body references the view (used by sql functions
+  --      and by some plpgsql edge cases) — pg_depend records this as
+  --      pg_proc → pg_class.
+  -- pg_get_functiondef returns a complete CREATE OR REPLACE FUNCTION
+  -- statement that we replay verbatim. We DO include RETURNS-only
+  -- references because that's the dominant codegen pattern (sp* CRUD
+  -- functions all RETURNS SETOF the matching vwX).
+  INSERT INTO _vw_regen_fn_deps (schema_name, fn_name, fn_oid, definition)
+  SELECT DISTINCT
+      pn.nspname,
+      pp.proname,
+      pp.oid,
+      pg_get_functiondef(pp.oid)
+  FROM pg_depend d
+  JOIN pg_proc pp ON pp.oid = d.objid AND d.classid = 'pg_proc'::regclass
+  JOIN pg_namespace pn ON pn.oid = pp.pronamespace
+  JOIN pg_class tc ON tc.oid = d.refobjid
+  JOIN pg_namespace tn ON tn.oid = tc.relnamespace
+  WHERE tn.nspname = '__mj'
+    AND tc.relname = 'vwAISkillSearchScopes'
+    AND tc.relkind IN ('v', 'm')
+  UNION
+  SELECT DISTINCT
+      pn.nspname,
+      pp.proname,
+      pp.oid,
+      pg_get_functiondef(pp.oid)
+  FROM pg_depend d
+  JOIN pg_type pt ON pt.oid = d.refobjid AND d.refclassid = 'pg_type'::regclass
+  JOIN pg_proc pp ON pp.prorettype = pt.oid OR pt.typrelid = pp.oid
+  JOIN pg_namespace pn ON pn.oid = pp.pronamespace
+  WHERE EXISTS (
+      SELECT 1 FROM pg_class tc
+      JOIN pg_namespace tn ON tn.oid = tc.relnamespace
+      WHERE tc.reltype = pt.oid
+        AND tn.nspname = '__mj'
+        AND tc.relname = 'vwAISkillSearchScopes'
+        AND tc.relkind IN ('v', 'm')
+  );
+
+  DROP VIEW IF EXISTS __mj."vwAISkillSearchScopes" CASCADE;
+  EXECUTE vsql;
+
+  -- Replay captured dependents. Best-effort: log + continue on failure.
+  -- IMPORTANT: the CREATE VIEW and the GRANTs run in SEPARATE inner BEGIN
+  -- blocks. PL/pgSQL's BEGIN ... EXCEPTION creates an implicit savepoint
+  -- and rolls back EVERY statement in the block on any exception. If we
+  -- combined CREATE+GRANT in one block and a GRANT failed (e.g. role not
+  -- present in target environment), the just-recreated VIEW would also
+  -- get rolled back and stay missing — the exact failure mode this
+  -- wrapper exists to prevent.
+  FOR rec IN SELECT schema_name, view_name, relkind, definition, grants_sql FROM _vw_regen_deps LOOP
+    BEGIN
+      IF rec.relkind = 'm' THEN
+        EXECUTE 'CREATE MATERIALIZED VIEW ' || quote_ident(rec.schema_name) || '.' || quote_ident(rec.view_name) || ' AS ' || rec.definition;
+      ELSE
+        EXECUTE 'CREATE VIEW ' || quote_ident(rec.schema_name) || '.' || quote_ident(rec.view_name) || ' AS ' || rec.definition;
+      END IF;
+    EXCEPTION WHEN OTHERS THEN
+      RAISE NOTICE 'Best-effort restore skipped dependent %.%: %', rec.schema_name, rec.view_name, SQLERRM;
+    END;
+
+    IF rec.grants_sql IS NOT NULL THEN
+      BEGIN
+        EXECUTE rec.grants_sql;
+      EXCEPTION WHEN OTHERS THEN
+        RAISE NOTICE 'Best-effort grant restore skipped %.%: %', rec.schema_name, rec.view_name, SQLERRM;
+      END;
+    END IF;
+  END LOOP;
+
+  -- Replay captured dependent functions AFTER all dependent views are
+  -- restored — most codegen-emitted sp* functions reference both the
+  -- target view AND the dependent views in their bodies/return types.
+  -- Wrapped per-function in its own savepoint so a single failure
+  -- doesn't poison subsequent restores or the just-recreated target.
+  FOR rec IN SELECT schema_name, fn_name, definition FROM _vw_regen_fn_deps LOOP
+    BEGIN
+      EXECUTE rec.definition;
+    EXCEPTION WHEN OTHERS THEN
+      RAISE NOTICE 'Best-effort restore skipped dependent function %.%: %', rec.schema_name, rec.fn_name, SQLERRM;
+    END;
+  END LOOP;
+
+  DROP TABLE _vw_regen_deps;
+  DROP TABLE _vw_regen_fn_deps;
+END $vw_regen$;
+GRANT SELECT ON __mj."vwAISkillSearchScopes" TO "cdp_UI";
+GRANT SELECT ON __mj."vwAISkillSearchScopes" TO "cdp_Developer";
+GRANT SELECT ON __mj."vwAISkillSearchScopes" TO "cdp_Integration";
+
+-- ============================================================
+-- PostgreSQL Generated SQL for Entity: MJ: AI Skill Search Scopes
+-- Item: spCreateAISkillSearchScope
+-- ============================================================
+
+------------------------------------------------------------
+----- CREATE FUNCTION FOR AISkillSearchScope
+------------------------------------------------------------
+DO $do$
+DECLARE r RECORD;
+BEGIN
+    FOR r IN SELECT oid::regprocedure AS sig
+             FROM pg_proc
+             WHERE proname = 'spCreateAISkillSearchScope'
+               AND pronamespace = '__mj'::regnamespace
+    LOOP
+        EXECUTE 'DROP FUNCTION ' || r.sig::text;
+    END LOOP;
+END
+$do$;
+
+CREATE OR REPLACE FUNCTION __mj."spCreateAISkillSearchScope"(
+    p_id UUID DEFAULT NULL,
+    p_skillid UUID DEFAULT NULL,
+    p_searchscopeid UUID DEFAULT NULL,
+    p_status varchar(20) DEFAULT NULL,
+    p_startat_clear boolean DEFAULT false,
+    p_startat TIMESTAMPTZ DEFAULT NULL,
+    p_endat_clear boolean DEFAULT false,
+    p_endat TIMESTAMPTZ DEFAULT NULL,
+    p_priority_clear boolean DEFAULT false,
+    p_priority int DEFAULT NULL,
+    p_isdefault BOOLEAN DEFAULT NULL
+) RETURNS SETOF __mj."vwAISkillSearchScopes" AS $$
+DECLARE
+    v_new_id UUID;
+BEGIN
+    v_new_id := COALESCE(p_id, gen_random_uuid());
+    INSERT INTO __mj."AISkillSearchScope"
+        (
+            "ID",
+            "SkillID",
+                "SearchScopeID",
+                "Status",
+                "StartAt",
+                "EndAt",
+                "Priority",
+                "IsDefault"
+        )
+    VALUES
+        (
+            v_new_id,
+            p_skillid,
+                p_searchscopeid,
+                COALESCE(p_status, 'Active'),
+                CASE WHEN p_startat_clear = true THEN NULL ELSE COALESCE(p_startat, NULL) END,
+                CASE WHEN p_endat_clear = true THEN NULL ELSE COALESCE(p_endat, NULL) END,
+                CASE WHEN p_priority_clear = true THEN NULL ELSE COALESCE(p_priority, NULL) END,
+                COALESCE(p_isdefault, FALSE)
+        )
+    ;
+
+    RETURN QUERY
+    SELECT * FROM __mj."vwAISkillSearchScopes"
+    WHERE "ID" = v_new_id;
+END;
+$$ LANGUAGE plpgsql;
+GRANT EXECUTE ON FUNCTION __mj."spCreateAISkillSearchScope" TO "cdp_Developer";
+GRANT EXECUTE ON FUNCTION __mj."spCreateAISkillSearchScope" TO "cdp_Integration";
+
+
+-- ============================================================
+-- PostgreSQL Generated SQL for Entity: MJ: AI Skill Search Scopes
+-- Item: spUpdateAISkillSearchScope
+-- ============================================================
+
+------------------------------------------------------------
+----- UPDATE FUNCTION FOR AISkillSearchScope
+------------------------------------------------------------
+DO $do$
+DECLARE r RECORD;
+BEGIN
+    FOR r IN SELECT oid::regprocedure AS sig
+             FROM pg_proc
+             WHERE proname = 'spUpdateAISkillSearchScope'
+               AND pronamespace = '__mj'::regnamespace
+    LOOP
+        EXECUTE 'DROP FUNCTION ' || r.sig::text;
+    END LOOP;
+END
+$do$;
+
+CREATE OR REPLACE FUNCTION __mj."spUpdateAISkillSearchScope"(
+    p_id UUID,
+    p_skillid UUID DEFAULT NULL,
+    p_searchscopeid UUID DEFAULT NULL,
+    p_status varchar(20) DEFAULT NULL,
+    p_startat_clear boolean DEFAULT false,
+    p_startat TIMESTAMPTZ DEFAULT NULL,
+    p_endat_clear boolean DEFAULT false,
+    p_endat TIMESTAMPTZ DEFAULT NULL,
+    p_priority_clear boolean DEFAULT false,
+    p_priority int DEFAULT NULL,
+    p_isdefault BOOLEAN DEFAULT NULL
+) RETURNS SETOF __mj."vwAISkillSearchScopes" AS $$
+DECLARE
+    v_updated_count INTEGER;
+BEGIN
+    UPDATE __mj."AISkillSearchScope"
+    SET
+        "SkillID" = COALESCE(p_skillid, "SkillID"),
+        "SearchScopeID" = COALESCE(p_searchscopeid, "SearchScopeID"),
+        "Status" = COALESCE(p_status, "Status"),
+        "StartAt" = CASE WHEN p_startat_clear = true THEN NULL ELSE COALESCE(p_startat, "StartAt") END,
+        "EndAt" = CASE WHEN p_endat_clear = true THEN NULL ELSE COALESCE(p_endat, "EndAt") END,
+        "Priority" = CASE WHEN p_priority_clear = true THEN NULL ELSE COALESCE(p_priority, "Priority") END,
+        "IsDefault" = COALESCE(p_isdefault, "IsDefault")
+    WHERE
+        "ID" = p_id;
+
+    GET DIAGNOSTICS v_updated_count = ROW_COUNT;
+
+    IF v_updated_count = 0 THEN
+        -- Nothing was updated, return empty result set
+        RETURN;
+    END IF;
+
+    -- Return the updated record from the base view
+    RETURN QUERY
+    SELECT * FROM __mj."vwAISkillSearchScopes"
+    WHERE "ID" = p_id;
+END;
+$$ LANGUAGE plpgsql;
+GRANT EXECUTE ON FUNCTION __mj."spUpdateAISkillSearchScope" TO "cdp_Developer";
+GRANT EXECUTE ON FUNCTION __mj."spUpdateAISkillSearchScope" TO "cdp_Integration";
+
+
+------------------------------------------------------------
+----- TRIGGER FOR __mj_UpdatedAt field for the AISkillSearchScope table
+------------------------------------------------------------
+CREATE OR REPLACE FUNCTION __mj."fn_trg_update_ai_skill_search_scope"()
+RETURNS TRIGGER AS $$
+BEGIN
+    NEW."__mj_UpdatedAt" := NOW() AT TIME ZONE 'UTC';
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+DROP TRIGGER IF EXISTS "trg_update_ai_skill_search_scope" ON __mj."AISkillSearchScope";
+
+CREATE TRIGGER "trg_update_ai_skill_search_scope"
+BEFORE UPDATE ON __mj."AISkillSearchScope"
+FOR EACH ROW
+EXECUTE FUNCTION __mj."fn_trg_update_ai_skill_search_scope"();
+
+
+
+-- ============================================================
+-- PostgreSQL Generated SQL for Entity: MJ: AI Skill Search Scopes
+-- Item: spDeleteAISkillSearchScope
+-- ============================================================
+
+------------------------------------------------------------
+----- DELETE FUNCTION FOR AISkillSearchScope
+------------------------------------------------------------
+DO $do$
+DECLARE r RECORD;
+BEGIN
+    FOR r IN SELECT oid::regprocedure AS sig
+             FROM pg_proc
+             WHERE proname = 'spDeleteAISkillSearchScope'
+               AND pronamespace = '__mj'::regnamespace
+    LOOP
+        EXECUTE 'DROP FUNCTION ' || r.sig::text;
+    END LOOP;
+END
+$do$;
+
+CREATE OR REPLACE FUNCTION __mj."spDeleteAISkillSearchScope"(
+    p_id UUID
+) RETURNS TABLE("ID" UUID) AS $$
+#variable_conflict use_column
+DECLARE
+    v_affected_count INTEGER;
+BEGIN
+
+    DELETE FROM __mj."AISkillSearchScope"
+    WHERE "ID" = p_id;
+
+    GET DIAGNOSTICS v_affected_count = ROW_COUNT;
+
+    IF v_affected_count = 0 THEN
+        RETURN QUERY SELECT NULL::UUID AS "ID";
+    ELSE
+        RETURN QUERY SELECT p_id AS "ID";
+    END IF;
+END;
+$$ LANGUAGE plpgsql;
+GRANT EXECUTE ON FUNCTION __mj."spDeleteAISkillSearchScope" TO "cdp_Developer";
+GRANT EXECUTE ON FUNCTION __mj."spDeleteAISkillSearchScope" TO "cdp_Integration";
+
+-- ============================================================
+-- PostgreSQL Generated SQL for Entity: MJ: AI Skills
+-- Item: Index for Foreign Keys
+-- ============================================================
+CREATE INDEX IF NOT EXISTS "idx_auto_mj_fkey_ai_skill_created_by_user_id"
+    ON __mj."AISkill" ("CreatedByUserID");
+
+-- ============================================================
+-- PostgreSQL Generated SQL for Entity: MJ: AI Skills
+-- Item: vwAISkills
+-- ============================================================
+
+------------------------------------------------------------
+----- BASE VIEW FOR ENTITY:      MJ: AI Skills
+-----               SCHEMA:      __mj
+-----               BASE TABLE:  AISkill
+-----               PRIMARY KEY: ID
+------------------------------------------------------------
+DO $vw_regen$
+DECLARE
+  vsql CONSTANT TEXT := $vsql$CREATE OR REPLACE VIEW __mj."vwAISkills"
+AS
+SELECT
+    a.*,
+    MJUser_CreatedByUserID."Name" AS "CreatedByUser"
+FROM
+    __mj."AISkill" AS a
+INNER JOIN
+    __mj."User" AS MJUser_CreatedByUserID
+  ON
+    "a"."CreatedByUserID" = MJUser_CreatedByUserID."ID"
+$vsql$;
+  rec RECORD;
+BEGIN
+  EXECUTE vsql;
+EXCEPTION WHEN invalid_table_definition THEN
+  -- 42P16: column rename/reorder/type change. CREATE OR REPLACE can't handle
+  -- non-additive shape changes — must DROP CASCADE + recreate. CASCADE drops
+  -- every dependent view (anything that JOINs this view in its body), so we
+  -- capture each dependent's definition + grants BEFORE the drop and replay
+  -- them afterward (best-effort). Without this, on a fresh-DB replay where
+  -- one entity's wrapper triggers (e.g. vwAIModelTypes shape changed since
+  -- baseline V202605021056), CASCADE wipes downstream views (vwAIModels)
+  -- that the wrapper for this entity doesn't know how to recreate, and
+  -- those views stay permanently missing.
+  CREATE TEMP TABLE IF NOT EXISTS _vw_regen_deps (
+    schema_name TEXT,
+    view_name   TEXT,
+    relkind     CHAR(1),
+    definition  TEXT,
+    grants_sql  TEXT
+  ) ON COMMIT DROP;
+  DELETE FROM _vw_regen_deps;
+
+  -- Capture dependent FUNCTIONS too. CASCADE drops every function with
+  -- RETURNS SETOF <view> (the codegen-emitted spCreate/spUpdate/spDelete
+  -- pattern) when the target view is dropped. Without restoring them,
+  -- post-codegen CRUD validation reports those routines as missing —
+  -- e.g. "MJ: Recommendation Items → missing create routine
+  -- spCreateRecommendationItem" — even though the next codegen pass
+  -- emits them. The restored definitions are pg_get_functiondef() output
+  -- which is a complete CREATE OR REPLACE FUNCTION statement plus a
+  -- trailing semicolon; replaying them verbatim recreates the function
+  -- with its original body, parameter list, and return type.
+  CREATE TEMP TABLE IF NOT EXISTS _vw_regen_fn_deps (
+    schema_name TEXT,
+    fn_name     TEXT,
+    fn_oid      OID,
+    definition  TEXT
+  ) ON COMMIT DROP;
+  DELETE FROM _vw_regen_fn_deps;
+
+  -- Capture dependents. NOTES on the grants_sql build:
+  --   - Resolve role name via pg_get_userbyid(oid) — returns the bare,
+  --     unquoted role name (or 'unknown (OID=N)' if the oid no longer
+  --     exists). pg_get_userbyid is a public catalog function available to
+  --     every database user, including unprivileged accounts on managed
+  --     PostgreSQL services (Amazon RDS, Azure Database for PostgreSQL,
+  --     Cloud SQL) where pg_authid is restricted to the rds_superuser /
+  --     azure_pg_admin / cloudsqlsuperuser group. Earlier revisions joined
+  --     to pg_authid which works on self-hosted PG but fails with
+  --     "permission denied for table pg_authid" on managed services.
+  --   - The earlier (broken) approach cast (aclexplode).grantee::regrole::text
+  --     which RETURNS the role name pre-quoted when it contains uppercase
+  --     (e.g. cdp_Developer comes back already wrapped); calling quote_ident
+  --     on the already-quoted string double-wrapped and the GRANT failed at
+  --     replay with "role does not exist". Using
+  --     pg_get_userbyid returns a bare name and lets quote_ident wrap it
+  --     correctly exactly once.
+  --   - PUBLIC is grantee oid 0; pg_get_userbyid(0) returns 'unknown
+  --     (OID=0)' so handle the PUBLIC case explicitly and use it as the
+  --     literal 'PUBLIC' rather than quote_ident on the synthetic name.
+  INSERT INTO _vw_regen_deps (schema_name, view_name, relkind, definition, grants_sql)
+  SELECT DISTINCT
+      dn.nspname,
+      dc.relname,
+      dc.relkind,
+      pg_get_viewdef(dc.oid),
+      (SELECT string_agg(
+          'GRANT ' || g.privilege || ' ON ' || quote_ident(dn.nspname) || '.' || quote_ident(dc.relname) ||
+          ' TO ' || (CASE WHEN g.grantee_oid = 0 THEN 'PUBLIC' ELSE quote_ident(pg_get_userbyid(g.grantee_oid)) END) || ';',
+          E'
+')
+       FROM (
+           SELECT (aclexplode(dc.relacl)).grantee AS grantee_oid,
+                  (aclexplode(dc.relacl)).privilege_type AS privilege
+       ) g
+       WHERE g.privilege IN ('SELECT', 'INSERT', 'UPDATE', 'DELETE', 'TRUNCATE', 'REFERENCES', 'TRIGGER'))
+  FROM pg_depend d
+  JOIN pg_rewrite r ON r.oid = d.objid AND d.classid = 'pg_rewrite'::regclass
+  JOIN pg_class dc ON dc.oid = r.ev_class AND dc.relkind IN ('v', 'm')
+  JOIN pg_namespace dn ON dn.oid = dc.relnamespace
+  JOIN pg_class tc ON tc.oid = d.refobjid
+  JOIN pg_namespace tn ON tn.oid = tc.relnamespace
+  WHERE tn.nspname = '__mj'
+    AND tc.relname = 'vwAISkills'
+    AND tc.relkind IN ('v', 'm')
+    AND dc.oid <> tc.oid;
+
+  -- Capture dependent functions. Two paths matter on PG:
+  --   1. Functions whose RETURN type references the view (RETURNS SETOF
+  --      <view>) — pg_depend records this as type=pg_type → pg_class.
+  --   2. Functions whose body references the view (used by sql functions
+  --      and by some plpgsql edge cases) — pg_depend records this as
+  --      pg_proc → pg_class.
+  -- pg_get_functiondef returns a complete CREATE OR REPLACE FUNCTION
+  -- statement that we replay verbatim. We DO include RETURNS-only
+  -- references because that's the dominant codegen pattern (sp* CRUD
+  -- functions all RETURNS SETOF the matching vwX).
+  INSERT INTO _vw_regen_fn_deps (schema_name, fn_name, fn_oid, definition)
+  SELECT DISTINCT
+      pn.nspname,
+      pp.proname,
+      pp.oid,
+      pg_get_functiondef(pp.oid)
+  FROM pg_depend d
+  JOIN pg_proc pp ON pp.oid = d.objid AND d.classid = 'pg_proc'::regclass
+  JOIN pg_namespace pn ON pn.oid = pp.pronamespace
+  JOIN pg_class tc ON tc.oid = d.refobjid
+  JOIN pg_namespace tn ON tn.oid = tc.relnamespace
+  WHERE tn.nspname = '__mj'
+    AND tc.relname = 'vwAISkills'
+    AND tc.relkind IN ('v', 'm')
+  UNION
+  SELECT DISTINCT
+      pn.nspname,
+      pp.proname,
+      pp.oid,
+      pg_get_functiondef(pp.oid)
+  FROM pg_depend d
+  JOIN pg_type pt ON pt.oid = d.refobjid AND d.refclassid = 'pg_type'::regclass
+  JOIN pg_proc pp ON pp.prorettype = pt.oid OR pt.typrelid = pp.oid
+  JOIN pg_namespace pn ON pn.oid = pp.pronamespace
+  WHERE EXISTS (
+      SELECT 1 FROM pg_class tc
+      JOIN pg_namespace tn ON tn.oid = tc.relnamespace
+      WHERE tc.reltype = pt.oid
+        AND tn.nspname = '__mj'
+        AND tc.relname = 'vwAISkills'
+        AND tc.relkind IN ('v', 'm')
+  );
+
+  DROP VIEW IF EXISTS __mj."vwAISkills" CASCADE;
+  EXECUTE vsql;
+
+  -- Replay captured dependents. Best-effort: log + continue on failure.
+  -- IMPORTANT: the CREATE VIEW and the GRANTs run in SEPARATE inner BEGIN
+  -- blocks. PL/pgSQL's BEGIN ... EXCEPTION creates an implicit savepoint
+  -- and rolls back EVERY statement in the block on any exception. If we
+  -- combined CREATE+GRANT in one block and a GRANT failed (e.g. role not
+  -- present in target environment), the just-recreated VIEW would also
+  -- get rolled back and stay missing — the exact failure mode this
+  -- wrapper exists to prevent.
+  FOR rec IN SELECT schema_name, view_name, relkind, definition, grants_sql FROM _vw_regen_deps LOOP
+    BEGIN
+      IF rec.relkind = 'm' THEN
+        EXECUTE 'CREATE MATERIALIZED VIEW ' || quote_ident(rec.schema_name) || '.' || quote_ident(rec.view_name) || ' AS ' || rec.definition;
+      ELSE
+        EXECUTE 'CREATE VIEW ' || quote_ident(rec.schema_name) || '.' || quote_ident(rec.view_name) || ' AS ' || rec.definition;
+      END IF;
+    EXCEPTION WHEN OTHERS THEN
+      RAISE NOTICE 'Best-effort restore skipped dependent %.%: %', rec.schema_name, rec.view_name, SQLERRM;
+    END;
+
+    IF rec.grants_sql IS NOT NULL THEN
+      BEGIN
+        EXECUTE rec.grants_sql;
+      EXCEPTION WHEN OTHERS THEN
+        RAISE NOTICE 'Best-effort grant restore skipped %.%: %', rec.schema_name, rec.view_name, SQLERRM;
+      END;
+    END IF;
+  END LOOP;
+
+  -- Replay captured dependent functions AFTER all dependent views are
+  -- restored — most codegen-emitted sp* functions reference both the
+  -- target view AND the dependent views in their bodies/return types.
+  -- Wrapped per-function in its own savepoint so a single failure
+  -- doesn't poison subsequent restores or the just-recreated target.
+  FOR rec IN SELECT schema_name, fn_name, definition FROM _vw_regen_fn_deps LOOP
+    BEGIN
+      EXECUTE rec.definition;
+    EXCEPTION WHEN OTHERS THEN
+      RAISE NOTICE 'Best-effort restore skipped dependent function %.%: %', rec.schema_name, rec.fn_name, SQLERRM;
+    END;
+  END LOOP;
+
+  DROP TABLE _vw_regen_deps;
+  DROP TABLE _vw_regen_fn_deps;
+END $vw_regen$;
+GRANT SELECT ON __mj."vwAISkills" TO "cdp_UI";
+GRANT SELECT ON __mj."vwAISkills" TO "cdp_Developer";
+GRANT SELECT ON __mj."vwAISkills" TO "cdp_Integration";
+
+-- ============================================================
+-- PostgreSQL Generated SQL for Entity: MJ: AI Skills
+-- Item: spCreateAISkill
+-- ============================================================
+
+------------------------------------------------------------
+----- CREATE FUNCTION FOR AISkill
+------------------------------------------------------------
+DO $do$
+DECLARE r RECORD;
+BEGIN
+    FOR r IN SELECT oid::regprocedure AS sig
+             FROM pg_proc
+             WHERE proname = 'spCreateAISkill'
+               AND pronamespace = '__mj'::regnamespace
+    LOOP
+        EXECUTE 'DROP FUNCTION ' || r.sig::text;
+    END LOOP;
+END
+$do$;
+
+CREATE OR REPLACE FUNCTION __mj."spCreateAISkill"(
+    p_id UUID DEFAULT NULL,
+    p_name varchar(255) DEFAULT NULL,
+    p_description_clear boolean DEFAULT false,
+    p_description TEXT DEFAULT NULL,
+    p_instructions TEXT DEFAULT NULL,
+    p_status varchar(20) DEFAULT NULL,
+    p_category_clear boolean DEFAULT false,
+    p_category varchar(100) DEFAULT NULL,
+    p_iconclass_clear boolean DEFAULT false,
+    p_iconclass varchar(100) DEFAULT NULL,
+    p_color_clear boolean DEFAULT false,
+    p_color varchar(50) DEFAULT NULL,
+    p_createdbyuserid UUID DEFAULT NULL,
+    p_activationmode varchar(20) DEFAULT NULL,
+    p_searchscopeaccess_clear boolean DEFAULT false,
+    p_searchscopeaccess varchar(20) DEFAULT NULL
+) RETURNS SETOF __mj."vwAISkills" AS $$
+DECLARE
+    v_new_id UUID;
+BEGIN
+    v_new_id := COALESCE(p_id, gen_random_uuid());
+    INSERT INTO __mj."AISkill"
+        (
+            "ID",
+            "Name",
+                "Description",
+                "Instructions",
+                "Status",
+                "Category",
+                "IconClass",
+                "Color",
+                "CreatedByUserID",
+                "ActivationMode",
+                "SearchScopeAccess"
+        )
+    VALUES
+        (
+            v_new_id,
+            p_name,
+                CASE WHEN p_description_clear = true THEN NULL ELSE COALESCE(p_description, NULL) END,
+                p_instructions,
+                COALESCE(p_status, 'Active'),
+                CASE WHEN p_category_clear = true THEN NULL ELSE COALESCE(p_category, NULL) END,
+                CASE WHEN p_iconclass_clear = true THEN NULL ELSE COALESCE(p_iconclass, NULL) END,
+                CASE WHEN p_color_clear = true THEN NULL ELSE COALESCE(p_color, NULL) END,
+                p_createdbyuserid,
+                COALESCE(p_activationmode, 'RequestedOnly'),
+                CASE WHEN p_searchscopeaccess_clear = true THEN NULL ELSE COALESCE(p_searchscopeaccess, NULL) END
+        )
+    ;
+
+    RETURN QUERY
+    SELECT * FROM __mj."vwAISkills"
+    WHERE "ID" = v_new_id;
+END;
+$$ LANGUAGE plpgsql;
+GRANT EXECUTE ON FUNCTION __mj."spCreateAISkill" TO "cdp_Developer";
+GRANT EXECUTE ON FUNCTION __mj."spCreateAISkill" TO "cdp_Integration";
+
+
+-- ============================================================
+-- PostgreSQL Generated SQL for Entity: MJ: AI Skills
+-- Item: spUpdateAISkill
+-- ============================================================
+
+------------------------------------------------------------
+----- UPDATE FUNCTION FOR AISkill
+------------------------------------------------------------
+DO $do$
+DECLARE r RECORD;
+BEGIN
+    FOR r IN SELECT oid::regprocedure AS sig
+             FROM pg_proc
+             WHERE proname = 'spUpdateAISkill'
+               AND pronamespace = '__mj'::regnamespace
+    LOOP
+        EXECUTE 'DROP FUNCTION ' || r.sig::text;
+    END LOOP;
+END
+$do$;
+
+CREATE OR REPLACE FUNCTION __mj."spUpdateAISkill"(
+    p_id UUID,
+    p_name varchar(255) DEFAULT NULL,
+    p_description_clear boolean DEFAULT false,
+    p_description TEXT DEFAULT NULL,
+    p_instructions TEXT DEFAULT NULL,
+    p_status varchar(20) DEFAULT NULL,
+    p_category_clear boolean DEFAULT false,
+    p_category varchar(100) DEFAULT NULL,
+    p_iconclass_clear boolean DEFAULT false,
+    p_iconclass varchar(100) DEFAULT NULL,
+    p_color_clear boolean DEFAULT false,
+    p_color varchar(50) DEFAULT NULL,
+    p_createdbyuserid UUID DEFAULT NULL,
+    p_activationmode varchar(20) DEFAULT NULL,
+    p_searchscopeaccess_clear boolean DEFAULT false,
+    p_searchscopeaccess varchar(20) DEFAULT NULL
+) RETURNS SETOF __mj."vwAISkills" AS $$
+DECLARE
+    v_updated_count INTEGER;
+BEGIN
+    UPDATE __mj."AISkill"
+    SET
+        "Name" = COALESCE(p_name, "Name"),
+        "Description" = CASE WHEN p_description_clear = true THEN NULL ELSE COALESCE(p_description, "Description") END,
+        "Instructions" = COALESCE(p_instructions, "Instructions"),
+        "Status" = COALESCE(p_status, "Status"),
+        "Category" = CASE WHEN p_category_clear = true THEN NULL ELSE COALESCE(p_category, "Category") END,
+        "IconClass" = CASE WHEN p_iconclass_clear = true THEN NULL ELSE COALESCE(p_iconclass, "IconClass") END,
+        "Color" = CASE WHEN p_color_clear = true THEN NULL ELSE COALESCE(p_color, "Color") END,
+        "CreatedByUserID" = COALESCE(p_createdbyuserid, "CreatedByUserID"),
+        "ActivationMode" = COALESCE(p_activationmode, "ActivationMode"),
+        "SearchScopeAccess" = CASE WHEN p_searchscopeaccess_clear = true THEN NULL ELSE COALESCE(p_searchscopeaccess, "SearchScopeAccess") END
+    WHERE
+        "ID" = p_id;
+
+    GET DIAGNOSTICS v_updated_count = ROW_COUNT;
+
+    IF v_updated_count = 0 THEN
+        -- Nothing was updated, return empty result set
+        RETURN;
+    END IF;
+
+    -- Return the updated record from the base view
+    RETURN QUERY
+    SELECT * FROM __mj."vwAISkills"
+    WHERE "ID" = p_id;
+END;
+$$ LANGUAGE plpgsql;
+GRANT EXECUTE ON FUNCTION __mj."spUpdateAISkill" TO "cdp_Developer";
+GRANT EXECUTE ON FUNCTION __mj."spUpdateAISkill" TO "cdp_Integration";
+
+
+------------------------------------------------------------
+----- TRIGGER FOR __mj_UpdatedAt field for the AISkill table
+------------------------------------------------------------
+CREATE OR REPLACE FUNCTION __mj."fn_trg_update_ai_skill"()
+RETURNS TRIGGER AS $$
+BEGIN
+    NEW."__mj_UpdatedAt" := NOW() AT TIME ZONE 'UTC';
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+DROP TRIGGER IF EXISTS "trg_update_ai_skill" ON __mj."AISkill";
+
+CREATE TRIGGER "trg_update_ai_skill"
+BEFORE UPDATE ON __mj."AISkill"
+FOR EACH ROW
+EXECUTE FUNCTION __mj."fn_trg_update_ai_skill"();
+
+
+
+-- ============================================================
+-- PostgreSQL Generated SQL for Entity: MJ: AI Skills
+-- Item: spDeleteAISkill
+-- ============================================================
+
+------------------------------------------------------------
+----- DELETE FUNCTION FOR AISkill
+------------------------------------------------------------
+DO $do$
+DECLARE r RECORD;
+BEGIN
+    FOR r IN SELECT oid::regprocedure AS sig
+             FROM pg_proc
+             WHERE proname = 'spDeleteAISkill'
+               AND pronamespace = '__mj'::regnamespace
+    LOOP
+        EXECUTE 'DROP FUNCTION ' || r.sig::text;
+    END LOOP;
+END
+$do$;
+
+CREATE OR REPLACE FUNCTION __mj."spDeleteAISkill"(
+    p_id UUID
+) RETURNS TABLE("ID" UUID) AS $$
+#variable_conflict use_column
+DECLARE
+    v_affected_count INTEGER;
+BEGIN
+
+    DELETE FROM __mj."AISkill"
+    WHERE "ID" = p_id;
+
+    GET DIAGNOSTICS v_affected_count = ROW_COUNT;
+
+    IF v_affected_count = 0 THEN
+        RETURN QUERY SELECT NULL::UUID AS "ID";
+    ELSE
+        RETURN QUERY SELECT p_id AS "ID";
+    END IF;
+END;
+$$ LANGUAGE plpgsql;
+GRANT EXECUTE ON FUNCTION __mj."spDeleteAISkill" TO "cdp_Developer";
+GRANT EXECUTE ON FUNCTION __mj."spDeleteAISkill" TO "cdp_Integration";
+
+-- ============================================================
+-- PostgreSQL Generated SQL for Entity: MJ: Search Execution Logs
+-- Item: Index for Foreign Keys
+-- ============================================================
+CREATE INDEX IF NOT EXISTS "idx_auto_mj_fkey_search_execution_log_search_scope_id"
+    ON __mj."SearchExecutionLog" ("SearchScopeID");
+
+CREATE INDEX IF NOT EXISTS "idx_auto_mj_fkey_search_execution_log_user_id"
+    ON __mj."SearchExecutionLog" ("UserID");
+
+CREATE INDEX IF NOT EXISTS "idx_auto_mj_fkey_search_execution_log_ai_agent_id"
+    ON __mj."SearchExecutionLog" ("AIAgentID");
+
+CREATE INDEX IF NOT EXISTS "idx_auto_mj_fkey_search_execution_log_ai_skill_id"
+    ON __mj."SearchExecutionLog" ("AISkillID");
+
+-- ============================================================
+-- PostgreSQL Generated SQL for Entity: MJ: Search Execution Logs
+-- Item: vwSearchExecutionLogs
+-- ============================================================
+
+------------------------------------------------------------
+----- BASE VIEW FOR ENTITY:      MJ: Search Execution Logs
+-----               SCHEMA:      __mj
+-----               BASE TABLE:  SearchExecutionLog
+-----               PRIMARY KEY: ID
+------------------------------------------------------------
+DO $vw_regen$
+DECLARE
+  vsql CONSTANT TEXT := $vsql$CREATE OR REPLACE VIEW __mj."vwSearchExecutionLogs"
+AS
+SELECT
+    s.*,
+    MJSearchScope_SearchScopeID."Name" AS "SearchScope",
+    MJUser_UserID."Name" AS "User",
+    MJAIAgent_AIAgentID."Name" AS "AIAgent",
+    MJAISkill_AISkillID."Name" AS "AISkill"
+FROM
+    __mj."SearchExecutionLog" AS s
+LEFT OUTER JOIN
+    __mj."SearchScope" AS MJSearchScope_SearchScopeID
+  ON
+    "s"."SearchScopeID" = MJSearchScope_SearchScopeID."ID"
+LEFT OUTER JOIN
+    __mj."User" AS MJUser_UserID
+  ON
+    "s"."UserID" = MJUser_UserID."ID"
+LEFT OUTER JOIN
+    __mj."AIAgent" AS MJAIAgent_AIAgentID
+  ON
+    "s"."AIAgentID" = MJAIAgent_AIAgentID."ID"
+LEFT OUTER JOIN
+    __mj."AISkill" AS MJAISkill_AISkillID
+  ON
+    "s"."AISkillID" = MJAISkill_AISkillID."ID"
+$vsql$;
+  rec RECORD;
+BEGIN
+  EXECUTE vsql;
+EXCEPTION WHEN invalid_table_definition THEN
+  -- 42P16: column rename/reorder/type change. CREATE OR REPLACE can't handle
+  -- non-additive shape changes — must DROP CASCADE + recreate. CASCADE drops
+  -- every dependent view (anything that JOINs this view in its body), so we
+  -- capture each dependent's definition + grants BEFORE the drop and replay
+  -- them afterward (best-effort). Without this, on a fresh-DB replay where
+  -- one entity's wrapper triggers (e.g. vwAIModelTypes shape changed since
+  -- baseline V202605021056), CASCADE wipes downstream views (vwAIModels)
+  -- that the wrapper for this entity doesn't know how to recreate, and
+  -- those views stay permanently missing.
+  CREATE TEMP TABLE IF NOT EXISTS _vw_regen_deps (
+    schema_name TEXT,
+    view_name   TEXT,
+    relkind     CHAR(1),
+    definition  TEXT,
+    grants_sql  TEXT
+  ) ON COMMIT DROP;
+  DELETE FROM _vw_regen_deps;
+
+  -- Capture dependent FUNCTIONS too. CASCADE drops every function with
+  -- RETURNS SETOF <view> (the codegen-emitted spCreate/spUpdate/spDelete
+  -- pattern) when the target view is dropped. Without restoring them,
+  -- post-codegen CRUD validation reports those routines as missing —
+  -- e.g. "MJ: Recommendation Items → missing create routine
+  -- spCreateRecommendationItem" — even though the next codegen pass
+  -- emits them. The restored definitions are pg_get_functiondef() output
+  -- which is a complete CREATE OR REPLACE FUNCTION statement plus a
+  -- trailing semicolon; replaying them verbatim recreates the function
+  -- with its original body, parameter list, and return type.
+  CREATE TEMP TABLE IF NOT EXISTS _vw_regen_fn_deps (
+    schema_name TEXT,
+    fn_name     TEXT,
+    fn_oid      OID,
+    definition  TEXT
+  ) ON COMMIT DROP;
+  DELETE FROM _vw_regen_fn_deps;
+
+  -- Capture dependents. NOTES on the grants_sql build:
+  --   - Resolve role name via pg_get_userbyid(oid) — returns the bare,
+  --     unquoted role name (or 'unknown (OID=N)' if the oid no longer
+  --     exists). pg_get_userbyid is a public catalog function available to
+  --     every database user, including unprivileged accounts on managed
+  --     PostgreSQL services (Amazon RDS, Azure Database for PostgreSQL,
+  --     Cloud SQL) where pg_authid is restricted to the rds_superuser /
+  --     azure_pg_admin / cloudsqlsuperuser group. Earlier revisions joined
+  --     to pg_authid which works on self-hosted PG but fails with
+  --     "permission denied for table pg_authid" on managed services.
+  --   - The earlier (broken) approach cast (aclexplode).grantee::regrole::text
+  --     which RETURNS the role name pre-quoted when it contains uppercase
+  --     (e.g. cdp_Developer comes back already wrapped); calling quote_ident
+  --     on the already-quoted string double-wrapped and the GRANT failed at
+  --     replay with "role does not exist". Using
+  --     pg_get_userbyid returns a bare name and lets quote_ident wrap it
+  --     correctly exactly once.
+  --   - PUBLIC is grantee oid 0; pg_get_userbyid(0) returns 'unknown
+  --     (OID=0)' so handle the PUBLIC case explicitly and use it as the
+  --     literal 'PUBLIC' rather than quote_ident on the synthetic name.
+  INSERT INTO _vw_regen_deps (schema_name, view_name, relkind, definition, grants_sql)
+  SELECT DISTINCT
+      dn.nspname,
+      dc.relname,
+      dc.relkind,
+      pg_get_viewdef(dc.oid),
+      (SELECT string_agg(
+          'GRANT ' || g.privilege || ' ON ' || quote_ident(dn.nspname) || '.' || quote_ident(dc.relname) ||
+          ' TO ' || (CASE WHEN g.grantee_oid = 0 THEN 'PUBLIC' ELSE quote_ident(pg_get_userbyid(g.grantee_oid)) END) || ';',
+          E'
+')
+       FROM (
+           SELECT (aclexplode(dc.relacl)).grantee AS grantee_oid,
+                  (aclexplode(dc.relacl)).privilege_type AS privilege
+       ) g
+       WHERE g.privilege IN ('SELECT', 'INSERT', 'UPDATE', 'DELETE', 'TRUNCATE', 'REFERENCES', 'TRIGGER'))
+  FROM pg_depend d
+  JOIN pg_rewrite r ON r.oid = d.objid AND d.classid = 'pg_rewrite'::regclass
+  JOIN pg_class dc ON dc.oid = r.ev_class AND dc.relkind IN ('v', 'm')
+  JOIN pg_namespace dn ON dn.oid = dc.relnamespace
+  JOIN pg_class tc ON tc.oid = d.refobjid
+  JOIN pg_namespace tn ON tn.oid = tc.relnamespace
+  WHERE tn.nspname = '__mj'
+    AND tc.relname = 'vwSearchExecutionLogs'
+    AND tc.relkind IN ('v', 'm')
+    AND dc.oid <> tc.oid;
+
+  -- Capture dependent functions. Two paths matter on PG:
+  --   1. Functions whose RETURN type references the view (RETURNS SETOF
+  --      <view>) — pg_depend records this as type=pg_type → pg_class.
+  --   2. Functions whose body references the view (used by sql functions
+  --      and by some plpgsql edge cases) — pg_depend records this as
+  --      pg_proc → pg_class.
+  -- pg_get_functiondef returns a complete CREATE OR REPLACE FUNCTION
+  -- statement that we replay verbatim. We DO include RETURNS-only
+  -- references because that's the dominant codegen pattern (sp* CRUD
+  -- functions all RETURNS SETOF the matching vwX).
+  INSERT INTO _vw_regen_fn_deps (schema_name, fn_name, fn_oid, definition)
+  SELECT DISTINCT
+      pn.nspname,
+      pp.proname,
+      pp.oid,
+      pg_get_functiondef(pp.oid)
+  FROM pg_depend d
+  JOIN pg_proc pp ON pp.oid = d.objid AND d.classid = 'pg_proc'::regclass
+  JOIN pg_namespace pn ON pn.oid = pp.pronamespace
+  JOIN pg_class tc ON tc.oid = d.refobjid
+  JOIN pg_namespace tn ON tn.oid = tc.relnamespace
+  WHERE tn.nspname = '__mj'
+    AND tc.relname = 'vwSearchExecutionLogs'
+    AND tc.relkind IN ('v', 'm')
+  UNION
+  SELECT DISTINCT
+      pn.nspname,
+      pp.proname,
+      pp.oid,
+      pg_get_functiondef(pp.oid)
+  FROM pg_depend d
+  JOIN pg_type pt ON pt.oid = d.refobjid AND d.refclassid = 'pg_type'::regclass
+  JOIN pg_proc pp ON pp.prorettype = pt.oid OR pt.typrelid = pp.oid
+  JOIN pg_namespace pn ON pn.oid = pp.pronamespace
+  WHERE EXISTS (
+      SELECT 1 FROM pg_class tc
+      JOIN pg_namespace tn ON tn.oid = tc.relnamespace
+      WHERE tc.reltype = pt.oid
+        AND tn.nspname = '__mj'
+        AND tc.relname = 'vwSearchExecutionLogs'
+        AND tc.relkind IN ('v', 'm')
+  );
+
+  DROP VIEW IF EXISTS __mj."vwSearchExecutionLogs" CASCADE;
+  EXECUTE vsql;
+
+  -- Replay captured dependents. Best-effort: log + continue on failure.
+  -- IMPORTANT: the CREATE VIEW and the GRANTs run in SEPARATE inner BEGIN
+  -- blocks. PL/pgSQL's BEGIN ... EXCEPTION creates an implicit savepoint
+  -- and rolls back EVERY statement in the block on any exception. If we
+  -- combined CREATE+GRANT in one block and a GRANT failed (e.g. role not
+  -- present in target environment), the just-recreated VIEW would also
+  -- get rolled back and stay missing — the exact failure mode this
+  -- wrapper exists to prevent.
+  FOR rec IN SELECT schema_name, view_name, relkind, definition, grants_sql FROM _vw_regen_deps LOOP
+    BEGIN
+      IF rec.relkind = 'm' THEN
+        EXECUTE 'CREATE MATERIALIZED VIEW ' || quote_ident(rec.schema_name) || '.' || quote_ident(rec.view_name) || ' AS ' || rec.definition;
+      ELSE
+        EXECUTE 'CREATE VIEW ' || quote_ident(rec.schema_name) || '.' || quote_ident(rec.view_name) || ' AS ' || rec.definition;
+      END IF;
+    EXCEPTION WHEN OTHERS THEN
+      RAISE NOTICE 'Best-effort restore skipped dependent %.%: %', rec.schema_name, rec.view_name, SQLERRM;
+    END;
+
+    IF rec.grants_sql IS NOT NULL THEN
+      BEGIN
+        EXECUTE rec.grants_sql;
+      EXCEPTION WHEN OTHERS THEN
+        RAISE NOTICE 'Best-effort grant restore skipped %.%: %', rec.schema_name, rec.view_name, SQLERRM;
+      END;
+    END IF;
+  END LOOP;
+
+  -- Replay captured dependent functions AFTER all dependent views are
+  -- restored — most codegen-emitted sp* functions reference both the
+  -- target view AND the dependent views in their bodies/return types.
+  -- Wrapped per-function in its own savepoint so a single failure
+  -- doesn't poison subsequent restores or the just-recreated target.
+  FOR rec IN SELECT schema_name, fn_name, definition FROM _vw_regen_fn_deps LOOP
+    BEGIN
+      EXECUTE rec.definition;
+    EXCEPTION WHEN OTHERS THEN
+      RAISE NOTICE 'Best-effort restore skipped dependent function %.%: %', rec.schema_name, rec.fn_name, SQLERRM;
+    END;
+  END LOOP;
+
+  DROP TABLE _vw_regen_deps;
+  DROP TABLE _vw_regen_fn_deps;
+END $vw_regen$;
+GRANT SELECT ON __mj."vwSearchExecutionLogs" TO "cdp_UI";
+GRANT SELECT ON __mj."vwSearchExecutionLogs" TO "cdp_Developer";
+GRANT SELECT ON __mj."vwSearchExecutionLogs" TO "cdp_Integration";
+
+-- ============================================================
+-- PostgreSQL Generated SQL for Entity: MJ: Search Execution Logs
+-- Item: spCreateSearchExecutionLog
+-- ============================================================
+
+------------------------------------------------------------
+----- CREATE FUNCTION FOR SearchExecutionLog
+------------------------------------------------------------
+DO $do$
+DECLARE r RECORD;
+BEGIN
+    FOR r IN SELECT oid::regprocedure AS sig
+             FROM pg_proc
+             WHERE proname = 'spCreateSearchExecutionLog'
+               AND pronamespace = '__mj'::regnamespace
+    LOOP
+        EXECUTE 'DROP FUNCTION ' || r.sig::text;
+    END LOOP;
+END
+$do$;
+
+CREATE OR REPLACE FUNCTION __mj."spCreateSearchExecutionLog"(
+    p_id UUID DEFAULT NULL,
+    p_searchscopeid_clear boolean DEFAULT false,
+    p_searchscopeid UUID DEFAULT NULL,
+    p_userid_clear boolean DEFAULT false,
+    p_userid UUID DEFAULT NULL,
+    p_aiagentid_clear boolean DEFAULT false,
+    p_aiagentid UUID DEFAULT NULL,
+    p_query TEXT DEFAULT NULL,
+    p_totaldurationms int DEFAULT NULL,
+    p_resultcount int DEFAULT NULL,
+    p_rerankername_clear boolean DEFAULT false,
+    p_rerankername varchar(100) DEFAULT NULL,
+    p_rerankercostcents_clear boolean DEFAULT false,
+    p_rerankercostcents decimal(10, 4) DEFAULT NULL,
+    p_status varchar(20) DEFAULT NULL,
+    p_failurereason_clear boolean DEFAULT false,
+    p_failurereason varchar(500) DEFAULT NULL,
+    p_providersjson_clear boolean DEFAULT false,
+    p_providersjson TEXT DEFAULT NULL,
+    p_aiskillid_clear boolean DEFAULT false,
+    p_aiskillid UUID DEFAULT NULL,
+    p_primaryscoperecordid_clear boolean DEFAULT false,
+    p_primaryscoperecordid UUID DEFAULT NULL,
+    p_scopedecisionjson_clear boolean DEFAULT false,
+    p_scopedecisionjson TEXT DEFAULT NULL
+) RETURNS SETOF __mj."vwSearchExecutionLogs" AS $$
+DECLARE
+    v_new_id UUID;
+BEGIN
+    v_new_id := COALESCE(p_id, gen_random_uuid());
+    INSERT INTO __mj."SearchExecutionLog"
+        (
+            "ID",
+            "SearchScopeID",
+                "UserID",
+                "AIAgentID",
+                "Query",
+                "TotalDurationMs",
+                "ResultCount",
+                "RerankerName",
+                "RerankerCostCents",
+                "Status",
+                "FailureReason",
+                "ProvidersJSON",
+                "AISkillID",
+                "PrimaryScopeRecordID",
+                "ScopeDecisionJSON"
+        )
+    VALUES
+        (
+            v_new_id,
+            CASE WHEN p_searchscopeid_clear = true THEN NULL ELSE COALESCE(p_searchscopeid, NULL) END,
+                CASE WHEN p_userid_clear = true THEN NULL ELSE COALESCE(p_userid, NULL) END,
+                CASE WHEN p_aiagentid_clear = true THEN NULL ELSE COALESCE(p_aiagentid, NULL) END,
+                p_query,
+                p_totaldurationms,
+                COALESCE(p_resultcount, 0),
+                CASE WHEN p_rerankername_clear = true THEN NULL ELSE COALESCE(p_rerankername, NULL) END,
+                CASE WHEN p_rerankercostcents_clear = true THEN NULL ELSE COALESCE(p_rerankercostcents, NULL) END,
+                p_status,
+                CASE WHEN p_failurereason_clear = true THEN NULL ELSE COALESCE(p_failurereason, NULL) END,
+                CASE WHEN p_providersjson_clear = true THEN NULL ELSE COALESCE(p_providersjson, NULL) END,
+                CASE WHEN p_aiskillid_clear = true THEN NULL ELSE COALESCE(p_aiskillid, NULL) END,
+                CASE WHEN p_primaryscoperecordid_clear = true THEN NULL ELSE COALESCE(p_primaryscoperecordid, NULL) END,
+                CASE WHEN p_scopedecisionjson_clear = true THEN NULL ELSE COALESCE(p_scopedecisionjson, NULL) END
+        )
+    ;
+
+    RETURN QUERY
+    SELECT * FROM __mj."vwSearchExecutionLogs"
+    WHERE "ID" = v_new_id;
+END;
+$$ LANGUAGE plpgsql;
+GRANT EXECUTE ON FUNCTION __mj."spCreateSearchExecutionLog" TO "cdp_Developer";
+GRANT EXECUTE ON FUNCTION __mj."spCreateSearchExecutionLog" TO "cdp_Integration";
+
+
+-- ============================================================
+-- PostgreSQL Generated SQL for Entity: MJ: Search Execution Logs
+-- Item: spUpdateSearchExecutionLog
+-- ============================================================
+
+------------------------------------------------------------
+----- UPDATE FUNCTION FOR SearchExecutionLog
+------------------------------------------------------------
+DO $do$
+DECLARE r RECORD;
+BEGIN
+    FOR r IN SELECT oid::regprocedure AS sig
+             FROM pg_proc
+             WHERE proname = 'spUpdateSearchExecutionLog'
+               AND pronamespace = '__mj'::regnamespace
+    LOOP
+        EXECUTE 'DROP FUNCTION ' || r.sig::text;
+    END LOOP;
+END
+$do$;
+
+CREATE OR REPLACE FUNCTION __mj."spUpdateSearchExecutionLog"(
+    p_id UUID,
+    p_searchscopeid_clear boolean DEFAULT false,
+    p_searchscopeid UUID DEFAULT NULL,
+    p_userid_clear boolean DEFAULT false,
+    p_userid UUID DEFAULT NULL,
+    p_aiagentid_clear boolean DEFAULT false,
+    p_aiagentid UUID DEFAULT NULL,
+    p_query TEXT DEFAULT NULL,
+    p_totaldurationms int DEFAULT NULL,
+    p_resultcount int DEFAULT NULL,
+    p_rerankername_clear boolean DEFAULT false,
+    p_rerankername varchar(100) DEFAULT NULL,
+    p_rerankercostcents_clear boolean DEFAULT false,
+    p_rerankercostcents decimal(10, 4) DEFAULT NULL,
+    p_status varchar(20) DEFAULT NULL,
+    p_failurereason_clear boolean DEFAULT false,
+    p_failurereason varchar(500) DEFAULT NULL,
+    p_providersjson_clear boolean DEFAULT false,
+    p_providersjson TEXT DEFAULT NULL,
+    p_aiskillid_clear boolean DEFAULT false,
+    p_aiskillid UUID DEFAULT NULL,
+    p_primaryscoperecordid_clear boolean DEFAULT false,
+    p_primaryscoperecordid UUID DEFAULT NULL,
+    p_scopedecisionjson_clear boolean DEFAULT false,
+    p_scopedecisionjson TEXT DEFAULT NULL
+) RETURNS SETOF __mj."vwSearchExecutionLogs" AS $$
+DECLARE
+    v_updated_count INTEGER;
+BEGIN
+    UPDATE __mj."SearchExecutionLog"
+    SET
+        "SearchScopeID" = CASE WHEN p_searchscopeid_clear = true THEN NULL ELSE COALESCE(p_searchscopeid, "SearchScopeID") END,
+        "UserID" = CASE WHEN p_userid_clear = true THEN NULL ELSE COALESCE(p_userid, "UserID") END,
+        "AIAgentID" = CASE WHEN p_aiagentid_clear = true THEN NULL ELSE COALESCE(p_aiagentid, "AIAgentID") END,
+        "Query" = COALESCE(p_query, "Query"),
+        "TotalDurationMs" = COALESCE(p_totaldurationms, "TotalDurationMs"),
+        "ResultCount" = COALESCE(p_resultcount, "ResultCount"),
+        "RerankerName" = CASE WHEN p_rerankername_clear = true THEN NULL ELSE COALESCE(p_rerankername, "RerankerName") END,
+        "RerankerCostCents" = CASE WHEN p_rerankercostcents_clear = true THEN NULL ELSE COALESCE(p_rerankercostcents, "RerankerCostCents") END,
+        "Status" = COALESCE(p_status, "Status"),
+        "FailureReason" = CASE WHEN p_failurereason_clear = true THEN NULL ELSE COALESCE(p_failurereason, "FailureReason") END,
+        "ProvidersJSON" = CASE WHEN p_providersjson_clear = true THEN NULL ELSE COALESCE(p_providersjson, "ProvidersJSON") END,
+        "AISkillID" = CASE WHEN p_aiskillid_clear = true THEN NULL ELSE COALESCE(p_aiskillid, "AISkillID") END,
+        "PrimaryScopeRecordID" = CASE WHEN p_primaryscoperecordid_clear = true THEN NULL ELSE COALESCE(p_primaryscoperecordid, "PrimaryScopeRecordID") END,
+        "ScopeDecisionJSON" = CASE WHEN p_scopedecisionjson_clear = true THEN NULL ELSE COALESCE(p_scopedecisionjson, "ScopeDecisionJSON") END
+    WHERE
+        "ID" = p_id;
+
+    GET DIAGNOSTICS v_updated_count = ROW_COUNT;
+
+    IF v_updated_count = 0 THEN
+        -- Nothing was updated, return empty result set
+        RETURN;
+    END IF;
+
+    -- Return the updated record from the base view
+    RETURN QUERY
+    SELECT * FROM __mj."vwSearchExecutionLogs"
+    WHERE "ID" = p_id;
+END;
+$$ LANGUAGE plpgsql;
+GRANT EXECUTE ON FUNCTION __mj."spUpdateSearchExecutionLog" TO "cdp_Developer";
+GRANT EXECUTE ON FUNCTION __mj."spUpdateSearchExecutionLog" TO "cdp_Integration";
+
+
+------------------------------------------------------------
+----- TRIGGER FOR __mj_UpdatedAt field for the SearchExecutionLog table
+------------------------------------------------------------
+CREATE OR REPLACE FUNCTION __mj."fn_trg_update_search_execution_log"()
+RETURNS TRIGGER AS $$
+BEGIN
+    NEW."__mj_UpdatedAt" := NOW() AT TIME ZONE 'UTC';
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+DROP TRIGGER IF EXISTS "trg_update_search_execution_log" ON __mj."SearchExecutionLog";
+
+CREATE TRIGGER "trg_update_search_execution_log"
+BEFORE UPDATE ON __mj."SearchExecutionLog"
+FOR EACH ROW
+EXECUTE FUNCTION __mj."fn_trg_update_search_execution_log"();
+
+
+
+-- ============================================================
+-- PostgreSQL Generated SQL for Entity: MJ: Search Execution Logs
+-- Item: spDeleteSearchExecutionLog
+-- ============================================================
+
+------------------------------------------------------------
+----- DELETE FUNCTION FOR SearchExecutionLog
+------------------------------------------------------------
+DO $do$
+DECLARE r RECORD;
+BEGIN
+    FOR r IN SELECT oid::regprocedure AS sig
+             FROM pg_proc
+             WHERE proname = 'spDeleteSearchExecutionLog'
+               AND pronamespace = '__mj'::regnamespace
+    LOOP
+        EXECUTE 'DROP FUNCTION ' || r.sig::text;
+    END LOOP;
+END
+$do$;
+
+CREATE OR REPLACE FUNCTION __mj."spDeleteSearchExecutionLog"(
+    p_id UUID
+) RETURNS TABLE("ID" UUID) AS $$
+#variable_conflict use_column
+DECLARE
+    v_affected_count INTEGER;
+BEGIN
+
+    DELETE FROM __mj."SearchExecutionLog"
+    WHERE "ID" = p_id;
+
+    GET DIAGNOSTICS v_affected_count = ROW_COUNT;
+
+    IF v_affected_count = 0 THEN
+        RETURN QUERY SELECT NULL::UUID AS "ID";
+    ELSE
+        RETURN QUERY SELECT p_id AS "ID";
+    END IF;
+END;
+$$ LANGUAGE plpgsql;
+GRANT EXECUTE ON FUNCTION __mj."spDeleteSearchExecutionLog" TO "cdp_Integration";
+
+-- ============================================================
+-- PostgreSQL Generated SQL for Entity: MJ: Search Scope Entities
+-- Item: Index for Foreign Keys
+-- ============================================================
+CREATE INDEX IF NOT EXISTS "idx_auto_mj_fkey_search_scope_entity_search_scope_id"
+    ON __mj."SearchScopeEntity" ("SearchScopeID");
+
+CREATE INDEX IF NOT EXISTS "idx_auto_mj_fkey_search_scope_entity_entity_id"
+    ON __mj."SearchScopeEntity" ("EntityID");
+
+-- ============================================================
+-- PostgreSQL Generated SQL for Entity: MJ: Search Scope Entities
+-- Item: vwSearchScopeEntities
+-- ============================================================
+
+------------------------------------------------------------
+----- BASE VIEW FOR ENTITY:      MJ: Search Scope Entities
+-----               SCHEMA:      __mj
+-----               BASE TABLE:  SearchScopeEntity
+-----               PRIMARY KEY: ID
+------------------------------------------------------------
+DO $vw_regen$
+DECLARE
+  vsql CONSTANT TEXT := $vsql$CREATE OR REPLACE VIEW __mj."vwSearchScopeEntities"
+AS
+SELECT
+    s.*,
+    MJSearchScope_SearchScopeID."Name" AS "SearchScope",
+    MJEntity_EntityID."Name" AS "Entity"
+FROM
+    __mj."SearchScopeEntity" AS s
+INNER JOIN
+    __mj."SearchScope" AS MJSearchScope_SearchScopeID
+  ON
+    "s"."SearchScopeID" = MJSearchScope_SearchScopeID."ID"
+INNER JOIN
+    __mj."Entity" AS MJEntity_EntityID
+  ON
+    "s"."EntityID" = MJEntity_EntityID."ID"
+$vsql$;
+  rec RECORD;
+BEGIN
+  EXECUTE vsql;
+EXCEPTION WHEN invalid_table_definition THEN
+  -- 42P16: column rename/reorder/type change. CREATE OR REPLACE can't handle
+  -- non-additive shape changes — must DROP CASCADE + recreate. CASCADE drops
+  -- every dependent view (anything that JOINs this view in its body), so we
+  -- capture each dependent's definition + grants BEFORE the drop and replay
+  -- them afterward (best-effort). Without this, on a fresh-DB replay where
+  -- one entity's wrapper triggers (e.g. vwAIModelTypes shape changed since
+  -- baseline V202605021056), CASCADE wipes downstream views (vwAIModels)
+  -- that the wrapper for this entity doesn't know how to recreate, and
+  -- those views stay permanently missing.
+  CREATE TEMP TABLE IF NOT EXISTS _vw_regen_deps (
+    schema_name TEXT,
+    view_name   TEXT,
+    relkind     CHAR(1),
+    definition  TEXT,
+    grants_sql  TEXT
+  ) ON COMMIT DROP;
+  DELETE FROM _vw_regen_deps;
+
+  -- Capture dependent FUNCTIONS too. CASCADE drops every function with
+  -- RETURNS SETOF <view> (the codegen-emitted spCreate/spUpdate/spDelete
+  -- pattern) when the target view is dropped. Without restoring them,
+  -- post-codegen CRUD validation reports those routines as missing —
+  -- e.g. "MJ: Recommendation Items → missing create routine
+  -- spCreateRecommendationItem" — even though the next codegen pass
+  -- emits them. The restored definitions are pg_get_functiondef() output
+  -- which is a complete CREATE OR REPLACE FUNCTION statement plus a
+  -- trailing semicolon; replaying them verbatim recreates the function
+  -- with its original body, parameter list, and return type.
+  CREATE TEMP TABLE IF NOT EXISTS _vw_regen_fn_deps (
+    schema_name TEXT,
+    fn_name     TEXT,
+    fn_oid      OID,
+    definition  TEXT
+  ) ON COMMIT DROP;
+  DELETE FROM _vw_regen_fn_deps;
+
+  -- Capture dependents. NOTES on the grants_sql build:
+  --   - Resolve role name via pg_get_userbyid(oid) — returns the bare,
+  --     unquoted role name (or 'unknown (OID=N)' if the oid no longer
+  --     exists). pg_get_userbyid is a public catalog function available to
+  --     every database user, including unprivileged accounts on managed
+  --     PostgreSQL services (Amazon RDS, Azure Database for PostgreSQL,
+  --     Cloud SQL) where pg_authid is restricted to the rds_superuser /
+  --     azure_pg_admin / cloudsqlsuperuser group. Earlier revisions joined
+  --     to pg_authid which works on self-hosted PG but fails with
+  --     "permission denied for table pg_authid" on managed services.
+  --   - The earlier (broken) approach cast (aclexplode).grantee::regrole::text
+  --     which RETURNS the role name pre-quoted when it contains uppercase
+  --     (e.g. cdp_Developer comes back already wrapped); calling quote_ident
+  --     on the already-quoted string double-wrapped and the GRANT failed at
+  --     replay with "role does not exist". Using
+  --     pg_get_userbyid returns a bare name and lets quote_ident wrap it
+  --     correctly exactly once.
+  --   - PUBLIC is grantee oid 0; pg_get_userbyid(0) returns 'unknown
+  --     (OID=0)' so handle the PUBLIC case explicitly and use it as the
+  --     literal 'PUBLIC' rather than quote_ident on the synthetic name.
+  INSERT INTO _vw_regen_deps (schema_name, view_name, relkind, definition, grants_sql)
+  SELECT DISTINCT
+      dn.nspname,
+      dc.relname,
+      dc.relkind,
+      pg_get_viewdef(dc.oid),
+      (SELECT string_agg(
+          'GRANT ' || g.privilege || ' ON ' || quote_ident(dn.nspname) || '.' || quote_ident(dc.relname) ||
+          ' TO ' || (CASE WHEN g.grantee_oid = 0 THEN 'PUBLIC' ELSE quote_ident(pg_get_userbyid(g.grantee_oid)) END) || ';',
+          E'
+')
+       FROM (
+           SELECT (aclexplode(dc.relacl)).grantee AS grantee_oid,
+                  (aclexplode(dc.relacl)).privilege_type AS privilege
+       ) g
+       WHERE g.privilege IN ('SELECT', 'INSERT', 'UPDATE', 'DELETE', 'TRUNCATE', 'REFERENCES', 'TRIGGER'))
+  FROM pg_depend d
+  JOIN pg_rewrite r ON r.oid = d.objid AND d.classid = 'pg_rewrite'::regclass
+  JOIN pg_class dc ON dc.oid = r.ev_class AND dc.relkind IN ('v', 'm')
+  JOIN pg_namespace dn ON dn.oid = dc.relnamespace
+  JOIN pg_class tc ON tc.oid = d.refobjid
+  JOIN pg_namespace tn ON tn.oid = tc.relnamespace
+  WHERE tn.nspname = '__mj'
+    AND tc.relname = 'vwSearchScopeEntities'
+    AND tc.relkind IN ('v', 'm')
+    AND dc.oid <> tc.oid;
+
+  -- Capture dependent functions. Two paths matter on PG:
+  --   1. Functions whose RETURN type references the view (RETURNS SETOF
+  --      <view>) — pg_depend records this as type=pg_type → pg_class.
+  --   2. Functions whose body references the view (used by sql functions
+  --      and by some plpgsql edge cases) — pg_depend records this as
+  --      pg_proc → pg_class.
+  -- pg_get_functiondef returns a complete CREATE OR REPLACE FUNCTION
+  -- statement that we replay verbatim. We DO include RETURNS-only
+  -- references because that's the dominant codegen pattern (sp* CRUD
+  -- functions all RETURNS SETOF the matching vwX).
+  INSERT INTO _vw_regen_fn_deps (schema_name, fn_name, fn_oid, definition)
+  SELECT DISTINCT
+      pn.nspname,
+      pp.proname,
+      pp.oid,
+      pg_get_functiondef(pp.oid)
+  FROM pg_depend d
+  JOIN pg_proc pp ON pp.oid = d.objid AND d.classid = 'pg_proc'::regclass
+  JOIN pg_namespace pn ON pn.oid = pp.pronamespace
+  JOIN pg_class tc ON tc.oid = d.refobjid
+  JOIN pg_namespace tn ON tn.oid = tc.relnamespace
+  WHERE tn.nspname = '__mj'
+    AND tc.relname = 'vwSearchScopeEntities'
+    AND tc.relkind IN ('v', 'm')
+  UNION
+  SELECT DISTINCT
+      pn.nspname,
+      pp.proname,
+      pp.oid,
+      pg_get_functiondef(pp.oid)
+  FROM pg_depend d
+  JOIN pg_type pt ON pt.oid = d.refobjid AND d.refclassid = 'pg_type'::regclass
+  JOIN pg_proc pp ON pp.prorettype = pt.oid OR pt.typrelid = pp.oid
+  JOIN pg_namespace pn ON pn.oid = pp.pronamespace
+  WHERE EXISTS (
+      SELECT 1 FROM pg_class tc
+      JOIN pg_namespace tn ON tn.oid = tc.relnamespace
+      WHERE tc.reltype = pt.oid
+        AND tn.nspname = '__mj'
+        AND tc.relname = 'vwSearchScopeEntities'
+        AND tc.relkind IN ('v', 'm')
+  );
+
+  DROP VIEW IF EXISTS __mj."vwSearchScopeEntities" CASCADE;
+  EXECUTE vsql;
+
+  -- Replay captured dependents. Best-effort: log + continue on failure.
+  -- IMPORTANT: the CREATE VIEW and the GRANTs run in SEPARATE inner BEGIN
+  -- blocks. PL/pgSQL's BEGIN ... EXCEPTION creates an implicit savepoint
+  -- and rolls back EVERY statement in the block on any exception. If we
+  -- combined CREATE+GRANT in one block and a GRANT failed (e.g. role not
+  -- present in target environment), the just-recreated VIEW would also
+  -- get rolled back and stay missing — the exact failure mode this
+  -- wrapper exists to prevent.
+  FOR rec IN SELECT schema_name, view_name, relkind, definition, grants_sql FROM _vw_regen_deps LOOP
+    BEGIN
+      IF rec.relkind = 'm' THEN
+        EXECUTE 'CREATE MATERIALIZED VIEW ' || quote_ident(rec.schema_name) || '.' || quote_ident(rec.view_name) || ' AS ' || rec.definition;
+      ELSE
+        EXECUTE 'CREATE VIEW ' || quote_ident(rec.schema_name) || '.' || quote_ident(rec.view_name) || ' AS ' || rec.definition;
+      END IF;
+    EXCEPTION WHEN OTHERS THEN
+      RAISE NOTICE 'Best-effort restore skipped dependent %.%: %', rec.schema_name, rec.view_name, SQLERRM;
+    END;
+
+    IF rec.grants_sql IS NOT NULL THEN
+      BEGIN
+        EXECUTE rec.grants_sql;
+      EXCEPTION WHEN OTHERS THEN
+        RAISE NOTICE 'Best-effort grant restore skipped %.%: %', rec.schema_name, rec.view_name, SQLERRM;
+      END;
+    END IF;
+  END LOOP;
+
+  -- Replay captured dependent functions AFTER all dependent views are
+  -- restored — most codegen-emitted sp* functions reference both the
+  -- target view AND the dependent views in their bodies/return types.
+  -- Wrapped per-function in its own savepoint so a single failure
+  -- doesn't poison subsequent restores or the just-recreated target.
+  FOR rec IN SELECT schema_name, fn_name, definition FROM _vw_regen_fn_deps LOOP
+    BEGIN
+      EXECUTE rec.definition;
+    EXCEPTION WHEN OTHERS THEN
+      RAISE NOTICE 'Best-effort restore skipped dependent function %.%: %', rec.schema_name, rec.fn_name, SQLERRM;
+    END;
+  END LOOP;
+
+  DROP TABLE _vw_regen_deps;
+  DROP TABLE _vw_regen_fn_deps;
+END $vw_regen$;
+GRANT SELECT ON __mj."vwSearchScopeEntities" TO "cdp_UI";
+GRANT SELECT ON __mj."vwSearchScopeEntities" TO "cdp_Developer";
+GRANT SELECT ON __mj."vwSearchScopeEntities" TO "cdp_Integration";
+
+-- ============================================================
+-- PostgreSQL Generated SQL for Entity: MJ: Search Scope Entities
+-- Item: spCreateSearchScopeEntity
+-- ============================================================
+
+------------------------------------------------------------
+----- CREATE FUNCTION FOR SearchScopeEntity
+------------------------------------------------------------
+DO $do$
+DECLARE r RECORD;
+BEGIN
+    FOR r IN SELECT oid::regprocedure AS sig
+             FROM pg_proc
+             WHERE proname = 'spCreateSearchScopeEntity'
+               AND pronamespace = '__mj'::regnamespace
+    LOOP
+        EXECUTE 'DROP FUNCTION ' || r.sig::text;
+    END LOOP;
+END
+$do$;
+
+CREATE OR REPLACE FUNCTION __mj."spCreateSearchScopeEntity"(
+    p_id UUID DEFAULT NULL,
+    p_searchscopeid UUID DEFAULT NULL,
+    p_entityid UUID DEFAULT NULL,
+    p_extrafilter_clear boolean DEFAULT false,
+    p_extrafilter TEXT DEFAULT NULL,
+    p_usersearchstring_clear boolean DEFAULT false,
+    p_usersearchstring TEXT DEFAULT NULL,
+    p_requiredmetadatakeys_clear boolean DEFAULT false,
+    p_requiredmetadatakeys TEXT DEFAULT NULL
+) RETURNS SETOF __mj."vwSearchScopeEntities" AS $$
+DECLARE
+    v_new_id UUID;
+BEGIN
+    v_new_id := COALESCE(p_id, gen_random_uuid());
+    INSERT INTO __mj."SearchScopeEntity"
+        (
+            "ID",
+            "SearchScopeID",
+                "EntityID",
+                "ExtraFilter",
+                "UserSearchString",
+                "RequiredMetadataKeys"
+        )
+    VALUES
+        (
+            v_new_id,
+            p_searchscopeid,
+                p_entityid,
+                CASE WHEN p_extrafilter_clear = true THEN NULL ELSE COALESCE(p_extrafilter, NULL) END,
+                CASE WHEN p_usersearchstring_clear = true THEN NULL ELSE COALESCE(p_usersearchstring, NULL) END,
+                CASE WHEN p_requiredmetadatakeys_clear = true THEN NULL ELSE COALESCE(p_requiredmetadatakeys, NULL) END
+        )
+    ;
+
+    RETURN QUERY
+    SELECT * FROM __mj."vwSearchScopeEntities"
+    WHERE "ID" = v_new_id;
+END;
+$$ LANGUAGE plpgsql;
+GRANT EXECUTE ON FUNCTION __mj."spCreateSearchScopeEntity" TO "cdp_Developer";
+GRANT EXECUTE ON FUNCTION __mj."spCreateSearchScopeEntity" TO "cdp_Integration";
+
+
+-- ============================================================
+-- PostgreSQL Generated SQL for Entity: MJ: Search Scope Entities
+-- Item: spUpdateSearchScopeEntity
+-- ============================================================
+
+------------------------------------------------------------
+----- UPDATE FUNCTION FOR SearchScopeEntity
+------------------------------------------------------------
+DO $do$
+DECLARE r RECORD;
+BEGIN
+    FOR r IN SELECT oid::regprocedure AS sig
+             FROM pg_proc
+             WHERE proname = 'spUpdateSearchScopeEntity'
+               AND pronamespace = '__mj'::regnamespace
+    LOOP
+        EXECUTE 'DROP FUNCTION ' || r.sig::text;
+    END LOOP;
+END
+$do$;
+
+CREATE OR REPLACE FUNCTION __mj."spUpdateSearchScopeEntity"(
+    p_id UUID,
+    p_searchscopeid UUID DEFAULT NULL,
+    p_entityid UUID DEFAULT NULL,
+    p_extrafilter_clear boolean DEFAULT false,
+    p_extrafilter TEXT DEFAULT NULL,
+    p_usersearchstring_clear boolean DEFAULT false,
+    p_usersearchstring TEXT DEFAULT NULL,
+    p_requiredmetadatakeys_clear boolean DEFAULT false,
+    p_requiredmetadatakeys TEXT DEFAULT NULL
+) RETURNS SETOF __mj."vwSearchScopeEntities" AS $$
+DECLARE
+    v_updated_count INTEGER;
+BEGIN
+    UPDATE __mj."SearchScopeEntity"
+    SET
+        "SearchScopeID" = COALESCE(p_searchscopeid, "SearchScopeID"),
+        "EntityID" = COALESCE(p_entityid, "EntityID"),
+        "ExtraFilter" = CASE WHEN p_extrafilter_clear = true THEN NULL ELSE COALESCE(p_extrafilter, "ExtraFilter") END,
+        "UserSearchString" = CASE WHEN p_usersearchstring_clear = true THEN NULL ELSE COALESCE(p_usersearchstring, "UserSearchString") END,
+        "RequiredMetadataKeys" = CASE WHEN p_requiredmetadatakeys_clear = true THEN NULL ELSE COALESCE(p_requiredmetadatakeys, "RequiredMetadataKeys") END
+    WHERE
+        "ID" = p_id;
+
+    GET DIAGNOSTICS v_updated_count = ROW_COUNT;
+
+    IF v_updated_count = 0 THEN
+        -- Nothing was updated, return empty result set
+        RETURN;
+    END IF;
+
+    -- Return the updated record from the base view
+    RETURN QUERY
+    SELECT * FROM __mj."vwSearchScopeEntities"
+    WHERE "ID" = p_id;
+END;
+$$ LANGUAGE plpgsql;
+GRANT EXECUTE ON FUNCTION __mj."spUpdateSearchScopeEntity" TO "cdp_Developer";
+GRANT EXECUTE ON FUNCTION __mj."spUpdateSearchScopeEntity" TO "cdp_Integration";
+
+
+------------------------------------------------------------
+----- TRIGGER FOR __mj_UpdatedAt field for the SearchScopeEntity table
+------------------------------------------------------------
+CREATE OR REPLACE FUNCTION __mj."fn_trg_update_search_scope_entity"()
+RETURNS TRIGGER AS $$
+BEGIN
+    NEW."__mj_UpdatedAt" := NOW() AT TIME ZONE 'UTC';
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+DROP TRIGGER IF EXISTS "trg_update_search_scope_entity" ON __mj."SearchScopeEntity";
+
+CREATE TRIGGER "trg_update_search_scope_entity"
+BEFORE UPDATE ON __mj."SearchScopeEntity"
+FOR EACH ROW
+EXECUTE FUNCTION __mj."fn_trg_update_search_scope_entity"();
+
+
+
+-- ============================================================
+-- PostgreSQL Generated SQL for Entity: MJ: Search Scope Entities
+-- Item: spDeleteSearchScopeEntity
+-- ============================================================
+
+------------------------------------------------------------
+----- DELETE FUNCTION FOR SearchScopeEntity
+------------------------------------------------------------
+DO $do$
+DECLARE r RECORD;
+BEGIN
+    FOR r IN SELECT oid::regprocedure AS sig
+             FROM pg_proc
+             WHERE proname = 'spDeleteSearchScopeEntity'
+               AND pronamespace = '__mj'::regnamespace
+    LOOP
+        EXECUTE 'DROP FUNCTION ' || r.sig::text;
+    END LOOP;
+END
+$do$;
+
+CREATE OR REPLACE FUNCTION __mj."spDeleteSearchScopeEntity"(
+    p_id UUID
+) RETURNS TABLE("ID" UUID) AS $$
+#variable_conflict use_column
+DECLARE
+    v_affected_count INTEGER;
+BEGIN
+
+    DELETE FROM __mj."SearchScopeEntity"
+    WHERE "ID" = p_id;
+
+    GET DIAGNOSTICS v_affected_count = ROW_COUNT;
+
+    IF v_affected_count = 0 THEN
+        RETURN QUERY SELECT NULL::UUID AS "ID";
+    ELSE
+        RETURN QUERY SELECT p_id AS "ID";
+    END IF;
+END;
+$$ LANGUAGE plpgsql;
+GRANT EXECUTE ON FUNCTION __mj."spDeleteSearchScopeEntity" TO "cdp_Developer";
+GRANT EXECUTE ON FUNCTION __mj."spDeleteSearchScopeEntity" TO "cdp_Integration";
+
+-- ============================================================
+-- PostgreSQL Generated SQL for Entity: MJ: Search Scope External Indexes
+-- Item: Index for Foreign Keys
+-- ============================================================
+CREATE INDEX IF NOT EXISTS "idx_auto_mj_fkey_search_scope_external_index_search_scope_id"
+    ON __mj."SearchScopeExternalIndex" ("SearchScopeID");
+
+CREATE INDEX IF NOT EXISTS "idx_auto_mj_fkey_search_scope_external_index_vector_index_id"
+    ON __mj."SearchScopeExternalIndex" ("VectorIndexID");
+
+-- ============================================================
+-- PostgreSQL Generated SQL for Entity: MJ: Search Scope External Indexes
+-- Item: vwSearchScopeExternalIndexes
+-- ============================================================
+
+------------------------------------------------------------
+----- BASE VIEW FOR ENTITY:      MJ: Search Scope External Indexes
+-----               SCHEMA:      __mj
+-----               BASE TABLE:  SearchScopeExternalIndex
+-----               PRIMARY KEY: ID
+------------------------------------------------------------
+DO $vw_regen$
+DECLARE
+  vsql CONSTANT TEXT := $vsql$CREATE OR REPLACE VIEW __mj."vwSearchScopeExternalIndexes"
+AS
+SELECT
+    s.*,
+    MJSearchScope_SearchScopeID."Name" AS "SearchScope",
+    MJVectorIndex_VectorIndexID."Name" AS "VectorIndex"
+FROM
+    __mj."SearchScopeExternalIndex" AS s
+INNER JOIN
+    __mj."SearchScope" AS MJSearchScope_SearchScopeID
+  ON
+    "s"."SearchScopeID" = MJSearchScope_SearchScopeID."ID"
+LEFT OUTER JOIN
+    __mj."VectorIndex" AS MJVectorIndex_VectorIndexID
+  ON
+    "s"."VectorIndexID" = MJVectorIndex_VectorIndexID."ID"
+$vsql$;
+  rec RECORD;
+BEGIN
+  EXECUTE vsql;
+EXCEPTION WHEN invalid_table_definition THEN
+  -- 42P16: column rename/reorder/type change. CREATE OR REPLACE can't handle
+  -- non-additive shape changes — must DROP CASCADE + recreate. CASCADE drops
+  -- every dependent view (anything that JOINs this view in its body), so we
+  -- capture each dependent's definition + grants BEFORE the drop and replay
+  -- them afterward (best-effort). Without this, on a fresh-DB replay where
+  -- one entity's wrapper triggers (e.g. vwAIModelTypes shape changed since
+  -- baseline V202605021056), CASCADE wipes downstream views (vwAIModels)
+  -- that the wrapper for this entity doesn't know how to recreate, and
+  -- those views stay permanently missing.
+  CREATE TEMP TABLE IF NOT EXISTS _vw_regen_deps (
+    schema_name TEXT,
+    view_name   TEXT,
+    relkind     CHAR(1),
+    definition  TEXT,
+    grants_sql  TEXT
+  ) ON COMMIT DROP;
+  DELETE FROM _vw_regen_deps;
+
+  -- Capture dependent FUNCTIONS too. CASCADE drops every function with
+  -- RETURNS SETOF <view> (the codegen-emitted spCreate/spUpdate/spDelete
+  -- pattern) when the target view is dropped. Without restoring them,
+  -- post-codegen CRUD validation reports those routines as missing —
+  -- e.g. "MJ: Recommendation Items → missing create routine
+  -- spCreateRecommendationItem" — even though the next codegen pass
+  -- emits them. The restored definitions are pg_get_functiondef() output
+  -- which is a complete CREATE OR REPLACE FUNCTION statement plus a
+  -- trailing semicolon; replaying them verbatim recreates the function
+  -- with its original body, parameter list, and return type.
+  CREATE TEMP TABLE IF NOT EXISTS _vw_regen_fn_deps (
+    schema_name TEXT,
+    fn_name     TEXT,
+    fn_oid      OID,
+    definition  TEXT
+  ) ON COMMIT DROP;
+  DELETE FROM _vw_regen_fn_deps;
+
+  -- Capture dependents. NOTES on the grants_sql build:
+  --   - Resolve role name via pg_get_userbyid(oid) — returns the bare,
+  --     unquoted role name (or 'unknown (OID=N)' if the oid no longer
+  --     exists). pg_get_userbyid is a public catalog function available to
+  --     every database user, including unprivileged accounts on managed
+  --     PostgreSQL services (Amazon RDS, Azure Database for PostgreSQL,
+  --     Cloud SQL) where pg_authid is restricted to the rds_superuser /
+  --     azure_pg_admin / cloudsqlsuperuser group. Earlier revisions joined
+  --     to pg_authid which works on self-hosted PG but fails with
+  --     "permission denied for table pg_authid" on managed services.
+  --   - The earlier (broken) approach cast (aclexplode).grantee::regrole::text
+  --     which RETURNS the role name pre-quoted when it contains uppercase
+  --     (e.g. cdp_Developer comes back already wrapped); calling quote_ident
+  --     on the already-quoted string double-wrapped and the GRANT failed at
+  --     replay with "role does not exist". Using
+  --     pg_get_userbyid returns a bare name and lets quote_ident wrap it
+  --     correctly exactly once.
+  --   - PUBLIC is grantee oid 0; pg_get_userbyid(0) returns 'unknown
+  --     (OID=0)' so handle the PUBLIC case explicitly and use it as the
+  --     literal 'PUBLIC' rather than quote_ident on the synthetic name.
+  INSERT INTO _vw_regen_deps (schema_name, view_name, relkind, definition, grants_sql)
+  SELECT DISTINCT
+      dn.nspname,
+      dc.relname,
+      dc.relkind,
+      pg_get_viewdef(dc.oid),
+      (SELECT string_agg(
+          'GRANT ' || g.privilege || ' ON ' || quote_ident(dn.nspname) || '.' || quote_ident(dc.relname) ||
+          ' TO ' || (CASE WHEN g.grantee_oid = 0 THEN 'PUBLIC' ELSE quote_ident(pg_get_userbyid(g.grantee_oid)) END) || ';',
+          E'
+')
+       FROM (
+           SELECT (aclexplode(dc.relacl)).grantee AS grantee_oid,
+                  (aclexplode(dc.relacl)).privilege_type AS privilege
+       ) g
+       WHERE g.privilege IN ('SELECT', 'INSERT', 'UPDATE', 'DELETE', 'TRUNCATE', 'REFERENCES', 'TRIGGER'))
+  FROM pg_depend d
+  JOIN pg_rewrite r ON r.oid = d.objid AND d.classid = 'pg_rewrite'::regclass
+  JOIN pg_class dc ON dc.oid = r.ev_class AND dc.relkind IN ('v', 'm')
+  JOIN pg_namespace dn ON dn.oid = dc.relnamespace
+  JOIN pg_class tc ON tc.oid = d.refobjid
+  JOIN pg_namespace tn ON tn.oid = tc.relnamespace
+  WHERE tn.nspname = '__mj'
+    AND tc.relname = 'vwSearchScopeExternalIndexes'
+    AND tc.relkind IN ('v', 'm')
+    AND dc.oid <> tc.oid;
+
+  -- Capture dependent functions. Two paths matter on PG:
+  --   1. Functions whose RETURN type references the view (RETURNS SETOF
+  --      <view>) — pg_depend records this as type=pg_type → pg_class.
+  --   2. Functions whose body references the view (used by sql functions
+  --      and by some plpgsql edge cases) — pg_depend records this as
+  --      pg_proc → pg_class.
+  -- pg_get_functiondef returns a complete CREATE OR REPLACE FUNCTION
+  -- statement that we replay verbatim. We DO include RETURNS-only
+  -- references because that's the dominant codegen pattern (sp* CRUD
+  -- functions all RETURNS SETOF the matching vwX).
+  INSERT INTO _vw_regen_fn_deps (schema_name, fn_name, fn_oid, definition)
+  SELECT DISTINCT
+      pn.nspname,
+      pp.proname,
+      pp.oid,
+      pg_get_functiondef(pp.oid)
+  FROM pg_depend d
+  JOIN pg_proc pp ON pp.oid = d.objid AND d.classid = 'pg_proc'::regclass
+  JOIN pg_namespace pn ON pn.oid = pp.pronamespace
+  JOIN pg_class tc ON tc.oid = d.refobjid
+  JOIN pg_namespace tn ON tn.oid = tc.relnamespace
+  WHERE tn.nspname = '__mj'
+    AND tc.relname = 'vwSearchScopeExternalIndexes'
+    AND tc.relkind IN ('v', 'm')
+  UNION
+  SELECT DISTINCT
+      pn.nspname,
+      pp.proname,
+      pp.oid,
+      pg_get_functiondef(pp.oid)
+  FROM pg_depend d
+  JOIN pg_type pt ON pt.oid = d.refobjid AND d.refclassid = 'pg_type'::regclass
+  JOIN pg_proc pp ON pp.prorettype = pt.oid OR pt.typrelid = pp.oid
+  JOIN pg_namespace pn ON pn.oid = pp.pronamespace
+  WHERE EXISTS (
+      SELECT 1 FROM pg_class tc
+      JOIN pg_namespace tn ON tn.oid = tc.relnamespace
+      WHERE tc.reltype = pt.oid
+        AND tn.nspname = '__mj'
+        AND tc.relname = 'vwSearchScopeExternalIndexes'
+        AND tc.relkind IN ('v', 'm')
+  );
+
+  DROP VIEW IF EXISTS __mj."vwSearchScopeExternalIndexes" CASCADE;
+  EXECUTE vsql;
+
+  -- Replay captured dependents. Best-effort: log + continue on failure.
+  -- IMPORTANT: the CREATE VIEW and the GRANTs run in SEPARATE inner BEGIN
+  -- blocks. PL/pgSQL's BEGIN ... EXCEPTION creates an implicit savepoint
+  -- and rolls back EVERY statement in the block on any exception. If we
+  -- combined CREATE+GRANT in one block and a GRANT failed (e.g. role not
+  -- present in target environment), the just-recreated VIEW would also
+  -- get rolled back and stay missing — the exact failure mode this
+  -- wrapper exists to prevent.
+  FOR rec IN SELECT schema_name, view_name, relkind, definition, grants_sql FROM _vw_regen_deps LOOP
+    BEGIN
+      IF rec.relkind = 'm' THEN
+        EXECUTE 'CREATE MATERIALIZED VIEW ' || quote_ident(rec.schema_name) || '.' || quote_ident(rec.view_name) || ' AS ' || rec.definition;
+      ELSE
+        EXECUTE 'CREATE VIEW ' || quote_ident(rec.schema_name) || '.' || quote_ident(rec.view_name) || ' AS ' || rec.definition;
+      END IF;
+    EXCEPTION WHEN OTHERS THEN
+      RAISE NOTICE 'Best-effort restore skipped dependent %.%: %', rec.schema_name, rec.view_name, SQLERRM;
+    END;
+
+    IF rec.grants_sql IS NOT NULL THEN
+      BEGIN
+        EXECUTE rec.grants_sql;
+      EXCEPTION WHEN OTHERS THEN
+        RAISE NOTICE 'Best-effort grant restore skipped %.%: %', rec.schema_name, rec.view_name, SQLERRM;
+      END;
+    END IF;
+  END LOOP;
+
+  -- Replay captured dependent functions AFTER all dependent views are
+  -- restored — most codegen-emitted sp* functions reference both the
+  -- target view AND the dependent views in their bodies/return types.
+  -- Wrapped per-function in its own savepoint so a single failure
+  -- doesn't poison subsequent restores or the just-recreated target.
+  FOR rec IN SELECT schema_name, fn_name, definition FROM _vw_regen_fn_deps LOOP
+    BEGIN
+      EXECUTE rec.definition;
+    EXCEPTION WHEN OTHERS THEN
+      RAISE NOTICE 'Best-effort restore skipped dependent function %.%: %', rec.schema_name, rec.fn_name, SQLERRM;
+    END;
+  END LOOP;
+
+  DROP TABLE _vw_regen_deps;
+  DROP TABLE _vw_regen_fn_deps;
+END $vw_regen$;
+GRANT SELECT ON __mj."vwSearchScopeExternalIndexes" TO "cdp_UI";
+GRANT SELECT ON __mj."vwSearchScopeExternalIndexes" TO "cdp_Developer";
+GRANT SELECT ON __mj."vwSearchScopeExternalIndexes" TO "cdp_Integration";
+
+-- ============================================================
+-- PostgreSQL Generated SQL for Entity: MJ: Search Scope External Indexes
+-- Item: spCreateSearchScopeExternalIndex
+-- ============================================================
+
+------------------------------------------------------------
+----- CREATE FUNCTION FOR SearchScopeExternalIndex
+------------------------------------------------------------
+DO $do$
+DECLARE r RECORD;
+BEGIN
+    FOR r IN SELECT oid::regprocedure AS sig
+             FROM pg_proc
+             WHERE proname = 'spCreateSearchScopeExternalIndex'
+               AND pronamespace = '__mj'::regnamespace
+    LOOP
+        EXECUTE 'DROP FUNCTION ' || r.sig::text;
+    END LOOP;
+END
+$do$;
+
+CREATE OR REPLACE FUNCTION __mj."spCreateSearchScopeExternalIndex"(
+    p_id UUID DEFAULT NULL,
+    p_searchscopeid UUID DEFAULT NULL,
+    p_indextype varchar(40) DEFAULT NULL,
+    p_vectorindexid_clear boolean DEFAULT false,
+    p_vectorindexid UUID DEFAULT NULL,
+    p_externalindexname_clear boolean DEFAULT false,
+    p_externalindexname varchar(400) DEFAULT NULL,
+    p_externalindexconfig_clear boolean DEFAULT false,
+    p_externalindexconfig TEXT DEFAULT NULL,
+    p_metadatafilter_clear boolean DEFAULT false,
+    p_metadatafilter TEXT DEFAULT NULL,
+    p_requiredmetadatakeys_clear boolean DEFAULT false,
+    p_requiredmetadatakeys TEXT DEFAULT NULL
+) RETURNS SETOF __mj."vwSearchScopeExternalIndexes" AS $$
+DECLARE
+    v_new_id UUID;
+BEGIN
+    v_new_id := COALESCE(p_id, gen_random_uuid());
+    INSERT INTO __mj."SearchScopeExternalIndex"
+        (
+            "ID",
+            "SearchScopeID",
+                "IndexType",
+                "VectorIndexID",
+                "ExternalIndexName",
+                "ExternalIndexConfig",
+                "MetadataFilter",
+                "RequiredMetadataKeys"
+        )
+    VALUES
+        (
+            v_new_id,
+            p_searchscopeid,
+                COALESCE(p_indextype, 'Vector'),
+                CASE WHEN p_vectorindexid_clear = true THEN NULL ELSE COALESCE(p_vectorindexid, NULL) END,
+                CASE WHEN p_externalindexname_clear = true THEN NULL ELSE COALESCE(p_externalindexname, NULL) END,
+                CASE WHEN p_externalindexconfig_clear = true THEN NULL ELSE COALESCE(p_externalindexconfig, NULL) END,
+                CASE WHEN p_metadatafilter_clear = true THEN NULL ELSE COALESCE(p_metadatafilter, NULL) END,
+                CASE WHEN p_requiredmetadatakeys_clear = true THEN NULL ELSE COALESCE(p_requiredmetadatakeys, NULL) END
+        )
+    ;
+
+    RETURN QUERY
+    SELECT * FROM __mj."vwSearchScopeExternalIndexes"
+    WHERE "ID" = v_new_id;
+END;
+$$ LANGUAGE plpgsql;
+GRANT EXECUTE ON FUNCTION __mj."spCreateSearchScopeExternalIndex" TO "cdp_Developer";
+GRANT EXECUTE ON FUNCTION __mj."spCreateSearchScopeExternalIndex" TO "cdp_Integration";
+
+
+-- ============================================================
+-- PostgreSQL Generated SQL for Entity: MJ: Search Scope External Indexes
+-- Item: spUpdateSearchScopeExternalIndex
+-- ============================================================
+
+------------------------------------------------------------
+----- UPDATE FUNCTION FOR SearchScopeExternalIndex
+------------------------------------------------------------
+DO $do$
+DECLARE r RECORD;
+BEGIN
+    FOR r IN SELECT oid::regprocedure AS sig
+             FROM pg_proc
+             WHERE proname = 'spUpdateSearchScopeExternalIndex'
+               AND pronamespace = '__mj'::regnamespace
+    LOOP
+        EXECUTE 'DROP FUNCTION ' || r.sig::text;
+    END LOOP;
+END
+$do$;
+
+CREATE OR REPLACE FUNCTION __mj."spUpdateSearchScopeExternalIndex"(
+    p_id UUID,
+    p_searchscopeid UUID DEFAULT NULL,
+    p_indextype varchar(40) DEFAULT NULL,
+    p_vectorindexid_clear boolean DEFAULT false,
+    p_vectorindexid UUID DEFAULT NULL,
+    p_externalindexname_clear boolean DEFAULT false,
+    p_externalindexname varchar(400) DEFAULT NULL,
+    p_externalindexconfig_clear boolean DEFAULT false,
+    p_externalindexconfig TEXT DEFAULT NULL,
+    p_metadatafilter_clear boolean DEFAULT false,
+    p_metadatafilter TEXT DEFAULT NULL,
+    p_requiredmetadatakeys_clear boolean DEFAULT false,
+    p_requiredmetadatakeys TEXT DEFAULT NULL
+) RETURNS SETOF __mj."vwSearchScopeExternalIndexes" AS $$
+DECLARE
+    v_updated_count INTEGER;
+BEGIN
+    UPDATE __mj."SearchScopeExternalIndex"
+    SET
+        "SearchScopeID" = COALESCE(p_searchscopeid, "SearchScopeID"),
+        "IndexType" = COALESCE(p_indextype, "IndexType"),
+        "VectorIndexID" = CASE WHEN p_vectorindexid_clear = true THEN NULL ELSE COALESCE(p_vectorindexid, "VectorIndexID") END,
+        "ExternalIndexName" = CASE WHEN p_externalindexname_clear = true THEN NULL ELSE COALESCE(p_externalindexname, "ExternalIndexName") END,
+        "ExternalIndexConfig" = CASE WHEN p_externalindexconfig_clear = true THEN NULL ELSE COALESCE(p_externalindexconfig, "ExternalIndexConfig") END,
+        "MetadataFilter" = CASE WHEN p_metadatafilter_clear = true THEN NULL ELSE COALESCE(p_metadatafilter, "MetadataFilter") END,
+        "RequiredMetadataKeys" = CASE WHEN p_requiredmetadatakeys_clear = true THEN NULL ELSE COALESCE(p_requiredmetadatakeys, "RequiredMetadataKeys") END
+    WHERE
+        "ID" = p_id;
+
+    GET DIAGNOSTICS v_updated_count = ROW_COUNT;
+
+    IF v_updated_count = 0 THEN
+        -- Nothing was updated, return empty result set
+        RETURN;
+    END IF;
+
+    -- Return the updated record from the base view
+    RETURN QUERY
+    SELECT * FROM __mj."vwSearchScopeExternalIndexes"
+    WHERE "ID" = p_id;
+END;
+$$ LANGUAGE plpgsql;
+GRANT EXECUTE ON FUNCTION __mj."spUpdateSearchScopeExternalIndex" TO "cdp_Developer";
+GRANT EXECUTE ON FUNCTION __mj."spUpdateSearchScopeExternalIndex" TO "cdp_Integration";
+
+
+------------------------------------------------------------
+----- TRIGGER FOR __mj_UpdatedAt field for the SearchScopeExternalIndex table
+------------------------------------------------------------
+CREATE OR REPLACE FUNCTION __mj."fn_trg_update_search_scope_external_index"()
+RETURNS TRIGGER AS $$
+BEGIN
+    NEW."__mj_UpdatedAt" := NOW() AT TIME ZONE 'UTC';
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+DROP TRIGGER IF EXISTS "trg_update_search_scope_external_index" ON __mj."SearchScopeExternalIndex";
+
+CREATE TRIGGER "trg_update_search_scope_external_index"
+BEFORE UPDATE ON __mj."SearchScopeExternalIndex"
+FOR EACH ROW
+EXECUTE FUNCTION __mj."fn_trg_update_search_scope_external_index"();
+
+
+
+-- ============================================================
+-- PostgreSQL Generated SQL for Entity: MJ: Search Scope External Indexes
+-- Item: spDeleteSearchScopeExternalIndex
+-- ============================================================
+
+------------------------------------------------------------
+----- DELETE FUNCTION FOR SearchScopeExternalIndex
+------------------------------------------------------------
+DO $do$
+DECLARE r RECORD;
+BEGIN
+    FOR r IN SELECT oid::regprocedure AS sig
+             FROM pg_proc
+             WHERE proname = 'spDeleteSearchScopeExternalIndex'
+               AND pronamespace = '__mj'::regnamespace
+    LOOP
+        EXECUTE 'DROP FUNCTION ' || r.sig::text;
+    END LOOP;
+END
+$do$;
+
+CREATE OR REPLACE FUNCTION __mj."spDeleteSearchScopeExternalIndex"(
+    p_id UUID
+) RETURNS TABLE("ID" UUID) AS $$
+#variable_conflict use_column
+DECLARE
+    v_affected_count INTEGER;
+BEGIN
+
+    DELETE FROM __mj."SearchScopeExternalIndex"
+    WHERE "ID" = p_id;
+
+    GET DIAGNOSTICS v_affected_count = ROW_COUNT;
+
+    IF v_affected_count = 0 THEN
+        RETURN QUERY SELECT NULL::UUID AS "ID";
+    ELSE
+        RETURN QUERY SELECT p_id AS "ID";
+    END IF;
+END;
+$$ LANGUAGE plpgsql;
+GRANT EXECUTE ON FUNCTION __mj."spDeleteSearchScopeExternalIndex" TO "cdp_Developer";
+GRANT EXECUTE ON FUNCTION __mj."spDeleteSearchScopeExternalIndex" TO "cdp_Integration";
+
+-- ============================================================
+-- PostgreSQL Generated SQL for Entity: MJ: Search Scope Permissions
+-- Item: Index for Foreign Keys
+-- ============================================================
+CREATE INDEX IF NOT EXISTS "idx_auto_mj_fkey_search_scope_permission_search_scope_id"
+    ON __mj."SearchScopePermission" ("SearchScopeID");
+
+CREATE INDEX IF NOT EXISTS "idx_auto_mj_fkey_search_scope_permission_user_id"
+    ON __mj."SearchScopePermission" ("UserID");
+
+CREATE INDEX IF NOT EXISTS "idx_auto_mj_fkey_search_scope_permission_role_id"
+    ON __mj."SearchScopePermission" ("RoleID");
+
+-- ============================================================
+-- PostgreSQL Generated SQL for Entity: MJ: Search Scope Permissions
+-- Item: vwSearchScopePermissions
+-- ============================================================
+
+------------------------------------------------------------
+----- BASE VIEW FOR ENTITY:      MJ: Search Scope Permissions
+-----               SCHEMA:      __mj
+-----               BASE TABLE:  SearchScopePermission
+-----               PRIMARY KEY: ID
+------------------------------------------------------------
+DO $vw_regen$
+DECLARE
+  vsql CONSTANT TEXT := $vsql$CREATE OR REPLACE VIEW __mj."vwSearchScopePermissions"
+AS
+SELECT
+    s.*,
+    MJSearchScope_SearchScopeID."Name" AS "SearchScope",
+    MJUser_UserID."Name" AS "User",
+    MJRole_RoleID."Name" AS "Role"
+FROM
+    __mj."SearchScopePermission" AS s
+INNER JOIN
+    __mj."SearchScope" AS MJSearchScope_SearchScopeID
+  ON
+    "s"."SearchScopeID" = MJSearchScope_SearchScopeID."ID"
+LEFT OUTER JOIN
+    __mj."User" AS MJUser_UserID
+  ON
+    "s"."UserID" = MJUser_UserID."ID"
+LEFT OUTER JOIN
+    __mj."Role" AS MJRole_RoleID
+  ON
+    "s"."RoleID" = MJRole_RoleID."ID"
+$vsql$;
+  rec RECORD;
+BEGIN
+  EXECUTE vsql;
+EXCEPTION WHEN invalid_table_definition THEN
+  -- 42P16: column rename/reorder/type change. CREATE OR REPLACE can't handle
+  -- non-additive shape changes — must DROP CASCADE + recreate. CASCADE drops
+  -- every dependent view (anything that JOINs this view in its body), so we
+  -- capture each dependent's definition + grants BEFORE the drop and replay
+  -- them afterward (best-effort). Without this, on a fresh-DB replay where
+  -- one entity's wrapper triggers (e.g. vwAIModelTypes shape changed since
+  -- baseline V202605021056), CASCADE wipes downstream views (vwAIModels)
+  -- that the wrapper for this entity doesn't know how to recreate, and
+  -- those views stay permanently missing.
+  CREATE TEMP TABLE IF NOT EXISTS _vw_regen_deps (
+    schema_name TEXT,
+    view_name   TEXT,
+    relkind     CHAR(1),
+    definition  TEXT,
+    grants_sql  TEXT
+  ) ON COMMIT DROP;
+  DELETE FROM _vw_regen_deps;
+
+  -- Capture dependent FUNCTIONS too. CASCADE drops every function with
+  -- RETURNS SETOF <view> (the codegen-emitted spCreate/spUpdate/spDelete
+  -- pattern) when the target view is dropped. Without restoring them,
+  -- post-codegen CRUD validation reports those routines as missing —
+  -- e.g. "MJ: Recommendation Items → missing create routine
+  -- spCreateRecommendationItem" — even though the next codegen pass
+  -- emits them. The restored definitions are pg_get_functiondef() output
+  -- which is a complete CREATE OR REPLACE FUNCTION statement plus a
+  -- trailing semicolon; replaying them verbatim recreates the function
+  -- with its original body, parameter list, and return type.
+  CREATE TEMP TABLE IF NOT EXISTS _vw_regen_fn_deps (
+    schema_name TEXT,
+    fn_name     TEXT,
+    fn_oid      OID,
+    definition  TEXT
+  ) ON COMMIT DROP;
+  DELETE FROM _vw_regen_fn_deps;
+
+  -- Capture dependents. NOTES on the grants_sql build:
+  --   - Resolve role name via pg_get_userbyid(oid) — returns the bare,
+  --     unquoted role name (or 'unknown (OID=N)' if the oid no longer
+  --     exists). pg_get_userbyid is a public catalog function available to
+  --     every database user, including unprivileged accounts on managed
+  --     PostgreSQL services (Amazon RDS, Azure Database for PostgreSQL,
+  --     Cloud SQL) where pg_authid is restricted to the rds_superuser /
+  --     azure_pg_admin / cloudsqlsuperuser group. Earlier revisions joined
+  --     to pg_authid which works on self-hosted PG but fails with
+  --     "permission denied for table pg_authid" on managed services.
+  --   - The earlier (broken) approach cast (aclexplode).grantee::regrole::text
+  --     which RETURNS the role name pre-quoted when it contains uppercase
+  --     (e.g. cdp_Developer comes back already wrapped); calling quote_ident
+  --     on the already-quoted string double-wrapped and the GRANT failed at
+  --     replay with "role does not exist". Using
+  --     pg_get_userbyid returns a bare name and lets quote_ident wrap it
+  --     correctly exactly once.
+  --   - PUBLIC is grantee oid 0; pg_get_userbyid(0) returns 'unknown
+  --     (OID=0)' so handle the PUBLIC case explicitly and use it as the
+  --     literal 'PUBLIC' rather than quote_ident on the synthetic name.
+  INSERT INTO _vw_regen_deps (schema_name, view_name, relkind, definition, grants_sql)
+  SELECT DISTINCT
+      dn.nspname,
+      dc.relname,
+      dc.relkind,
+      pg_get_viewdef(dc.oid),
+      (SELECT string_agg(
+          'GRANT ' || g.privilege || ' ON ' || quote_ident(dn.nspname) || '.' || quote_ident(dc.relname) ||
+          ' TO ' || (CASE WHEN g.grantee_oid = 0 THEN 'PUBLIC' ELSE quote_ident(pg_get_userbyid(g.grantee_oid)) END) || ';',
+          E'
+')
+       FROM (
+           SELECT (aclexplode(dc.relacl)).grantee AS grantee_oid,
+                  (aclexplode(dc.relacl)).privilege_type AS privilege
+       ) g
+       WHERE g.privilege IN ('SELECT', 'INSERT', 'UPDATE', 'DELETE', 'TRUNCATE', 'REFERENCES', 'TRIGGER'))
+  FROM pg_depend d
+  JOIN pg_rewrite r ON r.oid = d.objid AND d.classid = 'pg_rewrite'::regclass
+  JOIN pg_class dc ON dc.oid = r.ev_class AND dc.relkind IN ('v', 'm')
+  JOIN pg_namespace dn ON dn.oid = dc.relnamespace
+  JOIN pg_class tc ON tc.oid = d.refobjid
+  JOIN pg_namespace tn ON tn.oid = tc.relnamespace
+  WHERE tn.nspname = '__mj'
+    AND tc.relname = 'vwSearchScopePermissions'
+    AND tc.relkind IN ('v', 'm')
+    AND dc.oid <> tc.oid;
+
+  -- Capture dependent functions. Two paths matter on PG:
+  --   1. Functions whose RETURN type references the view (RETURNS SETOF
+  --      <view>) — pg_depend records this as type=pg_type → pg_class.
+  --   2. Functions whose body references the view (used by sql functions
+  --      and by some plpgsql edge cases) — pg_depend records this as
+  --      pg_proc → pg_class.
+  -- pg_get_functiondef returns a complete CREATE OR REPLACE FUNCTION
+  -- statement that we replay verbatim. We DO include RETURNS-only
+  -- references because that's the dominant codegen pattern (sp* CRUD
+  -- functions all RETURNS SETOF the matching vwX).
+  INSERT INTO _vw_regen_fn_deps (schema_name, fn_name, fn_oid, definition)
+  SELECT DISTINCT
+      pn.nspname,
+      pp.proname,
+      pp.oid,
+      pg_get_functiondef(pp.oid)
+  FROM pg_depend d
+  JOIN pg_proc pp ON pp.oid = d.objid AND d.classid = 'pg_proc'::regclass
+  JOIN pg_namespace pn ON pn.oid = pp.pronamespace
+  JOIN pg_class tc ON tc.oid = d.refobjid
+  JOIN pg_namespace tn ON tn.oid = tc.relnamespace
+  WHERE tn.nspname = '__mj'
+    AND tc.relname = 'vwSearchScopePermissions'
+    AND tc.relkind IN ('v', 'm')
+  UNION
+  SELECT DISTINCT
+      pn.nspname,
+      pp.proname,
+      pp.oid,
+      pg_get_functiondef(pp.oid)
+  FROM pg_depend d
+  JOIN pg_type pt ON pt.oid = d.refobjid AND d.refclassid = 'pg_type'::regclass
+  JOIN pg_proc pp ON pp.prorettype = pt.oid OR pt.typrelid = pp.oid
+  JOIN pg_namespace pn ON pn.oid = pp.pronamespace
+  WHERE EXISTS (
+      SELECT 1 FROM pg_class tc
+      JOIN pg_namespace tn ON tn.oid = tc.relnamespace
+      WHERE tc.reltype = pt.oid
+        AND tn.nspname = '__mj'
+        AND tc.relname = 'vwSearchScopePermissions'
+        AND tc.relkind IN ('v', 'm')
+  );
+
+  DROP VIEW IF EXISTS __mj."vwSearchScopePermissions" CASCADE;
+  EXECUTE vsql;
+
+  -- Replay captured dependents. Best-effort: log + continue on failure.
+  -- IMPORTANT: the CREATE VIEW and the GRANTs run in SEPARATE inner BEGIN
+  -- blocks. PL/pgSQL's BEGIN ... EXCEPTION creates an implicit savepoint
+  -- and rolls back EVERY statement in the block on any exception. If we
+  -- combined CREATE+GRANT in one block and a GRANT failed (e.g. role not
+  -- present in target environment), the just-recreated VIEW would also
+  -- get rolled back and stay missing — the exact failure mode this
+  -- wrapper exists to prevent.
+  FOR rec IN SELECT schema_name, view_name, relkind, definition, grants_sql FROM _vw_regen_deps LOOP
+    BEGIN
+      IF rec.relkind = 'm' THEN
+        EXECUTE 'CREATE MATERIALIZED VIEW ' || quote_ident(rec.schema_name) || '.' || quote_ident(rec.view_name) || ' AS ' || rec.definition;
+      ELSE
+        EXECUTE 'CREATE VIEW ' || quote_ident(rec.schema_name) || '.' || quote_ident(rec.view_name) || ' AS ' || rec.definition;
+      END IF;
+    EXCEPTION WHEN OTHERS THEN
+      RAISE NOTICE 'Best-effort restore skipped dependent %.%: %', rec.schema_name, rec.view_name, SQLERRM;
+    END;
+
+    IF rec.grants_sql IS NOT NULL THEN
+      BEGIN
+        EXECUTE rec.grants_sql;
+      EXCEPTION WHEN OTHERS THEN
+        RAISE NOTICE 'Best-effort grant restore skipped %.%: %', rec.schema_name, rec.view_name, SQLERRM;
+      END;
+    END IF;
+  END LOOP;
+
+  -- Replay captured dependent functions AFTER all dependent views are
+  -- restored — most codegen-emitted sp* functions reference both the
+  -- target view AND the dependent views in their bodies/return types.
+  -- Wrapped per-function in its own savepoint so a single failure
+  -- doesn't poison subsequent restores or the just-recreated target.
+  FOR rec IN SELECT schema_name, fn_name, definition FROM _vw_regen_fn_deps LOOP
+    BEGIN
+      EXECUTE rec.definition;
+    EXCEPTION WHEN OTHERS THEN
+      RAISE NOTICE 'Best-effort restore skipped dependent function %.%: %', rec.schema_name, rec.fn_name, SQLERRM;
+    END;
+  END LOOP;
+
+  DROP TABLE _vw_regen_deps;
+  DROP TABLE _vw_regen_fn_deps;
+END $vw_regen$;
+GRANT SELECT ON __mj."vwSearchScopePermissions" TO "cdp_UI";
+GRANT SELECT ON __mj."vwSearchScopePermissions" TO "cdp_Developer";
+GRANT SELECT ON __mj."vwSearchScopePermissions" TO "cdp_Integration";
+
+-- ============================================================
+-- PostgreSQL Generated SQL for Entity: MJ: Search Scope Permissions
+-- Item: spCreateSearchScopePermission
+-- ============================================================
+
+------------------------------------------------------------
+----- CREATE FUNCTION FOR SearchScopePermission
+------------------------------------------------------------
+DO $do$
+DECLARE r RECORD;
+BEGIN
+    FOR r IN SELECT oid::regprocedure AS sig
+             FROM pg_proc
+             WHERE proname = 'spCreateSearchScopePermission'
+               AND pronamespace = '__mj'::regnamespace
+    LOOP
+        EXECUTE 'DROP FUNCTION ' || r.sig::text;
+    END LOOP;
+END
+$do$;
+
+CREATE OR REPLACE FUNCTION __mj."spCreateSearchScopePermission"(
+    p_id UUID DEFAULT NULL,
+    p_searchscopeid UUID DEFAULT NULL,
+    p_userid_clear boolean DEFAULT false,
+    p_userid UUID DEFAULT NULL,
+    p_roleid_clear boolean DEFAULT false,
+    p_roleid UUID DEFAULT NULL,
+    p_permissionlevel varchar(20) DEFAULT NULL,
+    p_startat_clear boolean DEFAULT false,
+    p_startat TIMESTAMPTZ DEFAULT NULL,
+    p_endat_clear boolean DEFAULT false,
+    p_endat TIMESTAMPTZ DEFAULT NULL,
+    p_primaryscoperecordid_clear boolean DEFAULT false,
+    p_primaryscoperecordid UUID DEFAULT NULL
+) RETURNS SETOF __mj."vwSearchScopePermissions" AS $$
+DECLARE
+    v_new_id UUID;
+BEGIN
+    v_new_id := COALESCE(p_id, gen_random_uuid());
+    INSERT INTO __mj."SearchScopePermission"
+        (
+            "ID",
+            "SearchScopeID",
+                "UserID",
+                "RoleID",
+                "PermissionLevel",
+                "StartAt",
+                "EndAt",
+                "PrimaryScopeRecordID"
+        )
+    VALUES
+        (
+            v_new_id,
+            p_searchscopeid,
+                CASE WHEN p_userid_clear = true THEN NULL ELSE COALESCE(p_userid, NULL) END,
+                CASE WHEN p_roleid_clear = true THEN NULL ELSE COALESCE(p_roleid, NULL) END,
+                p_permissionlevel,
+                CASE WHEN p_startat_clear = true THEN NULL ELSE COALESCE(p_startat, NULL) END,
+                CASE WHEN p_endat_clear = true THEN NULL ELSE COALESCE(p_endat, NULL) END,
+                CASE WHEN p_primaryscoperecordid_clear = true THEN NULL ELSE COALESCE(p_primaryscoperecordid, NULL) END
+        )
+    ;
+
+    RETURN QUERY
+    SELECT * FROM __mj."vwSearchScopePermissions"
+    WHERE "ID" = v_new_id;
+END;
+$$ LANGUAGE plpgsql;
+GRANT EXECUTE ON FUNCTION __mj."spCreateSearchScopePermission" TO "cdp_Developer";
+GRANT EXECUTE ON FUNCTION __mj."spCreateSearchScopePermission" TO "cdp_Integration";
+
+
+-- ============================================================
+-- PostgreSQL Generated SQL for Entity: MJ: Search Scope Permissions
+-- Item: spUpdateSearchScopePermission
+-- ============================================================
+
+------------------------------------------------------------
+----- UPDATE FUNCTION FOR SearchScopePermission
+------------------------------------------------------------
+DO $do$
+DECLARE r RECORD;
+BEGIN
+    FOR r IN SELECT oid::regprocedure AS sig
+             FROM pg_proc
+             WHERE proname = 'spUpdateSearchScopePermission'
+               AND pronamespace = '__mj'::regnamespace
+    LOOP
+        EXECUTE 'DROP FUNCTION ' || r.sig::text;
+    END LOOP;
+END
+$do$;
+
+CREATE OR REPLACE FUNCTION __mj."spUpdateSearchScopePermission"(
+    p_id UUID,
+    p_searchscopeid UUID DEFAULT NULL,
+    p_userid_clear boolean DEFAULT false,
+    p_userid UUID DEFAULT NULL,
+    p_roleid_clear boolean DEFAULT false,
+    p_roleid UUID DEFAULT NULL,
+    p_permissionlevel varchar(20) DEFAULT NULL,
+    p_startat_clear boolean DEFAULT false,
+    p_startat TIMESTAMPTZ DEFAULT NULL,
+    p_endat_clear boolean DEFAULT false,
+    p_endat TIMESTAMPTZ DEFAULT NULL,
+    p_primaryscoperecordid_clear boolean DEFAULT false,
+    p_primaryscoperecordid UUID DEFAULT NULL
+) RETURNS SETOF __mj."vwSearchScopePermissions" AS $$
+DECLARE
+    v_updated_count INTEGER;
+BEGIN
+    UPDATE __mj."SearchScopePermission"
+    SET
+        "SearchScopeID" = COALESCE(p_searchscopeid, "SearchScopeID"),
+        "UserID" = CASE WHEN p_userid_clear = true THEN NULL ELSE COALESCE(p_userid, "UserID") END,
+        "RoleID" = CASE WHEN p_roleid_clear = true THEN NULL ELSE COALESCE(p_roleid, "RoleID") END,
+        "PermissionLevel" = COALESCE(p_permissionlevel, "PermissionLevel"),
+        "StartAt" = CASE WHEN p_startat_clear = true THEN NULL ELSE COALESCE(p_startat, "StartAt") END,
+        "EndAt" = CASE WHEN p_endat_clear = true THEN NULL ELSE COALESCE(p_endat, "EndAt") END,
+        "PrimaryScopeRecordID" = CASE WHEN p_primaryscoperecordid_clear = true THEN NULL ELSE COALESCE(p_primaryscoperecordid, "PrimaryScopeRecordID") END
+    WHERE
+        "ID" = p_id;
+
+    GET DIAGNOSTICS v_updated_count = ROW_COUNT;
+
+    IF v_updated_count = 0 THEN
+        -- Nothing was updated, return empty result set
+        RETURN;
+    END IF;
+
+    -- Return the updated record from the base view
+    RETURN QUERY
+    SELECT * FROM __mj."vwSearchScopePermissions"
+    WHERE "ID" = p_id;
+END;
+$$ LANGUAGE plpgsql;
+GRANT EXECUTE ON FUNCTION __mj."spUpdateSearchScopePermission" TO "cdp_Developer";
+GRANT EXECUTE ON FUNCTION __mj."spUpdateSearchScopePermission" TO "cdp_Integration";
+
+
+------------------------------------------------------------
+----- TRIGGER FOR __mj_UpdatedAt field for the SearchScopePermission table
+------------------------------------------------------------
+CREATE OR REPLACE FUNCTION __mj."fn_trg_update_search_scope_permission"()
+RETURNS TRIGGER AS $$
+BEGIN
+    NEW."__mj_UpdatedAt" := NOW() AT TIME ZONE 'UTC';
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+DROP TRIGGER IF EXISTS "trg_update_search_scope_permission" ON __mj."SearchScopePermission";
+
+CREATE TRIGGER "trg_update_search_scope_permission"
+BEFORE UPDATE ON __mj."SearchScopePermission"
+FOR EACH ROW
+EXECUTE FUNCTION __mj."fn_trg_update_search_scope_permission"();
+
+
+
+-- ============================================================
+-- PostgreSQL Generated SQL for Entity: MJ: Search Scope Permissions
+-- Item: spDeleteSearchScopePermission
+-- ============================================================
+
+------------------------------------------------------------
+----- DELETE FUNCTION FOR SearchScopePermission
+------------------------------------------------------------
+DO $do$
+DECLARE r RECORD;
+BEGIN
+    FOR r IN SELECT oid::regprocedure AS sig
+             FROM pg_proc
+             WHERE proname = 'spDeleteSearchScopePermission'
+               AND pronamespace = '__mj'::regnamespace
+    LOOP
+        EXECUTE 'DROP FUNCTION ' || r.sig::text;
+    END LOOP;
+END
+$do$;
+
+CREATE OR REPLACE FUNCTION __mj."spDeleteSearchScopePermission"(
+    p_id UUID
+) RETURNS TABLE("ID" UUID) AS $$
+#variable_conflict use_column
+DECLARE
+    v_affected_count INTEGER;
+BEGIN
+
+    DELETE FROM __mj."SearchScopePermission"
+    WHERE "ID" = p_id;
+
+    GET DIAGNOSTICS v_affected_count = ROW_COUNT;
+
+    IF v_affected_count = 0 THEN
+        RETURN QUERY SELECT NULL::UUID AS "ID";
+    ELSE
+        RETURN QUERY SELECT p_id AS "ID";
+    END IF;
+END;
+$$ LANGUAGE plpgsql;
+GRANT EXECUTE ON FUNCTION __mj."spDeleteSearchScopePermission" TO "cdp_Developer";
+GRANT EXECUTE ON FUNCTION __mj."spDeleteSearchScopePermission" TO "cdp_Integration";
+
+-- ============================================================
+-- PostgreSQL Generated SQL for Entity: MJ: AI Agents
+-- Item: Index for Foreign Keys
+-- ============================================================
+CREATE INDEX IF NOT EXISTS "idx_auto_mj_fkey_ai_agent_parent_id"
+    ON __mj."AIAgent" ("ParentID");
+
+CREATE INDEX IF NOT EXISTS "idx_auto_mj_fkey_ai_agent_context_compression_prompt_id"
+    ON __mj."AIAgent" ("ContextCompressionPromptID");
+
+CREATE INDEX IF NOT EXISTS "idx_auto_mj_fkey_ai_agent_type_id"
+    ON __mj."AIAgent" ("TypeID");
+
+CREATE INDEX IF NOT EXISTS "idx_auto_mj_fkey_ai_agent_default_artifact_type_id"
+    ON __mj."AIAgent" ("DefaultArtifactTypeID");
+
+CREATE INDEX IF NOT EXISTS "idx_auto_mj_fkey_ai_agent_owner_user_id"
+    ON __mj."AIAgent" ("OwnerUserID");
+
+CREATE INDEX IF NOT EXISTS "idx_auto_mj_fkey_ai_agent_attachment_storage_provider_id"
+    ON __mj."AIAgent" ("AttachmentStorageProviderID");
+
+CREATE INDEX IF NOT EXISTS "idx_auto_mj_fkey_ai_agent_category_id"
+    ON __mj."AIAgent" ("CategoryID");
+
+CREATE INDEX IF NOT EXISTS "idx_auto_mj_fkey_ai_agent_default_storage_account_id"
+    ON __mj."AIAgent" ("DefaultStorageAccountID");
+
+CREATE INDEX IF NOT EXISTS "idx_auto_mj_fkey_ai_agent_default_co_agent_id"
+    ON __mj."AIAgent" ("DefaultCoAgentID");
+
+CREATE INDEX IF NOT EXISTS "idx_auto_mj_fkey_ai_agent_recording_storage_provider_id"
+    ON __mj."AIAgent" ("RecordingStorageProviderID");
+
+CREATE INDEX IF NOT EXISTS "idx_auto_mj_fkey_ai_agent_default_media_collection_id"
+    ON __mj."AIAgent" ("DefaultMediaCollectionID");
+
+CREATE INDEX IF NOT EXISTS "idx_auto_mj_fkey_ai_agent_conversation_summary_prompt_id"
+    ON __mj."AIAgent" ("ConversationSummaryPromptID");
+
+-- ============================================================
+-- PostgreSQL Generated SQL for Entity: MJ: AI Agents
+-- Item: fnAIAgentParentID_GetRootID
+-- ============================================================
+
+------------------------------------------------------------
+----- ROOT ID FUNCTION FOR: AIAgent.ParentID
+------------------------------------------------------------
+CREATE OR REPLACE FUNCTION __mj."fn_ai_agent_parent_id_get_root_id"(
+    p_record_id UUID,
+    p_parent_id UUID
+) RETURNS UUID AS $$
+    WITH RECURSIVE cte_root_parent AS (
+        -- Anchor: Start from p_parent_id if not null, otherwise start from p_record_id
+        SELECT
+            "ID",
+            "ParentID",
+            "ID" AS root_parent_id,
+            0 AS depth
+        FROM
+            __mj."AIAgent"
+        WHERE
+            "ID" = COALESCE(p_parent_id, p_record_id)
+
+        UNION ALL
+
+        -- Recursive: Keep going up the hierarchy
+        SELECT
+            c."ID",
+            c."ParentID",
+            c."ID" AS root_parent_id,
+            p.depth + 1 AS depth
+        FROM
+            __mj."AIAgent" c
+        INNER JOIN
+            cte_root_parent p ON c."ID" = p."ParentID"
+        WHERE
+            p.depth < 100  -- Prevent infinite loops
+    )
+    SELECT root_parent_id
+    FROM cte_root_parent
+    WHERE "ParentID" IS NULL
+    ORDER BY root_parent_id
+    LIMIT 1;
+$$ LANGUAGE sql STABLE;
+
+
+-- ============================================================
+-- PostgreSQL Generated SQL for Entity: MJ: AI Agents
+-- Item: fnAIAgentDefaultCoAgentID_GetRootID
+-- ============================================================
+
+------------------------------------------------------------
+----- ROOT ID FUNCTION FOR: AIAgent.DefaultCoAgentID
+------------------------------------------------------------
+CREATE OR REPLACE FUNCTION __mj."fn_ai_agent_default_co_agent_id_get_root_id"(
+    p_record_id UUID,
+    p_parent_id UUID
+) RETURNS UUID AS $$
+    WITH RECURSIVE cte_root_parent AS (
+        -- Anchor: Start from p_parent_id if not null, otherwise start from p_record_id
+        SELECT
+            "ID",
+            "DefaultCoAgentID",
+            "ID" AS root_parent_id,
+            0 AS depth
+        FROM
+            __mj."AIAgent"
+        WHERE
+            "ID" = COALESCE(p_parent_id, p_record_id)
+
+        UNION ALL
+
+        -- Recursive: Keep going up the hierarchy
+        SELECT
+            c."ID",
+            c."DefaultCoAgentID",
+            c."ID" AS root_parent_id,
+            p.depth + 1 AS depth
+        FROM
+            __mj."AIAgent" c
+        INNER JOIN
+            cte_root_parent p ON c."ID" = p."DefaultCoAgentID"
+        WHERE
+            p.depth < 100  -- Prevent infinite loops
+    )
+    SELECT root_parent_id
+    FROM cte_root_parent
+    WHERE "DefaultCoAgentID" IS NULL
+    ORDER BY root_parent_id
+    LIMIT 1;
+$$ LANGUAGE sql STABLE;
+
+
+-- ============================================================
+-- PostgreSQL Generated SQL for Entity: MJ: AI Agents
+-- Item: vwAIAgents
+-- ============================================================
+
+------------------------------------------------------------
+----- BASE VIEW FOR ENTITY:      MJ: AI Agents
+-----               SCHEMA:      __mj
+-----               BASE TABLE:  AIAgent
+-----               PRIMARY KEY: ID
+------------------------------------------------------------
+DO $vw_regen$
+DECLARE
+  vsql CONSTANT TEXT := $vsql$CREATE OR REPLACE VIEW __mj."vwAIAgents"
+AS
+SELECT
+    a.*,
+    MJAIAgent_ParentID."Name" AS "Parent",
+    MJAIPrompt_ContextCompressionPromptID."Name" AS "ContextCompressionPrompt",
+    MJAIAgentType_TypeID."Name" AS "Type",
+    MJArtifactType_DefaultArtifactTypeID."Name" AS "DefaultArtifactType",
+    MJUser_OwnerUserID."Name" AS "OwnerUser",
+    MJFileStorageProvider_AttachmentStorageProviderID."Name" AS "AttachmentStorageProvider",
+    MJAIAgentCategory_CategoryID."Name" AS "Category",
+    MJFileStorageAccount_DefaultStorageAccountID."Name" AS "DefaultStorageAccount",
+    MJAIAgent_DefaultCoAgentID."Name" AS "DefaultCoAgent",
+    MJFileStorageProvider_RecordingStorageProviderID."Name" AS "RecordingStorageProvider",
+    MJCollection_DefaultMediaCollectionID."Name" AS "DefaultMediaCollection",
+    MJAIPrompt_ConversationSummaryPromptID."Name" AS "ConversationSummaryPrompt",
+    root_ParentID.root_id AS "RootParentID",
+    root_DefaultCoAgentID.root_id AS "RootDefaultCoAgentID"
+FROM
+    __mj."AIAgent" AS a
+LEFT OUTER JOIN
+    __mj."AIAgent" AS MJAIAgent_ParentID
+  ON
+    "a"."ParentID" = MJAIAgent_ParentID."ID"
+LEFT OUTER JOIN
+    __mj."AIPrompt" AS MJAIPrompt_ContextCompressionPromptID
+  ON
+    "a"."ContextCompressionPromptID" = MJAIPrompt_ContextCompressionPromptID."ID"
+LEFT OUTER JOIN
+    __mj."AIAgentType" AS MJAIAgentType_TypeID
+  ON
+    "a"."TypeID" = MJAIAgentType_TypeID."ID"
+LEFT OUTER JOIN
+    __mj."ArtifactType" AS MJArtifactType_DefaultArtifactTypeID
+  ON
+    "a"."DefaultArtifactTypeID" = MJArtifactType_DefaultArtifactTypeID."ID"
+INNER JOIN
+    __mj."User" AS MJUser_OwnerUserID
+  ON
+    "a"."OwnerUserID" = MJUser_OwnerUserID."ID"
+LEFT OUTER JOIN
+    __mj."FileStorageProvider" AS MJFileStorageProvider_AttachmentStorageProviderID
+  ON
+    "a"."AttachmentStorageProviderID" = MJFileStorageProvider_AttachmentStorageProviderID."ID"
+LEFT OUTER JOIN
+    __mj."AIAgentCategory" AS MJAIAgentCategory_CategoryID
+  ON
+    "a"."CategoryID" = MJAIAgentCategory_CategoryID."ID"
+LEFT OUTER JOIN
+    __mj."FileStorageAccount" AS MJFileStorageAccount_DefaultStorageAccountID
+  ON
+    "a"."DefaultStorageAccountID" = MJFileStorageAccount_DefaultStorageAccountID."ID"
+LEFT OUTER JOIN
+    __mj."AIAgent" AS MJAIAgent_DefaultCoAgentID
+  ON
+    "a"."DefaultCoAgentID" = MJAIAgent_DefaultCoAgentID."ID"
+LEFT OUTER JOIN
+    __mj."FileStorageProvider" AS MJFileStorageProvider_RecordingStorageProviderID
+  ON
+    "a"."RecordingStorageProviderID" = MJFileStorageProvider_RecordingStorageProviderID."ID"
+LEFT OUTER JOIN
+    __mj."Collection" AS MJCollection_DefaultMediaCollectionID
+  ON
+    "a"."DefaultMediaCollectionID" = MJCollection_DefaultMediaCollectionID."ID"
+LEFT OUTER JOIN
+    __mj."AIPrompt" AS MJAIPrompt_ConversationSummaryPromptID
+  ON
+    "a"."ConversationSummaryPromptID" = MJAIPrompt_ConversationSummaryPromptID."ID"
+
+LEFT JOIN LATERAL (
+    SELECT __mj."fn_ai_agent_parent_id_get_root_id"(a."ID", a."ParentID") AS root_id
+) AS root_ParentID ON true
+LEFT JOIN LATERAL (
+    SELECT __mj."fn_ai_agent_default_co_agent_id_get_root_id"(a."ID", a."DefaultCoAgentID") AS root_id
+) AS root_DefaultCoAgentID ON true
+$vsql$;
+  rec RECORD;
+BEGIN
+  EXECUTE vsql;
+EXCEPTION WHEN invalid_table_definition THEN
+  -- 42P16: column rename/reorder/type change. CREATE OR REPLACE can't handle
+  -- non-additive shape changes — must DROP CASCADE + recreate. CASCADE drops
+  -- every dependent view (anything that JOINs this view in its body), so we
+  -- capture each dependent's definition + grants BEFORE the drop and replay
+  -- them afterward (best-effort). Without this, on a fresh-DB replay where
+  -- one entity's wrapper triggers (e.g. vwAIModelTypes shape changed since
+  -- baseline V202605021056), CASCADE wipes downstream views (vwAIModels)
+  -- that the wrapper for this entity doesn't know how to recreate, and
+  -- those views stay permanently missing.
+  CREATE TEMP TABLE IF NOT EXISTS _vw_regen_deps (
+    schema_name TEXT,
+    view_name   TEXT,
+    relkind     CHAR(1),
+    definition  TEXT,
+    grants_sql  TEXT
+  ) ON COMMIT DROP;
+  DELETE FROM _vw_regen_deps;
+
+  -- Capture dependent FUNCTIONS too. CASCADE drops every function with
+  -- RETURNS SETOF <view> (the codegen-emitted spCreate/spUpdate/spDelete
+  -- pattern) when the target view is dropped. Without restoring them,
+  -- post-codegen CRUD validation reports those routines as missing —
+  -- e.g. "MJ: Recommendation Items → missing create routine
+  -- spCreateRecommendationItem" — even though the next codegen pass
+  -- emits them. The restored definitions are pg_get_functiondef() output
+  -- which is a complete CREATE OR REPLACE FUNCTION statement plus a
+  -- trailing semicolon; replaying them verbatim recreates the function
+  -- with its original body, parameter list, and return type.
+  CREATE TEMP TABLE IF NOT EXISTS _vw_regen_fn_deps (
+    schema_name TEXT,
+    fn_name     TEXT,
+    fn_oid      OID,
+    definition  TEXT
+  ) ON COMMIT DROP;
+  DELETE FROM _vw_regen_fn_deps;
+
+  -- Capture dependents. NOTES on the grants_sql build:
+  --   - Resolve role name via pg_get_userbyid(oid) — returns the bare,
+  --     unquoted role name (or 'unknown (OID=N)' if the oid no longer
+  --     exists). pg_get_userbyid is a public catalog function available to
+  --     every database user, including unprivileged accounts on managed
+  --     PostgreSQL services (Amazon RDS, Azure Database for PostgreSQL,
+  --     Cloud SQL) where pg_authid is restricted to the rds_superuser /
+  --     azure_pg_admin / cloudsqlsuperuser group. Earlier revisions joined
+  --     to pg_authid which works on self-hosted PG but fails with
+  --     "permission denied for table pg_authid" on managed services.
+  --   - The earlier (broken) approach cast (aclexplode).grantee::regrole::text
+  --     which RETURNS the role name pre-quoted when it contains uppercase
+  --     (e.g. cdp_Developer comes back already wrapped); calling quote_ident
+  --     on the already-quoted string double-wrapped and the GRANT failed at
+  --     replay with "role does not exist". Using
+  --     pg_get_userbyid returns a bare name and lets quote_ident wrap it
+  --     correctly exactly once.
+  --   - PUBLIC is grantee oid 0; pg_get_userbyid(0) returns 'unknown
+  --     (OID=0)' so handle the PUBLIC case explicitly and use it as the
+  --     literal 'PUBLIC' rather than quote_ident on the synthetic name.
+  INSERT INTO _vw_regen_deps (schema_name, view_name, relkind, definition, grants_sql)
+  SELECT DISTINCT
+      dn.nspname,
+      dc.relname,
+      dc.relkind,
+      pg_get_viewdef(dc.oid),
+      (SELECT string_agg(
+          'GRANT ' || g.privilege || ' ON ' || quote_ident(dn.nspname) || '.' || quote_ident(dc.relname) ||
+          ' TO ' || (CASE WHEN g.grantee_oid = 0 THEN 'PUBLIC' ELSE quote_ident(pg_get_userbyid(g.grantee_oid)) END) || ';',
+          E'
+')
+       FROM (
+           SELECT (aclexplode(dc.relacl)).grantee AS grantee_oid,
+                  (aclexplode(dc.relacl)).privilege_type AS privilege
+       ) g
+       WHERE g.privilege IN ('SELECT', 'INSERT', 'UPDATE', 'DELETE', 'TRUNCATE', 'REFERENCES', 'TRIGGER'))
+  FROM pg_depend d
+  JOIN pg_rewrite r ON r.oid = d.objid AND d.classid = 'pg_rewrite'::regclass
+  JOIN pg_class dc ON dc.oid = r.ev_class AND dc.relkind IN ('v', 'm')
+  JOIN pg_namespace dn ON dn.oid = dc.relnamespace
+  JOIN pg_class tc ON tc.oid = d.refobjid
+  JOIN pg_namespace tn ON tn.oid = tc.relnamespace
+  WHERE tn.nspname = '__mj'
+    AND tc.relname = 'vwAIAgents'
+    AND tc.relkind IN ('v', 'm')
+    AND dc.oid <> tc.oid;
+
+  -- Capture dependent functions. Two paths matter on PG:
+  --   1. Functions whose RETURN type references the view (RETURNS SETOF
+  --      <view>) — pg_depend records this as type=pg_type → pg_class.
+  --   2. Functions whose body references the view (used by sql functions
+  --      and by some plpgsql edge cases) — pg_depend records this as
+  --      pg_proc → pg_class.
+  -- pg_get_functiondef returns a complete CREATE OR REPLACE FUNCTION
+  -- statement that we replay verbatim. We DO include RETURNS-only
+  -- references because that's the dominant codegen pattern (sp* CRUD
+  -- functions all RETURNS SETOF the matching vwX).
+  INSERT INTO _vw_regen_fn_deps (schema_name, fn_name, fn_oid, definition)
+  SELECT DISTINCT
+      pn.nspname,
+      pp.proname,
+      pp.oid,
+      pg_get_functiondef(pp.oid)
+  FROM pg_depend d
+  JOIN pg_proc pp ON pp.oid = d.objid AND d.classid = 'pg_proc'::regclass
+  JOIN pg_namespace pn ON pn.oid = pp.pronamespace
+  JOIN pg_class tc ON tc.oid = d.refobjid
+  JOIN pg_namespace tn ON tn.oid = tc.relnamespace
+  WHERE tn.nspname = '__mj'
+    AND tc.relname = 'vwAIAgents'
+    AND tc.relkind IN ('v', 'm')
+  UNION
+  SELECT DISTINCT
+      pn.nspname,
+      pp.proname,
+      pp.oid,
+      pg_get_functiondef(pp.oid)
+  FROM pg_depend d
+  JOIN pg_type pt ON pt.oid = d.refobjid AND d.refclassid = 'pg_type'::regclass
+  JOIN pg_proc pp ON pp.prorettype = pt.oid OR pt.typrelid = pp.oid
+  JOIN pg_namespace pn ON pn.oid = pp.pronamespace
+  WHERE EXISTS (
+      SELECT 1 FROM pg_class tc
+      JOIN pg_namespace tn ON tn.oid = tc.relnamespace
+      WHERE tc.reltype = pt.oid
+        AND tn.nspname = '__mj'
+        AND tc.relname = 'vwAIAgents'
+        AND tc.relkind IN ('v', 'm')
+  );
+
+  DROP VIEW IF EXISTS __mj."vwAIAgents" CASCADE;
+  EXECUTE vsql;
+
+  -- Replay captured dependents. Best-effort: log + continue on failure.
+  -- IMPORTANT: the CREATE VIEW and the GRANTs run in SEPARATE inner BEGIN
+  -- blocks. PL/pgSQL's BEGIN ... EXCEPTION creates an implicit savepoint
+  -- and rolls back EVERY statement in the block on any exception. If we
+  -- combined CREATE+GRANT in one block and a GRANT failed (e.g. role not
+  -- present in target environment), the just-recreated VIEW would also
+  -- get rolled back and stay missing — the exact failure mode this
+  -- wrapper exists to prevent.
+  FOR rec IN SELECT schema_name, view_name, relkind, definition, grants_sql FROM _vw_regen_deps LOOP
+    BEGIN
+      IF rec.relkind = 'm' THEN
+        EXECUTE 'CREATE MATERIALIZED VIEW ' || quote_ident(rec.schema_name) || '.' || quote_ident(rec.view_name) || ' AS ' || rec.definition;
+      ELSE
+        EXECUTE 'CREATE VIEW ' || quote_ident(rec.schema_name) || '.' || quote_ident(rec.view_name) || ' AS ' || rec.definition;
+      END IF;
+    EXCEPTION WHEN OTHERS THEN
+      RAISE NOTICE 'Best-effort restore skipped dependent %.%: %', rec.schema_name, rec.view_name, SQLERRM;
+    END;
+
+    IF rec.grants_sql IS NOT NULL THEN
+      BEGIN
+        EXECUTE rec.grants_sql;
+      EXCEPTION WHEN OTHERS THEN
+        RAISE NOTICE 'Best-effort grant restore skipped %.%: %', rec.schema_name, rec.view_name, SQLERRM;
+      END;
+    END IF;
+  END LOOP;
+
+  -- Replay captured dependent functions AFTER all dependent views are
+  -- restored — most codegen-emitted sp* functions reference both the
+  -- target view AND the dependent views in their bodies/return types.
+  -- Wrapped per-function in its own savepoint so a single failure
+  -- doesn't poison subsequent restores or the just-recreated target.
+  FOR rec IN SELECT schema_name, fn_name, definition FROM _vw_regen_fn_deps LOOP
+    BEGIN
+      EXECUTE rec.definition;
+    EXCEPTION WHEN OTHERS THEN
+      RAISE NOTICE 'Best-effort restore skipped dependent function %.%: %', rec.schema_name, rec.fn_name, SQLERRM;
+    END;
+  END LOOP;
+
+  DROP TABLE _vw_regen_deps;
+  DROP TABLE _vw_regen_fn_deps;
+END $vw_regen$;
+GRANT SELECT ON __mj."vwAIAgents" TO "cdp_UI";
+GRANT SELECT ON __mj."vwAIAgents" TO "cdp_Developer";
+GRANT SELECT ON __mj."vwAIAgents" TO "cdp_Integration";
+
+-- ============================================================
+-- PostgreSQL Generated SQL for Entity: MJ: AI Agents
+-- Item: spCreateAIAgent
+-- ============================================================
+
+------------------------------------------------------------
+----- CREATE FUNCTION FOR AIAgent (JSON-arg shape)
+------------------------------------------------------------
+DO $do$
+DECLARE r RECORD;
+BEGIN
+    FOR r IN SELECT oid::regprocedure AS sig
+             FROM pg_proc
+             WHERE proname = 'spCreateAIAgent'
+               AND pronamespace = '__mj'::regnamespace
+    LOOP
+        EXECUTE 'DROP FUNCTION ' || r.sig::text;
+    END LOOP;
+END
+$do$;
+
+CREATE OR REPLACE FUNCTION __mj."spCreateAIAgent"(p_data JSONB)
+RETURNS SETOF __mj."vwAIAgents"
+AS $$
+DECLARE
+    v_id UUID;
+    v_field_name TEXT;
+    v_cast_expr  TEXT;
+    v_col_list   TEXT;
+    v_val_list   TEXT;
+    v_sql        TEXT;
+BEGIN
+    IF p_data ? 'ID' THEN
+        v_id := (p_data->>'ID')::UUID;
+    ELSE
+        v_id := gen_random_uuid();
+    END IF;
+
+    v_col_list := quote_ident('ID');
+    v_val_list := quote_literal(v_id) || '::UUID';
+
+    -- Build column / value lists from keys present in p_data. Absent keys are
+    -- omitted entirely so the column's DEFAULT applies (matching the typed-arg
+    -- sproc's default-substitution semantics).
+    FOREACH v_field_name IN ARRAY ARRAY['Name', 'Description', 'LogoURL', 'ParentID', 'ExposeAsAction', 'ExecutionOrder', 'ExecutionMode', 'EnableContextCompression', 'ContextCompressionMessageThreshold', 'ContextCompressionPromptID', 'ContextCompressionMessageRetentionCount', 'TypeID', 'Status', 'DriverClass', 'IconClass', 'ModelSelectionMode', 'PayloadDownstreamPaths', 'PayloadUpstreamPaths', 'PayloadSelfReadPaths', 'PayloadSelfWritePaths', 'PayloadScope', 'FinalPayloadValidation', 'FinalPayloadValidationMode', 'FinalPayloadValidationMaxRetries', 'MaxCostPerRun', 'MaxTokensPerRun', 'MaxIterationsPerRun', 'MaxTimePerRun', 'MinExecutionsPerRun', 'MaxExecutionsPerRun', 'StartingPayloadValidation', 'StartingPayloadValidationMode', 'DefaultPromptEffortLevel', 'ChatHandlingOption', 'DefaultArtifactTypeID', 'OwnerUserID', 'InvocationMode', 'ArtifactCreationMode', 'FunctionalRequirements', 'TechnicalDesign', 'InjectNotes', 'MaxNotesToInject', 'NoteInjectionStrategy', 'InjectExamples', 'MaxExamplesToInject', 'ExampleInjectionStrategy', 'IsRestricted', 'MessageMode', 'MaxMessages', 'AttachmentStorageProviderID', 'AttachmentRootPath', 'InlineStorageThresholdBytes', 'AgentTypePromptParams', 'ScopeConfig', 'NoteRetentionDays', 'ExampleRetentionDays', 'AutoArchiveEnabled', 'RerankerConfiguration', 'CategoryID', 'AllowEphemeralClientTools', 'DefaultStorageAccountID', 'SearchScopeAccess', 'AcceptUnregisteredFiles', 'DefaultCoAgentID', 'TypeConfiguration', 'AllowMemoryWrite', 'RecordingDefault', 'RecordingStorageProviderID', 'DefaultMediaCollectionID', 'SupportsPlanMode', 'AcceptsSkills', 'SkillActivationMode', 'RequirePlanMode', 'ContextWindowMaxTokens', 'CompactionTriggerPercent', 'CompactionTargetPercent', 'ConversationSummaryPromptID']
+    LOOP
+        IF p_data ? v_field_name THEN
+            v_cast_expr := CASE v_field_name
+        WHEN 'Name' THEN '($1->>''Name'')'
+        WHEN 'Description' THEN '($1->>''Description'')'
+        WHEN 'LogoURL' THEN '($1->>''LogoURL'')'
+        WHEN 'ParentID' THEN '($1->>''ParentID'')::UUID'
+        WHEN 'ExposeAsAction' THEN 'COALESCE(($1->>''ExposeAsAction'')::BOOLEAN, FALSE)'
+        WHEN 'ExecutionOrder' THEN 'COALESCE(($1->>''ExecutionOrder'')::INT, 0)'
+        WHEN 'ExecutionMode' THEN 'COALESCE(($1->>''ExecutionMode''), ''Sequential'')'
+        WHEN 'EnableContextCompression' THEN 'COALESCE(($1->>''EnableContextCompression'')::BOOLEAN, FALSE)'
+        WHEN 'ContextCompressionMessageThreshold' THEN '($1->>''ContextCompressionMessageThreshold'')::INT'
+        WHEN 'ContextCompressionPromptID' THEN '($1->>''ContextCompressionPromptID'')::UUID'
+        WHEN 'ContextCompressionMessageRetentionCount' THEN '($1->>''ContextCompressionMessageRetentionCount'')::INT'
+        WHEN 'TypeID' THEN '($1->>''TypeID'')::UUID'
+        WHEN 'Status' THEN 'COALESCE(($1->>''Status''), ''Pending'')'
+        WHEN 'DriverClass' THEN '($1->>''DriverClass'')'
+        WHEN 'IconClass' THEN '($1->>''IconClass'')'
+        WHEN 'ModelSelectionMode' THEN 'COALESCE(($1->>''ModelSelectionMode''), ''Agent Type'')'
+        WHEN 'PayloadDownstreamPaths' THEN 'COALESCE(($1->>''PayloadDownstreamPaths''), ''["*"]'')'
+        WHEN 'PayloadUpstreamPaths' THEN 'COALESCE(($1->>''PayloadUpstreamPaths''), ''["*"]'')'
+        WHEN 'PayloadSelfReadPaths' THEN '($1->>''PayloadSelfReadPaths'')'
+        WHEN 'PayloadSelfWritePaths' THEN '($1->>''PayloadSelfWritePaths'')'
+        WHEN 'PayloadScope' THEN '($1->>''PayloadScope'')'
+        WHEN 'FinalPayloadValidation' THEN '($1->>''FinalPayloadValidation'')'
+        WHEN 'FinalPayloadValidationMode' THEN 'COALESCE(($1->>''FinalPayloadValidationMode''), ''Retry'')'
+        WHEN 'FinalPayloadValidationMaxRetries' THEN 'COALESCE(($1->>''FinalPayloadValidationMaxRetries'')::INT, 3)'
+        WHEN 'MaxCostPerRun' THEN '($1->>''MaxCostPerRun'')::DECIMAL(10, 4)'
+        WHEN 'MaxTokensPerRun' THEN '($1->>''MaxTokensPerRun'')::INT'
+        WHEN 'MaxIterationsPerRun' THEN '($1->>''MaxIterationsPerRun'')::INT'
+        WHEN 'MaxTimePerRun' THEN '($1->>''MaxTimePerRun'')::INT'
+        WHEN 'MinExecutionsPerRun' THEN '($1->>''MinExecutionsPerRun'')::INT'
+        WHEN 'MaxExecutionsPerRun' THEN '($1->>''MaxExecutionsPerRun'')::INT'
+        WHEN 'StartingPayloadValidation' THEN '($1->>''StartingPayloadValidation'')'
+        WHEN 'StartingPayloadValidationMode' THEN 'COALESCE(($1->>''StartingPayloadValidationMode''), ''Fail'')'
+        WHEN 'DefaultPromptEffortLevel' THEN '($1->>''DefaultPromptEffortLevel'')::INT'
+        WHEN 'ChatHandlingOption' THEN '($1->>''ChatHandlingOption'')'
+        WHEN 'DefaultArtifactTypeID' THEN '($1->>''DefaultArtifactTypeID'')::UUID'
+        WHEN 'OwnerUserID' THEN 'CASE WHEN ($1->>''OwnerUserID'')::UUID = ''00000000-0000-0000-0000-000000000000''::uuid THEN ''ECAFCCEC-6A37-EF11-86D4-000D3A4E707E'' ELSE COALESCE(($1->>''OwnerUserID'')::UUID, ''ECAFCCEC-6A37-EF11-86D4-000D3A4E707E'') END'
+        WHEN 'InvocationMode' THEN 'COALESCE(($1->>''InvocationMode''), ''Any'')'
+        WHEN 'ArtifactCreationMode' THEN 'COALESCE(($1->>''ArtifactCreationMode''), ''Always'')'
+        WHEN 'FunctionalRequirements' THEN '($1->>''FunctionalRequirements'')'
+        WHEN 'TechnicalDesign' THEN '($1->>''TechnicalDesign'')'
+        WHEN 'InjectNotes' THEN 'COALESCE(($1->>''InjectNotes'')::BOOLEAN, TRUE)'
+        WHEN 'MaxNotesToInject' THEN 'COALESCE(($1->>''MaxNotesToInject'')::INT, 5)'
+        WHEN 'NoteInjectionStrategy' THEN 'COALESCE(($1->>''NoteInjectionStrategy''), ''Relevant'')'
+        WHEN 'InjectExamples' THEN 'COALESCE(($1->>''InjectExamples'')::BOOLEAN, FALSE)'
+        WHEN 'MaxExamplesToInject' THEN 'COALESCE(($1->>''MaxExamplesToInject'')::INT, 3)'
+        WHEN 'ExampleInjectionStrategy' THEN 'COALESCE(($1->>''ExampleInjectionStrategy''), ''Semantic'')'
+        WHEN 'IsRestricted' THEN 'COALESCE(($1->>''IsRestricted'')::BOOLEAN, FALSE)'
+        WHEN 'MessageMode' THEN 'COALESCE(($1->>''MessageMode''), ''None'')'
+        WHEN 'MaxMessages' THEN '($1->>''MaxMessages'')::INT'
+        WHEN 'AttachmentStorageProviderID' THEN '($1->>''AttachmentStorageProviderID'')::UUID'
+        WHEN 'AttachmentRootPath' THEN '($1->>''AttachmentRootPath'')'
+        WHEN 'InlineStorageThresholdBytes' THEN '($1->>''InlineStorageThresholdBytes'')::INT'
+        WHEN 'AgentTypePromptParams' THEN '($1->>''AgentTypePromptParams'')'
+        WHEN 'ScopeConfig' THEN '($1->>''ScopeConfig'')'
+        WHEN 'NoteRetentionDays' THEN '($1->>''NoteRetentionDays'')::INT'
+        WHEN 'ExampleRetentionDays' THEN '($1->>''ExampleRetentionDays'')::INT'
+        WHEN 'AutoArchiveEnabled' THEN 'COALESCE(($1->>''AutoArchiveEnabled'')::BOOLEAN, TRUE)'
+        WHEN 'RerankerConfiguration' THEN '($1->>''RerankerConfiguration'')'
+        WHEN 'CategoryID' THEN '($1->>''CategoryID'')::UUID'
+        WHEN 'AllowEphemeralClientTools' THEN 'COALESCE(($1->>''AllowEphemeralClientTools'')::BOOLEAN, TRUE)'
+        WHEN 'DefaultStorageAccountID' THEN '($1->>''DefaultStorageAccountID'')::UUID'
+        WHEN 'SearchScopeAccess' THEN 'COALESCE(($1->>''SearchScopeAccess''), ''None'')'
+        WHEN 'AcceptUnregisteredFiles' THEN 'COALESCE(($1->>''AcceptUnregisteredFiles'')::BOOLEAN, FALSE)'
+        WHEN 'DefaultCoAgentID' THEN '($1->>''DefaultCoAgentID'')::UUID'
+        WHEN 'TypeConfiguration' THEN '($1->>''TypeConfiguration'')'
+        WHEN 'AllowMemoryWrite' THEN 'COALESCE(($1->>''AllowMemoryWrite'')::BOOLEAN, TRUE)'
+        WHEN 'RecordingDefault' THEN '($1->>''RecordingDefault'')'
+        WHEN 'RecordingStorageProviderID' THEN '($1->>''RecordingStorageProviderID'')::UUID'
+        WHEN 'DefaultMediaCollectionID' THEN '($1->>''DefaultMediaCollectionID'')::UUID'
+        WHEN 'SupportsPlanMode' THEN 'COALESCE(($1->>''SupportsPlanMode'')::BOOLEAN, TRUE)'
+        WHEN 'AcceptsSkills' THEN 'COALESCE(($1->>''AcceptsSkills''), ''None'')'
+        WHEN 'SkillActivationMode' THEN 'COALESCE(($1->>''SkillActivationMode''), ''RequestedOnly'')'
+        WHEN 'RequirePlanMode' THEN 'COALESCE(($1->>''RequirePlanMode'')::BOOLEAN, FALSE)'
+        WHEN 'ContextWindowMaxTokens' THEN '($1->>''ContextWindowMaxTokens'')::INT'
+        WHEN 'CompactionTriggerPercent' THEN '($1->>''CompactionTriggerPercent'')::INT'
+        WHEN 'CompactionTargetPercent' THEN '($1->>''CompactionTargetPercent'')::INT'
+        WHEN 'ConversationSummaryPromptID' THEN '($1->>''ConversationSummaryPromptID'')::UUID'
+            END;
+            v_col_list := v_col_list || ', ' || quote_ident(v_field_name);
+            v_val_list := v_val_list || ', ' || v_cast_expr;
+        END IF;
+    END LOOP;
+
+    v_sql := format(
+        'INSERT INTO __mj."AIAgent" (%s) VALUES (%s)',
+        v_col_list,
+        v_val_list
+    );
+    -- Pass p_data as a positional parameter so the cast expressions inside
+    -- v_val_list (which reference $1) can read the JSONB payload.
+    EXECUTE v_sql USING p_data;
+
+    RETURN QUERY
+    SELECT * FROM __mj."vwAIAgents"
+    WHERE "ID" = v_id;
+END;
+$$ LANGUAGE plpgsql;
+GRANT EXECUTE ON FUNCTION __mj."spCreateAIAgent" TO "cdp_Developer";
+GRANT EXECUTE ON FUNCTION __mj."spCreateAIAgent" TO "cdp_Integration";
+
+
+-- ============================================================
+-- PostgreSQL Generated SQL for Entity: MJ: AI Agents
+-- Item: spUpdateAIAgent
+-- ============================================================
+
+------------------------------------------------------------
+----- UPDATE FUNCTION FOR AIAgent (JSON-arg shape)
+------------------------------------------------------------
+DO $do$
+DECLARE r RECORD;
+BEGIN
+    FOR r IN SELECT oid::regprocedure AS sig
+             FROM pg_proc
+             WHERE proname = 'spUpdateAIAgent'
+               AND pronamespace = '__mj'::regnamespace
+    LOOP
+        EXECUTE 'DROP FUNCTION ' || r.sig::text;
+    END LOOP;
+END
+$do$;
+
+CREATE OR REPLACE FUNCTION __mj."spUpdateAIAgent"(p_data JSONB)
+RETURNS SETOF __mj."vwAIAgents"
+AS $$
+DECLARE
+    v_id UUID := (p_data->>'ID')::UUID;
+    v_updated_count INTEGER;
+BEGIN
+    IF p_data IS NULL OR NOT (p_data ? 'ID') THEN
+        RAISE EXCEPTION 'spUpdateAIAgent: p_data must include "ID"';
+    END IF;
+
+    UPDATE __mj."AIAgent"
+    SET
+        "Name" = CASE WHEN p_data ? 'Name' THEN (p_data->>'Name') ELSE "Name" END,
+        "Description" = CASE WHEN p_data ? 'Description' THEN (p_data->>'Description') ELSE "Description" END,
+        "LogoURL" = CASE WHEN p_data ? 'LogoURL' THEN (p_data->>'LogoURL') ELSE "LogoURL" END,
+        "ParentID" = CASE WHEN p_data ? 'ParentID' THEN (p_data->>'ParentID')::UUID ELSE "ParentID" END,
+        "ExposeAsAction" = CASE WHEN p_data ? 'ExposeAsAction' THEN (p_data->>'ExposeAsAction')::BOOLEAN ELSE "ExposeAsAction" END,
+        "ExecutionOrder" = CASE WHEN p_data ? 'ExecutionOrder' THEN (p_data->>'ExecutionOrder')::INT ELSE "ExecutionOrder" END,
+        "ExecutionMode" = CASE WHEN p_data ? 'ExecutionMode' THEN (p_data->>'ExecutionMode') ELSE "ExecutionMode" END,
+        "EnableContextCompression" = CASE WHEN p_data ? 'EnableContextCompression' THEN (p_data->>'EnableContextCompression')::BOOLEAN ELSE "EnableContextCompression" END,
+        "ContextCompressionMessageThreshold" = CASE WHEN p_data ? 'ContextCompressionMessageThreshold' THEN (p_data->>'ContextCompressionMessageThreshold')::INT ELSE "ContextCompressionMessageThreshold" END,
+        "ContextCompressionPromptID" = CASE WHEN p_data ? 'ContextCompressionPromptID' THEN (p_data->>'ContextCompressionPromptID')::UUID ELSE "ContextCompressionPromptID" END,
+        "ContextCompressionMessageRetentionCount" = CASE WHEN p_data ? 'ContextCompressionMessageRetentionCount' THEN (p_data->>'ContextCompressionMessageRetentionCount')::INT ELSE "ContextCompressionMessageRetentionCount" END,
+        "TypeID" = CASE WHEN p_data ? 'TypeID' THEN (p_data->>'TypeID')::UUID ELSE "TypeID" END,
+        "Status" = CASE WHEN p_data ? 'Status' THEN (p_data->>'Status') ELSE "Status" END,
+        "DriverClass" = CASE WHEN p_data ? 'DriverClass' THEN (p_data->>'DriverClass') ELSE "DriverClass" END,
+        "IconClass" = CASE WHEN p_data ? 'IconClass' THEN (p_data->>'IconClass') ELSE "IconClass" END,
+        "ModelSelectionMode" = CASE WHEN p_data ? 'ModelSelectionMode' THEN (p_data->>'ModelSelectionMode') ELSE "ModelSelectionMode" END,
+        "PayloadDownstreamPaths" = CASE WHEN p_data ? 'PayloadDownstreamPaths' THEN (p_data->>'PayloadDownstreamPaths') ELSE "PayloadDownstreamPaths" END,
+        "PayloadUpstreamPaths" = CASE WHEN p_data ? 'PayloadUpstreamPaths' THEN (p_data->>'PayloadUpstreamPaths') ELSE "PayloadUpstreamPaths" END,
+        "PayloadSelfReadPaths" = CASE WHEN p_data ? 'PayloadSelfReadPaths' THEN (p_data->>'PayloadSelfReadPaths') ELSE "PayloadSelfReadPaths" END,
+        "PayloadSelfWritePaths" = CASE WHEN p_data ? 'PayloadSelfWritePaths' THEN (p_data->>'PayloadSelfWritePaths') ELSE "PayloadSelfWritePaths" END,
+        "PayloadScope" = CASE WHEN p_data ? 'PayloadScope' THEN (p_data->>'PayloadScope') ELSE "PayloadScope" END,
+        "FinalPayloadValidation" = CASE WHEN p_data ? 'FinalPayloadValidation' THEN (p_data->>'FinalPayloadValidation') ELSE "FinalPayloadValidation" END,
+        "FinalPayloadValidationMode" = CASE WHEN p_data ? 'FinalPayloadValidationMode' THEN (p_data->>'FinalPayloadValidationMode') ELSE "FinalPayloadValidationMode" END,
+        "FinalPayloadValidationMaxRetries" = CASE WHEN p_data ? 'FinalPayloadValidationMaxRetries' THEN (p_data->>'FinalPayloadValidationMaxRetries')::INT ELSE "FinalPayloadValidationMaxRetries" END,
+        "MaxCostPerRun" = CASE WHEN p_data ? 'MaxCostPerRun' THEN (p_data->>'MaxCostPerRun')::DECIMAL(10, 4) ELSE "MaxCostPerRun" END,
+        "MaxTokensPerRun" = CASE WHEN p_data ? 'MaxTokensPerRun' THEN (p_data->>'MaxTokensPerRun')::INT ELSE "MaxTokensPerRun" END,
+        "MaxIterationsPerRun" = CASE WHEN p_data ? 'MaxIterationsPerRun' THEN (p_data->>'MaxIterationsPerRun')::INT ELSE "MaxIterationsPerRun" END,
+        "MaxTimePerRun" = CASE WHEN p_data ? 'MaxTimePerRun' THEN (p_data->>'MaxTimePerRun')::INT ELSE "MaxTimePerRun" END,
+        "MinExecutionsPerRun" = CASE WHEN p_data ? 'MinExecutionsPerRun' THEN (p_data->>'MinExecutionsPerRun')::INT ELSE "MinExecutionsPerRun" END,
+        "MaxExecutionsPerRun" = CASE WHEN p_data ? 'MaxExecutionsPerRun' THEN (p_data->>'MaxExecutionsPerRun')::INT ELSE "MaxExecutionsPerRun" END,
+        "StartingPayloadValidation" = CASE WHEN p_data ? 'StartingPayloadValidation' THEN (p_data->>'StartingPayloadValidation') ELSE "StartingPayloadValidation" END,
+        "StartingPayloadValidationMode" = CASE WHEN p_data ? 'StartingPayloadValidationMode' THEN (p_data->>'StartingPayloadValidationMode') ELSE "StartingPayloadValidationMode" END,
+        "DefaultPromptEffortLevel" = CASE WHEN p_data ? 'DefaultPromptEffortLevel' THEN (p_data->>'DefaultPromptEffortLevel')::INT ELSE "DefaultPromptEffortLevel" END,
+        "ChatHandlingOption" = CASE WHEN p_data ? 'ChatHandlingOption' THEN (p_data->>'ChatHandlingOption') ELSE "ChatHandlingOption" END,
+        "DefaultArtifactTypeID" = CASE WHEN p_data ? 'DefaultArtifactTypeID' THEN (p_data->>'DefaultArtifactTypeID')::UUID ELSE "DefaultArtifactTypeID" END,
+        "OwnerUserID" = CASE WHEN p_data ? 'OwnerUserID' THEN (p_data->>'OwnerUserID')::UUID ELSE "OwnerUserID" END,
+        "InvocationMode" = CASE WHEN p_data ? 'InvocationMode' THEN (p_data->>'InvocationMode') ELSE "InvocationMode" END,
+        "ArtifactCreationMode" = CASE WHEN p_data ? 'ArtifactCreationMode' THEN (p_data->>'ArtifactCreationMode') ELSE "ArtifactCreationMode" END,
+        "FunctionalRequirements" = CASE WHEN p_data ? 'FunctionalRequirements' THEN (p_data->>'FunctionalRequirements') ELSE "FunctionalRequirements" END,
+        "TechnicalDesign" = CASE WHEN p_data ? 'TechnicalDesign' THEN (p_data->>'TechnicalDesign') ELSE "TechnicalDesign" END,
+        "InjectNotes" = CASE WHEN p_data ? 'InjectNotes' THEN (p_data->>'InjectNotes')::BOOLEAN ELSE "InjectNotes" END,
+        "MaxNotesToInject" = CASE WHEN p_data ? 'MaxNotesToInject' THEN (p_data->>'MaxNotesToInject')::INT ELSE "MaxNotesToInject" END,
+        "NoteInjectionStrategy" = CASE WHEN p_data ? 'NoteInjectionStrategy' THEN (p_data->>'NoteInjectionStrategy') ELSE "NoteInjectionStrategy" END,
+        "InjectExamples" = CASE WHEN p_data ? 'InjectExamples' THEN (p_data->>'InjectExamples')::BOOLEAN ELSE "InjectExamples" END,
+        "MaxExamplesToInject" = CASE WHEN p_data ? 'MaxExamplesToInject' THEN (p_data->>'MaxExamplesToInject')::INT ELSE "MaxExamplesToInject" END,
+        "ExampleInjectionStrategy" = CASE WHEN p_data ? 'ExampleInjectionStrategy' THEN (p_data->>'ExampleInjectionStrategy') ELSE "ExampleInjectionStrategy" END,
+        "IsRestricted" = CASE WHEN p_data ? 'IsRestricted' THEN (p_data->>'IsRestricted')::BOOLEAN ELSE "IsRestricted" END,
+        "MessageMode" = CASE WHEN p_data ? 'MessageMode' THEN (p_data->>'MessageMode') ELSE "MessageMode" END,
+        "MaxMessages" = CASE WHEN p_data ? 'MaxMessages' THEN (p_data->>'MaxMessages')::INT ELSE "MaxMessages" END,
+        "AttachmentStorageProviderID" = CASE WHEN p_data ? 'AttachmentStorageProviderID' THEN (p_data->>'AttachmentStorageProviderID')::UUID ELSE "AttachmentStorageProviderID" END,
+        "AttachmentRootPath" = CASE WHEN p_data ? 'AttachmentRootPath' THEN (p_data->>'AttachmentRootPath') ELSE "AttachmentRootPath" END,
+        "InlineStorageThresholdBytes" = CASE WHEN p_data ? 'InlineStorageThresholdBytes' THEN (p_data->>'InlineStorageThresholdBytes')::INT ELSE "InlineStorageThresholdBytes" END,
+        "AgentTypePromptParams" = CASE WHEN p_data ? 'AgentTypePromptParams' THEN (p_data->>'AgentTypePromptParams') ELSE "AgentTypePromptParams" END,
+        "ScopeConfig" = CASE WHEN p_data ? 'ScopeConfig' THEN (p_data->>'ScopeConfig') ELSE "ScopeConfig" END,
+        "NoteRetentionDays" = CASE WHEN p_data ? 'NoteRetentionDays' THEN (p_data->>'NoteRetentionDays')::INT ELSE "NoteRetentionDays" END,
+        "ExampleRetentionDays" = CASE WHEN p_data ? 'ExampleRetentionDays' THEN (p_data->>'ExampleRetentionDays')::INT ELSE "ExampleRetentionDays" END,
+        "AutoArchiveEnabled" = CASE WHEN p_data ? 'AutoArchiveEnabled' THEN (p_data->>'AutoArchiveEnabled')::BOOLEAN ELSE "AutoArchiveEnabled" END,
+        "RerankerConfiguration" = CASE WHEN p_data ? 'RerankerConfiguration' THEN (p_data->>'RerankerConfiguration') ELSE "RerankerConfiguration" END,
+        "CategoryID" = CASE WHEN p_data ? 'CategoryID' THEN (p_data->>'CategoryID')::UUID ELSE "CategoryID" END,
+        "AllowEphemeralClientTools" = CASE WHEN p_data ? 'AllowEphemeralClientTools' THEN (p_data->>'AllowEphemeralClientTools')::BOOLEAN ELSE "AllowEphemeralClientTools" END,
+        "DefaultStorageAccountID" = CASE WHEN p_data ? 'DefaultStorageAccountID' THEN (p_data->>'DefaultStorageAccountID')::UUID ELSE "DefaultStorageAccountID" END,
+        "SearchScopeAccess" = CASE WHEN p_data ? 'SearchScopeAccess' THEN (p_data->>'SearchScopeAccess') ELSE "SearchScopeAccess" END,
+        "AcceptUnregisteredFiles" = CASE WHEN p_data ? 'AcceptUnregisteredFiles' THEN (p_data->>'AcceptUnregisteredFiles')::BOOLEAN ELSE "AcceptUnregisteredFiles" END,
+        "DefaultCoAgentID" = CASE WHEN p_data ? 'DefaultCoAgentID' THEN (p_data->>'DefaultCoAgentID')::UUID ELSE "DefaultCoAgentID" END,
+        "TypeConfiguration" = CASE WHEN p_data ? 'TypeConfiguration' THEN (p_data->>'TypeConfiguration') ELSE "TypeConfiguration" END,
+        "AllowMemoryWrite" = CASE WHEN p_data ? 'AllowMemoryWrite' THEN (p_data->>'AllowMemoryWrite')::BOOLEAN ELSE "AllowMemoryWrite" END,
+        "RecordingDefault" = CASE WHEN p_data ? 'RecordingDefault' THEN (p_data->>'RecordingDefault') ELSE "RecordingDefault" END,
+        "RecordingStorageProviderID" = CASE WHEN p_data ? 'RecordingStorageProviderID' THEN (p_data->>'RecordingStorageProviderID')::UUID ELSE "RecordingStorageProviderID" END,
+        "DefaultMediaCollectionID" = CASE WHEN p_data ? 'DefaultMediaCollectionID' THEN (p_data->>'DefaultMediaCollectionID')::UUID ELSE "DefaultMediaCollectionID" END,
+        "SupportsPlanMode" = CASE WHEN p_data ? 'SupportsPlanMode' THEN (p_data->>'SupportsPlanMode')::BOOLEAN ELSE "SupportsPlanMode" END,
+        "AcceptsSkills" = CASE WHEN p_data ? 'AcceptsSkills' THEN (p_data->>'AcceptsSkills') ELSE "AcceptsSkills" END,
+        "SkillActivationMode" = CASE WHEN p_data ? 'SkillActivationMode' THEN (p_data->>'SkillActivationMode') ELSE "SkillActivationMode" END,
+        "RequirePlanMode" = CASE WHEN p_data ? 'RequirePlanMode' THEN (p_data->>'RequirePlanMode')::BOOLEAN ELSE "RequirePlanMode" END,
+        "ContextWindowMaxTokens" = CASE WHEN p_data ? 'ContextWindowMaxTokens' THEN (p_data->>'ContextWindowMaxTokens')::INT ELSE "ContextWindowMaxTokens" END,
+        "CompactionTriggerPercent" = CASE WHEN p_data ? 'CompactionTriggerPercent' THEN (p_data->>'CompactionTriggerPercent')::INT ELSE "CompactionTriggerPercent" END,
+        "CompactionTargetPercent" = CASE WHEN p_data ? 'CompactionTargetPercent' THEN (p_data->>'CompactionTargetPercent')::INT ELSE "CompactionTargetPercent" END,
+        "ConversationSummaryPromptID" = CASE WHEN p_data ? 'ConversationSummaryPromptID' THEN (p_data->>'ConversationSummaryPromptID')::UUID ELSE "ConversationSummaryPromptID" END,
+        "__mj_UpdatedAt" = NOW()
+    WHERE
+        "ID" = v_id;
+
+    GET DIAGNOSTICS v_updated_count = ROW_COUNT;
+
+    IF v_updated_count = 0 THEN
+        -- Nothing was updated, return empty result set
+        RETURN;
+    END IF;
+
+    -- Return the updated record from the base view
+    RETURN QUERY
+    SELECT * FROM __mj."vwAIAgents"
+    WHERE "ID" = v_id;
+END;
+$$ LANGUAGE plpgsql;
+GRANT EXECUTE ON FUNCTION __mj."spUpdateAIAgent" TO "cdp_Developer";
+GRANT EXECUTE ON FUNCTION __mj."spUpdateAIAgent" TO "cdp_Integration";
+
+
+------------------------------------------------------------
+----- TRIGGER FOR __mj_UpdatedAt field for the AIAgent table
+------------------------------------------------------------
+CREATE OR REPLACE FUNCTION __mj."fn_trg_update_ai_agent"()
+RETURNS TRIGGER AS $$
+BEGIN
+    NEW."__mj_UpdatedAt" := NOW() AT TIME ZONE 'UTC';
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+DROP TRIGGER IF EXISTS "trg_update_ai_agent" ON __mj."AIAgent";
+
+CREATE TRIGGER "trg_update_ai_agent"
+BEFORE UPDATE ON __mj."AIAgent"
+FOR EACH ROW
+EXECUTE FUNCTION __mj."fn_trg_update_ai_agent"();
+
+
+
+-- ============================================================
+-- PostgreSQL Generated SQL for Entity: MJ: AI Agents
+-- Item: spDeleteAIAgent
+-- ============================================================
+
+------------------------------------------------------------
+----- DELETE FUNCTION FOR AIAgent
+------------------------------------------------------------
+DO $do$
+DECLARE r RECORD;
+BEGIN
+    FOR r IN SELECT oid::regprocedure AS sig
+             FROM pg_proc
+             WHERE proname = 'spDeleteAIAgent'
+               AND pronamespace = '__mj'::regnamespace
+    LOOP
+        EXECUTE 'DROP FUNCTION ' || r.sig::text;
+    END LOOP;
+END
+$do$;
+
+CREATE OR REPLACE FUNCTION __mj."spDeleteAIAgent"(
+    p_id UUID
+) RETURNS TABLE("ID" UUID) AS $$
+#variable_conflict use_column
+DECLARE
+    v_affected_count INTEGER;
+    v_rec RECORD;
+BEGIN
+    -- Cascade: Set MJ: Actions.CreatedByAgentID to NULL
+    FOR v_rec IN
+        SELECT "ID"
+        FROM __mj."Action"
+        WHERE "CreatedByAgentID" = p_id
+    LOOP
+        -- Update related record to set FK to NULL
+        UPDATE __mj."Action"
+        SET "CreatedByAgentID" = NULL
+        WHERE "ID" = v_rec."ID";
+    END LOOP;
+
+        -- Cascade: Set MJ: AI Agent Actions.AgentID to NULL
+    FOR v_rec IN
+        SELECT "ID"
+        FROM __mj."AIAgentAction"
+        WHERE "AgentID" = p_id
+    LOOP
+        -- Update related record to set FK to NULL
+        UPDATE __mj."AIAgentAction"
+        SET "AgentID" = NULL
+        WHERE "ID" = v_rec."ID";
+    END LOOP;
+
+        -- Cascade: Delete MJ: AI Agent Artifact Types records via AgentID
+    FOR v_rec IN
+        SELECT "ID"
+        FROM __mj."AIAgentArtifactType"
+        WHERE "AgentID" = p_id
+    LOOP
+        PERFORM __mj."spDeleteAIAgentArtifactType"(v_rec."ID");
+    END LOOP;
+
+        -- Cascade: Delete MJ: AI Agent Client Tools records via AgentID
+    FOR v_rec IN
+        SELECT "ID"
+        FROM __mj."AIAgentClientTool"
+        WHERE "AgentID" = p_id
+    LOOP
+        PERFORM __mj."spDeleteAIAgentClientTool"(v_rec."ID");
+    END LOOP;
+
+        -- Cascade: Delete MJ: AI Agent Co Agents records via CoAgentID
+    FOR v_rec IN
+        SELECT "ID"
+        FROM __mj."AIAgentCoAgent"
+        WHERE "CoAgentID" = p_id
+    LOOP
+        PERFORM __mj."spDeleteAIAgentCoAgent"(v_rec."ID");
+    END LOOP;
+
+        -- Cascade: Set MJ: AI Agent Co Agents.TargetAgentID to NULL
+    FOR v_rec IN
+        SELECT "ID"
+        FROM __mj."AIAgentCoAgent"
+        WHERE "TargetAgentID" = p_id
+    LOOP
+        -- Update related record to set FK to NULL
+        UPDATE __mj."AIAgentCoAgent"
+        SET "TargetAgentID" = NULL
+        WHERE "ID" = v_rec."ID";
+    END LOOP;
+
+        -- Cascade: Delete MJ: AI Agent Configurations records via AgentID
+    FOR v_rec IN
+        SELECT "ID"
+        FROM __mj."AIAgentConfiguration"
+        WHERE "AgentID" = p_id
+    LOOP
+        PERFORM __mj."spDeleteAIAgentConfiguration"(v_rec."ID");
+    END LOOP;
+
+        -- Cascade: Delete MJ: AI Agent Data Sources records via AgentID
+    FOR v_rec IN
+        SELECT "ID"
+        FROM __mj."AIAgentDataSource"
+        WHERE "AgentID" = p_id
+    LOOP
+        PERFORM __mj."spDeleteAIAgentDataSource"(v_rec."ID");
+    END LOOP;
+
+        -- Cascade: Delete MJ: AI Agent Examples records via AgentID
+    FOR v_rec IN
+        SELECT "ID"
+        FROM __mj."AIAgentExample"
+        WHERE "AgentID" = p_id
+    LOOP
+        PERFORM __mj."spDeleteAIAgentExample"(v_rec."ID");
+    END LOOP;
+
+        -- Cascade: Delete MJ: AI Agent Learning Cycles records via AgentID
+    FOR v_rec IN
+        SELECT "ID"
+        FROM __mj."AIAgentLearningCycle"
+        WHERE "AgentID" = p_id
+    LOOP
+        PERFORM __mj."spDeleteAIAgentLearningCycle"(v_rec."ID");
+    END LOOP;
+
+        -- Cascade: Delete MJ: AI Agent Modalities records via AgentID
+    FOR v_rec IN
+        SELECT "ID"
+        FROM __mj."AIAgentModality"
+        WHERE "AgentID" = p_id
+    LOOP
+        PERFORM __mj."spDeleteAIAgentModality"(v_rec."ID");
+    END LOOP;
+
+        -- Cascade: Set MJ: AI Agent Models.AgentID to NULL
+    FOR v_rec IN
+        SELECT "ID"
+        FROM __mj."AIAgentModel"
+        WHERE "AgentID" = p_id
+    LOOP
+        -- Update related record to set FK to NULL
+        UPDATE __mj."AIAgentModel"
+        SET "AgentID" = NULL
+        WHERE "ID" = v_rec."ID";
+    END LOOP;
+
+        -- Cascade: Set MJ: AI Agent Notes.AgentID to NULL
+    FOR v_rec IN
+        SELECT "ID"
+        FROM __mj."AIAgentNote"
+        WHERE "AgentID" = p_id
+    LOOP
+        -- Update related record to set FK to NULL
+        UPDATE __mj."AIAgentNote"
+        SET "AgentID" = NULL
+        WHERE "ID" = v_rec."ID";
+    END LOOP;
+
+        -- Cascade: Delete MJ: AI Agent Permissions records via AgentID
+    FOR v_rec IN
+        SELECT "ID"
+        FROM __mj."AIAgentPermission"
+        WHERE "AgentID" = p_id
+    LOOP
+        PERFORM __mj."spDeleteAIAgentPermission"(v_rec."ID");
+    END LOOP;
+
+        -- Cascade: Delete MJ: AI Agent Prompts records via AgentID
+    FOR v_rec IN
+        SELECT "ID"
+        FROM __mj."AIAgentPrompt"
+        WHERE "AgentID" = p_id
+    LOOP
+        PERFORM __mj."spDeleteAIAgentPrompt"(v_rec."ID");
+    END LOOP;
+
+        -- Cascade: Delete MJ: AI Agent Relationships records via AgentID
+    FOR v_rec IN
+        SELECT "ID"
+        FROM __mj."AIAgentRelationship"
+        WHERE "AgentID" = p_id
+    LOOP
+        PERFORM __mj."spDeleteAIAgentRelationship"(v_rec."ID");
+    END LOOP;
+
+        -- Cascade: Delete MJ: AI Agent Relationships records via SubAgentID
+    FOR v_rec IN
+        SELECT "ID"
+        FROM __mj."AIAgentRelationship"
+        WHERE "SubAgentID" = p_id
+    LOOP
+        PERFORM __mj."spDeleteAIAgentRelationship"(v_rec."ID");
+    END LOOP;
+
+        -- Cascade: Delete MJ: AI Agent Requests records via AgentID
+    FOR v_rec IN
+        SELECT "ID"
+        FROM __mj."AIAgentRequest"
+        WHERE "AgentID" = p_id
+    LOOP
+        PERFORM __mj."spDeleteAIAgentRequest"(v_rec."ID");
+    END LOOP;
+
+        -- Cascade: Delete MJ: AI Agent Runs records via AgentID
+    FOR v_rec IN
+        SELECT "ID"
+        FROM __mj."AIAgentRun"
+        WHERE "AgentID" = p_id
+    LOOP
+        PERFORM __mj."spDeleteAIAgentRun"(v_rec."ID");
+    END LOOP;
+
+        -- Cascade: Delete MJ: AI Agent Search Scopes records via AgentID
+    FOR v_rec IN
+        SELECT "ID"
+        FROM __mj."AIAgentSearchScope"
+        WHERE "AgentID" = p_id
+    LOOP
+        PERFORM __mj."spDeleteAIAgentSearchScope"(v_rec."ID");
+    END LOOP;
+
+        -- Cascade: Delete MJ: AI Agent Sessions records via AgentID
+    FOR v_rec IN
+        SELECT "ID"
+        FROM __mj."AIAgentSession"
+        WHERE "AgentID" = p_id
+    LOOP
+        PERFORM __mj."spDeleteAIAgentSession"(v_rec."ID");
+    END LOOP;
+
+        -- Cascade: Delete MJ: AI Agent Skills records via AgentID
+    FOR v_rec IN
+        SELECT "ID"
+        FROM __mj."AIAgentSkill"
+        WHERE "AgentID" = p_id
+    LOOP
+        PERFORM __mj."spDeleteAIAgentSkill"(v_rec."ID");
+    END LOOP;
+
+        -- Cascade: Delete MJ: AI Agent Steps records via AgentID
+    FOR v_rec IN
+        SELECT "ID"
+        FROM __mj."AIAgentStep"
+        WHERE "AgentID" = p_id
+    LOOP
+        PERFORM __mj."spDeleteAIAgentStep"(v_rec."ID");
+    END LOOP;
+
+        -- Cascade: Set MJ: AI Agent Steps.SubAgentID to NULL
+    FOR v_rec IN
+        SELECT "ID"
+        FROM __mj."AIAgentStep"
+        WHERE "SubAgentID" = p_id
+    LOOP
+        -- Update related record to set FK to NULL
+        UPDATE __mj."AIAgentStep"
+        SET "SubAgentID" = NULL
+        WHERE "ID" = v_rec."ID";
+    END LOOP;
+
+        -- Cascade: Set MJ: AI Agents.ParentID to NULL
+    FOR v_rec IN
+        SELECT "ID"
+        FROM __mj."AIAgent"
+        WHERE "ParentID" = p_id
+    LOOP
+        -- Update related record to set FK to NULL
+        UPDATE __mj."AIAgent"
+        SET "ParentID" = NULL
+        WHERE "ID" = v_rec."ID";
+    END LOOP;
+
+        -- Cascade: Set MJ: AI Agents.DefaultCoAgentID to NULL
+    FOR v_rec IN
+        SELECT "ID"
+        FROM __mj."AIAgent"
+        WHERE "DefaultCoAgentID" = p_id
+    LOOP
+        -- Update related record to set FK to NULL
+        UPDATE __mj."AIAgent"
+        SET "DefaultCoAgentID" = NULL
+        WHERE "ID" = v_rec."ID";
+    END LOOP;
+
+        -- Cascade: Delete MJ: AI Bridge Agent Identities records via AgentID
+    FOR v_rec IN
+        SELECT "ID"
+        FROM __mj."AIBridgeAgentIdentity"
+        WHERE "AgentID" = p_id
+    LOOP
+        PERFORM __mj."spDeleteAIBridgeAgentIdentity"(v_rec."ID");
+    END LOOP;
+
+        -- Cascade: Set MJ: AI Prompt Runs.AgentID to NULL
+    FOR v_rec IN
+        SELECT "ID"
+        FROM __mj."AIPromptRun"
+        WHERE "AgentID" = p_id
+    LOOP
+        -- Update related record to set FK to NULL
+        UPDATE __mj."AIPromptRun"
+        SET "AgentID" = NULL
+        WHERE "ID" = v_rec."ID";
+    END LOOP;
+
+        -- Cascade: Set MJ: AI Result Cache.AgentID to NULL
+    FOR v_rec IN
+        SELECT "ID"
+        FROM __mj."AIResultCache"
+        WHERE "AgentID" = p_id
+    LOOP
+        -- Update related record to set FK to NULL
+        UPDATE __mj."AIResultCache"
+        SET "AgentID" = NULL
+        WHERE "ID" = v_rec."ID";
+    END LOOP;
+
+        -- Cascade: Delete MJ: AI Skill Sub Agents records via SubAgentID
+    FOR v_rec IN
+        SELECT "ID"
+        FROM __mj."AISkillSubAgent"
+        WHERE "SubAgentID" = p_id
+    LOOP
+        PERFORM __mj."spDeleteAISkillSubAgent"(v_rec."ID");
+    END LOOP;
+
+        -- Cascade: Set MJ: Conversation Details.AgentID to NULL
+    FOR v_rec IN
+        SELECT "ID"
+        FROM __mj."ConversationDetail"
+        WHERE "AgentID" = p_id
+    LOOP
+        -- Update related record to set FK to NULL
+        UPDATE __mj."ConversationDetail"
+        SET "AgentID" = NULL
+        WHERE "ID" = v_rec."ID";
+    END LOOP;
+
+        -- Cascade: Delete MJ: Conversation Widget Instances records via PinnedAgentID
+    FOR v_rec IN
+        SELECT "ID"
+        FROM __mj."ConversationWidgetInstance"
+        WHERE "PinnedAgentID" = p_id
+    LOOP
+        PERFORM __mj."spDeleteConversationWidgetInstance"(v_rec."ID");
+    END LOOP;
+
+        -- Cascade: Set MJ: Conversations.DefaultAgentID to NULL
+    FOR v_rec IN
+        SELECT "ID"
+        FROM __mj."Conversation"
+        WHERE "DefaultAgentID" = p_id
+    LOOP
+        -- Update related record to set FK to NULL
+        UPDATE __mj."Conversation"
+        SET "DefaultAgentID" = NULL
+        WHERE "ID" = v_rec."ID";
+    END LOOP;
+
+        -- Cascade: Set MJ: Entity Documents.ReasoningAgentID to NULL
+    FOR v_rec IN
+        SELECT "ID"
+        FROM __mj."EntityDocument"
+        WHERE "ReasoningAgentID" = p_id
+    LOOP
+        -- Update related record to set FK to NULL
+        UPDATE __mj."EntityDocument"
+        SET "ReasoningAgentID" = NULL
+        WHERE "ID" = v_rec."ID";
+    END LOOP;
+
+        -- Cascade: Set MJ: Record Processes.AgentID to NULL
+    FOR v_rec IN
+        SELECT "ID"
+        FROM __mj."RecordProcess"
+        WHERE "AgentID" = p_id
+    LOOP
+        -- Update related record to set FK to NULL
+        UPDATE __mj."RecordProcess"
+        SET "AgentID" = NULL
+        WHERE "ID" = v_rec."ID";
+    END LOOP;
+
+        -- Cascade: Set MJ: Search Execution Logs.AIAgentID to NULL
+    FOR v_rec IN
+        SELECT "ID"
+        FROM __mj."SearchExecutionLog"
+        WHERE "AIAgentID" = p_id
+    LOOP
+        -- Update related record to set FK to NULL
+        UPDATE __mj."SearchExecutionLog"
+        SET "AIAgentID" = NULL
+        WHERE "ID" = v_rec."ID";
+    END LOOP;
+
+        -- Cascade: Set MJ: Tasks.AgentID to NULL
+    FOR v_rec IN
+        SELECT "ID"
+        FROM __mj."Task"
+        WHERE "AgentID" = p_id
+    LOOP
+        -- Update related record to set FK to NULL
+        UPDATE __mj."Task"
+        SET "AgentID" = NULL
+        WHERE "ID" = v_rec."ID";
+    END LOOP;
+
+    
+    DELETE FROM __mj."AIAgent"
+    WHERE "ID" = p_id;
+
+    GET DIAGNOSTICS v_affected_count = ROW_COUNT;
+
+    IF v_affected_count = 0 THEN
+        RETURN QUERY SELECT NULL::UUID AS "ID";
+    ELSE
+        RETURN QUERY SELECT p_id AS "ID";
+    END IF;
+END;
+$$ LANGUAGE plpgsql;
+GRANT EXECUTE ON FUNCTION __mj."spDeleteAIAgent" TO "cdp_Developer";
+GRANT EXECUTE ON FUNCTION __mj."spDeleteAIAgent" TO "cdp_Integration";

--- a/packages/Angular/Bootstrap/src/generated/mj-class-registrations.ts
+++ b/packages/Angular/Bootstrap/src/generated/mj-class-registrations.ts
@@ -27,7 +27,7 @@ import {
     SimpleVectorServiceProvider,
 } from '@memberjunction/ai-vectors-memory';
 
-// @memberjunction/core-entities (409 classes)
+// @memberjunction/core-entities (410 classes)
 import {
     AIAgentPermissionProvider,
     AISkillPermissionProvider,
@@ -99,6 +99,7 @@ import {
     MJAISkillActionEntity,
     MJAISkillEntity,
     MJAISkillPermissionEntity,
+    MJAISkillSearchScopeEntity,
     MJAISkillSubAgentEntity,
     MJAIVendorEntity,
     MJAIVendorTypeDefinitionEntity,
@@ -796,6 +797,7 @@ export const CLASS_REGISTRATIONS: any[] = [
     MJAISkillActionEntity,
     MJAISkillEntity,
     MJAISkillPermissionEntity,
+    MJAISkillSearchScopeEntity,
     MJAISkillSubAgentEntity,
     MJAIVendorEntity,
     MJAIVendorTypeDefinitionEntity,
@@ -1341,7 +1343,7 @@ export const CLASS_REGISTRATIONS: any[] = [
 export const CLASS_REGISTRATIONS_MANIFEST_LOADED = true;
 
 /** Total @RegisterClass decorated classes discovered in dependency tree */
-export const CLASS_REGISTRATIONS_COUNT = 617;
+export const CLASS_REGISTRATIONS_COUNT = 618;
 
 /** Packages imported by this manifest */
 export const CLASS_REGISTRATIONS_PACKAGES = [

--- a/packages/Angular/BootstrapLite/src/generated/mj-class-registrations.ts
+++ b/packages/Angular/BootstrapLite/src/generated/mj-class-registrations.ts
@@ -27,7 +27,7 @@ import {
     SimpleVectorServiceProvider,
 } from '@memberjunction/ai-vectors-memory';
 
-// @memberjunction/core-entities (409 classes)
+// @memberjunction/core-entities (410 classes)
 import {
     AIAgentPermissionProvider,
     AISkillPermissionProvider,
@@ -99,6 +99,7 @@ import {
     MJAISkillActionEntity,
     MJAISkillEntity,
     MJAISkillPermissionEntity,
+    MJAISkillSearchScopeEntity,
     MJAISkillSubAgentEntity,
     MJAIVendorEntity,
     MJAIVendorTypeDefinitionEntity,
@@ -671,6 +672,7 @@ export const CLASS_REGISTRATIONS: any[] = [
     MJAISkillActionEntity,
     MJAISkillEntity,
     MJAISkillPermissionEntity,
+    MJAISkillSearchScopeEntity,
     MJAISkillSubAgentEntity,
     MJAIVendorEntity,
     MJAIVendorTypeDefinitionEntity,
@@ -1107,7 +1109,7 @@ export const CLASS_REGISTRATIONS: any[] = [
 export const CLASS_REGISTRATIONS_MANIFEST_LOADED = true;
 
 /** Total @RegisterClass decorated classes discovered in dependency tree */
-export const CLASS_REGISTRATIONS_COUNT = 508;
+export const CLASS_REGISTRATIONS_COUNT = 509;
 
 /** Packages imported by this manifest */
 export const CLASS_REGISTRATIONS_PACKAGES = [

--- a/packages/MJCLI/src/__tests__/manifest-client-bootstrap.test.ts
+++ b/packages/MJCLI/src/__tests__/manifest-client-bootstrap.test.ts
@@ -9,9 +9,56 @@
  * declares "sideEffects": false.
  */
 import { describe, it, expect } from 'vitest';
+import ts from 'typescript';
 import { applyOpenAppClientBootstrapBlock } from '../commands/codegen/manifest.js';
 
 const BASE = `// generated manifest\nexport const CLASS_REGISTRATIONS = [];\n`;
+
+/** TS4111 — "Property ... comes from an index signature, so it must be accessed with [...]". */
+const TS_PROPERTY_FROM_INDEX_SIGNATURE = 4111;
+
+/**
+ * Type-check generated manifest text the way a CONSUMER compiles it.
+ *
+ * This generator's output is compiled by a *different* package under a *different*
+ * tsconfig — MJExplorer sets `noPropertyAccessFromIndexSignature: true`. A string
+ * assertion over generated code cannot catch a type error in that code, so the only
+ * sound check is to actually compile it under the consumer's strictness.
+ *
+ * The manifest imports Open App packages that do not exist in this test, so module
+ * resolution is disabled and callers assert on specific diagnostic codes rather than
+ * on an empty diagnostic list.
+ */
+function typeCheckAsConsumer(source: string): ts.Diagnostic[] {
+    const fileName = '/generated-manifest.ts';
+    const options: ts.CompilerOptions = {
+        strict: true,
+        noPropertyAccessFromIndexSignature: true,
+        noResolve: true,
+        skipLibCheck: true,
+        target: ts.ScriptTarget.ES2022,
+        module: ts.ModuleKind.ESNext,
+    };
+    const libFileName = ts.getDefaultLibFilePath(options);
+    const sourceFile = ts.createSourceFile(fileName, source, ts.ScriptTarget.ES2022, true);
+    const host: ts.CompilerHost = {
+        getSourceFile: (name) => {
+            if (name === fileName) return sourceFile;
+            const text = ts.sys.readFile(name);
+            return text === undefined ? undefined : ts.createSourceFile(name, text, ts.ScriptTarget.ES2022, true);
+        },
+        writeFile: () => undefined,
+        getDefaultLibFileName: () => libFileName,
+        useCaseSensitiveFileNames: () => true,
+        getCanonicalFileName: (n) => n,
+        getCurrentDirectory: () => '/',
+        getNewLine: () => '\n',
+        fileExists: (name) => name === fileName || ts.sys.fileExists(name),
+        readFile: (name) => (name === fileName ? source : ts.sys.readFile(name)),
+    };
+    const program = ts.createProgram([fileName], options, host);
+    return [...program.getSyntacticDiagnostics(sourceFile), ...program.getSemanticDiagnostics(sourceFile)];
+}
 
 describe('applyOpenAppClientBootstrapBlock', () => {
     it('appends a referenced namespace import per enabled client package in a delimited block', () => {
@@ -25,7 +72,10 @@ describe('applyOpenAppClientBootstrapBlock', () => {
         expect(out).not.toContain("import '@acme/a-ng';");
         // The anchor: exported array references every namespace + observable global assignment.
         expect(out).toContain('export const OPEN_APP_CLIENT_MODULES: unknown[] = [__openAppClient0, __openAppClient1];');
-        expect(out).toContain('(globalThis as Record<string, unknown>).__mjOpenAppClientModules = OPEN_APP_CLIENT_MODULES;');
+        expect(out).toContain("(globalThis as Record<string, unknown>)['__mjOpenAppClientModules'] = OPEN_APP_CLIENT_MODULES;");
+        // Regression guard: dot access on this index-signature property is TS4111 in any consumer
+        // compiling with `noPropertyAccessFromIndexSignature` — MJExplorer does.
+        expect(out).not.toContain(').__mjOpenAppClientModules');
         // No `any` and therefore no eslint escape hatch in generated output.
         expect(out).not.toContain('any');
         expect(out).not.toContain('eslint-disable');
@@ -33,6 +83,17 @@ describe('applyOpenAppClientBootstrapBlock', () => {
         expect(out).toContain('END Open App client bootstrap');
         // Original manifest content is preserved.
         expect(out).toContain('export const CLASS_REGISTRATIONS = [];');
+    });
+
+    it('emits output that type-checks under a consumer using noPropertyAccessFromIndexSignature', () => {
+        // MJExplorer compiles this generated file with `noPropertyAccessFromIndexSignature: true`
+        // (packages/MJExplorer/tsconfig.json). Dot access on the `Record<string, unknown>` cast is
+        // TS4111 there, which fails the Explorer build and emits zero JS whenever an Open App exists.
+        const out = applyOpenAppClientBootstrapBlock(BASE, [{ PackageName: '@acme/a-ng', Enabled: true }]);
+        const violations = typeCheckAsConsumer(out)
+            .filter((d) => d.code === TS_PROPERTY_FROM_INDEX_SIGNATURE)
+            .map((d) => ts.flattenDiagnosticMessageText(d.messageText, ' '));
+        expect(violations).toEqual([]);
     });
 
     it('emits a disabled package as a comment, not an import', () => {

--- a/packages/MJCLI/src/commands/codegen/manifest.ts
+++ b/packages/MJCLI/src/commands/codegen/manifest.ts
@@ -69,7 +69,11 @@ export function applyOpenAppClientBootstrapBlock(content: string, clientEntries:
         // type — `unknown` states that precisely and needs no eslint escape hatch.
         lines.push('');
         lines.push(`export const OPEN_APP_CLIENT_MODULES: unknown[] = [${refs.join(', ')}];`);
-        lines.push('(globalThis as Record<string, unknown>).__mjOpenAppClientModules = OPEN_APP_CLIENT_MODULES;');
+        // Bracket access, not dot: `globalThis` is cast to `Record<string, unknown>`, so this
+        // property comes from an index signature. Consumers compile this generated file under
+        // their own tsconfig, and MJExplorer sets `noPropertyAccessFromIndexSignature: true`,
+        // which rejects dot access here (TS4111) and fails its build with zero JS emitted.
+        lines.push("(globalThis as Record<string, unknown>)['__mjOpenAppClientModules'] = OPEN_APP_CLIENT_MODULES;");
         result = `${result.replace(/\n+$/, '')}\n\n${OPEN_APP_BOOTSTRAP_BEGIN}\n${lines.join('\n')}\n${OPEN_APP_BOOTSTRAP_END}\n`;
     }
     return result;

--- a/packages/ServerBootstrap/src/generated/mj-class-registrations.ts
+++ b/packages/ServerBootstrap/src/generated/mj-class-registrations.ts
@@ -199,7 +199,7 @@ import {
     WorkOSProvider,
 } from '@memberjunction/auth-providers';
 
-// @memberjunction/core-entities (409 classes)
+// @memberjunction/core-entities (410 classes)
 import {
     AIAgentPermissionProvider,
     AISkillPermissionProvider,
@@ -271,6 +271,7 @@ import {
     MJAISkillActionEntity,
     MJAISkillEntity,
     MJAISkillPermissionEntity,
+    MJAISkillSearchScopeEntity,
     MJAISkillSubAgentEntity,
     MJAIVendorEntity,
     MJAIVendorTypeDefinitionEntity,
@@ -1566,6 +1567,7 @@ export const CLASS_REGISTRATIONS: any[] = [
     MJAISkillActionEntity,
     MJAISkillEntity,
     MJAISkillPermissionEntity,
+    MJAISkillSearchScopeEntity,
     MJAISkillSubAgentEntity,
     MJAIVendorEntity,
     MJAIVendorTypeDefinitionEntity,
@@ -2445,7 +2447,7 @@ export const CLASS_REGISTRATIONS: any[] = [
 export const CLASS_REGISTRATIONS_MANIFEST_LOADED = true;
 
 /** Total @RegisterClass decorated classes discovered in dependency tree */
-export const CLASS_REGISTRATIONS_COUNT = 999;
+export const CLASS_REGISTRATIONS_COUNT = 1000;
 
 /** Packages imported by this manifest */
 export const CLASS_REGISTRATIONS_PACKAGES = [

--- a/packages/ServerBootstrapLite/src/generated/mj-class-registrations.ts
+++ b/packages/ServerBootstrapLite/src/generated/mj-class-registrations.ts
@@ -182,7 +182,7 @@ import {
     ZhipuLLM,
 } from '@memberjunction/ai-zhipu';
 
-// @memberjunction/core-entities (409 classes)
+// @memberjunction/core-entities (410 classes)
 import {
     AIAgentPermissionProvider,
     AISkillPermissionProvider,
@@ -254,6 +254,7 @@ import {
     MJAISkillActionEntity,
     MJAISkillEntity,
     MJAISkillPermissionEntity,
+    MJAISkillSearchScopeEntity,
     MJAISkillSubAgentEntity,
     MJAIVendorEntity,
     MJAIVendorTypeDefinitionEntity,
@@ -1275,6 +1276,7 @@ export const CLASS_REGISTRATIONS: any[] = [
     MJAISkillActionEntity,
     MJAISkillEntity,
     MJAISkillPermissionEntity,
+    MJAISkillSearchScopeEntity,
     MJAISkillSubAgentEntity,
     MJAIVendorEntity,
     MJAIVendorTypeDefinitionEntity,
@@ -2045,7 +2047,7 @@ export const CLASS_REGISTRATIONS: any[] = [
 export const CLASS_REGISTRATIONS_MANIFEST_LOADED = true;
 
 /** Total @RegisterClass decorated classes discovered in dependency tree */
-export const CLASS_REGISTRATIONS_COUNT = 881;
+export const CLASS_REGISTRATIONS_COUNT = 882;
 
 /** Packages imported by this manifest */
 export const CLASS_REGISTRATIONS_PACKAGES = [


### PR DESCRIPTION
Release-prep branch for **v5.50.0**. This is the second attempt: the first prep merged as #3342, then the build was halted so other work could land on `next`. Everything here was re-derived from scratch against the current tip rather than carried over.

Three commits, one of which is a **build blocker** that would otherwise ship.

## The blocker: MJExplorer cannot build when any Open App is present

`mj codegen manifest --open-app-client-bootstrap` emitted its anchor using dot access on a property that comes from an index signature — `globalThis` is cast to `Record<string, unknown>`:

```ts
(globalThis as Record<string, unknown>).__mjOpenAppClientModules = OPEN_APP_CLIENT_MODULES;
```

Consumers compile that generated file under **their own** tsconfig, and `packages/MJExplorer/tsconfig.json` sets `noPropertyAccessFromIndexSignature: true`. So the manifest failed to type-check and the Explorer build exited 1 having emitted **zero JS**. `ng serve` printed `Watch mode enabled` *after* the error and then served nothing, which reads as a working dev server.

This affected any installation with at least one entry in `dynamicPackages.client`, whether installed via `mj app install` or dev-linked. The anchor is emitted once outside the per-app loop, so one Open App or fifty produced the same failure. Introduced by #3282.

The fix is bracket access. Runtime behavior is unchanged — JavaScript draws no distinction between dot- and bracket-written properties — and bracket access is valid under every strictness configuration, so no consumer is made worse.

**#3282 itself is correct and stays.** It fixes a real silent-data-loss defect: bare side-effect imports are legally dropped by bundlers when a package declares `"sideEffects": false`, killing every `@RegisterClass` registration in it with no error and exit 0. This PR fixes the one line, not the change.

### Why CI was green, and what that says about the test

MJ core has **no** `dynamicPackages.client` entries, so `clientEntries.length > 0` is never true in core's CI, the block is never generated, and the line is never type-checked.

The existing test asserted the emitted **string** — and it passed *precisely because* the text matched, while that text did not compile in the consumer. A string-equality test over generated code cannot catch a type error in that code.

So the test now compiles the generated output under `noPropertyAccessFromIndexSignature` using the TypeScript compiler API, which covers the whole class of defect rather than this one typo. A negative string assertion is kept as a fast guard. **Both were confirmed to fail against the unfixed generator before the fix was applied**, and again by temporarily reverting the source afterwards — this is not a test written to match code that already passes.

## PostgreSQL counterpart

`V202607290900__v5.50.x__Scoped_Search_Dimensional_Bounds.pg.sql` — 4,346 lines, converted from the 5,060-line SQL Server original via `mj migrate convert --split --bake-codegen`. It was the last v5.50 migration without a counterpart, and was never authored-then-deleted by a feature PR, so it is generated fresh.

Content was verified against the source rather than against the converter's `unhandled stmts: 0` summary, which is structurally blind to an emptied file — the failure mode that shipped a 126-byte `Metadata_Sync.pg.sql` in v5.45:

| Check | Result |
|---|---|
| Bare `EXEC spDelete` preserved as `PERFORM` | **21 / 21** (the v5.45 silent-drop class) |
| Views | **6 / 6**, plus `vwAIAgents` baked as a dependency |
| `CREATE TABLE` / `ALTER TABLE` | 1/1 · 13/13 |
| Bare-`;` statements | 6 found, all confirmed `INSERT ... VALUES` terminators inside PL/pgSQL — **not** the #3252 defect |
| `.needs-hand` files | 0 |

**The committed PG ledger is unchanged** — all 245 existing `.pg.sql` / `.pg-only.sql` files match their pre-conversion SHA-256 checksums, so the converter's EntityField-sequence dedup pass did not mutate any immutable file.

## Bootstrap manifests

The Scoped Search work added `MJAISkillSearchScopeEntity` to `@memberjunction/core-entities` (409 → 410 classes). Two PRs each adding a `@RegisterClass` merge without a git conflict, but the generated manifests only reconcile on a full build — so the registration was missing from all four bootstraps until now. Counts moved `999→1000`, `881→882`, `617→618`, `508→509`. These four files are generated output, not hand-edited.

## Evidence

| Gate | Result |
|---|---|
| Deterministic integration tier | **53 / 53**, DB tally `Passed=53` and nothing else, no environment-gap skips |
| MJCLI unit suite | **437 / 437** (24 files) |
| Full repo build | **267 / 267** |
| Integration sibling-parity gate (`--force`) | 144 tasks, **0 cached** |
| PG content + delete parity | 201 counterparts checked, **0 suspect**, **0 mismatched** |
| PG file parity (L1) | **204 / 204** |
| Fresh-database apply | **23 applied, 0 failed**; new table, 6 views, 18 indexes, 3 sprocs verified present |
| SS ↔ PG object counts | tables **385=385** · views **394=394** · FKs **804=804** |
| View semantic equivalence | **0 new divergences; 5 resolved** |
| CRUD behavioral oracle | 376 pass / 5 skip / 3 fail — **all 6 new entities pass**; the 3 failures are documented harness artifacts in unrelated entities |
| Full-stack on the converted schema | MJAPI boot · login · data render · write · **audit trigger emitted the expected `RecordChange`** |

The view-equivalence result is a controlled comparison: the same schema **without** this migration reports 43 semantic divergences, and **with** it 38. The conversion introduces none and resolves five — its own views.

The deterministic tier was run twice, before and after the CLI fix, and was 53/53 both times.

## Known, and deliberately not addressed here

- The **live-model tier** was run and triaged at 7/15. No confirmed product regression: the failures trace to two pre-existing test defects (a harness still querying the `AIPromptRun.AgentRunID` column this release drops, and a check asserting a `MIN_TERM_LENGTH` that #3289 intentionally lowered), plus a run-budget cascade and model variance. Those test fixes are tracked separately rather than widening this PR.
- **Two pre-existing SS/PG gaps** surfaced during verification and are **not** caused by this change: 6 CRUD procs exist on SQL Server but not PostgreSQL, and 38 views diverge semantically. Both predate v5.50.
- `mj sync push` against the gate database hit the documented dashboard-permission block. The gate criterion is a clean `mj migrate`, which passed; the push rolls back and leaves the schema untouched.

## Deploy notes

The PG migration is applied by Flyway independently of code, and is additive — a new table, columns, views, indexes and sprocs. There is no ordering hazard against the other two commits, which are a generated manifest and a build-time code generator.

**No `metadata/**` changes.** Step 3 of the release process was re-run against a fresh database and `mj sync push` reported `no changes`, so the already-committed `V202607281645__Metadata_Sync.sql` covers the current metadata tree and no new sync migration was required.

No related issue: the TS4111 defect was reported as a document rather than filed, and the other two commits are release mechanics.