### PR TITLE
fix(codegen): IS-A inheritance silently does nothing on PostgreSQL (v5 LTS backport)

### DIFF
--- a/.changeset/codegen-isa-postgres-portability.md
+++ b/.changeset/codegen-isa-postgres-portability.md
@@ -1,0 +1,13 @@
+---
+"@memberjunction/codegen-lib": patch
+---
+
+Fix two PostgreSQL-only defects that made IS-A (Table-Per-Type) inheritance silently do nothing on PostgreSQL. Both were caught-and-logged, so CodeGen ran to completion with a zero exit code while every declared IS-A relationship was skipped — the end state was an entity that registered and queried normally but had `Entity.ParentID` NULL, no mirrored parent fields, no parent JOIN in its base view, and a `Save()` that never wrote the parent row.
+
+1. **`processISARelationshipConfig` could not look up entities at all.** The lookup used `(@SchemaName IS NULL OR SchemaName = @SchemaName)`; the parameter's only unambiguous use is `IS NULL`, so PostgreSQL had no type to infer and failed to prepare the statement — `could not determine data type of parameter $2`. Every `ISARelationships` entry in `additionalSchemaInfo` was therefore skipped with a logged error. The predicate is now composed conditionally (emitted, with its parameter, only when a schema is declared), which is portable to both dialects without a cast.
+
+2. **`manageSingleEntityParentFields` threw before mirroring any field.** Its `EntityField` read and update referenced mixed-case columns unquoted — `SELECT ID, IsVirtual, Type, Length, …` — which PostgreSQL folds to lower case: `column "length" does not exist`. All identifiers now go through `qi()`.
+
+SQL Server was unaffected by both (it infers the parameter type from the other side of the `OR`, and resolves identifiers case-insensitively), which is why this survived: the only shipping consumer of IS-A authors T-SQL first and had exercised it exclusively on SQL Server.
+
+Adds `isa-postgres-portability.test.ts`, which composes the SQL through real `PostgreSQLDialect` and `SQLServerDialect` instances and asserts the contracts directly: no parameter is ever emitted whose only use is `@p IS NULL`, every placeholder in the composed SQL is bound, the Name-then-BaseTable match order is preserved, each dialect's row limit is honoured, and every mixed-case `EntityField` identifier survives quoting with its case intact.

--- a/packages/CodeGenLib/src/Database/manage-metadata.ts
+++ b/packages/CodeGenLib/src/Database/manage-metadata.ts
@@ -937,6 +937,42 @@ export class ManageMetadataBase {
     * within the given schema) and sets Entity.ParentID on the child entity.
     * Must run AFTER entities are created but BEFORE manageParentEntityFields().
     */
+   /**
+    * Builds the entity lookup behind {@link processISARelationshipConfig}: match on Name first, else
+    * on BaseTable, optionally constrained to a schema.
+    *
+    * The schema predicate is composed CONDITIONALLY rather than written as
+    * `(@SchemaName IS NULL OR SchemaName = @SchemaName)`. That form is fatal on PostgreSQL: the
+    * parameter's only unambiguous use is `$n IS NULL`, which gives the planner no type to infer, so
+    * the whole statement fails to prepare with "could not determine data type of parameter $n".
+    * SQL Server infers the type from the other side of the OR and never saw the problem.
+    *
+    * The failure was silent in the worst way — processISARelationshipConfig catches per-relationship
+    * errors and logs them, so CodeGen ran to completion with a zero exit code while every declared
+    * IS-A relationship on PostgreSQL was quietly skipped, leaving Entity.ParentID NULL. Downstream
+    * that means no mirrored parent fields, no parent JOIN in the child base view, and a child whose
+    * Save() never writes the parent row.
+    *
+    * Emitting the predicate only when a schema was supplied keeps the parameter list free of
+    * type-ambiguous entries and is portable to both dialects without a cast.
+    */
+   protected buildISAEntityLookupSQL(
+      schema: string,
+      selectBody: string,
+      nameParam: string,
+      schemaName?: string,
+   ): { sql: string; params: Record<string, unknown> } {
+      const schemaPredicate = schemaName ? ` AND SchemaName = @ISASchemaName` : '';
+      const sql = `
+                  ${this.selectTop(1, selectBody,
+                     `FROM ${this.qs(schema, 'vwEntities')}
+                  WHERE Name = @${nameParam}
+                     OR (BaseTable = @${nameParam}${schemaPredicate})`,
+                     `CASE WHEN Name = @${nameParam} THEN 0 ELSE 1 END`)}
+               `;
+      return { sql, params: schemaName ? { 'ISASchemaName': schemaName } : {} };
+   }
+
    protected async processISARelationshipConfig(pool: CodeGenConnection): Promise<{ success: boolean; updatedCount: number }> {
       const config = ManageMetadataBase.getSoftPKFKConfig();
       if (!config) return { success: true, updatedCount: 0 };
@@ -950,15 +986,11 @@ export class ManageMetadataBase {
       for (const rel of relationships) {
          try {
             // Look up the parent entity — try by Name first, then by BaseTable within the given schema
-            const parentResult = await this.runQueryWithParams(pool, `
-                  ${this.selectTop(1, 'ID, Name',
-                     `FROM ${this.qs(schema, 'vwEntities')}
-                  WHERE Name = @ParentName
-                     OR (BaseTable = @ParentName AND (@SchemaName IS NULL OR SchemaName = @SchemaName))`,
-                     'CASE WHEN Name = @ParentName THEN 0 ELSE 1 END')}
-               `,
-               { 'ParentName': rel.ParentEntity, 'SchemaName': rel.SchemaName || null }
-               );
+            const parentLookup = this.buildISAEntityLookupSQL(schema, 'ID, Name', 'ParentName', rel.SchemaName);
+            const parentResult = await this.runQueryWithParams(pool, parentLookup.sql, {
+               'ParentName': rel.ParentEntity,
+               ...parentLookup.params,
+            });
 
             if (parentResult.recordset.length === 0) {
                logError(`    > IS-A config: parent entity "${rel.ParentEntity}" not found — skipping`);
@@ -969,15 +1001,11 @@ export class ManageMetadataBase {
             const parentName = parentResult.recordset[0].Name;
 
             // Look up the child entity — same strategy
-            const childResult = await this.runQueryWithParams(pool, `
-                  ${this.selectTop(1, 'ID, Name, ParentID',
-                     `FROM ${this.qs(schema, 'vwEntities')}
-                  WHERE Name = @ChildName
-                     OR (BaseTable = @ChildName AND (@SchemaName IS NULL OR SchemaName = @SchemaName))`,
-                     'CASE WHEN Name = @ChildName THEN 0 ELSE 1 END')}
-               `,
-               { 'ChildName': rel.ChildEntity, 'SchemaName': rel.SchemaName || null }
-               );
+            const childLookup = this.buildISAEntityLookupSQL(schema, 'ID, Name, ParentID', 'ChildName', rel.SchemaName);
+            const childResult = await this.runQueryWithParams(pool, childLookup.sql, {
+               'ChildName': rel.ChildEntity,
+               ...childLookup.params,
+            });
 
             if (childResult.recordset.length === 0) {
                logError(`    > IS-A config: child entity "${rel.ChildEntity}" not found — skipping`);
@@ -2599,9 +2627,13 @@ export class ManageMetadataBase {
 
          // Check the DATABASE for existing field record — in-memory metadata may be stale
          // (e.g. createNewEntityFieldsFromSchema may have already added this field from the view)
-         const existsResult = await this.runQueryWithParams(pool, `SELECT ID, IsVirtual, Type, Length, Precision, Scale, AllowsNull, AllowUpdateAPI
+         // Identifiers are quoted via qi(): __mj.EntityField's columns are mixed-case, and an
+         // unquoted reference folds to lower case on PostgreSQL — `column "length" does not exist`.
+         // SQL Server's case-insensitive resolution hid this for as long as IS-A ran only there.
+         const existsResult = await this.runQueryWithParams(pool,
+               `SELECT ${this.qi('ID')}, ${this.qi('IsVirtual')}, ${this.qi('Type')}, ${this.qi('Length')}, ${this.qi('Precision')}, ${this.qi('Scale')}, ${this.qi('AllowsNull')}, ${this.qi('AllowUpdateAPI')}
                     FROM ${this.qs(mj_core_schema(), 'EntityField')}
-                    WHERE EntityID = @EntityID AND Name = @FieldName`,
+                    WHERE ${this.qi('EntityID')} = @EntityID AND ${this.qi('Name')} = @FieldName`,
                { 'EntityID': childEntity.ID, 'FieldName': parentField.Name }
                );
 
@@ -2618,14 +2650,14 @@ export class ManageMetadataBase {
 
             if (needsUpdate) {
                const sqlUpdate = `UPDATE ${this.qs(mj_core_schema(), 'EntityField')}
-                  SET IsVirtual=${this.boolLit(true)},
-                      Type='${parentField.Type}',
-                      Length=${parentField.Length},
-                      Precision=${parentField.Precision},
-                      Scale=${parentField.Scale},
-                      AllowsNull=${this.boolLit(parentField.AllowsNull)},
-                      AllowUpdateAPI=${this.boolLit(true)}
-                  WHERE ID='${existingRow.ID}'`;
+                  SET ${this.qi('IsVirtual')}=${this.boolLit(true)},
+                      ${this.qi('Type')}='${parentField.Type}',
+                      ${this.qi('Length')}=${parentField.Length},
+                      ${this.qi('Precision')}=${parentField.Precision},
+                      ${this.qi('Scale')}=${parentField.Scale},
+                      ${this.qi('AllowsNull')}=${this.boolLit(parentField.AllowsNull)},
+                      ${this.qi('AllowUpdateAPI')}=${this.boolLit(true)}
+                  WHERE ${this.qi('ID')}='${existingRow.ID}'`;
                await this.LogSQLAndExecute(pool, sqlUpdate,
                   `Update IS-A parent field ${parentField.Name} on ${childEntity.Name}`);
                bUpdated = true;

--- a/packages/CodeGenLib/src/__tests__/isa-postgres-portability.test.ts
+++ b/packages/CodeGenLib/src/__tests__/isa-postgres-portability.test.ts
@@ -1,0 +1,135 @@
+/**
+ * Unit tests for the PostgreSQL portability of the IS-A (Table-Per-Type) CodeGen path.
+ *
+ * Both defects these cover were PostgreSQL-only, and both were SILENT: the surrounding code
+ * catches per-relationship / per-entity errors and logs them, so CodeGen ran to completion with a
+ * zero exit code while the IS-A wiring did nothing at all. The observable end state was an entity
+ * that registered and queried normally but had Entity.ParentID NULL, no mirrored parent fields, no
+ * parent JOIN in its base view, and a Save() that never wrote the parent row.
+ *
+ *   1. buildISAEntityLookupSQL — the entity lookup must not emit a parameter whose only
+ *      unambiguous use is `@p IS NULL`. PostgreSQL cannot infer a type for it and fails to prepare
+ *      the statement ("could not determine data type of parameter $n"); SQL Server infers it from
+ *      the other side of the OR, which is why this survived.
+ *
+ *   2. manageSingleEntityParentFields — every __mj.EntityField identifier must be quoted. The
+ *      columns are mixed-case; an unquoted reference folds to lower case on PostgreSQL
+ *      (`column "length" does not exist`) while SQL Server resolves it case-insensitively.
+ *
+ * The SQL is composed through REAL dialects (both of them), so these assert what actually reaches
+ * the database rather than a restatement of the implementation.
+ */
+import { describe, it, expect, vi } from 'vitest';
+
+vi.mock('mssql', () => ({}));
+vi.mock('../Config/config', () => ({
+   configInfo: {},
+   currentWorkingDirectory: '/tmp',
+   getSettingValue: vi.fn(),
+   mj_core_schema: () => '__mj',
+   dbPlatform: () => 'postgresql',
+   outputDir: '/tmp',
+}));
+vi.mock('@memberjunction/core', async (importOriginal) => {
+   const actual = await importOriginal<typeof import('@memberjunction/core')>();
+   return { ...actual, LogError: vi.fn(), LogStatus: vi.fn() };
+});
+vi.mock('@memberjunction/core-entities', async (importOriginal) => {
+   const actual = await importOriginal<typeof import('@memberjunction/core-entities')>();
+   return { ...actual };
+});
+vi.mock('../Misc/status_logging', () => ({
+   logError: vi.fn(),
+   logMessage: vi.fn(),
+   logStatus: vi.fn(),
+}));
+vi.mock('../Database/sql', () => ({ SQLUtilityBase: class {} }));
+vi.mock('../Misc/advanced_generation', () => ({ AdvancedGeneration: class {} }));
+vi.mock('@memberjunction/global', async (importOriginal) => {
+   const actual = await importOriginal<typeof import('@memberjunction/global')>();
+   return { ...actual };
+});
+vi.mock('uuid', () => ({ v4: vi.fn(() => 'mock-uuid') }));
+vi.mock('../Misc/sql_logging', () => ({
+   SQLLogging: { LogSQLAndExecute: vi.fn(async () => undefined) },
+}));
+vi.mock('@memberjunction/aiengine', () => ({ AIEngine: class {} }));
+
+import { ManageMetadataBase } from '../Database/manage-metadata';
+import { PostgreSQLDialect, SQLServerDialect } from '@memberjunction/sql-dialect';
+import type { SQLDialect } from '@memberjunction/sql-dialect';
+
+class TestableISALookup extends ManageMetadataBase {
+   constructor(private readonly _dialect: SQLDialect) { super(); }
+   protected get dialect(): SQLDialect { return this._dialect; }
+
+   public build(selectBody: string, nameParam: string, schemaName?: string) {
+      return this.buildISAEntityLookupSQL('__mj', selectBody, nameParam, schemaName);
+   }
+}
+
+const pg = () => new TestableISALookup(new PostgreSQLDialect());
+const ss = () => new TestableISALookup(new SQLServerDialect());
+
+describe('buildISAEntityLookupSQL — parameter typing (PostgreSQL-fatal when wrong)', () => {
+   it('never emits a bare "@param IS NULL" test, which PostgreSQL cannot type', () => {
+      for (const builder of [pg(), ss()]) {
+         for (const schema of ['crm', undefined]) {
+            const { sql } = builder.build('ID, Name', 'ParentName', schema);
+            expect(sql).not.toMatch(/@\w+\s+IS\s+NULL/i);
+         }
+      }
+   });
+
+   it('omits the schema predicate AND its parameter when no schema is declared', () => {
+      const { sql, params } = pg().build('ID, Name', 'ParentName', undefined);
+      expect(sql).not.toContain('SchemaName');
+      expect(params).toEqual({});
+   });
+
+   it('emits the schema predicate and binds it when a schema IS declared', () => {
+      const { sql, params } = pg().build('ID, Name', 'ParentName', 'crm');
+      expect(sql).toContain('AND SchemaName = @ISASchemaName');
+      expect(params).toEqual({ ISASchemaName: 'crm' });
+   });
+
+   it('still matches on Name first, then BaseTable — the lookup contract is unchanged', () => {
+      const { sql } = pg().build('ID, Name, ParentID', 'ChildName', 'crm');
+      expect(sql).toContain('WHERE Name = @ChildName');
+      expect(sql).toContain('OR (BaseTable = @ChildName');
+      expect(sql).toContain('CASE WHEN Name = @ChildName THEN 0 ELSE 1 END');
+   });
+
+   it('honours each dialect row limit (TOP vs LIMIT)', () => {
+      expect(ss().build('ID, Name', 'ParentName', 'crm').sql).toMatch(/SELECT\s+TOP\s+1/i);
+      expect(pg().build('ID, Name', 'ParentName', 'crm').sql).toMatch(/LIMIT\s+1/i);
+   });
+
+   it('every parameter placeholder in the SQL is bound', () => {
+      for (const schema of ['crm', undefined]) {
+         const { sql, params } = pg().build('ID, Name', 'ParentName', schema);
+         const placeholders = new Set([...sql.matchAll(/@(\w+)/g)].map((m) => m[1]));
+         const bound = new Set([...Object.keys(params), 'ParentName']);
+         for (const p of placeholders) expect(bound.has(p)).toBe(true);
+      }
+   });
+});
+
+describe('EntityField identifier quoting in the IS-A parent-field sync', () => {
+   // The columns manageSingleEntityParentFields reads and writes. Each is mixed-case in __mj, so
+   // each must arrive quoted or PostgreSQL folds it to lower case and the statement throws.
+   const COLUMNS = ['ID', 'IsVirtual', 'Type', 'Length', 'Precision', 'Scale', 'AllowsNull', 'AllowUpdateAPI', 'EntityID', 'Name'];
+
+   it('PostgreSQL quotes every mixed-case EntityField column', () => {
+      const dialect = new PostgreSQLDialect();
+      for (const col of COLUMNS) {
+         expect(dialect.QuoteIdentifier(col)).toBe(`"${col}"`);
+      }
+   });
+
+   it('the quoted form preserves case, which is the whole point', () => {
+      const dialect = new PostgreSQLDialect();
+      expect(dialect.QuoteIdentifier('Length')).not.toBe('length');
+      expect(dialect.QuoteIdentifier('Length')).toContain('Length');
+   });
+});


### PR DESCRIPTION
v5 LTS backport of #3590 — clean cherry-pick, no conflicts, both defects are byte-identical on this line.

**This is the branch where the problem was actually found and where it is actually blocking.** A v5.51.0 PostgreSQL deployment (AIDP) is trying to ship `crm.Contact` / `crm.Account` as IS-A children of BizAppsCommon's `People` / `Organizations`, and cannot: `ISARelationships` config is a no-op on PostgreSQL, so `Entity.ParentID` stays NULL, nothing mirrors, and CodeGen reports success.

## The two defects

1. **`processISARelationshipConfig` cannot look up either entity.** `(@SchemaName IS NULL OR SchemaName = @SchemaName)` gives PostgreSQL no type to infer for that parameter, so the statement never prepares — `could not determine data type of parameter $2`. Every `ISARelationships` entry is skipped with a caught-and-logged error. Now composed conditionally instead of cast, so it stays dialect-neutral.
2. **`manageSingleEntityParentFields` throws before mirroring a field.** Unquoted mixed-case `EntityField` columns fold to lower case on PostgreSQL — `column "length" does not exist`. All identifiers now go through `qi()`.

Both are swallowed, so **CodeGen exits 0** either way. SQL Server is unaffected by both, which is why this went unnoticed.

## Verification on this line

Live PostgreSQL, MJ **5.51.0** + BizAppsCommon, two IS-A children declared via config. Before: `ParentID` NULL on both, zero mirrored fields, exit 0. After: `ParentID` set from config, 19 mirrored virtual fields, base view generated with the parent JOIN, CRUD sprocs across the chain, and a single `Save()` producing a parent row and child row sharing an ID with `DisplayName` populated.

CodeGenLib suite on `lts/5`: **650 passed, 60 skipped**. `tsc --noEmit` clean.

See #3590 for the full write-up, the standalone `PREPARE` reproduction, and the reasoning behind the conditional-predicate fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
