### PR TITLE
fix(agent-harness): add repository.url to package.json

### DIFF
--- a/packages/AI/AgentHarness/package.json
+++ b/packages/AI/AgentHarness/package.json
@@ -29,5 +29,9 @@
     "typescript": "^5.4.5",
     "tsc-alias": "^1.8.10",
     "vitest": "^4.0.18"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/MemberJunction/MJ"
   }
 }


### PR DESCRIPTION
## What

Adds the standard `repository` block to `packages/AI/AgentHarness/package.json`:

```json
"repository": {
  "type": "git",
  "url": "https://github.com/MemberJunction/MJ"
}
```

## Why

`@memberjunction/ai-agent-harness` shipped without a `repository` block. The **Build npm packages** action runs `.github/scripts/validate-package-repository.sh`, which requires every *publishable* `@memberjunction` package to declare `repository.url` — so the gate fails on every PR:

```
Error: Missing repository.url in packages/AI/AgentHarness/package.json
Error: Found 1 package(s) with missing or invalid repository.url
```

This is a pre-existing issue on `next` (independent of any feature branch), so fixing it here unblocks the action for all open PRs.

## Testing

`./.github/scripts/validate-package-repository.sh` → ✅ exit 0, *"All publishable @memberjunction packages have valid repository.url"* (was: 1 failure).

🤖 Generated with [Claude Code](https://claude.com/claude-code)