### PR TITLE
fix(integration): report a sub-minute run deadline in seconds, and cover it

### DIFF
--- a/.changeset/run-deadline-sub-minute-label.md
+++ b/.changeset/run-deadline-sub-minute-label.md
@@ -1,0 +1,16 @@
+---
+'@memberjunction/integration-engine': patch
+---
+
+Report a sub-minute connector-run deadline in seconds rather than rounding to
+minutes, and add the first test coverage for `RunDeadlineMs`.
+
+`RunDeadlineMs` is a public option and a caller may pass seconds, where rounding
+produced "the run deadline of 0min" — which reads as a pipeline bug rather than
+the limit the caller asked for. The 45min default is unaffected.
+
+The three new tests pin what a live run against a real database proved: a stage
+that never returns is failed *and* writes `result.json` (the point of the
+deadline, since a run is reported in-flight precisely when that file is absent),
+the label renders in seconds, and `0` means "no deadline" rather than "already
+expired".

--- a/packages/Integration/engine/src/IntegrationConnectorCreationPipeline.ts
+++ b/packages/Integration/engine/src/IntegrationConnectorCreationPipeline.ts
@@ -357,12 +357,18 @@ export class IntegrationConnectorCreationPipeline {
         // but it can be stopped being waited on — which is the difference between a run that fails and
         // one that is in-flight forever. See RunDeadlineMs.
         const deadlineMs = opts.RunDeadlineMs ?? IntegrationConnectorCreationPipeline.DEFAULT_RUN_DEADLINE_MS;
+        // The default is 45min, but RunDeadlineMs is a public knob and a caller may set seconds — in
+        // which case rounding to minutes reported the failure as a "deadline of 0min", which reads as
+        // a bug in the pipeline rather than the limit the caller actually asked for.
+        const deadlineLabel = deadlineMs >= 60_000
+            ? `${Math.round(deadlineMs / 60_000)}min`
+            : `${(deadlineMs / 1000).toFixed(deadlineMs % 1000 === 0 ? 0 : 1)}s`;
         let deadlineTimer: ReturnType<typeof setTimeout> | undefined;
         const withDeadline = async <T>(stage: string, work: Promise<T>): Promise<T> => {
             if (deadlineMs <= 0) return work;
             const remaining = deadlineMs - (Date.now() - startedMs);
             if (remaining <= 0) {
-                throw new Error(`Run deadline of ${Math.round(deadlineMs / 60000)}min exceeded before stage "${stage}" could start.`);
+                throw new Error(`Run deadline of ${deadlineLabel} exceeded before stage "${stage}" could start.`);
             }
             return Promise.race([
                 work,
@@ -370,7 +376,7 @@ export class IntegrationConnectorCreationPipeline {
                     deadlineTimer = setTimeout(
                         () => reject(new Error(
                             `Stage "${stage}" did not finish within the run deadline of ` +
-                            `${Math.round(deadlineMs / 60000)}min. The work may still be running on this ` +
+                            `${deadlineLabel}. The work may still be running on this ` +
                             `process — it cannot be cancelled — but the run is being failed so it stops ` +
                             `reporting itself in-flight and can be retried.`)),
                         remaining,

--- a/packages/Integration/engine/src/__tests__/ConnectorPipelineRunDeadline.test.ts
+++ b/packages/Integration/engine/src/__tests__/ConnectorPipelineRunDeadline.test.ts
@@ -1,0 +1,83 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, rmSync, existsSync, readFileSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import { IntegrationConnectorCreationPipeline } from '../IntegrationConnectorCreationPipeline.js';
+import type { ConnectorCreationPipelineOptions } from '../IntegrationConnectorCreationPipeline.js';
+
+/**
+ * A run must END.
+ *
+ * `complete()` and `fail()` are the only writers of `result.json`, and both sit inside the try/catch
+ * around the stages — so a stage that never returns reaches neither. Since a run is reported in-flight
+ * precisely when `result.json` is ABSENT, one stalled `await` made the run claim to be running for the
+ * rest of the process's life: no client could learn otherwise and no retry cleared it.
+ *
+ * The deadline cannot cancel the stalled work — a promise is not cancellable — so what is pinned here
+ * is narrower and is the part that matters: the pipeline stops WAITING, fails honestly, and writes the
+ * artifact that makes the run retryable.
+ *
+ * Verified live on 2026-08-15 against a real database and real artifacts before being pinned here.
+ */
+
+const CI_ID = 'ci-deadline';
+
+/** Clears the coalescing caches — a cached result would short-circuit `Run()` before any stage ran. */
+const clearCaches = () => {
+    const cls = IntegrationConnectorCreationPipeline as unknown as {
+        inFlightRuns: Map<string, unknown>;
+        recentRuns: Map<string, unknown>;
+    };
+    cls.inFlightRuns.clear();
+    cls.recentRuns.clear();
+};
+
+describe('IntegrationConnectorCreationPipeline — the run deadline', () => {
+    let rootDir: string;
+
+    /**
+     * Hangs in the FIRST stage, so nothing downstream needs stubbing: `StageConnectionTest` awaits
+     * `TestConnection` directly.
+     */
+    const hangingOpts = (deadlineMs: number): ConnectorCreationPipelineOptions => ({
+        CompanyIntegration: { ID: CI_ID, IntegrationID: 'int-1', Integration: 'Synthetic' },
+        Connector: { TestConnection: () => new Promise(() => { /* never settles */ }) },
+        ContextUser: {},
+        ArtifactRootDir: rootDir,
+        RunDeadlineMs: deadlineMs,
+    } as unknown as ConnectorCreationPipelineOptions);
+
+    beforeEach(() => { rootDir = mkdtempSync(join(tmpdir(), 'mj-deadline-')); clearCaches(); });
+    afterEach(() => { rmSync(rootDir, { recursive: true, force: true }); clearCaches(); });
+
+    it('fails a stage that never returns, and WRITES result.json so the run stops reporting itself in-flight', async () => {
+        const result = await new IntegrationConnectorCreationPipeline().Run(hangingOpts(200));
+
+        expect(result.Success).toBe(false);
+        expect(result.FailureMessage).toContain('ConnectionTest');
+
+        // The artifact is the whole point: in-flight is computed as "result.json is absent".
+        const resultFile = join(rootDir, result.RunID, 'result.json');
+        expect(existsSync(resultFile)).toBe(true);
+        expect(JSON.parse(readFileSync(resultFile, 'utf-8'))).toMatchObject({ success: false });
+    });
+
+    it('reports a sub-minute deadline in seconds', async () => {
+        // RunDeadlineMs is a public knob and the default is 45min, so minutes read well there — but
+        // rounding a 200ms deadline to minutes reported "a deadline of 0min", which reads as a bug in
+        // the pipeline rather than the limit the caller asked for.
+        const result = await new IntegrationConnectorCreationPipeline().Run(hangingOpts(200));
+        expect(result.FailureMessage).toContain('0.2s');
+        expect(result.FailureMessage).not.toContain('0min');
+    });
+
+    it('honours 0 as "no deadline" — the run stays pending rather than failing immediately', async () => {
+        // Guards the disable path: reading 0 as "already expired" would fail every run that opted out.
+        const run = new IntegrationConnectorCreationPipeline().Run(hangingOpts(0));
+        const settled = await Promise.race([
+            run.then(() => 'settled' as const),
+            new Promise<'pending'>(r => { const t = setTimeout(() => r('pending'), 300); t.unref?.(); }),
+        ]);
+        expect(settled).toBe('pending');
+    });
+});


### PR DESCRIPTION
Follow-up to #3748, found by running that PR's own behaviour end-to-end against a real database.

## The wart

`RunDeadlineMs` is a public option. Set it to 8 seconds and a stalled run reports:

> Stage "Introspect" did not finish within the run deadline of **0min**.

Both message sites rounded with `Math.round(deadlineMs / 60000)`, so any sub-minute deadline reads as `0min` — which sounds like a bug in the pipeline rather than the limit the caller actually asked for. The 45-minute default is unaffected and still reads in minutes.

## The bigger gap

`RunDeadlineMs` shipped with **no test at all**. That is the part worth reviewing: the deadline is the difference between a run that fails honestly and one that reports itself in-flight forever, and nothing pinned it.

Three tests, each pinning something a live run demonstrated:

- a stage that never returns is failed **and** `result.json` is written — the whole point, since a run is reported in-flight precisely when that file is absent;
- a sub-minute deadline renders in seconds;
- `0` means *no deadline*, not *already expired* — reading it the other way would fail every run that opted out.

## Verification

Proven live before being pinned here: real pipeline, real `MJCompanyIntegrationEntity`, real artifacts on disk. A connector hanging in `DiscoverObjects` with `RunDeadlineMs: 8000` returned `Success=false` in **8003ms** with `result.json` written (`exitReason: "failed"`), against a control run with the deadline disabled that never settled and never wrote one — and, in that control, a second caller for the same connection coalesced onto the dead promise and hung too.

integration-engine: **700 passed, exit 0**. `tsc --noEmit` clean. `check:changeset` green at `patch`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)