### PR TITLE
ci: deploy the docs site only after a release publishes

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -12,32 +12,26 @@ name: Update package documentation
 # Every build uses the docs-site/ TOOLING from next (overlaid onto the content
 # checkout), so ingest/site fixes apply to all versions without cherry-picks.
 # Because this file lives on the default branch (next), the workflow_run
-# trigger fires from here regardless of what main or lts/* carry; pushes to
-# lts/* are forwarded by the thin dispatcher workflow on those branches.
+# trigger fires from here regardless of what main or lts/* carry.
 
 on:
+  # Release-following only: a docs deploy is the last step of shipping, never a
+  # side effect of merging. Between releases both `main` and the npm registry
+  # lag `next`, so a merge-triggered deploy publishes authoritative-looking
+  # documentation — canonical links into `main` included — for bits nobody can
+  # install yet. Both publish paths are covered: the Edge line publishes from
+  # main, and a line release is dispatched from its own lts/* branch. The
+  # resolve job below hard-fails a trigger that did not conclude `success`.
   workflow_run:
-    workflows: [Build and publish new package versions]
-    branches: [main]
+    workflows:
+      - Build and publish new package versions  # publish.yml     — Edge line, runs on main
+      - Publish LTS line release                # publish-lts.yml — one line, runs on lts/*
+    branches: [main, 'lts/*']
     types:
       - completed
 
-  # Docs content or tooling changes on next: Edge content and the shared
-  # tooling both live here, so any of these paths can change the built site.
-  push:
-    branches: [next]
-    paths:
-      - 'docs-site/**'
-      - 'guides/**'
-      - 'README.md'
-      - 'UPGRADE-v5.0.md'
-      - 'UPGRADE-v6.0.md'
-      - 'CONTRIBUTING.md'
-      - 'metadata/README.md'
-      - '.claude/skills/**'
-      - 'releases/**'
-      - '.github/workflows/docs.yml'
-
+  # Manual escape hatch: re-deploy a docs-only fix without waiting for a
+  # release, and the only way to exercise the full pipeline from a branch.
   workflow_dispatch: {}
 
 permissions:
@@ -66,10 +60,11 @@ jobs:
             exit 1
           fi
 
-      # github.sha is the commit this run was triggered for: the pushed next
-      # commit, the default-branch head for workflow_run, or the chosen ref's
-      # head for a manual dispatch (which is what lets a feature branch test
-      # the full pipeline before merging).
+      # github.sha is the commit this run was triggered for: the default-branch
+      # head for workflow_run, or the chosen ref's head for a manual dispatch
+      # (which is what lets a feature branch test the full pipeline before
+      # merging). Note for workflow_run this is next's head, NOT the released
+      # commit — the ref each version's CONTENT comes from is the matrix below.
       - name: Checkout repo
         uses: actions/checkout@v4
         with:


### PR DESCRIPTION
**One sentence:** the versioned docs site now deploys only after an npm publish succeeds — the Edge publish from `main` or a line release dispatched from `lts/*` — instead of on every docs-touching merge to `next`.

## What changed

`.github/workflows/docs.yml`, trigger block only:

- **Removed** the `push: branches: [next]` trigger and its ten-entry `paths` filter.
- **Added** `Publish LTS line release` (`publish-lts.yml`) alongside the existing `Build and publish new package versions` (`publish.yml`) in the `workflow_run` trigger, and widened the branch filter from `[main]` to `[main, 'lts/*']` so a line release from its own branch also lands.
- **Kept** `workflow_dispatch: {}` as the manual escape hatch.
- Refreshed two now-stale comments (the header's trigger note, and the `github.sha` note in the `resolve` job that referenced "the pushed next commit").

No job, step, matrix, ref, or permission changed. `actionlint .github/workflows/docs.yml` exits 0.

`docs-site-ci.yml` — the fast PR gate that runs unit tests + ingest + Astro build on docs-touching pull requests — is **untouched**. It has its own independent `paths` filter, so PR-time feedback on docs changes is unaffected; only the *deploy* becomes release-following.

## Why

Craig's ruling: the docs site should follow releases, not merges.

The concrete hazard that surfaced it is PR #3820 (`feat: relicense to Business Source License 1.1 (v6.0.0+)`). Repo-verified state today:

- #3820 adds `docs-site/src/lib/license-line.mjs`, whose `licenseUrl` for a BUSL line is the literal `https://github.com/MemberJunction/MJ/blob/main/LICENSE`.
- #3820 targets `next`. `origin/main` and `origin/next` currently carry **byte-identical ISC** `LICENSE` files (`git diff origin/main origin/next -- LICENSE` is empty), and `packages/MJCore/package.json` says `"license": "ISC"` on both. The BUSL text exists only on the PR branch.
- `next` is **400** commits ahead of `main`; `main` is a strict ancestor of `next`. `main` only moves when a release-prep branch merges into it (most recently `#3751 release/v6.1-prep` → `RELEASING: Releasing 301 package(s)`).
- #3820 touches `docs-site/**`, `README.md`, `CONTRIBUTING.md`, `UPGRADE-v6.0.md`, `guides/**` and `.github/workflows/docs.yml` — six separate matches against the old push filter.

So under the old trigger, merging #3820 would have republished `/v6` within minutes, stating "Business Source License 1.1" with its canonical license link resolving to ISC text — authoritative-looking, and granting materially more rights than intended, for however long it took the next release to carry the relicense to `main`.

Release-following deploys narrow that window structurally: `main` is caught up *by the act of releasing*, so at the moment a publish succeeds, `main` carries the released content. It does not close the window completely — see the residual gap below.

## What a reviewer should double-check

1. **Workflow names are matched by string.** `workflow_run.workflows` matches the `name:` field, not the filename. Verified today: `publish.yml` → `Build and publish new package versions`; `publish-lts.yml` → `Publish LTS line release`. **Renaming either workflow silently stops docs deploying, with no error anywhere.** That is the main fragility this trigger introduces.
2. **Branch glob.** `lts/*` matches `lts/5` and `lts/6.1` (GitHub's `*` does not cross `/`). Line branches are all one segment, so this holds.
3. **`workflow_run` fires for dispatch-started runs.** `publish-lts.yml` is `workflow_dispatch`-only; `workflow_run` fires on any completion of a named workflow regardless of how it started, so this is fine — but it is the one assumption here that isn't visible in the diff.
4. **The build refs are deliberately unchanged.** `resolve` still checks out `github.sha` for the tooling overlay (for `workflow_run` that is `next`'s head, *not* the released commit), and the matrix still builds each `/vN` from `lts/N` and the Edge set from `next`. For the LTS sets this is already release-exact for free, because `publish-lts.yml` pushes the release commit to `lts/N` before docs run. For the Edge set it means `/v6` still documents `next` tip, not the tag that was just published. Pinning Edge content to the released tag would freeze `guides/**`, `README.md`, `UPGRADE-*.md`, `releases/**` and the TypeDoc API reference to the last release — a real semantic change I did not smuggle into a trigger PR. Flagged as an open question.
5. **Docs fixes now wait for a release.** A typo fix merged to `next` sits undeployed until the next edge publish. `workflow_dispatch` covers anything urgent. This is the intended trade, but it is a behaviour change for anyone used to docs going live on merge.
6. **Failed-publish runs now show red more often.** The existing `Error out if the trigger did not succeed` step hard-fails when the triggering run didn't succeed. `publish-lts.yml`'s guards (wrong branch, confirmation typo, no changesets, pre-mode leak) fail early and often, and each will now produce a red *"Update package documentation"* run that carries no information the publish run doesn't already carry. Converting that step into a job-level `if:` skip is a clean 4-line follow-up — deliberately **not** done here, because it swaps a loud failure for a silent skip and that's a CI-noise judgement call, not part of the trigger change.

## Residual gap this PR does not close

Two paths still deploy `/v6` from `next` at a moment when `main` may not yet carry the relicense:

- **An LTS line release.** Shipping, say, `5.51.1` from `lts/5` triggers a full deploy. That rebuilds every set, including `/v6` from `next`. If #3820 has merged to `next` but no *edge* release has happened since, `blob/main/LICENSE` is still ISC.
- **A release cut that predates the merge.** If `release/vX-prep` is branched, then #3820 merges to `next`, then that release publishes, `main` ships without the BUSL while `/v6` is built from `next` with it.

`license-line.mjs` does not exist on `next` (it arrives with #3820), so there is nothing in this branch to fix and this PR leaves it alone. Two defensible options for #3820's author, in preference order:

- **Point the link at the ref the docs were built from.** The Edge set's content ref *is* `next`, so `blob/next/LICENSE` is self-consistent by construction and needs no release to become true. Downside: a moving dev branch is poor optics for a canonical legal URL.
- **Point it at the released tag.** Most defensible for a legal document — an immutable ref whose license text provably matches the packages a reader installed. Costs a small amount of plumbing (a version/tag env var into the docs build, which `docs.yml` does not pass today).

Separately worth #3820's author knowing: `licenseUrl` returns `blob/main/LICENSE` for *every* major ≥ 6, so once `lts/6` is cut and `main` moves to v7, the `/v6` docs would link at v7's license. The `lts/N` branch it already uses for pre-BUSL lines is the natural answer there too.

## Unrelated observations

- **`docs.yml`'s `resolve` step cannot see a dotted line branch.** It filters `lts/*` through `grep -E '^[0-9]+$'`, so an `lts/6.1` branch would be dropped from the version matrix entirely and never get a docs set — while `publish-lts.yml` happily derives `lts-6.1` as its npm dist-tag from the same branch. Not touched here; worth a separate look before `lts/6.1` is cut.
- **The `lts/5` thin dispatcher is now the only non-release deploy path.** `.github/workflows/docs.yml` on `origin/lts/5` is a stub that forwards docs-content pushes on `lts/5` into a full deploy via `gh workflow run docs.yml --ref next` — i.e. via `workflow_dispatch`, which this PR does not and cannot gate. It lives on `lts/5`, so closing it needs a separate PR to that branch. Its comment cites "self-deploying line release notes" as the use case, which is arguably release-adjacent and may be worth keeping deliberately. **Craig's call.**
- **#3820 also modifies `docs.yml`** (+29 lines), adding an `/mjcertified` root redirect inside the `deploy` job's assemble step. That's a different hunk from this PR's `on:` block, so no textual conflict is expected — but the two PRs do touch the same file, and whichever merges second should be re-verified with `actionlint`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QnZaUxhuvSKe26rqvWuD6e
