### PR TITLE
docs(site): add Release Notes card to the homepage grid

### DIFF
--- a/docs-site/src/content/docs/index.mdx
+++ b/docs-site/src/content/docs/index.mdx
@@ -44,4 +44,7 @@ import { Card, CardGrid } from '@astrojs/starlight/components';
   <Card title="Ecosystem" icon="puzzle">
     Skyway migrations, the Forge SQL GUI, the VSCode extension, and BizApps. [Meet the ecosystem](./ecosystem/).
   </Card>
+  <Card title="Release Notes" icon="seti:clock">
+    What changed in each MemberJunction release, including the current LTS line. [See all releases](./releases/).
+  </Card>
 </CardGrid>


### PR DESCRIPTION
One-file follow-up to #3395/#3397: the homepage is a splash template (no sidebar), so /releases/ had no link from the site root. Adds a seventh card to the grid.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019EfGkq8cW9drueo1vEN4sM