### PR TITLE
fix(codegen): schema-named bucket apps are hidden from new users by d…

### DIFF
--- a/.changeset/codegen-bucket-app-hidden-by-default.md
+++ b/.changeset/codegen-bucket-app-hidden-by-default.md
@@ -1,0 +1,11 @@
+---
+"@memberjunction/codegen-lib": patch
+---
+
+Auto-created schema "bucket" Applications are now hidden from new users. `createNewApplication`'s
+INSERT omitted `DefaultForNewUser`, so the DB default of `1` won — every schema-named bucket app
+(`__mj_MySchema`, "Generated for schema") landed visible in each new user's app switcher, while a
+UI app's human-authored metadata Application often ships hidden. The bucket exists to carry entity
+links, role grants, and `SchemaAutoAddNewEntities`; it is plumbing, not a product, and is now
+emitted with `DefaultForNewUser = 0`. Affects newly emitted captures only — existing captured
+baselines keep their old INSERT until recaptured.

--- a/packages/CodeGenLib/src/Database/manage-metadata.ts
+++ b/packages/CodeGenLib/src/Database/manage-metadata.ts
@@ -5085,8 +5085,12 @@ export class ManageMetadataBase {
          // idempotent. drop-schema clears an app's ApplicationEntity/EntityPermission/Entity rows but NOT
          // its Application row, so replaying this block would otherwise collide on the Application PK.
          const appCheckQuery = `SELECT 1 FROM ${this.qs(mj_core_schema(), 'Application')} WHERE ${this.qi('ID')} = '${appID}'`;
-         const appInsert = `INSERT INTO ${this.qs(mj_core_schema(), 'Application')} (ID, Name, Description, SchemaAutoAddNewEntities, Path, AutoUpdatePath)
-                       VALUES ('${appID}', '${appName}', 'Generated for schema', '${schemaName}', '${path}', ${this.dialect.BooleanLiteral(true)})`;
+         // Schema-named bucket apps are plumbing (entity links, role grants, SchemaAutoAddNewEntities),
+         // not products — hide them from new users. Application.DefaultForNewUser defaults to 1 in the
+         // DB, so omitting the column here is what put raw '__mj_*'-named apps in every new user's
+         // app switcher while the human-authored metadata app stayed hidden.
+         const appInsert = `INSERT INTO ${this.qs(mj_core_schema(), 'Application')} (ID, Name, Description, SchemaAutoAddNewEntities, Path, AutoUpdatePath, DefaultForNewUser)
+                       VALUES ('${appID}', '${appName}', 'Generated for schema', '${schemaName}', '${path}', ${this.dialect.BooleanLiteral(true)}, ${this.dialect.BooleanLiteral(false)})`;
          const sSQL = this.conditionalInsert(appCheckQuery, appInsert);
          await this.LogSQLAndExecute(pool, sSQL, `SQL generated to create new application ${appName}`);
          LogStatus(`Created new application ${appName} with Path: ${path}`);


### PR DESCRIPTION
…efault

Application.DefaultForNewUser defaults to 1 in the DB and createNewApplication's INSERT omitted the column, so every auto-created schema bucket app (Name = '__mj_MySchema', Description = 'Generated for schema') landed visible in each new user's app switcher — while UI apps' human-authored metadata Application often ships hidden. The bucket exists to carry entity links, role grants, and SchemaAutoAddNewEntities; it is plumbing, not a product.

Repro (before): fresh DB → codegen over a new schema → the raw schema-named app appears in a new user's switcher. After: same flow, bucket app created with DefaultForNewUser = 0 and absent from the switcher. Affects newly emitted captures only; existing captured baselines keep their old INSERT until recaptured.

Found while rebuilding bizapps-accounting's baseline; discussion: https://github.com/MemberJunction/MJ/discussions/3683#discussioncomment-17954934