### PR TITLE
fix(forms): left-nav related grids fill leftover column height

### DIFF
--- a/packages/Angular/Generic/base-forms/src/lib/container/record-form-container.component.css
+++ b/packages/Angular/Generic/base-forms/src/lib/container/record-form-container.component.css
@@ -69,7 +69,13 @@ mj-record-form-container {
   padding: 16px 20px 24px;
   display: flex;
   flex-direction: column;
-  min-height: 100%;
+  /* Definite height = the scroll-area's client box. min-height: 100% alone
+     lets the column grow with content and never gives related grids a
+     containing-block height, so Height:auto (100%) on the grid collapses. */
+  height: 100%;
+  max-height: 100%;
+  min-height: 0;
+  overflow: hidden;
   box-sizing: border-box;
 }
 
@@ -79,9 +85,11 @@ mj-record-form-container {
   max-width: 1160px;
 }
 
-.mj-forms-layout--left-nav {
+.mj-forms-layout-row.mj-forms-layout--left-nav {
   flex: 1;
   min-height: 0;
+  /* Wins over .mj-forms-layout-row { align-items: flex-start } so the
+     body column stretches to the rail / viewport instead of hugging content. */
   align-items: stretch;
   gap: 16px;
 }
@@ -119,8 +127,10 @@ mj-record-form-container {
 }
 
 .mj-forms-layout--left-nav mj-collapsible-panel.mj-panel--related-entity.mj-chrome-show {
-  flex: 1 1 auto;
-  min-height: 360px;
+  /* flex-basis 0 so grow uses the leftover viewport, not content size.
+     Do not set a pixel min-height — that was hiding a broken containing block. */
+  flex: 1 1 0;
+  min-height: 0;
   display: flex;
   flex-direction: column;
 }
@@ -128,14 +138,36 @@ mj-record-form-container {
 .mj-forms-layout--left-nav mj-collapsible-panel.mj-panel--related-entity.mj-chrome-show .mj-forms-panel,
 .mj-forms-layout--left-nav mj-collapsible-panel.mj-panel--related-entity.mj-chrome-show .mj-forms-panel-body,
 .mj-forms-layout--left-nav mj-collapsible-panel.mj-panel--related-entity.mj-chrome-show .mj-forms-panel-content {
-  flex: 1;
+  flex: 1 1 0;
   min-height: 0;
   display: flex;
   flex-direction: column;
 }
 
+/* Accordion related panels use a 400px resizable box. Left-nav must drop that
+   so height:100% on the grid resolves against the leftover column, not 400px
+   or a circular auto. */
+.mj-forms-layout--left-nav mj-collapsible-panel.mj-panel--related-entity.mj-chrome-show .mj-forms-panel-content {
+  height: auto;
+  max-height: none;
+  overflow: hidden;
+  resize: none;
+}
+
 .mj-forms-layout--left-nav .mj-forms-all-panels {
   gap: 0;
+  min-height: 0;
+  overflow: hidden;
+}
+
+/* Details (field panels) can be taller than the viewport — scroll inside the
+   column. Related grids scroll inside AG Grid instead. */
+.mj-forms-layout--left-nav .mj-forms-all-panels:has(mj-collapsible-panel.mj-chrome-show:not(.mj-panel--related-entity)) {
+  overflow-y: auto;
+}
+
+.mj-forms-layout--left-nav .mj-forms-all-panels > *:not(mj-collapsible-panel.mj-panel--related-entity) {
+  flex-shrink: 0;
 }
 
 .mj-forms-layout--left-nav .biz-hero {

--- a/packages/Angular/Generic/base-forms/src/lib/panel/collapsible-panel.component.dom.test.ts
+++ b/packages/Angular/Generic/base-forms/src/lib/panel/collapsible-panel.component.dom.test.ts
@@ -1,8 +1,10 @@
 import { describe, it, expect, vi } from 'vitest';
 import { CommonModule } from '@angular/common';
+import { Subject } from 'rxjs';
 import { renderComponentFixture, query, text, hasClass } from '@memberjunction/ng-test-utils';
 import { CompositeKey } from '@memberjunction/core';
 import { MjCollapsiblePanelComponent } from './collapsible-panel.component';
+import { FormChromeCoordinator } from '../chrome/form-chrome-coordinator.service';
 import type { FormNavigationEvent } from '../types/navigation-events';
 import type { FormContext } from '../types/form-types';
 
@@ -44,6 +46,35 @@ describe('MjCollapsiblePanelComponent (DOM)', () => {
     const f = render({ SectionName: 'Orders', Variant: 'related-entity', Form: formStub(true) });
     expect(hasClass(f, '.mj-forms-panel', 'mj-forms-panel--related')).toBe(true);
     expect(hasClass(f, '.mj-forms-panel', 'mj-forms-panel--inherited')).toBe(false);
+  });
+
+  it('does not pin a persisted pixel height when left-nav hides accordion chrome', () => {
+    const form = {
+      ...formStub(true),
+      GetSectionPanelHeight: () => 48,
+    };
+    const f = renderComponentFixture(MjCollapsiblePanelComponent, {
+      declarations: [MjCollapsiblePanelComponent],
+      imports: [CommonModule],
+      providers: [{
+        provide: FormChromeCoordinator,
+        useValue: {
+          HidesAccordionChrome: () => true,
+          IsRelatedSectionVisible: () => true,
+          IsFirstClassSectionVisible: () => true,
+          Spec: { RelatedRoles: new Map() },
+          Changes: new Subject<void>(),
+        },
+      }],
+      inputs: {
+        SectionName: 'Payments',
+        SectionKey: 'payments',
+        Variant: 'related-entity',
+        Form: form,
+      },
+    });
+    const content = query(f, '.mj-forms-panel-content') as HTMLElement;
+    expect(content.style.height).toBe('');
   });
 
   it('applies the inherited variant class', () => {

--- a/packages/Angular/Generic/base-forms/src/lib/panel/collapsible-panel.component.ts
+++ b/packages/Angular/Generic/base-forms/src/lib/panel/collapsible-panel.component.ts
@@ -211,11 +211,13 @@ export class MjCollapsiblePanelComponent implements OnInit, OnChanges, AfterCont
   private resizeObserverPrimed = false;
 
   /**
-   * Persisted panel height for related-entity panels.
-   * Returns undefined to let CSS default (400px) apply.
+   * Persisted accordion resize height for related-entity panels.
+   * Undefined lets CSS apply (400px accordion, leftover column in left-nav).
+   * Left-nav must not apply a pixel height — that would beat the flex fill.
    */
   get PanelContentHeight(): number | undefined {
     if (this.Variant !== 'related-entity') return undefined;
+    if (this.chrome?.HidesAccordionChrome(this.SectionKey)) return undefined;
     const formRef = this.Form as { GetSectionPanelHeight?: (key: string) => number | undefined };
     return formRef?.GetSectionPanelHeight?.(this.SectionKey);
   }
@@ -461,6 +463,9 @@ export class MjCollapsiblePanelComponent implements OnInit, OnChanges, AfterCont
         // Only a height change while the panel is expanded reflects a genuine user drag of
         // the resize handle. Ignore reflows while collapsed (e.g. content settling on load).
         if (!this.Expanded) return;
+        // Left-nav sizes the grid from the leftover column. Persisting that
+        // computed height would write ~0 (or the toolbar) and then pin it.
+        if (this.chrome?.HidesAccordionChrome(this.SectionKey)) return;
         const entry = entries[0];
         if (!entry) return;
         const newHeight = Math.round(entry.contentRect.height);


### PR DESCRIPTION
## Summary
- Related grids on a left-nav form (`Height: auto` → `height: 100%`) were collapsing to the toolbar. The left-nav column never had a definite containing-block height, so `flex: 1; min-height: 0` resolved to 0 and the toolbar still painted because overflow was visible.
- The left-nav body is now pinned to the form viewport. The selected related grid fills the leftover column (hero stays natural height). Accordion's 400px resize box is not used here, and left-nav no longer persists that computed height as a user resize.

## Test plan
- [ ] Open a Person with Payments / Subscriptions / Orders that have rows
- [ ] Each rail item shows the full grid (rows visible), filling the space under the identity header
- [ ] Details still scrolls if field panels are tall
- [ ] Accordion layout (small forms) is unchanged

Follow-up to #3824.