### PR TITLE
5.51.1 security backport: #3410 + #3428 + #3633 onto lts/5

### DIFF
--- a/.changeset/backport-sql-injection-jwt-and-api-key-hardening.md
+++ b/.changeset/backport-sql-injection-jwt-and-api-key-hardening.md
@@ -1,0 +1,30 @@
+---
+"@memberjunction/global": patch
+"@memberjunction/core": patch
+"@memberjunction/server": patch
+"@memberjunction/generic-database-provider": patch
+"@memberjunction/ai-mcp-server": patch
+---
+
+security: validate and escape user-supplied values in SQL text-building paths, pin JWT algorithms, and compare the system API key in constant time
+
+Two upstream security commits landed without changesets; this records them for the release notes. All changes are additive/defensive and preserve existing behavior for legitimate inputs.
+
+**SQL filter validation (`@memberjunction/global`, `@memberjunction/core`, `@memberjunction/generic-database-provider`).**
+
+- `RunView`'s `ExcludeUserViewRunID` — a GraphQL string input — was interpolated raw into the view `WHERE` clause with no validation, unlike every sibling clause (`ExtraFilter`, `UserSearchString`, `OverrideExcludeFilter` all pass through `ValidateUserProvidedSQLClause`). The value is only ever a `UserViewRun` GUID, so it is now rejected unless it is a well-formed GUID, closing an authenticated injection sink that bypassed entity permissions and row-level security.
+- `DatabaseProviderBase.ValidateUserProvidedSQLClause` now denies `WAITFOR`, the time-based blind-injection vector. No legitimate filter or order-by clause uses it, and the intended subquery capability of `ExtraFilter` is unaffected.
+- `SQLExpressionValidator` now denies references to database system catalogs and metadata objects (`sys.*`, `INFORMATION_SCHEMA`, `syslogins`, `pg_catalog.*`, `pg_authid`/`pg_shadow`/`pg_user`/`pg_roles`) in **all** validation contexts, including `full_query`. These objects sit outside MemberJunction's entity-permission model, so permitting them turned a validated `SELECT` into a schema-enumeration and credential-exfiltration primitive. String literals are stripped before the check runs, so a literal value such as `'sys.x'` is still allowed.
+
+**Value escaping and parameterization (`@memberjunction/server`, `@memberjunction/core`, `@memberjunction/generic-database-provider`).**
+
+- `ReportResolver.CreateReportFromConversationDetailID` now binds `ConversationDetailID` through a parameterized `mssql` request as a `UniqueIdentifier` instead of interpolating it into the query string.
+- `GenericDatabaseProvider.CheckRecordRLS` now escapes embedded single quotes in primary-key values before building its `WHERE` clause, mirroring the escaping already present in the `Load()` path.
+- `RowLevelSecurityFilterInfo.MarkupFilterText` now escapes embedded single quotes in substituted user-property values, and treats `undefined` the same as `null`/object — leaving the token unresolved instead of substituting the literal string `"undefined"`.
+
+**Authentication hardening (`@memberjunction/server`, `@memberjunction/ai-mcp-server`).**
+
+- The superadmin `MJ_API_KEY` comparison in `getUserPayload` was a plain `===`, which short-circuits on the first differing byte and leaks a timing side channel. Both sides are now hashed to fixed-length SHA-256 digests and compared with `timingSafeEqual`.
+- JWT verification now explicitly pins the accepted signature algorithms to the asymmetric family (`RS256`/`RS384`/`RS512`, `ES256`/`ES384`/`ES512`, `PS256`) on both MJServer's issuer path and MCPServer's JWKS path — defense in depth against `alg=none` and RS256-to-HS256 confusion.
+
+Regression suites in each affected package pin the new behavior.

--- a/.changeset/harden-sql-filter-oauth-and-domain-gate.md
+++ b/.changeset/harden-sql-filter-oauth-and-domain-gate.md
@@ -1,0 +1,28 @@
+---
+"@memberjunction/global": patch
+"@memberjunction/core": patch
+"@memberjunction/server": patch
+"@memberjunction/api-keys": patch
+---
+
+security: harden SQL-filter validation, the OAuth callback handler, API-key lookup, and the new-user domain gate
+
+**SQL literal stripping (`@memberjunction/global`, `@memberjunction/core`).** Both of MJ's SQL screens — `DatabaseProviderBase.ValidateUserProvidedSQLClause` (which guards `ExtraFilter`, `OrderBy` and `UserSearchString`) and `SQLExpressionValidator` (which guards `Aggregates` and ad-hoc queries) — stripped string literals with a regex that honored **backslash escaping**. SQL Server and PostgreSQL do not treat `\` as an escape, so a payload such as `x = 'a\') ; DROP TABLE Users; --'` was swallowed whole as one "literal" and stripped away before the keyword denylist ran, while the database closed the literal at the real quote and executed the stacked statement. Both screens now share a single `StripSQLStringLiterals` helper that matches SQL-standard doubled-quote (`''`) semantics, and a regression suite in each package pins the behavior.
+
+**OAuth callback handler (`@memberjunction/server`).** Caller-supplied `connectionId` was interpolated into a raw `ExtraFilter` without escaping; it is now validated as a UUID at the request boundary and escaped at the SQL sink. `frontendReturnUrl` was redirected to after only a URL-parse check, making the callback an open redirect from the trusted MJAPI origin; its origin is now validated against `cors.allowedOrigins` (plus the built-in redirect origins) both when the flow is initiated and when the redirect is issued.
+
+If you run frontends other than MJExplorer against MJAPI, note that the return-URL allowlist is derived from `cors.allowedOrigins`. Deployments on the default `['*']` are unaffected — every return URL is still allowed. Deployments that have narrowed `cors.allowedOrigins` are mostly self-protecting, since a browser frontend must already be on that list to call `/oauth/initiate` at all, but three cases can now fall back to MJAPI's built-in page instead of returning to the app: a return URL on a *different* origin than the caller, a server-to-server initiate whose return origin was never CORS-listed, and any proxy setup where the browser-visible origin differs from the configured one (matching is exact on scheme + host + port). Each rejection is logged with the offending URL.
+
+**API-key lookup (`@memberjunction/api-keys`).** `ValidateKeyByHash` now asserts its argument is a SHA-256 hex digest before building the SQL filter, enforcing the injection-safety invariant at the sink for all present and future callers.
+
+**⚠️ Behavior change — `userHandling.newUserAuthorizedDomains`.** The new-user domain gate previously authorized against the hostname parsed from the request's `Origin` header, which is trivially spoofable on non-browser requests: a holder of any valid IdP token could auto-provision an account under an authorized domain by forging `Origin`. It now authorizes against the **email domain of the verified identity token**.
+
+If `newUserLimitedToAuthorizedDomains` is enabled, review `newUserAuthorizedDomains` before upgrading:
+
+- Entries that are **frontend hostnames** (`app.example.com`, `localhost`) must be replaced with the **email domains** your users sign in with (`example.com`). Deployments where the two happened to coincide are unaffected.
+- Wildcards match in full, so `*.example.com` matches `mail.example.com` but **not** `example.com` — list both if you need both.
+- Identity providers that issue a bare username with no `email` claim can no longer auto-provision; the denial is logged explicitly. Configure the provider to emit an `email` claim, or set `newUserLimitedToAuthorizedDomains: false`.
+
+The gate is off by default (`newUserLimitedToAuthorizedDomains: false`, `newUserAuthorizedDomains: []`), so deployments that never enabled it are unaffected.
+
+**⚠️ Related expansion — MCP OAuth auto-provisioning.** Auto-provisioning previously also required a non-empty request `Origin` as a precondition for entering the check at all. `MCPServer`'s `resolveOAuthUser` passes no request domain, so with the domain gate enabled, MCP OAuth users could never be auto-created regardless of their email domain. Now that the spoofable precondition is gone, an MCP OAuth user whose **JWKS-verified** token carries an authorized email domain plus given/family name claims **will** be auto-provisioned, consistent with the browser path. If you run MCP with `newUserLimitedToAuthorizedDomains` enabled and were relying on that side effect to keep MJ user records from being created, add the restriction explicitly (narrow `newUserAuthorizedDomains`, or set `autoCreateNewUsers: false`).

--- a/docker/MJAPI/docker.config.cjs
+++ b/docker/MJAPI/docker.config.cjs
@@ -176,6 +176,8 @@ const mjServerConfig = {
   userHandling: {
     autoCreateNewUsers: process.env.AUTO_CREATE_NEW_USERS ? process.env.AUTO_CREATE_NEW_USERS === 1 : false,
     newUserLimitedToAuthorizedDomains: false,
+    // Authorized EMAIL domains for auto-provisioned users, e.g. ['example.com', '*.example.org'].
+    // Matched against the email domain of the verified identity token — NOT the browser Origin.
     newUserAuthorizedDomains: [],
     newUserRoles: ['UI'],
     updateCacheWhenNotFound: true,

--- a/packages/AI/MCPServer/src/auth/TokenValidator.ts
+++ b/packages/AI/MCPServer/src/auth/TokenValidator.ts
@@ -433,6 +433,10 @@ async function verifyTokenSignature(
   return new Promise((resolve, reject) => {
     const verifyOptions: jwt.VerifyOptions = {
       clockTolerance: 30, // Allow 30 seconds of clock skew
+      // SECURITY: pin the accepted signature algorithms to the asymmetric family. The signing
+      // key is resolved from the issuer's JWKS (an RSA/EC public key); an explicit allow-list
+      // prevents `alg=none` and RS256->HS256 confusion attacks should the key format change.
+      algorithms: ['RS256', 'RS384', 'RS512', 'ES256', 'ES384', 'ES512', 'PS256'],
     };
 
     // jwt.verify() natively accepts string | string[] for audience.

--- a/packages/APIKeys/Engine/src/APIKeyEngine.ts
+++ b/packages/APIKeys/Engine/src/APIKeyEngine.ts
@@ -703,6 +703,12 @@ export class APIKeyEngine {
         hash: string,
         contextUser: UserInfo
     ): Promise<KeyHashValidationResult> {
+        // The hash is always a SHA-256 hex digest. Enforce that at this public entry point so the
+        // guarantee holds at the SQL sink (ExtraFilter is a raw SQL fragment) regardless of caller —
+        // a non-conforming value can never carry a quote and therefore cannot inject.
+        if (!/^[a-f0-9]{64}$/i.test(hash)) {
+            return { Valid: false, Reason: 'API key not found' };
+        }
         const rv = new RunView();
         const result = await rv.RunView<MJAPIKeyEntity>({
             EntityName: 'MJ: API Keys',

--- a/packages/GenericDatabaseProvider/src/GenericDatabaseProvider.ts
+++ b/packages/GenericDatabaseProvider/src/GenericDatabaseProvider.ts
@@ -1574,8 +1574,17 @@ export abstract class GenericDatabaseProvider extends DatabaseProviderBase {
                 let sExcludeSQL = `${this.QuoteIdentifier(entityInfo.FirstPrimaryKey?.Name ?? 'ID')} NOT IN (SELECT RecordID FROM ${this.QuoteSchemaAndView(this.MJCoreSchemaName, 'vwUserViewRunDetails')} WHERE EntityID='${viewEntity?.EntityID}' AND`;
                 if (params.ExcludeDataFromAllPriorViewRuns === true)
                     sExcludeSQL += ` UserViewID=${viewEntity?.ID})`;
-                else
+                else {
+                    // SECURITY: excludeUserViewRunID is user-supplied (GraphQL input) and is
+                    // interpolated directly into SQL here. Unlike ExtraFilter/UserSearchString/
+                    // OverrideExcludeFilter (all passed through ValidateUserProvidedSQLClause),
+                    // this value historically had NO validation — allowing SQL injection into the
+                    // view WHERE clause. It is only ever a UserViewRun.ID (a GUID), so reject
+                    // anything that is not a well-formed GUID before it reaches the query.
+                    if (!/^[0-9A-Fa-f]{8}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{12}$/.test(excludeUserViewRunID))
+                        throw new Error(`Invalid ExcludeUserViewRunID: must be a GUID`);
                     sExcludeSQL += ` UserViewRunID=${excludeUserViewRunID})`;
+                }
 
                 if (overrideExcludeFilter.length > 0) {
                     if (!this.ValidateUserProvidedSQLClause(overrideExcludeFilter))

--- a/packages/GenericDatabaseProvider/src/GenericDatabaseProvider.ts
+++ b/packages/GenericDatabaseProvider/src/GenericDatabaseProvider.ts
@@ -3904,7 +3904,9 @@ export abstract class GenericDatabaseProvider extends DatabaseProviderBase {
         const pkWhere = entity.PrimaryKeys.map(pk => {
             const fieldInfo = entityInfo.FieldByName(pk.Name);
             const quotes = fieldInfo?.NeedsQuotes ? "'" : '';
-            return `${this.QuoteIdentifier(pk.Name)}=${quotes}${pk.Value}${quotes}`;
+            // Escape embedded single quotes when the value is wrapped in quotes — see Load() above.
+            const safeVal = quotes ? String(pk.Value).replace(/'/g, "''") : pk.Value;
+            return `${this.QuoteIdentifier(pk.Name)}=${quotes}${safeVal}${quotes}`;
         }).join(' AND ');
 
         const sql = `SELECT COUNT(*) AS cnt FROM ${this.QuoteSchemaAndView(entityInfo.SchemaName, entityInfo.BaseView)} WHERE ${pkWhere} AND (${rlsWhereClause})`;

--- a/packages/GenericDatabaseProvider/src/__tests__/GenericDatabaseProvider.test.ts
+++ b/packages/GenericDatabaseProvider/src/__tests__/GenericDatabaseProvider.test.ts
@@ -643,6 +643,56 @@ describe('GenericDatabaseProvider', () => {
             }).CheckRecordRLS(entity, mockUser, 'Read');
             expect(result).toBe(true);
         });
+
+        it('escapes embedded single quotes in the primary key value instead of splicing them into the WHERE clause', async () => {
+            const entityInfo = {
+                SchemaName: 'dbo',
+                BaseView: 'vwTestEntities',
+                UserExemptFromRowLevelSecurity: () => false,
+                GetUserRowLevelSecurityWhereClause: () => "OwnerID = '42'",
+                FieldByName: () => ({ NeedsQuotes: true }) as unknown as ReturnType<EntityInfo['FieldByName']>,
+            } as unknown as EntityInfo;
+            const entity = {
+                EntityInfo: entityInfo,
+                PrimaryKeys: [{ Name: 'ID', Value: "abc' OR '1'='1", NeedsQuotes: true }],
+            } as unknown as BaseEntity;
+
+            provider.executeSQLResults = [[{ cnt: 0 }]];
+
+            await (provider as unknown as {
+                CheckRecordRLS: (e: BaseEntity, u: UserInfo, t: string) => Promise<boolean>;
+            }).CheckRecordRLS(entity, mockUser, 'Read');
+
+            const sql = provider.executeSQLCalls[0].sql;
+            // The apostrophe must be doubled (SQL-escaped), not left to close the string early —
+            // structure check: the OR clause must NOT be a bare, un-quoted SQL predicate.
+            expect(sql).toContain("'abc'' OR ''1''=''1'");
+            expect(sql).not.toContain("='abc' OR '1'='1'");
+        });
+
+        it('does not alter query structure for PK values containing --, quotes, or OR 1=1', async () => {
+            const entityInfo = {
+                SchemaName: 'dbo',
+                BaseView: 'vwTestEntities',
+                UserExemptFromRowLevelSecurity: () => false,
+                GetUserRowLevelSecurityWhereClause: () => "OwnerID = '42'",
+                FieldByName: () => ({ NeedsQuotes: true }) as unknown as ReturnType<EntityInfo['FieldByName']>,
+            } as unknown as EntityInfo;
+            const entity = {
+                EntityInfo: entityInfo,
+                PrimaryKeys: [{ Name: 'ID', Value: "x'; --", NeedsQuotes: true }],
+            } as unknown as BaseEntity;
+
+            provider.executeSQLResults = [[{ cnt: 1 }]];
+
+            await (provider as unknown as {
+                CheckRecordRLS: (e: BaseEntity, u: UserInfo, t: string) => Promise<boolean>;
+            }).CheckRecordRLS(entity, mockUser, 'Read');
+
+            const sql = provider.executeSQLCalls[0].sql;
+            // Single WHERE ... AND (...) structure must be preserved — no comment-truncated clause.
+            expect(sql).toMatch(/WHERE "ID"='x''; --' AND \(OwnerID = '42'\)$/);
+        });
     });
 
     describe('AdjustDatetimeFields (default no-op)', () => {

--- a/packages/MJCLI/mj.config.cjs
+++ b/packages/MJCLI/mj.config.cjs
@@ -222,6 +222,8 @@ const mjServerConfig = {
   userHandling: {
     autoCreateNewUsers: true,
     newUserLimitedToAuthorizedDomains: false,
+    // Authorized EMAIL domains for auto-provisioned users, e.g. ['example.com', '*.example.org'].
+    // Matched against the email domain of the verified identity token — NOT the browser Origin.
     newUserAuthorizedDomains: [],
     newUserRoles: ['UI', 'Developer'],
     updateCacheWhenNotFound: true,

--- a/packages/MJCore/src/__tests__/databaseProviderBase.test.ts
+++ b/packages/MJCore/src/__tests__/databaseProviderBase.test.ts
@@ -30,6 +30,11 @@ class TestSQLServerProvider extends DatabaseProviderBase {
         throw new Error('Not supported.');
     }
 
+    /** Test-only passthrough — ValidateUserProvidedSQLClause is protected on the base class. */
+    public TestValidateUserProvidedSQLClause(clause: string): boolean {
+        return this.ValidateUserProvidedSQLClause(clause);
+    }
+
     // RLS test hooks
     public checkRecordRLSResult = true;
     public checkCreateRLSResult = true;
@@ -302,6 +307,85 @@ describe('DatabaseProviderBase', () => {
             // Replay returns entity.GetAll() which has data, so ValidateDeleteResult runs
             // (but our mock may not satisfy it fully; the key thing is RLS didn't block it)
             expect(result).toBeDefined();
+        });
+    });
+
+    /**
+     * 🚨 SECURITY REGRESSION SUITE — ValidateUserProvidedSQLClause screens caller-supplied
+     * `ExtraFilter` / `OrderBy` / `UserSearchString` fragments, which are raw SQL. It strips string
+     * literals and then applies a keyword denylist, so the ONLY thing standing between a hostile
+     * filter and the database is that the stripper agrees with the database about where literals
+     * begin and end.
+     *
+     * The bypass these tests pin: the stripper once honored backslash escaping, which SQL Server and
+     * PostgreSQL do not. A payload could hide an entire stacked statement inside a fake "literal".
+     * If someone reintroduces backslash handling — here or in StripSQLStringLiterals — these fail.
+     */
+    describe('ValidateUserProvidedSQLClause — injection screening', () => {
+        let provider: TestSQLServerProvider;
+
+        beforeEach(() => {
+            provider = new TestSQLServerProvider();
+        });
+
+        describe('rejects backslash-hidden payloads (the stripper/parser mismatch)', () => {
+            // The trailing `'` makes the quote count even, so a backslash-aware stripper swallows
+            // the whole payload. The database closes the literal at the FIRST unescaped quote and
+            // executes what follows.
+            it('rejects a stacked DROP hidden behind a backslash', () => {
+                expect(
+                    provider.TestValidateUserProvidedSQLClause(`FirstName = 'a\\') ; DROP TABLE Users; --'`)
+                ).toBe(false);
+            });
+
+            it('rejects a time-based WAITFOR hidden behind a backslash', () => {
+                expect(
+                    provider.TestValidateUserProvidedSQLClause(`ID = 'x\\') ; WAITFOR DELAY '0:0:5'; --'`)
+                ).toBe(false);
+            });
+
+            it('rejects a stacked UPDATE hidden behind a backslash', () => {
+                expect(
+                    provider.TestValidateUserProvidedSQLClause(`Name = 'a\\') ; UPDATE Users SET IsActive=1; --'`)
+                ).toBe(false);
+            });
+        });
+
+        describe('rejects plain injection attempts', () => {
+            it.each([
+                ['stacked statement', `Name = 'x'; DROP TABLE Users`],
+                ['line comment', `Name = 'x' -- rest`],
+                ['block comment', `Name = 'x' /* rest */`],
+                ['UNION', `Name = 'x' UNION SELECT 1`],
+                ['EXEC', `Name = 'x' EXEC sp_who`],
+                ['extended proc', `Name = 'x' AND xp_cmdshell 'dir' = 1`],
+                ['unterminated literal hiding a keyword', `Name = 'abc; DROP TABLE t`],
+                ['double-quoted identifier cannot hide a payload', `"Name") ; DROP TABLE Users; --"`],
+            ])('rejects %s', (_label, clause) => {
+                expect(provider.TestValidateUserProvidedSQLClause(clause)).toBe(false);
+            });
+        });
+
+        describe('accepts legitimate clauses (no false positives)', () => {
+            it.each([
+                ['keyword-looking text inside a literal', `Comments LIKE '%DROP TABLE%'`],
+                ['comment marker inside a literal', `Comments LIKE '%--%'`],
+                ['SQL-standard doubled quote', `Name = 'O''Brien'`],
+                ['doubled quote next to a denied keyword', `Note = 'it''s a delete; really'`],
+                ['backslash as ordinary data', `Path = 'C:\\temp\\'`],
+                ['simple comparison', `IsActive = 1`],
+                ['order by', `CreatedAt DESC, Name ASC`],
+                ['IN list', `Status IN ('Active', 'Pending')`],
+            ])('accepts %s', (_label, clause) => {
+                expect(provider.TestValidateUserProvidedSQLClause(clause)).toBe(true);
+            });
+        });
+
+        it('is linear-time on a long unterminated literal (no catastrophic backtracking)', () => {
+            const clause = `Name = '${'a'.repeat(50000)}`;
+            const start = Date.now();
+            provider.TestValidateUserProvidedSQLClause(clause);
+            expect(Date.now() - start).toBeLessThan(1000);
         });
     });
 });

--- a/packages/MJCore/src/__tests__/securityInfo.test.ts
+++ b/packages/MJCore/src/__tests__/securityInfo.test.ts
@@ -230,6 +230,42 @@ describe('RowLevelSecurityFilterInfo', () => {
             // Date is typeof 'object', so it should be skipped
             expect(result).toBe("X = '{{User__mj_CreatedAt}}'");
         });
+
+        it('should skip undefined values leaving token unresolved, not stringify as "undefined"', () => {
+            const filter = new RowLevelSecurityFilterInfo({
+                FilterText: "X = '{{UserEmployeeID}}'"
+            });
+            const user = new UserInfo(null, { EmployeeID: undefined });
+
+            const result = filter.MarkupFilterText(user);
+
+            expect(result).toBe("X = '{{UserEmployeeID}}'");
+            expect(result).not.toContain('undefined');
+        });
+
+        it('should not become permissive on negation-shaped filters when a value is undefined', () => {
+            const filter = new RowLevelSecurityFilterInfo({
+                FilterText: "Status <> '{{UserEmployeeID}}'"
+            });
+            const user = new UserInfo(null, { EmployeeID: undefined });
+
+            const result = filter.MarkupFilterText(user);
+
+            // Previously this substituted the literal string 'undefined', which a <> comparison
+            // would satisfy for virtually every row. It must stay unresolved instead.
+            expect(result).toBe("Status <> '{{UserEmployeeID}}'");
+        });
+
+        it('should escape embedded single quotes in substituted values', () => {
+            const filter = new RowLevelSecurityFilterInfo({
+                FilterText: "LastName = '{{UserLastName}}'"
+            });
+            const user = new UserInfo(null, { LastName: "O'Brien'; DROP TABLE Users; --" });
+
+            const result = filter.MarkupFilterText(user);
+
+            expect(result).toBe("LastName = 'O''Brien''; DROP TABLE Users; --'");
+        });
     });
 });
 

--- a/packages/MJCore/src/generic/databaseProviderBase.ts
+++ b/packages/MJCore/src/generic/databaseProviderBase.ts
@@ -10,7 +10,7 @@ import { LogError } from "./logging";
 import { AggregateResult, EntityRecordNameInput, EntityRecordNameResult, RunReportResult, RunQueryResult } from "./interfaces";
 import { QueryExecutionSpec } from "./queryExecutionSpec";
 import { RunReportParams } from "./runReport";
-import { SQLExpressionValidator, uuidv4 } from "@memberjunction/global";
+import { SQLExpressionValidator, StripSQLStringLiterals, uuidv4 } from "@memberjunction/global";
 import { GetDialect, SQLDialect } from "@memberjunction/sql-dialect";
 
 // Re-export PlatformSQL types from their canonical location for backward compatibility
@@ -981,9 +981,13 @@ export abstract class DatabaseProviderBase extends ProviderBase {
      * @returns true if the clause is safe, false if it contains forbidden patterns
      */
     protected ValidateUserProvidedSQLClause(clause: string): boolean {
-        // Remove string literals to avoid false positives
-        const stringLiteralPattern = /(['"])(?:(?=(\\?))\2[\s\S])*?\1/g;
-        const clauseWithoutStrings = clause.replace(stringLiteralPattern, '');
+        // Remove string literals to avoid false positives.
+        //
+        // 🚨 SECURITY: this uses the SHARED stripper in @memberjunction/global. It must match how
+        // SQL Server / PostgreSQL actually parse literals — see StripSQLStringLiterals for the full
+        // rationale and the backslash-escape bypass it exists to prevent. Do NOT inline a regex here;
+        // an inline copy is exactly how this screen and SQLExpressionValidator drifted apart before.
+        const clauseWithoutStrings = StripSQLStringLiterals(clause);
         const lowerClause = clauseWithoutStrings.toLowerCase();
 
         const forbiddenPatterns: RegExp[] = [

--- a/packages/MJCore/src/generic/databaseProviderBase.ts
+++ b/packages/MJCore/src/generic/databaseProviderBase.ts
@@ -990,6 +990,8 @@ export abstract class DatabaseProviderBase extends ProviderBase {
             /\binsert\b/, /\bupdate\b/, /\bdelete\b/,
             /\bexec\b/, /\bexecute\b/, /\bdrop\b/,
             /--/, /\/\*/, /\*\//, /\bunion\b/, /\bxp_/, /;/,
+            // Time-based blind injection vector — no legitimate filter/order-by clause uses WAITFOR.
+            /\bwaitfor\b/,
         ];
 
         for (const pattern of forbiddenPatterns) {

--- a/packages/MJCore/src/generic/securityInfo.ts
+++ b/packages/MJCore/src/generic/securityInfo.ts
@@ -467,8 +467,9 @@ export class RowLevelSecurityFilterInfo extends BaseInfo {
             for (let i = 0; i < keys.length; i++) {
                 const key = keys[i];
                 const val = (user as unknown as Record<string, unknown>)[key]
-                if (val !== null && typeof val !== 'object') {
-                    ret = ret.replace(new RegExp(`{{User${key}}}`, 'g'), String(val))
+                if (val !== null && val !== undefined && typeof val !== 'object') {
+                    const safeVal = String(val).replace(/'/g, "''")
+                    ret = ret.replace(new RegExp(`{{User${key}}}`, 'g'), safeVal)
                 }
             }
             // Per-session magic-link resource scope. Fail-closed: an absent scope resolves

--- a/packages/MJGlobal/src/SQLExpressionValidator.ts
+++ b/packages/MJGlobal/src/SQLExpressionValidator.ts
@@ -98,6 +98,46 @@ export const BLOCKED_SYSTEM_OBJECT_PATTERNS: RegExp[] = [
 ];
 
 /**
+ * Matches SQL string literals the way SQL Server and PostgreSQL (with the default
+ * `standard_conforming_strings=on`) actually parse them: a literal is closed by the next
+ * single quote, `''` is an embedded quote, and a backslash is an ORDINARY character that
+ * does NOT escape the closing quote. Double-quoted runs are matched with the same doubling
+ * rule so a delimited identifier can't hide a payload either.
+ *
+ * @see StripSQLStringLiterals — use that, not this constant, so every caller gets the
+ * documented semantics and the two validators in MJ can never drift apart again.
+ */
+const SQL_STRING_LITERAL_PATTERN = /'(?:[^']|'')*'|"(?:[^"]|"")*"/g;
+
+/**
+ * Removes SQL string literals from a clause or expression so that a keyword denylist can be
+ * applied to the *code* portion without tripping over keywords that appear inside quoted data
+ * (e.g. `Comments LIKE '%--%'`).
+ *
+ * 🚨 SECURITY — this is the single implementation of literal-stripping for MJ's SQL screens, and
+ * it MUST stay byte-for-byte consistent with how the database parses literals. If the stripper
+ * removes a span the database does NOT treat as a literal, everything hidden inside that span
+ * bypasses the denylist while the database still executes it.
+ *
+ * An earlier version of this logic (duplicated in two places, which is how it survived) honored
+ * **backslash escaping** — `/(['"])(?:(?=(\\?))\2[\s\S])*?\1/g`. SQL Server and PostgreSQL do not
+ * treat `\` as an escape character, so `x = 'a\') ; DROP TABLE Users; --'` was swallowed whole as
+ * one "literal" and stripped to `x = `, which passed every denylist — while the database closed
+ * the literal at the real quote and executed the stacked statement.
+ *
+ * **Do NOT reintroduce backslash-escape handling here, and do NOT inline a second copy of this
+ * regex anywhere else — call this function.**
+ *
+ * @param sql The clause, expression, or query to strip literals from
+ * @returns The input with every complete string literal removed. An UNTERMINATED literal is left
+ *          in place on purpose: the stray quote and everything after it stay visible to the
+ *          denylist rather than being silently swallowed.
+ */
+export function StripSQLStringLiterals(sql: string): string {
+  return sql.replace(SQL_STRING_LITERAL_PATTERN, '');
+}
+
+/**
  * Safe SQL functions allowed in expressions, organized by category
  */
 export const ALLOWED_SQL_FUNCTIONS = {
@@ -257,12 +297,12 @@ export class SQLExpressionValidator extends BaseSingleton<SQLExpressionValidator
 
   /**
    * Remove string literals to avoid false positives in keyword detection.
-   * Handles both single and double quoted strings with escaped quotes.
+   *
+   * 🚨 SECURITY: delegates to {@link StripSQLStringLiterals} — read the warning there before
+   * changing anything about how literals are matched. This must never grow its own regex again.
    */
   private removeStringLiterals(expression: string): string {
-    // Match both single and double quoted strings, handling escaped quotes
-    const stringPattern = /(['"])(?:(?=(\\?))\2[\s\S])*?\1/g;
-    return expression.replace(stringPattern, '');
+    return StripSQLStringLiterals(expression);
   }
 
   /**

--- a/packages/MJGlobal/src/SQLExpressionValidator.ts
+++ b/packages/MJGlobal/src/SQLExpressionValidator.ts
@@ -81,6 +81,23 @@ export const FULL_QUERY_ALLOWED_KEYWORDS = [
 ] as const;
 
 /**
+ * System catalog / metadata objects that must never be referenced from a user-supplied
+ * expression or ad-hoc query, in ANY context (including `full_query`). These sit outside
+ * MemberJunction's entity-permission model, so allowing them turns a validated SELECT into
+ * a schema-enumeration and credential-exfiltration primitive
+ * (e.g. `SELECT name, password_hash FROM sys.sql_logins`,
+ *  `SELECT * FROM INFORMATION_SCHEMA.COLUMNS`, `SELECT * FROM pg_catalog.pg_authid`).
+ * String literals are stripped before this check runs, so a literal value like `'sys.x'` is safe.
+ */
+export const BLOCKED_SYSTEM_OBJECT_PATTERNS: RegExp[] = [
+  /\bSYS\s*\.\s*\w/i,                      // SQL Server system catalog schema: sys.sql_logins, sys.objects, sys.fn_*, ...
+  /\bINFORMATION_SCHEMA\b/i,               // ANSI catalog views — schema/table/column enumeration
+  /\bSYSLOGINS\b/i,                        // legacy SQL Server logins view
+  /\bPG_CATALOG\s*\./i,                    // PostgreSQL system catalog schema
+  /\bPG_(AUTHID|SHADOW|USER|ROLES)\b/i,    // PostgreSQL credential / role catalogs
+];
+
+/**
  * Safe SQL functions allowed in expressions, organized by category
  */
 export const ALLOWED_SQL_FUNCTIONS = {
@@ -297,6 +314,20 @@ export class SQLExpressionValidator extends BaseSingleton<SQLExpressionValidator
           error: `Dangerous SQL keyword detected: ${keyword}`,
           trigger: keyword,
           suggestion: keyword === 'SELECT' ? 'Subqueries are not allowed. Use a direct expression instead.' : undefined
+        };
+      }
+    }
+
+    // Block references to database system catalogs / metadata objects in ALL contexts
+    // (including full_query). These live outside MemberJunction's entity-permission model, so
+    // permitting them turns a validated SELECT into a schema-enumeration / credential-exfiltration
+    // primitive. String literals were already stripped upstream, so legitimate literal values are safe.
+    for (const sysPattern of BLOCKED_SYSTEM_OBJECT_PATTERNS) {
+      if (sysPattern.test(textToCheck)) {
+        return {
+          valid: false,
+          error: 'Access to database system catalogs / metadata objects is not allowed',
+          trigger: 'system-object'
         };
       }
     }

--- a/packages/MJGlobal/src/__tests__/SQLExpressionValidator.security.test.ts
+++ b/packages/MJGlobal/src/__tests__/SQLExpressionValidator.security.test.ts
@@ -26,17 +26,33 @@ describe('SQLExpressionValidator - Security', () => {
       expect(r.trigger).toBe('DROP');
     });
 
-    it('should block UNION-based data exfiltration', () => {
-      // This is valid in full_query because UNION is allowed—
-      // BUT it must still start with SELECT. The attack vector here
-      // is actually fine for full_query (UNION is legitimate).
-      // The real guard is that only SELECT queries can be submitted.
+    it('should block UNION-based data exfiltration from system catalogs', () => {
+      // UNION itself is legitimate in full_query, but reading SQL Server system catalogs
+      // (sys.sql_logins holds login password hashes) sits entirely outside MJ's
+      // entity-permission model. The system-object denylist rejects it regardless of the
+      // read-only connection, so a validated ad-hoc SELECT can't be used to exfiltrate credentials.
       const r = validator.validateFullQuery(
         "SELECT 1 UNION SELECT password FROM sys.sql_logins"
       );
-      // UNION is allowed in full_query, so this is valid from a syntax perspective.
-      // The protection is that ad-hoc queries run on a read-only connection.
+      expect(r.valid).toBe(false);
+      expect(r.trigger).toBe('system-object');
+    });
+
+    it('should still allow a legitimate UNION over application views', () => {
+      // Regression guard: the system-catalog denylist must NOT block ordinary UNION queries
+      // over application entity views — only true system/metadata objects are rejected.
+      const r = validator.validateFullQuery(
+        "SELECT ID FROM vwCustomers UNION SELECT ID FROM vwProspects"
+      );
       expect(r.valid).toBe(true);
+    });
+
+    it('should block INFORMATION_SCHEMA enumeration', () => {
+      const r = validator.validateFullQuery(
+        "SELECT TABLE_NAME FROM INFORMATION_SCHEMA.TABLES"
+      );
+      expect(r.valid).toBe(false);
+      expect(r.trigger).toBe('system-object');
     });
 
     it('should block stacked DELETE after SELECT', () => {

--- a/packages/MJGlobal/src/__tests__/SQLExpressionValidator.security.test.ts
+++ b/packages/MJGlobal/src/__tests__/SQLExpressionValidator.security.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach } from 'vitest';
-import { SQLExpressionValidator } from '../SQLExpressionValidator';
+import { SQLExpressionValidator, StripSQLStringLiterals } from '../SQLExpressionValidator';
 
 /**
  * Adversarial security tests for SQLExpressionValidator.
@@ -258,6 +258,78 @@ describe('SQLExpressionValidator - Security', () => {
       expect(r.valid).toBe(false);
       // DROP is detected before semicolon in the keyword scan
       expect(r.trigger).toBe('DROP');
+    });
+  });
+
+  // ---------------------------------------------------------------
+  // Literal-stripper / parser agreement
+  // ---------------------------------------------------------------
+  /**
+   * 🚨 The stripper runs BEFORE every other check (keyword denylist, function allowlist,
+   * system-object denylist), so anything it wrongly treats as "inside a literal" is invisible to
+   * all of them — while the database, which does not agree, still executes it.
+   *
+   * SQL Server and PostgreSQL (standard_conforming_strings=on) do NOT treat `\` as an escape
+   * character. A stripper that honors `\'` swallows an entire stacked statement as one "literal".
+   * These tests pin that behavior; see StripSQLStringLiterals.
+   */
+  describe('literal stripper must match database parsing (backslash is NOT an escape)', () => {
+    it('strips a doubled-quote literal exactly, leaving injected code visible', () => {
+      expect(StripSQLStringLiterals(`Name = 'O''Brien'`)).toBe('Name = ');
+      expect(StripSQLStringLiterals(`x = 'a\\') ; DROP TABLE Users; --'`)).toContain('DROP TABLE Users');
+    });
+
+    it('leaves an UNTERMINATED literal in place rather than swallowing the rest', () => {
+      expect(StripSQLStringLiterals(`Name = 'abc; DROP TABLE t`)).toContain('DROP TABLE t');
+    });
+
+    it('does not over-strip across a double-quoted identifier', () => {
+      // The match must end at the closing quote of "Name", NOT run to the final quote.
+      expect(StripSQLStringLiterals(`"Name") ; DROP TABLE Users; --"`)).toContain('DROP TABLE Users');
+    });
+
+    it('blocks a backslash-hidden DROP in an aggregate expression', () => {
+      const r = validator.validate(`SUM(A)+'\\'; DROP TABLE Users; --'`, {
+        context: 'aggregate',
+        entityFields: ['A'],
+      });
+      expect(r.valid).toBe(false);
+    });
+
+    it('blocks a backslash-hidden DROP with no trailing comment', () => {
+      const r = validator.validate(`SUM(A)+'\\'; DROP TABLE Users; SELECT 1+'`, {
+        context: 'aggregate',
+        entityFields: ['A'],
+      });
+      expect(r.valid).toBe(false);
+      expect(r.trigger).toBe('DROP');
+    });
+
+    it('blocks a backslash-hidden WAITFOR in an aggregate expression', () => {
+      const r = validator.validate(`SUM(A)+'\\'; WAITFOR DELAY '0:0:5'; SELECT 1+'`, {
+        context: 'aggregate',
+        entityFields: ['A'],
+      });
+      expect(r.valid).toBe(false);
+    });
+
+    it('blocks a backslash-hidden stacked statement in a full query', () => {
+      const r = validator.validateFullQuery(`SELECT 'a'+'\\'; DROP TABLE Users; --' FROM T`);
+      expect(r.valid).toBe(false);
+    });
+
+    it('blocks backslash-hidden system-catalog exfiltration in a full query', () => {
+      // Read-only connections still make this a credential-disclosure primitive, which is
+      // exactly what the system-object denylist exists to stop.
+      const r = validator.validateFullQuery(
+        `SELECT 'a'+'\\'; SELECT name, password_hash FROM sys.sql_logins; --' FROM T`
+      );
+      expect(r.valid).toBe(false);
+    });
+
+    it('still allows legitimate literals containing backslashes', () => {
+      const r = validator.validateFullQuery(`SELECT * FROM __mj.vwFiles WHERE Path = 'C:\\temp\\'`);
+      expect(r.valid).toBe(true);
     });
   });
 

--- a/packages/MJServer/src/__tests__/OAuthCallbackHandler.openRedirect.test.ts
+++ b/packages/MJServer/src/__tests__/OAuthCallbackHandler.openRedirect.test.ts
@@ -1,0 +1,117 @@
+import { describe, it, expect } from 'vitest';
+import { OAuthCallbackHandler, OAuthCallbackHandlerOptions } from '../rest/OAuthCallbackHandler.js';
+
+/**
+ * The OAuth callback redirects to a caller-supplied `frontendReturnUrl`. Without an origin check
+ * that is an open redirect issued *from the trusted MJAPI origin* — a phishing primitive that
+ * inherits MJAPI's reputation and any origin-scoped trust a user or downstream system places in it.
+ *
+ * The guard is reached through a narrowly-typed view of the instance, following the same pattern as
+ * OAuthCallbackHandler.xss.test.ts (the method is private by design).
+ */
+interface RedirectGuard {
+    isFrontendReturnUrlAllowed(url: URL): boolean;
+    parseAllowedFrontendReturnUrl(frontendReturnUrl: string): URL | null;
+    isFrontendReturnUrlAcceptable(frontendReturnUrl: unknown): boolean;
+}
+
+const BASE_OPTIONS: Omit<OAuthCallbackHandlerOptions, 'allowedFrontendOrigins'> = {
+    publicUrl: 'https://api.example.test',
+    successRedirectUrl: 'https://api.example.test/oauth/success',
+    errorRedirectUrl: 'https://api.example.test/oauth/error',
+};
+
+function makeGuard(allowedFrontendOrigins: string[]): RedirectGuard {
+    const handler = new OAuthCallbackHandler({ ...BASE_OPTIONS, allowedFrontendOrigins });
+    return handler as unknown as RedirectGuard;
+}
+
+describe('OAuthCallbackHandler open-redirect protection', () => {
+    describe('with an explicit origin allowlist', () => {
+        const allowed = ['https://app.example.test', 'https://admin.example.test'];
+
+        it.each([
+            'https://evil.test/steal',
+            'https://app.example.test.evil.test/steal',
+            'http://app.example.test',            // scheme mismatch — origin includes the scheme
+            'https://app.example.test:8443',      // port mismatch — origin includes the port
+        ])('rejects %s', (url) => {
+            expect(makeGuard(allowed).parseAllowedFrontendReturnUrl(url)).toBeNull();
+        });
+
+        it.each([
+            'https://app.example.test/done',
+            'https://admin.example.test/oauth/landing?keep=1',
+        ])('allows %s', (url) => {
+            expect(makeGuard(allowed).parseAllowedFrontendReturnUrl(url)).not.toBeNull();
+        });
+
+        it('allows the built-in redirect origin even when it is not in the allowlist', () => {
+            // The success/error pages MJAPI itself serves must always remain reachable.
+            expect(
+                makeGuard(allowed).parseAllowedFrontendReturnUrl('https://api.example.test/oauth/success')
+            ).not.toBeNull();
+        });
+
+        it('rejects an unparseable URL', () => {
+            expect(makeGuard(allowed).parseAllowedFrontendReturnUrl('not-a-url')).toBeNull();
+        });
+
+        it('rejects a javascript: pseudo-URL', () => {
+            // Parses fine as a URL, but its origin is "null" and must not match an allowlist entry.
+            expect(makeGuard(allowed).parseAllowedFrontendReturnUrl('javascript:alert(1)')).toBeNull();
+        });
+    });
+
+    describe('allowlist edge values', () => {
+        it("allows any origin when the allowlist is ['*'] (MJ's default CORS posture)", () => {
+            expect(makeGuard(['*']).parseAllowedFrontendReturnUrl('https://evil.test/steal')).not.toBeNull();
+        });
+
+        it('an empty allowlist denies every external origin (fails closed)', () => {
+            expect(makeGuard([]).parseAllowedFrontendReturnUrl('https://app.example.test/done')).toBeNull();
+        });
+
+        it('an empty allowlist still permits the built-in redirect origin', () => {
+            // Otherwise MJAPI could not reach its own success/error pages.
+            expect(
+                makeGuard([]).parseAllowedFrontendReturnUrl('https://api.example.test/oauth/success')
+            ).not.toBeNull();
+        });
+    });
+
+    describe('request-boundary check used by /oauth/initiate', () => {
+        const guard = () => makeGuard(['https://app.example.test']);
+
+        it('accepts an allowed origin', () => {
+            expect(guard().isFrontendReturnUrlAcceptable('https://app.example.test/done')).toBe(true);
+        });
+
+        it('rejects a disallowed origin', () => {
+            expect(guard().isFrontendReturnUrlAcceptable('https://evil.test/steal')).toBe(false);
+        });
+
+        it.each([
+            ['an array', ['https://app.example.test/done']],
+            ['an object', { url: 'https://app.example.test/done' }],
+            ['a number', 42],
+        ])('rejects %s rather than coercing it', (_label, value) => {
+            expect(guard().isFrontendReturnUrlAcceptable(value)).toBe(false);
+        });
+
+        /**
+         * REGRESSION GUARD: frontendReturnUrl is optional, and every downstream consumer decides
+         * whether to use it with a truthiness check. If this boundary check rejected absent values,
+         * a client that omits the field — or sends null / "" for it, which is what an unset form
+         * field and most serializers produce — would start getting a 400 on a request that has
+         * always worked. Absent means "no return URL", not "invalid return URL".
+         */
+        it.each([
+            ['undefined', undefined],
+            ['null', null],
+            ['an empty string', ''],
+        ])('accepts %s — an absent return URL is not an invalid one', (_label, value) => {
+            expect(guard().isFrontendReturnUrlAcceptable(value)).toBe(true);
+        });
+    });
+});

--- a/packages/MJServer/src/__tests__/OAuthCallbackHandler.xss.test.ts
+++ b/packages/MJServer/src/__tests__/OAuthCallbackHandler.xss.test.ts
@@ -16,7 +16,10 @@ interface PageRenderer {
 }
 
 function makeRenderer(): PageRenderer {
-    const handler = new OAuthCallbackHandler({ publicUrl: 'https://example.test' });
+    const handler = new OAuthCallbackHandler({
+        publicUrl: 'https://example.test',
+        allowedFrontendOrigins: ['*'],
+    });
     return handler as unknown as PageRenderer;
 }
 

--- a/packages/MJServer/src/__tests__/newUsers.test.ts
+++ b/packages/MJServer/src/__tests__/newUsers.test.ts
@@ -74,7 +74,10 @@ const {
 
 vi.mock('../config.js', () => ({ configInfo: mockConfig }));
 
-vi.mock('@memberjunction/generic-database-provider', () => {
+// On the 5.x line UserCache is exported by @memberjunction/sqlserver-dataprovider, not
+// generic-database-provider — mocking it here is what keeps the real SQLServerDataProvider
+// (and its mssql-dependent config module) out of the module graph.
+vi.mock('@memberjunction/sqlserver-dataprovider', () => {
     const instance = {
         UserByName: mockUserByName,
         get Users() {

--- a/packages/MJServer/src/__tests__/newUsers.test.ts
+++ b/packages/MJServer/src/__tests__/newUsers.test.ts
@@ -1,0 +1,726 @@
+/**
+ * Tests for the new-user provisioning flow:
+ *
+ *  - NewUserBase.createNewUser (auth/newUsers.ts): context-user resolution,
+ *    field mapping, transactional role / application / application-entity
+ *    provisioning, and every rollback path.
+ *  - verifyUserRecord (auth/index.ts): the authorization gate in front of it —
+ *    autoCreateNewUsers on/off, authorized-domain restrictions against the
+ *    verified identity's email domain (including wildcards, suffix/prefix
+ *    confusion, and a forged Origin), cache-refresh retry, and the UserRoles
+ *    the created user is stamped with.
+ *
+ * Both production modules run unmodified; mocking happens at the package
+ * boundaries (@memberjunction/core, generic-database-provider, core-entities)
+ * plus the config module, matching unifiedAuth.test.ts.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { UserInfo } from '@memberjunction/core';
+
+// ─── Hoisted state ──────────────────────────────────────────────────────────
+const {
+    mockConfig,
+    mockCacheUsers,
+    mockUserByName,
+    mockRefresh,
+    mockGetEntityObject,
+    mockRunViewFn,
+    mockLogError,
+    mockLogStatus,
+    mockBeginTransaction,
+    mockCommitTransaction,
+    mockRollbackTransaction,
+    mockGetDefaultApplicationsForNewUser,
+    mockRolesArray,
+    mockApplicationsArray,
+} = vi.hoisted(() => {
+    interface HoistedCacheUser {
+        ID: string;
+        Name: string;
+        Email: string;
+        Type: string;
+    }
+    return {
+        mockConfig: {
+            userHandling: {
+                autoCreateNewUsers: true,
+                newUserLimitedToAuthorizedDomains: false,
+                newUserAuthorizedDomains: [] as string[],
+                newUserRoles: ['UI'] as string[],
+                updateCacheWhenNotFound: false,
+                updateCacheWhenNotFoundDelay: 0,
+                contextUserForNewUserCreation: 'system@test.com',
+                CreateUserApplicationRecords: false,
+                UserApplications: [] as string[],
+            },
+        },
+        mockCacheUsers: [] as HoistedCacheUser[],
+        mockUserByName: vi.fn(),
+        mockRefresh: vi.fn(),
+        mockGetEntityObject: vi.fn(),
+        mockRunViewFn: vi.fn(),
+        mockLogError: vi.fn(),
+        mockLogStatus: vi.fn(),
+        mockBeginTransaction: vi.fn(),
+        mockCommitTransaction: vi.fn(),
+        mockRollbackTransaction: vi.fn(),
+        mockGetDefaultApplicationsForNewUser: vi.fn(),
+        mockRolesArray: [] as Array<{ ID: string; Name: string }>,
+        mockApplicationsArray: [] as Array<{ ID: string; Name: string }>,
+    };
+});
+
+// ─── Module mocks ───────────────────────────────────────────────────────────
+
+vi.mock('../config.js', () => ({ configInfo: mockConfig }));
+
+vi.mock('@memberjunction/generic-database-provider', () => {
+    const instance = {
+        UserByName: mockUserByName,
+        get Users() {
+            return mockCacheUsers;
+        },
+        Refresh: mockRefresh,
+        GetSystemUser: vi.fn(),
+    };
+    return {
+        UserCache: class MockUserCache {
+            static get Instance() {
+                return instance;
+            }
+            static get Users() {
+                return mockCacheUsers;
+            }
+        },
+    };
+});
+
+vi.mock('@memberjunction/core', async (importOriginal) => {
+    const actual = await importOriginal<typeof import('@memberjunction/core')>();
+    const provider = {
+        BeginTransaction: mockBeginTransaction,
+        CommitTransaction: mockCommitTransaction,
+        RollbackTransaction: mockRollbackTransaction,
+        Dialect: { BooleanLiteral: (value: boolean) => (value ? '1' : '0') },
+    };
+    class MockMetadata {
+        public get Roles() {
+            return mockRolesArray;
+        }
+        public get Applications() {
+            return mockApplicationsArray;
+        }
+        public GetEntityObject(entityName: string, contextUser?: UserInfo): Promise<unknown> {
+            return mockGetEntityObject(entityName, contextUser);
+        }
+        static Provider = provider;
+    }
+    class MockUserInfo {
+        constructor(_provider: unknown, initData: Record<string, unknown>) {
+            Object.assign(this, initData);
+        }
+    }
+    class MockRunView {
+        public RunView(params: unknown, contextUser?: UserInfo): Promise<unknown> {
+            return mockRunViewFn(params, contextUser);
+        }
+    }
+    return {
+        ...actual,
+        Metadata: MockMetadata,
+        UserInfo: MockUserInfo,
+        RunView: MockRunView,
+        LogError: mockLogError,
+        LogStatus: mockLogStatus,
+    };
+});
+
+vi.mock('@memberjunction/core-entities', async (importOriginal) => {
+    const actual = await importOriginal<typeof import('@memberjunction/core-entities')>();
+    return {
+        ...actual,
+        UserInfoEngine: {
+            GetDefaultApplicationsForNewUser: mockGetDefaultApplicationsForNewUser,
+        },
+    };
+});
+
+vi.mock('@memberjunction/global', async (importOriginal) => {
+    const actual = await importOriginal<typeof import('@memberjunction/global')>();
+    return {
+        ...actual,
+        MJGlobal: {
+            get Instance() {
+                return {
+                    ClassFactory: {
+                        CreateInstance: <T>(cls: new () => T): T => new cls(),
+                    },
+                };
+            },
+        },
+    };
+});
+
+vi.mock('../auth/initializeProviders.js', () => ({ initializeAuthProviders: vi.fn() }));
+
+vi.mock('@memberjunction/auth-providers', () => ({
+    AuthProviderFactory: {
+        get Instance() {
+            return {
+                getAllByIssuer: () => [],
+                getByIssuer: () => undefined,
+                getAllProviders: () => [],
+                hasProviders: () => false,
+            };
+        },
+    },
+}));
+
+vi.mock('mssql', () => ({ default: {} }));
+
+vi.mock('type-graphql', () => ({
+    AuthorizationError: class AuthorizationError extends Error {},
+}));
+
+vi.mock('@memberjunction/api-keys', () => ({
+    GetAPIKeyEngine: vi.fn(),
+}));
+
+// ─── Import after mocks ─────────────────────────────────────────────────────
+import { NewUserBase } from '../auth/newUsers.js';
+import { verifyUserRecord } from '../auth/index.js';
+
+// ─── Mock-entity plumbing ───────────────────────────────────────────────────
+
+interface MockEntity {
+    [key: string]: unknown;
+    TestEntityName: string;
+    NewRecord: ReturnType<typeof vi.fn>;
+    Save: ReturnType<typeof vi.fn>;
+    GetAll: () => Record<string, unknown>;
+    LatestResult: { CompleteMessage: string };
+}
+
+/** Entities handed out by the mocked Metadata.GetEntityObject, in creation order. */
+let createdEntities: MockEntity[];
+/** Per-entity-name Save() outcome; defaults to success. */
+let saveBehavior: Record<string, () => boolean>;
+/** Every GetEntityObject call: entity name + the contextUser it was scoped to. */
+let getEntityObjectCalls: Array<{ entityName: string; contextUser: UserInfo | undefined }>;
+
+let entitySeq = 0;
+
+function makeMockEntity(entityName: string): MockEntity {
+    const entity: MockEntity = {
+        TestEntityName: entityName,
+        ID: `${entityName}#${++entitySeq}`,
+        NewRecord: vi.fn(),
+        LatestResult: { CompleteMessage: `mock save failure for ${entityName}` },
+        Save: vi.fn(async () => (saveBehavior[entityName] ?? (() => true))()),
+        GetAll: (): Record<string, unknown> => {
+            const out: Record<string, unknown> = {};
+            for (const [key, value] of Object.entries(entity)) {
+                if (typeof value !== 'function' && key !== 'LatestResult' && key !== 'TestEntityName') {
+                    out[key] = value;
+                }
+            }
+            return out;
+        },
+    };
+    return entity;
+}
+
+function entitiesOf(name: string): MockEntity[] {
+    return createdEntities.filter((e) => e.TestEntityName === name);
+}
+
+const CONTEXT_USER = { ID: 'sys-1', Name: 'system@test.com', Email: 'system@test.com', Type: 'Owner' } as unknown as UserInfo;
+
+function resetConfig(): void {
+    mockConfig.userHandling = {
+        autoCreateNewUsers: true,
+        newUserLimitedToAuthorizedDomains: false,
+        newUserAuthorizedDomains: [],
+        newUserRoles: ['UI'],
+        updateCacheWhenNotFound: false,
+        updateCacheWhenNotFoundDelay: 0,
+        contextUserForNewUserCreation: 'system@test.com',
+        CreateUserApplicationRecords: false,
+        UserApplications: [],
+    };
+}
+
+beforeEach(() => {
+    vi.clearAllMocks();
+    vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+    vi.spyOn(console, 'log').mockImplementation(() => undefined);
+    vi.spyOn(console, 'error').mockImplementation(() => undefined);
+
+    resetConfig();
+    createdEntities = [];
+    getEntityObjectCalls = [];
+    saveBehavior = {};
+    entitySeq = 0;
+    mockCacheUsers.length = 0;
+
+    mockRolesArray.length = 0;
+    mockRolesArray.push({ ID: 'role-ui', Name: 'UI' }, { ID: 'role-dev', Name: 'Developer' });
+    mockApplicationsArray.length = 0;
+    mockApplicationsArray.push({ ID: 'app-crm', Name: ' CRM ' }, { ID: 'app-admin', Name: 'Admin' });
+
+    mockUserByName.mockImplementation((name: string) => (name === 'system@test.com' ? CONTEXT_USER : undefined));
+    mockGetEntityObject.mockImplementation(async (entityName: string, contextUser?: UserInfo) => {
+        const entity = makeMockEntity(entityName);
+        createdEntities.push(entity);
+        getEntityObjectCalls.push({ entityName, contextUser });
+        return entity;
+    });
+    mockRunViewFn.mockResolvedValue({ Success: true, Results: [] });
+    mockGetDefaultApplicationsForNewUser.mockReturnValue([]);
+});
+
+// ─── NewUserBase.createNewUser ──────────────────────────────────────────────
+
+describe('NewUserBase.createNewUser', () => {
+    const create = (first = 'Ada', last = 'Lovelace', email = 'ada@example.com') =>
+        new NewUserBase().createNewUser(first, last, email);
+
+    describe('context-user resolution', () => {
+        it('uses the configured contextUserForNewUserCreation for every entity it creates', async () => {
+            const user = await create();
+
+            expect(user).not.toBeNull();
+            expect(mockUserByName).toHaveBeenCalledWith('system@test.com');
+            expect(getEntityObjectCalls[0]).toEqual({ entityName: 'MJ: Users', contextUser: CONTEXT_USER });
+            // Role records are scoped to the same creation context user
+            for (const call of getEntityObjectCalls) {
+                expect(call.contextUser).toBe(CONTEXT_USER);
+            }
+        });
+
+        it('falls back to an Owner-typed cache user (case-insensitive, trimmed) when the configured user is missing', async () => {
+            mockUserByName.mockReturnValue(undefined);
+            const owner = { ID: 'owner-9', Name: 'Fallback Owner', Email: 'owner@x.com', Type: '  OWNER  ' };
+            mockCacheUsers.push({ ID: 'u-1', Name: 'Plain', Email: 'p@x.com', Type: 'User' }, owner);
+
+            const user = await create();
+
+            expect(user).not.toBeNull();
+            expect(mockLogError).toHaveBeenCalled(); // the miss is logged
+            expect(getEntityObjectCalls[0].contextUser).toBe(owner as unknown as UserInfo);
+        });
+
+        it('returns null without opening a transaction when no context user can be resolved at all', async () => {
+            mockUserByName.mockReturnValue(undefined);
+            mockCacheUsers.push({ ID: 'u-1', Name: 'Plain', Email: 'p@x.com', Type: 'User' });
+
+            const user = await create();
+
+            expect(user).toBeNull();
+            expect(mockBeginTransaction).not.toHaveBeenCalled();
+            expect(mockGetEntityObject).not.toHaveBeenCalled();
+        });
+
+        it('returns undefined (outer catch) when context resolution throws', async () => {
+            mockUserByName.mockImplementation(() => {
+                throw new Error('cache exploded');
+            });
+
+            const user = await create();
+
+            expect(user).toBeUndefined();
+            expect(mockLogError).toHaveBeenCalled();
+        });
+    });
+
+    describe('user record construction', () => {
+        it('maps the identity fields onto a NewRecord-ed MJ: Users entity', async () => {
+            const user = await create('Grace', 'Hopper', 'grace@navy.mil');
+
+            const userEntity = entitiesOf('MJ: Users')[0];
+            expect(user as unknown).toBe(userEntity); // the saved entity itself is returned
+            expect(userEntity.NewRecord).toHaveBeenCalledTimes(1);
+            expect(userEntity.Name).toBe('grace@navy.mil'); // Name IS the email
+            expect(userEntity.Email).toBe('grace@navy.mil');
+            expect(userEntity.FirstName).toBe('Grace');
+            expect(userEntity.LastName).toBe('Hopper');
+            expect(userEntity.IsActive).toBe(true);
+            expect(userEntity.Type).toBe('User');
+            expect(userEntity.LinkedRecordType).toBe('None'); // default
+            expect(userEntity.LinkedEntityID).toBeUndefined();
+            expect(userEntity.LinkedEntityRecordID).toBeUndefined();
+        });
+
+        it('sets linked-record fields only when provided', async () => {
+            await new NewUserBase().createNewUser('A', 'B', 'ab@x.com', 'Employee', 'ent-77', 'rec-88');
+
+            const userEntity = entitiesOf('MJ: Users')[0];
+            expect(userEntity.LinkedRecordType).toBe('Employee');
+            expect(userEntity.LinkedEntityID).toBe('ent-77');
+            expect(userEntity.LinkedEntityRecordID).toBe('rec-88');
+        });
+
+        it('rolls back and returns null when the user Save() fails — never a half-provisioned user', async () => {
+            saveBehavior['MJ: Users'] = () => false;
+
+            const user = await create();
+
+            expect(user).toBeNull();
+            expect(mockBeginTransaction).toHaveBeenCalledTimes(1);
+            expect(mockRollbackTransaction).toHaveBeenCalledTimes(1);
+            expect(mockCommitTransaction).not.toHaveBeenCalled();
+            expect(entitiesOf('MJ: User Roles')).toHaveLength(0);
+        });
+    });
+
+    describe('role assignment', () => {
+        it('creates one saved MJ: User Roles record per configured role, inside the transaction', async () => {
+            mockConfig.userHandling.newUserRoles = ['UI', 'Developer'];
+
+            const user = await create();
+
+            expect(user).not.toBeNull();
+            const roleEntities = entitiesOf('MJ: User Roles');
+            expect(roleEntities).toHaveLength(2);
+            const userEntity = entitiesOf('MJ: Users')[0];
+            expect(roleEntities[0].UserID).toBe(userEntity.ID);
+            expect(roleEntities[0].RoleID).toBe('role-ui');
+            expect(roleEntities[1].RoleID).toBe('role-dev');
+            for (const roleEntity of roleEntities) {
+                expect(roleEntity.Save).toHaveBeenCalledTimes(1);
+            }
+            expect(mockCommitTransaction).toHaveBeenCalledTimes(1);
+        });
+
+        it('skips unknown roles with a logged error but still commits (KNOWN GAP: role-name match is case-sensitive)', async () => {
+            // md.Roles.find(r => r.Name === role) — 'ui' does NOT match the metadata
+            // role 'UI'. A casing typo in mj.config silently yields a user with fewer
+            // roles than intended. Pinned as documentation of the sharp edge.
+            mockConfig.userHandling.newUserRoles = ['ui', 'Developer'];
+
+            const user = await create();
+
+            expect(user).not.toBeNull();
+            const roleEntities = entitiesOf('MJ: User Roles');
+            expect(roleEntities).toHaveLength(1);
+            expect(roleEntities[0].RoleID).toBe('role-dev');
+            expect(mockLogError).toHaveBeenCalledWith(expect.stringContaining('Role ui not found'));
+            expect(mockCommitTransaction).toHaveBeenCalledTimes(1);
+        });
+
+        it('rolls back everything when a role Save() fails', async () => {
+            mockConfig.userHandling.newUserRoles = ['UI'];
+            saveBehavior['MJ: User Roles'] = () => false;
+
+            const user = await create();
+
+            expect(user).toBeNull();
+            expect(mockRollbackTransaction).toHaveBeenCalledTimes(1);
+            expect(mockCommitTransaction).not.toHaveBeenCalled();
+        });
+    });
+
+    describe('user application provisioning', () => {
+        beforeEach(() => {
+            mockConfig.userHandling.CreateUserApplicationRecords = true;
+        });
+
+        it('creates User Applications for explicitly configured app names (trimmed, case-insensitive)', async () => {
+            mockConfig.userHandling.UserApplications = ['crm', 'ADMIN '];
+
+            const user = await create();
+
+            expect(user).not.toBeNull();
+            const appEntities = entitiesOf('MJ: User Applications');
+            expect(appEntities).toHaveLength(2);
+            expect(appEntities[0].ApplicationID).toBe('app-crm');
+            expect(appEntities[0].Sequence).toBe(0);
+            expect(appEntities[0].IsActive).toBe(true);
+            expect(appEntities[1].ApplicationID).toBe('app-admin');
+            expect(appEntities[1].Sequence).toBe(1);
+        });
+
+        it('logs and skips configured app names that do not exist in metadata', async () => {
+            mockConfig.userHandling.UserApplications = ['NoSuchApp', 'Admin'];
+
+            const user = await create();
+
+            expect(user).not.toBeNull();
+            expect(entitiesOf('MJ: User Applications')).toHaveLength(1);
+            expect(mockLogError).toHaveBeenCalledWith(expect.stringContaining('Application NoSuchApp not found'));
+        });
+
+        it('falls back to UserInfoEngine.GetDefaultApplicationsForNewUser when no apps are configured', async () => {
+            mockConfig.userHandling.UserApplications = [];
+            mockGetDefaultApplicationsForNewUser.mockReturnValue([{ ID: 'app-admin', Name: 'Admin' }]);
+
+            const user = await create();
+
+            expect(user).not.toBeNull();
+            expect(mockGetDefaultApplicationsForNewUser).toHaveBeenCalledTimes(1);
+            const appEntities = entitiesOf('MJ: User Applications');
+            expect(appEntities).toHaveLength(1);
+            expect(appEntities[0].ApplicationID).toBe('app-admin');
+        });
+
+        it('creates User Application Entities from the DefaultForNewUser view rows, using the dialect boolean literal', async () => {
+            mockConfig.userHandling.UserApplications = ['Admin'];
+            mockRunViewFn.mockResolvedValue({
+                Success: true,
+                Results: [
+                    { EntityID: 'ent-cust', Entity: 'Customers' },
+                    { EntityID: 'ent-ord', Entity: 'Orders' },
+                ],
+            });
+
+            const user = await create();
+
+            expect(user).not.toBeNull();
+            expect(mockRunViewFn).toHaveBeenCalledWith(
+                {
+                    EntityName: 'MJ: Application Entities',
+                    ExtraFilter: `ApplicationID = 'app-admin' AND DefaultForNewUser = 1`,
+                },
+                CONTEXT_USER,
+            );
+            const appEntity = entitiesOf('MJ: User Applications')[0];
+            const uae = entitiesOf('MJ: User Application Entities');
+            expect(uae).toHaveLength(2);
+            expect(uae[0].UserApplicationID).toBe(appEntity.ID);
+            expect(uae[0].EntityID).toBe('ent-cust');
+            expect(uae[0].Sequence).toBe(0);
+            expect(uae[1].EntityID).toBe('ent-ord');
+            expect(uae[1].Sequence).toBe(1);
+        });
+
+        it('continues (and still commits) when the Application Entities view fails to load', async () => {
+            mockConfig.userHandling.UserApplications = ['Admin'];
+            mockRunViewFn.mockResolvedValue({ Success: false, Results: [], ErrorMessage: 'view blew up' });
+
+            const user = await create();
+
+            expect(user).not.toBeNull();
+            expect(entitiesOf('MJ: User Application Entities')).toHaveLength(0);
+            expect(mockCommitTransaction).toHaveBeenCalledTimes(1);
+            expect(mockRollbackTransaction).not.toHaveBeenCalled();
+        });
+
+        it('rolls back when a User Application Entity Save() fails', async () => {
+            mockConfig.userHandling.UserApplications = ['Admin'];
+            mockRunViewFn.mockResolvedValue({ Success: true, Results: [{ EntityID: 'ent-1', Entity: 'X' }] });
+            saveBehavior['MJ: User Application Entities'] = () => false;
+
+            const user = await create();
+
+            expect(user).toBeNull();
+            expect(mockRollbackTransaction).toHaveBeenCalledTimes(1);
+            expect(mockCommitTransaction).not.toHaveBeenCalled();
+        });
+
+        it('rolls back when a User Application Save() fails', async () => {
+            mockConfig.userHandling.UserApplications = ['Admin'];
+            saveBehavior['MJ: User Applications'] = () => false;
+
+            const user = await create();
+
+            expect(user).toBeNull();
+            expect(mockRollbackTransaction).toHaveBeenCalledTimes(1);
+        });
+    });
+});
+
+// ─── verifyUserRecord (the authorization gate) ──────────────────────────────
+
+describe('verifyUserRecord', () => {
+    function addCacheUser(email: string): void {
+        mockCacheUsers.push({ ID: `u-${email}`, Name: email, Email: email, Type: 'User' });
+    }
+
+    it('returns undefined when no email is supplied', async () => {
+        const user = await verifyUserRecord(undefined, 'A', 'B');
+
+        expect(user).toBeUndefined();
+        expect(mockGetEntityObject).not.toHaveBeenCalled();
+    });
+
+    it('returns the cached user, matching email case-insensitively and trimmed', async () => {
+        addCacheUser('someone@example.com');
+
+        const user = await verifyUserRecord('  SomeOne@Example.COM  ', 'A', 'B');
+
+        expect(user).toBeDefined();
+        expect((user as unknown as { Email: string }).Email).toBe('someone@example.com');
+        expect(mockGetEntityObject).not.toHaveBeenCalled(); // no creation for existing users
+    });
+
+    it('skips (and logs) cache entries with a blank email instead of matching them', async () => {
+        mockCacheUsers.push({ ID: 'broken-1', Name: 'Broken', Email: '  ', Type: 'User' });
+        const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+
+        const user = await verifyUserRecord('missing@example.com', undefined, undefined);
+
+        expect(user).toBeUndefined();
+        expect(errorSpy).toHaveBeenCalledWith(expect.stringContaining('broken-1'));
+    });
+
+    describe('autoCreateNewUsers gate', () => {
+        it('does NOT create a user when autoCreateNewUsers is false', async () => {
+            mockConfig.userHandling.autoCreateNewUsers = false;
+
+            const user = await verifyUserRecord('new@example.com', 'New', 'User');
+
+            expect(user).toBeUndefined();
+            expect(mockGetEntityObject).not.toHaveBeenCalled();
+        });
+
+        it('does NOT create a user when firstName or lastName is missing', async () => {
+            const missingFirst = await verifyUserRecord('new@example.com', undefined, 'User');
+            const missingLast = await verifyUserRecord('new@example.com', 'New', undefined);
+
+            expect(missingFirst).toBeUndefined();
+            expect(missingLast).toBeUndefined();
+            expect(mockGetEntityObject).not.toHaveBeenCalled();
+        });
+
+        it('creates the user when enabled and domains are unrestricted, stamping config roles onto the returned UserInfo', async () => {
+            mockConfig.userHandling.newUserRoles = ['UI', 'Developer'];
+
+            const user = await verifyUserRecord('new@example.com', 'New', 'User');
+
+            expect(user).toBeDefined();
+            const stamped = user as unknown as { Email: string; UserRoles: Array<{ Role: string; RoleID: string; UserID: string }> };
+            expect(stamped.Email).toBe('new@example.com');
+            expect(stamped.UserRoles).toEqual([
+                { UserID: entitiesOf('MJ: Users')[0].ID, Role: 'UI', RoleID: 'role-ui' },
+                { UserID: entitiesOf('MJ: Users')[0].ID, Role: 'Developer', RoleID: 'role-dev' },
+            ]);
+            // The new user joins the shared cache so subsequent requests resolve it
+            expect(mockCacheUsers.some((u) => u.Email === 'new@example.com')).toBe(true);
+        });
+
+        it('returns undefined when the underlying createNewUser fails', async () => {
+            saveBehavior['MJ: Users'] = () => false;
+
+            const user = await verifyUserRecord('new@example.com', 'New', 'User');
+
+            expect(user).toBeUndefined();
+            expect(mockCacheUsers).toHaveLength(0);
+        });
+    });
+
+    describe('authorized-domain restrictions', () => {
+        beforeEach(() => {
+            mockConfig.userHandling.newUserLimitedToAuthorizedDomains = true;
+            mockConfig.userHandling.newUserAuthorizedDomains = ['example.com'];
+        });
+
+        it('creates the user when the email domain is authorized', async () => {
+            const user = await verifyUserRecord('new@example.com', 'New', 'User');
+
+            expect(user).toBeDefined();
+            expect(entitiesOf('MJ: Users')).toHaveLength(1);
+        });
+
+        it('does NOT create when the email domain is not authorized', async () => {
+            const user = await verifyUserRecord('new@evil.com', 'New', 'User');
+
+            expect(user).toBeUndefined();
+            expect(mockGetEntityObject).not.toHaveBeenCalled();
+        });
+
+        it('creates when restricted and no request Origin is supplied, if the email domain is authorized', async () => {
+            const user = await verifyUserRecord('new@example.com', 'New', 'User', undefined);
+
+            expect(user).toBeDefined();
+            expect(entitiesOf('MJ: Users')).toHaveLength(1);
+        });
+
+        it('does NOT create when a forged Origin is authorized but the email domain is not', async () => {
+            const user = await verifyUserRecord('new@evil.com', 'New', 'User', 'example.com');
+
+            expect(user).toBeUndefined();
+            expect(mockGetEntityObject).not.toHaveBeenCalled();
+        });
+
+        it('matches email domains case-insensitively', async () => {
+            const user = await verifyUserRecord('new@EXAMPLE.COM', 'New', 'User');
+
+            expect(user).toBeDefined();
+        });
+
+        it('supports wildcard patterns for email subdomains', async () => {
+            mockConfig.userHandling.newUserAuthorizedDomains = ['*.example.com'];
+
+            const user = await verifyUserRecord('new@mail.example.com', 'New', 'User');
+
+            expect(user).toBeDefined();
+        });
+
+        it('does NOT match the apex against "*.example.com" (pattern is matched in full)', async () => {
+            mockConfig.userHandling.newUserAuthorizedDomains = ['*.example.com'];
+
+            const user = await verifyUserRecord('new@example.com', 'New', 'User');
+
+            expect(user).toBeUndefined();
+            expect(mockGetEntityObject).not.toHaveBeenCalled();
+        });
+
+        it('rejects prefix confusion: "*.example.com" does not match "evilexample.com" (dot is escaped)', async () => {
+            mockConfig.userHandling.newUserAuthorizedDomains = ['*.example.com'];
+
+            const user = await verifyUserRecord('new@evilexample.com', 'New', 'User');
+
+            expect(user).toBeUndefined();
+            expect(mockGetEntityObject).not.toHaveBeenCalled();
+        });
+
+        it('rejects suffix confusion: the pattern is anchored, so "example.com.evil.com" is not authorized', async () => {
+            const user = await verifyUserRecord('new@example.com.evil.com', 'New', 'User');
+
+            expect(user).toBeUndefined();
+            expect(mockGetEntityObject).not.toHaveBeenCalled();
+        });
+
+        it('rejects "evilexample.com" against the plain "example.com" pattern (anchored at both ends)', async () => {
+            const user = await verifyUserRecord('x@evilexample.com', 'New', 'User');
+
+            expect(user).toBeUndefined();
+        });
+
+        it('does NOT create when the identity has no email domain (username-only IdP)', async () => {
+            const user = await verifyUserRecord('bare-username', 'New', 'User');
+
+            expect(user).toBeUndefined();
+            expect(mockGetEntityObject).not.toHaveBeenCalled();
+        });
+    });
+
+    describe('cache-refresh retry', () => {
+        it('refreshes the cache once and retries when updateCacheWhenNotFound is set', async () => {
+            mockConfig.userHandling.autoCreateNewUsers = false;
+            mockConfig.userHandling.updateCacheWhenNotFound = true;
+            mockConfig.userHandling.updateCacheWhenNotFoundDelay = 0;
+            mockRefresh.mockImplementation(async () => {
+                addCacheUser('late@example.com');
+            });
+            const dataSource = {} as unknown as import('mssql').ConnectionPool;
+
+            const user = await verifyUserRecord('late@example.com', undefined, undefined, undefined, dataSource);
+
+            expect(user).toBeDefined();
+            expect((user as unknown as { Email: string }).Email).toBe('late@example.com');
+            expect(mockRefresh).toHaveBeenCalledTimes(1); // no infinite retry loop
+        });
+
+        it('gives up after one refresh when the user still is not found', async () => {
+            mockConfig.userHandling.autoCreateNewUsers = false;
+            mockConfig.userHandling.updateCacheWhenNotFound = true;
+            const dataSource = {} as unknown as import('mssql').ConnectionPool;
+
+            const user = await verifyUserRecord('never@example.com', undefined, undefined, undefined, dataSource);
+
+            expect(user).toBeUndefined();
+            expect(mockRefresh).toHaveBeenCalledTimes(1);
+        });
+    });
+});

--- a/packages/MJServer/src/auth/index.ts
+++ b/packages/MJServer/src/auth/index.ts
@@ -186,6 +186,42 @@ export const getSystemUser = async (dataSource?: sql.ConnectionPool, attemptCach
   return systemUser;
 };
 
+/**
+ * Extracts the lowercased domain portion of an email address.
+ *
+ * @returns the domain, or an empty string when the value is not an email address (e.g. an IdP that
+ *          issues a bare username). Callers MUST treat an empty result as "cannot be authorized"
+ *          rather than as a wildcard.
+ */
+const extractEmailDomain = (email: string): string => {
+  const parts = email.split('@');
+  // Reject anything that isn't exactly local@domain — a value with 0 or 2+ '@' is not an address we
+  // can make a trust decision about.
+  if (parts.length !== 2) return '';
+  return parts[1].toLowerCase().trim();
+};
+
+/**
+ * Tests a domain against `userHandling.newUserAuthorizedDomains`, honoring `*` wildcards.
+ *
+ * Note that a pattern is matched in full, so `*.example.com` matches `mail.example.com` but NOT
+ * `example.com` — list both if you need both.
+ */
+const isDomainAuthorized = (domain: string): boolean =>
+  configInfo.userHandling.newUserAuthorizedDomains.some((pattern) => {
+    // Convert wildcard domain patterns to regular expressions
+    const regex = new RegExp('^' + pattern.toLowerCase().trim().replace(/\./g, '\\.').replace(/\*/g, '.*') + '$');
+    return regex.test(domain);
+  });
+
+/**
+ * Resolves a verified identity to an MJ `UserInfo`, optionally auto-provisioning a new user.
+ *
+ * @param requestDomain the hostname parsed from the request's `Origin` header. **Not used for any
+ *        authorization decision** — it is spoofable on non-browser requests, and new-user domain
+ *        authorization runs against the verified JWT's email domain instead. Retained for audit
+ *        logging and for the recursive retry call.
+ */
 export const verifyUserRecord = async (
   email?: string,
   firstName?: string,
@@ -206,23 +242,21 @@ export const verifyUserRecord = async (
   });
 
   if (!user) {
-    if (
-      configInfo.userHandling.autoCreateNewUsers &&
-      firstName &&
-      lastName &&
-      (requestDomain || configInfo.userHandling.newUserLimitedToAuthorizedDomains === false)
-    ) {
-      // check to see if the domain that we have a request coming in from matches one of the domains in the autoCreateNewUsersDomains setting
+    // NOTE: `requestDomain` (parsed from the spoofable `Origin` header) is deliberately NOT part of
+    // this condition. It was previously required here, which meant a non-browser client sending no
+    // Origin could never auto-provision while an attacker simply forged one — it gated entry without
+    // authorizing anything. Authorization happens below, against the verified identity's email domain.
+    if (configInfo.userHandling.autoCreateNewUsers && firstName && lastName) {
+      // SECURITY: authorize against the EMAIL DOMAIN of the cryptographically-verified identity,
+      // NOT the request `Origin` header. Origin is trivially spoofable on non-browser / bearer-token
+      // requests, so gating on it let a holder of any valid IdP token auto-provision an account under
+      // an authorized domain by sending a forged Origin. The email comes from the verified JWT.
+      const emailDomain: string = extractEmailDomain(email);
       let passesDomainCheck: boolean =
         configInfo.userHandling.newUserLimitedToAuthorizedDomains ===
         false; /*in this first condition, we are set up to NOT care about domain */
-      if (!passesDomainCheck && requestDomain) {
-        /*in this second condition, we check the domain against authorized domains*/
-        passesDomainCheck = configInfo.userHandling.newUserAuthorizedDomains.some((pattern) => {
-          // Convert wildcard domain patterns to regular expressions
-          const regex = new RegExp('^' + pattern.toLowerCase().trim().replace(/\./g, '\\.').replace(/\*/g, '.*') + '$');
-          return regex.test(requestDomain?.toLowerCase().trim());
-        });
+      if (!passesDomainCheck) {
+        passesDomainCheck = emailDomain.length > 0 && isDomainAuthorized(emailDomain);
       }
 
       if (passesDomainCheck) {
@@ -248,9 +282,16 @@ export const verifyUserRecord = async (
           UserCache.Instance.Users.push(user);
           console.warn(`   >>> New user ${email} created successfully!`);
         }
+      } else if (emailDomain.length === 0) {
+        // The verified identity carries no email domain at all — typically an IdP that issues a bare
+        // `preferred_username` with no `email` claim. There is nothing to match against, so the gate
+        // denies rather than falling back to anything spoofable.
+        console.warn(
+          `User ${email} not found in cache and will NOT be auto-created: the verified identity has no email domain (no '@'), so it cannot be matched against newUserAuthorizedDomains. This usually means the identity provider issues a username rather than an email address — configure it to emit an 'email' claim, or set newUserLimitedToAuthorizedDomains to false to disable domain checking.`
+        );
       } else {
         console.warn(
-          `User ${email} not found in cache. Request domain '${requestDomain}' does not match any of the domains in the newUserAuthorizedDomains setting. To ignore domain, make sure you set the newUserLimitedToAuthorizedDomains setting to false. In this case we are NOT creating a new user.`
+          `User ${email} not found in cache. Email domain '${emailDomain}' does not match any of the domains in the newUserAuthorizedDomains setting. NOTE: this check is against the EMAIL DOMAIN of the verified identity, NOT the browser Origin — if newUserAuthorizedDomains lists frontend hostnames (e.g. 'app.example.com'), replace them with email domains (e.g. 'example.com'). To ignore domain, make sure you set the newUserLimitedToAuthorizedDomains setting to false. In this case we are NOT creating a new user.`
         );
       }
     }

--- a/packages/MJServer/src/config.ts
+++ b/packages/MJServer/src/config.ts
@@ -7,7 +7,19 @@ const explorer = cosmiconfigSync('mj', { searchStrategy: 'global' });
 
 const userHandlingInfoSchema = z.object({
   autoCreateNewUsers: z.boolean().optional().default(false),
+  /** When true, auto-provisioning is restricted to the domains in `newUserAuthorizedDomains`. */
   newUserLimitedToAuthorizedDomains: z.boolean().optional().default(false),
+  /**
+   * Authorized **email domains** for auto-provisioned users — e.g. `['example.com', '*.example.org']`.
+   *
+   * These are matched against the domain of the email address in the verified identity token, NOT
+   * against the browser `Origin` / frontend hostname. If you are upgrading from a build that
+   * compared these to the request origin, replace any frontend hostnames here (`app.example.com`,
+   * `localhost`) with the email domains your users actually sign in with.
+   *
+   * `*` wildcards are supported and match in full: `*.example.com` matches `mail.example.com` but
+   * NOT `example.com` — list both if you need both.
+   */
   newUserAuthorizedDomains: z.array(z.string()).optional().default([]),
   newUserRoles: z.array(z.string()).optional().default([]),
   updateCacheWhenNotFound: z.boolean().optional().default(false),

--- a/packages/MJServer/src/context.ts
+++ b/packages/MJServer/src/context.ts
@@ -1,4 +1,5 @@
 import { IncomingMessage } from 'http';
+import { createHash, timingSafeEqual } from 'crypto';
 import { default as jwt } from 'jsonwebtoken';
 import 'reflect-metadata';
 import { Subject, firstValueFrom } from 'rxjs';
@@ -319,7 +320,13 @@ const verifyAsync = async (issuer: string, token: string): Promise<jwt.JwtPayloa
       return;
     }
 
-    const verifyOptions: jwt.VerifyOptions = {};
+    const verifyOptions: jwt.VerifyOptions = {
+      // SECURITY: explicitly pin the accepted signature algorithms to the asymmetric family.
+      // The signing key here comes from the issuer's JWKS (an RSA/EC public key), so without an
+      // explicit allow-list a future key-format change or library regression could reintroduce
+      // classic `alg=none` / RS256->HS256 confusion attacks. Pinning fails such tokens closed.
+      algorithms: ['RS256', 'RS384', 'RS512', 'ES256', 'ES384', 'ES512', 'PS256'],
+    };
     if (Array.isArray(options.audience)) {
       verifyOptions.audience = options.audience as [string, ...string[]];
     } else {
@@ -420,7 +427,13 @@ export const getUserPayload = async (
     // Check for system API key (x-mj-api-key header)
     // This authenticates as the system user for system-level operations
     if (systemApiKey && systemApiKey != String(undefined)) {
-      if (systemApiKey === apiKey) {
+      // SECURITY: compare the superadmin system API key in constant time. A plain `===`
+      // short-circuits on the first differing byte, leaking a timing side-channel that could
+      // be used to recover the key byte-by-byte. Hash both sides to fixed-length digests so
+      // timingSafeEqual never throws on length mismatch and the comparison is length-agnostic.
+      const systemKeyDigest = createHash('sha256').update(String(systemApiKey)).digest();
+      const providedKeyDigest = createHash('sha256').update(String(apiKey)).digest();
+      if (timingSafeEqual(systemKeyDigest, providedKeyDigest)) {
         const systemUser = await getSystemUser(readOnlyDataSource);
         return {
           userRecord: systemUser,

--- a/packages/MJServer/src/context.ts
+++ b/packages/MJServer/src/context.ts
@@ -431,8 +431,12 @@ export const getUserPayload = async (
       // short-circuits on the first differing byte, leaking a timing side-channel that could
       // be used to recover the key byte-by-byte. Hash both sides to fixed-length digests so
       // timingSafeEqual never throws on length mismatch and the comparison is length-agnostic.
-      const systemKeyDigest = createHash('sha256').update(String(systemApiKey)).digest();
-      const providedKeyDigest = createHash('sha256').update(String(apiKey)).digest();
+      // The Uint8Array wrappers are required by the @types/node version this line is pinned to
+      // (20.14.2, via the root `overrides`), whose `timingSafeEqual` takes NodeJS.ArrayBufferView —
+      // a type its own non-generic `Buffer` does not satisfy under TypeScript 5.9's lib. Copying
+      // two fixed-length 32-byte digests is content-independent, so the comparison stays constant time.
+      const systemKeyDigest = new Uint8Array(createHash('sha256').update(String(systemApiKey)).digest());
+      const providedKeyDigest = new Uint8Array(createHash('sha256').update(String(apiKey)).digest());
       if (timingSafeEqual(systemKeyDigest, providedKeyDigest)) {
         const systemUser = await getSystemUser(readOnlyDataSource);
         return {

--- a/packages/MJServer/src/index.ts
+++ b/packages/MJServer/src/index.ts
@@ -1038,7 +1038,9 @@ export const serve = async (resolverPaths: Array<string>, app: Application = cre
     const { callbackRouter, authenticatedRouter } = createOAuthCallbackHandler({
       publicUrl: oauthPublicUrl,
       successRedirectUrl: `${oauthPublicUrl}/oauth/success`,
-      errorRedirectUrl: `${oauthPublicUrl}/oauth/error`
+      errorRedirectUrl: `${oauthPublicUrl}/oauth/error`,
+      // Constrains where a caller-supplied frontendReturnUrl may point (open-redirect guard).
+      allowedFrontendOrigins: configInfo.cors?.allowedOrigins ?? ['*']
     });
     oauthAuthenticatedRouter = authenticatedRouter;
 

--- a/packages/MJServer/src/resolvers/ReportResolver.ts
+++ b/packages/MJServer/src/resolvers/ReportResolver.ts
@@ -98,9 +98,10 @@ export class ReportResolverExtended extends ResolverBase {
                    ON
                       cd.ConversationID = c.ID
                    WHERE
-                      cd.ID='${ConversationDetailID}'`;
+                      cd.ID=@ConversationDetailID`;
 
       const request = new mssql.Request(dataSource);
+      request.input('ConversationDetailID', mssql.UniqueIdentifier, ConversationDetailID);
       const result = await request.query(sql);
       if (!result || !result.recordset || result.recordset.length === 0) throw new Error('Unable to retrieve converation details');
       const skipData: { title?: string; reportTitle?: string; userExplanation?: string; messages?: unknown[] } = JSON.parse(result.recordset[0].Message);

--- a/packages/MJServer/src/resolvers/__tests__/ReportResolver.test.ts
+++ b/packages/MJServer/src/resolvers/__tests__/ReportResolver.test.ts
@@ -1,0 +1,232 @@
+/**
+ * Tests for ReportResolverExtended.CreateReportFromConversationDetailID.
+ *
+ * Regression coverage for a SQL injection fix: ConversationDetailID (a plain GraphQL
+ * String arg) used to be interpolated directly into the WHERE clause. It is now bound
+ * via mssql's parameterized `request.input(...)`, so a hostile value must never appear
+ * spliced into the executed SQL text, and query structure must stay identical regardless
+ * of what the value contains.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// ─── Hoisted mocks ────────────────────────────────────────────────────────
+const { mockUserCacheUsers, mssqlState } = vi.hoisted(() => ({
+    mockUserCacheUsers: [] as Array<{ Email: string; ID: string }>,
+    mssqlState: {
+        inputCalls: [] as Array<{ name: string; type: unknown; value: unknown }>,
+        queryCalls: [] as string[],
+        poolArgs: [] as unknown[],
+        recordset: [] as Array<Record<string, unknown>>,
+    },
+}));
+
+// Stub external deps before imports (mirrors resolverBase.rls.test.ts)
+vi.mock('@memberjunction/sqlserver-dataprovider', () => ({
+    SQLServerDataProvider: class {},
+    UserCache: {
+        get Users() { return mockUserCacheUsers; },
+    },
+}));
+
+vi.mock('cloudevents', () => ({
+    CloudEvent: class {},
+    httpTransport: () => () => undefined,
+    emitterFor: () => () => undefined,
+}));
+
+vi.mock('type-graphql', () => ({
+    Resolver:           () => () => undefined,
+    Mutation:           () => () => undefined,
+    Query:              () => () => undefined,
+    Subscription:       () => () => undefined,
+    Ctx:                () => () => undefined,
+    Arg:                () => () => undefined,
+    PubSub:             () => () => undefined,
+    Root:               () => () => undefined,
+    ObjectType:         () => () => undefined,
+    InputType:          () => () => undefined,
+    Field:              () => () => undefined,
+    FieldResolver:      () => () => undefined,
+    Int:                () => undefined,
+    Float:              () => undefined,
+    registerEnumType:   () => undefined,
+}));
+
+vi.mock('graphql', () => ({
+    GraphQLError: class extends Error {
+        constructor(msg: string) { super(msg); }
+    },
+}));
+
+vi.mock('mssql', () => {
+    const UniqueIdentifier = { __marker: 'UniqueIdentifier' };
+    class Request {
+        constructor(pool: unknown) {
+            mssqlState.poolArgs.push(pool);
+        }
+        input(name: string, type: unknown, value: unknown) {
+            mssqlState.inputCalls.push({ name, type, value });
+        }
+        async query(sql: string) {
+            mssqlState.queryCalls.push(sql);
+            return { recordset: mssqlState.recordset };
+        }
+    }
+    return { default: { Request, UniqueIdentifier }, Request, UniqueIdentifier };
+});
+
+vi.mock('@memberjunction/data-context', () => {
+    class DataContext {
+        LoadMetadata = vi.fn(async () => true);
+    }
+    (DataContext as unknown as { Clone: unknown }).Clone = vi.fn(async () => ({ ID: 'dctx-clone-1' }));
+    return { DataContext };
+});
+
+vi.mock('@memberjunction/api-keys', () => ({
+    GetAPIKeyEngine: vi.fn(),
+}));
+
+vi.mock('@memberjunction/encryption', () => ({
+    EncryptionEngine: { Instance: {} },
+}));
+
+vi.mock('@memberjunction/graphql-dataprovider', () => ({
+    FieldMapper: class { static Instance = { MapFieldsFromCodeNamesToDBNames: vi.fn() }; },
+}));
+
+vi.mock('../../generic/PubSubManager.js', () => ({
+    PubSubManager: class { static Instance = { publish: vi.fn() }; },
+}));
+
+vi.mock('../../generic/PushStatusResolver.js', () => ({
+    PUSH_STATUS_UPDATES_TOPIC: 'test-push-topic',
+    PushStatusNotification: class {},
+    PushStatusResolver: class {},
+}));
+
+vi.mock('../../generic/CacheInvalidationResolver.js', () => ({
+    CACHE_INVALIDATION_TOPIC: 'test-cache-topic',
+}));
+
+vi.mock('../../generic/RunViewResolver.js', () => ({
+    RunViewByIDInput: class {},
+    RunViewByNameInput: class {},
+    RunDynamicViewInput: class {},
+}));
+
+vi.mock('../../generic/DeleteOptionsInput.js', () => ({
+    DeleteOptionsInput: class {},
+}));
+
+vi.mock('../../types.js', () => ({
+    RunViewGenericParams: class {},
+}));
+
+vi.mock('@memberjunction/core', async () => {
+    const actual = await vi.importActual<typeof import('@memberjunction/core')>('@memberjunction/core');
+    return {
+        ...actual,
+        LogError: vi.fn(),
+        LogStatus: vi.fn(),
+    };
+});
+
+vi.mock('@memberjunction/core-entities', () => ({}));
+
+// ─── Import after mocks ──────────────────────────────────────────────────
+import { ReportResolverExtended } from '../ReportResolver';
+
+// ─── Helpers ──────────────────────────────────────────────────────────────
+
+function makeReportEntity() {
+    return {
+        ID: 'report-1',
+        Name: '',
+        Description: '',
+        ConversationID: '',
+        ConversationDetailID: '',
+        DataContextID: '',
+        Configuration: '',
+        SharingScope: '',
+        UserID: '',
+        NewRecord: vi.fn(),
+        Save: vi.fn(async () => true),
+    };
+}
+
+function makeContext(getEntityObject: () => ReturnType<typeof makeReportEntity>) {
+    const md = {
+        Entities: [
+            { Name: 'MJ: Conversation Details', SchemaName: 'dbo', BaseView: 'vwConversationDetails' },
+            { Name: 'MJ: Conversations', SchemaName: 'dbo', BaseView: 'vwConversations' },
+        ],
+        GetEntityObject: vi.fn(async () => getEntityObject()),
+    };
+    return {
+        dataSource: { __fakePool: true },
+        userPayload: { email: 'test@example.com' }, // no apiKeyHash -> scope check no-ops
+        providers: [{ type: 'Read-Write', provider: md }],
+    } as unknown as Parameters<ReportResolverExtended['CreateReportFromConversationDetailID']>[1];
+}
+
+describe('ReportResolverExtended.CreateReportFromConversationDetailID', () => {
+    let resolver: ReportResolverExtended;
+
+    beforeEach(() => {
+        resolver = new ReportResolverExtended();
+        mssqlState.inputCalls.length = 0;
+        mssqlState.queryCalls.length = 0;
+        mssqlState.poolArgs.length = 0;
+        mssqlState.recordset.length = 0;
+        mssqlState.recordset.push({
+            Message: JSON.stringify({ title: 'Test Report', userExplanation: 'exp' }),
+            ConversationID: 'conv-1',
+            DataContextID: 'dctx-1',
+        });
+
+        mockUserCacheUsers.length = 0;
+        mockUserCacheUsers.push({ Email: 'test@example.com', ID: 'user-1' });
+    });
+
+    it('binds ConversationDetailID as a query parameter rather than splicing it into the SQL text', async () => {
+        const maliciousID = "1'; DROP TABLE MJ_Reports; --";
+        const context = makeContext(makeReportEntity);
+
+        const result = await resolver.CreateReportFromConversationDetailID(maliciousID, context);
+
+        expect(result.Success).toBe(true);
+
+        // The query text must use a bound parameter, never the raw value.
+        expect(mssqlState.queryCalls).toHaveLength(1);
+        expect(mssqlState.queryCalls[0]).toContain('@ConversationDetailID');
+        expect(mssqlState.queryCalls[0]).not.toContain(maliciousID);
+        expect(mssqlState.queryCalls[0]).not.toContain('DROP TABLE');
+
+        // The value must be bound through request.input, not string concatenation.
+        expect(mssqlState.inputCalls).toHaveLength(1);
+        expect(mssqlState.inputCalls[0].name).toBe('ConversationDetailID');
+        expect(mssqlState.inputCalls[0].value).toBe(maliciousID);
+    });
+
+    it('does not alter query structure for values containing quotes, --, or OR 1=1', async () => {
+        const hostileID = "abc' OR '1'='1' --";
+        const context = makeContext(makeReportEntity);
+
+        await resolver.CreateReportFromConversationDetailID(hostileID, context);
+
+        expect(mssqlState.queryCalls[0]).toMatch(/WHERE\s+cd\.ID=@ConversationDetailID\s*$/);
+        expect(mssqlState.inputCalls[0].value).toBe(hostileID);
+    });
+
+    it('still succeeds end to end for a normal GUID-shaped value', async () => {
+        const normalID = '12345678-1234-1234-1234-123456789012';
+        const context = makeContext(makeReportEntity);
+
+        const result = await resolver.CreateReportFromConversationDetailID(normalID, context);
+
+        expect(result.Success).toBe(true);
+        expect(result.ReportName).toBe('Test Report');
+        expect(mssqlState.inputCalls[0].value).toBe(normalID);
+    });
+});

--- a/packages/MJServer/src/rest/OAuthCallbackHandler.ts
+++ b/packages/MJServer/src/rest/OAuthCallbackHandler.ts
@@ -14,7 +14,7 @@
 
 import express from 'express';
 import { LogError, LogStatus, RunView, UserInfo } from '@memberjunction/core';
-import { UUIDsEqual } from '@memberjunction/global';
+import { IsValidUUID, UUIDsEqual } from '@memberjunction/global';
 import { UserCache } from '@memberjunction/sqlserver-dataprovider';
 import { OAuthManager, MCPClientManager } from '@memberjunction/ai-mcp-client';
 import type { MCPServerOAuthConfig } from '@memberjunction/ai-mcp-client';
@@ -38,6 +38,23 @@ export interface OAuthCallbackHandlerOptions {
     successRedirectUrl?: string;
     /** URL to redirect to after failed authorization */
     errorRedirectUrl?: string;
+    /**
+     * Origins a caller-supplied `frontendReturnUrl` is allowed to point at, so the OAuth callback
+     * cannot be turned into an open redirect from the trusted MJAPI origin. Normally wired to
+     * `cors.allowedOrigins`. Pass `['*']` to allow any origin — MJ's backward-compatible default
+     * CORS posture, and what a deployment that has not narrowed `cors.allowedOrigins` gets.
+     *
+     * REQUIRED on purpose. An optional field defaulting to allow-all is fail-open: a construction
+     * site that forgets it loses the open-redirect protection silently, with nothing to notice.
+     * Being required makes that a compile error instead. The handler is not exported from this
+     * package's barrel and the package declares no subpath exports, so no consumer outside MJServer
+     * can construct it — revisit this if it is ever added to the public API.
+     *
+     * Injected rather than read from `configInfo` directly so this module has no import-time
+     * dependency on configuration loading — importing the config module validates the whole config
+     * as a side effect, which makes this handler unimportable in any context without one.
+     */
+    allowedFrontendOrigins: string[];
 }
 
 /**
@@ -46,10 +63,15 @@ export interface OAuthCallbackHandlerOptions {
  * The callback endpoint is unauthenticated because it's called by external auth servers.
  * It uses the state parameter to look up the authorization context and validate the flow.
  *
+ * NOTE: `allowedFrontendOrigins` is what prevents the callback becoming an open redirect, and is
+ * required so it cannot be forgotten. Wire it to `configInfo.cors?.allowedOrigins`; `['*']` allows
+ * any origin, matching MJ's default CORS posture.
+ *
  * @example
  * ```typescript
  * const oauthHandler = new OAuthCallbackHandler({
- *     publicUrl: 'https://api.example.com'
+ *     publicUrl: 'https://api.example.com',
+ *     allowedFrontendOrigins: configInfo.cors?.allowedOrigins ?? ['*']
  * });
  *
  * // Mount unauthenticated callback route
@@ -348,7 +370,10 @@ export class OAuthCallbackHandler {
      * @param res - Express response
      */
     private async initiateFlow(req: express.Request, res: express.Response): Promise<void> {
-        const { connectionId, additionalScopes, frontendReturnUrl } = req.body;
+        // Coerce request-body values to strings up front. A JSON body can carry arrays/objects, and
+        // passing those downstream unvalidated turns a bad request into a confusing internal failure.
+        const connectionId: string = typeof req.body?.connectionId === 'string' ? req.body.connectionId : '';
+        const { additionalScopes, frontendReturnUrl } = req.body;
         const contextUser = req['mjUser'] as UserInfo;
 
         if (!contextUser) {
@@ -364,6 +389,29 @@ export class OAuthCallbackHandler {
                 success: false,
                 errorCode: 'invalid_request',
                 errorMessage: 'connectionId is required'
+            });
+            return;
+        }
+
+        // connectionId is a record ID (UUID). Reject anything else at the boundary so it can never
+        // reach a SQL filter or downstream consumer as injectable input.
+        if (!IsValidUUID(connectionId)) {
+            res.status(400).json({
+                success: false,
+                errorCode: 'invalid_request',
+                errorMessage: 'connectionId must be a valid record identifier'
+            });
+            return;
+        }
+
+        // Reject a disallowed return URL here rather than at the callback. Otherwise the caller only
+        // finds out after the whole OAuth round trip, by being silently sent to the default page.
+        // An absent value is acceptable — see isFrontendReturnUrlAcceptable.
+        if (!this.isFrontendReturnUrlAcceptable(frontendReturnUrl)) {
+            res.status(400).json({
+                success: false,
+                errorCode: 'invalid_request',
+                errorMessage: 'frontendReturnUrl is not an allowed redirect target'
             });
             return;
         }
@@ -644,10 +692,13 @@ export class OAuthCallbackHandler {
         try {
             const rv = new RunView();
 
-            // Get connection to get server ID
+            // Get connection to get server ID.
+            // connectionId is caller-supplied (POST /oauth/initiate body). MJ ExtraFilter is a raw
+            // SQL fragment, so single quotes MUST be doubled to prevent injection — matching the
+            // escaping used for stateParameter in loadAuthorizationState().
             const connResult = await rv.RunView<{ MCPServerID: string }>({
                 EntityName: ENTITY_MCP_SERVER_CONNECTIONS,
-                ExtraFilter: `ID='${connectionId}'`,
+                ExtraFilter: `ID='${connectionId.replace(/'/g, "''")}'`,
                 Fields: ['MCPServerID'],
                 ResultType: 'simple'
             }, contextUser);
@@ -697,31 +748,92 @@ export class OAuthCallbackHandler {
     }
 
     /**
+     * Validates that a caller-supplied frontend return URL points at an allowed origin, so the
+     * OAuth callback cannot be turned into an open redirect from the trusted MJAPI origin.
+     *
+     * Allowed when: the allowlist is "allow all" (`['*']`, the backward-compatible default),
+     * the URL's origin is in `options.allowedFrontendOrigins`, or it matches the origin of a
+     * built-in success/error redirect URL. Anything else is rejected and the caller falls back to
+     * the default redirect page.
+     */
+    private isFrontendReturnUrlAllowed(url: URL): boolean {
+        const allowed = this.options.allowedFrontendOrigins;
+        if (allowed.includes('*')) {
+            return true;
+        }
+        if (allowed.includes(url.origin)) {
+            return true;
+        }
+        for (const builtIn of [this.options.successRedirectUrl, this.options.errorRedirectUrl]) {
+            try {
+                if (builtIn && new URL(builtIn).origin === url.origin) {
+                    return true;
+                }
+            } catch {
+                // Ignore an unparseable built-in URL and keep checking.
+            }
+        }
+        return false;
+    }
+
+    /**
+     * Parses a caller-supplied return URL and applies {@link isFrontendReturnUrlAllowed}.
+     *
+     * @returns the parsed URL when it is well-formed AND points at an allowed origin, otherwise null.
+     */
+    private parseAllowedFrontendReturnUrl(frontendReturnUrl: string): URL | null {
+        let url: URL;
+        try {
+            url = new URL(frontendReturnUrl);
+        } catch {
+            LogError(`[OAuth Callback] Invalid frontend return URL '${frontendReturnUrl}', falling back to default`);
+            return null;
+        }
+        if (!this.isFrontendReturnUrlAllowed(url)) {
+            LogError(`[OAuth Callback] frontend return URL '${frontendReturnUrl}' origin not allowed, falling back to default`);
+            return null;
+        }
+        return url;
+    }
+
+    /**
+     * Boundary check for `/oauth/initiate` — validates the return URL before it is persisted onto
+     * the authorization state, so a caller gets a 400 instead of a silent fallback later.
+     *
+     * An ABSENT value (undefined / null / empty string) is acceptable: it means "no return URL", and
+     * every downstream consumer treats it that way via a truthiness check. Only a value the caller
+     * actually supplied is validated — otherwise omitting the field, or sending an empty one, would
+     * newly fail a request that has always worked.
+     */
+    private isFrontendReturnUrlAcceptable(frontendReturnUrl: unknown): boolean {
+        if (!frontendReturnUrl) {
+            return true;
+        }
+        return typeof frontendReturnUrl === 'string' && this.parseAllowedFrontendReturnUrl(frontendReturnUrl) !== null;
+    }
+
+    /**
      * Redirects to success page with state info.
      * If a frontend return URL is provided, redirects there instead of the default success page.
      */
     private redirectToSuccess(res: express.Response, state: string, connectionId: string, frontendReturnUrl?: string): void {
-        // If frontend return URL is provided, redirect there with success parameters
-        if (frontendReturnUrl) {
-            try {
-                const url = new URL(frontendReturnUrl);
-                url.searchParams.set('oauth', 'success');
-                url.searchParams.set('state', state);
-                url.searchParams.set('connectionId', connectionId);
-                LogStatus(`[OAuth Callback] Redirecting to frontend URL: ${url.toString()}`);
-                res.redirect(302, url.toString());
-                return;
-            } catch (error) {
-                LogError(`[OAuth Callback] Invalid frontend return URL '${frontendReturnUrl}', falling back to default`);
-                // Fall through to default redirect
-            }
+        // If frontend return URL is provided and points at an allowed origin, redirect there with
+        // success parameters. Anything else falls through to the built-in page.
+        const url = frontendReturnUrl ? this.parseAllowedFrontendReturnUrl(frontendReturnUrl) : null;
+        if (url) {
+            url.searchParams.set('oauth', 'success');
+            url.searchParams.set('state', state);
+            url.searchParams.set('connectionId', connectionId);
+            LogStatus(`[OAuth Callback] Redirecting to frontend URL: ${url.toString()}`);
+            res.redirect(302, url.toString());
+            return;
         }
 
         // Default: redirect to built-in success page
-        const url = new URL(this.options.successRedirectUrl!);
-        url.searchParams.set('state', state);
-        url.searchParams.set('connectionId', connectionId);
-        res.redirect(302, url.toString());
+        const defaultUrl = new URL(this.options.successRedirectUrl!);
+        defaultUrl.searchParams.set('state', state);
+        defaultUrl.searchParams.set('connectionId', connectionId);
+        res.redirect(302, defaultUrl.toString());
     }
 
     /**
@@ -729,27 +841,23 @@ export class OAuthCallbackHandler {
      * If a frontend return URL is provided, redirects there instead of the default error page.
      */
     private redirectToError(res: express.Response, errorCode: string, errorMessage: string, frontendReturnUrl?: string): void {
-        // If frontend return URL is provided, redirect there with error parameters
-        if (frontendReturnUrl) {
-            try {
-                const url = new URL(frontendReturnUrl);
-                url.searchParams.set('oauth', 'error');
-                url.searchParams.set('error', errorCode);
-                url.searchParams.set('error_description', errorMessage);
-                LogStatus(`[OAuth Callback] Redirecting to frontend URL with error: ${url.toString()}`);
-                res.redirect(302, url.toString());
-                return;
-            } catch (error) {
-                LogError(`[OAuth Callback] Invalid frontend return URL '${frontendReturnUrl}', falling back to default`);
-                // Fall through to default redirect
-            }
+        // If frontend return URL is provided and points at an allowed origin, redirect there with
+        // error parameters. Anything else falls through to the built-in page.
+        const url = frontendReturnUrl ? this.parseAllowedFrontendReturnUrl(frontendReturnUrl) : null;
+        if (url) {
+            url.searchParams.set('oauth', 'error');
+            url.searchParams.set('error', errorCode);
+            url.searchParams.set('error_description', errorMessage);
+            LogStatus(`[OAuth Callback] Redirecting to frontend URL with error: ${url.toString()}`);
+            res.redirect(302, url.toString());
+            return;
         }
 
         // Default: redirect to built-in error page
-        const url = new URL(this.options.errorRedirectUrl!);
-        url.searchParams.set('error', errorCode);
-        url.searchParams.set('error_description', errorMessage);
-        res.redirect(302, url.toString());
+        const defaultUrl = new URL(this.options.errorRedirectUrl!);
+        defaultUrl.searchParams.set('error', errorCode);
+        defaultUrl.searchParams.set('error_description', errorMessage);
+        res.redirect(302, defaultUrl.toString());
     }
 
     /**


### PR DESCRIPTION
**One sentence:** this backports the three outstanding security commits onto `lts/5` so 5.51.1 can be published, and it is the first time that pick set has ever been compiled or tested — which surfaced one real CI-blocking type error and one broken test, both fixed here.

## The three cherry-picks

Each was applied with `git cherry-pick -x` in this order onto `lts/5` tip `d6ff8f384c`, so every commit message carries its source SHA.

| Pick | Source | What it fixes |
|---|---|---|
| `9bd0f1cf86` | `a71aa0bd` (#3410) | `RunView`'s `ExcludeUserViewRunID` was interpolated raw into the view `WHERE` clause with no validation (all sibling clauses go through `ValidateUserProvidedSQLClause`) — now GUID-checked; `WAITFOR` denied in user filter/order-by clauses; `SQLExpressionValidator` now denies system catalogs (`sys.*`, `INFORMATION_SCHEMA`, `pg_catalog.*`, `pg_authid`…) in **all** contexts including `full_query`; superadmin `MJ_API_KEY` compared in constant time; JWT algorithms pinned to the asymmetric family on both the MJServer issuer path and MCPServer's JWKS path. |
| `9ae2671670` | `cf651b13` (#3428) | `ReportResolver.CreateReportFromConversationDetailID` binds `ConversationDetailID` as a parameterized `UniqueIdentifier`; `CheckRecordRLS` escapes embedded quotes in primary-key values; `MarkupFilterText` escapes substituted user-property values and stops substituting the literal string `"undefined"`. |
| `e10a71f6fc` | `cefc302d9b` (#3633) | SQL literal stripping that honors SQL-standard `''` rather than backslash escaping; `connectionId` UUID-validated and escaped in the OAuth callback; `frontendReturnUrl` origin validated against `cors.allowedOrigins` (open-redirect guard); `ValidateKeyByHash` asserts a SHA-256 digest; the new-user domain gate authorizes against the **verified token's email domain** instead of the spoofable `Origin` header. |

All five call sites covered by #3410 were confirmed vulnerable on `lts/5` before picking.

## Conflict resolutions

Three conflicts, all pre-documented and verified here:

1. **`packages/MJCore/src/generic/databaseProviderBase.ts` import** — `StripSQLStringLiterals` added to the existing `@memberjunction/global` import. Kept the 5.x module path, took the new symbol.
2. **`packages/MJServer/src/rest/OAuthCallbackHandler.ts` import** — `IsValidUUID` added alongside `UUIDsEqual`, same package. Same resolution shape.
3. **`packages/MJServer/src/__tests__/newUsers.test.ts`** — a delete/modify conflict, since the file does not exist on `lts/5`. Resolved by taking #3633's version. Viability was pre-checked (`NewUserBase` is exported at `packages/MJServer/src/auth/newUsers.ts:7`, `verifyUserRecord` at `packages/MJServer/src/auth/index.ts:189`, and MJServer already has a vitest `__tests__` directory).

Separately, #3633 also moved MJServer's `UserCache` import to a package that only owns it on `next`; the resolution deliberately kept `lts/5`'s `@memberjunction/sqlserver-dataprovider` path. That decision is correct but had a consequence — see the second fix below.

## ⚠️ Two fixes this PR adds beyond the picks

Neither pick had ever been compiled or run on this line. Both problems below are real and would have failed CI or shipped broken.

### 1. `0fffcdafec` — the constant-time comparison did not compile on `lts/5`

`packages/MJServer/src/context.ts` passes `createHash().digest()` Buffers to `timingSafeEqual`. That compiles on `next`, which resolves `@types/node@24.10.11`. But `lts/5`'s root `package.json` pins `"@types/node": "20.14.2"` in `overrides` — which **defeats MJServer's own declared `24.10.11`** — and that version types the function as `timingSafeEqual(a: NodeJS.ArrayBufferView, b: NodeJS.ArrayBufferView)`, which its non-generic `Buffer` does not satisfy under TypeScript 5.9's generic `Uint8Array<TArrayBuffer>` lib types:

```
src/context.ts(436,27): error TS2345: Argument of type 'Buffer' is not assignable to parameter of type 'ArrayBufferView'.
```

Fixed by wrapping each digest in `new Uint8Array(...)`. Both digests are always 32 bytes and the copy is content-independent, so the comparison remains constant time and the behavior is identical. No cast, no `any`.

This reproduces under `npm ci`, not just `npm install` — see the verification note below.

### 2. `67dfd263bd` — the adopted `newUsers.test.ts` could not run on `lts/5`

The test mocks `@memberjunction/generic-database-provider` to supply `UserCache`, which is where that class lives on `next`. On the 5.x line it is exported by `@memberjunction/sqlserver-dataprovider` — the path resolution 3 above deliberately kept — so the mock intercepted nothing, the real `SQLServerDataProvider` loaded, and its `config.ts` failed on a `GenericDatabaseProvider` export the mock never provided:

```
Error: [vitest] No "GenericDatabaseProvider" export is defined on the
"@memberjunction/generic-database-provider" mock.
 ❯ ../SQLServerDataProvider/src/config.ts:2:1
```

Fixed by re-pointing that one `vi.mock` at `@memberjunction/sqlserver-dataprovider`. **No assertions were changed** — all 37 tests then pass, including the ones that matter most here: "does NOT create when a forged Origin is authorized but the email domain is not", wildcard apex/prefix/suffix confusion, and the username-only-IdP denial.

The documented fallback was to drop the file if it broke. That was not needed — the one-line re-point was sufficient, so the 726 lines of coverage over the most behavior-changing part of this backport are retained.

## Verification

Everything below ran in an isolated worktree on this exact branch.

**Install** — `npm install` succeeded, then `npm ci` (what every CI workflow on this line actually runs) was used for the authoritative tree. Worth knowing: `lts/5` pins `@types/node` globally via `overrides`, so MJServer resolves `20.14.2` under **both** install paths despite the lockfile recording a nested `24.10.11`. The type error above is therefore genuinely CI-blocking, not a local artifact.

**Build** — `turbo build` over all six affected packages plus their transitive dependencies: **172/172 tasks successful, 0 TypeScript errors.**

**Tests** — every package with source changes, full suites, not just the new files:

| Package | Result |
|---|---|
| `@memberjunction/global` | 20 files, **597 passed** |
| `@memberjunction/core` | 103 files, **1617 passed** |
| `@memberjunction/generic-database-provider` | 18 files, **842 passed**, 5 skipped |
| `@memberjunction/server` | 56 files, **806 passed**, 56 skipped |
| `@memberjunction/api-keys` | 6 files, **173 passed** |
| `@memberjunction/ai-mcp-server` | 5 files, **113 passed** |

**Total: 4,148 passed, 61 skipped, 0 failed.**

One MJServer suite (`mjapi-bootstrap.test.ts`) failed until `mj_generatedentities` and `mj_generatedactions` were built — it transitively imports the whole MJAPI bootstrap graph. It is untouched by this PR and passes once those packages exist, which CI's `turbo run build` does for it. Called out only so nobody re-diagnoses it.

## Changesets → 5.51.1 is automatic

`.changeset/config.json` is lockstep (`fixed: [["@memberjunction/*"]]`), so the exact package list in any changeset does not affect the resulting version.

- `harden-sql-filter-oauth-and-domain-gate.md` arrives with the #3633 pick — all patch.
- `action-filter-evaluation-hotfix.md` (#3539) was already banked on `lts/5` — patch.
- `cc6f321f6c` adds one hand-written all-patch changeset covering #3410 and #3428, which arrived changeset-less, so they appear in the release notes.

All patch + lockstep ⇒ **5.51.1** falls out with no manual version work.

## What a reviewer should scrutinize

1. **`new Uint8Array(...)` in `context.ts`** — this is security-sensitive code. The claim is that copying two fixed-length 32-byte digests is content-independent and preserves constant-time comparison. Please confirm you agree.
2. **Adopting `newUsers.test.ts` at all** — 726 lines of test arriving from `next` into a line whose module topology differs. It passes, and the mock change is one line, but it is the largest single file in the diff.
3. **The behavior change in #3633's changeset** — `userHandling.newUserAuthorizedDomains` now matches the verified token's **email domain**, not the request `Origin`. Deployments that listed frontend hostnames must update their config. The gate is off by default. Fully documented in that changeset.
4. **Not included on purpose:** `npm install` rewrites 2,549 line-pairs of `package-lock.json` because the committed lockfile still records the workspace packages at `5.50.0` while their `package.json` files say `5.51.0`. I verified that churn is *exclusively* that version-string rewrite (normalizing `5.50.0`→`5.51.0` makes the two files byte-identical — zero dependency-tree change), so I left it out rather than bury a security patch in 5,098 lines of noise. It is pre-existing `lts/5` drift and does not block `npm ci`, which exits 0 on pristine `lts/5`.

## Next step after merge

One `publish-lts.yml` dispatch on `lts/5`, run by the release coordinator. Nothing for the merger to do beyond merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QnZaUxhuvSKe26rqvWuD6e
