### PR TITLE
fix(ci): harden publish-lts.yml with the Aug 5 edge-release lessons

### DIFF
--- a/.github/workflows/publish-lts.yml
+++ b/.github/workflows/publish-lts.yml
@@ -121,8 +121,9 @@ jobs:
         run: |
           ${{ steps.pm.outputs.PM }} run version
           ${{ steps.pm.outputs.PM == 'pnpm' && 'pnpm install --lockfile-only' || 'npm install' }}
-          if ! git diff --quiet package-lock.json; then
-            git add package-lock.json
+          LOCK=${{ steps.pm.outputs.PM == 'pnpm' && 'pnpm-lock.yaml' || 'package-lock.json' }}
+          if ! git diff --quiet -- "$LOCK"; then
+            git add "$LOCK"
             git commit -m "chore: lockfile for line release [skip ci]"
           fi
           VERSION=$(jq -r .version packages/MJServer/package.json)
@@ -144,30 +145,76 @@ jobs:
         run: ${{ steps.pm.outputs.PM }} run build
 
       - name: Publish to npm (line tag, never latest)
-        run: ${{ steps.pm.outputs.PM }} run change publish -- --tag ${{ steps.version.outputs.NPM_TAG }}
+        # 🚨 Invoke changesets directly, NOT via `<pm> run change publish -- --tag <x>`.
+        # pnpm 10 forwards the `--` separator LITERALLY, so changesets receives
+        # `publish -- --tag lts-x`, dies with "Too many arguments" — and exits 0.
+        # That is the exact silent no-op that version-bumped and tagged 6.1.0-edge.0
+        # while publishing ZERO packages (see publish.yml). npm strips the `--`,
+        # which is why the npm-era lts/5 path would have worked; every pnpm-era line
+        # (lts/6.1 onward) would have hit it. Direct invocation works under both.
+        run: |
+          set -euo pipefail
+          npx changeset publish --tag ${{ steps.version.outputs.NPM_TAG }} 2>&1 | tee /tmp/publish.log
+          if ! grep -qE 'New tag:|Packages published|already published' /tmp/publish.log; then
+            echo "::error::changeset publish produced no evidence of a publish - refusing to report success."
+            exit 1
+          fi
         env:
           NPM_TOKEN: ''
 
-      - name: Verify latest did not move
+      # The registry is the only signal that cannot be lied to (changesets exits 0
+      # on its own errors; log-grep assertions only prove what was printed). Assert
+      # the line dist-tag actually reached the new version, then that `latest` is
+      # untouched.
+      - name: Verify the publish reached npm and latest did not move
         run: |
+          set -euo pipefail
+          VERSION="${{ steps.version.outputs.VERSION }}"
+          VERSION="${VERSION#v}"
+          NPM_TAG='${{ steps.version.outputs.NPM_TAG }}'
+          AT_TAG=''
+          for i in 1 2 3 4 5; do
+            AT_TAG=$(npm view "@memberjunction/core@$NPM_TAG" version 2>/dev/null || true)
+            [ "$AT_TAG" = "$VERSION" ] && break
+            echo "dist-tag '$NPM_TAG' is at '${AT_TAG:-<unset>}', want $VERSION - retry $i/5 in 15s"
+            sleep 15
+          done
+          if [ "$AT_TAG" != "$VERSION" ]; then
+            echo "::error::npm dist-tag '$NPM_TAG' never reached $VERSION - the publish did not happen (or failed before tagging). Do not trust this run's green steps."
+            exit 1
+          fi
           NOW=$(npm view @memberjunction/core dist-tags.latest)
           if [ "$NOW" != "${{ steps.before.outputs.LATEST }}" ]; then
             echo "::error::npm 'latest' moved during a line publish (${{ steps.before.outputs.LATEST }} -> $NOW). Investigate immediately; restore with ci/dist-tag-all.mjs from the certified tag."
             exit 1
           fi
+          echo "::notice::Verified: @memberjunction/core@$VERSION is live under '$NPM_TAG'; latest unmoved at ${{ steps.before.outputs.LATEST }}"
 
+      # Tag and release steps tolerate a re-run of a partially completed publish
+      # (publish succeeded, a later step failed): the publish step's "already
+      # published" evidence passes, and these skip instead of dying on collisions.
       - name: Push release commit and tag to the line branch
         env:
           VERSION: ${{ steps.version.outputs.VERSION }}
         run: |
+          set -euo pipefail
           git push origin "HEAD:${{ github.ref_name }}"
-          git tag "$VERSION"
-          git push origin "refs/tags/$VERSION"
+          if git ls-remote --tags origin "refs/tags/$VERSION" | grep -q .; then
+            echo "::notice::Tag $VERSION already exists on origin - skipping (re-run of a partially completed publish)"
+          else
+            git tag "$VERSION"
+            git push origin "refs/tags/$VERSION"
+          fi
 
       - name: Create GitHub Release (never latest; certification promotes)
         env:
           GH_TOKEN: ${{ secrets.MJ_GH_BOT_GITHUB_TOKEN }}
           VERSION: ${{ steps.version.outputs.VERSION }}
         run: |
+          set -euo pipefail
+          if gh release view "$VERSION" --repo "${{ github.repository }}" >/dev/null 2>&1; then
+            echo "Release $VERSION already exists - skipping creation (re-run of a partially completed publish)"
+            exit 0
+          fi
           gh release create "$VERSION" --title "$VERSION" --generate-notes --latest=false \
             --target "${{ github.ref_name }}" --repo "${{ github.repository }}"


### PR DESCRIPTION
## What

The one-button LTS line release (publish-lts.yml, added Aug 3) predates the 6.1.0-edge.0 silent-no-op publish and never got the hardening that went into publish.yml afterward. This PR backfills those lessons. Four fixes, all inside the existing workflow, no restructuring:

1. **Invoke changesets directly.** The publish step used `<pm> run change publish -- --tag lts-x`. pnpm 10 forwards the `--` separator literally, changesets dies on "Too many arguments" and exits 0. That is the exact failure that version-bumped and tagged 6.1.0-edge.0 while publishing zero packages. npm strips the `--`, so the npm-era lts/5 path would have worked, but every pnpm-era line (lts/6.1 onward) would have published nothing while reporting green. Now: `npx changeset publish --tag ...` plus a publish-evidence assertion on the log.
2. **Positive registry verification.** The workflow only asserted that `latest` did not move. It never checked that the line dist-tag actually reached the new version, so a silent no-op sailed through green. Now it polls `npm view @memberjunction/core@lts-x version` (5 tries, 15s apart) and fails the run if the version never appears. The latest-unmoved check stays.
3. **Commit the right lockfile.** The version step only checked and committed package-lock.json. On a pnpm line the refreshed pnpm-lock.yaml would never be committed, so line version commits would drop the lockfile. Now the lockfile name follows the detected package manager.
4. **Re-run tolerance.** A re-run after a partially completed publish (published to npm, then a later step failed) used to die on the existing git tag or GH release. Both steps now skip when the artifact already exists, which composes with the "already published" branch of the publish-evidence check.

## Why now

5.51.1 is queued behind this: lts/5 has the backported RunSingleFilter fix (#3539) banked as its only changeset, and this workflow is how it ships. Fixes 2 and 4 matter for that dispatch; fix 1 and 3 are for every line after it.

## For reviewers

- The publish invocation change (step "Publish to npm") is the load-bearing one. It mirrors publish.yml's current form exactly, minus the pre-mode branch, which cannot occur here (this workflow refuses pre-mode branches earlier).
- `VERSION` output carries a `v` prefix for the tag steps; the registry check strips it. Worth a second pair of eyes.
- Not addressed here, called out so it is not forgotten: publish-lts.yml does not exist on the lts/5 branch (the branch was cut Aug 1, the workflow landed Aug 3, and workflow_dispatch runs the file from the selected ref). A companion PR adds the hardened file to lts/5; link in comments.
- Also not addressed: npm trusted publishing may be scoped per package to the publish.yml filename. If so, the first dispatch of this workflow fails loudly at publish and we either add this filename as a trusted publisher or supply a token. The registry verification added here is what makes that failure loud instead of silent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MYWbAFjiCkR8LWJK3VXWX3
