### PR TITLE
ci: keep Docker :latest on certified builds, and fix build.yml's dead path filter

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,7 +6,7 @@ on:
     branches:
       - next
     paths:
-      - 'package-lock.json'
+      - 'pnpm-lock.yaml'
       - 'packages/**'
 
 jobs:

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,5 +1,22 @@
 name: Build and publish docker images
 
+# Docker `:latest` must mean the same thing npm's `latest` dist-tag means:
+# the newest CERTIFIED build (LTS process doc §4.3). It never follows the fast
+# channel.
+#
+# Since the 6.x era opened, everything published through `next -> main` is an
+# Edge prerelease (`6.1.0-edge.N`), so an unguarded run here would drag Docker
+# `:latest` onto uncertified bits while npm `latest` correctly stayed put. The
+# `channel` job below therefore skips any prerelease version.
+#
+# Consequence, stated plainly: during the Edge era this workflow auto-publishes
+# nothing. Certified and line builds ship from `lts/*` via publish-lts.yml,
+# which does not trigger this workflow — so a certified image is produced by
+# dispatching this workflow manually against the certified tag. Wiring line
+# publishes to Docker, and deciding whether an `:edge` tag is wanted at all,
+# are open items (process doc §15 item 4). Until then: no Docker image for
+# Edge builds, by decision, not by omission.
+
 on:
   workflow_run:
     workflows: [Build and publish new package versions]
@@ -10,8 +27,12 @@ on:
   workflow_dispatch:
 
 jobs:
-  api:
+  channel:
+    name: Decide whether this version gets an image
     runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.version.outputs.VERSION }}
+      publish: ${{ steps.decide.outputs.PUBLISH }}
     steps:
       - name: Error out if the trigger did not succeed
         run: |
@@ -22,12 +43,40 @@ jobs:
 
       - name: Checkout repo
         uses: actions/checkout@v4
+
       - name: Get version
         id: version
         run: |
           # Use MJServer package since core and global are pinned at 2.100.3
           VERSION=$(jq -r .version packages/MJServer/package.json)
           echo "VERSION=$VERSION" >> $GITHUB_OUTPUT
+
+      # A prerelease suffix (`-edge.N`, `-rc.N`, …) means uncertified bits.
+      # The guard keys off the version grammar rather than the trigger, so it
+      # also protects a manual dispatch accidentally aimed at `next`.
+      - name: Decide on the channel
+        id: decide
+        env:
+          VERSION: ${{ steps.version.outputs.VERSION }}
+        run: |
+          case "$VERSION" in
+            *-*)
+              echo "PUBLISH=false" >> "$GITHUB_OUTPUT"
+              echo "::notice::$VERSION is a prerelease — skipping the Docker build. Docker :latest tracks certified builds only (LTS process doc §4.3)."
+              ;;
+            *)
+              echo "PUBLISH=true" >> "$GITHUB_OUTPUT"
+              echo "::notice::$VERSION is an unsuffixed release — building and tagging :latest."
+              ;;
+          esac
+
+  api:
+    needs: channel
+    if: needs.channel.outputs.publish == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v4
 
       - name: Login to Docker Hub
         uses: docker/login-action@v3
@@ -44,7 +93,7 @@ jobs:
           push: true
           tags: |
             memberjunction/api:latest
-            memberjunction/api:v${{ steps.version.outputs.VERSION }}
+            memberjunction/api:v${{ needs.channel.outputs.version }}
           platforms: |
             linux/amd64
             linux/arm64
@@ -62,5 +111,5 @@ jobs:
         run: |
           docker buildx imagetools create \
             --tag askskip.azurecr.io/memberjunction/api:latest \
-            --tag askskip.azurecr.io/memberjunction/api:v${{ steps.version.outputs.VERSION }} \
+            --tag askskip.azurecr.io/memberjunction/api:v${{ needs.channel.outputs.version }} \
             memberjunction/api:latest

--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -698,15 +698,19 @@ This workflow:
 
 ### 10b. `docker.yml` — Build & Publish Docker Images
 
-**Triggered by:** `publish.yml` completion
+**Triggered by:** `publish.yml` completion, or manual dispatch
 
 Builds and pushes multi-platform Docker images (`linux/amd64`, `linux/arm64`):
 - Docker Hub: `memberjunction/api:latest` and `memberjunction/api:v{VERSION}`
 - Azure ACR: `askskip.azurecr.io` with same tags
 
-> 🚨 **Known gap — Docker tags are not channel-aware yet.** The LTS policy (process doc §4.3) calls for `:edge` on Edge builds and `:latest` following the newest *certified* build — but `docker.yml` still tags **every** publish `:latest`, so an Edge release currently moves Docker `:latest` to an uncertified image while npm `latest` correctly stays put. Per-channel Docker tags are era-split tooling (process doc §15 item 4), still pending. Until that lands, treat Docker `:latest` as "newest build", not "newest certified".
+> 🐳 **Docker `:latest` means the same thing npm's `latest` means — newest certified.** The workflow's `channel` job reads the version and **skips any prerelease**, so an Edge release publishes npm packages but produces **no Docker image**. Expect `docker.yml` to report a skipped `api` job on every Edge release; that is the guard working, not a failure.
+>
+> **What this means in practice during the Edge era:** nothing auto-publishes to Docker. Certified and line builds ship from `lts/*` through `publish-lts.yml`, which does not trigger this workflow — so a certified image is produced by **dispatching `docker.yml` manually against the certified tag**. The guard keys off version grammar, not the trigger, so a manual dispatch accidentally aimed at `next` is skipped too.
+>
+> **Open:** whether an `:edge` Docker tag is wanted at all, and wiring line publishes to Docker automatically (process doc §15 item 4). Until someone confirms a real need for Edge images, Edge simply doesn't get them.
 
-> **Known issue:** This workflow sometimes fails because it tries to install the newly published npm packages before they've fully propagated on the npm registry. If it fails, **re-run the failed job** — it usually succeeds on the second attempt.
+> **Known issue:** When it does build, this workflow sometimes fails because it tries to install the newly published npm packages before they've fully propagated on the npm registry. If it fails, **re-run the failed job** — it usually succeeds on the second attempt.
 
 ### 10c. `docs.yml` — Build & Deploy the Documentation Site
 
@@ -727,7 +731,7 @@ Installs the workspace (`pnpm install --frozen-lockfile` — the workflow auto-d
 - [ ] `publish.yml` completes successfully (npm packages published, tag created)
 - [ ] **Dist-tags landed on the right channel**: `npm view @memberjunction/core dist-tags` — `edge` moved to the new version, **`latest` did not move** (it moves only at certification)
 - [ ] **GitHub Release exists** for the new tag, notes auto-generated, marked prerelease (edge) and **not** latest
-- [ ] `docker.yml` completes successfully (Docker images pushed — note the `:latest` channel gap above)
+- [ ] `docker.yml` behaved for the channel: on an **Edge** release its `api` job is **skipped** (correct — Docker `:latest` tracks certified builds); on a certified build dispatched manually, images pushed
 - [ ] `docs.yml` completes successfully (https://docs.memberjunction.org rebuilt, `/api` included)
 - [ ] `main` auto-merged back into `next` (includes the `pnpm-lock.yaml` refresh)
 - [ ] **`next` branch build passes** after the auto-merge — the lockfile and version updates can sometimes cause issues, so always verify `build.yml` passes on `next` after a release
@@ -787,7 +791,7 @@ Your only job here is the verification already in the Post-Merge Checklist — a
 | Per-package changelogs | `packages/*/CHANGELOG.md` | changesets, in the `RELEASING: Releasing N package(s)` commit, from each PR's changeset summary |
 | npm packages | `edge` / `lts-<line>` dist-tags — **`latest` moves only at certification** | `publish.yml` / `publish-lts.yml`; `ci/dist-tag-all.mjs` at certification |
 | Git tag `vX.Y.Z[-edge.N]` | repo tags | `ci/commit_push.mjs` |
-| Docker images | Docker Hub `memberjunction/api`, Azure ACR | `docker.yml` (`:latest` not yet channel-aware — see 10b) |
+| Docker images | Docker Hub `memberjunction/api`, Azure ACR | `docker.yml` — certified builds only; Edge is skipped (see 10b) |
 | API docs | https://docs.memberjunction.org/api | `docs.yml` |
 | Release/support state | [`release-lines.json`](release-lines.json) | Workflows append mechanical fields; status changes only via CODEOWNERS-gated PR |
 | Certification scorecards | `certifications/<version>.md`, linked from the certified GitHub Release | Certification owner |


### PR DESCRIPTION
## One sentence

Docker `:latest` was about to follow the first Edge release onto uncertified bits while npm `latest` correctly stayed put; this teaches `docker.yml` about channels and skips prereleases entirely.

## Why

The LTS process (`plans/lts-process.md` §4.3) reserves `latest` for the newest **certified** build. `publish.yml` already honors that on npm — routine releases publish to the `edge` dist-tag and never move `latest`. `docker.yml` had no notion of channel and tagged **every** publish `:latest`.

So on the first Edge release (`6.1.0-edge.0`, imminent), npm `latest` would correctly stay at 5.51.0 while Docker `:latest` silently moved to an uncertified image. Anyone pulling `memberjunction/api:latest` would get Edge bits.

## What changed

**`docker.yml`** — a `channel` job reads the version and skips any prerelease; the `api` job is gated on it. The guard keys off **version grammar, not the trigger**, so a manual dispatch accidentally aimed at `next` is skipped too.

**`build.yml`** — the push path filter still listed `package-lock.json`, deleted in the pnpm cutover. That trigger path has been dead since; now `pnpm-lock.yaml`.

**`DEPLOYMENT.md`** — 10b documents the behavior so a skipped `api` job doesn't read as a failure.

## 👀 Reviewer attention

**This changes what auto-publishes to Docker, and the consequence is deliberate rather than accidental — please confirm you want it.** During the Edge era this workflow now auto-publishes **nothing**: everything through `next → main` is a prerelease and gets skipped, and certified/line builds ship from `lts/*` via `publish-lts.yml`, which does not trigger this workflow at all. Certified images therefore come from **dispatching `docker.yml` manually against the certified tag**.

That is the behavior Craig asked for ("Docker latest should match npm's; skip edge on Docker until we confirm there's a need for edge images"), but it means the Docker image for `memberjunction/api` will stop advancing until the first 6.x certification. If any consumer depends on a per-build image, they need the `:edge` tag this PR deliberately does **not** add.

Still open, not decided here (process doc §15 item 4): whether an `:edge` Docker tag is wanted, and whether line publishes should trigger Docker automatically.

## Unrelated changes

The `build.yml` path-filter fix is unrelated to the Docker change — both are post-cutover cleanups found in the same pass, and each is one line of intent.

## Testing

Both workflows parse; job graph verified (`api` `needs: channel`, `if: needs.channel.outputs.publish == 'true'`). Guard logic is a shell `case` on the version: `6.1.0-edge.0` matches `*-*` → skip; `5.51.0` → build. Not exercised end-to-end — the first real proof is the next Edge release showing a skipped `api` job.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019EfGkq8cW9drueo1vEN4sM