### PR TITLE
fix(integration-tests): compile-check AEH4's capability list, and restore IT70's transport ordering

### DIFF
--- a/metadata-optional/integration-test/test-suites/.integration-suite.json
+++ b/metadata-optional/integration-test/test-suites/.integration-suite.json
@@ -835,7 +835,7 @@
           "fields": {
             "SuiteID": "@parent:ID",
             "TestID": "@lookup:MJ: Tests.Name=IT70 - External Agent Harness",
-            "Sequence": 53,
+            "Sequence": 33,
             "Status": "Active"
           },
           "primaryKey": {

--- a/packages/TestingFramework/integration-test-suite/src/checks/agent-external-harness.checks.ts
+++ b/packages/TestingFramework/integration-test-suite/src/checks/agent-external-harness.checks.ts
@@ -35,6 +35,7 @@
  */
 import { MJGlobal } from '@memberjunction/global';
 import { RunView } from '@memberjunction/core';
+import type { MJAIAgentHarnessEntity_IHarnessCapabilitySettings } from '@memberjunction/core-entities';
 import { BaseAgent, BaseAgentType } from '@memberjunction/ai-agents';
 import { BaseHarnessAdapter } from '@memberjunction/ai-agent-harness';
 import { IntegrationCheckRegistry } from '@memberjunction/testing-integration';
@@ -45,6 +46,33 @@ import { Assert, AssertEqual } from '@memberjunction/testing-integration';
 const HARNESS_ENTITY = 'MJ: AI Agent Harnesses';
 const AGENT_TYPE_NAME = 'Harness';
 const DEMO_AGENT_NAME = 'Demo Harness Agent';
+
+/**
+ * The capability names AEH4 accepts — the runtime shadow of
+ * `MJAIAgentHarnessEntity_IHarnessCapabilitySettings`, which is a TypeScript interface and therefore
+ * erased before this check can enumerate it.
+ *
+ * Typed as `Record<keyof …, true>` **on purpose**: TypeScript then refuses to compile this file if a
+ * capability is added to the interface and not listed here, or listed here and not on the interface.
+ * That converts what would otherwise be silent drift into a build error at the moment the interface
+ * changes.
+ *
+ * This is not hypothetical — the hand-maintained list it replaces went stale the first time a
+ * capability was added (`PermissionPolicy`), and the failure surfaced as a red integration check
+ * accusing correct metadata of a typo. The check was right that something had drifted and wrong
+ * about which side.
+ */
+const KNOWN_CAPABILITIES: Record<keyof MJAIAgentHarnessEntity_IHarnessCapabilitySettings, true> = {
+    SessionResume: true,
+    MidTurnCancellation: true,
+    StructuredOutput: true,
+    UsageReporting: true,
+    PermissionPolicy: true,
+    PermissionHooks: true,
+    McpClient: true,
+    WorkspaceScoping: true,
+    ModelSelection: true,
+};
 
 interface AgentTypeRow { ID: string; Name: string; DriverClass: string | null; SystemPromptID: string | null; }
 interface AgentRow { ID: string; Name: string; TypeID: string; TypeConfiguration: string | null; MaxCostPerRun: number | null; }
@@ -166,16 +194,7 @@ export const AgentExternalHarnessChecks: NamedCheck[] = [
         Id: 'agent-external-harness.AEH4',
         Name: 'AEH4: CapabilitySettings parse and declare only known capabilities',
         Fn: async (ctx): Promise<void> => {
-            const known = new Set([
-                'SessionResume',
-                'MidTurnCancellation',
-                'StructuredOutput',
-                'UsageReporting',
-                'PermissionHooks',
-                'McpClient',
-                'WorkspaceScoping',
-                'ModelSelection',
-            ]);
+            const known = new Set(Object.keys(KNOWN_CAPABILITIES));
 
             const rows = await loadHarnessRows(ctx);
             for (const row of rows) {


### PR DESCRIPTION
Two defects found by running the deterministic integration tier, which had never been run on the harness branch. Follow-up to #3523 (merged).

## AEH4's capability list was hand-maintained, and went stale immediately

AEH4 validates `AIAgentHarness.CapabilitySettings` keys against a `Set` of known capability names — a hand-copied runtime shadow of the `IHarnessCapabilitySettings` interface, which is a TypeScript type and therefore erased before the check can enumerate it.

It went stale the **first** time a capability was added. #3523 introduced `PermissionPolicy` in lockstep across the interface, the adapters and the metadata; AEH4's list wasn't updated, so the check failed with:

> Harness 'Claude Code' declares unknown capability 'PermissionPolicy'. A typo here reads as "unsupported"…

The check was **right that something had drifted and wrong about which side** — the most expensive kind of test failure, because it sends you looking at correct code.

Now typed as `Record<keyof MJAIAgentHarnessEntity_IHarnessCapabilitySettings, true>`. TypeScript refuses to compile the file if a capability is on the interface and missing here, or here and missing from the interface. Silent drift becomes a build error at the moment the interface changes.

Verified rather than assumed: deleting a key produces `TS2741: Property 'PermissionPolicy' is missing in type … but required in type 'Record<keyof MJAIAgentHarnessEntity_IHarnessCapabilitySettings, true>'`.

Same spirit as the repo's existing "derive field types from the entity, never hand-copy a value-list union" rule.

## IT70 violated an ordering invariant its own suite documents

`IT70 - External Agent Harness` was appended to the deterministic suite at **Sequence 53** — after every client-transport member (34–52). The suite's Description already states the rule:

> ORDERING INVARIANT: client-transport members are sequenced LAST — `bootstrapIntegrationClient` rebinds the process's global provider to GraphQL, so no server-transport member may run after the first client one.

IT70 declares `transport: "server"`, so by the time it ran the process-global provider had been rebound and it died at bootstrap:

```
Bootstrap failed: transport 'server' resolved a 'Network' provider — the
process-global provider was rebound (a client-transport bundle ran earlier
in this process).
```

**It passed standalone the entire time**, which is exactly why nobody noticed — a bundle that's green on its own and dead in the suite. Moved to Sequence 33, alongside IT69, the last server-transport member.

## Result

| | Before | After |
|---|---|---|
| Deterministic tier | 54/56 | **55/56** |
| IT70 standalone | 7/7 | 7/7 |
| IT70 in-suite | ✗ bootstrap error | **7/7** |

## The one remaining failure is not from this work

`rls-isolation-client.RLS7` — *"RLS LEAK: users with different RLS clauses produced IDENTICAL client cache fingerprints — B would be served A's slot."*

Pre-existing and unrelated to the harness: nothing in #3523 or this PR touches client cache fingerprinting or RLS. Flagging it rather than folding it in, because it reads as a genuine cross-user cache-isolation problem and deserves its own investigation by whoever owns that area — not a drive-by fix from someone who hasn't looked at it.

## Note for whoever runs this next

The deterministic tier's records were not seeded in the dev DB — `mj test run` reported *"Test not found"* until `mj sync push --dir=metadata-optional/integration-test` had been run (255 records). Worth knowing before concluding a bundle is missing.
