### PR TITLE
ci: unbreak next — defer the two base-forms panel-slot components on the DOM ratchet

### DIFF
--- a/scripts/dom-test-report.mjs
+++ b/scripts/dom-test-report.mjs
@@ -48,6 +48,10 @@ const DEFERRALS = [
   [/\/task-graph-debug-toolbar\.component\.ts$/, "new task-graph-editor debug UI; DOM spec pending"],
   [/\/task-graph-debugger\.component\.ts$/, "new task-graph-editor debug UI; DOM spec pending"],
   [/\/task-graph-variables\.component\.ts$/, "new task-graph-editor variables UI; DOM spec pending"],
+  // New base-forms panel-slot components landed on `next` in #3811 without DOM specs; deferred
+  // here so the ratchet stays honest until the forms team backfills specs (then remove these).
+  [/\/form-contributions\.component\.ts$/, "new base-forms panel-slot UI; DOM spec pending"],
+  [/\/related-entity-grid-panel\.component\.ts$/, "new base-forms panel-slot UI; DOM spec pending"],
 ];
 const deferralReason = (rel) => (DEFERRALS.find(([re]) => re.test(rel)) || [])[1] || "";
 


### PR DESCRIPTION
## One sentence

`next` has been red since #3811 merged, because it added two Angular components with no DOM specs and pushed the coverage ratchet from 134 to 136 — this defers those two components so the ratchet passes at the **same** gate value, without raising it.

## What happened

PR #3811 ("form contributions + left-nav chrome") added:

- `packages/Angular/Generic/base-forms/src/lib/panel-slot/form-contributions.component.ts`
- `packages/Angular/Generic/base-forms/src/lib/panel-slot/related-entity-grid-panel.component.ts`

Neither has a DOM spec, which takes the undeferred-gap count from 134 to 136 against `node scripts/dom-test-report.mjs packages/Angular/Generic --max-none=134`.

**The gate worked.** #3811's "Run unit tests" check was already `FAILURE` when the PR merged at 22:16Z. The break therefore landed on `next`, and every branch cut from it since inherits a red check that has nothing to do with its own diff — the same shape as the #3793 breakage on Aug 13.

## What this does

Adds two `DEFERRALS` entries, following the precedent already in the file for the task-graph-editor debug/variables components. Deferrals are still reported as gaps and annotated with *why*, so the ratchet stays honest — the count returns to **134 against the same `--max-none=134`**.

**Deliberately not raising `--max-none` to 136.** The script's own docs call it "an absolute ratchet; lower N as specs land"; bumping it would pocket the regression permanently and silently.

## The specs are still owed

These two entries should come out when the forms team backfills the specs. `node scripts/dom-test-report.mjs packages/Angular/Generic` gives the ranked gap list.

## Verification

All five DOM gates, run exactly as CI runs them:

| Gate | Result |
|---|---|
| Generic ratchet | ✅ 134 <= 134 |
| Bootstrap ratchet | ✅ 0 <= 0 |
| Explorer coverage gate | ✅ 95.0% >= 85% |
| DOM-spec placement | ✅ exit 0 |
| Spec anti-pattern lint | ✅ exit 0 |

Both regexes were checked against the entire tree: they match **exactly one file each**, and nothing in `packages/Angular/Bootstrap` or `packages/Angular/Explorer`, so no other component is silently exempted.

## Reviewer note

One file, four added lines. This unblocks every open PR — including #3818, whose only failing check is this inherited breakage.
