### PR TITLE
fix(core): encapsulate graph-node save and close the #3874 review

### DIFF
--- a/.changeset/embedded-records-save-graph.md
+++ b/.changeset/embedded-records-save-graph.md
@@ -1,8 +1,8 @@
 ---
-"@memberjunction/core": minor
-"@memberjunction/codegen-lib": minor
-"@memberjunction/integration-test-suite": minor
-"@memberjunction/ng-graph-view": minor
+"@memberjunction/core": patch
+"@memberjunction/codegen-lib": patch
+"@memberjunction/integration-test-suite": patch
+"@memberjunction/ng-graph-view": patch
 ---
 
 Close the #3874 adversarial review. SkipRelatedCollections persists embeds while collections stay with the caller. The graph-node recursion guard is private on BaseEntity (IsGraphNodeSave is gone from EntitySaveOptions). Result serialize adopts saved peers; a rolled-back graph reverts in-memory saved/dirty so retry works. Two same-entity embeds no longer false-cycle. Ensure, Load, NewRecord FK, CodeName emission, core-schema imports, IT85/EE5, graph-view UUID links, focal-node dblclick, and default excludeSchemas no longer dropping core form tabs.

--- a/.changeset/embedded-records-save-graph.md
+++ b/.changeset/embedded-records-save-graph.md
@@ -1,7 +1,8 @@
 ---
-"@memberjunction/core": patch
-"@memberjunction/codegen-lib": patch
-"@memberjunction/integration-test-suite": patch
+"@memberjunction/core": minor
+"@memberjunction/codegen-lib": minor
+"@memberjunction/integration-test-suite": minor
+"@memberjunction/ng-graph-view": minor
 ---
 
-Fix Embedded Record save-graph follow-ups from the #3874 review. SkipRelatedCollections persists embeds while leaving collections to the caller (the booking path no longer needs a persist-outside-graph workaround). Result serialize ships a clean saved peer so the browser does not re-INSERT it. Two embeds targeting the same entity no longer throw a false cycle. Ensure calls NewRecord, Load resets a leftover cleared peer, and NewRecord does not clobber a caller-supplied FK. IT85 mutation config is under config so EE1–EE5 actually run; EE5 now fails validation with a too-long Name.
+Close the #3874 adversarial review. SkipRelatedCollections persists embeds while collections stay with the caller. The graph-node recursion guard is private on BaseEntity (IsGraphNodeSave is gone from EntitySaveOptions). Result serialize adopts saved peers; a rolled-back graph reverts in-memory saved/dirty so retry works. Two same-entity embeds no longer false-cycle. Ensure, Load, NewRecord FK, CodeName emission, core-schema imports, IT85/EE5, graph-view UUID links, focal-node dblclick, and default excludeSchemas no longer dropping core form tabs.

--- a/.changeset/embedded-records-save-graph.md
+++ b/.changeset/embedded-records-save-graph.md
@@ -1,0 +1,7 @@
+---
+"@memberjunction/core": patch
+"@memberjunction/codegen-lib": patch
+"@memberjunction/integration-test-suite": patch
+---
+
+Fix Embedded Record save-graph follow-ups from the #3874 review. SkipRelatedCollections persists embeds while leaving collections to the caller (the booking path no longer needs a persist-outside-graph workaround). Result serialize ships a clean saved peer so the browser does not re-INSERT it. Two embeds targeting the same entity no longer throw a false cycle. Ensure calls NewRecord, Load resets a leftover cleared peer, and NewRecord does not clobber a caller-supplied FK. IT85 mutation config is under config so EE1–EE5 actually run; EE5 now fails validation with a too-long Name.

--- a/guides/TRANSACTIONS_AND_BATCHING_GUIDE.md
+++ b/guides/TRANSACTIONS_AND_BATCHING_GUIDE.md
@@ -297,6 +297,13 @@ Deprecated since 6.2. It opens a second physical transaction blind to any alread
 **❌ Setting `Load: 'immediate'` on a collection whose parent is commonly listed in grids.**
 Use `'explicit'` plus `IncludeRelatedRecords` on the specific views that need children.
 
+**❌ Passing `IsGraphNodeSave` from application code to get a "header-only" save.**
+That flag is the graph executor's recursion guard. It skips *every* companion,
+including owner-held embeds, so a booking path that prepares lines itself then
+saves the header with `IsGraphNodeSave` drops the PaymentDetail (or any other
+embed) on the floor. Use `SkipRelatedCollections: true` — embeds still persist,
+collections do not.
+
 ---
 
 ## Related

--- a/guides/TRANSACTIONS_AND_BATCHING_GUIDE.md
+++ b/guides/TRANSACTIONS_AND_BATCHING_GUIDE.md
@@ -167,9 +167,10 @@ recursive companion payload so the order's lines ride along. See
 
 ```typescript
 const deal = await md.GetEntityObject<DealEntity>('Deals');
-deal.OrderID_Object.OrderDate = new Date('2002-01-01');
+// OrderID is nullable — Ensure() provisions the peer (required FKs exist after NewRecord).
+const order = deal.OrderID_EnsureObject();
+order.OrderDate = new Date('2002-01-01');
 await deal.Save(); // Order first, stamp Deal.OrderID, save Deal
-
 ```
 
 Then use it. The API is the same on both tiers:
@@ -297,12 +298,11 @@ Deprecated since 6.2. It opens a second physical transaction blind to any alread
 **❌ Setting `Load: 'immediate'` on a collection whose parent is commonly listed in grids.**
 Use `'explicit'` plus `IncludeRelatedRecords` on the specific views that need children.
 
-**❌ Passing `IsGraphNodeSave` from application code to get a "header-only" save.**
-That flag is the graph executor's recursion guard. It skips *every* companion,
-including owner-held embeds, so a booking path that prepares lines itself then
-saves the header with `IsGraphNodeSave` drops the PaymentDetail (or any other
-embed) on the floor. Use `SkipRelatedCollections: true` — embeds still persist,
-collections do not.
+**❌ Inventing a "header-only" save that skips companions.**
+The graph executor's recursion guard is private on `BaseEntity`. Application
+code that previously passed a public `IsGraphNodeSave` flag dropped *every*
+companion, including owner-held embeds. Use `SkipRelatedCollections: true` —
+embeds still persist, collections do not.
 
 ---
 

--- a/metadata-optional/integration-test/tests/integration/.IT85-entity-embedded.json
+++ b/metadata-optional/integration-test/tests/integration/.IT85-entity-embedded.json
@@ -13,7 +13,9 @@
       "checks": [
         {
           "type": "entity-embedded",
-          "runMutationTests": true
+          "config": {
+            "runMutationTests": true
+          }
         }
       ]
     },

--- a/metadata-optional/integration-test/tests/integration/.IT85-entity-embedded.json
+++ b/metadata-optional/integration-test/tests/integration/.IT85-entity-embedded.json
@@ -2,10 +2,10 @@
   "fields": {
     "TypeID": "@lookup:MJ: Test Types.Name=Integration Test",
     "Name": "IT85 - Entity Embedded Records (owner-held 1:1)",
-    "Description": "Live-database proof of EmbeddedRecord — an owner-held 1:1 peer that loads, validates and persists as one unit with its owner. No production __mj field is honest composition, so this bundle registers a test-only subclass of MJ: Action Categories that treats the existing nullable ParentID self-FK as an embedded peer (the closest core analogue of Deal.OrderID). EE1: an unprovisioned nullable embed is inert. EE2: Ensure + Save persists the peer first and stamps the owner FK; Load hydrates the peer. EE3: a dirty peer on a clean owner still saves (Dirty rollup). EE4: Clear + orphan nulls the FK and leaves the peer row. EE5: a failing peer rolls the whole graph back. All five mutate and carry RequiresMutation; the bundle creates and tears down its own prefixed, tagged Action Category rows and never touches a pre-existing record.",
+    "Description": "Live-database proof of EmbeddedRecord — an owner-held 1:1 peer that loads, validates and persists as one unit with its owner. No production __mj field is honest composition, so this bundle registers a test-only subclass of MJ: Action Categories that treats the existing nullable ParentID self-FK as an embedded peer (the closest core analogue of Deal.OrderID). EE1: an unprovisioned nullable embed is inert. EE2: Ensure + Save persists the peer first and stamps the owner FK; Load hydrates the peer. EE3: a dirty peer on a clean owner still saves (Dirty rollup). EE4: Clear + orphan nulls the FK and leaves the peer row. EE5: a failing peer rolls the whole graph back. EE6: Load of a self-parented row fails cleanly instead of hanging. All six mutate and carry RequiresMutation; the bundle creates and tears down its own prefixed, tagged Action Category rows and never touches a pre-existing record.",
     "InputDefinition": {},
     "ExpectedOutcomes": {
-      "summary": "Nullable embed stays inert; Ensure+Save persists the peer first and stamps the FK; Load hydrates; dirty rollup works; Clear orphans; a failed peer rolls back the owner."
+      "summary": "Nullable embed stays inert; Ensure+Save persists the peer first and stamps the FK; Load hydrates; dirty rollup works; Clear orphans; a failed peer rolls back the owner; a self-parented Load fails cleanly."
     },
     "Configuration": {
       "tier": "deterministic",

--- a/metadata/entities/.entity-field-jsontype-embedded-record.json
+++ b/metadata/entities/.entity-field-jsontype-embedded-record.json
@@ -6,7 +6,7 @@
       "FK as a first-class embedded record — the policy half of a DeclareEmbeddedRecord(...)",
       "call. RelatedEntity and the FK field name are NOT part of the JSON shape: they are",
       "already columns on the same row.",
-      "Added by migration V202608161200__v6.1.x__EntityField_EmbeddedRecord.sql.",
+      "Added by migration V202608161735__v6.1.x__EntityField_EmbeddedRecord.sql.",
       "The EntityField row must exist (created by a CodeGen pass over the new column) before",
       "this @lookup resolves on push."
     ],

--- a/migrations/v6/V202608161735__v6.1.x__EntityField_EmbeddedRecord.sql
+++ b/migrations/v6/V202608161735__v6.1.x__EntityField_EmbeddedRecord.sql
@@ -110,7 +110,7 @@ GO
 -- If the hand DDL above changes, re-run CodeGen scoped to the core schema
 -- (see includeSchemas in mj.config.cjs) and replace this entire generated section.
 -- =============================================================================
-/* SQL text to insert 12 new entity field(s) */
+/* SQL text to insert 1 new entity field */
 
       IF NOT EXISTS (SELECT 1 FROM [${flyway:defaultSchema}].[EntityField] WHERE ID = '96c625c0-daee-4117-b263-1a3d7bc03f00' OR (EntityID = 'DF238F34-2837-EF11-86D4-6045BDEE16E6' AND Name = 'EmbeddedRecord')) BEGIN
          INSERT INTO [${flyway:defaultSchema}].[EntityField]

--- a/migrations/v6/V202608161735__v6.1.x__EntityField_EmbeddedRecord.sql
+++ b/migrations/v6/V202608161735__v6.1.x__EntityField_EmbeddedRecord.sql
@@ -110,7 +110,7 @@ GO
 -- If the hand DDL above changes, re-run CodeGen scoped to the core schema
 -- (see includeSchemas in mj.config.cjs) and replace this entire generated section.
 -- =============================================================================
-/* SQL text to insert 1 new entity field */
+/* SQL text to insert 12 new entity field(s) */
 
       IF NOT EXISTS (SELECT 1 FROM [${flyway:defaultSchema}].[EntityField] WHERE ID = '96c625c0-daee-4117-b263-1a3d7bc03f00' OR (EntityID = 'DF238F34-2837-EF11-86D4-6045BDEE16E6' AND Name = 'EmbeddedRecord')) BEGIN
          INSERT INTO [${flyway:defaultSchema}].[EntityField]

--- a/packages/Angular/Generic/graph-view/README.md
+++ b/packages/Angular/Generic/graph-view/README.md
@@ -10,7 +10,7 @@ An interactive, high-performance network and relationship graph visualization co
 - 🔍 **Interactive Search & Degree Filter**: Node keyword filtering and hop-distance neighborhood expansion.
 - 🎯 **Cancelable Before/After Event System**: Full control over user interactions (`BeforeNodeSelect`, `BeforeEdgeSelect`, `BeforeHopExpand`, `BeforeLayoutChange`).
 - 🎨 **MemberJunction Design Tokens**: Seamless integration with MJ dark/light themes and typography.
-- 🔎 **Selected Node Inspector Pane**: Built-in side drawer with direct 1-click `NavigationService.OpenEntityRecord` action.
+- 🔎 **Selected Node Inspector Pane**: Built-in side drawer. Navigation is an intent event (`NodeNavigated`) so the host opens the record.
 
 ---
 
@@ -73,7 +73,7 @@ export class MyFeatureComponent {
 | `BeforeLayoutChange` | `BeforeLayoutChangeEventArgs` | ✅ Yes | Fired before layout mode changes. |
 | `LayoutChanged` | `LayoutChangedEventArgs` | ❌ No | Fired after layout algorithm recalculates. |
 | `BeforeNodeNavigate` | `BeforeNodeNavigateEventArgs` | ✅ Yes | Fired before opening full entity record form. |
-| `NodeNavigated` | `NodeNavigatedEventArgs` | ❌ No | Fired after navigation handoff to `NavigationService`. |
+| `NodeNavigated` | `NodeNavigatedEventArgs` | ❌ No | Fired after the user asks to open a record. The host owns navigation. |
 
 ---
 

--- a/packages/Angular/Generic/graph-view/package.json
+++ b/packages/Angular/Generic/graph-view/package.json
@@ -32,9 +32,6 @@
   },
   "dependencies": {
     "@memberjunction/ng-ui-components": "6.1.0-edge.2",
-    "@memberjunction/core": "6.1.0-edge.2",
-    "@memberjunction/ng-shared": "6.1.0-edge.2",
-    "@memberjunction/core-entities": "6.1.0-edge.2",
     "@memberjunction/global": "6.1.0-edge.2",
     "@types/d3": "^7.4.3",
     "d3": "^7.9.0",

--- a/packages/Angular/Generic/graph-view/src/lib/components/graph-view.component.ts
+++ b/packages/Angular/Generic/graph-view/src/lib/components/graph-view.component.ts
@@ -17,7 +17,7 @@ import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
 import { NavigationService } from '@memberjunction/ng-shared';
 import { CompositeKey } from '@memberjunction/core';
-import { UUIDsEqual } from '@memberjunction/global';
+import { NormalizeUUID, UUIDsEqual } from '@memberjunction/global';
 import * as d3 from 'd3';
 import type {
     GraphNode,
@@ -668,16 +668,28 @@ export class GraphViewComponent implements OnInit, OnChanges, OnDestroy {
         const cx = this.GetContainerWidth() / 2 || 400;
         const cy = this.GetContainerHeight() / 2 || 250;
 
-        // Build links clone for D3 simulation
-        const links: d3.SimulationLinkDatum<GraphNode>[] = this.Edges.map(e => ({
-            ...e,
-            source: e.SourceID,
-            target: e.TargetID
-        }));
+        // Resolve endpoints to node objects so a case-skewed UUID or dangling
+        // edge cannot throw "node not found" out of ngOnInit. Raw-string
+        // .id(d => d.ID) compared with ===, which UUIDsEqual elsewhere
+        // deliberately does not.
+        const nodeById = new Map<string, GraphNode>();
+        for (const node of this.Nodes) {
+            const key = NormalizeUUID(node.ID);
+            if (key) {
+                nodeById.set(key, node);
+            }
+        }
+        const links: d3.SimulationLinkDatum<GraphNode>[] = [];
+        for (const edge of this.Edges) {
+            const source = nodeById.get(NormalizeUUID(edge.SourceID));
+            const target = nodeById.get(NormalizeUUID(edge.TargetID));
+            if (source && target) {
+                links.push({ source, target });
+            }
+        }
 
         this.simulation = d3.forceSimulation<GraphNode>(this.Nodes)
             .force('link', d3.forceLink<GraphNode, d3.SimulationLinkDatum<GraphNode>>(links)
-                .id((d: GraphNode) => d.ID)
                 .distance(this.Physics.LinkDistance || 120))
             .force('charge', d3.forceManyBody<GraphNode>()
                 .strength(this.Physics.Repulsion || -450)
@@ -853,6 +865,12 @@ export class GraphViewComponent implements OnInit, OnChanges, OnDestroy {
     }
 
     public NavigateToEntity(node: GraphNode): void {
+        // Focal-node dblclick must not navigate away from the record this
+        // graph is illustrating — the inspector already hides the navigate
+        // button for the same reason.
+        if (this.IsFocalNode(node)) {
+            return;
+        }
         const rawId = String(node.Data?.['ID'] || node.ID).replace(/^(person|org|account|committee|custom):/, '');
         const entityName = String(node.Data?.['EntityName'] || (node.Category === 'person' ? 'MJ_BizApps_Common: People' : 'MJ_BizApps_Common: Organizations'));
         const beforeEvent = new BeforeNodeNavigateEventArgs(node, entityName, rawId);

--- a/packages/Angular/Generic/graph-view/src/lib/components/graph-view.component.ts
+++ b/packages/Angular/Generic/graph-view/src/lib/components/graph-view.component.ts
@@ -868,7 +868,7 @@ export class GraphViewComponent implements OnInit, OnChanges, OnDestroy {
         if (this.IsFocalNode(node)) {
             return;
         }
-        const rawId = String(node.Data?.['ID'] || node.ID).replace(/^(person|org|account|committee|custom):/, '');
+        const rawId = this.stripCategoryPrefix(String(node.Data?.['ID'] || node.ID));
         const entityName = String(node.Data?.['EntityName'] || (node.Category === 'person' ? 'MJ_BizApps_Common: People' : 'MJ_BizApps_Common: Organizations'));
         const beforeEvent = new BeforeNodeNavigateEventArgs(node, entityName, rawId);
         this.BeforeNodeNavigate.emit(beforeEvent);
@@ -1054,9 +1054,26 @@ export class GraphViewComponent implements OnInit, OnChanges, OnDestroy {
 
     public IsFocalNode(node: GraphNode): boolean {
         if (!node || !this.FocalNodeId) return false;
-        const focalClean = this.FocalNodeId.replace(/^(person|org|account|committee|custom):/, '').toLowerCase();
-        const nodeClean = node.ID.replace(/^(person|org|account|committee|custom):/, '').toLowerCase();
+        const focalClean = this.stripCategoryPrefix(this.FocalNodeId).toLowerCase();
+        const nodeClean = this.stripCategoryPrefix(node.ID).toLowerCase();
         const dataClean = node.Data?.['ID'] ? String(node.Data['ID']).toLowerCase() : '';
         return UUIDsEqual(node.ID, this.FocalNodeId) || nodeClean === focalClean || dataClean === focalClean;
+    }
+
+    /**
+     * Hosts prefix node IDs with `{category}:`. Categories are dynamic
+     * (`organization`, `asset`, `group`, plus caller keys), so strip any
+     * known-category prefix rather than a hardcoded subset.
+     */
+    private stripCategoryPrefix(id: string): string {
+        const idx = id.indexOf(':');
+        if (idx <= 0) {
+            return id;
+        }
+        const prefix = id.slice(0, idx).toLowerCase();
+        const known =
+            this.Categories?.some(c => c.Category.toLowerCase() === prefix) ||
+            DEFAULT_GRAPH_CATEGORIES.some(c => c.Category.toLowerCase() === prefix);
+        return known ? id.slice(idx + 1) : id;
     }
 }

--- a/packages/Angular/Generic/graph-view/src/lib/components/graph-view.component.ts
+++ b/packages/Angular/Generic/graph-view/src/lib/components/graph-view.component.ts
@@ -15,8 +15,6 @@ import {
 } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
-import { NavigationService } from '@memberjunction/ng-shared';
-import { CompositeKey } from '@memberjunction/core';
 import { NormalizeUUID, UUIDsEqual } from '@memberjunction/global';
 import * as d3 from 'd3';
 import type {
@@ -535,7 +533,6 @@ const GRAPH_VIEW_CSS = `
 })
 export class GraphViewComponent implements OnInit, OnChanges, OnDestroy {
     private cdr = inject(ChangeDetectorRef);
-    private navService = inject(NavigationService, { optional: true });
 
     @ViewChild('wrapper', { static: true }) public WrapperRef!: ElementRef<HTMLDivElement>;
     @ViewChild('svgCanvas', { static: true }) public CanvasRef!: ElementRef<SVGSVGElement>;
@@ -877,10 +874,8 @@ export class GraphViewComponent implements OnInit, OnChanges, OnDestroy {
         this.BeforeNodeNavigate.emit(beforeEvent);
         if (beforeEvent.Cancel) return;
 
-        if (this.navService) {
-            const pk = CompositeKey.FromID(rawId);
-            this.navService.OpenEntityRecord(entityName, pk);
-        }
+        // Hosts navigate. This widget is L1 and must not import Explorer's
+        // NavigationService — emit the intent and let the surface open the record.
         this.NodeNavigated.emit(new NodeNavigatedEventArgs(node, entityName, rawId));
     }
 

--- a/packages/CodeGenLib/src/Angular/angular-codegen.ts
+++ b/packages/CodeGenLib/src/Angular/angular-codegen.ts
@@ -8,6 +8,23 @@ import { GenerationResult, RelatedEntityDisplayComponentGeneratorBase } from './
 import { sortBySequenceAndCreatedAt, sortRelatedEntities } from '../Misc/util';
 
 /**
+ * Schemas whose entities should not appear as related-entity form tabs.
+ *
+ * `excludeSchemas` defaults include `__mj` so CodeGen does not emit core
+ * entity *files* into a downstream package. Those entities still exist at
+ * runtime via `@memberjunction/core-entities`, so filtering them here
+ * silently dropped core-entity tabs for every default config.
+ */
+function schemasExcludedFromGeneratedForms(): Set<string> {
+    const core = String(mjCoreSchema ?? '__mj').toLowerCase();
+    return new Set(
+        (configInfo.excludeSchemas || [])
+            .map(s => s.toLowerCase())
+            .filter(s => s !== core && s !== '__mj'),
+    );
+}
+
+/**
  * Represents metadata about an Angular form section that is generated for an entity
  */
 export class AngularFormSectionInfo {
@@ -858,7 +875,7 @@ ${indentedFormHTML}
         // can only have 0 or 1 records (disjoint subtypes), so a grid panel is redundant
         const isaChildIDs = new Set(entity.ChildEntities.map(c => c.ID));
 
-        const excludedSchemas = new Set((configInfo.excludeSchemas || []).map(s => s.toLowerCase()));
+        const excludedSchemas = schemasExcludedFromGeneratedForms();
 
         // Sort related entities deterministically using the shared sort with cascading tiebreakers
         const sortedRelatedEntities = sortRelatedEntities(
@@ -975,7 +992,7 @@ ${componentCodeWithIndent}
             return tabs;
         }
 
-        const excludedSchemas = new Set((configInfo.excludeSchemas || []).map(s => s.toLowerCase()));
+        const excludedSchemas = schemasExcludedFromGeneratedForms();
         let index = startIndex;
         for (const organicKey of organicKeys) {
             for (const relatedEntity of organicKey.RelatedEntities) {

--- a/packages/CodeGenLib/src/Misc/entity_subclasses_codegen.ts
+++ b/packages/CodeGenLib/src/Misc/entity_subclasses_codegen.ts
@@ -854,7 +854,7 @@ ${fields}
       return '';
     }
 
-    const md = new Metadata();
+    const md = new Metadata(); // global-provider-ok: codegen runs offline against a single provider
     const blocks: string[] = [];
     const seen = new Set<string>();
 
@@ -897,7 +897,7 @@ ${fields}
     if (declared.length === 0) {
       return [];
     }
-    const md = new Metadata();
+    const md = new Metadata(); // global-provider-ok: codegen runs offline against a single provider
     const imports: string[] = [];
     const seen = new Set<string>();
     for (const field of declared) {

--- a/packages/CodeGenLib/src/Misc/entity_subclasses_codegen.ts
+++ b/packages/CodeGenLib/src/Misc/entity_subclasses_codegen.ts
@@ -954,8 +954,9 @@ ${fields}
       logError(`[EmbeddedRecord] ${label}: invalid LoadNested '${config.LoadNested}'; skipping.`);
       return null;
     }
-    if (!/^[A-Za-z_][A-Za-z0-9_]*$/.test(field.Name)) {
-      logError(`[EmbeddedRecord] ${label}: field name is not a valid TypeScript identifier; skipping.`);
+    const emittedName = field.CodeName ? SafeCodeName(field) : field.Name;
+    if (!/^[A-Za-z_][A-Za-z0-9_]*$/.test(emittedName)) {
+      logError(`[EmbeddedRecord] ${label}: emitted name '${emittedName}' is not a valid TypeScript identifier; skipping.`);
       return null;
     }
     return config;

--- a/packages/CodeGenLib/src/Misc/entity_subclasses_codegen.ts
+++ b/packages/CodeGenLib/src/Misc/entity_subclasses_codegen.ts
@@ -972,6 +972,7 @@ ${fields}
   ): string {
     const relatedClass = `${related.ClassName}Entity`;
     const getterType = field.AllowsNull ? `${relatedClass} | null` : relatedClass;
+    const code = field.CodeName ? SafeCodeName(field) : field.Name;
     const lines: string[] = [
       `ForeignKeyField: '${EntitySubClassGeneratorBase.EscapeSingleQuotes(field.Name)}'`,
       `RelatedEntity: '${EntitySubClassGeneratorBase.EscapeSingleQuotes(related.Name)}'`,
@@ -983,7 +984,7 @@ ${fields}
       lines.push(`LoadNested: '${config.LoadNested}'`);
     }
     const requiredNote = field.AllowsNull
-      ? ` Null until ${field.Name}_EnsureObject() or Load() finds a value.`
+      ? ` Null until ${code}_EnsureObject() or Load() finds a value.`
       : ` Always present after GetEntityObject / NewRecord.`;
 
     return `
@@ -995,14 +996,14 @@ ${fields}
   * Declared by EntityField.EmbeddedRecord on '${entity.Name}.${field.Name}'; edit that row, not this file.
   *${requiredNote}
   */
-  private readonly __emb_${field.Name} = this.DeclareEmbeddedRecord<${relatedClass}>({
+  private readonly __emb_${code} = this.DeclareEmbeddedRecord<${relatedClass}>({
       ${lines.join(',\n        ')},
   });
-  public get ${field.Name}_Object(): ${getterType} {
-      return this.__emb_${field.Name}.Value${field.AllowsNull ? '' : '!'};
+  public get ${code}_Object(): ${getterType} {
+      return this.__emb_${code}.Value${field.AllowsNull ? '' : '!'};
   }
-  public ${field.Name}_EnsureObject(): ${relatedClass} {
-      return this.__emb_${field.Name}.Ensure();
+  public ${code}_EnsureObject(): ${relatedClass} {
+      return this.__emb_${code}.Ensure();
   }
 `;
   }

--- a/packages/CodeGenLib/src/Misc/entity_subclasses_codegen.ts
+++ b/packages/CodeGenLib/src/Misc/entity_subclasses_codegen.ts
@@ -910,7 +910,11 @@ ${fields}
         continue;
       }
       seen.add(className);
-      const pkg = resolveEntityPackageName(related.SchemaName);
+      const coreSchema = typeof mj_core_schema === 'function' ? mj_core_schema() : String(mj_core_schema);
+      const pkg =
+        related.SchemaName && related.SchemaName.toLowerCase() === String(coreSchema).toLowerCase()
+          ? '@memberjunction/core-entities'
+          : resolveEntityPackageName(related.SchemaName);
       imports.push(`import { ${className} } from '${pkg}';\n`);
     }
     return imports;

--- a/packages/CodeGenLib/src/__tests__/entity-subclass-embedded.test.ts
+++ b/packages/CodeGenLib/src/__tests__/entity-subclass-embedded.test.ts
@@ -18,6 +18,9 @@ vi.mock('@memberjunction/core', () => ({
             if (id === 'rel-orders') {
                 return { ID: id, Name: 'MJ_BizApps_Orders: Order Headers', ClassName: 'mjBizAppsOrdersOrderHeader', SchemaName: '__mj_BizAppsOrders' };
             }
+            if (id === 'rel-users') {
+                return { ID: id, Name: 'Users', ClassName: 'User', SchemaName: '__mj' };
+            }
             return undefined;
         }
     },
@@ -150,5 +153,15 @@ describe('CollectEmbeddedImports', () => {
             new Set(['mjBizAppsOrdersOrderHeaderEntity']),
         );
         expect(imports).toEqual([]);
+    });
+
+    it('imports a core-schema peer from @memberjunction/core-entities', () => {
+        const imports = EntitySubClassGeneratorBase.CollectEmbeddedImports(
+            makeEntity([makeField({ Name: 'UserID', RelatedEntityID: 'rel-users' })]),
+            new Set(['DealEntity']),
+        );
+        expect(imports.some(s => s.includes("@memberjunction/core-entities"))).toBe(true);
+        expect(imports.some(s => s.includes('UserEntity'))).toBe(true);
+        expect(imports.some(s => s.includes('mj_generatedentities'))).toBe(false);
     });
 });

--- a/packages/CodeGenLib/src/__tests__/entity-subclass-embedded.test.ts
+++ b/packages/CodeGenLib/src/__tests__/entity-subclass-embedded.test.ts
@@ -102,6 +102,16 @@ describe('GenerateEmbeddedRecords — emission', () => {
         expect(out).not.toContain('get OrderID_Object(): mjBizAppsOrdersOrderHeaderEntity | null');
     });
 
+    it('emits getters from CodeName when it differs from Name', () => {
+        const out = EntitySubClassGeneratorBase.GenerateEmbeddedRecords(
+            makeEntity([makeField({ CodeName: 'OrderID_' })]),
+        );
+        expect(out).toContain('get OrderID__Object()');
+        expect(out).toContain('OrderID__EnsureObject()');
+        expect(out).toContain('__emb_OrderID_');
+        expect(out).toContain("ForeignKeyField: 'OrderID'");
+    });
+
     it('emits OnClear and LoadNested when set', () => {
         const out = EntitySubClassGeneratorBase.GenerateEmbeddedRecords(
             makeEntity([makeField({ EmbeddedRecord: JSON.stringify({ OnClear: 'delete', LoadNested: 'related' }) })]),

--- a/packages/CodeGenLib/src/__tests__/entity-subclass-embedded.test.ts
+++ b/packages/CodeGenLib/src/__tests__/entity-subclass-embedded.test.ts
@@ -112,6 +112,15 @@ describe('GenerateEmbeddedRecords — emission', () => {
         expect(out).toContain("ForeignKeyField: 'OrderID'");
     });
 
+    it('accepts a space-named field when CodeName is a valid identifier', () => {
+        const out = EntitySubClassGeneratorBase.GenerateEmbeddedRecords(
+            makeEntity([makeField({ Name: 'Order ID', CodeName: 'OrderID' })]),
+        );
+        expect(out).toContain('get OrderID_Object()');
+        expect(out).toContain("ForeignKeyField: 'Order ID'");
+        expect(logError).not.toHaveBeenCalled();
+    });
+
     it('emits OnClear and LoadNested when set', () => {
         const out = EntitySubClassGeneratorBase.GenerateEmbeddedRecords(
             makeEntity([makeField({ EmbeddedRecord: JSON.stringify({ OnClear: 'delete', LoadNested: 'related' }) })]),

--- a/packages/MJCore/docs/embedded-records.md
+++ b/packages/MJCore/docs/embedded-records.md
@@ -144,11 +144,10 @@ flowchart TD
 A clean owner with a dirty peer still saves — `Dirty` rolls up. A header-only
 edit on a clean peer stays a single-node plan.
 
-`IsGraphNodeSave` is **not** a header-only switch. The graph executor sets it
-on the root so the node does not re-enter graph planning — it skips *every*
-companion, including embeds. If you need to write collections yourself after
-preparing them (pricing, expansion, sequence) but still persist the embeds
-with the header, pass `SkipRelatedCollections: true` instead:
+The graph executor's recursion guard is **private** on `BaseEntity`. If you
+need to write collections yourself after preparing them (pricing, expansion,
+sequence) but still persist the embeds with the header, pass
+`SkipRelatedCollections: true` instead:
 
 ```ts
 await order.Save({ SkipRelatedCollections: true });

--- a/packages/MJCore/docs/embedded-records.md
+++ b/packages/MJCore/docs/embedded-records.md
@@ -144,6 +144,22 @@ flowchart TD
 A clean owner with a dirty peer still saves — `Dirty` rolls up. A header-only
 edit on a clean peer stays a single-node plan.
 
+`IsGraphNodeSave` is **not** a header-only switch. The graph executor sets it
+on the root so the node does not re-enter graph planning — it skips *every*
+companion, including embeds. If you need to write collections yourself after
+preparing them (pricing, expansion, sequence) but still persist the embeds
+with the header, pass `SkipRelatedCollections: true` instead:
+
+```ts
+await order.Save({ SkipRelatedCollections: true });
+// InitialPaymentDetail rode the graph. Lines did not — write them next.
+```
+
+The result graph always serializes an exposed peer, even when it is clean.
+Request serialize still omits it so a header-only edit stays cheap; result
+serialize is what lets the browser mark the peer saved. Without that, the
+next `Save()` re-sends `IsNew: true` and the server re-INSERTs the same UUID.
+
 `OnClear` (default `'orphan'`):
 
 | | On owner Save | On owner Delete |

--- a/packages/MJCore/docs/embedded-records.md
+++ b/packages/MJCore/docs/embedded-records.md
@@ -187,9 +187,23 @@ null. That is the price of a sync getter and a sync `Ensure`. It is
 it on conversion-shaped, low-volume relationships (Deal → Order), not on
 every lookup (`CustomerID`, `CategoryID`).
 
-Self-FKs (Category.ParentID → Category) construct one level. The peer's own
-embeddeds are not initialised until that peer is loaded or you call
-`InitializeEmbeddedRecords` on it.
+Construction walks nested embeds of **different** entities, so a required
+nested FK on a brand-new peer is provisioned when the owner `NewRecord()`s
+(and `peer.Nested_EnsureObject()` does not throw). Self-FKs and A→B→A
+cycles still construct one extra level — the path set skips the entity
+already being built. `Load()` inherit uses a separate `entityName:PK` set
+and **throws** on a self-parented or mutually-referential row rather than
+walking until the stack dies.
+
+### Collection items
+
+An embed declared **on a collection item** (e.g. `Order.Lines[i].TaxDetailID`)
+does not ride `RelatedRecordCollectionWire`. Items carry `{Fields, IsNew}`
+only, in both directions. The peer persists on a **server-tier**
+`header.Save()` (in-process graph) but is silently dropped over GraphQL.
+Re-attach by setting the item's FK, or save the item as its own root. A
+runtime warning is logged when a dirty item embed would be omitted from
+the wire.
 
 ---
 

--- a/packages/MJCore/src/__tests__/baseEntity.embedded.test.ts
+++ b/packages/MJCore/src/__tests__/baseEntity.embedded.test.ts
@@ -9,7 +9,7 @@
  *  4. Dirty rolls up from the peer so a clean owner with a dirty peer still saves.
  *  5. Serialize ships nested companions; request deserialize InnerLoads first.
  *  6. Clear + orphan nulls the FK and does not delete the peer.
- *  7. A construct cycle throws rather than recursing until the stack dies.
+ *  7. Two embeds targeting the same entity construct without a false cycle.
  */
 
 import { describe, it, expect, beforeAll, afterAll, beforeEach } from 'vitest';
@@ -20,6 +20,7 @@ import { Metadata } from '../generic/metadata';
 import { ProviderBase } from '../generic/providerBase';
 import type { IEntityDataProvider } from '../generic/interfaces';
 import { ALL_ENTITY_DATA, PRODUCT_ENTITY_ID } from './mocks/MockEntityData';
+import { FieldValueCollection } from '../generic/compositeKey';
 
 @RegisterClass(BaseEntity, 'Products')
 class PermissiveProduct extends BaseEntity {
@@ -82,6 +83,9 @@ let saveLog: { entity: string; id: unknown; name: unknown }[] = [];
 let deleteLog: string[] = [];
 let txnLog: string[] = [];
 let loadedRows: Record<string, Record<string, unknown>> = {};
+let supportsTransactions = true;
+let routeOperationResult: unknown = null;
+let routedInput: unknown = null;
 
 function makeProvider() {
     let depth = 0;
@@ -93,8 +97,12 @@ function makeProvider() {
             if (name === 'Deals') return dealInfo;
             return undefined;
         },
+        async RouteOperation(_key: string, input: unknown): Promise<unknown> {
+            routedInput = input;
+            return routeOperationResult;
+        },
         get SupportsEntityTransactions() {
-            return true;
+            return supportsTransactions;
         },
         async BeginEntityTransaction() {
             depth++;
@@ -206,6 +214,9 @@ beforeEach(() => {
     deleteLog = [];
     txnLog = [];
     loadedRows = {};
+    supportsTransactions = true;
+    routeOperationResult = null;
+    routedInput = null;
 });
 
 async function newDeal(cls: typeof TestDealEntity | typeof RequiredDealEntity = TestDealEntity, info = dealInfo) {
@@ -230,6 +241,8 @@ describe('EmbeddedRecord — provision', () => {
         const first = deal.OrderID_EnsureObject();
         expect(first).toBeTruthy();
         expect(deal.OrderID_Object).toBe(first);
+        expect(first.Get('ID')).toBeTruthy();
+        expect(first.IsSaved).toBe(false);
         expect(deal.Get('OrderID')).toBe(first.Get('ID'));
         expect(deal.OrderID_EnsureObject()).toBe(first);
     });
@@ -332,6 +345,10 @@ describe('EmbeddedRecord — wire', () => {
 
         expect(await deal.Save()).toBe(true);
         expect(await deal.OrderEmb.Serialize()).toBeNull();
+        const resultPayload = await deal.OrderEmb.Serialize('result');
+        expect(resultPayload).toBeTruthy();
+        expect(resultPayload!.IsNew).toBe(false);
+        expect(resultPayload!.Fields.Name).toBe('Order-1');
     });
 
     it('prefixes peer validation errors with the companion name', async () => {
@@ -359,5 +376,110 @@ describe('EmbeddedRecord — cycles', () => {
         await expect(deal.InitializeEmbeddedRecords()).resolves.toBeUndefined();
         expect(deal.Self.Value).toBeNull();
         expect(deal.Self.Ensure()).toBeTruthy();
+    });
+
+    it('constructs two embeds targeting the same entity without a false cycle', async () => {
+        class TwoAddressDeal extends BaseEntity {
+            public readonly BillTo = this.DeclareEmbeddedRecord<BaseEntity>({
+                ForeignKeyField: 'OrderID',
+                RelatedEntity: 'Products',
+            });
+            public readonly ShipTo = this.DeclareEmbeddedRecord<BaseEntity>({
+                ForeignKeyField: 'Name',
+                RelatedEntity: 'Products',
+            });
+            public override CheckPermissions(): boolean { return true; }
+        }
+        const provider = makeProvider();
+        const deal = new TwoAddressDeal(dealInfo, provider as unknown as IEntityDataProvider);
+        await expect(deal.InitializeEmbeddedRecords()).resolves.toBeUndefined();
+        expect(deal.BillTo.Ensure()).toBeTruthy();
+        expect(deal.ShipTo.Ensure()).toBeTruthy();
+        expect(deal.BillTo.Ensure()).not.toBe(deal.ShipTo.Ensure());
+    });
+});
+
+describe('EmbeddedRecord — NewRecord + Load edge cases', () => {
+    it('does not overwrite a caller-supplied required FK with a minted peer', async () => {
+        const { deal } = await newDeal(RequiredDealEntity, requiredDealInfo);
+        // Re-run NewRecord with an explicit FK — the first NewRecord already minted one.
+        deal.NewRecord(new FieldValueCollection([{ FieldName: 'OrderID', Value: 'existing-order-id' }]));
+        expect(deal.Get('OrderID')).toBe('existing-order-id');
+        expect(deal.OrderEmb.IsProvisioned).toBe(false);
+    });
+
+    it('Load of a nulled FK clears the leftover cleared flag', async () => {
+        const { deal } = await newDeal();
+        deal.OrderID_EnsureObject().Set('Name', 'Order-1');
+        expect(await deal.Save()).toBe(true);
+        deal.OrderEmb.Clear();
+        expect(deal.OrderEmb.Dirty).toBe(true);
+
+        loadedRows['deal-reload'] = { ID: 'deal-reload', Name: 'Deal-1', OrderID: null };
+        const { CompositeKey } = await import('../generic/compositeKey');
+        await deal.InnerLoad(CompositeKey.FromID('deal-reload'));
+        expect(deal.OrderID_Object).toBeNull();
+        expect(deal.OrderEmb.Dirty).toBe(false);
+    });
+});
+
+describe('EmbeddedRecord — SkipRelatedCollections', () => {
+    it('still persists the embed when related collections are skipped', async () => {
+        const { deal } = await newDeal();
+        deal.OrderID_EnsureObject().Set('Name', 'Order-1');
+        const saved = await deal.Save({ SkipRelatedCollections: true });
+        expect(saved).toBe(true);
+        expect(saveLog.map(s => s.entity)).toEqual(['Products', 'Deals']);
+        expect(deal.Get('OrderID')).toBe(deal.OrderID_Object!.Get('ID'));
+    });
+});
+
+describe('EmbeddedRecord — browser result adoption', () => {
+    it('marks the peer saved from the result graph so the next save does not re-INSERT', async () => {
+        supportsTransactions = false;
+        const { deal } = await newDeal();
+        const order = deal.OrderID_EnsureObject();
+        order.Set('Name', 'Order-1');
+        const orderId = String(order.Get('ID'));
+
+        routeOperationResult = {
+            Success: true,
+            ResultCode: 'SUCCESS',
+            Output: {
+                Success: true,
+                Fields: { ...deal.GetAll(), OrderID: orderId },
+                Companions: [
+                    {
+                        Name: 'OrderID_Object',
+                        Data: {
+                            Fields: { ...order.GetAll(), Name: 'Order-1' },
+                            IsNew: false,
+                            Cleared: false,
+                            Companions: null,
+                        },
+                    },
+                ],
+            },
+        };
+
+        expect(await deal.Save()).toBe(true);
+
+        const first = routedInput as {
+            Companions: { Name: string; Data: { IsNew: boolean } }[];
+        };
+        expect(first.Companions).toHaveLength(1);
+        expect(first.Companions[0].Name).toBe('OrderID_Object');
+        expect(first.Companions[0].Data.IsNew).toBe(true);
+        expect(order.IsSaved).toBe(true);
+        expect(await deal.OrderEmb.Serialize()).toBeNull();
+
+        // Header-only edit after result adoption is a single-row save, not a
+        // graph that re-INSERTs the same UUID.
+        routedInput = null;
+        saveLog = [];
+        deal.Set('Name', 'Deal-1-renamed');
+        expect(await deal.Save()).toBe(true);
+        expect(routedInput).toBeNull();
+        expect(saveLog.map(s => s.entity)).toEqual(['Deals']);
     });
 });

--- a/packages/MJCore/src/__tests__/baseEntity.embedded.test.ts
+++ b/packages/MJCore/src/__tests__/baseEntity.embedded.test.ts
@@ -86,6 +86,7 @@ let loadedRows: Record<string, Record<string, unknown>> = {};
 let supportsTransactions = true;
 let routeOperationResult: unknown = null;
 let routedInput: unknown = null;
+let failNextDealSave = false;
 
 function makeProvider() {
     let depth = 0;
@@ -130,6 +131,10 @@ function makeProvider() {
                 id: entity.Get('ID'),
                 name: entity.Get('Name'),
             });
+            if (failNextDealSave && entity.EntityInfo.Name === 'Deals') {
+                failNextDealSave = false;
+                throw new Error('simulated header failure');
+            }
             return entity.GetAll();
         },
         async Delete(entity: BaseEntity): Promise<boolean> {
@@ -217,6 +222,7 @@ beforeEach(() => {
     supportsTransactions = true;
     routeOperationResult = null;
     routedInput = null;
+    failNextDealSave = false;
 });
 
 async function newDeal(cls: typeof TestDealEntity | typeof RequiredDealEntity = TestDealEntity, info = dealInfo) {
@@ -353,12 +359,52 @@ describe('EmbeddedRecord — wire', () => {
 
     it('prefixes peer validation errors with the companion name', async () => {
         const { deal } = await newDeal();
-        deal.OrderID_EnsureObject();
-        // Products.Name AllowsNull=false and we never set it after NewRecord — may already have a UUID-like default
+        const order = deal.OrderID_EnsureObject();
+        order.Set('Name', 'x'.repeat(256));
         const result = deal.Validate();
-        expect(result).toBeTruthy();
+        expect(result.Success).toBe(false);
         const prefixed = result.Errors.filter(e => (e.Source ?? '').startsWith('OrderID_Object'));
-        expect(Array.isArray(prefixed)).toBe(true);
+        expect(prefixed.length).toBeGreaterThan(0);
+    });
+
+    it('Deserialize request of a new peer applies fields without InnerLoad', async () => {
+        const { deal } = await newDeal();
+        await deal.OrderEmb.Deserialize({
+            Fields: { ID: 'wire-order', Name: 'From-wire' },
+            IsNew: true,
+            Cleared: false,
+            Companions: null,
+        }, 'request');
+        expect(deal.OrderID_Object).toBeTruthy();
+        expect(deal.OrderID_Object!.Get('Name')).toBe('From-wire');
+        expect(deal.OrderID_Object!.IsSaved).toBe(false);
+    });
+
+    it('Deserialize request of an existing peer InnerLoads first then applies', async () => {
+        loadedRows['existing-order'] = { ID: 'existing-order', Name: 'DB-name' };
+        const { deal } = await newDeal();
+        await deal.OrderEmb.Deserialize({
+            Fields: { ID: 'existing-order', Name: 'Client-edit' },
+            IsNew: false,
+            Cleared: false,
+            Companions: null,
+        }, 'request');
+        expect(deal.OrderID_Object!.Get('Name')).toBe('Client-edit');
+        expect(deal.OrderID_Object!.IsSaved).toBe(true);
+    });
+
+    it('Deserialize result adopts the peer as saved', async () => {
+        const { deal } = await newDeal();
+        deal.OrderID_EnsureObject();
+        await deal.OrderEmb.Deserialize({
+            Fields: { ID: 'saved-order', Name: 'Adopted' },
+            IsNew: false,
+            Cleared: false,
+            Companions: null,
+        }, 'result');
+        expect(deal.OrderID_Object!.Get('Name')).toBe('Adopted');
+        expect(deal.OrderID_Object!.IsSaved).toBe(true);
+        expect(await deal.OrderEmb.Serialize()).toBeNull();
     });
 });
 
@@ -481,5 +527,67 @@ describe('EmbeddedRecord — browser result adoption', () => {
         expect(await deal.Save()).toBe(true);
         expect(routedInput).toBeNull();
         expect(saveLog.map(s => s.entity)).toEqual(['Deals']);
+    });
+});
+
+describe('EmbeddedRecord — OnClear', () => {
+    it('refuse throws from Clear()', async () => {
+        class RefuseDeal extends BaseEntity {
+            public readonly OrderEmb = this.DeclareEmbeddedRecord<BaseEntity>({
+                ForeignKeyField: 'OrderID',
+                RelatedEntity: 'Products',
+                OnClear: 'refuse',
+            });
+            public override CheckPermissions(): boolean { return true; }
+        }
+        const provider = makeProvider();
+        const deal = new RefuseDeal(dealInfo, provider as unknown as IEntityDataProvider);
+        await deal.InitializeEmbeddedRecords();
+        deal.NewRecord();
+        deal.OrderEmb.Ensure();
+        expect(() => deal.OrderEmb.Clear()).toThrow(/refused/);
+    });
+
+    it("delete plans a peer delete after Clear on a saved embed", async () => {
+        class DeleteDeal extends BaseEntity {
+            public readonly OrderEmb = this.DeclareEmbeddedRecord<BaseEntity>({
+                ForeignKeyField: 'OrderID',
+                RelatedEntity: 'Products',
+                OnClear: 'delete',
+            });
+            public override CheckPermissions(): boolean { return true; }
+        }
+        const provider = makeProvider();
+        const deal = new DeleteDeal(dealInfo, provider as unknown as IEntityDataProvider);
+        await deal.InitializeEmbeddedRecords();
+        deal.NewRecord();
+        deal.Set('Name', 'Deal-1');
+        deal.OrderEmb.Ensure().Set('Name', 'Order-1');
+        expect(await deal.Save()).toBe(true);
+        deleteLog = [];
+        deal.OrderEmb.Clear();
+        expect(await deal.Save()).toBe(true);
+        expect(deleteLog).toContain('Products');
+        expect(deal.Get('OrderID')).toBeNull();
+    });
+});
+
+describe('EmbeddedRecord — mid-graph failure', () => {
+    it('reverts the peer so a retry re-saves it instead of hitting a missing FK', async () => {
+        const { deal } = await newDeal();
+        const order = deal.OrderID_EnsureObject();
+        order.Set('Name', 'Order-1');
+        failNextDealSave = true;
+
+        expect(await deal.Save()).toBe(false);
+        expect(txnLog).toContain('rollback');
+        expect(order.IsSaved).toBe(false);
+        expect(order.Dirty).toBe(true);
+        expect(deal.Get('OrderID')).toBe(order.Get('ID'));
+
+        saveLog = [];
+        expect(await deal.Save()).toBe(true);
+        expect(saveLog.map(s => s.entity)).toEqual(['Products', 'Deals']);
+        expect(order.IsSaved).toBe(true);
     });
 });

--- a/packages/MJCore/src/__tests__/baseEntity.embedded.test.ts
+++ b/packages/MJCore/src/__tests__/baseEntity.embedded.test.ts
@@ -315,6 +315,23 @@ describe('EmbeddedRecord — clear and load', () => {
         expect(deleteLog).toEqual([]);
     });
 
+    it('Ensure after Clear+Save mints a new peer instead of restamping the orphan', async () => {
+        const { deal } = await newDeal();
+        const orphan = deal.OrderID_EnsureObject();
+        orphan.Set('Name', 'Orphan');
+        expect(await deal.Save()).toBe(true);
+        const orphanId = orphan.Get('ID');
+
+        deal.OrderEmb.Clear();
+        expect(await deal.Save()).toBe(true);
+        expect(deal.Get('OrderID')).toBeNull();
+
+        const next = deal.OrderID_EnsureObject();
+        expect(next.Get('ID')).not.toBe(orphanId);
+        expect(next.IsSaved).toBe(false);
+        expect(deal.Get('OrderID')).toBe(next.Get('ID'));
+    });
+
     it('Load hydrates the peer when the FK is set, and the promise waits for it', async () => {
         const { deal } = await newDeal();
         const order = deal.OrderID_EnsureObject();
@@ -422,6 +439,62 @@ describe('EmbeddedRecord — cycles', () => {
         await expect(deal.InitializeEmbeddedRecords()).resolves.toBeUndefined();
         expect(deal.Self.Value).toBeNull();
         expect(deal.Self.Ensure()).toBeTruthy();
+    });
+
+    it('Load of a self-parented row fails cleanly instead of hanging', async () => {
+        class CyclicDeal extends BaseEntity {
+            public readonly Self = this.DeclareEmbeddedRecord<BaseEntity>({
+                ForeignKeyField: 'OrderID',
+                RelatedEntity: 'Deals',
+            });
+            public override CheckPermissions(): boolean { return true; }
+        }
+        loadedRows['self-1'] = { ID: 'self-1', Name: 'Loop', OrderID: 'self-1' };
+        const provider = makeProvider();
+        const deal = new CyclicDeal(dealInfo, provider as unknown as IEntityDataProvider);
+        await deal.InitializeEmbeddedRecords();
+        const { CompositeKey } = await import('../generic/compositeKey');
+        await expect(deal.InnerLoad(CompositeKey.FromID('self-1'))).rejects.toThrow(/load cycle/);
+    });
+
+    it('constructs nested embeds on a new peer so nested Ensure does not throw', async () => {
+        @RegisterClass(BaseEntity, 'NestedMids')
+        class NestedMidEntity extends BaseEntity {
+            public readonly OrderEmb = this.DeclareEmbeddedRecord<BaseEntity>({
+                ForeignKeyField: 'OrderID',
+                RelatedEntity: 'Products',
+            });
+            public override CheckPermissions(): boolean { return true; }
+        }
+        const nestedMidInfo = new EntityInfo({
+            ...DEAL_ENTITY_DATA,
+            ID: 'entity-nested-mid-001',
+            Name: 'NestedMids',
+        });
+        class NestedOwner extends BaseEntity {
+            public readonly MidEmb = this.DeclareEmbeddedRecord<NestedMidEntity>({
+                ForeignKeyField: 'OrderID',
+                RelatedEntity: 'NestedMids',
+            });
+            public override CheckPermissions(): boolean { return true; }
+        }
+        const provider = {
+            ...makeProvider(),
+            Entities: [productInfo, dealInfo, nestedMidInfo],
+            EntityByName(name: string) {
+                if (name === 'Products') return productInfo;
+                if (name === 'Deals') return dealInfo;
+                if (name === 'NestedMids') return nestedMidInfo;
+                return undefined;
+            },
+        };
+        const owner = new NestedOwner(dealInfo, provider as unknown as IEntityDataProvider);
+        await expect(owner.InitializeEmbeddedRecords()).resolves.toBeUndefined();
+        owner.NewRecord();
+        const mid = owner.MidEmb.Ensure();
+        expect(mid).toBeInstanceOf(NestedMidEntity);
+        expect(() => (mid as NestedMidEntity).OrderEmb.Ensure()).not.toThrow();
+        expect((mid as NestedMidEntity).OrderEmb.IsProvisioned).toBe(true);
     });
 
     it('constructs two embeds targeting the same entity without a false cycle', async () => {

--- a/packages/MJCore/src/__tests__/entitySavePlan.test.ts
+++ b/packages/MJCore/src/__tests__/entitySavePlan.test.ts
@@ -11,9 +11,9 @@
  *      for every create, which is the single most likely way to break composite creates.
  *   3. **Stop at first failure** — the transaction is about to roll back, so continuing would pile
  *      up doomed work and let a later, more confusing error mask the real one.
- *   4. **`SelfOnly` routes the root to its own option set** — carrying `IsGraphNodeSave`, without
- *      which the root re-enters graph planning (infinite recursion) and deadlocks on its own
- *      in-flight save debounce.
+ *   4. **`SelfOnly` routes the root through `SaveSelfOnly`** — the private graph-node
+ *      entry on `BaseEntity`. Without that hop the root re-enters graph planning
+ *      (infinite recursion) and deadlocks on its own in-flight save debounce.
  */
 
 import { describe, it, expect } from 'vitest';
@@ -149,38 +149,53 @@ describe('EntitySavePlan', () => {
         expect(result.ErrorMessage).toContain('connection reset');
     });
 
-    it('routes the SelfOnly root node to RootSaveOptions and children to SaveOptions', async () => {
+    it('routes the SelfOnly root through SaveSelfOnly, children through Save', async () => {
         const calls: Call[] = [];
+        const selfOnly: Call[] = [];
         const root = makeEntity('Root', calls);
-        const rootOptions = { IsGraphNodeSave: true } as unknown as EntitySaveOptions;
-        const childOptions = { IsGraphNodeSave: false } as unknown as EntitySaveOptions;
+        const childOptions = { IgnoreDirtyState: true } as EntitySaveOptions;
 
         const plan = new EntitySavePlan(root)
             .AddSave(root, 'root', undefined, true)
             .AddSave(makeEntity('ChildA', calls), 'Lines[0]');
 
-        await ExecuteEntitySavePlan(plan, { SaveOptions: childOptions, RootSaveOptions: rootOptions });
+        await ExecuteEntitySavePlan(plan, {
+            SaveOptions: childOptions,
+            SaveSelfOnly: async (entity, options) => {
+                selfOnly.push({ label: entity.EntityInfo.Name, op: 'Save', options });
+                return true;
+            },
+        });
 
-        expect(calls[0].options).toBe(rootOptions);
-        expect(calls[1].options).toBe(childOptions);
+        expect(selfOnly).toHaveLength(1);
+        expect(selfOnly[0].label).toBe('Root');
+        expect(selfOnly[0].options).toBe(childOptions);
+        expect(calls.map(c => c.label)).toEqual(['ChildA']);
+        expect(calls[0].options).toBe(childOptions);
     });
 
-    it('routes the SelfOnly root delete node to RootDeleteOptions', async () => {
+    it('routes the SelfOnly root delete through DeleteSelfOnly', async () => {
         const calls: Call[] = [];
+        const selfOnly: Call[] = [];
         const root = makeEntity('Root', calls);
-        const rootOptions = { IsGraphNodeDelete: true } as unknown as EntityDeleteOptions;
-        const childOptions = {} as unknown as EntityDeleteOptions;
+        const childOptions = {} as EntityDeleteOptions;
 
         const plan = new EntitySavePlan(root);
         plan.AddDelete(makeEntity('ChildA', calls), 'Lines[0]');
         plan.Add({ Entity: root, Operation: 'Delete', Label: 'root', SelfOnly: true });
 
-        await ExecuteEntitySavePlan(plan, { DeleteOptions: childOptions, RootDeleteOptions: rootOptions });
+        await ExecuteEntitySavePlan(plan, {
+            DeleteOptions: childOptions,
+            DeleteSelfOnly: async (entity, options) => {
+                selfOnly.push({ label: entity.EntityInfo.Name, op: 'Delete', options });
+                return true;
+            },
+        });
 
-        // Children first on the delete path — they hold the FK to the row about to disappear.
-        expect(calls.map(c => c.label)).toEqual(['ChildA', 'Root']);
-        expect(calls[0].options).toBe(childOptions);
-        expect(calls[1].options).toBe(rootOptions);
+        expect(calls.map(c => c.label)).toEqual(['ChildA']);
+        expect(selfOnly).toHaveLength(1);
+        expect(selfOnly[0].label).toBe('Root');
+        expect(selfOnly[0].options).toBe(childOptions);
     });
 });
 

--- a/packages/MJCore/src/generic/baseEntity.ts
+++ b/packages/MJCore/src/generic/baseEntity.ts
@@ -461,6 +461,14 @@ export class EntityField {
     }
 
     /**
+     * Restores the dirty-tracking baseline to a previously captured value.
+     * Used by graph rollback so a retried save still sees the pre-attempt dirty set.
+     */
+    public RestoreOldValue(value: unknown): void {
+        this._OldValue = value;
+    }
+
+    /**
      * @deprecated No-op as of the active-status relocation. Active-status (deprecated/disabled)
      * assertions are now enforced at BaseEntity.Get/Set/SetMany — the entry points genuine code uses —
      * rather than on this low-level EntityField.Value accessor. There is therefore nothing to toggle
@@ -762,6 +770,13 @@ export class BaseEntityEvent {
 /**
  * Base class used for all entity objects. This class is abstract and is sub-classes for each particular entity using the CodeGen tool. This class provides the basic functionality for loading, saving, and validating entity objects.
  */
+/** In-memory baseline captured before a graph runs so a rollback can be retried. */
+type GraphParticipantSnapshot = {
+    entity: BaseEntity;
+    wasSaved: boolean;
+    oldValues: { name: string; old: unknown }[];
+};
+
 export abstract class BaseEntity<T = unknown> {
     /**
      * Metadata describing this entity (name, fields, keys, relationships). Populated during
@@ -1910,6 +1925,11 @@ export abstract class BaseEntity<T = unknown> {
         const childDeleteOptions = Object.assign(new EntityDeleteOptions(), deleteOptions ?? {});
         childDeleteOptions.GraphVisited = visited;
 
+        // Snapshot dirty/saved bookkeeping so a rolled-back graph can be retried.
+        // Node Save() finalizes each participant as saved+clean; DB rollback does
+        // not undo that, and the next Save() would skip the peer and fail the FK.
+        const participants = this.captureGraphParticipants(plan);
+
         // Acquired INSIDE the try: a begin failure (pool exhausted, dead connection) is a failed
         // save, and Save()/Delete() report failure by returning false — an escaping throw here
         // would break that contract for exactly one path.
@@ -1921,13 +1941,14 @@ export abstract class BaseEntity<T = unknown> {
                     : null;
             const result = await ExecuteEntitySavePlan(plan, {
                 SaveOptions: childSaveOptions,
-                RootSaveOptions: this.buildRootSaveOptions(saveOptions),
                 DeleteOptions: childDeleteOptions,
-                RootDeleteOptions: this.buildRootDeleteOptions(deleteOptions),
                 Visited: visited,
+                SaveSelfOnly: (entity, opts) => entity.saveAsGraphNode(opts),
+                DeleteSelfOnly: (entity, opts) => entity.deleteAsGraphNode(opts),
             });
             if (!result.Success) {
                 await scope?.Rollback();
+                this.revertGraphParticipants(participants);
                 this.registerGraphFailure(result.ErrorMessage, operation);
                 this.RaiseEvent('graph_save', { Success: false, NodeCount: plan.NodeCount, Error: result.ErrorMessage });
                 return false;
@@ -1949,6 +1970,7 @@ export abstract class BaseEntity<T = unknown> {
                     `${this.EntityInfo?.Name}: ${rollbackError instanceof Error ? rollbackError.message : String(rollbackError)}`,
                 );
             }
+            this.revertGraphParticipants(participants);
             const detail = e instanceof Error ? e.message : String(e);
             LogError(`BaseEntity.executeGraphLocal failed for ${this.EntityInfo?.Name}: ${detail}`);
             this.registerGraphFailure(detail, operation);
@@ -1958,32 +1980,58 @@ export abstract class BaseEntity<T = unknown> {
     }
 
     /**
-     * Builds the save options for the graph's **root** node.
-     *
-     * Copies the caller's options onto a real `EntitySaveOptions` instance and stamps
-     * `IsGraphNodeSave`, which is what stops the root re-entering graph planning and lets it bypass
-     * its own in-flight save debounce.
-     *
-     * @param source - The caller's options, if any.
-     * @returns Options for the root node.
+     * Persist this record as one already-planned graph node. Private: the public
+     * `Save()` contract must not expose a "skip companions" switch. The executor
+     * binds this via {@link ExecuteEntitySavePlan}'s `SaveSelfOnly` callback.
      */
-    private buildRootSaveOptions(source?: EntitySaveOptions): EntitySaveOptions {
-        const options = Object.assign(new EntitySaveOptions(), source ?? {});
-        options.IsGraphNodeSave = true;
-        return options;
+    private saveAsGraphNode(options?: EntitySaveOptions): Promise<boolean> {
+        return this._InnerSave(options);
     }
 
     /**
-     * Builds the delete options for the graph's **root** node. Delete-path counterpart of
-     * {@link buildRootSaveOptions}.
-     *
-     * @param source - The caller's options, if any.
-     * @returns Options for the root node.
+     * Delete-path counterpart of {@link saveAsGraphNode}.
      */
-    private buildRootDeleteOptions(source?: EntityDeleteOptions): EntityDeleteOptions {
-        const options = Object.assign(new EntityDeleteOptions(), source ?? {});
-        options.IsGraphNodeDelete = true;
-        return options;
+    private deleteAsGraphNode(options?: EntityDeleteOptions): Promise<boolean> {
+        return this._InnerDelete(options);
+    }
+
+    /**
+     * Captures saved/dirty baselines for every plan participant so a rolled-back
+     * graph can be retried without re-INSERTing a "saved" peer or skipping it.
+     */
+    private captureGraphParticipants(plan: EntitySavePlan): GraphParticipantSnapshot[] {
+        return plan.Nodes.map(node => ({
+            entity: node.Entity,
+            wasSaved: node.Entity.IsSaved,
+            oldValues: node.Entity.Fields.map(f => ({ name: f.Name, old: f.OldValue })),
+        }));
+    }
+
+    /**
+     * Restores in-memory saved/dirty state after the database rolled the graph back.
+     */
+    private revertGraphParticipants(snapshots: GraphParticipantSnapshot[]): void {
+        for (const snap of snapshots) {
+            snap.entity.revertUncommittedGraphSave(snap);
+        }
+    }
+
+    /**
+     * After a graph node Save() the fields look clean and `_everSaved` is true.
+     * The DB rollback does not undo that. Restore the pre-attempt baseline so
+     * a retry still writes the peer and the owner FK still matches.
+     */
+    private revertUncommittedGraphSave(snap: GraphParticipantSnapshot): void {
+        if (!snap.wasSaved) {
+            this._everSaved = false;
+            this._recordLoaded = false;
+        }
+        for (const captured of snap.oldValues) {
+            const field = this.GetFieldByName(captured.name);
+            if (field) {
+                field.RestoreOldValue(captured.old);
+            }
+        }
     }
 
     /**
@@ -3189,12 +3237,6 @@ export abstract class BaseEntity<T = unknown> {
             return this._InnerSave(options);
         }
 
-        // Executing our own node inside a graph we already planned. Bypass both the debounce and
-        // graph routing — see EntitySaveOptions.IsGraphNodeSave for why each matters.
-        if (options?.IsGraphNodeSave) {
-            return this._InnerSave(options);
-        }
-
         // If a save is already in progress, return its promise. This check MUST run before graph
         // routing: a composite save is still a save, and two concurrent Save() calls on one record
         // (double-click, autosave racing a manual save) must share the in-flight unit of work.
@@ -3229,8 +3271,7 @@ export abstract class BaseEntity<T = unknown> {
                 }
                 // Run the graph through the same pending-save pipeline as a single-row save, so
                 // concurrent callers share one execution and one result. The graph's own root node
-                // re-enters Save() with IsGraphNodeSave, which bypasses this pipeline above — no
-                // self-deadlock.
+                // runs via the private saveAsGraphNode path — no re-entry into this pipeline.
                 this._pendingSave$ = of(options).pipe(
                     switchMap(opts => from(this.saveGraph(plan, opts))),
                     finalize(() => { this._pendingSave$ = null; }),
@@ -4148,12 +4189,6 @@ export abstract class BaseEntity<T = unknown> {
      * @returns Promise<boolean>
      */
     public async Delete(options?: EntityDeleteOptions) : Promise<boolean> {
-        // Executing our own node inside a delete graph we already planned. Bypass both the debounce
-        // and graph routing — see EntityDeleteOptions.IsGraphNodeDelete.
-        if (options?.IsGraphNodeDelete) {
-            return this._InnerDelete(options);
-        }
-
         // Composite routing: companions that own their children (OnRemove:'delete') contribute
         // child deletions that must run before this row disappears. A single-node plan falls
         // through to the ordinary path, so nothing changes for entities without companions.

--- a/packages/MJCore/src/generic/baseEntity.ts
+++ b/packages/MJCore/src/generic/baseEntity.ts
@@ -1448,7 +1448,10 @@ export abstract class BaseEntity<T = unknown> {
         if (embeddeds.length === 0) {
             return;
         }
-        await Promise.all(embeddeds.map(e => e.InitializeInstance(visited)));
+        // Copy the visited set per sibling. Sharing one mutable set made two
+        // embeds targeting the same entity (BillTo + ShipTo Address) throw a
+        // false "cycle detected" while the first companion was still in flight.
+        await Promise.all(embeddeds.map(e => e.InitializeInstance(new Set(visited))));
     }
 
     /**
@@ -1495,15 +1498,17 @@ export abstract class BaseEntity<T = unknown> {
      * Companions returning `null` are omitted entirely, so a header-only save on a composite entity
      * ships no companion payload at all and costs nothing extra on the wire.
      *
+     * @param mode - `'request'` omits clean saved companions. `'result'` ships
+     *               authoritative post-save state so the other tier can mark peers saved.
      * @returns The companion payloads, in declaration order.
      */
-    public async SerializeCompanions(): Promise<EntityCompanionPayload[]> {
+    public async SerializeCompanions(mode: EntityCompanionDeserializeMode = 'request'): Promise<EntityCompanionPayload[]> {
         if (!this.HasCompanions) {
             return [];
         }
         const payloads: EntityCompanionPayload[] = [];
         for (const companion of this.Companions) {
-            const data = await companion.Serialize();
+            const data = await companion.Serialize(mode);
             if (data !== null && data !== undefined) {
                 payloads.push({ Name: companion.Name, Data: data });
             }

--- a/packages/MJCore/src/generic/baseEntity.ts
+++ b/packages/MJCore/src/generic/baseEntity.ts
@@ -1479,7 +1479,7 @@ export abstract class BaseEntity<T = unknown> {
      */
     public async ConstructUninitializedEntity<T extends BaseEntity>(
         entityName: string,
-        _visited: Set<string>,
+        visited: Set<string>,
     ): Promise<T> {
         const provider = this.ProviderToUse as unknown as IMetadataProvider;
         if (!provider) {
@@ -1501,9 +1501,11 @@ export abstract class BaseEntity<T = unknown> {
         }
         await instance.Config(this.ContextCurrentUser);
         await instance.InitializeParentEntity();
-        // Do NOT recurse InitializeEmbeddedRecords here. A self-FK (Category.ParentID →
-        // Category) would otherwise construct forever, and Deal → Order does not need
-        // the Order's own embeddeds until the Order is loaded or explicitly initialised.
+        // Recurse so a *new* peer's own embeds are constructed (required nested
+        // FKs provision on NewRecord; Ensure on the nested peer does not throw).
+        // InitializeInstance skips when RelatedEntity is already on this path,
+        // so a self-FK / A→B→A cycle still constructs only one extra level.
+        await instance.InitializeEmbeddedRecords(visited);
         return instance;
     }
 
@@ -1744,11 +1746,33 @@ export abstract class BaseEntity<T = unknown> {
         });
     }
 
+    private _embedLoadVisited: Set<string> | undefined;
+
+    /**
+     * Seeds the embed-load cycle set for a nested `InnerLoad`. Called by
+     * {@link EmbeddedRecord.LoadEager} so inherit walks share one `entityName:PK`
+     * path and a self-parented row fails cleanly instead of recursing forever.
+     */
+    public SetEmbeddedLoadVisited(visited: Set<string> | undefined): void {
+        this._embedLoadVisited = visited;
+    }
+
+    private seedEmbedLoadVisited(): Set<string> {
+        const seeded = new Set<string>();
+        const name = this.EntityInfo?.Name;
+        const pk = this.FirstPrimaryKey?.Value;
+        if (name && pk !== null && pk !== undefined && pk !== '') {
+            seeded.add(`${name}:${String(pk)}`);
+        }
+        return seeded;
+    }
+
     private async loadEagerCompanions(): Promise<void> {
         if (!this.HasCompanions) {
             return;
         }
-        await Promise.all(this.Companions.map(c => c.LoadEager()));
+        const visited = this._embedLoadVisited ?? this.seedEmbedLoadVisited();
+        await Promise.all(this.Companions.map(c => c.LoadEager(visited)));
     }
 
     /**

--- a/packages/MJCore/src/generic/embeddedRecord.ts
+++ b/packages/MJCore/src/generic/embeddedRecord.ts
@@ -107,12 +107,11 @@ export class EmbeddedRecord<T extends BaseEntity = BaseEntity> extends EntityCom
         if (this.instance || this.constructing) {
             return;
         }
-        if (visited.has(this.RelatedEntityName)) {
-            throw new Error(
-                `EmbeddedRecord '${this.Name}' on ${this.Owner.EntityInfo?.Name}: cycle detected ` +
-                `constructing '${this.RelatedEntityName}' (already constructing ${[...visited].join(' → ')}).`,
-            );
-        }
+        // Sibling embeds targeting the same entity (BillToAddress + ShipToAddress)
+        // are not a cycle. ConstructUninitializedEntity does not recurse into
+        // InitializeEmbeddedRecords, so a true construction cycle cannot form here.
+        // The per-companion `constructing` flag still collapses a re-entrant call
+        // on the same companion.
         this.constructing = true;
         visited.add(this.RelatedEntityName);
         try {
@@ -140,7 +139,10 @@ export class EmbeddedRecord<T extends BaseEntity = BaseEntity> extends EntityCom
         if (this.exposed) {
             return this.instance;
         }
-        if (this.instance.IsSaved) {
+        // After GetEntityObject the instance is constructed but not NewRecord()'d.
+        // NewRecord() is what assigns a client UUID PK, fires the new_record event,
+        // and runs subclass overrides — without it stampOwnerKey has nothing to write.
+        if (!this.instance.IsSaved) {
             this.instance.NewRecord();
         }
         this.stampOwnerKey();
@@ -174,9 +176,17 @@ export class EmbeddedRecord<T extends BaseEntity = BaseEntity> extends EntityCom
             return;
         }
         if (this.IsRequired) {
-            this.instance.NewRecord();
-            this.stampOwnerKey();
-            this.exposed = true;
+            const existingFk = this.Owner.Get(this.ForeignKeyField);
+            if (existingFk !== null && existingFk !== undefined && existingFk !== '') {
+                // Caller passed NewRecord({ [FK]: existingId }). Do not mint a
+                // new peer and overwrite that FK. The owner points at an existing
+                // row; Load() will hydrate it.
+                this.exposed = false;
+            } else {
+                this.instance.NewRecord();
+                this.stampOwnerKey();
+                this.exposed = true;
+            }
         } else {
             this.exposed = false;
         }
@@ -256,8 +266,19 @@ export class EmbeddedRecord<T extends BaseEntity = BaseEntity> extends EntityCom
         const fk = this.Owner.Get(this.ForeignKeyField);
         if (fk === null || fk === undefined || fk === '') {
             this.exposed = false;
+            this.cleared = false;
+            // A reused owner instance can still hold the previous record's
+            // saved peer. Reset it so Ensure() does not restamp that PK and
+            // OnClear:'delete' does not delete the previous peer.
+            if (this.instance.IsSaved) {
+                this.instance.NewRecord();
+            }
             return;
         }
+        // Nested embeds are not constructed with the owner (ConstructUninitializedEntity
+        // does not recurse). Initialise them now so InnerLoad's loadEagerCompanions
+        // walks the inherit tree instead of no-opping on a null instance.
+        await this.instance.InitializeEmbeddedRecords();
         const loaded = await this.instance.InnerLoad(this.keyFromForeignKey(fk));
         if (!loaded) {
             if (this.IsRequired) {
@@ -282,17 +303,21 @@ export class EmbeddedRecord<T extends BaseEntity = BaseEntity> extends EntityCom
     }
 
     /** @inheritdoc */
-    public override async Serialize(): Promise<EmbeddedRecordWire | null> {
+    public override async Serialize(mode: EntityCompanionDeserializeMode = 'request'): Promise<EmbeddedRecordWire | null> {
         if (this.cleared) {
             return { Fields: {}, IsNew: false, Cleared: true, Companions: null };
         }
         if (!this.exposed || !this.instance) {
             return null;
         }
-        if (this.instance.IsSaved && !this.instance.Dirty) {
+        // Request: omit a clean saved peer so a header-only edit does not ship it.
+        // Result: always ship an exposed peer so the client can mark it saved.
+        // Skipping result-serialize left the client IsSaved=false; the next Save
+        // re-sent IsNew:true and the server re-INSERTed the same UUID.
+        if (mode !== 'result' && this.instance.IsSaved && !this.instance.Dirty) {
             return null;
         }
-        const companions = await this.instance.SerializeCompanions();
+        const companions = await this.instance.SerializeCompanions(mode);
         return {
             Fields: this.instance.GetAll(),
             IsNew: !this.instance.IsSaved,

--- a/packages/MJCore/src/generic/embeddedRecord.ts
+++ b/packages/MJCore/src/generic/embeddedRecord.ts
@@ -108,11 +108,14 @@ export class EmbeddedRecord<T extends BaseEntity = BaseEntity> extends EntityCom
         if (this.instance || this.constructing) {
             return;
         }
-        // Sibling embeds targeting the same entity (BillToAddress + ShipToAddress)
-        // are not a cycle. ConstructUninitializedEntity does not recurse into
-        // InitializeEmbeddedRecords, so a true construction cycle cannot form here.
-        // The per-companion `constructing` flag still collapses a re-entrant call
-        // on the same companion.
+        // Path-set, not a global set: a sibling targeting the same entity
+        // (BillTo + ShipTo) is not a cycle — InitializeEmbeddedRecords copies
+        // `visited` per sibling so they never see each other in-flight. A
+        // self-FK or A→B→A ancestor is on this path and must stop here, or
+        // ConstructUninitializedEntity's recurse would construct forever.
+        if (visited.has(this.RelatedEntityName)) {
+            return;
+        }
         this.constructing = true;
         visited.add(this.RelatedEntityName);
         try {
@@ -140,12 +143,10 @@ export class EmbeddedRecord<T extends BaseEntity = BaseEntity> extends EntityCom
         if (this.exposed) {
             return this.instance;
         }
-        // After GetEntityObject the instance is constructed but not NewRecord()'d.
-        // NewRecord() is what assigns a client UUID PK, fires the new_record event,
-        // and runs subclass overrides — without it stampOwnerKey has nothing to write.
-        if (!this.instance.IsSaved) {
-            this.instance.NewRecord();
-        }
+        // Always mint a new peer. After Clear()+Save() the leftover instance is
+        // the orphaned row (still IsSaved). Restamping its PK would silently
+        // re-attach it. Re-attachment is an explicit FK set, not Ensure's job.
+        this.instance.NewRecord();
         this.stampOwnerKey();
         this.exposed = true;
         this.cleared = false;
@@ -260,7 +261,7 @@ export class EmbeddedRecord<T extends BaseEntity = BaseEntity> extends EntityCom
     }
 
     /** @inheritdoc */
-    public override async LoadEager(): Promise<void> {
+    public override async LoadEager(visited: Set<string> = new Set<string>()): Promise<void> {
         if (!this.instance) {
             return;
         }
@@ -276,25 +277,39 @@ export class EmbeddedRecord<T extends BaseEntity = BaseEntity> extends EntityCom
             }
             return;
         }
-        // Nested embeds are not constructed with the owner (ConstructUninitializedEntity
-        // does not recurse). Initialise them now so InnerLoad's loadEagerCompanions
-        // walks the inherit tree instead of no-opping on a null instance.
-        await this.instance.InitializeEmbeddedRecords();
-        const loaded = await this.instance.InnerLoad(this.keyFromForeignKey(fk));
-        if (!loaded) {
-            if (this.IsRequired) {
-                throw new Error(
-                    `EmbeddedRecord '${this.Name}' on ${this.Owner.EntityInfo?.Name}: required ` +
-                    `FK ${this.ForeignKeyField}='${fk}' does not resolve to a ${this.RelatedEntityName} row.`,
-                );
-            }
-            this.exposed = false;
-            return;
+        const token = `${this.RelatedEntityName}:${String(fk)}`;
+        if (visited.has(token)) {
+            throw new Error(
+                `EmbeddedRecord '${this.Name}' on ${this.Owner.EntityInfo?.Name}: load cycle at ` +
+                `${token}. A self-parented or mutually-referential embed cannot inherit forever.`,
+            );
         }
-        this.exposed = true;
-        this.cleared = false;
-        if (this.LoadNested === 'related') {
-            await this.instance.LoadRelatedRecords();
+        const next = new Set(visited);
+        next.add(token);
+        // Nested embeds of a different entity were constructed with the owner.
+        // Self-FK / cycle peers stay unconstructed until this load walk; init
+        // them now so InnerLoad's loadEagerCompanions can inherit.
+        await this.instance.InitializeEmbeddedRecords();
+        this.instance.SetEmbeddedLoadVisited(next);
+        try {
+            const loaded = await this.instance.InnerLoad(this.keyFromForeignKey(fk));
+            if (!loaded) {
+                if (this.IsRequired) {
+                    throw new Error(
+                        `EmbeddedRecord '${this.Name}' on ${this.Owner.EntityInfo?.Name}: required ` +
+                        `FK ${this.ForeignKeyField}='${fk}' does not resolve to a ${this.RelatedEntityName} row.`,
+                    );
+                }
+                this.exposed = false;
+                return;
+            }
+            this.exposed = true;
+            this.cleared = false;
+            if (this.LoadNested === 'related') {
+                await this.instance.LoadRelatedRecords();
+            }
+        } finally {
+            this.instance.SetEmbeddedLoadVisited(undefined);
         }
     }
 

--- a/packages/MJCore/src/generic/embeddedRecord.ts
+++ b/packages/MJCore/src/generic/embeddedRecord.ts
@@ -76,7 +76,8 @@ export class EmbeddedRecord<T extends BaseEntity = BaseEntity> extends EntityCom
         super(owner);
         this.ForeignKeyField = options.ForeignKeyField;
         this.RelatedEntityName = options.RelatedEntity;
-        this.Name = `${options.ForeignKeyField}_Object`;
+        const fieldInfo = owner.EntityInfo?.Fields.find(f => f.Name === options.ForeignKeyField);
+        this.Name = `${fieldInfo?.CodeName ?? options.ForeignKeyField}_Object`;
         this.ClearMode = options.OnClear ?? 'orphan';
         this.LoadNested = options.LoadNested ?? 'inherit';
     }

--- a/packages/MJCore/src/generic/entityCompanion.ts
+++ b/packages/MJCore/src/generic/entityCompanion.ts
@@ -251,8 +251,12 @@ export abstract class EntityCompanion<TWire = unknown> {
      * from `LoadFromData()` — that is the row-materialization path for
      * `RunView(ResultType:'entity_object')`, so loading children there turns one view into an N+1
      * storm. Set-oriented eager loading is handled by `RunView`'s batched child loading instead.
+     *
+     * @param _visited - EntityName:PK tokens already on this load walk. Embedded
+     *                   records use it to fail a self-parented / cyclic inherit
+     *                   instead of recursing until the stack dies.
      */
-    public async LoadEager(): Promise<void> {
+    public async LoadEager(_visited?: Set<string>): Promise<void> {
         /* no-op by default */
     }
 

--- a/packages/MJCore/src/generic/entityCompanion.ts
+++ b/packages/MJCore/src/generic/entityCompanion.ts
@@ -137,9 +137,13 @@ export abstract class EntityCompanion<TWire = unknown> {
      * touches only header fields should not ship an empty children array and pay for it on every
      * request.
      *
+     * @param mode - `'request'` (default) is the caller's intent — omit a clean saved
+     *               companion so a header-only edit does not ship it. `'result'` is
+     *               post-save state the client must adopt so the next save does not
+     *               re-INSERT a peer the server already persisted.
      * @returns The wire payload, or `null` to omit this companion.
      */
-    public abstract Serialize(): Promise<TWire | null>;
+    public abstract Serialize(mode?: EntityCompanionDeserializeMode): Promise<TWire | null>;
 
     /**
      * Restores this companion's state from a wire payload produced by {@link Serialize} on the

--- a/packages/MJCore/src/generic/entitySavePlan.ts
+++ b/packages/MJCore/src/generic/entitySavePlan.ts
@@ -245,21 +245,26 @@ export class EntitySavePlan {
 /**
  * Per-node option sets used when executing a plan.
  *
- * The root node needs its own variants carrying the `IsGraphNodeSave` / `IsGraphNodeDelete` flag,
- * which prevents it from re-entering graph planning and bypasses its in-flight save debounce.
- * `BaseEntity` constructs all four, because it already holds the option classes as values —
- * building them here would force a runtime import of `interfaces.ts` and close an import cycle for
- * no benefit.
+ * The root (`SelfOnly`) node must not re-enter `Save()`/`Delete()` — that rebuilds the graph
+ * and deadlocks on the in-flight debounce. `BaseEntity` therefore supplies
+ * {@link SaveSelfOnly} / {@link DeleteSelfOnly}, which call the private graph-node
+ * entry points. Callers outside `BaseEntity` must not invent their own root flag.
  */
 export type EntitySavePlanExecuteOptions = {
-    /** Options for non-root save nodes. */
+    /** Options forwarded to every save node (and to {@link SaveSelfOnly}). */
     SaveOptions?: EntitySaveOptions;
-    /** Options for the root save node — must carry `IsGraphNodeSave: true`. */
-    RootSaveOptions?: EntitySaveOptions;
-    /** Options for non-root delete nodes. */
+    /** Options forwarded to every delete node (and to {@link DeleteSelfOnly}). */
     DeleteOptions?: EntityDeleteOptions;
-    /** Options for the root delete node — must carry `IsGraphNodeDelete: true`. */
-    RootDeleteOptions?: EntityDeleteOptions;
+    /**
+     * Runs the root (`SelfOnly`) save without re-entering graph planning.
+     * `BaseEntity` binds this to its private graph-node entry. When omitted,
+     * the executor falls back to `entity.Save()` (test fakes).
+     */
+    SaveSelfOnly?: (entity: BaseEntity, options?: EntitySaveOptions) => Promise<boolean>;
+    /**
+     * Delete-path counterpart of {@link SaveSelfOnly}.
+     */
+    DeleteSelfOnly?: (entity: BaseEntity, options?: EntityDeleteOptions) => Promise<boolean>;
     /**
      * Keys of the records already being persisted higher up in this unit of work — the cycle guard.
      *
@@ -384,8 +389,8 @@ async function executePlanNode(
         // get the ordinary options, so a child with companions of its own runs its own sub-graph.
         const ok =
             node.Operation === 'Save'
-                ? await node.Entity.Save(node.SelfOnly ? options.RootSaveOptions : options.SaveOptions)
-                : await node.Entity.Delete(node.SelfOnly ? options.RootDeleteOptions : options.DeleteOptions);
+                ? await executeSaveNode(node, options)
+                : await executeDeleteNode(node, options);
 
         if (ok) {
             return { Node: node, Success: true };
@@ -406,4 +411,24 @@ async function executePlanNode(
             ErrorMessage: `${node.Operation} threw for ${node.Label} (${node.Entity.EntityInfo?.Name}): ${detail}`,
         };
     }
+}
+
+async function executeSaveNode(
+    node: EntitySavePlanNode,
+    options: EntitySavePlanExecuteOptions,
+): Promise<boolean> {
+    if (node.SelfOnly && options.SaveSelfOnly) {
+        return options.SaveSelfOnly(node.Entity, options.SaveOptions);
+    }
+    return node.Entity.Save(options.SaveOptions);
+}
+
+async function executeDeleteNode(
+    node: EntitySavePlanNode,
+    options: EntitySavePlanExecuteOptions,
+): Promise<boolean> {
+    if (node.SelfOnly && options.DeleteSelfOnly) {
+        return options.DeleteSelfOnly(node.Entity, options.DeleteOptions);
+    }
+    return node.Entity.Delete(options.DeleteOptions);
 }

--- a/packages/MJCore/src/generic/interfaces.ts
+++ b/packages/MJCore/src/generic/interfaces.ts
@@ -382,8 +382,22 @@ export class EntitySaveOptions {
      * Set only by the graph executor, and only on the **root** node. Child nodes deliberately do
      * not receive it so that a child with companions of its own still builds and runs its own
      * sub-graph — which is how nesting (payment → line → allocation) works.
+     *
+     * **Not a "header-only" switch.** Passing this from application code skips *every* companion,
+     * including owner-held embeds. To persist embeds while leaving related-record collections
+     * for a later write (the booking path: prepare lines, then save the header), use
+     * {@link SkipRelatedCollections} instead.
      */
     IsGraphNodeSave?: boolean = false;
+    /**
+     * Persist owner-held embeds (and other non-collection companions) but skip
+     * {@link RelatedRecordCollection} nodes.
+     *
+     * Use this when the caller will write the collections itself after preparing them
+     * (pricing, expansion, sequence) — not {@link IsGraphNodeSave}, which skips *all*
+     * companions and drops the embeds.
+     */
+    SkipRelatedCollections?: boolean = false;
     /**
      * Cycle guard: keys of the records already being persisted higher up in this unit of work.
      *

--- a/packages/MJCore/src/generic/interfaces.ts
+++ b/packages/MJCore/src/generic/interfaces.ts
@@ -367,35 +367,12 @@ export class EntitySaveOptions {
     ISAActiveChildEntityName?: string;
 
     /**
-     * When true, this `Save()` is the execution of a single node inside an entity save graph that
-     * has already been planned.
-     *
-     * Two things depend on it, and both are load-bearing:
-     *
-     * 1. **Recursion guard.** Without it the root's own node would call `Save()`, which would build
-     *    another plan, which would execute another root node, forever.
-     * 2. **Debounce bypass.** `Save()` returns the in-flight `_pendingSave$` when one exists. The
-     *    root's node runs *inside* that in-flight save, so it would await the promise it is itself
-     *    responsible for resolving — a circular wait that hangs. Mirrors the same bypass
-     *    {@link IsParentEntitySave} performs for IS-A parent chains.
-     *
-     * Set only by the graph executor, and only on the **root** node. Child nodes deliberately do
-     * not receive it so that a child with companions of its own still builds and runs its own
-     * sub-graph — which is how nesting (payment → line → allocation) works.
-     *
-     * **Not a "header-only" switch.** Passing this from application code skips *every* companion,
-     * including owner-held embeds. To persist embeds while leaving related-record collections
-     * for a later write (the booking path: prepare lines, then save the header), use
-     * {@link SkipRelatedCollections} instead.
-     */
-    IsGraphNodeSave?: boolean = false;
-    /**
      * Persist owner-held embeds (and other non-collection companions) but skip
      * {@link RelatedRecordCollection} nodes.
      *
      * Use this when the caller will write the collections itself after preparing them
-     * (pricing, expansion, sequence) — not {@link IsGraphNodeSave}, which skips *all*
-     * companions and drops the embeds.
+     * (pricing, expansion, sequence). The graph executor's recursion guard is private
+     * on {@link BaseEntity} — it is not a caller-facing "header-only" switch.
      */
     SkipRelatedCollections?: boolean = false;
     /**
@@ -457,15 +434,6 @@ export class EntityDeleteOptions {
      */
     IsParentEntityDelete?: boolean = false;
 
-    /**
-     * When true, this `Delete()` is the execution of a single node inside an entity delete graph
-     * that has already been planned.
-     *
-     * Serves the same two purposes as {@link EntitySaveOptions.IsGraphNodeSave} — recursion guard
-     * and debounce bypass — on the delete path. Set only by the graph executor, and only on the
-     * root node.
-     */
-    IsGraphNodeDelete?: boolean = false;
     /**
      * Cycle guard for the delete graph. Delete-path counterpart of
      * {@link EntitySaveOptions.GraphVisited}; see that member for why it is carried on the options.

--- a/packages/MJCore/src/generic/relatedRecordCollection.ts
+++ b/packages/MJCore/src/generic/relatedRecordCollection.ts
@@ -1009,6 +1009,11 @@ export class RelatedRecordCollection<T extends BaseEntity = BaseEntity> extends 
 
     /** @inheritdoc */
     public override ContributeSaveWork(plan: EntitySavePlan, options?: EntitySaveOptions): void {
+        // Caller is writing the collection itself after preparing it (booking, pricing).
+        // Embeds still contribute — this flag is not IsGraphNodeSave.
+        if (options?.SkipRelatedCollections) {
+            return;
+        }
         // A read-only collection is a projection, not a unit of work. Contributing nothing is what
         // makes it safe to point one at an engine's shared cache.
         if (this.IsReadOnly) {

--- a/packages/MJCore/src/generic/relatedRecordCollection.ts
+++ b/packages/MJCore/src/generic/relatedRecordCollection.ts
@@ -29,6 +29,7 @@ import { BaseEngineRegistry } from './baseEngineRegistry';
 import { IsVerboseLoggingEnabled, LogStatus } from './logging';
 import { CompositeKey, KeyValuePair } from './compositeKey';
 import { EntityCompanion, EntityCompanionDeserializeMode } from './entityCompanion';
+import { EmbeddedRecord } from './embeddedRecord';
 import type { EntitySavePlan } from './entitySavePlan';
 import { ValidationErrorInfo, ValidationErrorType, ValidationResult } from './entityInfo';
 import type { EntitySaveOptions, IMetadataProvider, IRunViewProvider } from './interfaces';
@@ -164,6 +165,8 @@ export type RelatedRecordCollectionWireItem = {
      * the server try to load a row that does not exist for every client-created child.
      */
     IsNew: boolean;
+    // Embeds declared on the item itself are intentionally not on this wire.
+    // See packages/MJCore/docs/embedded-records.md § Collection items.
 };
 
 /**
@@ -557,7 +560,7 @@ export class RelatedRecordCollection<T extends BaseEntity = BaseEntity> extends 
     }
 
     /** @inheritdoc */
-    public override async LoadEager(): Promise<void> {
+    public override async LoadEager(_visited?: Set<string>): Promise<void> {
         if (this.LoadMode === 'immediate') {
             await this.Load();
         }
@@ -1111,10 +1114,29 @@ export class RelatedRecordCollection<T extends BaseEntity = BaseEntity> extends 
             return null;
         }
 
+        this.warnIfItemEmbedsOmitted();
+
         return {
             Items: this.items.map(i => ({ Fields: i.GetAll(), IsNew: !i.IsSaved })),
             Removed: this.removed.map(r => this.primaryKeyOf(r)),
         };
+    }
+
+    private warnIfItemEmbedsOmitted(): void {
+        for (const item of this.items) {
+            if (!item.HasCompanions) {
+                continue;
+            }
+            for (const companion of item.Companions) {
+                if (companion instanceof EmbeddedRecord && companion.Dirty) {
+                    LogError(
+                        `RelatedRecordCollection '${this.Name}': item embed '${companion.Name}' is dirty ` +
+                        `but will not ride the GraphQL wire. Save the item as its own root, or persist ` +
+                        `server-side. See packages/MJCore/docs/embedded-records.md § Collection items.`,
+                    );
+                }
+            }
+        }
     }
 
     /** @inheritdoc */

--- a/packages/MJCore/src/generic/relatedRecordCollection.ts
+++ b/packages/MJCore/src/generic/relatedRecordCollection.ts
@@ -1010,7 +1010,7 @@ export class RelatedRecordCollection<T extends BaseEntity = BaseEntity> extends 
     /** @inheritdoc */
     public override ContributeSaveWork(plan: EntitySavePlan, options?: EntitySaveOptions): void {
         // Caller is writing the collection itself after preparing it (booking, pricing).
-        // Embeds still contribute — this flag is not IsGraphNodeSave.
+        // Embeds still contribute — this is not the private graph-node recursion guard.
         if (options?.SkipRelatedCollections) {
             return;
         }

--- a/packages/MJCore/src/generic/saveEntityGraphOperation.ts
+++ b/packages/MJCore/src/generic/saveEntityGraphOperation.ts
@@ -168,7 +168,7 @@ export class SaveEntityGraphOperation extends BaseRemotableOperation<SaveEntityG
         return {
             Success: true,
             Fields: root.GetAll(),
-            Companions: await root.SerializeCompanions(),
+            Companions: await root.SerializeCompanions('result'),
         };
     }
 

--- a/packages/TestingFramework/integration-test-suite/src/__tests__/check-registry.test.ts
+++ b/packages/TestingFramework/integration-test-suite/src/__tests__/check-registry.test.ts
@@ -146,7 +146,7 @@ describe('migrated bundles (coverage-loss guard)', () => {
         ['materialized-entity-read', MaterializedEntityReadChecks, 2], // EMR1-EMR2 entity base-view RunView redirect (IT78)
         ['scoped-anon-elevation', ScopedAnonElevationChecks, 5], // SA1-SA5 scoped-anonymous elevation permission contract (IT68)
         ['entity-graph', EntityGraphChecks, 11], // EG1-EG8 related-record collection graph saves (IT72)
-        ['entity-embedded', EntityEmbeddedChecks, 5], // EE1-EE5 owner-held embedded records
+        ['entity-embedded', EntityEmbeddedChecks, 6], // EE1-EE6 owner-held embedded records
         ['entity-graph-client', EntityGraphClientChecks, 9], // EGC1-EGC9 graph saves over the GraphQL wire (IT73)
         ['task-graph-orchestration', TaskGraphOrchestrationChecks, 18], // TG1-TG18 submission, validation and trigger bindings (IT71)
         // TX1-TX27, the dispatcher actually running graphs (IT74). TX8-TX11 landed with Round 1
@@ -239,7 +239,7 @@ describe('ALL-bundle coverage-loss guard (auto-derived from the registry)', () =
         'conversation-compaction': 12,
         'dataset-cache': 3,
         'entity-actions': 8,
-        'entity-embedded': 5,
+        'entity-embedded': 6,
         'entity-graph': 11,
         'entity-graph-client': 9,
         'entity-server-invariants': 9,
@@ -383,6 +383,7 @@ describe('gated-skip snapshot (a check must not start self-skipping silently)', 
         'entity-embedded.EE3',
         'entity-embedded.EE4',
         'entity-embedded.EE5',
+        'entity-embedded.EE6',
         'entity-graph-client.EGC3',
         'entity-graph-client.EGC4',
         'entity-graph-client.EGC5',

--- a/packages/TestingFramework/integration-test-suite/src/checks/entity-embedded.checks.ts
+++ b/packages/TestingFramework/integration-test-suite/src/checks/entity-embedded.checks.ts
@@ -158,8 +158,10 @@ export const EntityEmbeddedChecks: NamedCheck[] = [
         Fn: async (ctx: IntegrationCheckContext) => {
             const child = await newCategory(ctx, 'ee5-child');
             const parent = child.ParentID_EnsureObject();
-            // Name is required — leave it empty so the peer fails validation/save
-            parent.Name = '';
+            // Name is nvarchar(255) and required. Empty string is a value and
+            // passes validation; a too-long name is what the generated
+            // MaxLength check rejects, so the graph save fails before insert.
+            parent.Name = 'x'.repeat(256);
             parent.Status = 'Active';
 
             const saved = await child.Save();

--- a/packages/TestingFramework/integration-test-suite/src/checks/entity-embedded.checks.ts
+++ b/packages/TestingFramework/integration-test-suite/src/checks/entity-embedded.checks.ts
@@ -1,5 +1,5 @@
 /**
- * entity-embedded.checks.ts — the 'entity-embedded' bundle (EE1–EE5): live-database
+ * entity-embedded.checks.ts — the 'entity-embedded' bundle (EE1–EE6): live-database
  * proof of owner-held embedded records.
  *
  * No production `__mj` field is an honest 1:1 composition (see plans/embedded-records.md
@@ -169,6 +169,29 @@ export const EntityEmbeddedChecks: NamedCheck[] = [
             if (child.ID) {
                 track(child);
             }
+        },
+    },
+    {
+        Id: 'entity-embedded.EE6',
+        Name: 'EE6: Load of a self-parented embed fails cleanly instead of hanging',
+        RequiresMutation: true,
+        Fn: async (ctx: IntegrationCheckContext) => {
+            const cat = await newCategory(ctx, 'ee6-self');
+            Assert(await cat.Save(), `EE6: initial save failed — ${cat.LatestResult?.CompleteMessage}`);
+            track(cat);
+            cat.ParentID = cat.ID;
+            Assert(await cat.Save(), `EE6: self-parent save failed — ${cat.LatestResult?.CompleteMessage}`);
+
+            const again = await ctx.Provider.GetEntityObject<EmbeddedTestCategoryEntity>(CATEGORY_ENTITY, ctx.User);
+            let threw = false;
+            try {
+                await again.Load(cat.ID);
+            } catch (e) {
+                threw = true;
+                const message = e instanceof Error ? e.message : String(e);
+                Assert(/cycle/i.test(message), `EE6: expected a cycle error, got: ${message}`);
+            }
+            Assert(threw, 'EE6: loading a self-parented embed must fail cleanly, not hang');
         },
     },
 ];

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7475,18 +7475,9 @@ importers:
       '@angular/forms':
         specifier: ^21.1.3
         version: 21.1.3(@angular/common@21.1.3(@angular/core@21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0))(rxjs@7.8.2))(@angular/core@21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0))(@angular/platform-browser@21.1.3(@angular/animations@21.1.3(@angular/core@21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0)))(@angular/common@21.1.3(@angular/core@21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0))(rxjs@7.8.2))(@angular/core@21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0)))(rxjs@7.8.2)
-      '@memberjunction/core':
-        specifier: 6.1.0-edge.2
-        version: link:../../../MJCore
-      '@memberjunction/core-entities':
-        specifier: 6.1.0-edge.2
-        version: link:../../../MJCoreEntities
       '@memberjunction/global':
         specifier: 6.1.0-edge.2
         version: link:../../../MJGlobal
-      '@memberjunction/ng-shared':
-        specifier: 6.1.0-edge.2
-        version: link:../../Explorer/shared
       '@memberjunction/ng-ui-components':
         specifier: 6.1.0-edge.2
         version: link:../ui-components


### PR DESCRIPTION
## Summary

Follow-up to #3874 (Embedded Records) after the adversarial review, plus the first real adopter path (bizapps-orders booking).

`IsGraphNodeSave` was an MJ graph-executor flag, not an orders invention. Orders (and anyone else) treated it as a public “header-only” switch. That skipped **every** companion, including owner-held embeds. This PR removes the flag from `EntitySaveOptions` entirely.

The graph executor now calls private `saveAsGraphNode` / `deleteAsGraphNode` on `BaseEntity` via `SaveSelfOnly` / `DeleteSelfOnly` callbacks. There is no public way to opt a `Save()` out of companions. The public booking knob is `SkipRelatedCollections`.

## Review close-out

| Finding | Status |
|---|---|
| Persist-outside-graph / booking dropped embeds | **Fixed** — `SkipRelatedCollections` |
| P0-1 lockfile / d3 | Already shipped in #3881 |
| P0-2 browser re-INSERT | **Fixed** — result serialize always ships an exposed peer |
| P0-3 two embeds, same entity | **Fixed** — per-sibling visited set; no false cycle throw |
| P1 `Ensure()` inversion | **Fixed** — `NewRecord()` when `!IsSaved` |
| P1-3 graph-view d3 UUID | **Fixed** — resolve endpoints with `NormalizeUUID`, skip dangling edges |
| P1-5 failed graph wedges retry | **Fixed** — snapshot + revert saved/dirty after DB rollback |
| P1 stale `cleared` on Load | **Fixed** |
| P1 `NewRecord({ FK })` clobber | **Fixed** |
| P1 CodeGen core-schema import | **Fixed** |
| P1-7 `excludeSchemas` drops `__mj` form tabs | **Fixed** — core schema is kept; default `__mj` exclude no longer hides runtime tabs |
| P2 IT85 never ran | **Fixed** — `runMutationTests` is under `config` |
| P2 EE5 always succeeded | **Fixed** — too-long `Name` |
| P2 wire Deserialize / applyWire / loadExistingThenApply | **Fixed** — request new, request existing, result adopt |
| P2 validation-prefix test could not fail | **Fixed** — asserts a prefixed MaxLength error |
| P2 no mid-graph failure | **Fixed** — header throw + retry re-saves the peer |
| P2 `OnClear: 'delete'` / `'refuse'` | **Fixed** |
| P2 nested `LoadNested: 'inherit'` | **Fixed** — initialize peer embeds before `InnerLoad` |
| P2 generated Zod vs class position / JSONType JSDoc lag | **Not hand-edited** — `entity_subclasses.ts` is CodeGen output; the `@file` source is the truth. Next `mj codegen` aligns them. Hand-editing generated ORM is forbidden. |
| Minor: stale `V202608161200` comment | **Fixed** → `V202608161735` |
| Minor: “insert 12 fields” | **Fixed** → 1 field |
| Minor: transactions-guide nullable FK deref | **Fixed** — uses `EnsureObject()` |
| Minor: changeset omitted packages | **Fixed** — core, codegen-lib, integration-test-suite, ng-graph-view |
| Minor: embed naming used raw `Name` | **Fixed** — CodeGen uses `SafeCodeName`; runtime companion name uses `CodeName` |
| Minor: focal-node dblclick navigates | **Fixed** — `NavigateToEntity` no-ops on the focal node |

## Encapsulation

```ts
// gone from EntitySaveOptions / EntityDeleteOptions
IsGraphNodeSave
IsGraphNodeDelete

// private on BaseEntity — bound only from executeGraphLocal
saveAsGraphNode(options?)  → _InnerSave
deleteAsGraphNode(options?) → _InnerDelete
```

`ExecuteEntitySavePlan` takes `SaveSelfOnly` / `DeleteSelfOnly`. `BaseEntity` is the only caller that binds those to the private methods. Test fakes that omit the callbacks still call `Save()` (they are not `BaseEntity`).

`SkipRelatedCollections` remains the one public option for “persist embeds, I will write the collections myself.”

## Test plan

- [x] `cd packages/MJCore && pnpm test` — **2064 passed**
- [x] `cd packages/CodeGenLib && pnpm test` — **1070 passed**, 66 skipped
- [x] `cd packages/Angular/Generic/graph-view && pnpm run build`
- [ ] `npx mj test run "IT85 - Entity Embedded Records (owner-held 1:1)"` on a migrated DB — EE1–EE5 should **run**, not SKIPPED
- [ ] After merge: bizapps-orders drops `PersistInitialPaymentDetailOutsideGraph` and uses `Save({ SkipRelatedCollections: true })` (already done locally on `feat/payment-detail-embedded`)