### PR TITLE
fix: UUIDsEqual at the six raw UUID comparisons failing MJGlobal's sweep

### DIFF
--- a/packages/AI/CorePlus/src/task-graph/flow-graph-compiler.ts
+++ b/packages/AI/CorePlus/src/task-graph/flow-graph-compiler.ts
@@ -17,6 +17,7 @@
  * @module @memberjunction/ai-core-plus
  */
 import type { MJAIAgentStepEntity } from '@memberjunction/core-entities';
+import { UUIDsEqual } from '@memberjunction/global';
 import { DetectCycle, type TaskGraphEdge, type TaskGraphNode } from './graph-algorithms';
 import {
     TaskNode,
@@ -171,7 +172,7 @@ export function CompileFlowToTaskGraph(
     }));
     const cycle = DetectCycle(cycleNodes, cycleEdges);
     if (cycle.hasCycle) {
-        const names = cycle.path.map((id) => compiledSteps.find((s) => s.ID === id)?.Name ?? id);
+        const names = cycle.path.map((id) => compiledSteps.find((s) => UUIDsEqual(s.ID, id))?.Name ?? id);
         errors.push({
             Code: 'LoopDetected',
             Message: `These steps form a loop: ${names.join(' → ')}. A workflow runs each step once, so express repetition with a ForEach or While step instead.`,

--- a/packages/MJServer/src/services/TaskGraphActionRunner.ts
+++ b/packages/MJServer/src/services/TaskGraphActionRunner.ts
@@ -12,13 +12,14 @@
 import { ActionEngineServer } from '@memberjunction/actions';
 import { ActionParam } from '@memberjunction/actions-base';
 import { LogError } from '@memberjunction/core';
+import { UUIDsEqual } from '@memberjunction/global';
 import type { TaskActionRunner, TaskActionRunParams, TaskActionRunResult } from '@memberjunction/task-graph';
 
 export class TaskGraphActionRunner implements TaskActionRunner {
     public async RunActionForTask(params: TaskActionRunParams): Promise<TaskActionRunResult> {
         try {
             await ActionEngineServer.Instance.Config(false, params.ContextUser);
-            const action = ActionEngineServer.Instance.Actions.find((a) => a.ID === params.ActionID);
+            const action = ActionEngineServer.Instance.Actions.find((a) => UUIDsEqual(a.ID, params.ActionID));
             if (!action) {
                 return { Success: false, ErrorMessage: `Action ${params.ActionID} is not in the engine's metadata.` };
             }

--- a/packages/TestingFramework/integration-test-suite/src/checks/entity-actions.checks.ts
+++ b/packages/TestingFramework/integration-test-suite/src/checks/entity-actions.checks.ts
@@ -19,6 +19,7 @@
  * @module @memberjunction/integration-test-suite
  */
 import { RunView, type BaseEntity } from '@memberjunction/core';
+import { NormalizeUUID, UUIDsEqual } from '@memberjunction/global';
 import {
     MJActionEntity,
     MJActionFilterEntity,
@@ -384,7 +385,7 @@ export const EntityActionChecks: NamedCheck[] = [
             // the binding points at it, and dropping the junction row too would remove the binding
             // being tested rather than break it.
             const filters = ActionEngineServer.Instance.ActionFilters;
-            const at = filters.findIndex((f) => f.ID === Filter.ID);
+            const at = filters.findIndex((f) => UUIDsEqual(f.ID, Filter.ID));
             Assert(at >= 0, 'the filter fixture must be visible to the engine before it is removed');
             filters.splice(at, 1);
             void link;
@@ -453,13 +454,13 @@ export const EntityActionChecks: NamedCheck[] = [
 
                 // Filtered to THIS binding: every Durable binding an earlier check created is still
                 // Active on the same entity, so a shared submitter sees their submissions too.
-                const mine = () => submitter.Requests.filter((r) => r.EntityActionID === binding.ID);
+                const mine = () => submitter.Requests.filter((r) => UUIDsEqual(r.EntityActionID, binding.ID));
                 await waitFor(() => mine().length > 0, 'the durable submission');
                 const request = mine()[0];
                 AssertEqual(request.EntityActionID, binding.ID, 'the request must name the binding that fired');
                 AssertEqual(request.ActionID, action.ID, 'the request must name the action to run');
                 AssertEqual(request.InvocationType, 'AfterUpdate', 'the request must name the event that fired it');
-                Assert(request.RecordID.includes(list.ID), 'the request must carry the record that changed');
+                Assert(NormalizeUUID(request.RecordID).includes(NormalizeUUID(list.ID)), 'the request must carry the record that changed');
                 Assert(!!request.EntityName, 'the request must name the entity, for a readable task');
                 Assert(typeof request.RedactedParams === 'object', 'params must arrive as a plain JSON-safe object');
 
@@ -502,7 +503,7 @@ export const EntityActionChecks: NamedCheck[] = [
 
                 await waitFor(async () => (await executionCountFor(ctx, binding.ID)) > before,
                     'the inline fallback to run the action after a failed submission');
-                AssertEqual(submitter.Requests.filter((r) => r.EntityActionID === binding.ID).length, 1,
+                AssertEqual(submitter.Requests.filter((r) => UUIDsEqual(r.EntityActionID, binding.ID)).length, 1,
                     'submission must have been attempted exactly once for THIS binding');
             } finally {
                 DurableEntityActionRegistry.Instance.Clear();


### PR DESCRIPTION
## What

next's Unit Tests backstop has been red since Friday on MJGlobal's UUID-compliance sweep. Six raw comparisons, all from recent task-graph work (the five I listed on #3670, plus one that arrived with the weekend merges):

| Site | Fix |
|---|---|
| `MJServer/src/services/TaskGraphActionRunner.ts:21` | `UUIDsEqual(a.ID, params.ActionID)` |
| `entity-actions.checks.ts:387` (filter removal index) | `UUIDsEqual(f.ID, Filter.ID)` |
| `entity-actions.checks.ts:456` (submission filter) | `UUIDsEqual(r.EntityActionID, binding.ID)` |
| `entity-actions.checks.ts:462` (RecordID substring) | `NormalizeUUID()` both sides — see below |
| `entity-actions.checks.ts:505` (exactly-once assert) | `UUIDsEqual(r.EntityActionID, binding.ID)` |
| `AI/CorePlus/src/task-graph/flow-graph-compiler.ts:174` (cycle-path names) | `UUIDsEqual(s.ID, id)` |

The RecordID site is a substring check on a composite-key string, so `UUIDsEqual` does not fit — `NormalizeUUID` (trim+lowercase) on both sides keeps the containment check while making it case-insensitive, which matters because SQL Server hands out uppercase GUIDs.

## Verification

- MJGlobal's `UUIDCompliance.test.ts`: **passes** (was 1 failed with 6 violations).
- `@memberjunction/server`, `@memberjunction/testing-integration`, `@memberjunction/ai-core-plus` all build clean with their full dependency graphs (zero TS errors).

## For reviewers

- No behavior change on same-platform data (all six compared same-source metadata UUIDs); the fix removes the latent cross-platform case-sensitivity bug the sweep exists to catch.
- No changeset: the MJServer/CorePlus lines are behavior-preserving one-liners; say the word if you want a patch changeset anyway.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MYWbAFjiCkR8LWJK3VXWX3