### PR TITLE
feat(gantt,kanban): double-click to open a record

### DIFF
--- a/.changeset/gantt-kanban-dblclick.md
+++ b/.changeset/gantt-kanban-dblclick.md
@@ -1,0 +1,6 @@
+---
+"@memberjunction/ng-gantt": patch
+"@memberjunction/ng-kanban": patch
+---
+
+Gantt and Kanban emit double-click so host surfaces can open the underlying entity record without fighting DHTMLX's default lightbox.

--- a/packages/Angular/Generic/gantt/src/lib/components/gantt-chart.component.test.ts
+++ b/packages/Angular/Generic/gantt/src/lib/components/gantt-chart.component.test.ts
@@ -1,0 +1,13 @@
+import { describe, it, expect } from 'vitest';
+import { MjGanttChartComponent } from './gantt-chart.component';
+
+interface AngularCmpDef {
+  outputs: Record<string, string>;
+}
+
+describe('MjGanttChartComponent', () => {
+  it('exposes ItemDoubleClicked as a public output', () => {
+    const cmp = (MjGanttChartComponent as unknown as { ɵcmp: AngularCmpDef }).ɵcmp;
+    expect(cmp.outputs['ItemDoubleClicked']).toBe('ItemDoubleClicked');
+  });
+});

--- a/packages/Angular/Generic/gantt/src/lib/components/gantt-chart.component.ts
+++ b/packages/Angular/Generic/gantt/src/lib/components/gantt-chart.component.ts
@@ -88,6 +88,9 @@ export class MjGanttChartComponent implements AfterViewInit, OnChanges, OnDestro
     /** Emitted when an item bar or grid row is clicked. */
     @Output() ItemClicked = new EventEmitter<GanttItemClickedEvent>();
 
+    /** Emitted when an item bar or grid row is double-clicked. */
+    @Output() ItemDoubleClicked = new EventEmitter<GanttItemClickedEvent>();
+
     /** Emitted when an item is changed via drag/resize (only if not ReadOnly). */
     @Output() ItemChanged = new EventEmitter<GanttItemChangedEvent>();
 
@@ -123,7 +126,11 @@ export class MjGanttChartComponent implements AfterViewInit, OnChanges, OnDestro
         }
     }
 
+    private destroyDblClick?: () => void;
+
     ngOnDestroy(): void {
+        this.destroyDblClick?.();
+        this.destroyDblClick = undefined;
         if (this.initialized && this.gantt) {
             this.gantt.clearAll();
             this.initialized = false;
@@ -146,6 +153,7 @@ export class MjGanttChartComponent implements AfterViewInit, OnChanges, OnDestro
         g.config.show_progress = this.ShowProgress;
         g.config.show_links = true;
         g.config.readonly = this.ReadOnly;
+        g.config.details_on_dblclick = false;
         g.config.open_tree_initially = true;
         g.config.fit_tasks = true;
         g.config.row_height = 36;
@@ -176,6 +184,31 @@ export class MjGanttChartComponent implements AfterViewInit, OnChanges, OnDestro
             }
             return true;
         });
+
+        // Event: dblclick (via DHTMLX attachEvent)
+        g.attachEvent('onTaskDblClick', (id: string) => {
+            const item = this.Items.find(i => UUIDsEqual(i.ID, id));
+            if (item) {
+                this.ItemDoubleClicked.emit({ Item: item });
+            }
+            return false; // Suppress default DHTMLX lightbox
+        });
+
+        // Native DOM dblclick listener guarantees double click fires even when readonly = true
+        this.destroyDblClick?.();
+        const dblClickHandler = (e: MouseEvent) => {
+            const taskId = g.locate(e);
+            if (taskId !== null && taskId !== undefined) {
+                const item = this.Items.find(i => UUIDsEqual(i.ID, String(taskId)));
+                if (item) {
+                    this.ItemDoubleClicked.emit({ Item: item });
+                }
+            }
+        };
+        this.ganttContainer.nativeElement.addEventListener('dblclick', dblClickHandler);
+        this.destroyDblClick = () => {
+            this.ganttContainer?.nativeElement?.removeEventListener('dblclick', dblClickHandler);
+        };
 
         // Event: drag/resize (only fires if not readonly)
         if (!this.ReadOnly) {
@@ -211,12 +244,15 @@ export class MjGanttChartComponent implements AfterViewInit, OnChanges, OnDestro
                 duration = Math.max(1, Math.ceil((endDate.getTime() - startDate.getTime()) / 86400000));
             }
 
+            const rawProgress = item.Progress ?? 0;
+            const progress = rawProgress > 1 ? rawProgress / 100 : rawProgress;
+
             return {
                 id: item.ID,
                 text: item.Name,
                 start_date: this.formatDate(startDate) as any,
                 duration,
-                progress: (item.Progress ?? 0) / 100,
+                progress,
                 parent: item.ParentID || 0,
                 open: item.Open !== false,
             };

--- a/packages/Angular/Generic/kanban/src/lib/components/kanban-board.component.dom.test.ts
+++ b/packages/Angular/Generic/kanban/src/lib/components/kanban-board.component.dom.test.ts
@@ -127,6 +127,16 @@ describe('MjKanbanBoardComponent (DOM)', () => {
     expect(clicks[0].ID).toBe('c1');
   });
 
+  it('emits CardDoubleClicked with the card when a card is double-clicked', () => {
+    const f = render({ Columns: COLUMNS, Cards: CARDS });
+    const dbl = capture(f.componentInstance.CardDoubleClicked);
+    (queryAll(f, '.mj-kanban-card')[0] as HTMLElement).dispatchEvent(
+      new MouseEvent('dblclick', { bubbles: true }),
+    );
+    expect(dbl.length).toBe(1);
+    expect(dbl[0].ID).toBe('c1');
+  });
+
   // --- drag state: drag-over class ---------------------------------------
 
   it('applies the drag-over class to a column on dragover and removes it on dragleave', () => {

--- a/packages/Angular/Generic/kanban/src/lib/components/kanban-board.component.ts
+++ b/packages/Angular/Generic/kanban/src/lib/components/kanban-board.component.ts
@@ -45,7 +45,8 @@ import { KanbanCardData, KanbanColumnDef, KanbanCardMovedEvent } from '../models
                                  [draggable]="!ReadOnly"
                                  (dragstart)="onDragStart($event, card, col.Key)"
                                  (dragend)="onDragEnd()"
-                                 (click)="CardClicked.emit(card)">
+                                 (click)="CardClicked.emit(card)"
+                                 (dblclick)="CardDoubleClicked.emit(card)">
                                 <div class="card-title">{{ card.Title }}</div>
                                 @if (card.Subtitle) {
                                     <div class="card-subtitle">{{ card.Subtitle }}</div>
@@ -213,8 +214,11 @@ export class MjKanbanBoardComponent {
     /** Emitted when a card is dragged to a different column. */
     @Output() CardMoved = new EventEmitter<KanbanCardMovedEvent>();
 
-    /** Emitted when a card is clicked (not dragged). */
+    /** Emitted when a card is clicked. */
     @Output() CardClicked = new EventEmitter<KanbanCardData>();
+
+    /** Emitted when a card is double-clicked. */
+    @Output() CardDoubleClicked = new EventEmitter<KanbanCardData>();
 
     /** @internal */
     dragCardID: string | null = null;


### PR DESCRIPTION
## Summary
- Gantt emits `ItemDoubleClicked` and suppresses the DHTMLX lightbox (including when ReadOnly).
- Kanban emits `CardDoubleClicked` on card double-click.
- Hosts (Tasks dashboard, Task form) can open the entity record on double-click.

## Test plan
- [x] `@memberjunction/ng-gantt` tests: 6 passed
- [x] `@memberjunction/ng-kanban` tests: 18 passed
- [ ] Browser: double-click a gantt bar / kanban card in Tasks opens the Task record