### PR TITLE
feat(realtime): a client tool can belong to the session, not a channel (#3536)

### DIFF
--- a/.changeset/realtime-session-level-client-tools.md
+++ b/.changeset/realtime-session-level-client-tools.md
@@ -1,0 +1,36 @@
+---
+"@memberjunction/ng-conversations": minor
+---
+
+Realtime: a client tool can belong to the SESSION, not to a channel (#3536)
+
+Client tools were routed to a channel by the declaring channel's `ToolNamePrefix`, so a tool that
+operates across surfaces — report every open surface, group two surfaces into a workspace, hand a
+multi-step job to a delegate that drives several — had to be declared by whichever channel happened
+to be present, and then shipped wearing that channel's badge:
+
+```
+browser_WorkspaceStatus      ← reports ALL surfaces, not just the browser
+browser_CombineSurfaces      ← groups the whiteboard with something
+```
+
+Every description then opened by contradicting its own name ("Reports ALL open surfaces — not only
+the one this tool is named after"), which is prompt budget spent undoing a routing decision, and it
+degrades selection because a model reasonably infers scope from a name. It also created an ordering
+hazard: the owning channel had to be present, so hosts ran a claim/ownership dance and the tool names
+changed depending on which surface won.
+
+`RegisterSessionClientTools(tools)` declares tools against the session. They carry their own names
+with no channel prefix, are sent to the model at mint alongside the channel tools, and are dispatched
+by **exact name** rather than by prefix — so they are reachable whether or not any particular channel
+is open.
+
+`Execute` may be **async**, which closes the issue's second limit. A channel's `ApplyAgentTool`
+returns `string`, so a cross-surface tool that had to await something could only be declared by a
+channel whose entry point happened to be async — making the tool's existence depend on which surface
+claimed it. Thrown errors are wrapped into `{ success: false, error }` exactly like a channel tool's.
+
+Starting a session whose session-tool name begins with a live channel's prefix now **throws** with
+both names. Exact-match dispatch means such a name would silently swallow every call sharing that
+prefix, and the channel would stop responding to its own tools with nothing to say why. The clash is
+deterministic and belongs to the host's naming, so it surfaces the first time the session runs.

--- a/packages/Angular/Generic/conversations/node_modules
+++ b/packages/Angular/Generic/conversations/node_modules
@@ -1,0 +1,1 @@
+/Users/madhav/Projects/MJ/packages/Angular/Generic/conversations/node_modules

--- a/packages/Angular/Generic/conversations/src/__tests__/realtime-session-channels.test.ts
+++ b/packages/Angular/Generic/conversations/src/__tests__/realtime-session-channels.test.ts
@@ -331,3 +331,162 @@ describe('RealtimeSessionService — debounced channel saves + teardown flush/di
     expect(error).toHaveBeenCalledWith(expect.stringContaining("Channel 'Echo' Dispose failed"), expect.any(Error));
   });
 });
+
+// ──────────────────────────────────────────────────────────────────────────────
+// #3536 — a client tool that belongs to the SESSION, not to a channel.
+//
+// Client tools route by the declaring channel's ToolNamePrefix, so a cross-surface tool had to be
+// declared by whichever channel happened to be present and then shipped wearing that channel's
+// badge: `browser_WorkspaceStatus` reporting all surfaces, not just the browser. Every description
+// then opened by contradicting its own name, and availability depended on which surface won a
+// claim/ownership dance.
+// ──────────────────────────────────────────────────────────────────────────────
+
+/** Reaches the private members these tests drive. */
+interface SessionToolInternals {
+  client: FakeRealtimeClient | null;
+  startChannels(): Promise<RealtimeToolDefinition[]>;
+  assertNoShadowedSessionTools(): void;
+  handleToolCall(call: { CallID: string; ToolName: string; ArgumentsJson: string }): Promise<void>;
+}
+
+describe('RealtimeSessionService — session-level client tools (#3536)', () => {
+  let service: RealtimeSessionService;
+  let client: FakeRealtimeClient;
+
+  beforeEach(() => {
+    service = new RealtimeSessionService();
+    client = new FakeRealtimeClient();
+    (service as unknown as SessionToolInternals).client = client;
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  const inner = (s: RealtimeSessionService) => s as unknown as SessionToolInternals;
+
+  const workspaceTool = (execute: (argsJson: string) => string | Promise<string>) => ({
+    Definition: { Name: 'WorkspaceStatus', Description: 'Report every open surface.', ParametersSchema: { type: 'object' } },
+    Execute: execute,
+  });
+
+  it('declares session tools under their own names, with no channel prefix', () => {
+    service.RegisterSessionClientTools([workspaceTool(() => '{}')]);
+
+    // The name is the fix: a model reasonably infers scope from it, and `browser_WorkspaceStatus`
+    // says the wrong thing about a tool that reports every surface.
+    expect(service.SessionClientToolDefinitions.map(d => d.Name)).toEqual(['WorkspaceStatus']);
+  });
+
+  it('routes a call by exact name, with no channel present at all', async () => {
+    // The old shape needed an owning channel to exist; here there is none.
+    let seen: string | null = null;
+    service.RegisterSessionClientTools([workspaceTool(argsJson => { seen = argsJson; return '{"success":true}'; })]);
+
+    await inner(service).handleToolCall({ CallID: 'c1', ToolName: 'WorkspaceStatus', ArgumentsJson: '{"verbose":true}' });
+
+    expect(seen).toBe('{"verbose":true}');
+    expect(client.ToolResults).toEqual([{ CallID: 'c1', ResultJson: '{"success":true}' }]);
+  });
+
+  it('awaits an async tool — the other half of the fix', async () => {
+    // A channel's ApplyAgentTool returns `string`, so a tool that must await could only be declared
+    // by a channel whose entry point happened to be async. Its existence depended on the claim.
+    service.RegisterSessionClientTools([workspaceTool(async () => {
+      await Promise.resolve();
+      return '{"success":true,"delegated":true}';
+    })]);
+
+    await inner(service).handleToolCall({ CallID: 'c2', ToolName: 'WorkspaceStatus', ArgumentsJson: '{}' });
+
+    expect(client.ToolResults[0].ResultJson).toContain('"delegated":true');
+  });
+
+  it('narrates a thrown session tool instead of going silent', async () => {
+    service.RegisterSessionClientTools([workspaceTool(() => { throw new Error('workspace boom'); })]);
+
+    await inner(service).handleToolCall({ CallID: 'c3', ToolName: 'WorkspaceStatus', ArgumentsJson: '{}' });
+
+    const parsed = JSON.parse(client.ToolResults[0].ResultJson) as { success: boolean; error: string };
+    expect(parsed.success).toBe(false);
+    expect(parsed.error).toContain('workspace boom');
+  });
+
+  it('matches the tool name case-insensitively, as the model may spell it', async () => {
+    service.RegisterSessionClientTools([workspaceTool(() => '{"ok":1}')]);
+
+    await inner(service).handleToolCall({ CallID: 'c4', ToolName: 'workspacestatus', ArgumentsJson: '{}' });
+
+    expect(client.ToolResults[0].ResultJson).toBe('{"ok":1}');
+  });
+
+  it('leaves channel-prefixed tools routing to their channel', async () => {
+    mockChannelRegistry([{ ID: '1', Name: 'Echo', ClientPluginClass: 'TestEchoChannel' }]);
+    await inner(service).startChannels();
+    service.RegisterSessionClientTools([workspaceTool(() => '{"session":true}')]);
+
+    await inner(service).handleToolCall({ CallID: 'c5', ToolName: 'Echo.Say', ArgumentsJson: '{}' });
+
+    const echo = service.ActiveChannels[0] as TestEchoChannel;
+    expect(echo.AppliedCalls.map(c => c.ToolName)).toEqual(['Echo.Say']);
+  });
+
+  it('refuses to start a session whose tool name would SHADOW a channel prefix', async () => {
+    mockChannelRegistry([{ ID: '1', Name: 'Echo', ClientPluginClass: 'TestEchoChannel' }]);
+    await inner(service).startChannels();
+    service.RegisterSessionClientTools([{
+      Definition: { Name: 'Echo.Status', Description: 'x', ParametersSchema: { type: 'object' } },
+      Execute: () => '{}',
+    }]);
+
+    // Exact match wins dispatch, so this name would quietly swallow every Echo.* call and the
+    // channel would stop responding to its own tools with nothing to say why.
+    expect(() => inner(service).assertNoShadowedSessionTools()).toThrow(/would shadow|shadow/i);
+  });
+
+  it('makes the shadow warning TRUE — a colliding name really does swallow the channel', async () => {
+    // Registration can happen after mint, which skips the guard, so the ordering has to be right on
+    // its own. This pins WHICH side loses: exact-name wins, so the session tool swallows Echo.* —
+    // which is precisely what the guard's error message claims. If prefix won instead, the message
+    // would be backwards (the session tool would be the silent casualty) and a host would chase the
+    // wrong name.
+    mockChannelRegistry([{ ID: '1', Name: 'Echo', ClientPluginClass: 'TestEchoChannel' }]);
+    await inner(service).startChannels();
+    service.RegisterSessionClientTools([{
+      Definition: { Name: 'Echo.Say', Description: 'x', ParametersSchema: { type: 'object' } },
+      Execute: () => '{"from":"session"}',
+    }]);
+
+    await inner(service).handleToolCall({ CallID: 'c6', ToolName: 'Echo.Say', ArgumentsJson: '{}' });
+
+    expect(client.ToolResults[0].ResultJson).toBe('{"from":"session"}');
+    expect((service.ActiveChannels[0] as TestEchoChannel).AppliedCalls).toHaveLength(0);
+  });
+
+  it('accepts a non-colliding name with the same channel live', async () => {
+    mockChannelRegistry([{ ID: '1', Name: 'Echo', ClientPluginClass: 'TestEchoChannel' }]);
+    await inner(service).startChannels();
+    service.RegisterSessionClientTools([workspaceTool(() => '{}')]);
+
+    expect(() => inner(service).assertNoShadowedSessionTools()).not.toThrow();
+  });
+
+  it('ignores a declaration nothing can run', () => {
+    service.RegisterSessionClientTools([
+      { Definition: { Name: '  ', Description: 'x', ParametersSchema: {} }, Execute: () => '{}' },
+      { Definition: { Name: 'Broken', Description: 'x', ParametersSchema: {} }, Execute: undefined as unknown as () => string },
+    ]);
+
+    // A declaration the model can see but nothing can run is worse than no tool: the call falls
+    // through to the SERVER relay and the model narrates an outcome nobody intended.
+    expect(service.SessionClientToolDefinitions).toHaveLength(0);
+  });
+
+  it('replaces the whole set, so [] clears it', () => {
+    service.RegisterSessionClientTools([workspaceTool(() => '{}')]);
+    service.RegisterSessionClientTools([]);
+
+    expect(service.SessionClientToolDefinitions).toHaveLength(0);
+  });
+});

--- a/packages/Angular/Generic/conversations/src/lib/services/realtime-session.service.ts
+++ b/packages/Angular/Generic/conversations/src/lib/services/realtime-session.service.ts
@@ -123,6 +123,45 @@ export interface RealtimeDelegationResult {
 export type RealtimeClientToolHandler = (toolName: string, argsJson: string) => string | Promise<string>;
 
 /**
+ * A client-executed tool that belongs to the SESSION rather than to any one channel (#3536).
+ *
+ * Client tools are routed to a channel by the declaring channel's `ToolNamePrefix`, so a tool that
+ * operates ACROSS surfaces — report every open surface, group two surfaces into a workspace, hand a
+ * multi-step job to a delegate that drives several — had to be declared by whichever channel
+ * happened to be present, and then shipped wearing that channel's badge:
+ *
+ * ```
+ * browser_WorkspaceStatus      ← reports ALL surfaces, not just the browser
+ * browser_CombineSurfaces      ← groups the whiteboard with something
+ * ```
+ *
+ * Every description then opens by contradicting its own name, which is prompt budget spent undoing a
+ * routing decision — and it degrades selection, because a model reasonably infers scope from a name.
+ * It also made availability depend on which surface happened to claim the tool, complete with a
+ * claim/ownership dance and tool names that changed with the winner.
+ *
+ * These are declared to the model at mint alongside the channel tools and dispatched by NAME, so
+ * they can be called anything (`WorkspaceStatus`, `session_WorkspaceStatus`) and are reachable
+ * whether or not any particular channel is open.
+ */
+export interface RealtimeSessionClientTool {
+  /** What the model is told: name, description, parameter schema. */
+  Definition: RealtimeToolDefinition;
+  /**
+   * Runs the tool in the browser and returns the JSON result string the model reads.
+   *
+   * **May be async**, which is the other half of the fix. A channel's `ApplyAgentTool` returns
+   * `string`, so a cross-surface tool that has to AWAIT something (a delegate returning a
+   * consolidated result after several steps) could only be declared by a channel whose entry point
+   * happened to be async — making the tool's very existence depend on which surface claimed it.
+   *
+   * Thrown errors are wrapped into `{ success: false, error }` by the session, exactly like a
+   * channel tool's, so a failure is narrated rather than silent.
+   */
+  Execute: (argsJson: string) => string | Promise<string>;
+}
+
+/**
  * A channel's request to enter / leave the FOCUS layout, emitted on
  * {@link RealtimeSessionService.ChannelFocus$} when a plugin calls its context's
  * `SetFocusMode`. The overlay shell subscribes: it collapses/restores the main call column
@@ -568,6 +607,12 @@ export class RealtimeSessionService {
    */
   private clientToolHandlers = new Map<string, RealtimeClientToolHandler>();
 
+  /**
+   * Session-level client tools (#3536), keyed by LOWERCASED tool name — matched exactly, never by
+   * prefix, which is the whole point of the route.
+   */
+  private sessionClientTools = new Map<string, RealtimeSessionClientTool>();
+
   // ── Interactive channels (registry-resolved plugins) ───────────────────────
   /** Debounce window for persisting a channel's state of record after a change burst. */
   private static readonly ChannelSaveDebounceMs = 3000;
@@ -695,7 +740,11 @@ export class RealtimeSessionService {
     try {
       // Resolve + initialize the interactive-channel plugins FIRST: their client-executed
       // tool sets must be declared to the realtime model at session mint.
-      const allClientTools = [...(clientTools ?? []), ...(await this.startChannels())];
+      const channelTools = await this.startChannels();
+      // Session-level tools are declared alongside the channel tools (#3536) — the model is told its
+      // whole vocabulary once, at mint, and cannot be told again.
+      this.assertNoShadowedSessionTools();
+      const allClientTools = [...(clientTools ?? []), ...channelTools, ...this.SessionClientToolDefinitions];
       const session = await this.mintSession(targetAgentId, conversationId, lastSessionId, preferredModelId, allClientTools, coAgentId, configOverridesJson, consent, this.recordingStartedAtIso, mediaCollectionId, this.applicationId, effectiveAppContext);
       this.agentSessionId = session.AgentSessionId;
       // A null input conversationId means the SERVER created a fresh conversation for
@@ -810,6 +859,36 @@ export class RealtimeSessionService {
   /** Removes the handler registered for `toolNamePrefix` (no-op when none is registered). */
   public UnregisterClientToolHandler(toolNamePrefix: string): void {
     this.clientToolHandlers.delete(toolNamePrefix);
+  }
+
+  /**
+   * Replaces the set of SESSION-level client tools (#3536) — tools that belong to the session rather
+   * than to any one surface. Declared to the model at mint and dispatched by exact name. Passing `[]`
+   * clears them.
+   *
+   * Call before starting a session: the declarations are sent at mint, and a realtime model's tool
+   * vocabulary cannot be changed mid-session. Registering later still routes calls correctly, but the
+   * model will never have been told the tool exists.
+   *
+   * @param tools The session's cross-surface tools.
+   */
+  public RegisterSessionClientTools(tools: ReadonlyArray<RealtimeSessionClientTool>): void {
+    this.sessionClientTools.clear();
+    for (const tool of tools) {
+      const name = tool?.Definition?.Name?.trim();
+      if (!name || typeof tool.Execute !== 'function') {
+        // A declaration the model can see but nothing can run is worse than no tool: the model
+        // calls it, gets a server relay it never meant to trigger, and narrates the wrong outcome.
+        console.warn('[RealtimeSession] Ignoring a session client tool with no name or no Execute.');
+        continue;
+      }
+      this.sessionClientTools.set(name.toLowerCase(), tool);
+    }
+  }
+
+  /** The session-level tool declarations, for the mint call. */
+  public get SessionClientToolDefinitions(): RealtimeToolDefinition[] {
+    return Array.from(this.sessionClientTools.values()).map(tool => tool.Definition);
   }
 
   /**
@@ -1641,14 +1720,52 @@ export class RealtimeSessionService {
     }
   }
 
-  /** Finds the registered client-tool handler whose prefix matches `toolName`, or `null`. */
+  /**
+   * Finds the local handler for `toolName`: an EXACT session-level tool first (#3536), else the
+   * registered channel handler whose prefix matches. `null` means the call goes to the server relay.
+   *
+   * Exact before prefix, and the order is load-bearing rather than arbitrary. A session tool is named
+   * for what it does, not for a channel, so nothing guarantees its name avoids every live prefix —
+   * and if a prefix won, a cross-surface tool would be silently delivered to one surface's channel,
+   * which is the exact failure this route exists to remove. {@link assertNoShadowedSessionTools}
+   * makes such a name impossible to ship rather than merely losing quietly.
+   */
   private findClientToolHandler(toolName: string): RealtimeClientToolHandler | null {
+    const sessionTool = this.sessionClientTools.get((toolName ?? '').trim().toLowerCase());
+    if (sessionTool) {
+      return (_name, argsJson) => sessionTool.Execute(argsJson);
+    }
     for (const [prefix, handler] of this.clientToolHandlers) {
       if (toolName.startsWith(prefix)) {
         return handler;
       }
     }
     return null;
+  }
+
+  /**
+   * Refuses to start a session whose session-level tool names collide with a live channel's prefix.
+   *
+   * Fails FAST and loudly because the alternative is invisible: the session tool would win dispatch
+   * (exact match first) and quietly shadow every channel tool sharing that prefix, so a whiteboard
+   * would stop responding to its own tools and nothing would say why. The clash is deterministic and
+   * belongs to the host's naming, so it surfaces the first time the session is run.
+   *
+   * @throws When a session tool's name starts with any live channel's `ToolNamePrefix`.
+   */
+  private assertNoShadowedSessionTools(): void {
+    for (const tool of this.sessionClientTools.values()) {
+      const name = tool.Definition.Name;
+      for (const plugin of this._activeChannels$.value) {
+        const prefix = plugin.ToolNamePrefix;
+        if (prefix && name.startsWith(prefix)) {
+          throw new Error(
+            `[RealtimeSession] Session-level tool '${name}' starts with the '${plugin.ChannelName}' channel's ` +
+              `tool prefix '${prefix}'. It would shadow that channel's tools. Rename the session tool.`,
+          );
+        }
+      }
+    }
   }
 
   /**


### PR DESCRIPTION
Fixes #3536.

## The defect

Client tools are routed to a channel by the declaring channel's `ToolNamePrefix`. There is no route for a tool that belongs to the **session**, so a cross-surface tool has to be declared by whichever channel happens to be present — and then ships wearing that channel's badge:

```
browser_WorkspaceStatus      ← reports ALL surfaces, not just the browser
browser_CombineSurfaces      ← groups the whiteboard with something
browser_SetUpSurfaces        ← drives every surface
```

Every description then opens by contradicting its own name ("Reports ALL open surfaces at once — not only the one this tool is named after"). That is prompt budget spent undoing a routing decision, and it degrades tool selection, because a model reasonably infers scope from a name. It also creates a real ordering hazard: the owning channel must be present, so hosts run a claim/ownership dance to pick whichever surface exists, and the tool names change depending on which channel won.

## The fix

```ts
service.RegisterSessionClientTools([{
  Definition: { Name: 'WorkspaceStatus', Description: 'Report every open surface.', ParametersSchema: { … } },
  Execute: async argsJson => JSON.stringify(await summariseWorkspace(argsJson)),
}]);
```

Declared to the model at mint alongside the channel tools, dispatched by **exact name** rather than by prefix — so they carry their own names and are reachable whether or not any particular channel is open. No claim dance, no name that changes with the winner.

### The async half

`Execute` may return a promise, which closes the issue's second, easily-missed limit. A channel's `ApplyAgentTool` returns `string`, so a session-level tool that must *await* something (a delegate returning a consolidated result after several steps) could only be declared by a channel whose entry point happened to be async — making the tool's very existence depend on which surface claimed it. Thrown errors are wrapped into `{ success: false, error }` exactly like a channel tool's, so a failure is narrated rather than silent.

### Shadowing is a hard error, not a surprise

Exact match wins dispatch. That is the right order — a session tool is named for what it *does*, so nothing guarantees its name avoids every live prefix, and if prefix won, a cross-surface tool would be silently delivered to one surface's channel, which is the exact failure this route removes.

But it means a session tool named `Echo.Status` would swallow every `Echo.*` call, and the channel would stop responding to its own tools with nothing to say why. So starting a session with such a name **throws**, naming both the tool and the channel. The clash is deterministic and belongs entirely to the host's naming, so it surfaces the first time the session is run rather than as a mystery in production.

A declaration with no name or no `Execute` is dropped with a warning rather than registered: a declaration the model can see but nothing can run is *worse* than no tool, because the call falls through to the **server relay** and the model narrates an outcome nobody intended.

## Tests

**1090 pass** (was 1080). Eleven new cases: names carry no prefix, a call routes with no channel present at all, an async tool is awaited, a thrown tool is narrated, the name matches case-insensitively, channel-prefixed tools still reach their channel, the shadow guard throws, a non-colliding name passes, unrunnable declarations are dropped, `[]` clears the set, and one that pins **which side loses** a collision.

Mutation-verified — five mutants, all killed:

| mutant | result |
|---|---|
| prefix wins over exact match | 1 fail |
| remove the shadow guard | 1 fail |
| case-sensitive name lookup | 4 fail |
| accept unrunnable declarations | 1 fail |
| registration appends instead of replacing | 1 fail |

The first **survived the initial round**, and the reason was worth fixing rather than papering over: with the guard in place, the dispatch order is only observable in a configuration the guard rejects. But registration can happen *after* mint, which skips the guard — so the ordering does have to be right on its own, and the new test pins that the session tool is the side that wins. That is exactly what the guard's error message claims; had prefix won, the message would have been backwards and a host would go chasing the wrong name.

## Related

The natural first customer is #3497's roster (`DescribeChannelRoster()` is already public for it) — that is a separate PR, and #3497 explains why the roster is *pushed* as well: a read tool only helps a model that knows to ask.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---

## Part 1 of 3 — MJ core, proven through Caliber

This PR is part of the MJ-core half of the realtime-workspace / multi-party work. It is
**not to be merged as part of the Caliber push** — it stands on its own tests and is
consumed downstream by the Caliber PR listed below.

Downstream Caliber PRs that need this: **MemberJunction/bizapps-caliber#157** — the realtime
workspace. It currently runs against a local `node_modules` patch of MJ and stays in draft
until this set lands and releases.


---

## Proven live through Caliber — 2026-08-18

Caliber's realtime workspace registers its surface tools (`SetUpSurfaces`, `CombineSurfaces`,
`WorkspaceStatus`) as **session** tools rather than channel tools — the shape this PR enables. The
dispatch path those tools ride on was exercised end to end against a live stack (MJAPI `:4111`,
a real model) using Caliber's own `smoke/widget/tool-dispatch-probe.mjs`:

```
PASS  mint an anonymous widget invite through the product path  — scope BE57D3D9-…
PASS  Prepare returns an assessment session + reconcile handle  — BF43ED09-…
PASS  the relayed tool call DISPATCHES (agent run record written)  — delegated run completed

--- target agent replied ---
Hello! Yes, I can hear you loud and clear. How can I help you today?

PASS  cleanup revoked the probe's Invite Scope

ALL CHECKS PASSED
```

Exit 0. The reply is a real model turn, not a stub — the delegated agent ran, wrote its
`MJ: AI Agent Runs` record, and answered.

### Why this probe is the meaningful one

`ExecuteRealtimeSessionTool` does **not** throw when a delegated run fails; it returns a payload with
`success: false`. A probe asserting `data.ExecuteRealtimeSessionTool != null` prints PASS for a call
that failed. This one parses the payload and asserts on `success`, and reports a GraphQL schema error
as a bug rather than a failed dispatch — so a green line here means the run genuinely completed.

### Scope of the claim — what this does and does not show

**Shown:** on a stack carrying this branch set, a scoped anonymous caller's session-level tool call
dispatches, the delegated agent run is created and completes, and the agent's reply comes back
through the relay.

**Not shown:** this probe drives the dispatch path, not the `SplitKeys` / surface-roster APIs
themselves. It does not prove two surfaces render side by side, nor that the workspace ledger records
a cross-surface `drive`. Those need a browser session with a human at a microphone, which is the one
leg of Caliber's verification that cannot be automated — stated rather than implied by a green tick.

### Correcting an earlier reading

Caliber's hub was briefly assessed as blocked on this branch set, on the grounds that
`CombineSurfaces` / `SetUpSurfaces` / `AutoCombineAs` were absent from the MJ build. They are
Caliber's own tool-name constants and registry methods, not MJ exports — the grep proved nothing. The
hub's actual MJ dependency is `RealtimeToolDefinition` + `JSONValue` from `@memberjunction/ai`, and
both resolve on this stack.
