### PR TITLE
fix(ci): lockfile d3 for graph-view and EmbeddedRecord __mj comment

### DIFF
--- a/.changeset/quiet-locks-align.md
+++ b/.changeset/quiet-locks-align.md
@@ -1,0 +1,5 @@
+---
+"@memberjunction/ng-graph-view": minor
+---
+
+Record graph-view's d3 / @types/d3 in the lockfile so CI frozen-lockfile install succeeds, and reword a CodeGen comment that tripped the hard-coded `__mj` schema gate.

--- a/migrations/v6/V202608161735__v6.1.x__EntityField_EmbeddedRecord.sql
+++ b/migrations/v6/V202608161735__v6.1.x__EntityField_EmbeddedRecord.sql
@@ -107,8 +107,8 @@ GO
 --
 -- FormChromeRule / other-entity residue from this CodeGen run was DISCARDED —
 -- that belongs to a sibling agent's migration on this omnibus branch.
--- If the hand DDL above changes, re-run CodeGen (includeSchemas: ['__mj'])
--- and replace this entire generated section.
+-- If the hand DDL above changes, re-run CodeGen scoped to the core schema
+-- (see includeSchemas in mj.config.cjs) and replace this entire generated section.
 -- =============================================================================
 /* SQL text to insert 12 new entity field(s) */
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7490,6 +7490,12 @@ importers:
       '@memberjunction/ng-ui-components':
         specifier: 6.1.0-edge.2
         version: link:../ui-components
+      '@types/d3':
+        specifier: ^7.4.3
+        version: 7.4.3
+      d3:
+        specifier: ^7.9.0
+        version: 7.9.0
       rxjs:
         specifier: ^7.8.2
         version: 7.8.2


### PR DESCRIPTION
## Summary

Unblocks `next` after [#3874](https://github.com/MemberJunction/MJ/pull/3874) merged with red CI.

- Record `d3@^7.9.0` and `@types/d3@^7.4.3` as importers on `@memberjunction/ng-graph-view` in `pnpm-lock.yaml`. The package.json already declared them; frozen-lockfile install failed because the lockfile did not. Snapshots were already present (MJExplorer uses the same versions) — no version resolution churn.
- Reword the CodeGen comment in `V202608161735__v6.1.x__EntityField_EmbeddedRecord.sql` so it no longer contains a hard-coded `__mj` token. The gate strips string literals but not comments, so `includeSchemas: ['__mj']` failed Check migrations. Allowed `__mj_*` timestamp columns are unchanged.

## Test plan

- [x] `perl` check of the stripped migration: no `__mj[^_]` tokens remain
- [x] lockfile diff is the six-line graph-view importer only
- [ ] CI: Check migrations, Unit Tests, Integration (deterministic), adopted standards, Detect missing/unused dependencies all pass on this PR
- [ ] Confirm `next` goes green after merge