### PR TITLE
fix(dashboards): make the query splitter and entity-map rows keyboard-operable

### DIFF
--- a/.changeset/fix-a11y-keyboard-operability.md
+++ b/.changeset/fix-a11y-keyboard-operability.md
@@ -1,0 +1,11 @@
+---
+'@memberjunction/ng-dashboards': patch
+---
+
+Make two mouse-only controls keyboard-operable.
+
+- **Query browser splitter** — had no role and no keyboard affordance, so the panel
+  could only be resized by dragging. Now a real keyboard-operable separator with TS
+  handlers and focus styling.
+- **Integration entity-map rows** — were click-only. Now `role="button"`, `tabindex`,
+  `aria-label`, and Enter/Space activation.

--- a/packages/Angular/Explorer/dashboards/src/Integration/components/connections/connections.component.html
+++ b/packages/Angular/Explorer/dashboards/src/Integration/components/connections/connections.component.html
@@ -619,7 +619,16 @@
           <!-- Table body -->
           <div class="detail-table-body">
             @for (em of DetailFilteredMaps; track em.ID) {
-              <div class="detail-map-row" [class.sync-disabled]="!em.SyncEnabled" (click)="OnEntityMapClick(em)">
+              <!-- The row is the only way to open the field-mapping editor, so it needs a
+                   role and a keyboard path. TODO: the row also contains a checkbox and a
+                   button, which makes role="button" an ARIA structural violation — the real
+                   fix is a dedicated open button (the .map-edit-hint chevron). -->
+              <div class="detail-map-row" [class.sync-disabled]="!em.SyncEnabled"
+                   role="button"
+                   tabindex="0"
+                   [attr.aria-label]="'Open field mapping for ' + em.Entity"
+                   (click)="OnEntityMapClick(em)"
+                   (keydown)="OnEntityMapRowKeydown($event, em)">
                 <span class="dt-col-toggle" (click)="$event.stopPropagation()">
                   <label class="toggle-switch" [title]="em.SyncEnabled ? 'Sync enabled' : 'Sync disabled'">
                     <input type="checkbox"

--- a/packages/Angular/Explorer/dashboards/src/Integration/components/connections/connections.component.ts
+++ b/packages/Angular/Explorer/dashboards/src/Integration/components/connections/connections.component.ts
@@ -960,6 +960,24 @@ export class ConnectionsComponent extends BaseResourceComponent implements OnIni
     this.cdr.detectChanges();
   }
 
+  /**
+   * Enter/Space on the row opens the field-mapping editor — but ONLY when the row
+   * itself is focused. The row contains its own controls (the sync checkbox and the
+   * direction button), and their `stopPropagation()` guards are on `click`, not
+   * `keydown`, which bubbles. Without the target check, Space on the checkbox both
+   * opened the editor and had its default toggle cancelled by `preventDefault()`.
+   */
+  OnEntityMapRowKeydown(event: KeyboardEvent, em: EntityMapRow): void {
+    if (event.target !== event.currentTarget) {
+      return;
+    }
+    if (event.key !== 'Enter' && event.key !== ' ') {
+      return;
+    }
+    event.preventDefault();
+    this.OnEntityMapClick(em);
+  }
+
   CloseEntityMapEditor(): void {
     this.EditorEntityMap = null;
     this.cdr.detectChanges();

--- a/packages/Angular/Explorer/dashboards/src/QueryBrowser/query-browser-resource.component.css
+++ b/packages/Angular/Explorer/dashboards/src/QueryBrowser/query-browser-resource.component.css
@@ -397,8 +397,16 @@
 }
 
 .resize-handle:hover,
+.resize-handle:focus-visible,
 .resize-handle.active {
     background: color-mix(in srgb, var(--mj-brand-primary) 15%, transparent);
+}
+
+/* The handle is a keyboard-operable widget (arrows/Home/End), so it needs a visible
+   focus ring — the 6px hover tint alone is too subtle to serve as one. */
+.resize-handle:focus-visible {
+    outline: 2px solid var(--mj-brand-primary);
+    outline-offset: -1px;
 }
 
 .resize-handle-grip {
@@ -410,6 +418,7 @@
 }
 
 .resize-handle:hover .resize-handle-grip,
+.resize-handle:focus-visible .resize-handle-grip,
 .resize-handle.active .resize-handle-grip {
     background: var(--mj-brand-primary);
 }

--- a/packages/Angular/Explorer/dashboards/src/QueryBrowser/query-browser-resource.component.html
+++ b/packages/Angular/Explorer/dashboards/src/QueryBrowser/query-browser-resource.component.html
@@ -94,10 +94,23 @@
     </div>
   </div>
 
-  <!-- Resize Handle -->
+  <!-- Resize Handle. A separator WITHOUT tabindex is a static (decorative) separator per
+       ARIA, so the action-phrased label would announce a control that can't be operated:
+       tabindex + the keydown handler + aria-value* are what make it a real widget. Before
+       this it was a bare <div> whose only handler was (mousedown) — an addEventListener,
+       not an onclick attribute — so a 6px unlabeled target appeared in no accessibility
+       tree and in no automation's element list. -->
   <div class="resize-handle"
+    role="separator"
+    aria-orientation="vertical"
+    aria-label="Resize query list panel"
+    tabindex="0"
+    [attr.aria-valuenow]="PanelWidth"
+    [attr.aria-valuemin]="MinPanelWidth"
+    [attr.aria-valuemax]="MaxPanelWidth"
     [class.active]="IsResizing"
-    (mousedown)="onResizeStart($event)">
+    (mousedown)="onResizeStart($event)"
+    (keydown)="onResizeKeydown($event)">
     <div class="resize-handle-grip"></div>
   </div>
 

--- a/packages/Angular/Explorer/dashboards/src/QueryBrowser/query-browser-resource.component.ts
+++ b/packages/Angular/Explorer/dashboards/src/QueryBrowser/query-browser-resource.component.ts
@@ -1469,20 +1469,49 @@ export class QueryBrowserResourceComponent extends BaseResourceComponent impleme
         });
     }
 
+    /** Arrow keys nudge the splitter; Home/End jump to the bounds. */
+    public onResizeKeydown(event: KeyboardEvent): void {
+        const step = event.shiftKey ? 40 : 8;
+        switch (event.key) {
+            case 'ArrowLeft':  this.setPanelWidth(this.PanelWidth - step); break;
+            case 'ArrowRight': this.setPanelWidth(this.PanelWidth + step); break;
+            case 'Home':       this.setPanelWidth(this.MinPanelWidth); break;
+            case 'End':        this.setPanelWidth(this.MaxPanelWidth); break;
+            default: return;
+        }
+        event.preventDefault();
+        this.persistPanelWidth();
+    }
+
+    /** Exposed for the splitter's aria-valuemin/max. */
+    public get MinPanelWidth(): number {
+        return QueryBrowserResourceComponent.MIN_PANEL_WIDTH;
+    }
+
+    public get MaxPanelWidth(): number {
+        return QueryBrowserResourceComponent.MAX_PANEL_WIDTH;
+    }
+
+    /** Single clamp+assign for both the drag and keyboard paths. */
+    private setPanelWidth(width: number): void {
+        this.PanelWidth = Math.max(this.MinPanelWidth, Math.min(this.MaxPanelWidth, width));
+        this.cdr.markForCheck();
+    }
+
+    private persistPanelWidth(): void {
+        UserInfoEngine.Instance.SetSettingDebounced(
+            QueryBrowserResourceComponent.SETTINGS_KEY,
+            this.PanelWidth.toString()
+        );
+    }
+
     private onResizeMove(event: MouseEvent): void {
         if (!this.IsResizing) return;
 
         const containerRect = this.elementRef.nativeElement.querySelector('.query-browser-container')?.getBoundingClientRect();
         if (!containerRect) return;
 
-        const newWidth = event.clientX - containerRect.left;
-        const clamped = Math.max(
-            QueryBrowserResourceComponent.MIN_PANEL_WIDTH,
-            Math.min(QueryBrowserResourceComponent.MAX_PANEL_WIDTH, newWidth)
-        );
-
-        this.PanelWidth = clamped;
-        this.zone.run(() => this.cdr.markForCheck());
+        this.zone.run(() => this.setPanelWidth(event.clientX - containerRect.left));
     }
 
     private onResizeEnd(): void {
@@ -1492,12 +1521,7 @@ export class QueryBrowserResourceComponent extends BaseResourceComponent impleme
         document.removeEventListener('mousemove', this.boundOnResizeMove);
         document.removeEventListener('mouseup', this.boundOnResizeEnd);
 
-        // Persist width with debouncing
-        UserInfoEngine.Instance.SetSettingDebounced(
-            QueryBrowserResourceComponent.SETTINGS_KEY,
-            this.PanelWidth.toString()
-        );
-
+        this.persistPanelWidth();
         this.zone.run(() => this.cdr.markForCheck());
     }
 


### PR DESCRIPTION
Split out of #3380 — independently revertable.

## Defects

Two controls were mouse-only:

**Query-browser splitter** — no role, no keyboard affordance. The panel could only be resized by dragging. This is also the control that regression test T045 could never satisfy: it's a 6px-wide `background: transparent` strip with a 2px grip, invisible until hover.

**Integration entity-map rows** — click-only, with no role, no tab stop and no key handler.

## Fix

Both get real keyboard operability — the splitter as a proper separator with TS handlers and focus styling (not markup attributes alone), and the rows with `role="button"`, `tabindex`, `aria-label` and Enter/Space.

## Verified still present

Confirmed against `origin/next` @ `b23bf5933d`: **0** occurrences of `role="separator"` in `query-browser-resource.component.html` and **0** of `role="button"` in `connections.component.html`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)