### PR TITLE
fix(metadata): remove invalid entries from the hierarchy configuration seed

### DIFF
--- a/.changeset/fix-hierarchy-metadata-invalid-entries.md
+++ b/.changeset/fix-hierarchy-metadata-invalid-entries.md
@@ -1,0 +1,29 @@
+---
+"@memberjunction/core-entities": minor
+---
+
+fix(metadata): remove invalid entries from the hierarchy configuration seed
+
+`metadata/entities/.entity-field-hierarchy-configurations.json` (added in #3939) declared
+`Hierarchy.IsHierarchy` for four entities that cannot resolve. `mj sync push` runs in a single
+transaction, so any one bad `@lookup` rolls the whole push back — meaning **no** `Configuration`
+value was seeded for **any** entity, not just the four. With `IsHierarchy` then false everywhere,
+the next `mj codegen` regenerated every base view without its hierarchy projections and dropped
+the `Root*ID` columns the migrations had correctly created, leaving `EntityField` rows demanding
+columns that no longer existed (`Invalid column name 'RootParentID'`). On a from-scratch database
+this made `mj sync push` and `mj codegen` both unrunnable.
+
+- `MJ: Prompt Categories` → `MJ: AI Prompt Categories`. No entity by the former name exists; the
+  latter has the `ParentID` self-referencing FK the entry intends, and `vwAIPromptCategories`
+  already carries `RootParentID`.
+- Removed `MJ: Resource Types`, `MJ: Roles` and `MJ: Tests`. Each declared a `ParentID` hierarchy,
+  but none has a `ParentID` field, a self-referencing FK, or any parent column on its underlying
+  table (`ResourceType`, `Role`, `Test`) — so the lookups could never resolve.
+
+Verified on a database built from migrations alone: `mj sync push` now completes (13,777 records,
+0 errors) and seeds all 14 remaining declarations.
+
+Not addressed here — 18 `RootParentID` fields on genuine tree entities remain undeclared, and the
+seed file's `Name=ParentID` shape cannot express non-`ParentID` hierarchy fields such as
+`ParentArchitectureID` or `ParentChunkID`. Both need a decision on the opt-in surface rather than
+another entry.

--- a/metadata/entities/.entity-field-hierarchy-configurations.json
+++ b/metadata/entities/.entity-field-hierarchy-configurations.json
@@ -53,54 +53,6 @@
   },
   {
     "fields": {
-      "Name": "MJ: Resource Types"
-    },
-    "relatedEntities": {
-      "MJ: Entity Fields": [
-        {
-          "fields": {
-            "Configuration": {
-              "Hierarchy": {
-                "IsHierarchy": true
-              }
-            }
-          },
-          "primaryKey": {
-            "ID": "@lookup:MJ: Entity Fields.EntityID=@lookup:MJ: Entities.Name=MJ: Resource Types&Name=ParentID"
-          }
-        }
-      ]
-    },
-    "primaryKey": {
-      "ID": "@lookup:MJ: Entities.Name=MJ: Resource Types"
-    }
-  },
-  {
-    "fields": {
-      "Name": "MJ: Roles"
-    },
-    "relatedEntities": {
-      "MJ: Entity Fields": [
-        {
-          "fields": {
-            "Configuration": {
-              "Hierarchy": {
-                "IsHierarchy": true
-              }
-            }
-          },
-          "primaryKey": {
-            "ID": "@lookup:MJ: Entity Fields.EntityID=@lookup:MJ: Entities.Name=MJ: Roles&Name=ParentID"
-          }
-        }
-      ]
-    },
-    "primaryKey": {
-      "ID": "@lookup:MJ: Entities.Name=MJ: Roles"
-    }
-  },
-  {
-    "fields": {
       "Name": "MJ: Dashboard Categories"
     },
     "relatedEntities": {
@@ -317,7 +269,7 @@
   },
   {
     "fields": {
-      "Name": "MJ: Prompt Categories"
+      "Name": "MJ: AI Prompt Categories"
     },
     "relatedEntities": {
       "MJ: Entity Fields": [
@@ -330,13 +282,13 @@
             }
           },
           "primaryKey": {
-            "ID": "@lookup:MJ: Entity Fields.EntityID=@lookup:MJ: Entities.Name=MJ: Prompt Categories&Name=ParentID"
+            "ID": "@lookup:MJ: Entity Fields.EntityID=@lookup:MJ: Entities.Name=MJ: AI Prompt Categories&Name=ParentID"
           }
         }
       ]
     },
     "primaryKey": {
-      "ID": "@lookup:MJ: Entities.Name=MJ: Prompt Categories"
+      "ID": "@lookup:MJ: Entities.Name=MJ: AI Prompt Categories"
     }
   },
   {
@@ -361,30 +313,6 @@
     },
     "primaryKey": {
       "ID": "@lookup:MJ: Entities.Name=MJ: Tags"
-    }
-  },
-  {
-    "fields": {
-      "Name": "MJ: Tests"
-    },
-    "relatedEntities": {
-      "MJ: Entity Fields": [
-        {
-          "fields": {
-            "Configuration": {
-              "Hierarchy": {
-                "IsHierarchy": true
-              }
-            }
-          },
-          "primaryKey": {
-            "ID": "@lookup:MJ: Entity Fields.EntityID=@lookup:MJ: Entities.Name=MJ: Tests&Name=ParentID"
-          }
-        }
-      ]
-    },
-    "primaryKey": {
-      "ID": "@lookup:MJ: Entities.Name=MJ: Tests"
     }
   },
   {


### PR DESCRIPTION
## Summary

`metadata/entities/.entity-field-hierarchy-configurations.json` (added in #3939) declares `Hierarchy.IsHierarchy` for four entities that cannot resolve. Because `mj sync push` runs in a **single transaction**, one bad `@lookup` rolls back the entire push — so **no** entity got its `Configuration` seeded, not just the four.

With `IsHierarchy` false everywhere, the next `mj codegen` regenerated every base view without its hierarchy projections and dropped the `Root*ID` columns the migrations had correctly created. `EntityField` rows were left demanding columns that no longer existed:

```
Error: Invalid column name 'RootParentID'.
Query: SELECT …,[RootParentID] FROM [__mj].[vwActions]
```

On a database built from what the repo ships, this made **both `mj sync push` and `mj codegen` unrunnable** — nine engines failed to load and CodeGen crashed with `TypeError: Cannot read properties of undefined (reading 'filter')`.

## The four invalid entries

| Entry | Problem |
|---|---|
| `MJ: Prompt Categories` | No entity by that name exists |
| `MJ: Resource Types` | Declares a `ParentID` hierarchy — no `ParentID` field, no self-ref FK, no parent column on table `ResourceType` |
| `MJ: Roles` | Same, on table `Role` |
| `MJ: Tests` | Same, on table `Test` |

All 17 entries were validated against a live database; the other 13 are correct.

**Fixes**
- `MJ: Prompt Categories` → `MJ: AI Prompt Categories`. The latter has the `ParentID` self-referencing FK the entry intends, and `vwAIPromptCategories` already carries `RootParentID`.
- Removed the three entries whose hierarchies do not exist in the schema at any level.

## Verification

Built a database from migrations alone (`MJ_v6_1_3_test`), then:

| Step | Before | After |
|---|---|---|
| `mj sync push` | ✖ aborted, transaction rolled back | ✅ **13,777 records, 0 errors** |
| `EntityField` rows with `Configuration` seeded | 0 | **14** |
| `mj codegen` | ✖ crashed | ✅ 379 entities, no errors |
| `vwTasks.RootParentID` after codegen | dropped | **retained** |

Also confirms the ordering in [`CLAUDE.md`](CLAUDE.md): `mj sync push` must precede `mj codegen`. Run the other way on a fresh database, CodeGen regenerates views from unseeded metadata and destroys correct schema. The `bootstrap-clean-db` skill currently documents the opposite order and should be corrected separately.

## Not addressed here

Deliberately scoped to entries that are demonstrably invalid. Three things remain and need a decision on the opt-in surface rather than another entry:

1. **18 `RootParentID` fields on genuine tree entities are undeclared** — `MJ: Actions`, `MJ: AI Agents`, `MJ: AI Configurations`, `MJ: Action Categories`, and others — so they lose hierarchy support after CodeGen.
2. **The seed file's `Name=ParentID` shape cannot express non-`ParentID` hierarchies.** `ParentArchitectureID`, `ParentChunkID` and `ParentRunID` are real trees with no way to opt in.
3. **No cleanup path for stale `Root*ID` `EntityField` rows.** CodeGen retains rows for hierarchies that no longer qualify; 12 such rows remain (`LastRunID`, `ConsolidatedIntoNoteID`, `MergedIntoTagID`, …). Most of these are correctly no longer projected — per #3939 they were never trees — but nothing removes the leftovers.

Separately, #3939's changeset does not flag that hierarchy generation became opt-in. Downstream apps with self-referencing FKs in their own schemas get no back-fill (the migration only adds the column; seeding covers the core MJ schema only) and no cleanup, so `mj codegen` after upgrade would break them the same way.

## Test plan

- [x] JSON validates; 14 entries remain, all names verified against `__mj.Entity`
- [x] `mj sync push --dir=./metadata` — 13,777 records, 0 errors
- [x] `mj codegen --skipfiles` — 379 entities, no `Invalid column` errors, hierarchy view columns retained
- [x] `npm run check:changeset` — `Branch touches metadata — minor is required` ✅
- [ ] Full `pnpm run build` — not run; blocked on an unrelated pre-existing `ng-base-forms` type error on `next` (`RelatedFormRoleCandidate.Configuration` is `string | null` while `EntityRelationshipInfo.Configuration` now yields `IEntityRelationshipConfiguration`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
