### PR TITLE
Docs: forbid hand-written SQL DML, route bulk writes to Record Set Processing

### DIFF
--- a/.claude/rules/data-access.md
+++ b/.claude/rules/data-access.md
@@ -10,6 +10,70 @@ caching, and the performance patterns that go with them.
 
 ---
 
+## 🚨 NEVER HAND-WRITE SQL DML AGAINST MJ ENTITY TABLES 🚨
+
+**All writes to MJ entity tables go through `BaseEntity.Save()` / `Delete()`.** Never hand-write
+`INSERT`, `UPDATE`, `DELETE`, or `MERGE` from application code — not via `provider.ExecuteSQL(...)`,
+not via a raw connection, not "just for this one bulk case."
+
+```typescript
+// ❌ WRONG — bypasses the entire save pipeline, silently
+await provider.ExecuteSQL(`INSERT INTO ${schema}.Score (ID, Value) VALUES ('${id}', ${value})`, ...);
+
+// ✅ CORRECT
+const score = await md.GetEntityObject<ScoreEntity>('Scores', contextUser);
+score.NewRecord();
+score.Value = value;
+if (!await score.Save()) LogError(score.LatestResult?.CompleteMessage);
+```
+
+### What direct DML silently skips
+
+`BaseEntity.Save()` is not a thin wrapper around an `INSERT`. The provider's save pipeline
+(`databaseProviderBase.Save()`) runs a sequence of steps, and raw SQL gets none of them:
+
+| Skipped | Consequence |
+|---|---|
+| Field validation | Invalid data lands in the table with no error |
+| **Entity Actions** (`Validate` / `Before*` / `After*`) | Configured workflow hooks never fire. `Validate` is a real blocking gate, so a business rule someone configured as metadata is simply not enforced |
+| **Record Changes** | No audit history for those rows. MJ's built-in version control has a hole in it |
+| Cache invalidation | Server-side caches keep serving pre-write data until something else evicts them |
+| Geocoding sync, ISA sibling propagation, `OnSaveCompleted` patches | Any provider-level post-save behavior for that entity |
+
+None of these fail loudly. The rows appear, everything looks fine, and the gaps surface much later
+as "why is there no history for these records" or "why didn't that workflow run."
+
+### Bulk and long-running work
+
+If the reason you reached for raw SQL is volume — a scheduled recompute, an import, a bulk
+update over thousands of records — the answer is **Record Set Processing**, not hand-rolled SQL.
+It owns batching, bounded concurrency, rate limiting, an error-rate circuit breaker, progress,
+pause/cancel/resume, per-record isolation, and a persisted audit trail in `MJ: Process Runs`.
+See [`guides/RECORD_SET_PROCESSING_GUIDE.md`](../../guides/RECORD_SET_PROCESSING_GUIDE.md).
+
+**Be aware of the tradeoff, and don't work around it silently.** RSP is an *orchestration*
+substrate: `IRecordProcessor.ProcessRecord` handles one record at a time, and its write-back path
+calls `Save()` per row. There is no set-based write primitive on the provider surface today
+(no `BulkSave`, no `SaveMany`), and `TransactionGroup` gives atomicity rather than a reduced
+statement count. So a high-volume write is N round trips times writes-per-record, and that is the
+current, accepted cost of a correct write.
+
+If that cost is genuinely prohibitive for your workload, **raise it as a framework gap** — a bulk
+write seam that still fires hooks and records changes would serve every app. Do not solve it
+privately with a SQL string builder; that is how this rule gets violated in shipped code.
+
+### Where raw SQL IS legitimate
+
+- **Reads.** Prefer `RunView` / `RunViews` / `RunQuery`. `provider.ExecuteSQL` for a genuinely
+  set-based read (aggregates, compiled declarative queries) is a judgment call, not a violation.
+  Parameterize it — never interpolate user input.
+- **Migrations.** That's what they're for. See [`migrations/CLAUDE.md`](../../migrations/CLAUDE.md).
+- **View and stored-proc bodies**, which CodeGen owns and generates.
+- **CodeGen-generated code.** Don't hand-edit it, and don't copy its `ExecuteSQL` calls as a
+  pattern for your own code — it operates at a layer below this rule.
+
+---
+
 ## Entity Metadata Best Practices (CRITICAL)
 
 ### 🚨 GROUND TRUTH FOR SCHEMA IS THE ORM LAYER — NOT MIGRATIONS 🚨

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -88,6 +88,8 @@ Unit tests passing is necessary but **not sufficient** — the integration tier 
 
 **Strong typing, always.** Never use `any`, `as any`, or `unknown`-as-a-shortcut — MJ has a proper type for everything; ask if you think you need one. Never use `.Get()`/`.Set()` as a substitute for generated entity properties. Details: [`.claude/rules/typescript-style.md`](.claude/rules/typescript-style.md).
 
+**All writes go through `BaseEntity.Save()`/`Delete()`.** Never hand-write `INSERT`/`UPDATE`/`DELETE`/`MERGE` from application code, including "just for this bulk case" — raw DML silently skips validation, Entity Actions, Record Changes, and cache invalidation. Bulk work goes to Record Set Processing. Raw SQL is fine for *reads*, migrations, and CodeGen output. Details: [`.claude/rules/data-access.md`](.claude/rules/data-access.md).
+
 **Entity names carry the `MJ: ` prefix.** As of v5.0, all core entities are `MJ: AI Agents`, `MJ: AI Prompt Runs`, etc. An unprefixed name throws `Entity ... not found in metadata`. Verify names in `packages/MJCoreEntities/src/generated/entity_subclasses.ts`.
 
 **The generated ORM is the schema's source of truth** — not migration SQL. Migrations are append-only history; the entity classes reflect the net result.
@@ -120,7 +122,7 @@ Guidance is **loaded on demand**, so it costs nothing until it's relevant. This 
 
 | Rule | Loads for | Covers |
 |---|---|---|
-| [`data-access.md`](.claude/rules/data-access.md) | `**/*.ts` | `RunView`/`RunViews`, `ResultType`/`Fields`, `BaseEntity` Save/Delete error handling, entity metadata lookup (`EntityByName`), per-provider `Metadata` scoping, caching + `BaseEngine`/`BaseEngineRegistry`, keyset pagination, `UserInfoEngine` preferences |
+| [`data-access.md`](.claude/rules/data-access.md) | `**/*.ts` | No hand-written SQL DML, `RunView`/`RunViews`, `ResultType`/`Fields`, `BaseEntity` Save/Delete error handling, entity metadata lookup (`EntityByName`), per-provider `Metadata` scoping, caching + `BaseEngine`/`BaseEngineRegistry`, keyset pagination, `UserInfoEngine` preferences |
 | [`typescript-style.md`](.claude/rules/typescript-style.md) | `**/*.ts` | No `any`, no `.Get()`/`.Set()`, derive field types from the entity, no cross-package re-exports, `BaseSingleton`, no dynamic `import()`, naming conventions, functional decomposition, OOD |
 | [`design-tokens.md`](.claude/rules/design-tokens.md) | `**/*.scss`, `**/*.css` | No hardcoded colors, the semantic token catalog, hex→token mappings, `color-mix()`, the CI gates |
 | [`testing.md`](.claude/rules/testing.md) | `**/*.test.ts`, `**/__tests__/**` | Vitest conventions, test structure, the scaffold script, fixing test drift, CI integration |


### PR DESCRIPTION
Per @AmithNagarajan's note on [bizapps-sonar#47](https://github.com/MemberJunction/bizapps-sonar/pull/47) — the instruction files never actually said "don't hand-write `INSERT`/`UPDATE`/`DELETE`/`MERGE`."

There's plenty on using `BaseEntity`, `RunView`, and generated types, but the prohibition on raw DML was implied rather than stated. Sonar shipped a set-based `ScoreWriter` to `main` on that ambiguity, so this closes the doc gap that allowed it.

## What's added

Main content goes in [`.claude/rules/data-access.md`](.claude/rules/data-access.md), which loads for `**/*.ts`. One line in root `CLAUDE.md` under **Always-true facts**, since the consequence is unrecoverable in shipped code and the path-scoped rule only loads once a matching file is already open. Root is 200/260 lines and `check:claude-md` passes.

**What raw DML silently skips** — the point being that none of it fails loudly:

| Skipped | Consequence |
|---|---|
| Field validation | Invalid data lands with no error |
| Entity Actions (`Validate`/`Before*`/`After*`) | Configured workflow hooks never fire; `Validate` is a real blocking gate, so a metadata-configured business rule goes unenforced |
| Record Changes | No audit history for those rows |
| Cache invalidation | Server caches keep serving pre-write data |
| Geocoding sync, ISA propagation, `OnSaveCompleted` | Any provider-level post-save behavior |

The gaps surface months later as "why is there no history for these records."

## On bulk writes

The rule points high-volume work at Record Set Processing, and states the tradeoff rather than pretending it away, because a prohibition with no viable alternative is one people break under deadline pressure.

RSP is the right home for looping work and brings batching, concurrency, resume, and a `MJ: Process Runs` audit trail. But it's an orchestration substrate: `IRecordProcessor.ProcessRecord` takes one record at a time, and [`writeBack.ts`](packages/RecordSetProcessor/engine/src/writeBack.ts) calls `Save()` per row. There's no `BulkSave`/`SaveMany` on the provider surface, and `TransactionGroup` gives atomicity rather than a reduced statement count.

So a correct high-volume write is N round trips times writes-per-record, and the rule says that's the accepted cost — and that anyone for whom it's genuinely prohibitive should **raise it as a framework gap** rather than solve it privately with a SQL string builder. A bulk write seam that still fires hooks and records changes would serve every app doing scheduled recompute, import, or bulk update.

Legitimate uses stay explicit so the rule is followable: reads (prefer `RunView`/`RunQuery`, parameterize `ExecuteSQL`), migrations, view/proc bodies, and CodeGen output.

cc @rkihm-BC re: the training side.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)