### PR TITLE
fix(integration): a partial discovery must not deactivate absent objects

### DIFF
--- a/packages/Integration/engine/src/BaseIntegrationConnector.ts
+++ b/packages/Integration/engine/src/BaseIntegrationConnector.ts
@@ -1078,6 +1078,37 @@ export abstract class BaseIntegrationConnector {
 
         await RunAdaptive(objects, introspectOne, controller);
 
+        // A PARTIAL enumeration is not an authoritative one.
+        //
+        // IsAuthoritative was decided up front, before a single describe ran, and it means exactly
+        // "every object the credentials expose is in this list". But an object whose DiscoverFields
+        // throws is SKIPPED — it never reaches result.Objects — and the causes are routinely
+        // transient: a throttle, a read timeout, a momentary permission blip.
+        //
+        // Downstream, `decideAbsentDeactivations` deactivates every ACTIVE object missing from an
+        // authoritative refresh, because absence is supposed to prove the source dropped it. Leaving
+        // the flag true after skips therefore turns a transient describe failure into a silent
+        // DEACTIVATION of a live entity map — the sync stops for that object and the run stays green.
+        //
+        // Skips are already reported per object; this is the safety consequence of them. Everything
+        // discovered is still returned and still upserted — only the authority to DELETE on absence
+        // is withdrawn, which is the one action that cannot be undone by the next healthy refresh.
+        if (skipped > 0 && result.IsAuthoritative) {
+            result.IsAuthoritative = false;
+            console.warn(
+                `WARNING: IntrospectSchema enumerated ${succeeded}/${total} objects (${skipped} skipped) — ` +
+                `treating this discovery as NON-authoritative so absent objects are not deactivated. ` +
+                `Everything discovered is still applied; re-run once the skipped objects describe cleanly ` +
+                `to restore deactivation.`
+            );
+            console.log(JSON.stringify({
+                ts: new Date().toISOString(),
+                event: 'introspect.authority.withdrawn',
+                reason: 'PARTIAL_ENUMERATION',
+                total, succeeded, skipped,
+            }));
+        }
+
         return result;
     }
 

--- a/packages/Integration/engine/src/__tests__/PartialDiscoveryAuthority.test.ts
+++ b/packages/Integration/engine/src/__tests__/PartialDiscoveryAuthority.test.ts
@@ -1,0 +1,152 @@
+/**
+ * A PARTIAL enumeration must not carry deactivation authority.
+ *
+ * `IntrospectSchema` decides `IsAuthoritative` before a single describe runs — it means "every object
+ * the credentials expose is in this list". But an object whose `DiscoverFields` throws is SKIPPED and
+ * never reaches `result.Objects`, and the causes are routinely transient: a throttle, a read timeout,
+ * a momentary permission blip.
+ *
+ * Downstream, `decideAbsentDeactivations` deactivates every ACTIVE object missing from an
+ * authoritative refresh, because absence is supposed to prove the source dropped it. Leaving the flag
+ * true after skips turns a transient describe failure into a silent DEACTIVATION of a live entity map
+ * — the sync stops for that object and the run stays green.
+ *
+ * Everything discovered is still returned and still upserted; only the authority to deactivate on
+ * absence is withdrawn, because that is the one action a later healthy refresh cannot undo.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import type { UserInfo } from '@memberjunction/core';
+import type { MJCompanyIntegrationEntity } from '@memberjunction/core-entities';
+import {
+    BaseIntegrationConnector,
+    type ExternalObjectSchema,
+    type ExternalFieldSchema,
+    type FetchContext,
+    type FetchBatchResult,
+    type ConnectionTestResult,
+} from '../BaseIntegrationConnector';
+import { decideAbsentDeactivations } from '../IntegrationSchemaSync';
+
+const CI = { ID: 'ci-1', IntegrationID: 'int-1' } as unknown as MJCompanyIntegrationEntity;
+const USER = {} as UserInfo;
+
+/** Affirms authoritative discovery (a connector that really does list everything), and can fail
+ *  DiscoverFields for named objects to simulate a throttle / timeout / permission blip. */
+class AuthoritativeConnector extends BaseIntegrationConnector {
+    public FailFor = new Set<string>();
+    public ObjectNames = ['Alpha', 'Bravo', 'Charlie'];
+
+    public get IntegrationName(): string { return 'Test'; }
+    public override get DiscoveryIsAuthoritative(): boolean { return true; }
+
+    public async TestConnection(): Promise<ConnectionTestResult> { return { Success: true }; }
+    public async FetchChanges(_ctx: FetchContext): Promise<FetchBatchResult> {
+        return { Records: [], HasMore: false };
+    }
+    public async DiscoverObjects(): Promise<ExternalObjectSchema[]> {
+        return this.ObjectNames.map(Name => ({ Name, Label: Name, Fields: [] })) as ExternalObjectSchema[];
+    }
+    public async DiscoverFields(
+        _ci: MJCompanyIntegrationEntity, objectName: string,
+    ): Promise<ExternalFieldSchema[]> {
+        if (this.FailFor.has(objectName)) {
+            throw new Error(`HTTP 429 throttled while describing ${objectName}`);
+        }
+        return [{ Name: 'Id', Label: 'Id', Type: 'string', IsPrimaryKey: true }] as ExternalFieldSchema[];
+    }
+}
+
+describe('IntrospectSchema authority after a partial enumeration', () => {
+    beforeEach(() => {
+        vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+        vi.spyOn(console, 'log').mockImplementation(() => undefined);
+    });
+    afterEach(() => {
+        vi.restoreAllMocks();
+    });
+
+    it('stays authoritative when every object describes cleanly', async () => {
+        const c = new AuthoritativeConnector();
+        const info = await c.IntrospectSchema(CI, USER);
+        expect(info.Objects.map(o => o.ExternalName).sort()).toEqual(['Alpha', 'Bravo', 'Charlie']);
+        expect(info.IsAuthoritative).toBe(true);
+    });
+
+    it('WITHDRAWS authority when any object is skipped', async () => {
+        const c = new AuthoritativeConnector();
+        c.FailFor.add('Bravo');
+        const info = await c.IntrospectSchema(CI, USER);
+
+        // The skipped object is genuinely absent from the result — that part is unchanged.
+        expect(info.Objects.map(o => o.ExternalName).sort()).toEqual(['Alpha', 'Charlie']);
+        // ...which is exactly why the result must no longer be allowed to deactivate on absence.
+        expect(info.IsAuthoritative).toBe(false);
+    });
+
+    it('still returns everything that DID describe — discovery is not abandoned', async () => {
+        const c = new AuthoritativeConnector();
+        c.FailFor.add('Alpha');
+        const info = await c.IntrospectSchema(CI, USER);
+        expect(info.Objects).toHaveLength(2);
+        expect(info.Objects.every(o => o.Fields.length > 0)).toBe(true);
+    });
+
+    it('says so loudly rather than silently downgrading', async () => {
+        const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+        const c = new AuthoritativeConnector();
+        c.FailFor.add('Charlie');
+        await c.IntrospectSchema(CI, USER);
+        const said = warn.mock.calls.map(a => String(a[0])).join('\n');
+        expect(said).toContain('NON-authoritative');
+        expect(said).toContain('not deactivated');
+    });
+
+    it('end-to-end: the skipped object is NOT deactivated', async () => {
+        const c = new AuthoritativeConnector();
+        c.FailFor.add('Bravo');
+        const info = await c.IntrospectSchema(CI, USER);
+
+        // Feed the real decision function the way IntegrationSchemaSync does.
+        const out = decideAbsentDeactivations({
+            DeactivateAbsent: true,
+            IsAuthoritative: info.IsAuthoritative,
+            DiscoveredObjectNames: info.Objects.map(o => o.ExternalName),
+            DiscoveredFieldNamesByObject: {},
+            ActiveObjects: [
+                { ID: 'o-alpha', Name: 'Alpha' },
+                { ID: 'o-bravo', Name: 'Bravo' },
+                { ID: 'o-charlie', Name: 'Charlie' },
+            ],
+            ActiveFieldsByObjectID: {},
+            ObjectIDByName: { Alpha: 'o-alpha', Bravo: 'o-bravo', Charlie: 'o-charlie' },
+        });
+
+        // Before this fix: Bravo was absent from an "authoritative" list, so it was deactivated —
+        // a live entity map turned off by a transient 429, behind a green run.
+        expect(out.ObjectIDsToDeactivate).toEqual([]);
+    });
+
+    it('a clean authoritative refresh still deactivates a genuinely dropped object', async () => {
+        // The guard must not disable deactivation altogether — that would trade one silent failure
+        // for another (stale objects accumulating forever).
+        const c = new AuthoritativeConnector();
+        c.ObjectNames = ['Alpha', 'Charlie'];
+        const info = await c.IntrospectSchema(CI, USER);
+        expect(info.IsAuthoritative).toBe(true);
+
+        const out = decideAbsentDeactivations({
+            DeactivateAbsent: true,
+            IsAuthoritative: info.IsAuthoritative,
+            DiscoveredObjectNames: info.Objects.map(o => o.ExternalName),
+            DiscoveredFieldNamesByObject: {},
+            ActiveObjects: [
+                { ID: 'o-alpha', Name: 'Alpha' },
+                { ID: 'o-bravo', Name: 'Bravo' },
+                { ID: 'o-charlie', Name: 'Charlie' },
+            ],
+            ActiveFieldsByObjectID: {},
+            ObjectIDByName: { Alpha: 'o-alpha', Bravo: 'o-bravo', Charlie: 'o-charlie' },
+        });
+        expect(out.ObjectIDsToDeactivate).toEqual(['o-bravo']);
+    });
+});


### PR DESCRIPTION
## The bug

`IntrospectSchema` decides `IsAuthoritative` **before a single describe runs**:

```ts
const result: SourceSchemaInfo = { Objects: [], IsAuthoritative: this.DiscoveryIsAuthoritative && !wanted };
```

Per its own doc comment, that flag means *"DiscoverObjects hits a real list/describe endpoint that returns EVERYTHING accessible — so an object absent from a refresh genuinely means the source dropped it (and may be deactivated)."*

But an object whose `DiscoverFields` throws is **skipped** and never reaches `result.Objects`:

```ts
} catch (err) {
    console.warn(`WARNING: Skipping object "${obj.Name}" — DiscoverFields failed: ${msg}`);
    ...
    skipped++;
    return { ok: false, throttled: this.ExtractRetryAfterMs(err) !== undefined };
}
```

The flag is never revisited. So the result claims to be a complete enumeration while being demonstrably incomplete — and the code even counts exactly how incomplete it is.

## Why it matters

`decideAbsentDeactivations` deactivates every ACTIVE object missing from an authoritative refresh:

```ts
if (!input.DeactivateAbsent || !input.IsAuthoritative) { /* deactivate nothing */ }
```

That guard is correct and carefully written — it just trusts a flag that has gone stale. The result is that **one 429 while describing one object silently deactivates that object's entity map**: its sync stops, and the run reports success.

The failure modes that produce a skip are all ordinary — a throttle, a read timeout, a momentary permission blip — and this is the one discovery outcome a later healthy refresh cannot undo on its own. Everything else discovery does is additive or idempotent.

## The change

Withdraw authority when anything was skipped, and say so:

```ts
if (skipped > 0 && result.IsAuthoritative) {
    result.IsAuthoritative = false;
    console.warn(`... enumerated ${succeeded}/${total} objects (${skipped} skipped) — treating this
        discovery as NON-authoritative so absent objects are not deactivated ...`);
}
```

Deliberately narrow:

- **Nothing is abandoned.** Every object that *did* describe is still returned and still upserted — adds and updates proceed exactly as before.
- **Only the authority to delete on absence is dropped**, because that is the irreversible one.
- **A clean authoritative refresh still deactivates**, so genuinely dropped objects don't accumulate. The guard doesn't trade one silent failure for another.
- Skips were already reported per object; this is the *safety consequence* of them, plus a structured `introspect.authority.withdrawn` event.

## Tests

`PartialDiscoveryAuthority.test.ts` — 6 added, all passing:

- authority is retained when every object describes cleanly
- authority is **withdrawn** when any object is skipped
- everything that did describe is still returned (discovery isn't abandoned)
- the downgrade is announced rather than silent
- **end-to-end through the real `decideAbsentDeactivations`**: the skipped object is not deactivated (before this fix it was)
- a clean authoritative refresh still deactivates a genuinely dropped object

Full `Integration/engine` suite: **614 passing**. The 13 files that fail to import in a shallow checkout fail identically on unmodified `next` — they need the built workspace.

## Related

Part of a set from a production discovery investigation: #3896 (honour `Retry-After` between fetch attempts — the same throttles that cause these skips), #3897 (an explicit MAX width must survive discovery), #3898 (refuse to write a record with no soft primary key).