### PR TITLE
fix(changeset): unblock v6.1.0-edge.1 publish — drop package no longer in the workspace

### DIFF
--- a/.changeset/pnpm-workspace-cutover.md
+++ b/.changeset/pnpm-workspace-cutover.md
@@ -8,7 +8,6 @@
 "@memberjunction/ng-explorer-core": patch
 "@memberjunction/react-linter": patch
 "@memberjunction/react-test-harness": patch
-"@memberjunction/scheduled-actions-server": patch
 "@memberjunction/server": patch
 "@memberjunction/server-extensions-core": patch
 "@memberjunction/sqlserver-dataprovider": patch
@@ -27,4 +26,4 @@ Two changes are more than a declaration:
 - **`@memberjunction/server`**: `@types/express` moves `^4.17.25` → `^5.0.6`. The package declares `express@^5.2.1` at runtime, so it was only compiling because hoisting supplied the v5 types that six sibling packages declare. The types now match the express it actually runs.
 - **`@memberjunction/ng-auth-services`**: `angularProviderFactory` gains an explicit `Provider[]` return type. Declaring `@auth0/auth0-spa-js` alone does not resolve TS2742 — the emitted declaration file still needed a nameable type rather than one inferred through a transitive package path.
 
-- **`@memberjunction/scheduled-actions-server`**: drops `@types/axios`, a deprecated stub package that carries no type definitions; its presence made TypeScript auto-include it and then fail to find any types. axios ships its own.
+(A third change in this set applied to `@memberjunction/scheduled-actions-server` — dropping `@types/axios`, a deprecated stub carrying no type definitions. That package has since been removed from the workspace, so its entry is no longer part of this changeset.)


### PR DESCRIPTION
## What happened

`publish.yml` for **v6.1.0-edge.1** failed ~3s after the release merge, at `changeset version`:

```
Found changeset pnpm-workspace-cutover for package
@memberjunction/scheduled-actions-server which is not in the workspace
```

`.changeset/pnpm-workspace-cutover.md` predates that package's removal and still listed it. `changeset version` treats an unknown package as a hard error rather than skipping it.

## Nothing was published

The failure is **upstream of the publish loop**, so this is a clean retry, not a partial release:

| Check | State |
|---|---|
| `npm view @memberjunction/core dist-tags` | `edge: 6.1.0-edge.0`, `latest: 5.51.0` — **unmoved** |
| `main:packages/MJCore/package.json` | still `6.1.0-edge.0` — no version bump ran |
| Newest tag | `v6.1.0-edge.0` — no new tag |

This is *not* the mid-publish-cancel scenario DEPLOYMENT.md documents, so `gh run rerun --failed` alone would have failed identically — the stale changeset had to be removed first.

## The fix

Removes the frontmatter entry, and rewrites the prose bullet that described its change so the changelog stays accurate instead of referencing a package the repo no longer has.

## Verification

Audited **every** changeset against the 308 live workspace packages — this was the only stale entry, so the retry will not trip over a second one.

## After merge

The push to `main` re-triggers `publish.yml`. Then verify per DEPLOYMENT.md §10a: `edge` moves to `6.1.0-edge.1` and **`latest` does NOT move**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)