### PR TITLE
fix(core): a related-record Load() no longer silently discards unsaved children

### DIFF
--- a/.changeset/related-collection-load-over-unsaved.md
+++ b/.changeset/related-collection-load-over-unsaved.md
@@ -1,0 +1,5 @@
+---
+"@memberjunction/core": patch
+---
+
+`RelatedRecordCollection.Load()` now refuses to load over unsaved work instead of silently discarding it. `Add()` and `Create()` deliberately do not mark a collection loaded, so a collection that has only ever been appended to still has `IsLoaded === false` — and the "already loaded" early return therefore did not protect it. Any later `Load()` (a lazy read, a refresh, a sibling component sharing the entity) replaced `items` wholesale and took the caller's unsaved children with it, along with any queued removals, reporting nothing: the screen simply showed fewer rows than the user typed and the save wrote fewer children than they entered. The load now throws when the collection is dirty and `force` is not set, naming how many children and removals would have been lost; `Load(true)` still discards, which is what a deliberate refresh means. Merging was rejected — it invents an ordering and can duplicate — and refusing matches what this collection already does elsewhere, where a load that would produce quietly wrong data throws rather than returning something plausible.

--- a/packages/MJCore/docs/related-record-collections.md
+++ b/packages/MJCore/docs/related-record-collections.md
@@ -491,6 +491,25 @@ const result = await rv.RunView<OrderEntity>({
 }, user);
 ```
 
+**Loading over unsaved work throws.** `Add()` and `Create()` deliberately do not mark a collection
+loaded — an appended child says nothing about what is on disk — so the "already loaded" early return
+does not cover a collection you have only appended to. Without a guard, a later `Load()` from
+anywhere (a lazy read, a refresh, a sibling component) would replace the items wholesale and take
+your unsaved children with it, silently:
+
+```typescript
+await order.Load(id);
+await order.Lines.Create();     // one unsaved line, collection still IsLoaded === false
+await order.Lines.Load();       // ❌ throws: "cannot load over unsaved changes — 1 unsaved child
+                                //    record(s) and 0 pending removal(s) would be discarded."
+
+await order.Lines.Load(true);   // ✅ discards them, because you said so
+```
+
+Merging was rejected: it invents an ordering and can duplicate. Refusing is the same choice this
+collection makes everywhere else — a load that would produce quietly wrong data throws rather than
+returning something plausible.
+
 ### Read-only collections
 
 Cache-sourced collections default to read-only, and say so clearly when you try:

--- a/packages/MJCore/src/__tests__/relatedRecordCollection.load.test.ts
+++ b/packages/MJCore/src/__tests__/relatedRecordCollection.load.test.ts
@@ -1,0 +1,131 @@
+/**
+ * RelatedRecordCollection — `Load()` over unsaved work.
+ *
+ * THE BUG THIS EXISTS FOR. `Add()` and `Create()` deliberately do not mark a collection loaded — an
+ * appended child says nothing about what is on disk. So a collection that has only ever been
+ * appended to still has `IsLoaded === false`, and `Load()`'s "already loaded" early return does not
+ * protect it: the load runs, `items` is replaced wholesale with the database rows, and the caller's
+ * unsaved children are gone. Queued removals go with them.
+ *
+ * Nothing reports that. The screen shows fewer rows than the user typed, the save writes fewer lines
+ * than they entered, and the totals agree with each other the whole way down — which is exactly the
+ * class of failure this file's own doctrine says a silent empty load produces.
+ *
+ * It is reachable from ordinary code: a lazily-loaded collection appended to before its first read,
+ * a component that refreshes on a route event, two sibling components sharing one entity. The fix is
+ * not to merge — a merge invents an ordering and can duplicate — but to refuse, and to let `force`
+ * mean "discard, I meant it".
+ */
+import { describe, it, expect } from 'vitest';
+import { RelatedRecordCollection } from '../generic/relatedRecordCollection';
+import type { BaseEntity } from '../generic/baseEntity';
+
+/** Rows the fake provider will return for the parent. */
+const PERSISTED = [{ ID: 'P1', ActionID: 'A1' }, { ID: 'P2', ActionID: 'A1' }];
+
+/** Minimal owner whose provider answers one RunView with the persisted rows. */
+function makeOwner(): BaseEntity {
+    return {
+        EntityInfo: { Name: 'MJ: Actions' },
+        FirstPrimaryKey: { Value: 'A1' },
+        PrimaryKey: { ToString: () => 'A1' },
+        IsSaved: true,
+        ContextCurrentUser: undefined,
+        ProviderToUse: {
+            RunView: async () => ({ Success: true, Results: PERSISTED.map(r => makeRecord(r.ID, false, true)) }),
+        },
+    } as unknown as BaseEntity;
+}
+
+function makeRecord(id: string, dirty = false, saved = true): BaseEntity {
+    const data: Record<string, unknown> = { ID: id, ActionID: 'A1' };
+    return {
+        Dirty: dirty,
+        IsSaved: saved,
+        Get: (f: string) => data[f],
+        Set: (f: string, v: unknown) => { data[f] = v; },
+        GetAll: () => ({ ...data }),
+    } as unknown as BaseEntity;
+}
+
+function makeCollection(options: Record<string, unknown> = {}) {
+    return new RelatedRecordCollection(makeOwner(), {
+        Name: 'Params',
+        RelatedEntity: 'MJ: Action Params',
+        RelatedEntityJoinField: 'ActionID',
+        ...options,
+    });
+}
+
+describe('RelatedRecordCollection.Load — unsaved work', () => {
+    it('refuses to load over an unsaved child rather than silently discarding it', async () => {
+        const collection = makeCollection();
+        collection.Add(makeRecord('NEW', true, false));
+
+        // The early return does NOT cover this: Add() leaves the collection un-loaded.
+        expect(collection.IsLoaded).toBe(false);
+
+        await expect(collection.Load()).rejects.toThrow(/unsaved changes/i);
+        expect(collection.Count).toBe(1);
+        expect(collection.Items[0].Get('ID')).toBe('NEW');
+    });
+
+    it('names what would have been lost, so the message is actionable', async () => {
+        const collection = makeCollection();
+        collection.Add(makeRecord('NEW1', true, false));
+        collection.Add(makeRecord('NEW2', true, false));
+
+        await expect(collection.Load()).rejects.toThrow(/2 unsaved child record\(s\)/);
+    });
+
+    it('leaves a pending REMOVAL alone on an ordinary load — a resurrected row is as wrong as a lost one', async () => {
+        // A removal can only be queued on a collection that was loaded, so the "already loaded"
+        // early return covers this case and the guard never sees it. Asserted anyway, because the
+        // property that matters is the OUTCOME — the removal survives — not which branch delivers it.
+        const collection = makeCollection();
+        collection.SetLoadedItems([makeRecord('P1'), makeRecord('P2')]);
+        collection.Remove(0);
+        expect(collection.Dirty).toBe(true);
+
+        await collection.Load();
+
+        expect(collection.Count).toBe(1);
+        expect(collection.Items[0].Get('ID')).toBe('P2');
+    });
+
+    it('discards deliberately when force is passed', async () => {
+        const collection = makeCollection();
+        collection.Add(makeRecord('NEW', true, false));
+
+        await collection.Load(true);
+
+        expect(collection.IsLoaded).toBe(true);
+        expect(collection.Count).toBe(2);
+        expect(collection.Items.map(i => i.Get('ID'))).toEqual(['P1', 'P2']);
+    });
+
+    it('still loads normally when there is nothing unsaved', async () => {
+        const collection = makeCollection();
+
+        await collection.Load();
+
+        expect(collection.IsLoaded).toBe(true);
+        expect(collection.Count).toBe(2);
+    });
+
+    it('is still a no-op for an unsaved parent, unsaved children or not', async () => {
+        const owner = makeOwner();
+        (owner as unknown as { IsSaved: boolean }).IsSaved = false;
+        const collection = new RelatedRecordCollection(owner, {
+            Name: 'Params',
+            RelatedEntity: 'MJ: Action Params',
+            RelatedEntityJoinField: 'ActionID',
+        });
+        collection.Add(makeRecord('NEW', true, false));
+
+        // There is nothing to be a child OF, so this returns before the guard — a new parent
+        // composing children in memory must not be told it cannot load.
+        await expect(collection.Load()).resolves.toBeUndefined();
+        expect(collection.Count).toBe(1);
+    });
+});

--- a/packages/MJCore/src/generic/relatedRecordCollection.ts
+++ b/packages/MJCore/src/generic/relatedRecordCollection.ts
@@ -487,7 +487,17 @@ export class RelatedRecordCollection<T extends BaseEntity = BaseEntity> extends 
      * total, a validation decision — is then wrong in a way nothing downstream can detect. Only
      * saves use the boolean-return convention.
      *
-     * @param force - Reload even if already loaded.
+     * Loading over UNSAVED WORK also throws, for the same reason. `Add()` and `Create()` do not mark
+     * a collection loaded, so a collection that has only ever been appended to still has
+     * `loaded === false` — and the early return above therefore does *not* protect it. A `Load()`
+     * from anywhere (a lazy read, a refresh, a sibling component) would replace `items` wholesale
+     * and take the caller's unsaved children with it, along with any queued deletions. Nothing
+     * reports that; the screen simply shows fewer rows than the user typed.
+     *
+     * Pass `force` to discard deliberately — that is what a refresh means, and saying so is cheap.
+     *
+     * @param force - Reload even if already loaded, discarding any unsaved children and removals.
+     * @throws When the collection has unsaved changes and `force` is not set.
      */
     public async Load(force = false): Promise<void> {
         if (this.LoadMode === 'never') {
@@ -498,6 +508,14 @@ export class RelatedRecordCollection<T extends BaseEntity = BaseEntity> extends 
         }
         if (this.loaded && !force) {
             return;
+        }
+        if (this.Dirty && !force) {
+            throw new Error(
+                `RelatedRecordCollection '${this.Name}': cannot load over unsaved changes — ` +
+                    `${this.items.filter(i => !i.IsSaved).length} unsaved child record(s) and ` +
+                    `${this.removed.length} pending removal(s) would be discarded. ` +
+                    `Save the parent first, or pass force to discard them deliberately.`,
+            );
         }
 
         // Cache first when declared. A hit costs zero queries; a miss falls straight through to the


### PR DESCRIPTION
## The defect

`RelatedRecordCollection.Add()` and `.Create()` deliberately do not mark a collection loaded — an
appended child says nothing about what is on disk. That is correct, and it has a consequence nobody
had followed through: a collection you have **only appended to** still has `IsLoaded === false`, so
`Load()`'s "already loaded" early return does not protect it.

```typescript
await order.Load(id);
await order.Lines.Create();     // one unsaved line; IsLoaded is still false
await order.Lines.Load();       // items replaced wholesale — the line is gone
```

The load runs, `this.items = result.Results ?? []` replaces everything, and the caller's unsaved
children vanish. Any queued removals go with them, so a row the user deleted comes back.

**Nothing reports it.** The screen shows fewer rows than the user typed, the save writes fewer
children than they entered, and every total agrees with every other total the whole way down. That is
the same class of failure this file's own doctrine already names, in the remark explaining why a
*failed* load throws instead of yielding an empty collection:

> Silently returning no children makes a populated parent look empty, and anything derived from that
> — a reversal, a total, a validation decision — is then wrong in a way nothing downstream can detect.

## How it is reached

Not a contrived sequence:

- a `Load: 'lazy'` collection appended to before its first read
- a component that refreshes on a route event while an editor holds unsaved lines
- two sibling components sharing one entity, one of which loads

Found while moving two BizApps order/journal editors onto related-record collections: both compose
children in the browser before anything has loaded the collection, which is precisely the window.

## The fix

`Load()` throws when the collection is dirty and `force` is not set, and names what would have been
lost:

```
RelatedRecordCollection 'Lines': cannot load over unsaved changes — 1 unsaved child record(s) and
0 pending removal(s) would be discarded. Save the parent first, or pass force to discard them
deliberately.
```

`Load(true)` still discards. That is what a deliberate refresh means, and saying so is cheap.

`Dirty` already answers exactly the question the guard needs — any retained child unsaved or dirty,
or any removal pending — so the guard is one condition rather than new bookkeeping.

**Merging was rejected.** It invents an ordering between what the user typed and what the database
holds, and it can duplicate a child that was saved by another path in between. Refusing is the same
choice this collection makes everywhere else.

## Compatibility

A `Load()` that previously discarded now throws. Any caller relying on the old behaviour was relying
on losing data; if the discard was intended, `force` says so. The no-op paths are untouched:
`LoadMode: 'never'`, an unsaved parent, and an already-loaded clean collection all return exactly as
before — the guard sits after all three.

## Verification

- 6 new tests in `relatedRecordCollection.load.test.ts`, covering the refusal, the message contents, the forced discard, the clean load, the pending-removal case, and the unsaved-parent no-op
- `@memberjunction/core`: **1829 tests pass**, 120 files
- Docs updated in `packages/MJCore/docs/related-record-collections.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)