### PR TITLE
feat(realtime): close ONE live channel without ending the call (#3498)

### DIFF
--- a/.changeset/realtime-close-one-channel.md
+++ b/.changeset/realtime-close-one-channel.md
@@ -1,0 +1,36 @@
+---
+"@memberjunction/ng-conversations": minor
+---
+
+Realtime: close ONE live channel without ending the call (#3498)
+
+Once two channel surfaces were open there was no way to close just one. A user done with the browser
+but still wanting the whiteboard had a single option: end the call — which tore down both surfaces
+plus the voice session.
+
+`RealtimeSurfaceTabsComponent.RemoveTab` already existed and did the right thing, but its only
+callers were review-mode cleanup, and **hiding a tab is not closing a channel**: the plugin stayed
+initialized, its tools stayed advertised to the model, and (for Remote Browser) a server-side headless
+Chrome kept running. So the agent could still act on a surface the user believed they had dismissed.
+
+`RealtimeSessionService.CloseChannel(channelName)` is the real action. It flushes the channel's
+debounced state save (a board closed three seconds after the last stroke does not lose those
+strokes), points its tool prefix at a refusal, disposes the plugin — which is where the Remote Browser
+channel stops its screencast and audio stream — drops it from the live set, tells the model the
+surface is gone, and announces on the new `ChannelClosed$`. Tab removal is a **consequence** of that,
+driven by the observable.
+
+The tool prefix is re-registered with a refusal rather than unregistered, and that distinction
+matters: the model was handed its vocabulary at connect and there is no mid-session way to withdraw
+part of it, so `browser_*` stays callable regardless. An *unregistered* prefix is not inert — unrouted
+tools fall through to the **server relay**, so the agent would keep driving the very browser the user
+dismissed, now with no surface showing it. A refusal keeps the call local and gives the model an
+answer it can narrate.
+
+Tabs carry a `Closable` flag (channel tabs default to closable; Activity never is, being the panel's
+fallback focus with nothing to release). A host can set `Closable: false` for a channel the session
+depends on — closing withdraws a channel's tools for the rest of the session and is not undoable.
+
+**Not covered here:** releasing the server-side browser on a per-channel close. The server-side
+`RemoteBrowserChannel` ends it on SESSION close, and there is no mutation for "this one channel is
+going away" — that needs a server change and is tracked separately.

--- a/packages/Angular/Generic/conversations/node_modules
+++ b/packages/Angular/Generic/conversations/node_modules
@@ -1,0 +1,1 @@
+/Users/madhav/Projects/MJ/packages/Angular/Generic/conversations/node_modules

--- a/packages/Angular/Generic/conversations/src/__tests__/realtime-surface-tabs-model.test.ts
+++ b/packages/Angular/Generic/conversations/src/__tests__/realtime-surface-tabs-model.test.ts
@@ -158,6 +158,35 @@ describe('RealtimeSurfaceTabsModel', () => {
     });
   });
 
+  describe('Closable (#3498)', () => {
+    it('makes channel tabs closable by default and the Activity tab never closable', () => {
+      model.RegisterChannelTab({ Key: 'Whiteboard', Title: 'Whiteboard', Icon: 'fa-solid fa-chalkboard' });
+      model.SetShowActivityTab(true);
+
+      expect(model.Tabs.find(t => t.Key === 'Whiteboard')?.Closable).toBe(true);
+      // Activity is the panel's fallback focus and owns nothing to release, so it stays irremovable —
+      // which RemoveTab already enforced and the strip must not offer a control for.
+      expect(model.Tabs.find(t => t.Key === 'activity')?.Closable).toBeFalsy();
+    });
+
+    it('lets a host mark a channel the user may NOT dismiss', () => {
+      // Closing withdraws a channel's tools for the rest of the session and is not undoable, so a
+      // session that depends on a surface can refuse the affordance.
+      model.RegisterChannelTab({ Key: 'Whiteboard', Title: 'Whiteboard', Icon: 'fa-solid fa-chalkboard', Closable: false });
+
+      expect(model.Tabs.find(t => t.Key === 'Whiteboard')?.Closable).toBe(false);
+    });
+
+    it('re-registering a tab carries the closable decision through the upgrade', () => {
+      // Channel tabs are registered as placeholders and UPGRADED when the plugin arrives; an upgrade
+      // that silently re-enabled the affordance would hand the user a close button the host refused.
+      model.RegisterChannelTab({ Key: 'Whiteboard', Title: 'Whiteboard', Icon: 'fa-solid fa-chalkboard', Closable: false });
+      model.RegisterChannelTab({ Key: 'Whiteboard', Title: 'Whiteboard', Icon: 'fa-solid fa-chalkboard', Closable: false });
+
+      expect(model.Tabs.find(t => t.Key === 'Whiteboard')?.Closable).toBe(false);
+    });
+  });
+
   describe('RemoveTab', () => {
     it('removes a channel tab and emits Changed$ once', () => {
       model.RegisterChannelTab({ Key: 'Whiteboard', Title: 'Whiteboard', Icon: 'fa-solid fa-chalkboard' });

--- a/packages/Angular/Generic/conversations/src/lib/components/realtime/realtime-session-overlay.component.html
+++ b/packages/Angular/Generic/conversations/src/lib/components/realtime/realtime-session-overlay.component.html
@@ -139,6 +139,7 @@
           [ExtraArtifacts]="ReviewArtifacts"
           [Fill]="ChannelFocusMode"
           (OpenRunRequested)="OnOpenRunRequested($event)"
+          (CloseTabRequested)="OnCloseTabRequested($event)"
           (CollapsedChange)="OnPanelCollapsedChange($event)"
           (WideChanged)="OnPanelWideChanged($event)">
         </mj-realtime-surface-tabs>

--- a/packages/Angular/Generic/conversations/src/lib/components/realtime/realtime-session-overlay.component.ts
+++ b/packages/Angular/Generic/conversations/src/lib/components/realtime/realtime-session-overlay.component.ts
@@ -609,6 +609,8 @@ export class RealtimeSessionOverlayComponent extends BaseAngularComponent implem
       this.realtime.ChannelFocus$.subscribe(event => this.onChannelFocus(event.Channel, event.Focused)),
       // The agent ACTED on a channel — auto-reveal its surface tab on first activity.
       this.realtime.ChannelActivity$.subscribe(plugin => this.onChannelActivity(plugin)),
+      // Tab removal is a CONSEQUENCE of the channel being closed, never the action itself (#3498).
+      this.realtime.ChannelClosed$.subscribe(channelName => this.onChannelClosed(channelName)),
       // Live/idle flips: reset/ratchet disclosure + re-evaluate the review-vs-live branch.
       this.realtime.Active$.subscribe(active => this.onActiveChanged(active)),
       // Connection lifecycle drives chrome (the `connecting` loader) + the public output.
@@ -1396,6 +1398,28 @@ export class RealtimeSessionOverlayComponent extends BaseAngularComponent implem
       this.registerPluginChannelTab(plugin);
     }
     this.cdr.markForCheck();
+  }
+
+  /** Removes a closed channel's tab once the session service has finished tearing the channel down. */
+  private onChannelClosed(channelName: string): void {
+    this.surfaceTabs?.RemoveTab(channelName);
+    this.recomputeUi();
+    this.cdr.markForCheck();
+  }
+
+  /**
+   * The user dismissed a surface (#3498). Closes the CHANNEL — the tab disappears as a consequence,
+   * via {@link RealtimeSessionService.ChannelClosed$}, not because this hid it.
+   *
+   * A key that matches no live channel still removes the tab: a review-mode board tab or a stale
+   * placeholder has no plugin behind it, and leaving a close control that visibly does nothing is
+   * worse than removing a tab that owns no resources.
+   */
+  public OnCloseTabRequested(key: string): void {
+    if (this.realtime.CloseChannel(key)) {
+      return;   // ChannelClosed$ removes the tab
+    }
+    this.surfaceTabs?.RemoveTab(key);
   }
 
   /** Registers (or upgrades) one channel plugin's surface tab on the panel. */

--- a/packages/Angular/Generic/conversations/src/lib/components/realtime/realtime-surface-tabs-close.dom.test.ts
+++ b/packages/Angular/Generic/conversations/src/lib/components/realtime/realtime-surface-tabs-close.dom.test.ts
@@ -1,0 +1,82 @@
+import { describe, it, expect } from 'vitest';
+import { renderComponentFixture, query, queryAll } from '@memberjunction/ng-test-utils';
+import { RealtimeSurfaceTabsComponent } from './realtime-surface-tabs.component';
+import { RealtimeSessionState } from './realtime-session-state';
+
+/**
+ * DOM spec for the per-tab CLOSE affordance (#3498).
+ *
+ * Before this, two open surfaces could only be reduced by ending the call — which tore down both
+ * plus the voice session. The control below is the missing half; the other half is that pressing it
+ * asks the HOST to close the channel rather than hiding the tab itself, because a hidden tab leaves
+ * the plugin initialized, its tools answering, and its server-side browser running.
+ */
+describe('RealtimeSurfaceTabsComponent — closing one surface (DOM)', () => {
+  const render = () =>
+    renderComponentFixture(RealtimeSurfaceTabsComponent, {
+      inputs: { State: new RealtimeSessionState() },
+    });
+
+  /**
+   * `RegisterChannelTab` defers its mutation to a microtask (the component's own NG0100 guard), so
+   * every test has to let that land before the strip reflects it.
+   */
+  const flush = async (f: { detectChanges(): void }) => {
+    await Promise.resolve();
+    f.detectChanges();
+  };
+
+  it('renders a close control on a channel tab and none on Activity', async () => {
+    const f = render();
+    f.componentInstance.RegisterChannelTab({ Key: 'Whiteboard', Title: 'Whiteboard', Icon: 'fa-solid fa-chalkboard' });
+    f.componentInstance.ShowActivityTab = true;
+    await flush(f);
+
+    const closers = queryAll(f, '.s-tab__close');
+    expect(closers).toHaveLength(1);
+    expect(closers[0].getAttribute('aria-label')).toBe('Close Whiteboard');
+  });
+
+  it('renders no close control when the host marked the channel un-closable', async () => {
+    const f = render();
+    f.componentInstance.RegisterChannelTab({
+      Key: 'Whiteboard', Title: 'Whiteboard', Icon: 'fa-solid fa-chalkboard', Closable: false,
+    });
+    await flush(f);
+
+    expect(queryAll(f, '.s-tab')).toHaveLength(1);   // the tab IS there…
+    expect(query(f, '.s-tab__close')).toBeNull();    // …it just cannot be dismissed
+  });
+
+  it('asks the host to close, and does NOT remove the tab itself', async () => {
+    const f = render();
+    f.componentInstance.RegisterChannelTab({ Key: 'Remote Browser', Title: 'Remote Browser', Icon: 'fa-solid fa-globe' });
+    await flush(f);
+    const requested: string[] = [];
+    f.componentInstance.CloseTabRequested.subscribe((key: string) => requested.push(key));
+
+    query(f, '.s-tab__close')?.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    f.detectChanges();
+
+    expect(requested).toEqual(['Remote Browser']);
+    // Still there: removing it here would hide a surface whose plugin is still live and whose tools
+    // still answer. The tab goes when the CHANNEL goes.
+    expect(f.componentInstance.Model.Tabs.some(t => t.Key === 'Remote Browser')).toBe(true);
+  });
+
+  it('does not focus the tab being dismissed', async () => {
+    const f = render();
+    f.componentInstance.RegisterChannelTab({ Key: 'Whiteboard', Title: 'Whiteboard', Icon: 'fa-solid fa-chalkboard', Focus: true });
+    f.componentInstance.RegisterChannelTab({ Key: 'Remote Browser', Title: 'Remote Browser', Icon: 'fa-solid fa-globe' });
+    await flush(f);
+    expect(f.componentInstance.Model.ActiveKey).toBe('Whiteboard');
+
+    // The close control LOOKS like it is inside the tab, but it is a sibling — a button cannot
+    // contain a button. That structure is what stops a dismissal from first switching the user to
+    // the surface they are getting rid of, so this test fails if anyone nests the two.
+    queryAll(f, '.s-tab__close')[1]?.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    f.detectChanges();
+
+    expect(f.componentInstance.Model.ActiveKey).toBe('Whiteboard');
+  });
+});

--- a/packages/Angular/Generic/conversations/src/lib/components/realtime/realtime-surface-tabs.component.css
+++ b/packages/Angular/Generic/conversations/src/lib/components/realtime/realtime-surface-tabs.component.css
@@ -82,6 +82,54 @@
   min-width: 12px;
 }
 
+/* Each tab shares a slot with its close control — the control cannot nest inside the tab's own
+   <button>, so the slot is what the strip lays out and the tab fills it. */
+.s-tab-slot {
+  position: relative;
+  display: inline-flex;
+  align-items: stretch;
+  flex: 0 1 auto;
+  min-width: 0;
+}
+.s-tab-slot--active {
+  flex-shrink: 0;
+}
+
+/* The close control sits over the tab's trailing padding rather than beside it, so revealing it
+   never reflows the strip — a tab that widened on hover would shuffle every tab after it. */
+.s-tab__close {
+  position: absolute;
+  right: 4px;
+  top: 50%;
+  transform: translateY(-50%);
+  width: 18px;
+  height: 18px;
+  padding: 0;
+  border: 0;
+  border-radius: 4px;
+  background: transparent;
+  color: var(--mj-text-muted);
+  font-size: 10px;
+  line-height: 1;
+  cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  /* Hidden until the tab is hovered, focused or active — but never `display: none`, so the control
+     stays in the a11y tree and is reachable by keyboard without a pointer. */
+  opacity: 0;
+  transition: opacity 120ms ease, background 120ms ease, color 120ms ease;
+}
+.s-tab-slot:hover .s-tab__close,
+.s-tab-slot--active .s-tab__close,
+.s-tab__close:focus-visible {
+  opacity: 1;
+}
+.s-tab__close:hover {
+  background: var(--mj-bg-surface-hover);
+  color: var(--mj-text-primary);
+}
+
 /* Tabs keep their natural width while there's room; when space gets tight they shrink
    (ellipsizing their titles) down to a readable floor. The ACTIVE tab never shrinks. */
 .s-tab {
@@ -106,6 +154,10 @@
 .s-tab i {
   font-size: 11px;
   flex-shrink: 0;
+}
+/* Room for the close control, reserved always — so the title never reflows when it appears. */
+.s-tab--closable {
+  padding-right: 26px;
 }
 .s-tab__title {
   max-width: 22ch;

--- a/packages/Angular/Generic/conversations/src/lib/components/realtime/realtime-surface-tabs.component.html
+++ b/packages/Angular/Generic/conversations/src/lib/components/realtime/realtime-surface-tabs.component.html
@@ -25,26 +25,40 @@
           <!-- Flex spacer pushes the Activity tab to the far right -->
           <span class="tabs-spacer" aria-hidden="true"></span>
         }
-        <button type="button"
-                class="s-tab"
-                role="tab"
-                [class.s-tab--activity]="tab.Kind === 'activity'"
-                [class.s-tab--channel]="tab.Kind === 'channel'"
-                [class.s-tab--active]="tab.Key === Model.ActiveKey"
-                [class.s-tab--flash]="tab.Key === Model.FlashKey"
-                [style.--tab-accent]="tab.Color || null"
-                [attr.aria-selected]="tab.Key === Model.ActiveKey"
-                [title]="tab.Title"
-                (click)="Model.Focus(tab.Key)">
-          @if (tab.Kind === 'channel') {
-            <span class="s-tab__dot" aria-hidden="true"></span>
+        <!-- A close control cannot nest inside the tab button, so each tab lives in a slot with the
+             close affordance as its sibling. -->
+        <span class="s-tab-slot" [class.s-tab-slot--active]="tab.Key === Model.ActiveKey">
+          <button type="button"
+                  class="s-tab"
+                  role="tab"
+                  [class.s-tab--activity]="tab.Kind === 'activity'"
+                  [class.s-tab--channel]="tab.Kind === 'channel'"
+                  [class.s-tab--active]="tab.Key === Model.ActiveKey"
+                  [class.s-tab--flash]="tab.Key === Model.FlashKey"
+                  [class.s-tab--closable]="tab.Closable"
+                  [style.--tab-accent]="tab.Color || null"
+                  [attr.aria-selected]="tab.Key === Model.ActiveKey"
+                  [title]="tab.Title"
+                  (click)="Model.Focus(tab.Key)">
+            @if (tab.Kind === 'channel') {
+              <span class="s-tab__dot" aria-hidden="true"></span>
+            }
+            <i [class]="tab.Icon" aria-hidden="true"></i>
+            <span class="s-tab__title">{{ tab.Title }}</span>
+            @if (tab.Kind === 'activity' && State.Cards.length > 0) {
+              <span class="s-tab__badge" aria-hidden="true">{{ State.Cards.length }}</span>
+            }
+          </button>
+          @if (tab.Closable) {
+            <button type="button"
+                    class="s-tab__close"
+                    [attr.aria-label]="'Close ' + tab.Title"
+                    [title]="'Close ' + tab.Title"
+                    (click)="RequestCloseTab(tab.Key)">
+              <i class="fa-solid fa-xmark" aria-hidden="true"></i>
+            </button>
           }
-          <i [class]="tab.Icon" aria-hidden="true"></i>
-          <span class="s-tab__title">{{ tab.Title }}</span>
-          @if (tab.Kind === 'activity' && State.Cards.length > 0) {
-            <span class="s-tab__badge" aria-hidden="true">{{ State.Cards.length }}</span>
-          }
-        </button>
+        </span>
       }
       <div class="tabs-end">
         <button type="button"

--- a/packages/Angular/Generic/conversations/src/lib/components/realtime/realtime-surface-tabs.component.ts
+++ b/packages/Angular/Generic/conversations/src/lib/components/realtime/realtime-surface-tabs.component.ts
@@ -122,6 +122,14 @@ export class RealtimeSurfaceTabsComponent implements OnInit, OnDestroy {
    */
   @Output() WideChanged = new EventEmitter<boolean>();
 
+  /**
+   * The user asked to close a surface, by tab key (#3498). The HOST closes the channel — this
+   * component does not remove the tab itself, because hiding a tab is not closing a channel: the
+   * plugin would stay initialized, its tools would keep answering, and its server-side resources
+   * would stay held. The tab goes away when the host's close completes.
+   */
+  @Output() CloseTabRequested = new EventEmitter<string>();
+
   /** The panel's tab state (add / focus / dedupe / flash) — see the model for the rules. */
   public readonly Model = new RealtimeSurfaceTabsModel();
 
@@ -260,6 +268,18 @@ export class RealtimeSurfaceTabsComponent implements OnInit, OnDestroy {
    *
    * @returns `true` when a tab was removed.
    */
+  /**
+   * Handles the tab strip's close control: asks the host to close that surface.
+   *
+   * No `stopPropagation` here, deliberately. The control is a SIBLING of the tab button rather than
+   * nested inside it — a button cannot contain a button — so a dismissal never reaches the tab's own
+   * click handler and never focuses the surface the user is getting rid of. That structure is the
+   * guarantee; a defensive `stopPropagation` would only make it look like the guarantee lives here.
+   */
+  public RequestCloseTab(key: string): void {
+    this.CloseTabRequested.emit(key);
+  }
+
   public RemoveTab(key: string): boolean {
     const removed = this.Model.RemoveTab(key);
     if (removed) {

--- a/packages/Angular/Generic/conversations/src/lib/components/realtime/realtime-surface-tabs.model.ts
+++ b/packages/Angular/Generic/conversations/src/lib/components/realtime/realtime-surface-tabs.model.ts
@@ -60,6 +60,14 @@ export interface RealtimeSurfaceTab {
   Color?: string;
   /** Kind-specific payload. */
   Data?: RealtimeSurfaceTabData;
+  /**
+   * Whether the user may dismiss this surface (#3498). Channel tabs default to `true`; the Activity
+   * tab is never closable, because it is the panel's fallback focus and has nothing to release.
+   *
+   * A host sets `Closable: false` on a registration for a channel the session depends on — closing a
+   * surface withdraws its tools for the rest of the session, so it is deliberately not undoable.
+   */
+  Closable?: boolean;
 }
 
 /**
@@ -85,6 +93,11 @@ export interface RealtimeChannelTabRegistration {
   Content?: TemplateRef<unknown>;
   /** Focus the tab immediately after registration (default `false`). */
   Focus?: boolean;
+  /**
+   * May the user close this surface (default `true`)? Set `false` for a channel the session depends
+   * on — closing withdraws the channel's tools for the rest of the session and is not undoable.
+   */
+  Closable?: boolean;
 }
 
 /**
@@ -196,7 +209,8 @@ export class RealtimeSurfaceTabsModel {
       Icon: registration.Icon,
       Kind: 'channel',
       Color: registration.Color ?? ChannelTabColor(registration.Key),
-      Data: { Plugin: registration.Plugin, Content: registration.Content }
+      Data: { Plugin: registration.Plugin, Content: registration.Content },
+      Closable: registration.Closable !== false
     };
     const idx = this.channelTabs.findIndex(t => t.Key === registration.Key);
     if (idx >= 0) {

--- a/packages/Angular/Generic/conversations/src/lib/services/realtime-session.service.ts
+++ b/packages/Angular/Generic/conversations/src/lib/services/realtime-session.service.ts
@@ -265,6 +265,16 @@ export class RealtimeSessionService {
   private _modelName$ = new BehaviorSubject<string | null>(null);
   private _minimized$ = new BehaviorSubject<boolean>(false);
   private _activeChannels$ = new BehaviorSubject<BaseRealtimeChannelClient[]>([]);
+
+  /** Emits a channel's name once {@link CloseChannel} has finished tearing it down (#3498). */
+  private _channelClosed$ = new Subject<string>();
+
+  /**
+   * `ToolNamePrefix`es of channels closed this session. The model was told its tool vocabulary at
+   * connect and cannot be told otherwise mid-session, so a closed channel's tools remain CALLABLE —
+   * see {@link CloseChannel} for why they are answered with a refusal rather than unregistered.
+   */
+  private closedToolPrefixes = new Set<string>();
   private _channelFocus$ = new Subject<RealtimeChannelFocusEvent>();
   // ─── Generic session-lifecycle events (consumed by RealtimeSessionsAdapter to
   // bridge into @memberjunction/conversations-runtime's framework-agnostic
@@ -360,6 +370,15 @@ export class RealtimeSessionService {
    * than {@link SessionStarted$}/{@link SessionEnded$} (per tool call, not per session).
    */
   public readonly ChannelActivity$: Observable<BaseRealtimeChannelClient> = this._channelActivity$.asObservable();
+
+  /**
+   * Fires with a channel's name after {@link CloseChannel} has torn it down (#3498). The overlay
+   * removes the surface tab in response, which is why tab removal is a CONSEQUENCE of closing rather
+   * than the whole action — hiding the tab on its own would leave the plugin initialized, its tools
+   * answering, and its server-side resources held, so the agent could still act on a surface the user
+   * believes they dismissed.
+   */
+  public readonly ChannelClosed$: Observable<string> = this._channelClosed$.asObservable();
 
   /** Synchronous access to the session's active interactive-channel plugins. */
   public get ActiveChannels(): readonly BaseRealtimeChannelClient[] {
@@ -1347,6 +1366,82 @@ export class RealtimeSessionService {
     }
   }
 
+  /**
+   * Closes ONE live interactive channel: the user is done with the browser but still wants the
+   * whiteboard (#3498).
+   *
+   * Before this, the only way to remove a surface was to end the call, which tore down every channel
+   * plus the voice session. `RealtimeSurfaceTabsComponent.RemoveTab` existed and did the right thing,
+   * but hiding a tab is not closing a channel — it would leave the plugin initialized, its tools
+   * answering, and its server-side resources held. So tab removal is a CONSEQUENCE of this, driven by
+   * {@link ChannelClosed$}, rather than the whole action.
+   *
+   * What closing actually does, in order:
+   *  1. flushes the channel's debounced state save, so a board closed three seconds after the last
+   *     stroke does not lose those strokes;
+   *  2. replaces its tool route with a REFUSAL (see below);
+   *  3. disposes the plugin, which releases what the plugin owns (the Remote Browser channel stops
+   *     its screencast and audio stream here);
+   *  4. drops it from the live set and announces the close.
+   *
+   * **Why the tool prefix is re-registered rather than unregistered.** The model was handed its tool
+   * vocabulary at connect and there is no mid-session way to withdraw part of it, so `browser_*` stays
+   * callable no matter what happens here. An unregistered prefix does not become inert — unrouted
+   * tools fall through to the SERVER relay, so the agent would keep driving the very browser the user
+   * dismissed, now with no surface showing it. A refusal keeps the call local, gives the model an
+   * answer it can narrate, and cannot reach the server.
+   *
+   * @param channelName The channel to close (compared case-insensitively, like every channel name).
+   * @returns `true` when a live channel was found and closed; `false` when none matched.
+   */
+  public CloseChannel(channelName: string): boolean {
+    const wanted = (channelName ?? '').trim().toLowerCase();
+    const plugin = this._activeChannels$.value.find(c => (c.ChannelName ?? '').trim().toLowerCase() === wanted);
+    if (!plugin) {
+      return false;
+    }
+    this.flushChannelSave(plugin.ChannelName);
+    this.refuseToolsFor(plugin);
+    try {
+      plugin.Dispose();
+    } catch (error) {
+      // A plugin that throws on the way out must not strand the close: the tab, the tool route and the
+      // live set all still have to change, or the user's dismissal silently does nothing.
+      console.error(`[RealtimeSession] Channel '${plugin.ChannelName}' Dispose failed while closing:`, error);
+    }
+    this._activeChannels$.next(this._activeChannels$.value.filter(c => c !== plugin));
+    this.SendContextNote(
+      `[${plugin.ChannelName}] The user closed this surface. It is no longer available — do not try to use it, ` +
+        `and say so plainly if asked to.`,
+    );
+    this._channelClosed$.next(plugin.ChannelName);
+    return true;
+  }
+
+  /**
+   * Points a closed channel's tool prefix at a refusal, so a tool the model still knows about answers
+   * "that surface is closed" instead of falling through to the server relay.
+   *
+   * The refusal shape matches what {@link handleToolCall} produces for a thrown handler, so the model
+   * reads it exactly the way it reads any other tool failure.
+   */
+  private refuseToolsFor(plugin: BaseRealtimeChannelClient): void {
+    const channelName = plugin.ChannelName;
+    this.closedToolPrefixes.add(plugin.ToolNamePrefix);
+    this.RegisterClientToolHandler(plugin.ToolNamePrefix, (toolName: string) =>
+      JSON.stringify({
+        success: false,
+        error: `The '${channelName}' surface was closed by the user. '${toolName}' is unavailable for the rest of this session.`,
+      }),
+    );
+  }
+
+  /** Whether the named channel is live right now — false once {@link CloseChannel} has closed it. */
+  public IsChannelOpen(channelName: string): boolean {
+    const wanted = (channelName ?? '').trim().toLowerCase();
+    return this._activeChannels$.value.some(c => (c.ChannelName ?? '').trim().toLowerCase() === wanted);
+  }
+
   /** Disposes all channel plugins (errors contained per plugin) and clears the live set. */
   private disposeChannels(): void {
     for (const plugin of this._activeChannels$.value) {
@@ -1360,6 +1455,12 @@ export class RealtimeSessionService {
       this._activeChannels$.next([]);
     }
     this.usedChannelNames.clear();
+    // Tombstones are per SESSION: the next session mints a fresh tool vocabulary, and a stale refusal
+    // would answer for a channel that is open again.
+    for (const prefix of this.closedToolPrefixes) {
+      this.UnregisterClientToolHandler(prefix);
+    }
+    this.closedToolPrefixes.clear();
   }
 
   // ── Realtime client resolution + wiring ────────────────────────────────────


### PR DESCRIPTION
Fixes #3498.

## The defect

Once two channel surfaces are open there is no way to close just one. The user who is done with the browser but still wants the whiteboard has a single option: **end the call** — which tears down both surfaces plus the voice session.

`RealtimeSurfaceTabsComponent.RemoveTab(key)` already existed and did the right thing (Activity is irremovable, focus falls back). But its only callers were review-mode cleanup, no live tab rendered a close affordance, and — the important half — **hiding a tab is not closing a channel**. Even calling `RemoveTab` on a live channel would leave the plugin initialized, its tools advertised to the model, and (for Remote Browser) a server-side headless Chrome running. The agent could still act on a surface the user believed they had dismissed.

## The fix

`RealtimeSessionService.CloseChannel(channelName)` is the real action, and tab removal is a **consequence** of it (via a new `ChannelClosed$`) rather than the whole action. In order, closing:

1. **flushes the channel's debounced state save** — a board closed three seconds after the last stroke must not lose those strokes;
2. **points its tool prefix at a refusal** (see below);
3. **disposes the plugin**, which is where the Remote Browser channel stops its screencast and audio stream;
4. **drops it from the live set**, pushes a context note so the model knows the surface is gone, and announces the close.

A plugin that throws on the way out does not strand the close — the tab, the tool route and the live set all still change, or the user's dismissal silently does nothing.

### Why the tool prefix is re-registered, not unregistered

This is the part worth reviewing carefully. The model was handed its tool vocabulary at connect and there is no mid-session way to withdraw part of it, so `browser_*` stays **callable** no matter what happens here. An *unregistered* prefix does not become inert:

```ts
const clientHandler = this.findClientToolHandler(call.ToolName);
if (clientHandler) { … }        // local
// otherwise → the MJ SERVER relay
```

So unregistering would send the agent's browser tools to the server resolver, which would drive **the very browser the user dismissed**, now with no surface showing it — strictly worse than the original bug. A refusal handler keeps the call local, cannot reach the server, and gives the model an answer it can narrate ("that surface was closed"). Tombstones are cleared at session teardown, since the next session mints a fresh vocabulary.

### The affordance

Tabs carry a `Closable` flag: channel tabs default to closable, the Activity tab never is (it is the panel's fallback focus and owns nothing to release). A host sets `Closable: false` for a channel the session depends on — closing withdraws a channel's tools for the rest of the session and is deliberately not undoable.

The close control is a **sibling** of the tab button, not nested inside it — a button cannot contain a button. It is absolutely positioned over the tab's reserved trailing padding, so revealing it on hover never reflows the strip, and it stays in the a11y tree (opacity, not `display: none`) so it is keyboard-reachable.

`OnCloseTabRequested` falls back to a plain `RemoveTab` when the key matches no live channel — a review-mode board tab or a stale placeholder has no plugin behind it, and a close control that visibly does nothing is worse than removing a tab that owns no resources.

## Scope note

**Releasing the server-side browser on a per-channel close is not covered here.** The server-side `RemoteBrowserChannel` ends the browser on *session* close (`OnSessionClosed` / `Dispose`), and there is no mutation meaning "this one channel is going away". That needs a server change; it is outside this PR's blast radius and I will file it separately rather than bolt a resolver onto a UI change.

## Tests

**1087 pass** (was 1080): 3 new model cases for `Closable` (default true for channels, never for Activity, honoured through a re-registration upgrade) and a new 4-case DOM spec for the affordance — the control renders for a closable channel and not for an un-closable one, pressing it asks the host and does **not** remove the tab itself, and dismissing does not focus the surface being dismissed.

Mutation-verified:

| mutant | result |
|---|---|
| `Closable` ignores the host's `false` | 3 fail |
| the component removes the tab itself instead of asking the host | 1 fail |
| nest the close button inside the tab button | 1 fail |

The third one replaced a mutant that **survived**: I had written `event.stopPropagation()` with a comment claiming the control sits inside the tab's hit area. It does not — it is a sibling, so the click never reaches the tab's handler. The guard was dead code justified by a false comment, so it is gone, and the test now pins the structural choice that actually provides the guarantee.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---

## Part 1 of 3 — MJ core, proven through Caliber

This PR is part of the MJ-core half of the realtime-workspace / multi-party work. It is
**not to be merged as part of the Caliber push** — it stands on its own tests and is
consumed downstream by the Caliber PR listed below.

Downstream Caliber PRs that need this: **MemberJunction/bizapps-caliber#157** — the realtime
workspace. It currently runs against a local `node_modules` patch of MJ and stays in draft
until this set lands and releases.
