### PR TITLE
ci: stop the migration gate failing in its post-job cache save

### DIFF
--- a/.github/workflows/changes.yml
+++ b/.github/workflows/changes.yml
@@ -82,7 +82,11 @@ jobs:
         uses: actions/setup-node@v6
         with:
           node-version: 24
-          cache: 'pnpm'
+          # No dependency cache here on purpose: this job never runs `pnpm install`
+          # (the gate is shell + jq over filenames), so there is no pnpm store to save.
+          # With `cache: 'pnpm'` the post-job cache-save step fails the whole check with
+          # "Path Validation Error: Path(s) specified in the action for caching do(es) not
+          # exist" — after every real validation step has already passed.
 
       - name: Get current version
         if: steps.check_migrations.outputs.has_migrations == 'true'


### PR DESCRIPTION
`Check migrations` red on every PR that touches a migration, with all of its own validation steps green.

The pnpm cutover put `cache: 'pnpm'` on this job's `setup-node`. The job never runs `pnpm install` — it validates migration filenames and timestamps with shell + `jq` — so there is no pnpm store on disk when the post-job cache save runs, and it fails the check with:

```
Path Validation Error: Path(s) specified in the action for caching do(es) not exist, hence no cache is being saved.
```

On #3291 the job conclusion was `failure` with **every** validation step `success` and only `Post Set up node` failed. Dropping the cache key removes the post step; nothing else in the job depends on it.

Verified the workflow still parses and `setup-node` now carries only `node-version: 24`.