### PR TITLE
fix(core): unbreak next — accept a parsed Configuration on RelatedFormRoleCandidate

### DIFF
--- a/.changeset/fix-related-form-role-candidate-config-type.md
+++ b/.changeset/fix-related-form-role-candidate-config-type.md
@@ -1,0 +1,20 @@
+---
+"@memberjunction/core": patch
+---
+
+fix(core): accept a parsed Configuration on RelatedFormRoleCandidate
+
+`EntityRelationshipInfo.Configuration` became a lazily-parsed getter returning
+`IEntityRelationshipConfiguration | null`, but `RelatedFormRoleCandidate.Configuration`
+was left declared `string | null`. `resolve-form-chrome.ts` assigns one to the other, so
+`@memberjunction/ng-base-forms` failed to compile and took the workspace build down with it:
+
+```
+resolve-form-chrome.ts:706:9 - error TS2322: Type 'IEntityRelationshipConfiguration | null'
+is not assignable to type 'string | null | undefined'.
+```
+
+Widened the field to `string | IEntityRelationshipConfiguration | null` — the exact union
+that `ReadRelationshipInclusion`, `ReadRelationshipSortKey` and `ReadRelationshipJoinFields`
+already accept. Widening rather than swapping keeps callers that read a raw row value
+working, while allowing the parsed object the getter now hands back.

--- a/packages/MJCore/src/__tests__/entityConfiguration.test.ts
+++ b/packages/MJCore/src/__tests__/entityConfiguration.test.ts
@@ -61,6 +61,23 @@ describe('ParseEntityRelationshipConfiguration', () => {
         expect(parsed?.UI?.inclusion).toBe('Primary');
         expect(parsed?.UI?.join?.fields).toEqual(['BillToPersonID', 'ShipToPersonID']);
     });
+
+    // EntityRelationshipInfo.Configuration parses lazily and hands back an object, so the
+    // already-parsed form reaches these helpers as often as the raw string does. Passing one
+    // through must be an identity, not a re-parse — otherwise every caller reading
+    // RelatedFormRoleCandidate.Configuration silently degrades to null.
+    it('passes an already-parsed configuration through unchanged', () => {
+        const config = { UI: { inclusion: 'Primary' as const, sortKey: 42 } };
+        const parsed = ParseEntityRelationshipConfiguration(config);
+        expect(parsed).toBe(config);
+    });
+
+    it('returns null for nullish input in either form', () => {
+        expect(ParseEntityRelationshipConfiguration(null)).toBeNull();
+        expect(ParseEntityRelationshipConfiguration(undefined)).toBeNull();
+        expect(ParseEntityRelationshipConfiguration('')).toBeNull();
+        expect(ParseEntityRelationshipConfiguration('   ')).toBeNull();
+    });
 });
 
 describe('ReadRelationshipInclusion / ReadRelationshipJoinFields', () => {
@@ -79,6 +96,20 @@ describe('ReadRelationshipInclusion / ReadRelationshipJoinFields', () => {
         expect(ReadRelationshipSortKey(JSON.stringify({ UI: { sortKey: 90 } }))).toBe(90);
         expect(ReadRelationshipSortKey(JSON.stringify({ UI: { inclusion: 'Primary' } }))).toBeNull();
         expect(ReadRelationshipSortKey(null)).toBeNull();
+    });
+
+    // The parsed form is what RelatedFormRoleCandidate.Configuration actually carries once it
+    // has been populated from EntityRelationshipInfo — both shapes must read identically.
+    it('reads the same values from a parsed bag as from its JSON string', () => {
+        const config = {
+            UI: { inclusion: 'Primary' as const, sortKey: 90, join: { fields: ['BillToPersonID'] } },
+        };
+        expect(ReadRelationshipInclusion(config)).toBe(ReadRelationshipInclusion(JSON.stringify(config)));
+        expect(ReadRelationshipSortKey(config)).toBe(ReadRelationshipSortKey(JSON.stringify(config)));
+        expect(ReadRelationshipJoinFields(config)).toEqual(ReadRelationshipJoinFields(JSON.stringify(config)));
+        expect(ReadRelationshipInclusion(config)).toBe('Primary');
+        expect(ReadRelationshipSortKey(config)).toBe(90);
+        expect(ReadRelationshipJoinFields(config)).toEqual(['BillToPersonID']);
     });
 
     it('returns null when the bag is Auto', () => {

--- a/packages/MJCore/src/generic/entityConfiguration.ts
+++ b/packages/MJCore/src/generic/entityConfiguration.ts
@@ -119,7 +119,15 @@ export interface RelatedFormRoleCandidate {
     JoinView?: string | null;
     Type?: string | null;
     Sequence?: number | null;
-    Configuration?: string | null;
+    /**
+     * The relationship's configuration bag, either raw JSON or already parsed.
+     * `EntityRelationshipInfo.Configuration` parses lazily and hands back
+     * {@link IEntityRelationshipConfiguration}, while callers reading straight
+     * from a row still supply the raw string — so both are accepted, matching
+     * what {@link ReadRelationshipInclusion}, {@link ReadRelationshipSortKey}
+     * and {@link ReadRelationshipJoinFields} already take.
+     */
+    Configuration?: string | IEntityRelationshipConfiguration | null;
     /**
      * How many EntityRelationships across metadata point at this related
      * entity. Runtime-only — the ranker uses it as graph in-degree.


### PR DESCRIPTION
## Summary

`next` is red. `@memberjunction/ng-base-forms` fails to compile, failing the whole workspace build:

```
src/lib/chrome/resolve-form-chrome.ts:706:9 - error TS2322:
  Type 'IEntityRelationshipConfiguration | null' is not assignable to type 'string | null | undefined'.

  706         Configuration: rel.Configuration,
                             ~~~~~~~~~~~~~
  ../../../MJCore/dist/generic/entityConfiguration.d.ts:70:5
    70     Configuration?: string | null;
       The expected type comes from property 'Configuration' which is declared here on type 'RelatedFormRoleCandidate'
```

**Not caused by #3951.** That PR changed two files — a metadata JSON and a changeset — and zero TypeScript. The break predates it and surfaced on the post-merge `next` build.

## Cause

`EntityRelationshipInfo.Configuration` was converted to a lazily-parsed getter returning `IEntityRelationshipConfiguration | null`. Its consumer `RelatedFormRoleCandidate.Configuration` was left declared `string | null`. A producer moved to parsed objects; one consumer type didn't follow.

## Two error sites, not one

The compiler reported one, but there are **two** identical assignments:

| Site | Package |
|---|---|
| `resolve-form-chrome.ts:706` | `ng-base-forms` — the reported failure |
| `entity-form.component.ts` (`FormChromeCandidates`) | `ng-core-entity-forms` — **masked** |

`ng-core-entity-forms` declares a dependency on `@memberjunction/ng-base-forms`, so turbo halted before reaching it. The second error would have appeared as soon as the first was fixed in isolation. Both are covered here.

## Fix

Widened the field to `string | IEntityRelationshipConfiguration | null` — the **exact union** the three helpers that read it already declare:

```ts
ReadRelationshipInclusion (raw: string | IEntityRelationshipConfiguration | null | undefined)
ReadRelationshipSortKey   (raw: string | IEntityRelationshipConfiguration | null | undefined)
ReadRelationshipJoinFields(raw: string | IEntityRelationshipConfiguration | null | undefined)
```

**Why widen rather than swap to the object type.** Both in-tree construction sites assign from `EntityRelationshipInfo.Configuration`, so in this repo the `string` arm is currently unused — narrowing to `IEntityRelationshipConfiguration | null` would also compile. It is kept because `RelatedFormRoleCandidate` is exported public API from `@memberjunction/core`: a downstream app building a candidate straight from a row supplies the raw string, and narrowing would break it for no gain. The union also matches the helper signatures exactly, so there is one accepted shape across the surface rather than two.

Runtime safety comes from `ParseEntityRelationshipConfiguration`, which returns an object input unchanged instead of re-parsing it (`if (typeof raw === 'object') return raw;`).

## Test plan

- [x] `@memberjunction/ng-base-forms` scoped build — 41/41 tasks, 0 errors; TS2322 gone
- [x] **Full workspace build — 302/302 tasks, exit 0, 0 TypeScript errors** (vs `271/273` on `next` today). This matters beyond the one package: `RelatedFormRoleCandidate` ships from `@memberjunction/core`, which ~300 packages consume — 302/302 confirms no other consumer relied on the `string`-only declaration.
- [x] **MJCore unit suite — 2,085 tests / 139 files green**
- [x] New coverage for the object path the fix depends on; it previously had none, as every existing case passed a `JSON.stringify(...)` string
- [x] **Mutation-verified**: deleting `if (typeof raw === 'object') return raw;` fails exactly 2 of the new tests
- [x] `npm run check:changeset` — patch (no migration/metadata) ✅

## Follow-ups (deliberately not in this PR)

**`ConfigurationObject` is now a pure alias** — `get ConfigurationObject() { return this.Configuration; }`. Two public names for one parsed value, on all three of `EntityInfo`, `EntityFieldInfo` and `EntityRelationshipInfo`.

**`X.Configuration` is inconsistent across MJ.** On generated entities it is a raw JSON string — 10+ call sites do `JSON.parse(x.Configuration)`. On these three metadata classes it silently became a parsed object, which is what broke the build. Leaving `Configuration` as the string and letting `ConfigurationObject` be the parsed accessor would have broken no consumer, and is presumably why `ConfigurationObject` exists. The raw string is also now unreachable — `_configuration` is `protected`, so nothing can round-trip or diff the original JSON.

That is a larger change than unbreaking CI and belongs on its own PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
