### PR TITLE
feat(realtime): give the agent a live roster of its own surfaces (#3497)

### DIFF
--- a/.changeset/realtime-live-channel-roster.md
+++ b/.changeset/realtime-live-channel-roster.md
@@ -1,0 +1,32 @@
+---
+"@memberjunction/ng-conversations": minor
+---
+
+Realtime: the agent can finally see its own surfaces (#3497)
+
+The agent could not answer questions about its own channels — how many are open, which ones, or what
+each holds. At connect the model is told its **tool vocabulary** and nothing else, so it inferred
+capability from the tools it was given ("I have `browser_*`, so there must be a browser") and then
+answered from that inference, confidently. With one surface the guess is usually right; with three,
+"let me check the board" versus "let me check the browser" is a coin flip.
+
+The state existed all along — every plugin has `SerializeState()`, already persisted for resume.
+Nothing composed it into something a model could read, and nothing told the model when the set
+changed. Same root cause as #3496: state lives on the client, and the model is only ever told about
+the parts it caused itself.
+
+`RealtimeSessionService.ChannelRoster` / `DescribeChannelRoster()` compose the live set — name, tab
+title, whether the channel has a visible surface, which one owns the screen, and a short
+channel-supplied summary. The roster is pushed to the model at connect and whenever that answer
+changes, deduped on the composed line.
+
+**Pushed rather than offered as a read tool, deliberately.** The failure being fixed is a model that
+does not know it should ask; a tool it never calls leaves the guess in place. The public getter is
+there so a host — or a session-level tool once #3536 lands — can take the same read on demand.
+
+New optional `BaseRealtimeChannelClient.DescribeState(): string | null`. It is **not**
+`SerializeState` in prose: that payload is a machine format written for a future instance of the same
+channel, while this is written for a model about to speak. Both shipped channels implement it — the
+whiteboard reports what is on the board, the Remote Browser reports which page it is showing, which
+is the part the agent could not infer from having the tools. A channel that throws while describing
+itself is omitted rather than taking the roster down with it.

--- a/packages/Angular/Generic/conversations/node_modules
+++ b/packages/Angular/Generic/conversations/node_modules
@@ -1,0 +1,1 @@
+/Users/madhav/Projects/MJ/packages/Angular/Generic/conversations/node_modules

--- a/packages/Angular/Generic/conversations/src/__tests__/realtime-channel-roster.test.ts
+++ b/packages/Angular/Generic/conversations/src/__tests__/realtime-channel-roster.test.ts
@@ -1,0 +1,85 @@
+import { describe, it, expect } from 'vitest';
+import {
+  DescribeChannelRoster, RealtimeChannelRosterEntry,
+} from '../lib/components/realtime/realtime-channel-roster';
+
+/**
+ * #3497 — the agent has no live channel roster.
+ *
+ * At connect the model is told its TOOL VOCABULARY and nothing else, so it infers surfaces from
+ * tools ("I have `browser_*`, so there must be a browser") and answers questions about its own
+ * screen by guessing. These pin the wording the roster uses, because the wording IS the fix: a line
+ * the model misreads is no better than the guess it replaces.
+ */
+const entry = (over: Partial<RealtimeChannelRosterEntry> = {}): RealtimeChannelRosterEntry => ({
+  ChannelName: 'Whiteboard',
+  TabTitle: 'Whiteboard',
+  HasSurface: true,
+  Focused: false,
+  State: null,
+  ...over,
+});
+
+describe('DescribeChannelRoster', () => {
+  it('says explicitly that nothing is open', () => {
+    // Silence is what the model already had, and silence is what it filled in with a guess.
+    const note = DescribeChannelRoster([]);
+    expect(note).toContain('[surfaces]');
+    expect(note).toContain('none open');
+  });
+
+  it('names every open surface and counts them', () => {
+    const note = DescribeChannelRoster([
+      entry({ ChannelName: 'Whiteboard', TabTitle: 'Whiteboard' }),
+      entry({ ChannelName: 'Remote Browser', TabTitle: 'Remote Browser' }),
+    ]);
+    expect(note).toContain('2 surfaces open');
+    expect(note).toContain('Whiteboard');
+    expect(note).toContain('Remote Browser');
+  });
+
+  it('counts one surface in the singular', () => {
+    expect(DescribeChannelRoster([entry()])).toContain('1 surface open');
+  });
+
+  it('carries each channel\'s own summary — the part the agent cannot infer', () => {
+    // "A browser is open" is derivable from having browser tools. WHICH page is open is not.
+    const note = DescribeChannelRoster([
+      entry({ ChannelName: 'Remote Browser', TabTitle: 'Remote Browser', State: 'showing https://careers.acme.com' }),
+    ]);
+    expect(note).toContain('(showing https://careers.acme.com)');
+  });
+
+  it('omits a summary the channel declined to give, rather than saying "null"', () => {
+    const note = DescribeChannelRoster([entry({ State: null }), entry({ ChannelName: 'Notes', TabTitle: 'Notes', State: '   ' })]);
+    expect(note).not.toContain('null');
+    expect(note).not.toContain('()');
+  });
+
+  it('marks which surface owns the screen', () => {
+    const note = DescribeChannelRoster([
+      entry({ ChannelName: 'Whiteboard', TabTitle: 'Whiteboard', Focused: true }),
+      entry({ ChannelName: 'Remote Browser', TabTitle: 'Remote Browser' }),
+    ]);
+    expect(note).toContain('Whiteboard — focused');
+    expect(note).not.toContain('Remote Browser — focused');
+  });
+
+  it('flags a channel that is wired but has nothing on screen', () => {
+    // The agent HAS this channel's tools, so hiding it would recreate the guessing problem one
+    // level down — it would act on a surface that does not exist.
+    const note = DescribeChannelRoster([entry({ ChannelName: 'Client Context', TabTitle: 'Client Context', HasSurface: false })]);
+    expect(note).toContain('Client Context — no visible surface');
+  });
+
+  it('never calls a surface-less channel focused', () => {
+    const note = DescribeChannelRoster([entry({ HasSurface: false, Focused: true })]);
+    expect(note).toContain('no visible surface');
+    expect(note).not.toContain('focused');
+  });
+
+  it('falls back to the channel name when the tab has no title', () => {
+    const note = DescribeChannelRoster([entry({ ChannelName: 'Remote Browser', TabTitle: '  ' })]);
+    expect(note).toContain('Remote Browser');
+  });
+});

--- a/packages/Angular/Generic/conversations/src/__tests__/realtime-session-channels.test.ts
+++ b/packages/Angular/Generic/conversations/src/__tests__/realtime-session-channels.test.ts
@@ -331,3 +331,137 @@ describe('RealtimeSessionService — debounced channel saves + teardown flush/di
     expect(error).toHaveBeenCalledWith(expect.stringContaining("Channel 'Echo' Dispose failed"), expect.any(Error));
   });
 });
+
+// ──────────────────────────────────────────────────────────────────────────────
+// #3497 — the live surface roster.
+//
+// The model is told its tool vocabulary at connect and nothing else, so it infers surfaces from
+// tools and answers questions about its own screen by guessing. These drive the real service:
+// composing the roster from live plugins, and pushing it only when the answer changes.
+// ──────────────────────────────────────────────────────────────────────────────
+
+/** A channel that describes itself, and one that refuses to. */
+@RegisterClass(BaseRealtimeChannelClient, 'TestDescribingChannel')
+class TestDescribingChannel extends TestEchoChannel {
+  public Summary: string | null = 'showing https://example.com';
+  public ThrowOnDescribe = false;
+  public override get ChannelName(): string { return 'Describer'; }
+  public override get ToolNamePrefix(): string { return 'Describer.'; }
+  public override get TabTitle(): string { return 'Describer'; }
+  public override DescribeState(): string | null {
+    if (this.ThrowOnDescribe) {
+      throw new Error('describe boom');
+    }
+    return this.Summary;
+  }
+}
+
+/** Reaches the private members the roster tests drive. */
+interface RosterInternals {
+  announceChannelRoster(): void;
+  focusedChannelName: string | null;
+  startChannels(): Promise<RealtimeToolDefinition[]>;
+}
+
+describe('RealtimeSessionService — the live surface roster (#3497)', () => {
+  let service: RealtimeSessionService;
+  let notes: string[];
+
+  beforeEach(() => {
+    service = new RealtimeSessionService();
+    notes = [];
+    vi.spyOn(service, 'SendContextNote').mockImplementation((text: string) => { notes.push(text); });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  const roster = (s: RealtimeSessionService) => s as unknown as RosterInternals;
+
+  it('composes the roster from the LIVE plugins, not from the registry', async () => {
+    mockChannelRegistry([
+      { ID: '1', Name: 'Echo', ClientPluginClass: 'TestEchoChannel' },
+      { ID: '2', Name: 'Describer', ClientPluginClass: 'TestDescribingChannel' },
+    ]);
+    await roster(service).startChannels();
+
+    // The registry lists what a deployment CONFIGURED; the roster must report what actually
+    // resolved, because a row whose plugin class is missing is exactly the surface the agent
+    // would otherwise believe it has.
+    expect(service.ChannelRoster.map(e => e.ChannelName)).toEqual(['Echo', 'Describer']);
+    expect(service.ChannelRoster.find(e => e.ChannelName === 'Describer')?.State)
+      .toBe('showing https://example.com');
+  });
+
+  it('leaves a channel out of the roster when its plugin never resolved', async () => {
+    mockChannelRegistry([
+      { ID: '1', Name: 'Echo', ClientPluginClass: 'TestEchoChannel' },
+      { ID: '2', Name: 'Ghost', ClientPluginClass: 'NoSuchPluginClass' },
+    ]);
+    await roster(service).startChannels();
+
+    expect(service.ChannelRoster.map(e => e.ChannelName)).toEqual(['Echo']);
+    expect(service.DescribeChannelRoster()).not.toContain('Ghost');
+  });
+
+  it('survives a channel that throws while describing itself', async () => {
+    mockChannelRegistry([
+      { ID: '1', Name: 'Describer', ClientPluginClass: 'TestDescribingChannel' },
+      { ID: '2', Name: 'Echo', ClientPluginClass: 'TestEchoChannel' },
+    ]);
+    await roster(service).startChannels();
+    (service.ActiveChannels[0] as TestDescribingChannel).ThrowOnDescribe = true;
+
+    // One broken description must not put every OTHER surface back into the dark.
+    expect(() => service.DescribeChannelRoster()).not.toThrow();
+    expect(service.DescribeChannelRoster()).toContain('Echo');
+    expect(service.ChannelRoster[0].State).toBeNull();
+  });
+
+  it('announces the roster once, and stays quiet while it is unchanged', async () => {
+    mockChannelRegistry([{ ID: '1', Name: 'Echo', ClientPluginClass: 'TestEchoChannel' }]);
+    await roster(service).startChannels();
+
+    roster(service).announceChannelRoster();
+    roster(service).announceChannelRoster();
+    roster(service).announceChannelRoster();
+
+    expect(notes).toHaveLength(1);
+    expect(notes[0]).toContain('1 surface open');
+  });
+
+  it('announces again once the answer actually changes', async () => {
+    mockChannelRegistry([{ ID: '1', Name: 'Describer', ClientPluginClass: 'TestDescribingChannel' }]);
+    await roster(service).startChannels();
+    roster(service).announceChannelRoster();
+
+    (service.ActiveChannels[0] as TestDescribingChannel).Summary = 'showing https://example.com/jobs';
+    roster(service).announceChannelRoster();
+
+    expect(notes).toHaveLength(2);
+    expect(notes[1]).toContain('https://example.com/jobs');
+  });
+
+  it('tells the model when a channel takes over the screen', async () => {
+    mockChannelRegistry([
+      { ID: '1', Name: 'Echo', ClientPluginClass: 'TestEchoChannel' },
+      { ID: '2', Name: 'Describer', ClientPluginClass: 'TestDescribingChannel' },
+    ]);
+    await roster(service).startChannels();
+    const echo = service.ActiveChannels[0] as TestEchoChannel;
+
+    echo.Ctx?.SetFocusMode(true);
+
+    expect(notes.at(-1)).toContain('Echo — focused');
+    echo.Ctx?.SetFocusMode(false);
+    expect(notes.at(-1)).not.toContain('focused');
+  });
+
+  it('reports an empty session as having no surfaces, not as silence', async () => {
+    mockChannelRegistry([]);
+    await roster(service).startChannels();
+
+    expect(service.DescribeChannelRoster()).toContain('none open');
+  });
+});

--- a/packages/Angular/Generic/conversations/src/lib/components/realtime/channels/base-realtime-channel-client.ts
+++ b/packages/Angular/Generic/conversations/src/lib/components/realtime/channels/base-realtime-channel-client.ts
@@ -385,6 +385,25 @@ export abstract class BaseRealtimeChannelClient<TSurface extends object = object
   }
 
   /**
+   * ONE SHORT SENTENCE describing what this surface currently holds, for the model to read (#3497).
+   * `null` — the default — means the channel has nothing worth saying, and it is simply omitted from
+   * the roster rather than listed as empty.
+   *
+   * **Not `SerializeState` in prose.** That payload is for RESUME: it is a machine format, it can be
+   * large, and it is written for a future instance of this same channel. This is written for a
+   * language model that is about to speak, so it should read like a person describing their screen —
+   * `'showing https://careers.acme.com'`, `'12 shapes, last edit 30s ago'` — not a JSON dump. A
+   * channel that returns its serialized state here spends the session's context on syntax.
+   *
+   * Called when the roster is composed, so treat it as a cheap synchronous read of state the channel
+   * already has. Never throw: a channel that cannot describe itself is omitted, and a description is
+   * never worth breaking a session over.
+   */
+  public DescribeState(): string | null {
+    return null;
+  }
+
+  /**
    * Restores a PRIOR session's saved channel state (the payload a previous session
    * persisted via {@link SerializeState} / {@link RealtimeChannelContext.RequestSave}).
    * Invoked by the session host AFTER {@link Initialize} and BEFORE any surface binding,

--- a/packages/Angular/Generic/conversations/src/lib/components/realtime/realtime-channel-roster.ts
+++ b/packages/Angular/Generic/conversations/src/lib/components/realtime/realtime-channel-roster.ts
@@ -1,0 +1,76 @@
+/**
+ * The live CHANNEL ROSTER — what the agent is allowed to know about its own surfaces (#3497).
+ *
+ * At connect the model is told its TOOL VOCABULARY and nothing else. It is never told which channels
+ * actually opened, which failed to resolve a plugin, or what each currently holds. So it infers
+ * capability from the tools it was given — "I have `browser_*` tools, so there must be a browser" —
+ * and then answers questions about its surfaces by GUESSING, confidently. With one surface the guess
+ * is usually right; with three, "let me check the board" versus "let me check the browser" is a coin
+ * flip, and anything trying to coordinate across surfaces routes through a model that does not know
+ * what the surfaces are.
+ *
+ * The state existed all along: every plugin has `SerializeState()` and it is already persisted for
+ * resume. Nothing composed it into something a model could read. That is all this module does — it
+ * is deliberately framework-free (no Angular, no service) so the wording, the ordering and the empty
+ * cases are unit-testable in isolation, exactly like the surface-tab helpers next door.
+ */
+
+/** One live surface, as the model should hear about it. */
+export interface RealtimeChannelRosterEntry {
+  /** The channel's registry name — the same string its tools are prefixed from. */
+  ChannelName: string;
+  /** What the user sees on its tab, which is what they will call it out loud. */
+  TabTitle: string;
+  /**
+   * Whether the channel has a visible surface at all. A server-only channel is wired for tools and
+   * perception but has no pane, and telling the agent it is "open" would invite it to describe
+   * something nobody can see.
+   */
+  HasSurface: boolean;
+  /** Whether this surface currently owns the screen (channel focus mode). */
+  Focused: boolean;
+  /** The channel's own one-line summary, or `null` when it has nothing to say. */
+  State: string | null;
+}
+
+/** Prefix marking the roster note, matching the `[browser]`-style convention already in use. */
+const ROSTER_PREFIX = '[surfaces]';
+
+/**
+ * Renders the roster as one line for the model.
+ *
+ * Deliberately terse. This is pushed on every membership or focus change, so it is paid for
+ * repeatedly across a session — a paragraph per surface would cost more context than the confusion
+ * it removes. One line, most-useful facts first: how many, what they are called, what each holds.
+ *
+ * A channel with no surface is marked rather than omitted: the agent has that channel's TOOLS, so it
+ * needs to know the channel exists AND that there is nothing on screen for it. Omitting it would
+ * recreate the original guessing problem one level down.
+ */
+export function DescribeChannelRoster(entries: readonly RealtimeChannelRosterEntry[]): string {
+  if (entries.length === 0) {
+    // Said explicitly rather than skipped. "No surfaces are open" is exactly the fact an agent with
+    // browser tools and no browser gets wrong, and silence reads as "nobody told me" — which is how
+    // it started guessing in the first place.
+    return `${ROSTER_PREFIX} none open. You have no visible surface right now.`;
+  }
+  const described = entries.map(describeOne).join('; ');
+  const count = entries.length === 1 ? '1 surface open' : `${entries.length} surfaces open`;
+  return `${ROSTER_PREFIX} ${count}: ${described}`;
+}
+
+/** One entry: `Whiteboard (12 shapes) — focused`, `Notes — no visible surface`. */
+function describeOne(entry: RealtimeChannelRosterEntry): string {
+  const label = (entry.TabTitle ?? '').trim().length > 0 ? entry.TabTitle.trim() : entry.ChannelName;
+  const parts: string[] = [label];
+  const state = (entry.State ?? '').trim();
+  if (state.length > 0) {
+    parts.push(`(${state})`);
+  }
+  if (!entry.HasSurface) {
+    parts.push('— no visible surface');
+  } else if (entry.Focused) {
+    parts.push('— focused');
+  }
+  return parts.join(' ');
+}

--- a/packages/Angular/Generic/conversations/src/lib/components/realtime/remote-browser/remote-browser-channel.ts
+++ b/packages/Angular/Generic/conversations/src/lib/components/realtime/remote-browser/remote-browser-channel.ts
@@ -305,6 +305,12 @@ export class RemoteBrowserChannel extends BaseRealtimeChannelClient<RemoteBrowse
   private streaming = false;
 
   /**
+   * The page the browser was last known to be on, kept so the surface roster can say where this
+   * channel is pointing (#3497). Fed from the same results that tell the agent about a navigation.
+   */
+  private lastKnownUrl: string | null = null;
+
+  /**
    * Whether the server confirmed it is PUSHING tab-audio chunks for this session (the backend can capture
    * audio). When `true` {@link OnAudioChunk} feeds each pushed chunk to {@link audioPlayer}; when `false`
    * no audio plays.
@@ -627,8 +633,20 @@ export class RemoteBrowserChannel extends BaseRealtimeChannelClient<RemoteBrowse
       // In streaming mode the surface's snapshot poll (which carries the URL) is stopped, so push the new
       // URL to the live-view bar directly — otherwise it stays stuck on "No page loaded yet".
       this.surface?.SetCurrentUrl(result.CurrentUrl);
+      this.lastKnownUrl = result.CurrentUrl;
     }
     return this.ok(result.CurrentUrl, result.Detail);
+  }
+
+  /**
+   * Where this browser is pointing, for the surface roster (#3497).
+   *
+   * "A browser is open" is not the useful fact — the agent could already infer that from having
+   * `browser_*` tools, and inferring it is what made it guess. WHICH page is open is the part it
+   * could not know.
+   */
+  public override DescribeState(): string | null {
+    return this.lastKnownUrl ? `showing ${this.lastKnownUrl}` : 'no page loaded yet';
   }
 
   /** Builds the flat mutation variables from a normalized action (omitted fields ride as null). */
@@ -690,6 +708,7 @@ export class RemoteBrowserChannel extends BaseRealtimeChannelClient<RemoteBrowse
     if (result.CurrentUrl) {
       this.Context?.SendContextNote(`[browser] current page: ${result.CurrentUrl}`);
       this.surface?.SetCurrentUrl(result.CurrentUrl);
+      this.lastKnownUrl = result.CurrentUrl;
     }
     if (!result.Success) {
       return this.fail(result.Detail ?? `The goal could not be completed (${result.Status ?? 'unknown'}).`);

--- a/packages/Angular/Generic/conversations/src/lib/components/realtime/whiteboard/whiteboard-channel.ts
+++ b/packages/Angular/Generic/conversations/src/lib/components/realtime/whiteboard/whiteboard-channel.ts
@@ -262,6 +262,21 @@ export class RealtimeWhiteboardChannel extends BaseRealtimeChannelClient<Realtim
   }
 
   /**
+   * What is on the board right now, for the surface roster (#3497) — deliberately a count and not
+   * the scene. The model already receives coalesced scene deltas as it watches; the roster answers
+   * the different question "is there anything on the board at all", which is what it used to guess.
+   */
+  public override DescribeState(): string | null {
+    const items = this.State.Items.length;
+    const pages = this.State.Pages.length;
+    if (items === 0) {
+      return pages > 1 ? `empty, ${pages} pages` : 'empty';
+    }
+    const drawn = items === 1 ? '1 item' : `${items} items`;
+    return pages > 1 ? `${drawn} across ${pages} pages` : drawn;
+  }
+
+  /**
    * Rehydrates a prior session's saved board into THIS session's state engine (in place —
    * the {@link State} instance and its subscriptions are preserved). Returns `true` on
    * success; malformed / incompatible JSON returns `false` and the board stays fresh

--- a/packages/Angular/Generic/conversations/src/lib/services/realtime-session.service.ts
+++ b/packages/Angular/Generic/conversations/src/lib/services/realtime-session.service.ts
@@ -6,6 +6,7 @@ import { AIEngineBase } from '@memberjunction/ai-engine-base';
 import { GraphQLDataProvider } from '@memberjunction/graphql-dataprovider';
 import { MJGlobal } from '@memberjunction/global';
 import { ClientRealtimeSessionConfig, JSONObject, JSONValue, RealtimeToolDefinition } from '@memberjunction/ai';
+import { DescribeChannelRoster, RealtimeChannelRosterEntry } from '../components/realtime/realtime-channel-roster';
 import { AppContextSnapshot } from '@memberjunction/ai-core-plus';
 import {
   BaseRealtimeClient,
@@ -265,6 +266,16 @@ export class RealtimeSessionService {
   private _modelName$ = new BehaviorSubject<string | null>(null);
   private _minimized$ = new BehaviorSubject<boolean>(false);
   private _activeChannels$ = new BehaviorSubject<BaseRealtimeChannelClient[]>([]);
+
+  /** The channel currently owning the screen (channel focus mode), or `null` when none is (#3497). */
+  private focusedChannelName: string | null = null;
+
+  /**
+   * The last roster line the model was told, so an unchanged roster is not re-announced. Same
+   * discipline the page-change note uses: a fact repeated verbatim costs context and teaches the
+   * model nothing.
+   */
+  private lastRosterNote: string | null = null;
   private _channelFocus$ = new Subject<RealtimeChannelFocusEvent>();
   // ─── Generic session-lifecycle events (consumed by RealtimeSessionsAdapter to
   // bridge into @memberjunction/conversations-runtime's framework-agnostic
@@ -738,6 +749,11 @@ export class RealtimeSessionService {
         sessionId: this.agentSessionId,
         channelNames: this._activeChannels$.value.map(c => c.ChannelName),
       });
+
+      // Tell the model what surfaces it actually has (#3497). Here and not in startChannels():
+      // SendContextNote is a no-op until the session is live, and the moment the model most needs
+      // the roster is its FIRST — before it has answered anything from a guess.
+      this.announceChannelRoster();
     } catch (error) {
       console.error('[RealtimeSession] Failed to start session:', error);
       this._connectionState$.next('error');
@@ -1027,6 +1043,8 @@ export class RealtimeSessionService {
     }
     this._activeChannels$.next(channels);
     return channels.flatMap(plugin => plugin.GetToolDefinitions());
+    // NOTE: the roster is announced AFTER the session is live (see the mint path) — SendContextNote
+    // is a no-op before then, and the one moment the model most needs the roster is its first.
   }
 
   /**
@@ -1127,7 +1145,11 @@ export class RealtimeSessionService {
       RequestSpokenResponse: (instructions: string) => this.requestChannelSpokenResponse(instructions),
       RequestSave: (stateJson: string) => this.scheduleChannelSave(plugin.ChannelName, stateJson),
       SaveAsArtifact: (name: string, contentJson: string) => this.saveChannelArtifact(plugin.ChannelName, name, contentJson),
-      SetFocusMode: (on: boolean) => this._channelFocus$.next({ Channel: plugin, Focused: on }),
+      SetFocusMode: (on: boolean) => {
+        this.focusedChannelName = on ? plugin.ChannelName : null;
+        this._channelFocus$.next({ Channel: plugin, Focused: on });
+        this.announceChannelRoster();
+      },
       // Live session id + GraphQL escape hatch for SERVER-BACKED channels (e.g. Remote
       // Browser). `get` so a channel always reads the CURRENT id — it's null at Initialize
       // (the plugin is built before mintSession resolves) and set once the session is live.
@@ -1347,6 +1369,68 @@ export class RealtimeSessionService {
     }
   }
 
+  /**
+   * The live surface roster (#3497) — which channels are actually open, and what each holds.
+   *
+   * Public because the roster is a READ the host (and, once a session-level tool route exists, the
+   * agent itself) should be able to take at any moment. The pushed note below is a snapshot; a
+   * channel's contents keep changing after it is sent, and this is how you get the current answer
+   * rather than the last announced one.
+   */
+  public get ChannelRoster(): RealtimeChannelRosterEntry[] {
+    return this._activeChannels$.value.map(plugin => ({
+      ChannelName: plugin.ChannelName,
+      TabTitle: plugin.TabTitle,
+      HasSurface: plugin.HasSurface(),
+      Focused: plugin.ChannelName === this.focusedChannelName,
+      State: this.describeChannelSafely(plugin),
+    }));
+  }
+
+  /** The roster as the one line the model reads. See `DescribeChannelRoster` for the wording rules. */
+  public DescribeChannelRoster(): string {
+    return DescribeChannelRoster(this.ChannelRoster);
+  }
+
+  /**
+   * Asks a channel to describe itself, containing any failure.
+   *
+   * A channel that throws while describing itself must not take out the roster — the roster's whole
+   * job is to stop the model guessing, and one broken description would put every OTHER surface back
+   * into the dark.
+   */
+  private describeChannelSafely(plugin: BaseRealtimeChannelClient): string | null {
+    try {
+      return plugin.DescribeState();
+    } catch (error) {
+      console.warn(`[RealtimeSession] Channel '${plugin.ChannelName}' DescribeState threw — omitting its summary:`, error);
+      return null;
+    }
+  }
+
+  /**
+   * Tells the model what surfaces it has, when that answer CHANGES (#3497).
+   *
+   * Pushed rather than offered as a read tool, and that is the point: the failure being fixed is a
+   * model that does not know it should ask. It infers a browser exists from having `browser_*` tools
+   * and answers from that inference. A tool it never calls would leave the guess in place.
+   *
+   * Sent on membership and focus changes only — not on every stroke or navigation. Per-channel
+   * contents move constantly, and a note per change would drown the conversation; what the model
+   * could not previously work out at all is which surfaces EXIST.
+   *
+   * Silent when the composed line is unchanged, so a refresh triggered by something that did not
+   * actually alter the roster costs nothing.
+   */
+  private announceChannelRoster(): void {
+    const note = this.DescribeChannelRoster();
+    if (note === this.lastRosterNote) {
+      return;
+    }
+    this.lastRosterNote = note;
+    this.SendContextNote(note);
+  }
+
   /** Disposes all channel plugins (errors contained per plugin) and clears the live set. */
   private disposeChannels(): void {
     for (const plugin of this._activeChannels$.value) {
@@ -1360,6 +1444,8 @@ export class RealtimeSessionService {
       this._activeChannels$.next([]);
     }
     this.usedChannelNames.clear();
+    this.focusedChannelName = null;
+    this.lastRosterNote = null;
   }
 
   // ── Realtime client resolution + wiring ────────────────────────────────────


### PR DESCRIPTION
Fixes #3497.

## The defect

The agent cannot answer questions about its own surfaces: how many are open, which ones, or what each currently holds. At connect the model is told its **tool vocabulary** and nothing else. It is never told the **channel roster** — which channels actually opened, which failed to resolve a plugin, what state each holds. So it infers capability from the tools it was given ("I have `browser_*` tools, so there must be a browser") and answers from that inference, confidently.

The state existed all along. Every plugin has `SerializeState()`, and it is already persisted for resume. Nothing composed it into something a model could read, and nothing told the model when the set changed. Same root cause as #3496: state lives on the client, and the model is only ever told about the parts it caused itself.

It gets worse as channels multiply, which is the direction the channel system is built to go — with one surface the agent can assume; with three, "let me check the board" versus "let me check the browser" is a coin flip.

## The fix

`RealtimeSessionService` gains `ChannelRoster` (structured) and `DescribeChannelRoster()` (one line for the model), composed from the **live plugins**: name, tab title, whether the channel has a visible surface, which one owns the screen, and a short channel-supplied summary.

```
[surfaces] 2 surfaces open: Whiteboard (12 items) — focused; Remote Browser (showing https://careers.acme.com)
```

Pushed at connect and whenever that line changes.

### Pushed, not offered as a read tool

The issue allows either. Pushing is the right one here, because **the failure is a model that does not know it should ask** — it already believes it knows what surfaces it has. A read tool it never calls leaves the guess exactly where it was. The public getter exists so a host (or a session-level tool once #3536 lands) can take the same read on demand.

Refreshed on **membership and focus** changes only, not on every stroke or navigation: per-channel contents move constantly and a note per change would drown the conversation. What the model could not work out at all is which surfaces *exist*. The composed line is deduped, so a refresh that did not change the answer costs nothing.

### `DescribeState()` — and why it is not `SerializeState`

New optional `BaseRealtimeChannelClient.DescribeState(): string | null`, defaulting to `null`.

`SerializeState` is for **resume**: a machine format, potentially large, written for a future instance of the same channel. `DescribeState` is written for a language model that is about to speak — `showing https://careers.acme.com`, `12 items across 2 pages`. A channel that returned its serialized state here would spend the session's context on syntax.

**Both shipped channels implement it**, so the hook is not inert on arrival: the whiteboard reports what is on the board, the Remote Browser reports which page it is showing — the part the agent could not infer from merely having the tools. A channel that throws while describing itself is omitted (logged), because one broken description must not put every *other* surface back into the dark.

### Three details worth reviewing

- The roster is composed from **resolved plugins**, not registry rows. A row whose `ClientPluginClass` is missing is precisely the surface the agent would otherwise believe it has.
- A **surface-less** channel (server-only, `HasSurface() === false`) is listed and marked rather than omitted — the agent has its tools, so hiding it recreates the guessing problem one level down.
- An **empty** session says "none open" explicitly. Silence is what the model had before, and silence is what it filled in with a guess.

## Tests

**1096 pass** (was 1080). A new 9-case spec for the roster wording (framework-free, like the surface-tab helpers next door) and 7 new service-level cases driven against the real `RealtimeSessionService` with a fake registered channel: composition from live plugins, an unresolved plugin left out, a throwing `DescribeState` contained, announce-once/stay-quiet, re-announce on a real change, focus announced, and the empty session.

Mutation-verified — six mutants, all killed:

| mutant | result |
|---|---|
| an empty roster says nothing | 2 fail |
| drop each channel's summary | 2 fail |
| surface-less channels look like normal ones | 2 fail |
| no dedupe — announce on every refresh | 1 fail |
| focus is never tracked | 1 fail |
| a throwing `DescribeState` takes down the roster | 1 fail |

## Related

#3498 closes a channel, which mutates this same roster, and #3536 is the missing route that would let the agent *read* it as a session-level tool. One concept, three symptoms — each in its own PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---

## Part 1 of 3 — MJ core, proven through Caliber

This PR is part of the MJ-core half of the realtime-workspace / multi-party work. It is
**not to be merged as part of the Caliber push** — it stands on its own tests and is
consumed downstream by the Caliber PR listed below.

Downstream Caliber PRs that need this: **MemberJunction/bizapps-caliber#157** — the realtime
workspace. It currently runs against a local `node_modules` patch of MJ and stays in draft
until this set lands and releases.
