### PR TITLE
Generated remote-operation clients for the eight workflow debug verbs

### DIFF
--- a/.changeset/task-graph-debug-operation-clients.md
+++ b/.changeset/task-graph-debug-operation-clients.md
@@ -1,5 +1,5 @@
 ---
-'@memberjunction/core-entities': patch
+'@memberjunction/core-entities': minor
 ---
 
 Generated remote-operation clients for the workflow debug verbs that #3770 shipped.

--- a/.changeset/task-graph-debug-operation-clients.md
+++ b/.changeset/task-graph-debug-operation-clients.md
@@ -1,0 +1,11 @@
+---
+'@memberjunction/core-entities': patch
+---
+
+Generated remote-operation clients for the workflow debug verbs that #3770 shipped.
+
+The Run Console calls eight control verbs — pause, resume, step, set breakpoints, override path, skip step, force-complete step, update step input — and #3770 added their rows to `metadata/remote-operations`. The generated client classes are produced by CodeGen *from the database*, so they do not exist until someone pushes that metadata and regenerates. Until then the console's controls have no typed client to call.
+
+This is that regeneration, run against a from-scratch database (migrations → DB-side CodeGen → `mj sync push --dir=metadata` → file CodeGen), which is what proves the classes come from the repo's own metadata rather than from state a long-lived dev database happened to hold.
+
+Additive except for one deliberate change CodeGen picked up with them: `TaskGraphRetryInput` gains an optional `inputPayload`, so an operator who can see why a step failed can correct the brief for the re-run.

--- a/metadata/remote-operations/.remote-operations.json
+++ b/metadata/remote-operations/.remote-operations.json
@@ -450,8 +450,8 @@
       "ID": "9A3CAF75-D794-4223-9AEE-A40AE8A0A012"
     },
     "sync": {
-      "lastModified": "2026-08-11T22:51:23.062Z",
-      "checksum": "4f72d0b464e9dc8133154227eb24f9c1b7674afa479f3c869435de04fe08e4f1"
+      "lastModified": "2026-08-13T12:59:26.240Z",
+      "checksum": "2a908f8e8a3be055b6a4c0c65aadfe781edef29ffc37df77517613abf73a0619"
     }
   },
   {
@@ -498,8 +498,8 @@
       "ID": "4EB01F8A-B68E-4F59-AC0C-4A5D470A4808"
     },
     "sync": {
-      "lastModified": "2026-08-07T23:58:30.479Z",
-      "checksum": "a511cd2319d56bbd059cb425bc535a83b901a5b024b9412946aed50b89d8efea"
+      "lastModified": "2026-08-13T12:59:26.279Z",
+      "checksum": "afbab38dcb09f821e2bbf9561fb26db135e1e95378269460bc58f88676d0f93b"
     }
   },
   {
@@ -616,6 +616,10 @@
     },
     "primaryKey": {
       "ID": "FD74A63B-C8CF-4B18-9CCB-C7E4BF3443D0"
+    },
+    "sync": {
+      "lastModified": "2026-08-13T12:59:26.352Z",
+      "checksum": "d8aeea7fac4f81230ca2309a97aa245096517b3f10038562643a784743bc91ac"
     }
   },
   {
@@ -636,6 +640,10 @@
     },
     "primaryKey": {
       "ID": "947E7915-FBBA-44FD-AE92-596B898F0B4E"
+    },
+    "sync": {
+      "lastModified": "2026-08-13T12:59:26.374Z",
+      "checksum": "8385fce901441760dbb75ce07e81253a9f49cfde1f5b58aaf7b837d6370654e9"
     }
   },
   {
@@ -656,6 +664,10 @@
     },
     "primaryKey": {
       "ID": "1958E87B-D176-4EB9-9922-4048775C86BC"
+    },
+    "sync": {
+      "lastModified": "2026-08-13T12:59:26.397Z",
+      "checksum": "2c5706db3021b99c2197caf4ae83eae6c989326f58718403eeaf5cc9cdbda335"
     }
   },
   {
@@ -676,6 +688,10 @@
     },
     "primaryKey": {
       "ID": "621FA934-77AB-4C18-BED9-E9F69261A23F"
+    },
+    "sync": {
+      "lastModified": "2026-08-13T12:59:26.422Z",
+      "checksum": "2b52490eca41abcf531cd0d228947d09dddb6df2388cfbd6f1970bb151c31c82"
     }
   },
   {
@@ -696,6 +712,10 @@
     },
     "primaryKey": {
       "ID": "E79D98D2-CB64-4E59-85C1-36873FBF5B22"
+    },
+    "sync": {
+      "lastModified": "2026-08-13T12:59:26.444Z",
+      "checksum": "f106bcd5d0208a031c969a0745e923584e6666f5f4a10dbd633b7d543ad0171a"
     }
   },
   {
@@ -716,6 +736,10 @@
     },
     "primaryKey": {
       "ID": "720B80EC-B9AC-4859-A069-AC56C9896633"
+    },
+    "sync": {
+      "lastModified": "2026-08-13T12:59:26.470Z",
+      "checksum": "1a97e757ce0d7c75a455eb6a652aad3116779409b7c306fffd6290b587e366c3"
     }
   },
   {
@@ -736,6 +760,10 @@
     },
     "primaryKey": {
       "ID": "8E27B453-5CB7-43F2-8995-90F92DEB7583"
+    },
+    "sync": {
+      "lastModified": "2026-08-13T12:59:26.492Z",
+      "checksum": "79ecfcec899bfa887735a5002f949da73f9c5adddc3fdccb740ccc3e68805fe3"
     }
   },
   {
@@ -756,6 +784,10 @@
     },
     "primaryKey": {
       "ID": "304F8D29-D2ED-4110-88B6-E5052876B89D"
+    },
+    "sync": {
+      "lastModified": "2026-08-13T12:59:26.522Z",
+      "checksum": "539da9d1f411241289a3296151d08ee671b180c2da09ef0e31f7345bf14c6c8e"
     }
   }
 ]

--- a/packages/MJCoreEntities/src/generated/remote_operations.ts
+++ b/packages/MJCoreEntities/src/generated/remote_operations.ts
@@ -549,6 +549,29 @@ export interface TaskGraphControlOutput {
     errorMessage?: string;
 }
 
+/** Input for the step-scoped intervention verbs. */
+export interface TaskGraphTaskInterventionInput {
+    taskID: string;
+    /** ForceCompleteTask: the output downstream paths evaluate against. UpdateTaskInput: the new input. */
+    payload?: Record<string, unknown> | string | null;
+}
+
+/** Output of the task-graph debug control verbs — what happened and the debug state now in force. */
+export interface TaskGraphDebugControlOutput {
+    success: boolean;
+    /** The graph's debug state after the verb (pause/step/breakpoints/overrides). */
+    debug?: {
+        paused?: boolean;
+        pausedBy?: string | null;
+        pausedReason?: 'user' | 'breakpoint';
+        pausedAtTaskID?: string | null;
+        breakpoints?: string[];
+        step?: string;
+        edgeOverrides?: Record<string, 'true' | 'false'>;
+    };
+    errorMessage?: string;
+}
+
 /** Output of `TaskGraph.GetStatus`. */
 export interface TaskGraphStatusOutput {
     success: boolean;
@@ -567,10 +590,41 @@ export interface TaskGraphStatusOutput {
     errorMessage?: string;
 }
 
-/** Input for `TaskGraph.RetryTask`. */
+/** Input for TaskGraph.OverrideEdge. */
+export interface TaskGraphOverrideEdgeInput {
+    parentTaskID: string;
+    /** The MJ: Task Dependencies row being answered. */
+    edgeID: string;
+    /** 'false' = branch not taken, 'true' = gate open, omitted/null = remove the override. */
+    verdict?: 'true' | 'false' | null;
+}
+
+/** Input for TaskGraph.Pause and TaskGraph.Resume. */
+export interface TaskGraphPauseInput {
+    /** Parent task ID identifying the workflow run. */
+    parentTaskID: string;
+}
+
+/** Input for TaskGraph.RetryTask. */
 export interface TaskGraphRetryInput {
-    /** The failed task to retry. */
+    /** The failed task to return to Pending. */
     taskID: string;
+    /** Optional edited input for the re-run — the operator saw why it failed and corrected the brief. Applies to this run only. */
+    inputPayload?: Record<string, unknown> | string;
+}
+
+/** Input for TaskGraph.SetBreakpoints. */
+export interface TaskGraphSetBreakpointsInput {
+    parentTaskID: string;
+    /** The full breakpoint set — replaces what was there. Empty clears all breakpoints. */
+    taskIDs: string[];
+}
+
+/** Input for TaskGraph.Step. */
+export interface TaskGraphStepInput {
+    parentTaskID: string;
+    /** 'one' (default) releases the next eligible step, 'wave' the current frontier, a task ID exactly that step. */
+    target?: string;
 }
 
 /** Input for `TaskGraph.Submit`. */
@@ -608,6 +662,10 @@ export interface TaskGraphSubmitInput {
     environmentID: string;
     /** Conversation this graph answers, when submitted from a conversational channel. */
     conversationDetailID?: string;
+    /** Continuation hops that produced this graph. Counts toward the runaway-loop reinvoke cap exactly as in-process submissions do; omit for a fresh submission. */
+    reinvokeDepth?: number;
+    /** The invocation's runtime parameters, resolved by the flow dialect's `data.*` and `context.*` condition roots. Without it those documented conditions evaluate against nothing. */
+    invocation?: { data?: unknown; context?: unknown };
 }
 
 /** Output of `TaskGraph.Submit`. */
@@ -1007,6 +1065,22 @@ export class TaskGraphCancelOperation extends BaseRemotableOperation<TaskGraphCo
 }
 
 // ============================================================
+// TaskGraph.ForceCompleteTask — Force Complete Workflow Step
+// ============================================================
+/**
+ * Force Complete Workflow Step
+ * Mark a wedged or externally-resolved step Complete with an operator-supplied output; downstream paths evaluate against it exactly as they would a runner's. Refused for a step running under a live claim (cancel it or wait for the claim to lapse) and for human steps (those complete through CompleteTask with the assignee check). Implemented by TaskGraphForceCompleteTaskServerOperation in @memberjunction/task-graph.
+ * GenerationType=Manual — the server body is supplied by a hand-authored subclass registered
+ * under 'TaskGraph.ForceCompleteTask'. This generated base provides the typed contract only (client-safe).
+ */
+export class TaskGraphForceCompleteTaskOperation extends BaseRemotableOperation<TaskGraphTaskInterventionInput, TaskGraphDebugControlOutput> {
+    public readonly OperationKey = "TaskGraph.ForceCompleteTask";
+    public readonly ExecutionMode = 'Sync' as const;
+    public readonly RequiredScope = "taskgraph:execute";
+    public readonly RequiresSystemUser = false;
+}
+
+// ============================================================
 // TaskGraph.GetStatus — Get Task Graph Status
 // ============================================================
 /**
@@ -1019,6 +1093,54 @@ export class TaskGraphGetStatusOperation extends BaseRemotableOperation<TaskGrap
     public readonly OperationKey = "TaskGraph.GetStatus";
     public readonly ExecutionMode = 'Sync' as const;
     public readonly RequiredScope = "taskgraph:read";
+    public readonly RequiresSystemUser = false;
+}
+
+// ============================================================
+// TaskGraph.OverrideEdge — Override Workflow Path
+// ============================================================
+/**
+ * Override Workflow Path
+ * Answer one path's condition by operator decision — the escape hatch for a held graph (a condition that cannot be evaluated) or a broken guard. 'false' reads as branch-not-taken and cascades skips; 'true' opens the gate; omitting the verdict removes the override. Durable: survives restarts and is honored by every dispatcher instance. Implemented by TaskGraphOverrideEdgeServerOperation in @memberjunction/task-graph.
+ * GenerationType=Manual — the server body is supplied by a hand-authored subclass registered
+ * under 'TaskGraph.OverrideEdge'. This generated base provides the typed contract only (client-safe).
+ */
+export class TaskGraphOverrideEdgeOperation extends BaseRemotableOperation<TaskGraphOverrideEdgeInput, TaskGraphDebugControlOutput> {
+    public readonly OperationKey = "TaskGraph.OverrideEdge";
+    public readonly ExecutionMode = 'Sync' as const;
+    public readonly RequiredScope = "taskgraph:execute";
+    public readonly RequiresSystemUser = false;
+}
+
+// ============================================================
+// TaskGraph.Pause — Pause Workflow Run
+// ============================================================
+/**
+ * Pause Workflow Run
+ * Pause a running workflow: nothing new is claimed until it is resumed, while in-flight steps finish naturally and their completions land. Durable, declarative state the dispatcher's claim filter consults on its next pass — works across instances and restarts. Implemented by TaskGraphPauseServerOperation in @memberjunction/task-graph.
+ * GenerationType=Manual — the server body is supplied by a hand-authored subclass registered
+ * under 'TaskGraph.Pause'. This generated base provides the typed contract only (client-safe).
+ */
+export class TaskGraphPauseOperation extends BaseRemotableOperation<TaskGraphPauseInput, TaskGraphDebugControlOutput> {
+    public readonly OperationKey = "TaskGraph.Pause";
+    public readonly ExecutionMode = 'Sync' as const;
+    public readonly RequiredScope = "taskgraph:execute";
+    public readonly RequiresSystemUser = false;
+}
+
+// ============================================================
+// TaskGraph.Resume — Resume Workflow Run
+// ============================================================
+/**
+ * Resume Workflow Run
+ * Resume a paused workflow run; claiming continues normally. Breakpoints and edge overrides survive — only the pause clears. Implemented by TaskGraphResumeServerOperation in @memberjunction/task-graph.
+ * GenerationType=Manual — the server body is supplied by a hand-authored subclass registered
+ * under 'TaskGraph.Resume'. This generated base provides the typed contract only (client-safe).
+ */
+export class TaskGraphResumeOperation extends BaseRemotableOperation<TaskGraphPauseInput, TaskGraphDebugControlOutput> {
+    public readonly OperationKey = "TaskGraph.Resume";
+    public readonly ExecutionMode = 'Sync' as const;
+    public readonly RequiredScope = "taskgraph:execute";
     public readonly RequiresSystemUser = false;
 }
 
@@ -1039,6 +1161,54 @@ export class TaskGraphRetryTaskOperation extends BaseRemotableOperation<TaskGrap
 }
 
 // ============================================================
+// TaskGraph.SetBreakpoints — Set Workflow Breakpoints
+// ============================================================
+/**
+ * Set Workflow Breakpoints
+ * Replace a workflow run's breakpoint set. When an eligible step carries a breakpoint the dispatcher pauses the whole graph BEFORE claiming it and announces BreakpointHit — a breakpoint is an authored hold, implemented by the same claim-filter machinery that already holds unevaluable conditions. Empty array clears all breakpoints. Implemented by TaskGraphSetBreakpointsServerOperation in @memberjunction/task-graph.
+ * GenerationType=Manual — the server body is supplied by a hand-authored subclass registered
+ * under 'TaskGraph.SetBreakpoints'. This generated base provides the typed contract only (client-safe).
+ */
+export class TaskGraphSetBreakpointsOperation extends BaseRemotableOperation<TaskGraphSetBreakpointsInput, TaskGraphDebugControlOutput> {
+    public readonly OperationKey = "TaskGraph.SetBreakpoints";
+    public readonly ExecutionMode = 'Sync' as const;
+    public readonly RequiredScope = "taskgraph:execute";
+    public readonly RequiresSystemUser = false;
+}
+
+// ============================================================
+// TaskGraph.SkipTask — Skip Workflow Step
+// ============================================================
+/**
+ * Skip Workflow Step
+ * Declare a Pending step not-taken. Dependents proceed (Skipped satisfies a prerequisite) and any open human request for the step is withdrawn. Only a step that has not started can be skipped. Implemented by TaskGraphSkipTaskServerOperation in @memberjunction/task-graph.
+ * GenerationType=Manual — the server body is supplied by a hand-authored subclass registered
+ * under 'TaskGraph.SkipTask'. This generated base provides the typed contract only (client-safe).
+ */
+export class TaskGraphSkipTaskOperation extends BaseRemotableOperation<TaskGraphTaskInterventionInput, TaskGraphDebugControlOutput> {
+    public readonly OperationKey = "TaskGraph.SkipTask";
+    public readonly ExecutionMode = 'Sync' as const;
+    public readonly RequiredScope = "taskgraph:execute";
+    public readonly RequiresSystemUser = false;
+}
+
+// ============================================================
+// TaskGraph.Step — Step Workflow Run
+// ============================================================
+/**
+ * Step Workflow Run
+ * Arm a one-shot claim allowance on a paused workflow run: 'one' releases the next eligible step, 'wave' releases the current frontier, a task ID releases exactly that step. Consumed atomically so two dispatcher instances stepping the same graph release work exactly once. Implemented by TaskGraphStepServerOperation in @memberjunction/task-graph.
+ * GenerationType=Manual — the server body is supplied by a hand-authored subclass registered
+ * under 'TaskGraph.Step'. This generated base provides the typed contract only (client-safe).
+ */
+export class TaskGraphStepOperation extends BaseRemotableOperation<TaskGraphStepInput, TaskGraphDebugControlOutput> {
+    public readonly OperationKey = "TaskGraph.Step";
+    public readonly ExecutionMode = 'Sync' as const;
+    public readonly RequiredScope = "taskgraph:execute";
+    public readonly RequiresSystemUser = false;
+}
+
+// ============================================================
 // TaskGraph.Submit — Submit Task Graph
 // ============================================================
 /**
@@ -1049,6 +1219,22 @@ export class TaskGraphRetryTaskOperation extends BaseRemotableOperation<TaskGrap
  */
 export class TaskGraphSubmitOperation extends BaseRemotableOperation<TaskGraphSubmitInput, TaskGraphSubmitOutput> {
     public readonly OperationKey = "TaskGraph.Submit";
+    public readonly ExecutionMode = 'Sync' as const;
+    public readonly RequiredScope = "taskgraph:execute";
+    public readonly RequiresSystemUser = false;
+}
+
+// ============================================================
+// TaskGraph.UpdateTaskInput — Update Workflow Step Input
+// ============================================================
+/**
+ * Update Workflow Step Input
+ * Replace a Pending step's input — the edit-the-brief-before-stepping move at a breakpoint. Applies to this run only; the step must not have started. Implemented by TaskGraphUpdateTaskInputServerOperation in @memberjunction/task-graph.
+ * GenerationType=Manual — the server body is supplied by a hand-authored subclass registered
+ * under 'TaskGraph.UpdateTaskInput'. This generated base provides the typed contract only (client-safe).
+ */
+export class TaskGraphUpdateTaskInputOperation extends BaseRemotableOperation<TaskGraphTaskInterventionInput, TaskGraphDebugControlOutput> {
+    public readonly OperationKey = "TaskGraph.UpdateTaskInput";
     public readonly ExecutionMode = 'Sync' as const;
     public readonly RequiredScope = "taskgraph:execute";
     public readonly RequiresSystemUser = false;


### PR DESCRIPTION
## What this is

#3770 shipped the Run Console and added its eight control verbs to `metadata/remote-operations`. The **generated client classes for those verbs did not exist yet** — CodeGen produces them by reading the *database*, so they only appear once someone pushes that metadata and regenerates. Until then every console control has no typed client to call.

This is that regeneration.

## Why it was done on a from-scratch database

A long-lived dev database accumulates rows from every session that touched it, and that state can make generated output look right for reasons the repo does not actually ship. Built on a clean database (`MJ_6_1_0_CLEAN_20260813`) so the output is provably a function of migrations + metadata alone:

```
mj migrate                     46 applied — 376 tables, 387 views, 374 entities
mj codegen --skipfiles         SQL side only
mj sync push --dir=metadata    8 created, 2 updated, 0 errors, 13,717 unchanged
mj codegen --skipdb            TypeScript from complete metadata
```

**Why CodeGen is split around the push.** On an empty database neither single ordering works: pushing first fails because the metadata's `@lookup` refs point at `EntityField` rows CodeGen has not created yet, and generating files first emits them from metadata that is not there — which is how `remote_operations.ts` gets *emptied* rather than filled. The file-generating half still runs after the push, so the repo's push-before-codegen rule is preserved.

## What landed

`packages/MJCoreEntities/src/generated/remote_operations.ts`, +188 lines:

- 8 operation classes — `TaskGraphPauseOperation`, `ResumeOperation`, `StepOperation`, `SetBreakpointsOperation`, `OverrideEdgeOperation`, `SkipTaskOperation`, `ForceCompleteTaskOperation`, `UpdateTaskInputOperation`
- 6 input/output interfaces — `TaskGraphPauseInput`, `StepInput`, `SetBreakpointsInput`, `OverrideEdgeInput`, `TaskInterventionInput`, `DebugControlOutput`
- `TaskGraphSubmitInput` gains the two #3771 contract fields — `reinvokeDepth` (clamped server-side; the runaway-loop cap counts remote hops) and the `invocation` envelope (`data.*`/`context.*` condition roots) — these are the push's "2 updated" rows
- `TaskGraphRetryInput` gains an optional `inputPayload`, so an operator who saw why a step failed can correct the brief for the re-run

Additive otherwise — nothing was deleted beyond regenerated doc comments.

`metadata/remote-operations/.remote-operations.json`: the `mj sync push` write-back — eight new `sync` blocks and the two updated checksums. **Included on purpose** (an earlier draft of this description said otherwise): the file already carries `sync` blocks for every previously-synced record, so committing these keeps the file's own convention and spares the next `mj sync push` from re-reporting the eight rows as unsynced. The eight operations carry authored `primaryKey` UUIDs, so their IDs are identical in every environment; the release-time consolidated sync migration is unaffected.

## Verified against the database, not assumed

All eight rows present and `Active`, `Sync`, `RequiredScope=taskgraph:execute`, `RequiresSystemUser=false`, each carrying an `InputTypeDefinition`. The only TaskGraph operation on a different scope is `GetStatus` at `taskgraph:read`, correct for a read verb.

Build `EXIT=0` (271/271 tasks). Unit tests for every package #3770 touched:

| Package | Tests |
|---|---|
| TaskGraph | 219 |
| MJServer | 838 (+56 skipped) |
| GraphQLDataProvider | 319 |
| AI/Agents | 1872 |
| AI/CorePlus | 633 |
| ServerBootstrap | 28 |
| ServerBootstrapLite | 4 |
| integration-test-suite | 177 |
| Angular/Generic/task-graph-editor | 161 |
| Angular/Explorer/dashboards | 1746 |

## Follow-up (non-blocking)

- Re-parent `TaskGraphDebugOperations` onto these generated bases and drop the now-redundant local widenings in `TaskGraphOperations.ts` (`TaskGraphSubmitInput & {...}`, the RetryTask intersection) — the generated fields are identical, so the intersections are harmless until then.
- The live two-instance step-allowance exercise — a Run Console on instance A single-stepping a graph whose tasks are executed by a dispatcher on instance B. No test in the repo covers it, and CI never runs two instances. Note it cannot share a database with IT74, which requires no other dispatcher running.

## Notes

`mj codegen` exits **1** on this repo even when generation succeeds — `mj.config.cjs` runs six `npm run build` AFTER commands and `npm` cannot build packages in this pnpm workspace. Anything gating on that exit code sees a false failure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DX1QANPL1HK11tMjQb2gUL