### PR TITLE
fix(forms): scope LoadFormChromeRules' read to the provider it was handed

### DIFF
--- a/.changeset/form-chrome-rules-provider-scoped-runview.md
+++ b/.changeset/form-chrome-rules-provider-scoped-runview.md
@@ -1,0 +1,11 @@
+---
+'@memberjunction/ng-base-forms': patch
+---
+
+Scope `LoadFormChromeRules`' read to the provider it was handed.
+
+The function resolves `md = provider ?? Metadata.Provider` and checks the entity is in that provider's metadata — then ran the actual query through `new RunView()`, which binds the **global** provider. In a multi-provider app that validated against the caller's provider and read from a different one, so a form could be handed another environment's chrome rules, or none, depending on which provider happened to be global at the time. The `provider` parameter was effectively decorative for the read.
+
+Now `RunView.FromMetadataProvider(md)`, so the check and the read use one provider. Single-provider apps are unaffected — there `md` *is* the global provider.
+
+This also clears the repo's `ui-layers` adopted-standard error, which had been failing the `adopted standards` gate on every PR that merged `next`.

--- a/packages/Angular/Generic/base-forms/src/lib/chrome/load-form-chrome-rules.ts
+++ b/packages/Angular/Generic/base-forms/src/lib/chrome/load-form-chrome-rules.ts
@@ -32,7 +32,11 @@ export async function LoadFormChromeRules(
     const md = provider ?? Metadata.Provider;
     if (!md?.EntityByName(FORM_CHROME_RULES_ENTITY)) return [];
 
-    const rv = new RunView();
+    // Read through the SAME provider the check above resolved. `new RunView()` binds the GLOBAL
+    // provider, so in a multi-provider app this validated the entity against the caller's provider
+    // and then read the rows from a different one — yielding another environment's chrome rules, or
+    // none at all, depending on which provider happened to be global at the time.
+    const rv = RunView.FromMetadataProvider(md);
     const result = await rv.RunView<FormChromeRuleRow>({
         EntityName: FORM_CHROME_RULES_ENTITY,
         ExtraFilter: `EntityID='${id}'`,


### PR DESCRIPTION
## The bug

`LoadFormChromeRules` resolves the provider it should use, checks the entity is present in **that** provider's metadata — and then runs the actual query through the global one:

```ts
const md = provider ?? Metadata.Provider;
if (!md?.EntityByName(FORM_CHROME_RULES_ENTITY)) return [];

const rv = new RunView();          // ← binds the GLOBAL provider, not md
```

In a multi-provider app this validates against the caller's provider and reads from a different one, so a form can be handed **another environment's chrome rules — or none at all** — depending on which provider happened to be global at the time. The `provider` parameter was decorative for the read.

Single-provider apps are unaffected, because there `md` *is* the global provider. That is why it was invisible.

## The fix

```ts
const rv = RunView.FromMetadataProvider(md);
```

One provider for both the check and the read. One line, plus the comment explaining it.

## Why now

This is what MJ's `ui-layers` adopted standard exists to catch, and it has been failing the **`adopted standards` gate on every PR that merges `next`** since #3829 landed:

```
✗ ui-layers [error] — 1 violation(s)
    packages/Angular/Generic/base-forms/src/lib/chrome/load-form-chrome-rules.ts:35
    uses new RunView() — binds the global provider — use RunView.FromMetadataProvider(this.ProviderToUse)
```

It red-flagged #3354, #3774, #3758 and #3381 in a row, none of which touch Angular. Fixing it here rather than folding it into an unrelated PR keeps the history honest.

Introduced by `7b4abe7655` (*feat(forms): L0–L4 form chrome layering*).

## No test added

The standard **is** the regression guard: it is a lint rule over the source, so any recurrence fails CI without needing a runtime case. Adding a provider-routing unit test here would duplicate the gate at higher cost.

## Verification

- `npm run check:standards` → **"✓ All adopted standards pass"** (was 1 error)
- `@memberjunction/ng-base-forms` → **253 passed / 20 files**
- `tsc --noEmit -p tsconfig.spec.json` → clean
- `check:changeset` → green (`patch`; no migration, no metadata)

🤖 Generated with [Claude Code](https://claude.com/claude-code)