### PR TITLE
fix(codegen): a new schema could never get an Application on PostgreSQL

### DIFF
--- a/.changeset/application-insert-pg-quoting.md
+++ b/.changeset/application-insert-pg-quoting.md
@@ -1,0 +1,9 @@
+---
+'@memberjunction/codegen-lib': patch
+---
+
+A new schema gets its Application on PostgreSQL, and never loses the window on any platform
+
+Two defects closed the same door. `createNewApplication` named the `Application` columns unquoted, and `conditionalInsert` wraps that statement in PG's `DO $$ ... $$` block — which the identifier auto-quoter skips wholesale, since it cannot know whether a dollar-quoted block holds SQL or text. `ID` therefore reached PostgreSQL folded to `id` and the INSERT failed on every run, silently: the method catches, logs and returns null, and its caller carries on, so CodeGen finished green while the schema got no Application. Separately, Application creation was gated on `isSchemaNew()`, evaluated moments before the INSERT that ends that condition — so the window closed permanently on first use whether or not an Application was ever created.
+
+Columns are now quoted, and the create path is the shared `addEntityToApplicationForSchema` helper (already used for virtual and query entities), which looks up and creates if absent every time rather than once.

--- a/.changeset/application-insert-pg-quoting.md
+++ b/.changeset/application-insert-pg-quoting.md
@@ -2,8 +2,8 @@
 '@memberjunction/codegen-lib': patch
 ---
 
-A new schema gets its Application on PostgreSQL, and never loses the window on any platform
+A new schema gets its Application on PostgreSQL
 
-Two defects closed the same door. `createNewApplication` named the `Application` columns unquoted, and `conditionalInsert` wraps that statement in PG's `DO $$ ... $$` block — which the identifier auto-quoter skips wholesale, since it cannot know whether a dollar-quoted block holds SQL or text. `ID` therefore reached PostgreSQL folded to `id` and the INSERT failed on every run, silently: the method catches, logs and returns null, and its caller carries on, so CodeGen finished green while the schema got no Application. Separately, Application creation was gated on `isSchemaNew()`, evaluated moments before the INSERT that ends that condition — so the window closed permanently on first use whether or not an Application was ever created.
+`createNewApplication` named the `Application` columns unquoted, and `conditionalInsert` wraps that statement in PG's `DO $$ ... $$` block — which the identifier auto-quoter skips wholesale, since it cannot know whether a dollar-quoted block holds SQL or literal text. `ID` therefore reached PostgreSQL folded to `id`, and the INSERT failed on every run. It failed silently: the method catches, logs and returns null, and its caller logs and carries on, so CodeGen finished green while the schema got no Application and every one of its entities rendered in the UI's "System & Other" bucket. SQL Server resolves the unquoted identifiers case-insensitively, which is why this survived unnoticed since before 5.49.
 
-Columns are now quoted, and the create path is the shared `addEntityToApplicationForSchema` helper (already used for virtual and query entities), which looks up and creates if absent every time rather than once.
+The columns are now quoted through `qi()`, matching the sibling `ApplicationRole` insert a few lines below. `conditionalInsertSQL` now documents the pre-quoting contract that makes it the one exception to this file's usual "write identifiers bare, the auto-quoter handles it" convention.

--- a/packages/CodeGenLib/src/Database/codeGenDatabaseProvider.ts
+++ b/packages/CodeGenLib/src/Database/codeGenDatabaseProvider.ts
@@ -1077,8 +1077,15 @@ export abstract class CodeGenDatabaseProvider {
      * SQL Server: `IF NOT EXISTS (checkQuery) BEGIN insertSQL END`
      * PostgreSQL: `DO $$ BEGIN IF NOT EXISTS (checkQuery) THEN insertSQL; END IF; END $$`
      *
-     * @param checkQuery The SELECT query to check for existence.
-     * @param insertSQL The INSERT statement to execute if the check returns no rows.
+     * **Both arguments must already be identifier-quoted by the caller** (`qi()`/`qs()`).
+     * On PostgreSQL the result is a `DO $$ ... $$` block, and the identifier auto-quoter
+     * (`quoteSQLForExecution`, applied later by `runQuery`/`LogSQLAndExecute`) skips dollar-quoted
+     * blocks wholesale — it cannot know whether their contents are SQL or literal text. So this is
+     * the one SQL-building path where the usual "write it bare, the quoter handles it" convention
+     * does not hold: a bare `ID` survives to PG folded as `id` and the statement fails every run.
+     *
+     * @param checkQuery The SELECT query to check for existence. Identifiers must be pre-quoted.
+     * @param insertSQL The INSERT statement to execute if the check returns no rows. Identifiers must be pre-quoted.
      */
     abstract conditionalInsertSQL(checkQuery: string, insertSQL: string): string;
 

--- a/packages/CodeGenLib/src/Database/manage-metadata.ts
+++ b/packages/CodeGenLib/src/Database/manage-metadata.ts
@@ -6031,7 +6031,11 @@ export class ManageMetadataBase {
          // not products — hide them from new users. Application.DefaultForNewUser defaults to 1 in the
          // DB, so omitting the column here is what put raw '__mj_*'-named apps in every new user's
          // app switcher while the human-authored metadata app stayed hidden.
-         const appInsert = `INSERT INTO ${this.qs(mj_core_schema(), 'Application')} (ID, Name, Description, SchemaAutoAddNewEntities, Path, AutoUpdatePath, DefaultForNewUser)
+         // Every column is quoted through `qi()` rather than written bare. `conditionalInsert` wraps this
+         // statement in PG's `DO $$ ... $$` block, and the identifier auto-quoter skips dollar-quoted
+         // blocks wholesale (they can legally contain arbitrary text), so nothing downstream will quote
+         // these for us. Bare `ID` reaches PG folded to `id` and the INSERT fails on every run.
+         const appInsert = `INSERT INTO ${this.qs(mj_core_schema(), 'Application')} (${this.qi('ID')}, ${this.qi('Name')}, ${this.qi('Description')}, ${this.qi('SchemaAutoAddNewEntities')}, ${this.qi('Path')}, ${this.qi('AutoUpdatePath')}, ${this.qi('DefaultForNewUser')})
                        VALUES ('${appID}', '${appName}', 'Generated for schema', '${schemaName}', '${path}', ${this.dialect.BooleanLiteral(true)}, ${this.dialect.BooleanLiteral(false)})`;
          const sSQL = this.conditionalInsert(appCheckQuery, appInsert);
          await this.LogSQLAndExecute(pool, sSQL, `SQL generated to create new application ${appName}`);

--- a/packages/CodeGenLib/src/__tests__/application-insert-pg-quoting.test.ts
+++ b/packages/CodeGenLib/src/__tests__/application-insert-pg-quoting.test.ts
@@ -1,0 +1,139 @@
+/**
+ * Unit test for the PostgreSQL correctness of the schema-Application INSERT.
+ *
+ * `createNewApplication` is the only writer of an Application row for a newly registered schema,
+ * and its statement is wrapped by `conditionalInsert`. On PostgreSQL that wrapper produces a
+ * `DO $$ ... $$` block, and the identifier auto-quoter that every statement passes through on its
+ * way to the database (`quoteSQLForExecution`, here exercised through the real
+ * `AutoQuotePostgreSQLIdentifiers`) skips dollar-quoted blocks wholesale — it cannot know whether
+ * their contents are SQL or literal text. So this is the one build path where the usual
+ * "write identifiers bare, the quoter handles it" convention silently does not apply.
+ *
+ * With a bare column list, `ID` reached PostgreSQL folded to `id` and the INSERT failed on every
+ * run with `column "id" of relation "Application" does not exist`. The failure was invisible:
+ * `createNewApplication` catches, logs, and returns null, and the caller logs and carries on, so
+ * CodeGen completed successfully while the schema silently got no Application — every one of its
+ * entities landing in the UI's fallback bucket with no way to recover.
+ *
+ * SQL Server resolves the unquoted identifiers case-insensitively, which is why this survived.
+ * The test therefore asserts the property on BOTH dialects: what reaches the database is quoted.
+ */
+import { describe, it, expect, vi } from 'vitest';
+
+vi.mock('mssql', () => ({}));
+vi.mock('../Config/config', () => ({
+   configInfo: { newSchemaDefaults: { ApplicationRoleDefaults: { AutoAddRolesForNewApplications: false, Roles: [] } } },
+   currentWorkingDirectory: '/tmp',
+   getSettingValue: vi.fn(),
+   mj_core_schema: () => '__mj',
+   dbPlatform: () => 'postgresql',
+   outputDir: '/tmp',
+}));
+vi.mock('@memberjunction/core', async (importOriginal) => {
+   const actual = await importOriginal<typeof import('@memberjunction/core')>();
+   return { ...actual, LogError: vi.fn(), LogStatus: vi.fn() };
+});
+vi.mock('../Misc/status_logging', () => ({
+   logError: vi.fn(),
+   logMessage: vi.fn(),
+   logStatus: vi.fn(),
+}));
+vi.mock('../Database/sql', () => ({ SQLUtilityBase: class {} }));
+vi.mock('../Misc/advanced_generation', () => ({ AdvancedGeneration: class {} }));
+vi.mock('uuid', () => ({ v4: vi.fn(() => 'mock-uuid') }));
+vi.mock('../Misc/sql_logging', () => ({
+   SQLLogging: { LogSQLAndExecute: vi.fn(async () => undefined) },
+}));
+vi.mock('@memberjunction/aiengine', () => ({ AIEngine: class {} }));
+
+import { ManageMetadataBase } from '../Database/manage-metadata';
+import {
+   AutoQuotePostgreSQLIdentifiers,
+   PostgreSQLDialect,
+   SQLServerDialect,
+} from '@memberjunction/sql-dialect';
+import type { SQLDialect } from '@memberjunction/sql-dialect';
+import type { UserInfo } from '@memberjunction/core';
+
+/** The columns the Application INSERT names. All are mixed-case in __mj.Application. */
+const APPLICATION_COLUMNS = [
+   'ID',
+   'Name',
+   'Description',
+   'SchemaAutoAddNewEntities',
+   'Path',
+   'AutoUpdatePath',
+   'DefaultForNewUser',
+];
+
+/**
+ * Exercises the real `createNewApplication`, capturing the statement it hands to
+ * `LogSQLAndExecute` — i.e. exactly what the database is asked to run.
+ */
+class TestableCreateApp extends ManageMetadataBase {
+   public captured: string[] = [];
+
+   constructor(private readonly _dialect: SQLDialect, private readonly _isPG: boolean) { super(); }
+
+   protected get dialect(): SQLDialect { return this._dialect; }
+
+   protected conditionalInsert(checkQuery: string, insertSQL: string): string {
+      // The two real provider implementations, inlined so the test needs no provider wiring.
+      return this._isPG
+         ? `DO $$ BEGIN\n   IF NOT EXISTS (${checkQuery}) THEN\n      ${insertSQL};\n   END IF;\nEND $$`
+         : `IF NOT EXISTS (\n      ${checkQuery}\n   )\n   BEGIN\n      ${insertSQL}\n   END`;
+   }
+
+   protected async LogSQLAndExecute(_pool: unknown, query: string): Promise<void> {
+      this.captured.push(query);
+   }
+
+   protected async addDefaultRolesForApplication(): Promise<void> { /* out of scope */ }
+
+   public run(): Promise<string | null> {
+      return this.createNewApplication(
+         null as never,
+         '11111111-1111-1111-1111-111111111111',
+         'pheedloop',
+         'pheedloop',
+         {} as UserInfo
+      );
+   }
+}
+
+describe('createNewApplication — the statement that reaches the database', () => {
+   it('names every Application column quoted, so PostgreSQL does not fold it to lower case', async () => {
+      const pg = new TestableCreateApp(new PostgreSQLDialect(), true);
+      await pg.run();
+
+      expect(pg.captured).toHaveLength(1);
+      // What actually reaches PG: the emitted statement after the auto-quoter has run over it.
+      const executed = AutoQuotePostgreSQLIdentifiers(pg.captured[0]);
+
+      for (const column of APPLICATION_COLUMNS) {
+         expect(executed).toContain(`"${column}"`);
+      }
+      // No bare occurrence survives anywhere in the column list.
+      expect(executed).not.toMatch(/\(\s*ID\s*,/);
+   });
+
+   it('is not rescued by the auto-quoter, because the quoter skips the DO $$ block', async () => {
+      const pg = new TestableCreateApp(new PostgreSQLDialect(), true);
+      await pg.run();
+
+      // This is the trap the fix exists for: the quoter is a no-op on this statement, so the
+      // statement must already be correct when it is built. If this ever stops holding, the
+      // pre-quoting contract on conditionalInsertSQL can be relaxed — until then it cannot.
+      expect(AutoQuotePostgreSQLIdentifiers(pg.captured[0])).toEqual(pg.captured[0]);
+   });
+
+   it('emits the same quoted column list on SQL Server', async () => {
+      const ss = new TestableCreateApp(new SQLServerDialect(), false);
+      await ss.run();
+
+      expect(ss.captured).toHaveLength(1);
+      for (const column of APPLICATION_COLUMNS) {
+         expect(ss.captured[0]).toContain(`[${column}]`);
+      }
+   });
+});


### PR DESCRIPTION
## The defect

`createNewApplication` names the `Application` columns unquoted:

```
INSERT INTO "__mj"."Application" (ID, Name, Description, SchemaAutoAddNewEntities, Path, AutoUpdatePath, DefaultForNewUser)
```

Normally that is fine — every statement passes through the PostgreSQL identifier auto-quoter on its way to the database. But this one is wrapped by `conditionalInsert`, which on PG emits a `DO $$ ... $$` block, and the auto-quoter **skips dollar-quoted blocks wholesale**: it cannot know whether their contents are SQL or literal text. Nothing downstream quotes them, so `ID` reaches PostgreSQL folded to `id`.

Reproduced against PostgreSQL 16 with the exact emitted statement:

```
ERROR:  column "id" of relation "Application" does not exist
LINE 1: INSERT INTO "__mj"."Application" (ID, Name, Description, Sch...
```

The same statement with the columns quoted succeeds.

SQL Server resolves the unquoted identifiers case-insensitively, which is why this survived — present unchanged in 5.49, 5.51 and `next`. **On PostgreSQL, `createNewApplication` has never worked.**

## Why nobody saw it

Every layer swallows it. `createNewApplication` catches its own exception, logs, and returns `null`. The caller logs `Unable to create new application for schema X` and carries on. CodeGen exits **0**.

So a new schema registers all of its entities normally, gets no Application, and every one of those entities renders in the UI's "System & Other" bucket — which is simply where an entity with no `ApplicationEntity` row goes. The tables and the data are fine; only the grouping is wrong.

Observed on a PostgreSQL instance: 27 entities in one schema, 0 Applications, 0 `ApplicationEntity` rows, `CreateNewApplicationWithSchemaName` `true` throughout.

## The fix

Quote the seven columns through `qi()`, exactly as the sibling `ApplicationRole` insert a few lines below already does.

`conditionalInsertSQL` now documents the contract that makes this the one exception to the usual convention: its arguments must be pre-quoted by the caller, because on PG the result is a dollar-quoted block the auto-quoter will not descend into. That contract was the trap — every other SQL-building path in this file can safely write identifiers bare, which is exactly why this one read as correct.

## Verification

- The emitted statement reproduced against a real PostgreSQL 16, before and after.
- New test `application-insert-pg-quoting.test.ts` (3 cases) asserts what actually reaches the database — the statement composed by the real `createNewApplication`, run through the real auto-quoter — on **both** dialects. Confirmed it fails without the fix (2 of 3 cases) and passes with it.
- One case pins the trap itself: the auto-quoter is a **no-op** on this statement. If that ever stops holding, the pre-quoting contract can be relaxed; until then it cannot.
- Full CodeGenLib suite: 1,086 passed, 0 failed.

## Risk

The quoted and unquoted forms are identical on SQL Server, where unquoted identifiers already resolved case-insensitively — the emitted text changes, the resolved columns do not. On PostgreSQL the statement goes from always failing to succeeding.

Scope is one statement plus a doc comment. Nothing else in the create path changes.

## Scope — what this PR deliberately does not include

Per @rkihm-BC's review: the `isSchemaNew()` **latch** in `createNewEntity` is a real, separate defect and is *not* fixed here. Because `isSchemaNew()` reads live `__mj.Entity` state and is evaluated before the entity INSERT commits, any single failure to create the Application — on either platform, from any cause — locks that schema out of ever getting one. This PR removes the *certainty* of that failure on PostgreSQL; it does not remove the latch.

That is tracked separately in #4034, with the repro and the proposed fix (swap the bespoke block for the existing `addEntityToApplicationForSchema` helper, as virtual and query entities already do). Keeping it out keeps this PR to one statement plus a doc comment, which is what CI has verified.

The changeset has been corrected to describe only what this diff contains — an earlier revision described the helper swap that is not in it. The branch name (`fix/application-latch-never-reopens`) predates that narrowing and now over-describes the change; the title and body are authoritative.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

