### PR TITLE
ci(docs): lts/5 thin dispatcher to the versioned docs build (companion to #3509)

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,118 +1,37 @@
 name: Update package documentation
 
-on:
-  workflow_run:
-    workflows: [Build and publish new package versions]
-    branches: [main]
-    types:
-      - completed
+# lts/5 thin dispatcher: the real versioned docs build lives on next
+# (.github/workflows/docs.yml there builds one site per release line, reading
+# lts/5 CONTENT via its own checkout). This stub only forwards docs-content
+# pushes on this branch (e.g. self-deploying line release notes) to that
+# workflow, so this branch never needs docs tooling updates again.
+#
+# workflow_dispatch is one of the two documented exceptions to the
+# "GITHUB_TOKEN events don't trigger workflows" rule, so github.token works.
 
-  # Docs content changes that land on main or the LTS line outside a release
-  # cycle. The lts/5 trigger is what makes line release notes self-deploying:
-  # the notes commit pushed to lts/5 touches releases/** and fires this.
+on:
   push:
-    branches: [main, lts/5]
+    branches: [lts/5]
     paths:
       - 'docs-site/**'
       - 'guides/**'
       - 'README.md'
-      - 'DEPLOYMENT.md'
       - 'UPGRADE-v5.0.md'
       - 'CONTRIBUTING.md'
       - 'metadata/README.md'
       - '.claude/skills/**'
       - 'releases/**'
 
-  workflow_dispatch:
-    inputs:
-      ref:
-        description: 'Git ref to build the site from (defaults to the certified LTS line)'
-        required: false
-        default: 'lts/5'
-
 permissions:
-  contents: read
-  pages: write
-  id-token: write
-
-concurrency:
-  group: "pages"
-  cancel-in-progress: false
+  actions: write
 
 jobs:
-  docs:
-    name: Generate and deploy documentation site
-    timeout-minutes: 45
+  dispatch:
+    name: Trigger the versioned docs deploy on next
+    timeout-minutes: 5
     runs-on: ubuntu-latest
     steps:
-      - name: Error out if the trigger did not succeed
-        run: |
-          if [ "${{ github.event_name == 'workflow_run' && github.event.workflow_run.conclusion || 'success' }}" != "success" ]; then
-            echo "::error::The triggering workflow did not succeed"
-            exit 1
-          fi
-
-      # The public site documents the LTS line, whatever branch fired the
-      # trigger. Without an explicit ref, workflow_run events check out the
-      # repo DEFAULT branch (next) — verified from past run history — which
-      # after the 6.x era opens would publish Edge dev content on every
-      # release. Pinned until versioned docs (/v5, /v6) land; update this ref
-      # when a new line certifies.
-      - name: Checkout repo
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-          ref: ${{ github.event.inputs.ref || 'lts/5' }}
-
-      - name: Set up node
-        uses: actions/setup-node@v6
-        with:
-          node-version: 24
-          cache: 'npm'
-          cache-dependency-path: |
-            package-lock.json
-            docs-site/package-lock.json
-
-      - name: Install dependencies
-        run: npm ci
-
-      - name: Build packages
-        run: npm run build
-
-      - name: Generate API reference (TypeDoc)
-        run: npx typedoc
-
-      - name: Install docs site dependencies
-        run: npm ci
-        working-directory: docs-site
-
-      - name: Run docs site unit tests
-        run: npm test
-        working-directory: docs-site
-
-      - name: Build docs site (ingest + Astro)
-        run: npm run build
-        working-directory: docs-site
+      - name: Dispatch docs.yml on next
         env:
-          # Custom domain (docs.memberjunction.org) serves the site at the
-          # domain ROOT — no /MJ/ repo prefix. github.io/MJ/ 301s here.
-          DOCS_BASE: /
-          DOCS_SITE: https://docs.memberjunction.org
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Attach API reference under /api
-        run: |
-          mkdir -p docs-site/dist/api
-          cp -R docs/. docs-site/dist/api/
-
-      - name: Setup Pages
-        uses: actions/configure-pages@v5
-
-      - name: Upload artifact
-        uses: actions/upload-pages-artifact@v3
-        with:
-          path: 'docs-site/dist'
-
-      - name: Deploy to GitHub Pages
-        id: deployment
-        uses: actions/deploy-pages@v4
+          GH_TOKEN: ${{ github.token }}
+        run: gh workflow run docs.yml --repo "$GITHUB_REPOSITORY" --ref next


### PR DESCRIPTION
## One sentence

Replaces lts/5's obsolete single-version `docs.yml` with a five-line stub that forwards docs-content pushes (e.g. self-deploying line release notes) to the versioned build on next, so lts/5 never needs docs tooling updates again.

## Why

The versioned deploy from #3509 reads lts/5 **content** via its own checkout — this branch's own build would clobber the `/v5` + `/v6` layout on every line-notes push. The stub uses `gh workflow run docs.yml --ref next` with `github.token`; `workflow_dispatch` is one of the two documented exceptions to the "GITHUB_TOKEN events don't trigger workflows" rule, and the job carries `permissions: actions: write`.

## Reviewer attention

- **Merge after #3509** — the dispatch targets `docs.yml` on next, which needs the new `workflow_dispatch`-friendly (no required inputs) form. Dispatching the old one would just rebuild the old single-version site.
- This removes ~140 lines of build logic from lts/5; the tooling-overlay design in #3509 is what makes that safe (site fixes flow from next to all versions).
- Companion PRs: #3509 (to next) and the main sync PR (linked in comments).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MYWbAFjiCkR8LWJK3VXWX3