### PR TITLE
fix(standards): give the ui-layers manifest half a reviewed-exception form

### DIFF
--- a/.changeset/ui-layers-manifest-exception.md
+++ b/.changeset/ui-layers-manifest-exception.md
@@ -1,0 +1,20 @@
+---
+"@memberjunction/standards": patch
+---
+
+ui-layers: let the manifest half of the layer ban carry a reviewed exception.
+
+The source half honours an `mj-ui-layers-allow` comment, but `package.json` carries no comments, so a
+package whose blessed import forces it to declare a banned dependency has no green state: declaring
+the dep trips the manifest half, and dropping it breaks the build the blessed import still needs.
+
+Packages can now declare `"mjUILayerAllow": { "<dep>": "<reason>" }`. The reason is required — a blank
+one fails, and so does an entry that no longer excuses anything, so the allowlist has to shrink on its
+own rather than rotting into a permanent pass.
+
+The alternative already available — relabelling the package to a layer where the dependency is legal —
+stays the right call when the package really does belong to that layer. This is for the narrower case:
+a package that is genuinely widgets apart from one reviewed import, where a whole-package downgrade
+would drop the widget rules from every other file in it.
+
+No change to what any layer forbids.

--- a/guides/UI_LAYERING_GUIDE.md
+++ b/guides/UI_LAYERING_GUIDE.md
@@ -410,6 +410,29 @@ Two things keep the gate from crying wolf, because a gate that cries wolf gets s
 directly above it, with a reason. One line above, not more — a marker that can drift away from the
 thing it excuses stops meaning anything.
 
+The manifest half needs its own form, because JSON carries no comments. A blessed import still has
+to resolve, so the dependency still has to be declared — use `mjUILayerAllow`:
+
+```jsonc
+{
+  "mjUILayer": "widgets",
+  "mjUILayerAllow": {
+    "@memberjunction/ng-shared": "why this exception exists, and what unblocks removing it"
+  }
+}
+```
+
+The reason is required, not decorative: an entry with a blank reason fails, and so does an entry
+that no longer excuses anything. Without this, a package holding a blessed import had no green
+state at all — declaring the dep tripped the manifest half, dropping it broke the build the import
+needs — and a permanently red gate teaches everyone to merge red.
+
+**Reach for the layer value first.** If the package genuinely belongs to a layer where the dependency
+is legal, say so in `mjUILayer` — that is what the field is for, and `ng-file-storage` was corrected
+to `surface` on exactly that basis. Use `mjUILayerAllow` for the narrower case: a package that is
+genuinely `widgets` apart from one reviewed import, where relabelling would drop the widget rules
+from every other file in it.
+
 The check ships in **[`@memberjunction/standards`](../packages/Standards/README.md)**, versioned
 with the platform. A repo adopts it once:
 

--- a/packages/Standards/README.md
+++ b/packages/Standards/README.md
@@ -106,7 +106,7 @@ Every registered standard, when it was introduced, and what this repo does with 
 
 | Id | Since | What it enforces |
 |---|---|---|
-| `ui-layers` | 6.0.0 | The four-layer UI architecture — [guide](https://github.com/MemberJunction/MJ/blob/next/guides/UI_LAYERING_GUIDE.md). Widgets may not import `@angular/router` or MJ Explorer, and may not construct a global-provider `RunView`/`Metadata`. Packages opt in with `"mjUILayer"` in their own `package.json`. |
+| `ui-layers` | 6.0.0 | The four-layer UI architecture — [guide](https://github.com/MemberJunction/MJ/blob/next/guides/UI_LAYERING_GUIDE.md). Widgets may not import `@angular/router` or MJ Explorer, and may not construct a global-provider `RunView`/`Metadata`. Packages opt in with `"mjUILayer"` in their own `package.json`. Reviewed exceptions: an `mj-ui-layers-allow` comment in source, or a reasoned `"mjUILayerAllow"` entry for a dependency. |
 
 ## Adding a standard
 

--- a/packages/Standards/src/__tests__/ui-layers.test.ts
+++ b/packages/Standards/src/__tests__/ui-layers.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
-import { IsAllowed, ParseImports, ProbeUndeclaredPackages, StripComments, UILayersCheck } from '../checks/ui-layers.js';
+import { CheckForbiddenDeps, IsAllowed, ParseImports, ProbeUndeclaredPackages, StripComments, UILayersCheck } from '../checks/ui-layers.js';
 
 describe('StripComments', () => {
     it('blanks line comments while preserving line numbers', () => {
@@ -91,6 +91,41 @@ afterEach(() => {
 const run = (options: Record<string, unknown> = {}) =>
     UILayersCheck.Run({ RepoRoot: repo, Roots: ['packages'], Options: { ...UILayersCheck.DefaultOptions, ...options } });
 
+describe('CheckForbiddenDeps — the manifest-half exception', () => {
+    const REASON = { '@memberjunction/ng-shared': 'blessed import, tracked in MJ#3404' };
+
+    it('flags a forbidden dep with no exception', () => {
+        expect(CheckForbiddenDeps(['@memberjunction/ng-shared'], {}, 'widgets')).toEqual([
+            expect.stringContaining('must not depend on it'),
+        ]);
+    });
+
+    it('excuses a forbidden dep that carries a reason', () => {
+        expect(CheckForbiddenDeps(['@memberjunction/ng-shared'], REASON, 'widgets')).toEqual([]);
+    });
+
+    it('rejects an exception whose reason is blank', () => {
+        expect(CheckForbiddenDeps(['@angular/router'], { '@angular/router': '  \t ' }, 'widgets')).toEqual([
+            expect.stringContaining('empty "mjUILayerAllow" reason'),
+        ]);
+    });
+
+    it('flags a stale exception so the allowlist has to shrink on its own', () => {
+        // The dep is gone but the entry survives, reading as a live reviewed decision.
+        expect(CheckForbiddenDeps([], REASON, 'widgets')).toEqual([expect.stringContaining('stale exception')]);
+    });
+
+    it('flags an exception for a dep that was never forbidden here', () => {
+        expect(CheckForbiddenDeps(['@memberjunction/core'], { '@memberjunction/core': 'why' }, 'widgets')).toEqual([
+            expect.stringContaining('stale exception'),
+        ]);
+    });
+
+    it('leaves layers with no forbidden deps alone', () => {
+        expect(CheckForbiddenDeps(['@memberjunction/ng-shared', '@angular/router'], {}, 'shell')).toEqual([]);
+    });
+});
+
 describe('UILayersCheck', () => {
     it('skips undeclared packages by default', async () => {
         writePackage('undeclared', {}, { 'a.ts': `import { Router } from '@angular/router';` });
@@ -112,6 +147,33 @@ describe('UILayersCheck', () => {
         const result = await run();
         expect(result.Violations).toHaveLength(1);
         expect(result.Violations[0].Message).toContain('declares "@angular/router"');
+    });
+
+    it('honours a reasoned mjUILayerAllow for a dep the source is already allowed to import', async () => {
+        // The case this exists for: an import carrying an mj-ui-layers-allow marker still has to
+        // resolve, so the dep MUST be declared for it to build — leaving the package no green state
+        // at all until the manifest half can be excused too.
+        writePackage(
+            'w',
+            {
+                mjUILayer: 'widgets',
+                dependencies: { '@memberjunction/ng-shared': '6.0.0' },
+                mjUILayerAllow: { '@memberjunction/ng-shared': 'L3 surface awaiting relocation — MJ#3404' },
+            },
+            { 'a.ts': `// mj-ui-layers-allow: MJ#3404\nimport { BaseResourceComponent } from '@memberjunction/ng-shared';` },
+        );
+        expect((await run()).Violations).toEqual([]);
+    });
+
+    it('rejects an mjUILayerAllow entry with a blank reason', async () => {
+        writePackage(
+            'w',
+            { mjUILayer: 'widgets', dependencies: { '@angular/router': '21.1.3' }, mjUILayerAllow: { '@angular/router': '   ' } },
+            { 'a.ts': 'export const x = 1;' },
+        );
+        const result = await run();
+        expect(result.Violations).toHaveLength(1);
+        expect(result.Violations[0].Message).toContain('empty "mjUILayerAllow" reason');
     });
 
     it('flags a zero-arg RunView but NOT one given a provider', async () => {

--- a/packages/Standards/src/checks/ui-layers.ts
+++ b/packages/Standards/src/checks/ui-layers.ts
@@ -88,6 +88,22 @@ const FORBIDDEN_DEPS: Record<UILayer, RegExp[]> = {
     shell: [],
 };
 
+/**
+ * Reviewed exceptions to the manifest half of the ban: `"mjUILayerAllow": { "<dep>": "<reason>" }`.
+ *
+ * The source half has the `mj-ui-layers-allow` comment marker, but JSON carries no comments, so a
+ * package holding a blessed import has no way to be green: declaring the dep trips this half, and
+ * dropping it breaks the build the blessed import still needs. ng-file-storage hit exactly that on
+ * `next` and was resolved by relabelling the package to `surface`, which is the honest fix when a
+ * package really is L3 — but it is a whole-package downgrade, so it is the wrong tool for a package
+ * that is genuinely widgets apart from one blessed import. This is the scoped alternative.
+ *
+ * The object form is deliberate. A bare array would let an exception accumulate silently; requiring
+ * a reason string holds the manifest to the same standard {@link IsAllowed} holds the comment form
+ * to — "a real exception deserves a sentence of explanation".
+ */
+export type UILayerAllowances = Record<string, string>;
+
 const SOURCE_EXTENSIONS = ['.ts', '.tsx', '.mts', '.cts'];
 const SKIP_DIRS = new Set(['node_modules', 'dist', 'build', '.git', '.angular', 'coverage', 'generated']);
 const ALLOW_MARKER = 'mj-ui-layers-allow';
@@ -225,6 +241,37 @@ function findSourceFiles(packageDir: string): string[] {
 // The check
 // ─────────────────────────────────────────────────────────────────────────────
 
+/**
+ * The manifest half of the ban: which declared dependencies this layer may not have.
+ *
+ * Returns one message per problem, so the caller owns file/line attribution. Three ways to fail:
+ * a forbidden dep with no exception, an exception with no reason, and an exception that no longer
+ * matches anything. The last one matters because a stale entry reads as a live, reviewed decision
+ * long after the dep it excused is gone — the allowlist has to shrink on its own.
+ */
+export function CheckForbiddenDeps(declared: string[], allowances: UILayerAllowances, layer: UILayer): string[] {
+    const messages: string[] = [];
+    const isForbidden = (dep: string): boolean => FORBIDDEN_DEPS[layer].some((pattern) => pattern.test(dep));
+
+    for (const dep of declared) {
+        if (!isForbidden(dep)) continue;
+        if (!(dep in allowances)) {
+            messages.push(`declares "${dep}" — a "${layer}" package must not depend on it`);
+            continue;
+        }
+        if (allowances[dep].trim().length === 0) {
+            messages.push(`declares "${dep}" with an empty "mjUILayerAllow" reason — say why the exception exists`);
+        }
+    }
+
+    for (const dep of Object.keys(allowances)) {
+        if (declared.includes(dep) && isForbidden(dep)) continue;
+        messages.push(`lists "${dep}" in "mjUILayerAllow", but nothing there needs excusing — drop the stale exception`);
+    }
+
+    return messages;
+}
+
 /** Check one opted-in package. */
 function checkPackage(packageDir: string, layer: UILayer, repoRoot: string, packageName: string): Violation[] {
     const violations: Violation[] = [];
@@ -236,12 +283,11 @@ function checkPackage(packageDir: string, layer: UILayer, repoRoot: string, pack
     const manifest = JSON.parse(readFileSync(manifestPath, 'utf8')) as {
         dependencies?: Record<string, string>;
         peerDependencies?: Record<string, string>;
+        mjUILayerAllow?: UILayerAllowances;
     };
     const declared = { ...(manifest.dependencies ?? {}), ...(manifest.peerDependencies ?? {}) };
-    for (const dep of Object.keys(declared)) {
-        for (const pattern of FORBIDDEN_DEPS[layer]) {
-            if (pattern.test(dep)) add(manifestPath, 0, `declares "${dep}" — a "${layer}" package must not depend on it`);
-        }
+    for (const message of CheckForbiddenDeps(Object.keys(declared), manifest.mjUILayerAllow ?? {}, layer)) {
+        add(manifestPath, 0, message);
     }
 
     for (const file of findSourceFiles(packageDir)) {


### PR DESCRIPTION
**One sentence:** The `ui-layers` gate enforces a rule on `package.json` that it has no way to grant an exception to, so a package whose blessed import forces it to declare a banned dependency has no green state at all — this adds the manifest twin of the `mj-ui-layers-allow` comment marker.

> **Rebased.** This PR originally also fixed the self-flagging regex and `ng-file-storage`'s red. Both were fixed on `next` in parallel while it was open (`4d05392347`, `c9b7423c3f`) and have been dropped. What remains is only the piece still missing from `next`.

## The gap

The check enforces the layer ban in two halves:

| Half | Checks | Exception mechanism |
|---|---|---|
| Source | `import` statements | ✅ `mj-ui-layers-allow` comment |
| Manifest | `dependencies` in `package.json` | ❌ **none** |

A blessed import still has to resolve, so its dependency still has to be declared. That leaves no green state:

- **Declare the dep** → manifest half fails.
- **Don't declare it** → TS2307, because the blessed import needs it.

## The fix

```jsonc
{
  "mjUILayer": "widgets",
  "mjUILayerAllow": {
    "@memberjunction/ng-shared": "why this exception exists, and what unblocks removing it"
  }
}
```

The object form is deliberate — a bare array lets exceptions accumulate silently. The reason is required, and **the allowlist has to shrink on its own**: a blank reason fails, and so does an entry that no longer excuses anything.

## Relationship to the `surface` fix already on `next`

These are complementary, and the guide now says which to reach for first:

- **Relabel via `mjUILayer`** when the package genuinely belongs to a layer where the dep is legal. That was the right call for `ng-file-storage` in `c9b7423c3f`.
- **`mjUILayerAllow`** for the narrower case: a package that is genuinely `widgets` apart from one reviewed import, where relabelling would drop the widget rules from *every other file* in it.

## For the reviewer

- **This mechanism already landed once and was lost.** `4d05392347` added it as an unreasoned `mjUILayerAllowedDeps` array; `next`'s manifest-half loop is now byte-identical to the original, so it vanished in a later merge conflict resolution. That is the **second** time work in this area has been lost that way — `e1acebd09a` did it to the dependency declaration itself. Worth a look at whether something structural is going wrong in this area's conflict resolutions.
- **Nothing uses this yet.** No package declares an exception; `next` is green without it. This is the escape hatch being available before the next package needs it, not a fix for a current red. Reasonable to push back on that as speculative — the argument for landing it is that the hole is reachable by design, since any allow-marked import of a *dependency* trips the manifest half automatically.
- **Check I didn't weaken the gate.** The hatch is per-dependency and per-package, never a global off-switch, and I ran the negative case before the rebase: removing an exception re-fails the check with the original message.

## Verification

- Standards gate on the rebased tree: **exit 0**, `✓ All adopted standards pass`
- `@memberjunction/standards`: **57 tests pass** (49 before, 8 added)
- `MultiProviderCompliance`: still passes
- Integration tier not run — this touches a lint gate and docs, nothing in the runtime path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Mn3NY1z42C27NgyPEf491p