### PR TITLE
feat(forms): related-grid NewRecordValues, leftover height, section search

### DIFF
--- a/.changeset/related-new-record-defaults.md
+++ b/.changeset/related-new-record-defaults.md
@@ -1,0 +1,12 @@
+---
+"@memberjunction/core": patch
+"@memberjunction/ng-base-forms": patch
+"@memberjunction/ng-explorer-core": patch
+"@memberjunction/codegen-lib": patch
+---
+
+Related-entity grids prefill every join field on a new child record and persist those defaults on the new-record URL (`/record/:entity/new?NewRecordValues=...`) so the link survives refresh and deeplink.
+
+Left-nav related grids (including slot-mounted contributions) fill leftover column height and report their row-count badge: SetSectionRowCount upserts unknown section keys, contribution hosts are display:contents so they participate in the flex column, and accordion pixel heights are not applied while the rail is showing the panel.
+
+Section search matches contribution titles (Orders) in both accordion and left-nav, keeps the rail visible when only one group hits, and does not treat chrome-hidden panels as non-matches.

--- a/guides/FORMS_ARCHITECTURE_GUIDE.md
+++ b/guides/FORMS_ARCHITECTURE_GUIDE.md
@@ -101,7 +101,7 @@ shows a loading state until the record is ready (and an error state on failure).
   [EntityName]="'Users'"
   [PrimaryKey]="pk"          <!-- omit/empty → new record -->
   [Record]="preloaded"        <!-- OR bind an already-loaded BaseEntity -->
-  [NewRecordValues]="defaults"
+  [NewRecordValues]="defaults"   <!-- object or Field|value||Field2|value2 URL segment -->
   [EditMode]="null"           <!-- null = new→edit, existing→read -->
   [Config]="myConfig"
   [Provider]="Provider"
@@ -124,6 +124,24 @@ handle.
 host: it maps `Navigate` → `NavigationService`, `Notification` → `SharedService`,
 and record loads → `RecentAccessService`. That's the only Explorer-specific glue;
 all mechanics are Generic.
+
+Related-entity grids pass `NewRecordValues` from the join fields that filter the
+grid so **New** opens a child already linked to the parent.
+
+- `BaseFormComponent.NewRecordValues(relatedEntity, joinField?)` — one
+  relationship, or every join field when several `EntityRelationship` rows
+  share the related entity (Bill-To + Ship-To on the same Orders grid).
+- `NewRecordValuesForJoinFields(relatedEntity, fields)` — explicit list when
+  the grid already knows the FKs (Person Orders, Organization Orders).
+- `EntityInfo.BuildRelationshipNewRecordValues` / `…ForJoinFields` — typed
+  core helpers. When `EntityRelationship.Configuration.UI.join.fields` is set,
+  every named FK is copied, not only `RelatedEntityJoinField`.
+
+Explorer persists those defaults on the new-record URL
+(`/record/:entity/new?NewRecordValues=Field|value||Field2|value2`, using
+`NEW_ENTITY_RECORD_URL_ID` and `NEW_RECORD_VALUES_QUERY_PARAM` from
+`@memberjunction/core`). Refresh and share keep the child linked. Overlay
+hosts accept the same object or URL-segment string on `[NewRecordValues]`.
 
 ---
 
@@ -476,17 +494,36 @@ container.
 #### Left-nav
 
 The rail picks one group; the body shows only that group. Selected content
-has **no accordion chrome** (the rail is the header) and related grids fill
-the remaining height. **More** is a folder on the rail — click to expand
-sub-nodes, then pick one item like any other rail entry. Field panels
-collapse into one **Details** item. Related Primary grids stay first-class
-(same related entity and same-title grids merge). `System Metadata` and
-More related always sit in More. Rail items use the same icon as the
-accordion header (entity `Icon` when present) and show related-grid row
-counts after they load. Users reorder first-class items by dragging the
-rail grip (or Manage Sections / reset in the toolbar). Section search
-filters the rail the same way it filters accordion panels. The centered /
-full-width toolbar toggle still applies.
+has **no accordion chrome** (the rail is the header). Related grids fill the
+**leftover column height** — the selected panel is `flex: 1 1 auto` in the
+column, not a pinned pixel height. Accordion-persisted heights are not
+applied while the rail is showing the panel.
+
+Slot-mounted contributions (`<mj-form-panel-slot>` / `BaseFormPanel` hosts)
+use `display: contents` so they do not sit as an extra wrapper in that flex
+column. `SetSectionRowCount` **upserts** the key: contribution sections are
+not seeded by generated `initSections()`, so the rail badge still appears
+(Orders on Person, Payments, etc.).
+
+**More** is a folder on the rail — click to expand sub-nodes, then pick one
+item like any other rail entry. Field panels collapse into one **Details**
+item. Related Primary grids stay first-class (same related entity and
+same-title grids merge). `System Metadata` and More related always sit in
+More. Rail items use the same icon as the accordion header (entity `Icon`
+when present). Users reorder first-class items by dragging the rail grip
+(or Manage Sections / reset in the toolbar). The centered / full-width
+toolbar toggle still applies.
+
+#### Section search
+
+Search matches a group's **title** and each panel's `MatchesSearch` (title
+plus registered keywords). It does **not** use `IsVisible` — chrome hides
+inactive left-nav groups, so visibility would make search miss everything
+except the selected item. Contribution titles (Orders, Payments) match in
+both accordion and left-nav. The rail stays visible whenever more than one
+chrome group exists **or** search is active, even if only one group hits.
+The empty state is **SearchHasNoMatches** (live match), not a baked
+ContentChildren snapshot that would miss slot-mounted panels.
 
 Authoring: `Entity.Configuration` / `EntityRelationship.Configuration`
 JSONType interfaces, [`PANELS.md`](../packages/Angular/Generic/base-forms/PANELS.md).

--- a/guides/NAVIGATION_AND_ROUTING_GUIDE.md
+++ b/guides/NAVIGATION_AND_ROUTING_GUIDE.md
@@ -93,6 +93,7 @@ this.router.events.pipe(
 | Nav item (static) | `/app/:appPath/:navItemName` |
 | App default (no nav items) | `/app/:appPath` |
 | Entity record | `/app/:appPath/record/:entityName/:recordId` |
+| New entity record | `/app/:appPath/record/:entityName/new?NewRecordValues=Field\|value\|\|Field2\|value2` |
 | Saved view | `/app/:appPath/view/:viewId` |
 | Dynamic view | `/app/:appPath/view/dynamic/:entityName?ExtraFilter=...` |
 | Dashboard | `/app/:appPath/dashboard/:dashboardId` |
@@ -234,6 +235,17 @@ Sub-navigation state is appended directly to the nav item URL:
 ```
 
 These params are stored in `tab.configuration.queryParams` by the `WorkspaceStateManager` and serialized into the URL by `buildResourceUrl` via `appendQP`.
+
+New-record tabs use the path sentinel `new` (`NEW_ENTITY_RECORD_URL_ID` in
+`@memberjunction/core`; `IsNewEntityRecordUrlId` is the matcher) and an
+optional `NewRecordValues` query param (`NEW_RECORD_VALUES_QUERY_PARAM`).
+The value is `FieldValueCollection` encoding (`Field|value||Field2|value2`);
+`EncodeNewRecordValuesForURL` builds it from an object. Related-entity
+grids pass every join field that filters the grid, so a deeplink such as
+`/app/Home/record/Order%20Headers/new?NewRecordValues=BillToPersonID|<id>||ShipToPersonID|<id>`
+opens a new order already linked back to the person. `recordId === 'new'`
+loads an empty `CompositeKey` (not a UUID named `new`). Refresh and share
+keep those defaults.
 
 ---
 

--- a/packages/Angular/Explorer/explorer-core/src/app-routing.module.ts
+++ b/packages/Angular/Explorer/explorer-core/src/app-routing.module.ts
@@ -6,7 +6,7 @@ import {
   AppLockGuardService as AppLockGuard
 } from './public-api';
 import { OAuthCallbackComponent } from './lib/oauth/oauth-callback.component';
-import { LogError, Metadata, StartupManager, IMetadataProvider } from '@memberjunction/core';
+import { LogError, Metadata, StartupManager, IMetadataProvider, IsNewEntityRecordUrlId, NEW_RECORD_VALUES_QUERY_PARAM } from '@memberjunction/core';
 import { SharedService, SYSTEM_APP_ID, RECORDS_RESOURCE_TYPE } from '@memberjunction/ng-shared';
 import { DetachedRouteHandle, RouteReuseStrategy } from '@angular/router';
 import { ApplicationManager, TabService } from '@memberjunction/ng-base-application';
@@ -115,6 +115,14 @@ export class CustomReuseStrategy implements RouteReuseStrategy {
       componentRef.instance[hookName]();
     }
   }
+}
+
+function readNewRecordValuesQuery(queryParams: { [key: string]: string | string[] | undefined | null }): string | undefined {
+  const raw = queryParams[NEW_RECORD_VALUES_QUERY_PARAM] ?? queryParams['newRecordValues'];
+  if (raw == null) return undefined;
+  const value = Array.isArray(raw) ? raw[0] : raw;
+  const trimmed = value?.trim();
+  return trimmed && trimmed.length > 0 ? trimmed : undefined;
 }
 
 @Injectable({
@@ -246,6 +254,8 @@ export class ResourceResolver implements Resolve<void> {
           // /app/:appName/record/:entityName/:recordId
           const entityName = decodeURIComponent(param1);
           const recordId = param2;
+          const isNew = IsNewEntityRecordUrlId(recordId);
+          const newRecordValues = readNewRecordValuesQuery(route.queryParams);
 
           const entityInfo = md.EntityByName(entityName);
           if (!entityInfo) {
@@ -255,15 +265,17 @@ export class ResourceResolver implements Resolve<void> {
 
           this.tabService.OpenTab({
             ApplicationId: app.ID,
-            Title: `${entityName} - ${recordId}`,
+            Title: isNew ? `New ${entityName}` : `${entityName} - ${recordId}`,
             Configuration: {
               resourceType: RECORDS_RESOURCE_TYPE,
               Entity: entityName,
-              recordId: recordId,
+              recordId: isNew ? '' : recordId,
+              isNew: isNew || undefined,
+              NewRecordValues: newRecordValues,
               appName: appName,
               appId: app.ID
             },
-            ResourceRecordId: recordId,
+            ResourceRecordId: isNew ? '' : recordId,
             IsPinned: false
           });
           return;
@@ -491,6 +503,8 @@ export class ResourceResolver implements Resolve<void> {
       // /resource/record/:entityName/:recordId
       const entityName = decodeURIComponent(route.params['entityName']);
       const recordId = route.params['recordId'];
+      const isNew = IsNewEntityRecordUrlId(recordId);
+      const newRecordValues = readNewRecordValuesQuery(route.queryParams);
 
       const entityInfo = md.EntityByName(entityName);
       if (!entityInfo) {
@@ -501,13 +515,15 @@ export class ResourceResolver implements Resolve<void> {
       // Queue tab request via TabService
       this.tabService.OpenTab({
         ApplicationId: SYSTEM_APP_ID,
-        Title: `${entityName} - ${recordId}`,
+        Title: isNew ? `New ${entityName}` : `${entityName} - ${recordId}`,
         Configuration: {
           resourceType: RECORDS_RESOURCE_TYPE,
           Entity: entityName,
-          recordId: recordId
+          recordId: isNew ? '' : recordId,
+          isNew: isNew || undefined,
+          NewRecordValues: newRecordValues
         },
-        ResourceRecordId: recordId,
+        ResourceRecordId: isNew ? '' : recordId,
         IsPinned: false
       });
       return;

--- a/packages/Angular/Explorer/explorer-core/src/lib/resource-wrappers/record-resource.component.ts
+++ b/packages/Angular/Explorer/explorer-core/src/lib/resource-wrappers/record-resource.component.ts
@@ -2,7 +2,7 @@ import { Component } from '@angular/core';
 import { BaseResourceComponent } from '@memberjunction/ng-shared';
 import { ResourceData } from '@memberjunction/core-entities';
 import { RegisterClass } from '@memberjunction/global';
-import { Metadata, CompositeKey, EntityInfo, IMetadataProvider } from '@memberjunction/core';
+import { Metadata, CompositeKey, EntityInfo, IMetadataProvider, IsNewEntityRecordUrlId } from '@memberjunction/core';
 @RegisterClass(BaseResourceComponent, 'RecordResource')
 @Component({
   standalone: false,
@@ -32,6 +32,10 @@ export class EntityRecordResource extends BaseResourceComponent {
         }
         if (!e){
             throw new Error(`Entity ${data.Configuration.Entity} not found in metadata (tried Name and DisplayName)`);
+        }
+
+        if (IsNewEntityRecordUrlId(data.ResourceRecordID)) {
+            return new CompositeKey();
         }
 
         let compositeKey: CompositeKey = new CompositeKey();

--- a/packages/Angular/Explorer/explorer-core/src/lib/shell/shell.component.ts
+++ b/packages/Angular/Explorer/explorer-core/src/lib/shell/shell.component.ts
@@ -13,7 +13,7 @@ import {
   AppAccessResult,
   NavItem
 } from '@memberjunction/ng-base-application';
-import { Metadata, EntityInfo, LogStatus, LogError, StartupManager, CompositeKey } from '@memberjunction/core';
+import { Metadata, EntityInfo, LogStatus, LogError, StartupManager, CompositeKey, EncodeNewRecordValuesForURL, IsNewEntityRecordUrlId, NEW_ENTITY_RECORD_URL_ID, NEW_RECORD_VALUES_QUERY_PARAM } from '@memberjunction/core';
 import { MJEventType, MJGlobal, uuidv4 , UUIDsEqual } from '@memberjunction/global';
 import { EventCodes, NavigationService, SharedService, SYSTEM_APP_ID, TitleService, DeveloperModeService, ThemeService, HomeAppPinService, ActivityService, ActivityItem, SetRecordOpenStyle, RecordOpenStyle, IsRecordsRegionTab, IsRecordsTabConfiguration } from '@memberjunction/ng-shared';
 import { StartupValidationService } from '../services/startup-validation.service';
@@ -1428,10 +1428,11 @@ export class ShellComponent extends BaseAngularComponent implements OnInit, OnDe
     const tabAppId = tab.applicationId;
 
     // Helper to append query params to a URL, preserving any existing params
-    const appendQP = (url: string): string => {
-      if (!queryParams || Object.keys(queryParams).length === 0) return url;
+    const appendQP = (url: string, extra?: Record<string, string>): string => {
+      const all = { ...(queryParams ?? {}), ...(extra ?? {}) };
+      if (Object.keys(all).length === 0) return url;
       const separator = url.includes('?') ? '&' : '?';
-      const params = new URLSearchParams(queryParams);
+      const params = new URLSearchParams(all);
       return `${url}${separator}${params.toString()}`;
     };
 
@@ -1550,13 +1551,22 @@ export class ShellComponent extends BaseAngularComponent implements OnInit, OnDe
       switch (resourceType) {
         case 'records':
           // /app/:appName/record/:entityName/:recordId
-          if (entityName && recordId) {
-            // recordId is a CompositeKey URL segment ("ID|<value>") — the '|' MUST be encoded.
-            // Angular's UrlSerializer percent-encodes '|' to %7C in router.url, so if we embed it raw
-            // here, `syncUrlWithWorkspace`'s `currentUrl !== newUrl` check is permanently true and can
-            // drive a re-navigation loop (with onSameUrlNavigation:'reload'). The read side already
-            // decodeURIComponent()s this segment, so encoding here keeps both sides consistent.
-            return appendQP(`/app/${encodeURIComponent(appPath)}/record/${encodeURIComponent(entityName)}/${encodeURIComponent(recordId)}`);
+          // Unsaved records use the `new` sentinel so they can deeplink with NewRecordValues.
+          if (entityName) {
+            const isNewRecord = config['isNew'] === true || IsNewEntityRecordUrlId(recordId);
+            const idSeg = isNewRecord ? NEW_ENTITY_RECORD_URL_ID : recordId;
+            if (idSeg) {
+              // recordId is a CompositeKey URL segment ("ID|<value>") — the '|' MUST be encoded.
+              // Angular's UrlSerializer percent-encodes '|' to %7C in router.url, so if we embed it raw
+              // here, `syncUrlWithWorkspace`'s `currentUrl !== newUrl` check is permanently true and can
+              // drive a re-navigation loop (with onSameUrlNavigation:'reload'). The read side already
+              // decodeURIComponent()s this segment, so encoding here keeps both sides consistent.
+              const nrv = isNewRecord ? EncodeNewRecordValuesForURL(config['NewRecordValues']) : undefined;
+              return appendQP(
+                `/app/${encodeURIComponent(appPath)}/record/${encodeURIComponent(entityName)}/${encodeURIComponent(idSeg)}`,
+                nrv ? { [NEW_RECORD_VALUES_QUERY_PARAM]: nrv } : undefined,
+              );
+            }
           }
           break;
 
@@ -1625,10 +1635,18 @@ export class ShellComponent extends BaseAngularComponent implements OnInit, OnDe
     // Fallback to legacy routes (for backward compatibility during transition)
     switch (resourceType) {
       case 'records':
-        if (entityName && recordId) {
-          // Encode the CompositeKey segment ('|' → %7C) to match Angular's serialized router.url and
-          // the decodeURIComponent() on the read side — see the app-scoped 'records' case above.
-          return appendQP(`/resource/record/${encodeURIComponent(entityName)}/${encodeURIComponent(recordId)}`);
+        if (entityName) {
+          const isNewRecord = config['isNew'] === true || IsNewEntityRecordUrlId(recordId);
+          const idSeg = isNewRecord ? NEW_ENTITY_RECORD_URL_ID : recordId;
+          if (idSeg) {
+            // Encode the CompositeKey segment ('|' → %7C) to match Angular's serialized router.url and
+            // the decodeURIComponent() on the read side — see the app-scoped 'records' case above.
+            const nrv = isNewRecord ? EncodeNewRecordValuesForURL(config['NewRecordValues']) : undefined;
+            return appendQP(
+              `/resource/record/${encodeURIComponent(entityName)}/${encodeURIComponent(idSeg)}`,
+              nrv ? { [NEW_RECORD_VALUES_QUERY_PARAM]: nrv } : undefined,
+            );
+          }
         }
         break;
 

--- a/packages/Angular/Generic/base-forms/PANELS.md
+++ b/packages/Angular/Generic/base-forms/PANELS.md
@@ -55,7 +55,11 @@ Every `<mj-form-panel-slot>` host:
 - Queries `MJGlobal.Instance.ClassFactory.GetAllRegistrationsByMetadata(BaseFormPanel, ...)` to find panels for its `(entity, slot)` pair.
 - Sorts results by `metadata.sortKey` desc, then `Priority` desc, then registration order.
 - Mounts each registered panel via `ViewContainerRef.createComponent`, wiring `[Record]` / `[FormComponent]` / `[FormContext]`.
+- Sets the slot host (and `BaseFormPanel` itself) to `display: contents` so left-nav leftover height reaches the related grid, not a wrapper.
 - Coordinates with siblings via the per-container `FormSlotCoordinator` to handle fallbacks (see below).
+
+Related grids call `FormComponent.NewRecordValues(relatedEntity, joinField)`
+so **New** prefills every join field that filters the grid.
 
 ## Available slots
 

--- a/packages/Angular/Generic/base-forms/README.md
+++ b/packages/Angular/Generic/base-forms/README.md
@@ -26,7 +26,8 @@ per-surface code and no regeneration.
 | **Per-instance config** | `EntityFormConfig` + `TAB_/DIALOG_/SLIDEIN_FORM_CONFIG` | Toolbar / related sections / collapsibility / width / record-links. Applied via the form reference — **no regeneration**. |
 | **Form resolution** | `FormResolverService` | Picks generated / custom / interactive-override form + variants (cached via `InteractiveFormsEngine`). |
 | **Form extension** | `BaseFormPanel` + `<mj-form-panel-slot>` + `<mj-form-contributions>` | Inject custom sections; claim a related-entity grid; fill in unbaked `DisplayInForm` relationships. See [PANELS.md](./PANELS.md) and [`/plans/form-contributions.md`](../../../../plans/form-contributions.md). |
-| **Form chrome** | `ResolveFormChrome`, `BaseFormPolicy`, `MJ: Form Chrome Rules` | L0–L4 stack: inclusion, Auto ranker, install overlay, user order. Policy is cosmetics only. See [Forms Architecture §7d](../../../../guides/FORMS_ARCHITECTURE_GUIDE.md#7d-form-chrome--accordion-left-nav-and-more). |
+| **Form chrome** | `ResolveFormChrome`, `BaseFormPolicy`, `MJ: Form Chrome Rules` | L0–L4 stack: inclusion, Auto ranker, install overlay, user order. Policy is cosmetics only. Left-nav related grids fill leftover column height (`display: contents` on slot hosts; no accordion pixel pin). `SetSectionRowCount` upserts so contribution badges appear. Section search matches title/`MatchesSearch`, not `IsVisible`. See [Forms Architecture §7d](../../../../guides/FORMS_ARCHITECTURE_GUIDE.md#7d-form-chrome--accordion-left-nav-and-more). |
+| **New-record defaults** | `BaseFormComponent.NewRecordValues` / `NewRecordValuesForJoinFields` | Related grids copy every join field onto the child. Explorer persists them as `/record/:entity/new?NewRecordValues=...`. |
 
 ## Quick start
 

--- a/packages/Angular/Generic/base-forms/src/lib/base-form-component.ts
+++ b/packages/Angular/Generic/base-forms/src/lib/base-form-component.ts
@@ -169,7 +169,8 @@ export abstract class BaseFormComponent extends BaseRecordComponent implements A
   /** Subscription to form state changes */
   private formStateSubscription?: Subscription;
 
-  @ViewChildren(MjCollapsiblePanelComponent) collapsiblePanels!: QueryList<MjCollapsiblePanelComponent>;
+  @ViewChildren(MjCollapsiblePanelComponent)
+  collapsiblePanels!: QueryList<MjCollapsiblePanelComponent>;
 
   async ngOnInit() {
     if (this.record) {
@@ -578,12 +579,37 @@ export abstract class BaseFormComponent extends BaseRecordComponent implements A
     return undefined;
   }
 
-  public NewRecordValues(relatedEntityName: string): Record<string, unknown> {
-    const eri = this.GetEntityRelationshipByRelatedEntityName(relatedEntityName);
-    if (eri)
-      return this.NewRecordValuesByEntityRelationship(eri);
-    else
-      return {};
+  /**
+   * Default values for a new related-entity record so it links back here.
+   * Pass `relatedEntityJoinField` when more than one relationship targets the
+   * same entity (Bill-To vs Ship-To). When omitted and several matches exist,
+   * every matching FK is set — same fields the related grid is filtering on.
+   */
+  public NewRecordValues(relatedEntityName: string, relatedEntityJoinField?: string): Record<string, unknown> {
+    if (!this.record) return {};
+    if (relatedEntityJoinField) {
+      const eri = this.GetEntityRelationshipByRelatedEntityName(relatedEntityName, relatedEntityJoinField);
+      if (eri) return this.NewRecordValuesByEntityRelationship(eri);
+      return EntityInfo.BuildRelationshipNewRecordValuesForJoinFields(this.record, [relatedEntityJoinField]);
+    }
+    const matches = this.record.EntityInfo.RelatedEntities.filter(
+      (x) => x.RelatedEntity.trim().toLowerCase() === relatedEntityName.trim().toLowerCase(),
+    );
+    if (matches.length === 0) return {};
+    if (matches.length === 1) return this.NewRecordValuesByEntityRelationship(matches[0]);
+    return EntityInfo.BuildRelationshipNewRecordValuesForJoinFields(
+      this.record,
+      matches.map((m) => m.RelatedEntityJoinField),
+    );
+  }
+
+  /**
+   * Default values for a new related record, setting every listed join field
+   * to this record's key. Pair with {@link BuildRelationshipViewParamsForJoinFields}.
+   */
+  public NewRecordValuesForJoinFields(relatedEntityName: string, joinFields: readonly string[]): Record<string, unknown> {
+    if (!this.record || !relatedEntityName) return {};
+    return EntityInfo.BuildRelationshipNewRecordValuesForJoinFields(this.record, joinFields);
   }
 
   public NewRecordValuesByEntityRelationship(item: EntityRelationshipInfo): Record<string, unknown> {
@@ -862,10 +888,18 @@ export abstract class BaseFormComponent extends BaseRecordComponent implements A
   }
 
   public SetSectionRowCount(sectionKey: string, rowCount: number): void {
-    const section = this.sectionMap.get(sectionKey);
-    if (section) {
+    let section = this.sectionMap.get(sectionKey);
+    if (!section) {
+      // Contribution panels use their own SectionKey (e.g. 'orders') which
+      // is never seeded by generated initSections(). Upsert so the left-nav
+      // rail badge can read the count the same way baked grids do.
+      section = new BaseFormSectionInfo(sectionKey, sectionKey, false, rowCount);
+      this.sections.push(section);
+      this.sectionMap.set(sectionKey, section);
+    } else {
       section.rowCount = rowCount;
     }
+    this.cdr.markForCheck();
   }
 
   public GetSectionPanelHeight(sectionKey: string): number | undefined {

--- a/packages/Angular/Generic/base-forms/src/lib/container/record-form-container.component.css
+++ b/packages/Angular/Generic/base-forms/src/lib/container/record-form-container.component.css
@@ -69,7 +69,13 @@ mj-record-form-container {
   padding: 16px 20px 24px;
   display: flex;
   flex-direction: column;
-  min-height: 100%;
+  /* Definite height = the scroll-area's client box. min-height: 100% alone
+     lets the column grow with content and never gives related grids a
+     containing-block height, so Height:auto (100%) on the grid collapses. */
+  height: 100%;
+  max-height: 100%;
+  min-height: 0;
+  overflow: hidden;
   box-sizing: border-box;
 }
 
@@ -79,9 +85,11 @@ mj-record-form-container {
   max-width: 1160px;
 }
 
-.mj-forms-layout--left-nav {
+.mj-forms-layout-row.mj-forms-layout--left-nav {
   flex: 1;
   min-height: 0;
+  /* Wins over .mj-forms-layout-row { align-items: flex-start } so the
+     body column stretches to the rail / viewport instead of hugging content. */
   align-items: stretch;
   gap: 16px;
 }
@@ -119,8 +127,10 @@ mj-record-form-container {
 }
 
 .mj-forms-layout--left-nav mj-collapsible-panel.mj-panel--related-entity.mj-chrome-show {
-  flex: 1 1 auto;
-  min-height: 360px;
+  /* flex-basis 0 so grow uses the leftover viewport, not content size.
+     Do not set a pixel min-height — that was hiding a broken containing block. */
+  flex: 1 1 0;
+  min-height: 0;
   display: flex;
   flex-direction: column;
 }
@@ -128,14 +138,36 @@ mj-record-form-container {
 .mj-forms-layout--left-nav mj-collapsible-panel.mj-panel--related-entity.mj-chrome-show .mj-forms-panel,
 .mj-forms-layout--left-nav mj-collapsible-panel.mj-panel--related-entity.mj-chrome-show .mj-forms-panel-body,
 .mj-forms-layout--left-nav mj-collapsible-panel.mj-panel--related-entity.mj-chrome-show .mj-forms-panel-content {
-  flex: 1;
+  flex: 1 1 0;
   min-height: 0;
   display: flex;
   flex-direction: column;
 }
 
+/* Accordion related panels use a 400px resizable box. Left-nav must drop that
+   so height:100% on the grid resolves against the leftover column, not 400px
+   or a circular auto. */
+.mj-forms-layout--left-nav mj-collapsible-panel.mj-panel--related-entity.mj-chrome-show .mj-forms-panel-content {
+  height: auto;
+  max-height: none;
+  overflow: hidden;
+  resize: none;
+}
+
 .mj-forms-layout--left-nav .mj-forms-all-panels {
   gap: 0;
+  min-height: 0;
+  overflow: hidden;
+}
+
+/* Details (field panels) can be taller than the viewport — scroll inside the
+   column. Related grids scroll inside AG Grid instead. */
+.mj-forms-layout--left-nav .mj-forms-all-panels:has(mj-collapsible-panel.mj-chrome-show:not(.mj-panel--related-entity)) {
+  overflow-y: auto;
+}
+
+.mj-forms-layout--left-nav .mj-forms-all-panels > *:not(mj-collapsible-panel.mj-panel--related-entity) {
+  flex-shrink: 0;
 }
 
 .mj-forms-layout--left-nav .biz-hero {

--- a/packages/Angular/Generic/base-forms/src/lib/container/record-form-container.component.html
+++ b/packages/Angular/Generic/base-forms/src/lib/container/record-form-container.component.html
@@ -75,7 +75,7 @@
          [class.mj-forms-layout--left-nav]="ChromeLayout === 'left-nav'"
          [class.mj-forms-layout--accordion]="ChromeLayout === 'accordion'"
          [class.mj-forms-layout--more]="IsChromeMoreActive">
-      @if (ChromeLayout === 'left-nav' && ChromeGroups.length > 1) {
+      @if (ShowChromeRail) {
         <nav class="mj-forms-chrome-rail" aria-label="Form sections">
           @for (group of ChromeFirstClassGroups; track group.Key) {
             <div class="mj-forms-chrome-rail-item"
@@ -216,7 +216,7 @@
         }
 
         <!-- Empty state when no sections match search -->
-        @if (EffectiveSearchFilter && VisibleSectionCount === 0) {
+        @if (EffectiveSearchFilter && SearchHasNoMatches) {
           <mj-empty-state class="mj-forms-empty-search-state"
             Variant="no-results"
             Title="No sections found"

--- a/packages/Angular/Generic/base-forms/src/lib/container/record-form-container.component.ts
+++ b/packages/Angular/Generic/base-forms/src/lib/container/record-form-container.component.ts
@@ -357,11 +357,33 @@ export class MjRecordFormContainerComponent extends BaseAngularComponent impleme
   }
 
   get VisibleSectionCount(): number {
+    const filter = this.EffectiveSearchFilter.toLowerCase().trim();
+    if (filter) {
+      const fromPanels = this.allChromePanels().filter((p) => p.MatchesSearch(filter)).length;
+      const fromRail = this.ChromeFirstClassGroups.length + this.ChromeMoreItems.length;
+      return Math.max(fromPanels, fromRail);
+    }
     if (this.fc?.getVisibleSectionCount) {
       return this.fc.getVisibleSectionCount();
     }
-    if (!this.Panels) return 0;
-    return this.Panels.filter(p => p.IsVisible).length;
+    return this.Panels?.filter((p) => p.IsVisible).length ?? 0;
+  }
+
+  /** True when the current section search matches nothing in this layout. */
+  get SearchHasNoMatches(): boolean {
+    const filter = this.EffectiveSearchFilter.toLowerCase().trim();
+    if (!filter) return false;
+    return this.ChromeFirstClassGroups.length === 0 && this.ChromeMoreItems.length === 0
+      && this.allChromePanels().every((p) => !p.MatchesSearch(filter));
+  }
+
+  /** Left-nav rail stays up while searching even if only one group matches. */
+  get ShowChromeRail(): boolean {
+    if (this.ChromeLayout !== 'left-nav') return false;
+    if (this.EffectiveSearchFilter.trim()) {
+      return this.ChromeFirstClassGroups.length > 0 || this.ChromeMoreItems.length > 0;
+    }
+    return this.chrome.Spec.Groups.length > 1;
   }
 
   /**
@@ -723,6 +745,7 @@ export class MjRecordFormContainerComponent extends BaseAngularComponent impleme
   }
 
   private groupMatchesSearch(group: FormChromeGroup, filter: string): boolean {
+    if (!filter) return true;
     if (group.Title.toLowerCase().includes(filter)) return true;
     if (group.IsMore) {
       return group.SectionKeys.some((key) => {
@@ -732,8 +755,9 @@ export class MjRecordFormContainerComponent extends BaseAngularComponent impleme
     }
     return group.SectionKeys.some((key) => {
       const panel = this.allChromePanels().find((p) => p.SectionKey === key);
-      if (panel) return panel.IsVisible;
-      return key.toLowerCase().includes(filter);
+      if (panel) return panel.MatchesSearch(filter);
+      const human = HumanizeEntityTitle(key).toLowerCase();
+      return human.includes(filter) || key.toLowerCase().includes(filter);
     });
   }
 

--- a/packages/Angular/Generic/base-forms/src/lib/panel-slot/base-form-panel.ts
+++ b/packages/Angular/Generic/base-forms/src/lib/panel-slot/base-form-panel.ts
@@ -1,4 +1,4 @@
-import { Directive, Input } from '@angular/core';
+import { Directive, HostBinding, Input } from '@angular/core';
 import { BaseEntity, ValidationResult } from '@memberjunction/core';
 import { BaseFormComponent } from '../base-form-component';
 import { FormContext } from '../types/form-types';
@@ -112,6 +112,14 @@ export interface FormPanelRegistrationMetadata extends Record<string, unknown> {
  */
 @Directive()
 export abstract class BaseFormPanel<TRecord extends BaseEntity = BaseEntity> {
+    /**
+     * Slot-mounted hosts must not sit in the left-nav flex column — leftover
+     * height targets `mj-collapsible-panel` as a direct child of
+     * `.mj-forms-all-panels`. `display: contents` makes the inner panel that child.
+     */
+    @HostBinding('style.display')
+    readonly HostDisplay = 'contents';
+
     /** The entity record being edited. Set by the slot host before view init. */
     @Input() Record!: TRecord;
     /** The host form component (use for EditMode, dirty notifications, etc). Set by the slot host. */

--- a/packages/Angular/Generic/base-forms/src/lib/panel-slot/form-panel-slot.component.ts
+++ b/packages/Angular/Generic/base-forms/src/lib/panel-slot/form-panel-slot.component.ts
@@ -183,6 +183,11 @@ export class FormPanelSlotComponent implements OnInit, OnChanges, OnDestroy {
                 ref.instance.Record = this.Record;
                 ref.instance.FormComponent = this.FormComponent;
                 if (this.FormContext) ref.instance.FormContext = this.FormContext;
+                // Left-nav leftover height targets mj-collapsible-panel as a
+                // flex child of .mj-forms-all-panels. The slot is already
+                // display:contents; the mounted host must be too.
+                const host = ref.location.nativeElement as HTMLElement | null;
+                if (host) host.style.display = 'contents';
                 // No detectChanges() — Angular's normal CD pass picks the new
                 // component up. Calling detectChanges() synchronously inside
                 // an ongoing CD cycle (which is when ngOnChanges → remount

--- a/packages/Angular/Generic/base-forms/src/lib/panel-slot/related-entity-grid-panel.component.ts
+++ b/packages/Angular/Generic/base-forms/src/lib/panel-slot/related-entity-grid-panel.component.ts
@@ -25,7 +25,7 @@ import type { FormContributionWinner } from './form-contribution';
             @if (Record.IsSaved) {
                 <mj-explorer-entity-data-grid
                     [Params]="FormComponent.BuildRelationshipViewParamsByEntityName(Contribution.RelatedEntity!, Contribution.RelatedJoinField)"
-                    [NewRecordValues]="FormComponent.NewRecordValues(Contribution.RelatedEntity!)"
+                    [NewRecordValues]="FormComponent.NewRecordValues(Contribution.RelatedEntity!, Contribution.RelatedJoinField)"
                     [AllowLoad]="FormComponent.IsSectionExpanded(Contribution.BakedSectionKey)"
                     [ShowToolbar]="true"
                     (Navigate)="FormComponent.OnFormNavigate($event)"

--- a/packages/Angular/Generic/base-forms/src/lib/panel/collapsible-panel.component.dom.test.ts
+++ b/packages/Angular/Generic/base-forms/src/lib/panel/collapsible-panel.component.dom.test.ts
@@ -1,8 +1,10 @@
 import { describe, it, expect, vi } from 'vitest';
 import { CommonModule } from '@angular/common';
+import { Subject } from 'rxjs';
 import { renderComponentFixture, query, text, hasClass } from '@memberjunction/ng-test-utils';
 import { CompositeKey } from '@memberjunction/core';
 import { MjCollapsiblePanelComponent } from './collapsible-panel.component';
+import { FormChromeCoordinator } from '../chrome/form-chrome-coordinator.service';
 import type { FormNavigationEvent } from '../types/navigation-events';
 import type { FormContext } from '../types/form-types';
 
@@ -46,9 +48,48 @@ describe('MjCollapsiblePanelComponent (DOM)', () => {
     expect(hasClass(f, '.mj-forms-panel', 'mj-forms-panel--inherited')).toBe(false);
   });
 
+  it('does not pin a persisted pixel height when left-nav hides accordion chrome', () => {
+    const form = {
+      ...formStub(true),
+      GetSectionPanelHeight: () => 48,
+    };
+    const f = renderComponentFixture(MjCollapsiblePanelComponent, {
+      declarations: [MjCollapsiblePanelComponent],
+      imports: [CommonModule],
+      providers: [{
+        provide: FormChromeCoordinator,
+        useValue: {
+          HidesAccordionChrome: () => true,
+          IsRelatedSectionVisible: () => true,
+          IsFirstClassSectionVisible: () => true,
+          Spec: { RelatedRoles: new Map() },
+          Changes: new Subject<void>(),
+        },
+      }],
+      inputs: {
+        SectionName: 'Payments',
+        SectionKey: 'payments',
+        Variant: 'related-entity',
+        Form: form,
+      },
+    });
+    const content = query(f, '.mj-forms-panel-content') as HTMLElement;
+    expect(content.style.height).toBe('');
+  });
+
   it('applies the inherited variant class', () => {
     const f = render({ SectionName: 'Base', Variant: 'inherited', Form: formStub(true) });
     expect(hasClass(f, '.mj-forms-panel', 'mj-forms-panel--inherited')).toBe(true);
+  });
+
+  it('MatchesSearch hits section name, key, and field names without requiring chrome visibility', () => {
+    const f = render({ SectionName: 'Orders', SectionKey: 'orders', Form: formStub(false) });
+    const panel = f.componentInstance;
+    expect(panel.MatchesSearch('ord')).toBe(true);
+    expect(panel.MatchesSearch('orders')).toBe(true);
+    expect(panel.MatchesSearch('xyz')).toBe(false);
+    panel.FieldNames = 'order date total gross';
+    expect(panel.MatchesSearch('gross')).toBe(true);
   });
 
   it('omits the row-count badge when BadgeCount is undefined', () => {

--- a/packages/Angular/Generic/base-forms/src/lib/panel/collapsible-panel.component.ts
+++ b/packages/Angular/Generic/base-forms/src/lib/panel/collapsible-panel.component.ts
@@ -216,8 +216,19 @@ export class MjCollapsiblePanelComponent implements OnInit, OnChanges, AfterCont
    */
   get PanelContentHeight(): number | undefined {
     if (this.Variant !== 'related-entity') return undefined;
+    // Left-nav sizes the grid from leftover column height. A persisted
+    // accordion pixel height (or a 0 measured while hidden) would pin the
+    // body to the toolbar. Slot-mounted panels cannot inject the coordinator,
+    // so also honor the container-applied `mj-chrome-show` host class.
+    if (this.hidesAccordionChrome()) return undefined;
     const formRef = this.Form as { GetSectionPanelHeight?: (key: string) => number | undefined };
     return formRef?.GetSectionPanelHeight?.(this.SectionKey);
+  }
+
+  private hidesAccordionChrome(): boolean {
+    if (this.chrome?.HidesAccordionChrome(this.SectionKey)) return true;
+    const el = this.elementRef.nativeElement as HTMLElement | undefined;
+    return !!el?.classList.contains('mj-chrome-show');
   }
 
   /** Whether drag-to-reorder is allowed (from FormContext) */
@@ -400,6 +411,19 @@ export class MjCollapsiblePanelComponent implements OnInit, OnChanges, AfterCont
    * `Details` with just unused geo columns) should not take space.
    * Custom widgets and related grids have no FieldComponents — keep them.
    */
+  /**
+   * Whether this panel matches a section-search term by title or field
+   * name. Ignores chrome hide/show — the rail uses this to decide if the
+   * *group* matches, even when another section is currently selected.
+   */
+  public MatchesSearch(term: string): boolean {
+    const filter = (term || '').toLowerCase().trim();
+    if (!filter) return true;
+    if (this.SectionName.toLowerCase().includes(filter)) return true;
+    if (this.SectionKey.toLowerCase().includes(filter)) return true;
+    return this.FieldNames.includes(filter);
+  }
+
   private hasRenderableContent(): boolean {
     if (this.Variant === 'related-entity') return true;
     if (!this.FieldComponents || this.FieldComponents.length === 0) return true;
@@ -461,6 +485,9 @@ export class MjCollapsiblePanelComponent implements OnInit, OnChanges, AfterCont
         // Only a height change while the panel is expanded reflects a genuine user drag of
         // the resize handle. Ignore reflows while collapsed (e.g. content settling on load).
         if (!this.Expanded) return;
+        // Left-nav sizes the grid from the leftover column. Persisting that
+        // computed height would write ~0 (or the toolbar) and then pin it.
+        if (this.hidesAccordionChrome()) return;
         const entry = entries[0];
         if (!entry) return;
         const newHeight = Math.round(entry.contentRect.height);
@@ -506,7 +533,7 @@ export class MjCollapsiblePanelComponent implements OnInit, OnChanges, AfterCont
 
     const sectionMatches = this.SectionName.toLowerCase().includes(searchTerm);
     const fieldsMatch = this.FieldNames.includes(searchTerm);
-    this.IsVisible = sectionMatches || fieldsMatch;
+    this.IsVisible = this.MatchesSearch(searchTerm);
 
     // DisplayName is bound to `[innerHTML]` in the template — must always be HTML-safe.
     this.DisplayName =

--- a/packages/CodeGenLib/src/Angular/entity-data-grid-related-entity-component.ts
+++ b/packages/CodeGenLib/src/Angular/entity-data-grid-related-entity-component.ts
@@ -53,7 +53,7 @@ export class EntityDataGridRelatedEntityGenerator extends RelatedEntityDisplayCo
 
         const template = `<mj-explorer-entity-data-grid
     [Params]="BuildRelationshipViewParamsByEntityName('${input.RelationshipInfo!.RelatedEntity.trim()}','${input.RelationshipInfo!.RelatedEntityJoinField.trim()}')"
-    [NewRecordValues]="NewRecordValues('${input.RelationshipInfo!.RelatedEntity.trim()}')"
+    [NewRecordValues]="NewRecordValues('${input.RelationshipInfo!.RelatedEntity.trim()}','${input.RelationshipInfo!.RelatedEntityJoinField.trim()}')"
     [AllowLoad]="${allowLoadCheck}"
     [ShowToolbar]="true"
     (Navigate)="OnFormNavigate($event)"${afterDataLoadEvent ? `\n    ${afterDataLoadEvent}` : ''}

--- a/packages/CodeGenLib/src/Angular/related-entity-components.ts
+++ b/packages/CodeGenLib/src/Angular/related-entity-components.ts
@@ -141,7 +141,7 @@ export class ComponentConfigBase {
  * 
  * **Commonly used BaseFormComponent methods/properties:**
  * - `BuildRelationshipViewParamsByEntityName()` - Creates view parameters for related entities
- * - `NewRecordValues()` - Provides default values for new related records
+ * - `NewRecordValues(relatedEntity, joinField?)` - FK defaults for a new related record (deeplinkable)
  * - `IsCurrentTab()` - Checks if the current tab is active (useful for deferred loading)
  * - `GridEditMode()` - Determines if grids should be in edit mode
  * - `GridBottomMargin()` - Provides consistent bottom margin for grids

--- a/packages/MJCore/src/__tests__/compositeKey.test.ts
+++ b/packages/MJCore/src/__tests__/compositeKey.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach } from 'vitest';
-import { CompositeKey, KeyValuePair, FieldValueCollection } from '../generic/compositeKey';
+import { CompositeKey, KeyValuePair, FieldValueCollection, EncodeNewRecordValuesForURL, IsNewEntityRecordUrlId, NEW_ENTITY_RECORD_URL_ID, NEW_RECORD_VALUES_QUERY_PARAM } from '../generic/compositeKey';
 import type { EntityInfo } from '../generic/entityInfo';
 
 /**
@@ -543,5 +543,37 @@ describe('CompositeKey', () => {
       expect(loaded.KeyValuePairs[0].Value).not.toBe('ID|11055');
       expect(loaded.KeyValuePairs[0].Value).not.toBe('ID');
     });
+  });
+});
+
+describe('new-record URL helpers', () => {
+  it('treats empty, missing, and the new sentinel as a create', () => {
+    expect(IsNewEntityRecordUrlId(undefined)).toBe(true);
+    expect(IsNewEntityRecordUrlId(null)).toBe(true);
+    expect(IsNewEntityRecordUrlId('')).toBe(true);
+    expect(IsNewEntityRecordUrlId('  ')).toBe(true);
+    expect(IsNewEntityRecordUrlId(NEW_ENTITY_RECORD_URL_ID)).toBe(true);
+    expect(IsNewEntityRecordUrlId('NEW')).toBe(true);
+    expect(IsNewEntityRecordUrlId('abc')).toBe(false);
+  });
+
+  it('encodes an object as a FieldValueCollection URL segment', () => {
+    expect(EncodeNewRecordValuesForURL({
+      BillToPersonID: 'p1',
+      ShipToPersonID: 'p1',
+    })).toBe('BillToPersonID|p1||ShipToPersonID|p1');
+  });
+
+  it('passes through a non-empty string and drops empty values', () => {
+    expect(EncodeNewRecordValuesForURL('BillToPersonID|p1')).toBe('BillToPersonID|p1');
+    expect(EncodeNewRecordValuesForURL('  ')).toBeUndefined();
+    expect(EncodeNewRecordValuesForURL(null)).toBeUndefined();
+    expect(EncodeNewRecordValuesForURL({})).toBeUndefined();
+    expect(EncodeNewRecordValuesForURL({ BillToPersonID: null })).toBeUndefined();
+    expect(EncodeNewRecordValuesForURL(['BillToPersonID', 'p1'])).toBeUndefined();
+  });
+
+  it('keeps the query-param name stable for deeplinks', () => {
+    expect(NEW_RECORD_VALUES_QUERY_PARAM).toBe('NewRecordValues');
   });
 });

--- a/packages/MJCore/src/__tests__/entityInfo.relationshipNewRecordValues.test.ts
+++ b/packages/MJCore/src/__tests__/entityInfo.relationshipNewRecordValues.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it } from 'vitest';
+import { EntityInfo, EntityRelationshipInfo } from '../generic/entityInfo';
+import type { BaseEntity } from '../generic/baseEntity';
+
+function parentRecord(id: string): BaseEntity {
+    const values: Record<string, unknown> = { ID: id };
+    return {
+        Get: (name: string) => values[name],
+        FirstPrimaryKey: { Name: 'ID', Value: id },
+    } as unknown as BaseEntity;
+}
+
+function relationship(over: Record<string, unknown>): EntityRelationshipInfo {
+    return new EntityRelationshipInfo({
+        RelatedEntity: 'MJ_BizApps_Orders: Order Headers',
+        RelatedEntityJoinField: 'BillToPersonID',
+        EntityKeyField: '',
+        Type: 'One to Many',
+        ...over,
+    });
+}
+
+describe('BuildRelationshipNewRecordValues', () => {
+    it('sets the single join field from the parent primary key', () => {
+        const values = EntityInfo.BuildRelationshipNewRecordValues(
+            parentRecord('person-1'),
+            relationship({}),
+        );
+        expect(values).toEqual({ BillToPersonID: 'person-1' });
+    });
+
+    it('sets every UI.join.fields FK when the relationship is an OR join', () => {
+        const values = EntityInfo.BuildRelationshipNewRecordValues(
+            parentRecord('person-1'),
+            relationship({
+                Configuration: JSON.stringify({
+                    UI: { join: { op: 'any', fields: ['BillToPersonID', 'ShipToPersonID'] } },
+                }),
+            }),
+        );
+        expect(values).toEqual({
+            BillToPersonID: 'person-1',
+            ShipToPersonID: 'person-1',
+        });
+    });
+
+    it('uses EntityKeyField when the parent key is not the first PK', () => {
+        const record = {
+            Get: (name: string) => (name === 'Code' ? 'ACME' : undefined),
+            FirstPrimaryKey: { Name: 'ID', Value: 'uuid-1' },
+        } as unknown as BaseEntity;
+        const values = EntityInfo.BuildRelationshipNewRecordValues(
+            record,
+            relationship({
+                RelatedEntityJoinField: 'AccountCode',
+                EntityKeyField: 'Code',
+            }),
+        );
+        expect(values).toEqual({ AccountCode: 'ACME' });
+    });
+});
+
+describe('BuildRelationshipNewRecordValuesForJoinFields', () => {
+    it('sets every listed field to the parent key', () => {
+        const values = EntityInfo.BuildRelationshipNewRecordValuesForJoinFields(
+            parentRecord('org-9'),
+            ['BillToOrganizationID', 'ShipToOrganizationID'],
+        );
+        expect(values).toEqual({
+            BillToOrganizationID: 'org-9',
+            ShipToOrganizationID: 'org-9',
+        });
+    });
+
+    it('ignores blank join field names', () => {
+        const values = EntityInfo.BuildRelationshipNewRecordValuesForJoinFields(
+            parentRecord('p'),
+            ['  ', 'BillToPersonID', ''],
+        );
+        expect(values).toEqual({ BillToPersonID: 'p' });
+    });
+});

--- a/packages/MJCore/src/generic/compositeKey.ts
+++ b/packages/MJCore/src/generic/compositeKey.ts
@@ -332,6 +332,43 @@ export class FieldValueCollection {
     }
 }
 
+/**
+ * Path segment used for an unsaved entity record so the URL can be deeplinked
+ * (`/app/:app/record/:entity/new?NewRecordValues=...`).
+ */
+export const NEW_ENTITY_RECORD_URL_ID = 'new';
+
+/** Query-string key that carries FieldValueCollection.ToURLSegment() defaults. */
+export const NEW_RECORD_VALUES_QUERY_PARAM = 'NewRecordValues';
+
+/** True when the record-id path segment means "create", not a stored key. */
+export function IsNewEntityRecordUrlId(recordId: string | null | undefined): boolean {
+    if (recordId == null) return true;
+    const trimmed = recordId.trim();
+    return trimmed.length === 0 || trimmed.toLowerCase() === NEW_ENTITY_RECORD_URL_ID;
+}
+
+/**
+ * Encode new-record defaults for a deeplink. Objects become
+ * `Field|value||Field2|value2`. Empty / null returns undefined.
+ */
+export function EncodeNewRecordValuesForURL(values: unknown): string | undefined {
+    if (values == null) return undefined;
+    if (typeof values === 'string') {
+        const trimmed = values.trim();
+        return trimmed.length > 0 ? trimmed : undefined;
+    }
+    if (typeof values !== 'object' || Array.isArray(values)) return undefined;
+    const record = values as Record<string, unknown>;
+    const keys = Object.keys(record).filter((key) => record[key] != null);
+    if (keys.length === 0) return undefined;
+    const obj: Record<string, unknown> = {};
+    for (const key of keys) {
+        obj[key] = record[key];
+    }
+    return FieldValueCollection.FromObject(obj).ToURLSegment();
+}
+
 
 /**
  * Composite keys are used to represent database keys and can include one or more key value pairs.

--- a/packages/MJCore/src/generic/entityInfo.ts
+++ b/packages/MJCore/src/generic/entityInfo.ts
@@ -2629,7 +2629,6 @@ export class EntityInfo extends BaseInfo {
 
     /**
      * One related-entity grid over several join fields (Bill-To OR Ship-To).
-     * New records still default to the first join field.
      */
     public static BuildRelationshipViewParamsForJoinFields(
         record: BaseEntity,
@@ -2657,19 +2656,49 @@ export class EntityInfo extends BaseInfo {
     }
     
     /**
-     * Builds a simple javascript object that will pre-populate a new record in the related entity with values that link back to the specified record. 
-     * This is useful, for example, when creating a new contact from an account, we want to pre-populate the account ID in the new contact record
+     * Default field values for a new related record so it links back to `record`.
+     * When the relationship's Configuration declares `UI.join.fields`, every
+     * listed FK is set (Bill-To AND Ship-To). Otherwise only
+     * `RelatedEntityJoinField` is set.
      */
-    public static BuildRelationshipNewRecordValues(record: BaseEntity, relationship: EntityRelationshipInfo): any {
-        // we want to build a simple javascript object that will pre-populate a new record in the related entity with values that link
-        // abck to the current record. This is useful for example when creating a new contact from an account, we want to pre-populate the
-        // account ID in the new contact record
-        const obj: any = {};
-        if (record && relationship) {
-            const keyField = relationship.EntityKeyField && relationship.EntityKeyField.trim().length > 0 ? relationship.EntityKeyField : record.FirstPrimaryKey.Name;
-            obj[relationship.RelatedEntityJoinField] = record.Get(keyField);
+    public static BuildRelationshipNewRecordValues(record: BaseEntity, relationship: EntityRelationshipInfo): Record<string, unknown> {
+        if (!record || !relationship) return {};
+        const joinFields = ReadRelationshipJoinFields(relationship.Configuration);
+        if (joinFields && joinFields.length > 0) {
+            return EntityInfo.BuildRelationshipNewRecordValuesForJoinFields(record, joinFields, relationship);
+        }
+        const joinField = (relationship.RelatedEntityJoinField ?? '').trim();
+        if (!joinField) return {};
+        return { [joinField]: EntityInfo.resolveRelationshipKeyValue(record, relationship) };
+    }
+
+    /**
+     * Default field values for a new related record, setting every listed join
+     * field to the parent key. Use this when one grid filters on several FKs
+     * (Bill-To OR Ship-To) so "New" still auto-links the child to this parent.
+     */
+    public static BuildRelationshipNewRecordValuesForJoinFields(
+        record: BaseEntity,
+        joinFields: readonly string[],
+        relationship?: EntityRelationshipInfo,
+    ): Record<string, unknown> {
+        if (!record) return {};
+        const fields = joinFields.map((f) => f.trim()).filter((f) => f.length > 0);
+        if (fields.length === 0) return {};
+        const keyValue = EntityInfo.resolveRelationshipKeyValue(record, relationship);
+        const obj: Record<string, unknown> = {};
+        for (const field of fields) {
+            obj[field] = keyValue;
         }
         return obj;
+    }
+
+    private static resolveRelationshipKeyValue(record: BaseEntity, relationship?: EntityRelationshipInfo): unknown {
+        const explicit = relationship?.EntityKeyField?.trim();
+        if (explicit) return record.Get(explicit);
+        const first = record.FirstPrimaryKey;
+        if (first?.Name) return record.Get(first.Name);
+        return first?.Value;
     }
 
     /**


### PR DESCRIPTION
## Summary
- Related-entity grids prefill **every** join field on a new child (`NewRecordValues` / `NewRecordValuesForJoinFields`) and persist those defaults on `/record/:entity/new?NewRecordValues=Field|value||Field2|value2`.
- Left-nav related grids (including slot-mounted contributions) fill leftover column height — slot hosts are `display: contents`, accordion pixel heights are not applied, `SetSectionRowCount` upserts so rail badges appear.
- Section search matches contribution titles in accordion and left-nav, keeps the rail visible when search is active, and does not treat chrome-hidden panels as non-matches.

## Test plan
- [ ] From a Person **Orders** grid, click New — URL is `/record/.../new?NewRecordValues=BillToPersonID|<id>||ShipToPersonID|<id>` and both FKs are set.
- [ ] Refresh that new-record tab; defaults survive.
- [ ] Open a Person with Orders/Payments contributions in left-nav: the selected related grid fills leftover height and the rail shows a row-count badge.
- [ ] Search sections for `ord` — Orders matches in accordion and left-nav; rail stays visible.
- [ ] Confirm leftover local config (`mj.config.cjs`, MJAPI/MJExplorer package.json, angular.json, MJServer index.ts) is **not** in this PR.