### PR TITLE
release-lines: certify line 5.51 — 5.51.0, support through 2027-02-14

### DIFF
--- a/release-lines.json
+++ b/release-lines.json
@@ -14,5 +14,15 @@
       }
     }
   },
-  "lines": {}
+  "lines": {
+    "5.51": {
+      "status": "certified",
+      "certifiedBuild": "5.51.0",
+      "candidateDate": "2026-07-31",
+      "certifiedDate": "2026-08-14",
+      "supportEnds": "2027-02-14",
+      "upgradeImpact": "none",
+      "scorecard": "certifications/5.51.0.md"
+    }
+  }
 }


### PR DESCRIPTION
## Summary

The certification record for line **5.51**: all seven gates closed on scorecard PR #3597 (final gate filed as 3616708e). This PR flips `lines{}` from empty to the first certified line — the CODEOWNERS-gated status transition per lts-process.md §4.1.

| Field | Value | Basis |
|---|---|---|
| status | certified | 7/7 gates, evidence on #3597 |
| certifiedBuild | 5.51.0 | the candidate, unchanged through cert |
| candidateDate | 2026-07-31 | the batched cert-blocker respin cut |
| certifiedDate | 2026-08-14 | actual certification (slip-tolerant clock starts here) |
| supportEnds | 2027-02-14 | the bootstrap line's fixed 6-month exception |
| upgradeImpact | none | first line — nothing to upgrade from |
| scorecard | certifications/5.51.0.md | lands on next when #3597 merges |

`newest` and `releases` are deliberately unset — publish appends those mechanically at the 5.51.1 dispatch.

## Verification

- `node ci/validate-release-lines.mjs` → OK.
- npm `latest` dist-tag verified already pointing at 5.51.0 (no flip needed).

## Merge order

**Merge #3597 first** (the sign-off act — this PR's scorecard path resolves once it lands), then this. Then `gh release create v5.51.0 --latest` (the tag has no Release object — create, not edit).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
Claude-Session: https://claude.ai/code/session_01MYWbAFjiCkR8LWJK3VXWX3