### PR TITLE
docs: publish release notes on the docs site (releases/v*.md)

### DIFF
--- a/.claude/commands/notes.md
+++ b/.claude/commands/notes.md
@@ -7,8 +7,9 @@ You are a techncal analyst working as a release coordinator for MemberJunction. 
 2. Figure out the next version (whether patch or minor) using `npx changeset status --since main` 
 3.Use both the diff contents and git commit messages to build up the context.  
 - The .changeset/ dir also has more focused human-entered notes you can use. 
-4. Write the release notes to tmp/release-<version>.md following the template given below.
+4. Write the release notes to releases/v<version>.md (the `releases/` directory at the repo root) following the template given below.
 - You can add/remove bullets as needed and omit sections if there are no bullets.
+- This directory is rendered on the docs site automatically (docs.memberjunction.org/releases/), so the file IS the publication — commit it with the release. See releases/README.md.
 5. Verify that the file was written correctly and include its content in your final response.
 
 <template>

--- a/.github/workflows/docs-site-ci.yml
+++ b/.github/workflows/docs-site-ci.yml
@@ -15,6 +15,7 @@ on:
       - 'CONTRIBUTING.md'
       - 'metadata/README.md'
       - '.claude/skills/**'
+      - 'releases/**'
       - '.github/workflows/docs-site-ci.yml'
 
 permissions:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -19,6 +19,7 @@ on:
       - 'CONTRIBUTING.md'
       - 'metadata/README.md'
       - '.claude/skills/**'
+      - 'releases/**'
 
   workflow_dispatch:
 

--- a/docs-site/.gitignore
+++ b/docs-site/.gitignore
@@ -7,6 +7,7 @@ dist/
 # (The list mirrors GENERATED_PATHS in scripts/ingest.mjs.)
 src/content/docs/guides/
 src/content/docs/packages/
+src/content/docs/releases/
 src/content/docs/community/
 src/content/docs/overview.md
 src/content/docs/deployment.md

--- a/docs-site/README.md
+++ b/docs-site/README.md
@@ -7,6 +7,7 @@ The MemberJunction documentation site — an [Astro Starlight](https://starlight
 | Developer guides | `guides/*.md` | Auto-discovered by `scripts/ingest.mjs` |
 | Package docs | `packages/**/README.md` (package roots + grouping dirs) | Auto-discovered; index table built from each `package.json` |
 | Overview / Deployment / Upgrade / Contributing / Metadata | Root repo docs | Fixed list in `ingest.mjs` |
+| Release notes | `releases/v*.md` (written by the `/notes` skill) | Auto-discovered; newest-first index generated |
 | Agent skills catalog | `.claude/skills/*/SKILL.md` | Auto-discovered frontmatter |
 | Ecosystem cards | Skyway / Forge / VSCode / bizapps GitHub repos | Fetched at build time (fail-soft) |
 | API reference (`/api/`) | TypeDoc over all packages | Built by `.github/workflows/docs.yml`, copied into `dist/api/` |

--- a/docs-site/astro.config.mjs
+++ b/docs-site/astro.config.mjs
@@ -45,6 +45,7 @@ export default defineConfig({
             { label: 'Upgrading to v5', slug: 'upgrade-v5' },
           ],
         },
+        { label: 'Release Notes', collapsed: true, autogenerate: { directory: 'releases', collapsed: true } },
         { label: 'Architecture', slug: 'architecture' },
         { label: 'Building Apps on MJ', slug: 'custom-apps' },
         { label: 'Guides', collapsed: true, autogenerate: { directory: 'guides', collapsed: true } },

--- a/docs-site/scripts/ingest.mjs
+++ b/docs-site/scripts/ingest.mjs
@@ -16,7 +16,7 @@ import { existsSync, mkdirSync, readdirSync, readFileSync, rmSync, statSync, wri
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { transformRepoMarkdown, buildFrontmatter } from './lib/markdown.mjs';
-import { guideSlug, labelFromSlug, packageSlug, relativeSiteLink } from './lib/site-map.mjs';
+import { compareReleasesDesc, guideSlug, labelFromSlug, packageSlug, relativeSiteLink, releaseSlug, releaseVersion } from './lib/site-map.mjs';
 import { fetchEcosystem } from './lib/ecosystem.mjs';
 
 const SCRIPT_DIR = path.dirname(fileURLToPath(import.meta.url));
@@ -29,6 +29,7 @@ const SKIP_DIRS = new Set(['node_modules', 'dist', '.turbo', '.angular', 'covera
 const GENERATED_PATHS = [
   'guides',
   'packages',
+  'releases',
   'community',
   'overview.md',
   'deployment.md',
@@ -55,11 +56,13 @@ async function main() {
   const sha = resolveBuildSha(warn);
 
   cleanGeneratedPaths();
-  const entries = [...rootDocEntries(), ...guideEntries(), ...packageEntries(warn)];
+  const entries = [...rootDocEntries(), ...guideEntries(), ...packageEntries(warn), ...releaseEntries(warn)];
   const siteMap = new Map(entries.map((e) => [e.src, e.slug]));
 
-  for (const entry of entries) writeEntry(entry, siteMap, sha, warn);
+  const written = new Map();
+  for (const entry of entries) written.set(entry.slug, writeEntry(entry, siteMap, sha, warn));
   writePackagesIndex(entries.filter((e) => e.package));
+  writeReleasesIndex(entries.filter((e) => e.release), written);
   writeSkillsPage(sha, warn);
   await writeEcosystemPage(warn);
 
@@ -141,6 +144,33 @@ function* walkPackageDirs(dirRel) {
   }
 }
 
+/**
+ * Release notes: one markdown file per version in releases/ at the repo root
+ * (written by the /notes release-coordinator skill). Files are named
+ * v<major>.<minor>.<patch>.md; newest versions sort first in the sidebar.
+ */
+function releaseEntries(warn) {
+  const releasesDir = path.join(REPO_ROOT, 'releases');
+  if (!existsSync(releasesDir)) return [];
+  const files = readdirSync(releasesDir).filter((name) => name.endsWith('.md') && name !== 'README.md');
+  for (const name of files) {
+    if (releaseVersion(name) === null) warn(`releases: cannot parse a version from "${name}"; it will sort last`);
+  }
+  return files.sort(compareReleasesDesc).map((name, index) => {
+    const version = name.replace(/\.md$/i, '');
+    return {
+      src: `releases/${name}`,
+      slug: `releases/${releaseSlug(name)}`,
+      out: `releases/${releaseSlug(name)}.md`,
+      fallbackTitle: version,
+      titlePrefix: version,
+      sidebarLabel: version,
+      sidebarOrder: index + 1,
+      release: { version },
+    };
+  });
+}
+
 function readPackageMeta(dirRel) {
   const manifestPath = path.join(REPO_ROOT, dirRel, 'package.json');
   if (!existsSync(manifestPath)) return { name: null, description: '', isPrivate: true };
@@ -156,14 +186,24 @@ function writeEntry(entry, siteMap, sha, warn) {
   const source = readFileSync(path.join(REPO_ROOT, entry.src), 'utf8');
   const ctx = { srcRepoPath: entry.src, currentSlug: entry.slug, siteMap, sha, fileKind: repoFileKind, warn };
   const { title, description, body } = transformRepoMarkdown(source, ctx);
+  const pageTitle = composeTitle(entry, title);
   const frontmatter = buildFrontmatter({
-    title: title || entry.fallbackTitle,
+    title: pageTitle,
     description,
     editUrl: EDIT_BASE + entry.src,
     sidebarLabel: entry.sidebarLabel,
     sidebarOrder: entry.sidebarOrder,
   });
   writePage(entry.out, frontmatter + body);
+  return { title: pageTitle, summary: title, description };
+}
+
+/** Releases title as "v5.51.0: <the file's H1 summary>"; everything else uses the H1 (or fallback). */
+function composeTitle(entry, extractedTitle) {
+  if (entry.titlePrefix) {
+    return extractedTitle ? `${entry.titlePrefix}: ${extractedTitle}` : entry.titlePrefix;
+  }
+  return extractedTitle || entry.fallbackTitle;
 }
 
 function repoFileKind(repoPath) {
@@ -202,6 +242,23 @@ function writePackagesIndex(packageEntries) {
 
 function mdCell(text) {
   return (text ?? '').replace(/\|/g, '\\|').replace(/\s+/g, ' ').trim();
+}
+
+function writeReleasesIndex(releaseEntries, written) {
+  const lines = [
+    buildFrontmatter({ title: 'Release Notes', description: 'What changed in each MemberJunction release.', sidebarLabel: 'All Releases', sidebarOrder: 0 }),
+    'Release notes live as markdown in [`releases/`](https://github.com/MemberJunction/MJ/tree/next/releases) in the MJ repo — one file per version, published here automatically with each deploy.',
+    '',
+  ];
+  if (releaseEntries.length === 0) {
+    lines.push('_Notes will appear here starting with the next release._');
+  }
+  for (const entry of releaseEntries) {
+    const info = written.get(entry.slug);
+    const summary = info?.summary ? `: ${info.summary}` : '';
+    lines.push(`- **[${entry.release.version}](${relativeSiteLink('releases', entry.slug)})**${summary}`);
+  }
+  writePage('releases/index.md', lines.join('\n'));
 }
 
 function writeSkillsPage(sha, warn) {

--- a/docs-site/scripts/lib/rewrite.test.mjs
+++ b/docs-site/scripts/lib/rewrite.test.mjs
@@ -2,7 +2,7 @@ import { test } from 'node:test';
 import assert from 'node:assert/strict';
 import { transformRepoMarkdown, buildFrontmatter, extractDescription } from './markdown.mjs';
 import { rewriteHtmlValue, rewriteLinkTarget, rewriteImageTarget } from './rewrite.mjs';
-import { guideSlug, labelFromSlug, packageSlug, relativeSiteLink, resolveRepoPath } from './site-map.mjs';
+import { compareReleasesDesc, guideSlug, labelFromSlug, packageSlug, relativeSiteLink, releaseSlug, releaseVersion, resolveRepoPath } from './site-map.mjs';
 
 const SHA = 'abc1234';
 
@@ -42,6 +42,17 @@ test('slug derivation strips _GUIDE and kebab-cases', () => {
 
 test('package slug lowercases each segment', () => {
   assert.equal(packageSlug('packages/AI/Providers/OpenAI'), 'packages/ai/providers/openai');
+});
+
+test('release slug and version parsing', () => {
+  assert.equal(releaseSlug('v5.51.0.md'), 'v5-51-0');
+  assert.deepEqual(releaseVersion('v5.51.0.md'), [5, 51, 0]);
+  assert.equal(releaseVersion('notes.md'), null);
+});
+
+test('releases sort newest-first with numeric (not lexical) comparison', () => {
+  const files = ['v5.9.0.md', 'v5.51.0.md', 'v6.0.0.md', 'v5.51.1.md', 'weird.md'];
+  assert.deepEqual(files.sort(compareReleasesDesc), ['v6.0.0.md', 'v5.51.1.md', 'v5.51.0.md', 'v5.9.0.md', 'weird.md']);
 });
 
 test('label from slug title-cases the last segment', () => {

--- a/docs-site/scripts/lib/site-map.mjs
+++ b/docs-site/scripts/lib/site-map.mjs
@@ -37,6 +37,34 @@ export function packageSlug(dirRelPath) {
   return dirRelPath.split('/').map((seg) => seg.toLowerCase()).join('/');
 }
 
+/** 'v5.51.0.md' -> 'v5-51-0' */
+export function releaseSlug(filename) {
+  return filename.replace(/\.md$/i, '').toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-|-$/g, '');
+}
+
+/**
+ * Sort key for release filenames: higher versions sort FIRST (newest-first).
+ * 'v5.51.0.md' -> [5, 51, 0]; unparseable names sort last (and should be
+ * warned about by the caller).
+ */
+export function releaseVersion(filename) {
+  const match = filename.match(/(\d+)\.(\d+)\.(\d+)/);
+  if (!match) return null;
+  return [Number(match[1]), Number(match[2]), Number(match[3])];
+}
+
+export function compareReleasesDesc(a, b) {
+  const va = releaseVersion(a);
+  const vb = releaseVersion(b);
+  if (va === null && vb === null) return a.localeCompare(b);
+  if (va === null) return 1;
+  if (vb === null) return -1;
+  for (let i = 0; i < 3; i++) {
+    if (va[i] !== vb[i]) return vb[i] - va[i];
+  }
+  return 0;
+}
+
 /**
  * Relative URL from one site slug to another (both without leading/trailing
  * slashes). Returns a path ending in '/', or '#anchor'-only for self-links.

--- a/docs-site/src/content/docs/community.mdx
+++ b/docs-site/src/content/docs/community.mdx
@@ -7,7 +7,7 @@ MemberJunction is developed in the open. Everything happens on GitHub:
 
 - **[Discussions](https://github.com/MemberJunction/MJ/discussions)** — questions, ideas, and show-and-tell.
 - **[Issues](https://github.com/MemberJunction/MJ/issues)** — bug reports and feature requests.
-- **[Releases](https://github.com/MemberJunction/MJ/releases)** — release notes for every version.
+- **[Release Notes](../releases/)** — what changed in each version, rendered from `releases/` in the repo.
 - **[npm](https://www.npmjs.com/org/memberjunction)** — all published packages under the `@memberjunction` scope.
 - **[Contributing](./contributing/)** — how to contribute, rendered from the repo's CONTRIBUTING.md.
 - **[License](https://github.com/MemberJunction/MJ/blob/main/LICENSE)** — open source, free to use.

--- a/plans/mj-documentation/plan.md
+++ b/plans/mj-documentation/plan.md
@@ -87,5 +87,5 @@ Implementation becomes possible the day the LTS branch exists; nothing to do bef
 
 1. Analytics — Plausible / GoatCounter / nothing? (Nothing is the current state.)
 2. Branded OG image for social cards (`docs-site/public/og-image.png`) — needs a designed asset.
-3. A "What's new" page aggregating recent release notes — small lift, deferred.
+3. ~~A "What's new" page aggregating recent release notes~~ **Resolved 2026-07-31:** release notes live as `releases/v*.md` in the repo (written by the `/notes` skill, which previously wrote to throwaway `tmp/`), auto-rendered at `/releases/` with a newest-first index. The build engineer's Teams post becomes optional; the file is the publication.
 4. Should the `training` repo be revived and linked from Getting Started? If not, archive it.

--- a/releases/README.md
+++ b/releases/README.md
@@ -1,0 +1,30 @@
+# Release Notes
+
+One markdown file per release, named `v<major>.<minor>.<patch>.md` (e.g. `v5.51.0.md`).
+
+These files are the **canonical release notes**. The docs site renders every file in this
+directory automatically at [docs.memberjunction.org/releases/](https://docs.memberjunction.org/releases/),
+newest first, with an auto-generated index — no site changes needed. Posting the same
+content to Teams is optional; this directory is the record.
+
+## Authoring
+
+The `/notes` skill (`.claude/commands/notes.md`) generates a release's notes from the
+diff, commit messages, and `.changeset/` entries, and writes the file here. Format:
+
+```markdown
+# <6-10 word summary of the release>
+
+## New Features
+- ...
+
+## Improvements
+- ...
+
+## Bug Fixes
+- ...
+```
+
+The H1 summary becomes part of the page title on the site (`v5.51.0: <summary>`).
+Commit the file as part of the release; the site deploy that follows the npm publish
+picks it up. This README itself is not rendered.


### PR DESCRIPTION
## One sentence

Release notes get a durable home in the repo (`releases/v5.51.0.md`-style files, written by the existing `/notes` skill) and the docs site renders them automatically at [docs.memberjunction.org/releases/](https://docs.memberjunction.org/releases/), so the build engineer's Teams post stops being the only publication.

## The gap

The `/notes` skill already says its output is "to be used in the documentation," but step 4 wrote the file to throwaway `tmp/`. Soham generates good notes each release, pastes them into Teams, and the markdown evaporates. The team doesn't use GitHub Releases, so there was no durable record anywhere.

## What changes

- **`releases/` at the repo root** is the canonical home: one file per version, `v<major>.<minor>.<patch>.md`, template unchanged (H1 summary + New Features / Improvements / Bug Fixes). `releases/README.md` documents the convention.
- **`/notes` skill** (`.claude/commands/notes.md`) now writes there instead of `tmp/` — the release workflow otherwise doesn't change: run `/notes`, commit the file with the release, done. Teams post becomes an optional copy-paste of the same file.
- **The docs site auto-renders the directory**: newest-first (numeric semver sort, so 5.51 > 5.9), page titles composed as `v5.51.0: <summary>`, an auto-generated All Releases index, links inside notes go through the same rewriter as everything else. New "Release Notes" sidebar group; the Community page now points at it instead of GitHub Releases.
- **Both docs workflows** trigger on `releases/**` so a notes commit after the publish still deploys.

## Verification

17/17 unit tests (2 new: version parsing + numeric newest-first ordering). Full local build verified three ways: with a scratch release file (page renders, title composes, an in-note repo link rewrote to the site's caching guide, index lists it), then with the directory empty (index renders a "notes will appear here" placeholder, build green), then final build clean.

## Follow-up for the build engineer

Backfill `releases/v5.51.0.md` with the exact markdown already posted to Teams (it's canonical since it was published), and use `/notes` as usual from the next release on.

## Unrelated changes

None.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01121onMFALyqJbWX7K9zsPR