### PR TITLE
ci: set GEMINI_CLI_TRUST_WORKSPACE — the Gemini CLI refuses to start without it

### DIFF
--- a/.github/workflows/gemini-command.yml
+++ b/.github/workflows/gemini-command.yml
@@ -69,6 +69,18 @@ jobs:
       - name: Run Gemini
         id: gemini
         uses: google-github-actions/run-gemini-cli@v0.1.22
+        env:
+          # REQUIRED — without it the CLI exits 1 without running anything:
+          #   "Gemini CLI is not running in a trusted directory."
+          # It does NOT quietly fall back to prompting-then-denying; it refuses to
+          # start. The action does not set this itself, so every caller must.
+          #
+          # The cost is real and is why the tool allowlist below is written the way
+          # it is: trusting the workspace lets the action's hardcoded `--yolo` take
+          # effect, so every tool the model can see is auto-approved. Untrusted, the
+          # CLI logs "Approval mode overridden to default" — but it never gets far
+          # enough for that to protect anything.
+          GEMINI_CLI_TRUST_WORKSPACE: 'true'
         with:
           gemini_api_key: ${{ secrets.GEMINI_API_KEY }}
 
@@ -161,7 +173,10 @@ jobs:
               # text is untrusted enough that it should not be able to close a fence
               # and inject markdown into the comment either way.
               if [ -n "$ERRORS" ]; then
-                printf '%s\n' "$ERRORS" | sed 's/^/    /'
+                # Strip ANSI colour codes before indenting — the CLI colourises its
+                # stderr even when not attached to a TTY, and the raw escapes render
+                # as literal ^[[31m garbage in a GitHub comment.
+                printf '%s\n' "$ERRORS" | sed -e 's/\x1b\[[0-9;]*m//g' -e 's/^/    /'
                 printf '\n'
               fi
               printf '[Run log](%s)\n' "$RUN_URL"

--- a/.github/workflows/generate-release-notes.yml
+++ b/.github/workflows/generate-release-notes.yml
@@ -59,6 +59,12 @@ jobs:
         if: github.event_name == 'workflow_dispatch' || steps.cs.outputs.count != '0'
         uses: google-github-actions/run-gemini-cli@v0.1.22
         env:
+          # REQUIRED — without it the CLI exits 1 without running anything:
+          # "Gemini CLI is not running in a trusted directory." It refuses to start
+          # rather than falling back to a safer approval mode. Confirmed empirically
+          # on run 31453795512, where its absence killed the sibling gemini-command
+          # workflow before a single tool call. The action does not set it itself.
+          GEMINI_CLI_TRUST_WORKSPACE: 'true'
           # Consumed by the github MCP server declared in `settings` below, via the
           # ${GITHUB_TOKEN} expansion in its `env` block. Settings values expand $VAR
           # from the process environment — but an UNSET variable is left as the


### PR DESCRIPTION
Follow-up to #3730. The first live `@gemini-cli` invocation failed before reaching a single tool call ([run 31453795512](https://github.com/MemberJunction/MJ/actions/runs/31453795512)):

```
Gemini CLI is not running in a trusted directory. To proceed, either use
`--skip-trust`, set the `GEMINI_CLI_TRUST_WORKSPACE=true` environment
variable, or trust this directory in interactive mode.
```

`GEMINI_CLI_TRUST_WORKSPACE: 'true'` is now set on both Gemini steps.

## Why it was left out, and why that was wrong

#3730 omitted it on purpose. The reasoning was that an untrusted workspace downgrades the action's hardcoded `--yolo` to default-approval mode, which in a headless run means deny-by-default — so the explicitly-allowed tools would still work, everything else would be refused, and we would get a stricter posture for free.

The CLI does log `Approval mode overridden to "default" because the current folder is not trusted`. It then **exits 1 without running anything**. The downgrade is real but unreachable, so it protects nothing. Trust is a prerequisite for the CLI starting at all, not a hardening knob.

`generate-release-notes.yml` had the same omission and would have failed identically on the next release PR into `main` — a much worse place to find this than a smoke test.

## What this costs

With the workspace trusted, `--yolo` genuinely takes effect and **every tool the model can see is auto-approved**. That makes registry-level removal the only restriction that holds:

- `tools.core` — the built-in allowlist (tools are never registered, so policy never gets consulted)
- `includeTools` on the MCP server — filters at discovery, before the model sees the tool

Both lists were already written for exactly this threat model; this PR makes the dependency explicit in comments at both call sites rather than leaving it as an unstated assumption. Approval-based controls are not load-bearing here and should not be added under the impression that they are.

## Also

Strips ANSI colour codes from the failure comment before posting. The CLI colourises stderr even with no TTY attached, so the first failure rendered as literal `^[[31m` escapes in the [posted comment](https://github.com/MemberJunction/MJ/pull/3730#issuecomment-5248466065).

## What the smoke test did confirm

- The insider `if:` gate and `@gemini-cli` trigger matching both work — the run fired on the mention
- The error-reporting step works: the failure was posted to the PR with the real stderr and a run link, rather than the job finishing silently green. That is why this took one run to diagnose

## Still untested

The MCP wiring in `generate-release-notes.yml`. The run died before any tool call, so whether `tools.allowed` successfully re-permits the GitHub tools above the blanket `*` DENY that `tools.core` emits at priority 4.24 remains an open question — see item 1 of #3730 for the reasoning. One more `@gemini-cli` comment after this merges settles the mention bot; the release-notes path still needs a throwaway PR into `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LgZCjpeHD7qnAFxLeqTfNW
