### PR TITLE
ci: verify new packages are publish-ready at PR time, not release time

### DIFF
--- a/.github/scripts/__tests__/check-new-npm-packages.test.mjs
+++ b/.github/scripts/__tests__/check-new-npm-packages.test.mjs
@@ -1,0 +1,338 @@
+// Tests for .github/scripts/check-new-npm-packages.mjs
+// Run with: npx vitest run --config .github/scripts/vitest.config.mts
+import { describe, it, expect } from 'vitest';
+import {
+    parseManifest,
+    publishableNames,
+    diffNewPackages,
+    selectManifestPaths,
+    selectVersionToVerify,
+    extractProvenance,
+    verifyProvenance,
+    classifyPackage,
+    fetchRegistryJson,
+    formatGateFailure,
+    packumentUrl,
+    attestationUrl,
+    STATUS,
+    NPM_MAX_RETRIES,
+    GITHUB_REPO,
+    GITHUB_REPO_URL,
+    PUBLISH_WORKFLOW_FILE,
+    PUBLISH_WORKFLOW_PATH,
+    SEED_WORKFLOW_NAME,
+    NPM_MEMBERS_URL,
+    NPM_ESCALATION_HANDLE,
+} from '../check-new-npm-packages.mjs';
+
+// --- fixtures ---------------------------------------------------------------
+
+/** Wrap a workflow identity in the envelope shape npm actually returns. */
+const attestationDoc = (workflow) => ({
+    attestations: [
+        // npm returns a publish attestation alongside provenance; it has no buildDefinition
+        // and must be skipped rather than treated as malformed.
+        { predicateType: 'https://github.com/npm/attestation/tree/main/specs/publish/v0.1', bundle: { dsseEnvelope: { payload: Buffer.from(JSON.stringify({ predicate: {} })).toString('base64') } } },
+        {
+            predicateType: 'https://slsa.dev/provenance/v1',
+            bundle: {
+                dsseEnvelope: {
+                    payload: Buffer.from(
+                        JSON.stringify({ predicate: { buildDefinition: { externalParameters: { workflow } } } })
+                    ).toString('base64'),
+                },
+            },
+        },
+    ],
+});
+
+const GOOD_WORKFLOW = { path: PUBLISH_WORKFLOW_PATH, repository: GITHUB_REPO_URL, ref: 'refs/heads/main' };
+
+/** A fetch double driven by a url -> {status, body} map. Unlisted urls 404. */
+const fakeFetch = (routes) => async (url) => {
+    const hit = routes[url];
+    if (!hit) {
+        return { status: 404, json: async () => ({}) };
+    }
+    return { status: hit.status, json: async () => hit.body };
+};
+
+// --- tests ------------------------------------------------------------------
+
+describe('parseManifest', () => {
+    it('extracts name and private flag', () => {
+        expect(parseManifest('{"name":"@memberjunction/core","private":true}', 'a/package.json')).toEqual({
+            path: 'a/package.json',
+            name: '@memberjunction/core',
+            isPrivate: true,
+        });
+    });
+
+    it('treats a missing private field as publishable', () => {
+        expect(parseManifest('{"name":"@memberjunction/core"}', 'p').isPrivate).toBe(false);
+    });
+
+    it('treats the string "true" as NOT private — only a real boolean counts', () => {
+        // npm itself only honors the boolean, so mirroring it keeps the gate and the
+        // publisher agreeing on which packages ship.
+        expect(parseManifest('{"name":"@memberjunction/x","private":"true"}', 'p').isPrivate).toBe(false);
+    });
+
+    it('throws on malformed JSON, naming the file', () => {
+        expect(() => parseManifest('{ not json', 'packages/Bad/package.json')).toThrow(/packages\/Bad\/package\.json/);
+    });
+});
+
+describe('publishableNames', () => {
+    it('keeps only public @memberjunction packages', () => {
+        const manifests = [
+            { path: 'a', name: '@memberjunction/core', isPrivate: false },
+            { path: 'b', name: '@memberjunction/secret', isPrivate: true },
+            { path: 'c', name: '@other/thing', isPrivate: false },
+            { path: 'd', name: null, isPrivate: false },
+        ];
+        expect([...publishableNames(manifests)]).toEqual(['@memberjunction/core']);
+    });
+});
+
+describe('diffNewPackages', () => {
+    it('returns names present at head but not at base, sorted', () => {
+        const base = new Set(['@memberjunction/core']);
+        const head = new Set(['@memberjunction/core', '@memberjunction/zeta', '@memberjunction/alpha']);
+        expect(diffNewPackages(base, head)).toEqual(['@memberjunction/alpha', '@memberjunction/zeta']);
+    });
+
+    it('ignores packages removed at head', () => {
+        expect(diffNewPackages(new Set(['@memberjunction/a', '@memberjunction/gone']), new Set(['@memberjunction/a']))).toEqual([]);
+    });
+
+    it('treats a package flipped from private to public as new', () => {
+        expect(diffNewPackages(new Set(), new Set(['@memberjunction/newly-public']))).toEqual(['@memberjunction/newly-public']);
+    });
+});
+
+describe('selectManifestPaths', () => {
+    it('keeps package.json paths and drops everything else', () => {
+        expect(selectManifestPaths('packages/Core/package.json\npackages/Core/src/index.ts')).toEqual([
+            'packages/Core/package.json',
+        ]);
+    });
+
+    it('drops vendored manifests under node_modules', () => {
+        expect(selectManifestPaths('packages/A/package.json\npackages/A/node_modules/dep/package.json')).toEqual([
+            'packages/A/package.json',
+        ]);
+    });
+
+    it('does not match a file merely ending in package.json', () => {
+        expect(selectManifestPaths('packages/A/not-package.json')).toEqual([]);
+    });
+});
+
+describe('selectVersionToVerify', () => {
+    it('prefers the seed tag', () => {
+        expect(selectVersionToVerify({ 'dist-tags': { seed: '0.0.1-seed.1', latest: '1.2.3' } })).toBe('0.0.1-seed.1');
+    });
+
+    it('falls back to latest when there is no seed tag', () => {
+        expect(selectVersionToVerify({ 'dist-tags': { latest: '1.2.3' } })).toBe('1.2.3');
+    });
+
+    it('returns null when the package has no versions at all', () => {
+        expect(selectVersionToVerify({})).toBeNull();
+        expect(selectVersionToVerify(null)).toBeNull();
+    });
+});
+
+describe('extractProvenance', () => {
+    it('pulls workflow identity out of the SLSA envelope', () => {
+        expect(extractProvenance(attestationDoc(GOOD_WORKFLOW))).toEqual(GOOD_WORKFLOW);
+    });
+
+    it('returns null when no attestation carries a buildDefinition', () => {
+        expect(extractProvenance({ attestations: [] })).toBeNull();
+        expect(extractProvenance(null)).toBeNull();
+    });
+
+    it('skips an unparseable envelope rather than losing a valid one beside it', () => {
+        const doc = attestationDoc(GOOD_WORKFLOW);
+        doc.attestations.unshift({ bundle: { dsseEnvelope: { payload: 'not-base64-json!!' } } });
+        expect(extractProvenance(doc)).toEqual(GOOD_WORKFLOW);
+    });
+});
+
+describe('verifyProvenance', () => {
+    it('accepts the MJ publish workflow', () => {
+        expect(verifyProvenance(GOOD_WORKFLOW).ok).toBe(true);
+    });
+
+    it('rejects the right workflow in the wrong repository', () => {
+        // An attacker-controlled fork running a file at the same path is not our publisher.
+        const verdict = verifyProvenance({ ...GOOD_WORKFLOW, repository: 'https://github.com/evil/MJ' });
+        expect(verdict.ok).toBe(false);
+        expect(verdict.reason).toContain('evil/MJ');
+    });
+
+    it('rejects the wrong workflow in the right repository', () => {
+        const verdict = verifyProvenance({ ...GOOD_WORKFLOW, path: '.github/workflows/something-else.yml' });
+        expect(verdict.ok).toBe(false);
+        expect(verdict.reason).toContain('something-else.yml');
+    });
+
+    it('rejects missing provenance', () => {
+        expect(verifyProvenance(null).ok).toBe(false);
+    });
+});
+
+describe('fetchRegistryJson', () => {
+    it('returns 404 without retrying — it is an answer, not a failure', async () => {
+        let calls = 0;
+        const counting = async () => {
+            calls += 1;
+            return { status: 404, json: async () => ({}) };
+        };
+        await expect(fetchRegistryJson('u', counting, 0)).resolves.toEqual({ status: 404, body: null });
+        expect(calls).toBe(1);
+    });
+
+    it('retries a server error and succeeds when it clears', async () => {
+        let calls = 0;
+        const flaky = async () => {
+            calls += 1;
+            return calls < 3 ? { status: 503, json: async () => ({}) } : { status: 200, json: async () => ({ ok: 1 }) };
+        };
+        await expect(fetchRegistryJson('u', flaky, 0)).resolves.toEqual({ status: 200, body: { ok: 1 } });
+        expect(calls).toBe(3);
+    });
+
+    it('throws rather than reporting missing when the registry never answers', async () => {
+        // A network blip must never read as "package does not exist" — that would block a
+        // PR whose package is perfectly fine.
+        let calls = 0;
+        const broken = async () => {
+            calls += 1;
+            throw new Error('ECONNRESET');
+        };
+        await expect(fetchRegistryJson('u', broken, 0)).rejects.toThrow(/ECONNRESET/);
+        expect(calls).toBe(NPM_MAX_RETRIES);
+    });
+});
+
+describe('classifyPackage', () => {
+    const name = '@memberjunction/alpha';
+    const pkgUrl = packumentUrl(name);
+    const attUrl = (v) => attestationUrl(name, v);
+
+    it('reports MISSING when the package does not exist', async () => {
+        const verdict = await classifyPackage(name, fakeFetch({}), 0);
+        expect(verdict.status).toBe(STATUS.MISSING);
+    });
+
+    it('reports NO_PROVENANCE when the package exists but was never seeded', async () => {
+        const routes = { [pkgUrl]: { status: 200, body: { 'dist-tags': { latest: '0.0.0' } } } };
+        const verdict = await classifyPackage(name, fakeFetch(routes), 0);
+        expect(verdict.status).toBe(STATUS.NO_PROVENANCE);
+        expect(verdict.detail).toContain('seed workflow not run');
+    });
+
+    it('reports NO_PROVENANCE when the package exists with no published version', async () => {
+        const routes = { [pkgUrl]: { status: 200, body: {} } };
+        const verdict = await classifyPackage(name, fakeFetch(routes), 0);
+        expect(verdict.status).toBe(STATUS.NO_PROVENANCE);
+        expect(verdict.detail).toContain('no published version');
+    });
+
+    it('reports WRONG_PROVENANCE when another repository built it', async () => {
+        const routes = {
+            [pkgUrl]: { status: 200, body: { 'dist-tags': { seed: '0.0.1-seed.1' } } },
+            [attUrl('0.0.1-seed.1')]: { status: 200, body: attestationDoc({ ...GOOD_WORKFLOW, repository: 'https://github.com/evil/MJ' }) },
+        };
+        const verdict = await classifyPackage(name, fakeFetch(routes), 0);
+        expect(verdict.status).toBe(STATUS.WRONG_PROVENANCE);
+    });
+
+    it('reports READY when the seed carries MJ provenance', async () => {
+        const routes = {
+            [pkgUrl]: { status: 200, body: { 'dist-tags': { seed: '0.0.1-seed.1' } } },
+            [attUrl('0.0.1-seed.1')]: { status: 200, body: attestationDoc(GOOD_WORKFLOW) },
+        };
+        const verdict = await classifyPackage(name, fakeFetch(routes), 0);
+        expect(verdict.status).toBe(STATUS.READY);
+        expect(verdict.detail).toContain('0.0.1-seed.1');
+    });
+
+    it('verifies the seed tag in preference to latest', async () => {
+        // A package that already has a real release must still be judged on its seed, so a
+        // provenance-less latest cannot mask a missing trust config.
+        const routes = {
+            [pkgUrl]: { status: 200, body: { 'dist-tags': { seed: '0.0.1-seed.1', latest: '9.9.9' } } },
+            [attUrl('0.0.1-seed.1')]: { status: 200, body: attestationDoc(GOOD_WORKFLOW) },
+        };
+        await expect(classifyPackage(name, fakeFetch(routes), 0)).resolves.toMatchObject({ status: STATUS.READY });
+    });
+});
+
+describe('formatGateFailure', () => {
+    const message = formatGateFailure([
+        { name: '@memberjunction/alpha', status: STATUS.MISSING, detail: 'package does not exist on npm' },
+        { name: '@memberjunction/beta', status: STATUS.NO_PROVENANCE, detail: '0.0.0 has no provenance — seed workflow not run' },
+        { name: '@memberjunction/ready', status: STATUS.READY, detail: 'fine' },
+    ]);
+
+    it('lists only the blocked packages, not the ready ones', () => {
+        expect(message).toContain('@memberjunction/alpha');
+        expect(message).toContain('@memberjunction/beta');
+        expect(message).not.toContain('@memberjunction/ready');
+        expect(message).toContain('2 new package(s) are not ready');
+    });
+
+    it('distinguishes a missing package from an unseeded one', () => {
+        expect(message).toContain('NOT ON NPM');
+        expect(message).toContain('NOT SEEDED');
+    });
+
+    it('offers to create only the packages that do not exist', () => {
+        expect(message).toContain('npx setup-npm-trusted-publish @memberjunction/alpha');
+        expect(message).not.toContain('npx setup-npm-trusted-publish @memberjunction/beta');
+    });
+
+    it('gives a runnable npm trust command per blocked package', () => {
+        expect(message).toContain('npm trust github @memberjunction/alpha');
+        expect(message).toContain('npm trust github @memberjunction/beta');
+        expect(message).toContain(`--repo ${GITHUB_REPO}`);
+        expect(message).toContain(`--file ${PUBLISH_WORKFLOW_FILE}`);
+    });
+
+    it('orders the steps so trust is configured before seeding', () => {
+        // Seeding before `npm trust github` cannot work — the publish would be rejected.
+        expect(message.indexOf('npm trust github')).toBeLessThan(message.indexOf(SEED_WORKFLOW_NAME));
+    });
+
+    it('names the seed workflow as the proof step', () => {
+        expect(message).toContain(SEED_WORKFLOW_NAME);
+        expect(message).toContain('succeeds ONLY if step 4 actually worked');
+    });
+
+    it('no longer asks a human to paste anything', () => {
+        // The attestation check replaced the human attestation; if this string comes back,
+        // the message and the verification have drifted apart.
+        expect(message).not.toContain('PASTE THE OUTPUT');
+    });
+
+    it('includes an escalation path for authors without npm access', () => {
+        expect(message).toContain('IF YOU DO NOT HAVE NPM ACCESS');
+        expect(message).toContain(NPM_MEMBERS_URL);
+        expect(message).toContain(NPM_ESCALATION_HANDLE);
+        expect(message).toContain('one working day');
+    });
+
+    it('tags a real GitHub handle, not an invented team', () => {
+        // The @memberjunction org has exactly one GitHub team (bc-labs), so a plausible
+        // -sounding team handle here would silently notify nobody.
+        expect(message).not.toContain('npm-admins');
+    });
+
+    it('warns against silencing the gate with private: true', () => {
+        expect(message).toContain('"private": true');
+    });
+});

--- a/.github/scripts/check-new-npm-packages.mjs
+++ b/.github/scripts/check-new-npm-packages.mjs
@@ -1,0 +1,524 @@
+/**
+ * New-package npm gate — runs at PR time, not release time.
+ *
+ * WHY THIS EXISTS: a `@memberjunction/*` package cannot be published by `publish.yml`
+ * until it exists on npm *and* carries a trusted-publisher (OIDC) configuration. npm
+ * refuses to attach that configuration to a package that does not yet exist
+ * (`npm trust` POSTs to `/-/package/<name>/trust`, which 404s), and creating it requires
+ * an interactive 2FA challenge that no CI token can satisfy — bypass-2FA granular access
+ * tokens were explicitly barred from changing trusted-publishing config on 2026-07-31.
+ *
+ * So the setup is irreducibly manual. What is NOT irreducible is *when* it happens.
+ * Before this gate, `DEPLOYMENT.md` Step 5 discovered missing packages during the release,
+ * putting a human 2FA prompt on the release critical path. This gate moves that discovery
+ * to the pull request that introduces the package, days earlier, where it blocks one PR
+ * instead of a release.
+ *
+ * HOW IT VERIFIES — this is the part worth understanding. Checking that a package merely
+ * *exists* is weak: a hand-published placeholder with no OIDC config passes that check and
+ * still fails the release. But the config itself cannot be read from CI. The endpoint is
+ * `GET /-/package/<name>/trust`, and it rejects a read-only granular token with HTTP 403
+ * ("You may not perform that action with these credentials" — measured 2026-08-14). The
+ * only token that can read it is write-scoped across @memberjunction: exactly the
+ * long-lived credential trusted publishing exists to abolish.
+ *
+ * The way out is to stop asking npm whether trust is configured, and instead look at
+ * something only a working trust configuration could have produced. npm provenance
+ * attestations are that thing. They are public, readable unauthenticated, and they name
+ * the workflow that produced the publish:
+ *
+ *     GET /-/npm/v1/attestations/<pkg>@<version>
+ *     -> predicate.buildDefinition.externalParameters.workflow
+ *        { path: '.github/workflows/publish.yml',
+ *          repository: 'https://github.com/MemberJunction/MJ' }
+ *
+ * A package can only carry that attestation if it was published *through* the trusted
+ * publisher. So `seed-new-package.yml` publishes a seed version over OIDC — which succeeds
+ * only when `npm trust github` has been run — and this gate verifies the resulting
+ * attestation. Full verification, no secrets, nothing for a human to attest to.
+ *
+ * WHAT IT CHECKS: only packages *new in this PR* — publishable `@memberjunction/*` names
+ * present at head but absent from the merge base. That keeps it to a couple of requests
+ * rather than the ~300 `validate-npm-packages.sh` performs at publish time. This gate does
+ * not replace that script; the release still verifies the whole set.
+ *
+ * CAVEAT: the registry is queried unauthenticated, where a *restricted* package returns 404
+ * exactly like a nonexistent one. Every `@memberjunction/*` package is public, so a 404
+ * here genuinely means "not created yet". If MJ ever publishes a restricted package, this
+ * needs an auth token or it will report that package as missing forever.
+ *
+ * Usage:  node .github/scripts/check-new-npm-packages.mjs <base-ref>
+ * Exit:   0 = no new packages, or every new package is fully set up
+ *         1 = a new package is missing or unverified — merge blocked
+ *         2 = usage error, or the check could not be completed
+ */
+
+import { execFileSync } from 'node:child_process';
+import { readFileSync } from 'node:fs';
+import { pathToFileURL } from 'node:url';
+
+/** Only packages in this scope are published to npm. */
+export const NPM_SCOPE = '@memberjunction/';
+
+/** The workflow that publishes MJ. Provenance must name this exact path. */
+export const PUBLISH_WORKFLOW_PATH = '.github/workflows/publish.yml';
+
+/** Bare filename, as `npm trust github --file` wants it. */
+export const PUBLISH_WORKFLOW_FILE = 'publish.yml';
+
+/** The workflow that seeds a new package over OIDC. */
+export const SEED_WORKFLOW_NAME = 'Seed new package';
+
+/** The repository provenance must name, as `owner/repo`. */
+export const GITHUB_REPO = 'MemberJunction/MJ';
+
+/** The same repository as provenance spells it. */
+export const GITHUB_REPO_URL = `https://github.com/${GITHUB_REPO}`;
+
+/** dist-tag applied to seed publishes, so `latest` never points at a placeholder. */
+export const SEED_DIST_TAG = 'seed';
+
+/** `npm trust` shipped in this version; earlier CLIs have no such command. */
+export const MIN_NPM_VERSION = '11.15.0';
+
+/** Where a maintainer without npm rights goes to find someone who has them. */
+export const NPM_MEMBERS_URL = 'https://www.npmjs.com/settings/memberjunction/members';
+
+/**
+ * Who to tag on the PR when the author cannot do the npm setup themselves.
+ *
+ * Hardcoded on purpose. The authoritative list of who can perform the setup lives on npm,
+ * and reading it (`npm org ls memberjunction`) requires an authenticated org member —
+ * unauthenticated the endpoint returns `{}`. Resolving it at runtime would mean an npm
+ * token in CI, would fail on fork PRs where secrets are unavailable, and would still yield
+ * npm usernames, which are not GitHub handles and cannot be mentioned here.
+ *
+ * Sourced from .github/CODEOWNERS, which assigns publish.yml to this handle.
+ *
+ * TO REFRESH: `npm login && npm org ls memberjunction`, map to GitHub handles by hand. If
+ * a GitHub team is ever created for npm publishers, use that handle so it self-maintains.
+ */
+export const NPM_ESCALATION_HANDLE = '@cadam11';
+
+/** Public registry origin. */
+export const REGISTRY_URL = 'https://registry.npmjs.org';
+
+/** Guards against a runaway tree walk; the monorepo is nowhere near this. */
+export const MAX_MANIFESTS = 2000;
+
+/** A PR adding more than this many packages at once is a mistake worth stopping on. */
+export const MAX_NEW_PACKAGES = 50;
+
+/** Bounded retries for a request that neither succeeds nor 404s. */
+export const NPM_MAX_RETRIES = 3;
+
+/** Backoff between retries, in milliseconds. */
+export const NPM_RETRY_DELAY_MS = 2000;
+
+/** Verdicts a new package can receive. Order matters: each implies the previous passed. */
+export const STATUS = {
+    MISSING: 'missing',
+    NO_PROVENANCE: 'no-provenance',
+    WRONG_PROVENANCE: 'wrong-provenance',
+    READY: 'ready',
+};
+
+// ---------------------------------------------------------------------------
+// Pure functions — no I/O, directly unit tested.
+// ---------------------------------------------------------------------------
+
+/**
+ * Parse one package.json into the two facts this gate cares about.
+ * Throws on malformed JSON rather than skipping: a manifest this gate cannot read is a
+ * manifest whose publishability it cannot rule on.
+ */
+export function parseManifest(json, path) {
+    let parsed;
+    try {
+        parsed = JSON.parse(json);
+    } catch (err) {
+        throw new Error(`Invalid JSON in ${path}: ${err.message}`);
+    }
+    const name = typeof parsed.name === 'string' ? parsed.name : null;
+    return { path, name, isPrivate: parsed.private === true };
+}
+
+/**
+ * Reduce manifests to the set of names npm would actually receive.
+ * Private packages are excluded because changesets never publishes them
+ * (`packages.filter(pkg => !pkg.packageJson.private)`), so requiring an npm entry for one
+ * would gate on a question with no bearing on the outcome.
+ */
+export function publishableNames(manifests) {
+    const names = new Set();
+    for (const manifest of manifests) {
+        if (!manifest.name || !manifest.name.startsWith(NPM_SCOPE)) {
+            continue;
+        }
+        if (manifest.isPrivate) {
+            continue;
+        }
+        names.add(manifest.name);
+    }
+    return names;
+}
+
+/**
+ * Names newly publishable on this branch: present at head, absent at the merge base.
+ * Flipping `private: true` to `false` counts as new, which is correct — that package has
+ * never been published either.
+ */
+export function diffNewPackages(baseNames, headNames) {
+    return [...headNames].filter((name) => !baseNames.has(name)).sort();
+}
+
+/** Keep only tracked manifests under packages/, excluding any vendored copies. */
+export function selectManifestPaths(gitOutput) {
+    return gitOutput
+        .split('\n')
+        .map((line) => line.trim())
+        .filter((line) => line.endsWith('/package.json') || line === 'package.json')
+        .filter((line) => !line.includes('node_modules/'));
+}
+
+/**
+ * Which published version to demand provenance for.
+ * Prefers the seed tag, since a package new in this PR should have nothing else. Falls
+ * back to `latest` so a package seeded by some other route still verifies.
+ */
+export function selectVersionToVerify(packument) {
+    const tags = packument?.['dist-tags'] ?? {};
+    return tags[SEED_DIST_TAG] ?? tags.latest ?? null;
+}
+
+/**
+ * Pull the workflow identity out of an npm attestation document.
+ * npm returns several attestations per version (a publish attestation and a SLSA
+ * provenance one); only the provenance carries `buildDefinition`, so the others are
+ * skipped rather than treated as malformed.
+ */
+export function extractProvenance(attestationDoc) {
+    for (const attestation of attestationDoc?.attestations ?? []) {
+        const payload = attestation?.bundle?.dsseEnvelope?.payload;
+        if (!payload) {
+            continue;
+        }
+        let statement;
+        try {
+            statement = JSON.parse(Buffer.from(payload, 'base64').toString('utf8'));
+        } catch {
+            // A single unparseable envelope must not mask a valid one alongside it.
+            continue;
+        }
+        const workflow = statement?.predicate?.buildDefinition?.externalParameters?.workflow;
+        if (workflow) {
+            return { path: workflow.path ?? null, repository: workflow.repository ?? null, ref: workflow.ref ?? null };
+        }
+    }
+    return null;
+}
+
+/**
+ * Does this provenance prove MJ's own trusted publisher produced the package?
+ * Both fields must match: the right workflow in the wrong repository, or the wrong
+ * workflow in the right repository, is not the identity `publish.yml` will present.
+ */
+export function verifyProvenance(provenance) {
+    if (!provenance) {
+        return { ok: false, reason: 'no provenance attestation found' };
+    }
+    if (provenance.repository !== GITHUB_REPO_URL) {
+        return { ok: false, reason: `built from ${provenance.repository ?? 'an unknown repository'}, expected ${GITHUB_REPO_URL}` };
+    }
+    if (provenance.path !== PUBLISH_WORKFLOW_PATH) {
+        return { ok: false, reason: `built by ${provenance.path ?? 'an unknown workflow'}, expected ${PUBLISH_WORKFLOW_PATH}` };
+    }
+    return { ok: true, reason: 'provenance names the MJ publish workflow' };
+}
+
+/** One line per package, aligned, so a multi-package failure stays readable. */
+export function formatVerdictLine({ name, status, detail }) {
+    const label = {
+        [STATUS.MISSING]: 'NOT ON NPM',
+        [STATUS.NO_PROVENANCE]: 'NOT SEEDED',
+        [STATUS.WRONG_PROVENANCE]: 'BAD PROVENANCE',
+        [STATUS.READY]: 'ready',
+    }[status];
+    return `  ${label.padEnd(15)} ${name}${detail ? ` — ${detail}` : ''}`;
+}
+
+/**
+ * The whole point of the gate: tell the PR author exactly what to do, and what to do if
+ * they cannot do it. Kept pure so its wording is covered by tests.
+ */
+export function formatGateFailure(verdicts) {
+    const blocked = verdicts.filter((v) => v.status !== STATUS.READY);
+    const names = blocked.map((v) => v.name);
+    const first = names[0];
+    const needsCreating = blocked.filter((v) => v.status === STATUS.MISSING).map((v) => v.name);
+    const createStep = (needsCreating.length ? needsCreating : names)
+        .map((name) => `     npx setup-npm-trusted-publish ${name}`)
+        .join('\n');
+    const trustStep = names
+        .map(
+            (name) =>
+                `     npm trust github ${name} \\\n` +
+                `       --file ${PUBLISH_WORKFLOW_FILE} --repo ${GITHUB_REPO} --allow-publish -y`
+        )
+        .join('\n');
+
+    return `
+================================================================================
+BLOCKED: ${blocked.length} new package(s) are not ready to publish
+================================================================================
+
+${blocked.map(formatVerdictLine).join('\n')}
+
+These packages are new in this PR. Each must exist on npm AND have a trusted-publisher
+(OIDC) configuration before this PR merges, or the next release fails partway through.
+
+Creating them cannot be automated: npm will not attach a trusted-publisher config to a
+package that does not exist, and creating one needs an interactive 2FA challenge no CI
+token may satisfy. Doing it here, at PR time, keeps it off the release critical path.
+
+--------------------------------------------------------------------------------
+HOW TO FIX (about 5 minutes, plus one 2FA prompt)
+--------------------------------------------------------------------------------
+
+1. Upgrade your npm CLI. \`npm trust\` requires ${MIN_NPM_VERSION} or newer:
+
+     npm install -g npm@^11.15.0
+     npm --version
+
+2. Log in. Your account needs 2FA enabled — the trust API rejects granular access
+   tokens that bypass 2FA:
+
+     npm login
+
+3. Create the package on npm. It must exist before step 4 will work:
+
+${createStep}
+
+4. Attach the trusted-publisher config so ${PUBLISH_WORKFLOW_FILE} can publish it:
+
+${trustStep}
+
+   You get one 2FA prompt. Setting up several packages? The npm website offers a
+   "skip 2FA for the next 5 minutes" option during that prompt — tick it and the rest
+   run without further prompts.
+
+5. Seed the package over OIDC. In the Actions tab, run the "${SEED_WORKFLOW_NAME}"
+   workflow with the package name. It publishes a seed version using the trusted
+   publisher, so it succeeds ONLY if step 4 actually worked.
+
+6. Re-run this check. It reads the public provenance attestation the seed left behind
+   and confirms it names ${GITHUB_REPO} / ${PUBLISH_WORKFLOW_PATH}.
+
+Nothing to paste, nothing to take on trust — step 5 is the proof, and step 6 reads it.
+You can check the same thing yourself at any time:
+
+     curl -s ${REGISTRY_URL}/-/npm/v1/attestations/${first?.replace('/', '%2f')}@<version>
+
+--------------------------------------------------------------------------------
+IF YOU DO NOT HAVE NPM ACCESS
+--------------------------------------------------------------------------------
+
+Publishing rights on the @memberjunction org are deliberately narrow, so most authors
+cannot run steps 1 to 4. That is expected — hand it off:
+
+1. Comment on this PR with exactly this, so whoever picks it up needs no other context:
+
+     ${NPM_ESCALATION_HANDLE} — new package npm setup needed before merge:
+${names.map((name) => `       ${name}`).join('\n')}
+     Repo ${GITHUB_REPO}, workflow ${PUBLISH_WORKFLOW_FILE}, allow-publish, no environment.
+     Then run the "${SEED_WORKFLOW_NAME}" workflow for each.
+
+2. If nobody responds within one working day, escalate to any MemberJunction npm org
+   owner or admin. The current list is visible to org members via:
+
+     npm org ls memberjunction
+
+   or on the web at:
+
+     ${NPM_MEMBERS_URL}
+
+3. If a release is imminent, raise it with the build engineer running it — a missing
+   package stops the publish partway through, which is far more expensive to unwind
+   than a blocked PR.
+
+Do NOT work around this by marking the package \`"private": true\` unless it genuinely
+should never be published. This gate skips private packages, so that silences the error
+without solving it, and the package quietly ships to nobody.
+
+Reference: NEW_PACKAGE_SETUP.md, and DEPLOYMENT.md Step 5.
+================================================================================
+`.trimStart();
+}
+
+// ---------------------------------------------------------------------------
+// I/O — git, the filesystem, and the npm registry.
+// ---------------------------------------------------------------------------
+
+/** Run git and return stdout. Throws with git's own stderr on failure. */
+function git(args) {
+    return execFileSync('git', args, { encoding: 'utf8', maxBuffer: 64 * 1024 * 1024 });
+}
+
+/**
+ * Manifest paths tracked under packages/ at `ref`, or in the working tree when ref is null.
+ * Uses git rather than a directory walk so ignored trees (node_modules, dist) never appear.
+ */
+export function listManifestPaths(ref) {
+    const output = ref
+        ? git(['ls-tree', '-r', '--name-only', ref, '--', 'packages'])
+        : git(['ls-files', '--', 'packages']);
+    const paths = selectManifestPaths(output);
+    if (paths.length > MAX_MANIFESTS) {
+        throw new Error(`Found ${paths.length} manifests under packages/, above the ${MAX_MANIFESTS} cap`);
+    }
+    return paths;
+}
+
+/** Read one manifest at `ref`, or from the working tree when ref is null. */
+function readManifestAt(ref, path) {
+    return ref ? git(['show', `${ref}:${path}`]) : readFileSync(path, 'utf8');
+}
+
+/** The set of publishable package names at `ref` (null = working tree). */
+export function collectPublishableNames(ref) {
+    const paths = listManifestPaths(ref);
+    const manifests = paths.map((path) => parseManifest(readManifestAt(ref, path), path));
+    return publishableNames(manifests);
+}
+
+const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+
+/**
+ * GET a registry document, returning `{ status, body }` where body is parsed JSON or null.
+ * 200 and 404 are answers and returned immediately. Anything else is retried, then raised —
+ * never downgraded to "missing", because a network blip that reads as a missing package
+ * would block a PR for no reason.
+ */
+export async function fetchRegistryJson(url, fetchImpl = fetch, delayMs = NPM_RETRY_DELAY_MS) {
+    let lastFailure = 'no attempt made';
+
+    for (let attempt = 1; attempt <= NPM_MAX_RETRIES; attempt++) {
+        let response = null;
+        try {
+            response = await fetchImpl(url, { headers: { accept: 'application/json' } });
+        } catch (err) {
+            lastFailure = `network error: ${err.message}`;
+        }
+
+        if (response && response.status === 404) {
+            return { status: 404, body: null };
+        }
+        if (response && response.status === 200) {
+            try {
+                return { status: 200, body: await response.json() };
+            } catch (err) {
+                lastFailure = `unparseable JSON: ${err.message}`;
+            }
+        } else if (response) {
+            lastFailure = `HTTP ${response.status}`;
+        }
+
+        if (attempt < NPM_MAX_RETRIES) {
+            console.log(`   Retry ${attempt}/${NPM_MAX_RETRIES} for ${url} (${lastFailure})`);
+            await sleep(delayMs);
+        }
+    }
+
+    throw new Error(
+        `Could not read ${url} after ${NPM_MAX_RETRIES} attempts (${lastFailure}). ` +
+            `Check https://status.npmjs.org/ and re-run.`
+    );
+}
+
+/** Registry path for a scoped package name. */
+export function packumentUrl(name) {
+    return `${REGISTRY_URL}/${name.replace('/', '%2f')}`;
+}
+
+/** Registry path for one version's attestations. */
+export function attestationUrl(name, version) {
+    return `${REGISTRY_URL}/-/npm/v1/attestations/${name.replace('/', '%2f')}@${version}`;
+}
+
+/**
+ * Decide whether one new package is ready to be published by `publish.yml`.
+ * Three questions in order, each only meaningful if the previous passed: does it exist,
+ * was it published through a trusted publisher, and was that publisher ours.
+ */
+export async function classifyPackage(name, fetchImpl = fetch, delayMs = NPM_RETRY_DELAY_MS) {
+    const packument = await fetchRegistryJson(packumentUrl(name), fetchImpl, delayMs);
+    if (packument.status === 404) {
+        return { name, status: STATUS.MISSING, detail: 'package does not exist on npm' };
+    }
+
+    const version = selectVersionToVerify(packument.body);
+    if (!version) {
+        return { name, status: STATUS.NO_PROVENANCE, detail: 'package exists but has no published version' };
+    }
+
+    const attestations = await fetchRegistryJson(attestationUrl(name, version), fetchImpl, delayMs);
+    if (attestations.status === 404) {
+        return { name, status: STATUS.NO_PROVENANCE, detail: `${version} has no provenance — seed workflow not run` };
+    }
+
+    const verdict = verifyProvenance(extractProvenance(attestations.body));
+    return verdict.ok
+        ? { name, status: STATUS.READY, detail: `${version} ${verdict.reason}` }
+        : { name, status: STATUS.WRONG_PROVENANCE, detail: `${version} ${verdict.reason}` };
+}
+
+// ---------------------------------------------------------------------------
+// Entry point
+// ---------------------------------------------------------------------------
+
+export async function main(argv) {
+    const baseRef = argv[0];
+    if (!baseRef) {
+        console.error('Usage: node .github/scripts/check-new-npm-packages.mjs <base-ref>');
+        return 2;
+    }
+
+    console.log(`Comparing publishable packages against ${baseRef}...`);
+    const baseNames = collectPublishableNames(baseRef);
+    const headNames = collectPublishableNames(null);
+    const added = diffNewPackages(baseNames, headNames);
+
+    if (added.length === 0) {
+        console.log(`No new publishable packages in this PR (${headNames.size} total, unchanged).`);
+        return 0;
+    }
+    if (added.length > MAX_NEW_PACKAGES) {
+        console.error(`This PR adds ${added.length} packages, above the ${MAX_NEW_PACKAGES} cap. Split it.`);
+        return 2;
+    }
+
+    console.log(`New publishable package(s) in this PR: ${added.length}`);
+    const verdicts = [];
+    for (const name of added) {
+        const verdict = await classifyPackage(name);
+        console.log(formatVerdictLine(verdict));
+        verdicts.push(verdict);
+    }
+
+    if (verdicts.every((verdict) => verdict.status === STATUS.READY)) {
+        console.log(`All ${added.length} new package(s) verified against ${GITHUB_REPO_URL}/${PUBLISH_WORKFLOW_PATH}.`);
+        return 0;
+    }
+
+    console.error(formatGateFailure(verdicts));
+    return 1;
+}
+
+if (import.meta.url === pathToFileURL(process.argv[1] ?? '').href) {
+    main(process.argv.slice(2))
+        .then((code) => process.exit(code))
+        .catch((err) => {
+            console.error(`Check could not be completed: ${err.message}`);
+            process.exit(2);
+        });
+}

--- a/.github/workflows/new-package-gate.yml
+++ b/.github/workflows/new-package-gate.yml
@@ -1,0 +1,79 @@
+name: New package npm gate
+
+# Blocks a PR that introduces a publishable @memberjunction/* package which does not yet
+# exist on npm with a trusted-publisher (OIDC) configuration.
+#
+# WHY THIS WORKFLOW EXISTS: npm will not attach a trusted-publisher config to a package
+# that does not exist, and creating one requires an interactive 2FA challenge no CI token
+# may satisfy (bypass-2FA granular access tokens were barred from changing trusted-
+# publishing config on 2026-07-31). The setup is therefore irreducibly manual — but it
+# does not have to happen during a release. Before this gate, DEPLOYMENT.md Step 5 found
+# missing packages mid-release, putting a human 2FA prompt on the release critical path
+# and failing `publish.yml` partway through if it was skipped. This moves that discovery
+# to the PR that adds the package, where it blocks one PR instead of a release.
+#
+# This does NOT replace `validate-npm-packages.sh`, which still checks all ~300 packages
+# at publish time. This gate checks only what the PR adds, so it costs a few seconds.
+#
+# Make this a required status check in branch protection, otherwise it reports but does
+# not block.
+
+on:
+  pull_request:
+    branches: [next]
+    paths:
+      - 'packages/**/package.json'
+      - '.github/scripts/check-new-npm-packages.mjs'
+      - '.github/workflows/new-package-gate.yml'
+  workflow_dispatch:
+
+concurrency:
+  group: new-package-gate-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  check:
+    name: Check new packages exist on npm
+    timeout-minutes: 10
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+          fetch-depth: 1
+
+      # The default PR checkout is the merge commit at depth 1, so the base commit is not
+      # present locally. Fetch just that one object rather than the full history.
+      - name: Fetch merge base
+        run: git fetch --no-tags --depth=1 origin ${{ github.event.pull_request.base.sha }}
+
+      - name: Set up node
+        uses: actions/setup-node@v6
+        with:
+          node-version: 24
+
+      # No `pnpm install`: the script uses only Node's stdlib plus git, deliberately, so
+      # this stays a seconds-long gate. Keep it that way.
+      - name: Check for new packages missing from npm
+        id: gate
+        run: |
+          set -o pipefail
+          node .github/scripts/check-new-npm-packages.mjs \
+            "${{ github.event.pull_request.base.sha }}" 2>&1 | tee /tmp/new-package-gate.log
+
+      # Surface the instructions in the PR's Checks summary so an author never has to
+      # expand a log to learn what to do.
+      - name: Publish result to job summary
+        if: always()
+        run: |
+          {
+            echo '## New package npm gate'
+            echo ''
+            echo '```'
+            cat /tmp/new-package-gate.log 2>/dev/null || echo 'The gate produced no output.'
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/seed-new-package.yml
+++ b/.github/workflows/seed-new-package.yml
@@ -1,0 +1,171 @@
+name: Seed new package
+
+# Publishes a seed version of a new @memberjunction/* package THROUGH the trusted
+# publisher, so that a public, machine-checkable proof of the OIDC configuration exists.
+#
+# WHY THIS WORKFLOW EXISTS: `new-package-gate.yml` needs to know whether a new package has
+# a trusted-publisher configuration attached. It cannot ask npm directly — the config lives
+# behind `GET /-/package/<name>/trust`, which rejects a read-only granular token with HTTP
+# 403, and the only token that can read it is write-scoped across every @memberjunction
+# package: the exact long-lived credential trusted publishing exists to abolish.
+#
+# So instead of asking whether trust is configured, we USE it and check what it leaves
+# behind. This job publishes over OIDC with `--provenance`. That publish can only succeed
+# if `npm trust github` has already been run for the package, and it deposits a public
+# provenance attestation naming this repository and publish.yml. The gate then reads that
+# attestation unauthenticated. No secrets anywhere in the chain.
+#
+# WHEN TO RUN IT: step 5 of the new-package setup, after `npm trust github`. The gate's
+# failure message walks the author through it.
+#
+# The seed is a prerelease published under a non-default dist-tag, so `latest` never points
+# at it and a real release is unaffected.
+
+on:
+  workflow_dispatch:
+    inputs:
+      package:
+        description: 'Package name, e.g. @memberjunction/new-thing'
+        required: true
+        type: string
+      version:
+        description: 'Seed version (prerelease — must not collide with a real release)'
+        required: false
+        default: '0.0.1-seed.1'
+        type: string
+
+concurrency:
+  group: seed-new-package-${{ inputs.package }}
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+  id-token: write # mints the OIDC token npm exchanges for publish rights
+
+jobs:
+  seed:
+    name: Seed ${{ inputs.package }} over OIDC
+    timeout-minutes: 10
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set up node
+        uses: actions/setup-node@v6
+        with:
+          node-version: 24
+          registry-url: 'https://registry.npmjs.org'
+
+      # Trusted publishing needs npm >= 11.5.1; pin well above it so the runner's bundled
+      # npm version can drift without silently changing behaviour here.
+      - name: Pin npm
+        run: |
+          npm install -g npm@^11.15.0
+          npm --version
+
+      - name: Validate inputs
+        env:
+          PACKAGE: ${{ inputs.package }}
+          VERSION: ${{ inputs.version }}
+        run: |
+          set -euo pipefail
+          case "$PACKAGE" in
+            @memberjunction/*) ;;
+            *) echo "::error::'$PACKAGE' is not in the @memberjunction scope."; exit 1 ;;
+          esac
+          # A seed must be a prerelease. A plain x.y.z could win the `latest` tag and point
+          # consumers at an empty placeholder.
+          case "$VERSION" in
+            *-*) ;;
+            *) echo "::error::'$VERSION' is not a prerelease. Use something like 0.0.1-seed.1."; exit 1 ;;
+          esac
+
+      # If the package does not exist, `npm trust github` cannot have been run against it
+      # either — npm refuses to configure trust for a nonexistent package. Say so plainly
+      # rather than letting the publish fail with a less obvious error.
+      - name: Require the package to already exist
+        env:
+          PACKAGE: ${{ inputs.package }}
+        run: |
+          set -euo pipefail
+          encoded="${PACKAGE/\//%2f}"
+          code=$(curl -s -o /dev/null -w '%{http_code}' "https://registry.npmjs.org/$encoded")
+          echo "registry returned HTTP $code for $PACKAGE"
+          if [ "$code" = "404" ]; then
+            echo "::error::$PACKAGE does not exist on npm yet. Run 'npx setup-npm-trusted-publish $PACKAGE' first, then 'npm trust github ...', then re-run this workflow."
+            exit 1
+          fi
+          if [ "$code" != "200" ]; then
+            echo "::error::Unexpected HTTP $code from the registry. Check https://status.npmjs.org/ and re-run."
+            exit 1
+          fi
+
+      # Published from a scratch directory, not the repo: the seed is a marker, not code.
+      # `repository` must name this repo or npm refuses to attach provenance.
+      - name: Build the seed package
+        env:
+          PACKAGE: ${{ inputs.package }}
+          VERSION: ${{ inputs.version }}
+        run: |
+          set -euo pipefail
+          mkdir -p /tmp/seed && cd /tmp/seed
+          cat > package.json <<EOF
+          {
+            "name": "$PACKAGE",
+            "version": "$VERSION",
+            "description": "Trusted-publishing seed. Proves OIDC is configured; contains no code.",
+            "license": "ISC",
+            "repository": {
+              "type": "git",
+              "url": "git+https://github.com/${{ github.repository }}.git"
+            }
+          }
+          EOF
+          cat > README.md <<EOF
+          # $PACKAGE
+
+          Seed release published over OIDC to prove trusted publishing is configured for
+          this package. It contains no code and is tagged \`seed\`, never \`latest\`.
+          Real releases are published by .github/workflows/publish.yml.
+          EOF
+          cat package.json
+
+      # The load-bearing step. Succeeds only if a trusted publisher naming this repository
+      # and publish.yml is already attached to the package. No NPM_TOKEN is set, on purpose.
+      - name: Publish seed over OIDC
+        working-directory: /tmp/seed
+        env:
+          NPM_TOKEN: ''
+        run: |
+          set -euo pipefail
+          npm publish --provenance --access public --tag seed 2>&1 | tee /tmp/seed-publish.log
+
+      # Read back what the publish deposited, so the operator sees the same evidence the
+      # gate will, without waiting for a PR run.
+      - name: Verify the attestation is public
+        env:
+          PACKAGE: ${{ inputs.package }}
+          VERSION: ${{ inputs.version }}
+        run: |
+          set -euo pipefail
+          encoded="${PACKAGE/\//%2f}"
+          url="https://registry.npmjs.org/-/npm/v1/attestations/$encoded@$VERSION"
+          code=$(curl -s -o /tmp/att.json -w '%{http_code}' "$url")
+          echo "attestation endpoint returned HTTP $code"
+          if [ "$code" != "200" ]; then
+            echo "::error::Published, but no public attestation at $url. The gate will still block. Confirm 'npm trust list $PACKAGE' names publish.yml."
+            exit 1
+          fi
+          node -e '
+            const d = require("/tmp/att.json");
+            for (const a of d.attestations ?? []) {
+              const p = a?.bundle?.dsseEnvelope?.payload;
+              if (!p) continue;
+              const s = JSON.parse(Buffer.from(p, "base64").toString());
+              const w = s?.predicate?.buildDefinition?.externalParameters?.workflow;
+              if (w) { console.log("workflow path :", w.path); console.log("workflow repo :", w.repository); }
+            }
+          '
+          {
+            echo "## Seeded ${PACKAGE}@${VERSION}"
+            echo ''
+            echo 'Published over OIDC with provenance. The new-package gate will now pass for this package.'
+          } >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
## One sentence

A new `@memberjunction/*` package can't be published until someone manually creates it on npm and attaches a trusted publisher — this moves that discovery from the middle of a release to the PR that adds the package, and verifies it via public provenance instead of taking anyone's word for it.

## The problem

`DEPLOYMENT.md` Step 5 checks for new packages **during the release**. If it's skipped, `publish.yml` fails partway through — after some packages have already gone out. Recovering from that is expensive (see the v5.49.0 incident in `DEPLOYMENT.md:691`).

The setup itself can't be automated, and that's not going to change:

- npm won't attach a trusted-publisher config to a package that doesn't exist (`npm trust` POSTs to `/-/package/<name>/trust`, which 404s)
- creating one requires an interactive 2FA challenge no CI token may satisfy — bypass-2FA granular tokens were barred from changing trusted-publishing config on **2026-07-31**, and lose publish entirely in **January 2027**
- [npm/cli#8544](https://github.com/npm/cli/issues/8544) (publish initial version with OIDC) has been open since Sept 2025, last activity Aug 5 2026, with no maintainer commitment

So the human stays. What changes is *when* they're needed: days earlier, blocking one PR instead of a release.

## Why provenance, not existence

An existence check is too weak — a hand-published placeholder with no OIDC config passes it and still fails the release. But the trust config can't be read from CI:

```
GET /-/package/@memberjunction%2fcore/trust
-> HTTP 403 {"error":"You may not perform that action with these credentials."}
```

Measured 2026-08-14 with a **read-only** granular token. The only token that can read it is write-scoped across every `@memberjunction` package — precisely the long-lived credential trusted publishing exists to abolish, and one npm is stripping of publish rights in January 2027 anyway.

So rather than asking npm whether trust is configured, this uses it and checks what it leaves behind. **Provenance attestations are public and readable unauthenticated:**

```
GET /-/npm/v1/attestations/@memberjunction%2fcore@5.51.0  -> 200
  workflow path  : .github/workflows/publish.yml
  workflow repo  : https://github.com/MemberJunction/MJ
```

A package can only carry that attestation if it was published *through* the trusted publisher. `seed-new-package.yml` publishes a seed version over OIDC — which succeeds only if `npm trust github` has been run — and the gate verifies the attestation. No secrets anywhere in the chain.

## What's here

| File | Role |
|---|---|
| `.github/scripts/check-new-npm-packages.mjs` | Diffs publishable names head vs merge base; classifies each new one |
| `.github/scripts/__tests__/check-new-npm-packages.test.mjs` | 40 tests, picked up by the existing `test.yml` glob |
| `.github/workflows/new-package-gate.yml` | PR gate; remediation goes into the Checks summary |
| `.github/workflows/seed-new-package.yml` | `workflow_dispatch`, `id-token: write`, no `NPM_TOKEN` |

Four verdicts: `NOT ON NPM`, `NOT SEEDED`, `BAD PROVENANCE`, `ready`. `NOT SEEDED` is the case an existence-only check would silently pass.

New-package setup becomes: create → `npm trust github` → click the seed dispatch → gate goes green on its own.

Verified against live npm:

```
ready           @memberjunction/core — 5.51.0 provenance names the MJ publish workflow
ready           @memberjunction/global — 5.51.0 provenance names the MJ publish workflow
NOT ON NPM      @memberjunction/does-not-exist-xyz — package does not exist on npm
```

## Please look closely at

1. **`seed-new-package.yml` has never run.** Its logic is sound but unexercised — the first new package is its first live test. Worth seeding a throwaway name before relying on it.
2. **The seed publishes a real version to the real registry** (`0.0.1-seed.1`, prerelease, `--tag seed`). It should never win `latest`, but that reasoning deserves a second pair of eyes.
3. **`NPM_ESCALATION_HANDLE` is `@cadam11`**, sourced from CODEOWNERS. I checked — the org has exactly one GitHub team (`bc-labs`), so there's no npm-publishers team to point at. If one gets created, swap the constant and it self-maintains.
4. **Only *new* packages are probed**, so a package that regressed after merge isn't caught here. `validate-npm-packages.sh` is unchanged and still gates the release.
5. **Restricted packages would read as missing** — the registry is queried unauthenticated, where restricted and nonexistent both return 404. Fine today (all MJ packages are public); documented in the header if that ever changes.

## Notes

- **No changeset.** No migrations and no package source touched; `changes.yml` only requires one for migrations, and a changeset here would bump all ~300 packages for a CI-only change.
- **Not yet a required status check** — Craig is wiring branch protection separately. Until then this reports but does not block.
- **No `pnpm install` in either workflow.** The script uses only Node stdlib and git; keeping it dependency-free is deliberate, same constraint as `ci-scripts.yml`.
- `DEPLOYMENT.md` / `NEW_PACKAGE_SETUP.md` still describe the old browser-based flow. Deliberately not touched here to keep this reviewable; worth a follow-up once the seed workflow has a live run behind it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DiWghfaiHmNd7a351cqonz
