### PR TITLE
fix(ci): get the publish.yml fix onto main so v6.1.0-edge.0 can actually publish

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -197,7 +197,20 @@ jobs:
           echo "::notice::Publishing $VERSION to npm dist-tag $NPM_TAG (prerelease: $PRERELEASE)"
 
       - name: Publish to npm
-        run: pnpm run change publish -- --tag ${{ steps.channel.outputs.NPM_TAG }}
+        # 🚨 Invoke changesets directly, NOT via `pnpm run change publish -- --tag <x>`.
+        # `"change": "changeset"`, and pnpm 10 forwards the `--` separator LITERALLY, so that
+        # form reaches changesets as `publish -- --tag edge` and dies with "Too many arguments
+        # passed to changesets". It exits non-zero but the step still concluded `success`, so
+        # v6.1.0-edge.0 was version-bumped, tagged and back-merged while ZERO packages reached
+        # npm — a release the repo believes shipped and the registry has never heard of.
+        # `set -o pipefail` + an explicit publish-happened assertion below make a repeat loud.
+        run: |
+          set -euo pipefail
+          pnpm exec changeset publish --tag ${{ steps.channel.outputs.NPM_TAG }} 2>&1 | tee /tmp/publish.log
+          if ! grep -qE 'New tag:|Packages published|already published' /tmp/publish.log; then
+            echo "::error::changeset publish produced no evidence of a publish — refusing to report success."
+            exit 1
+          fi
         env:
           NPM_TOKEN: ''
 

--- a/package.json
+++ b/package.json
@@ -167,9 +167,9 @@
     "@types/lodash": "^4.17.23",
     "rimraf": "^5.0.10",
     "@angular/compiler": "21.1.3",
-    "@memberjunction/cli": "6.0.0",
+    "@memberjunction/cli": "workspace:*",
     "tsx": "^4.21.0",
-    "@memberjunction/integration-test-suite": "6.0.0"
+    "@memberjunction/integration-test-suite": "workspace:*"
   },
   "pnpm": {
     "overrides": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -73,10 +73,10 @@ importers:
         specifier: ^2.27.12
         version: 2.29.8(@types/node@24.10.11)
       '@memberjunction/cli':
-        specifier: 6.0.0
+        specifier: workspace:*
         version: link:packages/MJCLI
       '@memberjunction/integration-test-suite':
-        specifier: 6.0.0
+        specifier: workspace:*
         version: link:packages/TestingFramework/integration-test-suite
       '@playwright/test':
         specifier: ^1.58.1
@@ -178,43 +178,43 @@ importers:
   packages/AI/A2AServer:
     dependencies:
       '@memberjunction/ai':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../Core
       '@memberjunction/ai-agents':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../Agents
       '@memberjunction/ai-core-plus':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../CorePlus
       '@memberjunction/aiengine':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../Engine
       '@memberjunction/api-keys':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../APIKeys/Engine
       '@memberjunction/config':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../Config
       '@memberjunction/core':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../MJCore
       '@memberjunction/core-entities':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../MJCoreEntities
       '@memberjunction/encryption':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../Encryption
       '@memberjunction/global':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../MJGlobal
       '@memberjunction/server':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../MJServer
       '@memberjunction/server-bootstrap-lite':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../ServerBootstrapLite
       '@memberjunction/sqlserver-dataprovider':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../SQLServerDataProvider
       cosmiconfig:
         specifier: ^9.0.0
@@ -251,52 +251,52 @@ importers:
         specifier: ^8.2.0
         version: 8.2.0(@types/node@24.10.11)
       '@memberjunction/actions':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../Actions/Engine
       '@memberjunction/ai':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../Core
       '@memberjunction/ai-agents':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../Agents
       '@memberjunction/ai-anthropic':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../Providers/Anthropic
       '@memberjunction/ai-betty-bot':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../Providers/BettyBot
       '@memberjunction/ai-cerebras':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../Providers/Cerebras
       '@memberjunction/ai-core-plus':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../CorePlus
       '@memberjunction/ai-groq':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../Providers/Groq
       '@memberjunction/ai-mistral':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../Providers/Mistral
       '@memberjunction/ai-openai':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../Providers/OpenAI
       '@memberjunction/ai-prompts':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../Prompts
       '@memberjunction/core':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../MJCore
       '@memberjunction/core-actions':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../Actions/CoreActions
       '@memberjunction/core-entities':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../MJCoreEntities
       '@memberjunction/core-entities-server':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../MJCoreEntitiesServer
       '@memberjunction/sqlserver-dataprovider':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../SQLServerDataProvider
       '@oclif/core':
         specifier: ^3.27.0
@@ -357,28 +357,28 @@ importers:
   packages/AI/AgentManager/actions:
     dependencies:
       '@memberjunction/actions':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../../Actions/Engine
       '@memberjunction/actions-base':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../../Actions/Base
       '@memberjunction/ai-agent-manager':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../core
       '@memberjunction/ai-core-plus':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../CorePlus
       '@memberjunction/ai-engine-base':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../BaseAIEngine
       '@memberjunction/core':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../../MJCore
       '@memberjunction/core-entities':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../../MJCoreEntities
       '@memberjunction/global':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../../MJGlobal
     devDependencies:
       '@types/node':
@@ -394,28 +394,28 @@ importers:
   packages/AI/AgentManager/core:
     dependencies:
       '@memberjunction/ai-agents':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../Agents
       '@memberjunction/ai-core-plus':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../CorePlus
       '@memberjunction/ai-engine-base':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../BaseAIEngine
       '@memberjunction/aiengine':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../Engine
       '@memberjunction/core':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../../MJCore
       '@memberjunction/core-entities':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../../MJCoreEntities
       '@memberjunction/global':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../../MJGlobal
       '@memberjunction/templates':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../../Templates/engine
     devDependencies:
       '@types/node':
@@ -431,55 +431,55 @@ importers:
   packages/AI/Agents:
     dependencies:
       '@memberjunction/actions':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../Actions/Engine
       '@memberjunction/actions-base':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../Actions/Base
       '@memberjunction/ai':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../Core
       '@memberjunction/ai-core-plus':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../CorePlus
       '@memberjunction/ai-engine-base':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../BaseAIEngine
       '@memberjunction/ai-prompts':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../Prompts
       '@memberjunction/ai-reranker':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../Reranker
       '@memberjunction/ai-vector-dupe':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../Vectors/Dupe
       '@memberjunction/ai-vector-sync':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../Vectors/Sync
       '@memberjunction/aiengine':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../Engine
       '@memberjunction/context-crush':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../ContextCrush
       '@memberjunction/core':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../MJCore
       '@memberjunction/core-entities':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../MJCoreEntities
       '@memberjunction/global':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../MJGlobal
       '@memberjunction/search-engine':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../SearchEngine
       '@memberjunction/storage':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../MJStorage
       '@memberjunction/templates':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../Templates/engine
       dotenv:
         specifier: ^17.2.4
@@ -528,13 +528,13 @@ importers:
   packages/AI/AgentsClient:
     dependencies:
       '@memberjunction/core':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../MJCore
       '@memberjunction/global':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../MJGlobal
       '@memberjunction/graphql-dataprovider':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../GraphQLDataProvider
       rxjs:
         specifier: ^7.8.1
@@ -550,22 +550,22 @@ importers:
   packages/AI/BaseAIEngine:
     dependencies:
       '@memberjunction/ai':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../Core
       '@memberjunction/ai-core-plus':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../CorePlus
       '@memberjunction/core':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../MJCore
       '@memberjunction/core-entities':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../MJCoreEntities
       '@memberjunction/global':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../MJGlobal
       '@memberjunction/templates-base-types':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../Templates/base-types
       dotenv:
         specifier: ^17.2.4
@@ -590,25 +590,25 @@ importers:
   packages/AI/Clustering:
     dependencies:
       '@memberjunction/ai-core-plus':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../CorePlus
       '@memberjunction/ai-engine-base':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../BaseAIEngine
       '@memberjunction/ai-prompts':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../Prompts
       '@memberjunction/ai-vectors-memory':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../Vectors/Memory
       '@memberjunction/core':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../MJCore
       '@memberjunction/core-entities':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../MJCoreEntities
       '@memberjunction/global':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../MJGlobal
       umap-js:
         specifier: ^1.4.0
@@ -627,13 +627,13 @@ importers:
   packages/AI/ComputerUse:
     dependencies:
       '@memberjunction/ai':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../Core
       '@memberjunction/core':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../MJCore
       '@memberjunction/global':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../MJGlobal
       playwright:
         specifier: '>=1.40.0'
@@ -667,7 +667,7 @@ importers:
   packages/AI/Core:
     dependencies:
       '@memberjunction/global':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../MJGlobal
       dotenv:
         specifier: ^17.2.4
@@ -692,22 +692,22 @@ importers:
   packages/AI/CorePlus:
     dependencies:
       '@memberjunction/actions-base':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../Actions/Base
       '@memberjunction/ai':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../Core
       '@memberjunction/core':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../MJCore
       '@memberjunction/core-entities':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../MJCoreEntities
       '@memberjunction/global':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../MJGlobal
       '@memberjunction/templates-base-types':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../Templates/base-types
       date-fns:
         specifier: ^4.1.0
@@ -738,25 +738,25 @@ importers:
   packages/AI/DatabaseDesigner/actions:
     dependencies:
       '@memberjunction/actions':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../../Actions/Engine
       '@memberjunction/actions-base':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../../Actions/Base
       '@memberjunction/core':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../../MJCore
       '@memberjunction/core-entities':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../../MJCoreEntities
       '@memberjunction/database-designer-core':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../core
       '@memberjunction/global':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../../MJGlobal
       '@memberjunction/schema-engine':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../../SchemaEngine
     devDependencies:
       '@types/node':
@@ -778,25 +778,25 @@ importers:
   packages/AI/DatabaseDesigner/core:
     dependencies:
       '@memberjunction/ai-agents':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../Agents
       '@memberjunction/ai-core-plus':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../CorePlus
       '@memberjunction/ai-engine-base':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../BaseAIEngine
       '@memberjunction/core':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../../MJCore
       '@memberjunction/core-entities':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../../MJCoreEntities
       '@memberjunction/global':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../../MJGlobal
       '@memberjunction/schema-engine':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../../SchemaEngine
     devDependencies:
       '@types/node':
@@ -818,31 +818,31 @@ importers:
   packages/AI/Engine:
     dependencies:
       '@memberjunction/actions-base':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../Actions/Base
       '@memberjunction/ai':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../Core
       '@memberjunction/ai-core-plus':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../CorePlus
       '@memberjunction/ai-engine-base':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../BaseAIEngine
       '@memberjunction/ai-vectors-memory':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../Vectors/Memory
       '@memberjunction/core':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../MJCore
       '@memberjunction/core-entities':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../MJCoreEntities
       '@memberjunction/global':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../MJGlobal
       '@memberjunction/storage':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../MJStorage
       dotenv:
         specifier: ^17.2.4
@@ -867,34 +867,34 @@ importers:
   packages/AI/FormBuilder/core:
     dependencies:
       '@memberjunction/actions':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../../Actions/Engine
       '@memberjunction/ai-agents':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../Agents
       '@memberjunction/ai-core-plus':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../CorePlus
       '@memberjunction/ai-engine-base':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../BaseAIEngine
       '@memberjunction/ai-prompts':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../Prompts
       '@memberjunction/aiengine':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../Engine
       '@memberjunction/core':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../../MJCore
       '@memberjunction/core-entities':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../../MJCoreEntities
       '@memberjunction/global':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../../MJGlobal
       '@memberjunction/interactive-component-types':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../../InteractiveComponents
     devDependencies:
       '@types/node':
@@ -916,28 +916,28 @@ importers:
   packages/AI/Knowledge/Pipeline:
     dependencies:
       '@memberjunction/ai':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../Core
       '@memberjunction/ai-vector-sync':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../Vectors/Sync
       '@memberjunction/ai-vectordb':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../Vectors/Database
       '@memberjunction/ai-vectors':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../Vectors/Core
       '@memberjunction/aiengine':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../Engine
       '@memberjunction/core':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../../MJCore
       '@memberjunction/core-entities':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../../MJCoreEntities
       '@memberjunction/global':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../../MJGlobal
     devDependencies:
       '@types/node':
@@ -950,37 +950,37 @@ importers:
   packages/AI/Knowledge/TagEngine:
     dependencies:
       '@memberjunction/ai':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../Core
       '@memberjunction/ai-core-plus':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../CorePlus
       '@memberjunction/ai-engine-base':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../BaseAIEngine
       '@memberjunction/ai-prompts':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../Prompts
       '@memberjunction/ai-vectors-memory':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../Vectors/Memory
       '@memberjunction/aiengine':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../Engine
       '@memberjunction/clustering-engine':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../Clustering
       '@memberjunction/core':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../../MJCore
       '@memberjunction/core-entities':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../../MJCoreEntities
       '@memberjunction/global':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../../MJGlobal
       '@memberjunction/tag-engine-base':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../TagEngineBase
     devDependencies:
       '@types/node':
@@ -996,13 +996,13 @@ importers:
   packages/AI/Knowledge/TagEngineBase:
     dependencies:
       '@memberjunction/core':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../../MJCore
       '@memberjunction/core-entities':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../../MJCoreEntities
       '@memberjunction/global':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../../MJGlobal
     devDependencies:
       '@types/node':
@@ -1018,16 +1018,16 @@ importers:
   packages/AI/MCPClient:
     dependencies:
       '@memberjunction/core':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../MJCore
       '@memberjunction/core-entities':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../MJCoreEntities
       '@memberjunction/credentials':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../Credentials/Engine
       '@memberjunction/global':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../MJGlobal
       '@modelcontextprotocol/sdk':
         specifier: ^1.26.0
@@ -1049,64 +1049,64 @@ importers:
   packages/AI/MCPServer:
     dependencies:
       '@memberjunction/actions':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../Actions/Engine
       '@memberjunction/actions-base':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../Actions/Base
       '@memberjunction/ai':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../Core
       '@memberjunction/ai-agent-manager':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../AgentManager/core
       '@memberjunction/ai-agents':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../Agents
       '@memberjunction/ai-core-plus':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../CorePlus
       '@memberjunction/ai-prompts':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../Prompts
       '@memberjunction/ai-provider-bundle':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../Providers/Bundle
       '@memberjunction/aiengine':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../Engine
       '@memberjunction/api-keys':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../APIKeys/Engine
       '@memberjunction/auth-providers':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../AuthProviders
       '@memberjunction/config':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../Config
       '@memberjunction/core':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../MJCore
       '@memberjunction/core-entities':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../MJCoreEntities
       '@memberjunction/credentials':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../Credentials/Engine
       '@memberjunction/encryption':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../Encryption
       '@memberjunction/global':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../MJGlobal
       '@memberjunction/server':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../MJServer
       '@memberjunction/server-bootstrap-lite':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../ServerBootstrapLite
       '@memberjunction/sqlserver-dataprovider':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../SQLServerDataProvider
       '@modelcontextprotocol/sdk':
         specifier: ^1.26.0
@@ -1161,37 +1161,37 @@ importers:
   packages/AI/MJComputerUse:
     dependencies:
       '@memberjunction/actions':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../Actions/Engine
       '@memberjunction/actions-base':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../Actions/Base
       '@memberjunction/ai':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../Core
       '@memberjunction/ai-core-plus':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../CorePlus
       '@memberjunction/ai-prompts':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../Prompts
       '@memberjunction/aiengine':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../Engine
       '@memberjunction/computer-use':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../ComputerUse
       '@memberjunction/core':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../MJCore
       '@memberjunction/core-entities':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../MJCoreEntities
       '@memberjunction/global':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../MJGlobal
       '@memberjunction/testing-engine':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../TestingFramework/Engine
       playwright:
         specifier: '>=1.40.0'
@@ -1235,40 +1235,40 @@ importers:
   packages/AI/PredictiveStudio/Engine:
     dependencies:
       '@memberjunction/actions':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../../Actions/Engine
       '@memberjunction/actions-base':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../../Actions/Base
       '@memberjunction/ai':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../Core
       '@memberjunction/ai-agents':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../Agents
       '@memberjunction/ai-core-plus':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../CorePlus
       '@memberjunction/core':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../../MJCore
       '@memberjunction/core-entities':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../../MJCoreEntities
       '@memberjunction/global':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../../MJGlobal
       '@memberjunction/predictive-studio-core':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../Core
       '@memberjunction/predictive-studio-sidecar':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../Sidecar
       '@memberjunction/record-set-processor':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../../RecordSetProcessor/engine
       '@memberjunction/record-set-processor-base':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../../RecordSetProcessor/base
       rxjs:
         specifier: ^7.8.2
@@ -1293,7 +1293,7 @@ importers:
   packages/AI/PredictiveStudio/Sidecar:
     dependencies:
       '@memberjunction/predictive-studio-core':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../Core
     devDependencies:
       tsc-alias:
@@ -1309,34 +1309,34 @@ importers:
   packages/AI/Prompts:
     dependencies:
       '@memberjunction/ai':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../Core
       '@memberjunction/ai-core-plus':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../CorePlus
       '@memberjunction/ai-engine-base':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../BaseAIEngine
       '@memberjunction/aiengine':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../Engine
       '@memberjunction/core':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../MJCore
       '@memberjunction/core-entities':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../MJCoreEntities
       '@memberjunction/credentials':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../Credentials/Engine
       '@memberjunction/global':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../MJGlobal
       '@memberjunction/templates':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../Templates/engine
       '@memberjunction/templates-base-types':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../Templates/base-types
       date-fns:
         specifier: ^2.30.0
@@ -1376,10 +1376,10 @@ importers:
         specifier: 0.73.0
         version: 0.73.0(zod@4.3.6)
       '@memberjunction/ai':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../Core
       '@memberjunction/global':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../../MJGlobal
     devDependencies:
       ts-node-dev:
@@ -1392,10 +1392,10 @@ importers:
   packages/AI/Providers/AssemblyAI:
     dependencies:
       '@memberjunction/ai':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../Core
       '@memberjunction/global':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../../MJGlobal
     devDependencies:
       typescript:
@@ -1414,10 +1414,10 @@ importers:
         specifier: ^4.13.0
         version: 4.13.1
       '@memberjunction/ai':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../Core
       '@memberjunction/global':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../../MJGlobal
     devDependencies:
       rimraf:
@@ -1433,10 +1433,10 @@ importers:
         specifier: ^3.984.0
         version: 3.984.0
       '@memberjunction/ai':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../Core
       '@memberjunction/global':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../../MJGlobal
     devDependencies:
       ts-node-dev:
@@ -1449,10 +1449,10 @@ importers:
   packages/AI/Providers/BettyBot:
     dependencies:
       '@memberjunction/ai':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../Core
       '@memberjunction/global':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../../MJGlobal
       axios:
         specifier: ^1.13.4
@@ -1474,10 +1474,10 @@ importers:
   packages/AI/Providers/BlackForestLabs:
     dependencies:
       '@memberjunction/ai':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../Core
       '@memberjunction/global':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../../MJGlobal
     devDependencies:
       ts-node-dev:
@@ -1490,88 +1490,88 @@ importers:
   packages/AI/Providers/Bundle:
     dependencies:
       '@memberjunction/ai-anthropic':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../Anthropic
       '@memberjunction/ai-assemblyai':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../AssemblyAI
       '@memberjunction/ai-azure':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../Azure
       '@memberjunction/ai-bedrock':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../Bedrock
       '@memberjunction/ai-betty-bot':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../BettyBot
       '@memberjunction/ai-blackforestlabs':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../BlackForestLabs
       '@memberjunction/ai-cerebras':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../Cerebras
       '@memberjunction/ai-cohere':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../Cohere
       '@memberjunction/ai-elevenlabs':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../ElevenLabs
       '@memberjunction/ai-fireworks':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../Fireworks
       '@memberjunction/ai-gemini':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../Gemini
       '@memberjunction/ai-groq':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../Groq
       '@memberjunction/ai-heygen':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../HeyGen
       '@memberjunction/ai-inception':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../Inception
       '@memberjunction/ai-inworld':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../Inworld
       '@memberjunction/ai-llamacpp':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../LlamaCpp
       '@memberjunction/ai-lmstudio':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../LMStudio
       '@memberjunction/ai-local-embeddings':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../LocalEmbeddings
       '@memberjunction/ai-minimax':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../MiniMax
       '@memberjunction/ai-mistral':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../Mistral
       '@memberjunction/ai-ollama':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../Ollama
       '@memberjunction/ai-openai':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../OpenAI
       '@memberjunction/ai-openrouter':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../OpenRouter
       '@memberjunction/ai-recommendations-rex':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../Recommendations-Rex
       '@memberjunction/ai-vectors-pinecone':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../Vectors/Providers/Pinecone
       '@memberjunction/ai-vertex':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../Vertex
       '@memberjunction/ai-xai':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../xAI
       '@memberjunction/ai-zhipu':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../Zhipu
     devDependencies:
       typescript:
@@ -1584,10 +1584,10 @@ importers:
         specifier: ^1.64.1
         version: 1.64.1(encoding@0.1.13)
       '@memberjunction/ai':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../Core
       '@memberjunction/global':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../../MJGlobal
     devDependencies:
       ts-node-dev:
@@ -1600,10 +1600,10 @@ importers:
   packages/AI/Providers/Cohere:
     dependencies:
       '@memberjunction/ai':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../Core
       '@memberjunction/global':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../../MJGlobal
       cohere-ai:
         specifier: ^7.20.0
@@ -1625,10 +1625,10 @@ importers:
         specifier: ^2.34.0
         version: 2.34.0(encoding@0.1.13)
       '@memberjunction/ai':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../Core
       '@memberjunction/global':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../../MJGlobal
     devDependencies:
       ts-node-dev:
@@ -1641,10 +1641,10 @@ importers:
   packages/AI/Providers/Fireworks:
     dependencies:
       '@memberjunction/ai':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../Core
       '@memberjunction/global':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../../MJGlobal
       openai:
         specifier: 6.18.0
@@ -1666,10 +1666,10 @@ importers:
         specifier: ^2.8.0
         version: 2.8.0(@modelcontextprotocol/sdk@1.26.0(zod@4.3.6))
       '@memberjunction/ai':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../Core
       '@memberjunction/global':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../../MJGlobal
     devDependencies:
       ts-node-dev:
@@ -1682,10 +1682,10 @@ importers:
   packages/AI/Providers/Groq:
     dependencies:
       '@memberjunction/ai':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../Core
       '@memberjunction/global':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../../MJGlobal
       groq-sdk:
         specifier: ^0.37.0
@@ -1704,10 +1704,10 @@ importers:
         specifier: ^2.34.0
         version: 2.34.0(encoding@0.1.13)
       '@memberjunction/ai':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../Core
       '@memberjunction/global':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../../MJGlobal
       axios:
         specifier: ^1.13.4
@@ -1723,13 +1723,13 @@ importers:
   packages/AI/Providers/HuggingFace:
     dependencies:
       '@memberjunction/ai':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../Core
       '@memberjunction/ai-openai':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../OpenAI
       '@memberjunction/global':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../../MJGlobal
       openai:
         specifier: 6.18.0
@@ -1742,13 +1742,13 @@ importers:
   packages/AI/Providers/Inception:
     dependencies:
       '@memberjunction/ai':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../Core
       '@memberjunction/ai-openai':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../OpenAI
       '@memberjunction/global':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../../MJGlobal
       openai:
         specifier: 6.18.0
@@ -1764,10 +1764,10 @@ importers:
   packages/AI/Providers/Inworld:
     dependencies:
       '@memberjunction/ai':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../Core
       '@memberjunction/global':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../../MJGlobal
     devDependencies:
       typescript:
@@ -1780,10 +1780,10 @@ importers:
         specifier: ^1.5.0
         version: 1.5.0
       '@memberjunction/ai':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../Core
       '@memberjunction/global':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../../MJGlobal
     devDependencies:
       ts-node-dev:
@@ -1796,13 +1796,13 @@ importers:
   packages/AI/Providers/LlamaCpp:
     dependencies:
       '@memberjunction/ai':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../Core
       '@memberjunction/ai-openai':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../OpenAI
       '@memberjunction/global':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../../MJGlobal
     devDependencies:
       ts-node-dev:
@@ -1815,10 +1815,10 @@ importers:
   packages/AI/Providers/LocalEmbeddings:
     dependencies:
       '@memberjunction/ai':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../Core
       '@memberjunction/global':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../../MJGlobal
       '@xenova/transformers':
         specifier: ^2.17.2
@@ -1834,13 +1834,13 @@ importers:
   packages/AI/Providers/MiniMax:
     dependencies:
       '@memberjunction/ai':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../Core
       '@memberjunction/ai-openai':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../OpenAI
       '@memberjunction/global':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../../MJGlobal
     devDependencies:
       ts-node-dev:
@@ -1853,10 +1853,10 @@ importers:
   packages/AI/Providers/Mistral:
     dependencies:
       '@memberjunction/ai':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../Core
       '@memberjunction/global':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../../MJGlobal
       '@mistralai/mistralai':
         specifier: ^1.14.0
@@ -1875,10 +1875,10 @@ importers:
   packages/AI/Providers/Ollama:
     dependencies:
       '@memberjunction/ai':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../Core
       '@memberjunction/global':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../../MJGlobal
       ollama:
         specifier: ^0.6.3
@@ -1894,10 +1894,10 @@ importers:
   packages/AI/Providers/OpenAI:
     dependencies:
       '@memberjunction/ai':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../Core
       '@memberjunction/global':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../../MJGlobal
       openai:
         specifier: 6.18.0
@@ -1913,13 +1913,13 @@ importers:
   packages/AI/Providers/OpenRouter:
     dependencies:
       '@memberjunction/ai':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../Core
       '@memberjunction/ai-openai':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../OpenAI
       '@memberjunction/global':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../../MJGlobal
     devDependencies:
       ts-node-dev:
@@ -1932,19 +1932,19 @@ importers:
   packages/AI/Providers/Recommendations-Rex:
     dependencies:
       '@memberjunction/ai':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../Core
       '@memberjunction/ai-recommendations':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../Recommendations/Engine
       '@memberjunction/core':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../../MJCore
       '@memberjunction/core-entities':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../../MJCoreEntities
       '@memberjunction/global':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../../MJGlobal
       axios:
         specifier: ^1.13.4
@@ -1972,13 +1972,13 @@ importers:
         specifier: ^2.8.0
         version: 2.8.0(@modelcontextprotocol/sdk@1.26.0(zod@4.3.6))
       '@memberjunction/ai':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../Core
       '@memberjunction/ai-gemini':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../Gemini
       '@memberjunction/global':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../../MJGlobal
     devDependencies:
       ts-node-dev:
@@ -1994,13 +1994,13 @@ importers:
   packages/AI/Providers/Zhipu:
     dependencies:
       '@memberjunction/ai':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../Core
       '@memberjunction/ai-openai':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../OpenAI
       '@memberjunction/global':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../../MJGlobal
     devDependencies:
       ts-node-dev:
@@ -2013,13 +2013,13 @@ importers:
   packages/AI/Providers/xAI:
     dependencies:
       '@memberjunction/ai':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../Core
       '@memberjunction/ai-openai':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../OpenAI
       '@memberjunction/global':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../../MJGlobal
       openai:
         specifier: 6.18.0
@@ -2035,13 +2035,13 @@ importers:
   packages/AI/RealtimeBridge/Base:
     dependencies:
       '@memberjunction/core':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../../MJCore
       '@memberjunction/core-entities':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../../MJCoreEntities
       '@memberjunction/global':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../../MJGlobal
       rxjs:
         specifier: ^7.8.2
@@ -2063,16 +2063,16 @@ importers:
   packages/AI/RealtimeBridge/Providers/Discord:
     dependencies:
       '@memberjunction/ai-bridge-base':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../Base
       '@memberjunction/core':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../../../MJCore
       '@memberjunction/core-entities':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../../../MJCoreEntities
       '@memberjunction/global':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../../../MJGlobal
     devDependencies:
       '@types/node':
@@ -2091,16 +2091,16 @@ importers:
   packages/AI/RealtimeBridge/Providers/GoogleMeet:
     dependencies:
       '@memberjunction/ai-bridge-base':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../Base
       '@memberjunction/core':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../../../MJCore
       '@memberjunction/core-entities':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../../../MJCoreEntities
       '@memberjunction/global':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../../../MJGlobal
     devDependencies:
       '@types/node':
@@ -2119,16 +2119,16 @@ importers:
   packages/AI/RealtimeBridge/Providers/LiveKit:
     dependencies:
       '@memberjunction/ai-bridge-base':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../Base
       '@memberjunction/core':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../../../MJCore
       '@memberjunction/core-entities':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../../../MJCoreEntities
       '@memberjunction/global':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../../../MJGlobal
     devDependencies:
       '@types/node':
@@ -2147,10 +2147,10 @@ importers:
   packages/AI/RealtimeBridge/Providers/LiveKitNative:
     dependencies:
       '@memberjunction/ai-bridge-livekit':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../LiveKit
       '@memberjunction/core':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../../../MJCore
     devDependencies:
       '@types/node':
@@ -2173,16 +2173,16 @@ importers:
   packages/AI/RealtimeBridge/Providers/RingCentral:
     dependencies:
       '@memberjunction/ai-bridge-base':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../Base
       '@memberjunction/core':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../../../MJCore
       '@memberjunction/core-entities':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../../../MJCoreEntities
       '@memberjunction/global':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../../../MJGlobal
     devDependencies:
       '@types/node':
@@ -2211,16 +2211,16 @@ importers:
   packages/AI/RealtimeBridge/Providers/Slack:
     dependencies:
       '@memberjunction/ai-bridge-base':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../Base
       '@memberjunction/core':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../../../MJCore
       '@memberjunction/core-entities':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../../../MJCoreEntities
       '@memberjunction/global':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../../../MJGlobal
     devDependencies:
       '@types/node':
@@ -2239,16 +2239,16 @@ importers:
   packages/AI/RealtimeBridge/Providers/Teams:
     dependencies:
       '@memberjunction/ai-bridge-base':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../Base
       '@memberjunction/core':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../../../MJCore
       '@memberjunction/core-entities':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../../../MJCoreEntities
       '@memberjunction/global':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../../../MJGlobal
     devDependencies:
       '@types/node':
@@ -2274,16 +2274,16 @@ importers:
   packages/AI/RealtimeBridge/Providers/Twilio:
     dependencies:
       '@memberjunction/ai-bridge-base':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../Base
       '@memberjunction/core':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../../../MJCore
       '@memberjunction/core-entities':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../../../MJCoreEntities
       '@memberjunction/global':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../../../MJGlobal
     devDependencies:
       '@types/node':
@@ -2306,16 +2306,16 @@ importers:
   packages/AI/RealtimeBridge/Providers/Vonage:
     dependencies:
       '@memberjunction/ai-bridge-base':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../Base
       '@memberjunction/core':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../../../MJCore
       '@memberjunction/core-entities':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../../../MJCoreEntities
       '@memberjunction/global':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../../../MJGlobal
     devDependencies:
       '@types/node':
@@ -2338,16 +2338,16 @@ importers:
   packages/AI/RealtimeBridge/Providers/Webex:
     dependencies:
       '@memberjunction/ai-bridge-base':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../Base
       '@memberjunction/core':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../../../MJCore
       '@memberjunction/core-entities':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../../../MJCoreEntities
       '@memberjunction/global':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../../../MJGlobal
     devDependencies:
       '@types/node':
@@ -2366,16 +2366,16 @@ importers:
   packages/AI/RealtimeBridge/Providers/Zoom:
     dependencies:
       '@memberjunction/ai-bridge-base':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../Base
       '@memberjunction/core':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../../../MJCore
       '@memberjunction/core-entities':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../../../MJCoreEntities
       '@memberjunction/global':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../../../MJGlobal
     devDependencies:
       '@types/node':
@@ -2398,19 +2398,19 @@ importers:
   packages/AI/RealtimeBridge/Server:
     dependencies:
       '@memberjunction/ai':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../Core
       '@memberjunction/ai-bridge-base':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../Base
       '@memberjunction/core':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../../MJCore
       '@memberjunction/core-entities':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../../MJCoreEntities
       '@memberjunction/global':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../../MJGlobal
       rxjs:
         specifier: ^7.8.2
@@ -2434,7 +2434,7 @@ importers:
         version: 3.0.7(@azure/identity@4.13.1)
       googleapis:
         specifier: ^144.0.0
-        version: 144.0.0(encoding@0.1.13)
+        version: 144.0.0
 
   packages/AI/RealtimeClient:
     dependencies:
@@ -2442,10 +2442,10 @@ importers:
         specifier: ^1.40.0
         version: 1.52.0(@modelcontextprotocol/sdk@1.26.0(zod@4.3.6))
       '@memberjunction/ai':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../Core
       '@memberjunction/global':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../MJGlobal
     devDependencies:
       '@types/node':
@@ -2458,16 +2458,16 @@ importers:
   packages/AI/Recommendations/Engine:
     dependencies:
       '@memberjunction/ai':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../Core
       '@memberjunction/core':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../../MJCore
       '@memberjunction/core-entities':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../../MJCoreEntities
       '@memberjunction/global':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../../MJGlobal
     devDependencies:
       ts-node-dev:
@@ -2480,13 +2480,13 @@ importers:
   packages/AI/RemoteBrowser/Base:
     dependencies:
       '@memberjunction/core':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../../MJCore
       '@memberjunction/core-entities':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../../MJCoreEntities
       '@memberjunction/global':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../../MJGlobal
       rxjs:
         specifier: ^7.8.2
@@ -2508,16 +2508,16 @@ importers:
   packages/AI/RemoteBrowser/Cdp:
     dependencies:
       '@memberjunction/computer-use':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../ComputerUse
       '@memberjunction/core':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../../MJCore
       '@memberjunction/global':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../../MJGlobal
       '@memberjunction/remote-browser-base':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../Base
     devDependencies:
       '@types/node':
@@ -2536,16 +2536,16 @@ importers:
   packages/AI/RemoteBrowser/Providers/Browserbase:
     dependencies:
       '@memberjunction/core':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../../../MJCore
       '@memberjunction/global':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../../../MJGlobal
       '@memberjunction/remote-browser-base':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../Base
       '@memberjunction/remote-browser-cdp':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../Cdp
     devDependencies:
       '@types/node':
@@ -2564,16 +2564,16 @@ importers:
   packages/AI/RemoteBrowser/Providers/Browserless:
     dependencies:
       '@memberjunction/core':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../../../MJCore
       '@memberjunction/global':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../../../MJGlobal
       '@memberjunction/remote-browser-base':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../Base
       '@memberjunction/remote-browser-cdp':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../Cdp
     devDependencies:
       '@types/node':
@@ -2595,16 +2595,16 @@ importers:
         specifier: '*'
         version: 0.91.8(encoding@0.1.13)
       '@memberjunction/core':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../../../MJCore
       '@memberjunction/global':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../../../MJGlobal
       '@memberjunction/remote-browser-base':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../Base
       '@memberjunction/remote-browser-cdp':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../Cdp
     devDependencies:
       '@types/node':
@@ -2623,19 +2623,19 @@ importers:
   packages/AI/RemoteBrowser/Providers/SelfHost:
     dependencies:
       '@memberjunction/computer-use':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../../ComputerUse
       '@memberjunction/core':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../../../MJCore
       '@memberjunction/global':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../../../MJGlobal
       '@memberjunction/remote-browser-base':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../Base
       '@memberjunction/remote-browser-cdp':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../Cdp
     devDependencies:
       '@types/node':
@@ -2657,16 +2657,16 @@ importers:
   packages/AI/RemoteBrowser/Providers/Steel:
     dependencies:
       '@memberjunction/core':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../../../MJCore
       '@memberjunction/global':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../../../MJGlobal
       '@memberjunction/remote-browser-base':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../Base
       '@memberjunction/remote-browser-cdp':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../Cdp
     devDependencies:
       '@types/node':
@@ -2685,19 +2685,19 @@ importers:
   packages/AI/RemoteBrowser/Server:
     dependencies:
       '@memberjunction/ai':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../Core
       '@memberjunction/core':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../../MJCore
       '@memberjunction/core-entities':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../../MJCoreEntities
       '@memberjunction/global':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../../MJGlobal
       '@memberjunction/remote-browser-base':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../Base
     devDependencies:
       '@types/node':
@@ -2716,25 +2716,25 @@ importers:
   packages/AI/Reranker:
     dependencies:
       '@memberjunction/ai':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../Core
       '@memberjunction/ai-core-plus':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../CorePlus
       '@memberjunction/ai-prompts':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../Prompts
       '@memberjunction/aiengine':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../Engine
       '@memberjunction/core':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../MJCore
       '@memberjunction/core-entities':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../MJCoreEntities
       '@memberjunction/global':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../MJGlobal
     devDependencies:
       '@types/node':
@@ -2753,25 +2753,25 @@ importers:
   packages/AI/Segmentation:
     dependencies:
       '@memberjunction/ai-core-plus':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../CorePlus
       '@memberjunction/ai-prompts':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../Prompts
       '@memberjunction/ai-vectors':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../Vectors/Core
       '@memberjunction/aiengine':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../Engine
       '@memberjunction/core':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../MJCore
       '@memberjunction/core-entities':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../MJCoreEntities
       '@memberjunction/global':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../MJGlobal
       cheerio:
         specifier: ^1.2.0
@@ -2787,25 +2787,25 @@ importers:
   packages/AI/Vectors/Core:
     dependencies:
       '@memberjunction/ai':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../Core
       '@memberjunction/ai-core-plus':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../CorePlus
       '@memberjunction/ai-vectordb':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../Database
       '@memberjunction/aiengine':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../Engine
       '@memberjunction/core':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../../MJCore
       '@memberjunction/core-entities':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../../MJCoreEntities
       '@memberjunction/global':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../../MJGlobal
       dotenv:
         specifier: ^17.2.4
@@ -2827,13 +2827,13 @@ importers:
   packages/AI/Vectors/Database:
     dependencies:
       '@memberjunction/core':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../../MJCore
       '@memberjunction/global':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../../MJGlobal
       '@memberjunction/sql-dialect':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../../SQLDialect
       dotenv:
         specifier: ^17.2.4
@@ -2852,40 +2852,40 @@ importers:
   packages/AI/Vectors/Dupe:
     dependencies:
       '@memberjunction/ai':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../Core
       '@memberjunction/ai-core-plus':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../CorePlus
       '@memberjunction/ai-prompts':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../Prompts
       '@memberjunction/ai-vector-sync':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../Sync
       '@memberjunction/ai-vectordb':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../Database
       '@memberjunction/ai-vectors':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../Core
       '@memberjunction/aiengine':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../Engine
       '@memberjunction/core':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../../MJCore
       '@memberjunction/core-entities':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../../MJCoreEntities
       '@memberjunction/global':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../../MJGlobal
       '@memberjunction/record-comparison':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../../RecordComparison
       '@memberjunction/templates':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../../Templates/engine
       dotenv:
         specifier: ^17.2.4
@@ -2907,13 +2907,13 @@ importers:
   packages/AI/Vectors/Memory:
     dependencies:
       '@memberjunction/ai-vectordb':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../Database
       '@memberjunction/core':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../../MJCore
       '@memberjunction/global':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../../MJGlobal
     devDependencies:
       '@types/node':
@@ -2929,19 +2929,19 @@ importers:
   packages/AI/Vectors/Providers/Pinecone:
     dependencies:
       '@memberjunction/ai-vectordb':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../Database
       '@memberjunction/ai-vectors':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../Core
       '@memberjunction/aiengine':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../../Engine
       '@memberjunction/core':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../../../MJCore
       '@memberjunction/global':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../../../MJGlobal
       '@pinecone-database/pinecone':
         specifier: 2.2.2
@@ -2969,13 +2969,13 @@ importers:
   packages/AI/Vectors/Providers/Qdrant:
     dependencies:
       '@memberjunction/ai-vectordb':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../Database
       '@memberjunction/core':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../../../MJCore
       '@memberjunction/global':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../../../MJGlobal
       '@qdrant/js-client-rest':
         specifier: ^1.13.0
@@ -2997,13 +2997,13 @@ importers:
   packages/AI/Vectors/Providers/SQLServer:
     dependencies:
       '@memberjunction/ai-vectordb':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../Database
       '@memberjunction/core':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../../../MJCore
       '@memberjunction/global':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../../../MJGlobal
       dotenv:
         specifier: ^17.2.4
@@ -3022,13 +3022,13 @@ importers:
   packages/AI/Vectors/Providers/pgvector:
     dependencies:
       '@memberjunction/ai-vectordb':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../Database
       '@memberjunction/core':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../../../MJCore
       '@memberjunction/global':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../../../MJGlobal
       dotenv:
         specifier: ^17.2.4
@@ -3053,43 +3053,43 @@ importers:
   packages/AI/Vectors/Sync:
     dependencies:
       '@memberjunction/ai':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../Core
       '@memberjunction/ai-core-plus':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../CorePlus
       '@memberjunction/ai-prompts':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../Prompts
       '@memberjunction/ai-vectordb':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../Database
       '@memberjunction/ai-vectors':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../Core
       '@memberjunction/ai-vectors-pinecone':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../Providers/Pinecone
       '@memberjunction/aiengine':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../Engine
       '@memberjunction/core':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../../MJCore
       '@memberjunction/core-entities':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../../MJCoreEntities
       '@memberjunction/credentials':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../../Credentials/Engine
       '@memberjunction/global':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../../MJGlobal
       '@memberjunction/templates':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../../Templates/engine
       '@memberjunction/templates-base-types':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../../Templates/base-types
       dotenv:
         specifier: ^17.2.4
@@ -3114,13 +3114,13 @@ importers:
   packages/APIKeys/Base:
     dependencies:
       '@memberjunction/core':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../MJCore
       '@memberjunction/core-entities':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../MJCoreEntities
       '@memberjunction/global':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../MJGlobal
     devDependencies:
       '@types/node':
@@ -3136,16 +3136,16 @@ importers:
   packages/APIKeys/Engine:
     dependencies:
       '@memberjunction/api-keys-base':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../Base
       '@memberjunction/core':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../MJCore
       '@memberjunction/core-entities':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../MJCoreEntities
       '@memberjunction/global':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../MJGlobal
       cosmiconfig:
         specifier: 9.0.0
@@ -3167,19 +3167,19 @@ importers:
   packages/Actions/ApolloEnrichment:
     dependencies:
       '@memberjunction/actions':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../Engine
       '@memberjunction/actions-base':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../Base
       '@memberjunction/core':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../MJCore
       '@memberjunction/core-entities':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../MJCoreEntities
       '@memberjunction/global':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../MJGlobal
       axios:
         specifier: ^1.13.4
@@ -3195,16 +3195,16 @@ importers:
   packages/Actions/Base:
     dependencies:
       '@memberjunction/code-execution':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../CodeExecution
       '@memberjunction/core':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../MJCore
       '@memberjunction/core-entities':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../MJCoreEntities
       '@memberjunction/global':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../MJGlobal
       zod:
         specifier: ^3.25.0
@@ -3220,19 +3220,19 @@ importers:
   packages/Actions/BizApps/Accounting:
     dependencies:
       '@memberjunction/actions':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../Engine
       '@memberjunction/actions-base':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../Base
       '@memberjunction/core':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../../MJCore
       '@memberjunction/core-entities':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../../MJCoreEntities
       '@memberjunction/global':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../../MJGlobal
     devDependencies:
       '@types/node':
@@ -3248,19 +3248,19 @@ importers:
   packages/Actions/BizApps/CRM:
     dependencies:
       '@memberjunction/actions':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../Engine
       '@memberjunction/actions-base':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../Base
       '@memberjunction/core':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../../MJCore
       '@memberjunction/core-entities':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../../MJCoreEntities
       '@memberjunction/global':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../../MJGlobal
     devDependencies:
       '@types/node':
@@ -3276,19 +3276,19 @@ importers:
   packages/Actions/BizApps/FormBuilders:
     dependencies:
       '@memberjunction/actions':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../Engine
       '@memberjunction/actions-base':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../Base
       '@memberjunction/core':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../../MJCore
       '@memberjunction/core-entities':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../../MJCoreEntities
       '@memberjunction/global':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../../MJGlobal
       axios:
         specifier: ^1.13.4
@@ -3316,19 +3316,19 @@ importers:
   packages/Actions/BizApps/LMS:
     dependencies:
       '@memberjunction/actions':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../Engine
       '@memberjunction/actions-base':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../Base
       '@memberjunction/core':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../../MJCore
       '@memberjunction/core-entities':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../../MJCoreEntities
       '@memberjunction/global':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../../MJGlobal
     devDependencies:
       '@types/node':
@@ -3347,19 +3347,19 @@ importers:
   packages/Actions/BizApps/Social:
     dependencies:
       '@memberjunction/actions':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../Engine
       '@memberjunction/actions-base':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../Base
       '@memberjunction/core':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../../MJCore
       '@memberjunction/core-entities':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../../MJCoreEntities
       '@memberjunction/global':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../../MJGlobal
       axios:
         specifier: ^1.13.4
@@ -3381,10 +3381,10 @@ importers:
   packages/Actions/CodeExecution:
     dependencies:
       '@memberjunction/core':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../MJCore
       '@memberjunction/global':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../MJGlobal
       date-fns:
         specifier: ^3.0.0
@@ -3433,28 +3433,28 @@ importers:
   packages/Actions/ContentAutotag:
     dependencies:
       '@memberjunction/actions':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../Engine
       '@memberjunction/actions-base':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../Base
       '@memberjunction/ai-vector-sync':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../AI/Vectors/Sync
       '@memberjunction/content-autotagging':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../ContentAutotagging
       '@memberjunction/core':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../MJCore
       '@memberjunction/core-actions':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../CoreActions
       '@memberjunction/core-entities':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../MJCoreEntities
       '@memberjunction/global':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../MJGlobal
       axios:
         specifier: ^1.13.4
@@ -3479,115 +3479,115 @@ importers:
         specifier: ^1.1.8
         version: 1.1.8
       '@memberjunction/actions':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../Engine
       '@memberjunction/actions-base':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../Base
       '@memberjunction/ai':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../AI/Core
       '@memberjunction/ai-agent-manager':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../AI/AgentManager/core
       '@memberjunction/ai-agents':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../AI/Agents
       '@memberjunction/ai-betty-bot':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../AI/Providers/BettyBot
       '@memberjunction/ai-core-plus':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../AI/CorePlus
       '@memberjunction/ai-engine-base':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../AI/BaseAIEngine
       '@memberjunction/ai-mcp-client':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../AI/MCPClient
       '@memberjunction/ai-prompts':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../AI/Prompts
       '@memberjunction/ai-vector-sync':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../AI/Vectors/Sync
       '@memberjunction/aiengine':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../AI/Engine
       '@memberjunction/clustering-engine':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../AI/Clustering
       '@memberjunction/code-execution':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../CodeExecution
       '@memberjunction/communication-engine':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../Communication/engine
       '@memberjunction/communication-types':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../Communication/base-types
       '@memberjunction/content-autotagging':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../ContentAutotagging
       '@memberjunction/core':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../MJCore
       '@memberjunction/core-entities':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../MJCoreEntities
       '@memberjunction/core-entities-server':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../MJCoreEntitiesServer
       '@memberjunction/esignature':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../eSignature/Base
       '@memberjunction/export-engine':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../MJExportEngine
       '@memberjunction/external-change-detection':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../ExternalChangeDetection
       '@memberjunction/generic-database-provider':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../GenericDatabaseProvider
       '@memberjunction/geo-core':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../geo/geo-core
       '@memberjunction/global':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../MJGlobal
       '@memberjunction/integration-engine':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../Integration/engine
       '@memberjunction/interactive-component-types':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../InteractiveComponents
       '@memberjunction/lists':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../Lists/server
       '@memberjunction/lists-base':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../Lists/base
       '@memberjunction/react-linter':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../React/linter
       '@memberjunction/record-set-processor':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../RecordSetProcessor/engine
       '@memberjunction/record-set-processor-base':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../RecordSetProcessor/base
       '@memberjunction/search-engine':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../SearchEngine
       '@memberjunction/sql-dialect':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../SQLDialect
       '@memberjunction/sqlserver-dataprovider':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../SQLServerDataProvider
       '@memberjunction/storage':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../MJStorage
       '@types/d3-cloud':
         specifier: ^1.2.9
@@ -3780,28 +3780,28 @@ importers:
   packages/Actions/Engine:
     dependencies:
       '@memberjunction/action-runtime':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../Runtime
       '@memberjunction/actions-base':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../Base
       '@memberjunction/ai':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../AI/Core
       '@memberjunction/code-execution':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../CodeExecution
       '@memberjunction/core':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../MJCore
       '@memberjunction/core-entities':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../MJCoreEntities
       '@memberjunction/doc-utils':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../DocUtils
       '@memberjunction/global':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../MJGlobal
     devDependencies:
       ts-node-dev:
@@ -3814,19 +3814,19 @@ importers:
   packages/Actions/Runtime:
     dependencies:
       '@memberjunction/actions-base':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../Base
       '@memberjunction/code-execution':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../CodeExecution
       '@memberjunction/core':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../MJCore
       '@memberjunction/core-entities':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../MJCoreEntities
       '@memberjunction/global':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../MJGlobal
     devDependencies:
       ts-node-dev:
@@ -3839,37 +3839,37 @@ importers:
   packages/Actions/RuntimeHost:
     dependencies:
       '@memberjunction/actions':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../Engine
       '@memberjunction/actions-base':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../Base
       '@memberjunction/ai':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../AI/Core
       '@memberjunction/ai-agents':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../AI/Agents
       '@memberjunction/ai-core-plus':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../AI/CorePlus
       '@memberjunction/ai-prompts':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../AI/Prompts
       '@memberjunction/aiengine':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../AI/Engine
       '@memberjunction/code-execution':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../CodeExecution
       '@memberjunction/core':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../MJCore
       '@memberjunction/core-entities':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../MJCoreEntities
       '@memberjunction/global':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../MJGlobal
     devDependencies:
       ts-node-dev:
@@ -3882,28 +3882,28 @@ importers:
   packages/Actions/ScheduledActions:
     dependencies:
       '@memberjunction/actions':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../Engine
       '@memberjunction/actions-base':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../Base
       '@memberjunction/core':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../MJCore
       '@memberjunction/core-actions':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../CoreActions
       '@memberjunction/core-entities':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../MJCoreEntities
       '@memberjunction/core-entities-server':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../MJCoreEntitiesServer
       '@memberjunction/generic-database-provider':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../GenericDatabaseProvider
       '@memberjunction/global':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../MJGlobal
       cron-parser:
         specifier: ^4.9.0
@@ -3919,40 +3919,40 @@ importers:
   packages/Actions/ScheduledActionsServer:
     dependencies:
       '@memberjunction/actions':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../Engine
       '@memberjunction/actions-apollo':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../ApolloEnrichment
       '@memberjunction/actions-content-autotag':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../ContentAutotag
       '@memberjunction/ai':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../AI/Core
       '@memberjunction/ai-mistral':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../AI/Providers/Mistral
       '@memberjunction/ai-openai':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../AI/Providers/OpenAI
       '@memberjunction/ai-vector-sync':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../AI/Vectors/Sync
       '@memberjunction/ai-vectors-pinecone':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../AI/Vectors/Providers/Pinecone
       '@memberjunction/core':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../MJCore
       '@memberjunction/core-entities':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../MJCoreEntities
       '@memberjunction/scheduled-actions':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../ScheduledActions
       '@memberjunction/sqlserver-dataprovider':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../SQLServerDataProvider
       dotenv:
         specifier: ^17.2.4
@@ -3983,76 +3983,76 @@ importers:
   packages/Angular/Bootstrap:
     dependencies:
       '@memberjunction/actions-base':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../Actions/Base
       '@memberjunction/ai-core-plus':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../AI/CorePlus
       '@memberjunction/ai-engine-base':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../AI/BaseAIEngine
       '@memberjunction/ai-realtime-client':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../AI/RealtimeClient
       '@memberjunction/ai-vectors-memory':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../AI/Vectors/Memory
       '@memberjunction/communication-types':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../Communication/base-types
       '@memberjunction/core':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../MJCore
       '@memberjunction/core-entities':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../MJCoreEntities
       '@memberjunction/entity-communications-base':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../Communication/entity-comm-base
       '@memberjunction/graphql-dataprovider':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../GraphQLDataProvider
       '@memberjunction/ng-artifacts':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../Generic/artifacts
       '@memberjunction/ng-auth-services':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../Explorer/auth-services
       '@memberjunction/ng-clustering':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../Generic/clustering
       '@memberjunction/ng-conversations':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../Generic/conversations
       '@memberjunction/ng-core-entity-forms':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../Explorer/core-entity-forms
       '@memberjunction/ng-dashboard-viewer':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../Generic/dashboard-viewer
       '@memberjunction/ng-dashboards':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../Explorer/dashboards
       '@memberjunction/ng-entity-action-ux':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../Generic/entity-action-ux
       '@memberjunction/ng-entity-viewer':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../Generic/entity-viewer
       '@memberjunction/ng-explorer-core':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../Explorer/explorer-core
       '@memberjunction/ng-explorer-settings':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../Explorer/explorer-settings
       '@memberjunction/ng-file-storage':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../Generic/file-storage
       '@memberjunction/ng-shared':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../Explorer/shared
       '@memberjunction/tag-engine-base':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../AI/Knowledge/TagEngineBase
       rxjs:
         specifier: ^7.8.2
@@ -4074,7 +4074,7 @@ importers:
         specifier: ^21.1.3
         version: 21.1.3(@angular/common@21.1.3(@angular/core@21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0))(rxjs@7.8.2))(@angular/core@21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0))(@angular/platform-browser@21.1.3(@angular/animations@21.1.3(@angular/core@21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0)))(@angular/common@21.1.3(@angular/core@21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0))(rxjs@7.8.2))(@angular/core@21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0)))(rxjs@7.8.2)
       '@memberjunction/ng-test-utils':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../Generic/test-utils
       ng-packagr:
         specifier: ^21.1.0
@@ -4090,64 +4090,64 @@ importers:
   packages/Angular/BootstrapLite:
     dependencies:
       '@memberjunction/actions-base':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../Actions/Base
       '@memberjunction/ai-core-plus':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../AI/CorePlus
       '@memberjunction/ai-engine-base':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../AI/BaseAIEngine
       '@memberjunction/ai-realtime-client':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../AI/RealtimeClient
       '@memberjunction/ai-vectors-memory':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../AI/Vectors/Memory
       '@memberjunction/communication-types':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../Communication/base-types
       '@memberjunction/core':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../MJCore
       '@memberjunction/core-entities':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../MJCoreEntities
       '@memberjunction/entity-communications-base':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../Communication/entity-comm-base
       '@memberjunction/graphql-dataprovider':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../GraphQLDataProvider
       '@memberjunction/ng-artifacts':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../Generic/artifacts
       '@memberjunction/ng-auth-services':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../Explorer/auth-services
       '@memberjunction/ng-conversations':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../Generic/conversations
       '@memberjunction/ng-core-entity-forms':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../Explorer/core-entity-forms
       '@memberjunction/ng-dashboard-viewer':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../Generic/dashboard-viewer
       '@memberjunction/ng-entity-action-ux':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../Generic/entity-action-ux
       '@memberjunction/ng-entity-viewer':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../Generic/entity-viewer
       '@memberjunction/ng-explorer-core':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../Explorer/explorer-core
       '@memberjunction/ng-file-storage':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../Generic/file-storage
       '@memberjunction/ng-shared':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../Explorer/shared
       rxjs:
         specifier: ^7.8.2
@@ -4187,10 +4187,10 @@ importers:
         specifier: ^16.0.3
         version: 16.11.1
       '@memberjunction/core':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../../MJCore
       '@memberjunction/global':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../../MJGlobal
       '@okta/okta-auth-js':
         specifier: ^7.14.1
@@ -4224,13 +4224,13 @@ importers:
         specifier: 21.1.3
         version: 21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0)
       '@memberjunction/core':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../../MJCore
       '@memberjunction/core-entities':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../../MJCoreEntities
       '@memberjunction/global':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../../MJGlobal
       golden-layout:
         specifier: ^2.6.0
@@ -4273,115 +4273,115 @@ importers:
         specifier: ^6.5.2
         version: 6.5.2
       '@memberjunction/actions-base':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../../Actions/Base
       '@memberjunction/ai':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../../AI/Core
       '@memberjunction/ai-core-plus':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../../AI/CorePlus
       '@memberjunction/ai-engine-base':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../../AI/BaseAIEngine
       '@memberjunction/core':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../../MJCore
       '@memberjunction/core-entities':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../../MJCoreEntities
       '@memberjunction/global':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../../MJGlobal
       '@memberjunction/graphql-dataprovider':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../../GraphQLDataProvider
       '@memberjunction/ng-action-gallery':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../Generic/action-gallery
       '@memberjunction/ng-actions':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../Generic/actions
       '@memberjunction/ng-agents':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../Generic/agents
       '@memberjunction/ng-ai-test-harness':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../Generic/ai-test-harness
       '@memberjunction/ng-base-application':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../base-application
       '@memberjunction/ng-base-forms':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../Generic/base-forms
       '@memberjunction/ng-base-types':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../Generic/base-types
       '@memberjunction/ng-code-editor':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../Generic/code-editor
       '@memberjunction/ng-deep-diff':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../Generic/deep-diff
       '@memberjunction/ng-entity-relationship-diagram':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../Generic/entity-relationship-diagram
       '@memberjunction/ng-entity-viewer':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../Generic/entity-viewer
       '@memberjunction/ng-flow-editor':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../Generic/flow-editor
       '@memberjunction/ng-join-grid':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../Generic/join-grid
       '@memberjunction/ng-link-directives':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../link-directives
       '@memberjunction/ng-list-management':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../Generic/list-management
       '@memberjunction/ng-markdown':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../Generic/markdown
       '@memberjunction/ng-notifications':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../Generic/notifications
       '@memberjunction/ng-record-process-studio':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../Generic/record-process-studio
       '@memberjunction/ng-resource-permissions':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../Generic/resource-permissions
       '@memberjunction/ng-search':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../Generic/search
       '@memberjunction/ng-shared':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../shared
       '@memberjunction/ng-shared-generic':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../Generic/shared
       '@memberjunction/ng-tabstrip':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../Generic/tab-strip
       '@memberjunction/ng-testing':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../Generic/Testing
       '@memberjunction/ng-timeline':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../Generic/timeline
       '@memberjunction/ng-trees':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../Generic/trees
       '@memberjunction/ng-ui-components':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../Generic/ui-components
       '@memberjunction/ng-versions':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../Generic/versions
       '@memberjunction/templates-base-types':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../../Templates/base-types
       '@types/d3':
         specifier: ^7.4.3
@@ -4424,7 +4424,7 @@ importers:
         specifier: 21.1.3
         version: 21.1.3(@angular/compiler@21.1.3)(typescript@5.9.3)
       '@memberjunction/ng-test-utils':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../Generic/test-utils
 
   packages/Angular/Explorer/dashboards:
@@ -4466,181 +4466,181 @@ importers:
         specifier: 6.43.8
         version: 6.43.8
       '@memberjunction/actions-base':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../../Actions/Base
       '@memberjunction/ai-core-plus':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../../AI/CorePlus
       '@memberjunction/ai-engine-base':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../../AI/BaseAIEngine
       '@memberjunction/api-keys-base':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../../APIKeys/Base
       '@memberjunction/core':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../../MJCore
       '@memberjunction/core-entities':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../../MJCoreEntities
       '@memberjunction/credentials':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../../Credentials/Engine
       '@memberjunction/export-engine':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../../MJExportEngine
       '@memberjunction/global':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../../MJGlobal
       '@memberjunction/graphql-dataprovider':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../../GraphQLDataProvider
       '@memberjunction/integration-engine-base':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../../Integration/engine-base
       '@memberjunction/interactive-component-types':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../../InteractiveComponents
       '@memberjunction/lists-base':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../../Lists/base
       '@memberjunction/ng-action-gallery':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../Generic/action-gallery
       '@memberjunction/ng-actions':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../Generic/actions
       '@memberjunction/ng-agent-requests':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../Generic/agent-requests
       '@memberjunction/ng-agents':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../Generic/agents
       '@memberjunction/ng-ai-test-harness':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../Generic/ai-test-harness
       '@memberjunction/ng-archive-manager':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../Generic/archive-manager
       '@memberjunction/ng-base-application':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../base-application
       '@memberjunction/ng-base-forms':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../Generic/base-forms
       '@memberjunction/ng-base-types':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../Generic/base-types
       '@memberjunction/ng-clustering':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../Generic/clustering
       '@memberjunction/ng-code-editor':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../Generic/code-editor
       '@memberjunction/ng-composer':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../Generic/composer
       '@memberjunction/ng-container-directives':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../Generic/container-directives
       '@memberjunction/ng-conversations':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../Generic/conversations
       '@memberjunction/ng-core-entity-forms':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../core-entity-forms
       '@memberjunction/ng-credentials':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../Generic/credentials
       '@memberjunction/ng-dashboard-viewer':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../Generic/dashboard-viewer
       '@memberjunction/ng-entity-relationship-diagram':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../Generic/entity-relationship-diagram
       '@memberjunction/ng-entity-viewer':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../Generic/entity-viewer
       '@memberjunction/ng-explorer-settings':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../explorer-settings
       '@memberjunction/ng-export-service':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../Generic/export-service
       '@memberjunction/ng-filter-builder':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../Generic/filter-builder
       '@memberjunction/ng-list-management':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../Generic/list-management
       '@memberjunction/ng-map-view':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../Generic/ng-map-view
       '@memberjunction/ng-markdown':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../Generic/markdown
       '@memberjunction/ng-media-player':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../Generic/media-player
       '@memberjunction/ng-notifications':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../Generic/notifications
       '@memberjunction/ng-query-viewer':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../Generic/query-viewer
       '@memberjunction/ng-react':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../Generic/react
       '@memberjunction/ng-record-process-studio':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../Generic/record-process-studio
       '@memberjunction/ng-resource-permissions':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../Generic/resource-permissions
       '@memberjunction/ng-scheduling':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../Generic/scheduling
       '@memberjunction/ng-search':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../Generic/search
       '@memberjunction/ng-shared':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../shared
       '@memberjunction/ng-shared-generic':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../Generic/shared
       '@memberjunction/ng-testing':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../Generic/Testing
       '@memberjunction/ng-trees':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../Generic/trees
       '@memberjunction/ng-ui-components':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../Generic/ui-components
       '@memberjunction/ng-user-routines':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../Generic/user-routines
       '@memberjunction/ng-versions':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../Generic/versions
       '@memberjunction/ng-word-cloud':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../Generic/word-cloud
       '@memberjunction/predictive-studio-core':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../../AI/PredictiveStudio/Core
       '@memberjunction/tag-engine-base':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../../AI/Knowledge/TagEngineBase
       '@memberjunction/templates-base-types':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../../Templates/base-types
       '@memberjunction/testing-engine-base':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../../TestingFramework/EngineBase
       '@memberjunction/theme-engine':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../../ThemeEngine
       ag-grid-angular:
         specifier: ^35.0.1
@@ -4671,7 +4671,7 @@ importers:
         specifier: 21.1.3
         version: 21.1.3(@angular/compiler@21.1.3)(typescript@5.9.3)
       '@memberjunction/ng-test-utils':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../Generic/test-utils
       '@types/d3':
         specifier: ^7.4.0
@@ -4692,25 +4692,25 @@ importers:
         specifier: 21.1.3
         version: 21.1.3(@angular/common@21.1.3(@angular/core@21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0))(rxjs@7.8.2))(@angular/core@21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0))(@angular/platform-browser@21.1.3(@angular/animations@21.1.3(@angular/core@21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0)))(@angular/common@21.1.3(@angular/core@21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0))(rxjs@7.8.2))(@angular/core@21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0)))(rxjs@7.8.2)
       '@memberjunction/core':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../../MJCore
       '@memberjunction/core-entities':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../../MJCoreEntities
       '@memberjunction/global':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../../MJGlobal
       '@memberjunction/ng-base-forms':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../Generic/base-forms
       '@memberjunction/ng-container-directives':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../Generic/container-directives
       '@memberjunction/ng-shared':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../shared
       '@memberjunction/ng-ui-components':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../Generic/ui-components
       tslib:
         specifier: ^2.8.1
@@ -4723,7 +4723,7 @@ importers:
         specifier: 21.1.3
         version: 21.1.3(@angular/compiler@21.1.3)(typescript@5.9.3)
       '@memberjunction/ng-test-utils':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../Generic/test-utils
 
   packages/Angular/Explorer/entity-permissions:
@@ -4738,25 +4738,25 @@ importers:
         specifier: 21.1.3
         version: 21.1.3(@angular/common@21.1.3(@angular/core@21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0))(rxjs@7.8.2))(@angular/core@21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0))(@angular/platform-browser@21.1.3(@angular/animations@21.1.3(@angular/core@21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0)))(@angular/common@21.1.3(@angular/core@21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0))(rxjs@7.8.2))(@angular/core@21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0)))(rxjs@7.8.2)
       '@memberjunction/core':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../../MJCore
       '@memberjunction/core-entities':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../../MJCoreEntities
       '@memberjunction/global':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../../MJGlobal
       '@memberjunction/ng-base-types':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../Generic/base-types
       '@memberjunction/ng-container-directives':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../Generic/container-directives
       '@memberjunction/ng-shared-generic':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../Generic/shared
       '@memberjunction/ng-ui-components':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../Generic/ui-components
       tslib:
         specifier: ^2.8.1
@@ -4769,7 +4769,7 @@ importers:
         specifier: 21.1.3
         version: 21.1.3(@angular/compiler@21.1.3)(typescript@5.9.3)
       '@memberjunction/ng-test-utils':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../Generic/test-utils
 
   packages/Angular/Explorer/explorer-app:
@@ -4778,52 +4778,52 @@ importers:
         specifier: ^21.0.0
         version: 21.1.3(@angular/common@21.1.3(@angular/core@21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0))(rxjs@7.8.2))(@angular/core@21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0))(@angular/platform-browser@21.1.3(@angular/animations@21.1.3(@angular/core@21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0)))(@angular/common@21.1.3(@angular/core@21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0))(rxjs@7.8.2))(@angular/core@21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0)))(rxjs@7.8.2)
       '@memberjunction/ai-agent-client':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../../AI/AgentsClient
       '@memberjunction/ai-core-plus':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../../AI/CorePlus
       '@memberjunction/core':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../../MJCore
       '@memberjunction/core-entities':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../../MJCoreEntities
       '@memberjunction/ng-agent-client':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../Generic/agent-client
       '@memberjunction/ng-auth-services':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../auth-services
       '@memberjunction/ng-base-application':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../base-application
       '@memberjunction/ng-base-types':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../Generic/base-types
       '@memberjunction/ng-bootstrap':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../Bootstrap/dist
       '@memberjunction/ng-conversations':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../Generic/conversations
       '@memberjunction/ng-explorer-core':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../explorer-core
       '@memberjunction/ng-explorer-service-worker':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../service-worker
       '@memberjunction/ng-feedback':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../Generic/feedback
       '@memberjunction/ng-notifications':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../Generic/notifications
       '@memberjunction/ng-shared':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../shared
       '@memberjunction/ng-workspace-initializer':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../workspace-initializer
       rxjs:
         specifier: ^7.8.2
@@ -4872,154 +4872,154 @@ importers:
         specifier: ^2.6.0
         version: 2.6.0(@angular/common@21.1.3(@angular/core@21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0))(rxjs@7.8.2))(@angular/core@21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0))(@angular/router@21.1.3(@angular/common@21.1.3(@angular/core@21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0))(rxjs@7.8.2))(@angular/core@21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0))(@angular/platform-browser@21.1.3(@angular/animations@21.1.3(@angular/core@21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0)))(@angular/common@21.1.3(@angular/core@21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0))(rxjs@7.8.2))(@angular/core@21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0)))(rxjs@7.8.2))
       '@memberjunction/ai-core-plus':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../../AI/CorePlus
       '@memberjunction/ai-engine-base':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../../AI/BaseAIEngine
       '@memberjunction/communication-types':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../../Communication/base-types
       '@memberjunction/core':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../../MJCore
       '@memberjunction/core-entities':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../../MJCoreEntities
       '@memberjunction/entity-communications-client':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../../Communication/entity-comm-client
       '@memberjunction/export-engine':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../../MJExportEngine
       '@memberjunction/global':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../../MJGlobal
       '@memberjunction/graphql-dataprovider':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../../GraphQLDataProvider
       '@memberjunction/interactive-component-types':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../../InteractiveComponents
       '@memberjunction/lists-base':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../../Lists/base
       '@memberjunction/ng-ai-test-harness':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../Generic/ai-test-harness
       '@memberjunction/ng-artifacts':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../Generic/artifacts
       '@memberjunction/ng-auth-services':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../auth-services
       '@memberjunction/ng-base-application':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../base-application
       '@memberjunction/ng-base-forms':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../Generic/base-forms
       '@memberjunction/ng-base-types':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../Generic/base-types
       '@memberjunction/ng-composer':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../Generic/composer
       '@memberjunction/ng-container-directives':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../Generic/container-directives
       '@memberjunction/ng-conversations':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../Generic/conversations
       '@memberjunction/ng-dashboard-viewer':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../Generic/dashboard-viewer
       '@memberjunction/ng-dashboards':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../dashboards
       '@memberjunction/ng-entity-form-dialog':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../entity-form-dialog
       '@memberjunction/ng-entity-permissions':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../entity-permissions
       '@memberjunction/ng-entity-viewer':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../Generic/entity-viewer
       '@memberjunction/ng-explorer-settings':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../explorer-settings
       '@memberjunction/ng-export-service':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../Generic/export-service
       '@memberjunction/ng-feedback':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../Generic/feedback
       '@memberjunction/ng-file-storage':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../Generic/file-storage
       '@memberjunction/ng-generic-dialog':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../Generic/generic-dialog
       '@memberjunction/ng-list-detail-grid':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../list-detail-grid
       '@memberjunction/ng-list-management':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../Generic/list-management
       '@memberjunction/ng-markdown':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../Generic/markdown
       '@memberjunction/ng-mj-livekit-room':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../Generic/mj-livekit-room
       '@memberjunction/ng-notifications':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../Generic/notifications
       '@memberjunction/ng-pagination':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../Generic/pagination
       '@memberjunction/ng-query-viewer':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../Generic/query-viewer
       '@memberjunction/ng-react':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../Generic/react
       '@memberjunction/ng-record-changes':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../Generic/record-changes
       '@memberjunction/ng-record-selector':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../Generic/record-selector
       '@memberjunction/ng-record-tags':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../Generic/record-tags
       '@memberjunction/ng-resource-permissions':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../Generic/resource-permissions
       '@memberjunction/ng-search':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../Generic/search
       '@memberjunction/ng-shared':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../shared
       '@memberjunction/ng-shared-generic':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../Generic/shared
       '@memberjunction/ng-ui-components':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../Generic/ui-components
       '@memberjunction/ng-user-avatar':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../Generic/user-avatar
       '@memberjunction/ng-word-cloud':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../Generic/word-cloud
       '@memberjunction/templates-base-types':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../../Templates/base-types
       '@memberjunction/theme-engine':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../../ThemeEngine
       golden-layout:
         specifier: ^2.6.0
@@ -5038,7 +5038,7 @@ importers:
         specifier: 21.1.3
         version: 21.1.3(@angular/compiler@21.1.3)(typescript@5.9.3)
       '@memberjunction/ng-test-utils':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../Generic/test-utils
       sass:
         specifier: ^1.97.3
@@ -5056,25 +5056,25 @@ importers:
         specifier: ^21.0.0
         version: 21.1.3(@angular/common@21.1.3(@angular/core@21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0))(rxjs@7.8.2))(@angular/core@21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0))(@angular/platform-browser@21.1.3(@angular/animations@21.1.3(@angular/core@21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0)))(@angular/common@21.1.3(@angular/core@21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0))(rxjs@7.8.2))(@angular/core@21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0)))(rxjs@7.8.2)
       '@memberjunction/ng-container-directives':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../Generic/container-directives
       '@memberjunction/ng-core-entity-forms':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../core-entity-forms
       '@memberjunction/ng-explorer-core':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../explorer-core
       '@memberjunction/ng-explorer-settings':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../explorer-settings
       '@memberjunction/ng-link-directives':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../link-directives
       '@memberjunction/ng-shared':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../shared
       '@memberjunction/ng-workspace-initializer':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../workspace-initializer
       tslib:
         specifier: ^2.8.1
@@ -5102,58 +5102,58 @@ importers:
         specifier: 21.1.3
         version: 21.1.3(@angular/common@21.1.3(@angular/core@21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0))(rxjs@7.8.2))(@angular/core@21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0))(@angular/platform-browser@21.1.3(@angular/animations@21.1.3(@angular/core@21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0)))(@angular/common@21.1.3(@angular/core@21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0))(rxjs@7.8.2))(@angular/core@21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0)))(rxjs@7.8.2)
       '@memberjunction/core':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../../MJCore
       '@memberjunction/core-entities':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../../MJCoreEntities
       '@memberjunction/global':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../../MJGlobal
       '@memberjunction/graphql-dataprovider':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../../GraphQLDataProvider
       '@memberjunction/ng-base-application':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../base-application
       '@memberjunction/ng-base-forms':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../Generic/base-forms
       '@memberjunction/ng-base-types':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../Generic/base-types
       '@memberjunction/ng-code-editor':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../Generic/code-editor
       '@memberjunction/ng-entity-form-dialog':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../entity-form-dialog
       '@memberjunction/ng-entity-permissions':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../entity-permissions
       '@memberjunction/ng-join-grid':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../Generic/join-grid
       '@memberjunction/ng-notifications':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../Generic/notifications
       '@memberjunction/ng-shared':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../shared
       '@memberjunction/ng-shared-generic':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../Generic/shared
       '@memberjunction/ng-simple-record-list':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../simple-record-list
       '@memberjunction/ng-tabstrip':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../Generic/tab-strip
       '@memberjunction/ng-ui-components':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../Generic/ui-components
       '@memberjunction/ng-user-avatar':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../Generic/user-avatar
       rxjs:
         specifier: ~7.8.2
@@ -5169,7 +5169,7 @@ importers:
         specifier: 21.1.3
         version: 21.1.3(@angular/compiler@21.1.3)(typescript@5.9.3)
       '@memberjunction/ng-test-utils':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../Generic/test-utils
 
   packages/Angular/Explorer/link-directives:
@@ -5181,13 +5181,13 @@ importers:
         specifier: 21.1.3
         version: 21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0)
       '@memberjunction/core':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../../MJCore
       '@memberjunction/ng-base-types':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../Generic/base-types
       '@memberjunction/ng-shared':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../shared
       tslib:
         specifier: ^2.8.1
@@ -5215,28 +5215,28 @@ importers:
         specifier: 21.1.3
         version: 21.1.3(@angular/common@21.1.3(@angular/core@21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0))(rxjs@7.8.2))(@angular/core@21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0))(@angular/platform-browser@21.1.3(@angular/animations@21.1.3(@angular/core@21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0)))(@angular/common@21.1.3(@angular/core@21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0))(rxjs@7.8.2))(@angular/core@21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0)))(rxjs@7.8.2)
       '@memberjunction/core':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../../MJCore
       '@memberjunction/core-entities':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../../MJCoreEntities
       '@memberjunction/global':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../../MJGlobal
       '@memberjunction/ng-base-types':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../Generic/base-types
       '@memberjunction/ng-entity-viewer':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../Generic/entity-viewer
       '@memberjunction/ng-shared':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../shared
       '@memberjunction/ng-shared-generic':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../Generic/shared
       '@memberjunction/ng-ui-components':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../Generic/ui-components
       rxjs:
         specifier: ~7.8.2
@@ -5252,7 +5252,7 @@ importers:
         specifier: 21.1.3
         version: 21.1.3(@angular/compiler@21.1.3)(typescript@5.9.3)
       '@memberjunction/ng-test-utils':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../Generic/test-utils
 
   packages/Angular/Explorer/service-worker:
@@ -5298,37 +5298,37 @@ importers:
         specifier: 21.1.3
         version: 21.1.3(@angular/common@21.1.3(@angular/core@21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0))(rxjs@7.8.2))(@angular/core@21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0))(@angular/platform-browser@21.1.3(@angular/animations@21.1.3(@angular/core@21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0)))(@angular/common@21.1.3(@angular/core@21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0))(rxjs@7.8.2))(@angular/core@21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0)))(rxjs@7.8.2)
       '@memberjunction/ai-core-plus':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../../AI/CorePlus
       '@memberjunction/ai-engine-base':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../../AI/BaseAIEngine
       '@memberjunction/core':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../../MJCore
       '@memberjunction/core-entities':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../../MJCoreEntities
       '@memberjunction/entity-communications-base':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../../Communication/entity-comm-base
       '@memberjunction/global':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../../MJGlobal
       '@memberjunction/graphql-dataprovider':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../../GraphQLDataProvider
       '@memberjunction/ng-base-application':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../base-application
       '@memberjunction/ng-base-types':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../Generic/base-types
       '@memberjunction/ng-notifications':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../Generic/notifications
       '@memberjunction/ng-shared-generic':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../Generic/shared
       html-to-image:
         specifier: ^1.11.11
@@ -5359,31 +5359,31 @@ importers:
         specifier: 21.1.3
         version: 21.1.3(@angular/common@21.1.3(@angular/core@21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0))(rxjs@7.8.2))(@angular/core@21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0))(@angular/platform-browser@21.1.3(@angular/animations@21.1.3(@angular/core@21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0)))(@angular/common@21.1.3(@angular/core@21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0))(rxjs@7.8.2))(@angular/core@21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0)))(rxjs@7.8.2)
       '@memberjunction/core':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../../MJCore
       '@memberjunction/core-entities':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../../MJCoreEntities
       '@memberjunction/global':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../../MJGlobal
       '@memberjunction/ng-base-types':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../Generic/base-types
       '@memberjunction/ng-container-directives':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../Generic/container-directives
       '@memberjunction/ng-entity-form-dialog':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../entity-form-dialog
       '@memberjunction/ng-notifications':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../Generic/notifications
       '@memberjunction/ng-shared-generic':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../Generic/shared
       '@memberjunction/ng-ui-components':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../Generic/ui-components
       tslib:
         specifier: ^2.8.1
@@ -5396,7 +5396,7 @@ importers:
         specifier: 21.1.3
         version: 21.1.3(@angular/compiler@21.1.3)(typescript@5.9.3)
       '@memberjunction/ng-test-utils':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../Generic/test-utils
 
   packages/Angular/Explorer/workspace-initializer:
@@ -5411,31 +5411,31 @@ importers:
         specifier: 21.1.3
         version: 21.1.3(@angular/common@21.1.3(@angular/core@21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0))(rxjs@7.8.2))(@angular/core@21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0))(@angular/platform-browser@21.1.3(@angular/animations@21.1.3(@angular/core@21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0)))(@angular/common@21.1.3(@angular/core@21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0))(rxjs@7.8.2))(@angular/core@21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0)))(rxjs@7.8.2)
       '@memberjunction/core':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../../MJCore
       '@memberjunction/core-entities':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../../MJCoreEntities
       '@memberjunction/global':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../../MJGlobal
       '@memberjunction/graphql-dataprovider':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../../GraphQLDataProvider
       '@memberjunction/ng-auth-services':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../auth-services
       '@memberjunction/ng-explorer-core':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../explorer-core
       '@memberjunction/ng-shared':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../shared
       '@memberjunction/ng-shared-generic':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../Generic/shared
       '@memberjunction/theme-engine':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../../ThemeEngine
       rxjs:
         specifier: ^7.8.2
@@ -5466,34 +5466,34 @@ importers:
         specifier: 21.1.3
         version: 21.1.3(@angular/animations@21.1.3(@angular/core@21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0)))(@angular/common@21.1.3(@angular/core@21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0))(rxjs@7.8.2))(@angular/core@21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0))
       '@memberjunction/core':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../../MJCore
       '@memberjunction/core-entities':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../../MJCoreEntities
       '@memberjunction/global':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../../MJGlobal
       '@memberjunction/graphql-dataprovider':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../../GraphQLDataProvider
       '@memberjunction/ng-base-types':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../base-types
       '@memberjunction/ng-code-editor':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../code-editor
       '@memberjunction/ng-container-directives':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../container-directives
       '@memberjunction/ng-notifications':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../notifications
       '@memberjunction/ng-ui-components':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../ui-components
       '@memberjunction/testing-engine-base':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../../TestingFramework/EngineBase
       rxjs:
         specifier: ^7.8.2
@@ -5509,7 +5509,7 @@ importers:
         specifier: 21.1.3
         version: 21.1.3(@angular/compiler@21.1.3)(typescript@5.9.3)
       '@memberjunction/ng-test-utils':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../test-utils
       vitest:
         specifier: ^4.0.18
@@ -5530,28 +5530,28 @@ importers:
         specifier: 21.1.3
         version: 21.1.3(@angular/common@21.1.3(@angular/core@21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0))(rxjs@7.8.2))(@angular/core@21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0))(@angular/platform-browser@21.1.3(@angular/animations@21.1.3(@angular/core@21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0)))(@angular/common@21.1.3(@angular/core@21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0))(rxjs@7.8.2))(@angular/core@21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0)))(rxjs@7.8.2)
       '@memberjunction/core':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../../MJCore
       '@memberjunction/core-entities':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../../MJCoreEntities
       '@memberjunction/global':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../../MJGlobal
       '@memberjunction/ng-ai-test-harness':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../ai-test-harness
       '@memberjunction/ng-base-types':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../base-types
       '@memberjunction/ng-container-directives':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../container-directives
       '@memberjunction/ng-shared-generic':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../shared
       '@memberjunction/ng-ui-components':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../ui-components
       rxjs:
         specifier: ^7.8.2
@@ -5567,7 +5567,7 @@ importers:
         specifier: 21.1.3
         version: 21.1.3(@angular/compiler@21.1.3)(typescript@5.9.3)
       '@memberjunction/ng-test-utils':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../test-utils
       sass:
         specifier: ^1.97.3
@@ -5591,22 +5591,22 @@ importers:
         specifier: 21.1.3
         version: 21.1.3(@angular/animations@21.1.3(@angular/core@21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0)))(@angular/common@21.1.3(@angular/core@21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0))(rxjs@7.8.2))(@angular/core@21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0))
       '@memberjunction/core':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../../MJCore
       '@memberjunction/core-entities':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../../MJCoreEntities
       '@memberjunction/global':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../../MJGlobal
       '@memberjunction/graphql-dataprovider':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../../GraphQLDataProvider
       '@memberjunction/ng-base-types':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../base-types
       '@memberjunction/ng-ui-components':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../ui-components
       rxjs:
         specifier: ^7.8.2
@@ -5622,10 +5622,10 @@ importers:
         specifier: 21.1.3
         version: 21.1.3(@angular/compiler@21.1.3)(typescript@5.9.3)
       '@memberjunction/actions-base':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../../Actions/Base
       '@memberjunction/ng-test-utils':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../test-utils
       vitest:
         specifier: ^4.0.18
@@ -5640,10 +5640,10 @@ importers:
         specifier: 21.1.3
         version: 21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0)
       '@memberjunction/ai-agent-client':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../../AI/AgentsClient
       '@memberjunction/global':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../../MJGlobal
       rxjs:
         specifier: ^7.8.2
@@ -5674,28 +5674,28 @@ importers:
         specifier: 21.1.3
         version: 21.1.3(@angular/common@21.1.3(@angular/core@21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0))(rxjs@7.8.2))(@angular/core@21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0))(@angular/platform-browser@21.1.3(@angular/animations@21.1.3(@angular/core@21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0)))(@angular/common@21.1.3(@angular/core@21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0))(rxjs@7.8.2))(@angular/core@21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0)))(rxjs@7.8.2)
       '@memberjunction/ai-core-plus':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../../AI/CorePlus
       '@memberjunction/core':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../../MJCore
       '@memberjunction/core-entities':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../../MJCoreEntities
       '@memberjunction/global':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../../MJGlobal
       '@memberjunction/ng-base-types':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../base-types
       '@memberjunction/ng-forms':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../forms
       '@memberjunction/ng-notifications':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../notifications
       '@memberjunction/ng-shared-generic':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../shared
       rxjs:
         specifier: ^7.8.2
@@ -5711,7 +5711,7 @@ importers:
         specifier: 21.1.3
         version: 21.1.3(@angular/compiler@21.1.3)(typescript@5.9.3)
       '@memberjunction/ng-test-utils':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../test-utils
       vitest:
         specifier: ^4.0.18
@@ -5738,25 +5738,25 @@ importers:
         specifier: 21.1.3
         version: 21.1.3(@angular/animations@21.1.3(@angular/core@21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0)))(@angular/common@21.1.3(@angular/core@21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0))(rxjs@7.8.2))(@angular/core@21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0))
       '@memberjunction/ai-core-plus':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../../AI/CorePlus
       '@memberjunction/ai-engine-base':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../../AI/BaseAIEngine
       '@memberjunction/core':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../../MJCore
       '@memberjunction/core-entities':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../../MJCoreEntities
       '@memberjunction/global':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../../MJGlobal
       '@memberjunction/ng-base-types':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../base-types
       '@memberjunction/ng-ui-components':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../ui-components
       rxjs:
         specifier: ^7.8.2
@@ -5772,7 +5772,7 @@ importers:
         specifier: 21.1.3
         version: 21.1.3(@angular/compiler@21.1.3)(typescript@5.9.3)
       '@memberjunction/ng-test-utils':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../test-utils
       sass:
         specifier: ^1.97.3
@@ -5799,43 +5799,43 @@ importers:
         specifier: 21.1.3
         version: 21.1.3(@angular/animations@21.1.3(@angular/core@21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0)))(@angular/common@21.1.3(@angular/core@21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0))(rxjs@7.8.2))(@angular/core@21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0))
       '@memberjunction/ai':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../../AI/Core
       '@memberjunction/ai-core-plus':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../../AI/CorePlus
       '@memberjunction/ai-engine-base':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../../AI/BaseAIEngine
       '@memberjunction/core':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../../MJCore
       '@memberjunction/core-entities':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../../MJCoreEntities
       '@memberjunction/global':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../../MJGlobal
       '@memberjunction/graphql-dataprovider':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../../GraphQLDataProvider
       '@memberjunction/ng-base-types':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../base-types
       '@memberjunction/ng-code-editor':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../code-editor
       '@memberjunction/ng-container-directives':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../container-directives
       '@memberjunction/ng-notifications':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../notifications
       '@memberjunction/ng-shared-generic':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../shared
       '@memberjunction/ng-ui-components':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../ui-components
       angular-split:
         specifier: ^20.0.0
@@ -5854,7 +5854,7 @@ importers:
         specifier: 21.1.3
         version: 21.1.3(@angular/compiler@21.1.3)(typescript@5.9.3)
       '@memberjunction/ng-test-utils':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../test-utils
       vitest:
         specifier: ^4.0.18
@@ -5872,22 +5872,22 @@ importers:
         specifier: 21.1.3
         version: 21.1.3(@angular/common@21.1.3(@angular/core@21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0))(rxjs@7.8.2))(@angular/core@21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0))(@angular/platform-browser@21.1.3(@angular/animations@21.1.3(@angular/core@21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0)))(@angular/common@21.1.3(@angular/core@21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0))(rxjs@7.8.2))(@angular/core@21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0)))(rxjs@7.8.2)
       '@memberjunction/core':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../../MJCore
       '@memberjunction/core-entities':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../../MJCoreEntities
       '@memberjunction/global':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../../MJGlobal
       '@memberjunction/ng-base-types':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../base-types
       '@memberjunction/ng-shared-generic':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../shared
       '@memberjunction/ng-ui-components':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../ui-components
       rxjs:
         specifier: ^7.8.2
@@ -5903,7 +5903,7 @@ importers:
         specifier: 21.1.3
         version: 21.1.3(@angular/compiler@21.1.3)(typescript@5.9.3)
       '@memberjunction/ng-test-utils':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../test-utils
       vitest:
         specifier: ^4.0.18
@@ -5930,58 +5930,58 @@ importers:
         specifier: 21.1.3
         version: 21.1.3(@angular/animations@21.1.3(@angular/core@21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0)))(@angular/common@21.1.3(@angular/core@21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0))(rxjs@7.8.2))(@angular/core@21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0))
       '@memberjunction/core':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../../MJCore
       '@memberjunction/core-entities':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../../MJCoreEntities
       '@memberjunction/global':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../../MJGlobal
       '@memberjunction/graphql-dataprovider':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../../GraphQLDataProvider
       '@memberjunction/interactive-component-types':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../../InteractiveComponents
       '@memberjunction/ng-base-forms':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../base-forms
       '@memberjunction/ng-base-types':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../base-types
       '@memberjunction/ng-code-editor':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../code-editor
       '@memberjunction/ng-export-service':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../export-service
       '@memberjunction/ng-markdown':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../markdown
       '@memberjunction/ng-media-player':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../media-player
       '@memberjunction/ng-notifications':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../notifications
       '@memberjunction/ng-pagination':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../pagination
       '@memberjunction/ng-query-viewer':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../query-viewer
       '@memberjunction/ng-react':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../react
       '@memberjunction/ng-shared-generic':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../shared
       '@memberjunction/ng-trees':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../trees
       '@memberjunction/ng-ui-components':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../ui-components
       ag-grid-angular:
         specifier: ^35.0.1
@@ -6012,7 +6012,7 @@ importers:
         specifier: 21.1.3
         version: 21.1.3(@angular/compiler@21.1.3)(typescript@5.9.3)
       '@memberjunction/ng-test-utils':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../test-utils
       sass:
         specifier: ^1.97.3
@@ -6036,49 +6036,49 @@ importers:
         specifier: 21.1.3
         version: 21.1.3(@angular/common@21.1.3(@angular/core@21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0))(rxjs@7.8.2))(@angular/core@21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0))(@angular/platform-browser@21.1.3(@angular/animations@21.1.3(@angular/core@21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0)))(@angular/common@21.1.3(@angular/core@21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0))(rxjs@7.8.2))(@angular/core@21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0)))(rxjs@7.8.2)
       '@memberjunction/core':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../../MJCore
       '@memberjunction/core-entities':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../../MJCoreEntities
       '@memberjunction/global':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../../MJGlobal
       '@memberjunction/interactive-component-types':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../../InteractiveComponents
       '@memberjunction/ng-base-types':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../base-types
       '@memberjunction/ng-code-editor':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../code-editor
       '@memberjunction/ng-entity-viewer':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../entity-viewer
       '@memberjunction/ng-list-management':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../list-management
       '@memberjunction/ng-markdown':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../markdown
       '@memberjunction/ng-notifications':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../notifications
       '@memberjunction/ng-react':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../react
       '@memberjunction/ng-record-changes':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../record-changes
       '@memberjunction/ng-record-tags':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../record-tags
       '@memberjunction/ng-shared-generic':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../shared
       '@memberjunction/ng-ui-components':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../ui-components
       primeng:
         specifier: 21.1.1
@@ -6097,7 +6097,7 @@ importers:
         specifier: 21.1.3
         version: 21.1.3(@angular/compiler@21.1.3)(typescript@5.9.3)
       '@memberjunction/ng-test-utils':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../test-utils
       vitest:
         specifier: ^4.0.18
@@ -6112,13 +6112,13 @@ importers:
         specifier: 21.1.3
         version: 21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0)
       '@memberjunction/core':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../../MJCore
       '@memberjunction/core-entities':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../../MJCoreEntities
       '@memberjunction/global':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../../MJGlobal
       tslib:
         specifier: ^2.8.1
@@ -6146,19 +6146,19 @@ importers:
         specifier: 21.1.3
         version: 21.1.3(@angular/common@21.1.3(@angular/core@21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0))(rxjs@7.8.2))(@angular/core@21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0))(@angular/platform-browser@21.1.3(@angular/animations@21.1.3(@angular/core@21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0)))(@angular/common@21.1.3(@angular/core@21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0))(rxjs@7.8.2))(@angular/core@21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0)))(rxjs@7.8.2)
       '@memberjunction/core':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../../MJCore
       '@memberjunction/ng-container-directives':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../container-directives
       '@memberjunction/ng-markdown':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../markdown
       '@memberjunction/ng-shared-generic':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../shared
       '@memberjunction/ng-ui-components':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../ui-components
       tslib:
         specifier: ^2.8.1
@@ -6171,7 +6171,7 @@ importers:
         specifier: 21.1.3
         version: 21.1.3(@angular/compiler@21.1.3)(typescript@5.9.3)
       '@memberjunction/ng-test-utils':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../test-utils
       vitest:
         specifier: ^4.0.18
@@ -6189,34 +6189,34 @@ importers:
         specifier: 21.1.3
         version: 21.1.3(@angular/common@21.1.3(@angular/core@21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0))(rxjs@7.8.2))(@angular/core@21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0))(@angular/platform-browser@21.1.3(@angular/animations@21.1.3(@angular/core@21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0)))(@angular/common@21.1.3(@angular/core@21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0))(rxjs@7.8.2))(@angular/core@21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0)))(rxjs@7.8.2)
       '@memberjunction/ai-engine-base':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../../AI/BaseAIEngine
       '@memberjunction/ai-vectors-memory':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../../AI/Vectors/Memory
       '@memberjunction/core':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../../MJCore
       '@memberjunction/core-entities':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../../MJCoreEntities
       '@memberjunction/global':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../../MJGlobal
       '@memberjunction/graphql-dataprovider':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../../GraphQLDataProvider
       '@memberjunction/ng-base-types':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../base-types
       '@memberjunction/ng-entity-card':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../entity-card
       '@memberjunction/ng-entity-viewer':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../entity-viewer
       '@memberjunction/ng-ui-components':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../ui-components
       rxjs:
         specifier: ^7.8.2
@@ -6235,7 +6235,7 @@ importers:
         specifier: 21.1.3
         version: 21.1.3(@angular/compiler@21.1.3)(typescript@5.9.3)
       '@memberjunction/ng-test-utils':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../test-utils
       vitest:
         specifier: ^4.0.18
@@ -6286,19 +6286,19 @@ importers:
         specifier: ^1.2.3
         version: 1.2.3
       '@memberjunction/core':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../../MJCore
       '@memberjunction/core-entities':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../../MJCoreEntities
       '@memberjunction/global':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../../MJGlobal
       '@memberjunction/ng-base-types':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../base-types
       '@memberjunction/ng-container-directives':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../container-directives
       codemirror:
         specifier: ^6.0.2
@@ -6314,7 +6314,7 @@ importers:
         specifier: 21.1.3
         version: 21.1.3(@angular/compiler@21.1.3)(typescript@5.9.3)
       '@memberjunction/ng-test-utils':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../test-utils
       sass:
         specifier: ^1.97.3
@@ -6335,13 +6335,13 @@ importers:
         specifier: 21.1.3
         version: 21.1.3(@angular/common@21.1.3(@angular/core@21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0))(rxjs@7.8.2))(@angular/core@21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0))(@angular/platform-browser@21.1.3(@angular/animations@21.1.3(@angular/core@21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0)))(@angular/common@21.1.3(@angular/core@21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0))(rxjs@7.8.2))(@angular/core@21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0)))(rxjs@7.8.2)
       '@memberjunction/core':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../../MJCore
       '@memberjunction/global':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../../MJGlobal
       '@memberjunction/ng-ui-components':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../ui-components
       tslib:
         specifier: ^2.8.1
@@ -6354,7 +6354,7 @@ importers:
         specifier: 21.1.3
         version: 21.1.3(@angular/compiler@21.1.3)(typescript@5.9.3)
       '@memberjunction/ng-test-utils':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../test-utils
       vitest:
         specifier: ^4.0.18
@@ -6369,10 +6369,10 @@ importers:
         specifier: 21.1.3
         version: 21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0)
       '@memberjunction/core':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../../MJCore
       '@memberjunction/global':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../../MJGlobal
       rxjs:
         specifier: ~7.8.2
@@ -6412,88 +6412,88 @@ importers:
         specifier: 21.1.3
         version: 21.1.3(@angular/animations@21.1.3(@angular/core@21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0)))(@angular/common@21.1.3(@angular/core@21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0))(rxjs@7.8.2))(@angular/core@21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0))
       '@memberjunction/ai':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../../AI/Core
       '@memberjunction/ai-agent-client':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../../AI/AgentsClient
       '@memberjunction/ai-core-plus':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../../AI/CorePlus
       '@memberjunction/ai-engine-base':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../../AI/BaseAIEngine
       '@memberjunction/ai-realtime-client':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../../AI/RealtimeClient
       '@memberjunction/conversations-runtime':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../../ConversationsRuntime
       '@memberjunction/core':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../../MJCore
       '@memberjunction/core-entities':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../../MJCoreEntities
       '@memberjunction/global':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../../MJGlobal
       '@memberjunction/graphql-dataprovider':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../../GraphQLDataProvider
       '@memberjunction/interactive-component-types':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../../InteractiveComponents
       '@memberjunction/ng-agent-client':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../agent-client
       '@memberjunction/ng-artifacts':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../artifacts
       '@memberjunction/ng-base-types':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../base-types
       '@memberjunction/ng-code-editor':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../code-editor
       '@memberjunction/ng-composer':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../composer
       '@memberjunction/ng-container-directives':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../container-directives
       '@memberjunction/ng-forms':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../forms
       '@memberjunction/ng-markdown':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../markdown
       '@memberjunction/ng-media-player':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../media-player
       '@memberjunction/ng-notifications':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../notifications
       '@memberjunction/ng-resource-permissions':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../resource-permissions
       '@memberjunction/ng-shared-generic':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../shared
       '@memberjunction/ng-tasks':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../tasks
       '@memberjunction/ng-testing':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../Testing
       '@memberjunction/ng-ui-components':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../ui-components
       '@memberjunction/ng-user-routines':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../user-routines
       '@memberjunction/ng-whiteboard':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../whiteboard
       angular-split:
         specifier: ^20.0.0
@@ -6512,7 +6512,7 @@ importers:
         specifier: 21.1.3
         version: 21.1.3(@angular/compiler@21.1.3)(typescript@5.9.3)
       '@memberjunction/ng-test-utils':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../test-utils
       sass:
         specifier: ^1.97.3
@@ -6533,25 +6533,25 @@ importers:
         specifier: 21.1.3
         version: 21.1.3(@angular/common@21.1.3(@angular/core@21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0))(rxjs@7.8.2))(@angular/core@21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0))(@angular/platform-browser@21.1.3(@angular/animations@21.1.3(@angular/core@21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0)))(@angular/common@21.1.3(@angular/core@21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0))(rxjs@7.8.2))(@angular/core@21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0)))(rxjs@7.8.2)
       '@memberjunction/core':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../../MJCore
       '@memberjunction/core-entities':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../../MJCoreEntities
       '@memberjunction/global':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../../MJGlobal
       '@memberjunction/ng-base-types':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../base-types
       '@memberjunction/ng-notifications':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../notifications
       '@memberjunction/ng-shared-generic':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../shared
       '@memberjunction/ng-ui-components':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../ui-components
       rxjs:
         specifier: ^7.8.2
@@ -6567,7 +6567,7 @@ importers:
         specifier: 21.1.3
         version: 21.1.3(@angular/compiler@21.1.3)(typescript@5.9.3)
       '@memberjunction/ng-test-utils':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../test-utils
       vitest:
         specifier: ^4.0.18
@@ -6591,37 +6591,37 @@ importers:
         specifier: 21.1.3
         version: 21.1.3(@angular/animations@21.1.3(@angular/core@21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0)))(@angular/common@21.1.3(@angular/core@21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0))(rxjs@7.8.2))(@angular/core@21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0))
       '@memberjunction/core':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../../MJCore
       '@memberjunction/core-entities':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../../MJCoreEntities
       '@memberjunction/global':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../../MJGlobal
       '@memberjunction/ng-artifacts':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../artifacts
       '@memberjunction/ng-base-types':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../base-types
       '@memberjunction/ng-entity-viewer':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../entity-viewer
       '@memberjunction/ng-map-view':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../ng-map-view
       '@memberjunction/ng-query-viewer':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../query-viewer
       '@memberjunction/ng-shared-generic':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../shared
       '@memberjunction/ng-trees':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../trees
       '@memberjunction/ng-ui-components':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../ui-components
       golden-layout:
         specifier: ^2.6.0
@@ -6640,7 +6640,7 @@ importers:
         specifier: 21.1.3
         version: 21.1.3(@angular/compiler@21.1.3)(typescript@5.9.3)
       '@memberjunction/ng-test-utils':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../test-utils
       vitest:
         specifier: ^4.0.18
@@ -6658,25 +6658,25 @@ importers:
         specifier: 21.1.3
         version: 21.1.3(@angular/common@21.1.3(@angular/core@21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0))(rxjs@7.8.2))(@angular/core@21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0))(@angular/platform-browser@21.1.3(@angular/animations@21.1.3(@angular/core@21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0)))(@angular/common@21.1.3(@angular/core@21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0))(rxjs@7.8.2))(@angular/core@21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0)))(rxjs@7.8.2)
       '@memberjunction/core':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../../MJCore
       '@memberjunction/core-entities':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../../MJCoreEntities
       '@memberjunction/global':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../../MJGlobal
       '@memberjunction/ng-base-types':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../base-types
       '@memberjunction/ng-container-directives':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../container-directives
       '@memberjunction/ng-shared-generic':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../shared
       '@memberjunction/ng-ui-components':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../ui-components
       tslib:
         specifier: ^2.8.1
@@ -6689,7 +6689,7 @@ importers:
         specifier: 21.1.3
         version: 21.1.3(@angular/compiler@21.1.3)(typescript@5.9.3)
       '@memberjunction/ng-test-utils':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../test-utils
       vitest:
         specifier: ^4.0.18
@@ -6707,13 +6707,13 @@ importers:
         specifier: 21.1.3
         version: 21.1.3(@angular/common@21.1.3(@angular/core@21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0))(rxjs@7.8.2))(@angular/core@21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0))(@angular/platform-browser@21.1.3(@angular/animations@21.1.3(@angular/core@21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0)))(@angular/common@21.1.3(@angular/core@21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0))(rxjs@7.8.2))(@angular/core@21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0)))(rxjs@7.8.2)
       '@memberjunction/core':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../../MJCore
       '@memberjunction/global':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../../MJGlobal
       '@memberjunction/ng-ui-components':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../ui-components
       tslib:
         specifier: ^2.8.1
@@ -6726,7 +6726,7 @@ importers:
         specifier: 21.1.3
         version: 21.1.3(@angular/compiler@21.1.3)(typescript@5.9.3)
       '@memberjunction/ng-test-utils':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../test-utils
       vitest:
         specifier: ^4.0.18
@@ -6744,25 +6744,25 @@ importers:
         specifier: 21.1.3
         version: 21.1.3(@angular/common@21.1.3(@angular/core@21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0))(rxjs@7.8.2))(@angular/core@21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0))(@angular/platform-browser@21.1.3(@angular/animations@21.1.3(@angular/core@21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0)))(@angular/common@21.1.3(@angular/core@21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0))(rxjs@7.8.2))(@angular/core@21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0)))(rxjs@7.8.2)
       '@memberjunction/core':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../../MJCore
       '@memberjunction/core-entities':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../../MJCoreEntities
       '@memberjunction/global':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../../MJGlobal
       '@memberjunction/graphql-dataprovider':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../../GraphQLDataProvider
       '@memberjunction/ng-base-types':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../base-types
       '@memberjunction/ng-ui-components':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../ui-components
       '@memberjunction/record-set-processor-base':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../../RecordSetProcessor/base
       rxjs:
         specifier: ^7.8.2
@@ -6778,7 +6778,7 @@ importers:
         specifier: 21.1.3
         version: 21.1.3(@angular/compiler@21.1.3)(typescript@5.9.3)
       '@memberjunction/ng-test-utils':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../test-utils
       rimraf:
         specifier: ^5.0.10
@@ -6796,13 +6796,13 @@ importers:
         specifier: 21.1.3
         version: 21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0)
       '@memberjunction/core':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../../MJCore
       '@memberjunction/global':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../../MJGlobal
       '@memberjunction/ng-base-types':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../base-types
       tslib:
         specifier: ^2.8.1
@@ -6815,7 +6815,7 @@ importers:
         specifier: 21.1.3
         version: 21.1.3(@angular/compiler@21.1.3)(typescript@5.9.3)
       '@memberjunction/ng-test-utils':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../test-utils
       vitest:
         specifier: ^4.0.18
@@ -6833,37 +6833,37 @@ importers:
         specifier: 21.1.3
         version: 21.1.3(@angular/common@21.1.3(@angular/core@21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0))(rxjs@7.8.2))(@angular/core@21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0))(@angular/platform-browser@21.1.3(@angular/animations@21.1.3(@angular/core@21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0)))(@angular/common@21.1.3(@angular/core@21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0))(rxjs@7.8.2))(@angular/core@21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0)))(rxjs@7.8.2)
       '@memberjunction/communication-types':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../../Communication/base-types
       '@memberjunction/core':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../../MJCore
       '@memberjunction/core-entities':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../../MJCoreEntities
       '@memberjunction/entity-communications-base':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../../Communication/entity-comm-base
       '@memberjunction/entity-communications-client':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../../Communication/entity-comm-client
       '@memberjunction/global':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../../MJGlobal
       '@memberjunction/ng-base-types':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../base-types
       '@memberjunction/ng-container-directives':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../container-directives
       '@memberjunction/ng-shared-generic':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../shared
       '@memberjunction/ng-ui-components':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../ui-components
       '@memberjunction/templates-base-types':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../../Templates/base-types
       tslib:
         specifier: ^2.8.1
@@ -6876,7 +6876,7 @@ importers:
         specifier: 21.1.3
         version: 21.1.3(@angular/compiler@21.1.3)(typescript@5.9.3)
       '@memberjunction/ng-test-utils':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../test-utils
       vitest:
         specifier: ^4.0.18
@@ -6900,16 +6900,16 @@ importers:
         specifier: ^1.1.8
         version: 1.1.8
       '@memberjunction/core':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../../MJCore
       '@memberjunction/global':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../../MJGlobal
       '@memberjunction/ng-base-types':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../base-types
       '@memberjunction/ng-ui-components':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../ui-components
       '@types/d3':
         specifier: ^7.4.3
@@ -6934,7 +6934,7 @@ importers:
         specifier: 21.1.3
         version: 21.1.3(@angular/compiler@21.1.3)(typescript@5.9.3)
       '@memberjunction/ng-test-utils':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../test-utils
       sass:
         specifier: ^1.97.3
@@ -6958,55 +6958,55 @@ importers:
         specifier: 21.1.3
         version: 21.1.3(@angular/common@21.1.3(@angular/core@21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0))(rxjs@7.8.2))(@angular/core@21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0))(@angular/platform-browser@21.1.3(@angular/animations@21.1.3(@angular/core@21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0)))(@angular/common@21.1.3(@angular/core@21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0))(rxjs@7.8.2))(@angular/core@21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0)))(rxjs@7.8.2)
       '@memberjunction/actions-base':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../../Actions/Base
       '@memberjunction/core':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../../MJCore
       '@memberjunction/core-entities':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../../MJCoreEntities
       '@memberjunction/export-engine':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../../MJExportEngine
       '@memberjunction/global':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../../MJGlobal
       '@memberjunction/ng-base-types':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../base-types
       '@memberjunction/ng-entity-action-ux':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../entity-action-ux
       '@memberjunction/ng-export-service':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../export-service
       '@memberjunction/ng-filter-builder':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../filter-builder
       '@memberjunction/ng-list-management':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../list-management
       '@memberjunction/ng-map-view':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../ng-map-view
       '@memberjunction/ng-notifications':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../notifications
       '@memberjunction/ng-pagination':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../pagination
       '@memberjunction/ng-record-changes':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../record-changes
       '@memberjunction/ng-shared-generic':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../shared
       '@memberjunction/ng-timeline':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../timeline
       '@memberjunction/ng-ui-components':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../ui-components
       ag-grid-angular:
         specifier: ^35.0.1
@@ -7028,7 +7028,7 @@ importers:
         specifier: 21.1.3
         version: 21.1.3(@angular/compiler@21.1.3)(typescript@5.9.3)
       '@memberjunction/ng-test-utils':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../test-utils
       vitest:
         specifier: ^4.0.18
@@ -7049,7 +7049,7 @@ importers:
         specifier: 21.1.3
         version: 21.1.3(@angular/common@21.1.3(@angular/core@21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0))(rxjs@7.8.2))(@angular/core@21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0))(@angular/platform-browser@21.1.3(@angular/animations@21.1.3(@angular/core@21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0)))(@angular/common@21.1.3(@angular/core@21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0))(rxjs@7.8.2))(@angular/core@21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0)))(rxjs@7.8.2)
       '@memberjunction/export-engine':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../../MJExportEngine
       tslib:
         specifier: ^2.8.1
@@ -7062,7 +7062,7 @@ importers:
         specifier: 21.1.3
         version: 21.1.3(@angular/compiler@21.1.3)(typescript@5.9.3)
       '@memberjunction/ng-test-utils':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../test-utils
       vitest:
         specifier: ^4.0.18
@@ -7080,19 +7080,19 @@ importers:
         specifier: 21.1.3
         version: 21.1.3(@angular/common@21.1.3(@angular/core@21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0))(rxjs@7.8.2))(@angular/core@21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0))(@angular/platform-browser@21.1.3(@angular/animations@21.1.3(@angular/core@21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0)))(@angular/common@21.1.3(@angular/core@21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0))(rxjs@7.8.2))(@angular/core@21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0)))(rxjs@7.8.2)
       '@memberjunction/core':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../../MJCore
       '@memberjunction/graphql-dataprovider':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../../GraphQLDataProvider
       '@memberjunction/ng-base-types':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../base-types
       '@memberjunction/ng-shared-generic':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../shared
       '@memberjunction/ng-ui-components':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../ui-components
       rxjs:
         specifier: ~7.8.2
@@ -7108,7 +7108,7 @@ importers:
         specifier: 21.1.3
         version: 21.1.3(@angular/compiler@21.1.3)(typescript@5.9.3)
       '@memberjunction/ng-test-utils':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../test-utils
       vitest:
         specifier: ^4.0.18
@@ -7129,34 +7129,34 @@ importers:
         specifier: 21.1.3
         version: 21.1.3(@angular/animations@21.1.3(@angular/core@21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0)))(@angular/common@21.1.3(@angular/core@21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0))(rxjs@7.8.2))(@angular/core@21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0))
       '@memberjunction/core':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../../MJCore
       '@memberjunction/core-entities':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../../MJCoreEntities
       '@memberjunction/global':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../../MJGlobal
       '@memberjunction/graphql-dataprovider':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../../GraphQLDataProvider
       '@memberjunction/ng-base-types':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../base-types
       '@memberjunction/ng-container-directives':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../container-directives
       '@memberjunction/ng-notifications':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../notifications
       '@memberjunction/ng-shared':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../Explorer/shared
       '@memberjunction/ng-shared-generic':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../shared
       '@memberjunction/ng-ui-components':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../ui-components
       ag-grid-angular:
         specifier: ^35.0.1
@@ -7178,7 +7178,7 @@ importers:
         specifier: 21.1.3
         version: 21.1.3(@angular/compiler@21.1.3)(typescript@5.9.3)
       '@memberjunction/ng-test-utils':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../test-utils
       vitest:
         specifier: ^4.0.18
@@ -7199,10 +7199,10 @@ importers:
         specifier: 21.1.3
         version: 21.1.3(@angular/animations@21.1.3(@angular/core@21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0)))(@angular/common@21.1.3(@angular/core@21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0))(rxjs@7.8.2))(@angular/core@21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0))
       '@memberjunction/core':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../../MJCore
       '@memberjunction/ng-ui-components':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../ui-components
       rxjs:
         specifier: ^7.8.2
@@ -7233,25 +7233,25 @@ importers:
         specifier: 21.1.3
         version: 21.1.3(@angular/common@21.1.3(@angular/core@21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0))(rxjs@7.8.2))(@angular/core@21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0))(@angular/platform-browser@21.1.3(@angular/animations@21.1.3(@angular/core@21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0)))(@angular/common@21.1.3(@angular/core@21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0))(rxjs@7.8.2))(@angular/core@21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0)))(rxjs@7.8.2)
       '@memberjunction/core':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../../MJCore
       '@memberjunction/core-entities':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../../MJCoreEntities
       '@memberjunction/global':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../../MJGlobal
       '@memberjunction/ng-base-types':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../base-types
       '@memberjunction/ng-container-directives':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../container-directives
       '@memberjunction/ng-shared-generic':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../shared
       '@memberjunction/ng-ui-components':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../ui-components
       ag-grid-angular:
         specifier: ^35.0.1
@@ -7273,7 +7273,7 @@ importers:
         specifier: 21.1.3
         version: 21.1.3(@angular/compiler@21.1.3)(typescript@5.9.3)
       '@memberjunction/ng-test-utils':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../test-utils
       vitest:
         specifier: ^4.0.18
@@ -7312,22 +7312,22 @@ importers:
         specifier: 1.1.1
         version: 1.1.1
       '@memberjunction/core':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../../MJCore
       '@memberjunction/core-entities':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../../MJCoreEntities
       '@memberjunction/global':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../../MJGlobal
       '@memberjunction/ng-base-types':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../base-types
       '@memberjunction/ng-code-editor':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../code-editor
       '@memberjunction/ng-ui-components':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../ui-components
       rxjs:
         specifier: ^7.8.2
@@ -7343,7 +7343,7 @@ importers:
         specifier: 21.1.3
         version: 21.1.3(@angular/compiler@21.1.3)(typescript@5.9.3)
       '@memberjunction/ng-test-utils':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../test-utils
       sass:
         specifier: ^1.97.3
@@ -7364,13 +7364,13 @@ importers:
         specifier: 21.1.3
         version: 21.1.3(@angular/common@21.1.3(@angular/core@21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0))(rxjs@7.8.2))(@angular/core@21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0))(@angular/platform-browser@21.1.3(@angular/animations@21.1.3(@angular/core@21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0)))(@angular/common@21.1.3(@angular/core@21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0))(rxjs@7.8.2))(@angular/core@21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0)))(rxjs@7.8.2)
       '@memberjunction/ai-core-plus':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../../AI/CorePlus
       '@memberjunction/ng-markdown':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../markdown
       '@memberjunction/ng-ui-components':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../ui-components
       tslib:
         specifier: ^2.8.1
@@ -7383,7 +7383,7 @@ importers:
         specifier: 21.1.3
         version: 21.1.3(@angular/compiler@21.1.3)(typescript@5.9.3)
       '@memberjunction/ng-test-utils':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../test-utils
       vitest:
         specifier: ^4.0.18
@@ -7398,7 +7398,7 @@ importers:
         specifier: 21.1.3
         version: 21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0)
       '@memberjunction/global':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../../MJGlobal
       dhtmlx-gantt:
         specifier: ^9.1.1
@@ -7414,7 +7414,7 @@ importers:
         specifier: 21.1.3
         version: 21.1.3(@angular/compiler@21.1.3)(typescript@5.9.3)
       '@memberjunction/ng-test-utils':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../test-utils
       vitest:
         specifier: ^4.0.18
@@ -7429,7 +7429,7 @@ importers:
         specifier: 21.1.3
         version: 21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0)
       '@memberjunction/ng-ui-components':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../ui-components
       tslib:
         specifier: ^2.8.1
@@ -7442,7 +7442,7 @@ importers:
         specifier: 21.1.3
         version: 21.1.3(@angular/compiler@21.1.3)(typescript@5.9.3)
       '@memberjunction/ng-test-utils':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../test-utils
       vitest:
         specifier: ^4.0.18
@@ -7460,28 +7460,28 @@ importers:
         specifier: 21.1.3
         version: 21.1.3(@angular/common@21.1.3(@angular/core@21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0))(rxjs@7.8.2))(@angular/core@21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0))(@angular/platform-browser@21.1.3(@angular/animations@21.1.3(@angular/core@21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0)))(@angular/common@21.1.3(@angular/core@21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0))(rxjs@7.8.2))(@angular/core@21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0)))(rxjs@7.8.2)
       '@memberjunction/core':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../../MJCore
       '@memberjunction/core-entities':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../../MJCoreEntities
       '@memberjunction/global':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../../MJGlobal
       '@memberjunction/ng-base-types':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../base-types
       '@memberjunction/ng-container-directives':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../container-directives
       '@memberjunction/ng-notifications':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../notifications
       '@memberjunction/ng-shared-generic':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../shared
       '@memberjunction/ng-ui-components':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../ui-components
       tslib:
         specifier: ^2.8.1
@@ -7494,7 +7494,7 @@ importers:
         specifier: 21.1.3
         version: 21.1.3(@angular/compiler@21.1.3)(typescript@5.9.3)
       '@memberjunction/ng-test-utils':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../test-utils
       vitest:
         specifier: ^4.0.18
@@ -7509,7 +7509,7 @@ importers:
         specifier: 21.1.3
         version: 21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0)
       '@memberjunction/global':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../../MJGlobal
       tslib:
         specifier: ^2.8.1
@@ -7522,7 +7522,7 @@ importers:
         specifier: 21.1.3
         version: 21.1.3(@angular/compiler@21.1.3)(typescript@5.9.3)
       '@memberjunction/ng-test-utils':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../test-utils
       vitest:
         specifier: ^4.0.18
@@ -7540,31 +7540,31 @@ importers:
         specifier: 21.1.3
         version: 21.1.3(@angular/common@21.1.3(@angular/core@21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0))(rxjs@7.8.2))(@angular/core@21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0))(@angular/platform-browser@21.1.3(@angular/animations@21.1.3(@angular/core@21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0)))(@angular/common@21.1.3(@angular/core@21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0))(rxjs@7.8.2))(@angular/core@21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0)))(rxjs@7.8.2)
       '@memberjunction/core':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../../MJCore
       '@memberjunction/core-entities':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../../MJCoreEntities
       '@memberjunction/global':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../../MJGlobal
       '@memberjunction/graphql-dataprovider':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../../GraphQLDataProvider
       '@memberjunction/lists-base':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../../Lists/base
       '@memberjunction/ng-base-types':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../base-types
       '@memberjunction/ng-container-directives':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../container-directives
       '@memberjunction/ng-shared-generic':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../shared
       '@memberjunction/ng-ui-components':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../ui-components
       rxjs:
         specifier: ^7.8.2
@@ -7580,7 +7580,7 @@ importers:
         specifier: 21.1.3
         version: 21.1.3(@angular/compiler@21.1.3)(typescript@5.9.3)
       '@memberjunction/ng-test-utils':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../test-utils
       vitest:
         specifier: ^4.0.18
@@ -7598,13 +7598,13 @@ importers:
         specifier: 21.1.3
         version: 21.1.3(@angular/common@21.1.3(@angular/core@21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0))(rxjs@7.8.2))(@angular/core@21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0))(@angular/platform-browser@21.1.3(@angular/animations@21.1.3(@angular/core@21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0)))(@angular/common@21.1.3(@angular/core@21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0))(rxjs@7.8.2))(@angular/core@21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0)))(rxjs@7.8.2)
       '@memberjunction/livekit-room-core':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../../LiveKitRoomCore
       '@memberjunction/ng-ui-components':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../ui-components
       '@memberjunction/ng-whiteboard':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../whiteboard
       livekit-client:
         specifier: ^2.7.4
@@ -7623,7 +7623,7 @@ importers:
         specifier: 21.1.3
         version: 21.1.3(@angular/compiler@21.1.3)(typescript@5.9.3)
       '@memberjunction/ng-test-utils':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../test-utils
       vitest:
         specifier: ^4.0.18
@@ -7641,7 +7641,7 @@ importers:
         specifier: 21.1.3
         version: 21.1.3(@angular/animations@21.1.3(@angular/core@21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0)))(@angular/common@21.1.3(@angular/core@21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0))(rxjs@7.8.2))(@angular/core@21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0))
       '@memberjunction/markdown-core':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../../MarkdownCore
       mermaid:
         specifier: ^11.12.2
@@ -7660,7 +7660,7 @@ importers:
         specifier: 21.1.3
         version: 21.1.3(@angular/compiler@21.1.3)(typescript@5.9.3)
       '@memberjunction/ng-test-utils':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../test-utils
       jsdom:
         specifier: 26.1.0
@@ -7678,13 +7678,13 @@ importers:
         specifier: 21.1.3
         version: 21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0)
       '@memberjunction/core':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../../MJCore
       '@memberjunction/graphql-dataprovider':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../../GraphQLDataProvider
       '@memberjunction/ng-base-types':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../base-types
       tslib:
         specifier: ^2.8.1
@@ -7697,7 +7697,7 @@ importers:
         specifier: 21.1.3
         version: 21.1.3(@angular/compiler@21.1.3)(typescript@5.9.3)
       '@memberjunction/ng-test-utils':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../test-utils
       vitest:
         specifier: ^4.0.18
@@ -7712,25 +7712,25 @@ importers:
         specifier: 21.1.3
         version: 21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0)
       '@memberjunction/core':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../../MJCore
       '@memberjunction/global':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../../MJGlobal
       '@memberjunction/graphql-dataprovider':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../../GraphQLDataProvider
       '@memberjunction/livekit-room-core':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../../LiveKitRoomCore
       '@memberjunction/ng-base-types':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../base-types
       '@memberjunction/ng-livekit-room':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../livekit-room
       '@memberjunction/ng-media-player':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../media-player
       rxjs:
         specifier: ^7.8.2
@@ -7758,19 +7758,19 @@ importers:
         specifier: 21.1.3
         version: 21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0)
       '@memberjunction/core':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../../MJCore
       '@memberjunction/core-entities':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../../MJCoreEntities
       '@memberjunction/geo-maps':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../../geo/geo-maps
       '@memberjunction/global':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../../MJGlobal
       '@memberjunction/ng-shared-generic':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../shared
       '@types/leaflet':
         specifier: ^1.9.17
@@ -7792,7 +7792,7 @@ importers:
         specifier: 21.1.3
         version: 21.1.3(@angular/compiler@21.1.3)(typescript@5.9.3)
       '@memberjunction/ng-test-utils':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../test-utils
       vitest:
         specifier: ^4.0.18
@@ -7807,19 +7807,19 @@ importers:
         specifier: 21.1.3
         version: 21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0)
       '@memberjunction/core':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../../MJCore
       '@memberjunction/core-entities':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../../MJCoreEntities
       '@memberjunction/global':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../../MJGlobal
       '@memberjunction/graphql-dataprovider':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../../GraphQLDataProvider
       '@memberjunction/ng-base-types':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../base-types
       rxjs:
         specifier: ^7.8.2
@@ -7875,40 +7875,40 @@ importers:
         specifier: 21.1.3
         version: 21.1.3(@angular/common@21.1.3(@angular/core@21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0))(rxjs@7.8.2))(@angular/core@21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0))(@angular/platform-browser@21.1.3(@angular/animations@21.1.3(@angular/core@21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0)))(@angular/common@21.1.3(@angular/core@21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0))(rxjs@7.8.2))(@angular/core@21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0)))(rxjs@7.8.2)
       '@memberjunction/core':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../../MJCore
       '@memberjunction/core-entities':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../../MJCoreEntities
       '@memberjunction/export-engine':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../../MJExportEngine
       '@memberjunction/global':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../../MJGlobal
       '@memberjunction/ng-base-types':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../base-types
       '@memberjunction/ng-code-editor':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../code-editor
       '@memberjunction/ng-export-service':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../export-service
       '@memberjunction/ng-markdown':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../markdown
       '@memberjunction/ng-notifications':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../notifications
       '@memberjunction/ng-pagination':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../pagination
       '@memberjunction/ng-shared-generic':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../shared
       '@memberjunction/ng-ui-components':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../ui-components
       ag-grid-angular:
         specifier: ^35.0.1
@@ -7930,7 +7930,7 @@ importers:
         specifier: 21.1.3
         version: 21.1.3(@angular/compiler@21.1.3)(typescript@5.9.3)
       '@memberjunction/ng-test-utils':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../test-utils
       vitest:
         specifier: ^4.0.18
@@ -7951,31 +7951,31 @@ importers:
         specifier: ^7.29.1
         version: 7.29.1
       '@memberjunction/ai-vectors-memory':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../../AI/Vectors/Memory
       '@memberjunction/core':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../../MJCore
       '@memberjunction/core-entities':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../../MJCoreEntities
       '@memberjunction/global':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../../MJGlobal
       '@memberjunction/graphql-dataprovider':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../../GraphQLDataProvider
       '@memberjunction/interactive-component-types':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../../InteractiveComponents
       '@memberjunction/ng-base-types':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../base-types
       '@memberjunction/ng-notifications':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../notifications
       '@memberjunction/react-runtime':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../../React/runtime
       '@types/react':
         specifier: ^19.2.13
@@ -8021,28 +8021,28 @@ importers:
         specifier: 21.1.3
         version: 21.1.3(@angular/animations@21.1.3(@angular/core@21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0)))(@angular/common@21.1.3(@angular/core@21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0))(rxjs@7.8.2))(@angular/core@21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0))
       '@memberjunction/core':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../../MJCore
       '@memberjunction/core-entities':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../../MJCoreEntities
       '@memberjunction/global':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../../MJGlobal
       '@memberjunction/ng-base-types':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../base-types
       '@memberjunction/ng-notifications':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../notifications
       '@memberjunction/ng-shared-generic':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../shared
       '@memberjunction/ng-ui-components':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../ui-components
       '@memberjunction/ng-versions':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../versions
       diff:
         specifier: 8.0.3
@@ -8061,7 +8061,7 @@ importers:
         specifier: 21.1.3
         version: 21.1.3(@angular/compiler@21.1.3)(typescript@5.9.3)
       '@memberjunction/ng-test-utils':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../test-utils
       '@types/diff':
         specifier: ^5.2.3
@@ -8079,19 +8079,19 @@ importers:
         specifier: 21.1.3
         version: 21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0)
       '@memberjunction/core':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../../MJCore
       '@memberjunction/core-entities':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../../MJCoreEntities
       '@memberjunction/global':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../../MJGlobal
       '@memberjunction/ng-shared-generic':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../shared
       '@memberjunction/ng-ui-components':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../ui-components
       rxjs:
         specifier: ^7.8.2
@@ -8107,7 +8107,7 @@ importers:
         specifier: 21.1.3
         version: 21.1.3(@angular/compiler@21.1.3)(typescript@5.9.3)
       '@memberjunction/ng-test-utils':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../test-utils
       vitest:
         specifier: ^4.0.18
@@ -8125,25 +8125,25 @@ importers:
         specifier: 21.1.3
         version: 21.1.3(@angular/common@21.1.3(@angular/core@21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0))(rxjs@7.8.2))(@angular/core@21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0))(@angular/platform-browser@21.1.3(@angular/animations@21.1.3(@angular/core@21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0)))(@angular/common@21.1.3(@angular/core@21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0))(rxjs@7.8.2))(@angular/core@21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0)))(rxjs@7.8.2)
       '@memberjunction/core':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../../MJCore
       '@memberjunction/core-entities':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../../MJCoreEntities
       '@memberjunction/global':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../../MJGlobal
       '@memberjunction/graphql-dataprovider':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../../GraphQLDataProvider
       '@memberjunction/ng-base-types':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../base-types
       '@memberjunction/ng-entity-action-ux':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../entity-action-ux
       '@memberjunction/ng-ui-components':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../ui-components
       rxjs:
         specifier: ^7.8.2
@@ -8159,7 +8159,7 @@ importers:
         specifier: 21.1.3
         version: 21.1.3(@angular/compiler@21.1.3)(typescript@5.9.3)
       '@memberjunction/ng-test-utils':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../test-utils
       rimraf:
         specifier: ^5.0.10
@@ -8180,19 +8180,19 @@ importers:
         specifier: 21.1.3
         version: 21.1.3(@angular/common@21.1.3(@angular/core@21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0))(rxjs@7.8.2))(@angular/core@21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0))(@angular/platform-browser@21.1.3(@angular/animations@21.1.3(@angular/core@21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0)))(@angular/common@21.1.3(@angular/core@21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0))(rxjs@7.8.2))(@angular/core@21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0)))(rxjs@7.8.2)
       '@memberjunction/core':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../../MJCore
       '@memberjunction/core-entities':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../../MJCoreEntities
       '@memberjunction/global':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../../MJGlobal
       '@memberjunction/ng-container-directives':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../container-directives
       '@memberjunction/ng-ui-components':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../ui-components
       tslib:
         specifier: ^2.8.1
@@ -8205,7 +8205,7 @@ importers:
         specifier: 21.1.3
         version: 21.1.3(@angular/compiler@21.1.3)(typescript@5.9.3)
       '@memberjunction/ng-test-utils':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../test-utils
       vitest:
         specifier: ^4.0.18
@@ -8220,28 +8220,28 @@ importers:
         specifier: 21.1.3
         version: 21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0)
       '@memberjunction/core':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../../MJCore
       '@memberjunction/core-entities':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../../MJCoreEntities
       '@memberjunction/global':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../../MJGlobal
       '@memberjunction/graphql-dataprovider':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../../GraphQLDataProvider
       '@memberjunction/ng-base-types':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../base-types
       '@memberjunction/ng-shared-generic':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../shared
       '@memberjunction/ng-ui-components':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../ui-components
       '@memberjunction/ng-word-cloud':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../word-cloud
       tslib:
         specifier: ^2.8.1
@@ -8254,7 +8254,7 @@ importers:
         specifier: 21.1.3
         version: 21.1.3(@angular/compiler@21.1.3)(typescript@5.9.3)
       '@memberjunction/ng-test-utils':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../test-utils
       vitest:
         specifier: ^4.0.18
@@ -8272,31 +8272,31 @@ importers:
         specifier: 21.1.3
         version: 21.1.3(@angular/common@21.1.3(@angular/core@21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0))(rxjs@7.8.2))(@angular/core@21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0))(@angular/platform-browser@21.1.3(@angular/animations@21.1.3(@angular/core@21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0)))(@angular/common@21.1.3(@angular/core@21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0))(rxjs@7.8.2))(@angular/core@21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0)))(rxjs@7.8.2)
       '@memberjunction/core':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../../MJCore
       '@memberjunction/core-entities':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../../MJCoreEntities
       '@memberjunction/global':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../../MJGlobal
       '@memberjunction/ng-base-types':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../base-types
       '@memberjunction/ng-container-directives':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../container-directives
       '@memberjunction/ng-generic-dialog':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../generic-dialog
       '@memberjunction/ng-notifications':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../notifications
       '@memberjunction/ng-shared-generic':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../shared
       '@memberjunction/ng-ui-components':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../ui-components
       ag-grid-angular:
         specifier: ^35.0.1
@@ -8315,7 +8315,7 @@ importers:
         specifier: 21.1.3
         version: 21.1.3(@angular/compiler@21.1.3)(typescript@5.9.3)
       '@memberjunction/ng-test-utils':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../test-utils
       vitest:
         specifier: ^4.0.18
@@ -8333,25 +8333,25 @@ importers:
         specifier: 21.1.3
         version: 21.1.3(@angular/common@21.1.3(@angular/core@21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0))(rxjs@7.8.2))(@angular/core@21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0))(@angular/platform-browser@21.1.3(@angular/animations@21.1.3(@angular/core@21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0)))(@angular/common@21.1.3(@angular/core@21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0))(rxjs@7.8.2))(@angular/core@21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0)))(rxjs@7.8.2)
       '@memberjunction/core':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../../MJCore
       '@memberjunction/core-entities':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../../MJCoreEntities
       '@memberjunction/global':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../../MJGlobal
       '@memberjunction/ng-base-types':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../base-types
       '@memberjunction/ng-notifications':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../notifications
       '@memberjunction/ng-shared-generic':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../shared
       '@memberjunction/ng-ui-components':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../ui-components
       rxjs:
         specifier: ^7.8.2
@@ -8367,7 +8367,7 @@ importers:
         specifier: 21.1.3
         version: 21.1.3(@angular/compiler@21.1.3)(typescript@5.9.3)
       '@memberjunction/ng-test-utils':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../test-utils
       vitest:
         specifier: ^4.0.18
@@ -8385,25 +8385,25 @@ importers:
         specifier: 21.1.3
         version: 21.1.3(@angular/common@21.1.3(@angular/core@21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0))(rxjs@7.8.2))(@angular/core@21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0))(@angular/platform-browser@21.1.3(@angular/animations@21.1.3(@angular/core@21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0)))(@angular/common@21.1.3(@angular/core@21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0))(rxjs@7.8.2))(@angular/core@21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0)))(rxjs@7.8.2)
       '@memberjunction/core':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../../MJCore
       '@memberjunction/core-entities':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../../MJCoreEntities
       '@memberjunction/global':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../../MJGlobal
       '@memberjunction/graphql-dataprovider':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../../GraphQLDataProvider
       '@memberjunction/ng-base-types':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../base-types
       '@memberjunction/ng-shared-generic':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../shared
       '@memberjunction/ng-ui-components':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../ui-components
       rxjs:
         specifier: ^7.8.2
@@ -8419,7 +8419,7 @@ importers:
         specifier: 21.1.3
         version: 21.1.3(@angular/compiler@21.1.3)(typescript@5.9.3)
       '@memberjunction/ng-test-utils':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../test-utils
       vitest:
         specifier: ^4.0.18
@@ -8437,19 +8437,19 @@ importers:
         specifier: 21.1.3
         version: 21.1.3(@angular/animations@21.1.3(@angular/core@21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0)))(@angular/common@21.1.3(@angular/core@21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0))(rxjs@7.8.2))(@angular/core@21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0))
       '@memberjunction/core':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../../MJCore
       '@memberjunction/core-entities':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../../MJCoreEntities
       '@memberjunction/global':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../../MJGlobal
       '@memberjunction/ng-base-types':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../base-types
       '@memberjunction/theme-engine':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../../ThemeEngine
       dompurify:
         specifier: ^3.3.0
@@ -8468,7 +8468,7 @@ importers:
         specifier: 21.1.3
         version: 21.1.3(@angular/compiler@21.1.3)(typescript@5.9.3)
       '@memberjunction/ng-test-utils':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../test-utils
       vitest:
         specifier: ^4.0.18
@@ -8483,7 +8483,7 @@ importers:
         specifier: 21.1.3
         version: 21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0)
       '@memberjunction/ng-container-directives':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../container-directives
       tslib:
         specifier: ^2.8.1
@@ -8496,7 +8496,7 @@ importers:
         specifier: 21.1.3
         version: 21.1.3(@angular/compiler@21.1.3)(typescript@5.9.3)
       '@memberjunction/ng-test-utils':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../test-utils
       vitest:
         specifier: ^4.0.18
@@ -8517,22 +8517,22 @@ importers:
         specifier: 21.1.3
         version: 21.1.3(@angular/animations@21.1.3(@angular/core@21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0)))(@angular/common@21.1.3(@angular/core@21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0))(rxjs@7.8.2))(@angular/core@21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0))
       '@memberjunction/ai-core-plus':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../../AI/CorePlus
       '@memberjunction/ai-engine-base':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../../AI/BaseAIEngine
       '@memberjunction/core':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../../MJCore
       '@memberjunction/core-entities':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../../MJCoreEntities
       '@memberjunction/global':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../../MJGlobal
       '@memberjunction/ng-shared-generic':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../shared
       dhtmlx-gantt:
         specifier: ^9.1.1
@@ -8545,7 +8545,7 @@ importers:
         specifier: 21.1.3
         version: 21.1.3(@angular/compiler@21.1.3)(typescript@5.9.3)
       '@memberjunction/ng-test-utils':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../test-utils
       vitest:
         specifier: ^4.0.18
@@ -8554,7 +8554,7 @@ importers:
   packages/Angular/Generic/test-utils:
     dependencies:
       '@memberjunction/core':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../../MJCore
       tslib:
         specifier: ^2.8.1
@@ -8582,13 +8582,13 @@ importers:
         specifier: 21.1.3
         version: 21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0)
       '@memberjunction/core':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../../MJCore
       '@memberjunction/ng-base-types':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../base-types
       '@memberjunction/ng-ui-components':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../ui-components
       rxjs:
         specifier: ~7.8.2
@@ -8604,7 +8604,7 @@ importers:
         specifier: 21.1.3
         version: 21.1.3(@angular/compiler@21.1.3)(typescript@5.9.3)
       '@memberjunction/ng-test-utils':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../test-utils
       vitest:
         specifier: ^4.0.18
@@ -8622,19 +8622,19 @@ importers:
         specifier: 21.1.3
         version: 21.1.3(@angular/common@21.1.3(@angular/core@21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0))(rxjs@7.8.2))(@angular/core@21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0))(@angular/platform-browser@21.1.3(@angular/animations@21.1.3(@angular/core@21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0)))(@angular/common@21.1.3(@angular/core@21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0))(rxjs@7.8.2))(@angular/core@21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0)))(rxjs@7.8.2)
       '@memberjunction/core':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../../MJCore
       '@memberjunction/core-entities':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../../MJCoreEntities
       '@memberjunction/global':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../../MJGlobal
       '@memberjunction/ng-base-types':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../base-types
       '@memberjunction/ng-ui-components':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../ui-components
       rxjs:
         specifier: ^7.8.2
@@ -8650,7 +8650,7 @@ importers:
         specifier: 21.1.3
         version: 21.1.3(@angular/compiler@21.1.3)(typescript@5.9.3)
       '@memberjunction/ng-test-utils':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../test-utils
       vitest:
         specifier: ^4.0.18
@@ -8687,7 +8687,7 @@ importers:
         specifier: 21.1.3
         version: 21.1.3(@angular/compiler@21.1.3)(typescript@5.9.3)
       '@memberjunction/ng-test-utils':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../test-utils
       vitest:
         specifier: ^4.0.18
@@ -8702,13 +8702,13 @@ importers:
         specifier: 21.1.3
         version: 21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0)
       '@memberjunction/core':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../../MJCore
       '@memberjunction/core-entities':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../../MJCoreEntities
       '@memberjunction/global':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../../MJGlobal
       rxjs:
         specifier: ^7.8.2
@@ -8745,43 +8745,43 @@ importers:
         specifier: 21.1.3
         version: 21.1.3(@angular/animations@21.1.3(@angular/core@21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0)))(@angular/common@21.1.3(@angular/core@21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0))(rxjs@7.8.2))(@angular/core@21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0))
       '@memberjunction/actions-base':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../../Actions/Base
       '@memberjunction/ai-engine-base':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../../AI/BaseAIEngine
       '@memberjunction/core':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../../MJCore
       '@memberjunction/core-entities':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../../MJCoreEntities
       '@memberjunction/global':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../../MJGlobal
       '@memberjunction/ng-base-types':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../base-types
       '@memberjunction/ng-code-editor':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../code-editor
       '@memberjunction/ng-composer':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../composer
       '@memberjunction/ng-container-directives':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../container-directives
       '@memberjunction/ng-notifications':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../notifications
       '@memberjunction/ng-shared-generic':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../shared
       '@memberjunction/ng-trees':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../trees
       '@memberjunction/ng-ui-components':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../ui-components
       rxjs:
         specifier: ^7.8.2
@@ -8797,7 +8797,7 @@ importers:
         specifier: 21.1.3
         version: 21.1.3(@angular/compiler@21.1.3)(typescript@5.9.3)
       '@memberjunction/ng-test-utils':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../test-utils
       vitest:
         specifier: ^4.0.18
@@ -8815,25 +8815,25 @@ importers:
         specifier: 21.1.3
         version: 21.1.3(@angular/common@21.1.3(@angular/core@21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0))(rxjs@7.8.2))(@angular/core@21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0))(@angular/platform-browser@21.1.3(@angular/animations@21.1.3(@angular/core@21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0)))(@angular/common@21.1.3(@angular/core@21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0))(rxjs@7.8.2))(@angular/core@21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0)))(rxjs@7.8.2)
       '@memberjunction/core':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../../MJCore
       '@memberjunction/core-entities':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../../MJCoreEntities
       '@memberjunction/global':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../../MJGlobal
       '@memberjunction/graphql-dataprovider':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../../GraphQLDataProvider
       '@memberjunction/ng-base-types':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../base-types
       '@memberjunction/ng-shared-generic':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../shared
       '@memberjunction/ng-ui-components':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../ui-components
       rxjs:
         specifier: ^7.8.2
@@ -8849,7 +8849,7 @@ importers:
         specifier: 21.1.3
         version: 21.1.3(@angular/compiler@21.1.3)(typescript@5.9.3)
       '@memberjunction/ng-test-utils':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../test-utils
       vitest:
         specifier: ^4.0.18
@@ -8867,16 +8867,16 @@ importers:
         specifier: 21.1.3
         version: 21.1.3(@angular/animations@21.1.3(@angular/core@21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0)))(@angular/common@21.1.3(@angular/core@21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0))(rxjs@7.8.2))(@angular/core@21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0))
       '@memberjunction/global':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../../MJGlobal
       '@memberjunction/ng-code-editor':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../code-editor
       '@memberjunction/ng-markdown':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../markdown
       '@memberjunction/ng-ui-components':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../ui-components
       rxjs:
         specifier: ^7.8.2
@@ -8892,7 +8892,7 @@ importers:
         specifier: 21.1.3
         version: 21.1.3(@angular/compiler@21.1.3)(typescript@5.9.3)
       '@memberjunction/ng-test-utils':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../test-utils
       vitest:
         specifier: ^4.0.18
@@ -8917,7 +8917,7 @@ importers:
         specifier: 21.1.3
         version: 21.1.3(@angular/compiler@21.1.3)(typescript@5.9.3)
       '@memberjunction/ng-test-utils':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../test-utils
       vitest:
         specifier: ^4.0.18
@@ -8953,13 +8953,13 @@ importers:
         specifier: 21.1.3
         version: 21.1.3(@angular/common@21.1.3(@angular/core@21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0))(rxjs@7.8.2))(@angular/core@21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0))(@angular/platform-browser@21.1.3(@angular/animations@21.1.3(@angular/core@21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0)))(@angular/common@21.1.3(@angular/core@21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0))(rxjs@7.8.2))(@angular/core@21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0)))(rxjs@7.8.2)
       '@memberjunction/core':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../MJCore
       '@memberjunction/global':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../MJGlobal
       '@memberjunction/graphql-dataprovider':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../GraphQLDataProvider
       rxjs:
         specifier: ^7.8.2
@@ -8987,34 +8987,34 @@ importers:
   packages/Archiving/Action:
     dependencies:
       '@memberjunction/actions':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../Actions/Engine
       '@memberjunction/actions-base':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../Actions/Base
       '@memberjunction/archiving-engine':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../Engine
       '@memberjunction/core':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../MJCore
       '@memberjunction/global':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../MJGlobal
 
   packages/Archiving/Engine:
     dependencies:
       '@memberjunction/core':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../MJCore
       '@memberjunction/core-entities':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../MJCoreEntities
       '@memberjunction/global':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../MJGlobal
       '@memberjunction/storage':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../MJStorage
     devDependencies:
       typescript:
@@ -9027,10 +9027,10 @@ importers:
   packages/AuthProviders:
     dependencies:
       '@memberjunction/core':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../MJCore
       '@memberjunction/global':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../MJGlobal
       graphql:
         specifier: ^16.12.0
@@ -9061,7 +9061,7 @@ importers:
   packages/CLICore:
     dependencies:
       '@memberjunction/global':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../MJGlobal
       '@oclif/core':
         specifier: ^3.27.0
@@ -9092,82 +9092,82 @@ importers:
   packages/CodeGenLib:
     dependencies:
       '@memberjunction/actions':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../Actions/Engine
       '@memberjunction/actions-base':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../Actions/Base
       '@memberjunction/ai':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../AI/Core
       '@memberjunction/ai-core-plus':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../AI/CorePlus
       '@memberjunction/ai-prompts':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../AI/Prompts
       '@memberjunction/ai-provider-bundle':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../AI/Providers/Bundle
       '@memberjunction/aiengine':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../AI/Engine
       '@memberjunction/cli-core':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../CLICore
       '@memberjunction/config':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../Config
       '@memberjunction/core':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../MJCore
       '@memberjunction/core-entities':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../MJCoreEntities
       '@memberjunction/core-entities-server':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../MJCoreEntitiesServer
       '@memberjunction/external-data-source-mongodb':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../ExternalDataSources/Providers/MongoDB
       '@memberjunction/external-data-source-mysql':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../ExternalDataSources/Providers/MySQL
       '@memberjunction/external-data-source-oracle':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../ExternalDataSources/Providers/Oracle
       '@memberjunction/external-data-source-postgres':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../ExternalDataSources/Providers/Postgres
       '@memberjunction/external-data-source-snowflake':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../ExternalDataSources/Providers/Snowflake
       '@memberjunction/external-data-source-sqlserver':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../ExternalDataSources/Providers/SQLServer
       '@memberjunction/external-data-sources':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../ExternalDataSources/Engine
       '@memberjunction/generic-database-provider':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../GenericDatabaseProvider
       '@memberjunction/global':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../MJGlobal
       '@memberjunction/postgresql-dataprovider':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../PostgreSQLDataProvider
       '@memberjunction/server-bootstrap-lite':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../ServerBootstrapLite
       '@memberjunction/sql-dialect':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../SQLDialect
       '@memberjunction/sql-parser':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../SQLParser
       '@memberjunction/sqlserver-dataprovider':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../SQLServerDataProvider
       '@oclif/core':
         specifier: ^3.27.0
@@ -9222,16 +9222,16 @@ importers:
   packages/Communication/base-types:
     dependencies:
       '@memberjunction/core':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../MJCore
       '@memberjunction/core-entities':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../MJCoreEntities
       '@memberjunction/global':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../MJGlobal
       '@memberjunction/templates-base-types':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../Templates/base-types
       rxjs:
         specifier: ^7.8.2
@@ -9247,25 +9247,25 @@ importers:
   packages/Communication/engine:
     dependencies:
       '@memberjunction/communication-types':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../base-types
       '@memberjunction/core':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../MJCore
       '@memberjunction/core-entities':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../MJCoreEntities
       '@memberjunction/global':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../MJGlobal
       '@memberjunction/lists':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../Lists/server
       '@memberjunction/lists-base':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../Lists/base
       '@memberjunction/templates':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../Templates/engine
       rxjs:
         specifier: ^7.8.2
@@ -9281,16 +9281,16 @@ importers:
   packages/Communication/entity-comm-base:
     dependencies:
       '@memberjunction/communication-types':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../base-types
       '@memberjunction/core':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../MJCore
       '@memberjunction/core-entities':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../MJCoreEntities
       '@memberjunction/global':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../MJGlobal
     devDependencies:
       ts-node-dev:
@@ -9303,22 +9303,22 @@ importers:
   packages/Communication/entity-comm-client:
     dependencies:
       '@memberjunction/communication-types':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../base-types
       '@memberjunction/core':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../MJCore
       '@memberjunction/core-entities':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../MJCoreEntities
       '@memberjunction/entity-communications-base':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../entity-comm-base
       '@memberjunction/global':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../MJGlobal
       '@memberjunction/graphql-dataprovider':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../GraphQLDataProvider
     devDependencies:
       ts-node-dev:
@@ -9331,22 +9331,22 @@ importers:
   packages/Communication/entity-comm-server:
     dependencies:
       '@memberjunction/communication-engine':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../engine
       '@memberjunction/communication-types':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../base-types
       '@memberjunction/core':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../MJCore
       '@memberjunction/core-entities':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../MJCoreEntities
       '@memberjunction/entity-communications-base':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../entity-comm-base
       '@memberjunction/global':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../MJGlobal
     devDependencies:
       ts-node-dev:
@@ -9359,25 +9359,25 @@ importers:
   packages/Communication/notifications:
     dependencies:
       '@memberjunction/communication-engine':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../engine
       '@memberjunction/communication-types':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../base-types
       '@memberjunction/core':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../MJCore
       '@memberjunction/core-entities':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../MJCoreEntities
       '@memberjunction/global':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../MJGlobal
       '@memberjunction/sqlserver-dataprovider':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../SQLServerDataProvider
       '@memberjunction/templates':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../Templates/engine
     devDependencies:
       ts-node-dev:
@@ -9396,28 +9396,28 @@ importers:
         specifier: ^5.0.3
         version: 5.4.0
       '@memberjunction/ai':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../../AI/Core
       '@memberjunction/ai-provider-bundle':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../../AI/Providers/Bundle
       '@memberjunction/aiengine':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../../AI/Engine
       '@memberjunction/communication-types':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../base-types
       '@memberjunction/core':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../../MJCore
       '@memberjunction/core-entities':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../../MJCoreEntities
       '@memberjunction/global':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../../MJGlobal
       '@memberjunction/sqlserver-dataprovider':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../../SQLServerDataProvider
       '@microsoft/microsoft-graph-client':
         specifier: ^3.0.7
@@ -9454,13 +9454,13 @@ importers:
   packages/Communication/providers/expo-push:
     dependencies:
       '@memberjunction/communication-types':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../base-types
       '@memberjunction/core':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../../MJCore
       '@memberjunction/global':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../../MJGlobal
       dotenv:
         specifier: ^17.2.4
@@ -9479,13 +9479,13 @@ importers:
   packages/Communication/providers/gmail:
     dependencies:
       '@memberjunction/communication-types':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../base-types
       '@memberjunction/core':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../../MJCore
       '@memberjunction/global':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../../MJGlobal
       dotenv:
         specifier: ^17.2.4
@@ -9507,16 +9507,16 @@ importers:
   packages/Communication/providers/sendgrid:
     dependencies:
       '@memberjunction/communication-types':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../base-types
       '@memberjunction/core':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../../MJCore
       '@memberjunction/core-entities':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../../MJCoreEntities
       '@memberjunction/global':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../../MJGlobal
       '@sendgrid/mail':
         specifier: ^8.1.6
@@ -9535,13 +9535,13 @@ importers:
   packages/Communication/providers/twilio:
     dependencies:
       '@memberjunction/communication-types':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../base-types
       '@memberjunction/core':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../../MJCore
       '@memberjunction/global':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../../MJGlobal
       dotenv:
         specifier: ^17.2.4
@@ -9563,19 +9563,19 @@ importers:
   packages/ComponentRegistry:
     dependencies:
       '@memberjunction/core':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../MJCore
       '@memberjunction/core-entities':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../MJCoreEntities
       '@memberjunction/global':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../MJGlobal
       '@memberjunction/interactive-component-types':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../InteractiveComponents
       '@memberjunction/sqlserver-dataprovider':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../SQLServerDataProvider
       '@types/express':
         specifier: ^5.0.6
@@ -9612,13 +9612,13 @@ importers:
   packages/ComponentRegistryClientSDK:
     dependencies:
       '@memberjunction/core':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../MJCore
       '@memberjunction/global':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../MJGlobal
       '@memberjunction/interactive-component-types':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../InteractiveComponents
     devDependencies:
       ts-node-dev:
@@ -9659,52 +9659,52 @@ importers:
         specifier: ^12.30.0
         version: 12.30.0
       '@memberjunction/ai':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../AI/Core
       '@memberjunction/ai-core-plus':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../AI/CorePlus
       '@memberjunction/ai-prompts':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../AI/Prompts
       '@memberjunction/ai-provider-bundle':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../AI/Providers/Bundle
       '@memberjunction/ai-segmentation':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../AI/Segmentation
       '@memberjunction/ai-vector-sync':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../AI/Vectors/Sync
       '@memberjunction/ai-vectordb':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../AI/Vectors/Database
       '@memberjunction/ai-vectors':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../AI/Vectors/Core
       '@memberjunction/aiengine':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../AI/Engine
       '@memberjunction/core':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../MJCore
       '@memberjunction/core-entities':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../MJCoreEntities
       '@memberjunction/global':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../MJGlobal
       '@memberjunction/storage':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../MJStorage
       '@memberjunction/tag-engine':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../AI/Knowledge/TagEngine
       '@memberjunction/tag-engine-base':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../AI/Knowledge/TagEngineBase
       '@memberjunction/templates':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../Templates/engine
       axios:
         specifier: ^1.13.4
@@ -9768,25 +9768,25 @@ importers:
   packages/ConversationsRuntime:
     dependencies:
       '@memberjunction/ai-agent-client':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../AI/AgentsClient
       '@memberjunction/ai-core-plus':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../AI/CorePlus
       '@memberjunction/ai-engine-base':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../AI/BaseAIEngine
       '@memberjunction/core':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../MJCore
       '@memberjunction/core-entities':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../MJCoreEntities
       '@memberjunction/global':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../MJGlobal
       '@memberjunction/graphql-dataprovider':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../GraphQLDataProvider
       rxjs:
         specifier: ^7.8.2
@@ -9802,13 +9802,13 @@ importers:
   packages/Credentials/Engine:
     dependencies:
       '@memberjunction/core':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../MJCore
       '@memberjunction/core-entities':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../MJCoreEntities
       '@memberjunction/global':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../MJGlobal
       ajv:
         specifier: ^8.17.1
@@ -9842,16 +9842,16 @@ importers:
         specifier: ^8.2.0
         version: 8.2.0(@types/node@24.10.11)
       '@memberjunction/ai':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../AI/Core
       '@memberjunction/core':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../MJCore
       '@memberjunction/global':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../MJGlobal
       '@memberjunction/server-bootstrap-lite':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../ServerBootstrapLite
       '@oclif/core':
         specifier: ^3.27.0
@@ -9924,13 +9924,13 @@ importers:
         specifier: ^4.1.2
         version: 4.1.2
       '@memberjunction/core':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../MJCore
       '@memberjunction/core-entities':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../MJCoreEntities
       '@memberjunction/global':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../MJGlobal
       axios:
         specifier: ^1.13.4
@@ -10015,19 +10015,19 @@ importers:
   packages/Encryption:
     dependencies:
       '@memberjunction/actions-base':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../Actions/Base
       '@memberjunction/core':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../MJCore
       '@memberjunction/core-entities':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../MJCoreEntities
       '@memberjunction/credentials':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../Credentials/Engine
       '@memberjunction/global':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../MJGlobal
       cosmiconfig:
         specifier: ^9.0.0
@@ -10056,22 +10056,22 @@ importers:
   packages/ExternalChangeDetection:
     dependencies:
       '@memberjunction/core':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../MJCore
       '@memberjunction/core-entities':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../MJCoreEntities
       '@memberjunction/encryption':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../Encryption
       '@memberjunction/global':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../MJGlobal
       '@memberjunction/sql-dialect':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../SQLDialect
       '@memberjunction/sqlserver-dataprovider':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../SQLServerDataProvider
     devDependencies:
       ts-node-dev:
@@ -10084,22 +10084,22 @@ importers:
   packages/ExternalDataSources/Engine:
     dependencies:
       '@memberjunction/core':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../MJCore
       '@memberjunction/core-entities':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../MJCoreEntities
       '@memberjunction/credentials':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../Credentials/Engine
       '@memberjunction/global':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../MJGlobal
       '@memberjunction/sql-dialect':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../SQLDialect
       '@memberjunction/sql-parser':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../SQLParser
     devDependencies:
       '@types/node':
@@ -10121,16 +10121,16 @@ importers:
   packages/ExternalDataSources/Providers/MongoDB:
     dependencies:
       '@memberjunction/core':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../../MJCore
       '@memberjunction/core-entities':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../../MJCoreEntities
       '@memberjunction/external-data-sources':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../Engine
       '@memberjunction/global':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../../MJGlobal
       mongodb:
         specifier: ^6.10.0
@@ -10155,16 +10155,16 @@ importers:
   packages/ExternalDataSources/Providers/MySQL:
     dependencies:
       '@memberjunction/core':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../../MJCore
       '@memberjunction/core-entities':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../../MJCoreEntities
       '@memberjunction/external-data-sources':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../Engine
       '@memberjunction/global':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../../MJGlobal
       mysql2:
         specifier: ^3.16.3
@@ -10189,16 +10189,16 @@ importers:
   packages/ExternalDataSources/Providers/Oracle:
     dependencies:
       '@memberjunction/core':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../../MJCore
       '@memberjunction/core-entities':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../../MJCoreEntities
       '@memberjunction/external-data-sources':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../Engine
       '@memberjunction/global':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../../MJGlobal
       oracledb:
         specifier: ^6.8.0
@@ -10223,16 +10223,16 @@ importers:
   packages/ExternalDataSources/Providers/Postgres:
     dependencies:
       '@memberjunction/core':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../../MJCore
       '@memberjunction/core-entities':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../../MJCoreEntities
       '@memberjunction/external-data-sources':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../Engine
       '@memberjunction/global':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../../MJGlobal
       pg:
         specifier: ^8.13.3
@@ -10260,16 +10260,16 @@ importers:
   packages/ExternalDataSources/Providers/SQLServer:
     dependencies:
       '@memberjunction/core':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../../MJCore
       '@memberjunction/core-entities':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../../MJCoreEntities
       '@memberjunction/external-data-sources':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../Engine
       '@memberjunction/global':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../../MJGlobal
       mssql:
         specifier: ^12.7.0
@@ -10297,16 +10297,16 @@ importers:
   packages/ExternalDataSources/Providers/Snowflake:
     dependencies:
       '@memberjunction/core':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../../MJCore
       '@memberjunction/core-entities':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../../MJCoreEntities
       '@memberjunction/external-data-sources':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../Engine
       '@memberjunction/global':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../../MJGlobal
       snowflake-sdk:
         specifier: ^2.4.0
@@ -10334,7 +10334,7 @@ importers:
   packages/FieldRulesTransforms:
     dependencies:
       '@memberjunction/global':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../MJGlobal
       '@xmldom/xmldom':
         specifier: ^0.8.11
@@ -10359,28 +10359,28 @@ importers:
   packages/GeneratedActions:
     dependencies:
       '@memberjunction/actions':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../Actions/Engine
       '@memberjunction/actions-base':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../Actions/Base
       '@memberjunction/ai':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../AI/Core
       '@memberjunction/aiengine':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../AI/Engine
       '@memberjunction/core':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../MJCore
       '@memberjunction/core-entities':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../MJCoreEntities
       '@memberjunction/core-entities-server':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../MJCoreEntitiesServer
       '@memberjunction/global':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../MJGlobal
       zod:
         specifier: ^3.25.0
@@ -10396,10 +10396,10 @@ importers:
   packages/GeneratedEntities:
     dependencies:
       '@memberjunction/core':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../MJCore
       '@memberjunction/global':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../MJGlobal
       zod:
         specifier: ^3.25.0
@@ -10415,43 +10415,43 @@ importers:
   packages/GenericDatabaseProvider:
     dependencies:
       '@memberjunction/actions':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../Actions/Engine
       '@memberjunction/actions-base':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../Actions/Base
       '@memberjunction/ai-vectors-memory':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../AI/Vectors/Memory
       '@memberjunction/aiengine':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../AI/Engine
       '@memberjunction/core':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../MJCore
       '@memberjunction/core-entities':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../MJCoreEntities
       '@memberjunction/encryption':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../Encryption
       '@memberjunction/geo-core':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../geo/geo-core
       '@memberjunction/global':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../MJGlobal
       '@memberjunction/query-processor':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../QueryProcessor
       '@memberjunction/queue':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../MJQueue
       '@memberjunction/sql-dialect':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../SQLDialect
       '@memberjunction/sql-parser':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../SQLParser
       sql-formatter:
         specifier: ^15.7.0
@@ -10473,25 +10473,25 @@ importers:
   packages/GraphQLDataProvider:
     dependencies:
       '@memberjunction/actions-base':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../Actions/Base
       '@memberjunction/ai-core-plus':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../AI/CorePlus
       '@memberjunction/core':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../MJCore
       '@memberjunction/core-entities':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../MJCoreEntities
       '@memberjunction/global':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../MJGlobal
       '@memberjunction/interactive-component-types':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../InteractiveComponents
       '@memberjunction/lists-base':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../Lists/base
       '@tempfix/idb':
         specifier: ^8.0.3
@@ -10535,22 +10535,22 @@ importers:
   packages/Integration/actions:
     dependencies:
       '@memberjunction/actions':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../Actions/Engine
       '@memberjunction/actions-base':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../Actions/Base
       '@memberjunction/core':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../MJCore
       '@memberjunction/core-entities':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../MJCoreEntities
       '@memberjunction/global':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../MJGlobal
       '@memberjunction/integration-engine':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../engine
     devDependencies:
       tsc-alias:
@@ -10566,19 +10566,19 @@ importers:
   packages/Integration/connectors:
     dependencies:
       '@memberjunction/core':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../MJCore
       '@memberjunction/core-entities':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../MJCoreEntities
       '@memberjunction/external-data-sources':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../ExternalDataSources/Engine
       '@memberjunction/integration-engine':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../engine
       '@memberjunction/integration-engine-base':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../engine-base
     devDependencies:
       tsc-alias:
@@ -10594,22 +10594,22 @@ importers:
   packages/Integration/engine:
     dependencies:
       '@memberjunction/core':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../MJCore
       '@memberjunction/core-entities':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../MJCoreEntities
       '@memberjunction/global':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../MJGlobal
       '@memberjunction/integration-engine-base':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../engine-base
       '@memberjunction/integration-pk-classifier':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../pk-classifier
       '@memberjunction/integration-progress-artifacts':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../progress-artifacts
     devDependencies:
       tsc-alias:
@@ -10625,13 +10625,13 @@ importers:
   packages/Integration/engine-base:
     dependencies:
       '@memberjunction/core':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../MJCore
       '@memberjunction/core-entities':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../MJCoreEntities
       '@memberjunction/global':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../MJGlobal
     devDependencies:
       tsc-alias:
@@ -10647,13 +10647,13 @@ importers:
   packages/Integration/pk-classifier:
     dependencies:
       '@memberjunction/core':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../MJCore
       '@memberjunction/core-entities':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../MJCoreEntities
       '@memberjunction/global':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../MJGlobal
     devDependencies:
       tsc-alias:
@@ -10669,7 +10669,7 @@ importers:
   packages/Integration/progress-artifacts:
     dependencies:
       '@memberjunction/global':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../MJGlobal
     devDependencies:
       tsc-alias:
@@ -10685,19 +10685,19 @@ importers:
   packages/Integration/schema-builder:
     dependencies:
       '@memberjunction/core':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../MJCore
       '@memberjunction/global':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../MJGlobal
       '@memberjunction/integration-engine':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../engine
       '@memberjunction/schema-engine':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../SchemaEngine
       '@memberjunction/sql-dialect':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../SQLDialect
     devDependencies:
       tsc-alias:
@@ -10719,10 +10719,10 @@ importers:
   packages/InteractiveComponents:
     dependencies:
       '@memberjunction/ai-vectors-memory':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../AI/Vectors/Memory
       '@memberjunction/core':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../MJCore
     devDependencies:
       ts-node-dev:
@@ -10744,16 +10744,16 @@ importers:
   packages/Lists/server:
     dependencies:
       '@memberjunction/core':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../MJCore
       '@memberjunction/core-entities':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../MJCoreEntities
       '@memberjunction/global':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../MJGlobal
       '@memberjunction/lists-base':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../base
     devDependencies:
       ts-node-dev:
@@ -10775,7 +10775,7 @@ importers:
         specifier: ^0.7.2
         version: 0.7.2(@types/dom-mediacapture-transform@0.1.11)(livekit-client@2.19.2(@types/dom-mediacapture-record@1.0.22))
       '@memberjunction/global':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../MJGlobal
       livekit-client:
         specifier: ^2.7.4
@@ -10794,25 +10794,25 @@ importers:
   packages/LiveKitRoomServer:
     dependencies:
       '@memberjunction/ai':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../AI/Core
       '@memberjunction/ai-bridge-base':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../AI/RealtimeBridge/Base
       '@memberjunction/ai-bridge-livekit':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../AI/RealtimeBridge/Providers/LiveKit
       '@memberjunction/ai-bridge-server':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../AI/RealtimeBridge/Server
       '@memberjunction/core':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../MJCore
       '@memberjunction/core-entities':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../MJCoreEntities
       '@memberjunction/global':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../MJGlobal
       livekit-server-sdk:
         specifier: ^2.9.7
@@ -10831,31 +10831,31 @@ importers:
   packages/MJAPI:
     dependencies:
       '@memberjunction/ai':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../AI/Core
       '@memberjunction/communication-sendgrid':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../Communication/providers/sendgrid
       '@memberjunction/core':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../MJCore
       '@memberjunction/global':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../MJGlobal
       '@memberjunction/messaging-adapters':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../MessagingAdapters
       '@memberjunction/server':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../MJServer
       '@memberjunction/server-bootstrap':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../ServerBootstrap
       '@memberjunction/sqlserver-dataprovider':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../SQLServerDataProvider
       '@memberjunction/templates':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../Templates/engine
       axios:
         specifier: ^1.13.4
@@ -10871,7 +10871,7 @@ importers:
         version: link:../GeneratedEntities
     devDependencies:
       '@memberjunction/cli':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../MJCLI
       dotenv:
         specifier: 17.2.4
@@ -10895,49 +10895,49 @@ importers:
         specifier: ^8.2.0
         version: 8.2.0(@types/node@24.10.11)
       '@memberjunction/ai-cli':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../AI/AICLI
       '@memberjunction/aiengine':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../AI/Engine
       '@memberjunction/cli-core':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../CLICore
       '@memberjunction/codegen-lib':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../CodeGenLib
       '@memberjunction/config':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../Config
       '@memberjunction/core':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../MJCore
       '@memberjunction/core-entities':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../MJCoreEntities
       '@memberjunction/db-auto-doc':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../DBAutoDoc
       '@memberjunction/generic-database-provider':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../GenericDatabaseProvider
       '@memberjunction/global':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../MJGlobal
       '@memberjunction/installer':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../MJInstaller
       '@memberjunction/metadata-sync':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../MetadataSync
       '@memberjunction/open-app-engine':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../OpenApp/Engine
       '@memberjunction/query-gen':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../QueryGen
       '@memberjunction/server-bootstrap-lite':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../ServerBootstrapLite
       '@memberjunction/skyway-core':
         specifier: ^0.6.2
@@ -10949,19 +10949,19 @@ importers:
         specifier: ^0.6.2
         version: 0.6.2
       '@memberjunction/sql-converter':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../SQLConverter
       '@memberjunction/sqlglot-ts':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../SQLGlotTS
       '@memberjunction/sqlserver-dataprovider':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../SQLServerDataProvider
       '@memberjunction/standards':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../Standards
       '@memberjunction/testing-cli':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../TestingFramework/CLI
       '@oclif/core':
         specifier: ^3.27.0
@@ -11049,22 +11049,22 @@ importers:
   packages/MJCodeGenAPI:
     dependencies:
       '@memberjunction/codegen-lib':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../CodeGenLib
       '@memberjunction/core':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../MJCore
       '@memberjunction/core-entities':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../MJCoreEntities
       '@memberjunction/global':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../MJGlobal
       '@memberjunction/server-bootstrap-lite':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../ServerBootstrapLite
       '@memberjunction/sqlserver-dataprovider':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../SQLServerDataProvider
       '@types/axios':
         specifier: ^0.14.4
@@ -11119,10 +11119,10 @@ importers:
   packages/MJCore:
     dependencies:
       '@memberjunction/global':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../MJGlobal
       '@memberjunction/sql-dialect':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../SQLDialect
       debug:
         specifier: ^4.4.3
@@ -11150,16 +11150,16 @@ importers:
   packages/MJCoreEntities:
     dependencies:
       '@memberjunction/ai':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../AI/Core
       '@memberjunction/core':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../MJCore
       '@memberjunction/global':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../MJGlobal
       '@memberjunction/interactive-component-types':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../InteractiveComponents
       rxjs:
         specifier: ^7.8.2
@@ -11178,76 +11178,76 @@ importers:
   packages/MJCoreEntitiesServer:
     dependencies:
       '@memberjunction/actions-base':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../Actions/Base
       '@memberjunction/ai':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../AI/Core
       '@memberjunction/ai-core-plus':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../AI/CorePlus
       '@memberjunction/ai-engine-base':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../AI/BaseAIEngine
       '@memberjunction/ai-prompts':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../AI/Prompts
       '@memberjunction/ai-provider-bundle':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../AI/Providers/Bundle
       '@memberjunction/ai-vector-dupe':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../AI/Vectors/Dupe
       '@memberjunction/ai-vectordb':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../AI/Vectors/Database
       '@memberjunction/ai-vectors-memory':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../AI/Vectors/Memory
       '@memberjunction/aiengine':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../AI/Engine
       '@memberjunction/core':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../MJCore
       '@memberjunction/core-entities':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../MJCoreEntities
       '@memberjunction/doc-utils':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../DocUtils
       '@memberjunction/generic-database-provider':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../GenericDatabaseProvider
       '@memberjunction/global':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../MJGlobal
       '@memberjunction/integration-engine':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../Integration/engine
       '@memberjunction/integration-pk-classifier':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../Integration/pk-classifier
       '@memberjunction/predictive-studio-core':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../AI/PredictiveStudio/Core
       '@memberjunction/scheduling-engine':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../Scheduling/engine
       '@memberjunction/sql-converter':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../SQLConverter
       '@memberjunction/sql-dialect':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../SQLDialect
       '@memberjunction/sql-parser':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../SQLParser
       '@memberjunction/sqlserver-dataprovider':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../SQLServerDataProvider
       '@memberjunction/tag-engine':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../AI/Knowledge/TagEngine
       nunjucks:
         specifier: 3.2.4
@@ -11269,13 +11269,13 @@ importers:
   packages/MJDataContext:
     dependencies:
       '@memberjunction/core':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../MJCore
       '@memberjunction/core-entities':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../MJCoreEntities
       '@memberjunction/global':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../MJGlobal
     devDependencies:
       ts-node-dev:
@@ -11288,13 +11288,13 @@ importers:
   packages/MJDataContextServer:
     dependencies:
       '@memberjunction/core':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../MJCore
       '@memberjunction/data-context':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../MJDataContext
       '@memberjunction/global':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../MJGlobal
       mssql:
         specifier: ^12.2.0
@@ -11418,79 +11418,79 @@ importers:
         specifier: ^0.7.2
         version: 0.7.2(@types/dom-mediacapture-transform@0.1.11)(livekit-client@2.19.2(@types/dom-mediacapture-record@1.0.22))
       '@memberjunction/core':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../MJCore
       '@memberjunction/core-entities':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../MJCoreEntities
       '@memberjunction/global':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../MJGlobal
       '@memberjunction/graphql-dataprovider':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../GraphQLDataProvider
       '@memberjunction/ng-auth-services':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../Angular/Explorer/auth-services
       '@memberjunction/ng-base-application':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../Angular/Explorer/base-application
       '@memberjunction/ng-base-forms':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../Angular/Generic/base-forms
       '@memberjunction/ng-bootstrap':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../Angular/Bootstrap/dist
       '@memberjunction/ng-bootstrap-lite':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../Angular/BootstrapLite
       '@memberjunction/ng-core-entity-forms':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../Angular/Explorer/core-entity-forms
       '@memberjunction/ng-dashboards':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../Angular/Explorer/dashboards
       '@memberjunction/ng-entity-viewer':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../Angular/Generic/entity-viewer
       '@memberjunction/ng-explorer-app':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../Angular/Explorer/explorer-app
       '@memberjunction/ng-explorer-core':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../Angular/Explorer/explorer-core
       '@memberjunction/ng-explorer-modules':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../Angular/Explorer/explorer-modules
       '@memberjunction/ng-explorer-service-worker':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../Angular/Explorer/service-worker
       '@memberjunction/ng-explorer-settings':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../Angular/Explorer/explorer-settings
       '@memberjunction/ng-join-grid':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../Angular/Generic/join-grid
       '@memberjunction/ng-link-directives':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../Angular/Explorer/link-directives
       '@memberjunction/ng-record-changes':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../Angular/Generic/record-changes
       '@memberjunction/ng-shared':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../Angular/Explorer/shared
       '@memberjunction/ng-shared-generic':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../Angular/Generic/shared
       '@memberjunction/ng-timeline':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../Angular/Generic/timeline
       '@memberjunction/ng-ui-components':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../Angular/Generic/ui-components
       '@memberjunction/ng-workspace-initializer':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../Angular/Explorer/workspace-initializer
       '@okta/okta-auth-js':
         specifier: ^7.14.1
@@ -11683,7 +11683,7 @@ importers:
         specifier: 21.1.3
         version: 21.1.3(@angular/compiler@21.1.3)(typescript@5.9.3)
       '@memberjunction/cli':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../MJCLI
       '@types/body-parser':
         specifier: ^1.19.6
@@ -11774,22 +11774,22 @@ importers:
   packages/MJQueue:
     dependencies:
       '@memberjunction/ai':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../AI/Core
       '@memberjunction/ai-provider-bundle':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../AI/Providers/Bundle
       '@memberjunction/aiengine':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../AI/Engine
       '@memberjunction/core':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../MJCore
       '@memberjunction/core-entities':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../MJCoreEntities
       '@memberjunction/global':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../MJGlobal
       '@types/uuid':
         specifier: ^11.0.0
@@ -11820,268 +11820,268 @@ importers:
         specifier: ^11.0.0
         version: 11.0.0(graphql@16.12.0)
       '@memberjunction/actions':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../Actions/Engine
       '@memberjunction/actions-apollo':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../Actions/ApolloEnrichment
       '@memberjunction/actions-base':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../Actions/Base
       '@memberjunction/actions-bizapps-accounting':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../Actions/BizApps/Accounting
       '@memberjunction/actions-bizapps-crm':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../Actions/BizApps/CRM
       '@memberjunction/actions-bizapps-formbuilders':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../Actions/BizApps/FormBuilders
       '@memberjunction/actions-bizapps-lms':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../Actions/BizApps/LMS
       '@memberjunction/actions-bizapps-social':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../Actions/BizApps/Social
       '@memberjunction/ai':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../AI/Core
       '@memberjunction/ai-agent-manager':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../AI/AgentManager/core
       '@memberjunction/ai-agent-manager-actions':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../AI/AgentManager/actions
       '@memberjunction/ai-agents':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../AI/Agents
       '@memberjunction/ai-bridge-base':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../AI/RealtimeBridge/Base
       '@memberjunction/ai-bridge-ringcentral':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../AI/RealtimeBridge/Providers/RingCentral
       '@memberjunction/ai-bridge-server':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../AI/RealtimeBridge/Server
       '@memberjunction/ai-bridge-teams':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../AI/RealtimeBridge/Providers/Teams
       '@memberjunction/ai-bridge-twilio':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../AI/RealtimeBridge/Providers/Twilio
       '@memberjunction/ai-bridge-vonage':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../AI/RealtimeBridge/Providers/Vonage
       '@memberjunction/ai-core-plus':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../AI/CorePlus
       '@memberjunction/ai-engine-base':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../AI/BaseAIEngine
       '@memberjunction/ai-mcp-client':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../AI/MCPClient
       '@memberjunction/ai-prompts':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../AI/Prompts
       '@memberjunction/ai-provider-bundle':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../AI/Providers/Bundle
       '@memberjunction/ai-vector-sync':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../AI/Vectors/Sync
       '@memberjunction/ai-vectordb':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../AI/Vectors/Database
       '@memberjunction/ai-vectors-pinecone':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../AI/Vectors/Providers/Pinecone
       '@memberjunction/aiengine':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../AI/Engine
       '@memberjunction/api-keys':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../APIKeys/Engine
       '@memberjunction/auth-providers':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../AuthProviders
       '@memberjunction/clustering-engine':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../AI/Clustering
       '@memberjunction/codegen-lib':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../CodeGenLib
       '@memberjunction/communication-engine':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../Communication/engine
       '@memberjunction/communication-ms-graph':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../Communication/providers/MSGraph
       '@memberjunction/communication-sendgrid':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../Communication/providers/sendgrid
       '@memberjunction/communication-types':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../Communication/base-types
       '@memberjunction/component-registry-client-sdk':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../ComponentRegistryClientSDK
       '@memberjunction/computer-use':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../AI/ComputerUse
       '@memberjunction/computer-use-engine':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../AI/MJComputerUse
       '@memberjunction/config':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../Config
       '@memberjunction/core':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../MJCore
       '@memberjunction/core-actions':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../Actions/CoreActions
       '@memberjunction/core-entities':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../MJCoreEntities
       '@memberjunction/core-entities-server':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../MJCoreEntitiesServer
       '@memberjunction/credentials':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../Credentials/Engine
       '@memberjunction/data-context':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../MJDataContext
       '@memberjunction/data-context-server':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../MJDataContextServer
       '@memberjunction/doc-utils':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../DocUtils
       '@memberjunction/encryption':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../Encryption
       '@memberjunction/entity-communications-base':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../Communication/entity-comm-base
       '@memberjunction/entity-communications-server':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../Communication/entity-comm-server
       '@memberjunction/esignature':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../eSignature/Base
       '@memberjunction/external-change-detection':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../ExternalChangeDetection
       '@memberjunction/generic-database-provider':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../GenericDatabaseProvider
       '@memberjunction/global':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../MJGlobal
       '@memberjunction/graphql-dataprovider':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../GraphQLDataProvider
       '@memberjunction/integration-engine':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../Integration/engine
       '@memberjunction/integration-engine-base':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../Integration/engine-base
       '@memberjunction/integration-progress-artifacts':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../Integration/progress-artifacts
       '@memberjunction/integration-schema-builder':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../Integration/schema-builder
       '@memberjunction/interactive-component-types':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../InteractiveComponents
       '@memberjunction/lists':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../Lists/server
       '@memberjunction/lists-base':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../Lists/base
       '@memberjunction/livekit-room-server':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../LiveKitRoomServer
       '@memberjunction/notifications':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../Communication/notifications
       '@memberjunction/postgresql-dataprovider':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../PostgreSQLDataProvider
       '@memberjunction/queue':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../MJQueue
       '@memberjunction/record-comparison':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../RecordComparison
       '@memberjunction/redis-provider':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../RedisProvider
       '@memberjunction/remote-browser-base':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../AI/RemoteBrowser/Base
       '@memberjunction/remote-browser-cdp':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../AI/RemoteBrowser/Cdp
       '@memberjunction/remote-browser-selfhost':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../AI/RemoteBrowser/Providers/SelfHost
       '@memberjunction/remote-browser-server':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../AI/RemoteBrowser/Server
       '@memberjunction/scheduling-actions':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../Scheduling/actions
       '@memberjunction/scheduling-base-types':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../Scheduling/base-types
       '@memberjunction/scheduling-engine':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../Scheduling/engine
       '@memberjunction/scheduling-engine-base':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../Scheduling/base-engine
       '@memberjunction/schema-engine':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../SchemaEngine
       '@memberjunction/search-engine':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../SearchEngine
       '@memberjunction/server-extensions-core':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../ServerExtensionsCore
       '@memberjunction/sql-dialect':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../SQLDialect
       '@memberjunction/sqlserver-dataprovider':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../SQLServerDataProvider
       '@memberjunction/storage':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../MJStorage
       '@memberjunction/tag-engine':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../AI/Knowledge/TagEngine
       '@memberjunction/tag-engine-base':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../AI/Knowledge/TagEngineBase
       '@memberjunction/templates':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../Templates/engine
       '@memberjunction/testing-engine':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../TestingFramework/Engine
       '@memberjunction/testing-engine-base':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../TestingFramework/EngineBase
       '@memberjunction/version-history':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../VersionHistory
       '@octokit/auth-app':
         specifier: ^7.1.5
@@ -12226,16 +12226,16 @@ importers:
         specifier: ^7.19.0
         version: 7.19.0(encoding@0.1.13)
       '@memberjunction/core':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../MJCore
       '@memberjunction/core-entities':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../MJCoreEntities
       '@memberjunction/credentials':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../Credentials/Engine
       '@memberjunction/global':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../MJGlobal
       '@microsoft/mgt-element':
         specifier: ^4.6.0
@@ -12315,28 +12315,28 @@ importers:
   packages/MessagingAdapters:
     dependencies:
       '@memberjunction/ai':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../AI/Core
       '@memberjunction/ai-agents':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../AI/Agents
       '@memberjunction/ai-core-plus':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../AI/CorePlus
       '@memberjunction/core':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../MJCore
       '@memberjunction/core-entities':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../MJCoreEntities
       '@memberjunction/global':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../MJGlobal
       '@memberjunction/server-extensions-core':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../ServerExtensionsCore
       '@memberjunction/sqlserver-dataprovider':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../SQLServerDataProvider
       '@slack/socket-mode':
         specifier: ^2.0.3
@@ -12373,40 +12373,40 @@ importers:
         specifier: ^8.2.0
         version: 8.2.0(@types/node@24.10.11)
       '@memberjunction/cli-core':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../CLICore
       '@memberjunction/config':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../Config
       '@memberjunction/core':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../MJCore
       '@memberjunction/core-entities':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../MJCoreEntities
       '@memberjunction/core-entities-server':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../MJCoreEntitiesServer
       '@memberjunction/generic-database-provider':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../GenericDatabaseProvider
       '@memberjunction/global':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../MJGlobal
       '@memberjunction/graphql-dataprovider':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../GraphQLDataProvider
       '@memberjunction/postgresql-dataprovider':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../PostgreSQLDataProvider
       '@memberjunction/server-bootstrap-lite':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../ServerBootstrapLite
       '@memberjunction/sql-dialect':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../SQLDialect
       '@memberjunction/sqlserver-dataprovider':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../SQLServerDataProvider
       '@oclif/core':
         specifier: ^3.27.0
@@ -12473,28 +12473,28 @@ importers:
         specifier: ^57.0.7
         version: 57.0.7(expo@54.0.35)(typescript@5.9.3)
       '@memberjunction/ai':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../AI/Core
       '@memberjunction/ai-realtime-client':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../AI/RealtimeClient
       '@memberjunction/core':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../MJCore
       '@memberjunction/core-entities':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../MJCoreEntities
       '@memberjunction/global':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../MJGlobal
       '@memberjunction/graphql-dataprovider':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../GraphQLDataProvider
       '@memberjunction/markdown-core':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../MarkdownCore
       '@memberjunction/react-runtime':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../React/runtime
       expo:
         specifier: ~54.0.0
@@ -12603,16 +12603,16 @@ importers:
   packages/OpenApp/Engine:
     dependencies:
       '@memberjunction/core':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../MJCore
       '@memberjunction/core-entities':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../MJCoreEntities
       '@memberjunction/global':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../MJGlobal
       '@memberjunction/sql-dialect':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../SQLDialect
       '@octokit/rest':
         specifier: ^21.1.1
@@ -12649,22 +12649,22 @@ importers:
   packages/PostgreSQLDataProvider:
     dependencies:
       '@memberjunction/ai-vectordb':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../AI/Vectors/Database
       '@memberjunction/core':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../MJCore
       '@memberjunction/generic-database-provider':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../GenericDatabaseProvider
       '@memberjunction/global':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../MJGlobal
       '@memberjunction/query-processor':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../QueryProcessor
       '@memberjunction/sql-dialect':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../SQLDialect
       pg:
         specifier: ^8.13.3
@@ -12686,31 +12686,31 @@ importers:
   packages/QueryGen:
     dependencies:
       '@memberjunction/ai':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../AI/Core
       '@memberjunction/ai-core-plus':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../AI/CorePlus
       '@memberjunction/ai-prompts':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../AI/Prompts
       '@memberjunction/ai-vectors-memory':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../AI/Vectors/Memory
       '@memberjunction/aiengine':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../AI/Engine
       '@memberjunction/core':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../MJCore
       '@memberjunction/core-entities':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../MJCoreEntities
       '@memberjunction/global':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../MJGlobal
       '@memberjunction/sqlserver-dataprovider':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../SQLServerDataProvider
       chalk:
         specifier: ^5.6.2
@@ -12744,13 +12744,13 @@ importers:
   packages/QueryProcessor:
     dependencies:
       '@memberjunction/core':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../MJCore
       '@memberjunction/core-entities':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../MJCoreEntities
       '@memberjunction/global':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../MJGlobal
       nunjucks:
         specifier: ^3.2.4
@@ -12778,25 +12778,25 @@ importers:
         specifier: ^7.29.0
         version: 7.29.7
       '@memberjunction/core':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../MJCore
       '@memberjunction/core-entities':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../MJCoreEntities
       '@memberjunction/global':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../MJGlobal
       '@memberjunction/interactive-component-types':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../InteractiveComponents
       '@memberjunction/react-runtime':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../runtime
       '@memberjunction/sql-dialect':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../SQLDialect
       '@memberjunction/sql-parser':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../SQLParser
       typescript:
         specifier: ^5.9.3
@@ -12815,19 +12815,19 @@ importers:
         specifier: ^7.29.1
         version: 7.29.1
       '@memberjunction/core':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../MJCore
       '@memberjunction/core-entities':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../MJCoreEntities
       '@memberjunction/global':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../MJGlobal
       '@memberjunction/graphql-dataprovider':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../GraphQLDataProvider
       '@memberjunction/interactive-component-types':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../InteractiveComponents
       rxjs:
         specifier: ^7.8.2
@@ -12876,40 +12876,40 @@ importers:
         specifier: ^7.29.0
         version: 7.29.7
       '@memberjunction/ai-core-plus':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../AI/CorePlus
       '@memberjunction/ai-vectors-memory':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../AI/Vectors/Memory
       '@memberjunction/aiengine':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../AI/Engine
       '@memberjunction/core':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../MJCore
       '@memberjunction/core-entities':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../MJCoreEntities
       '@memberjunction/core-entities-server':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../MJCoreEntitiesServer
       '@memberjunction/global':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../MJGlobal
       '@memberjunction/interactive-component-types':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../InteractiveComponents
       '@memberjunction/react-linter':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../linter
       '@memberjunction/react-runtime':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../runtime
       '@memberjunction/sql-dialect':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../SQLDialect
       '@memberjunction/sql-parser':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../SQLParser
       '@playwright/test':
         specifier: ^1.58.1
@@ -12934,7 +12934,7 @@ importers:
         version: 5.9.3
     devDependencies:
       '@memberjunction/sqlserver-dataprovider':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../SQLServerDataProvider
       '@types/mssql':
         specifier: ^9.1.9
@@ -12955,13 +12955,13 @@ importers:
   packages/RecordComparison:
     dependencies:
       '@memberjunction/core':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../MJCore
       '@memberjunction/core-entities':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../MJCoreEntities
       '@memberjunction/global':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../MJGlobal
     devDependencies:
       '@types/node':
@@ -12974,10 +12974,10 @@ importers:
   packages/RecordSetProcessor/base:
     dependencies:
       '@memberjunction/core':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../MJCore
       '@memberjunction/global':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../MJGlobal
     devDependencies:
       '@types/node':
@@ -12993,40 +12993,40 @@ importers:
   packages/RecordSetProcessor/engine:
     dependencies:
       '@memberjunction/actions':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../Actions/Engine
       '@memberjunction/actions-base':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../Actions/Base
       '@memberjunction/ai-agents':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../AI/Agents
       '@memberjunction/ai-core-plus':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../AI/CorePlus
       '@memberjunction/ai-prompts':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../AI/Prompts
       '@memberjunction/aiengine':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../AI/Engine
       '@memberjunction/core':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../MJCore
       '@memberjunction/core-entities':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../MJCoreEntities
       '@memberjunction/field-rules-transforms':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../FieldRulesTransforms
       '@memberjunction/global':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../MJGlobal
       '@memberjunction/record-set-processor-base':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../base
       '@memberjunction/templates':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../Templates/engine
     devDependencies:
       '@types/node':
@@ -13042,10 +13042,10 @@ importers:
   packages/RedisProvider:
     dependencies:
       '@memberjunction/core':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../MJCore
       '@memberjunction/global':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../MJGlobal
       ioredis:
         specifier: ^5.6.1
@@ -13064,10 +13064,10 @@ importers:
   packages/SQLConverter:
     dependencies:
       '@memberjunction/sql-dialect':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../SQLDialect
       '@memberjunction/sqlglot-ts':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../SQLGlotTS
     devDependencies:
       '@types/pg':
@@ -13107,7 +13107,7 @@ importers:
   packages/SQLParser:
     dependencies:
       '@memberjunction/sql-dialect':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../SQLDialect
       node-sql-parser:
         specifier: ^5.4.0
@@ -13123,49 +13123,49 @@ importers:
   packages/SQLServerDataProvider:
     dependencies:
       '@memberjunction/actions':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../Actions/Engine
       '@memberjunction/actions-base':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../Actions/Base
       '@memberjunction/ai':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../AI/Core
       '@memberjunction/ai-provider-bundle':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../AI/Providers/Bundle
       '@memberjunction/ai-vector-dupe':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../AI/Vectors/Dupe
       '@memberjunction/ai-vectordb':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../AI/Vectors/Database
       '@memberjunction/aiengine':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../AI/Engine
       '@memberjunction/core':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../MJCore
       '@memberjunction/core-entities':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../MJCoreEntities
       '@memberjunction/encryption':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../Encryption
       '@memberjunction/generic-database-provider':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../GenericDatabaseProvider
       '@memberjunction/global':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../MJGlobal
       '@memberjunction/query-processor':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../QueryProcessor
       '@memberjunction/queue':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../MJQueue
       '@memberjunction/sql-dialect':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../SQLDialect
       mssql:
         specifier: ^12.2.0
@@ -13196,22 +13196,22 @@ importers:
   packages/Scheduling/actions:
     dependencies:
       '@memberjunction/actions':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../Actions/Engine
       '@memberjunction/actions-base':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../Actions/Base
       '@memberjunction/core':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../MJCore
       '@memberjunction/core-entities':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../MJCoreEntities
       '@memberjunction/global':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../MJGlobal
       '@memberjunction/scheduling-base-types':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../base-types
       cron-parser:
         specifier: ^4.9.0
@@ -13230,16 +13230,16 @@ importers:
   packages/Scheduling/base-engine:
     dependencies:
       '@memberjunction/core':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../MJCore
       '@memberjunction/core-entities':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../MJCoreEntities
       '@memberjunction/global':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../MJGlobal
       '@memberjunction/scheduling-base-types':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../base-types
       rxjs:
         specifier: ^7.8.2
@@ -13255,7 +13255,7 @@ importers:
   packages/Scheduling/base-types:
     dependencies:
       '@memberjunction/global':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../MJGlobal
     devDependencies:
       '@types/node':
@@ -13268,49 +13268,49 @@ importers:
   packages/Scheduling/engine:
     dependencies:
       '@memberjunction/actions':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../Actions/Engine
       '@memberjunction/actions-base':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../Actions/Base
       '@memberjunction/ai-agents':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../AI/Agents
       '@memberjunction/ai-core-plus':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../AI/CorePlus
       '@memberjunction/ai-prompts':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../AI/Prompts
       '@memberjunction/core':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../MJCore
       '@memberjunction/core-entities':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../MJCoreEntities
       '@memberjunction/global':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../MJGlobal
       '@memberjunction/integration-engine':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../Integration/engine
       '@memberjunction/notifications':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../Communication/notifications
       '@memberjunction/record-set-processor':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../RecordSetProcessor/engine
       '@memberjunction/scheduling-base-types':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../base-types
       '@memberjunction/scheduling-engine-base':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../base-engine
       '@memberjunction/sqlserver-dataprovider':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../SQLServerDataProvider
       '@memberjunction/templates':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../Templates/engine
       cron-parser:
         specifier: ^4.9.0
@@ -13335,16 +13335,16 @@ importers:
   packages/SchemaEngine:
     dependencies:
       '@memberjunction/core':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../MJCore
       '@memberjunction/global':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../MJGlobal
       '@memberjunction/queue':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../MJQueue
       '@memberjunction/sql-dialect':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../SQLDialect
       '@octokit/rest':
         specifier: ^21.1.1
@@ -13363,25 +13363,25 @@ importers:
   packages/SearchEngine:
     dependencies:
       '@memberjunction/ai':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../AI/Core
       '@memberjunction/ai-vectordb':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../AI/Vectors/Database
       '@memberjunction/aiengine':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../AI/Engine
       '@memberjunction/core':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../MJCore
       '@memberjunction/core-entities':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../MJCoreEntities
       '@memberjunction/global':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../MJGlobal
       '@memberjunction/storage':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../MJStorage
       nunjucks:
         specifier: ^3.2.4
@@ -13404,337 +13404,337 @@ importers:
   packages/ServerBootstrap:
     dependencies:
       '@memberjunction/action-runtime-host':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../Actions/RuntimeHost
       '@memberjunction/actions':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../Actions/Engine
       '@memberjunction/actions-apollo':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../Actions/ApolloEnrichment
       '@memberjunction/actions-base':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../Actions/Base
       '@memberjunction/actions-bizapps-accounting':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../Actions/BizApps/Accounting
       '@memberjunction/actions-bizapps-crm':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../Actions/BizApps/CRM
       '@memberjunction/actions-bizapps-formbuilders':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../Actions/BizApps/FormBuilders
       '@memberjunction/actions-bizapps-lms':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../Actions/BizApps/LMS
       '@memberjunction/actions-bizapps-social':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../Actions/BizApps/Social
       '@memberjunction/actions-content-autotag':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../Actions/ContentAutotag
       '@memberjunction/ai-agent-manager':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../AI/AgentManager/core
       '@memberjunction/ai-agents':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../AI/Agents
       '@memberjunction/ai-anthropic':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../AI/Providers/Anthropic
       '@memberjunction/ai-assemblyai':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../AI/Providers/AssemblyAI
       '@memberjunction/ai-azure':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../AI/Providers/Azure
       '@memberjunction/ai-bedrock':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../AI/Providers/Bedrock
       '@memberjunction/ai-betty-bot':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../AI/Providers/BettyBot
       '@memberjunction/ai-blackforestlabs':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../AI/Providers/BlackForestLabs
       '@memberjunction/ai-bridge-livekit':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../AI/RealtimeBridge/Providers/LiveKit
       '@memberjunction/ai-bridge-ringcentral':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../AI/RealtimeBridge/Providers/RingCentral
       '@memberjunction/ai-bridge-server':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../AI/RealtimeBridge/Server
       '@memberjunction/ai-bridge-teams':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../AI/RealtimeBridge/Providers/Teams
       '@memberjunction/ai-bridge-twilio':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../AI/RealtimeBridge/Providers/Twilio
       '@memberjunction/ai-bridge-vonage':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../AI/RealtimeBridge/Providers/Vonage
       '@memberjunction/ai-cerebras':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../AI/Providers/Cerebras
       '@memberjunction/ai-cohere':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../AI/Providers/Cohere
       '@memberjunction/ai-core-plus':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../AI/CorePlus
       '@memberjunction/ai-elevenlabs':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../AI/Providers/ElevenLabs
       '@memberjunction/ai-engine-base':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../AI/BaseAIEngine
       '@memberjunction/ai-fireworks':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../AI/Providers/Fireworks
       '@memberjunction/ai-form-builder':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../AI/FormBuilder/core
       '@memberjunction/ai-gemini':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../AI/Providers/Gemini
       '@memberjunction/ai-groq':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../AI/Providers/Groq
       '@memberjunction/ai-heygen':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../AI/Providers/HeyGen
       '@memberjunction/ai-huggingface':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../AI/Providers/HuggingFace
       '@memberjunction/ai-inception':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../AI/Providers/Inception
       '@memberjunction/ai-inworld':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../AI/Providers/Inworld
       '@memberjunction/ai-llamacpp':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../AI/Providers/LlamaCpp
       '@memberjunction/ai-lmstudio':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../AI/Providers/LMStudio
       '@memberjunction/ai-local-embeddings':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../AI/Providers/LocalEmbeddings
       '@memberjunction/ai-minimax':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../AI/Providers/MiniMax
       '@memberjunction/ai-mistral':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../AI/Providers/Mistral
       '@memberjunction/ai-ollama':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../AI/Providers/Ollama
       '@memberjunction/ai-openai':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../AI/Providers/OpenAI
       '@memberjunction/ai-openrouter':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../AI/Providers/OpenRouter
       '@memberjunction/ai-prompts':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../AI/Prompts
       '@memberjunction/ai-provider-bundle':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../AI/Providers/Bundle
       '@memberjunction/ai-recommendations-rex':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../AI/Providers/Recommendations-Rex
       '@memberjunction/ai-reranker':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../AI/Reranker
       '@memberjunction/ai-segmentation':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../AI/Segmentation
       '@memberjunction/ai-vector-dupe':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../AI/Vectors/Dupe
       '@memberjunction/ai-vectors-memory':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../AI/Vectors/Memory
       '@memberjunction/ai-vectors-pgvector':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../AI/Vectors/Providers/pgvector
       '@memberjunction/ai-vectors-pinecone':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../AI/Vectors/Providers/Pinecone
       '@memberjunction/ai-vectors-qdrant':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../AI/Vectors/Providers/Qdrant
       '@memberjunction/ai-vectors-sqlserver':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../AI/Vectors/Providers/SQLServer
       '@memberjunction/ai-vertex':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../AI/Providers/Vertex
       '@memberjunction/ai-xai':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../AI/Providers/xAI
       '@memberjunction/ai-zhipu':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../AI/Providers/Zhipu
       '@memberjunction/archiving-action':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../Archiving/Action
       '@memberjunction/archiving-engine':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../Archiving/Engine
       '@memberjunction/auth-providers':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../AuthProviders
       '@memberjunction/codegen-lib':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../CodeGenLib
       '@memberjunction/communication-ms-graph':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../Communication/providers/MSGraph
       '@memberjunction/communication-sendgrid':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../Communication/providers/sendgrid
       '@memberjunction/communication-types':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../Communication/base-types
       '@memberjunction/computer-use-engine':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../AI/MJComputerUse
       '@memberjunction/content-autotagging':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../ContentAutotagging
       '@memberjunction/core':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../MJCore
       '@memberjunction/core-actions':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../Actions/CoreActions
       '@memberjunction/core-entities':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../MJCoreEntities
       '@memberjunction/core-entities-server':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../MJCoreEntitiesServer
       '@memberjunction/data-context-server':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../MJDataContextServer
       '@memberjunction/database-designer-actions':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../AI/DatabaseDesigner/actions
       '@memberjunction/database-designer-core':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../AI/DatabaseDesigner/core
       '@memberjunction/doc-utils':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../DocUtils
       '@memberjunction/encryption':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../Encryption
       '@memberjunction/entity-communications-base':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../Communication/entity-comm-base
       '@memberjunction/esignature':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../eSignature/Base
       '@memberjunction/esignature-docusign':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../eSignature/Providers/DocuSign
       '@memberjunction/esignature-dropboxsign':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../eSignature/Providers/DropboxSign
       '@memberjunction/esignature-pandadoc':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../eSignature/Providers/PandaDoc
       '@memberjunction/external-data-source-mongodb':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../ExternalDataSources/Providers/MongoDB
       '@memberjunction/external-data-source-mysql':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../ExternalDataSources/Providers/MySQL
       '@memberjunction/external-data-source-oracle':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../ExternalDataSources/Providers/Oracle
       '@memberjunction/external-data-source-postgres':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../ExternalDataSources/Providers/Postgres
       '@memberjunction/external-data-source-snowflake':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../ExternalDataSources/Providers/Snowflake
       '@memberjunction/external-data-source-sqlserver':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../ExternalDataSources/Providers/SQLServer
       '@memberjunction/external-data-sources':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../ExternalDataSources/Engine
       '@memberjunction/geo-core':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../geo/geo-core
       '@memberjunction/integration-actions':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../Integration/actions
       '@memberjunction/integration-engine':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../Integration/engine
       '@memberjunction/messaging-adapters':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../MessagingAdapters
       '@memberjunction/predictive-studio':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../AI/PredictiveStudio/Engine
       '@memberjunction/queue':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../MJQueue
       '@memberjunction/react-linter':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../React/linter
       '@memberjunction/record-comparison':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../RecordComparison
       '@memberjunction/record-set-processor':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../RecordSetProcessor/engine
       '@memberjunction/remote-browser-selfhost':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../AI/RemoteBrowser/Providers/SelfHost
       '@memberjunction/remote-browser-server':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../AI/RemoteBrowser/Server
       '@memberjunction/scheduling-actions':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../Scheduling/actions
       '@memberjunction/scheduling-engine':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../Scheduling/engine
       '@memberjunction/scheduling-engine-base':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../Scheduling/base-engine
       '@memberjunction/search-engine':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../SearchEngine
       '@memberjunction/server':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../MJServer
       '@memberjunction/server-extensions-core':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../ServerExtensionsCore
       '@memberjunction/storage':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../MJStorage
       '@memberjunction/tag-engine-base':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../AI/Knowledge/TagEngineBase
       '@memberjunction/templates':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../Templates/engine
       '@memberjunction/testing-engine':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../TestingFramework/Engine
       '@memberjunction/testing-integration':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../TestingFramework/testing-integration
       cosmiconfig:
         specifier: ^9.0.0
@@ -13750,220 +13750,220 @@ importers:
   packages/ServerBootstrapLite:
     dependencies:
       '@memberjunction/actions':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../Actions/Engine
       '@memberjunction/actions-apollo':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../Actions/ApolloEnrichment
       '@memberjunction/actions-base':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../Actions/Base
       '@memberjunction/actions-bizapps-accounting':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../Actions/BizApps/Accounting
       '@memberjunction/actions-bizapps-crm':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../Actions/BizApps/CRM
       '@memberjunction/actions-bizapps-formbuilders':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../Actions/BizApps/FormBuilders
       '@memberjunction/actions-bizapps-lms':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../Actions/BizApps/LMS
       '@memberjunction/actions-bizapps-social':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../Actions/BizApps/Social
       '@memberjunction/ai-agent-manager':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../AI/AgentManager/core
       '@memberjunction/ai-agents':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../AI/Agents
       '@memberjunction/ai-anthropic':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../AI/Providers/Anthropic
       '@memberjunction/ai-assemblyai':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../AI/Providers/AssemblyAI
       '@memberjunction/ai-azure':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../AI/Providers/Azure
       '@memberjunction/ai-bedrock':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../AI/Providers/Bedrock
       '@memberjunction/ai-betty-bot':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../AI/Providers/BettyBot
       '@memberjunction/ai-blackforestlabs':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../AI/Providers/BlackForestLabs
       '@memberjunction/ai-cerebras':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../AI/Providers/Cerebras
       '@memberjunction/ai-cohere':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../AI/Providers/Cohere
       '@memberjunction/ai-core-plus':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../AI/CorePlus
       '@memberjunction/ai-elevenlabs':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../AI/Providers/ElevenLabs
       '@memberjunction/ai-engine-base':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../AI/BaseAIEngine
       '@memberjunction/ai-fireworks':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../AI/Providers/Fireworks
       '@memberjunction/ai-form-builder':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../AI/FormBuilder/core
       '@memberjunction/ai-gemini':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../AI/Providers/Gemini
       '@memberjunction/ai-groq':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../AI/Providers/Groq
       '@memberjunction/ai-heygen':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../AI/Providers/HeyGen
       '@memberjunction/ai-inception':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../AI/Providers/Inception
       '@memberjunction/ai-inworld':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../AI/Providers/Inworld
       '@memberjunction/ai-llamacpp':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../AI/Providers/LlamaCpp
       '@memberjunction/ai-lmstudio':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../AI/Providers/LMStudio
       '@memberjunction/ai-local-embeddings':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../AI/Providers/LocalEmbeddings
       '@memberjunction/ai-minimax':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../AI/Providers/MiniMax
       '@memberjunction/ai-mistral':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../AI/Providers/Mistral
       '@memberjunction/ai-ollama':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../AI/Providers/Ollama
       '@memberjunction/ai-openai':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../AI/Providers/OpenAI
       '@memberjunction/ai-openrouter':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../AI/Providers/OpenRouter
       '@memberjunction/ai-prompts':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../AI/Prompts
       '@memberjunction/ai-provider-bundle':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../AI/Providers/Bundle
       '@memberjunction/ai-recommendations-rex':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../AI/Providers/Recommendations-Rex
       '@memberjunction/ai-reranker':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../AI/Reranker
       '@memberjunction/ai-vector-dupe':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../AI/Vectors/Dupe
       '@memberjunction/ai-vectors-memory':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../AI/Vectors/Memory
       '@memberjunction/ai-vectors-pgvector':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../AI/Vectors/Providers/pgvector
       '@memberjunction/ai-vectors-pinecone':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../AI/Vectors/Providers/Pinecone
       '@memberjunction/ai-vectors-qdrant':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../AI/Vectors/Providers/Qdrant
       '@memberjunction/ai-vectors-sqlserver':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../AI/Vectors/Providers/SQLServer
       '@memberjunction/ai-vertex':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../AI/Providers/Vertex
       '@memberjunction/ai-xai':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../AI/Providers/xAI
       '@memberjunction/ai-zhipu':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../AI/Providers/Zhipu
       '@memberjunction/communication-types':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../Communication/base-types
       '@memberjunction/content-autotagging':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../ContentAutotagging
       '@memberjunction/core':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../MJCore
       '@memberjunction/core-actions':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../Actions/CoreActions
       '@memberjunction/core-entities':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../MJCoreEntities
       '@memberjunction/core-entities-server':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../MJCoreEntitiesServer
       '@memberjunction/data-context-server':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../MJDataContextServer
       '@memberjunction/doc-utils':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../DocUtils
       '@memberjunction/encryption':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../Encryption
       '@memberjunction/geo-core':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../geo/geo-core
       '@memberjunction/predictive-studio':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../AI/PredictiveStudio/Engine
       '@memberjunction/queue':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../MJQueue
       '@memberjunction/react-linter':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../React/linter
       '@memberjunction/record-comparison':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../RecordComparison
       '@memberjunction/record-set-processor':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../RecordSetProcessor/engine
       '@memberjunction/scheduling-actions':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../Scheduling/actions
       '@memberjunction/scheduling-engine':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../Scheduling/engine
       '@memberjunction/scheduling-engine-base':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../Scheduling/base-engine
       '@memberjunction/search-engine':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../SearchEngine
       '@memberjunction/storage':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../MJStorage
       '@memberjunction/tag-engine-base':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../AI/Knowledge/TagEngineBase
       '@memberjunction/templates':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../Templates/engine
       '@memberjunction/testing-engine':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../TestingFramework/Engine
     devDependencies:
       '@types/node':
@@ -13976,10 +13976,10 @@ importers:
   packages/ServerExtensionsCore:
     dependencies:
       '@memberjunction/core':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../MJCore
       '@memberjunction/global':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../MJGlobal
       express:
         specifier: ^5.2.1
@@ -14013,13 +14013,13 @@ importers:
   packages/Templates/base-types:
     dependencies:
       '@memberjunction/core':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../MJCore
       '@memberjunction/core-entities':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../MJCoreEntities
       '@memberjunction/global':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../MJGlobal
     devDependencies:
       typescript:
@@ -14029,28 +14029,28 @@ importers:
   packages/Templates/engine:
     dependencies:
       '@memberjunction/ai':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../AI/Core
       '@memberjunction/ai-core-plus':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../AI/CorePlus
       '@memberjunction/ai-provider-bundle':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../AI/Providers/Bundle
       '@memberjunction/aiengine':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../AI/Engine
       '@memberjunction/core':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../MJCore
       '@memberjunction/core-entities':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../MJCoreEntities
       '@memberjunction/global':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../MJGlobal
       '@memberjunction/templates-base-types':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../base-types
       nunjucks:
         specifier: 3.2.4
@@ -14063,25 +14063,25 @@ importers:
   packages/TestingFramework/CLI:
     dependencies:
       '@memberjunction/core':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../MJCore
       '@memberjunction/core-entities':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../MJCoreEntities
       '@memberjunction/global':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../MJGlobal
       '@memberjunction/sqlserver-dataprovider':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../SQLServerDataProvider
       '@memberjunction/testing-engine':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../Engine
       '@memberjunction/testing-engine-base':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../EngineBase
       '@memberjunction/testing-integration':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../testing-integration
       '@oclif/core':
         specifier: ^3.27.0
@@ -14124,31 +14124,31 @@ importers:
   packages/TestingFramework/Engine:
     dependencies:
       '@memberjunction/ai':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../AI/Core
       '@memberjunction/ai-agents':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../AI/Agents
       '@memberjunction/ai-core-plus':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../AI/CorePlus
       '@memberjunction/ai-prompts':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../AI/Prompts
       '@memberjunction/aiengine':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../AI/Engine
       '@memberjunction/core':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../MJCore
       '@memberjunction/core-entities':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../MJCoreEntities
       '@memberjunction/global':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../MJGlobal
       '@memberjunction/testing-engine-base':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../EngineBase
       debug:
         specifier: ^4.4.3
@@ -14176,13 +14176,13 @@ importers:
   packages/TestingFramework/EngineBase:
     dependencies:
       '@memberjunction/core':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../MJCore
       '@memberjunction/core-entities':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../MJCoreEntities
       '@memberjunction/global':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../MJGlobal
       debug:
         specifier: ^4.4.3
@@ -14204,121 +14204,121 @@ importers:
   packages/TestingFramework/integration-test-suite:
     dependencies:
       '@memberjunction/actions':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../Actions/Engine
       '@memberjunction/actions-base':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../Actions/Base
       '@memberjunction/ai':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../AI/Core
       '@memberjunction/ai-agents':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../AI/Agents
       '@memberjunction/ai-bridge-base':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../AI/RealtimeBridge/Base
       '@memberjunction/ai-bridge-server':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../AI/RealtimeBridge/Server
       '@memberjunction/ai-core-plus':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../AI/CorePlus
       '@memberjunction/ai-engine-base':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../AI/BaseAIEngine
       '@memberjunction/ai-prompts':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../AI/Prompts
       '@memberjunction/aiengine':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../AI/Engine
       '@memberjunction/api-keys':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../APIKeys/Engine
       '@memberjunction/codegen-lib':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../CodeGenLib
       '@memberjunction/communication-engine':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../Communication/engine
       '@memberjunction/communication-expo-push':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../Communication/providers/expo-push
       '@memberjunction/communication-gmail':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../Communication/providers/gmail
       '@memberjunction/communication-ms-graph':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../Communication/providers/MSGraph
       '@memberjunction/communication-sendgrid':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../Communication/providers/sendgrid
       '@memberjunction/communication-twilio':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../Communication/providers/twilio
       '@memberjunction/communication-types':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../Communication/base-types
       '@memberjunction/content-autotagging':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../ContentAutotagging
       '@memberjunction/conversations-runtime':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../ConversationsRuntime
       '@memberjunction/core':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../MJCore
       '@memberjunction/core-entities':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../MJCoreEntities
       '@memberjunction/global':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../MJGlobal
       '@memberjunction/graphql-dataprovider':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../GraphQLDataProvider
       '@memberjunction/metadata-sync':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../MetadataSync
       '@memberjunction/notifications':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../Communication/notifications
       '@memberjunction/open-app-engine':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../OpenApp/Engine
       '@memberjunction/predictive-studio':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../AI/PredictiveStudio/Engine
       '@memberjunction/predictive-studio-core':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../AI/PredictiveStudio/Core
       '@memberjunction/query-processor':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../QueryProcessor
       '@memberjunction/record-set-processor':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../RecordSetProcessor/engine
       '@memberjunction/record-set-processor-base':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../RecordSetProcessor/base
       '@memberjunction/scheduling-engine':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../Scheduling/engine
       '@memberjunction/search-engine':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../SearchEngine
       '@memberjunction/sqlserver-dataprovider':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../SQLServerDataProvider
       '@memberjunction/templates':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../Templates/engine
       '@memberjunction/templates-base-types':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../Templates/base-types
       '@memberjunction/testing-integration':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../testing-integration
       dotenv:
         specifier: 17.2.4
@@ -14340,28 +14340,28 @@ importers:
   packages/TestingFramework/testing-integration:
     dependencies:
       '@memberjunction/core':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../MJCore
       '@memberjunction/core-entities':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../MJCoreEntities
       '@memberjunction/global':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../MJGlobal
       '@memberjunction/graphql-dataprovider':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../GraphQLDataProvider
       '@memberjunction/server-bootstrap-lite':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../ServerBootstrapLite
       '@memberjunction/sqlserver-dataprovider':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../SQLServerDataProvider
       '@memberjunction/testing-engine':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../Engine
       '@memberjunction/testing-engine-base':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../EngineBase
       cosmiconfig:
         specifier: 9.0.0
@@ -14384,7 +14384,7 @@ importers:
         version: 4.0.18(@types/node@24.10.11)(jiti@2.6.1)(jsdom@26.1.0)(less@4.4.2)(lightningcss@1.32.0)(sass@1.97.3)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2)
     optionalDependencies:
       '@memberjunction/postgresql-dataprovider':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../PostgreSQLDataProvider
 
   packages/ThemeEngine:
@@ -14396,7 +14396,7 @@ importers:
   packages/UnitTesting:
     dependencies:
       '@memberjunction/global':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../MJGlobal
     devDependencies:
       ts-node-dev:
@@ -14412,13 +14412,13 @@ importers:
   packages/VersionHistory:
     dependencies:
       '@memberjunction/core':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../MJCore
       '@memberjunction/core-entities':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../MJCoreEntities
       '@memberjunction/global':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../MJGlobal
     devDependencies:
       typescript:
@@ -14428,25 +14428,25 @@ importers:
   packages/Web/RealtimeWidget:
     dependencies:
       '@memberjunction/ai':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../AI/Core
       '@memberjunction/ai-realtime-client':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../AI/RealtimeClient
       '@memberjunction/conversations-runtime':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../ConversationsRuntime
       '@memberjunction/core':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../MJCore
       '@memberjunction/core-entities':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../MJCoreEntities
       '@memberjunction/global':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../MJGlobal
       '@memberjunction/graphql-dataprovider':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../GraphQLDataProvider
     devDependencies:
       '@types/node':
@@ -14465,28 +14465,28 @@ importers:
   packages/eSignature/Base:
     dependencies:
       '@memberjunction/core':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../MJCore
       '@memberjunction/core-entities':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../MJCoreEntities
       '@memberjunction/credentials':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../Credentials/Engine
       '@memberjunction/global':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../MJGlobal
       '@memberjunction/storage':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../MJStorage
 
   packages/eSignature/Providers/DocuSign:
     dependencies:
       '@memberjunction/esignature':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../Base
       '@memberjunction/global':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../../MJGlobal
       jsonwebtoken:
         specifier: ^9.0.0
@@ -14499,31 +14499,31 @@ importers:
   packages/eSignature/Providers/DropboxSign:
     dependencies:
       '@memberjunction/esignature':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../Base
       '@memberjunction/global':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../../MJGlobal
 
   packages/eSignature/Providers/PandaDoc:
     dependencies:
       '@memberjunction/esignature':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../Base
       '@memberjunction/global':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../../MJGlobal
 
   packages/geo/geo-core:
     dependencies:
       '@memberjunction/core':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../MJCore
       '@memberjunction/core-entities':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../MJCoreEntities
       '@memberjunction/global':
-        specifier: 6.0.0
+        specifier: 6.1.0-edge.0
         version: link:../../MJGlobal
     devDependencies:
       '@types/node':
@@ -29138,7 +29138,7 @@ snapshots:
     dependencies:
       '@ampproject/remapping': 2.3.0
       '@angular-devkit/architect': 0.2101.3(chokidar@5.0.0)
-      '@angular-devkit/build-webpack': 0.2101.3(chokidar@5.0.0)(webpack-dev-server@5.2.2(tslib@2.8.1)(webpack@5.105.0(esbuild@0.27.2)))(webpack@5.105.0(esbuild@0.27.2))
+      '@angular-devkit/build-webpack': 0.2101.3(chokidar@5.0.0)(webpack-dev-server@5.2.2(debug@4.4.3)(tslib@2.8.1)(webpack@5.105.0(esbuild@0.27.2)))(webpack@5.105.0(esbuild@0.27.2))
       '@angular-devkit/core': 21.1.3(chokidar@5.0.0)
       '@angular/build': 21.1.3(a1c152c28654637a273e49d67cbd7227)
       '@angular/compiler-cli': 21.1.3(@angular/compiler@21.1.3)(typescript@5.9.3)
@@ -29189,7 +29189,7 @@ snapshots:
       typescript: 5.9.3
       webpack: 5.105.0(esbuild@0.27.2)
       webpack-dev-middleware: 7.4.5(tslib@2.8.1)(webpack@5.105.0(esbuild@0.27.2))
-      webpack-dev-server: 5.2.2(tslib@2.8.1)(webpack@5.105.0(esbuild@0.27.2))
+      webpack-dev-server: 5.2.2(debug@4.4.3)(tslib@2.8.1)(webpack@5.105.0(esbuild@0.27.2))
       webpack-merge: 6.0.1
       webpack-subresource-integrity: 5.1.0(webpack@5.105.0(esbuild@0.27.2))
     optionalDependencies:
@@ -29228,15 +29228,6 @@ snapshots:
       rxjs: 7.8.2
       webpack: 5.105.0(esbuild@0.27.2)
       webpack-dev-server: 5.2.2(debug@4.4.3)(tslib@2.8.1)(webpack@5.105.0(esbuild@0.27.2))
-    transitivePeerDependencies:
-      - chokidar
-
-  '@angular-devkit/build-webpack@0.2101.3(chokidar@5.0.0)(webpack-dev-server@5.2.2(tslib@2.8.1)(webpack@5.105.0(esbuild@0.27.2)))(webpack@5.105.0(esbuild@0.27.2))':
-    dependencies:
-      '@angular-devkit/architect': 0.2101.3(chokidar@5.0.0)
-      rxjs: 7.8.2
-      webpack: 5.105.0(esbuild@0.27.2)
-      webpack-dev-server: 5.2.2(tslib@2.8.1)(webpack@5.105.0(esbuild@0.27.2))
     transitivePeerDependencies:
       - chokidar
 
@@ -42130,7 +42121,7 @@ snapshots:
 
   google-logging-utils@1.1.3: {}
 
-  googleapis-common@7.2.0(encoding@0.1.13):
+  googleapis-common@7.2.0:
     dependencies:
       extend: 3.0.2
       gaxios: 6.7.1(encoding@0.1.13)
@@ -42153,10 +42144,10 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  googleapis@144.0.0(encoding@0.1.13):
+  googleapis@144.0.0:
     dependencies:
       google-auth-library: 9.15.1(encoding@0.1.13)
-      googleapis-common: 7.2.0(encoding@0.1.13)
+      googleapis-common: 7.2.0
     transitivePeerDependencies:
       - encoding
       - supports-color
@@ -48054,45 +48045,6 @@ snapshots:
       - tslib
 
   webpack-dev-server@5.2.2(debug@4.4.3)(tslib@2.8.1)(webpack@5.105.0(esbuild@0.27.2)):
-    dependencies:
-      '@types/bonjour': 3.5.13
-      '@types/connect-history-api-fallback': 1.5.4
-      '@types/express': 4.17.25
-      '@types/express-serve-static-core': 4.19.8
-      '@types/serve-index': 1.9.4
-      '@types/serve-static': 1.15.10
-      '@types/sockjs': 0.3.36
-      '@types/ws': 8.18.1
-      ansi-html-community: 0.0.8
-      bonjour-service: 1.3.0
-      chokidar: 3.6.0
-      colorette: 2.0.20
-      compression: 1.8.1
-      connect-history-api-fallback: 2.0.0
-      express: 4.22.1
-      graceful-fs: 4.2.11
-      http-proxy-middleware: 2.0.9(@types/express@4.17.25)(debug@4.4.3)
-      ipaddr.js: 2.3.0
-      launch-editor: 2.12.0
-      open: 10.2.0
-      p-retry: 6.2.1
-      schema-utils: 4.3.3
-      selfsigned: 2.4.1
-      serve-index: 1.9.2
-      sockjs: 0.3.24
-      spdy: 4.0.2
-      webpack-dev-middleware: 7.4.5(tslib@2.8.1)(webpack@5.105.0(esbuild@0.27.2))
-      ws: 8.19.0
-    optionalDependencies:
-      webpack: 5.105.0(esbuild@0.27.2)
-    transitivePeerDependencies:
-      - bufferutil
-      - debug
-      - supports-color
-      - tslib
-      - utf-8-validate
-
-  webpack-dev-server@5.2.2(tslib@2.8.1)(webpack@5.105.0(esbuild@0.27.2)):
     dependencies:
       '@types/bonjour': 3.5.13
       '@types/connect-history-api-fallback': 1.5.4


### PR DESCRIPTION
Cherry-pick of #3502 (already merged to `next`) onto `main`.

`publish.yml` runs from `main`, and `main` still carries the broken invocation, so a `workflow_dispatch` today would fail exactly the same way. This puts the fix where the workflow actually reads it.

Identical commit — no changes beyond the cherry-pick. Full root-cause writeup in #3502.

### ⚠️ Merging this triggers `publish.yml`

That is the intent — it is how `v6.1.0-edge.0` reaches npm, and no separate dispatch is needed afterward. What the triggered run will do:

- `changeset version` is a **no-op**: the 25 changesets were consumed by the previous run and every package already reads `6.1.0-edge.0`. Nothing gets re-versioned.
- The channel step reads `6.1.0-edge.0` from `packages/MJServer/package.json` → dist-tag **`edge`**, prerelease true.
- `changeset publish` publishes the 299 packages. It skips anything already on npm, so this is safe even if some subset somehow landed.

**Do not cancel that run.** Its Cancel button has no confirmation dialog, and a cancel mid-publish splits the fixed-version group across two versions on npm with no rollback (this happened in v5.49.0). If it fails on its own, `gh run rerun <id> --failed` is the recovery.

The new assertion in the publish step means a repeat of the silent failure now fails the job loudly instead of reporting success.

🤖 Generated with [Claude Code](https://claude.com/claude-code)