### PR TITLE
feat(realtime): side-by-side surfaces via [SplitKeys], not a stylesheet fight (#3535)

### DIFF
--- a/.changeset/realtime-surface-split-layout.md
+++ b/.changeset/realtime-surface-split-layout.md
@@ -1,0 +1,33 @@
+---
+"@memberjunction/ng-conversations": minor
+---
+
+Realtime surface panel: show surfaces side by side, through the component's own API (#3535)
+
+`RealtimeSurfaceTabsComponent` showed exactly one pane at a time, and arranging two from outside
+could not be done honestly. MJ emits `.surface { display: flex }` at specificity (0,2,0) with
+Angular's attribute scoping; a host writing `.surface.my-split { display: grid }` is **also** (0,2,0);
+ties break on document order, and component styles are injected when the component first renders —
+after a host stylesheet added at startup. So MJ won, and the failure was invisible:
+`grid-template-columns` computed correctly and was silently ignored on a flex container. The
+workaround was doubling the class (`.surface.my-split.my-split`), which works and which nobody should
+have to know.
+
+`[SplitKeys]` names the tab keys to show side by side, in the order the panes should read.
+`null`/`[]` is the ordinary tabbed panel, which is the default and what every existing host gets.
+
+**One input rather than a `Layout` mode plus a key list**, deliberately: two inputs make "split with
+no keys" expressible, and that state has no good answer — an empty panel or a silent downgrade, both
+surprises. "Split these" is the whole instruction, so the invalid combination does not exist.
+`Layout` is a read-only `'tabs' | 'split'` derived from it, and it reports `'tabs'` when fewer than
+two named surfaces are actually present, so naming a channel before it exists is safe.
+
+Host order is honoured through CSS `order`, not by reordering the DOM — moving pane elements would
+tear down and recreate the dynamically-created channel surfaces inside them, blanking a live browser
+canvas because someone wanted it on the left. A focused tab outside the arrangement stays hidden, so
+choosing a third surface cannot drop an extra pane into a two-column grid, and the focused pane keeps
+an accent so "which one am I acting on" stays answerable.
+
+Also addresses the issue's secondary ask: every pane now carries `data-channel` and `data-tab-kind`,
+so a host pairs a pane with its channel by identity instead of by index — which only ever worked
+because both lists render from the same array in the same order.

--- a/packages/Angular/Generic/conversations/node_modules
+++ b/packages/Angular/Generic/conversations/node_modules
@@ -1,0 +1,1 @@
+/Users/madhav/Projects/MJ/packages/Angular/Generic/conversations/node_modules

--- a/packages/Angular/Generic/conversations/src/lib/components/realtime/realtime-surface-tabs-split.dom.test.ts
+++ b/packages/Angular/Generic/conversations/src/lib/components/realtime/realtime-surface-tabs-split.dom.test.ts
@@ -1,0 +1,125 @@
+import { describe, it, expect } from 'vitest';
+import { renderComponentFixture, query, queryAll } from '@memberjunction/ng-test-utils';
+import { RealtimeSurfaceTabsComponent } from './realtime-surface-tabs.component';
+import { RealtimeSessionState } from './realtime-session-state';
+
+/**
+ * DOM spec for the side-by-side surface layout (#3535).
+ *
+ * The panel showed exactly one pane at a time, and arranging two from OUTSIDE could not be done
+ * honestly: MJ's `.surface { display: flex }` and a host's `.surface.my-split { display: grid }`
+ * are both specificity (0,2,0), ties break on document order, and component styles are injected
+ * after a startup stylesheet — so MJ won and `grid-template-columns` was silently ignored on a flex
+ * container. These pin the component's own answer, so no host has to discover that.
+ */
+describe('RealtimeSurfaceTabsComponent — side-by-side surfaces (DOM)', () => {
+  const render = () =>
+    renderComponentFixture(RealtimeSurfaceTabsComponent, {
+      inputs: { State: new RealtimeSessionState() },
+    });
+
+  /** `RegisterChannelTab` defers to a microtask (the component's NG0100 guard). */
+  const flush = async (f: { detectChanges(): void }) => {
+    await Promise.resolve();
+    f.detectChanges();
+  };
+
+  /**
+   * Sets the input the way a host template does — through the input machinery, which marks this
+   * OnPush component dirty. Assigning the field directly does not, and the panel would keep
+   * rendering the previous arrangement.
+   */
+  const setSplit = (f: { componentRef: { setInput(name: string, value: unknown): void }; detectChanges(): void }, keys: string[] | null) => {
+    f.componentRef.setInput('SplitKeys', keys);
+    f.detectChanges();
+  };
+
+  const withTabs = async (keys: string[]) => {
+    const f = render();
+    for (const key of keys) {
+      f.componentInstance.RegisterChannelTab({ Key: key, Title: key, Icon: 'fa-solid fa-globe' });
+    }
+    await flush(f);
+    return f;
+  };
+
+  it('stays tabbed by default — one pane displayed, no split marker', async () => {
+    const f = await withTabs(['Left', 'Right']);
+
+    expect(f.componentInstance.Layout).toBe('tabs');
+    expect(query(f, '.surface')?.classList.contains('surface--split')).toBe(false);
+    expect(queryAll(f, '.s-pane--split')).toHaveLength(0);
+  });
+
+  it('shows the named surfaces side by side', async () => {
+    const f = await withTabs(['Left', 'Right']);
+    setSplit(f, ['Left', 'Right']);
+
+    expect(f.componentInstance.Layout).toBe('split');
+    // Two things, both required: `surface--split` is what the stylesheet keys the grid off, and
+    // `data-layout` is the stable attribute a host reads. Asserting only the second would let the
+    // grid silently stop applying.
+    expect(query(f, '.surface')?.classList.contains('surface--split')).toBe(true);
+    expect(query(f, '.surface')?.getAttribute('data-layout')).toBe('split');
+    expect(queryAll(f, '.s-pane--split')).toHaveLength(2);
+    // The column count rides on the wrapper, so the grid matches the number of panes rather than
+    // assuming two.
+    expect(query(f, '.s-panes')?.getAttribute('style')).toContain('--surface-split-count: 2');
+  });
+
+  it('honours the host ORDER without moving the pane elements', async () => {
+    // Panes render in registration order; a host asking for the reverse gets it via CSS `order`.
+    // Moving the DOM instead would tear down and recreate the dynamic channel surfaces inside —
+    // a live browser canvas would go blank because someone wanted it on the left.
+    const f = await withTabs(['Left', 'Right']);
+    setSplit(f, ['Right', 'Left']);
+
+    const panes = queryAll(f, '.s-pane');
+    expect(panes.map(p => p.getAttribute('data-channel'))).toEqual(['Left', 'Right']);
+    expect((panes[0] as HTMLElement).style.order).toBe('1');
+    expect((panes[1] as HTMLElement).style.order).toBe('0');
+  });
+
+  it('ignores keys for surfaces that do not exist yet', async () => {
+    // A host names its arrangement up front; the channels arrive as the session gets going.
+    const f = await withTabs(['Left']);
+    setSplit(f, ['Left', 'NotHereYet']);
+
+    expect(f.componentInstance.SplitTabKeys).toEqual(['Left']);
+    // One present surface is not a split — falling back to tabs beats a one-column "grid".
+    expect(f.componentInstance.Layout).toBe('tabs');
+  });
+
+  it('hides a focused surface that is not part of the arrangement', async () => {
+    // Otherwise choosing a third tab would silently drop an extra pane into a two-column grid.
+    const f = await withTabs(['Left', 'Right', 'Other']);
+    f.componentInstance.Model.Focus('Other');
+    setSplit(f, ['Left', 'Right']);
+
+    const other = queryAll(f, '.s-pane').find(p => p.getAttribute('data-channel') === 'Other');
+    expect(other?.classList.contains('s-pane--split')).toBe(false);
+    expect(other?.classList.contains('s-pane--active')).toBe(true);   // still the focused TAB…
+    expect(queryAll(f, '.s-pane--split')).toHaveLength(2);            // …but not a shown PANE
+  });
+
+  it('gives every pane its own identity so a host never matches by index', async () => {
+    // Before this, panes were bare `.s-pane` elements and a host had to pair them with tabs by
+    // position — which only worked because both lists render from the same array.
+    const f = await withTabs(['Left', 'Right']);
+    f.componentInstance.ShowActivityTab = true;
+    await flush(f);
+
+    const panes = queryAll(f, '.s-pane');
+    expect(panes.map(p => p.getAttribute('data-channel'))).toEqual(['Left', 'Right', 'activity']);
+    expect(panes.map(p => p.getAttribute('data-tab-kind'))).toEqual(['channel', 'channel', 'activity']);
+  });
+
+  it('treats null and an empty list as the ordinary tabbed panel', async () => {
+    const f = await withTabs(['Left', 'Right']);
+    setSplit(f, []);
+    expect(f.componentInstance.Layout).toBe('tabs');
+
+    setSplit(f, null);
+    expect(f.componentInstance.Layout).toBe('tabs');
+  });
+});

--- a/packages/Angular/Generic/conversations/src/lib/components/realtime/realtime-surface-tabs.component.css
+++ b/packages/Angular/Generic/conversations/src/lib/components/realtime/realtime-surface-tabs.component.css
@@ -204,6 +204,23 @@
 }
 
 /* ---------- panes: all alive, only the active one displayed ---------- */
+/* The pane region. In tabbed mode it is a plain column holding the one visible pane; in split mode
+   it becomes the grid, which is why it exists at all — the panel itself is a flex COLUMN carrying
+   the tab strip, so panes cannot be laid out in a row at that level. */
+.s-panes {
+  flex: 1;
+  min-height: 0;
+  display: flex;
+  flex-direction: column;
+}
+.surface--split .s-panes {
+  display: grid;
+  grid-template-columns: repeat(var(--surface-split-count, 2), minmax(0, 1fr));
+  grid-auto-rows: minmax(0, 1fr);
+  gap: 1px;
+  background: var(--mj-border-default);   /* the gap reads as a divider between surfaces */
+}
+
 .s-pane {
   display: none;
   flex: 1;
@@ -215,6 +232,23 @@
 }
 .s-pane--active {
   display: flex;
+}
+/* A split pane shows whether or not it is the focused one — that is the whole point of the mode.
+   `min-width: 0` keeps a wide surface (a browser canvas) from forcing its column past its share. */
+.surface--split .s-pane--split {
+  display: flex;
+  min-width: 0;
+  background: var(--mj-bg-surface);
+}
+/* …and a pane NOT in the split stays hidden even when it is the focused tab, so choosing a tab
+   outside the arrangement cannot silently drop a third surface into a two-column grid. */
+.surface--split .s-pane:not(.s-pane--split) {
+  display: none;
+}
+/* The focused surface stays identifiable inside the split — the tab strip still drives focus, and
+   an unmarked grid would make "which one am I acting on" unanswerable. */
+.surface--split .s-pane--split.s-pane--active {
+  box-shadow: inset 0 2px 0 0 var(--tab-accent);
 }
 
 /* Empty strip (idle voice-first session): a gentle hint rather than a bare grid. */

--- a/packages/Angular/Generic/conversations/src/lib/components/realtime/realtime-surface-tabs.component.html
+++ b/packages/Angular/Generic/conversations/src/lib/components/realtime/realtime-surface-tabs.component.html
@@ -1,8 +1,14 @@
 <!-- SIZING IS EXTERNAL: the overlay hosts this panel inside a fixed-width flex item and
      owns its width (drag, persistence, default tiers) — the panel just fills it. -->
+<!-- `data-layout` and `data-channel` are the HOST-facing contract (#3535): stable hooks for reading
+     or styling around the arrangement without reaching for internal class names, and for pairing a
+     pane with its channel instead of matching by index. `data-layout` is bound from the same
+     expression as `surface--split`, so the attribute and the class cannot disagree. -->
 <aside class="surface"
        [class.surface--collapsed]="Collapsed"
        [class.surface--fill]="Fill && !Collapsed"
+       [class.surface--split]="Layout === 'split'"
+       [attr.data-layout]="Layout"
        aria-label="Session surfaces">
 
   @if (Collapsed) {
@@ -57,9 +63,19 @@
       </div>
     </div>
 
-    <!-- Panes: ALL kept alive; only the active one is displayed -->
+    <!-- Panes: ALL kept alive; the active one is displayed — or several, side by side, when the
+         host named them in [SplitKeys]. The wrapper is what becomes the split grid: the panel
+         itself is a flex COLUMN holding the tab strip, so laying panes out in a row has to happen
+         one level in. -->
+    <div class="s-panes" [style.--surface-split-count]="SplitTabKeys.length">
     @for (tab of Model.Tabs; track TrackTab($index, tab)) {
-      <div class="s-pane" [class.s-pane--active]="tab.Key === Model.ActiveKey" role="tabpanel">
+      <div class="s-pane"
+           [class.s-pane--active]="tab.Key === Model.ActiveKey"
+           [class.s-pane--split]="IsSplitPane(tab.Key)"
+           [style.order]="SplitOrder(tab.Key)"
+           [attr.data-channel]="tab.Key"
+           [attr.data-tab-kind]="tab.Kind"
+           role="tabpanel">
         @switch (tab.Kind) {
           @case ('activity') {
             <mj-realtime-activity-rail
@@ -99,6 +115,7 @@
         }
       </div>
     }
+    </div>
 
     @if (Model.Tabs.length === 0) {
       <!-- Nothing in play yet (idle voice-first session): a gentle hint, not an empty grid -->

--- a/packages/Angular/Generic/conversations/src/lib/components/realtime/realtime-surface-tabs.component.ts
+++ b/packages/Angular/Generic/conversations/src/lib/components/realtime/realtime-surface-tabs.component.ts
@@ -12,7 +12,7 @@ import { RealtimeChannelPaneComponent } from './channels/realtime-channel-pane.c
 import { ChannelOnboardingPanelComponent } from './channels/channel-onboarding-panel.component';
 import { ChannelOnboardingDetails } from './channels/base-realtime-channel-client';
 import {
-  RealtimeSurfaceTabsModel, RealtimeSurfaceTab, RealtimeChannelTabRegistration
+  RealtimeSurfaceTabsModel, RealtimeSurfaceTab, RealtimeChannelTabRegistration, RealtimeSurfacePanelLayout
 } from './realtime-surface-tabs.model';
 import { ParsedDelegationArtifact } from '../../services/delegation-result-parser';
 
@@ -105,6 +105,32 @@ export class RealtimeSurfaceTabsComponent implements OnInit, OnDestroy {
   get ShowActivityTab(): boolean {
     return this._showActivityTab;
   }
+
+  /**
+   * Show these surfaces SIDE BY SIDE instead of one at a time (#3535).
+   *
+   * Names tab keys, in the order the panes should read left-to-right; unknown keys are ignored, so a
+   * host can name a channel before it exists. `null` or an empty list is the ordinary tabbed panel,
+   * which is the default and what every existing host gets.
+   *
+   * **Why one input rather than a `Layout: 'tabs' | 'split'` flag plus a key list.** Two inputs make
+   * "split with no keys" expressible, and that state has no good answer — a split of nothing is
+   * either an empty panel or a silent downgrade to tabs, and both are surprises. "Split these" is
+   * the entire instruction, so the invalid combination simply does not exist. {@link Layout} reads
+   * the resulting mode for a host that wants it.
+   *
+   * This exists because arranging surfaces from OUTSIDE the component could not be done honestly.
+   * MJ emits `.surface { display: flex }` at specificity (0,2,0) with Angular's attribute scoping,
+   * a host's `.surface.my-split { display: grid }` is also (0,2,0), and ties break on document
+   * order — component styles are injected when the component first renders, AFTER a host stylesheet
+   * added at startup. So MJ wins and the failure is invisible: `grid-template-columns` computes
+   * correctly and is silently ignored on a flex container. Nobody should have to know that, or
+   * discover the `.surface.my-split.my-split` double-class workaround.
+   *
+   * Bind a NEW array to change the arrangement — this component is OnPush, so mutating the bound
+   * array in place is not seen.
+   */
+  @Input() SplitKeys: string[] | null = null;
 
   /** Re-emitted from the Activity rail's dev "Open run" links. */
   @Output() OpenRunRequested = new EventEmitter<string>();
@@ -260,6 +286,47 @@ export class RealtimeSurfaceTabsComponent implements OnInit, OnDestroy {
    *
    * @returns `true` when a tab was removed.
    */
+  /**
+   * The keys actually shown side by side: {@link SplitKeys} narrowed to tabs that exist, in the
+   * order the host asked for. Empty when the panel is in ordinary tabbed mode.
+   *
+   * Recomputed per change-detection pass rather than cached — the tab set changes as channels come
+   * into play, and a cache would show yesterday's panes.
+   */
+  public get SplitTabKeys(): string[] {
+    if (!this.SplitKeys?.length) {
+      return [];
+    }
+    const present = new Set(this.Model.Tabs.map(t => t.Key));
+    return this.SplitKeys.filter(key => present.has(key));
+  }
+
+  /** `'split'` when at least two named surfaces are actually present, else `'tabs'`. */
+  public get Layout(): RealtimeSurfacePanelLayout {
+    return this.SplitTabKeys.length >= 2 ? 'split' : 'tabs';
+  }
+
+  /** Whether this tab's pane is one of the side-by-side panes right now. */
+  public IsSplitPane(key: string): boolean {
+    return this.Layout === 'split' && this.SplitTabKeys.includes(key);
+  }
+
+  /**
+   * The pane's visual position in the split, so the host's ORDER is honoured without reordering the
+   * DOM. Panes render in tab-registration order; a host asking for `['Right', 'Left']` gets them
+   * that way via CSS `order`, and the pane elements stay put — moving them would tear down and
+   * recreate the dynamically-created channel surfaces inside, losing a live browser's canvas.
+   *
+   * `null` outside a split, so the property is not written at all in ordinary tabbed mode.
+   */
+  public SplitOrder(key: string): number | null {
+    if (this.Layout !== 'split') {
+      return null;
+    }
+    const index = this.SplitTabKeys.indexOf(key);
+    return index >= 0 ? index : null;
+  }
+
   public RemoveTab(key: string): boolean {
     const removed = this.Model.RemoveTab(key);
     if (removed) {

--- a/packages/Angular/Generic/conversations/src/lib/components/realtime/realtime-surface-tabs.model.ts
+++ b/packages/Angular/Generic/conversations/src/lib/components/realtime/realtime-surface-tabs.model.ts
@@ -22,6 +22,16 @@ import { ChannelTabColor } from './realtime-surface-tab-style';
 export type RealtimeSurfaceTabKind = 'activity' | 'channel';
 
 /**
+ * How the surface panel arranges its panes (#3535).
+ *
+ * `'tabs'` shows one at a time — the default and the only mode before a host could ask for more.
+ * `'split'` shows several side by side, which is what a comparison wants (two browsers, a board
+ * beside a browser). DERIVED from `RealtimeSurfaceTabsComponent.SplitKeys` rather than set: a mode
+ * and a key list as separate inputs would let a host express "split with nothing in it".
+ */
+export type RealtimeSurfacePanelLayout = 'tabs' | 'split';
+
+/**
  * Per-kind payload carried on a {@link RealtimeSurfaceTab}.
  */
 export interface RealtimeSurfaceTabData {


### PR DESCRIPTION
Fixes #3535.

## The defect

`RealtimeSurfaceTabsComponent` shows exactly one pane at a time, and there is no way for a host to say "show these two together". Arranging them from outside runs into a trap that fails **silently**:

- MJ emits `.surface { display: flex }` with Angular's attribute scoping → specificity **(0,2,0)**
- a host writing `.surface.my-split { display: grid; grid-template-columns: 1fr 1fr }` is **also (0,2,0)**
- ties break on document order, and component styles are injected when the component first renders — *after* a host stylesheet added at startup

So MJ wins, and nothing reports it: `grid-template-columns` computes correctly and is simply ignored on a flex container. Everything looks applied; the panes just stack. The issue records two debugging sessions lost to this — once with a CSS grid, once with Golden Layout, where the host element ended up 0px tall and GL laid its entire tree into nothing while reporting no error. The workaround, doubling the class (`.surface.my-split.my-split`), works — and nobody should have to know it.

## The fix

```html
<mj-realtime-surface-tabs [SplitKeys]="['Left Browser', 'Right Browser']">
```

`[SplitKeys]` names the tab keys to show side by side, in the order the panes should read. `null` or `[]` is the ordinary tabbed panel — the default, and what every existing host gets.

### One input, not a mode plus a list

The issue suggested `Layout: 'tabs' | 'split'` **plus** the key set. I went with the single input, because two make **"split with no keys"** expressible and that state has no good answer — an empty panel or a silent downgrade to tabs, both surprises. "Split these" is the entire instruction, so the invalid combination does not exist. `Layout` survives as a read-only `'tabs' | 'split'` derived from it, reporting `'tabs'` when fewer than two named surfaces are actually present — so a host can name its arrangement up front and have channels arrive as the session gets going.

### Three decisions inside the mode

**Order via CSS `order`, not by reordering the DOM.** Panes render in registration order; a host asking for the reverse gets it visually while the elements stay put. Moving them would tear down and recreate the dynamically-created channel surfaces inside — a live browser canvas would go blank because someone wanted it on the left.

**A focused tab outside the arrangement stays hidden.** Otherwise selecting a third tab would silently drop an extra pane into a two-column grid.

**The focused pane keeps an accent inside the split.** The tab strip still drives focus, and an unmarked grid makes "which one am I acting on" unanswerable.

The panes needed a wrapper (`.s-panes`) to become the grid: the panel itself is a flex **column** carrying the tab strip, so panes cannot be laid out in a row at that level. That wrapper is the piece a host could never add from outside.

### The secondary ask

Every pane now carries `data-channel` and `data-tab-kind`. Before, panes were bare `.s-pane` elements and a host had to pair them with tabs **by index** — which worked only because both lists render from the same array in the same order, an implementation detail nobody should be resting on. `data-layout` on the container is the matching host-facing hook for the mode itself, bound from the same expression as the internal `surface--split` class so the two cannot disagree.

## Tests

A new 7-case DOM spec: tabbed by default, the named surfaces render side by side with the column count matching, host order is honoured without moving elements, absent keys are ignored (and one present surface is not a "split"), a focused non-member pane stays hidden, every pane carries its identity, and `null`/`[]` both mean tabs.

**1087 tests pass** (was 1080).

Mutation-verified — six mutants, all killed:

| mutant | result |
|---|---|
| split on a single present key | 1 fail |
| stop filtering keys for surfaces that do not exist | 1 fail |
| drop pane ordering (registration order wins) | 1 fail |
| drop `data-channel` | 3 fail |
| drop the `surface--split` container class | 1 fail |
| drop `data-layout` | 1 fail |

The `surface--split` mutant **survived the first round**: my test asserted `data-layout` and the pane classes but not the container class the stylesheet actually keys the grid off, so the grid could have stopped applying with every assertion still green. Both are now asserted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---

## Part 1 of 3 — MJ core, proven through Caliber

This PR is part of the MJ-core half of the realtime-workspace / multi-party work. It is
**not to be merged as part of the Caliber push** — it stands on its own tests and is
consumed downstream by the Caliber PR listed below.

Downstream Caliber PRs that need this: **MemberJunction/bizapps-caliber#157** — the realtime
workspace. It currently runs against a local `node_modules` patch of MJ and stays in draft
until this set lands and releases.
