### PR TITLE
Multi-agent rooms: gating that holds, and seats that can be quiet, silenced, human-held, and in character

### DIFF
--- a/.changeset/multi-party-room-capabilities.md
+++ b/.changeset/multi-party-room-capabilities.md
@@ -1,0 +1,64 @@
+---
+"@memberjunction/ai-agents": minor
+"@memberjunction/ai-bridge-server": minor
+"@memberjunction/livekit-room-server": minor
+"@memberjunction/server": minor
+"@memberjunction/graphql-dataprovider": minor
+---
+
+Multi-agent rooms: gating that actually holds, and seats that can be quiet, silenced, human-held, and in character
+
+The room layer already put N agents in one LiveKit room and arbitrated a floor between them. Five
+gaps kept that from being usable by a consumer whose agents are configured characters rather than
+one generic assistant. All five were found building a panel interview on it.
+
+**A room whose FIRST agent cannot reconfigure a live socket is now re-gated by reconnecting it.**
+`ReconfigureSessionToMeeting` previously logged and gave up when the provider fixed its turn config
+at connect (Gemini), leaving that agent auto-responding to all room audio, bypassing the moderator
+and talking over the cast — the code's own comment named the fix. `EnsureSessionMeetingGated` now
+mints a replacement session in meeting mode, swaps it onto the same `AIAgentSessionBridge` row and
+`AIAgentSession`, re-wires the transport and turn seams, and closes the old socket in a `finally`.
+Room membership, scribe election and attribution survive; the reopened leg starts a fresh co-agent
+run under the same agent session. Outbound frames are dropped while a reopen is in flight (an
+un-gated agent must not keep talking through its own reconnect), concurrent callers share one
+promise, and attempts are capped — at the limit the agent keeps its original socket, because a
+degraded seat beats a dead one.
+
+**The effective turn state is now readable.** `GetEffectiveTurnState`, plus `MeetingGated` /
+`CanReconfigureTurnMode` on the room-start result. Whether a room is properly gated was previously
+observable only by listening to it.
+
+**`ParticipationMode` is per-agent.** It was hard-coded `'proactive'` for every agent, with a
+comment acknowledging per-agent resolution as a follow-up, so a room could not have a deliberately
+quiet seat — an observer, or a specialist who answers only when called on. An explicitly
+`addressed-only` agent is now gated even when it is alone in the room, rather than auto-responding
+until a second agent happens to arrive.
+
+**An agent can be silenced without being killed.** `SuspendBridgeAgent` / `ResumeBridgeAgent` stop
+an agent responding and publishing while keeping its socket, session, transcript persistence and
+observability run — the previous only option was `StopBridgeSession`, which tears all of that down.
+Suspension holds at three points because the moderator drain bypasses the turn policy: the outbound
+seam, the speak trigger, and the room roster. Prior state is captured and restored verbatim rather
+than guessed.
+
+**A human can hold the floor.** `MultiAgentRoomCoordinator` keyed membership on `AgentSessionID`
+only, so a human participant could never be granted the floor and agents had no structural reason
+to yield. Floor membership is now a participant reference — agent session or user — with every
+existing string caller still compiling and behaving identically. A human's claim always wins
+(`HumanOverride`: the coordinator cannot mute a person) and agents yield to `HeldByHuman`,
+facilitator included. `IsMultiAgentRoom` still counts agents only, so one agent plus one human stays
+a 1:1 call rather than being re-gated into a meeting.
+
+**A bridged seat can be given per-session instructions.** Neither `BridgeRealtimeSessionContext` nor
+`RealtimeSessionStartContext` could carry them, so a bridged agent's prompt came from its agent
+record alone: two agents in a room could be given distinct *voices* but not distinct *characters*.
+`Instructions` now threads from `StartLiveKitAgentRoomSessionInput` through to
+`buildCompanionSystemPrompt`, **appended** to the companion prompt exactly as the client-direct
+subclass seam composes it, so framework framing and safety text survive. It rides the reopen closure
+above, so a re-gated seat comes back as the same character instead of silently becoming someone
+else mid-meeting. Gated behind `Realtime: Advanced Session Controls` — caller-supplied text appended
+to a system prompt is strictly more prompt influence than the `configOverridesJson` that gate
+already protects — and the check is extracted rather than copied, because two copies of a
+fail-closed gate must agree on which direction they fail in.
+
+All additive: every omitted field behaves exactly as before.

--- a/.changeset/multi-party-roster-and-native-dep.md
+++ b/.changeset/multi-party-roster-and-native-dep.md
@@ -3,23 +3,40 @@
 "@memberjunction/ai-bridge-livekit": patch
 ---
 
-Multi-agent rooms: an agent is recorded as an agent, and the native room client can actually be installed
+Multi-agent rooms: every other agent in the room was recorded as a human
 
-Both found by running a real two-agent LiveKit room rather than by reading the code.
+Found by running a real two-agent LiveKit room rather than by reading the code, and confirmed
+against the persisted rows.
 
-**No participant row in a multi-agent room was ever flagged as an agent.** `upsertParticipants`
-recomputed `IsAgent` as "is this MY bot", discarding the driver's answer, on the reasoning that
-diarization could OR-reduce across the room because "each agent's OWN bridge marks itself". That
-premise is false: a roster comes from `room.remoteParticipants`, and a participant is never in its
-own remote list, so a bridge's own bot never appears in its own roster. Measured on a live
-two-agent room: **zero** rows had `IsAgent` set, so per-turn diarization could not tell an agent
-from a human anywhere in a panel. The engine now trusts the driver's `IsAgent`, which already means
-"is this identity an agent" — the local bot or any bot by identity convention. That is also the
-question a consumer actually asks: whether a speaker is an agent is a property of the identity, not
-of which bridge happened to observe it.
+**The shared false premise.** `IsLocal` identifies only a bridge's OWN bot, and an SFU never lists
+a participant in its own remote roster — so in a multi-agent room `IsLocal` is false for every agent
+a bridge can actually *see*. Measured: bridge `53C6…` owns agent session `779F…`, and its one roster
+row is `agent-03E2…` — the OTHER bridge's bot. A bridge's own bot never appears in its own roster,
+so anything deriving agent-ness from `IsLocal` answers "human" for the entire rest of the panel.
 
-**`@memberjunction/ai-bridge-livekit` could not load the native room client it documents.** It
-imports `@memberjunction/ai-bridge-livekit-native` dynamically but never declared it, so under
-pnpm's strict isolation the import resolves from the provider's own location and fails there — no
-host can satisfy the error message the provider itself prints, because installing the package
-alongside the *host* does not put it where the *provider* looks. Declared as an optional dependency.
+Three places had derived it that way:
+
+- `upsertParticipants` recomputed `IsAgent` as "is this MY bot", discarding the driver's answer, on
+  the reasoning that diarization could OR-reduce across the room because "each agent's OWN bridge
+  marks itself". Measured on a live two-agent room: **zero** rows had `IsAgent` set, so per-turn
+  diarization could not tell an agent from a human anywhere in a panel. The engine now trusts the
+  driver's `IsAgent`, which already means "is this identity an agent".
+- `mapParticipantRole` returned `'Agent'` only for `IsLocal`, so remote agents persisted as
+  `Role = 'Participant'` — a row asserting `IsAgent = true` and `Role = 'Participant'` about the same
+  participant, leaving consumers to pick a half to believe. This sat one line above the identity
+  convention that already existed to fix exactly this, and whose own doc comment describes the bug.
+- The Meeting Controls roster (`toMeetingParticipant`) applied no identity check at all, so the Meet
+  UI's participant list showed every other agent in the room as a person.
+
+Agent-ness is a property of the IDENTITY, not of which bridge observed it. It is now decided once,
+in `IsAgentParticipant`, and both roster mappers derive `IsAgent` **and** `Role` from that single
+answer — so the two fields on a row can no longer disagree.
+
+**Loading the native room client is now explained where it fails.** `@memberjunction/ai-bridge-livekit`
+imports `@memberjunction/ai-bridge-livekit-native` dynamically and cannot declare it:
+the native package depends on this one, so declaring it back is a dependency cycle (turbo rejects the
+graph outright). The load therefore resolves from the *provider's* location, and installing the
+wrapper alongside the **host** does not put it where the provider looks — which is what the previous
+error message told operators to do. The existing `LIVEKIT_NATIVE_MODULE` env override is the
+supported lever; the error now names it, says an absolute path is required under a strict-isolation
+installer such as pnpm, and states why the dependency is deliberately undeclared.

--- a/.changeset/multi-party-roster-and-native-dep.md
+++ b/.changeset/multi-party-roster-and-native-dep.md
@@ -1,0 +1,25 @@
+---
+"@memberjunction/ai-bridge-server": patch
+"@memberjunction/ai-bridge-livekit": patch
+---
+
+Multi-agent rooms: an agent is recorded as an agent, and the native room client can actually be installed
+
+Both found by running a real two-agent LiveKit room rather than by reading the code.
+
+**No participant row in a multi-agent room was ever flagged as an agent.** `upsertParticipants`
+recomputed `IsAgent` as "is this MY bot", discarding the driver's answer, on the reasoning that
+diarization could OR-reduce across the room because "each agent's OWN bridge marks itself". That
+premise is false: a roster comes from `room.remoteParticipants`, and a participant is never in its
+own remote list, so a bridge's own bot never appears in its own roster. Measured on a live
+two-agent room: **zero** rows had `IsAgent` set, so per-turn diarization could not tell an agent
+from a human anywhere in a panel. The engine now trusts the driver's `IsAgent`, which already means
+"is this identity an agent" — the local bot or any bot by identity convention. That is also the
+question a consumer actually asks: whether a speaker is an agent is a property of the identity, not
+of which bridge happened to observe it.
+
+**`@memberjunction/ai-bridge-livekit` could not load the native room client it documents.** It
+imports `@memberjunction/ai-bridge-livekit-native` dynamically but never declared it, so under
+pnpm's strict isolation the import resolves from the provider's own location and fails there — no
+host can satisfy the error message the provider itself prints, because installing the package
+alongside the *host* does not put it where the *provider* looks. Declared as an optional dependency.

--- a/.changeset/realtime-room-mode-query.md
+++ b/.changeset/realtime-room-mode-query.md
@@ -1,0 +1,18 @@
+---
+"@memberjunction/ai-bridge-server": patch
+"@memberjunction/server": patch
+---
+
+Ask the server whether multi-agent rooms actually take turns
+
+`MJ_REALTIME_MODERATOR_MODE` is off by default, and with it off a multi-agent room is a free-for-all:
+every agent hears everything and decides for itself when to speak, including in response to the other
+agents. Reasonable for a webinar, crosstalk for anything structured — and **nothing at the API surface
+said which one you had**. Every mutation succeeds identically either way, so a deployment that never
+set the variable, or mistyped it, found out by listening.
+
+Adds `RealtimeRoomMode { ModeratorMode }` and the `AIBridgeEngine.HasTurnModerator` accessor behind it.
+It reports the **effective** state — whether a turn moderator is actually bound — rather than echoing
+the environment variable, so a typo reads as off instead of reading as what was intended. Authenticated,
+since it describes server configuration; not otherwise gated, being one boolean about how rooms behave
+that any client able to start one already needs.

--- a/packages/AI/Agents/src/__tests__/bridge-realtime-session-factory.test.ts
+++ b/packages/AI/Agents/src/__tests__/bridge-realtime-session-factory.test.ts
@@ -98,6 +98,43 @@ describe('CreateBridgeRealtimeSession', () => {
         expect(lastStartParams?.conversationMessages).toEqual([]);
     });
 
+    it('threads Instructions into params.data.realtimeInstructions (trimmed)', async () => {
+        await CreateBridgeRealtimeSession({
+            AgentID: 'AAAA0000-0000-0000-0000-000000000001',
+            Instructions: '  You are Dr. Chen, a skeptical CFO.  ',
+        });
+        const data = lastStartParams?.data as Record<string, unknown>;
+        expect(data.realtimeInstructions).toBe('You are Dr. Chen, a skeptical CFO.');
+    });
+
+    it('omits realtimeInstructions entirely when none are supplied (data stays absent for a plain start)', async () => {
+        await CreateBridgeRealtimeSession({ AgentID: 'AAAA0000-0000-0000-0000-000000000001' });
+        expect(lastStartParams?.data).toBeUndefined();
+    });
+
+    it('omits realtimeInstructions for a whitespace-only value (never an empty prompt section)', async () => {
+        await CreateBridgeRealtimeSession({ AgentID: 'AAAA0000-0000-0000-0000-000000000001', Instructions: '   \n ' });
+        expect(lastStartParams?.data).toBeUndefined();
+    });
+
+    it('carries Instructions alongside the other realtime extras without disturbing them', async () => {
+        await CreateBridgeRealtimeSession({
+            AgentID: 'AAAA0000-0000-0000-0000-000000000001',
+            TargetAgentID: 'target-1',
+            RealtimeVoice: 'echo',
+            MeetingMode: true,
+            SelfNames: ['Chen'],
+            Instructions: 'Be terse.',
+        });
+        expect(lastStartParams?.data).toEqual({
+            targetAgentID: 'target-1',
+            realtimeVoice: 'echo',
+            realtimeMeetingMode: true,
+            realtimeSelfNames: ['Chen'],
+            realtimeInstructions: 'Be terse.',
+        });
+    });
+
     it('throws a clear error when the agent cannot be resolved', async () => {
         await expect(CreateBridgeRealtimeSession({ AgentID: 'missing-id' })).rejects.toThrow(/no agent found/);
     });

--- a/packages/AI/Agents/src/__tests__/realtime-agent-integration.test.ts
+++ b/packages/AI/Agents/src/__tests__/realtime-agent-integration.test.ts
@@ -27,6 +27,7 @@ import { IMetadataProvider } from '@memberjunction/core';
 import { BaseAgentType } from '../agent-types/base-agent-type';
 import { BaseAgent } from '../base-agent';
 import { INVOKE_TARGET_AGENT_TOOL_NAME, DelegateToTargetRequest } from '../realtime/realtime-session-runner';
+import { PrepareClientSessionInput } from '../realtime/realtime-client-session-service';
 import { RealtimeRecordingController } from '../realtime/realtime-recording-capture';
 
 // ════════════════════════════════════════════════════════════════════
@@ -95,6 +96,12 @@ class TestableRealtimeAgent extends BaseAgent {
     /** Injects (or clears) the active recording controller so the media-field stamping path can be exercised. */
     public setRecording(controller: RealtimeRecordingController | null): void {
         (this as unknown as { realtimeRecording: RealtimeRecordingController | null }).realtimeRecording = controller;
+    }
+    /** Drives the private `params.data` → core prep-input adaptation every server-bridged host goes through. */
+    public callBuildBridgePrepInput(params: ExecuteAgentParams): PrepareClientSessionInput {
+        return (this as unknown as {
+            buildBridgePrepInput(p: ExecuteAgentParams): PrepareClientSessionInput;
+        }).buildBridgePrepInput(params);
     }
 }
 
@@ -523,6 +530,32 @@ describe('BaseAgent realtime (session-driven) integration', () => {
             clock = 2100; // 1100ms in
             await agent.callPersist(params, { Role: 'user', Text: 'question', IsFinal: true });
             expect(detail.UtteranceEndMs).toBe(1100);
+        });
+    });
+
+    // The adaptation a bridge host's extras go through on their way to the ONE shared session-prep
+    // producer. Instructions matter here specifically: they are the only extra that ends up as prompt
+    // TEXT, so a drop shows up as a seat quietly speaking as the generic co-agent instead of failing.
+    describe('buildBridgePrepInput — per-session instructions', () => {
+        it('maps params.data.realtimeInstructions onto the core prep input (trimmed)', () => {
+            const agent = new TestableRealtimeAgent();
+            const input = agent.callBuildBridgePrepInput(
+                makeParams({ data: { targetAgentID: 'target-1', realtimeInstructions: '  Be Dr. Chen.  ' } }),
+            );
+            expect(input.Instructions).toBe('Be Dr. Chen.');
+            expect(input.TargetAgentID).toBe('target-1'); // the other extras are untouched
+        });
+
+        it('leaves Instructions undefined when the host supplied none', () => {
+            const agent = new TestableRealtimeAgent();
+            const input = agent.callBuildBridgePrepInput(makeParams({ data: { targetAgentID: 'target-1' } }));
+            expect(input.Instructions).toBeUndefined();
+        });
+
+        it('leaves Instructions undefined for a blank value (never an empty appended section)', () => {
+            const agent = new TestableRealtimeAgent();
+            const input = agent.callBuildBridgePrepInput(makeParams({ data: { realtimeInstructions: '   ' } }));
+            expect(input.Instructions).toBeUndefined();
         });
     });
 });

--- a/packages/AI/Agents/src/__tests__/realtime-agent-integration.test.ts
+++ b/packages/AI/Agents/src/__tests__/realtime-agent-integration.test.ts
@@ -557,5 +557,26 @@ describe('BaseAgent realtime (session-driven) integration', () => {
             const input = agent.callBuildBridgePrepInput(makeParams({ data: { realtimeInstructions: '   ' } }));
             expect(input.Instructions).toBeUndefined();
         });
+
+        // On the bridge path the caller's text IS the seat's identity. Without this the framing —
+        // "you are the real-time voice for another agent; do not do the work yourself" — precedes the
+        // persona and wins: seats offer to fetch the character they are supposed to be.
+        it('declares that bridged instructions OWN the identity, so they lead the prompt', () => {
+            const agent = new TestableRealtimeAgent();
+            const input = agent.callBuildBridgePrepInput(
+                makeParams({ data: { realtimeInstructions: 'You are Dr. Maya Chen.' } }),
+            );
+            expect(input.InstructionsOwnIdentity).toBe(true);
+        });
+
+        it('never claims ownership of an identity the host did not supply', () => {
+            const agent = new TestableRealtimeAgent();
+            for (const data of [{ targetAgentID: 'target-1' }, { realtimeInstructions: '  ' }]) {
+                const input = agent.callBuildBridgePrepInput(makeParams({ data }));
+                // False, not merely falsy: the service gates on `=== true`, and a seat that claimed to
+                // own an identity it did not supply would get no identity at all.
+                expect(input.InstructionsOwnIdentity).toBe(false);
+            }
+        });
     });
 });

--- a/packages/AI/Agents/src/__tests__/realtime-client-session-service.test.ts
+++ b/packages/AI/Agents/src/__tests__/realtime-client-session-service.test.ts
@@ -657,6 +657,57 @@ describe('RealtimeClientSessionService.PrepareClientSession — PriorTranscript 
 });
 
 // ════════════════════════════════════════════════════════════════════
+// Caller-supplied per-session Instructions (persona text)
+// ════════════════════════════════════════════════════════════════════
+
+describe('RealtimeClientSessionService.PrepareClientSession — caller Instructions', () => {
+    const persona = 'You are Dr. Chen, a skeptical CFO. Interrupt when numbers do not add up.';
+
+    it('APPENDS the instructions to the companion prompt — the framework framing is still there, first', async () => {
+        const svc = new TestableService();
+        const result = await svc.PrepareClientSession(makePrepInput({ Instructions: persona }), contextUser, provider);
+
+        const prompt = result.SessionParams!.SystemPrompt;
+        expect(prompt).toContain(persona);
+        // Nothing the framework assembles was replaced — and all of it precedes the caller's text.
+        expect(prompt).toContain(INVOKE_TARGET_AGENT_TOOL_NAME);
+        expect(prompt).toContain('CO-AGENT PROMPT BODY');
+        expect(prompt).toContain('Sales Agent');
+        expect(prompt.indexOf('CO-AGENT PROMPT BODY')).toBeLessThan(prompt.indexOf(persona));
+        expect(prompt.indexOf(INVOKE_TARGET_AGENT_TOOL_NAME)).toBeLessThan(prompt.indexOf(persona));
+    });
+
+    it('appends LAST, joined by a blank line — the prompt is the base prompt plus the persona text', async () => {
+        const svc = new TestableService();
+        const base = await svc.PrepareClientSession(makePrepInput(), contextUser, provider);
+        const withPersona = await svc.PrepareClientSession(makePrepInput({ Instructions: persona }), contextUser, provider);
+
+        expect(withPersona.SessionParams!.SystemPrompt).toBe(`${base.SessionParams!.SystemPrompt}\n\n${persona}`);
+        expect(withPersona.SessionParams!.SystemPrompt.endsWith(persona)).toBe(true);
+    });
+
+    it('leaves the prompt byte-for-byte unchanged when Instructions are omitted', async () => {
+        const svc = new TestableService();
+        const withField = await svc.PrepareClientSession(makePrepInput({ Instructions: undefined }), contextUser, provider);
+        const without = await svc.PrepareClientSession(makePrepInput(), contextUser, provider);
+        expect(withField.SessionParams!.SystemPrompt).toBe(without.SessionParams!.SystemPrompt);
+    });
+
+    it('contributes nothing for an empty / whitespace-only value (no trailing blank section)', async () => {
+        const svc = new TestableService();
+        const blank = await svc.PrepareClientSession(makePrepInput({ Instructions: '   \n  ' }), contextUser, provider);
+        const without = await svc.PrepareClientSession(makePrepInput(), contextUser, provider);
+        expect(blank.SessionParams!.SystemPrompt).toBe(without.SessionParams!.SystemPrompt);
+    });
+
+    it('reaches the minted session (the model is asked to speak with the persona in its instructions)', async () => {
+        const svc = new TestableService();
+        await svc.PrepareClientSession(makePrepInput({ Instructions: persona }), contextUser, provider);
+        expect(svc.Model.LastParams!.SystemPrompt).toContain(persona);
+    });
+});
+
+// ════════════════════════════════════════════════════════════════════
 // FinalizeCoAgentRun
 // ════════════════════════════════════════════════════════════════════
 

--- a/packages/AI/Agents/src/base-agent.ts
+++ b/packages/AI/Agents/src/base-agent.ts
@@ -1968,7 +1968,8 @@ export class BaseAgent {
      * `ConfigOverridesJson` cascade slot via {@link BuildRealtimeOverridesJson}). Tools are left empty — a
      * bridge host injects its OWN UX tools (none for LiveKit audio today); identity/precedence/invoke-target
      * come from the core. `AgentSessionID` groups this session's observability runs (see
-     * {@link RealtimeClientSessionService.WireBridgeRealtimeSession}).
+     * {@link RealtimeClientSessionService.WireBridgeRealtimeSession}). `realtimeInstructions` is the host's
+     * optional per-session persona text, which the core APPENDS to the companion prompt.
      *
      * @param params The bridge execution parameters.
      * @returns The core prep input.
@@ -1985,6 +1986,11 @@ export class BaseAgent {
         const selfNames = Array.isArray(params.data?.realtimeSelfNames)
             ? (params.data?.realtimeSelfNames as unknown[]).filter((n): n is string => typeof n === 'string')
             : undefined;
+        // Caller-supplied per-session persona/scenario text (a bridge host asking THIS seat to be a
+        // specific character). The core producer APPENDS it to the companion prompt it assembles — it
+        // never replaces the framing — and the transport layer gated it before it got here, exactly as
+        // it gates the config overrides. Blank/absent ⇒ omitted, so the prompt is unchanged.
+        const instructions = (params.data?.realtimeInstructions as string | undefined)?.trim() || undefined;
         return {
             CoAgent: params.agent,
             TargetAgentID: targetID,
@@ -1995,6 +2001,7 @@ export class BaseAgent {
             UserID: params.contextUser?.ID,
             DisableAutoResponse: meetingMode || undefined,
             SelfNames: selfNames,
+            Instructions: instructions,
             // App awareness (Move 1/3/4): the app the session runs in (sources the app cascade layer +
             // RelevantAgents → allowed-agent union) and the live app-context snapshot injected at mint.
             // Both ride params.data, the same conduit async agents use for appContext.

--- a/packages/AI/Agents/src/base-agent.ts
+++ b/packages/AI/Agents/src/base-agent.ts
@@ -1969,7 +1969,8 @@ export class BaseAgent {
      * bridge host injects its OWN UX tools (none for LiveKit audio today); identity/precedence/invoke-target
      * come from the core. `AgentSessionID` groups this session's observability runs (see
      * {@link RealtimeClientSessionService.WireBridgeRealtimeSession}). `realtimeInstructions` is the host's
-     * optional per-session persona text, which the core APPENDS to the companion prompt.
+     * optional per-session persona text; on this path it IS the seat's identity, so the core leads with
+     * it instead of appending it behind the framework's own framing.
      *
      * @param params The bridge execution parameters.
      * @returns The core prep input.
@@ -1987,9 +1988,16 @@ export class BaseAgent {
             ? (params.data?.realtimeSelfNames as unknown[]).filter((n): n is string => typeof n === 'string')
             : undefined;
         // Caller-supplied per-session persona/scenario text (a bridge host asking THIS seat to be a
-        // specific character). The core producer APPENDS it to the companion prompt it assembles — it
-        // never replaces the framing — and the transport layer gated it before it got here, exactly as
-        // it gates the config overrides. Blank/absent ⇒ omitted, so the prompt is unchanged.
+        // specific character), gated by the transport layer before it got here exactly as the config
+        // overrides are. Blank/absent ⇒ omitted, so the prompt is unchanged.
+        //
+        // On the BRIDGE path this text IS the seat's identity, so it leads the prompt and the
+        // framework's identity framing is left out (`InstructionsOwnIdentity`). That is what the field
+        // was added for: a room seat asked to be Dr. Chen is not a voice speaking on Dr. Chen's behalf.
+        // Composed the other way round — framing first, persona 200 words later — the framing wins:
+        // measured on a live three-seat room, seats introduced themselves as assistants and offered to
+        // fetch the character they were supposed to BE, with the correct persona text sitting in the
+        // delivered prompt the whole time. Client-direct callers are untouched and keep the append rule.
         const instructions = (params.data?.realtimeInstructions as string | undefined)?.trim() || undefined;
         return {
             CoAgent: params.agent,
@@ -2002,6 +2010,7 @@ export class BaseAgent {
             DisableAutoResponse: meetingMode || undefined,
             SelfNames: selfNames,
             Instructions: instructions,
+            InstructionsOwnIdentity: instructions !== undefined,
             // App awareness (Move 1/3/4): the app the session runs in (sources the app cascade layer +
             // RelevantAgents → allowed-agent union) and the live app-context snapshot injected at mint.
             // Both ride params.data, the same conduit async agents use for appContext.

--- a/packages/AI/Agents/src/realtime/bridge-realtime-session-factory.ts
+++ b/packages/AI/Agents/src/realtime/bridge-realtime-session-factory.ts
@@ -72,6 +72,21 @@ export interface BridgeRealtimeSessionContext {
     MeetingMode?: boolean;
     /** The names the agent answers to (display name + aliases) — phrasing for the meeting prompt only. */
     SelfNames?: string[];
+    /**
+     * Optional per-session INSTRUCTIONS — the persona/scenario text that makes THIS seat a specific
+     * character. It is **APPENDED to** the co-agent's companion system prompt, never a replacement for
+     * it: the core producer builds the framework's framing (identity, `invoke-target-agent` discipline,
+     * meeting rules, voice manner, memory) first and joins this onto the end, so the framing and safety
+     * text always survive. This is the same composition the client-direct path gets by overriding
+     * `RealtimeClientSessionService.buildCompanionSystemPrompt` and appending to `super(...)` — exposed
+     * as a parameter for hosts that can't subclass. Without it a multi-agent room is N copies of one
+     * generic voice instead of a panel of distinct characters.
+     *
+     * **Pre-authorized by the transport layer** (the MJServer resolver gates it behind the
+     * `Realtime: Advanced Session Controls` authorization, as it does the config overrides). Flows to
+     * `params.data.realtimeInstructions`. Absent/blank ⇒ the prompt is exactly what it is today.
+     */
+    Instructions?: string;
 }
 
 /**
@@ -115,7 +130,8 @@ export async function CreateBridgeRealtimeSession(ctx: BridgeRealtimeSessionCont
         conversationMessages: [] as ChatMessage[],
         // Realtime extras ride params.data: the TARGET agent the co-agent voices via `invoke-target-agent`
         // (without it the co-agent stays idle), plus optional per-session dev overrides for the model/voice
-        // so two agents in the same room can sound distinct. Omitted keys are simply absent.
+        // so two agents in the same room can sound distinct, plus the caller's per-session instructions so
+        // they can also BE distinct characters. Omitted keys are simply absent.
         data: buildRealtimeData(ctx),
     });
 }
@@ -144,6 +160,10 @@ function buildRealtimeData(ctx: BridgeRealtimeSessionContext): Record<string, un
     }
     if (ctx.SelfNames && ctx.SelfNames.length > 0) {
         data.realtimeSelfNames = ctx.SelfNames;
+    }
+    if (ctx.Instructions && ctx.Instructions.trim().length > 0) {
+        // Appended to the companion prompt by the core producer — see BridgeRealtimeSessionContext.Instructions.
+        data.realtimeInstructions = ctx.Instructions.trim();
     }
     return Object.keys(data).length > 0 ? data : undefined;
 }

--- a/packages/AI/Agents/src/realtime/realtime-client-session-service.ts
+++ b/packages/AI/Agents/src/realtime/realtime-client-session-service.ts
@@ -194,6 +194,37 @@ export interface PrepareClientSessionInput {
      * the input. Absent/blank ⇒ the prompt is byte-for-byte what it is without this field.
      */
     Instructions?: string;
+
+    /**
+     * Declares that {@link Instructions} **is the agent's identity**, not an addition to it — so it
+     * LEADS the prompt and the framework's identity framing is left out.
+     *
+     * Default (absent/false) is the composition rule described above and nothing changes for any
+     * existing caller: framing first, caller text appended.
+     *
+     * ── WHY THIS EXISTS ──
+     *
+     * The default rule is right for a co-agent that speaks *on behalf of* another agent. It is wrong
+     * for a room SEAT that is a character in its own right, and the failure is not subtle: the framing
+     * opens by telling the model it is the real-time voice for another agent and must not do the work
+     * itself, and only then — 200-odd words later — does the seat's own persona arrive. Measured on a
+     * live three-seat room: seats introduced themselves as assistants, offered to fetch the person they
+     * were supposed to BE, and answered "I'm here, how can I help" in a panel interview. The persona
+     * text was present and correct in the delivered prompt the whole time; it was simply behind an
+     * instruction that contradicted it.
+     *
+     * What is suppressed is exactly the identity trio — the companion framing, the co-agent's own
+     * system prompt, and the target-identity block. Everything that is not identity still applies and
+     * still cannot be stripped by a caller: meeting rules, voice manner, app context, prior transcript,
+     * history and memory. A host that sets this is choosing WHO the model is, never what safety text
+     * it gets.
+     *
+     * Ignored when {@link Instructions} is absent or blank — a caller claiming to own an identity it
+     * did not supply would otherwise get a seat with no identity at all.
+     *
+     * **Pre-authorized by the transport layer**, exactly like {@link Instructions} itself.
+     */
+    InstructionsOwnIdentity?: boolean;
 }
 
 /**
@@ -1908,16 +1939,32 @@ export class RealtimeClientSessionService {
         const priorTranscript = this.formatPriorTranscript(input.PriorTranscript);
         const history = this.formatConversationHistory(input.ConversationMessages);
         const memoryContext = await this.assembleMemoryContext(input, coAgent, contextUser, provider);
-        // The caller's per-session persona text goes LAST, appended — the ONE composition rule this field
-        // has (see PrepareClientSessionInput.Instructions). Doing it here, in the shared producer, is what
-        // makes it byte-identical to the `super(...) + own text` subclass override every client-direct
-        // consumer already uses, and keeps the framework's framing ahead of caller text on EVERY host.
+        // The caller's per-session persona text goes LAST, appended — the composition rule this field
+        // has by DEFAULT (see PrepareClientSessionInput.Instructions). Doing it here, in the shared
+        // producer, is what makes it byte-identical to the `super(...) + own text` subclass override
+        // every client-direct consumer already uses, and keeps the framework's framing ahead of caller
+        // text on every host.
         const callerInstructions = input.Instructions ?? '';
 
-        return [
-            framing, meetingFraming, coAgentPrompt, voiceManner, targetIdentity, appContextSection,
-            priorTranscript, history, memoryContext, callerInstructions,
-        ]
+        // ...unless the caller declares those instructions ARE the identity (a room seat that is a
+        // character rather than a voice for someone else). Then they LEAD and the identity trio is
+        // left out — see PrepareClientSessionInput.InstructionsOwnIdentity for what that does and
+        // does not suppress. Gated on the text being present, so the flag can never produce a seat
+        // with no identity at all.
+        const callerOwnsIdentity = input.InstructionsOwnIdentity === true
+            && callerInstructions.trim().length > 0;
+
+        const parts = callerOwnsIdentity
+            ? [
+                callerInstructions, meetingFraming, voiceManner, appContextSection,
+                priorTranscript, history, memoryContext,
+            ]
+            : [
+                framing, meetingFraming, coAgentPrompt, voiceManner, targetIdentity, appContextSection,
+                priorTranscript, history, memoryContext, callerInstructions,
+            ];
+
+        return parts
             .filter(part => part && part.trim().length > 0)
             .join('\n\n');
     }

--- a/packages/AI/Agents/src/realtime/realtime-client-session-service.ts
+++ b/packages/AI/Agents/src/realtime/realtime-client-session-service.ts
@@ -174,6 +174,26 @@ export interface PrepareClientSessionInput {
      * deployments (a public web-widget guest's `VoiceMaxSessionMinutes`); omitted otherwise.
      */
     MaxSessionSeconds?: number;
+    /**
+     * Optional CALLER-SUPPLIED per-session instructions — the persona/scenario text that makes THIS
+     * session a specific character. It is **APPENDED to** the companion system prompt, never a
+     * replacement for it: {@link RealtimeClientSessionService.buildCompanionSystemPrompt} assembles the
+     * framework's own framing (first-person-as-the-target identity, the `invoke-target-agent`
+     * discipline, meeting rules, voice manner, memory) FIRST and joins this text onto the end — exactly
+     * what a subclass overriding that seam does when it composes `super(...)` + its own text (the
+     * established client-direct pattern). No host can strip the framing or safety text by supplying it.
+     *
+     * Why it exists: without it a bridged ROOM seat could only ever be the generic co-agent voice, so a
+     * multi-agent room was N copies of one character rather than a panel of distinct ones — while a solo
+     * client-direct session could already be a persona via the subclass seam. This closes that gap for
+     * hosts that cannot subclass (a GraphQL caller starting a room seat).
+     *
+     * **Pre-authorized by the transport layer**, exactly like {@link ConfigOverridesJson}: it is
+     * per-session prompt influence, so the MJServer resolvers gate it behind the
+     * `Realtime: Advanced Session Controls` authorization BEFORE threading it here; the service trusts
+     * the input. Absent/blank ⇒ the prompt is byte-for-byte what it is without this field.
+     */
+    Instructions?: string;
 }
 
 /**
@@ -1853,6 +1873,9 @@ export class RealtimeClientSessionService {
      * short "Voice & manner" section (tone / speaking style) is appended after the co-agent's
      * own prompt so the model speaks in the configured manner.
      *
+     * Caller-supplied {@link PrepareClientSessionInput.Instructions} land LAST — appended to everything
+     * the framework assembled, never replacing any of it (see that field for the why + the gate).
+     *
      * @param input The prepare-session input.
      * @param coAgent The resolved co-agent.
      * @param contextUser The calling user.
@@ -1885,8 +1908,16 @@ export class RealtimeClientSessionService {
         const priorTranscript = this.formatPriorTranscript(input.PriorTranscript);
         const history = this.formatConversationHistory(input.ConversationMessages);
         const memoryContext = await this.assembleMemoryContext(input, coAgent, contextUser, provider);
+        // The caller's per-session persona text goes LAST, appended — the ONE composition rule this field
+        // has (see PrepareClientSessionInput.Instructions). Doing it here, in the shared producer, is what
+        // makes it byte-identical to the `super(...) + own text` subclass override every client-direct
+        // consumer already uses, and keeps the framework's framing ahead of caller text on EVERY host.
+        const callerInstructions = input.Instructions ?? '';
 
-        return [framing, meetingFraming, coAgentPrompt, voiceManner, targetIdentity, appContextSection, priorTranscript, history, memoryContext]
+        return [
+            framing, meetingFraming, coAgentPrompt, voiceManner, targetIdentity, appContextSection,
+            priorTranscript, history, memoryContext, callerInstructions,
+        ]
             .filter(part => part && part.trim().length > 0)
             .join('\n\n');
     }

--- a/packages/AI/RealtimeBridge/Providers/LiveKit/package.json
+++ b/packages/AI/RealtimeBridge/Providers/LiveKit/package.json
@@ -31,5 +31,8 @@
   "repository": {
     "type": "git",
     "url": "https://github.com/MemberJunction/MJ"
+  },
+  "optionalDependencies": {
+    "@memberjunction/ai-bridge-livekit-native": "workspace:*"
   }
 }

--- a/packages/AI/RealtimeBridge/Providers/LiveKit/package.json
+++ b/packages/AI/RealtimeBridge/Providers/LiveKit/package.json
@@ -31,8 +31,5 @@
   "repository": {
     "type": "git",
     "url": "https://github.com/MemberJunction/MJ"
-  },
-  "optionalDependencies": {
-    "@memberjunction/ai-bridge-livekit-native": "workspace:*"
   }
 }

--- a/packages/AI/RealtimeBridge/Providers/LiveKit/src/__tests__/livekit-bridge.test.ts
+++ b/packages/AI/RealtimeBridge/Providers/LiveKit/src/__tests__/livekit-bridge.test.ts
@@ -252,6 +252,25 @@ describe('LiveKitBridge — participants', () => {
         expect(bot).toMatchObject({ Role: 'Agent', IsAgent: true });
     });
 
+    // The multi-agent case, which is the ONLY kind of agent a bridge can actually see: an SFU never lists a
+    // participant in its own remote roster, so every co-agent arrives with IsLocal false. Deriving agent-ness
+    // from IsLocal recorded the whole rest of the panel as human — and, separately, as Role 'Participant'.
+    it('flags a REMOTE co-agent as an Agent in both IsAgent and Role', async () => {
+        const bridge = makeBridge(sdk);
+        await bridge.Connect(ctx());
+        sdk.DriveJoin({ Identity: 'agent-9F2C', DisplayName: 'Co-Agent', Role: 'Participant', IsLocal: false });
+        const coAgent = (await bridge.GetParticipants()).find((p) => p.ExternalId === 'agent-9F2C');
+        expect(coAgent).toMatchObject({ Role: 'Agent', IsAgent: true });
+    });
+
+    it('does not mistake a human whose name merely contains "agent" for a bot', async () => {
+        const bridge = makeBridge(sdk);
+        await bridge.Connect(ctx());
+        sdk.DriveJoin({ Identity: 'u-agentina', DisplayName: 'Agentina', Role: 'Participant', IsLocal: false });
+        const human = (await bridge.GetParticipants()).find((p) => p.ExternalId === 'u-agentina');
+        expect(human).toMatchObject({ Role: 'Participant', IsAgent: false });
+    });
+
     it('OnParticipantChange fires the full roster on a join and a leave', async () => {
         const bridge = makeBridge(sdk);
         await bridge.Connect(ctx());

--- a/packages/AI/RealtimeBridge/Providers/LiveKit/src/livekit-bridge.ts
+++ b/packages/AI/RealtimeBridge/Providers/LiveKit/src/livekit-bridge.ts
@@ -45,6 +45,7 @@ import {
     LiveKitParticipantRole,
     LiveKitAudioFrame,
     LiveKitConnectArgs,
+    IsAgentParticipant,
 } from './livekit-sdk';
 import { LiveKitMeetingControlsEventSource } from './livekit-meeting-controls';
 
@@ -55,11 +56,12 @@ import { LiveKitMeetingControlsEventSource } from './livekit-meeting-controls';
 export const LIVEKIT_BRIDGE_DRIVER_CLASS = 'LiveKitBridge';
 
 /**
- * Maps a LiveKit participant role to the bridge's {@link BridgeParticipantRole}. The bot (`IsLocal`) is
- * surfaced as `'Agent'`.
+ * Maps a LiveKit participant role to the bridge's {@link BridgeParticipantRole}. An agent bot is surfaced as
+ * `'Agent'` — which outranks any room role it also holds, since a consumer asking "is this a person?" must
+ * not get `'Host'` for a bot.
  */
-function mapParticipantRole(role: LiveKitParticipantRole, isLocal: boolean | undefined): BridgeParticipantRole {
-    if (isLocal) {
+function mapParticipantRole(role: LiveKitParticipantRole, isAgent: boolean): BridgeParticipantRole {
+    if (isAgent) {
         return 'Agent';
     }
     switch (role) {
@@ -72,25 +74,16 @@ function mapParticipantRole(role: LiveKitParticipantRole, isLocal: boolean | und
     }
 }
 
-/**
- * The bot-identity convention the LiveKit room coordinator mints (`agent-<agentSessionId>`). A bridge only
- * knows its OWN bot via `IsLocal`; OTHER agents in a multi-agent room are REMOTE participants, so they must
- * be recognized by this identity prefix. Without it every other agent reads as a human — breaking
- * turn-taking's agent-exclusion (an agent treats another agent's speech as being addressed) AND the
- * "are any humans still present?" occupancy check the engine uses to auto-leave an empty room.
- */
-function isAgentParticipantIdentity(identity: string | undefined): boolean {
-    return typeof identity === 'string' && identity.toLowerCase().startsWith('agent-');
-}
-
 /** Maps a LiveKit participant onto the bridge's {@link BridgeParticipantInfo}. */
 function toBridgeParticipant(p: LiveKitParticipant): BridgeParticipantInfo {
+    // Decided ONCE and used for both fields: a row saying IsAgent=true / Role='Participant' about the same
+    // participant is what shipped before, and consumers disagree about which half to believe.
+    const isAgent = IsAgentParticipant(p);
     return {
         ExternalId: p.Identity,
         DisplayName: p.DisplayName,
-        Role: mapParticipantRole(p.Role, p.IsLocal),
-        // The local bot OR any remote agent bot (by identity convention) counts as an agent, not a human.
-        IsAgent: p.IsLocal === true || isAgentParticipantIdentity(p.Identity),
+        Role: mapParticipantRole(p.Role, isAgent),
+        IsAgent: isAgent,
     };
 }
 

--- a/packages/AI/RealtimeBridge/Providers/LiveKit/src/livekit-meeting-controls.ts
+++ b/packages/AI/RealtimeBridge/Providers/LiveKit/src/livekit-meeting-controls.ts
@@ -21,14 +21,14 @@ import {
     BridgeMeetingControlsCapability,
     BridgeMeetingParticipantRole,
 } from '@memberjunction/ai-bridge-base';
-import { ILiveKitRoomSdk, LiveKitParticipant, LiveKitParticipantRole } from './livekit-sdk';
+import { ILiveKitRoomSdk, LiveKitParticipant, LiveKitParticipantRole, IsAgentParticipant } from './livekit-sdk';
 
 /**
  * Maps a LiveKit participant role to the bridge's meeting-participant role. LiveKit has no distinct
  * "Agent" role; the bot is flagged via `IsLocal` and surfaced as `'Agent'`.
  */
-function mapRole(role: LiveKitParticipantRole, isLocal: boolean | undefined): BridgeMeetingParticipantRole {
-    if (isLocal) {
+function mapRole(role: LiveKitParticipantRole, isAgent: boolean): BridgeMeetingParticipantRole {
+    if (isAgent) {
         return 'Agent';
     }
     switch (role) {
@@ -43,11 +43,14 @@ function mapRole(role: LiveKitParticipantRole, isLocal: boolean | undefined): Br
 
 /** Maps one LiveKit participant onto the channel's {@link BridgeMeetingParticipant} shape. */
 export function toMeetingParticipant(p: LiveKitParticipant): BridgeMeetingParticipant {
+    // Same single decision the bridge roster uses — the Meet UI's participant list and the persisted roster
+    // must not disagree about who in the room is a bot.
+    const isAgent = IsAgentParticipant(p);
     return {
         ParticipantId: p.Identity,
         DisplayName: p.DisplayName,
-        Role: mapRole(p.Role, p.IsLocal),
-        IsAgent: p.IsLocal === true,
+        Role: mapRole(p.Role, isAgent),
+        IsAgent: isAgent,
     };
 }
 

--- a/packages/AI/RealtimeBridge/Providers/LiveKit/src/livekit-native-sdk.ts
+++ b/packages/AI/RealtimeBridge/Providers/LiveKit/src/livekit-native-sdk.ts
@@ -282,9 +282,14 @@ export const defaultNativeLoader: NativeModuleLoader = async (specifier: string)
     } catch (err) {
         const message = err instanceof Error ? err.message : String(err);
         throw new Error(
-            `LiveKitNativeMeetingSdk could not load the native LiveKit room module at '${specifier}'. Build/install ` +
-                'the native LiveKit Node room-client wrapper (livekit-server-sdk + a room client like @livekit/rtc-node) ' +
-                `and set LiveKitNativeSdkConfig.NativeModuleSpecifier to it. Underlying error: ${message}`,
+            `LiveKitNativeMeetingSdk could not load the native LiveKit room module at '${specifier}'. Install the ` +
+                'native LiveKit Node room-client wrapper (livekit-server-sdk + a room client like @livekit/rtc-node), ' +
+                'then point this provider at it with the LIVEKIT_NATIVE_MODULE env var (or ' +
+                'LiveKitNativeSdkConfig.NativeModuleSpecifier directly). NOTE: a bare package name is resolved from ' +
+                "THIS provider's location, not the host's — so installing the wrapper alongside your app is not enough " +
+                'on a strict-isolation installer such as pnpm. Use an ABSOLUTE PATH to the wrapper there. The provider ' +
+                'deliberately does not declare the wrapper as a dependency: @memberjunction/ai-bridge-livekit-native ' +
+                `depends on this package, so declaring it back would be a dependency cycle. Underlying error: ${message}`,
         );
     }
 };

--- a/packages/AI/RealtimeBridge/Providers/LiveKit/src/livekit-sdk.ts
+++ b/packages/AI/RealtimeBridge/Providers/LiveKit/src/livekit-sdk.ts
@@ -61,6 +61,27 @@ export interface LiveKitParticipant {
 }
 
 /**
+ * The bot-identity convention the LiveKit room coordinator mints (`agent-<agentSessionId>`).
+ *
+ * `IsLocal` identifies only a bridge's OWN bot, and an SFU never lists a participant in its own remote
+ * roster — so in a multi-agent room `IsLocal` is false for every agent a bridge can actually see. Agent-ness
+ * is therefore a property of the IDENTITY, not of which bridge observed it, and this predicate is the single
+ * place that decision is made (both the bridge roster and the Meeting Controls roster read it).
+ */
+export function IsAgentParticipantIdentity(identity: string | undefined): boolean {
+    return typeof identity === 'string' && identity.toLowerCase().startsWith('agent-');
+}
+
+/**
+ * Whether a participant is an agent bot: this bridge's own bot, or any other agent in the room by
+ * {@link IsAgentParticipantIdentity}. Both roster mappers derive `IsAgent` AND `Role` from this one answer,
+ * so the two fields on a row can never disagree about the same participant.
+ */
+export function IsAgentParticipant(p: LiveKitParticipant): boolean {
+    return p.IsLocal === true || IsAgentParticipantIdentity(p.Identity);
+}
+
+/**
  * One frame of raw per-participant audio the seam surfaces for diarization + the agent's "hearing".
  * Because LiveKit subscribes tracks **per participant**, every inbound frame is already attributed to a
  * single speaker — diarization comes free from the SFU.

--- a/packages/AI/RealtimeBridge/Server/src/__tests__/multi-agent-room-coordinator.test.ts
+++ b/packages/AI/RealtimeBridge/Server/src/__tests__/multi-agent-room-coordinator.test.ts
@@ -1,11 +1,16 @@
 import { describe, it, expect, beforeEach } from 'vitest';
-import { MultiAgentRoomCoordinator } from '../multi-agent-room-coordinator';
+import { MultiAgentRoomCoordinator, AgentParticipant, HumanParticipant, RoomParticipantKey } from '../multi-agent-room-coordinator';
 
 const ROOM = 'room-alpha';
 const ROOM_B = 'room-beta';
 const SAGE = 'sess-sage';
 const DEMO = 'sess-demo';
 const SCOUT = 'sess-scout';
+
+/** A human room member — the coach who takes an agent's seat. */
+const COACH = HumanParticipant('user-coach');
+/** A second human, for the "two people in the room" cases. */
+const HOST = HumanParticipant('user-host');
 
 let coord: MultiAgentRoomCoordinator;
 beforeEach(() => {
@@ -203,5 +208,145 @@ describe('MultiAgentRoomCoordinator — loop-safety (passive agents)', () => {
         expect(coord.TakeFloor(ROOM, SAGE).Granted).toBe(true);
         coord.ReleaseFloor(ROOM, SAGE);
         expect(coord.TakeFloor(ROOM, SAGE).Granted).toBe(true);
+    });
+});
+
+// ──────────────────────────────────────────────────────────────────────────────
+// Human participants — a person holds the floor, and agents yield to them.
+// ──────────────────────────────────────────────────────────────────────────────
+
+describe('MultiAgentRoomCoordinator — human participants', () => {
+    it('a bare string is still an agent session id (the pre-human calling shape)', () => {
+        coord.RegisterRoomParticipant(ROOM, SAGE);
+        // The string form and the explicit agent ref name the SAME member.
+        expect(coord.CanTakeFloor(ROOM, AgentParticipant(SAGE))).toEqual({ Granted: true, Reason: 'FloorFree' });
+        coord.TakeFloor(ROOM, AgentParticipant(SAGE));
+        expect(coord.IsFloorHolder(ROOM, SAGE)).toBe(true);
+        expect(coord.GetRoomState(ROOM)!.Participants).toEqual([{ Kind: 'Agent', AgentSessionId: SAGE }]);
+    });
+
+    it('an agent session and a user sharing an id are distinct members', () => {
+        const shared = 'A1B2C3';
+        coord.RegisterRoomParticipant(ROOM, shared);
+        coord.RegisterRoomParticipant(ROOM, HumanParticipant(shared));
+        expect(RoomParticipantKey(AgentParticipant(shared))).not.toBe(RoomParticipantKey(HumanParticipant(shared)));
+        expect(coord.GetRoomState(ROOM)!.Participants.length).toBe(2);
+        // The agent takes the floor; the human is NOT treated as already holding it.
+        coord.TakeFloor(ROOM, shared);
+        expect(coord.IsFloorHolder(ROOM, HumanParticipant(shared))).toBe(false);
+    });
+
+    it('a human can hold the floor, and every agent is denied while they do', () => {
+        coord.RegisterRoomParticipant(ROOM, SAGE);
+        coord.RegisterRoomParticipant(ROOM, DEMO);
+        coord.RegisterRoomParticipant(ROOM, COACH);
+
+        // Nobody is speaking yet, so the coach simply takes a free floor.
+        expect(coord.TakeFloor(ROOM, COACH)).toEqual({ Granted: true, Reason: 'FloorFree' });
+        expect(coord.IsFloorHolder(ROOM, COACH)).toBe(true);
+        expect(coord.CanTakeFloor(ROOM, SAGE)).toEqual({ Granted: false, Reason: 'HeldByHuman' });
+        expect(coord.TakeFloor(ROOM, DEMO).Granted).toBe(false);
+        expect(coord.IsFloorHolder(ROOM, SAGE)).toBe(false);
+    });
+
+    it('a FACILITATOR agent still yields to a human — it overrides agents, not people', () => {
+        coord.RegisterRoomParticipant(ROOM, SAGE, /* isFacilitator */ true);
+        coord.RegisterRoomParticipant(ROOM, COACH);
+        coord.TakeFloor(ROOM, COACH);
+        expect(coord.CanTakeFloor(ROOM, SAGE)).toEqual({ Granted: false, Reason: 'HeldByHuman' });
+        expect(coord.IsFloorHolder(ROOM, COACH)).toBe(true);
+    });
+
+    it('a human overrides a speaking agent, and the bumped agent learns it must yield', () => {
+        coord.RegisterRoomParticipant(ROOM, SAGE);
+        coord.RegisterRoomParticipant(ROOM, COACH);
+        coord.TakeFloor(ROOM, SAGE);
+        expect(coord.CanTakeFloor(ROOM, COACH)).toEqual({ Granted: true, Reason: 'HumanOverride' });
+        coord.TakeFloor(ROOM, COACH);
+        expect(coord.IsFloorHolder(ROOM, COACH)).toBe(true);
+        expect(coord.IsFloorHolder(ROOM, SAGE)).toBe(false);
+    });
+
+    it('a human re-asserting is AlreadyHolder and keeps the original since-stamp', () => {
+        let t = 1000;
+        const c = new MultiAgentRoomCoordinator(() => t);
+        c.RegisterRoomParticipant(ROOM, COACH);
+        t = 4000;
+        c.TakeFloor(ROOM, COACH);
+        t = 9000;
+        expect(c.CanTakeFloor(ROOM, COACH)).toEqual({ Granted: true, Reason: 'AlreadyHolder' });
+        c.TakeFloor(ROOM, COACH);
+        expect(c.GetRoomState(ROOM)!.FloorHeldSinceMs).toBe(4000);
+    });
+
+    it('one human may take the floor from another (the coordinator cannot mute a person)', () => {
+        coord.RegisterRoomParticipant(ROOM, COACH);
+        coord.RegisterRoomParticipant(ROOM, HOST);
+        coord.TakeFloor(ROOM, COACH);
+        expect(coord.TakeFloor(ROOM, HOST)).toEqual({ Granted: true, Reason: 'HumanOverride' });
+        expect(coord.IsFloorHolder(ROOM, HOST)).toBe(true);
+    });
+
+    it('an unregistered human is not a room member', () => {
+        coord.RegisterRoomParticipant(ROOM, SAGE);
+        expect(coord.CanTakeFloor(ROOM, COACH)).toEqual({ Granted: false, Reason: 'NotInRoom' });
+    });
+
+    it('a human leaving frees the floor it held', () => {
+        coord.RegisterRoomParticipant(ROOM, SAGE);
+        coord.RegisterRoomParticipant(ROOM, COACH);
+        coord.TakeFloor(ROOM, COACH);
+        coord.UnregisterRoomParticipant(ROOM, COACH);
+        expect(coord.CanTakeFloor(ROOM, SAGE)).toEqual({ Granted: true, Reason: 'FloorFree' });
+        expect(coord.GetRoomState(ROOM)!.FloorHolder).toBeNull();
+    });
+
+    it('a human can be the facilitator, and the agent-only projection reads null', () => {
+        coord.RegisterRoomParticipant(ROOM, SAGE);
+        coord.RegisterRoomParticipant(ROOM, COACH);
+        expect(coord.SetFacilitator(ROOM, COACH)).toBe(true);
+        const state = coord.GetRoomState(ROOM)!;
+        expect(state.Facilitator).toEqual(COACH);
+        expect(state.FacilitatorAgentSessionId).toBeNull();
+    });
+
+    it('one agent + one human is NOT a multi-agent room (it is a 1:1 call)', () => {
+        coord.RegisterRoomParticipant(ROOM, SAGE);
+        coord.RegisterRoomParticipant(ROOM, COACH);
+        expect(coord.IsMultiAgentRoom(ROOM)).toBe(false);
+        coord.RegisterRoomParticipant(ROOM, DEMO);
+        expect(coord.IsMultiAgentRoom(ROOM)).toBe(true);
+    });
+
+    it('GetRoomState separates the full roster from the agent-only projections', () => {
+        coord.RegisterRoomParticipant(ROOM, SAGE);
+        coord.RegisterRoomParticipant(ROOM, COACH);
+        coord.TakeFloor(ROOM, COACH);
+        const state = coord.GetRoomState(ROOM)!;
+        expect(state.Participants).toEqual([{ Kind: 'Agent', AgentSessionId: SAGE }, COACH]);
+        expect(state.AgentSessionIds).toEqual([SAGE]); // humans excluded — back-compat shape
+        expect(state.FloorHolder).toEqual(COACH);
+        // The pre-human projection can only describe an AGENT holder, so it reads null here.
+        expect(state.FloorHolderAgentSessionId).toBeNull();
+    });
+
+    it('the takeover round-trip: agent speaks → human takes the seat → hands it back', () => {
+        coord.RegisterRoomParticipant(ROOM, SAGE);
+        coord.RegisterRoomParticipant(ROOM, DEMO);
+        coord.RegisterRoomParticipant(ROOM, COACH);
+
+        // Sage is mid-turn.
+        expect(coord.TakeFloor(ROOM, SAGE).Granted).toBe(true);
+
+        // The coach steps into Sage's seat: granted over the sitting agent, and now NO agent may speak.
+        expect(coord.TakeFloor(ROOM, COACH)).toEqual({ Granted: true, Reason: 'HumanOverride' });
+        expect([SAGE, DEMO].filter(a => coord.IsFloorHolder(ROOM, a))).toEqual([]);
+        expect(coord.CanTakeFloor(ROOM, SAGE).Reason).toBe('HeldByHuman');
+        expect(coord.CanTakeFloor(ROOM, DEMO).Reason).toBe('HeldByHuman');
+
+        // The coach hands the seat back — the agents can take turns again, still one at a time.
+        expect(coord.ReleaseFloor(ROOM, COACH)).toBe(true);
+        expect(coord.TakeFloor(ROOM, SAGE).Granted).toBe(true);
+        expect(coord.CanTakeFloor(ROOM, DEMO)).toEqual({ Granted: false, Reason: 'HeldByOtherAgent' });
     });
 });

--- a/packages/AI/RealtimeBridge/Server/src/__tests__/transport-seam.test.ts
+++ b/packages/AI/RealtimeBridge/Server/src/__tests__/transport-seam.test.ts
@@ -1337,6 +1337,18 @@ describe('AIBridgeEngine — turn moderator (LLM router)', () => {
         }
     });
 
+    // Backs the RealtimeRoomMode query: an operator must be able to ASK whether rooms are moderated,
+    // because the alternative — a deployment that mistyped MJ_REALTIME_MODERATOR_MODE — is otherwise
+    // only discoverable by listening to a panel talk over itself.
+    it('HasTurnModerator reports whether a moderator is actually bound', () => {
+        engine().SetTurnModerator(undefined);
+        expect(engine().HasTurnModerator).toBe(false);
+        engine().SetTurnModerator(async () => []);
+        expect(engine().HasTurnModerator).toBe(true);
+        engine().SetTurnModerator(undefined);
+        expect(engine().HasTurnModerator).toBe(false);
+    });
+
     it('falls back to per-agent matchers when no moderator is set', async () => {
         engine().SetTurnModerator(undefined);
         const addr = 'loopback://no-moderator-room';

--- a/packages/AI/RealtimeBridge/Server/src/__tests__/transport-seam.test.ts
+++ b/packages/AI/RealtimeBridge/Server/src/__tests__/transport-seam.test.ts
@@ -945,7 +945,7 @@ describe('AIBridgeEngine — participant tracking', () => {
         await engine().StopBridgeSession(active.SessionBridgeID, 'Explicit');
     });
 
-    it('persists IsAgent ONLY for this bridge’s own bot — other agents in the room are remote participants (one-bot-per-bridge invariant)', async () => {
+    it('flags EVERY agent identity, not just this bridge’s own bot — a room’s own bot never appears in its roster', async () => {
         const session = new MockRealtimeSession();
         const bridgeRow = makeBridgeRow();
         const participantRows: FakeEntity[] = [];
@@ -962,8 +962,16 @@ describe('AIBridgeEngine — participant tracking', () => {
         const loopback = active.Bridge as LoopbackBridge;
         await new Promise((r) => setTimeout(r, 0));
 
-        // A multi-agent room as THIS bridge sees it: its OWN bot, ANOTHER agent, and a human — both agents
-        // arrive IsAgent=true in the live roster, but only the bot may persist IsAgent=true.
+        // A multi-agent room as THIS bridge sees it. NOTE the shape: a real roster comes from
+        // `room.remoteParticipants`, and a participant is never in its own remote list — so in
+        // production the bridge's own bot is NOT here. It is included below only to prove the
+        // self-match branch still works; the row that matters is `agent-other`.
+        //
+        // This test previously asserted the opposite (`other` must be false), on the reasoning that
+        // diarization would OR-reduce IsAgent across the room because every agent's own bridge marks
+        // itself. Measured against a live two-agent LiveKit room, ZERO participant rows had IsAgent
+        // set at all — because no bridge ever sees its own bot — so the OR-reduce reduced over
+        // nothing and a panel's agents were indistinguishable from its humans.
         loopback.EmitParticipants([
             { ExternalId: active.BotParticipantID as string, DisplayName: 'Me', Role: 'Agent', IsAgent: true },
             { ExternalId: 'agent-other', DisplayName: 'Other Bot', Role: 'Participant', IsAgent: true },
@@ -974,9 +982,9 @@ describe('AIBridgeEngine — participant tracking', () => {
         const bot = participantRows.find((p) => p.ExternalParticipantID === active.BotParticipantID);
         const other = participantRows.find((p) => p.ExternalParticipantID === 'agent-other');
         const human = participantRows.find((p) => p.ExternalParticipantID === 'human-1');
-        expect(bot?.IsAgent).toBe(true); // its own bot
-        expect(other?.IsAgent).toBe(false); // another agent → not THIS bridge's bot
-        expect(human?.IsAgent).toBe(false);
+        expect(bot?.IsAgent).toBe(true);    // its own bot, when the driver does report it
+        expect(other?.IsAgent).toBe(true);  // a REMOTE agent is still an agent — this is the fix
+        expect(human?.IsAgent).toBe(false); // and a human is still a human
 
         await engine().StopBridgeSession(active.SessionBridgeID, 'Explicit');
     });

--- a/packages/AI/RealtimeBridge/Server/src/__tests__/transport-seam.test.ts
+++ b/packages/AI/RealtimeBridge/Server/src/__tests__/transport-seam.test.ts
@@ -69,8 +69,10 @@ class MockRealtimeSession implements IRealtimeSession {
     public OnUsage(): void {
         /* no-op */
     }
+    /** `true` once Close() ran — lets a re-gate test assert the replaced socket was actually released. */
+    public Closed = false;
     public async Close(): Promise<void> {
-        /* no-op */
+        this.Closed = true;
     }
     public RequestSpokenUpdate(instructions: string): void {
         this.SpokenUpdates.push(instructions);
@@ -493,6 +495,390 @@ describe('AIBridgeEngine — ReconfigureSessionToMeeting', () => {
 
     it('returns false for an unknown bridge', () => {
         expect(engine().ReconfigureSessionToMeeting('nope', { IsAddressed: () => true })).toBe(false);
+    });
+});
+
+// ──────────────────────────────────────────────────────────────────────────────
+// EnsureSessionMeetingGated — the complete gate, including the RECONNECT path for providers whose turn
+// config is fixed at connect (Gemini-like). Before this existed, such an agent — if it was FIRST into the
+// room — simply kept auto-responding to every utterance and talked over the whole cast.
+// ──────────────────────────────────────────────────────────────────────────────
+
+describe('AIBridgeEngine — EnsureSessionMeetingGated', () => {
+    /** Only "gem" addresses this agent — so an unaddressed turn proves the gate, not just the flag. */
+    const addressesGem = { IsAddressed: (seg: { Text: string }) => /gem/i.test(seg.Text) };
+    const always = { IsAddressed: () => true };
+
+    it('re-gates a NON-reconfigurable provider by RECONNECTING it in meeting mode, on the same seat', async () => {
+        const { provider } = makeProvider(() => makeBridgeRow());
+        const original = new MockRealtimeSession();
+        original.CanReconfigure = false; // Gemini-like: turn config fixed at connect
+        // The replacement is the SAME provider — it is the meeting-mode MINT that gates it, not a capability
+        // that magically appeared. Keeping the flag false is what makes this test about the reconnect.
+        const fresh = new MockRealtimeSession();
+        fresh.CanReconfigure = false;
+        let reopens = 0;
+
+        const a = await engine().StartBridgeSession(
+            baseParams(original, provider, {
+                Address: 'loopback://regate-reconnect-room',
+                AgentSessionID: 'regate-1',
+                ReopenInMeetingMode: async () => {
+                    reopens++;
+                    return fresh;
+                },
+            }),
+        );
+        // The bug, stated as an assertion: a solo 1:1 seat answers everything it hears.
+        expect(engine().GetEffectiveTurnState(a.SessionBridgeID)).toEqual({ MeetingGated: false, CanReconfigureTurnMode: false });
+
+        expect(await engine().EnsureSessionMeetingGated(a.SessionBridgeID, addressesGem)).toBe(true);
+
+        expect(reopens).toBe(1);
+        expect(engine().GetEffectiveTurnState(a.SessionBridgeID)).toEqual({ MeetingGated: true, CanReconfigureTurnMode: false });
+        // Same seat: same ActiveBridgeSession object, same bridge row, same agent session — only the socket moved.
+        expect(engine().ActiveSessions).toContain(a);
+        expect(a.AgentSessionID).toBe('regate-1');
+        expect(a.RealtimeSession).toBe(fresh);
+        expect(original.Closed).toBe(true); // the replaced socket is released, never left auto-responding
+        expect(original.ReconfigureCalls.length).toBe(0); // no dead call on a provider that can't take one
+
+        // The transport seam follows the swap: room audio reaches the FRESH socket, and only it.
+        (a.Bridge as LoopbackBridge).EmitInbound({ Track: 'audio-in', Bytes: bytes(7) });
+        expect(fresh.Heard.length).toBe(1);
+        expect(original.Heard.length).toBe(0);
+
+        // And turn-taking is genuinely gated now: addressed → the bridge triggers it; unaddressed → silence.
+        fresh.EmitTranscript({ Role: 'user', Text: 'gem, are you with us?', IsFinal: true });
+        expect(fresh.SpokenUpdates.length).toBe(1);
+        fresh.EmitTranscript({ Role: 'assistant', Text: 'yes', IsFinal: true }); // finishes → frees the floor
+        fresh.EmitTranscript({ Role: 'user', Text: 'anyway, back to the roadmap', IsFinal: true });
+        expect(fresh.SpokenUpdates.length).toBe(1); // it stayed OUT of a turn it wasn't named in
+
+        await engine().StopBridgeSession(a.SessionBridgeID, 'Explicit');
+    });
+
+    it('keeps the cheap in-place path for a re-configurable provider, and is idempotent', async () => {
+        const { provider } = makeProvider(() => makeBridgeRow());
+        const capable = new MockRealtimeSession(); // CanReconfigure defaults true (OpenAI-like)
+        let reopens = 0;
+        const a = await engine().StartBridgeSession(
+            baseParams(capable, provider, {
+                Address: 'loopback://regate-inplace-room',
+                ReopenInMeetingMode: async () => {
+                    reopens++;
+                    return new MockRealtimeSession();
+                },
+            }),
+        );
+
+        expect(await engine().EnsureSessionMeetingGated(a.SessionBridgeID, always)).toBe(true);
+        // No reconnect: the live socket was simply reconfigured, and it is still the session in use.
+        expect(reopens).toBe(0);
+        expect(capable.ReconfigureCalls).toEqual([{ DisableAutoResponse: true }]);
+        expect(a.RealtimeSession).toBe(capable);
+        expect(capable.Closed).toBe(false);
+        expect(engine().GetEffectiveTurnState(a.SessionBridgeID)).toEqual({ MeetingGated: true, CanReconfigureTurnMode: true });
+
+        // Idempotent — a second (or third) agent joining must not re-push the same reconfigure.
+        expect(await engine().EnsureSessionMeetingGated(a.SessionBridgeID, always)).toBe(true);
+        expect(capable.ReconfigureCalls.length).toBe(1);
+        expect(reopens).toBe(0);
+
+        await engine().StopBridgeSession(a.SessionBridgeID, 'Explicit');
+    });
+
+    it('reconnects ONCE for concurrent callers, and mutes the un-gated socket while it happens', async () => {
+        const { provider } = makeProvider(() => makeBridgeRow());
+        const original = new MockRealtimeSession();
+        original.CanReconfigure = false;
+        const fresh = new MockRealtimeSession();
+        fresh.CanReconfigure = false;
+        let reopens = 0;
+        let releaseReopen: (() => void) | undefined;
+        const a = await engine().StartBridgeSession(
+            baseParams(original, provider, {
+                Address: 'loopback://regate-concurrent-room',
+                ReopenInMeetingMode: async () => {
+                    reopens++;
+                    await new Promise<void>((resolve) => {
+                        releaseReopen = resolve;
+                    });
+                    return fresh;
+                },
+            }),
+        );
+        const loopback = a.Bridge as LoopbackBridge;
+        // Baseline: while un-gated, the agent's audio does reach the room.
+        original.EmitOutput(bytes(1));
+        expect(loopback.Sent.length).toBe(1);
+
+        // Two agents join the room at the same instant → both ask for the gate.
+        const first = engine().EnsureSessionMeetingGated(a.SessionBridgeID, addressesGem);
+        const second = engine().EnsureSessionMeetingGated(a.SessionBridgeID, addressesGem);
+
+        // MID-RECONNECT: the socket still wired here is the one we've decided must stop answering the room —
+        // and by definition it can't be told to. The outbound seam is what keeps it quiet meanwhile.
+        original.EmitOutput(bytes(2));
+        expect(loopback.Sent.length).toBe(1);
+
+        releaseReopen?.();
+        expect(await first).toBe(true);
+        expect(await second).toBe(true);
+        expect(reopens).toBe(1); // ONE socket minted, not two racing to be swapped in
+        expect(a.RealtimeSession).toBe(fresh);
+
+        // Un-muted once the gated session is in place.
+        fresh.EmitOutput(bytes(3));
+        expect(loopback.Sent.length).toBe(2);
+
+        await engine().StopBridgeSession(a.SessionBridgeID, 'Explicit');
+    });
+
+    it('fails LOUDLY (never silently degrades) when the session cannot be re-opened', async () => {
+        const { provider } = makeProvider(() => makeBridgeRow());
+
+        // (a) No reopen hook at all → nothing can gate this seat; it must say so rather than pretend.
+        const orphan = new MockRealtimeSession();
+        orphan.CanReconfigure = false;
+        const noHook = await engine().StartBridgeSession(
+            baseParams(orphan, provider, { Address: 'loopback://regate-nohook-room' }),
+        );
+        expect(await engine().EnsureSessionMeetingGated(noHook.SessionBridgeID, always)).toBe(false);
+        expect(engine().GetEffectiveTurnState(noHook.SessionBridgeID)).toEqual({ MeetingGated: false, CanReconfigureTurnMode: false });
+        await engine().StopBridgeSession(noHook.SessionBridgeID, 'Explicit');
+
+        // (b) The hook is there but the provider is down. Capped attempts, then an honest `false` — and the
+        //     agent keeps its ORIGINAL socket: a degraded seat beats a dead one.
+        const stubborn = new MockRealtimeSession();
+        stubborn.CanReconfigure = false;
+        let attempts = 0;
+        const failing = await engine().StartBridgeSession(
+            baseParams(stubborn, provider, {
+                Address: 'loopback://regate-failing-room',
+                ReopenInMeetingMode: async () => {
+                    attempts++;
+                    throw new Error('provider refused the connection');
+                },
+            }),
+        );
+        expect(await engine().EnsureSessionMeetingGated(failing.SessionBridgeID, always)).toBe(false);
+        expect(attempts).toBe(2); // MEETING_REGATE_REOPEN_MAX_ATTEMPTS — bounded, not a retry storm
+        expect(failing.RealtimeSession).toBe(stubborn);
+        expect(stubborn.Closed).toBe(false);
+        expect(engine().GetEffectiveTurnState(failing.SessionBridgeID)?.MeetingGated).toBe(false);
+
+        // Retryable: a later join can try again (the in-flight guard was cleared, not latched).
+        expect(await engine().EnsureSessionMeetingGated(failing.SessionBridgeID, always)).toBe(false);
+        expect(attempts).toBe(4);
+
+        await engine().StopBridgeSession(failing.SessionBridgeID, 'Explicit');
+    });
+
+    it('does not strand the fresh socket when the seat is torn down mid-reopen', async () => {
+        const { provider } = makeProvider(() => makeBridgeRow());
+        const original = new MockRealtimeSession();
+        original.CanReconfigure = false;
+        const fresh = new MockRealtimeSession();
+        let releaseReopen: (() => void) | undefined;
+        const a = await engine().StartBridgeSession(
+            baseParams(original, provider, {
+                Address: 'loopback://regate-torndown-room',
+                ReopenInMeetingMode: async () => {
+                    await new Promise<void>((resolve) => {
+                        releaseReopen = resolve;
+                    });
+                    return fresh;
+                },
+            }),
+        );
+
+        const gating = engine().EnsureSessionMeetingGated(a.SessionBridgeID, always);
+        // The room empties (or the janitor reaps it) while the replacement socket is still being minted.
+        await engine().StopBridgeSession(a.SessionBridgeID, 'Explicit');
+        releaseReopen?.();
+
+        expect(await gating).toBe(false);
+        // Teardown already ran, so nothing would ever close the newcomer — it is handed back, not wired in.
+        expect(fresh.Closed).toBe(true);
+        expect(fresh.Heard.length).toBe(0);
+    });
+
+    it('reports no turn state for a bridge this process does not hold', async () => {
+        expect(engine().GetEffectiveTurnState('nope')).toBeNull();
+        expect(await engine().EnsureSessionMeetingGated('nope', always)).toBe(false);
+    });
+});
+
+// ──────────────────────────────────────────────────────────────────────────────
+// Human takeover — suspend / resume an agent WITHOUT ending its session.
+// ──────────────────────────────────────────────────────────────────────────────
+
+describe('AIBridgeEngine — SuspendBridgeAgent / ResumeBridgeAgent', () => {
+    it('a suspended meeting agent stops speaking + publishing but keeps hearing on a live session', async () => {
+        const session = new MockRealtimeSession();
+        const { provider } = makeProvider(() => makeBridgeRow());
+        const active = await engine().StartBridgeSession(
+            baseParams(session, provider, {
+                TurnMode: 'Passive',
+                DisableAutoResponse: true,
+                TurnMatcher: { IsAddressed: () => true },
+            }),
+        );
+        const loopback = active.Bridge as LoopbackBridge;
+
+        // Baseline: addressed → the bridge triggers the model, and the agent's audio reaches the room.
+        session.EmitTranscript({ Role: 'user', Text: 'hello', IsFinal: true });
+        expect(session.SpokenUpdates.length).toBe(1);
+        session.EmitOutput(bytes(1));
+        expect(loopback.Sent.length).toBe(1);
+        session.EmitTranscript({ Role: 'assistant', Text: 'hi there', IsFinal: true }); // finishes → frees the floor
+
+        // A human takes the seat.
+        expect(engine().SuspendBridgeAgent(active.SessionBridgeID)).toBe(true);
+        expect(engine().SuspendBridgeAgent(active.SessionBridgeID)).toBe(true); // idempotent
+
+        // It no longer answers when addressed...
+        session.EmitTranscript({ Role: 'user', Text: 'hello again', IsFinal: true });
+        expect(session.SpokenUpdates.length).toBe(1);
+        // ...and nothing it emits reaches the room (an in-flight response can't leak through).
+        session.EmitOutput(bytes(2));
+        expect(loopback.Sent.length).toBe(1);
+
+        // But the session is fully alive: still connected, still in the registry, still HEARING the meeting
+        // (so it resumes with the context it missed rather than a hole).
+        expect(loopback.IsConnected).toBe(true);
+        expect(engine().ActiveSessions.find((s) => s.SessionBridgeID === active.SessionBridgeID)).toBeDefined();
+        const heardBefore = session.Heard.length;
+        loopback.EmitInbound({ Track: 'audio-in', Bytes: bytes(5) });
+        expect(session.Heard.length).toBe(heardBefore + 1);
+
+        // Handing the seat back restores the voice.
+        expect(engine().ResumeBridgeAgent(active.SessionBridgeID)).toBe(true);
+        session.EmitTranscript({ Role: 'user', Text: 'you again', IsFinal: true });
+        expect(session.SpokenUpdates.length).toBe(2);
+        session.EmitOutput(bytes(3));
+        expect(loopback.Sent.length).toBe(2);
+        // It was ALREADY in meeting mode, so suspending never had to touch the socket config.
+        expect(session.ReconfigureCalls.length).toBe(0);
+
+        await engine().StopBridgeSession(active.SessionBridgeID, 'Explicit');
+    });
+
+    it('silences a 1:1 agent on the live socket, and resume restores exactly the prior state (not a default)', async () => {
+        const session = new MockRealtimeSession();
+        const { provider } = makeProvider(() => makeBridgeRow());
+        const active = await engine().StartBridgeSession(
+            baseParams(session, provider, { TurnMode: 'Passive', TurnMatcher: { IsAddressed: () => true } }),
+        );
+        const priorPolicy = active.TurnPolicy;
+        expect(active.DisableAutoResponse).toBe(false);
+
+        expect(engine().SuspendBridgeAgent(active.SessionBridgeID)).toBe(true);
+        // The only way to silence an auto-responding model is to turn auto-response off on the live socket.
+        expect(session.ReconfigureCalls).toEqual([{ DisableAutoResponse: true }]);
+        expect(active.DisableAutoResponse).toBe(true);
+        expect(active.TurnPolicy).not.toBe(priorPolicy); // swapped onto the never-addressed matcher
+        expect(active.SuspendedState?.PriorDisableAutoResponse).toBe(false);
+
+        expect(engine().ResumeBridgeAgent(active.SessionBridgeID)).toBe(true);
+        // Restored to what it WAS (1:1 auto-response + its own policy), NOT to the meeting-mode state the
+        // suspension gated it into — a resumed agent must behave exactly as it did before the takeover.
+        expect(session.ReconfigureCalls).toEqual([{ DisableAutoResponse: true }, { DisableAutoResponse: false }]);
+        expect(active.DisableAutoResponse).toBe(false);
+        expect(active.TurnPolicy).toBe(priorPolicy);
+        expect(active.SuspendedState).toBeUndefined();
+        // Idempotent — resuming an active agent changes nothing.
+        expect(engine().ResumeBridgeAgent(active.SessionBridgeID)).toBe(true);
+        expect(session.ReconfigureCalls.length).toBe(2);
+
+        await engine().StopBridgeSession(active.SessionBridgeID, 'Explicit');
+    });
+
+    it('refuses to suspend a 1:1 agent whose provider cannot gate the model mid-session — and mutates NOTHING', async () => {
+        const session = new MockRealtimeSession();
+        session.CanReconfigure = false; // Gemini-like: config fixed at connect
+        const { provider } = makeProvider(() => makeBridgeRow());
+        const active = await engine().StartBridgeSession(
+            baseParams(session, provider, { TurnMode: 'Passive', TurnMatcher: { IsAddressed: () => true } }),
+        );
+        const priorPolicy = active.TurnPolicy;
+
+        // Refused: a half-suspended agent would keep auto-answering OVER the human taking its seat.
+        expect(engine().SuspendBridgeAgent(active.SessionBridgeID)).toBe(false);
+        expect(session.ReconfigureCalls.length).toBe(0);
+        expect(active.TurnPolicy).toBe(priorPolicy);
+        expect(active.DisableAutoResponse).toBe(false);
+        expect(active.SuspendedState).toBeUndefined();
+        // Still fully operational — its audio still reaches the room.
+        session.EmitOutput(bytes(1));
+        expect((active.Bridge as LoopbackBridge).Sent.length).toBe(1);
+
+        await engine().StopBridgeSession(active.SessionBridgeID, 'Explicit');
+    });
+
+    it('suspends an INCAPABLE agent that is already in meeting mode (no socket change is needed)', async () => {
+        const session = new MockRealtimeSession();
+        session.CanReconfigure = false;
+        const { provider } = makeProvider(() => makeBridgeRow());
+        const active = await engine().StartBridgeSession(
+            baseParams(session, provider, {
+                TurnMode: 'Passive',
+                DisableAutoResponse: true,
+                TurnMatcher: { IsAddressed: () => true },
+            }),
+        );
+
+        expect(engine().SuspendBridgeAgent(active.SessionBridgeID)).toBe(true);
+        expect(session.ReconfigureCalls.length).toBe(0);
+        session.EmitTranscript({ Role: 'user', Text: 'anyone there?', IsFinal: true });
+        expect(session.SpokenUpdates.length).toBe(0);
+        // Resume likewise needs no socket change (the prior state was already auto-response-off).
+        expect(engine().ResumeBridgeAgent(active.SessionBridgeID)).toBe(true);
+        expect(session.ReconfigureCalls.length).toBe(0);
+        session.EmitTranscript({ Role: 'user', Text: 'back with us?', IsFinal: true });
+        expect(session.SpokenUpdates.length).toBe(1);
+
+        await engine().StopBridgeSession(active.SessionBridgeID, 'Explicit');
+    });
+
+    it('suspending frees the room floor and takes the seat out of the room broadcast', async () => {
+        const addr = 'loopback://takeover-room';
+        const sessionA = new MockRealtimeSession();
+        const sessionB = new MockRealtimeSession();
+        const { provider } = makeProvider(() => makeBridgeRow());
+        const meeting = { TurnMode: 'Passive' as const, DisableAutoResponse: true, TurnMatcher: { IsAddressed: () => true } };
+        const a = await engine().StartBridgeSession(baseParams(sessionA, provider, { ...meeting, Address: addr, AgentSessionID: 'take-A' }));
+        const b = await engine().StartBridgeSession(baseParams(sessionB, provider, { ...meeting, Address: addr, AgentSessionID: 'take-B' }));
+        const coord = engine().RoomCoordinator;
+        const roomKey = a.RoomKey!;
+
+        // A answers first and holds the floor; B is blocked behind it.
+        sessionA.EmitTranscript({ Role: 'user', Text: 'hello room', IsFinal: true });
+        expect(sessionA.SpokenUpdates.length).toBe(1);
+        expect(sessionB.SpokenUpdates.length).toBe(0);
+        expect(coord.IsFloorHolder(roomKey, 'take-A')).toBe(true);
+
+        // A human takes A's seat mid-turn: the floor is handed back immediately...
+        expect(engine().SuspendBridgeAgent(a.SessionBridgeID)).toBe(true);
+        expect(coord.IsFloorHolder(roomKey, 'take-A')).toBe(false);
+        expect(a.SuspendedState?.HeldFloor).toBe(true);
+
+        // ...and the next turn routes past the suspended seat to B.
+        sessionA.EmitTranscript({ Role: 'user', Text: 'anyone else', IsFinal: true });
+        expect(sessionA.SpokenUpdates.length).toBe(1);
+        expect(sessionB.SpokenUpdates.length).toBe(1);
+
+        // A is still a room member throughout (present, just silent) — never unregistered, never reaped.
+        expect(coord.GetRoomState(roomKey)!.AgentSessionIds).toEqual(expect.arrayContaining(['take-A', 'take-B']));
+
+        await engine().StopBridgeSession(a.SessionBridgeID, 'Explicit');
+        await engine().StopBridgeSession(b.SessionBridgeID, 'Explicit');
+    });
+
+    it('returns false for an unknown bridge (both directions)', () => {
+        expect(engine().SuspendBridgeAgent('nope')).toBe(false);
+        expect(engine().ResumeBridgeAgent('nope')).toBe(false);
     });
 });
 

--- a/packages/AI/RealtimeBridge/Server/src/ai-bridge-engine.ts
+++ b/packages/AI/RealtimeBridge/Server/src/ai-bridge-engine.ts
@@ -1372,13 +1372,23 @@ export class AIBridgeEngine extends BaseSingleton<AIBridgeEngine> implements ISt
         }
         row.DisplayName = p.DisplayName ?? null;
         row.Role = p.Role;
-        // Persist IsAgent ONLY for THIS bridge's own bot — the row-level invariant is "one bot per bridge".
-        // In a multi-agent room the live roster (driver-side `p.IsAgent`) flags OTHER agents too (turn-taking
-        // + occupancy need that), but on THIS bridge's persisted roster they are remote participants, not its
-        // bot. Diarization still resolves them: each agent's OWN bridge marks itself, and the transcript
-        // viewer OR-reduces IsAgent per identity across all of the room's bridges.
+        // Trust the DRIVER's answer, which already means "is this identity an agent" — the local bot
+        // (`IsLocal`) or any bot by identity convention.
+        //
+        // This used to recompute it as "is this MY bot", on the reasoning that a remote agent is not
+        // this bridge's bot and that diarization could OR-reduce across the room because "each
+        // agent's OWN bridge marks itself". That last premise is false: a roster comes from
+        // `room.remoteParticipants`, and a participant is never in its own remote list, so a
+        // bridge's own bot NEVER appears in its roster. The OR-reduce therefore reduced over
+        // nothing — measured on a live two-agent room, ZERO rows had IsAgent set, so per-turn
+        // diarization could not tell an agent from a human anywhere in a panel.
+        //
+        // Flagging remote agents is also what a consumer actually asks: "is this speaker an agent?"
+        // is a property of the identity, not of which bridge happened to observe it.
         row.IsAgent =
-            active.BotParticipantID != null && p.ExternalId.toLowerCase() === active.BotParticipantID.toLowerCase();
+            p.IsAgent === true
+            || (active.BotParticipantID != null
+                && p.ExternalId.toLowerCase() === active.BotParticipantID.toLowerCase());
         const saved = await row.Save();
         if (!saved) {
             LogError(

--- a/packages/AI/RealtimeBridge/Server/src/ai-bridge-engine.ts
+++ b/packages/AI/RealtimeBridge/Server/src/ai-bridge-engine.ts
@@ -93,11 +93,77 @@ const SESSION_IDLE_TTL_MS = 10 * 60 * 1000; // 10 min with no transcript activit
 const SESSION_MAX_DURATION_MS = 4 * 60 * 60 * 1000; // 4 h absolute cap
 const STALE_SWEEP_INTERVAL_MS = 60 * 1000; // sweep cadence when self-scheduled
 
+/**
+ * The addressed-matcher a **suspended** agent runs behind: nothing ever addresses it, so its turn policy
+ * can never decide `Speak` while a human holds its seat. Swapping the matcher (rather than tearing the
+ * policy out) is the same move {@link AIBridgeEngine.ReconfigureSessionToMeeting} makes to re-gate a live
+ * session — everything else about the session keeps running; only the gate that lets it talk changes.
+ * Stateless and side-effect-free, so one shared instance serves every suspended session.
+ */
+const SUSPENDED_AGENT_MATCHER: IAddressedMatcher = {
+    IsAddressed: () => false,
+};
+
 /** Context note injected into a re-gated agent so it knows it's now in a meeting (its prompt predates it). */
 const MEETING_REGATE_CONTEXT_NOTE =
     'You are now in a multi-party meeting with other people and agents. Stop responding to everything you ' +
     'hear — listen, and speak only when you are addressed by name or the conversation clearly needs your ' +
     'expertise. Never talk over others, and keep your replies brief.';
+
+/**
+ * How many times {@link AIBridgeEngine.EnsureSessionMeetingGated} will ask the session's
+ * {@link MeetingModeSessionReopener} for a fresh meeting-mode socket before giving up. Small on purpose: the
+ * reopen runs INSIDE room formation while the un-gated agent is muted, so a long retry ladder would hold the
+ * room open with a silent seat. One retry covers a transient provider hiccup; anything worse is a real
+ * outage and is reported LOUDLY instead of being retried into a timeout.
+ */
+const MEETING_REGATE_REOPEN_MAX_ATTEMPTS = 2;
+
+/**
+ * Re-opens ONE bridged agent's provider socket in **meeting mode** (model auto-response disabled, meeting
+ * prompt phrasing) and returns the fresh session — the escape hatch for providers that fix their turn config
+ * at connect (Gemini Live) and therefore cannot be re-gated on a live socket.
+ *
+ * Registered per session via {@link StartBridgeSessionParams.ReopenInMeetingMode}, because the engine
+ * deliberately does NOT own the realtime-session factory (see {@link AIBridgeEngine} — the injected
+ * `IRealtimeSession` is the engine's only coupling to the model layer). The layer that DID mint the session
+ * hands the engine a closure over its own factory arguments, so the engine keeps the whole "can this provider
+ * re-gate in place, and what do we do if it can't?" decision in one place instead of leaking it to callers.
+ *
+ * The reopened session MUST be for the same agent + the same `AIAgentSession`: the engine reuses the existing
+ * `AIAgentSessionBridge` row, driver, room membership, scribe role and per-turn attribution, and only swaps
+ * the provider socket underneath them.
+ *
+ * @returns The fresh, meeting-mode realtime session to swap in.
+ * @throws When the session cannot be re-opened (surfaced by the engine, capped by
+ *   {@link MEETING_REGATE_REOPEN_MAX_ATTEMPTS}).
+ */
+export type MeetingModeSessionReopener = () => Promise<IRealtimeSession>;
+
+/**
+ * The **effective** turn state of a live bridged session — what the session is actually doing right now, as
+ * opposed to what it was started with. Read via {@link AIBridgeEngine.GetEffectiveTurnState}.
+ *
+ * This exists because a mis-gated agent is otherwise only *audible*: an agent that keeps auto-responding to a
+ * whole room talks over the cast, and nothing in the API surface said so. Exposing the state lets room
+ * formation (and automated tests) ASSERT the room is gated instead of listening to it.
+ */
+export interface EffectiveTurnState {
+    /**
+     * Whether the session is currently meeting-gated: the model's blind auto-response is OFF **and** the
+     * bridge's own gate is the addressed-only (`Passive`) policy — i.e. it speaks only when its matcher says
+     * it was addressed (or when the room moderator routes it a turn). `false` means the session is in 1:1
+     * auto-response and WILL answer everything it hears, which is exactly the multi-agent failure mode.
+     */
+    MeetingGated: boolean;
+
+    /**
+     * Whether this session's provider can change turn mode on a LIVE socket
+     * ({@link RealtimeSessionCapabilities.CanReconfigureTurnMode}). `false` (Gemini Live) means re-gating it
+     * costs a socket reconnect — see {@link AIBridgeEngine.EnsureSessionMeetingGated}.
+     */
+    CanReconfigureTurnMode: boolean;
+}
 
 /**
  * Finalizes the co-agent observability run(s) for an agent session when a bridge is torn down WITHOUT a
@@ -316,6 +382,14 @@ export interface StartBridgeSessionParams {
      */
     DisableAutoResponse?: boolean;
 
+    /**
+     * Optional per-session hook that re-opens THIS agent's provider socket in meeting mode. Supplied by the
+     * layer that owns the realtime-session factory (e.g. `LiveKitAgentRoomCoordinator`), it is what lets
+     * {@link AIBridgeEngine.EnsureSessionMeetingGated} re-gate a provider whose turn config is fixed at
+     * connect — the reconnect path. Omit it and such a session simply cannot be gated (reported loudly).
+     */
+    ReopenInMeetingMode?: MeetingModeSessionReopener;
+
     /** Per-session bridge configuration (resolved credential refs, region, …) passed to the driver. */
     Configuration?: Record<string, unknown>;
 
@@ -375,6 +449,31 @@ export interface StartBridgeSessionParams {
 }
 
 /**
+ * What a **suspended** agent's seat is restored to on resume — captured verbatim at suspend time so
+ * {@link AIBridgeEngine.ResumeBridgeAgent} puts back what was actually there instead of a guessed default.
+ * That matters: a session may have started 1:1 and been re-gated to meeting mode by
+ * {@link AIBridgeEngine.ReconfigureSessionToMeeting}, or carry per-session turn tuning from its start
+ * params — "restore the defaults" would silently change how the agent behaves after a takeover.
+ */
+export interface SuspendedAgentState {
+    /** The turn-taking policy in force at suspend time (mode + matcher + tuning + its live throttle state). */
+    PriorTurnPolicy: TurnTakingPolicy;
+
+    /** {@link ActiveBridgeSession.DisableAutoResponse} as it was at suspend time. */
+    PriorDisableAutoResponse: boolean;
+
+    /**
+     * Whether the session held the room floor when it was suspended. Recorded for observability only —
+     * the floor is released on suspend and deliberately NOT re-claimed on resume (the agent speaks again
+     * when it is next addressed/routed, like any other agent that just finished a turn).
+     */
+    HeldFloor: boolean;
+
+    /** Epoch-ms the suspension began (observability / diagnostics). */
+    SuspendedAtMs: number;
+}
+
+/**
  * The live, in-memory handle for one running bridged session held by the engine. Carries the driver,
  * the wired realtime session, the per-session turn-taking policy, and the persisted bridge row id so
  * teardown can reach all of them.
@@ -404,6 +503,36 @@ export interface ActiveBridgeSession {
      * `false` the model auto-responds and the engine stays hands-off (forcing would double-fire).
      */
     DisableAutoResponse: boolean;
+
+    /**
+     * Set while this agent is **suspended** — a human has taken its seat. Its presence IS the suspended
+     * flag, and it carries the exact pre-suspend state {@link AIBridgeEngine.ResumeBridgeAgent} restores.
+     * A suspended session stays fully alive — provider socket, `AIAgentSession`, transcript persistence,
+     * participant row and co-agent observability run all keep running, and it keeps HEARING the room — it
+     * simply never speaks or publishes. `undefined` whenever the agent is active.
+     */
+    SuspendedState?: SuspendedAgentState;
+
+    /**
+     * The per-session hook that re-opens this agent's provider socket in meeting mode, as supplied at start
+     * ({@link StartBridgeSessionParams.ReopenInMeetingMode}). Held here because the re-gate decision happens
+     * long after start, when a second agent joins the room.
+     */
+    ReopenInMeetingMode?: MeetingModeSessionReopener;
+
+    /**
+     * The in-flight meeting-mode reopen for this session, when one is running. Serves two jobs at once:
+     *
+     * 1. **Idempotency** — a second `EnsureSessionMeetingGated` call (two agents joining at once) awaits the
+     *    SAME promise instead of minting a second socket and racing to swap it in.
+     * 2. **The mute** — its mere presence means "the socket currently wired here is the un-gated one we are
+     *    replacing", so the outbound half of the transport seam drops its frames (see
+     *    {@link AIBridgeEngine.wireTransportSeam}). Without it, the agent we've already decided is talking
+     *    over the room would keep doing exactly that for the whole reconnect.
+     *
+     * `undefined` whenever no reopen is running.
+     */
+    PendingMeetingReopen?: Promise<boolean>;
 
     /**
      * Whether at least one HUMAN participant has been seen in the room. Auto-leave only fires after a human
@@ -870,6 +999,7 @@ export class AIBridgeEngine extends BaseSingleton<AIBridgeEngine> implements ISt
                 RealtimeSession: params.RealtimeSession,
                 TurnPolicy: turnPolicy,
                 DisableAutoResponse: params.DisableAutoResponse === true,
+                ReopenInMeetingMode: params.ReopenInMeetingMode,
                 HasSeenHuman: false,
                 RoomKey: result.ExternalConnectionId,
                 BotParticipantID: result.BotParticipantId,
@@ -993,6 +1123,18 @@ export class AIBridgeEngine extends BaseSingleton<AIBridgeEngine> implements ISt
 
         // Outbound: the agent speaks → into the meeting/call.
         RealtimeSession.OnOutput((chunk: ArrayBuffer) => {
+            // SUSPENDED (a human took this agent's seat): the model may still be finishing a response it
+            // started before the takeover, and a provider that ignores a reconfigure would keep generating.
+            // The outbound half of the seam is the one place the engine can GUARANTEE silence regardless —
+            // so drop the frames here rather than trusting the gates upstream. See SuspendBridgeAgent.
+            //
+            // RE-GATING (a meeting-mode reopen is in flight): the socket wired here is the un-gated 1:1 one
+            // we have already decided must stop answering the room — and by definition it cannot be told to.
+            // The same outbound gate is the only thing that keeps it quiet for the seconds the reconnect
+            // takes. See EnsureSessionMeetingGated.
+            if (active.SuspendedState || active.PendingMeetingReopen) {
+                return;
+            }
             if (!this.diagOutbound.has(active.SessionBridgeID)) {
                 this.diagOutbound.add(active.SessionBridgeID);
                 LogStatusEx({ message: `[AIBridgeEngine][diag] FIRST outbound audio from the agent (bridge ${active.SessionBridgeID}). The agent is SPEAKING into the room.`, verboseOnly: true });
@@ -1005,6 +1147,9 @@ export class AIBridgeEngine extends BaseSingleton<AIBridgeEngine> implements ISt
         // audio-only sessions don't implement OnVideoOutput, so call it null-safely. The bridge driver
         // gates the actual publish on its `VideoOut` capability.
         RealtimeSession.OnVideoOutput?.((chunk: ArrayBuffer) => {
+            if (active.SuspendedState || active.PendingMeetingReopen) {
+                return; // takeover / re-gate reopen — the avatar goes quiet with the voice (same rationale as above)
+            }
             const track: BridgeMediaTrackKind = 'video-out';
             Bridge.SendMedia(track, this.arrayBufferToFrame(chunk, track));
         });
@@ -1320,10 +1465,19 @@ export class AIBridgeEngine extends BaseSingleton<AIBridgeEngine> implements ISt
             this.roomConsecutiveAgentTurns.set(source.RoomKey.toLowerCase(), 0);
         }
 
+        // Speaking discipline only concerns agents that MAY speak: a suspended seat (a human took it over)
+        // is skipped from here down — the human answers in its place. It still got `noteHumanPresence`
+        // above, so it is never auto-reaped while the person is holding its seat.
+        const speakers = peers.filter((p) => !p.SuspendedState);
+        if (speakers.length === 0) {
+            return; // every agent in this room is suspended — the humans have the conversation to themselves
+        }
         if (peers.length <= 1) {
-            this.evaluateUserTurnForAgent(source, text); // 1:1 / solo room — no broadcast, no dedup
+            this.evaluateUserTurnForAgent(speakers[0], text); // 1:1 / solo room — no broadcast, no dedup
             return;
         }
+        // Dedup keys on the ROOM, not on the eligible speakers: a SUSPENDED agent still hears and transcribes,
+        // so the same utterance can arrive from it too and must collapse into the one dispatch.
         const now = Date.now();
         const dedupKey = `${source.RoomKey!.toLowerCase()}\n${text.trim().toLowerCase()}`;
         if (now - (this.recentRoomTurnDispatch.get(dedupKey) ?? 0) < ROOM_TURN_DEDUP_MS) {
@@ -1336,12 +1490,15 @@ export class AIBridgeEngine extends BaseSingleton<AIBridgeEngine> implements ISt
 
         // MODERATOR PATH: one LLM decision routes the turn to 0+ agents (serialized via the floor). FALLBACK
         // (no moderator configured): each agent independently evaluates its own addressed-matcher (broadcast).
-        if (this.turnModerator) {
+        // The moderator only arbitrates BETWEEN agents, so a room down to one eligible speaker (its peers on
+        // human takeover) falls through to the matcher path — the moderator would bail on a 1-agent roster
+        // and nobody would answer.
+        if (this.turnModerator && speakers.length > 1) {
             void this.runRoomModerator(source.RoomKey!, { Speaker: this.speakerLabel(source, false), IsAgent: false, Text: text });
             return;
         }
-        LogStatusEx({ message: `[AIBridgeEngine][diag] broadcasting user turn "${text.slice(0, 60)}" to ${peers.length} room agents for addressing (source bridge ${source.SessionBridgeID})`, verboseOnly: true });
-        for (const peer of peers) {
+        LogStatusEx({ message: `[AIBridgeEngine][diag] broadcasting user turn "${text.slice(0, 60)}" to ${speakers.length} room agents for addressing (source bridge ${source.SessionBridgeID})`, verboseOnly: true });
+        for (const peer of speakers) {
             this.evaluateUserTurnForAgent(peer, text);
         }
     }
@@ -1362,6 +1519,17 @@ export class AIBridgeEngine extends BaseSingleton<AIBridgeEngine> implements ISt
         const decision = active.TurnPolicy.EvaluateTurn({ Segment: segment });
         LogStatusEx({ message: `[AIBridgeEngine][diag] turn decision=${decision.Action} for user turn "${(text ?? '').slice(0, 60)}" (bridge ${active.SessionBridgeID})`, verboseOnly: true });
         this.applyTurnDecision(active, decision.Action);
+    }
+
+    /**
+     * The room's agents that are eligible to SPEAK — everything in the room minus the seats a human has
+     * taken over ({@link SuspendBridgeAgent}). Turn routing (broadcast, moderator roster, continuation)
+     * uses this. Anything about presence or liveness — occupancy, auto-leave, the stale sweep — must keep
+     * using {@link roomAgents}: a suspended agent is still very much in the room and must not be reaped
+     * while the human is speaking for it.
+     */
+    private speakingRoomAgents(roomKey: string): ActiveBridgeSession[] {
+        return this.roomAgents(roomKey).filter((a) => !a.SuspendedState);
     }
 
     /** All active bridged sessions sharing a room (by external room key), case-insensitive. */
@@ -1430,7 +1598,9 @@ export class AIBridgeEngine extends BaseSingleton<AIBridgeEngine> implements ISt
      * still playing out), the moderator's latency is hidden behind playback. No-op for single-agent rooms.
      */
     private onAgentTurnCompleted(active: ActiveBridgeSession, text: string): void {
-        if (!active.RoomKey || !this.turnModerator || this.roomAgents(active.RoomKey).length <= 1) {
+        // Suspended seats don't take turns, so a room whose only other agent is on takeover has no
+        // agent↔agent continuation to run (its remaining agent is routed by the matcher path instead).
+        if (!active.RoomKey || !this.turnModerator || this.speakingRoomAgents(active.RoomKey).length <= 1) {
             return;
         }
         const key = active.RoomKey.toLowerCase();
@@ -1505,7 +1675,9 @@ export class AIBridgeEngine extends BaseSingleton<AIBridgeEngine> implements ISt
     /** Builds the {@link TurnModeratorContext} for a room from the live roster + diarized lookback. */
     private buildModeratorContext(roomKey: string, latest: ModeratorLookbackTurn): TurnModeratorContext {
         const key = roomKey.toLowerCase();
-        const agents = this.roomAgents(roomKey);
+        // Suspended agents are off the roster: the moderator must never route a turn to a seat a human is
+        // holding (it would be answered by nobody, since triggerMeetingSpeak refuses a suspended session).
+        const agents = this.speakingRoomAgents(roomKey);
         const roster: ModeratorRosterAgent[] = agents.map((a) => ({
             AgentSessionID: a.AgentSessionID,
             AgentID: a.AgentID,
@@ -1561,6 +1733,14 @@ export class AIBridgeEngine extends BaseSingleton<AIBridgeEngine> implements ISt
      * (stays silent) when another agent holds the floor. Shared by the matcher path and the moderator drainer.
      */
     private triggerMeetingSpeak(active: ActiveBridgeSession): boolean {
+        if (active.SuspendedState) {
+            // A human holds this seat. BOTH routes to the agent's voice funnel through here — the matcher
+            // path via applyTurnDecision and the moderator's queue drain, which bypasses the turn policy
+            // entirely — so this single guard is what actually keeps a suspended agent silent. Returning
+            // `false` also makes drainSpeakerQueue advance to the next queued speaker instead of stalling.
+            LogStatusEx({ message: `[AIBridgeEngine][diag] meeting trigger SKIPPED for bridge ${active.SessionBridgeID} — the agent is suspended (a human has its seat)`, verboseOnly: true });
+            return false;
+        }
         if (active.RoomKey) {
             const floor = this.roomCoordinator.TakeFloor(active.RoomKey, active.AgentSessionID);
             if (!floor.Granted) {
@@ -1653,11 +1833,16 @@ export class AIBridgeEngine extends BaseSingleton<AIBridgeEngine> implements ISt
     }
 
     /**
-     * Retroactively switches an already-running session into **meeting mode** (auto-response off +
-     * addressed-only) — used when a room becomes multi-agent and the first (1:1) agent must stop
-     * auto-responding. **Capability-gated**: only sessions whose provider reports
-     * {@link RealtimeSessionCapabilities.CanReconfigureTurnMode} can change turn mode on a live socket;
-     * others (e.g. Gemini, fixed at connect) are left in their start mode — no dead-method call. Idempotent.
+     * The **in-place** half of re-gating: switches an already-running session into meeting mode
+     * (auto-response off + addressed-only) on its LIVE socket, with no reconnect. Used when a room becomes
+     * multi-agent and the first (1:1) agent must stop auto-responding. **Capability-gated**: only sessions
+     * whose provider reports {@link RealtimeSessionCapabilities.CanReconfigureTurnMode} can change turn mode
+     * on a live socket; others (e.g. Gemini, fixed at connect) are refused here — no dead-method call.
+     * Idempotent.
+     *
+     * **Prefer {@link EnsureSessionMeetingGated}**, the complete operation: it takes this cheap path when the
+     * provider supports it and re-opens the socket in meeting mode when it doesn't. This primitive stays
+     * public (and synchronous) for callers that specifically want "re-gate it only if it's free".
      *
      * @param sessionBridgeID The bridge to re-gate.
      * @param matcher The addressed-matcher (the agent's names) the re-gated session should speak on.
@@ -1674,15 +1859,16 @@ export class AIBridgeEngine extends BaseSingleton<AIBridgeEngine> implements ISt
         }
         if (active.RealtimeSession.Capabilities?.CanReconfigureTurnMode !== true) {
             // LOUD: this agent was the FIRST in the room (1:1 auto-response) and its provider can't switch a
-            // live socket to meeting mode (e.g. Gemini). It will keep auto-responding to ALL room audio,
-            // bypassing the turn moderator and likely talking over the other agents. The robust fix is to
-            // reconnect it in meeting mode; until then, prefer a re-configurable provider (OpenAI) as the FIRST
-            // agent in a room that will become multi-agent. See the Bridges guide §9.
+            // live socket to meeting mode (e.g. Gemini). Left like this it keeps auto-responding to ALL room
+            // audio, bypassing the turn moderator and talking over the other agents. That is exactly what
+            // {@link EnsureSessionMeetingGated} exists to prevent — it re-opens the socket in meeting mode
+            // instead of giving up — so callers should use IT, not this in-place primitive, whenever a
+            // reconnect is acceptable. Reaching here means the caller took the in-place path knowingly.
             LogError(
-                `[AIBridgeEngine] ⚠️ bridge ${sessionBridgeID} CANNOT re-gate to meeting mode mid-session ` +
+                `[AIBridgeEngine] ⚠️ bridge ${sessionBridgeID} CANNOT re-gate to meeting mode IN PLACE ` +
                     `(provider config fixed at connect, e.g. Gemini). It stays in 1:1 auto-response and will ` +
-                    `respond to ALL room audio, bypassing the moderator — use an OpenAI-realtime agent as the ` +
-                    `first agent in multi-agent rooms.`,
+                    `respond to ALL room audio, bypassing the moderator. Call EnsureSessionMeetingGated ` +
+                    `instead — it re-opens the session in meeting mode when the provider can't be reconfigured.`,
             );
             return false;
         }
@@ -1694,6 +1880,352 @@ export class AIBridgeEngine extends BaseSingleton<AIBridgeEngine> implements ISt
         // meeting-appropriate. A context note is additive (doesn't clobber the prompt) — no-op if unsupported.
         active.RealtimeSession.SendContextNote?.(MEETING_REGATE_CONTEXT_NOTE);
         LogStatus(`[AIBridgeEngine] re-gated bridge ${sessionBridgeID} to meeting mode (room became multi-agent)`);
+        return true;
+    }
+
+    /**
+     * Guarantees a live session ends up **meeting-gated** — the complete operation
+     * {@link ReconfigureSessionToMeeting} is only the cheap half of. Two paths, one outcome:
+     *
+     * - **Provider can reconfigure a live socket** (OpenAI realtime): the in-place path, unchanged and free.
+     * - **Provider fixes its turn config at connect** (Gemini Live): the socket is **re-opened** in meeting
+     *   mode via the session's {@link MeetingModeSessionReopener} and swapped in underneath the running
+     *   bridge. The `AIAgentSessionBridge` row, the `AIAgentSession`, the driver + room membership, the
+     *   scribe election and per-turn attribution are all reused — only the provider socket changes.
+     *
+     * That second path is why this method exists. Before it, a room whose FIRST agent ran a fixed-config
+     * provider was never gated at all: the engine logged a warning and that agent kept auto-responding to
+     * every utterance in the room, talking over the whole cast. There was no way to even *observe* it short
+     * of listening — see {@link GetEffectiveTurnState}, which now makes the outcome assertable.
+     *
+     * **Idempotent and concurrency-safe.** An already-gated session returns `true` untouched; two callers
+     * arriving together (two agents joining at once) share ONE reopen via
+     * {@link ActiveBridgeSession.PendingMeetingReopen} rather than minting two sockets. Never throws — a
+     * failure is logged LOUDLY and reported as `false` so room formation can decide what to do about a seat
+     * it could not gate.
+     *
+     * @param sessionBridgeID The bridge to gate into meeting mode.
+     * @param matcher The addressed-matcher (the agent's names) the gated session should speak on.
+     * @returns `true` when the session is meeting-gated (or already was); `false` when it is unknown to this
+     *   process, has no reopen hook and can't reconfigure, or the reopen failed.
+     */
+    public async EnsureSessionMeetingGated(sessionBridgeID: string, matcher: IAddressedMatcher): Promise<boolean> {
+        const active = this.activeSessions.get(sessionBridgeID.toLowerCase());
+        if (!active) {
+            return false;
+        }
+        if (active.DisableAutoResponse) {
+            return true; // already meeting mode — nothing to do (same idempotency contract as the in-place path)
+        }
+        if (active.PendingMeetingReopen) {
+            return active.PendingMeetingReopen; // a reopen is already running for this session — share it
+        }
+        if (active.RealtimeSession.Capabilities?.CanReconfigureTurnMode === true) {
+            return this.ReconfigureSessionToMeeting(sessionBridgeID, matcher);
+        }
+        if (!active.ReopenInMeetingMode) {
+            // LOUD + structured: the provider can't be reconfigured AND nobody gave us a way to re-open it, so
+            // this seat physically cannot be gated. Say exactly that — the alternative is an agent that talks
+            // over the room with only a stale log line to explain it.
+            LogError(
+                `[AIBridgeEngine] ⚠️ bridge ${sessionBridgeID} (agentSession ${active.AgentSessionID}) CANNOT be ` +
+                    `meeting-gated: its provider fixes turn config at connect (e.g. Gemini) and no ` +
+                    `ReopenInMeetingMode hook was supplied at StartBridgeSession. It stays in 1:1 auto-response ` +
+                    `and will answer ALL room audio, talking over the other agents. Supply the reopen hook from ` +
+                    `the layer that owns the realtime-session factory, or start this agent addressed-only.`,
+            );
+            return false;
+        }
+
+        // Publish the in-flight promise BEFORE anything can await: it is both the dedupe key and the outbound
+        // mute that keeps the un-gated socket quiet for the duration (see ActiveBridgeSession.PendingMeetingReopen).
+        const pending = this.reopenSessionInMeetingMode(active, matcher);
+        active.PendingMeetingReopen = pending;
+        try {
+            return await pending;
+        } finally {
+            // Always un-mute: on success the freshly-wired session is gated and may speak; on failure the old
+            // socket is still there and going permanently silent would be a worse, invisible failure than the
+            // loud one already logged.
+            active.PendingMeetingReopen = undefined;
+        }
+    }
+
+    /**
+     * Re-opens a session's provider socket in meeting mode and swaps it onto the SAME
+     * {@link ActiveBridgeSession}. The reconnect path of {@link EnsureSessionMeetingGated} — see there for
+     * the why; this is the mechanism.
+     *
+     * Ordering is deliberate: mint the replacement FIRST, swap, and only then close the old socket. A mint
+     * that fails therefore leaves the agent exactly as it was (present, un-gated, audible) rather than mute
+     * or dead — a degraded seat beats a missing one. The close runs in a `finally` so the old provider
+     * connection is released on every path, including a re-wire that throws; leaking it would leave a second
+     * live socket happily auto-responding into the room, which is the very bug being fixed.
+     *
+     * Two things deliberately NOT redone: the channel plane (its perception sink reads
+     * `active.RealtimeSession` at call time, so it follows the swap by itself) and the meeting context note
+     * (the fresh session was MINTED in meeting mode, so its prompt already carries the discipline).
+     *
+     * @param active The live session to re-open.
+     * @param matcher The addressed-matcher the re-gated session should speak on.
+     * @returns `true` when the fresh, gated session is wired in; `false` when the reopen was exhausted or the
+     *   swap failed.
+     */
+    private async reopenSessionInMeetingMode(active: ActiveBridgeSession, matcher: IAddressedMatcher): Promise<boolean> {
+        const reopen = active.ReopenInMeetingMode;
+        if (!reopen) {
+            return false; // guarded by the caller; defensive so this stays safe if ever called elsewhere
+        }
+        const previous = active.RealtimeSession;
+        let fresh: IRealtimeSession | undefined;
+        for (let attempt = 1; attempt <= MEETING_REGATE_REOPEN_MAX_ATTEMPTS; attempt++) {
+            try {
+                fresh = await reopen();
+                break;
+            } catch (err) {
+                LogError(
+                    `[AIBridgeEngine] meeting-mode reopen attempt ${attempt}/${MEETING_REGATE_REOPEN_MAX_ATTEMPTS} ` +
+                        `failed for bridge ${active.SessionBridgeID}: ${err instanceof Error ? err.message : String(err)}`,
+                );
+            }
+        }
+        if (!fresh) {
+            // Attempt cap hit — handled explicitly rather than looping: the agent keeps its ORIGINAL, un-gated
+            // socket (it is still in the room and still audible), and the room is told loudly that one seat is
+            // not gated so an operator isn't left guessing why an agent talks over everyone.
+            LogError(
+                `[AIBridgeEngine] ⚠️ bridge ${active.SessionBridgeID} (agentSession ${active.AgentSessionID}) could ` +
+                    `NOT be re-opened in meeting mode after ${MEETING_REGATE_REOPEN_MAX_ATTEMPTS} attempts. It stays ` +
+                    `on its original 1:1 socket and will answer ALL room audio — expect it to talk over the room.`,
+            );
+            return false;
+        }
+        if (this.activeSessions.get(active.SessionBridgeID.toLowerCase()) !== active) {
+            // The seat went away while we were minting (room emptied, janitor reaped it, the caller hung up).
+            // Wiring the fresh socket onto a torn-down session would strand it — teardown has already run and
+            // will never close it — so hand it straight back to the provider.
+            LogStatus(
+                `[AIBridgeEngine] bridge ${active.SessionBridgeID} was torn down during its meeting-mode reopen — ` +
+                    `closing the freshly minted session instead of wiring it to a dead seat.`,
+            );
+            try {
+                await fresh.Close();
+            } catch (err) {
+                LogError(
+                    `[AIBridgeEngine] closing the orphaned re-gate session failed for bridge ` +
+                        `${active.SessionBridgeID}: ${err instanceof Error ? err.message : String(err)}`,
+                );
+            }
+            return false;
+        }
+
+        let swapped = false;
+        try {
+            // Swap the socket, then re-run the two wirings that close over the session handle. Both register a
+            // SINGLE handler per hook (IRealtimeSession contract; the driver's OnMedia likewise), so re-running
+            // them replaces the old closures instead of stacking a second copy.
+            active.RealtimeSession = fresh;
+            active.DisableAutoResponse = true;
+            active.TurnPolicy = new TurnTakingPolicy({ Mode: 'Passive', Matcher: matcher });
+            this.wireTransportSeam(active);
+            this.wireTurnTaking(active);
+            swapped = true;
+        } catch (err) {
+            LogError(
+                `[AIBridgeEngine] ⚠️ bridge ${active.SessionBridgeID} re-opened in meeting mode but FAILED to wire ` +
+                    `the fresh session: ${err instanceof Error ? err.message : String(err)}. The agent may be mute ` +
+                    `until the session is stopped and restarted.`,
+            );
+        } finally {
+            // Release the old provider connection on every path. Closing it also finalizes the co-agent run the
+            // agent layer wrapped onto Close(): the `AIAgentSession` is unchanged, so the reopened session's run
+            // groups under the SAME session — one session, two runs across the re-gate, not a severed chain.
+            try {
+                await previous.Close();
+            } catch (err) {
+                LogError(
+                    `[AIBridgeEngine] closing the pre-re-gate realtime session failed for bridge ` +
+                        `${active.SessionBridgeID}: ${err instanceof Error ? err.message : String(err)}`,
+                );
+            }
+        }
+        if (swapped) {
+            LogStatus(
+                `[AIBridgeEngine] re-gated bridge ${active.SessionBridgeID} to meeting mode by RECONNECTING its ` +
+                    `provider socket (config fixed at connect) — same bridge row, same agent session, same seat.`,
+            );
+        }
+        return swapped;
+    }
+
+    /**
+     * Reports the **effective** turn state of a live session — is this seat actually gated right now?
+     *
+     * The read exists so callers (room formation, health checks, tests) can ASSERT a multi-agent room is
+     * properly gated instead of discovering it by ear when an agent talks over everyone. Pure query: it never
+     * mutates the session.
+     *
+     * {@link EffectiveTurnState.MeetingGated} is the conjunction the room actually depends on — the model's
+     * blind auto-response is off AND the bridge's own gate is the addressed-only `Passive` policy. Either one
+     * alone is not enough: auto-response on means the model answers everything regardless of the bridge, and
+     * an `Active`/`Hybrid` policy is a scorer-driven seat rather than an addressed-only one.
+     *
+     * @param sessionBridgeID The bridge row id to inspect.
+     * @returns The session's effective turn state, or `null` when this process holds no such session.
+     */
+    public GetEffectiveTurnState(sessionBridgeID: string): EffectiveTurnState | null {
+        const active = this.activeSessions.get(sessionBridgeID.toLowerCase());
+        if (!active) {
+            return null;
+        }
+        return {
+            MeetingGated: active.DisableAutoResponse && active.TurnPolicy.Mode === 'Passive',
+            CanReconfigureTurnMode: active.RealtimeSession.Capabilities?.CanReconfigureTurnMode === true,
+        };
+    }
+
+    // ──────────────────────────────────────────────────────────────────────────────
+    // Human takeover — suspend / resume an agent WITHOUT ending its session.
+    // ──────────────────────────────────────────────────────────────────────────────
+
+    /**
+     * **Suspends** the agent on a live bridge session: it stops talking and stops publishing, but stays
+     * present. This is the seat-takeover primitive — a coach steps into the agent's place, speaks to the
+     * room themselves, then hands the seat back via {@link ResumeBridgeAgent}.
+     *
+     * Suspend is deliberately NOT {@link StopBridgeSession}. Stopping disconnects the driver, closes the
+     * realtime session, finalizes the co-agent run and marks the bridge `Disconnected` — which severs the
+     * session chain and the recording legs, so "hand it back" would mean a brand-new session with none of
+     * the meeting's history. Here **everything keeps running**: the provider socket, the `AIAgentSession`,
+     * the participant rows, transcript persistence and the observability run. Only the ways the agent can
+     * make sound are closed:
+     *
+     * 1. The model's blind auto-response goes OFF, so it stops answering the room on its own.
+     * 2. Its turn policy is swapped onto {@link SUSPENDED_AGENT_MATCHER}, so the bridge's own addressing
+     *    gate can never decide `Speak`. (The moderator path bypasses the policy entirely, so
+     *    {@link triggerMeetingSpeak} refuses a suspended session too — that's the second, load-bearing gate.)
+     * 3. The room floor is released if this session held it, so the human can speak immediately.
+     * 4. Queued outbound media is flushed and the outbound half of the transport seam drops frames while
+     *    suspended (see {@link wireTransportSeam}), so not even an in-flight response reaches the room.
+     *
+     * The INBOUND half stays wired on purpose: a suspended agent keeps hearing and transcribing the
+     * meeting, so when it resumes it has the context it missed rather than a hole.
+     *
+     * **Capability-gated**, on the same terms as {@link ReconfigureSessionToMeeting}: a session still in
+     * 1:1 auto-response can only be silenced by turning auto-response off on the LIVE socket, which a
+     * provider that fixes its config at connect (e.g. Gemini) cannot do. Nothing is mutated before that
+     * check — a half-suspended agent (gated by the bridge, yet still auto-answering over the human who
+     * just took its seat) is worse than a refusal, so it refuses LOUDLY instead.
+     *
+     * Idempotent — suspending an already-suspended session is a no-op that returns `true`.
+     *
+     * @param sessionBridgeID The `AIAgentSessionBridge` row id of the agent to suspend.
+     * @returns `true` when the agent is suspended (or already was); `false` when the session is unknown to
+     *   this process or its provider cannot stop auto-responding mid-session.
+     */
+    public SuspendBridgeAgent(sessionBridgeID: string): boolean {
+        const active = this.activeSessions.get(sessionBridgeID.toLowerCase());
+        if (!active) {
+            return false;
+        }
+        if (active.SuspendedState) {
+            return true; // already suspended — nothing to do
+        }
+        const needsAutoResponseOff = !active.DisableAutoResponse;
+        if (needsAutoResponseOff && active.RealtimeSession.Capabilities?.CanReconfigureTurnMode !== true) {
+            // LOUD: this session is in 1:1 auto-response and its provider can't change that on a live socket
+            // (e.g. Gemini). Suspending it would leave the model answering every human turn — talking OVER
+            // the person who just took its seat. The robust fix is to run a re-configurable provider
+            // (OpenAI realtime) for any seat a human may take over; otherwise stop the session instead.
+            LogError(
+                `[AIBridgeEngine] ⚠️ bridge ${sessionBridgeID} CANNOT be suspended for a human takeover ` +
+                    `(provider config fixed at connect, e.g. Gemini): its model would keep auto-responding to ` +
+                    `the room, talking over the human taking the seat. Stop the session instead, or use an ` +
+                    `OpenAI-realtime agent for seats a human may take over.`,
+            );
+            return false;
+        }
+
+        const prior: SuspendedAgentState = {
+            PriorTurnPolicy: active.TurnPolicy,
+            PriorDisableAutoResponse: active.DisableAutoResponse,
+            HeldFloor: active.HoldsFloor,
+            SuspendedAtMs: Date.now(),
+        };
+        // Mark the seat suspended FIRST: releasing the floor below drains the room's speaker queue, and a
+        // session that isn't yet flagged could be routed straight back into speaking by that drain.
+        active.SuspendedState = prior;
+
+        if (needsAutoResponseOff) {
+            active.RealtimeSession.Reconfigure?.({ DisableAutoResponse: true });
+            active.DisableAutoResponse = true;
+        }
+        active.TurnPolicy = new TurnTakingPolicy({ Mode: 'Passive', Matcher: SUSPENDED_AGENT_MATCHER });
+        if (active.HoldsFloor) {
+            this.releaseRoomFloor(active);
+        }
+        // Drop whatever the driver still has buffered, so the tail of the agent's last sentence doesn't
+        // play over the person taking the seat. No-op for drivers with no outbound buffer.
+        active.Bridge.FlushOutboundMedia();
+
+        LogStatus(
+            `[AIBridgeEngine] SUSPENDED agent on bridge ${sessionBridgeID} (agentSession ${active.AgentSessionID}) — ` +
+                `a human has its seat. The session, its transcript and its co-agent run stay live; it keeps ` +
+                `listening but cannot speak or publish until ResumeBridgeAgent.`,
+        );
+        return true;
+    }
+
+    /**
+     * **Resumes** an agent suspended by {@link SuspendBridgeAgent} — the human hands the seat back. Puts
+     * back exactly the turn policy and auto-response state that were in force at suspend time (captured in
+     * {@link SuspendedAgentState}, never re-derived), and re-opens the outbound seam.
+     *
+     * The room floor is deliberately NOT re-claimed even if the agent held it when suspended: it becomes
+     * *eligible* to speak again and takes the floor the next time it is addressed or routed, exactly like
+     * an agent that just finished a turn. Re-claiming would make a resumed agent cut off whoever is
+     * speaking now.
+     *
+     * Idempotent — resuming a session that isn't suspended is a no-op that returns `true`.
+     *
+     * @param sessionBridgeID The `AIAgentSessionBridge` row id of the agent to resume.
+     * @returns `true` when the agent is active again (or already was); `false` when the session is unknown
+     *   to this process or its provider can no longer restore the prior auto-response mode.
+     */
+    public ResumeBridgeAgent(sessionBridgeID: string): boolean {
+        const active = this.activeSessions.get(sessionBridgeID.toLowerCase());
+        if (!active) {
+            return false;
+        }
+        const prior = active.SuspendedState;
+        if (!prior) {
+            return true; // not suspended — nothing to do
+        }
+        // Same gate-before-mutate posture as suspend. Only a session that must go BACK to auto-response
+        // needs the live-reconfigure capability, and suspend already refused when that wasn't available —
+        // so this is defense-in-depth against a session whose capability changed underneath us. Leaving it
+        // permanently mute after a takeover would be a silent failure, so it is refused LOUDLY.
+        const needsAutoResponseRestored = active.DisableAutoResponse !== prior.PriorDisableAutoResponse;
+        if (needsAutoResponseRestored && active.RealtimeSession.Capabilities?.CanReconfigureTurnMode !== true) {
+            LogError(
+                `[AIBridgeEngine] ⚠️ bridge ${sessionBridgeID} CANNOT be resumed: its provider can no longer ` +
+                    `restore auto-response on a live socket, so the agent would stay silent with no signal. ` +
+                    `It remains suspended — stop and restart the session to bring this agent back.`,
+            );
+            return false;
+        }
+        if (needsAutoResponseRestored) {
+            active.RealtimeSession.Reconfigure?.({ DisableAutoResponse: prior.PriorDisableAutoResponse });
+            active.DisableAutoResponse = prior.PriorDisableAutoResponse;
+        }
+        active.TurnPolicy = prior.PriorTurnPolicy;
+        active.SuspendedState = undefined;
+
+        LogStatus(
+            `[AIBridgeEngine] RESUMED agent on bridge ${sessionBridgeID} (agentSession ${active.AgentSessionID}) ` +
+                `after ${Date.now() - prior.SuspendedAtMs}ms suspended — prior turn gate restored; it speaks ` +
+                `again when next addressed (the floor is not re-claimed).`,
+        );
         return true;
     }
 

--- a/packages/AI/RealtimeBridge/Server/src/ai-bridge-engine.ts
+++ b/packages/AI/RealtimeBridge/Server/src/ai-bridge-engine.ts
@@ -865,6 +865,19 @@ export class AIBridgeEngine extends BaseSingleton<AIBridgeEngine> implements ISt
         this.turnModerator = moderator;
     }
 
+    /**
+     * Whether a room turn moderator is bound — i.e. whether a multi-agent room will actually take turns
+     * rather than run free-for-all.
+     *
+     * Reports the EFFECTIVE state, not what an env var says. `MJ_REALTIME_MODERATOR_MODE=on` is only the
+     * usual way the moderator gets bound; a host can bind one directly, and a typo in the variable binds
+     * nothing while still looking set. Since the difference between a moderated panel and crosstalk is
+     * otherwise only AUDIBLE, an operator needs a way to ask the running server which one they have.
+     */
+    public get HasTurnModerator(): boolean {
+        return this.turnModerator != null;
+    }
+
     /** Returns the active identities for an agent. @see AIBridgeEngineBase.IdentitiesForAgent */
     public IdentitiesForAgent(agentId: string, providerId?: string): MJAIBridgeAgentIdentityEntity[] {
         return this.Base.IdentitiesForAgent(agentId, providerId);

--- a/packages/AI/RealtimeBridge/Server/src/multi-agent-room-coordinator.ts
+++ b/packages/AI/RealtimeBridge/Server/src/multi-agent-room-coordinator.ts
@@ -13,9 +13,9 @@
  * So the ONLY genuinely new problem is **turn-taking discipline among multiple agents** so they don't
  * talk over each other or loop forever. This coordinator solves exactly that and nothing else:
  *
- * 1. **Floor arbitration** — at most ONE agent "holds the floor" (is speaking) in a room at any instant.
+ * 1. **Floor arbitration** — at most ONE member "holds the floor" (is speaking) in a room at any instant.
  *    An agent calls {@link CanTakeFloor} before generating speech; it returns `true` only if no OTHER
- *    agent currently holds the floor. {@link TakeFloor} grants it; {@link ReleaseFloor} frees it.
+ *    member currently holds the floor. {@link TakeFloor} grants it; {@link ReleaseFloor} frees it.
  * 2. **Passive-default loop safety** — combined with passive turn-taking (an agent speaks only when
  *    *addressed by name*, per {@link import('@memberjunction/ai-bridge-base').TurnTakingPolicy}), two
  *    agents in a room never loop: neither speaks unless a human calls on it, and even then only one holds
@@ -25,6 +25,15 @@
  *    Controls channel) may be granted the floor even while another agent holds it, so it can arbitrate /
  *    call on a specific agent. See {@link RegisterRoom}'s `facilitatorAgentSessionId` and
  *    {@link CanTakeFloor}'s facilitator path.
+ * 4. **Humans hold the floor too** — a room member is either an AGENT session or a HUMAN user
+ *    ({@link RoomParticipantRef}), because the thing that actually needs the floor is "whoever is
+ *    speaking", and half the time that's a person. A human who takes the floor (a coach stepping into an
+ *    agent's seat, a host taking over) makes every agent — **facilitator included** — yield: see
+ *    {@link CanTakeFloor}'s `HeldByHuman` / `HumanOverride` paths. The asymmetry is deliberate and
+ *    reflects the media plane rather than a policy preference: the coordinator can silence an agent (it
+ *    gates the trigger that makes it speak) but it cannot mute a person, whose voice is already in the
+ *    room's mix. Denying a human the floor would only make the state WRONG, so a human's claim always
+ *    wins and the agents are told to stand down.
  *
  * ## Echo / self-audio (documented, handled by the bridge, not here)
  * A bot must not hear its OWN output, or it would react to itself and loop. Conferencing platforms
@@ -41,15 +50,67 @@
  */
 
 /**
- * One agent's membership in a shared room, as the coordinator tracks it.
+ * WHO a room member is — the floor is held by **a speaker**, and a speaker is either an agent session or
+ * a person. Discriminated so the two identities can never be confused: an agent is keyed by its
+ * `MJ: AI Agent Sessions` row id, a human by its `MJ: Users` row id (the same `UserID` MJ persists on
+ * `MJ: AI Agent Session Bridge Participants`). A human participant has NO agent-session id, which is
+ * exactly why floor membership can't be keyed on one.
  */
-export interface RoomAgentMembership {
-    /** The `MJ: AI Agent Sessions` row id of this agent's bridge session in the room. */
-    AgentSessionId: string;
+export type RoomParticipantRef =
+    | {
+          Kind: 'Agent';
+          /** The `MJ: AI Agent Sessions` row id of this agent's bridge session in the room. */
+          AgentSessionId: string;
+      }
+    | {
+          Kind: 'Human';
+          /** The `MJ: Users` row id of the person in the room. */
+          UserId: string;
+      };
 
-    /** Whether this agent is the room's designated facilitator (may override the floor to arbitrate). */
+/**
+ * What the participant-taking methods accept. A **bare string is an agent session id** — the pre-human
+ * shape, kept so every existing caller (the engine's `RegisterRoomParticipant` / floor calls) keeps
+ * compiling and behaving identically. Pass a {@link RoomParticipantRef} to name a human.
+ */
+export type RoomParticipantSelector = string | RoomParticipantRef;
+
+/** Builds an agent {@link RoomParticipantRef} from an agent-session id. */
+export function AgentParticipant(agentSessionId: string): RoomParticipantRef {
+    return { Kind: 'Agent', AgentSessionId: agentSessionId };
+}
+
+/** Builds a human {@link RoomParticipantRef} from an MJ user id. */
+export function HumanParticipant(userId: string): RoomParticipantRef {
+    return { Kind: 'Human', UserId: userId };
+}
+
+/**
+ * The stable map/identity key for a participant — kind-prefixed so an agent session and a user that
+ * happen to share a UUID are still distinct members, and lowercased because UUID casing differs across
+ * DB platforms.
+ */
+export function RoomParticipantKey(participant: RoomParticipantRef): string {
+    const id = participant.Kind === 'Agent' ? participant.AgentSessionId : participant.UserId;
+    return `${participant.Kind.toLowerCase()}:${id.trim().toLowerCase()}`;
+}
+
+/**
+ * One participant's membership in a shared room, as the coordinator tracks it.
+ */
+export interface RoomParticipantMembership {
+    /** Who this member is — an agent session or a human user. */
+    Participant: RoomParticipantRef;
+
+    /** Whether this member is the room's designated facilitator (may override the floor to arbitrate). */
     IsFacilitator: boolean;
 }
+
+/**
+ * @deprecated The pre-human name for {@link RoomParticipantMembership} — membership is no longer
+ * agent-only. Kept as an alias so existing imports keep resolving; use the new name.
+ */
+export type RoomAgentMembership = RoomParticipantMembership;
 
 /**
  * The live floor state of a room, returned by {@link MultiAgentRoomCoordinator.GetRoomState} for
@@ -59,13 +120,22 @@ export interface RoomFloorState {
     /** The room's external id (the shared external connection id / ConversationID all agents key on). */
     RoomId: string;
 
-    /** The agent session ids currently in the room. */
+    /** Every member currently in the room — agents AND humans — in registration order. */
+    Participants: RoomParticipantRef[];
+
+    /** The agent session ids currently in the room (humans excluded — the agent projection of {@link RoomFloorState.Participants}). */
     AgentSessionIds: string[];
 
-    /** The facilitator agent session id, when one is designated; otherwise `null`. */
+    /** The room's facilitator (agent or human), when one is designated; otherwise `null`. */
+    Facilitator: RoomParticipantRef | null;
+
+    /** The facilitator's agent session id — `null` when there is no facilitator OR the facilitator is a human. */
     FacilitatorAgentSessionId: string | null;
 
-    /** The agent session id currently holding the floor (speaking), or `null` when the floor is free. */
+    /** Who currently holds the floor (is speaking), or `null` when the floor is free. */
+    FloorHolder: RoomParticipantRef | null;
+
+    /** The floor holder's agent session id — `null` when the floor is free OR a HUMAN holds it (read {@link RoomFloorState.FloorHolder} for that case). */
     FloorHolderAgentSessionId: string | null;
 
     /** Epoch-ms the current floor holder took the floor, or `null` when the floor is free. */
@@ -77,7 +147,9 @@ export type FloorDecisionReason =
     | 'FloorFree'
     | 'AlreadyHolder'
     | 'FacilitatorOverride'
+    | 'HumanOverride'
     | 'HeldByOtherAgent'
+    | 'HeldByHuman'
     | 'NotInRoom'
     | 'UnknownRoom';
 
@@ -93,20 +165,21 @@ export interface FloorDecision {
 /** Internal per-room state held by the coordinator. */
 interface RoomRecord {
     readonly roomId: string;
-    /** Agent session id (lowercased) → membership. */
-    readonly members: Map<string, RoomAgentMembership>;
-    facilitatorAgentSessionId: string | null;
-    floorHolderAgentSessionId: string | null;
+    /** {@link RoomParticipantKey} → membership (agents and humans in one roster). */
+    readonly members: Map<string, RoomParticipantMembership>;
+    facilitator: RoomParticipantRef | null;
+    floorHolder: RoomParticipantRef | null;
     floorHeldSinceMs: number | null;
 }
 
 /**
- * Coordinates speaking discipline for multiple agents sharing one room. Construct one per process (the
- * engine holds a single instance) and key everything on the **room id** — the shared external connection
- * id (or ConversationID) that all co-located agent sessions belong to.
+ * Coordinates speaking discipline among the members sharing one room — agent sessions and the humans
+ * with them. Construct one per process (the engine holds a single instance) and key everything on the
+ * **room id**: the shared external connection id (or ConversationID) all co-located members belong to.
  *
- * The coordinator is additive: single-agent sessions never register here and are wholly unaffected. Only
- * when 2+ agent sessions share a room does floor arbitration come into play.
+ * The coordinator is additive: a lone agent in a room finds the floor always free, so arbitration costs
+ * it nothing. It starts to bite only when a room holds two or more would-be speakers — several agents, or
+ * one agent and a human who has taken a seat.
  */
 export class MultiAgentRoomCoordinator {
     /** Room id (lowercased) → room record. */
@@ -128,46 +201,54 @@ export class MultiAgentRoomCoordinator {
     // ──────────────────────────────────────────────────────────────────────────────
 
     /**
-     * Registers an agent session as a participant in a shared room, creating the room on first member.
-     * Idempotent — re-registering the same agent updates its facilitator flag without disturbing the
-     * floor. Designating an agent as the facilitator records it as the room's arbiter; only one
-     * facilitator is tracked (the latest designation wins, mirroring "one chair").
+     * Registers a participant in a shared room, creating the room on first member. Idempotent —
+     * re-registering the same participant updates its facilitator flag without disturbing the floor.
+     * Designating a member as the facilitator records it as the room's arbiter; only one facilitator is
+     * tracked (the latest designation wins, mirroring "one chair").
      *
-     * @param roomId The shared room id (external connection id / ConversationID) all agents key on.
-     * @param agentSessionId The agent's `MJ: AI Agent Sessions` row id.
-     * @param isFacilitator Whether this agent is the room's facilitator (may override the floor).
+     * Pass a bare **string** for the pre-human shape (an agent session id); pass a
+     * {@link RoomParticipantRef} — e.g. `HumanParticipant(userId)` — to seat a person. Role mapping stays
+     * with the caller: an app that persists Host/CoHost/Participant on
+     * `MJ: AI Agent Session Bridge Participants` decides which of those becomes `isFacilitator` here, so
+     * this module never learns an entity's enum.
+     *
+     * @param roomId The shared room id (external connection id / ConversationID) all members key on.
+     * @param participant The agent session id (string) or participant ref joining the room.
+     * @param isFacilitator Whether this member is the room's facilitator (may override the floor).
      */
-    public RegisterRoomParticipant(roomId: string, agentSessionId: string, isFacilitator = false): void {
+    public RegisterRoomParticipant(roomId: string, participant: RoomParticipantSelector, isFacilitator = false): void {
         const room = this.ensureRoom(roomId);
-        const memberKey = this.key(agentSessionId);
-        room.members.set(memberKey, { AgentSessionId: agentSessionId, IsFacilitator: isFacilitator });
+        const ref = this.toRef(participant);
+        room.members.set(RoomParticipantKey(ref), { Participant: ref, IsFacilitator: isFacilitator });
         if (isFacilitator) {
-            room.facilitatorAgentSessionId = agentSessionId;
+            room.facilitator = ref;
         }
     }
 
     /**
-     * Unregisters an agent session from a room (the agent left / its bridge stopped). If the leaving
-     * agent held the floor, the floor is released. If it was the facilitator, the facilitator slot is
-     * cleared. When the last member leaves, the room record is discarded.
+     * Unregisters a participant from a room (the agent left / its bridge stopped, or the person left the
+     * call). If the leaving member held the floor, the floor is released. If it was the facilitator, the
+     * facilitator slot is cleared. When the last member leaves, the room record is discarded — so whoever
+     * registers a human is responsible for unregistering it, exactly as the engine does for agents.
      *
-     * @param roomId The room the agent is leaving.
-     * @param agentSessionId The agent session leaving.
+     * @param roomId The room the member is leaving.
+     * @param participant The agent session id (string) or participant ref leaving.
      */
-    public UnregisterRoomParticipant(roomId: string, agentSessionId: string): void {
+    public UnregisterRoomParticipant(roomId: string, participant: RoomParticipantSelector): void {
         const room = this.rooms.get(this.key(roomId));
         if (!room) {
             return;
         }
-        const memberKey = this.key(agentSessionId);
+        const ref = this.toRef(participant);
+        const memberKey = RoomParticipantKey(ref);
         room.members.delete(memberKey);
 
-        if (room.floorHolderAgentSessionId && this.key(room.floorHolderAgentSessionId) === memberKey) {
-            room.floorHolderAgentSessionId = null;
+        if (room.floorHolder && RoomParticipantKey(room.floorHolder) === memberKey) {
+            room.floorHolder = null;
             room.floorHeldSinceMs = null;
         }
-        if (room.facilitatorAgentSessionId && this.key(room.facilitatorAgentSessionId) === memberKey) {
-            room.facilitatorAgentSessionId = null;
+        if (room.facilitator && RoomParticipantKey(room.facilitator) === memberKey) {
+            room.facilitator = null;
         }
         if (room.members.size === 0) {
             this.rooms.delete(this.key(roomId));
@@ -175,15 +256,28 @@ export class MultiAgentRoomCoordinator {
     }
 
     /**
-     * Whether a room currently has more than one agent session — i.e. floor arbitration is meaningful.
-     * Single-agent rooms can skip the floor dance entirely.
+     * Whether a room currently has more than one AGENT session — i.e. inter-agent floor arbitration is
+     * meaningful. Single-agent rooms can skip the floor dance entirely.
+     *
+     * Humans are deliberately NOT counted: one agent talking with one person is a 1:1 call, and callers
+     * use this to decide whether to re-gate an agent into meeting mode. Counting the human would flip a
+     * plain 1:1 into "multi-agent" and gate the agent behind an addressed-matcher it never needed.
      *
      * @param roomId The room to check.
      * @returns `true` when 2+ agents share the room.
      */
     public IsMultiAgentRoom(roomId: string): boolean {
         const room = this.rooms.get(this.key(roomId));
-        return room ? room.members.size > 1 : false;
+        if (!room) {
+            return false;
+        }
+        let agents = 0;
+        for (const m of room.members.values()) {
+            if (m.Participant.Kind === 'Agent') {
+                agents++;
+            }
+        }
+        return agents > 1;
     }
 
     // ──────────────────────────────────────────────────────────────────────────────
@@ -191,12 +285,17 @@ export class MultiAgentRoomCoordinator {
     // ──────────────────────────────────────────────────────────────────────────────
 
     /**
-     * Asks whether an agent MAY take the floor (speak) now — the read-only arbitration check an agent
-     * runs before generating speech. Returns `true` only when no OTHER agent holds the floor, with the
-     * facilitator exception:
+     * Asks whether a member MAY take the floor (speak) now — the read-only arbitration check an agent
+     * runs before generating speech, and the same check a human takeover runs before claiming the seat.
+     * Granted only when nobody else is speaking, with the facilitator and human exceptions:
      *
      * - **Floor free** → granted (`FloorFree`).
      * - **The requester already holds it** → granted (`AlreadyHolder`) — re-asserting is fine.
+     * - **The requester is a HUMAN** → granted (`HumanOverride`) whoever holds it. A person's voice is
+     *   already in the room's mix; refusing them would only make this state a lie.
+     * - **A HUMAN holds it** (and the requester is an agent) → denied (`HeldByHuman`) — including for the
+     *   facilitator, which overrides agents, not people. This is the structural reason agents yield to a
+     *   human who has taken a seat.
      * - **The requester is the facilitator** → granted (`FacilitatorOverride`) even if another agent
      *   holds it, so the facilitator can cut in to arbitrate / call on a specific agent.
      * - **Another (non-facilitator) agent holds it** → denied (`HeldByOtherAgent`).
@@ -207,107 +306,119 @@ export class MultiAgentRoomCoordinator {
      * (read) and the claim (write) separate lets a caller test-then-act atomically within its own turn.
      *
      * @param roomId The shared room id.
-     * @param agentSessionId The agent asking to speak.
+     * @param participant The agent session id (string) or participant ref asking to speak.
      * @returns The floor decision (granted + reason).
      */
-    public CanTakeFloor(roomId: string, agentSessionId: string): FloorDecision {
+    public CanTakeFloor(roomId: string, participant: RoomParticipantSelector): FloorDecision {
         const room = this.rooms.get(this.key(roomId));
         if (!room) {
             return { Granted: false, Reason: 'UnknownRoom' };
         }
-        if (!room.members.has(this.key(agentSessionId))) {
+        const ref = this.toRef(participant);
+        if (!room.members.has(RoomParticipantKey(ref))) {
             return { Granted: false, Reason: 'NotInRoom' };
         }
-        const holder = room.floorHolderAgentSessionId;
+        const holder = room.floorHolder;
         if (holder === null) {
             return { Granted: true, Reason: 'FloorFree' };
         }
-        if (this.key(holder) === this.key(agentSessionId)) {
+        if (RoomParticipantKey(holder) === RoomParticipantKey(ref)) {
             return { Granted: true, Reason: 'AlreadyHolder' };
         }
-        if (this.isFacilitator(room, agentSessionId)) {
+        if (ref.Kind === 'Human') {
+            return { Granted: true, Reason: 'HumanOverride' };
+        }
+        if (holder.Kind === 'Human') {
+            return { Granted: false, Reason: 'HeldByHuman' };
+        }
+        if (this.isFacilitator(room, ref)) {
             return { Granted: true, Reason: 'FacilitatorOverride' };
         }
         return { Granted: false, Reason: 'HeldByOtherAgent' };
     }
 
     /**
-     * Atomically attempts to claim the floor for an agent: runs {@link CanTakeFloor} and, when granted,
-     * records the agent as the floor holder (stamping the take time) and returns the decision. When a
-     * **facilitator** overrides a sitting holder, the holder is replaced — the facilitator now holds the
-     * floor (the prior holder should observe this via {@link IsFloorHolder} on its next check and yield).
+     * Atomically attempts to claim the floor for a member: runs {@link CanTakeFloor} and, when granted,
+     * records the member as the floor holder (stamping the take time) and returns the decision. When a
+     * **facilitator** or a **human** overrides a sitting holder, the holder is replaced — the new holder
+     * now has the floor (the prior holder should observe this via {@link IsFloorHolder} on its next check
+     * and yield).
      *
      * @param roomId The shared room id.
-     * @param agentSessionId The agent claiming the floor.
-     * @returns The decision; on `Granted` the agent now holds the floor.
+     * @param participant The agent session id (string) or participant ref claiming the floor.
+     * @returns The decision; on `Granted` the member now holds the floor.
      */
-    public TakeFloor(roomId: string, agentSessionId: string): FloorDecision {
-        const decision = this.CanTakeFloor(roomId, agentSessionId);
+    public TakeFloor(roomId: string, participant: RoomParticipantSelector): FloorDecision {
+        const decision = this.CanTakeFloor(roomId, participant);
         if (!decision.Granted) {
             return decision;
         }
         const room = this.rooms.get(this.key(roomId))!;
+        const ref = this.toRef(participant);
         // Already-holder re-assert: keep the original since-stamp; otherwise stamp now.
-        if (room.floorHolderAgentSessionId === null || this.key(room.floorHolderAgentSessionId) !== this.key(agentSessionId)) {
-            room.floorHolderAgentSessionId = agentSessionId;
+        if (room.floorHolder === null || RoomParticipantKey(room.floorHolder) !== RoomParticipantKey(ref)) {
+            room.floorHolder = ref;
             room.floorHeldSinceMs = this.now();
         }
         return decision;
     }
 
     /**
-     * Releases the floor held by an agent (it finished speaking). A no-op when the agent is not the
-     * current holder, so a late/duplicate release can never steal the floor from another agent.
+     * Releases the floor held by a member (it finished speaking / the human handed the seat back). A
+     * no-op when the member is not the current holder, so a late/duplicate release can never steal the
+     * floor from someone else.
      *
      * @param roomId The shared room id.
-     * @param agentSessionId The agent releasing the floor.
-     * @returns `true` when this call actually freed the floor (the agent was the holder).
+     * @param participant The agent session id (string) or participant ref releasing the floor.
+     * @returns `true` when this call actually freed the floor (the member was the holder).
      */
-    public ReleaseFloor(roomId: string, agentSessionId: string): boolean {
+    public ReleaseFloor(roomId: string, participant: RoomParticipantSelector): boolean {
         const room = this.rooms.get(this.key(roomId));
-        if (!room || room.floorHolderAgentSessionId === null) {
+        if (!room || room.floorHolder === null) {
             return false;
         }
-        if (this.key(room.floorHolderAgentSessionId) !== this.key(agentSessionId)) {
+        if (RoomParticipantKey(room.floorHolder) !== RoomParticipantKey(this.toRef(participant))) {
             return false; // not the holder — don't free someone else's floor
         }
-        room.floorHolderAgentSessionId = null;
+        room.floorHolder = null;
         room.floorHeldSinceMs = null;
         return true;
     }
 
     /**
-     * Whether a given agent currently holds the floor in a room. An agent that was bumped by a
-     * facilitator override checks this to learn it should yield.
+     * Whether a given member currently holds the floor in a room. An agent that was bumped by a
+     * facilitator override — or by a human taking its seat — checks this to learn it should yield.
      *
      * @param roomId The shared room id.
-     * @param agentSessionId The agent to test.
-     * @returns `true` when the agent is the current floor holder.
+     * @param participant The agent session id (string) or participant ref to test.
+     * @returns `true` when the member is the current floor holder.
      */
-    public IsFloorHolder(roomId: string, agentSessionId: string): boolean {
+    public IsFloorHolder(roomId: string, participant: RoomParticipantSelector): boolean {
         const room = this.rooms.get(this.key(roomId));
-        if (!room || room.floorHolderAgentSessionId === null) {
+        if (!room || room.floorHolder === null) {
             return false;
         }
-        return this.key(room.floorHolderAgentSessionId) === this.key(agentSessionId);
+        return RoomParticipantKey(room.floorHolder) === RoomParticipantKey(this.toRef(participant));
     }
 
     /**
      * Designates (or re-designates) a room's facilitator at runtime — e.g. when the agent running the
-     * Meeting Controls channel is determined after join. The agent must already be a room member.
+     * Meeting Controls channel is determined after join, or when a human host takes the chair. The
+     * member must already be registered in the room.
      *
      * @param roomId The shared room id.
-     * @param agentSessionId The agent to make facilitator (must be a member).
-     * @returns `true` when the facilitator was set; `false` when the room/agent is unknown.
+     * @param participant The agent session id (string) or participant ref to make facilitator (must be a member).
+     * @returns `true` when the facilitator was set; `false` when the room/member is unknown.
      */
-    public SetFacilitator(roomId: string, agentSessionId: string): boolean {
+    public SetFacilitator(roomId: string, participant: RoomParticipantSelector): boolean {
         const room = this.rooms.get(this.key(roomId));
-        const member = room?.members.get(this.key(agentSessionId));
+        const ref = this.toRef(participant);
+        const member = room?.members.get(RoomParticipantKey(ref));
         if (!room || !member) {
             return false;
         }
         member.IsFacilitator = true;
-        room.facilitatorAgentSessionId = agentSessionId;
+        room.facilitator = ref;
         return true;
     }
 
@@ -327,16 +438,20 @@ export class MultiAgentRoomCoordinator {
         if (!room) {
             return null;
         }
+        const participants = Array.from(room.members.values()).map(m => m.Participant);
         return {
             RoomId: room.roomId,
-            AgentSessionIds: Array.from(room.members.values()).map(m => m.AgentSessionId),
-            FacilitatorAgentSessionId: room.facilitatorAgentSessionId,
-            FloorHolderAgentSessionId: room.floorHolderAgentSessionId,
+            Participants: participants,
+            AgentSessionIds: participants.filter(p => p.Kind === 'Agent').map(p => p.AgentSessionId),
+            Facilitator: room.facilitator,
+            FacilitatorAgentSessionId: this.agentIdOf(room.facilitator),
+            FloorHolder: room.floorHolder,
+            FloorHolderAgentSessionId: this.agentIdOf(room.floorHolder),
             FloorHeldSinceMs: room.floorHeldSinceMs,
         };
     }
 
-    /** The ids of all rooms the coordinator currently tracks (those with ≥1 agent member). */
+    /** The ids of all rooms the coordinator currently tracks (those with ≥1 member). */
     public get RoomIds(): string[] {
         return Array.from(this.rooms.values()).map(r => r.roomId);
     }
@@ -352,9 +467,9 @@ export class MultiAgentRoomCoordinator {
         if (!room) {
             room = {
                 roomId,
-                members: new Map<string, RoomAgentMembership>(),
-                facilitatorAgentSessionId: null,
-                floorHolderAgentSessionId: null,
+                members: new Map<string, RoomParticipantMembership>(),
+                facilitator: null,
+                floorHolder: null,
                 floorHeldSinceMs: null,
             };
             this.rooms.set(k, room);
@@ -362,13 +477,27 @@ export class MultiAgentRoomCoordinator {
         return room;
     }
 
-    /** Whether an agent is the room's facilitator (by membership flag or the room's facilitator slot). */
-    private isFacilitator(room: RoomRecord, agentSessionId: string): boolean {
-        const member = room.members.get(this.key(agentSessionId));
+    /** Whether a member is the room's facilitator (by membership flag or the room's facilitator slot). */
+    private isFacilitator(room: RoomRecord, participant: RoomParticipantRef): boolean {
+        const memberKey = RoomParticipantKey(participant);
+        const member = room.members.get(memberKey);
         if (member?.IsFacilitator) {
             return true;
         }
-        return room.facilitatorAgentSessionId !== null && this.key(room.facilitatorAgentSessionId) === this.key(agentSessionId);
+        return room.facilitator !== null && RoomParticipantKey(room.facilitator) === memberKey;
+    }
+
+    /**
+     * Normalizes a {@link RoomParticipantSelector} to a ref. A bare string is an AGENT session id — the
+     * pre-human calling shape every existing caller still uses.
+     */
+    private toRef(participant: RoomParticipantSelector): RoomParticipantRef {
+        return typeof participant === 'string' ? AgentParticipant(participant) : participant;
+    }
+
+    /** The agent-session id of a ref for the back-compat `*AgentSessionId` projections; `null` for a human/none. */
+    private agentIdOf(participant: RoomParticipantRef | null): string | null {
+        return participant !== null && participant.Kind === 'Agent' ? participant.AgentSessionId : null;
     }
 
     /** Normalizes an id for case-insensitive map keying (UUIDs differ in case across DB platforms). */

--- a/packages/GraphQLDataProvider/src/graphQLLiveKitClient.ts
+++ b/packages/GraphQLDataProvider/src/graphQLLiveKitClient.ts
@@ -58,6 +58,12 @@ export interface StartLiveKitAgentRoomSessionInput {
   AgentSessionID?: string;
   /** Turn-taking mode. */
   TurnMode?: 'Passive' | 'Active' | 'Hybrid';
+  /**
+   * How eagerly the agent takes the floor: `'proactive'` (the default — an ordinary voice that
+   * auto-responds and can be brought into a meeting unaddressed) or `'addressed-only'` (a deliberately
+   * quiet observer/specialist seat that speaks only when one of its names is said, alone or in a meeting).
+   */
+  ParticipationMode?: 'proactive' | 'addressed-only';
 }
 
 /** Result of starting an agent room session (includes a client token so the caller can immediately join). */

--- a/packages/LiveKitRoomServer/src/__tests__/livekit-coordinator-egress.test.ts
+++ b/packages/LiveKitRoomServer/src/__tests__/livekit-coordinator-egress.test.ts
@@ -20,10 +20,13 @@ function makeBridgeOps(providerFound = true) {
       return { SessionBridgeID: `bridge-${++seq}` } as any;
     }),
     StopBridgeSession: vi.fn(async () => true),
-    ReconfigureSessionToMeeting: vi.fn((id: string) => {
+    // The gate the coordinator drives: reconfigure-in-place where the provider allows it, reconnect where it
+    // doesn't. The engine owns that choice — from out here it is one call that either gates the seat or doesn't.
+    EnsureSessionMeetingGated: vi.fn(async (id: string) => {
       reconfigureCalls.push({ id });
       return true;
     }),
+    GetEffectiveTurnState: vi.fn(() => ({ MeetingGated: true, CanReconfigureTurnMode: true })),
   } satisfies BridgeOps;
   return { ops, startCalls, reconfigureCalls };
 }
@@ -125,6 +128,37 @@ describe('LiveKitAgentRoomCoordinator', () => {
     expect((startCalls[1].TurnMatcher as object).constructor.name).toBe('RegexAddressedMatcher');
   });
 
+  it('an explicitly addressed-only agent is gated even when it is ALONE in the room', async () => {
+    const { ops, startCalls } = makeBridgeOps(true);
+    coordinator.SetBridgeOps(ops);
+    const factoryCtx: Record<string, unknown>[] = [];
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    coordinator.SetSessionFactory(async (ctx: any) => { factoryCtx.push(ctx); return {} as any; });
+
+    // No moderator mode, no other agent in the room — the gate comes purely from the caller's request.
+    await coordinator.StartAgentRoomSession({
+      AgentSessionID: 'q1', RoomName: 'quiet-room-1', AgentName: 'Scribe', AgentAliases: ['Note Taker'],
+      ParticipationMode: 'addressed-only',
+    });
+
+    expect(startCalls[0].ParticipationMode).toBe('addressed-only');
+    expect(startCalls[0].DisableAutoResponse).toBe(true);
+    expect((startCalls[0].TurnMatcher as object).constructor.name).toBe('RegexAddressedMatcher');
+    expect(factoryCtx[0].MeetingMode).toBe(true);
+    expect(factoryCtx[0].SelfNames).toEqual(['Scribe', 'Note Taker']);
+  });
+
+  it('defaults to proactive — omitting ParticipationMode keeps the solo 1:1 auto-response behavior', async () => {
+    const { ops, startCalls } = makeBridgeOps(true);
+    coordinator.SetBridgeOps(ops);
+
+    await coordinator.StartAgentRoomSession({ AgentSessionID: 'q2', RoomName: 'quiet-room-2', AgentName: 'Sage' });
+
+    expect(startCalls[0].ParticipationMode).toBe('proactive');
+    expect(startCalls[0].DisableAutoResponse).toBeUndefined();
+    expect((startCalls[0].TurnMatcher as object).constructor.name).toBe('AlwaysAddressedMatcher');
+  });
+
   it('re-gates the agents already in the room when it becomes multi-agent', async () => {
     vi.stubEnv('MJ_REALTIME_MODERATOR_MODE', 'on'); // meeting mode is gated behind the moderator opt-in
     const { ops, reconfigureCalls } = makeBridgeOps(true);
@@ -139,7 +173,70 @@ describe('LiveKitAgentRoomCoordinator', () => {
     await coordinator.StartAgentRoomSession({ AgentSessionID: 'g2', RoomName: room, AgentName: 'Marketing' });
     expect(reconfigureCalls.map((c) => c.id)).toContain('bridge-1');
     // The re-gate matcher carries the first agent's names (built into a RegexAddressedMatcher).
-    expect(ops.ReconfigureSessionToMeeting).toHaveBeenCalledWith('bridge-1', expect.anything());
+    expect(ops.EnsureSessionMeetingGated).toHaveBeenCalledWith('bridge-1', expect.anything());
+  });
+
+  it('passes per-session Instructions through to the realtime session factory', async () => {
+    const { ops } = makeBridgeOps(true);
+    coordinator.SetBridgeOps(ops);
+    const factoryCtx: Record<string, unknown>[] = [];
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    coordinator.SetSessionFactory(async (ctx: any) => { factoryCtx.push(ctx); return {} as any; });
+
+    await coordinator.StartAgentRoomSession({
+      AgentSessionID: 'p1', RoomName: 'persona-room-1', AgentName: 'Chen',
+      Instructions: 'You are Dr. Chen, a skeptical CFO.',
+    });
+
+    expect(factoryCtx[0].Instructions).toBe('You are Dr. Chen, a skeptical CFO.');
+  });
+
+  it('leaves Instructions undefined when the caller supplies none (today’s behavior, unchanged)', async () => {
+    const { ops } = makeBridgeOps(true);
+    coordinator.SetBridgeOps(ops);
+    const factoryCtx: Record<string, unknown>[] = [];
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    coordinator.SetSessionFactory(async (ctx: any) => { factoryCtx.push(ctx); return {} as any; });
+
+    await coordinator.StartAgentRoomSession({ AgentSessionID: 'p2', RoomName: 'persona-room-2', AgentName: 'Sage' });
+
+    expect(factoryCtx[0].Instructions).toBeUndefined();
+  });
+
+  it('carries Instructions into a meeting-mode RE-MINT — a re-opened seat is the SAME character', async () => {
+    const { ops, startCalls } = makeBridgeOps(true);
+    coordinator.SetBridgeOps(ops);
+    const factoryCtx: Record<string, unknown>[] = [];
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    coordinator.SetSessionFactory(async (ctx: any) => { factoryCtx.push(ctx); return {} as any; });
+
+    await coordinator.StartAgentRoomSession({
+      AgentSessionID: 'p3', RoomName: 'persona-room-3', AgentName: 'Chen',
+      Instructions: 'You are Dr. Chen, a skeptical CFO.',
+    });
+
+    // A provider that fixes turn config at connect is re-opened in meeting mode through this closure. The
+    // persona has to come back with it, or the agent returns mid-meeting as somebody else.
+    const reopen = startCalls[0].ReopenInMeetingMode as () => Promise<unknown>;
+    await reopen();
+
+    expect(factoryCtx).toHaveLength(2);
+    expect(factoryCtx[1].Instructions).toBe('You are Dr. Chen, a skeptical CFO.');
+    expect(factoryCtx[1].MeetingMode).toBe(true);
+  });
+
+  it('reports the seat’s EFFECTIVE turn state, read back from the engine rather than assumed', async () => {
+    const { ops } = makeBridgeOps(true);
+    ops.GetEffectiveTurnState.mockReturnValue({ MeetingGated: true, CanReconfigureTurnMode: false });
+    coordinator.SetBridgeOps(ops);
+
+    const result = await coordinator.StartAgentRoomSession({ AgentSessionID: 't1', RoomName: 'turnstate-room-1', AgentName: 'Sage' });
+
+    // A fixed-config provider (CanReconfigureTurnMode false) that IS gated — i.e. it had to be reconnected.
+    // The point of the read-back: the coordinator reports what the seat is doing, not what it asked for.
+    expect(result.MeetingGated).toBe(true);
+    expect(result.CanReconfigureTurnMode).toBe(false);
+    expect(ops.GetEffectiveTurnState).toHaveBeenCalledWith('bridge-1');
   });
 });
 

--- a/packages/LiveKitRoomServer/src/livekit-agent-room-coordinator.ts
+++ b/packages/LiveKitRoomServer/src/livekit-agent-room-coordinator.ts
@@ -21,7 +21,15 @@ import { AIBridgeEngine } from '@memberjunction/ai-bridge-server';
 import { LiveKitTokenService } from './livekit-token-service';
 
 /** The subset of {@link AIBridgeEngine} the coordinator drives — an injectable seam for unit testing. */
-export type BridgeOps = Pick<AIBridgeEngine, 'Config' | 'ProviderByDriverClass' | 'StartBridgeSession' | 'StopBridgeSession' | 'ReconfigureSessionToMeeting'>;
+export type BridgeOps = Pick<
+  AIBridgeEngine,
+  | 'Config'
+  | 'ProviderByDriverClass'
+  | 'StartBridgeSession'
+  | 'StopBridgeSession'
+  | 'EnsureSessionMeetingGated'
+  | 'GetEffectiveTurnState'
+>;
 
 /** The `DriverClass` the LiveKit bridge registers under (must match the `MJ: AI Bridge Providers` row). */
 export const LIVEKIT_BRIDGE_DRIVER_CLASS = 'LiveKitBridge';
@@ -53,6 +61,12 @@ export interface RealtimeSessionStartContext {
   MeetingMode?: boolean;
   /** The names the agent answers to (display name + aliases) — phrasing for the meeting prompt. */
   SelfNames?: string[];
+  /**
+   * Optional per-session INSTRUCTIONS — the persona/scenario text for THIS seat, **appended to** the
+   * co-agent's companion system prompt by the realtime core (never a replacement, so the framework's
+   * framing and safety text always survive). See `BridgeRealtimeSessionContext.Instructions`.
+   */
+  Instructions?: string;
 }
 
 /**
@@ -84,6 +98,23 @@ export interface StartAgentRoomSessionParams {
   AgentAliases?: string[];
   /** Turn-taking mode. Default: `'Passive'` (speak only when addressed). */
   TurnMode?: BridgeTurnMode;
+  /**
+   * How eagerly this agent takes the floor. `'proactive'` (the default) is an ordinary voice: it
+   * auto-responds when alone and the room moderator may bring it in unaddressed in a meeting.
+   * `'addressed-only'` is a deliberately QUIET seat — an observer/specialist that stays silent until
+   * someone says one of its names — and it is gated that way in a meeting AND when it is the room's only
+   * agent (see {@link StartAgentRoomSession}).
+   */
+  ParticipationMode?: 'proactive' | 'addressed-only';
+  /**
+   * Optional per-session INSTRUCTIONS for this seat — persona/scenario text **appended to** the
+   * co-agent's companion system prompt (never replacing it). This is what lets a room hold a PANEL of
+   * distinct characters rather than N copies of the same generic co-agent voice; the model/voice
+   * overrides above only make them SOUND different. Passed straight through to the realtime session
+   * factory. **Pre-authorized by the caller** — the MJServer resolver gates it behind the
+   * `Realtime: Advanced Session Controls` authorization. Omitted ⇒ today's behavior exactly.
+   */
+  Instructions?: string;
   /** The user the session runs as. */
   ContextUser?: UserInfo;
   /** The metadata provider for the session. */
@@ -108,6 +139,18 @@ export interface AgentRoomSession {
   RoomName: string;
   /** The LiveKit server URL. */
   ServerUrl: string;
+  /**
+   * Whether this seat ended up **meeting-gated** — model auto-response off + addressed-only. Reported so a
+   * caller can ASSERT the turn discipline it asked for instead of discovering by ear that an agent is
+   * answering everything. `false` for an ordinary solo 1:1 seat (correct), and `false` for a seat that was
+   * *supposed* to be gated but couldn't be (a failure — the engine logs why).
+   */
+  MeetingGated: boolean;
+  /**
+   * Whether this seat's realtime provider can change turn mode on a live socket. `false` (Gemini Live) means
+   * gating it costs a reconnect — see `AIBridgeEngine.EnsureSessionMeetingGated`.
+   */
+  CanReconfigureTurnMode: boolean;
 }
 
 /**
@@ -122,9 +165,9 @@ export class LiveKitAgentRoomCoordinator extends BaseSingleton<LiveKitAgentRoomC
    * Per-room roster of the agents currently bridged in (keyed by lowercased room name). Drives
    * **multi-agent meeting detection**: when an agent joins a room that ALREADY holds an agent, the new
    * agent starts in meeting mode (auto-response off + addressed-only) so several agents can share a room
-   * without all answering every utterance. The first agent stays a normal 1:1 voice (it isn't
-   * retroactively re-gated — that needs a live session re-config, a follow-up). See
-   * `plans/realtime/multi-agent-meeting-turn-taking.md`.
+   * without all answering every utterance. The agents already in the room are gated too, retroactively —
+   * on their live socket where the provider allows it, otherwise by re-opening the session in meeting mode
+   * (`AIBridgeEngine.EnsureSessionMeetingGated`). See `plans/realtime/multi-agent-meeting-turn-taking.md`.
    */
   private roomRosters = new Map<string, RoomAgentEntry[]>();
   private bridgeOps: BridgeOps = AIBridgeEngine.Instance;
@@ -198,8 +241,9 @@ export class LiveKitAgentRoomCoordinator extends BaseSingleton<LiveKitAgentRoomC
 
     // Multi-agent MEETING detection: if the room already holds an agent, THIS agent joins as a meeting
     // participant — auto-response OFF, speaks only when addressed by name. When a room becomes multi-agent
-    // the agents ALREADY in it are retroactively re-gated too (capability-permitting — see below). The names
-    // the agent answers to drive both its addressing matcher (the GATE) and the meeting prompt phrasing.
+    // the agents ALREADY in it are retroactively gated too, reconnecting them if that's what their provider
+    // requires (see below). The names the agent answers to drive both its addressing matcher (the GATE) and
+    // the meeting prompt phrasing.
     const roomKey = params.RoomName.trim().toLowerCase();
     const selfNames = [botName, ...(params.AgentAliases ?? [])].map(n => n.trim()).filter(n => n.length > 0);
     const existingAgents = this.roomRosters.get(roomKey) ?? [];
@@ -210,8 +254,21 @@ export class LiveKitAgentRoomCoordinator extends BaseSingleton<LiveKitAgentRoomC
     // (gated meeting mode + LLM router) for controlled scenarios (webinars, large rooms, weaker models).
     const moderatorMode = process.env.MJ_REALTIME_MODERATOR_MODE === 'on';
     const isMeeting = moderatorMode && existingAgents.length > 0;
+    // A caller can also ask for a QUIET seat outright (`'addressed-only'` — an observer/specialist that
+    // speaks only when called by name). That request has to hold even when the agent is ALONE in the room:
+    // gating it on roster size would leave it auto-responding to every utterance until a second agent
+    // happened to join — the same "why is it talking?" surprise meeting detection exists to prevent. So
+    // `gated` (not `isMeeting`) is what drives the addressing matcher, the model's auto-response, and the
+    // meeting prompt phrasing below. Omitting ParticipationMode leaves behavior exactly as before.
+    const participationMode = params.ParticipationMode ?? 'proactive';
+    const gated = isMeeting || participationMode === 'addressed-only';
 
-    const session = await this.sessionFactory({
+    // The identity half of the factory context — everything that does NOT depend on how the seat is gated.
+    // Held as one value because this agent's session may be minted TWICE: once now, and again in meeting mode
+    // if the room later becomes multi-agent and this provider can't be reconfigured on a live socket (see the
+    // reopen hook below). Both mints must describe the same agent, model, voice and AgentSession — deriving
+    // them twice is how the second session quietly becomes a different agent.
+    const sessionIdentity: RealtimeSessionStartContext = {
       AgentID: params.AgentID,
       AgentName: params.AgentName,
       TargetAgentID: params.TargetAgentID,
@@ -222,8 +279,16 @@ export class LiveKitAgentRoomCoordinator extends BaseSingleton<LiveKitAgentRoomC
       MetadataProvider: params.MetadataProvider,
       // So the co-agent observability run groups under THIS agent session (parity with native chat).
       AgentSessionID: params.AgentSessionID,
-      MeetingMode: isMeeting || undefined,
-      SelfNames: isMeeting ? selfNames : undefined,
+      // The seat's persona text (appended to the companion prompt, never replacing it). It belongs to the
+      // IDENTITY half precisely because of the re-mint: a re-opened session that dropped it would come back
+      // as a different character mid-meeting — the loudest possible version of the drift this value prevents.
+      Instructions: params.Instructions,
+    };
+
+    const session = await this.sessionFactory({
+      ...sessionIdentity,
+      MeetingMode: gated || undefined,
+      SelfNames: gated ? selfNames : undefined,
     });
 
     const active = await this.bridgeOps.StartBridgeSession({
@@ -234,17 +299,27 @@ export class LiveKitAgentRoomCoordinator extends BaseSingleton<LiveKitAgentRoomC
       Address: botToken.ServerUrl,
       JoinMethod: 'OnDemand',
       TurnMode: params.TurnMode ?? 'Passive',
-      // Meeting: gate speech to ADDRESSED turns (RegexAddressedMatcher on the agent's names) AND tell the
-      // engine the model's auto-response is off so the bridge becomes the sole trigger. Solo 1:1: respond to
-      // ALL the user's speech (AlwaysAddressedMatcher) with the model's own auto-response — Passive's
-      // name-match would otherwise leave a single agent silent unless you said its name each turn.
-      TurnMatcher: isMeeting ? new RegexAddressedMatcher(selfNames) : new AlwaysAddressedMatcher(),
-      DisableAutoResponse: isMeeting || undefined,
+      // Gated (a meeting, or an explicitly addressed-only seat): limit speech to ADDRESSED turns
+      // (RegexAddressedMatcher on the agent's names) AND tell the engine the model's auto-response is off so
+      // the bridge becomes the sole trigger. Otherwise (a proactive solo 1:1): respond to ALL the user's
+      // speech (AlwaysAddressedMatcher) with the model's own auto-response — Passive's name-match would
+      // leave a single agent silent unless you said its name each turn.
+      TurnMatcher: gated ? new RegexAddressedMatcher(selfNames) : new AlwaysAddressedMatcher(),
+      DisableAutoResponse: gated || undefined,
+      // How the engine re-gates THIS agent if the room becomes multi-agent later and its provider fixes turn
+      // config at connect (Gemini Live): it can't be reconfigured on a live socket, so it has to be re-opened
+      // in meeting mode. The engine owns that decision — it holds the live session and the capability flag —
+      // but it deliberately doesn't own the session factory, so we hand it the one thing only we can supply:
+      // a closure that re-mints THIS agent's session, meeting-gated. Passing a callback down beats exposing
+      // the factory up: the engine's interface grows by one optional field and the capability decision stays
+      // in exactly one place instead of being re-derived out here.
+      ReopenInMeetingMode: () => this.sessionFactory({ ...sessionIdentity, MeetingMode: true, SelfNames: selfNames }),
       // Roster info for the room turn moderator (the LLM router, when one is wired via SetTurnModerator):
-      // the names it answers to + its participation style. `'proactive'` (default) lets the moderator bring
-      // it in unaddressed when relevant; per-agent `'addressed-only'` resolution from config is a follow-up.
+      // the names it answers to + its participation style. `'proactive'` (the default) lets the moderator
+      // bring it in unaddressed when relevant; `'addressed-only'` keeps it out of every turn it wasn't
+      // named in.
       AgentNames: selfNames,
-      ParticipationMode: 'proactive',
+      ParticipationMode: participationMode,
       // The voiced TARGET agent (e.g. Sage) — the moderator resolves its role + per-agent turnTaking.mode.
       TargetAgentID: params.TargetAgentID,
       // NativeModuleSpecifier tells LiveKitNativeMeetingSdk which native room-client wrapper to load — the
@@ -263,21 +338,47 @@ export class LiveKitAgentRoomCoordinator extends BaseSingleton<LiveKitAgentRoomC
 
     this.addToRoster(roomKey, { AgentSessionID: params.AgentSessionID, SessionBridgeID: active.SessionBridgeID, Names: selfNames });
 
-    // The room just became (or stayed) multi-agent → retroactively re-gate the agents already in it into
-    // meeting mode so the whole room takes turns, not just the newcomers. Capability-gated in the engine:
-    // a provider that can't reconfigure a live session (e.g. Gemini) is left conversational, no dead call.
-    // Idempotent — agents already in meeting mode are no-ops.
+    // The room just became (or stayed) multi-agent → retroactively gate the agents already in it into meeting
+    // mode so the whole room takes turns, not just the newcomers. `EnsureSessionMeetingGated` reconfigures the
+    // live socket where the provider allows it and RE-OPENS the session in meeting mode where it doesn't
+    // (Gemini) — so a room whose first agent runs a fixed-config provider is gated too, instead of that agent
+    // auto-responding over everyone. Idempotent; awaited so room formation completes with the room gated.
     if (isMeeting) {
-      for (const agent of existingAgents) {
-        this.bridgeOps.ReconfigureSessionToMeeting(agent.SessionBridgeID, new RegexAddressedMatcher(agent.Names));
+      const gatedResults = await Promise.all(
+        existingAgents.map(async (agent) => ({
+          agent,
+          ok: await this.bridgeOps.EnsureSessionMeetingGated(agent.SessionBridgeID, new RegexAddressedMatcher(agent.Names)),
+        })),
+      );
+      const ungated = gatedResults.filter((r) => !r.ok).map((r) => r.agent.SessionBridgeID);
+      if (ungated.length > 0) {
+        // The engine already logged WHY each one failed; this says what it means for the room, which is the
+        // part an operator watching a call needs: some seat in here will talk over the others.
+        LogError(
+          `[LiveKitAgentRoomCoordinator] room ${params.RoomName} is NOT fully meeting-gated — ` +
+            `${ungated.length} of ${existingAgents.length} existing agent(s) could not be gated ` +
+            `(bridges: ${ungated.join(', ')}). Expect them to respond to all room audio.`,
+        );
       }
     }
 
+    // Three distinguishable seats, because "why is/isn't it talking?" is the first question an operator asks.
+    const seat = isMeeting ? 'MEETING — addressed-only' : gated ? 'solo — addressed-only (requested)' : 'solo 1:1';
     LogStatus(
       `[LiveKitAgentRoomCoordinator] Agent ${botName} bridged into LiveKit room ${params.RoomName} ` +
-        `(bridge ${active.SessionBridgeID}, ${isMeeting ? 'MEETING — addressed-only' : 'solo 1:1'})`,
+        `(bridge ${active.SessionBridgeID}, ${seat})`,
     );
-    return { SessionBridgeID: active.SessionBridgeID, RoomName: params.RoomName, ServerUrl: botToken.ServerUrl };
+    // The seat's EFFECTIVE gate, read back from the engine rather than re-derived from `gated` here: the two
+    // can legitimately differ (a provider that had to be re-opened, a gate that failed), and the whole point
+    // of surfacing it is that callers can assert what the seat is actually doing.
+    const turnState = this.bridgeOps.GetEffectiveTurnState(active.SessionBridgeID);
+    return {
+      SessionBridgeID: active.SessionBridgeID,
+      RoomName: params.RoomName,
+      ServerUrl: botToken.ServerUrl,
+      MeetingGated: turnState?.MeetingGated ?? false,
+      CanReconfigureTurnMode: turnState?.CanReconfigureTurnMode ?? false,
+    };
   }
 
   /** Appends an agent to a room's roster (creating the room's list on first join). */

--- a/packages/MJServer/src/__tests__/RealtimeBridgeResolver.test.ts
+++ b/packages/MJServer/src/__tests__/RealtimeBridgeResolver.test.ts
@@ -17,9 +17,9 @@ const h = vi.hoisted(() => ({
   stopRecording: vi.fn(async () => ({ EgressID: 'eg-1', RoomName: 'room-1', Status: 'EGRESS_COMPLETE' })),
 }));
 
-// These two are instantiated with `new` by the resolver, so they must be constructible. They were
-// `vi.fn(() => ({...}))`, which vitest 3 tolerated as a constructor but vitest 4 rejects with
-// "is not a constructor" — classes express the intent and work under both.
+// The resolver `new`s these, so the doubles must be CLASSES: an arrow-bodied `vi.fn()` is not a
+// constructor under vitest 4, and every mutation that constructed one was failing with
+// "... is not a constructor" (caught by the resolver's own try/catch, so it surfaced only as Success:false).
 vi.mock('@memberjunction/livekit-room-server', () => ({
   LiveKitTokenService: class {
     MintClientToken = h.mintClientToken;
@@ -47,6 +47,14 @@ vi.mock('@memberjunction/ai-agents', () => ({
   },
 }));
 
+// Mock the `Realtime: Advanced Session Controls` check so the GATE'S EFFECT is tested here without
+// standing up authorization metadata + role hierarchies. The check itself (and its fail-closed
+// direction) is one shared function, exercised on the client-direct path it was extracted from.
+const authz = vi.hoisted(() => ({ hasAdvancedControls: vi.fn(() => false) }));
+vi.mock('../resolvers/realtimeAdvancedSessionControls', () => ({
+  UserHasRealtimeAdvancedSessionControls: () => authz.hasAdvancedControls(),
+}));
+
 // Mock the meeting-recording registration so the thin resolver is tested in isolation (no MJStorage /
 // core-entities graph). Its own behavior is covered by meetingRecordingRegistration.test.ts.
 vi.mock('../resolvers/meetingRecordingRegistration', () => ({
@@ -54,7 +62,13 @@ vi.mock('../resolvers/meetingRecordingRegistration', () => ({
   correlateRecordingStart: vi.fn(async () => true),
 }));
 
-import { RealtimeBridgeResolver, MintLiveKitClientTokenInput, LiveKitRecordingInput } from '../resolvers/RealtimeBridgeResolver';
+import { LiveKitAgentRoomCoordinator } from '@memberjunction/livekit-room-server';
+import {
+  RealtimeBridgeResolver,
+  MintLiveKitClientTokenInput,
+  LiveKitRecordingInput,
+  StartLiveKitAgentRoomSessionInput,
+} from '../resolvers/RealtimeBridgeResolver';
 import type { AppContext } from '../types.js';
 
 /** A resolver subclass that supplies a fake authenticated user (GetUserFromPayload is protected). */
@@ -92,6 +106,69 @@ describe('RealtimeBridgeResolver', () => {
       expect(result.Success).toBe(false);
       expect(result.ErrorMessage).toMatch(/current user/i);
       expect(result.RoomName).toBe('room-1');
+    });
+  });
+
+  describe('StartLiveKitAgentRoomSession — per-session Instructions', () => {
+    /** The coordinator seam the resolver drives (mocked at module scope above). */
+    const startSession = LiveKitAgentRoomCoordinator.Instance.StartAgentRoomSession as ReturnType<typeof vi.fn>;
+
+    function makeInput(overrides: Partial<StartLiveKitAgentRoomSessionInput> = {}): StartLiveKitAgentRoomSessionInput {
+      return Object.assign(new StartLiveKitAgentRoomSessionInput(), {
+        RoomName: 'room-1',
+        AgentID: 'agent-1',
+        AgentSessionID: 'session-1', // supplied, so the resolver never needs to create one
+        ...overrides,
+      });
+    }
+
+    beforeEach(() => {
+      startSession.mockReset();
+      startSession.mockResolvedValue({
+        SessionBridgeID: 'bridge-1',
+        RoomName: 'room-1',
+        ServerUrl: 'wss://x.livekit.cloud',
+        MeetingGated: false,
+        CanReconfigureTurnMode: true,
+      });
+      authz.hasAdvancedControls.mockReset(); // call history matters below: the gate must go UNCONSULTED
+      authz.hasAdvancedControls.mockReturnValue(false);
+    });
+
+    it('REFUSES caller-supplied Instructions without the advanced-session-controls authorization', async () => {
+      const result = await resolver.StartLiveKitAgentRoomSession(makeInput({ Instructions: 'You are Dr. Chen.' }), ctx);
+
+      expect(result.Success).toBe(false);
+      expect(result.ErrorMessage).toMatch(/Realtime: Advanced Session Controls/);
+      expect(result.RoomName).toBe('room-1'); // the refusal still names the room it was for
+      // Refused OUTRIGHT, not downgraded to a generic-voice session the caller would think worked.
+      expect(startSession).not.toHaveBeenCalled();
+    });
+
+    it('passes Instructions to the coordinator for an authorized caller', async () => {
+      authz.hasAdvancedControls.mockReturnValue(true);
+
+      const result = await resolver.StartLiveKitAgentRoomSession(makeInput({ Instructions: '  You are Dr. Chen.  ' }), ctx);
+
+      expect(result.Success).toBe(true);
+      expect(startSession).toHaveBeenCalledOnce();
+      expect(startSession.mock.calls[0][0].Instructions).toBe('You are Dr. Chen.'); // trimmed
+    });
+
+    it('is UNGATED without Instructions — the everyday start never consults the authorization', async () => {
+      const result = await resolver.StartLiveKitAgentRoomSession(makeInput(), ctx);
+
+      expect(result.Success).toBe(true);
+      expect(authz.hasAdvancedControls).not.toHaveBeenCalled();
+      expect(startSession.mock.calls[0][0].Instructions).toBeUndefined();
+    });
+
+    it('treats a whitespace-only Instructions value as absent (no gate, no prompt change)', async () => {
+      const result = await resolver.StartLiveKitAgentRoomSession(makeInput({ Instructions: '   ' }), ctx);
+
+      expect(result.Success).toBe(true);
+      expect(authz.hasAdvancedControls).not.toHaveBeenCalled();
+      expect(startSession.mock.calls[0][0].Instructions).toBeUndefined();
     });
   });
 

--- a/packages/MJServer/src/resolvers/RealtimeBridgeResolver.ts
+++ b/packages/MJServer/src/resolvers/RealtimeBridgeResolver.ts
@@ -10,6 +10,7 @@ import { AIBridgeEngine } from '@memberjunction/ai-bridge-server';
 import { SessionManager } from '../agentSessions/SessionManager.js';
 import { NotificationEngine } from '@memberjunction/notifications';
 import { registerMeetingRecordingFile, correlateRecordingStart } from './meetingRecordingRegistration.js';
+import { UserHasRealtimeAdvancedSessionControls } from './realtimeAdvancedSessionControls.js';
 
 /**
  * Binds the agent realtime-session factory onto the LiveKit room coordinator's model-session creation seam.
@@ -127,6 +128,28 @@ export class StartLiveKitAgentRoomSessionInput {
 
   @Field(() => String, { nullable: true })
   TurnMode?: string;
+
+  /**
+   * How eagerly this agent takes the floor: `'proactive'` (the default — an ordinary voice) or
+   * `'addressed-only'` (a deliberately quiet observer/specialist seat that speaks only when named).
+   */
+  @Field(() => String, { nullable: true })
+  ParticipationMode?: string;
+
+  /**
+   * Optional per-session INSTRUCTIONS for this seat — the persona/scenario text that makes it a
+   * specific character (a panel of distinct voices instead of N copies of one). The realtime core
+   * APPENDS it to the co-agent's companion system prompt; it never replaces the framework's framing
+   * or safety text.
+   *
+   * **AUTHORIZATION-GATED**: caller-supplied prompt content is per-session prompt influence, so it
+   * requires the `Realtime: Advanced Session Controls` authorization — the same gate the client-direct
+   * `configOverridesJson` sits behind, and this is the stronger knob of the two (that path cannot
+   * carry prompt text at all). Unauthorized callers get a structured refusal, never a silent drop;
+   * omitting the field is the unchanged, ungated everyday flow.
+   */
+  @Field(() => String, { nullable: true })
+  Instructions?: string;
 }
 
 @ObjectType()
@@ -151,6 +174,22 @@ export class LiveKitAgentRoomSessionResult {
 
   @Field(() => String)
   Identity: string;
+
+  /**
+   * Whether the started seat is **meeting-gated** — the agent's model auto-response is off and it speaks only
+   * when addressed. Surfaced because turn discipline was previously only *audible*: an agent that keeps
+   * auto-responding in a multi-agent room talks over the whole cast, and nothing in the API said so. `false`
+   * is correct for an ordinary solo 1:1 seat, and a failure for a seat that was meant to be gated.
+   */
+  @Field(() => Boolean, { nullable: true })
+  MeetingGated?: boolean;
+
+  /**
+   * Whether this seat's realtime provider can change turn mode on a LIVE socket. `false` (e.g. Gemini Live)
+   * means gating it costs a session reconnect — which the bridge engine performs automatically.
+   */
+  @Field(() => Boolean, { nullable: true })
+  CanReconfigureTurnMode?: boolean;
 }
 
 @InputType()
@@ -244,6 +283,10 @@ export class RealtimeBridgeResolver extends ResolverBase {
   /**
    * Starts (or reuses) an agent's presence in a LiveKit room and returns a client token so the calling
    * user can immediately join the same room.
+   *
+   * Everything but one field is the plain authenticated flow: supplying `Instructions` (caller-authored
+   * text appended to the seat's system prompt) additionally requires the `Realtime: Advanced Session
+   * Controls` authorization and is refused with a reason when the caller lacks it.
    */
   @Mutation(() => LiveKitAgentRoomSessionResult)
   async StartLiveKitAgentRoomSession(
@@ -266,6 +309,20 @@ export class RealtimeBridgeResolver extends ResolverBase {
       }
       const provider = GetReadWriteProvider(context.providers) as unknown as IMetadataProvider;
       const roomName = input.RoomName?.trim() || `mj-${randomUUID()}`;
+
+      // PROMPT-INFLUENCE GATE. Caller-supplied Instructions are appended to the seat's system prompt, so
+      // they are the same class of privilege as the client-direct `configOverridesJson` and sit behind the
+      // same `Realtime: Advanced Session Controls` authorization (one shared, fail-closed check). Refused
+      // OUT LOUD rather than dropped: a caller who asked for a persona and silently got the generic voice
+      // would have no way to tell — and everything else about the start still looks like it worked.
+      const instructions = input.Instructions?.trim() || undefined;
+      if (instructions && !UserHasRealtimeAdvancedSessionControls(user, provider, 'StartLiveKitAgentRoomSession')) {
+        return failure(
+          "Not authorized: per-session agent instructions require the 'Realtime: Advanced Session Controls' " +
+            'authorization. Omit Instructions to start the agent with its configured persona.',
+          roomName,
+        );
+      }
 
       // Resolve the AIAgentSession the bridge will reference. The bridge row FK-references
       // AIAgentSession(ID), so we must use an EXISTING session — either one the caller supplied, or a
@@ -293,6 +350,9 @@ export class RealtimeBridgeResolver extends ResolverBase {
         RealtimeModelID: input.RealtimeModelID,
         RealtimeVoice: input.RealtimeVoice,
         TurnMode: this.normalizeTurnMode(input.TurnMode),
+        ParticipationMode: this.normalizeParticipationMode(input.ParticipationMode),
+        // Gated above; the coordinator and the realtime core treat it as pre-authorized from here on.
+        Instructions: instructions,
         ContextUser: user,
         MetadataProvider: provider,
       });
@@ -307,6 +367,10 @@ export class RealtimeBridgeResolver extends ResolverBase {
         ServerUrl: session.ServerUrl,
         ClientToken: clientToken.Token,
         Identity: clientToken.Identity,
+        // The seat's effective turn discipline, straight from the engine — so a caller can assert the room is
+        // gated instead of listening for an agent talking over everyone.
+        MeetingGated: session.MeetingGated,
+        CanReconfigureTurnMode: session.CanReconfigureTurnMode,
       };
     } catch (error) {
       const msg = error instanceof Error ? error.message : String(error);
@@ -336,6 +400,72 @@ export class RealtimeBridgeResolver extends ResolverBase {
       return await LiveKitAgentRoomCoordinator.Instance.StopAgentRoomSession(sessionBridgeID, 'Explicit', user, provider);
     } catch (error) {
       LogError(`StopLiveKitAgentRoomSession failed: ${error instanceof Error ? error.message : String(error)}`);
+      return false;
+    }
+  }
+
+  /**
+   * **Suspends** one agent so a human can take its seat — the agent stops talking but stays in the room.
+   * The half of in-room agent management that {@link StopLiveKitAgentRoomSession} is too blunt for: stopping
+   * ends the session, finalizes its co-agent run and severs its recording legs, so handing the seat back
+   * would mean a brand-new agent with none of the meeting's history. Suspending keeps the provider socket,
+   * the agent session, the transcript persistence and the observability run alive — only the agent's voice
+   * is gated off. Pair with {@link ResumeBridgeAgent} to hand the seat back.
+   *
+   * Deliberately NOT named `*LiveKit*`: it goes straight to the transport-agnostic {@link AIBridgeEngine},
+   * so it works for any bridged agent (LiveKit, Zoom, Teams, telephony). Best-effort — an unknown bridge, a
+   * provider that cannot gate its model mid-session, or any error resolves `false`.
+   *
+   * @param sessionBridgeID The `MJ: AI Agent Session Bridges` row id of the agent to suspend.
+   */
+  @Mutation(() => Boolean)
+  async SuspendBridgeAgent(
+    @Arg('sessionBridgeID', () => String) sessionBridgeID: string,
+    @Ctx() context: AppContext = {} as AppContext,
+  ): Promise<boolean> {
+    try {
+      const user = this.GetUserFromPayload(context.userPayload);
+      if (!user) {
+        return false;
+      }
+      const suspended = AIBridgeEngine.Instance.SuspendBridgeAgent(sessionBridgeID);
+      // A seat takeover is worth an audit line — WHO stepped into the agent's place, not just that someone did.
+      LogStatusEx({
+        message: `[RealtimeBridge] SuspendBridgeAgent(${sessionBridgeID}) by ${user.Email ?? user.ID} → ${suspended}`,
+        verboseOnly: true,
+      });
+      return suspended;
+    } catch (error) {
+      LogError(`SuspendBridgeAgent failed: ${error instanceof Error ? error.message : String(error)}`);
+      return false;
+    }
+  }
+
+  /**
+   * **Resumes** an agent suspended by {@link SuspendBridgeAgent} — the human hands the seat back and the
+   * agent responds again behind exactly the turn-taking gate it had before the takeover. It does not grab
+   * the floor on resume; it speaks when next addressed. Best-effort: any error resolves `false`.
+   *
+   * @param sessionBridgeID The `MJ: AI Agent Session Bridges` row id of the agent to resume.
+   */
+  @Mutation(() => Boolean)
+  async ResumeBridgeAgent(
+    @Arg('sessionBridgeID', () => String) sessionBridgeID: string,
+    @Ctx() context: AppContext = {} as AppContext,
+  ): Promise<boolean> {
+    try {
+      const user = this.GetUserFromPayload(context.userPayload);
+      if (!user) {
+        return false;
+      }
+      const resumed = AIBridgeEngine.Instance.ResumeBridgeAgent(sessionBridgeID);
+      LogStatusEx({
+        message: `[RealtimeBridge] ResumeBridgeAgent(${sessionBridgeID}) by ${user.Email ?? user.ID} → ${resumed}`,
+        verboseOnly: true,
+      });
+      return resumed;
+    } catch (error) {
+      LogError(`ResumeBridgeAgent failed: ${error instanceof Error ? error.message : String(error)}`);
       return false;
     }
   }
@@ -518,6 +648,22 @@ export class RealtimeBridgeResolver extends ResolverBase {
         return 'Hybrid';
       case 'passive':
         return 'Passive';
+      default:
+        return undefined;
+    }
+  }
+
+  /**
+   * Normalizes a participation-mode string to the bridge's accepted values. `undefined` (anything
+   * unrecognized included) leaves the coordinator on its `'proactive'` default rather than guessing a
+   * quiet seat the caller never asked for.
+   */
+  private normalizeParticipationMode(mode?: string): 'proactive' | 'addressed-only' | undefined {
+    switch ((mode ?? '').toLowerCase()) {
+      case 'proactive':
+        return 'proactive';
+      case 'addressed-only':
+        return 'addressed-only';
       default:
         return undefined;
     }

--- a/packages/MJServer/src/resolvers/RealtimeBridgeResolver.ts
+++ b/packages/MJServer/src/resolvers/RealtimeBridgeResolver.ts
@@ -243,6 +243,16 @@ export class RealtimeModelVoicesResult {
   Voices: RealtimeVoiceOptionResult[];
 }
 
+/**
+ * How a multi-agent room on THIS server will behave — the one thing about a panel that is otherwise
+ * only discoverable by listening to it.
+ */
+@ObjectType()
+export class RealtimeRoomModeResult {
+  @Field(() => Boolean)
+  ModeratorMode: boolean;
+}
+
 @Resolver()
 export class RealtimeBridgeResolver extends ResolverBase {
   /** Durable `AIAgentSession` record manager — creates the session row the bridge FK-references. */
@@ -495,6 +505,27 @@ export class RealtimeBridgeResolver extends ResolverBase {
       LogError(`EndLiveKitRoom failed: ${error instanceof Error ? error.message : String(error)}`);
       return false;
     }
+  }
+
+  /**
+   * Reports whether multi-agent rooms on this server are MODERATED (agents take turns through the LLM
+   * router) or FREE-FOR-ALL (every agent auto-responds to everything).
+   *
+   * Exists because the difference is otherwise only **audible**: `MJ_REALTIME_MODERATOR_MODE` is off by
+   * default, a deployment that forgets it gets crosstalk, and nothing at the API surface says so — the
+   * mutations all succeed either way. Reads the engine's effective state rather than the env var, so a
+   * typo in the variable reports honestly instead of reporting what was intended.
+   *
+   * Authenticated (it describes server configuration) but not otherwise gated: it is a single boolean
+   * about how rooms behave, which any client that can start one already needs to know.
+   */
+  @Query(() => RealtimeRoomModeResult)
+  RealtimeRoomMode(@Ctx() context: AppContext = {} as AppContext): RealtimeRoomModeResult {
+    const user = this.GetUserFromPayload(context.userPayload);
+    if (!user) {
+      throw new Error('RealtimeRoomMode requires an authenticated user.');
+    }
+    return { ModeratorMode: AIBridgeEngine.Instance.HasTurnModerator };
   }
 
   /**

--- a/packages/MJServer/src/resolvers/RealtimeClientSessionResolver.ts
+++ b/packages/MJServer/src/resolvers/RealtimeClientSessionResolver.ts
@@ -26,7 +26,7 @@
  */
 import { Resolver, Mutation, Arg, Ctx, Int, Float, ObjectType, Field, PubSub, PubSubEngine } from 'type-graphql';
 import { AppContext, UserPayload } from '../types.js';
-import { AuthorizationEvaluator, UserInfo, IMetadataProvider, LogError, LogStatus, RunView } from '@memberjunction/core';
+import { UserInfo, IMetadataProvider, LogError, LogStatus, RunView } from '@memberjunction/core';
 import { UUIDsEqual, IsValidUUID } from '@memberjunction/global';
 import {
     MJAIAgentEntity,
@@ -48,7 +48,6 @@ import {
     ParseRealtimeTypeConfiguration,
     ResolveEffectiveRealtimeConfig,
     RealtimeAllowedAgent,
-    REALTIME_ADVANCED_SESSION_CONTROLS_AUTHORIZATION,
     resolveRecordingStorageAccountID,
     storeRealtimeRecording,
     writeRealtimeRecordingSegment,
@@ -61,6 +60,7 @@ import { PUSH_STATUS_UPDATES_TOPIC } from '../generic/PushStatusResolver.js';
 import { GetReadWriteProvider } from '../util.js';
 import { SessionManager } from '../agentSessions/index.js';
 import { resolveWidgetGuestRunContext, ResolveScopedAnonymousRunUser } from '../realtimeWidget/widgetGuestElevation.js';
+import { UserHasRealtimeAdvancedSessionControls } from './realtimeAdvancedSessionControls.js';
 
 /**
  * Progress steps worth narrating to the realtime model — mirrors the normal agent-run path's filter
@@ -1391,32 +1391,12 @@ export class RealtimeClientSessionResolver extends ResolverBase {
     }
 
     /**
-     * Hierarchy-aware check for the `Realtime: Advanced Session Controls` authorization against
-     * the request provider's cached Authorizations + the caller's roles. FAIL-CLOSED: an absent
-     * authorization row (un-synced seed) or an evaluation error denies — runtime overrides are a
-     * privileged path, and unauthorized callers still get a fully working session without them.
+     * Hierarchy-aware, FAIL-CLOSED check for the `Realtime: Advanced Session Controls` authorization.
+     * Delegates to the shared {@link UserHasRealtimeAdvancedSessionControls} so this gate and the
+     * bridged room-session gate can never drift apart on the direction they fail in.
      */
     private userHasAdvancedSessionControls(contextUser: UserInfo, provider: IMetadataProvider): boolean {
-        try {
-            const auths = provider.Authorizations ?? [];
-            const wanted = REALTIME_ADVANCED_SESSION_CONTROLS_AUTHORIZATION.trim().toLowerCase();
-            const auth = auths.find((a) => a.Name?.trim().toLowerCase() === wanted);
-            if (!auth) {
-                LogError(
-                    `StartRealtimeClientSession: the '${REALTIME_ADVANCED_SESSION_CONTROLS_AUTHORIZATION}' ` +
-                        'authorization is not present in metadata — runtime overrides are denied (fail closed). ' +
-                        'Sync the authorization seed metadata to enable them.',
-                );
-                return false;
-            }
-            return new AuthorizationEvaluator().UserCanExecuteWithAncestors(auth, contextUser, auths);
-        } catch (error) {
-            LogError(
-                `StartRealtimeClientSession: authorization evaluation failed (${(error as Error).message}) — ` +
-                    'runtime overrides are denied (fail closed).',
-            );
-            return false;
-        }
+        return UserHasRealtimeAdvancedSessionControls(contextUser, provider, 'StartRealtimeClientSession');
     }
 
     /**

--- a/packages/MJServer/src/resolvers/realtimeAdvancedSessionControls.ts
+++ b/packages/MJServer/src/resolvers/realtimeAdvancedSessionControls.ts
@@ -1,0 +1,57 @@
+/**
+ * @fileoverview The `Realtime: Advanced Session Controls` authorization check — the ONE copy of the
+ * fail-closed decision that gates **per-session prompt/config influence** across every realtime
+ * surface MJServer exposes.
+ *
+ * Two surfaces need the identical answer: the CLIENT-DIRECT start
+ * ({@link import('./RealtimeClientSessionResolver.js').RealtimeClientSessionResolver}, gating
+ * `configOverridesJson` + a deviating explicit model) and the BRIDGED room start
+ * ({@link import('./RealtimeBridgeResolver.js').RealtimeBridgeResolver}, gating a room seat's
+ * caller-supplied `Instructions`). It lives here rather than being duplicated because the two copies
+ * would have to agree on the failure DIRECTION — an authorization row that is missing from metadata
+ * must DENY, not allow — and a second copy is exactly where that inverts unnoticed.
+ *
+ * @module @memberjunction/server
+ */
+import { AuthorizationEvaluator, IMetadataProvider, LogError, UserInfo } from '@memberjunction/core';
+import { REALTIME_ADVANCED_SESSION_CONTROLS_AUTHORIZATION } from '@memberjunction/ai-agents';
+
+/**
+ * Hierarchy-aware check for the `Realtime: Advanced Session Controls` authorization against the
+ * request provider's cached Authorizations + the caller's roles.
+ *
+ * **FAIL-CLOSED**: an absent provider, an absent authorization row (un-synced seed), or an evaluation
+ * error all DENY — these controls are a privileged path, and an unauthorized caller still gets a fully
+ * working session without them, so denial costs a feature while a wrong allow costs the guarantee.
+ *
+ * @param contextUser The calling user.
+ * @param provider The request-scoped metadata provider (its cached `Authorizations` are the source).
+ * @param surface The calling mutation, for log attribution (e.g. `StartLiveKitAgentRoomSession`).
+ * @returns `true` only when the caller demonstrably holds the authorization.
+ */
+export function UserHasRealtimeAdvancedSessionControls(
+  contextUser: UserInfo,
+  provider: IMetadataProvider | null | undefined,
+  surface: string,
+): boolean {
+  try {
+    const auths = provider?.Authorizations ?? [];
+    const wanted = REALTIME_ADVANCED_SESSION_CONTROLS_AUTHORIZATION.trim().toLowerCase();
+    const auth = auths.find((a) => a.Name?.trim().toLowerCase() === wanted);
+    if (!auth) {
+      LogError(
+        `${surface}: the '${REALTIME_ADVANCED_SESSION_CONTROLS_AUTHORIZATION}' authorization is not ` +
+          'present in metadata — advanced session controls are denied (fail closed). Sync the ' +
+          'authorization seed metadata to enable them.',
+      );
+      return false;
+    }
+    return new AuthorizationEvaluator().UserCanExecuteWithAncestors(auth, contextUser, auths);
+  } catch (error) {
+    LogError(
+      `${surface}: authorization evaluation failed (${error instanceof Error ? error.message : String(error)}) — ` +
+        'advanced session controls are denied (fail closed).',
+    );
+    return false;
+  }
+}


### PR DESCRIPTION
The room layer already puts N agents in one LiveKit room and arbitrates a floor between them. Five gaps kept that from being usable by a consumer whose agents are configured **characters** rather than one generic assistant. All five were found building a panel interview on it, and each is small on its own.

Everything here is additive: an omitted field behaves exactly as it does today.

---

### 1. A room whose FIRST agent cannot reconfigure a live socket is now re-gated by reconnecting it

`ReconfigureSessionToMeeting` logged and gave up when the provider fixes its turn config at connect (Gemini). Its own comment named the consequence and the fix:

> *"It will keep auto-responding to ALL room audio, bypassing the turn moderator and likely talking over the other agents. The robust fix is to reconnect it in meeting mode."*

`EnsureSessionMeetingGated` now mints a replacement session in meeting mode, swaps it onto the **same** `AIAgentSessionBridge` row and `AIAgentSession`, re-runs the transport and turn wiring, and closes the old socket in a `finally`. Room membership, scribe election and per-turn attribution survive the swap.

Three things the design forced, all documented in-code: outbound frames are dropped while a reopen is in flight (an un-gated agent must not keep talking through its own reconnect), concurrent callers share one pending promise, and attempts are capped — at the limit the agent keeps its original socket, because a degraded seat beats a dead one. Honest caveat: closing the old socket finalizes its co-agent run, so the reopened leg starts a fresh run *under the same agent session* — one session, two runs, not a severed chain.

The coordinator passes a reopen closure down rather than the engine reaching up: the alternative would force the coordinator to re-derive the "can this provider reconfigure?" decision, duplicating it outside the only place that holds both the live session and the capability flag.

### 2. The effective turn state is readable

`GetEffectiveTurnState`, plus `MeetingGated` / `CanReconfigureTurnMode` on the room-start result. Whether a room is properly gated was previously observable only by listening to it — which means a misconfiguration reaches production as crosstalk rather than as a failed check.

### 3. `ParticipationMode` resolves per agent

It was hard-coded `'proactive'` for every agent, with a comment acknowledging per-agent resolution as a follow-up. So a room could not have a deliberately quiet seat — an observer, or a specialist who answers only when called on by name.

An explicitly `addressed-only` agent is now gated **even when alone in the room**, rather than auto-responding to everything until a second agent happens to arrive. That asymmetry would have been the same class of surprise this PR's first item removes.

### 4. An agent can be silenced without being killed

`SuspendBridgeAgent` / `ResumeBridgeAgent`. The only previous mid-session control was `StopBridgeSession`, which tears down the socket, the run and the transcript continuity — so "a human takes this seat for a minute, then hands back" was not expressible.

Suspension has to hold at three points, because the moderator drain bypasses the turn policy and a matcher swap alone would not silence the agent: the outbound seam drops frames, `triggerMeetingSpeak` refuses a suspended session (the choke point both speak routes funnel through), and suspended seats drop out of the room broadcast and moderator roster. Presence paths still see them, so a suspended agent is never auto-reaped. Prior state is captured and restored verbatim rather than guessed, and both calls are idempotent and capability-gated **before** mutating anything — a half-suspended agent answering over the human is worse than a refusal.

### 5. A human can hold the floor

`MultiAgentRoomCoordinator` keyed membership on `AgentSessionID` only, so a human participant — who has a `UserID` and no agent session — could never be granted the floor, and agents had no structural reason to yield to one.

Floor membership becomes a participant reference (agent session **or** user). Every existing string caller still compiles and behaves identically; `RoomFloorState` keeps its agent-only projections. Two new decisions: a human's claim always wins (`HumanOverride` — the coordinator cannot mute a person), and agents yield to `HeldByHuman`, facilitator included. `IsMultiAgentRoom` still counts agents only, so one agent plus one human stays a 1:1 call rather than being re-gated into a meeting. The module stays pure, synchronous and injectable-clock, which is what keeps it unit-testable.

### 6. A bridged seat can be given per-session instructions

Neither `BridgeRealtimeSessionContext` nor `RealtimeSessionStartContext` could carry them, so a bridged agent's prompt came from its agent record alone. Two agents in a room could be given distinct **voices** (`RealtimeVoice` exists for exactly that) but not distinct **characters** — a panel is N copies of the same assistant in different timbres, and it is invisible from outside because the room still forms and the agents still talk.

`Instructions` threads from `StartLiveKitAgentRoomSessionInput` → `StartAgentRoomSessionParams` → `RealtimeSessionStartContext` → `BridgeRealtimeSessionContext` → `buildCompanionSystemPrompt`, **appended** as the last element of the existing join — byte-identical to how the client-direct subclass seam composes it, so framework framing and safety text survive. Putting it in the shared producer rather than mutating `SessionParams.SystemPrompt` afterwards also means the observability prompt-run records the prompt that was actually sent. It rides the reopen closure from item 1, so a re-gated seat comes back as the same character instead of silently becoming someone else mid-meeting.

**Gated behind `Realtime: Advanced Session Controls`.** Caller-supplied text appended to a system prompt is strictly more prompt influence than the `configOverridesJson` that gate already protects — that path cannot carry prompt text at all. Ungated, this would be the only privilege-unchecked prompt-injection surface in the realtime stack. The check is **extracted** rather than copied, because two copies of a fail-closed gate have to agree on which direction they fail in, and that is exactly what inverts unnoticed in a duplicate.

---

## Verification

Verified on this branch's base, not the tree it was written on:

| Package | tsc | tests |
|---|---|---|
| `ai-bridge-server` | clean | 186 passed |
| `livekit-room-server` | clean | 28 passed |
| `ai-agents` | clean | — |
| `server` | clean | `RealtimeBridgeResolver` 9 passed |

**Incidental fix:** `RealtimeBridgeResolver.test.ts` had 3 of 5 tests already failing at HEAD — vitest 4 rejects `vi.fn(() => ({...}))` as a constructor, so every mutation doing `new LiveKitTokenService()` failed behind the resolver's try/catch. Converted those two doubles to classes, matching the mock style already in the file.

## Provenance

Found while building multi-party assessment sessions on this layer in a downstream Open App. Worth stating plainly: a sixth "gap" we were about to file — 3+ agent echo — turned out not to exist. The SFU never returns a participant its own track, exactly as `livekit-bridge.ts` documents; the downstream risk register had been carrying it unsourced for months. That entry is retired rather than filed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)



---

## Part 1 of 3 — MJ core, proven through Caliber

This PR is part of the MJ-core half of the realtime-workspace / multi-party work. It is
**not to be merged as part of the Caliber push** — it stands on its own tests and is
consumed downstream by the Caliber PR listed below.

Downstream Caliber PRs that need this: **MemberJunction/bizapps-caliber#318** — the bridged
room launcher, which needs `Instructions` and `ParticipationMode` on
`StartAgentRoomSessionParams`. Its base branch, Caliber #317, defines the room-launcher
port and the cast/config layer but calls none of the APIs added here, so #317 is not gated
by this PR.


---

## Proven live through Caliber

Run against a live stack on 2026-08-18: MJAPI on `:4111`, LiveKit `livekit-dev` container, and
Caliber's own S15 probe (`smoke/bridge/room-panel-probe.mjs`) driving the room through this PR's
API. **Exit 0, 8 passing checks, 0 failures**, and not the `SKIPPED_NO_LIVEKIT` path — LiveKit was
up and the room genuinely formed.

```
S15 multi-party room probe — http://localhost:4111/
room: s15-probe-20260818175140

[1] two agent seats join one room
  PASS  two agent seats started in the same room
[2] a human joins the same room
  PASS  human client token minted for the room
[3] both bridges share one room key (ExternalConnectionID)
  PASS  both bridge rows found — 2 found
  PASS  both bridges carry the SAME ExternalConnectionID
  PASS  each agent seat has its OWN AIAgentSession
[4] participant roster persists
  PASS  roster rows written for the room
  PASS  agent participants recorded with an Agent role — Caliber Roleplay Co-Agent:Agent
[5] no agent transcribed its own audio (the retired-R3 assertion)
  PASS  no AI turn is duplicated across agent transcripts (self-echo)

PASS — 0 failed check(s).
```

Moderator mode was confirmed from the MJAPI boot log rather than asserted by the probe, since MJ
exposes no query for it (that is the second half of the upstream ask):

```
[RealtimeBridge] turn MODERATOR mode is ON (MJ_REALTIME_MODERATOR_MODE=on) — multi-agent rooms use the LLM router.
```

### What this does and does not establish

**Established:** two agent seats and one human occupy a single room; the bridges group under one
`ExternalConnectionID` while each seat keeps its own `AIAgentSession`; the roster persists with
agent roles; and no agent transcribes its own audio.

**Not established, deliberately stated:**
- **Turn-taking quality.** The probe proves the room forms and groups, not that the conversation
  *sounds* right. That needs the manual leg in `smoke/README.md`.
- **Caliber's own seat rows** (probe check `[5b]`) were not exercised: this room was started
  directly against MJ, not through a Caliber session with a `CastProfileID` set. That path is
  Caliber #318's, and it needs an authored cast.

### Downstream

Caliber **#318** consumes this API and does not function without it. Caliber **#317** was
*previously* listed as depending on this PR and does not — it defines the launcher port and calls
none of the APIs added here.
