### PR TITLE
fix(ai): only log the failover banner on an actual failover

### DIFF
--- a/.changeset/fix-false-failover-banner.md
+++ b/.changeset/fix-false-failover-banner.md
@@ -1,0 +1,12 @@
+---
+'@memberjunction/ai-prompts': patch
+---
+
+Stop logging a failover banner for failovers that never happened.
+
+The "🔄 Trying candidate N/M" line was keyed off `i > 0`, which is not the same as
+"a previous candidate failed": candidates lacking credentials in the current
+environment are skipped without ever issuing a request, so the first *called*
+candidate is routinely `i > 0`. Successful first-try calls logged
+`🔄 Trying candidate 2/315`. One regression-suite run produced 515 such lines and
+zero real failovers. Now keyed off an actual prior failure.

--- a/packages/AI/Prompts/src/AIPromptRunner.ts
+++ b/packages/AI/Prompts/src/AIPromptRunner.ts
@@ -3159,21 +3159,47 @@ export class AIPromptRunner {
       }
 
       try {
-        // Log the attempt if not the first one
-        if (i > 0) {
+        // Log the attempt. A "🔄 retry" banner is only truthful once a PREVIOUS
+        // candidate has actually failed — `i > 0` was NOT that test. Candidates
+        // with no credentials in this environment are skipped above without ever
+        // issuing a request, so the first CALLED candidate is routinely i>0 and
+        // every single successful call logged "🔄 Trying candidate 2/315". That
+        // reads as a failover from a failed attempt that never happened (515 such
+        // lines, and zero real failovers, in one regression run). Key off the
+        // real-failure list instead.
+        //
+        // Nothing is logged on the happy path (no prior failures, nothing skipped), so
+        // build the banner and its args only when one of the two branches will fire —
+        // this runs on every attempt of every prompt run.
+        if (failoverAttempts.length > 0 || skippedForCredentials > 0) {
           const vendorName = candidate.vendorName || 'default';
-          LogStatusEx({
-            message: `🔄 Trying candidate ${i + 1}/${allCandidates.length}: ${candidate.model.Name} via ${vendorName}`,
-            category: 'AI',
-            additionalArgs: [{
-              promptId: prompt.ID,
-              modelId: candidate.model.ID,
-              model: candidate.model.Name,
-              vendorId: candidate.vendorId,
-              vendor: candidate.vendorName,
-              attemptNumber: i + 1
-            }]
-          });
+          const attemptArgs = [{
+            promptId: prompt.ID,
+            modelId: candidate.model.ID,
+            model: candidate.model.Name,
+            vendorId: candidate.vendorId,
+            vendor: candidate.vendorName,
+            candidatePosition: i + 1,
+            candidateCount: allCandidates.length,
+            priorFailures: failoverAttempts.length,
+            skippedForCredentials
+          }];
+          if (failoverAttempts.length > 0) {
+            LogStatusEx({
+              message: `🔄 Failover after ${failoverAttempts.length} failed attempt(s) — trying candidate ${i + 1}/${allCandidates.length}: ${candidate.model.Name} via ${vendorName}`,
+              category: 'AI',
+              additionalArgs: attemptArgs
+            });
+          } else {
+            // First real attempt, but earlier candidates were skipped for missing
+            // credentials. State that plainly (and quietly) rather than implying a retry.
+            LogStatusEx({
+              message: `Using candidate ${i + 1}/${allCandidates.length}: ${candidate.model.Name} via ${vendorName} — skipped ${skippedForCredentials} higher-priority candidate(s) with no credentials configured`,
+              category: 'AI',
+              verboseOnly: true,
+              additionalArgs: attemptArgs
+            });
+          }
         }
 
         // Execute the model with this candidate


### PR DESCRIPTION
Split out of #3380 — one root cause, independently revertable.

## Defect

`AIPromptRunner` logged its failover banner based on `i > 0`:

```ts
// Log the attempt if not the first one
if (i > 0) {
  LogStatusEx({ message: `🔄 Trying candidate ${i + 1}/${allCandidates.length}: …` })
```

`i > 0` is **not** "a previous candidate failed". Candidates that lack credentials in the current environment are skipped without ever issuing a request, so the first candidate actually *called* is routinely at index > 0. A successful first-try call logged `🔄 Trying candidate 2/315`.

One regression-suite run produced **515 of these banners and zero real failovers**, which makes the log actively misleading when you are trying to diagnose model routing.

## Fix

Key the banner off an actual prior failure.

## Verified still present

Confirmed against `origin/next` @ `b23bf5933d` — the `if (i > 0)` guard is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)