### PR TITLE
fix(integration): discovery could not recognise a throttle from any connector

### DIFF
--- a/.changeset/discovery-must-recognise-a-throttle.md
+++ b/.changeset/discovery-must-recognise-a-throttle.md
@@ -2,13 +2,21 @@
 "@memberjunction/integration-engine": minor
 ---
 
-Discovery now recognises a rate limit for connectors that write no rate-limit code — which is all of them.
+Discovery can recognise a rate limit again — its throttle test could never return true.
 
-`IntrospectSchema` fans describes out to 8 concurrent and feeds each outcome to an AIMD controller that cuts the in-flight cap when an item reports `throttled`. It decided `throttled` by asking one question: whether `ExtractRetryAfterMs` returned a value. That method's base implementation returned `undefined` unconditionally, and **no connector in this repo overrides it** — so the answer was "not a throttle" for every 429 MJ has ever received, and the fan-out stayed at 8 straight through the vendor telling it to slow down.
+`IntrospectSchema` fans describes out to 8 concurrent and feeds each outcome to an AIMD controller that cuts the in-flight cap when an item reports `throttled`. It decided that by asking one question:
+
+```ts
+return { ok: false, throttled: this.ExtractRetryAfterMs(err) !== undefined };
+```
+
+and the base `ExtractRetryAfterMs` returned `undefined` unconditionally. So for any connector that did not override it — and for any error an overriding connector could not parse — the expression was `undefined !== undefined`, permanently false. The fan-out stayed at 8 straight through the vendor saying to slow down.
 
 Two changes, both in the base class so every connector inherits them:
 
 - **Classifier fallback.** The throttle test now falls back to `ClassifyError`, which reads the error's own text (`rate limit` / `throttl` / `429`) — the same classifier the sync fetch path already uses for exactly this decision. A connector's parsed value still wins when it has one; this is the floor beneath it. A throttled describe also emits an `introspect.object.throttled` event, so backing off is visible rather than inferred.
-- **`ExtractRetryAfterMs` now reads the standard header by default.** `Retry-After` (RFC 9110 §10.2.3) in both delay-seconds and HTTP-date forms, from headers on the error, on `error.response`, or one level into `error.cause`. Values are bounded at 5 minutes, so a vendor returning a Unix timestamp as delay-seconds can't freeze the token bucket for millennia; anything unusable falls back to the limiter's own decrease. Deliberately not a message-text parser — inventing a delay is worse than having none, so prose signals stay the connector's job.
+- **`ExtractRetryAfterMs` reads the standard header by default.** `Retry-After` (RFC 9110 §10.2.3) in both delay-seconds and HTTP-date forms, from headers on the error, on `error.response`, or one level into `error.cause`. Values are bounded at 5 minutes, so a vendor returning a Unix timestamp as delay-seconds cannot freeze the token bucket for millennia; anything unusable falls back to the limiter's own decrease. Deliberately not a message-text parser — inventing a delay is worse than having none, so prose signals stay the connector's job.
+
+Connectors that already override `ExtractRetryAfterMs` keep their own parsing and are unaffected by the new default; they gain only the classifier floor for errors their parser returns nothing for.
 
 Ordinary describe failures are still not throttles: cutting concurrency on every error would make a permissions problem look like a rate limit.

--- a/.changeset/discovery-must-recognise-a-throttle.md
+++ b/.changeset/discovery-must-recognise-a-throttle.md
@@ -1,0 +1,14 @@
+---
+"@memberjunction/integration-engine": minor
+---
+
+Discovery now recognises a rate limit for connectors that write no rate-limit code — which is all of them.
+
+`IntrospectSchema` fans describes out to 8 concurrent and feeds each outcome to an AIMD controller that cuts the in-flight cap when an item reports `throttled`. It decided `throttled` by asking one question: whether `ExtractRetryAfterMs` returned a value. That method's base implementation returned `undefined` unconditionally, and **no connector in this repo overrides it** — so the answer was "not a throttle" for every 429 MJ has ever received, and the fan-out stayed at 8 straight through the vendor telling it to slow down.
+
+Two changes, both in the base class so every connector inherits them:
+
+- **Classifier fallback.** The throttle test now falls back to `ClassifyError`, which reads the error's own text (`rate limit` / `throttl` / `429`) — the same classifier the sync fetch path already uses for exactly this decision. A connector's parsed value still wins when it has one; this is the floor beneath it. A throttled describe also emits an `introspect.object.throttled` event, so backing off is visible rather than inferred.
+- **`ExtractRetryAfterMs` now reads the standard header by default.** `Retry-After` (RFC 9110 §10.2.3) in both delay-seconds and HTTP-date forms, from headers on the error, on `error.response`, or one level into `error.cause`. Values are bounded at 5 minutes, so a vendor returning a Unix timestamp as delay-seconds can't freeze the token bucket for millennia; anything unusable falls back to the limiter's own decrease. Deliberately not a message-text parser — inventing a delay is worse than having none, so prose signals stay the connector's job.
+
+Ordinary describe failures are still not throttles: cutting concurrency on every error would make a permissions problem look like a rate limit.

--- a/packages/Integration/engine/src/BaseIntegrationConnector.ts
+++ b/packages/Integration/engine/src/BaseIntegrationConnector.ts
@@ -20,6 +20,8 @@ import type {
     ListContext,
     ListResult,
 } from './types.js';
+import { ClassifyError } from './types.js';
+import { ExtractRetryAfterFromError } from './RetryAfter.js';
 import {
     discoverFromStream,
     pickKeyFromStats,
@@ -522,8 +524,25 @@ export abstract class BaseIntegrationConnector {
      * Parse a Retry-After / rate-limit signal out of a failed response or thrown error into
      * milliseconds so the engine can back off precisely. Return `undefined` when the error is not a
      * throttle (or carries no hint).
+     *
+     * The default reads the standard `Retry-After` header (RFC 9110 §10.2.3 — the header a 429 and a
+     * 503 carry), in both its delay-seconds and HTTP-date forms, from wherever the HTTP client put
+     * it. That is not a heuristic and not vendor-specific: there is one correct reading of it, and
+     * every HTTP connector benefits from having it read.
+     *
+     * This used to return `undefined` unconditionally, and no connector in this repo overrode it —
+     * so the engine's limiter never learned a delay any vendor had actually stated, and discovery's
+     * throttle check (which asked this and only this) concluded "not a throttle" for every 429 MJ
+     * ever received.
+     *
+     * Override when the vendor signals its delay somewhere non-standard — in the response body, or
+     * in prose (PheedLoop's "Expected available in N second"). Deliberately not parsed here:
+     * guessing a duration out of message text risks inventing one, and a wrong Retry-After is worse
+     * than none, since it freezes the token bucket for a made-up interval.
      */
-    public ExtractRetryAfterMs(_error: unknown): number | undefined { return undefined; }
+    public ExtractRetryAfterMs(error: unknown): number | undefined {
+        return ExtractRetryAfterFromError(error);
+    }
 
     /**
      * Highest SAFE per-layer concurrency the source tolerates (plan.md §7 peak parallelization) — the
@@ -1079,7 +1098,29 @@ export abstract class BaseIntegrationConnector {
                 // U11 — determinate discovery progress: a skipped object still advances the bar.
                 try { options?.OnProgress?.(succeeded + skipped, total); } catch { /* progress must never break introspection */ }
                 // A real rate-limit failure cuts the in-flight cap (AIMD); a plain describe error does not.
-                return { ok: false, throttled: this.ExtractRetryAfterMs(err) !== undefined };
+                //
+                // `ExtractRetryAfterMs` alone is not enough to make that distinction. Its base
+                // implementation returns `undefined`, and NO connector in this repo overrides it — so
+                // asking only that question answered "not a throttle" for every connector MJ ships, and
+                // discovery kept all 8 describes in flight straight through a vendor's 429s. That is the
+                // shape of a brittle discovery: the source says slow down, the fan-out doesn't, more
+                // objects fail, and the enumeration comes back short for a reason that was transient.
+                //
+                // `ClassifyError` reads the error's own text ('rate limit' / 'throttl' / '429'), which
+                // costs a connector nothing to benefit from — the same classifier the sync fetch path at
+                // IntegrationEngine already uses for exactly this decision. Keep `ExtractRetryAfterMs`
+                // first: a connector that DOES parse the vendor's header gives a precise signal, and this
+                // is a fallback under it, not a replacement for it.
+                const retryAfterMs = this.ExtractRetryAfterMs(err);
+                const throttled = retryAfterMs !== undefined || ClassifyError(err).Code === 'RATE_LIMIT_EXCEEDED';
+                if (throttled) {
+                    console.log(JSON.stringify({
+                        ts: new Date().toISOString(), event: 'introspect.object.throttled',
+                        objectName: obj.Name, total, retryAfterMs: retryAfterMs ?? null,
+                        source: retryAfterMs !== undefined ? 'connector' : 'classifier',
+                    }));
+                }
+                return { ok: false, throttled };
             }
             console.log(JSON.stringify({
                 ts: new Date().toISOString(), event: 'introspect.object.complete',

--- a/packages/Integration/engine/src/BaseIntegrationConnector.ts
+++ b/packages/Integration/engine/src/BaseIntegrationConnector.ts
@@ -20,6 +20,8 @@ import type {
     ListContext,
     ListResult,
 } from './types.js';
+import { ClassifyError } from './types.js';
+import { ExtractRetryAfterFromError } from './RetryAfter.js';
 import {
     discoverFromStream,
     pickKeyFromStats,
@@ -521,8 +523,25 @@ export abstract class BaseIntegrationConnector {
      * Parse a Retry-After / rate-limit signal out of a failed response or thrown error into
      * milliseconds so the engine can back off precisely. Return `undefined` when the error is not a
      * throttle (or carries no hint).
+     *
+     * The default reads the standard `Retry-After` header (RFC 9110 §10.2.3 — the header a 429 and a
+     * 503 carry), in both its delay-seconds and HTTP-date forms, from wherever the HTTP client put
+     * it. That is not a heuristic and not vendor-specific: there is one correct reading of it, and
+     * every HTTP connector benefits from having it read.
+     *
+     * This used to return `undefined` unconditionally, and no connector in this repo overrode it —
+     * so the engine's limiter never learned a delay any vendor had actually stated, and discovery's
+     * throttle check (which asked this and only this) concluded "not a throttle" for every 429 MJ
+     * ever received.
+     *
+     * Override when the vendor signals its delay somewhere non-standard — in the response body, or
+     * in prose (PheedLoop's "Expected available in N second"). Deliberately not parsed here:
+     * guessing a duration out of message text risks inventing one, and a wrong Retry-After is worse
+     * than none, since it freezes the token bucket for a made-up interval.
      */
-    public ExtractRetryAfterMs(_error: unknown): number | undefined { return undefined; }
+    public ExtractRetryAfterMs(error: unknown): number | undefined {
+        return ExtractRetryAfterFromError(error);
+    }
 
     /**
      * Highest SAFE per-layer concurrency the source tolerates (plan.md §7 peak parallelization) — the
@@ -1024,7 +1043,29 @@ export abstract class BaseIntegrationConnector {
                 // U11 — determinate discovery progress: a skipped object still advances the bar.
                 try { options?.OnProgress?.(succeeded + skipped, total); } catch { /* progress must never break introspection */ }
                 // A real rate-limit failure cuts the in-flight cap (AIMD); a plain describe error does not.
-                return { ok: false, throttled: this.ExtractRetryAfterMs(err) !== undefined };
+                //
+                // `ExtractRetryAfterMs` alone is not enough to make that distinction. Its base
+                // implementation returns `undefined`, and NO connector in this repo overrides it — so
+                // asking only that question answered "not a throttle" for every connector MJ ships, and
+                // discovery kept all 8 describes in flight straight through a vendor's 429s. That is the
+                // shape of a brittle discovery: the source says slow down, the fan-out doesn't, more
+                // objects fail, and the enumeration comes back short for a reason that was transient.
+                //
+                // `ClassifyError` reads the error's own text ('rate limit' / 'throttl' / '429'), which
+                // costs a connector nothing to benefit from — the same classifier the sync fetch path at
+                // IntegrationEngine already uses for exactly this decision. Keep `ExtractRetryAfterMs`
+                // first: a connector that DOES parse the vendor's header gives a precise signal, and this
+                // is a fallback under it, not a replacement for it.
+                const retryAfterMs = this.ExtractRetryAfterMs(err);
+                const throttled = retryAfterMs !== undefined || ClassifyError(err).Code === 'RATE_LIMIT_EXCEEDED';
+                if (throttled) {
+                    console.log(JSON.stringify({
+                        ts: new Date().toISOString(), event: 'introspect.object.throttled',
+                        objectName: obj.Name, total, retryAfterMs: retryAfterMs ?? null,
+                        source: retryAfterMs !== undefined ? 'connector' : 'classifier',
+                    }));
+                }
+                return { ok: false, throttled };
             }
             console.log(JSON.stringify({
                 ts: new Date().toISOString(), event: 'introspect.object.complete',

--- a/packages/Integration/engine/src/RetryAfter.ts
+++ b/packages/Integration/engine/src/RetryAfter.ts
@@ -1,0 +1,133 @@
+/**
+ * @fileoverview Standard `Retry-After` extraction, so a connector that writes no rate-limit code
+ * still backs off by the amount the vendor actually asked for.
+ *
+ * `BaseIntegrationConnector.ExtractRetryAfterMs` returned `undefined` unconditionally and no
+ * connector in this repo overrode it. The engine's limiter therefore always fell back to its own
+ * multiplicative decrease — correct in direction, but blind to a number the vendor had already
+ * supplied in the response.
+ *
+ * `Retry-After` is defined by RFC 9110 §10.2.3 and is the header a 429 (RFC 6585) and a 503 carry.
+ * Parsing it is not a heuristic and not vendor-specific, which is exactly why it belongs in the
+ * base class rather than in each connector: there is one correct reading of it, and every HTTP
+ * connector benefits from having it read.
+ *
+ * Deliberately NOT a message-text parser. Guessing a duration out of prose ("try again in a bit")
+ * risks inventing a number, and a wrong Retry-After is worse than none — it would freeze the bucket
+ * for a made-up interval. Text-shaped signals stay the connector's job (see PheedLoop, whose vendor
+ * puts its delay in the body rather than a header); this reads the standard header only.
+ */
+
+/**
+ * Upper bound on an honored `Retry-After`, in milliseconds (5 minutes).
+ *
+ * A vendor occasionally returns an enormous or malformed value — a Unix timestamp mistaken for
+ * delay-seconds, a date years out. Freezing a sync's token bucket for hours on the strength of one
+ * response is a worse failure than backing off by the limiter's own decrease, so anything beyond
+ * this is treated as unusable and the limiter's default applies.
+ */
+export const MAX_HONORED_RETRY_AFTER_MS = 5 * 60_000;
+
+/** Something that might carry HTTP headers, in any of the shapes clients actually produce. */
+type HeaderCarrier = {
+    headers?: unknown;
+    response?: { headers?: unknown; status?: number } | undefined;
+    cause?: unknown;
+    status?: number;
+    statusCode?: number;
+};
+
+/**
+ * Reads one header by name from a `Headers` instance, a `Map`, or a plain object, case-insensitively.
+ * Returns undefined when the container is not one of those or the header is absent.
+ */
+function readHeader(container: unknown, name: string): string | undefined {
+    if (!container || typeof container !== 'object') return undefined;
+
+    // fetch's Headers (and anything else exposing a case-insensitive get)
+    const getter = (container as { get?: unknown }).get;
+    if (typeof getter === 'function') {
+        try {
+            const v = (container as { get(k: string): unknown }).get(name);
+            if (typeof v === 'string' && v.length > 0) return v;
+        } catch { /* not a Headers-like after all */ }
+    }
+
+    // Plain object / axios-style header bag. Node lower-cases response header names, but a hand-built
+    // object may not, so compare case-insensitively rather than trusting the spelling.
+    const target = name.toLowerCase();
+    for (const [k, v] of Object.entries(container as Record<string, unknown>)) {
+        if (k.toLowerCase() !== target) continue;
+        // Node can hand back string[] for a repeated header; the first value is the one that counts.
+        const raw = Array.isArray(v) ? v[0] : v;
+        if (typeof raw === 'string' && raw.length > 0) return raw;
+        if (typeof raw === 'number' && Number.isFinite(raw)) return String(raw);
+    }
+    return undefined;
+}
+
+/**
+ * Parses a `Retry-After` value into milliseconds. RFC 9110 permits two forms:
+ *   - delay-seconds: a non-negative integer, e.g. `120`
+ *   - HTTP-date:     e.g. `Wed, 21 Oct 2015 07:28:00 GMT`
+ *
+ * @param value the raw header value
+ * @param nowMs clock reading used to convert an HTTP-date into a delay; injectable for tests
+ * @returns milliseconds to wait, or undefined when the value is unusable
+ */
+export function ParseRetryAfterValue(value: string | undefined, nowMs: number = Date.now()): number | undefined {
+    if (!value) return undefined;
+    const trimmed = value.trim();
+    if (trimmed.length === 0) return undefined;
+
+    // delay-seconds. Accept only a bare integer: a decimal or anything with trailing junk is not
+    // what the spec defines, and Number() would happily coerce forms that mean something else.
+    if (/^\d+$/.test(trimmed)) {
+        const ms = Number(trimmed) * 1000;
+        return ms > 0 && ms <= MAX_HONORED_RETRY_AFTER_MS ? ms : undefined;
+    }
+
+    // HTTP-date. `Date.parse` is extremely permissive — it happily reads '1.5' as a date and
+    // returns a real timestamp — so gate it on the string actually LOOKING like one first.
+    // Every form RFC 9110 permits (IMF-fixdate, obsolete RFC 850, asctime) carries a three-letter
+    // day or month name AND a digit; the junk that reaches here ('1.5', '30s', '1e3', 'soon')
+    // carries at most one of the two. Falling through to a misparsed date would invent a delay,
+    // which is the one outcome worse than having none.
+    if (!/[A-Za-z]{3}/.test(trimmed) || !/\d/.test(trimmed)) return undefined;
+
+    // A date already in the past means "retry now" — no wait, but also not a parse failure, so it
+    // must not fall through to the limiter's default as though nothing was said.
+    const at = Date.parse(trimmed);
+    if (Number.isNaN(at)) return undefined;
+    const ms = at - nowMs;
+    if (ms <= 0) return 0;
+    return ms <= MAX_HONORED_RETRY_AFTER_MS ? ms : undefined;
+}
+
+/**
+ * Extracts a `Retry-After` delay, in milliseconds, from a thrown error or a failed response.
+ *
+ * Walks the shapes HTTP clients actually throw: the error itself carrying `headers`, an axios-style
+ * `error.response.headers`, and one level of `error.cause` (how a wrapper preserves the original).
+ *
+ * @param error the thrown value
+ * @param nowMs clock reading for HTTP-date conversion; injectable for tests
+ * @returns milliseconds to wait, or undefined when no usable header is present
+ */
+export function ExtractRetryAfterFromError(error: unknown, nowMs: number = Date.now()): number | undefined {
+    if (!error || typeof error !== 'object') return undefined;
+    const e = error as HeaderCarrier;
+
+    const candidates: unknown[] = [
+        e.headers,
+        e.response?.headers,
+        (e.cause as HeaderCarrier | undefined)?.headers,
+        (e.cause as HeaderCarrier | undefined)?.response?.headers,
+    ];
+
+    for (const container of candidates) {
+        const parsed = ParseRetryAfterValue(readHeader(container, 'retry-after'), nowMs);
+        if (parsed !== undefined) return parsed;
+    }
+    return undefined;
+}

--- a/packages/Integration/engine/src/__tests__/DiscoveryThrottleRecognition.test.ts
+++ b/packages/Integration/engine/src/__tests__/DiscoveryThrottleRecognition.test.ts
@@ -1,0 +1,167 @@
+/**
+ * Discovery has to notice a 429 for a connector that wrote no rate-limit code.
+ *
+ * `IntrospectSchema` fans describes out to 8 concurrent by default and feeds each outcome to an
+ * AIMD controller, which cuts the in-flight cap when an item reports `throttled`. That is the
+ * mechanism that makes a discovery survive a vendor's rate limit instead of driving into it.
+ *
+ * It asked exactly one question to decide `throttled`: whether `ExtractRetryAfterMs` returned a
+ * value. The base implementation returned `undefined` unconditionally and NO connector in the repo
+ * overrode it — so the answer was "not a throttle" for every 429 MJ ever received, and the fan-out
+ * stayed at 8 straight through. More describes failed, the enumeration came back short, and it came
+ * back short for a reason that was entirely transient.
+ *
+ * These pin both halves of the fix: the classifier fallback that makes throttles visible without
+ * any connector effort, and the standard `Retry-After` default that makes the back-off precise
+ * when the vendor stated a number.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import type { UserInfo } from '@memberjunction/core';
+import type { MJCompanyIntegrationEntity } from '@memberjunction/core-entities';
+import {
+    BaseIntegrationConnector,
+    type ExternalObjectSchema,
+    type ExternalFieldSchema,
+    type FetchContext,
+    type FetchBatchResult,
+    type ConnectionTestResult,
+} from '../BaseIntegrationConnector';
+
+const CI = { ID: 'ci-1', IntegrationID: 'int-1', Configuration: null } as unknown as MJCompanyIntegrationEntity;
+const USER = {} as UserInfo;
+
+/** A connector that writes no rate-limit code at all — i.e. every connector in this repo. */
+class PlainConnector extends BaseIntegrationConnector {
+    public ThrowFor = new Map<string, Error>();
+    public ObjectNames = ['Alpha', 'Bravo', 'Charlie'];
+
+    public get IntegrationName(): string { return 'Test'; }
+
+    public async TestConnection(): Promise<ConnectionTestResult> { return { Success: true, Message: 'ok' }; }
+    public async FetchChanges(_ctx: FetchContext): Promise<FetchBatchResult> {
+        return { Records: [], HasMore: false };
+    }
+    public async DiscoverObjects(): Promise<ExternalObjectSchema[]> {
+        return this.ObjectNames.map(Name => ({
+            Name, Label: Name, SupportsIncrementalSync: false, SupportsWrite: false,
+        }));
+    }
+    public async DiscoverFields(
+        _ci: MJCompanyIntegrationEntity, objectName: string,
+    ): Promise<ExternalFieldSchema[]> {
+        const err = this.ThrowFor.get(objectName);
+        if (err) throw err;
+        return [{
+            Name: 'Id', Label: 'Id', DataType: 'string',
+            IsRequired: true, IsUniqueKey: true, IsReadOnly: true, IsPrimaryKey: true,
+        }];
+    }
+}
+
+/** Captures the structured events IntrospectSchema logs, so the assertions read real output. */
+function captureEvents(): { events: Record<string, unknown>[]; restore: () => void } {
+    const events: Record<string, unknown>[] = [];
+    const log = vi.spyOn(console, 'log').mockImplementation((...args: unknown[]) => {
+        const first = args[0];
+        if (typeof first !== 'string') return;
+        try {
+            const parsed = JSON.parse(first) as Record<string, unknown>;
+            if (typeof parsed.event === 'string') events.push(parsed);
+        } catch { /* not one of ours */ }
+    });
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+    return { events, restore: () => { log.mockRestore(); warn.mockRestore(); } };
+}
+
+describe('discovery throttle recognition', () => {
+    let cap: ReturnType<typeof captureEvents>;
+
+    beforeEach(() => { cap = captureEvents(); });
+    afterEach(() => { cap.restore(); vi.restoreAllMocks(); });
+
+    it('recognises a 429 from the error TEXT, with no connector support whatsoever', () => {
+        // Before the fix this object was skipped as an ordinary describe failure and the fan-out
+        // never backed off.
+        const c = new PlainConnector();
+        c.ThrowFor.set('Bravo', new Error('Request failed with status code 429'));
+
+        return c.IntrospectSchema(CI, USER).then(() => {
+            const throttles = cap.events.filter(e => e.event === 'introspect.object.throttled');
+            expect(throttles.length).toBe(1);
+            expect(throttles[0].objectName).toBe('Bravo');
+            expect(throttles[0].source).toBe('classifier');
+        });
+    });
+
+    it('recognises the other phrasings a vendor uses', async () => {
+        for (const message of ['Rate limit exceeded', 'You are being throttled', 'HTTP 429 Too Many Requests']) {
+            cap.restore();
+            cap = captureEvents();
+            const c = new PlainConnector();
+            c.ThrowFor.set('Alpha', new Error(message));
+
+            await c.IntrospectSchema(CI, USER);
+
+            expect(
+                cap.events.some(e => e.event === 'introspect.object.throttled'),
+                `"${message}" should read as a throttle`,
+            ).toBe(true);
+        }
+    });
+
+    it('does NOT treat an ordinary describe failure as a throttle', () => {
+        // The distinction is the whole point — cutting concurrency on every error would make a
+        // permission problem look like a rate limit and slow the discovery down for nothing.
+        const c = new PlainConnector();
+        c.ThrowFor.set('Bravo', new Error('Object Bravo: insufficient privileges'));
+
+        return c.IntrospectSchema(CI, USER).then(() => {
+            expect(cap.events.some(e => e.event === 'introspect.object.throttled')).toBe(false);
+            // ...but it IS still recorded as a skip.
+            expect(cap.events.some(e => e.event === 'introspect.object.skipped')).toBe(true);
+        });
+    });
+
+    it('prefers the connector’s parsed Retry-After over the classifier when both apply', async () => {
+        // A connector that DOES parse the vendor's signal gives a precise number; the classifier is
+        // the floor beneath it, not a replacement for it.
+        class PreciseConnector extends PlainConnector {
+            public override ExtractRetryAfterMs(_error: unknown): number | undefined { return 4_000; }
+        }
+        const c = new PreciseConnector();
+        c.ThrowFor.set('Charlie', new Error('slow down please'));   // text the classifier would NOT match
+
+        await c.IntrospectSchema(CI, USER);
+
+        const throttles = cap.events.filter(e => e.event === 'introspect.object.throttled');
+        expect(throttles.length).toBe(1);
+        expect(throttles[0].source).toBe('connector');
+        expect(throttles[0].retryAfterMs).toBe(4_000);
+    });
+
+    it('reads a standard Retry-After header with no connector override at all', async () => {
+        // The base ExtractRetryAfterMs now parses RFC 9110's header, so an HTTP connector that
+        // simply lets its client's error propagate gets a precise back-off for free.
+        const c = new PlainConnector();
+        const err = Object.assign(new Error('Request failed with status code 429'), {
+            response: { status: 429, headers: { 'retry-after': '30' } },
+        });
+        c.ThrowFor.set('Alpha', err);
+
+        await c.IntrospectSchema(CI, USER);
+
+        const throttles = cap.events.filter(e => e.event === 'introspect.object.throttled');
+        expect(throttles.length).toBe(1);
+        expect(throttles[0].source).toBe('connector');
+        expect(throttles[0].retryAfterMs).toBe(30_000);
+    });
+
+    it('still returns everything that DID describe — a throttle is not an abandoned discovery', async () => {
+        const c = new PlainConnector();
+        c.ThrowFor.set('Bravo', new Error('429 rate limit'));
+
+        const info = await c.IntrospectSchema(CI, USER);
+
+        expect(info.Objects.map(o => o.ExternalName).sort()).toEqual(['Alpha', 'Charlie']);
+    });
+});

--- a/packages/Integration/engine/src/__tests__/RetryAfter.test.ts
+++ b/packages/Integration/engine/src/__tests__/RetryAfter.test.ts
@@ -1,0 +1,149 @@
+/**
+ * `Retry-After` parsing. RFC 9110 §10.2.3 defines exactly two forms — delay-seconds and HTTP-date —
+ * and this reads both from wherever an HTTP client put the headers.
+ *
+ * The bound matters as much as the parsing. A vendor occasionally returns something unusable (a
+ * Unix timestamp mistaken for delay-seconds, a date years out), and honouring it would freeze a
+ * sync's token bucket for hours on the strength of one response. Anything past the cap is treated
+ * as absent so the limiter's own multiplicative decrease applies instead — a worse number is worse
+ * than no number.
+ */
+import { describe, it, expect } from 'vitest';
+import {
+    ParseRetryAfterValue,
+    ExtractRetryAfterFromError,
+    MAX_HONORED_RETRY_AFTER_MS,
+} from '../RetryAfter';
+
+const NOW = Date.parse('2026-08-17T12:00:00Z');
+
+describe('ParseRetryAfterValue', () => {
+    describe('delay-seconds', () => {
+        it('converts whole seconds to milliseconds', () => {
+            expect(ParseRetryAfterValue('30', NOW)).toBe(30_000);
+            expect(ParseRetryAfterValue('1', NOW)).toBe(1_000);
+        });
+
+        it('tolerates surrounding whitespace', () => {
+            expect(ParseRetryAfterValue('  15  ', NOW)).toBe(15_000);
+        });
+
+        it('rejects anything that is not a bare integer', () => {
+            // Number() would coerce several of these into a plausible-looking value, which is
+            // precisely the risk: a silently wrong delay is worse than no delay.
+            for (const bad of ['1.5', '30s', 'soon', '-5', '1e3', '', '  ']) {
+                expect(ParseRetryAfterValue(bad, NOW), `"${bad}" must not parse`).toBeUndefined();
+            }
+        });
+
+        it('rejects zero — nothing to wait for is not a wait instruction', () => {
+            expect(ParseRetryAfterValue('0', NOW)).toBeUndefined();
+        });
+    });
+
+    describe('HTTP-date', () => {
+        it('converts a future date to a delay', () => {
+            expect(ParseRetryAfterValue('Mon, 17 Aug 2026 12:00:45 GMT', NOW)).toBe(45_000);
+        });
+
+        it('returns 0 for a date already past — "retry now", not a parse failure', () => {
+            // Distinct from undefined: the vendor DID answer, and the answer was "go ahead".
+            expect(ParseRetryAfterValue('Mon, 17 Aug 2026 11:59:00 GMT', NOW)).toBe(0);
+        });
+
+        it('rejects an unparseable date', () => {
+            expect(ParseRetryAfterValue('next tuesday', NOW)).toBeUndefined();
+        });
+
+        it('accepts the obsolete forms RFC 9110 still requires recipients to read', () => {
+            // RFC 850 and asctime. No server sends these for Retry-After in practice, but the
+            // date-shape gate must not be the reason they fail.
+            expect(ParseRetryAfterValue('Monday, 17-Aug-26 12:00:30 GMT', NOW)).toBe(30_000);
+            expect(ParseRetryAfterValue('Mon Aug 17 12:00:30 2026', Date.parse('2026-08-17T12:00:00'))).toBe(30_000);
+        });
+    });
+
+    describe('the sanity bound', () => {
+        it('accepts a value at the cap', () => {
+            expect(ParseRetryAfterValue(String(MAX_HONORED_RETRY_AFTER_MS / 1000), NOW)).toBe(MAX_HONORED_RETRY_AFTER_MS);
+        });
+
+        it('refuses a value past the cap rather than freezing the bucket', () => {
+            expect(ParseRetryAfterValue(String(MAX_HONORED_RETRY_AFTER_MS / 1000 + 1), NOW)).toBeUndefined();
+        });
+
+        it('refuses a Unix timestamp sent as delay-seconds', () => {
+            // A real vendor bug, and the reason the cap exists: honouring this would stall the
+            // connection for ~55,000 years.
+            expect(ParseRetryAfterValue('1786000000', NOW)).toBeUndefined();
+        });
+
+        it('refuses an absurd future date', () => {
+            expect(ParseRetryAfterValue('Fri, 17 Aug 2035 12:00:00 GMT', NOW)).toBeUndefined();
+        });
+    });
+
+    it('returns undefined for a missing value', () => {
+        expect(ParseRetryAfterValue(undefined, NOW)).toBeUndefined();
+    });
+});
+
+describe('ExtractRetryAfterFromError', () => {
+    it('reads headers hung directly off the error', () => {
+        const err = Object.assign(new Error('429'), { headers: { 'retry-after': '12' } });
+        expect(ExtractRetryAfterFromError(err, NOW)).toBe(12_000);
+    });
+
+    it('reads an axios-style error.response.headers', () => {
+        const err = Object.assign(new Error('Request failed with status code 429'), {
+            response: { status: 429, headers: { 'retry-after': '20' } },
+        });
+        expect(ExtractRetryAfterFromError(err, NOW)).toBe(20_000);
+    });
+
+    it('reads a fetch Headers instance via its case-insensitive get()', () => {
+        const headers = new Headers({ 'Retry-After': '7' });
+        const err = Object.assign(new Error('429'), { response: { status: 429, headers } });
+        expect(ExtractRetryAfterFromError(err, NOW)).toBe(7_000);
+    });
+
+    it('matches the header name case-insensitively on a plain object', () => {
+        const err = Object.assign(new Error('429'), { headers: { 'Retry-After': '9' } });
+        expect(ExtractRetryAfterFromError(err, NOW)).toBe(9_000);
+    });
+
+    it('takes the first value when a client hands back a repeated header as an array', () => {
+        const err = Object.assign(new Error('429'), { headers: { 'retry-after': ['11', '99'] } });
+        expect(ExtractRetryAfterFromError(err, NOW)).toBe(11_000);
+    });
+
+    it('accepts a numeric header value', () => {
+        const err = Object.assign(new Error('429'), { headers: { 'retry-after': 5 } });
+        expect(ExtractRetryAfterFromError(err, NOW)).toBe(5_000);
+    });
+
+    it('looks one level into error.cause, where a wrapper keeps the original', () => {
+        const inner = Object.assign(new Error('429'), { response: { headers: { 'retry-after': '3' } } });
+        const err = Object.assign(new Error('fetch failed'), { cause: inner });
+        expect(ExtractRetryAfterFromError(err, NOW)).toBe(3_000);
+    });
+
+    it('skips a header container that carries an unusable value and keeps looking', () => {
+        const err = Object.assign(new Error('429'), {
+            headers: { 'retry-after': 'whenever' },
+            response: { headers: { 'retry-after': '8' } },
+        });
+        expect(ExtractRetryAfterFromError(err, NOW)).toBe(8_000);
+    });
+
+    it('returns undefined when nothing carries the header', () => {
+        expect(ExtractRetryAfterFromError(new Error('429 too many requests'), NOW)).toBeUndefined();
+        expect(ExtractRetryAfterFromError(Object.assign(new Error('x'), { response: { status: 500 } }), NOW)).toBeUndefined();
+    });
+
+    it('returns undefined for non-object throws rather than guessing', () => {
+        expect(ExtractRetryAfterFromError('429', NOW)).toBeUndefined();
+        expect(ExtractRetryAfterFromError(null, NOW)).toBeUndefined();
+        expect(ExtractRetryAfterFromError(undefined, NOW)).toBeUndefined();
+    });
+});

--- a/packages/Integration/engine/src/index.ts
+++ b/packages/Integration/engine/src/index.ts
@@ -49,6 +49,9 @@ export type {
 
 // Error classification helpers
 export { IsRetryableError, ClassifyError } from './types.js';
+// Standard Retry-After extraction — exported so a connector overriding ExtractRetryAfterMs for a
+// non-standard vendor signal can still fall back to the header when the vendor sends one.
+export { ExtractRetryAfterFromError, ParseRetryAfterValue, MAX_HONORED_RETRY_AFTER_MS } from './RetryAfter.js';
 
 // Transforms
 export type {


### PR DESCRIPTION
## The bug

`IntrospectSchema` fans describes out to 8 concurrent and feeds every outcome to an AIMD controller that cuts the in-flight cap when an item reports `throttled`. That's the mechanism that lets a discovery survive a vendor's rate limit instead of driving straight into it.

It decided `throttled` by asking exactly one question:

```ts
// A real rate-limit failure cuts the in-flight cap (AIMD); a plain describe error does not.
return { ok: false, throttled: this.ExtractRetryAfterMs(err) !== undefined };
```

And the base implementation is:

```ts
public ExtractRetryAfterMs(_error: unknown): number | undefined { return undefined; }
```

**No connector in this repo overrides it.** (`grep -rn "ExtractRetryAfterMs" packages/Integration` — the only non-test hits are the declaration, this call site, and one in `IntegrationEngine`.)

So the answer was **"not a throttle" for every 429 MJ has ever received.** The source says slow down; the fan-out stays at 8; more describes fail; and the enumeration comes back short for a reason that was entirely transient.

This is the shape of what gets reported as *"discovery takes forever and things go wrong."* It also compounds with **#3903** — a short enumeration used to keep full authority to switch absent objects off.

## Two changes, both in the base class

### 1. The throttle test falls back to the classifier

```ts
const retryAfterMs = this.ExtractRetryAfterMs(err);
const throttled = retryAfterMs !== undefined || ClassifyError(err).Code === 'RATE_LIMIT_EXCEEDED';
```

`ClassifyError` reads the error's own text (`rate limit` / `throttl` / `429`) and costs a connector nothing to benefit from — it's the same classifier the **sync fetch path already uses for exactly this decision** (`IntegrationEngine.ts`, in the `FetchChanges` catch). Discovery was the odd one out.

A connector that *does* parse the vendor's signal still wins; this is the floor beneath it, not a replacement.

A throttled describe now emits `introspect.object.throttled` naming whether the signal came from the connector or the classifier — so backing off is observable, rather than inferred from a slowdown.

### 2. `ExtractRetryAfterMs` reads the standard header by default

`Retry-After` (RFC 9110 §10.2.3 — the header a 429 and a 503 carry), in both its delay-seconds and HTTP-date forms, from headers on the error, on `error.response`, or one level into `error.cause`. That's not a heuristic and not vendor-specific: there is one correct reading of it, and every HTTP connector benefits from having it read.

**Bounded at 5 minutes.** A vendor occasionally returns a Unix timestamp as delay-seconds, and honouring that would freeze the token bucket for ~55,000 years. Past the bound the value is treated as absent so the limiter's own multiplicative decrease applies.

Same reasoning gates the date branch: `Date.parse` is permissive enough to read `'1.5'` as a date and hand back a real timestamp, so the string has to *look* like a date before it's trusted. **A wrong Retry-After is worse than none** — it freezes the bucket for a made-up interval.

Deliberately **not** a message-text parser. Guessing a duration out of prose risks inventing one; vendors that put their delay in the body (PheedLoop's `"Expected available in N second"`) stay a connector override.

## What doesn't change

An ordinary describe failure is still not a throttle. Cutting concurrency on every error would make a permissions problem look like a rate limit and slow a healthy discovery down for nothing — there's a test pinning that.

## Tests

**23** for `Retry-After` parsing: both RFC forms, the obsolete forms recipients are still required to read, every header shape a client produces (`Headers`, axios bag, repeated-header array, numeric value, `error.cause`), the sanity bound, and each way a malformed value must fail closed.

**6** driving the real `IntrospectSchema` against a connector with no rate-limit code at all — asserting a text-only 429 is recognised, an ordinary failure is not, a connector's own value takes precedence, a plain header is honoured with no override, and a throttled discovery still returns everything that did describe.

Full Integration engine suite: **48 files, 729 tests, 0 failures.**

## Related

Direct companion to **#3903** (a partial discovery must not deactivate absent objects) — that one stops a short enumeration from doing damage; this one stops it being short in the first place.

Also **#3896** (honour Retry-After between fetch retry attempts), which fixed the same blindness on the retry loop.
