### PR TITLE
fix: ng-base-forms Configuration type mismatch breaking the full build on next

### DIFF
--- a/.changeset/related-form-role-candidate-configuration-union.md
+++ b/.changeset/related-form-role-candidate-configuration-union.md
@@ -1,0 +1,7 @@
+---
+"@memberjunction/core": patch
+---
+
+`RelatedFormRoleCandidate.Configuration` now accepts `IEntityRelationshipConfiguration` as well as the raw JSON string.
+
+`EntityRelationshipInfo.Configuration` became a lazily-parsed getter returning the typed object, and the three readers that consume a candidate's bag (`ReadRelationshipInclusion`, `ReadRelationshipSortKey`, `ReadRelationshipJoinFields`) were widened to take either shape — but the candidate DTO itself was left declared `string | null`, so every caller that builds a candidate from an `EntityRelationshipInfo` failed to compile. Widening the field to the same union unbreaks `@memberjunction/ng-base-forms` and `@memberjunction/ng-core-entity-forms`; candidates built straight from a metadata row still pass the string.

--- a/packages/MJCore/src/generic/entityConfiguration.ts
+++ b/packages/MJCore/src/generic/entityConfiguration.ts
@@ -119,7 +119,15 @@ export interface RelatedFormRoleCandidate {
     JoinView?: string | null;
     Type?: string | null;
     Sequence?: number | null;
-    Configuration?: string | null;
+    /**
+     * Either shape is accepted, matching the readers below
+     * ({@link ReadRelationshipInclusion}, {@link ReadRelationshipSortKey},
+     * {@link ReadRelationshipJoinFields}): a candidate built from an
+     * `EntityRelationshipInfo` carries the parsed object its `Configuration`
+     * getter returns, while one built straight from a metadata row carries the
+     * raw JSON string.
+     */
+    Configuration?: string | IEntityRelationshipConfiguration | null;
     /**
      * How many EntityRelationships across metadata point at this related
      * entity. Runtime-only — the ranker uses it as graph in-degree.


### PR DESCRIPTION
**One sentence:** `EntityRelationshipInfo.Configuration` became a lazily-parsed getter that returns the typed object, but the `RelatedFormRoleCandidate` DTO it gets copied into was left declared `string | null` — so this widens that one field to the same string-or-object union the readers already accept, unbreaking the full build on `next`.

## The breaking commit and its intent

`1f6c1ffbfd` (AN-BC, in #3948 — *"strongly-typed lazy Configuration parsing for Entity, EntityField, and EntityRelationship info classes"*) deliberately turned `Configuration` on `EntityInfo`, `EntityFieldInfo`, and `EntityRelationshipInfo` into a **getter that returns the parsed object**, with a setter accepting a string or an object. That intent is explicit and tested — `packages/MJCore/src/__tests__/metadata.configuration.test.ts`, added in the same commit, asserts `rel.Configuration?.UI?.inclusion` reads through as an object and that assigning either shape works.

The same commit widened every function that reads one of these bags to `string | I…Configuration | null | undefined`: `ParseEntityConfiguration`, `ParseEntityRelationshipConfiguration`, `ParseEntityFieldConfiguration`, `ReadRelationshipInclusion`, `ReadRelationshipSortKey`, `ReadRelationshipJoinFields`. The plain-DTO field `RelatedFormRoleCandidate.Configuration` was the one spot that didn't get the same treatment, so copying the now-parsed value into a candidate stopped type-checking:

```
packages/Angular/Generic/base-forms: src/lib/chrome/resolve-form-chrome.ts:706:9 - error TS2322:
Type 'IEntityRelationshipConfiguration | null' is not assignable to type 'string | null | undefined'.
```

Both existing producers hit it — `resolve-form-chrome.ts:706` (`toCandidate`) and `entity-form.component.ts:744` (`FormChromeCandidates`) — so `ng-core-entity-forms` was the next package in line to fail once `ng-base-forms` was fixed.

## Why the PR check was green while `next` went red

**The merge backstop did catch this** — `next` has been failing on `@memberjunction/ng-base-forms#build` since #3948 landed ([run 32192025184](https://github.com/MemberJunction/MJ/actions/runs/32192025184), and still at `8194ed723c` in [run 32206453145](https://github.com/MemberJunction/MJ/actions/runs/32206453145)). It was the *PR-time* check that missed it: #3948's last `pull_request` run started at 22:17:20Z against head `dcc6f7e0fe`, the PR was merged 14 seconds later at 22:17:34Z, and by the time that run's "Determine test scope" step fetched `origin/next` at 22:19:59Z the merge had already landed — so `--filter=...[origin/next]` diffed the head against a `next` that already contained it, turbo reported `Packages in scope:` (empty) and `Running build in 0 packages`, and the job passed in 2m50s having compiled nothing.

Worth a reviewer's attention: that race makes *any* PR merged shortly after its final CI run start report a vacuous green unit-test check. Not fixed here — flagging it as a separate CI hardening item (e.g. pin the filter to the merge-base captured at checkout rather than re-fetching `origin/next`, or fail the step when the selected package set is empty on a PR that changed files under `packages/`).

The earlier red backstops that day (runs `32154481411`, `32155072137`, `32155199504`, `32185619945`) were a different, already-fixed problem — all four failed at "Install dependencies", cleared by `1f4af2b858` regenerating the lockfile. This type error is the only thing keeping `next` red now.

## The fix

One field, one union — no cast, no `any`, no behavior change:

```ts
Configuration?: string | IEntityRelationshipConfiguration | null;
```

Both shapes have to stay legal: a candidate built from an `EntityRelationshipInfo` carries the parsed object its getter returns, while one built straight from a metadata row carries the raw JSON string (which is what MJCore's own `entityConfiguration.test.ts` passes). The three readers already accept either, so nothing downstream changes. Plus a patch changeset for `@memberjunction/core`.

## Proof

Built in a clean worktree off `8194ed723c` after a `pnpm install --frozen-lockfile`:

- `turbo run build --filter=@memberjunction/ng-base-forms... --filter=@memberjunction/ng-core-entity-forms...` — **203 successful, 203 total**, exit 0 (both formerly-failing packages plus every dependency).
- Workspace-wide `turbo run build` — **307 successful, 308 total**. The single failure is `mj_explorer#build`, and it is unrelated to this change: `mj_explorer` sits *outside* the `--filter="@memberjunction*"` scope that the root `build:stream` (i.e. `pnpm run build`, what docs.yml runs) uses, and it fails in any fresh checkout because `packages/MJExplorer/src/environments/environment.ts` is gitignored (`.gitignore:109`) and therefore absent. Every one of the 304 packages the docs build actually compiles is green.
- `@memberjunction/core` — 139 test files, **2082 tests passed**.
- `@memberjunction/ng-base-forms` — 24 test files, **294 tests passed**.
- `@memberjunction/ng-core-entity-forms` — 32 test files, **279 tests passed**.
- `turbo run test:types test` for all three — 71 successful, 71 total (the `tsc --noEmit -p tsconfig.spec.json` spec gate included).

## Why this is urgent

The red full build is **blocking the versioned docs deploy** ([docs.yml run 32208676764](https://github.com/MemberJunction/MJ/actions/runs/32208676764), which builds all packages). Since #3911 landed, docs no longer deploy on push to `next` — after this merges the docs redeploy needs a **`workflow_dispatch` of docs.yml**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QnZaUxhuvSKe26rqvWuD6e
