### PR TITLE
feat(realtime): let a deployment choose which channels tab up front (#3599)

### DIFF
--- a/.changeset/realtime-tab-up-front-configurable.md
+++ b/.changeset/realtime-tab-up-front-configurable.md
@@ -1,0 +1,28 @@
+---
+"@memberjunction/ng-conversations": minor
+---
+
+Realtime surface tabs: which channels tab up front is now the deployment's choice (#3599)
+
+`ShouldRegisterChannelTabUpFront` returned `IsWhiteboardChannel(channelName) || hasBeenUsed`, so the
+whiteboard — and only the whiteboard, matched by name — got a surface tab at session start before
+anything had touched it. The reasoning was sound (a user can be the first to draw on a board, whereas
+every other channel earns its tab on first use) but it was one deployment's answer compiled in. The
+predicate's own comment said detection was by name "so a deployment can't accidentally opt a
+non-board channel into the immediate-tab behavior" — which also meant a deployment could not
+deliberately opt OUT.
+
+`<mj-realtime-session-overlay>` takes a new `[TabUpFrontChannels]`:
+
+- **`null`** (the default) keeps MJ's answer exactly, so no existing deployment changes.
+- **an array** is the complete list of channels that tab up front, REPLACING the default rather than
+  adding to it. `[]` therefore means "no surface until something uses one" — the voice-first case,
+  where a session opens on the agent talking and a blank board makes the product read as a tool with
+  a canvas bolted on rather than as a conversation that can produce one.
+
+A channel the agent has already used always gets its tab, whatever is configured: a surface being
+driven with no tab on screen is a hidden surface, not a decluttered strip.
+
+Also removes an accidental duplicate of the whiteboard-name rule — `ShouldRemoveReviewWhiteboardTab`
+had its own inline `trim().toLowerCase() === 'whiteboard'` and now shares `IsWhiteboardChannel`, so
+the two cannot drift.

--- a/packages/Angular/Generic/conversations/node_modules
+++ b/packages/Angular/Generic/conversations/node_modules
@@ -1,0 +1,1 @@
+/Users/madhav/Projects/MJ/packages/Angular/Generic/conversations/node_modules

--- a/packages/Angular/Generic/conversations/src/__tests__/realtime-surface-tab-style.test.ts
+++ b/packages/Angular/Generic/conversations/src/__tests__/realtime-surface-tab-style.test.ts
@@ -29,6 +29,43 @@ describe('ShouldRegisterChannelTabUpFront', () => {
     expect(ShouldRegisterChannelTabUpFront('Notes', false)).toBe(false);
     expect(ShouldRegisterChannelTabUpFront('Notes', true)).toBe(true);
   });
+
+  // #3599 — the deployment's answer, replacing MJ's default rather than adding to it.
+
+  it('treats null/undefined as MJ\'s default, so nothing changes for existing deployments', () => {
+    expect(ShouldRegisterChannelTabUpFront('Whiteboard', false, null)).toBe(true);
+    expect(ShouldRegisterChannelTabUpFront('Whiteboard', false, undefined)).toBe(true);
+    expect(ShouldRegisterChannelTabUpFront('Remote Browser', false, null)).toBe(false);
+  });
+
+  it('lets a voice-first deployment have NO surface until one is used', () => {
+    // An empty list is the whole point of making this configuration: a session that opens on the
+    // agent talking should not open on a blank whiteboard nobody is going to draw on first.
+    expect(ShouldRegisterChannelTabUpFront('Whiteboard', false, [])).toBe(false);
+    expect(ShouldRegisterChannelTabUpFront('Remote Browser', false, [])).toBe(false);
+  });
+
+  it('lets a deployment tab up a channel that is not the whiteboard', () => {
+    expect(ShouldRegisterChannelTabUpFront('Remote Browser', false, ['Remote Browser'])).toBe(true);
+    // The list REPLACES the default — naming the browser does not silently keep the board.
+    expect(ShouldRegisterChannelTabUpFront('Whiteboard', false, ['Remote Browser'])).toBe(false);
+  });
+
+  it('matches configured names the way channel names are compared everywhere else', () => {
+    expect(ShouldRegisterChannelTabUpFront('Remote Browser', false, ['  remote browser  '])).toBe(true);
+    expect(ShouldRegisterChannelTabUpFront('  WHITEBOARD ', false, ['whiteboard'])).toBe(true);
+  });
+
+  it('always registers a channel already in use, whatever the deployment configured', () => {
+    // A surface the agent is driving with no tab on screen is a hidden surface, not a tidy strip.
+    expect(ShouldRegisterChannelTabUpFront('Remote Browser', true, [])).toBe(true);
+    expect(ShouldRegisterChannelTabUpFront('Whiteboard', true, ['Notes'])).toBe(true);
+  });
+
+  it('never matches a blank channel name against a blank configured entry', () => {
+    expect(ShouldRegisterChannelTabUpFront('', false, [''])).toBe(false);
+    expect(ShouldRegisterChannelTabUpFront('   ', false, ['   '])).toBe(false);
+  });
 });
 
 describe('ShouldShowActivityTab', () => {

--- a/packages/Angular/Generic/conversations/src/lib/components/realtime/realtime-session-overlay.component.ts
+++ b/packages/Angular/Generic/conversations/src/lib/components/realtime/realtime-session-overlay.component.ts
@@ -136,6 +136,22 @@ export class RealtimeSessionOverlayComponent extends BaseAngularComponent implem
    */
   @Input() Hidden = false;
 
+  /**
+   * Which channels get a surface tab at session start, before anything has used them (#3599).
+   *
+   * `null` (the default) keeps MJ's answer: the whiteboard tabs up front, nothing else does. Bind an
+   * array to replace that entirely — `[]` means no surface appears until something uses one, which
+   * is what a voice-first session wants (nobody is going to draw first, and a blank board makes the
+   * product read as a tool with a canvas bolted on). A design-review session wants the opposite, and
+   * both are legitimate, so this is the deployment's call rather than a compiled-in one.
+   *
+   * A channel the agent has already used ALWAYS gets its tab, whatever is bound here — a surface
+   * being driven with no tab on screen is a hidden surface, not a decluttered strip.
+   *
+   * Read when the session's channels resolve, so bind it before the call starts.
+   */
+  @Input() TabUpFrontChannels: string[] | null = null;
+
   /** Display name of the agent the voice session fronts (e.g. "Sage"). */
   @Input()
   set AgentName(value: string) {
@@ -1390,8 +1406,8 @@ export class RealtimeSessionOverlayComponent extends BaseAngularComponent implem
       if (!plugin.HasSurface()) {
         continue; // server-only channel — no surface to tab.
       }
-      if (!ShouldRegisterChannelTabUpFront(plugin.ChannelName, this.realtime.HasChannelBeenUsed(plugin.ChannelName))) {
-        continue; // not the whiteboard and not used yet — it earns its tab on first activity.
+      if (!ShouldRegisterChannelTabUpFront(plugin.ChannelName, this.realtime.HasChannelBeenUsed(plugin.ChannelName), this.TabUpFrontChannels)) {
+        continue; // not configured to tab up front and not used yet — it earns its tab on first activity.
       }
       this.registerPluginChannelTab(plugin);
     }

--- a/packages/Angular/Generic/conversations/src/lib/components/realtime/realtime-surface-tab-style.ts
+++ b/packages/Angular/Generic/conversations/src/lib/components/realtime/realtime-surface-tab-style.ts
@@ -10,26 +10,53 @@
 /**
  * Whether a channel name denotes the live WHITEBOARD channel (case-insensitive, trimmed).
  *
- * The whiteboard is the ONE channel whose surface tab appears immediately at session start
- * — a user can be the first to draw on it, whereas every other channel only earns its tab
- * once the agent actually USES it. Detection is by name (the registry `Name` / plugin
- * `ChannelName`) rather than a flag so a deployment can't accidentally opt a non-board
- * channel into the immediate-tab behavior.
+ * The whiteboard is the channel MJ tabs up front by DEFAULT — a user can be the first to draw on
+ * it, whereas every other channel only earns its tab once the agent actually uses it. That default
+ * is a good one, and a deployment that disagrees now says so via `tabUpFrontChannels`
+ * ({@link ShouldRegisterChannelTabUpFront}) rather than being stuck with it.
  */
 export function IsWhiteboardChannel(channelName: string | null | undefined): boolean {
-  return (channelName ?? '').trim().toLowerCase() === 'whiteboard';
+  return NormalizeChannelName(channelName) === 'whiteboard';
+}
+
+/** The comparable form of a channel name — trimmed and lowercased, in exactly one place. */
+export function NormalizeChannelName(channelName: string | null | undefined): string {
+  return (channelName ?? '').trim().toLowerCase();
 }
 
 /**
- * Whether a channel should get its surface tab registered UP FRONT (at the
- * registry-resolved emission) rather than waiting for first use.
+ * Whether a channel should get its surface tab registered UP FRONT (at the registry-resolved
+ * emission) rather than waiting for first use.
  *
- * True only for the whiteboard (see {@link IsWhiteboardChannel}) OR a channel the agent has
- * already used this session (`hasBeenUsed`). Every other channel stays tab-less until its
- * first activity registers it — keeping the strip decluttered to the surfaces actually in play.
+ * **A channel already in use always gets its tab**, whatever the deployment configured — a surface
+ * the agent is driving with no tab on screen is not a decluttered strip, it is a hidden surface.
+ *
+ * `tabUpFrontChannels` is the deployment's answer for everything else:
+ *
+ *  - **omitted / `null`** — MJ's default: the whiteboard tabs up front, nothing else does. This is
+ *    exactly the previous behaviour, so no existing deployment changes.
+ *  - **an array** — the COMPLETE list of channels that tab up front, replacing the default rather
+ *    than adding to it. `[]` therefore means "no surface until something uses it", which is the
+ *    voice-first interview case: a session opens on the agent talking, nobody is going to draw
+ *    first, and a blank board sitting there makes the product read as a tool with a canvas bolted
+ *    on rather than a conversation that can produce one.
+ *
+ * A design-review session wants the opposite of that interview, and both are legitimate — which is
+ * why this is configuration rather than a different hardcoded answer.
  */
-export function ShouldRegisterChannelTabUpFront(channelName: string, hasBeenUsed: boolean): boolean {
-  return IsWhiteboardChannel(channelName) || hasBeenUsed;
+export function ShouldRegisterChannelTabUpFront(
+  channelName: string,
+  hasBeenUsed: boolean,
+  tabUpFrontChannels?: readonly string[] | null,
+): boolean {
+  if (hasBeenUsed) {
+    return true;
+  }
+  if (tabUpFrontChannels === null || tabUpFrontChannels === undefined) {
+    return IsWhiteboardChannel(channelName);
+  }
+  const wanted = NormalizeChannelName(channelName);
+  return wanted.length > 0 && tabUpFrontChannels.some((name) => NormalizeChannelName(name) === wanted);
 }
 
 /**

--- a/packages/Angular/Generic/conversations/src/lib/components/realtime/realtime-surface-tabs.model.ts
+++ b/packages/Angular/Generic/conversations/src/lib/components/realtime/realtime-surface-tabs.model.ts
@@ -1,7 +1,7 @@
 import { Subject } from 'rxjs';
 import type { TemplateRef } from '@angular/core';
 import type { BaseRealtimeChannelClient } from './channels/base-realtime-channel-client';
-import { ChannelTabColor } from './realtime-surface-tab-style';
+import { ChannelTabColor, IsWhiteboardChannel } from './realtime-surface-tab-style';
 
 /**
  * The kind of a surface-panel tab:
@@ -294,5 +294,5 @@ export function ShouldRemoveReviewWhiteboardTab(
   if (!liveSessionActive || !reviewWhiteboardTabRegistered) {
     return false;
   }
-  return !liveChannels.some(c => c.ChannelName?.trim().toLowerCase() === 'whiteboard');
+  return !liveChannels.some(c => IsWhiteboardChannel(c.ChannelName));
 }


### PR DESCRIPTION
Fixes #3599.

## The defect

```ts
export function ShouldRegisterChannelTabUpFront(channelName: string, hasBeenUsed: boolean): boolean {
  return IsWhiteboardChannel(channelName) || hasBeenUsed;
}
```

The whiteboard — and only the whiteboard, matched by name — gets a surface tab at session start before anything has touched it. The stated reason is a good one: a user can be the first to draw on a board, whereas every other channel earns its tab on first use. But it is **one deployment's answer compiled in**, and the predicate's own comment gives the tell — detection is by name *"so a deployment can't accidentally opt a non-board channel into the immediate-tab behavior"*, which also means a deployment cannot deliberately opt **out**.

In a voice-first interview the session opens on the agent talking and nobody is going to draw first. A blank board sitting there makes the product read as a tool with a canvas bolted on rather than a conversation that can produce one. A design-review session wants the opposite — and both are legitimate, which is the argument for configuration rather than a different hardcoded answer. (Locally this was patched to `return hasBeenUsed`, a reversal rather than a fix, which is exactly why it was filed as configuration.)

## The fix

`<mj-realtime-session-overlay>` takes a new `[TabUpFrontChannels]`:

| bound value | behaviour |
|---|---|
| `null` (default) | MJ's answer, unchanged: the whiteboard tabs up front, nothing else does |
| `['Remote Browser']` | that channel tabs up front — and the whiteboard does **not** |
| `[]` | no surface until something uses one — the voice-first case |

**The array replaces the default rather than adding to it.** A deployment that names one channel is stating the complete list, not appending to a hidden one; otherwise `[]` could not express "nothing", which is the case that motivated the issue.

**A channel already in use always gets its tab**, whatever is configured. A surface the agent is driving with no tab on screen is a hidden surface, not a decluttered strip — so `hasBeenUsed` short-circuits ahead of the configuration.

Names are compared through a shared `NormalizeChannelName`, the same trim-and-lowercase rule channel names already use, so `'  remote browser  '` in a deployment's config matches the plugin's `'Remote Browser'`.

### The second half the issue flags

The issue warns that *"anything tracking surface presence separately must agree with the strip"*. Grepping for that turned up one real instance: `ShouldRemoveReviewWhiteboardTab` carried its own inline `c.ChannelName?.trim().toLowerCase() === 'whiteboard'` rather than calling `IsWhiteboardChannel`. Two copies of one rule, in a change that alters when whiteboard tabs appear, is how they drift — so it now shares the predicate.

## Tests

`realtime-surface-tab-style.test.ts` grows from 2 to 8 cases on this predicate: the default is unchanged for `null`/`undefined`, `[]` yields no up-front surface, a non-whiteboard channel can be named, the list replaces rather than extends the default, names normalise, `hasBeenUsed` overrides everything, and a blank name never matches a blank entry.

**1086 tests pass** across `@memberjunction/ng-conversations` (92 files).

Mutation-verified — five mutants, all killed:

| mutant | result |
|---|---|
| ignore the configuration entirely | 3 fail |
| let the configuration ADD to the default instead of replacing it | 3 fail |
| drop the `hasBeenUsed` override | 2 fail |
| drop name normalization | 2 fail |
| allow a blank name to match a blank entry | 1 fail |

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---

## Part 1 of 3 — MJ core, proven through Caliber

This PR is part of the MJ-core half of the realtime-workspace / multi-party work. It is
**not to be merged as part of the Caliber push** — it stands on its own tests and is
consumed downstream by the Caliber PR listed below.

Downstream Caliber PRs that need this: **MemberJunction/bizapps-caliber#157** — the realtime
workspace. It currently runs against a local `node_modules` patch of MJ and stays in draft
until this set lands and releases.
