### PR TITLE
test(angular): DOM specs for bottom-sheet + workspace tabs, ratchet Generic gate to 135

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -159,7 +159,7 @@ jobs:
         run: node scripts/classify-explorer-components.mjs --min 85
 
       - name: Generic DOM coverage ratchet
-        run: node scripts/dom-test-report.mjs packages/Angular/Generic --max-none=137
+        run: node scripts/dom-test-report.mjs packages/Angular/Generic --max-none=135
 
       - name: Bootstrap DOM coverage ratchet
         run: node scripts/dom-test-report.mjs packages/Angular/Bootstrap --max-none=0

--- a/packages/Angular/Generic/ui-components/src/lib/bottom-sheet/bottom-sheet.component.dom.test.ts
+++ b/packages/Angular/Generic/ui-components/src/lib/bottom-sheet/bottom-sheet.component.dom.test.ts
@@ -1,0 +1,92 @@
+import { describe, it, expect, vi } from 'vitest';
+import { renderComponentFixture, query, text, attr, hasClass, click, capture } from '@memberjunction/ng-test-utils';
+import { MJBottomSheetComponent } from './bottom-sheet.component';
+
+/**
+ * DOM spec for <mj-bottom-sheet> — the canonical mobile overlay surface (scrim + panel).
+ * The open/close lifecycle is rAF/transition-driven and non-deterministic under jsdom, so
+ * rather than toggling `Visible` and racing animation frames we drive the component's public
+ * render state (`IsRendered`, `IsOpen`, `IsSettled`) directly via the `setup` hook and assert
+ * the template contract that state produces. Covers: the `@if (IsRendered)` gate, the
+ * `role="dialog"`/`aria-modal` modality baseline, the `[attr.aria-label]` accessible-name
+ * fallback (AriaLabel → Title → none), the `mj-bottom-sheet-scrim--open` / `mj-bottom-sheet--open`
+ * / `mj-bottom-sheet--settled` transition classes, and the `VisibleChange` + `Closed` outputs
+ * emitted on dismissal.
+ */
+describe('MJBottomSheetComponent (DOM)', () => {
+  type Fix = ReturnType<typeof renderComponentFixture<MJBottomSheetComponent>>;
+
+  /** Render already-open by default so the `@if (IsRendered)` body exists; callers tune state. */
+  const render = (
+    inputs: Record<string, unknown> = {},
+    setup: (c: MJBottomSheetComponent) => void = (c) => { c.IsRendered = true; },
+  ): Fix => renderComponentFixture(MJBottomSheetComponent, { inputs, setup });
+
+  it('renders nothing while IsRendered is false', () => {
+    const f = render({}, () => { /* leave IsRendered at its false default */ });
+    expect(query(f, '.mj-bottom-sheet')).toBeNull();
+    expect(query(f, '.mj-bottom-sheet-scrim')).toBeNull();
+  });
+
+  it('renders a modal dialog once rendered', () => {
+    const f = render();
+    const sheet = query(f, '.mj-bottom-sheet');
+    expect(sheet).not.toBeNull();
+    expect(attr(f, '.mj-bottom-sheet', 'role')).toBe('dialog');
+    expect(attr(f, '.mj-bottom-sheet', 'aria-modal')).toBe('true');
+  });
+
+  it('renders the Title in the header and as the accessible name', () => {
+    const f = render({ Title: 'Open Records' });
+    expect(text(f, '.mj-bottom-sheet-header')).toBe('Open Records');
+    expect(attr(f, '.mj-bottom-sheet', 'aria-label')).toBe('Open Records');
+  });
+
+  it('honors AriaLabel over Title for the accessible name', () => {
+    const f = render({ Title: 'Open Records', AriaLabel: 'Open records overlay' });
+    // header still shows the visible Title...
+    expect(text(f, '.mj-bottom-sheet-header')).toBe('Open Records');
+    // ...but the accessible name is the override
+    expect(attr(f, '.mj-bottom-sheet', 'aria-label')).toBe('Open records overlay');
+  });
+
+  it('omits the header and aria-label when neither Title nor AriaLabel is set', () => {
+    const f = render();
+    expect(query(f, '.mj-bottom-sheet-header')).toBeNull();
+    expect(attr(f, '.mj-bottom-sheet', 'aria-label')).toBeNull();
+  });
+
+  it('applies the open + settled transition classes when open and settled', () => {
+    const f = render({}, (c) => { c.IsRendered = true; c.IsOpen = true; c.IsSettled = true; });
+    expect(hasClass(f, '.mj-bottom-sheet-scrim', 'mj-bottom-sheet-scrim--open')).toBe(true);
+    expect(hasClass(f, '.mj-bottom-sheet', 'mj-bottom-sheet--open')).toBe(true);
+    expect(hasClass(f, '.mj-bottom-sheet', 'mj-bottom-sheet--settled')).toBe(true);
+  });
+
+  it('withholds the transition classes while rendered but not yet open', () => {
+    const f = render();
+    expect(hasClass(f, '.mj-bottom-sheet-scrim', 'mj-bottom-sheet-scrim--open')).toBe(false);
+    expect(hasClass(f, '.mj-bottom-sheet', 'mj-bottom-sheet--open')).toBe(false);
+    expect(hasClass(f, '.mj-bottom-sheet', 'mj-bottom-sheet--settled')).toBe(false);
+  });
+
+  it('emits VisibleChange(false) when the scrim is clicked to dismiss an open sheet', () => {
+    const f = render({}, (c) => { c.IsRendered = true; c.IsOpen = true; });
+    const visibleChanges = capture(f.componentInstance.VisibleChange);
+    click(f, '.mj-bottom-sheet-scrim');
+    expect(visibleChanges).toEqual([false]);
+  });
+
+  it('emits Closed after the exit transition settles', () => {
+    vi.useFakeTimers();
+    try {
+      const f = render({}, (c) => { c.IsRendered = true; c.IsOpen = true; });
+      const closed = capture(f.componentInstance.Closed);
+      click(f, '.mj-bottom-sheet-scrim'); // Close() → close() schedules the settle fallback
+      vi.advanceTimersByTime(300);        // fallback fires finishClose() under reduced motion
+      expect(closed.length).toBe(1);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+});

--- a/packages/Angular/Generic/ui-components/src/lib/workspace-tabs/workspace-card.component.dom.test.ts
+++ b/packages/Angular/Generic/ui-components/src/lib/workspace-tabs/workspace-card.component.dom.test.ts
@@ -1,0 +1,77 @@
+import { describe, it, expect } from 'vitest';
+import { renderComponentFixture, query, queryAll, text, attr, click, capture } from '@memberjunction/ng-test-utils';
+import { MJWorkspaceCardComponent } from './workspace-card.component';
+import { MJWorkspaceTab } from './workspace-tabs.types';
+
+/**
+ * DOM spec for <mj-workspace-card> — the thin slotted frame every workspace screen shares. It owns
+ * the card surface, the delegated `<mj-workspace-tab-strip>`, and the opt-in standardized footer
+ * (confirm / save-as-draft / discard). Covers: the `aria-label` on the card surface, the
+ * `@if (ShowFooter)` / `@if (ShowDraft)` footer gating, the per-workshop `ConfirmLabel` /
+ * `ConfirmBusy` states, the `Confirm` / `SaveDraft` / `Discard` outputs, and that the tab-strip
+ * outputs (`TabSelected` etc.) are forwarded up through the card.
+ */
+describe('MJWorkspaceCardComponent (DOM)', () => {
+  type Fix = ReturnType<typeof renderComponentFixture<MJWorkspaceCardComponent>>;
+
+  const tab = (over: Partial<MJWorkspaceTab>): MJWorkspaceTab =>
+    ({ Id: 'a', Label: 'Alpha', Status: 'draft', State: null, ...over });
+
+  const render = (inputs: Record<string, unknown> = {}): Fix =>
+    renderComponentFixture(MJWorkspaceCardComponent, { inputs });
+
+  it('labels the card surface with AriaLabel', () => {
+    const f = render({ AriaLabel: 'Journal entries' });
+    expect(attr(f, '.ws-card', 'aria-label')).toBe('Journal entries');
+  });
+
+  it('hides the standardized footer unless ShowFooter is set', () => {
+    const f = render();
+    expect(query(f, '.ws-card__foot')).toBeNull();
+  });
+
+  it('renders the footer with the per-workshop ConfirmLabel when ShowFooter is set', () => {
+    const f = render({ ShowFooter: true, ConfirmLabel: 'Create entry' });
+    expect(query(f, '.ws-card__foot')).not.toBeNull();
+    expect(text(f, '.ws-card__foot button[variant="primary"]')).toContain('Create entry');
+  });
+
+  it('swaps the confirm label for the busy label while ConfirmBusy is true', () => {
+    const f = render({ ShowFooter: true, ConfirmLabel: 'Create entry', ConfirmBusy: true, ConfirmBusyLabel: 'Saving…' });
+    const confirm = text(f, '.ws-card__foot button[variant="primary"]');
+    expect(confirm).toContain('Saving…');
+    expect(confirm).not.toContain('Create entry');
+  });
+
+  it('emits Confirm, SaveDraft and Discard from the three footer verbs', () => {
+    const f = render({ ShowFooter: true });
+    const confirm = capture(f.componentInstance.Confirm);
+    const draft = capture(f.componentInstance.SaveDraft);
+    const discard = capture(f.componentInstance.Discard);
+    click(f, '.ws-card__foot button[variant="primary"]');
+    click(f, '.ws-card__foot button[variant="outline"]'); // save-as-draft
+    click(f, '.ws-card__foot button[variant="flat"]');     // discard
+    expect(confirm.length).toBe(1);
+    expect(draft.length).toBe(1);
+    expect(discard.length).toBe(1);
+  });
+
+  it('omits the save-as-draft verb when ShowDraft is false', () => {
+    const f = render({ ShowFooter: true, ShowDraft: false });
+    expect(queryAll(f, '.ws-card__foot button[variant="outline"]').length).toBe(0);
+  });
+
+  it('forwards TabSelected up from the embedded tab strip', () => {
+    const f = render({ Tabs: [tab({ Id: 'a' }), tab({ Id: 'b', Label: 'Beta' })], ActiveId: 'a' });
+    const selected = capture(f.componentInstance.TabSelected);
+    (queryAll(f, '.mj-tabs__tab')[1] as HTMLElement).click();
+    expect(selected).toEqual(['b']);
+  });
+
+  it('forwards NewTabRequested up from the embedded tab strip', () => {
+    const f = render({ Tabs: [tab({ Id: 'a' })] });
+    const requested = capture(f.componentInstance.NewTabRequested);
+    click(f, '.mj-tabs__new');
+    expect(requested.length).toBe(1);
+  });
+});

--- a/packages/Angular/Generic/ui-components/src/lib/workspace-tabs/workspace-tab-strip.component.dom.test.ts
+++ b/packages/Angular/Generic/ui-components/src/lib/workspace-tabs/workspace-tab-strip.component.dom.test.ts
@@ -1,0 +1,89 @@
+import { describe, it, expect } from 'vitest';
+import { renderComponentFixture, queryAll, attr, hasClass, click, capture } from '@memberjunction/ng-test-utils';
+import { MJWorkspaceTabStripComponent } from './workspace-tab-strip.component';
+import { MJWorkspaceTab } from './workspace-tabs.types';
+
+/**
+ * DOM spec for <mj-workspace-tab-strip> — the dumb, presentation-over-store draft tab strip.
+ * It renders the tabs it is handed and emits intent; there is no data provider, so it renders
+ * purely from the `Tabs` input. Covers: the `@for` tab-per-item render, the
+ * `mj-tabs__tab--active` / `--rejected` / `--complete` status classes, the `aria-selected` state,
+ * the `aria-label` accessible name that folds in rejected/unsaved state, the dirty dot, the
+ * `@if (ShowNewTab)` new-tab affordance, and the `TabSelected` / `TabClosed` / `NewTabRequested`
+ * outputs. (Drag-reorder / `TabReordered` is CDK-pointer-driven and out of scope for a jsdom DOM
+ * spec — its emit logic is unit-covered via `onDrop`.)
+ */
+describe('MJWorkspaceTabStripComponent (DOM)', () => {
+  type Fix = ReturnType<typeof renderComponentFixture<MJWorkspaceTabStripComponent>>;
+
+  const tab = (over: Partial<MJWorkspaceTab>): MJWorkspaceTab =>
+    ({ Id: 'a', Label: 'Alpha', Status: 'draft', State: null, ...over });
+
+  const render = (
+    inputs: Record<string, unknown>,
+    setup?: (c: MJWorkspaceTabStripComponent) => void,
+  ): Fix => renderComponentFixture(MJWorkspaceTabStripComponent, { inputs, setup });
+
+  const tabs = (f: Fix) => queryAll(f, '.mj-tabs__tab') as HTMLElement[];
+
+  it('renders one tab per item in Tabs', () => {
+    const f = render({ Tabs: [tab({ Id: 'a' }), tab({ Id: 'b', Label: 'Beta' })] });
+    expect(tabs(f).length).toBe(2);
+  });
+
+  it('marks the active tab with --active and aria-selected, and only that one', () => {
+    const f = render({ Tabs: [tab({ Id: 'a' }), tab({ Id: 'b', Label: 'Beta' })], ActiveId: 'b' });
+    const active = tabs(f).filter((t) => t.classList.contains('mj-tabs__tab--active'));
+    expect(active.length).toBe(1);
+    expect(active[0].getAttribute('aria-selected')).toBe('true');
+    // the inactive tab reports aria-selected=false
+    const inactive = tabs(f).find((t) => !t.classList.contains('mj-tabs__tab--active'))!;
+    expect(inactive.getAttribute('aria-selected')).toBe('false');
+  });
+
+  it('applies the rejected and complete status classes from tab.Status', () => {
+    const f = render({ Tabs: [tab({ Id: 'r', Status: 'rejected' }), tab({ Id: 'c', Status: 'complete' })] });
+    const [rejected, complete] = tabs(f);
+    expect(rejected.classList.contains('mj-tabs__tab--rejected')).toBe(true);
+    expect(complete.classList.contains('mj-tabs__tab--complete')).toBe(true);
+  });
+
+  it('folds rejected + unsaved state into the tab accessible name', () => {
+    const f = render({ Tabs: [tab({ Label: 'Alpha', Status: 'rejected', Dirty: true })] });
+    expect(tabs(f)[0].getAttribute('aria-label')).toBe('Alpha (rejected) (unsaved changes)');
+  });
+
+  it('renders the dirty dot only for tabs with unsaved changes', () => {
+    const f = render({ Tabs: [tab({ Id: 'a', Dirty: true }), tab({ Id: 'b', Label: 'Beta' })] });
+    expect(queryAll(f, '.mj-tabs__dirty').length).toBe(1);
+  });
+
+  it('emits TabSelected with the tab id when a tab body is clicked', () => {
+    const f = render({ Tabs: [tab({ Id: 'a' }), tab({ Id: 'b', Label: 'Beta' })] });
+    const selected = capture(f.componentInstance.TabSelected);
+    tabs(f)[1].click();
+    expect(selected).toEqual(['b']);
+  });
+
+  it('emits TabClosed (and not TabSelected) when a tab close button is clicked', () => {
+    const f = render({ Tabs: [tab({ Id: 'a' })] });
+    const closed = capture(f.componentInstance.TabClosed);
+    const selected = capture(f.componentInstance.TabSelected);
+    click(f, '.mj-tabs__close');
+    expect(closed).toEqual(['a']);
+    expect(selected).toEqual([]); // stopPropagation keeps the row click from firing
+  });
+
+  it('shows the new-tab button by default and emits NewTabRequested on click', () => {
+    const f = render({ Tabs: [tab({ Id: 'a' })], NewTabLabel: 'New draft' });
+    const requested = capture(f.componentInstance.NewTabRequested);
+    expect(attr(f, '.mj-tabs__new', 'aria-label')).toBe('New draft');
+    click(f, '.mj-tabs__new');
+    expect(requested.length).toBe(1);
+  });
+
+  it('hides the new-tab button when ShowNewTab is false', () => {
+    const f = render({ Tabs: [tab({ Id: 'a' })], ShowNewTab: false });
+    expect(queryAll(f, '.mj-tabs__new').length).toBe(0);
+  });
+});


### PR DESCRIPTION
## What

Adds DOM specs for three `@memberjunction/ng-ui-components` components and ratchets the **Generic DOM-coverage gate from 137 → 135**.

| Component | Status | Tests | Behavior coverage |
|---|---|---|---|
| `MJBottomSheetComponent` | solid | 9 | 6/6 |
| `MJWorkspaceTabStripComponent` | solid | 9 | 9/9 |
| `MJWorkspaceCardComponent` | solid | 8 | 6/8 |

## Why

These three components landed after #3174 set the ratchet to `--max-none=137`, but shipped without DOM specs — pushing the specless count to **138** and tripping the `Generic DOM coverage ratchet` gate on any PR touching the tree (surfaced on #3568). Rather than loosen the gate or defer, this specs all three (bringing them to `solid`), drops the count to **135**, and ratchets the gate **down** — the direction the ratchet is designed to move — so the restored buffer actually catches the next regression.

## Coverage of what the specs assert

- **bottom-sheet** — `@if (IsRendered)` gate, `role="dialog"`/`aria-modal` modality baseline, the `aria-label` accessible-name fallback (AriaLabel → Title → none), the `--open`/`--settled` transition classes, and the `VisibleChange`/`Closed` dismissal outputs.
- **workspace-tab-strip** — one tab per `@for` item, `--active`/`--rejected`/`--complete` status classes, `aria-selected`, the accessible name that folds in rejected/unsaved state, the dirty dot, the `@if (ShowNewTab)` affordance, and `TabSelected`/`TabClosed`/`NewTabRequested`. (Drag-reorder is CDK-pointer-driven and out of scope for a jsdom DOM spec.)
- **workspace-card** — the card `aria-label`, `@if (ShowFooter)`/`@if (ShowDraft)` footer gating, `ConfirmLabel`/`ConfirmBusy` states, the confirm/save-draft/discard outputs, and tab-strip output forwarding.

## Testing

- New specs: **26/26 pass**
- Full `@memberjunction/ng-ui-components` suite: **543/543 pass**
- Type-check (`tsc --noEmit -p tsconfig.spec.json`): clean
- `node scripts/dom-test-report.mjs packages/Angular/Generic --max-none=135` → ✅ 135 ≤ 135

🤖 Generated with [Claude Code](https://claude.com/claude-code)