### PR TITLE
fix(server,docs): clean dist before building MJServer; correct the documented API port

### DIFF
--- a/.changeset/mjserver-prebuild-clean.md
+++ b/.changeset/mjserver-prebuild-clean.md
@@ -1,0 +1,11 @@
+---
+"@memberjunction/server": patch
+---
+
+Clean `dist` before building MJServer, so a deleted source file cannot strand a compiled orphan.
+
+`tsc` only writes outputs — it never prunes them. When a source file is deleted, its previously-compiled `.js` survives in `dist/`, and because MJServer loads resolvers by glob, that orphan still gets imported at runtime. The build stays green (TypeScript compiles the current sources fine) and then the server dies on boot with an error pointing at a file that no longer exists in source.
+
+This happened for real: the v6 legacy-retirement work deleted `src/resolvers/ReportResolver.ts`, but every developer with a pre-existing `dist/` kept `dist/resolvers/ReportResolver.js`, which still did `import { RunReport } from '@memberjunction/core'` — an export removed in the same change. Result: `SyntaxError: The requested module '@memberjunction/core' does not provide an export named 'RunReport'`, MJAPI refusing to start, and a confusing hunt because the offending file isn't in the repo. A fresh CI checkout was unaffected (empty `dist`), so published packages were never at risk — this is purely a local incremental-build trap.
+
+Adding `"prebuild": "rimraf dist"` makes it structurally impossible. `rimraf` is already the convention for this in `MJCLI`, `CLICore`, and `MJCodeGenAPI`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -98,7 +98,7 @@ Unit tests passing is necessary but **not sufficient** — the integration tier 
 ```bash
 pnpm run build            # all packages, from repo root
 pnpm run watch            # watch mode
-pnpm run start:api        # MJAPI (port 4001)
+pnpm run start:api        # MJAPI — port 4000 by default, override with GRAPHQL_PORT
 pnpm run start:explorer   # MJExplorer (port 4201)
 cd packages/PackageName && pnpm run build   # single package — use this, NOT turbo from root
 ```

--- a/packages/MJServer/package.json
+++ b/packages/MJServer/package.json
@@ -15,6 +15,7 @@
     ".": "./dist/index.js"
   },
   "scripts": {
+    "prebuild": "rimraf dist",
     "build": "tsc && tsc-alias -f",
     "bundle": "tsc -noEmit && pkgroll --sourcemap --minify",
     "watch": "tsc -w",
@@ -156,6 +157,7 @@
   "devDependencies": {
     "@types/express": "^5.0.6",
     "pkgroll": "2.23.0",
+    "rimraf": "6.1.2",
     "typescript": "^5.9.3",
     "vitest": "^3.1.1"
   },


### PR DESCRIPTION
Two small fixes for traps that each cost real debugging time today. Independent of the task-graph program work — kept separate deliberately.

## 1. Stale `dist` orphans can kill MJAPI

`tsc` only *writes* outputs; it never prunes them. Delete a source file and its compiled `.js` survives in `dist/` — and because MJServer loads resolvers by glob, that orphan is still imported at runtime.

The failure mode is nasty because the build stays **green**: TypeScript compiles the current sources fine, and only the server's boot fails, with an error naming a file that no longer exists in the repo.

**This actually happened.** Phase 0 of the workflow program (#3553) deleted `src/resolvers/ReportResolver.ts`. Any developer with a pre-existing `dist/` kept `dist/resolvers/ReportResolver.js`, which still did `import { RunReport } from '@memberjunction/core'` — an export removed in that same PR:

```
file:///…/packages/MJServer/dist/resolvers/ReportResolver.js:13
import { RunReport } from '@memberjunction/core';
         ^^^^^^^^^
SyntaxError: The requested module '@memberjunction/core' does not provide an export named 'RunReport'
```

MJAPI simply refused to start.

**Not a shipping risk.** `publish.yml` runs `actions/checkout@v4` on a fresh runner — empty `dist` — then builds and publishes, so the orphan could never be packed. This is purely a *local incremental-build* trap, which is why it bit developers and not consumers.

**Fix:** `"prebuild": "rimraf dist"`, matching the existing convention in `MJCLI`, `CLICore` and `MJCodeGenAPI`.

**Scope:** deliberately MJServer only. MJServer is where glob-loading makes an orphan *fatal* rather than merely dead weight, and editing ~300 package.json files is not a small PR. Whether every package should clean its `dist` is a fair question — it just deserves its own pass rather than riding along here. Worth noting the next change queued to hit this exact trap is Phase 4's `TaskOrchestrator` retirement.

## 2. The documented API port is wrong

Root `CLAUDE.md` said MJAPI listens on **4001**. It listens on **4000**:

```ts
// packages/MJServer/src/config.ts:601
graphqlPort: process.env.GRAPHQL_PORT ? parseInt(process.env.GRAPHQL_PORT, 10) : 4000,
```

Confirmed against a live boot — `Ready http://localhost:4000/`.

This isn't cosmetic: a wrong port makes a perfectly healthy server look dead. Probing 4001 returned nothing while the server was up and serving, which sent me hunting a non-existent problem *while* diagnosing the orphan above. Updated to state the real default and that `GRAPHQL_PORT` overrides it.

## Verification

- MJAPI boots clean in **17.2s** and serves on 4000 (401 on an unauthenticated probe, as expected).
- No source changes — a `package.json` script, a devDependency, and a doc line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)