### PR TITLE
fix(ci): raise publish job timeout 30m→120m (it killed the edge.1 publish mid-loop)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -63,7 +63,18 @@ jobs:
 
   build-and-publish:
     name: Build and publish new versions of NPM packages
-    timeout-minutes: 30
+    # 30 minutes was not enough and the failure mode is DESTRUCTIVE, not a clean retry.
+    # v6.1.0-edge.1 ran 30m16s and GitHub killed it mid-`changeset publish`, leaving the
+    # fixed-version group split across two versions on npm (~100 packages at the new version,
+    # ~200 at the old) with no version-bump commit, no tag, and no back-merge. A job timeout
+    # reports as "The operation was canceled", which is indistinguishable at a glance from
+    # someone clicking Cancel — the v5.49.0 split was attributed to an accidental click and
+    # may well have been this same ceiling.
+    #
+    # The budget is structurally tight: the build alone takes ~25 minutes, leaving ~5 for a
+    # publish loop that uploads ~300 packages serially. Every package added shrinks the margin.
+    # 120 leaves real headroom. This only bounds a hung job; it cannot make one publish more.
+    timeout-minutes: 120
     runs-on: ubuntu-latest
     outputs:
       version: ${{ steps.version.outputs.VERSION }}


### PR DESCRIPTION
## Root cause of the v6.1.0-edge.1 split publish

The publish job ran **30m16s** and GitHub killed it at its `timeout-minutes: 30` ceiling, **mid-`changeset publish`**. Nobody cancelled it.

```
success   Update version and check against expected
success   Build packages
cancelled Publish to npm            ← job timeout, ~2 min into the upload loop
skipped   Push release commit and tag
skipped   Create GitHub Release
skipped   Merge main into next
```

## Why it's not bad luck

The budget is structurally too tight:

| Phase | Time |
|---|---|
| Checkout + install + **build** | ~25 min |
| Remaining for publishing **~300 packages** serially | ~5 min |

Every package added to the workspace shrank the margin further. Some release was going to draw the short straw.

## Current damage (unchanged by this PR)

- npm `edge` is **split** — ~100 packages at `6.1.0-edge.1`, the rest at `6.1.0-edge.0`
- npm `latest` safely **unmoved** at `5.51.0`
- No version-bump commit, no `v6.1.0-edge.1` tag, no GitHub Release, no `main`→`next` back-merge

## A note for the runbook

A job timeout surfaces as `##[error]The operation was canceled.` — **the same wording a manual cancel produces.** DEPLOYMENT.md attributes the v5.49.0 split to *"an accidental click mid-publish"*; that job carried this same 30-minute cap and produced this same symptom, so that diagnosis may have been wrong.

## Safety

Raising a timeout cannot cause a publish — it only bounds a hung job. The runbook's "do not cancel `publish.yml`" caution doesn't apply to this change.

## After merge

The push to `main` re-triggers `publish.yml`. `changeset publish` skips versions already on npm, so it resumes with the remainder, then proceeds to bump, tag, release, and back-merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)