### PR TITLE
test(query-viewer): fix GridStub missing ExportDataProvider input (NG0303)

### DIFF
--- a/.changeset/query-viewer-domtest-exportdataprovider.md
+++ b/.changeset/query-viewer-domtest-exportdataprovider.md
@@ -1,0 +1,5 @@
+---
+"@memberjunction/ng-query-viewer": patch
+---
+
+test(query-viewer): add the missing `ExportDataProvider` input to the DOM-test `GridStub` so the QueryViewer specs render the grid branch without NG0303. Dev-only; no runtime change.

--- a/packages/Angular/Generic/query-viewer/src/lib/query-viewer/query-viewer.component.dom.test.ts
+++ b/packages/Angular/Generic/query-viewer/src/lib/query-viewer/query-viewer.component.dom.test.ts
@@ -19,6 +19,7 @@ class GridStub {
   @Input() QueryInfo: MJQueryEntityExtended | null = null;
   @Input() Data: unknown; @Input() TotalRowCount = 0; @Input() PageNumber = 1; @Input() PageSize = 100;
   @Input() SelectionMode = ''; @Input() ShowToolbar = true; @Input() VisualConfig: unknown; @Input() IsLoading = false;
+  @Input() ExportDataProvider: (() => Promise<Record<string, unknown>[]>) | null = null;
   @Output() PageChange = new EventEmitter<unknown>();
   @Output() EntityLinkClick = new EventEmitter<QueryEntityLinkClickEvent>();
   @Output() RowDoubleClick = new EventEmitter<unknown>();


### PR DESCRIPTION
## What

Adds the missing `@Input() ExportDataProvider` to the `GridStub` in `query-viewer.component.dom.test.ts`, mirroring the real `QueryDataGridComponent` signature.

## Why

`QueryViewerComponent`'s template binds `[ExportDataProvider]` on `mj-query-data-grid` (added with the full-set-export work). The DOM test stubs that child but the stub omitted the input, so rendering the grid branch threw **NG0303 (unknown property)** — 6 of 8 QueryViewer specs failed.

This was **latent** on the Phase-4 DOM-testing PR (#3174) that introduced these specs: `turbo run test` fail-fasted earlier at `@memberjunction/global#test` (an unrelated false-positive, since fixed), so `query-viewer#test` never actually ran. Once that earlier failure was resolved, the query-viewer failure surfaced on `next` after #3174 merged.

## Scope / verification

- One-line stub fix + changeset. **Dev-only; no runtime code touched.**
- A tree-wide stub/template scan confirmed this was the **only** genuine drift of its kind — `entity-viewer`'s `ExportDataProvider` is the grid's *own* input (used in a `[disabled]` expression), not a binding on a stubbed child, so it is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)