### PR TITLE
AI Model Research Report — Grok Voice Think Fast 2.0 (focused)

### DIFF
--- a/metadata/ai-models/.ai-models.json
+++ b/metadata/ai-models/.ai-models.json
@@ -17739,7 +17739,7 @@
     "fields": {
       "Name": "Grok Voice",
       "PowerRank": 11,
-      "Description": "xAI's Grok Voice Agent API — a streaming, full-duplex, tool-calling speech-to-speech realtime model. OpenAI-Realtime-API compatible (WebSocket endpoint wss://api.x.ai/v1/realtime, Base64-encoded PCM16 @ 24 kHz audio), so the MJ driver reuses the OpenAI SDK pointed at xAI's base URL. Supports custom function tools plus xAI's built-in web search, X search, and RAG. Drives the Realtime agent type / Voice Co-Agent via BaseRealtimeModel (DriverClass GrokRealtime).",
+      "Description": "xAI's Grok Voice Agent API — a streaming, full-duplex, tool-calling speech-to-speech realtime model. OpenAI-Realtime-API compatible (WebSocket endpoint wss://api.x.ai/v1/realtime, Base64-encoded PCM16 @ 24 kHz audio), so the MJ driver reuses the OpenAI SDK pointed at xAI's base URL. Supports custom function tools plus xAI's built-in web search, X search, and RAG. Drives the Realtime agent type / Voice Co-Agent via BaseRealtimeModel (DriverClass GrokRealtime). Superseded by Grok Voice Think Fast 2.0 (announced July 29, 2026); xAI's grok-voice-latest alias resolves to Think Fast 2.0 as of August 5, 2026, while this entry's pinned grok-voice API name continues to serve the prior generation.",
       "AIModelTypeID": "@lookup:MJ: AI Model Types.Name=Realtime",
       "IsActive": true,
       "SpeedRank": 8,
@@ -21050,6 +21050,81 @@
     "sync": {
       "lastModified": "2026-07-31T18:53:06.281Z",
       "checksum": "44335a233fb0fb335593efa45b401ea4d90a8100894e3dbdffec1afcafdaf3f9"
+    }
+  },
+  {
+    "fields": {
+      "Name": "Grok Voice Think Fast 2.0",
+      "PowerRank": 12,
+      "Description": "xAI's second-generation speech-to-speech realtime voice model, announced July 29, 2026; the grok-voice-latest alias resolves to it as of August 5, 2026. Reasons while speaking rather than pausing to think — ~60% fewer reasoning tokens than Think Fast 1.0 at ~0.70s time-to-first-audio. Transcription WER 1.5-2.0x better than dedicated STT (Deepgram Nova 3, ElevenLabs Scribe v2) on xAI's 24-language eval, widening to ~10x in noisy environments; 20+ languages with automatic language detection. OpenAI-Realtime-API compatible (WebSocket endpoint wss://api.x.ai/v1/realtime), so the MJ driver reuses the OpenAI SDK pointed at xAI's base URL. Supports custom function tools plus xAI's built-in web search, X search, collections search, and remote MCP tools. Priced per minute of audio ($0.08/min API list price). Drives the Realtime agent type / Voice Co-Agent via BaseRealtimeModel (DriverClass GrokRealtime).",
+      "AIModelTypeID": "@lookup:MJ: AI Model Types.Name=Realtime",
+      "IsActive": true,
+      "SpeedRank": 9,
+      "CostRank": 4,
+      "InheritTypeModalities": true,
+      "PriorVersionID": "@lookup:MJ: AI Models.Name=Grok Voice"
+    },
+    "relatedEntities": {
+      "MJ: AI Model Vendors": [
+        {
+          "fields": {
+            "ModelID": "@parent:ID",
+            "VendorID": "@lookup:MJ: AI Vendors.Name=x.ai",
+            "Priority": 0,
+            "Status": "Active",
+            "SupportedResponseFormats": "Any",
+            "SupportsEffortLevel": false,
+            "SupportsStreaming": true,
+            "TypeID": "@lookup:MJ: AI Vendor Type Definitions.Name=Model Developer"
+          },
+          "primaryKey": {
+            "ID": "E7131979-6EC6-420E-AB53-B7D931181B11"
+          }
+        },
+        {
+          "fields": {
+            "ModelID": "@parent:ID",
+            "VendorID": "@lookup:MJ: AI Vendors.Name=x.ai",
+            "Priority": 1,
+            "Status": "Active",
+            "DriverClass": "GrokRealtime",
+            "APIName": "grok-voice-think-fast-2.0",
+            "MaxInputTokens": 128000,
+            "SupportedResponseFormats": "Any",
+            "SupportsEffortLevel": false,
+            "SupportsStreaming": true,
+            "TypeID": "@lookup:MJ: AI Vendor Type Definitions.Name=Inference Provider"
+          },
+          "primaryKey": {
+            "ID": "85C4AD09-757C-4739-95AA-236B02B5E8D7"
+          }
+        }
+      ],
+      "MJ: AI Model Costs": [
+        {
+          "fields": {
+            "ModelID": "@parent:ID",
+            "VendorID": "@lookup:MJ: AI Vendors.Name=x.ai",
+            "StartedAt": "2026-07-29T00:00:00.000Z",
+            "Status": "Active",
+            "Currency": "USD",
+            "PriceTypeID": "@lookup:MJ: AI Model Price Types.Name=Minutes",
+            "InputPricePerUnit": 0.08,
+            "OutputPricePerUnit": 0,
+            "CacheReadPricePerUnit": null,
+            "CacheWritePricePerUnit": null,
+            "UnitTypeID": "@lookup:MJ: AI Model Price Unit Types.Name=Per Minute",
+            "ProcessingType": "Realtime",
+            "Comments": "Grok Voice Think Fast 2.0 API list pricing on x.ai as of the July 29, 2026 announcement: $0.08 per minute of audio, expressed as a single blended session rate in InputPricePerUnit with OutputPricePerUnit set to 0 so per-minute consumers multiply elapsed minutes by one rate and never double-count. First cost row in the catalog on the Minutes price type / Per Minute unit. The Grok Voice Agent Builder product lists $0.05/min but is a separate SKU, not the raw realtime API. Cache pricing does not apply to per-minute audio billing (both cache columns null)."
+          },
+          "primaryKey": {
+            "ID": "3466CD84-31F6-40D0-A0A0-A35448BB65C4"
+          }
+        }
+      ]
+    },
+    "primaryKey": {
+      "ID": "9E9C9FBD-0092-4873-9D47-D45E3026DDA0"
     }
   }
 ]

--- a/reports/ai-model-research/2026-08-08-grok-voice-think-fast-2-report.md
+++ b/reports/ai-model-research/2026-08-08-grok-voice-think-fast-2-report.md
@@ -1,0 +1,110 @@
+# AI Model Research Report — Grok Voice Think Fast 2.0 (Focused)
+**Generated**: 2026-08-08
+**Scope**: Single-model addition — off-cadence, focused PR (not the weekly sweep)
+**Base Branch**: `next`
+**Working Branch**: `claude/add-grok-model-catalog-s1amt7`
+
+## Executive Summary
+
+xAI announced **Grok Voice Think Fast 2.0** on **July 29, 2026**
+([x.ai/news/grok-voice-think-fast-2](https://x.ai/news/grok-voice-think-fast-2)). The
+announcement fell inside the 2026-07-31 off-cadence report's window, but that report was a
+v5.51.0 release refresh and only noted in passing that *"MJ tracks speech models unevenly
+(`Grok Voice` is present; dedicated STT is generally [not])"*. The 2026-08-03 weekly report's
+3-day window opened after the announcement and focused on the OpenAI GPT-5.6 price cuts. This
+focused report closes that gap: **1 new model added**, **1 description-text edit**, **0 new
+vendors**.
+
+The addition matters operationally, not just for inventory completeness: xAI's
+`grok-voice-latest` alias **flipped to Think Fast 2.0 on August 5, 2026** — three days before
+this report — so any MJ deployment routing voice traffic through the alias is already on the
+new generation, while the catalog still only described the old one.
+
+## Inventory Snapshot
+
+| Category | Before | After this PR | Delta |
+|---|---|---|---|
+| Total model entries | 178 | 179 | +1 |
+| Active models | 151 | 152 | +1 |
+| Vendors | 30 | 30 | 0 |
+| Realtime-type models | 9 | 10 | +1 |
+
+## New Model — Grok Voice Think Fast 2.0 (xAI, July 29, 2026)
+
+Second-generation speech-to-speech realtime voice model; successor to the catalog's existing
+`Grok Voice` entry (`PriorVersionID` set accordingly — a genuine version lineage, since the
+`grok-voice-latest` alias now resolves to 2.0).
+
+### Specs as modeled
+
+| Field | Value | Basis |
+|---|---|---|
+| Model type | Realtime | Speech-to-speech over WebSocket, same family as `Grok Voice` / `GPT Realtime 2.1` |
+| API name | `grok-voice-think-fast-2.0` | Production model ID per Vercel AI Gateway and BLACKBOX AI model listings |
+| DriverClass | `GrokRealtime` | 2.0 keeps OpenAI-Realtime-API compatibility at `wss://api.x.ai/v1/realtime`, so the existing driver works unchanged |
+| Vendor rows | x.ai Model Developer + x.ai Inference Provider | Matches the newest realtime precedent (GPT Realtime 2.1); the older `Grok Voice` entry predates the two-row convention |
+| MaxInputTokens | 128,000 | **Carried from the `Grok Voice` predecessor row** — xAI does not publish a token-denominated context figure for the voice models in available coverage. Weakest fact in this addition; flagged below |
+| SupportsEffortLevel | false | Reasoning is always-on-while-speaking; no documented `reasoning_effort`-style parameter. Conservative default per skill guidance |
+| SupportsStreaming | true | Full-duplex realtime streaming is the product |
+| PowerRank | 12 | One above `Grok Voice` and `GPT Realtime 2.1` (both 11): xAI reports benchmark wins over OpenAI and Google voice models, plus Starlink A/B gains in conversion and support containment |
+| SpeedRank | 9 | ~0.70s time-to-first-audio and reasons-while-speaking (no thinking pause); one above `GPT Realtime 2.1` (8) |
+| CostRank | 4 | $0.08/min ≈ $4.80/hr of audio — under typical realtime-voice spend on the token-priced OpenAI realtime models at conversational audio rates |
+
+### Capabilities recorded in Description
+
+- Reasons **while speaking** rather than pausing to think; ~60% fewer reasoning tokens than
+  Think Fast 1.0 at ~0.70s time-to-first-audio.
+- Transcription WER **1.5–2.0× better** than dedicated STT (Deepgram Nova 3, ElevenLabs
+  Scribe v2) on xAI's 24-language eval; gap widens to **~10×** in noisy environments.
+- 20+ languages with automatic language detection.
+- Custom function tools plus xAI built-ins: web search, X search, collections search, and
+  remote MCP tools.
+
+### Cost row — first use of Minutes / Per Minute
+
+xAI prices the raw Voice API at **$0.08 per minute of audio** — not per token. The catalog
+has had a `Minutes` price type (baseline seed) and a `Per Minute` unit type (added
+2026-06-16, self-describedly for realtime voice) with **zero rows using them** until now.
+
+Encoding decision: the $0.08 blended session rate goes in `InputPricePerUnit` with
+`OutputPricePerUnit: 0`, so a consumer computing `minutes × rate` counts elapsed minutes
+once instead of double-counting a directionless rate stored in both columns. The cost row's
+`Comments` states this convention explicitly for the next per-minute model to follow. Both
+cache columns are `null` — cache pricing has no meaning for per-minute audio billing.
+
+The **Grok Voice Agent Builder** product lists $0.05/min; that is a separate managed SKU,
+not the raw realtime API, and is deliberately not modeled.
+
+### Description-only edit — `Grok Voice`
+
+Appended a supersession note: Think Fast 2.0 announced July 29, 2026; `grok-voice-latest`
+resolves to it as of August 5, 2026; the entry's pinned `grok-voice` API name continues to
+serve the prior generation. `IsActive` stays `true` — no retirement announced, matching repo
+precedent of deactivating only at actual retirement.
+
+## Confidence Caveats
+
+1. **MaxInputTokens 128,000** is inherited from the predecessor entry, not from a
+   first-party 2.0 spec sheet (x.ai and docs.x.ai are unreachable from this environment's
+   egress policy; secondary coverage does not state a token context figure). If docs.x.ai
+   publishes a figure, correct in a follow-up weekly report.
+2. **$0.08/min** is corroborated across multiple independent secondary sources but not
+   verified against docs.x.ai directly, for the same egress reason.
+3. New-record UUIDs were generated with Python `uuid.uuid4()` (uppercased) because the
+   `uuidgen` binary is not present in this container — same RFC-4122 v4 generation the CLI
+   rule intends; no UUIDs were invented or inferred.
+
+## Sources
+
+- [Introducing Grok Voice Think Fast 2.0 — x.ai](https://x.ai/news/grok-voice-think-fast-2)
+- [Grok Voice Think Fast 1.0 — x.ai](https://x.ai/news/grok-voice-think-fast-1)
+- [Speech to Speech — xAI Docs](https://docs.x.ai/developers/model-capabilities/audio/speech-to-speech)
+- [Grok Voice Think Fast 2.0 API & Pricing — Vercel AI Gateway](https://vercel.com/ai-gateway/models/grok-voice-think-fast-2.0)
+- [Grok Voice Think Fast 2.0 — BLACKBOX AI model listing](https://www.blackbox.ai/models/blackboxai/xai/grok-voice-think-fast-2.0)
+- [Grok Voice Think Fast 2.0 API — explainx.ai](https://www.explainx.ai/blog/grok-voice-think-fast-2-speech-to-speech-july-2026)
+- [All About Grok Voice Think Fast 2.0 — bleap.finance](https://www.bleap.finance/en-us/blog/all-about-grok-voice-think-fast-2-0)
+- [xAI upgrades Grok Voice with faster Think Fast 2 mode — YourStory](https://yourstory.com/ai-story/xai-grok-voice-think-fast-2)
+- [xAI Unveils Grok Voice Think Fast 2.0 — BigGo Finance](https://finance.biggo.com/news/4bf16f12-1046-46f1-8d01-aa9649230336)
+- [xAI releases Grok Voice Think Fast 2.0 — AIbase](https://www.aibase.com/news/30002)
+- [Grok Voice 2.0 and the State of Speech-to-Speech Agents — Digital Applied](https://www.digitalapplied.com/blog/grok-voice-think-fast-2-speech-to-speech-agents-2026)
+- [xAI Voice Agent (Realtime API) — LiteLLM docs](https://docs.litellm.ai/docs/providers/xai_realtime)


### PR DESCRIPTION
## Summary

Focused, off-cadence catalog addition following the weekly AI-model-research PR pattern: **1 new model**, **1 description-text edit**, **0 pricing changes to existing rows**, **0 new vendors**.

### Why off-cadence

xAI announced [Grok Voice Think Fast 2.0](https://x.ai/news/grok-voice-think-fast-2) on **July 29, 2026**. The announcement fell between report windows: the 2026-07-31 report was a v5.51.0 release refresh (it only noted "MJ tracks speech models unevenly"), and the 2026-08-03 weekly focused on the OpenAI GPT-5.6 price cuts. Meanwhile xAI's `grok-voice-latest` alias **flipped to Think Fast 2.0 on August 5** — so deployments routing through the alias are already on the new generation while the catalog only described the old one.

### New model — Grok Voice Think Fast 2.0 (xAI, July 29, 2026)

Added to `metadata/ai-models/.ai-models.json` with:
- 2 vendor rows: x.ai Model Developer + x.ai Inference Provider (`DriverClass: GrokRealtime`, `APIName: grok-voice-think-fast-2.0`) — the driver is unchanged because 2.0 keeps OpenAI-Realtime-API compatibility at `wss://api.x.ai/v1/realtime`
- 1 USD cost row — **the catalog's first row on the `Minutes` price type / `Per Minute` unit**
- `PriorVersionID` → `Grok Voice` (genuine lineage: the `grok-voice-latest` alias now resolves to 2.0)

Headline specs:
- **Pricing**: $0.08 per minute of audio (API list price; the $0.05/min Agent Builder product is a separate SKU, deliberately not modeled)
- **Capabilities**: reasons while speaking (~60% fewer reasoning tokens than 1.0, ~0.70s time-to-first-audio), transcription WER 1.5–2.0× better than dedicated STT on xAI's 24-language eval (~10× in noise), 20+ languages, function tools + built-in web/X/collections search and remote MCP tools
- **Positioning**: `PowerRank: 12` (one above `Grok Voice` / `GPT Realtime 2.1`), `SpeedRank: 9`, `CostRank: 4`
- **SupportsEffortLevel**: `false` — reasoning is always-on; no documented effort parameter (conservative default)

### Decisions worth defending

- **Per-minute encoding convention**: the $0.08 blended session rate lives in `InputPricePerUnit` with `OutputPricePerUnit: 0`, so a consumer computing `minutes × rate` counts elapsed minutes once instead of double-counting a directionless rate stored in both columns. The cost row's `Comments` documents this for the next per-minute model. Both cache columns are `null` — cache pricing has no meaning for per-minute audio billing.
- **Two vendor rows, not one**: the older `Grok Voice` entry carries only an Inference Provider row, but the newest realtime precedent (GPT Realtime 2.1) uses Model Developer + Inference Provider; this follows the newer convention.
- **Description-only edit to `Grok Voice`**: supersession note (alias flip date, pinned `grok-voice` API name still serves the prior generation). `IsActive` stays `true` — no retirement announced, matching repo precedent of deactivating only at actual retirement.

### Confidence caveats

- **`MaxInputTokens: 128000` is carried from the predecessor row** — xAI publishes no token-denominated context figure for the voice models in available coverage, and x.ai/docs.x.ai are unreachable from this environment's egress policy. Weakest fact in the addition; flagged in the report for correction if docs publish a figure.
- $0.08/min is corroborated across multiple independent secondary sources (Vercel AI Gateway, explainx, bleap, BigGo) but not verified against docs.x.ai directly, for the same egress reason.

## Full report

`reports/ai-model-research/2026-08-08-grok-voice-think-fast-2-report.md` — source links, spec-basis table, and rationale.

## Test plan

- [x] JSON parses (Python `json.load`): 179 models (+1), 152 active (+1)
- [x] All `@lookup:` references resolve against existing metadata: `MJ: AI Model Types.Name=Realtime`, `MJ: AI Vendors.Name=x.ai`, `MJ: AI Vendor Type Definitions.Name=Model Developer|Inference Provider`, `MJ: AI Model Price Types.Name=Minutes` (baseline seed `82504284-7D03-4DB2-8392-9C25A59F67D9`), `MJ: AI Model Price Unit Types.Name=Per Minute`
- [x] `PriorVersionID` resolves to the existing `Grok Voice` entry
- [x] New-record UUIDs are unique across the file (the 4 pre-existing duplicate UUIDs documented in #3330 are untouched); no `sync` blocks on new records
- [ ] `mj sync push --dry-run --dir=metadata --include="ai-models"` before the build engineer's release-time consolidated sync push (no DB available in this session)

## Notes for reviewers

- No hand-authored `*__Metadata_Sync.sql` migration — per `metadata/CLAUDE.md` §1b, the consolidated sync migration is generated at release time.
- New-record UUIDs were generated with Python `uuid.uuid4()` (uppercased) because the `uuidgen` binary is absent in this container — same RFC-4122 v4 generation the CLI rule intends.

---
_Generated by [Claude Code](https://claude.ai/code/session_01PXYrar3YFstUcexdRR5g1f)_