### PR TITLE
A layout mode on the realtime surface panel, so a host can show surfaces side by side (#3535)

### DIFF
--- a/.changeset/realtime-surface-split-layout.md
+++ b/.changeset/realtime-surface-split-layout.md
@@ -1,0 +1,37 @@
+---
+"@memberjunction/ng-conversations": minor
+---
+
+Realtime surface panel: a declared layout mode, so a host can show two surfaces at once (#3535)
+
+`RealtimeSurfaceTabsComponent` showed exactly one surface at a time, and there was no way to ask
+it for more — so a side-by-side arrangement had to be imposed from outside, which silently lost a
+specificity tie: the panel's own `.surface { display: flex }` carries the same specificity as a
+host's `.surface.my-split { display: grid }` and wins on document order, so `grid-template-columns`
+computed correctly and was ignored. Two debugging sessions were lost to that, once with CSS grid
+and once with Golden Layout laying its whole tree into a 0px-tall container while reporting no
+error.
+
+- **`[Layout]="'tabs' | 'split'"` + `[SplitKeys]`** on `mj-realtime-surface-tabs` (and
+  `[SurfaceLayout]` / `[SurfaceSplitKeys]` on `mj-realtime-session-overlay`, which hosts it).
+  `'tabs'` is the default and is unchanged — existing callers bind nothing and get today's panel.
+  `'split'` arranges the named surfaces side by side with draggable splitters (Golden Layout),
+  and shows every open surface when no keys are named.
+- **Panes are never re-created by a layout switch.** Golden Layout runs in VIRTUAL component mode:
+  the panes stay exactly where they are in the panel's template and only get positioned, so a
+  whiteboard's drawing and a remote browser's page survive switching in and out of a split.
+  Inline positioning is also what makes the mode declarable — it outranks every stylesheet, so
+  nobody has to win a specificity tie to arrange this panel.
+- **The zero-size trap fails loudly now.** The split waits (capped) for its container to report a
+  real size before Golden Layout ever sees it, re-checks afterwards that every pane actually
+  received area, and on any failure logs with context and degrades to the tabs layout instead of
+  leaving a blank panel. It also degrades when fewer than two of the requested surfaces are open.
+- **Panes carry `data-channel`** (the issue's secondary ask), so a host — and the split itself —
+  addresses a pane by its channel rather than by index into the tab list.
+- The structural Golden Layout rules the arrangement depends on are injected (scoped to the
+  layout host), so a host that never imported `goldenlayout-base.css` gets a real split rather
+  than two silently stacked surfaces.
+
+Geometry is verified in a real browser by `npm run verify:split-layout` in the package — jsdom has
+no layout engine, so the unit specs fake Golden Layout and that script proves the part a fake
+cannot.

--- a/packages/Angular/Generic/conversations/package.json
+++ b/packages/Angular/Generic/conversations/package.json
@@ -11,7 +11,8 @@
     "test": "vitest run",
     "test:types": "tsc --noEmit -p tsconfig.spec.json",
     "build": "ngc",
-    "test:watch": "vitest"
+    "test:watch": "vitest",
+    "verify:split-layout": "node scripts/verify-split-layout.mjs"
   },
   "keywords": [],
   "author": "",
@@ -19,6 +20,7 @@
   "devDependencies": {
     "@angular/compiler": "21.1.3",
     "@angular/compiler-cli": "21.1.3",
+    "esbuild": "^0.27.3",
     "sass": "^1.97.3",
     "vitest": "^4.0.18",
     "@memberjunction/ng-test-utils": "6.1.0-edge.2"
@@ -62,6 +64,7 @@
     "@memberjunction/ng-user-routines": "6.1.0-edge.2",
     "@memberjunction/ng-whiteboard": "6.1.0-edge.2",
     "angular-split": "^20.0.0",
+    "golden-layout": "^2.6.0",
     "rxjs": "^7.8.2",
     "tslib": "^2.8.1"
   },

--- a/packages/Angular/Generic/conversations/scripts/verify-split-layout.mjs
+++ b/packages/Angular/Generic/conversations/scripts/verify-split-layout.mjs
@@ -1,0 +1,184 @@
+#!/usr/bin/env node
+/**
+ * REAL-BROWSER check of the realtime surface panel's `Layout="split"` geometry.
+ *
+ * The unit specs fake Golden Layout, because jsdom has no layout engine and a fake is the only
+ * honest thing to assert against there. That leaves exactly one claim unproven — and it is the
+ * claim two lost debugging sessions were spent on (issue #3535): that Golden Layout, given a
+ * measured container, really does report side-by-side rects for a headerless row, that this
+ * driver really does land the panes on them, and that it really does re-rect when the panel is
+ * resized. A zero-height container makes GL lay its whole tree into nothing while reporting no
+ * error, so "it compiled" and "the tests passed" are not evidence.
+ *
+ * Deliberately runs WITHOUT `goldenlayout-base.css`: the structural rules the driver injects
+ * itself are what must be sufficient, so a host that never imported GL's stylesheet still gets a
+ * split rather than two silently stacked surfaces.
+ *
+ * Usage: node scripts/verify-split-layout.mjs [--headed]
+ */
+import { chromium } from '@playwright/test';
+import * as esbuild from 'esbuild';
+import { fileURLToPath } from 'node:url';
+import { dirname, resolve } from 'node:path';
+import { writeFileSync, mkdtempSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const driverPath = resolve(here, '../src/lib/components/realtime/realtime-surface-split-layout.ts');
+
+/** The panel's own layout rules, reduced to the parts that decide the split's geometry. */
+const HARNESS_CSS = `
+  body { margin: 0; }
+  .surface {
+    position: relative; display: flex; flex-direction: column;
+    width: 900px; height: 600px; border-left: 1px solid #ccc;
+  }
+  .surface-tabs { flex-shrink: 0; height: 40px; background: #eee; }
+  .s-pane { display: none; flex: 1; min-height: 0; flex-direction: column; overflow: hidden; position: relative; }
+  .s-pane--active { display: flex; }
+  .surface--split .s-pane { display: none; }
+  .surface__split { flex: 1; min-height: 0; position: relative; }
+`;
+
+const HARNESS_HTML = `
+  <aside class="surface surface--split">
+    <div class="surface-tabs">tabs</div>
+    <div class="s-pane s-pane--active" data-channel="Site A"><div class="body">A</div></div>
+    <div class="s-pane" data-channel="Site B"><div class="body">B</div></div>
+    <div class="surface__split"></div>
+  </aside>
+`;
+
+const failures = [];
+const check = (label, condition, detail) => {
+  if (condition) {
+    console.log(`  ok    ${label}`);
+  } else {
+    console.log(`  FAIL  ${label}${detail === undefined ? '' : ` — ${detail}`}`);
+    failures.push(label);
+  }
+};
+
+/** Bundle the driver for the browser, with MJ's logger stubbed to the console. */
+async function bundleDriver() {
+  const stubDir = mkdtempSync(join(tmpdir(), 'mj-split-verify-'));
+  const stubPath = join(stubDir, 'mj-core-stub.js');
+  writeFileSync(stubPath, 'export function LogError(message) { console.error(message); }\n');
+  const result = await esbuild.build({
+    entryPoints: [driverPath],
+    bundle: true,
+    format: 'iife',
+    globalName: 'MJSplitLayout',
+    write: false,
+    platform: 'browser',
+    alias: { '@memberjunction/core': stubPath },
+  });
+  return result.outputFiles[0].text;
+}
+
+const run = async () => {
+  const driverBundle = await bundleDriver();
+  const browser = await chromium.launch({ headless: !process.argv.includes('--headed') });
+  try {
+    const page = await browser.newPage({ viewport: { width: 1200, height: 800 } });
+    page.on('console', message => {
+      if (message.type() === 'error') {
+        console.log(`  [page error] ${message.text()}`);
+      }
+    });
+    await page.setContent(`<!doctype html><html><head><style>${HARNESS_CSS}</style></head><body>${HARNESS_HTML}</body></html>`);
+    await page.addScriptTag({ content: driverBundle });
+
+    console.log('Golden Layout split, in Chromium, without goldenlayout-base.css:');
+
+    const attached = await page.evaluate(() => {
+      const surface = document.querySelector('.surface');
+      const host = document.querySelector('.surface__split');
+      const paneOf = key => document.querySelector(`.s-pane[data-channel="${key}"]`);
+      const panes = ['Site A', 'Site B'].map(key => ({ Key: key, Title: key, Element: paneOf(key) }));
+      window.__panes = panes;
+      window.__layout = new window.MJSplitLayout.RealtimeSurfaceSplitLayout();
+      const ok = window.__layout.Attach(host, panes);
+      const rect = element => {
+        const r = element.getBoundingClientRect();
+        return { left: r.left, top: r.top, width: r.width, height: r.height, right: r.right, bottom: r.bottom };
+      };
+      return {
+        ok,
+        host: rect(host),
+        surface: rect(surface),
+        panes: panes.map(p => ({ Key: p.Key, Rect: rect(p.Element), Parent: p.Element.parentElement.className })),
+      };
+    });
+
+    check('Attach reports success', attached.ok === true);
+    const [a, b] = attached.panes.map(p => p.Rect);
+    check('both surfaces have real area', a.width > 100 && a.height > 100 && b.width > 100 && b.height > 100,
+      `A ${a.width}×${a.height}, B ${b.width}×${b.height}`);
+    check('the surfaces sit SIDE BY SIDE, not stacked', a.left < b.left && a.right <= b.left + 1,
+      `A.right=${a.right} B.left=${b.left}`);
+    check('they share a top edge and height (a row, not a cascade)',
+      Math.abs(a.top - b.top) < 1 && Math.abs(a.height - b.height) < 1,
+      `A.top=${a.top} B.top=${b.top}`);
+    check('they cover the layout host', Math.abs(a.left - attached.host.left) < 2 && Math.abs(b.right - attached.host.right) < 2,
+      `host ${attached.host.left}..${attached.host.right}, panes ${a.left}..${b.right}`);
+    check('they sit below the tab strip, inside the panel', a.top >= attached.surface.top + 40 - 1);
+    check('no pane was re-parented', attached.panes.every(p => p.Parent.includes('surface')));
+
+    // Resize: the panel's width is owned by the shell, so the arrangement has to follow it.
+    const resized = await page.evaluate(async () => {
+      document.querySelector('.surface').style.width = '600px';
+      await new Promise(r => setTimeout(r, 500));
+      return window.__panes.map(p => {
+        const r = p.Element.getBoundingClientRect();
+        return { left: r.left, width: r.width, right: r.right };
+      });
+    });
+    check('the split follows a panel resize', resized[0].width < a.width && resized[1].width < b.width,
+      `A ${a.width}→${resized[0].width}, B ${b.width}→${resized[1].width}`);
+    check('it still fills the resized panel', Math.abs(resized[1].right - 600) < 3, `right edge ${resized[1].right}`);
+
+    // Teardown: the panes go back to the tabs layout with nothing left on them.
+    const destroyed = await page.evaluate(() => {
+      window.__layout.Destroy();
+      return {
+        styles: window.__panes.map(p => p.Element.getAttribute('style') ?? ''),
+        goldenLayoutDom: document.querySelectorAll('.surface__split .lm_root, .surface__split .lm_goldenlayout').length,
+        activePaneVisible: getComputedStyle(window.__panes[0].Element).display,
+      };
+    });
+    check('every pane is handed back with no inline geometry', destroyed.styles.every(s => s === ''), JSON.stringify(destroyed.styles));
+    check('Golden Layout took its DOM with it', destroyed.goldenLayoutDom === 0, `${destroyed.goldenLayoutDom} left`);
+    // .surface--split is still on the harness element, so panes stay hidden — that class is the
+    // panel's to remove; what matters is that nothing inline is pinning them anymore.
+    check('pane visibility is back under the stylesheet', destroyed.activePaneVisible === 'none', destroyed.activePaneVisible);
+
+    // The trap itself: a host with no height must FAIL the attach, not lay the tree into nothing.
+    const collapsed = await page.evaluate(() => {
+      document.querySelector('.surface').style.height = '0px';
+      const host = document.querySelector('.surface__split');
+      const layout = new window.MJSplitLayout.RealtimeSurfaceSplitLayout();
+      const ok = layout.Attach(host, window.__panes);
+      const styles = window.__panes.map(p => p.Element.getAttribute('style') ?? '');
+      layout.Destroy();
+      return { ok, styles, hostHeight: host.getBoundingClientRect().height };
+    });
+    check('a zero-height host FAILS the attach instead of collapsing silently',
+      collapsed.ok === false, `host height ${collapsed.hostHeight}, Attach returned ${collapsed.ok}`);
+    check('a failed attach leaves the panes untouched', collapsed.styles.every(s => s === ''), JSON.stringify(collapsed.styles));
+  } finally {
+    await browser.close();
+  }
+
+  if (failures.length > 0) {
+    console.error(`\n${failures.length} check(s) FAILED: ${failures.join('; ')}`);
+    process.exit(1);
+  }
+  console.log('\nAll split-layout geometry checks passed.');
+};
+
+run().catch(err => {
+  console.error(err);
+  process.exit(1);
+});

--- a/packages/Angular/Generic/conversations/src/__tests__/realtime-surface-tabs-model.test.ts
+++ b/packages/Angular/Generic/conversations/src/__tests__/realtime-surface-tabs-model.test.ts
@@ -1,5 +1,7 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
-import { RealtimeSurfaceTabsModel, ShouldRemoveReviewWhiteboardTab } from '../lib/components/realtime/realtime-surface-tabs.model';
+import {
+  MIN_SPLIT_PANES, RealtimeSurfaceTabsModel, ResolveSplitPaneKeys, ShouldRemoveReviewWhiteboardTab
+} from '../lib/components/realtime/realtime-surface-tabs.model';
 
 describe('RealtimeSurfaceTabsModel', () => {
   let model: RealtimeSurfaceTabsModel;
@@ -238,6 +240,36 @@ describe('RealtimeSurfaceTabsModel', () => {
       expect(model.Tabs.some(t => t.Key === 'Whiteboard')).toBe(true);
       expect(model.ActiveKey).toBe('Whiteboard');
     });
+  });
+});
+
+describe('ResolveSplitPaneKeys (which surfaces a Layout="split" shows)', () => {
+  const model = new RealtimeSurfaceTabsModel();
+  model.RegisterChannelTab({ Key: 'Site A', Title: 'Site A', Icon: 'fa-solid fa-globe' });
+  model.RegisterChannelTab({ Key: 'Site B', Title: 'Site B', Icon: 'fa-solid fa-globe' });
+  model.SetShowActivityTab(true);
+
+  it('shows the surfaces the host named, in STRIP order (not the order it listed them)', () => {
+    expect(ResolveSplitPaneKeys(model.Tabs, ['Site B', 'Site A'])).toEqual(['Site A', 'Site B']);
+  });
+
+  it('shows every open surface when the host names none', () => {
+    expect(ResolveSplitPaneKeys(model.Tabs, [])).toEqual(['Site A', 'Site B', 'activity']);
+  });
+
+  it('drops a named surface that has not come into play yet, rather than holding space for it', () => {
+    expect(ResolveSplitPaneKeys(model.Tabs, ['Site A', 'Site B', 'Site C'])).toEqual(['Site A', 'Site B']);
+  });
+
+  it('resolves to nothing below two surfaces — that is the tabs layout, not a split', () => {
+    expect(ResolveSplitPaneKeys(model.Tabs, ['Site A'])).toEqual([]);
+    expect(ResolveSplitPaneKeys(model.Tabs, ['nope'])).toEqual([]);
+    expect(ResolveSplitPaneKeys([], [])).toEqual([]);
+    expect(MIN_SPLIT_PANES).toBe(2);
+  });
+
+  it('can split the Activity surface alongside a channel', () => {
+    expect(ResolveSplitPaneKeys(model.Tabs, ['Site A', 'activity'])).toEqual(['Site A', 'activity']);
   });
 });
 

--- a/packages/Angular/Generic/conversations/src/lib/components/realtime/README.md
+++ b/packages/Angular/Generic/conversations/src/lib/components/realtime/README.md
@@ -41,6 +41,8 @@ All inputs are optional and default to the historical behaviour, so existing cal
 | `[ShowActivityRail]` | `boolean` | `true` | Activity rail/tab (delegations, artifacts). |
 | `[ShowDevLinks]` | `boolean` | `true` | Developer links/panels (still gated by per‑session dev mode). |
 | `[AllowResize]` | `boolean` | `true` | Drag‑to‑resize the surface panel. |
+| `[SurfaceLayout]` | `'tabs'\|'split'` | `'tabs'` | How the surface panel arranges surfaces: one at a time, or side by side with draggable splitters. |
+| `[SurfaceSplitKeys]` | `string[]` | `[]` | Which surfaces a `'split'` layout shows, by channel key (empty ⇒ all open ones). Degrades to `'tabs'` below two. |
 | `[UiConfig]` | `RealtimeUiInputs` | — | Programmatic override bag; merged under the individual inputs. |
 | `[Hidden]` | `boolean` | `false` | Minimized (kept alive, CSS‑hidden). |
 | `[AgentName]` | `string` | — | Display name. |

--- a/packages/Angular/Generic/conversations/src/lib/components/realtime/realtime-session-overlay.component.html
+++ b/packages/Angular/Generic/conversations/src/lib/components/realtime/realtime-session-overlay.component.html
@@ -138,6 +138,8 @@
           [ShowActivityTab]="ShowActivityTab"
           [ExtraArtifacts]="ReviewArtifacts"
           [Fill]="ChannelFocusMode"
+          [Layout]="SurfaceLayout"
+          [SplitKeys]="SurfaceSplitKeys"
           (OpenRunRequested)="OnOpenRunRequested($event)"
           (CollapsedChange)="OnPanelCollapsedChange($event)"
           (WideChanged)="OnPanelWideChanged($event)">

--- a/packages/Angular/Generic/conversations/src/lib/components/realtime/realtime-session-overlay.component.ts
+++ b/packages/Angular/Generic/conversations/src/lib/components/realtime/realtime-session-overlay.component.ts
@@ -27,7 +27,9 @@ import {
   RealtimeChromeMode, RealtimeControlId, RealtimeUiConnectionState
 } from './realtime-ui-config';
 import { RealtimeAudioVisualFrame, RealtimeAudioVisualSmoother, RealtimeDirection } from './realtime-audio-visuals';
-import { RealtimeChannelTabRegistration, ShouldRemoveReviewWhiteboardTab } from './realtime-surface-tabs.model';
+import {
+  RealtimeChannelTabRegistration, RealtimeSurfaceLayoutMode, ShouldRemoveReviewWhiteboardTab
+} from './realtime-surface-tabs.model';
 import { ShouldRegisterChannelTabUpFront } from './realtime-surface-tab-style';
 import { BaseRealtimeChannelClient } from './channels/base-realtime-channel-client';
 import { RealtimeWhiteboardBoardComponent, WhiteboardState } from '@memberjunction/ng-whiteboard';
@@ -151,6 +153,22 @@ export class RealtimeSessionOverlayComponent extends BaseAngularComponent implem
 
   /** The active environment id, threaded to the surface panel's artifact viewer. */
   @Input() EnvironmentID = '';
+
+  /**
+   * How the surface panel arranges its surfaces — `'tabs'` (default, one at a time) or
+   * `'split'` (the surfaces {@link SurfaceSplitKeys} names, side by side). Passed straight
+   * through to {@link RealtimeSurfaceTabsComponent.Layout}; see it for the degrade rules.
+   *
+   * A deployment that wants two surfaces on screen at once declares it here rather than
+   * overriding the panel's stylesheet from outside, which silently loses a specificity tie.
+   */
+  @Input() SurfaceLayout: RealtimeSurfaceLayoutMode = 'tabs';
+
+  /**
+   * Which surfaces a `'split'` {@link SurfaceLayout} shows, by channel key (empty = all of
+   * them). Passed straight through to {@link RealtimeSurfaceTabsComponent.SplitKeys}.
+   */
+  @Input() SurfaceSplitKeys: string[] = [];
 
   // ── Declarative UI configuration (host controls every aspect of the surface) ──
   //

--- a/packages/Angular/Generic/conversations/src/lib/components/realtime/realtime-surface-split-layout.dom.test.ts
+++ b/packages/Angular/Generic/conversations/src/lib/components/realtime/realtime-surface-split-layout.dom.test.ts
@@ -1,0 +1,312 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+
+/**
+ * Golden Layout stands in for the real thing here: it is a browser layout engine and jsdom has
+ * no layout, so the real one would report zeros for everything and prove nothing. The fake keeps
+ * GL's CONTRACT — construct, `loadLayout` binds one component per config entry, each bound
+ * container is handed its geometry through the virtual events, `destroy` releases it all — which
+ * is the half this driver is responsible for. The geometry itself (that GL really does report
+ * side-by-side rects for a headerless row, and really does re-rect on resize) is verified in a
+ * REAL browser by `scripts/verify-split-layout.mjs`; see that script's header.
+ */
+const { FakeVirtualLayout } = vi.hoisted(() => {
+  interface FakeContainer {
+    element: HTMLElement;
+    virtualRectingRequiredEvent?: (container: FakeContainer, width: number, height: number) => void;
+    virtualVisibilityChangeRequiredEvent?: (container: FakeContainer, visible: boolean) => void;
+    virtualZIndexChangeRequiredEvent?: (container: FakeContainer, logicalZIndex: number, defaultZIndex: string) => void;
+  }
+  interface FakeComponentConfig {
+    componentType: string;
+    componentState: unknown;
+    title: string;
+    isClosable: boolean;
+  }
+  interface FakeLayoutConfig {
+    root: { type: string; content: FakeComponentConfig[] };
+    header: { show: false | string };
+    settings: { reorderEnabled: boolean };
+  }
+
+  class FakeVirtualLayout {
+    /** Every instance created this test — the driver should only ever leave one alive. */
+    public static Instances: FakeVirtualLayout[] = [];
+    /** Per-pane geometry the fake reports. Set to 0 to reproduce the zero-size collapse. */
+    public static PaneWidth = 400;
+    public static PaneHeight = 300;
+
+    public Destroyed = false;
+    public LoadedConfig: FakeLayoutConfig | null = null;
+    public Size: { Width: number; Height: number } | null = null;
+    public Containers: FakeContainer[] = [];
+    public resizeWithContainerAutomatically = false;
+
+    constructor(
+      private readonly host: HTMLElement,
+      private readonly bind: (container: FakeContainer, itemConfig: { componentState: unknown }) => unknown,
+      private readonly unbind: (container: FakeContainer) => void
+    ) {
+      FakeVirtualLayout.Instances.push(this);
+    }
+
+    public loadLayout(config: FakeLayoutConfig): void {
+      this.LoadedConfig = config;
+      config.root.content.forEach((item, index) => {
+        const element = this.host.ownerDocument.createElement('div');
+        element.className = 'lm_content';
+        const left = index * FakeVirtualLayout.PaneWidth;
+        element.getBoundingClientRect = () => ({
+          left, top: 0, right: left + FakeVirtualLayout.PaneWidth, bottom: FakeVirtualLayout.PaneHeight,
+          width: FakeVirtualLayout.PaneWidth, height: FakeVirtualLayout.PaneHeight, x: left, y: 0,
+          toJSON: () => ({})
+        }) as DOMRect;
+        this.host.appendChild(element);
+        const container: FakeContainer = { element };
+        this.bind(container, { componentState: item.componentState });
+        this.Containers.push(container);
+        container.virtualRectingRequiredEvent?.(container, FakeVirtualLayout.PaneWidth, FakeVirtualLayout.PaneHeight);
+        container.virtualZIndexChangeRequiredEvent?.(container, 0, '10');
+      });
+    }
+
+    public setSize(Width: number, Height: number): void {
+      this.Size = { Width, Height };
+    }
+
+    public destroy(): void {
+      this.Destroyed = true;
+      for (const container of this.Containers) {
+        this.unbind(container);
+        container.element.remove();
+      }
+      this.Containers = [];
+    }
+  }
+
+  return { FakeVirtualLayout };
+});
+
+vi.mock('golden-layout', () => ({ VirtualLayout: FakeVirtualLayout }));
+
+import {
+  ComputeSplitPaneRect, EnsureSplitLayoutBaseStyles, RealtimeSplitPane, RealtimeSurfaceSplitLayout,
+  RestoreSplitPaneElement, SPLIT_LAYOUT_HOST_CLASS, SplitPaneKeyFromState
+} from './realtime-surface-split-layout';
+
+describe('ComputeSplitPaneRect', () => {
+  it('places a pane over its container, in the positioned root\'s coordinates', () => {
+    // Host sits 40px down the panel (below the tab strip) and 1px in (the panel's left border).
+    const rect = ComputeSplitPaneRect(
+      { Left: 1, Top: 40 },
+      { Left: 501, Top: 140 },   // host on screen
+      { Left: 901, Top: 140 },   // second container, 400px along
+      400,
+      300
+    );
+    expect(rect).toEqual({ Left: 401, Top: 40, Width: 400, Height: 300 });
+  });
+
+  it('is an identity offset for a container that starts exactly at the host', () => {
+    expect(ComputeSplitPaneRect({ Left: 0, Top: 0 }, { Left: 10, Top: 20 }, { Left: 10, Top: 20 }, 100, 50))
+      .toEqual({ Left: 0, Top: 0, Width: 100, Height: 50 });
+  });
+});
+
+describe('SplitPaneKeyFromState', () => {
+  it('reads the key from a component state', () => {
+    expect(SplitPaneKeyFromState({ Key: 'Whiteboard' })).toBe('Whiteboard');
+  });
+
+  it('returns null for anything that is not a keyed object', () => {
+    expect(SplitPaneKeyFromState(null)).toBeNull();
+    expect(SplitPaneKeyFromState('Whiteboard')).toBeNull();
+    expect(SplitPaneKeyFromState(['Whiteboard'])).toBeNull();
+    expect(SplitPaneKeyFromState({ Key: 7 })).toBeNull();
+    expect(SplitPaneKeyFromState({})).toBeNull();
+  });
+});
+
+describe('EnsureSplitLayoutBaseStyles', () => {
+  afterEach(() => {
+    document.getElementById('mj-realtime-split-gl-base')?.remove();
+  });
+
+  it('injects the structural rules once, however many layouts attach', () => {
+    EnsureSplitLayoutBaseStyles(document);
+    EnsureSplitLayoutBaseStyles(document);
+    const styles = document.querySelectorAll('#mj-realtime-split-gl-base');
+    expect(styles).toHaveLength(1);
+    // The rule that decides whether two surfaces sit side by side or silently stack.
+    expect(styles[0].textContent).toContain(`.${SPLIT_LAYOUT_HOST_CLASS} .lm_row > .lm_item { float: left; }`);
+  });
+});
+
+describe('RealtimeSurfaceSplitLayout', () => {
+  let host: HTMLElement;
+  let panes: RealtimeSplitPane[];
+
+  const makePane = (key: string): RealtimeSplitPane => {
+    const element = document.createElement('div');
+    element.className = 's-pane';
+    element.dataset['channel'] = key;
+    document.body.appendChild(element);
+    return { Key: key, Title: key, Element: element };
+  };
+
+  beforeEach(() => {
+    FakeVirtualLayout.Instances = [];
+    FakeVirtualLayout.PaneWidth = 400;
+    FakeVirtualLayout.PaneHeight = 300;
+    host = document.createElement('div');
+    document.body.appendChild(host);
+    panes = [makePane('Site A'), makePane('Site B')];
+  });
+
+  afterEach(() => {
+    document.body.innerHTML = '';
+    document.getElementById('mj-realtime-split-gl-base')?.remove();
+  });
+
+  it('arranges the panes as a headerless Golden Layout row', () => {
+    const layout = new RealtimeSurfaceSplitLayout();
+
+    expect(layout.Attach(host, panes)).toBe(true);
+
+    expect(FakeVirtualLayout.Instances).toHaveLength(1);
+    const gl = FakeVirtualLayout.Instances[0];
+    expect(gl.LoadedConfig?.root.type).toBe('row');
+    expect(gl.LoadedConfig?.root.content.map(c => c.componentState)).toEqual([{ Key: 'Site A' }, { Key: 'Site B' }]);
+    // Headers off: the panel's own tab strip is the panel's identity, GL only splits.
+    expect(gl.LoadedConfig?.header.show).toBe(false);
+    // Nothing in a live session's split may be closed or re-ordered out from under it.
+    expect(gl.LoadedConfig?.root.content.every(c => c.isClosable === false)).toBe(true);
+    expect(gl.LoadedConfig?.settings.reorderEnabled).toBe(false);
+    expect(gl.resizeWithContainerAutomatically).toBe(true);
+    expect(layout.IsAttached).toBe(true);
+    expect(layout.PaneKeys).toEqual(['Site A', 'Site B']);
+  });
+
+  it('reports NO arranged panes until an attach has actually succeeded', () => {
+    FakeVirtualLayout.PaneWidth = 0;
+    FakeVirtualLayout.PaneHeight = 0;
+    const layout = new RealtimeSurfaceSplitLayout();
+    expect(layout.PaneKeys).toEqual([]);
+
+    layout.Attach(host, panes);
+
+    // A request that could not be honoured must never read as "already arranged".
+    expect(layout.PaneKeys).toEqual([]);
+  });
+
+  it('positions the SAME pane elements it was given — never a copy, never re-parented', () => {
+    const layout = new RealtimeSurfaceSplitLayout();
+    const parents = panes.map(p => p.Element.parentElement);
+
+    layout.Attach(host, panes);
+
+    expect(panes.map(p => p.Element.parentElement)).toEqual(parents);
+    expect(panes[0].Element.style.left).toBe('0px');
+    expect(panes[0].Element.style.width).toBe('400px');
+    expect(panes[1].Element.style.left).toBe('400px');
+    expect(panes.every(p => p.Element.style.position === 'absolute')).toBe(true);
+    expect(panes.every(p => p.Element.style.display === 'flex')).toBe(true);
+  });
+
+  it('follows Golden Layout\'s visibility events for a pane it is arranging', () => {
+    const layout = new RealtimeSurfaceSplitLayout();
+    layout.Attach(host, panes);
+    const container = FakeVirtualLayout.Instances[0].Containers[1];
+
+    container.virtualVisibilityChangeRequiredEvent?.(container, false);
+    expect(panes[1].Element.style.display).toBe('none');
+
+    container.virtualVisibilityChangeRequiredEvent?.(container, true);
+    expect(panes[1].Element.style.display).toBe('flex');
+  });
+
+  it('scopes the structural stylesheet to the host it marks', () => {
+    const layout = new RealtimeSurfaceSplitLayout();
+    layout.Attach(host, panes);
+
+    expect(host.classList.contains(SPLIT_LAYOUT_HOST_CLASS)).toBe(true);
+    expect(document.getElementById('mj-realtime-split-gl-base')).not.toBeNull();
+
+    layout.Destroy();
+    expect(host.classList.contains(SPLIT_LAYOUT_HOST_CLASS)).toBe(false);
+  });
+
+  it('hands every pane back untouched on Destroy', () => {
+    const layout = new RealtimeSurfaceSplitLayout();
+    layout.Attach(host, panes);
+
+    layout.Destroy();
+
+    expect(FakeVirtualLayout.Instances[0].Destroyed).toBe(true);
+    expect(layout.IsAttached).toBe(false);
+    // Not one leftover inline property — the tabs layout owns these panes again.
+    expect(panes.map(p => p.Element.getAttribute('style') ?? '')).toEqual(['', '']);
+    expect(panes.map(p => p.Element.className)).toEqual(['s-pane', 's-pane']);
+  });
+
+  it('is idempotent: Destroy without an Attach, and Attach over a live layout', () => {
+    const layout = new RealtimeSurfaceSplitLayout();
+    expect(() => layout.Destroy()).not.toThrow();
+
+    layout.Attach(host, panes);
+    layout.Attach(host, panes);
+
+    expect(FakeVirtualLayout.Instances).toHaveLength(2);
+    expect(FakeVirtualLayout.Instances[0].Destroyed).toBe(true);
+    expect(FakeVirtualLayout.Instances[1].Destroyed).toBe(false);
+  });
+
+  it('refuses a single pane — one surface side by side with nothing is the tabs layout', () => {
+    const layout = new RealtimeSurfaceSplitLayout();
+    expect(layout.Attach(host, [panes[0]])).toBe(false);
+    expect(FakeVirtualLayout.Instances).toHaveLength(0);
+  });
+
+  it('FAILS LOUDLY when the layout produces no area, instead of leaving a blank panel', () => {
+    // The zero-height container trap: GL lays its whole tree into nothing and reports no error.
+    FakeVirtualLayout.PaneWidth = 0;
+    FakeVirtualLayout.PaneHeight = 0;
+    const layout = new RealtimeSurfaceSplitLayout();
+
+    expect(layout.Attach(host, panes)).toBe(false);
+
+    expect(layout.IsAttached).toBe(false);
+    expect(FakeVirtualLayout.Instances[0].Destroyed).toBe(true);
+    expect(panes.map(p => p.Element.getAttribute('style') ?? '')).toEqual(['', '']);
+  });
+
+  it('reports a Golden Layout that throws on init rather than half-attaching', () => {
+    const boom = vi.spyOn(FakeVirtualLayout.prototype, 'loadLayout').mockImplementation(() => {
+      throw new Error('layout config rejected');
+    });
+    const layout = new RealtimeSurfaceSplitLayout();
+
+    expect(layout.Attach(host, panes)).toBe(false);
+    expect(layout.IsAttached).toBe(false);
+    expect(FakeVirtualLayout.Instances[0].Destroyed).toBe(true);
+
+    boom.mockRestore();
+  });
+});
+
+describe('RestoreSplitPaneElement', () => {
+  it('removes exactly the properties the split writes, leaving the rest alone', () => {
+    const element = document.createElement('div');
+    element.style.setProperty('position', 'absolute');
+    element.style.setProperty('left', '10px');
+    element.style.setProperty('top', '20px');
+    element.style.setProperty('width', '30px');
+    element.style.setProperty('height', '40px');
+    element.style.setProperty('display', 'flex');
+    element.style.setProperty('z-index', '5');
+    element.style.setProperty('opacity', '0.5');
+
+    RestoreSplitPaneElement(element);
+
+    expect(element.getAttribute('style')).toBe('opacity: 0.5;');
+  });
+});

--- a/packages/Angular/Generic/conversations/src/lib/components/realtime/realtime-surface-split-layout.ts
+++ b/packages/Angular/Generic/conversations/src/lib/components/realtime/realtime-surface-split-layout.ts
@@ -1,0 +1,353 @@
+import {
+  ComponentContainer, LayoutConfig, LogicalZIndex, ResolvedComponentItemConfig, RowOrColumnItemConfig,
+  VirtualLayout
+} from 'golden-layout';
+import { LogError } from '@memberjunction/core';
+
+/** The Golden Layout `componentType` every surface pane is registered under. */
+const SPLIT_COMPONENT_TYPE = 'mj-realtime-surface-pane';
+
+/**
+ * The smallest pane size {@link RealtimeSurfaceSplitLayout.Attach} accepts as "laid out". Golden
+ * Layout delivers virtual rects synchronously from `loadLayout` / `setSize`, so one post-attach
+ * measurement settles it — the constant exists so the postcondition reads as a named rule rather
+ * than a bare `> 0` buried in a filter.
+ */
+const MIN_LAID_OUT_PANE_PX = 1;
+
+/**
+ * The inline style properties this layout writes onto a pane element. Recorded as ONE list so
+ * teardown restores a pane exactly (every property written is a property removed) — the panes are
+ * shared with the tabs layout, and a leftover `position: absolute` would break it silently.
+ */
+const MANAGED_PANE_STYLE_PROPERTIES = ['position', 'left', 'top', 'width', 'height', 'display', 'z-index'] as const;
+
+/** DOM id of the one-time structural stylesheet {@link EnsureSplitLayoutBaseStyles} injects. */
+const SPLIT_BASE_STYLE_ELEMENT_ID = 'mj-realtime-split-gl-base';
+
+/** Class placed on the Golden Layout host element — the scope for the structural stylesheet. */
+export const SPLIT_LAYOUT_HOST_CLASS = 'mj-realtime-split-host';
+
+/**
+ * One surface pane the split layout arranges: the channel key it belongs to, its tab title
+ * (Golden Layout wants a title per component even with headers hidden), and the LIVE pane
+ * element — which stays exactly where it is in the panel's own template. Golden Layout never
+ * takes ownership of it; see {@link RealtimeSurfaceSplitLayout}.
+ */
+export interface RealtimeSplitPane {
+  /** The pane's channel key (`RealtimeSurfaceTab.Key`). */
+  Key: string;
+  /** The pane's tab title, handed to Golden Layout as the component title. */
+  Title: string;
+  /** The pane element the layout positions. NEVER re-parented. */
+  Element: HTMLElement;
+}
+
+/** A pane's computed position, relative to the panel's positioned root (px). */
+export interface SplitPaneRect {
+  Left: number;
+  Top: number;
+  Width: number;
+  Height: number;
+}
+
+/**
+ * Where a pane must sit so it covers the Golden Layout container that represents it.
+ *
+ * The pane is absolutely positioned against the surface panel (the nearest positioned
+ * ancestor), NOT against the layout host — so the host's own offset within the panel has to be
+ * added back. `offsetLeft`/`offsetTop` are measured to exactly the same box that `left`/`top`
+ * resolve against (the offset parent's padding box), which is why they're used instead of
+ * subtracting border widths by hand: the panel carries a 1px left border in one presentation
+ * and none in the other, and that difference is precisely what offsetLeft already accounts for.
+ *
+ * Pure so the geometry is unit-testable without a layout engine.
+ *
+ * @param hostOffset  The layout host's `offsetLeft`/`offsetTop` within the positioned root.
+ * @param hostViewport The layout host's viewport-relative origin (`getBoundingClientRect`).
+ * @param containerViewport The Golden Layout container's viewport-relative origin.
+ * @param width Container width, as reported by Golden Layout.
+ * @param height Container height, as reported by Golden Layout.
+ */
+export function ComputeSplitPaneRect(
+  hostOffset: { Left: number; Top: number },
+  hostViewport: { Left: number; Top: number },
+  containerViewport: { Left: number; Top: number },
+  width: number,
+  height: number
+): SplitPaneRect {
+  return {
+    Left: hostOffset.Left + (containerViewport.Left - hostViewport.Left),
+    Top: hostOffset.Top + (containerViewport.Top - hostViewport.Top),
+    Width: width,
+    Height: height
+  };
+}
+
+/**
+ * Injects (once per document) the STRUCTURAL Golden Layout rules the split arrangement needs,
+ * scoped to {@link SPLIT_LAYOUT_HOST_CLASS}.
+ *
+ * Golden Layout ships its structure in `golden-layout/dist/css/goldenlayout-base.css`, which
+ * Explorer-based apps import globally — but this panel renders inside a conversation widget that
+ * any host may embed, and a MISSING stylesheet fails the worst possible way: GL's inline
+ * width/height still land on its items, the items just stop floating, so both surfaces silently
+ * stack instead of sitting side by side. Rather than document a global-CSS prerequisite and hope,
+ * the few rules that decide geometry are carried here. They are byte-equivalent to GL's own, so an
+ * app that DOES ship the base stylesheet sees no difference; everything cosmetic (themes, headers,
+ * drag proxies) still comes from the app.
+ */
+export function EnsureSplitLayoutBaseStyles(doc: Document): void {
+  if (doc.getElementById(SPLIT_BASE_STYLE_ELEMENT_ID)) {
+    return;
+  }
+  const style = doc.createElement('style');
+  style.id = SPLIT_BASE_STYLE_ELEMENT_ID;
+  style.textContent = `
+.${SPLIT_LAYOUT_HOST_CLASS} .lm_root { position: relative; }
+.${SPLIT_LAYOUT_HOST_CLASS} .lm_row > .lm_item { float: left; }
+.${SPLIT_LAYOUT_HOST_CLASS} .lm_column > .lm_item { position: relative; }
+.${SPLIT_LAYOUT_HOST_CLASS} .lm_content { overflow: hidden; position: relative; }
+.${SPLIT_LAYOUT_HOST_CLASS} .lm_splitter { position: relative; z-index: 2; touch-action: none; background: var(--mj-border-default); }
+.${SPLIT_LAYOUT_HOST_CLASS} .lm_splitter.lm_horizontal { float: left; height: 100%; }
+.${SPLIT_LAYOUT_HOST_CLASS} .lm_splitter.lm_horizontal .lm_drag_handle { height: 100%; position: absolute; cursor: ew-resize; touch-action: none; user-select: none; }
+.${SPLIT_LAYOUT_HOST_CLASS} .lm_splitter.lm_vertical .lm_drag_handle { width: 100%; position: absolute; cursor: ns-resize; touch-action: none; user-select: none; }
+`;
+  doc.head.appendChild(style);
+}
+
+/**
+ * Arranges a set of the surface panel's panes SIDE BY SIDE (with draggable splitters) using
+ * Golden Layout — the panel's `Layout="split"` mode.
+ *
+ * The one design constraint everything else follows from: **a pane is never re-parented and never
+ * re-created**. A channel surface holds live state (a whiteboard's drawing, a remote browser's
+ * page, a media element's stream) that moving its DOM would destroy, and the panel's whole
+ * contract is that panes stay alive while hidden. So the panes stay children of the panel's own
+ * template and Golden Layout runs in VIRTUAL component mode: GL owns only its splitters and the
+ * (invisible, headerless) container boxes, and reports where each box is; this class copies that
+ * geometry onto the corresponding pane as inline `position/left/top/width/height`. Switching
+ * back to tabs removes those inline properties and the panes fall straight back to the tab
+ * layout's CSS — no re-render, no state loss.
+ *
+ * Positioning via inline styles is also what makes the mode declarable at all: inline styles
+ * outrank every stylesheet, so neither the panel's own rules nor a host's can silently win the
+ * specificity tie that made this arrangement impossible to impose from outside (issue #3535).
+ *
+ * Callers own the lifecycle: {@link Attach} once the host element has a measured size,
+ * {@link Destroy} on teardown or when leaving split mode.
+ */
+export class RealtimeSurfaceSplitLayout {
+  private layout: VirtualLayout | null = null;
+  /** The layout host, kept for the per-pane offset math and resize handling. */
+  private host: HTMLElement | null = null;
+  /** Panes by key — the bind handler resolves the element GL asks about through this. */
+  private panes = new Map<string, RealtimeSplitPane>();
+
+  /** Whether a Golden Layout instance is currently arranging panes. */
+  public get IsAttached(): boolean {
+    return this.layout !== null;
+  }
+
+  /**
+   * The panes this layout is ACTUALLY arranging, left to right — empty when not attached. The
+   * owner compares its requested set against this (rather than against what it last asked for)
+   * to decide whether anything needs rebuilding: a request that hasn't been honoured yet must
+   * not read as already done.
+   */
+  public get PaneKeys(): ReadonlyArray<string> {
+    return this.layout === null ? [] : [...this.panes.keys()];
+  }
+
+  /**
+   * Builds a Golden Layout row over `panes` inside `host` and positions each pane over its
+   * container.
+   *
+   * The caller MUST have established that `host` has a non-zero measured size: Golden Layout
+   * lays its entire tree into whatever the container reports at init and reports no error when
+   * that is nothing, which is the failure this whole mode exists to stop repeating. That
+   * postcondition is re-checked here — a pane that ends up with no area fails the attach loudly
+   * instead of leaving a blank panel.
+   *
+   * @param host The (measured) element Golden Layout renders its splitters into.
+   * @param panes The panes to arrange, left to right. Two or more; a single pane is the tabs
+   *              layout's job.
+   * @returns `true` when every pane was laid out with real area. On `false` the layout has
+   *          already been torn down and the caller should fall back to the tabs presentation.
+   */
+  public Attach(host: HTMLElement, panes: RealtimeSplitPane[]): boolean {
+    if (panes.length < 2) {
+      LogError(`RealtimeSurfaceSplitLayout.Attach requires at least 2 panes, got ${panes.length}`);
+      return false;
+    }
+    this.Destroy();
+    EnsureSplitLayoutBaseStyles(host.ownerDocument);
+    host.classList.add(SPLIT_LAYOUT_HOST_CLASS);
+    this.host = host;
+    this.panes = new Map(panes.map(p => [p.Key, p]));
+
+    try {
+      this.layout = new VirtualLayout(
+        host,
+        (container, itemConfig) => this.bindPane(container, itemConfig),
+        () => { /* per-pane cleanup is done in Destroy, which owns every managed element */ }
+      );
+      // GL watches the container itself, so a panel resize (the shell's drag handle, a window
+      // resize, the panel collapsing) re-rects the panes without any wiring of our own.
+      this.layout.resizeWithContainerAutomatically = true;
+      this.layout.loadLayout(this.buildLayoutConfig(panes));
+      const rect = host.getBoundingClientRect();
+      this.layout.setSize(rect.width, rect.height);
+    } catch (err) {
+      LogError(`RealtimeSurfaceSplitLayout failed to initialise Golden Layout for panes [${panes.map(p => p.Key).join(', ')}]: ${err instanceof Error ? err.message : String(err)}`);
+      this.Destroy();
+      return false;
+    }
+
+    const unplaced = panes.filter(p => !this.isLaidOut(p.Element)).map(p => p.Key);
+    if (unplaced.length > 0) {
+      LogError(`RealtimeSurfaceSplitLayout laid out no area for pane(s) [${unplaced.join(', ')}] — the layout host measured ${host.getBoundingClientRect().width}×${host.getBoundingClientRect().height}. Falling back to the tabs layout.`);
+      this.Destroy();
+      return false;
+    }
+    return true;
+  }
+
+  /**
+   * Re-measures the layout against its host. Golden Layout resizes with the container on its own
+   * (see {@link Attach}); this is for the cases it cannot observe — a host that moved without
+   * changing size, e.g. the panel's siblings collapsing.
+   */
+  public UpdateSize(): void {
+    if (!this.layout || !this.host) {
+      return;
+    }
+    const rect = this.host.getBoundingClientRect();
+    if (rect.width > 0 && rect.height > 0) {
+      this.layout.setSize(rect.width, rect.height);
+    }
+  }
+
+  /**
+   * Tears the layout down and hands every pane back to the tabs layout exactly as it was found:
+   * Golden Layout's own DOM goes with it, and each managed pane loses every inline property this
+   * class wrote. Safe to call when not attached.
+   */
+  public Destroy(): void {
+    try {
+      this.layout?.destroy();
+    } catch (err) {
+      // A GL teardown throw must not strand panes mid-arrangement — report it and finish the job.
+      LogError(`RealtimeSurfaceSplitLayout failed to destroy Golden Layout: ${err instanceof Error ? err.message : String(err)}`);
+    } finally {
+      this.layout = null;
+      for (const pane of this.panes.values()) {
+        RestoreSplitPaneElement(pane.Element);
+      }
+      this.panes.clear();
+      this.host?.classList.remove(SPLIT_LAYOUT_HOST_CLASS);
+      this.host = null;
+    }
+  }
+
+  /** A headerless row of one component per pane — GL contributes splitters, nothing else. */
+  private buildLayoutConfig(panes: RealtimeSplitPane[]): LayoutConfig {
+    const root: RowOrColumnItemConfig = {
+      type: 'row',
+      content: panes.map(pane => ({
+        type: 'component' as const,
+        componentType: SPLIT_COMPONENT_TYPE,
+        componentState: { Key: pane.Key },
+        title: pane.Title,
+        isClosable: false
+      }))
+    };
+    return {
+      // The panel's own tab strip is the panel's identity; GL is here for the arrangement, so its
+      // headers stay off ("the layout will be displayed with splitters only") and nothing in the
+      // split can be closed or torn off out from under the session.
+      header: { show: false, popout: false, maximise: false, close: false },
+      settings: { reorderEnabled: false, popoutWholeStack: false },
+      root
+    };
+  }
+
+  /**
+   * Golden Layout asks for the component behind one of its containers. We hand back the pane
+   * element that is ALREADY on screen (virtual: true — GL positions it, never adopts it) and
+   * subscribe the element to the container's geometry.
+   */
+  private bindPane(container: ComponentContainer, itemConfig: ResolvedComponentItemConfig): ComponentContainer.BindableComponent {
+    const key = SplitPaneKeyFromState(itemConfig.componentState);
+    const pane = key === null ? undefined : this.panes.get(key);
+    if (!pane) {
+      // Only reachable if the config this class just built disagrees with its own pane map.
+      LogError(`RealtimeSurfaceSplitLayout was asked to bind unknown pane '${key ?? '(no key)'}' — the pane will be blank.`);
+      return { component: container.element.ownerDocument.createElement('div'), virtual: true };
+    }
+    const element = pane.Element;
+    // Show the pane up front: the tabs layout hides every inactive pane, and GL's visibility
+    // event is not guaranteed to arrive before the first paint — a pane that waited for it
+    // would flash empty (or stay empty) with nothing reporting why.
+    element.style.setProperty('position', 'absolute');
+    element.style.setProperty('display', 'flex');
+    container.virtualRectingRequiredEvent = (_c, width, height) => this.applyRect(element, container, width, height);
+    container.virtualVisibilityChangeRequiredEvent = (_c, visible) => {
+      element.style.setProperty('display', visible ? 'flex' : 'none');
+    };
+    container.virtualZIndexChangeRequiredEvent = (_c, _logicalZIndex: LogicalZIndex, defaultZIndex: string) => {
+      element.style.setProperty('z-index', defaultZIndex);
+    };
+    return { component: element, virtual: true };
+  }
+
+  /** Copies one container's geometry onto its pane. */
+  private applyRect(element: HTMLElement, container: ComponentContainer, width: number, height: number): void {
+    const host = this.host;
+    if (!host) {
+      return;
+    }
+    const hostViewport = host.getBoundingClientRect();
+    const containerViewport = container.element.getBoundingClientRect();
+    const rect = ComputeSplitPaneRect(
+      { Left: host.offsetLeft, Top: host.offsetTop },
+      { Left: hostViewport.left, Top: hostViewport.top },
+      { Left: containerViewport.left, Top: containerViewport.top },
+      width,
+      height
+    );
+    element.style.setProperty('position', 'absolute');
+    element.style.setProperty('left', `${rect.Left}px`);
+    element.style.setProperty('top', `${rect.Top}px`);
+    element.style.setProperty('width', `${rect.Width}px`);
+    element.style.setProperty('height', `${rect.Height}px`);
+  }
+
+  /** Whether a pane actually received area — the postcondition {@link Attach} enforces. */
+  private isLaidOut(element: HTMLElement): boolean {
+    return parseFloat(element.style.width || '0') >= MIN_LAID_OUT_PANE_PX
+      && parseFloat(element.style.height || '0') >= MIN_LAID_OUT_PANE_PX;
+  }
+}
+
+/**
+ * Reads the pane key out of a Golden Layout component state. Exported for the panel's specs; GL
+ * types component state as free-form JSON, so the shape is checked rather than asserted.
+ */
+export function SplitPaneKeyFromState(state: unknown): string | null {
+  if (state === null || typeof state !== 'object' || Array.isArray(state)) {
+    return null;
+  }
+  return 'Key' in state && typeof state.Key === 'string' ? state.Key : null;
+}
+
+/**
+ * Removes every inline property the split layout may have written to a pane, returning it to
+ * whatever the panel's stylesheet says. Exported so the panel can clean up a pane that left the
+ * split (a channel tab removed mid-session) without tearing the whole layout down.
+ */
+export function RestoreSplitPaneElement(element: HTMLElement): void {
+  for (const property of MANAGED_PANE_STYLE_PROPERTIES) {
+    element.style.removeProperty(property);
+  }
+}

--- a/packages/Angular/Generic/conversations/src/lib/components/realtime/realtime-surface-tabs.component.css
+++ b/packages/Angular/Generic/conversations/src/lib/components/realtime/realtime-surface-tabs.component.css
@@ -217,6 +217,36 @@
   display: flex;
 }
 
+/* ---------- split layout (Layout="split") ---------- */
+/* Golden Layout's container. It carries GL's splitters and its (headerless, empty) container
+   boxes only — the panes are VIRTUAL components that stay in this template and get positioned
+   over this host, so a layout switch never re-creates a surface.
+
+   `flex: 1; min-height: 0` is load-bearing, not cosmetic: GL lays its entire tree into whatever
+   the container measures at init and reports nothing when that is zero. The panel defers the
+   attach until this element measures (see the component's waitForMeasuredSplitHost). */
+.surface__split {
+  flex: 1;
+  min-height: 0;
+  position: relative;
+}
+/* While a split is arranging the panes, their visibility comes from the inline styles it writes.
+   Every other pane stays hidden — including the model's "active" one, which would otherwise take
+   flex space beside the host and squash the arrangement. */
+.surface--split .s-pane {
+  display: none;
+}
+/* A surface the split isn't showing: still listed (the session HAS it), just not reachable
+   without the host changing the layout. */
+.s-tab--outside-split {
+  opacity: 0.45;
+  cursor: default;
+}
+.s-tab--outside-split:hover {
+  background: transparent;
+  color: var(--mj-text-muted);
+}
+
 /* Empty strip (idle voice-first session): a gentle hint rather than a bare grid. */
 .surface__empty {
   flex: 1;

--- a/packages/Angular/Generic/conversations/src/lib/components/realtime/realtime-surface-tabs.component.dom.test.ts
+++ b/packages/Angular/Generic/conversations/src/lib/components/realtime/realtime-surface-tabs.component.dom.test.ts
@@ -1,0 +1,365 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import type { ComponentFixture } from '@angular/core/testing';
+
+/**
+ * Golden Layout is faked for the same reason as in the driver's own spec: jsdom has no layout
+ * engine, so the real one would report zeros and prove nothing. This spec is about the PANEL's
+ * half of the contract — that `tabs` is untouched, that a `split` puts several surfaces on screen
+ * at once through the same pane elements, and that switching between them never re-creates a
+ * surface or leaks a layout.
+ */
+const { FakeVirtualLayout } = vi.hoisted(() => {
+  interface FakeContainer {
+    element: HTMLElement;
+    virtualRectingRequiredEvent?: (container: FakeContainer, width: number, height: number) => void;
+    virtualVisibilityChangeRequiredEvent?: (container: FakeContainer, visible: boolean) => void;
+    virtualZIndexChangeRequiredEvent?: (container: FakeContainer, logicalZIndex: number, defaultZIndex: string) => void;
+  }
+  interface FakeLayoutConfig {
+    root: { type: string; content: Array<{ componentState: unknown; title: string }> };
+  }
+
+  class FakeVirtualLayout {
+    public static Instances: FakeVirtualLayout[] = [];
+    public static PaneWidth = 400;
+    public static PaneHeight = 300;
+
+    public Destroyed = false;
+    public LoadedConfig: FakeLayoutConfig | null = null;
+    public Containers: FakeContainer[] = [];
+    public resizeWithContainerAutomatically = false;
+
+    constructor(
+      public readonly Host: HTMLElement,
+      private readonly bind: (container: FakeContainer, itemConfig: { componentState: unknown }) => unknown,
+      private readonly unbind: (container: FakeContainer) => void
+    ) {
+      FakeVirtualLayout.Instances.push(this);
+    }
+
+    public loadLayout(config: FakeLayoutConfig): void {
+      this.LoadedConfig = config;
+      config.root.content.forEach((item, index) => {
+        const element = this.Host.ownerDocument.createElement('div');
+        const left = index * FakeVirtualLayout.PaneWidth;
+        element.getBoundingClientRect = () => ({
+          left, top: 0, right: left + FakeVirtualLayout.PaneWidth, bottom: FakeVirtualLayout.PaneHeight,
+          width: FakeVirtualLayout.PaneWidth, height: FakeVirtualLayout.PaneHeight, x: left, y: 0,
+          toJSON: () => ({})
+        }) as DOMRect;
+        this.Host.appendChild(element);
+        const container: FakeContainer = { element };
+        this.bind(container, { componentState: item.componentState });
+        this.Containers.push(container);
+        container.virtualRectingRequiredEvent?.(container, FakeVirtualLayout.PaneWidth, FakeVirtualLayout.PaneHeight);
+      });
+    }
+
+    public setSize(): void { /* the fake's geometry is fixed */ }
+
+    public destroy(): void {
+      this.Destroyed = true;
+      for (const container of this.Containers) {
+        this.unbind(container);
+        container.element.remove();
+      }
+      this.Containers = [];
+    }
+  }
+
+  return { FakeVirtualLayout };
+});
+
+vi.mock('golden-layout', () => ({ VirtualLayout: FakeVirtualLayout }));
+
+import { renderComponentFixture, queryAll, query } from '@memberjunction/ng-test-utils';
+import { RealtimeSurfaceTabsComponent } from './realtime-surface-tabs.component';
+import { RealtimeSessionState } from './realtime-session-state';
+
+describe('RealtimeSurfaceTabsComponent layout modes (DOM)', () => {
+  /** Give jsdom (which lays nothing out) a measured box, so the split can be established. */
+  let restoreLayoutBoxes: (() => void) | null = null;
+
+  const stubLayoutBoxes = (): void => {
+    const original = HTMLElement.prototype.getBoundingClientRect;
+    HTMLElement.prototype.getBoundingClientRect = function (this: HTMLElement): DOMRect {
+      return {
+        left: 0, top: 0, right: 800, bottom: 600, width: 800, height: 600, x: 0, y: 0,
+        toJSON: () => ({})
+      } as DOMRect;
+    };
+    restoreLayoutBoxes = () => { HTMLElement.prototype.getBoundingClientRect = original; };
+  };
+
+  beforeEach(() => {
+    FakeVirtualLayout.Instances = [];
+    FakeVirtualLayout.PaneWidth = 400;
+    FakeVirtualLayout.PaneHeight = 300;
+  });
+
+  afterEach(() => {
+    restoreLayoutBoxes?.();
+    restoreLayoutBoxes = null;
+    document.getElementById('mj-realtime-split-gl-base')?.remove();
+  });
+
+  /**
+   * The panel defers every layout decision by a microtask (and re-enters once the split host has
+   * rendered), so a spec has to let those passes run. Bounded, never a bare sleep.
+   */
+  const settle = async (fixture: ComponentFixture<RealtimeSurfaceTabsComponent>): Promise<void> => {
+    for (let i = 0; i < 6; i++) {
+      await fixture.whenStable();
+      fixture.detectChanges();
+    }
+  };
+
+  const render = (inputs: Record<string, unknown> = {}, channelKeys: string[] = ['Site A', 'Site B']) =>
+    renderComponentFixture(RealtimeSurfaceTabsComponent, {
+      inputs: { State: new RealtimeSessionState(), ...inputs },
+      setup: instance => {
+        for (const key of channelKeys) {
+          instance.Model.RegisterChannelTab({ Key: key, Title: key, Icon: 'fa-solid fa-chalkboard' });
+        }
+        instance.Model.Focus(channelKeys[0]);
+      }
+    });
+
+  const panes = (fixture: ComponentFixture<RealtimeSurfaceTabsComponent>): HTMLElement[] =>
+    queryAll(fixture, '.s-pane') as HTMLElement[];
+  const tabs = (fixture: ComponentFixture<RealtimeSurfaceTabsComponent>): HTMLButtonElement[] =>
+    queryAll(fixture, '.s-tab') as HTMLButtonElement[];
+
+  // ── the layout that must not have moved ───────────────────────────────────────────────────
+  describe('tabs (the default, and what every existing caller gets)', () => {
+    it('defaults to tabs and never touches Golden Layout', async () => {
+      const fixture = render();
+      await settle(fixture);
+
+      expect(fixture.componentInstance.Layout).toBe('tabs');
+      expect(FakeVirtualLayout.Instances).toHaveLength(0);
+      expect(query(fixture, '.surface__split')).toBeNull();
+      expect((query(fixture, '.surface') as HTMLElement).classList.contains('surface--split')).toBe(false);
+      expect(fixture.componentInstance.SplitEngaged).toBe(false);
+    });
+
+    it('shows exactly one pane — the focused one — and leaves every pane free of inline geometry', async () => {
+      const fixture = render();
+      await settle(fixture);
+
+      const active = panes(fixture).filter(p => p.classList.contains('s-pane--active'));
+      expect(active).toHaveLength(1);
+      expect(active[0].dataset['channel']).toBe('Site A');
+      // Nothing inline: the panel's stylesheet is the only thing deciding what shows.
+      expect(panes(fixture).map(p => p.getAttribute('style'))).toEqual([null, null]);
+    });
+
+    it('renders the pane exactly as before, plus the channel name the issue asked for', async () => {
+      const fixture = render();
+      await settle(fixture);
+
+      const pane = panes(fixture)[0];
+      expect(pane.className).toBe('s-pane s-pane--active');
+      // Nothing on the pane but what was always there and the channel name — no layout classes,
+      // no stray attributes leaking in from the split. (`_ngcontent-*` is Angular's own scoping.)
+      const attributes = Array.from(pane.attributes, a => a.name).filter(n => !n.startsWith('_ngcontent')).sort();
+      expect(attributes).toEqual(['class', 'data-channel', 'role']);
+      expect(pane.getAttribute('role')).toBe('tabpanel');
+    });
+
+    it('keeps the strip a single-select: one tab selected, none disabled', async () => {
+      const fixture = render();
+      await settle(fixture);
+
+      expect(tabs(fixture).map(t => t.getAttribute('aria-selected'))).toEqual(['true', 'false']);
+      expect(tabs(fixture).some(t => t.disabled)).toBe(false);
+      expect(tabs(fixture).some(t => t.classList.contains('s-tab--outside-split'))).toBe(false);
+    });
+
+    it('still switches surface on a tab click', async () => {
+      const fixture = render();
+      await settle(fixture);
+
+      tabs(fixture)[1].click();
+      await settle(fixture);
+
+      expect(fixture.componentInstance.Model.ActiveKey).toBe('Site B');
+      const active = panes(fixture).filter(p => p.classList.contains('s-pane--active'));
+      expect(active.map(p => p.dataset['channel'])).toEqual(['Site B']);
+    });
+  });
+
+  // ── the layout the issue asked for ────────────────────────────────────────────────────────
+  describe('split', () => {
+    it('shows two surfaces at once, through the panel\'s own API', async () => {
+      stubLayoutBoxes();
+      const fixture = render({ Layout: 'split', SplitKeys: ['Site A', 'Site B'] });
+      await settle(fixture);
+
+      expect(fixture.componentInstance.SplitEngaged).toBe(true);
+      expect(fixture.componentInstance.SplitMemberKeys).toEqual(['Site A', 'Site B']);
+      expect(FakeVirtualLayout.Instances).toHaveLength(1);
+      expect(FakeVirtualLayout.Instances[0].Host).toBe(query(fixture, '.surface__split'));
+
+      // BOTH panes on screen at the same time, side by side — the whole point.
+      const shown = panes(fixture).filter(p => p.style.display === 'flex');
+      expect(shown.map(p => p.dataset['channel'])).toEqual(['Site A', 'Site B']);
+      expect(shown.map(p => p.style.left)).toEqual(['0px', '400px']);
+      expect(shown.every(p => p.style.position === 'absolute')).toBe(true);
+      expect(shown.every(p => parseFloat(p.style.width) > 0 && parseFloat(p.style.height) > 0)).toBe(true);
+    });
+
+    it('reports every shown surface in the strip, and disables one the split is not showing', async () => {
+      stubLayoutBoxes();
+      const fixture = render({ Layout: 'split', SplitKeys: ['Site A', 'Site B'] }, ['Site A', 'Site B', 'Site C']);
+      await settle(fixture);
+
+      expect(tabs(fixture).map(t => t.getAttribute('aria-selected'))).toEqual(['true', 'true', 'false']);
+      expect(tabs(fixture).map(t => t.disabled)).toEqual([false, false, true]);
+      expect(query(fixture, '.s-tab--outside-split')?.getAttribute('title')).toBe('Site C');
+      // The surface outside the split is hidden — including when it is the model's active tab.
+      expect(panes(fixture)[2].style.display).toBe('');
+    });
+
+    it('splits every open surface when the host names none', async () => {
+      stubLayoutBoxes();
+      const fixture = render({ Layout: 'split' }, ['Site A', 'Site B', 'Site C']);
+      await settle(fixture);
+
+      expect(fixture.componentInstance.SplitMemberKeys).toEqual(['Site A', 'Site B', 'Site C']);
+      expect(panes(fixture).filter(p => p.style.display === 'flex')).toHaveLength(3);
+    });
+
+    it('grows into a surface that registers later', async () => {
+      stubLayoutBoxes();
+      const fixture = render({ Layout: 'split', SplitKeys: ['Site A', 'Site B', 'Site C'] }, ['Site A', 'Site B']);
+      await settle(fixture);
+      expect(fixture.componentInstance.SplitMemberKeys).toEqual(['Site A', 'Site B']);
+
+      fixture.componentInstance.Model.RegisterChannelTab({ Key: 'Site C', Title: 'Site C', Icon: 'fa-solid fa-globe' });
+      await settle(fixture);
+
+      expect(fixture.componentInstance.SplitMemberKeys).toEqual(['Site A', 'Site B', 'Site C']);
+      expect(panes(fixture).filter(p => p.style.display === 'flex')).toHaveLength(3);
+    });
+
+    it('does not rebuild the arrangement when the membership has not changed', async () => {
+      stubLayoutBoxes();
+      const fixture = render({ Layout: 'split', SplitKeys: ['Site A', 'Site B'] });
+      await settle(fixture);
+      const arrangement = FakeVirtualLayout.Instances[0];
+
+      // A surface outside the split joining, and a focus change, are both noise to it — a rebuild
+      // would throw away wherever the user dragged the splitters.
+      fixture.componentInstance.Model.RegisterChannelTab({ Key: 'Site C', Title: 'Site C', Icon: 'fa-solid fa-globe' });
+      fixture.componentInstance.Model.Focus('Site B');
+      await settle(fixture);
+
+      expect(FakeVirtualLayout.Instances).toHaveLength(1);
+      expect(arrangement.Destroyed).toBe(false);
+    });
+
+    it('stays on tabs when only one surface is open — a split of one is the tabs layout', async () => {
+      stubLayoutBoxes();
+      const fixture = render({ Layout: 'split', SplitKeys: ['Site A', 'Site B'] }, ['Site A']);
+      await settle(fixture);
+
+      expect(fixture.componentInstance.SplitEngaged).toBe(false);
+      expect(FakeVirtualLayout.Instances).toHaveLength(0);
+      expect(query(fixture, '.surface__split')).toBeNull();
+      expect(panes(fixture)[0].classList.contains('s-pane--active')).toBe(true);
+      expect(tabs(fixture)[0].disabled).toBe(false);
+    });
+
+    it('stays on tabs — loudly — when the host never gains a size', async () => {
+      // No layout-box stub: jsdom reports 0×0, exactly the trap this mode exists to stop.
+      vi.useFakeTimers();
+      try {
+        const fixture = render({ Layout: 'split', SplitKeys: ['Site A', 'Site B'] });
+        await settle(fixture);
+        expect(fixture.componentInstance.SplitEngaged).toBe(true); // waiting for a size
+
+        await vi.advanceTimersByTimeAsync(5000);
+        await settle(fixture);
+
+        expect(fixture.componentInstance.SplitEngaged).toBe(false);
+        expect(FakeVirtualLayout.Instances).toHaveLength(0);
+        expect(panes(fixture).filter(p => p.classList.contains('s-pane--active'))).toHaveLength(1);
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+  });
+
+  // ── the constraint everything else follows from ───────────────────────────────────────────
+  describe('switching layout', () => {
+    it('keeps the SAME pane elements alive across tabs → split → tabs', async () => {
+      stubLayoutBoxes();
+      const fixture = render();
+      await settle(fixture);
+      const before = panes(fixture);
+      const beforeContent = before.map(p => p.firstElementChild);
+      expect(before).toHaveLength(2);
+
+      fixture.componentRef.setInput('Layout', 'split');
+      await settle(fixture);
+      const during = panes(fixture);
+      expect(during[0]).toBe(before[0]);
+      expect(during[1]).toBe(before[1]);
+      expect(during.map(p => p.firstElementChild)).toEqual(beforeContent);
+
+      fixture.componentRef.setInput('Layout', 'tabs');
+      await settle(fixture);
+      const after = panes(fixture);
+      expect(after[0]).toBe(before[0]);
+      expect(after[1]).toBe(before[1]);
+      expect(after.map(p => p.firstElementChild)).toEqual(beforeContent);
+    });
+
+    it('hands the panes back to the tabs layout with no inline geometry left over', async () => {
+      stubLayoutBoxes();
+      const fixture = render({ Layout: 'split' });
+      await settle(fixture);
+      expect(panes(fixture).every(p => p.style.position === 'absolute')).toBe(true);
+
+      fixture.componentRef.setInput('Layout', 'tabs');
+      await settle(fixture);
+
+      expect(FakeVirtualLayout.Instances[0].Destroyed).toBe(true);
+      expect(panes(fixture).map(p => p.getAttribute('style') ?? '')).toEqual(['', '']);
+      expect(panes(fixture).filter(p => p.classList.contains('s-pane--active'))).toHaveLength(1);
+      expect(query(fixture, '.surface__split')).toBeNull();
+      expect(tabs(fixture).some(t => t.disabled)).toBe(false);
+    });
+
+    it('releases Golden Layout when the panel collapses, and re-splits when it re-opens', async () => {
+      stubLayoutBoxes();
+      const fixture = render({ Layout: 'split' });
+      await settle(fixture);
+
+      fixture.componentInstance.ToggleCollapsed();
+      await settle(fixture);
+      expect(FakeVirtualLayout.Instances[0].Destroyed).toBe(true);
+      expect(fixture.componentInstance.SplitEngaged).toBe(false);
+
+      fixture.componentInstance.ToggleCollapsed();
+      await settle(fixture);
+      expect(FakeVirtualLayout.Instances).toHaveLength(2);
+      expect(FakeVirtualLayout.Instances[1].Destroyed).toBe(false);
+      expect(fixture.componentInstance.SplitEngaged).toBe(true);
+    });
+  });
+
+  describe('teardown', () => {
+    it('destroys Golden Layout with the panel', async () => {
+      stubLayoutBoxes();
+      const fixture = render({ Layout: 'split' });
+      await settle(fixture);
+      expect(FakeVirtualLayout.Instances[0].Destroyed).toBe(false);
+
+      fixture.destroy();
+
+      expect(FakeVirtualLayout.Instances[0].Destroyed).toBe(true);
+    });
+  });
+});

--- a/packages/Angular/Generic/conversations/src/lib/components/realtime/realtime-surface-tabs.component.html
+++ b/packages/Angular/Generic/conversations/src/lib/components/realtime/realtime-surface-tabs.component.html
@@ -3,6 +3,7 @@
 <aside class="surface"
        [class.surface--collapsed]="Collapsed"
        [class.surface--fill]="Fill && !Collapsed"
+       [class.surface--split]="SplitEngaged"
        aria-label="Session surfaces">
 
   @if (Collapsed) {
@@ -25,15 +26,19 @@
           <!-- Flex spacer pushes the Activity tab to the far right -->
           <span class="tabs-spacer" aria-hidden="true"></span>
         }
+        <!-- A split shows several surfaces at once, so "active" means SHOWN (IsTabShown), and a
+             surface the split isn't showing is disabled rather than a click that does nothing. -->
         <button type="button"
                 class="s-tab"
                 role="tab"
                 [class.s-tab--activity]="tab.Kind === 'activity'"
                 [class.s-tab--channel]="tab.Kind === 'channel'"
-                [class.s-tab--active]="tab.Key === Model.ActiveKey"
+                [class.s-tab--active]="IsTabShown(tab.Key)"
                 [class.s-tab--flash]="tab.Key === Model.FlashKey"
+                [class.s-tab--outside-split]="IsTabOutsideSplit(tab.Key)"
+                [disabled]="IsTabOutsideSplit(tab.Key)"
                 [style.--tab-accent]="tab.Color || null"
-                [attr.aria-selected]="tab.Key === Model.ActiveKey"
+                [attr.aria-selected]="IsTabShown(tab.Key)"
                 [title]="tab.Title"
                 (click)="Model.Focus(tab.Key)">
           @if (tab.Kind === 'channel') {
@@ -57,9 +62,13 @@
       </div>
     </div>
 
-    <!-- Panes: ALL kept alive; only the active one is displayed -->
+    <!-- Panes: ALL kept alive; only the active one is displayed (in a SPLIT the arrangement
+         positions its members inline instead — same elements either way, so switching layout
+         never re-creates a surface). Each pane names its channel so a host — and the split —
+         can address one without counting positions. -->
     @for (tab of Model.Tabs; track TrackTab($index, tab)) {
-      <div class="s-pane" [class.s-pane--active]="tab.Key === Model.ActiveKey" role="tabpanel">
+      <div class="s-pane" #surfacePane [class.s-pane--active]="tab.Key === Model.ActiveKey"
+           [attr.data-channel]="tab.Key" role="tabpanel">
         @switch (tab.Kind) {
           @case ('activity') {
             <mj-realtime-activity-rail
@@ -98,6 +107,14 @@
           }
         }
       </div>
+    }
+
+    @if (SplitEngaged) {
+      <!-- The split arrangement's own container. It holds ONLY Golden Layout's splitters: the
+           panes above stay where they are and are positioned over this host, which is what keeps
+           them alive across a layout switch. Sized by flex so it has a measured height before
+           Golden Layout ever looks at it. -->
+      <div class="surface__split" #splitHost></div>
     }
 
     @if (Model.Tabs.length === 0) {

--- a/packages/Angular/Generic/conversations/src/lib/components/realtime/realtime-surface-tabs.component.ts
+++ b/packages/Angular/Generic/conversations/src/lib/components/realtime/realtime-surface-tabs.component.ts
@@ -1,9 +1,10 @@
 import {
-  Component, EventEmitter, Input, Output, OnInit, OnDestroy, ChangeDetectorRef, ViewChild, inject
+  AfterViewInit, Component, ElementRef, EventEmitter, Input, Output, OnInit, OnDestroy,
+  ChangeDetectorRef, QueryList, ViewChild, ViewChildren, inject
 } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { Subscription } from 'rxjs';
-import { UserInfo } from '@memberjunction/core';
+import { LogError, UserInfo } from '@memberjunction/core';
 import { UserInfoEngine } from '@memberjunction/core-entities';
 import { ArtifactsModule } from '@memberjunction/ng-artifacts';
 import { RealtimeSessionState } from './realtime-session-state';
@@ -12,8 +13,10 @@ import { RealtimeChannelPaneComponent } from './channels/realtime-channel-pane.c
 import { ChannelOnboardingPanelComponent } from './channels/channel-onboarding-panel.component';
 import { ChannelOnboardingDetails } from './channels/base-realtime-channel-client';
 import {
-  RealtimeSurfaceTabsModel, RealtimeSurfaceTab, RealtimeChannelTabRegistration
+  RealtimeSurfaceTabsModel, RealtimeSurfaceTab, RealtimeChannelTabRegistration,
+  RealtimeSurfaceLayoutMode, ResolveSplitPaneKeys
 } from './realtime-surface-tabs.model';
+import { RealtimeSplitPane, RealtimeSurfaceSplitLayout } from './realtime-surface-split-layout';
 import { ParsedDelegationArtifact } from '../../services/delegation-result-parser';
 
 /**
@@ -23,6 +26,21 @@ import { ParsedDelegationArtifact } from '../../services/delegation-result-parse
  * follows them across devices.
  */
 const CHANNEL_ONBOARDING_SEEN_SETTING_KEY = 'mj.realtimeChannels.onboardingSeen.v1';
+
+/**
+ * How long a `split` layout waits for its Golden Layout host to report a real size before giving
+ * up and staying on tabs. The host is a flex child of an already-laid-out panel, so it normally
+ * measures on the very first check; the wait covers the panel being rendered inside something
+ * that has not sized ITSELF yet (a collapsed shell, a hidden route). Capped because "wait for a
+ * size" with no limit is how a surface silently never appears.
+ */
+const SPLIT_HOST_MEASURE_TIMEOUT_MS = 4000;
+
+/** Whether an element has a real, laid-out box — the precondition for arranging anything in it. */
+function IsMeasured(element: HTMLElement): boolean {
+  const rect = element.getBoundingClientRect();
+  return rect.width > 0 && rect.height > 0;
+}
 
 /**
  * The call overlay's TABBED SURFACE PANEL (the right panel) — decluttered redesign:
@@ -44,6 +62,16 @@ const CHANNEL_ONBOARDING_SEEN_SETTING_KEY = 'mj.realtimeChannels.onboardingSeen.
  * Panes are kept ALIVE while hidden (CSS `display:none`) so switching tabs never reloads a
  * channel surface or resets the rail. The whole panel collapses to a slim strip via the chevron.
  *
+ * LAYOUT IS DECLARED, NOT IMPOSED: {@link Layout} picks between the tab strip (default, one
+ * surface at a time) and a `split` arrangement of the surfaces named by {@link SplitKeys}, shown
+ * side by side with draggable splitters. A host asking for two surfaces at once says so through
+ * this input rather than overriding the panel's stylesheet — an override that LOOKS applied and
+ * silently loses a specificity tie, because the panel's own `display: flex` on `.surface` carries
+ * the same specificity and wins on document order (issue #3535). Panes are shared between the two
+ * layouts and never re-created by a switch: split mode positions the same elements inline (see
+ * {@link RealtimeSurfaceSplitLayout}), so a whiteboard's drawing and a remote browser's page
+ * survive it.
+ *
  * SIZING IS EXTERNAL: the overlay shell hosts this panel in a fixed-width flex item and owns
  * the width. This panel just fills it and REPORTS the layout signals the shell sizes from:
  * {@link CollapsedChange} (slim-strip toggle) and {@link WideChanged} (a channel tab is focused
@@ -59,7 +87,7 @@ const CHANNEL_ONBOARDING_SEEN_SETTING_KEY = 'mj.realtimeChannels.onboardingSeen.
   templateUrl: './realtime-surface-tabs.component.html',
   styleUrl: './realtime-surface-tabs.component.css'
 })
-export class RealtimeSurfaceTabsComponent implements OnInit, OnDestroy {
+export class RealtimeSurfaceTabsComponent implements OnInit, AfterViewInit, OnDestroy {
   /** How long a just-revealed channel tab keeps its flash highlight. */
   private static readonly FlashDurationMs = 1400;
 
@@ -87,6 +115,49 @@ export class RealtimeSurfaceTabsComponent implements OnInit, OnDestroy {
    * activity card. Forwarded to the rail's "Session artifacts" group. Empty for a live session.
    */
   @Input() ExtraArtifacts: ParsedDelegationArtifact[] = [];
+
+  /**
+   * The panel's LAYOUT MODE — the host's declaration of how many surfaces are on screen:
+   *
+   *  - `tabs` (default) — unchanged behaviour: the tab strip picks one surface at a time.
+   *  - `split` — the surfaces {@link SplitKeys} names are arranged side by side, with draggable
+   *    splitters between them, and the strip reports them all as shown.
+   *
+   * `split` DEGRADES to the tabs presentation whenever it can't be honoured — fewer than two of
+   * the requested surfaces are open, the panel is collapsed, or the arrangement fails to lay out
+   * (which is reported via `LogError`, never silently). Existing callers pass nothing and get
+   * exactly today's panel.
+   */
+  private _layout: RealtimeSurfaceLayoutMode = 'tabs';
+  @Input()
+  set Layout(value: RealtimeSurfaceLayoutMode) {
+    if (value !== this._layout) {
+      this._layout = value;
+      this.scheduleSplitSync();
+    }
+  }
+  get Layout(): RealtimeSurfaceLayoutMode {
+    return this._layout;
+  }
+
+  /**
+   * Which surfaces a `split` {@link Layout} shows, by tab key (a channel's `ChannelName`, or
+   * `activity`). Keys that aren't open yet are simply not shown — a host may name surfaces the
+   * agent hasn't brought into play, and the split grows into them as they register. EMPTY (the
+   * default) means "every open surface". Ignored while {@link Layout} is `tabs`.
+   */
+  private _splitKeys: string[] = [];
+  @Input()
+  set SplitKeys(value: string[]) {
+    const next = value ?? [];
+    if (next.length !== this._splitKeys.length || next.some((key, i) => key !== this._splitKeys[i])) {
+      this._splitKeys = [...next];
+      this.scheduleSplitSync();
+    }
+  }
+  get SplitKeys(): string[] {
+    return this._splitKeys;
+  }
 
   /**
    * Whether the gated Activity tab should be shown — driven by the overlay shell once ≥1
@@ -128,13 +199,54 @@ export class RealtimeSurfaceTabsComponent implements OnInit, OnDestroy {
   /** Whether the panel is collapsed to its slim strip. */
   public Collapsed = false;
 
+  /**
+   * Whether the panel is currently arranged as a SPLIT: renders the Golden Layout host and puts
+   * pane visibility under the arrangement's control (`.surface--split`). Distinct from
+   * `Layout === 'split'`, which is only the host's request — this is whether it is honoured.
+   */
+  public SplitEngaged = false;
+
   /** The embedded Activity rail (owns the inline artifact previews + the split-pane viewer). */
   @ViewChild(RealtimeActivityRailComponent) private activityRail?: RealtimeActivityRailComponent;
+
+  /**
+   * The Golden Layout host, as a SETTER: the element only exists once {@link SplitEngaged}
+   * renders it, and the arrangement can't be measured before that. Angular calling this back is
+   * the signal that the host is now in the DOM and the deferred sync can finish.
+   */
+  @ViewChild('splitHost')
+  private set splitHostRef(ref: ElementRef<HTMLElement> | undefined) {
+    const element = ref?.nativeElement ?? null;
+    if (element === this.splitHostElement) {
+      return;
+    }
+    this.splitHostElement = element;
+    if (element) {
+      this.scheduleSplitSync();
+    }
+  }
+
+  /**
+   * The live pane elements. The split resolves each pane by its own `data-channel` rather than
+   * by index into this list, and the list's `changes` is the signal that a surface registered
+   * mid-session has actually RENDERED — which is when a pending split can take it in.
+   */
+  @ViewChildren('surfacePane') private paneQuery!: QueryList<ElementRef<HTMLElement>>;
 
   private flashTimer: ReturnType<typeof setTimeout> | null = null;
   private subs: Subscription[] = [];
   private lastWide = false;
   private cdr = inject(ChangeDetectorRef);
+
+  /** The Golden Layout arrangement used by `Layout="split"` (idle until engaged). */
+  private readonly splitLayout = new RealtimeSurfaceSplitLayout();
+  /** The split's current members, in strip order. Empty while the panel is on tabs. */
+  private splitMemberKeys: string[] = [];
+  private splitHostElement: HTMLElement | null = null;
+  /** Bumped by every layout request so a superseded (awaiting) sync stands down. */
+  private splitSyncGeneration = 0;
+  /** Live while a sync is waiting for the host to be measured — cancelled on teardown. */
+  private splitMeasureWait: { Cancel: () => void } | null = null;
 
   /**
    * The channel whose first-run intro is currently being shown (its `ChannelName`), or `null`
@@ -161,6 +273,18 @@ export class RealtimeSurfaceTabsComponent implements OnInit, OnDestroy {
     );
   }
 
+  ngAfterViewInit(): void {
+    // A surface that comes into play mid-session renders its pane one change-detection pass after
+    // it joins the strip; this is how a pending split learns the element now exists.
+    this.subs.push(
+      this.paneQuery.changes.subscribe(() => {
+        if (this._layout === 'split') {
+          this.scheduleSplitSync();
+        }
+      })
+    );
+  }
+
   ngOnDestroy(): void {
     for (const s of this.subs) {
       s.unsubscribe();
@@ -170,6 +294,8 @@ export class RealtimeSurfaceTabsComponent implements OnInit, OnDestroy {
       clearTimeout(this.flashTimer);
       this.flashTimer = null;
     }
+    // Golden Layout holds DOM and listeners of its own — it goes with the panel, not with GC.
+    this.teardownSplit();
   }
 
   /** Toggle the panel between expanded and slim-collapsed. */
@@ -181,6 +307,14 @@ export class RealtimeSurfaceTabsComponent implements OnInit, OnDestroy {
   private setCollapsed(value: boolean): void {
     if (this.Collapsed !== value) {
       this.Collapsed = value;
+      if (value) {
+        // Collapsing removes the panes (and the split host) from the DOM. Hand them back to the
+        // tabs layout NOW rather than leaving Golden Layout holding elements Angular is about to
+        // destroy — the panes come back on expand and re-split from scratch.
+        this.teardownSplit();
+      } else {
+        this.scheduleSplitSync();
+      }
       this.CollapsedChange.emit(value);
       this.syncWide();
     }
@@ -198,6 +332,29 @@ export class RealtimeSurfaceTabsComponent implements OnInit, OnDestroy {
   /** track fn for the @for over tabs. */
   public TrackTab(index: number, tab: RealtimeSurfaceTab): string {
     return tab.Key;
+  }
+
+  /** The surfaces the split is currently showing, in strip order. Empty while on tabs. */
+  public get SplitMemberKeys(): ReadonlyArray<string> {
+    return this.splitMemberKeys;
+  }
+
+  /**
+   * Whether a tab's surface is ON SCREEN — the focused tab on tabs, every split member on a
+   * split. The strip's active treatment and `aria-selected` read from this so it stays honest
+   * about a layout showing more than one surface at a time.
+   */
+  public IsTabShown(key: string): boolean {
+    return this.SplitEngaged ? this.splitMemberKeys.includes(key) : key === this.Model.ActiveKey;
+  }
+
+  /**
+   * Whether a tab is unreachable in the current layout — a surface the split isn't showing.
+   * Its strip button is disabled rather than left as a click that would do nothing visible:
+   * which surfaces a split shows is the host's declaration ({@link SplitKeys}), not the user's.
+   */
+  public IsTabOutsideSplit(key: string): boolean {
+    return this.SplitEngaged && !this.splitMemberKeys.includes(key);
   }
 
   /**
@@ -287,6 +444,7 @@ export class RealtimeSurfaceTabsComponent implements OnInit, OnDestroy {
     this.scheduleFlashClear();
     this.syncWide();
     this.evaluateOnboarding();
+    this.resyncSplitOnTabChange();
     this.cdr.markForCheck();
   }
 
@@ -364,6 +522,175 @@ export class RealtimeSurfaceTabsComponent implements OnInit, OnDestroy {
       this.Model.Focus(first.Key);
       this.cdr.markForCheck();
     }
+  }
+
+  // ── split layout (Layout="split") ─────────────────────────────────────────────────────────
+
+  /**
+   * Re-syncs the split when the STRIP changed under it — a channel registering, or a tab being
+   * removed, changes which surfaces the split resolves to. Deliberately silent while the panel is
+   * on tabs, so the default layout does no work at all on a model change; whether the membership
+   * ACTUALLY changed is the sync's own call, made in one place.
+   */
+  private resyncSplitOnTabChange(): void {
+    if (this._layout === 'split') {
+      this.scheduleSplitSync();
+    }
+  }
+
+  /**
+   * Queues a layout sync for the next microtask, superseding any sync still in flight.
+   *
+   * Deferred for the same reason the channel-tab reveals are (NG0100): a layout request commonly
+   * arrives mid change-detection, and this one additionally needs the DOM it is about to measure
+   * to have been RENDERED — which the flag it sets is what triggers.
+   */
+  private scheduleSplitSync(): void {
+    const generation = ++this.splitSyncGeneration;
+    Promise.resolve().then(() => { void this.syncSplitLayout(generation); });
+  }
+
+  /**
+   * Brings the actual arrangement in line with {@link Layout} / {@link SplitKeys}.
+   *
+   * Runs in up to three passes, re-entered by the `splitHost` ViewChild setter: engage (render
+   * the host), measure (wait for it to have a size), attach. Anything that makes the split
+   * unhonourable at any point — too few surfaces, a collapsed panel, a host that never gains a
+   * size, a Golden Layout that lays out nothing — falls back to the tabs presentation, loudly.
+   */
+  private async syncSplitLayout(generation: number): Promise<void> {
+    if (generation !== this.splitSyncGeneration) {
+      return;
+    }
+    const keys = ResolveSplitPaneKeys(this.Model.Tabs, this._splitKeys);
+    if (this._layout !== 'split' || this.Collapsed || keys.length === 0) {
+      this.teardownSplit();
+      return;
+    }
+    const arranged = this.splitLayout.PaneKeys;
+    if (keys.length === arranged.length && keys.every((key, i) => key === arranged[i])) {
+      // Already arranged exactly this way. Re-attaching would rebuild the layout and throw away
+      // wherever the user has dragged the splitters, for no change at all.
+      return;
+    }
+    if (!this.SplitEngaged) {
+      // Pass 1: render the host (and hand pane visibility to the arrangement). The ViewChild
+      // setter re-enters once the element exists.
+      this.SplitEngaged = true;
+      this.splitMemberKeys = keys;
+      this.cdr.markForCheck();
+      return;
+    }
+    this.splitMemberKeys = keys;
+    const host = this.splitHostElement;
+    if (!host) {
+      // Engaged but not rendered yet — the ViewChild setter will re-enter with the element.
+      return;
+    }
+
+    // Pass 2: Golden Layout lays its whole tree into whatever the host measures AT INIT and
+    // reports nothing when that is nothing, so the size is established before it ever sees it.
+    const measured = await this.waitForMeasuredSplitHost(host, generation);
+    if (generation !== this.splitSyncGeneration) {
+      return;
+    }
+    if (!measured) {
+      LogError(`Realtime surface panel: the split layout host never gained a size within ${SPLIT_HOST_MEASURE_TIMEOUT_MS}ms (surfaces [${keys.join(', ')}]) — staying on the tabs layout.`);
+      this.teardownSplit();
+      return;
+    }
+
+    // Pass 3: attach. Every pane is looked up by its own data-channel, never by position.
+    const panes: RealtimeSplitPane[] = [];
+    for (const tab of this.Model.Tabs.filter(t => keys.includes(t.Key))) {
+      const element = this.paneElement(tab.Key);
+      if (element) {
+        panes.push({ Key: tab.Key, Title: tab.Title, Element: element });
+      }
+    }
+    if (panes.length !== keys.length) {
+      // A surface that JUST joined the strip renders its pane on the next change-detection pass.
+      // Not an error and not a reason to collapse the split — the pane list's `changes` re-enters
+      // here the moment the element exists.
+      return;
+    }
+    if (!this.splitLayout.Attach(host, panes)) {
+      // Attach already reported WHY, and left the panes as it found them.
+      this.teardownSplit();
+      return;
+    }
+    this.cdr.markForCheck();
+  }
+
+  /**
+   * Resolves once the split host reports a non-zero size, `false` if it never does within
+   * {@link SPLIT_HOST_MEASURE_TIMEOUT_MS} or the sync is superseded. Never throws: the caller
+   * degrades to tabs, which is the useful answer for a live session.
+   */
+  private waitForMeasuredSplitHost(host: HTMLElement, generation: number): Promise<boolean> {
+    this.cancelSplitMeasureWait();
+    if (IsMeasured(host)) {
+      return Promise.resolve(true);
+    }
+    return new Promise<boolean>(resolve => {
+      let timer: ReturnType<typeof setTimeout> | null = null;
+      let observer: ResizeObserver | null = null;
+      const settle = (measured: boolean): void => {
+        if (timer !== null) {
+          clearTimeout(timer);
+          timer = null;
+        }
+        observer?.disconnect();
+        observer = null;
+        this.splitMeasureWait = null;
+        resolve(measured);
+      };
+      observer = new ResizeObserver(() => {
+        if (generation !== this.splitSyncGeneration) {
+          settle(false);
+        } else if (IsMeasured(host)) {
+          settle(true);
+        }
+      });
+      timer = setTimeout(() => settle(false), SPLIT_HOST_MEASURE_TIMEOUT_MS);
+      this.splitMeasureWait = { Cancel: () => settle(false) };
+      observer.observe(host);
+    });
+  }
+
+  /** Drops a pending measure wait (teardown / a superseding request) so nothing dangles. */
+  private cancelSplitMeasureWait(): void {
+    const wait = this.splitMeasureWait;
+    this.splitMeasureWait = null;
+    wait?.Cancel();
+  }
+
+  /**
+   * Returns the panel to the tabs layout: Golden Layout destroyed, every pane's inline geometry
+   * removed, the host un-rendered. Idempotent — the panel spends most of its life here.
+   */
+  private teardownSplit(): void {
+    this.cancelSplitMeasureWait();
+    this.splitLayout.Destroy();
+    this.splitMemberKeys = [];
+    if (this.SplitEngaged) {
+      this.SplitEngaged = false;
+      this.cdr.markForCheck();
+    }
+  }
+
+  /**
+   * The live pane element for a tab key. Matched on the pane's own `data-channel` rather than by
+   * index into the tab list: both lists render from the same array today, but that is an
+   * implementation detail and not something a layout should be built on.
+   */
+  private paneElement(key: string): HTMLElement | null {
+    for (const ref of this.paneQuery ?? []) {
+      if (ref.nativeElement.dataset['channel'] === key) {
+        return ref.nativeElement;
+      }
+    }
+    return null;
   }
 
   /** Clears the model's flash highlight after a beat (one timer; latest flash wins). */

--- a/packages/Angular/Generic/conversations/src/lib/components/realtime/realtime-surface-tabs.model.ts
+++ b/packages/Angular/Generic/conversations/src/lib/components/realtime/realtime-surface-tabs.model.ts
@@ -274,6 +274,43 @@ export class RealtimeSurfaceTabsModel {
 }
 
 /**
+ * The panel's layout mode (see `RealtimeSurfaceTabsComponent.Layout`):
+ *  - `tabs`  — the default: one surface at a time, picked from the tab strip.
+ *  - `split` — the surfaces named by `SplitKeys` arranged side by side at once.
+ */
+export type RealtimeSurfaceLayoutMode = 'tabs' | 'split';
+
+/**
+ * The minimum number of panes a split arrangement needs. One surface side by side with nothing
+ * is the tabs layout, so the panel stays in tabs presentation below this — that's the "only one
+ * surface is open" degrade, not a failure.
+ */
+export const MIN_SPLIT_PANES = 2;
+
+/**
+ * Resolves which of the strip's tabs a `split` layout should show, in STRIP order.
+ *
+ * `requestedKeys` is the host's declared set (`SplitKeys`); an empty set means "whatever is
+ * open", which is what makes `Layout="split"` meaningful on its own. Unknown keys are dropped
+ * rather than reserving empty space — a host commonly declares the surfaces it expects before
+ * the agent has brought them into play, and the split should grow into them as they register.
+ * Strip order (not the order the host listed) decides left-to-right, so the split reads the same
+ * way as the tabs it replaces.
+ *
+ * Returns an empty array when fewer than {@link MIN_SPLIT_PANES} tabs qualify — the caller stays
+ * in the tabs presentation.
+ *
+ * Kept framework-free (like the model) so the rule is unit-testable in isolation.
+ */
+export function ResolveSplitPaneKeys(tabs: ReadonlyArray<RealtimeSurfaceTab>, requestedKeys: ReadonlyArray<string>): string[] {
+  const requested = new Set(requestedKeys);
+  const keys = tabs
+    .filter(t => requested.size === 0 || requested.has(t.Key))
+    .map(t => t.Key);
+  return keys.length >= MIN_SPLIT_PANES ? keys : [];
+}
+
+/**
  * Pure decision helper for the REVIEW→LIVE continuation edge: should the overlay REMOVE the
  * review-registered (template-based, read-only) Whiteboard tab?
  *

--- a/packages/Angular/Generic/conversations/src/public-api.ts
+++ b/packages/Angular/Generic/conversations/src/public-api.ts
@@ -134,6 +134,7 @@ export * from './lib/components/realtime/realtime-delegation-card.component';
 export * from './lib/components/realtime/realtime-activity-rail.component';
 export * from './lib/components/realtime/realtime-surface-tabs.component';
 export * from './lib/components/realtime/realtime-surface-tabs.model';
+export * from './lib/components/realtime/realtime-surface-split-layout';
 export * from './lib/components/realtime/realtime-surface-panel-prefs';
 export * from './lib/components/realtime/realtime-disclosure';
 export * from './lib/components/realtime/realtime-audio-visuals';


### PR DESCRIPTION
Closes #3535.

## The problem, and the trap

`RealtimeSurfaceTabsComponent` shows exactly one pane at a time. A host has no way to say *"show these two together"* — and imposing it from outside fails **silently**:

- MJ emits `.surface { display: flex }` with Angular attribute scoping → **(0,2,0)**
- a host's `.surface.my-split { display: grid; … }` is **also (0,2,0)**
- ties break on document order, and component styles are injected when the component first renders — *after* a host stylesheet added at startup

MJ wins. `grid-template-columns` computes correctly and is **ignored on a flex container**. Everything looks applied; the panes just stack. The issue records two debugging sessions lost to this — once with CSS grid, once with **Golden Layout**, where the host ended up 0px tall and GL laid its entire tree into nothing while reporting no error.

## The API

Exactly the issue's Ask — same names, nothing invented around them:

```ts
@Input() Layout: 'tabs' | 'split' = 'tabs';
@Input() SplitKeys: string[] = [];        // [] === every open surface
// and the secondary ask:
[attr.data-channel]="tab.Key"             // a pane is identifiable
```

Plus both as **pass-throughs on `RealtimeSessionOverlayComponent`** — that is the component host apps actually embed, and without it the panel input is unreachable from a host, which is the situation the issue was written from.

## The 0px trap is answered, not assumed away

Four layers:

1. The GL host is `.surface__split { flex: 1; min-height: 0 }` — a flex child of an already-laid-out panel, so it inherits a real height instead of auto-sizing from empty content.
2. It renders **before GL exists**: pass 1 sets `SplitEngaged` and returns; a `@ViewChild('splitHost')` **setter** re-enters the sync once the element is in the DOM.
3. `waitForMeasuredSplitHost()` resolves immediately on a non-zero rect, else waits on a `ResizeObserver` with a **capped** `SPLIT_HOST_MEASURE_TIMEOUT_MS = 4000`. Timeout ⇒ `LogError` naming the surfaces, then **degrade to tabs**.
4. **Postcondition after attach**: every pane's applied size is re-measured; anything under 1px tears GL down, restores the panes, and logs the host's measured size.

Proven in Chromium: a `height:0` host makes `Attach()` return `false` and logs `…the layout host measured 600×0`. The failure the issue is about now fails **loudly**.

## Panes are never re-parented

GL runs in `virtual: true` mode, so switching layouts moves no DOM — a whiteboard keeps its drawing and a remote browser keeps its page. Asserted both in Chromium (`no pane was re-parented`) and in the component spec (same element *and* same first child across tabs → split → tabs).

## `'tabs'` is unchanged — the most important property here

This component is on the live interview path for an Open App, so a regression is a broken interview, not a broken layout.

- with no input bound, **Golden Layout is never constructed** (asserted)
- no `.surface__split` renders, `.surface--split` absent, every pane's `style` attribute is `null`
- pane DOM asserted attribute-by-attribute: attributes are exactly `class`, `data-channel`, `role` — nothing leaked
- `aria-selected` is `['true','false']`, no tab disabled, clicking tab 2 still moves `s-pane--active`
- both rebound expressions collapse to the old ones by construction: `IsTabShown(k)` returns `k === Model.ActiveKey` whenever `SplitEngaged` is false
- every split entry point early-exits on `layout !== 'split'`, so a tabs-mode model change does no work

## Verification

| | exit |
|---|---|
| `npm run build` (`ngc`, after `rm -rf dist`) | **0** |
| `npm run test:types` | **0** |
| `npm test` (vitest) | **0** — 94 files / **1117 tests** (baseline 92 / 1080) |
| `node scripts/verify-split-layout.mjs` (real Chromium) | **0** — 14 geometry assertions |

The Chromium check covers side-by-side non-overlapping rects, shared top edge and height, covering the host, no re-parenting, following a panel resize, clean teardown, and the zero-height host failing loudly. Run **deliberately without** `goldenlayout-base.css`, to prove the injected structural rules suffice on their own.

## Two judgement calls

- **GL headers are off.** The panel's own tab strip stays the identity; GL contributes splitters only. Tabs outside the split are disabled rather than left as clicks that do nothing.
- **Added the overlay pass-throughs**, as above — otherwise the feature is unreachable.

## On the siblings

- **#3599** (whiteboard hardcoded up front) — *not* made trivially addressable. It lives on a different path (`ShouldRegisterChannelTabUpFront()` in `realtime-surface-tab-style.ts`) and needs its own host input plus the issue's flagged second half. Left deliberately. Partial mitigation: a `split` deployment that names its surfaces no longer *shows* an unwanted blank board, though the tab still registers.
- **#3531** (one surface per channel type) — out of scope by a wide margin (four layers, server/session-side). **Caveat for anyone using this:** `Layout="split"` works today for two *different* channels; two Remote Browsers still collide on the tab key, so that comparison case needs #3531 too.

## Note for CI

`golden-layout ^2.6.0` and `esbuild ^0.27.3` are new in `package.json`, so a run needs `pnpm install`. Golden Layout was already a dependency of four other MJ packages; `dashboard-viewer` was the reference for init and teardown.

🤖 Generated with [Claude Code](https://claude.com/claude-code)