### PR TITLE
fix(explorer): declare @memberjunction/ng-container-directives — fresh-clone start:explorer is broken without it

### DIFF
--- a/packages/MJExplorer/package.json
+++ b/packages/MJExplorer/package.json
@@ -61,6 +61,7 @@
     "@memberjunction/ng-base-forms": "6.1.0-edge.0",
     "@memberjunction/ng-bootstrap": "6.1.0-edge.0",
     "@memberjunction/ng-bootstrap-lite": "6.1.0-edge.0",
+    "@memberjunction/ng-container-directives": "6.1.0-edge.0",
     "@memberjunction/ng-core-entity-forms": "6.1.0-edge.0",
     "@memberjunction/ng-dashboards": "6.1.0-edge.0",
     "@memberjunction/ng-explorer-app": "6.1.0-edge.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2434,7 +2434,7 @@ importers:
         version: 3.0.7(@azure/identity@4.13.1)
       googleapis:
         specifier: ^144.0.0
-        version: 144.0.0
+        version: 144.0.0(encoding@0.1.13)
 
   packages/AI/RealtimeClient:
     dependencies:
@@ -11444,6 +11444,9 @@ importers:
       '@memberjunction/ng-bootstrap-lite':
         specifier: 6.1.0-edge.0
         version: link:../Angular/BootstrapLite
+      '@memberjunction/ng-container-directives':
+        specifier: 6.1.0-edge.0
+        version: link:../Angular/Generic/container-directives
       '@memberjunction/ng-core-entity-forms':
         specifier: 6.1.0-edge.0
         version: link:../Angular/Explorer/core-entity-forms
@@ -29138,7 +29141,7 @@ snapshots:
     dependencies:
       '@ampproject/remapping': 2.3.0
       '@angular-devkit/architect': 0.2101.3(chokidar@5.0.0)
-      '@angular-devkit/build-webpack': 0.2101.3(chokidar@5.0.0)(webpack-dev-server@5.2.2(debug@4.4.3)(tslib@2.8.1)(webpack@5.105.0(esbuild@0.27.2)))(webpack@5.105.0(esbuild@0.27.2))
+      '@angular-devkit/build-webpack': 0.2101.3(chokidar@5.0.0)(webpack-dev-server@5.2.2(tslib@2.8.1)(webpack@5.105.0(esbuild@0.27.2)))(webpack@5.105.0(esbuild@0.27.2))
       '@angular-devkit/core': 21.1.3(chokidar@5.0.0)
       '@angular/build': 21.1.3(a1c152c28654637a273e49d67cbd7227)
       '@angular/compiler-cli': 21.1.3(@angular/compiler@21.1.3)(typescript@5.9.3)
@@ -29189,7 +29192,7 @@ snapshots:
       typescript: 5.9.3
       webpack: 5.105.0(esbuild@0.27.2)
       webpack-dev-middleware: 7.4.5(tslib@2.8.1)(webpack@5.105.0(esbuild@0.27.2))
-      webpack-dev-server: 5.2.2(debug@4.4.3)(tslib@2.8.1)(webpack@5.105.0(esbuild@0.27.2))
+      webpack-dev-server: 5.2.2(tslib@2.8.1)(webpack@5.105.0(esbuild@0.27.2))
       webpack-merge: 6.0.1
       webpack-subresource-integrity: 5.1.0(webpack@5.105.0(esbuild@0.27.2))
     optionalDependencies:
@@ -29228,6 +29231,15 @@ snapshots:
       rxjs: 7.8.2
       webpack: 5.105.0(esbuild@0.27.2)
       webpack-dev-server: 5.2.2(debug@4.4.3)(tslib@2.8.1)(webpack@5.105.0(esbuild@0.27.2))
+    transitivePeerDependencies:
+      - chokidar
+
+  '@angular-devkit/build-webpack@0.2101.3(chokidar@5.0.0)(webpack-dev-server@5.2.2(tslib@2.8.1)(webpack@5.105.0(esbuild@0.27.2)))(webpack@5.105.0(esbuild@0.27.2))':
+    dependencies:
+      '@angular-devkit/architect': 0.2101.3(chokidar@5.0.0)
+      rxjs: 7.8.2
+      webpack: 5.105.0(esbuild@0.27.2)
+      webpack-dev-server: 5.2.2(tslib@2.8.1)(webpack@5.105.0(esbuild@0.27.2))
     transitivePeerDependencies:
       - chokidar
 
@@ -42121,7 +42133,7 @@ snapshots:
 
   google-logging-utils@1.1.3: {}
 
-  googleapis-common@7.2.0:
+  googleapis-common@7.2.0(encoding@0.1.13):
     dependencies:
       extend: 3.0.2
       gaxios: 6.7.1(encoding@0.1.13)
@@ -42144,10 +42156,10 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  googleapis@144.0.0:
+  googleapis@144.0.0(encoding@0.1.13):
     dependencies:
       google-auth-library: 9.15.1(encoding@0.1.13)
-      googleapis-common: 7.2.0
+      googleapis-common: 7.2.0(encoding@0.1.13)
     transitivePeerDependencies:
       - encoding
       - supports-color
@@ -48045,6 +48057,45 @@ snapshots:
       - tslib
 
   webpack-dev-server@5.2.2(debug@4.4.3)(tslib@2.8.1)(webpack@5.105.0(esbuild@0.27.2)):
+    dependencies:
+      '@types/bonjour': 3.5.13
+      '@types/connect-history-api-fallback': 1.5.4
+      '@types/express': 4.17.25
+      '@types/express-serve-static-core': 4.19.8
+      '@types/serve-index': 1.9.4
+      '@types/serve-static': 1.15.10
+      '@types/sockjs': 0.3.36
+      '@types/ws': 8.18.1
+      ansi-html-community: 0.0.8
+      bonjour-service: 1.3.0
+      chokidar: 3.6.0
+      colorette: 2.0.20
+      compression: 1.8.1
+      connect-history-api-fallback: 2.0.0
+      express: 4.22.1
+      graceful-fs: 4.2.11
+      http-proxy-middleware: 2.0.9(@types/express@4.17.25)(debug@4.4.3)
+      ipaddr.js: 2.3.0
+      launch-editor: 2.12.0
+      open: 10.2.0
+      p-retry: 6.2.1
+      schema-utils: 4.3.3
+      selfsigned: 2.4.1
+      serve-index: 1.9.2
+      sockjs: 0.3.24
+      spdy: 4.0.2
+      webpack-dev-middleware: 7.4.5(tslib@2.8.1)(webpack@5.105.0(esbuild@0.27.2))
+      ws: 8.19.0
+    optionalDependencies:
+      webpack: 5.105.0(esbuild@0.27.2)
+    transitivePeerDependencies:
+      - bufferutil
+      - debug
+      - supports-color
+      - tslib
+      - utf-8-validate
+
+  webpack-dev-server@5.2.2(tslib@2.8.1)(webpack@5.105.0(esbuild@0.27.2)):
     dependencies:
       '@types/bonjour': 3.5.13
       '@types/connect-history-api-fallback': 1.5.4


### PR DESCRIPTION
## One sentence

`pnpm run start:explorer` fails on every fresh clone of `next` with `Could not resolve "@memberjunction/ng-container-directives"` because MJExplorer uses the package (via Angular AOT inlining the `<mj-explorer-app />` template's `[mjContainer]`/`[mjFillContainer]` directives) but never declares it — this adds the one-line declaration.

## Detail

The import is not in MJExplorer's source — `ngc` generates it into MJExplorer's compilation unit (`import * as i5 from "@memberjunction/ng-container-directives"` in the compiled `app.component`). Eight sibling packages declare it; MJExplorer (121 deps) did not. npm's hoisting subsidized the gap invisibly; the pnpm cutover (#3466) exposed it — exactly the latent-bug class the root CLAUDE.md warns about. No changeset: app-level package in the fixed group, same pattern as #3420.

**Verified**: found and fix-confirmed by the Open App quickstart host smoke test (2026-08-06) — on a fresh `--depth 1` clone of `next`, Explorer failed in ~4s as described; with this declaration it compiled and served HTTP 200 (`<title>MemberJunction Explorer</title>`).

## Reviewer attention — lockfile diff has two ride-along clusters

`pnpm install` deterministically re-trues two stale resolutions while writing the new importer entry (reproduced identically in two independent installs from clean clones — this is what pnpm writes for this manifest, not hand drift):
- `googleapis: 144.0.0` → `144.0.0(encoding@0.1.13)` (peer-variant suffix)
- `webpack-dev-server@5.2.2` loses its `(debug@4.4.3)` peer-variant suffix (peer-graph re-resolution in MJExplorer's subtree)

The intended change is the 3-line `ng-container-directives` importer entry under `packages/MJExplorer`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MYWbAFjiCkR8LWJK3VXWX3