### PR TITLE
[lts/5] fix(actions): implement Action Filter evaluation — RunSingleFilter was a return-true stub

### DIFF
--- a/.changeset/action-filter-evaluation-hotfix.md
+++ b/.changeset/action-filter-evaluation-hotfix.md
@@ -1,0 +1,5 @@
+---
+"@memberjunction/actions": patch
+---
+
+Implement Action Filter evaluation — `ActionEngineServer.RunSingleFilter` was a `return true` stub, making every Action Filter a no-op. Filters now resolve via a registered `BaseActionFilter` subclass (ClassFactory, keyed by filter ID) or by evaluating the filter's `Code` column with an `ActionFilterContext`, cached per row version. Failure semantics are fail-closed: a filter that throws, yields a non-boolean, or has no evaluable logic prevents the action and logs the reason. No shipped metadata contains ActionFilter rows, so no existing behavior changes.

--- a/packages/Actions/Engine/src/__tests__/ActionEngine.test.ts
+++ b/packages/Actions/Engine/src/__tests__/ActionEngine.test.ts
@@ -359,9 +359,81 @@ describe('ActionEngineServer', () => {
     });
 
     describe('RunSingleFilter', () => {
-        it('should return true (stub implementation)', async () => {
-            const result = await (engine as unknown as Record<string, Function>)['RunSingleFilter']({} as never, {} as unknown as Record<string, Function>);
-            expect(result).toBe(true);
+        // Minimal filter-row shape the engine reads: ID, Code, __mj_UpdatedAt.
+        const makeFilter = (code: string, id = 'filter-1') => ({
+            ID: id,
+            Code: code,
+            __mj_UpdatedAt: new Date('2026-01-01T00:00:00Z'),
+        });
+        const runFilter = (filter: Record<string, unknown>, params: Record<string, unknown> = {}) =>
+            (engine as unknown as Record<string, Function>)['RunSingleFilter'](params, filter);
+
+        it('should allow the action when filter code returns true', async () => {
+            await expect(runFilter(makeFilter('return true;'))).resolves.toBe(true);
+        });
+
+        it('should prevent the action when filter code returns false', async () => {
+            await expect(runFilter(makeFilter('return false;'))).resolves.toBe(false);
+        });
+
+        it('should read the verdict from ActionFilterContext.result when code does not return', async () => {
+            await expect(runFilter(makeFilter('ActionFilterContext.result = true;'))).resolves.toBe(true);
+        });
+
+        it('should expose params and filter on the execution context', async () => {
+            const params = { Action: { Name: 'Test Action' } };
+            const code = 'return ActionFilterContext.params.Action.Name === "Test Action" && ActionFilterContext.filter.ID === "filter-1";';
+            await expect(runFilter(makeFilter(code), params)).resolves.toBe(true);
+        });
+
+        it('should support async filter code', async () => {
+            await expect(runFilter(makeFilter('return await Promise.resolve(true);'))).resolves.toBe(true);
+        });
+
+        it('should fail closed and log when filter code throws', async () => {
+            await expect(runFilter(makeFilter('throw new Error("boom");'))).resolves.toBe(false);
+            expect(LogErrorEx).toHaveBeenCalled();
+        });
+
+        it('should fail closed and log on a non-boolean verdict', async () => {
+            await expect(runFilter(makeFilter('return "yes";'))).resolves.toBe(false);
+            expect(LogError).toHaveBeenCalled();
+        });
+
+        it('should fail closed and log when Code is empty and no subclass is registered', async () => {
+            await expect(runFilter(makeFilter('   '))).resolves.toBe(false);
+            expect(LogError).toHaveBeenCalled();
+        });
+
+        it('should recompile when the filter row version changes', async () => {
+            const first = makeFilter('return true;', 'filter-2');
+            await expect(runFilter(first)).resolves.toBe(true);
+            const edited = { ...first, Code: 'return false;', __mj_UpdatedAt: new Date('2026-02-01T00:00:00Z') };
+            await expect(runFilter(edited)).resolves.toBe(false);
+        });
+
+        it('should serve the cached compilation for an unchanged row version', async () => {
+            const filter = makeFilter('return true;', 'filter-3');
+            await expect(runFilter(filter)).resolves.toBe(true);
+            // Same ID + same __mj_UpdatedAt → the cached compilation runs even though Code text changed.
+            const sameVersion = { ...filter, Code: 'return false;' };
+            await expect(runFilter(sameVersion)).resolves.toBe(true);
+        });
+
+        it('should let a registered BaseActionFilter subclass win over inline Code', async () => {
+            const subclassRun = vi.fn().mockResolvedValue(false);
+            mockClassFactory.GetAllRegistrations.mockReturnValueOnce([{ SubClass: class {} }]);
+            mockClassFactory.CreateInstance.mockReturnValueOnce({ Run: subclassRun });
+
+            await expect(runFilter(makeFilter('return true;', 'filter-4'))).resolves.toBe(false);
+            expect(subclassRun).toHaveBeenCalled();
+        });
+
+        it('should coerce a non-boolean subclass verdict to false', async () => {
+            mockClassFactory.GetAllRegistrations.mockReturnValueOnce([{ SubClass: class {} }]);
+            mockClassFactory.CreateInstance.mockReturnValueOnce({ Run: vi.fn().mockResolvedValue('truthy') });
+
+            await expect(runFilter(makeFilter('return true;', 'filter-5'))).resolves.toBe(false);
         });
     });
 

--- a/packages/Actions/Engine/src/generic/ActionEngine.ts
+++ b/packages/Actions/Engine/src/generic/ActionEngine.ts
@@ -1,7 +1,8 @@
 import { BaseEntitySaveQueue, LogError, LogErrorEx, Metadata, UserInfo, IMetadataProvider } from "@memberjunction/core";
 import { MJActionExecutionLogEntity, MJActionEntity_IRuntimeActionConfiguration, MJActionCategoryEntity, MJActionFilterEntity, MJActionLibraryEntity, MJActionParamEntity, MJActionResultCodeEntity } from "@memberjunction/core-entities";
-import { BaseSingleton, MJGlobal, SafeJSONParse, UUIDsEqual } from "@memberjunction/global";
+import { BaseSingleton, MJGlobal, MJLruCache, SafeJSONParse, UUIDsEqual } from "@memberjunction/global";
 import { BaseAction } from "./BaseAction";
+import { BaseActionFilter } from "./BaseActionFilter";
 import {
     ActionEngineBase,
     MJActionEntityExtended,
@@ -18,7 +19,22 @@ import type { BridgeHandlerMap } from "@memberjunction/code-execution";
  
 
 /**
- * Base class for executing actions. This class can be sub-classed if desired if you would like to modify the logic across ALL actions. To do so, sub-class this class and use the 
+ * Execution context handed to an Action Filter's `Code` when the engine evaluates it inline
+ * (i.e. when no {@link BaseActionFilter} subclass is registered for the filter). The code runs
+ * with this object bound as `ActionFilterContext` and signals its verdict either by returning
+ * a boolean or by assigning `ActionFilterContext.result`.
+ */
+export interface ActionFilterContext {
+   /** The full parameters of the action run being gated, including Action, Params, and ContextUser. */
+   params: RunActionParams;
+   /** The filter row being evaluated. */
+   filter: MJActionFilterEntity;
+   /** Alternative verdict channel: filter code may assign true (allow) / false (prevent) here instead of returning. */
+   result: boolean | null;
+}
+
+/**
+ * Base class for executing actions. This class can be sub-classed if desired if you would like to modify the logic across ALL actions. To do so, sub-class this class and use the
  * @RegisterClass decorator from the @memberjunction/global package to register your sub-class with the ClassFactory. This will cause your sub-class to be used instead of this base class when the Metadata object insantiates the ActionEngine.
  */
 export class ActionEngineServer extends BaseSingleton<ActionEngineServer> {
@@ -296,13 +312,71 @@ export class ActionEngineServer extends BaseSingleton<ActionEngineServer> {
    }
 
    /**
-    * This method runs a single filter. Subclasses can override this method to provide custom filter logic.
-    * 
-    * @param filter 
+    * Bounded cache of compiled filter functions. Keyed by filter ID + row version so an edited
+    * filter's Code is recompiled on next use instead of serving the stale compilation.
+    */
+   private _filterCache = new MJLruCache<string, (context: ActionFilterContext) => Promise<unknown>>({ maxSize: 1000 });
+
+   /**
+    * Runs a single Action Filter and returns whether the action should proceed.
+    *
+    * Resolution order:
+    * 1. A {@link BaseActionFilter} subclass registered with the ClassFactory under the filter's ID
+    *    (the CodeGen / custom-subclass pattern documented on BaseActionFilter) wins when present.
+    * 2. Otherwise the filter's `Code` column — JavaScript that evaluates to true (allow) or
+    *    false (prevent), per the column contract — is compiled once per filter row version and
+    *    executed with an {@link ActionFilterContext} argument. The code may `return` its verdict
+    *    or assign `ActionFilterContext.result`.
+    *
+    * Failure semantics are FAIL-CLOSED: a filter that throws, yields a non-boolean, or has no
+    * evaluable logic prevents the action and logs the reason. A broken gate must not silently
+    * allow execution — silently allowing everything is precisely the pre-fix bug this replaces.
+    *
+    * Subclasses can still override this method entirely to provide custom filter logic.
     */
    protected async RunSingleFilter(params: RunActionParams, filter: MJActionFilterEntity): Promise<boolean> {
-      return true;
-      // temp stub above, replace with code that will run the filter      
+      try {
+         const registered = MJGlobal.Instance.ClassFactory.GetAllRegistrations(BaseActionFilter, filter.ID);
+         if (registered && registered.length > 0) {
+            const instance = MJGlobal.Instance.ClassFactory.CreateInstance<BaseActionFilter>(BaseActionFilter, filter.ID);
+            if (instance) {
+               return await instance.Run(params, filter) === true;
+            }
+         }
+
+         const code = filter.Code?.trim();
+         if (!code) {
+            LogError(`Action Filter ${filter.ID} has no Code and no registered BaseActionFilter subclass — failing closed, action prevented.`);
+            return false;
+         }
+
+         const cacheKey = `${filter.ID}:${filter.__mj_UpdatedAt instanceof Date ? filter.__mj_UpdatedAt.getTime() : ''}`;
+         let filterFunction = this._filterCache.Get(cacheKey);
+         if (!filterFunction) {
+            filterFunction = new Function('ActionFilterContext', `
+               return (async () => {
+                  ${code}
+               })();
+            `) as (context: ActionFilterContext) => Promise<unknown>;
+            this._filterCache.Set(cacheKey, filterFunction);
+         }
+
+         const context: ActionFilterContext = { params, filter, result: null };
+         const returned = await filterFunction(context);
+         const verdict = returned ?? context.result;
+         if (typeof verdict !== 'boolean') {
+            LogError(`Action Filter ${filter.ID} evaluated to a non-boolean verdict (${String(verdict)}) — failing closed, action prevented.`);
+            return false;
+         }
+         return verdict;
+      }
+      catch (e) {
+         LogErrorEx({
+            message: `Action Filter ${filter.ID} threw during evaluation — failing closed, action prevented.`,
+            error: e instanceof Error ? e : new Error(String(e))
+         });
+         return false;
+      }
    }
 
    protected async InternalRunAction(params: RunActionParams): Promise<ActionResult> {


### PR DESCRIPTION
Manual backport of #3525 to `lts/5`. The `backport lts/5` label could not deliver it: the source branch contains merge-of-`next` commits and the backport workflow is configured `merge_commits: fail`, so the bot refused (see its comment on #3525) — while the workflow run itself still reported success. A workflow fix for that silent-failure gap is coming as a separate PR.

Cherry-picked with `-x` (original authorship preserved), verified conflict-free before opening:
- 5c9100f — the RunSingleFilter fail-closed fix (ActionEngine.ts + tests)
- 2bafb6b — its changeset (`@memberjunction/actions`: patch)

The merge-of-next commit (4317fec) is deliberately excluded — it carries next-era content, not PR payload.

Line rules check: patch-only ✓ (bug fix + changeset, no migrations, no features).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MYWbAFjiCkR8LWJK3VXWX3