### PR TITLE
fix: BaseEngine cache callback fingerprint mismatch breaking cross-server invalidation

### DIFF
--- a/.changeset/steady-engines-align.md
+++ b/.changeset/steady-engines-align.md
@@ -1,0 +1,5 @@
+---
+"@memberjunction/core": patch
+---
+
+Fix BaseEngine cache callback fingerprint mismatch that broke cross-server invalidation via Redis pub/sub by extracting a shared BuildRunViewParamsForConfig method to ensure consistent RunViewParams across LoadSingleEntityConfig, LoadMultipleEntityConfigs, and RegisterCacheChangeCallbacks

--- a/packages/MJCore/src/generic/baseEngine.ts
+++ b/packages/MJCore/src/generic/baseEngine.ts
@@ -1731,6 +1731,27 @@ export abstract class BaseEngine<T> extends BaseSingleton<T> implements IStartup
     }
 
     /**
+     * Builds the RunViewParams for an engine config. Used by LoadSingleEntityConfig,
+     * LoadMultipleEntityConfigs, and RegisterCacheChangeCallbacks to ensure the
+     * fingerprint-affecting params (EntityName, ExtraFilter, OrderBy, IgnoreMaxRows)
+     * are always consistent — preventing cache key mismatches that break cross-server
+     * invalidation via Redis pub/sub.
+     */
+    protected BuildRunViewParamsForConfig(config: BaseEnginePropertyConfig, bypassCache: boolean = false): RunViewParams {
+        return {
+            EntityName: config.EntityName,
+            ResultType: config.ResultType || this.EngineDefaultResultType,
+            ExtraFilter: config.Filter,
+            OrderBy: config.OrderBy,
+            IgnoreMaxRows: true, // Engines always need ALL data — bypass entity-level UserViewMaxRows caps
+            _fromEngine: true,   // Mark as engine-initiated to avoid false positive telemetry warnings
+            CacheLocal: config.CacheLocal,
+            CacheLocalTTL: config.CacheLocalTTL,
+            BypassCache: bypassCache
+        } as RunViewParams;
+    }
+
+    /**
      * Handles the process of loading a single config of type 'entity'.
      * @param config
      * @param contextUser
@@ -1745,17 +1766,7 @@ export abstract class BaseEngine<T> extends BaseSingleton<T> implements IStartup
         const generation = this.beginConfigRefresh(config.PropertyName);
         const p = this.RunViewProviderToUse;
         const rv = new RunView(p);
-        const result = await rv.RunView({
-            EntityName: config.EntityName,
-            ResultType: config.ResultType || this.EngineDefaultResultType,
-            ExtraFilter: config.Filter,
-            OrderBy: config.OrderBy,
-            IgnoreMaxRows: true, // Engines always need ALL data — bypass entity-level UserViewMaxRows caps
-            _fromEngine: true,  // Mark as engine-initiated to avoid false positive telemetry warnings
-            CacheLocal: config.CacheLocal,
-            CacheLocalTTL: config.CacheLocalTTL,
-            BypassCache: bypassCache
-        }, contextUser);
+        const result = await rv.RunView(this.BuildRunViewParamsForConfig(config, bypassCache), contextUser);
 
         // A newer full refresh superseded us while we awaited — drop this (staler) snapshot
         // rather than clobber the newer one. The newer refresh owns the assignment, the
@@ -1871,19 +1882,7 @@ export abstract class BaseEngine<T> extends BaseSingleton<T> implements IStartup
         if (configs && configs.length > 0) {
             const p = this.RunViewProviderToUse;
             const rv = new RunView(p);
-            const viewConfigs = configs.map(c => {
-                return <RunViewParams>{
-                    EntityName: c.EntityName,
-                    ResultType: c.ResultType || this.EngineDefaultResultType,
-                    ExtraFilter: c.Filter,
-                    OrderBy: c.OrderBy,
-                    IgnoreMaxRows: true, // Engines always need ALL data — bypass entity-level UserViewMaxRows caps
-                    _fromEngine: true,  // Mark as engine-initiated to avoid false positive telemetry warnings
-                    CacheLocal: c.CacheLocal,
-                    CacheLocalTTL: c.CacheLocalTTL,
-                    BypassCache: bypassCache
-                };
-            });
+            const viewConfigs = configs.map(c => this.BuildRunViewParamsForConfig(c, bypassCache));
             const results = await rv.RunViews(viewConfigs, contextUser);
 
             // Process results and record entity loads for redundancy detection
@@ -2008,12 +2007,7 @@ export abstract class BaseEngine<T> extends BaseSingleton<T> implements IStartup
 
         for (const config of entityConfigs) {
             const fingerprint = LocalCacheManager.Instance.GenerateRunViewFingerprint(
-                {
-                    EntityName: config.EntityName,
-                    ExtraFilter: config.Filter,
-                    OrderBy: config.OrderBy,
-                    ResultType: 'entity_object',
-                } as RunViewParams,
+                this.BuildRunViewParamsForConfig(config),
                 connectionPrefix
             );
 


### PR DESCRIPTION
## Summary
- Extracts a shared `BuildRunViewParamsForConfig()` method in `BaseEngine` to ensure `RunViewParams` fingerprints are consistent across `LoadSingleEntityConfig`, `LoadMultipleEntityConfigs`, and `RegisterCacheChangeCallbacks`
- Fixes a bug where `RegisterCacheChangeCallbacks` used a manually-constructed params object with different fields (e.g., hardcoded `ResultType: 'entity_object'`, missing `IgnoreMaxRows`) compared to the load methods, causing Redis pub/sub cache invalidation callbacks to never match

## Test plan
- [x] Build `@memberjunction/core` (`cd packages/MJCore && npm run build`)
- [x] Verify cross-server cache invalidation works via Redis pub/sub (cache callback fingerprints now match between load and registration)
- [x] Confirm single-server cache refresh still functions correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)