### PR TITLE
feat(core-actions): Tavily Search and Read RSS Feed actions

### DIFF
--- a/.changeset/core-actions-tavily-and-rss.md
+++ b/.changeset/core-actions-tavily-and-rss.md
@@ -1,0 +1,19 @@
+---
+"@memberjunction/core-actions": minor
+---
+
+Add two web-read actions — **Tavily Search** and **Read RSS Feed** — and fix an environment-variable fallback that never worked.
+
+**Tavily Search** (`custom/web/tavily-search.action.ts`) searches through Tavily, whose results arrive as extracted page content rather than as snippets plus links to go fetch. Two capabilities distinguish it from the other search actions here: `Topic: 'news'` is the only topic that returns a publication date per result and the only one the `Days` window applies to, which is what makes recency-sensitive questions answerable; and `IncludeAnswer` returns a synthesized answer alongside the results, so a caller that only needs the conclusion does not have to run its own summarization pass. Authentication is `Authorization: Bearer <key>` — Tavily still accepts an `api_key` body field, but that form puts the credential in the payload and is not used.
+
+Deliberate behaviours: `MaxResults` is **clamped** to Tavily's cap of 20 rather than rejected, because a caller asking for 50 wants as many as possible and the vendor rejects the whole request above the cap. `Days` on a non-news topic is **dropped with the reason stated** in a `Warnings` output param, since silently forwarding it would leave the caller believing their window applied. Zero results is `Success: true` — a narrow query has a real, empty answer, and reporting failure would send a caller into retrying a query that will keep returning nothing. Failure modes are separated so a caller can act on them: `INVALID_API_KEY` (401/403), `RATE_LIMITED` (429), `INVALID_REQUEST` (400/422, retrying unchanged is pointless), `API_ERROR`, and `SEARCH_FAILED` for a failure with no HTTP response at all.
+
+**Read RSS Feed** (`custom/web/rss-feed-read.action.ts`, with the parsing and scoring split out as the dependency-free `custom/web/rss-feed-parsing.ts`) reads any number of RSS 2.0 or Atom feeds, filters by article age, and optionally scores articles for keyword relevance and recency. It needs no credential.
+
+Parsing is regex-based rather than using a strict XML parser, on purpose: feeds in the wild are frequently malformed, and a strict parser fails the entire document over one unescaped ampersand where the regex costs only the affected item's text. Text extraction decodes entities *before* stripping tags, because RSS descriptions overwhelmingly arrive with their HTML escaped (`&lt;p&gt;`, not `<p>`) — strip first and those tags survive as literal text in the output. A second decode pass afterward finishes values that were escaped twice.
+
+One feed failing is a `FeedStatuses` entry, not an action failure, unless `RequireAllFeeds` is set; feed URLs must be http(s) so this cannot become a local file reader. Undated articles are excluded by default and **counted**, as are articles dropped by the age window, and every such count appears in the result message — so an unexpectedly small answer is explained rather than merely small. A single injected clock serves the whole run, so the age filter and the recency score cannot disagree about what "now" is.
+
+**Fix:** `getCoreActionsConfig()` early-returned an empty parsed config whenever no `mj.config.cjs` was found, so environment variables were ignored entirely — contradicting every schema doc comment and every "or `X_API_KEY` environment variable" error message in the package. A deployment configured only through the environment got a config with no keys and every affected action reported its key as missing. The config build is now hoisted out of that early return, so the documented fallbacks (`PERPLEXITY_API_KEY`, `TAVILY_API_KEY`, `GAMMA_API_KEY`, the Google keys) work as described.
+
+103 new tests cover both actions and the parsing module.

--- a/packages/Actions/CoreActions/src/__tests__/rss-feed.test.ts
+++ b/packages/Actions/CoreActions/src/__tests__/rss-feed.test.ts
@@ -1,0 +1,553 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// ---------------------------------------------------------------------------
+// The pure parsing/scoring module has no framework imports at all, so it needs
+// no mocks. The action does — but only for the decorator and the loggers.
+// ---------------------------------------------------------------------------
+vi.mock('@memberjunction/actions', () => ({
+    BaseAction: class BaseAction {
+        public async Run(params: unknown): Promise<unknown> {
+            return (this as unknown as { InternalRunAction(p: unknown): Promise<unknown> }).InternalRunAction(params);
+        }
+    },
+}));
+
+vi.mock('@memberjunction/global', () => ({
+    RegisterClass: () => (target: unknown) => target,
+}));
+
+vi.mock('@memberjunction/core', () => ({
+    LogError: vi.fn(),
+    LogStatus: vi.fn(),
+}));
+
+vi.mock('@memberjunction/actions-base', () => ({}));
+
+import {
+    RELEVANCE_WEIGHTS,
+    computeRecencyScore,
+    computeRelevanceScore,
+    filterByAge,
+    filterRelevant,
+    parseFeedArticles,
+    parseFeedDate,
+    scoreAndRankArticles,
+    stripHtml,
+    type FeedArticle,
+} from '../custom/web/rss-feed-parsing';
+import { ReadRSSFeedAction } from '../custom/web/rss-feed-read.action';
+
+const NOW = new Date('2026-08-05T12:00:00Z');
+
+/** An article at a given age in days, with whatever fields the test cares about. */
+function article(overrides: Partial<FeedArticle> & { ageDays?: number } = {}): FeedArticle {
+    const { ageDays, ...rest } = overrides;
+    return {
+        title: 'A title',
+        link: 'https://example.org/a',
+        description: '',
+        publishedAt: ageDays === undefined ? NOW.toISOString() : new Date(NOW.getTime() - ageDays * 86400000).toISOString(),
+        categories: [],
+        feedName: 'Example',
+        ...rest,
+    };
+}
+
+const RSS_FEED = `<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0">
+  <channel>
+    <title>Channel Title</title>
+    <item>
+      <title>Membership dues are rising</title>
+      <link>https://example.org/dues</link>
+      <description>&lt;p&gt;Associations raised &amp;amp; restructured dues.&lt;/p&gt;</description>
+      <pubDate>Tue, 04 Aug 2026 09:00:00 GMT</pubDate>
+      <category>Membership</category>
+      <category>Finance</category>
+    </item>
+    <item>
+      <title><![CDATA[Retention playbooks]]></title>
+      <guid isPermaLink="true">https://example.org/retention</guid>
+      <description><![CDATA[<b>Retention</b> tactics that worked]]></description>
+      <pubDate>Mon, 03 Aug 2026 09:00:00 GMT</pubDate>
+    </item>
+  </channel>
+</rss>`;
+
+const ATOM_FEED = `<?xml version="1.0" encoding="utf-8"?>
+<feed xmlns="http://www.w3.org/2005/Atom">
+  <title>Atom Channel</title>
+  <entry>
+    <title>Board governance changes</title>
+    <link rel="alternate" href="https://example.net/governance"/>
+    <summary>New rules for nonprofit boards</summary>
+    <published>2026-08-04T10:00:00Z</published>
+    <category term="Governance"/>
+  </entry>
+</feed>`;
+
+// =====================================================================
+// Parsing
+// =====================================================================
+
+describe('parseFeedArticles — RSS 2.0', () => {
+    it('extracts every item field', () => {
+        const articles = parseFeedArticles(RSS_FEED, 'Example');
+        expect(articles).toHaveLength(2);
+        expect(articles[0]).toEqual({
+            title: 'Membership dues are rising',
+            link: 'https://example.org/dues',
+            description: 'Associations raised & restructured dues.',
+            publishedAt: '2026-08-04T09:00:00.000Z',
+            categories: ['Membership', 'Finance'],
+            feedName: 'Example',
+        });
+    });
+
+    it('reads CDATA titles and descriptions', () => {
+        const articles = parseFeedArticles(RSS_FEED, 'Example');
+        expect(articles[1].title).toBe('Retention playbooks');
+        expect(articles[1].description).toBe('Retention tactics that worked');
+    });
+
+    it('falls back to a permalink guid when there is no link', () => {
+        const articles = parseFeedArticles(RSS_FEED, 'Example');
+        expect(articles[1].link).toBe('https://example.org/retention');
+    });
+
+    it('does not pick up a non-permalink guid as the link', () => {
+        // An opaque guid is not a URL; emitting it would produce a dead link.
+        const xml = `<rss><channel><item><title>T</title><guid isPermaLink="false">abc-123</guid></item></channel></rss>`;
+        expect(parseFeedArticles(xml, 'F')[0].link).toBe('');
+    });
+
+    it('ignores the channel-level title', () => {
+        // The channel <title> sits outside every <item>, so item parsing must not see it.
+        expect(parseFeedArticles(RSS_FEED, 'Example').map(a => a.title)).not.toContain('Channel Title');
+    });
+
+    it('skips an item with no title, since there is nothing to rank', () => {
+        const xml = `<rss><channel><item><link>https://x.test/a</link></item><item><title>Kept</title></item></channel></rss>`;
+        expect(parseFeedArticles(xml, 'F').map(a => a.title)).toEqual(['Kept']);
+    });
+
+    it('reads content:encoded when there is no description', () => {
+        const xml = `<rss><channel><item><title>T</title><content:encoded><![CDATA[<p>Body text</p>]]></content:encoded></item></channel></rss>`;
+        expect(parseFeedArticles(xml, 'F')[0].description).toBe('Body text');
+    });
+
+    it('truncates a description that inlines a whole article body', () => {
+        const xml = `<rss><channel><item><title>T</title><description>${'x'.repeat(900)}</description></item></channel></rss>`;
+        expect(parseFeedArticles(xml, 'F')[0].description).toHaveLength(500);
+    });
+
+    it('reads dc:date as a last resort', () => {
+        const xml = `<rss><channel><item><title>T</title><dc:date>2026-08-01T00:00:00Z</dc:date></item></channel></rss>`;
+        expect(parseFeedArticles(xml, 'F')[0].publishedAt).toBe('2026-08-01T00:00:00.000Z');
+    });
+
+    it('keeps an undated item rather than dropping it silently', () => {
+        // Dropping it here would make it invisible; filterByAge decides its fate,
+        // and reports the count when it does.
+        const xml = `<rss><channel><item><title>No date</title></item></channel></rss>`;
+        expect(parseFeedArticles(xml, 'F')[0].publishedAt).toBeNull();
+    });
+
+    it('keeps an item with an unparseable date, as undated', () => {
+        const xml = `<rss><channel><item><title>T</title><pubDate>last Thursday</pubDate></item></channel></rss>`;
+        expect(parseFeedArticles(xml, 'F')[0].publishedAt).toBeNull();
+    });
+
+    it('parses every item when one carries content a strict parser would reject', () => {
+        // The reason for regex parsing over a strict XML parser: a bare ampersand or a
+        // stray character costs that item's text, not the whole document. (An item whose
+        // own tag is never closed is a different matter — the lazy block match swallows
+        // whatever follows it, so graceful degradation covers bad content, not bad tags.)
+        const xml =
+            `<rss><channel>` +
+            `<item><title>Broken & unescaped</title></item>` +
+            `<item><title>Second</title></item>` +
+            `</channel></rss>`;
+        expect(parseFeedArticles(xml, 'F').map(a => a.title)).toEqual(['Broken & unescaped', 'Second']);
+    });
+
+    it('returns nothing for an empty or non-feed document instead of throwing', () => {
+        expect(parseFeedArticles('', 'F')).toEqual([]);
+        expect(parseFeedArticles('<html><body>not a feed</body></html>', 'F')).toEqual([]);
+    });
+
+    it('does not match a tag that merely starts with the name it was asked for', () => {
+        const xml = `<rss><channel><item><titleAlternate>Wrong</titleAlternate><title>Right</title></item></channel></rss>`;
+        expect(parseFeedArticles(xml, 'F')[0].title).toBe('Right');
+    });
+});
+
+describe('parseFeedArticles — Atom', () => {
+    it('reads entries, href links, summaries and term categories', () => {
+        const articles = parseFeedArticles(ATOM_FEED, 'Atom');
+        expect(articles).toHaveLength(1);
+        expect(articles[0]).toEqual({
+            title: 'Board governance changes',
+            link: 'https://example.net/governance',
+            description: 'New rules for nonprofit boards',
+            publishedAt: '2026-08-04T10:00:00.000Z',
+            categories: ['Governance'],
+            feedName: 'Atom',
+        });
+    });
+
+    it('prefers published over updated', () => {
+        const xml = `<feed><entry><title>T</title><published>2026-08-01T00:00:00Z</published><updated>2026-08-04T00:00:00Z</updated></entry></feed>`;
+        expect(parseFeedArticles(xml, 'F')[0].publishedAt).toBe('2026-08-01T00:00:00.000Z');
+    });
+
+    it('uses updated when there is no published', () => {
+        const xml = `<feed><entry><title>T</title><updated>2026-08-04T00:00:00Z</updated></entry></feed>`;
+        expect(parseFeedArticles(xml, 'F')[0].publishedAt).toBe('2026-08-04T00:00:00.000Z');
+    });
+
+    it('reads a hybrid document that carries both items and entries', () => {
+        const xml = `<feed><item><title>From item</title></item><entry><title>From entry</title></entry></feed>`;
+        expect(parseFeedArticles(xml, 'F').map(a => a.title)).toEqual(['From item', 'From entry']);
+    });
+});
+
+describe('stripHtml and entity decoding', () => {
+    it('strips tags and collapses whitespace', () => {
+        expect(stripHtml('<p>One</p>\n\n  <p>Two</p>')).toBe('One Two');
+    });
+
+    it('decodes named and numeric entities', () => {
+        expect(stripHtml('&quot;q&quot; &#39;a&#39; &#x27;b&#x27; &nbsp;end')).toBe('"q" \'a\' \'b\' end');
+    });
+
+    it('strips markup that arrived escaped, which is how most feeds send it', () => {
+        // Decoding after stripping would leave a literal "<p>" in the output for
+        // every RSS description in the wild.
+        expect(stripHtml('&lt;p&gt;Body &lt;b&gt;text&lt;/b&gt;&lt;/p&gt;')).toBe('Body text');
+    });
+
+    it('finishes decoding an ampersand that was escaped twice', () => {
+        // Source rendering as "&" arrives as &amp;amp; through an escaped-HTML
+        // description; one decode pass would leave a visible "&amp;".
+        expect(stripHtml('Raised &amp;amp; restructured')).toBe('Raised & restructured');
+    });
+
+    it('drops an out-of-range numeric entity rather than throwing', () => {
+        expect(stripHtml('before &#1114112; after')).toBe('before after');
+    });
+});
+
+describe('parseFeedDate', () => {
+    it('accepts RFC 822 and ISO 8601', () => {
+        expect(parseFeedDate('Tue, 04 Aug 2026 09:00:00 GMT')).toBe('2026-08-04T09:00:00.000Z');
+        expect(parseFeedDate('2026-08-04T09:00:00Z')).toBe('2026-08-04T09:00:00.000Z');
+    });
+
+    it('returns null for missing or unparseable input', () => {
+        expect(parseFeedDate('')).toBeNull();
+        expect(parseFeedDate('sometime')).toBeNull();
+    });
+});
+
+// =====================================================================
+// Age filtering
+// =====================================================================
+
+describe('filterByAge', () => {
+    it('keeps in-window articles and counts what it dropped', () => {
+        const result = filterByAge([article({ ageDays: 1 }), article({ ageDays: 30 })], 7, NOW, false);
+        expect(result.kept).toHaveLength(1);
+        expect(result.tooOldCount).toBe(1);
+    });
+
+    it('counts undated articles whether or not they are kept', () => {
+        const articles = [article({ ageDays: 1 }), article({ publishedAt: null })];
+        expect(filterByAge(articles, 7, NOW, false)).toMatchObject({ undatedCount: 1 });
+        expect(filterByAge(articles, 7, NOW, false).kept).toHaveLength(1);
+        expect(filterByAge(articles, 7, NOW, true).kept).toHaveLength(2);
+    });
+
+    it('keeps a future-dated article rather than deleting the newest item over clock skew', () => {
+        expect(filterByAge([article({ ageDays: -1 })], 7, NOW, false).kept).toHaveLength(1);
+    });
+
+    it('keeps an article exactly at the window edge', () => {
+        expect(filterByAge([article({ ageDays: 7 })], 7, NOW, false).kept).toHaveLength(1);
+    });
+});
+
+// =====================================================================
+// Scoring
+// =====================================================================
+
+describe('computeRelevanceScore', () => {
+    it('weights title above category above description', () => {
+        expect(computeRelevanceScore(article({ title: 'dues rising' }), ['dues']).score).toBe(RELEVANCE_WEIGHTS.title);
+        expect(computeRelevanceScore(article({ categories: ['Dues'] }), ['dues']).score).toBe(RELEVANCE_WEIGHTS.category);
+        expect(computeRelevanceScore(article({ description: 'about dues' }), ['dues']).score).toBe(RELEVANCE_WEIGHTS.description);
+    });
+
+    it('sums all three placements for one keyword', () => {
+        const a = article({ title: 'Dues', categories: ['dues'], description: 'dues' });
+        expect(computeRelevanceScore(a, ['dues']).score).toBe(
+            RELEVANCE_WEIGHTS.title + RELEVANCE_WEIGHTS.category + RELEVANCE_WEIGHTS.description,
+        );
+    });
+
+    it('matches case-insensitively and reports which keywords hit', () => {
+        const a = article({ title: 'DUES and Retention' });
+        const result = computeRelevanceScore(a, ['dues', 'retention', 'sponsorship']);
+        expect(result.matched).toEqual(['dues', 'retention']);
+        expect(result.score).toBe(RELEVANCE_WEIGHTS.title * 2);
+    });
+
+    it('scores zero against no keywords, rather than treating everything as a match', () => {
+        expect(computeRelevanceScore(article({ title: 'anything' }), [])).toEqual({ score: 0, matched: [] });
+    });
+
+    it('ignores blank keywords instead of matching every article on the empty string', () => {
+        expect(computeRelevanceScore(article({ title: 'anything' }), ['', '  ']).score).toBe(0);
+    });
+});
+
+describe('computeRecencyScore', () => {
+    it('scores 1 for something published now and clamps future dates to 1', () => {
+        expect(computeRecencyScore(NOW.toISOString(), 7, NOW)).toBe(1);
+        expect(computeRecencyScore(new Date(NOW.getTime() + 86400000).toISOString(), 7, NOW)).toBe(1);
+    });
+
+    it('decays across the window, never below 0.1 while still in it', () => {
+        expect(computeRecencyScore(new Date(NOW.getTime() - 3.5 * 86400000).toISOString(), 7, NOW)).toBeCloseTo(0.5, 5);
+        expect(computeRecencyScore(new Date(NOW.getTime() - 7 * 86400000).toISOString(), 7, NOW)).toBe(0.1);
+    });
+
+    it('scores 0 out of window, for an undated article, and for a zero window', () => {
+        expect(computeRecencyScore(new Date(NOW.getTime() - 8 * 86400000).toISOString(), 7, NOW)).toBe(0);
+        expect(computeRecencyScore(null, 7, NOW)).toBe(0);
+        expect(computeRecencyScore(NOW.toISOString(), 0, NOW)).toBe(0);
+    });
+});
+
+describe('scoreAndRankArticles', () => {
+    it('lets relevance dominate recency', () => {
+        // A week-old article about the topic beats a brand-new article about nothing.
+        const relevant = article({ title: 'dues', ageDays: 6 });
+        const fresh = article({ title: 'unrelated', ageDays: 0 });
+        const ranked = scoreAndRankArticles([fresh, relevant], ['dues'], 7, NOW);
+        expect(ranked[0].article.title).toBe('dues');
+    });
+
+    it('breaks relevance ties on recency', () => {
+        const older = article({ title: 'dues one', ageDays: 5 });
+        const newer = article({ title: 'dues two', ageDays: 1 });
+        const ranked = scoreAndRankArticles([older, newer], ['dues'], 7, NOW);
+        expect(ranked.map(r => r.article.title)).toEqual(['dues two', 'dues one']);
+    });
+
+    it('ranks purely by recency when no keywords are supplied', () => {
+        const ranked = scoreAndRankArticles([article({ title: 'old', ageDays: 5 }), article({ title: 'new', ageDays: 1 })], [], 7, NOW);
+        expect(ranked.map(r => r.article.title)).toEqual(['new', 'old']);
+        expect(ranked.every(r => r.relevanceScore === 0)).toBe(true);
+    });
+
+    it('keeps feed order among fully tied articles, so a re-read ranks identically', () => {
+        const a = article({ title: 'dues a', ageDays: 2 });
+        const b = article({ title: 'dues b', ageDays: 2 });
+        expect(scoreAndRankArticles([a, b], ['dues'], 7, NOW).map(r => r.article.title)).toEqual(['dues a', 'dues b']);
+    });
+});
+
+describe('filterRelevant', () => {
+    it('drops articles that matched nothing and are not fresh', () => {
+        const scored = scoreAndRankArticles([article({ title: 'unrelated', ageDays: 5 })], ['dues'], 7, NOW);
+        expect(filterRelevant(scored, ['dues'])).toHaveLength(0);
+    });
+
+    it('keeps a very fresh article that matched nothing, since a keyword list is never complete', () => {
+        const scored = scoreAndRankArticles([article({ title: 'unrelated', ageDays: 0 })], ['dues'], 7, NOW);
+        expect(filterRelevant(scored, ['dues'])).toHaveLength(1);
+    });
+
+    it('keeps everything when no keywords were supplied', () => {
+        const scored = scoreAndRankArticles([article({ title: 'unrelated', ageDays: 6 })], [], 7, NOW);
+        expect(filterRelevant(scored, [])).toHaveLength(1);
+    });
+});
+
+// =====================================================================
+// The action
+// =====================================================================
+
+/** A ReadRSSFeedAction with a pinned clock and a canned fetch. */
+class TestReadRSSFeedAction extends ReadRSSFeedAction {
+    public Requested: string[] = [];
+    constructor(private readonly bodies: Record<string, string | Error>) {
+        super();
+    }
+    protected override Now(): Date {
+        return NOW;
+    }
+    protected override async FetchFeed(url: string): Promise<string> {
+        this.Requested.push(url);
+        const body = this.bodies[url];
+        if (body === undefined) throw new Error(`no canned body for ${url}`);
+        if (body instanceof Error) throw body;
+        return body;
+    }
+}
+
+interface ActionParams {
+    Params: Array<{ Name: string; Value: unknown; Type: string }>;
+}
+
+async function runFeedAction(inputs: Record<string, unknown>, bodies: Record<string, string | Error>) {
+    const params: ActionParams = {
+        Params: Object.entries(inputs).map(([Name, Value]) => ({ Name, Value, Type: 'Input' })),
+    };
+    const action = new TestReadRSSFeedAction(bodies);
+    const result = (await action.Run(params as never)) as { Success: boolean; Message: string; ResultCode: string };
+    return { result, params, action };
+}
+
+function output(params: ActionParams, name: string): unknown {
+    return params.Params.find(p => p.Name === name)?.Value;
+}
+
+const URL_A = 'https://example.org/feed.xml';
+const URL_B = 'https://example.net/atom.xml';
+
+beforeEach(() => {
+    vi.clearAllMocks();
+});
+
+describe('ReadRSSFeedAction', () => {
+    it('reads a single feed given only a URL, naming it after the host', async () => {
+        const { result, params } = await runFeedAction({ FeedURLs: URL_A }, { [URL_A]: RSS_FEED });
+        expect(result.Success).toBe(true);
+        expect(result.ResultCode).toBe('SUCCESS');
+        expect(output(params, 'ArticleCount')).toBe(2);
+        expect((output(params, 'FeedStatuses') as Array<{ name: string }>)[0].name).toBe('example.org');
+    });
+
+    it('requires at least one feed', async () => {
+        const { result } = await runFeedAction({}, {});
+        expect(result.Success).toBe(false);
+        expect(result.ResultCode).toBe('MISSING_FEEDS');
+    });
+
+    it('accepts named feeds as an array or as a JSON string', async () => {
+        const asArray = await runFeedAction({ Feeds: [{ name: 'Named', url: URL_A }] }, { [URL_A]: RSS_FEED });
+        expect((output(asArray.params, 'FeedStatuses') as Array<{ name: string }>)[0].name).toBe('Named');
+
+        const asJson = await runFeedAction({ Feeds: JSON.stringify([{ name: 'Named', url: URL_A }]) }, { [URL_A]: RSS_FEED });
+        expect((output(asJson.params, 'FeedStatuses') as Array<{ name: string }>)[0].name).toBe('Named');
+    });
+
+    it('reports a malformed Feeds value instead of reading nothing', async () => {
+        expect((await runFeedAction({ Feeds: '[{bad json' }, {})).result.ResultCode).toBe('INVALID_FEEDS');
+        expect((await runFeedAction({ Feeds: [{ name: 'No URL' }] }, {})).result.ResultCode).toBe('INVALID_FEEDS');
+    });
+
+    it('refuses a non-http URL, so this cannot become a local file reader', async () => {
+        const { result } = await runFeedAction({ FeedURLs: 'file:///etc/passwd' }, {});
+        expect(result.ResultCode).toBe('INVALID_FEED_URL');
+    });
+
+    it('de-duplicates a feed listed twice, which would otherwise double every article', async () => {
+        const { params, action } = await runFeedAction({ FeedURLs: `${URL_A}, ${URL_A}` }, { [URL_A]: RSS_FEED });
+        expect(action.Requested).toEqual([URL_A]);
+        expect(output(params, 'ArticleCount')).toBe(2);
+    });
+
+    it('merges several feeds and attributes each article to its own feed', async () => {
+        const { params } = await runFeedAction(
+            { Feeds: [{ name: 'RSS One', url: URL_A }, { name: 'Atom Two', url: URL_B }] },
+            { [URL_A]: RSS_FEED, [URL_B]: ATOM_FEED },
+        );
+        const feedNames = (output(params, 'Articles') as Array<{ feedName: string }>).map(a => a.feedName);
+        expect(new Set(feedNames)).toEqual(new Set(['RSS One', 'Atom Two']));
+    });
+
+    it('keeps a failing feed from costing the caller the working ones', async () => {
+        const { result, params } = await runFeedAction(
+            { Feeds: [{ name: 'Good', url: URL_A }, { name: 'Dead', url: URL_B }] },
+            { [URL_A]: RSS_FEED, [URL_B]: new Error('HTTP 503') },
+        );
+        expect(result.Success).toBe(true);
+        expect(output(params, 'FailedFeedCount')).toBe(1);
+        const statuses = output(params, 'FeedStatuses') as Array<{ name: string; success: boolean; error: string | null }>;
+        expect(statuses.find(s => s.name === 'Dead')).toMatchObject({ success: false, error: 'HTTP 503' });
+        expect(output(params, 'ArticleCount')).toBe(2);
+        expect(result.Message).toMatch(/1 feed\(s\) failed/);
+    });
+
+    it('fails the whole action on any feed failure only when asked to', async () => {
+        const { result } = await runFeedAction(
+            { Feeds: [{ name: 'Good', url: URL_A }, { name: 'Dead', url: URL_B }], RequireAllFeeds: true },
+            { [URL_A]: RSS_FEED, [URL_B]: new Error('HTTP 503') },
+        );
+        expect(result.Success).toBe(false);
+        expect(result.ResultCode).toBe('FEED_FETCH_FAILED');
+        expect(result.Message).toMatch(/Dead \(HTTP 503\)/);
+    });
+
+    it('applies the age window and says how many articles it excluded', async () => {
+        // Against the fixed clock the two RSS items are 1.125 and 2.125 days old, so a
+        // 2-day window keeps the newer one and excludes the other.
+        const { result, params } = await runFeedAction({ FeedURLs: URL_A, MaxAgeDays: 2 }, { [URL_A]: RSS_FEED });
+        expect(output(params, 'ArticleCount')).toBe(1);
+        expect(output(params, 'FilteredOutTooOld')).toBe(1);
+        expect(result.Message).toMatch(/1 older than 2 day\(s\)/);
+    });
+
+    it('excludes undated articles by default and reports that it did', async () => {
+        const undated = `<rss><channel><item><title>No date here</title></item></channel></rss>`;
+        const excluded = await runFeedAction({ FeedURLs: URL_A }, { [URL_A]: undated });
+        expect(output(excluded.params, 'ArticleCount')).toBe(0);
+        expect(output(excluded.params, 'UndatedCount')).toBe(1);
+        expect(excluded.result.Message).toMatch(/1 undated \(excluded\)/);
+
+        const included = await runFeedAction({ FeedURLs: URL_A, IncludeUndated: true }, { [URL_A]: undated });
+        expect(output(included.params, 'ArticleCount')).toBe(1);
+        expect(included.result.Message).toMatch(/1 undated \(kept\)/);
+    });
+
+    it('ranks by keyword relevance and returns the scores that produced the order', async () => {
+        const { params } = await runFeedAction({ FeedURLs: URL_A, Keywords: 'retention' }, { [URL_A]: RSS_FEED });
+        const articles = output(params, 'Articles') as Array<{ title: string; matchedKeywords: string[]; relevanceScore: number; totalScore: number }>;
+        expect(articles[0].title).toBe('Retention playbooks');
+        expect(articles[0].matchedKeywords).toEqual(['retention']);
+        expect(articles[0].relevanceScore).toBeGreaterThan(0);
+        expect(articles[0].totalScore).toBeGreaterThan(0);
+    });
+
+    it('does not bucket scores into labels, since "high" depends on the caller not the batch', async () => {
+        const { params } = await runFeedAction({ FeedURLs: URL_A, Keywords: 'dues' }, { [URL_A]: RSS_FEED });
+        const first = (output(params, 'Articles') as Array<Record<string, unknown>>)[0];
+        expect(first).not.toHaveProperty('strength');
+        expect(typeof first.recencyScore).toBe('number');
+    });
+
+    it('caps the returned articles and still reports the total it read', async () => {
+        const { params } = await runFeedAction({ FeedURLs: URL_A, MaxResults: 1 }, { [URL_A]: RSS_FEED });
+        expect(output(params, 'ArticleCount')).toBe(1);
+        expect(output(params, 'TotalFetched')).toBe(2);
+    });
+
+    it('succeeds with an empty result set — a quiet week is an answer, not a failure', async () => {
+        const { result, params } = await runFeedAction(
+            { FeedURLs: URL_A, Keywords: 'sponsorship', MaxAgeDays: 1 },
+            { [URL_A]: RSS_FEED },
+        );
+        expect(result.Success).toBe(true);
+        expect(output(params, 'ArticleCount')).toBe(0);
+        expect(result.Message).toMatch(/returning 0/);
+    });
+
+    it('succeeds on a document that is not a feed at all, reporting zero articles', async () => {
+        const { result, params } = await runFeedAction({ FeedURLs: URL_A }, { [URL_A]: '<html><body>Not a feed</body></html>' });
+        expect(result.Success).toBe(true);
+        expect(output(params, 'TotalFetched')).toBe(0);
+    });
+});

--- a/packages/Actions/CoreActions/src/__tests__/tavily-search.action.test.ts
+++ b/packages/Actions/CoreActions/src/__tests__/tavily-search.action.test.ts
@@ -1,0 +1,467 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// ---------------------------------------------------------------------------
+// The action only needs the decorator, the BaseAction shell, the config reader
+// and the HTTP client. Everything here is a stand-in for one of those four.
+// ---------------------------------------------------------------------------
+vi.mock('@memberjunction/actions', () => ({
+    BaseAction: class BaseAction {
+        public async Run(params: unknown): Promise<unknown> {
+            return (this as unknown as { InternalRunAction(p: unknown): Promise<unknown> }).InternalRunAction(params);
+        }
+    },
+}));
+
+vi.mock('@memberjunction/global', () => ({
+    RegisterClass: () => (target: unknown) => target,
+}));
+
+vi.mock('@memberjunction/core', () => ({
+    LogError: vi.fn(),
+    LogStatus: vi.fn(),
+}));
+
+vi.mock('@memberjunction/actions-base', () => ({}));
+
+const post = vi.fn();
+
+vi.mock('axios', () => ({
+    default: {
+        post: (...args: unknown[]) => post(...args),
+        // The real helper reads the marker property the same way, so a plain object
+        // carrying it is indistinguishable from a genuine AxiosError here.
+        isAxiosError: (e: unknown) => Boolean((e as { isAxiosError?: boolean })?.isAxiosError),
+    },
+}));
+
+const apiKey = { value: 'tvly-test-key' as string | undefined };
+
+vi.mock('../config', () => ({
+    getApiIntegrationsConfig: () => ({ tavilyApiKey: apiKey.value }),
+}));
+
+import { TavilySearchAction } from '../custom/web/tavily-search.action';
+
+// ---------------------------------------------------------------------------
+// Harness
+// ---------------------------------------------------------------------------
+
+type Params = { Params: Array<{ Name: string; Type: string; Value: unknown }>; ContextUser: unknown };
+
+async function run(inputs: Record<string, unknown>) {
+    const params: Params = {
+        Params: Object.entries(inputs).map(([Name, Value]) => ({ Name, Value, Type: 'Input' })),
+        ContextUser: {},
+    };
+    const action = new TavilySearchAction();
+    const result = await (action as unknown as { Run(p: Params): Promise<{ Success: boolean; ResultCode?: string; Message?: string }> }).Run(params);
+    return { result, params };
+}
+
+function output(params: Params, name: string): unknown {
+    return params.Params.find(p => p.Name === name && p.Type === 'Output')?.Value;
+}
+
+/** The body of the single POST the action made. */
+function sentBody(): Record<string, unknown> {
+    return post.mock.calls[0][1] as Record<string, unknown>;
+}
+
+function sentHeaders(): Record<string, string> {
+    return (post.mock.calls[0][2] as { headers: Record<string, string> }).headers;
+}
+
+/** An error shaped like the one axios throws on a non-2xx response. */
+function httpError(status: number, data: unknown, message = `Request failed with status code ${status}`) {
+    return { isAxiosError: true, response: { status, data }, message };
+}
+
+const RESULT_A = {
+    title: 'Dues restructuring in 2026',
+    url: 'https://example.org/dues',
+    content: 'Associations are moving to tiered dues.',
+    score: 0.91,
+};
+
+const RESULT_B = {
+    title: 'Membership growth report',
+    url: 'https://example.net/growth',
+    content: 'Growth slowed in Q2.',
+    score: 0.62,
+};
+
+function ok(data: unknown) {
+    post.mockResolvedValueOnce({ data });
+}
+
+beforeEach(() => {
+    post.mockReset();
+    apiKey.value = 'tvly-test-key';
+});
+
+// ---------------------------------------------------------------------------
+// Preconditions
+// ---------------------------------------------------------------------------
+
+describe('TavilySearchAction — preconditions', () => {
+    it('requires a query, and does not call the API without one', async () => {
+        const { result } = await run({});
+        expect(result.Success).toBe(false);
+        expect(result.ResultCode).toBe('MISSING_QUERY');
+        expect(post).not.toHaveBeenCalled();
+    });
+
+    it('treats a whitespace-only query as missing', async () => {
+        const { result } = await run({ Query: '   ' });
+        expect(result.ResultCode).toBe('MISSING_QUERY');
+    });
+
+    it('names both places the key can come from when it is absent', async () => {
+        apiKey.value = undefined;
+        const { result } = await run({ Query: 'dues' });
+        expect(result.Success).toBe(false);
+        expect(result.ResultCode).toBe('MISSING_API_KEY');
+        // A caller who reads only the message must still know how to fix it.
+        expect(result.Message).toMatch(/tavilyApiKey/);
+        expect(result.Message).toMatch(/TAVILY_API_KEY/);
+        expect(post).not.toHaveBeenCalled();
+    });
+
+    it('checks the query before the key, so a caller fixes the nearer problem first', async () => {
+        apiKey.value = undefined;
+        const { result } = await run({});
+        expect(result.ResultCode).toBe('MISSING_QUERY');
+    });
+
+    it('sends the key as a bearer token, never in the request body', async () => {
+        ok({ results: [RESULT_A] });
+        await run({ Query: 'dues' });
+        expect(sentHeaders()['Authorization']).toBe('Bearer tvly-test-key');
+        expect(sentBody()).not.toHaveProperty('api_key');
+    });
+
+    it('posts to Tavily search', async () => {
+        ok({ results: [] });
+        await run({ Query: 'dues' });
+        expect(post.mock.calls[0][0]).toBe('https://api.tavily.com/search');
+    });
+});
+
+// ---------------------------------------------------------------------------
+// Parameter validation and defaults
+// ---------------------------------------------------------------------------
+
+describe('TavilySearchAction — parameters', () => {
+    it('defaults to a basic general search of 10 results with nothing extra included', async () => {
+        ok({ results: [] });
+        await run({ Query: 'dues' });
+        expect(sentBody()).toEqual({
+            query: 'dues',
+            search_depth: 'basic',
+            topic: 'general',
+            max_results: 10,
+            include_answer: false,
+            include_raw_content: false,
+        });
+    });
+
+    it('rejects an unknown SearchDepth by name', async () => {
+        const { result } = await run({ Query: 'dues', SearchDepth: 'deep' });
+        expect(result.ResultCode).toBe('INVALID_SEARCH_DEPTH');
+        expect(result.Message).toMatch(/'deep'/);
+        expect(post).not.toHaveBeenCalled();
+    });
+
+    it('rejects an unknown Topic by name', async () => {
+        const { result } = await run({ Query: 'dues', Topic: 'sports' });
+        expect(result.ResultCode).toBe('INVALID_TOPIC');
+        expect(result.Message).toMatch(/'sports'/);
+        expect(post).not.toHaveBeenCalled();
+    });
+
+    it('accepts SearchDepth and Topic case-insensitively', async () => {
+        ok({ results: [] });
+        await run({ Query: 'dues', SearchDepth: 'ADVANCED', Topic: 'News' });
+        expect(sentBody().search_depth).toBe('advanced');
+        expect(sentBody().topic).toBe('news');
+    });
+
+    it('matches parameter names case-insensitively, as the engine passes them', async () => {
+        ok({ results: [] });
+        await run({ query: 'dues', maxresults: 3 });
+        expect(sentBody().query).toBe('dues');
+        expect(sentBody().max_results).toBe(3);
+    });
+
+    it('clamps MaxResults to Tavily cap rather than letting the vendor reject the call', async () => {
+        ok({ results: [] });
+        await run({ Query: 'dues', MaxResults: 50 });
+        expect(sentBody().max_results).toBe(20);
+    });
+
+    it('clamps MaxResults up to 1, so a zero request still asks for something', async () => {
+        ok({ results: [] });
+        await run({ Query: 'dues', MaxResults: 0 });
+        expect(sentBody().max_results).toBe(1);
+    });
+
+    it('floors a fractional MaxResults', async () => {
+        ok({ results: [] });
+        await run({ Query: 'dues', MaxResults: 7.8 });
+        expect(sentBody().max_results).toBe(7);
+    });
+
+    it('falls back to the default when MaxResults is not a number', async () => {
+        ok({ results: [] });
+        await run({ Query: 'dues', MaxResults: 'lots' });
+        expect(sentBody().max_results).toBe(10);
+    });
+
+    it('passes the include flags through when set', async () => {
+        ok({ results: [] });
+        await run({ Query: 'dues', IncludeAnswer: true, IncludeRawContent: 'true' });
+        expect(sentBody().include_answer).toBe(true);
+        expect(sentBody().include_raw_content).toBe(true);
+    });
+
+    it('takes domain lists as arrays', async () => {
+        ok({ results: [] });
+        await run({ Query: 'dues', IncludeDomains: ['irs.gov', 'example.org'], ExcludeDomains: ['spam.example'] });
+        expect(sentBody().include_domains).toEqual(['irs.gov', 'example.org']);
+        expect(sentBody().exclude_domains).toEqual(['spam.example']);
+    });
+
+    it('takes domain lists as a comma-separated string, which is how humans type them', async () => {
+        ok({ results: [] });
+        await run({ Query: 'dues', IncludeDomains: 'irs.gov, example.org ,' });
+        expect(sentBody().include_domains).toEqual(['irs.gov', 'example.org']);
+    });
+
+    it('omits the domain keys entirely when nothing was given', async () => {
+        ok({ results: [] });
+        await run({ Query: 'dues', IncludeDomains: '', ExcludeDomains: [] });
+        expect(sentBody()).not.toHaveProperty('include_domains');
+        expect(sentBody()).not.toHaveProperty('exclude_domains');
+    });
+});
+
+// ---------------------------------------------------------------------------
+// Days is news-only
+// ---------------------------------------------------------------------------
+
+describe('TavilySearchAction — the news-only Days window', () => {
+    it('sends Days on a news search', async () => {
+        ok({ results: [] });
+        const { params } = await run({ Query: 'dues', Topic: 'news', Days: 7 });
+        expect(sentBody().days).toBe(7);
+        expect(output(params, 'Warnings')).toBeUndefined();
+    });
+
+    it('drops Days on a general search and says why', async () => {
+        // Silently sending it would leave a caller believing their window applied.
+        ok({ results: [] });
+        const { result, params } = await run({ Query: 'dues', Days: 7 });
+        expect(sentBody()).not.toHaveProperty('days');
+        expect(result.Success).toBe(true);
+        expect(String((output(params, 'Warnings') as string[])[0])).toMatch(/only applies when Topic is 'news'/);
+    });
+
+    it('floors and raises Days to at least 1', async () => {
+        ok({ results: [] });
+        await run({ Query: 'dues', Topic: 'news', Days: 0 });
+        expect(sentBody().days).toBe(1);
+
+        post.mockReset();
+        ok({ results: [] });
+        await run({ Query: 'dues', Topic: 'news', Days: 3.9 });
+        expect(sentBody().days).toBe(3);
+    });
+
+    it('omits Days when it was not asked for, leaving Tavily its own default', async () => {
+        ok({ results: [] });
+        await run({ Query: 'dues', Topic: 'news' });
+        expect(sentBody()).not.toHaveProperty('days');
+    });
+});
+
+// ---------------------------------------------------------------------------
+// Result mapping
+// ---------------------------------------------------------------------------
+
+describe('TavilySearchAction — results', () => {
+    it('maps each result and reports how many came back', async () => {
+        ok({ results: [RESULT_A, RESULT_B], response_time: 1.4 });
+        const { result, params } = await run({ Query: 'dues' });
+
+        expect(result.Success).toBe(true);
+        expect(result.ResultCode).toBe('SUCCESS');
+        expect(result.Message).toMatch(/2 result\(s\)/);
+        expect(output(params, 'ResultCount')).toBe(2);
+        expect(output(params, 'Results')).toEqual([
+            { title: RESULT_A.title, url: RESULT_A.url, content: RESULT_A.content, score: 0.91 },
+            { title: RESULT_B.title, url: RESULT_B.url, content: RESULT_B.content, score: 0.62 },
+        ]);
+    });
+
+    it('keeps Tavily ranking order rather than re-sorting', async () => {
+        // The score is only comparable within one response, so the vendor's order is
+        // the only defensible one.
+        ok({ results: [RESULT_B, RESULT_A] });
+        const { params } = await run({ Query: 'dues' });
+        const urls = (output(params, 'Results') as Array<{ url: string }>).map(r => r.url);
+        expect(urls).toEqual([RESULT_B.url, RESULT_A.url]);
+    });
+
+    it('carries publishedDate only when the response has one', async () => {
+        ok({ results: [{ ...RESULT_A, published_date: 'Mon, 04 Aug 2026 09:00:00 GMT' }, RESULT_B] });
+        const { params } = await run({ Query: 'dues', Topic: 'news' });
+        const results = output(params, 'Results') as Array<Record<string, unknown>>;
+        expect(results[0].publishedDate).toBe('Mon, 04 Aug 2026 09:00:00 GMT');
+        expect(results[1]).not.toHaveProperty('publishedDate');
+    });
+
+    it('carries rawContent only when the response has one', async () => {
+        ok({ results: [{ ...RESULT_A, raw_content: 'the whole page' }] });
+        const { params } = await run({ Query: 'dues', IncludeRawContent: true });
+        expect((output(params, 'Results') as Array<Record<string, unknown>>)[0].rawContent).toBe('the whole page');
+    });
+
+    it('fills missing fields rather than emitting undefined', async () => {
+        ok({ results: [{}] });
+        const { params } = await run({ Query: 'dues' });
+        expect((output(params, 'Results') as unknown[])[0]).toEqual({ title: '', url: '', content: '', score: 0 });
+    });
+
+    it('scores a non-numeric score as 0 instead of passing the junk on', async () => {
+        ok({ results: [{ ...RESULT_A, score: 'high' }] });
+        const { params } = await run({ Query: 'dues' });
+        expect((output(params, 'Results') as Array<{ score: number }>)[0].score).toBe(0);
+    });
+
+    it('adds Answer only when it was requested', async () => {
+        ok({ results: [RESULT_A], answer: 'Dues are moving to tiers.' });
+        const { params: withAnswer } = await run({ Query: 'dues', IncludeAnswer: true });
+        expect(output(withAnswer, 'Answer')).toBe('Dues are moving to tiers.');
+
+        post.mockReset();
+        ok({ results: [RESULT_A], answer: 'Dues are moving to tiers.' });
+        const { params: without } = await run({ Query: 'dues' });
+        expect(output(without, 'Answer')).toBeUndefined();
+    });
+
+    it('records what it actually asked for alongside what came back', async () => {
+        ok({ results: [RESULT_A], answer: 'A', response_time: 0.8 });
+        const { params } = await run({ Query: 'dues', SearchDepth: 'advanced', Topic: 'news', MaxResults: 5 });
+        expect(output(params, 'SearchResultDetails')).toMatchObject({
+            query: 'dues',
+            searchDepth: 'advanced',
+            topic: 'news',
+            maxResults: 5,
+            answer: 'A',
+            responseTime: 0.8,
+        });
+    });
+
+    it('treats zero results as a successful, narrow search', async () => {
+        // A failure here would send a caller into retrying a query that will keep
+        // returning nothing.
+        ok({ results: [] });
+        const { result, params } = await run({ Query: 'obscure phrase' });
+        expect(result.Success).toBe(true);
+        expect(result.ResultCode).toBe('SUCCESS');
+        expect(result.Message).toMatch(/no results/);
+        expect(output(params, 'ResultCount')).toBe(0);
+        expect(output(params, 'Results')).toEqual([]);
+    });
+
+    it('treats a missing results array as zero results, not a crash', async () => {
+        ok({ answer: 'just an answer' });
+        const { result, params } = await run({ Query: 'dues' });
+        expect(result.Success).toBe(true);
+        expect(output(params, 'ResultCount')).toBe(0);
+    });
+
+    it('reports an empty response body as an error', async () => {
+        post.mockResolvedValueOnce({ data: undefined });
+        const { result } = await run({ Query: 'dues' });
+        expect(result.Success).toBe(false);
+        expect(result.ResultCode).toBe('EMPTY_RESPONSE');
+    });
+});
+
+// ---------------------------------------------------------------------------
+// Errors
+// ---------------------------------------------------------------------------
+
+describe('TavilySearchAction — errors', () => {
+    it('distinguishes a rejected key from any other failure', async () => {
+        for (const status of [401, 403]) {
+            post.mockReset();
+            post.mockRejectedValueOnce(httpError(status, { detail: 'Unauthorized: missing or invalid API key' }));
+            const { result } = await run({ Query: 'dues' });
+            expect(result.ResultCode).toBe('INVALID_API_KEY');
+            expect(result.Message).toMatch(/missing or invalid API key/);
+            expect(result.Message).toMatch(new RegExp(String(status)));
+        }
+    });
+
+    it('reports a rate limit or exhausted credits as retryable in its own right', async () => {
+        post.mockRejectedValueOnce(httpError(429, { detail: 'Usage limit exceeded' }));
+        const { result } = await run({ Query: 'dues' });
+        expect(result.ResultCode).toBe('RATE_LIMITED');
+        expect(result.Message).toMatch(/Usage limit exceeded/);
+    });
+
+    it('reports a rejected request separately, since retrying it unchanged is pointless', async () => {
+        for (const status of [400, 422]) {
+            post.mockReset();
+            post.mockRejectedValueOnce(httpError(status, { detail: { error: 'max_results must be <= 20' } }));
+            const { result } = await run({ Query: 'dues' });
+            expect(result.ResultCode).toBe('INVALID_REQUEST');
+            // The nested { detail: { error } } shape is Tavily's 422 form.
+            expect(result.Message).toMatch(/max_results must be <= 20/);
+        }
+    });
+
+    it('falls back to a generic API error for any other status', async () => {
+        post.mockRejectedValueOnce(httpError(500, { message: 'Internal error' }));
+        const { result } = await run({ Query: 'dues' });
+        expect(result.ResultCode).toBe('API_ERROR');
+        expect(result.Message).toMatch(/Internal error/);
+    });
+
+    it('uses the axios message when the error body explains nothing', async () => {
+        post.mockRejectedValueOnce(httpError(503, undefined, 'socket hang up'));
+        const { result } = await run({ Query: 'dues' });
+        expect(result.ResultCode).toBe('API_ERROR');
+        expect(result.Message).toMatch(/socket hang up/);
+    });
+
+    it('reads a plain-string error body', async () => {
+        post.mockRejectedValueOnce(httpError(500, 'gateway exploded'));
+        const { result } = await run({ Query: 'dues' });
+        expect(result.Message).toMatch(/gateway exploded/);
+    });
+
+    it('reports a non-HTTP failure, such as a timeout with no response, distinctly', async () => {
+        post.mockRejectedValueOnce(new Error('timeout of 60000ms exceeded'));
+        const { result } = await run({ Query: 'dues' });
+        expect(result.Success).toBe(false);
+        expect(result.ResultCode).toBe('SEARCH_FAILED');
+        expect(result.Message).toMatch(/timeout of 60000ms exceeded/);
+    });
+
+    it('reports a thrown non-Error without losing what was thrown', async () => {
+        post.mockRejectedValueOnce('something odd');
+        const { result } = await run({ Query: 'dues' });
+        expect(result.ResultCode).toBe('SEARCH_FAILED');
+        expect(result.Message).toMatch(/something odd/);
+    });
+
+    it('does not emit result output params on a failure', async () => {
+        post.mockRejectedValueOnce(httpError(401, { detail: 'no' }));
+        const { params } = await run({ Query: 'dues' });
+        expect(output(params, 'Results')).toBeUndefined();
+        expect(output(params, 'ResultCount')).toBeUndefined();
+    });
+});

--- a/packages/Actions/CoreActions/src/config.ts
+++ b/packages/Actions/CoreActions/src/config.ts
@@ -16,6 +16,13 @@ const apiIntegrationsSchema = z.object({
   perplexityApiKey: z.string().optional(),
 
   /**
+   * Tavily API Key for search built for LLM consumption
+   * Used by: Tavily Search action
+   * Get your API key from: https://app.tavily.com (keys are prefixed `tvly-`)
+   */
+  tavilyApiKey: z.string().optional(),
+
+  /**
    * Gamma API Key for presentation generation
    * Used by: Gamma Generate Presentation action
    * Get your API key from: https://gamma.app/settings (requires Pro or higher account)
@@ -87,27 +94,32 @@ export function getCoreActionsConfig(): CoreActionsConfig {
   try {
     const result = explorer.search();
     if (!result || result.isEmpty) {
-      LogStatus('No mj.config.cjs found, using default Core Actions configuration');
-      _config = coreActionsConfigSchema.parse({});
-      return _config;
+      LogStatus('No mj.config.cjs found; reading Core Actions API keys from the environment only');
     }
 
-    // Extract only the fields relevant to Core Actions
+    // Extract only the fields relevant to Core Actions.
+    //
+    // This runs whether or not a config file was found. Every key below documents
+    // an environment-variable fallback, and until this was hoisted out of the
+    // no-config early return, a deployment that set only environment variables
+    // silently got an empty config and every action reported its key as missing.
+    const fileConfig = result?.config;
     const rawConfig = {
       apiIntegrations: {
-        perplexityApiKey: result.config?.perplexityApiKey || process.env.PERPLEXITY_API_KEY,
-        gammaApiKey: result.config?.gammaApiKey || process.env.GAMMA_API_KEY,
+        perplexityApiKey: fileConfig?.perplexityApiKey || process.env.PERPLEXITY_API_KEY,
+        tavilyApiKey: fileConfig?.tavilyApiKey || process.env.TAVILY_API_KEY,
+        gammaApiKey: fileConfig?.gammaApiKey || process.env.GAMMA_API_KEY,
         google: {
           customSearch: {
-            apiKey: result.config?.google?.customSearch?.apiKey ||
-                    result.config?.googleCustomSearchApiKey ||  // Backwards compatibility
+            apiKey: fileConfig?.google?.customSearch?.apiKey ||
+                    fileConfig?.googleCustomSearchApiKey ||  // Backwards compatibility
                     process.env.GOOGLE_CUSTOM_SEARCH_API_KEY,
-            cx: result.config?.google?.customSearch?.cx ||
-                result.config?.googleCustomSearchCx ||  // Backwards compatibility
+            cx: fileConfig?.google?.customSearch?.cx ||
+                fileConfig?.googleCustomSearchCx ||  // Backwards compatibility
                 process.env.GOOGLE_CUSTOM_SEARCH_CX,
           },
           geocoding: {
-            apiKey: result.config?.google?.geocoding?.apiKey ||
+            apiKey: fileConfig?.google?.geocoding?.apiKey ||
                     process.env.GOOGLE_GEOCODING_API_KEY ||
                     process.env.GOOGLE_MAPS_API_KEY,
           },

--- a/packages/Actions/CoreActions/src/custom/web/rss-feed-parsing.ts
+++ b/packages/Actions/CoreActions/src/custom/web/rss-feed-parsing.ts
@@ -1,0 +1,345 @@
+/**
+ * RSS and Atom feed parsing and keyword scoring — pure functions.
+ *
+ * No HTTP, no logging, no clock of its own: every function that needs the current
+ * time takes it as a parameter. That is deliberate. A single feed read filters by
+ * age and then scores by recency, and if those two steps read `Date.now()`
+ * independently they can disagree — an article can pass the age filter and then
+ * score as out-of-window, producing a result the caller cannot explain. One
+ * injected `now` also makes every threshold here testable without faking timers.
+ *
+ * Parsing is by regex rather than by an XML parser. That is a deliberate trade:
+ * feeds in the wild are frequently not well-formed, and a strict parser fails the
+ * whole document over one unescaped ampersand in one item. The regex approach
+ * degrades per item instead. The cost is that deeply nested or namespace-heavy
+ * markup is not understood; both are rare in the item-level fields extracted here.
+ */
+
+/** One article from a feed, normalized across RSS 2.0 and Atom. */
+export interface FeedArticle {
+    title: string;
+    link: string;
+    /** Plain text — HTML tags stripped and entities decoded. */
+    description: string;
+    /**
+     * ISO 8601 publication date, or null when the feed did not carry a parseable
+     * one. Null is preserved rather than defaulted to "now", because a
+     * fabricated date would make an undated item the freshest thing in the batch.
+     */
+    publishedAt: string | null;
+    categories: string[];
+    /** Which feed this came from, so a merged result set stays attributable. */
+    feedName: string;
+}
+
+/** An article with its keyword-relevance and recency scores. */
+export interface ScoredFeedArticle {
+    article: FeedArticle;
+    /** Weighted sum of keyword hits: title 3, category 2, description 1, per keyword. */
+    relevanceScore: number;
+    /** 1.0 for something published now, decaying to 0.1 at the edge of the window; 0 for undated. */
+    recencyScore: number;
+    /** `relevanceScore * 10 + recencyScore * 5` — relevance dominates, recency breaks ties. */
+    totalScore: number;
+    matchedKeywords: string[];
+}
+
+const MS_PER_DAY = 24 * 60 * 60 * 1000;
+
+/** Weights behind {@link computeRelevanceScore}, exported so callers can explain a score. */
+export const RELEVANCE_WEIGHTS = { title: 3, category: 2, description: 1 } as const;
+
+/** How long a description is kept. Feeds sometimes inline a whole article body. */
+const MAX_DESCRIPTION_LENGTH = 500;
+
+// ─── Parsing ──────────────────────────────────────────────────────────────────
+
+/**
+ * Extract one tag's text, handling CDATA.
+ *
+ * The name is matched only when followed by whitespace, `/` or `>`, so asking for
+ * `link` does not match `<linkGroup>` — and, more importantly for Atom, asking for
+ * `title` does not match a namespaced sibling that merely starts with it.
+ */
+function extractTag(xml: string, tagName: string): string {
+    const pattern = new RegExp(`<${tagName}(?:\\s[^>]*)?>(?:<!\\[CDATA\\[)?([\\s\\S]*?)(?:\\]\\]>)?<\\/${tagName}\\s*>`);
+    return pattern.exec(xml)?.[1]?.trim() ?? '';
+}
+
+/** Every occurrence of a tag's text, in document order. */
+function extractAllTags(xml: string, tagName: string): string[] {
+    const pattern = new RegExp(`<${tagName}(?:\\s[^>]*)?>(?:<!\\[CDATA\\[)?([\\s\\S]*?)(?:\\]\\]>)?<\\/${tagName}\\s*>`, 'g');
+    const results: string[] = [];
+    let match: RegExpExecArray | null;
+    while ((match = pattern.exec(xml)) !== null) {
+        const value = decodeEntities(match[1]?.trim() ?? '');
+        if (value) results.push(value);
+    }
+    return results;
+}
+
+/** One attribute off the first matching tag, e.g. Atom's `<link href="…"/>`. */
+function extractAttribute(xml: string, tagName: string, attribute: string): string {
+    const pattern = new RegExp(`<${tagName}(?:\\s[^>]*)?\\s${attribute}\\s*=\\s*["']([^"']*)["']`);
+    return pattern.exec(xml)?.[1]?.trim() ?? '';
+}
+
+/** Decode the entities that actually appear in feed text. */
+function decodeEntities(text: string): string {
+    return text
+        .replace(/&#x([0-9a-fA-F]+);/g, (_, hex: string) => safeCodePoint(parseInt(hex, 16)))
+        .replace(/&#(\d+);/g, (_, dec: string) => safeCodePoint(parseInt(dec, 10)))
+        .replace(/&lt;/g, '<')
+        .replace(/&gt;/g, '>')
+        .replace(/&quot;/g, '"')
+        .replace(/&apos;/g, "'")
+        .replace(/&nbsp;/g, ' ')
+        // `&amp;` is decoded last so `&amp;lt;` yields the literal text `&lt;`
+        // rather than being decoded twice into `<`.
+        .replace(/&amp;/g, '&');
+}
+
+function safeCodePoint(code: number): string {
+    // An out-of-range numeric entity throws from fromCodePoint; dropping it is
+    // better than failing the whole item over one bad character reference.
+    return Number.isFinite(code) && code >= 0 && code <= 0x10ffff ? String.fromCodePoint(code) : '';
+}
+
+/**
+ * Reduce feed text to plain text: decode, strip markup, decode again, collapse.
+ *
+ * Decoding runs *before* stripping because RSS descriptions overwhelmingly carry
+ * their HTML escaped — `&lt;p&gt;text&lt;/p&gt;` rather than `<p>text</p>`. Strip
+ * first and those tags survive as literal `<p>` in the output, which is what a
+ * consumer then has to clean up itself.
+ *
+ * The second decode pass exists for that same escaped-HTML case: source that
+ * renders as `&amp;` arrives as `&amp;amp;`, so one pass leaves a visible `&amp;`
+ * where the reader expects `&`. Running it again after the tags are gone finishes
+ * the job. Text that was never double-escaped has no entities left by then, so the
+ * extra pass is a no-op on it.
+ */
+export function stripHtml(text: string): string {
+    const unescaped = decodeEntities(text);
+    const withoutTags = unescaped.replace(/<[^>]*>/g, '');
+    return decodeEntities(withoutTags).replace(/\s+/g, ' ').trim();
+}
+
+/**
+ * Parse a feed document into articles. Handles RSS 2.0 (`<item>`) and Atom
+ * (`<entry>`); a document containing both has both read, since some publishers
+ * serve a hybrid.
+ *
+ * Items with no title are skipped — there is nothing to show or score. Items with
+ * no parseable date are kept with `publishedAt: null`, which is what lets the
+ * caller report them rather than wonder where they went. Age filtering is a
+ * separate step ({@link filterByAge}) precisely so that decision stays visible.
+ */
+export function parseFeedArticles(xml: string, feedName: string): FeedArticle[] {
+    const articles: FeedArticle[] = [];
+    const blockPattern = /<(item|entry)(?:\s[^>]*)?>([\s\S]*?)<\/\1\s*>/g;
+    let match: RegExpExecArray | null;
+
+    while ((match = blockPattern.exec(xml)) !== null) {
+        const itemXml = match[2];
+
+        const title = stripHtml(extractTag(itemXml, 'title'));
+        if (!title) continue;
+
+        // RSS puts the URL in <link>text</link>; Atom puts it in <link href="…"/>,
+        // which leaves the text extraction empty.
+        const link =
+            decodeEntities(extractTag(itemXml, 'link')) ||
+            extractAttribute(itemXml, 'link', 'href') ||
+            extractPermalinkGuid(itemXml);
+
+        // RSS: description or content:encoded. Atom: summary or content.
+        const rawDescription =
+            extractTag(itemXml, 'description') ||
+            extractTag(itemXml, 'content:encoded') ||
+            extractTag(itemXml, 'summary') ||
+            extractTag(itemXml, 'content');
+
+        // RSS: pubDate (RFC 822), sometimes dc:date. Atom: published, else updated.
+        const rawDate =
+            extractTag(itemXml, 'pubDate') ||
+            extractTag(itemXml, 'published') ||
+            extractTag(itemXml, 'updated') ||
+            extractTag(itemXml, 'dc:date');
+
+        // Atom categories are an attribute, not element text.
+        const categories = extractAllTags(itemXml, 'category');
+        if (categories.length === 0) {
+            const term = extractAttribute(itemXml, 'category', 'term');
+            if (term) categories.push(term);
+        }
+
+        articles.push({
+            title,
+            link,
+            description: stripHtml(rawDescription).slice(0, MAX_DESCRIPTION_LENGTH),
+            publishedAt: parseFeedDate(rawDate),
+            categories,
+            feedName,
+        });
+    }
+
+    return articles;
+}
+
+/** Some feeds carry the canonical URL as a permalink `<guid>` and no `<link>`. */
+function extractPermalinkGuid(xml: string): string {
+    const match = xml.match(/<guid[^>]*isPermaLink\s*=\s*["']true["'][^>]*>([\s\S]*?)<\/guid\s*>/);
+    return decodeEntities(match?.[1]?.trim() ?? '');
+}
+
+/** A feed date as ISO 8601, or null when it is missing or unparseable. */
+export function parseFeedDate(raw: string): string | null {
+    if (!raw) return null;
+    const parsed = new Date(raw);
+    return isNaN(parsed.getTime()) ? null : parsed.toISOString();
+}
+
+// ─── Age filtering ────────────────────────────────────────────────────────────
+
+/** The outcome of an age filter, keeping what it dropped countable. */
+export interface AgeFilterResult {
+    kept: FeedArticle[];
+    /** Dropped for being older than the window. */
+    tooOldCount: number;
+    /** Undated articles, kept or dropped per `includeUndated`. */
+    undatedCount: number;
+}
+
+/**
+ * Keep articles published within `maxAgeDays` of `now`.
+ *
+ * Undated articles cannot be age-filtered, so `includeUndated` decides them
+ * explicitly rather than having them silently vanish — which is what happens when
+ * an undated item is compared against a cutoff. Both counts come back so the
+ * caller can say how many articles a quiet result set actually hid.
+ *
+ * A future-dated article is kept: publishers do post-date, and a clock skew of a
+ * few minutes should not delete the newest item in the feed.
+ */
+export function filterByAge(
+    articles: FeedArticle[],
+    maxAgeDays: number,
+    now: Date,
+    includeUndated: boolean,
+): AgeFilterResult {
+    const cutoff = now.getTime() - maxAgeDays * MS_PER_DAY;
+    const kept: FeedArticle[] = [];
+    let tooOldCount = 0;
+    let undatedCount = 0;
+
+    for (const article of articles) {
+        if (article.publishedAt === null) {
+            undatedCount++;
+            if (includeUndated) kept.push(article);
+            continue;
+        }
+        if (new Date(article.publishedAt).getTime() < cutoff) {
+            tooOldCount++;
+            continue;
+        }
+        kept.push(article);
+    }
+
+    return { kept, tooOldCount, undatedCount };
+}
+
+// ─── Scoring ──────────────────────────────────────────────────────────────────
+
+/**
+ * Score keyword relevance. A hit in the title counts 3, in a category 2, in the
+ * description 1, and one keyword can hit all three.
+ *
+ * Matching is case-insensitive substring, which is what makes it useful on feed
+ * text — but it means 'AI' matches 'said'. Prefer multi-word keywords when that
+ * matters; the alternative, word-boundary matching, would miss 'AI-driven' and
+ * plurals, which costs more in practice.
+ */
+export function computeRelevanceScore(article: FeedArticle, keywords: string[]): { score: number; matched: string[] } {
+    const title = article.title.toLowerCase();
+    const description = article.description.toLowerCase();
+    const categories = article.categories.map(c => c.toLowerCase()).join(' ');
+
+    let score = 0;
+    const matched: string[] = [];
+
+    for (const keyword of keywords) {
+        const needle = keyword.trim().toLowerCase();
+        if (needle.length === 0) continue;
+
+        let keywordScore = 0;
+        if (title.includes(needle)) keywordScore += RELEVANCE_WEIGHTS.title;
+        if (categories.includes(needle)) keywordScore += RELEVANCE_WEIGHTS.category;
+        if (description.includes(needle)) keywordScore += RELEVANCE_WEIGHTS.description;
+
+        if (keywordScore > 0) {
+            score += keywordScore;
+            matched.push(keyword);
+        }
+    }
+
+    return { score, matched };
+}
+
+/**
+ * Recency as a 0-1 decay across the window: 1.0 for something published at `now`,
+ * floored at 0.1 at the far edge so an in-window article never scores as though it
+ * were out of window. Undated and out-of-window both score 0.
+ */
+export function computeRecencyScore(publishedAt: string | null, timeWindowDays: number, now: Date): number {
+    if (publishedAt === null || timeWindowDays <= 0) return 0;
+    const ageDays = (now.getTime() - new Date(publishedAt).getTime()) / MS_PER_DAY;
+    if (ageDays > timeWindowDays) return 0;
+    // Future-dated articles clamp to the maximum rather than exceeding it.
+    if (ageDays <= 0) return 1;
+    return Math.max(0.1, 1 - ageDays / timeWindowDays);
+}
+
+/**
+ * Score every article and rank them, highest total first.
+ *
+ * With no keywords, relevance is 0 for everything and the ranking is pure
+ * recency — which is the right behaviour for "just show me what is new" rather
+ * than an error.
+ */
+export function scoreAndRankArticles(
+    articles: FeedArticle[],
+    keywords: string[],
+    timeWindowDays: number,
+    now: Date,
+): ScoredFeedArticle[] {
+    const scored = articles.map((article): ScoredFeedArticle => {
+        const { score: relevanceScore, matched } = computeRelevanceScore(article, keywords);
+        const recencyScore = computeRecencyScore(article.publishedAt, timeWindowDays, now);
+        return {
+            article,
+            relevanceScore,
+            recencyScore,
+            totalScore: relevanceScore * 10 + recencyScore * 5,
+            matchedKeywords: matched,
+        };
+    });
+
+    // Stable within equal scores: sort is stable in every supported runtime, so
+    // ties keep feed order and a re-read of an unchanged feed ranks identically.
+    return scored.sort((a, b) => b.totalScore - a.totalScore);
+}
+
+/**
+ * Drop articles that matched nothing and are not fresh enough to be interesting
+ * on their own.
+ *
+ * The recency escape hatch exists because a keyword list is always incomplete: an
+ * article published in the last quarter of the window is worth surfacing even
+ * though none of the supplied keywords appeared in it. With no keywords supplied,
+ * everything is relevant by definition and nothing is dropped.
+ */
+export function filterRelevant(scored: ScoredFeedArticle[], keywords: string[], recencyFloor = 0.75): ScoredFeedArticle[] {
+    if (keywords.length === 0) return scored;
+    return scored.filter(s => s.relevanceScore > 0 || s.recencyScore >= recencyFloor);
+}

--- a/packages/Actions/CoreActions/src/custom/web/rss-feed-read.action.ts
+++ b/packages/Actions/CoreActions/src/custom/web/rss-feed-read.action.ts
@@ -1,0 +1,360 @@
+import { ActionResultSimple, RunActionParams } from "@memberjunction/actions-base";
+import { BaseAction } from "@memberjunction/actions";
+import { RegisterClass } from "@memberjunction/global";
+import { LogError, LogStatus } from "@memberjunction/core";
+import {
+    FeedArticle,
+    ScoredFeedArticle,
+    filterByAge,
+    filterRelevant,
+    parseFeedArticles,
+    scoreAndRankArticles,
+} from "./rss-feed-parsing";
+
+/** One feed to read. `Name` is what a merged result set is attributed to. */
+export interface RSSFeedInput {
+    name: string;
+    url: string;
+}
+
+/** Per-feed outcome, reported whether the feed succeeded or not. */
+export interface RSSFeedStatus {
+    name: string;
+    url: string;
+    success: boolean;
+    articleCount: number;
+    error: string | null;
+}
+
+/**
+ * Action that reads one or more RSS or Atom feeds and returns their articles,
+ * optionally scored and ranked against a keyword list.
+ *
+ * Feeds are fetched concurrently and a failing feed does not fail the action: its
+ * error is reported in `FeedStatuses` while the other feeds still return their
+ * articles. A feed being unreachable is the normal case at any scale — one dead
+ * URL in a list of twenty should not cost the caller the other nineteen.
+ *
+ * No credential. These are public HTTP endpoints.
+ *
+ * Scoring is a keyword-relevance weight (title 3, category 2, description 1)
+ * plus a recency decay across the time window, combined as
+ * `relevance * 10 + recency * 5` so relevance dominates and recency breaks ties.
+ * The numeric scores come back on every article rather than being bucketed into
+ * labels, because what counts as "high" depends on the caller's corpus, not on
+ * this action's batch.
+ *
+ * @example
+ * ```typescript
+ * // Just read a feed
+ * await runAction({
+ *   ActionName: 'Read RSS Feed',
+ *   Params: [{ Name: 'FeedURLs', Value: 'https://example.org/news/feed.xml' }]
+ * });
+ *
+ * // Several named feeds, ranked against keywords, last 7 days
+ * await runAction({
+ *   ActionName: 'Read RSS Feed',
+ *   Params: [
+ *     { Name: 'Feeds', Value: [
+ *         { name: 'Associations Now', url: 'https://associationsnow.com/feed/' },
+ *         { name: 'NonprofitPRO',     url: 'https://www.nonprofitpro.com/feed/' }
+ *     ]},
+ *     { Name: 'Keywords', Value: ['membership', 'dues', 'retention'] },
+ *     { Name: 'MaxAgeDays', Value: 7 },
+ *     { Name: 'MaxResults', Value: 25 }
+ *   ]
+ * });
+ * ```
+ */
+@RegisterClass(BaseAction, "Read RSS Feed")
+export class ReadRSSFeedAction extends BaseAction {
+    private static readonly DEFAULT_MAX_AGE_DAYS = 7;
+    private static readonly DEFAULT_MAX_RESULTS = 25;
+    private static readonly FETCH_TIMEOUT_MS = 15000;
+    /** Bounded so one enormous feed cannot exhaust memory. */
+    private static readonly MAX_FEED_BYTES = 10 * 1024 * 1024;
+    private static readonly USER_AGENT = 'MemberJunction-CoreActions/1.0';
+
+    /**
+     * Executes the feed read.
+     *
+     * @param params - The action parameters containing:
+     *   - Feeds: Array of `{ name, url }` (or a JSON string of one). Either this
+     *     or FeedURLs is required
+     *   - FeedURLs: Array or comma-separated string of URLs, named after their host
+     *   - Keywords: Array or comma-separated string. Optional — with none supplied,
+     *     articles come back ranked purely by recency
+     *   - MaxAgeDays: Age window, default 7. News has a short shelf life
+     *   - MaxResults: Cap on returned articles, default 25
+     *   - IncludeUndated: Keep articles the feed gave no parseable date (default
+     *     false). They cannot be age-filtered, so this is an explicit choice
+     *   - RequireAllFeeds: Fail the action if any feed failed (default false)
+     *
+     * @returns Ranked articles, plus a per-feed status list
+     */
+    protected async InternalRunAction(params: RunActionParams): Promise<ActionResultSimple> {
+        const feedsResult = this.resolveFeeds(params);
+        if (feedsResult.error !== null) {
+            return feedsResult.error;
+        }
+        const feeds = feedsResult.feeds;
+
+        const keywords = this.getStringArrayParam(params, 'keywords');
+        const maxAgeDays = Math.max(this.getNumericParam(params, 'maxagedays', ReadRSSFeedAction.DEFAULT_MAX_AGE_DAYS), 0);
+        const maxResults = Math.max(Math.floor(this.getNumericParam(params, 'maxresults', ReadRSSFeedAction.DEFAULT_MAX_RESULTS)), 1);
+        const includeUndated = this.getBooleanParam(params, 'includeundated', false);
+        const requireAllFeeds = this.getBooleanParam(params, 'requireallfeeds', false);
+
+        // One clock for the whole run: the age filter and the recency score must
+        // agree, or an article can pass the filter and then score as out-of-window.
+        const now = this.Now();
+
+        const settled = await Promise.allSettled(feeds.map(feed => this.fetchAndParse(feed)));
+
+        const statuses: RSSFeedStatus[] = [];
+        const allArticles: FeedArticle[] = [];
+        for (let i = 0; i < settled.length; i++) {
+            const outcome = settled[i];
+            const feed = feeds[i];
+            if (outcome.status === 'fulfilled') {
+                allArticles.push(...outcome.value);
+                statuses.push({ name: feed.name, url: feed.url, success: true, articleCount: outcome.value.length, error: null });
+            } else {
+                const message = outcome.reason instanceof Error ? outcome.reason.message : String(outcome.reason);
+                LogError(`ReadRSSFeed: failed to read '${feed.name}' (${feed.url}): ${message}`);
+                statuses.push({ name: feed.name, url: feed.url, success: false, articleCount: 0, error: message });
+            }
+        }
+
+        const failedFeeds = statuses.filter(s => !s.success);
+        if (requireAllFeeds && failedFeeds.length > 0) {
+            return {
+                Success: false,
+                Message:
+                    `${failedFeeds.length} of ${feeds.length} feed(s) failed and RequireAllFeeds is set: ` +
+                    failedFeeds.map(f => `${f.name} (${f.error})`).join('; '),
+                ResultCode: 'FEED_FETCH_FAILED',
+            };
+        }
+
+        const aged = filterByAge(allArticles, maxAgeDays, now, includeUndated);
+        const ranked = scoreAndRankArticles(aged.kept, keywords, maxAgeDays, now);
+        const relevant = filterRelevant(ranked, keywords);
+        const top = relevant.slice(0, maxResults);
+
+        LogStatus(
+            `ReadRSSFeed: ${allArticles.length} article(s) from ${statuses.filter(s => s.success).length}/${feeds.length} feed(s); ` +
+            `${aged.kept.length} within ${maxAgeDays} day(s), ${relevant.length} relevant, returning ${top.length}.`
+        );
+
+        this.addOutputParam(params, 'Articles', top.map(this.toOutputArticle));
+        this.addOutputParam(params, 'ArticleCount', top.length);
+        this.addOutputParam(params, 'FeedStatuses', statuses);
+        this.addOutputParam(params, 'TotalFetched', allArticles.length);
+        this.addOutputParam(params, 'FilteredOutTooOld', aged.tooOldCount);
+        this.addOutputParam(params, 'UndatedCount', aged.undatedCount);
+        this.addOutputParam(params, 'FailedFeedCount', failedFeeds.length);
+
+        // Every count that shaped the answer is stated, so an empty or short result
+        // set is explainable without re-running anything. An empty result is a real
+        // answer — a quiet week is not a failure.
+        const message =
+            `Read ${allArticles.length} article(s) from ${statuses.filter(s => s.success).length} of ${feeds.length} feed(s); ` +
+            `returning ${top.length}` +
+            (aged.tooOldCount > 0 ? `, ${aged.tooOldCount} older than ${maxAgeDays} day(s)` : '') +
+            (aged.undatedCount > 0 ? `, ${aged.undatedCount} undated (${includeUndated ? 'kept' : 'excluded'})` : '') +
+            (keywords.length > 0 ? `, ${ranked.length - relevant.length} matched no keyword and were not fresh enough` : '') +
+            (failedFeeds.length > 0 ? `, ${failedFeeds.length} feed(s) failed` : '') +
+            '.';
+
+        return { Success: true, Message: message, ResultCode: 'SUCCESS' };
+    }
+
+    /** The current time. Overridable so tests can pin the clock. */
+    protected Now(): Date {
+        return new Date();
+    }
+
+    /** Fetch, with a timeout and a size bound. Overridable for tests. */
+    protected async FetchFeed(url: string): Promise<string> {
+        const controller = new AbortController();
+        const timeout = setTimeout(() => controller.abort(), ReadRSSFeedAction.FETCH_TIMEOUT_MS);
+        try {
+            const response = await fetch(url, {
+                signal: controller.signal,
+                headers: {
+                    'User-Agent': ReadRSSFeedAction.USER_AGENT,
+                    accept: 'application/rss+xml, application/atom+xml, application/xml, text/xml, */*',
+                },
+            });
+            if (!response.ok) {
+                const body = await response.text().catch(() => '');
+                throw new Error(`HTTP ${response.status}${body ? `: ${body.slice(0, 200)}` : ''}`);
+            }
+            const text = await response.text();
+            if (text.length > ReadRSSFeedAction.MAX_FEED_BYTES) {
+                throw new Error(
+                    `feed body is ${text.length} bytes, above the ${ReadRSSFeedAction.MAX_FEED_BYTES}-byte limit`
+                );
+            }
+            return text;
+        } finally {
+            clearTimeout(timeout);
+        }
+    }
+
+    private async fetchAndParse(feed: RSSFeedInput): Promise<FeedArticle[]> {
+        const xml = await this.FetchFeed(feed.url);
+        return parseFeedArticles(xml, feed.name);
+    }
+
+    /**
+     * Resolve `Feeds` or `FeedURLs` into a validated list.
+     *
+     * A URL that is not http(s) is rejected rather than attempted: `file://` and
+     * friends would turn a feed-reading action into a local-file reader, which is
+     * not what any caller of this means.
+     */
+    private resolveFeeds(params: RunActionParams): { feeds: RSSFeedInput[]; error: null } | { feeds: never[]; error: ActionResultSimple } {
+        const feeds: RSSFeedInput[] = [];
+
+        const rawFeeds = this.getParamValue(params, 'feeds');
+        if (rawFeeds !== undefined && rawFeeds !== null && rawFeeds !== '') {
+            let parsed: unknown = rawFeeds;
+            if (typeof parsed === 'string') {
+                try {
+                    parsed = JSON.parse(parsed);
+                } catch (error) {
+                    return {
+                        feeds: [],
+                        error: this.createErrorResult(
+                            `Feeds could not be parsed as JSON: ${error instanceof Error ? error.message : String(error)}. ` +
+                            `Supply an array of { name, url }, or use FeedURLs for a plain list of URLs.`,
+                            'INVALID_FEEDS'
+                        ),
+                    };
+                }
+            }
+            if (!Array.isArray(parsed)) {
+                return {
+                    feeds: [],
+                    error: this.createErrorResult('Feeds must be an array of { name, url } objects', 'INVALID_FEEDS'),
+                };
+            }
+            for (const entry of parsed) {
+                if (!entry || typeof entry !== 'object') {
+                    return { feeds: [], error: this.createErrorResult('Each Feeds entry must be an object with a url', 'INVALID_FEEDS') };
+                }
+                const record = entry as Record<string, unknown>;
+                const url = typeof record.url === 'string' ? record.url.trim() : '';
+                if (!url) {
+                    return { feeds: [], error: this.createErrorResult('Each Feeds entry requires a url', 'INVALID_FEEDS') };
+                }
+                const name = typeof record.name === 'string' && record.name.trim().length > 0 ? record.name.trim() : this.nameFromUrl(url);
+                feeds.push({ name, url });
+            }
+        }
+
+        for (const url of this.getStringArrayParam(params, 'feedurls')) {
+            feeds.push({ name: this.nameFromUrl(url), url });
+        }
+
+        if (feeds.length === 0) {
+            return {
+                feeds: [],
+                error: this.createErrorResult(
+                    'Supply at least one feed through Feeds ([{ name, url }]) or FeedURLs (a list of URLs)',
+                    'MISSING_FEEDS'
+                ),
+            };
+        }
+
+        const invalid = feeds.filter(f => !this.isHttpUrl(f.url));
+        if (invalid.length > 0) {
+            return {
+                feeds: [],
+                error: this.createErrorResult(
+                    `Only http and https feed URLs are supported. Rejected: ${invalid.map(f => f.url).join(', ')}`,
+                    'INVALID_FEED_URL'
+                ),
+            };
+        }
+
+        // De-duplicate by URL. The same feed listed twice would double every
+        // article and distort the ranking, since scores are per article.
+        const seen = new Set<string>();
+        return { feeds: feeds.filter(f => (seen.has(f.url) ? false : (seen.add(f.url), true))), error: null };
+    }
+
+    private isHttpUrl(url: string): boolean {
+        try {
+            const protocol = new URL(url).protocol;
+            return protocol === 'http:' || protocol === 'https:';
+        } catch {
+            return false;
+        }
+    }
+
+    /** Fall back to the host as a feed's display name. */
+    private nameFromUrl(url: string): string {
+        try {
+            return new URL(url).hostname;
+        } catch {
+            return url;
+        }
+    }
+
+    /** Flatten a scored article for output — scores at the top level, not nested. */
+    private toOutputArticle(scored: ScoredFeedArticle) {
+        return {
+            title: scored.article.title,
+            link: scored.article.link,
+            description: scored.article.description,
+            publishedAt: scored.article.publishedAt,
+            categories: scored.article.categories,
+            feedName: scored.article.feedName,
+            relevanceScore: scored.relevanceScore,
+            recencyScore: Number(scored.recencyScore.toFixed(4)),
+            totalScore: Number(scored.totalScore.toFixed(4)),
+            matchedKeywords: scored.matchedKeywords,
+        };
+    }
+
+    private getParamValue(params: RunActionParams, paramName: string): unknown {
+        return params.Params.find(p => p.Name.trim().toLowerCase() === paramName.toLowerCase())?.Value;
+    }
+
+    private getStringArrayParam(params: RunActionParams, paramName: string): string[] {
+        const value = this.getParamValue(params, paramName);
+        if (value === undefined || value === null) return [];
+        const raw = Array.isArray(value) ? value.map(v => String(v)) : String(value).split(',');
+        return raw.map(v => v.trim()).filter(v => v.length > 0);
+    }
+
+    private getNumericParam(params: RunActionParams, paramName: string, defaultValue: number): number {
+        const value = this.getParamValue(params, paramName);
+        if (value === undefined || value === null || value === '') return defaultValue;
+        const num = Number(value);
+        return isNaN(num) ? defaultValue : num;
+    }
+
+    private getBooleanParam(params: RunActionParams, paramName: string, defaultValue: boolean): boolean {
+        const value = this.getParamValue(params, paramName);
+        if (value === undefined || value === null || value === '') return defaultValue;
+        if (typeof value === 'boolean') return value;
+        return String(value).trim().toLowerCase() === 'true';
+    }
+
+    private addOutputParam(params: RunActionParams, name: string, value: unknown): void {
+        params.Params.push({ Name: name, Type: 'Output', Value: value });
+    }
+
+    private createErrorResult(message: string, code: string): ActionResultSimple {
+        return { Success: false, Message: message, ResultCode: code };
+    }
+}
+
+export function LoadReadRSSFeedAction(): void {
+    // Referenced by consumers to keep this registration from being tree-shaken.
+}

--- a/packages/Actions/CoreActions/src/custom/web/tavily-search.action.ts
+++ b/packages/Actions/CoreActions/src/custom/web/tavily-search.action.ts
@@ -1,0 +1,344 @@
+import { ActionResultSimple, RunActionParams } from "@memberjunction/actions-base";
+import { BaseAction } from "@memberjunction/actions";
+import { RegisterClass } from "@memberjunction/global";
+import axios from "axios";
+import { getApiIntegrationsConfig } from "../../config";
+
+/** One result from Tavily's /search endpoint. */
+export interface TavilySearchResultItem {
+    title: string;
+    url: string;
+    /** Extracted page content, already trimmed by Tavily to what an LLM needs. */
+    content: string;
+    /**
+     * Tavily's relevance score for this result against the query, 0-1.
+     *
+     * It is a *relative* ranking signal within one response, not a calibrated
+     * probability — do not compare scores across queries, and do not hard-code
+     * thresholds against it.
+     */
+    score: number;
+    /** Only populated when `Topic` is 'news'; absent otherwise. */
+    publishedDate?: string;
+    /** Only populated when `IncludeRawContent` is set. */
+    rawContent?: string;
+}
+
+interface TavilyAPIResult {
+    title?: string;
+    url?: string;
+    content?: string;
+    score?: number;
+    published_date?: string;
+    raw_content?: string;
+}
+
+interface TavilyAPIResponse {
+    query?: string;
+    answer?: string;
+    results?: TavilyAPIResult[];
+    images?: unknown[];
+    response_time?: number;
+}
+
+/**
+ * Action that searches the web through Tavily, a search API built for LLM
+ * consumption: results arrive as extracted page content rather than as snippets
+ * plus links to go fetch.
+ *
+ * Two things distinguish it from the other search actions in this package.
+ * `Topic: 'news'` gives a date-filtered news index with `PublishedDate` on every
+ * result, which is what makes recency-sensitive questions answerable. And
+ * `IncludeAnswer` returns a synthesized answer alongside the results, so a caller
+ * that only needs the conclusion does not have to run its own summarization pass.
+ *
+ * Authentication is `Authorization: Bearer <key>`. Tavily also still accepts an
+ * `api_key` field in the request body, but that form is legacy and puts the
+ * credential in the payload, so it is not used here.
+ *
+ * @example
+ * ```typescript
+ * // Basic search
+ * await runAction({
+ *   ActionName: 'Tavily Search',
+ *   Params: [{ Name: 'Query', Value: 'association management software trends' }]
+ * });
+ *
+ * // Recent news, with a synthesized answer
+ * await runAction({
+ *   ActionName: 'Tavily Search',
+ *   Params: [
+ *     { Name: 'Query', Value: 'nonprofit membership dues changes' },
+ *     { Name: 'Topic', Value: 'news' },
+ *     { Name: 'Days', Value: 7 },
+ *     { Name: 'IncludeAnswer', Value: true }
+ *   ]
+ * });
+ *
+ * // Advanced depth, restricted to two domains
+ * await runAction({
+ *   ActionName: 'Tavily Search',
+ *   Params: [
+ *     { Name: 'Query', Value: 'IRS Form 990 filing requirements' },
+ *     { Name: 'SearchDepth', Value: 'advanced' },
+ *     { Name: 'IncludeDomains', Value: ['irs.gov', 'councilofnonprofits.org'] }
+ *   ]
+ * });
+ * ```
+ */
+@RegisterClass(BaseAction, "Tavily Search")
+export class TavilySearchAction extends BaseAction {
+    /** Tavily's cap on results per request. */
+    private static readonly MAX_RESULTS = 20;
+    private static readonly DEFAULT_MAX_RESULTS = 10;
+    private static readonly ENDPOINT = 'https://api.tavily.com/search';
+
+    /**
+     * Executes the Tavily search.
+     *
+     * @param params - The action parameters containing:
+     *   - Query: Search query text (required)
+     *   - SearchDepth: 'basic' (default) or 'advanced'. Advanced costs more Tavily
+     *     credits per call and returns better-extracted content
+     *   - Topic: 'general' (default) or 'news'. 'news' is the only topic that
+     *     returns publication dates and the only one `Days` applies to
+     *   - Days: For Topic 'news', how far back to search (default 3 at Tavily)
+     *   - MaxResults: 1-20 (default 10)
+     *   - IncludeAnswer: Return a synthesized answer alongside results (default false)
+     *   - IncludeRawContent: Return full page text per result (default false) —
+     *     this can be very large, so it is off unless asked for
+     *   - IncludeDomains: Only return results from these domains
+     *   - ExcludeDomains: Never return results from these domains
+     *
+     * @returns Search results, and the synthesized answer when requested
+     */
+    protected async InternalRunAction(params: RunActionParams): Promise<ActionResultSimple> {
+        const query = this.getStringParam(params, 'query');
+        if (!query) {
+            return this.createErrorResult("Query parameter is required", "MISSING_QUERY");
+        }
+
+        const apiKey = getApiIntegrationsConfig().tavilyApiKey;
+        if (!apiKey) {
+            return this.createErrorResult(
+                "Tavily API key not found. Set tavilyApiKey in mj.config.cjs or the TAVILY_API_KEY environment variable",
+                "MISSING_API_KEY"
+            );
+        }
+
+        const searchDepth = (this.getStringParam(params, 'searchdepth') || 'basic').toLowerCase();
+        if (searchDepth !== 'basic' && searchDepth !== 'advanced') {
+            return this.createErrorResult(
+                `SearchDepth must be 'basic' or 'advanced' (got '${searchDepth}')`,
+                "INVALID_SEARCH_DEPTH"
+            );
+        }
+
+        const topic = (this.getStringParam(params, 'topic') || 'general').toLowerCase();
+        if (topic !== 'general' && topic !== 'news') {
+            return this.createErrorResult(
+                `Topic must be 'general' or 'news' (got '${topic}')`,
+                "INVALID_TOPIC"
+            );
+        }
+
+        // Clamped rather than rejected: a caller asking for 50 results wants as many
+        // as possible, and Tavily rejects the whole request above its cap.
+        const requestedMaxResults = this.getNumericParam(params, 'maxresults', TavilySearchAction.DEFAULT_MAX_RESULTS);
+        const maxResults = Math.min(Math.max(Math.floor(requestedMaxResults), 1), TavilySearchAction.MAX_RESULTS);
+
+        const includeAnswer = this.getBooleanParam(params, 'includeanswer', false);
+        const includeRawContent = this.getBooleanParam(params, 'includerawcontent', false);
+        const includeDomains = this.getStringArrayParam(params, 'includedomains');
+        const excludeDomains = this.getStringArrayParam(params, 'excludedomains');
+        const days = this.getOptionalNumericParam(params, 'days');
+
+        const requestBody: Record<string, unknown> = {
+            query,
+            search_depth: searchDepth,
+            topic,
+            max_results: maxResults,
+            include_answer: includeAnswer,
+            include_raw_content: includeRawContent,
+        };
+        if (includeDomains.length > 0) {
+            requestBody.include_domains = includeDomains;
+        }
+        if (excludeDomains.length > 0) {
+            requestBody.exclude_domains = excludeDomains;
+        }
+        // `days` is a news-only parameter. Sending it on a general search is at best
+        // ignored, so it is dropped with the reason stated rather than passed through.
+        if (days !== undefined) {
+            if (topic === 'news') {
+                requestBody.days = Math.max(Math.floor(days), 1);
+            } else {
+                this.addOutputParam(
+                    params,
+                    'Warnings',
+                    [`Days was ignored: it only applies when Topic is 'news' (Topic was '${topic}').`]
+                );
+            }
+        }
+
+        try {
+            const response = await axios.post<TavilyAPIResponse>(
+                TavilySearchAction.ENDPOINT,
+                requestBody,
+                {
+                    headers: {
+                        'Authorization': `Bearer ${apiKey}`,
+                        'Content-Type': 'application/json'
+                    },
+                    timeout: 60000
+                }
+            );
+
+            if (!response.data) {
+                return this.createErrorResult("Empty response from Tavily API", "EMPTY_RESPONSE");
+            }
+
+            const results = (response.data.results ?? []).map((item): TavilySearchResultItem => {
+                const mapped: TavilySearchResultItem = {
+                    title: item.title ?? '',
+                    url: item.url ?? '',
+                    content: item.content ?? '',
+                    score: typeof item.score === 'number' ? item.score : 0,
+                };
+                if (item.published_date) {
+                    mapped.publishedDate = item.published_date;
+                }
+                if (item.raw_content) {
+                    mapped.rawContent = item.raw_content;
+                }
+                return mapped;
+            });
+
+            const answer = response.data.answer ?? '';
+
+            this.addOutputParam(params, 'Results', results);
+            this.addOutputParam(params, 'ResultCount', results.length);
+            if (includeAnswer) {
+                this.addOutputParam(params, 'Answer', answer);
+            }
+            this.addOutputParam(params, 'SearchResultDetails', {
+                query,
+                searchDepth,
+                topic,
+                maxResults,
+                results,
+                answer,
+                responseTime: response.data.response_time,
+            });
+
+            // Zero results is a real answer to a narrow query, not a failure — a
+            // caller that treats it as one would retry a query that will keep
+            // returning nothing. It is reported in the message instead.
+            return {
+                Success: true,
+                ResultCode: "SUCCESS",
+                Message: results.length === 0
+                    ? `Tavily returned no results for '${query}'.`
+                    : `Tavily returned ${results.length} result(s) for '${query}'.`
+            };
+        } catch (error) {
+            if (axios.isAxiosError(error)) {
+                const status = error.response?.status;
+                const detail = this.describeAxiosError(error.response?.data) || error.message;
+
+                if (status === 401 || status === 403) {
+                    return this.createErrorResult(
+                        `Tavily rejected the API key (HTTP ${status}): ${detail}`,
+                        "INVALID_API_KEY"
+                    );
+                }
+                if (status === 429) {
+                    return this.createErrorResult(
+                        `Tavily rate limit or credit allowance exceeded: ${detail}`,
+                        "RATE_LIMITED"
+                    );
+                }
+                if (status === 400 || status === 422) {
+                    return this.createErrorResult(
+                        `Tavily rejected the request (HTTP ${status}): ${detail}`,
+                        "INVALID_REQUEST"
+                    );
+                }
+                return this.createErrorResult(`Tavily API error: ${detail}`, "API_ERROR");
+            }
+
+            return this.createErrorResult(
+                `Failed to perform Tavily search: ${error instanceof Error ? error.message : String(error)}`,
+                "SEARCH_FAILED"
+            );
+        }
+    }
+
+    /** Pull whatever explanation the error body carries, without assuming a shape. */
+    private describeAxiosError(data: unknown): string {
+        if (typeof data === 'string') return data.slice(0, 500);
+        if (data && typeof data === 'object') {
+            const record = data as Record<string, unknown>;
+            for (const key of ['detail', 'error', 'message']) {
+                const value = record[key];
+                if (typeof value === 'string' && value.length > 0) return value;
+                // Tavily's 422 nests the explanation as { detail: { error: '…' } }.
+                if (value && typeof value === 'object') {
+                    const nested = (value as Record<string, unknown>).error;
+                    if (typeof nested === 'string' && nested.length > 0) return nested;
+                }
+            }
+        }
+        return '';
+    }
+
+    private getStringParam(params: RunActionParams, paramName: string): string | undefined {
+        const param = params.Params.find(p => p.Name.trim().toLowerCase() === paramName.toLowerCase());
+        if (param?.Value === undefined || param?.Value === null) return undefined;
+        const value = String(param.Value).trim();
+        return value.length > 0 ? value : undefined;
+    }
+
+    private getBooleanParam(params: RunActionParams, paramName: string, defaultValue: boolean): boolean {
+        const param = params.Params.find(p => p.Name.trim().toLowerCase() === paramName.toLowerCase());
+        if (param?.Value === undefined || param?.Value === null) return defaultValue;
+        if (typeof param.Value === 'boolean') return param.Value;
+        return String(param.Value).trim().toLowerCase() === 'true';
+    }
+
+    private getNumericParam(params: RunActionParams, paramName: string, defaultValue: number): number {
+        return this.getOptionalNumericParam(params, paramName) ?? defaultValue;
+    }
+
+    private getOptionalNumericParam(params: RunActionParams, paramName: string): number | undefined {
+        const param = params.Params.find(p => p.Name.trim().toLowerCase() === paramName.toLowerCase());
+        if (param?.Value === undefined || param?.Value === null || param.Value === '') return undefined;
+        const num = Number(param.Value);
+        return isNaN(num) ? undefined : num;
+    }
+
+    /**
+     * A list param, accepted as a real array or as a comma-separated string —
+     * both forms arrive in practice, from agent input mappings and from humans
+     * respectively.
+     */
+    private getStringArrayParam(params: RunActionParams, paramName: string): string[] {
+        const param = params.Params.find(p => p.Name.trim().toLowerCase() === paramName.toLowerCase());
+        const value = param?.Value;
+        if (value === undefined || value === null) return [];
+        const raw = Array.isArray(value) ? value.map(v => String(v)) : String(value).split(',');
+        return raw.map(v => v.trim()).filter(v => v.length > 0);
+    }
+
+    private addOutputParam(params: RunActionParams, name: string, value: unknown): void {
+        params.Params.push({ Name: name, Type: 'Output', Value: value });
+    }
+
+    private createErrorResult(message: string, code: string): ActionResultSimple {
+        return { Success: false, Message: message, ResultCode: code };
+    }
+}
+
+export function LoadTavilySearchAction(): void {
+    // Referenced by consumers to keep this registration from being tree-shaken.
+}

--- a/packages/Actions/CoreActions/src/index.ts
+++ b/packages/Actions/CoreActions/src/index.ts
@@ -46,6 +46,9 @@ export * from './custom/web/url-link-validator.action';
 export * from './custom/web/url-metadata-extractor.action';
 export * from './custom/web/perplexity-search.action';
 export * from './custom/web/google-custom-search.action';
+export * from './custom/web/tavily-search.action';
+export * from './custom/web/rss-feed-read.action';
+export * from './custom/web/rss-feed-parsing';
 
 // Data Transformation Actions
 export * from './custom/data/csv-parser.action';


### PR DESCRIPTION
Two new actions in `@memberjunction/core-actions`, plus a config fix. Ported from AIDP's `TavilyTrendProvider` (104 LOC) and `RSSNewsTrendProvider` + `RSSNewsTrendScoring` (285 LOC).

Neither vendor is a system of record, so neither is a connector; neither has an upstream equivalent today.

### Tavily Search

`POST https://api.tavily.com/search` with `Authorization: Bearer tvly-…`. The header form, not the body `api_key` — the latter is legacy and puts the credential in the payload, where it lands in every request log along the way.

`topic: 'news'` is the only topic that returns `published_date` and the only one `days` applies to, so `Days` is accepted for news and produces a `Warnings` output param otherwise, rather than being silently ignored. `MaxResults` clamps at 20. Errors map to `INVALID_API_KEY` / `RATE_LIMITED` / `INVALID_REQUEST` / `API_ERROR` / `SEARCH_FAILED`, with `describeAxiosError` walking `detail` / `error` / `message` including the nested `{detail:{error}}` shape Tavily sometimes returns. Zero results is `Success: true` — a search that legitimately found nothing is not an error.

### Read RSS Feed

**Regex parsing over a strict XML parser is deliberate.** A strict parser fails the whole document over one unescaped ampersand, and unescaped ampersands are common in the wild. This costs that item's text, not the feed. The limit is honest and documented: an item whose own tag is never closed *is* swallowed by the lazy block match, so graceful degradation covers bad **content**, not bad **tags**.

**`stripHtml`'s ordering is load-bearing:** decode → strip tags → decode again → collapse. RSS descriptions overwhelmingly arrive with their HTML *escaped* (`&lt;p&gt;`), so decoding after stripping would leave a literal `<p>` in the output of nearly every feed item; the second pass finishes ampersands that were escaped twice.

One injected `now: Date` for the whole run, so the age filter and the recency score cannot disagree with each other mid-run.

### Left behind deliberately

CDP's trend-specific logic — Tavily's `scoreToStrength` / `inferPlatforms` and RSS's quartile `assignStrength`. Those are AIDP marketing judgments over the results; the actions return the raw numeric scores and let the consumer judge.

### Fix

`getCoreActionsConfig()` built `rawConfig` *inside* the no-config early return, so every environment-variable fallback was dead whenever no config file was present. The build is hoisted out via `const fileConfig = result?.config`. `tavilyApiKey` is added to the zod schema.

### Verification

103 new tests (60 RSS, 43 Tavily); 381 pass across the package; `tsc --noEmit` clean. Note `tsconfig.json` excludes `src/__tests__`, so the tests are not typechecked by that run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)