### PR TITLE
fix(metadata): purge orphaned audit records for Phase 0-retired entities

### DIFF
--- a/metadata/entities/.audit-related-entities.json
+++ b/metadata/entities/.audit-related-entities.json
@@ -457,25 +457,6 @@
   },
   {
     "_comments": [
-      "Report Snapshots - point-in-time report execution snapshots (added with search hygiene)"
-    ],
-    "fields": {
-      "Name": "MJ: Report Snapshots",
-      "TrackRecordChanges": false,
-      "TrustServerCacheCompletely": false,
-      "AllowUserSearchAPI": false,
-      "AutoUpdateAllowUserSearchAPI": false
-    },
-    "primaryKey": {
-      "ID": "@lookup:MJ: Entities.Name=MJ: Report Snapshots"
-    },
-    "sync": {
-      "lastModified": "2026-08-05T18:34:41.584Z",
-      "checksum": "45f782fe5d501db8e4e2b809d55968f8c94f72d759c940ef6c281d0013885b1b"
-    }
-  },
-  {
-    "_comments": [
       "Scheduled Job Runs - scheduled job execution history"
     ],
     "fields": {
@@ -709,22 +690,6 @@
     },
     "primaryKey": {
       "ID": "@lookup:MJ: Entities.Name=MJ: User View Runs"
-    }
-  },
-  {
-    "_comments": [
-      "Workflow Runs - workflow execution history"
-    ],
-    "fields": {
-      "Name": "MJ: Workflow Runs",
-      "BaseView": "vwWorkflowRuns",
-      "TrackRecordChanges": false,
-      "TrustServerCacheCompletely": false,
-      "AllowUserSearchAPI": false,
-      "AutoUpdateAllowUserSearchAPI": false
-    },
-    "primaryKey": {
-      "ID": "@lookup:MJ: Entities.Name=MJ: Workflow Runs"
     }
   },
   {


### PR DESCRIPTION
## Problem

The Phase 0 retirement migration [`V202608061704__v6.1.x__Phase0_..._Retirement.sql`](migrations/v6/V202608061704__v6.1.x__Phase0_Legacy_Workflow_Report_ScheduledAction_Retirement.sql) deletes 11 legacy entities via `spDeleteEntityWithCoreDependencies` (Workflow / Report / Scheduled Action subsystems). It cleaned `metadata/resource-types/.resource-types.json` but **missed** [`metadata/entities/.audit-related-entities.json`](metadata/entities/.audit-related-entities.json), which still held audit-tuning records for two of the deleted entities:

- `MJ: Report Snapshots`
- `MJ: Workflow Runs`

Because integration CI checks out **each PR merged into `next`** (`actions/checkout@v4` on `pull_request`), the Phase 0 migration now runs during `mj migrate`, deletes those entities, and the subsequent `mj sync push --dir=metadata --ci` fails resolving `@lookup:MJ: Entities.Name=MJ: Report Snapshots`:

```
❌ Processing failed for MJ: Entities at MJ: Entities[29]
   Lookup failed: No record found in 'MJ: Entities' where Name='MJ: Report Snapshots'
```

This reddens the integration gate on **every** open PR targeting `next`, not just one (surfaced on #3568).

## Fix

Remove the two orphaned audit-tuning records. The entities themselves are already dropped by the migration; these were leftover metadata with no backing row. No migration needed — declarative metadata only. JSON validated; record count 47 → 45.

🤖 Generated with [Claude Code](https://claude.com/claude-code)