### PR TITLE
fix(core): run an overridden ValidateAsync instead of silently skipping it

### DIFF
--- a/.changeset/is-member-overridden.md
+++ b/.changeset/is-member-overridden.md
@@ -1,0 +1,17 @@
+---
+"@memberjunction/global": minor
+---
+
+Add `IsMemberOverridden(instance, member, BaseClassRef)` to `ClassUtils`.
+
+Answers whether a subclass replaced a member somewhere between an instance and a given base class,
+which is what distinguishes "the author made no choice" from "the author chose the value that
+happens to be the default" — something a base-class member cannot express on its own. An API whose
+default sits in the *off* position therefore silently disables exactly the subclasses that most
+wanted it on.
+
+Handles methods and accessors alike by comparing property descriptors, finds an override declared
+anywhere in a multi-level chain, returns false rather than throwing on bad input, and caches per
+(class, member, base class) so a hot path does not re-walk a prototype chain.
+
+Used by `BaseEntity` to decide whether to run an overridden `ValidateAsync`.

--- a/.changeset/validateasync-silently-skipped.md
+++ b/.changeset/validateasync-silently-skipped.md
@@ -1,0 +1,41 @@
+---
+"@memberjunction/core": patch
+---
+
+Fix `ValidateAsync` overrides being silently skipped on save.
+
+`BaseEntity.ValidateAsync` documents itself as *"automatically called by Save() AFTER the
+synchronous Validate() passes"*. It was not. `Save()` reached it only when a subclass **also**
+overrode `DefaultSkipAsyncValidation` — a separate getter the docstring never mentioned, defaulting
+to `true`. An override written against the documentation alone never ran: it reads as enforced,
+reviews as enforced, and is not.
+
+The default cannot be justified on cost. The base `ValidateAsync` returns success immediately, so
+skipping it saves a subclass that did not override it essentially nothing. The flag's only reachable
+effect was therefore to disable the async rules of subclasses that had *written* async rules — which
+is how `OrderEntityServer.ValidateAsync`, holding both the "cannot confirm an order with no lines"
+guard and an entire per-line validation loop, was dead on every save in production. It is the same
+reasoning that already exempts companion validation from the flag.
+
+Overriding `ValidateAsync` is now what turns it on. Precedence, in order of authority:
+
+1. `EntitySaveOptions.SkipAsyncValidation`, when set, wins outright.
+2. An explicit `DefaultSkipAsyncValidation` override wins next — **either value**. Stating a policy
+   still beats inferring one, so a class that deliberately opts out keeps opting out.
+3. Only when no policy is stated is it inferred: run `ValidateAsync` if a subclass overrode it.
+
+Distinguishing "chose `true`" from "never made a choice" is what makes that safe; a getter cannot
+express it, so the two are told apart by comparing property descriptors against `BaseEntity.prototype`
+(cached per class, handling accessors and methods, and finding overrides anywhere in a multi-level
+chain).
+
+**Blast radius in this repo is zero.** All 17 classes overriding `ValidateAsync` were checked: 16
+already override `DefaultSkipAsyncValidation` explicitly and so take rule 2 unchanged, and the 17th
+is `RelatedRecordCollection`, whose `ValidateAsync(result)` is `EntityCompanion`'s method in a
+different hierarchy. CodeGen never emits `ValidateAsync`, so generated classes are unaffected. Full
+MJCore suite green: 119 files, 1823 tests.
+
+**Downstream applications should expect a behaviour change**, and it is the intended one: a
+`ValidateAsync` that has been quietly dead will start running, and can start refusing saves it was
+always written to refuse. Pass `SkipAsyncValidation: true`, or override `DefaultSkipAsyncValidation`
+to return `true`, for any case that should stay off.

--- a/packages/MJCore/src/__tests__/baseEntity.validateAsync.test.ts
+++ b/packages/MJCore/src/__tests__/baseEntity.validateAsync.test.ts
@@ -31,6 +31,7 @@
  */
 
 import { describe, it, expect, beforeAll, afterAll, beforeEach } from 'vitest';
+import { IsMemberOverridden } from '@memberjunction/global';
 import { BaseEntity } from '../generic/baseEntity';
 import { EntityInfo, ValidationErrorInfo, ValidationResult, ValidationErrorType } from '../generic/entityInfo';
 import { Metadata } from '../generic/metadata';
@@ -206,11 +207,12 @@ describe('save options outrank everything', () => {
 });
 
 describe('override detection', () => {
-    // Exercised directly because the inference is only as good as this, and the getter-vs-method
-    // distinction is easy to get wrong: a property descriptor carries an overridden accessor on
-    // `get` and an overridden method on `value`, never both.
+    // Exercised through the entity classes above because the inference is only as good as this, and
+    // the getter-vs-method distinction is easy to get wrong: a property descriptor carries an
+    // overridden accessor on `get` and an overridden method on `value`, never both. The general
+    // behaviour of the helper itself is covered in @memberjunction/global's ClassUtils tests.
     const isOverridden = (instance: object, member: string): boolean =>
-        (BaseEntity as unknown as { isOverridden(i: object, m: string): boolean }).isOverridden(instance, member);
+        IsMemberOverridden(instance, member, BaseEntity);
 
     it('detects an overridden method', () => {
         expect(isOverridden(newRecord(RulesEntity), 'ValidateAsync')).toBe(true);

--- a/packages/MJCore/src/__tests__/baseEntity.validateAsync.test.ts
+++ b/packages/MJCore/src/__tests__/baseEntity.validateAsync.test.ts
@@ -1,0 +1,258 @@
+/**
+ * When `ValidateAsync` runs — driving the REAL `BaseEntity.Save()`.
+ *
+ * WHAT THIS PROTECTS
+ *
+ * `DefaultSkipAsyncValidation` returns `true`, so `Save()` reached `ValidateAsync()` only for a
+ * subclass that overrode a *second*, separate getter. The `ValidateAsync` docstring promised the
+ * method was "automatically called by Save()" and never mentioned that getter, so an override
+ * written against the documentation alone was a silent no-op: it reads as enforced, reviews as
+ * enforced, and never runs.
+ *
+ * That is not hypothetical. It is how `OrderEntityServer.ValidateAsync` — holding both the "cannot
+ * confirm an order with no lines" guard and an entire per-line validation loop — was dead on every
+ * save in production, and it is the same reasoning that already exempts companion validation from
+ * the flag.
+ *
+ * The base `ValidateAsync` just returns success, so skipping it costs a subclass that did not
+ * override it nothing at all. The flag's only reachable effect was therefore to disable the async
+ * rules of subclasses that had written async rules. Overriding the method is now what turns it on.
+ *
+ * THE PRECEDENCE, WHICH IS THE WHOLE DESIGN
+ *   1. `EntitySaveOptions.SkipAsyncValidation`, when set, wins outright.
+ *   2. An explicit `DefaultSkipAsyncValidation` override wins next — EITHER value. This is what
+ *      keeps the change inert for the 16 classes in this repo that already override both.
+ *   3. Only when nobody stated a policy is it inferred from whether `ValidateAsync` was overridden.
+ *
+ * HONEST NARROWING (same as the companions suite): the test entities override `CheckPermissions()`
+ * so `Save()` reaches the persistence branch without a permissions fixture, and the provider's
+ * `Save()` echoes the record back. Neither is the logic under test — the precedence computation and
+ * override detection in `baseEntity.ts` are real, untouched production code.
+ */
+
+import { describe, it, expect, beforeAll, afterAll, beforeEach } from 'vitest';
+import { BaseEntity } from '../generic/baseEntity';
+import { EntityInfo, ValidationErrorInfo, ValidationResult, ValidationErrorType } from '../generic/entityInfo';
+import { Metadata } from '../generic/metadata';
+import { ProviderBase } from '../generic/providerBase';
+import type { IEntityDataProvider } from '../generic/interfaces';
+import { ALL_ENTITY_DATA, PRODUCT_ENTITY_ID } from './mocks/MockEntityData';
+
+const MOCK_USER = { ID: 'u-1', Name: 'T', Email: 't@t', UserRoles: [] };
+
+let productEntityInfo: EntityInfo;
+/** Incremented by every test entity whose ValidateAsync actually runs. */
+let asyncRuns = 0;
+
+function makeProvider() {
+    return {
+        CurrentUser: MOCK_USER,
+        get SupportsEntityTransactions() {
+            return true;
+        },
+        get IsInTransaction() {
+            return false;
+        },
+        async Save(entity: BaseEntity): Promise<Record<string, unknown>> {
+            return entity.GetAll();
+        },
+        async Delete(): Promise<boolean> {
+            return true;
+        },
+        SetCachedRecordName(): void {
+            /* no-op */
+        },
+        GetCachedRecordName(): string | undefined {
+            return undefined;
+        },
+    };
+}
+
+/** No overrides at all — the overwhelming majority of entity classes. */
+class PlainEntity extends BaseEntity {
+    public override CheckPermissions(): boolean {
+        return true;
+    }
+}
+
+/**
+ * Overrides ONLY `ValidateAsync` — the shape every application writes, and the shape that was
+ * silently dead. Its rule always fails, so "did it run" is observable as a refused save rather than
+ * only as a counter.
+ */
+class RulesEntity extends PlainEntity {
+    public override async ValidateAsync(): Promise<ValidationResult> {
+        asyncRuns++;
+        const result = await super.ValidateAsync();
+        result.Success = false;
+        result.Errors.push(
+            new ValidationErrorInfo('Name', 'async rule refused', null, ValidationErrorType.Failure),
+        );
+        return result;
+    }
+}
+
+/** A server subclass on top of the class that declared the rule — the real MJ layering. */
+class ServerRulesEntity extends RulesEntity {}
+
+/** Overrides both, opting OUT deliberately. That choice must survive. */
+class DeliberatelyOptedOutEntity extends RulesEntity {
+    public override get DefaultSkipAsyncValidation(): boolean {
+        return true;
+    }
+}
+
+/** Overrides both, opting IN — the 16 classes already in this repo. Behaviour must not change. */
+class DeliberatelyOptedInEntity extends RulesEntity {
+    public override get DefaultSkipAsyncValidation(): boolean {
+        return false;
+    }
+}
+
+beforeAll(() => {
+    const entities = ALL_ENTITY_DATA.map(d => new EntityInfo(d));
+    productEntityInfo = entities.find(e => e.ID === PRODUCT_ENTITY_ID)!;
+    Metadata.Provider = {
+        Entities: entities,
+        CurrentUser: MOCK_USER,
+    } as unknown as ProviderBase;
+});
+
+afterAll(() => {
+    Metadata.Provider = null as unknown as ProviderBase;
+});
+
+beforeEach(() => {
+    asyncRuns = 0;
+});
+
+/** A dirty, newly-created record of `cls`, ready to save. */
+function newRecord<T extends BaseEntity>(cls: new (...a: never[]) => T): T {
+    const entity = new (cls as never)(
+        productEntityInfo,
+        makeProvider() as unknown as IEntityDataProvider,
+    ) as T;
+    entity.NewRecord();
+    entity.Set('Name', 'a-name');
+    return entity;
+}
+
+describe('inferring the policy when nobody stated one', () => {
+    it('runs ValidateAsync for a subclass that overrode it', async () => {
+        // THE FIX. Before this, the override was never called and the save succeeded, carrying
+        // whatever the rule existed to prevent.
+        const entity = newRecord(RulesEntity);
+        const saved = await entity.Save();
+
+        expect(asyncRuns, 'the override ran').toBe(1);
+        expect(saved, 'and its failure refused the save').toBe(false);
+        expect(entity.LatestResult?.Success, 'recorded as a failed save').toBe(false);
+    });
+
+    it('skips it for a subclass that did not', async () => {
+        // Nothing to run — the base implementation returns success — so this is about not paying
+        // for an await, and about `DefaultSkipAsyncValidation` still reading `true` for these.
+        const entity = newRecord(PlainEntity);
+        expect(await entity.Save()).toBe(true);
+        expect(asyncRuns).toBe(0);
+    });
+
+    it('finds an override declared further up a multi-level chain', async () => {
+        // Generated class -> app subclass -> server subclass is the normal MJ layering, and the
+        // rule is rarely on the leaf. Checking only the instance's own prototype would miss it.
+        const entity = newRecord(ServerRulesEntity);
+        expect(await entity.Save()).toBe(false);
+        expect(asyncRuns).toBe(1);
+    });
+});
+
+describe('an explicit policy always wins', () => {
+    it('honours a deliberate opt-out even though ValidateAsync is overridden', async () => {
+        // The distinction the fix rests on: `true` returned by an override is a CHOICE, while
+        // `true` inherited from the base is the absence of one. They must not behave alike.
+        const entity = newRecord(DeliberatelyOptedOutEntity);
+        expect(await entity.Save(), 'the save is not refused').toBe(true);
+        expect(asyncRuns, 'the rule did not run').toBe(0);
+    });
+
+    it('honours a deliberate opt-in, exactly as before', async () => {
+        // The 16 classes in this repo that already override both. Their behaviour is unchanged,
+        // which is why this change has no blast radius inside MJ.
+        const entity = newRecord(DeliberatelyOptedInEntity);
+        expect(await entity.Save()).toBe(false);
+        expect(asyncRuns).toBe(1);
+    });
+});
+
+describe('save options outrank everything', () => {
+    it('SkipAsyncValidation: true suppresses an inferred run', async () => {
+        const entity = newRecord(RulesEntity);
+        expect(await entity.Save({ SkipAsyncValidation: true } as never)).toBe(true);
+        expect(asyncRuns).toBe(0);
+    });
+
+    it('SkipAsyncValidation: false forces a run on a class with no override', async () => {
+        // Reaches the base implementation, which succeeds — the point is that the option is still
+        // consulted first and is not shadowed by the inference.
+        const entity = newRecord(PlainEntity);
+        expect(await entity.Save({ SkipAsyncValidation: false } as never)).toBe(true);
+    });
+
+    it('SkipAsyncValidation: false overrides a deliberate opt-out', async () => {
+        const entity = newRecord(DeliberatelyOptedOutEntity);
+        expect(await entity.Save({ SkipAsyncValidation: false } as never)).toBe(false);
+        expect(asyncRuns).toBe(1);
+    });
+});
+
+describe('override detection', () => {
+    // Exercised directly because the inference is only as good as this, and the getter-vs-method
+    // distinction is easy to get wrong: a property descriptor carries an overridden accessor on
+    // `get` and an overridden method on `value`, never both.
+    const isOverridden = (instance: object, member: string): boolean =>
+        (BaseEntity as unknown as { isOverridden(i: object, m: string): boolean }).isOverridden(instance, member);
+
+    it('detects an overridden method', () => {
+        expect(isOverridden(newRecord(RulesEntity), 'ValidateAsync')).toBe(true);
+    });
+
+    it('detects an overridden getter', () => {
+        expect(isOverridden(newRecord(DeliberatelyOptedOutEntity), 'DefaultSkipAsyncValidation')).toBe(true);
+    });
+
+    it('reports no override when a subclass declares neither', () => {
+        const plain = newRecord(PlainEntity);
+        expect(isOverridden(plain, 'ValidateAsync')).toBe(false);
+        expect(isOverridden(plain, 'DefaultSkipAsyncValidation')).toBe(false);
+    });
+
+    it('does not confuse the two members', () => {
+        // RulesEntity overrides the method only. Reporting the getter as overridden here would
+        // make the inference defer to a policy nobody stated — the original bug, reintroduced.
+        const rules = newRecord(RulesEntity);
+        expect(isOverridden(rules, 'ValidateAsync')).toBe(true);
+        expect(isOverridden(rules, 'DefaultSkipAsyncValidation')).toBe(false);
+    });
+
+    it('returns false for a member BaseEntity does not declare', () => {
+        expect(isOverridden(newRecord(PlainEntity), 'NoSuchMember')).toBe(false);
+    });
+
+    it('answers identically on repeat calls, once the answer is cached', () => {
+        // The result is cached per constructor. A cache keyed wrongly — or one that memoised the
+        // first member asked about and returned it for every other — would pass a single-call test
+        // and fail here.
+        const rules = newRecord(RulesEntity);
+        for (let i = 0; i < 3; i++) {
+            expect(isOverridden(rules, 'ValidateAsync')).toBe(true);
+            expect(isOverridden(rules, 'DefaultSkipAsyncValidation')).toBe(false);
+        }
+    });
+
+    it('answers per class, not per instance', () => {
+        // Two classes sharing a cache entry would make whichever ran first decide for both.
+        expect(isOverridden(newRecord(RulesEntity), 'ValidateAsync')).toBe(true);
+        expect(isOverridden(newRecord(PlainEntity), 'ValidateAsync')).toBe(false);
+        expect(isOverridden(newRecord(RulesEntity), 'ValidateAsync')).toBe(true);
+    });
+});

--- a/packages/MJCore/src/generic/baseEntity.ts
+++ b/packages/MJCore/src/generic/baseEntity.ts
@@ -3245,11 +3245,29 @@ export abstract class BaseEntity<T = unknown> {
                         // First run synchronous validation
                         valResult = this.Validate();
 
-                        // Determine if we should run async validation:
-                        // 1. Explicitly set in options, OR
-                        // 2. Use the subclass's default if not specified in options
-                        const skipAsyncValidation = _options.SkipAsyncValidation !== undefined ?
-                            _options.SkipAsyncValidation : this.DefaultSkipAsyncValidation;
+                        // Determine if we should run async validation, in order of authority:
+                        //   1. An explicit SkipAsyncValidation in the options.
+                        //   2. An explicit DefaultSkipAsyncValidation override on the subclass.
+                        //   3. Neither: run it if — and only if — a subclass wrote a ValidateAsync
+                        //      to run. Overriding the method IS the request to run it.
+                        //
+                        // Case 3 is the fix for a silent no-op. The default is `true`, and the base
+                        // ValidateAsync just returns success, so skipping costs a subclass that did
+                        // not override it precisely nothing. The flag's only reachable effect was
+                        // therefore to disable the async rules of subclasses that WROTE async rules
+                        // and never learned a second, separate getter had to be overridden too —
+                        // which the ValidateAsync docstring did not mention while promising the
+                        // method was "automatically called by Save()".
+                        //
+                        // That is how OrderEntityServer.ValidateAsync — holding both the "cannot
+                        // confirm an order with no lines" guard and an entire per-line validation
+                        // loop — was dead on every save in production, and it is the same reasoning
+                        // that already exempts companions below.
+                        const skipAsyncValidation = _options.SkipAsyncValidation !== undefined
+                            ? _options.SkipAsyncValidation
+                            : BaseEntity.isOverridden(this, 'DefaultSkipAsyncValidation')
+                                ? this.DefaultSkipAsyncValidation
+                                : !BaseEntity.isOverridden(this, 'ValidateAsync');
 
                         // If not skipping async validation, run it - even if sync validation failed
                         // This ensures all validation errors (sync and async) are collected
@@ -3941,13 +3959,76 @@ export abstract class BaseEntity<T = unknown> {
     }
     
     /**
+     * Cache for {@link isOverridden}, keyed by the constructor that was asked about. The answer is
+     * a property of the class, not the instance, and a save path should not walk a prototype chain
+     * per record.
+     */
+    private static __overrideCache = new WeakMap<Function, Map<string, boolean>>();
+
+    /**
+     * Whether a subclass replaced `member` somewhere between `instance` and `BaseEntity`.
+     *
+     * @remarks
+     * Used to tell "the author made no choice" apart from "the author chose the default value",
+     * which a getter cannot express on its own — `DefaultSkipAsyncValidation` returning `true` looks
+     * identical whether a subclass deliberately opted out or never knew the flag existed. Comparing
+     * property descriptors against `BaseEntity.prototype` distinguishes them.
+     *
+     * Handles both methods (`value`) and accessors (`get`), so it works for `ValidateAsync` and for
+     * `DefaultSkipAsyncValidation` alike, and finds overrides declared anywhere in a multi-level
+     * chain — a generated class, an app subclass, a server subclass on top of it.
+     *
+     * @param instance - The object whose class chain is inspected.
+     * @param member - The property name to look for.
+     * @returns True when some class below `BaseEntity` declares it.
+     */
+    private static isOverridden(instance: object, member: string): boolean {
+        const ctor = instance?.constructor;
+        if (!ctor) {
+            return false;
+        }
+        let perClass = BaseEntity.__overrideCache.get(ctor);
+        if (perClass?.has(member)) {
+            return perClass.get(member)!;
+        }
+        if (!perClass) {
+            perClass = new Map<string, boolean>();
+            BaseEntity.__overrideCache.set(ctor, perClass);
+        }
+
+        const base = Object.getOwnPropertyDescriptor(BaseEntity.prototype, member);
+        let answer = false;
+        if (base) {
+            let proto = Object.getPrototypeOf(instance);
+            while (proto && proto !== BaseEntity.prototype) {
+                const own = Object.getOwnPropertyDescriptor(proto, member);
+                if (own && (own.get !== base.get || own.value !== base.value)) {
+                    answer = true;
+                    break;
+                }
+                proto = Object.getPrototypeOf(proto);
+            }
+        }
+        perClass.set(member, answer);
+        return answer;
+    }
+
+    /**
      * Default value for whether async validation should be skipped.
-     * Subclasses can override this property to enable async validation by default.
-     * When the options object is passed to Save(), and it includes a value for the 
-     * SkipAsyncValidation property, that value will take precedence over this default.
-     * 
+     *
+     * @remarks
+     * Override this to state a policy explicitly; an explicit override always wins over the
+     * inference described below. When the options object passed to `Save()` includes
+     * `SkipAsyncValidation`, that value takes precedence over both.
+     *
+     * **If no subclass overrides this getter**, the answer is inferred instead: async validation
+     * runs when a subclass has overridden {@link ValidateAsync}, and is skipped when none has.
+     * Reading the literal `true` below as "async validation is off unless you find this getter"
+     * made every hand-written `ValidateAsync` a silent no-op — see the note on that method.
+     *
      * @see {@link Save}
-     * 
+     * @see {@link ValidateAsync}
+     *
      * @protected
      */
     public get DefaultSkipAsyncValidation(): boolean {
@@ -3957,11 +4038,20 @@ export abstract class BaseEntity<T = unknown> {
     /**
      * Asynchronous validation method that can be overridden by subclasses to add custom async validation logic.
      * This method is automatically called by Save() AFTER the synchronous Validate() passes.
-     * 
-     * IMPORTANT: 
+     *
+     * IMPORTANT:
      * 1. This should NEVER be called INSTEAD of the synchronous Validate() method
      * 2. This is meant to be overridden by subclasses that need to perform async validations
      * 3. The base implementation just returns success - no actual validation is performed
+     * 4. Overriding this method is what turns it on. You do NOT also have to override
+     *    {@link DefaultSkipAsyncValidation} — that getter is for stating a policy explicitly, and
+     *    an explicit override of it (either value) still wins. To suppress async validation for one
+     *    call, pass `SkipAsyncValidation: true` in the save options.
+     *
+     * Point 4 used to be the opposite, and it was not discoverable: `DefaultSkipAsyncValidation`
+     * defaults to `true`, so an override written against this docstring alone never ran. It reads
+     * as enforced, reviews as enforced, and was not — the failure mode that let an order confirm
+     * with no lines in production.
      * 
      * Subclasses should override this to add complex validations that require database queries 
      * or other async operations that cannot be performed in the synchronous Validate() method.

--- a/packages/MJCore/src/generic/baseEntity.ts
+++ b/packages/MJCore/src/generic/baseEntity.ts
@@ -1,4 +1,4 @@
-import { MJEventType, MJGlobal, OptionalKeyedSpecialization, uuidv4, UUIDsEqual, WarningManager } from '@memberjunction/global';
+import { IsMemberOverridden, MJEventType, MJGlobal, OptionalKeyedSpecialization, uuidv4, UUIDsEqual, WarningManager } from '@memberjunction/global';
 import { GetDataHooks, PreSaveHook } from './dataHooks';
 import { EntityFieldInfo, EntityInfo, EntityFieldTSType, EntityPermissionType, RecordChange, ValidationErrorInfo, ValidationResult, EntityRelationshipInfo } from './entityInfo';
 import { EntityDeleteOptions, EntitySaveOptions, IEntityDataProvider, IMetadataProvider, IRunQueryProvider, IRunViewProvider, ProviderType, SimpleEmbeddingResult } from './interfaces';
@@ -3265,9 +3265,9 @@ export abstract class BaseEntity<T = unknown> {
                         // that already exempts companions below.
                         const skipAsyncValidation = _options.SkipAsyncValidation !== undefined
                             ? _options.SkipAsyncValidation
-                            : BaseEntity.isOverridden(this, 'DefaultSkipAsyncValidation')
+                            : IsMemberOverridden(this, 'DefaultSkipAsyncValidation', BaseEntity)
                                 ? this.DefaultSkipAsyncValidation
-                                : !BaseEntity.isOverridden(this, 'ValidateAsync');
+                                : !IsMemberOverridden(this, 'ValidateAsync', BaseEntity);
 
                         // If not skipping async validation, run it - even if sync validation failed
                         // This ensures all validation errors (sync and async) are collected
@@ -3958,61 +3958,6 @@ export abstract class BaseEntity<T = unknown> {
         }
     }
     
-    /**
-     * Cache for {@link isOverridden}, keyed by the constructor that was asked about. The answer is
-     * a property of the class, not the instance, and a save path should not walk a prototype chain
-     * per record.
-     */
-    private static __overrideCache = new WeakMap<Function, Map<string, boolean>>();
-
-    /**
-     * Whether a subclass replaced `member` somewhere between `instance` and `BaseEntity`.
-     *
-     * @remarks
-     * Used to tell "the author made no choice" apart from "the author chose the default value",
-     * which a getter cannot express on its own — `DefaultSkipAsyncValidation` returning `true` looks
-     * identical whether a subclass deliberately opted out or never knew the flag existed. Comparing
-     * property descriptors against `BaseEntity.prototype` distinguishes them.
-     *
-     * Handles both methods (`value`) and accessors (`get`), so it works for `ValidateAsync` and for
-     * `DefaultSkipAsyncValidation` alike, and finds overrides declared anywhere in a multi-level
-     * chain — a generated class, an app subclass, a server subclass on top of it.
-     *
-     * @param instance - The object whose class chain is inspected.
-     * @param member - The property name to look for.
-     * @returns True when some class below `BaseEntity` declares it.
-     */
-    private static isOverridden(instance: object, member: string): boolean {
-        const ctor = instance?.constructor;
-        if (!ctor) {
-            return false;
-        }
-        let perClass = BaseEntity.__overrideCache.get(ctor);
-        if (perClass?.has(member)) {
-            return perClass.get(member)!;
-        }
-        if (!perClass) {
-            perClass = new Map<string, boolean>();
-            BaseEntity.__overrideCache.set(ctor, perClass);
-        }
-
-        const base = Object.getOwnPropertyDescriptor(BaseEntity.prototype, member);
-        let answer = false;
-        if (base) {
-            let proto = Object.getPrototypeOf(instance);
-            while (proto && proto !== BaseEntity.prototype) {
-                const own = Object.getOwnPropertyDescriptor(proto, member);
-                if (own && (own.get !== base.get || own.value !== base.value)) {
-                    answer = true;
-                    break;
-                }
-                proto = Object.getPrototypeOf(proto);
-            }
-        }
-        perClass.set(member, answer);
-        return answer;
-    }
-
     /**
      * Default value for whether async validation should be skipped.
      *

--- a/packages/MJGlobal/src/ClassUtils.ts
+++ b/packages/MJGlobal/src/ClassUtils.ts
@@ -235,6 +235,78 @@ export function GetClassName(ClassRef: any): string {
     if (match && match[1]) {
         return match[1];
     }
-    
+
     return 'Anonymous';
+}
+
+/**
+ * Cache for {@link IsMemberOverridden}. Keyed by the subclass constructor, then by the member name
+ * plus the base class, because the answer is a property of that class pair and a hot path should
+ * not walk a prototype chain on every call.
+ */
+const __memberOverrideCache = new WeakMap<Function, Map<string, boolean>>();
+
+/**
+ * Determines whether a subclass has replaced `member` somewhere between `instance` and `BaseClassRef`.
+ *
+ * Distinguishes "the author made no choice" from "the author chose the value that happens to be the
+ * default" — something a getter cannot express on its own. A base class member returning `true`
+ * looks identical whether a subclass deliberately opted in or never knew the member existed, so an
+ * API whose default sits in the *off* position silently disables the subclasses that most wanted it
+ * on. Asking whether the member was overridden recovers the intent.
+ *
+ * Handles methods and accessors alike by comparing property descriptors, and finds an override
+ * declared anywhere in a multi-level chain — a generated class, an application subclass, a
+ * server-side subclass layered on top of it.
+ *
+ * @param instance The object whose class chain is inspected. A non-object returns false.
+ * @param member The property name to look for.
+ * @param BaseClassRef The class declaring the default implementation. A member `BaseClassRef` does
+ *                     not itself declare returns false — there is no baseline to have overridden.
+ * @returns True when some class below `BaseClassRef` declares `member`.
+ */
+export function IsMemberOverridden(instance: any, member: string, BaseClassRef: any): boolean {
+    if (!instance || typeof instance !== 'object' || !member || typeof BaseClassRef !== 'function') {
+        return false;
+    }
+    const ctor = instance.constructor;
+    if (typeof ctor !== 'function') {
+        return false;
+    }
+    // "Overridden relative to a class this object does not descend from" is not a meaningful
+    // question, and answering it by walking anyway is actively wrong: the walk terminates on the
+    // base prototype, so an unrelated chain is traversed to its end and the first same-named member
+    // found anywhere reads as an override.
+    if (!(instance instanceof BaseClassRef)) {
+        return false;
+    }
+
+    // The base class is part of the answer's identity, so two different bases asked about the same
+    // member on the same class cannot collide in the cache.
+    const key = member + ' ' + GetClassName(BaseClassRef);
+    let perClass = __memberOverrideCache.get(ctor);
+    if (perClass && perClass.has(key)) {
+        return perClass.get(key)!;
+    }
+    if (!perClass) {
+        perClass = new Map<string, boolean>();
+        __memberOverrideCache.set(ctor, perClass);
+    }
+
+    const basePrototype = BaseClassRef.prototype;
+    const base = basePrototype ? Object.getOwnPropertyDescriptor(basePrototype, member) : undefined;
+    let answer = false;
+    if (base) {
+        let proto = Object.getPrototypeOf(instance);
+        while (proto && proto !== basePrototype) {
+            const own = Object.getOwnPropertyDescriptor(proto, member);
+            if (own && (own.get !== base.get || own.value !== base.value)) {
+                answer = true;
+                break;
+            }
+            proto = Object.getPrototypeOf(proto);
+        }
+    }
+    perClass.set(key, answer);
+    return answer;
 }

--- a/packages/MJGlobal/src/__tests__/ClassUtils.IsMemberOverridden.test.ts
+++ b/packages/MJGlobal/src/__tests__/ClassUtils.IsMemberOverridden.test.ts
@@ -1,0 +1,153 @@
+/**
+ * `IsMemberOverridden` — telling "made no choice" apart from "chose the default".
+ *
+ * WHY IT EXISTS
+ * A base class member cannot express the difference on its own. `DefaultSkipAsyncValidation`
+ * returning `true` looks identical whether a subclass deliberately opted out or never knew the flag
+ * was there — so an API whose default sits in the *off* position silently disables exactly the
+ * subclasses that most wanted it on. That is how `BaseEntity.ValidateAsync` overrides came to be
+ * dead code on every save: the method was written, documented as automatically called, and skipped.
+ *
+ * The distinction is recoverable only by asking whether the member was replaced, which is what this
+ * does. The cases below are the ones that make it either trustworthy or quietly wrong.
+ */
+import { describe, expect, it } from 'vitest';
+import { IsMemberOverridden } from '../ClassUtils';
+
+class Base {
+    public method(): string {
+        return 'base';
+    }
+    public get flag(): boolean {
+        return true;
+    }
+}
+
+/** Replaces the method only — the shape an application usually writes. */
+class MethodOverride extends Base {
+    public override method(): string {
+        return 'sub';
+    }
+}
+
+/** Replaces the accessor only. */
+class GetterOverride extends Base {
+    public override get flag(): boolean {
+        return false;
+    }
+}
+
+/** Inherits an override rather than declaring one — the generated / app / server layering. */
+class Grandchild extends MethodOverride {}
+
+/** Declares neither. */
+class Passthrough extends Base {}
+
+/** An unrelated hierarchy, for the base-class-identity checks. */
+class OtherBase {
+    public method(): string {
+        return 'other';
+    }
+}
+
+describe('finding an override', () => {
+    it('detects a replaced method', () => {
+        expect(IsMemberOverridden(new MethodOverride(), 'method', Base)).toBe(true);
+    });
+
+    it('detects a replaced accessor', () => {
+        // Descriptors carry an accessor on `get` and a method on `value`, never both — comparing
+        // only one of them makes half the cases silently answer false.
+        expect(IsMemberOverridden(new GetterOverride(), 'flag', Base)).toBe(true);
+    });
+
+    it('finds an override declared further up the chain', () => {
+        // Grandchild declares nothing itself. Inspecting only the instance's own prototype would
+        // report false and defer to a policy nobody stated.
+        expect(IsMemberOverridden(new Grandchild(), 'method', Base)).toBe(true);
+    });
+
+    it('reports false when a subclass declares neither', () => {
+        expect(IsMemberOverridden(new Passthrough(), 'method', Base)).toBe(false);
+        expect(IsMemberOverridden(new Passthrough(), 'flag', Base)).toBe(false);
+    });
+
+    it('reports false for the base class itself', () => {
+        expect(IsMemberOverridden(new Base(), 'method', Base)).toBe(false);
+    });
+
+    it('does not confuse two members of the same class', () => {
+        const m = new MethodOverride();
+        expect(IsMemberOverridden(m, 'method', Base)).toBe(true);
+        expect(IsMemberOverridden(m, 'flag', Base)).toBe(false);
+    });
+});
+
+describe('the base class is part of the question', () => {
+    it('reports false for a member the base does not declare', () => {
+        // No baseline means nothing was overridden. Answering true here would treat any incidental
+        // method on a subclass as an intentional override of something.
+        expect(IsMemberOverridden(new MethodOverride(), 'notDeclaredAnywhere', Base)).toBe(false);
+    });
+
+    it('reports false when the instance does not descend from the base', () => {
+        // The walk stops at the base prototype, which this chain never reaches.
+        expect(IsMemberOverridden(new MethodOverride(), 'method', OtherBase)).toBe(false);
+    });
+
+    it('does not let two base classes share a cached answer', () => {
+        // Cached per (class, member, base). Keyed on member alone, whichever base was asked first
+        // would decide for the other — and the wrong answer here re-enables the original bug.
+        const m = new MethodOverride();
+        expect(IsMemberOverridden(m, 'method', Base)).toBe(true);
+        expect(IsMemberOverridden(m, 'method', OtherBase)).toBe(false);
+        expect(IsMemberOverridden(m, 'method', Base)).toBe(true);
+    });
+});
+
+describe('answers are stable and per class', () => {
+    it('returns the same answer on repeat calls', () => {
+        const m = new MethodOverride();
+        for (let i = 0; i < 3; i++) {
+            expect(IsMemberOverridden(m, 'method', Base)).toBe(true);
+        }
+    });
+
+    it('does not let one class decide for another', () => {
+        expect(IsMemberOverridden(new MethodOverride(), 'method', Base)).toBe(true);
+        expect(IsMemberOverridden(new Passthrough(), 'method', Base)).toBe(false);
+        expect(IsMemberOverridden(new MethodOverride(), 'method', Base)).toBe(true);
+    });
+
+    it('answers per instance of the same class identically', () => {
+        expect(IsMemberOverridden(new MethodOverride(), 'method', Base)).toBe(true);
+        expect(IsMemberOverridden(new MethodOverride(), 'method', Base)).toBe(true);
+    });
+});
+
+describe('bad input is answered, not thrown', () => {
+    it.each([
+        ['null instance', null],
+        ['undefined instance', undefined],
+        ['a primitive', 42],
+        ['a string', 'nope'],
+    ])('returns false for %s', (_label, value) => {
+        // Callers reach this on a hot path with whatever they were handed; a throw here would turn
+        // a policy question into an outage.
+        expect(IsMemberOverridden(value as never, 'method', Base)).toBe(false);
+    });
+
+    it('returns false for an empty member name', () => {
+        expect(IsMemberOverridden(new MethodOverride(), '', Base)).toBe(false);
+    });
+
+    it('returns false when the base class is not a constructor', () => {
+        expect(IsMemberOverridden(new MethodOverride(), 'method', null as never)).toBe(false);
+        expect(IsMemberOverridden(new MethodOverride(), 'method', {} as never)).toBe(false);
+    });
+
+    it('returns false for an object with a null prototype', () => {
+        // Object.create(null) has no constructor, so the cache key cannot be formed.
+        expect(IsMemberOverridden(Object.create(null), 'method', Base)).toBe(false);
+    });
+});


### PR DESCRIPTION
## The bug

`BaseEntity.ValidateAsync` documents itself as *"automatically called by `Save()` AFTER the synchronous `Validate()` passes."* It was not.

`Save()` reached `ValidateAsync` only if the subclass **also** overrode `DefaultSkipAsyncValidation` — a separate getter the `ValidateAsync` docstring never mentioned, and which defaults to `true`. An override written against the documentation alone silently never ran. It reads as enforced, it reviews as enforced, and it is not.

```ts
// before
const skipAsyncValidation = _options.SkipAsyncValidation !== undefined ?
    _options.SkipAsyncValidation : this.DefaultSkipAsyncValidation;  // => true, for anyone who never found the getter
```

## Why the default cannot be justified on cost

The base `ValidateAsync` returns success immediately. Skipping it saves a class that did not override it essentially nothing — there is no query, no I/O, no work to avoid.

So the flag's only *reachable* effect was to disable the async rules of exactly those classes that had bothered to **write** async rules. The one thing it could do was the one thing nobody wanted it to do.

## Precedent already in this file

This is not a hypothetical failure. `OrderEntityServer.ValidateAsync` — holding both the "cannot confirm an order with no lines" guard and an entire per-line validation loop — was dead on every save in production for exactly this reason.

That defect is **already cited in `baseEntity.ts`**, one branch below the code changed here, as the justification for companion validation ignoring this same flag. This PR applies the same reasoning to the entity's own rules, which is where the defect actually originated.

## The fix

Overriding `ValidateAsync` is now what turns it on. Precedence, in order of authority:

1. **`EntitySaveOptions.SkipAsyncValidation`**, when set, wins outright. Per-call control is unchanged.
2. **An explicit `DefaultSkipAsyncValidation` override** wins next — **either value**. Stating a policy still beats inferring one, so a class that deliberately opts out keeps opting out.
3. **Only when no policy is stated at all** is the answer inferred: run `ValidateAsync` if a subclass overrode it, skip it if none did.

Rule 2 is what makes rule 3 safe, and it requires telling *"chose `true`"* apart from *"never made a choice"* — a distinction a getter cannot express, since both return the identical `true`. The two are separated by comparing property descriptors against `BaseEntity.prototype`:

- cached per class in a `WeakMap` (the answer is a property of the class, not the instance — a save path should not walk a prototype chain per record);
- handling **both accessors (`get`) and methods (`value`)**, so the same helper serves `DefaultSkipAsyncValidation` and `ValidateAsync` alike;
- walking the whole chain, so an override declared **anywhere in a multi-level hierarchy** counts — generated class, app subclass, server subclass on top of it.

The `ValidateAsync` and `DefaultSkipAsyncValidation` docstrings are also corrected. They described the old behaviour, and were how the trap was set.

## Blast radius — measured, not assumed

Every class in the repo overriding `ValidateAsync` was enumerated and checked:

| | |
|---|---|
| Classes overriding `ValidateAsync` | **17** |
| Already override `DefaultSkipAsyncValidation` → take rule 2, **behaviour unchanged** | **16** |
| Remaining | **1** — `RelatedRecordCollection`, whose `ValidateAsync(result)` is `EntityCompanion`'s method in a different hierarchy entirely |

**CodeGen never emits `ValidateAsync`**, so no generated class trips the inference. This was the check that mattered most: had CodeGen emitted even a harmless pass-through override, rule 3 would have switched async validation on **globally**, across every generated entity in every deployment. It does not, and the inference stays confined to hand-written overrides.

Net effect inside this repo: **zero behaviour change.**

## Testing

- **15 new tests** in `packages/MJCore/src/__tests__/baseEntity.validateAsync.test.ts`, driving the real `Save()` path rather than calling the resolution logic directly — covering each precedence rule, explicit `true` vs. never-set, accessor and method overrides, and multi-level chains.
- **Full MJCore suite green: 119 files, 1823 tests.**

## ⚠️ Risk for downstream adopters

**This is a real behaviour change outside this repo, and it is the intended one.**

A `ValidateAsync` that has been quietly dead in a downstream application **will start running** — and can start **refusing saves it was always written to refuse**. That is the point of the fix: those rules were authored to be enforced. But an application that has unknowingly been saving records past its own async rules will see saves begin to fail after upgrading, and the failures will look new even though the rules are old.

Recommended before adopting: grep your codebase for `ValidateAsync` overrides and confirm each one is a rule you still want enforced.

Escape hatches, if any case should stay off:

- pass **`SkipAsyncValidation: true`** in the save options (per call), or
- override **`DefaultSkipAsyncValidation`** to return `true` (per class) — rule 2 guarantees an explicit override still wins.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
