### PR TITLE
feat(docs-site): versioned site (/v5 LTS + /v6 Edge) + remove internal pages from the public site

### DIFF
--- a/.github/workflows/docs-site-ci.yml
+++ b/.github/workflows/docs-site-ci.yml
@@ -10,7 +10,6 @@ on:
       - 'docs-site/**'
       - 'guides/**'
       - 'README.md'
-      - 'DEPLOYMENT.md'
       - 'UPGRADE-v5.0.md'
       - 'CONTRIBUTING.md'
       - 'metadata/README.md'
@@ -53,7 +52,10 @@ jobs:
         run: npm run build
         working-directory: docs-site
         env:
-          # Mirror the deploy config (docs.yml) so CI builds what prod ships.
-          DOCS_BASE: /
+          # Mirror one leg of the versioned deploy (docs.yml) so CI builds what
+          # prod ships, version switcher included.
+          DOCS_BASE: /v6
           DOCS_SITE: https://docs.memberjunction.org
+          DOCS_VERSION: v6
+          DOCS_VERSIONS: '[{"id":"v5","label":"v5 (LTS)"},{"id":"v6","label":"v6 (Edge)"}]'
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,5 +1,20 @@
 name: Update package documentation
 
+# Versioned docs deploy: one Starlight build per release line, assembled into a
+# single GitHub Pages site.
+#
+#   /v5/…  ← content at lts/5 (one set per lts/* branch — the branch IS the
+#            line's certification artifact, so no ref is hardcoded here)
+#   /v6/…  ← content at next (the Edge line; major from the newest v*-edge tag)
+#   /      ← redirect to the newest LTS set
+#   404    ← forwards legacy pre-versioning URLs into the newest LTS set
+#
+# Every build uses the docs-site/ TOOLING from next (overlaid onto the content
+# checkout), so ingest/site fixes apply to all versions without cherry-picks.
+# Because this file lives on the default branch (next), the workflow_run
+# trigger fires from here regardless of what main or lts/* carry; pushes to
+# lts/* are forwarded by the thin dispatcher workflow on those branches.
+
 on:
   workflow_run:
     workflows: [Build and publish new package versions]
@@ -7,28 +22,22 @@ on:
     types:
       - completed
 
-  # Docs content changes that land on main or the LTS line outside a release
-  # cycle. The lts/5 trigger is what makes line release notes self-deploying:
-  # the notes commit pushed to lts/5 touches releases/** and fires this.
+  # Docs content or tooling changes on next: Edge content and the shared
+  # tooling both live here, so any of these paths can change the built site.
   push:
-    branches: [main, lts/5]
+    branches: [next]
     paths:
       - 'docs-site/**'
       - 'guides/**'
       - 'README.md'
-      - 'DEPLOYMENT.md'
       - 'UPGRADE-v5.0.md'
       - 'CONTRIBUTING.md'
       - 'metadata/README.md'
       - '.claude/skills/**'
       - 'releases/**'
+      - '.github/workflows/docs.yml'
 
-  workflow_dispatch:
-    inputs:
-      ref:
-        description: 'Git ref to build the site from (defaults to the certified LTS line)'
-        required: false
-        default: 'lts/5'
+  workflow_dispatch: {}
 
 permissions:
   contents: read
@@ -40,10 +49,14 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
-  docs:
-    name: Generate and deploy documentation site
-    timeout-minutes: 45
+  resolve:
+    name: Resolve release lines to build
+    timeout-minutes: 5
     runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.lines.outputs.MATRIX }}
+      versions: ${{ steps.lines.outputs.VERSIONS }}
+      default: ${{ steps.lines.outputs.DEFAULT }}
     steps:
       - name: Error out if the trigger did not succeed
         run: |
@@ -52,19 +65,85 @@ jobs:
             exit 1
           fi
 
-      # The public site documents the LTS line, whatever branch fired the
-      # trigger. Without an explicit ref, workflow_run events check out the
-      # repo DEFAULT branch (next) — verified from past run history — which
-      # after the 6.x era opens would publish Edge dev content on every
-      # release. Pinned until versioned docs (/v5, /v6) land; update this ref
-      # when a new line certifies.
+      # github.sha is the commit this run was triggered for: the pushed next
+      # commit, the default-branch head for workflow_run, or the chosen ref's
+      # head for a manual dispatch (which is what lets a feature branch test
+      # the full pipeline before merging).
       - name: Checkout repo
         uses: actions/checkout@v4
         with:
-          fetch-depth: 0
-          ref: ${{ github.event.inputs.ref || 'lts/5' }}
+          ref: ${{ github.sha }}
+          fetch-depth: 1
 
-      # lts/5 is the last npm line; 6.x and every later LTS line use pnpm. The
+      - name: Enumerate release lines
+        id: lines
+        run: |
+          set -euo pipefail
+          # LTS sets: one per lts/N branch. The branch is created by the LTS
+          # process at line cut, so its existence is the source of truth for
+          # "this line has public docs".
+          mapfile -t LTS < <(git ls-remote --heads origin 'lts/*' | sed -E 's#.*refs/heads/lts/##' | grep -E '^[0-9]+$' | sort -n)
+          # Edge set: built from next; its major comes from the newest edge tag.
+          EDGE_MAJOR=$(git ls-remote --tags origin 'v*-edge.*' | sed -E 's#.*refs/tags/v##; s#\^\{\}$##' | sort -uV | tail -1 | cut -d. -f1)
+
+          MATRIX='[]'
+          VERSIONS='[]'
+          for major in ${LTS[@]+"${LTS[@]}"}; do
+            MATRIX=$(jq -c --arg id "v$major" --arg ref "lts/$major" '. + [{id: $id, ref: $ref}]' <<<"$MATRIX")
+            VERSIONS=$(jq -c --arg id "v$major" --arg label "v$major (LTS)" '. + [{id: $id, label: $label}]' <<<"$VERSIONS")
+          done
+          if [ -n "$EDGE_MAJOR" ] && ! printf '%s\n' ${LTS[@]+"${LTS[@]}"} | grep -qx "$EDGE_MAJOR"; then
+            MATRIX=$(jq -c --arg id "v$EDGE_MAJOR" '. + [{id: $id, ref: "next"}]' <<<"$MATRIX")
+            VERSIONS=$(jq -c --arg id "v$EDGE_MAJOR" --arg label "v$EDGE_MAJOR (Edge)" '. + [{id: $id, label: $label}]' <<<"$VERSIONS")
+          else
+            echo "::warning::No distinct Edge line to publish (edge major: '$EDGE_MAJOR', LTS lines: ${LTS[*]:-none}) — an lts/N branch supersedes the Edge set for the same major."
+          fi
+
+          if [ "$(jq length <<<"$MATRIX")" -eq 0 ]; then
+            echo "::error::No release lines found (no lts/* branches and no v*-edge.* tags)"
+            exit 1
+          fi
+          # The site default (root redirect target) is the newest LTS line —
+          # the certified public face. Before any line exists, fall back to Edge.
+          if [ "${#LTS[@]}" -gt 0 ]; then DEFAULT="v${LTS[-1]}"; else DEFAULT="v$EDGE_MAJOR"; fi
+
+          {
+            echo "MATRIX=$MATRIX"
+            echo "VERSIONS=$VERSIONS"
+            echo "DEFAULT=$DEFAULT"
+          } >> "$GITHUB_OUTPUT"
+          echo "::notice::Building versions: $VERSIONS (default: $DEFAULT)"
+
+  build:
+    name: Build ${{ matrix.id }} (${{ matrix.ref }})
+    needs: resolve
+    timeout-minutes: 45
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        include: ${{ fromJSON(needs.resolve.outputs.matrix) }}
+    steps:
+      # fetch-depth 0 serves two needs: Starlight's lastUpdated reads per-file
+      # git history, and the full fetch brings origin/next for the tooling
+      # overlay below.
+      - name: Checkout content ref
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: ${{ matrix.ref }}
+
+      # The site tooling (ingest, Astro config, hand-authored pages) always
+      # comes from the commit that triggered this run — next in normal
+      # operation — whatever ref the content is at. This is what makes tooling
+      # fixes (e.g. the internal-page exclusions) apply to every version
+      # without cherry-picking to lts/* branches.
+      - name: Overlay docs-site tooling from the triggering commit
+        run: |
+          set -euo pipefail
+          rm -rf docs-site
+          git checkout ${{ github.sha }} -- docs-site
+
+      # lts/5 is the last npm line; 6.x and every later line use pnpm. The
       # lockfile committed on the checked-out ref is the signal, so this needs
       # no edit when a new line is cut.
       - name: Detect package manager
@@ -75,11 +154,11 @@ jobs:
           elif [ -f package-lock.json ]; then
             PM=npm
           else
-            echo "::error::No lockfile found on ${{ github.ref_name }}"
+            echo "::error::No lockfile found on ${{ matrix.ref }}"
             exit 1
           fi
           echo "PM=$PM" >> "$GITHUB_OUTPUT"
-          echo "::notice::Package manager for this ref: $PM"
+          echo "::notice::Package manager for ${{ matrix.ref }}: $PM"
 
       - name: Set up pnpm
         if: steps.pm.outputs.PM == 'pnpm'
@@ -90,9 +169,9 @@ jobs:
         with:
           node-version: 24
           cache: 'npm'
-          cache-dependency-path: |
-            package-lock.json
-            docs-site/package-lock.json
+          # Root-install caching would need era-aware lockfile paths; only the
+          # docs-site install (always npm, tooling from next) is cached.
+          cache-dependency-path: docs-site/package-lock.json
 
       - name: Install dependencies
         run: ${{ steps.pm.outputs.PM == 'pnpm' && 'pnpm install --frozen-lockfile' || 'npm ci' }}
@@ -101,7 +180,7 @@ jobs:
         run: ${{ steps.pm.outputs.PM }} run build
 
       - name: Generate API reference (TypeDoc)
-        run: npx typedoc
+        run: ${{ steps.pm.outputs.PM == 'pnpm' && 'pnpm exec typedoc' || 'npx typedoc' }}
 
       - name: Install docs site dependencies
         run: npm ci
@@ -115,10 +194,12 @@ jobs:
         run: npm run build
         working-directory: docs-site
         env:
-          # Custom domain (docs.memberjunction.org) serves the site at the
-          # domain ROOT — no /MJ/ repo prefix. github.io/MJ/ 301s here.
-          DOCS_BASE: /
+          # Each version is served under its /vN prefix on the custom domain
+          # (docs.memberjunction.org — no /MJ/ project prefix, github.io 301s).
+          DOCS_BASE: /${{ matrix.id }}
           DOCS_SITE: https://docs.memberjunction.org
+          DOCS_VERSION: ${{ matrix.id }}
+          DOCS_VERSIONS: ${{ needs.resolve.outputs.versions }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Attach API reference under /api
@@ -126,13 +207,99 @@ jobs:
           mkdir -p docs-site/dist/api
           cp -R docs/. docs-site/dist/api/
 
+      - name: Upload version artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: site-${{ matrix.id }}
+          path: docs-site/dist
+          retention-days: 3
+
+  deploy:
+    name: Assemble and deploy
+    needs: [resolve, build]
+    timeout-minutes: 15
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download version artifacts
+        uses: actions/download-artifact@v4
+        with:
+          pattern: site-*
+          path: dist
+
+      - name: Assemble versioned site
+        env:
+          VERSIONS: ${{ needs.resolve.outputs.versions }}
+          DEFAULT: ${{ needs.resolve.outputs.default }}
+        run: |
+          set -euo pipefail
+          # dist/site-v5 -> dist/v5, matching each build's /vN base path.
+          for d in dist/site-*; do
+            mv "$d" "dist/${d#dist/site-}"
+          done
+          ls dist
+
+          IDS_JS=$(jq -c '[.[].id]' <<<"$VERSIONS")
+          LINKS_MD=$(jq -r 'map("<li><a href=\"/\(.id)/\">\(.label)</a></li>") | join("")' <<<"$VERSIONS")
+
+          # Root redirect: the site's front door is the newest LTS set.
+          cat > dist/index.html <<EOF
+          <!doctype html>
+          <html lang="en">
+          <head>
+          <meta charset="utf-8">
+          <meta http-equiv="refresh" content="0; url=/$DEFAULT/">
+          <link rel="canonical" href="https://docs.memberjunction.org/$DEFAULT/">
+          <title>MemberJunction Documentation</title>
+          </head>
+          <body><a href="/$DEFAULT/">MemberJunction documentation</a></body>
+          </html>
+          EOF
+
+          # Sitewide 404 (GitHub Pages serves only the root one). Forwards
+          # legacy pre-versioning URLs (/guides/x/, /api/…, old root TypeDoc
+          # deep links) into the default set; a path already carrying a /vN
+          # prefix is never re-forwarded, so every request redirects at most
+          # twice (legacy -> /vN -> /vN/api for old TypeDoc paths).
+          cat > dist/404.html <<EOF
+          <!doctype html>
+          <html lang="en">
+          <head>
+          <meta charset="utf-8">
+          <title>Page not found — MemberJunction Documentation</title>
+          <script>
+          (function () {
+            var versions = $IDS_JS;
+            var fallback = '/$DEFAULT';
+            var path = location.pathname;
+            var prefixed = versions.some(function (v) {
+              return path === '/' + v || path.indexOf('/' + v + '/') === 0;
+            });
+            if (!prefixed) {
+              location.replace(fallback + path + location.search + location.hash);
+              return;
+            }
+            var deep = path.match(/^(\/v\d+)\/(classes|interfaces|enums|functions|modules|variables|types|documents|media|hierarchy)\/(.+)\$/);
+            if (deep) {
+              location.replace(deep[1] + '/api/' + deep[2] + '/' + deep[3] + location.search + location.hash);
+            }
+          })();
+          </script>
+          </head>
+          <body>
+          <h1>Page not found</h1>
+          <p>That page doesn't exist in this version of the documentation. Try one of the documentation sets:</p>
+          <ul>$LINKS_MD</ul>
+          </body>
+          </html>
+          EOF
+
       - name: Setup Pages
         uses: actions/configure-pages@v5
 
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3
         with:
-          path: 'docs-site/dist'
+          path: 'dist'
 
       - name: Deploy to GitHub Pages
         id: deployment

--- a/docs-site/astro.config.mjs
+++ b/docs-site/astro.config.mjs
@@ -34,14 +34,18 @@ export default defineConfig({
       editLink: { baseUrl: 'https://github.com/MemberJunction/MJ/edit/next/docs-site/' },
       lastUpdated: true,
       customCss: ['./src/styles/custom.css'],
-      components: { Footer: './src/components/Footer.astro' },
+      components: {
+        Footer: './src/components/Footer.astro',
+        // Adds the documentation-version switcher next to the theme select
+        // on versioned deploys (DOCS_VERSION/DOCS_VERSIONS set by docs.yml).
+        ThemeSelect: './src/components/ThemeSelect.astro',
+      },
       sidebar: [
         {
           label: 'Start Here',
           items: [
             { label: 'What is MemberJunction?', slug: 'overview' },
             { label: 'Getting Started', slug: 'getting-started' },
-            { label: 'Deployment', slug: 'deployment' },
             { label: 'Upgrading to v5', slug: 'upgrade-v5' },
           ],
         },

--- a/docs-site/scripts/ingest.mjs
+++ b/docs-site/scripts/ingest.mjs
@@ -39,14 +39,21 @@ const GENERATED_PATHS = [
   'ai-and-agents/skills.md',
 ];
 
-/** Root-level repo docs rendered as top-level site pages. */
+/**
+ * Root-level repo docs rendered as top-level site pages.
+ * DEPLOYMENT.md is deliberately absent: it is internal release-engineering
+ * material, not user documentation. Links to it from rendered pages become
+ * SHA-pinned GitHub URLs (the rewriter's treatment of any unrendered file).
+ */
 const ROOT_DOCS = [
   { src: 'README.md', slug: 'overview', out: 'overview.md', fallbackTitle: 'What is MemberJunction?' },
-  { src: 'DEPLOYMENT.md', slug: 'deployment', out: 'deployment.md', fallbackTitle: 'Deployment' },
   { src: 'UPGRADE-v5.0.md', slug: 'upgrade-v5', out: 'upgrade-v5.md', fallbackTitle: 'Upgrading to v5' },
   { src: 'CONTRIBUTING.md', slug: 'community/contributing', out: 'community/contributing.md', fallbackTitle: 'Contributing' },
   { src: 'metadata/README.md', slug: 'metadata', out: 'metadata.md', fallbackTitle: 'Metadata System' },
 ];
+
+/** Guides that are internal ops manuals for MJ maintainers — never rendered on the public site. */
+const INTERNAL_GUIDES = new Set(['RELEASE_ENGINEERING_RUNBOOK.md']);
 
 main();
 
@@ -94,6 +101,7 @@ function guideEntries() {
   const entries = [];
   for (const name of readdirSync(guidesDir)) {
     if (!name.endsWith('.md') || !statSync(path.join(guidesDir, name)).isFile()) continue;
+    if (INTERNAL_GUIDES.has(name)) continue;
     if (name === 'README.md') {
       entries.push({ src: 'guides/README.md', slug: 'guides', out: 'guides/index.md', fallbackTitle: 'Developer Guides', sidebarLabel: 'All Guides', sidebarOrder: 0 });
     } else {

--- a/docs-site/src/components/ThemeSelect.astro
+++ b/docs-site/src/components/ThemeSelect.astro
@@ -1,0 +1,49 @@
+---
+import Default from '@astrojs/starlight/components/ThemeSelect.astro';
+import Select from '@astrojs/starlight/components/Select.astro';
+
+/**
+ * Starlight ThemeSelect override that prepends a documentation-version
+ * switcher. Versioned-deploy knobs (set by .github/workflows/docs.yml):
+ *   DOCS_VERSION   this build's version id, e.g. "v6" — also the path prefix
+ *                  the site is served under (/v6).
+ *   DOCS_VERSIONS  JSON list of every deployed version: [{"id","label"}, …].
+ * Local and single-version builds set neither, so the switcher renders
+ * nothing and the component is just the stock theme select.
+ */
+const current = process.env.DOCS_VERSION ?? '';
+const versions = JSON.parse(process.env.DOCS_VERSIONS ?? '[]');
+if (current && versions.length > 0 && !versions.some((v) => v.id === current)) {
+  throw new Error(`DOCS_VERSION "${current}" is not in DOCS_VERSIONS ${process.env.DOCS_VERSIONS}`);
+}
+const show = current !== '' && versions.length > 1;
+const options = versions.map((v) => ({ label: v.label, value: v.id, selected: v.id === current }));
+---
+
+{
+  show && (
+    <mj-version-select data-current={current}>
+      <Select icon="open-book" label="Select documentation version" options={options} width="8em" />
+    </mj-version-select>
+  )
+}
+<Default><slot /></Default>
+
+<script>
+  class MJVersionSelect extends HTMLElement {
+    constructor() {
+      super();
+      this.querySelector('select')?.addEventListener('change', (e) => {
+        if (!(e.currentTarget instanceof HTMLSelectElement)) return;
+        const target = e.currentTarget.value;
+        const prefix = `/${this.dataset.current ?? ''}`;
+        const path = location.pathname;
+        // Same-path swap: /v6/guides/x/ -> /v5/guides/x/. A page missing in
+        // the target version lands on the root 404, which links both homes.
+        const rest = path.startsWith(prefix) ? path.slice(prefix.length) : '/';
+        location.assign(`/${target}${rest}${location.search}${location.hash}`);
+      });
+    }
+  }
+  customElements.define('mj-version-select', MJVersionSelect);
+</script>

--- a/docs-site/src/content/docs/getting-started.mdx
+++ b/docs-site/src/content/docs/getting-started.mdx
@@ -17,9 +17,8 @@ Self-hosting MemberJunction needs:
 
 ## Install paths
 
-1. **Full platform, step by step** — the [Deployment runbook](../deployment/) is the authoritative, battle-tested walkthrough: database provisioning, migrations, CodeGen, MJAPI, and Explorer.
-2. **Explore the code first** — clone [MemberJunction/MJ](https://github.com/MemberJunction/MJ), then read the [repo overview](../overview/) for the quick-start commands and the layout of the 290+ packages.
-3. **Coming from v4?** — read [Upgrading to v5](../upgrade-v5/) before anything else.
+1. **Full platform, step by step** — clone [MemberJunction/MJ](https://github.com/MemberJunction/MJ) and follow the [repo overview](../overview/): database provisioning, migrations, CodeGen, MJAPI, and Explorer, with the quick-start commands and the layout of the 290+ packages.
+2. **Coming from v4?** — read [Upgrading to v5](../upgrade-v5/) before anything else.
 
 ## Your first hour
 


### PR DESCRIPTION
## One sentence

The docs site now builds one set per release line — `/v5` from `lts/5`, `/v6` (Edge) from `next`, root redirecting to the newest LTS — and the internal release-ops pages (`/deployment/`, the release-engineering runbook) are no longer rendered publicly.

## What changed

**`docs.yml` → three-job versioned build**
- `resolve` enumerates release lines from git structure: one LTS set per `lts/*` branch, plus an Edge set from `next` whose major comes from the newest `v*-edge.*` tag. No hardcoded refs — cutting `lts/6` someday adds `/v6` (and retires the Edge set for that major, guarded) with zero workflow edits.
- `build` (matrix, parallel) checks out each content ref, **overlays `docs-site/` tooling from the triggering commit** (i.e. `next` in normal operation), detects npm-vs-pnpm per era from the committed lockfile, builds packages + TypeDoc, then builds the site at `DOCS_BASE=/vN`.
- `deploy` assembles `dist/v5 + dist/v6`, writes the root redirect (`/` → newest LTS) and a sitewide 404 that forwards legacy pre-versioning URLs (`/guides/x/`, `/api/…`, old TypeDoc deep links) into the default set, then deploys Pages once.
- Triggers: push to `next` on docs paths, `workflow_run` post-publish, plain `workflow_dispatch`. The `lts/5` pin and its trap (green deploys ignoring the triggering commit) are gone.

**Internal pages off the public site**
- `DEPLOYMENT.md` removed from `ROOT_DOCS` (and the sidebar); `guides/RELEASE_ENGINEERING_RUNBOOK.md` excluded via a new `INTERNAL_GUIDES` set. Both are maintainer release-ops manuals — that was the full audit result; the other guides are contributor/developer-facing and stay.
- Inbound links degrade automatically to SHA-pinned GitHub URLs (existing rewriter behavior for unrendered files) — verified in both built sets.
- `getting-started.mdx` no longer describes DEPLOYMENT.md as an install walkthrough (it's the release content-prep handbook).

**Version switcher** — a `ThemeSelect` override renders a version `<select>` next to the theme picker when `DOCS_VERSION`/`DOCS_VERSIONS` are set (deploy-only; local dev and single-version builds are unchanged). Same-path swap between versions; misses land on the root 404 which links both sets.

**`docs-site-ci.yml`** — now mirrors one versioned leg (`/v6` + switcher env) so the PR gate builds what prod ships; dropped `DEPLOYMENT.md` from its trigger paths.

## Verified locally

- v6 leg built from this branch: 335 ingested pages (exactly 2 fewer than the 337 baseline = the two removed pages), warnings unchanged at 52, `/deployment/` and the runbook absent, switcher rendered + its inlined script present, `/v6/` base pathing correct.
- v5 leg simulated exactly as the workflow does it (worktree at `origin/lts/5` + this branch's `docs-site/` overlaid): builds clean cross-era (npm-era content, new tooling), same assertions pass, GitHub links pin to the lts/5 SHA.
- The `resolve` and `assemble` scripts were extracted from this exact YAML and executed: resolve produced `[{v5←lts/5},{v6←next}]`/default `v5` against the real remote; assemble's generated `index.html`/`404.html` parse and redirect correctly. `actionlint` clean on both workflows.

## Reviewer attention

- **Deliberate deviation from the release-lines.json plan**: refs resolve from `lts/*` branches + edge tags, not the manifest — `lines{}` is empty until certification (CODEOWNERS-gated, Craig's call) and the schema has no branch/ref field. The branch IS the certification artifact, so this is the same source of truth one level down. Revisit if the manifest grows a docs field.
- **Edge content builds from `next`, not the edge tag** — the tag predates its own release notes (#3508 merged after tagging), and Edge is the moving line by definition.
- **Merging this deploys immediately** (push trigger matches these paths) and flips the live site to the versioned layout. Old bookmarks 301-equivalent via the 404 forwarder.
- **Two companion PRs are required to close the clobber window**: main's stale `docs.yml` copy still fires on release merges (it would deploy the old single-version layout over this one), and lts/5's copy does the same on line-notes pushes. Links in comments once open.
- Pre-merge full-pipeline test is possible: `gh workflow run docs.yml --ref docs-versioned-site` — tooling follows the triggering commit — but note it deploys to the live site.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MYWbAFjiCkR8LWJK3VXWX3