### PR TITLE
fix(materialization): close the fail-open gates in the shipped materialization feature

### DIFF
--- a/.changeset/materialization-followup-hardening.md
+++ b/.changeset/materialization-followup-hardening.md
@@ -1,0 +1,63 @@
+---
+"@memberjunction/codegen-lib": patch
+"@memberjunction/generic-database-provider": patch
+"@memberjunction/materialization": patch
+"@memberjunction/global": patch
+"@memberjunction/server-bootstrap": patch
+"@memberjunction/server-bootstrap-lite": patch
+"@memberjunction/ng-core-entity-forms": patch
+---
+
+Follow-up hardening for Query & Entity Materialization (#3735). Each item below fails toward doing the
+wrong thing rather than doing nothing, so none of them surface as an error in normal operation.
+
+**Row-restriction gates read both fence layers.** MJ enforces row restrictions in two AND-composed
+layers — role RLS and API-key row filters — and the mint, drift and runtime Leak-1 gates each re-derived
+a role-only predicate inline. An entity fenced *only* by an API-key row filter therefore read as
+unrestricted; because the mint gives the materialized entity a NEW EntityID, the key's EntityID-keyed
+binding stops matching it, and the principal is served a full unscoped snapshot of rows it cannot read
+live. All gates now compose both layers, and an unproven layer counts as restricted.
+
+**Lost provenance is now drift.** Deleting a source query cascade-deletes the `MaterializedResultQuery`
+join row while the snapshot, the minted entity and its read grants all survive — which silently disarmed
+both the RLS re-check and the read-grant re-narrow, leaving the unscoped snapshot serving indefinitely.
+It now revokes read and holds.
+
+**A zero-row external query no longer destroys the snapshot.** Columns are derived from the returned
+rows, so an empty result built a surrogate-only shadow, dropped the canonical table and renamed that
+shell into its place — every subsequent read failing on a missing column while the refresh reported
+success. An empty result now refuses the rebuild and leaves the existing snapshot serving.
+
+**The refresher snapshots the statement the read path executes.** Reads resolve SQL through
+`GetPlatformSQL(PlatformKey)`; the refresher snapshotted the base `SQL`, so a query carrying a
+per-platform variant was materialized from a different statement than live serves.
+
+**`XACT_ABORT` no longer escapes onto the pooled connection.** The swap, recompute and dirty-group
+batches each set it ON and never restored it. SET options persist for the session, so unrelated requests
+handed the same physical connection inherited it — turning their recoverable statement-level errors into
+full transaction aborts, far from anything to do with materialization.
+
+**The DDL identifier guard no longer opens on its own failure.** `assertSafeObjectNames` throws on a
+tampered `SchemaName`, but the failure path then passed that same rejected name to the best-effort shadow
+cleanup, which interpolated it raw into `DROP TABLE`/`OBJECT_ID`. The cleanup now re-checks and declines.
+
+**Two analyzers that produced silently wrong rows.** A `UNION`/`EXCEPT`/`INTERSECT` parses to a single
+`select` root whose `groupby` and `columns` describe only the first branch, so a set operation yielded an
+aggregation key covering one branch and the incremental MERGE collided both branches on the same hash.
+And a row-filter predicate was bound to an output column by bare name, which cannot tell `o.Status` from
+`c.Status` across a join, nor an alias from the column it rebinds.
+
+**Missing manifest registrations.** Neither new `@RegisterClass` class was in the pre-built manifests, so
+a bundled MJAPI tree-shook both away: the refresh driver never resolved, nothing was ever refreshed, and
+`Status` stayed `Active` while the read paths served mint-time data forever.
+
+**Read-routing distinguishes a failed lookup from "not materialized".** Only three roles hold `CanRead`
+on `MJ: Materialized Results`, so a restricted user silently got live data for every materialized request
+while an admin got the snapshot. The live fallback is correct and unchanged; the silence was the defect.
+
+**Note on coverage.** The predicate-binding proof and the join-qualifier requirement are deliberately
+conservative and will refuse shapes that previously qualified: a row-filter query whose predicate or
+projection is unqualified across a join now stays live-only, and an aggregation over a join with an
+unqualified `GROUP BY` loses its incremental key and falls back to `FullRebuild`. Both refusals are
+logged with the specific reason. Falling back to live is always correct — but a query that silently gets
+slower is easier to diagnose knowing this changed.

--- a/packages/Angular/Explorer/core-entity-forms/src/lib/generated/Entities/MJQuery/mjquery.form.component.html
+++ b/packages/Angular/Explorer/core-entity-forms/src/lib/generated/Entities/MJQuery/mjquery.form.component.html
@@ -245,15 +245,6 @@
             [EditMode]="EditMode"
             [FormContext]="formContext"
         ></mj-form-field>
-        <mj-form-field 
-            [Record]="record"
-            [ShowLabel]="true"
-            FieldName="MaterializedResultID"
-            Type="textbox"
-            [EditMode]="EditMode"
-            [FormContext]="formContext"
-            LinkType="Record"
-        ></mj-form-field>
 
     </mj-collapsible-panel>
 
@@ -483,31 +474,6 @@
                 [ShowToolbar]="false"
                 (Navigate)="OnFormNavigate($event)"
                 (AfterDataLoad)="SetSectionRowCount('mJQuerySQLs', $event.totalRowCount)"
-                >
-            </mj-explorer-entity-data-grid>
-        </div>
-        }
-    </mj-collapsible-panel>
-
-    <!-- Materialized Results Section -->
-    <mj-collapsible-panel
-        SectionKey="mJMaterializedResults"
-        SectionName="Materialized Results"
-        Icon="fa fa-table"
-        Variant="related-entity"
-        [Form]="this"
-        [FormContext]="formContext"
-        [BadgeCount]="GetSectionRowCount('mJMaterializedResults')"
-        [DefaultExpanded]="false">
-        @if (record.IsSaved) {
-        <div>
-            <mj-explorer-entity-data-grid
-                [Params]="BuildRelationshipViewParamsByEntityName('MJ: Materialized Results','SourceQueryID')"
-                [NewRecordValues]="NewRecordValues('MJ: Materialized Results')"
-                [AllowLoad]="IsSectionExpanded('mJMaterializedResults')"
-                [ShowToolbar]="false"
-                (Navigate)="OnFormNavigate($event)"
-                (AfterDataLoad)="SetSectionRowCount('mJMaterializedResults', $event.totalRowCount)"
                 >
             </mj-explorer-entity-data-grid>
         </div>

--- a/packages/Angular/Explorer/core-entity-forms/src/lib/generated/Entities/MJQuery/mjquery.form.component.ts
+++ b/packages/Angular/Explorer/core-entity-forms/src/lib/generated/Entities/MJQuery/mjquery.form.component.ts
@@ -29,8 +29,7 @@ export class MJQueryFormComponent extends BaseFormComponent {
             { sectionKey: 'mJQueryParameters', sectionName: 'Query Parameters', isExpanded: false },
             { sectionKey: 'mJQueryDependenciesQueryID', sectionName: 'Query Dependencies (Query)', isExpanded: false },
             { sectionKey: 'mJQueryEntities', sectionName: 'Query Entities', isExpanded: false },
-            { sectionKey: 'mJQuerySQLs', sectionName: 'Query SQLs', isExpanded: false },
-            { sectionKey: 'mJMaterializedResults', sectionName: 'Materialized Results', isExpanded: false }
+            { sectionKey: 'mJQuerySQLs', sectionName: 'Query SQLs', isExpanded: false }
         ]);
     }
 }

--- a/packages/CodeGenLib/src/Database/manage-metadata.ts
+++ b/packages/CodeGenLib/src/Database/manage-metadata.ts
@@ -6467,7 +6467,10 @@ export class ManageMetadataBase {
                const r = row as CodeGenQueryRow;
                const pattern = ((r.ResourcePattern ?? r.resourcepattern) as string | null) ?? '';
                const trimmed = pattern.trim();
-               if (trimmed.length === 0 || /[*%,]/.test(trimmed)) {
+               // Superset of what IsExactResourceName (rowFilterValidation.ts) rejects at save time — `*`, `?`,
+               // `,` — plus `%` as an extra fail-closed. Omitting `?` would fail OPEN: `Sk?p` would be stored as
+               // a literal target name, match no entity, and the entity it fences would read as unrestricted.
+               if (trimmed.length === 0 || /[*%,?]/.test(trimmed)) {
                   logError(
                      `    > API-key row-filter enumeration: a filtered scope rule in ${table} has an unmappable ResourcePattern ` +
                      `("${trimmed}") — it cannot be resolved to a single entity, so EVERY entity is treated as row-restricted ` +

--- a/packages/CodeGenLib/src/Database/manage-metadata.ts
+++ b/packages/CodeGenLib/src/Database/manage-metadata.ts
@@ -1379,6 +1379,10 @@ export class ManageMetadataBase {
          return { success: true, processedCount: 0 };
       }
 
+      // Enumerate the API-key row-filter layer BEFORE any leak gate below evaluates it. Until this runs the cache
+      // reads 'unknown' and every entity is treated as row-restricted (fail closed) — see loadAPIKeyRowFilterTargets.
+      await this.loadAPIKeyRowFilterTargets(pool);
+
       // Refresh so entity.Fields reflect this run's field sync before we snapshot the shape.
       const md = new Metadata(); // global-provider-ok: codegen runs offline against a single provider
       await md.Refresh();
@@ -1410,8 +1414,8 @@ export class ManageMetadataBase {
          // re-apply source RLS" exemption is unreachable here. Mirroring the remote rows into a local table
          // would expose, via any raw query joining the wrapper view, data the live path refuses entirely.
          // (A LOCAL RLS base-view is safe: its read path swaps to the mirror and re-applies the entity's RLS.)
-         if (entity.ExternalDataSourceID && this.entityHasRowLevelSecurity(entity)) {
-            logError(`    > REFUSING base-view materialization of external entity "${entity.Name}": it is read-RLS-protected and its live reads are refused under RLS, so a local mirror would leak its rows via raw queries over the wrapper view (a mirror cannot reproduce remote RLS). Skipping.`);
+         if (entity.ExternalDataSourceID && this.entityHasRowLevelRestriction(entity)) {
+            logError(`    > REFUSING base-view materialization of external entity "${entity.Name}": it is row-restricted (role RLS and/or an API-key row filter) and its live reads are refused under RLS, so a local mirror would leak its rows via raw queries over the wrapper view (a mirror cannot reproduce remote row restrictions). Skipping.`);
             continue;
          }
 
@@ -1433,8 +1437,7 @@ export class ManageMetadataBase {
          // virtual-field reads at the DB AND permanently tripping DriftHold on the next drift scan). LOCAL base
          // views compute virtual columns in the view itself, so `SELECT * FROM <baseView>` includes them and the
          // mint keeps all fields — the mint/refresh column sets stay symmetric on both paths.
-         const columns: MaterializedColumnSpec[] = entity.Fields
-            .filter((f) => !(entity.ExternalDataSourceID && f.IsVirtual))
+         const columns: MaterializedColumnSpec[] = this.materializedEntityFields(entity)
             .map((f) => ({
                Name: f.Name,
                SQLType: f.SQLFullType,
@@ -1604,6 +1607,10 @@ export class ManageMetadataBase {
          logStatus(`    > Query materialization: ${flagged.recordset.length} query(ies) flagged IsMaterialized but the MaterializedResult table is absent on this database — skipping (has the materialization migration been applied?)`);
          return { success: true, processedCount: 0, mintedCount: 0 };
       }
+
+      // Enumerate the API-key row-filter layer BEFORE the mint-time RLS gate consults it (see
+      // loadAPIKeyRowFilterTargets — an unloaded cache reads 'unknown' and refuses every materialization).
+      await this.loadAPIKeyRowFilterTargets(pool);
 
       const esc = (s: string) => s.replace(/'/g, "''");
       const idLit = (id: string | null | undefined) => (id ? `'${id}'` : 'NULL');
@@ -1846,6 +1853,9 @@ export class ManageMetadataBase {
       // applied on this DB) ⇒ no materializations exist to check for drift; skip cleanly rather than throwing and
       // aborting the codegen pass.
       if (!(await this.materializedResultTableExists(pool))) return { success: true, heldCount: 0 };
+      // Enumerate the API-key row-filter layer BEFORE the per-row C1 re-check / leak guard consults it (see
+      // loadAPIKeyRowFilterTargets — an unloaded cache reads 'unknown' and holds every materialization).
+      await this.loadAPIKeyRowFilterTargets(pool);
       const rows = await this.runQuery(
          pool,
          `SELECT mr.ID, mr.SourceType, mr.SourceEntityID, mrq.QueryID AS SourceQueryID, mr.GeneratedEntityID, mr.SchemaName, mr.TableName
@@ -1894,6 +1904,27 @@ export class ManageMetadataBase {
       // snapshot cannot enforce per-user scoping, so fail closed until a human authors protection. Base-view
       // materializations re-apply the source entity's RLS at read time (they reuse the source entity), so
       // they are exempt from this check.
+      if (r.SourceType === 'Query' && !r.SourceQueryID) {
+         // FAIL CLOSED on LOST PROVENANCE. `SourceQueryID` comes from a LEFT JOIN on MaterializedResultQuery.
+         // `spDeleteQuery` cascade-deletes that join row, but everything the join row protected SURVIVES: the
+         // MaterializedResult, the minted read-only virtual entity, its EntityPermission read grants, and the
+         // already-POPULATED materialized_<Name> table. With a NULL QueryID the C1 RLS re-check and the C2 grant
+         // re-narrow below are both unreachable, `gatherDriftFacts`' Query branch returns all-empty arrays,
+         // `evaluateMaterializationDrift` returns `{drift:false}`, and Status stays 'Active' — so the guard whose
+         // whole job is to revoke read + hold could never fire again and the unscoped snapshot would keep serving
+         // indefinitely. A query materialization that cannot name its source query has, by definition, lost the
+         // provenance every one of those safety checks is computed from, so treat it as drift and drive it down
+         // the established revoke-then-hold path. Over-holding is harmless (a human can relink and re-activate);
+         // under-holding is the leak.
+         await this.revokeReadAndHoldMaterialization(
+            pool,
+            r,
+            coreSchema,
+            'PROVENANCE DRIFT',
+            'its MaterializedResultQuery link is gone (the source query was deleted), so the RLS re-check and read-grant re-narrow can no longer be computed for it',
+         );
+         return true;
+      }
       if (r.SourceType === 'Query' && r.SourceQueryID) {
          const qe = await this.runQueryWithParams(pool, `SELECT EntityID FROM ${this.qs(coreSchema, 'QueryEntity')} WHERE QueryID = @Q`, { Q: r.SourceQueryID as string });
          const sourceEntityIds = qe.recordset.map((x: CodeGenQueryRow) => x.EntityID as string);
@@ -1904,19 +1935,7 @@ export class ManageMetadataBase {
          const driftSQL = (qSqlRes.recordset?.[0] as CodeGenQueryRow)?.SQL as string | undefined;
          const rlsVerdict = this.assessQuerySourceRLSSafety(md, sourceEntityIds, driftSQL);
          if (!rlsVerdict.safe) {
-            // Revoke read FIRST, then flag DriftHold. The revoke is the security-critical action (closes the
-            // leak — the snapshot serving unscoped source rows); DriftHold only stops future refreshes. Doing
-            // revoke first means that if the second statement fails, the readable window is already closed
-            // (fail-safe) — whereas DriftHold-then-revoke would leave read OPEN if the revoke failed.
-            if (r.GeneratedEntityID) {
-               await this.revokeMaterializedEntityReadAccess(pool, r.GeneratedEntityID as string, r.TableName as string, rlsVerdict.reason ?? 'source RLS drift');
-            }
-            await this.LogSQLAndExecute(
-               pool,
-               `UPDATE ${this.qs(coreSchema, 'MaterializedResult')} SET ${this.qi('Status')}='DriftHold' WHERE ID='${r.ID}'`,
-               `Flag materialization "${r.TableName}" as DriftHold (source RLS drift)`,
-            );
-            logError(`    > RLS DRIFT: materialization "${r.TableName}" → read access revoked + DriftHold — ${rlsVerdict.reason}`);
+            await this.revokeReadAndHoldMaterialization(pool, r, coreSchema, 'RLS DRIFT', rlsVerdict.reason ?? 'source RLS drift');
             return true; // already held for the leak; the shape-drift check below is moot
          }
          // Leak 2 (C2 ongoing): RLS is still safe, but a role may have LOST plain read on a source since mint.
@@ -1939,7 +1958,7 @@ export class ManageMetadataBase {
       // a human to drop the mirror. (Local base-view RLS is safe and not held.)
       if (r.SourceType === 'EntityBaseView' && r.SourceEntityID) {
          const bvEntity = md.EntityByID(r.SourceEntityID as string);
-         if (bvEntity && bvEntity.ExternalDataSourceID && this.entityHasRowLevelSecurity(bvEntity)) {
+         if (bvEntity && bvEntity.ExternalDataSourceID && this.entityHasRowLevelRestriction(bvEntity)) {
             // EMPTY the mirror now — it holds remote rows the live path refuses under RLS, and DriftHold alone
             // would only stop FUTURE refreshes while leaving the already-populated rows queryable via raw SQL
             // over the wrapper view. Emptying (not dropping) removes the leaked data without breaking any object
@@ -1954,7 +1973,7 @@ export class ManageMetadataBase {
                `UPDATE ${this.qs(coreSchema, 'MaterializedResult')} SET ${this.qi('Status')}='DriftHold' WHERE ID='${r.ID}'`,
                `Flag external RLS base-view materialization "${r.TableName}" as DriftHold (leak guard)`,
             );
-            logError(`    > RLS LEAK GUARD: base-view materialization "${r.TableName}" mirrors an EXTERNAL read-RLS-protected entity ("${bvEntity.Name}") → mirror EMPTIED + DriftHold (refresh stopped). It exposed rows the live path refuses under RLS.`);
+            logError(`    > RLS LEAK GUARD: base-view materialization "${r.TableName}" mirrors an EXTERNAL row-restricted entity ("${bvEntity.Name}" — role RLS and/or an API-key row filter) → mirror EMPTIED + DriftHold (refresh stopped). It exposed rows the live path refuses under RLS.`);
             return true;
          }
       }
@@ -1983,6 +2002,49 @@ export class ManageMetadataBase {
       return false;
    }
 
+   /**
+    * THE single rule for "which of an entity's fields get materialized" in a base-view materialization. Every
+    * site that computes a base-view column set — the MINT (physical table + wrapper view), the DRIFT comparison,
+    * and the runtime REFRESH mirror — must use this one predicate, or they judge each other's output as drift.
+    *
+    * Rule: for an EXTERNAL entity, virtual fields are MJ-computed and absent from the remote source, so the
+    * refresh mirror only materializes non-virtual columns and the mint must match. A LOCAL base view computes its
+    * virtual columns in the view itself, so `SELECT * FROM <baseView>` includes them and every field is kept.
+    * (`MaterializationRefresher.rebuildFromExternalEntity` applies `!f.IsVirtual` on the external path only — the
+    * same rule, expressed in a context where "external" is already established.)
+    */
+   protected materializedEntityFields(entity: EntityInfo): EntityFieldInfo[] {
+      return entity.Fields.filter((f) => !(entity.ExternalDataSourceID && f.IsVirtual));
+   }
+
+   /**
+    * The established fail-closed "stop serving this materialization" sequence, shared by every branch that must
+    * take a query materialization out of service.
+    *
+    * Revoke read FIRST, then flag DriftHold. The revoke is the security-critical action (it closes the leak — a
+    * snapshot serving unscoped source rows); DriftHold only stops FUTURE refreshes. Revoke-first means that if
+    * the second statement fails, the readable window is already closed (fail-safe) — whereas DriftHold-then-revoke
+    * would leave read OPEN if the revoke failed. A row with no minted entity has no grant row to flip; it is still
+    * held.
+    */
+   protected async revokeReadAndHoldMaterialization(
+      pool: CodeGenConnection,
+      r: CodeGenQueryRow,
+      coreSchema: string,
+      label: string,
+      reason: string,
+   ): Promise<void> {
+      if (r.GeneratedEntityID) {
+         await this.revokeMaterializedEntityReadAccess(pool, r.GeneratedEntityID as string, r.TableName as string, reason);
+      }
+      await this.LogSQLAndExecute(
+         pool,
+         `UPDATE ${this.qs(coreSchema, 'MaterializedResult')} SET ${this.qi('Status')}='DriftHold' WHERE ID='${r.ID}'`,
+         `Flag materialization "${r.TableName}" as DriftHold (${label.toLowerCase()})`,
+      );
+      logError(`    > ${label}: materialization "${r.TableName}" → read access revoked + DriftHold — ${reason}`);
+   }
+
    /** Gathers the drift-relevant existence facts for one materialization against current metadata. */
    protected async gatherDriftFacts(pool: CodeGenConnection, md: Metadata, r: CodeGenQueryRow, coreSchema: string): Promise<MaterializationDriftFacts> {
       if (r.SourceType === 'EntityBaseView') {
@@ -1993,7 +2055,12 @@ export class ManageMetadataBase {
          const materializedColumns = await this.getMaterializedTableColumns(pool, r.SchemaName as string, r.TableName as string);
          return {
             sourceType: 'EntityBaseView',
-            baseView: { sourceEntityExists: true, currentEntityFields: entity.Fields.map((f) => f.Name), materializedColumns },
+            // MUST use the same field-exclusion rule the MINT and the REFRESH use ({@link materializedEntityFields}).
+            // Comparing the UNFILTERED field list against the mirror's columns made every external entity with an
+            // IsVirtual field look like it had drifted the very first run after minting (added=[<virtual fields>])
+            // → Status='DriftHold' → permanent live-only fallback, and DriftHold rows are excluded from the sweep,
+            // so it could never recover. The comparison has to be apples-to-apples with what was actually built.
+            baseView: { sourceEntityExists: true, currentEntityFields: this.materializedEntityFields(entity).map((f) => f.Name), materializedColumns },
          };
       }
 
@@ -6153,7 +6220,9 @@ export class ManageMetadataBase {
     *     source's RLS, so we cannot prove safety.
     *  2. **Unresolvable link** — a linked EntityID that doesn't resolve to a known `EntityInfo`: if it secretly
     *     carried a read RLS filter we'd never see it.
-    *  3. **RLS-protected source** — any resolved source with a non-empty `ReadRLSFilterID`.
+    *  3. **Row-restricted source** — any resolved source protected by role RLS *or* an API-key row filter (see
+    *     {@link entityHasRowLevelRestriction}; the API-key layer matters because such an entity carries no
+    *     `ReadRLSFilterID`, and the minted entity's NEW EntityID would not match the key's EntityID binding).
     * Over-restriction here is harmless (the query stays live-only, or an existing materialization is held); the
     * reverse — serving a protected source's rows unscoped — is the leak this guard exists to prevent.
     */
@@ -6168,10 +6237,10 @@ export class ManageMetadataBase {
       }
       const rlsProtected = resolved
          .map((x) => x.entity as EntityInfo)
-         .filter((e) => e.Permissions.some((p) => !!p.ReadRLSFilterID && p.ReadRLSFilterID.trim().length > 0));
+         .filter((e) => this.entityHasRowLevelRestriction(e));
       if (rlsProtected.length > 0) {
          const names = rlsProtected.map((e) => `"${e.Name}"`).join(', ');
-         return { safe: false, reason: `source entit${rlsProtected.length === 1 ? 'y' : 'ies'} ${names} ${rlsProtected.length === 1 ? 'is' : 'are'} read-RLS-protected, and a materialized query entity does NOT inherit source RLS (plan §6.2)` };
+         return { safe: false, reason: `source entit${rlsProtected.length === 1 ? 'y' : 'ies'} ${names} ${rlsProtected.length === 1 ? 'is' : 'are'} read-RLS-protected (role RLS and/or an API-key row filter), and a materialized query entity does NOT inherit source row restrictions (plan §6.2)` };
       }
       // P1 hardening — catch RLS sources the LINKER MISSED. The checks above inspect only the LINKED sources
       // (vwQueryEntities); a source reached via a wrapping view / CTE / function / aliased columns that
@@ -6222,7 +6291,7 @@ export class ManageMetadataBase {
             const candidates = this.findEntitiesByBaseObject(md, ref.SchemaName, ref.TableName);
             const unlinked = candidates.find((e) => !linkedSet.has(e.ID.trim().toLowerCase()));
             if (unlinked) {
-               const rlsNote = this.entityHasRowLevelSecurity(unlinked) ? ' read-RLS-protected' : ' read-restricted';
+               const rlsNote = this.entityHasRowLevelRestriction(unlinked) ? ' row-restricted (role RLS and/or an API-key row filter)' : ' read-restricted';
                return { safe: false, reason: `query references${rlsNote} source "${unlinked.Name}" (${ref.SchemaName ?? ''}.${ref.TableName}) that query-analysis did NOT link — an unscoped snapshot cannot prove its per-source read access is honored (P1 under-linking guard)` };
             }
          }
@@ -6313,11 +6382,128 @@ export class ManageMetadataBase {
    }
 
    /**
-    * True if an entity is read-RLS-protected — any of its role permissions carries a non-empty `ReadRLSFilterID`.
-    * Same definition {@link assessQuerySourceRLSSafety} uses; extracted so the base-view leak gate can reuse it.
+    * ROLE-RLS LAYER ONLY — true if any of the entity's role permissions carries a non-empty `ReadRLSFilterID`.
+    *
+    * This is deliberately NOT a gate on its own, and no materialization gate may call it directly. MJ enforces
+    * row restrictions in TWO layers (see `EntityInfo.GetEffectiveRowFilterWhereClause`, the sanctioned composer):
+    * role RLS *and* API-key row filters, AND-composed. An entity bound ONLY by an API-key row filter carries no
+    * `ReadRLSFilterID` at all, so a gate that stopped at this layer would judge it unprotected and fail OPEN —
+    * minting a materialized entity with a NEW EntityID, which the API-key binding (which binds by EntityID) no
+    * longer matches, handing a filtered principal a full unscoped snapshot of rows it cannot read live.
+    *
+    * `EntityInfo` exposes no user-free accessor for either layer (`GetEffectiveRowFilterWhereClause` needs a
+    * session `UserInfo`, and CodeGen has no session), so the composition is done explicitly here — by
+    * {@link entityHasRowLevelRestriction}, which is what every gate calls.
     */
    protected entityHasRowLevelSecurity(entity: EntityInfo): boolean {
+      return ManageMetadataBase.EntityHasRoleReadRLS(entity);
+   }
+
+   /** Pure form of the role-RLS layer (see {@link entityHasRowLevelSecurity}). IO-free so it can be reused
+    *  verbatim by the runtime refresher's equivalent gate. */
+   public static EntityHasRoleReadRLS(entity: EntityInfo): boolean {
       return entity.Permissions.some((p) => !!p.ReadRLSFilterID && p.ReadRLSFilterID.trim().length > 0);
+   }
+
+   /**
+    * Per-run cache of the entity NAMES (trimmed + lowercased) that an API-KEY row filter
+    * (`APIKeyScope.RowFilterID`) or an API-APPLICATION row ceiling (`APIApplicationScope.RowFilterID`) binds to.
+    *
+    * `'unknown'` — the INITIAL value — means "not loaded, or could not be enumerated", and makes
+    * {@link entityHasRowLevelRestriction} treat EVERY entity as row-restricted. That is the fail-CLOSED
+    * direction on purpose: refusing to materialize costs nothing (the entity/query stays live-only), while
+    * materializing an entity whose API-key row filter we failed to see is the precise leak these gates exist to
+    * prevent. Loaded by {@link loadAPIKeyRowFilterTargets} at the top of every materialization entry point.
+    * `protected` (not `private`) so a unit-test seam can declare "this fixture configures no API-key row filters".
+    */
+   protected apiKeyRowFilterTargets: ReadonlySet<string> | 'unknown' = 'unknown';
+
+   /**
+    * THE row-restriction gate for materialization. True when the entity is protected by ANY row-level
+    * restriction — role RLS **or** an API-key / API-application row filter — because a materialized snapshot
+    * reproduces neither. Fails closed when the API-key layer could not be enumerated (see
+    * {@link apiKeyRowFilterTargets}).
+    */
+   protected entityHasRowLevelRestriction(entity: EntityInfo): boolean {
+      return ManageMetadataBase.EntityHasRowLevelRestriction(entity, this.apiKeyRowFilterTargets);
+   }
+
+   /**
+    * Pure, IO-free core of {@link entityHasRowLevelRestriction} — the predicate any other layer (e.g. the
+    * runtime `MaterializationRefresher`) should mirror, supplying the API-key target set however it can obtain
+    * it. `'unknown'` for the target set ⇒ true (fail closed).
+    */
+   public static EntityHasRowLevelRestriction(entity: EntityInfo, apiKeyRowFilterTargets: ReadonlySet<string> | 'unknown'): boolean {
+      if (ManageMetadataBase.EntityHasRoleReadRLS(entity)) return true;
+      if (apiKeyRowFilterTargets === 'unknown') return true; // cannot prove the key layer is empty → fail closed
+      return apiKeyRowFilterTargets.has((entity.Name ?? '').trim().toLowerCase());
+   }
+
+   /**
+    * Loads {@link apiKeyRowFilterTargets} once per CodeGen run. Called at the top of every materialization entry
+    * point, BEFORE any gate runs, so the gates never evaluate against an unloaded cache in production.
+    *
+    * Resolution rules (all biased fail-closed):
+    *  - The `RowFilterID` column absent on a scope table ⇒ that binding layer cannot exist on this database
+    *    (pre-v6 schema / the PostgreSQL parallel world) ⇒ contributes nothing. This is CORRECT, not fail-open.
+    *  - A filtered rule's `ResourcePattern` must name ONE exact entity (enforced at rule save). A filtered rule
+    *    with a NULL/blank pattern, or one carrying a wildcard/list (`*`, `%`, `,`), cannot be mapped to a single
+    *    entity, so the whole set collapses to `'unknown'` — every entity is then treated as restricted.
+    *  - Any error enumerating the rules ⇒ `'unknown'` (never a silently-empty set).
+    * Permission type is deliberately NOT narrowed to `Read`: mapping a scope rule to a permission type requires
+    * the APIScope path taxonomy that lives outside CodeGen, and over-restriction here is harmless.
+    */
+   protected async loadAPIKeyRowFilterTargets(pool: CodeGenConnection): Promise<void> {
+      if (this.apiKeyRowFilterTargets !== 'unknown') return; // already loaded this run
+      try {
+         const targets = new Set<string>();
+         for (const table of ['APIKeyScope', 'APIApplicationScope']) {
+            if (!(await this.columnExistsInCoreSchema(pool, table, 'RowFilterID'))) continue;
+            const res = await this.runQuery(
+               pool,
+               `SELECT DISTINCT ${this.qi('ResourcePattern')} AS ResourcePattern FROM ${this.qs(mj_core_schema(), table)} WHERE ${this.qi('RowFilterID')} IS NOT NULL`,
+            );
+            for (const row of res.recordset ?? []) {
+               const r = row as CodeGenQueryRow;
+               const pattern = ((r.ResourcePattern ?? r.resourcepattern) as string | null) ?? '';
+               const trimmed = pattern.trim();
+               if (trimmed.length === 0 || /[*%,]/.test(trimmed)) {
+                  logError(
+                     `    > API-key row-filter enumeration: a filtered scope rule in ${table} has an unmappable ResourcePattern ` +
+                     `("${trimmed}") — it cannot be resolved to a single entity, so EVERY entity is treated as row-restricted ` +
+                     `for materialization this run (fail closed). Fix the rule to name one exact entity.`,
+                  );
+                  this.apiKeyRowFilterTargets = 'unknown';
+                  return;
+               }
+               targets.add(trimmed.toLowerCase());
+            }
+         }
+         this.apiKeyRowFilterTargets = targets;
+      } catch (err) {
+         this.apiKeyRowFilterTargets = 'unknown';
+         logError(
+            `    > API-key row-filter enumeration FAILED — every entity will be treated as row-restricted for materialization ` +
+            `this run (fail closed): ${err instanceof Error ? err.message : String(err)}`,
+         );
+      }
+   }
+
+   /** Cached INFORMATION_SCHEMA column-existence probe against the MJ core schema. Generalizes the
+    *  hand-rolled probes above so new gates don't each hand-roll another one. */
+   private _coreSchemaColumnExists = new Map<string, boolean>();
+   protected async columnExistsInCoreSchema(pool: CodeGenConnection, table: string, column: string): Promise<boolean> {
+      const key = `${table}.${column}`.toLowerCase();
+      const cached = this._coreSchemaColumnExists.get(key);
+      if (cached !== undefined) return cached;
+      const sql = `SELECT COUNT(*) AS ColExists FROM INFORMATION_SCHEMA.COLUMNS ` +
+                  `WHERE TABLE_SCHEMA = '${mj_core_schema()}' AND TABLE_NAME = '${table}' AND COLUMN_NAME = '${column}'`;
+      const result = await this.runQuery(pool, sql);
+      const row = (result.recordset?.[0] ?? {}) as Record<string, unknown>;
+      const cnt = row.ColExists ?? row.colexists ?? 0;
+      const exists = Number(cnt) > 0;
+      this._coreSchemaColumnExists.set(key, exists);
+      return exists;
    }
 
    /**

--- a/packages/CodeGenLib/src/Database/manage-metadata.ts
+++ b/packages/CodeGenLib/src/Database/manage-metadata.ts
@@ -29,7 +29,7 @@ import {
 } from "./search-guardrails";
 import { mapExternalNativeTypeToMJ } from "../Misc/externalTypeMapping";
 import { SQLParser } from "@memberjunction/sql-parser";
-import { createDisplayName, generatePluralName, MJGlobal, RegisterClass, SafeJSONParse, stripTrailingChars, UUIDsEqual } from "@memberjunction/global";
+import { createDisplayName, generatePluralName, MJGlobal, RegisterClass, ResolveSingleEntityResourceTarget, SafeJSONParse, stripTrailingChars, UUIDsEqual } from "@memberjunction/global";
 import { v4 as uuidv4 } from 'uuid';
 
 import * as fs from 'fs';
@@ -2507,20 +2507,11 @@ export class ManageMetadataBase {
     * metadataSupportObjects.ts). Cross-platform via INFORMATION_SCHEMA; cached for the run (the schema
     * cannot change mid-run).
     */
-   private _entityHasExternalDataSourceColumn: boolean | null = null;
    protected async entityHasExternalDataSourceColumn(pool: CodeGenConnection): Promise<boolean> {
-      if (this._entityHasExternalDataSourceColumn === null) {
-         // Check the VIEW the gated queries actually read (vwEntities), not the base Entity table — a
-         // schema where the table has the column but the view wasn't refreshed to expose it would still
-         // throw. (Matches the PG guard in metadataSupportObjects.ts, which also checks the view.)
-         const sql = `SELECT COUNT(*) AS ColExists FROM INFORMATION_SCHEMA.COLUMNS ` +
-                     `WHERE TABLE_SCHEMA = '${mj_core_schema()}' AND TABLE_NAME = 'vwEntities' AND COLUMN_NAME = 'ExternalDataSourceID'`;
-         const result = await this.runQuery(pool, sql);
-         const row = (result.recordset?.[0] ?? {}) as Record<string, unknown>;
-         const cnt = row.ColExists ?? row.colexists ?? 0;
-         this._entityHasExternalDataSourceColumn = Number(cnt) > 0;
-      }
-      return this._entityHasExternalDataSourceColumn;
+      // Check the VIEW the gated queries actually read (vwEntities), not the base Entity table — a
+      // schema where the table has the column but the view wasn't refreshed to expose it would still
+      // throw. (Matches the PG guard in metadataSupportObjects.ts, which also checks the view.)
+      return await this.columnExistsInCoreSchema(pool, 'vwEntities', 'ExternalDataSourceID');
    }
 
    /**
@@ -2529,17 +2520,8 @@ export class ManageMetadataBase {
     * on a DB without it (PostgreSQL today) the column is absent and any raw SQL referencing it aborts the
     * CodeGen run. processQueryMaterializations gates its ExternalDataSourceID reference on this. Cached per run.
     */
-   private _queryHasExternalDataSourceColumn: boolean | null = null;
    protected async queryHasExternalDataSourceColumn(pool: CodeGenConnection): Promise<boolean> {
-      if (this._queryHasExternalDataSourceColumn === null) {
-         const sql = `SELECT COUNT(*) AS ColExists FROM INFORMATION_SCHEMA.COLUMNS ` +
-                     `WHERE TABLE_SCHEMA = '${mj_core_schema()}' AND TABLE_NAME = 'Query' AND COLUMN_NAME = 'ExternalDataSourceID'`;
-         const result = await this.runQuery(pool, sql);
-         const row = (result.recordset?.[0] ?? {}) as Record<string, unknown>;
-         const cnt = row.ColExists ?? row.colexists ?? 0;
-         this._queryHasExternalDataSourceColumn = Number(cnt) > 0;
-      }
-      return this._queryHasExternalDataSourceColumn;
+      return await this.columnExistsInCoreSchema(pool, 'Query', 'ExternalDataSourceID');
    }
 
    /**
@@ -2548,17 +2530,8 @@ export class ManageMetadataBase {
     * yet (e.g. the PostgreSQL parallel world's object-availability lag) — same defensive pattern as
     * queryHasExternalDataSourceColumn. Cached per run.
     */
-   private _queryHasIsMaterializedColumn: boolean | null = null;
    protected async queryHasIsMaterializedColumn(pool: CodeGenConnection): Promise<boolean> {
-      if (this._queryHasIsMaterializedColumn === null) {
-         const sql = `SELECT COUNT(*) AS ColExists FROM INFORMATION_SCHEMA.COLUMNS ` +
-                     `WHERE TABLE_SCHEMA = '${mj_core_schema()}' AND TABLE_NAME = 'Query' AND COLUMN_NAME = 'IsMaterialized'`;
-         const result = await this.runQuery(pool, sql);
-         const row = (result.recordset?.[0] ?? {}) as Record<string, unknown>;
-         const cnt = row.ColExists ?? row.colexists ?? 0;
-         this._queryHasIsMaterializedColumn = Number(cnt) > 0;
-      }
-      return this._queryHasIsMaterializedColumn;
+      return await this.columnExistsInCoreSchema(pool, 'Query', 'IsMaterialized');
    }
 
    /**
@@ -6446,9 +6419,10 @@ export class ManageMetadataBase {
     * Resolution rules (all biased fail-closed):
     *  - The `RowFilterID` column absent on a scope table ⇒ that binding layer cannot exist on this database
     *    (pre-v6 schema / the PostgreSQL parallel world) ⇒ contributes nothing. This is CORRECT, not fail-open.
-    *  - A filtered rule's `ResourcePattern` must name ONE exact entity (enforced at rule save). A filtered rule
-    *    with a NULL/blank pattern, or one carrying a wildcard/list (`*`, `%`, `,`), cannot be mapped to a single
-    *    entity, so the whole set collapses to `'unknown'` — every entity is then treated as restricted.
+    *  - A filtered rule's `ResourcePattern` must name ONE exact entity (enforced at rule save). Mappability is
+    *    decided by {@link ResolveSingleEntityResourceTarget}, shared verbatim with the runtime refresher's
+    *    identical gate; a rule it cannot resolve collapses the whole set to `'unknown'` — every entity is then
+    *    treated as restricted.
     *  - Any error enumerating the rules ⇒ `'unknown'` (never a silently-empty set).
     * Permission type is deliberately NOT narrowed to `Read`: mapping a scope rule to a permission type requires
     * the APIScope path taxonomy that lives outside CodeGen, and over-restriction here is harmless.
@@ -6466,20 +6440,21 @@ export class ManageMetadataBase {
             for (const row of res.recordset ?? []) {
                const r = row as CodeGenQueryRow;
                const pattern = ((r.ResourcePattern ?? r.resourcepattern) as string | null) ?? '';
-               const trimmed = pattern.trim();
-               // Superset of what IsExactResourceName (rowFilterValidation.ts) rejects at save time — `*`, `?`,
-               // `,` — plus `%` as an extra fail-closed. Omitting `?` would fail OPEN: `Sk?p` would be stored as
-               // a literal target name, match no entity, and the entity it fences would read as unrestricted.
-               if (trimmed.length === 0 || /[*%,?]/.test(trimmed)) {
+               // The mappability rule is SHARED with the runtime refresher's identical gate
+               // (ResolveSingleEntityResourceTarget in @memberjunction/global) rather than copied. The two
+               // gates must agree exactly: a copy that drifts open here silently re-opens the leak the
+               // runtime gate closes, and vice versa — with nothing in the build to notice.
+               const target = ResolveSingleEntityResourceTarget(pattern);
+               if (target === null) {
                   logError(
                      `    > API-key row-filter enumeration: a filtered scope rule in ${table} has an unmappable ResourcePattern ` +
-                     `("${trimmed}") — it cannot be resolved to a single entity, so EVERY entity is treated as row-restricted ` +
+                     `("${pattern.trim()}") — it cannot be resolved to a single entity, so EVERY entity is treated as row-restricted ` +
                      `for materialization this run (fail closed). Fix the rule to name one exact entity.`,
                   );
                   this.apiKeyRowFilterTargets = 'unknown';
                   return;
                }
-               targets.add(trimmed.toLowerCase());
+               targets.add(target);
             }
          }
          this.apiKeyRowFilterTargets = targets;
@@ -6492,8 +6467,13 @@ export class ManageMetadataBase {
       }
    }
 
-   /** Cached INFORMATION_SCHEMA column-existence probe against the MJ core schema. Generalizes the
-    *  hand-rolled probes above so new gates don't each hand-roll another one. */
+   /**
+    * THE cached INFORMATION_SCHEMA column-existence probe against the MJ core schema — cross-platform, and
+    * cached for the run (the schema cannot change mid-run). Every column gate in this class routes through
+    * it: {@link entityHasExternalDataSourceColumn}, {@link queryHasExternalDataSourceColumn},
+    * {@link queryHasIsMaterializedColumn} and {@link loadAPIKeyRowFilterTargets} are each a one-line call,
+    * so a new gate has no reason to hand-roll a fourth copy of the same query and its own cache field.
+    */
    private _coreSchemaColumnExists = new Map<string, boolean>();
    protected async columnExistsInCoreSchema(pool: CodeGenConnection, table: string, column: string): Promise<boolean> {
       const key = `${table}.${column}`.toLowerCase();

--- a/packages/CodeGenLib/src/Database/materializationAnalysis.ts
+++ b/packages/CodeGenLib/src/Database/materializationAnalysis.ts
@@ -1,7 +1,10 @@
 import { MaterializedColumnSpec } from './codeGenDatabaseProvider';
 import { SQLParser, type SQLSelectColumn } from '@memberjunction/sql-parser';
 import type { SQLParserDialect } from '@memberjunction/sql-dialect';
-import { isObject, nodeType, columnName, type AstNode } from './materializationSqlAst';
+import {
+    isObject, nodeType, qualifiedColumn, identifiersEqual, isSetOperationRoot, soleStatement,
+    type AstNode, type AstObject,
+} from './materializationSqlAst';
 
 /**
  * Result-shape + key analysis for query materialization (CodeGen materialization phase,
@@ -202,6 +205,19 @@ export function qualifyParameterizedQuery(opts: {
      * Phase-2 enablement switch (finalize the read-time predicate injection first).
      */
     allowRowFilterBroad?: boolean;
+    /**
+     * The query's **rendered** SQL (a concrete instance — parameters already substituted). REQUIRED to
+     * qualify a `RowFilter` param: the verifier reports `filterColumn` as a BARE column name, and matching
+     * that name against the output-column list alone cannot tell `o.Status` (the predicate) apart from
+     * `c.Status` (the projected output) in a join, nor `BillRegion` (an alias over `ShipRegion`) apart from
+     * a real `BillRegion` column. Both mis-matches produce a materialized read that filters on a DIFFERENT
+     * column than the live query, with no error and no count-guard signal. See
+     * {@link proveFilterColumnBinding}. When omitted, RowFilter params are REFUSED (fail closed, §10) —
+     * the query stays live-only, which is always correct.
+     */
+    sql?: string;
+    /** Dialect used to parse {@link sql}. Required alongside it; RowFilter params refuse without both. */
+    dialect?: SQLParserDialect;
 }): ParamQualification {
     const { queryName, params, outputColumns } = opts;
     const allowPerValueCache = opts.allowPerValueCache ?? false;
@@ -252,6 +268,17 @@ export function qualifyParameterizedQuery(opts: {
         if (p.filterKind !== expectedKind) {
             return refuse(`query "${queryName}" param "${p.name}" operator "${op}" expects a ${expectedKind} value but the verifier reported "${p.filterKind ?? '(none)'}" — refusing under uncertainty`);
         }
+        // Qualifier-aware binding proof: the predicate's SOURCE column must provably be the very column the
+        // identically-named materialized OUTPUT column carries. A bare-name match is not that proof (join
+        // collision / alias rebinding) — and neither is broad-render's removal count, which is exactly 1 in
+        // both wrong cases. Without the rendered SQL there is nothing to prove it with → refuse (§10).
+        if (!opts.sql || !opts.dialect) {
+            return refuse(`query "${queryName}" param "${p.name}" filters on "${p.filterColumn}" but no rendered SQL was supplied to prove that predicate binds to the materialized output column of the same name — refusing under uncertainty (the query stays live-only)`);
+        }
+        const binding = proveFilterColumnBinding({ sql: opts.sql, dialect: opts.dialect, filterColumn: p.filterColumn });
+        if (!binding.provable) {
+            return refuse(`query "${queryName}" param "${p.name}" filters on "${p.filterColumn}" but that predicate cannot be proven to bind to the materialized output column of the same name: ${binding.reason} — a materialized read would filter a different column than the live query. Refusing (the query stays live-only).`);
+        }
         rowFilterColumns.push(p.filterColumn);
         readFilterSpec.push({ column: p.filterColumn, operator: op, paramName: p.name, kind: expectedKind });
     }
@@ -272,17 +299,197 @@ export function qualifyParameterizedQuery(opts: {
 
 // AST-walking primitives are shared with the param verifier + broad-render via ./materializationSqlAst
 // (single source of truth — see that module's header). extractGroupByTerms is GROUP-BY-specific and stays here.
-/** Extracts the top-level GROUP BY term nodes, normalizing node-sql-parser's dialect-varying shapes. */
-function extractGroupByTerms(sql: string, dialect: SQLParserDialect): AstNode[] {
-    const parsed = SQLParser.Astify(sql, dialect);
-    if (!parsed.astParsed || parsed.ast == null) return [];
-    const stmt = Array.isArray(parsed.ast) ? (parsed.ast.length === 1 ? parsed.ast[0] : null) : parsed.ast;
-    if (!isObject(stmt)) return [];
+/**
+ * Extracts the top-level GROUP BY term nodes, normalizing node-sql-parser's dialect-varying shapes.
+ * Returns `[]` (→ no key → full rebuild) for anything it cannot read as a single plain SELECT's GROUP BY.
+ *
+ * **Set-operation refusal (soundness-critical).** A `UNION` / `UNION ALL` / `EXCEPT` / `INTERSECT` parses to
+ * a SINGLE `select` root carrying `set_op`/`_next`, whose `groupby` and `columns` describe **only the first
+ * branch** (see {@link isSetOperationRoot}). Reading that root would report the first branch's grouping
+ * columns as the key of the WHOLE query — but the combined result legitimately contains one row per
+ * (branch × group), so those "key" columns are NOT unique across the result. The caller would then hash the
+ * key into the surrogate PK and pick the MERGE-upsert Incremental path, where the branches collide on the
+ * same hash and one silently overwrites the other — permanently wrong aggregates with no error. Refuse.
+ */
+function extractGroupByTerms(stmt: AstObject): AstNode[] {
     const gb = stmt.groupby;
     if (isObject(gb) && Array.isArray(gb.columns)) return gb.columns; // observed shape: { columns: [...] }
     if (Array.isArray(gb)) return gb; // some dialects emit a bare array
     if (isObject(gb) && Array.isArray(gb.value)) return gb.value; // …or { value: [...] }
     return [];
+}
+
+/**
+ * Parses `sql` and returns its sole plain-SELECT statement root, or null when that is not what it is —
+ * unparseable, multi-statement, a non-SELECT, or a SET OPERATION (see {@link isSetOperationRoot}, whose
+ * first-branch-only view every analyzer here must refuse). Every analyzer in this module goes through
+ * this one gate so no future reader can reintroduce a bare `ast[0]` set-op blind spot.
+ */
+function parseSoleSelectRoot(sql: string, dialect: SQLParserDialect): AstObject | null {
+    const parsed = SQLParser.Astify(sql, dialect);
+    if (!parsed.astParsed || parsed.ast == null) return null;
+    const stmt = soleStatement(parsed.ast);
+    if (!isObject(stmt) || nodeType(stmt) !== 'select') return null;
+    if (isSetOperationRoot(stmt)) return null;
+    return stmt;
+}
+
+/** Number of relations in a SELECT's FROM clause (each JOIN / comma source counts). 0 when unreadable. */
+function fromSourceCount(stmt: AstObject): number {
+    return Array.isArray(stmt.from) ? stmt.from.length : 0;
+}
+
+/**
+ * Whether a SELECT-list column reference and another reference to the same bare name (a GROUP BY term, a
+ * WHERE predicate operand) provably denote the SAME source column.
+ *
+ * With a SINGLE FROM relation, every reference to a given name necessarily resolves to that one relation,
+ * so the qualifier carries no information and the bare-name match is already a proof. With a JOIN the bare
+ * name is ambiguous — `o.Status` and `c.Status` are different columns — so BOTH sides must carry the same
+ * explicit qualifier; an unqualified reference on either side is unprovable and refuses (§10).
+ */
+function sourceRefsMatch(selectQualifier: string | null, refQualifier: string | null, singleSource: boolean): boolean {
+    if (singleSource) return true;
+    return identifiersEqual(selectQualifier, refQualifier);
+}
+
+/** Verdict of {@link proveFilterColumnBinding}: provable, or refused with the precise reason. */
+export interface FilterColumnBindingProof {
+    /** True ONLY when the predicate column is proven to be the same source column the output column carries. */
+    provable: boolean;
+    /** When not provable, the precise reason (logged; never guessed past). */
+    reason?: string;
+}
+
+/**
+ * Collects the table qualifiers of every reference to `column` inside an AST subtree, in encounter order.
+ * A `null` entry means an unqualified reference. Used to read the WHERE clause's view of a filter column.
+ */
+function collectColumnQualifiers(node: AstNode, column: string, found: (string | null)[]): void {
+    if (Array.isArray(node)) {
+        for (const child of node) collectColumnQualifiers(child, column, found);
+        return;
+    }
+    if (!isObject(node)) return;
+    const qc = qualifiedColumn(node);
+    if (qc != null) {
+        if (identifiersEqual(qc.column, column)) found.push(qc.qualifier);
+        return; // a column_ref has no further column_ref descendants
+    }
+    for (const [k, v] of Object.entries(node)) {
+        if (k !== 'loc') collectColumnQualifiers(v, column, found);
+    }
+}
+
+/**
+ * Proves that a verified row-filter predicate on `filterColumn` refers to **exactly** the materialized
+ * output column of that same name — the gap a bare-name `outputColumns.includes(filterColumn)` check leaves
+ * open, and which nothing downstream can close.
+ *
+ * Two silently-wrong-data cases motivate it, both of which pass every existing guard (in particular the
+ * broad-render count guard, since exactly ONE predicate is stripped in each):
+ *
+ *  - **Join collision** — `SELECT o.ID, c.Status FROM Orders o JOIN Customers c … WHERE o.Status = {{s}}`.
+ *    The output `Status` is the CUSTOMER's; the predicate is the ORDER's. The materialized read emits
+ *    `WHERE [Status] = @p0` against the customer's value.
+ *  - **Alias rebinding** — `SELECT ID, ShipRegion AS BillRegion FROM Orders WHERE BillRegion = {{r}}` on a
+ *    table that has BOTH columns. The materialized `BillRegion` column holds `ShipRegion` values, so the
+ *    read filters `ShipRegion = 'East'` while live filters `BillRegion = 'East'`.
+ *
+ * Refuses (never guesses) unless ALL of the following hold — falling back to the live query, always correct:
+ *  1. `sql` parses to a single plain SELECT (not multi-statement, not a set operation — a `UNION` root
+ *     exposes only its first branch, so nothing about the whole result can be proven from it);
+ *  2. the SELECT list is readable and not a wildcard (`SELECT *` hides the real output↔source mapping);
+ *  3. exactly ONE output column is named `filterColumn` (two would make the read-time predicate ambiguous);
+ *  4. that output column is a plain column reference, not a computed expression;
+ *  5. it projects the SAME source column name (no alias rebinding);
+ *  6. the WHERE clause references `filterColumn` under a single, consistent qualifier; and
+ *  7. that qualifier provably denotes the same relation as the output column's — trivially true for a
+ *     single-relation FROM, otherwise both must carry the same explicit qualifier ({@link sourceRefsMatch}).
+ *
+ * Pure — no DB/IO.
+ */
+export function proveFilterColumnBinding(opts: {
+    /** The query's RENDERED SQL (parameters substituted), still carrying the row-filter predicate. */
+    sql: string;
+    /** Dialect to parse with. */
+    dialect: SQLParserDialect;
+    /** The verifier-reported bare filter column name. */
+    filterColumn: string;
+}): FilterColumnBindingProof {
+    const { sql, dialect, filterColumn } = opts;
+    const refuse = (reason: string): FilterColumnBindingProof => ({ provable: false, reason });
+    if (!sql || sql.trim().length === 0) return refuse('no rendered SQL to analyze');
+
+    let root: AstObject | null;
+    let selectCols: SQLSelectColumn[];
+    try {
+        root = parseSoleSelectRoot(sql, dialect);
+        selectCols = SQLParser.ExtractSelectColumns(sql, dialect);
+    } catch {
+        return refuse('the rendered SQL could not be parsed');
+    }
+    if (root == null) {
+        return refuse('the rendered SQL is not a single plain SELECT (multi-statement, non-SELECT, or a UNION/EXCEPT/INTERSECT whose branches are not all visible)');
+    }
+    const outputCheck = resolveProvableOutputColumn(selectCols, filterColumn);
+    if (!outputCheck.provable) return refuse(outputCheck.reason);
+    const output = outputCheck.column;
+
+    const qualifiers: (string | null)[] = [];
+    collectColumnQualifiers(root.where, filterColumn, qualifiers);
+    if (qualifiers.length === 0) {
+        return refuse(`the WHERE clause of the rendered SQL has no reference to a column named "${filterColumn}"`);
+    }
+    const distinct = new Set(qualifiers.map((q) => (q == null ? '' : q.trim().toLowerCase())));
+    if (distinct.size > 1) {
+        return refuse(`the WHERE clause references "${filterColumn}" under ${distinct.size} different table qualifiers — the parameter's predicate cannot be attributed to one of them`);
+    }
+    const predicateQualifier = qualifiers[0];
+
+    const singleSource = fromSourceCount(root) === 1;
+    if (!singleSource && (predicateQualifier == null || output.TableQualifier == null)) {
+        return refuse(`the query reads ${fromSourceCount(root)} relations and the ${predicateQualifier == null ? 'WHERE predicate on' : 'SELECT-list projection of'} "${filterColumn}" is unqualified, so the name cannot be attributed to a single source`);
+    }
+    if (!sourceRefsMatch(output.TableQualifier, predicateQualifier, singleSource)) {
+        return refuse(`the WHERE predicate filters "${predicateQualifier}.${filterColumn}" but the output column "${filterColumn}" projects "${output.TableQualifier}.${filterColumn}" — a different source column`);
+    }
+    return { provable: true };
+}
+
+/** Either the proven output column, or the reason the projection could not be proven. */
+type OutputColumnResolution =
+    | { provable: true; column: SQLSelectColumn }
+    | { provable: false; reason: string };
+
+/**
+ * Resolves the single SELECT-list output column that a read-time filter on `filterColumn` would target,
+ * or the reason it is not provably that source column (wildcard projection, duplicate/absent name,
+ * computed expression, or an alias rebinding a differently-named source column).
+ */
+function resolveProvableOutputColumn(selectCols: SQLSelectColumn[], filterColumn: string): OutputColumnResolution {
+    const no = (reason: string): OutputColumnResolution => ({ provable: false, reason });
+    if (!selectCols || selectCols.length === 0) {
+        return no('the SELECT list could not be read');
+    }
+    if (selectCols.some((c) => c.OutputName === '*')) {
+        return no('the query projects a wildcard (SELECT *), so the output-to-source column mapping is unknown');
+    }
+    const matches = selectCols.filter((c) => identifiersEqual(c.OutputName, filterColumn));
+    if (matches.length === 0) {
+        return no(`no SELECT-list output column is named "${filterColumn}"`);
+    }
+    if (matches.length > 1) {
+        return no(`the SELECT list projects ${matches.length} output columns named "${filterColumn}"`);
+    }
+    const output = matches[0];
+    if (output.IsExpression) {
+        return no(`the output column "${filterColumn}" is a computed expression, not a plain projection of a source column`);
+    }
+    if (!identifiersEqual(output.SourceColumn, filterColumn)) {
+        return no(`the output column "${filterColumn}" is an ALIAS over source column "${output.SourceColumn}", so filtering the materialized "${filterColumn}" is not the same predicate as the live "${filterColumn}"`);
+    }
+    return { provable: true, column: output };
 }
 
 /**
@@ -310,26 +517,34 @@ export function detectAggregationKeyColumns(opts: {
     // be at least one aggregate measure; (3) every grouping column must map to exactly one PROJECTED output
     // column (so the key is expressible in the materialized table — a grouped-but-unprojected column would
     // make the surrogate key too narrow and collide).
-    let groupByTerms: AstNode[];
+    let root: AstObject | null;
     let selectCols: SQLSelectColumn[];
     try {
-        groupByTerms = extractGroupByTerms(sql, dialect);
+        root = parseSoleSelectRoot(sql, dialect);
         selectCols = SQLParser.ExtractSelectColumns(sql, dialect);
     } catch {
         return null; // unparseable → not keyed (safe: synthetic surrogate + full rebuild)
     }
+    if (root == null) return null; // multi-statement / non-SELECT / set operation → refuse
+    const groupByTerms = extractGroupByTerms(root);
     if (groupByTerms.length === 0 || !selectCols || selectCols.length === 0) return null;
     if (groupByTerms.some((t) => nodeType(t) !== 'column_ref')) return null; // expression grouping → bail
     if (!selectCols.some((c) => c.IsExpression)) return null; // no aggregate measure → not an aggregation
 
+    // (4) A grouping term is matched to a projected output column by SOURCE COLUMN NAME — which is ambiguous
+    // across a join (`GROUP BY o.Region` vs. a projected `c.Region` are different columns). Require the table
+    // qualifiers to agree whenever there is more than one FROM relation; see sourceRefsMatch.
+    const singleSource = fromSourceCount(root) === 1;
     const fieldByOutput = new Map(fields.map((f) => [f.Name.trim().toLowerCase(), f]));
     const key: { name: string; type: string }[] = [];
     for (const term of groupByTerms) {
-        const gbName = columnName(term);
-        if (gbName == null) return null;
+        const gb = qualifiedColumn(term);
+        if (gb == null) return null;
         // The projected (non-expression) SELECT column whose pre-alias source column IS this grouping column.
         const projected = selectCols.filter(
-            (c) => !c.IsExpression && c.SourceColumn.trim().toLowerCase() === gbName.trim().toLowerCase(),
+            (c) => !c.IsExpression
+                && identifiersEqual(c.SourceColumn, gb.column)
+                && sourceRefsMatch(c.TableQualifier, gb.qualifier, singleSource),
         );
         if (projected.length !== 1) return null; // unprojected (0) or ambiguous (>1) → bail
         const f = fieldByOutput.get(projected[0].OutputName.trim().toLowerCase());

--- a/packages/CodeGenLib/src/Database/materializationParamClassifier.ts
+++ b/packages/CodeGenLib/src/Database/materializationParamClassifier.ts
@@ -276,12 +276,26 @@ export function classifyQueryParameters(opts: {
         filterKind: pv.verdict.filterKind,
     }));
 
+    // The qualifier needs the CONCRETE SQL to prove each RowFilter predicate binds to the materialized
+    // output column of the same name (a bare column-name match cannot see a join collision or an alias
+    // rebinding — see proveFilterColumnBinding). The held baseline render is the right instance: it is the
+    // same shape the broad-render step strips, and it still carries the row-filter predicate. If the render
+    // throws, we pass nothing and RowFilter params refuse (fail closed → the query stays live-only).
+    let heldSQL: string | undefined;
+    try {
+        heldSQL = render(held);
+    } catch {
+        heldSQL = undefined;
+    }
+
     const qualification = qualifyParameterizedQuery({
         queryName,
         params: classifications,
         outputColumns,
         allowPerValueCache: opts.allowPerValueCache ?? false,
         allowRowFilterBroad: opts.allowRowFilterBroad ?? false,
+        sql: heldSQL,
+        dialect,
     });
 
     return { qualification, perParam };

--- a/packages/CodeGenLib/src/Database/materializationSqlAst.ts
+++ b/packages/CodeGenLib/src/Database/materializationSqlAst.ts
@@ -55,22 +55,105 @@ export function isLiteralNode(v: AstNode): boolean {
 }
 
 /**
+ * Unwraps a node-sql-parser identifier slot (`column`, `table`) to plain text across dialects.
+ * SQL Server emits a bare string; PostgreSQL wraps a quoted identifier as
+ * `{ expr: { type: 'double_quote_string' | 'default', value: 'X' } }`. Returns null for anything else
+ * (an absent qualifier, or a computed/expression node that is not a plain identifier).
+ */
+function identifierText(v: AstNode): string | null {
+    if (typeof v === 'string') {
+        return v;
+    }
+    if (isObject(v) && isObject(v.expr) && typeof v.expr.value === 'string') {
+        return v.expr.value;
+    }
+    return null;
+}
+
+/**
  * Resolves a `column_ref` node's bare column name across dialects. SQL Server emits `column` as a string;
  * PostgreSQL emits `column: { expr: { type: 'default', value: 'X' } }`. Returns null for computed/expression
  * columns (which are not clean filter/grouping columns).
+ *
+ * **This deliberately DISCARDS the table qualifier** — `o.Status` and `c.Status` both return `'Status'`.
+ * That is correct for callers that only need a name, but a caller that MATCHES a column reference against
+ * another column reference (a SELECT-list output, another predicate) MUST also compare
+ * {@link columnQualifier} — see {@link qualifiedColumn}. Matching on the bare name alone silently conflates
+ * same-named columns from different tables in a join.
  */
 export function columnName(v: AstNode): string | null {
     if (nodeType(v) !== 'column_ref' || !isObject(v)) {
         return null;
     }
-    const col = v.column;
-    if (typeof col === 'string') {
-        return col;
+    return identifierText(v.column);
+}
+
+/**
+ * Resolves a `column_ref` node's TABLE QUALIFIER — the `o` in `o.Status` (a table alias, or the table name
+ * when no alias is declared). Returns null when the reference is unqualified (`Status`) or when the node is
+ * not a `column_ref`. Dialect-tolerant in the same way as {@link columnName}.
+ */
+export function columnQualifier(v: AstNode): string | null {
+    if (nodeType(v) !== 'column_ref' || !isObject(v)) {
+        return null;
     }
-    if (isObject(col) && isObject(col.expr) && typeof col.expr.value === 'string') {
-        return col.expr.value;
+    return identifierText(v.table);
+}
+
+/** A `column_ref` split into its optional table qualifier and its bare column name. */
+export interface QualifiedColumn {
+    /** Table alias / table name qualifying the reference (`o` in `o.Status`); null when unqualified. */
+    qualifier: string | null;
+    /** Bare column name (`Status` in `o.Status`). */
+    column: string;
+}
+
+/**
+ * Resolves a `column_ref` into its qualifier + column pair, or null when the node is not a plain column
+ * reference. Prefer this over {@link columnName} whenever the resolved column is compared to ANOTHER
+ * column reference — the qualifier is what distinguishes `o.Status` from `c.Status`.
+ */
+export function qualifiedColumn(v: AstNode): QualifiedColumn | null {
+    const column = columnName(v);
+    if (column == null) {
+        return null;
     }
-    return null;
+    return { qualifier: columnQualifier(v), column };
+}
+
+/** Case- and whitespace-insensitive SQL identifier equality. Null/undefined never matches anything. */
+export function identifiersEqual(a: string | null | undefined, b: string | null | undefined): boolean {
+    if (a == null || b == null) {
+        return false;
+    }
+    return a.trim().toLowerCase() === b.trim().toLowerCase();
+}
+
+/**
+ * True when a parsed statement root is a SET OPERATION (`UNION` / `UNION ALL` / `EXCEPT` / `INTERSECT`).
+ *
+ * **Why every analyzer needs this guard:** node-sql-parser does NOT emit a distinct `union` node type. It
+ * emits a SINGLE `type: 'select'` root for the FIRST branch, carrying `set_op: 'union all'` and `_next`
+ * (the remaining branch, itself a select node). So a naive `ast[0]` reader sees a plain SELECT whose
+ * `columns`, `where`, and `groupby` describe **only the first branch** — every other branch is invisible.
+ * Any analyzer that draws a conclusion about the whole result set (its key, its predicates, its shape)
+ * from that root is silently reasoning about a fraction of the query. All such analyzers MUST refuse a
+ * set-op root outright (§10 refuse-under-uncertainty).
+ */
+export function isSetOperationRoot(node: AstNode): boolean {
+    return isObject(node) && (node.set_op != null || node._next != null);
+}
+
+/**
+ * Returns the sole statement of a parsed AST, or null when it is not exactly one statement.
+ * A multi-statement script cannot be analyzed from its first statement alone, so callers refuse
+ * rather than inspect only `ast[0]`.
+ */
+export function soleStatement(ast: AstNode): AstNode | null {
+    if (Array.isArray(ast)) {
+        return ast.length === 1 ? ast[0] : null;
+    }
+    return ast;
 }
 
 /** True when every element of an `expr_list` value array is a literal leaf (an all-literal bag). */

--- a/packages/CodeGenLib/src/__tests__/manage-metadata-drift-baseview-symmetry.test.ts
+++ b/packages/CodeGenLib/src/__tests__/manage-metadata-drift-baseview-symmetry.test.ts
@@ -1,0 +1,141 @@
+import { describe, it, expect } from 'vitest';
+import { ManageMetadataBase } from '../Database/manage-metadata';
+import { evaluateMaterializationDrift } from '../Database/materializationDrift';
+import type { EntityInfo, Metadata } from '@memberjunction/core';
+import type { CodeGenConnection, CodeGenQueryRow } from '../Database/codeGenDatabaseProvider';
+
+/**
+ * MINT/DRIFT COLUMN-SET SYMMETRY for base-view materializations.
+ *
+ * The mint builds an EXTERNAL entity's snapshot from its NON-VIRTUAL fields only (virtual fields are
+ * MJ-computed and absent from the remote source, so the refresh mirror cannot populate them). Drift then
+ * compares "what the entity has now" against "what the snapshot actually holds" — and it used to build the
+ * first half from the entity's UNFILTERED field list.
+ *
+ * The result was self-inflicted and terminal: every external base-view materialization of an entity holding
+ * even one virtual field looked drifted on its VERY FIRST drift scan after minting, with the virtual fields
+ * reported as `added`. That set Status='DriftHold' — and held rows are excluded from the drift sweep's
+ * `WHERE Status NOT IN ('DriftHold', ...)`, so the materialization could never be re-examined and never
+ * recovered. It silently fell back to live forever, having never actually drifted.
+ *
+ * Both halves of the comparison now come from the one predicate (`materializedEntityFields`). These tests
+ * pin that: they drive the REAL `gatherDriftFacts` and feed its output to the REAL
+ * `evaluateMaterializationDrift`, so a regression in either the predicate or the site that calls it fails
+ * here rather than in a codegen run against a live external data source.
+ */
+
+/** The only `EntityInfo` surface the predicate and the fact-gatherer read. */
+type FieldStub = { Name: string; IsVirtual: boolean };
+const entity = (opts: { external: boolean; fields: FieldStub[] }): EntityInfo =>
+    ({
+        Name: 'Ext',
+        ID: 'e1',
+        ExternalDataSourceID: opts.external ? 'eds-1' : null,
+        Fields: opts.fields,
+    }) as unknown as EntityInfo;
+
+/** Metadata stub — `gatherDriftFacts`' base-view branch reads nothing but `EntityByID`. */
+const metadataWith = (e: EntityInfo | undefined): Metadata => ({ EntityByID: () => e }) as unknown as Metadata;
+
+const FAKE_POOL = {} as unknown as CodeGenConnection;
+
+class TestableDriftSymmetry extends ManageMetadataBase {
+    /** The snapshot table's ACTUAL columns, as INFORMATION_SCHEMA would report them. */
+    public snapshotColumns: string[] = [];
+
+    /** Stubbed so no DB is needed; this is the "what was actually built" half of the comparison. */
+    protected async getMaterializedTableColumns(): Promise<string[]> {
+        return this.snapshotColumns;
+    }
+
+    /** Exposes the protected single-rule predicate. */
+    public fieldsFor(e: EntityInfo): string[] {
+        return this.materializedEntityFields(e).map((f) => f.Name);
+    }
+
+    /** Drives the REAL base-view fact-gatherer for a resolved source entity. */
+    public gather(e: EntityInfo | undefined): Promise<ReturnType<ManageMetadataBase['gatherDriftFacts']>> {
+        const row = { SourceType: 'EntityBaseView', SourceEntityID: 'e1', SchemaName: '__mj', TableName: 'materialized_Ext' } as unknown as CodeGenQueryRow;
+        return this.gatherDriftFacts(FAKE_POOL, metadataWith(e), row, '__mj');
+    }
+}
+
+describe('materializedEntityFields — the single mint/drift/refresh column rule', () => {
+    const mm = new TestableDriftSymmetry();
+
+    it('DROPS virtual fields for an EXTERNAL entity (the remote source cannot supply them)', () => {
+        const e = entity({ external: true, fields: [{ Name: 'ID', IsVirtual: false }, { Name: 'Total', IsVirtual: false }, { Name: 'OwnerName', IsVirtual: true }] });
+        expect(mm.fieldsFor(e)).toEqual(['ID', 'Total']);
+    });
+
+    it('KEEPS virtual fields for a LOCAL entity (its base view computes them, so SELECT * includes them)', () => {
+        const e = entity({ external: false, fields: [{ Name: 'ID', IsVirtual: false }, { Name: 'OwnerName', IsVirtual: true }] });
+        expect(mm.fieldsFor(e)).toEqual(['ID', 'OwnerName']);
+    });
+});
+
+describe('base-view drift — mint and drift must compare the same column set', () => {
+    it('REGRESSION: an external entity with a virtual field does NOT drift against its own snapshot', async () => {
+        // Exactly the post-mint steady state: the snapshot holds the non-virtual columns the mint built,
+        // the entity still declares its virtual field, and nothing has changed. This must be quiet.
+        const mm = new TestableDriftSymmetry();
+        mm.snapshotColumns = ['ID', 'Total'];
+        const facts = await mm.gather(entity({ external: true, fields: [{ Name: 'ID', IsVirtual: false }, { Name: 'Total', IsVirtual: false }, { Name: 'OwnerName', IsVirtual: true }] }));
+
+        expect(facts.baseView?.currentEntityFields).toEqual(['ID', 'Total']); // virtual excluded — symmetric with the mint
+        expect(evaluateMaterializationDrift(facts)).toEqual({ drift: false });
+    });
+
+    it('documents the OLD behavior: the unfiltered field list flags the virtual field as added, and holds forever', () => {
+        // Not a test of current code — it pins WHY the fix matters, by running the evaluator on the fact
+        // shape the pre-fix gatherer produced. DriftHold here is terminal: held rows are excluded from the
+        // sweep, so this verdict could never be revisited.
+        const verdict = evaluateMaterializationDrift({
+            sourceType: 'EntityBaseView',
+            baseView: { sourceEntityExists: true, currentEntityFields: ['ID', 'Total', 'OwnerName'], materializedColumns: ['ID', 'Total'] },
+        });
+        expect(verdict.drift).toBe(true);
+        expect(verdict.reason).toMatch(/ownername/i);
+    });
+
+    it('a LOCAL base view whose snapshot INCLUDES the virtual column also does not drift', async () => {
+        // The mirror image: the fix must not over-filter. A local base view materializes its computed
+        // columns, so dropping them here would report them as orphaned and hold the materialization instead.
+        const mm = new TestableDriftSymmetry();
+        mm.snapshotColumns = ['ID', 'OwnerName'];
+        const facts = await mm.gather(entity({ external: false, fields: [{ Name: 'ID', IsVirtual: false }, { Name: 'OwnerName', IsVirtual: true }] }));
+
+        expect(facts.baseView?.currentEntityFields).toEqual(['ID', 'OwnerName']);
+        expect(evaluateMaterializationDrift(facts)).toEqual({ drift: false });
+    });
+
+    it('STILL detects real drift: a new NON-virtual field on an external entity', async () => {
+        // The guard that keeps this fix from being a stealth drift-disable — a genuine schema change on the
+        // source must still be caught.
+        const mm = new TestableDriftSymmetry();
+        mm.snapshotColumns = ['ID', 'Total'];
+        const facts = await mm.gather(entity({ external: true, fields: [{ Name: 'ID', IsVirtual: false }, { Name: 'Total', IsVirtual: false }, { Name: 'Currency', IsVirtual: false }, { Name: 'OwnerName', IsVirtual: true }] }));
+
+        const verdict = evaluateMaterializationDrift(facts);
+        expect(verdict.drift).toBe(true);
+        expect(verdict.reason).toMatch(/currency/i);
+        expect(verdict.reason).not.toMatch(/ownername/i); // the virtual field is still not the reason
+    });
+
+    it('STILL detects real drift: a column dropped from the source entity leaves the snapshot orphaned', async () => {
+        const mm = new TestableDriftSymmetry();
+        mm.snapshotColumns = ['ID', 'Total', 'LegacyCode'];
+        const facts = await mm.gather(entity({ external: true, fields: [{ Name: 'ID', IsVirtual: false }, { Name: 'Total', IsVirtual: false }] }));
+
+        const verdict = evaluateMaterializationDrift(facts);
+        expect(verdict.drift).toBe(true);
+        expect(verdict.reason).toMatch(/legacycode/i);
+    });
+
+    it('a source entity that no longer resolves is drift, regardless of fields', async () => {
+        const mm = new TestableDriftSymmetry();
+        const facts = await mm.gather(undefined);
+        expect(facts.baseView?.sourceEntityExists).toBe(false);
+        expect(evaluateMaterializationDrift(facts)).toEqual({ drift: true, reason: 'source entity no longer exists' });
+    });
+});

--- a/packages/CodeGenLib/src/__tests__/manage-metadata-drift-hold-revoke.test.ts
+++ b/packages/CodeGenLib/src/__tests__/manage-metadata-drift-hold-revoke.test.ts
@@ -123,6 +123,28 @@ describe('evaluateAndHoldDriftRow — fail-closed read-grant revoke on hold', ()
         expect(mm.revokeCalls).toHaveLength(0);
     });
 
+    it('FAILS CLOSED on a query mat whose MaterializedResultQuery link vanished (source query deleted) — revoke + hold', async () => {
+        // spDeleteQuery cascade-deletes the join row, but the MaterializedResult, the minted entity, its read
+        // grants and the populated table all survive. With a NULL SourceQueryID the C1/C2 re-checks were both
+        // unreachable and the Query fact-gatherer returned all-empty ⇒ {drift:false} ⇒ Status stayed 'Active',
+        // so the revoke+hold guard could never fire again and the unscoped snapshot served indefinitely.
+        mm.rlsSafe = true;
+        mm.facts = QUERY_NO_DRIFT; // exactly what the old path computed for an orphaned row
+        const held = await mm.run({ ID: 'm6', SourceType: 'Query', SourceQueryID: null, GeneratedEntityID: 'gen-6', TableName: 'materialized_Orphan' });
+        expect(held).toBe(true);
+        expect(mm.revokeCalls).toHaveLength(1);
+        expect(mm.revokeCalls[0].entityId).toBe('gen-6');
+        expect(mm.revokeCalls[0].reason).toMatch(/MaterializedResultQuery link is gone/i);
+    });
+
+    it('still holds an orphaned query mat that has no minted entity id (nothing to revoke, but it stops serving)', async () => {
+        mm.rlsSafe = true;
+        mm.facts = QUERY_NO_DRIFT;
+        const held = await mm.run({ ID: 'm7', SourceType: 'Query', SourceQueryID: undefined, GeneratedEntityID: null, TableName: 'materialized_Orphan2' });
+        expect(held).toBe(true);
+        expect(mm.revokeCalls).toHaveLength(0);
+    });
+
     it('still revokes on the C1 RLS-drift branch (regression guard — the pre-existing revoke path is intact)', async () => {
         mm.rlsSafe = false; // source now RLS-unsafe
         mm.facts = QUERY_NO_DRIFT; // irrelevant — the RLS branch returns before the shape check

--- a/packages/CodeGenLib/src/__tests__/manage-metadata-materialization-rls.test.ts
+++ b/packages/CodeGenLib/src/__tests__/manage-metadata-materialization-rls.test.ts
@@ -19,9 +19,25 @@ type FakePermission = { ReadRLSFilterID?: string | null };
 type FakeEntity = { Name: string; Permissions: FakePermission[]; ID?: string; SchemaName?: string; BaseView?: string; BaseTable?: string };
 
 class TestableRLS extends ManageMetadataBase {
+    constructor() {
+        super();
+        // The gate composes TWO row-restriction layers: role RLS and API-key row filters. The API-key layer is
+        // enumerated from the DB once per CodeGen run and defaults to 'unknown' (⇒ every entity is treated as
+        // restricted, so the gate fails CLOSED on an unloaded cache). These fixtures exercise the role-RLS +
+        // under-linking layers against no DB, so declare the key layer as "loaded, and this deployment configures
+        // no API-key row filters". `seedAPIKeyRowFilterTargets` below drives the key layer explicitly.
+        this.apiKeyRowFilterTargets = new Set<string>();
+    }
+
     /** Override the platform dialect so the P1 SQL-parsing branch works on a bare instance (no DB provider). */
     protected get dialect(): SQLDialect {
         return new SQLServerDialect();
+    }
+
+    /** Test seam for the API-key row-filter layer: the entity names bound by an APIKeyScope /
+     *  APIApplicationScope row filter, or 'unknown' to simulate "could not be enumerated". */
+    public seedAPIKeyRowFilterTargets(targets: ReadonlySet<string> | 'unknown'): void {
+        this.apiKeyRowFilterTargets = targets;
     }
 
     /** Exposes the protected guard, taking a structural stub for the entity-by-id lookup. The optional `sql`
@@ -38,9 +54,14 @@ class TestableRLS extends ManageMetadataBase {
         return this.assessQuerySourceRLSSafety(md, ids, sql);
     }
 
-    /** Exposes the RLS detector the base-view leak gate (Leak 1) uses to refuse external RLS mirrors. */
+    /** Exposes the ROLE-RLS layer (one input to the composite gate below). */
     public hasRLS(entity: FakeEntity): boolean {
         return this.entityHasRowLevelSecurity(entity as unknown as EntityInfo);
+    }
+
+    /** Exposes the COMPOSITE row-restriction gate every materialization gate calls. */
+    public hasRestriction(entity: FakeEntity): boolean {
+        return this.entityHasRowLevelRestriction(entity as unknown as EntityInfo);
     }
 }
 
@@ -212,5 +233,70 @@ describe('entityHasRowLevelSecurity — base-view leak-gate RLS detector', () =>
 
     it('is FALSE for an entity with no permissions at all', () => {
         expect(mm.hasRLS({ Name: 'Orders', Permissions: [] })).toBe(false);
+    });
+});
+
+/**
+ * Tests for `entityHasRowLevelRestriction` — THE gate every materialization check calls. It composes BOTH
+ * row-restriction layers MJ enforces (see `EntityInfo.GetEffectiveRowFilterWhereClause`): role RLS AND API-key
+ * row filters. The key layer matters because an entity bound ONLY by an API-key row filter carries no
+ * `ReadRLSFilterID` — the role-only predicate judges it unprotected, CodeGen mints a materialized entity with a
+ * NEW EntityID, and the key's EntityID-keyed binding stops matching, handing the principal a full unscoped
+ * snapshot of rows it cannot read live.
+ */
+describe('entityHasRowLevelRestriction — composite (role RLS + API-key row filter) gate', () => {
+    let mm: TestableRLS;
+    beforeEach(() => { mm = new TestableRLS(); });
+
+    const plain: FakeEntity = { Name: 'Orders', Permissions: [] };
+
+    it('is FALSE when neither layer restricts the entity (the only materializable case)', () => {
+        expect(mm.hasRestriction(plain)).toBe(false);
+    });
+
+    it('is TRUE from the ROLE layer alone (unchanged behavior)', () => {
+        expect(mm.hasRestriction({ Name: 'Salaries', Permissions: [{ ReadRLSFilterID: 'rls-1' }] })).toBe(true);
+    });
+
+    it('is TRUE from the API-KEY layer alone — the fail-open hole this gate closes', () => {
+        // No ReadRLSFilterID anywhere: role-only detection would call this materializable.
+        mm.seedAPIKeyRowFilterTargets(new Set(['orders']));
+        expect(mm.hasRLS(plain)).toBe(false); // role layer sees nothing…
+        expect(mm.hasRestriction(plain)).toBe(true); // …the composite gate refuses
+    });
+
+    it('matches the API-key target case- and whitespace-insensitively', () => {
+        mm.seedAPIKeyRowFilterTargets(new Set(['orders']));
+        expect(mm.hasRestriction({ Name: '  ORDERS ', Permissions: [] })).toBe(true);
+    });
+
+    it('does NOT restrict an entity that no API-key filter targets', () => {
+        mm.seedAPIKeyRowFilterTargets(new Set(['salaries']));
+        expect(mm.hasRestriction(plain)).toBe(false);
+    });
+
+    it('FAILS CLOSED when the API-key layer could not be enumerated (unknown ⇒ every entity restricted)', () => {
+        mm.seedAPIKeyRowFilterTargets('unknown');
+        expect(mm.hasRestriction(plain)).toBe(true);
+    });
+});
+
+/** The query gate must inherit the same composite detection — an API-key-filtered SOURCE entity makes a query
+ *  unsafe to materialize even though it carries no ReadRLSFilterID. */
+describe('assessQuerySourceRLSSafety — API-key row-filter layer', () => {
+    let mm: TestableRLS;
+    beforeEach(() => { mm = new TestableRLS(); });
+
+    it('REFUSES a query whose source is bound only by an API-key row filter (no ReadRLSFilterID present)', () => {
+        mm.seedAPIKeyRowFilterTargets(new Set(['salaries']));
+        const v = mm.assess({ e1: { Name: 'Salaries', Permissions: [{ ReadRLSFilterID: null }] } }, ['e1']);
+        expect(v.safe).toBe(false);
+        expect(v.reason).toContain('"Salaries"');
+    });
+
+    it('REFUSES everything when the API-key layer could not be enumerated (fail closed)', () => {
+        mm.seedAPIKeyRowFilterTargets('unknown');
+        const v = mm.assess({ e1: { Name: 'Orders', Permissions: [] } }, ['e1']);
+        expect(v.safe).toBe(false);
     });
 });

--- a/packages/CodeGenLib/src/__tests__/materializationAnalysis.test.ts
+++ b/packages/CodeGenLib/src/__tests__/materializationAnalysis.test.ts
@@ -123,6 +123,84 @@ describe('detectAggregationKeyColumns (Phase 3)', () => {
             dialect, fields: [{ Name: 'region', SQLFullType: 'nvarchar(50)' }, { Name: 'total', SQLFullType: 'decimal(18,2)' }],
         })).toBeNull();
     });
+
+    describe('set-operation roots (UNION/EXCEPT/INTERSECT) must refuse — first-branch-only blind spot', () => {
+        // node-sql-parser does NOT emit a distinct union node: a set operation is a SINGLE type:'select'
+        // root carrying set_op/_next whose `groupby` and `columns` describe ONLY THE FIRST BRANCH. Reading
+        // it would report {region} as the key of the WHOLE query, but the combined result legitimately has
+        // ONE ROW PER (branch × region). The caller would then hash {region} into the surrogate PK and pick
+        // the additive MERGE-upsert Incremental path, where the two branches collide on the same hash and
+        // one silently overwrites the other — permanently wrong aggregates, no error, no fallback.
+        const twoFields: QueryFieldShape[] = [
+            { Name: 'Region', SQLFullType: 'nvarchar(50)' },
+            { Name: 'Total', SQLFullType: 'decimal(18,2)' },
+        ];
+
+        it('refuses a UNION ALL of two identically-grouped branches (the reported repro)', () => {
+            const sql =
+                'SELECT Region, SUM(Amount) AS Total FROM CurrentSales GROUP BY Region ' +
+                'UNION ALL ' +
+                'SELECT Region, SUM(Amount) AS Total FROM ArchiveSales GROUP BY Region';
+            expect(detectAggregationKeyColumns({ sql, dialect, fields: twoFields })).toBeNull();
+        });
+
+        it('refuses a plain UNION and an EXCEPT the same way', () => {
+            const union =
+                'SELECT Region, SUM(Amount) AS Total FROM CurrentSales GROUP BY Region ' +
+                'UNION SELECT Region, SUM(Amount) AS Total FROM ArchiveSales GROUP BY Region';
+            const except =
+                'SELECT Region, SUM(Amount) AS Total FROM CurrentSales GROUP BY Region ' +
+                'EXCEPT SELECT Region, SUM(Amount) AS Total FROM ArchiveSales GROUP BY Region';
+            expect(detectAggregationKeyColumns({ sql: union, dialect, fields: twoFields })).toBeNull();
+            expect(detectAggregationKeyColumns({ sql: except, dialect, fields: twoFields })).toBeNull();
+        });
+
+        it('NON-REGRESSION: the first branch on its own (no set op) still keys normally', () => {
+            // Proves the guard fires on the SET OPERATION, not on the branch SQL — i.e. it has not
+            // disabled aggregation keying generally.
+            expect(detectAggregationKeyColumns({
+                sql: 'SELECT Region, SUM(Amount) AS Total FROM CurrentSales GROUP BY Region',
+                dialect, fields: twoFields,
+            })).toEqual([{ name: 'Region', type: 'nvarchar(50)' }]);
+        });
+    });
+
+    describe('join qualifier awareness — a grouping column must be the column that is projected', () => {
+        const joinFields: QueryFieldShape[] = [
+            { Name: 'region', SQLFullType: 'nvarchar(50)' },
+            { Name: 'total', SQLFullType: 'decimal(18,2)' },
+        ];
+
+        it('refuses when GROUP BY groups o.region but the SELECT list projects c.region', () => {
+            // Both are "region" by bare name, so a name-only match would key the materialization on the
+            // CUSTOMER's region while the query groups by the ORDER's — a key that does not identify a row.
+            expect(detectAggregationKeyColumns({
+                sql: 'SELECT c.region, SUM(o.amt) AS total FROM orders o INNER JOIN customers c ON c.id = o.customer_id GROUP BY o.region',
+                dialect, fields: joinFields,
+            })).toBeNull();
+        });
+
+        it('refuses when the join query leaves either side unqualified (unprovable)', () => {
+            expect(detectAggregationKeyColumns({
+                sql: 'SELECT c.region, SUM(o.amt) AS total FROM orders o INNER JOIN customers c ON c.id = o.customer_id GROUP BY region',
+                dialect, fields: joinFields,
+            })).toBeNull();
+        });
+
+        it('NON-REGRESSION: a join whose GROUP BY and projection carry the SAME qualifier still keys', () => {
+            expect(detectAggregationKeyColumns({
+                sql: 'SELECT o.region, SUM(o.amt) AS total FROM orders o INNER JOIN customers c ON c.id = o.customer_id GROUP BY o.region',
+                dialect, fields: joinFields,
+            })).toEqual([{ name: 'region', type: 'nvarchar(50)' }]);
+        });
+
+        it('NON-REGRESSION: a single-table query needs no qualifiers at all (mixed forms still key)', () => {
+            expect(detectAggregationKeyColumns({
+                sql: 'SELECT s.region, SUM(s.amt) AS total FROM sales s GROUP BY region',
+                dialect, fields: joinFields,
+            })).toEqual([{ name: 'region', type: 'nvarchar(50)' }]);
+        });
+    });
 });
 
 describe('detectAdditiveMeasures (Phase 4)', () => {

--- a/packages/CodeGenLib/src/__tests__/materializationParamClassifier.test.ts
+++ b/packages/CodeGenLib/src/__tests__/materializationParamClassifier.test.ts
@@ -225,6 +225,56 @@ describe('classifyQueryParameters', () => {
         expect(r.qualification.qualifies).toBe(false);
     });
 
+    /**
+     * End-to-end evidence that the qualifier-aware binding proof is actually WIRED IN through the production
+     * entry point (classifyQueryParameters renders the held baseline and hands it to the qualifier). Without
+     * that threading the proof would be dead code and both queries below would still mint a materialization
+     * whose read filters a different column than the live query.
+     */
+    describe('filter-column binding proof is enforced end-to-end', () => {
+        it('JOIN COLLISION is refused: predicate on o.Status, output projects c.Status', () => {
+            const params: QueryParamDef[] = [{ Name: 'status', Type: 'string' }];
+            const render: VariantRenderer = (v) =>
+                `SELECT o.ID, c.Status FROM Orders o INNER JOIN Customers c ON c.ID = o.CustomerID WHERE o.Status = ${lit(v['status'])}`;
+            const r = classifyQueryParameters({ queryName: 'Q', params, outputColumns: ['ID', 'Status'], dialect: tsql, render, allowRowFilterBroad: true });
+            expect(r.perParam[0].verdict.role).toBe('RowFilter'); // the verifier still sees a clean row filter…
+            expect(r.qualification.qualifies).toBe(false);        // …but the binding proof refuses it
+            expect(r.qualification.paramMode).not.toBe('RowFilterBroad');
+            expect(r.qualification.reason).toMatch(/different source column/i);
+        });
+
+        it('ALIAS REBINDING is refused: the output BillRegion is an alias over ShipRegion', () => {
+            const params: QueryParamDef[] = [{ Name: 'region', Type: 'string' }];
+            const render: VariantRenderer = (v) =>
+                `SELECT ID, ShipRegion AS BillRegion FROM Orders WHERE BillRegion = ${lit(v['region'])}`;
+            const r = classifyQueryParameters({ queryName: 'Q', params, outputColumns: ['ID', 'BillRegion'], dialect: tsql, render, allowRowFilterBroad: true });
+            expect(r.perParam[0].verdict.role).toBe('RowFilter');
+            expect(r.qualification.qualifies).toBe(false);
+            expect(r.qualification.reason).toMatch(/ALIAS over source column "ShipRegion"/i);
+        });
+
+        it('NON-REGRESSION: an ordinary single-table row-filter query still qualifies unchanged', () => {
+            // The assertion that keeps this fix from being a stealth feature-disable: the plain, common shape
+            // must still reach RowFilterBroad with the same columns and read-filter spec as before.
+            const params: QueryParamDef[] = [{ Name: 'status', Type: 'string' }];
+            const render: VariantRenderer = (v) => `SELECT ID, Status FROM Orders WHERE Status = ${lit(v['status'])}`;
+            const r = classifyQueryParameters({ queryName: 'Q', params, outputColumns: ['ID', 'Status'], dialect: tsql, render, allowRowFilterBroad: true });
+            expect(r.qualification.qualifies).toBe(true);
+            expect(r.qualification.paramMode).toBe('RowFilterBroad');
+            expect(r.qualification.rowFilterColumns).toEqual(['Status']);
+            expect(r.qualification.readFilterSpec).toEqual([{ column: 'Status', operator: '=', paramName: 'status', kind: 'scalar' }]);
+        });
+
+        it('NON-REGRESSION: a JOIN whose predicate and projection share the same qualifier still qualifies', () => {
+            const params: QueryParamDef[] = [{ Name: 'status', Type: 'string' }];
+            const render: VariantRenderer = (v) =>
+                `SELECT o.ID, o.Status FROM Orders o INNER JOIN Customers c ON c.ID = o.CustomerID WHERE o.Status = ${lit(v['status'])}`;
+            const r = classifyQueryParameters({ queryName: 'Q', params, outputColumns: ['ID', 'Status'], dialect: tsql, render, allowRowFilterBroad: true });
+            expect(r.qualification.qualifies).toBe(true);
+            expect(r.qualification.paramMode).toBe('RowFilterBroad');
+        });
+    });
+
     describe('probeValues', () => {
         it('produces distinct values per type', () => {
             for (const t of ['string', 'number', 'date', 'array'] as const) {

--- a/packages/CodeGenLib/src/__tests__/materializationParamQualify.test.ts
+++ b/packages/CodeGenLib/src/__tests__/materializationParamQualify.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from 'vitest';
-import { qualifyParameterizedQuery, type ParamClassification } from '../Database/materializationAnalysis';
+import { SQLServerDialect } from '@memberjunction/sql-dialect';
+import { qualifyParameterizedQuery, proveFilterColumnBinding, type ParamClassification } from '../Database/materializationAnalysis';
 
 /**
  * Phase 2a — parameterization qualifying core (plan §9 buckets + §10 asymmetric-risk).
@@ -7,6 +8,14 @@ import { qualifyParameterizedQuery, type ParamClassification } from '../Database
  */
 describe('qualifyParameterizedQuery', () => {
     const out = ['ID', 'Amount', 'ChapterID', 'Region'];
+    const dialect = new SQLServerDialect();
+    /**
+     * The rendered SQL that goes with `out`: one table, no aliases, every output column a plain projection
+     * of the identically-named source column, and both row-filter predicates present in the top-level WHERE.
+     * This is the ordinary shape a RowFilterBroad query has, so every case below that supplies it is also a
+     * standing non-regression check that the new binding proof does not refuse the normal path.
+     */
+    const sql = "SELECT ID, Amount, ChapterID, Region FROM Orders WHERE ChapterID = 7 AND Region = 'East'";
 
     it('no params → mode None, qualifies', () => {
         const r = qualifyParameterizedQuery({ queryName: 'Q', params: [], outputColumns: out });
@@ -15,7 +24,7 @@ describe('qualifyParameterizedQuery', () => {
 
     it('single row-filter on a present output column → RowFilterBroad + that column + read-filter spec', () => {
         const params: ParamClassification[] = [{ name: 'chapterId', role: 'RowFilter', filterColumn: 'ChapterID', filterOperator: '=', filterKind: 'scalar' }];
-        const r = qualifyParameterizedQuery({ queryName: 'Q', params, outputColumns: out, allowRowFilterBroad: true });
+        const r = qualifyParameterizedQuery({ queryName: 'Q', params, outputColumns: out, allowRowFilterBroad: true, sql, dialect });
         expect(r.qualifies).toBe(true);
         expect(r.paramMode).toBe('RowFilterBroad');
         expect(r.rowFilterColumns).toEqual(['ChapterID']);
@@ -27,7 +36,7 @@ describe('qualifyParameterizedQuery', () => {
             { name: 'chapterId', role: 'RowFilter', filterColumn: 'ChapterID', filterOperator: '>=', filterKind: 'scalar' },
             { name: 'regions', role: 'RowFilter', filterColumn: 'Region', filterOperator: 'IN', filterKind: 'list' },
         ];
-        const r = qualifyParameterizedQuery({ queryName: 'Q', params, outputColumns: out, allowRowFilterBroad: true });
+        const r = qualifyParameterizedQuery({ queryName: 'Q', params, outputColumns: out, allowRowFilterBroad: true, sql, dialect });
         expect(r.paramMode).toBe('RowFilterBroad');
         expect(r.rowFilterColumns).toEqual(['ChapterID', 'Region']);
         expect(r.readFilterSpec).toEqual([
@@ -38,14 +47,14 @@ describe('qualifyParameterizedQuery', () => {
 
     it('row-filter column matched case-insensitively', () => {
         const params: ParamClassification[] = [{ name: 'c', role: 'RowFilter', filterColumn: 'chapterid', filterOperator: '=', filterKind: 'scalar' }];
-        const r = qualifyParameterizedQuery({ queryName: 'Q', params, outputColumns: out, allowRowFilterBroad: true });
+        const r = qualifyParameterizedQuery({ queryName: 'Q', params, outputColumns: out, allowRowFilterBroad: true, sql, dialect });
         expect(r.qualifies).toBe(true);
         expect(r.paramMode).toBe('RowFilterBroad');
     });
 
     it('row-filter refuses BY DEFAULT (RowFilterBroad enablement switch off)', () => {
         const params: ParamClassification[] = [{ name: 'chapterId', role: 'RowFilter', filterColumn: 'ChapterID', filterOperator: '=', filterKind: 'scalar' }];
-        const r = qualifyParameterizedQuery({ queryName: 'Q', params, outputColumns: out }); // allowRowFilterBroad omitted → false
+        const r = qualifyParameterizedQuery({ queryName: 'Q', params, outputColumns: out, sql, dialect }); // allowRowFilterBroad omitted → false
         expect(r.qualifies).toBe(false);
         expect(r.paramMode).toBe('None');
         expect(r.reason).toMatch(/not enabled in this build/i);
@@ -119,8 +128,105 @@ describe('qualifyParameterizedQuery', () => {
             { name: 'chapterId', role: 'RowFilter', filterColumn: 'ChapterID', filterOperator: '=', filterKind: 'scalar' },
             { name: 'reportType', role: 'Structural', boundedDomain: ['a'] },
         ];
-        const r = qualifyParameterizedQuery({ queryName: 'Q', params, outputColumns: out, allowPerValueCache: true });
+        const r = qualifyParameterizedQuery({ queryName: 'Q', params, outputColumns: out, allowPerValueCache: true, sql, dialect });
         expect(r.qualifies).toBe(false);
         expect(r.reason).toMatch(/mixes row-filter and structural/i);
+    });
+
+    /**
+     * The filter column the verifier reports is a BARE name; the output-column list is built from
+     * `QueryField.Name` — i.e. SELECT-list OUTPUT ALIASES. Matching one against the other by name alone
+     * qualifies two queries whose materialized read would filter a DIFFERENT column than the live query.
+     * Neither is catchable downstream: broad-render strips exactly ONE predicate in both, so
+     * `removedCount === expectedRemovals` and `ambiguous` stays false.
+     */
+    describe('filter-column binding proof (qualifier awareness)', () => {
+        it('JOIN COLLISION: predicate on o.Status, output projects c.Status → refuse', () => {
+            const joinSQL = "SELECT o.ID, c.Status FROM Orders o INNER JOIN Customers c ON c.ID = o.CustomerID WHERE o.Status = 'X'";
+            const params: ParamClassification[] = [{ name: 's', role: 'RowFilter', filterColumn: 'Status', filterOperator: '=', filterKind: 'scalar' }];
+            const r = qualifyParameterizedQuery({ queryName: 'Q', params, outputColumns: ['ID', 'Status'], allowRowFilterBroad: true, sql: joinSQL, dialect });
+            expect(r.qualifies).toBe(false);
+            expect(r.paramMode).not.toBe('RowFilterBroad');
+            expect(r.reason).toMatch(/different source column/i);
+        });
+
+        it('ALIAS REBINDING: output BillRegion is an alias over ShipRegion → refuse', () => {
+            const aliasSQL = "SELECT ID, ShipRegion AS BillRegion FROM Orders WHERE BillRegion = 'East'";
+            const params: ParamClassification[] = [{ name: 'r', role: 'RowFilter', filterColumn: 'BillRegion', filterOperator: '=', filterKind: 'scalar' }];
+            const r = qualifyParameterizedQuery({ queryName: 'Q', params, outputColumns: ['ID', 'BillRegion'], allowRowFilterBroad: true, sql: aliasSQL, dialect });
+            expect(r.qualifies).toBe(false);
+            expect(r.reason).toMatch(/ALIAS over source column "ShipRegion"/i);
+        });
+
+        it('no rendered SQL supplied → refuse (fail closed; nothing can prove the binding)', () => {
+            const params: ParamClassification[] = [{ name: 'c', role: 'RowFilter', filterColumn: 'ChapterID', filterOperator: '=', filterKind: 'scalar' }];
+            const r = qualifyParameterizedQuery({ queryName: 'Q', params, outputColumns: out, allowRowFilterBroad: true });
+            expect(r.qualifies).toBe(false);
+            expect(r.reason).toMatch(/no rendered SQL was supplied/i);
+        });
+
+        it('NON-REGRESSION: a JOIN whose predicate and projection share the SAME qualifier still qualifies', () => {
+            const joinSQL = "SELECT o.ID, o.Status FROM Orders o INNER JOIN Customers c ON c.ID = o.CustomerID WHERE o.Status = 'X'";
+            const params: ParamClassification[] = [{ name: 's', role: 'RowFilter', filterColumn: 'Status', filterOperator: '=', filterKind: 'scalar' }];
+            const r = qualifyParameterizedQuery({ queryName: 'Q', params, outputColumns: ['ID', 'Status'], allowRowFilterBroad: true, sql: joinSQL, dialect });
+            expect(r.qualifies).toBe(true);
+            expect(r.paramMode).toBe('RowFilterBroad');
+            expect(r.rowFilterColumns).toEqual(['Status']);
+        });
+    });
+});
+
+describe('proveFilterColumnBinding', () => {
+    const dialect = new SQLServerDialect();
+    const prove = (sql: string, filterColumn: string) => proveFilterColumnBinding({ sql, dialect, filterColumn });
+
+    it('proves the ordinary single-table, unqualified, un-aliased case', () => {
+        expect(prove("SELECT ID, Region FROM Orders WHERE Region = 'East'", 'Region')).toEqual({ provable: true });
+    });
+
+    it('proves a single-table query even when the reference forms differ (qualifier carries no information)', () => {
+        expect(prove("SELECT o.ID, o.Region FROM Orders o WHERE Region = 'East'", 'Region').provable).toBe(true);
+        expect(prove("SELECT ID, Region FROM Orders o WHERE o.Region = 'East'", 'Region').provable).toBe(true);
+    });
+
+    it('refuses a join collision and names both sides in the reason', () => {
+        const r = prove("SELECT o.ID, c.Status FROM Orders o INNER JOIN Customers c ON c.ID = o.CustomerID WHERE o.Status = 'X'", 'Status');
+        expect(r.provable).toBe(false);
+        expect(r.reason).toMatch(/filters "o\.Status".*projects "c\.Status"/i);
+    });
+
+    it('refuses a join where either side is unqualified (the name cannot be attributed)', () => {
+        expect(prove("SELECT Status, o.ID FROM Orders o INNER JOIN Customers c ON c.ID = o.CustomerID WHERE o.Status = 'X'", 'Status').provable).toBe(false);
+        expect(prove("SELECT o.Status, o.ID FROM Orders o INNER JOIN Customers c ON c.ID = o.CustomerID WHERE Status = 'X'", 'Status').provable).toBe(false);
+    });
+
+    it('refuses an alias that rebinds a differently-named source column', () => {
+        const r = prove("SELECT ID, ShipRegion AS BillRegion FROM Orders WHERE BillRegion = 'East'", 'BillRegion');
+        expect(r.provable).toBe(false);
+        expect(r.reason).toMatch(/ALIAS over source column "ShipRegion"/);
+    });
+
+    it('refuses a computed output column of the same name', () => {
+        const r = prove("SELECT ID, UPPER(Region) AS Region FROM Orders WHERE Region = 'East'", 'Region');
+        expect(r.provable).toBe(false);
+        expect(r.reason).toMatch(/computed expression/i);
+    });
+
+    it('refuses a wildcard projection (output-to-source mapping unknown)', () => {
+        expect(prove("SELECT * FROM Orders WHERE Region = 'East'", 'Region').reason).toMatch(/wildcard/i);
+    });
+
+    it('refuses a set-operation root (only the first branch is visible)', () => {
+        const unionSQL = "SELECT ID, Region FROM Orders WHERE Region = 'East' UNION ALL SELECT ID, Region FROM Archive";
+        expect(prove(unionSQL, 'Region').reason).toMatch(/UNION|single plain SELECT/i);
+    });
+
+    it('refuses when the WHERE clause does not actually reference the column', () => {
+        expect(prove("SELECT ID, Region FROM Orders WHERE ID = 3", 'Region').reason).toMatch(/no reference to a column named/i);
+    });
+
+    it('refuses unparseable SQL and empty SQL', () => {
+        expect(prove('this is not sql at all', 'Region').provable).toBe(false);
+        expect(prove('', 'Region').provable).toBe(false);
     });
 });

--- a/packages/GenericDatabaseProvider/src/GenericDatabaseProvider.ts
+++ b/packages/GenericDatabaseProvider/src/GenericDatabaseProvider.ts
@@ -1315,7 +1315,13 @@ export abstract class GenericDatabaseProvider extends DatabaseProviderBase {
             },
             contextUser,
         );
-        const row = res.Success && res.Results?.length > 0 ? res.Results[0] : null;
+        // A FAILED lookup must not masquerade as "no materialization exists" — see MaterializationLookupFailed
+        // for why the two must stay distinguishable. Falling back to the LIVE base view is correct in BOTH
+        // cases; only the silence was the defect.
+        if (this.MaterializationLookupFailed(res, `entity "${entityInfo.Name}" (base-view materialization status)`)) {
+            return entityInfo.BaseView;
+        }
+        const row = res.Results?.length > 0 ? res.Results[0] : null;
         if (row?.Status !== 'Active') return entityInfo.BaseView;
         // Use the AUTHORITATIVE wrapper-view name persisted on the row rather than re-deriving
         // materialized_vw<CodeName>: the row's ViewName is what the mint/migration actually created, so it stays
@@ -1324,6 +1330,38 @@ export abstract class GenericDatabaseProvider extends DatabaseProviderBase {
         // Fall back to the convention only if the row somehow lacks a ViewName. (SchemaName stays the entity's —
         // base-view materialization always mints into the source entity's own schema.)
         return row.ViewName?.trim() || `materialized_vw${entityInfo.CodeName}`;
+    }
+
+    /**
+     * Reports whether a materialization-metadata `RunView` FAILED, logging the failure when it did.
+     *
+     * Every materialization read path falls back to LIVE data when it cannot confirm an Active snapshot, and
+     * that fallback is correct — live data is always right, materialization is a transparent optimization,
+     * never a correctness dependency. The defect this guards is the **silence**: `RunView` signals an
+     * authorization or query failure through `Success === false` rather than by throwing, so collapsing a
+     * failure into the same branch as the legitimate "no materialization row exists" case makes the two
+     * indistinguishable to operator and caller alike.
+     *
+     * That matters because read access to the materialization entities is role-gated (`CanRead` is granted
+     * only to the UI / Developer / Integration roles). A user on a restricted role — including MJ's
+     * magic-link / external-access pattern — therefore has every one of these lookups fail, and so
+     * permanently reads LIVE data for every `DataSource:'Materialized'` request, while an admin issuing the
+     * identical request is served the snapshot. Two users, different data, no error surfaced to either.
+     * Logging leaves the safe fallback intact but makes the divergence diagnosable.
+     *
+     * @param result the `RunView` result to inspect (structurally a `RunViewResult`).
+     * @param context human-readable description of what was being resolved, for the log message.
+     * @returns `true` if the lookup failed and the caller should take its live-data fallback; `false` otherwise.
+     */
+    protected MaterializationLookupFailed(result: { Success: boolean; ErrorMessage: string }, context: string): boolean {
+        if (result.Success) return false;
+        LogError(
+            `GenericDatabaseProvider: materialization metadata lookup failed for ${context} — falling back to LIVE data. ` +
+                `The fallback is safe (live data is always correct), but the snapshot will NEVER be served for this caller. ` +
+                `The most likely cause is the current user's roles lacking CanRead on the materialization entities. ` +
+                `Error: ${result.ErrorMessage || 'unknown error'}`,
+        );
+        return true;
     }
 
     /**
@@ -3500,7 +3538,11 @@ export abstract class GenericDatabaseProvider extends DatabaseProviderBase {
             },
             contextUser,
         );
-        if (!linkRes.Success || !linkRes.Results || linkRes.Results.length === 0) return null; // query not materialized → live
+        // Same failure-vs-absence distinction as the base-view path: a permission/query failure here would
+        // otherwise be indistinguishable from "this query is not materialized", silently pinning the caller to
+        // live data forever. Still fall back to live (correct either way) — just not silently.
+        if (this.MaterializationLookupFailed(linkRes, `query "${query.Name}" (materialization join lookup)`)) return null;
+        if (!linkRes.Results || linkRes.Results.length === 0) return null; // query not materialized → live
         const matId = linkRes.Results[0].MaterializedResultID;
         if (!matId) return null;                                       // query not materialized → live
         // Ordering fidelity: buildMaterializedReadQuery emits no ORDER BY, and the snapshot was built with the
@@ -3531,7 +3573,8 @@ export abstract class GenericDatabaseProvider extends DatabaseProviderBase {
             },
             contextUser,
         );
-        if (!res.Success || !res.Results || res.Results.length === 0) return null;
+        if (this.MaterializationLookupFailed(res, `query "${query.Name}" (materialization metadata)`)) return null;
+        if (!res.Results || res.Results.length === 0) return null;
         const mat = res.Results[0];
         if (mat.Status !== 'Active') return null;                 // Building / DriftHold / stale → live
         if (mat.ParamMode !== 'RowFilterBroad') return null;      // None / PerValueCache → live (this path only serves Bucket 1)

--- a/packages/GenericDatabaseProvider/src/__tests__/materializedReadQuery.test.ts
+++ b/packages/GenericDatabaseProvider/src/__tests__/materializedReadQuery.test.ts
@@ -2,6 +2,13 @@ import { describe, it, expect } from 'vitest';
 import { GenericDatabaseProvider } from '../GenericDatabaseProvider';
 
 /**
+ * The `spec` shape `buildMaterializedReadQuery` declares, derived from the real signature so it cannot drift.
+ * Lets the malformed-input tests double-cast deliberately-bad fixtures against the true parameter type instead
+ * of reaching for `any`.
+ */
+type MaterializedReadSpec = Parameters<typeof GenericDatabaseProvider.buildMaterializedReadQuery>[0]['spec'];
+
+/**
  * Phase 2 (plan §5): the PURE materialized-read query builder — the injection-safe, faithfulness-critical
  * core of parameterized RowFilterBroad read-time injection. Every caller value is BOUND (never in the SQL
  * string); ANY condition that would diverge from the live query returns null (→ caller runs live).
@@ -197,7 +204,11 @@ describe('GenericDatabaseProvider.buildMaterializedReadQuery', () => {
         });
 
         it('a malformed spec element (missing/non-string column, operator, or paramName) → null, never throws', () => {
-            const bad = [
+            // Deliberately malformed specs — the whole point is that they VIOLATE the declared spec shape, so
+            // they are typed as `unknown[][]` and reach the call through the sanctioned double-cast. That keeps
+            // the call typed against the real signature while still exercising the runtime guard that must
+            // reject bad persisted metadata rather than throw.
+            const bad: unknown[][] = [
                 [{ operator: '=', paramName: 'status', kind: 'scalar' }],            // missing column
                 [{ column: 'Status', paramName: 'status', kind: 'scalar' }],         // missing operator
                 [{ column: 'Status', operator: '=', kind: 'scalar' }],               // missing paramName
@@ -205,8 +216,7 @@ describe('GenericDatabaseProvider.buildMaterializedReadQuery', () => {
                 [null],                                                              // null element
             ];
             for (const s of bad) {
-                // eslint-disable-next-line @typescript-eslint/no-explicit-any
-                expect(build({ ...base, spec: s as any, paramValues: { status: 'x' }, isPostgres: false })).toBeNull();
+                expect(build({ ...base, spec: s as unknown as MaterializedReadSpec, paramValues: { status: 'x' }, isPostgres: false })).toBeNull();
             }
         });
     });

--- a/packages/MJGlobal/src/__tests__/ResourcePatternUtils.test.ts
+++ b/packages/MJGlobal/src/__tests__/ResourcePatternUtils.test.ts
@@ -1,0 +1,56 @@
+import { describe, it, expect } from 'vitest';
+import { ResolveSingleEntityResourceTarget } from '../util/ResourcePatternUtils';
+
+/**
+ * This predicate decides whether an API scope rule's `ResourcePattern` names exactly one entity, and
+ * two materialization row-restriction gates — CodeGen's mint/drift gates and the runtime refresher's
+ * Leak-1 gate — depend on it agreeing with itself. `null` is the fail-CLOSED answer ("this rule may
+ * name any entity"), so a pattern that wrongly resolves to a name is a fail-OPEN hole: it would be
+ * kept as a literal target, match no entity, and leave the entity it fences reading as unrestricted.
+ */
+describe('ResolveSingleEntityResourceTarget', () => {
+    describe('resolvable — an exact entity name', () => {
+        it('returns the name normalized for lookup (trimmed + lowercased)', () => {
+            expect(ResolveSingleEntityResourceTarget('Salaries')).toBe('salaries');
+            expect(ResolveSingleEntityResourceTarget('  Salaries  ')).toBe('salaries');
+            expect(ResolveSingleEntityResourceTarget('SALARIES')).toBe('salaries');
+        });
+
+        it('accepts an MJ-prefixed name, spaces and colon included', () => {
+            // Every v5+ core entity name has this shape, so rejecting it would fail closed on
+            // literally every core entity and stop all materialization.
+            expect(ResolveSingleEntityResourceTarget('MJ: AI Agent Runs')).toBe('mj: ai agent runs');
+        });
+    });
+
+    describe('unresolvable — must be null (fail closed)', () => {
+        it('rejects blank, whitespace-only, null and undefined', () => {
+            expect(ResolveSingleEntityResourceTarget('')).toBeNull();
+            expect(ResolveSingleEntityResourceTarget('   ')).toBeNull();
+            expect(ResolveSingleEntityResourceTarget(null)).toBeNull();
+            expect(ResolveSingleEntityResourceTarget(undefined)).toBeNull();
+        });
+
+        it('rejects every wildcard/list form the save-time validator rejects (* ? ,)', () => {
+            // Mirrors IsExactResourceName in MJCoreEntitiesServer's rowFilterValidation.ts.
+            for (const p of ['*', 'Sk*p', '*Skip', 'Skip*', 'Sk?p', 'A,B', 'Salaries, Orders']) {
+                expect(ResolveSingleEntityResourceTarget(p)).toBeNull();
+            }
+        });
+
+        it("rejects '?' specifically — the character whose omission fails OPEN", () => {
+            // A `?` pattern kept as a literal target name matches no entity, so the entity it was
+            // meant to fence reads as unrestricted. This is the regression this file exists to pin.
+            expect(ResolveSingleEntityResourceTarget('Sk?p')).toBeNull();
+        });
+
+        it("also rejects the SQL wildcard '%', which the save-time validator does not police", () => {
+            expect(ResolveSingleEntityResourceTarget('Sk%p')).toBeNull();
+            expect(ResolveSingleEntityResourceTarget('%')).toBeNull();
+        });
+
+        it('rejects an unresolvable character anywhere in the pattern, including after trimming', () => {
+            expect(ResolveSingleEntityResourceTarget('  Orders*  ')).toBeNull();
+        });
+    });
+});

--- a/packages/MJGlobal/src/index.ts
+++ b/packages/MJGlobal/src/index.ts
@@ -10,6 +10,7 @@ export * from './ShutdownRegistry'
 export * from './DeepDiff'
 export * from './ClassUtils'
 export * from './util/PatternUtils';
+export * from './util/ResourcePatternUtils';
 export * from './util/UUIDUtils';
 export * from './util/CronUtils';
 export * from './util/SerializationUtils';

--- a/packages/MJGlobal/src/util/ResourcePatternUtils.ts
+++ b/packages/MJGlobal/src/util/ResourcePatternUtils.ts
@@ -1,0 +1,57 @@
+/**
+ * @fileoverview Resolution of API scope-rule `ResourcePattern` values to a single entity target.
+ *
+ * Lives here, in the one package every consumer already depends on, because the rule has to be
+ * IDENTICAL in two places that cannot import each other: CodeGenLib's mint/drift materialization
+ * gates (`ManageMetadataBase.loadAPIKeyRowFilterTargets`) and the runtime refresher's Leak-1 gate
+ * (`MaterializationRefresher.loadAPIKeyRowFilterTargets`). Those gates decide whether an entity is
+ * row-restricted; a copy that drifts open in one of them silently re-opens the leak the other one
+ * closes, and nothing in the build would notice.
+ *
+ * @module @memberjunction/global/ResourcePatternUtils
+ */
+
+/**
+ * Characters that make a `ResourcePattern` impossible to resolve to exactly one entity.
+ *
+ * A deliberate SUPERSET of what `IsExactResourceName` (MJCoreEntitiesServer's save-time validator)
+ * rejects — `*`, `?`, `,` — with `%` added as extra fail-closed cover for the SQL wildcard, which the
+ * save-time validator does not police. Each character matters independently:
+ *  - `*` / `%` — a glob or SQL wildcard spans an unknown number of entities;
+ *  - `?`       — omitting it fails OPEN: `Sk?p` would be kept as a literal target name, match no
+ *                entity, and leave the entity it was meant to fence reading as unrestricted;
+ *  - `,`       — a list names more than one resource.
+ */
+const UNRESOLVABLE_RESOURCE_PATTERN_CHARS = /[*%,?]/;
+
+/**
+ * Resolves an API scope rule's `ResourcePattern` to the single entity name it targets, normalized for
+ * lookup (trimmed and lowercased), or `null` when it cannot be resolved to exactly one entity.
+ *
+ * `null` is the FAIL-CLOSED answer, and callers must treat it as "this rule may name any entity"
+ * rather than "this rule names nothing" — a pattern we cannot map may well name the very entity the
+ * caller is about to mirror into an unscoped snapshot. Refusing to materialize is recoverable and
+ * loud; mirroring restricted rows is neither.
+ *
+ * Normalization matches the way scope rules are authored and resolved: `IsExactResourceName` gates
+ * the pattern at save time and `Metadata.EntityByName` resolves it, both case-insensitively.
+ *
+ * @param pattern the rule's raw `ResourcePattern` (null/undefined/blank all resolve to `null`).
+ * @returns the trimmed, lowercased entity name, or `null` when the pattern is not a single exact name.
+ *
+ * @example
+ * ResolveSingleEntityResourceTarget('  Salaries ')   // 'salaries'
+ * ResolveSingleEntityResourceTarget('MJ: AI Agents') // 'mj: ai agents'
+ * ResolveSingleEntityResourceTarget('Sk?p')          // null  (would otherwise fence nothing)
+ * ResolveSingleEntityResourceTarget('A,B')           // null
+ */
+export function ResolveSingleEntityResourceTarget(pattern: string | null | undefined): string | null {
+    if (pattern == null) {
+        return null;
+    }
+    const trimmed = pattern.trim();
+    if (trimmed.length === 0 || UNRESOLVABLE_RESOURCE_PATTERN_CHARS.test(trimmed)) {
+        return null;
+    }
+    return trimmed.toLowerCase();
+}

--- a/packages/Materialization/src/MaterializationRefresher.ts
+++ b/packages/Materialization/src/MaterializationRefresher.ts
@@ -90,6 +90,10 @@ export class MaterializationRefresher {
     /** A plain, unquoted SQL identifier: leading letter/underscore, then letters/digits/underscores. */
     private static readonly SAFE_SQL_IDENTIFIER = /^[A-Za-z_][A-Za-z0-9_]*$/;
 
+    /** Cached API-key row-filter targets for this refresher; `null` = not yet enumerated (see
+     *  {@link loadAPIKeyRowFilterTargets}). `'unknown'` is a LOADED state meaning "assume restricted". */
+    private _apiKeyRowFilterTargets: ReadonlySet<string> | 'unknown' | null = null;
+
     /**
      * Guards the schema/table/view identifiers that get interpolated into materialization DDL/DML — names
      * read from the *writable* `MJ: Materialized Results` metadata row. A materialization's names are always
@@ -354,8 +358,12 @@ export class MaterializationRefresher {
                 // The CodeGen mint/drift gates also cover this, but they run only per codegen pass; this runtime
                 // refusal closes the window between an entity gaining RLS and the next codegen run, during which
                 // the scheduled sweep would otherwise keep refilling the mirror with the now-protected rows.
-                if (MaterializationRefresher.entityHasReadRLS(externalEntity)) {
-                    return await this.failRefresh(matResult, provider, options, `Refusing to refresh base-view materialization of external RLS-protected entity "${externalEntity.Name}": a local mirror would expose rows the live path refuses under RLS.`);
+                // Both fence layers, not just role RLS: an entity fenced ONLY by an API-key row filter is just
+                // as unsafe to mirror, and checking only the role layer would leave this window open for it —
+                // the very window this gate exists to close. Symmetric with CodeGen's mint/drift gates.
+                const apiKeyTargets = await this.loadAPIKeyRowFilterTargets(provider, contextUser);
+                if (MaterializationRefresher.entityHasRowLevelRestriction(externalEntity, apiKeyTargets)) {
+                    return await this.failRefresh(matResult, provider, options, `Refusing to refresh base-view materialization of external row-restricted entity "${externalEntity.Name}" (role RLS and/or an API-key row filter): a local mirror would expose rows the live path refuses.`);
                 }
                 const ext = await this.rebuildFromExternalEntity(matResult, externalEntity, exec, isPostgres, contextUser, provider, runShadowName);
                 if (!ext.Success) return await this.failRefresh(matResult, provider, options, ext.ErrorMessage ?? `External entity rebuild failed for materialization ${matResult.ID}`);
@@ -823,6 +831,62 @@ export class MaterializationRefresher {
      */
     public static entityHasReadRLS(entity: EntityInfo): boolean {
         return entity.Permissions.some((p) => !!p.ReadRLSFilterID && p.ReadRLSFilterID.trim().length > 0);
+    }
+
+    /**
+     * The composite row-restriction test the Leak-1 gate uses: role RLS **or** an API-key row filter.
+     *
+     * {@link entityHasReadRLS} covers only the ROLE layer. `EntityInfo`'s equivalent role-only accessor is
+     * deprecated precisely because it omits API-key row filters, so a gate built on it alone judges an
+     * entity fenced only by a key filter to be unrestricted. CodeGen's mint and drift gates compose both
+     * layers; this is the runtime half, kept deliberately symmetric with them.
+     *
+     * @param apiKeyRowFilterTargets lowercased entity names carrying an API-key row filter, or `'unknown'`
+     *        when that layer could not be enumerated — in which case every entity is treated as restricted,
+     *        because refusing to refresh is recoverable and mirroring restricted rows is not.
+     */
+    public static entityHasRowLevelRestriction(entity: EntityInfo, apiKeyRowFilterTargets: ReadonlySet<string> | 'unknown'): boolean {
+        if (MaterializationRefresher.entityHasReadRLS(entity)) return true;
+        if (apiKeyRowFilterTargets === 'unknown') return true;
+        return apiKeyRowFilterTargets.has((entity.Name ?? '').trim().toLowerCase());
+    }
+
+    /**
+     * Enumerates the entities carrying an API-key row filter, cached for this refresher's lifetime (the gate
+     * runs per materialization; the fence changes far more slowly than a sweep).
+     *
+     * Mirrors CodeGen's enumeration contract exactly: entity NAMES, trimmed and lowercased, taken from the
+     * `ResourcePattern` of scope rows that carry a `RowFilterID`. A pattern that cannot be resolved to one
+     * exact entity — blank, or wildcard/list (`*`, `%`, `,`) — collapses the WHOLE set to `'unknown'`, since
+     * a rule we cannot map may well name the entity we are about to mirror. Any read failure does the same.
+     */
+    private async loadAPIKeyRowFilterTargets(provider: IMetadataProvider, contextUser: UserInfo): Promise<ReadonlySet<string> | 'unknown'> {
+        if (this._apiKeyRowFilterTargets !== null) return this._apiKeyRowFilterTargets;
+        try {
+            const targets = new Set<string>();
+            const rv = RunView.FromMetadataProvider(provider);
+            for (const entityName of ['MJ: API Key Scopes', 'MJ: API Application Scopes']) {
+                const res = await rv.RunView<{ ResourcePattern: string | null }>(
+                    { EntityName: entityName, Fields: ['ResourcePattern'], ExtraFilter: 'RowFilterID IS NOT NULL', ResultType: 'simple' },
+                    contextUser,
+                );
+                if (!res.Success) throw new Error(`${entityName}: ${res.ErrorMessage}`);
+                for (const row of res.Results ?? []) {
+                    const pattern = (row.ResourcePattern ?? '').trim();
+                    if (pattern.length === 0 || /[*%,]/.test(pattern)) {
+                        LogError(`MaterializationRefresher: an API-key scope rule with a row filter has an unmappable ResourcePattern ("${pattern}") — it cannot be resolved to one entity, so EVERY entity is treated as row-restricted for refresh (fail closed). Fix the rule to name one exact entity.`);
+                        this._apiKeyRowFilterTargets = 'unknown';
+                        return this._apiKeyRowFilterTargets;
+                    }
+                    targets.add(pattern.toLowerCase());
+                }
+            }
+            this._apiKeyRowFilterTargets = targets;
+        } catch (err) {
+            LogError(`MaterializationRefresher: API-key row-filter enumeration FAILED — every entity is treated as row-restricted for refresh (fail closed): ${err instanceof Error ? err.message : String(err)}`);
+            this._apiKeyRowFilterTargets = 'unknown';
+        }
+        return this._apiKeyRowFilterTargets;
     }
 
     /**

--- a/packages/Materialization/src/MaterializationRefresher.ts
+++ b/packages/Materialization/src/MaterializationRefresher.ts
@@ -468,9 +468,12 @@ export class MaterializationRefresher {
             // shadow is renamed INTO the canonical name, so there's nothing to drop.) Never let a cleanup error
             // mask the original failure. `exec`/`isPostgres` are re-derived because they're scoped to the try.
             await this.dropShadowTableBestEffort(provider, matResult.SchemaName, runShadowName);
-            // A batch that aborted mid-swap never reached its trailing `SET XACT_ABORT OFF`, so the pooled
-            // connection would go back to the pool still carrying ON. Reset it best-effort here (no-op on PG,
-            // which has no such setting) so the leak cannot outlive the failed refresh.
+            // A batch that aborted mid-swap never reached its trailing `SET XACT_ABORT OFF`. Best-effort reset
+            // (no-op on PG, which has no such setting). Note this is a genuine BEST effort, not a guarantee:
+            // the pool hands out any idle connection, so this may well reset a different one than the batch
+            // poisoned. Harmless either way — OFF is the connection default, so resetting an innocent
+            // connection is a no-op. The trailing OFF inside each batch is the load-bearing half, since only
+            // that one is guaranteed to run on the same connection.
             await this.resetXactAbortBestEffort(provider);
             return await this.failRefresh(matResult, provider, options, msg);
         }
@@ -866,6 +869,14 @@ export class MaterializationRefresher {
             const targets = new Set<string>();
             const rv = RunView.FromMetadataProvider(provider);
             for (const entityName of ['MJ: API Key Scopes', 'MJ: API Application Scopes']) {
+                // Skip a scope entity that has no RowFilterID field — the same guard CodeGen's enumeration
+                // makes with an INFORMATION_SCHEMA probe, expressed here in the metadata the refresher already
+                // has. Without it, a database predating that column fails the filtered read, which collapses
+                // the set to 'unknown' and stops EVERY external base-view refresh until someone migrates. The
+                // column's absence means the key-filter layer cannot exist there, so contributing nothing is
+                // correct rather than fail-open.
+                const scopeEntity = provider.EntityByName(entityName);
+                if (!scopeEntity || !scopeEntity.Fields.some((f) => f.Name === 'RowFilterID')) continue;
                 const res = await rv.RunView<{ ResourcePattern: string | null }>(
                     { EntityName: entityName, Fields: ['ResourcePattern'], ExtraFilter: 'RowFilterID IS NOT NULL', ResultType: 'simple' },
                     contextUser,
@@ -873,7 +884,11 @@ export class MaterializationRefresher {
                 if (!res.Success) throw new Error(`${entityName}: ${res.ErrorMessage}`);
                 for (const row of res.Results ?? []) {
                     const pattern = (row.ResourcePattern ?? '').trim();
-                    if (pattern.length === 0 || /[*%,]/.test(pattern)) {
+                    // Superset of what IsExactResourceName (rowFilterValidation.ts) rejects at save time — `*`,
+                    // `?`, `,` — plus `%` as an extra fail-closed. Omitting `?` would fail OPEN: `Sk?p` would be
+                    // stored as a literal target name, match no entity, and the entity it fences would read as
+                    // unrestricted. Kept character-identical to CodeGen's copy in manage-metadata.ts.
+                    if (pattern.length === 0 || /[*%,?]/.test(pattern)) {
                         LogError(`MaterializationRefresher: an API-key scope rule with a row filter has an unmappable ResourcePattern ("${pattern}") — it cannot be resolved to one entity, so EVERY entity is treated as row-restricted for refresh (fail closed). Fix the rule to name one exact entity.`);
                         this._apiKeyRowFilterTargets = 'unknown';
                         return this._apiKeyRowFilterTargets;

--- a/packages/Materialization/src/MaterializationRefresher.ts
+++ b/packages/Materialization/src/MaterializationRefresher.ts
@@ -1,7 +1,7 @@
 import { randomUUID } from 'node:crypto';
 import { IMetadataProvider, UserInfo, LogError, LogStatus, EntityInfo, ExternalDataSourceReadRouter, RunView } from '@memberjunction/core';
 import { MJMaterializedResultEntity, MJQueryEntity } from '@memberjunction/core-entities';
-import { MJGlobal, UUIDsEqual } from '@memberjunction/global';
+import { MJGlobal, ResolveSingleEntityResourceTarget, UUIDsEqual } from '@memberjunction/global';
 import { SQLParser } from '@memberjunction/sql-parser';
 import { GetDialect, DatabasePlatform } from '@memberjunction/sql-dialect';
 
@@ -858,10 +858,11 @@ export class MaterializationRefresher {
      * Enumerates the entities carrying an API-key row filter, cached for this refresher's lifetime (the gate
      * runs per materialization; the fence changes far more slowly than a sweep).
      *
-     * Mirrors CodeGen's enumeration contract exactly: entity NAMES, trimmed and lowercased, taken from the
-     * `ResourcePattern` of scope rows that carry a `RowFilterID`. A pattern that cannot be resolved to one
-     * exact entity — blank, or wildcard/list (`*`, `%`, `,`) — collapses the WHOLE set to `'unknown'`, since
-     * a rule we cannot map may well name the entity we are about to mirror. Any read failure does the same.
+     * Mirrors CodeGen's enumeration contract exactly, because it shares the rule rather than restating it:
+     * entity NAMES normalized by {@link ResolveSingleEntityResourceTarget}, taken from the `ResourcePattern`
+     * of scope rows that carry a `RowFilterID`. A pattern that function cannot resolve to one exact entity
+     * collapses the WHOLE set to `'unknown'`, since a rule we cannot map may well name the entity we are
+     * about to mirror. Any read failure does the same.
      */
     private async loadAPIKeyRowFilterTargets(provider: IMetadataProvider, contextUser: UserInfo): Promise<ReadonlySet<string> | 'unknown'> {
         if (this._apiKeyRowFilterTargets !== null) return this._apiKeyRowFilterTargets;
@@ -884,16 +885,17 @@ export class MaterializationRefresher {
                 if (!res.Success) throw new Error(`${entityName}: ${res.ErrorMessage}`);
                 for (const row of res.Results ?? []) {
                     const pattern = (row.ResourcePattern ?? '').trim();
-                    // Superset of what IsExactResourceName (rowFilterValidation.ts) rejects at save time — `*`,
-                    // `?`, `,` — plus `%` as an extra fail-closed. Omitting `?` would fail OPEN: `Sk?p` would be
-                    // stored as a literal target name, match no entity, and the entity it fences would read as
-                    // unrestricted. Kept character-identical to CodeGen's copy in manage-metadata.ts.
-                    if (pattern.length === 0 || /[*%,?]/.test(pattern)) {
+                    // SHARED with CodeGen's identical gate (ResolveSingleEntityResourceTarget in
+                    // @memberjunction/global) rather than copied. These two enumerations must agree exactly —
+                    // a copy that drifts open in either one silently re-opens the leak the other closes, and
+                    // nothing in the build would catch the divergence.
+                    const target = ResolveSingleEntityResourceTarget(pattern);
+                    if (target === null) {
                         LogError(`MaterializationRefresher: an API-key scope rule with a row filter has an unmappable ResourcePattern ("${pattern}") — it cannot be resolved to one entity, so EVERY entity is treated as row-restricted for refresh (fail closed). Fix the rule to name one exact entity.`);
                         this._apiKeyRowFilterTargets = 'unknown';
                         return this._apiKeyRowFilterTargets;
                     }
-                    targets.add(pattern.toLowerCase());
+                    targets.add(target);
                 }
             }
             this._apiKeyRowFilterTargets = targets;

--- a/packages/Materialization/src/MaterializationRefresher.ts
+++ b/packages/Materialization/src/MaterializationRefresher.ts
@@ -1,9 +1,9 @@
 import { randomUUID } from 'node:crypto';
 import { IMetadataProvider, UserInfo, LogError, LogStatus, EntityInfo, ExternalDataSourceReadRouter, RunView } from '@memberjunction/core';
 import { MJMaterializedResultEntity, MJQueryEntity } from '@memberjunction/core-entities';
-import { MJGlobal } from '@memberjunction/global';
+import { MJGlobal, UUIDsEqual } from '@memberjunction/global';
 import { SQLParser } from '@memberjunction/sql-parser';
-import { GetDialect } from '@memberjunction/sql-dialect';
+import { GetDialect, DatabasePlatform } from '@memberjunction/sql-dialect';
 
 /**
  * Synthetic surrogate key column name for query-materialized tables. MUST match CodeGenLib's
@@ -103,10 +103,42 @@ export class MaterializationRefresher {
      */
     private static assertSafeObjectNames(schema: string, tableName: string, viewName: string): void {
         for (const [role, value] of [['schema', schema], ['table', tableName], ['view', viewName]] as const) {
-            if (typeof value !== 'string' || !MaterializationRefresher.SAFE_SQL_IDENTIFIER.test(value)) {
+            if (!MaterializationRefresher.isSafeObjectName(value)) {
                 throw new Error(`Unsafe materialization ${role} identifier ${JSON.stringify(value)} — expected a plain SQL identifier (^[A-Za-z_][A-Za-z0-9_]*$); refusing to build DDL.`);
             }
         }
+    }
+
+    /**
+     * Non-throwing form of the identifier check. Needed by callers on the FAILURE path, which is precisely
+     * where {@link assertSafeObjectNames} may have just thrown — those callers must be able to re-check and
+     * decline quietly rather than re-enter (or bypass) the assertion that already rejected the value.
+     * @internal exposed for unit testing; not part of the supported surface.
+     */
+    public static isSafeObjectName(value: string): boolean {
+        return typeof value === 'string' && MaterializationRefresher.SAFE_SQL_IDENTIFIER.test(value);
+    }
+
+    /**
+     * Resolves the SQL that the READ path would execute for `queryId` on the engine we are refreshing against,
+     * so the snapshot is built from the same statement live serves. Mirrors the read path's
+     * `QueryInfo.GetPlatformSQL(PlatformKey)`, whose precedence is: `MJ: Query SQLs` child row for the platform
+     * → legacy PlatformVariants → base SQL.
+     *
+     * `GetPlatformSQL` lives on the metadata `QueryInfo`, not on the generated `MJQueryEntity`, so the variant
+     * is resolved through the provider's query metadata. Falls back to the entity's own SQL when the query
+     * isn't present in that metadata (e.g. a provider whose cache hasn't loaded it), which reproduces exactly
+     * the previous behavior rather than failing the refresh.
+     *
+     * @returns the platform-resolved SQL, or null when neither source yields a non-empty statement.
+     * @internal exposed for unit testing; not part of the supported surface.
+     */
+    public static resolvePlatformQuerySQL(provider: IMetadataProvider, queryId: string, entitySql: string | null, isPostgres: boolean): string | null {
+        const platform: DatabasePlatform = isPostgres ? 'postgresql' : 'sqlserver';
+        const info = provider.Queries?.find((q) => UUIDsEqual(q.ID, queryId));
+        const resolved = info ? info.GetPlatformSQL(platform) : null;
+        const chosen = resolved && resolved.trim().length > 0 ? resolved : entitySql;
+        return chosen && chosen.trim().length > 0 ? chosen : null;
     }
 
     /**
@@ -434,6 +466,15 @@ export class MaterializationRefresher {
      * created or was already renamed into the canonical table on success.
      */
     private async dropShadowTableBestEffort(provider: IMetadataProvider, schema: string, shadowName: string): Promise<void> {
+        // Fail CLOSED. This runs from the RefreshOne catch block — which is exactly where
+        // assertSafeObjectNames may have just REJECTED these very names. Interpolating them here would let the
+        // guard's own rejection be the thing that routes a tampered SchemaName into privileged DDL, inverting
+        // the guarantee the guard exists to provide. Re-check and decline instead; declining drops nothing
+        // real, because the assertion fires before any shadow table could have been created.
+        if (!MaterializationRefresher.isSafeObjectName(schema) || !MaterializationRefresher.isSafeObjectName(shadowName)) {
+            LogError(`MaterializationRefresher: refusing best-effort shadow cleanup — unsafe identifier(s) schema=${JSON.stringify(schema)} shadow=${JSON.stringify(shadowName)}. No shadow table can exist under these names.`);
+            return;
+        }
         try {
             const exec = provider as unknown as ISQLExecutor;
             const isPostgres = exec.PlatformKey === 'postgresql';
@@ -792,7 +833,14 @@ export class MaterializationRefresher {
                 query = await provider.GetEntityObject<MJQueryEntity>('MJ: Queries', contextUser);
                 await query.Load(sourceQueryId);
             }
-            rawSql = query.SQL && query.SQL.trim().length > 0 ? query.SQL : null;
+            // Snapshot the SAME statement the READ path executes. Reads resolve SQL via
+            // QueryInfo.GetPlatformSQL(PlatformKey) (GenericDatabaseProvider's ORDER BY gate and its query
+            // execution both do), which prefers a per-platform `MJ: Query SQLs` variant over the base SQL.
+            // Snapshotting the base `SQL` instead means a query carrying a variant for THIS engine is
+            // materialized from a different statement than the one live serves — either a hard refresh
+            // failure every cycle, or (worse) a snapshot whose contents silently disagree with live, which
+            // is precisely the invariant materialization exists to preserve.
+            rawSql = MaterializationRefresher.resolvePlatformQuerySQL(provider, sourceQueryId, query.SQL, isPostgres);
         }
         // Strip a top-level ORDER BY before this SELECT is wrapped in a derived table by the rebuild
         // (SELECT … INTO shadow FROM (<sql>) AS src): SQL Server rejects ORDER BY inside a derived table /
@@ -1025,6 +1073,16 @@ export class MaterializationRefresher {
         // feeding PG-native names in would double-convert everything down to `text` (broken sorts/joins).
         const surrogate = MATERIALIZATION_SURROGATE_COLUMN;
         const dataColNames = [...new Set(rawRows.flatMap((r) => Object.keys(r)))];
+        // A zero-row result carries NO column information, so the rebuild below would emit a shadow table
+        // holding only the surrogate, then DROP the canonical table and rename that one-column shell into its
+        // place — permanently breaking every read of the minted entity ("Invalid column name") while reporting
+        // Success. Refuse instead: the existing snapshot is left intact and serving (at worst slightly stale),
+        // and failRefresh advances NextRefreshAt so this backs off to its cadence and stays visible in the log.
+        // The alternative (truncate-in-place to preserve the shape) is the nicer semantic for a legitimately
+        // empty source, but it cannot be done safely without first proving the canonical table's shape here.
+        if (rawRows.length === 0) {
+            return { Success: false, ErrorMessage: `External query '${query.Name}' returned zero rows, so the snapshot's column shape cannot be determined. Refusing to rebuild — the existing snapshot is preserved rather than replaced with an empty, unreadable table.` };
+        }
         // Refuse if the external result already has a column named like the surrogate — prepending ours
         // would emit a duplicate column and the CREATE TABLE / INSERT would fail on every refresh. (Parity
         // with the local path's analyzeQueryForMaterialization shadow-check; here it's a runtime guard.)

--- a/packages/Materialization/src/MaterializationRefresher.ts
+++ b/packages/Materialization/src/MaterializationRefresher.ts
@@ -204,7 +204,11 @@ export class MaterializationRefresher {
                 `  EXEC sp_rename '${schema}.${shadow}', '${tableName}';\n` +
                 `  EXEC('CREATE OR ALTER VIEW ${obj(viewName)} AS SELECT * FROM ${obj(tableName)}');\n` +
                 indexLine +
-                `COMMIT TRANSACTION;`,
+                // Restore the connection default after the swap. SET options persist for the SESSION and the
+                // pool hands this same physical connection to unrelated requests, which would otherwise
+                // silently inherit XACT_ABORT ON — converting their recoverable statement-level errors into
+                // full transaction aborts, far from anything to do with materialization.
+                `COMMIT TRANSACTION;\nSET XACT_ABORT OFF;`,
         ];
     }
 
@@ -456,6 +460,10 @@ export class MaterializationRefresher {
             // shadow is renamed INTO the canonical name, so there's nothing to drop.) Never let a cleanup error
             // mask the original failure. `exec`/`isPostgres` are re-derived because they're scoped to the try.
             await this.dropShadowTableBestEffort(provider, matResult.SchemaName, runShadowName);
+            // A batch that aborted mid-swap never reached its trailing `SET XACT_ABORT OFF`, so the pooled
+            // connection would go back to the pool still carrying ON. Reset it best-effort here (no-op on PG,
+            // which has no such setting) so the leak cannot outlive the failed refresh.
+            await this.resetXactAbortBestEffort(provider);
             return await this.failRefresh(matResult, provider, options, msg);
         }
     }
@@ -465,6 +473,21 @@ export class MaterializationRefresher {
      * a crashed/failed rebuild leaves no orphan). Uses IF EXISTS so it's a no-op when the shadow was never
      * created or was already renamed into the canonical table on success.
      */
+    /**
+     * Restores `XACT_ABORT` to the connection default after a failed refresh, swallowing any error. SQL Server
+     * only — PostgreSQL has no equivalent session setting, so this is a no-op there. Needed because a batch
+     * that aborts mid-swap never reaches the trailing `SET XACT_ABORT OFF` in its own statement list.
+     */
+    private async resetXactAbortBestEffort(provider: IMetadataProvider): Promise<void> {
+        try {
+            const exec = provider as unknown as ISQLExecutor;
+            if (exec.PlatformKey === 'postgresql') return;
+            await exec.ExecuteSQL('SET XACT_ABORT OFF');
+        } catch (resetErr) {
+            LogError(`MaterializationRefresher: best-effort XACT_ABORT reset failed (ignored): ${resetErr instanceof Error ? resetErr.message : String(resetErr)}`);
+        }
+    }
+
     private async dropShadowTableBestEffort(provider: IMetadataProvider, schema: string, shadowName: string): Promise<void> {
         // Fail CLOSED. This runs from the RefreshOne catch block — which is exactly where
         // assertSafeObjectNames may have just REJECTED these very names. Interpolating them here would let the
@@ -660,7 +683,7 @@ export class MaterializationRefresher {
                 : MaterializationRefresher.buildDirtyGroupRecomputeStatementsSQLServer(opts);
             const batch = isPostgres
                 ? `BEGIN;\n${dg.join(';\n')};\nCOMMIT;`
-                : `SET XACT_ABORT ON;\nBEGIN TRANSACTION;\n${dg.join(';\n')};\nCOMMIT TRANSACTION;`;
+                : `SET XACT_ABORT ON;\nBEGIN TRANSACTION;\n${dg.join(';\n')};\nCOMMIT TRANSACTION;\nSET XACT_ABORT OFF;`;
             await exec.ExecuteSQL(batch);
         }
 
@@ -1249,7 +1272,11 @@ export class MaterializationRefresher {
                       // table can't overflow the 128-char sysname limit and roll back the swap — matches
                       // buildFullRebuildStatementsSQLServer.
                       (surrogateColumn ? `  CREATE UNIQUE INDEX [UQ_MJ_Materialized_Surrogate] ON ${obj(tableName)} (${q(surrogateColumn)});\n` : '') +
-                      `COMMIT TRANSACTION;`,
+                      // Restore the connection default after the swap. SET options persist for the SESSION and the
+                // pool hands this same physical connection to unrelated requests, which would otherwise
+                // silently inherit XACT_ABORT ON — converting their recoverable statement-level errors into
+                // full transaction aborts, far from anything to do with materialization.
+                `COMMIT TRANSACTION;\nSET XACT_ABORT OFF;`,
               ];
 
         return { preStatements, insertBatches, postStatements };

--- a/packages/Materialization/src/__tests__/MaterializationRefresher.test.ts
+++ b/packages/Materialization/src/__tests__/MaterializationRefresher.test.ts
@@ -29,7 +29,12 @@ describe('MaterializationRefresher.buildFullRebuildStatementsSQLServer', () => {
             const swap = stmts[2];
             expect(swap.startsWith('SET XACT_ABORT ON;')).toBe(true); // rolls back on mid-swap error (no orphaned tran)
             expect(swap).toContain('BEGIN TRANSACTION;');
-            expect(swap.trim().endsWith('COMMIT TRANSACTION;')).toBe(true);
+            // The batch commits and THEN restores the connection default: SET options persist for the session,
+            // and the pool reuses this physical connection for unrelated requests, which would otherwise
+            // inherit XACT_ABORT ON and see their recoverable statement errors escalate to transaction aborts.
+            expect(swap).toContain('COMMIT TRANSACTION;');
+            expect(swap.trim().endsWith('SET XACT_ABORT OFF;')).toBe(true);
+            expect(swap.indexOf('COMMIT TRANSACTION;')).toBeLessThan(swap.indexOf('SET XACT_ABORT OFF;'));
             expect(swap).toContain('DROP TABLE [__mj].[materialized_Demo]');
             expect(swap).toContain("EXEC sp_rename '__mj.materialized_Demo__shadow', 'materialized_Demo'");
             // CREATE VIEW runs via EXEC() (must be sole statement of its batch) and points at the canonical name

--- a/packages/Materialization/src/__tests__/MaterializationRefresher.test.ts
+++ b/packages/Materialization/src/__tests__/MaterializationRefresher.test.ts
@@ -919,25 +919,7 @@ describe('MaterializationRefresher.entityHasRowLevelRestriction (both fence laye
     });
 });
 
-/**
- * The pattern rule that decides whether a scope row maps to one entity. Kept a superset of
- * IsExactResourceName (rowFilterValidation.ts), which rejects `*`, `?` and `,` at save time. `?` matters:
- * omitting it fails OPEN — the pattern would be stored as a literal target name, match no entity, and the
- * entity it was meant to fence would read as unrestricted.
- */
-describe('API-key ResourcePattern mappability rule (fail-closed superset of IsExactResourceName)', () => {
-    const UNMAPPABLE = /[*%,?]/;
-    const mappable = (p: string) => p.trim().length > 0 && !UNMAPPABLE.test(p.trim());
-
-    it('treats every wildcard/list form the save-time validator rejects as unmappable', () => {
-        for (const p of ['*', 'Sk*p', 'Sk?p', 'A,B', '  ', '']) expect(mappable(p)).toBe(false);
-    });
-
-    it('also refuses the SQL wildcard % , which the save-time validator does not police', () => {
-        expect(mappable('Sk%p')).toBe(false);
-    });
-
-    it('accepts an exact entity name, including one with spaces', () => {
-        for (const p of ['Salaries', 'MJ: AI Agent Runs', '  Salaries  ']) expect(mappable(p)).toBe(true);
-    });
-});
+// The ResourcePattern mappability rule this refresher's enumeration depends on lives in
+// @memberjunction/global (ResolveSingleEntityResourceTarget), shared verbatim with CodeGen's identical
+// gate rather than restated here, and is tested against the real implementation in
+// packages/MJGlobal/src/__tests__/ResourcePatternUtils.test.ts.

--- a/packages/Materialization/src/__tests__/MaterializationRefresher.test.ts
+++ b/packages/Materialization/src/__tests__/MaterializationRefresher.test.ts
@@ -798,3 +798,79 @@ describe('MaterializationRefresher.entityHasReadRLS (Leak-1 runtime gate detecto
         expect(MaterializationRefresher.entityHasReadRLS(ent([]))).toBe(false);
     });
 });
+
+/**
+ * Review finding (fail-open DDL guard): assertSafeObjectNames throws on a tampered SchemaName, but the
+ * RefreshOne catch block then handed that SAME rejected name to the best-effort shadow cleanup, which
+ * interpolated it raw into DROP TABLE / OBJECT_ID. The guard's own rejection was the thing that routed the
+ * payload into privileged DDL. isSafeObjectName is the non-throwing re-check that makes the cleanup path
+ * decline instead.
+ */
+describe('MaterializationRefresher.isSafeObjectName (fail-closed re-check for the failure path)', () => {
+    it('accepts the plain identifiers a legitimate materialization always uses', () => {
+        for (const ok of ['__mj', 'materialized_Demo', 'materialized_vwDemo', '_x', 'A1_b2']) {
+            expect(MaterializationRefresher.isSafeObjectName(ok)).toBe(true);
+        }
+    });
+
+    it('REFUSES the injection payload from the finding, and every quoting escape it relies on', () => {
+        // The exact payload: a tampered SchemaName that closes the bracket and appends its own statement.
+        expect(MaterializationRefresher.isSafeObjectName(`x']; DROP TABLE __mj.Entity--`)).toBe(false);
+        // The individual characters that would break out of [..] / ".." / '..' quoting.
+        for (const bad of [`a]b`, `a"b`, `a'b`, `a;b`, `a b`, `a-b`, `a.b`, `1abc`, '']) {
+            expect(MaterializationRefresher.isSafeObjectName(bad)).toBe(false);
+        }
+    });
+
+    it('REFUSES non-string input rather than coercing it', () => {
+        // Values arrive from a writable metadata row, so a null/undefined column must not pass the check.
+        expect(MaterializationRefresher.isSafeObjectName(null as unknown as string)).toBe(false);
+        expect(MaterializationRefresher.isSafeObjectName(undefined as unknown as string)).toBe(false);
+    });
+});
+
+/**
+ * Review finding (snapshot/live divergence): the refresher snapshotted `query.SQL` while every read path
+ * executes `QueryInfo.GetPlatformSQL(PlatformKey)`. A query carrying a per-platform variant was therefore
+ * materialized from a different statement than the one live serves.
+ */
+describe('MaterializationRefresher.resolvePlatformQuerySQL (snapshot the statement the read path runs)', () => {
+    const QID = 'A1B2C3D4-E5F6-7890-ABCD-EF1234567890';
+    /** Minimal provider stub: only `.Queries` is read, and only `.ID` / `.GetPlatformSQL` off each entry. */
+    const providerWith = (queries: Array<{ ID: string; GetPlatformSQL: (p: string) => string }>) =>
+        ({ Queries: queries }) as unknown as Parameters<typeof MaterializationRefresher.resolvePlatformQuerySQL>[0];
+
+    const variantQuery = (id: string) => ({
+        ID: id,
+        GetPlatformSQL: (p: string) => (p === 'postgresql' ? 'SELECT pg_variant' : 'SELECT ss_variant'),
+    });
+
+    it('prefers the platform variant over the base SQL, per engine', () => {
+        const p = providerWith([variantQuery(QID)]);
+        expect(MaterializationRefresher.resolvePlatformQuerySQL(p, QID, 'SELECT base', true)).toBe('SELECT pg_variant');
+        expect(MaterializationRefresher.resolvePlatformQuerySQL(p, QID, 'SELECT base', false)).toBe('SELECT ss_variant');
+    });
+
+    it('matches the query through UUIDsEqual, so platform resolution survives cross-platform ID casing', () => {
+        // SQL Server returns UUIDs uppercase and PostgreSQL lowercase; a `===` match would silently miss here
+        // and fall back to the base SQL — reintroducing the very divergence this resolves.
+        const p = providerWith([variantQuery(QID.toLowerCase())]);
+        expect(MaterializationRefresher.resolvePlatformQuerySQL(p, QID.toUpperCase(), 'SELECT base', false)).toBe('SELECT ss_variant');
+    });
+
+    it('falls back to the entity SQL when the query is absent from provider metadata (previous behavior)', () => {
+        const p = providerWith([]);
+        expect(MaterializationRefresher.resolvePlatformQuerySQL(p, QID, 'SELECT base', false)).toBe('SELECT base');
+    });
+
+    it('falls back to the entity SQL when the resolved variant is empty/whitespace', () => {
+        const p = providerWith([{ ID: QID, GetPlatformSQL: () => '   ' }]);
+        expect(MaterializationRefresher.resolvePlatformQuerySQL(p, QID, 'SELECT base', false)).toBe('SELECT base');
+    });
+
+    it('returns null when neither source yields a usable statement', () => {
+        const p = providerWith([{ ID: QID, GetPlatformSQL: () => '' }]);
+        expect(MaterializationRefresher.resolvePlatformQuerySQL(p, QID, null, false)).toBeNull();
+        expect(MaterializationRefresher.resolvePlatformQuerySQL(p, QID, '  ', false)).toBeNull();
+    });
+});

--- a/packages/Materialization/src/__tests__/MaterializationRefresher.test.ts
+++ b/packages/Materialization/src/__tests__/MaterializationRefresher.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect } from 'vitest';
+import type { EntityInfo } from '@memberjunction/core';
 import { MaterializationRefresher, MATERIALIZATION_SURROGATE_COLUMN, FULL_REBUILD_EVERY_N_INCREMENTAL_REFRESHES, WATERMARK_SAFETY_OVERLAP_MS } from '../MaterializationRefresher';
 
 /**
@@ -776,9 +777,10 @@ describe('MaterializationRefresher.applyWatermarkSafetyOverlap (commit-skew safe
  * RLS the same way CodeGenLib does — any permission with a non-empty, non-whitespace ReadRLSFilterID.
  */
 describe('MaterializationRefresher.entityHasReadRLS (Leak-1 runtime gate detector)', () => {
-    // Structural stub of the only EntityInfo surface the detector reads.
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const ent = (perms: Array<{ ReadRLSFilterID?: string | null }>): any => ({ Name: 'Ext', Permissions: perms });
+    // Structural stub of the only EntityInfo surface the detector reads (it touches nothing but .Permissions);
+    // the sanctioned double-cast keeps the test typed against the real signature without a full EntityInfo.
+    const ent = (perms: Array<{ ReadRLSFilterID?: string | null }>): EntityInfo =>
+        ({ Name: 'Ext', Permissions: perms }) as unknown as EntityInfo;
 
     it('is TRUE when any permission carries a non-empty ReadRLSFilterID', () => {
         expect(MaterializationRefresher.entityHasReadRLS(ent([{}, { ReadRLSFilterID: 'rls-1' }]))).toBe(true);

--- a/packages/Materialization/src/__tests__/MaterializationRefresher.test.ts
+++ b/packages/Materialization/src/__tests__/MaterializationRefresher.test.ts
@@ -918,3 +918,26 @@ describe('MaterializationRefresher.entityHasRowLevelRestriction (both fence laye
         expect(MaterializationRefresher.entityHasRowLevelRestriction(e, new Set())).toBe(false);
     });
 });
+
+/**
+ * The pattern rule that decides whether a scope row maps to one entity. Kept a superset of
+ * IsExactResourceName (rowFilterValidation.ts), which rejects `*`, `?` and `,` at save time. `?` matters:
+ * omitting it fails OPEN — the pattern would be stored as a literal target name, match no entity, and the
+ * entity it was meant to fence would read as unrestricted.
+ */
+describe('API-key ResourcePattern mappability rule (fail-closed superset of IsExactResourceName)', () => {
+    const UNMAPPABLE = /[*%,?]/;
+    const mappable = (p: string) => p.trim().length > 0 && !UNMAPPABLE.test(p.trim());
+
+    it('treats every wildcard/list form the save-time validator rejects as unmappable', () => {
+        for (const p of ['*', 'Sk*p', 'Sk?p', 'A,B', '  ', '']) expect(mappable(p)).toBe(false);
+    });
+
+    it('also refuses the SQL wildcard % , which the save-time validator does not police', () => {
+        expect(mappable('Sk%p')).toBe(false);
+    });
+
+    it('accepts an exact entity name, including one with spaces', () => {
+        for (const p of ['Salaries', 'MJ: AI Agent Runs', '  Salaries  ']) expect(mappable(p)).toBe(true);
+    });
+});

--- a/packages/Materialization/src/__tests__/MaterializationRefresher.test.ts
+++ b/packages/Materialization/src/__tests__/MaterializationRefresher.test.ts
@@ -879,3 +879,42 @@ describe('MaterializationRefresher.resolvePlatformQuerySQL (snapshot the stateme
         expect(MaterializationRefresher.resolvePlatformQuerySQL(p, QID, '  ', false)).toBeNull();
     });
 });
+
+/**
+ * Review finding (fail-open RLS gate), runtime half. The Leak-1 gate exists specifically to close the window
+ * between an entity gaining a row restriction and the next CodeGen run, during which the sweep would keep
+ * refilling the mirror. Checking only the ROLE layer left that window open for an entity fenced solely by an
+ * API-key row filter — so the gate now composes both layers, symmetric with CodeGen's mint/drift gates.
+ */
+describe('MaterializationRefresher.entityHasRowLevelRestriction (both fence layers)', () => {
+    const ent = (name: string, perms: Array<{ ReadRLSFilterID?: string | null }> = []): EntityInfo =>
+        ({ Name: name, Permissions: perms }) as unknown as EntityInfo;
+
+    it('is TRUE on role RLS alone, regardless of the key layer', () => {
+        const e = ent('Orders', [{ ReadRLSFilterID: 'rls-1' }]);
+        expect(MaterializationRefresher.entityHasRowLevelRestriction(e, new Set())).toBe(true);
+    });
+
+    it('is TRUE on an API-key row filter alone — the case the role-only check missed', () => {
+        // No ReadRLSFilterID anywhere: the old gate judged this unrestricted and kept refilling the mirror.
+        const e = ent('Orders');
+        expect(MaterializationRefresher.entityHasReadRLS(e)).toBe(false);
+        expect(MaterializationRefresher.entityHasRowLevelRestriction(e, new Set(['orders']))).toBe(true);
+    });
+
+    it('matches the key layer case- and whitespace-insensitively (targets are normalized names)', () => {
+        expect(MaterializationRefresher.entityHasRowLevelRestriction(ent('  OrDeRs '), new Set(['orders']))).toBe(true);
+    });
+
+    it('FAILS CLOSED when the key layer could not be enumerated', () => {
+        // 'unknown' means we cannot prove the fence is empty. Refusing to refresh is recoverable and loud;
+        // mirroring restricted rows is neither.
+        expect(MaterializationRefresher.entityHasRowLevelRestriction(ent('Anything'), 'unknown')).toBe(true);
+    });
+
+    it('is FALSE only when BOTH layers are proven empty for this entity', () => {
+        const e = ent('Orders', [{ ReadRLSFilterID: null }, {}]);
+        expect(MaterializationRefresher.entityHasRowLevelRestriction(e, new Set(['customers']))).toBe(false);
+        expect(MaterializationRefresher.entityHasRowLevelRestriction(e, new Set())).toBe(false);
+    });
+});

--- a/packages/ServerBootstrap/src/generated/mj-class-registrations.ts
+++ b/packages/ServerBootstrap/src/generated/mj-class-registrations.ts
@@ -205,7 +205,7 @@ import {
     WorkOSProvider,
 } from '@memberjunction/auth-providers';
 
-// @memberjunction/core-entities (400 classes)
+// @memberjunction/core-entities (402 classes)
 import {
     AIAgentPermissionProvider,
     AISkillPermissionProvider,
@@ -480,6 +480,8 @@ import {
     MJMagicLinkInviteEntity,
     MJMagicLinkInviteRoleEntity,
     MJMagicLinkRedemptionEntity,
+    MJMaterializedResultEntity,
+    MJMaterializedResultQueryEntity,
     MJOAuthAuthServerMetadataCacheEntity,
     MJOAuthAuthorizationStateEntity,
     MJOAuthClientRegistrationEntity,
@@ -1183,7 +1185,7 @@ import {
     TeamsMessagingExtension,
 } from '@memberjunction/messaging-adapters';
 
-// @memberjunction/scheduling-engine (8 classes)
+// @memberjunction/scheduling-engine (9 classes)
 import {
     ActionLogRetentionScheduledJobDriver,
     ActionScheduledJobDriver,
@@ -1191,11 +1193,12 @@ import {
     AgentScheduledJobDriver,
     IntegrationDiscoveryScheduledJobDriver,
     IntegrationSyncScheduledJobDriver,
+    MaterializationRefreshScheduledJobDriver,
     RecordProcessScheduledJobDriver,
     UserRoutineDispatcherDriver,
 } from '@memberjunction/scheduling-engine';
 
-// @memberjunction/core-entities-server (41 classes)
+// @memberjunction/core-entities-server (42 classes)
 import {
     MJAIAgentCoAgentEntityServer,
     MJAIAgentEntityServer,
@@ -1225,6 +1228,7 @@ import {
     MJListDetailEntityServer,
     MJListEntityServer,
     MJMLTrainingPipelineEntityServer,
+    MJMaterializedResultEntityServer,
     MJQueryEntityServer,
     MJQuerySQLEntityServer,
     MJRecordProcessEntityServer,
@@ -1773,6 +1777,8 @@ export const CLASS_REGISTRATIONS: any[] = [
     MJMagicLinkInviteEntity,
     MJMagicLinkInviteRoleEntity,
     MJMagicLinkRedemptionEntity,
+    MJMaterializedResultEntity,
+    MJMaterializedResultQueryEntity,
     MJOAuthAuthServerMetadataCacheEntity,
     MJOAuthAuthorizationStateEntity,
     MJOAuthClientRegistrationEntity,
@@ -2224,6 +2230,7 @@ export const CLASS_REGISTRATIONS: any[] = [
     AgentScheduledJobDriver,
     IntegrationDiscoveryScheduledJobDriver,
     IntegrationSyncScheduledJobDriver,
+    MaterializationRefreshScheduledJobDriver,
     RecordProcessScheduledJobDriver,
     UserRoutineDispatcherDriver,
     MJAIAgentCoAgentEntityServer,
@@ -2254,6 +2261,7 @@ export const CLASS_REGISTRATIONS: any[] = [
     MJListDetailEntityServer,
     MJListEntityServer,
     MJMLTrainingPipelineEntityServer,
+    MJMaterializedResultEntityServer,
     MJQueryEntityServer,
     MJQuerySQLEntityServer,
     MJRecordProcessEntityServer,
@@ -2437,7 +2445,7 @@ export const CLASS_REGISTRATIONS: any[] = [
 export const CLASS_REGISTRATIONS_MANIFEST_LOADED = true;
 
 /** Total @RegisterClass decorated classes discovered in dependency tree */
-export const CLASS_REGISTRATIONS_COUNT = 989;
+export const CLASS_REGISTRATIONS_COUNT = 993;
 
 /** Packages imported by this manifest */
 export const CLASS_REGISTRATIONS_PACKAGES = [

--- a/packages/ServerBootstrapLite/src/generated/mj-class-registrations.ts
+++ b/packages/ServerBootstrapLite/src/generated/mj-class-registrations.ts
@@ -967,7 +967,7 @@ import {
     WorkflowValidateServerOperation,
 } from '@memberjunction/task-graph';
 
-// @memberjunction/scheduling-engine (8 classes)
+// @memberjunction/scheduling-engine (9 classes)
 import {
     ActionLogRetentionScheduledJobDriver,
     ActionScheduledJobDriver,
@@ -975,11 +975,12 @@ import {
     AgentScheduledJobDriver,
     IntegrationDiscoveryScheduledJobDriver,
     IntegrationSyncScheduledJobDriver,
+    MaterializationRefreshScheduledJobDriver,
     RecordProcessScheduledJobDriver,
     UserRoutineDispatcherDriver,
 } from '@memberjunction/scheduling-engine';
 
-// @memberjunction/core-entities-server (41 classes)
+// @memberjunction/core-entities-server (42 classes)
 import {
     MJAIAgentCoAgentEntityServer,
     MJAIAgentEntityServer,
@@ -1009,6 +1010,7 @@ import {
     MJListDetailEntityServer,
     MJListEntityServer,
     MJMLTrainingPipelineEntityServer,
+    MJMaterializedResultEntityServer,
     MJQueryEntityServer,
     MJQuerySQLEntityServer,
     MJRecordProcessEntityServer,
@@ -1904,6 +1906,7 @@ export const CLASS_REGISTRATIONS: any[] = [
     AgentScheduledJobDriver,
     IntegrationDiscoveryScheduledJobDriver,
     IntegrationSyncScheduledJobDriver,
+    MaterializationRefreshScheduledJobDriver,
     RecordProcessScheduledJobDriver,
     UserRoutineDispatcherDriver,
     MJAIAgentCoAgentEntityServer,
@@ -1934,6 +1937,7 @@ export const CLASS_REGISTRATIONS: any[] = [
     MJListDetailEntityServer,
     MJListEntityServer,
     MJMLTrainingPipelineEntityServer,
+    MJMaterializedResultEntityServer,
     MJQueryEntityServer,
     MJQuerySQLEntityServer,
     MJRecordProcessEntityServer,
@@ -2105,7 +2109,7 @@ export const CLASS_REGISTRATIONS: any[] = [
 export const CLASS_REGISTRATIONS_MANIFEST_LOADED = true;
 
 /** Total @RegisterClass decorated classes discovered in dependency tree */
-export const CLASS_REGISTRATIONS_COUNT = 905;
+export const CLASS_REGISTRATIONS_COUNT = 907;
 
 /** Packages imported by this manifest */
 export const CLASS_REGISTRATIONS_PACKAGES = [

--- a/packages/ServerBootstrapLite/src/generated/mj-class-registrations.ts
+++ b/packages/ServerBootstrapLite/src/generated/mj-class-registrations.ts
@@ -188,7 +188,7 @@ import {
     SQLServerVectorDatabase,
 } from '@memberjunction/ai-vectors-sqlserver';
 
-// @memberjunction/core-entities (400 classes)
+// @memberjunction/core-entities (402 classes)
 import {
     AIAgentPermissionProvider,
     AISkillPermissionProvider,
@@ -463,6 +463,8 @@ import {
     MJMagicLinkInviteEntity,
     MJMagicLinkInviteRoleEntity,
     MJMagicLinkRedemptionEntity,
+    MJMaterializedResultEntity,
+    MJMaterializedResultQueryEntity,
     MJOAuthAuthServerMetadataCacheEntity,
     MJOAuthAuthorizationStateEntity,
     MJOAuthClientRegistrationEntity,
@@ -1518,6 +1520,8 @@ export const CLASS_REGISTRATIONS: any[] = [
     MJMagicLinkInviteEntity,
     MJMagicLinkInviteRoleEntity,
     MJMagicLinkRedemptionEntity,
+    MJMaterializedResultEntity,
+    MJMaterializedResultQueryEntity,
     MJOAuthAuthServerMetadataCacheEntity,
     MJOAuthAuthorizationStateEntity,
     MJOAuthClientRegistrationEntity,
@@ -2109,7 +2113,7 @@ export const CLASS_REGISTRATIONS: any[] = [
 export const CLASS_REGISTRATIONS_MANIFEST_LOADED = true;
 
 /** Total @RegisterClass decorated classes discovered in dependency tree */
-export const CLASS_REGISTRATIONS_COUNT = 907;
+export const CLASS_REGISTRATIONS_COUNT = 909;
 
 /** Packages imported by this manifest */
 export const CLASS_REGISTRATIONS_PACKAGES = [

--- a/packages/TestingFramework/integration-test-suite/src/checks/materialized-entity-read.checks.ts
+++ b/packages/TestingFramework/integration-test-suite/src/checks/materialized-entity-read.checks.ts
@@ -127,7 +127,10 @@ export const MaterializedEntityReadChecks: NamedCheck[] = [
             const res = await readSentinel(ctx, 'Materialized');
             Assert(res.Success, `materialized RunView must succeed: ${res.ErrorMessage}`);
             Assert((res.Results?.length ?? 0) === 1, `EMR1: exactly the sentinel row must come back from the snapshot, got ${res.Results?.length}`);
-            Assert(UUIDsEqual(String(res.Results?.[0]?.ID ?? ''), SentinelID), 'EMR1: the returned row is the snapshot-only sentinel — proof the read hit the materialized view, not the live base view');
+            // UUIDsEqual (not AssertEqual) because the two sides can differ in casing across platforms; the
+            // expected/got detail AssertEqual would have appended is restated here so a failure stays diagnosable.
+            const returnedID = String(res.Results?.[0]?.ID ?? '');
+            Assert(UUIDsEqual(returnedID, SentinelID), `EMR1: the returned row is the snapshot-only sentinel — proof the read hit the materialized view, not the live base view — expected ${SentinelID}, got ${returnedID}`);
         },
     },
     {

--- a/packages/TestingFramework/integration-test-suite/src/checks/materialized-entity-read.checks.ts
+++ b/packages/TestingFramework/integration-test-suite/src/checks/materialized-entity-read.checks.ts
@@ -23,6 +23,7 @@ import { randomUUID } from 'node:crypto';
 import { RunView, Metadata, LogError } from '@memberjunction/core';
 import type { IMetadataProvider } from '@memberjunction/core';
 import type { MJMaterializedResultEntity } from '@memberjunction/core-entities';
+import { UUIDsEqual } from '@memberjunction/global';
 import { Assert, AssertEqual } from '@memberjunction/testing-integration';
 import { IntegrationCheckRegistry } from '@memberjunction/testing-integration';
 import { NamedCheck, IntegrationCheckContext } from '@memberjunction/testing-integration';
@@ -126,7 +127,7 @@ export const MaterializedEntityReadChecks: NamedCheck[] = [
             const res = await readSentinel(ctx, 'Materialized');
             Assert(res.Success, `materialized RunView must succeed: ${res.ErrorMessage}`);
             Assert((res.Results?.length ?? 0) === 1, `EMR1: exactly the sentinel row must come back from the snapshot, got ${res.Results?.length}`);
-            AssertEqual(String(res.Results?.[0]?.ID ?? '').toLowerCase(), SentinelID.toLowerCase(), 'EMR1: the returned row is the snapshot-only sentinel — proof the read hit the materialized view, not the live base view');
+            Assert(UUIDsEqual(String(res.Results?.[0]?.ID ?? ''), SentinelID), 'EMR1: the returned row is the snapshot-only sentinel — proof the read hit the materialized view, not the live base view');
         },
     },
     {


### PR DESCRIPTION
Follow-up to the Query & Entity Materialization rework (#3735, merged). What began as three test-side fixes that landed after that branch was squash-merged grew, via review and self-audit passes, into a set of **runtime security and correctness fixes** to the shipped feature.

> **Scope note:** this PR is **not** test-only. It changes runtime behavior in `codegen-lib`, `generic-database-provider` and `materialization`, adds missing registrations to both pre-built server manifests, and corrects generated Angular form artifacts. An earlier version of this description said "test-only, no runtime impact" — that was wrong, and is corrected here.

Every item below shares a shape: it **fails toward doing the wrong thing rather than doing nothing**, so none of them surface as an error in normal operation.

---

## Row-restriction gates were reading half the fence

MJ enforces row restrictions in **two AND-composed layers** (`EntityInfo.GetEffectiveRowFilterWhereClause`): role RLS *and* API-key row filters. The mint, drift and runtime Leak-1 gates each re-derived a **role-only** predicate inline from raw field access. `EntityInfo` marks the equivalent accessor deprecated precisely because it omits the API-key layer, and a repo test asserts nothing calls it — so re-deriving the predicate *evaded* that test rather than satisfying it.

The consequence is a real leak. An entity fenced **only** by an API-key row filter carries no `ReadRLSFilterID`, so it read as unprotected. The mint then gives the materialized entity a **new EntityID**, which the key's EntityID-keyed binding no longer matches — handing a filtered principal a full unscoped snapshot of rows it cannot read live.

All gates now compose both layers behind one predicate, enumerating the key layer once per run. **An unproven layer counts as restricted**, in both CodeGen and the runtime refresher.

## Lost provenance silently disarmed the drift guards

`spDeleteQuery` cascade-deletes the `MaterializedResultQuery` join row, but everything that row protected **survives**: the `MaterializedResult`, the minted read-only entity, its read grants, and the already-populated table. With a NULL `QueryID` the C1 RLS re-check and C2 grant re-narrow were both unreachable, the fact-gatherer returned all-empty, drift evaluated to `false`, and `Status` stayed `Active` — so the guard whose whole job is revoke-then-hold could never fire again. Lost provenance is now itself drift: revoke, then hold.

## Drift held every external base-view materialization, permanently

Drift compared the entity's **full** field list against columns the mint had deliberately built **without** virtual fields. Every external base-view materialization holding a virtual field therefore looked drifted on its very first run → `DriftHold` → and because held rows are excluded from the sweep, it could never recover. Both sites now share one predicate (`materializedEntityFields`).

## A zero-row external query destroyed the snapshot

Columns are derived from the returned rows, so an empty result produced a shadow holding only the surrogate — then the swap dropped the canonical table and renamed that one-column shell into its place. Every subsequent read failed on a missing column while the refresh reported **success**. An empty result now refuses the rebuild and leaves the existing snapshot serving, with the failure visible and backed off.

## The refresher materialized a different statement than live serves

Every read path executes `QueryInfo.GetPlatformSQL(PlatformKey)`; the refresher snapshotted the base `query.SQL`. A query carrying a per-platform variant was materialized from a **different statement** than live serves — the one invariant materialization exists to hold. Resolution now mirrors the read path, matching the query through `UUIDsEqual` so it survives cross-platform ID casing.

## `XACT_ABORT` escaped onto the pooled connection

The swap, recompute and dirty-group batches each `SET XACT_ABORT ON` so a mid-transaction error rolls back instead of leaving a transaction open. Nothing ever set it back. SET options persist for the **session**, and the pool hands the same physical connection to unrelated requests — which silently inherited `ON`, turning their recoverable statement-level errors into full transaction aborts, with the symptom surfacing far from materialization and looking nondeterministic.

Each batch now restores the default after `COMMIT`. A batch that aborts mid-swap never reaches that line, so the failure path also resets best-effort (a no-op on PostgreSQL, which has no such setting). Note the failure-path reset is genuinely best-effort — the pool may hand back a different connection than the one poisoned; the trailing reset **inside** each batch is the half guaranteed to run where it matters.

## The DDL identifier guard opened on its own failure

`assertSafeObjectNames` throws on a tampered `SchemaName` read from the writable metadata row — but the `RefreshOne` catch block then passed that **same rejected name** to the best-effort shadow cleanup, which interpolated it raw into `DROP TABLE` / `OBJECT_ID`. The guard's rejection was precisely what routed the payload into privileged DDL. The cleanup now re-checks with a non-throwing predicate and declines; declining loses nothing, because the assertion fires before any shadow table can exist.

## Two analyzers produced silently wrong rows

Both are invisible to the existing count guard, which strips exactly one predicate in each wrong case.

- **Set operations.** `node-sql-parser` emits no distinct union node: a `UNION`/`EXCEPT`/`INTERSECT` is a single `select` root carrying `set_op`/`_next` whose `groupby` and `columns` describe **only the first branch**. `extractGroupByTerms` read that root as a plain statement, so a UNION of two grouped branches yielded a key covering one of them — and the incremental MERGE then keyed both branches' rows to the same hash, one silently overwriting the other. The sibling verifier already had the guard; it is now shared, and the caller degrades to `FullRebuild`.
- **Predicate binding.** `columnName` discarded the table qualifier while the gate matched the bare name against SELECT-list aliases. A join could bind a predicate to a same-named column of a **different table** (`WHERE o.Status` vs. projected `c.Status`), and an alias could rebind it to a different source column entirely (`ShipRegion AS BillRegion`). The materialized read then filtered a different column than live, with no error. Binding must now be **proven**: same source column, one consistent qualifier, and a qualifier that demonstrably denotes the same relation. What cannot be proven is refused, which falls back to live and is always correct.

## Parts that only fail once it ships

- **Missing manifest registrations.** Neither new `@RegisterClass` class was in the pre-built manifests, so a bundled MJAPI tree-shook both away: the refresh driver never resolved, nothing was ever refreshed, and `Status` stayed `Active` — the read paths serving mint-time data forever, with no error and no fallback. Both are added to **both** manifests, along with two entity classes the generator itself found.
- **Generated Query form was broken for every Query record.** The form still bound `MaterializedResultID` and a related section keyed on `SourceQueryID`; the join-table redesign deleted both columns and the Angular artifacts were never regenerated. Both bindings are removed. The migration marks the join relationship `DisplayInForm`, so a future CodeGen run will emit a *Materialized Result Queries* panel in its place — this change does not hand-write that panel, so expect that file to change again on the next codegen pass.
- **Read-routing treated a failed lookup as proof of nothing materialized.** Only three roles hold `CanRead` on `MJ: Materialized Results`, so a restricted user (including the magic-link / external-access pattern) silently got live data for every materialized request while an admin got the snapshot — two users, two answers, no error either side. Falling back to live stays correct; the silence does not. All three sites now log it. The lookup is gated on `DataSource:'Materialized'`, so this does not add logging to ordinary reads.

## The original three test-side fixes

1. **IT78 carried the UUID compare that was fixed in IT79.** #3735 routed `ensureQueryMetadata`/`containsSentinel` in the IT79 bundle through `UUIDsEqual`; the sibling IT78 (`materialized-entity-read`) had the same hand-rolled comparison in EMR1. The repo-wide `UUIDCompliance` scanner matches `===`/`!==`, not `AssertEqual(...toLowerCase(), ...toLowerCase())`, so it slipped the scan. Now that the integration tier also runs on PostgreSQL, a raw string compare across platforms with different UUID casing is a real hazard rather than a style point.
2. **…which quietly cost the failure diagnostics.** `AssertEqual` appends `— expected X, got Y`; a bare `Assert` throws the message alone. The expected/got detail is restated in the message so a snapshot-read regression still names the offending ID.
3. **Two `any`s removed** from the materialization tests, replaced by structural stubs via the sanctioned `as unknown as EntityInfo` double-cast and a fixture type derived from the real signature.

## Follow-up: sharing the rules the gates must agree on

Three de-duplications after review, no behavior change intended in any:

- The **ResourcePattern mappability rule** existed twice — CodeGen's enumeration and the refresher's — each carrying a comment that it must stay character-identical to the other, which is an admission that nothing enforced it. Both now call `ResolveSingleEntityResourceTarget` in `@memberjunction/global`. The rule fails **open** when it drifts (a wrongly-accepted pattern is stored as a literal target name, matches no entity, and leaves the entity it fences reading as unrestricted), so construction beats convention here.
- Its **test was a third copy** — it re-declared the regex and a local helper inside the refresher's test file and asserted against those, exercising no production code. Replaced by tests against the real exported function, including the `?` case whose omission is the specific fail-open the rule exists to prevent.
- **`columnExistsInCoreSchema`** documented itself as generalizing the hand-rolled column probes while all three remained hand-rolled — a fourth copy, not a generalization. The three now delegate to it; caching semantics are unchanged (shared `Map` keyed `table.column`, all four keys distinct).

A **regression test** now pins the mint/drift column-set symmetry — the one fix here whose failure mode was both silent and terminal (`DriftHold` is excluded from the sweep, so the verdict could never be revisited). It drives the real `gatherDriftFacts` into the real `evaluateMaterializationDrift`, and was verified to actually catch the defect: restoring `entity.Fields` fails two cases with messages naming the virtual field. Four further cases guard the other direction so the fix cannot become a stealth drift-disable.

A **changeset** is included (`patch` — the branch touches no migration and no metadata).

---

## Behavior change worth knowing

The predicate-binding proof and the join-qualifier requirement are deliberately conservative and **will refuse shapes that previously qualified**:

- a row-filter query whose predicate or projection is unqualified across a join now stays **live-only**;
- an aggregation over a join with an unqualified `GROUP BY` loses its incremental key and falls back to **`FullRebuild`**.

Both refusals log the specific reason. Falling back to live is always correct — but a query that silently gets *slower* is easier to diagnose knowing this changed.

## Verification

Locally re-verified on this `next` base, at the current head of the branch:

| Package | Result |
|---|---|
| `@memberjunction/codegen-lib` | 1005 passed / 66 skipped |
| `@memberjunction/global` | 647 passed (incl. the `UUIDCompliance` and multi-provider scanners) |
| `@memberjunction/materialization` | 118 passed |
| `@memberjunction/integration-test-suite` | 183 passed (check-registry + sibling-parity guards included) |

`codegen-lib`, `materialization`, `global` and `integration-test-suite` all build clean, and `check:changeset` passes. CI on the pre-follow-up head was fully green — unit tests, deterministic integration tier (SQL Server), migrations, adopted standards, dependency and ngc gates — and is re-running for the two follow-up commits.

*(The `materialization` count drops from 121 to 118 and `global` rises from 640 to 647 because the three tautological tests moved to `@memberjunction/global` as seven real ones.)*

🤖 Generated with [Claude Code](https://claude.com/claude-code)
