### PR TITLE
fix(entity-viewer,dashboards): reveal hover-gated actions on focus; stop card collapse

### DIFF
--- a/.changeset/fix-a11y-focus-and-layout.md
+++ b/.changeset/fix-a11y-focus-and-layout.md
@@ -1,0 +1,18 @@
+---
+'@memberjunction/ng-entity-viewer': patch
+'@memberjunction/ng-dashboards': patch
+---
+
+Reveal hover-gated row actions on keyboard focus, and stop a card collapsing under
+its own content.
+
+- `view-selector` and `home-dashboard` gated row/pin actions on `:hover` alone. At
+  `opacity: 0` they were pointer-only — invisible to a tabbing keyboard user and
+  unreachable without a mouse. Added `:focus-within`.
+- `ps-catalog` cards had no `flex-shrink: 0`. The default shrink compressed the guide
+  card below its own content at 1280x720 (46px vs 166px) and the overflow landed
+  *behind* the `position: relative` gallery cards, making filter chips genuinely
+  unclickable.
+
+Note: roughly 20 other stylesheets still gate row actions on `:hover` alone. Not
+addressed here — worth a dedicated sweep.

--- a/packages/Angular/Explorer/dashboards/src/Home/home-dashboard.component.css
+++ b/packages/Angular/Explorer/dashboards/src/Home/home-dashboard.component.css
@@ -922,7 +922,11 @@
   font-size: 14px;
 }
 
-.pin-card:hover .pin-name .more-btn {
+/* Also reveal on keyboard focus — the pin's overflow menu is the only route to
+   rename/remove/configure, and at opacity 0 it was pointer-only: invisible to a
+   tabbing keyboard user and unreachable without a hover. */
+.pin-card:hover .pin-name .more-btn,
+.pin-card:focus-within .pin-name .more-btn {
   opacity: 1;
 }
 

--- a/packages/Angular/Explorer/dashboards/src/PredictiveStudio/components/ps-catalog.component.css
+++ b/packages/Angular/Explorer/dashboards/src/PredictiveStudio/components/ps-catalog.component.css
@@ -1,4 +1,9 @@
 .ps-catalog { display: flex; flex-direction: column; gap: 16px; }
+/* Cards size to their content. Without this the default flex-shrink:1 compresses the
+   guide card below its own body when the panel is height-constrained (46px vs 166px at
+   1280x720), and the overflowing content — including the filter chips — lands behind the
+   position:relative gallery cards, making the chips unclickable. */
+.ps-catalog > .ps-card { flex-shrink: 0; }
 
 .ps-catalog .guide-card .guide-head { display: flex; gap: 12px; align-items: flex-start; }
 .ps-catalog .guide-head i { font-size: 18px; margin-top: 2px; }

--- a/packages/Angular/Generic/entity-viewer/src/lib/view-selector/view-selector.component.css
+++ b/packages/Angular/Generic/entity-viewer/src/lib/view-selector/view-selector.component.css
@@ -367,7 +367,12 @@
   margin-top: 2px;
 }
 
-.vs-card:hover .vs-card-actions {
+/* :focus-within matters as much as :hover — these buttons (Duplicate, Configure,
+   Open in Tab) were reachable ONLY by pointer. A keyboard user could tab into them
+   and see nothing at opacity 0, and anything driving the page without a hover
+   (assistive tech, automation) could not reach them at all. */
+.vs-card:hover .vs-card-actions,
+.vs-card:focus-within .vs-card-actions {
   opacity: 1;
 }
 


### PR DESCRIPTION
Split out of #3380 — independently revertable.

## Defects

**Hover-gated row actions (2 files).** `view-selector` and `home-dashboard` revealed their row/pin actions on `:hover` alone. At `opacity: 0` those controls are pointer-only — invisible to a tabbing keyboard user and unreachable without a mouse. For the pin card this is a genuine dead end: the overflow menu is the *only* route to rename/remove/configure.

**`ps-catalog` card collapse.** Cards had no `flex-shrink: 0`. The default shrink compressed the guide card below its own content at 1280×720 — **46px against 166px of content** — and the overflow landed *behind* the `position: relative` gallery cards. That made the filter chips genuinely unclickable for real users, not just for a test agent.

## Verified still present

Confirmed against `origin/next` @ `b23bf5933d`:
- `view-selector.component.css` — **0** `focus-within`
- `ps-catalog.component.css` — **0** `flex-shrink`
- `home-dashboard.component.css` — its one `focus-within` is on an unrelated `.search-input-wrapper`; the `.pin-card` actions are still hover-only

## Scope note

Roughly **20 other stylesheets** still gate row actions on `:hover` alone. Deliberately not swept here — this PR stays revertable, and the sweep deserves its own change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)