### PR TITLE
fix(bizapps-social): Buffer createPost assets shape; add CredentialID and PlatformMetadata

### DIFF
--- a/.changeset/buffer-identity-metadata-and-assets.md
+++ b/.changeset/buffer-identity-metadata-and-assets.md
@@ -1,0 +1,15 @@
+---
+"@memberjunction/actions-bizapps-social": minor
+---
+
+Buffer: publish as another identity, pass per-service metadata, and fix the createPost assets shape.
+
+**`CredentialID`** is now accepted by every Buffer action. When given, the calls are made with the `accessToken` from that `MJ: Credentials` row instead of the CompanyIntegration's own token — which is what publishing to an employee's personal channel, or reading the queue of the person who owns it, requires. `CompanyIntegrationID` stays required: it is what identifies which Buffer integration this is, and the organization and channel context still come from it. A `CredentialID` that was supplied but cannot be read is **fatal** (`INVALID_CREDENTIAL`), never a silent fallback to the tenant token — falling back would publish under the wrong identity with nothing for the caller to notice. The token itself never travels through action params; only its id does.
+
+**`PlatformMetadata`** on `Create Post (Buffer)` passes Buffer's per-service extras through to the mutation — `{ "linkedin": { "annotations": [...] } }` is how a LinkedIn @mention survives the trip, and without it the post publishes as plain text with the mention spelled out. It is accepted as an object or as a JSON string, since both forms arrive in practice. It is passed through untouched rather than modelled, because its shape belongs to whichever network the channel points at and Buffer extends it independently of this package. Unparseable input **fails** rather than being dropped, for the same reason the credential failure is fatal: quietly posting without the metadata publishes something other than what the caller composed.
+
+**Fix — the createPost assets shape.** Buffer moved createPost's input to `[AssetInput!]` (`[{ image: { url } }]`, one entry per attachment naming its kind) on 2026-05-25 and rejects the older `{ images: [...] }` object, which is what this package was sending. Any post with `ImageURLs`, `VideoURLs` or `MediaLink` was therefore being rejected by Buffer. Reads are unaffected — Buffer still *returns* the object form — so the input shape is now its own type, `BufferAssetInput`, alongside the unchanged `BufferAssets` response type.
+
+This is a breaking change for any caller passing a hand-built `assets` object to the protected `createBufferPost`; the action's own `ImageURLs`/`VideoURLs`/`MediaLink` params are unchanged.
+
+27 tests cover the credential override, the metadata passthrough and the asset shape.

--- a/packages/Actions/BizApps/Social/src/__tests__/buffer-identity-and-metadata.test.ts
+++ b/packages/Actions/BizApps/Social/src/__tests__/buffer-identity-and-metadata.test.ts
@@ -1,0 +1,387 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// ---------------------------------------------------------------------------
+// Mocks
+//
+// `initializeOAuth` succeeds and hands back a tenant token, so every test here is
+// about what happens *after* the CompanyIntegration resolved — which token the
+// calls end up using, and what reaches the createPost mutation.
+// ---------------------------------------------------------------------------
+
+const TENANT_TOKEN = 'tenant-company-integration-token';
+
+vi.mock('@memberjunction/actions', () => ({
+    BaseAction: class BaseAction {},
+    BaseOAuthAction: class BaseOAuthAction {
+        protected oauthParams: unknown[] = [{ Name: 'CompanyIntegrationID', Type: 'Input', Value: null }];
+        public initializeOAuthCalls: unknown[] = [];
+        protected async initializeOAuth(companyIntegrationId: string): Promise<boolean> {
+            this.initializeOAuthCalls.push(companyIntegrationId);
+            return true;
+        }
+        protected getAccessToken(): string | null {
+            return TENANT_TOKEN;
+        }
+        protected getCustomAttribute(): string | null {
+            return null;
+        }
+        protected getParamValue(params: Array<{ Name: string; Value: unknown }>, name: string): unknown {
+            return params.find(p => p.Name === name)?.Value ?? null;
+        }
+    },
+    OAuth2Manager: class OAuth2Manager {},
+}));
+
+vi.mock('@memberjunction/global', () => ({
+    RegisterClass: () => (target: unknown) => target,
+}));
+
+/** What the next `MJ: Credentials` RunView returns, and every view it was asked for. */
+const credentialView = {
+    reply: { Success: true, Results: [] as Array<{ ID: string; Values: string }> },
+    filters: [] as string[],
+};
+
+vi.mock('@memberjunction/core', () => ({
+    UserInfo: class UserInfo {},
+    Metadata: vi.fn(),
+    LogStatus: vi.fn(),
+    LogError: vi.fn(),
+    RunView: class RunView {
+        public async RunView(params: { ExtraFilter?: string }): Promise<unknown> {
+            credentialView.filters.push(params.ExtraFilter ?? '');
+            return credentialView.reply;
+        }
+    },
+}));
+
+vi.mock('@memberjunction/core-entities', () => ({
+    MJCompanyIntegrationEntity: class MJCompanyIntegrationEntity {},
+}));
+
+vi.mock('@memberjunction/actions-base', () => ({}));
+
+vi.mock('axios', () => ({
+    default: { post: vi.fn(), isAxiosError: vi.fn(() => false) },
+}));
+
+import { BufferCreatePostAction } from '../providers/buffer/actions/create-post.action';
+
+// ---------------------------------------------------------------------------
+// Harness
+// ---------------------------------------------------------------------------
+
+interface GraphQLCall {
+    token: string | null;
+    variables: Record<string, unknown> | undefined;
+}
+
+/**
+ * The action with its one network method replaced. `executeGraphQL` is the single
+ * point every Buffer call funnels through, so recording the token it resolved at
+ * that moment is exactly the assertion the credential override needs.
+ */
+class TestCreatePostAction extends BufferCreatePostAction {
+    public Calls: GraphQLCall[] = [];
+    public FailWith: Error | null = null;
+
+    protected override async executeGraphQL<T>(_query: string, variables?: Record<string, unknown>): Promise<T> {
+        this.Calls.push({ token: this.getAccessToken(), variables });
+        if (this.FailWith) throw this.FailWith;
+        const input = (variables?.input ?? {}) as { channelId?: string; text?: string };
+        return {
+            createPost: {
+                post: {
+                    id: `post-${this.Calls.length}`,
+                    text: input.text ?? '',
+                    status: 'buffer',
+                    dueAt: null,
+                    sentAt: null,
+                    createdAt: '2026-08-05T00:00:00Z',
+                    updatedAt: '2026-08-05T00:00:00Z',
+                    channelId: input.channelId ?? '',
+                    channelService: 'linkedin',
+                    schedulingType: 'automatic',
+                    via: 'api',
+                    assets: null,
+                    tags: [],
+                },
+            },
+        } as T;
+    }
+}
+
+type Params = { Params: Array<{ Name: string; Type: string; Value: unknown }>; ContextUser: unknown };
+
+async function run(inputs: Record<string, unknown>, configure?: (a: TestCreatePostAction) => void) {
+    const action = new TestCreatePostAction();
+    configure?.(action);
+    const params: Params = {
+        Params: Object.entries(inputs).map(([Name, Value]) => ({ Name, Value, Type: 'Input' })),
+        ContextUser: {},
+    };
+    const result = await (action as unknown as {
+        InternalRunAction(p: Params): Promise<{ Success: boolean; ResultCode?: string; Message?: string }>;
+    }).InternalRunAction(params);
+    return { result, action, params };
+}
+
+/** The `input` object of the nth createPost mutation. */
+function mutationInput(action: TestCreatePostAction, index = 0): Record<string, unknown> {
+    return action.Calls[index].variables?.input as Record<string, unknown>;
+}
+
+function credentialRow(values: string) {
+    credentialView.reply = { Success: true, Results: [{ ID: 'cred-1', Values: values }] };
+}
+
+const BASE = { CompanyIntegrationID: 'ci-1', ChannelIDs: ['chan-1'], Content: 'Hello' };
+
+beforeEach(() => {
+    credentialView.reply = { Success: true, Results: [] };
+    credentialView.filters = [];
+});
+
+// ---------------------------------------------------------------------------
+// Identity: whose token the calls are made with
+// ---------------------------------------------------------------------------
+
+describe('Buffer CredentialID — acting as another identity', () => {
+    it("uses the CompanyIntegration's own token when no CredentialID is given", async () => {
+        const { result, action } = await run(BASE);
+        expect(result.Success).toBe(true);
+        expect(action.Calls[0].token).toBe(TENANT_TOKEN);
+        // Nothing should have been asked of the credential store at all.
+        expect(credentialView.filters).toHaveLength(0);
+    });
+
+    it('uses the credential token when a CredentialID is given', async () => {
+        credentialRow(JSON.stringify({ accessToken: 'employee-personal-token' }));
+        const { result, action } = await run({ ...BASE, CredentialID: 'cred-1' });
+        expect(result.Success).toBe(true);
+        expect(action.Calls[0].token).toBe('employee-personal-token');
+    });
+
+    it('still requires CompanyIntegrationID, which says which integration this is', async () => {
+        credentialRow(JSON.stringify({ accessToken: 'employee-personal-token' }));
+        const { result } = await run({ ChannelIDs: ['chan-1'], Content: 'Hello', CredentialID: 'cred-1' });
+        expect(result.Success).toBe(false);
+        expect(result.ResultCode).toBe('MISSING_PARAM');
+    });
+
+    it('looks the credential up by id and only when active', async () => {
+        credentialRow(JSON.stringify({ accessToken: 'tok' }));
+        await run({ ...BASE, CredentialID: 'cred-1' });
+        expect(credentialView.filters[0]).toContain("ID='cred-1'");
+        expect(credentialView.filters[0]).toContain('IsActive=1');
+    });
+
+    it('escapes a quote in the credential id rather than building broken SQL', async () => {
+        credentialRow(JSON.stringify({ accessToken: 'tok' }));
+        await run({ ...BASE, CredentialID: "cred-'1" });
+        expect(credentialView.filters[0]).toContain("ID='cred-''1'");
+    });
+
+    it('fails rather than falling back to the tenant token when the credential is missing', async () => {
+        // Falling back would publish under the wrong identity with nothing to notice.
+        credentialView.reply = { Success: true, Results: [] };
+        const { result, action } = await run({ ...BASE, CredentialID: 'cred-1' });
+        expect(result.Success).toBe(false);
+        expect(result.ResultCode).toBe('INVALID_CREDENTIAL');
+        expect(result.Message).toMatch(/not found, or not active/);
+        expect(action.Calls).toHaveLength(0);
+    });
+
+    it('fails when the credential Values cannot be read, naming decrypt as the likely cause', async () => {
+        credentialRow('not json at all');
+        const { result, action } = await run({ ...BASE, CredentialID: 'cred-1' });
+        expect(result.ResultCode).toBe('INVALID_CREDENTIAL');
+        expect(result.Message).toMatch(/decrypt/);
+        expect(action.Calls).toHaveLength(0);
+    });
+
+    it('fails when the credential carries no accessToken', async () => {
+        credentialRow(JSON.stringify({ apiKey: 'wrong-field' }));
+        const { result } = await run({ ...BASE, CredentialID: 'cred-1' });
+        expect(result.ResultCode).toBe('INVALID_CREDENTIAL');
+        expect(result.Message).toMatch(/no accessToken/);
+    });
+
+    it('fails on an empty accessToken rather than sending an empty bearer header', async () => {
+        credentialRow(JSON.stringify({ accessToken: '' }));
+        const { result } = await run({ ...BASE, CredentialID: 'cred-1' });
+        expect(result.ResultCode).toBe('INVALID_CREDENTIAL');
+    });
+
+    it('applies the credential token to every channel in a multi-channel post', async () => {
+        credentialRow(JSON.stringify({ accessToken: 'employee-personal-token' }));
+        const { action } = await run({ ...BASE, ChannelIDs: ['chan-1', 'chan-2', 'chan-3'], CredentialID: 'cred-1' });
+        expect(action.Calls).toHaveLength(3);
+        expect(action.Calls.map(c => c.token)).toEqual(Array(3).fill('employee-personal-token'));
+    });
+
+    it('does not leak one action run\'s credential token into another', async () => {
+        credentialRow(JSON.stringify({ accessToken: 'employee-personal-token' }));
+        await run({ ...BASE, CredentialID: 'cred-1' });
+
+        const { action } = await run(BASE);
+        expect(action.Calls[0].token).toBe(TENANT_TOKEN);
+    });
+
+    it('advertises CredentialID as an input param', () => {
+        const names = new TestCreatePostAction().Params.map(p => p.Name);
+        expect(names).toContain('CredentialID');
+    });
+});
+
+// ---------------------------------------------------------------------------
+// PlatformMetadata
+// ---------------------------------------------------------------------------
+
+describe('Buffer PlatformMetadata — per-service extras', () => {
+    it('sends no metadata when none was given', async () => {
+        // Undefined, like the sibling `dueAt`/`assets` inputs — JSON serialization
+        // drops it, so nothing reaches Buffer.
+        const { action } = await run(BASE);
+        expect(mutationInput(action).metadata).toBeUndefined();
+        expect(JSON.parse(JSON.stringify(mutationInput(action)))).not.toHaveProperty('metadata');
+    });
+
+    it('passes an object through untouched', async () => {
+        const metadata = { linkedin: { annotations: [{ entity: 'urn:li:organization:1', start: 0, length: 5 }] } };
+        const { action } = await run({ ...BASE, PlatformMetadata: metadata });
+        expect(mutationInput(action).metadata).toEqual(metadata);
+    });
+
+    it('accepts a JSON string, which is how UI and agent inputs arrive', async () => {
+        const { action } = await run({ ...BASE, PlatformMetadata: '{"linkedin":{"annotations":[]}}' });
+        expect(mutationInput(action).metadata).toEqual({ linkedin: { annotations: [] } });
+    });
+
+    it('treats an empty string as absent rather than as bad input', async () => {
+        const { result, action } = await run({ ...BASE, PlatformMetadata: '' });
+        expect(result.Success).toBe(true);
+        expect(mutationInput(action).metadata).toBeUndefined();
+    });
+
+    it('fails on unparseable JSON instead of silently posting without the metadata', async () => {
+        // Dropping it would publish plain text where the caller composed a mention.
+        const { result, action } = await run({ ...BASE, PlatformMetadata: '{linkedin:' });
+        expect(result.Success).toBe(false);
+        expect(result.Message).toMatch(/not valid JSON/);
+        expect(action.Calls).toHaveLength(0);
+    });
+
+    it('rejects a non-object, since Buffer keys metadata by service name', async () => {
+        for (const bad of [['linkedin'], '["linkedin"]', 42]) {
+            const { result } = await run({ ...BASE, PlatformMetadata: bad });
+            expect(result.Success).toBe(false);
+            expect(result.Message).toMatch(/keyed by service name/);
+        }
+    });
+
+    it('sends the same metadata to each channel of a multi-channel post', async () => {
+        const metadata = { linkedin: { annotations: [] } };
+        const { action } = await run({ ...BASE, ChannelIDs: ['chan-1', 'chan-2'], PlatformMetadata: metadata });
+        expect(action.Calls).toHaveLength(2);
+        expect(mutationInput(action, 0).metadata).toEqual(metadata);
+        expect(mutationInput(action, 1).metadata).toEqual(metadata);
+    });
+
+    it('advertises PlatformMetadata as an input param', () => {
+        const names = new TestCreatePostAction().Params.map(p => p.Name);
+        expect(names).toContain('PlatformMetadata');
+    });
+});
+
+// ---------------------------------------------------------------------------
+// Asset input shape
+// ---------------------------------------------------------------------------
+
+describe('Buffer assets — the AssetInput array shape', () => {
+    it('sends one array entry per image, each naming its kind', async () => {
+        // Buffer moved createPost to `[AssetInput!]` on 2026-05-25 and rejects the
+        // older { images: [...] } object outright, so the shape is the whole point.
+        const { action } = await run({ ...BASE, ImageURLs: ['https://example.org/a.png', 'https://example.org/b.png'] });
+        expect(mutationInput(action).assets).toEqual([
+            { image: { url: 'https://example.org/a.png' } },
+            { image: { url: 'https://example.org/b.png' } },
+        ]);
+    });
+
+    it('names videos and links by their own kinds', async () => {
+        const { action } = await run({
+            ...BASE,
+            VideoURLs: ['https://example.org/v.mp4'],
+            MediaLink: 'https://example.org/article',
+            MediaDescription: 'An article',
+        });
+        expect(mutationInput(action).assets).toEqual([
+            { video: { url: 'https://example.org/v.mp4' } },
+            { link: { url: 'https://example.org/article', description: 'An article' } },
+        ]);
+    });
+
+    it('keeps images, then videos, then the link in one flat array', async () => {
+        const { action } = await run({
+            ...BASE,
+            ImageURLs: ['https://example.org/a.png'],
+            VideoURLs: ['https://example.org/v.mp4'],
+            MediaLink: 'https://example.org/article',
+        });
+        expect(mutationInput(action).assets).toEqual([
+            { image: { url: 'https://example.org/a.png' } },
+            { video: { url: 'https://example.org/v.mp4' } },
+            { link: { url: 'https://example.org/article', description: undefined } },
+        ]);
+    });
+
+    it('sends no assets when there is no media', async () => {
+        const { action } = await run(BASE);
+        expect(mutationInput(action).assets).toBeUndefined();
+    });
+
+    it('skips an empty URL rather than sending an asset with no url', async () => {
+        const { action } = await run({ ...BASE, ImageURLs: ['', 'https://example.org/a.png'] });
+        expect(mutationInput(action).assets).toEqual([{ image: { url: 'https://example.org/a.png' } }]);
+    });
+});
+
+// ---------------------------------------------------------------------------
+// The two together — the employee-mention publish this exists for
+// ---------------------------------------------------------------------------
+
+describe('Buffer create post — publishing as an employee with a mention', () => {
+    it('sends the employee token and the LinkedIn annotations in one call', async () => {
+        credentialRow(JSON.stringify({ accessToken: 'employee-personal-token' }));
+        const annotations = [{ entity: 'urn:li:organization:42', start: 6, length: 9 }];
+        const { result, action } = await run({
+            CompanyIntegrationID: 'ci-1',
+            CredentialID: 'cred-1',
+            ChannelIDs: ['chan-1'],
+            Content: 'Thanks @Acme Corp for hosting',
+            ImageURLs: ['https://example.org/card.png'],
+            PlatformMetadata: { linkedin: { annotations } },
+        });
+
+        expect(result.Success).toBe(true);
+        expect(action.Calls[0].token).toBe('employee-personal-token');
+        expect(mutationInput(action)).toMatchObject({
+            channelId: 'chan-1',
+            text: 'Thanks @Acme Corp for hosting',
+            mode: 'addToQueue',
+            metadata: { linkedin: { annotations } },
+        });
+    });
+
+    it('reports a mutation failure without claiming a post was made', async () => {
+        credentialRow(JSON.stringify({ accessToken: 'employee-personal-token' }));
+        const { result } = await run(
+            { ...BASE, CredentialID: 'cred-1' },
+            a => { a.FailWith = new Error('channel is disconnected'); },
+        );
+        expect(result.Success).toBe(false);
+        expect(result.ResultCode).toBe('CREATE_FAILED');
+        expect(result.Message).toMatch(/channel is disconnected/);
+    });
+});

--- a/packages/Actions/BizApps/Social/src/providers/buffer/actions/create-post.action.ts
+++ b/packages/Actions/BizApps/Social/src/providers/buffer/actions/create-post.action.ts
@@ -1,5 +1,5 @@
 import { RegisterClass } from '@memberjunction/global';
-import { BufferBaseAction, BufferAssets, BufferPost, BufferPostStatus, BufferShareMode } from '../buffer-base.action';
+import { BufferBaseAction, BufferAssetInput, BufferPost, BufferPostStatus, BufferShareMode } from '../buffer-base.action';
 import { ActionParam, ActionResultSimple, RunActionParams } from '@memberjunction/actions-base';
 import { BaseAction } from '@memberjunction/actions';
 
@@ -12,30 +12,58 @@ function resolveShareMode(postNow: boolean, addToTop: boolean, scheduledTime: st
 
 /**
  * Builds the assets input from image/video URLs and link params.
+ *
+ * One `AssetInput` entry per attachment, each naming its kind. Buffer moved
+ * createPost to this array form on 2026-05-25 and rejects the older
+ * `{ images: [...] }` object, which is why this does not build a `BufferAssets`.
  */
 function buildAssetsInput(
   imageUrls: string[] | null,
   videoUrls: string[] | null,
   mediaLink: string | null,
   mediaDescription: string | null,
-): BufferAssets | undefined {
-  const assets: BufferAssets = {};
-  let hasAssets = false;
+): BufferAssetInput[] | undefined {
+  const assets: BufferAssetInput[] = [];
 
-  if (imageUrls?.length) {
-    assets.images = imageUrls.map((url) => ({ url }));
-    hasAssets = true;
+  for (const url of imageUrls ?? []) {
+    if (url) assets.push({ image: { url } });
   }
-  if (videoUrls?.length) {
-    assets.videos = videoUrls.map((url) => ({ url }));
-    hasAssets = true;
+  for (const url of videoUrls ?? []) {
+    if (url) assets.push({ video: { url } });
   }
   if (mediaLink) {
-    assets.link = { url: mediaLink, description: mediaDescription || undefined };
-    hasAssets = true;
+    assets.push({ link: { url: mediaLink, description: mediaDescription || undefined } });
   }
 
-  return hasAssets ? assets : undefined;
+  return assets.length > 0 ? assets : undefined;
+}
+
+/**
+ * Read the `PlatformMetadata` param, accepted as an object or as a JSON string —
+ * both forms arrive, from typed callers and from agent/UI inputs respectively.
+ *
+ * Unparseable JSON throws rather than being dropped: metadata carries things like
+ * LinkedIn @mention annotations, and posting the text without them silently
+ * publishes something different from what the caller composed.
+ */
+function parsePlatformMetadata(value: unknown): Record<string, unknown> | undefined {
+  if (value === null || value === undefined || value === '') return undefined;
+  if (typeof value === 'string') {
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(value);
+    } catch {
+      throw new Error('PlatformMetadata was a string but not valid JSON');
+    }
+    if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
+      throw new Error('PlatformMetadata must be an object keyed by service name, e.g. { "linkedin": { ... } }');
+    }
+    return parsed as Record<string, unknown>;
+  }
+  if (typeof value !== 'object' || Array.isArray(value)) {
+    throw new Error('PlatformMetadata must be an object keyed by service name, e.g. { "linkedin": { ... } }');
+  }
+  return value as Record<string, unknown>;
 }
 
 interface CreatedPostSummary {
@@ -64,6 +92,13 @@ function summarizePost(post: BufferPost): CreatedPostSummary {
  * The new API accepts one channelId per mutation call. To post to multiple
  * channels, pass an array of ChannelIDs and a separate createPost call is
  * made for each.
+ *
+ * Two params exist for posting on someone else's behalf. `CredentialID` (on every
+ * Buffer action) makes the calls with a token from an `MJ: Credentials` row instead
+ * of the tenant's own connection, which is what publishing to an employee's personal
+ * channel requires. `PlatformMetadata` passes Buffer's per-service extras through —
+ * `{ "linkedin": { "annotations": [...] } }` is how an @mention survives the trip,
+ * and without it the post publishes as plain text with the mention spelled out.
  */
 @RegisterClass(BaseAction, 'BufferCreatePostAction')
 export class BufferCreatePostAction extends BufferBaseAction {
@@ -80,6 +115,7 @@ export class BufferCreatePostAction extends BufferBaseAction {
       const scheduledTime = this.getParamValue(Params, 'ScheduledTime') as string | null;
       const postNow = this.getParamValue(Params, 'PostNow') === true;
       const addToTop = this.getParamValue(Params, 'AddToTop') === true;
+      const platformMetadata = parsePlatformMetadata(this.getParamValue(Params, 'PlatformMetadata'));
 
       if (!channelIds?.length) throw new Error('ChannelIDs array is required with at least one channel');
       if (!content && !imageUrls?.length && !videoUrls?.length && !mediaLink) {
@@ -101,6 +137,7 @@ export class BufferCreatePostAction extends BufferBaseAction {
             mode,
             dueAt,
             assets,
+            metadata: platformMetadata,
           }),
         ),
       );
@@ -149,6 +186,7 @@ export class BufferCreatePostAction extends BufferBaseAction {
       { Name: 'ScheduledTime', Type: 'Input', Value: null },
       { Name: 'PostNow', Type: 'Input', Value: false },
       { Name: 'AddToTop', Type: 'Input', Value: false },
+      { Name: 'PlatformMetadata', Type: 'Input', Value: null },
       { Name: 'CreatedPosts', Type: 'Output', Value: null },
       { Name: 'Summary', Type: 'Output', Value: null },
     ];

--- a/packages/Actions/BizApps/Social/src/providers/buffer/buffer-base.action.ts
+++ b/packages/Actions/BizApps/Social/src/providers/buffer/buffer-base.action.ts
@@ -1,6 +1,6 @@
 import { RegisterClass } from '@memberjunction/global';
 import { BaseSocialMediaAction, SocialPost, SocialAnalytics, MediaFile } from '../../base/base-social.action';
-import { LogStatus } from '@memberjunction/core';
+import { LogStatus, RunView } from '@memberjunction/core';
 import axios from 'axios';
 import { BaseAction } from '@memberjunction/actions';
 import { ActionParam, ActionResultSimple, RunActionParams } from '@memberjunction/actions-base';
@@ -51,10 +51,29 @@ export interface BufferChannel {
   serviceId: string;
 }
 
+/**
+ * The assets shape Buffer **returns** on a post: one object with a list per kind.
+ */
 export interface BufferAssets {
   images?: Array<{ url: string; thumbnailUrl?: string }>;
   videos?: Array<{ url: string; thumbnailUrl?: string }>;
   documents?: Array<{ url: string; title?: string }>;
+  link?: { url: string; title?: string; description?: string; thumbnailUrl?: string };
+}
+
+/**
+ * The assets shape Buffer **accepts** on createPost: `[AssetInput!]`, one entry per
+ * attachment, each naming its kind.
+ *
+ * This is deliberately not `BufferAssets`. Buffer switched createPost's input to the
+ * array form on 2026-05-25 and rejects the old `{ images: [...] }` object, but keeps
+ * returning the object form on reads — so input and output genuinely differ and
+ * sharing one type here would break one direction or the other.
+ */
+export interface BufferAssetInput {
+  image?: { url: string; thumbnailUrl?: string };
+  video?: { url: string; thumbnailUrl?: string };
+  document?: { url: string; title?: string };
   link?: { url: string; title?: string; description?: string; thumbnailUrl?: string };
 }
 
@@ -231,8 +250,18 @@ export abstract class BufferBaseAction extends BaseSocialMediaAction {
 
   /** Common params shared by all Buffer actions. */
   protected get bufferCommonParams(): ActionParam[] {
-    return [...this.commonSocialParams, { Name: 'OrganizationID', Type: 'Input', Value: null }];
+    return [
+      ...this.commonSocialParams,
+      { Name: 'OrganizationID', Type: 'Input', Value: null },
+      { Name: 'CredentialID', Type: 'Input', Value: null },
+    ];
   }
+
+  /**
+   * A token resolved from the `CredentialID` param, standing in for the
+   * CompanyIntegration's own token for the rest of this action run.
+   */
+  private _credentialAccessToken: string | null = null;
 
   // -----------------------------------------------------------------------
   // Action helpers — reduce boilerplate in subclasses
@@ -245,6 +274,10 @@ export abstract class BufferBaseAction extends BaseSocialMediaAction {
    * threaded into `initializeOAuth` (multi-tenant correctness — every entity load/save
    * inside the OAuth flow binds to the request's connection, not the global default).
    *
+   * `CompanyIntegrationID` stays required even when `CredentialID` is given: it is what
+   * identifies *which* Buffer integration this is, and the org/channel context still
+   * comes from it. `CredentialID` only changes whose token the calls are made with.
+   *
    * Returns null on success, or an error result.
    */
   protected async ensureAuthenticated(params: RunActionParams): Promise<ActionResultSimple | null> {
@@ -255,7 +288,78 @@ export abstract class BufferBaseAction extends BaseSocialMediaAction {
     if (!(await this.initializeOAuth(companyIntegrationId, params))) {
       return { Success: false, ResultCode: 'INVALID_TOKEN', Message: 'Failed to initialize Buffer connection', Params: params.Params };
     }
+
+    const credentialId = this.getParamValue(params.Params, 'CredentialID');
+    if (credentialId) {
+      const resolved = await this.resolveCredentialAccessToken(String(credentialId), params);
+      if (typeof resolved !== 'string') return resolved;
+      this._credentialAccessToken = resolved;
+    }
     return null;
+  }
+
+  /**
+   * Load an access token out of an `MJ: Credentials` row.
+   *
+   * This is the seam for acting as an identity other than the tenant's own Buffer
+   * connection — publishing to an employee's personal channel, reading the queue of
+   * the person who owns it. The token stays in the credential store; only its ID
+   * travels through action params.
+   *
+   * A `CredentialID` that was supplied but cannot be read is **fatal**, never a
+   * silent fallback to the CompanyIntegration token: falling back would publish
+   * under the wrong identity, and the caller would have no way to notice.
+   *
+   * Returns the token, or an error result to hand straight back to the caller.
+   */
+  protected async resolveCredentialAccessToken(
+    credentialId: string,
+    params: RunActionParams,
+  ): Promise<string | ActionResultSimple> {
+    const notUsable = (detail: string): ActionResultSimple => ({
+      Success: false,
+      ResultCode: 'INVALID_CREDENTIAL',
+      Message: `CredentialID ${credentialId} cannot be used for Buffer: ${detail}`,
+      Params: params.Params,
+    });
+
+    const rv = new RunView();
+    const result = await rv.RunView<{ ID: string; Values: string }>(
+      {
+        EntityName: 'MJ: Credentials',
+        ExtraFilter: `ID='${credentialId.replace(/'/g, "''")}' AND IsActive=1`,
+        ResultType: 'simple',
+        Fields: ['ID', 'Values'],
+        MaxRows: 1,
+      },
+      params.ContextUser,
+    );
+    if (!result.Success || result.Results.length === 0) {
+      return notUsable('not found, or not active');
+    }
+
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(result.Results[0].Values);
+    } catch {
+      // Values arriving unparseable is the signature of a failed decrypt, so say so
+      // rather than reporting a malformed-JSON error the operator cannot act on.
+      return notUsable('its Values could not be read as JSON (the value may not have decrypted)');
+    }
+
+    const token = (parsed as { accessToken?: unknown })?.accessToken;
+    if (typeof token !== 'string' || token.length === 0) {
+      return notUsable('its Values carry no accessToken');
+    }
+    return token;
+  }
+
+  /**
+   * The token every Buffer call is made with: the `CredentialID` token when one was
+   * supplied, otherwise the CompanyIntegration's own.
+   */
+  protected override getAccessToken(): string | null {
+    return this._credentialAccessToken ?? super.getAccessToken();
   }
 
   /** Set an output parameter value by name. */
@@ -428,15 +532,23 @@ export abstract class BufferBaseAction extends BaseSocialMediaAction {
     return input;
   }
 
-  /** Create a post via the createPost mutation. */
+  /**
+   * Create a post via the createPost mutation.
+   *
+   * `metadata` is Buffer's per-service extras channel, keyed by service name — e.g.
+   * `{ linkedin: { annotations: [...] } }` for @mention annotations. It is passed
+   * through untouched rather than modelled, because its shape belongs to whichever
+   * network the channel points at and Buffer adds to it independently of this package.
+   */
   protected async createBufferPost(input: {
     channelId: string;
     text: string;
     mode?: BufferShareMode;
     dueAt?: string;
     schedulingType?: string;
-    assets?: BufferAssets;
+    assets?: BufferAssetInput[];
     tagIds?: string[];
+    metadata?: Record<string, unknown>;
   }): Promise<BufferPost> {
     const data = await this.executeGraphQL<CreatePostMutationData>(CREATE_POST_MUTATION, { input });
 


### PR DESCRIPTION
Three changes to the Buffer provider, one of them a live defect.

### Fix — the createPost assets shape

Buffer moved `createPost`'s input to `[AssetInput!]` (`[{ image: { url } }]`, one entry per attachment naming its kind) on 2026-05-25 and **rejects** the older `{ images: [...] }` object — which is what this package was sending. Any post with `ImageURLs`, `VideoURLs` or `MediaLink` was therefore being rejected by Buffer.

Reads are unaffected: Buffer still *returns* the object form. So the input shape is now its own type, `BufferAssetInput`, alongside the unchanged `BufferAssets` response type — sharing one type would break one direction or the other.

This rests on AIDP's production evidence (a dated test asserting the array form against a live account) and cannot be confirmed offline in this repo. Flagging that explicitly rather than claiming it verified.

Breaking for any caller passing a hand-built `assets` object to the protected `createBufferPost`; the action's own `ImageURLs`/`VideoURLs`/`MediaLink` params are unchanged.

### `CredentialID` on every Buffer action

Token resolution was strictly `BaseOAuthAction.getAccessToken()` → `this._companyIntegration?.AccessToken`, with no per-call override seam. That makes publishing to an employee's personal channel — or reading the queue of the person who owns it — impossible through this package.

With `CredentialID`, calls are made using the `accessToken` from that `MJ: Credentials` row. `CompanyIntegrationID` stays required: it identifies *which* Buffer integration this is, and organization and channel context still come from it. `CredentialID` only changes whose token the calls are made with.

A `CredentialID` that was supplied but cannot be read is **fatal** (`INVALID_CREDENTIAL`), never a silent fallback to the tenant token — falling back would publish under the wrong identity with nothing for the caller to notice. Unparseable `Values` is reported as a probable failed decrypt rather than as a malformed-JSON error the operator cannot act on. The token itself never travels through action params; only its id does.

Because it lives on `bufferCommonParams`, reads and writes use the same identity — which matters, since channel ids returned to one token may not be visible to another.

### `PlatformMetadata` on `Create Post (Buffer)`

Passes Buffer's per-service extras through to the mutation. `{ "linkedin": { "annotations": [...] } }` is how a LinkedIn @mention survives the trip; without it the post publishes as plain text with the mention spelled out.

Accepted as an object or a JSON string, since both forms arrive (typed callers and agent/UI inputs). Passed through untouched rather than modelled — its shape belongs to whichever network the channel points at, and Buffer extends it independently of this package. Unparseable input **fails** rather than being dropped, for the same reason the credential failure is fatal: quietly posting without the metadata publishes something other than what the caller composed.

### Verification

27 tests covering the credential override (including SQL quote escaping in the lookup filter, and that a failed lookup makes zero GraphQL calls), the metadata passthrough, and the asset shape. Full package suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)