### PR TITLE
ci: build the Edge docs set from main, not next (docs describe released state)

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -10,12 +10,13 @@ name: Update package documentation
 #   /      ← redirect to the newest LTS set
 #   404    ← forwards legacy pre-versioning URLs into the newest LTS set
 #
-# EVERY docs set is built from a RELEASED ref — never from next. main is caught
-# up by the act of releasing, so the Edge set documents what users can actually
-# install, and a docs deploy no longer depends on next compiling at all. (That
-# dependency was not theoretical: the first chained line-release deploy, run
-# 32208676764, failed in "Build v6 (next)" on an unrelated next-only type break,
-# and the whole site's deploy was skipped because `deploy` needs `build`.)
+# EVERY docs set's CONTENT is built from a RELEASED ref — never from next: main
+# for the Edge line, the lts/N branch for each line. main is caught up by the act
+# of releasing, so the Edge set documents what users can actually install, and a
+# docs deploy no longer depends on next compiling at all. (That dependency was
+# not theoretical: the first chained line-release deploy, run 32208676764, failed
+# in "Build v6 (next)" on an unrelated next-only type break, and the whole site's
+# deploy was skipped because `deploy` needs `build`.)
 #
 # What comes from where — the ONE seam in this design:
 #   content ref (main, lts/N)  everything ingest reads out of the repo: guides/,
@@ -196,6 +197,28 @@ jobs:
       # while a change to a page inside docs-site/ publishes on the next docs
       # deploy. Nothing here reads product code, so the overlay cannot resurrect
       # the next-must-compile dependency this design removes.
+      #
+      # RETIRING THIS STEP (the goal — page-affecting source should come from a
+      # released ref too). It is really a compatibility shim for lts/5, which was
+      # cut before versioned docs existed: that branch's docs-site is 16 files
+      # behind, with no DOCS_VERSIONS support and no ThemeSelect override, so
+      # without the overlay /v5 would lose its version switcher outright. Lines
+      # cut from next after this point carry a current docs-site by construction,
+      # so the shim ages out with lts/5.
+      #
+      # For the Edge set the overlay is redundant with the release flow — main
+      # receives next's docs-site at every release — but it CANNOT be dropped
+      # yet: main's docs-site has no src/lib/license-line.mjs (so /v6 would lose
+      # the ISC-vs-BUSL distinction entirely) and no mjcertified.mdx, which the
+      # BUSL Additional Use Grant names by URL and the deploy job's /mjcertified
+      # redirect points at. Dropping it today would 404 that front door.
+      #
+      # So the gate is mechanical: once main's docs-site carries mjcertified.mdx,
+      # src/lib/license-line.mjs, src/lib/documented-line.mjs and the ThemeSelect
+      # override — which the next Edge release delivers on its own — this step can
+      # take `if: matrix.ref != 'main'` and /v6 renders entirely from released
+      # code. Check with:
+      #   git ls-tree -r origin/main docs-site/ | grep -E 'mjcertified|license-line|documented-line|ThemeSelect'
       - name: Overlay docs-site tooling from the triggering commit
         run: |
           set -euo pipefail

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -5,12 +5,28 @@ name: Update package documentation
 #
 #   /v5/…  ← content at lts/5 (one set per lts/* branch — the branch IS the
 #            line's certification artifact, so no ref is hardcoded here)
-#   /v6/…  ← content at next (the Edge line; major from the newest v*-edge tag)
+#   /v6/…  ← content at MAIN (the Edge line's released state; the major itself
+#            comes from the newest v*-edge tag)
 #   /      ← redirect to the newest LTS set
 #   404    ← forwards legacy pre-versioning URLs into the newest LTS set
 #
-# Every build uses the docs-site/ TOOLING from next (overlaid onto the content
-# checkout), so ingest/site fixes apply to all versions without cherry-picks.
+# EVERY docs set is built from a RELEASED ref — never from next. main is caught
+# up by the act of releasing, so the Edge set documents what users can actually
+# install, and a docs deploy no longer depends on next compiling at all. (That
+# dependency was not theoretical: the first chained line-release deploy, run
+# 32208676764, failed in "Build v6 (next)" on an unrelated next-only type break,
+# and the whole site's deploy was skipped because `deploy` needs `build`.)
+#
+# What comes from where — the ONE seam in this design:
+#   content ref (main, lts/N)  everything ingest reads out of the repo: guides/,
+#                              root docs, packages/**/README.md, releases/,
+#                              .claude/skills/, the built packages, the TypeDoc
+#                              API reference, and the commit its GitHub links pin
+#   docs-site/ from next       the Astro app, Starlight component overrides,
+#                              src/lib/* rendering logic, the hand-authored pages
+#                              under docs-site/src/content/docs/, and ingest
+#                              itself — overlaid onto every content checkout so
+#                              site fixes never need cherry-picking to a line
 # Because this file lives on the default branch (next), the workflow_run
 # trigger fires from here regardless of what main or lts/* carry.
 
@@ -19,8 +35,10 @@ on:
   # side effect of merging. Between releases both `main` and the npm registry
   # lag `next`, so a merge-triggered deploy publishes authoritative-looking
   # documentation — canonical links into `main` included — for bits nobody can
-  # install yet. The resolve job below hard-fails a trigger that did not
-  # conclude `success`.
+  # install yet. The content refs above enforce the same thing from the other
+  # direction: even a deploy triggered off-cycle can only publish released
+  # content. The resolve job below hard-fails a trigger that did not conclude
+  # `success`.
   #
   # `main` ONLY, and `next` is deliberately absent: no docs deploy is ever
   # triggered by an event on next (the trigger removed in #3911 does not come
@@ -109,7 +127,9 @@ jobs:
           # of `sort -n` (sort -n orders 6.10 before 6.9), and the 404
           # forwarder's `^(\/v\d+)\/` deep-link regex.
           mapfile -t LTS < <(git ls-remote --heads origin 'lts/*' | sed -E 's#.*refs/heads/lts/##' | grep -E '^[0-9]+$' | sort -n)
-          # Edge set: built from next; its major comes from the newest edge tag.
+          # Edge set: the major comes from the newest edge TAG (tags are pushed by
+          # the publish workflow, so this is released state too), and its content
+          # is built from main — see the ref below.
           EDGE_MAJOR=$(git ls-remote --tags origin 'v*-edge.*' | sed -E 's#.*refs/tags/v##; s#\^\{\}$##' | sort -uV | tail -1 | cut -d. -f1)
 
           MATRIX='[]'
@@ -119,7 +139,10 @@ jobs:
             VERSIONS=$(jq -c --arg id "v$major" --arg label "v$major (LTS)" '. + [{id: $id, label: $label}]' <<<"$VERSIONS")
           done
           if [ -n "$EDGE_MAJOR" ] && ! printf '%s\n' ${LTS[@]+"${LTS[@]}"} | grep -qx "$EDGE_MAJOR"; then
-            MATRIX=$(jq -c --arg id "v$EDGE_MAJOR" '. + [{id: $id, ref: "next"}]' <<<"$MATRIX")
+            # main, NOT next: the Edge line's docs describe the newest RELEASED
+            # Edge build, which is exactly what main carries after publish.yml
+            # pushes the release commit there.
+            MATRIX=$(jq -c --arg id "v$EDGE_MAJOR" '. + [{id: $id, ref: "main"}]' <<<"$MATRIX")
             VERSIONS=$(jq -c --arg id "v$EDGE_MAJOR" --arg label "v$EDGE_MAJOR (Edge)" '. + [{id: $id, label: $label}]' <<<"$VERSIONS")
           else
             echo "::warning::No distinct Edge line to publish (edge major: '$EDGE_MAJOR', LTS lines: ${LTS[*]:-none}) — an lts/N branch supersedes the Edge set for the same major."
@@ -150,19 +173,29 @@ jobs:
         include: ${{ fromJSON(needs.resolve.outputs.matrix) }}
     steps:
       # fetch-depth 0 serves two needs: Starlight's lastUpdated reads per-file
-      # git history, and the full fetch brings origin/next for the tooling
-      # overlay below.
+      # git history, and the full fetch brings the triggering commit (next's head
+      # in normal operation) into this checkout so the tooling overlay below can
+      # reach it. Now that no content ref is ever `next`, that second need is the
+      # only reason next appears in this job at all — do not narrow the fetch.
       - name: Checkout content ref
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
           ref: ${{ matrix.ref }}
 
-      # The site tooling (ingest, Astro config, hand-authored pages) always
-      # comes from the commit that triggered this run — next in normal
-      # operation — whatever ref the content is at. This is what makes tooling
-      # fixes (e.g. the internal-page exclusions) apply to every version
-      # without cherry-picking to lts/* branches.
+      # The site tooling (ingest, Astro config, src/lib rendering logic, and the
+      # hand-authored pages under docs-site/src/content/docs/) always comes from
+      # the commit that triggered this run — next in normal operation — whatever
+      # ref the content is at. This is what makes tooling fixes (e.g. the
+      # internal-page exclusions) apply to every version without cherry-picking
+      # to lts/* branches.
+      #
+      # It is also the one place where the released-content rule does not reach,
+      # and the asymmetry is worth knowing before you write docs: a change to
+      # guides/ or a package README publishes only once it reaches a released ref,
+      # while a change to a page inside docs-site/ publishes on the next docs
+      # deploy. Nothing here reads product code, so the overlay cannot resurrect
+      # the next-must-compile dependency this design removes.
       - name: Overlay docs-site tooling from the triggering commit
         run: |
           set -euo pipefail


### PR DESCRIPTION
**One sentence:** the Edge line's docs set (`/v6`) now builds its content from `main` instead of `next`, so every docs set on the site — LTS lines and Edge alike — comes from a released ref, and a docs deploy no longer depends on `next` compiling.

## Craig's ruling

> "we don't want docs to be generated based on next"

and, sharpening it:

> "docs build should ONLY follow a release"
>
> "the basis of the docs should be `main` for edge and the lts/ branch for lts"

`main` is caught up by the act of releasing, so the Edge docs describe what users can actually install, and the docs pipeline stops being coupled to whatever is mid-flight on `next`. The line sets already satisfied the second half (`/vN` ← `lts/N`); this PR makes the Edge set match.

## The concrete failure this fixes

Tonight's **run [32208676764](https://github.com/MemberJunction/MJ/actions/runs/32208676764)** — the first chained docs deploy from the new line-release path (`workflow_dispatch`, branch `next`):

| Job | Result |
|---|---|
| Resolve release lines to build | success |
| **Build v6 (next)** | **failure** — unrelated next-only type break (ng-base-forms vs MJCore, separate fix in flight) |
| Build v5 (lts/5) | **cancelled** by matrix fail-fast, despite having nothing to do with the break |
| Assemble and deploy | skipped (`deploy` needs `build`) |

The site was left unchanged: a line release published correctly to npm and its docs never shipped, because an in-progress change on a branch nobody released broke the build. The break arrived with #3948, which is **next-only** — verified, `main` does not contain it (`git merge-base --is-ancestor 12068596fe origin/main` → not an ancestor; `main` has no `baseEntity.hierarchy` test at all).

Note the blast radius: it was not just `/v6`. Fail-fast cancelled the `lts/5` build too, so *nothing* deployed. (Adding `fail-fast: false` to the matrix would at least keep sibling lines building and make the signal clearer. Deliberately **not** in this PR — the deploy would still be blocked, and this PR is one ordered change. Flagged as an optional follow-up.)

## Boundary analysis: what comes from the content ref vs the tooling overlay

This is the part that decides whether the change produces coherent pages, so I traced it in the code rather than inferring it from the step names.

**From the content ref** (`main` for `/v6`, `lts/N` for line sets) — everything `docs-site/scripts/ingest.mjs` reads, all of it resolved against `REPO_ROOT = path.resolve(SCRIPT_DIR, '../..')`, i.e. the checkout:

- `guides/`, root docs (`README.md`, `DEPLOYMENT.md`, …), `packages/**/README.md`, `releases/`, `.claude/skills/`
- the built packages and the TypeDoc API reference (`typedoc.json` → `out: "docs"`, copied to `/api`)
- `git rev-parse HEAD` (ingest, line 83), which is what the generated GitHub links pin — so those links now point at released commits

**From the tooling overlay** (`github.sha`, i.e. `next`'s head in normal operation) — the whole `docs-site/` directory:

- the Astro app and `astro.config.mjs`, the Starlight component overrides (`SiteTitle.astro`, `ThemeSelect.astro`)
- `src/lib/*.mjs` — the rendering logic, including `documented-line.mjs` and `license-line.mjs`
- the hand-authored pages under `docs-site/src/content/docs/`
- `ingest.mjs` itself, plus `docs-site/package.json` / `package-lock.json`

**Conclusion in three sentences.** All *ingested* content and the API reference now come from a released ref, while `docs-site/` — the site app, its rendering logic, and its hand-authored pages — still comes from `next`, which is the existing design that keeps site fixes from needing a cherry-pick onto every line branch. That seam is not new (every `lts/*` set has always been rendered by `next`'s tooling) but it now also applies to `/v6`, so the residual is this: a change to `guides/` or a package README publishes only once it reaches a released ref, while a change to a page inside `docs-site/` publishes on the next docs deploy. Nothing in the overlay reads product code, so it cannot resurrect the next-must-compile dependency — which is why leaving it alone is safe, and why rendering line sets entirely from their own ref would be a policy reversal (cherry-pick every site fix to `main` and every `lts/*`), not a cleanup.

### What still comes from `next`, and the mechanical gate for removing it

Craig's sharpened ruling makes released refs the basis of everything page-affecting, so I pushed on eliminating the overlay rather than just describing it. **It cannot go yet, and the reason is a regression, not effort** — every claim below is from `git ls-tree` / `git grep` against the actual refs:

| Ref | docs-site files | `DOCS_VERSIONS` support | ThemeSelect override | `documented-line.mjs` | `license-line.mjs` | `mjcertified.mdx` |
|---|---|---|---|---|---|---|
| `next` | 41 | yes | yes | yes | **yes** | **yes** |
| `main` | 34 | yes | yes | yes | **no** | **no** |
| `lts/5` | 25 | **no** | **no** | **no** | no | no |

Dropping the overlay today would mean:

- **`/v6` loses the ISC-vs-BUSL distinction entirely** — `license-line.mjs` is absent from `main`, and it is what `LandingFooter.astro`, `index.mdx` and `community.mdx` import to decide the license label, name, badge and link.
- **`/mjcertified` starts 404ing.** `mjcertified.mdx` exists only on `next`, while the deploy job's `/mjcertified` redirect targets `/$CERT_SET/mjcertified/` — and that URL is named *by the BUSL Additional Use Grant*. Trading a label mismatch for a dead legally-referenced page is not a tightening.
- **`/v5` loses its version switcher.** `lts/5` was cut before versioned docs existed; its docs-site has no `DOCS_VERSIONS` support and no ThemeSelect override at all.

The useful conclusion: **the overlay is a compatibility shim for `lts/5`, not a permanent design feature.** Any line cut from `next` after this point carries a current docs-site by construction, and `main` receives `next`'s docs-site at every release. So the elimination path needs no design work, only sequencing:

1. **Next Edge release** — delivers `mjcertified.mdx` + `license-line.mjs` to `main` automatically. No action.
2. **Follow-up PR, gated on step 1** — add `if: matrix.ref != 'main'` to the overlay step; `/v6` then renders entirely from released code. Gate check: `git ls-tree -r origin/main docs-site/ | grep -E 'mjcertified|license-line|documented-line|ThemeSelect'` must show all four.
3. **`lts/*`** — either backport docs-site to a line branch, or keep the shim until `lts/5` leaves support. Newer lines will not need it.

The orchestration YAML itself (this file, and the `DOCS_VERSIONS` list it computes) necessarily runs from `next`; that is unavoidable and out of scope by Craig's own framing. This plan is also recorded in the workflow at the overlay step, where the next person will look.

### Correction to the license-link rationale — read this one

The premise that this "structurally resolves the /v6 BUSL/ISC license-link gap" is **half right, and the half that is wrong matters.** Verified state right now:

| | LICENSE file | `packages/MJCore` license field | version |
|---|---|---|---|
| `origin/main` | **ISC** | **ISC** | 6.1.0-edge.2 |
| `origin/next` | **BUSL 1.1** | **BUSL-1.1** | 6.1.0-edge.2 |

The BUSL relicense has landed on `next` but has **not shipped in a release**, so `main` — and therefore every installable v6 artifact — is still ISC. Meanwhile `license-line.mjs` derives `isBusl` from `documentedMajor >= 6`, i.e. from `DOCS_VERSION`, **not** from any ref. So:

- **Before:** `/v6` content from `next` (BUSL text) + label BUSL + `blob/main/LICENSE` link resolving to ISC. Label and content agreed; the link disagreed.
- **After:** `/v6` content from `main` (ISC text) + label BUSL + link resolving to ISC. **Content and link now agree** — a real improvement, and the "canonical link into main" concern in this file's own trigger comment is satisfied — but the *label* is now the odd one out.

So the gap is narrowed and moved, not closed. It self-closes the moment a release carries the relicense to `main`. Closing it properly instead means deriving the license from the content ref (read the checked-out `LICENSE` / `MJCore` license field) in `docs-site/src/lib/license-line.mjs` — one small file, but it changes a **licensing statement** on the public site, so it is Craig's call, not mine, and it is deliberately not in this PR. It also lands in the same file family already flagged for the dotted-line work (`documented-line.mjs`).

## Both deploy paths, and the escape hatch

The matrix is derived from remote refs and tags, so it does **not** depend on the trigger — all three paths build the same sets:

| Path | `github.sha` (tooling) | Sets built | Result |
|---|---|---|---|
| Edge publish → `workflow_run` on `main` | `next` head | `/v5` ← `lts/5`, `/v6` ← `main` | `/v6` is the release that just landed on `main` (publish.yml pushes the release commit before this fires) |
| LTS release → chained dispatch `--ref next` | `next` head | same | `/v5` is the line that just released; `/v6` unchanged since the last Edge release |
| Docs-only manual dispatch (any ref) | that ref's head | same | tooling from your branch, content still released-only |

The escape hatch keeps working and its semantics barely change: content was never taken from the dispatching ref (the Edge entry was the literal string `next`, not `github.sha`), so the only difference is that `/v6` now shows `main`'s content instead of `next`'s.

## Behavior change, stated plainly

**`/v6` docs content now lags `next` until each release. That is the point.** As of this commit `main` is 470 commits behind `next`, which in ingestable terms is 3 guides, 1 release note, and 4 package READMEs that will not appear on `/v6` until the next Edge release ships them. Anyone who merges a guide edit to `next` and expects it on the site that day will be surprised once; the workflow comments now say so at the overlay step.

## Reviewer checklist

- The only functional change is one word: the Edge matrix entry's `ref` (`"next"` → `"main"`). Everything else in the diff is comments.
- `main` is a viable build ref, verified rather than assumed: HEAD is `27ba0ae5e4` "chore: post-release generated files [skip ci]" (the commit `publish.yml` writes after building and publishing that tree), `pnpm-lock.yaml` present so era detection picks pnpm, `typedoc.json` still `out: "docs"`, `docs-site/package-lock.json` present for the `setup-node` cache path.
- The tooling overlay still needs `next`'s head reachable from a `main` checkout — that is why `fetch-depth: 0` must stay; the comment there now says so explicitly.
- Decide on the license derivation (above). Until then `/v6` labels BUSL over ISC-licensed released content.
- Decide whether you want `fail-fast: false` on the build matrix as a follow-up.
- `actionlint .github/workflows/docs.yml` → exit 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QnZaUxhuvSKe26rqvWuD6e
