### PR TITLE
ci: one-button Edge and LTS-line releases (+ the guard fix the first Edge publish needs)

### DIFF
--- a/.github/workflows/publish-lts.yml
+++ b/.github/workflows/publish-lts.yml
@@ -1,0 +1,151 @@
+name: Publish LTS line release
+
+# The one-button line release (guides/RELEASE_ENGINEERING_RUNBOOK.md, operation 3;
+# plans/lts-process.md section 5.2 rule 3 / section 14.1). Run it FROM a line branch:
+# Actions -> "Publish LTS line release" -> pick the lts/* branch -> Run workflow.
+#
+# Automates the dry-check-verified manual sequence: changeset version (normal, non-pre
+# mode) -> lockfile refresh -> build -> changeset publish --tag lts-<line> -> push the
+# release commit + git tag back to the line branch -> GitHub Release (never latest).
+# `latest` NEVER moves here - certification moves it via ci/dist-tag-all.mjs.
+
+on:
+  workflow_dispatch:
+    inputs:
+      confirm_branch:
+        description: "Type the line branch name (e.g. lts/5) to confirm you selected the right ref above"
+        required: true
+
+permissions:
+  contents: write
+  id-token: write
+
+concurrency:
+  group: "publish"
+  cancel-in-progress: false
+
+jobs:
+  publish-line:
+    name: Version, build, and publish from the line branch
+    timeout-minutes: 45
+    runs-on: ubuntu-latest
+    steps:
+      - name: Guard - must run from an lts/* branch, confirmed
+        run: |
+          REF="${{ github.ref_name }}"
+          if [[ "$REF" != lts/* ]]; then
+            echo "::error::This workflow must be dispatched from an lts/* branch (got '$REF'). Use the branch picker in the Run workflow dialog."
+            exit 1
+          fi
+          if [ "${{ github.event.inputs.confirm_branch }}" != "$REF" ]; then
+            echo "::error::Confirmation mismatch: dialog ran on '$REF' but you typed '${{ github.event.inputs.confirm_branch }}'. Re-run with matching values."
+            exit 1
+          fi
+
+      - name: Checkout line branch
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          fetch-tags: true
+          persist-credentials: false
+
+      - name: Guard - line branch must NOT be in prerelease mode
+        run: |
+          if [ -f .changeset/pre.json ]; then
+            echo "::error::.changeset/pre.json exists on ${{ github.ref_name }} - pre-mode state leaked from next. Fix the branch before publishing."
+            exit 1
+          fi
+
+      - name: Guard - there must be changesets to release
+        run: |
+          count=$(ls .changeset/*.md 2>/dev/null | grep -cv 'README.md' || true)
+          if [ "$count" = "0" ]; then
+            echo "::error::No changesets on ${{ github.ref_name }} - nothing to release. Backported fixes carry their changeset files; did the backport PR merge?"
+            exit 1
+          fi
+
+      - name: Set up node
+        uses: actions/setup-node@v6
+        with:
+          node-version: 24
+          cache: 'npm'
+          cache-dependency-path: 'package-lock.json'
+
+      - name: Pin npm to 11.6.4
+        run: npm install -g npm@11.6.4
+
+      - name: Validate migration filenames
+        run: ./.github/scripts/validate-migration-filenames.sh
+
+      - name: Validate package-lock.json case-sensitivity
+        run: ./.github/scripts/validate-package-lock-case.sh
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Validate package repository.url for npm provenance
+        run: ./.github/scripts/validate-package-repository.sh
+
+      - name: Set up git credentials
+        env:
+          REPO_PAT: ${{ secrets.MJ_GH_BOT_GITHUB_TOKEN }}
+        run: |
+          git config --global user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git config --global user.name "GitHub Actions"
+          git remote set-url origin "https://$REPO_PAT@github.com/${GITHUB_REPOSITORY}"
+
+      - name: Version (normal mode) and refresh lockfile
+        id: version
+        run: |
+          npm run version
+          npm install
+          if ! git diff --quiet package-lock.json; then
+            git add package-lock.json
+            git commit -m "chore: lockfile for line release [skip ci]"
+          fi
+          VERSION=$(jq -r .version packages/MJServer/package.json)
+          if [[ "$VERSION" == *-* ]]; then
+            echo "::error::Line release produced a prerelease version ($VERSION) - refusing."
+            exit 1
+          fi
+          LINE="${{ github.ref_name }}"
+          NPM_TAG="lts-${LINE#lts/}"
+          echo "VERSION=v$VERSION" >> "$GITHUB_OUTPUT"
+          echo "NPM_TAG=$NPM_TAG" >> "$GITHUB_OUTPUT"
+          echo "::notice::Publishing $VERSION from $LINE to npm dist-tag $NPM_TAG"
+
+      - name: Record latest dist-tag before publish
+        id: before
+        run: echo "LATEST=$(npm view @memberjunction/core dist-tags.latest)" >> "$GITHUB_OUTPUT"
+
+      - name: Build packages
+        run: npm run build
+
+      - name: Publish to npm (line tag, never latest)
+        run: npm run change publish -- --tag ${{ steps.version.outputs.NPM_TAG }}
+        env:
+          NPM_TOKEN: ''
+
+      - name: Verify latest did not move
+        run: |
+          NOW=$(npm view @memberjunction/core dist-tags.latest)
+          if [ "$NOW" != "${{ steps.before.outputs.LATEST }}" ]; then
+            echo "::error::npm 'latest' moved during a line publish (${{ steps.before.outputs.LATEST }} -> $NOW). Investigate immediately; restore with ci/dist-tag-all.mjs from the certified tag."
+            exit 1
+          fi
+
+      - name: Push release commit and tag to the line branch
+        env:
+          VERSION: ${{ steps.version.outputs.VERSION }}
+        run: |
+          git push origin "HEAD:${{ github.ref_name }}"
+          git tag "$VERSION"
+          git push origin "refs/tags/$VERSION"
+
+      - name: Create GitHub Release (never latest; certification promotes)
+        env:
+          GH_TOKEN: ${{ secrets.MJ_GH_BOT_GITHUB_TOKEN }}
+          VERSION: ${{ steps.version.outputs.VERSION }}
+        run: |
+          gh release create "$VERSION" --title "$VERSION" --generate-notes --latest=false \
+            --target "${{ github.ref_name }}" --repo "${{ github.repository }}"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -108,6 +108,17 @@ jobs:
         env:
           REPO_PAT: ${{ secrets.MJ_GH_BOT_GITHUB_TOKEN }}
 
+      # In Edge pre-mode the string-math version guard below is not
+      # prerelease-aware (and migration=>minor holds at tuple level by
+      # construction in the Edge grammar), so it yields to a grammar assertion.
+      - name: Detect changesets prerelease mode
+        id: premode
+        run: |
+          MODE=none
+          if [ -f .changeset/pre.json ]; then MODE=$(jq -r .mode .changeset/pre.json); fi
+          echo "MODE=$MODE" >> "$GITHUB_OUTPUT"
+          echo "::notice::Changesets mode: $MODE"
+
       - name: Check for version override in commit message
         id: commit_override
         run: |
@@ -118,7 +129,7 @@ jobs:
           fi
 
       - name: Determine next expected version
-        if: ${{ env.BRANCH == 'main' && !github.event.inputs.targetVersion && !steps.commit_override.outputs.VERSION_OVERRIDE }}
+        if: ${{ env.BRANCH == 'main' && !github.event.inputs.targetVersion && !steps.commit_override.outputs.VERSION_OVERRIDE && steps.premode.outputs.MODE != 'pre' }}
         id: version_check
         run: |
           git fetch --tags
@@ -137,14 +148,21 @@ jobs:
       - name: Update version and check against expected
         if: ${{ env.BRANCH == 'main' }}
         run: |
-          EXPECTED_NEXT_VERSION="${{ github.event.inputs.targetVersion || steps.commit_override.outputs.VERSION_OVERRIDE || steps.version_check.outputs.EXPECTED_NEXT_VERSION }}"
           npm run version
 
           NEXT_VERSION=$(jq -r .version packages/MJServer/package.json)
           echo "::notice::Version to be published: $NEXT_VERSION"
-          if [ "$NEXT_VERSION" != "$EXPECTED_NEXT_VERSION" ]; then
-            echo "::error::The version to be published ($NEXT_VERSION) does not match the expected version ($EXPECTED_NEXT_VERSION)"
-            exit 1
+          if [ "${{ steps.premode.outputs.MODE }}" = "pre" ]; then
+            if [[ "$NEXT_VERSION" != *-edge.* ]]; then
+              echo "::error::Repo is in Edge prerelease mode but changeset version produced unsuffixed $NEXT_VERSION"
+              exit 1
+            fi
+          else
+            EXPECTED_NEXT_VERSION="${{ github.event.inputs.targetVersion || steps.commit_override.outputs.VERSION_OVERRIDE || steps.version_check.outputs.EXPECTED_NEXT_VERSION }}"
+            if [ "$NEXT_VERSION" != "$EXPECTED_NEXT_VERSION" ]; then
+              echo "::error::The version to be published ($NEXT_VERSION) does not match the expected version ($EXPECTED_NEXT_VERSION)"
+              exit 1
+            fi
           fi
 
       - name: Build packages

--- a/.github/workflows/release-edge.yml
+++ b/.github/workflows/release-edge.yml
@@ -1,0 +1,78 @@
+name: Release Edge
+
+# The one-button Edge release (guides/RELEASE_ENGINEERING_RUNBOOK.md, operation 1).
+# Dispatching this merges next into main; the push to main triggers publish.yml,
+# which does everything else: changeset version (pre-mode -> X.Y.0-edge.N), the
+# version-grammar guard, build, publish to the `edge` dist-tag, release commit +
+# tag, GitHub prerelease (never latest), and the merge of main back into next.
+# This workflow ONLY performs guarded merge-and-push - all release logic stays
+# in publish.yml so the button and a manual next->main merge behave identically.
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  actions: read
+
+concurrency:
+  group: release-edge
+  cancel-in-progress: false
+
+jobs:
+  release:
+    name: Merge next into main (guarded)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout next
+        uses: actions/checkout@v4
+        with:
+          ref: next
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Guard - repo must be in Edge prerelease mode
+        run: |
+          if [ ! -f .changeset/pre.json ] || [ "$(jq -r .mode .changeset/pre.json)" != "pre" ]; then
+            echo "::error::next is not in Edge prerelease mode (.changeset/pre.json missing or mode != pre). If a candidate cut is in progress, finish it before releasing Edge."
+            exit 1
+          fi
+
+      - name: Guard - there must be unapplied changesets
+        run: |
+          applied=$(jq -r '.changesets[]' .changeset/pre.json)
+          pending=""
+          for f in .changeset/*.md; do
+            id=$(basename "$f" .md)
+            [ "$id" = "README" ] && continue
+            echo "$applied" | grep -qx "$id" || pending="$pending $id"
+          done
+          if [ -z "$pending" ]; then
+            echo "::error::No unapplied changesets on next - nothing to release."
+            exit 1
+          fi
+          echo "::notice::Pending changesets:$pending"
+
+      - name: Guard - latest unit-test run on next must be green
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          RESULT=$(gh run list --repo "$GITHUB_REPOSITORY" --workflow test.yml --branch next --limit 1 \
+            --json status,conclusion --jq '.[0] | if .status != "completed" then "still-running" else .conclusion end')
+          if [ "$RESULT" != "success" ]; then
+            echo "::error::Latest Unit Tests run on next is '$RESULT'. Wait for a green run (or investigate) before releasing."
+            exit 1
+          fi
+
+      - name: Merge next into main and push (this triggers publish.yml)
+        env:
+          REPO_PAT: ${{ secrets.MJ_GH_BOT_GITHUB_TOKEN }}
+        run: |
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git config user.name "GitHub Actions"
+          git remote set-url origin "https://$REPO_PAT@github.com/${GITHUB_REPOSITORY}"
+          git fetch origin main
+          git checkout main
+          git merge --no-ff origin/next -m "Release edge (dispatched by @${{ github.actor }}): merge next into main"
+          git push origin main
+          echo "::notice::Pushed to main - publish.yml takes it from here."


### PR DESCRIPTION
## What this does

Makes both release tracks one-button, and fixes a guard that would have failed the era's first publish.

1. **publish.yml — pre-mode-aware version guard (required fix).** The expected-version check does plain `X.Y.Z` string arithmetic. With the repo now in Edge prerelease mode, the first routine publish computes expected `6.0.1`/`6.1.0` but `changeset version` produces `6.1.0-edge.0` → hard error. In pre mode the guard now asserts the `-edge.N` grammar instead of string equality (migration⇒minor holds at tuple level by construction in the Edge grammar, so the original check's purpose isn't lost). Non-pre behavior byte-identical.

2. **`release-edge.yml` (new) — the Edge button.** `workflow_dispatch` → three guards (repo is in pre mode; there are unapplied changesets; the latest unit-test run on `next` is green) → merge `next → main` with the dispatcher's name in the merge commit → push (bot PAT, so publish.yml triggers). All release logic stays in publish.yml: the button and a manual `next → main` merge behave identically.

3. **`publish-lts.yml` (new) — the line-release button** (the §15 punch-list item). Dispatched *from* an `lts/*` branch, with a typed branch-name confirmation (the branch picker defaults to `next`, and running this from `next` must be impossible). Automates the dry-check-verified §14.1 manual sequence: `changeset version` (normal mode) → lockfile refresh → build → `changeset publish --tag lts-<line>` (derived from the branch name) → push release commit + tag to the line branch → GitHub Release with `--latest=false`. Guards: refuses non-`lts/*` refs, pre-mode leakage from `next`, empty changesets, and any prerelease-shaped version; after publishing it asserts npm `latest` did not move.

## For reviewers

- **The guard fix (item 1) is load-bearing for this week** — without it the first Edge release fails in CI regardless of how it's triggered.
- `publish-lts.yml` shares the `publish` concurrency group with publish.yml so line and Edge publishes serialize.
- Neither button changes what `latest` means: it still moves only at certification via `ci/dist-tag-all.mjs`.
- YAML validated locally; the buttons themselves can only be end-to-end tested by dispatching them — suggest the first Edge release this week be done via the button with eyes on it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019EfGkq8cW9drueo1vEN4sM