### PR TITLE
chore(vscode): stop the editor following pnpm's symlink graph

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -34,5 +34,14 @@
   "typescript.tsdk": "node_modules/typescript/lib",
   "claudeCode.allowDangerouslySkipPermissions": true,
   "claudeCode.initialPermissionMode": "bypassPermissions",
-  "npm.packageManager": "pnpm"
+  "npm.packageManager": "pnpm",
+  "search.followSymlinks": false,
+  "search.exclude": {
+    "**/node_modules": true,
+    "**/.pnpm": true
+  },
+  "files.watcherExclude": {
+    "**/node_modules/**": true,
+    "**/.pnpm/**": true
+  }
 }


### PR DESCRIPTION
Ten lines in `.vscode/settings.json`. It addresses a real, measurable slowdown that arrived with the pnpm move and presents as "VS Code got slow" rather than as an error — so it has gone unattributed.

## The problem

VS Code's search defaults to **`search.followSymlinks: true`**. Against npm's hoisted `node_modules` that was harmless. Against pnpm's store it is not: every package gets its own `node_modules` full of symlinks into `.pnpm`, so the tree is a **cyclic graph**, and a following walk revisits the same real files through unboundedly many paths.

Measured on a clean clone of `next` (`pnpm install`, nothing else), using the ripgrep binary VS Code ships:

| | paths emitted | time |
| --- | --- | --- |
| `rg --files` | 17,516 | **0 s** |
| `rg --files --follow` | **49,219,818** | **60 s and still running** (19 GB of output; a first attempt was killed at 10 min) |

The repo has ~17.5k real files. 49.2M paths in a minute is not a slow walk, it is an unbounded one.

Notably **none** of those paths were inside `.pnpm` itself — the walk goes *through* the per-package symlink farm, where package A's `node_modules` links to B whose links reach back to A.

**This is also why the existing `node_modules` exclusion does not save you.** Exclusion globs match the path *as traversed*, so once a symlink is followed the files are reached under a path that no longer looks like a dependency.

Tree shape on this commit: **3,226** `.pnpm` store dirs, **11,782** symlinks at depth 4, **131** per-package `node_modules`.

## Not just VS Code

Spotlight hits the same structure independently. On a machine with **no editor running**, `fseventsd` was pegged at **137% CPU** and `mds_stores` at 71%; both dropped away once the stores were excluded from indexing (a `.metadata_never_index` file inside `node_modules` does this per-directory, no privileges needed). That is outside the scope of this PR, but worth knowing if your machine feels hot with nothing open — and it is corroborating evidence that the structure, not the editor, is the cause.

## Verified after the change

Same clone, same machine: VS Code idles at **0.3–1.6%** total CPU across all processes, **zero** ripgrep spawns, project-wide search settles quickly with correctly scoped results, and the file picker is instant.

**Go-to-definition is unaffected.** That is the TypeScript language server resolving `types` → `dist/*.d.ts` — a different subsystem that never consulted this setting. (If ⌘-click does not work for you in a fresh clone, that is because nothing has been built yet, not because of this change.)

## The one real trade-off — and a question for the Open App local-dev work

Disabling symlink following means **text search will not descend into symlinked directories**. In this repo that is exactly the intent: the only symlinks are inside `node_modules`. Everything you would search is a real directory.

**But that assumption is topology-dependent, and it is worth checking against `mj dev workspace`.** `guides/OPEN_APP_WORKSPACE_LINKING_SPEC.md` generates a workspace at the common parent of sibling repos — if members are reached through symlinks under that scheme, then with this setting a developer's project-wide search would silently skip the linked app's source. That is a bad failure mode: no error, just missing results.

So, for whoever owns that work:

1. Under the generated workspace, are member repos reached via **symlink** or added as **real folder roots**?
2. If symlinked, should the generated workspace ship `search.followSymlinks: true` *plus* an explicit `.pnpm` exclude, rather than inheriting this repo-level `false`?
3. Is the store still at the common parent (one `.pnpm` for N repos), or one per member? That changes the size of the graph a following walk would face.

Happy to test any of these against a real generated workspace once the tool exists — this was found while bringing open apps onto MJ 6.x, so we are already exercising that path.

## Scope

Deliberately minimal: no build, lint, or CI changes, and `.vscode/settings.json` is a file this repo already maintains. Anyone who prefers the old behaviour can override it in their user settings.