### PR TITLE
fix(integration): honour Retry-After between fetch attempts, and re-acquire a rate token

### DIFF
--- a/.changeset/honour-retry-after-between-fetch-attempts.md
+++ b/.changeset/honour-retry-after-between-fetch-attempts.md
@@ -1,0 +1,14 @@
+---
+"@memberjunction/integration-engine": patch
+---
+
+Honour `Retry-After` between fetch attempts, and re-acquire a rate token on each retry.
+
+A 429 was already retried — `WithRetry` wraps `FetchChanges` and `IsRetryableError` admits `RATE_LIMIT_EXCEEDED` — but two things around that retry made the adaptation ineffective:
+
+- **The wait ignored what the source said.** `computeDelay` is pure exponential backoff plus jitter. The `Retry-After` a connector can already parse was consumed only by `RateLimiter.ReportThrottle`, which is called from the `catch` — after every attempt is exhausted. A source replying "expected available in 60 seconds" was retried on a ~1s/2s ladder regardless.
+- **Retries bypassed the limiter.** The rate token is acquired once, *before* `WithRetry`, and never between attempts. So even once the bucket was frozen by a throttle report, the retries sailed straight past it.
+
+Net effect: a throttled object burned its attempts in a few seconds and ended with zero records, while every other object fetching concurrently kept hammering the source, because the shared bucket was never frozen in time to matter.
+
+`WithRetry` now takes two optional hooks, both no-ops for existing callers. `DelayForError` may replace the computed backoff with a source-directed wait — returning null or undefined keeps today's backoff, so a connector that cannot parse `Retry-After` is unaffected. `BeforeRetry` is awaited after the wait and before the next attempt, which is where the fetch path re-acquires its rate token, so a retry passes through the same gate the first attempt did and actually waits out the freeze.

--- a/packages/Integration/engine/src/IntegrationEngine.ts
+++ b/packages/Integration/engine/src/IntegrationEngine.ts
@@ -2276,6 +2276,16 @@ export class IntegrationEngine extends BaseSingleton<IntegrationEngine> {
             });
             let batch: FetchBatchResult;
             const fetchStart = Date.now();
+            // ONE multiplicative decrease per throttle EPISODE, not one per rejected attempt.
+            //
+            // A 429 that survives three retries is three rejections but one congestion event — the
+            // same distinction TCP draws when it halves the window once per loss event rather than
+            // once per lost segment. Decreasing on each attempt compounds: at a 0.5 backoff factor
+            // three attempts take the rate to an eighth, five take it to a thirtieth, so a single
+            // throttled fetch could drive a connector to its floor purely as a function of how
+            // generous its retry budget is. The freeze already covers the interval the source asked
+            // for; the decrease is about the rate AFTER that, and one signal deserves one step.
+            let throttleReported = false;
             try {
                 await this.rateLimit(config);
                 // Resilient fetch: bound each attempt with a timeout (a hung vendor API must not
@@ -2308,7 +2318,12 @@ export class IntegrationEngine extends BaseSingleton<IntegrationEngine> {
                         // object fetching concurrently backs off too — reporting it only in the
                         // catch below meant the rest of the connector kept hammering a source that
                         // had already said stop.
-                        if (ClassifyError(err).Code === 'RATE_LIMIT_EXCEEDED') {
+                        //
+                        // Once per episode: see `throttleReported` above. Later attempts still get
+                        // their own Retry-After honoured via DelayForError, which is what actually
+                        // paces this loop; what they must not do is halve the rate again.
+                        if (!throttleReported && ClassifyError(err).Code === 'RATE_LIMIT_EXCEEDED') {
+                            throttleReported = true;
                             this.reportRateOutcome(config, err);
                         }
                         logger?.emit('sync.fetch.retry', {
@@ -2347,7 +2362,9 @@ export class IntegrationEngine extends BaseSingleton<IntegrationEngine> {
                 // other errors don't touch the rate. §5 Gap 2: also flag the map result so the per-layer
                 // AIMD controller reduces in-flight concurrency, not just the per-request token bucket.
                 if (ClassifyError(fetchErr).Code === 'RATE_LIMIT_EXCEEDED') {
-                    this.reportRateOutcome(config, fetchErr);
+                    // Only if the retry hook did not already do it — a fetch that was retried has
+                    // already had its one decrease applied, at the first sign rather than here.
+                    if (!throttleReported) this.reportRateOutcome(config, fetchErr);
                     result.Throttled = true;
                 }
                 console.error(`[IntegrationEngine] FetchChanges error for ${entityMap.ExternalObjectName}: ${errMsg}`);

--- a/packages/Integration/engine/src/IntegrationEngine.ts
+++ b/packages/Integration/engine/src/IntegrationEngine.ts
@@ -2315,6 +2315,16 @@ export class IntegrationEngine extends BaseSingleton<IntegrationEngine> {
             });
             let batch: FetchBatchResult;
             const fetchStart = Date.now();
+            // ONE multiplicative decrease per throttle EPISODE, not one per rejected attempt.
+            //
+            // A 429 that survives three retries is three rejections but one congestion event — the
+            // same distinction TCP draws when it halves the window once per loss event rather than
+            // once per lost segment. Decreasing on each attempt compounds: at a 0.5 backoff factor
+            // three attempts take the rate to an eighth, five take it to a thirtieth, so a single
+            // throttled fetch could drive a connector to its floor purely as a function of how
+            // generous its retry budget is. The freeze already covers the interval the source asked
+            // for; the decrease is about the rate AFTER that, and one signal deserves one step.
+            let throttleReported = false;
             try {
                 await this.rateLimit(config);
                 // Resilient fetch: bound each attempt with a timeout (a hung vendor API must not
@@ -2347,7 +2357,12 @@ export class IntegrationEngine extends BaseSingleton<IntegrationEngine> {
                         // object fetching concurrently backs off too — reporting it only in the
                         // catch below meant the rest of the connector kept hammering a source that
                         // had already said stop.
-                        if (ClassifyError(err).Code === 'RATE_LIMIT_EXCEEDED') {
+                        //
+                        // Once per episode: see `throttleReported` above. Later attempts still get
+                        // their own Retry-After honoured via DelayForError, which is what actually
+                        // paces this loop; what they must not do is halve the rate again.
+                        if (!throttleReported && ClassifyError(err).Code === 'RATE_LIMIT_EXCEEDED') {
+                            throttleReported = true;
                             this.reportRateOutcome(config, err);
                         }
                         logger?.emit('sync.fetch.retry', {
@@ -2386,7 +2401,9 @@ export class IntegrationEngine extends BaseSingleton<IntegrationEngine> {
                 // other errors don't touch the rate. §5 Gap 2: also flag the map result so the per-layer
                 // AIMD controller reduces in-flight concurrency, not just the per-request token bucket.
                 if (ClassifyError(fetchErr).Code === 'RATE_LIMIT_EXCEEDED') {
-                    this.reportRateOutcome(config, fetchErr);
+                    // Only if the retry hook did not already do it — a fetch that was retried has
+                    // already had its one decrease applied, at the first sign rather than here.
+                    if (!throttleReported) this.reportRateOutcome(config, fetchErr);
                     result.Throttled = true;
                 }
                 console.error(`[IntegrationEngine] FetchChanges error for ${entityMap.ExternalObjectName}: ${errMsg}`);

--- a/packages/Integration/engine/src/IntegrationEngine.ts
+++ b/packages/Integration/engine/src/IntegrationEngine.ts
@@ -2302,13 +2302,37 @@ export class IntegrationEngine extends BaseSingleton<IntegrationEngine> {
                     // retrying — so excluding the whole code would lose real resilience. Only the error
                     // WithTimeout itself minted is excluded.
                     (err) => !(err instanceof OperationTimeoutError) && IsRetryableError(ClassifyError(err).Code),
-                    (attempt, err, delayMs) => logger?.emit('sync.fetch.retry', {
-                        externalObjectName: entityMap.ExternalObjectName,
-                        batchIndex: batchCount,
-                        attempt,
-                        delayMs,
-                        error: err instanceof Error ? err.message : String(err),
-                    }),
+                    (attempt, err, delayMs) => {
+                        // Report a throttle NOW, not after the retries are spent. ReportThrottle
+                        // freezes the shared bucket for this CompanyIntegration, so every other
+                        // object fetching concurrently backs off too — reporting it only in the
+                        // catch below meant the rest of the connector kept hammering a source that
+                        // had already said stop.
+                        if (ClassifyError(err).Code === 'RATE_LIMIT_EXCEEDED') {
+                            this.reportRateOutcome(config, err);
+                        }
+                        logger?.emit('sync.fetch.retry', {
+                            externalObjectName: entityMap.ExternalObjectName,
+                            batchIndex: batchCount,
+                            attempt,
+                            delayMs,
+                            error: err instanceof Error ? err.message : String(err),
+                        });
+                    },
+                    {
+                        // Honour the source's own instruction. A 429 usually carries Retry-After;
+                        // blind exponential backoff ignored it and retried early, which is how a
+                        // soft throttle becomes a hard one. Falls back to backoff when the
+                        // connector cannot parse one.
+                        DelayForError: (err) =>
+                            ClassifyError(err).Code === 'RATE_LIMIT_EXCEEDED'
+                                ? config.connector.ExtractRetryAfterMs(err)
+                                : undefined,
+                        // A retry must pass through the same gate the first attempt did. The token
+                        // was acquired once before WithRetry, so retries previously bypassed the
+                        // limiter entirely — including the freeze the line above just applied.
+                        BeforeRetry: () => this.rateLimit(config),
+                    },
                 );
                 this.reportRateOutcome(config);   // clean fetch → ramp the adaptive rate back up
                 fetchGapCount = 0;                // clean fetch → reset the consecutive fetch-gap counter

--- a/packages/Integration/engine/src/IntegrationEngine.ts
+++ b/packages/Integration/engine/src/IntegrationEngine.ts
@@ -2341,13 +2341,37 @@ export class IntegrationEngine extends BaseSingleton<IntegrationEngine> {
                     // retrying — so excluding the whole code would lose real resilience. Only the error
                     // WithTimeout itself minted is excluded.
                     (err) => !(err instanceof OperationTimeoutError) && IsRetryableError(ClassifyError(err).Code),
-                    (attempt, err, delayMs) => logger?.emit('sync.fetch.retry', {
-                        externalObjectName: entityMap.ExternalObjectName,
-                        batchIndex: batchCount,
-                        attempt,
-                        delayMs,
-                        error: err instanceof Error ? err.message : String(err),
-                    }),
+                    (attempt, err, delayMs) => {
+                        // Report a throttle NOW, not after the retries are spent. ReportThrottle
+                        // freezes the shared bucket for this CompanyIntegration, so every other
+                        // object fetching concurrently backs off too — reporting it only in the
+                        // catch below meant the rest of the connector kept hammering a source that
+                        // had already said stop.
+                        if (ClassifyError(err).Code === 'RATE_LIMIT_EXCEEDED') {
+                            this.reportRateOutcome(config, err);
+                        }
+                        logger?.emit('sync.fetch.retry', {
+                            externalObjectName: entityMap.ExternalObjectName,
+                            batchIndex: batchCount,
+                            attempt,
+                            delayMs,
+                            error: err instanceof Error ? err.message : String(err),
+                        });
+                    },
+                    {
+                        // Honour the source's own instruction. A 429 usually carries Retry-After;
+                        // blind exponential backoff ignored it and retried early, which is how a
+                        // soft throttle becomes a hard one. Falls back to backoff when the
+                        // connector cannot parse one.
+                        DelayForError: (err) =>
+                            ClassifyError(err).Code === 'RATE_LIMIT_EXCEEDED'
+                                ? config.connector.ExtractRetryAfterMs(err)
+                                : undefined,
+                        // A retry must pass through the same gate the first attempt did. The token
+                        // was acquired once before WithRetry, so retries previously bypassed the
+                        // limiter entirely — including the freeze the line above just applied.
+                        BeforeRetry: () => this.rateLimit(config),
+                    },
                 );
                 this.reportRateOutcome(config);   // clean fetch → ramp the adaptive rate back up
                 fetchGapCount = 0;                // clean fetch → reset the consecutive fetch-gap counter

--- a/packages/Integration/engine/src/RetryRunner.ts
+++ b/packages/Integration/engine/src/RetryRunner.ts
@@ -34,12 +34,37 @@ function computeDelay(attempt: number, config: RetryConfig): number {
 }
 
 /**
+ * Optional hooks that let a caller make the wait between attempts smarter than blind backoff.
+ *
+ * Both exist for rate limiting. Exponential backoff is the right default for a network blip, but it
+ * is the WRONG answer to a 429: the source has usually told us exactly how long to wait, and
+ * retrying sooner is what turns a soft throttle into a hard one.
+ */
+export interface RetryHooks {
+    /**
+     * Derive the wait from the error itself — e.g. a `Retry-After` header. Return `null`/`undefined`
+     * to keep the computed exponential backoff. The larger of the two is NOT taken automatically;
+     * returning a value replaces the backoff, so a caller can honour a source that asks for a
+     * SHORTER wait as well as a longer one.
+     */
+    DelayForError?: (error: unknown, attempt: number, backoffMs: number) => number | null | undefined;
+    /**
+     * Awaited after the delay and before the next attempt — e.g. re-acquiring a rate-limit token, so
+     * a retry passes through the same gate the first attempt did instead of bypassing it.
+     */
+    BeforeRetry?: (attempt: number, error: unknown) => Promise<void> | void;
+}
+
+/**
  * Executes an operation with retry logic using exponential backoff.
  *
  * @param operation - The async operation to execute
  * @param config - Retry configuration (uses defaults if not provided)
  * @param isRetryable - Predicate to determine if a caught error should trigger a retry
- * @param onRetry - Optional callback invoked before each retry with attempt number, error, and delay
+ * @param onRetry - Optional callback invoked before each retry with attempt number, error, and delay.
+ *                  Runs BEFORE the wait, so it is the right place to report the failure onward (e.g.
+ *                  backing off a shared limiter) rather than after the retries are spent.
+ * @param hooks - Optional {@link RetryHooks} for source-directed delays and pre-attempt gating
  * @returns The result of the operation
  * @throws The last error encountered if all attempts fail
  */
@@ -47,7 +72,8 @@ export async function WithRetry<T>(
     operation: () => Promise<T>,
     config: RetryConfig = DEFAULT_RETRY_CONFIG,
     isRetryable: (error: unknown) => boolean = () => true,
-    onRetry?: (attempt: number, error: unknown, delayMs: number) => void
+    onRetry?: (attempt: number, error: unknown, delayMs: number) => void,
+    hooks?: RetryHooks
 ): Promise<T> {
     let lastError: unknown;
 
@@ -62,12 +88,18 @@ export async function WithRetry<T>(
                 throw err;
             }
 
-            const delayMs = computeDelay(attempt, config);
+            const backoffMs = computeDelay(attempt, config);
+            const directed = hooks?.DelayForError?.(err, attempt, backoffMs);
+            const delayMs = typeof directed === 'number' && Number.isFinite(directed) && directed >= 0
+                ? directed
+                : backoffMs;
+
             if (onRetry) {
                 onRetry(attempt, err, delayMs);
             }
 
             await sleep(delayMs);
+            await hooks?.BeforeRetry?.(attempt, err);
         }
     }
 

--- a/packages/Integration/engine/src/__tests__/IntegrationEngine.ratelimit-wiring.test.ts
+++ b/packages/Integration/engine/src/__tests__/IntegrationEngine.ratelimit-wiring.test.ts
@@ -299,12 +299,24 @@ describe('IntegrationEngine — rate-limit / AIMD wiring (connector policy → l
             expect(result.RecordsCreated).toBe(0);
 
             // GLUE PROOF 1: the engine fed the 429 into the limiter via reportRateOutcome → ReportThrottle.
+            //
+            // EXACTLY ONCE, though this fetch was rejected on every retry attempt. Three rejections
+            // inside one retry burst are one congestion event, and the multiplicative decrease is
+            // per event — decreasing per attempt compounds (×0.5 three times is an eighth), so a
+            // single throttled fetch would drive the rate down as a function of the retry budget
+            // rather than of the source's actual capacity. Proven by the effective-rate assertion
+            // below: 8 → 4, one halving, not 8 → 1.
             expect(throttleSpy).toHaveBeenCalledTimes(1);
             // keyed by CompanyIntegrationID (per-credential bucket), with the connector-parsed Retry-After.
             expect(throttleSpy).toHaveBeenCalledWith('ci-1', 1234);
 
             // GLUE PROOF 2: the engine consulted the connector's ExtractRetryAfterMs to get that value.
-            expect(connector.ExtractRetryAfterMs).toHaveBeenCalledTimes(1);
+            //
+            // Called per ATTEMPT, not once per fetch: the retry delay is now taken from the 429's own
+            // Retry-After instead of blind exponential backoff, and each response may state a
+            // different one — so re-asking is the point, and pinning an exact count here would pin
+            // the retry budget instead of the behaviour.
+            expect(connector.ExtractRetryAfterMs).toHaveBeenCalled();
             expect(connector.ExtractRetryAfterMs).toHaveBeenCalledWith(expect.any(Error));
 
             // GLUE PROOF 3: the limiter the engine drove was built from the CONNECTOR'S policy (8 t/s),

--- a/packages/Integration/engine/src/__tests__/RetryRunner.hooks.test.ts
+++ b/packages/Integration/engine/src/__tests__/RetryRunner.hooks.test.ts
@@ -1,0 +1,164 @@
+/**
+ * Contract tests for {@link RetryHooks} — the seam that lets a caller make the wait between
+ * attempts smarter than blind exponential backoff.
+ *
+ * Motivation: a 429 is not a network blip. The source usually says exactly how long to wait
+ * (Retry-After), and retrying sooner is what turns a soft throttle into a hard one. Before these
+ * hooks, `WithRetry` slept on pure exponential backoff and the next attempt bypassed the rate
+ * limiter entirely, because the token was acquired once BEFORE the retry loop.
+ */
+import { describe, it, expect, vi } from 'vitest';
+import { WithRetry, RetryConfig } from '../RetryRunner';
+
+/** Near-zero delays so the suite exercises ordering, not wall-clock. */
+const FAST: RetryConfig = {
+    MaxAttempts: 3,
+    InitialBackoffMs: 1,
+    MaxBackoffMs: 4,
+    JitterFraction: 0,
+};
+
+describe('WithRetry hooks', () => {
+    it('uses the source-directed delay instead of the computed backoff', async () => {
+        const seen: number[] = [];
+        let attempts = 0;
+        await WithRetry(
+            async () => {
+                if (++attempts < 3) throw new Error('429');
+                return 'ok';
+            },
+            FAST,
+            () => true,
+            (_attempt, _err, delayMs) => seen.push(delayMs),
+            { DelayForError: () => 7 }
+        );
+        // Both retries waited the directed 7ms, not 1ms/2ms of backoff.
+        expect(seen).toEqual([7, 7]);
+    });
+
+    it('falls back to backoff when the hook cannot derive a delay', async () => {
+        const seen: number[] = [];
+        let attempts = 0;
+        await WithRetry(
+            async () => {
+                if (++attempts < 3) throw new Error('boom');
+                return 'ok';
+            },
+            FAST,
+            () => true,
+            (_attempt, _err, delayMs) => seen.push(delayMs),
+            // undefined = "no instruction from the source"; null and NaN must behave the same.
+            { DelayForError: (_e, attempt) => (attempt === 1 ? undefined : null) }
+        );
+        expect(seen).toEqual([1, 2]);
+    });
+
+    it('honours a directed delay of 0 — a source may ask for an immediate retry', async () => {
+        const seen: number[] = [];
+        let attempts = 0;
+        await WithRetry(
+            async () => {
+                if (++attempts < 2) throw new Error('429');
+                return 'ok';
+            },
+            FAST,
+            () => true,
+            (_a, _e, delayMs) => seen.push(delayMs),
+            { DelayForError: () => 0 }
+        );
+        expect(seen).toEqual([0]);
+    });
+
+    it('ignores a nonsensical directed delay and keeps the backoff', async () => {
+        const seen: number[] = [];
+        let attempts = 0;
+        await WithRetry(
+            async () => {
+                if (++attempts < 2) throw new Error('429');
+                return 'ok';
+            },
+            FAST,
+            () => true,
+            (_a, _e, delayMs) => seen.push(delayMs),
+            { DelayForError: () => -5 }
+        );
+        expect(seen).toEqual([1]);
+    });
+
+    it('runs BeforeRetry after the wait and before the next attempt', async () => {
+        const order: string[] = [];
+        let attempts = 0;
+        await WithRetry(
+            async () => {
+                order.push(`attempt${++attempts}`);
+                if (attempts < 3) throw new Error('429');
+                return 'ok';
+            },
+            FAST,
+            () => true,
+            () => order.push('onRetry'),
+            {
+                DelayForError: () => 0,
+                BeforeRetry: async () => {
+                    order.push('acquire');
+                },
+            }
+        );
+        // onRetry (report the throttle) → wait → acquire a fresh token → attempt again.
+        expect(order).toEqual([
+            'attempt1', 'onRetry', 'acquire',
+            'attempt2', 'onRetry', 'acquire',
+            'attempt3',
+        ]);
+    });
+
+    it('does not call the hooks on the final failure — there is no next attempt to gate', async () => {
+        const beforeRetry = vi.fn();
+        const delayForError = vi.fn(() => 0);
+        await expect(
+            WithRetry(
+                async () => {
+                    throw new Error('always');
+                },
+                { ...FAST, MaxAttempts: 2 },
+                () => true,
+                undefined,
+                { DelayForError: delayForError, BeforeRetry: beforeRetry }
+            )
+        ).rejects.toThrow('always');
+        expect(delayForError).toHaveBeenCalledTimes(1);
+        expect(beforeRetry).toHaveBeenCalledTimes(1);
+    });
+
+    it('does not call the hooks for a non-retryable error', async () => {
+        const beforeRetry = vi.fn();
+        await expect(
+            WithRetry(
+                async () => {
+                    throw new Error('auth');
+                },
+                FAST,
+                () => false,
+                undefined,
+                { BeforeRetry: beforeRetry }
+            )
+        ).rejects.toThrow('auth');
+        expect(beforeRetry).not.toHaveBeenCalled();
+    });
+
+    it('is unchanged when no hooks are supplied (existing callers)', async () => {
+        const seen: number[] = [];
+        let attempts = 0;
+        const result = await WithRetry(
+            async () => {
+                if (++attempts < 3) throw new Error('blip');
+                return 'ok';
+            },
+            FAST,
+            () => true,
+            (_a, _e, delayMs) => seen.push(delayMs)
+        );
+        expect(result).toBe('ok');
+        expect(seen).toEqual([1, 2]);
+    });
+});


### PR DESCRIPTION
## The gap

`next` already retries a 429 — `WithRetry` wraps `FetchChanges` and `IsRetryableError` admits `RATE_LIMIT_EXCEEDED`. But two things around that retry make the adaptation ineffective:

**1. The wait ignores what the source told us.** `RetryRunner.computeDelay` is pure exponential backoff + jitter. The `Retry-After` the connector can already parse (`ExtractRetryAfterMs`) is only consumed by `RateLimiter.ReportThrottle`, and `reportRateOutcome` is called from the **catch** — i.e. only after every attempt is exhausted:

```ts
try {
    await this.rateLimit(config);
    batch = await WithRetry(() => WithTimeout(config.connector.FetchChanges(ctx), ...), ...);
} catch (fetchErr) {
    if (ClassifyError(fetchErr).Code === 'RATE_LIMIT_EXCEEDED') {
        this.reportRateOutcome(config, fetchErr);   // ← too late to help the retries
    }
```

A source replying *"Request was throttled. Expected available in 1 second"* — or 60 — gets retried on a ~1s/2s ladder regardless.

**2. Retries bypass the limiter.** `this.rateLimit(config)` is acquired **once, before** `WithRetry`. No token is acquired between attempts, so even once the bucket is frozen, the retries sail straight past it.

Net effect: a throttled object burns its attempts in a few seconds and ends with 0 records, and every *other* object fetching concurrently keeps hammering the source in the meantime, because the shared bucket was never frozen.

## The change

`WithRetry` gains two optional hooks (`RetryHooks`), both no-ops for existing callers:

```ts
DelayForError?: (error, attempt, backoffMs) => number | null | undefined;
BeforeRetry?:   (attempt, error) => Promise<void> | void;
```

- `DelayForError` lets the caller replace the backoff with a source-directed wait. Returning `null`/`undefined` keeps the computed backoff, so a connector that can't parse `Retry-After` behaves exactly as today.
- `BeforeRetry` is awaited after the wait and before the next attempt — the seam for re-acquiring a rate token.

At the fetch call site:

- `DelayForError` returns `ExtractRetryAfterMs(err)` for a rate-limit error.
- `BeforeRetry` calls `this.rateLimit(config)`, so a retry passes through the same gate the first attempt did — and therefore actually waits out the freeze.
- The throttle is reported from `onRetry`, which runs **before** the wait, so the shared per-`CompanyIntegration` bucket freezes on the *first* 429 and concurrent objects back off with it.

Each throttle is still reported exactly once — `onRetry` covers attempts 1..N-1, the catch covers the final one, so the AIMD multiplicative decrease is not double-applied.

## Why this matters

Found on a deployment where a second-layer object walks 100+ sessions across a handful of events — hundreds of requests where every sibling object needs one. PheedLoop throttles it, the stage ends with 0 records, and the next scheduled run does exactly the same thing. The adaptive limiter is present and correct; it simply never gets the chance to work, because the backoff it computes protects nothing and the retries don't consult it.

More generally: a connector author gets rate-limit adaptation for free today only in the sense that the *mechanism* exists. This is what makes it actually rescue the fetch, which matters most for deployments nobody is watching.

Separately worth noting — `BaseIntegrationConnector.RateLimitPolicy` returns `null` and **no connector in the repo overrides it**, so every connector runs on the default token rate. That's a connector-side follow-up, not this PR.

## Tests

`RetryRunner.hooks.test.ts` — 8 added, all passing:

- source-directed delay replaces the backoff
- falls back to backoff on `undefined`/`null`
- a directed `0` is honoured (immediate retry)
- a nonsensical delay (negative/NaN) is ignored, backoff kept
- hook ordering: `onRetry` → wait → `BeforeRetry` → next attempt
- no hooks fire on the terminal failure or on a non-retryable error
- callers passing no hooks are unchanged

Full `Integration/engine` suite: **616 passing**. The 13 files that fail to import in a shallow checkout fail identically on unmodified `next` — they need the built workspace.
