### PR TITLE
ci: label-driven backports to LTS lines (korthout/backport-action)

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -1,0 +1,37 @@
+name: Backport merged pull request
+
+# Line-fix flow (see plans/lts-process.md §5.2 on PR #3241): fixes land on
+# next first, then reach an LTS line by label. Put `backport lts/5` on a
+# merged next PR and this opens the cherry-pick PR against lts/5
+# automatically; conflicts become a draft PR a human finishes. Labeling
+# after the merge also triggers (the `labeled` event type below).
+
+on:
+  pull_request_target:
+    types: [closed, labeled]
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  backport:
+    name: Open backport pull request
+    if: >
+      github.repository_owner == 'MemberJunction' &&
+      github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Create backport pull requests
+        uses: korthout/backport-action@v3
+        with:
+          # Matches labels of the form `backport <branch>`, e.g. `backport lts/5`
+          label_pattern: ^backport ([^ ]+)$
+          pull_title: "[${target_branch}] ${pull_title}"
+          pull_description: |-
+            Backport of #${pull_number} to `${target_branch}`, opened automatically by the `backport ${target_branch}` label.
+
+            Line rules apply: patch-only; migrations require their §12 label.


### PR DESCRIPTION
Stands up the backport third of the line machinery (E-workstream): the `backport lts/5` label on a merged `next` PR opens the cherry-pick PR against the line automatically (korthout/backport-action@v3, the flow specified in the LTS process doc §5.2 on #3241). Labeling after merge also triggers, so it works retroactively for already-merged PRs. The `backport lts/5` label itself is created.

Inert until a label is applied. First consumer: #3157 (cache-refresh interval fix) once it merges Monday.

Reviewer note: uses `pull_request_target` (required — the workflow must run with write perms on label events), but the job only fires on merged PRs and never checks out or executes PR-head code; the action cherry-picks server-side history onto the target branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019EfGkq8cW9drueo1vEN4sM