### PR TITLE
fix(docs-site): version-true pills and a visible version switcher on every line

### DIFF
--- a/docs-site/src/components/SiteTitle.astro
+++ b/docs-site/src/components/SiteTitle.astro
@@ -3,14 +3,13 @@
  * Starlight SiteTitle override: renders the default logo link, then appends the
  * documented-line version pill from the landing mockup.
  *
- * The pill tracks the LINE the site documents, not the repo version in
- * package.json — docs.memberjunction.org builds from `lts/5` (see the pinned
- * ref in .github/workflows/docs.yml), so this stays "v5.x" until a new line
- * certifies and that workflow ref moves.
+ * The pill tracks the LINE this build documents. Every deployed version gets
+ * its own build with DOCS_VERSION set (see .github/workflows/docs.yml) and this
+ * tooling overlaid from next, so the value MUST come from the environment —
+ * a literal here shows the wrong line on every other version's site.
  */
 import Default from '@astrojs/starlight/components/SiteTitle.astro';
-
-const documentedLine = 'v5.x';
+import { documentedLine } from '../lib/documented-line.mjs';
 ---
 
 <Default><slot /></Default>

--- a/docs-site/src/content/docs/index.mdx
+++ b/docs-site/src/content/docs/index.mdx
@@ -7,12 +7,13 @@ editUrl: false
 
 import InstallBlock from '../../components/InstallBlock.astro';
 import LandingFooter from '../../components/LandingFooter.astro';
+import { documentedLine } from '../../lib/documented-line.mjs';
 
 <div class="mjd-landing">
 
 <section class="mjd-hero">
   <div class="mjd-pills">
-    <span class="mjd-pill mjd-pill--accent">v5.x</span>
+    <span class="mjd-pill mjd-pill--accent">{documentedLine}</span>
     <span class="mjd-pill">Open Source</span>
     <span class="mjd-pill">ISC License</span>
   </div>

--- a/docs-site/src/lib/documented-line.mjs
+++ b/docs-site/src/lib/documented-line.mjs
@@ -1,0 +1,24 @@
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+
+/**
+ * The release line this build documents, as the "v6.x" pill text used in the
+ * site header and the landing hero.
+ *
+ * Versioned deploys set DOCS_VERSION per line (one build per line — see
+ * .github/workflows/docs.yml), and that always wins. Local previews have no
+ * env, so the line is derived from @memberjunction/core's version on the
+ * checked-out ref — the product version, which the workspace root's
+ * placeholder package.json is not.
+ */
+function repoLine() {
+  const corePkg = fileURLToPath(new URL('../../../packages/MJCore/package.json', import.meta.url));
+  const version = JSON.parse(readFileSync(corePkg, 'utf8')).version ?? '';
+  const major = version.split('.')[0];
+  if (!/^\d+$/.test(major)) {
+    throw new Error(`Cannot derive the documented line from @memberjunction/core version "${version}" and DOCS_VERSION is unset`);
+  }
+  return `v${major}`;
+}
+
+export const documentedLine = `${process.env.DOCS_VERSION || repoLine()}.x`;

--- a/docs-site/src/styles/custom.css
+++ b/docs-site/src/styles/custom.css
@@ -166,17 +166,26 @@
   color: var(--mjd-header-ink-dim);
 }
 
+/*
+ * mj-version-select is the documentation-version switcher (ThemeSelect
+ * override) — same Starlight <Select> markup as the theme picker, so it needs
+ * the same navy-contrast treatment or it renders in the default header colors
+ * and disappears against the navy bar.
+ */
 .header .social-icons a,
-.header starlight-theme-select label {
+.header starlight-theme-select label,
+.header mj-version-select label {
   color: var(--mjd-header-ink);
 }
 
 .header .social-icons a:hover,
-.header starlight-theme-select label:hover {
+.header starlight-theme-select label:hover,
+.header mj-version-select label:hover {
   color: #ffffff;
 }
 
-.header starlight-theme-select select {
+.header starlight-theme-select select,
+.header mj-version-select select {
   color: var(--mjd-header-ink);
   background: transparent;
 }


### PR DESCRIPTION
## What

The landing redesign (#3495) collided with the versioned-site work that landed a day earlier (#3509 line). Three defects, all visible on https://docs.memberjunction.org/v6/ right now:

1. **Header pill says v5.x on the v6 site.** `SiteTitle.astro` hardcoded the line, with a comment written against the old single-version workflow ("builds from lts/5"). The versioned deploy overlays docs-site tooling from next onto EVERY line's build, so a literal there is wrong on every other line's site.
2. **Landing hero pill** hardcoded the same `v5.x`.
3. **The version switcher looked missing — it isn't.** `mj-version-select` (the ThemeSelect override from the versioned-site work) is present in the live markup, but the redesign's navy-header CSS only restyled `starlight-theme-select`, leaving the switcher in Starlight's default header colors — invisible against the navy bar.

## How

- New `docs-site/src/lib/documented-line.mjs`: the pill text comes from `DOCS_VERSION` (docs.yml already passes it per line), falling back to `@memberjunction/core`'s major for local previews. The workspace root package.json is a placeholder (1.0.10) and cannot be the source.
- Both pills consume the shared value.
- The navy-contrast CSS rules now cover `mj-version-select` alongside `starlight-theme-select`.

## Verification

- docs-site unit tests: 24/24 pass.
- Full build with the v6 deploy env (`DOCS_VERSION=v6`, `DOCS_VERSIONS` with both lines): header pill and hero pill render `v6.x`; the switcher renders on every page with both "v5 (LTS)" and "v6 (Edge)" options.
- Local no-env build derives `v6.x` from MJCore on a next checkout (era-true on lts/5 too).

## For reviewers

- Deploy is automatic: docs.yml triggers on `docs-site/**` pushes to next and rebuilds all lines with this tooling, so merging fixes /v5 and /v6 in one shot.
- No changeset: docs-site is not a published package.
- The switcher's *visibility* fix is CSS-only; if the styling reads wrong against the mockup, that's the piece to iterate on — the env plumbing is independent of it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MYWbAFjiCkR8LWJK3VXWX3