### PR TITLE
test(ui-components): assert slide-panel's real state class, sp-open

### DIFF
--- a/packages/Angular/Generic/ui-components/src/lib/slide-panel/slide-panel.component.dom.test.ts
+++ b/packages/Angular/Generic/ui-components/src/lib/slide-panel/slide-panel.component.dom.test.ts
@@ -8,6 +8,10 @@ import { MjSlidePanelComponent } from './slide-panel.component';
  * after a 300ms CSS-transition timer — the specs flush those explicitly. Covers the slide vs dialog
  * rendering, the Title header + close button, projected body, and the close/backdrop → Closed path
  * with the CanClose guard.
+ *
+ * The open-state class is `sp-open`, never `visible` — see the comment in slide-panel.component.css
+ * for why. Assert on `sp-open` here: a negative assertion against a class the template never emits
+ * passes no matter what the component does, so a wrong name here buys silence, not coverage.
  */
 
 const tick = (ms = 0) => new Promise((r) => setTimeout(r, ms));
@@ -28,7 +32,7 @@ describe('MjSlidePanelComponent (DOM)', () => {
     const f = await renderOpen({ Title: 'Details' });
     const panel = query(f, '.sp-panel');
     expect(panel).not.toBeNull();
-    expect(panel?.classList.contains('visible')).toBe(true);
+    expect(panel?.classList.contains('sp-open')).toBe(true);
     expect(query(f, '.sp-dialog')).toBeNull();
   });
 
@@ -40,8 +44,8 @@ describe('MjSlidePanelComponent (DOM)', () => {
 
   it('is not visible when Visible is false', async () => {
     const f = await renderOpen({ Visible: false, Title: 'Details' });
-    expect(query(f, '.sp-panel')?.classList.contains('visible')).toBe(false);
-    expect(query(f, '.sp-backdrop')?.classList.contains('visible')).toBe(false);
+    expect(query(f, '.sp-panel')?.classList.contains('sp-open')).toBe(false);
+    expect(query(f, '.sp-backdrop')?.classList.contains('sp-open')).toBe(false);
   });
 
   it('renders the Title header + close button when a Title is set', async () => {
@@ -86,6 +90,6 @@ describe('MjSlidePanelComponent (DOM)', () => {
     await tick(320);
     expect(closed.length).toBe(0);
     f.detectChanges(false);
-    expect(query(f, '.sp-panel')?.classList.contains('visible')).toBe(true);
+    expect(query(f, '.sp-panel')?.classList.contains('sp-open')).toBe(true);
   });
 });


### PR DESCRIPTION
**One sentence:** The slide-panel DOM spec asserts a CSS class the component stopped emitting on Aug 4, so two assertions were red and two more were silently testing nothing — this points all four at the real class, `sp-open`.

## What happened

Two PRs landed on `next` hours apart the same day, and the second invalidated the first:

| Time (Aug 4) | PR | Change |
|---|---|---|
| 16:40 | #3174 | Adds `slide-panel.component.dom.test.ts`, asserting `classList.contains('visible')` |
| 18:53 | #3444 | Renames the state class `visible` → `sp-open` in `.html` + `.css` — **does not touch the spec** |

The rename is correct and must stay. `slide-panel.component.css` documents why: explorer-app ships a global `.visible { visibility: visible !important }` utility, and a state class named `visible` accidentally matches it, forcing the panel to punch through its container. This PR changes the spec, not the component.

## Reviewer note — why this took a while to find

Only **two of four** `contains('visible')` assertions went red. The two negative ones (`.toBe(false)`) kept passing, because a class the template never emits is never present — they could not have failed no matter what the component did. That left 7-of-9 green, which reads like a change-detection or timing bug rather than a stale string, and the failure was initially misattributed to the pnpm cutover in #3466.

It isn't pnpm-related. `git merge-base --is-ancestor d26e202e7b 535f2573ff^1` confirms the rename was already on npm-era `next` before that merge, and no package manager can add a class to a template.

Pointing the negative assertions at `sp-open` restores them to actually testing something: if the class is ever renamed again, the positive spec now fails immediately instead of the suite going quietly hollow.

## Scope and verification

- One file, test-only. No runtime or published output changes, so no changeset.
- `@memberjunction/ng-ui-components`: **466/466 passing** locally.
- Swept the repo — no other spec asserts a bare `visible` class, and no live source still uses the old name.

## Unrelated changes

None. `DEPLOYMENT.md` and three regenerated `mj-class-registrations.ts` files were dirty in the working tree and were deliberately left out of this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MWKANF66dZbzGqJDk2zov5
