### PR TITLE
docs(MJCore): show how to CREATE an IS-A child, not just how IDs propagate

### DIFF
--- a/packages/MJCore/docs/isa-relationships.md
+++ b/packages/MJCore/docs/isa-relationships.md
@@ -500,9 +500,90 @@ WHERE Name = 'Persons';
 
 No other changes are needed — the existing IS-A infrastructure handles everything else automatically.
 
+## Creating a Child Record
+
+**Create the CHILD and set fields from anywhere in the chain. One save writes every table.**
+
+You do not create the parent and then attach a child to it. You create the child, set both its own
+fields and its ancestors', and save once — `BaseEntity` routes each field to the entity that owns it
+via `EntityInfo.ParentEntityFieldNames`, saves the chain root-first, and shares one primary key
+across every level.
+
+```typescript
+// Webinar IS-A Meeting IS-A Product
+const webinar = await md.GetEntityObject<WebinarEntity>('Webinars', contextUser);
+webinar.NewRecord();
+
+// Webinar's own fields
+webinar.RecordingURL = 'https://example.com/rec/123';
+webinar.MaxViewers   = 500;
+
+// Meeting's fields — one level up
+webinar.StartTime    = new Date('2026-03-01T15:00:00Z');
+webinar.Location     = 'Online';
+
+// Product's fields — two levels up. Set on the SAME object.
+webinar.Name         = 'Q1 Product Webinar';
+webinar.Status       = 'Active';
+webinar.CompanyID    = companyId;
+
+await webinar.Save();   // writes Product, then Meeting, then Webinar — one call
+```
+
+There is no depth limit: a field belonging to any ancestor is set on the child object and routed
+upward. `Get` reads back the same way, so `webinar.Name` returns the Product's `Name`.
+
+### Set the parent's required fields, or the save fails
+
+The most common IS-A mistake is forgetting a NOT NULL column that lives on an ANCESTOR table. The
+child's own fields are all present, the child looks complete, and the save still fails — because the
+parent insert is rejected first.
+
+```typescript
+const webinar = await md.GetEntityObject<WebinarEntity>('Webinars', contextUser);
+webinar.NewRecord();
+webinar.RecordingURL = 'https://example.com/rec/123';   // child fields only
+await webinar.Save();   // → false. Product.Name is NOT NULL and was never set.
+```
+
+From v5.50.0 the failure explains itself:
+
+```
+Failed to save parent entity 'Products': Name cannot be null; Status cannot be null
+```
+
+**Before v5.50.0 this returned `false` with `LatestResult === null` and an empty `ResultHistory`** —
+every result had been written to the parent object, which callers hold no reference to. If you are on
+an older version and a child save returns `false` with no message anywhere, this is almost certainly
+why; read `entity.ISAParent?.LatestResult` to see it.
+
+### Anti-pattern: creating the parent, then "attaching" a child
+
+```typescript
+// ❌ WRONG — this is not how IS-A works
+const product = await md.GetEntityObject<ProductEntity>('Products', contextUser);
+product.NewRecord();
+product.Name = 'Q1 Product Webinar';
+await product.Save();                       // parent row exists
+
+const webinar = await md.GetEntityObject<WebinarEntity>('Webinars', contextUser);
+webinar.NewRecord();
+webinar.Set('ID', product.ID);              // trying to adopt the parent's key
+webinar.RecordingURL = '...';
+await webinar.Save();                       // → false
+```
+
+`NewRecord()` starts a NEW chain, so this creates a second parent and then fights the first over the
+primary key. Use the correct form above instead: one `GetEntityObject` on the child, one `Save`.
+
+If you genuinely need to add a child to a parent row that ALREADY exists — a subtype decided after
+the fact — that is a different operation from creation, and IS-A's save path does not model it: it
+always saves the parent too, which fails if the parent is immutable or frozen by a trigger. Handle
+that case explicitly rather than expecting `Save()` to attach.
+
 ## NewRecord & ID Propagation
 
-When creating a new IS-A child record, the UUID is automatically shared across the entire chain:
+`NewRecord()` walks the chain and shares one UUID across every level:
 
 ```typescript
 const webinar = await md.GetEntityObject<WebinarEntity>('Webinars');
@@ -515,6 +596,8 @@ webinar.NewRecord();
 // 5. Propagates Meeting's ID to Product: product.Set('ID', 'abc-123')
 // Result: All three entities share 'abc-123' as their primary key
 ```
+
+You never set the ID yourself — that shared key IS the relationship.
 
 ## Provider Implementation
 
@@ -799,7 +882,9 @@ class BaseEntity {
 | Parent fields not appearing in view | `ParentID` not set on entity | Set `Entity.ParentID` to parent entity's ID |
 | "Field collision" error in CodeGen | Child table has column with same name as parent field | Rename the child column to avoid conflict |
 | Disjoint violation on save | Same ID exists in a sibling child entity | Each record can only be one child type |
-| Save fails with rollback | Parent entity validation failed | Check parent entity field requirements |
+| Save fails with rollback | Parent entity validation failed | Check parent entity field requirements — most often a NOT NULL column on an ANCESTOR table that was never set. See [Creating a Child Record](#creating-a-child-record) |
+| Save returns `false` with NO message, empty `ResultHistory` | Parent save failed on core **< 5.50.0**, where the result was recorded only on the parent object | Upgrade to 5.50.0+, which reports `Failed to save parent entity '<Name>': <detail>`. On older versions read `entity.ISAParent?.LatestResult` |
+| Child save fails after creating the parent separately | `NewRecord()` starts a NEW chain — it does not adopt an existing parent row | Create the CHILD and set the parent's fields on it; one `Save()` writes both |
 | Delete blocked on parent | Child records exist | Delete children first or enable `CascadeDeletes` |
 | `_parentEntity` is null | Entity not properly initialized | Ensure `GetEntityObject()` is used (not direct constructor) |
 | `ISAChild` is null after Load | Provider doesn't implement `FindISAChildEntity` | Update provider or use `ResolveLeafEntity()` static method |

--- a/packages/MJCore/readme.md
+++ b/packages/MJCore/readme.md
@@ -444,6 +444,29 @@ if (!result.Success) {
 }
 ```
 
+#### IS-A (Table-Per-Type) entities
+
+An entity may inherit from another — `Webinar` IS-A `Meeting` IS-A `Product` — with one primary key
+shared across every table. `BaseEntity` makes the chain invisible: set a field belonging to ANY
+ancestor directly on the child, and one `Save()` writes every level in a single transaction.
+
+```typescript
+const webinar = await md.GetEntityObject<WebinarEntity>('Webinars', contextUser);
+webinar.NewRecord();
+webinar.RecordingURL = '...';        // Webinar's own field
+webinar.StartTime    = startTime;    // Meeting's field
+webinar.Name         = 'Q1 Webinar'; // Product's field — same object
+await webinar.Save();                // writes Product, Meeting, Webinar
+```
+
+Two things catch people out. Do **not** create the parent separately and then attach a child to it —
+`NewRecord()` starts a new chain rather than adopting an existing row. And remember to set NOT NULL
+columns that live on ANCESTOR tables: the child can look complete while the parent insert is
+rejected, which fails the whole save.
+
+See [docs/isa-relationships.md](docs/isa-relationships.md) for the full model — discovery, disjoint
+vs overlapping subtypes, delete orchestration, and CodeGen integration.
+
 ### CompositeKey
 
 The `CompositeKey` class provides flexible primary key representation supporting both single and multi-field primary keys.

--- a/packages/MJCore/src/generic/baseEntity.ts
+++ b/packages/MJCore/src/generic/baseEntity.ts
@@ -2360,10 +2360,40 @@ export abstract class BaseEntity<T = unknown> {
     /**
      * Saves the current state of the object to the database. Uses the active provider to handle the actual saving of the record.
      * If the record is new, it will be created, if it already exists, it will be updated.
-     * 
+     *
      * Debounces multiple calls so that if Save() is called again while a save is in progress,
      * the second call will simply receive the same result as the first.
-     * 
+     *
+     * ## IS-A entities: one Save() writes the whole chain
+     *
+     * For a Table-Per-Type child, this saves EVERY level — root first, then down to this entity —
+     * inside one transaction, with a single primary key shared across all of them. Set fields
+     * belonging to any ancestor directly on this object; {@link Set} routes each one to the entity
+     * that owns it. There is no depth limit.
+     *
+     * ```typescript
+     * // Webinar IS-A Meeting IS-A Product
+     * const webinar = await md.GetEntityObject<WebinarEntity>('Webinars', contextUser);
+     * webinar.NewRecord();
+     * webinar.RecordingURL = '...';   // Webinar's own
+     * webinar.StartTime    = start;   // Meeting's
+     * webinar.Name         = 'Q1';    // Product's — set on the SAME object
+     * await webinar.Save();           // writes Product, Meeting, Webinar
+     * ```
+     *
+     * Do NOT create the parent separately and then try to attach a child to it — `NewRecord()`
+     * starts a new chain rather than adopting an existing parent row, so that produces a second
+     * parent and a primary-key conflict.
+     *
+     * If a PARENT level fails validation, this returns false and the failure is reported on THIS
+     * entity's result as `Failed to save parent entity '<Name>': <detail>`. The commonest cause is a
+     * NOT NULL column on an ancestor table that was never set — the child looks complete and the
+     * save still fails. (Before v5.50.0 that result was recorded only on the parent object, so the
+     * caller saw `false` with a null `LatestResult` and an empty `ResultHistory`.)
+     *
+     * @see {@link ISAParent} to inspect the parent instance directly
+     * @see packages/MJCore/docs/isa-relationships.md — "Creating a Child Record"
+     *
      * @param options
      * @returns Promise<boolean>
      */


### PR DESCRIPTION
Docs and JSDoc only. No behaviour change.

## The gap

`isa-relationships.md` is thorough about the model — discovery, disjoint vs overlapping, delete orchestration, CodeGen integration — and near-silent about the first thing a developer actually does: create one.

Every creation example in the file is about **UUID propagation**. Not one sets a field belonging to a parent. And the natural-but-wrong mental model — *create the parent, then attach a child to it* — isn't warned against anywhere.

## Why I think it's worth fixing rather than just being more careful

Working on `bizapps-orders` I concluded, wrote down, and committed the claim that **IS-A children could not be created through the object model at all**. It went into a commit message and a build-inventory doc as a shipped limitation.

They can, at any depth. What I'd done was create the parent `Product` first and then try to attach an `EventProduct` with the same id. The parent save failed on a NOT NULL column the child never set; the child looked complete; it read as a framework limitation. I also built two supporting theories that were wrong — that `IsVirtual=1 AND AllowUpdateAPI=1` was a CodeGen defect (it's the deliberate marker for an IS-A parent field, per `manage-metadata.ts`), and that a 30-field entity against an 11-parameter proc proved the save path couldn't work.

The part that convinced me this is a docs problem: **a previous author had reached the same wrong conclusion in the same file months earlier**, and left a comment saying `BaseEntity` "cannot express that". Two people independently inventing the same limitation is a signal about the documentation, not the readers.

## What this adds

**`isa-relationships.md`** — a new *Creating a Child Record* section:

- A worked example setting fields from **three levels** on one child object and saving once, with the rule stated plainly: fields route to whichever entity owns them, no depth limit.
- The failure that looks like a bug — a NOT NULL column on an **ancestor** table — with the v5.50.0 message that now names it, and what the pre-5.50.0 silence looked like so anyone on an older version recognises it.
- The anti-pattern, with code, because it's what people try first: `NewRecord()` starts a **new chain** rather than adopting an existing parent row.
- A note that attaching a child to an already-saved parent is a genuinely different operation the save path doesn't model — relevant when the parent is frozen by a trigger.
- Three troubleshooting rows, including the silent-`false` symptom keyed to the version that fixed it (#3280).

**`BaseEntity.Save` JSDoc** — the same guidance at the call site, because that's where someone looks when a save returns `false`, not in a doc they don't know exists.

**`packages/MJCore/readme.md`** — had no mention of IS-A at all. Now carries a short section under `BaseEntity` with the example, the two traps, and a pointer to the full document.

## Note on #3280

The pre-5.50.0 silent-`false` behaviour is exactly what your PR #3280 fixed. This documents it from the reader's side: what the symptom looked like, and which version to be on. The two go together — #3280 makes the failure speak, this makes the correct usage discoverable before you hit it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)