### PR TITLE
fix(workflows): stop the canvas re-zooming on every edit; keep node positions

### DIFF
--- a/packages/Angular/Generic/task-graph-editor/src/__tests__/task-graph-canvas-adapter.test.ts
+++ b/packages/Angular/Generic/task-graph-editor/src/__tests__/task-graph-canvas-adapter.test.ts
@@ -54,6 +54,37 @@ const diamond = (): TaskGraphSpec => spec({
     ],
 });
 
+describe('SpecToNodes — geometry the spec cannot hold', () => {
+    // TaskGraphSpec is an execution contract with no layout field. Before this, every projection
+    // reset each node to the origin, so the component had to re-run auto-layout after EVERY edit —
+    // and auto-layout ends in zoom-to-fit, which is why adding a step yanked the viewport. These
+    // tests pin the carrier that makes arranging-once possible.
+    it('honours a caller-supplied position', () => {
+        const positions = new Map([['a', { X: 120, Y: 40 }]]);
+        const node = SpecToNodes(spec(), undefined, positions).find((n) => n.ID === 'a')!;
+        expect(node.Position).toEqual({ X: 120, Y: 40 });
+    });
+
+    it('falls back to the origin for a task it has never seen', () => {
+        const positions = new Map([['a', { X: 120, Y: 40 }]]);
+        const node = SpecToNodes(spec(), undefined, positions).find((n) => n.ID === 'b')!;
+        expect(node.Position).toEqual({ X: 0, Y: 0 });
+    });
+
+    it('copies the position rather than aliasing the caller’s object', () => {
+        // The canvas mutates node.Position in place during a drag; sharing the reference would let
+        // that write back into the map and quietly defeat the next projection's comparison.
+        const shared = { X: 5, Y: 5 };
+        const node = SpecToNodes(spec(), undefined, new Map([['a', shared]])).find((n) => n.ID === 'a')!;
+        node.Position.X = 999;
+        expect(shared.X).toBe(5);
+    });
+
+    it('still projects at the origin when no positions are supplied', () => {
+        expect(SpecToNodes(spec()).every((n) => n.Position.X === 0 && n.Position.Y === 0)).toBe(true);
+    });
+});
+
 describe('SpecToNodes', () => {
     it('projects one node per task', () => {
         expect(SpecToNodes(spec())).toHaveLength(2);

--- a/packages/Angular/Generic/task-graph-editor/src/lib/task-graph-canvas-adapter.ts
+++ b/packages/Angular/Generic/task-graph-editor/src/lib/task-graph-canvas-adapter.ts
@@ -21,7 +21,7 @@ import {
     type TaskGraphSpecNode,
     type TaskGraphDependency,
 } from '@memberjunction/ai-core-plus';
-import type { FlowConnection, FlowNode, FlowNodeStatus, FlowNodeTypeConfig } from '@memberjunction/ng-flow-editor';
+import type { FlowConnection, FlowNode, FlowNodeStatus, FlowNodeTypeConfig, FlowPosition } from '@memberjunction/ng-flow-editor';
 
 /**
  * The kinds of step a `TaskGraphSpec` can express.
@@ -200,11 +200,25 @@ function edgeId(fromTempId: string, toTempId: string): string {
  * geometry precisely because a task graph is a *logical* structure. An agent that emitted one never
  * had an opinion about where the boxes go.
  */
-export function SpecToNodes(spec: TaskGraphSpec, runtime?: TaskGraphRuntimeStatus): FlowNode[] {
+/**
+ * Projects the spec onto canvas nodes.
+ *
+ * `positions` carries geometry the spec cannot hold. `TaskGraphSpec` is an execution contract with
+ * no layout field, so without a caller-held map every re-projection would return every node to the
+ * origin — which is what previously forced a full re-arrange (and a viewport re-zoom) after every
+ * single edit. Unknown ids fall back to the origin, which is also the correct starting state for a
+ * graph that has never been laid out.
+ */
+export function SpecToNodes(
+    spec: TaskGraphSpec,
+    runtime?: TaskGraphRuntimeStatus,
+    positions?: ReadonlyMap<string, FlowPosition>,
+): FlowNode[] {
     const entryIds = new Set(GetEntryTempIds(spec));
 
     return (spec.tasks ?? []).map((task) => {
         const type = GetTaskNodeType(task);
+        const known = positions?.get(task.tempId);
         return {
             ID: task.tempId,
             Type: type,
@@ -214,7 +228,7 @@ export function SpecToNodes(spec: TaskGraphSpec, runtime?: TaskGraphRuntimeStatu
             Status: RuntimeStateToNodeStatus(runtime?.[task.tempId]),
             StatusMessage: task.description,
             IsStartNode: entryIds.has(task.tempId),
-            Position: { X: 0, Y: 0 },
+            Position: known ? { ...known } : { X: 0, Y: 0 },
             Ports: [
                 { ID: 'in', Direction: 'input', Side: 'top', Multiple: true },
                 { ID: 'out', Direction: 'output', Side: 'bottom', Multiple: true },

--- a/packages/Angular/Generic/task-graph-editor/src/lib/task-graph-editor.component.html
+++ b/packages/Angular/Generic/task-graph-editor/src/lib/task-graph-editor.component.html
@@ -40,6 +40,8 @@
         (NodeSelected)="OnNodeSelected($event)"
         (NodeAdded)="OnNodeAdded($event)"
         (NodeRemoved)="OnNodeRemoved($event)"
+        (NodesChanged)="OnNodesChanged($event)"
+        (NodeMoved)="OnNodeMoved($event)"
         (ConnectionCreated)="OnConnectionCreated($event)"
         (ConnectionRemoved)="OnConnectionRemoved($event)">
       </mj-flow-editor>

--- a/packages/Angular/Generic/task-graph-editor/src/lib/task-graph-editor.component.ts
+++ b/packages/Angular/Generic/task-graph-editor/src/lib/task-graph-editor.component.ts
@@ -39,7 +39,9 @@ import type {
     FlowLayoutDirection,
     FlowNode,
     FlowNodeAddedEvent,
+    FlowNodeMovedEvent,
     FlowNodeTypeConfig,
+    FlowPosition,
 } from '@memberjunction/ng-flow-editor';
 import {
     AddDependency,
@@ -356,7 +358,16 @@ export class TaskGraphEditorComponent extends BaseAngularComponent implements On
                 actionName: this.AvailableActionNames[0],
             }),
         );
-        if (added) this.selectTask(added);
+        if (!added) return;
+
+        // Remember where the canvas put it BEFORE anything re-projects. The spec has no geometry
+        // field, so this map is the only record that the author dropped (or clicked) it here — and
+        // without it the node would snap back to the origin on the very next edit.
+        this.knownPositions.set(added.tempId, { ...event.Node.Position });
+        // A graph that has received a hand-placed node is laid out, by definition. Marking it here
+        // stops the one-time Dagre pass from firing later and discarding that placement.
+        this.hasLaidOut = true;
+        this.selectTask(added);
     }
 
     /** Applies a properties-panel edit through the same vetoable path a canvas edit takes. */
@@ -406,38 +417,63 @@ export class TaskGraphEditorComponent extends BaseAngularComponent implements On
             this.Connections = [];
             this.ValidationErrors = [];
             this.IsValid = true;
-            this.laidOutTopology = '';
+            this.hasLaidOut = false;
+            this.knownPositions.clear();
             return;
         }
-        this.Nodes = SpecToNodes(this.currentSpec, this.currentRuntime ?? undefined);
+        this.Nodes = SpecToNodes(this.currentSpec, this.currentRuntime ?? undefined, this.knownPositions);
         this.Connections = SpecToConnections(this.currentSpec);
         this.Validate();
-        this.arrangeIfTopologyChanged();
+        this.arrangeIfNeverLaidOut();
     }
 
     /**
-     * Lays the graph out whenever its shape changes.
+     * Lays the graph out ONCE — when it arrives with no geometry of its own.
      *
-     * A `TaskGraphSpec` carries no geometry — every projected node starts at the origin — so without
-     * this every step is stacked on the last one and a two-step graph looks like a one-step graph
-     * with a rendering glitch. Layout is Dagre's, inside the canvas, run only when the *topology*
-     * changes: a rename or an edge-condition edit re-projects too, and re-arranging on those would
-     * make boxes jump under the author's cursor mid-edit.
+     * A `TaskGraphSpec` carries no positions, so a spec opened for the first time projects with
+     * every node at the origin and needs Dagre to make it readable. After that the author's layout
+     * is the layout: `knownPositions` carries it across re-projections, and re-arranging again would
+     * throw away the arrangement they just made.
+     *
+     * It must also not run on every edit, because `AutoArrange` ends in `ZoomToFit` — so arranging
+     * per change meant the viewport snapped to fit after every added step and every drawn
+     * connection, which on a one-node graph zooms to maximum. That is the behaviour being fixed
+     * here; the rule mirrors the Flow Agent editor's (`flow-agent-editor.component.ts`), which has
+     * always arranged only when every node sits at the origin.
      */
-    private arrangeIfTopologyChanged(): void {
-        const topology = this.Nodes.map((n) => n.ID).join(',') + '|' + this.Connections.map((c) => c.ID).join(',');
-        if (topology === this.laidOutTopology) return;
-        this.laidOutTopology = topology;
+    private arrangeIfNeverLaidOut(): void {
         if (this.Nodes.length === 0) return;
+        if (this.hasLaidOut) return;
 
-        // Deferred one turn: the canvas has to render the new node before Dagre can measure and
-        // place it. Guarded on the topology it was scheduled for, so a burst of edits lays out once,
-        // and cleared on destroy so a pending layout cannot run against a torn-down view.
+        // Nothing to rescue a layout from: a spec whose nodes all sit at the origin has never been
+        // arranged. One node at the origin is the legitimate starting case too.
+        const allAtOrigin = this.Nodes.every((n) => n.Position.X === 0 && n.Position.Y === 0);
+        if (!allAtOrigin) { this.hasLaidOut = true; return; }
+
+        this.hasLaidOut = true;
+        // Deferred one turn: the canvas has to render the nodes before Dagre can measure them.
+        // Cleared on destroy so a pending layout cannot run against a torn-down view.
         if (this.pendingLayout !== null) clearTimeout(this.pendingLayout);
         this.pendingLayout = setTimeout(() => {
             this.pendingLayout = null;
-            if (this.laidOutTopology === topology) this.canvas?.AutoArrange(this.AutoLayoutDirection);
+            this.canvas?.AutoArrange(this.AutoLayoutDirection);
         });
+    }
+
+    /**
+     * The canvas is the authority on geometry, so remember what it reports.
+     *
+     * Without this the spec — which has no geometry field — is the only survivor of a re-projection,
+     * and every edit silently moved every node back to the origin. That is what forced a re-arrange
+     * (and therefore a re-zoom) on each change.
+     */
+    public OnNodesChanged(nodes: FlowNode[]): void {
+        for (const n of nodes) this.knownPositions.set(n.ID, { ...n.Position });
+    }
+
+    /** A single node was dragged. Same authority, narrower event. */
+    public OnNodeMoved(event: FlowNodeMovedEvent): void {
+        this.knownPositions.set(event.NodeID, { ...event.NewPosition });
     }
 
     public ngOnDestroy(): void {
@@ -448,6 +484,17 @@ export class TaskGraphEditorComponent extends BaseAngularComponent implements On
     }
 
     /** The topology the current layout was computed for; '' when nothing has been laid out. */
-    private laidOutTopology: string = '';
+    /**
+     * Node geometry, which the spec cannot hold.
+     *
+     * `TaskGraphSpec` is an execution contract with no layout field, so a re-projection would
+     * otherwise return every node to the origin. Keyed by `tempId`; written from the canvas
+     * (`NodesChanged` / `NodeMoved`) and from the drop position of a newly added node, and read back
+     * by `SpecToNodes` on every projection.
+     */
+    private readonly knownPositions = new Map<string, FlowPosition>();
+
+    /** Whether the one-time Dagre pass has run (or been made unnecessary by a hand-placed node). */
+    private hasLaidOut: boolean = false;
     private pendingLayout: ReturnType<typeof setTimeout> | null = null;
 }


### PR DESCRIPTION
Two of the three reported canvas problems trace to **one cause**, and it's a structural one.

## Root cause

`TaskGraphSpec` is an execution contract with **no layout field**. So `SpecToNodes` reset every node to `{0,0}` on every projection, and the component compensated by re-running auto-layout whenever the topology changed — and `AutoArrange` ends in:

```ts
setTimeout(() => this.ZoomToFit(), 100);
```

So **every added step and every drawn connection** re-arranged the graph and snapped the viewport to fit. On a one-node graph, "fit" is maximum zoom — the *"it super zooms into the step right away"* report. It also meant an author's own arrangement was thrown away by their next edit.

**The Flow Agent editor has never had this problem.** It arranges only when *every* node sits at the origin (`flow-agent-editor.component.ts:244-245`) and stores what the canvas hands back via `NodesChanged`/`ConnectionsChanged`. This adopts that rule rather than inventing a second one.

## Changes

- `SpecToNodes` takes an optional positions map. Unknown ids still fall back to the origin — the correct first-open state. Positions are **copied, not aliased**: the canvas mutates `node.Position` in place while dragging, so sharing the reference would write back into the map and defeat the next projection's comparison.
- The component owns that map — seeded from `NodesChanged`, `NodeMoved`, and the drop position of a newly added node, cleared when the spec is replaced.
- **Auto-layout runs once**, only for a graph that arrives with no geometry. Adding a node by hand marks the graph as laid out, so the deferred Dagre pass can't fire later and discard that placement.

## On the "can't connect steps" report

Not a separate defect as far as I can tell. Nodes piled up at the origin between projections, and the viewport sat at fit-one-node zoom — so the second step's ports were routinely off-screen. The connection plumbing itself is correct: `SpecToConnections` projects `dependsOn` with `out`→`in` ports, `OnConnectionCreated` → `AddDependency` commits, and both are bound in the template. **Worth re-testing specifically.**

## Verification

| Check | Result |
|---|---|
| `ng-task-graph-editor` tests | **138 pass** (4 new) |
| `ng-task-graph-editor` build | exit 0 |
| `ng-dashboards` build | exit 0 |
| `npm run check:ui` | 0 violations |
| `mj standards check` | all adopted standards pass |

The four new tests pin the geometry carrier: honoured position, origin fallback, copy-not-alias, and no-positions-supplied.

## Two honest limitations

**Not verified in a live browser.** The cached Playwright auth profile has an expired JWT (`JWT_EXPIRED`) and MSAL needs a human, so this is reasoned from source and covered by unit tests — not observed.

**The vanishing-palette-entry report is NOT fixed here.** The palette renders unconditionally from a static readonly array that nothing mutates, entries are tracked by object identity, and nothing filters by usage. I could not reproduce or explain it from the source, and I'd rather say so than ship a speculative change. It needs one more detail to pin down (whole palette vs. one entry; does a reload restore it).

🤖 Generated with [Claude Code](https://claude.com/claude-code)