### PR TITLE
fix(file-storage): stop requesting wire aliases as entity fields on upload

### DIFF
--- a/.changeset/fix-file-upload-wire-names.md
+++ b/.changeset/fix-file-upload-wire-names.md
@@ -1,0 +1,11 @@
+---
+'@memberjunction/ng-file-storage': patch
+---
+
+Stop requesting GraphQL wire aliases as entity field names in the file-upload path.
+
+The upload requested `_mj__CreatedAt` / `_mj__UpdatedAt`. GraphQL reserves the `__`
+prefix, so MJ exposes its `__mj_*` columns under a `_mj__*` alias — but that alias is
+the **wire** name, not an entity field name. The response goes straight to
+`LoadFromData()`, where `SetMany` rejects the unknown keys. Nothing consumed the
+timestamps anyway, so they are simply no longer requested.

--- a/packages/Angular/Generic/file-storage/src/lib/file-upload/file-upload.ts
+++ b/packages/Angular/Generic/file-storage/src/lib/file-upload/file-upload.ts
@@ -16,12 +16,20 @@ export interface FileSelectInfo {
 
 export type FileUploadEvent = { success: true; file: MJFileEntity } | { success: false; file: FileSelectInfo };
 
+// NOTE: deliberately does NOT request the `_mj__CreatedAt` / `_mj__UpdatedAt`
+// transport aliases. GraphQL reserves the `__` prefix, so MJ exposes `__mj_*`
+// columns under a `_mj__*` alias — but the alias is the WIRE name, not an entity
+// field name. The response object is handed straight to `LoadFromData()` below,
+// and `BaseEntity.SetMany` rejects unknown keys ("Field _mj__CreatedAt does not
+// exist on MJ: Files"). Nothing here consumes the timestamps either — the zod
+// schema explicitly omits them — so requesting them only manufactured keys the
+// entity cannot accept. If they're ever needed, reverse-map with
+// `FieldMapper.ReverseMapFields` before hydrating rather than passing them through.
 const FileFieldsFragment = gql`
   fragment FileFields on MJFile_ {
     Category
     CategoryID
     ContentType
-    _mj__CreatedAt
     Description
     ID
     Name
@@ -29,7 +37,6 @@ const FileFieldsFragment = gql`
     ProviderID
     ProviderKey
     Status
-    _mj__UpdatedAt
   }
 `;
 


### PR DESCRIPTION
Split out of #3380 — independently revertable.

## Defect

The file-upload path requested `_mj__CreatedAt` / `_mj__UpdatedAt` as fields.

GraphQL reserves the `__` prefix, so MJ exposes its `__mj_*` columns under a `_mj__*` alias. That alias is the **wire** name, not an entity field name. The response goes straight to `LoadFromData()`, where `SetMany` rejects the unknown keys.

Nothing consumed the timestamps, so they are simply no longer requested.

## Verified still present

Confirmed against `origin/next` @ `b23bf5933d` — `file-upload.ts` still requests both aliases (lines 24 and 32).

🤖 Generated with [Claude Code](https://claude.com/claude-code)