### PR TITLE
HITL, loop first-classing, and the silent-wrongness class from the post-merge review

### DIFF
--- a/metadata/actions/.additional-core-actions.json
+++ b/metadata/actions/.additional-core-actions.json
@@ -5358,11 +5358,15 @@
             "Type": "Output",
             "ValueType": "Scalar",
             "IsArray": true,
-            "Description": "The rows returned by the query. This is the action's result \u2014 map it into the payload to use the records downstream, e.g. {\"Records\": \"accounts\"}.",
+            "Description": "The rows returned by the query. This is the action's result — map it into the payload to use the records downstream, e.g. {\"Records\": \"accounts\"}.",
             "IsRequired": false
           },
           "primaryKey": {
             "ID": "93B80E4B-36E6-4CFD-A957-E922A4264B17"
+          },
+          "sync": {
+            "lastModified": "2026-08-10T20:58:45.759Z",
+            "checksum": "54d3d4449ce81e7a96358b6effdadf17859f6d2e161f0c7efb52e52b2f4e7506"
           }
         },
         {
@@ -5377,6 +5381,10 @@
           },
           "primaryKey": {
             "ID": "A4604694-D070-45FF-BE22-74A3AFC40D33"
+          },
+          "sync": {
+            "lastModified": "2026-08-10T20:58:45.789Z",
+            "checksum": "e51f5e36b840bb4e59725161f2e3005f2bccde1a1500a87a95336c234b46d66e"
           }
         }
       ]

--- a/metadata/agents/.workflow-demo-agents.json
+++ b/metadata/agents/.workflow-demo-agents.json
@@ -53,9 +53,17 @@
                 },
                 "primaryKey": {
                   "ID": "0000A923-0586-4175-A8FD-3192EA66FF02"
+                },
+                "sync": {
+                  "lastModified": "2026-08-10T20:58:57.454Z",
+                  "checksum": "af7e117a867a53471dc3a64ddbf2fd70eaadfab70a3d35daa9f5e8347564a5fd"
                 }
               }
             ]
+          },
+          "sync": {
+            "lastModified": "2026-08-10T20:58:57.282Z",
+            "checksum": "99855f06aa35416404e20b21b6eecbf9faa1238bf3966113fd23ee3f5ca7db81"
           }
         },
         {
@@ -99,9 +107,17 @@
                 },
                 "primaryKey": {
                   "ID": "C546274A-30B7-427A-B765-6ACB1A4D0088"
+                },
+                "sync": {
+                  "lastModified": "2026-08-10T20:58:57.467Z",
+                  "checksum": "bc4d3373bf510f42546209ddbca59c7a14d9a122cc25c61c9801e421e5d497bd"
                 }
               }
             ]
+          },
+          "sync": {
+            "lastModified": "2026-08-10T20:58:57.298Z",
+            "checksum": "7f58004791e33caac3db85f5946b71c229ee6490ba11d7c489d367291952399d"
           }
         },
         {
@@ -119,12 +135,20 @@
           },
           "primaryKey": {
             "ID": "F7EE2A1A-01A5-4592-95ED-DD4A8A974F5D"
+          },
+          "sync": {
+            "lastModified": "2026-08-10T20:58:57.314Z",
+            "checksum": "3d117107dc4c8e53af4f97847a06d776f521ee2faf376e300cbec1ac3a26cbb6"
           }
         }
       ]
     },
     "primaryKey": {
       "ID": "E359CA7B-EDC3-45B8-8E8D-25C84B08ABA8"
+    },
+    "sync": {
+      "lastModified": "2026-08-10T20:58:57.200Z",
+      "checksum": "530ac892c96d5656c1a5b7d7e96cce94c42de8014b2cf9f46bfe1bbc932bd29e"
     }
   },
   {
@@ -173,6 +197,10 @@
                 },
                 "primaryKey": {
                   "ID": "3A773E7E-7C54-40FA-BF6E-E4509A3E01C5"
+                },
+                "sync": {
+                  "lastModified": "2026-08-10T20:58:57.479Z",
+                  "checksum": "e503d57914a77ff8330f450fc7b35f2059293050f21a22c9b14926d8541552ec"
                 }
               },
               {
@@ -187,7 +215,7 @@
                   "ID": "F3F2BAF1-4A77-490D-922D-8E5F4BDEC8D8"
                 },
                 "sync": {
-                  "lastModified": "2026-08-10T16:15:27.960Z",
+                  "lastModified": "2026-08-10T20:58:57.495Z",
                   "checksum": "ca99fd6da072a98fe7d32f51ad5ac84af227961a8d867cf9306ca6194fb6ac08"
                 }
               }
@@ -195,6 +223,10 @@
           },
           "primaryKey": {
             "ID": "1E9F8F35-9523-4739-B01C-2025246703D9"
+          },
+          "sync": {
+            "lastModified": "2026-08-10T20:58:57.330Z",
+            "checksum": "8b7187e9a7fe89676357bfc523811b60ac3ea0f66846d2ed9408cea66f4757d0"
           }
         },
         {
@@ -229,6 +261,10 @@
                 },
                 "primaryKey": {
                   "ID": "30BF8477-8297-4C35-A6EE-33FC0C5E05CD"
+                },
+                "sync": {
+                  "lastModified": "2026-08-10T20:58:57.510Z",
+                  "checksum": "43fc4a79e82d0b11a4caf8fecd9c866a16e083000956681affce4433be46741e"
                 }
               }
             ]
@@ -237,7 +273,7 @@
             "ID": "F98FD583-6CD3-4E41-BF00-C2A097478465"
           },
           "sync": {
-            "lastModified": "2026-08-10T16:15:27.863Z",
+            "lastModified": "2026-08-10T20:58:57.364Z",
             "checksum": "a948a6503f63bcdde67f1274aeebd5ee7282065be945368171257d236b4e103c"
           }
         },
@@ -267,12 +303,20 @@
                 },
                 "primaryKey": {
                   "ID": "EE251343-A1BA-4F75-BC73-50EC1F695918"
+                },
+                "sync": {
+                  "lastModified": "2026-08-10T20:58:57.524Z",
+                  "checksum": "78ef84b51b3d99ee8b6f4c48240a102c6034ead49469f89142ecabd9def14cdf"
                 }
               }
             ]
           },
           "primaryKey": {
             "ID": "6D5CCA48-833D-46EF-A30D-4DC821F58CE1"
+          },
+          "sync": {
+            "lastModified": "2026-08-10T20:58:57.348Z",
+            "checksum": "bca39656b4c151c7486a6d5169b27cab3a51c6959d715c6e2a2eb099713f6b07"
           }
         },
         {
@@ -308,6 +352,10 @@
                 },
                 "primaryKey": {
                   "ID": "C024E6C9-A595-4AAA-BBF5-4864427F7751"
+                },
+                "sync": {
+                  "lastModified": "2026-08-10T20:58:57.548Z",
+                  "checksum": "b839b5bc1e4d91fb3ea814db2ab52c119aae8ee4015416b59cc3b4e633b0d961"
                 }
               },
               {
@@ -320,12 +368,20 @@
                 },
                 "primaryKey": {
                   "ID": "41C2AEE5-E5CF-48E3-AFED-C08AC0D30393"
+                },
+                "sync": {
+                  "lastModified": "2026-08-10T20:58:57.536Z",
+                  "checksum": "a1303b38cb73a6ab712eed07188f2c0ad5981c50af196cc6dd29dda9151c2986"
                 }
               }
             ]
           },
           "primaryKey": {
             "ID": "8B9721A0-3184-465B-B50F-2985E66BCF04"
+          },
+          "sync": {
+            "lastModified": "2026-08-10T20:58:57.381Z",
+            "checksum": "c33ab04353e57591814902d6d68d1ffa9609284c58ca20188c2add86bb96ae72"
           }
         },
         {
@@ -349,6 +405,10 @@
           },
           "primaryKey": {
             "ID": "C6CA3D22-CF83-4C53-A2A9-9AE29140F99E"
+          },
+          "sync": {
+            "lastModified": "2026-08-10T20:58:57.398Z",
+            "checksum": "109e9b2ad7d9fa82ca0ee72ad7ff6ddac3314550d2bfe881caa9e1628f16eac4"
           }
         },
         {
@@ -372,12 +432,20 @@
           },
           "primaryKey": {
             "ID": "BC28C6F7-3035-4981-8224-64C573806680"
+          },
+          "sync": {
+            "lastModified": "2026-08-10T20:58:57.412Z",
+            "checksum": "3f3158de9d01d8c1a27f4c6664745b81559dc05c5f6d96735f1bbd589947fa76"
           }
         }
       ]
     },
     "primaryKey": {
       "ID": "C36FA358-CDFD-4443-9CF3-19E194C994EE"
+    },
+    "sync": {
+      "lastModified": "2026-08-10T20:58:57.226Z",
+      "checksum": "1d1386a97b4ba28c5ab2b17c3a83a320295cf70c29df57d124a02f8946c85338"
     }
   }
 ]

--- a/metadata/agents/.workflow-demo-agents.json
+++ b/metadata/agents/.workflow-demo-agents.json
@@ -3,7 +3,7 @@
     "fields": {
       "Name": "Schema Documentation Sweep",
       "CategoryID": "@lookup:MJ: AI Agent Categories.Name=Demo",
-      "Description": "Finds MemberJunction entity fields that have no description and proposes one for each, then asks a person to approve them. A workflow demo that runs entirely on framework metadata \u2014 every install has undocumented fields, so it has real work to do on day one without any business data. The approval step is a genuine human-in-the-loop pause: the graph waits, every other branch keeps running, and answering releases it.",
+      "Description": "Finds MemberJunction entity fields that have no description and proposes one for each, then asks a person to approve them. A workflow demo that runs entirely on framework metadata — every install has undocumented fields, so it has real work to do on day one without any business data. The approval step is a genuine human-in-the-loop pause: the graph waits, every other branch keeps running, and answering releases it.",
       "TypeID": "@lookup:MJ: AI Agent Types.Name=Flow",
       "Status": "Active",
       "ExecutionOrder": 0,
@@ -17,7 +17,7 @@
           "fields": {
             "AgentID": "@parent:ID",
             "Name": "Find undocumented fields",
-            "Description": "Reads MJ: Entity Fields for rows with no Description. Capped low on purpose \u2014 this is a demo, and a sweep of every undocumented field in a stock install would be thousands of prompt calls.",
+            "Description": "Reads MJ: Entity Fields for rows with no Description. Capped low on purpose — this is a demo, and a sweep of every undocumented field in a stock install would be thousands of prompt calls.",
             "StartingStep": 1,
             "StepType": "Action",
             "ActionID": "@lookup:MJ: Actions.Name=Get Records",
@@ -49,7 +49,7 @@
                   "DestinationStepID": "@lookup:MJ: AI Agent Steps.Name=Propose a description for each field&AgentID=@parent:AgentID",
                   "Condition": null,
                   "Priority": 100,
-                  "Description": "Feeds the records into the loop. Without this edge the two steps are disconnected and only the starting step is ever compiled \u2014 the workflow silently does half its job."
+                  "Description": "Feeds the records into the loop. Without this edge the two steps are disconnected and only the starting step is ever compiled — the workflow silently does half its job."
                 },
                 "primaryKey": {
                   "ID": "0000A923-0586-4175-A8FD-3192EA66FF02"
@@ -62,7 +62,7 @@
           "fields": {
             "AgentID": "@parent:ID",
             "Name": "Propose a description for each field",
-            "Description": "One prompt call per field. A Prompt step rather than a sub-agent because there is nothing to reason about across turns \u2014 it is a single transformation of one field into one sentence, and an agent wrapper would add a reasoning loop, guardrails and a run record for no benefit.",
+            "Description": "One prompt call per field. A Prompt step rather than a sub-agent because there is nothing to reason about across turns — it is a single transformation of one field into one sentence, and an agent wrapper would add a reasoning loop, guardrails and a run record for no benefit.",
             "StartingStep": 0,
             "StepType": "ForEach",
             "LoopBodyType": "Prompt",
@@ -145,7 +145,7 @@
           "fields": {
             "AgentID": "@parent:ID",
             "Name": "Research: broad",
-            "Description": "One half of the research join. Runs in parallel with the focused search \u2014 they are independent, so making them sequential would double the wait for no reason.",
+            "Description": "One half of the research join. Runs in parallel with the focused search — they are independent, so making them sequential would double the wait for no reason.",
             "StartingStep": 1,
             "StepType": "Action",
             "ActionID": "@lookup:MJ: Actions.Name=Web Search",
@@ -174,6 +174,22 @@
                 "primaryKey": {
                   "ID": "3A773E7E-7C54-40FA-BF6E-E4509A3E01C5"
                 }
+              },
+              {
+                "fields": {
+                  "OriginStepID": "@parent:ID",
+                  "DestinationStepID": "@lookup:MJ: AI Agent Steps.Name=Research: focused&AgentID=@parent:AgentID",
+                  "Condition": null,
+                  "Priority": 100,
+                  "Description": "Reaches the second research angle. Both still feed the draft, so the join below still waits for BOTH."
+                },
+                "primaryKey": {
+                  "ID": "F3F2BAF1-4A77-490D-922D-8E5F4BDEC8D8"
+                },
+                "sync": {
+                  "lastModified": "2026-08-10T16:15:27.960Z",
+                  "checksum": "ca99fd6da072a98fe7d32f51ad5ac84af227961a8d867cf9306ca6194fb6ac08"
+                }
               }
             ]
           },
@@ -185,8 +201,8 @@
           "fields": {
             "AgentID": "@parent:ID",
             "Name": "Research: focused",
-            "Description": "The other half of the join. A different search angle on purpose \u2014 the draft step is told both ran, so it is never writing from half the evidence.",
-            "StartingStep": 1,
+            "Description": "The other half of the research join, reached from the broad search. NOT a second starting step: a workflow has exactly one entry, and a step marked as a second one is pruned as unreachable — which is how this demo spent its early life drafting from half the evidence.",
+            "StartingStep": 0,
             "StepType": "Action",
             "ActionID": "@lookup:MJ: Actions.Name=Google Custom Search",
             "ActionInputMapping": {
@@ -219,13 +235,17 @@
           },
           "primaryKey": {
             "ID": "F98FD583-6CD3-4E41-BF00-C2A097478465"
+          },
+          "sync": {
+            "lastModified": "2026-08-10T16:15:27.863Z",
+            "checksum": "a948a6503f63bcdde67f1274aeebd5ee7282065be945368171257d236b4e103c"
           }
         },
         {
           "fields": {
             "AgentID": "@parent:ID",
             "Name": "Draft the piece",
-            "Description": "The AND-join. Two paths lead here, so the dispatcher holds this step until both research steps have settled \u2014 that is what a graph gives you that a linear flow cannot.",
+            "Description": "The AND-join. Two paths lead here, so the dispatcher holds this step until both research steps have settled — that is what a graph gives you that a linear flow cannot.",
             "StartingStep": 0,
             "StepType": "Prompt",
             "PromptID": "@lookup:MJ: AI Prompts.Name=Workflow Demo: Draft Content",
@@ -296,7 +316,7 @@
                   "DestinationStepID": "@lookup:MJ: AI Agent Steps.Name=Close out: gave up&AgentID=@parent:AgentID",
                   "Condition": "payload.brandOK !== true",
                   "Priority": 100,
-                  "Description": "The give-up branch. The loop hit its cap without the draft passing, and that has to be SAID \u2014 a workflow that gives up quietly is indistinguishable from one that succeeded."
+                  "Description": "The give-up branch. The loop hit its cap without the draft passing, and that has to be SAID — a workflow that gives up quietly is indistinguishable from one that succeeded."
                 },
                 "primaryKey": {
                   "ID": "41C2AEE5-E5CF-48E3-AFED-C08AC0D30393"
@@ -312,7 +332,7 @@
           "fields": {
             "AgentID": "@parent:ID",
             "Name": "Close out: approved",
-            "Description": "One of an exclusive pair \u2014 exactly one of these two runs, and the other settles Skipped, which is a normal outcome and never rendered as a failure.",
+            "Description": "One of an exclusive pair — exactly one of these two runs, and the other settles Skipped, which is a normal outcome and never rendered as a failure.",
             "StartingStep": 0,
             "StepType": "Prompt",
             "PromptID": "@lookup:MJ: AI Prompts.Name=Workflow Demo: Final Note",
@@ -335,7 +355,7 @@
           "fields": {
             "AgentID": "@parent:ID",
             "Name": "Close out: gave up",
-            "Description": "The other half of the exclusive pair. Sets needsHuman so the stalled work is findable \u2014 the whole point of a give-up branch is that someone learns about it.",
+            "Description": "The other half of the exclusive pair. Sets needsHuman so the stalled work is findable — the whole point of a give-up branch is that someone learns about it.",
             "StartingStep": 0,
             "StepType": "Prompt",
             "PromptID": "@lookup:MJ: AI Prompts.Name=Workflow Demo: Final Note",

--- a/metadata/ai-model-types/.ai-model-types.json
+++ b/metadata/ai-model-types/.ai-model-types.json
@@ -27,6 +27,10 @@
     "relatedEntities": {},
     "primaryKey": {
       "ID": "583D65B5-F2EB-458E-8F5B-7F53FEBB12A4"
+    },
+    "sync": {
+      "lastModified": "2026-08-10T20:58:44.307Z",
+      "checksum": "76b164ae07f431fc96486c9aba2d084c9b9cfe72f26d059529e8858e66ee35a7"
     }
   }
 ]

--- a/metadata/ai-models/.ai-models.json
+++ b/metadata/ai-models/.ai-models.json
@@ -21286,6 +21286,10 @@
           },
           "primaryKey": {
             "ID": "FECDBACF-2EA8-428B-982F-AD0CAFFCBCEC"
+          },
+          "sync": {
+            "lastModified": "2026-08-10T20:58:44.961Z",
+            "checksum": "58375140d7b9af03ed7998a4c0ef1e36415e1c2e8d053e7ea6f65b001448fbb5"
           }
         },
         {
@@ -21301,12 +21305,20 @@
           },
           "primaryKey": {
             "ID": "29DE17F3-F01F-4292-B840-4747D915D1F6"
+          },
+          "sync": {
+            "lastModified": "2026-08-10T20:58:44.981Z",
+            "checksum": "bd9f90b1ce53009b1d2a9baa3fe9507fa650c91ae9f89f92dba3781a3453ff49"
           }
         }
       ]
     },
     "primaryKey": {
       "ID": "8778F6F5-7738-48CF-BA67-694DE686639C"
+    },
+    "sync": {
+      "lastModified": "2026-08-10T20:58:44.495Z",
+      "checksum": "495478cf7272832069731b16e400b0c3b1ab3a2951b83ac9d04674cc26222641"
     }
   },
   {
@@ -21338,6 +21350,10 @@
           },
           "primaryKey": {
             "ID": "4086CA48-C3A0-4E8E-93BC-E8A34E032B85"
+          },
+          "sync": {
+            "lastModified": "2026-08-10T20:58:45.004Z",
+            "checksum": "bb138ba45ab6037e63d13a823fc18f54b107fcad9ea55d14f876408f0fcdab13"
           }
         },
         {
@@ -21353,12 +21369,20 @@
           },
           "primaryKey": {
             "ID": "9BBB4DEE-A12F-46C4-AFCC-B6D391C2F2F1"
+          },
+          "sync": {
+            "lastModified": "2026-08-10T20:58:45.020Z",
+            "checksum": "bd9f90b1ce53009b1d2a9baa3fe9507fa650c91ae9f89f92dba3781a3453ff49"
           }
         }
       ]
     },
     "primaryKey": {
       "ID": "B0DFE543-E954-4639-AE14-E56EC763356E"
+    },
+    "sync": {
+      "lastModified": "2026-08-10T20:58:44.513Z",
+      "checksum": "c1eba073f3f2ceb6dfe07e9994d170756e19f8d174cf62ddec6b52081c88b940"
     }
   }
 ]

--- a/metadata/applications/.workflows-application.json
+++ b/metadata/applications/.workflows-application.json
@@ -27,5 +27,9 @@
   },
   "primaryKey": {
     "ID": "E29BDE35-88CA-4AC0-8810-1DE5F4DFF2FB"
+  },
+  "sync": {
+    "lastModified": "2026-08-10T20:59:28.911Z",
+    "checksum": "1e9ae5a968684cea17d7bcdfd5a57ff2be9c18a425d62490bdd2ff1efb68b531"
   }
 }

--- a/metadata/entities/.entity-field-jsontype-model-configuration.json
+++ b/metadata/entities/.entity-field-jsontype-model-configuration.json
@@ -22,6 +22,10 @@
           ],
           "primaryKey": {
             "ID": "@lookup:MJ: Entity Fields.EntityID=@lookup:MJ: Entities.Name=MJ: AI Model Types&Name=ModelConfiguration"
+          },
+          "sync": {
+            "lastModified": "2026-08-10T20:59:31.831Z",
+            "checksum": "90b7ca25c11e1dd4ae8432a187eb496c975cb7464c93106e2990735013e43ab4"
           }
         }
       ]
@@ -52,6 +56,10 @@
           ],
           "primaryKey": {
             "ID": "@lookup:MJ: Entity Fields.EntityID=@lookup:MJ: Entities.Name=MJ: AI Models&Name=ModelConfiguration"
+          },
+          "sync": {
+            "lastModified": "2026-08-10T20:59:31.871Z",
+            "checksum": "90b7ca25c11e1dd4ae8432a187eb496c975cb7464c93106e2990735013e43ab4"
           }
         }
       ]
@@ -81,6 +89,10 @@
           ],
           "primaryKey": {
             "ID": "@lookup:MJ: Entity Fields.EntityID=@lookup:MJ: Entities.Name=MJ: AI Model Vendors&Name=ModelConfiguration"
+          },
+          "sync": {
+            "lastModified": "2026-08-10T20:59:31.903Z",
+            "checksum": "90b7ca25c11e1dd4ae8432a187eb496c975cb7464c93106e2990735013e43ab4"
           }
         }
       ]

--- a/metadata/entities/.entity-field-jsontype-task-step-configuration.json
+++ b/metadata/entities/.entity-field-jsontype-task-step-configuration.json
@@ -30,6 +30,10 @@
           ],
           "primaryKey": {
             "ID": "@lookup:MJ: Entity Fields.EntityID=@lookup:MJ: Entities.Name=MJ: Tasks&Name=Configuration"
+          },
+          "sync": {
+            "lastModified": "2026-08-10T20:59:31.985Z",
+            "checksum": "f9865c213e3a7f57db70f0eee1980f55cb840cb21b4c6711fc10b11e4f2828c5"
           }
         }
       ]

--- a/metadata/prompts/.agent-manager-prompts.json
+++ b/metadata/prompts/.agent-manager-prompts.json
@@ -383,7 +383,7 @@
       "ID": "FA0031BB-4838-4C16-A161-ED670E9A147B"
     },
     "sync": {
-      "lastModified": "2026-08-09T04:09:46.206Z",
+      "lastModified": "2026-08-10T20:58:50.108Z",
       "checksum": "e84bc3e8225ce09c68ff96200b0d92ad753f31ba403b55654aebf99c5c53ac5f"
     }
   }

--- a/metadata/prompts/.prompts.json
+++ b/metadata/prompts/.prompts.json
@@ -194,8 +194,8 @@
       "ID": "FF7D441F-36E1-458A-B548-0FC2208923BE"
     },
     "sync": {
-      "lastModified": "2026-08-09T04:19:20.049Z",
-      "checksum": "5f6a7ef750cec3e19417cbc1c5a3fbcd853f4b14cb7730a14891bf8edc703cdb"
+      "lastModified": "2026-08-10T20:58:53.778Z",
+      "checksum": "0741cdb058f79fefeb3db7dc2d73742385a74c5fa49fbdd7c1dafa24a054d601"
     }
   },
   {

--- a/metadata/prompts/.workflow-demo-prompts.json
+++ b/metadata/prompts/.workflow-demo-prompts.json
@@ -26,6 +26,10 @@
           },
           "primaryKey": {
             "ID": "63F27C20-5D59-4990-BA5C-EAEBB3771803"
+          },
+          "sync": {
+            "lastModified": "2026-08-10T20:58:55.196Z",
+            "checksum": "838b0c0525f1a8c599bcb8071466d5523684bc3417307a05b6a235f5c3f66a88"
           }
         },
         {
@@ -37,6 +41,10 @@
           },
           "primaryKey": {
             "ID": "DEDD469A-9CA7-44B7-990A-7028B5854A97"
+          },
+          "sync": {
+            "lastModified": "2026-08-10T20:58:55.213Z",
+            "checksum": "ffd5b9eff3841d49c631cb7772a65010a059ac43aff2b953fa14672b0936741b"
           }
         },
         {
@@ -48,12 +56,20 @@
           },
           "primaryKey": {
             "ID": "9C3194E1-2660-49B3-A5B2-C25ED785E8F6"
+          },
+          "sync": {
+            "lastModified": "2026-08-10T20:58:55.228Z",
+            "checksum": "5daf3d0de11eb147870f0a71402075747f9373e11c7f20e637eee282c25ef955"
           }
         }
       ]
     },
     "primaryKey": {
       "ID": "394C02C0-5DC7-4E57-B258-CF3C7934F842"
+    },
+    "sync": {
+      "lastModified": "2026-08-10T20:58:55.068Z",
+      "checksum": "e77d06347935acc06ba7ac908e0325e8cfecb2be4547f99543e8c2d2c97bac63"
     }
   },
   {
@@ -83,6 +99,10 @@
           },
           "primaryKey": {
             "ID": "140F6C1C-EB04-401E-83DF-4AD9AE4FB83E"
+          },
+          "sync": {
+            "lastModified": "2026-08-10T20:58:55.242Z",
+            "checksum": "838b0c0525f1a8c599bcb8071466d5523684bc3417307a05b6a235f5c3f66a88"
           }
         },
         {
@@ -94,6 +114,10 @@
           },
           "primaryKey": {
             "ID": "3C2C3502-4040-41DE-87AE-F838D0B3316C"
+          },
+          "sync": {
+            "lastModified": "2026-08-10T20:58:55.255Z",
+            "checksum": "ffd5b9eff3841d49c631cb7772a65010a059ac43aff2b953fa14672b0936741b"
           }
         },
         {
@@ -105,12 +129,20 @@
           },
           "primaryKey": {
             "ID": "C3C4DF3D-4676-47ED-8908-7E239BB56B78"
+          },
+          "sync": {
+            "lastModified": "2026-08-10T20:58:55.269Z",
+            "checksum": "5daf3d0de11eb147870f0a71402075747f9373e11c7f20e637eee282c25ef955"
           }
         }
       ]
     },
     "primaryKey": {
       "ID": "F473E42B-D6FA-44AE-AEB8-F5693415B416"
+    },
+    "sync": {
+      "lastModified": "2026-08-10T20:58:54.380Z",
+      "checksum": "dda4360f8dd5a67c341d5b3fc5295d78cf0cd6b02189d277205d6cfa2743648d"
     }
   },
   {
@@ -140,6 +172,10 @@
           },
           "primaryKey": {
             "ID": "F001D15A-0970-436D-8CD4-88D4FA4B6ADA"
+          },
+          "sync": {
+            "lastModified": "2026-08-10T20:58:55.285Z",
+            "checksum": "838b0c0525f1a8c599bcb8071466d5523684bc3417307a05b6a235f5c3f66a88"
           }
         },
         {
@@ -151,6 +187,10 @@
           },
           "primaryKey": {
             "ID": "ADBE12BA-195F-4CB4-8E4B-A095832EA031"
+          },
+          "sync": {
+            "lastModified": "2026-08-10T20:58:55.300Z",
+            "checksum": "ffd5b9eff3841d49c631cb7772a65010a059ac43aff2b953fa14672b0936741b"
           }
         },
         {
@@ -162,18 +202,26 @@
           },
           "primaryKey": {
             "ID": "92F58C86-BA6E-4AF5-8384-BE51884F56DC"
+          },
+          "sync": {
+            "lastModified": "2026-08-10T20:58:55.315Z",
+            "checksum": "5daf3d0de11eb147870f0a71402075747f9373e11c7f20e637eee282c25ef955"
           }
         }
       ]
     },
     "primaryKey": {
       "ID": "63A2CD67-A531-4D26-946D-995E29096304"
+    },
+    "sync": {
+      "lastModified": "2026-08-10T20:58:54.401Z",
+      "checksum": "77777daaab1adfcba6d7fb786f0e7ff84cbe1a5228e2f27a7bddf2e5a08b796b"
     }
   },
   {
     "fields": {
       "Name": "Workflow Demo: Final Note",
-      "Description": "Writes the closing note for the Content Pipeline demo workflow. Used by BOTH terminal steps of the exclusive pair \u2014 the approved branch and the gave-up branch \u2014 distinguished by a template parameter, so the two outcomes are one prompt with two truthful voices rather than two near-identical prompts.",
+      "Description": "Writes the closing note for the Content Pipeline demo workflow. Used by BOTH terminal steps of the exclusive pair — the approved branch and the gave-up branch — distinguished by a template parameter, so the two outcomes are one prompt with two truthful voices rather than two near-identical prompts.",
       "TypeID": "@lookup:MJ: AI Prompt Types.Name=Chat",
       "TemplateText": "@file:templates/workflow-demos/final-note.template.md",
       "Status": "Active",
@@ -197,6 +245,10 @@
           },
           "primaryKey": {
             "ID": "B4C145C6-3A0F-4076-ACFB-06070F0D321D"
+          },
+          "sync": {
+            "lastModified": "2026-08-10T20:58:55.328Z",
+            "checksum": "838b0c0525f1a8c599bcb8071466d5523684bc3417307a05b6a235f5c3f66a88"
           }
         },
         {
@@ -208,6 +260,10 @@
           },
           "primaryKey": {
             "ID": "89CC910B-8178-4601-831D-240F3ACDFEA0"
+          },
+          "sync": {
+            "lastModified": "2026-08-10T20:58:55.348Z",
+            "checksum": "ffd5b9eff3841d49c631cb7772a65010a059ac43aff2b953fa14672b0936741b"
           }
         },
         {
@@ -219,12 +275,20 @@
           },
           "primaryKey": {
             "ID": "F7194740-28C7-4916-8263-52E425C0200B"
+          },
+          "sync": {
+            "lastModified": "2026-08-10T20:58:55.361Z",
+            "checksum": "5daf3d0de11eb147870f0a71402075747f9373e11c7f20e637eee282c25ef955"
           }
         }
       ]
     },
     "primaryKey": {
       "ID": "99CE926D-FEE4-492C-8129-E474B8F5E05C"
+    },
+    "sync": {
+      "lastModified": "2026-08-10T20:58:55.147Z",
+      "checksum": "de7db133fd23766d9de38854770eacd1bd9edd140df41a53c5bbed62dd3700e8"
     }
   }
 ]

--- a/metadata/prompts/.workflow-drafting-prompt.json
+++ b/metadata/prompts/.workflow-drafting-prompt.json
@@ -19,6 +19,10 @@
     },
     "primaryKey": {
       "ID": "1D9A1657-41E8-4B44-89D1-B1E3398F7408"
+    },
+    "sync": {
+      "lastModified": "2026-08-10T20:58:56.630Z",
+      "checksum": "9b352be8f282f980e9e04d4b16fabac36cbebb49eb7824297315dcb3907a37ef"
     }
   }
 ]

--- a/metadata/prompts/.workflow-planner-prompt.json
+++ b/metadata/prompts/.workflow-planner-prompt.json
@@ -71,8 +71,8 @@
       "ID": "836D0CCD-0C4C-422B-9AD9-F44B7D52BC3A"
     },
     "sync": {
-      "lastModified": "2026-08-07T23:58:27.675Z",
-      "checksum": "a66c7c5847e3b5ba3bebba0715afa4ff9a5af7342ddd8efc684dc570f5315360"
+      "lastModified": "2026-08-10T20:58:56.674Z",
+      "checksum": "e80a1cc8a95e16f10f04dea07f4580baeb585852217ccffa8be26dc70275ae8a"
     }
   }
 ]

--- a/metadata/queries/.get-agent-run-tree.json
+++ b/metadata/queries/.get-agent-run-tree.json
@@ -19,7 +19,7 @@
       "ID": "344ADDAD-458B-4FBC-9F2E-34915ED5373A"
     },
     "sync": {
-      "lastModified": "2026-08-10T14:58:18.129Z",
+      "lastModified": "2026-08-10T20:59:28.345Z",
       "checksum": "e658f297e9bd09d4675e74a3e155f67a310252a32ef70f9e9135056a44dde226"
     }
   }

--- a/metadata/queries/.get-agent-run-tree.json
+++ b/metadata/queries/.get-agent-run-tree.json
@@ -19,8 +19,8 @@
       "ID": "344ADDAD-458B-4FBC-9F2E-34915ED5373A"
     },
     "sync": {
-      "lastModified": "2026-08-10T13:08:10.776Z",
-      "checksum": "6fe6c42d746b078a018b2e41ff154e60e2975551bd3321a98494a41f5a86d546"
+      "lastModified": "2026-08-10T14:58:18.129Z",
+      "checksum": "e658f297e9bd09d4675e74a3e155f67a310252a32ef70f9e9135056a44dde226"
     }
   }
 ]

--- a/metadata/queries/SQL/get-agent-run-tree.sql
+++ b/metadata/queries/SQL/get-agent-run-tree.sql
@@ -149,6 +149,39 @@ WITH Tree AS (
 
     UNION ALL
 
+    -- ── The run a SUB-AGENT step started ──────────────────────────────────────────────────────
+    -- The other way a run nests, and the common one: an agent calling a sub-agent directly, with no
+    -- task graph involved. Without this member such a run appears in the tree as a single childless
+    -- Step — which is why a directly-invoked sub-agent rendered as an empty line in the run
+    -- visualizations while its steps sat in the database untouched.
+    --
+    -- Linked through TargetLogID, which is where a Sub-Agent step records the run it started.
+    SELECT
+        CAST(r.ID AS NVARCHAR(50)),
+        t.NodeID,
+        t.Depth + 1,
+        0,
+        CAST('Run' AS NVARCHAR(20)),
+        CAST(COALESCE(r.RunName, r.Agent, 'Agent Run') AS NVARCHAR(500)),
+        CAST(r.Status AS NVARCHAR(50)),
+        r.StartedAt,
+        r.CompletedAt,
+        r.TotalCost,
+        r.TotalTokensUsed,
+        CAST('MJ: AI Agent Runs' AS NVARCHAR(100)),
+        CAST(NULL AS NVARCHAR(50)),
+        CAST(NULL AS NVARCHAR(50))
+    FROM Tree t
+    INNER JOIN [__mj].[vwAIAgentRunSteps] s
+        ON s.ID = t.NodeID
+    INNER JOIN [__mj].[vwAIAgentRuns] r
+        ON r.ID = s.TargetLogID
+    WHERE t.NodeType = 'Step'
+      AND s.StepType = 'Sub-Agent'
+      AND t.Depth < {{ maxDepth }}
+
+    UNION ALL
+
     -- ── The run a task spawned ────────────────────────────────────────────────────────────────
     -- This is what makes the structure genuinely recursive rather than three fixed levels: a task
     -- can run an agent, that agent can submit another graph, and so on.
@@ -172,7 +205,12 @@ WITH Tree AS (
         ON tk.ID = t.NodeID
     INNER JOIN [__mj].[vwAIAgentRuns] r
         ON r.ID = tk.AgentRunID
-    WHERE t.NodeType IN ('Task', 'TaskGraph')
+    -- 'Task' ONLY — never 'TaskGraph'. A child task's AgentRunID is the run it STARTED, which is
+    -- downward. The graph's own parent row uses the same column for the opposite direction: the run
+    -- that SUBMITTED it. Following that link descends into the run we came from, which re-enters
+    -- this graph, forever — a cycle bounded only by the depth cap, producing a tree a hundred
+    -- levels deep that is the same five nodes repeated.
+    WHERE t.NodeType = 'Task'
       AND t.Depth < {{ maxDepth }}
 )
 SELECT

--- a/metadata/remote-operations/.remote-operations.json
+++ b/metadata/remote-operations/.remote-operations.json
@@ -246,7 +246,7 @@
       "Name": "Run Feature Pipeline",
       "OperationKey": "PredictiveStudio.RunFeaturePipeline",
       "CategoryID": "@lookup:MJ: Remote Operation Categories.Name=Predictive Studio",
-      "Description": "Run a Feature Pipeline \u2014 a categorized MJ: Record Processes row \u2014 over an optional runtime scope (selected records / view / list / filter), optionally as a dry-run preview that computes feature values without writing. Returns processed/written/skipped/error counts plus the MJ: Process Runs id. Runs the underlying Record Process (no dedicated entity); delegates to the Record Process substrate.",
+      "Description": "Run a Feature Pipeline — a categorized MJ: Record Processes row — over an optional runtime scope (selected records / view / list / filter), optionally as a dry-run preview that computes feature values without writing. Returns processed/written/skipped/error counts plus the MJ: Process Runs id. Runs the underlying Record Process (no dedicated entity); delegates to the Record Process substrate.",
       "InputTypeName": "PredictiveStudioRunFeaturePipelineInput",
       "InputTypeDefinition": "@file:types/predictive-studio-run-feature-pipeline.input.ts",
       "InputTypeIsArray": false,
@@ -273,7 +273,7 @@
       "Name": "Start Experiment Session",
       "OperationKey": "PredictiveStudio.StartExperimentSession",
       "CategoryID": "@lookup:MJ: Remote Operation Categories.Name=Predictive Studio",
-      "Description": "Start an experiment session from an approved ModelingPlanSpec \u2014 running its proposed experiments in waves under a Budget, maintaining a leaderboard. Optionally attaches to an existing MJ: Experiments definition or creates a new one. Returns the session id, experiment id, and initial status. Delegates to ExperimentOrchestrator.runSession in @memberjunction/predictive-studio-engine.",
+      "Description": "Start an experiment session from an approved ModelingPlanSpec — running its proposed experiments in waves under a Budget, maintaining a leaderboard. Optionally attaches to an existing MJ: Experiments definition or creates a new one. Returns the session id, experiment id, and initial status. Delegates to ExperimentOrchestrator.runSession in @memberjunction/predictive-studio-engine.",
       "InputTypeName": "PredictiveStudioStartExperimentSessionInput",
       "InputTypeDefinition": "@file:types/predictive-studio-start-experiment-session.input.ts",
       "InputTypeIsArray": false,
@@ -327,7 +327,7 @@
       "Name": "Promote ML Model",
       "OperationKey": "PredictiveStudio.PromoteModel",
       "CategoryID": "@lookup:MJ: Remote Operation Categories.Name=Predictive Studio",
-      "Description": "Transition an MJ: ML Models row through its lifecycle (Validated / Published / Archived). Enforces the leakage sign-off gate \u2014 a model flagged for possible target leakage cannot be promoted unless signOff=true. Lifecycle-only: never edits metrics or artifact, only Status. Returns whether the model was promoted and its new status. Delegates to the ProductionModelPromotionGate in @memberjunction/predictive-studio-engine.",
+      "Description": "Transition an MJ: ML Models row through its lifecycle (Validated / Published / Archived). Enforces the leakage sign-off gate — a model flagged for possible target leakage cannot be promoted unless signOff=true. Lifecycle-only: never edits metrics or artifact, only Status. Returns whether the model was promoted and its new status. Delegates to the ProductionModelPromotionGate in @memberjunction/predictive-studio-engine.",
       "InputTypeName": "PredictiveStudioPromoteModelInput",
       "InputTypeDefinition": "@file:types/predictive-studio-promote-model.input.ts",
       "InputTypeIsArray": false,
@@ -435,7 +435,7 @@
       "Name": "Submit Task Graph",
       "OperationKey": "TaskGraph.Submit",
       "CategoryID": "@lookup:MJ: Remote Operation Categories.Name=Control",
-      "Description": "Validate and durably persist a dependency-ordered task graph, returning as soon as it is safe. Does NOT wait for execution: the durable dispatcher runs the graph independently, so a submitted graph outlives the submitting request, agent run, and server. Producer-agnostic \u2014 an agent, deterministic code, or a UI can all submit. Implemented by TaskGraphSubmitOperation in @memberjunction/task-graph.",
+      "Description": "Validate and durably persist a dependency-ordered task graph, returning as soon as it is safe. Does NOT wait for execution: the durable dispatcher runs the graph independently, so a submitted graph outlives the submitting request, agent run, and server. Producer-agnostic — an agent, deterministic code, or a UI can all submit. Implemented by TaskGraphSubmitOperation in @memberjunction/task-graph.",
       "GenerationType": "Manual",
       "ExecutionMode": "Sync",
       "RequiredScope": "taskgraph:execute",
@@ -444,14 +444,14 @@
       "InputTypeName": "TaskGraphSubmitInput",
       "InputTypeDefinition": "/** Input for `TaskGraph.Submit`. */\nexport interface TaskGraphSubmitInput {\n    /** The graph to submit, as a `TaskGraphSpec`. */\n    spec: {\n        workflowName: string;\n        reasoning?: string;\n        tasks: Array<{\n            /** One step. `kind` selects which `configuration` shape applies. */\n            tempId: string;\n            name: string;\n            description: string;\n            kind: 'Agent' | 'Action' | 'Human' | 'Prompt' | 'ForEach' | 'While' | 'External';\n            configuration:\n                | { agentName: string; message?: string; templateParameters?: Record<string, string> }\n                | { actionName: string; inputMapping?: string; outputMapping?: string }\n                | { assignToUserID?: string; instructions?: string }\n                | { promptName: string; templateParameters?: Record<string, string> }\n                | { collectionPath: string; itemVariable?: string; maxIterations?: number; executionMode?: 'sequential' | 'parallel' }\n                | { condition: string; itemVariable?: string; maxIterations?: number }\n                | { domain: string; ref?: string };\n            dependsOn: Array<string | { tempId: string; condition?: string; dependencyType?: 'Prerequisite' | 'Corequisite' | 'Optional'; priority?: number; sequence?: number; exclusiveGroup?: string; pathPoints?: string }>;\n            policy?: { timeoutSeconds?: number; retryCount?: number; onError?: 'fail' | 'continue' };\n            /** Canvas geometry. Presentation only: the dispatcher ignores it, the validator never requires it. */\n            layout?: { x?: number; y?: number; width?: number; height?: number };\n            inputPayload?: Record<string, unknown>;\n        }>;\n        continuation?: 'message' | 'reinvoke' | 'none';\n        durable?: boolean;\n        /** 'edges' (flow-compiled) evaluates a failed step's outgoing edges; 'block' (default) is terminal for dependents. */\n        failureSemantics?: 'block' | 'edges';\n    };\n    /** Environment the tasks belong to. */\n    environmentID: string;\n    /** Conversation this graph answers, when submitted from a conversational channel. */\n    conversationDetailID?: string;\n}",
       "OutputTypeName": "TaskGraphSubmitOutput",
-      "OutputTypeDefinition": "/** Output of `TaskGraph.Submit`. */\nexport interface TaskGraphSubmitOutput {\n    /** True when the graph was validated and persisted. */\n    success: boolean;\n    /** Parent task representing the whole graph \u2014 the handle for status, cancel and retry. */\n    parentTaskID?: string;\n    /** Every validation failure, not just the first, when the graph was rejected. */\n    errorMessage?: string;\n}"
+      "OutputTypeDefinition": "/** Output of `TaskGraph.Submit`. */\nexport interface TaskGraphSubmitOutput {\n    /** True when the graph was validated and persisted. */\n    success: boolean;\n    /** Parent task representing the whole graph — the handle for status, cancel and retry. */\n    parentTaskID?: string;\n    /** Every validation failure, not just the first, when the graph was rejected. */\n    errorMessage?: string;\n}"
     },
     "primaryKey": {
       "ID": "9A3CAF75-D794-4223-9AEE-A40AE8A0A012"
     },
     "sync": {
-      "lastModified": "2026-08-07T23:58:30.442Z",
-      "checksum": "5c706e323d64108c07f34914a1029076e60669ed6d653d5b3f02541d668252af"
+      "lastModified": "2026-08-10T20:59:32.273Z",
+      "checksum": "4f72d0b464e9dc8133154227eb24f9c1b7674afa479f3c869435de04fe08e4f1"
     }
   },
   {
@@ -468,7 +468,7 @@
       "InputTypeName": "TaskGraphControlInput",
       "InputTypeDefinition": "/** Input for the task-graph control operations. */\nexport interface TaskGraphControlInput {\n    /** Parent task ID identifying the graph. */\n    parentTaskID: string;\n}",
       "OutputTypeName": "TaskGraphControlOutput",
-      "OutputTypeDefinition": "/** Output of the task-graph control operations \u2014 the graph's status after the action. */\nexport interface TaskGraphControlOutput {\n    success: boolean;\n    /** The parent task's status after the action. */\n    status?: string;\n    errorMessage?: string;\n}"
+      "OutputTypeDefinition": "/** Output of the task-graph control operations — the graph's status after the action. */\nexport interface TaskGraphControlOutput {\n    success: boolean;\n    /** The parent task's status after the action. */\n    status?: string;\n    errorMessage?: string;\n}"
     },
     "primaryKey": {
       "ID": "4B4F21F7-7C47-471C-A573-B39275EF23BB"
@@ -507,7 +507,7 @@
       "Name": "Get Task Graph Status",
       "OperationKey": "TaskGraph.GetStatus",
       "CategoryID": "@lookup:MJ: Remote Operation Categories.Name=Control",
-      "Description": "Return a snapshot of a task graph's progress \u2014 the parent's rolled-up status and per-task states \u2014 without waiting for anything. This is how a client, an agent, or an external caller observes a running graph now that execution is durable and nobody holds a request open. Implemented by TaskGraphGetStatusOperation in @memberjunction/task-graph.",
+      "Description": "Return a snapshot of a task graph's progress — the parent's rolled-up status and per-task states — without waiting for anything. This is how a client, an agent, or an external caller observes a running graph now that execution is durable and nobody holds a request open. Implemented by TaskGraphGetStatusOperation in @memberjunction/task-graph.",
       "GenerationType": "Manual",
       "ExecutionMode": "Sync",
       "RequiredScope": "taskgraph:read",
@@ -531,11 +531,11 @@
       "Name": "Save Workflow",
       "OperationKey": "Workflow.Save",
       "CategoryID": "@lookup:MJ: Remote Operation Categories.Name=Record Processes",
-      "Description": "Validate and persist a workflow \u2014 its graph of steps AND the triggers that fire it \u2014 by reconciling the substrates that already exist (a Flow agent for the graph, Scheduled Jobs for schedules). Creates no new storage: there is no Workflow table, because a second definition of a scheduled thing would give the scheduler two masters. Producer-agnostic \u2014 an agent over MCP, an Action, or the workflow editor all call this. Implemented by WorkflowSaveServerOperation in @memberjunction/task-graph.",
+      "Description": "Validate and persist a workflow — its graph of steps AND the triggers that fire it — by reconciling the substrates that already exist (a Flow agent for the graph, Scheduled Jobs for schedules). Creates no new storage: there is no Workflow table, because a second definition of a scheduled thing would give the scheduler two masters. Producer-agnostic — an agent over MCP, an Action, or the workflow editor all call this. Implemented by WorkflowSaveServerOperation in @memberjunction/task-graph.",
       "InputTypeName": "WorkflowSaveInput",
       "InputTypeDefinition": "/** Input for `Workflow.Save`. */\nexport interface WorkflowSaveInput {\n    /** The workflow to save, as a `WorkflowSpec`. */\n    spec: {\n        name: string;\n        description?: string;\n        status: 'Active' | 'Paused' | 'Draft';\n        graph: {\n            workflowName: string;\n            reasoning?: string;\n            tasks: Array<{\n                /** One step. `kind` selects which `configuration` shape applies. */\n                tempId: string;\n                name: string;\n                description: string;\n                kind: 'Agent' | 'Action' | 'Human' | 'Prompt' | 'ForEach' | 'While' | 'External';\n                configuration:\n                    | { agentName: string; message?: string; templateParameters?: Record<string, string> }\n                    | { actionName: string; inputMapping?: string; outputMapping?: string }\n                    | { assignToUserID?: string; instructions?: string }\n                    | { promptName: string; templateParameters?: Record<string, string> }\n                    | { collectionPath: string; itemVariable?: string; maxIterations?: number; executionMode?: 'sequential' | 'parallel' }\n                    | { condition: string; itemVariable?: string; maxIterations?: number }\n                    | { domain: string; ref?: string };\n                dependsOn: Array<string | { tempId: string; condition?: string; dependencyType?: 'Prerequisite' | 'Corequisite' | 'Optional'; priority?: number; sequence?: number; exclusiveGroup?: string; pathPoints?: string }>;\n                policy?: { timeoutSeconds?: number; retryCount?: number; onError?: 'fail' | 'continue' };\n                /** Canvas geometry. Presentation only: the dispatcher ignores it, the validator never requires it. */\n                layout?: { x?: number; y?: number; width?: number; height?: number };\n                inputPayload?: Record<string, unknown>;\n            }>;\n            continuation?: 'message' | 'reinvoke' | 'none';\n            durable?: boolean;\n            /** 'edges' (flow-compiled) evaluates a failed step's outgoing edges; 'block' (default) is terminal for dependents. */\n            failureSemantics?: 'block' | 'edges';\n        };\n        triggers: Array<\n            | { type: 'EntityEvent'; entityName: string; invocationType: string; filter?: string; scopeEntityName?: string; scopeRecordID?: string }\n            | { type: 'Schedule'; cron: string; timezone?: string }\n            | { type: 'OnDemand' }>;\n        notifications?: { condition: 'Always' | 'OnFailure' | 'OnChange'; recipients: string[] };\n    };\n}",
       "OutputTypeName": "WorkflowSaveOutput",
-      "OutputTypeDefinition": "/** Output of `Workflow.Save`. */\nexport interface WorkflowSaveOutput {\n    /** True when the workflow was validated and every substrate reconciled. */\n    success: boolean;\n    /** The Flow agent the workflow's graph persisted as \u2014 the handle for everything downstream. */\n    agentID?: string;\n    /** Scheduled Jobs created, updated or disabled by this save. */\n    scheduledJobIDs?: string[];\n    /** Triggers the spec asked for that this build cannot yet reconcile, stated rather than dropped. */\n    unreconciled?: string[];\n    /** Every validation failure, not just the first, when the workflow was rejected. */\n    errorMessage?: string;\n}",
+      "OutputTypeDefinition": "/** Output of `Workflow.Save`. */\nexport interface WorkflowSaveOutput {\n    /** True when the workflow was validated and every substrate reconciled. */\n    success: boolean;\n    /** The Flow agent the workflow's graph persisted as — the handle for everything downstream. */\n    agentID?: string;\n    /** Scheduled Jobs created, updated or disabled by this save. */\n    scheduledJobIDs?: string[];\n    /** Triggers the spec asked for that this build cannot yet reconcile, stated rather than dropped. */\n    unreconciled?: string[];\n    /** Every validation failure, not just the first, when the workflow was rejected. */\n    errorMessage?: string;\n}",
       "ExecutionMode": "Sync",
       "RequiredScope": "workflow:write",
       "RequiresSystemUser": false,
@@ -546,8 +546,8 @@
       "ID": "8C89A2A0-DB22-4EE2-86CF-40555401BAF0"
     },
     "sync": {
-      "lastModified": "2026-08-07T23:58:30.521Z",
-      "checksum": "e7ee6e8ad1da19e6fd2441f906d1501f299b92dba669c9e917f95660b3924cc3"
+      "lastModified": "2026-08-10T20:59:32.331Z",
+      "checksum": "561f101e8049a0b88ea4af8a2fb8a6db653deb2a4c322db446e5dfdb54186749"
     }
   },
   {
@@ -555,7 +555,7 @@
       "Name": "Validate Workflow",
       "OperationKey": "Workflow.Validate",
       "CategoryID": "@lookup:MJ: Remote Operation Categories.Name=Record Processes",
-      "Description": "Check a workflow for problems without saving it. Runs the identical validation Workflow.Save runs, so a workflow that validates here cannot be rejected for a different reason on save. Exists so an agent drafting a workflow can iterate before committing anything \u2014 the draft-then-confirm shape dry-run and Plan Mode already established. Implemented by WorkflowValidateServerOperation in @memberjunction/task-graph.",
+      "Description": "Check a workflow for problems without saving it. Runs the identical validation Workflow.Save runs, so a workflow that validates here cannot be rejected for a different reason on save. Exists so an agent drafting a workflow can iterate before committing anything — the draft-then-confirm shape dry-run and Plan Mode already established. Implemented by WorkflowValidateServerOperation in @memberjunction/task-graph.",
       "InputTypeName": "WorkflowSaveInput",
       "InputTypeDefinition": "/** Input for `Workflow.Save`. */\nexport interface WorkflowSaveInput {\n    /** The workflow to save, as a `WorkflowSpec`. */\n    spec: {\n        name: string;\n        description?: string;\n        status: 'Active' | 'Paused' | 'Draft';\n        graph: {\n            workflowName: string;\n            reasoning?: string;\n            tasks: Array<{\n                /** One step. `kind` selects which `configuration` shape applies. */\n                tempId: string;\n                name: string;\n                description: string;\n                kind: 'Agent' | 'Action' | 'Human' | 'Prompt' | 'ForEach' | 'While' | 'External';\n                configuration:\n                    | { agentName: string; message?: string; templateParameters?: Record<string, string> }\n                    | { actionName: string; inputMapping?: string; outputMapping?: string }\n                    | { assignToUserID?: string; instructions?: string }\n                    | { promptName: string; templateParameters?: Record<string, string> }\n                    | { collectionPath: string; itemVariable?: string; maxIterations?: number; executionMode?: 'sequential' | 'parallel' }\n                    | { condition: string; itemVariable?: string; maxIterations?: number }\n                    | { domain: string; ref?: string };\n                dependsOn: Array<string | { tempId: string; condition?: string; dependencyType?: 'Prerequisite' | 'Corequisite' | 'Optional'; priority?: number; sequence?: number; exclusiveGroup?: string; pathPoints?: string }>;\n                policy?: { timeoutSeconds?: number; retryCount?: number; onError?: 'fail' | 'continue' };\n                /** Canvas geometry. Presentation only: the dispatcher ignores it, the validator never requires it. */\n                layout?: { x?: number; y?: number; width?: number; height?: number };\n                inputPayload?: Record<string, unknown>;\n            }>;\n            continuation?: 'message' | 'reinvoke' | 'none';\n            durable?: boolean;\n            /** 'edges' (flow-compiled) evaluates a failed step's outgoing edges; 'block' (default) is terminal for dependents. */\n            failureSemantics?: 'block' | 'edges';\n        };\n        triggers: Array<\n            | { type: 'EntityEvent'; entityName: string; invocationType: string; filter?: string; scopeEntityName?: string; scopeRecordID?: string }\n            | { type: 'Schedule'; cron: string; timezone?: string }\n            | { type: 'OnDemand' }>;\n        notifications?: { condition: 'Always' | 'OnFailure' | 'OnChange'; recipients: string[] };\n    };\n}",
       "OutputTypeName": "WorkflowValidateOutput",
@@ -570,8 +570,8 @@
       "ID": "7F7EDC70-2668-49CA-BBE6-2E86808D256C"
     },
     "sync": {
-      "lastModified": "2026-08-07T23:58:30.534Z",
-      "checksum": "a39161dbca099253dc351b30c6bdeec74c8644a165332e257ab918d15ab19457"
+      "lastModified": "2026-08-10T20:59:32.310Z",
+      "checksum": "cda79f30eefb25edd2a784cf7dafcedf08ab9a0930bc95b1d88288fffadc30a3"
     }
   },
   {
@@ -579,11 +579,11 @@
       "Name": "Draft Workflow",
       "OperationKey": "Workflow.Draft",
       "CategoryID": "@lookup:MJ: Remote Operation Categories.Name=Record Processes",
-      "Description": "Draft a workflow's steps from a plain-English description. Returns a TaskGraphSpec and persists NOTHING \u2014 the draft goes to the canvas for the author to review, and only Workflow.Save commits it, which is what makes the front door's \"nothing is saved until you approve it\" promise true rather than merely stated. Constrained to agents that actually exist on the instance, because a workflow referencing an unknown agent cannot be saved and a draft that cannot be saved wastes the author's time. Validated with the SAME ValidateTaskGraphSpec the canvas and Workflow.Save run, so a draft that comes back cannot be rejected later for a reason drafting never checked. Implemented by WorkflowDraftServerOperation in @memberjunction/task-graph.",
+      "Description": "Draft a workflow's steps from a plain-English description. Returns a TaskGraphSpec and persists NOTHING — the draft goes to the canvas for the author to review, and only Workflow.Save commits it, which is what makes the front door's \"nothing is saved until you approve it\" promise true rather than merely stated. Constrained to agents that actually exist on the instance, because a workflow referencing an unknown agent cannot be saved and a draft that cannot be saved wastes the author's time. Validated with the SAME ValidateTaskGraphSpec the canvas and Workflow.Save run, so a draft that comes back cannot be rejected later for a reason drafting never checked. Implemented by WorkflowDraftServerOperation in @memberjunction/task-graph.",
       "InputTypeName": "WorkflowDraftInput",
       "InputTypeDefinition": "/** Input for `Workflow.Draft`. */\nexport interface WorkflowDraftInput {\n    /** What the person wants done, in their own words. */\n    description: string;\n    /** What to call the workflow. Carried through to the draft's `workflowName`. */\n    workflowName: string;\n}",
       "OutputTypeName": "WorkflowDraftOutput",
-      "OutputTypeDefinition": "/** Output of `Workflow.Draft`. */\nexport interface WorkflowDraftOutput {\n    /** True when a structurally valid draft came back. */\n    success: boolean;\n    /**\n     * The drafted graph, in the same `TaskGraphSpec` shape the canvas and `Workflow.Save` use.\n     *\n     * A DRAFT \u2014 nothing is persisted. The author reviews it on the canvas and commits with\n     * `Workflow.Save`, which is what makes \"nothing is saved until you approve it\" true rather than\n     * merely promised.\n     */\n    graph?: {\n        workflowName: string;\n        reasoning?: string;\n        tasks: Array<{\n            /** One step. `kind` selects which `configuration` shape applies. */\n            tempId: string;\n            name: string;\n            description: string;\n            kind: 'Agent' | 'Action' | 'Human' | 'Prompt' | 'ForEach' | 'While' | 'External';\n            configuration:\n                | { agentName: string; message?: string; templateParameters?: Record<string, string> }\n                | { actionName: string; inputMapping?: string; outputMapping?: string }\n                | { assignToUserID?: string; instructions?: string }\n                | { promptName: string; templateParameters?: Record<string, string> }\n                | { collectionPath: string; itemVariable?: string; maxIterations?: number; executionMode?: 'sequential' | 'parallel' }\n                | { condition: string; itemVariable?: string; maxIterations?: number }\n                | { domain: string; ref?: string };\n            dependsOn: Array<string | { tempId: string; condition?: string; dependencyType?: 'Prerequisite' | 'Corequisite' | 'Optional'; priority?: number; sequence?: number; exclusiveGroup?: string; pathPoints?: string }>;\n            policy?: { timeoutSeconds?: number; retryCount?: number; onError?: 'fail' | 'continue' };\n            /** Canvas geometry. Presentation only: the dispatcher ignores it, the validator never requires it. */\n            layout?: { x?: number; y?: number; width?: number; height?: number };\n            inputPayload?: Record<string, unknown>;\n        }>;\n        continuation?: 'message' | 'reinvoke' | 'none';\n        durable?: boolean;\n        /** 'edges' (flow-compiled) evaluates a failed step's outgoing edges; 'block' (default) is terminal for dependents. */\n        failureSemantics?: 'block' | 'edges';\n    };\n    /** Why drafting failed, or why the model's output was rejected. */\n    errorMessage?: string;\n}",
+      "OutputTypeDefinition": "/** Output of `Workflow.Draft`. */\nexport interface WorkflowDraftOutput {\n    /** True when a structurally valid draft came back. */\n    success: boolean;\n    /**\n     * The drafted graph, in the same `TaskGraphSpec` shape the canvas and `Workflow.Save` use.\n     *\n     * A DRAFT — nothing is persisted. The author reviews it on the canvas and commits with\n     * `Workflow.Save`, which is what makes \"nothing is saved until you approve it\" true rather than\n     * merely promised.\n     */\n    graph?: {\n        workflowName: string;\n        reasoning?: string;\n        tasks: Array<{\n            /** One step. `kind` selects which `configuration` shape applies. */\n            tempId: string;\n            name: string;\n            description: string;\n            kind: 'Agent' | 'Action' | 'Human' | 'Prompt' | 'ForEach' | 'While' | 'External';\n            configuration:\n                | { agentName: string; message?: string; templateParameters?: Record<string, string> }\n                | { actionName: string; inputMapping?: string; outputMapping?: string }\n                | { assignToUserID?: string; instructions?: string }\n                | { promptName: string; templateParameters?: Record<string, string> }\n                | { collectionPath: string; itemVariable?: string; maxIterations?: number; executionMode?: 'sequential' | 'parallel' }\n                | { condition: string; itemVariable?: string; maxIterations?: number }\n                | { domain: string; ref?: string };\n            dependsOn: Array<string | { tempId: string; condition?: string; dependencyType?: 'Prerequisite' | 'Corequisite' | 'Optional'; priority?: number; sequence?: number; exclusiveGroup?: string; pathPoints?: string }>;\n            policy?: { timeoutSeconds?: number; retryCount?: number; onError?: 'fail' | 'continue' };\n            /** Canvas geometry. Presentation only: the dispatcher ignores it, the validator never requires it. */\n            layout?: { x?: number; y?: number; width?: number; height?: number };\n            inputPayload?: Record<string, unknown>;\n        }>;\n        continuation?: 'message' | 'reinvoke' | 'none';\n        durable?: boolean;\n        /** 'edges' (flow-compiled) evaluates a failed step's outgoing edges; 'block' (default) is terminal for dependents. */\n        failureSemantics?: 'block' | 'edges';\n    };\n    /** Why drafting failed, or why the model's output was rejected. */\n    errorMessage?: string;\n}",
       "ExecutionMode": "Sync",
       "RequiredScope": "workflow:read",
       "RequiresSystemUser": "False",
@@ -592,6 +592,10 @@
     },
     "primaryKey": {
       "ID": "3456242D-6BC8-4EC0-9AA5-F671B2FCE644"
+    },
+    "sync": {
+      "lastModified": "2026-08-10T20:59:32.358Z",
+      "checksum": "86b91cbac083f799953044b24182b004ec201d22e670252968786a2f2623ad67"
     }
   }
 ]

--- a/metadata/scheduled-job-types/.action-log-retention-type.json
+++ b/metadata/scheduled-job-types/.action-log-retention-type.json
@@ -11,6 +11,10 @@
     },
     "primaryKey": {
       "ID": "450EA449-F204-45AC-981C-CAF55CBF3C86"
+    },
+    "sync": {
+      "lastModified": "2026-08-10T20:58:57.616Z",
+      "checksum": "a782fa5390f092de91d9c72a17350a0f042f89a776ee914bf4961601c20c6f10"
     }
   }
 ]

--- a/metadata/test-suites/.integration-deterministic-suite.json
+++ b/metadata/test-suites/.integration-deterministic-suite.json
@@ -18,7 +18,7 @@
             "ID": "0DCF5F3D-48EA-4FB6-9555-D39E955E471A"
           },
           "sync": {
-            "lastModified": "2026-08-10T01:59:28.308Z",
+            "lastModified": "2026-08-10T20:59:30.336Z",
             "checksum": "a1bc2e7c8d193e4ed0c560874ac6ec61bb155b94ff90d49563b9f1a543ea9180"
           }
         },
@@ -33,7 +33,7 @@
             "ID": "B78ADCB7-74FA-4B06-BC29-9F7176174E45"
           },
           "sync": {
-            "lastModified": "2026-08-10T01:59:28.341Z",
+            "lastModified": "2026-08-10T20:59:30.349Z",
             "checksum": "dc81a5eb2fbfffd4bcf7bd49282bf4ccc98a8fb14d1ae42a59c6c20a3c8a5d5b"
           }
         },
@@ -48,7 +48,7 @@
             "ID": "75E38C65-46E8-42F1-AE12-5D58EFC7B1F0"
           },
           "sync": {
-            "lastModified": "2026-08-10T01:59:28.376Z",
+            "lastModified": "2026-08-10T20:59:30.362Z",
             "checksum": "c878b405dab530842d7b5512c24bb053c8bc24e7d522da9aac8d508a814ec85c"
           }
         },
@@ -63,7 +63,7 @@
             "ID": "7E41B175-97BA-4D6C-B01A-73D5E97D0732"
           },
           "sync": {
-            "lastModified": "2026-08-10T01:59:28.412Z",
+            "lastModified": "2026-08-10T20:59:30.374Z",
             "checksum": "0bea2da69110a4c6d8c0c62fab641b02c0169df68acc2e244cc8131535fc656f"
           }
         },
@@ -78,7 +78,7 @@
             "ID": "AD32A8E9-9FF8-4A47-90DE-2682C97AB610"
           },
           "sync": {
-            "lastModified": "2026-08-10T01:59:28.461Z",
+            "lastModified": "2026-08-10T20:59:30.386Z",
             "checksum": "7c49c987d5b77f687b6cb384a7bd655912f6aecff9a8aa36b02b5c856dcf687a"
           }
         },
@@ -93,7 +93,7 @@
             "ID": "14A33062-84C6-4F96-826A-B337835F9010"
           },
           "sync": {
-            "lastModified": "2026-08-10T01:59:28.512Z",
+            "lastModified": "2026-08-10T20:59:30.398Z",
             "checksum": "1d51d9d4f09ec9c156e0a1094b1696a111a5e0d02b720c40deba2c165225d1d4"
           }
         },
@@ -108,7 +108,7 @@
             "ID": "0A7BF2F7-62AD-4A68-A52D-3BF89B1D7918"
           },
           "sync": {
-            "lastModified": "2026-08-10T01:59:28.536Z",
+            "lastModified": "2026-08-10T20:59:30.410Z",
             "checksum": "d3a73eb24ec2411a8783b02bd28139179a9f918d51ca7c140bdf6c8e6c6fafb5"
           }
         },
@@ -123,7 +123,7 @@
             "ID": "8B022F90-A942-4A3A-AF15-083DFE1F38BA"
           },
           "sync": {
-            "lastModified": "2026-08-10T01:59:28.575Z",
+            "lastModified": "2026-08-10T20:59:30.422Z",
             "checksum": "174cfe2af9e59bb4e54787a29a188dc4c3e2d13e840bc6d7e885ecbaeae5cdf3"
           }
         },
@@ -138,7 +138,7 @@
             "ID": "EC071966-25FB-43F9-9952-179BAD28A8CE"
           },
           "sync": {
-            "lastModified": "2026-08-10T01:59:28.617Z",
+            "lastModified": "2026-08-10T20:59:30.435Z",
             "checksum": "772948b2953c858e3db3a0387cb6be8832704b00ab412245c145f469ae893a4d"
           }
         },
@@ -153,7 +153,7 @@
             "ID": "25AE67D2-7F21-48F5-972E-BA7BE6E82AC0"
           },
           "sync": {
-            "lastModified": "2026-08-10T01:59:28.644Z",
+            "lastModified": "2026-08-10T20:59:30.447Z",
             "checksum": "65bfbe28d81577a2997f3073f33c72a37eecbd9dc7742f2ddeaf44a9e4e835d6"
           }
         },
@@ -168,7 +168,7 @@
             "ID": "A2DFAD81-7C48-4B69-8629-454552058408"
           },
           "sync": {
-            "lastModified": "2026-08-10T01:59:29.088Z",
+            "lastModified": "2026-08-10T20:59:30.469Z",
             "checksum": "bb18988ad2341027911e4fc0ca15090146b5ce0c2c4ea052ee7e1f032f45651a"
           }
         },
@@ -183,7 +183,7 @@
             "ID": "10314796-94CF-4CEE-AB2C-775B6442A2B5"
           },
           "sync": {
-            "lastModified": "2026-08-10T01:59:29.115Z",
+            "lastModified": "2026-08-10T20:59:30.482Z",
             "checksum": "dea7cd0e8ca0f2e7772b3fad1dbeea031a6fa103dbc278cc2b465c8aa038a8eb"
           }
         },
@@ -198,7 +198,7 @@
             "ID": "3FC27013-7336-4FCD-8810-DAC4BBD611D8"
           },
           "sync": {
-            "lastModified": "2026-08-10T01:59:29.154Z",
+            "lastModified": "2026-08-10T20:59:30.493Z",
             "checksum": "ae95e3be147b0856c85f06b4db054701206281bc235e3264993d566f9cce4f18"
           }
         },
@@ -213,7 +213,7 @@
             "ID": "DCB9179A-3EB0-48AC-8627-CA963992014E"
           },
           "sync": {
-            "lastModified": "2026-08-10T01:59:29.201Z",
+            "lastModified": "2026-08-10T20:59:30.505Z",
             "checksum": "d10079ae1799213467e923bddb3c3c5177c4e54dd25c54b0440977711da40342"
           }
         },
@@ -228,7 +228,7 @@
             "ID": "DBF0F0DC-9A63-445B-B15F-55837198C173"
           },
           "sync": {
-            "lastModified": "2026-08-10T01:59:29.305Z",
+            "lastModified": "2026-08-10T20:59:30.517Z",
             "checksum": "8eccf089bac357c1eead4ef7d65fe16dbed0e5d4d493129d6975fd676bf09039"
           }
         },
@@ -243,7 +243,7 @@
             "ID": "04E7D764-D3AB-4BD6-B05B-5CB3F1711CDF"
           },
           "sync": {
-            "lastModified": "2026-08-10T01:59:29.360Z",
+            "lastModified": "2026-08-10T20:59:30.528Z",
             "checksum": "33d8b16a16ca26e1334a4e89b4e6fae48ad3f3ebebbd669f8c28d0f1dd5b753e"
           }
         },
@@ -258,7 +258,7 @@
             "ID": "08FC29B4-DDAB-46F0-B7CC-A1033DF5E04A"
           },
           "sync": {
-            "lastModified": "2026-08-10T01:59:29.404Z",
+            "lastModified": "2026-08-10T20:59:30.542Z",
             "checksum": "132fbb34b7cabbd1b1ebcea5664ce7ce5c04d9fd839876c614109ba7a2a64f9e"
           }
         },
@@ -273,7 +273,7 @@
             "ID": "88342B4E-A51F-4D12-A327-AB86501F6038"
           },
           "sync": {
-            "lastModified": "2026-08-10T01:59:29.443Z",
+            "lastModified": "2026-08-10T20:59:30.554Z",
             "checksum": "4c68520317d6fa54a1c94f521d488099950df7a07257e431ce4b6160fe967dc4"
           }
         },
@@ -288,7 +288,7 @@
             "ID": "AEC1AA6F-6CA8-45A8-98B6-4B84AB44C51F"
           },
           "sync": {
-            "lastModified": "2026-08-10T01:59:29.476Z",
+            "lastModified": "2026-08-10T20:59:30.566Z",
             "checksum": "75b70952647fd413e76fb8b57a556714013eea1648f963c9589792373139650f"
           }
         },
@@ -303,7 +303,7 @@
             "ID": "C1E9CDC5-9A6E-43F9-AB0A-790AF6B9547E"
           },
           "sync": {
-            "lastModified": "2026-08-10T01:59:29.558Z",
+            "lastModified": "2026-08-10T20:59:30.577Z",
             "checksum": "f9a4bc9a5ca7a08781e5b54526d337f28ac5efa7479011ee06b702c28d5c13a4"
           }
         },
@@ -318,7 +318,7 @@
             "ID": "EEA2A026-1C2E-4674-9698-60367D4A69A9"
           },
           "sync": {
-            "lastModified": "2026-08-10T01:59:29.976Z",
+            "lastModified": "2026-08-10T20:59:30.601Z",
             "checksum": "b370a6e5897d1c59cb977fdf2ef8eafe79607325a6dd94e9d226367f2c8fdc5f"
           }
         },
@@ -333,7 +333,7 @@
             "ID": "33193527-A388-4CEC-8317-5553BC8EC713"
           },
           "sync": {
-            "lastModified": "2026-08-10T01:59:30.018Z",
+            "lastModified": "2026-08-10T20:59:30.613Z",
             "checksum": "0a2fa393a3b7541bc0fde3aed12bb9ad140260e2019dadeeddd7489ea15982ef"
           }
         },
@@ -348,7 +348,7 @@
             "ID": "424E3DE4-8C49-44E2-BBF4-C6BC54D379CD"
           },
           "sync": {
-            "lastModified": "2026-08-10T01:59:30.049Z",
+            "lastModified": "2026-08-10T20:59:30.626Z",
             "checksum": "885553d92b86c09a203d7f8c8a7226b03a63be8e6438016352cb516036c495b2"
           }
         },
@@ -363,7 +363,7 @@
             "ID": "F1051287-40EC-47C1-98A2-8B6AA325629E"
           },
           "sync": {
-            "lastModified": "2026-08-10T01:59:30.124Z",
+            "lastModified": "2026-08-10T20:59:30.638Z",
             "checksum": "8d4a89b9ef0c30fdf08916ae88503bd424dfc040656de7ae616d628f02236e5e"
           }
         },
@@ -378,7 +378,7 @@
             "ID": "FD3BC8CF-8F5F-4EC8-A286-C224BD242F47"
           },
           "sync": {
-            "lastModified": "2026-08-10T01:59:30.174Z",
+            "lastModified": "2026-08-10T20:59:30.651Z",
             "checksum": "f0c2553ac3c577e1235b09c6449fff4b997ac954d5b407d86b2fc4e3ee9c8da9"
           }
         },
@@ -393,7 +393,7 @@
             "ID": "67D6A962-E798-48F0-B039-99362A503E97"
           },
           "sync": {
-            "lastModified": "2026-08-10T02:01:51.402Z",
+            "lastModified": "2026-08-10T20:59:30.664Z",
             "checksum": "90e114e1a5a7065c99d451d63e7dd38ec34a6d0dda78f3e169db373017055210"
           }
         },
@@ -408,7 +408,7 @@
             "ID": "3C304C18-AB46-4B7B-BE38-F80CC12BF127"
           },
           "sync": {
-            "lastModified": "2026-08-10T02:01:51.486Z",
+            "lastModified": "2026-08-10T20:59:30.677Z",
             "checksum": "64e88fa9b696f286f107142c4b9874b48e005995be7299596004031fdfc13827"
           }
         },
@@ -423,7 +423,7 @@
             "ID": "227AA3FB-339E-4B72-81B6-B69E8E35235F"
           },
           "sync": {
-            "lastModified": "2026-08-10T02:01:51.551Z",
+            "lastModified": "2026-08-10T20:59:30.691Z",
             "checksum": "79f8b1242993565cb50fe9f073eb6abd12923ee5245ffc2a8de55735e16a190d"
           }
         },
@@ -438,7 +438,7 @@
             "ID": "DC80ACB0-6FB3-489C-B819-98DA3AC2AC64"
           },
           "sync": {
-            "lastModified": "2026-08-10T02:01:51.582Z",
+            "lastModified": "2026-08-10T20:59:30.704Z",
             "checksum": "33a7ca84d2f9a6389e0f7fc21bd08e416c242ec296d592bc684448980a46b394"
           }
         },
@@ -453,7 +453,7 @@
             "ID": "78CC7F8F-C8DF-45A8-81B8-CECAA5036323"
           },
           "sync": {
-            "lastModified": "2026-08-10T02:01:51.624Z",
+            "lastModified": "2026-08-10T20:59:30.715Z",
             "checksum": "a463ca431a9c182b20e01551376f1a33349e06377a3daf7881fdf0bdb5b1c45b"
           }
         },
@@ -468,7 +468,7 @@
             "ID": "6742EA99-B98B-423C-A342-41706E966801"
           },
           "sync": {
-            "lastModified": "2026-08-10T02:01:52.005Z",
+            "lastModified": "2026-08-10T20:59:30.744Z",
             "checksum": "8f7c987de7cc4895596e60a5d6aa34df4468c2fc2e051eb0d6a1b6a4b1c2ca82"
           }
         },
@@ -483,7 +483,7 @@
             "ID": "F8450142-C56C-4CA6-8FBC-2C542553B1E3"
           },
           "sync": {
-            "lastModified": "2026-08-10T02:01:52.062Z",
+            "lastModified": "2026-08-10T20:59:30.757Z",
             "checksum": "2722f80894f6d7e67e23cfd56d08f652ea7b2c76d098853645d6a03c19b3bd53"
           }
         },
@@ -498,7 +498,7 @@
             "ID": "349799EF-65A4-48B7-BE3F-931D109C5B17"
           },
           "sync": {
-            "lastModified": "2026-08-10T02:01:52.097Z",
+            "lastModified": "2026-08-10T20:59:30.770Z",
             "checksum": "8f8559541a0de4f9a4c8a728ab9669b6477bb5d5ce82cc3dcf3c03598fdae14b"
           }
         },
@@ -513,7 +513,7 @@
             "ID": "014AC71E-93E6-47D1-844E-A53248076D0B"
           },
           "sync": {
-            "lastModified": "2026-08-10T02:01:52.131Z",
+            "lastModified": "2026-08-10T20:59:30.781Z",
             "checksum": "dac3c088d1a60eada8363f4084629ce40ec09a59b95b678a7cb57bc53fa64b6d"
           }
         },
@@ -528,7 +528,7 @@
             "ID": "C674136E-64C4-4C20-89F1-31E98AC8C349"
           },
           "sync": {
-            "lastModified": "2026-08-10T02:01:52.163Z",
+            "lastModified": "2026-08-10T20:59:30.795Z",
             "checksum": "bf78be4dee94cd5cc4dbf88555d01908530f184e5284f7e9cfc890767e85f690"
           }
         },
@@ -543,7 +543,7 @@
             "ID": "8E698BA2-DC85-4612-B1E8-60BE630617AA"
           },
           "sync": {
-            "lastModified": "2026-08-10T02:01:52.203Z",
+            "lastModified": "2026-08-10T20:59:30.809Z",
             "checksum": "036f5b75554830785e3f31e7b73ba5700c103cd52f11fba745343ad000e840b4"
           }
         },
@@ -558,7 +558,7 @@
             "ID": "4EF003FA-028B-4A81-B689-D7B2682BCC29"
           },
           "sync": {
-            "lastModified": "2026-08-10T02:01:52.230Z",
+            "lastModified": "2026-08-10T20:59:30.822Z",
             "checksum": "b4ace85c6e5559b11bc645565f0601eef35eaa4f06344be1cb8fec319d2fd9db"
           }
         },
@@ -573,7 +573,7 @@
             "ID": "A8B38D74-361B-44E2-B941-CF0B87F07CD7"
           },
           "sync": {
-            "lastModified": "2026-08-10T02:01:52.255Z",
+            "lastModified": "2026-08-10T20:59:30.835Z",
             "checksum": "9bded35344181460c601699b155c44e6bbdb48f4157c2b0dcc88532c28415886"
           }
         },
@@ -588,7 +588,7 @@
             "ID": "67F361C5-5406-436C-8CD9-2A733D326BB5"
           },
           "sync": {
-            "lastModified": "2026-08-10T02:01:52.288Z",
+            "lastModified": "2026-08-10T20:59:30.847Z",
             "checksum": "577f304613b5f77580ff0417129a37fc0377cba1b8dba0c7e77fc3e11e6cff7d"
           }
         },
@@ -603,7 +603,7 @@
             "ID": "489DE3AA-2814-4CFD-A89B-66400506A321"
           },
           "sync": {
-            "lastModified": "2026-08-10T02:01:52.315Z",
+            "lastModified": "2026-08-10T20:59:30.859Z",
             "checksum": "0aef5543d6f6bbe7140695129960cd1c291f6a5b0fac34d60da192a214ee79f8"
           }
         },
@@ -618,7 +618,7 @@
             "ID": "85A5FC5F-02EF-4A80-B8F5-51510373F50C"
           },
           "sync": {
-            "lastModified": "2026-08-10T02:01:52.615Z",
+            "lastModified": "2026-08-10T20:59:30.886Z",
             "checksum": "83a50a6a2e4729499222c535b943f3ac1b8ecd80962086194203af3dcd61f6f1"
           }
         },
@@ -633,7 +633,7 @@
             "ID": "EE626909-318E-46CF-B587-D45D670A241A"
           },
           "sync": {
-            "lastModified": "2026-08-10T02:01:52.656Z",
+            "lastModified": "2026-08-10T20:59:30.898Z",
             "checksum": "f4af028c143cbc00985cc96c5194a346b9dfdc0521486680aa7bc3458f11e102"
           }
         },
@@ -648,7 +648,7 @@
             "ID": "2853D700-7AA6-47AC-8118-033A3ABE4D08"
           },
           "sync": {
-            "lastModified": "2026-08-10T02:01:52.685Z",
+            "lastModified": "2026-08-10T20:59:30.910Z",
             "checksum": "43f66ebce7a41eba53346000fec16be131d96aaca058aff7bb8b91c1f1a06add"
           }
         },
@@ -663,7 +663,7 @@
             "ID": "0C76A47C-FA25-4622-9B74-1F9B180E4B6A"
           },
           "sync": {
-            "lastModified": "2026-08-10T02:01:52.725Z",
+            "lastModified": "2026-08-10T20:59:30.922Z",
             "checksum": "a941cc89bcee03f28002f16e61a1e485bf367b35cac837563baa45cfd02e0727"
           }
         },
@@ -678,7 +678,7 @@
             "ID": "A5509FDE-5AB1-4789-A8AD-3BCD2D5B63C8"
           },
           "sync": {
-            "lastModified": "2026-08-10T02:01:52.779Z",
+            "lastModified": "2026-08-10T20:59:30.935Z",
             "checksum": "73ceb3995be2f3b2fef17de0376dd23e455ff25674d987be1d208eebbd975dae"
           }
         },
@@ -693,7 +693,7 @@
             "ID": "8C82E2A1-0B80-45E1-9E3B-A81CCF7949D1"
           },
           "sync": {
-            "lastModified": "2026-08-10T02:01:52.804Z",
+            "lastModified": "2026-08-10T20:59:30.948Z",
             "checksum": "50accf2c7afe872b8b95664aec47eba66d51938b6756704cf002dcafd8935594"
           }
         },
@@ -708,7 +708,7 @@
             "ID": "6D1F6183-41BC-498D-BA20-8D9BF47DAC47"
           },
           "sync": {
-            "lastModified": "2026-08-10T02:01:52.851Z",
+            "lastModified": "2026-08-10T20:59:30.961Z",
             "checksum": "813738a7467bd7b378b74ba958c137824c22b065a04a45f6201cf6832706ebdc"
           }
         },
@@ -723,7 +723,7 @@
             "ID": "F6CF7202-7FA3-4B40-90F6-656E6D5ACEA9"
           },
           "sync": {
-            "lastModified": "2026-08-10T02:01:52.881Z",
+            "lastModified": "2026-08-10T20:59:30.975Z",
             "checksum": "d143baeaea8279f48a2fc2ebf53747315174499fbb49b2c7e9c1ad1d91f966af"
           }
         },
@@ -738,7 +738,7 @@
             "ID": "2B66C6C0-12CF-4FDD-A925-522182220D70"
           },
           "sync": {
-            "lastModified": "2026-08-10T02:01:52.908Z",
+            "lastModified": "2026-08-10T20:59:30.989Z",
             "checksum": "9df57ecb2836a233c2ec7ca51a529747fc48b9e1a7903a6e459609d41a21ef81"
           }
         },
@@ -753,7 +753,7 @@
             "ID": "01460922-55FC-4AF9-AFDE-2B2ECEE477F0"
           },
           "sync": {
-            "lastModified": "2026-08-10T02:01:52.953Z",
+            "lastModified": "2026-08-10T20:59:31.002Z",
             "checksum": "ae4adcc0e8843d6184952146c2dd17523aa441bdd22ced5198fad16d3d01c8b2"
           }
         },
@@ -768,7 +768,7 @@
             "ID": "CA35DA31-B724-42EB-9CAB-CD28F9A96470"
           },
           "sync": {
-            "lastModified": "2026-08-10T02:01:53.208Z",
+            "lastModified": "2026-08-10T20:59:31.030Z",
             "checksum": "124e7f4a0b359a1cf8672f0cdd860b908bd517463c0a0172e469838efa1b3fb7"
           }
         },
@@ -783,7 +783,7 @@
             "ID": "84F658B1-00AF-42B5-A0BB-0AFCFFCB7EE2"
           },
           "sync": {
-            "lastModified": "2026-08-10T02:01:53.242Z",
+            "lastModified": "2026-08-10T20:59:31.042Z",
             "checksum": "1345fdeb1fc1af3f6b7bb24c33f7c9285f350b51e85e4eb132bd03b2a49f281b"
           }
         },
@@ -798,7 +798,7 @@
             "ID": "1585D731-53CC-4799-ADEC-E9CE92645B67"
           },
           "sync": {
-            "lastModified": "2026-08-10T02:01:53.289Z",
+            "lastModified": "2026-08-10T20:59:31.055Z",
             "checksum": "32463ec099339423e352715f6600ee51ad1581d683976f3801aee71201e2ac1a"
           }
         },
@@ -813,7 +813,7 @@
             "ID": "52AA7287-B5D8-413A-A644-487DD96878C9"
           },
           "sync": {
-            "lastModified": "2026-08-10T02:01:53.318Z",
+            "lastModified": "2026-08-10T20:59:31.069Z",
             "checksum": "93605d17e6999bf1730538c9971dc0e73593a654d5547f319a315795e2e6f829"
           }
         },
@@ -828,7 +828,7 @@
             "ID": "F31FB5E9-BC70-4F23-84E5-35273566E696"
           },
           "sync": {
-            "lastModified": "2026-08-10T02:01:53.348Z",
+            "lastModified": "2026-08-10T20:59:31.082Z",
             "checksum": "25411e3c102a6fcaec1471e898b89e9884c23fc5e9c6fe540ebf6d91f3f02928"
           }
         },
@@ -843,7 +843,7 @@
             "ID": "2E7BBFAA-66E4-4E1E-AF15-5717F0E26D23"
           },
           "sync": {
-            "lastModified": "2026-08-10T02:01:53.388Z",
+            "lastModified": "2026-08-10T20:59:31.095Z",
             "checksum": "b72770ca15fcccf43efb5795d0dd05f36c7c3ab7265948af914684da98b185f3"
           }
         },
@@ -858,7 +858,7 @@
             "ID": "6564B8E1-CA6E-4F14-89E8-768E8E039BBB"
           },
           "sync": {
-            "lastModified": "2026-08-10T02:01:53.413Z",
+            "lastModified": "2026-08-10T20:59:31.108Z",
             "checksum": "fa841f86da849bf6dc5b4e6542b8cb5d57cdf508509f40d267659a884da96c86"
           }
         },
@@ -873,7 +873,7 @@
             "ID": "1012346E-117F-445E-828B-AC4D2791D23B"
           },
           "sync": {
-            "lastModified": "2026-08-10T02:01:53.473Z",
+            "lastModified": "2026-08-10T20:59:31.120Z",
             "checksum": "9d510d7c0598ec42d4f08d393d5c9bcbee6ff6a55a7f5844110b030dc4fc1f55"
           }
         },
@@ -888,7 +888,7 @@
             "ID": "FC9C2DD2-FC18-4C46-A5D1-595BDAD266A2"
           },
           "sync": {
-            "lastModified": "2026-08-10T02:01:53.517Z",
+            "lastModified": "2026-08-10T20:59:31.133Z",
             "checksum": "e67db51739e86ce51bda0ff9060fe83e0ebb6194540cfff11b14e3611d8fd23f"
           }
         },
@@ -903,7 +903,7 @@
             "ID": "3F4CC62D-69A6-4545-BDD2-BED203C833E4"
           },
           "sync": {
-            "lastModified": "2026-08-10T02:01:53.560Z",
+            "lastModified": "2026-08-10T20:59:31.145Z",
             "checksum": "0ca3806475f6f3468a453bdcf53c53939af4289d16b0ededcde3f4294edf6719"
           }
         },
@@ -918,7 +918,7 @@
             "ID": "C803C37C-353E-486D-B01E-B723A98BBCDE"
           },
           "sync": {
-            "lastModified": "2026-08-10T02:01:53.844Z",
+            "lastModified": "2026-08-10T20:59:31.171Z",
             "checksum": "81c2454e8c88dd3314919a2394984ed64270a138c81f87f2822e68a8b5b46529"
           }
         },
@@ -933,7 +933,7 @@
             "ID": "0A893D31-276A-430B-B4A3-8E5D5B3B9C7E"
           },
           "sync": {
-            "lastModified": "2026-08-10T02:01:53.909Z",
+            "lastModified": "2026-08-10T20:59:31.186Z",
             "checksum": "2124d0f1803aca8f95cc25cb9fa5feeaf6a75156c80a5b08b949c13460710161"
           }
         },
@@ -948,7 +948,7 @@
             "ID": "3A838FA9-664D-4953-A3B0-69085F9C4249"
           },
           "sync": {
-            "lastModified": "2026-08-10T02:01:53.934Z",
+            "lastModified": "2026-08-10T20:59:31.198Z",
             "checksum": "d2ec3a795990ddd6a3740313823197069ce382ab58b1ad55e2074f58d7f61812"
           }
         },
@@ -963,7 +963,7 @@
             "ID": "96D85DB1-B642-4F00-99B0-943546CFF652"
           },
           "sync": {
-            "lastModified": "2026-08-10T02:01:53.969Z",
+            "lastModified": "2026-08-10T20:59:31.211Z",
             "checksum": "f7bf2d6d33f6125461c822c17b9a578a34f9733c0e3124b4e768c501a2574361"
           }
         },
@@ -978,7 +978,7 @@
             "ID": "B07F36D3-AD43-45E7-8068-A82B2AB5546C"
           },
           "sync": {
-            "lastModified": "2026-08-10T02:01:53.998Z",
+            "lastModified": "2026-08-10T20:59:31.224Z",
             "checksum": "3b0dad72b04a19567f1bae7410538ea3089fe27fd0341b077a47ba1cd1ed4151"
           }
         },
@@ -993,7 +993,7 @@
             "ID": "19D88BF4-A41D-4E09-8A5A-78E15703AAA9"
           },
           "sync": {
-            "lastModified": "2026-08-10T02:01:54.022Z",
+            "lastModified": "2026-08-10T20:59:31.238Z",
             "checksum": "c2a6b5bd0b8a3687c7246b53323f0074727a859c2232f4ac4d33c8a845cb20ae"
           }
         },
@@ -1008,7 +1008,7 @@
             "ID": "A4F93334-A43D-4489-90D5-EC368695D21F"
           },
           "sync": {
-            "lastModified": "2026-08-10T02:01:54.083Z",
+            "lastModified": "2026-08-10T20:59:31.252Z",
             "checksum": "03436ffd0ca9d20bffc51d9a892e862555632255c3e3ae093e28532affe05103"
           }
         },
@@ -1023,7 +1023,7 @@
             "ID": "EDEADF39-3336-427E-8C68-DD643668C0E1"
           },
           "sync": {
-            "lastModified": "2026-08-10T02:01:54.118Z",
+            "lastModified": "2026-08-10T20:59:31.265Z",
             "checksum": "5f9efa9a53252d1c63a93aefcc453156e3a5df50ac84ae647cab0a807f1032bc"
           }
         },
@@ -1038,7 +1038,7 @@
             "ID": "F7E6DBC1-DA94-46CD-B501-FEA406CC0993"
           },
           "sync": {
-            "lastModified": "2026-08-10T02:01:54.161Z",
+            "lastModified": "2026-08-10T20:59:31.278Z",
             "checksum": "08acda687cea795cdc71cb0d6911ae3b254c51ef47cf86c551e8b66e2ade5817"
           }
         },
@@ -1053,7 +1053,7 @@
             "ID": "1BDC3268-2422-4E0A-A7F9-421CE58A4B1E"
           },
           "sync": {
-            "lastModified": "2026-08-10T02:01:54.202Z",
+            "lastModified": "2026-08-10T20:59:31.290Z",
             "checksum": "20b8fe5c5c76eaec0fdcf15bfe4dd9a63c28077c3ef58d26560f4fc79a33847a"
           }
         },
@@ -1068,7 +1068,7 @@
             "ID": "9879D965-D0EB-4AF3-9A0B-45FD933C0D81"
           },
           "sync": {
-            "lastModified": "2026-08-10T02:01:54.490Z",
+            "lastModified": "2026-08-10T20:59:31.317Z",
             "checksum": "50f5fb5faf6cc9663a5b794366d94f6fc182c3418e0ea2110404db9a851a92a1"
           }
         },
@@ -1083,7 +1083,7 @@
             "ID": "FAB92C71-45A4-4342-A667-7DCC1F473334"
           },
           "sync": {
-            "lastModified": "2026-08-10T02:01:54.521Z",
+            "lastModified": "2026-08-10T20:59:31.330Z",
             "checksum": "1a958c3b9c672aa008598fac0dd307051412cffd9e90172f46897b9a76e26ad0"
           }
         },
@@ -1098,7 +1098,7 @@
             "ID": "56B77470-D975-4A98-B332-4754B8AAF45E"
           },
           "sync": {
-            "lastModified": "2026-08-10T02:01:54.560Z",
+            "lastModified": "2026-08-10T20:59:31.342Z",
             "checksum": "ad2e51f2603a41ed4b4e0f21025ffd73ccf30b6c4583aa343080b7baecf58738"
           }
         },
@@ -1113,7 +1113,7 @@
             "ID": "292CF8D7-6B27-4393-AE5D-B3EF47F78F59"
           },
           "sync": {
-            "lastModified": "2026-08-10T02:01:54.593Z",
+            "lastModified": "2026-08-10T20:59:31.354Z",
             "checksum": "8c2e7d5aedf6ea03adca3545f6259861a371b8d4f9eca6449883cf6f6baf111a"
           }
         },
@@ -1128,7 +1128,7 @@
             "ID": "0C1DA5F5-9200-46A5-BF45-136F11F7A606"
           },
           "sync": {
-            "lastModified": "2026-08-10T02:01:54.643Z",
+            "lastModified": "2026-08-10T20:59:31.367Z",
             "checksum": "01224befa22d93ab7bcd4365b7caeee40bf193d7c6ec167498e6de83e0e66eab"
           }
         },
@@ -1143,7 +1143,7 @@
             "ID": "D6CB8B12-F290-4B90-80B0-9913177EAC34"
           },
           "sync": {
-            "lastModified": "2026-08-10T02:01:54.735Z",
+            "lastModified": "2026-08-10T20:59:31.380Z",
             "checksum": "b0cf4e6a48047b148fa0cc8d0c37905691aeed915c5430ec925024144418b147"
           }
         },
@@ -1158,7 +1158,7 @@
             "ID": "9C25C434-64BC-4AA3-8F8C-2CEBFDD7870E"
           },
           "sync": {
-            "lastModified": "2026-08-10T02:01:54.688Z",
+            "lastModified": "2026-08-10T20:59:31.394Z",
             "checksum": "d11a44c5c1ecfce7995e2350f924f31d26bc653c8afee65d515825bc5e9e49f8"
           }
         },
@@ -1173,7 +1173,7 @@
             "ID": "F2D8C539-F48C-4D26-AEB5-20A6C435F282"
           },
           "sync": {
-            "lastModified": "2026-08-10T02:01:54.769Z",
+            "lastModified": "2026-08-10T20:59:31.406Z",
             "checksum": "15b57137e66b05185e63f9337662e483a0823eb72fb044d58fa8af1fd45aacb7"
           }
         }
@@ -1183,7 +1183,7 @@
       "ID": "023751C5-3A16-4EA0-802E-6534E499F185"
     },
     "sync": {
-      "lastModified": "2026-08-10T02:01:50.614Z",
+      "lastModified": "2026-08-10T20:59:30.303Z",
       "checksum": "01e3df284a2e608267583ad725027a27585c5faad1843954bf862d64bc4549fd"
     }
   }

--- a/metadata/tests/integration/.integration-tests.json
+++ b/metadata/tests/integration/.integration-tests.json
@@ -18,7 +18,7 @@
       "ID": "9779DB72-D458-4C8C-8413-1E35BA5950A1"
     },
     "sync": {
-      "lastModified": "2026-08-10T02:01:36.461Z",
+      "lastModified": "2026-08-10T20:59:29.036Z",
       "checksum": "756d461116dc0103d656c60d8dde2b2cedb2b1f9538deb5f09bb3c6a5da7d322"
     }
   },
@@ -41,7 +41,7 @@
       "ID": "0CECE635-E495-4A91-90E6-36BCE0C3E6F8"
     },
     "sync": {
-      "lastModified": "2026-08-10T02:01:36.494Z",
+      "lastModified": "2026-08-10T20:59:29.053Z",
       "checksum": "e267d2ae5d42f495c055b90b6b0cca61941a47c1ee4b68d27ec7cbca64ec0698"
     }
   },
@@ -64,7 +64,7 @@
       "ID": "F50DA0E5-19B4-4F4B-A29B-21FA1FDA32F1"
     },
     "sync": {
-      "lastModified": "2026-08-10T02:01:36.524Z",
+      "lastModified": "2026-08-10T20:59:29.070Z",
       "checksum": "6a41f9f00a072955542a4cff5529aa4074589ba31d2c710d146acc84a64a718c"
     }
   },
@@ -87,7 +87,7 @@
       "ID": "BDF70BC9-1B5F-4ABA-8BDA-C6A31CEB44CC"
     },
     "sync": {
-      "lastModified": "2026-08-10T02:01:36.556Z",
+      "lastModified": "2026-08-10T20:59:29.089Z",
       "checksum": "0aa6a589490c3a43474e800512f10e3a3c9e624ea775577023b6f501e3ce095b"
     }
   },
@@ -110,7 +110,7 @@
       "ID": "5127A822-85B3-456B-8531-7B9C40853508"
     },
     "sync": {
-      "lastModified": "2026-08-10T02:01:36.577Z",
+      "lastModified": "2026-08-10T20:59:29.104Z",
       "checksum": "74d2c8b0cf28f4564255029be2869b00ead2e36f945c159f41a3882268de2ee1"
     }
   },
@@ -133,7 +133,7 @@
       "ID": "4EEABDB8-F5EA-468E-B331-328EAB7B0C06"
     },
     "sync": {
-      "lastModified": "2026-08-10T02:01:36.619Z",
+      "lastModified": "2026-08-10T20:59:29.119Z",
       "checksum": "7ac21247339214abc287cbe7e0be2d8d3967fe4f6d498c34fa45cea2d603b474"
     }
   },
@@ -156,7 +156,7 @@
       "ID": "140D90E8-CD1D-4C5F-90E1-DB42FC87743B"
     },
     "sync": {
-      "lastModified": "2026-08-10T02:01:36.659Z",
+      "lastModified": "2026-08-10T20:59:29.136Z",
       "checksum": "63b6e2f854b8cf93ce62f11a9e3757423dad5cab98107800009a3109d0e18f2b"
     }
   },
@@ -179,7 +179,7 @@
       "ID": "758D1FC1-152E-4567-81F0-A5F6754393DA"
     },
     "sync": {
-      "lastModified": "2026-08-10T02:01:36.757Z",
+      "lastModified": "2026-08-10T20:59:29.150Z",
       "checksum": "4d73f04ca2755991375a318badf40106c1e5f033f53199ac36c012026cceef83"
     }
   },
@@ -202,7 +202,7 @@
       "ID": "A1C11DF0-1BD2-42EC-A114-AC0CE6BC8504"
     },
     "sync": {
-      "lastModified": "2026-08-10T02:01:36.799Z",
+      "lastModified": "2026-08-10T20:59:29.166Z",
       "checksum": "177ede04edb0a1f27ac4ddf498a10c7a9863510124ab3dcd8d91e5176db3479a"
     }
   },
@@ -225,7 +225,7 @@
       "ID": "080A6EA4-EE93-413D-9BB9-DC0AD697E59A"
     },
     "sync": {
-      "lastModified": "2026-08-10T02:01:36.839Z",
+      "lastModified": "2026-08-10T20:59:29.180Z",
       "checksum": "d7b697ef6d0963937361182529abe491cb37918b02c1319f4d671d88e2922268"
     }
   },
@@ -248,7 +248,7 @@
       "ID": "789AAE7D-CFC0-46BC-9688-17D0E5EDA291"
     },
     "sync": {
-      "lastModified": "2026-08-10T02:01:36.921Z",
+      "lastModified": "2026-08-10T20:59:29.210Z",
       "checksum": "f25eaf394e7e9a9d692dcdf377a61bc6a4866011306900a3326a06095028a23c"
     }
   },
@@ -271,7 +271,7 @@
       "ID": "489770F6-2A5D-4B25-ADAA-D44CE5D3AED2"
     },
     "sync": {
-      "lastModified": "2026-08-10T02:01:36.948Z",
+      "lastModified": "2026-08-10T20:59:29.226Z",
       "checksum": "9dcd90009f91b5307c4da14764fb08fe7130378d363f5739de372923d5c644fb"
     }
   },
@@ -294,7 +294,7 @@
       "ID": "582BC0CE-5FF9-4BCC-86FE-9222451D119F"
     },
     "sync": {
-      "lastModified": "2026-08-10T02:01:36.994Z",
+      "lastModified": "2026-08-10T20:59:29.239Z",
       "checksum": "fd858339a77f0c42254c5c19e542617074bcf3501dc50b5588d86ff51beaa409"
     }
   },
@@ -317,7 +317,7 @@
       "ID": "FDB14B72-89BC-475C-AC40-BB81116741D3"
     },
     "sync": {
-      "lastModified": "2026-08-10T02:01:37.040Z",
+      "lastModified": "2026-08-10T20:59:29.254Z",
       "checksum": "12c8d6d8dcaca698c02242e3f87b08cb073a41e12c94548a503a119eb8fc2568"
     }
   },
@@ -340,7 +340,7 @@
       "ID": "99C47D1E-276F-4568-9DCD-259D7C72E32B"
     },
     "sync": {
-      "lastModified": "2026-08-10T02:01:37.085Z",
+      "lastModified": "2026-08-10T20:59:29.267Z",
       "checksum": "d5507e4dc12329b29527436ae7509f7349b7c36adf232bbb699551f01fbcbff9"
     }
   },
@@ -363,7 +363,7 @@
       "ID": "ED0FC232-6017-4B01-895F-8489B7B393E4"
     },
     "sync": {
-      "lastModified": "2026-08-10T02:01:37.112Z",
+      "lastModified": "2026-08-10T20:59:29.281Z",
       "checksum": "f8056199ab46c6bc823e585129934908ec17cffcc6636f55b1bde704ae3be4ca"
     }
   },
@@ -386,7 +386,7 @@
       "ID": "B5B535E2-AD55-430B-B873-1A53D87ADFE4"
     },
     "sync": {
-      "lastModified": "2026-08-10T02:01:37.171Z",
+      "lastModified": "2026-08-10T20:59:29.297Z",
       "checksum": "7a47aed90649e6ecc185fbd9f7a2d6c702d6051d501b8e630b1bd0c5db9f40ac"
     }
   },
@@ -409,7 +409,7 @@
       "ID": "F5D63AE4-BC67-40EA-AE16-4A97059205F1"
     },
     "sync": {
-      "lastModified": "2026-08-10T02:01:37.222Z",
+      "lastModified": "2026-08-10T20:59:29.311Z",
       "checksum": "f6d59478b423c356830e784a2bcefc6e98b830faf792a8209a1186f7a952b233"
     }
   },
@@ -432,7 +432,7 @@
       "ID": "B580439B-A38A-4FF1-AFEE-7476AAB261AA"
     },
     "sync": {
-      "lastModified": "2026-08-10T02:01:37.265Z",
+      "lastModified": "2026-08-10T20:59:29.326Z",
       "checksum": "5ece34a4b6be8d931c1426d315da9e6c196d7c7175f74e2deeab2709478a28c8"
     }
   },
@@ -455,7 +455,7 @@
       "ID": "056179F6-1425-4A4B-83A0-974D107F4909"
     },
     "sync": {
-      "lastModified": "2026-08-10T02:01:37.308Z",
+      "lastModified": "2026-08-10T20:59:29.338Z",
       "checksum": "0ccb09e6eccb2a023f840237d41e3c9a9eae4b6d6695baf7c731927463bca820"
     }
   },
@@ -478,7 +478,7 @@
       "ID": "9884D21A-2A7F-4C0F-B196-9E7B86A809BC"
     },
     "sync": {
-      "lastModified": "2026-08-10T02:01:37.357Z",
+      "lastModified": "2026-08-10T20:59:29.369Z",
       "checksum": "a4b6af6cdf654ee54b427ebbdd92debee46be5dc4cbee38b631374fcecb34c13"
     }
   },
@@ -501,7 +501,7 @@
       "ID": "24CD0BA9-1A78-4C9B-8579-D75398A82984"
     },
     "sync": {
-      "lastModified": "2026-08-10T02:01:37.396Z",
+      "lastModified": "2026-08-10T20:59:29.384Z",
       "checksum": "71b2ff624120470e18bcb163ec86128f29df73305e1288dacf2f1711bba7796f"
     }
   },
@@ -524,7 +524,7 @@
       "ID": "6094344B-6351-4557-8F56-D3AB7AECA2D6"
     },
     "sync": {
-      "lastModified": "2026-08-10T02:01:37.458Z",
+      "lastModified": "2026-08-10T20:59:29.399Z",
       "checksum": "a1bf119d3214b5db5c2b0f6c8a281b8b43fee886d83b921609da281c2d3d3f3b"
     }
   },
@@ -547,7 +547,7 @@
       "ID": "4A3C5545-F1A7-4D2C-BB87-419FB3FA3686"
     },
     "sync": {
-      "lastModified": "2026-08-10T02:01:37.485Z",
+      "lastModified": "2026-08-10T20:59:29.412Z",
       "checksum": "35bae3db8584293b810e0977290e5a6df3f1f183d6fa4106ae0794aa2c6b3389"
     }
   },
@@ -570,7 +570,7 @@
       "ID": "8F647ECA-5209-4EF7-ABB7-4809E2AFCEFE"
     },
     "sync": {
-      "lastModified": "2026-08-10T02:01:37.544Z",
+      "lastModified": "2026-08-10T20:59:29.427Z",
       "checksum": "3d631f2b60a3237cba33b74314eaebba3fbc9b4d623e75a03795c4226c60b2f2"
     }
   },
@@ -594,7 +594,7 @@
       "ID": "D7BD2F22-21F3-4035-99F7-2FB8AC8B6B5B"
     },
     "sync": {
-      "lastModified": "2026-08-10T02:01:37.580Z",
+      "lastModified": "2026-08-10T20:59:29.441Z",
       "checksum": "7ed95aa28af3ab3839836df2356d5758baf9859cf74252ad330b14646db03ea4"
     }
   },
@@ -617,7 +617,7 @@
       "ID": "5DEE63CA-EC6A-4745-BAE5-11BD188DF7B0"
     },
     "sync": {
-      "lastModified": "2026-08-10T02:01:37.641Z",
+      "lastModified": "2026-08-10T20:59:29.455Z",
       "checksum": "9a06d44cf705b80eeed260740838d394358ad5b2de4e63ed23c84fc8feb05f38"
     }
   },
@@ -640,7 +640,7 @@
       "ID": "B55E6B58-7BA6-410B-A0FB-C2E7E951D0D5"
     },
     "sync": {
-      "lastModified": "2026-08-10T02:01:37.711Z",
+      "lastModified": "2026-08-10T20:59:29.469Z",
       "checksum": "8d6725b62161705d02323c79c50ee5301ec630dffe83e465547deeca52ffc04f"
     }
   },
@@ -663,7 +663,7 @@
       "ID": "0361B22D-E98C-4B86-B111-38F6390A587F"
     },
     "sync": {
-      "lastModified": "2026-08-10T02:01:37.753Z",
+      "lastModified": "2026-08-10T20:59:29.483Z",
       "checksum": "8314cc9af9307afd95f0e977ab54dfb804f3b5d111b62b65804b9f2edf6350d9"
     }
   },
@@ -686,7 +686,7 @@
       "ID": "A07B0739-0B26-4338-98C3-A3CAC0B55F76"
     },
     "sync": {
-      "lastModified": "2026-08-10T02:01:37.792Z",
+      "lastModified": "2026-08-10T20:59:29.496Z",
       "checksum": "c3f40cd464d10527ad9da2759c5c92090694c08d31c9603eb351b330ff87e337"
     }
   },
@@ -709,7 +709,7 @@
       "ID": "A0AFFE9E-A187-48ED-B315-61F12F033D40"
     },
     "sync": {
-      "lastModified": "2026-08-10T02:01:37.861Z",
+      "lastModified": "2026-08-10T20:59:29.527Z",
       "checksum": "8b8b7b9f9949577eab8d15d6b35e9df974a02da67fbd52423b6f18e04d1256cb"
     }
   },
@@ -732,7 +732,7 @@
       "ID": "F7E9DA5E-CDE2-4C2E-BA2B-E29A366EA33C"
     },
     "sync": {
-      "lastModified": "2026-08-10T02:01:37.889Z",
+      "lastModified": "2026-08-10T20:59:29.554Z",
       "checksum": "06ed24d425a6623b6c8cd1ef54f3bc7a15a2bdba5ff458ad34456b8479ead792"
     }
   },
@@ -755,7 +755,7 @@
       "ID": "5B745322-0A03-4E48-B118-1B177012185F"
     },
     "sync": {
-      "lastModified": "2026-08-10T02:01:37.924Z",
+      "lastModified": "2026-08-10T20:59:29.569Z",
       "checksum": "a4f3b36c64108f8305efe114ea7247621e21a189b5ecaa1c676553555ade8b0e"
     }
   },
@@ -778,7 +778,7 @@
       "ID": "2B1C0558-76B4-4D36-AA7C-ED21199D133B"
     },
     "sync": {
-      "lastModified": "2026-08-10T02:01:37.972Z",
+      "lastModified": "2026-08-10T20:59:29.583Z",
       "checksum": "474d2a84556b544dbeebc01c7dae277ce3077e6738f8eaadc5650c6d2f68da0d"
     }
   },
@@ -802,7 +802,7 @@
       "ID": "FA51D663-0E31-40AC-A3FB-8440100BDC6C"
     },
     "sync": {
-      "lastModified": "2026-08-10T02:01:38.002Z",
+      "lastModified": "2026-08-10T20:59:29.597Z",
       "checksum": "1e0fe495498441fdb54a354f50e3ef9078706869bc9957345c69fc39ebc2bfe7"
     }
   },
@@ -825,7 +825,7 @@
       "ID": "C8D0E4E4-0393-415B-8CC5-E3C26C23D515"
     },
     "sync": {
-      "lastModified": "2026-08-10T02:01:38.039Z",
+      "lastModified": "2026-08-10T20:59:29.611Z",
       "checksum": "e19581979be10e64243698c289d710e19ab08d13f47716a94ac9563550a0f94c"
     }
   },
@@ -848,7 +848,7 @@
       "ID": "31E8E79A-1293-41FE-945E-5AD3DF3A6F55"
     },
     "sync": {
-      "lastModified": "2026-08-10T02:01:38.064Z",
+      "lastModified": "2026-08-10T20:59:29.625Z",
       "checksum": "4d54be527da0e0c5eb6101a381b7f4d380a633ce187d34074792f6a2d98b4e6e"
     }
   },
@@ -871,7 +871,7 @@
       "ID": "ACA51672-C8BA-40B1-9F39-BC9FD587C162"
     },
     "sync": {
-      "lastModified": "2026-08-10T02:01:38.118Z",
+      "lastModified": "2026-08-10T20:59:29.640Z",
       "checksum": "953703604694299b2b2333f252132626bf91b13e2a815958e3dc52e783ab4573"
     }
   },
@@ -894,7 +894,7 @@
       "ID": "8ECDDB11-3047-4F27-B676-CF05D605D7B3"
     },
     "sync": {
-      "lastModified": "2026-08-10T02:01:38.150Z",
+      "lastModified": "2026-08-10T20:59:29.653Z",
       "checksum": "5f425f8f1f9ef930b381a5a1c5448f6a2f81edc79d8f440e51409f5c362af5dc"
     }
   },
@@ -917,7 +917,7 @@
       "ID": "04E58DD7-5E44-415A-8206-A5F7BE403BAD"
     },
     "sync": {
-      "lastModified": "2026-08-10T02:01:38.180Z",
+      "lastModified": "2026-08-10T20:59:29.665Z",
       "checksum": "c6bd9260bf7378b4e495bf5d30dbbcd04e8dcf51c3afb7195dcbf82a38ddbbaa"
     }
   },
@@ -940,7 +940,7 @@
       "ID": "E6B045A6-F72C-4774-831C-B41CD73D488A"
     },
     "sync": {
-      "lastModified": "2026-08-10T02:01:38.229Z",
+      "lastModified": "2026-08-10T20:59:29.695Z",
       "checksum": "5755dbe45c847a04353810bcc327db0b6d91a9240894f79762decf09ef8f0810"
     }
   },
@@ -963,7 +963,7 @@
       "ID": "4D195DBC-D119-48A2-837D-46FCA85C8E0D"
     },
     "sync": {
-      "lastModified": "2026-08-10T02:01:38.256Z",
+      "lastModified": "2026-08-10T20:59:29.708Z",
       "checksum": "ad9f24be9d89a92e5befd7b532cdfb145d8dcf1e3607f3d878fce3750828a855"
     }
   },
@@ -986,7 +986,7 @@
       "ID": "FF91BBAB-A29B-4D8C-B1BE-862EEFF9E875"
     },
     "sync": {
-      "lastModified": "2026-08-10T02:01:38.284Z",
+      "lastModified": "2026-08-10T20:59:29.723Z",
       "checksum": "af85f0a151a76ab2c3ce44006f3ed3f9b4c2986bb767bbb86744557f95b7b2ce"
     }
   },
@@ -1009,7 +1009,7 @@
       "ID": "19CEBF98-BF7C-4D57-956F-68BA857D23B8"
     },
     "sync": {
-      "lastModified": "2026-08-10T02:01:38.326Z",
+      "lastModified": "2026-08-10T20:59:29.736Z",
       "checksum": "ebcb0ee1afe2842bb454130e3f93bfacd036244b6b85e7bd2b04043b9bb13bc3"
     }
   },
@@ -1032,7 +1032,7 @@
       "ID": "89E3CB84-D2CF-4CFF-9CD4-B0A0B238FC70"
     },
     "sync": {
-      "lastModified": "2026-08-10T02:01:38.359Z",
+      "lastModified": "2026-08-10T20:59:29.750Z",
       "checksum": "ac0d93ea71659012ec084055b52115dca5ab58879c52e39952c0e01ae05df058"
     }
   },
@@ -1055,7 +1055,7 @@
       "ID": "742F6F0E-51F8-4F6C-B4D9-635A5E05D09C"
     },
     "sync": {
-      "lastModified": "2026-08-10T02:01:38.406Z",
+      "lastModified": "2026-08-10T20:59:29.765Z",
       "checksum": "0a751e534823a726ea73315969ca2ed03098356222d299be4e03cc72643f0ba5"
     }
   },
@@ -1078,7 +1078,7 @@
       "ID": "B06CEBCC-6E77-44D5-A6F7-22B5280682FB"
     },
     "sync": {
-      "lastModified": "2026-08-10T02:01:38.451Z",
+      "lastModified": "2026-08-10T20:59:29.779Z",
       "checksum": "2a3f43299e9c3c0c70ad374bae962c48e2bd26304d6ef708fc255d717cf7deec"
     }
   },
@@ -1101,7 +1101,7 @@
       "ID": "50F6847B-8CC8-4A37-A1E9-B5B099A4A624"
     },
     "sync": {
-      "lastModified": "2026-08-10T02:01:38.476Z",
+      "lastModified": "2026-08-10T20:59:29.794Z",
       "checksum": "768cf6645f90b93133b2e99e22f97728fcf9693ca3a9d322788f43613487045b"
     }
   },
@@ -1124,7 +1124,7 @@
       "ID": "03258BA8-AE20-4CB3-82F3-38FDE3D1F411"
     },
     "sync": {
-      "lastModified": "2026-08-10T02:01:38.517Z",
+      "lastModified": "2026-08-10T20:59:29.807Z",
       "checksum": "9d3d34bca612c624f85b5da4d0f36861a8d7b878a99f6a4bcca6430d38ff53fa"
     }
   },
@@ -1147,7 +1147,7 @@
       "ID": "DA3F3EEF-7842-4916-8420-03C5AEF590F6"
     },
     "sync": {
-      "lastModified": "2026-08-10T02:01:38.565Z",
+      "lastModified": "2026-08-10T20:59:29.819Z",
       "checksum": "06bc0ec42d7e7154fea063486a3c6cdf66e2227425aca03a2b23ed238a616192"
     }
   },
@@ -1170,7 +1170,7 @@
       "ID": "5FC2F4F5-E4DC-44DF-8C79-342F30E1BD9F"
     },
     "sync": {
-      "lastModified": "2026-08-10T02:01:38.603Z",
+      "lastModified": "2026-08-10T20:59:29.852Z",
       "checksum": "4d863211e352e257545a4ac93ef8ccd5a528bc7e5db46e9ad58af064e442a0c0"
     }
   },
@@ -1193,7 +1193,7 @@
       "ID": "35C910E5-D02B-4A80-B55A-79D704F953AC"
     },
     "sync": {
-      "lastModified": "2026-08-10T02:01:38.638Z",
+      "lastModified": "2026-08-10T20:59:29.866Z",
       "checksum": "2af7533bcf1a692a46538e67e7b18438d164bfa7ce10d555557d60635bbec4b9"
     }
   },
@@ -1216,7 +1216,7 @@
       "ID": "36872673-831A-4674-ADD4-EC845E4D1D35"
     },
     "sync": {
-      "lastModified": "2026-08-10T02:01:38.680Z",
+      "lastModified": "2026-08-10T20:59:29.880Z",
       "checksum": "6cce48acd92e1da5b48106e974ff281d6d84ba2198ce915f7569a4ba1b57040a"
     }
   },
@@ -1240,7 +1240,7 @@
       "ID": "F4F903C9-6296-408B-BA8F-397EE205C220"
     },
     "sync": {
-      "lastModified": "2026-08-10T02:01:38.727Z",
+      "lastModified": "2026-08-10T20:59:29.895Z",
       "checksum": "a5c26985478598ed83d2fd98cb367f844ed54c4e8e76c576de622bcc3f11a5f0"
     }
   },
@@ -1263,7 +1263,7 @@
       "ID": "4C91B175-C4D7-4A74-8C70-44E247BA1799"
     },
     "sync": {
-      "lastModified": "2026-08-10T02:01:38.780Z",
+      "lastModified": "2026-08-10T20:59:29.909Z",
       "checksum": "394fa0567341b3242fb21d1aca9a4f4fcbf850defc14b84eb4cfcfdfff2c4761"
     }
   },
@@ -1286,7 +1286,7 @@
       "ID": "EAAD9641-6DDE-4D2B-88E7-D1CC2E5EEB54"
     },
     "sync": {
-      "lastModified": "2026-08-10T02:01:38.850Z",
+      "lastModified": "2026-08-10T20:59:29.924Z",
       "checksum": "6c9040b908982af382a05960ffb1b33c7924bf75ded223e1da354e905b71663d"
     }
   },
@@ -1309,7 +1309,7 @@
       "ID": "9D4E86D9-C42C-49D1-88BF-6599F4793259"
     },
     "sync": {
-      "lastModified": "2026-08-10T02:01:38.900Z",
+      "lastModified": "2026-08-10T20:59:29.938Z",
       "checksum": "64ec51f9c85f904d1d2e1ee334d796f2e2a39f033898025308ee3b47e4be7408"
     }
   },
@@ -1332,7 +1332,7 @@
       "ID": "C8B095F0-C48A-4BDC-B7F5-80AF88D9959C"
     },
     "sync": {
-      "lastModified": "2026-08-10T02:01:38.932Z",
+      "lastModified": "2026-08-10T20:59:29.953Z",
       "checksum": "d69d57a0a13b3c9d254963e7c945bf1c745dc809bcc52cf15570900f959e5a1c"
     }
   },
@@ -1355,7 +1355,7 @@
       "ID": "C9D5DD5C-EE16-4923-9BA0-13C6BF60A783"
     },
     "sync": {
-      "lastModified": "2026-08-10T02:01:38.960Z",
+      "lastModified": "2026-08-10T20:59:29.966Z",
       "checksum": "0a3c9498e08f813aebc890486b402914005731e091c18df65712e07c8691316e"
     }
   },
@@ -1378,7 +1378,7 @@
       "ID": "DC4D28A0-1795-4356-B01A-47111091F600"
     },
     "sync": {
-      "lastModified": "2026-08-10T02:01:38.988Z",
+      "lastModified": "2026-08-10T20:59:29.978Z",
       "checksum": "67ea3546cf896e606c82f4cbdaab5105acfff5db8917ed690fbad481c200a57c"
     }
   },
@@ -1401,7 +1401,7 @@
       "ID": "10902F3E-4269-4ADF-9273-AC57B026BA10"
     },
     "sync": {
-      "lastModified": "2026-08-10T02:01:39.065Z",
+      "lastModified": "2026-08-10T20:59:30.009Z",
       "checksum": "4eb0c0758944ecc678bb393f9d4dddcfe7775bb9223ea42b06ffcd55e2e48002"
     }
   },
@@ -1424,7 +1424,7 @@
       "ID": "3EBBE165-3AB4-45F8-B8F7-685AB208DA53"
     },
     "sync": {
-      "lastModified": "2026-08-10T02:01:39.092Z",
+      "lastModified": "2026-08-10T20:59:30.024Z",
       "checksum": "41db552de325203720ceedd7f79b1e7d4a4d082d6c971daaf141b2b691e7f209"
     }
   },
@@ -1447,7 +1447,7 @@
       "ID": "1213DA27-4496-4E88-B3F0-1E1F67D6735F"
     },
     "sync": {
-      "lastModified": "2026-08-10T02:01:39.131Z",
+      "lastModified": "2026-08-10T20:59:30.038Z",
       "checksum": "82d66d530475028f780153815164dff11e817931f9ed376bbc3a46c5383da4b6"
     }
   },
@@ -1470,7 +1470,7 @@
       "ID": "6B084DF6-831F-47F5-8966-68699D46B7D7"
     },
     "sync": {
-      "lastModified": "2026-08-10T02:01:39.183Z",
+      "lastModified": "2026-08-10T20:59:30.051Z",
       "checksum": "9311c4fe1f80ecdf16514107d98c523180ea5a05f89756c950af82f91808cb86"
     }
   },
@@ -1493,7 +1493,7 @@
       "ID": "49C26709-C626-4786-9A24-F885E4A232B1"
     },
     "sync": {
-      "lastModified": "2026-08-10T02:01:39.223Z",
+      "lastModified": "2026-08-10T20:59:30.064Z",
       "checksum": "fc3d6718183fabaa021a87bc4fe22c2eb901815d89bb87ded685ab380dd8213b"
     }
   },
@@ -1516,7 +1516,7 @@
       "ID": "D18C4017-812F-4C3D-B806-2947B92C7E24"
     },
     "sync": {
-      "lastModified": "2026-08-10T02:01:39.246Z",
+      "lastModified": "2026-08-10T20:59:30.078Z",
       "checksum": "2f366ebc8a79475cec345107c0f460f06c9ea152eebd31d0f6a110cba09396e9"
     }
   },
@@ -1539,7 +1539,7 @@
       "ID": "3A4E05E7-040D-480C-A571-FB79D4B14EED"
     },
     "sync": {
-      "lastModified": "2026-08-10T02:01:39.290Z",
+      "lastModified": "2026-08-10T20:59:30.092Z",
       "checksum": "685e4345ae8c39cddf56489e609b43ff799c303eda95bcf57fae364cbae177a0"
     }
   },
@@ -1562,7 +1562,7 @@
       "ID": "9013B954-77E8-4085-9300-92306D656210"
     },
     "sync": {
-      "lastModified": "2026-08-10T02:01:39.320Z",
+      "lastModified": "2026-08-10T20:59:30.105Z",
       "checksum": "9a9c746dfb7f84a207eaacfa401b9fb670a2dc4e79fc47da8b3b284d984f9497"
     }
   },
@@ -1585,7 +1585,7 @@
       "ID": "ECD03116-DACD-4A97-9295-10A076CF5FF6"
     },
     "sync": {
-      "lastModified": "2026-08-10T02:01:39.361Z",
+      "lastModified": "2026-08-10T20:59:30.119Z",
       "checksum": "9a43d4b56d7f792ec150e30b55e4640092708ff2b41c49c8f32dfa57f21ad10f"
     }
   },
@@ -1608,7 +1608,7 @@
       "ID": "3B73EEEA-6FC8-4053-A0CE-A2C22FBF6FA3"
     },
     "sync": {
-      "lastModified": "2026-08-10T02:01:39.387Z",
+      "lastModified": "2026-08-10T20:59:30.132Z",
       "checksum": "b6f7599c38db26a9d862c6c57162dda9c8af74287e07b09fcd6245ba789bcf81"
     }
   },
@@ -1631,7 +1631,7 @@
       "ID": "6F9D9FB3-5CE7-45EA-80A2-6D39B32086B4"
     },
     "sync": {
-      "lastModified": "2026-08-10T02:01:39.448Z",
+      "lastModified": "2026-08-10T20:59:30.168Z",
       "checksum": "697fa2e0cf67223a165bb89ea5ba5b67d42a44a4bffec8184097d5fa9fbe51c9"
     }
   },
@@ -1654,7 +1654,7 @@
       "ID": "51953C1B-9EE4-4AFB-972F-2EBF38CCCA3E"
     },
     "sync": {
-      "lastModified": "2026-08-10T02:01:39.472Z",
+      "lastModified": "2026-08-10T20:59:30.183Z",
       "checksum": "27128035d9397e5abbfc93d868690939178a311843789be6c406d4a96af07428"
     }
   },
@@ -1677,7 +1677,7 @@
       "ID": "01D3FB65-1CD0-47F7-90AF-1DEFA72C0EC9"
     },
     "sync": {
-      "lastModified": "2026-08-10T02:01:39.496Z",
+      "lastModified": "2026-08-10T20:59:30.198Z",
       "checksum": "6485f1b616d76587a993a07dc51dd28e4e752332481a018ba538821f798bf42c"
     }
   },
@@ -1700,7 +1700,7 @@
       "ID": "05EDF06F-2D13-464E-AE0A-BA70A07C88E2"
     },
     "sync": {
-      "lastModified": "2026-08-10T02:01:39.532Z",
+      "lastModified": "2026-08-10T20:59:30.212Z",
       "checksum": "07370be75e69ab8940e6fa5c245dba6ad5122348b1c3ba78417104b8c22f2ae2"
     }
   },
@@ -1723,7 +1723,7 @@
       "ID": "CB5AA463-08E2-48AB-A0A4-3B9E022F028F"
     },
     "sync": {
-      "lastModified": "2026-08-10T02:01:39.570Z",
+      "lastModified": "2026-08-10T20:59:30.226Z",
       "checksum": "6348aae660273b641a13abba2fb1a858574dc526c9354290e0aeb24c816078dd"
     }
   },
@@ -1746,7 +1746,7 @@
       "ID": "DE1800E9-5EAD-439B-A851-FA0CAE284E69"
     },
     "sync": {
-      "lastModified": "2026-08-10T02:01:39.646Z",
+      "lastModified": "2026-08-10T20:59:30.240Z",
       "checksum": "f9e83b96032843c793d32a172fc5179033c4dd26d4c3f17f9e5ddc375afa1f8f"
     }
   },
@@ -1769,7 +1769,7 @@
       "ID": "9D99DD47-8443-4A89-B9A7-FD747672B912"
     },
     "sync": {
-      "lastModified": "2026-08-10T02:01:39.721Z",
+      "lastModified": "2026-08-10T20:59:30.254Z",
       "checksum": "544ac39bcfafafd73ad2f299836870b55ebebd3ac28873397a2c8d68d1f8fcae"
     }
   },
@@ -1792,7 +1792,7 @@
       "ID": "47F34437-E092-40BC-B576-758B1D7BC0C3"
     },
     "sync": {
-      "lastModified": "2026-08-10T02:01:39.696Z",
+      "lastModified": "2026-08-10T20:59:30.269Z",
       "checksum": "d7784b1c00e2d477f394296ccab443a141e317fe25ef1b37075b3ef1a1ea9a8d"
     }
   }

--- a/packages/AI/Agents/src/MJAIAgentRequestEntityServer.ts
+++ b/packages/AI/Agents/src/MJAIAgentRequestEntityServer.ts
@@ -38,11 +38,20 @@ export class MJAIAgentRequestEntityServer extends MJAIAgentRequestEntity {
         // 1. Status transitioned from 'Requested' to a responded status
         // 2. There's an originating run to resume from
         // 3. No resuming run has been created yet (guard against re-trigger)
+        // 4. It is not a WORKFLOW approval. A request raised by a task graph carries
+        //    OriginatingTaskID, and resuming is exactly the wrong thing for it: the graph OUTLIVES
+        //    the run that submitted it, so nothing is suspended and nothing needs resuming — the
+        //    dispatcher settles the waiting task and releases its dependents on the next poll.
+        //    Resuming re-runs the Flow agent, which submits a BRAND-NEW graph, which raises its own
+        //    new approval. Every dashboard or API approval would both settle the step (correct) and
+        //    silently start a duplicate execution — observed in the wild: approving one request at
+        //    13:56 produced a second, unasked-for graph at 14:05.
         const shouldResume =
             wasRequested &&
             isNowResponded &&
             this.OriginatingAgentRunID != null &&
-            this.ResumingAgentRunID == null;
+            this.ResumingAgentRunID == null &&
+            this.OriginatingTaskID == null;
 
         if (shouldResume) {
             // Fire-and-forget: don't block the save response

--- a/packages/AI/CorePlus/src/__tests__/flow-graph-compiler.test.ts
+++ b/packages/AI/CorePlus/src/__tests__/flow-graph-compiler.test.ts
@@ -71,15 +71,22 @@ describe('phase 1 — exclusion', () => {
 });
 
 describe('phase 2 — single entry', () => {
-    it('takes the alphabetically-first starting step, matching the walker', () => {
+    it('takes the alphabetically-first starting step, and REFUSES the orphaned one', () => {
         const res = CompileFlowToTaskGraph(
             [step({ ID: 'z', Name: 'Zebra', StartingStep: true }), step({ ID: 'a', Name: 'Apple', StartingStep: true })],
             [],
             options,
         );
         // Apple is the entry; Zebra is not reachable from it and is pruned rather than becoming a
-        // second root that runs work the flow never ran.
-        expect(res.Spec!.tasks.map((t) => t.tempId)).toEqual(['a']);
+        // second root that runs work the flow never ran. That much is unchanged.
+        //
+        // What changed is that this now FAILS to compile. It used to succeed, quietly shipping a
+        // workflow missing a step its author had explicitly marked as an entry — which is how the
+        // Content Pipeline demo drafted from half its research for its entire life, with nothing
+        // anywhere reporting a problem. Refusing at submission, before anything runs, is strictly
+        // better than running half a workflow and reporting success.
+        expect(res.Success).toBe(false);
+        expect(res.Errors.map((e) => e.Code)).toContain('UnreachableStartingStep');
         expect(res.Excluded).toContainEqual({ StepID: 'z', Reason: 'Unreachable' });
     });
 
@@ -362,5 +369,44 @@ describe('human steps', () => {
         // Dependencies normalize to objects, so the assertion is on the id they carry.
         const deps = depsOf(res.Spec!, 'w').map((d) => (typeof d === 'string' ? d : (d as { tempId: string }).tempId));
         expect(deps).toContain('h');
+    });
+});
+
+describe('a second starting step is reported, not silently dropped', () => {
+    it('names the step that would never run', () => {
+        // A workflow has ONE entry. A step flagged as a second one is pruned as unreachable — and
+        // pruning it in silence is how a workflow ships with half its work missing while looking
+        // complete on the canvas. The Content Pipeline demo lived that: its second research step
+        // was dropped, the join it fed had one input instead of two, and every draft was written
+        // from half the evidence with nothing anywhere saying so.
+        const res = CompileFlowToTaskGraph(
+            [
+                step({ ID: 'a', Name: 'A first', StartingStep: true }),
+                step({ ID: 'b', Name: 'B second', StartingStep: true }),
+            ],
+            [],
+            options,
+        );
+
+        const unreachable = res.Errors.filter((e) => e.Code === 'UnreachableStartingStep');
+        expect(unreachable).toHaveLength(1);
+        expect(unreachable[0].Message).toContain('B second');
+        expect(unreachable[0].Message).toContain('A first');   // says where it DOES begin
+    });
+
+    it('stays quiet when the second starting step is reachable from the entry', () => {
+        // Wired into the flow, it runs — the flag is redundant but harmless, and warning here would
+        // train people to ignore the message that matters.
+        const res = CompileFlowToTaskGraph(
+            [
+                step({ ID: 'a', Name: 'A first', StartingStep: true }),
+                step({ ID: 'b', Name: 'B second', StartingStep: true }),
+            ],
+            [path({ ID: 'p', OriginStepID: 'a', DestinationStepID: 'b' })],
+            options,
+        );
+
+        expect(res.Errors.filter((e) => e.Code === 'UnreachableStartingStep')).toHaveLength(0);
+        expect(res.Spec!.tasks.map((t) => t.tempId).sort()).toEqual(['a', 'b']);
     });
 });

--- a/packages/AI/CorePlus/src/__tests__/graph-algorithms-skipped.test.ts
+++ b/packages/AI/CorePlus/src/__tests__/graph-algorithms-skipped.test.ts
@@ -194,3 +194,37 @@ describe('handled failures do not block dependents', () => {
         expect(ComputeTasksToBlock([n('f', 'Failed'), n('d')], [e('d', 'f')], new Set(['f']))).toEqual([]);
     });
 });
+
+describe('a handled failure releases its recovery path', () => {
+    it('makes the recovery target eligible when the failure is handled', () => {
+        // Under failureSemantics 'edges', a Failed origin with a satisfied outgoing edge is a
+        // HANDLED failure: the author drew a way out and it is live. Its target was previously
+        // neither Blocked (handled failures are excluded from blocking) nor Skipped nor eligible —
+        // so the graph sat In Progress forever. Before the recovery machinery existed it at least
+        // settled Failed; turning a wrong answer into NO answer is worse.
+        const nodes = [n('risky', 'Failed'), n('recover')];
+        const edges = [e('recover', 'risky')];
+
+        expect(ComputeEligibleTasks(nodes, edges)).toHaveLength(0);
+        expect(ComputeEligibleTasks(nodes, edges, new Set(['risky'])).map((x) => x.id)).toEqual(['recover']);
+    });
+
+    it('leaves an UNhandled failure blocking, which is the whole point of the distinction', () => {
+        // Nobody drew a recovery route here, so the failure is terminal for its dependents. If this
+        // released too, a graph would sail past every failure it never anticipated.
+        const nodes = [n('risky', 'Failed'), n('after')];
+        const edges = [e('after', 'risky')];
+
+        expect(ComputeEligibleTasks(nodes, edges, new Set(['someone-else']))).toHaveLength(0);
+    });
+
+    it('still requires the OTHER prerequisites to be satisfied', () => {
+        // A handled failure satisfies its own edge, not the node's other edges.
+        const nodes = [n('risky', 'Failed'), n('slow', 'Pending'), n('recover')];
+        const edges = [e('recover', 'risky'), e('recover', 'slow')];
+
+        // `slow` is itself eligible — it has no prerequisites. The assertion is about `recover`.
+        const eligible = ComputeEligibleTasks(nodes, edges, new Set(['risky'])).map((x) => x.id);
+        expect(eligible).not.toContain('recover');
+    });
+});

--- a/packages/AI/CorePlus/src/task-graph/flow-graph-compiler.ts
+++ b/packages/AI/CorePlus/src/task-graph/flow-graph-compiler.ts
@@ -100,7 +100,7 @@ export type FlowCompilerOptions = {
 
 /** Why a flow could not be compiled, in workflow vocabulary (D18 — never graph/DAG/node). */
 export type FlowCompileError = {
-    Code: 'NoStartingStep' | 'LoopDetected' | 'UnresolvedReference' | 'UnsupportedStepType';
+    Code: 'NoStartingStep' | 'UnreachableStartingStep' | 'LoopDetected' | 'UnresolvedReference' | 'UnsupportedStepType';
     Message: string;
     /** The offending step, when attributable. */
     StepID?: string;
@@ -157,6 +157,26 @@ export function CompileFlowToTaskGraph(
     const reachable = computeReachable(entry.ID, livePaths);
     const compiledSteps = active.filter((s) => reachable.has(s.ID));
     for (const s of active) if (!reachable.has(s.ID)) excluded.push({ StepID: s.ID, Reason: 'Unreachable' });
+
+    // A step the author explicitly marked as a STARTING step, dropped for being unreachable, is
+    // reported rather than quietly excluded. Everything else pruned here was simply not wired up;
+    // this one was wired up *as an entry point* and the single-entry rule overruled it. Staying
+    // silent is how a workflow ships with half its work missing while looking correct on the canvas
+    // — which is exactly what happened to the Content Pipeline demo: its second research step was
+    // pruned, the join it fed had one input instead of two, and every draft was written from half
+    // the evidence. Nothing anywhere said so.
+    for (const s of startingSteps) {
+        if (reachable.has(s.ID)) continue;
+        errors.push({
+            Code: 'UnreachableStartingStep',
+            Message:
+                `Step "${s.Name}" is marked as a starting step, but this workflow begins at ` +
+                `"${entry.Name}" and nothing leads from there to it, so it would never run. ` +
+                `A workflow has ONE starting step: connect "${s.Name}" into the flow, or make it ` +
+                `the starting step instead.`,
+            StepID: s.ID,
+        });
+    }
 
     const compiledIDs = new Set(compiledSteps.map((s) => s.ID));
     const compiledPaths = livePaths.filter((p) => compiledIDs.has(p.OriginStepID) && compiledIDs.has(p.DestinationStepID));

--- a/packages/AI/CorePlus/src/task-graph/graph-algorithms.ts
+++ b/packages/AI/CorePlus/src/task-graph/graph-algorithms.ts
@@ -176,7 +176,8 @@ export function FindUnknownDependencyRefs(
  */
 export function ComputeEligibleTasks(
     nodes: readonly TaskGraphNode[],
-    edges: readonly TaskGraphEdge[]
+    edges: readonly TaskGraphEdge[],
+    handledFailureIDs: ReadonlySet<string> = new Set()
 ): TaskGraphNode[] {
     const statusById = new Map(nodes.map((n) => [n.id, n.status]));
     const prerequisites = buildDependsOnAdjacency(edges.filter(isGatingEdge));
@@ -186,9 +187,16 @@ export function ComputeEligibleTasks(
         const deps = prerequisites.get(node.id) ?? [];
         // Skipped satisfies: a join downstream of an exclusive fork is reached by whichever branch
         // ran, and the branches that did not run must not hold it hostage forever.
+        //
+        // A HANDLED failure satisfies too, and without that a recovery path is unreachable: under
+        // `failureSemantics: 'edges'` a Failed origin with a satisfied outgoing edge is not Blocked
+        // and not Skipped, so its target was never blocked, never skipped, and never ELIGIBLE. The
+        // graph sat In Progress forever. Before the failure-semantics work it at least settled
+        // Failed; the recovery machinery turned a wrong answer into no answer, which is worse.
         return deps.every((depId) => {
             const st = statusById.get(depId);
-            return st !== undefined && SATISFIES_DEPENDENT.has(st);
+            if (st === undefined) return false;
+            return SATISFIES_DEPENDENT.has(st) || (st === 'Failed' && handledFailureIDs.has(depId));
         });
     });
 }

--- a/packages/Angular/Explorer/core-entity-forms/src/lib/custom/ai-agent-run/__tests__/real-run-trees.test.ts
+++ b/packages/Angular/Explorer/core-entity-forms/src/lib/custom/ai-agent-run/__tests__/real-run-trees.test.ts
@@ -43,9 +43,14 @@ describe('real Content Pipeline run', () => {
         const items = ProjectRunTreeToTimeline(treeFor('Content Pipeline'));
         const byTitle = new Map(items.map((i) => [i.title, i]));
 
-        // These are MJ: Tasks rows. Before the tree they appeared in NO timeline at all.
-        expect(byTitle.get('Draft the piece')?.type).toBe('task');
-        expect(byTitle.get('Review against brand rules')?.type).toBe('task');
+        // These are MJ: Tasks rows. Before the tree they appeared in NO timeline at all — and when
+        // they first did, they all rendered as a generic 'task', throwing away the action and prompt
+        // displayers every other row gets. A workflow step that runs a prompt IS a prompt.
+        expect(byTitle.get('Draft the piece')?.type).toBe('prompt');
+        expect(byTitle.get('Research: broad')?.type).toBe('action');
+        // What marks them as dispatcher work is provenance, not a different row type.
+        expect(byTitle.get('Draft the piece')?.provenance).toBe('workflow');
+        expect(byTitle.get('Review against brand rules')?.provenance).toBe('workflow');
         expect(byTitle.get('Draft the piece')!.level).toBeGreaterThan(byTitle.get('Content Pipeline')!.level);
     });
 

--- a/packages/Angular/Explorer/core-entity-forms/src/lib/custom/ai-agent-run/__tests__/run-tree-timeline-projection.test.ts
+++ b/packages/Angular/Explorer/core-entity-forms/src/lib/custom/ai-agent-run/__tests__/run-tree-timeline-projection.test.ts
@@ -25,6 +25,7 @@ function node(partial: Partial<AgentRunTreeNode> & { NodeID: string }): AgentRun
         Cost: partial.Cost ?? null,
         Tokens: partial.Tokens ?? null,
         SourceEntity: partial.SourceEntity ?? 'MJ: AI Agent Run Steps',
+        SourceKind: partial.SourceKind ?? null,
         SourceID: partial.SourceID ?? partial.NodeID,
         Children: partial.Children ?? [],
     } as AgentRunTreeNode;
@@ -97,6 +98,8 @@ describe('ProjectRunTreeToTimeline', () => {
         const items = ProjectRunTreeToTimeline(sampleTree());
         const types = Object.fromEntries(items.map((i) => [i.id, i.type]));
 
+        // Tasks map onto the SAME row vocabulary as run steps, so they pick up the same displayers.
+        // These fixtures carry no SourceKind, so they fall back to the generic row type.
         expect(types).toEqual({
             run: 'subrun',
             step: 'step',
@@ -105,6 +108,25 @@ describe('ProjectRunTreeToTimeline', () => {
             'task-b': 'task',
             subrun: 'subrun',
         });
+    });
+
+    it('renders a task by its KIND, so an action gets the action displayer', () => {
+        const tree = node({
+            NodeID: 'g', NodeType: 'TaskGraph', Name: 'Graph',
+            Children: [
+                node({ NodeID: 'a', NodeType: 'Task', Name: 'Search', SourceKind: 'Action' }),
+                node({ NodeID: 'p', NodeType: 'Task', Name: 'Draft', SourceKind: 'Prompt' }),
+                node({ NodeID: 's', NodeType: 'Task', Name: 'Delegate', SourceKind: 'Agent' }),
+            ],
+        });
+        const items = ProjectRunTreeToTimeline(tree);
+        const typeOf = (id: string) => items.find((i) => i.id === id)?.type;
+
+        expect(typeOf('a')).toBe('action');
+        expect(typeOf('p')).toBe('prompt');
+        expect(typeOf('s')).toBe('subrun');
+        // …while still being marked as dispatcher work.
+        expect(items.filter((i) => i.provenance === 'workflow')).toHaveLength(4);
     });
 
     it('can splice a subtree under an existing row', () => {

--- a/packages/Angular/Explorer/core-entity-forms/src/lib/custom/ai-agent-run/ai-agent-run-step-node.component.css
+++ b/packages/Angular/Explorer/core-entity-forms/src/lib/custom/ai-agent-run/ai-agent-run-step-node.component.css
@@ -230,15 +230,18 @@
 /* Dispatcher provenance.
    A workflow step ran on the task-graph dispatcher and OUTLIVES the agent run that submitted it —
    genuinely a different thing from a step the run executed itself. Someone reading a failure needs
-   to know which they are looking at before they know where to go next, so the two are visually
-   distinct rather than differing only by an icon. The graph header carries the tint; its steps carry
-   the rail, so a run reads as "everything under this line is dispatcher work". */
+   to know which they are looking at before they know where to go next.
+
+   Keyed on PROVENANCE rather than on type, so a workflow's action still renders as an action —
+   same icon, same status treatment, same navigation as every other action row — and merely carries
+   the rail that says where it ran. Keying this on type is what turned every workflow step into an
+   undifferentiated box and threw away the displayer it should have had. */
 .timeline-item[data-type="taskgraph"] {
   border-left: 3px solid var(--mj-status-info);
   background: color-mix(in srgb, var(--mj-status-info) 6%, var(--mj-bg-surface));
 }
 
-.timeline-item[data-type="task"] {
+.timeline-item[data-provenance="workflow"]:not([data-type="taskgraph"]) {
   border-left: 3px solid color-mix(in srgb, var(--mj-status-info) 55%, transparent);
 }
 /* ============================================================

--- a/packages/Angular/Explorer/core-entity-forms/src/lib/custom/ai-agent-run/ai-agent-run-step-node.component.html
+++ b/packages/Angular/Explorer/core-entity-forms/src/lib/custom/ai-agent-run/ai-agent-run-step-node.component.html
@@ -2,6 +2,7 @@
   [class.selected]="isSelected"
   [attr.data-status]="item.status"
   [attr.data-type]="item.type"
+  [attr.data-provenance]="item.provenance"
   [style.margin-left.px]="item.level * 24"
   (click)="handleClick()">
 

--- a/packages/Angular/Explorer/core-entity-forms/src/lib/custom/ai-agent-run/ai-agent-run-step-node.component.ts
+++ b/packages/Angular/Explorer/core-entity-forms/src/lib/custom/ai-agent-run/ai-agent-run-step-node.component.ts
@@ -27,10 +27,11 @@ export class AIAgentRunStepNodeComponent {
   }
 
   get isParentStep(): boolean {
-    // Check if this step has children via ParentID relationships (non-Sub-Agent hierarchy)
-    return this.item.type === 'step' &&
-           this.item.data?.StepType !== 'Sub-Agent' &&
-           this.hasChildren;
+    // STRUCTURAL, not type-gated. Anything holding children can be opened — a loop's iterations, a
+    // workflow's steps, a nested run. The old test required `type === 'step'`, so a ForEach that
+    // came from a task graph rendered its children into the model and then offered no way to reach
+    // them: the work existed, was loaded, and was unreachable.
+    return !this.isSubAgent && this.hasChildren;
   }
 
   get canExpand(): boolean {

--- a/packages/Angular/Explorer/core-entity-forms/src/lib/custom/ai-agent-run/ai-agent-run-timeline.component.ts
+++ b/packages/Angular/Explorer/core-entity-forms/src/lib/custom/ai-agent-run/ai-agent-run-timeline.component.ts
@@ -19,6 +19,14 @@ export interface TimelineItem {
    * and colour-coded so their provenance is visible without opening anything.
    */
   type: 'step' | 'subrun' | 'action' | 'prompt' | 'taskgraph' | 'task';
+  /**
+   * Where this row's work ran, when that is not obvious from its type.
+   *
+   * `'workflow'` means it ran on the task-graph dispatcher and outlives the agent run that
+   * submitted it. Kept separate from `type` on purpose: a workflow step that runs an action IS an
+   * action and should render as one — provenance styles it, it does not redefine it.
+   */
+  provenance?: 'workflow';
   title: string;
   subtitle: string;
   status: string;

--- a/packages/Angular/Explorer/core-entity-forms/src/lib/custom/ai-agent-run/run-tree-timeline-projection.ts
+++ b/packages/Angular/Explorer/core-entity-forms/src/lib/custom/ai-agent-run/run-tree-timeline-projection.ts
@@ -33,13 +33,42 @@ const NODE_PRESENTATION: Record<AgentRunTreeNodeType, { icon: string; color: str
     Task: { icon: 'fa-solid fa-diagram-next', color: 'var(--mj-color-info)' },
 };
 
-/** The timeline's item type for each tree node kind. */
+/**
+ * The timeline's item type for each tree node kind.
+ *
+ * A `Task` deliberately does NOT get its own row type. A workflow step that runs an action IS an
+ * action, and rendering it as a generic "workflow step" threw away the action displayer — icon,
+ * status treatment, navigation — that every other action row in the timeline already gets. Tasks map
+ * onto the SAME vocabulary as run steps and pick up the same presentation; what marks them as
+ * dispatcher work is `provenance`, which styles them without changing what they are.
+ */
 const NODE_ITEM_TYPE: Record<AgentRunTreeNodeType, TimelineItem['type']> = {
     Run: 'subrun',
     Step: 'step',
+    // The graph itself keeps a distinct type — it is a container, not a step, and the visual break
+    // between "the run" and "the workflow it submitted" is worth preserving.
     TaskGraph: 'taskgraph',
     Task: 'task',
 };
+
+/** A task's own kind, mapped onto the row types the timeline already knows how to render. */
+const TASK_KIND_TO_ITEM_TYPE: Record<string, TimelineItem['type']> = {
+    Action: 'action',
+    Prompt: 'prompt',
+    Agent: 'subrun',
+    ForEach: 'step',
+    While: 'step',
+    Human: 'step',
+    External: 'step',
+};
+
+/** The row type for a node: a task by its kind, anything else by its structural role. */
+function itemTypeOf(node: AgentRunTreeNode): TimelineItem['type'] {
+    if (node.NodeType === 'Task' && node.SourceKind) {
+        return TASK_KIND_TO_ITEM_TYPE[node.SourceKind] ?? 'task';
+    }
+    return NODE_ITEM_TYPE[node.NodeType] ?? 'step';
+}
 
 /**
  * Flattens a run tree into timeline rows, in display order.
@@ -83,7 +112,10 @@ function toTimelineItem(node: AgentRunTreeNode, level: number, parentID: string 
 
     return {
         id: node.NodeID,
-        type: NODE_ITEM_TYPE[node.NodeType] ?? 'step',
+        type: itemTypeOf(node),
+        // Marks the row as dispatcher work WITHOUT changing what it is. Styling keys off this, so a
+        // workflow's action still renders as an action and still reads as part of the workflow.
+        provenance: node.NodeType === 'Task' || node.NodeType === 'TaskGraph' ? 'workflow' : undefined,
         title: node.Name,
         subtitle: describeNode(node),
         status: node.Status,
@@ -116,7 +148,9 @@ function describeNode(node: AgentRunTreeNode): string {
             parts.push('Workflow — runs on the dispatcher');
             break;
         case 'Task':
-            parts.push('Workflow step');
+            // Names the kind rather than saying "workflow step" for all of them. "Action" or
+            // "Prompt" is what a reader needs; the provenance styling already says it is workflow.
+            parts.push(node.SourceKind ? `${node.SourceKind} step` : 'Workflow step');
             break;
         case 'Run':
             parts.push('Agent run');

--- a/packages/Angular/Explorer/core-entity-forms/src/lib/generated/Entities/MJAIAgentRequest/mjaiagentrequest.form.component.html
+++ b/packages/Angular/Explorer/core-entity-forms/src/lib/generated/Entities/MJAIAgentRequest/mjaiagentrequest.form.component.html
@@ -188,6 +188,15 @@
             [FormContext]="formContext"
             LinkType="Record"
         ></mj-form-field>
+        <mj-form-field 
+            [Record]="record"
+            [ShowLabel]="true"
+            FieldName="OriginatingTaskID"
+            Type="textbox"
+            [EditMode]="EditMode"
+            [FormContext]="formContext"
+            LinkType="Record"
+        ></mj-form-field>
 
     </mj-collapsible-panel>
 

--- a/packages/Angular/Explorer/core-entity-forms/src/lib/generated/Entities/MJAIPrompt/mjaiprompt.form.component.html
+++ b/packages/Angular/Explorer/core-entity-forms/src/lib/generated/Entities/MJAIPrompt/mjaiprompt.form.component.html
@@ -1038,6 +1038,31 @@
         }
     </mj-collapsible-panel>
 
+    <!-- Tasks Section -->
+    <mj-collapsible-panel
+        SectionKey="mJTasks"
+        SectionName="Tasks"
+        Icon="fa fa-tasks"
+        Variant="related-entity"
+        [Form]="this"
+        [FormContext]="formContext"
+        [BadgeCount]="GetSectionRowCount('mJTasks')"
+        [DefaultExpanded]="false">
+        @if (record.IsSaved) {
+        <div>
+            <mj-explorer-entity-data-grid
+                [Params]="BuildRelationshipViewParamsByEntityName('MJ: Tasks','PromptID')"
+                [NewRecordValues]="NewRecordValues('MJ: Tasks')"
+                [AllowLoad]="IsSectionExpanded('mJTasks')"
+                [ShowToolbar]="false"
+                (Navigate)="OnFormNavigate($event)"
+                (AfterDataLoad)="SetSectionRowCount('mJTasks', $event.totalRowCount)"
+                >
+            </mj-explorer-entity-data-grid>
+        </div>
+        }
+    </mj-collapsible-panel>
+
     <mj-form-panel-slot Entity="{{record.EntityInfo.Name}}" Slot="after-related" [Record]="record" [FormComponent]="this" [FormContext]="formContext"></mj-form-panel-slot>
 </mj-record-form-container>
         

--- a/packages/Angular/Explorer/core-entity-forms/src/lib/generated/Entities/MJAIPrompt/mjaiprompt.form.component.ts
+++ b/packages/Angular/Explorer/core-entity-forms/src/lib/generated/Entities/MJAIPrompt/mjaiprompt.form.component.ts
@@ -42,7 +42,8 @@ export class MJAIPromptFormComponent extends BaseFormComponent {
             { sectionKey: 'mJScopedPromptConfigs', sectionName: 'Scoped Prompt Configs', isExpanded: false },
             { sectionKey: 'mJAIAgentsConversationSummaryPromptID', sectionName: 'AI Agents (Conversation Summary Prompt ID)', isExpanded: false },
             { sectionKey: 'mJAIAgentTypesContextCompressionPromptID', sectionName: 'AI Agent Types (Context Compression Prompt ID)', isExpanded: false },
-            { sectionKey: 'mJAIAgentTypesConversationSummaryPromptID', sectionName: 'AI Agent Types (Conversation Summary Prompt ID)', isExpanded: false }
+            { sectionKey: 'mJAIAgentTypesConversationSummaryPromptID', sectionName: 'AI Agent Types (Conversation Summary Prompt ID)', isExpanded: false },
+            { sectionKey: 'mJTasks', sectionName: 'Tasks', isExpanded: false }
         ]);
     }
 }

--- a/packages/Angular/Explorer/core-entity-forms/src/lib/generated/Entities/MJActionExecutionLog/mjactionexecutionlog.form.component.html
+++ b/packages/Angular/Explorer/core-entity-forms/src/lib/generated/Entities/MJActionExecutionLog/mjactionexecutionlog.form.component.html
@@ -14,7 +14,7 @@
     <mj-collapsible-panel
         SectionKey="retentionAudit"
         SectionName="Retention & Audit"
-        Icon="fa fa-cog"
+        Icon="fa fa-info-circle"
         [Form]="this"
         [FormContext]="formContext">
         <mj-form-field 
@@ -32,7 +32,7 @@
     <mj-collapsible-panel
         SectionKey="associatedEntities"
         SectionName="Associated Entities"
-        Icon="fa fa-users"
+        Icon="fa fa-info-circle"
         [Form]="this"
         [FormContext]="formContext">
         <mj-form-field 
@@ -53,6 +53,15 @@
             [FormContext]="formContext"
             LinkType="Record"
         ></mj-form-field>
+        <mj-form-field 
+            [Record]="record"
+            [ShowLabel]="true"
+            FieldName="EntityActionID"
+            Type="textbox"
+            [EditMode]="EditMode"
+            [FormContext]="formContext"
+            LinkType="Record"
+        ></mj-form-field>
 
     </mj-collapsible-panel>
 
@@ -60,7 +69,7 @@
     <mj-collapsible-panel
         SectionKey="executionDetails"
         SectionName="Execution Details"
-        Icon="fa fa-tasks"
+        Icon="fa fa-align-left"
         [Form]="this"
         [FormContext]="formContext">
         <mj-form-field 
@@ -83,7 +92,7 @@
             [Record]="record"
             [ShowLabel]="true"
             FieldName="Params"
-            Type="textarea"
+            Type="code"
             [EditMode]="EditMode"
             [FormContext]="formContext"
         ></mj-form-field>
@@ -103,25 +112,6 @@
             [EditMode]="EditMode"
             [FormContext]="formContext"
         ></mj-form-field>
-
-    </mj-collapsible-panel>
-
-    <!-- Details Section -->
-    <mj-collapsible-panel
-        SectionKey="details"
-        SectionName="Details"
-        Icon="fa fa-align-left"
-        [Form]="this"
-        [FormContext]="formContext">
-        <mj-form-field 
-            [Record]="record"
-            [ShowLabel]="true"
-            FieldName="EntityActionID"
-            Type="textbox"
-            [EditMode]="EditMode"
-            [FormContext]="formContext"
-            LinkType="Record"
-        ></mj-form-field>
         <mj-form-field 
             [Record]="record"
             [ShowLabel]="true"
@@ -131,6 +121,24 @@
             [FormContext]="formContext"
             LinkType="Record"
         ></mj-form-field>
+        <mj-form-field 
+            [Record]="record"
+            [ShowLabel]="true"
+            FieldName="ResultParams"
+            Type="code"
+            [EditMode]="EditMode"
+            [FormContext]="formContext"
+        ></mj-form-field>
+
+    </mj-collapsible-panel>
+
+    <!-- Target Record Section -->
+    <mj-collapsible-panel
+        SectionKey="targetRecord"
+        SectionName="Target Record"
+        Icon="fa fa-crosshairs"
+        [Form]="this"
+        [FormContext]="formContext">
         <mj-form-field 
             [Record]="record"
             [ShowLabel]="true"
@@ -145,14 +153,6 @@
             [ShowLabel]="true"
             FieldName="TargetRecordID"
             Type="textbox"
-            [EditMode]="EditMode"
-            [FormContext]="formContext"
-        ></mj-form-field>
-        <mj-form-field 
-            [Record]="record"
-            [ShowLabel]="true"
-            FieldName="ResultParams"
-            Type="textarea"
             [EditMode]="EditMode"
             [FormContext]="formContext"
         ></mj-form-field>

--- a/packages/Angular/Explorer/core-entity-forms/src/lib/generated/Entities/MJActionExecutionLog/mjactionexecutionlog.form.component.ts
+++ b/packages/Angular/Explorer/core-entity-forms/src/lib/generated/Entities/MJActionExecutionLog/mjactionexecutionlog.form.component.ts
@@ -19,7 +19,7 @@ export class MJActionExecutionLogFormComponent extends BaseFormComponent {
             { sectionKey: 'retentionAudit', sectionName: 'Retention & Audit', isExpanded: true },
             { sectionKey: 'associatedEntities', sectionName: 'Associated Entities', isExpanded: true },
             { sectionKey: 'executionDetails', sectionName: 'Execution Details', isExpanded: true },
-            { sectionKey: 'details', sectionName: 'Details', isExpanded: true },
+            { sectionKey: 'targetRecord', sectionName: 'Target Record', isExpanded: true },
             { sectionKey: 'systemMetadata', sectionName: 'System Metadata', isExpanded: false },
             { sectionKey: 'mJProcessRunDetails', sectionName: 'Process Run Details', isExpanded: false },
             { sectionKey: 'mJUserRoutineRuns', sectionName: 'User Routine Runs', isExpanded: false }

--- a/packages/Angular/Explorer/core-entity-forms/src/lib/generated/Entities/MJEntityActionParam/mjentityactionparam.form.component.html
+++ b/packages/Angular/Explorer/core-entity-forms/src/lib/generated/Entities/MJEntityActionParam/mjentityactionparam.form.component.html
@@ -69,19 +69,9 @@
             [EditMode]="EditMode"
             [FormContext]="formContext"
         ></mj-form-field>
-
-    </mj-collapsible-panel>
-
-    <!-- Details Section -->
-    <mj-collapsible-panel
-        SectionKey="details"
-        SectionName="Details"
-        Icon="fa fa-align-left"
-        [Form]="this"
-        [FormContext]="formContext">
         <mj-form-field 
             [Record]="record"
-            [ShowLabel]="false"
+            [ShowLabel]="true"
             FieldName="LogValue"
             Type="checkbox"
             [EditMode]="EditMode"

--- a/packages/Angular/Explorer/core-entity-forms/src/lib/generated/Entities/MJEntityActionParam/mjentityactionparam.form.component.ts
+++ b/packages/Angular/Explorer/core-entity-forms/src/lib/generated/Entities/MJEntityActionParam/mjentityactionparam.form.component.ts
@@ -17,7 +17,6 @@ export class MJEntityActionParamFormComponent extends BaseFormComponent {
         this.initSections([
             { sectionKey: 'identifierRelationships', sectionName: 'Identifier & Relationships', isExpanded: true },
             { sectionKey: 'parameterDefinition', sectionName: 'Parameter Definition', isExpanded: true },
-            { sectionKey: 'details', sectionName: 'Details', isExpanded: true },
             { sectionKey: 'systemMetadata', sectionName: 'System Metadata', isExpanded: false }
         ]);
     }

--- a/packages/Angular/Explorer/core-entity-forms/src/lib/generated/Entities/MJTask/mjtask.form.component.html
+++ b/packages/Angular/Explorer/core-entity-forms/src/lib/generated/Entities/MJTask/mjtask.form.component.html
@@ -342,6 +342,31 @@
         }
     </mj-collapsible-panel>
 
+    <!-- AI Agent Requests Section -->
+    <mj-collapsible-panel
+        SectionKey="mJAIAgentRequests"
+        SectionName="AI Agent Requests"
+        Icon="fa fa-robot"
+        Variant="related-entity"
+        [Form]="this"
+        [FormContext]="formContext"
+        [BadgeCount]="GetSectionRowCount('mJAIAgentRequests')"
+        [DefaultExpanded]="false">
+        @if (record.IsSaved) {
+        <div>
+            <mj-explorer-entity-data-grid
+                [Params]="BuildRelationshipViewParamsByEntityName('MJ: AI Agent Requests','OriginatingTaskID')"
+                [NewRecordValues]="NewRecordValues('MJ: AI Agent Requests')"
+                [AllowLoad]="IsSectionExpanded('mJAIAgentRequests')"
+                [ShowToolbar]="false"
+                (Navigate)="OnFormNavigate($event)"
+                (AfterDataLoad)="SetSectionRowCount('mJAIAgentRequests', $event.totalRowCount)"
+                >
+            </mj-explorer-entity-data-grid>
+        </div>
+        }
+    </mj-collapsible-panel>
+
     <!-- Tasks Section -->
     <mj-collapsible-panel
         SectionKey="mJTasks"

--- a/packages/Angular/Explorer/core-entity-forms/src/lib/generated/Entities/MJTask/mjtask.form.component.ts
+++ b/packages/Angular/Explorer/core-entity-forms/src/lib/generated/Entities/MJTask/mjtask.form.component.ts
@@ -23,6 +23,7 @@ export class MJTaskFormComponent extends BaseFormComponent {
             { sectionKey: 'systemMetadata', sectionName: 'System Metadata', isExpanded: false },
             { sectionKey: 'mJTaskDependenciesTaskID', sectionName: 'Task Dependencies (Task)', isExpanded: false },
             { sectionKey: 'mJTaskDependenciesDependsOnTaskID', sectionName: 'Task Dependencies (Depends On Task ID)', isExpanded: false },
+            { sectionKey: 'mJAIAgentRequests', sectionName: 'AI Agent Requests', isExpanded: false },
             { sectionKey: 'mJTasks', sectionName: 'Tasks', isExpanded: false }
         ]);
     }

--- a/packages/Angular/Explorer/dashboards/src/Workflows/components/workflow-runs-resource.component.ts
+++ b/packages/Angular/Explorer/dashboards/src/Workflows/components/workflow-runs-resource.component.ts
@@ -1,7 +1,7 @@
 import { AfterViewInit, ChangeDetectionStrategy, ChangeDetectorRef, Component } from '@angular/core';
 import { CompositeKey, RunView } from '@memberjunction/core';
 import { MJTaskEntity, ResourceData } from '@memberjunction/core-entities';
-import { RegisterClass } from '@memberjunction/global';
+import { RegisterClass, UUIDsEqual } from '@memberjunction/global';
 import { BaseDashboard } from '@memberjunction/ng-shared';
 
 /** A settled-or-running graph, projected for the list. */
@@ -80,7 +80,7 @@ export class WorkflowRunsResourceComponent extends BaseDashboard implements Afte
     }
 
     public get SelectedRun(): WorkflowRunRow | null {
-        return this.Runs.find((r) => r.ID === this.SelectedRunID) ?? null;
+        return this.Runs.find((r) => UUIDsEqual(r.ID, this.SelectedRunID ?? '')) ?? null;
     }
 
     async loadData(): Promise<void> {
@@ -142,7 +142,7 @@ export class WorkflowRunsResourceComponent extends BaseDashboard implements Afte
     }
 
     public OnSelectRun(run: WorkflowRunRow): void {
-        this.SelectedRunID = this.SelectedRunID === run.ID ? null : run.ID;
+        this.SelectedRunID = UUIDsEqual(this.SelectedRunID ?? '', run.ID) ? null : run.ID;
         this.publishAgentContext();
         this.cdr.markForCheck();
     }
@@ -231,7 +231,7 @@ export class WorkflowRunsResourceComponent extends BaseDashboard implements Afte
                 Handler: async (params: Record<string, unknown>) => {
                     const wanted = String(params['run'] ?? '').trim().toLowerCase();
                     const match =
-                        this.Runs.find((r) => r.ID.toLowerCase() === wanted) ??
+                        this.Runs.find((r) => UUIDsEqual(r.ID, wanted)) ??
                         this.Runs.find((r) => r.Name.trim().toLowerCase() === wanted) ??
                         this.Runs.find((r) => r.Name.toLowerCase().includes(wanted));
                     if (!match) {

--- a/packages/Angular/Generic/flow-editor/src/__tests__/agent-flow-edge-labels.test.ts
+++ b/packages/Angular/Generic/flow-editor/src/__tests__/agent-flow-edge-labels.test.ts
@@ -1,0 +1,147 @@
+/**
+ * Edge labels on the agent flow canvas.
+ *
+ * An edge label answers exactly one question — **when is this path taken?** The rules below all
+ * follow from that, and each of them replaces a behaviour that made a real graph unreadable: full
+ * rationale prose rendered at any length, "Default" captioned on every unconditional arrow, and
+ * exclusive precedence shown nowhere at all.
+ */
+import { describe, expect, it } from 'vitest';
+import { AgentFlowTransformerService } from '../lib/agent-editor/agent-flow-transformer.service';
+import type { MJAIAgentStepPathEntity } from '@memberjunction/core-entities';
+
+/** A path row with only the fields the label logic reads. */
+function path(over: Partial<MJAIAgentStepPathEntity> & { ID: string }): MJAIAgentStepPathEntity {
+    return {
+        OriginStepID: 'origin',
+        DestinationStepID: 'dest',
+        Condition: null,
+        Description: null,
+        Priority: 0,
+        Sequence: 0,
+        ...over,
+    } as unknown as MJAIAgentStepPathEntity;
+}
+
+/** Reaches the private visual builder; it is the unit under test and has no public seam. */
+function visualsFor(
+    target: MJAIAgentStepPathEntity,
+    siblings: MJAIAgentStepPathEntity[] = [target],
+): { label?: string; labelDetail?: string; labelIcon?: string } {
+    const svc = new AgentFlowTransformerService() as unknown as {
+        buildPathVisuals(
+            p: MJAIAgentStepPathEntity,
+            hasCondition: boolean,
+            isOnlyPath: boolean,
+            hasAmbiguousAlways: boolean,
+            rank: { position: number; total: number } | null,
+        ): { label?: string; labelDetail?: string; labelIcon?: string };
+        rankWithinGroup(
+            p: MJAIAgentStepPathEntity,
+            s: MJAIAgentStepPathEntity[],
+        ): { position: number; total: number };
+    };
+
+    const hasCondition = !!target.Condition?.trim();
+    const conditional = siblings.filter((s) => s.Condition && s.Condition.trim().length > 0);
+    const unconditional = siblings.filter((s) => !s.Condition || !s.Condition.trim());
+    const rank = hasCondition && conditional.length > 1 ? svc.rankWithinGroup(target, conditional) : null;
+
+    return svc.buildPathVisuals(
+        target,
+        hasCondition,
+        siblings.length === 1,
+        !hasCondition && unconditional.length > 1,
+        rank,
+    );
+}
+
+describe('conditional edges show the RULE', () => {
+    it('labels with the condition, not the author rationale', () => {
+        const v = visualsFor(path({
+            ID: 'p', Condition: 'payload.brandOK === true',
+            Description: 'The winning branch when the draft passed. Higher priority so it is chosen when both conditions could be read as true.',
+        }));
+
+        // The description is prose of arbitrary length; rendering it always is what buried the
+        // canvas under overlapping pills.
+        expect(v.label).toContain('payload.brandOK === true');
+        expect(v.label).not.toContain('winning branch');
+    });
+
+    it('keeps the full condition AND the rationale one hover away', () => {
+        const v = visualsFor(path({
+            ID: 'p', Condition: 'payload.brandOK === true', Description: 'Why this exists.',
+        }));
+
+        // Truncating a label is only safe if the whole thing is recoverable.
+        expect(v.labelDetail).toContain('payload.brandOK === true');
+        expect(v.labelDetail).toContain('Why this exists.');
+    });
+
+    it('truncates a long condition on a word boundary', () => {
+        const long = 'payload.someVeryLongPropertyName === "a rather long literal value here"';
+        const v = visualsFor(path({ ID: 'p', Condition: long }));
+
+        expect(v.label!.length).toBeLessThanOrEqual(34);
+        expect(v.label).toMatch(/…$/);
+        expect(v.labelDetail).toContain(long);   // nothing is lost
+    });
+});
+
+describe('unconditional edges say nothing', () => {
+    it('emits no label for an ordinary path', () => {
+        const v = visualsFor(path({ ID: 'p', Description: 'Feeds the records into the loop.' }));
+
+        // A plain line already means "then". "Default" on every arrow is a caption on a diagram
+        // saying "arrow" — and it was the bulk of the clutter, because most edges are unconditional.
+        expect(v.label).toBeUndefined();
+    });
+
+    it('still carries the rationale on hover', () => {
+        const v = visualsFor(path({ ID: 'p', Description: 'Feeds the records into the loop.' }));
+        expect(v.labelDetail).toBe('Feeds the records into the loop.');
+    });
+
+    it('DOES label duplicate defaults, because that is a defect', () => {
+        const a = path({ ID: 'a' });
+        const b = path({ ID: 'b' });
+        const v = visualsFor(a, [a, b]);
+
+        // The one unconditional case worth shouting about: only the highest-priority one runs, and
+        // the author needs to see that without hovering anything.
+        expect(v.label).toBe('Duplicate default');
+        expect(v.labelIcon).toBe('fa-triangle-exclamation');
+    });
+});
+
+describe('exclusive precedence is visible', () => {
+    it('ranks conditional siblings by priority, then sequence', () => {
+        const win = path({ ID: 'win', Condition: 'a', Priority: 200 });
+        const lose = path({ ID: 'lose', Condition: 'b', Priority: 100 });
+
+        expect(visualsFor(win, [win, lose]).label).toMatch(/^1\/2 /);
+        expect(visualsFor(lose, [win, lose]).label).toMatch(/^2\/2 /);
+    });
+
+    it('breaks a priority tie by ascending sequence', () => {
+        const first = path({ ID: 'first', Condition: 'a', Priority: 100, Sequence: 1 });
+        const second = path({ ID: 'second', Condition: 'b', Priority: 100, Sequence: 2 });
+
+        expect(visualsFor(first, [first, second]).label).toMatch(/^1\/2 /);
+        expect(visualsFor(second, [first, second]).label).toMatch(/^2\/2 /);
+    });
+
+    it('explains the ordering on hover', () => {
+        const win = path({ ID: 'win', Condition: 'a', Priority: 200 });
+        const lose = path({ ID: 'lose', Condition: 'b', Priority: 100 });
+
+        expect(visualsFor(win, [win, lose]).labelDetail).toContain('Checked 1st of 2');
+    });
+
+    it('omits the rank when a condition has no competing sibling', () => {
+        // A lone conditional edge has no precedence to explain, and "1/1" would be noise.
+        const v = visualsFor(path({ ID: 'p', Condition: 'payload.ok === true' }));
+        expect(v.label).not.toMatch(/^\d\/\d /);
+    });
+});

--- a/packages/Angular/Generic/flow-editor/src/__tests__/agent-flow-edge-labels.test.ts
+++ b/packages/Angular/Generic/flow-editor/src/__tests__/agent-flow-edge-labels.test.ts
@@ -18,7 +18,6 @@ function path(over: Partial<MJAIAgentStepPathEntity> & { ID: string }): MJAIAgen
         Condition: null,
         Description: null,
         Priority: 0,
-        Sequence: 0,
         ...over,
     } as unknown as MJAIAgentStepPathEntity;
 }
@@ -124,12 +123,16 @@ describe('exclusive precedence is visible', () => {
         expect(visualsFor(lose, [win, lose]).label).toMatch(/^2\/2 /);
     });
 
-    it('breaks a priority tie by ascending sequence', () => {
-        const first = path({ ID: 'first', Condition: 'a', Priority: 100, Sequence: 1 });
-        const second = path({ ID: 'second', Condition: 'b', Priority: 100, Sequence: 2 });
+    it('breaks a priority tie by ascending path ID, NOT by declaration order', () => {
+        // Declared high-ID-first on purpose. `Priority` defaults to 0, so a tie is the COMMON case,
+        // and this is exactly where a badge that sorted by array order would quietly disagree with
+        // the engine — the compiler assigns TaskDependency.Sequence by ascending path ID, and a
+        // path row has no Sequence column of its own to sort on.
+        const zulu = path({ ID: 'zulu', Condition: 'a', Priority: 100 });
+        const alpha = path({ ID: 'alpha', Condition: 'b', Priority: 100 });
 
-        expect(visualsFor(first, [first, second]).label).toMatch(/^1\/2 /);
-        expect(visualsFor(second, [first, second]).label).toMatch(/^2\/2 /);
+        expect(visualsFor(alpha, [zulu, alpha]).label).toMatch(/^1\/2 /);
+        expect(visualsFor(zulu, [zulu, alpha]).label).toMatch(/^2\/2 /);
     });
 
     it('explains the ordering on hover', () => {

--- a/packages/Angular/Generic/flow-editor/src/lib/agent-editor/agent-flow-transformer.service.ts
+++ b/packages/Angular/Generic/flow-editor/src/lib/agent-editor/agent-flow-transformer.service.ts
@@ -333,7 +333,7 @@ export class AgentFlowTransformerService {
     const hasAmbiguousAlways = isAlwaysPath && unconditionalSiblings.length > 1;
 
     // Where this path sits in its exclusive group, when it is IN one. Highest Priority wins, ties
-    // broken by Sequence — and none of that precedence is visible on the canvas today, so someone
+    // broken by path ID — and none of that precedence is visible on the canvas today, so someone
     // debugging a fork cannot tell which branch takes it when two conditions are both true.
     const conditionalSiblings = siblingPaths.filter(p => p.Condition && p.Condition.trim().length > 0);
     const rank = hasCondition && conditionalSiblings.length > 1
@@ -393,7 +393,7 @@ export class AgentFlowTransformerService {
       // precedence is exactly what a truncated condition would otherwise hide.
       const prefix = rank ? `${rank.position}/${rank.total} ` : '';
       const precedence = rank
-        ? `\n\nChecked ${ordinal(rank.position)} of ${rank.total}: highest priority wins, ties by sequence.`
+        ? `\n\nChecked ${ordinal(rank.position)} of ${rank.total}: highest priority wins, ties by path ID.`
         : '';
       return {
         label: prefix + this.truncateLabel(condition, rank ? 28 : 32),
@@ -435,16 +435,20 @@ export class AgentFlowTransformerService {
   /**
    * This path's position among its conditional siblings, in the order the dispatcher checks them.
    *
-   * Mirrors ResolveExclusiveGroups: highest `Priority` first, ties broken by ascending `Sequence`.
-   * Kept in lockstep with that rule deliberately — a badge that disagreed with the engine would be
-   * worse than no badge, because it would be believed.
+   * Mirrors the COMPILER, which is where the order is actually decided: `buildDependencies` sorts a
+   * fan-out by `Priority` descending, then path ID ascending, and writes that ordinal into
+   * `TaskDependency.Sequence` — which is what `ResolveExclusiveGroups` then reads at runtime. A path
+   * row has no `Sequence` of its own and deliberately never has: a compiled edge gets a fresh UUID
+   * and needs a stored ordinal to stay deterministic across machines, while a design-time path still
+   * has its own stable ID to break the tie with. Ranking here by anything else would disagree with
+   * the engine precisely on ties — and `Priority` defaults to 0, so ties are the common case.
    */
   private rankWithinGroup(
     path: MJAIAgentStepPathEntity,
     siblings: MJAIAgentStepPathEntity[]
   ): { position: number; total: number } {
     const ordered = [...siblings].sort((a, b) =>
-      (b.Priority ?? 0) - (a.Priority ?? 0) || (a.Sequence ?? 0) - (b.Sequence ?? 0)
+      (b.Priority ?? 0) - (a.Priority ?? 0) || a.ID.localeCompare(b.ID)
     );
     return {
       position: ordered.findIndex(p => UUIDsEqual(p.ID, path.ID)) + 1,

--- a/packages/Angular/Generic/flow-editor/src/lib/agent-editor/agent-flow-transformer.service.ts
+++ b/packages/Angular/Generic/flow-editor/src/lib/agent-editor/agent-flow-transformer.service.ts
@@ -68,6 +68,13 @@ export const AGENT_STEP_TYPE_CONFIGS: FlowNodeTypeConfig[] = [
   }
 ];
 
+/** "1st", "2nd", "3rd", … for the precedence note on an exclusive branch. */
+function ordinal(n: number): string {
+  const suffix = n % 100 >= 11 && n % 100 <= 13 ? 'th'
+    : ['th', 'st', 'nd', 'rd'][n % 10] ?? 'th';
+  return `${n}${suffix}`;
+}
+
 /**
  * Transforms MJ AIAgentStep/Path entities to/from generic FlowNode/FlowConnection models.
  */
@@ -325,8 +332,16 @@ export class AgentFlowTransformerService {
     // highest-priority one will execute — regardless of whether they have descriptions.
     const hasAmbiguousAlways = isAlwaysPath && unconditionalSiblings.length > 1;
 
+    // Where this path sits in its exclusive group, when it is IN one. Highest Priority wins, ties
+    // broken by Sequence — and none of that precedence is visible on the canvas today, so someone
+    // debugging a fork cannot tell which branch takes it when two conditions are both true.
+    const conditionalSiblings = siblingPaths.filter(p => p.Condition && p.Condition.trim().length > 0);
+    const rank = hasCondition && conditionalSiblings.length > 1
+      ? this.rankWithinGroup(path, conditionalSiblings)
+      : null;
+
     // Build label, icon, and visual style
-    const visual = this.buildPathVisuals(path, hasCondition, isOnlyPath, hasAmbiguousAlways);
+    const visual = this.buildPathVisuals(path, hasCondition, isOnlyPath, hasAmbiguousAlways, rank);
 
     return {
       ID: path.ID,
@@ -350,52 +365,106 @@ export class AgentFlowTransformerService {
     };
   }
 
+  /**
+   * What an edge says on the canvas, and what it says on inspection.
+   *
+   * **An edge label answers one question: WHEN is this path taken?** That is the condition. The
+   * `Description` is the author's rationale — genuinely useful, and inspection-time content: it is
+   * prose, it is arbitrarily long, and rendering it always turned the least important element on the
+   * canvas into the most visually dominant one, overlapping nodes and other labels.
+   *
+   * So the condition is the LABEL (truncated), the description is the DETAIL (the hover tooltip),
+   * and an unconditional edge says nothing at all — a plain line already means "then". That last
+   * rule removes most of the clutter on a real graph, because most edges are unconditional.
+   */
   private buildPathVisuals(
     path: MJAIAgentStepPathEntity,
     hasCondition: boolean,
     isOnlyPath: boolean,
-    hasAmbiguousAlways: boolean
+    hasAmbiguousAlways: boolean,
+    rank: { position: number; total: number } | null = null
   ): { label?: string; labelIcon?: string; labelIconColor?: string; labelDetail?: string; color: string; style: FlowConnectionStyle } {
-    // Conditional path — amber dashed with condition text
+    const rationale = path.Description?.trim();
+
+    // Conditional path — amber dashed, labelled with the RULE.
     if (hasCondition) {
+      const condition = path.Condition!.trim();
+      // The rank prefix is tiny and always fits, so it survives truncation — which matters, because
+      // precedence is exactly what a truncated condition would otherwise hide.
+      const prefix = rank ? `${rank.position}/${rank.total} ` : '';
+      const precedence = rank
+        ? `\n\nChecked ${ordinal(rank.position)} of ${rank.total}: highest priority wins, ties by sequence.`
+        : '';
       return {
-        label: path.Description || path.Condition!,
+        label: prefix + this.truncateLabel(condition, rank ? 28 : 32),
+        labelIcon: 'fa-code-branch',
+        labelIconColor: '#f59e0b',
+        // Full condition first — a truncated label is only safe if the whole thing is one hover
+        // away — then the rationale, then how this branch is chosen against its siblings.
+        labelDetail: (rationale ? `${condition}\n\n${rationale}` : condition) + precedence,
         color: '#f59e0b',
         style: 'dashed'
       };
     }
 
-    // Sole unconditional (only exit path) — neutral dark slate with Default indicator
-    if (isOnlyPath) {
-      return {
-        label: path.Description || 'Default',
-        labelIcon: 'fa-circle-check',
-        labelIconColor: '#16a34a',
-        color: '#64748b',
-        style: 'solid'
-      };
-    }
-
-    // Ambiguous: multiple unconditional paths from the same step
+    // Ambiguous: multiple unconditional paths from the same step. This one KEEPS its label, because
+    // it is a defect the author needs to see without hovering anything.
     if (hasAmbiguousAlways) {
       return {
-        label: path.Description || 'Default',
+        label: 'Duplicate default',
         labelIcon: 'fa-triangle-exclamation',
         labelIconColor: '#ef4444',
-        labelDetail: 'Duplicate default paths: only the highest-priority one will execute',
+        labelDetail: rationale
+          ? `Duplicate default paths: only the highest-priority one will execute.\n\n${rationale}`
+          : 'Duplicate default paths: only the highest-priority one will execute',
         color: '#ef4444',
         style: 'solid'
       };
     }
 
-    // Valid default path (unconditional among conditional siblings) — forest green with checkmark
+    // Every other unconditional path — NO LABEL. The line already means "then", and "Default" on
+    // every edge of a linear flow is a caption on each arrow of a diagram saying "arrow".
+    // The rationale stays reachable on hover.
     return {
-      label: path.Description || 'Default',
-      labelIcon: 'fa-circle-check',
-      labelIconColor: '#16a34a',
-      color: '#16a34a',
+      labelDetail: rationale || undefined,
+      color: isOnlyPath ? '#64748b' : '#16a34a',
       style: 'solid'
     };
+  }
+
+  /**
+   * This path's position among its conditional siblings, in the order the dispatcher checks them.
+   *
+   * Mirrors ResolveExclusiveGroups: highest `Priority` first, ties broken by ascending `Sequence`.
+   * Kept in lockstep with that rule deliberately — a badge that disagreed with the engine would be
+   * worse than no badge, because it would be believed.
+   */
+  private rankWithinGroup(
+    path: MJAIAgentStepPathEntity,
+    siblings: MJAIAgentStepPathEntity[]
+  ): { position: number; total: number } {
+    const ordered = [...siblings].sort((a, b) =>
+      (b.Priority ?? 0) - (a.Priority ?? 0) || (a.Sequence ?? 0) - (b.Sequence ?? 0)
+    );
+    return {
+      position: ordered.findIndex(p => UUIDsEqual(p.ID, path.ID)) + 1,
+      total: ordered.length
+    };
+  }
+
+  /**
+   * Trims a condition to what fits on an edge without covering its neighbours.
+   *
+   * Breaks on a word boundary when there is one near the limit, so the visible part stays readable
+   * rather than ending mid-identifier. The full text is always in `labelDetail`.
+   */
+  private truncateLabel(text: string, limit = 32): string {
+    const flat = text.replace(/\s+/g, ' ').trim();
+    if (flat.length <= limit) return flat;
+
+    const cut = flat.slice(0, limit);
+    const lastSpace = cut.lastIndexOf(' ');
+    return `${(lastSpace > limit * 0.6 ? cut.slice(0, lastSpace) : cut).trimEnd()}…`;
   }
 
   /** Populate loop-specific display data on the node's Data payload */

--- a/packages/Angular/Generic/flow-editor/src/lib/components/flow-editor.component.ts
+++ b/packages/Angular/Generic/flow-editor/src/lib/components/flow-editor.component.ts
@@ -56,11 +56,13 @@ export class FlowEditorComponent implements OnInit, OnDestroy {
   @Input() GridSize = 20;
   @Input() AutoLayoutDirection: FlowLayoutDirection = 'vertical';
   /** Background color for connection labels */
-  @Input() ConnectionLabelBackground = '#fffef5';
+  // Design tokens, not literals — the canvas renders on both themes, and a near-white pill on a
+  // dark canvas made the least important element the most visually dominant thing on screen.
+  @Input() ConnectionLabelBackground = 'var(--mj-bg-surface)';
   /** Border color for connection labels */
-  @Input() ConnectionLabelBorderColor = '#cbd5e1';
+  @Input() ConnectionLabelBorderColor = 'var(--mj-border-default)';
   /** Text color for connection labels */
-  @Input() ConnectionLabelTextColor = '#334155';
+  @Input() ConnectionLabelTextColor = 'var(--mj-text-secondary)';
 
   /** Title for the canvas empty-state overlay — depends on read-only mode. */
   public get EmptyStateTitle(): string {

--- a/packages/MJServer/src/services/TaskGraphPromptRunner.ts
+++ b/packages/MJServer/src/services/TaskGraphPromptRunner.ts
@@ -82,8 +82,14 @@ export class TaskGraphPromptRunner implements TaskPromptRunner {
 
         return {
             ...(params.TemplateParameters ?? {}),
-            [CURRENT_PAYLOAD_PLACEHOLDER]: payload,
-            flowContext: { dependencyOutputs },
+            // JSON, not the object. A template writes `{{ _CURRENT_PAYLOAD }}` and expects to SEE
+            // the payload; handing the renderer an object yields "[object Object]", and the model
+            // then answers about a value it was never shown. That failure is invisible from the
+            // outside — the prompt run succeeds, the response is well-formed, and it is about
+            // nothing. It is what kept the Content Pipeline reviewer rejecting a draft it could not
+            // read, on every iteration, forever.
+            [CURRENT_PAYLOAD_PLACEHOLDER]: JSON.stringify(payload, null, 2),
+            flowContext: JSON.stringify({ dependencyOutputs }, null, 2),
         };
     }
 

--- a/packages/ServerBootstrap/src/generated/mj-class-registrations.ts
+++ b/packages/ServerBootstrap/src/generated/mj-class-registrations.ts
@@ -73,8 +73,9 @@ import {
     GeminiRealtime,
 } from '@memberjunction/ai-gemini';
 
-// @memberjunction/ai-groq (1 classes)
+// @memberjunction/ai-groq (2 classes)
 import {
+    GroqAudioGenerator,
     GroqLLM,
 } from '@memberjunction/ai-groq';
 
@@ -1451,6 +1452,7 @@ export const CLASS_REGISTRATIONS: any[] = [
     GeminiImageGenerator,
     GeminiLLM,
     GeminiRealtime,
+    GroqAudioGenerator,
     GroqLLM,
     HeyGenVideoGenerator,
     InworldRealtime,
@@ -2419,7 +2421,7 @@ export const CLASS_REGISTRATIONS: any[] = [
 export const CLASS_REGISTRATIONS_MANIFEST_LOADED = true;
 
 /** Total @RegisterClass decorated classes discovered in dependency tree */
-export const CLASS_REGISTRATIONS_COUNT = 980;
+export const CLASS_REGISTRATIONS_COUNT = 981;
 
 /** Packages imported by this manifest */
 export const CLASS_REGISTRATIONS_PACKAGES = [

--- a/packages/ServerBootstrapLite/src/generated/mj-class-registrations.ts
+++ b/packages/ServerBootstrapLite/src/generated/mj-class-registrations.ts
@@ -73,8 +73,9 @@ import {
     GeminiRealtime,
 } from '@memberjunction/ai-gemini';
 
-// @memberjunction/ai-groq (1 classes)
+// @memberjunction/ai-groq (2 classes)
 import {
+    GroqAudioGenerator,
     GroqLLM,
 } from '@memberjunction/ai-groq';
 
@@ -1203,6 +1204,7 @@ export const CLASS_REGISTRATIONS: any[] = [
     GeminiImageGenerator,
     GeminiLLM,
     GeminiRealtime,
+    GroqAudioGenerator,
     GroqLLM,
     HeyGenVideoGenerator,
     InworldRealtime,
@@ -2087,7 +2089,7 @@ export const CLASS_REGISTRATIONS: any[] = [
 export const CLASS_REGISTRATIONS_MANIFEST_LOADED = true;
 
 /** Total @RegisterClass decorated classes discovered in dependency tree */
-export const CLASS_REGISTRATIONS_COUNT = 896;
+export const CLASS_REGISTRATIONS_COUNT = 897;
 
 /** Packages imported by this manifest */
 export const CLASS_REGISTRATIONS_PACKAGES = [

--- a/packages/TaskGraph/src/TaskGraphDispatcher.ts
+++ b/packages/TaskGraph/src/TaskGraphDispatcher.ts
@@ -1047,8 +1047,17 @@ export class TaskGraphDispatcher implements IShutdownable {
             // a satisfied prerequisite on a Complete origin. A poll landing in that window would
             // claim and execute the branch the workflow chose NOT to take — irreversibly, since the
             // action has already run by the time Skipped is written over it.
-            const eligible = ComputeEligibleTasks(graph.nodes, graph.edges)
-                .filter((n) => !graph.holdTaskIDs.has(n.id) && !graph.skipSeedTaskIDs.has(n.id));
+            // `unreachableTaskIDs` joins the filter for exactly the reason above. R6 made a
+            // definite-false ordinary edge seed the skip cascade rather than Block its target — but
+            // until that Skipped write lands, the target has no unsatisfied prerequisite and is
+            // vacuously eligible. That is the same race the XOR fix closed, reopened on the new
+            // path: a branch the workflow decided against, claimed and executed irreversibly in the
+            // window before it was marked.
+            const eligible = ComputeEligibleTasks(graph.nodes, graph.edges, graph.handledFailureIDs)
+                .filter((n) =>
+                    !graph.holdTaskIDs.has(n.id) &&
+                    !graph.skipSeedTaskIDs.has(n.id) &&
+                    !graph.unreachableTaskIDs.has(n.id));
             for (const node of eligible) {
                 const entity = graph.entityById.get(node.id);
                 if (!entity) continue;
@@ -1671,11 +1680,36 @@ export class TaskGraphDispatcher implements IShutdownable {
         // A prompt body has no params of its own — it receives the payload (with the loop bindings
         // merged in) through the placeholder, so an empty mapping is correct rather than missing.
         const bodyMapping = (op.action?.params ?? {}) as Record<string, unknown>;
+
+        // Where this step sits in its graph, resolved ONCE rather than per iteration. A loop body is
+        // dispatched exactly like a one-shot step and needs the same two things: the run that
+        // submitted the graph (so a spawned run gets a ParentRunID and is visible to the tree and to
+        // cost), and the continuation depth (so the recursion cap still applies). Omitting them made
+        // loop bodies second-class in every dimension — and reopened the unbounded-recursion hole
+        // THROUGH loops, since each spawned run restarted the chain at zero.
+        const graphContext = await this.graphContext(provider, task);
+
+        // THE LOOP'S PAYLOAD ACCUMULATES. Each iteration's output merges in, and the next iteration
+        // — and the While condition — sees it. Without this the condition closure re-read the
+        // payload as it was when the loop STARTED, so a `while payload.brandOK !== true` could never
+        // become false: the loop burned every iteration re-examining the original input and always
+        // took the give-up branch, making the other branch unreachable. The loop ran, reported
+        // success, and its result was predetermined.
+        let livePayload: Record<string, unknown> = { ...payload };
+
         const invokeBody: LoopBodyInvoker = async ({ Bindings }) => {
             // Bindings go INTO the payload rather than beside it, so an authored mapping reaches the
             // current item the same way it reaches anything else: `payload.<itemVariable>`.
-            const iterationPayload = { ...payload, ...Bindings };
+            const iterationPayload = { ...livePayload, ...Bindings };
             const resolved = ResolveMappedInput(bodyMapping, { payload: iterationPayload }) as Record<string, unknown>;
+
+            /** Folds an iteration's output into the running payload the next pass will see. */
+            const absorb = <T extends { Success: boolean; Output?: unknown }>(outcome: T): T => {
+                if (outcome.Output && typeof outcome.Output === 'object' && !Array.isArray(outcome.Output)) {
+                    livePayload = deepMergePayload(livePayload, outcome.Output as Record<string, unknown>);
+                }
+                return outcome;
+            };
 
             // A prompt body is checked FIRST because it is the only one whose id lives in its own
             // column: a loop repeating a prompt has PromptID set and both ActionID and AgentID null,
@@ -1684,7 +1718,7 @@ export class TaskGraphDispatcher implements IShutdownable {
                 if (!this.promptRunner) {
                     return { Success: false, ErrorMessage: 'No prompt runner is loaded on this host.' };
                 }
-                return this.promptRunner.RunPromptForTask({
+                return absorb(await this.promptRunner.RunPromptForTask({
                     TaskID: task.ID,
                     PromptID: task.PromptID,
                     // The ITERATION payload, not the mapped params. An action body declares its
@@ -1704,26 +1738,33 @@ export class TaskGraphDispatcher implements IShutdownable {
                     TemplateParameters: { ...stringifyBindings(Bindings), ...op.prompt?.templateParameters },
                     Provider: provider,
                     ContextUser: this.contextUser,
-                });
+                }));
             }
 
-            return task.ActionID
-                ? this.actionRunner!.RunActionForTask({
+            if (task.ActionID) {
+                return absorb(await this.actionRunner!.RunActionForTask({
                     TaskID: task.ID,
                     ActionID: task.ActionID,
                     InputPayload: resolved,
                     DependencyOutputs: dependencyOutputs,
                     Provider: provider,
                     ContextUser: this.contextUser,
-                })
-                : this.agentRunner.RunAgentForTask({
-                    TaskID: task.ID,
-                    AgentID: task.AgentID!,
-                    InputPayload: resolved,
-                    DependencyOutputs: dependencyOutputs,
-                    Provider: provider,
-                    ContextUser: this.contextUser,
-                });
+                }));
+            }
+
+            return absorb(await this.agentRunner.RunAgentForTask({
+                TaskID: task.ID,
+                AgentID: task.AgentID!,
+                // The ITERATION payload when the body declares no inputs of its own. A sub-agent
+                // body has no `params`, so the mapped result is `{}` — every iteration was handing
+                // the agent nothing and asking it to work from that.
+                InputPayload: Object.keys(resolved).length > 0 ? resolved : iterationPayload,
+                DependencyOutputs: dependencyOutputs,
+                ContinuationDepth: graphContext.Depth,
+                SubmittingAgentRunID: graphContext.SubmittingAgentRunID,
+                Provider: provider,
+                ContextUser: this.contextUser,
+            }));
         };
 
         const outcome = task.StepType === 'ForEach'
@@ -1738,7 +1779,7 @@ export class TaskGraphDispatcher implements IShutdownable {
                     // so the same expression that routes an edge failed here with
                     // "payload is not defined". The spread stays for conditions already written
                     // against it.
-                    { ...payload, payload, iteration },
+                    { ...livePayload, payload: livePayload, iteration },
                 ),
                 invokeBody,
             );
@@ -1747,7 +1788,12 @@ export class TaskGraphDispatcher implements IShutdownable {
             Success: outcome.Success,
             AgentRunID: null,
             ErrorMessage: outcome.ErrorMessage,
-            Output: this.applyStepOutputMapping(task, payload, outcome.Output, op.action?.outputMapping ?? config?.outputMapping),
+            // The ACCUMULATED payload — everything the iterations established — not the one the
+            // loop started with, which would discard the loop's whole effect on the workflow.
+            Output: this.applyStepOutputMapping(
+                task, livePayload, outcome.Output,
+                op.action?.outputMapping ?? op.prompt?.outputMapping ?? config?.outputMapping,
+            ),
         };
     }
 

--- a/packages/TaskGraph/src/TaskGraphDispatcher.ts
+++ b/packages/TaskGraph/src/TaskGraphDispatcher.ts
@@ -931,11 +931,20 @@ export class TaskGraphDispatcher implements IShutdownable {
         // is a legitimate "somebody needs to look at this", and a request nobody was notified about
         // is still findable in the inbox — whereas returning early here is how such a step used to
         // become invisible work that stalled a workflow with nothing anywhere saying why.
-        // The marker goes down only once a request is genuinely open. A notification storm is the
-        // failure the marker exists to prevent, but a MISSING request is worse than a repeated
-        // attempt: nothing would appear in anyone's inbox and the workflow would wait forever with
-        // no indication why. Retrying on the next poll is the recoverable choice.
-        if (!(await this.raiseHumanRequest(task, provider))) return;
+        // TRANSIENT failures retry; PERMANENT ones stop. That distinction is the whole point, and
+        // getting it wrong took a server down: retrying unconditionally meant a task whose workflow
+        // has no owning agent — which can never succeed — was re-attempted on every poll forever,
+        // each pass re-reading the graph, until the process was OOM-killed. The marker exists to
+        // prevent exactly that storm; a permanent failure has to set it.
+        const raised = await this.raiseHumanRequest(task, provider);
+        if (raised === 'transient-failure') return;   // try again next poll
+        if (raised === 'permanent-failure') {
+            // Nothing will change on a retry. Mark it so the loop stops, and leave the task Pending
+            // and visible — a person can still see it in the Tasks UI, which is the fallback the
+            // notification was only ever an accelerant for.
+            await this.markHumanTaskNotified(task);
+            return;
+        }
 
         if (!task.UserID) {
             await this.markHumanTaskNotified(task);
@@ -1122,10 +1131,13 @@ export class TaskGraphDispatcher implements IShutdownable {
      * submitted it, so nothing is suspended — the task sits Pending, every other branch keeps
      * running, and answering settles the task. That column staying null is meaningful, not missing.
      */
-    private async raiseHumanRequest(task: MJTaskEntity, provider: IMetadataProvider): Promise<boolean> {
+    private async raiseHumanRequest(
+        task: MJTaskEntity,
+        provider: IMetadataProvider,
+    ): Promise<'raised' | 'permanent-failure' | 'transient-failure'> {
         try {
             const existing = await this.findOpenRequest(provider, task.ID);
-            if (existing) return true;   // already waiting on someone
+            if (existing) return 'raised';   // already waiting on someone
 
             const request = await provider.GetEntityObject<MJAIAgentRequestEntity>(
                 'MJ: AI Agent Requests', this.contextUser,
@@ -1137,11 +1149,14 @@ export class TaskGraphDispatcher implements IShutdownable {
             // owns the workflow: the graph's own agent, which is who is asking.
             const owningAgentID = await this.owningAgentOf(provider, task);
             if (!owningAgentID) {
+                // PERMANENT: a graph with no owning agent will not acquire one by being asked
+                // again. Graphs submitted before the provenance stamp landed are all in this state.
                 LogError(
                     `[TaskGraphDispatcher] Task ${task.ID} needs a person, but its workflow has no ` +
-                    `agent to ask on behalf of, so no request could be raised.`,
+                    `agent to ask on behalf of, so no request can be raised. The task stays Pending ` +
+                    `and visible in the Tasks UI; it will not be retried.`,
                 );
-                return false;
+                return 'permanent-failure';
             }
             request.AgentID = owningAgentID;
             request.RequestForUserID = task.UserID;
@@ -1156,14 +1171,15 @@ export class TaskGraphDispatcher implements IShutdownable {
                     `[TaskGraphDispatcher] Could not raise a request for task ${task.ID}: ` +
                     `${request.LatestResult?.CompleteMessage ?? 'unknown error'}`,
                 );
-                return false;
+                // A failed SAVE may be transient (deadlock, contention), so this one earns a retry.
+                return 'transient-failure';
             }
-            return true;
+            return 'raised';
         } catch (e) {
             // Never fatal. The task remains Pending and visible; a missing request is recoverable,
             // whereas throwing here would abort the whole dispatch pass for every other branch.
             LogError(`[TaskGraphDispatcher] Could not raise a request for task ${task.ID}: ${e instanceof Error ? e.message : String(e)}`);
-            return false;
+            return 'transient-failure';
         }
     }
 

--- a/packages/TaskGraph/src/__tests__/task-loop-executor.test.ts
+++ b/packages/TaskGraph/src/__tests__/task-loop-executor.test.ts
@@ -178,3 +178,40 @@ describe('RunWhileLoop', () => {
         expect(result.Output.iterations).toBe(1);
     });
 });
+
+describe('a While loop must be able to reach its exit condition', () => {
+    it('stops as soon as the condition flips, rather than burning every iteration', async () => {
+        // The shape the Content Pipeline demo needs, and the one it could not do: the body CHANGES
+        // something the condition reads. The dispatcher used to evaluate the condition against the
+        // payload as it was when the loop STARTED, so `while payload.brandOK !== true` could never
+        // go false — the loop always exhausted its cap and the branch behind "approved" was
+        // unreachable dead code. The loop ran, reported success, and its outcome was predetermined.
+        const payload: Record<string, unknown> = { brandOK: false };
+
+        const result = await RunWhileLoop(
+            { condition: 'payload.brandOK !== true', maxIterations: 5 } as never,
+            // Stands in for the dispatcher's evaluator reading the LIVE payload.
+            () => ({ Success: true, Value: payload['brandOK'] !== true }),
+            async () => {
+                payload['brandOK'] = true;    // the body's effect, as the next check must see it
+                return { Success: true, Output: { brandOK: true } };
+            },
+        );
+
+        expect(result.Success).toBe(true);
+        expect(result.Output).toMatchObject({ iterations: 1 });
+    });
+
+    it('still honours the cap when the condition never flips', async () => {
+        // The give-up path stays intact: a body that cannot satisfy its condition must not spin.
+        let iterations = 0;
+        const result = await RunWhileLoop(
+            { condition: 'payload.brandOK !== true', maxIterations: 3 } as never,
+            () => ({ Success: true, Value: true }),
+            async () => { iterations++; return { Success: true, Output: {} }; },
+        );
+
+        expect(iterations).toBe(3);
+        expect(result.Output).toMatchObject({ iterations: 3 });
+    });
+});

--- a/packages/TestingFramework/integration-test-suite/src/checks/workflow-demo-agents.checks.ts
+++ b/packages/TestingFramework/integration-test-suite/src/checks/workflow-demo-agents.checks.ts
@@ -25,6 +25,7 @@
  * creates and the bundle Teardown removes.
  */
 import { RunView, type IMetadataProvider, type IRunQueryProvider } from '@memberjunction/core';
+import { UUIDsEqual } from '@memberjunction/global';
 import type { TaskGraphSpec, TaskGraphSpecNode } from '@memberjunction/ai-core-plus';
 import { BuildAgentRunTree, LoadAgentRunTree } from '@memberjunction/ai-core-plus';
 import { MJAIAgentEntity, MJAIAgentRunEntity } from '@memberjunction/core-entities';
@@ -121,6 +122,17 @@ async function compile(ctx: IntegrationCheckContext, agent: MJAIAgentEntity): Pr
     return result.Spec!;
 }
 
+/**
+ * The task id a dependency points at, in either form it can take.
+ *
+ * A dependency is normally an object carrying the id plus its condition; the bare-string form
+ * survives from older specs. Reading only one of them is how an assertion ends up permanently false
+ * while looking correct.
+ */
+function dependencyId(dep: unknown): string {
+    return typeof dep === 'string' ? dep : String((dep as { tempId?: string })?.tempId ?? '');
+}
+
 /** The node with this name, or a failure that names what WAS found. */
 function nodeNamed(spec: TaskGraphSpec, name: string): TaskGraphSpecNode {
     const match = spec.tasks.find((t) => t.name === name);
@@ -150,10 +162,12 @@ export const WorkflowDemoAgentChecks: NamedCheck[] = [
             );
             Assert(steps.Success, `could not read agent steps: ${steps.ErrorMessage}`);
 
-            const sweepSteps = (steps.Results ?? []).filter((s) => s.AgentID.toLowerCase() === sweep.ID.toLowerCase());
-            const pipelineSteps = (steps.Results ?? []).filter((s) => s.AgentID.toLowerCase() === pipeline.ID.toLowerCase());
+            const sweepSteps = (steps.Results ?? []).filter((s) => UUIDsEqual(s.AgentID, sweep.ID));
+            const pipelineSteps = (steps.Results ?? []).filter((s) => UUIDsEqual(s.AgentID, pipeline.ID));
 
-            AssertEqual(sweepSteps.length, 2, `${SCHEMA_SWEEP} should have 2 steps`);
+            // 3, not 2: the sweep gained its Human approval step when HITL landed. This assertion
+            // was merged stale — the demo changed in the same range and the check did not.
+            AssertEqual(sweepSteps.length, 3, `${SCHEMA_SWEEP} should have 3 steps`);
             AssertEqual(pipelineSteps.length, 6, `${CONTENT_PIPELINE} should have 6 steps`);
 
             console.log(`      → ${SCHEMA_SWEEP}: ${sweepSteps.length} steps · ${CONTENT_PIPELINE}: ${pipelineSteps.length} steps`);
@@ -169,9 +183,13 @@ export const WorkflowDemoAgentChecks: NamedCheck[] = [
             // The AND-join. Asserted on the compiled EDGES rather than on the two research steps
             // existing, because two steps pointing at a third is the only thing that actually makes
             // the draft wait for both — and it is exactly what a careless edit drops.
+            // Dependencies are OBJECTS, not bare strings, and they point BACKWARD — a node lists
+            // what it depends ON. The original assertion did `.includes(<string>)` against object
+            // form (always false) with the direction inverted, so it could never be green in either
+            // reading; it was merged without a passing run.
             const draft = nodeNamed(spec, 'Draft the piece');
-            const intoDraft = spec.tasks.filter((t) => (t.dependsOn ?? []).includes(draft.tempId));
-            AssertEqual(intoDraft.length, 2, 'the draft step must join BOTH research steps, not one');
+            const draftDeps = (draft.dependsOn ?? []).map(dependencyId);
+            AssertEqual(draftDeps.length, 2, 'the draft step must join BOTH research steps, not one');
 
             // The bounded loop. An unbounded revision loop on a model that will not converge is the
             // failure mode this cap exists to prevent, so the cap itself is the assertion.
@@ -186,7 +204,7 @@ export const WorkflowDemoAgentChecks: NamedCheck[] = [
             const approved = nodeNamed(spec, 'Close out: approved');
             const gaveUp = nodeNamed(spec, 'Close out: gave up');
             for (const [node, label] of [[approved, 'approved'], [gaveUp, 'gave up']] as const) {
-                const edges = (node.dependsOn ?? []);
+                const edges = (node.dependsOn ?? []).map(dependencyId);
                 Assert(edges.includes(review.tempId), `the '${label}' branch must follow the review step`);
             }
             Assert(
@@ -255,7 +273,7 @@ export const WorkflowDemoAgentChecks: NamedCheck[] = [
             Assert(!tree.ErrorMessage, `the run-tree query failed: ${tree.ErrorMessage}`);
             AssertEqual(tree.Rows.length, 1, 'a run with no steps must return exactly its own node');
             AssertEqual(tree.Root?.NodeType, 'Run', 'the root of a run tree must be the run');
-            AssertEqual(tree.Root?.NodeID.toLowerCase(), run.ID.toLowerCase(), 'the root must be the run asked for');
+            Assert(UUIDsEqual(tree.Root?.NodeID ?? '', run.ID), 'the root must be the run asked for');
             AssertEqual(tree.Truncated, false, 'a one-node tree cannot be truncated');
 
             // The assembler is pure and must agree with what the loader returned — if these ever

--- a/plans/workflow-followup-worklist.md
+++ b/plans/workflow-followup-worklist.md
@@ -139,6 +139,43 @@ Post **one** comment on PR #3692 addressed to the planner agent:
       Playwright via MJExplorer). User explicitly asked for this.
 
 
+## CURRENT STATE (2026-08-10) — read this first
+
+**Branch `feat/workflow-hitl` → PR #3716 (OPEN).** #3701 and #3710 are MERGED. `next` is merged in.
+
+### Landed in this wave (all verified live, not inferred)
+- Duplicate workflow on approval — resume hook armed by our own null `ResumingAgentRunID`. DB-confirmed.
+- OOM kill (exit 137) — unraisable request retried every poll forever. Split permanent vs transient.
+- Loop first-classing — accumulating payload (a `While` can now reach its exit), `ContinuationDepth`
+  (recursion hole through loops), `SubmittingAgentRunID`, sub-agent body payload, `prompt.outputMapping`.
+- Recovery deadlock — `handledFailureIDs` now reaches eligibility; `unreachableTaskIDs` in claim filter.
+- `[object Object]` — `_CURRENT_PAYLOAD` now JSON-serialized for templates.
+- Run tree — sub-agent CTE member added; recursion cycle closed; task rows use normal displayers.
+- Edge labels — condition not description, hover detail, `1/2` rank badge, token-based chip.
+- **Behaviour change:** a second unreachable `StartingStep` now FAILS compile (was silent). Flagged in the PR.
+
+### OPEN — next session picks up here
+1. **Content Pipeline still not fully green.** Metadata fixed (single entry; `broad -> focused` path added
+   and pushed) but NOT re-verified end to end — the last run was interrupted. Re-run and confirm the
+   `approved` branch is now reachable. This is the only demo-blocking item.
+2. **R7 decision** — `rollUpCostToSubmittingRun` (prompt-blind, mixed basis) vs the tree query
+   (prompt-aware, own-cost). Two authorities disagree by construction. My vote: delete the write-back.
+   BLOCKED pending confirmation nothing reads `AIAgentRun.TotalCostRollup` for display.
+3. Review items not yet done: #10 envelope truthfulness, #4 input snapshot, #12 hold-aware stall,
+   #14/#15/#17/#18.
+4. **HITL gaps:** `assignToUserID` compiled+tested then discarded at persist; Cancelled = permanent
+   stall (no re-raise path); nothing ever sets `ExpiresAt`; no caller authz on respond; D17 converter
+   still drops `Human`; no Human node in the visual editor.
+5. **Playwright screenshots** — blocked on an expired Auth0 token in `.playwright-cli/profile`.
+   One headed login unblocks `scripts/verification/verify-agent-run-ui.mjs` permanently.
+
+### Pattern worth remembering
+Two of the last three bugs shared a shape: reasoned carefully about a trade-off, wrote the reasoning
+down, got the direction backwards. Both produced SUCCESSFUL runs with wrong results. Run the demo
+agents after each dispatcher change, not at the end of a batch.
+
+---
+
 ## Standing facts worth not rediscovering
 
 - **Stale `dist` trap:** `tsc && tsc-alias -f` — a failed `tsc` skips `tsc-alias`, leaving


### PR DESCRIPTION
Follow-up wave to the merged workflow work (#3701, #3710), plus the confirmed findings from the post-merge review on #3698. `next` merged in.

Every fix here was **verified against a live database or a live run**, not inferred from the diff. Two were found by the reviewing agent, one took my dev server down, and one I found by re-running a demo I had already called verified.

## ⚠️ One behaviour change reviewers must weigh

**A workflow with a second, unreachable starting step now FAILS to compile.** It used to succeed.

A workflow has exactly one entry; the compiler takes the alphabetically-first `StartingStep` and prunes whatever that entry cannot reach. Previously it pruned in silence — so a step the author had *explicitly marked as an entry point* simply vanished, and the workflow shipped missing work while looking complete on the canvas.

That is not hypothetical: it is what the **Content Pipeline demo did for its entire life**. Its second research step was pruned, the AND-join it fed had one input instead of two, every draft was written from half the evidence, and nothing anywhere reported a problem.

Refusing at submission — before anything runs — is strictly better than running half a workflow and reporting success. But it can reject a previously-accepted workflow, so it deserves a deliberate yes/no.

## The one that mattered most — a duplicate workflow on every approval

`MJAIAgentRequestEntityServer` arms its resume hook on exactly the shape a workflow approval has: out of `Requested`, an `OriginatingAgentRunID` present, `ResumingAgentRunID` still null. So approving a workflow step fired `resumeAgent()`, re-ran the Flow agent, and **submitted a brand-new graph** — which raised its own new approval.

The null `ResumingAgentRunID` is the thing I chose deliberately and wrote a paragraph defending. It is also what armed the hook.

**Confirmed in the database, not inferred:** approving one request at 13:56 produced a second, unasked-for graph at 14:05. My own live verification missed it because I checked that the *approved* graph completed and never looked for a graph I had not asked for. Both executions look successful.

One guard: skip resume when `OriginatingTaskID` is set.

## An unraisable request looped until the server died

Exit **137 — OOM kill**, on my own dev API. Mine, and the reasoning error is the interesting part.

Making the notified-marker conditional on a request actually being raised, I wrote `if (!raised) return;` — never marking, so never stopping — and justified it as *"a missing request is worse than a repeated attempt; retrying next poll is the recoverable choice."*

True for a **transient** failure, false for a **permanent** one. A task whose graph has no owning agent can never succeed, so it was re-attempted every poll forever, each pass re-reading the graph (`MJ: Tasks` 70×, `Task Dependencies` 19× per sweep) until the process ran out of memory. The unconditional marker I replaced existed to prevent exactly that storm.

Now three outcomes — `raised` / `transient-failure` (retry) / `permanent-failure` (mark, stop, stay visible in the Tasks UI). Verified: a full minute of polling produces **zero** of the log lines that previously repeated hundreds of times.

## Loops were second-class in every dimension

- **A `While` could never reach its exit.** The condition closure captured the payload as it was when the loop *started* and re-read that same object every pass, so `while payload.brandOK !== true` could not go false. The loop burned every iteration on the original input and always took the give-up branch — the other branch was unreachable dead code. **This is why I reported the Content Pipeline demo as working**: I saw 3-of-3 iterations and the gave-up branch and read it as the loop functioning. It was the loop being unable to do anything else. The payload now accumulates.
- **No `ContinuationDepth`** → runs spawned inside a loop restarted the chain at zero, so `MAX_REINVOKE_DEPTH` never fired and **unbounded recursion was reachable through a loop**. A Flow agent used as a loop body also went around the sub-agent refusal entirely — a bypass of a guard, not just an observability gap.
- **No `SubmittingAgentRunID`** → loop-spawned runs got no `ParentRunID`, invisible to the tree and to cost.
- **Sub-agent bodies received `{}`** every iteration; their mapped params are empty by definition.
- `op.prompt.outputMapping` was written by the compiler and consumed by nothing — the sweep demo's `proposals[index]` mapping was silently dead.

## A handled failure released nothing

`handledFailureIDs` reached blocking and rollup but never **eligibility**. Under `failureSemantics: 'edges'` a Failed origin with a satisfied outgoing edge is neither Blocked nor Skipped — so its recovery target was never blocked, never skipped, and **never eligible**. The graph sat `In Progress` forever. Before this machinery existed it settled `Failed`; turning a wrong answer into no answer is a regression. The old tests hid it by hand-placing the recovery target at `Complete`.

Also closes the claim race R6 reopened: `unreachableTaskIDs` was missing from the claim filter, so a definite-false edge's target was vacuously eligible in the window before its `Skipped` write landed — claimed and executed irreversibly, exactly as XOR losers were before that fix.

## A template was shown `[object Object]`

`_CURRENT_PAYLOAD` was handed to the renderer as an object. Templates write `{{ _CURRENT_PAYLOAD }}` and expect to see the payload; they got `"[object Object]"`, and the model then answered confidently about a value it had never been shown. The prompt run succeeds, the JSON is well-formed, and it is about nothing.

The Content Pipeline reviewer said so in its own feedback: *"The provided draft was '[object Object]', which is not a valid text body."* Every iteration, forever.

## Run-tree and visualization fixes

- **A directly-invoked sub-agent had no steps in the tree** — no CTE member for `Sub-Agent step → the run it started`, so Subway Lines drew an empty line while 13 steps sat in the database. That run went from 8 nodes to 21.
- **Infinite recursion** — my own `parent.AgentRunID` provenance stamp gave one column two directions; the spawned-run member followed both and re-entered the graph it came from. *The direction of a link is not a property of the column; it is a property of which row you are standing on.*
- **Workflow actions rendered as generic "workflow step"** — tasks now map onto the same row vocabulary as run steps, so an action gets the action displayer; a separate `provenance` field styles them without redefining them.
- **Loops loaded their iterations and hid them** — expandability is structural now.

## Edge labels

An edge answers one question: *when is this taken?* That is the **condition**, not the author's rationale. Condition is the label (truncated on a word boundary), description moves to the hover tooltip, **unconditional edges say nothing at all** (a line already means "then" — most of the clutter), duplicate-defaults keep a loud label because that is a real defect, and conditional siblings get a `1/2` rank badge mirroring `ResolveExclusiveGroups` so XOR precedence stops being invisible.

## Tests

`ai-core-plus` **530** · `task-graph` **62** · `ng-flow-editor` **46** · `core-entity-forms` **247** · `ng-dashboards` **1714** · `ai-agents` **1845**

New coverage targets the two shapes the old suites structurally could not catch: a recovery path that must *become* eligible, and a loop whose body changes what its condition reads. Also fixes **WD1/WD2**, two integration checks merged red — WD2 was structurally never-green (`.includes(<string>)` against object-form dependencies, direction inverted), which is the part I own.

## Still open

`R7` (two disagreeing cost authorities — my vote is to delete the write-back, but I want confirmation nothing reads `AIAgentRun.TotalCostRollup` for display first), `#10` envelope truthfulness, `#4` input snapshot, and the remaining HITL gaps (`assignToUserID` discarded at persist, Cancelled-as-permanent-stall, nothing sets `ExpiresAt`, no caller authz on respond).

**Suggested handling:** two of my last three bugs share a shape — I reasoned carefully about a trade-off, wrote the reasoning down, and got the direction backwards. That argues for a real soak on this branch rather than a read-through review.

PG counterpart deferred to the release build, per `migrations/CLAUDE.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
