### PR TITLE
fix(ng-task-graph-editor): add required Status to context-menu test fixture (unbreaks next CI)

### DIFF
--- a/packages/Angular/Generic/task-graph-editor/src/lib/task-graph-run-view.context-menu.test.ts
+++ b/packages/Angular/Generic/task-graph-editor/src/lib/task-graph-run-view.context-menu.test.ts
@@ -10,7 +10,7 @@ import { TaskGraphRunViewComponent } from './task-graph-run-view.component';
 const NODE_ID = 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa';
 
 function node(id: string): FlowNode {
-    return { ID: id, Type: 'Action', Label: 'Step', Position: { X: 0, Y: 0 }, Ports: [] };
+    return { ID: id, Type: 'Action', Label: 'Step', Status: 'default', Position: { X: 0, Y: 0 }, Ports: [] };
 }
 
 function viewWithBreakpoints(ids: readonly string[]): TaskGraphRunViewComponent {


### PR DESCRIPTION
## What / why

`FlowNode.Status` is a required property on the flow-editor interface. The context-menu test fixture added in #3793 predates it and omits it, so `@memberjunction/ng-task-graph-editor#test:types` fails `TS2741` — on `next` itself and on **every PR branched from it** since today's merges (e.g. #3801's unit-test check fails on exactly this line; #3793's own final CI run shows the same failure).

One line: the fixture gains `Status: 'default'`.

## Verification

Fresh checkout of `next`, `pnpm install --frozen-lockfile`, full dependency-closure build (`turbo run build --filter='@memberjunction/ng-task-graph-editor^...'`, 161/161 tasks), then `pnpm run test:types` in the package — green with this change, reproduces the TS2741 without it.

## Reviewer attention

- Test-only change; no changeset included (no publishable behavior changes).
- Root-cause note: this is the second `next`-breaking artifact from today's task-graph-debugger merges — both were visible as failing checks on #3793 before merge (the DOM-ratchet failure was fixed by #3799; this type error is the remaining one).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Claude-Session: https://claude.ai/code/session_01MYWbAFjiCkR8LWJK3VXWX3
