### PR TITLE
fix(explorer,whiteboard): remove duplicate @HostListener declarations

### DIFF
--- a/.changeset/fix-duplicate-hostlistener.md
+++ b/.changeset/fix-duplicate-hostlistener.md
@@ -1,0 +1,18 @@
+---
+'@memberjunction/ng-explorer-core': patch
+'@memberjunction/ng-whiteboard': patch
+---
+
+Fix two components that declared the same host event twice, silently disabling a handler.
+
+Angular collects host listeners into an object keyed by event name, so a second
+`@HostListener` for the same event **replaces** the first — no build error, no warning.
+
+- `ShellComponent` declared `document:keydown` twice; the surviving handler did not
+  handle the command-palette chord, so Ctrl/Cmd+/ never fired for the entire life of
+  the feature.
+- `WhiteboardHostComponent` had the same bug for `document:click`, killing the Sees
+  dropdown's outside-click dismissal.
+
+Adds a source-level guard test, because a behavioural test can only observe the
+surviving handler — it cannot see that a second declaration clobbered the first.

--- a/packages/Angular/Explorer/explorer-core/src/lib/__tests__/host-listener-uniqueness.test.ts
+++ b/packages/Angular/Explorer/explorer-core/src/lib/__tests__/host-listener-uniqueness.test.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, resolve } from 'node:path';
+
+/**
+ * A component may declare at most ONE `@HostListener` per event name.
+ *
+ * Angular's compiler collects host listeners into an object keyed by event name, so a
+ * second declaration for the same event silently replaces the first — no build error,
+ * no warning, the earlier handler simply never registers. `ShellComponent` shipped that
+ * way: a separate `handleGlobalKeyboardShortcuts` owned Ctrl+/ and was overwritten by
+ * `OnGlobalKeydown`, so the command-palette shortcut was dead for its entire life.
+ *
+ * The failure mode is a duplicate *declaration*, which is what a source check detects
+ * and a behavioural test does not — a behavioural test only ever sees the surviving
+ * handler. Guarded here because #3380 and #3033 both touch this file, so whichever
+ * merges second resolves a conflict on it, and taking "the other side" reintroduces the
+ * duplicate silently.
+ */
+
+/**
+ * Anchored to the start of a line (after indentation) so the decorator is matched but
+ * prose about it is not — `shell.component.ts` carries a "do NOT add a second
+ * `@HostListener('document:keydown')`" warning in a JSDoc block.
+ */
+const HOST_LISTENER = /^[ \t]*@HostListener\(\s*['"]([^'"]+)['"]/gm;
+
+/** Files whose host-listener declarations must stay unique per event. */
+const GUARDED = ['../shell/shell.component.ts'];
+
+function eventsIn(relativePath: string): string[] {
+  const source = readFileSync(resolve(dirname(fileURLToPath(import.meta.url)), relativePath), 'utf8');
+  return [...source.matchAll(HOST_LISTENER)].map((m) => m[1]);
+}
+
+describe('@HostListener uniqueness', () => {
+  for (const file of GUARDED) {
+    it(`${file} declares each host event exactly once`, () => {
+      const events = eventsIn(file);
+      expect(events.length).toBeGreaterThan(0); // the regex must still match something
+
+      const duplicates = events.filter((e, i) => events.indexOf(e) !== i);
+      expect(duplicates).toEqual([]);
+    });
+  }
+
+  it('the shell still owns the global keydown chord handler', () => {
+    // Guards the other direction: a merge that drops the consolidated listener
+    // entirely would leave the duplicate check trivially satisfied.
+    expect(eventsIn(GUARDED[0])).toContain('document:keydown');
+  });
+});

--- a/packages/Angular/Explorer/explorer-core/src/lib/shell/shell.component.ts
+++ b/packages/Angular/Explorer/explorer-core/src/lib/shell/shell.component.ts
@@ -2674,37 +2674,6 @@ export class ShellComponent extends BaseAngularComponent implements OnInit, OnDe
   }
 
   /**
-   * Global keyboard shortcut handler
-   * Cmd+/ (Mac) or Ctrl+/ (Windows) opens the command palette
-   */
-  @HostListener('document:keydown', ['$event'])
-  handleGlobalKeyboardShortcuts(event: KeyboardEvent): void {
-    // Skip if user is typing in an input/textarea — EXCEPT when the omnibar is on:
-    // a modal palette is summonable from anywhere (incl. the chat composer), like
-    // Slack/Linear. The legacy path keeps the guard (its binding steals focus).
-    const target = event.target as HTMLElement;
-    const inEditable = target.tagName === 'INPUT' || target.tagName === 'TEXTAREA' || target.isContentEditable;
-    if (inEditable && !this.UseOmnibar) {
-      return;
-    }
-
-    // Platform detection
-    const isMac = navigator.platform.toUpperCase().indexOf('MAC') >= 0;
-    const isCtrlOrCmd = isMac ? event.metaKey : event.ctrlKey;
-
-    // Cmd+/ or Ctrl+/ opens the palette (omnibar '/' mode when enabled, legacy otherwise)
-    if (isCtrlOrCmd && event.key === '/') {
-      event.preventDefault();
-      event.stopPropagation();
-      if (this.UseOmnibar) {
-        this.OpenOmnibar('/');
-      } else {
-        this.commandPaletteService.Open();
-      }
-    }
-  }
-
-  /**
    * Load user avatar from database, auto-sync from auth provider if needed
    */
   private async loadUserAvatar(currentUserInfo: { ID: string; FirstLast?: string; Name?: string; Email?: string }): Promise<void> {
@@ -2877,21 +2846,52 @@ export class ShellComponent extends BaseAngularComponent implements OnInit, OnDe
   // UNIVERSAL SEARCH EVENT HANDLERS
   // ========================================
 
+  /**
+   * The shell's ONLY `document:keydown` listener — handles every global chord.
+   *
+   * ⚠️ Do NOT add a second `@HostListener('document:keydown')` to this component.
+   * Angular's compiler collects host listeners into an object keyed by event name,
+   * so a second declaration for the same event SILENTLY REPLACES the first — no
+   * build error, no warning, the earlier handler simply never registers. That is
+   * exactly what happened here: a separate `handleGlobalKeyboardShortcuts` owned
+   * Ctrl+/ and was overwritten by this method, so the command palette shortcut was
+   * dead for its entire life. Every new global chord belongs in this one method.
+   *
+   * - **Ctrl/Cmd+K** summons search. Omnibar on: the modal palette opens from
+   *   anywhere, even while typing (explicit chord, Slack/Linear semantics). Omnibar
+   *   off: the chord FOCUSES the inline header composite on desktop (results attach
+   *   beneath it), so keep the don't-steal-focus-mid-typing guard; on mobile (no
+   *   composite rendered) it opens the Spotlight overlay instead.
+   * - **Ctrl/Cmd+/** opens the command palette. Deliberately NOT gated on "is focus
+   *   in an input?" — it responds to exactly one chord that can never be mistaken
+   *   for ordinary typing, and focus-stealing is the expected behavior when you
+   *   summon a modal palette.
+   */
   @HostListener('document:keydown', ['$event'])
   OnGlobalKeydown(event: KeyboardEvent): void {
-      // Ctrl/Cmd+K summons search. Omnibar: the modal palette opens from anywhere,
-      // even while typing (explicit chord, Slack/Linear semantics). Legacy: the
-      // chord FOCUSES the inline header composite on desktop (results attach
-      // beneath it), so keep the don't-steal-focus-mid-typing guard; on mobile
-      // (no composite rendered) it opens the Spotlight overlay instead.
-      const target = event.target as HTMLElement;
-      const inEditable = target.tagName === 'INPUT' || target.tagName === 'TEXTAREA' || target.isContentEditable;
-      if (inEditable && !this.UseOmnibar) {
-          return;
-      }
       const isMac = navigator.platform.toUpperCase().indexOf('MAC') >= 0;
       const isCtrlOrCmd = isMac ? event.metaKey : event.ctrlKey;
-      if (isCtrlOrCmd && event.key === 'k') {
+      if (!isCtrlOrCmd) {
+          return;
+      }
+
+      if (event.key === '/') {
+          event.preventDefault();
+          event.stopPropagation();
+          if (this.UseOmnibar) {
+              this.OpenOmnibar('/');
+          } else {
+              this.commandPaletteService.Open();
+          }
+          return;
+      }
+
+      if (event.key === 'k') {
+          const target = event.target as HTMLElement;
+          const inEditable = target.tagName === 'INPUT' || target.tagName === 'TEXTAREA' || target.isContentEditable;
+          if (inEditable && !this.UseOmnibar) {
+              return;
+          }
           event.preventDefault();
           event.stopPropagation();
           this.OnHeaderSearchClick();

--- a/packages/Angular/Generic/whiteboard/src/lib/whiteboard-host.component.ts
+++ b/packages/Angular/Generic/whiteboard/src/lib/whiteboard-host.component.ts
@@ -248,8 +248,7 @@ export class RealtimeWhiteboardHostComponent implements OnInit, OnDestroy {
     this.SeesOpen = !this.SeesOpen;
   }
 
-  @HostListener('document:click')
-  public CloseSees(): void {
+  private closeSees(): void {
     if (this.SeesOpen) {
       this.SeesOpen = false;
     }
@@ -267,11 +266,25 @@ export class RealtimeWhiteboardHostComponent implements OnInit, OnDestroy {
     this.ExportOpen = !this.ExportOpen;
   }
 
-  @HostListener('document:click')
-  public CloseExport(): void {
+  private closeExport(): void {
     if (this.ExportOpen) {
       this.ExportOpen = false;
     }
+  }
+
+  /**
+   * The component's ONLY `document:click` listener — dismisses every open popover.
+   *
+   * ⚠️ Do NOT add a second `@HostListener('document:click')` here. Angular keys host
+   * listeners by event name, so a second declaration for the same event silently
+   * replaces the first (no build error, no warning). That had already happened:
+   * `closeSees` and `closeExport` each declared one, so only the latter registered
+   * and the Sees dropdown never closed on an outside click.
+   */
+  @HostListener('document:click')
+  public CloseOpenPopovers(): void {
+    this.closeSees();
+    this.closeExport();
   }
 
   /** Download the board as one self-contained HTML document. */


### PR DESCRIPTION
Split out of #3380 — one root cause (in two places), independently revertable.

## Defect

Angular collects host listeners into an object keyed by event name. A second `@HostListener` for the same event **silently replaces** the first — no build error, no warning. The code reads as correct and one handler simply never runs.

Two components shipped that way:

| Component | Duplicated event | Consequence |
|---|---|---|
| `ShellComponent` | `document:keydown` | The surviving declaration didn't handle the command-palette chord, so **Ctrl/Cmd+/ never fired** — for the entire life of the feature |
| `WhiteboardHostComponent` | `document:click` | Killed the Sees dropdown's outside-click dismissal |

## Why the test is source-level, not behavioural

`host-listener-uniqueness.test.ts` asserts on the **source**, which is unusual enough to justify.

The failure mode is a duplicate *declaration*. A behavioural test can only ever observe the **surviving** handler — by construction it cannot see that a second declaration clobbered the first. A behavioural test would have passed happily throughout the entire period Ctrl/Cmd+/ was dead.

It also guards a concrete merge hazard: more than one open branch touches `shell.component.ts`, so whichever merges second resolves a conflict there, and taking "the other side" reintroduces the duplicate silently.

## Verified still present

Confirmed against `origin/next` @ `b23bf5933d`: `shell.component.ts` still has **2** `@HostListener('document:keydown')` and `whiteboard-host.component.ts` still has **2** `@HostListener('document:click')`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)