### PR TITLE
fix(ci): omit --tag when changesets is in pre mode

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -204,9 +204,19 @@ jobs:
         # v6.1.0-edge.0 was version-bumped, tagged and back-merged while ZERO packages reached
         # npm — a release the repo believes shipped and the registry has never heard of.
         # `set -o pipefail` + an explicit publish-happened assertion below make a repeat loud.
+        #
+        # 🚨 And in changesets PRE MODE, `--tag` must be OMITTED entirely — changesets rejects it
+        # with "Releasing under custom tag is not allowed in pre mode" and publishes under the tag
+        # from .changeset/pre.json instead (currently `edge`), which is the tag we wanted anyway.
+        # The channel step's NPM_TAG stays authoritative outside pre mode.
         run: |
           set -euo pipefail
-          pnpm exec changeset publish --tag ${{ steps.channel.outputs.NPM_TAG }} 2>&1 | tee /tmp/publish.log
+          if [ "${{ steps.premode.outputs.MODE }}" = "pre" ]; then
+            echo "::notice::changesets pre mode — publishing under the pre.json tag ($(jq -r .tag .changeset/pre.json)); --tag is not permitted"
+            pnpm exec changeset publish 2>&1 | tee /tmp/publish.log
+          else
+            pnpm exec changeset publish --tag ${{ steps.channel.outputs.NPM_TAG }} 2>&1 | tee /tmp/publish.log
+          fi
           if ! grep -qE 'New tag:|Packages published|already published' /tmp/publish.log; then
             echo "::error::changeset publish produced no evidence of a publish — refusing to report success."
             exit 1


### PR DESCRIPTION
Second defect in the same step, surfaced by the assertion added in #3503.

With the `--` argument bug fixed, changesets got far enough to reject the flag itself:

```
🦋  error Releasing under custom tag is not allowed in pre mode
```

In **pre mode**, changesets derives the npm dist-tag from `.changeset/pre.json` (`"tag": "edge"`) and refuses an explicit `--tag`. That is the tag this release wanted anyway — the flag was never doing anything except failing the command.

**Fix:** branch on the MODE the workflow already computes in the `premode` step (step 7; the publish step is 13, so it's in scope). Omit `--tag` in pre mode; keep the channel step's `NPM_TAG` authoritative outside it.

### Worth noting

Between this and #3503, **this workflow has never successfully published an edge release.** The previous attempt only appeared to, because the step reported `success` over a failed command — which is how `v6.1.0-edge.0` got tagged, version-bumped and back-merged while npm never received a single package.

The publish-happened assertion from #3503 is what caught this one: the job **failed loudly** instead of going green over an empty registry. That guard is doing exactly what it was added for.

### After merge

Merging triggers `publish.yml`. `changeset version` remains a no-op (packages already read `6.1.0-edge.0`), and `changeset publish` will publish the 299 packages under dist-tag `edge`. Verify against the registry, not the workflow's exit code:

```bash
npm view @memberjunction/core dist-tags
```

**Do not cancel that run.** If it fails, `gh run rerun <id> --failed` — `changeset publish` skips anything already on npm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)