### PR TITLE
A workflow run draws what actually happened — and the Runs surface remembers how you arranged it

### DIFF
--- a/.changeset/workflow-run-canvas-and-runs-layout.md
+++ b/.changeset/workflow-run-canvas-and-runs-layout.md
@@ -1,0 +1,46 @@
+---
+'@memberjunction/ng-flow-editor': minor
+'@memberjunction/ng-task-graph-editor': minor
+'@memberjunction/ng-dashboards': minor
+'@memberjunction/ng-core-entity-forms': minor
+---
+
+A workflow run now draws what happened, and the Runs surface remembers how you arranged it.
+
+**Edges could never bind.** Every task-graph node declared canvas ports literally named `in` and
+`out`, and the canvas resolves a connection by looking its port ids up in one flat, graph-wide
+namespace — so no connection could say which node's port it meant, and a workflow drew its boxes
+with no edges at all. Nothing errored: an unresolvable port is just a connection with nowhere to
+attach. Port ids are now scoped to their node (`InputPortID` / `OutputPortID`), matching the
+convention the Flow Agent editor has always used.
+
+**A declined branch was reported as `Pending`.** `NormalizeRuntimeState` falls back to `Pending` for
+any status it does not recognise, and it did not recognise `Skipped` — so a branch the workflow
+chose not to take reached the canvas as "still waiting to run". The node drew as an ordinary pending
+step, its edges drew as live routes, and `IsRuntimeSettled` could never report a graph containing one
+as finished, so a host polling on it polled a completed run forever. `Skipped` is now carried
+through and counts as terminal.
+
+With those two fixed, run mode draws **only the path taken**: edges touching a declined step are
+omitted (both ends — an edge leaving a skipped step is as untravelled as one entering it) and the
+step is hatched and struck through, in the same visual language the run timeline already uses.
+Design mode still draws every edge, because there is no route yet — the graph is all the routes that
+*could* be taken, which is exactly what an author is arranging.
+
+**The agent run's Workflow tab now shows the run, not the plan.** It rendered the recorded
+`TaskGraphSpec` on a bare canvas with no runtime, so every branch appeared to have run. It uses the
+same `mj-task-graph-run-view` the Workflows app does, falling back to the spec view only for a
+constant-folded graph that never reached the dispatcher — where a plan is the honest thing to draw.
+
+**Layout.** `FlowNodeStatus` gains `skipped` (deliberately not folded into `disabled`: disabled means
+"cannot run", skipped means "the graph went the other way"). `ShowLegend` and `ShowToolbar` are
+separately controllable, defaulting legend-off / toolbar-on in run views — the legend explains
+authoring vocabulary a run does not need, while the toolbar is how a person navigates the picture.
+`LegendToggled` is forwarded so a host can persist the choice rather than adding a second control.
+The run view's height chain was also broken: `Height` sat on the canvas and resolved against an
+auto-height ancestor, so `100%` meant nothing; it now governs the widget and the canvas flexes.
+
+**Workflows → Runs** gains resizable, per-user-persisted panes (list | detail, and canvas | step
+record inside it), with the step record moved beside the canvas rather than in a strip below it.
+Sizes are stored separately from openness, so closing and reopening returns a pane to the width you
+dragged it to. Preferences go through `UserInfoEngine`, never `localStorage`.

--- a/packages/Angular/Explorer/core-entity-forms/src/lib/custom/ai-agent-run/ai-agent-run-step-detail.component.css
+++ b/packages/Angular/Explorer/core-entity-forms/src/lib/custom/ai-agent-run/ai-agent-run-step-detail.component.css
@@ -553,3 +553,17 @@
 .step-notice {
   padding: 0 var(--mj-space-3, 12px) var(--mj-space-2, 8px);
 }
+
+/* The run view fills the tab rather than taking its intrinsic size — a canvas that stops halfway
+   down its pane with dead space beneath reads as a broken layout. */
+.detail-graph {
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
+  height: 100%;
+}
+
+.detail-graph__canvas {
+  flex: 1 1 auto;
+  min-height: 0;
+}

--- a/packages/Angular/Explorer/core-entity-forms/src/lib/custom/ai-agent-run/ai-agent-run-step-detail.component.html
+++ b/packages/Angular/Explorer/core-entity-forms/src/lib/custom/ai-agent-run/ai-agent-run-step-detail.component.html
@@ -110,13 +110,29 @@
                 <i class="fa-solid fa-floppy-disk"></i> Save as Workflow
               </button>
             </div>
-            <mj-task-graph-editor
-              class="detail-graph__canvas"
-              [Spec]="stepTaskGraph"
-              [NodePositions]="stepTaskGraphPositions"
-              [ReadOnly]="true"
-              [ShowPalette]="false">
-            </mj-task-graph-editor>
+            @if (stepTaskGraphParentTaskID; as parentTaskID) {
+              <!-- The RUN, not the plan. Same component the Workflows app uses, so a workflow is
+                   drawn identically wherever it is opened from — declined branches hatched,
+                   untravelled edges absent, toolbar on, legend off. -->
+              <mj-task-graph-run-view
+                class="detail-graph__canvas"
+                [Provider]="Provider"
+                [ParentTaskID]="parentTaskID"
+                [WorkflowName]="stepTaskGraph?.workflowName || 'Workflow'"
+                Height="100%">
+              </mj-task-graph-run-view>
+            } @else {
+              <!-- No dispatcher rows to read: a folded graph never ran. Drawing the spec is the
+                   honest rendering — it is a plan, and it is drawn as one. -->
+              <mj-task-graph-editor
+                class="detail-graph__canvas"
+                [Spec]="stepTaskGraph"
+                [NodePositions]="stepTaskGraphPositions"
+                [ReadOnly]="true"
+                [ShowPalette]="false"
+                [ShowLegend]="false">
+              </mj-task-graph-editor>
+            }
           </div>
         }
         @if (detailPaneTab === 'skills' && showSkillsTab) {

--- a/packages/Angular/Explorer/core-entity-forms/src/lib/custom/ai-agent-run/ai-agent-run-step-detail.component.ts
+++ b/packages/Angular/Explorer/core-entity-forms/src/lib/custom/ai-agent-run/ai-agent-run-step-detail.component.ts
@@ -4,6 +4,7 @@ import { MJAIAgentRunStepEntity, MJAIAgentRunStepEntity_AgentSkillInvocation } f
 import { ResolveTaskGraphPositions, type TaskGraphSpec } from '@memberjunction/ai-core-plus';
 import type { FlowPosition } from '@memberjunction/ng-flow-editor';
 import { ParseJSONRecursive, ParseJSONOptions } from '@memberjunction/global';
+import type { IMetadataProvider } from '@memberjunction/core';
 
 interface ScratchpadSnapshotView {
   notes: string;
@@ -23,6 +24,8 @@ interface ScratchpadSnapshotView {
 })
 export class AIAgentRunStepDetailComponent {
   @Input() selectedTimelineItem: TimelineItem | null = null;
+  /** The provider the host is on, so the run view reads through the right one. */
+  @Input() Provider: IMetadataProvider | null = null;
   @Output() closePanel = new EventEmitter<void>();
   @Output() navigateToActionLog = new EventEmitter<string>();
   @Output() copyToClipboard = new EventEmitter<string>();
@@ -309,6 +312,31 @@ export class AIAgentRunStepDetailComponent {
     const spec = this.stepTaskGraph;
     if (!spec) return null;
     return ResolveTaskGraphPositions(spec);
+  }
+
+  /**
+   * The graph's parent `MJ: Tasks` row, when this step actually dispatched one.
+   *
+   * **This is what turns the panel from a picture of the plan into a picture of the run.** With it,
+   * the same `mj-task-graph-run-view` the Workflows app uses reads the Task rows and draws what
+   * happened — declined branches hatched, untravelled edges absent, the toolbar available and the
+   * legend off. Without it the panel had only the SPEC, so it rendered in design mode: every branch
+   * drawn as though it had run, on a canvas that could not know otherwise.
+   *
+   * Null for a graph that was constant-folded (D9) — it never reached the dispatcher, so there are no
+   * rows and no run to show. The spec view is the honest rendering there: it is a plan, and it is
+   * drawn as one.
+   */
+  get stepTaskGraphParentTaskID(): string | null {
+    const raw = this.selectedTimelineItem?.data?.OutputData;
+    if (!raw) return null;
+    try {
+      const parsed = typeof raw === 'string' ? JSON.parse(raw) : raw;
+      const id = (parsed as { parentTaskID?: unknown })?.parentTaskID;
+      return typeof id === 'string' && id.length > 0 ? id : null;
+    } catch {
+      return null;
+    }
   }
 
   /** True when the recorded graph was constant-folded rather than dispatched (D9). */

--- a/packages/Angular/Explorer/core-entity-forms/src/lib/custom/ai-agent-run/ai-agent-run.component.html
+++ b/packages/Angular/Explorer/core-entity-forms/src/lib/custom/ai-agent-run/ai-agent-run.component.html
@@ -180,6 +180,7 @@
               <as-split-area [size]="45">
                 <mj-ai-agent-run-step-detail
                   [selectedTimelineItem]="selectedTimelineItem"
+                  [Provider]="ProviderToUse"
                   (closePanel)="closeJsonPanel()"
                   (navigateToActionLog)="navigateToActionLog($event)"
                   (copyToClipboard)="copyToClipboard($event)">

--- a/packages/Angular/Explorer/dashboards/src/Workflows/__tests__/workflow-runs-layout.test.ts
+++ b/packages/Angular/Explorer/dashboards/src/Workflows/__tests__/workflow-runs-layout.test.ts
@@ -1,0 +1,100 @@
+/**
+ * Layout preferences for the Runs surface.
+ *
+ * Pane sizes are the kind of preference people notice only when it breaks: someone drags the list
+ * narrow to read a graph, and it is back to 40/60 next time. The rules worth pinning are the ones
+ * that fail quietly — a stored value that no longer makes sense restoring a pane the user cannot
+ * find, and a close/reopen silently discarding a size they chose.
+ */
+import { describe, expect, it, beforeEach } from 'vitest';
+import { WorkflowRunLayout } from '../components/workflow-run-layout';
+
+/** Preferences held in memory: these tests are about the RULES, not the settings engine. */
+const settings = new Map<string, string>();
+
+const layout = () => new WorkflowRunLayout({
+    Get: (key) => settings.get(key),
+    Set: (key, value) => { settings.set(key, value); },
+});
+
+const restore = (c: WorkflowRunLayout) => c.Restore();
+
+describe('Runs layout preferences', () => {
+    beforeEach(() => settings.clear());
+
+    it('restores a saved split', async () => {
+        settings.set('mj.workflowRuns.splitSizes.v1', JSON.stringify([25, 75]));
+        const c = layout();
+        restore(c);
+        expect(c.SplitSizes).toEqual([25, 75]);
+    });
+
+    it('ignores a stored size that would hide a pane', async () => {
+        // A pane restored to 0% is a pane the user cannot find again, with no obvious way back.
+        // Falling back to the default is always recoverable.
+        settings.set('mj.workflowRuns.splitSizes.v1', JSON.stringify([0, 100]));
+        const c = layout();
+        restore(c);
+        expect(c.SplitSizes).toEqual([40, 60]);
+    });
+
+    it('ignores a stored value that is not a usable pair', async () => {
+        for (const bad of ['not json', '{}', '[50]', '[null,null]', '["a","b"]']) {
+            settings.set('mj.workflowRuns.splitSizes.v1', bad);
+            const c = layout();
+            restore(c);
+            expect(c.SplitSizes).toEqual([40, 60]);
+        }
+    });
+
+    it('keeps the step panel open unless it was explicitly closed', async () => {
+        const open = layout();
+        restore(open);
+        expect(open.StepPanelOpen).toBe(true);
+
+        settings.set('mj.workflowRuns.stepPanelOpen.v1', 'false');
+        const closed = layout();
+        restore(closed);
+        expect(closed.StepPanelOpen).toBe(false);
+    });
+
+    it('defaults the legend OFF in a run, and remembers being turned on', async () => {
+        const c = layout();
+        restore(c);
+        expect(c.ShowLegend).toBe(false);
+
+        c.ToggleLegend();
+        const next = layout();
+        restore(next);
+        expect(next.ShowLegend).toBe(true);
+    });
+
+    it('KEEPS the step pane size across a close and reopen', async () => {
+        // Restoring a default here instead of the size someone dragged to is the small betrayal that
+        // stops people using the control. Size and openness are stored separately for this reason.
+        const c = layout();
+        c.OnStepSplitDragEnd([70, 30]);
+        c.ToggleStepPanel();
+        expect(c.StepPanelOpen).toBe(false);
+        c.ToggleStepPanel();
+        expect(c.StepPanelOpen).toBe(true);
+        expect(c.StepSplitSizes).toEqual([70, 30]);
+    });
+
+    it('persists a drag so the next visit opens the same way', async () => {
+        const c = layout();
+        c.OnSplitDragEnd([30, 70]);
+        const next = layout();
+        restore(next);
+        expect(next.SplitSizes).toEqual([30, 70]);
+    });
+
+    it('ignores a drag reported with an auto-sized area', async () => {
+        // angular-split reports `'*'` for an area with no explicit size; storing that would write a
+        // pair that fails validation on the next read and silently reset the layout.
+        const c = layout();
+        c.OnSplitDragEnd([50, '*']);
+        expect(c.SplitSizes).toEqual([40, 60]);
+        expect(settings.has('mj.workflowRuns.splitSizes.v1')).toBe(false);
+    });
+});

--- a/packages/Angular/Explorer/dashboards/src/Workflows/components/workflow-run-layout.ts
+++ b/packages/Angular/Explorer/dashboards/src/Workflows/components/workflow-run-layout.ts
@@ -131,7 +131,12 @@ export class WorkflowRunLayout {
     }
 
     public ToggleLegend(): void {
-        this.ShowLegend = !this.ShowLegend;
-        this.settings.Set(WORKFLOW_RUN_LAYOUT_KEYS.ShowLegend, String(this.ShowLegend));
+        this.SetLegendVisible(!this.ShowLegend);
+    }
+
+    /** Records an explicit choice — what the canvas toolbar reports. */
+    public SetLegendVisible(show: boolean): void {
+        this.ShowLegend = show;
+        this.settings.Set(WORKFLOW_RUN_LAYOUT_KEYS.ShowLegend, String(show));
     }
 }

--- a/packages/Angular/Explorer/dashboards/src/Workflows/components/workflow-run-layout.ts
+++ b/packages/Angular/Explorer/dashboards/src/Workflows/components/workflow-run-layout.ts
@@ -1,0 +1,137 @@
+/**
+ * @fileoverview Pane sizes and panel visibility for a run surface — pure, so it can be checked.
+ *
+ * **Why this is not a handful of fields on the component.** Every rule here fails quietly when it is
+ * wrong: a stored size that no longer makes sense restores a pane the user cannot find, a close and
+ * reopen silently discards the width they dragged to, and a size written from an auto-sized area
+ * fails validation on the next read and resets the layout for good. None of that throws, and none of
+ * it is visible in a screenshot — it shows up days later as "why does this keep resetting".
+ *
+ * Angular is deliberately absent so the rules can be exercised in a node test rather than through a
+ * TestBed, which would test Angular instead.
+ */
+
+/** Where preferences live. Injected so the rules can be tested without the settings engine. */
+export type LayoutSettingsPort = {
+    Get(key: string): string | undefined;
+    Set(key: string, value: string): void;
+};
+
+/** A two-pane split, as percentages. */
+export type SizePair = [number, number];
+
+/**
+ * Preference keys.
+ *
+ * `mj.<feature>.<pref>` per the repo convention, versioned because the shape may change and a future
+ * reader needs to be able to tell an old value from a new one rather than mis-parsing it.
+ */
+export const WORKFLOW_RUN_LAYOUT_KEYS = {
+    Split: 'mj.workflowRuns.splitSizes.v1',
+    StepSplit: 'mj.workflowRuns.stepSplitSizes.v1',
+    StepPanelOpen: 'mj.workflowRuns.stepPanelOpen.v1',
+    ShowLegend: 'mj.workflowRuns.showLegend.v1',
+} as const;
+
+/** A pane narrower than this is one the user cannot get hold of again. */
+const MIN_USABLE_PERCENT = 5;
+
+/**
+ * A stored size pair, or null when it is absent or unusable.
+ *
+ * Validated rather than trusted. A stored value can predate a layout change or have been hand-edited,
+ * and restoring a pane to 0% — or to NaN — leaves someone with no obvious way to recover it. Falling
+ * back to the default is always recoverable, so an unreadable preference is treated as no preference.
+ */
+export function ReadSizePair(raw: string | undefined): SizePair | null {
+    if (!raw) return null;
+    try {
+        const parsed: unknown = JSON.parse(raw);
+        if (!Array.isArray(parsed) || parsed.length !== 2) return null;
+        const [a, b] = parsed as unknown[];
+        if (typeof a !== 'number' || typeof b !== 'number') return null;
+        if (!Number.isFinite(a) || !Number.isFinite(b)) return null;
+        if (a < MIN_USABLE_PERCENT || b < MIN_USABLE_PERCENT) return null;
+        return [a, b];
+    } catch {
+        return null;
+    }
+}
+
+/**
+ * A drag's reported sizes as a storable pair, or null.
+ *
+ * angular-split reports `'*'` for an area with no explicit size. Storing that produces a value that
+ * fails {@link ReadSizePair} on the next visit — so the layout would appear to save and then reset,
+ * which is worse than not saving at all.
+ */
+export function ToSizePair(sizes: readonly (number | '*')[]): SizePair | null {
+    if (sizes.length !== 2) return null;
+    const [a, b] = sizes;
+    return typeof a === 'number' && typeof b === 'number' ? [a, b] : null;
+}
+
+/**
+ * The Runs surface's layout, and its persistence.
+ *
+ * Size and openness are stored **separately** on purpose: closing the step panel and reopening it
+ * must return the pane to the width someone dragged it to, not to a default. Resetting a size the
+ * user chose is the small betrayal that stops people using a control at all.
+ */
+export class WorkflowRunLayout {
+    /** [list, detail] percentages. */
+    public SplitSizes: SizePair = [40, 60];
+    /** [canvas, step JSON] percentages, remembered even while the panel is closed. */
+    public StepSplitSizes: SizePair = [60, 40];
+    public StepPanelOpen = true;
+    /**
+     * Whether the canvas legend shows. **Off by default in a run.**
+     *
+     * The legend explains the authoring vocabulary — what a conditional edge means, what a duplicate
+     * default looks like — which is what someone drawing a graph needs. A run view answers a
+     * different question, "what happened", which the legend helps with not at all while covering a
+     * corner of the canvas the graph is usually occupying.
+     */
+    public ShowLegend = false;
+
+    constructor(private readonly settings: LayoutSettingsPort) {}
+
+    /** Applies the saved layout, ignoring anything no longer usable. */
+    public Restore(): void {
+        this.SplitSizes = ReadSizePair(this.settings.Get(WORKFLOW_RUN_LAYOUT_KEYS.Split)) ?? this.SplitSizes;
+        this.StepSplitSizes = ReadSizePair(this.settings.Get(WORKFLOW_RUN_LAYOUT_KEYS.StepSplit)) ?? this.StepSplitSizes;
+        // Absent means open — the panel is the point of selecting a step, so the default is to show
+        // it and only a recorded "closed" hides it.
+        this.StepPanelOpen = this.settings.Get(WORKFLOW_RUN_LAYOUT_KEYS.StepPanelOpen) !== 'false';
+        this.ShowLegend = this.settings.Get(WORKFLOW_RUN_LAYOUT_KEYS.ShowLegend) === 'true';
+    }
+
+    public OnSplitDragEnd(sizes: readonly (number | '*')[]): void {
+        const pair = ToSizePair(sizes);
+        if (!pair) return;
+        this.SplitSizes = pair;
+        this.settings.Set(WORKFLOW_RUN_LAYOUT_KEYS.Split, JSON.stringify(pair));
+    }
+
+    public OnStepSplitDragEnd(sizes: readonly (number | '*')[]): void {
+        const pair = ToSizePair(sizes);
+        if (!pair) return;
+        this.StepSplitSizes = pair;
+        this.settings.Set(WORKFLOW_RUN_LAYOUT_KEYS.StepSplit, JSON.stringify(pair));
+    }
+
+    public ToggleStepPanel(): void {
+        this.SetStepPanelOpen(!this.StepPanelOpen);
+    }
+
+    /** Opens or closes the panel. The size is untouched — see the class note. */
+    public SetStepPanelOpen(open: boolean): void {
+        this.StepPanelOpen = open;
+        this.settings.Set(WORKFLOW_RUN_LAYOUT_KEYS.StepPanelOpen, String(open));
+    }
+
+    public ToggleLegend(): void {
+        this.ShowLegend = !this.ShowLegend;
+        this.settings.Set(WORKFLOW_RUN_LAYOUT_KEYS.ShowLegend, String(this.ShowLegend));
+    }
+}

--- a/packages/Angular/Explorer/dashboards/src/Workflows/components/workflow-runs-resource.component.css
+++ b/packages/Angular/Explorer/dashboards/src/Workflows/components/workflow-runs-resource.component.css
@@ -9,24 +9,50 @@
   align-items: center;
 }
 
-/* List alone until something is selected; two panes after. The canvas gets the larger share
-   because a graph is the thing being read once it is open. */
+/* List alone until something is selected; two resizable panes after. The size is the user's — see
+   the LAYOUT_KEYS note on the component for why it is persisted server-side rather than locally. */
 .wfr-split {
-  display: grid;
-  grid-template-columns: 1fr;
-  gap: var(--mj-space-3);
   height: 100%;
   min-height: 0;
 }
 
-.wfr-split-open {
-  grid-template-columns: minmax(28rem, 40%) 1fr;
+/* A gutter you can find. The default is a hairline, which is discoverable only by accident. */
+:host ::ng-deep .wfr-split > .as-split-gutter,
+:host ::ng-deep .wfr-graph-split > .as-split-gutter {
+  background: transparent !important;
+  position: relative;
 }
 
-@media (max-width: 900px) {
-  .wfr-split-open {
-    grid-template-columns: 1fr;
-  }
+:host ::ng-deep .wfr-split > .as-split-gutter::after,
+:host ::ng-deep .wfr-graph-split > .as-split-gutter::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  margin: auto;
+  background: var(--mj-border-default);
+  border-radius: var(--mj-radius-full);
+}
+
+:host ::ng-deep .wfr-split.as-horizontal > .as-split-gutter::after,
+:host ::ng-deep .wfr-graph-split.as-horizontal > .as-split-gutter::after {
+  width: 2px;
+}
+
+:host ::ng-deep .wfr-graph-split.as-vertical > .as-split-gutter::after {
+  height: 2px;
+}
+
+:host ::ng-deep .wfr-split > .as-split-gutter:hover::after,
+:host ::ng-deep .wfr-graph-split > .as-split-gutter:hover::after {
+  background: var(--mj-brand-primary);
+}
+
+/* The canvas and the step record sit SIDE BY SIDE — a JSON record in a strip along the bottom shows
+   about ten lines. Stacks below the breakpoint, where three columns would leave each too narrow to
+   use. */
+.wfr-graph-split {
+  flex: 1 1 auto;
+  min-height: 0;
 }
 
 .wfr-list {
@@ -246,19 +272,24 @@
   border-bottom-color: var(--mj-brand-primary);
 }
 
-/* The canvas takes the larger share; the step pane below it is a reading surface, not a diagram. */
 .wfr-graph-pane {
-  flex: 1 1 55%;
+  height: 100%;
   min-height: 12rem;
 }
 
 .wfr-steps-pane {
-  flex: 1 1 45%;
   display: flex;
   flex-direction: column;
+  height: 100%;
   min-height: 0;
-  border-top: 1px solid var(--mj-border-default);
+  border-left: 1px solid var(--mj-border-default);
   overflow: hidden;
+}
+
+/* Stacked layout puts the divider back on top, where the eye expects it. */
+:host ::ng-deep .as-vertical .wfr-steps-pane {
+  border-left: none;
+  border-top: 1px solid var(--mj-border-default);
 }
 
 .wfr-step-list {
@@ -267,8 +298,9 @@
   gap: var(--mj-space-1);
   padding: var(--mj-space-2);
   border-bottom: 1px solid var(--mj-border-default);
-  max-height: 30%;
+  max-height: 8rem;
   overflow-y: auto;
+  flex: none;
 }
 
 .wfr-step {
@@ -319,8 +351,13 @@
 }
 
 .wfr-step-json-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--mj-space-2);
   padding: var(--mj-space-1) var(--mj-space-3);
   font-weight: 600;
   font-size: var(--mj-font-size-sm);
   color: var(--mj-text-secondary);
+  flex: none;
 }

--- a/packages/Angular/Explorer/dashboards/src/Workflows/components/workflow-runs-resource.component.html
+++ b/packages/Angular/Explorer/dashboards/src/Workflows/components/workflow-runs-resource.component.html
@@ -118,10 +118,6 @@
                   </button>
                 }
                 @if (DetailTab === 'graph') {
-                  <button mjButton variant="flat" size="sm" (click)="ToggleLegend()"
-                          [title]="Layout.ShowLegend ? 'Hide the legend' : 'Show the legend'">
-                    <i class="fa-solid fa-list-check" aria-hidden="true"></i>
-                  </button>
                   <button mjButton variant="flat" size="sm" (click)="ToggleStepPanel()"
                           [title]="Layout.StepPanelOpen ? 'Hide step details' : 'Show step details'">
                     <i class="fa-solid" [class.fa-square-caret-right]="Layout.StepPanelOpen"
@@ -159,7 +155,8 @@
                       [LiveUpdates]="selected.Status === 'Running' || selected.Status === 'In Progress'"
                       [ShowLegend]="Layout.ShowLegend"
                       Height="100%"
-                      (NodeSelected)="OnGraphNodeSelected($event)">
+                      (NodeSelected)="OnGraphNodeSelected($event)"
+                      (LegendToggled)="OnLegendToggled($event)">
                     </mj-task-graph-run-view>
                   </div>
                 </as-split-area>

--- a/packages/Angular/Explorer/dashboards/src/Workflows/components/workflow-runs-resource.component.html
+++ b/packages/Angular/Explorer/dashboards/src/Workflows/components/workflow-runs-resource.component.html
@@ -56,7 +56,9 @@
         Message="Nothing matches the current filter. Clear it to see everything that has run.">
       </mj-empty-state>
     } @else {
-      <div class="wfr-split" [class.wfr-split-open]="SelectedRun">
+      <as-split class="wfr-split" direction="horizontal" unit="percent"
+                [gutterSize]="8" [disabled]="!SelectedRun" (dragEnd)="OnSplitDragEnd($event.sizes)">
+        <as-split-area [size]="SelectedRun ? Layout.SplitSizes[0] : 100" [minSize]="20">
         <div class="wfr-list">
           <!-- A header row that sorts. Every column a person scans by is sortable, because "the
                longest run" and "the one that failed this morning" are the two questions this list
@@ -95,7 +97,9 @@
             </button>
           }
         </div>
+        </as-split-area>
 
+        <as-split-area [size]="SelectedRun ? Layout.SplitSizes[1] : 0" [minSize]="25" [visible]="!!SelectedRun">
         @if (SelectedRun; as selected) {
           <!-- The canvas lives in the RIGHT PANEL on selection, not nested inside the list row.
                A graph needs room to be read; inlining one per row turns a scannable list into a
@@ -111,6 +115,17 @@
                   <button mjButton variant="flat" size="sm" (click)="OnOpenAgentRun(selected)">
                     <i class="fa-solid fa-arrow-up-right-from-square" aria-hidden="true"></i>
                     Agent run
+                  </button>
+                }
+                @if (DetailTab === 'graph') {
+                  <button mjButton variant="flat" size="sm" (click)="ToggleLegend()"
+                          [title]="Layout.ShowLegend ? 'Hide the legend' : 'Show the legend'">
+                    <i class="fa-solid fa-list-check" aria-hidden="true"></i>
+                  </button>
+                  <button mjButton variant="flat" size="sm" (click)="ToggleStepPanel()"
+                          [title]="Layout.StepPanelOpen ? 'Hide step details' : 'Show step details'">
+                    <i class="fa-solid" [class.fa-square-caret-right]="Layout.StepPanelOpen"
+                       [class.fa-square-caret-left]="!Layout.StepPanelOpen" aria-hidden="true"></i>
                   </button>
                 }
                 <button mjButton variant="flat" size="sm" (click)="OnSelectRun(selected)" aria-label="Close">
@@ -131,57 +146,67 @@
             </div>
 
             @if (DetailTab === 'graph') {
-              <!-- The canvas, then whatever step is selected on it. Clicking a node shows that
-                   step's record — the same move the agent-run timeline offers, so a workflow reads
-                   the same way wherever it is opened from. -->
-              <div class="wfr-graph-pane">
-                <mj-task-graph-run-view
-                  [Provider]="ProviderToUse"
-                  [ParentTaskID]="selected.ID"
-                  [WorkflowName]="selected.Name"
-                  [LiveUpdates]="selected.Status === 'Running' || selected.Status === 'In Progress'"
-                  Height="100%"
-                  (NodeSelected)="OnGraphNodeSelected($event)">
-                </mj-task-graph-run-view>
-              </div>
+              <!-- Canvas BESIDE the step it opened, not above it. A JSON record in a strip along the
+                   bottom shows about ten lines, which is not enough of a record to read. -->
+              <as-split class="wfr-graph-split" [direction]="InnerSplitDirection" unit="percent"
+                        [gutterSize]="8" (dragEnd)="OnStepSplitDragEnd($event.sizes)">
+                <as-split-area [size]="Layout.StepPanelOpen ? Layout.StepSplitSizes[0] : 100" [minSize]="25">
+                  <div class="wfr-graph-pane">
+                    <mj-task-graph-run-view
+                      [Provider]="ProviderToUse"
+                      [ParentTaskID]="selected.ID"
+                      [WorkflowName]="selected.Name"
+                      [LiveUpdates]="selected.Status === 'Running' || selected.Status === 'In Progress'"
+                      [ShowLegend]="Layout.ShowLegend"
+                      Height="100%"
+                      (NodeSelected)="OnGraphNodeSelected($event)">
+                    </mj-task-graph-run-view>
+                  </div>
+                </as-split-area>
 
-              <div class="wfr-steps-pane">
-                @if (StepsLoading) {
-                  <mj-loading text="Loading steps..."></mj-loading>
-                } @else {
-                  <div class="wfr-step-list">
-                    @for (step of SelectedSteps; track step.ID) {
-                      <button type="button" class="wfr-step"
-                              [class.wfr-step-selected]="step.ID === SelectedStepID"
-                              [attr.data-status]="step.Status"
-                              (click)="OnSelectStep(step)">
-                        <span class="wfr-step-name">{{ step.Name }}</span>
-                        <span class="wfr-step-meta">{{ step.StepType || 'Step' }}</span>
-                        <span class="wfr-row-status" [attr.data-status]="step.Status">{{ step.Status }}</span>
-                      </button>
+                <as-split-area [size]="Layout.StepPanelOpen ? Layout.StepSplitSizes[1] : 0" [minSize]="20"
+                               [visible]="Layout.StepPanelOpen">
+                  <div class="wfr-steps-pane">
+                    @if (StepsLoading) {
+                      <mj-loading text="Loading steps..."></mj-loading>
+                    } @else {
+                      <div class="wfr-step-list">
+                        @for (step of SelectedSteps; track step.ID) {
+                          <button type="button" class="wfr-step"
+                                  [class.wfr-step-selected]="step.ID === SelectedStepID"
+                                  [attr.data-status]="step.Status"
+                                  (click)="OnSelectStep(step)">
+                            <span class="wfr-step-name">{{ step.Name }}</span>
+                            <span class="wfr-step-meta">{{ step.StepType || 'Step' }}</span>
+                          </button>
+                        }
+                      </div>
+
+                      @if (SelectedStep; as step) {
+                        <div class="wfr-step-json">
+                          <div class="wfr-step-json-head">
+                            <span>{{ step.Name }}</span>
+                            <span class="wfr-row-status" [attr.data-status]="step.Status">{{ step.Status }}</span>
+                          </div>
+                          <mj-code-editor
+                            [ngModel]="SelectedStepJson"
+                            [language]="'json'"
+                            [readonly]="true"
+                            style="width: 100%;">
+                          </mj-code-editor>
+                        </div>
+                      } @else {
+                        <mj-empty-state
+                          Size="compact"
+                          Icon="fa-solid fa-hand-pointer"
+                          Title="Select a step"
+                          Message="Click a step on the canvas or in the list to see everything it recorded.">
+                        </mj-empty-state>
+                      }
                     }
                   </div>
-
-                  @if (SelectedStep; as step) {
-                    <div class="wfr-step-json">
-                      <div class="wfr-step-json-head">{{ step.Name }}</div>
-                      <mj-code-editor
-                        [ngModel]="SelectedStepJson"
-                        [language]="'json'"
-                        [readonly]="true"
-                        style="width: 100%;">
-                      </mj-code-editor>
-                    </div>
-                  } @else {
-                    <mj-empty-state
-                      Size="compact"
-                      Icon="fa-solid fa-hand-pointer"
-                      Title="Select a step"
-                      Message="Click a step on the canvas or in the list to see everything it recorded.">
-                    </mj-empty-state>
-                  }
-                }
-              </div>
+                </as-split-area>
+              </as-split>
             } @else {
               <div class="wfr-json-pane">
                 <mj-code-editor
@@ -194,7 +219,8 @@
             }
           </aside>
         }
-      </div>
+        </as-split-area>
+      </as-split>
     }
   </mj-page-body>
 </mj-page-layout>

--- a/packages/Angular/Explorer/dashboards/src/Workflows/components/workflow-runs-resource.component.ts
+++ b/packages/Angular/Explorer/dashboards/src/Workflows/components/workflow-runs-resource.component.ts
@@ -1,9 +1,13 @@
-import { AfterViewInit, ChangeDetectionStrategy, ChangeDetectorRef, Component } from '@angular/core';
+import { AfterViewInit, ChangeDetectionStrategy, ChangeDetectorRef, Component, HostListener } from '@angular/core';
 import { CompositeKey, RunView } from '@memberjunction/core';
-import { MJTaskEntity, ResourceData } from '@memberjunction/core-entities';
+import { MJTaskEntity, ResourceData, UserInfoEngine } from '@memberjunction/core-entities';
 import { ParseJSONOptions, ParseJSONRecursive, RegisterClass, UUIDsEqual } from '@memberjunction/global';
 import { BaseDashboard, BaseResourceComponent } from '@memberjunction/ng-shared';
 import { SortWorkflowRuns, type WorkflowRunSortColumn } from './workflow-run-sorting';
+import { WorkflowRunLayout } from './workflow-run-layout';
+
+/** Below this the detail pane cannot hold a canvas AND a JSON pane side by side. */
+const STACK_INNER_BELOW_PX = 1100;
 
 /**
  * How the JSON panes unpack nested JSON.
@@ -114,6 +118,23 @@ export class WorkflowRunsResourceComponent extends BaseDashboard implements Afte
     /** The step whose JSON is showing, or null when none is selected. */
     public SelectedStepID: string | null = null;
 
+    /**
+     * Pane sizes, panel visibility and the legend toggle — the rules live in `workflow-run-layout`,
+     * which is pure and therefore testable without standing up Angular.
+     *
+     * Preferences go through `UserInfoEngine` (`MJ: User Settings`), never `localStorage`: a pane
+     * width that vanishes when someone opens a different browser is exactly the kind of preference
+     * people notice when it disappears. Reads are a synchronous cache hit; writes are debounced,
+     * because dragging a splitter fires continuously.
+     */
+    public readonly Layout = new WorkflowRunLayout({
+        Get: (key) => UserInfoEngine.Instance.GetSetting(key),
+        Set: (key, value) => UserInfoEngine.Instance.SetSettingDebounced(key, value),
+    });
+
+    /** Stacked rather than side-by-side when the detail pane is too narrow for both. */
+    public InnerSplitDirection: 'horizontal' | 'vertical' = 'horizontal';
+
     constructor(private cdr: ChangeDetectorRef) {
         super();
     }
@@ -123,11 +144,45 @@ export class WorkflowRunsResourceComponent extends BaseDashboard implements Afte
     }
 
     initDashboard(): void {
-        // Nothing to set up — loadData does the work and the filters default to "everything".
+        this.Layout.Restore();
+        this.applyViewportRules();
     }
 
     ngAfterViewInit(): void {
         this.publishAgentContext();
+    }
+
+    /** Re-evaluates the stacking rule; the detail pane's width follows the window's. */
+    @HostListener('window:resize')
+    public onViewportResized(): void {
+        const before = this.InnerSplitDirection;
+        this.applyViewportRules();
+        if (before !== this.InnerSplitDirection) this.cdr.markForCheck();
+    }
+
+    private applyViewportRules(): void {
+        // Three columns on a laptop gives each about 400px and the canvas stops being usable, so the
+        // inner pair stacks instead. Mirrors the outer split's existing breakpoint rather than
+        // inventing a second responsive scheme.
+        this.InnerSplitDirection = window.innerWidth < STACK_INNER_BELOW_PX ? 'vertical' : 'horizontal';
+    }
+
+    public OnSplitDragEnd(sizes: readonly (number | '*')[]): void {
+        this.Layout.OnSplitDragEnd(sizes);
+    }
+
+    public OnStepSplitDragEnd(sizes: readonly (number | '*')[]): void {
+        this.Layout.OnStepSplitDragEnd(sizes);
+    }
+
+    public ToggleStepPanel(): void {
+        this.Layout.ToggleStepPanel();
+        this.cdr.markForCheck();
+    }
+
+    public ToggleLegend(): void {
+        this.Layout.ToggleLegend();
+        this.cdr.markForCheck();
     }
 
     /** The rows after the active filter and search, in the chosen order — what the template renders. */
@@ -285,6 +340,9 @@ export class WorkflowRunsResourceComponent extends BaseDashboard implements Afte
     /** A node was clicked on the canvas — show that step's JSON. */
     public OnGraphNodeSelected(event: { TaskID: string }): void {
         this.SelectedStepID = event.TaskID;
+        // Asking to see a step is asking for the panel. Leaving it closed would make the click look
+        // like it did nothing.
+        if (!this.Layout.StepPanelOpen) this.ToggleStepPanel();
         this.cdr.markForCheck();
     }
 

--- a/packages/Angular/Explorer/dashboards/src/Workflows/components/workflow-runs-resource.component.ts
+++ b/packages/Angular/Explorer/dashboards/src/Workflows/components/workflow-runs-resource.component.ts
@@ -180,8 +180,15 @@ export class WorkflowRunsResourceComponent extends BaseDashboard implements Afte
         this.cdr.markForCheck();
     }
 
-    public ToggleLegend(): void {
-        this.Layout.ToggleLegend();
+    /**
+     * The legend was toggled on the canvas toolbar — remember it.
+     *
+     * Driven from the toolbar rather than a button of our own: the canvas already has a legend
+     * control in the place people look for one, and adding a second in the header would be two
+     * controls for one setting, free to disagree.
+     */
+    public OnLegendToggled(show: boolean): void {
+        this.Layout.SetLegendVisible(show);
         this.cdr.markForCheck();
     }
 

--- a/packages/Angular/Explorer/dashboards/src/workflows-dashboards.module.ts
+++ b/packages/Angular/Explorer/dashboards/src/workflows-dashboards.module.ts
@@ -16,6 +16,7 @@ import { ContainerDirectivesModule } from '@memberjunction/ng-container-directiv
 import { SharedGenericModule } from '@memberjunction/ng-shared-generic';
 import { TaskGraphEditorModule } from '@memberjunction/ng-task-graph-editor';
 import { CodeEditorModule } from '@memberjunction/ng-code-editor';
+import { AngularSplitModule } from 'angular-split';
 
 import { WorkflowsDashboardComponent } from './Workflows/workflows-dashboard.component';
 import { CreateWorkflowComponent } from './Workflows/components/create-workflow.component';
@@ -59,6 +60,7 @@ import { WorkflowRunsResourceComponent } from './Workflows/components/workflow-r
         SharedGenericModule,
         TaskGraphEditorModule,
         CodeEditorModule,
+        AngularSplitModule,
     ],
     exports: [
         WorkflowsDashboardComponent,

--- a/packages/Angular/Generic/flow-editor/src/lib/components/flow-editor.component.css
+++ b/packages/Angular/Generic/flow-editor/src/lib/components/flow-editor.component.css
@@ -393,3 +393,10 @@ f-line-alignment {
   outline-offset: 1px;
   border-radius: var(--mj-radius-md);
 }
+
+/* An edge into a step the workflow did not take. Receding rather than removed: deleting it would
+   leave the skipped node floating unattached, which reads as a rendering fault — and that the
+   branch EXISTS is precisely what a reader is trying to see. */
+.mj-flow-connection-not-taken {
+  opacity: 0.3;
+}

--- a/packages/Angular/Generic/flow-editor/src/lib/components/flow-editor.component.css
+++ b/packages/Angular/Generic/flow-editor/src/lib/components/flow-editor.component.css
@@ -393,10 +393,3 @@ f-line-alignment {
   outline-offset: 1px;
   border-radius: var(--mj-radius-md);
 }
-
-/* An edge into a step the workflow did not take. Receding rather than removed: deleting it would
-   leave the skipped node floating unattached, which reads as a rendering fault — and that the
-   branch EXISTS is precisely what a reader is trying to see. */
-.mj-flow-connection-not-taken {
-  opacity: 0.3;
-}

--- a/packages/Angular/Generic/flow-editor/src/lib/components/flow-editor.component.html
+++ b/packages/Angular/Generic/flow-editor/src/lib/components/flow-editor.component.html
@@ -98,6 +98,7 @@
               [class.mj-flow-connection-colored]="!!conn.Color"
               [class.mj-flow-connection-dashed]="conn.Style === 'dashed'"
               [class.mj-flow-connection-dotted]="conn.Style === 'dotted'"
+              [class.mj-flow-connection-not-taken]="conn.NotTaken"
               (click)="onConnectionClicked($event, conn)"
               (contextmenu)="onConnectionContextMenu($event, conn)">
               <!-- Arrow marker -->

--- a/packages/Angular/Generic/flow-editor/src/lib/components/flow-editor.component.html
+++ b/packages/Angular/Generic/flow-editor/src/lib/components/flow-editor.component.html
@@ -98,7 +98,6 @@
               [class.mj-flow-connection-colored]="!!conn.Color"
               [class.mj-flow-connection-dashed]="conn.Style === 'dashed'"
               [class.mj-flow-connection-dotted]="conn.Style === 'dotted'"
-              [class.mj-flow-connection-not-taken]="conn.NotTaken"
               (click)="onConnectionClicked($event, conn)"
               (contextmenu)="onConnectionContextMenu($event, conn)">
               <!-- Arrow marker -->

--- a/packages/Angular/Generic/flow-editor/src/lib/components/flow-node.component.css
+++ b/packages/Angular/Generic/flow-editor/src/lib/components/flow-node.component.css
@@ -470,3 +470,30 @@ mj-flow-node {
     box-shadow: 0 0 0 6px transparent;
   }
 }
+
+/* ============================================================
+   A step the graph did not take
+   ============================================================
+   Its own treatment rather than a shade of `disabled`: disabled means "cannot run", skipped means
+   "the workflow chose another route". A reader who cannot tell them apart goes looking for a
+   failure that never happened.
+
+   Hatching + strike-through, deliberately the same language the run timeline uses for the same
+   fact, so a step reads identically whether someone is looking at the list or the diagram. */
+.mj-flow-node-body--skipped {
+  opacity: 0.55;
+  background-image: repeating-linear-gradient(
+    135deg,
+    transparent,
+    transparent 5px,
+    color-mix(in srgb, var(--mj-text-disabled) 22%, transparent) 5px,
+    color-mix(in srgb, var(--mj-text-disabled) 22%, transparent) 10px
+  );
+}
+
+.mj-flow-node-body--skipped .mj-flow-node-title {
+  text-decoration: line-through;
+  text-decoration-color: var(--mj-text-disabled);
+}
+
+.mj-flow-node-status--skipped { color: var(--mj-text-disabled); }

--- a/packages/Angular/Generic/flow-editor/src/lib/components/flow-node.component.html
+++ b/packages/Angular/Generic/flow-editor/src/lib/components/flow-node.component.html
@@ -16,6 +16,7 @@
   [class.mj-flow-node-body--loop]="isLoopNode"
   [class.mj-flow-node-body--disabled]="Node.Status === 'disabled'"
   [class.mj-flow-node-body--pending]="Node.Status === 'pending'"
+  [class.mj-flow-node-body--skipped]="Node.Status === 'skipped'"
   [class.mj-flow-node-body--running]="Node.Status === 'running'"
   [class.mj-flow-node-body--warning]="Node.Status === 'warning'"
   [class.mj-flow-node-body--error]="Node.Status === 'error'"

--- a/packages/Angular/Generic/flow-editor/src/lib/interfaces/flow-types.ts
+++ b/packages/Angular/Generic/flow-editor/src/lib/interfaces/flow-types.ts
@@ -40,7 +40,14 @@ export interface FlowNodeBadge {
 }
 
 /** Visual status of a node */
-export type FlowNodeStatus = 'default' | 'success' | 'error' | 'warning' | 'running' | 'disabled' | 'pending';
+/**
+ * How a node presents its state.
+ *
+ * `skipped` is deliberately its own value rather than a shade of `disabled`. Disabled means "this
+ * cannot run"; skipped means "the graph chose another route" — nothing is wrong, and a reader who
+ * cannot tell them apart goes looking for a failure that never happened.
+ */
+export type FlowNodeStatus = 'default' | 'success' | 'error' | 'warning' | 'running' | 'disabled' | 'pending' | 'skipped';
 
 /** A node in the flow graph */
 export interface FlowNode {
@@ -73,6 +80,15 @@ export type FlowConnectionStyle = 'solid' | 'dashed' | 'dotted';
 
 /** A connection (edge) between two nodes */
 export interface FlowConnection {
+  /**
+   * The route was NOT followed — a conditional branch the graph declined.
+   *
+   * Distinct from `Style`, which is about the edge's KIND (conditional vs default). An edge can be
+   * conditional and taken, conditional and not taken, or unconditional; collapsing "not taken" into
+   * the dash pattern would make those indistinguishable at exactly the moment someone is trying to
+   * work out which way a run went.
+   */
+  NotTaken?: boolean;
   ID: string;
   SourceNodeID: string;
   SourcePortID: string;

--- a/packages/Angular/Generic/flow-editor/src/lib/interfaces/flow-types.ts
+++ b/packages/Angular/Generic/flow-editor/src/lib/interfaces/flow-types.ts
@@ -80,15 +80,6 @@ export type FlowConnectionStyle = 'solid' | 'dashed' | 'dotted';
 
 /** A connection (edge) between two nodes */
 export interface FlowConnection {
-  /**
-   * The route was NOT followed — a conditional branch the graph declined.
-   *
-   * Distinct from `Style`, which is about the edge's KIND (conditional vs default). An edge can be
-   * conditional and taken, conditional and not taken, or unconditional; collapsing "not taken" into
-   * the dash pattern would make those indistinguishable at exactly the moment someone is trying to
-   * work out which way a run went.
-   */
-  NotTaken?: boolean;
   ID: string;
   SourceNodeID: string;
   SourcePortID: string;

--- a/packages/Angular/Generic/task-graph-editor/src/__tests__/task-graph-editor.component.test.ts
+++ b/packages/Angular/Generic/task-graph-editor/src/__tests__/task-graph-editor.component.test.ts
@@ -345,16 +345,26 @@ describe('routes the workflow did not take', () => {
     };
     const runtime = { start: 'Complete', taken: 'Complete', 'not-taken': 'Skipped' } as const;
 
-    it('marks the edge into a skipped step as not taken', () => {
-        const byTarget = new Map(SpecToConnections(branching, runtime).map((c) => [c.TargetNodeID, c]));
-        expect(byTarget.get('not-taken')?.NotTaken).toBe(true);
-        expect(byTarget.get('taken')?.NotTaken).toBeUndefined();
+    it('draws no edge into a step the workflow declined', () => {
+        expect(SpecToConnections(branching, runtime).some((c) => c.TargetNodeID === 'not-taken')).toBe(false);
     });
 
-    it('still draws the edge, so the branch remains visible', () => {
-        // Removing it would leave the skipped node floating unattached — a rendering fault to a
-        // reader, rather than a branch nobody took.
-        expect(SpecToConnections(branching, runtime).some((c) => c.TargetNodeID === 'not-taken')).toBe(true);
+    it('draws no edge OUT of a declined step either', () => {
+        // An edge leaving a skipped step is as untravelled as one entering it — checking only the
+        // target would leave half of every abandoned branch drawn as though it had carried something.
+        const withDownstream: TaskGraphSpec = {
+            ...branching,
+            tasks: [
+                ...branching.tasks,
+                TaskNode.Action({ tempId: 'after', name: 'After', description: '', dependsOn: ['not-taken'] }, { actionName: 'Q' }),
+            ],
+        };
+        const conns = SpecToConnections(withDownstream, { ...runtime, after: 'Pending' });
+        expect(conns.some((c) => c.SourceNodeID === 'not-taken')).toBe(false);
+    });
+
+    it('keeps the edges along the route that WAS taken', () => {
+        expect(SpecToConnections(branching, runtime).some((c) => c.TargetNodeID === 'taken')).toBe(true);
     });
 
     it('gives a skipped step its own node status, not the default one', () => {
@@ -363,7 +373,9 @@ describe('routes the workflow did not take', () => {
         expect(nodes.find((n) => n.ID === 'taken')?.Status).toBe('success');
     });
 
-    it('marks nothing when no runtime is supplied — design time has no routes taken', () => {
-        expect(SpecToConnections(branching).every((c) => c.NotTaken === undefined)).toBe(true);
+    it('DESIGN mode keeps every edge — there is no route yet, only routes that could be taken', () => {
+        // The same graph with no runtime is what an author is arranging; hiding a branch there would
+        // hide part of what they are building.
+        expect(SpecToConnections(branching)).toHaveLength(2);
     });
 });

--- a/packages/Angular/Generic/task-graph-editor/src/__tests__/task-graph-editor.component.test.ts
+++ b/packages/Angular/Generic/task-graph-editor/src/__tests__/task-graph-editor.component.test.ts
@@ -13,7 +13,8 @@
  */
 import { describe, it, expect, beforeEach } from 'vitest';
 import { TaskGraphEditorComponent } from '../lib/task-graph-editor.component';
-import type { TaskGraphSpec, TaskGraphSpecNode } from '@memberjunction/ai-core-plus';
+import { TaskNode, type TaskGraphSpec, type TaskGraphSpecNode } from '@memberjunction/ai-core-plus';
+import { SpecToConnections, SpecToNodes } from '../lib/task-graph-canvas-adapter';
 import type {
     AfterDependencyAddedEventArgs,
     AfterTaskAddedEventArgs,
@@ -282,5 +283,87 @@ describe('TaskGraphEditorComponent', () => {
             c.OnNodeRemoved(c.Nodes[0]);
             expect(c.Spec!.tasks).toHaveLength(1);
         });
+    });
+});
+
+/**
+ * Port identity, and why edges vanished.
+ *
+ * The canvas resolves a connection by looking its `fOutputId` / `fInputId` up among ALL registered
+ * ports — one flat namespace for the whole graph. Every node used to declare ports literally called
+ * `in` and `out`, so no connection could name which node's port it meant, and a workflow drew its
+ * boxes with no edges at all. Nothing errored: an unresolvable port is just a connection with
+ * nowhere to attach.
+ */
+describe('canvas ports are scoped to their node', () => {
+    const spec: TaskGraphSpec = {
+        workflowName: 'W',
+        reasoning: '',
+        tasks: [
+            TaskNode.Action({ tempId: 'a', name: 'A', description: '', dependsOn: [] }, { actionName: 'X' }),
+            TaskNode.Action({ tempId: 'b', name: 'B', description: '', dependsOn: ['a'] }, { actionName: 'Y' }),
+        ],
+    };
+
+    it('gives no two nodes the same port id', () => {
+        const ids = SpecToNodes(spec).flatMap((n) => n.Ports.map((p) => p.ID));
+        expect(new Set(ids).size).toBe(ids.length);
+    });
+
+    it('points a connection at ports that actually exist on its endpoints', () => {
+        const nodes = SpecToNodes(spec);
+        const [conn] = SpecToConnections(spec);
+        const source = nodes.find((n) => n.ID === conn.SourceNodeID)!;
+        const target = nodes.find((n) => n.ID === conn.TargetNodeID)!;
+
+        expect(source.Ports.map((p) => p.ID)).toContain(conn.SourcePortID);
+        expect(target.Ports.map((p) => p.ID)).toContain(conn.TargetPortID);
+    });
+
+    it('does not reuse one endpoint id for both ends', () => {
+        const [conn] = SpecToConnections(spec);
+        expect(conn.SourcePortID).not.toBe(conn.TargetPortID);
+    });
+});
+
+/**
+ * A branch the workflow declined must not read like a route it followed.
+ *
+ * `Skipped` was absent from the runtime-state union entirely, so it fell through to the default
+ * rendering and a not-taken step drew as an ordinary node with an ordinary edge into it — which is
+ * how a conditional workflow looks like it ran every branch.
+ */
+describe('routes the workflow did not take', () => {
+    const branching: TaskGraphSpec = {
+        workflowName: 'W',
+        reasoning: '',
+        tasks: [
+            TaskNode.Action({ tempId: 'start', name: 'Start', description: '', dependsOn: [] }, { actionName: 'X' }),
+            TaskNode.Action({ tempId: 'taken', name: 'Taken', description: '', dependsOn: ['start'] }, { actionName: 'Y' }),
+            TaskNode.Action({ tempId: 'not-taken', name: 'Not taken', description: '', dependsOn: ['start'] }, { actionName: 'Z' }),
+        ],
+    };
+    const runtime = { start: 'Complete', taken: 'Complete', 'not-taken': 'Skipped' } as const;
+
+    it('marks the edge into a skipped step as not taken', () => {
+        const byTarget = new Map(SpecToConnections(branching, runtime).map((c) => [c.TargetNodeID, c]));
+        expect(byTarget.get('not-taken')?.NotTaken).toBe(true);
+        expect(byTarget.get('taken')?.NotTaken).toBeUndefined();
+    });
+
+    it('still draws the edge, so the branch remains visible', () => {
+        // Removing it would leave the skipped node floating unattached — a rendering fault to a
+        // reader, rather than a branch nobody took.
+        expect(SpecToConnections(branching, runtime).some((c) => c.TargetNodeID === 'not-taken')).toBe(true);
+    });
+
+    it('gives a skipped step its own node status, not the default one', () => {
+        const nodes = SpecToNodes(branching, runtime);
+        expect(nodes.find((n) => n.ID === 'not-taken')?.Status).toBe('skipped');
+        expect(nodes.find((n) => n.ID === 'taken')?.Status).toBe('success');
+    });
+
+    it('marks nothing when no runtime is supplied — design time has no routes taken', () => {
+        expect(SpecToConnections(branching).every((c) => c.NotTaken === undefined)).toBe(true);
     });
 });

--- a/packages/Angular/Generic/task-graph-editor/src/__tests__/task-graph-runtime-source.test.ts
+++ b/packages/Angular/Generic/task-graph-editor/src/__tests__/task-graph-runtime-source.test.ts
@@ -129,3 +129,41 @@ describe('SummarizeRuntime', () => {
         expect(SummarizeRuntime({ a: 'Complete' }, ['a'])).toContain('1 step —');
     });
 });
+
+/**
+ * `Skipped` and the silent default.
+ *
+ * `NormalizeRuntimeState` fell back to `Pending` for anything it did not recognise, and it did not
+ * recognise `Skipped` — so a branch the workflow declined was reported to the canvas as STILL
+ * WAITING TO RUN. That is not a near-miss, it is the opposite of the truth, and every consumer
+ * believed it: the node drew as an ordinary pending step, the edges into and out of it drew as live
+ * routes, and a settled graph could never satisfy `IsRuntimeSettled`.
+ */
+describe('a branch that was not taken', () => {
+    it('is carried through as Skipped, not flattened to Pending', () => {
+        expect(NormalizeRuntimeState('Skipped')).toBe('Skipped');
+    });
+
+    it('still falls back to Pending for a status the client has never heard of', () => {
+        // The fallback itself is right — a schema ahead of the client should degrade to "we don't
+        // know yet" rather than throw in a render path. The defect was what it was swallowing.
+        expect(NormalizeRuntimeState('SomethingNew')).toBe('Pending');
+        expect(NormalizeRuntimeState(null)).toBe('Pending');
+    });
+
+    it('reaches the canvas from a row', () => {
+        const status = BuildRuntimeStatus(
+            [{ ID: 'a', Name: 'Get Weather', Status: 'Skipped' }],
+            new Map(),
+            new Set(['a']),
+        );
+        expect(status['a']).toBe('Skipped');
+    });
+
+    it('counts as settled — it is not going to be taken later', () => {
+        // Without this a workflow containing a declined branch never reports as finished, so a host
+        // polling on it polls a completed run forever.
+        const status = { a: 'Complete', b: 'Skipped' } as const;
+        expect(IsRuntimeSettled(status, ['a', 'b'])).toBe(true);
+    });
+});

--- a/packages/Angular/Generic/task-graph-editor/src/lib/task-graph-canvas-adapter.ts
+++ b/packages/Angular/Generic/task-graph-editor/src/lib/task-graph-canvas-adapter.ts
@@ -379,12 +379,18 @@ export function SpecToConnections(spec: TaskGraphSpec, runtime?: TaskGraphRuntim
         for (const dep of GetDependencies(task)) {
             if (!known.has(dep.tempId)) continue;
 
+            // RUN MODE DRAWS ONLY THE PATH TAKEN.
+            //
+            // An edge touching a step the workflow declined did not carry anything, and drawing it
+            // makes a conditional workflow look as though both branches ran. Both ENDS are checked:
+            // an edge out of a skipped step is as untravelled as one into it.
+            //
+            // Design mode keeps every edge, because there is no route yet — the graph is all the
+            // routes that COULD be taken, which is exactly what an author is arranging. `runtime`
+            // being present is what distinguishes the two, so the same function serves both.
+            if (runtime && (runtime[task.tempId] === 'Skipped' || runtime[dep.tempId] === 'Skipped')) continue;
+
             const conditional = !!dep.condition?.trim();
-            // An edge into a step the workflow did not take must not read like a route that was
-            // followed. Drawn receding rather than removed: deleting it would leave the skipped node
-            // floating unattached, which reads as a rendering fault rather than as a branch nobody
-            // took — and the fact that the branch EXISTS is the thing a reader is trying to see.
-            const notTaken = runtime?.[task.tempId] === 'Skipped';
             connections.push({
                 ID: edgeId(dep.tempId, task.tempId),
                 // Reversed: dependsOn points back at the prerequisite, the drawn arrow points forward.
@@ -398,8 +404,7 @@ export function SpecToConnections(spec: TaskGraphSpec, runtime?: TaskGraphRuntim
                 LabelDetail: dep.condition ?? undefined,
                 LabelIcon: conditional ? 'fa-code-branch' : undefined,
                 Condition: dep.condition ?? undefined,
-                Style: notTaken ? 'dotted' : (conditional ? 'dashed' : 'solid'),
-                NotTaken: notTaken || undefined,
+                Style: conditional ? 'dashed' : 'solid',
                 Data: { FromTempId: dep.tempId, ToTempId: task.tempId },
             });
         }

--- a/packages/Angular/Generic/task-graph-editor/src/lib/task-graph-canvas-adapter.ts
+++ b/packages/Angular/Generic/task-graph-editor/src/lib/task-graph-canvas-adapter.ts
@@ -66,6 +66,32 @@ export function IsAuthorableNodeType(type: TaskGraphRenderType): type is TaskGra
 /** A rendering entry — every shape the canvas can depict, authorable or not. */
 export type TaskGraphRenderTypeConfig = FlowNodeTypeConfig & { Type: TaskGraphRenderType };
 
+/**
+ * Port ids are scoped to their NODE, and must be.
+ *
+ * The canvas resolves a connection by looking its `fOutputId` / `fInputId` up among all registered
+ * ports — a flat, graph-wide namespace. Giving every node ports literally called `in` and `out` made
+ * every node's ports collide with every other node's, so a connection could not name which node's
+ * port it meant. The result was a workflow that drew its boxes correctly and **no edges at all**:
+ * nothing errored, because an unresolvable port is simply a connection with nowhere to attach.
+ *
+ * The Flow Agent editor — the other consumer of this canvas, whose edges have always drawn — scopes
+ * its ports the same way (`${stepId}-input` / `${stepId}-output`). This is that convention, named,
+ * so a future producer cannot reintroduce the collision by writing the obvious literal.
+ */
+export function InputPortID(tempId: string): string {
+    return `${tempId}-in`;
+}
+
+export function OutputPortID(tempId: string): string {
+    return `${tempId}-out`;
+}
+
+/**
+ * Palette defaults. These carry the bare names because a palette entry describes a node TYPE, not a
+ * placed node — there is no id to scope them to yet. {@link SpecToNodes} assigns the real, scoped
+ * ids when a node is actually placed on the canvas.
+ */
 const TASK_GRAPH_PORTS: FlowNodeTypeConfig['DefaultPorts'] = [
     { ID: 'in', Direction: 'input', Side: 'top', Multiple: true },
     { ID: 'out', Direction: 'output', Side: 'bottom', Multiple: true },
@@ -134,7 +160,10 @@ export type TaskGraphRuntimeState =
     | 'Failed'
     | 'Blocked'
     | 'Cancelled'
-    | 'Deferred';
+    | 'Deferred'
+    // A branch the workflow did not take. Absent from this union until now, which is why it fell
+    // through to the default rendering and a not-taken step drew as an ordinary one.
+    | 'Skipped';
 
 /**
  * Maps a durable task state onto the canvas's visual vocabulary.
@@ -151,6 +180,10 @@ export function RuntimeStateToNodeStatus(state: TaskGraphRuntimeState | undefine
         case 'Failed':      return 'error';
         case 'Blocked':     return 'warning';
         case 'Cancelled':   return 'disabled';
+        // Its own state, not a shade of disabled: a branch the workflow did not take is a normal
+        // outcome. Falling through to 'default' — which is what happened before — drew it as an
+        // ordinary node, so a conditional workflow looked like it had run every branch.
+        case 'Skipped':     return 'skipped';
         case 'Deferred':    return 'pending';
         case 'Pending':     return 'pending';
         default:            return 'default';
@@ -288,8 +321,8 @@ export function SpecToNodes(
             IsStartNode: entryIds.has(task.tempId),
             Position: known ? { ...known } : { X: 0, Y: 0 },
             Ports: [
-                { ID: 'in', Direction: 'input', Side: 'top', Multiple: true },
-                { ID: 'out', Direction: 'output', Side: 'bottom', Multiple: true },
+                { ID: InputPortID(task.tempId), Direction: 'input', Side: 'top', Multiple: true },
+                { ID: OutputPortID(task.tempId), Direction: 'output', Side: 'bottom', Multiple: true },
             ],
             Data: { TempId: task.tempId },
         };
@@ -338,7 +371,7 @@ function LoopBodyLabel(
  * validator reports them as `UnknownDependency`, and rendering a connection to nowhere would be a
  * second, worse way of saying the same thing.
  */
-export function SpecToConnections(spec: TaskGraphSpec): FlowConnection[] {
+export function SpecToConnections(spec: TaskGraphSpec, runtime?: TaskGraphRuntimeStatus): FlowConnection[] {
     const known = new Set((spec.tasks ?? []).map((t) => t.tempId));
     const connections: FlowConnection[] = [];
 
@@ -347,18 +380,26 @@ export function SpecToConnections(spec: TaskGraphSpec): FlowConnection[] {
             if (!known.has(dep.tempId)) continue;
 
             const conditional = !!dep.condition?.trim();
+            // An edge into a step the workflow did not take must not read like a route that was
+            // followed. Drawn receding rather than removed: deleting it would leave the skipped node
+            // floating unattached, which reads as a rendering fault rather than as a branch nobody
+            // took — and the fact that the branch EXISTS is the thing a reader is trying to see.
+            const notTaken = runtime?.[task.tempId] === 'Skipped';
             connections.push({
                 ID: edgeId(dep.tempId, task.tempId),
                 // Reversed: dependsOn points back at the prerequisite, the drawn arrow points forward.
                 SourceNodeID: dep.tempId,
-                SourcePortID: 'out',
+                // Scoped to the node — see InputPortID/OutputPortID. Bare 'out'/'in' named a port
+                // that every node in the graph also had, so no connection could resolve one.
+                SourcePortID: OutputPortID(dep.tempId),
                 TargetNodeID: task.tempId,
-                TargetPortID: 'in',
+                TargetPortID: InputPortID(task.tempId),
                 Label: conditional ? 'if' : undefined,
                 LabelDetail: dep.condition ?? undefined,
                 LabelIcon: conditional ? 'fa-code-branch' : undefined,
                 Condition: dep.condition ?? undefined,
-                Style: conditional ? 'dashed' : 'solid',
+                Style: notTaken ? 'dotted' : (conditional ? 'dashed' : 'solid'),
+                NotTaken: notTaken || undefined,
                 Data: { FromTempId: dep.tempId, ToTempId: task.tempId },
             });
         }

--- a/packages/Angular/Generic/task-graph-editor/src/lib/task-graph-editor.component.html
+++ b/packages/Angular/Generic/task-graph-editor/src/lib/task-graph-editor.component.html
@@ -35,6 +35,7 @@
         [ShowToolbar]="ShowToolbar"
         [ShowPalette]="ShowPalette && !ReadOnly"
         [ShowMinimap]="ShowMinimap"
+        [ShowLegend]="ShowLegend"
         [ShowStatusBar]="ShowStatusBar"
         [AutoLayoutDirection]="AutoLayoutDirection"
         (NodeSelected)="OnNodeSelected($event)"

--- a/packages/Angular/Generic/task-graph-editor/src/lib/task-graph-editor.component.html
+++ b/packages/Angular/Generic/task-graph-editor/src/lib/task-graph-editor.component.html
@@ -44,7 +44,8 @@
         (NodesChanged)="OnNodesChanged($event)"
         (NodeMoved)="OnNodeMoved($event)"
         (ConnectionCreated)="OnConnectionCreated($event)"
-        (ConnectionRemoved)="OnConnectionRemoved($event)">
+        (ConnectionRemoved)="OnConnectionRemoved($event)"
+        (LegendToggled)="OnLegendToggled($event)">
       </mj-flow-editor>
 
       <!-- The canvas draws structure; this supplies content. A step added from the palette arrives

--- a/packages/Angular/Generic/task-graph-editor/src/lib/task-graph-editor.component.ts
+++ b/packages/Angular/Generic/task-graph-editor/src/lib/task-graph-editor.component.ts
@@ -199,6 +199,16 @@ export class TaskGraphEditorComponent extends BaseAngularComponent implements On
     @Output() public AfterDependencyRemoved = new EventEmitter<AfterDependencyRemovedEventArgs>();
 
     /** Informational — no `Before` pair, because these report what already happened. */
+    /**
+     * The legend was shown or hidden from the canvas toolbar.
+     *
+     * Forwarded so a host can PERSIST the choice. Without it the toolbar's toggle mutates the
+     * canvas's own flag and nothing else, so the preference dies with the view — and a host that
+     * wanted it remembered would have to add a second control beside the one that already exists,
+     * which is how a surface ends up with two buttons doing the same thing and disagreeing.
+     */
+    @Output() public LegendToggled = new EventEmitter<boolean>();
+
     @Output() public SpecChanged = new EventEmitter<TaskGraphSpecChangedEventArgs>();
     @Output() public SelectionChanged = new EventEmitter<TaskGraphSelectionChangedEventArgs>();
     @Output() public ValidationChanged = new EventEmitter<TaskGraphValidationChangedEventArgs>();
@@ -528,6 +538,12 @@ export class TaskGraphEditorComponent extends BaseAngularComponent implements On
      */
     public OnNodesChanged(nodes: FlowNode[]): void {
         for (const n of nodes) this.knownPositions.set(n.ID, { ...n.Position });
+    }
+
+    /** The canvas toolbar showed or hid the legend; tell whoever is remembering that choice. */
+    public OnLegendToggled(show: boolean): void {
+        this.ShowLegend = show;
+        this.LegendToggled.emit(show);
     }
 
     /** A single node was dragged. Same authority, narrower event. */

--- a/packages/Angular/Generic/task-graph-editor/src/lib/task-graph-editor.component.ts
+++ b/packages/Angular/Generic/task-graph-editor/src/lib/task-graph-editor.component.ts
@@ -151,6 +151,15 @@ export class TaskGraphEditorComponent extends BaseAngularComponent implements On
     @Input() public ShowToolbar: boolean = true;
     @Input() public ShowPalette: boolean = true;
     @Input() public ShowMinimap: boolean = true;
+    /**
+     * Whether the legend rides on the canvas.
+     *
+     * On for authoring, off for a run — and the difference is what the legend is FOR. It explains the
+     * authoring vocabulary (what a conditional edge means, what a duplicate default looks like),
+     * which is what someone drawing a graph needs. A run view is answering a different question —
+     * what happened — and the legend answers none of it while occluding a third of the canvas.
+     */
+    @Input() public ShowLegend: boolean = true;
     @Input() public ShowStatusBar: boolean = true;
     @Input() public AutoLayoutDirection: FlowLayoutDirection = 'vertical';
 

--- a/packages/Angular/Generic/task-graph-editor/src/lib/task-graph-editor.component.ts
+++ b/packages/Angular/Generic/task-graph-editor/src/lib/task-graph-editor.component.ts
@@ -456,7 +456,7 @@ export class TaskGraphEditorComponent extends BaseAngularComponent implements On
             return;
         }
         this.Nodes = SpecToNodes(this.currentSpec, this.currentRuntime ?? undefined, this.knownPositions);
-        this.Connections = SpecToConnections(this.currentSpec);
+        this.Connections = SpecToConnections(this.currentSpec, this.currentRuntime ?? undefined);
         this.Validate();
         this.arrangeIfNeverLaidOut();
     }

--- a/packages/Angular/Generic/task-graph-editor/src/lib/task-graph-run-view.component.css
+++ b/packages/Angular/Generic/task-graph-editor/src/lib/task-graph-run-view.component.css
@@ -1,6 +1,14 @@
-:host { display: block; }
+/* `height: 100%` here resolves to auto when the host's parent has no definite height, so this is
+   safe for both callers: one that gives the widget a box to fill, and one that asks for 320px. */
+:host { display: block; height: 100%; min-height: 0; }
 
-.run-view { display: flex; flex-direction: column; gap: var(--mj-space-2); }
+.run-view {
+  display: flex;
+  flex-direction: column;
+  gap: var(--mj-space-2);
+  height: 100%;
+  min-height: 0;
+}
 
 .run-view-summary {
   display: flex;
@@ -16,7 +24,12 @@
    colouring it like an error sends people hunting for a bug that does not exist. */
 .run-view-skipped { color: var(--mj-text-tertiary); }
 
+/* Takes what the summary line leaves, rather than a percentage of an ancestor that may not have a
+   definite height — which is what left a canvas stopping halfway down its pane with dead space
+   below it. */
 .run-view-canvas {
+  flex: 1 1 auto;
+  min-height: 0;
   border: 1px solid var(--mj-border-default);
   border-radius: var(--mj-radius-md);
   overflow: hidden;

--- a/packages/Angular/Generic/task-graph-editor/src/lib/task-graph-run-view.component.html
+++ b/packages/Angular/Generic/task-graph-editor/src/lib/task-graph-run-view.component.html
@@ -9,7 +9,7 @@
     Message="This workflow has not created any steps.">
   </mj-empty-state>
 } @else {
-  <div class="run-view">
+  <div class="run-view" [style.height]="Height">
     <div class="run-view-summary">
       <span class="run-view-count">{{ CompletedCount }} of {{ TotalCount }} complete</span>
       @if (SkippedCount > 0) {
@@ -17,19 +17,20 @@
       }
     </div>
 
-    <div class="run-view-canvas" [style.height]="Height">
+    <div class="run-view-canvas">
       <mj-task-graph-editor
         [Spec]="Spec"
         [RuntimeStatus]="RuntimeStatus"
         [NodePositions]="Positions"
         [ReadOnly]="true"
-        [ShowToolbar]="false"
+        [ShowToolbar]="ShowToolbar"
         [ShowPalette]="false"
         [ShowProperties]="false"
         [ShowMinimap]="false"
         [ShowStatusBar]="false"
         [ShowLegend]="ShowLegend"
-        (SelectionChanged)="OnSelectionChanged($event)">
+        (SelectionChanged)="OnSelectionChanged($event)"
+        (LegendToggled)="LegendToggled.emit($event)">
       </mj-task-graph-editor>
     </div>
   </div>

--- a/packages/Angular/Generic/task-graph-editor/src/lib/task-graph-run-view.component.html
+++ b/packages/Angular/Generic/task-graph-editor/src/lib/task-graph-run-view.component.html
@@ -28,6 +28,7 @@
         [ShowProperties]="false"
         [ShowMinimap]="false"
         [ShowStatusBar]="false"
+        [ShowLegend]="ShowLegend"
         (SelectionChanged)="OnSelectionChanged($event)">
       </mj-task-graph-editor>
     </div>

--- a/packages/Angular/Generic/task-graph-editor/src/lib/task-graph-run-view.component.ts
+++ b/packages/Angular/Generic/task-graph-editor/src/lib/task-graph-run-view.component.ts
@@ -91,6 +91,16 @@ export class TaskGraphRunViewComponent extends BaseAngularComponent implements O
     /** Height of the canvas. Hosts embed this in very different amounts of space. */
     @Input() public Height: string = '320px';
 
+    /**
+     * Whether the canvas legend shows. **Off by default here**, unlike the editor.
+     *
+     * The legend explains the authoring vocabulary — what a conditional edge means, what a duplicate
+     * default looks like. That is what someone drawing a graph needs. A run view answers a different
+     * question, "what happened", which the legend helps with not at all while covering a corner of
+     * the canvas the graph is usually occupying.
+     */
+    @Input() public ShowLegend: boolean = false;
+
     @Output() public NodeSelected = new EventEmitter<TaskGraphRunNodeSelectedEvent>();
     /** Emitted once, when every step has reached a terminal status. */
     @Output() public Settled = new EventEmitter<void>();

--- a/packages/Angular/Generic/task-graph-editor/src/lib/task-graph-run-view.component.ts
+++ b/packages/Angular/Generic/task-graph-editor/src/lib/task-graph-run-view.component.ts
@@ -101,7 +101,19 @@ export class TaskGraphRunViewComponent extends BaseAngularComponent implements O
      */
     @Input() public ShowLegend: boolean = false;
 
+    /**
+     * Whether the canvas toolbar rides above the graph. **On**, unlike the legend.
+     *
+     * The two were switched off together, and they are not the same kind of thing. The legend
+     * explains authoring vocabulary, which a run does not need. The toolbar is how a person
+     * navigates the picture — zoom, fit, pan versus select — and a graph you cannot pan is a graph
+     * you can only read if it happens to fit.
+     */
+    @Input() public ShowToolbar: boolean = true;
+
     @Output() public NodeSelected = new EventEmitter<TaskGraphRunNodeSelectedEvent>();
+    /** The legend was toggled from the toolbar, so a host can remember the choice. */
+    @Output() public LegendToggled = new EventEmitter<boolean>();
     /** Emitted once, when every step has reached a terminal status. */
     @Output() public Settled = new EventEmitter<void>();
 

--- a/packages/Angular/Generic/task-graph-editor/src/lib/task-graph-runtime-source.ts
+++ b/packages/Angular/Generic/task-graph-editor/src/lib/task-graph-runtime-source.ts
@@ -67,6 +67,12 @@ export function NormalizeRuntimeState(status: string | null | undefined): TaskGr
         case 'Cancelled':
         case 'Deferred':
         case 'Pending':
+        // A branch the workflow declined. Absent from this list until now, so it fell to the default
+        // and was reported to the canvas as **Pending** — which is not a near-miss, it is the
+        // opposite: "still waiting to run" for a step that will never run. Everything downstream
+        // believed it. The node drew as an ordinary pending step, the edges into and out of it drew
+        // as live routes, and a settled graph could never satisfy `IsRuntimeSettled`.
+        case 'Skipped':
             return status;
         default:
             return 'Pending';
@@ -80,9 +86,15 @@ export function BuildNameIndex(tasks: readonly { tempId: string; name: string }[
     return new Map(tasks.map((t) => [t.name, t.tempId]));
 }
 
-/** True once every task has reached a state nothing will move it out of. */
+/**
+ * True once every task has reached a state nothing will move it out of.
+ *
+ * `Skipped` is terminal — a branch that was not taken is not going to be taken later — and its
+ * absence here meant a graph containing one never reported as settled, so a host polling on this
+ * would poll a finished workflow forever.
+ */
 export function IsRuntimeSettled(status: TaskGraphRuntimeStatus, tempIds: readonly string[]): boolean {
-    const terminal = new Set<TaskGraphRuntimeState>(['Complete', 'Failed', 'Cancelled']);
+    const terminal = new Set<TaskGraphRuntimeState>(['Complete', 'Failed', 'Cancelled', 'Skipped']);
     return tempIds.length > 0 && tempIds.every((id) => terminal.has(status[id] ?? 'Pending'));
 }
 


### PR DESCRIPTION
A workflow run is a picture of what happened. This makes the picture true, and makes the surface around it usable.

Four defects here shared one signature — **the code produced a plausible result and nothing said it was wrong**. Two of them had been shipping since the canvas existed.

---

## 1. Edges could never bind

Every task-graph node declared its canvas ports literally named `in` and `out`. The canvas resolves a connection by looking its `fOutputId` / `fInputId` up in **one flat, graph-wide namespace** — so with every node's ports named identically, no connection could say *which* node's port it meant.

A workflow drew its boxes and no edges at all. Nothing errored, because an unresolvable port is simply a connection with nowhere to attach, so the canvas rendered a stray endpoint and moved on. It looked like a graph that had no edges rather than a graph whose edges could not resolve.

The Flow Agent editor — the other consumer of this same canvas, whose edges have always drawn — scopes its ports `${stepId}-input`. That convention is now named (`InputPortID` / `OutputPortID`) rather than spelled out at each site, so writing the obvious literal cannot reintroduce the collision.

## 2. A declined branch was reported to the canvas as `Pending`

`NormalizeRuntimeState` coerces a row's status into the canvas vocabulary and falls back to `Pending` for anything it does not recognise. It did not recognise `Skipped`.

So a branch the workflow *chose not to take* arrived as **"still waiting to run"** — not a near-miss, the opposite of the truth. Three consumers believed it:

- the node drew as an ordinary pending step, never hatched;
- its edges drew as live routes, because the rule that hides them asks "is this Skipped?" and was told Pending;
- `IsRuntimeSettled` treats Pending as non-terminal, so **a graph containing a declined branch never reported as settled** — a host polling on it would poll a completed run forever. That one was lurking independently of anything visible.

The fallback itself is right: a schema ahead of the client should degrade to "we don't know yet" rather than throw inside a render path. What was wrong is that it was swallowing a status the schema has had all along.

## 3. The agent run's Workflow tab showed the plan, not the run

It rendered the recorded `TaskGraphSpec` on a bare canvas with **no runtime**, so every branch appeared to have run and the legend sat over the graph. It now uses the same `mj-task-graph-run-view` the Workflows app does, which reads the `Task` rows.

It falls back to the spec view only for a constant-folded graph (D9) — that one never reached the dispatcher, so there are no rows and no run to show, and a plan is the honest thing to draw.

## 4. The canvas never filled its pane

`Height` was applied to the canvas element, whose ancestors had no definite height — so `100%` resolved to `auto`, the graph took its intrinsic size, and dead space sat beneath it. It now governs the widget: the summary takes its natural height and the canvas flexes into the rest. Both callers still work — one that hands the widget a box to fill, and one that asks for `320px`.

---

## What a run looks like now

**Only the path taken.** Edges touching a declined step are omitted — *both ends*, since an edge leaving a skipped step is as untravelled as one entering it — and the step is hatched and struck through, in the same visual language the run timeline already uses for the same fact.

**Design mode still draws every edge.** There is no route yet; the graph is all the routes that *could* be taken, which is exactly what an author is arranging. `runtime` being present is what distinguishes the two, so one function serves both.

**`FlowNodeStatus` gains `skipped`**, deliberately not folded into `disabled`. Disabled means "cannot run"; skipped means "the graph went the other way". A reader who cannot tell them apart goes hunting for a failure that never happened.

**The toolbar is back, the legend is not.** They had been switched off together and they are not the same kind of thing: the legend explains authoring vocabulary a run does not need, while the toolbar is how a person navigates the picture — zoom, fit, pan versus select. A graph you cannot pan is one you can only read if it happens to fit. The toolbar already had a legend toggle, so `LegendToggled` is forwarded and persisted rather than adding a second control beside it; two controls for one setting are two controls free to disagree.

## Workflows → Runs

Resizable panes — list | detail, and canvas | step record inside it — with the step record moved **beside** the canvas rather than into a strip below it, where a JSON record showed about ten lines.

Sizes persist per user through `UserInfoEngine`, never `localStorage`: a pane width that vanishes when you open a different browser is exactly the preference people notice when it disappears.

Two rules worth naming, both of which fail silently when wrong:

- **Size is stored separately from openness.** Close and reopen returns the pane to the width you dragged to, not to a default. Resetting a size someone chose is the small betrayal that stops people using a control.
- **A stored size is validated, not trusted.** A value that predates a layout change — or an `'*'` that angular-split reports for an auto-sized area — would restore a pane nobody can find, or save and then silently reset on the next read.

Below 1100px the inner pair stacks; three columns on a laptop leaves each about 400px and the canvas stops being usable.

---

## Verification

- **flow-editor 46 · task-graph-editor 161 · core-entity-forms 263 · dashboards 1746**
- Spec type gate (`tsc --noEmit -p tsconfig.spec.json`) clean on every touched package — it is a separate gate from vitest, which cannot see these because esbuild strips types without checking them
- UI token + button gates clean
- Live-verified against a real Demo Flow Agent run: declined branch hatched with no edges to or from it, remaining path drawn end to end

## A note on how these were found

Each of the four was invisible to the tests that existed. The port collision passed every unit test because `SpecToConnections` returns correct-looking objects — they simply name ports nothing could resolve. The `Skipped` normalization passed because I had tested the edge rule with a hand-written runtime map containing `'Skipped'`, which proved the rule and proved nothing about whether that value can ever reach it; the gap was *between* two units I had tested separately.

The new tests close those seams: a row with `Status: 'Skipped'` must come out the other side as `Skipped`, no two nodes may share a port id, and a connection must name ports its endpoints actually have.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
