### PR TITLE
ci: add the hardened publish-lts.yml to the lts/5 line branch

### DIFF
--- a/.github/workflows/publish-lts.yml
+++ b/.github/workflows/publish-lts.yml
@@ -1,0 +1,220 @@
+name: Publish LTS line release
+
+# The one-button line release (guides/RELEASE_ENGINEERING_RUNBOOK.md, operation 3;
+# plans/lts-process.md section 5.2 rule 3 / section 14.1). Run it FROM a line branch:
+# Actions -> "Publish LTS line release" -> pick the lts/* branch -> Run workflow.
+#
+# Automates the dry-check-verified manual sequence: changeset version (normal, non-pre
+# mode) -> lockfile refresh -> build -> changeset publish --tag lts-<line> -> push the
+# release commit + git tag back to the line branch -> GitHub Release (never latest).
+# `latest` NEVER moves here - certification moves it via ci/dist-tag-all.mjs.
+
+on:
+  workflow_dispatch:
+    inputs:
+      confirm_branch:
+        description: "Type the line branch name (e.g. lts/5) to confirm you selected the right ref above"
+        required: true
+
+permissions:
+  contents: write
+  id-token: write
+
+concurrency:
+  group: "publish"
+  cancel-in-progress: false
+
+jobs:
+  publish-line:
+    name: Version, build, and publish from the line branch
+    timeout-minutes: 45
+    runs-on: ubuntu-latest
+    steps:
+      - name: Guard - must run from an lts/* branch, confirmed
+        run: |
+          REF="${{ github.ref_name }}"
+          if [[ "$REF" != lts/* ]]; then
+            echo "::error::This workflow must be dispatched from an lts/* branch (got '$REF'). Use the branch picker in the Run workflow dialog."
+            exit 1
+          fi
+          if [ "${{ github.event.inputs.confirm_branch }}" != "$REF" ]; then
+            echo "::error::Confirmation mismatch: dialog ran on '$REF' but you typed '${{ github.event.inputs.confirm_branch }}'. Re-run with matching values."
+            exit 1
+          fi
+
+      - name: Checkout line branch
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          fetch-tags: true
+          persist-credentials: false
+
+      - name: Guard - line branch must NOT be in prerelease mode
+        run: |
+          if [ -f .changeset/pre.json ]; then
+            echo "::error::.changeset/pre.json exists on ${{ github.ref_name }} - pre-mode state leaked from next. Fix the branch before publishing."
+            exit 1
+          fi
+
+      - name: Guard - there must be changesets to release
+        run: |
+          count=$(ls .changeset/*.md 2>/dev/null | grep -cv 'README.md' || true)
+          if [ "$count" = "0" ]; then
+            echo "::error::No changesets on ${{ github.ref_name }} - nothing to release. Backported fixes carry their changeset files; did the backport PR merge?"
+            exit 1
+          fi
+
+      # lts/5 is the last npm line; 6.x and every later LTS line use pnpm. The
+      # lockfile committed on the checked-out ref is the signal, so this needs
+      # no edit when a new line is cut.
+      - name: Detect package manager
+        id: pm
+        run: |
+          if [ -f pnpm-lock.yaml ]; then
+            PM=pnpm
+          elif [ -f package-lock.json ]; then
+            PM=npm
+          else
+            echo "::error::No lockfile found on ${{ github.ref_name }}"
+            exit 1
+          fi
+          echo "PM=$PM" >> "$GITHUB_OUTPUT"
+          echo "::notice::Package manager for this ref: $PM"
+
+      - name: Set up pnpm
+        if: steps.pm.outputs.PM == 'pnpm'
+        uses: pnpm/action-setup@v4
+
+      - name: Set up node
+        uses: actions/setup-node@v6
+        with:
+          node-version: 24
+          cache: ${{ steps.pm.outputs.PM }}
+
+      - name: Pin npm to 11.6.4
+        if: steps.pm.outputs.PM == 'npm'
+        run: npm install -g npm@11.6.4
+
+      - name: Validate migration filenames
+        run: ./.github/scripts/validate-migration-filenames.sh
+
+      - name: Validate package-lock.json case-sensitivity
+        if: steps.pm.outputs.PM == 'npm'
+        run: ./.github/scripts/validate-package-lock-case.sh
+
+      - name: Install dependencies
+        run: ${{ steps.pm.outputs.PM == 'pnpm' && 'pnpm install --frozen-lockfile' || 'npm ci' }}
+
+      - name: Validate package repository.url for npm provenance
+        run: ./.github/scripts/validate-package-repository.sh
+
+      - name: Set up git credentials
+        env:
+          REPO_PAT: ${{ secrets.MJ_GH_BOT_GITHUB_TOKEN }}
+        run: |
+          git config --global user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git config --global user.name "GitHub Actions"
+          git remote set-url origin "https://$REPO_PAT@github.com/${GITHUB_REPOSITORY}"
+
+      - name: Version (normal mode) and refresh lockfile
+        id: version
+        run: |
+          ${{ steps.pm.outputs.PM }} run version
+          ${{ steps.pm.outputs.PM == 'pnpm' && 'pnpm install --lockfile-only' || 'npm install' }}
+          LOCK=${{ steps.pm.outputs.PM == 'pnpm' && 'pnpm-lock.yaml' || 'package-lock.json' }}
+          if ! git diff --quiet -- "$LOCK"; then
+            git add "$LOCK"
+            git commit -m "chore: lockfile for line release [skip ci]"
+          fi
+          VERSION=$(jq -r .version packages/MJServer/package.json)
+          if [[ "$VERSION" == *-* ]]; then
+            echo "::error::Line release produced a prerelease version ($VERSION) - refusing."
+            exit 1
+          fi
+          LINE="${{ github.ref_name }}"
+          NPM_TAG="lts-${LINE#lts/}"
+          echo "VERSION=v$VERSION" >> "$GITHUB_OUTPUT"
+          echo "NPM_TAG=$NPM_TAG" >> "$GITHUB_OUTPUT"
+          echo "::notice::Publishing $VERSION from $LINE to npm dist-tag $NPM_TAG"
+
+      - name: Record latest dist-tag before publish
+        id: before
+        run: echo "LATEST=$(npm view @memberjunction/core dist-tags.latest)" >> "$GITHUB_OUTPUT"
+
+      - name: Build packages
+        run: ${{ steps.pm.outputs.PM }} run build
+
+      - name: Publish to npm (line tag, never latest)
+        # 🚨 Invoke changesets directly, NOT via `<pm> run change publish -- --tag <x>`.
+        # pnpm 10 forwards the `--` separator LITERALLY, so changesets receives
+        # `publish -- --tag lts-x`, dies with "Too many arguments" — and exits 0.
+        # That is the exact silent no-op that version-bumped and tagged 6.1.0-edge.0
+        # while publishing ZERO packages (see publish.yml). npm strips the `--`,
+        # which is why the npm-era lts/5 path would have worked; every pnpm-era line
+        # (lts/6.1 onward) would have hit it. Direct invocation works under both.
+        run: |
+          set -euo pipefail
+          npx changeset publish --tag ${{ steps.version.outputs.NPM_TAG }} 2>&1 | tee /tmp/publish.log
+          if ! grep -qE 'New tag:|Packages published|already published' /tmp/publish.log; then
+            echo "::error::changeset publish produced no evidence of a publish - refusing to report success."
+            exit 1
+          fi
+        env:
+          NPM_TOKEN: ''
+
+      # The registry is the only signal that cannot be lied to (changesets exits 0
+      # on its own errors; log-grep assertions only prove what was printed). Assert
+      # the line dist-tag actually reached the new version, then that `latest` is
+      # untouched.
+      - name: Verify the publish reached npm and latest did not move
+        run: |
+          set -euo pipefail
+          VERSION="${{ steps.version.outputs.VERSION }}"
+          VERSION="${VERSION#v}"
+          NPM_TAG='${{ steps.version.outputs.NPM_TAG }}'
+          AT_TAG=''
+          for i in 1 2 3 4 5; do
+            AT_TAG=$(npm view "@memberjunction/core@$NPM_TAG" version 2>/dev/null || true)
+            [ "$AT_TAG" = "$VERSION" ] && break
+            echo "dist-tag '$NPM_TAG' is at '${AT_TAG:-<unset>}', want $VERSION - retry $i/5 in 15s"
+            sleep 15
+          done
+          if [ "$AT_TAG" != "$VERSION" ]; then
+            echo "::error::npm dist-tag '$NPM_TAG' never reached $VERSION - the publish did not happen (or failed before tagging). Do not trust this run's green steps."
+            exit 1
+          fi
+          NOW=$(npm view @memberjunction/core dist-tags.latest)
+          if [ "$NOW" != "${{ steps.before.outputs.LATEST }}" ]; then
+            echo "::error::npm 'latest' moved during a line publish (${{ steps.before.outputs.LATEST }} -> $NOW). Investigate immediately; restore with ci/dist-tag-all.mjs from the certified tag."
+            exit 1
+          fi
+          echo "::notice::Verified: @memberjunction/core@$VERSION is live under '$NPM_TAG'; latest unmoved at ${{ steps.before.outputs.LATEST }}"
+
+      # Tag and release steps tolerate a re-run of a partially completed publish
+      # (publish succeeded, a later step failed): the publish step's "already
+      # published" evidence passes, and these skip instead of dying on collisions.
+      - name: Push release commit and tag to the line branch
+        env:
+          VERSION: ${{ steps.version.outputs.VERSION }}
+        run: |
+          set -euo pipefail
+          git push origin "HEAD:${{ github.ref_name }}"
+          if git ls-remote --tags origin "refs/tags/$VERSION" | grep -q .; then
+            echo "::notice::Tag $VERSION already exists on origin - skipping (re-run of a partially completed publish)"
+          else
+            git tag "$VERSION"
+            git push origin "refs/tags/$VERSION"
+          fi
+
+      - name: Create GitHub Release (never latest; certification promotes)
+        env:
+          GH_TOKEN: ${{ secrets.MJ_GH_BOT_GITHUB_TOKEN }}
+          VERSION: ${{ steps.version.outputs.VERSION }}
+        run: |
+          set -euo pipefail
+          if gh release view "$VERSION" --repo "${{ github.repository }}" >/dev/null 2>&1; then
+            echo "Release $VERSION already exists - skipping creation (re-run of a partially completed publish)"
+            exit 0
+          fi
+          gh release create "$VERSION" --title "$VERSION" --generate-notes --latest=false \
+            --target "${{ github.ref_name }}" --repo "${{ github.repository }}"


### PR DESCRIPTION
## What

Adds .github/workflows/publish-lts.yml to lts/5, byte-identical to the hardened version in #3559.

## Why

lts/5 was cut Aug 1 from the v5.51.0 tag. The one-button line-release workflow landed on next Aug 3, two days later, so this branch never carried it. workflow_dispatch runs the workflow file from the selected ref, meaning the 5.51.1 release cannot be dispatched on lts/5 until the file exists here. Future lines inherit the file at branch cut automatically; lts/5 is the only line that needs this manual add.

This is an add of a net-new file, not a backport of a diff, which is why it is a direct PR to lts/5 rather than a backport label (the label machinery cherry-picks diffs against files the branch has).

## For reviewers

Review the workflow content itself in #3559 where it diffs against the known base. This PR should merge after (or together with) #3559 so the two branches carry the same bytes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MYWbAFjiCkR8LWJK3VXWX3