### PR TITLE
fix(docs): pin the site deploy to the LTS line ref

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -7,9 +7,11 @@ on:
     types:
       - completed
 
-  # Docs content changes that land on main outside a release cycle
+  # Docs content changes that land on main or the LTS line outside a release
+  # cycle. The lts/5 trigger is what makes line release notes self-deploying:
+  # the notes commit pushed to lts/5 touches releases/** and fires this.
   push:
-    branches: [main]
+    branches: [main, lts/5]
     paths:
       - 'docs-site/**'
       - 'guides/**'
@@ -22,6 +24,11 @@ on:
       - 'releases/**'
 
   workflow_dispatch:
+    inputs:
+      ref:
+        description: 'Git ref to build the site from (defaults to the certified LTS line)'
+        required: false
+        default: 'lts/5'
 
 permissions:
   contents: read
@@ -45,10 +52,17 @@ jobs:
             exit 1
           fi
 
+      # The public site documents the LTS line, whatever branch fired the
+      # trigger. Without an explicit ref, workflow_run events check out the
+      # repo DEFAULT branch (next) — verified from past run history — which
+      # after the 6.x era opens would publish Edge dev content on every
+      # release. Pinned until versioned docs (/v5, /v6) land; update this ref
+      # when a new line certifies.
       - name: Checkout repo
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          ref: ${{ github.event.inputs.ref || 'lts/5' }}
 
       - name: Set up node
         uses: actions/setup-node@v6


### PR DESCRIPTION
Follow-up to #3395, which merged while this amendment was being prepared.

## Problem

The docs-site deploy's `workflow_run` trigger (fires after each publish) checks out the repo **default branch (`next`)** — GitHub's default for `workflow_run` events, verified from run history (e.g. tonight's post-publish deploy built `next@7eb2117e`). The `push` trigger builds `main`. Once the 6.x era opens, `main` tracks Edge publishes and `next` is the dev tip — so every Edge publish would rebuild the public docs site from unreleased 6.x content, and releases published from `lts/5` could never reach the site at all (line publishes never merge to `main`, so no trigger fires for them).

## Change (one file, `.github/workflows/docs.yml`)

- **Checkout pinned to `lts/5`** regardless of which trigger fired — the public site documents the certified LTS line. Pinned until versioned docs (/v5, /v6) land; the ref updates when a new line certifies.
- **New `push` trigger on `lts/5`** (same docs paths) — this makes line release notes self-deploying: the notes commit pushed to `lts/5` touches `releases/**` and fires the deploy.
- **`workflow_dispatch` gains a `ref` input** (default `lts/5`) for manual overrides.

## Reviewer notes

- For this to take effect the docs-site tooling (including #3395's releases rendering) must also exist on `lts/5` — the plan is to cherry-pick #3395 + this commit onto `lts/5` after merge, so the deploy's checked-out tree carries the generator it needs.
- Until then, deploys triggered from this workflow build `lts/5`'s current (pre-#3395) tree — same content the site shows today, so nothing regresses in the gap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019EfGkq8cW9drueo1vEN4sM