### PR TITLE
The workflow canvas fills its pane instead of resting on a 400px floor

### DIFF
--- a/.changeset/workflow-run-canvas-height.md
+++ b/.changeset/workflow-run-canvas-height.md
@@ -1,0 +1,22 @@
+---
+'@memberjunction/ng-flow-editor': patch
+'@memberjunction/ng-task-graph-editor': patch
+'@memberjunction/ng-dashboards': patch
+---
+
+The workflow canvas fills the space it is given instead of sitting at 400px.
+
+Two broken links in one height chain, both of which fail silently — CSS does not report a percentage
+height that had nothing to resolve against, it just computes `auto`.
+
+`FlowEditorComponent` and `TaskGraphEditorComponent` are custom elements with no `:host` rule, so
+their host boxes were `display: inline` with automatic height. The `height: 100%` on each component's
+root element therefore resolved against an auto-height parent — which means `auto` — and
+`.mj-flow-editor` fell through to its `min-height: 400px` floor. The canvas was pinned at 400px no
+matter how much room its pane had. Both hosts now declare `display: block; height: 100%`, which is
+safe for callers that don't give them a box: it resolves to `auto` there and the floor takes over
+exactly as before.
+
+The Workflows Runs detail pane had the same defect one level up: `.wfr-detail` is a flex column
+inside a split area with no height of its own, so the canvas below it — `flex: 1 1 auto` of an
+auto-height parent — got its intrinsic size and left dead space beneath.

--- a/packages/Angular/Explorer/dashboards/src/Workflows/components/workflow-runs-resource.component.css
+++ b/packages/Angular/Explorer/dashboards/src/Workflows/components/workflow-runs-resource.component.css
@@ -145,6 +145,9 @@
 .wfr-detail {
   display: flex;
   flex-direction: column;
+  /* Fills its split area. Without it the column sizes to its CONTENT, so the canvas below —
+     `flex: 1 1 auto` of an auto-height parent — got its intrinsic height and left dead space. */
+  height: 100%;
   min-height: 0;
   background: var(--mj-bg-surface);
   border: 1px solid var(--mj-border-default);

--- a/packages/Angular/Generic/flow-editor/src/lib/components/flow-editor.component.css
+++ b/packages/Angular/Generic/flow-editor/src/lib/components/flow-editor.component.css
@@ -2,6 +2,19 @@
    Flow Editor — Main container styles
    ============================================================ */
 
+/* The HOST is a custom element, which is `display: inline` with auto height until told otherwise.
+   Without this, `.mj-flow-editor { height: 100% }` below resolved against an auto-height parent —
+   which means auto — so the canvas fell back to its `min-height` floor and sat at 400px no matter
+   how much room its pane actually had.
+
+   `height: 100%` here is safe for hosts that DON'T give it a box: it resolves to auto in that case,
+   and the floor takes over exactly as before. */
+:host {
+  display: block;
+  height: 100%;
+  min-height: 0;
+}
+
 .mj-flow-editor {
   display: flex;
   flex-direction: column;

--- a/packages/Angular/Generic/task-graph-editor/src/lib/task-graph-editor.component.css
+++ b/packages/Angular/Generic/task-graph-editor/src/lib/task-graph-editor.component.css
@@ -1,4 +1,13 @@
 /* Design tokens only — no hardcoded colors (see .claude/rules/design-tokens.md). */
+
+/* Same reason as the flow editor's host: a custom element is inline with auto height, so the
+   `height: 100%` on `.mj-tge` below had nothing to resolve against. */
+:host {
+  display: block;
+  height: 100%;
+  min-height: 0;
+}
+
 .mj-tge {
   display: flex;
   flex-direction: column;


### PR DESCRIPTION
The workflow canvas was never filling its pane — it was **resting on a floor**.

Two broken links in one height chain, both silent. CSS does not report a percentage height that had nothing to resolve against; it quietly computes `auto` and moves on.

## 1. The canvas hosts had no box

`FlowEditorComponent` and `TaskGraphEditorComponent` are custom elements, and **neither had a `:host` rule** — so their host boxes were `display: inline` with automatic height.

Each component's root element carries `height: 100%`. Against an auto-height parent that means `auto`, so `.mj-flow-editor` fell through to its `min-height: 400px` floor. The graph sat at a fixed height regardless of the space available, because it was never filling anything.

Both hosts now declare `display: block; height: 100%`. That is safe for callers that *don't* hand them a box: `height: 100%` resolves to `auto` there and the `min-height` floor takes over exactly as before.

## 2. The Runs detail pane had the same defect one level up

`.wfr-detail` is a flex column inside a split area with no height of its own, so it sized to its content. The canvas below it — `flex: 1 1 auto` of an auto-height parent — got its intrinsic size and left dead space beneath.

## Why the previous fix wasn't enough

#3743 moved `Height` off the canvas element and onto the run-view widget, and made the canvas flex into what the summary line leaves. That was **necessary and not sufficient**: it repaired the middle of the chain while both ends were still broken. A percentage height only means something when every ancestor up to a definite height agrees, and two of them didn't.

## Verification

- flow-editor **46** · task-graph-editor **161** · dashboards **1746** · core-entity-forms **263**
- UI token + button gates clean
- Chain audited link by link (`.wfr-split` → `.wfr-detail` → `.wfr-graph-split` → `.wfr-graph-pane` → run-view host → `.run-view` → `.run-view-canvas` → editor host → `.mj-tge` → flow-editor host → `.mj-flow-editor`) rather than fixing one and re-checking by eye

🤖 Generated with [Claude Code](https://claude.com/claude-code)
