### PR TITLE
feat(cli): mj dev workspace doctor — health checks with one-copy census

### DIFF
--- a/.changeset/feat-dev-workspace-doctor.md
+++ b/.changeset/feat-dev-workspace-doctor.md
@@ -1,0 +1,5 @@
+---
+"@memberjunction/cli": patch
+---
+
+New `mj dev workspace doctor`: a read-only health check for a generated cross-repo workspace that prints PASS/WARN/FAIL/SKIP per check and exits non-zero on any failure — including a one-copy census of the parent package store that fails when more than one version of `@angular/core`, `@angular/common`, `@angular/compiler`, `rxjs`, `zone.js`, `@memberjunction/core` or `@memberjunction/global` is installed.

--- a/packages/MJCLI/src/__tests__/dev-workspace-commands.test.ts
+++ b/packages/MJCLI/src/__tests__/dev-workspace-commands.test.ts
@@ -13,6 +13,7 @@ describe('dev workspace command modules load cleanly', () => {
       import('../commands/dev/index.js'),
       import('../commands/dev/workspace/index.js'),
       import('../commands/dev/workspace/status.js'),
+      import('../commands/dev/workspace/doctor.js'),
       import('../commands/dev/workspace/clean.js'),
     ]);
     for (const mod of modules) {
@@ -42,12 +43,14 @@ describe('dev workspace flag defaults', () => {
     expect(DevWorkspace.examples.join('\n')).not.toContain('hoist');
   });
 
-  it('dir defaults to the current directory on all three commands', async () => {
+  it('dir defaults to the current directory on all four commands', async () => {
     const { default: DevWorkspace } = await import('../commands/dev/workspace/index.js');
     const { default: DevWorkspaceStatus } = await import('../commands/dev/workspace/status.js');
+    const { default: DevWorkspaceDoctor } = await import('../commands/dev/workspace/doctor.js');
     const { default: DevWorkspaceClean } = await import('../commands/dev/workspace/clean.js');
     expect(DevWorkspace.flags.dir.default).toBe('.');
     expect(DevWorkspaceStatus.flags.dir.default).toBe('.');
+    expect(DevWorkspaceDoctor.flags.dir.default).toBe('.');
     expect(DevWorkspaceClean.flags.dir.default).toBe('.');
   });
 
@@ -80,11 +83,30 @@ describe('dev workspace clean flag defaults', () => {
   });
 });
 
+describe('dev workspace doctor flags', () => {
+  it('takes --dir and nothing else — doctor diagnoses, it never changes behavior', async () => {
+    const { default: DevWorkspaceDoctor } = await import('../commands/dev/workspace/doctor.js');
+    expect(Object.keys(DevWorkspaceDoctor.flags)).toEqual(['dir']);
+  });
+
+  it('binds --dir to the shared environment variable', async () => {
+    const { default: DevWorkspaceDoctor } = await import('../commands/dev/workspace/doctor.js');
+    expect(DevWorkspaceDoctor.flags.dir.env).toBe('MJ_DEV_WORKSPACE_DIR');
+  });
+
+  it('describes itself as read-only with a non-zero exit on failure', async () => {
+    const { default: DevWorkspaceDoctor } = await import('../commands/dev/workspace/doctor.js');
+    expect(DevWorkspaceDoctor.description).toMatch(/Read-only/);
+    expect(DevWorkspaceDoctor.description).toMatch(/exits non-zero/);
+  });
+});
+
 describe('light-command registration', () => {
   it('dev commands run without the MJ bootstrap', () => {
     expect(LIGHT_COMMANDS.has('dev')).toBe(true);
     expect(LIGHT_COMMANDS.has('dev workspace')).toBe(true);
     expect(LIGHT_COMMANDS.has('dev workspace status')).toBe(true);
+    expect(LIGHT_COMMANDS.has('dev workspace doctor')).toBe(true);
     expect(LIGHT_COMMANDS.has('dev workspace clean')).toBe(true);
   });
 });

--- a/packages/MJCLI/src/__tests__/dev-workspace.doctor.test.ts
+++ b/packages/MJCLI/src/__tests__/dev-workspace.doctor.test.ts
@@ -1,0 +1,352 @@
+/**
+ * Tests for the workspace health check (src/lib/dev-workspace/doctor.ts).
+ * Collection runs against temp fixtures; store-name parsing and rendering are
+ * pure. The pnpm version is injected — no spawns, and doctor writes nothing.
+ */
+import { afterEach, describe, expect, it } from 'vitest';
+import { mkdirSync, writeFileSync } from 'node:fs';
+import path from 'node:path';
+import { BuildSentinel, BuildWorkspaceYaml } from '../lib/dev-workspace/build.js';
+import {
+  CollectDoctorReport,
+  CollectSingletonCensus,
+  DoctorHasFailures,
+  ParseStoreEntry,
+  RenderDoctor,
+  SINGLETON_PACKAGES,
+} from '../lib/dev-workspace/doctor.js';
+import type { DoctorCheck, DoctorReport } from '../lib/dev-workspace/doctor.js';
+import { CreateFixtureParent, RemoveFixture } from './dev-workspace-fixture.js';
+
+let parent: string | null = null;
+
+afterEach(() => {
+  if (parent !== null) RemoveFixture(parent);
+  parent = null;
+});
+
+/** Creates `<parent>/node_modules/.pnpm/<entry>` for each virtual-store entry name. */
+function writeStore(parentDir: string, entryNames: readonly string[]): void {
+  const storeDir = path.join(parentDir, 'node_modules', '.pnpm');
+  mkdirSync(storeDir, { recursive: true });
+  for (const entryName of entryNames) {
+    mkdirSync(path.join(storeDir, entryName), { recursive: true });
+  }
+}
+
+/** Writes the four generated files, the sentinel and a lockfile for the given members. */
+function writeGeneratedWorkspace(parentDir: string, members: readonly string[]): void {
+  const yaml = BuildWorkspaceYaml(members.map((Name) => ({ Name, WorkspaceGlobs: ['packages/*'] })));
+  writeFileSync(path.join(parentDir, 'pnpm-workspace.yaml'), yaml, 'utf8');
+  writeFileSync(path.join(parentDir, '.npmrc'), 'node-linker=isolated\n', 'utf8');
+  writeFileSync(path.join(parentDir, 'package.json'), JSON.stringify({ packageManager: 'pnpm@10.33.0' }), 'utf8');
+  writeFileSync(path.join(parentDir, 'turbo.json'), '{}', 'utf8');
+  writeFileSync(path.join(parentDir, 'pnpm-lock.yaml'), 'lockfileVersion: 9.0\n', 'utf8');
+  writeFileSync(path.join(parentDir, '.mj-dev-workspace.json'), BuildSentinel(['package.json'], [...members]), 'utf8');
+}
+
+/** The named check, or a failure that names what was actually collected. */
+function checkNamed(report: DoctorReport, name: string): DoctorCheck {
+  const found = report.Checks.find((check) => check.Name === name);
+  if (found === undefined) {
+    throw new Error(`no check named '${name}'; got: ${report.Checks.map((c) => c.Name).join(', ')}`);
+  }
+  return found;
+}
+
+describe('ParseStoreEntry', () => {
+  it('reads an unscoped entry', () => {
+    expect(ParseStoreEntry('rxjs@7.8.1')).toEqual({ Name: 'rxjs', Version: '7.8.1' });
+  });
+
+  it('decodes the + scope separator', () => {
+    expect(ParseStoreEntry('@angular+core@21.1.3')).toEqual({ Name: '@angular/core', Version: '21.1.3' });
+  });
+
+  it('strips a peer suffix that itself contains @ — the last-@ parse would be wrong here', () => {
+    const entry = '@angular+common@21.1.3(@angular+core@21.1.3)(rxjs@7.8.1)';
+    expect(ParseStoreEntry(entry)).toEqual({ Name: '@angular/common', Version: '21.1.3' });
+
+    // proof the naive rule the parser deliberately avoids really does break:
+    const naiveVersion = entry.slice(entry.lastIndexOf('@') + 1);
+    expect(naiveVersion).not.toBe('21.1.3');
+  });
+
+  it('strips an underscore peer suffix (semver forbids _, so a real version survives)', () => {
+    expect(ParseStoreEntry('rxjs@7.8.1_typescript@5.9.2')).toEqual({ Name: 'rxjs', Version: '7.8.1' });
+  });
+
+  it('reads the shape pnpm 10.33 actually writes — copied verbatim from a real store', () => {
+    // `ls node_modules/.pnpm | grep @angular+core` in this repo's own install:
+    const entry = '@angular+core@21.1.3_@angular+compiler@21.1.3_rxjs@7.8.2_zone.js@0.16.0';
+    expect(ParseStoreEntry(entry)).toEqual({ Name: '@angular/core', Version: '21.1.3' });
+
+    // the last-@ rule would report a DIFFERENT package's version as @angular/core's:
+    expect(entry.slice(entry.lastIndexOf('@') + 1)).toBe('0.16.0');
+  });
+
+  it('keeps an underscore that belongs to the package name', () => {
+    expect(ParseStoreEntry('some_pkg@1.0.0')).toEqual({ Name: 'some_pkg', Version: '1.0.0' });
+  });
+
+  it('keeps a prerelease version intact', () => {
+    expect(ParseStoreEntry('zone.js@0.15.1-next.0')).toEqual({ Name: 'zone.js', Version: '0.15.1-next.0' });
+  });
+
+  it('returns null for the store\'s own node_modules directory', () => {
+    expect(ParseStoreEntry('node_modules')).toBeNull();
+  });
+
+  it('returns null for file:/link: entries, whose version segment is not a version', () => {
+    expect(ParseStoreEntry('file+..+bizapps-common@file+..+bizapps-common')).toBeNull();
+  });
+
+  it('returns null for a scoped name with no version', () => {
+    expect(ParseStoreEntry('@memberjunction+global')).toBeNull();
+  });
+});
+
+describe('CollectSingletonCensus', () => {
+  it('reports no store when the parent has never been installed', () => {
+    parent = CreateFixtureParent({ 'bizapps-x': { RootPackageJson: { name: 'x' }, MjAppJson: true } });
+    const census = CollectSingletonCensus(parent);
+    expect(census.StorePresent).toBe(false);
+    expect(census.Packages).toEqual([]);
+  });
+
+  it('finds exactly one version of each singleton in a healthy store', () => {
+    parent = CreateFixtureParent({ 'bizapps-x': { RootPackageJson: { name: 'x' }, MjAppJson: true } });
+    writeStore(parent, [
+      '@angular+core@21.1.3_@angular+compiler@21.1.3_rxjs@7.8.1_zone.js@0.15.1', // pnpm 10 underscore form
+      '@angular+common@21.1.3(@angular+core@21.1.3)(rxjs@7.8.1)', // parenthesised form
+      'rxjs@7.8.1',
+      'zone.js@0.15.1',
+      '@memberjunction+global@6.1.0',
+      'lodash@4.17.21',
+      'node_modules',
+    ]);
+    const census = CollectSingletonCensus(parent);
+    expect(census.StorePresent).toBe(true);
+    expect(census.Packages).toEqual([
+      { Package: '@angular/core', Versions: ['21.1.3'] },
+      { Package: '@angular/common', Versions: ['21.1.3'] },
+      { Package: 'rxjs', Versions: ['7.8.1'] },
+      { Package: 'zone.js', Versions: ['0.15.1'] },
+      { Package: '@memberjunction/global', Versions: ['6.1.0'] },
+    ]);
+    expect(census.UnparsedEntryCount).toBe(1); // node_modules
+  });
+
+  it('counts distinct versions of a duplicated singleton, sorted', () => {
+    parent = CreateFixtureParent({ 'bizapps-x': { RootPackageJson: { name: 'x' }, MjAppJson: true } });
+    writeStore(parent, ['rxjs@7.8.1', 'rxjs@6.6.7', 'rxjs@7.8.1(typescript@5.9.2)']);
+    const census = CollectSingletonCensus(parent);
+    expect(census.Packages).toEqual([{ Package: 'rxjs', Versions: ['6.6.7', '7.8.1'] }]);
+  });
+
+  it('ignores files in the store directory — only directory names are package resolutions', () => {
+    parent = CreateFixtureParent({ 'bizapps-x': { RootPackageJson: { name: 'x' }, MjAppJson: true } });
+    writeStore(parent, ['rxjs@7.8.1']);
+    writeFileSync(path.join(parent, 'node_modules', '.pnpm', 'rxjs@9.9.9'), 'not a package', 'utf8');
+    expect(CollectSingletonCensus(parent).Packages).toEqual([{ Package: 'rxjs', Versions: ['7.8.1'] }]);
+  });
+
+  it('rejects a relative parent path', () => {
+    expect(() => CollectSingletonCensus('relative/dir')).toThrow(/absolute/);
+  });
+});
+
+describe('CollectDoctorReport', () => {
+  it('passes every check on a generated, installed, single-copy workspace', () => {
+    parent = CreateFixtureParent({ 'bizapps-x': { RootPackageJson: { name: 'x' }, MjAppJson: true } });
+    writeGeneratedWorkspace(parent, ['bizapps-x']);
+    writeStore(parent, ['@angular+core@21.1.3', 'rxjs@7.8.1']);
+
+    const report = CollectDoctorReport(parent, '10.33.0', 'flag');
+    expect(DoctorHasFailures(report)).toBe(false);
+    expect(checkNamed(report, 'one-copy census').Severity).toBe('pass');
+    expect(checkNamed(report, 'workspace files').Severity).toBe('pass');
+    expect(checkNamed(report, 'sentinel').Severity).toBe('pass');
+    expect(checkNamed(report, 'pnpm version').Severity).toBe('pass');
+    expect(checkNamed(report, 'member dirs').Severity).toBe('pass');
+    expect(checkNamed(report, 'candidates').Severity).toBe('pass');
+    expect(checkNamed(report, 'standalone installs').Severity).toBe('pass');
+  });
+
+  it('FAILS the census and names both versions when two rxjs copies are installed', () => {
+    parent = CreateFixtureParent({ 'bizapps-x': { RootPackageJson: { name: 'x' }, MjAppJson: true } });
+    writeGeneratedWorkspace(parent, ['bizapps-x']);
+    writeStore(parent, ['rxjs@7.8.1', 'rxjs@6.6.7']);
+
+    const report = CollectDoctorReport(parent, '10.33.0', 'flag');
+    const census = checkNamed(report, 'one-copy census');
+    expect(census.Severity).toBe('fail');
+    expect(census.Detail).toContain('rxjs (6.6.7, 7.8.1)');
+    expect(census.Detail).toContain('mj dev workspace --force');
+    expect(DoctorHasFailures(report)).toBe(true);
+  });
+
+  it('FAILS on a member carrying a standalone install, and names the fix', () => {
+    parent = CreateFixtureParent({
+      'bizapps-forked': { RootPackageJson: { name: 'forked' }, MjAppJson: true },
+      'bizapps-npm': { RootPackageJson: { name: 'npmish' }, MjAppJson: true },
+    });
+    writeGeneratedWorkspace(parent, ['bizapps-forked', 'bizapps-npm']);
+    writeStore(parent, ['rxjs@7.8.1']);
+    mkdirSync(path.join(parent, 'bizapps-forked', 'node_modules', '.pnpm'), { recursive: true });
+    mkdirSync(path.join(parent, 'bizapps-npm', 'node_modules'), { recursive: true });
+    writeFileSync(path.join(parent, 'bizapps-npm', 'node_modules', '.package-lock.json'), '{}', 'utf8');
+
+    const report = CollectDoctorReport(parent, '10.33.0', 'flag');
+    const standalone = checkNamed(report, 'standalone installs');
+    expect(standalone.Severity).toBe('fail');
+    expect(standalone.Detail).toContain('bizapps-forked');
+    expect(standalone.Detail).toContain('bizapps-npm');
+    expect(standalone.Detail).toContain('--clean-members');
+    expect(DoctorHasFailures(report)).toBe(true);
+  });
+
+  it('does NOT call a plain member node_modules a standalone install (the parent install creates those)', () => {
+    parent = CreateFixtureParent({ 'bizapps-linked': { RootPackageJson: { name: 'linked' }, MjAppJson: true } });
+    writeGeneratedWorkspace(parent, ['bizapps-linked']);
+    writeStore(parent, ['rxjs@7.8.1']);
+    mkdirSync(path.join(parent, 'bizapps-linked', 'node_modules', '@memberjunction'), { recursive: true });
+
+    const report = CollectDoctorReport(parent, '10.33.0', 'flag');
+    expect(checkNamed(report, 'standalone installs').Severity).toBe('pass');
+    expect(DoctorHasFailures(report)).toBe(false);
+  });
+
+  it('FAILS when a workspace member has no directory on disk', () => {
+    parent = CreateFixtureParent({ 'bizapps-x': { RootPackageJson: { name: 'x' }, MjAppJson: true } });
+    writeGeneratedWorkspace(parent, ['bizapps-x', 'ghost-repo']);
+    writeStore(parent, ['rxjs@7.8.1']);
+
+    const report = CollectDoctorReport(parent, '10.33.0', 'flag');
+    const members = checkNamed(report, 'member dirs');
+    expect(members.Severity).toBe('fail');
+    expect(members.Detail).toContain('ghost-repo');
+    expect(DoctorHasFailures(report)).toBe(true);
+  });
+
+  it('WARNS about a detected repo that is not a workspace member', () => {
+    parent = CreateFixtureParent({
+      'bizapps-x': { RootPackageJson: { name: 'x' }, MjAppJson: true },
+      'bizapps-y': { RootPackageJson: { name: 'y' }, MjAppJson: true },
+    });
+    writeGeneratedWorkspace(parent, ['bizapps-x']);
+    writeStore(parent, ['rxjs@7.8.1']);
+
+    const report = CollectDoctorReport(parent, '10.33.0', 'flag');
+    const candidates = checkNamed(report, 'candidates');
+    expect(candidates.Severity).toBe('warn');
+    expect(candidates.Detail).toContain('bizapps-y');
+    expect(DoctorHasFailures(report)).toBe(false); // a narrower workspace is not a broken one
+  });
+
+  it('on a bare parent: files FAIL, install WARNs, and the census SKIPs rather than passing', () => {
+    parent = CreateFixtureParent({ 'bizapps-x': { RootPackageJson: { name: 'x' }, MjAppJson: true } });
+
+    const report = CollectDoctorReport(parent, '10.33.0', 'default');
+    expect(checkNamed(report, 'workspace files').Severity).toBe('fail');
+    expect(checkNamed(report, 'workspace files').Detail).toContain('mj dev workspace --dir');
+    expect(checkNamed(report, 'install').Severity).toBe('warn');
+    expect(checkNamed(report, 'sentinel').Severity).toBe('warn');
+    expect(checkNamed(report, 'pnpm version').Severity).toBe('skip');
+    expect(checkNamed(report, 'member dirs').Severity).toBe('skip');
+    expect(checkNamed(report, 'one-copy census').Severity).toBe('skip');
+    expect(DoctorHasFailures(report)).toBe(true);
+  });
+
+  it('SKIPs the census when the store holds none of the single-copy packages', () => {
+    parent = CreateFixtureParent({ 'bizapps-x': { RootPackageJson: { name: 'x' }, MjAppJson: true } });
+    writeGeneratedWorkspace(parent, ['bizapps-x']);
+    writeStore(parent, ['lodash@4.17.21', 'chalk@5.6.2']);
+
+    const census = checkNamed(CollectDoctorReport(parent, '10.33.0', 'flag'), 'one-copy census');
+    expect(census.Severity).toBe('skip');
+  });
+
+  it('FAILS when the parent directory is itself a git repo root', () => {
+    parent = CreateFixtureParent({ 'bizapps-x': { RootPackageJson: { name: 'x' }, MjAppJson: true } });
+    mkdirSync(path.join(parent, '.git'), { recursive: true });
+
+    const report = CollectDoctorReport(parent, '10.33.0', 'flag');
+    expect(checkNamed(report, 'parent directory').Severity).toBe('fail');
+    expect(DoctorHasFailures(report)).toBe(true);
+  });
+
+  it('WARNS on a pnpm pin/active mismatch without failing the run', () => {
+    parent = CreateFixtureParent({ 'bizapps-x': { RootPackageJson: { name: 'x' }, MjAppJson: true } });
+    writeGeneratedWorkspace(parent, ['bizapps-x']);
+    writeStore(parent, ['rxjs@7.8.1']);
+
+    const report = CollectDoctorReport(parent, '9.15.0', 'flag');
+    const pnpmCheck = checkNamed(report, 'pnpm version');
+    expect(pnpmCheck.Severity).toBe('warn');
+    expect(pnpmCheck.Detail).toContain('MISMATCH');
+    expect(DoctorHasFailures(report)).toBe(false);
+  });
+
+  it('rejects a relative parent path', () => {
+    expect(() => CollectDoctorReport('relative/dir', null, 'default')).toThrow(/absolute/);
+  });
+});
+
+/** A report literal the render tests mutate per-case. */
+function baseReport(): DoctorReport {
+  return {
+    ParentDir: '/the/parent',
+    DirSource: 'flag',
+    Census: { StorePresent: true, Packages: [{ Package: 'rxjs', Versions: ['7.8.1'] }], UnparsedEntryCount: 0 },
+    Checks: [
+      { Name: 'workspace files', Severity: 'pass', Detail: 'all 4 generated files present' },
+      { Name: 'install', Severity: 'warn', Detail: 'missing pnpm-lock.yaml — run `pnpm install`' },
+      { Name: 'pnpm version', Severity: 'skip', Detail: 'no pnpm pin at the parent' },
+    ],
+  };
+}
+
+describe('RenderDoctor', () => {
+  it('prints one tagged line per check, with the check name and detail', () => {
+    const out = RenderDoctor(baseReport());
+    expect(out).toContain('[PASS] workspace files: all 4 generated files present');
+    expect(out).toContain('[WARN] install:');
+    expect(out).toContain('[SKIP] pnpm version:');
+  });
+
+  it('heads the report with the parent and how --dir was resolved', () => {
+    const out = RenderDoctor(baseReport());
+    expect(out).toContain('Workspace doctor: /the/parent');
+    expect(out).toContain('resolved from: --dir flag');
+  });
+
+  it('summarises the counts and says there were no failures', () => {
+    const out = RenderDoctor(baseReport());
+    expect(out).toContain('1 passed, 1 warned, 0 failed, 1 skipped');
+    expect(out).toContain('no failures');
+  });
+
+  it('tags a failure and states that doctor exits non-zero', () => {
+    const report = baseReport();
+    report.Checks.push({ Name: 'one-copy census', Severity: 'fail', Detail: 'rxjs (6.6.7, 7.8.1)' });
+    const out = RenderDoctor(report);
+    expect(out).toContain('[FAIL] one-copy census: rxjs (6.6.7, 7.8.1)');
+    expect(out).toContain('1 failed');
+    expect(out).toContain('doctor exits non-zero');
+  });
+});
+
+describe('SINGLETON_PACKAGES', () => {
+  it('covers the packages whose second copy is a second runtime', () => {
+    expect(SINGLETON_PACKAGES).toEqual([
+      '@angular/core',
+      '@angular/common',
+      '@angular/compiler',
+      'rxjs',
+      'zone.js',
+      '@memberjunction/core',
+      '@memberjunction/global',
+    ]);
+  });
+});

--- a/packages/MJCLI/src/__tests__/dev-workspace.usage.test.ts
+++ b/packages/MJCLI/src/__tests__/dev-workspace.usage.test.ts
@@ -13,6 +13,7 @@ import { CLIPluginRegistry } from '@memberjunction/cli-core';
 import {
   DEV_DOMAIN_USAGE,
   DEV_WORKSPACE_CLEAN_USAGE,
+  DEV_WORKSPACE_DOCTOR_USAGE,
   DEV_WORKSPACE_STATUS_USAGE,
   DEV_WORKSPACE_USAGE,
   RegisterDevWorkspaceUsage,
@@ -21,10 +22,11 @@ import { WORKSPACE_DIR_ENV_VAR } from '../lib/dev-workspace/dir-flag.js';
 import { LIGHT_COMMANDS } from '../light-commands.js';
 
 describe('dev domain usage declarations', () => {
-  it('declares all three commands under the dev domain', () => {
+  it('declares all four commands under the dev domain', () => {
     expect(DEV_DOMAIN_USAGE.map((u) => u.command)).toEqual([
       'dev:workspace',
       'dev:workspace:status',
+      'dev:workspace:doctor',
       'dev:workspace:clean',
     ]);
     for (const usage of DEV_DOMAIN_USAGE) {
@@ -83,6 +85,19 @@ describe('dev domain usage declarations', () => {
     );
   });
 
+  it('teaches doctor: the non-zero exit, the census, and what a standalone install actually is', () => {
+    const text = DEV_WORKSPACE_DOCTOR_USAGE.description ?? '';
+    expect(text).toMatch(/read-only/i);
+    expect(text).toMatch(/exits non-zero/i);
+    expect(text).toContain('@angular/core');
+    expect(text).toContain('@memberjunction/global');
+    expect(text).toContain('one-copy census');
+    // the trap: a plain member node_modules is NOT a standalone install
+    expect(text).toContain('.package-lock.json');
+    expect(text).toMatch(/NOT the plain node_modules/);
+    expect(DEV_WORKSPACE_DOCTOR_USAGE.flags?.map((f) => f.name)).toEqual(['--dir']);
+  });
+
   it('marks status as read-only and mentions the dir-resolution report', () => {
     const text = DEV_WORKSPACE_STATUS_USAGE.description ?? '';
     expect(text).toMatch(/read-only/i);
@@ -100,6 +115,7 @@ describe('dev domain usage declarations', () => {
     expect(DEV_WORKSPACE_USAGE.runtime.class).toBe('variable');
     expect(DEV_WORKSPACE_USAGE.runtime.note).toMatch(/pnpm install/);
     expect(DEV_WORKSPACE_STATUS_USAGE.runtime.class).toBe('fast');
+    expect(DEV_WORKSPACE_DOCTOR_USAGE.runtime.class).toBe('fast');
     expect(DEV_WORKSPACE_CLEAN_USAGE.runtime.class).toBe('moderate');
   });
 });
@@ -111,6 +127,7 @@ describe('dev domain registration with the usage registry', () => {
     expect(detail.commands.map((c) => c.command).sort()).toEqual([
       'dev:workspace',
       'dev:workspace:clean',
+      'dev:workspace:doctor',
       'dev:workspace:status',
     ]);
   });
@@ -129,7 +146,7 @@ describe('dev domain registration with the usage registry', () => {
     RegisterDevWorkspaceUsage();
     RegisterDevWorkspaceUsage();
     const detail = CLIPluginRegistry.BuildDomainDetail('dev');
-    expect(detail.commands).toHaveLength(3);
+    expect(detail.commands).toHaveLength(4);
   });
 });
 

--- a/packages/MJCLI/src/commands/dev/workspace/doctor.ts
+++ b/packages/MJCLI/src/commands/dev/workspace/doctor.ts
@@ -1,0 +1,68 @@
+import { Command, Flags } from '@oclif/core';
+import path from 'node:path';
+import { ResolveDirSource, WORKSPACE_DIR_ENV_VAR } from '../../../lib/dev-workspace/dir-flag.js';
+import { CollectDoctorReport, DoctorHasFailures, RenderDoctor, type DoctorReport } from '../../../lib/dev-workspace/doctor.js';
+import { GetPnpmVersion } from '../../../lib/dev-workspace/pnpm.js';
+import type { DirSource } from '../../../lib/dev-workspace/types.js';
+
+/**
+ * CLI command: `mj dev workspace doctor`.
+ *
+ * Read-only health check for a generated cross-repo workspace: prints one
+ * PASS/WARN/FAIL/SKIP line per check and exits non-zero when any check FAILS, so
+ * it can gate a script. It writes nothing, deletes nothing and makes no network
+ * call — every fix it finds is printed as a command for the user to run.
+ *
+ * The check `status` cannot do is the one-copy census: it reads the parent's pnpm
+ * virtual store and fails when more than one version of a must-be-single-copy
+ * package (Angular, RxJS, zone.js, MJ core/global) is installed there.
+ */
+export default class DevWorkspaceDoctor extends Command {
+  static description =
+    'Health-check the generated cross-repo pnpm workspace at a parent directory: workspace files, sentinel, ' +
+    'pnpm pin vs. active version, member directories, detected-but-unlisted repos, members carrying a standalone ' +
+    'install, and a one-copy census of the parent package store (more than one @angular/core, rxjs, zone.js or ' +
+    'MJ core/global is a FAIL). Prints PASS/WARN/FAIL per check and exits non-zero on any FAIL. Read-only.';
+
+  static examples = [
+    '<%= config.bin %> dev workspace doctor',
+    '<%= config.bin %> dev workspace doctor --dir ~/code/bluecypress',
+    `MJ_DEV_WORKSPACE_DIR=~/code/bluecypress <%= config.bin %> dev workspace doctor`,
+  ];
+
+  static flags = {
+    dir: Flags.string({
+      description: `Parent directory holding the sibling repo clones (env: ${WORKSPACE_DIR_ENV_VAR})`,
+      env: WORKSPACE_DIR_ENV_VAR,
+      default: '.',
+    }),
+  };
+
+  async run(): Promise<void> {
+    const { flags } = await this.parse(DevWorkspaceDoctor);
+    const parentDir = path.resolve(flags.dir);
+    const dirSource = ResolveDirSource(this.argv, process.env[WORKSPACE_DIR_ENV_VAR]);
+
+    const report = await this.collectReport(parentDir, dirSource);
+    this.log('');
+    this.log(RenderDoctor(report));
+    if (DoctorHasFailures(report)) {
+      this.exit(1);
+    }
+  }
+
+  /**
+   * Probes the active pnpm version (the one spawn in this command) and collects the
+   * report. Collection errors — an unreadable store, a parent that does not exist —
+   * become a clean CLI error rather than a stack trace; `this.error` never returns.
+   */
+  private async collectReport(parentDir: string, dirSource: DirSource): Promise<DoctorReport> {
+    try {
+      const activePnpm = await GetPnpmVersion(parentDir);
+      return CollectDoctorReport(parentDir, activePnpm, dirSource);
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      return this.error(message);
+    }
+  }
+}

--- a/packages/MJCLI/src/lib/dev-workspace/doctor.ts
+++ b/packages/MJCLI/src/lib/dev-workspace/doctor.ts
@@ -1,0 +1,476 @@
+/**
+ * Health checks for `mj dev workspace doctor`.
+ *
+ * SIDE EFFECTS: READ-ONLY filesystem access, and nothing else. Two reads happen
+ * here — the workspace state collection delegated to `status.ts` (existence checks
+ * plus small file reads), and ONE `readdirSync` of the parent's pnpm virtual store
+ * for the one-copy census. Doctor never writes, never deletes, never spawns a
+ * process (the active pnpm version is probed by the command and passed in, the same
+ * contract `CollectWorkspaceStatus` uses) and never touches the network.
+ *
+ * The census exists because the failure that actually bites a joined workspace is
+ * not a missing file — it is TWO COPIES of a package the runtime requires exactly
+ * one of. Two `@angular/core`s give `NG0203 inject() must be called from an
+ * injection context`; two `@memberjunction/global`s give two Global Object Stores,
+ * so every `BaseSingleton` silently becomes two singletons. Both look like
+ * application bugs and neither names the real cause, so doctor names it.
+ *
+ * @module lib/dev-workspace/doctor
+ */
+import { existsSync, readdirSync } from 'node:fs';
+import path from 'node:path';
+import chalk from 'chalk';
+import type { Dirent } from 'node:fs';
+import { SENTINEL_MARKER } from './build.js';
+import { LOCKFILE_NAME, NODE_MODULES_NAME } from './clean.js';
+import { DescribeDirSource } from './dir-flag.js';
+import { CollectWorkspaceStatus } from './status.js';
+import { SENTINEL_FILE_NAME } from './write.js';
+import type { DirSource, WorkspaceStatus } from './types.js';
+
+/**
+ * Packages that MUST resolve to exactly one copy across a joined workspace.
+ * Angular's DI, RxJS's operator identity checks and MJ's Global Object Store all
+ * key off module identity, so a second copy is not a duplicate — it is a second,
+ * mutually invisible runtime.
+ */
+export const SINGLETON_PACKAGES: readonly string[] = [
+  '@angular/core',
+  '@angular/common',
+  '@angular/compiler',
+  'rxjs',
+  'zone.js',
+  '@memberjunction/core',
+  '@memberjunction/global',
+];
+
+/** Hard cap on virtual-store entries the census will read; exceeding it throws rather than truncating. */
+const MAX_STORE_ENTRIES = 100_000;
+
+/** The pnpm virtual store, relative to the workspace parent. */
+const STORE_REL_PATH = path.join(NODE_MODULES_NAME, '.pnpm');
+
+/**
+ * Outcome of one health check. `skip` means the check did not apply — it is never a
+ * claim of health, which is exactly why it is not folded into `pass`.
+ */
+export type DoctorSeverity = 'pass' | 'warn' | 'fail' | 'skip';
+
+/** One health-check result: what was checked, how it went, and for warn/fail what to do. */
+export interface DoctorCheck {
+  Name: string;
+  Severity: DoctorSeverity;
+  Detail: string;
+}
+
+/** One decoded pnpm virtual-store directory name. */
+export interface StoreEntry {
+  /** Package name with the scope separator decoded (`@angular+core` -> `@angular/core`). */
+  Name: string;
+  /** Concrete version, peer suffix stripped. */
+  Version: string;
+}
+
+/** Distinct versions of one singleton package found in the parent's store. */
+export interface SingletonVersions {
+  Package: string;
+  /** Sorted distinct versions — always at least one entry. */
+  Versions: string[];
+}
+
+/** What the one-copy census read out of `<parent>/node_modules/.pnpm`. */
+export interface StoreCensus {
+  /** False when the parent has no virtual store — nothing has been installed there. */
+  StorePresent: boolean;
+  /** Every singleton package present in the store. Packages absent from it are omitted, not zero-filled. */
+  Packages: SingletonVersions[];
+  /**
+   * Store entries that are not `name@version` (the store's own `node_modules`,
+   * `file:`/`link:` entries). Counted and reported rather than silently dropped.
+   */
+  UnparsedEntryCount: number;
+}
+
+/** Everything `dev workspace doctor` reports. */
+export interface DoctorReport {
+  ParentDir: string;
+  DirSource: DirSource;
+  Checks: DoctorCheck[];
+  Census: StoreCensus;
+}
+
+/**
+ * Index of the `@` that separates name from version in a store directory name:
+ * the SECOND `@` for a scoped package (`@angular+core@21.1.3`), the first
+ * otherwise (`rxjs@7.8.1`). Returns -1 when there is none.
+ *
+ * Deliberately not "the last `@`": a peer-suffixed entry carries `@` characters
+ * INSIDE its suffix — `@angular+common@21.1.3(@angular+core@21.1.3)` — so the last
+ * `@` sits in the parentheses and the naive split yields nonsense.
+ */
+function findVersionSeparator(entry: string): number {
+  return entry.startsWith('@') ? entry.indexOf('@', 1) : entry.indexOf('@');
+}
+
+/** pnpm encodes the scope separator as `+`, and only that one: `@angular+core` -> `@angular/core`. */
+function decodeStoreName(encodedName: string): string {
+  return encodedName.startsWith('@') ? encodedName.replace('+', '/') : encodedName;
+}
+
+/**
+ * Decodes one `<parent>/node_modules/.pnpm` directory name into package name and
+ * version, or null when the entry is not a resolved package (the store's own
+ * `node_modules`, `file+..+repo@file+..+repo` link entries, and anything else whose
+ * version segment does not start with a digit).
+ *
+ * Peer suffixes come in BOTH shapes and both are handled — pnpm 10.33 writes the
+ * underscore form (verified against a real store: `@angular+core@21.1.3_@angular+
+ * compiler@21.1.3_rxjs@7.8.2_zone.js@0.16.0`), other versions write the parenthesised
+ * form (`@angular+common@21.1.3(@angular+core@21.1.3)`). Both carry `@` characters
+ * INSIDE the suffix, which is why the version is taken from the name/version
+ * separator forwards and then truncated, never from the LAST `@` backwards — on the
+ * entry above, the last `@` yields `0.16.0`, a version of a different package.
+ * Splitting the VERSION segment (not the whole entry) at `_` is safe: semver forbids
+ * `_` in a version, and a package name containing one is never reached. Pure.
+ */
+export function ParseStoreEntry(entryName: string): StoreEntry | null {
+  const withoutPeers = entryName.split('(')[0];
+  const separator = findVersionSeparator(withoutPeers);
+  if (separator <= 0) return null;
+  const encodedName = withoutPeers.slice(0, separator);
+  const version = withoutPeers.slice(separator + 1).split('_')[0];
+  if (!/^\d/.test(version)) return null;
+  return { Name: decodeStoreName(encodedName), Version: version };
+}
+
+/**
+ * Directory names in the virtual store. Reads the directory exactly once and is
+ * bounded by {@link MAX_STORE_ENTRIES} — hitting the cap throws rather than
+ * silently censusing a prefix of the store, which would be a false PASS.
+ */
+function readStoreEntries(storeDir: string): string[] {
+  let dirents: Dirent[];
+  try {
+    dirents = readdirSync(storeDir, { withFileTypes: true });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    throw new Error(`Cannot read the package store at ${storeDir}: ${message}`);
+  }
+  if (dirents.length > MAX_STORE_ENTRIES) {
+    throw new Error(
+      `${storeDir} holds ${dirents.length} entries, over the ${MAX_STORE_ENTRIES} cap — refusing to census it`
+    );
+  }
+  return dirents.filter((entry) => entry.isDirectory()).map((entry) => entry.name);
+}
+
+/** Groups parsed store entries into the distinct versions of each singleton package. Pure. */
+function tallySingletons(entryNames: readonly string[]): StoreCensus {
+  const wanted = new Set(SINGLETON_PACKAGES);
+  const found = new Map<string, Set<string>>();
+  let unparsed = 0;
+  for (const entryName of entryNames) {
+    const entry = ParseStoreEntry(entryName);
+    if (entry === null) {
+      unparsed++;
+      continue;
+    }
+    if (!wanted.has(entry.Name)) continue;
+    const versions = found.get(entry.Name) ?? new Set<string>();
+    versions.add(entry.Version);
+    found.set(entry.Name, versions);
+  }
+  const packages: SingletonVersions[] = [];
+  for (const name of SINGLETON_PACKAGES) {
+    const versions = found.get(name);
+    if (versions === undefined) continue;
+    packages.push({ Package: name, Versions: [...versions].sort() });
+  }
+  return { StorePresent: true, Packages: packages, UnparsedEntryCount: unparsed };
+}
+
+/**
+ * Counts the distinct versions of each singleton package in the parent's pnpm
+ * virtual store, reading DIRECTORY NAMES ONLY — a store entry name already carries
+ * `name@version`, so no package.json is opened and the whole census is one
+ * `readdirSync`. An absent store is reported as `StorePresent: false`, never as a
+ * clean bill of health.
+ *
+ * KNOWN LIMIT, stated so the PASS is not read as more than it is: pnpm gives
+ * workspace-linked packages no virtual-store entry at all (verified — an MJ
+ * checkout's own store holds zero `@memberjunction+core@…` entries), so this counts
+ * copies IN THE PARENT STORE. A registry copy sitting alongside a workspace link is
+ * one store entry and reads as one copy. Catching that is the job of the family
+ * `workspace:*` overrides the generator emits, not of this census.
+ *
+ * SIDE EFFECT: one read-only directory listing.
+ */
+export function CollectSingletonCensus(parentDir: string): StoreCensus {
+  if (!path.isAbsolute(parentDir)) {
+    throw new Error(`CollectSingletonCensus requires an absolute path, got: ${parentDir}`);
+  }
+  const storeDir = path.join(parentDir, STORE_REL_PATH);
+  if (!existsSync(storeDir)) return { StorePresent: false, Packages: [], UnparsedEntryCount: 0 };
+  return tallySingletons(readStoreEntries(storeDir));
+}
+
+/** The parent must be a plain directory holding sibling clones — never a git repo root itself. */
+function checkParentShape(status: WorkspaceStatus): DoctorCheck {
+  if (!status.ParentIsGitRepo) {
+    return { Name: 'parent directory', Severity: 'pass', Detail: 'a plain directory, not a git repo root' };
+  }
+  return {
+    Name: 'parent directory',
+    Severity: 'fail',
+    Detail:
+      'this directory is a git repo root (.git present) — a workspace parent must be the plain directory that ' +
+      'HOLDS the sibling clones; re-run with --dir pointing at their common parent',
+  };
+}
+
+/** All generated files must be present; a missing one means the workspace was never (fully) generated. */
+function checkGeneratedFiles(status: WorkspaceStatus): DoctorCheck {
+  const missing = status.Files.filter((file) => !file.Exists).map((file) => file.Name);
+  if (missing.length === 0) {
+    return { Name: 'workspace files', Severity: 'pass', Detail: `all ${status.Files.length} generated files present` };
+  }
+  return {
+    Name: 'workspace files',
+    Severity: 'fail',
+    Detail: `missing: ${missing.join(', ')} — run \`mj dev workspace --dir ${status.ParentDir}\` to generate them`,
+  };
+}
+
+/** The lockfile and node_modules come from `pnpm install`, not the generator — absence is incomplete, not broken. */
+function checkInstallArtifacts(status: WorkspaceStatus): DoctorCheck {
+  const missing: string[] = [];
+  if (!status.LockfileExists) missing.push(LOCKFILE_NAME);
+  if (!status.NodeModulesExists) missing.push(NODE_MODULES_NAME);
+  if (missing.length === 0) {
+    return { Name: 'install', Severity: 'pass', Detail: `${LOCKFILE_NAME} and ${NODE_MODULES_NAME} present` };
+  }
+  return {
+    Name: 'install',
+    Severity: 'warn',
+    Detail: `missing ${missing.join(' and ')} — run \`pnpm install\` at ${status.ParentDir}`,
+  };
+}
+
+/** The sentinel is what proves this workspace came from the generator, and what `clean` requires. */
+function checkSentinel(status: WorkspaceStatus): DoctorCheck {
+  const sentinel = status.Sentinel;
+  if (sentinel.Kind === 'valid') {
+    const members = sentinel.Sentinel.members.join(', ') || '(none recorded)';
+    return { Name: 'sentinel', Severity: 'pass', Detail: `${SENTINEL_FILE_NAME} written by ${SENTINEL_MARKER} (members: ${members})` };
+  }
+  if (sentinel.Kind === 'invalid') {
+    return {
+      Name: 'sentinel',
+      Severity: 'warn',
+      Detail: `${SENTINEL_FILE_NAME} is present but not ours (${sentinel.Reason}) — clean needs --force`,
+    };
+  }
+  return {
+    Name: 'sentinel',
+    Severity: 'warn',
+    Detail: `no ${SENTINEL_FILE_NAME} — hand-made or pre-sentinel workspace; clean needs --force`,
+  };
+}
+
+/** The generated pin and the pnpm actually running at the parent must be the same version. */
+function checkPnpmVersion(status: WorkspaceStatus): DoctorCheck {
+  const pinned = status.PinnedPnpm === null ? null : status.PinnedPnpm.slice('pnpm@'.length);
+  if (pinned === null) {
+    return { Name: 'pnpm version', Severity: 'skip', Detail: 'no pnpm pin at the parent (no generated package.json)' };
+  }
+  if (status.ActivePnpmVersion === null) {
+    return { Name: 'pnpm version', Severity: 'warn', Detail: `pinned ${pinned}, but pnpm is not runnable at the parent` };
+  }
+  if (status.ActivePnpmVersion === pinned) {
+    return { Name: 'pnpm version', Severity: 'pass', Detail: `pinned ${pinned}, active ${status.ActivePnpmVersion} — match` };
+  }
+  return {
+    Name: 'pnpm version',
+    Severity: 'warn',
+    Detail: `pinned ${pinned}, active ${status.ActivePnpmVersion} — MISMATCH; run \`corepack enable\` so the pin is honored`,
+  };
+}
+
+/**
+ * Every member named in pnpm-workspace.yaml must exist on disk. This is a FAIL, not
+ * a warning: the generated parent manifest carries a `workspace:*` override for each
+ * member-provided package name, so a member whose checkout is gone makes the next
+ * `pnpm install` fail outright rather than degrade.
+ */
+function checkMemberDirs(status: WorkspaceStatus): DoctorCheck {
+  if (status.Members.length === 0) {
+    return { Name: 'member dirs', Severity: 'skip', Detail: 'no pnpm-workspace.yaml — no members to check' };
+  }
+  if (status.MissingMemberDirs.length === 0) {
+    return { Name: 'member dirs', Severity: 'pass', Detail: `all ${status.Members.length} member directories present` };
+  }
+  return {
+    Name: 'member dirs',
+    Severity: 'fail',
+    Detail:
+      `in pnpm-workspace.yaml but missing on disk: ${status.MissingMemberDirs.join(', ')} — the parent manifest ` +
+      `overrides each member-provided package to workspace:*, so pnpm install will fail; re-clone them or ` +
+      `re-run \`mj dev workspace --force\` to regenerate without them`,
+  };
+}
+
+/** Repos on disk that qualify as members but are not in the workspace resolve against their own installs. */
+function checkCandidates(status: WorkspaceStatus): DoctorCheck {
+  if (status.DetectedCandidates.length === 0) {
+    return { Name: 'candidates', Severity: 'skip', Detail: 'no member-candidate repos detected at the parent' };
+  }
+  if (status.CandidatesNotInWorkspace.length === 0) {
+    return {
+      Name: 'candidates',
+      Severity: 'pass',
+      Detail: `all ${status.DetectedCandidates.length} detected repos are workspace members`,
+    };
+  }
+  return {
+    Name: 'candidates',
+    Severity: 'warn',
+    Detail:
+      `detected on disk but not in the workspace: ${status.CandidatesNotInWorkspace.join(', ')} — they resolve ` +
+      `against their own installs, not this workspace; re-run \`mj dev workspace --force\` to include them`,
+  };
+}
+
+/**
+ * A member carrying its OWN package store has forked resolution away from the
+ * workspace. Note what does NOT count: a plain `node_modules` inside a member is
+ * what a healthy parent install creates (symlinks into the parent store) — only a
+ * member-root `.pnpm` store or npm's `.package-lock.json` marker proves a
+ * standalone install, which is the distinction `status.ts` already encodes.
+ *
+ * Scope, stated in the PASS text rather than implied: this reads the member ROOT
+ * only. A repo whose root tree was deleted but whose nested per-package trees
+ * survive (the half-finished cleanup #3795 describes) passes here — enumerating
+ * those is `--clean-members`' depth-independent walk, not a health check's job.
+ */
+function checkStandaloneInstalls(status: WorkspaceStatus): DoctorCheck {
+  if (status.MembersWithStandaloneInstalls.length === 0) {
+    return {
+      Name: 'standalone installs',
+      Severity: 'pass',
+      Detail:
+        'no member root carries its own package store (a member node_modules from the parent install is normal; ' +
+        'nested per-package trees are not scanned — `dev workspace --clean-members` removes those)',
+    };
+  }
+  return {
+    Name: 'standalone installs',
+    Severity: 'fail',
+    Detail:
+      `${status.MembersWithStandaloneInstalls.join(', ')} — each has its own package store, so its code resolves ` +
+      `against that store instead of this workspace (split singletons, stale deps). ` +
+      `Fix: re-run \`mj dev workspace --clean-members\`.`,
+  };
+}
+
+/** Appends the unparsed-entry tally to a census detail, so dropped store entries are never silent. */
+function withUnparsedNote(detail: string, census: StoreCensus): string {
+  const count = census.UnparsedEntryCount;
+  if (count === 0) return detail;
+  const noun = count === 1 ? 'entry is' : 'entries are';
+  return `${detail} (${count} store ${noun} not name@version — links and the store's own node_modules)`;
+}
+
+/** Exactly one version of each singleton package may exist in the parent's store. */
+function checkOneCopyCensus(census: StoreCensus): DoctorCheck {
+  const name = 'one-copy census';
+  if (!census.StorePresent) {
+    return { Name: name, Severity: 'skip', Detail: `no ${STORE_REL_PATH} at the parent — no pnpm package store to census` };
+  }
+  if (census.Packages.length === 0) {
+    return { Name: name, Severity: 'skip', Detail: withUnparsedNote('none of the single-copy packages are installed here', census) };
+  }
+  const duplicated = census.Packages.filter((entry) => entry.Versions.length > 1);
+  if (duplicated.length === 0) {
+    const listed = census.Packages.map((entry) => `${entry.Package}@${entry.Versions[0]}`).join(', ');
+    return { Name: name, Severity: 'pass', Detail: withUnparsedNote(`one copy each in the parent store: ${listed}`, census) };
+  }
+  const broken = duplicated.map((entry) => `${entry.Package} (${entry.Versions.join(', ')})`).join('; ');
+  return {
+    Name: name,
+    Severity: 'fail',
+    Detail:
+      `more than one version in the parent store: ${broken} — these must be single-copy (Angular DI and MJ's ` +
+      `Global Object Store key off module identity, so a second copy is a second, invisible runtime). ` +
+      `Fix: re-run \`mj dev workspace --force\` to re-derive the pins, then \`pnpm install\` at the parent.`,
+  };
+}
+
+/**
+ * Runs every health check at a parent directory. `activePnpmVersion` comes from the
+ * caller (a spawn — see `pnpm.ts`) and `dirSource` likewise, so this module reads
+ * neither processes nor the environment. Read-only.
+ */
+export function CollectDoctorReport(
+  parentDir: string,
+  activePnpmVersion: string | null,
+  dirSource: DirSource
+): DoctorReport {
+  if (!path.isAbsolute(parentDir)) {
+    throw new Error(`CollectDoctorReport requires an absolute path, got: ${parentDir}`);
+  }
+  const status = CollectWorkspaceStatus(parentDir, activePnpmVersion, dirSource);
+  const census = CollectSingletonCensus(parentDir);
+  return {
+    ParentDir: parentDir,
+    DirSource: dirSource,
+    Census: census,
+    Checks: [
+      checkParentShape(status),
+      checkGeneratedFiles(status),
+      checkInstallArtifacts(status),
+      checkSentinel(status),
+      checkPnpmVersion(status),
+      checkMemberDirs(status),
+      checkCandidates(status),
+      checkStandaloneInstalls(status),
+      checkOneCopyCensus(census),
+    ],
+  };
+}
+
+/** Severity tag printed at the head of each line. */
+const SEVERITY_TAGS: Record<DoctorSeverity, string> = {
+  pass: chalk.green('[PASS]'),
+  warn: chalk.yellow('[WARN]'),
+  fail: chalk.red('[FAIL]'),
+  skip: chalk.dim('[SKIP]'),
+};
+
+/** True when any check failed — the command's exit-code decision. Pure. */
+export function DoctorHasFailures(report: DoctorReport): boolean {
+  return report.Checks.some((check) => check.Severity === 'fail');
+}
+
+/** Counts each severity and states the exit-code consequence plainly. Pure. */
+function renderSummary(report: DoctorReport): string {
+  const countOf = (severity: DoctorSeverity): number => report.Checks.filter((check) => check.Severity === severity).length;
+  const failed = countOf('fail');
+  const summary = `${countOf('pass')} passed, ${countOf('warn')} warned, ${failed} failed, ${countOf('skip')} skipped`;
+  if (failed === 0) return chalk.green(`${summary} — no failures.`);
+  return chalk.red(`${summary} — doctor exits non-zero.`);
+}
+
+/** Renders a DoctorReport as the terminal report. Pure. */
+export function RenderDoctor(report: DoctorReport): string {
+  const lines: string[] = [
+    chalk.bold(`Workspace doctor: ${report.ParentDir}`),
+    chalk.dim(`  resolved from: ${DescribeDirSource(report.DirSource)}`),
+    '',
+  ];
+  for (const check of report.Checks) {
+    lines.push(`${SEVERITY_TAGS[check.Severity]} ${check.Name}: ${check.Detail}`);
+  }
+  lines.push('');
+  lines.push(renderSummary(report));
+  return lines.join('\n');
+}

--- a/packages/MJCLI/src/lib/dev-workspace/usage.ts
+++ b/packages/MJCLI/src/lib/dev-workspace/usage.ts
@@ -112,6 +112,36 @@ export const DEV_WORKSPACE_STATUS_USAGE: PluginUsage = {
   runtime: { class: 'fast', typicalSeconds: 1, note: 'one `pnpm --version` probe plus directory reads' },
 };
 
+/** Usage for `mj dev workspace doctor` — the read-only health check. */
+export const DEV_WORKSPACE_DOCTOR_USAGE: PluginUsage = {
+  domain: 'dev',
+  command: 'dev:workspace:doctor',
+  summary: 'Health-check a generated cross-repo workspace and exit non-zero on any failure.',
+  description:
+    `Read-only: writes nothing, deletes nothing, no network. Prints one [PASS]/[WARN]/[FAIL]/[SKIP] line per check ` +
+    `and EXITS NON-ZERO when any check FAILS, so it can gate a script (status never exits non-zero — that is the ` +
+    `difference between the two). FAIL: the parent is itself a git repo root; a generated file is missing; a member ` +
+    `named in pnpm-workspace.yaml has no directory on disk (the parent manifest overrides that member's packages to ` +
+    `workspace:*, so pnpm install fails outright); a member carries a STANDALONE INSTALL — a member-root ` +
+    `${NODE_MODULES_NAME}/.pnpm store or npm .package-lock.json marker, NOT the plain ${NODE_MODULES_NAME} a healthy ` +
+    `parent install leaves inside every member; or the one-copy census finds more than one version of a package that ` +
+    `must be single-copy. WARN: not installed yet, no valid ${SENTINEL_FILE_NAME}, a pnpm pin/active mismatch, or a ` +
+    `detected repo that is not a workspace member. The one-copy census reads the DIRECTORY NAMES in the parent's ` +
+    `${NODE_MODULES_NAME}/.pnpm store (each already encodes name@version) and counts distinct versions of ` +
+    `@angular/core, @angular/common, @angular/compiler, rxjs, zone.js, @memberjunction/core and ` +
+    `@memberjunction/global — two copies of any of them is a second, mutually invisible runtime (Angular DI throws ` +
+    `NG0203; two Global Object Stores make every BaseSingleton two singletons), which is why it is a FAIL and not a ` +
+    `warning. Packages absent from the store are skipped, not failed. Light command: no MJ bootstrap. ` +
+    PARENT_DIR_RULE,
+  flags: [DIR_FLAG],
+  examples: [
+    'mj dev workspace doctor',
+    'mj dev workspace doctor --dir ~/code/bluecypress',
+    `${WORKSPACE_DIR_ENV_VAR}=~/code/bluecypress mj dev workspace doctor`,
+  ],
+  runtime: { class: 'fast', typicalSeconds: 1, note: 'one `pnpm --version` probe, directory reads, and one listing of the parent store' },
+};
+
 /** Usage for `mj dev workspace clean` — the teardown. */
 export const DEV_WORKSPACE_CLEAN_USAGE: PluginUsage = {
   domain: 'dev',
@@ -146,6 +176,7 @@ export const DEV_WORKSPACE_CLEAN_USAGE: PluginUsage = {
 export const DEV_DOMAIN_USAGE: readonly PluginUsage[] = [
   DEV_WORKSPACE_USAGE,
   DEV_WORKSPACE_STATUS_USAGE,
+  DEV_WORKSPACE_DOCTOR_USAGE,
   DEV_WORKSPACE_CLEAN_USAGE,
 ];
 

--- a/packages/MJCLI/src/light-commands.ts
+++ b/packages/MJCLI/src/light-commands.ts
@@ -56,6 +56,7 @@ export const LIGHT_COMMANDS: ReadonlySet<string> = new Set([
   // Dev workspace generator - node stdlib + chalk only, no bootstrap
   'dev workspace',
   'dev workspace status',
+  'dev workspace doctor',
   'dev workspace clean',
 
   // SQL conversion commands - use @memberjunction/sql-converter + sqlglot-ts only


### PR DESCRIPTION
## Summary

Adds `mj dev workspace doctor` — the C.2 health-check half of the doctor+reset item (reset already shipped as `--clean-members` in #3801). Read-only, one PASS/WARN/FAIL/SKIP line per check, exits non-zero on any FAIL so it can gate scripts — the deliberate difference from `status`, which always exits 0.

Nine checks: parent-not-a-git-root · the four generated files · lockfile + node_modules · sentinel · pnpm pin vs. active · member dirs on disk · detected-but-unlisted candidates · standalone-install split-brain (same markers as `status`) · **NEW: one-copy census** of the parent's pnpm store — more than one version of `@angular/core`/`common`/`compiler`, `rxjs`, `zone.js`, `@memberjunction/core`/`global` is a FAIL (two copies = NG0203 / split Global Object Stores, the classic workspace disease that presents as an app bug).

## Design notes for reviewers

- **The census reads directory NAMES only** out of `node_modules/.pnpm` — one `readdirSync`, no package.json opens, bounded at 100k entries (throws rather than censusing a prefix).
- **Store-entry parsing handles both pnpm peer-suffix encodings** — pnpm 10.33's underscore form (`@angular+core@21.1.3_@angular+compiler@...`) and the parenthesised form. The naive take-after-last-`@` rule reports *zone.js's version as @angular/core's* on real 10.33 stores; a test asserts that trap explicitly.
- **`skip` is a first-class severity** — a census with no store prints `[SKIP]`, never `[PASS]`; skips never affect the exit code.
- **Two scope limits stated in the PASS text rather than implied**: workspace-linked packages get no store entry (the census counts parent-store copies; link-vs-registry duality is the generator's `workspace:*` overrides' job), and the standalone-install check reads member roots only (nested trees are `--clean-members`' depth-independent walk).
- Zero mutations, zero network, one spawn (the pnpm version probe, in the command layer — the lib stays spawn-free and fixture-testable, same contract as `status.ts`).

## Verification

- MJCLI build clean; `oclif manifest` lists `dev:workspace:doctor`; **661/661 tests across 36 files** (31 new), independently re-run by the coordinating session.
- End-to-end against a real generated workspace: bare parent → exit 1; healthy → 9 PASS, exit 0; duplicate rxjs → FAIL exit 1; standalone install → FAIL exit 1.
- Changeset: `@memberjunction/cli` patch.

Built by an Opus subagent from a scoped brief; every line reviewed by the coordinating session before push. Tracker item C.2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
Claude-Session: https://claude.ai/code/session_01MYWbAFjiCkR8LWJK3VXWX3