### PR TITLE
fix(metadata-sync): load dynamicPackages.server so non-MJ entity subclasses register

### DIFF
--- a/.changeset/metadata-sync-dynamic-packages.md
+++ b/.changeset/metadata-sync-dynamic-packages.md
@@ -1,0 +1,5 @@
+---
+"@memberjunction/metadata-sync": patch
+---
+
+Load dynamicPackages.server (Open App server packages) during provider initialization so non-MJ-namespace entity subclasses are registered before sync operations run. Fixes silent data loss in `mj sync pull` for BizApps/BCSaaS entities (#3415): bare BaseEntity fallback made primary-key reads return undefined, collapsing every record onto one key and duplicating it on later pulls.

--- a/packages/MetadataSync/src/__tests__/dynamic-server-packages.test.ts
+++ b/packages/MetadataSync/src/__tests__/dynamic-server-packages.test.ts
@@ -1,0 +1,70 @@
+/**
+ * Tests for loadDynamicServerPackages (#3415): dynamicPackages.server entries from
+ * mj.config.cjs must be imported (registering non-MJ-namespace entity subclasses)
+ * before sync operations instantiate entity objects. The fixture stands in for a
+ * real Open App server package; its file URL plays the PackageName role since
+ * import() accepts both bare specifiers and URLs.
+ */
+import { describe, expect, it, beforeEach, vi } from 'vitest';
+import { loadDynamicServerPackages } from '../lib/provider-utils';
+
+const FIXTURE = new URL('./fixtures/fake-server-pkg.mjs', import.meta.url).href;
+
+type GlobalWithCounters = typeof globalThis & {
+  __fakeServerPkgImports?: number;
+  __fakeServerPkgKickerRuns?: number;
+};
+const g = globalThis as GlobalWithCounters;
+
+describe('loadDynamicServerPackages', () => {
+  beforeEach(() => {
+    g.__fakeServerPkgKickerRuns = 0;
+  });
+
+  it('is a no-op when the section is absent or empty', async () => {
+    await expect(loadDynamicServerPackages(undefined)).resolves.toBeUndefined();
+    await expect(loadDynamicServerPackages([])).resolves.toBeUndefined();
+  });
+
+  it('imports the package and invokes its StartupExport', async () => {
+    await loadDynamicServerPackages([{ PackageName: FIXTURE, StartupExport: 'LoadFakeServer' }]);
+    expect(g.__fakeServerPkgImports).toBeGreaterThanOrEqual(1);
+    expect(g.__fakeServerPkgKickerRuns).toBe(1);
+  });
+
+  it('imports without invoking anything when no StartupExport is declared', async () => {
+    await loadDynamicServerPackages([{ PackageName: FIXTURE }]);
+    expect(g.__fakeServerPkgKickerRuns).toBe(0);
+  });
+
+  it('skips entries with Enabled: false', async () => {
+    await loadDynamicServerPackages([{ PackageName: FIXTURE, StartupExport: 'LoadFakeServer', Enabled: false }]);
+    expect(g.__fakeServerPkgKickerRuns).toBe(0);
+  });
+
+  it('tolerates a package that is not installed (ERR_MODULE_NOT_FOUND)', async () => {
+    await expect(
+      loadDynamicServerPackages([{ PackageName: '@mj-test/definitely-not-installed' }])
+    ).resolves.toBeUndefined();
+  });
+
+  it('warns but does not throw when a StartupExport throws', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+    try {
+      await expect(
+        loadDynamicServerPackages([{ PackageName: FIXTURE, StartupExport: 'ExplodingStartup' }])
+      ).resolves.toBeUndefined();
+      expect(warn).toHaveBeenCalled();
+    } finally {
+      warn.mockRestore();
+    }
+  });
+
+  it('continues past a failing entry to load later ones', async () => {
+    await loadDynamicServerPackages([
+      { PackageName: '@mj-test/definitely-not-installed' },
+      { PackageName: FIXTURE, StartupExport: 'LoadFakeServer' },
+    ]);
+    expect(g.__fakeServerPkgKickerRuns).toBe(1);
+  });
+});

--- a/packages/MetadataSync/src/__tests__/fixtures/fake-server-pkg.mjs
+++ b/packages/MetadataSync/src/__tests__/fixtures/fake-server-pkg.mjs
@@ -1,0 +1,13 @@
+// Test fixture standing in for a dynamicPackages.server package (e.g. an Open App
+// server bundle). Importing it is the "class registration" side effect; the exported
+// kicker records invocations on globalThis so tests can assert across the dynamic
+// import boundary.
+globalThis.__fakeServerPkgImports = (globalThis.__fakeServerPkgImports ?? 0) + 1;
+
+export function LoadFakeServer() {
+  globalThis.__fakeServerPkgKickerRuns = (globalThis.__fakeServerPkgKickerRuns ?? 0) + 1;
+}
+
+export function ExplodingStartup() {
+  throw new Error('startup exploded (fixture)');
+}

--- a/packages/MetadataSync/src/config.ts
+++ b/packages/MetadataSync/src/config.ts
@@ -59,8 +59,31 @@ export interface MJConfig {
   };
   /** Schema name for MemberJunction core tables (defaults to __mj) */
   mjCoreSchema?: string;
+  /**
+   * Installed dynamic server packages (Open Apps) from mj.config.cjs. Each enabled entry
+   * is dynamically imported during provider initialization so its `@RegisterClass` entity
+   * subclasses (e.g. `MJ_BizApps_Common: *`, `BC: *`) are registered before any sync
+   * operation instantiates entity objects. Without this, non-`MJ:`-namespace entities
+   * fall back to bare BaseEntity and primary-key reads silently return undefined (#3415).
+   */
+  dynamicPackages?: {
+    server?: DynamicServerPackageConfig[];
+  };
   /** Allow additional properties for extensibility */
   [key: string]: any;
+}
+
+/**
+ * One `dynamicPackages.server` entry from mj.config.cjs. Shape shared with
+ * ServerBootstrap's loader — MetadataSync consumes the same config section.
+ */
+export interface DynamicServerPackageConfig {
+  /** npm package name to dynamically import (side effect: class registration) */
+  PackageName: string;
+  /** Optional exported function to invoke after import (a registration kicker) */
+  StartupExport?: string;
+  /** Set false to skip the entry without removing it from config */
+  Enabled?: boolean;
 }
 
 /**

--- a/packages/MetadataSync/src/lib/provider-utils.ts
+++ b/packages/MetadataSync/src/lib/provider-utils.ts
@@ -10,6 +10,7 @@
 import sql from 'mssql';
 import { SQLServerProviderConfigData, UserCache, setupSQLServerClient } from '@memberjunction/sqlserver-dataprovider';
 import type { MJConfig } from '../config';
+import type { DynamicServerPackageConfig } from '../config';
 import * as fs from 'fs';
 import * as path from 'path';
 import { DatabaseProviderBase, Metadata, ResolveStartupMode, SetProvider, StartupManager, UserInfo } from '@memberjunction/core';
@@ -59,11 +60,56 @@ export async function initializeProvider(config: MJConfig): Promise<DatabaseProv
 
   const platform = (config.dbPlatform ?? 'sqlserver').toLowerCase();
 
-  initializationPromise = platform === 'postgresql'
+  initializationPromise = (platform === 'postgresql'
     ? initializePostgresProvider(config)
-    : initializeSqlServerProvider(config);
+    : initializeSqlServerProvider(config)
+  ).then(async (provider) => {
+    // Register dynamic (Open App) entity subclasses AFTER provider init so app
+    // registrations land last and win ClassFactory priority — same ordering as
+    // ServerBootstrap. Must happen before any sync operation instantiates entity
+    // objects, or non-MJ-namespace entities fall back to bare BaseEntity (#3415).
+    await loadDynamicServerPackages(config.dynamicPackages?.server);
+    return provider;
+  });
 
   return initializationPromise;
+}
+
+/**
+ * Dynamically import each enabled `dynamicPackages.server` entry from mj.config.cjs so
+ * its `@RegisterClass` entity subclasses are registered, and invoke its StartupExport
+ * when declared. Mirrors ServerBootstrap's `loadDynamicAppPackages` robustness contract
+ * (minus GraphQL resolver-path collection, which has no meaning in a CLI process):
+ * no-op when the section is absent, per-package try/catch, tolerate
+ * `ERR_MODULE_NOT_FOUND`, warn on anything else, never crash the CLI.
+ *
+ * Exported for tests.
+ */
+export async function loadDynamicServerPackages(serverPackages: DynamicServerPackageConfig[] | undefined): Promise<void> {
+  if (!serverPackages || serverPackages.length === 0) {
+    return;
+  }
+  for (const entry of serverPackages) {
+    const pkgName = entry?.PackageName;
+    if (!pkgName || entry.Enabled === false) {
+      continue;
+    }
+    try {
+      const mod = (await import(pkgName)) as Record<string, unknown>;
+      const startup = entry.StartupExport ? mod[entry.StartupExport] : undefined;
+      if (typeof startup === 'function') {
+        await Promise.resolve((startup as () => unknown)());
+      }
+      console.log(`Loaded dynamic server package: ${pkgName}${entry.StartupExport ? ` (ran ${entry.StartupExport})` : ''}`);
+    } catch (error: unknown) {
+      const errObj = error as { code?: string };
+      if (errObj.code === 'ERR_MODULE_NOT_FOUND') {
+        console.log(`Dynamic server package not found (run 'npm install'?): ${pkgName}`);
+      } else {
+        console.warn(`Error loading dynamic server package ${pkgName}:`, error);
+      }
+    }
+  }
 }
 
 async function initializeSqlServerProvider(config: MJConfig): Promise<DatabaseProviderBase> {


### PR DESCRIPTION
Fixes #3415 — silent data loss and duplicate records in `mj sync pull` for non-`MJ:` namespaces (BizApps/BCSaaS).

## Root cause

`metadata-sync` bootstraps only the `@memberjunction/*` class manifest and never loaded `dynamicPackages.server` from `mj.config.cjs`. Entities like `MJ_BizApps_Common: Organizations` therefore fell back to bare `BaseEntity`, whose typed PK getters don't exist → primary-key extraction returned `undefined` → every record keyed as `"ID:undefined"` → the write batch collapsed them onto one non-deterministic survivor saved with `primaryKey: {}` → each later pull appended a duplicate. Full verification with file:line receipts is on the issue.

Latent since at least v5.48 — **not** a startup-mode regression: this is `@RegisterClass` entity registration, not engine pre-warm, so the loader runs in both `full` and `task` modes.

## The fix

Mirror `ServerBootstrap.loadDynamicAppPackages` (minus GraphQL resolver-path collection, which has no meaning in a CLI process) in metadata-sync's provider initialization, on **both** DB-platform paths: after provider init, dynamically import each enabled `dynamicPackages.server` entry and invoke its `StartupExport`. Robustness contract preserved: no-op when absent, per-package try/catch, `ERR_MODULE_NOT_FOUND` tolerated with a hint, anything else warns and continues, never crashes the CLI. App registrations load after the manifest, so they win ClassFactory priority — same ordering as the server.

Also adds a typed `dynamicPackages` field to `MJConfig` (previously reachable only through the index signature) with the shared entry shape.

## Tests

7 new tests (`dynamic-server-packages.test.ts`, fixture-based — the fixture's file URL plays the PackageName role): absent/empty no-op · import + StartupExport invocation · import without kicker · `Enabled: false` skip · not-installed tolerance · throwing StartupExport warns-not-throws · continues past a failing entry. Package suite: **268/268 green**. Dependency-chain build: 121/121.

## Reviewer notes

- `mj sync push` was verified data-safe (metadata-driven `.Get()`/`.Set()`) — no push changes needed. It will still faithfully propagate files a *broken* pull already wrote; recovering those files is manual.
- The same gap exists in the other lite-manifest CLI consumers (MJCLI, CodeGenLib, MJCodeGenAPI, MCPServer, A2AServer) — follow-up issue coming rather than one six-package PR.
- Line triage (does this ship as a 5.51.x patch?) goes through the LTS process separately; the changeset here is a normal Edge patch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019EfGkq8cW9drueo1vEN4sM