### PR TITLE
fix(graph-view): compare record IDs with UUIDsEqual, not ===

### DIFF
--- a/.changeset/graph-view-uuid-comparisons.md
+++ b/.changeset/graph-view-uuid-comparisons.md
@@ -1,0 +1,11 @@
+---
+"@memberjunction/ng-graph-view": patch
+---
+
+Compare graph node/edge record IDs with `UUIDsEqual()` instead of `===`.
+
+These are entity primary keys — `NavigateToEntity` passes `node.ID` through `CompositeKey.FromID()` into `OpenEntityRecord` — and SQL Server returns UUIDs uppercase while JS-generated ones are lowercase, so `===` silently failed to match across that boundary. Node selection, edge highlighting, hop expansion and edge-count all missed depending on where the ID came from.
+
+Twelve comparisons changed. Eleven were reported by `UUIDCompliance.test.ts`, whose failure also took the whole unit-test job down (it runs in `@memberjunction/global` but scans the repo, and turbo fails fast). The twelfth — `GetNodeEdgeCount`'s `e.SourceID === id || e.TargetID === id` — was not flagged, because the test's pattern matches `.ID ===` and those read `.SourceID ===` / `.TargetID ===`: the same UUIDs and the same defect, invisible to the gate.
+
+The template comparison became a component method (`IsNodeSelected(node)`), since an Angular template cannot call an imported function. Null semantics are unchanged: `UUIDsEqual` treats null-vs-value as false, exactly as `SelectedNode?.ID === node.ID` did when nothing was selected.

--- a/packages/Angular/Generic/graph-view/src/lib/components/graph-view.component.ts
+++ b/packages/Angular/Generic/graph-view/src/lib/components/graph-view.component.ts
@@ -17,6 +17,7 @@ import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
 import { NavigationService } from '@memberjunction/ng-shared';
 import { CompositeKey } from '@memberjunction/core';
+import { UUIDsEqual } from '@memberjunction/global';
 import type {
     GraphNode,
     GraphEdge,
@@ -478,7 +479,7 @@ const GRAPH_VIEW_CSS = `
                             (click)="OnNodeClick(node, $event)">
 
                             <!-- Outer Selection Glow -->
-                            @if (SelectedNode?.ID === node.ID) {
+                            @if (IsNodeSelected(node)) {
                                 <circle r="36" fill="rgba(56, 189, 248, 0.2)" stroke="#38bdf8" stroke-width="2"></circle>
                             }
 
@@ -584,7 +585,7 @@ export class GraphViewComponent implements OnInit, OnChanges, OnDestroy {
             this.SimulatePhysics();
         }
         if (changes['SelectedNodeId'] && this.SelectedNodeId) {
-            const found = this.Nodes.find(n => n.ID === this.SelectedNodeId);
+            const found = this.Nodes.find(n => UUIDsEqual(n.ID, this.SelectedNodeId));
             if (found) this.SelectedNode = found;
         }
     }
@@ -648,8 +649,8 @@ export class GraphViewComponent implements OnInit, OnChanges, OnDestroy {
 
             // 2. Link Attraction
             this.Edges.forEach(edge => {
-                const src = this.Nodes.find(n => n.ID === edge.SourceID);
-                const tgt = this.Nodes.find(n => n.ID === edge.TargetID);
+                const src = this.Nodes.find(n => UUIDsEqual(n.ID, edge.SourceID));
+                const tgt = this.Nodes.find(n => UUIDsEqual(n.ID, edge.TargetID));
                 if (src && tgt) {
                     const dx = (tgt.X || 0) - (src.X || 0);
                     const dy = (tgt.Y || 0) - (src.Y || 0);
@@ -736,7 +737,7 @@ export class GraphViewComponent implements OnInit, OnChanges, OnDestroy {
     }
 
     public SelectNode(id: string): void {
-        const node = this.Nodes.find(n => n.ID === id);
+        const node = this.Nodes.find(n => UUIDsEqual(n.ID, id));
         if (node) this.OnNodeClick(node, new MouseEvent('click'));
     }
 
@@ -752,7 +753,7 @@ export class GraphViewComponent implements OnInit, OnChanges, OnDestroy {
     }
 
     public ExpandHops(nodeId: string, depth: number): void {
-        const node = this.Nodes.find(n => n.ID === nodeId);
+        const node = this.Nodes.find(n => UUIDsEqual(n.ID, nodeId));
         if (!node) return;
 
         const beforeEvent = new BeforeHopExpandEventArgs(node, (node.HopDistance || 0) + depth, node.HopDistance || 0);
@@ -779,8 +780,8 @@ export class GraphViewComponent implements OnInit, OnChanges, OnDestroy {
 
     public OnEdgeClick(edge: GraphEdge, event: MouseEvent): void {
         event.stopPropagation();
-        const src = this.Nodes.find(n => n.ID === edge.SourceID) || null;
-        const tgt = this.Nodes.find(n => n.ID === edge.TargetID) || null;
+        const src = this.Nodes.find(n => UUIDsEqual(n.ID, edge.SourceID)) || null;
+        const tgt = this.Nodes.find(n => UUIDsEqual(n.ID, edge.TargetID)) || null;
 
         const beforeEvent = new BeforeEdgeSelectEventArgs(edge, src, tgt);
         this.BeforeEdgeSelect.emit(beforeEvent);
@@ -865,11 +866,11 @@ export class GraphViewComponent implements OnInit, OnChanges, OnDestroy {
     }
 
     public GetNodeX(id: string): number {
-        return this.Nodes.find(n => n.ID === id)?.X || 0;
+        return this.Nodes.find(n => UUIDsEqual(n.ID, id))?.X || 0;
     }
 
     public GetNodeY(id: string): number {
-        return this.Nodes.find(n => n.ID === id)?.Y || 0;
+        return this.Nodes.find(n => UUIDsEqual(n.ID, id))?.Y || 0;
     }
 
     public GetNodeColor(node: GraphNode): string {
@@ -895,11 +896,21 @@ export class GraphViewComponent implements OnInit, OnChanges, OnDestroy {
     }
 
     public GetNodeEdgeCount(id: string): number {
-        return this.Edges.filter(e => e.SourceID === id || e.TargetID === id).length;
+        return this.Edges.filter(e => UUIDsEqual(e.SourceID, id) || UUIDsEqual(e.TargetID, id)).length;
     }
 
     public IsEdgeHighlighted(edge: GraphEdge): boolean {
-        return this.SelectedEdge?.ID === edge.ID || this.SelectedNode?.ID === edge.SourceID || this.SelectedNode?.ID === edge.TargetID;
+        return UUIDsEqual(this.SelectedEdge?.ID, edge.ID) ||
+            UUIDsEqual(this.SelectedNode?.ID, edge.SourceID) ||
+            UUIDsEqual(this.SelectedNode?.ID, edge.TargetID);
+    }
+
+    /**
+     * Whether this node is the selected one. Exists as a method because the template cannot call
+     * an imported function directly, and the comparison must go through UUIDsEqual rather than ===.
+     */
+    public IsNodeSelected(node: GraphNode): boolean {
+        return UUIDsEqual(this.SelectedNode?.ID, node.ID);
     }
 
     public TruncateLabel(text: string, maxLen: number): string {


### PR DESCRIPTION
## Summary

`UUIDCompliance.test.ts` fails with 11 direct UUID comparisons, all in `graph-view.component.ts`. Because that test lives in `@memberjunction/global` and scans the whole repo, the failure lands on a package nobody edited — and turbo fails fast, so ~9 further test tasks never run. That's currently the only thing keeping the unit-test job red on `next`.

Refs #3877 (UUID half only — the UI-layering half of that issue is untouched).

## Twelve comparisons, not eleven

Line 898 was **not** flagged by the gate:

```ts
return this.Edges.filter(e => e.SourceID === id || e.TargetID === id).length;
```

The test's pattern looks for `.ID ===`; these read `.SourceID ===` / `.TargetID ===`. Same UUIDs, same defect, invisible to the check. Fixing only the flagged 11 would have turned the gate green while leaving a real bug in place, so it's fixed here too.

## Why this is semantics, not lint

These are entity record primary keys — `NavigateToEntity` passes `node.ID` through `CompositeKey.FromID()` into `OpenEntityRecord`. SQL Server returns UUIDs uppercase, JS-generated ones are lowercase, and `===` silently fails to match across that boundary. Node selection, edge highlighting and hop expansion would all miss depending on where the ID came from.

## The template needed a method

An Angular template can't call an imported function, so:

```diff
- @if (SelectedNode?.ID === node.ID) {
+ @if (IsNodeSelected(node)) {
```

with a small `IsNodeSelected(node)` doing the `UUIDsEqual` comparison.

**Null semantics unchanged.** `UUIDsEqual` returns false when one side is null/undefined and the other isn't — exactly what `SelectedNode?.ID === node.ID` did when nothing was selected.

## Verification

- [x] `UUIDCompliance.test.ts` passes (1/1)
- [x] `tsc --noEmit` clean
- [x] **`ngc` builds clean** — this one matters: `tsc` alone does not type-check the template, which is the part that changed
- [x] No raw `.ID ===` / `.SourceID ===` / `.TargetID ===` comparisons remain in the file
- [x] `@memberjunction/global` was already a declared dependency — no manifest or lockfile change

`.includes()` on line 862 is a label substring search, not a UUID comparison, and is deliberately left alone.

## Knock-on

Unblocks the unit-test job, which has now failed three times running on #2985 for three unrelated reasons — the DOM ratchet (#3819), the install break (#3849), and this. Its own tests still have never executed in CI.
