### PR TITLE
fix: relicense ng-graph-view to BUSL-1.1

### DIFF
--- a/packages/Angular/Generic/graph-view/package.json
+++ b/packages/Angular/Generic/graph-view/package.json
@@ -20,7 +20,7 @@
     "memberjunction"
   ],
   "author": "",
-  "license": "ISC",
+  "license": "BUSL-1.1",
   "devDependencies": {
     "@angular/compiler": "21.1.3",
     "@angular/compiler-cli": "21.1.3"


### PR DESCRIPTION
**One sentence:** one manifest missed the BUSL relicense because it landed on `next` after #3820 branched.

`packages/Angular/Generic/graph-view/package.json` arrived in `47930ef712` (*feat: add generic ng-graph-view component and modern form panels for core entities*), after the relicense sweep in #3820 had already branched. It carried `"license": "ISC"` through the merge, and it is now the only manifest in the repo that does not say `BUSL-1.1` — 323 of 324 do.

## How it was found

By re-running the manifest verification against `next` **after** #3820 merged, rather than trusting the pre-merge result. A long-running sweep across a moving base branch will always have this class of gap; the fix is to verify post-merge, which is what surfaced it.

The same re-run found four sibling repos in the same state (all `packages/IntegrationTests/package.json`, added after their sweeps branched). Companion PRs: bizapps-accounting#78, bizapps-common#72, bizapps-issues#22, bizapps-tasks#39.

## Scope

One line. No behaviour change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Lr9CosyUWHywcAWF3Gy5wK