### PR TITLE
feat(integration): a connector can declare a field excluded from sync

### DIFF
--- a/.changeset/sync-directive-exclude.md
+++ b/.changeset/sync-directive-exclude.md
@@ -1,0 +1,15 @@
+---
+"@memberjunction/integration-engine": patch
+---
+
+A connector can declare a source field excluded from sync.
+
+There was no way to say "do not sync this field". The nearest lever — deactivating its field map — does not exclude the value, it **reroutes** it: `FieldMappingEngine` captures every unmapped source key into `UnmappedFields`, the writer parks it in `__mj_integration_CustomOverflow`, and the custom-column promoter can later resurrect it as a real column. So the field costs more, not less.
+
+`SourceFieldInfo.SyncDirective?: 'Sync' | 'Exclude'` closes that. `undefined` means Sync, so connectors that predate this behave exactly as before.
+
+- **Persisted with no migration.** `IntegrationSchemaSync` writes the directive into `IntegrationObjectField.Configuration`, an existing JSON column. Overlay semantics match every other attribute — a stated directive wins, a silent connector preserves what is stored — so an operator-set directive survives connectors that never heard of the feature.
+- **Stripped before flatten and before mapping.** An excluded key reaches neither `MappedFields`, nor `UnmappedFields` (and so never the overflow column), nor the content hash, whose basis is `MappedFields`. An excluded field therefore stops influencing change detection entirely, rather than quietly forcing rewrites. The no-exclusions path allocates nothing.
+- **Visible in the run log.** The engine resolves the exclusion set once per entity map and emits `sync.entity-map.exclusions` naming what was withheld.
+
+Existing columns are untouched: exclusion stops fetching into them, and dropping a column stays an operator decision.

--- a/packages/Integration/engine/src/FieldMapValidation.ts
+++ b/packages/Integration/engine/src/FieldMapValidation.ts
@@ -1,0 +1,79 @@
+/**
+ * Start-of-run validation for the MJ side of a field map.
+ *
+ * A field map's `DestinationFieldName` is the MJ column, in BOTH directions — pull writes it,
+ * push reads it back out to build the external payload. Nothing checks that the column exists.
+ * `BaseEntity.Set` looks the field up and, when it finds nothing, returns without doing anything
+ * and without saying anything: the value is dropped for every record, the entity is never dirtied
+ * by it, the save succeeds, and the run reports the rows as written. The observable result is a
+ * column's worth of data that never arrives, on a sync that reports success — and if that field is
+ * a key field, every record is re-created on the next run because it can never be matched again.
+ *
+ * This is the cheap check that turns that into one warning per map per run: the map is metadata,
+ * so it is verifiable the moment the run knows its entity, long before the first record is fetched.
+ * The decision is kept pure so it is tested without a provider or an entity.
+ */
+
+/** The parts of a field map this validation reads. */
+export type ValidatableFieldMap = {
+    SourceFieldName: string;
+    DestinationFieldName: string;
+    Status?: string | null;
+    IsKeyField?: boolean | null;
+};
+
+/** One map that cannot bind, with the detail an operator needs to fix it. */
+export type UnbindableFieldMap = {
+    SourceFieldName: string;
+    DestinationFieldName: string;
+    IsKeyField: boolean;
+};
+
+/**
+ * Returns the ACTIVE field maps whose destination column does not exist on the target entity.
+ *
+ * Matching is case-insensitive, because `BaseEntity` resolves field names case-insensitively — a
+ * map that differs only in casing binds fine and is not a finding. An empty `entityFieldNames`
+ * means the caller could not resolve the entity at all; that is a different (already reported)
+ * condition, so nothing is returned rather than flagging every map.
+ */
+export function FindUnbindableFieldMaps(
+    fieldMaps: readonly ValidatableFieldMap[],
+    entityFieldNames: readonly string[],
+): UnbindableFieldMap[] {
+    if (entityFieldNames.length === 0) return [];
+    const known = new Set(entityFieldNames.map(n => n.toLowerCase()));
+    const unbindable: UnbindableFieldMap[] = [];
+    for (const fm of fieldMaps) {
+        if (fm.Status !== 'Active') continue;             // an inactive map is never applied
+        const dest = fm.DestinationFieldName;
+        if (!dest) continue;                              // no destination is a different defect
+        if (known.has(dest.toLowerCase())) continue;
+        unbindable.push({
+            SourceFieldName: fm.SourceFieldName,
+            DestinationFieldName: dest,
+            IsKeyField: fm.IsKeyField === true,
+        });
+    }
+    return unbindable;
+}
+
+/** The operator-facing sentence for a set of unbindable maps on one entity map. */
+export function DescribeUnbindableFieldMaps(
+    unbindable: readonly UnbindableFieldMap[],
+    externalObjectName: string,
+    entityName: string,
+): string {
+    const pairs = unbindable.map(u => `${u.SourceFieldName} -> ${u.DestinationFieldName}${u.IsKeyField ? ' (KEY)' : ''}`);
+    const keyCount = unbindable.filter(u => u.IsKeyField).length;
+    return (
+        `${unbindable.length} active field map(s) for '${externalObjectName}' target a column that does not exist ` +
+        `on '${entityName}': ${pairs.join(', ')}. Those values are silently dropped for every record — the write ` +
+        `succeeds without them` +
+        (keyCount > 0
+            ? `, and because ${keyCount === 1 ? 'one of them is a KEY field' : `${keyCount} of them are KEY fields`}, ` +
+              `records cannot be matched on a later run and will be re-created.`
+            : `.`) +
+        ` Apply the schema so the column exists, or point the map at a column that does.`
+    );
+}

--- a/packages/Integration/engine/src/FieldMappingEngine.ts
+++ b/packages/Integration/engine/src/FieldMappingEngine.ts
@@ -1,5 +1,6 @@
 import { FieldTransformEngine } from '@memberjunction/global';
 import { computeUnmappedFields } from './CustomOverflow.js';
+import { StripExcludedFields } from './SyncDirectives.js';
 import { flattenRecord, hasNestedObject } from './RecordFlatten.js';
 import type { ICompanyIntegrationFieldMap } from './entity-types.js';
 import type { ExternalRecord, MappedRecord } from './types.js';
@@ -17,6 +18,9 @@ import type { TransformStep } from './transforms.js';
  * capture. See the Field Rules guide in `@memberjunction/global` for the shared engine, and
  * `EntityFieldRules` in `@memberjunction/core` for the metadata-aware entity-update sibling.
  */
+/** Shared empty set for the common no-exclusions call. */
+const EMPTY_EXCLUSIONS: ReadonlySet<string> = new Set();
+
 export class FieldMappingEngine {
     /** The shared transform pipeline. Holds its own LRU cache of compiled custom expressions. */
     private readonly transformEngine = new FieldTransformEngine();
@@ -33,10 +37,12 @@ export class FieldMappingEngine {
     public Apply(
         records: ExternalRecord[],
         fieldMaps: ICompanyIntegrationFieldMap[],
-        entityName: string
+        entityName: string,
+        excludedSourceNames?: ReadonlySet<string>
     ): MappedRecord[] {
         const activeMaps = fieldMaps.filter(fm => fm.Status === 'Active');
-        return records.map(record => this.MapSingleRecord(record, activeMaps, entityName));
+        const excluded = excludedSourceNames ?? EMPTY_EXCLUSIONS;
+        return records.map(record => this.MapSingleRecord(record, activeMaps, entityName, excluded));
     }
 
     /**
@@ -45,8 +51,20 @@ export class FieldMappingEngine {
     private MapSingleRecord(
         record: ExternalRecord,
         fieldMaps: ICompanyIntegrationFieldMap[],
-        entityName: string
+        entityName: string,
+        excludedSourceNames: ReadonlySet<string>
     ): MappedRecord {
+        // Field-level exclusions strip BEFORE flatten and BEFORE mapping, so an excluded
+        // key reaches neither MappedFields, nor computeUnmappedFields (-> CustomOverflow),
+        // nor the content hash (whose basis is MappedFields). Deactivating a field map
+        // does NOT do this - the unmapped key would flow into overflow instead.
+        // No-exclusions and no-match paths return the original object: zero allocation.
+        if (excludedSourceNames.size > 0) {
+            const stripped = StripExcludedFields(record.Fields, excludedSourceNames);
+            if (stripped !== record.Fields) {
+                record = { ...record, Fields: stripped };
+            }
+        }
         // Flatten nested source objects to scalar columns (e.g. checkin_question.id →
         // checkin_question_id) BEFORE mapping. The match keys on the mapped PK VALUE
         // (MatchEngine.FindByKeyFields), so an object-valued source field would produce a

--- a/packages/Integration/engine/src/IntegrationEngine.ts
+++ b/packages/Integration/engine/src/IntegrationEngine.ts
@@ -50,6 +50,7 @@ import { RecordMapBatch } from './RecordMapBatch.js';
 import { buildContentHashPrefetchFilter, quoteTextLiteral } from './prefetchFilter.js';
 import { serializeKeyValue } from './KeySerialization.js';
 import { CUSTOM_OVERFLOW_COLUMN, reconcileOverflowValue, foldCustomKeyStats, type CustomKeyAccumulator } from './CustomOverflow.js';
+import { ComputeExcludedSourceNames } from './SyncDirectives.js';
 import { partitionRecords, partitionRollupHash, diffPartitions, partitionKeyForIdentity } from './HashDiff.js';
 import { RateLimiter } from './RateLimiter.js';
 import { AdaptiveConcurrencyController, RunAdaptive } from './AdaptiveConcurrency.js';
@@ -2117,6 +2118,17 @@ export class IntegrationEngine extends BaseSingleton<IntegrationEngine> {
     ): Promise<SyncResult> {
         const entityMapID = entityMap.ID;
         const fieldMaps = await this.LoadFieldMaps(entityMapID, contextUser);
+        // Field-level exclusions declared by the connector (SourceFieldInfo.SyncDirective
+        // -> IntegrationObjectField.Configuration). Resolved once per map, applied to every
+        // batch below. Empty set on any lookup miss - exclusion can only ever narrow.
+        const excludedSourceNames = this.ResolveExcludedSourceNames(
+            config.companyIntegration.IntegrationID, entityMap.ExternalObjectName);
+        if (excludedSourceNames.size > 0) {
+            logger?.emit('sync.entity-map.exclusions', {
+                externalObjectName: entityMap.ExternalObjectName,
+                excludedFields: Array.from(excludedSourceNames).sort(),
+            });
+        }
         const watermark = await this.runWriteExclusive(() => this.watermarkService.Load(entityMapID, contextUser, 'Pull'));
         logger?.emit('sync.entity-map.start', {
             phase: 'pull-detail',
@@ -2473,7 +2485,7 @@ export class IntegrationEngine extends BaseSingleton<IntegrationEngine> {
             }
 
             const mapped = this.fieldMappingEngine.Apply(
-                batch.Records, fieldMaps, entityMap.Entity
+                batch.Records, fieldMaps, entityMap.Entity, excludedSourceNames
             );
             // Custom-key stats: aggregate unmapped keys for EVERY mapped record here —
             // before any skip decision — so candidates + sizing stats exist even when the
@@ -5479,6 +5491,19 @@ export class IntegrationEngine extends BaseSingleton<IntegrationEngine> {
 
     public GetIntegrationObjectFields(objectID: string): MJIntegrationObjectFieldEntity[] {
         return this.Base.GetIntegrationObjectFields(objectID);
+    }
+
+    /**
+     * Source field names the connector declared as SyncDirective 'Exclude' for one
+     * integration object, read from IntegrationObjectField.Configuration. Empty set
+     * on any lookup miss (unknown object, no fields, no integration id) - a failed
+     * lookup must never widen or narrow the sync beyond its declared behaviour.
+     */
+    public ResolveExcludedSourceNames(integrationID: string | null | undefined, externalObjectName: string): Set<string> {
+        if (!integrationID || !externalObjectName) return new Set<string>();
+        const obj = this.GetIntegrationObject(integrationID, externalObjectName);
+        if (!obj) return new Set<string>();
+        return ComputeExcludedSourceNames(this.GetIntegrationObjectFields(obj.ID));
     }
 
     public GetActiveIntegrationObjects(integrationID: string): MJIntegrationObjectEntity[] {

--- a/packages/Integration/engine/src/IntegrationEngine.ts
+++ b/packages/Integration/engine/src/IntegrationEngine.ts
@@ -49,6 +49,7 @@ import { RecordMapBatch } from './RecordMapBatch.js';
 import { buildContentHashPrefetchFilter, quoteTextLiteral } from './prefetchFilter.js';
 import { serializeKeyValue } from './KeySerialization.js';
 import { CUSTOM_OVERFLOW_COLUMN, reconcileOverflowValue, foldCustomKeyStats, type CustomKeyAccumulator } from './CustomOverflow.js';
+import { ComputeExcludedSourceNames } from './SyncDirectives.js';
 import { partitionRecords, partitionRollupHash, diffPartitions, partitionKeyForIdentity } from './HashDiff.js';
 import { RateLimiter } from './RateLimiter.js';
 import { AdaptiveConcurrencyController, RunAdaptive } from './AdaptiveConcurrency.js';
@@ -2093,6 +2094,17 @@ export class IntegrationEngine extends BaseSingleton<IntegrationEngine> {
     ): Promise<SyncResult> {
         const entityMapID = entityMap.ID;
         const fieldMaps = await this.LoadFieldMaps(entityMapID, contextUser);
+        // Field-level exclusions declared by the connector (SourceFieldInfo.SyncDirective
+        // -> IntegrationObjectField.Configuration). Resolved once per map, applied to every
+        // batch below. Empty set on any lookup miss - exclusion can only ever narrow.
+        const excludedSourceNames = this.ResolveExcludedSourceNames(
+            config.companyIntegration.IntegrationID, entityMap.ExternalObjectName);
+        if (excludedSourceNames.size > 0) {
+            logger?.emit('sync.entity-map.exclusions', {
+                externalObjectName: entityMap.ExternalObjectName,
+                excludedFields: Array.from(excludedSourceNames).sort(),
+            });
+        }
         const watermark = await this.runWriteExclusive(() => this.watermarkService.Load(entityMapID, contextUser, 'Pull'));
         logger?.emit('sync.entity-map.start', {
             phase: 'pull-detail',
@@ -2449,7 +2461,7 @@ export class IntegrationEngine extends BaseSingleton<IntegrationEngine> {
             }
 
             const mapped = this.fieldMappingEngine.Apply(
-                batch.Records, fieldMaps, entityMap.Entity
+                batch.Records, fieldMaps, entityMap.Entity, excludedSourceNames
             );
             // Custom-key stats: aggregate unmapped keys for EVERY mapped record here —
             // before any skip decision — so candidates + sizing stats exist even when the
@@ -5420,6 +5432,19 @@ export class IntegrationEngine extends BaseSingleton<IntegrationEngine> {
 
     public GetIntegrationObjectFields(objectID: string): MJIntegrationObjectFieldEntity[] {
         return this.Base.GetIntegrationObjectFields(objectID);
+    }
+
+    /**
+     * Source field names the connector declared as SyncDirective 'Exclude' for one
+     * integration object, read from IntegrationObjectField.Configuration. Empty set
+     * on any lookup miss (unknown object, no fields, no integration id) - a failed
+     * lookup must never widen or narrow the sync beyond its declared behaviour.
+     */
+    public ResolveExcludedSourceNames(integrationID: string | null | undefined, externalObjectName: string): Set<string> {
+        if (!integrationID || !externalObjectName) return new Set<string>();
+        const obj = this.GetIntegrationObject(integrationID, externalObjectName);
+        if (!obj) return new Set<string>();
+        return ComputeExcludedSourceNames(this.GetIntegrationObjectFields(obj.ID));
     }
 
     public GetActiveIntegrationObjects(integrationID: string): MJIntegrationObjectEntity[] {

--- a/packages/Integration/engine/src/IntegrationEngine.ts
+++ b/packages/Integration/engine/src/IntegrationEngine.ts
@@ -51,6 +51,7 @@ import { buildContentHashPrefetchFilter, quoteTextLiteral } from './prefetchFilt
 import { serializeKeyValue } from './KeySerialization.js';
 import { CUSTOM_OVERFLOW_COLUMN, reconcileOverflowValue, foldCustomKeyStats, type CustomKeyAccumulator } from './CustomOverflow.js';
 import { ComputeExcludedSourceNames } from './SyncDirectives.js';
+import { DescribeUnbindableFieldMaps, FindUnbindableFieldMaps } from './FieldMapValidation.js';
 import { partitionRecords, partitionRollupHash, diffPartitions, partitionKeyForIdentity } from './HashDiff.js';
 import { RateLimiter } from './RateLimiter.js';
 import { AdaptiveConcurrencyController, RunAdaptive } from './AdaptiveConcurrency.js';
@@ -2144,6 +2145,7 @@ export class IntegrationEngine extends BaseSingleton<IntegrationEngine> {
             watermarkType: watermark?.WatermarkType ?? null,
             fullSync: config.fullSync,
         });
+        this.WarnOnUnbindableFieldMaps(entityMap, fieldMaps, logger);
 
         // A6: Validate watermark before using it — skip entirely when FullSync requested
         let initialWatermark = config.fullSync ? null : (watermark?.WatermarkValue ?? null);
@@ -2846,6 +2848,7 @@ export class IntegrationEngine extends BaseSingleton<IntegrationEngine> {
     ): Promise<SyncResult> {
         const entityMapID = entityMap.ID;
         const fieldMaps = await this.LoadFieldMaps(entityMapID, contextUser);
+        this.WarnOnUnbindableFieldMaps(entityMap, fieldMaps, logger);
         const pushWatermark = await this.watermarkService.Load(entityMapID, contextUser, 'Push');
         const lastPushAt = pushWatermark?.WatermarkValue ?? null;
 
@@ -4546,6 +4549,39 @@ export class IntegrationEngine extends BaseSingleton<IntegrationEngine> {
             }
         }
         return key;
+    }
+
+    /**
+     * Reports ACTIVE field maps whose MJ column does not exist, once per entity map per run.
+     *
+     * `BaseEntity.Set` no-ops on an unknown field — no throw, no log, no dirty flag — so a map
+     * pointing at a column that was never applied (or was renamed) drops its value for every
+     * record while the run reports those records as written. Checking it here costs one metadata
+     * read and happens before the first fetch, so the warning arrives before the wasted work.
+     */
+    private WarnOnUnbindableFieldMaps(
+        entityMap: ICompanyIntegrationEntityMap,
+        fieldMaps: ICompanyIntegrationFieldMap[],
+        logger?: SyncLogger,
+    ): void {
+        const entityName = entityMap.Entity ?? '';
+        // Diagnostics must never be able to fail a run: an unresolvable entity/provider is reported
+        // by the paths that actually need it, and here it simply means there is nothing to check.
+        let entityFieldNames: string[] = [];
+        try {
+            const entityInfo = entityName ? this.ProviderToUse?.EntityByName(entityName) : null;
+            entityFieldNames = entityInfo?.Fields?.map(f => f.Name) ?? [];
+        } catch {
+            return;
+        }
+        const unbindable = FindUnbindableFieldMaps(fieldMaps, entityFieldNames);
+        if (unbindable.length === 0) return;
+        logger?.warning(
+            entityMap.ExternalObjectName ?? entityMap.ID,
+            'FIELD_MAP_DESTINATION_MISSING',
+            DescribeUnbindableFieldMaps(unbindable, entityMap.ExternalObjectName ?? entityMap.ID, entityName),
+            { fieldMaps: unbindable },
+        );
     }
 
     /**

--- a/packages/Integration/engine/src/IntegrationSchemaSync.ts
+++ b/packages/Integration/engine/src/IntegrationSchemaSync.ts
@@ -24,6 +24,7 @@ import type {
   MJActionCategoryEntity,
 } from '@memberjunction/core-entities';
 import type { SourceSchemaInfo, SourceObjectInfo, SourceFieldInfo } from './types';
+import { ReadFieldSyncDirective, WriteFieldSyncDirective } from './SyncDirectives.js';
 import { ActionMetadataGenerator, type IntegrationObjectInfo } from './ActionMetadataGenerator';
 
 export interface PersistSchemaOptions {
@@ -716,6 +717,18 @@ export class IntegrationSchemaSync {
         existing.Status = 'Active';
         dirty = true;
       }
+      // SyncDirective follows the same rule as every other attribute: a source that STATES
+      // a directive overrides the stored one; a silent source (undefined) keeps whatever is
+      // stored — so a directive set by an operator by hand survives connectors that predate
+      // the feature. Stored in Configuration (JSON), so no DDL is involved.
+      if (srcField.SyncDirective !== undefined) {
+        const nextConfig = WriteFieldSyncDirective(existing.Configuration, srcField.SyncDirective);
+        if (nextConfig !== existing.Configuration
+            && ReadFieldSyncDirective(nextConfig) !== ReadFieldSyncDirective(existing.Configuration)) {
+          existing.Configuration = nextConfig;
+          dirty = true;
+        }
+      }
       const mappedType = MapSourceType(srcField.SourceType);
       const describedAllowsNull = srcField.AllowsNull ?? !srcField.IsRequired;
 
@@ -833,6 +846,11 @@ export class IntegrationSchemaSync {
       field.DisplayName = srcField.Label || srcField.Name;
       if (srcField.Description) field.Description = srcField.Description;
       field.Type = MapSourceType(srcField.SourceType);
+      // A declared 'Exclude' lands in Configuration from the first discovery, so the field
+      // never contributes to a single sync. 'Sync'/undefined writes nothing.
+      if (srcField.SyncDirective === 'Exclude') {
+        field.Configuration = WriteFieldSyncDirective(null, 'Exclude');
+      }
       // Persist the discovered length onto IOF.Length so the schema builder sizes the column
       // (nvarchar(N)). Large-text types carry their MAX in the Type ('nvarchar(MAX)') via
       // MapSourceType, so no length is set for them here.

--- a/packages/Integration/engine/src/IntegrationSchemaSync.ts
+++ b/packages/Integration/engine/src/IntegrationSchemaSync.ts
@@ -24,6 +24,7 @@ import type {
   MJActionCategoryEntity,
 } from '@memberjunction/core-entities';
 import type { SourceSchemaInfo, SourceObjectInfo, SourceFieldInfo } from './types';
+import { ReadFieldSyncDirective, WriteFieldSyncDirective } from './SyncDirectives.js';
 import { ActionMetadataGenerator, type IntegrationObjectInfo } from './ActionMetadataGenerator';
 
 export interface PersistSchemaOptions {
@@ -740,6 +741,18 @@ export class IntegrationSchemaSync {
         existing.Status = 'Active';
         dirty = true;
       }
+      // SyncDirective follows the same rule as every other attribute: a source that STATES
+      // a directive overrides the stored one; a silent source (undefined) keeps whatever is
+      // stored — so a directive set by an operator by hand survives connectors that predate
+      // the feature. Stored in Configuration (JSON), so no DDL is involved.
+      if (srcField.SyncDirective !== undefined) {
+        const nextConfig = WriteFieldSyncDirective(existing.Configuration, srcField.SyncDirective);
+        if (nextConfig !== existing.Configuration
+            && ReadFieldSyncDirective(nextConfig) !== ReadFieldSyncDirective(existing.Configuration)) {
+          existing.Configuration = nextConfig;
+          dirty = true;
+        }
+      }
       const mappedType = MapSourceType(srcField.SourceType);
       const describedAllowsNull = srcField.AllowsNull ?? !srcField.IsRequired;
 
@@ -857,6 +870,11 @@ export class IntegrationSchemaSync {
       field.DisplayName = srcField.Label || srcField.Name;
       if (srcField.Description) field.Description = srcField.Description;
       field.Type = MapSourceType(srcField.SourceType);
+      // A declared 'Exclude' lands in Configuration from the first discovery, so the field
+      // never contributes to a single sync. 'Sync'/undefined writes nothing.
+      if (srcField.SyncDirective === 'Exclude') {
+        field.Configuration = WriteFieldSyncDirective(null, 'Exclude');
+      }
       // Persist the discovered length onto IOF.Length so the schema builder sizes the column
       // (nvarchar(N)). Large-text types carry their MAX in the Type ('nvarchar(MAX)') via
       // MapSourceType, so no length is set for them here.

--- a/packages/Integration/engine/src/SyncDirectives.ts
+++ b/packages/Integration/engine/src/SyncDirectives.ts
@@ -1,0 +1,131 @@
+/**
+ * Field-level sync directives.
+ *
+ * A connector can now declare that a source field should not be synced at all
+ * (`SourceFieldInfo.SyncDirective: 'Exclude'`). The directive is persisted into
+ * `IntegrationObjectField.Configuration` (a JSON column that already exists, so no
+ * migration is required) and honoured by the mapping stage, which strips excluded
+ * keys from the record BEFORE field mapping runs.
+ *
+ * Why stripping must happen there and not by deactivating a field map: an unmapped
+ * source key does not disappear — `computeUnmappedFields` captures it and the writer
+ * parks it in `__mj_integration_CustomOverflow`. Deactivating the map therefore
+ * REROUTES the value instead of excluding it, and the custom-column promoter will
+ * happily resurrect it as a real column later. Stripping before mapping keeps the
+ * key out of MappedFields, out of the overflow, and out of the content hash (whose
+ * basis is MappedFields), so an excluded field stops influencing change detection
+ * entirely.
+ *
+ * What this is for, concretely (measured on a live tenant, 2026-08-19):
+ *   - `preferences` on Totara Users / Enrolled_Users: Moodle UI widget state
+ *     (file-picker recents, user-selector toggles), identical nine keys on 100% of
+ *     rows — ~2.5M expanded values of nothing.
+ *   - `courseformatoptions` on Courses: course theming (header colours, tile icons).
+ *   - `enrolledcourses` on Enrolled_Users: re-derives the Enrolled_Users table
+ *     itself — ~7.6M expanded values that duplicate an object already synced.
+ *
+ * The directive lives in Configuration rather than a new column so that existing
+ * installs pick it up on their next schema sync with no DDL. Absence of a directive
+ * means Sync — connectors that never heard of this feature behave exactly as before.
+ */
+
+/** The Configuration key under which a field's sync directive is stored. */
+export const SYNC_DIRECTIVE_CONFIG_KEY = 'syncDirective';
+
+/** Recognised directive values. Anything unrecognised is treated as 'Sync'. */
+export type FieldSyncDirective = 'Sync' | 'Exclude';
+
+/** Minimal shape of an IntegrationObjectField row this module needs. */
+export interface FieldWithConfiguration {
+    Name: string;
+    Configuration: string | null;
+}
+
+/**
+ * Reads the sync directive out of an IntegrationObjectField.Configuration JSON blob.
+ * Malformed JSON, a missing key, or an unrecognised value all mean 'Sync' — the
+ * directive can only ever narrow what is synced, never break a sync by its absence.
+ */
+export function ReadFieldSyncDirective(configuration: string | null | undefined): FieldSyncDirective {
+    if (!configuration) return 'Sync';
+    try {
+        const parsed: unknown = JSON.parse(configuration);
+        if (parsed && typeof parsed === 'object') {
+            const v = (parsed as Record<string, unknown>)[SYNC_DIRECTIVE_CONFIG_KEY];
+            if (typeof v === 'string' && v.toLowerCase() === 'exclude') return 'Exclude';
+        }
+    } catch {
+        // Malformed Configuration is not this feature's problem to surface.
+    }
+    return 'Sync';
+}
+
+/**
+ * Merges a directive into an existing Configuration JSON string, preserving every
+ * other key. Returns the new JSON, or the original string when nothing changes
+ * (so callers can cheaply detect no-op writes). Setting 'Sync' REMOVES the key
+ * rather than storing the default.
+ */
+export function WriteFieldSyncDirective(
+    configuration: string | null | undefined,
+    directive: FieldSyncDirective,
+): string | null {
+    let obj: Record<string, unknown> = {};
+    if (configuration) {
+        try {
+            const parsed: unknown = JSON.parse(configuration);
+            if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
+                obj = parsed as Record<string, unknown>;
+            }
+        } catch {
+            // Unparseable existing Configuration: preserve it untouched rather than
+            // destroy whatever it held. The directive is not worth data loss.
+            return configuration;
+        }
+    }
+    if (directive === 'Exclude') {
+        obj[SYNC_DIRECTIVE_CONFIG_KEY] = 'Exclude';
+    } else {
+        delete obj[SYNC_DIRECTIVE_CONFIG_KEY];
+    }
+    const out = Object.keys(obj).length > 0 ? JSON.stringify(obj) : null;
+    return out;
+}
+
+/**
+ * The set of source field names to strip for one integration object, derived from
+ * its IntegrationObjectField rows. Empty set when nothing is excluded — the
+ * mapping engine's fast path.
+ */
+export function ComputeExcludedSourceNames(fields: ReadonlyArray<FieldWithConfiguration>): Set<string> {
+    const out = new Set<string>();
+    for (const f of fields) {
+        if (ReadFieldSyncDirective(f.Configuration) === 'Exclude') {
+            out.add(f.Name);
+        }
+    }
+    return out;
+}
+
+/**
+ * Returns a copy of `fields` without the excluded keys, or the ORIGINAL object when
+ * no key matches (so the no-exclusions path allocates nothing). Matching is exact:
+ * source field names are the connector's own spelling, already used verbatim as
+ * field-map SourceFieldName and overflow keys.
+ */
+export function StripExcludedFields(
+    fields: Record<string, unknown>,
+    excluded: ReadonlySet<string>,
+): Record<string, unknown> {
+    if (excluded.size === 0) return fields;
+    let hit = false;
+    for (const k of Object.keys(fields)) {
+        if (excluded.has(k)) { hit = true; break; }
+    }
+    if (!hit) return fields;
+    const out: Record<string, unknown> = {};
+    for (const [k, v] of Object.entries(fields)) {
+        if (!excluded.has(k)) out[k] = v;
+    }
+    return out;
+}

--- a/packages/Integration/engine/src/SyncLogger.ts
+++ b/packages/Integration/engine/src/SyncLogger.ts
@@ -42,6 +42,7 @@ export type SyncLogEvent =
     | 'sync.connector.built'
     | 'sync.connector.test'
     | 'sync.entity-map.start'
+    | 'sync.entity-map.exclusions'
     | 'sync.resume.keyset'
     | 'sync.partition.reconcile'
     | 'sync.fetch.batch.start'

--- a/packages/Integration/engine/src/__tests__/FieldMapValidation.test.ts
+++ b/packages/Integration/engine/src/__tests__/FieldMapValidation.test.ts
@@ -1,0 +1,68 @@
+/**
+ * A field map's DestinationFieldName is the MJ column in both directions. Nothing validated it,
+ * and `BaseEntity.Set` no-ops on an unknown field: the value is dropped for every record, the save
+ * still succeeds, and the run reports the rows as written. These tests pin what counts as
+ * unbindable — and, just as importantly, what does not, since a false positive here would put a
+ * warning on every healthy run.
+ */
+import { describe, it, expect } from 'vitest';
+import { FindUnbindableFieldMaps, DescribeUnbindableFieldMaps } from '../FieldMapValidation.js';
+
+const map = (SourceFieldName: string, DestinationFieldName: string, extra: Record<string, unknown> = {}) =>
+    ({ SourceFieldName, DestinationFieldName, Status: 'Active', ...extra });
+
+const ENTITY_FIELDS = ['ID', 'FirstName', 'Email'];
+
+describe('FindUnbindableFieldMaps', () => {
+    it('finds a map whose destination column does not exist', () => {
+        const found = FindUnbindableFieldMaps([map('email', 'Email'), map('middle', 'MiddleName')], ENTITY_FIELDS);
+        expect(found).toEqual([{ SourceFieldName: 'middle', DestinationFieldName: 'MiddleName', IsKeyField: false }]);
+    });
+
+    it('binds case-insensitively, the way BaseEntity resolves field names', () => {
+        expect(FindUnbindableFieldMaps([map('email', 'EMAIL')], ENTITY_FIELDS)).toEqual([]);
+    });
+
+    it('ignores maps that are not Active — they are never applied', () => {
+        const found = FindUnbindableFieldMaps([map('middle', 'MiddleName', { Status: 'Inactive' })], ENTITY_FIELDS);
+        expect(found).toEqual([]);
+    });
+
+    it('ignores a map with no destination at all — that is a different defect', () => {
+        expect(FindUnbindableFieldMaps([map('middle', '')], ENTITY_FIELDS)).toEqual([]);
+    });
+
+    it('reports nothing when the entity could not be resolved, rather than flagging every map', () => {
+        expect(FindUnbindableFieldMaps([map('email', 'Email'), map('middle', 'MiddleName')], [])).toEqual([]);
+    });
+
+    it('carries the key-field flag through, because an unbindable KEY re-creates every record', () => {
+        const found = FindUnbindableFieldMaps([map('id', 'ExternalID', { IsKeyField: true })], ENTITY_FIELDS);
+        expect(found[0].IsKeyField).toBe(true);
+    });
+});
+
+describe('DescribeUnbindableFieldMaps', () => {
+    it('names the pairs and what the operator should do', () => {
+        const msg = DescribeUnbindableFieldMaps(
+            [{ SourceFieldName: 'middle', DestinationFieldName: 'MiddleName', IsKeyField: false }],
+            'contacts',
+            'Contacts',
+        );
+        expect(msg).toContain("'contacts'");
+        expect(msg).toContain("'Contacts'");
+        expect(msg).toContain('middle -> MiddleName');
+        expect(msg).toContain('silently dropped');
+        expect(msg).not.toContain('KEY');
+    });
+
+    it('spells out the matching consequence when a KEY field cannot bind', () => {
+        const msg = DescribeUnbindableFieldMaps(
+            [{ SourceFieldName: 'id', DestinationFieldName: 'ExternalID', IsKeyField: true }],
+            'contacts',
+            'Contacts',
+        );
+        expect(msg).toContain('id -> ExternalID (KEY)');
+        expect(msg).toContain('re-created');
+    });
+});

--- a/packages/Integration/engine/src/__tests__/SyncDirectives.test.ts
+++ b/packages/Integration/engine/src/__tests__/SyncDirectives.test.ts
@@ -1,0 +1,151 @@
+import { describe, it, expect } from 'vitest';
+import {
+    ReadFieldSyncDirective,
+    WriteFieldSyncDirective,
+    ComputeExcludedSourceNames,
+    StripExcludedFields,
+    SYNC_DIRECTIVE_CONFIG_KEY,
+} from '../SyncDirectives.js';
+import { FieldMappingEngine } from '../FieldMappingEngine.js';
+import { computeContentHash } from '../ContentHash.js';
+import type { ICompanyIntegrationFieldMap } from '../entity-types.js';
+import type { ExternalRecord } from '../types.js';
+
+describe('ReadFieldSyncDirective', () => {
+    it('defaults to Sync for null, empty, malformed, and unrecognised values', () => {
+        expect(ReadFieldSyncDirective(null)).toBe('Sync');
+        expect(ReadFieldSyncDirective(undefined)).toBe('Sync');
+        expect(ReadFieldSyncDirective('')).toBe('Sync');
+        expect(ReadFieldSyncDirective('not json at all')).toBe('Sync');
+        expect(ReadFieldSyncDirective('{"syncDirective":"banana"}')).toBe('Sync');
+        expect(ReadFieldSyncDirective('{"otherKey":true}')).toBe('Sync');
+        // a JSON array is an object to typeof — must still be Sync
+        expect(ReadFieldSyncDirective('[1,2,3]')).toBe('Sync');
+    });
+
+    it('reads Exclude case-insensitively', () => {
+        expect(ReadFieldSyncDirective('{"syncDirective":"Exclude"}')).toBe('Exclude');
+        expect(ReadFieldSyncDirective('{"syncDirective":"exclude"}')).toBe('Exclude');
+        expect(ReadFieldSyncDirective('{"syncDirective":"EXCLUDE"}')).toBe('Exclude');
+    });
+});
+
+describe('WriteFieldSyncDirective', () => {
+    it('preserves unrelated Configuration keys', () => {
+        const out = WriteFieldSyncDirective('{"wsfunction":"core_user_get_users","retries":3}', 'Exclude');
+        const parsed = JSON.parse(out!);
+        expect(parsed.wsfunction).toBe('core_user_get_users');
+        expect(parsed.retries).toBe(3);
+        expect(parsed[SYNC_DIRECTIVE_CONFIG_KEY]).toBe('Exclude');
+    });
+
+    it('Sync removes the key rather than storing the default, and collapses {} to null', () => {
+        expect(WriteFieldSyncDirective('{"syncDirective":"Exclude"}', 'Sync')).toBeNull();
+        const kept = WriteFieldSyncDirective('{"syncDirective":"Exclude","a":1}', 'Sync');
+        expect(JSON.parse(kept!)).toEqual({ a: 1 });
+    });
+
+    it('refuses to destroy an unparseable existing Configuration', () => {
+        expect(WriteFieldSyncDirective('{{{corrupt', 'Exclude')).toBe('{{{corrupt');
+    });
+
+    it('round-trips through ReadFieldSyncDirective', () => {
+        expect(ReadFieldSyncDirective(WriteFieldSyncDirective(null, 'Exclude'))).toBe('Exclude');
+        expect(ReadFieldSyncDirective(WriteFieldSyncDirective(null, 'Sync'))).toBe('Sync');
+    });
+});
+
+describe('ComputeExcludedSourceNames', () => {
+    it('collects only Exclude-directed fields', () => {
+        const out = ComputeExcludedSourceNames([
+            { Name: 'preferences', Configuration: '{"syncDirective":"Exclude"}' },
+            { Name: 'enrolledcourses', Configuration: WriteFieldSyncDirective(null, 'Exclude') },
+            { Name: 'fullname', Configuration: null },
+            { Name: 'email', Configuration: '{"unrelated":1}' },
+        ]);
+        expect(out).toEqual(new Set(['preferences', 'enrolledcourses']));
+    });
+});
+
+describe('StripExcludedFields', () => {
+    it('returns the ORIGINAL object when nothing matches (zero-allocation fast paths)', () => {
+        const fields = { a: 1, b: 2 };
+        expect(StripExcludedFields(fields, new Set())).toBe(fields);
+        expect(StripExcludedFields(fields, new Set(['zzz']))).toBe(fields);
+    });
+
+    it('removes exactly the excluded keys', () => {
+        const out = StripExcludedFields({ a: 1, preferences: '[...]', b: 2 }, new Set(['preferences']));
+        expect(out).toEqual({ a: 1, b: 2 });
+    });
+});
+
+describe('FieldMappingEngine with exclusions', () => {
+    const fm = (src: string, dest: string): ICompanyIntegrationFieldMap => ({
+        ID: `fm-${src}`, EntityMapID: 'em-1',
+        SourceFieldName: src, SourceFieldLabel: null,
+        DestinationFieldName: dest, DestinationFieldLabel: null,
+        Direction: 'SourceToDest', TransformPipeline: null,
+        IsKeyField: src === 'id', IsRequired: false, DefaultValue: null,
+        Priority: 0, OnError: 'Skip', Status: 'Active',
+        Get: () => undefined,
+    } as unknown as ICompanyIntegrationFieldMap);
+
+    const record: ExternalRecord = {
+        ExternalID: 'u-1',
+        Fields: {
+            id: 'u-1',
+            fullname: 'A Person',
+            preferences: '[{"name":"filepicker_recentlicense","value":"1"}]',
+            enrolledcourses: '[{"id":1}]',
+        },
+        IsDeleted: false,
+    } as unknown as ExternalRecord;
+
+    it('an excluded field reaches neither MappedFields nor UnmappedFields', () => {
+        const engine = new FieldMappingEngine();
+        const [mapped] = engine.Apply(
+            [record],
+            [fm('id', 'ExternalID'), fm('fullname', 'FullName'), fm('preferences', 'Preferences')],
+            'Test Entity',
+            new Set(['preferences', 'enrolledcourses'])
+        );
+        // not mapped even though a field map exists for it
+        expect(mapped.MappedFields.Preferences).toBeUndefined();
+        expect(mapped.MappedFields.FullName).toBe('A Person');
+        // not in overflow either - exclusion, not rerouting
+        expect(Object.keys(mapped.UnmappedFields ?? {})).not.toContain('preferences');
+        expect(Object.keys(mapped.UnmappedFields ?? {})).not.toContain('enrolledcourses');
+    });
+
+    it('the content hash is identical whether or not the excluded value changes', () => {
+        const engine = new FieldMappingEngine();
+        const maps = [fm('id', 'ExternalID'), fm('fullname', 'FullName'), fm('preferences', 'Preferences')];
+        const excl = new Set(['preferences']);
+        const changed: ExternalRecord = {
+            ...record,
+            Fields: { ...record.Fields, preferences: '[{"name":"filepicker_recentlicense","value":"CHANGED"}]' },
+        } as unknown as ExternalRecord;
+        const [a] = engine.Apply([record], maps, 'Test Entity', excl);
+        const [b] = engine.Apply([changed], maps, 'Test Entity', excl);
+        expect(computeContentHash(a.MappedFields)).toBe(computeContentHash(b.MappedFields));
+    });
+
+    it('without exclusions, behaviour is unchanged (regression guard)', () => {
+        const engine = new FieldMappingEngine();
+        const [mapped] = engine.Apply(
+            [record],
+            [fm('id', 'ExternalID'), fm('preferences', 'Preferences')],
+            'Test Entity'
+        );
+        expect(mapped.MappedFields.Preferences).toBeDefined();
+        // fullname has no map -> overflow captures it, exactly as before
+        expect(Object.keys(mapped.UnmappedFields ?? {})).toContain('fullname');
+    });
+
+    it('does not mutate the caller record when stripping', () => {
+        const engine = new FieldMappingEngine();
+        engine.Apply([record], [fm('id', 'ExternalID')], 'Test Entity', new Set(['preferences']));
+        expect(record.Fields.preferences).toBeDefined();
+    });
+});

--- a/packages/Integration/engine/src/index.ts
+++ b/packages/Integration/engine/src/index.ts
@@ -124,6 +124,8 @@ export type { PersistSchemaOptions, PersistSchemaResult } from './IntegrationSch
 // ── Restored module exports dropped by the origin/next index.ts merge (union) ──
 export { computeContentHash, CONTENT_HASH_COLUMN } from './ContentHash.js';
 export { CUSTOM_OVERFLOW_COLUMN, computeUnmappedFields, hasUnmappedFields, foldCustomKeyStats, CUSTOM_KEY_SAMPLE_CAP } from './CustomOverflow.js';
+export { SYNC_DIRECTIVE_CONFIG_KEY, ReadFieldSyncDirective, WriteFieldSyncDirective, ComputeExcludedSourceNames, StripExcludedFields } from './SyncDirectives.js';
+export type { FieldSyncDirective, FieldWithConfiguration } from './SyncDirectives.js';
 export type { CustomKeyAccumulator } from './CustomOverflow.js';
 export { planPromotions, planColumnReclamations, inferColumnTypeFromSamples, inferColumnTypeFromStats, buildOverflowStats, sanitizeColumnName } from './CustomColumnPromotion.js';
 export { discoverFromStream, pickPrimaryKeyFromStats } from './StreamingDiscovery.js';

--- a/packages/Integration/engine/src/index.ts
+++ b/packages/Integration/engine/src/index.ts
@@ -126,6 +126,8 @@ export { computeContentHash, CONTENT_HASH_COLUMN } from './ContentHash.js';
 export { CUSTOM_OVERFLOW_COLUMN, computeUnmappedFields, hasUnmappedFields, foldCustomKeyStats, CUSTOM_KEY_SAMPLE_CAP } from './CustomOverflow.js';
 export { SYNC_DIRECTIVE_CONFIG_KEY, ReadFieldSyncDirective, WriteFieldSyncDirective, ComputeExcludedSourceNames, StripExcludedFields } from './SyncDirectives.js';
 export type { FieldSyncDirective, FieldWithConfiguration } from './SyncDirectives.js';
+export { FindUnbindableFieldMaps, DescribeUnbindableFieldMaps } from './FieldMapValidation.js';
+export type { ValidatableFieldMap, UnbindableFieldMap } from './FieldMapValidation.js';
 export type { CustomKeyAccumulator } from './CustomOverflow.js';
 export { planPromotions, planColumnReclamations, inferColumnTypeFromSamples, inferColumnTypeFromStats, buildOverflowStats, sanitizeColumnName } from './CustomColumnPromotion.js';
 export { discoverFromStream, pickPrimaryKeyFromStats } from './StreamingDiscovery.js';

--- a/packages/Integration/engine/src/types.ts
+++ b/packages/Integration/engine/src/types.ts
@@ -565,6 +565,26 @@ export interface SourceFieldInfo {
     IsForeignKey?: boolean;
     /** If FK, which source object it references (null if not a FK). */
     ForeignKeyTarget: string | null;
+    /**
+     * How the sync engine should treat this field.
+     *
+     * - undefined / 'Sync' — normal behaviour (map, hash, persist).
+     * - 'Exclude' — the field is stripped from every fetched record BEFORE field
+     *   mapping. It reaches neither the mapped row, nor the CustomOverflow column,
+     *   nor the content-hash basis, so it stops influencing change detection.
+     *
+     * For payload a connector knows to be worthless or redundant at the field level:
+     * vendor UI state riding along on every record (Totara `preferences` — file-picker
+     * recents on 100% of rows), cosmetic configuration (`courseformatoptions`), or an
+     * embedded collection that re-derives an object already synced in its own right
+     * (`enrolledcourses` re-deriving Enrolled_Users). Exclusion — not field-map
+     * deactivation, which merely REROUTES the value into CustomOverflow, from which
+     * the custom-column promoter can resurrect it.
+     *
+     * Persisted into IntegrationObjectField.Configuration (JSON) by schema sync, so
+     * no migration is needed and existing installs pick it up on their next sync.
+     */
+    SyncDirective?: 'Sync' | 'Exclude';
 }
 
 /** One foreign key relationship in a source object. */

--- a/packages/Integration/engine/src/types.ts
+++ b/packages/Integration/engine/src/types.ts
@@ -502,6 +502,26 @@ export interface SourceFieldInfo {
     IsForeignKey?: boolean;
     /** If FK, which source object it references (null if not a FK). */
     ForeignKeyTarget: string | null;
+    /**
+     * How the sync engine should treat this field.
+     *
+     * - undefined / 'Sync' — normal behaviour (map, hash, persist).
+     * - 'Exclude' — the field is stripped from every fetched record BEFORE field
+     *   mapping. It reaches neither the mapped row, nor the CustomOverflow column,
+     *   nor the content-hash basis, so it stops influencing change detection.
+     *
+     * For payload a connector knows to be worthless or redundant at the field level:
+     * vendor UI state riding along on every record (Totara `preferences` — file-picker
+     * recents on 100% of rows), cosmetic configuration (`courseformatoptions`), or an
+     * embedded collection that re-derives an object already synced in its own right
+     * (`enrolledcourses` re-deriving Enrolled_Users). Exclusion — not field-map
+     * deactivation, which merely REROUTES the value into CustomOverflow, from which
+     * the custom-column promoter can resurrect it.
+     *
+     * Persisted into IntegrationObjectField.Configuration (JSON) by schema sync, so
+     * no migration is needed and existing installs pick it up on their next sync.
+     */
+    SyncDirective?: 'Sync' | 'Exclude';
 }
 
 /** One foreign key relationship in a source object. */

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2521,7 +2521,7 @@ importers:
         version: 3.0.7(@azure/identity@4.13.1)
       googleapis:
         specifier: ^144.0.0
-        version: 144.0.0(encoding@0.1.13)
+        version: 144.0.0
 
   packages/AI/RealtimeClient:
     dependencies:
@@ -29692,7 +29692,7 @@ snapshots:
     dependencies:
       '@ampproject/remapping': 2.3.0
       '@angular-devkit/architect': 0.2101.3(chokidar@5.0.0)
-      '@angular-devkit/build-webpack': 0.2101.3(chokidar@5.0.0)(webpack-dev-server@5.2.2(tslib@2.8.1)(webpack@5.105.0(esbuild@0.27.2)))(webpack@5.105.0(esbuild@0.27.2))
+      '@angular-devkit/build-webpack': 0.2101.3(chokidar@5.0.0)(webpack-dev-server@5.2.2(debug@4.4.3)(tslib@2.8.1)(webpack@5.105.0(esbuild@0.27.2)))(webpack@5.105.0(esbuild@0.27.2))
       '@angular-devkit/core': 21.1.3(chokidar@5.0.0)
       '@angular/build': 21.1.3(a1c152c28654637a273e49d67cbd7227)
       '@angular/compiler-cli': 21.1.3(@angular/compiler@21.1.3)(typescript@5.9.3)
@@ -29743,7 +29743,7 @@ snapshots:
       typescript: 5.9.3
       webpack: 5.105.0(esbuild@0.27.2)
       webpack-dev-middleware: 7.4.5(tslib@2.8.1)(webpack@5.105.0(esbuild@0.27.2))
-      webpack-dev-server: 5.2.2(tslib@2.8.1)(webpack@5.105.0(esbuild@0.27.2))
+      webpack-dev-server: 5.2.2(debug@4.4.3)(tslib@2.8.1)(webpack@5.105.0(esbuild@0.27.2))
       webpack-merge: 6.0.1
       webpack-subresource-integrity: 5.1.0(webpack@5.105.0(esbuild@0.27.2))
     optionalDependencies:
@@ -29782,15 +29782,6 @@ snapshots:
       rxjs: 7.8.2
       webpack: 5.105.0(esbuild@0.27.2)
       webpack-dev-server: 5.2.2(debug@4.4.3)(tslib@2.8.1)(webpack@5.105.0(esbuild@0.27.2))
-    transitivePeerDependencies:
-      - chokidar
-
-  '@angular-devkit/build-webpack@0.2101.3(chokidar@5.0.0)(webpack-dev-server@5.2.2(tslib@2.8.1)(webpack@5.105.0(esbuild@0.27.2)))(webpack@5.105.0(esbuild@0.27.2))':
-    dependencies:
-      '@angular-devkit/architect': 0.2101.3(chokidar@5.0.0)
-      rxjs: 7.8.2
-      webpack: 5.105.0(esbuild@0.27.2)
-      webpack-dev-server: 5.2.2(tslib@2.8.1)(webpack@5.105.0(esbuild@0.27.2))
     transitivePeerDependencies:
       - chokidar
 
@@ -42806,7 +42797,7 @@ snapshots:
 
   google-logging-utils@1.1.3: {}
 
-  googleapis-common@7.2.0(encoding@0.1.13):
+  googleapis-common@7.2.0:
     dependencies:
       extend: 3.0.2
       gaxios: 6.7.1(encoding@0.1.13)
@@ -42829,10 +42820,10 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  googleapis@144.0.0(encoding@0.1.13):
+  googleapis@144.0.0:
     dependencies:
       google-auth-library: 9.15.1(encoding@0.1.13)
-      googleapis-common: 7.2.0(encoding@0.1.13)
+      googleapis-common: 7.2.0
     transitivePeerDependencies:
       - encoding
       - supports-color
@@ -48797,45 +48788,6 @@ snapshots:
       - tslib
 
   webpack-dev-server@5.2.2(debug@4.4.3)(tslib@2.8.1)(webpack@5.105.0(esbuild@0.27.2)):
-    dependencies:
-      '@types/bonjour': 3.5.13
-      '@types/connect-history-api-fallback': 1.5.4
-      '@types/express': 4.17.25
-      '@types/express-serve-static-core': 4.19.8
-      '@types/serve-index': 1.9.4
-      '@types/serve-static': 1.15.10
-      '@types/sockjs': 0.3.36
-      '@types/ws': 8.18.1
-      ansi-html-community: 0.0.8
-      bonjour-service: 1.3.0
-      chokidar: 3.6.0
-      colorette: 2.0.20
-      compression: 1.8.1
-      connect-history-api-fallback: 2.0.0
-      express: 4.22.1
-      graceful-fs: 4.2.11
-      http-proxy-middleware: 2.0.9(@types/express@4.17.25)(debug@4.4.3)
-      ipaddr.js: 2.3.0
-      launch-editor: 2.12.0
-      open: 10.2.0
-      p-retry: 6.2.1
-      schema-utils: 4.3.3
-      selfsigned: 2.4.1
-      serve-index: 1.9.2
-      sockjs: 0.3.24
-      spdy: 4.0.2
-      webpack-dev-middleware: 7.4.5(tslib@2.8.1)(webpack@5.105.0(esbuild@0.27.2))
-      ws: 8.19.0
-    optionalDependencies:
-      webpack: 5.105.0(esbuild@0.27.2)
-    transitivePeerDependencies:
-      - bufferutil
-      - debug
-      - supports-color
-      - tslib
-      - utf-8-validate
-
-  webpack-dev-server@5.2.2(tslib@2.8.1)(webpack@5.105.0(esbuild@0.27.2)):
     dependencies:
       '@types/bonjour': 3.5.13
       '@types/connect-history-api-fallback': 1.5.4

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2518,7 +2518,7 @@ importers:
         version: 3.0.7(@azure/identity@4.13.1)
       googleapis:
         specifier: ^144.0.0
-        version: 144.0.0(encoding@0.1.13)
+        version: 144.0.0
 
   packages/AI/RealtimeClient:
     dependencies:
@@ -29757,7 +29757,7 @@ snapshots:
     dependencies:
       '@ampproject/remapping': 2.3.0
       '@angular-devkit/architect': 0.2101.3(chokidar@5.0.0)
-      '@angular-devkit/build-webpack': 0.2101.3(chokidar@5.0.0)(webpack-dev-server@5.2.2(tslib@2.8.1)(webpack@5.105.0(esbuild@0.27.2)))(webpack@5.105.0(esbuild@0.27.2))
+      '@angular-devkit/build-webpack': 0.2101.3(chokidar@5.0.0)(webpack-dev-server@5.2.2(debug@4.4.3)(tslib@2.8.1)(webpack@5.105.0(esbuild@0.27.2)))(webpack@5.105.0(esbuild@0.27.2))
       '@angular-devkit/core': 21.1.3(chokidar@5.0.0)
       '@angular/build': 21.1.3(a1c152c28654637a273e49d67cbd7227)
       '@angular/compiler-cli': 21.1.3(@angular/compiler@21.1.3)(typescript@5.9.3)
@@ -29808,7 +29808,7 @@ snapshots:
       typescript: 5.9.3
       webpack: 5.105.0(esbuild@0.27.2)
       webpack-dev-middleware: 7.4.5(tslib@2.8.1)(webpack@5.105.0(esbuild@0.27.2))
-      webpack-dev-server: 5.2.2(tslib@2.8.1)(webpack@5.105.0(esbuild@0.27.2))
+      webpack-dev-server: 5.2.2(debug@4.4.3)(tslib@2.8.1)(webpack@5.105.0(esbuild@0.27.2))
       webpack-merge: 6.0.1
       webpack-subresource-integrity: 5.1.0(webpack@5.105.0(esbuild@0.27.2))
     optionalDependencies:
@@ -29847,15 +29847,6 @@ snapshots:
       rxjs: 7.8.2
       webpack: 5.105.0(esbuild@0.27.2)
       webpack-dev-server: 5.2.2(debug@4.4.3)(tslib@2.8.1)(webpack@5.105.0(esbuild@0.27.2))
-    transitivePeerDependencies:
-      - chokidar
-
-  '@angular-devkit/build-webpack@0.2101.3(chokidar@5.0.0)(webpack-dev-server@5.2.2(tslib@2.8.1)(webpack@5.105.0(esbuild@0.27.2)))(webpack@5.105.0(esbuild@0.27.2))':
-    dependencies:
-      '@angular-devkit/architect': 0.2101.3(chokidar@5.0.0)
-      rxjs: 7.8.2
-      webpack: 5.105.0(esbuild@0.27.2)
-      webpack-dev-server: 5.2.2(tslib@2.8.1)(webpack@5.105.0(esbuild@0.27.2))
     transitivePeerDependencies:
       - chokidar
 
@@ -42845,7 +42836,7 @@ snapshots:
 
   google-logging-utils@1.1.3: {}
 
-  googleapis-common@7.2.0(encoding@0.1.13):
+  googleapis-common@7.2.0:
     dependencies:
       extend: 3.0.2
       gaxios: 6.7.1(encoding@0.1.13)
@@ -42868,10 +42859,10 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  googleapis@144.0.0(encoding@0.1.13):
+  googleapis@144.0.0:
     dependencies:
       google-auth-library: 9.15.1(encoding@0.1.13)
-      googleapis-common: 7.2.0(encoding@0.1.13)
+      googleapis-common: 7.2.0
     transitivePeerDependencies:
       - encoding
       - supports-color
@@ -48836,45 +48827,6 @@ snapshots:
       - tslib
 
   webpack-dev-server@5.2.2(debug@4.4.3)(tslib@2.8.1)(webpack@5.105.0(esbuild@0.27.2)):
-    dependencies:
-      '@types/bonjour': 3.5.13
-      '@types/connect-history-api-fallback': 1.5.4
-      '@types/express': 4.17.25
-      '@types/express-serve-static-core': 4.19.8
-      '@types/serve-index': 1.9.4
-      '@types/serve-static': 1.15.10
-      '@types/sockjs': 0.3.36
-      '@types/ws': 8.18.1
-      ansi-html-community: 0.0.8
-      bonjour-service: 1.3.0
-      chokidar: 3.6.0
-      colorette: 2.0.20
-      compression: 1.8.1
-      connect-history-api-fallback: 2.0.0
-      express: 4.22.1
-      graceful-fs: 4.2.11
-      http-proxy-middleware: 2.0.9(@types/express@4.17.25)(debug@4.4.3)
-      ipaddr.js: 2.3.0
-      launch-editor: 2.12.0
-      open: 10.2.0
-      p-retry: 6.2.1
-      schema-utils: 4.3.3
-      selfsigned: 2.4.1
-      serve-index: 1.9.2
-      sockjs: 0.3.24
-      spdy: 4.0.2
-      webpack-dev-middleware: 7.4.5(tslib@2.8.1)(webpack@5.105.0(esbuild@0.27.2))
-      ws: 8.19.0
-    optionalDependencies:
-      webpack: 5.105.0(esbuild@0.27.2)
-    transitivePeerDependencies:
-      - bufferutil
-      - debug
-      - supports-color
-      - tslib
-      - utf-8-validate
-
-  webpack-dev-server@5.2.2(tslib@2.8.1)(webpack@5.105.0(esbuild@0.27.2)):
     dependencies:
       '@types/bonjour': 3.5.13
       '@types/connect-history-api-fallback': 1.5.4

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2518,7 +2518,7 @@ importers:
         version: 3.0.7(@azure/identity@4.13.1)
       googleapis:
         specifier: ^144.0.0
-        version: 144.0.0
+        version: 144.0.0(encoding@0.1.13)
 
   packages/AI/RealtimeClient:
     dependencies:
@@ -29757,7 +29757,7 @@ snapshots:
     dependencies:
       '@ampproject/remapping': 2.3.0
       '@angular-devkit/architect': 0.2101.3(chokidar@5.0.0)
-      '@angular-devkit/build-webpack': 0.2101.3(chokidar@5.0.0)(webpack-dev-server@5.2.2(debug@4.4.3)(tslib@2.8.1)(webpack@5.105.0(esbuild@0.27.2)))(webpack@5.105.0(esbuild@0.27.2))
+      '@angular-devkit/build-webpack': 0.2101.3(chokidar@5.0.0)(webpack-dev-server@5.2.2(tslib@2.8.1)(webpack@5.105.0(esbuild@0.27.2)))(webpack@5.105.0(esbuild@0.27.2))
       '@angular-devkit/core': 21.1.3(chokidar@5.0.0)
       '@angular/build': 21.1.3(a1c152c28654637a273e49d67cbd7227)
       '@angular/compiler-cli': 21.1.3(@angular/compiler@21.1.3)(typescript@5.9.3)
@@ -29808,7 +29808,7 @@ snapshots:
       typescript: 5.9.3
       webpack: 5.105.0(esbuild@0.27.2)
       webpack-dev-middleware: 7.4.5(tslib@2.8.1)(webpack@5.105.0(esbuild@0.27.2))
-      webpack-dev-server: 5.2.2(debug@4.4.3)(tslib@2.8.1)(webpack@5.105.0(esbuild@0.27.2))
+      webpack-dev-server: 5.2.2(tslib@2.8.1)(webpack@5.105.0(esbuild@0.27.2))
       webpack-merge: 6.0.1
       webpack-subresource-integrity: 5.1.0(webpack@5.105.0(esbuild@0.27.2))
     optionalDependencies:
@@ -29847,6 +29847,15 @@ snapshots:
       rxjs: 7.8.2
       webpack: 5.105.0(esbuild@0.27.2)
       webpack-dev-server: 5.2.2(debug@4.4.3)(tslib@2.8.1)(webpack@5.105.0(esbuild@0.27.2))
+    transitivePeerDependencies:
+      - chokidar
+
+  '@angular-devkit/build-webpack@0.2101.3(chokidar@5.0.0)(webpack-dev-server@5.2.2(tslib@2.8.1)(webpack@5.105.0(esbuild@0.27.2)))(webpack@5.105.0(esbuild@0.27.2))':
+    dependencies:
+      '@angular-devkit/architect': 0.2101.3(chokidar@5.0.0)
+      rxjs: 7.8.2
+      webpack: 5.105.0(esbuild@0.27.2)
+      webpack-dev-server: 5.2.2(tslib@2.8.1)(webpack@5.105.0(esbuild@0.27.2))
     transitivePeerDependencies:
       - chokidar
 
@@ -42836,7 +42845,7 @@ snapshots:
 
   google-logging-utils@1.1.3: {}
 
-  googleapis-common@7.2.0:
+  googleapis-common@7.2.0(encoding@0.1.13):
     dependencies:
       extend: 3.0.2
       gaxios: 6.7.1(encoding@0.1.13)
@@ -42859,10 +42868,10 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  googleapis@144.0.0:
+  googleapis@144.0.0(encoding@0.1.13):
     dependencies:
       google-auth-library: 9.15.1(encoding@0.1.13)
-      googleapis-common: 7.2.0
+      googleapis-common: 7.2.0(encoding@0.1.13)
     transitivePeerDependencies:
       - encoding
       - supports-color
@@ -48827,6 +48836,45 @@ snapshots:
       - tslib
 
   webpack-dev-server@5.2.2(debug@4.4.3)(tslib@2.8.1)(webpack@5.105.0(esbuild@0.27.2)):
+    dependencies:
+      '@types/bonjour': 3.5.13
+      '@types/connect-history-api-fallback': 1.5.4
+      '@types/express': 4.17.25
+      '@types/express-serve-static-core': 4.19.8
+      '@types/serve-index': 1.9.4
+      '@types/serve-static': 1.15.10
+      '@types/sockjs': 0.3.36
+      '@types/ws': 8.18.1
+      ansi-html-community: 0.0.8
+      bonjour-service: 1.3.0
+      chokidar: 3.6.0
+      colorette: 2.0.20
+      compression: 1.8.1
+      connect-history-api-fallback: 2.0.0
+      express: 4.22.1
+      graceful-fs: 4.2.11
+      http-proxy-middleware: 2.0.9(@types/express@4.17.25)(debug@4.4.3)
+      ipaddr.js: 2.3.0
+      launch-editor: 2.12.0
+      open: 10.2.0
+      p-retry: 6.2.1
+      schema-utils: 4.3.3
+      selfsigned: 2.4.1
+      serve-index: 1.9.2
+      sockjs: 0.3.24
+      spdy: 4.0.2
+      webpack-dev-middleware: 7.4.5(tslib@2.8.1)(webpack@5.105.0(esbuild@0.27.2))
+      ws: 8.19.0
+    optionalDependencies:
+      webpack: 5.105.0(esbuild@0.27.2)
+    transitivePeerDependencies:
+      - bufferutil
+      - debug
+      - supports-color
+      - tslib
+      - utf-8-validate
+
+  webpack-dev-server@5.2.2(tslib@2.8.1)(webpack@5.105.0(esbuild@0.27.2)):
     dependencies:
       '@types/bonjour': 3.5.13
       '@types/connect-history-api-fallback': 1.5.4


### PR DESCRIPTION
## The gap

A connector has no way to say *"do not sync this field."* The nearest lever — deactivating its field map — doesn't exclude the value, it **reroutes** it: `FieldMappingEngine` captures every unmapped source key into `UnmappedFields`, the writer parks it in `__mj_integration_CustomOverflow`, and the custom-column promoter can later resurrect it as a real column.

## Why it matters, measured

Profiled in a production deployment, the payload nobody would choose to sync:

The same profile found the vendor pattern generally: parents embed collections that already exist as objects (OpenWater `Program.rounds` vs its `Rounds` table). Exclusion is the primitive that lets a connector say so.

## The change

`SourceFieldInfo.SyncDirective?: 'Sync' | 'Exclude'` (undefined = Sync — connectors that predate this behave exactly as before).

- **`IntegrationSchemaSync`** persists it into `IntegrationObjectField.Configuration` — an existing JSON column, so **no migration**. Overlay semantics match every other attribute: a stated directive wins, a silent connector preserves what's stored, so an operator-set directive survives connectors that never heard of the feature.
- **`IntegrationEngine`** resolves the exclusion set once per entity map and emits `sync.entity-map.exclusions` naming the excluded fields — the run log shows exactly what was withheld.
- **`FieldMappingEngine`** strips excluded keys **before** flatten and **before** mapping, so they reach neither `MappedFields`, nor `UnmappedFields` (→ CustomOverflow), nor the content hash (whose basis is `MappedFields`) — an excluded field stops influencing change detection entirely. The no-exclusions path allocates nothing (same-object fast paths).

Existing columns are untouched — exclusion stops fetching into them; dropping them stays an operator decision.

## Tests

13 new (`SyncDirectives.test.ts`): read/write round-trip incl. malformed-Configuration safety, exclusion reaching neither mapped fields nor overflow, **hash invariance when an excluded value changes**, no-exclusions regression guard, caller-record immutability. Engine suite **713/713**.

## Follow-on (separate PRs, same profiling)

This is the first of the collection-shape declarations. The profile found four recurring shapes — duplicates-an-existing-object, entity collection, EAV collection (`{name, value}` custom fields), scalar collection — of which `Exclude` handles the first and worst. Child-table expansion for the remaining three is a schema-builder feature and will come as its own design.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
