### PR TITLE
fix(integration): don't retry the engine's own FetchChanges timeout

### DIFF
--- a/.changeset/configurable-fetch-changes-timeout.md
+++ b/.changeset/configurable-fetch-changes-timeout.md
@@ -5,7 +5,7 @@
 
 Make the `FetchChanges` per-page timeout configurable instead of a hard-coded 30s.
 
-`IntegrationEngine` previously wrapped every `FetchChanges` call in `DEFAULT_OPERATION_TIMEOUTS.FetchChangesMs` (30s) with no way to change it. That punished the connectors that need it most: a connector that fans out one request per parent record does `BatchSize` requests inside a single `FetchChanges` call, so its page time scales with batch size and with however much concurrency the adaptive controller currently allows. Once a page exceeded 30s the timeout fired, `WithRetry` re-ran the *same* page (paying the cost again), and the resulting failures fed the AIMD controller — which cut concurrency, making the next page slower still.
+`IntegrationEngine` previously wrapped every `FetchChanges` call in `DEFAULT_OPERATION_TIMEOUTS.FetchChangesMs` (30s) with no way to change it. That punished the connectors that need it most: a connector that fans out one request per parent record does `BatchSize` requests inside a single `FetchChanges` call, so its page time scales with batch size and with however much concurrency the adaptive controller currently allows. Once a page exceeded 30s the timeout fired and `WithRetry` re-ran the *same* page, paying the full cost again, until the retry budget was spent and the object ended with an incomplete result set.
 
 Two new resolution sources, checked before the framework default:
 

--- a/.changeset/no-retry-on-own-fetch-timeout.md
+++ b/.changeset/no-retry-on-own-fetch-timeout.md
@@ -1,0 +1,15 @@
+---
+'@memberjunction/integration-engine': patch
+---
+
+Stop retrying the engine's own `FetchChanges` timeout — it multiplied load on sources that were already too slow.
+
+`WithTimeout` is a `Promise.race` with no cancellation: when the budget expires it rejects, but the wrapped operation **keeps running**. `ClassifyError` maps the timeout to `NETWORK_TIMEOUT` and `IsRetryableError` treats that as transient, so the fetch path retried it — up to `MaxAttempts: 3`.
+
+For a connector that fans out one request per parent record inside a single `FetchChanges` call, that meant attempt 1 timed out with its requests still in flight, ~1s later attempt 2 issued a *second* full page of vendor requests overlapping the first, and ~2s later a third overlapped both. Up to **3× the concurrent load on a source that could not finish the work once** — a reliable way to earn a genuine 429, which *does* back the adaptive limiter off. And the retry could never have succeeded on its merits: the same work under the same budget exceeds it again.
+
+`WithTimeout` now rejects with a new exported `OperationTimeoutError` (same message text, so `ClassifyError`, logging and the run-event stream are unchanged), and the fetch retry predicate excludes it by `instanceof`. The exclusion is deliberately identity-based rather than dropping `NETWORK_TIMEOUT` from `IsRetryableError`: `ClassifyError` folds `econnreset` in under that same code, and a reset socket genuinely is worth retrying. A vendor's own "gateway timeout" also stays retryable — only a budget *this engine* set is treated as terminal.
+
+A page that exceeds its budget now fails once and lets the object end incomplete, which surfaces as the `FETCH_ABORTED_INCOMPLETE` run-event warning rather than after three full-cost attempts. Deployments that need a longer budget raise `Configuration.fetchTimeoutMs` or the connector's `FetchChangesTimeoutMs`, which is what those knobs are for.
+
+Also corrects a comment on `BaseIntegrationConnector.FetchChangesTimeoutMs` that described a timeout→concurrency-cut spiral. Only `RATE_LIMIT_EXCEEDED` feeds the adaptive limiter; a timeout never cut concurrency directly.

--- a/packages/Integration/engine/src/BaseIntegrationConnector.ts
+++ b/packages/Integration/engine/src/BaseIntegrationConnector.ts
@@ -212,14 +212,48 @@ export const DEFAULT_OPERATION_TIMEOUTS: OperationTimeouts = {
 };
 
 /**
- * Wraps a promise with a timeout. Rejects with a timeout error if the
+ * The error {@link WithTimeout} rejects with when ITS OWN budget expires — as distinct from an error
+ * the wrapped operation itself produced.
+ *
+ * That distinction is the whole point of the class. `ClassifyError` maps anything matching "timeout"
+ * to `NETWORK_TIMEOUT`, which `IsRetryableError` treats as transient — correct for a socket that
+ * dropped, wrong for "we gave this operation N ms and it wanted more." Retrying the latter re-runs
+ * the same work under the same budget, so it fails the same way, having spent the budget again.
+ *
+ * The message is deliberately UNCHANGED from the plain `Error` this replaced: `ClassifyError` reads
+ * message text, so existing classification, logging and the run-event stream all behave exactly as
+ * before. Only callers that explicitly check `instanceof` see any difference.
+ */
+export class OperationTimeoutError extends Error {
+    /** The `operationName` passed to {@link WithTimeout}. */
+    public readonly OperationName: string;
+    /** The budget that expired, in milliseconds. */
+    public readonly TimeoutMs: number;
+
+    constructor(operationName: string, timeoutMs: number) {
+        super(`Operation '${operationName}' timed out after ${timeoutMs}ms`);
+        this.name = 'OperationTimeoutError';
+        this.OperationName = operationName;
+        this.TimeoutMs = timeoutMs;
+    }
+}
+
+/**
+ * Wraps a promise with a timeout. Rejects with {@link OperationTimeoutError} if the
  * promise does not resolve within the specified duration.
+ *
+ * CAVEAT — this does NOT cancel the wrapped operation. It is a `Promise.race`, so on timeout the
+ * underlying work keeps running to completion (or its own failure) with nobody awaiting it. A caller
+ * that retries a timed-out operation therefore stacks a second copy on top of the first, still
+ * in-flight — which is why `IntegrationEngine`'s fetch path does not retry
+ * {@link OperationTimeoutError}. Real cancellation needs an `AbortSignal` threaded into the
+ * connector contract; until then, treat a timeout as terminal for that attempt.
  *
  * @param promise - The promise to wrap
  * @param timeoutMs - Timeout in milliseconds
  * @param operationName - Name of the operation for error messaging
  * @returns The result of the promise
- * @throws Error if the operation times out
+ * @throws OperationTimeoutError if the operation times out
  */
 export async function WithTimeout<T>(
     promise: Promise<T>,
@@ -230,7 +264,7 @@ export async function WithTimeout<T>(
 
     const timeoutPromise = new Promise<never>((_resolve, reject) => {
         timeoutHandle = setTimeout(() => {
-            reject(new Error(`Operation '${operationName}' timed out after ${timeoutMs}ms`));
+            reject(new OperationTimeoutError(operationName, timeoutMs));
         }, timeoutMs);
     });
 
@@ -464,11 +498,16 @@ export abstract class BaseIntegrationConnector {
      * Raise this when a single page is legitimately slow: a connector that fans out one request per
      * parent (ORCID's per-iD `/record`, any second-layer object) does N requests inside ONE
      * `FetchChanges` call, so its page time scales with `BatchSize` — and with how much concurrency
-     * the engine's adaptive controller currently allows. The fixed 30s made that interact badly:
-     * after the controller cut concurrency, a page that comfortably fit when parallel no longer fit
-     * sequentially, so it timed out, which kept concurrency pinned down — a spiral that forced
-     * connector authors to shrink `BatchSize` for the sequential worst case and waste the parallel
-     * headroom the rest of the time.
+     * the engine's adaptive controller currently allows. Under the fixed 30s, a page that comfortably
+     * fit when parallel no longer fit once the controller had cut concurrency, which forced connector
+     * authors to shrink `BatchSize` for the sequential worst case and waste the parallel headroom the
+     * rest of the time.
+     *
+     * Note the timeout does NOT itself cut concurrency: `ClassifyError` gives it `NETWORK_TIMEOUT`,
+     * and only `RATE_LIMIT_EXCEEDED` feeds the adaptive limiter. A timing-out page simply never ramps
+     * the rate UP (the ramp needs a clean fetch), and the object ends incomplete — reported as
+     * `FETCH_ABORTED_INCOMPLETE`. Earlier revisions of this comment described a self-reinforcing
+     * timeout→concurrency-cut spiral; that is not what the code does.
      *
      * Precedence (highest first): `CompanyIntegration.Configuration.fetchTimeoutMs` → this property
      * → `DEFAULT_OPERATION_TIMEOUTS.FetchChangesMs`. Deployments therefore keep the last word without

--- a/packages/Integration/engine/src/IntegrationEngine.ts
+++ b/packages/Integration/engine/src/IntegrationEngine.ts
@@ -38,7 +38,7 @@ import type {
 } from './types.js';
 import { ClassifyError, IsRetryableError } from './types.js';
 import { WithRetry } from './RetryRunner.js';
-import { WithTimeout, DEFAULT_OPERATION_TIMEOUTS } from './BaseIntegrationConnector.js';
+import { WithTimeout, OperationTimeoutError, DEFAULT_OPERATION_TIMEOUTS } from './BaseIntegrationConnector.js';
 import { ConnectorFactory } from './ConnectorFactory.js';
 import { FieldMappingEngine } from './FieldMappingEngine.js';
 import { MatchEngine } from './MatchEngine.js';
@@ -2288,7 +2288,20 @@ export class IntegrationEngine extends BaseSingleton<IntegrationEngine> {
                         `FetchChanges(${entityMap.ExternalObjectName})`,
                     ),
                     undefined,
-                    (err) => IsRetryableError(ClassifyError(err).Code),
+                    // OUR OWN timeout is terminal for this page; a transport error is not.
+                    //
+                    // `WithTimeout` is a `Promise.race` with no cancellation, so the abandoned attempt
+                    // keeps running. Retrying meant a second full page of vendor requests overlapping
+                    // the first, then a third — up to 3x the load on a source that was already too slow
+                    // to finish once, which is a good way to earn a real 429 (and THAT does cut
+                    // concurrency). And the retry could not succeed on its merits anyway: the same work
+                    // under the same budget exceeds it again.
+                    //
+                    // Deliberately `instanceof` rather than the classified code. `ClassifyError` folds
+                    // `econnreset` in with timeouts under `NETWORK_TIMEOUT`, and a reset socket IS worth
+                    // retrying — so excluding the whole code would lose real resilience. Only the error
+                    // WithTimeout itself minted is excluded.
+                    (err) => !(err instanceof OperationTimeoutError) && IsRetryableError(ClassifyError(err).Code),
                     (attempt, err, delayMs) => logger?.emit('sync.fetch.retry', {
                         externalObjectName: entityMap.ExternalObjectName,
                         batchIndex: batchCount,

--- a/packages/Integration/engine/src/__tests__/IntegrationEngine.fetch-timeout.test.ts
+++ b/packages/Integration/engine/src/__tests__/IntegrationEngine.fetch-timeout.test.ts
@@ -305,6 +305,25 @@ describe('IntegrationEngine — FetchChanges timeout resolution', () => {
         expect(observed.every(ms => ms === 45)).toBe(true);
     }, 30000);
 
+    it('attempts a timed-out page exactly ONCE — no retry of our own timeout', async () => {
+        // `WithTimeout` cannot cancel the work it abandons, so a retry would put a second full page of
+        // vendor requests in flight alongside the first, then a third. Since the retried work runs under
+        // the same budget it just exceeded, it could not have succeeded either. Counting the connector's
+        // FetchChanges invocations through the REAL engine path is what pins that: 1, not MaxAttempts.
+        //
+        // The predicate's semantics — and why the exclusion is instanceof-based rather than dropping the
+        // NETWORK_TIMEOUT code, which would also stop retrying reset sockets — are in
+        // WithTimeoutNoRetry.test.ts.
+        const connector = createHangingConnector(30);
+        wireConfigMocks(createMockCompanyIntegration('{}'), buildIntegration());
+        ConnectorFactory.Resolve = vi.fn().mockReturnValue(connector);
+
+        await orchestrator.RunSync('ci-1', contextUser);
+
+        const fetchChanges = connector.FetchChanges as unknown as ReturnType<typeof vi.fn>;
+        expect(fetchChanges).toHaveBeenCalledTimes(1);
+    }, 30000);
+
 });
 
 /**

--- a/packages/Integration/engine/src/__tests__/WithTimeoutNoRetry.test.ts
+++ b/packages/Integration/engine/src/__tests__/WithTimeoutNoRetry.test.ts
@@ -1,0 +1,110 @@
+/**
+ * `WithTimeout`'s own timeout must be terminal for the attempt, while genuine transport errors stay
+ * retryable.
+ *
+ * WHY: `WithTimeout` is a `Promise.race` with no cancellation — the abandoned operation keeps
+ * running. `IsRetryableError` counts `NETWORK_TIMEOUT` as transient, so the fetch path used to retry
+ * a timed-out page twice more, each attempt issuing a fresh full page of vendor requests on top of
+ * the still-in-flight previous one. Up to 3x the load on a source already too slow to finish once —
+ * and it could not succeed anyway, since the same work under the same budget exceeds it again.
+ *
+ * The subtlety this pins: `ClassifyError` folds `econnreset` in with timeouts under the SAME
+ * `NETWORK_TIMEOUT` code, and a reset socket IS worth retrying. So the exclusion has to key on the
+ * error WithTimeout minted (`instanceof OperationTimeoutError`), not on the classified code. Both
+ * halves are asserted here — a fix that just dropped `NETWORK_TIMEOUT` from `IsRetryableError` would
+ * pass the first test and fail the second.
+ */
+import { describe, it, expect, vi } from 'vitest';
+import { WithTimeout, OperationTimeoutError } from '../BaseIntegrationConnector.js';
+import { WithRetry, type RetryConfig } from '../RetryRunner.js';
+import { ClassifyError, IsRetryableError } from '../types.js';
+
+/**
+ * Mirrors the predicate `IntegrationEngine`'s fetch path passes to `WithRetry`.
+ *
+ * This is a COPY — the engine spells it inline and does not export it — so these tests pin the
+ * predicate's semantics, not the engine's use of it. The engine-level guarantee (a timed-out page is
+ * attempted exactly once through the real `ExecuteEntityMaps` path) is asserted in
+ * `IntegrationEngine.fetch-timeout.test.ts`, which drives a never-settling `FetchChanges` through the
+ * real engine. Both matter: this file explains WHY the predicate is shaped this way, that one proves
+ * the engine still uses it.
+ */
+const fetchIsRetryable = (err: unknown): boolean =>
+    !(err instanceof OperationTimeoutError) && IsRetryableError(ClassifyError(err).Code);
+
+/** Fast retry config so these tests don't sit through exponential backoff. */
+const FAST_RETRY: RetryConfig = { MaxAttempts: 3, InitialBackoffMs: 1, MaxBackoffMs: 2, JitterFraction: 0 };
+
+describe('OperationTimeoutError', () => {
+    it('carries the operation name and the budget that expired', async () => {
+        const err = await WithTimeout(new Promise(() => { /* never settles */ }), 5, 'FetchChanges(contacts)')
+            .catch((e: unknown) => e);
+
+        expect(err).toBeInstanceOf(OperationTimeoutError);
+        const timeout = err as OperationTimeoutError;
+        expect(timeout.OperationName).toBe('FetchChanges(contacts)');
+        expect(timeout.TimeoutMs).toBe(5);
+    });
+
+    it('keeps the exact message text, so existing classification is unaffected', async () => {
+        const err = await WithTimeout(new Promise(() => { /* never settles */ }), 5, 'FetchChanges(contacts)')
+            .catch((e: unknown) => e);
+
+        // The message is load-bearing: ClassifyError reads it, and the run-event stream logs it.
+        expect((err as Error).message).toBe("Operation 'FetchChanges(contacts)' timed out after 5ms");
+        expect(ClassifyError(err).Code).toBe('NETWORK_TIMEOUT');
+        expect(ClassifyError(err).Severity).toBe('Warning');
+    });
+
+    it('is still an Error, so every existing catch and log path keeps working', async () => {
+        const err = await WithTimeout(new Promise(() => { /* never settles */ }), 5, 'op').catch((e: unknown) => e);
+        expect(err).toBeInstanceOf(Error);
+        expect((err as Error).name).toBe('OperationTimeoutError');
+    });
+});
+
+describe("the fetch path's retry predicate", () => {
+    it('does NOT retry our own timeout — the attempt is terminal', async () => {
+        const attempt = vi.fn(() => WithTimeout(new Promise(() => { /* never settles */ }), 5, 'FetchChanges(contacts)'));
+
+        const err = await WithRetry(attempt, FAST_RETRY, fetchIsRetryable).catch((e: unknown) => e);
+
+        expect(err).toBeInstanceOf(OperationTimeoutError);
+        expect(attempt).toHaveBeenCalledTimes(1);   // 1, not 3 — this is the whole fix
+    });
+
+    it('DOES still retry a reset socket, which shares the NETWORK_TIMEOUT code', async () => {
+        // Guards against "fixing" this by dropping NETWORK_TIMEOUT from IsRetryableError: that would
+        // silently cost real resilience, because ClassifyError puts econnreset under the same code.
+        let calls = 0;
+        const attempt = vi.fn(async () => {
+            calls++;
+            if (calls < 3) throw new Error('read ECONNRESET');
+            return 'recovered';
+        });
+
+        const result = await WithRetry(attempt, FAST_RETRY, fetchIsRetryable);
+
+        expect(result).toBe('recovered');
+        expect(attempt).toHaveBeenCalledTimes(3);
+        // Same classified code as the timeout — which is exactly why the exclusion is instanceof-based.
+        expect(ClassifyError(new Error('read ECONNRESET')).Code).toBe('NETWORK_TIMEOUT');
+    });
+
+    it('leaves rate-limit and database errors retryable', async () => {
+        expect(fetchIsRetryable(new Error('429 rate limit exceeded'))).toBe(true);
+        expect(fetchIsRetryable(new Error('connection lost'))).toBe(true);
+    });
+
+    it('still refuses non-transient errors, as before', async () => {
+        expect(fetchIsRetryable(new Error('401 unauthorized: invalid api key'))).toBe(false);
+        expect(fetchIsRetryable(new Error('foreign key constraint violated'))).toBe(false);
+    });
+
+    it('excludes the timeout by identity, not by message shape', () => {
+        // A vendor error that merely mentions a timeout is the vendor's, not ours — it did not come
+        // from a budget WE set, so it stays retryable.
+        expect(fetchIsRetryable(new Error('upstream gateway timeout'))).toBe(true);
+        expect(fetchIsRetryable(new OperationTimeoutError('FetchChanges(x)', 30000))).toBe(false);
+    });
+});

--- a/packages/Integration/engine/src/index.ts
+++ b/packages/Integration/engine/src/index.ts
@@ -68,7 +68,7 @@ export type {
 } from './transforms.js';
 
 // Connector
-export { BaseIntegrationConnector, WithTimeout, DEFAULT_OPERATION_TIMEOUTS } from './BaseIntegrationConnector.js';
+export { BaseIntegrationConnector, WithTimeout, OperationTimeoutError, DEFAULT_OPERATION_TIMEOUTS } from './BaseIntegrationConnector.js';
 export type {
   ConnectionTestResult,
   ExternalObjectSchema,


### PR DESCRIPTION
Follow-up to #3381. That PR made the `FetchChanges` timeout configurable; this fixes what happens **when it fires**.

## The bug

`WithTimeout` is a `Promise.race` with **no cancellation** — when the budget expires it rejects, but the wrapped operation keeps running:

```ts
const result = await Promise.race([promise, timeoutPromise]);   // nothing cancels `promise`
```

`ClassifyError` maps the timeout to `NETWORK_TIMEOUT`, `IsRetryableError` calls that transient, so the fetch path retried it up to `MaxAttempts: 3`.

For a connector that fans out one request per parent record inside a single `FetchChanges` call:

| | |
|---|---|
| attempt 1 | times out — **its requests are still in flight** |
| ~1s later, attempt 2 | issues a *second* full page of vendor requests, overlapping the first |
| ~2s later, attempt 3 | overlaps both |
| result | up to **3× concurrent load** on a source that couldn't finish the work once |

That is a reliable way to earn a genuine 429 — and *that* does back the adaptive limiter off. Meanwhile the retry could never have succeeded on its merits: the same work under the same budget exceeds it again.

**Measured:** reverting the predicate makes the new engine-level test observe **3** `FetchChanges` calls instead of 1, and its runtime goes from instant to **3205 ms**.

## The fix

`WithTimeout` rejects with a new exported `OperationTimeoutError`, and the fetch retry predicate excludes it:

```ts
(err) => !(err instanceof OperationTimeoutError) && IsRetryableError(ClassifyError(err).Code),
```

**The message text is deliberately unchanged.** `ClassifyError` reads message text, so classification, logging and the run-event stream behave exactly as before — only `instanceof` callers can tell the difference.

**The exclusion is identity-based, not "drop `NETWORK_TIMEOUT` from `IsRetryableError`."** `ClassifyError` folds `econnreset` in under that same code, and a reset socket genuinely *is* worth retrying — so a code-based fix would quietly cost real resilience. A vendor's own "gateway timeout" also stays retryable; only a budget **this engine** set is terminal.

A page that exceeds its budget now fails once and lets the object end incomplete — surfaced as the `FETCH_ABORTED_INCOMPLETE` run-event warning that shipped with #3381 — rather than after three full-cost attempts. Deployments needing a longer budget raise `Configuration.fetchTimeoutMs` or the connector's `FetchChangesTimeoutMs`, which is what those knobs are for.

## Tests

- **`WithTimeoutNoRetry.test.ts`** (8) — the predicate's semantics and the reason for each half, including the `econnreset` case a code-based fix would break, and that a vendor-worded timeout stays retryable.
- **One engine-level case** in `IntegrationEngine.fetch-timeout.test.ts` counting `FetchChanges` invocations through the real `RunSync` path: exactly 1. **Verified to fail without the fix.** The unit file explains *why* the predicate is shaped this way; this one proves the engine still uses it.

## Also corrects two overstated claims

#3381's changeset (**release-bound**, so it would have shipped as published CHANGELOG text) and the `FetchChangesTimeoutMs` doc comment both described a self-reinforcing *timeout → AIMD → concurrency-cut → slower* spiral. That is not what the code does: only `RATE_LIMIT_EXCEEDED` feeds the limiter ([IntegrationEngine.ts:2313](https://github.com/MemberJunction/MJ/blob/next/packages/Integration/engine/src/IntegrationEngine.ts#L2313)) and a timeout classifies as `NETWORK_TIMEOUT` ([types.ts:53](https://github.com/MemberJunction/MJ/blob/next/packages/Integration/engine/src/types.ts#L53)). A timing-out page simply never ramps the rate *up* and ends the object incomplete.

## Known limitation (deliberately not fixed here)

The abandoned attempt still runs to completion — this stops the *stacking*, not the orphaned work. Real cancellation needs an `AbortSignal` threaded into the connector contract, which touches every connector that does its own HTTP and belongs in its own PR. `WithTimeout`'s docstring now says so explicitly.

## Verification

- `@memberjunction/integration-engine`: **691 passed / 43 files** (was 682 / 42)
- `tsc --noEmit` clean on integration-engine and MJServer
- `check:changeset` green (`patch`; no migration, no metadata)

🤖 Generated with [Claude Code](https://claude.com/claude-code)