### PR TITLE
feat(actions-apollo): Apollo list management, search and prospecting

### DIFF
--- a/.changeset/apollo-lists-search-and-moves.md
+++ b/.changeset/apollo-lists-search-and-moves.md
@@ -1,0 +1,29 @@
+---
+"@memberjunction/actions-apollo": minor
+---
+
+Add Apollo's other half to this package: **list management, saved-record search and prospecting**, as seven new actions alongside the two enrichment actions it has always had.
+
+`ApolloGetListsAction` and `ApolloCreateListAction` read and create labels; `ApolloGetListAccountsAction` and `ApolloGetListContactsAction` page through a list's members; `ApolloSearchPeopleAction` searches Apollo's people database for net-new prospects; `ApolloMoveListAccountsAction` and `ApolloMoveListContactsAction` move records between lists. Together they are the outbound-campaign surface — build a list, drain it through a sequence of stages, and see what is where — which enrichment alone cannot express.
+
+These go to a **different Apollo base path** from enrichment: `api.apollo.io/api/v1` rather than `api.apollo.io/v1`. They are not interchangeable, and the same path under the wrong prefix 404s, so `ApolloRESTEndpoint` is declared beside the existing `ApolloAPIEndpoint` rather than derived from it.
+
+Five Apollo behaviours dictate the design, and each is what makes the naive implementation wrong:
+
+**A PATCH replaces the whole `label_names` array.** There is no add-one-label endpoint, so a move is *two* writes, each carrying the complete intended set: first `current ∪ {toList}`, then `(current ∪ {toList}) \ {fromList}`. Sending a bare `['Warm']` would silently delete every other list the record was on, and nothing in the response would reveal it. The remove set is computed from the *post-add* state, not from the pre-add state — deriving it from `current` alone would add the record to the destination and then immediately take it back out. The move actions accept only ids from the caller, never labels, and re-read the source list themselves, so a caller cannot supply a stale label set that quietly destroys memberships the record picked up since they last looked.
+
+**Roughly 15-17% of removes return success without applying.** Removes are verified by re-reading the destination list, and a record still carrying the source label is reported as `possiblyStuck` rather than retried — an immediate retry flakes the same way, while the next page-1 drain sees it carrying both labels and finishes the job. A possibly-stuck record is deliberately **not** a failure: the write succeeded and Apollo did not honour it, so calling it a failure would send the caller looking for a bug in the request. `PARTIAL_FAILURE` is reserved for a PATCH that actually failed. When the verify read itself fails, or the record is simply not on the destination page, the stuck state is left `null` — unknown, not verified-clean.
+
+**A list drain must always read page 1**, because removals shift every later page, so advancing to page 2 skips records. Paging therefore defaults to page 1 rather than to a saved position, and the move actions pin it explicitly.
+
+**Label reads and every write require a MASTER key.** A scoped key authenticates fine and then 403s, which is indistinguishable from a wrong key — so a 403 on a master-key operation is rewritten into a message that names the requirement instead of passing the bare status through. The prospecting search is the one read a scoped key can serve, so it deliberately skips the label fetch the other searches need.
+
+**Labels are read as `label_ids` but written as `label_names`.** The client fetches the label list once per instance and resolves ids to names on every read; an id with no matching label is dropped rather than passed through, since a raw id inside a `label_names` write would create a label named after a hex string.
+
+`ApolloCreateListAction` is idempotent — a same-named label is returned as-is with `AlreadyExisted: true`. Apollo will happily create two labels with one name, and once it has, every name-based lookup in this surface becomes ambiguous: half the moves would target one list and half the other. Idempotent create is what keeps name-addressing sound. `ApolloSearchPeopleAction` requires at least one filter; Apollo accepts a request with none and returns an unscoped, rate-limit-burning result set nobody asked for.
+
+Credentials resolve through `CompanyID` → the company's active `Apollo` **MJ: Company Integrations** row → `CredentialID` → the `apiKey` in **MJ: Credentials** `Values`, falling back to `APOLLO_API_KEY` so existing single-tenant deployments keep working untouched. `CompanyIntegration.APIKey` is deliberately not read: it is not a decrypt-on-read field, so a key written through metadata sync comes back as the literal `$ENC$…` ciphertext and produces a 401 that looks exactly like a wrong key. A credential that exists but will not parse fails with `CONFIGURATION_ERROR` rather than silently borrowing another workspace's key from the environment.
+
+92 tests cover the surface, driving the client through an injected `fetch` so the request bodies Apollo would receive are asserted directly — which matters more than usual here, because a move that sends the wrong label array is invisible in the response. Nothing in the suite can reach api.apollo.io: a live read would spend credits and a live write would mutate a real account's lists with no undo.
+
+The two enrichment actions are unchanged.

--- a/packages/Actions/ApolloEnrichment/README.md
+++ b/packages/Actions/ApolloEnrichment/README.md
@@ -13,6 +13,7 @@ Key capabilities:
 - **Configurable field mappings** -- JSON-based parameter configuration maps Apollo.io fields to your custom entity fields
 - **Rate limit handling** -- automatic retry with intelligent backoff for both per-minute and hourly Apollo.io rate limits
 - **Batch processing** -- concurrent group processing with configurable batch sizes and pagination for large datasets
+- **List management, search and prospecting** -- seven further actions that read and create Apollo lists (labels), page through a list's members, search Apollo's people database for net-new prospects, and move records between lists without destroying their other memberships. See [List management, search and prospecting](#list-management-search-and-prospecting)
 
 For general Actions framework architecture and design philosophy, see the [parent Actions README](../README.md) and [Actions CLAUDE.md](../CLAUDE.md).
 
@@ -321,6 +322,84 @@ const result = await engine.RunAction({
     ContextUser: contextUser
 });
 ```
+
+## List management, search and prospecting
+
+Seven actions cover the other half of Apollo: which records are on which list, and moving them between lists. They are the outbound-campaign surface — build a list, drain it through a sequence of stages, and see what is where.
+
+These talk to a **different Apollo base path** from enrichment: `api.apollo.io/api/v1` rather than `api.apollo.io/v1`. The paths are not interchangeable; the same path under the wrong prefix returns 404. Both are declared side by side in `src/config.ts`.
+
+| Action | Purpose | Key required |
+|---|---|---|
+| `ApolloGetListsAction` | Every label with its kind (`accounts`/`contacts`) and cached member count. Run this first — every other action addresses lists by exact name | MASTER |
+| `ApolloCreateListAction` | Create a list, idempotently. A same-named label is returned as-is with `AlreadyExisted: true` | MASTER |
+| `ApolloGetListAccountsAction` | One page of a list's accounts, with each one's current label names | MASTER |
+| `ApolloGetListContactsAction` | One page of a list's contacts, same shape | MASTER |
+| `ApolloSearchPeopleAction` | Search Apollo's people database by organization, title and seniority. At least one filter is required | scoped is fine |
+| `ApolloMoveListAccountsAction` | Move accounts between lists, preserving every other membership | MASTER |
+| `ApolloMoveListContactsAction` | The same for contacts | MASTER |
+
+### The five Apollo behaviours these encode
+
+These are the load-bearing part. They are documented in full on `src/generic/apollo-lists.types.ts` and referenced by number throughout the client.
+
+1. **A PATCH replaces the whole `label_names` array.** There is no add-one-label call, so a move is *two* writes, each carrying the complete intended set: first `current ∪ {toList}`, then `(current ∪ {toList}) \ {fromList}`. Writing a bare `['Warm']` would silently delete every other list the record was on — and nothing in the response would say so. This is why the move actions re-read the source list for current labels and only accept ids from the caller, never labels.
+2. **Roughly 15–17% of removes return success without applying.** Removes are therefore verified by re-reading the destination list, and a record still carrying the source label is reported as `possiblyStuck` — never auto-retried, because an immediate retry flakes the same way. The next page-1 drain sees it carrying both labels and finishes the job. A possibly-stuck record is **not** a failure: the write succeeded and Apollo did not honour it.
+3. **A list drain always reads page 1.** Removing records shifts every later page, so advancing to page 2 skips records. Paging therefore defaults to page 1 rather than to "wherever you left off".
+4. **Label reads and every write need a MASTER API key.** A scoped key authenticates fine and then 403s, which is indistinguishable from a wrong key — so the client rewrites that 403 into a message naming the requirement.
+5. **Labels are read as `label_ids` but written as `label_names`.** The client fetches the label list once per instance and resolves ids to names on every read. An id with no matching label is dropped rather than passed through, since a raw id inside a `label_names` write would create a label named after a hex string.
+
+### Credentials
+
+Two paths, in order:
+
+1. A `CompanyID` param → that company's active `Apollo` **MJ: Company Integrations** row → its `CredentialID` → the `apiKey` inside **MJ: Credentials** `Values`. This is the multi-tenant path.
+2. `APOLLO_API_KEY` from the environment, which is what the enrichment actions have always used. Single-tenant deployments keep working with no credential rows.
+
+Every action reports which path supplied its key as a `KeySource` output.
+
+`CompanyIntegration.APIKey` is deliberately **not** read. That column is not a decrypt-on-read field, so a key written through metadata sync comes back as the literal ciphertext string `$ENC$…`; sending that to Apollo produces a 401 that looks exactly like a wrong key. `MJ: Credentials` is the field that decrypts, so it is the only one used. A credential that exists but whose `Values` will not parse fails with `CONFIGURATION_ERROR` rather than falling back to the environment — a broken credential should not silently borrow another workspace's key.
+
+### A typical drain
+
+```typescript
+// 1. See the real label names.
+await engine.RunAction({ Action: getLists, Params: [], ContextUser: contextUser });
+
+// 2. Read page 1 of the source list — this is where current label names come from.
+const page = await engine.RunAction({
+    Action: getListAccounts,
+    Params: [{ Name: 'ListName', Value: 'Cold Outreach', Type: 'Input' }],
+    ContextUser: contextUser
+});
+
+// 3. Move by id. The action re-reads page 1 itself, so the labels it writes are
+//    never the ones you read above going stale in between.
+await engine.RunAction({
+    Action: moveListAccounts,
+    Params: [
+        { Name: 'AccountIDs', Value: ['5f2a…', '5f2b…'], Type: 'Input' },
+        { Name: 'FromList', Value: 'Cold Outreach', Type: 'Input' },
+        { Name: 'ToList', Value: 'Engaged', Type: 'Input' }
+    ],
+    ContextUser: contextUser
+});
+```
+
+Every list param (`AccountIDs`, `Titles`, `Seniorities`, …) accepts a real array, a JSON array string, or a comma-separated string, because these actions get called from an agent input mapping, from an LLM writing params, and from a human typing in a UI. Genuinely malformed input still fails loudly rather than becoming an empty filter — on a people search that is the difference between a scoped query and an unscoped firehose.
+
+### Additional endpoints
+
+| Endpoint | HTTP Method | Purpose |
+|---|---|---|
+| `/labels` | GET / POST | List and create labels (MASTER) |
+| `/accounts/search` | POST | Saved accounts, filtered by `account_label_ids` |
+| `/contacts/search` | POST | Saved contacts, filtered by `contact_label_ids` |
+| `/mixed_people/api_search` | POST | Prospecting people search — no emails or phones by design |
+| `/accounts/{id}` | PATCH | Replace one account's label set (MASTER) |
+| `/contacts/{id}` | PATCH | Replace one contact's label set (MASTER) |
+
+There is no delete surface. The only writes are label-array replacements and label creation.
 
 ## API Reference
 

--- a/packages/Actions/ApolloEnrichment/src/__tests__/apollo-lists.test.ts
+++ b/packages/Actions/ApolloEnrichment/src/__tests__/apollo-lists.test.ts
@@ -1,0 +1,1173 @@
+/**
+ * Tests for the Apollo list, search and move surface.
+ *
+ * Two levels:
+ *
+ *   - The client is driven through a fake `fetch`, so the request bodies Apollo
+ *     would receive are asserted directly. That matters more here than usual,
+ *     because the dangerous behaviours are all about what is IN the request: a
+ *     move that sends the wrong label array silently deletes memberships, and
+ *     nothing about the response would reveal it.
+ *   - The actions are driven with a fake client, so validation, list resolution
+ *     and result shaping are exercised without a transport.
+ *
+ * Nothing here may reach api.apollo.io. A real call would spend credits on the
+ * read side and mutate a real account's lists on the write side, with no undo.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// The only BaseAction behaviour these tests need is that Run() delegates to
+// InternalRunAction; the real one drags in the whole actions engine.
+vi.mock('@memberjunction/actions', () => ({
+    BaseAction: class BaseAction {
+        public async Run(params: unknown): Promise<unknown> {
+            return (this as unknown as { InternalRunAction(p: unknown): Promise<unknown> }).InternalRunAction(params);
+        }
+        protected async InternalRunAction(): Promise<unknown> {
+            return {};
+        }
+    },
+}));
+
+vi.mock('@memberjunction/global', () => ({
+    RegisterClass: () => (target: unknown) => target,
+}));
+
+vi.mock('@memberjunction/core', () => ({
+    LogError: vi.fn(),
+    LogStatus: vi.fn(),
+    Metadata: class Metadata {
+        async GetEntityObject(): Promise<unknown> {
+            throw new Error('Metadata should not be reached in these tests');
+        }
+    },
+    RunView: class RunView {
+        async RunView(): Promise<unknown> {
+            throw new Error('RunView should not be reached in these tests');
+        }
+    },
+}));
+
+// config.ts reads APOLLO_API_KEY at module load, so it has to be set before the
+// imports below rather than in a beforeEach.
+process.env.APOLLO_API_KEY = 'env-key';
+
+const { ApolloRESTClient } = await import('../lists/ApolloRESTClient.js');
+const { extractApolloKey } = await import('../lists/credentials.js');
+const {
+    getParam,
+    getParamRaw,
+    parseOptionalBooleanParam,
+    parseOptionalIntegerParam,
+    parseStringArrayParam,
+} = await import('../lists/params.js');
+const { ApolloGetListsAction, ApolloCreateListAction } = await import('../lists/ApolloListActions.js');
+const { ApolloGetListAccountsAction, ApolloGetListContactsAction, ApolloSearchPeopleAction } = await import(
+    '../lists/ApolloSearchActions.js'
+);
+const { ApolloMoveListAccountsAction, ApolloMoveListContactsAction } = await import('../lists/ApolloMoveActions.js');
+
+import type { ActionResultSimple, RunActionParams } from '@memberjunction/actions-base';
+import type {
+    ApolloAccount,
+    ApolloAccountsPage,
+    ApolloContact,
+    ApolloContactsPage,
+    ApolloLabel,
+    ApolloMoveResult,
+    ApolloPeoplePage,
+    IApolloRESTClient,
+} from '../generic/apollo-lists.types.js';
+
+// ── Transport fake ────────────────────────────────────────────────────────────
+
+interface Call {
+    url: string;
+    method: string;
+    headers: Record<string, string>;
+    body: Record<string, unknown> | null;
+}
+
+/** A canned reply. `status` defaults to 200. */
+interface Reply {
+    status?: number;
+    body?: unknown;
+    /** Raw text instead of JSON, for the non-JSON-body case. */
+    text?: string;
+}
+
+function fakeFetch(replies: Reply[] | ((call: Call, index: number) => Reply)): {
+    fetchImpl: typeof fetch;
+    calls: Call[];
+} {
+    const calls: Call[] = [];
+    const fetchImpl = (async (url: string, init: RequestInit) => {
+        const call: Call = {
+            url,
+            method: String(init.method),
+            headers: init.headers as Record<string, string>,
+            body: init.body ? (JSON.parse(String(init.body)) as Record<string, unknown>) : null,
+        };
+        calls.push(call);
+        const reply = typeof replies === 'function' ? replies(call, calls.length - 1) : replies[calls.length - 1];
+        if (!reply) throw new Error(`fakeFetch: no reply configured for call ${calls.length} (${call.method} ${call.url})`);
+        const status = reply.status ?? 200;
+        return {
+            ok: status >= 200 && status < 300,
+            status,
+            json: async () => {
+                if (reply.text !== undefined) throw new Error('Unexpected end of JSON input');
+                return reply.body;
+            },
+            text: async () => (reply.text !== undefined ? reply.text : JSON.stringify(reply.body)),
+        };
+    }) as unknown as typeof fetch;
+    return { fetchImpl, calls };
+}
+
+const LABELS_BODY = {
+    labels: [
+        { id: 'lab-cold', name: 'Cold', modality: 'accounts', cached_count: 40, created_at: 'c1', updated_at: 'u1' },
+        { id: 'lab-warm', name: 'Warm', modality: 'accounts', cached_count: 3, created_at: 'c2', updated_at: 'u2' },
+        { id: 'lab-keep', name: 'Do Not Touch', modality: 'accounts', cached_count: 9, created_at: 'c3', updated_at: 'u3' },
+        { id: 'lab-people', name: 'Qualified People', modality: 'contacts', cached_count: 12, created_at: 'c4', updated_at: 'u4' },
+    ],
+};
+
+function client(replies: Reply[] | ((call: Call, index: number) => Reply)) {
+    const { fetchImpl, calls } = fakeFetch(replies);
+    return { c: new ApolloRESTClient('key-1', { fetchImpl }), calls };
+}
+
+// ── Client: transport ─────────────────────────────────────────────────────────
+
+describe('ApolloRESTClient transport', () => {
+    it('sends the key as X-Api-Key against the /api/v1 base path', async () => {
+        const { c, calls } = client([{ body: LABELS_BODY }]);
+        await c.listLabels();
+        expect(calls[0].url).toBe('https://api.apollo.io/api/v1/labels');
+        expect(calls[0].headers['X-Api-Key']).toBe('key-1');
+    });
+
+    it('refuses to construct without a key', () => {
+        expect(() => new ApolloRESTClient('')).toThrow(/apiKey is required/);
+        expect(() => new ApolloRESTClient('   ')).toThrow(/apiKey is required/);
+    });
+
+    it('explains that a 403 on a label read means a scoped key, not a wrong one', async () => {
+        const { c } = client([{ status: 403, body: { error: 'Need master api key' } }]);
+        await expect(c.listLabels()).rejects.toThrow(/requires a MASTER Apollo API key/);
+    });
+
+    it('reports a plain failure with its status and Apollo detail', async () => {
+        const { c } = client([{ status: 422, body: { error: 'Please enter a non-empty modality!' } }]);
+        await expect(c.createLabel('X')).rejects.toThrow(/HTTP 422 — Please enter a non-empty modality!/);
+    });
+
+    it('surfaces a body that is not JSON rather than reporting an empty response', async () => {
+        const { c } = client([{ text: '<html>gateway timeout</html>' }]);
+        await expect(c.listLabels()).rejects.toThrow(/non-JSON body/);
+    });
+
+    it('keeps the raw body text when an error response is not JSON either', async () => {
+        const { c } = client([{ status: 502, text: 'upstream connect error' }]);
+        await expect(c.listLabels()).rejects.toThrow(/HTTP 502 — upstream connect error/);
+    });
+});
+
+// ── Client: labels ────────────────────────────────────────────────────────────
+
+describe('ApolloRESTClient labels', () => {
+    it('reads the enveloped and the bare array shape alike', async () => {
+        const enveloped = client([{ body: LABELS_BODY }]);
+        expect((await enveloped.c.listLabels())).toHaveLength(4);
+
+        const bare = client([{ body: LABELS_BODY.labels }]);
+        expect((await bare.c.listLabels())).toHaveLength(4);
+    });
+
+    it('surfaces Apollo modality as kind', async () => {
+        const { c } = client([{ body: LABELS_BODY }]);
+        const labels = await c.listLabels();
+        expect(labels[0]).toEqual({
+            id: 'lab-cold',
+            name: 'Cold',
+            kind: 'accounts',
+            cachedCount: 40,
+            createdAt: 'c1',
+            updatedAt: 'u1',
+        });
+    });
+
+    it('rejects a response that is neither an array nor an envelope', async () => {
+        const { c } = client([{ body: { data: 'nope' } }]);
+        await expect(c.listLabels()).rejects.toThrow(/unexpected response shape/);
+    });
+
+    it('sends the modality Apollo requires on create', async () => {
+        const { c, calls } = client([{ body: { id: 'lab-new', name: 'Fresh', modality: 'contacts' } }]);
+        await c.createLabel('Fresh');
+        expect(calls[0].method).toBe('POST');
+        expect(calls[0].body).toEqual({ name: 'Fresh', modality: 'contacts' });
+    });
+
+    it('creates an accounts label when asked', async () => {
+        const { c, calls } = client([{ body: { id: 'lab-new', name: 'Fresh', modality: 'accounts' } }]);
+        const created = await c.createLabel('Fresh', 'accounts');
+        expect(calls[0].body?.modality).toBe('accounts');
+        expect(created.kind).toBe('accounts');
+    });
+
+    it('accepts every create response shape Apollo has been seen to use', async () => {
+        for (const body of [
+            { id: 'lab-new', name: 'Fresh' },
+            { label: { id: 'lab-new', name: 'Fresh' } },
+            { labels: [{ id: 'lab-new', name: 'Fresh' }] },
+        ]) {
+            const { c } = client([{ body }]);
+            expect((await c.createLabel('Fresh')).id).toBe('lab-new');
+        }
+    });
+
+    it('refuses a create response with no id rather than returning a label that does not exist', async () => {
+        // An empty id would be written into a later label_names array as ''.
+        const { c } = client([{ body: { name: 'Fresh' } }]);
+        await expect(c.createLabel('Fresh')).rejects.toThrow(/carried no label id/);
+    });
+
+    it('requires a name to create or to look up', async () => {
+        const { c } = client([]);
+        await expect(c.createLabel('   ')).rejects.toThrow(/name is required/);
+        await expect(c.findLabelByName('  ')).rejects.toThrow(/name is required/);
+    });
+
+    it('matches a label name case-insensitively and returns null for no match', async () => {
+        const found = client([{ body: LABELS_BODY }]);
+        expect((await found.c.findLabelByName('  cOLD '))?.id).toBe('lab-cold');
+
+        const missing = client([{ body: LABELS_BODY }]);
+        expect(await missing.c.findLabelByName('Nonexistent')).toBeNull();
+    });
+});
+
+// ── Client: searches ──────────────────────────────────────────────────────────
+
+describe('ApolloRESTClient searches', () => {
+    const accountsBody = {
+        accounts: [
+            { id: 'acc-1', name: 'Acme', primary_domain: 'acme.com', label_ids: ['lab-cold', 'lab-keep'] },
+            { id: 'acc-2', name: 'Globex', primary_domain: 'globex.com', label_ids: ['lab-cold'] },
+        ],
+        pagination: { page: 1, per_page: 100, total_entries: 2, total_pages: 1 },
+    };
+
+    it('resolves the label ids the search returns into the names a move needs', async () => {
+        // The search payload carries no label_names at all — without this resolution
+        // the move math would have nothing to preserve.
+        const { c } = client([{ body: LABELS_BODY }, { body: accountsBody }]);
+        const page = await c.searchAccounts({ labelIds: ['lab-cold'] });
+        expect(page.accounts[0].labelIds).toEqual(['lab-cold', 'lab-keep']);
+        expect(page.accounts[0].labelNames).toEqual(['Cold', 'Do Not Touch']);
+    });
+
+    it('drops a label id with no matching label instead of passing it through as a name', async () => {
+        // A raw id inside a later label_names write would create a label named after a hex string.
+        const body = {
+            accounts: [{ id: 'acc-1', name: 'Acme', label_ids: ['lab-cold', 'lab-deleted'] }],
+            pagination: {},
+        };
+        const { c } = client([{ body: LABELS_BODY }, { body }]);
+        const page = await c.searchAccounts({});
+        expect(page.accounts[0].labelNames).toEqual(['Cold']);
+        expect(page.accounts[0].labelIds).toContain('lab-deleted');
+    });
+
+    it('fetches the labels once and reuses them across searches', async () => {
+        const { c, calls } = client([{ body: LABELS_BODY }, { body: accountsBody }, { body: accountsBody }]);
+        await c.searchAccounts({});
+        await c.searchAccounts({});
+        expect(calls.filter((call) => call.url.endsWith('/labels'))).toHaveLength(1);
+    });
+
+    it('maps the account filter onto Apollo field names', async () => {
+        const { c, calls } = client([{ body: LABELS_BODY }, { body: accountsBody }]);
+        await c.searchAccounts({ labelIds: ['lab-cold'], keywords: 'assoc' });
+        expect(calls[1].url).toBe('https://api.apollo.io/api/v1/accounts/search');
+        expect(calls[1].body).toEqual({
+            page: 1,
+            per_page: 100,
+            account_label_ids: ['lab-cold'],
+            q_organization_name: 'assoc',
+        });
+    });
+
+    it('maps the contact filter onto its own differently-named keyword field', async () => {
+        const body = { contacts: [], pagination: {} };
+        const { c, calls } = client([{ body: LABELS_BODY }, { body }]);
+        await c.searchContacts({ labelIds: ['lab-people'], keywords: 'director' });
+        expect(calls[1].body).toEqual({
+            page: 1,
+            per_page: 100,
+            contact_label_ids: ['lab-people'],
+            q_keywords: 'director',
+        });
+    });
+
+    it('omits filters that were not supplied rather than sending empty arrays', async () => {
+        const { c, calls } = client([{ body: LABELS_BODY }, { body: accountsBody }]);
+        await c.searchAccounts({ labelIds: [], keywords: '' });
+        expect(calls[1].body).toEqual({ page: 1, per_page: 100 });
+    });
+
+    it('defaults to page 1, which is what makes a drain correct', async () => {
+        const { c, calls } = client([{ body: LABELS_BODY }, { body: accountsBody }]);
+        await c.searchAccounts({});
+        expect(calls[1].body?.page).toBe(1);
+    });
+
+    it("clamps paging into Apollo's bounds", async () => {
+        const { c, calls } = client([{ body: LABELS_BODY }, { body: accountsBody }, { body: accountsBody }]);
+        await c.searchAccounts({}, { page: 9999, perPage: 9999 });
+        expect(calls[1].body).toMatchObject({ page: 500, per_page: 100 });
+        await c.searchAccounts({}, { page: 0, perPage: 0 });
+        expect(calls[2].body).toMatchObject({ page: 1, per_page: 1 });
+    });
+
+    it('reads the pagination envelope', async () => {
+        const { c } = client([{ body: LABELS_BODY }, { body: accountsBody }]);
+        const page = await c.searchAccounts({});
+        expect(page.pagination).toEqual({ page: 1, perPage: 100, totalEntries: 2, totalPages: 1 });
+    });
+
+    it('defaults a missing pagination envelope rather than failing the page', async () => {
+        const { c } = client([{ body: LABELS_BODY }, { body: { accounts: [] } }]);
+        expect((await c.searchAccounts({})).pagination).toEqual({ page: 1, perPage: 0, totalEntries: 0, totalPages: 0 });
+    });
+
+    it('accepts accounts under the organizations key too', async () => {
+        const body = { organizations: [{ id: 'acc-9', name: 'Initech' }], pagination: {} };
+        const { c } = client([{ body: LABELS_BODY }, { body }]);
+        expect((await c.searchAccounts({})).accounts[0].id).toBe('acc-9');
+    });
+
+    it('reads a contact employer from either the flat or the nested field', async () => {
+        const body = {
+            contacts: [
+                { id: 'con-1', first_name: 'A', last_name: 'B', organization_name: 'Flat Co' },
+                { id: 'con-2', first_name: 'C', last_name: 'D', organization: { name: 'Nested Co' } },
+            ],
+            pagination: {},
+        };
+        const { c } = client([{ body: LABELS_BODY }, { body }]);
+        const page = await c.searchContacts({});
+        expect(page.contacts.map((x) => x.organizationName)).toEqual(['Flat Co', 'Nested Co']);
+    });
+
+    it('maps the people filter onto its four Apollo fields', async () => {
+        const body = { people: [], pagination: {} };
+        const { c, calls } = client([{ body }]);
+        await c.searchPeople({
+            organizationDomains: ['acme.com'],
+            organizationIds: ['org-1'],
+            titles: ['VP of Marketing'],
+            seniorities: ['vp'],
+        });
+        expect(calls[0].url).toBe('https://api.apollo.io/api/v1/mixed_people/api_search');
+        expect(calls[0].body).toEqual({
+            page: 1,
+            per_page: 100,
+            q_organization_domains_list: ['acme.com'],
+            organization_ids: ['org-1'],
+            person_titles: ['VP of Marketing'],
+            person_seniorities: ['vp'],
+        });
+    });
+
+    it('does not spend a master-key labels call on a prospecting search', async () => {
+        // The prospecting response carries no memberships, so there is nothing to resolve.
+        const { c, calls } = client([{ body: { people: [], pagination: {} } }]);
+        await c.searchPeople({ titles: ['CEO'] });
+        expect(calls).toHaveLength(1);
+        expect(calls[0].url).not.toContain('/labels');
+    });
+
+    it('accepts people under the legacy contacts key', async () => {
+        const body = { contacts: [{ id: 'p-1', first_name: 'E', organization: { id: 'org-2', name: 'Umbrella' } }], pagination: {} };
+        const { c } = client([{ body }]);
+        const page = await c.searchPeople({ titles: ['CEO'] });
+        expect(page.people[0].organizationId).toBe('org-2');
+        expect(page.people[0].organizationName).toBe('Umbrella');
+    });
+
+    it('reports a null organization id rather than an empty string when absent', async () => {
+        const { c } = client([{ body: { people: [{ id: 'p-1' }], pagination: {} } }]);
+        expect((await c.searchPeople({ titles: ['CEO'] })).people[0].organizationId).toBeNull();
+    });
+
+    it('rejects a search response that is not an object', async () => {
+        const { c } = client([{ body: LABELS_BODY }, { body: [] }]);
+        await expect(c.searchAccounts({})).rejects.toThrow(/unexpected response shape/);
+    });
+});
+
+// ── Client: moves ─────────────────────────────────────────────────────────────
+
+describe('ApolloRESTClient moves', () => {
+    const acme: ApolloAccount = {
+        id: 'acc-1',
+        name: 'Acme',
+        primaryDomain: 'acme.com',
+        labelIds: ['lab-cold', 'lab-keep'],
+        labelNames: ['Cold', 'Do Not Touch'],
+    };
+
+    /**
+     * Replies for a move with verify: labels (for the destination id) → PATCH →
+     * PATCH → labels + destination-list search.
+     *
+     * `verifyLabels` is the record's label_ids as the verify read finds them, or
+     * `null` for "the record is not on the destination page at all" — a genuinely
+     * different case from "on the page with no labels".
+     */
+    function moveReplies(verifyLabels: string[] | null): (call: Call) => Reply {
+        return (call) => {
+            if (call.url.endsWith('/labels')) return { body: LABELS_BODY };
+            if (call.method === 'PATCH') return { body: { account: { id: 'acc-1' } } };
+            return {
+                body: {
+                    accounts: verifyLabels === null ? [] : [{ id: 'acc-1', name: 'Acme', label_ids: verifyLabels }],
+                    pagination: {},
+                },
+            };
+        };
+    }
+
+    it('preserves every other membership on both writes', async () => {
+        // This is the whole point of the two-step: Apollo replaces the array, so a
+        // bare ['Warm'] would silently drop 'Do Not Touch'.
+        const { c, calls } = client(moveReplies(['lab-warm', 'lab-keep']));
+        await c.moveAccounts([acme], 'Cold', 'Warm', { verify: true });
+
+        const patches = calls.filter((x) => x.method === 'PATCH');
+        expect(patches).toHaveLength(2);
+        expect(patches[0].body).toEqual({ label_names: ['Cold', 'Do Not Touch', 'Warm'] });
+        expect(patches[1].body).toEqual({ label_names: ['Do Not Touch', 'Warm'] });
+    });
+
+    it('keeps the destination label on the remove write', async () => {
+        // Computing the remove set from the pre-add state would add then immediately un-add.
+        const { c, calls } = client(moveReplies(['lab-warm', 'lab-keep']));
+        await c.moveAccounts([acme], 'Cold', 'Warm', { verify: true });
+        expect(calls.filter((x) => x.method === 'PATCH')[1].body?.label_names).toContain('Warm');
+    });
+
+    it('patches the record by id on the account path', async () => {
+        const { c, calls } = client(moveReplies(['lab-warm']));
+        await c.moveAccounts([acme], 'Cold', 'Warm', { verify: true });
+        expect(calls.find((x) => x.method === 'PATCH')?.url).toBe('https://api.apollo.io/api/v1/accounts/acc-1');
+    });
+
+    it('flags a record whose source label survived the remove', async () => {
+        const { c } = client(moveReplies(['lab-cold', 'lab-warm']));
+        const result = await c.moveAccounts([acme], 'Cold', 'Warm', { verify: true });
+        expect(result.possiblyStuckCount).toBe(1);
+        expect(result.movedCount).toBe(0);
+        expect(result.items[0]).toMatchObject({ added: true, removed: true, possiblyStuck: true, error: null });
+    });
+
+    it('does not retry a stuck record', async () => {
+        // An immediate retry flakes the same way; the next drain pass cleans it up.
+        const { c, calls } = client(moveReplies(['lab-cold', 'lab-warm']));
+        await c.moveAccounts([acme], 'Cold', 'Warm', { verify: true });
+        expect(calls.filter((x) => x.method === 'PATCH')).toHaveLength(2);
+    });
+
+    it('counts a clean move once the verify read confirms the source is gone', async () => {
+        const { c } = client(moveReplies(['lab-warm', 'lab-keep']));
+        const result = await c.moveAccounts([acme], 'Cold', 'Warm', { verify: true });
+        expect(result).toMatchObject({ movedCount: 1, failedCount: 0, possiblyStuckCount: 0 });
+        expect(result.items[0].possiblyStuck).toBe(false);
+    });
+
+    it('leaves the stuck state unknown when the record is not on the destination page', async () => {
+        // Absent from page 1 is not evidence the remove worked, so it must not be
+        // reported as verified-clean.
+        const { c } = client(moveReplies(null));
+        const result = await c.moveAccounts([acme], 'Cold', 'Warm', { verify: true });
+        expect(result.items[0].possiblyStuck).toBeNull();
+        expect(result.movedCount).toBe(1);
+    });
+
+    it('reports not-stuck only when it actually read the record back', async () => {
+        // On the page, source label gone — the one case that is genuinely verified.
+        const { c } = client(moveReplies(['lab-warm']));
+        const result = await c.moveAccounts([acme], 'Cold', 'Warm', { verify: true });
+        expect(result.items[0].possiblyStuck).toBe(false);
+    });
+
+    it('skips the verify read, and the label lookup it needs, when not asked to verify', async () => {
+        const { c, calls } = client((call) => (call.method === 'PATCH' ? { body: {} } : { body: LABELS_BODY }));
+        const result = await c.moveAccounts([acme], 'Cold', 'Warm');
+        expect(calls.filter((x) => x.method !== 'PATCH')).toHaveLength(0);
+        expect(result.items[0].possiblyStuck).toBeNull();
+        expect(result.movedCount).toBe(1);
+    });
+
+    it('never removes the source label when the add failed', async () => {
+        // Otherwise the record leaves the source list without reaching the destination.
+        let patches = 0;
+        const { c, calls } = client((call) => {
+            if (call.url.endsWith('/labels')) return { body: LABELS_BODY };
+            patches++;
+            return { status: 500, body: { error: 'boom' } };
+        });
+        const result = await c.moveAccounts([acme], 'Cold', 'Warm', { verify: true });
+        expect(patches).toBe(1);
+        expect(calls.filter((x) => x.method === 'PATCH')).toHaveLength(1);
+        expect(result).toMatchObject({ failedCount: 1, movedCount: 0 });
+        expect(result.items[0]).toMatchObject({ added: false, removed: false });
+        expect(result.items[0].error).toMatch(/^add phase:/);
+    });
+
+    it('reports a failed remove distinctly, since the record is now in both lists', async () => {
+        let seen = 0;
+        const { c } = client((call) => {
+            if (call.url.endsWith('/labels')) return { body: LABELS_BODY };
+            seen++;
+            return seen === 1 ? { body: {} } : { status: 500, body: { error: 'boom' } };
+        });
+        const result = await c.moveAccounts([acme], 'Cold', 'Warm', { verify: true });
+        expect(result.items[0]).toMatchObject({ added: true, removed: false });
+        expect(result.items[0].error).toMatch(/^remove phase:/);
+        expect(result.failedCount).toBe(1);
+    });
+
+    it('does not fail a move because the verify read failed', async () => {
+        let seen = 0;
+        const { c } = client((call) => {
+            if (call.url.endsWith('/labels')) return { body: LABELS_BODY };
+            if (call.method === 'PATCH') return { body: {} };
+            seen++;
+            return { status: 500, body: { error: 'search down' } };
+        });
+        const result = await c.moveAccounts([acme], 'Cold', 'Warm', { verify: true });
+        expect(seen).toBe(1);
+        expect(result).toMatchObject({ movedCount: 1, failedCount: 0 });
+        expect(result.items[0].possiblyStuck).toBeNull();
+    });
+
+    it('adds the destination idempotently when the record already carries it', async () => {
+        const both: ApolloAccount = { ...acme, labelNames: ['Cold', 'Warm'] };
+        const { c, calls } = client(moveReplies(['lab-warm']));
+        await c.moveAccounts([both], 'Cold', 'Warm', { verify: true });
+        const patches = calls.filter((x) => x.method === 'PATCH');
+        expect(patches[0].body).toEqual({ label_names: ['Cold', 'Warm'] });
+        expect(patches[1].body).toEqual({ label_names: ['Warm'] });
+    });
+
+    it('refuses a move to the same list, and a move with a blank list name', async () => {
+        const { c } = client([]);
+        await expect(c.moveAccounts([acme], 'Cold', 'Cold')).rejects.toThrow(/identical/);
+        await expect(c.moveAccounts([acme], '  ', 'Warm')).rejects.toThrow(/both required/);
+    });
+
+    it('returns an empty result for an empty batch without touching Apollo', async () => {
+        const { c, calls } = client([]);
+        const result = await c.moveAccounts([], 'Cold', 'Warm');
+        expect(result).toEqual({ movedCount: 0, failedCount: 0, possiblyStuckCount: 0, items: [] });
+        expect(calls).toHaveLength(0);
+    });
+
+    it('patches contacts on the contact path with the same label math', async () => {
+        const contact: ApolloContact = {
+            id: 'con-1',
+            firstName: 'A',
+            lastName: 'B',
+            name: 'A B',
+            title: 'VP',
+            email: 'a@b.com',
+            organizationName: 'Acme',
+            labelIds: ['lab-people'],
+            labelNames: ['Qualified People'],
+        };
+        const { c, calls } = client((call) => {
+            if (call.url.endsWith('/labels')) return { body: LABELS_BODY };
+            if (call.method === 'PATCH') return { body: {} };
+            return { body: { contacts: [{ id: 'con-1', label_ids: ['lab-warm'] }], pagination: {} } };
+        });
+        const result = await c.moveContacts([contact], 'Qualified People', 'Warm', { verify: true });
+        const patches = calls.filter((x) => x.method === 'PATCH');
+        expect(patches[0].url).toBe('https://api.apollo.io/api/v1/contacts/con-1');
+        expect(patches[0].body).toEqual({ label_names: ['Qualified People', 'Warm'] });
+        expect(patches[1].body).toEqual({ label_names: ['Warm'] });
+        expect(result.movedCount).toBe(1);
+    });
+
+    it('processes a batch in order, and one failed record does not stop the rest', async () => {
+        const globex: ApolloAccount = { ...acme, id: 'acc-2', labelNames: ['Cold'] };
+        const { c } = client((call) => {
+            if (call.url.endsWith('/labels')) return { body: LABELS_BODY };
+            if (call.method === 'PATCH') {
+                return call.url.endsWith('acc-1') ? { status: 500, body: { error: 'boom' } } : { body: {} };
+            }
+            return { body: { accounts: [{ id: 'acc-2', label_ids: ['lab-warm'] }], pagination: {} } };
+        });
+        const result = await c.moveAccounts([acme, globex], 'Cold', 'Warm', { verify: true });
+        expect(result).toMatchObject({ failedCount: 1, movedCount: 1 });
+        expect(result.items.map((i) => i.id)).toEqual(['acc-1', 'acc-2']);
+    });
+});
+
+// ── Params ────────────────────────────────────────────────────────────────────
+
+describe('param parsing', () => {
+    const withParams = (list: Array<{ Name: string; Value: unknown }>) =>
+        ({ Params: list } as unknown as Parameters<typeof getParam>[0]);
+
+    it('finds a param case-insensitively and trims it', () => {
+        expect(getParam(withParams([{ Name: 'listname', Value: '  Cold  ' }]), 'ListName')).toBe('Cold');
+    });
+
+    it('treats whitespace as absent, so a required check catches a blank list name', () => {
+        expect(getParam(withParams([{ Name: 'ListName', Value: '   ' }]), 'ListName')).toBeNull();
+        expect(getParam(withParams([]), 'ListName')).toBeNull();
+    });
+
+    it('returns a raw value untouched, for the array/JSON/CSV parsers', () => {
+        expect(getParamRaw(withParams([{ Name: 'Titles', Value: ['CEO'] }]), 'Titles')).toEqual(['CEO']);
+    });
+
+    it('accepts a list as an array, a JSON string, or a comma-separated string', () => {
+        expect(parseStringArrayParam(['CEO', 'CTO'], 'Titles').value).toEqual(['CEO', 'CTO']);
+        expect(parseStringArrayParam('["CEO","CTO"]', 'Titles').value).toEqual(['CEO', 'CTO']);
+        expect(parseStringArrayParam(' owner , founder ', 'Seniorities').value).toEqual(['owner', 'founder']);
+    });
+
+    it('treats an absent or empty list as unsupplied rather than as an empty filter', () => {
+        for (const raw of [null, undefined, '', '  ,  ', []]) {
+            expect(parseStringArrayParam(raw, 'Titles')).toEqual({ value: undefined, error: null });
+        }
+    });
+
+    it('reports a malformed JSON array instead of silently dropping the filter', () => {
+        expect(parseStringArrayParam('["CEO"', 'Titles').error).toMatch(/unparseable/);
+        expect(parseStringArrayParam([1, 2], 'Titles').error).toMatch(/JSON array of strings/);
+    });
+
+    it('parses an integer from a number or a numeric string, and enforces the range', () => {
+        expect(parseOptionalIntegerParam(5, 'Page', { min: 1, max: 500 }).value).toBe(5);
+        expect(parseOptionalIntegerParam(' 5 ', 'Page').value).toBe(5);
+        expect(parseOptionalIntegerParam(0, 'Page', { min: 1 }).error).toMatch(/>= 1/);
+        expect(parseOptionalIntegerParam(501, 'Page', { max: 500 }).error).toMatch(/<= 500/);
+    });
+
+    it('rejects a fractional page rather than rounding it into a plausible wrong answer', () => {
+        expect(parseOptionalIntegerParam(1.5, 'Page').error).toMatch(/must be an integer/);
+        expect(parseOptionalIntegerParam('abc', 'Page').error).toMatch(/must be an integer/);
+    });
+
+    it("does not treat the string 'false' as true", () => {
+        expect(parseOptionalBooleanParam('false', 'Verify').value).toBe(false);
+        expect(parseOptionalBooleanParam('TRUE', 'Verify').value).toBe(true);
+        expect(parseOptionalBooleanParam(false, 'Verify').value).toBe(false);
+        expect(parseOptionalBooleanParam('yes', 'Verify').error).toMatch(/must be a boolean/);
+    });
+});
+
+// ── Credentials ───────────────────────────────────────────────────────────────
+
+describe('credential parsing', () => {
+    it('accepts the key under any of the casings a hand-authored credential uses', () => {
+        for (const key of ['apiKey', 'APIKey', 'api_key', 'ApiKey', 'masterApiKey']) {
+            expect(extractApolloKey(JSON.stringify({ [key]: 'k-1' }), 'Apollo')).toBe('k-1');
+        }
+    });
+
+    it('trims the key and treats a blank one as absent', () => {
+        expect(extractApolloKey(JSON.stringify({ apiKey: '  k-1 ' }), 'Apollo')).toBe('k-1');
+        expect(extractApolloKey(JSON.stringify({ apiKey: '   ' }), 'Apollo')).toBeNull();
+        expect(extractApolloKey('', 'Apollo')).toBeNull();
+        expect(extractApolloKey(null, 'Apollo')).toBeNull();
+    });
+
+    it('throws on a broken Values payload rather than falling through to another workspace key', () => {
+        expect(() => extractApolloKey('{not json', 'Apollo')).toThrow(/not valid JSON/);
+        expect(() => extractApolloKey('"a string"', 'Apollo')).toThrow(/must be a JSON object/);
+    });
+
+    it('reports no key when the payload holds something unrelated', () => {
+        expect(extractApolloKey(JSON.stringify({ token: 'k-1' }), 'Apollo')).toBeNull();
+    });
+});
+
+// ── Actions ───────────────────────────────────────────────────────────────────
+
+/** A fake client whose every method is a spy; unimplemented ones throw. */
+function fakeClient(overrides: Partial<IApolloRESTClient>): IApolloRESTClient {
+    const notImplemented = (name: string) => async () => {
+        throw new Error(`fakeClient.${name} was not expected to be called`);
+    };
+    return {
+        listLabels: notImplemented('listLabels'),
+        createLabel: notImplemented('createLabel'),
+        findLabelByName: notImplemented('findLabelByName'),
+        searchAccounts: notImplemented('searchAccounts'),
+        searchContacts: notImplemented('searchContacts'),
+        searchPeople: notImplemented('searchPeople'),
+        moveAccounts: notImplemented('moveAccounts'),
+        moveContacts: notImplemented('moveContacts'),
+        ...overrides,
+    } as IApolloRESTClient;
+}
+
+const LABELS: ApolloLabel[] = [
+    { id: 'lab-cold', name: 'Cold', kind: 'accounts', cachedCount: 40, createdAt: '', updatedAt: '' },
+    { id: 'lab-warm', name: 'Warm', kind: 'accounts', cachedCount: 3, createdAt: '', updatedAt: '' },
+];
+
+/**
+ * Run an action against a fake client, with `APOLLO_API_KEY` set so credential
+ * resolution takes the environment path and never touches the database.
+ */
+async function run(
+    ActionClass: new () => { Run(params: RunActionParams): Promise<ActionResultSimple> },
+    inputs: Record<string, unknown>,
+    client: IApolloRESTClient,
+) {
+    const params = {
+        Params: Object.entries(inputs).map(([Name, Value]) => ({ Name, Value, Type: 'Input' })),
+        ContextUser: {},
+    };
+    const action = new ActionClass();
+    // The only seam: substitute the client so no transport is constructed.
+    (action as unknown as { CreateClient: (key: string) => IApolloRESTClient }).CreateClient = () => client;
+    const result = await action.Run(params as unknown as RunActionParams);
+    return { result, params };
+}
+
+/** Read an output param the action pushed. */
+function output(params: { Params: Array<{ Name: string; Value: unknown }> }, name: string): unknown {
+    return params.Params.find((p) => p.Name === name)?.Value;
+}
+
+beforeEach(() => {
+    process.env.APOLLO_API_KEY = 'env-key';
+    vi.resetModules();
+});
+
+describe('ApolloGetListsAction', () => {
+    it('returns the labels and their count', async () => {
+        const { result, params } = await run(ApolloGetListsAction, {}, fakeClient({ listLabels: async () => LABELS }));
+        expect(result.Success).toBe(true);
+        expect(result.ResultCode).toBe('SUCCESS');
+        expect(output(params, 'Count')).toBe(2);
+        expect(output(params, 'Lists')).toEqual(LABELS);
+    });
+
+    it('turns a client failure into a result rather than throwing', async () => {
+        const { result } = await run(
+            ApolloGetListsAction,
+            {},
+            fakeClient({
+                listLabels: async () => {
+                    throw new Error('requires a MASTER Apollo API key');
+                },
+            }),
+        );
+        expect(result.Success).toBe(false);
+        expect(result.ResultCode).toBe('ERROR');
+        expect(result.Message).toMatch(/MASTER Apollo API key/);
+    });
+});
+
+describe('ApolloCreateListAction', () => {
+    it('requires a list name', async () => {
+        const { result } = await run(ApolloCreateListAction, {}, fakeClient({}));
+        expect(result.ResultCode).toBe('MISSING_REQUIRED_FIELDS');
+    });
+
+    it('returns an existing same-named list instead of creating a duplicate', async () => {
+        // Two labels with one name would make every name-based lookup ambiguous.
+        const createLabel = vi.fn();
+        const { result, params } = await run(
+            ApolloCreateListAction,
+            { ListName: '  cold  ' },
+            fakeClient({ listLabels: async () => LABELS, createLabel: createLabel as never }),
+        );
+        expect(result.Success).toBe(true);
+        expect(output(params, 'AlreadyExisted')).toBe(true);
+        expect(output(params, 'ListID')).toBe('lab-cold');
+        expect(createLabel).not.toHaveBeenCalled();
+    });
+
+    it('creates the list when no label matches', async () => {
+        const created: ApolloLabel = { id: 'lab-new', name: 'Fresh', kind: 'contacts', cachedCount: 0, createdAt: '', updatedAt: '' };
+        const createLabel = vi.fn(async () => created);
+        const { result, params } = await run(
+            ApolloCreateListAction,
+            { ListName: 'Fresh' },
+            fakeClient({ listLabels: async () => LABELS, createLabel }),
+        );
+        expect(result.Success).toBe(true);
+        expect(output(params, 'AlreadyExisted')).toBe(false);
+        expect(createLabel).toHaveBeenCalledWith('Fresh', 'contacts');
+    });
+
+    it('passes the requested modality through, and rejects any other value', async () => {
+        const createLabel = vi.fn(async () => LABELS[0]);
+        await run(
+            ApolloCreateListAction,
+            { ListName: 'Fresh', Modality: 'Accounts' },
+            fakeClient({ listLabels: async () => [], createLabel }),
+        );
+        expect(createLabel).toHaveBeenCalledWith('Fresh', 'accounts');
+
+        const { result } = await run(ApolloCreateListAction, { ListName: 'Fresh', Modality: 'people' }, fakeClient({}));
+        expect(result.ResultCode).toBe('VALIDATION_ERROR');
+    });
+});
+
+describe('ApolloGetListAccountsAction', () => {
+    const page: ApolloAccountsPage = {
+        accounts: [{ id: 'acc-1', name: 'Acme', primaryDomain: 'acme.com', labelIds: ['lab-cold'], labelNames: ['Cold'] }],
+        pagination: { page: 1, perPage: 100, totalEntries: 1, totalPages: 1 },
+    };
+
+    it('requires a list name', async () => {
+        const { result } = await run(ApolloGetListAccountsAction, {}, fakeClient({}));
+        expect(result.ResultCode).toBe('MISSING_REQUIRED_FIELDS');
+    });
+
+    it('resolves the list name to an id and filters on it', async () => {
+        const searchAccounts = vi.fn(async () => page);
+        const { result, params } = await run(
+            ApolloGetListAccountsAction,
+            { ListName: 'Cold', Keywords: 'assoc', Page: '2', PerPage: '50' },
+            fakeClient({ findLabelByName: async () => LABELS[0], searchAccounts }),
+        );
+        expect(result.Success).toBe(true);
+        expect(searchAccounts).toHaveBeenCalledWith({ labelIds: ['lab-cold'], keywords: 'assoc' }, { page: 2, perPage: 50 });
+        expect(output(params, 'ListID')).toBe('lab-cold');
+        expect(output(params, 'ResolvedListName')).toBe('Cold');
+        expect(output(params, 'Count')).toBe(1);
+    });
+
+    it('points the caller at Get Lists when the name does not resolve', async () => {
+        const { result } = await run(
+            ApolloGetListAccountsAction,
+            { ListName: 'Typo' },
+            fakeClient({ findLabelByName: async () => null }),
+        );
+        expect(result.ResultCode).toBe('NOT_FOUND');
+        expect(result.Message).toMatch(/Get Lists/);
+    });
+
+    it('rejects bad paging before resolving anything', async () => {
+        const findLabelByName = vi.fn();
+        const { result } = await run(
+            ApolloGetListAccountsAction,
+            { ListName: 'Cold', Page: '0' },
+            fakeClient({ findLabelByName: findLabelByName as never }),
+        );
+        expect(result.ResultCode).toBe('VALIDATION_ERROR');
+        expect(findLabelByName).not.toHaveBeenCalled();
+    });
+
+    it('returns the labels a move will need to preserve', async () => {
+        const { params } = await run(
+            ApolloGetListAccountsAction,
+            { ListName: 'Cold' },
+            fakeClient({ findLabelByName: async () => LABELS[0], searchAccounts: async () => page }),
+        );
+        expect((output(params, 'Accounts') as ApolloAccount[])[0].labelNames).toEqual(['Cold']);
+    });
+});
+
+describe('ApolloGetListContactsAction', () => {
+    const page: ApolloContactsPage = {
+        contacts: [
+            {
+                id: 'con-1',
+                firstName: 'A',
+                lastName: 'B',
+                name: 'A B',
+                title: 'VP',
+                email: 'a@b.com',
+                organizationName: 'Acme',
+                labelIds: ['lab-cold'],
+                labelNames: ['Cold'],
+            },
+        ],
+        pagination: { page: 1, perPage: 100, totalEntries: 1, totalPages: 1 },
+    };
+
+    it('filters contacts on the resolved list id', async () => {
+        const searchContacts = vi.fn(async () => page);
+        const { result, params } = await run(
+            ApolloGetListContactsAction,
+            { ListName: 'Cold', Keywords: 'director' },
+            fakeClient({ findLabelByName: async () => LABELS[0], searchContacts }),
+        );
+        expect(result.Success).toBe(true);
+        expect(searchContacts).toHaveBeenCalledWith({ labelIds: ['lab-cold'], keywords: 'director' }, {});
+        expect(output(params, 'Count')).toBe(1);
+    });
+});
+
+describe('ApolloSearchPeopleAction', () => {
+    const page: ApolloPeoplePage = {
+        people: [
+            { id: 'p-1', firstName: 'A', lastName: 'B', name: 'A B', title: 'VP', linkedinUrl: '', organizationId: 'org-1', organizationName: 'Acme' },
+        ],
+        pagination: { page: 1, perPage: 100, totalEntries: 1, totalPages: 1 },
+    };
+
+    it('refuses an unscoped search rather than burning the rate limit', async () => {
+        const searchPeople = vi.fn();
+        const { result } = await run(ApolloSearchPeopleAction, {}, fakeClient({ searchPeople: searchPeople as never }));
+        expect(result.ResultCode).toBe('VALIDATION_ERROR');
+        expect(result.Message).toMatch(/at least one of/);
+        expect(searchPeople).not.toHaveBeenCalled();
+    });
+
+    it('builds the filter from whichever inputs were supplied', async () => {
+        const searchPeople = vi.fn(async () => page);
+        await run(
+            ApolloSearchPeopleAction,
+            { Titles: 'VP of Marketing, CMO', Seniorities: '["vp"]' },
+            fakeClient({ searchPeople }),
+        );
+        expect(searchPeople).toHaveBeenCalledWith({ titles: ['VP of Marketing', 'CMO'], seniorities: ['vp'] }, {});
+    });
+
+    it('says in the message that emails are not part of this answer', async () => {
+        const { result } = await run(ApolloSearchPeopleAction, { Titles: 'CEO' }, fakeClient({ searchPeople: async () => page }));
+        expect(result.Success).toBe(true);
+        expect(result.Message).toMatch(/Emails and phones are not returned/);
+    });
+
+    it('reports a malformed list input as a validation error', async () => {
+        const { result } = await run(ApolloSearchPeopleAction, { Titles: '["CEO"' }, fakeClient({}));
+        expect(result.ResultCode).toBe('VALIDATION_ERROR');
+    });
+});
+
+describe('ApolloMoveListAccountsAction', () => {
+    const sourcePage: ApolloAccountsPage = {
+        accounts: [
+            { id: 'acc-1', name: 'Acme', primaryDomain: '', labelIds: ['lab-cold'], labelNames: ['Cold', 'Do Not Touch'] },
+            { id: 'acc-2', name: 'Globex', primaryDomain: '', labelIds: ['lab-cold'], labelNames: ['Cold'] },
+        ],
+        pagination: { page: 1, perPage: 100, totalEntries: 2, totalPages: 1 },
+    };
+    const moveResult: ApolloMoveResult = {
+        movedCount: 1,
+        failedCount: 0,
+        possiblyStuckCount: 0,
+        items: [{ id: 'acc-1', added: true, removed: true, possiblyStuck: false, error: null }],
+    };
+
+    function moveClient(overrides: Partial<IApolloRESTClient> = {}) {
+        return fakeClient({
+            findLabelByName: async (name: string) => LABELS.find((l) => l.name === name) ?? null,
+            searchAccounts: async () => sourcePage,
+            moveAccounts: async () => moveResult,
+            ...overrides,
+        });
+    }
+
+    it('requires the ids and both list names', async () => {
+        expect((await run(ApolloMoveListAccountsAction, { FromList: 'Cold', ToList: 'Warm' }, fakeClient({}))).result.ResultCode).toBe(
+            'MISSING_REQUIRED_FIELDS',
+        );
+        expect((await run(ApolloMoveListAccountsAction, { AccountIDs: 'acc-1', ToList: 'Warm' }, fakeClient({}))).result.ResultCode).toBe(
+            'MISSING_REQUIRED_FIELDS',
+        );
+        expect((await run(ApolloMoveListAccountsAction, { AccountIDs: 'acc-1', FromList: 'Cold' }, fakeClient({}))).result.ResultCode).toBe(
+            'MISSING_REQUIRED_FIELDS',
+        );
+    });
+
+    it('refuses a move onto the same list', async () => {
+        const { result } = await run(
+            ApolloMoveListAccountsAction,
+            { AccountIDs: 'acc-1', FromList: 'Cold', ToList: ' cold ' },
+            fakeClient({}),
+        );
+        expect(result.ResultCode).toBe('VALIDATION_ERROR');
+    });
+
+    it('resolves both list names before writing anything', async () => {
+        // A typo in ToList caught halfway through would leave the batch split.
+        const moveAccounts = vi.fn();
+        const { result } = await run(
+            ApolloMoveListAccountsAction,
+            { AccountIDs: 'acc-1', FromList: 'Cold', ToList: 'Typo' },
+            moveClient({ moveAccounts: moveAccounts as never }),
+        );
+        expect(result.ResultCode).toBe('NOT_FOUND');
+        expect(result.Message).toMatch(/'Typo' \(ToList\)/);
+        expect(moveAccounts).not.toHaveBeenCalled();
+    });
+
+    it('moves the records with the labels it just read, not with anything the caller supplied', async () => {
+        const moveAccounts = vi.fn(async () => moveResult);
+        const { result } = await run(
+            ApolloMoveListAccountsAction,
+            { AccountIDs: '["acc-1"]', FromList: 'Cold', ToList: 'Warm' },
+            moveClient({ moveAccounts }),
+        );
+        expect(result.Success).toBe(true);
+        const [records, from, to, options] = moveAccounts.mock.calls[0] as unknown as [ApolloAccount[], string, string, { verify: boolean }];
+        expect(records).toEqual([sourcePage.accounts[0]]);
+        expect(records[0].labelNames).toEqual(['Cold', 'Do Not Touch']);
+        expect([from, to]).toEqual(['Cold', 'Warm']);
+        expect(options).toEqual({ verify: true });
+    });
+
+    it('reads page 1 of the source list, because removals shift later pages', async () => {
+        const searchAccounts = vi.fn(async () => sourcePage);
+        await run(
+            ApolloMoveListAccountsAction,
+            { AccountIDs: 'acc-1', FromList: 'Cold', ToList: 'Warm' },
+            moveClient({ searchAccounts }),
+        );
+        expect(searchAccounts).toHaveBeenCalledWith({ labelIds: ['lab-cold'] }, { page: 1, perPage: 100 });
+    });
+
+    it('reports ids that were not on the source page instead of failing the whole batch', async () => {
+        const { result, params } = await run(
+            ApolloMoveListAccountsAction,
+            { AccountIDs: 'acc-1, acc-999', FromList: 'Cold', ToList: 'Warm' },
+            moveClient(),
+        );
+        expect(result.Success).toBe(true);
+        expect(output(params, 'NotOnSourcePage')).toEqual(['acc-999']);
+    });
+
+    it('de-duplicates the supplied ids', async () => {
+        const moveAccounts = vi.fn(async () => moveResult);
+        await run(
+            ApolloMoveListAccountsAction,
+            { AccountIDs: 'acc-1, acc-1', FromList: 'Cold', ToList: 'Warm' },
+            moveClient({ moveAccounts }),
+        );
+        expect((moveAccounts.mock.calls[0] as unknown as [ApolloAccount[]])[0]).toHaveLength(1);
+    });
+
+    it('explains what to do when none of the ids are on the source page', async () => {
+        const { result } = await run(
+            ApolloMoveListAccountsAction,
+            { AccountIDs: 'acc-999', FromList: 'Cold', ToList: 'Warm' },
+            moveClient(),
+        );
+        expect(result.ResultCode).toBe('NOT_FOUND');
+        expect(result.Message).toMatch(/re-read page 1/);
+    });
+
+    it('reports a partial failure when a write failed', async () => {
+        const { result, params } = await run(
+            ApolloMoveListAccountsAction,
+            { AccountIDs: 'acc-1', FromList: 'Cold', ToList: 'Warm' },
+            moveClient({
+                moveAccounts: async () => ({
+                    movedCount: 0,
+                    failedCount: 1,
+                    possiblyStuckCount: 0,
+                    items: [{ id: 'acc-1', added: true, removed: false, possiblyStuck: null, error: 'remove phase: boom' }],
+                }),
+            }),
+        );
+        expect(result.Success).toBe(false);
+        expect(result.ResultCode).toBe('PARTIAL_FAILURE');
+        expect(output(params, 'FailedCount')).toBe(1);
+    });
+
+    it('treats a stuck record as a success with an explanation, not as a failure', async () => {
+        // The write succeeded; Apollo did not honour it. Reporting it as a failure
+        // would send the caller looking for a bug in the request.
+        const { result, params } = await run(
+            ApolloMoveListAccountsAction,
+            { AccountIDs: 'acc-1', FromList: 'Cold', ToList: 'Warm' },
+            moveClient({
+                moveAccounts: async () => ({
+                    movedCount: 0,
+                    failedCount: 0,
+                    possiblyStuckCount: 1,
+                    items: [{ id: 'acc-1', added: true, removed: true, possiblyStuck: true, error: null }],
+                }),
+            }),
+        );
+        expect(result.Success).toBe(true);
+        expect(result.ResultCode).toBe('SUCCESS');
+        expect(output(params, 'PossiblyStuckCount')).toBe(1);
+        expect(result.Message).toMatch(/next page-1 drain/);
+        expect(result.Message).toMatch(/does not attempt one/);
+    });
+});
+
+describe('ApolloMoveListContactsAction', () => {
+    const sourcePage: ApolloContactsPage = {
+        contacts: [
+            {
+                id: 'con-1',
+                firstName: 'A',
+                lastName: 'B',
+                name: 'A B',
+                title: 'VP',
+                email: 'a@b.com',
+                organizationName: 'Acme',
+                labelIds: ['lab-cold'],
+                labelNames: ['Cold'],
+            },
+        ],
+        pagination: { page: 1, perPage: 100, totalEntries: 1, totalPages: 1 },
+    };
+
+    it('moves contacts through the contact search and move surface', async () => {
+        const moveContacts = vi.fn(async () => ({
+            movedCount: 1,
+            failedCount: 0,
+            possiblyStuckCount: 0,
+            items: [{ id: 'con-1', added: true, removed: true, possiblyStuck: false, error: null }],
+        }));
+        const { result, params } = await run(
+            ApolloMoveListContactsAction,
+            { ContactIDs: 'con-1', FromList: 'Cold', ToList: 'Warm' },
+            fakeClient({
+                findLabelByName: async (name: string) => LABELS.find((l) => l.name === name) ?? null,
+                searchContacts: async () => sourcePage,
+                moveContacts,
+            }),
+        );
+        expect(result.Success).toBe(true);
+        expect(output(params, 'MovedCount')).toBe(1);
+        expect((moveContacts.mock.calls[0] as unknown as [ApolloContact[]])[0]).toEqual([sourcePage.contacts[0]]);
+    });
+
+    it('names its own id param in the missing-field message', async () => {
+        const { result } = await run(ApolloMoveListContactsAction, { FromList: 'Cold', ToList: 'Warm' }, fakeClient({}));
+        expect(result.Message).toMatch(/ContactIDs/);
+    });
+});
+
+// ── Credential resolution through an action ───────────────────────────────────
+
+describe('key resolution', () => {
+    it('falls back to the environment when no CompanyID is supplied', async () => {
+        const { result, params } = await run(ApolloGetListsAction, {}, fakeClient({ listLabels: async () => LABELS }));
+        expect(result.Success).toBe(true);
+        expect(output(params, 'KeySource')).toBe('environment');
+    });
+
+    it('fails with CREDENTIALS_NOT_FOUND when nothing is configured at all', async () => {
+        delete process.env.APOLLO_API_KEY;
+        vi.resetModules();
+        const { ApolloGetListsAction: Fresh } = await import('../lists/ApolloListActions.js');
+        const { result } = await run(Fresh as never, {}, fakeClient({}));
+        expect(result.Success).toBe(false);
+        expect(result.ResultCode).toBe('CREDENTIALS_NOT_FOUND');
+        expect(result.Message).toMatch(/MASTER Apollo key/);
+        expect(result.Message).toMatch(/APOLLO_API_KEY/);
+    });
+});

--- a/packages/Actions/ApolloEnrichment/src/config.ts
+++ b/packages/Actions/ApolloEnrichment/src/config.ts
@@ -1,4 +1,14 @@
 export const ApolloAPIEndpoint = 'https://api.apollo.io/v1';
+/**
+ * Base path for the list-management and search surface.
+ *
+ * Note the extra `/api` segment. Apollo serves the enrichment endpoints this
+ * package has always used from `api.apollo.io/v1`, and the labels / saved-search /
+ * record-update endpoints from `api.apollo.io/api/v1`. They are not
+ * interchangeable — the same path under the wrong prefix 404s — so both live here
+ * side by side rather than one being derived from the other.
+ */
+export const ApolloRESTEndpoint = 'https://api.apollo.io/api/v1';
 export const EmailSourceName = "Apollo.io"
 export const GroupSize = 10; // number of records per group to send to API, max number is 10
 export const ConcurrentGroups = 1; // number of groups to process concurrently

--- a/packages/Actions/ApolloEnrichment/src/generic/apollo-lists.types.ts
+++ b/packages/Actions/ApolloEnrichment/src/generic/apollo-lists.types.ts
@@ -1,0 +1,280 @@
+/**
+ * Apollo.io list-management and search contract types.
+ *
+ * These serve a different surface from the enrichment actions in this package.
+ * Enrichment answers "tell me more about this record I already have"; this
+ * surface answers "which records are in this list, who else is out there, and
+ * move these from one list to another". It talks to a different base path
+ * (`api.apollo.io/api/v1`, see {@link ApolloRESTEndpoint}) and, for writes, needs
+ * a MASTER key rather than a scoped one.
+ *
+ * Five API behaviours are encoded here rather than discovered by each caller.
+ * Every one of them was learned by running this against a real Apollo account
+ * with tens of thousands of records in it:
+ *
+ *   1. AN ACCOUNT/CONTACT UPDATE REPLACES THE FULL LABEL ARRAY. A PATCH carrying
+ *      `label_names` overwrites every membership the record had. So a move is two
+ *      writes — add destination (current ∪ target), then remove source (post-add
+ *      state minus source) — and each write carries the record's COMPLETE
+ *      intended set. Sending a bare `[target]` would silently strip the record
+ *      from every other list it belongs to.
+ *   2. ROUGHLY 15-17% OF REMOVES SILENTLY NO-OP. The PATCH returns success and
+ *      the label stays attached; the record resurfaces later carrying both
+ *      labels. The move surface re-reads afterwards and reports these as
+ *      `possiblyStuck`. It deliberately does NOT auto-retry — an immediate retry
+ *      flakes the same way — so they are cleaned up on the next drain pass.
+ *   3. A LIST DRAIN ALWAYS READS PAGE 1. Removing members shifts every later
+ *      page, so "page 2" of a shrinking list skips records. {@link ApolloPagingOptions}
+ *      therefore defaults `page` to 1.
+ *   4. UPDATES REQUIRE A MASTER KEY. Scoped keys return 403 on account/contact
+ *      updates and on the labels endpoints.
+ *   5. LABELS ARE READ AS IDS AND WRITTEN AS NAMES. The account/contact search
+ *      response carries memberships as `label_ids` ONLY — there is no
+ *      `label_names` on the search payload — while the PATCH body takes
+ *      `label_names`. The client bridges the asymmetry by caching the labels
+ *      id↔name map and resolving on every read, so the move math and the writes
+ *      both operate on real names.
+ *
+ * SAFETY INVARIANT: there is no delete surface anywhere in this contract. The
+ * only writes are label-array updates and label creation.
+ */
+
+// ─── Labels (Apollo "lists" / "tags") ───────────────────────────────────────
+
+/**
+ * A label. Apollo overloads "label" to mean account lists, contact lists, and
+ * freeform tags; `modality` discriminates, and is surfaced here as `kind`.
+ */
+export interface ApolloLabel {
+    id: string;
+    name: string;
+    /**
+     * The member count Apollo caches per label. It can lag the true count, so it
+     * is fine for display and wrong for paging math.
+     */
+    cachedCount: number;
+    /** 'accounts' | 'contacts'; any other value Apollo sends passes through verbatim. */
+    kind: 'accounts' | 'contacts' | string;
+    createdAt: string;
+    updatedAt: string;
+}
+
+// ─── Accounts and contacts (list members) ───────────────────────────────────
+
+/**
+ * An account from the saved-account search. Deliberately thin: a list-cleanup
+ * workflow needs the identity, the domain for triage, and — load-bearing — the
+ * current label set, so a move can preserve it. Apollo returns far more fields
+ * and they are not modelled.
+ */
+export interface ApolloAccount {
+    id: string;
+    name: string;
+    /** Apollo's `primary_domain`; '' when absent. */
+    primaryDomain: string;
+    /**
+     * Membership ids exactly as the search returned them (quirk #5). Kept for
+     * diagnostics, and as the input {@link labelNames} is resolved from.
+     */
+    labelIds: string[];
+    /**
+     * The account's CURRENT label names, resolved from {@link labelIds}. Every
+     * label write must start from this set or it clobbers the account's other
+     * memberships (quirk #1). An id with no matching label is dropped rather
+     * than passed through — a raw id inside a `label_names` write would create a
+     * junk label named after a hex string.
+     */
+    labelNames: string[];
+}
+
+/** A contact from the saved-contact search. Thin for the same reason as {@link ApolloAccount}. */
+export interface ApolloContact {
+    id: string;
+    firstName: string;
+    lastName: string;
+    name: string;
+    title: string;
+    email: string;
+    /** Employer name; '' when Apollo has none on the contact. */
+    organizationName: string;
+    /** Membership ids as returned (quirk #5). */
+    labelIds: string[];
+    /** CURRENT label names resolved from {@link labelIds} — load-bearing for moves (quirk #1). */
+    labelNames: string[];
+}
+
+/**
+ * A person from the prospecting search — net-new people in Apollo's database,
+ * not your saved contacts. This endpoint does not return emails or phones by
+ * design; that is the enrichment surface, which the other actions in this
+ * package cover.
+ */
+export interface ApolloPerson {
+    id: string;
+    firstName: string;
+    lastName: string;
+    name: string;
+    title: string;
+    /** LinkedIn profile URL when present; '' otherwise. */
+    linkedinUrl: string;
+    /** Apollo organization id of the employer; null when absent. */
+    organizationId: string | null;
+    /** Employer name; '' when absent. */
+    organizationName: string;
+}
+
+// ─── Pagination ─────────────────────────────────────────────────────────────
+
+/** Apollo's `pagination` envelope on every search response. */
+export interface ApolloPagination {
+    page: number;
+    perPage: number;
+    totalEntries: number;
+    totalPages: number;
+}
+
+/**
+ * Paging controls. Apollo caps a search at 100 per page and 500 pages.
+ *
+ * `page` defaults to 1 because of quirk #3: when draining a list — reading
+ * members in order to move them out — always re-read page 1. Removals shift
+ * every later page, so advancing to page 2 skips records. Read page 1, move,
+ * read page 1 again; it now surfaces what used to be page 2. The default is 1
+ * precisely so a caller who has not read that paragraph still drains correctly.
+ */
+export interface ApolloPagingOptions {
+    /** 1-based page. Defaults to 1 (drain-safe). Apollo's max is 500. */
+    page?: number;
+    /** Results per page. Defaults to 100, which is also Apollo's maximum. */
+    perPage?: number;
+}
+
+/** One page of accounts plus the pagination envelope. */
+export interface ApolloAccountsPage {
+    accounts: ApolloAccount[];
+    pagination: ApolloPagination;
+}
+
+/** One page of contacts plus the pagination envelope. */
+export interface ApolloContactsPage {
+    contacts: ApolloContact[];
+    pagination: ApolloPagination;
+}
+
+/** One page of prospecting people plus the pagination envelope. */
+export interface ApolloPeoplePage {
+    people: ApolloPerson[];
+    pagination: ApolloPagination;
+}
+
+// ─── Search filters ─────────────────────────────────────────────────────────
+
+/** Account search filter. `labelIds` → `account_label_ids`; `keywords` → `q_organization_name`. */
+export interface ApolloAccountSearchFilter {
+    labelIds?: string[];
+    keywords?: string;
+}
+
+/**
+ * Contact search filter. `labelIds` → `contact_label_ids`; `keywords` →
+ * `q_keywords`, which Apollo matches against names, titles, employers and emails.
+ */
+export interface ApolloContactSearchFilter {
+    labelIds?: string[];
+    keywords?: string;
+}
+
+/**
+ * Prospecting-search filter. `organizationDomains` → `q_organization_domains_list`,
+ * `organizationIds` → `organization_ids`, `titles` → `person_titles`,
+ * `seniorities` → `person_seniorities`. All are optional to Apollo, but supplying
+ * none returns an unscoped firehose that burns the rate limit for nothing, so the
+ * action requires at least one.
+ */
+export interface ApolloPeopleSearchFilter {
+    organizationDomains?: string[];
+    organizationIds?: string[];
+    titles?: string[];
+    /** e.g. 'owner' | 'founder' | 'c_suite' | 'vp' | 'director' | 'manager' */
+    seniorities?: string[];
+}
+
+// ─── Move results ───────────────────────────────────────────────────────────
+
+/**
+ * One record's move outcome. `added`/`removed` track the two PATCH phases
+ * separately, because an add that succeeded followed by a remove that failed
+ * leaves the record in both lists — a state the caller has to be able to see.
+ */
+export interface ApolloMoveItemResult {
+    /** Apollo id of the account or contact. */
+    id: string;
+    /** Phase 1 (add the destination label) succeeded. */
+    added: boolean;
+    /** Phase 2 (remove the source label) succeeded. */
+    removed: boolean;
+    /**
+     * true  — the verify re-read still found the source label attached (quirk #2).
+     * false — the verify re-read confirmed it is gone.
+     * null  — no verify pass ran, or the re-read itself failed; state unknown.
+     */
+    possiblyStuck: boolean | null;
+    /** Failure detail when `added` or `removed` is false; null otherwise. */
+    error: string | null;
+}
+
+/**
+ * The result of moving a batch between lists.
+ *
+ * `possiblyStuckCount` is Apollo's silent-fail rate showing up (quirk #2), not a
+ * bug in the caller. Those records are not retried here: they resurface on the
+ * next page-1 drain carrying both labels and get stripped then.
+ */
+export interface ApolloMoveResult {
+    /** Destination added AND source removed, and not flagged stuck. */
+    movedCount: number;
+    /** Records where a PATCH outright failed. */
+    failedCount: number;
+    /** Records whose remove reported success but did not apply (quirk #2). */
+    possiblyStuckCount: number;
+    /** Per-record detail, for auditing and for planning the next drain pass. */
+    items: ApolloMoveItemResult[];
+}
+
+// ─── Client surface ─────────────────────────────────────────────────────────
+
+/** The operations the list/search actions need. No delete surface, by design. */
+export interface IApolloRESTClient {
+    /** Every label, account and contact alike. Master key required. */
+    listLabels(): Promise<ApolloLabel[]>;
+    /** Create a label. `modality` is required by Apollo — omitting it returns 422. */
+    createLabel(name: string, modality?: 'contacts' | 'accounts'): Promise<ApolloLabel>;
+    /** Resolve a label by exact name, case-insensitive; null when no match. */
+    findLabelByName(name: string): Promise<ApolloLabel | null>;
+
+    /** One page of saved accounts. */
+    searchAccounts(filter: ApolloAccountSearchFilter, paging?: ApolloPagingOptions): Promise<ApolloAccountsPage>;
+    /** One page of saved contacts. */
+    searchContacts(filter: ApolloContactSearchFilter, paging?: ApolloPagingOptions): Promise<ApolloContactsPage>;
+    /** One page of net-new prospects. */
+    searchPeople(filter: ApolloPeopleSearchFilter, paging?: ApolloPagingOptions): Promise<ApolloPeoplePage>;
+
+    /**
+     * Move accounts between lists, two-step and label-preserving. The supplied
+     * accounts MUST carry current `labelNames` from a fresh read — stale labels
+     * would be written back as the intended set and strip real memberships.
+     */
+    moveAccounts(
+        accounts: ApolloAccount[],
+        fromList: string,
+        toList: string,
+        options?: { verify?: boolean },
+    ): Promise<ApolloMoveResult>;
+    /** The same for contacts. */
+    moveContacts(
+        contacts: ApolloContact[],
+        fromList: string,
+        toList: string,
+        options?: { verify?: boolean },
+    ): Promise<ApolloMoveResult>;
+}

--- a/packages/Actions/ApolloEnrichment/src/index.ts
+++ b/packages/Actions/ApolloEnrichment/src/index.ts
@@ -1,6 +1,18 @@
 export * from './accounts';
 export * from './contacts';
 
+// List management, saved-record search and prospecting. These talk to a different
+// Apollo base path from enrichment, and every write among them needs a master key
+// — see ./generic/apollo-lists.types.ts for the API behaviours involved.
+export * from './generic/apollo-lists.types';
+export * from './lists/ApolloRESTClient';
+export * from './lists/ApolloRESTBaseAction';
+export * from './lists/ApolloListActions';
+export * from './lists/ApolloSearchActions';
+export * from './lists/ApolloMoveActions';
+export * from './lists/credentials';
+export * from './lists/params';
+
 // ApolloEnrichContact this Action would use the www.apollo.io enrichment service and enrich a "contact" type of record. The parameters to this Action would be:
 // EntityName - entity in question that contacts "contact" types of records
 // EmailField - string - field name in the target entity that contains the email to be used for lookups

--- a/packages/Actions/ApolloEnrichment/src/lists/ApolloListActions.ts
+++ b/packages/Actions/ApolloEnrichment/src/lists/ApolloListActions.ts
@@ -1,0 +1,147 @@
+/**
+ * Apollo label (list) actions: read the lists, and create one.
+ *
+ * Both need a MASTER Apollo key — the labels endpoints 403 on scoped keys, which
+ * is worth knowing before wiring these into a workflow, because the failure is
+ * indistinguishable from a bad key until you read the message.
+ */
+import { RegisterClass } from '@memberjunction/global';
+import { LogError, LogStatus } from '@memberjunction/core';
+import { BaseAction } from '@memberjunction/actions';
+import type { ActionResultSimple, RunActionParams } from '@memberjunction/actions-base';
+import { ApolloRESTBaseAction } from './ApolloRESTBaseAction.js';
+import { getParam } from './params.js';
+
+/**
+ * Lists the Apollo labels — lists and tags — with each one's kind
+ * ('accounts' | 'contacts') and cached member count.
+ *
+ * This is the first call in any list workflow, because every other action here
+ * addresses lists by exact name and this is what tells you the names. Read-only.
+ *
+ * Inputs:
+ *   - CompanyID (optional) resolve the key from this company's Apollo credential
+ *                          instead of APOLLO_API_KEY
+ *
+ * Outputs:
+ *   - Lists         array of { id, name, kind, cachedCount, createdAt, updatedAt }
+ *   - Count         number of labels
+ *   - KeySource     'credential' | 'environment' — which path supplied the key
+ */
+@RegisterClass(BaseAction, 'ApolloGetListsAction')
+export class ApolloGetListsAction extends ApolloRESTBaseAction {
+    protected async InternalRunAction(params: RunActionParams): Promise<ActionResultSimple> {
+        const { resolved, error } = await this.ResolveClient(params);
+        if (error) return error;
+
+        try {
+            const lists = await resolved.client.listLabels();
+
+            params.Params.push(
+                { Name: 'Lists', Type: 'Output', Value: lists },
+                { Name: 'Count', Type: 'Output', Value: lists.length },
+                { Name: 'KeySource', Type: 'Output', Value: resolved.key.source },
+            );
+
+            return {
+                Success: true,
+                Message: `Apollo lists: ${lists.length} label(s).`,
+                ResultCode: 'SUCCESS',
+                Params: params.Params,
+            };
+        } catch (err) {
+            const msg = err instanceof Error ? err.message : String(err);
+            LogError(`ApolloGetLists: ${msg}`);
+            return { Success: false, Message: `Error listing Apollo labels: ${msg}`, ResultCode: 'ERROR' };
+        }
+    }
+}
+
+/**
+ * Creates an Apollo list (label), idempotently.
+ *
+ * The existing labels are read first, and a same-named label — matched
+ * case-insensitively — is returned as-is with `AlreadyExisted: true` rather than
+ * creating a second one. Apollo will happily create two labels with the same name,
+ * and once it has, every name-based lookup in this surface becomes ambiguous:
+ * `findLabelByName` returns whichever comes first, so half the moves would target
+ * one list and half the other. Making create idempotent is what keeps
+ * name-addressing sound.
+ *
+ * Master-key write.
+ *
+ * Inputs:
+ *   - ListName  (required) the label to create
+ *   - Modality  (optional) 'contacts' (default) | 'accounts' — Apollo rejects a
+ *                          create with no modality, so this is a real choice, not
+ *                          decoration: a contacts label cannot tag accounts
+ *   - CompanyID (optional) as above
+ *
+ * Outputs:
+ *   - ListID / ResolvedListName / AlreadyExisted / Modality / KeySource
+ */
+@RegisterClass(BaseAction, 'ApolloCreateListAction')
+export class ApolloCreateListAction extends ApolloRESTBaseAction {
+    protected async InternalRunAction(params: RunActionParams): Promise<ActionResultSimple> {
+        const listName = getParam(params, 'ListName');
+        if (!listName) return this.MissingField('ListName');
+
+        const rawModality = getParam(params, 'Modality');
+        const modality = (rawModality ?? 'contacts').toLowerCase();
+        if (modality !== 'contacts' && modality !== 'accounts') {
+            return this.Invalid(`Modality must be 'contacts' or 'accounts' (got '${rawModality}').`);
+        }
+
+        const { resolved, error } = await this.ResolveClient(params);
+        if (error) return error;
+
+        try {
+            const existingLabels = await resolved.client.listLabels();
+            const target = listName.toLowerCase();
+            const existing = existingLabels.find((l) => l.name.trim().toLowerCase() === target);
+
+            if (existing) {
+                LogStatus(`ApolloCreateList: label '${existing.name}' already exists (id ${existing.id}); not creating a duplicate.`);
+                params.Params.push(
+                    { Name: 'ListID', Type: 'Output', Value: existing.id },
+                    { Name: 'ResolvedListName', Type: 'Output', Value: existing.name },
+                    { Name: 'AlreadyExisted', Type: 'Output', Value: true },
+                    { Name: 'Modality', Type: 'Output', Value: existing.kind },
+                    { Name: 'KeySource', Type: 'Output', Value: resolved.key.source },
+                );
+                return {
+                    Success: true,
+                    Message: `Apollo list '${existing.name}' already existed (id ${existing.id}); returned without creating a duplicate.`,
+                    ResultCode: 'SUCCESS',
+                    Params: params.Params,
+                };
+            }
+
+            const created = await resolved.client.createLabel(listName, modality);
+            LogStatus(`ApolloCreateList: created label '${created.name}' (id ${created.id}, modality ${modality}).`);
+
+            params.Params.push(
+                { Name: 'ListID', Type: 'Output', Value: created.id },
+                { Name: 'ResolvedListName', Type: 'Output', Value: created.name },
+                { Name: 'AlreadyExisted', Type: 'Output', Value: false },
+                { Name: 'Modality', Type: 'Output', Value: created.kind },
+                { Name: 'KeySource', Type: 'Output', Value: resolved.key.source },
+            );
+
+            return {
+                Success: true,
+                Message: `Created Apollo list '${created.name}' (id ${created.id}).`,
+                ResultCode: 'SUCCESS',
+                Params: params.Params,
+            };
+        } catch (err) {
+            const msg = err instanceof Error ? err.message : String(err);
+            LogError(`ApolloCreateList: ${msg}`);
+            return { Success: false, Message: `Error creating Apollo list: ${msg}`, ResultCode: 'ERROR' };
+        }
+    }
+}
+
+export function LoadApolloListActions(): void {
+    // Referenced by consumers to keep these registrations from being tree-shaken.
+}

--- a/packages/Actions/ApolloEnrichment/src/lists/ApolloMoveActions.ts
+++ b/packages/Actions/ApolloEnrichment/src/lists/ApolloMoveActions.ts
@@ -1,0 +1,293 @@
+/**
+ * Apollo list-move actions.
+ *
+ * A move is the only genuinely dangerous thing in this surface, so the two actions
+ * below are more cautious than their size suggests:
+ *
+ *   - Both list names are resolved to real labels BEFORE any write. A typo in
+ *     `ToList` that was only noticed halfway through would leave a batch split
+ *     across two lists with no record of which half moved.
+ *   - The source list is re-read to get each record's CURRENT labels. The caller
+ *     supplies ids, never labels: Apollo replaces the whole label array on every
+ *     update, so writing a stale set silently strips memberships the record picked
+ *     up since the caller last looked.
+ *   - Removes are verified, and records whose remove silently no-op'd are reported
+ *     rather than retried. Apollo fails this way on roughly 15-17% of removes and
+ *     an immediate retry flakes the same way; the next page-1 drain sees them
+ *     carrying both labels and finishes the job.
+ *
+ * Both require a MASTER Apollo key. There is no delete surface.
+ */
+import { RegisterClass } from '@memberjunction/global';
+import { LogError, LogStatus } from '@memberjunction/core';
+import { BaseAction } from '@memberjunction/actions';
+import type { ActionResultSimple, RunActionParams } from '@memberjunction/actions-base';
+import type { ApolloAccount, ApolloContact, ApolloLabel } from '../generic/apollo-lists.types.js';
+import { ApolloRESTBaseAction } from './ApolloRESTBaseAction.js';
+import { LIST_NOT_FOUND_HINT, getParam, getParamRaw, parseStringArrayParam } from './params.js';
+
+/** Apollo's per-page maximum, which is also the widest source page a move can see. */
+const MOVE_SOURCE_PER_PAGE = 100;
+
+/** The validated inputs common to both move actions. */
+interface MoveInputs {
+    ids: string[];
+    fromList: string;
+    toList: string;
+}
+
+/**
+ * Validate the shared inputs. Identical `FromList`/`ToList` is rejected here
+ * rather than left to the client, so the caller gets a validation error instead of
+ * an exception out of the move engine.
+ */
+function parseMoveInputs(
+    params: RunActionParams,
+    idsParamName: string,
+): { inputs: MoveInputs; error: null } | { inputs: null; error: ActionResultSimple } {
+    const idsParsed = parseStringArrayParam(getParamRaw(params, idsParamName), idsParamName);
+    if (idsParsed.error !== null) {
+        return { inputs: null, error: { Success: false, Message: idsParsed.error, ResultCode: 'VALIDATION_ERROR' } };
+    }
+    if (idsParsed.value === undefined) {
+        return {
+            inputs: null,
+            error: {
+                Success: false,
+                Message: `Missing required field: ${idsParamName} (JSON array or comma-separated Apollo ids)`,
+                ResultCode: 'MISSING_REQUIRED_FIELDS',
+            },
+        };
+    }
+    const fromList = getParam(params, 'FromList');
+    if (!fromList) {
+        return { inputs: null, error: { Success: false, Message: 'Missing required field: FromList', ResultCode: 'MISSING_REQUIRED_FIELDS' } };
+    }
+    const toList = getParam(params, 'ToList');
+    if (!toList) {
+        return { inputs: null, error: { Success: false, Message: 'Missing required field: ToList', ResultCode: 'MISSING_REQUIRED_FIELDS' } };
+    }
+    if (fromList.toLowerCase() === toList.toLowerCase()) {
+        return {
+            inputs: null,
+            error: {
+                Success: false,
+                Message: `FromList and ToList are identical ('${fromList}') — nothing to move.`,
+                ResultCode: 'VALIDATION_ERROR',
+            },
+        };
+    }
+    return { inputs: { ids: idsParsed.value, fromList, toList }, error: null };
+}
+
+/** Resolve both list names to labels before any write happens. */
+async function resolveBothLabels(
+    client: { findLabelByName(name: string): Promise<ApolloLabel | null> },
+    fromList: string,
+    toList: string,
+): Promise<{ from: ApolloLabel; to: ApolloLabel; error: null } | { from: null; to: null; error: ActionResultSimple }> {
+    const from = await client.findLabelByName(fromList);
+    if (!from) {
+        return {
+            from: null,
+            to: null,
+            error: {
+                Success: false,
+                Message: `No Apollo list named '${fromList}' (FromList) was found. ${LIST_NOT_FOUND_HINT}`,
+                ResultCode: 'NOT_FOUND',
+            },
+        };
+    }
+    const to = await client.findLabelByName(toList);
+    if (!to) {
+        return {
+            from: null,
+            to: null,
+            error: {
+                Success: false,
+                Message: `No Apollo list named '${toList}' (ToList) was found. ${LIST_NOT_FOUND_HINT}`,
+                ResultCode: 'NOT_FOUND',
+            },
+        };
+    }
+    return { from, to, error: null };
+}
+
+/** The note appended when Apollo's silent-fail removes showed up. */
+function stuckNote(possiblyStuckCount: number, kind: string): string {
+    return possiblyStuckCount > 0
+        ? ` ${possiblyStuckCount} ${kind} may be stuck — Apollo's remove reported success without applying. ` +
+          `They will resurface on the next page-1 drain carrying both labels; strip the source label then. ` +
+          `An immediate retry flakes the same way, which is why this action does not attempt one.`
+        : '';
+}
+
+/**
+ * Moves accounts from one Apollo list to another.
+ *
+ * Inputs:
+ *   - AccountIDs (required) JSON array or comma-separated Apollo account ids
+ *   - FromList   (required) exact source label name
+ *   - ToList     (required) exact destination label name
+ *   - CompanyID  (optional) per-company credential resolution
+ *
+ * Outputs:
+ *   - MovedCount / FailedCount / PossiblyStuckCount
+ *   - Results          per-account { id, added, removed, possiblyStuck, error }
+ *   - NotOnSourcePage  supplied ids that were not on page 1 of the source list
+ *   - KeySource
+ *
+ * `PARTIAL_FAILURE` means at least one PATCH failed outright. Possibly-stuck
+ * records are NOT failures — the write succeeded and Apollo did not honour it.
+ */
+@RegisterClass(BaseAction, 'ApolloMoveListAccountsAction')
+export class ApolloMoveListAccountsAction extends ApolloRESTBaseAction {
+    protected async InternalRunAction(params: RunActionParams): Promise<ActionResultSimple> {
+        const parsed = parseMoveInputs(params, 'AccountIDs');
+        if (parsed.error) return parsed.error;
+        const { ids, fromList, toList } = parsed.inputs;
+
+        const { resolved, error } = await this.ResolveClient(params);
+        if (error) return error;
+
+        try {
+            const labels = await resolveBothLabels(resolved.client, fromList, toList);
+            if (labels.error) return labels.error;
+
+            // Re-read the source list to capture CURRENT labels — page 1, drain-safe.
+            const sourcePage = await resolved.client.searchAccounts(
+                { labelIds: [labels.from.id] },
+                { page: 1, perPage: MOVE_SOURCE_PER_PAGE },
+            );
+            const byId = new Map(sourcePage.accounts.map((a) => [a.id, a]));
+
+            const toMove: ApolloAccount[] = [];
+            const notOnSourcePage: string[] = [];
+            for (const id of new Set(ids)) {
+                const account = byId.get(id);
+                if (account) toMove.push(account);
+                else notOnSourcePage.push(id);
+            }
+
+            if (toMove.length === 0) {
+                return {
+                    Success: false,
+                    Message:
+                        `None of the ${ids.length} supplied account id(s) were found on page 1 of '${labels.from.name}'. ` +
+                        `They may already have moved, or sit on a later page — re-read page 1, since removals shift pages.`,
+                    ResultCode: 'NOT_FOUND',
+                };
+            }
+
+            const result = await resolved.client.moveAccounts(toMove, labels.from.name, labels.to.name, { verify: true });
+
+            LogStatus(
+                `ApolloMoveListAccounts: '${labels.from.name}' → '${labels.to.name}' — ${result.movedCount} moved, ` +
+                `${result.possiblyStuckCount} possibly stuck, ${result.failedCount} failed of ${toMove.length} ` +
+                `(${notOnSourcePage.length} supplied id(s) not on source page 1).`,
+            );
+
+            params.Params.push(
+                { Name: 'MovedCount', Type: 'Output', Value: result.movedCount },
+                { Name: 'FailedCount', Type: 'Output', Value: result.failedCount },
+                { Name: 'PossiblyStuckCount', Type: 'Output', Value: result.possiblyStuckCount },
+                { Name: 'Results', Type: 'Output', Value: result.items },
+                { Name: 'NotOnSourcePage', Type: 'Output', Value: notOnSourcePage },
+                { Name: 'KeySource', Type: 'Output', Value: resolved.key.source },
+            );
+
+            return {
+                Success: result.failedCount === 0,
+                Message:
+                    `Moved ${result.movedCount} of ${toMove.length} account(s) from '${labels.from.name}' to '${labels.to.name}'` +
+                    `${result.failedCount > 0 ? `; ${result.failedCount} failed` : ''}.${stuckNote(result.possiblyStuckCount, 'account(s)')}`,
+                ResultCode: result.failedCount === 0 ? 'SUCCESS' : 'PARTIAL_FAILURE',
+                Params: params.Params,
+            };
+        } catch (err) {
+            const msg = err instanceof Error ? err.message : String(err);
+            LogError(`ApolloMoveListAccounts: ${msg}`);
+            return { Success: false, Message: `Error moving Apollo accounts: ${msg}`, ResultCode: 'ERROR' };
+        }
+    }
+}
+
+/**
+ * Moves contacts from one Apollo list to another. Identical semantics to
+ * {@link ApolloMoveListAccountsAction}; the id param is `ContactIDs` and the
+ * outputs carry contact results.
+ */
+@RegisterClass(BaseAction, 'ApolloMoveListContactsAction')
+export class ApolloMoveListContactsAction extends ApolloRESTBaseAction {
+    protected async InternalRunAction(params: RunActionParams): Promise<ActionResultSimple> {
+        const parsed = parseMoveInputs(params, 'ContactIDs');
+        if (parsed.error) return parsed.error;
+        const { ids, fromList, toList } = parsed.inputs;
+
+        const { resolved, error } = await this.ResolveClient(params);
+        if (error) return error;
+
+        try {
+            const labels = await resolveBothLabels(resolved.client, fromList, toList);
+            if (labels.error) return labels.error;
+
+            const sourcePage = await resolved.client.searchContacts(
+                { labelIds: [labels.from.id] },
+                { page: 1, perPage: MOVE_SOURCE_PER_PAGE },
+            );
+            const byId = new Map(sourcePage.contacts.map((c) => [c.id, c]));
+
+            const toMove: ApolloContact[] = [];
+            const notOnSourcePage: string[] = [];
+            for (const id of new Set(ids)) {
+                const contact = byId.get(id);
+                if (contact) toMove.push(contact);
+                else notOnSourcePage.push(id);
+            }
+
+            if (toMove.length === 0) {
+                return {
+                    Success: false,
+                    Message:
+                        `None of the ${ids.length} supplied contact id(s) were found on page 1 of '${labels.from.name}'. ` +
+                        `They may already have moved, or sit on a later page — re-read page 1, since removals shift pages.`,
+                    ResultCode: 'NOT_FOUND',
+                };
+            }
+
+            const result = await resolved.client.moveContacts(toMove, labels.from.name, labels.to.name, { verify: true });
+
+            LogStatus(
+                `ApolloMoveListContacts: '${labels.from.name}' → '${labels.to.name}' — ${result.movedCount} moved, ` +
+                `${result.possiblyStuckCount} possibly stuck, ${result.failedCount} failed of ${toMove.length} ` +
+                `(${notOnSourcePage.length} supplied id(s) not on source page 1).`,
+            );
+
+            params.Params.push(
+                { Name: 'MovedCount', Type: 'Output', Value: result.movedCount },
+                { Name: 'FailedCount', Type: 'Output', Value: result.failedCount },
+                { Name: 'PossiblyStuckCount', Type: 'Output', Value: result.possiblyStuckCount },
+                { Name: 'Results', Type: 'Output', Value: result.items },
+                { Name: 'NotOnSourcePage', Type: 'Output', Value: notOnSourcePage },
+                { Name: 'KeySource', Type: 'Output', Value: resolved.key.source },
+            );
+
+            return {
+                Success: result.failedCount === 0,
+                Message:
+                    `Moved ${result.movedCount} of ${toMove.length} contact(s) from '${labels.from.name}' to '${labels.to.name}'` +
+                    `${result.failedCount > 0 ? `; ${result.failedCount} failed` : ''}.${stuckNote(result.possiblyStuckCount, 'contact(s)')}`,
+                ResultCode: result.failedCount === 0 ? 'SUCCESS' : 'PARTIAL_FAILURE',
+                Params: params.Params,
+            };
+        } catch (err) {
+            const msg = err instanceof Error ? err.message : String(err);
+            LogError(`ApolloMoveListContacts: ${msg}`);
+            return { Success: false, Message: `Error moving Apollo contacts: ${msg}`, ResultCode: 'ERROR' };
+        }
+    }
+}
+
+export function LoadApolloMoveActions(): void {
+    // Referenced by consumers to keep these registrations from being tree-shaken.
+}

--- a/packages/Actions/ApolloEnrichment/src/lists/ApolloRESTBaseAction.ts
+++ b/packages/Actions/ApolloEnrichment/src/lists/ApolloRESTBaseAction.ts
@@ -1,0 +1,82 @@
+/**
+ * Shared plumbing for the Apollo list and search actions.
+ *
+ * Each of these actions does the same three things before it does anything
+ * interesting: resolve a key, build a client, and turn whatever went wrong into a
+ * result object rather than an exception. That lives here so seven actions cannot
+ * drift into seven different answers for "no credential configured".
+ *
+ * {@link CreateClient} is a protected seam purely so tests can substitute a fake
+ * client. Nothing in this package may reach api.apollo.io from a test: a live call
+ * would spend real credits, and the move surface would mutate a real Apollo
+ * account's list membership with no undo.
+ */
+import { BaseAction } from '@memberjunction/actions';
+import type { ActionResultSimple, RunActionParams } from '@memberjunction/actions-base';
+import type { IApolloRESTClient } from '../generic/apollo-lists.types.js';
+import { ApolloRESTClient } from './ApolloRESTClient.js';
+import { NO_APOLLO_KEY_MESSAGE, resolveApolloAPIKey, type ResolvedApolloKey } from './credentials.js';
+import { getParam } from './params.js';
+
+/** A resolved client plus how its key was found. */
+export interface ResolvedApolloClient {
+    client: IApolloRESTClient;
+    key: ResolvedApolloKey;
+}
+
+export abstract class ApolloRESTBaseAction extends BaseAction {
+    /**
+     * Build the client. Overridden in tests; the only place `ApolloRESTClient` is
+     * constructed in this surface.
+     */
+    protected CreateClient(apiKey: string): IApolloRESTClient {
+        return new ApolloRESTClient(apiKey);
+    }
+
+    /**
+     * Resolve the key and construct the client, or return the failure result to
+     * hand straight back to the caller.
+     *
+     * `CompanyID` is optional here, unlike in the CDP actions this ports from,
+     * because a single-tenant instance with `APOLLO_API_KEY` set has no company
+     * to name. Supplying it switches on the per-company credential path.
+     */
+    protected async ResolveClient(
+        params: RunActionParams,
+    ): Promise<{ resolved: ResolvedApolloClient; error: null } | { resolved: null; error: ActionResultSimple }> {
+        const companyID = getParam(params, 'CompanyID');
+        let key: ResolvedApolloKey | null;
+        try {
+            key = await resolveApolloAPIKey(companyID, params.ContextUser);
+        } catch (error) {
+            // A credential that exists but is malformed — say so, rather than
+            // falling back to a different workspace's key from the environment.
+            return {
+                resolved: null,
+                error: {
+                    Success: false,
+                    Message: error instanceof Error ? error.message : String(error),
+                    ResultCode: 'CONFIGURATION_ERROR',
+                },
+            };
+        }
+        if (!key) {
+            return { resolved: null, error: { Success: false, Message: NO_APOLLO_KEY_MESSAGE, ResultCode: 'CREDENTIALS_NOT_FOUND' } };
+        }
+        return { resolved: { client: this.CreateClient(key.apiKey), key }, error: null };
+    }
+
+    /** A uniform missing-input failure. */
+    protected MissingField(name: string, detail?: string): ActionResultSimple {
+        return {
+            Success: false,
+            Message: `Missing required field: ${name}${detail ? ` (${detail})` : ''}`,
+            ResultCode: 'MISSING_REQUIRED_FIELDS',
+        };
+    }
+
+    /** A uniform validation failure. */
+    protected Invalid(message: string): ActionResultSimple {
+        return { Success: false, Message: message, ResultCode: 'VALIDATION_ERROR' };
+    }
+}

--- a/packages/Actions/ApolloEnrichment/src/lists/ApolloRESTClient.ts
+++ b/packages/Actions/ApolloEnrichment/src/lists/ApolloRESTClient.ts
@@ -1,0 +1,680 @@
+/**
+ * Apollo.io REST client for label management, saved-record search and prospecting.
+ *
+ * The five API behaviours this encodes are documented once, on
+ * `../generic/apollo-lists.types.ts`. Read that first; the methods below refer to
+ * them by number.
+ *
+ * Everything here goes through {@link ApolloRESTEndpoint} (`api.apollo.io/api/v1`),
+ * which is a different base path from the enrichment actions in this package.
+ * Auth is the `X-Api-Key` header — Apollo's REST convention, even though the
+ * docs' generic auth widget renders a "Bearer" label — and every write, plus the
+ * labels endpoints, needs a MASTER key. A scoped key returns 403, which this
+ * client rewrites into a message that says so instead of passing the bare status
+ * through.
+ *
+ * Endpoints used:
+ *   GET   /labels                    list labels
+ *   POST  /labels                    create a label
+ *   POST  /accounts/search           saved accounts
+ *   POST  /contacts/search           saved contacts
+ *   POST  /mixed_people/api_search   prospecting people
+ *   PATCH /accounts/{id}             update one account's labels (master key)
+ *   PATCH /contacts/{id}             update one contact's labels (master key)
+ *
+ * The write body key is `label_names` (strings), not `label_ids`. Apollo's
+ * update-a-contact reference documents it explicitly along with the full-replace
+ * semantics; the update-an-account reference documents no label parameter at all,
+ * but mirrors the contact body in practice. If a future Apollo change rejects
+ * names on the account PATCH, the fix is to resolve names → ids through the
+ * cached map and send `label_ids` — still as a COMPLETE set, since the
+ * full-replace behaviour is the part that matters.
+ *
+ * No delete surface. The only writes are label-array updates and label creation.
+ */
+import { LogError, LogStatus } from '@memberjunction/core';
+import { ApolloRESTEndpoint } from '../config.js';
+import type {
+    ApolloAccount,
+    ApolloAccountSearchFilter,
+    ApolloAccountsPage,
+    ApolloContact,
+    ApolloContactSearchFilter,
+    ApolloContactsPage,
+    ApolloLabel,
+    ApolloMoveItemResult,
+    ApolloMoveResult,
+    ApolloPagination,
+    ApolloPagingOptions,
+    ApolloPeoplePage,
+    ApolloPeopleSearchFilter,
+    ApolloPerson,
+    IApolloRESTClient,
+} from '../generic/apollo-lists.types.js';
+
+/** Apollo's per-page cap on every search endpoint. */
+const MAX_PER_PAGE = 100;
+/** Apollo's page cap, a consequence of its 50,000-record display limit. */
+const MAX_PAGE = 500;
+
+/** Options for {@link ApolloRESTClient}. */
+export interface ApolloRESTClientOptions {
+    /**
+     * Injected fetch, for tests. Tests must never reach api.apollo.io — a live
+     * call would consume real credits and mutate a real account's lists.
+     */
+    fetchImpl?: typeof fetch;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+    return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function stringOr(value: unknown, fallback: string): string {
+    return typeof value === 'string' ? value : fallback;
+}
+
+function stringOrNull(value: unknown): string | null {
+    return typeof value === 'string' && value.length > 0 ? value : null;
+}
+
+function numberOr(value: unknown, fallback: number): number {
+    return typeof value === 'number' && Number.isFinite(value) ? value : fallback;
+}
+
+/** Coerce an unknown into a string[], dropping anything that is not a string. */
+function toStringArray(value: unknown): string[] {
+    if (!Array.isArray(value)) return [];
+    return value.filter((v): v is string => typeof v === 'string');
+}
+
+/** Bidirectional label id↔name maps (quirk #5). */
+interface LabelMaps {
+    idToName: Map<string, string>;
+    nameToId: Map<string, string>;
+}
+
+/**
+ * Resolve a record's raw `label_ids` into names (quirk #5). An id with no
+ * matching label is dropped and reported through {@link onUnresolved} so the
+ * caller can log one aggregated warning instead of one per id. Dropping is the
+ * safe choice: passing a raw id through into a later `label_names` write would
+ * create a new label named after a hex string.
+ */
+function resolveLabelNames(labelIds: string[], idToName: Map<string, string>, onUnresolved: (id: string) => void): string[] {
+    const names: string[] = [];
+    for (const id of labelIds) {
+        const name = idToName.get(id);
+        if (name !== undefined) {
+            names.push(name);
+        } else {
+            onUnresolved(id);
+        }
+    }
+    return names;
+}
+
+function mapPagination(value: unknown): ApolloPagination {
+    const p = isRecord(value) ? value : {};
+    return {
+        page: numberOr(p.page, 1),
+        perPage: numberOr(p.per_page, 0),
+        totalEntries: numberOr(p.total_entries, 0),
+        totalPages: numberOr(p.total_pages, 0),
+    };
+}
+
+function mapAccount(item: Record<string, unknown>, idToName: Map<string, string>, onUnresolved: (id: string) => void): ApolloAccount {
+    const labelIds = toStringArray(item.label_ids);
+    return {
+        id: stringOr(item.id, ''),
+        name: stringOr(item.name, ''),
+        primaryDomain: stringOr(item.primary_domain, ''),
+        labelIds,
+        labelNames: resolveLabelNames(labelIds, idToName, onUnresolved),
+    };
+}
+
+function mapContact(item: Record<string, unknown>, idToName: Map<string, string>, onUnresolved: (id: string) => void): ApolloContact {
+    const labelIds = toStringArray(item.label_ids);
+    return {
+        id: stringOr(item.id, ''),
+        firstName: stringOr(item.first_name, ''),
+        lastName: stringOr(item.last_name, ''),
+        name: stringOr(item.name, ''),
+        title: stringOr(item.title, ''),
+        email: stringOr(item.email, ''),
+        // Apollo returns either a flat `organization_name` or a nested `organization.name`.
+        organizationName: stringOr(
+            item.organization_name,
+            isRecord(item.organization) ? stringOr(item.organization.name, '') : '',
+        ),
+        labelIds,
+        labelNames: resolveLabelNames(labelIds, idToName, onUnresolved),
+    };
+}
+
+function mapPerson(item: Record<string, unknown>): ApolloPerson {
+    const org = isRecord(item.organization) ? item.organization : {};
+    return {
+        id: stringOr(item.id, ''),
+        firstName: stringOr(item.first_name, ''),
+        lastName: stringOr(item.last_name, ''),
+        name: stringOr(item.name, ''),
+        title: stringOr(item.title, ''),
+        linkedinUrl: stringOr(item.linkedin_url, ''),
+        organizationId: stringOrNull(item.organization_id) ?? stringOrNull(org.id),
+        organizationName: stringOr(item.organization_name, stringOr(org.name, '')),
+    };
+}
+
+/** Clamp paging into Apollo's bounds, defaulting drain-safe (quirk #3). */
+function normalizePaging(paging?: ApolloPagingOptions): { page: number; perPage: number } {
+    const page = Math.min(Math.max(numberOr(paging?.page, 1), 1), MAX_PAGE);
+    const perPage = Math.min(Math.max(numberOr(paging?.perPage, MAX_PER_PAGE), 1), MAX_PER_PAGE);
+    return { page, perPage };
+}
+
+/**
+ * Apollo.io list/search client. See the module doc, and the quirk list on
+ * `apollo-lists.types.ts`, for the behaviours it encodes.
+ */
+export class ApolloRESTClient implements IApolloRESTClient {
+    private readonly apiKey: string;
+    private readonly fetchImpl: typeof fetch;
+    /**
+     * The label id↔name maps, built on first use and cached for the instance
+     * lifetime (quirk #5). One labels call per client, shared by every search and
+     * move. No TTL: a single drain or move operation uses one instance, and
+     * labels do not churn mid-operation. Construct a new client to see label
+     * changes made since.
+     */
+    private labelMaps: LabelMaps | null = null;
+
+    constructor(apiKey: string, options?: ApolloRESTClientOptions) {
+        if (!apiKey || apiKey.trim().length === 0) {
+            throw new Error('ApolloRESTClient: apiKey is required');
+        }
+        this.apiKey = apiKey;
+        // Bind global fetch so it keeps its expected `this` when not injected.
+        this.fetchImpl = options?.fetchImpl ?? fetch.bind(globalThis);
+    }
+
+    // ─── HTTP ────────────────────────────────────────────────────────────────
+
+    /**
+     * Issue one request and return the parsed body. A non-2xx throws with the
+     * method, path, status and whatever detail Apollo supplied; a 403 on a
+     * master-key operation throws the master-key explanation instead (quirk #4).
+     * Nothing is swallowed — a body that will not parse still surfaces its text.
+     */
+    private async request(args: {
+        method: 'GET' | 'POST' | 'PATCH';
+        path: string;
+        context: string;
+        body?: unknown;
+        /** When true, a 403 is reported as the master-key requirement (quirk #4). */
+        masterKeyOp?: boolean;
+    }): Promise<unknown> {
+        const { method, path, context, body, masterKeyOp } = args;
+        const url = `${ApolloRESTEndpoint}${path}`;
+        const headers: Record<string, string> = {
+            'X-Api-Key': this.apiKey,
+            accept: 'application/json',
+        };
+        if (body !== undefined) {
+            headers['Content-Type'] = 'application/json';
+        }
+
+        const response = await this.fetchImpl(url, {
+            method,
+            headers,
+            body: body !== undefined ? JSON.stringify(body) : undefined,
+        });
+
+        if (!response.ok) {
+            let rawText = '';
+            let detail = '';
+            try {
+                rawText = await response.text();
+                const parsed: unknown = JSON.parse(rawText);
+                if (isRecord(parsed)) {
+                    detail = stringOr(parsed.error, stringOr(parsed.message, ''));
+                }
+            } catch {
+                // Body was not JSON. The error thrown below still carries rawText,
+                // so nothing is lost here.
+            }
+            if (response.status === 403 && masterKeyOp) {
+                const message =
+                    `ApolloRESTClient.${context}: ${method} ${path} returned HTTP 403. ` +
+                    `This endpoint requires a MASTER Apollo API key — scoped keys 403 on label reads/writes ` +
+                    `and on account/contact updates.` +
+                    (detail ? ` (${detail})` : '');
+                LogError(message);
+                throw new Error(message);
+            }
+            const fallback = detail || rawText.slice(0, 500);
+            const message = `ApolloRESTClient.${context}: ${method} ${path} failed with HTTP ${response.status}${fallback ? ` — ${fallback}` : ''}`;
+            LogError(message);
+            throw new Error(message);
+        }
+
+        try {
+            return (await response.json()) as unknown;
+        } catch (error: unknown) {
+            const msg = error instanceof Error ? error.message : String(error);
+            const message = `ApolloRESTClient.${context}: ${method} ${path} returned a non-JSON body: ${msg}`;
+            LogError(message);
+            throw new Error(message);
+        }
+    }
+
+    // ─── Labels ──────────────────────────────────────────────────────────────
+
+    /**
+     * Every label, account lists and contact lists alike. Master key required.
+     * Apollo returns either a bare array or a `{ labels: [...] }` envelope
+     * depending on the account; both are accepted.
+     */
+    public async listLabels(): Promise<ApolloLabel[]> {
+        const data = await this.request({ method: 'GET', path: '/labels', context: 'listLabels', masterKeyOp: true });
+        const arr = Array.isArray(data) ? data : isRecord(data) && Array.isArray(data.labels) ? data.labels : null;
+        if (arr === null) {
+            throw new Error('ApolloRESTClient.listLabels: unexpected response shape — expected an array of labels or { labels: [...] }');
+        }
+        return arr.filter(isRecord).map((item): ApolloLabel => ({
+            id: stringOr(item.id, ''),
+            name: stringOr(item.name, ''),
+            cachedCount: numberOr(item.cached_count, 0),
+            // Apollo's field is `modality`; surfaced as `kind`.
+            kind: stringOr(item.modality, 'unknown'),
+            createdAt: stringOr(item.created_at, ''),
+            updatedAt: stringOr(item.updated_at, ''),
+        }));
+    }
+
+    /**
+     * Create a label. Master key required.
+     *
+     * `modality` is not optional to Apollo despite reading like it should be:
+     * posting without it returns HTTP 422 "Please enter a non-empty modality!".
+     * It defaults to 'contacts' here because a people list is the common case.
+     *
+     * The create response shape is not pinned in Apollo's docs, so a bare label
+     * object, a `{ label: {...} }` envelope and a `{ labels: [...] }` envelope
+     * are all accepted — mirroring how {@link listLabels} tolerates two read
+     * shapes. A shape none of those match throws rather than returning a label
+     * with an empty id, which would then be written into a membership array.
+     */
+    public async createLabel(name: string, modality: 'contacts' | 'accounts' = 'contacts'): Promise<ApolloLabel> {
+        const trimmed = name.trim();
+        if (trimmed.length === 0) {
+            throw new Error('ApolloRESTClient.createLabel: name is required');
+        }
+        const data = await this.request({
+            method: 'POST',
+            path: '/labels',
+            context: 'createLabel',
+            body: { name: trimmed, modality },
+            masterKeyOp: true,
+        });
+        const raw: unknown = isRecord(data) && isRecord(data.label)
+            ? data.label
+            : isRecord(data) && Array.isArray(data.labels) && data.labels.length > 0
+                ? data.labels[0]
+                : data;
+        if (!isRecord(raw)) {
+            throw new Error(
+                'ApolloRESTClient.createLabel: unexpected response shape — expected a label object, { label: {...} }, or { labels: [...] }',
+            );
+        }
+        const id = stringOr(raw.id, '');
+        if (id.length === 0) {
+            throw new Error('ApolloRESTClient.createLabel: response carried no label id — cannot confirm the label was created');
+        }
+        return {
+            id,
+            name: stringOr(raw.name, trimmed),
+            cachedCount: numberOr(raw.cached_count, 0),
+            kind: stringOr(raw.modality, 'unknown'),
+            createdAt: stringOr(raw.created_at, ''),
+            updatedAt: stringOr(raw.updated_at, ''),
+        };
+    }
+
+    /**
+     * Resolve a label by exact name, case-insensitive; null when nothing matches.
+     * This is how a human-supplied list name becomes the id a search filter needs.
+     */
+    public async findLabelByName(name: string): Promise<ApolloLabel | null> {
+        const target = name.trim().toLowerCase();
+        if (target.length === 0) {
+            throw new Error('ApolloRESTClient.findLabelByName: name is required');
+        }
+        const labels = await this.listLabels();
+        return labels.find((l) => l.name.trim().toLowerCase() === target) ?? null;
+    }
+
+    /**
+     * Build (once per instance) the id↔name maps that resolve search-response
+     * `label_ids` into names (quirk #5). When two labels share a name — rare — the
+     * last one wins in `nameToId`.
+     */
+    private async getLabelMaps(): Promise<LabelMaps> {
+        if (this.labelMaps !== null) {
+            return this.labelMaps;
+        }
+        const labels = await this.listLabels();
+        const idToName = new Map<string, string>();
+        const nameToId = new Map<string, string>();
+        for (const label of labels) {
+            if (label.id.length > 0) {
+                idToName.set(label.id, label.name);
+            }
+            if (label.name.length > 0) {
+                nameToId.set(label.name, label.id);
+            }
+        }
+        this.labelMaps = { idToName, nameToId };
+        return this.labelMaps;
+    }
+
+    /** One aggregated warning for label ids that did not resolve to a name (quirk #5). */
+    private warnUnresolvedLabels(context: string, unresolved: Set<string>): void {
+        if (unresolved.size > 0) {
+            LogStatus(
+                `ApolloRESTClient.${context}: ${unresolved.size} label id(s) had no matching label and were dropped from labelNames ` +
+                `(the raw ids stay on labelIds): ${[...unresolved].join(', ')}`,
+            );
+        }
+    }
+
+    // ─── Searches ────────────────────────────────────────────────────────────
+
+    /**
+     * One page of saved accounts. Paging defaults to page 1 — when draining a
+     * list, never advance (quirk #3).
+     */
+    public async searchAccounts(filter: ApolloAccountSearchFilter, paging?: ApolloPagingOptions): Promise<ApolloAccountsPage> {
+        const { page, perPage } = normalizePaging(paging);
+        const body: Record<string, unknown> = { page, per_page: perPage };
+        if (filter.labelIds && filter.labelIds.length > 0) body.account_label_ids = filter.labelIds;
+        if (filter.keywords) body.q_organization_name = filter.keywords;
+
+        const { idToName } = await this.getLabelMaps();
+        const data = await this.request({ method: 'POST', path: '/accounts/search', context: 'searchAccounts', body });
+        if (!isRecord(data)) {
+            throw new Error('ApolloRESTClient.searchAccounts: unexpected response shape — expected an object with accounts + pagination');
+        }
+        // Saved-account search returns `accounts`; some responses use `organizations`.
+        const rows = Array.isArray(data.accounts) ? data.accounts : Array.isArray(data.organizations) ? data.organizations : [];
+        const unresolved = new Set<string>();
+        const accounts = rows.filter(isRecord).map((item) => mapAccount(item, idToName, (id) => unresolved.add(id)));
+        this.warnUnresolvedLabels('searchAccounts', unresolved);
+        return { accounts, pagination: mapPagination(data.pagination) };
+    }
+
+    /** One page of saved contacts. Same drain-page-1 default as {@link searchAccounts}. */
+    public async searchContacts(filter: ApolloContactSearchFilter, paging?: ApolloPagingOptions): Promise<ApolloContactsPage> {
+        const { page, perPage } = normalizePaging(paging);
+        const body: Record<string, unknown> = { page, per_page: perPage };
+        if (filter.labelIds && filter.labelIds.length > 0) body.contact_label_ids = filter.labelIds;
+        if (filter.keywords) body.q_keywords = filter.keywords;
+
+        const { idToName } = await this.getLabelMaps();
+        const data = await this.request({ method: 'POST', path: '/contacts/search', context: 'searchContacts', body });
+        if (!isRecord(data)) {
+            throw new Error('ApolloRESTClient.searchContacts: unexpected response shape — expected an object with contacts + pagination');
+        }
+        const rows = Array.isArray(data.contacts) ? data.contacts : [];
+        const unresolved = new Set<string>();
+        const contacts = rows.filter(isRecord).map((item) => mapContact(item, idToName, (id) => unresolved.add(id)));
+        this.warnUnresolvedLabels('searchContacts', unresolved);
+        return { contacts, pagination: mapPagination(data.pagination) };
+    }
+
+    /**
+     * One page of prospecting people — net-new, not your saved contacts. Apollo
+     * does not return emails or phones here by design.
+     *
+     * Unlike the two searches above, this one does not need the label maps: the
+     * prospecting response carries no memberships, so fetching them would be a
+     * wasted master-key call on a read a scoped key can otherwise serve.
+     */
+    public async searchPeople(filter: ApolloPeopleSearchFilter, paging?: ApolloPagingOptions): Promise<ApolloPeoplePage> {
+        const { page, perPage } = normalizePaging(paging);
+        const body: Record<string, unknown> = { page, per_page: perPage };
+        if (filter.organizationDomains && filter.organizationDomains.length > 0) {
+            body.q_organization_domains_list = filter.organizationDomains;
+        }
+        if (filter.organizationIds && filter.organizationIds.length > 0) body.organization_ids = filter.organizationIds;
+        if (filter.titles && filter.titles.length > 0) body.person_titles = filter.titles;
+        if (filter.seniorities && filter.seniorities.length > 0) body.person_seniorities = filter.seniorities;
+
+        const data = await this.request({ method: 'POST', path: '/mixed_people/api_search', context: 'searchPeople', body });
+        if (!isRecord(data)) {
+            throw new Error('ApolloRESTClient.searchPeople: unexpected response shape — expected an object with people + pagination');
+        }
+        // Matches arrive under `people`, and historically under `contacts`.
+        const rows = Array.isArray(data.people) ? data.people : Array.isArray(data.contacts) ? data.contacts : [];
+        return { people: rows.filter(isRecord).map(mapPerson), pagination: mapPagination(data.pagination) };
+    }
+
+    // ─── Label writes: the two-step, label-preserving move ───────────────────
+
+    /**
+     * Replace one account's label set with `labelNames` — which must be the
+     * COMPLETE intended set, because Apollo overwrites wholesale (quirk #1).
+     * Master key required.
+     */
+    private async updateAccountLabels(accountId: string, labelNames: string[]): Promise<void> {
+        if (!accountId || accountId.trim().length === 0) {
+            throw new Error('ApolloRESTClient.updateAccountLabels: accountId is required');
+        }
+        await this.request({
+            method: 'PATCH',
+            path: `/accounts/${encodeURIComponent(accountId)}`,
+            context: 'updateAccountLabels',
+            body: { label_names: labelNames },
+            masterKeyOp: true,
+        });
+    }
+
+    /** The same for one contact. Identical full-replace and master-key semantics. */
+    private async updateContactLabels(contactId: string, labelNames: string[]): Promise<void> {
+        if (!contactId || contactId.trim().length === 0) {
+            throw new Error('ApolloRESTClient.updateContactLabels: contactId is required');
+        }
+        await this.request({
+            method: 'PATCH',
+            path: `/contacts/${encodeURIComponent(contactId)}`,
+            context: 'updateContactLabels',
+            body: { label_names: labelNames },
+            masterKeyOp: true,
+        });
+    }
+
+    /**
+     * Re-read one account's current labels for the verify pass (quirk #2), by
+     * searching the destination list and matching on id. Null when the record is
+     * not on that page, which is not the same as "the remove worked" — hence
+     * `possiblyStuck` stays null rather than becoming false.
+     */
+    private async readAccountLabels(accountId: string, toListLabelId: string | null): Promise<string[] | null> {
+        const filter: ApolloAccountSearchFilter = toListLabelId ? { labelIds: [toListLabelId] } : {};
+        const pageData = await this.searchAccounts(filter, { page: 1, perPage: MAX_PER_PAGE });
+        const found = pageData.accounts.find((a) => a.id === accountId);
+        return found ? found.labelNames : null;
+    }
+
+    private async readContactLabels(contactId: string, toListLabelId: string | null): Promise<string[] | null> {
+        const filter: ApolloContactSearchFilter = toListLabelId ? { labelIds: [toListLabelId] } : {};
+        const pageData = await this.searchContacts(filter, { page: 1, perPage: MAX_PER_PAGE });
+        const found = pageData.contacts.find((c) => c.id === contactId);
+        return found ? found.labelNames : null;
+    }
+
+    /**
+     * The ADD phase's label set: current ∪ {toList}. Idempotent — adding a label
+     * the record already carries is a set no-op, so re-running a partial move
+     * does not duplicate anything.
+     */
+    private addPhaseLabels(currentLabels: string[], toList: string): string[] {
+        return currentLabels.includes(toList) ? [...currentLabels] : [...currentLabels, toList];
+    }
+
+    /**
+     * The REMOVE phase's label set: (current ∪ {toList}) \ {fromList}.
+     *
+     * It is computed from the post-add state rather than from `current` so that
+     * the destination label survives the second write. Deriving it from `current`
+     * alone would add the record to the destination and then immediately take it
+     * back out.
+     */
+    private removePhaseLabels(currentLabels: string[], fromList: string, toList: string): string[] {
+        const postAdd = this.addPhaseLabels(currentLabels, toList);
+        return postAdd.filter((l) => l !== fromList);
+    }
+
+    /**
+     * The move engine, shared by accounts and contacts through the injected
+     * update/read closures so the label-preservation math and the stuck detection
+     * exist in exactly one place.
+     */
+    private async moveRecords<T extends { id: string; labelNames: string[] }>(
+        records: T[],
+        fromList: string,
+        toList: string,
+        ops: {
+            update: (id: string, labels: string[]) => Promise<void>;
+            readLabels: (id: string) => Promise<string[] | null>;
+            kind: 'accounts' | 'contacts';
+        },
+        options?: { verify?: boolean },
+    ): Promise<ApolloMoveResult> {
+        if (fromList.trim().length === 0 || toList.trim().length === 0) {
+            throw new Error('ApolloRESTClient.moveRecords: fromList and toList are both required');
+        }
+        if (fromList === toList) {
+            throw new Error(`ApolloRESTClient.moveRecords: fromList and toList are identical ('${fromList}') — nothing to move`);
+        }
+
+        const verify = options?.verify === true;
+        const items: ApolloMoveItemResult[] = [];
+        let movedCount = 0;
+        let failedCount = 0;
+        let possiblyStuckCount = 0;
+
+        for (const record of records) {
+            const item: ApolloMoveItemResult = { id: record.id, added: false, removed: false, possiblyStuck: null, error: null };
+
+            // Phase 1 — add the destination, preserving every current label (quirk #1).
+            try {
+                await ops.update(record.id, this.addPhaseLabels(record.labelNames, toList));
+                item.added = true;
+            } catch (error) {
+                item.error = `add phase: ${error instanceof Error ? error.message : String(error)}`;
+                failedCount++;
+                items.push(item);
+                // Never attempt the remove when the add failed — that would strip the
+                // record from the source list without it having reached the destination.
+                continue;
+            }
+
+            // Phase 2 — remove the source, from the post-add state (quirk #1).
+            try {
+                await ops.update(record.id, this.removePhaseLabels(record.labelNames, fromList, toList));
+                item.removed = true;
+            } catch (error) {
+                item.error = `remove phase: ${error instanceof Error ? error.message : String(error)}`;
+                failedCount++;
+                items.push(item);
+                continue;
+            }
+
+            // Optional verify — catches Apollo's silent-fail removes (quirk #2).
+            if (verify) {
+                try {
+                    const after = await ops.readLabels(record.id);
+                    // A null read means the record was not on the destination page,
+                    // which is not evidence that the remove worked — so the stuck
+                    // state stays unknown rather than being reported as verified.
+                    item.possiblyStuck = after === null ? null : after.includes(fromList);
+                } catch (error) {
+                    // A failed verify read is not a failed move. Note it and leave the
+                    // stuck state unknown rather than guessing either way.
+                    LogStatus(
+                        `ApolloRESTClient.move(${ops.kind}): verify re-read failed for ${record.id} — leaving possiblyStuck=null: ` +
+                        `${error instanceof Error ? error.message : String(error)}`,
+                    );
+                }
+            }
+
+            if (item.possiblyStuck === true) {
+                possiblyStuckCount++;
+            } else {
+                movedCount++;
+            }
+            items.push(item);
+        }
+
+        LogStatus(
+            `ApolloRESTClient.move(${ops.kind}): '${fromList}' → '${toList}' — ${movedCount} moved, ` +
+            `${possiblyStuckCount} possibly stuck (Apollo silent-fail, retried on the next drain), ${failedCount} failed of ${records.length}.`,
+        );
+
+        return { movedCount, failedCount, possiblyStuckCount, items };
+    }
+
+    /**
+     * Move accounts between lists. The supplied accounts must carry current
+     * `labelNames` from a fresh {@link searchAccounts} read — this method writes
+     * whatever it is given as the intended set, so stale labels here mean real
+     * memberships silently disappear.
+     *
+     * With `verify`, the destination list is re-read after each remove to flag
+     * silent-fail records. Never deletes, never auto-retries.
+     */
+    public async moveAccounts(
+        accounts: ApolloAccount[],
+        fromList: string,
+        toList: string,
+        options?: { verify?: boolean },
+    ): Promise<ApolloMoveResult> {
+        // Resolve the destination label id once, for the verify re-reads.
+        const toLabelId = options?.verify ? (await this.findLabelByName(toList))?.id ?? null : null;
+        return this.moveRecords(
+            accounts,
+            fromList,
+            toList,
+            {
+                update: (id, labels) => this.updateAccountLabels(id, labels),
+                readLabels: (id) => this.readAccountLabels(id, toLabelId),
+                kind: 'accounts',
+            },
+            options,
+        );
+    }
+
+    /** Move contacts between lists. Same two-step and verify semantics as accounts. */
+    public async moveContacts(
+        contacts: ApolloContact[],
+        fromList: string,
+        toList: string,
+        options?: { verify?: boolean },
+    ): Promise<ApolloMoveResult> {
+        const toLabelId = options?.verify ? (await this.findLabelByName(toList))?.id ?? null : null;
+        return this.moveRecords(
+            contacts,
+            fromList,
+            toList,
+            {
+                update: (id, labels) => this.updateContactLabels(id, labels),
+                readLabels: (id) => this.readContactLabels(id, toLabelId),
+                kind: 'contacts',
+            },
+            options,
+        );
+    }
+}

--- a/packages/Actions/ApolloEnrichment/src/lists/ApolloSearchActions.ts
+++ b/packages/Actions/ApolloEnrichment/src/lists/ApolloSearchActions.ts
@@ -1,0 +1,258 @@
+/**
+ * Apollo search actions: page through a list's members, and search Apollo's
+ * people database for net-new prospects.
+ *
+ * The two list-member searches return each record's CURRENT label names, which is
+ * what makes a later move able to preserve the record's other memberships. That is
+ * the reason these are separate from a move action rather than folded into it:
+ * read, decide, then move, with the labels you actually read.
+ */
+import { RegisterClass } from '@memberjunction/global';
+import { LogError } from '@memberjunction/core';
+import { BaseAction } from '@memberjunction/actions';
+import type { ActionResultSimple, RunActionParams } from '@memberjunction/actions-base';
+import type {
+    ApolloAccountSearchFilter,
+    ApolloContactSearchFilter,
+    ApolloPagingOptions,
+    ApolloPeopleSearchFilter,
+} from '../generic/apollo-lists.types.js';
+import { ApolloRESTBaseAction } from './ApolloRESTBaseAction.js';
+import { LIST_NOT_FOUND_HINT, getParam, getParamRaw, parseOptionalIntegerParam, parseStringArrayParam } from './params.js';
+
+/** Shared paging parse for the three search actions. Apollo's caps are 500 pages of 100. */
+function parsePaging(params: RunActionParams): { paging: ApolloPagingOptions; error: string | null } {
+    const pageParsed = parseOptionalIntegerParam(getParamRaw(params, 'Page'), 'Page', { min: 1, max: 500 });
+    if (pageParsed.error !== null) return { paging: {}, error: pageParsed.error };
+    const perPageParsed = parseOptionalIntegerParam(getParamRaw(params, 'PerPage'), 'PerPage', { min: 1, max: 100 });
+    if (perPageParsed.error !== null) return { paging: {}, error: perPageParsed.error };
+
+    const paging: ApolloPagingOptions = {};
+    if (pageParsed.value !== undefined) paging.page = pageParsed.value;
+    if (perPageParsed.value !== undefined) paging.perPage = perPageParsed.value;
+    return { paging, error: null };
+}
+
+/**
+ * Pages through the accounts in an Apollo list, addressed by exact list name.
+ *
+ * Returns each account's id, name, primary domain and current label names.
+ *
+ * When draining a list — reading members in order to move them out — read page 1
+ * every time. Removals shift every later page, so advancing to page 2 skips
+ * records. Read-only.
+ *
+ * Inputs:
+ *   - ListName  (required) exact label name; run Apollo Get Lists to see them
+ *   - Keywords  (optional) organization-name filter within the list
+ *   - Page      (optional, default 1, max 500)
+ *   - PerPage   (optional, default 100, max 100)
+ *   - CompanyID (optional) per-company credential resolution
+ *
+ * Outputs:
+ *   - Accounts / Pagination / Count / ResolvedListName / ListID / KeySource
+ */
+@RegisterClass(BaseAction, 'ApolloGetListAccountsAction')
+export class ApolloGetListAccountsAction extends ApolloRESTBaseAction {
+    protected async InternalRunAction(params: RunActionParams): Promise<ActionResultSimple> {
+        const listName = getParam(params, 'ListName');
+        if (!listName) return this.MissingField('ListName');
+        const keywords = getParam(params, 'Keywords');
+
+        const { paging, error: pagingError } = parsePaging(params);
+        if (pagingError !== null) return this.Invalid(pagingError);
+
+        const { resolved, error } = await this.ResolveClient(params);
+        if (error) return error;
+
+        try {
+            const label = await resolved.client.findLabelByName(listName);
+            if (!label) {
+                return {
+                    Success: false,
+                    Message: `No Apollo list named '${listName}' was found. ${LIST_NOT_FOUND_HINT}`,
+                    ResultCode: 'NOT_FOUND',
+                };
+            }
+
+            const filter: ApolloAccountSearchFilter = { labelIds: [label.id] };
+            if (keywords) filter.keywords = keywords;
+
+            const result = await resolved.client.searchAccounts(filter, paging);
+
+            params.Params.push(
+                { Name: 'Accounts', Type: 'Output', Value: result.accounts },
+                { Name: 'Pagination', Type: 'Output', Value: result.pagination },
+                { Name: 'Count', Type: 'Output', Value: result.accounts.length },
+                { Name: 'ResolvedListName', Type: 'Output', Value: label.name },
+                { Name: 'ListID', Type: 'Output', Value: label.id },
+                { Name: 'KeySource', Type: 'Output', Value: resolved.key.source },
+            );
+
+            return {
+                Success: true,
+                Message:
+                    `Apollo accounts in '${label.name}': ${result.accounts.length} on page ${result.pagination.page} ` +
+                    `of ${result.pagination.totalPages} (${result.pagination.totalEntries} total).`,
+                ResultCode: 'SUCCESS',
+                Params: params.Params,
+            };
+        } catch (err) {
+            const msg = err instanceof Error ? err.message : String(err);
+            LogError(`ApolloGetListAccounts: ${msg}`);
+            return { Success: false, Message: `Error fetching Apollo accounts: ${msg}`, ResultCode: 'ERROR' };
+        }
+    }
+}
+
+/**
+ * Pages through the contacts in an Apollo list. Same shape and same drain
+ * discipline as {@link ApolloGetListAccountsAction}; `Keywords` here matches
+ * names, titles, employers and emails rather than organization names.
+ *
+ * Outputs: Contacts / Pagination / Count / ResolvedListName / ListID / KeySource
+ */
+@RegisterClass(BaseAction, 'ApolloGetListContactsAction')
+export class ApolloGetListContactsAction extends ApolloRESTBaseAction {
+    protected async InternalRunAction(params: RunActionParams): Promise<ActionResultSimple> {
+        const listName = getParam(params, 'ListName');
+        if (!listName) return this.MissingField('ListName');
+        const keywords = getParam(params, 'Keywords');
+
+        const { paging, error: pagingError } = parsePaging(params);
+        if (pagingError !== null) return this.Invalid(pagingError);
+
+        const { resolved, error } = await this.ResolveClient(params);
+        if (error) return error;
+
+        try {
+            const label = await resolved.client.findLabelByName(listName);
+            if (!label) {
+                return {
+                    Success: false,
+                    Message: `No Apollo list named '${listName}' was found. ${LIST_NOT_FOUND_HINT}`,
+                    ResultCode: 'NOT_FOUND',
+                };
+            }
+
+            const filter: ApolloContactSearchFilter = { labelIds: [label.id] };
+            if (keywords) filter.keywords = keywords;
+
+            const result = await resolved.client.searchContacts(filter, paging);
+
+            params.Params.push(
+                { Name: 'Contacts', Type: 'Output', Value: result.contacts },
+                { Name: 'Pagination', Type: 'Output', Value: result.pagination },
+                { Name: 'Count', Type: 'Output', Value: result.contacts.length },
+                { Name: 'ResolvedListName', Type: 'Output', Value: label.name },
+                { Name: 'ListID', Type: 'Output', Value: label.id },
+                { Name: 'KeySource', Type: 'Output', Value: resolved.key.source },
+            );
+
+            return {
+                Success: true,
+                Message:
+                    `Apollo contacts in '${label.name}': ${result.contacts.length} on page ${result.pagination.page} ` +
+                    `of ${result.pagination.totalPages} (${result.pagination.totalEntries} total).`,
+                ResultCode: 'SUCCESS',
+                Params: params.Params,
+            };
+        } catch (err) {
+            const msg = err instanceof Error ? err.message : String(err);
+            LogError(`ApolloGetListContacts: ${msg}`);
+            return { Success: false, Message: `Error fetching Apollo contacts: ${msg}`, ResultCode: 'ERROR' };
+        }
+    }
+}
+
+/**
+ * Searches Apollo's people database for net-new prospects by organization, title
+ * and seniority — the list-building workhorse.
+ *
+ * This endpoint does not return emails or phones. That is Apollo's design, not an
+ * omission here: contact details come from the enrichment actions in this package,
+ * which are metered separately.
+ *
+ * At least one filter is required. Apollo will accept a request with none and
+ * return an unscoped result set, which burns the rate limit to produce something
+ * nobody asked for, so that case is rejected before the call.
+ *
+ * Inputs:
+ *   - OrganizationDomains (optional) company domains
+ *   - OrganizationIDs     (optional) Apollo organization ids
+ *   - Titles              (optional) job titles, e.g. ["VP of Marketing"]
+ *   - Seniorities         (optional) owner | founder | c_suite | vp | director | manager
+ *   - Page / PerPage      (optional)
+ *   - CompanyID           (optional)
+ *
+ * Each list param accepts a real array, a JSON array string, or a
+ * comma-separated string.
+ *
+ * Outputs: People / Pagination / Count / KeySource
+ */
+@RegisterClass(BaseAction, 'ApolloSearchPeopleAction')
+export class ApolloSearchPeopleAction extends ApolloRESTBaseAction {
+    protected async InternalRunAction(params: RunActionParams): Promise<ActionResultSimple> {
+        const domainsParsed = parseStringArrayParam(getParamRaw(params, 'OrganizationDomains'), 'OrganizationDomains');
+        if (domainsParsed.error !== null) return this.Invalid(domainsParsed.error);
+        const orgIdsParsed = parseStringArrayParam(getParamRaw(params, 'OrganizationIDs'), 'OrganizationIDs');
+        if (orgIdsParsed.error !== null) return this.Invalid(orgIdsParsed.error);
+        const titlesParsed = parseStringArrayParam(getParamRaw(params, 'Titles'), 'Titles');
+        if (titlesParsed.error !== null) return this.Invalid(titlesParsed.error);
+        const senioritiesParsed = parseStringArrayParam(getParamRaw(params, 'Seniorities'), 'Seniorities');
+        if (senioritiesParsed.error !== null) return this.Invalid(senioritiesParsed.error);
+
+        const { paging, error: pagingError } = parsePaging(params);
+        if (pagingError !== null) return this.Invalid(pagingError);
+
+        if (
+            domainsParsed.value === undefined &&
+            orgIdsParsed.value === undefined &&
+            titlesParsed.value === undefined &&
+            senioritiesParsed.value === undefined
+        ) {
+            return this.Invalid(
+                'Provide at least one of OrganizationDomains, OrganizationIDs, Titles, or Seniorities — ' +
+                'an unscoped people search returns a rate-limited firehose.',
+            );
+        }
+
+        const { resolved, error } = await this.ResolveClient(params);
+        if (error) return error;
+
+        try {
+            const filter: ApolloPeopleSearchFilter = {};
+            if (domainsParsed.value) filter.organizationDomains = domainsParsed.value;
+            if (orgIdsParsed.value) filter.organizationIds = orgIdsParsed.value;
+            if (titlesParsed.value) filter.titles = titlesParsed.value;
+            if (senioritiesParsed.value) filter.seniorities = senioritiesParsed.value;
+
+            const result = await resolved.client.searchPeople(filter, paging);
+
+            params.Params.push(
+                { Name: 'People', Type: 'Output', Value: result.people },
+                { Name: 'Pagination', Type: 'Output', Value: result.pagination },
+                { Name: 'Count', Type: 'Output', Value: result.people.length },
+                { Name: 'KeySource', Type: 'Output', Value: resolved.key.source },
+            );
+
+            return {
+                Success: true,
+                Message:
+                    `Apollo people search: ${result.people.length} on page ${result.pagination.page} ` +
+                    `of ${result.pagination.totalPages} (${result.pagination.totalEntries} total). ` +
+                    `Emails and phones are not returned by this endpoint.`,
+                ResultCode: 'SUCCESS',
+                Params: params.Params,
+            };
+        } catch (err) {
+            const msg = err instanceof Error ? err.message : String(err);
+            LogError(`ApolloSearchPeople: ${msg}`);
+            return { Success: false, Message: `Error searching Apollo people: ${msg}`, ResultCode: 'ERROR' };
+        }
+    }
+}
+
+export function LoadApolloSearchActions(): void {
+    // Referenced by consumers to keep these registrations from being tree-shaken.
+}

--- a/packages/Actions/ApolloEnrichment/src/lists/credentials.ts
+++ b/packages/Actions/ApolloEnrichment/src/lists/credentials.ts
@@ -1,0 +1,150 @@
+/**
+ * API-key resolution for the Apollo list and search actions.
+ *
+ * Two paths, in this order:
+ *
+ *   1. A `CompanyID` param → that company's active Apollo `MJ: Company Integrations`
+ *      row → its `CredentialID` → the `apiKey` inside `MJ: Credentials.Values`.
+ *      This is the multi-tenant path: several companies in one instance, each with
+ *      its own Apollo workspace and its own key.
+ *   2. `APOLLO_API_KEY` from the environment, which is what the enrichment actions
+ *      in this package have always used. Single-tenant deployments keep working
+ *      without any credential rows.
+ *
+ * `CompanyIntegration.APIKey` is deliberately NOT read, even though it exists and
+ * looks like the obvious place. That column is not a decrypt-on-read field, so a
+ * key written through metadata sync comes back as the literal ciphertext string
+ * `$ENC$…`. Sending that to Apollo produces a 401 whose message says nothing about
+ * encryption, and the failure looks exactly like a wrong key. `MJ: Credentials` is
+ * the field that decrypts, so it is the only one used.
+ *
+ * Every write in this surface needs a MASTER Apollo key. That is not something
+ * this code can detect ahead of time — a scoped key authenticates fine and then
+ * 403s on the first PATCH — so the client turns that 403 into an explanation, and
+ * the message below names the requirement up front.
+ */
+import { LogError, Metadata, RunView, type UserInfo } from '@memberjunction/core';
+import type { MJCompanyIntegrationEntityType, MJCredentialEntity } from '@memberjunction/core-entities';
+import { ApolloAPIKey } from '../config.js';
+
+/** The integration name looked up on the CompanyIntegration row. */
+export const APOLLO_INTEGRATION_NAME = 'Apollo';
+
+/** The standard failure text when neither resolution path yields a key. */
+export const NO_APOLLO_KEY_MESSAGE =
+    `No Apollo API key could be resolved. Either link an active '${APOLLO_INTEGRATION_NAME}' ` +
+    `MJ: Company Integrations row for the supplied CompanyID to an MJ: Credentials record whose Values ` +
+    `contain { "apiKey": "…" }, or set the APOLLO_API_KEY environment variable. ` +
+    `List reads and every write require a MASTER Apollo key — scoped keys return 403.`;
+
+/** Where a resolved key came from, so an action can say so in its output. */
+export interface ResolvedApolloKey {
+    apiKey: string;
+    source: 'credential' | 'environment';
+    /** The CompanyIntegration row's id when resolved through a company; null otherwise. */
+    companyIntegrationID: string | null;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+    return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+/**
+ * Pull the Apollo key out of a credential's `Values` JSON.
+ *
+ * Several key names are accepted because credential records get authored by hand
+ * and the casing varies. A `Values` blob that will not parse throws rather than
+ * falling through to the environment — a present-but-broken credential is a
+ * configuration error worth surfacing, not a reason to silently use a different
+ * workspace's key.
+ */
+export function extractApolloKey(values: string | null | undefined, credentialName: string): string | null {
+    if (!values || values.trim().length === 0) return null;
+    let parsed: unknown;
+    try {
+        parsed = JSON.parse(values);
+    } catch (error) {
+        const msg = error instanceof Error ? error.message : String(error);
+        throw new Error(`Apollo credential '${credentialName}' has a Values payload that is not valid JSON: ${msg}`);
+    }
+    if (!isRecord(parsed)) {
+        throw new Error(`Apollo credential '${credentialName}' Values must be a JSON object containing an apiKey.`);
+    }
+    for (const key of ['apiKey', 'APIKey', 'api_key', 'ApiKey', 'masterApiKey']) {
+        const candidate = parsed[key];
+        if (typeof candidate === 'string' && candidate.trim().length > 0) {
+            return candidate.trim();
+        }
+    }
+    return null;
+}
+
+/**
+ * Resolve the key for this run. `companyID` is optional: without it, only the
+ * environment is consulted.
+ *
+ * Returns null rather than throwing when nothing is configured, so an action can
+ * answer with `CREDENTIALS_NOT_FOUND` instead of a stack trace. A credential that
+ * exists but is malformed does throw — see {@link extractApolloKey}.
+ */
+export async function resolveApolloAPIKey(
+    companyID: string | null,
+    contextUser: UserInfo | undefined,
+): Promise<ResolvedApolloKey | null> {
+    if (companyID) {
+        const fromCredential = await resolveFromCompany(companyID, contextUser);
+        if (fromCredential) return fromCredential;
+    }
+    const env = ApolloAPIKey.trim();
+    if (env.length > 0) {
+        return { apiKey: env, source: 'environment', companyIntegrationID: null };
+    }
+    return null;
+}
+
+async function resolveFromCompany(companyID: string, contextUser: UserInfo | undefined): Promise<ResolvedApolloKey | null> {
+    const rv = new RunView();
+    const result = await rv.RunView<MJCompanyIntegrationEntityType>(
+        {
+            EntityName: 'MJ: Company Integrations',
+            // IsActive is nullable, so an unset flag must not exclude the row —
+            // a company with one Apollo integration and a NULL IsActive is the
+            // common shape after a hand-authored insert.
+            ExtraFilter: `CompanyID = '${companyID}' AND Integration = '${APOLLO_INTEGRATION_NAME}' AND (IsActive IS NULL OR IsActive = 1)`,
+            ResultType: 'simple',
+        },
+        contextUser,
+    );
+    if (!result.Success) {
+        LogError(`resolveApolloAPIKey: reading MJ: Company Integrations failed — ${result.ErrorMessage ?? 'unknown error'}`);
+        return null;
+    }
+    const row = result.Results?.[0];
+    if (!row) return null;
+    if (!row.CredentialID) {
+        LogError(
+            `resolveApolloAPIKey: CompanyIntegration ${row.ID} has no CredentialID. ` +
+            `The APIKey column is not read — it is not decrypt-on-read, so a synced value comes back as ciphertext. ` +
+            `Link an MJ: Credentials record instead.`,
+        );
+        return null;
+    }
+
+    const md = new Metadata();
+    const credential = await md.GetEntityObject<MJCredentialEntity>('MJ: Credentials', contextUser);
+    const loaded = await credential.Load(row.CredentialID);
+    if (!loaded) {
+        LogError(`resolveApolloAPIKey: MJ: Credentials record ${row.CredentialID} could not be loaded.`);
+        return null;
+    }
+    if (credential.IsActive === false) {
+        LogError(`resolveApolloAPIKey: MJ: Credentials record '${credential.Name}' is inactive.`);
+        return null;
+    }
+    const apiKey = extractApolloKey(credential.Values, credential.Name);
+    if (!apiKey) {
+        LogError(`resolveApolloAPIKey: MJ: Credentials record '${credential.Name}' contains no apiKey value.`);
+        return null;
+    }
+    return { apiKey, source: 'credential', companyIntegrationID: row.ID };
+}

--- a/packages/Actions/ApolloEnrichment/src/lists/params.ts
+++ b/packages/Actions/ApolloEnrichment/src/lists/params.ts
@@ -1,0 +1,140 @@
+/**
+ * Parameter parsing for the Apollo list and search actions.
+ *
+ * Pure functions over raw param values, with no framework imports, so every
+ * action validates its inputs identically and the validation is testable without
+ * constructing an action. They report problems as strings; the actions own the
+ * `Success`/`ResultCode` shape.
+ *
+ * The permissiveness is deliberate. These actions are called from three places
+ * that supply values in three different forms: an agent's input mapping passes a
+ * real array, an LLM writing params passes a JSON string, and a human testing in
+ * the UI types `owner, founder`. All three mean the same thing, so all three are
+ * accepted — while genuinely malformed input still fails loudly rather than
+ * silently becoming an empty filter, which on a people search is the difference
+ * between a scoped query and an unscoped firehose.
+ */
+import type { ActionParam, RunActionParams } from '@memberjunction/actions-base';
+
+/** A parse result: a value, or an error explaining what the value should have been. */
+export interface ParsedParam<T> {
+    value: T | undefined;
+    error: string | null;
+}
+
+/** Look up a param's raw value, unconverted. */
+export function getParamRaw(params: RunActionParams, name: string): unknown {
+    const lowered = name.trim().toLowerCase();
+    const found = params.Params?.find((p: ActionParam) => p.Name?.trim().toLowerCase() === lowered);
+    return found?.Value;
+}
+
+/**
+ * Look up a param as a trimmed non-empty string, or null.
+ *
+ * Returns null for whitespace as well as for absent, so a required-field check
+ * treats `'   '` the way the caller meant it rather than passing a blank list
+ * name into a label lookup.
+ */
+export function getParam(params: RunActionParams, name: string): string | null {
+    const raw = getParamRaw(params, name);
+    if (typeof raw !== 'string') {
+        return raw === null || raw === undefined ? null : String(raw).trim() || null;
+    }
+    return raw.trim() || null;
+}
+
+/**
+ * Normalize an optional array-of-strings param. Accepts a real array, a JSON
+ * array string, or a bare comma-separated string. Absent or empty yields
+ * `undefined` with no error — "not supplied" is a valid state for every filter
+ * that uses this.
+ */
+export function parseStringArrayParam(raw: unknown, name: string): ParsedParam<string[]> {
+    if (raw === null || raw === undefined || raw === '') {
+        return { value: undefined, error: null };
+    }
+    let value: unknown = raw;
+    if (typeof value === 'string') {
+        const trimmed = value.trim();
+        if (trimmed.startsWith('[')) {
+            try {
+                value = JSON.parse(trimmed);
+            } catch (error) {
+                const msg = error instanceof Error ? error.message : String(error);
+                return { value: undefined, error: `${name} must be a JSON array of strings — got an unparseable string (${msg})` };
+            }
+        } else {
+            // The comma-separated convenience form, e.g. "owner, founder".
+            value = trimmed.split(',').map((s) => s.trim()).filter((s) => s.length > 0);
+        }
+    }
+    if (!Array.isArray(value) || !value.every((v): v is string => typeof v === 'string')) {
+        return { value: undefined, error: `${name} must be a JSON array of strings (e.g. ["VP of Marketing"])` };
+    }
+    const cleaned = (value as string[]).map((s) => s.trim()).filter((s) => s.length > 0);
+    return { value: cleaned.length > 0 ? cleaned : undefined, error: null };
+}
+
+/**
+ * Normalize an optional integer param. Accepts a number or a numeric string.
+ * Rejects non-integers rather than rounding: a page of 1.5 is a caller mistake,
+ * and silently reading page 1 would return plausible wrong data.
+ */
+export function parseOptionalIntegerParam(
+    raw: unknown,
+    name: string,
+    options?: { min?: number; max?: number },
+): ParsedParam<number> {
+    if (raw === null || raw === undefined || raw === '') {
+        return { value: undefined, error: null };
+    }
+    let value: number;
+    if (typeof raw === 'number') {
+        value = raw;
+    } else if (typeof raw === 'string') {
+        value = Number(raw.trim());
+    } else {
+        return { value: undefined, error: `${name} must be a number (got ${typeof raw})` };
+    }
+    if (!Number.isInteger(value)) {
+        return { value: undefined, error: `${name} must be an integer (got '${String(raw)}')` };
+    }
+    const min = options?.min;
+    if (min !== undefined && value < min) {
+        return { value: undefined, error: `${name} must be >= ${min} (got ${value})` };
+    }
+    const max = options?.max;
+    if (max !== undefined && value > max) {
+        return { value: undefined, error: `${name} must be <= ${max} (got ${value})` };
+    }
+    return { value, error: null };
+}
+
+/**
+ * Normalize an optional boolean param. Accepts a real boolean or the strings
+ * 'true'/'false', case-insensitive. Anything else is an error rather than a
+ * truthiness coercion — `'false'` is truthy in JavaScript, and treating it as
+ * `true` on a verify flag would be a silent, expensive surprise.
+ */
+export function parseOptionalBooleanParam(raw: unknown, name: string): ParsedParam<boolean> {
+    if (raw === null || raw === undefined || raw === '') {
+        return { value: undefined, error: null };
+    }
+    if (typeof raw === 'boolean') {
+        return { value: raw, error: null };
+    }
+    if (typeof raw === 'string') {
+        const lowered = raw.trim().toLowerCase();
+        if (lowered === 'true') return { value: true, error: null };
+        if (lowered === 'false') return { value: false, error: null };
+    }
+    return { value: undefined, error: `${name} must be a boolean (true or false) — got '${String(raw)}'` };
+}
+
+/**
+ * The remediation tail appended whenever a list name does not resolve. Kept in
+ * one place so every action points the caller at the same next step.
+ */
+export const LIST_NOT_FOUND_HINT =
+    'Run the Apollo Get Lists action to see the exact label names this Apollo account has.';


### PR DESCRIPTION
Adds Apollo's other half to `@memberjunction/actions-apollo`: **list management, saved-record search and prospecting**, as seven new actions alongside the two enrichment actions the package has always had. Ported from AIDP's `ApolloClient` (745 LOC), which is the proven statement of these surfaces' quirks.

`ApolloGetListsAction` / `ApolloCreateListAction` read and create labels; `ApolloGetListAccountsAction` / `ApolloGetListContactsAction` page a list's members; `ApolloSearchPeopleAction` finds net-new prospects; `ApolloMoveListAccountsAction` / `ApolloMoveListContactsAction` move records between lists. Together they are the outbound-campaign surface — build a list, drain it through stages, see what is where — which enrichment alone cannot express.

These use a **different Apollo base path** from enrichment: `api.apollo.io/api/v1`, not `api.apollo.io/v1`. Not interchangeable; the same path under the wrong prefix 404s. So `ApolloRESTEndpoint` is declared beside the existing `ApolloAPIEndpoint` rather than derived from it.

### Five vendor behaviours that make the naive implementation wrong

**A PATCH replaces the whole `label_names` array.** There is no add-one-label endpoint, so a move is *two* writes, each carrying the complete intended set: `current ∪ {toList}`, then `(current ∪ {toList}) \ {fromList}`. Sending a bare `['Warm']` silently deletes every other list the record was on, and nothing in the response reveals it. The remove set is computed from the **post-add** state — deriving it from `current` alone would add the record to the destination then immediately take it back out. The move actions accept only ids, never labels, and re-read the source list themselves, so a caller cannot supply a stale label set that destroys memberships the record picked up since.

**Roughly 15–17% of removes return success without applying.** Removes are verified by re-reading the destination; a record still carrying the source label is reported `possiblyStuck` rather than retried — an immediate retry flakes the same way, while the next page-1 drain sees both labels and finishes the job. Deliberately **not** a failure: the write succeeded and Apollo did not honour it, so calling it a failure sends the caller hunting a bug in the request. `PARTIAL_FAILURE` is reserved for a PATCH that actually failed. When the verify read itself fails, the stuck state is `null` — unknown, not verified-clean.

**A list drain must always read page 1**, because removals shift every later page, so advancing to page 2 skips records. Paging defaults to page 1 rather than a saved position; the move actions pin it explicitly.

**Label reads and every write require a MASTER key.** A scoped key authenticates fine and then 403s, indistinguishable from a wrong key — so a 403 on a master-key operation is rewritten to name the requirement. The prospecting search is the one read a scoped key can serve, so it deliberately skips the label fetch.

**Labels are read as `label_ids` but written as `label_names`.** The client fetches the label list once per instance and resolves ids on read; an unmatched id is dropped, since a raw id inside a `label_names` write would create a label named after a hex string.

### Two smaller invariants

`ApolloCreateListAction` is idempotent — a same-named label returns as-is with `AlreadyExisted: true`. Apollo will happily create two labels with one name, and once it has, every name-based lookup here becomes ambiguous: half the moves target one list, half the other. `ApolloSearchPeopleAction` requires at least one filter; Apollo accepts a filterless request and returns an unscoped, rate-limit-burning result set nobody asked for.

### Credentials

`CompanyID` → the company's active `Apollo` **MJ: Company Integrations** row → `CredentialID` → `apiKey` in **MJ: Credentials** `Values`, falling back to `APOLLO_API_KEY` so existing single-tenant deployments keep working. `CompanyIntegration.APIKey` is deliberately **not** read — it is not decrypt-on-read, so a key written through metadata sync returns the literal `$ENC$…` and produces a 401 that looks exactly like a wrong key. A credential that exists but will not parse fails `CONFIGURATION_ERROR` rather than silently borrowing another workspace's key from the environment.

### Verification

92 tests, driving the client through an injected `fetch` so the request bodies Apollo would receive are asserted directly — which matters more than usual, because a move that sends the wrong label array is invisible in the response. Nothing in the suite can reach api.apollo.io: a live read would spend credits and a live write would mutate a real account's lists with no undo.

The two enrichment actions are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)