### PR TITLE
fix(sql-base): sync spDeleteEntityWithCoreDependencies inbound-ref cleanup into MJ_BASE_BEFORE_SQL

### DIFF
--- a/SQL Scripts/MJ_BASE_BEFORE_SQL.sql
+++ b/SQL Scripts/MJ_BASE_BEFORE_SQL.sql
@@ -1656,6 +1656,10 @@ DELETE FROM [__mj].[EntityAIAction] WHERE [EntityID] = @EntityID;
 DELETE FROM [__mj].[EntityCommunicationMessageType] WHERE [EntityID] = @EntityID;
 DELETE FROM [__mj].[EntityAIAction] WHERE [OutputEntityID] = @EntityID;
 
+-- Clear inbound metadata references from OTHER entities' fields that point AT this entity,
+-- so the Entity row can be deleted without tripping FK_EntityField_RelatedEntity.
+UPDATE __mj.EntityField SET RelatedEntityID = NULL WHERE RelatedEntityID = @EntityID
+
 DELETE FROM __mj.Entity WHERE ID = @EntityID
 GO
 


### PR DESCRIPTION
Follow-up to #3564 (per AN-BC's review on that PR).

#3564 hardened `spDeleteEntityWithCoreDependencies` **at runtime** via an `ALTER` in the Phase 0 retirement migration, so deleting an entity now nulls inbound `EntityField.RelatedEntityID` references before `DELETE FROM Entity`. But the **canonical `CREATE`** for that proc also lives in [`SQL Scripts/MJ_BASE_BEFORE_SQL.sql`](SQL Scripts/MJ_BASE_BEFORE_SQL.sql#L1628). Left unsynced, the two definitions diverge and a future baseline regenerated from this script would silently drop the fix — the class of bug returns.

This adds the identical cleanup line to the base template so it matches the shipped runtime proc:

```sql
-- Clear inbound metadata references from OTHER entities' fields that point AT this entity,
-- so the Entity row can be deleted without tripping FK_EntityField_RelatedEntity.
UPDATE __mj.EntityField SET RelatedEntityID = NULL WHERE RelatedEntityID = @EntityID
```

Docs/template-only change — no migration, no runtime effect on its own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)