### PR TITLE
Harden SQL parameterization and filter-value escaping

### DIFF
--- a/.changeset/harden-sql-parameterization-and-filter-escaping.md
+++ b/.changeset/harden-sql-parameterization-and-filter-escaping.md
@@ -1,0 +1,18 @@
+---
+"@memberjunction/server": patch
+"@memberjunction/generic-database-provider": patch
+"@memberjunction/core": patch
+"@memberjunction/ng-react": patch
+---
+
+Harden several SQL text-building paths that substituted values into query strings without parameterization or escaping.
+
+**`@memberjunction/server`** — `ReportResolver.CreateReportFromConversationDetailID` built its `WHERE` clause via direct string interpolation of the `ConversationDetailID` argument. It now binds the value through `mssql`'s parameterized `request.input(...)` as a `UniqueIdentifier`, consistent with the parameterization pattern already used elsewhere in the package, and gets GUID-format validation as a side effect.
+
+**`@memberjunction/generic-database-provider`** — `GenericDatabaseProvider.CheckRecordRLS` built its primary-key `WHERE` clause without escaping embedded quotes in the key value, unlike the sibling `Load()` path a few lines above, which already escapes. The RLS-check path now mirrors `Load()`'s escaping so a primary key value containing a quote can't alter the query's structure.
+
+**`@memberjunction/core`** — `RowLevelSecurityFilterInfo.MarkupFilterText` did two things that could weaken a row-level security filter: it let `undefined` user-property values through as the literal string `"undefined"`, and it never escaped quotes in substituted values. Both are fixed — `undefined` now falls through to the existing unresolved-token handling (same as `null` and object-typed values already did), and substituted values now have embedded single quotes doubled.
+
+Behavior note for deployments with existing role-based RLS filters: equality-style filters (`Col = '{{UserX}}'`) are unaffected. Filters written in negation form (`<>`, `NOT IN`, `NOT LIKE`) against a user property that can be `undefined` previously matched more rows than intended (a permissive gap) and will now correctly match fewer — reviewed as: users may see fewer rows than before the upgrade, which is the deliberate direction of this fix, not a new restriction to work around.
+
+**`@memberjunction/ng-react`** — `RuntimeUtilities.provider` was initialized directly from the global `Metadata.Provider` at class-field scope. The value was always overwritten before use by `buildUtilities()`'s existing `provider ?? Metadata.Provider` fallback, so this is a no-behavior-change cleanup that stops the class body from touching the global provider directly.

--- a/package-lock.json
+++ b/package-lock.json
@@ -30288,7 +30288,6 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "dependencies": {
         "prr": "~1.0.1"
       },
@@ -34380,7 +34379,6 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "bin": {
         "image-size": "bin/image-size.js"
       },
@@ -36568,7 +36566,6 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "dependencies": {
         "pify": "^4.0.1",
         "semver": "^5.6.0"
@@ -36584,7 +36581,6 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "engines": {
         "node": ">=6"
       }
@@ -36596,7 +36592,6 @@
       "dev": true,
       "license": "ISC",
       "optional": true,
-      "peer": true,
       "bin": {
         "semver": "bin/semver"
       }
@@ -39472,7 +39467,6 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "dependencies": {
         "iconv-lite": "^0.6.3",
         "sax": "^1.2.4"
@@ -39491,7 +39485,6 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "dependencies": {
         "safer-buffer": ">= 2.1.2 < 3.0.0"
       },
@@ -39594,7 +39587,6 @@
       "os": [
         "aix"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -39612,7 +39604,6 @@
       "os": [
         "android"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -39630,7 +39621,6 @@
       "os": [
         "android"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -39648,7 +39638,6 @@
       "os": [
         "android"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -39666,7 +39655,6 @@
       "os": [
         "darwin"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -39684,7 +39672,6 @@
       "os": [
         "darwin"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -39702,7 +39689,6 @@
       "os": [
         "freebsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -39720,7 +39706,6 @@
       "os": [
         "freebsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -39738,7 +39723,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -39756,7 +39740,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -39774,7 +39757,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -39792,7 +39774,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -39810,7 +39791,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -39828,7 +39808,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -39846,7 +39825,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -39864,7 +39842,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -39882,7 +39859,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -39900,7 +39876,6 @@
       "os": [
         "netbsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -39918,7 +39893,6 @@
       "os": [
         "netbsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -39936,7 +39910,6 @@
       "os": [
         "openbsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -39954,7 +39927,6 @@
       "os": [
         "openbsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -39972,7 +39944,6 @@
       "os": [
         "openharmony"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -39990,7 +39961,6 @@
       "os": [
         "sunos"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -40008,7 +39978,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -40026,7 +39995,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -40044,7 +40012,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -43423,8 +43390,7 @@
       "integrity": "sha512-yPw4Sng1gWghHQWj0B3ZggWUm4qVbPwPFcRG8KyxiU7J2OHFSoEHKS+EZ3fv5l1t9CyCiop6l/ZYeWbrgoQejw==",
       "dev": true,
       "license": "MIT",
-      "optional": true,
-      "peer": true
+      "optional": true
     },
     "node_modules/psl": {
       "version": "1.15.0",
@@ -48307,7 +48273,6 @@
       "os": [
         "aix"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -48325,7 +48290,6 @@
       "os": [
         "android"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -48343,7 +48307,6 @@
       "os": [
         "android"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -48361,7 +48324,6 @@
       "os": [
         "android"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -48379,7 +48341,6 @@
       "os": [
         "darwin"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -48397,7 +48358,6 @@
       "os": [
         "darwin"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -48415,7 +48375,6 @@
       "os": [
         "freebsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -48433,7 +48392,6 @@
       "os": [
         "freebsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -48451,7 +48409,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -48469,7 +48426,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -48487,7 +48443,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -48505,7 +48460,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -48523,7 +48477,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -48541,7 +48494,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -48559,7 +48511,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -48577,7 +48528,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -48595,7 +48545,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -48613,7 +48562,6 @@
       "os": [
         "netbsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -48631,7 +48579,6 @@
       "os": [
         "netbsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -48649,7 +48596,6 @@
       "os": [
         "openbsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -48667,7 +48613,6 @@
       "os": [
         "openbsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -48685,7 +48630,6 @@
       "os": [
         "openharmony"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -48703,7 +48647,6 @@
       "os": [
         "sunos"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -48721,7 +48664,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -48739,7 +48681,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -48757,7 +48698,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -58318,6 +58258,7 @@
         "@memberjunction/core-entities": "6.0.0",
         "@memberjunction/global": "6.0.0",
         "@memberjunction/ng-ai-test-harness": "6.0.0",
+        "@memberjunction/ng-base-types": "6.0.0",
         "@memberjunction/ng-container-directives": "6.0.0",
         "@memberjunction/ng-shared-generic": "6.0.0",
         "@memberjunction/ng-ui-components": "6.0.0",
@@ -58445,6 +58386,7 @@
         "@memberjunction/core": "6.0.0",
         "@memberjunction/core-entities": "6.0.0",
         "@memberjunction/global": "6.0.0",
+        "@memberjunction/ng-base-types": "6.0.0",
         "@memberjunction/ng-forms": "6.0.0",
         "@memberjunction/ng-notifications": "6.0.0",
         "@memberjunction/ng-shared-generic": "6.0.0",
@@ -59179,6 +59121,7 @@
         "@memberjunction/core-entities": "6.0.0",
         "@memberjunction/global": "6.0.0",
         "@memberjunction/graphql-dataprovider": "6.0.0",
+        "@memberjunction/ng-base-types": "6.0.0",
         "@memberjunction/ng-ui-components": "6.0.0",
         "@memberjunction/record-set-processor-base": "6.0.0",
         "tslib": "^2.8.1"
@@ -59228,6 +59171,7 @@
         "@memberjunction/entity-communications-base": "6.0.0",
         "@memberjunction/entity-communications-client": "6.0.0",
         "@memberjunction/global": "6.0.0",
+        "@memberjunction/ng-base-types": "6.0.0",
         "@memberjunction/ng-container-directives": "6.0.0",
         "@memberjunction/ng-shared-generic": "6.0.0",
         "@memberjunction/ng-ui-components": "6.0.0",
@@ -59462,6 +59406,7 @@
         "@memberjunction/ng-base-types": "6.0.0",
         "@memberjunction/ng-container-directives": "6.0.0",
         "@memberjunction/ng-notifications": "5.51.0",
+        "@memberjunction/ng-shared": "6.0.0",
         "@memberjunction/ng-shared-generic": "6.0.0",
         "@memberjunction/ng-ui-components": "6.0.0",
         "ag-grid-angular": "^35.0.1",

--- a/packages/Angular/Generic/action-gallery/package.json
+++ b/packages/Angular/Generic/action-gallery/package.json
@@ -38,6 +38,7 @@
     "@memberjunction/core-entities": "6.0.0",
     "@memberjunction/global": "6.0.0",
     "@memberjunction/ng-ai-test-harness": "6.0.0",
+    "@memberjunction/ng-base-types": "6.0.0",
     "@memberjunction/ng-container-directives": "6.0.0",
     "@memberjunction/ng-shared-generic": "6.0.0",
     "@memberjunction/ng-ui-components": "6.0.0",

--- a/packages/Angular/Generic/agent-requests/package.json
+++ b/packages/Angular/Generic/agent-requests/package.json
@@ -33,15 +33,16 @@
     "@angular/forms": "21.1.3"
   },
   "dependencies": {
+    "@memberjunction/ai-core-plus": "6.0.0",
     "@memberjunction/core": "6.0.0",
     "@memberjunction/core-entities": "6.0.0",
     "@memberjunction/global": "6.0.0",
-    "@memberjunction/ai-core-plus": "6.0.0",
+    "@memberjunction/ng-base-types": "6.0.0",
     "@memberjunction/ng-forms": "6.0.0",
     "@memberjunction/ng-notifications": "6.0.0",
     "@memberjunction/ng-shared-generic": "6.0.0",
-    "tslib": "^2.8.1",
-    "rxjs": "^7.8.2"
+    "rxjs": "^7.8.2",
+    "tslib": "^2.8.1"
   },
   "sideEffects": false,
   "repository": {

--- a/packages/Angular/Generic/entity-action-ux/package.json
+++ b/packages/Angular/Generic/entity-action-ux/package.json
@@ -39,6 +39,7 @@
     "@memberjunction/core-entities": "6.0.0",
     "@memberjunction/global": "6.0.0",
     "@memberjunction/graphql-dataprovider": "6.0.0",
+    "@memberjunction/ng-base-types": "6.0.0",
     "@memberjunction/ng-ui-components": "6.0.0",
     "@memberjunction/record-set-processor-base": "6.0.0",
     "tslib": "^2.8.1"

--- a/packages/Angular/Generic/entity-communication/package.json
+++ b/packages/Angular/Generic/entity-communication/package.json
@@ -33,6 +33,7 @@
     "@memberjunction/entity-communications-base": "6.0.0",
     "@memberjunction/entity-communications-client": "6.0.0",
     "@memberjunction/global": "6.0.0",
+    "@memberjunction/ng-base-types": "6.0.0",
     "@memberjunction/ng-container-directives": "6.0.0",
     "@memberjunction/ng-shared-generic": "6.0.0",
     "@memberjunction/ng-ui-components": "6.0.0",

--- a/packages/Angular/Generic/file-storage/package.json
+++ b/packages/Angular/Generic/file-storage/package.json
@@ -38,20 +38,21 @@
     "@angular/forms": "21.1.3"
   },
   "dependencies": {
-    "@memberjunction/ng-ui-components": "6.0.0",
     "@angular/platform-browser": "21.1.3",
     "@memberjunction/core": "6.0.0",
-    "@memberjunction/ng-base-types": "6.0.0",
     "@memberjunction/core-entities": "6.0.0",
     "@memberjunction/global": "6.0.0",
     "@memberjunction/graphql-dataprovider": "6.0.0",
+    "@memberjunction/ng-base-types": "6.0.0",
     "@memberjunction/ng-container-directives": "6.0.0",
+    "@memberjunction/ng-notifications": "5.51.0",
+    "@memberjunction/ng-shared": "6.0.0",
     "@memberjunction/ng-shared-generic": "6.0.0",
+    "@memberjunction/ng-ui-components": "6.0.0",
     "ag-grid-angular": "^35.0.1",
     "ag-grid-community": "^35.0.1",
     "tslib": "^2.8.1",
-    "zod": "^3.25.0",
-    "@memberjunction/ng-notifications": "5.51.0"
+    "zod": "^3.25.0"
   },
   "sideEffects": false,
   "repository": {

--- a/packages/Angular/Generic/react/src/lib/utilities/runtime-utilities.ts
+++ b/packages/Angular/Generic/react/src/lib/utilities/runtime-utilities.ts
@@ -52,10 +52,11 @@ import {
 export class RuntimeUtilities {
   private debug: boolean = false;
   /**
-   * The provider every read in the built utilities goes through. Set by {@link buildUtilities};
-   * defaults to the global provider when the host doesn't supply one.
+   * The provider every read in the built utilities goes through. Always set by
+   * {@link buildUtilities} before use — falls back to the global provider there
+   * (`provider ?? Metadata.Provider`) when the host doesn't supply one.
    */
-  private provider: IMetadataProvider = Metadata.Provider;
+  private provider!: IMetadataProvider;
 
   /**
    * Builds the complete utilities object for React components

--- a/packages/GenericDatabaseProvider/src/GenericDatabaseProvider.ts
+++ b/packages/GenericDatabaseProvider/src/GenericDatabaseProvider.ts
@@ -3904,7 +3904,9 @@ export abstract class GenericDatabaseProvider extends DatabaseProviderBase {
         const pkWhere = entity.PrimaryKeys.map(pk => {
             const fieldInfo = entityInfo.FieldByName(pk.Name);
             const quotes = fieldInfo?.NeedsQuotes ? "'" : '';
-            return `${this.QuoteIdentifier(pk.Name)}=${quotes}${pk.Value}${quotes}`;
+            // Escape embedded single quotes when the value is wrapped in quotes — see Load() above.
+            const safeVal = quotes ? String(pk.Value).replace(/'/g, "''") : pk.Value;
+            return `${this.QuoteIdentifier(pk.Name)}=${quotes}${safeVal}${quotes}`;
         }).join(' AND ');
 
         const sql = `SELECT COUNT(*) AS cnt FROM ${this.QuoteSchemaAndView(entityInfo.SchemaName, entityInfo.BaseView)} WHERE ${pkWhere} AND (${rlsWhereClause})`;

--- a/packages/GenericDatabaseProvider/src/__tests__/GenericDatabaseProvider.test.ts
+++ b/packages/GenericDatabaseProvider/src/__tests__/GenericDatabaseProvider.test.ts
@@ -643,6 +643,56 @@ describe('GenericDatabaseProvider', () => {
             }).CheckRecordRLS(entity, mockUser, 'Read');
             expect(result).toBe(true);
         });
+
+        it('escapes embedded single quotes in the primary key value instead of splicing them into the WHERE clause', async () => {
+            const entityInfo = {
+                SchemaName: 'dbo',
+                BaseView: 'vwTestEntities',
+                UserExemptFromRowLevelSecurity: () => false,
+                GetUserRowLevelSecurityWhereClause: () => "OwnerID = '42'",
+                FieldByName: () => ({ NeedsQuotes: true }) as unknown as ReturnType<EntityInfo['FieldByName']>,
+            } as unknown as EntityInfo;
+            const entity = {
+                EntityInfo: entityInfo,
+                PrimaryKeys: [{ Name: 'ID', Value: "abc' OR '1'='1", NeedsQuotes: true }],
+            } as unknown as BaseEntity;
+
+            provider.executeSQLResults = [[{ cnt: 0 }]];
+
+            await (provider as unknown as {
+                CheckRecordRLS: (e: BaseEntity, u: UserInfo, t: string) => Promise<boolean>;
+            }).CheckRecordRLS(entity, mockUser, 'Read');
+
+            const sql = provider.executeSQLCalls[0].sql;
+            // The apostrophe must be doubled (SQL-escaped), not left to close the string early —
+            // structure check: the OR clause must NOT be a bare, un-quoted SQL predicate.
+            expect(sql).toContain("'abc'' OR ''1''=''1'");
+            expect(sql).not.toContain("='abc' OR '1'='1'");
+        });
+
+        it('does not alter query structure for PK values containing --, quotes, or OR 1=1', async () => {
+            const entityInfo = {
+                SchemaName: 'dbo',
+                BaseView: 'vwTestEntities',
+                UserExemptFromRowLevelSecurity: () => false,
+                GetUserRowLevelSecurityWhereClause: () => "OwnerID = '42'",
+                FieldByName: () => ({ NeedsQuotes: true }) as unknown as ReturnType<EntityInfo['FieldByName']>,
+            } as unknown as EntityInfo;
+            const entity = {
+                EntityInfo: entityInfo,
+                PrimaryKeys: [{ Name: 'ID', Value: "x'; --", NeedsQuotes: true }],
+            } as unknown as BaseEntity;
+
+            provider.executeSQLResults = [[{ cnt: 1 }]];
+
+            await (provider as unknown as {
+                CheckRecordRLS: (e: BaseEntity, u: UserInfo, t: string) => Promise<boolean>;
+            }).CheckRecordRLS(entity, mockUser, 'Read');
+
+            const sql = provider.executeSQLCalls[0].sql;
+            // Single WHERE ... AND (...) structure must be preserved — no comment-truncated clause.
+            expect(sql).toMatch(/WHERE "ID"='x''; --' AND \(OwnerID = '42'\)$/);
+        });
     });
 
     describe('AdjustDatetimeFields (default no-op)', () => {

--- a/packages/MJCore/src/__tests__/securityInfo.test.ts
+++ b/packages/MJCore/src/__tests__/securityInfo.test.ts
@@ -230,6 +230,42 @@ describe('RowLevelSecurityFilterInfo', () => {
             // Date is typeof 'object', so it should be skipped
             expect(result).toBe("X = '{{User__mj_CreatedAt}}'");
         });
+
+        it('should skip undefined values leaving token unresolved, not stringify as "undefined"', () => {
+            const filter = new RowLevelSecurityFilterInfo({
+                FilterText: "X = '{{UserEmployeeID}}'"
+            });
+            const user = new UserInfo(null, { EmployeeID: undefined });
+
+            const result = filter.MarkupFilterText(user);
+
+            expect(result).toBe("X = '{{UserEmployeeID}}'");
+            expect(result).not.toContain('undefined');
+        });
+
+        it('should not become permissive on negation-shaped filters when a value is undefined', () => {
+            const filter = new RowLevelSecurityFilterInfo({
+                FilterText: "Status <> '{{UserEmployeeID}}'"
+            });
+            const user = new UserInfo(null, { EmployeeID: undefined });
+
+            const result = filter.MarkupFilterText(user);
+
+            // Previously this substituted the literal string 'undefined', which a <> comparison
+            // would satisfy for virtually every row. It must stay unresolved instead.
+            expect(result).toBe("Status <> '{{UserEmployeeID}}'");
+        });
+
+        it('should escape embedded single quotes in substituted values', () => {
+            const filter = new RowLevelSecurityFilterInfo({
+                FilterText: "LastName = '{{UserLastName}}'"
+            });
+            const user = new UserInfo(null, { LastName: "O'Brien'; DROP TABLE Users; --" });
+
+            const result = filter.MarkupFilterText(user);
+
+            expect(result).toBe("LastName = 'O''Brien''; DROP TABLE Users; --'");
+        });
     });
 });
 

--- a/packages/MJCore/src/generic/securityInfo.ts
+++ b/packages/MJCore/src/generic/securityInfo.ts
@@ -467,8 +467,9 @@ export class RowLevelSecurityFilterInfo extends BaseInfo {
             for (let i = 0; i < keys.length; i++) {
                 const key = keys[i];
                 const val = (user as unknown as Record<string, unknown>)[key]
-                if (val !== null && typeof val !== 'object') {
-                    ret = ret.replace(new RegExp(`{{User${key}}}`, 'g'), String(val))
+                if (val !== null && val !== undefined && typeof val !== 'object') {
+                    const safeVal = String(val).replace(/'/g, "''")
+                    ret = ret.replace(new RegExp(`{{User${key}}}`, 'g'), safeVal)
                 }
             }
             // Per-session magic-link resource scope. Fail-closed: an absent scope resolves

--- a/packages/MJServer/src/resolvers/ReportResolver.ts
+++ b/packages/MJServer/src/resolvers/ReportResolver.ts
@@ -98,9 +98,10 @@ export class ReportResolverExtended extends ResolverBase {
                    ON
                       cd.ConversationID = c.ID
                    WHERE
-                      cd.ID='${ConversationDetailID}'`;
+                      cd.ID=@ConversationDetailID`;
 
       const request = new mssql.Request(dataSource);
+      request.input('ConversationDetailID', mssql.UniqueIdentifier, ConversationDetailID);
       const result = await request.query(sql);
       if (!result || !result.recordset || result.recordset.length === 0) throw new Error('Unable to retrieve converation details');
       const skipData: { title?: string; reportTitle?: string; userExplanation?: string; messages?: unknown[] } = JSON.parse(result.recordset[0].Message);

--- a/packages/MJServer/src/resolvers/__tests__/ReportResolver.test.ts
+++ b/packages/MJServer/src/resolvers/__tests__/ReportResolver.test.ts
@@ -1,0 +1,232 @@
+/**
+ * Tests for ReportResolverExtended.CreateReportFromConversationDetailID.
+ *
+ * Regression coverage for a SQL injection fix: ConversationDetailID (a plain GraphQL
+ * String arg) used to be interpolated directly into the WHERE clause. It is now bound
+ * via mssql's parameterized `request.input(...)`, so a hostile value must never appear
+ * spliced into the executed SQL text, and query structure must stay identical regardless
+ * of what the value contains.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// ─── Hoisted mocks ────────────────────────────────────────────────────────
+const { mockUserCacheUsers, mssqlState } = vi.hoisted(() => ({
+    mockUserCacheUsers: [] as Array<{ Email: string; ID: string }>,
+    mssqlState: {
+        inputCalls: [] as Array<{ name: string; type: unknown; value: unknown }>,
+        queryCalls: [] as string[],
+        poolArgs: [] as unknown[],
+        recordset: [] as Array<Record<string, unknown>>,
+    },
+}));
+
+// Stub external deps before imports (mirrors resolverBase.rls.test.ts)
+vi.mock('@memberjunction/sqlserver-dataprovider', () => ({
+    SQLServerDataProvider: class {},
+    UserCache: {
+        get Users() { return mockUserCacheUsers; },
+    },
+}));
+
+vi.mock('cloudevents', () => ({
+    CloudEvent: class {},
+    httpTransport: () => () => undefined,
+    emitterFor: () => () => undefined,
+}));
+
+vi.mock('type-graphql', () => ({
+    Resolver:           () => () => undefined,
+    Mutation:           () => () => undefined,
+    Query:              () => () => undefined,
+    Subscription:       () => () => undefined,
+    Ctx:                () => () => undefined,
+    Arg:                () => () => undefined,
+    PubSub:             () => () => undefined,
+    Root:               () => () => undefined,
+    ObjectType:         () => () => undefined,
+    InputType:          () => () => undefined,
+    Field:              () => () => undefined,
+    FieldResolver:      () => () => undefined,
+    Int:                () => undefined,
+    Float:              () => undefined,
+    registerEnumType:   () => undefined,
+}));
+
+vi.mock('graphql', () => ({
+    GraphQLError: class extends Error {
+        constructor(msg: string) { super(msg); }
+    },
+}));
+
+vi.mock('mssql', () => {
+    const UniqueIdentifier = { __marker: 'UniqueIdentifier' };
+    class Request {
+        constructor(pool: unknown) {
+            mssqlState.poolArgs.push(pool);
+        }
+        input(name: string, type: unknown, value: unknown) {
+            mssqlState.inputCalls.push({ name, type, value });
+        }
+        async query(sql: string) {
+            mssqlState.queryCalls.push(sql);
+            return { recordset: mssqlState.recordset };
+        }
+    }
+    return { default: { Request, UniqueIdentifier }, Request, UniqueIdentifier };
+});
+
+vi.mock('@memberjunction/data-context', () => {
+    class DataContext {
+        LoadMetadata = vi.fn(async () => true);
+    }
+    (DataContext as unknown as { Clone: unknown }).Clone = vi.fn(async () => ({ ID: 'dctx-clone-1' }));
+    return { DataContext };
+});
+
+vi.mock('@memberjunction/api-keys', () => ({
+    GetAPIKeyEngine: vi.fn(),
+}));
+
+vi.mock('@memberjunction/encryption', () => ({
+    EncryptionEngine: { Instance: {} },
+}));
+
+vi.mock('@memberjunction/graphql-dataprovider', () => ({
+    FieldMapper: class { static Instance = { MapFieldsFromCodeNamesToDBNames: vi.fn() }; },
+}));
+
+vi.mock('../../generic/PubSubManager.js', () => ({
+    PubSubManager: class { static Instance = { publish: vi.fn() }; },
+}));
+
+vi.mock('../../generic/PushStatusResolver.js', () => ({
+    PUSH_STATUS_UPDATES_TOPIC: 'test-push-topic',
+    PushStatusNotification: class {},
+    PushStatusResolver: class {},
+}));
+
+vi.mock('../../generic/CacheInvalidationResolver.js', () => ({
+    CACHE_INVALIDATION_TOPIC: 'test-cache-topic',
+}));
+
+vi.mock('../../generic/RunViewResolver.js', () => ({
+    RunViewByIDInput: class {},
+    RunViewByNameInput: class {},
+    RunDynamicViewInput: class {},
+}));
+
+vi.mock('../../generic/DeleteOptionsInput.js', () => ({
+    DeleteOptionsInput: class {},
+}));
+
+vi.mock('../../types.js', () => ({
+    RunViewGenericParams: class {},
+}));
+
+vi.mock('@memberjunction/core', async () => {
+    const actual = await vi.importActual<typeof import('@memberjunction/core')>('@memberjunction/core');
+    return {
+        ...actual,
+        LogError: vi.fn(),
+        LogStatus: vi.fn(),
+    };
+});
+
+vi.mock('@memberjunction/core-entities', () => ({}));
+
+// ─── Import after mocks ──────────────────────────────────────────────────
+import { ReportResolverExtended } from '../ReportResolver';
+
+// ─── Helpers ──────────────────────────────────────────────────────────────
+
+function makeReportEntity() {
+    return {
+        ID: 'report-1',
+        Name: '',
+        Description: '',
+        ConversationID: '',
+        ConversationDetailID: '',
+        DataContextID: '',
+        Configuration: '',
+        SharingScope: '',
+        UserID: '',
+        NewRecord: vi.fn(),
+        Save: vi.fn(async () => true),
+    };
+}
+
+function makeContext(getEntityObject: () => ReturnType<typeof makeReportEntity>) {
+    const md = {
+        Entities: [
+            { Name: 'MJ: Conversation Details', SchemaName: 'dbo', BaseView: 'vwConversationDetails' },
+            { Name: 'MJ: Conversations', SchemaName: 'dbo', BaseView: 'vwConversations' },
+        ],
+        GetEntityObject: vi.fn(async () => getEntityObject()),
+    };
+    return {
+        dataSource: { __fakePool: true },
+        userPayload: { email: 'test@example.com' }, // no apiKeyHash -> scope check no-ops
+        providers: [{ type: 'Read-Write', provider: md }],
+    } as unknown as Parameters<ReportResolverExtended['CreateReportFromConversationDetailID']>[1];
+}
+
+describe('ReportResolverExtended.CreateReportFromConversationDetailID', () => {
+    let resolver: ReportResolverExtended;
+
+    beforeEach(() => {
+        resolver = new ReportResolverExtended();
+        mssqlState.inputCalls.length = 0;
+        mssqlState.queryCalls.length = 0;
+        mssqlState.poolArgs.length = 0;
+        mssqlState.recordset.length = 0;
+        mssqlState.recordset.push({
+            Message: JSON.stringify({ title: 'Test Report', userExplanation: 'exp' }),
+            ConversationID: 'conv-1',
+            DataContextID: 'dctx-1',
+        });
+
+        mockUserCacheUsers.length = 0;
+        mockUserCacheUsers.push({ Email: 'test@example.com', ID: 'user-1' });
+    });
+
+    it('binds ConversationDetailID as a query parameter rather than splicing it into the SQL text', async () => {
+        const maliciousID = "1'; DROP TABLE MJ_Reports; --";
+        const context = makeContext(makeReportEntity);
+
+        const result = await resolver.CreateReportFromConversationDetailID(maliciousID, context);
+
+        expect(result.Success).toBe(true);
+
+        // The query text must use a bound parameter, never the raw value.
+        expect(mssqlState.queryCalls).toHaveLength(1);
+        expect(mssqlState.queryCalls[0]).toContain('@ConversationDetailID');
+        expect(mssqlState.queryCalls[0]).not.toContain(maliciousID);
+        expect(mssqlState.queryCalls[0]).not.toContain('DROP TABLE');
+
+        // The value must be bound through request.input, not string concatenation.
+        expect(mssqlState.inputCalls).toHaveLength(1);
+        expect(mssqlState.inputCalls[0].name).toBe('ConversationDetailID');
+        expect(mssqlState.inputCalls[0].value).toBe(maliciousID);
+    });
+
+    it('does not alter query structure for values containing quotes, --, or OR 1=1', async () => {
+        const hostileID = "abc' OR '1'='1' --";
+        const context = makeContext(makeReportEntity);
+
+        await resolver.CreateReportFromConversationDetailID(hostileID, context);
+
+        expect(mssqlState.queryCalls[0]).toMatch(/WHERE\s+cd\.ID=@ConversationDetailID\s*$/);
+        expect(mssqlState.inputCalls[0].value).toBe(hostileID);
+    });
+
+    it('still succeeds end to end for a normal GUID-shaped value', async () => {
+        const normalID = '12345678-1234-1234-1234-123456789012';
+        const context = makeContext(makeReportEntity);
+
+        const result = await resolver.CreateReportFromConversationDetailID(normalID, context);
+
+        expect(result.Success).toBe(true);
+        expect(result.ReportName).toBe('Test Report');
+        expect(mssqlState.inputCalls[0].value).toBe(normalID);
+    });
+});


### PR DESCRIPTION
## Summary
- Bind `ConversationDetailID` in `ReportResolver.CreateReportFromConversationDetailID` via mssql's parameterized `request.input(...)` instead of string interpolation.
- Escape embedded quotes in primary-key values in `GenericDatabaseProvider.CheckRecordRLS`, mirroring the existing `Load()` path.
- Fix `RowLevelSecurityFilterInfo.MarkupFilterText` to treat `undefined` like `null`/object (leaves the token unresolved) and to escape quotes in substituted values. Negation-shaped RLS filters (`<>`, `NOT IN`, `NOT LIKE`) become correctly *more* restrictive for deployments relying on the old behavior — see the changeset for details.
- Also included: `RuntimeUtilities.provider` (`@memberjunction/ng-react`) no longer initializes from the global `Metadata.Provider` in a field initializer (dead code, no behavior change) — this was the one test failure found when running the full repo suite alongside this hotfix.
- Changeset added for `@memberjunction/server`, `@memberjunction/generic-database-provider`, `@memberjunction/core`, `@memberjunction/ng-react` (all patch).

## Test plan
- [x] New regression tests for all three fixes (quote/`--`/`OR 1=1`-shaped values; `undefined` no longer becomes the string `"undefined"`)
- [x] `npm run test` green in MJServer, GenericDatabaseProvider, MJCore, MJGlobal, ng-react
- [x] Full-repo `turbo run test --continue=always` green across all 601 tasks
- [x] All affected packages build clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)