### PR TITLE
fix(dashboards,clustering): harden the tree-shaking loader pattern

### DIFF
--- a/.changeset/fix-treeshake-loader-pattern.md
+++ b/.changeset/fix-treeshake-loader-pattern.md
@@ -1,0 +1,13 @@
+---
+'@memberjunction/ng-dashboards': patch
+'@memberjunction/ng-clustering': patch
+---
+
+Harden the `@RegisterClass` tree-shaking loader pattern so registration survives an
+aggressive build.
+
+Calling the loader functions from a module *constructor* only runs if something
+constructs the module, and the calls are plain statements a `sideEffects: false`
+build is free to drop. When a loader is elided the component never registers, its
+driver class resolves to nothing, and the tab renders "This view isn't available in
+the running build."

--- a/packages/Angular/Explorer/dashboards/src/ai-dashboards.module.ts
+++ b/packages/Angular/Explorer/dashboards/src/ai-dashboards.module.ts
@@ -249,27 +249,44 @@ import { MJWordCloudComponent } from '@memberjunction/ng-word-cloud';
     SharedDashboardWidgetsModule
   ]
 })
-export class AIDashboardsModule {
-    constructor() {
-        // Ensure tree-shaking prevention loaders are called
-        LoadTagsResource();
-        LoadClusterVisualizationResource();
-        LoadVisualizeResource();
-        LoadSchedulingResource();
-        LoadAnalyticsResource();
-        LoadFeaturePipelinesResource();
-        LoadAIAnalyticsResource();
-        LoadAnalyticsExecutiveSummary();
-        LoadAnalyticsPromptRuns();
-        LoadAnalyticsAgentRuns();
-        LoadAnalyticsModelPerformance();
-        LoadAnalyticsCostBudget();
-        LoadAnalyticsErrorAnalysis();
-        LoadAnalyticsUsagePatterns();
-        LoadAnalyticsRealtimeOverview();
-        LoadAnalyticsRealtimeSessions();
-        LoadRealtimeManagement();
-        LoadAnalyticsRealtimeTranscripts();
-        LoadAIOverviewHub();
-    }
-}
+export class AIDashboardsModule {}
+
+// ─── Tree-shaking prevention (MODULE SCOPE — do not move into a constructor) ───
+//
+// These MUST run on file EVALUATION, not NgModule instantiation: the lazy resource
+// path builds components with `createComponent(reg.SubClass)` and never instantiates
+// this NgModule, so a constructor loader never runs.
+//
+// A module-scope call is also the only reference that survives a production build.
+// `declarations` compiles to `ɵɵsetNgModuleScope`, which is `ngJitMode`-guarded and
+// stripped, leaving a component referenced ONLY by module metadata with no live
+// reference for ESBuild to keep. See PR #3380 for the `FeaturePipelinesResource` case.
+//
+// These calls are belt-and-braces, NOT the primary guarantee. Every @RegisterClass
+// component below is also in the eager `mj-class-registrations` manifest, which
+// `@memberjunction/ng-bootstrap` re-exports from its public API and publishes with
+// `sideEffects: true` (see its `scripts/fix-dist-package.js`) precisely so a bare
+// import runs the decorators. That manifest — populated by exporting the component
+// from this package's `public-api.ts` — is what actually fixed FeaturePipelines.
+// So `sideEffects: false` on THIS package is not a live hazard: nothing load-bearing
+// depends on this file being evaluated. Keep the calls as a second line of defense
+// for anything that lands here before it lands in the manifest.
+LoadTagsResource();
+LoadClusterVisualizationResource();
+LoadVisualizeResource();
+LoadSchedulingResource();
+LoadAnalyticsResource();
+LoadFeaturePipelinesResource();
+LoadAIAnalyticsResource();
+LoadAnalyticsExecutiveSummary();
+LoadAnalyticsPromptRuns();
+LoadAnalyticsAgentRuns();
+LoadAnalyticsModelPerformance();
+LoadAnalyticsCostBudget();
+LoadAnalyticsErrorAnalysis();
+LoadAnalyticsUsagePatterns();
+LoadAnalyticsRealtimeOverview();
+LoadAnalyticsRealtimeSessions();
+LoadRealtimeManagement();
+LoadAnalyticsRealtimeTranscripts();
+LoadAIOverviewHub();

--- a/packages/Angular/Explorer/dashboards/src/archiving-dashboards.module.ts
+++ b/packages/Angular/Explorer/dashboards/src/archiving-dashboards.module.ts
@@ -42,10 +42,12 @@ import {
         ArchiveRunsResourceComponent,
     ],
 })
-export class ArchivingDashboardsModule {
-    constructor() {
-        // Ensure tree-shaking prevention loaders are called
-        LoadArchiveConfigResource();
-        LoadArchiveRunsResource();
-    }
-}
+export class ArchivingDashboardsModule {}
+
+// Tree-shaking prevention at MODULE SCOPE — must run on file evaluation, not on
+// NgModule instantiation, because the lazy resource path builds components with
+// `createComponent(reg.SubClass)` and never instantiates this module. See the
+// longer explanation in `ai-dashboards.module.ts`, where a constructor-scoped
+// loader let `FeaturePipelinesResource` get tree-shaken out of its chunk entirely.
+LoadArchiveConfigResource();
+LoadArchiveRunsResource();

--- a/packages/Angular/Generic/clustering/src/lib/clustering.module.ts
+++ b/packages/Angular/Generic/clustering/src/lib/clustering.module.ts
@@ -31,11 +31,14 @@ import { MJEmptyStateComponent, MJAccordionModule } from '@memberjunction/ng-ui-
         ClusterViewPropSheetComponent,
     ],
 })
-export class ClusteringModule {
-    constructor() {
-        // Guarantee the Cluster view-type descriptor's @RegisterClass runs whenever the
-        // clustering feature loads (ng-clustering sets sideEffects:false). App-wide
-        // registration is also covered by the generated ng-bootstrap class manifest.
-        LoadClusterViewType();
-    }
-}
+export class ClusteringModule {}
+
+// Guarantee the Cluster view-type descriptor's @RegisterClass runs whenever the
+// clustering feature loads (ng-clustering sets sideEffects:false). App-wide
+// registration is also covered by the generated ng-bootstrap class manifest.
+//
+// MODULE SCOPE, not the constructor: a lazily-imported module is often evaluated
+// for its side effects without ever being instantiated, so a constructor-scoped
+// loader silently never runs. See `ai-dashboards.module.ts` for the case where
+// that let a whole resource component get tree-shaken out of its chunk.
+LoadClusterViewType();


### PR DESCRIPTION
Split out of #3380 — independently revertable.

## Defect

The `@RegisterClass` tree-shaking loader functions were invoked from module **constructors**:

```ts
export class AIDashboardsModule {
    constructor() {
        // Ensure tree-shaking prevention loaders are called
        LoadTagsResource();
        LoadClusterVisualizationResource();
        …
```

Two problems. A constructor only runs if something actually constructs the module, and the calls are plain statements that a `sideEffects: false` build is free to elide.

When a loader gets dropped, the component never registers, its driver class resolves to nothing, and the tab renders **"This view isn't available in the running build."**

This is the same failure class as the `public-api.ts` export bug from #3380 — which `next` has since fixed independently, landing on the identical export. Two people hitting the same class of bug is the argument for hardening the pattern rather than patching call sites one at a time.

## Verified still present

Confirmed against `origin/next` @ `b23bf5933d` — all three modules still use the constructor-call pattern.

Files: `ai-dashboards.module.ts`, `archiving-dashboards.module.ts`, `clustering.module.ts`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)