### PR TITLE
test(workflows): DOM specs so the debugger wrap stays under the Generic ratchet

### DIFF
--- a/.changeset/debugger-dom-specs.md
+++ b/.changeset/debugger-dom-specs.md
@@ -1,0 +1,5 @@
+---
+"@memberjunction/ng-task-graph-editor": patch
+---
+
+Add DOM specs for the debugger wrap, VCR toolbar, and variables pane so the Generic coverage ratchet stays at 134 after #3793.

--- a/packages/Angular/Generic/task-graph-editor/src/lib/task-graph-debug-toolbar.component.dom.test.ts
+++ b/packages/Angular/Generic/task-graph-editor/src/lib/task-graph-debug-toolbar.component.dom.test.ts
@@ -2,7 +2,14 @@ import { describe, it, expect, beforeEach } from 'vitest';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { TaskGraphDebugToolbarComponent } from './task-graph-debug-toolbar.component';
 
-describe('TaskGraphDebugToolbarComponent', () => {
+/**
+ * DOM spec for `<mj-task-graph-debug-toolbar>`.
+ *
+ * The bar is intent-only: Continue / Over / Into / Pause / Stop must render from
+ * Paused/Settled and emit Resume / Step / StepWave / Pause / Cancel. Class tests
+ * cannot see which aria-label is on the screen.
+ */
+describe('TaskGraphDebugToolbarComponent (DOM)', () => {
     let fixture: ComponentFixture<TaskGraphDebugToolbarComponent>;
 
     beforeEach(async () => {
@@ -46,5 +53,27 @@ describe('TaskGraphDebugToolbarComponent', () => {
         fixture.componentInstance.Resume.subscribe(() => events.push('resume'));
         host().querySelector<HTMLButtonElement>('[aria-label="Continue"]')?.click();
         expect(events).toEqual(['resume']);
+    });
+
+    it('emits Step, StepWave, and Cancel from the matching buttons', () => {
+        fixture.componentRef.setInput('Paused', true);
+        fixture.detectChanges();
+        const events: string[] = [];
+        fixture.componentInstance.Step.subscribe(() => events.push('step'));
+        fixture.componentInstance.StepWave.subscribe(() => events.push('wave'));
+        fixture.componentInstance.Cancel.subscribe(() => events.push('cancel'));
+        host().querySelector<HTMLButtonElement>('[aria-label="Step over"]')?.click();
+        host().querySelector<HTMLButtonElement>('[aria-label="Step into"]')?.click();
+        host().querySelector<HTMLButtonElement>('[aria-label="Stop"]')?.click();
+        expect(events).toEqual(['step', 'wave', 'cancel']);
+    });
+
+    it('emits Pause while the graph is running', () => {
+        fixture.componentRef.setInput('Paused', false);
+        fixture.detectChanges();
+        const events: string[] = [];
+        fixture.componentInstance.Pause.subscribe(() => events.push('pause'));
+        host().querySelector<HTMLButtonElement>('[aria-label="Pause"]')?.click();
+        expect(events).toEqual(['pause']);
     });
 });

--- a/packages/Angular/Generic/task-graph-editor/src/lib/task-graph-debugger.component.dom.test.ts
+++ b/packages/Angular/Generic/task-graph-editor/src/lib/task-graph-debugger.component.dom.test.ts
@@ -1,0 +1,77 @@
+import { describe, it, expect, vi } from 'vitest';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { By } from '@angular/platform-browser';
+import type { IMetadataProvider, RunViewParams } from '@memberjunction/core';
+import { createFakeProvider } from '@memberjunction/ng-test-utils';
+import type { TaskRunEdge, TaskRunRow } from '@memberjunction/ai-core-plus';
+import { TaskGraphEditorModule } from './task-graph-editor.module';
+import { TaskGraphDebuggerComponent } from './task-graph-debugger.component';
+
+/**
+ * DOM spec for `<mj-task-graph-debugger>`.
+ *
+ * The wrap's job is chrome + the run view. What a class test cannot see: ShowChrome
+ * actually mounts the VCR, a control failure paints an alert, and Continue on the
+ * toolbar calls Resume on the wrap.
+ */
+describe('TaskGraphDebuggerComponent (DOM)', () => {
+    function graphProvider(): IMetadataProvider {
+        const tasks: TaskRunRow[] = [{
+            ID: 't1',
+            Name: 'Gather',
+            Description: '',
+            Status: 'Pending',
+            StepType: 'Agent',
+            Configuration: null,
+        }];
+        const edges: TaskRunEdge[] = [];
+        return createFakeProvider<TaskRunRow | TaskRunEdge>({
+            runViewResults: (params: RunViewParams) => (
+                params.EntityName === 'MJ: Tasks' ? tasks : edges
+            ),
+        });
+    }
+
+    function render(): ComponentFixture<TaskGraphDebuggerComponent> {
+        TestBed.configureTestingModule({ imports: [TaskGraphEditorModule] });
+        const fixture = TestBed.createComponent(TaskGraphDebuggerComponent);
+        fixture.componentRef.setInput('Provider', graphProvider());
+        fixture.componentRef.setInput('ParentTaskID', 'parent-1');
+        fixture.detectChanges();
+        return fixture;
+    }
+
+    const host = (f: ComponentFixture<TaskGraphDebuggerComponent>) => f.nativeElement as HTMLElement;
+
+    it('mounts the VCR and the run view when chrome is on', () => {
+        const f = render();
+        expect(host(f).querySelector('mj-task-graph-debug-toolbar')).toBeTruthy();
+        expect(host(f).querySelector('mj-task-graph-run-view')).toBeTruthy();
+        expect(host(f).querySelector('[aria-label="Pause"]')).toBeTruthy();
+    });
+
+    it('hides the VCR when the host already has its own chrome', () => {
+        const f = render();
+        f.componentRef.setInput('ShowChrome', false);
+        f.detectChanges();
+        expect(host(f).querySelector('mj-task-graph-debug-toolbar')).toBeNull();
+        expect(host(f).querySelector('mj-task-graph-run-view')).toBeTruthy();
+    });
+
+    it('shows a control failure as an alert, not a silent no-op', async () => {
+        const f = render();
+        await f.componentInstance.Pause();
+        f.detectChanges();
+        expect(host(f).querySelector('mj-alert')).toBeTruthy();
+        expect(host(f).textContent).toContain('cannot send workflow controls');
+    });
+
+    it('wires the toolbar Resume event to the wrap Resume verb', () => {
+        const f = render();
+        const resume = vi.spyOn(f.componentInstance, 'Resume').mockResolvedValue(true);
+        const toolbar = f.debugElement.query(By.css('mj-task-graph-debug-toolbar'));
+        expect(toolbar).toBeTruthy();
+        toolbar.triggerEventHandler('Resume');
+        expect(resume).toHaveBeenCalled();
+    });
+});

--- a/packages/Angular/Generic/task-graph-editor/src/lib/task-graph-variables.component.dom.test.ts
+++ b/packages/Angular/Generic/task-graph-editor/src/lib/task-graph-variables.component.dom.test.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect } from 'vitest';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { TaskGraphVariablesComponent } from './task-graph-variables.component';
+
+/**
+ * DOM spec for `<mj-task-graph-variables>`.
+ *
+ * Paint only. What a class test cannot see: the empty prompt, Input/Output scope
+ * headings, and that clicking a scope head actually collapses the tree (aria-expanded).
+ */
+describe('TaskGraphVariablesComponent (DOM)', () => {
+    function render(): ComponentFixture<TaskGraphVariablesComponent> {
+        TestBed.configureTestingModule({ imports: [TaskGraphVariablesComponent] });
+        return TestBed.createComponent(TaskGraphVariablesComponent);
+    }
+
+    const host = (f: ComponentFixture<TaskGraphVariablesComponent>) => f.nativeElement as HTMLElement;
+
+    it('asks the operator to pick a step when there is nothing to inspect', () => {
+        const f = render();
+        f.detectChanges();
+        expect(host(f).querySelector('.vars-empty')).toBeTruthy();
+        expect(host(f).textContent).toContain('Select a step to inspect its input and output.');
+        expect(host(f).querySelector('.vars-scope')).toBeNull();
+    });
+
+    it('renders Input and Output scopes from the payloads', () => {
+        const f = render();
+        f.componentRef.setInput('InputPayload', JSON.stringify({ ticker: 'NVDA' }));
+        f.componentRef.setInput('OutputPayload', JSON.stringify({ stockPrice: 224.35 }));
+        f.detectChanges();
+        expect(host(f).querySelector('.vars-empty')).toBeNull();
+        expect(host(f).textContent).toContain('Input');
+        expect(host(f).textContent).toContain('ticker');
+        expect(host(f).textContent).toContain('NVDA');
+        expect(host(f).textContent).toContain('Output');
+        expect(host(f).textContent).toContain('stockPrice');
+    });
+
+    it('collapses a scope on click so the tree is not permanently open', () => {
+        const f = render();
+        f.componentRef.setInput('InputPayload', JSON.stringify({ ticker: 'NVDA' }));
+        f.detectChanges();
+        const head = host(f).querySelector('.vars-scope-head') as HTMLButtonElement;
+        expect(head).toBeTruthy();
+        expect(head.getAttribute('aria-expanded')).toBe('true');
+        expect(host(f).textContent).toContain('ticker');
+        head.click();
+        f.detectChanges();
+        expect(head.getAttribute('aria-expanded')).toBe('false');
+        expect(host(f).textContent).not.toContain('ticker');
+    });
+});


### PR DESCRIPTION
## Summary
- #3793 shipped `<mj-task-graph-debugger>`, the VCR toolbar, and the variables pane without `.dom.test.ts`, so merge CI failed the Generic DOM coverage ratchet (`137` undeferred vs `--max-none=134`).
- Add DOM specs for those three components (chrome gating, control-failure alert, toolbar intent, empty/collapse variables). The existing toolbar TestBed spec is renamed to `.dom.test.ts` so the ratchet can see it.
- Local: `pnpm test` in `@memberjunction/ng-task-graph-editor` — **218 passed, 0 failed**. `node scripts/dom-test-report.mjs packages/Angular/Generic --max-none=134` is green again.

Follow-up from #3793. Persistent breakpoints (always break on this step of this workflow) is tracked separately as #3798.

## Test plan
- [x] `cd packages/Angular/Generic/task-graph-editor && pnpm test` — 218 passed
- [x] `node scripts/dom-test-report.mjs packages/Angular/Generic --max-none=134` — ratchet holds
- [ ] CI unit-test job on this PR is green