### PR TITLE
chore: do not ship BizApps dynamicPackages in mj.config.cjs

### DIFF
--- a/mj.config.cjs
+++ b/mj.config.cjs
@@ -506,30 +506,4 @@ module.exports = {
   //
   // Note: If MJAPI_PUBLIC_URL env var is set, it will be used automatically.
   // If neither is set, the server constructs it from baseUrl + port + path.
-
-  // ── LOCAL DEV WORKSPACE ONLY — NEVER COMMIT ──────────────────────────────
-  // Registers the BizApps Open Apps into this host (MJAPI + MJExplorer) for the
-  // joined M5 parent workspace, running against the bizapps_orders database.
-  // Server order matters: common registers its base classes before accounting
-  // resolves them, and accounting before orders (orders-server imports both).
-  dynamicPackages: {
-    server: [
-      { PackageName: '@mj-biz-apps/common-server', StartupExport: 'LoadBizAppsCommonServer', AppName: 'mj-bizapps-common', Enabled: true },
-      { PackageName: '@mj-biz-apps/accounting-server', StartupExport: 'LoadBizAppsAccountingServer', AppName: 'mj-bizapps-accounting', Enabled: true },
-      { PackageName: '@mj-biz-apps/orders-server', StartupExport: 'LoadBizAppsOrdersServer', AppName: 'mj-bizapps-orders', Enabled: true },
-      { PackageName: '@mj-biz-apps/tasks-server', StartupExport: 'LoadBizAppsTasksServer', AppName: 'mj-bizapps-tasks', Enabled: true },
-      { PackageName: '@mj-biz-apps/issues-server', StartupExport: 'LoadBizAppsIssuesServer', AppName: 'mj-bizapps-issues', Enabled: true },
-      { PackageName: '@mj-biz-apps/committees-server', StartupExport: 'LoadBizAppsCommitteesServer', AppName: 'mj-bizapps-committees', Enabled: true },
-      { PackageName: '@mj-biz-apps/secure-messaging-server', StartupExport: 'LoadBizAppsSecureMessagingServer', AppName: 'mj-bizapps-secure-messaging', Enabled: true },
-    ],
-    client: [
-      { PackageName: '@mj-biz-apps/common-ng', AppName: 'mj-bizapps-common', Enabled: true },
-      { PackageName: '@mj-biz-apps/accounting-ng', AppName: 'mj-bizapps-accounting', Enabled: true },
-      { PackageName: '@mj-biz-apps/orders-ng', AppName: 'mj-bizapps-orders', Enabled: true },
-      { PackageName: '@mj-biz-apps/tasks-ng', AppName: 'mj-bizapps-tasks', Enabled: true },
-      { PackageName: '@mj-biz-apps/issues-ng', AppName: 'mj-bizapps-issues', Enabled: true },
-      { PackageName: '@mj-biz-apps/committees-ng', AppName: 'mj-bizapps-committees', Enabled: true },
-      { PackageName: '@mj-biz-apps/secure-messaging-ng', AppName: 'mj-bizapps-secure-messaging', Enabled: true },
-    ],
-  },
 };


### PR DESCRIPTION
## Summary
- Remove the BizApps `dynamicPackages` block from the shipped `mj.config.cjs`
- Those entries are joined-workspace host wiring (the comment even said NEVER COMMIT) and landed on `next` via #3842
- Open Apps register on a consumer host through `mj app install` — they must not ship inside the MJ repo config

## Test plan
- [ ] Diff vs `next` is only the `dynamicPackages` deletion in `mj.config.cjs`
- [ ] Fresh clone / CI host no longer tries to load `@mj-biz-apps/*` from this config
- [ ] Local joined-workspace `mj.config.cjs` is unchanged (this PR was authored in a worktree)